### PR TITLE
fix(app): make device freshness stamp-driven

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -57,6 +57,7 @@
     "test:e2e:android:lifecycle:reboot": "ELIZA_ANDROID_BACKEND=${ELIZA_ANDROID_BACKEND:-local} ELIZA_ANDROID_REQUIRE_AGENT=${ELIZA_ANDROID_REQUIRE_AGENT:-1} ELIZA_ANDROID_LIFECYCLE_REBOOT=1 bunx playwright test --config playwright.android.config.ts test/android/lifecycle-reboot.android.spec.ts",
     "test:e2e:android:cloud": "node scripts/android-e2e.mjs --skip-local-chat --skip-route-coverage --cloud",
     "test:e2e:android:webview": "ANDROID_SERIAL=${ANDROID_SERIAL:-} bunx playwright test --config playwright.android.config.ts",
+    "devices:status": "node scripts/devices-status.mjs",
     "test:e2e:ios:onboarding": "node scripts/ios-onboarding-smoke.mjs",
     "test:e2e:ios:voice": "node scripts/ios-voice-selftest-smoke.mjs",
     "test:sim:local-chat": "node scripts/mobile-local-chat-smoke.mjs --platform ios --require-installed",

--- a/packages/app/scripts/android-e2e.mjs
+++ b/packages/app/scripts/android-e2e.mjs
@@ -14,20 +14,31 @@
 //
 // Flags: --serial <s>  --skip-local-chat  --skip-route-coverage  --cloud
 //        --launcher-loop (≥200-action seeded launcher gesture loop; opt-in)
-//        --build (build the APK first)  --no-emulator-boot
+//        --force-build (build+reinstall the APK first)  --skip-build
+//        --build (compat alias for --force-build)  --no-emulator-boot
 import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  rendererLaneStampMismatches,
+  resolveExpectedRendererStamp,
+} from "../../app-core/scripts/lib/mobile-lane-stamp.mjs";
+import {
   ensureEmulatorBooted,
   ensureEmulatorPermissive,
   installApk,
-  isInstalled,
+  readApkRendererStamp,
+  readInstalledRendererStamp,
   resolveAdb,
   resolveApk,
   resolveSerial,
 } from "./lib/android-device.mjs";
+import {
+  decideAndroidInstall,
+  freshRendererManifestPath,
+  readRendererManifestFile,
+} from "./lib/device-renderer-status.mjs";
 
 const appDir = path.resolve(fileURLToPath(import.meta.url), "..", "..");
 const elizaRoot = path.resolve(appDir, "..", "..");
@@ -38,6 +49,13 @@ const val = (flag, fb) => {
   return i >= 0 ? process.argv[i + 1] : fb;
 };
 const log = (m) => console.log(`[android-e2e] ${m}`);
+const ANDROID_RENDERER_POLICY = Object.freeze({
+  buildVariant: "direct",
+  capacitorTarget: "android",
+  androidRuntimeMode: "local",
+  iosRuntimeMode: null,
+  runtimeExecutionMode: "local-yolo",
+});
 
 // Smallest local tier; same id the smoke + catalog use.
 const SMOKE_MODEL = {
@@ -171,6 +189,113 @@ function run(cmd, args, env = {}) {
   }
 }
 
+function buildAndroidApk() {
+  log("building WebView-debuggable APK…");
+  run("bun", ["run", "build:android"], {
+    ELIZA_MOBILE_REPO_ROOT: elizaRoot,
+    ELIZA_WEBVIEW_DEBUG: "1",
+    ELIZA_BUN_RISCV64_OPTIONAL: "1",
+  });
+}
+
+function readFreshRendererStampOrNull() {
+  const manifestPath = freshRendererManifestPath({ appDir });
+  if (!fs.existsSync(manifestPath)) return null;
+  return readRendererManifestFile(manifestPath, "fresh dist");
+}
+
+function androidLaneMismatches(stamp) {
+  return rendererLaneStampMismatches(
+    stamp,
+    resolveExpectedRendererStamp({
+      policy: ANDROID_RENDERER_POLICY,
+      env: process.env,
+    }),
+  );
+}
+
+function ensureFreshAndroidArtifacts({ forceBuild, skipBuild }) {
+  let fresh = readFreshRendererStampOrNull();
+  let apk = null;
+  let apkStamp = null;
+  let shouldBuild = forceBuild;
+  if (fresh) {
+    const mismatches = androidLaneMismatches(fresh);
+    if (mismatches.length > 0) {
+      log(`existing dist is for the wrong lane: ${mismatches.join("; ")}`);
+      shouldBuild = true;
+    }
+  } else {
+    log("fresh dist renderer manifest is missing.");
+    shouldBuild = true;
+  }
+  if (!shouldBuild) {
+    try {
+      apk = resolveApk(process.env.ELIZA_ANDROID_APK);
+      apkStamp = readApkRendererStamp(apk, "candidate APK");
+      if (apkStamp.buildId !== fresh.buildId) {
+        log(
+          `candidate APK buildId ${apkStamp.buildId} != fresh dist ${fresh.buildId}; rebuilding APK.`,
+        );
+        shouldBuild = true;
+      }
+    } catch (error) {
+      log(`candidate APK is not reusable: ${error?.message ?? error}`);
+      shouldBuild = true;
+    }
+  }
+  if (shouldBuild) {
+    if (skipBuild) {
+      throw new Error(
+        "--skip-build was set, but the Android dist/APK is missing or stale for this lane.",
+      );
+    }
+    buildAndroidApk();
+    fresh = readFreshRendererStampOrNull();
+    if (!fresh) {
+      throw new Error(
+        "build:android completed without a fresh renderer stamp.",
+      );
+    }
+    const mismatches = androidLaneMismatches(fresh);
+    if (mismatches.length > 0) {
+      throw new Error(
+        `build:android produced a renderer stamp for the wrong lane: ${mismatches.join("; ")}`,
+      );
+    }
+    apk = resolveApk(process.env.ELIZA_ANDROID_APK);
+    apkStamp = readApkRendererStamp(apk, "fresh APK");
+    if (apkStamp.buildId !== fresh.buildId) {
+      throw new Error(
+        `fresh APK buildId ${apkStamp.buildId} != fresh dist ${fresh.buildId}`,
+      );
+    }
+  }
+  return { apk, fresh };
+}
+
+function ensureInstalledRendererFresh({ adb, serial, apk, fresh, skipBuild }) {
+  const installed = readInstalledRendererStamp(adb, serial);
+  const decision = decideAndroidInstall({ installed, fresh, skipBuild });
+  if (decision.error) throw new Error(decision.error);
+  if (!decision.install) {
+    log(
+      `installed renderer is fresh: buildId=${fresh.buildId.slice(0, 12)} commit=${String(fresh.commit ?? "unknown").slice(0, 12)}`,
+    );
+    return;
+  }
+  const current = installed?.buildId ?? "not installed";
+  log(`${current} != fresh ${fresh.buildId} — reinstalling ${apk}`);
+  installApk(adb, serial, apk);
+  const after = readInstalledRendererStamp(adb, serial);
+  if (!after || after.buildId !== fresh.buildId) {
+    throw new Error(
+      `post-install renderer stamp mismatch: installed ${after?.buildId ?? "missing"} != fresh ${fresh.buildId}`,
+    );
+  }
+  log(`installed renderer verified: buildId=${after.buildId.slice(0, 12)}`);
+}
+
 // Node's fetch chokes on the HF Xet LFS redirect; curl handles it. Pre-cache the
 // model so the smoke reuses it offline instead of failing on the redirect.
 function ensureSmokeModelCached() {
@@ -195,6 +320,16 @@ function ensureSmokeModelCached() {
 
 async function main() {
   const adb = resolveAdb();
+  const forceBuild = has("--force-build") || has("--build");
+  const skipBuild = has("--skip-build");
+  if (has("--build")) {
+    log("--build is deprecated; treating it as --force-build.");
+  }
+  if (forceBuild && skipBuild) {
+    throw new Error(
+      "--force-build/--build cannot be combined with --skip-build.",
+    );
+  }
 
   let serial = val("--serial", process.env.ANDROID_SERIAL);
   if (!has("--no-emulator-boot")) {
@@ -206,19 +341,8 @@ async function main() {
 
   await ensureEmulatorPermissive(adb, serial, { log });
 
-  if (has("--build")) {
-    log("building WebView-debuggable APK…");
-    run("bun", ["run", "build:android"], {
-      ELIZA_MOBILE_REPO_ROOT: elizaRoot,
-      ELIZA_WEBVIEW_DEBUG: "1",
-      ELIZA_BUN_RISCV64_OPTIONAL: "1",
-    });
-  }
-  if (!isInstalled(adb, serial)) {
-    const apk = resolveApk(process.env.ELIZA_ANDROID_APK);
-    log(`installing ${apk}`);
-    installApk(adb, serial, apk);
-  }
+  const { apk, fresh } = ensureFreshAndroidArtifacts({ forceBuild, skipBuild });
+  ensureInstalledRendererFresh({ adb, serial, apk, fresh, skipBuild });
 
   if (!has("--skip-local-chat")) {
     const modelPath = ensureSmokeModelCached();

--- a/packages/app/scripts/devices-status.mjs
+++ b/packages/app/scripts/devices-status.mjs
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+/**
+ * Read-only device build-status report for the MVP mobile evidence fleet.
+ *
+ * The report answers the question stale mobile evidence usually hides: which
+ * renderer build is installed on each connected device, and does it match the
+ * fresh local dist and develop HEAD? Android and simulators are read directly;
+ * physical iOS devices use the deploy ledger written by ios-device-deploy.mjs
+ * because iOS app containers are not host-readable.
+ */
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { readDevicectlDeviceList } from "./ios-device-devicectl.mjs";
+import { DEFAULT_APP_BUNDLE_ID } from "./ios-device-lib.mjs";
+import {
+  APP_ID,
+  readInstalledRendererStamp,
+  resolveAdb,
+} from "./lib/android-device.mjs";
+import {
+  evaluateRendererFreshness,
+  freshRendererManifestPath,
+  latestIosDeployLedgerEntry,
+  readIosDeployLedgerEntries,
+  readRendererManifestFile,
+  shortSha,
+} from "./lib/device-renderer-status.mjs";
+import {
+  readRendererManifest,
+  rendererManifestPathFromAppPath,
+} from "./lib/ios-renderer-stamp.mjs";
+
+const appDir = path.resolve(fileURLToPath(import.meta.url), "..", "..");
+const repoRoot = path.resolve(appDir, "..", "..");
+
+function has(flag) {
+  return process.argv.includes(flag);
+}
+
+function runText(command, args, options = {}) {
+  try {
+    return execFileSync(command, args, {
+      cwd: options.cwd ?? repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (error) {
+    if (options.optional) return null;
+    throw error;
+  }
+}
+
+function readDevelopHead() {
+  if (!has("--no-fetch")) {
+    runText("git", ["fetch", "origin", "develop", "--quiet"]);
+  }
+  return runText("git", ["rev-parse", "origin/develop"]);
+}
+
+function readFreshDistStamp() {
+  const manifestPath = freshRendererManifestPath({ appDir });
+  if (!fs.existsSync(manifestPath)) return null;
+  return readRendererManifestFile(manifestPath, "fresh dist");
+}
+
+function rowForStamp({
+  platform,
+  kind,
+  id,
+  name,
+  source,
+  installed,
+  fresh,
+  developHead,
+}) {
+  const status = evaluateRendererFreshness({ installed, fresh, developHead });
+  return {
+    platform,
+    kind,
+    id,
+    name: name ?? "",
+    source,
+    verdict: status.verdict,
+    reason: status.reason,
+    installedBuildId: installed?.buildId ?? null,
+    installedCommit: installed?.commit ?? null,
+    freshBuildId: fresh?.buildId ?? null,
+    developHead,
+  };
+}
+
+function nARow(platform, kind, reason) {
+  return {
+    platform,
+    kind,
+    id: "",
+    name: "",
+    source: "host",
+    verdict: "N/A",
+    reason,
+    installedBuildId: null,
+    installedCommit: null,
+    freshBuildId: null,
+    developHead: null,
+  };
+}
+
+function readAndroidDeviceLines(adbBin) {
+  return runText(adbBin, ["devices", "-l"])
+    .split(/\r?\n/)
+    .slice(1)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const parts = line.split(/\s+/);
+      const serial = parts[0];
+      const state = parts[1];
+      const model = parts
+        .find((part) => part.startsWith("model:"))
+        ?.slice("model:".length);
+      return { serial, state, model: model ?? "" };
+    })
+    .filter((device) => device.state === "device");
+}
+
+function androidRows({ fresh, developHead }) {
+  let adbBin;
+  try {
+    adbBin = resolveAdb();
+  } catch (error) {
+    return [nARow("android", "device", error?.message ?? String(error))];
+  }
+  const devices = readAndroidDeviceLines(adbBin);
+  if (devices.length === 0) return [];
+  return devices.map((device) => {
+    try {
+      const installed = readInstalledRendererStamp(adbBin, device.serial);
+      return rowForStamp({
+        platform: "android",
+        kind: device.serial.startsWith("emulator-") ? "emulator" : "device",
+        id: device.serial,
+        name: device.model,
+        source: APP_ID,
+        installed,
+        fresh,
+        developHead,
+      });
+    } catch (error) {
+      return {
+        ...nARow("android", "device", error?.message ?? String(error)),
+        id: device.serial,
+        name: device.model,
+        verdict: "UNKNOWN",
+      };
+    }
+  });
+}
+
+function bootedSimulatorRows({ fresh, developHead, bundleId }) {
+  if (process.platform !== "darwin") {
+    return [nARow("ios", "simulator", "not macOS")];
+  }
+  const output = runText("xcrun", ["simctl", "list", "devices", "--json"], {
+    optional: true,
+  });
+  if (!output) return [nARow("ios", "simulator", "simctl unavailable")];
+  const payload = JSON.parse(output);
+  const sims = Object.values(payload.devices ?? {})
+    .flat()
+    .filter((device) => device?.state === "Booted");
+  return sims.map((sim) => {
+    const appPath = runText(
+      "xcrun",
+      ["simctl", "get_app_container", sim.udid, bundleId, "app"],
+      { optional: true },
+    );
+    const installed = appPath
+      ? readRendererManifest(
+          rendererManifestPathFromAppPath(appPath),
+          `simulator ${sim.name}`,
+        )
+      : null;
+    return rowForStamp({
+      platform: "ios",
+      kind: "simulator",
+      id: sim.udid,
+      name: sim.name,
+      source: appPath ?? bundleId,
+      installed,
+      fresh,
+      developHead,
+    });
+  });
+}
+
+function physicalIosRows({ fresh, developHead, bundleId }) {
+  if (process.platform !== "darwin") {
+    return [nARow("ios", "device", "not macOS")];
+  }
+  let payload;
+  try {
+    payload = readDevicectlDeviceList({ quiet: true });
+  } catch (error) {
+    return [
+      nARow(
+        "ios",
+        "device",
+        `devicectl unavailable: ${error?.message ?? error}`,
+      ),
+    ];
+  }
+  const ledgerEntries = readIosDeployLedgerEntries();
+  const devices = payload?.result?.devices ?? [];
+  return devices
+    .map((device) => ({
+      identifier: String(device?.identifier ?? ""),
+      udid: String(device?.hardwareProperties?.udid ?? ""),
+      name: String(device?.deviceProperties?.name ?? ""),
+    }))
+    .filter((device) => device.identifier && device.udid)
+    .map((device) => {
+      const entry = latestIosDeployLedgerEntry({
+        entries: ledgerEntries,
+        udid: device.udid,
+        bundleId,
+      });
+      const installed = entry
+        ? {
+            buildId: entry.buildId,
+            commit: entry.commit,
+            builtAt: entry.builtAt,
+            variant: entry.variant,
+            capacitorTarget: entry.capacitorTarget,
+            runtimeMode: entry.runtimeMode,
+          }
+        : null;
+      return rowForStamp({
+        platform: "ios",
+        kind: "device",
+        id: device.identifier,
+        name: device.name,
+        source: entry ? "ios-device-deploy ledger" : "no deploy ledger entry",
+        installed,
+        fresh,
+        developHead,
+      });
+    });
+}
+
+function pad(text, width) {
+  const value = String(text ?? "");
+  return value.length >= width
+    ? value
+    : value + " ".repeat(width - value.length);
+}
+
+function printTable(rows) {
+  const columns = [
+    ["platform", 8],
+    ["kind", 10],
+    ["device", 24],
+    ["verdict", 8],
+    ["installed", 12],
+    ["commit", 12],
+    ["develop", 12],
+    ["reason", 0],
+  ];
+  console.log(columns.map(([name, width]) => pad(name, width)).join("  "));
+  console.log(
+    columns
+      .map(([name, width]) => "-".repeat(width || Math.max(6, name.length)))
+      .join("  "),
+  );
+  for (const row of rows) {
+    const device = row.name ? `${row.name} ${row.id}` : row.id || row.source;
+    const values = [
+      row.platform,
+      row.kind,
+      device.slice(0, 24),
+      row.verdict,
+      row.installedBuildId ? row.installedBuildId.slice(0, 12) : "-",
+      shortSha(row.installedCommit) ?? "-",
+      shortSha(row.developHead) ?? "-",
+      row.reason,
+    ];
+    console.log(
+      values.map((value, index) => pad(value, columns[index][1])).join("  "),
+    );
+  }
+}
+
+async function main() {
+  const json = has("--json");
+  const requireFresh = has("--require-fresh");
+  const bundleId =
+    process.env.ELIZA_IOS_BUNDLE_ID?.trim() || DEFAULT_APP_BUNDLE_ID;
+  const developHead = readDevelopHead();
+  const fresh = readFreshDistStamp();
+  const rows = [
+    ...androidRows({ fresh, developHead }),
+    ...bootedSimulatorRows({ fresh, developHead, bundleId }),
+    ...physicalIosRows({ fresh, developHead, bundleId }),
+  ];
+  if (json) {
+    console.log(JSON.stringify(rows, null, 2));
+  } else {
+    printTable(rows);
+    console.log(
+      `\nfresh dist: ${fresh ? `${fresh.buildId.slice(0, 12)} commit=${shortSha(fresh.commit) ?? "unknown"}` : "missing"}`,
+    );
+    console.log(`develop HEAD: ${shortSha(developHead)}`);
+  }
+  if (
+    requireFresh &&
+    rows.some((row) => row.verdict !== "FRESH" && row.verdict !== "N/A")
+  ) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(`[devices:status] FAILED: ${error?.stack ?? error}`);
+  process.exit(1);
+});

--- a/packages/app/scripts/ios-device-deploy.mjs
+++ b/packages/app/scripts/ios-device-deploy.mjs
@@ -57,6 +57,11 @@ import {
   selectProvisioningProfile,
   selectSigningIdentity,
 } from "./ios-device-lib.mjs";
+import { appendIosDeployLedgerEntry } from "./lib/device-renderer-status.mjs";
+import {
+  readRendererManifest,
+  rendererManifestPathFromAppPath,
+} from "./lib/ios-renderer-stamp.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const appRoot = path.resolve(scriptDir, "..");
@@ -481,6 +486,18 @@ async function main() {
     device.identifier,
     stagedApp,
   ]);
+  const stamp = readRendererManifest(
+    rendererManifestPathFromAppPath(stagedApp),
+    "staged iOS app",
+  );
+  const { ledgerPath } = appendIosDeployLedgerEntry({
+    device,
+    bundleId,
+    stamp,
+  });
+  log(
+    `deploy ledger wrote buildId=${stamp.buildId.slice(0, 12)} commit=${String(stamp.commit ?? "unknown").slice(0, 12)} to ${ledgerPath}`,
+  );
 
   // 6. Launch (default on; --no-launch to skip). Console capture is
   //    ios-device-logs.mjs's job — this launch does not hold the terminal.

--- a/packages/app/scripts/ios-device-devicectl.mjs
+++ b/packages/app/scripts/ios-device-devicectl.mjs
@@ -20,14 +20,14 @@ import path from "node:path";
  *
  * @returns {{ result?: { devices?: Array<Record<string, unknown>> } }}
  */
-export function readDevicectlDeviceList() {
+export function readDevicectlDeviceList({ quiet = false } = {}) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-devicectl-"));
   const jsonPath = path.join(tmpDir, "devices.json");
   try {
     execFileSync(
       "xcrun",
       ["devicectl", "list", "devices", "--json-output", jsonPath, "--quiet"],
-      { stdio: ["ignore", "ignore", "inherit"] },
+      { stdio: ["ignore", "ignore", quiet ? "pipe" : "inherit"] },
     );
     return JSON.parse(fs.readFileSync(jsonPath, "utf8"));
   } finally {

--- a/packages/app/scripts/lib/android-device.mjs
+++ b/packages/app/scripts/lib/android-device.mjs
@@ -12,6 +12,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { RENDERER_MANIFEST_FILENAME } from "./device-renderer-status.mjs";
 
 const IS_WINDOWS = process.platform === "win32";
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -393,6 +394,58 @@ export function isInstalled(adbBin, serial) {
 
 export function installApk(adbBin, serial, apk) {
   adbDevice(adbBin, serial, ["install", "-r", "-d", apk], { stdio: "inherit" });
+}
+
+export function readApkRendererStamp(apkPath, label = "APK") {
+  const manifestPath = `assets/public/${RENDERER_MANIFEST_FILENAME}`;
+  let text;
+  try {
+    text = execFileSync("unzip", ["-p", apkPath, manifestPath], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (error) {
+    throw new Error(
+      `${label} renderer manifest is missing or unreadable at ${manifestPath}: ${apkPath}`,
+      { cause: error },
+    );
+  }
+  const parsed = JSON.parse(text);
+  if (typeof parsed.buildId !== "string" || parsed.buildId.length === 0) {
+    throw new Error(`${label} renderer manifest has no buildId: ${apkPath}`);
+  }
+  return parsed;
+}
+
+export function readInstalledRendererStamp(adbBin, serial) {
+  const pathOutput = adbTry(adbBin, [
+    "-s",
+    serial,
+    "shell",
+    "pm",
+    "path",
+    APP_ID,
+  ]).trim();
+  if (!pathOutput) return null;
+  const remoteApk = pathOutput
+    .split(/\r?\n/)
+    .map((line) => line.trim().replace(/^package:/, ""))
+    .find((line) => line.endsWith("/base.apk"));
+  if (!remoteApk) {
+    throw new Error(
+      `Cannot locate ${APP_ID} base.apk on ${serial}; pm path output was: ${pathOutput}`,
+    );
+  }
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-android-apk-"));
+  const localApk = path.join(tempDir, "base.apk");
+  try {
+    adbDevice(adbBin, serial, ["pull", remoteApk, localApk], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return readApkRendererStamp(localApk, `installed ${APP_ID} on ${serial}`);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
 }
 
 export function clearAppData(adbBin, serial) {

--- a/packages/app/scripts/lib/device-renderer-status.mjs
+++ b/packages/app/scripts/lib/device-renderer-status.mjs
@@ -1,0 +1,190 @@
+/**
+ * Renderer build-stamp status helpers for device evidence lanes.
+ *
+ * Android e2e, iOS deploy, and fleet status all need the same answer: which
+ * renderer build is installed, and does it match the fresh app bundle or
+ * develop HEAD? Keeping the comparison pure makes stale-install behavior
+ * unit-testable while the platform scripts own adb, simctl, and devicectl.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export const RENDERER_MANIFEST_FILENAME = "eliza-renderer-build.json";
+export const IOS_DEPLOY_LEDGER_FILENAME = "ios-device-deploy-ledger.jsonl";
+
+export function shortSha(value, length = 12) {
+  const text = typeof value === "string" ? value.trim() : "";
+  return text ? text.slice(0, length) : null;
+}
+
+export function normalizeCommit(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+export function commitsMatch(actual, expected) {
+  const a = normalizeCommit(actual);
+  const e = normalizeCommit(expected);
+  if (!a || !e) return false;
+  return a === e || a.startsWith(e) || e.startsWith(a);
+}
+
+export function readRendererManifestFile(manifestPath, label = "renderer") {
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error(`${label} manifest is missing: ${manifestPath}`);
+  }
+  const parsed = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  if (typeof parsed.buildId !== "string" || parsed.buildId.length === 0) {
+    throw new Error(`${label} manifest has no buildId: ${manifestPath}`);
+  }
+  return parsed;
+}
+
+export function freshRendererManifestPath({ appDir, rendererDist = null }) {
+  return path.join(
+    rendererDist ? path.resolve(rendererDist) : path.join(appDir, "dist"),
+    RENDERER_MANIFEST_FILENAME,
+  );
+}
+
+export function evaluateRendererFreshness({
+  installed,
+  fresh = null,
+  developHead = null,
+} = {}) {
+  if (!installed) {
+    return {
+      verdict: "UNKNOWN",
+      reason: "app is not installed or no installed stamp is available",
+    };
+  }
+  if (fresh && installed.buildId !== fresh.buildId) {
+    return {
+      verdict: "STALE",
+      reason: `installed buildId ${installed.buildId} != fresh buildId ${fresh.buildId}`,
+    };
+  }
+  const expectedCommit = normalizeCommit(developHead);
+  if (expectedCommit) {
+    const installedCommit = normalizeCommit(installed.commit);
+    if (!installedCommit) {
+      return {
+        verdict: "UNKNOWN",
+        reason: "installed stamp has no commit to compare with develop HEAD",
+      };
+    }
+    if (!commitsMatch(installedCommit, expectedCommit)) {
+      return {
+        verdict: "STALE",
+        reason: `installed commit ${shortSha(installedCommit)} != develop HEAD ${shortSha(expectedCommit)}`,
+      };
+    }
+  }
+  if (!fresh && !expectedCommit) {
+    return {
+      verdict: "UNKNOWN",
+      reason: "no fresh dist stamp or develop HEAD was provided",
+    };
+  }
+  return {
+    verdict: "FRESH",
+    reason: fresh
+      ? `installed buildId matches fresh buildId ${fresh.buildId}`
+      : `installed commit matches develop HEAD ${shortSha(expectedCommit)}`,
+  };
+}
+
+export function decideAndroidInstall({ installed, fresh, skipBuild = false }) {
+  const status = evaluateRendererFreshness({ installed, fresh });
+  if (status.verdict === "FRESH") {
+    return { install: false, status };
+  }
+  if (skipBuild) {
+    return {
+      install: false,
+      status,
+      error: `--skip-build requires installed renderer == fresh dist; ${status.reason}`,
+    };
+  }
+  return { install: true, status };
+}
+
+export function resolveDeviceStatusStateDir(
+  env = process.env,
+  homedir = os.homedir(),
+) {
+  const explicit = env.ELIZA_DEVICE_STATUS_STATE_DIR?.trim();
+  if (explicit) return path.resolve(explicit.replace(/^~(?=$|\/)/, homedir));
+  const stateDir = env.ELIZA_STATE_DIR?.trim();
+  if (stateDir) return path.resolve(stateDir.replace(/^~(?=$|\/)/, homedir));
+  const namespace = env.ELIZA_NAMESPACE?.trim() || "eliza";
+  const xdg = env.XDG_STATE_HOME?.trim();
+  return path.join(xdg || path.join(homedir, ".local", "state"), namespace);
+}
+
+export function iosDeployLedgerPath(stateDir) {
+  return path.join(stateDir, "device-status", IOS_DEPLOY_LEDGER_FILENAME);
+}
+
+export function appendIosDeployLedgerEntry({
+  stateDir = resolveDeviceStatusStateDir(),
+  device,
+  bundleId,
+  stamp,
+  source = "ios-device-deploy",
+  deployedAt = new Date().toISOString(),
+}) {
+  if (!device?.udid) {
+    throw new Error("cannot write iOS deploy ledger entry without device.udid");
+  }
+  if (!stamp?.buildId) {
+    throw new Error(
+      "cannot write iOS deploy ledger entry without stamp.buildId",
+    );
+  }
+  const entry = {
+    source,
+    deployedAt,
+    bundleId,
+    device: {
+      identifier: device.identifier ?? null,
+      udid: device.udid,
+      name: device.name ?? null,
+    },
+    buildId: stamp.buildId,
+    commit: normalizeCommit(stamp.commit),
+    builtAt: stamp.builtAt ?? null,
+    variant: stamp.variant ?? null,
+    capacitorTarget: stamp.capacitorTarget ?? null,
+    runtimeMode: stamp.runtimeMode ?? null,
+  };
+  const ledgerPath = iosDeployLedgerPath(stateDir);
+  fs.mkdirSync(path.dirname(ledgerPath), { recursive: true });
+  fs.appendFileSync(ledgerPath, `${JSON.stringify(entry)}\n`);
+  return { entry, ledgerPath };
+}
+
+export function readIosDeployLedgerEntries({
+  stateDir = resolveDeviceStatusStateDir(),
+} = {}) {
+  const ledgerPath = iosDeployLedgerPath(stateDir);
+  if (!fs.existsSync(ledgerPath)) return [];
+  return fs
+    .readFileSync(ledgerPath, "utf8")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+export function latestIosDeployLedgerEntry({ entries, udid, bundleId } = {}) {
+  const wantedUdid = String(udid ?? "").toLowerCase();
+  const wantedBundle = String(bundleId ?? "");
+  return [...(entries ?? [])]
+    .reverse()
+    .find(
+      (entry) =>
+        String(entry?.device?.udid ?? "").toLowerCase() === wantedUdid &&
+        String(entry?.bundleId ?? "") === wantedBundle,
+    );
+}

--- a/packages/app/test/device-renderer-status.test.ts
+++ b/packages/app/test/device-renderer-status.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Device renderer-status tests cover the pure freshness decisions that gate
+ * stale mobile installs before adb, simctl, or devicectl touch real hardware.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  appendIosDeployLedgerEntry,
+  commitsMatch,
+  decideAndroidInstall,
+  evaluateRendererFreshness,
+  latestIosDeployLedgerEntry,
+  readIosDeployLedgerEntries,
+} from "../scripts/lib/device-renderer-status.mjs";
+
+describe("device renderer status", () => {
+  it("accepts matching build ids and develop commits", () => {
+    expect(
+      evaluateRendererFreshness({
+        installed: { buildId: "same", commit: "abcdef1234567890" },
+        fresh: { buildId: "same" },
+        developHead: "abcdef1234567890",
+      }),
+    ).toEqual({
+      verdict: "FRESH",
+      reason: "installed buildId matches fresh buildId same",
+    });
+  });
+
+  it("flags mismatched build ids as stale", () => {
+    expect(
+      evaluateRendererFreshness({
+        installed: { buildId: "old", commit: "abcdef" },
+        fresh: { buildId: "new" },
+      }),
+    ).toEqual({
+      verdict: "STALE",
+      reason: "installed buildId old != fresh buildId new",
+    });
+  });
+
+  it("flags missing installed stamps as unknown", () => {
+    expect(evaluateRendererFreshness({ fresh: { buildId: "new" } })).toEqual({
+      verdict: "UNKNOWN",
+      reason: "app is not installed or no installed stamp is available",
+    });
+  });
+
+  it("compares full and shortened commits", () => {
+    expect(commitsMatch("abcdef1234567890", "abcdef123456")).toBe(true);
+    expect(commitsMatch("abcdef123456", "abcdef1234567890")).toBe(true);
+    expect(commitsMatch("abcdef123456", "fedcba123456")).toBe(false);
+  });
+
+  it("lets Android skip install only when installed matches fresh", () => {
+    expect(
+      decideAndroidInstall({
+        installed: { buildId: "same" },
+        fresh: { buildId: "same" },
+      }),
+    ).toEqual({
+      install: false,
+      status: {
+        verdict: "FRESH",
+        reason: "installed buildId matches fresh buildId same",
+      },
+    });
+  });
+
+  it("fails Android skip-build when installed is stale", () => {
+    expect(
+      decideAndroidInstall({
+        installed: { buildId: "old" },
+        fresh: { buildId: "new" },
+        skipBuild: true,
+      }),
+    ).toEqual({
+      install: false,
+      status: {
+        verdict: "STALE",
+        reason: "installed buildId old != fresh buildId new",
+      },
+      error:
+        "--skip-build requires installed renderer == fresh dist; installed buildId old != fresh buildId new",
+    });
+  });
+
+  it("round-trips the latest physical iOS deploy ledger entry", () => {
+    const stateDir = mkdtempSync(path.join(os.tmpdir(), "device-status-"));
+    try {
+      appendIosDeployLedgerEntry({
+        stateDir,
+        device: { identifier: "dev-1", udid: "UDID-1", name: "Phone" },
+        bundleId: "ai.elizaos.app",
+        stamp: { buildId: "old", commit: "aaa" },
+        deployedAt: "2026-07-05T00:00:00.000Z",
+      });
+      appendIosDeployLedgerEntry({
+        stateDir,
+        device: { identifier: "dev-1", udid: "UDID-1", name: "Phone" },
+        bundleId: "ai.elizaos.app",
+        stamp: { buildId: "new", commit: "bbb" },
+        deployedAt: "2026-07-05T01:00:00.000Z",
+      });
+
+      const latest = latestIosDeployLedgerEntry({
+        entries: readIosDeployLedgerEntries({ stateDir }),
+        udid: "udid-1",
+        bundleId: "ai.elizaos.app",
+      });
+      expect(latest?.buildId).toBe("new");
+      expect(latest?.commit).toBe("bbb");
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Implements the shared stamp-driven freshness path for #14334 and #14335.

- Android e2e now reads renderer stamps from the candidate APK and the installed app (`pm path` → pull `base.apk` → read `assets/public/eliza-renderer-build.json`) instead of trusting package presence.
- `android-e2e.mjs` rebuilds/reinstalls when dist/APK/installed stamps are missing or stale, treats `--build` as a compatibility alias for `--force-build`, and makes `--skip-build` fail loudly on mismatch.
- Adds `bun run --cwd packages/app devices:status` with table output, `--json`, `--require-fresh`, and read-only Android/iOS simulator/physical-iOS status reporting.
- `ios-device-deploy.mjs` now writes a physical-device deploy ledger after successful install so phones whose app container cannot be read can still report the last deployed build.
- Adds pure unit tests for freshness verdicts, Android install decisions, commit matching, and iOS deploy ledger lookup.

## Validation

- `bun run --cwd packages/app test -- test/device-renderer-status.test.ts test/ios-renderer-stamp.test.ts`
  - 2 files passed, 10 tests passed.
- `bunx @biomejs/biome check packages/app/scripts/lib/device-renderer-status.mjs packages/app/scripts/lib/android-device.mjs packages/app/scripts/android-e2e.mjs packages/app/scripts/ios-device-deploy.mjs packages/app/scripts/ios-device-devicectl.mjs packages/app/scripts/devices-status.mjs packages/app/test/device-renderer-status.test.ts packages/app/package.json`
- `bun run --cwd packages/app devices:status -- --json --no-fetch > /tmp/devices-status.json && node -e 'const rows=JSON.parse(require("fs").readFileSync("/tmp/devices-status.json","utf8")); console.log(`json ok rows=${rows.length}`); console.log(rows.map(r=>`${r.platform}/${r.kind}:${r.verdict}`).join("\\n"));'`
  - Output parsed as JSON.
  - Current host reports honest N/A rows: `android/device:N/A`, `ios/simulator:N/A`, `ios/device:N/A`.
- `git diff --check origin/develop...HEAD`

## Hardware Evidence Still Needed

This PR is draft because this host cannot satisfy the issue evidence bar:

- No adb/platform-tools available, so I could not run `bun run --cwd packages/app test:e2e:android` against a real device/emulator.
- `simctl`/`devicectl` are not usable here, so I could not capture the requested iOS device/simulator status evidence.
- Required before marking ready: run with at least one stale Android install and one fresh install, capture the terminal logs, `devices:status --json`, and device screenshot/recording requested in #14334/#14335.

Refs #14334.
Refs #14335.