### PR TITLE
feat(app): bundle device e2e artifacts

### DIFF
--- a/packages/app/.gitignore
+++ b/packages/app/.gitignore
@@ -43,3 +43,6 @@ test/ui-smoke/output/
 
 # Local platform capture output; PR evidence is attached inline from generated files.
 capture-output/
+
+# Device-e2e bundles are regenerated per run and posted inline to PRs/issues.
+device-e2e-output/

--- a/packages/app/playwright.android.config.ts
+++ b/packages/app/playwright.android.config.ts
@@ -18,6 +18,22 @@ import { defineConfig } from "@playwright/test";
 //   3. The on-device local agent is up (mobile-local-chat-smoke bring-up) OR the
 //      app is pointed at a reachable cloud agent.
 const appDir = path.dirname(fileURLToPath(import.meta.url));
+const reporters = [["list"] as const];
+if (process.env.ELIZA_ANDROID_PLAYWRIGHT_JUNIT) {
+  reporters.push([
+    "junit",
+    { outputFile: process.env.ELIZA_ANDROID_PLAYWRIGHT_JUNIT },
+  ] as const);
+}
+if (process.env.ELIZA_ANDROID_PLAYWRIGHT_JSON) {
+  reporters.push([
+    "json",
+    { outputFile: process.env.ELIZA_ANDROID_PLAYWRIGHT_JSON },
+  ] as const);
+}
+if (!process.env.CI) {
+  reporters.push(["html", { open: "never" }] as const);
+}
 
 export default defineConfig({
   testDir: "./test/android",
@@ -32,7 +48,10 @@ export default defineConfig({
   // can run several minutes on the first pass.
   timeout: 420_000,
   expect: { timeout: 45_000 },
-  reporter: process.env.CI ? "list" : [["list"], ["html", { open: "never" }]],
+  reporter: reporters,
+  outputDir:
+    process.env.ELIZA_ANDROID_PLAYWRIGHT_OUTPUT_DIR ??
+    "./test-results/android-playwright",
   globalSetup: path.join(appDir, "test/android/global-setup.ts"),
   use: {
     // Screenshots/trace over the Android CDP socket are slow; capture only on

--- a/packages/app/scripts/android-e2e.mjs
+++ b/packages/app/scripts/android-e2e.mjs
@@ -21,6 +21,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  captureAndroidLogcat,
+  captureAndroidScreenshot,
+  startAndroidScreenRecord,
+} from "./lib/android-capture.mjs";
+import {
   androidApkNeedsBuild,
   androidDistNeedsBuild,
   androidInstallDecision,
@@ -35,6 +40,17 @@ import {
   resolveApk,
   resolveSerial,
 } from "./lib/android-device.mjs";
+import {
+  createDeviceE2eBundle,
+  finalizeDeviceE2eBundle,
+  finishBundleStep,
+  parseOutputDirArg,
+  recordBundleArtifact,
+  runBundledCommand,
+  setBundleBuild,
+  setBundleDevice,
+  startBundleStep,
+} from "./lib/device-e2e-bundle.mjs";
 import { acquireDeviceLease, isDeviceLeased } from "./lib/device-lease.mjs";
 
 const appDir = path.resolve(fileURLToPath(import.meta.url), "..", "..");
@@ -168,15 +184,8 @@ function stageVoiceModels(adb, serial) {
   log(`voice models staged for on-device ASR/TTS (${toStage.length} pushed).`);
 }
 
-function run(cmd, args, env = {}) {
-  const res = spawnSync(cmd, args, {
-    cwd: appDir,
-    stdio: "inherit",
-    env: { ...process.env, ...env },
-  });
-  if (res.status !== 0) {
-    throw new Error(`${cmd} ${args.join(" ")} exited with code ${res.status}`);
-  }
+function run(bundle, name, cmd, args, env = {}) {
+  return runBundledCommand(bundle, name, cmd, args, { cwd: appDir, env });
 }
 
 function currentHeadCommit() {
@@ -191,9 +200,9 @@ function currentHeadCommit() {
   }
 }
 
-function buildAndroidApk() {
+function buildAndroidApk(bundle) {
   log("building WebView-debuggable APK…");
-  run("bun", ["run", "build:android"], {
+  run(bundle, "build Android APK", "bun", ["run", "build:android"], {
     ELIZA_MOBILE_REPO_ROOT: elizaRoot,
     ELIZA_WEBVIEW_DEBUG: "1",
     ELIZA_BUN_RISCV64_OPTIONAL: "1",
@@ -220,7 +229,7 @@ function readApkRendererStamp(apk) {
   }
 }
 
-function ensureFreshApkInstalled(adb, serial) {
+function ensureFreshApkInstalled(bundle, adb, serial) {
   const forceBuild = has("--force-build") || has("--build");
   const skipBuild = has("--skip-build");
   const headCommit = currentHeadCommit();
@@ -228,7 +237,7 @@ function ensureFreshApkInstalled(adb, serial) {
   const buildDecision = androidDistNeedsBuild({ freshStamp, headCommit });
 
   if (forceBuild) {
-    buildAndroidApk();
+    buildAndroidApk(bundle);
   } else if (buildDecision.build) {
     if (skipBuild) {
       throw new Error(
@@ -236,7 +245,7 @@ function ensureFreshApkInstalled(adb, serial) {
       );
     }
     log(`${buildDecision.reason} — rebuilding before install check.`);
-    buildAndroidApk();
+    buildAndroidApk(bundle);
   } else {
     log(`fresh dist renderer stamp: ${stampLabel(freshStamp)}`);
   }
@@ -259,7 +268,7 @@ function ensureFreshApkInstalled(adb, serial) {
     }
     if (!forceBuild) {
       log(`${apkDecision.reason} — rebuilding APK before install.`);
-      buildAndroidApk();
+      buildAndroidApk(bundle);
       freshStamp = readFreshAndroidRendererStamp();
       if (!freshStamp) {
         throw new Error(
@@ -284,7 +293,14 @@ function ensureFreshApkInstalled(adb, serial) {
     : androidInstallDecision({ freshStamp, installedStamp });
   if (installDecision.install) {
     log(`${installDecision.reason} — installing ${apk}`);
-    installApk(adb, serial, apk);
+    const step = startBundleStep(bundle, "install Android APK");
+    try {
+      installApk(adb, serial, apk);
+      finishBundleStep(bundle, step, "passed");
+    } catch (error) {
+      finishBundleStep(bundle, step, "failed", error);
+      throw error;
+    }
     const readback = readInstalledRendererStamp(adb, serial, { log });
     const readbackDecision = androidInstallDecision({
       freshStamp,
@@ -295,10 +311,18 @@ function ensureFreshApkInstalled(adb, serial) {
         `Android install did not produce the fresh renderer stamp: ${readbackDecision.reason}`,
       );
     }
+    setBundleBuild(bundle, {
+      buildId: readback?.buildId ?? freshStamp.buildId,
+      commit: readback?.commit ?? freshStamp.commit ?? null,
+    });
     log(`installed renderer stamp verified: ${stampLabel(readback)}`);
     return;
   }
 
+  setBundleBuild(bundle, {
+    buildId: installedStamp?.buildId ?? freshStamp.buildId,
+    commit: installedStamp?.commit ?? freshStamp.commit ?? null,
+  });
   log(`${installDecision.reason} — skipping APK install.`);
 }
 
@@ -325,35 +349,77 @@ function ensureSmokeModelCached() {
 }
 
 async function main() {
-  const adb = resolveAdb();
-
-  let serial = val("--serial", process.env.ANDROID_SERIAL);
-  if (!serial && has("--no-emulator-boot")) {
-    const unleased = listDevices(adb).find(
-      (candidate) => !isDeviceLeased(`android:${candidate}`),
-    );
-    if (unleased) serial = unleased;
-  }
-  if (!has("--no-emulator-boot")) {
-    serial = await ensureEmulatorBooted({ adb, avd: val("--avd"), log });
-  }
-  serial = resolveSerial(adb, serial);
-  process.env.ANDROID_SERIAL = serial;
-  log(`device serial=${serial}`);
-  const lease = await acquireDeviceLease(`android:${serial}`, {
-    waitMs: has("--no-wait") ? 0 : undefined,
-    log,
+  const bundle = createDeviceE2eBundle({
+    appDir,
+    lane: "android",
+    outputDir: parseOutputDirArg(process.argv),
   });
+  let adb = null;
+  let serial;
+  let lease = null;
+  let finalResult = "failed";
+  let routeRecording = null;
 
   try {
-    await ensureEmulatorPermissive(adb, serial, { log });
+    adb = resolveAdb();
+    {
+      const step = startBundleStep(bundle, "resolve Android device");
+      try {
+        serial = val("--serial", process.env.ANDROID_SERIAL);
+        if (!serial && has("--no-emulator-boot")) {
+          const unleased = listDevices(adb).find(
+            (candidate) => !isDeviceLeased(`android:${candidate}`),
+          );
+          if (unleased) serial = unleased;
+        }
+        if (!has("--no-emulator-boot")) {
+          const bootStep = startBundleStep(bundle, "boot Android device");
+          try {
+            serial = await ensureEmulatorBooted({
+              adb,
+              avd: val("--avd"),
+              log,
+            });
+            finishBundleStep(bundle, bootStep, "passed");
+          } catch (error) {
+            finishBundleStep(bundle, bootStep, "failed", error);
+            throw error;
+          }
+        }
+        serial = resolveSerial(adb, serial);
+        finishBundleStep(bundle, step, "passed");
+      } catch (error) {
+        finishBundleStep(bundle, step, "failed", error);
+        throw error;
+      }
+    }
+    process.env.ANDROID_SERIAL = serial;
+    setBundleDevice(bundle, { serial, kind: "android" });
+    log(`device serial=${serial}`);
+    lease = await acquireDeviceLease(`android:${serial}`, {
+      waitMs: has("--no-wait") ? 0 : undefined,
+      log,
+    });
 
-    ensureFreshApkInstalled(adb, serial);
+    {
+      const step = startBundleStep(bundle, "prepare Android device");
+      try {
+        await ensureEmulatorPermissive(adb, serial, { log });
+        finishBundleStep(bundle, step, "passed");
+      } catch (error) {
+        finishBundleStep(bundle, step, "failed", error);
+        throw error;
+      }
+    }
+
+    ensureFreshApkInstalled(bundle, adb, serial);
 
     if (!has("--skip-local-chat")) {
       const modelPath = ensureSmokeModelCached();
       log("local route: on-device agent + smallest model + real chat…");
       run(
+        bundle,
+        "local chat smoke",
         "node",
         [
           "scripts/mobile-local-chat-smoke.mjs",
@@ -375,13 +441,65 @@ async function main() {
       // round-trip; the latter needs the ASR/TTS GGUFs staged (the chat smoke only
       // stages the text model, and an `adb install -r` cycle can drop the
       // separately-pushed voice models).
-      stageVoiceModels(adb, serial);
+      {
+        const step = startBundleStep(bundle, "stage Android voice models");
+        try {
+          stageVoiceModels(adb, serial);
+          finishBundleStep(bundle, step, "passed");
+        } catch (error) {
+          finishBundleStep(bundle, step, "failed", error);
+          throw error;
+        }
+      }
       log("route coverage: driving every route on the real WebView…");
-      run("node", [
-        "scripts/run-ui-playwright.mjs",
-        "--config",
-        "playwright.android.config.ts",
-      ]);
+      routeRecording = await startAndroidScreenRecord({
+        adb,
+        serial,
+        artifactDir: bundle.rawDir,
+        filename: "android-route-coverage.mp4",
+        remotePath: "/sdcard/eliza-android-route-coverage.mp4",
+        log,
+      });
+      try {
+        run(
+          bundle,
+          "Android route coverage",
+          "node",
+          [
+            "scripts/run-ui-playwright.mjs",
+            "--config",
+            "playwright.android.config.ts",
+          ],
+          {
+            ANDROID_SERIAL: serial,
+            ELIZA_DEVICE_E2E_ARTIFACT_DIR: path.join(
+              bundle.root,
+              "test-results",
+            ),
+            ELIZA_ANDROID_ARTIFACT_DIR: path.join(
+              bundle.root,
+              "test-results",
+              "android",
+            ),
+            ELIZA_ANDROID_PLAYWRIGHT_JUNIT: path.join(
+              bundle.reportsDir,
+              "android-playwright.junit.xml",
+            ),
+            ELIZA_ANDROID_PLAYWRIGHT_JSON: path.join(
+              bundle.reportsDir,
+              "android-playwright.json",
+            ),
+            PLAYWRIGHT_HTML_REPORT: path.join(
+              bundle.reportsDir,
+              "android-playwright-html",
+            ),
+          },
+        );
+      } finally {
+        const videoPath = await routeRecording.stop();
+        routeRecording = null;
+        if (videoPath) recordBundleArtifact(bundle, videoPath, "video");
+      }
     }
 
     if (has("--launcher-loop")) {
@@ -392,6 +510,8 @@ async function main() {
         "launcher loop: ≥200 real device gestures with per-action invariants…",
       );
       run(
+        bundle,
+        "Android launcher loop",
         "bunx",
         [
           "playwright",
@@ -405,6 +525,12 @@ async function main() {
           ELIZA_ANDROID_REQUIRE_AGENT:
             process.env.ELIZA_ANDROID_REQUIRE_AGENT ?? "1",
           ANDROID_SERIAL: serial,
+          ELIZA_DEVICE_E2E_ARTIFACT_DIR: path.join(bundle.root, "test-results"),
+          ELIZA_ANDROID_ARTIFACT_DIR: path.join(
+            bundle.root,
+            "test-results",
+            "android",
+          ),
         },
       );
     }
@@ -413,13 +539,59 @@ async function main() {
       log(
         "cloud route: real Hetzner provisioning probe (loud-fails if it can't)…",
       );
-      run("node", ["scripts/cloud-provisioning-e2e.mjs"]);
+      run(bundle, "cloud provisioning", "node", [
+        "scripts/cloud-provisioning-e2e.mjs",
+      ]);
     }
+    finalResult = "passed";
+    log("ALL ANDROID E2E PASSED ✅");
   } finally {
-    lease.release();
+    if (routeRecording) {
+      const videoPath = await routeRecording.stop();
+      if (videoPath) recordBundleArtifact(bundle, videoPath, "video");
+    }
+    if (adb && serial) {
+      try {
+        recordBundleArtifact(
+          bundle,
+          captureAndroidScreenshot({
+            adb,
+            serial,
+            artifactDir: bundle.rawDir,
+            filename: "android-final.png",
+            log,
+          }),
+          "screenshot",
+        );
+      } catch (error) {
+        // error-policy:J7 Bundle capture is diagnostic; preserve the runner result.
+        bundle.warnings.push(
+          `final Android screenshot failed: ${error?.message ?? error}`,
+        );
+      }
+      try {
+        recordBundleArtifact(
+          bundle,
+          captureAndroidLogcat({
+            adb,
+            serial,
+            artifactDir: bundle.logsDir,
+            filename: "android-logcat.txt",
+            log,
+          }),
+          "log",
+        );
+      } catch (error) {
+        // error-policy:J7 Bundle capture is diagnostic; preserve the runner result.
+        bundle.warnings.push(
+          `Android logcat capture failed: ${error?.message ?? error}`,
+        );
+      }
+    }
+    lease?.release();
+    const bundleRoot = finalizeDeviceE2eBundle(bundle, finalResult);
+    log(`bundle: ${bundleRoot}`);
   }
-
-  log("ALL ANDROID E2E PASSED ✅");
 }
 
 main().catch((error) => {

--- a/packages/app/scripts/device-e2e-bundle.test.mjs
+++ b/packages/app/scripts/device-e2e-bundle.test.mjs
@@ -1,0 +1,180 @@
+/**
+ * Unit coverage for the device-e2e bundle assembler.
+ *
+ * The real runners need phones/simulators, so this test pins the pure filesystem
+ * contract: output directory selection, inline-ready artifact collection,
+ * summary writing, and JUnit generation on both passing and failed steps.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  collectBundleArtifacts,
+  createDeviceE2eBundle,
+  defaultDeviceE2eOutputDir,
+  finalizeDeviceE2eBundle,
+  finishBundleStep,
+  parseOutputDirArg,
+  recordBundleArtifact,
+  runBundledCommand,
+  startBundleStep,
+} from "./lib/device-e2e-bundle.mjs";
+
+const tempDirs = [];
+const ONE_BY_ONE_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+  "base64",
+);
+
+function tempRoot() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "device-e2e-bundle-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("device-e2e bundle assembly", () => {
+  it("parses --output and builds the default per-lane directory", () => {
+    expect(parseOutputDirArg(["node", "runner", "--output", "/tmp/out"])).toBe(
+      "/tmp/out",
+    );
+    expect(parseOutputDirArg(["node", "runner"])).toBeUndefined();
+    expect(
+      defaultDeviceE2eOutputDir({
+        appDir: "/repo/packages/app",
+        lane: "android",
+        date: new Date("2026-07-05T01:02:03.004Z"),
+      }),
+    ).toBe(
+      "/repo/packages/app/device-e2e-output/android-2026-07-05T01-02-03-004Z",
+    );
+  });
+
+  it("writes summary, junit, and inline copies for existing JPG/MP4 artifacts", () => {
+    const root = tempRoot();
+    const bundle = createDeviceE2eBundle({
+      appDir: root,
+      lane: "android",
+      outputDir: path.join(root, "bundle"),
+      device: { serial: "device-1" },
+      build: { buildId: "build-1", commit: "abc123" },
+    });
+
+    const sourceDir = path.join(root, "source");
+    fs.mkdirSync(sourceDir, { recursive: true });
+    const jpg = path.join(sourceDir, "screen.jpg");
+    const mp4 = path.join(sourceDir, "walkthrough.mp4");
+    fs.writeFileSync(jpg, "jpg");
+    fs.writeFileSync(mp4, "mp4");
+
+    const step = startBundleStep(bundle, "route coverage");
+    recordBundleArtifact(bundle, jpg, "screenshot", step);
+    recordBundleArtifact(bundle, mp4, "video", step);
+    finishBundleStep(bundle, step, "passed");
+
+    const bundleRoot = finalizeDeviceE2eBundle(bundle, "passed");
+    const summary = JSON.parse(
+      fs.readFileSync(path.join(bundleRoot, "summary.json"), "utf8"),
+    );
+
+    expect(summary.result).toBe("passed");
+    expect(summary.device.serial).toBe("device-1");
+    expect(summary.build.buildId).toBe("build-1");
+    expect(summary.steps).toHaveLength(1);
+    expect(fs.existsSync(path.join(bundleRoot, "junit.xml"))).toBe(true);
+    expect(fs.existsSync(path.join(bundleRoot, "inline", "screen.jpg"))).toBe(
+      true,
+    );
+    expect(
+      fs.existsSync(path.join(bundleRoot, "inline", "walkthrough.mp4")),
+    ).toBe(true);
+  });
+
+  it("collects logs from source directories and records failed steps in junit", () => {
+    const root = tempRoot();
+    const bundle = createDeviceE2eBundle({
+      appDir: root,
+      lane: "ios-sim",
+      outputDir: path.join(root, "bundle"),
+    });
+    const logDir = path.join(root, "logs");
+    fs.mkdirSync(logDir, { recursive: true });
+    fs.writeFileSync(path.join(logDir, "runner.log"), "failed\n");
+
+    const step = startBundleStep(bundle, "local chat");
+    finishBundleStep(bundle, step, "failed", new Error("chat failed"));
+    collectBundleArtifacts(bundle, [logDir]);
+    finalizeDeviceE2eBundle(bundle, "failed");
+
+    const junit = fs.readFileSync(path.join(bundle.root, "junit.xml"), "utf8");
+    const summary = JSON.parse(
+      fs.readFileSync(path.join(bundle.root, "summary.json"), "utf8"),
+    );
+    expect(junit).toContain('failures="1"');
+    expect(junit).toContain("chat failed");
+    expect(summary.result).toBe("failed");
+    expect(summary.artifacts.some((a) => a.path.endsWith("runner.log"))).toBe(
+      true,
+    );
+  });
+
+  it("converts PNG screenshots into inline JPG artifacts", () => {
+    const root = tempRoot();
+    const bundle = createDeviceE2eBundle({
+      appDir: root,
+      lane: "android",
+      outputDir: path.join(root, "bundle"),
+    });
+    const png = path.join(bundle.rawDir, "screen.png");
+    fs.writeFileSync(png, ONE_BY_ONE_PNG);
+    recordBundleArtifact(bundle, png, "screenshot");
+
+    finalizeDeviceE2eBundle(bundle, "passed");
+
+    const summary = JSON.parse(
+      fs.readFileSync(path.join(bundle.root, "summary.json"), "utf8"),
+    );
+    expect(fs.existsSync(path.join(bundle.inlineDir, "screen.jpg"))).toBe(true);
+    expect(summary.artifacts.some((a) => a.path === "inline/screen.jpg")).toBe(
+      true,
+    );
+  });
+
+  it("writes a failed summary and runner log when a bundled command fails", () => {
+    const root = tempRoot();
+    const bundle = createDeviceE2eBundle({
+      appDir: root,
+      lane: "android",
+      outputDir: path.join(root, "bundle"),
+    });
+
+    expect(() =>
+      runBundledCommand(
+        bundle,
+        "failing command",
+        process.execPath,
+        ["-e", "console.error('nope'); process.exit(7)"],
+        { cwd: root },
+      ),
+    ).toThrow(/exited with code 7/);
+    finalizeDeviceE2eBundle(bundle, "failed");
+
+    const summary = JSON.parse(
+      fs.readFileSync(path.join(bundle.root, "summary.json"), "utf8"),
+    );
+    expect(summary.result).toBe("failed");
+    expect(summary.steps[0]).toMatchObject({
+      name: "failing command",
+      status: "failed",
+    });
+    expect(
+      fs.readFileSync(path.join(bundle.logsDir, "runner.log"), "utf8"),
+    ).toContain("nope");
+  });
+});

--- a/packages/app/scripts/ios-e2e-lib.mjs
+++ b/packages/app/scripts/ios-e2e-lib.mjs
@@ -39,6 +39,7 @@ export function parseIosE2eArgs(argv) {
   return {
     device: val("--device"),
     appPath: val("--app-path"),
+    output: val("--output"),
     skipBuild: has("--skip-build"),
     skipAuth: has("--skip-auth"),
     skipLocalChat: has("--skip-local-chat"),

--- a/packages/app/scripts/ios-e2e-lib.test.mjs
+++ b/packages/app/scripts/ios-e2e-lib.test.mjs
@@ -33,6 +33,7 @@ describe("parseIosE2eArgs", () => {
     expect(f).toEqual({
       device: undefined,
       appPath: undefined,
+      output: undefined,
       skipBuild: false,
       skipAuth: false,
       skipLocalChat: false,
@@ -56,15 +57,18 @@ describe("parseIosE2eArgs", () => {
     expect(f.noWait).toBe(true);
   });
 
-  it("captures --device and --app-path values", () => {
+  it("captures --device, --app-path, and --output values", () => {
     const f = parseIosE2eArgs([
       "--device",
       "iPhone 15",
       "--app-path",
       "/tmp/App.app",
+      "--output",
+      "/tmp/evidence",
     ]);
     expect(f.device).toBe("iPhone 15");
     expect(f.appPath).toBe("/tmp/App.app");
+    expect(f.output).toBe("/tmp/evidence");
   });
 
   it("does not read past the end of argv for a trailing value flag", () => {

--- a/packages/app/scripts/ios-e2e.mjs
+++ b/packages/app/scripts/ios-e2e.mjs
@@ -11,8 +11,8 @@
 //   5. (optional) Cloud route: real provisioning probe.
 //
 // Flags: --device <name|udid>  --app-path <App.app>  --skip-build
-//        --skip-local-chat  --skip-auth  --cloud  --no-wait
-import { execFileSync, spawnSync } from "node:child_process";
+//        --skip-local-chat  --skip-auth  --cloud  --no-wait  --output <dir>
+import { execFileSync, spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -22,7 +22,6 @@ import {
   buildCloudProvisioningCommand,
   buildIosSimBuildCommand,
   buildLocalChatSmokeCommand,
-  classifyStepExit,
   extractAppId,
   isAppInstalled,
   parseIosE2eArgs,
@@ -30,6 +29,16 @@ import {
   resolveTargetDevice,
   selectBootedUdid,
 } from "./ios-e2e-lib.mjs";
+import {
+  createDeviceE2eBundle,
+  finalizeDeviceE2eBundle,
+  finishBundleStep,
+  recordBundleArtifact,
+  runBundledCommand,
+  setBundleBuild,
+  setBundleDevice,
+  startBundleStep,
+} from "./lib/device-e2e-bundle.mjs";
 import { acquireDeviceLease } from "./lib/device-lease.mjs";
 import {
   assertCandidateIosAppRendererFresh,
@@ -42,22 +51,15 @@ const appDir = path.resolve(fileURLToPath(import.meta.url), "..", "..");
 const repoRoot = path.resolve(appDir, "..", "..");
 const flags = parseIosE2eArgs(process.argv);
 const log = (m) => console.log(`[ios-e2e] ${m}`);
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function readAppId() {
   const configPath = path.join(appDir, "app.config.ts");
   return extractAppId(fs.readFileSync(configPath, "utf8"));
 }
 
-function run(cmd, args, env = {}) {
-  const res = spawnSync(cmd, args, {
-    cwd: appDir,
-    stdio: "inherit",
-    env: { ...process.env, ...env },
-  });
-  const outcome = classifyStepExit(res.status);
-  if (!outcome.ok) {
-    throw new Error(`${cmd} ${args.join(" ")} ${outcome.reason}`);
-  }
+function run(bundle, name, cmd, args, env = {}) {
+  runBundledCommand(bundle, name, cmd, args, { cwd: appDir, env });
 }
 
 function simctl(args) {
@@ -70,6 +72,64 @@ function trySimctl(args) {
   } catch {
     return null;
   }
+}
+
+function captureSimulatorScreenshot(bundle, udid) {
+  const outPath = path.join(bundle.rawDir, "ios-final.png");
+  simctl(["io", udid, "screenshot", "--type=png", outPath]);
+  return outPath;
+}
+
+async function recordSimulatorVideo(bundle, udid, durationSeconds = 3) {
+  const outPath = path.join(bundle.rawDir, "ios-final.mov");
+  const recorder = spawn(
+    "xcrun",
+    [
+      "simctl",
+      "io",
+      udid,
+      "recordVideo",
+      "--codec",
+      "h264",
+      "--force",
+      outPath,
+    ],
+    { stdio: "ignore" },
+  );
+  await delay(Math.max(1, durationSeconds) * 1000);
+  recorder.kill("SIGINT");
+  await Promise.race([
+    new Promise((resolve) => recorder.once("close", resolve)),
+    delay(5_000),
+  ]);
+  if (!fs.existsSync(outPath)) return null;
+  return outPath;
+}
+
+function captureSimulatorLog(bundle, udid) {
+  const outPath = path.join(bundle.logsDir, "ios-sim.log");
+  const result = spawnSync(
+    "xcrun",
+    [
+      "simctl",
+      "spawn",
+      udid,
+      "log",
+      "show",
+      "--style",
+      "compact",
+      "--last",
+      "5m",
+    ],
+    { encoding: "utf8", maxBuffer: 32 * 1024 * 1024 },
+  );
+  fs.writeFileSync(
+    outPath,
+    result.status === 0
+      ? result.stdout
+      : result.stderr || `simctl log show exited with ${result.status}\n`,
+  );
+  return outPath;
 }
 
 function bootedUdid() {
@@ -124,7 +184,7 @@ function installBuiltSimulatorApp(udid, appId) {
   if (!isAppInstalled(installed)) {
     throw new Error(`${appId} was not installed after simctl install.`);
   }
-  assertInstalledIosAppRendererFresh({
+  return assertInstalledIosAppRendererFresh({
     udid,
     bundleId: appId,
     repoRoot,
@@ -132,31 +192,45 @@ function installBuiltSimulatorApp(udid, appId) {
   });
 }
 
-function runStep(step, { udid, appId }) {
+function runStep(bundle, step, { udid, appId }) {
   switch (step.id) {
     case "build": {
       log("building the iOS Simulator app…");
       const build = buildIosSimBuildCommand();
-      run(build.cmd, build.args);
-      installBuiltSimulatorApp(udid, appId);
+      run(bundle, step.label, build.cmd, build.args);
+      const installStep = startBundleStep(bundle, "install iOS Simulator app");
+      try {
+        const stamp = installBuiltSimulatorApp(udid, appId);
+        setBundleBuild(bundle, {
+          buildId: stamp?.buildId ?? null,
+          commit: stamp?.commit ?? null,
+        });
+        finishBundleStep(bundle, installStep, "passed");
+      } catch (error) {
+        finishBundleStep(bundle, installStep, "failed", error);
+        throw error;
+      }
       return;
     }
     case "auth": {
       log(`${step.label}…`);
       const auth = buildAuthSmokeCommand(udid);
-      run(auth.cmd, auth.args);
+      run(bundle, step.label, auth.cmd, auth.args);
       return;
     }
     case "local-chat": {
       log(`${step.label}…`);
       const chat = buildLocalChatSmokeCommand();
-      run(chat.cmd, chat.args);
+      run(bundle, step.label, chat.cmd, chat.args, {
+        ELIZA_DEVICE_E2E_ARTIFACT_DIR: path.join(bundle.root, "test-results"),
+        ELIZA_IOS_ARTIFACT_DIR: path.join(bundle.root, "test-results", "ios"),
+      });
       return;
     }
     case "cloud": {
       log(`${step.label}…`);
       const cloud = buildCloudProvisioningCommand();
-      run(cloud.cmd, cloud.args);
+      run(bundle, step.label, cloud.cmd, cloud.args);
       return;
     }
     default:
@@ -165,27 +239,82 @@ function runStep(step, { udid, appId }) {
 }
 
 async function main() {
-  const steps = planIosE2eSteps(flags);
-  // Refuse a run that would print success without exercising any device path.
-  assertNonVacuousPlan(steps);
-  log(`plan: ${steps.map((s) => s.id).join(" → ")}`);
-
-  const appId = readAppId();
-  const udid = ensureSimulatorBooted(flags.device);
-  log(`simulator udid=${udid}`);
-  const lease = await acquireDeviceLease(`ios:${udid}`, {
-    waitMs: flags.noWait ? 0 : undefined,
-    log,
+  const bundle = createDeviceE2eBundle({
+    appDir,
+    lane: "ios-sim",
+    outputDir: flags.output,
   });
+  let finalResult = "failed";
+  let lease = null;
+  let udid = null;
+  let appId = null;
+
   try {
+    const steps = planIosE2eSteps(flags);
+    // Refuse a run that would print success without exercising any device path.
+    assertNonVacuousPlan(steps);
+    log(`plan: ${steps.map((s) => s.id).join(" → ")}`);
+
+    appId = readAppId();
+    const bootStep = startBundleStep(bundle, "boot iOS Simulator");
+    try {
+      udid = ensureSimulatorBooted(flags.device);
+      finishBundleStep(bundle, bootStep, "passed");
+    } catch (error) {
+      finishBundleStep(bundle, bootStep, "failed", error);
+      throw error;
+    }
+    log(`simulator udid=${udid}`);
+    setBundleDevice(bundle, { udid, kind: "ios-simulator" });
+    lease = await acquireDeviceLease(`ios:${udid}`, {
+      waitMs: flags.noWait ? 0 : undefined,
+      log,
+    });
+
     clearIosSmokeDefaults({ udid, bundleId: appId, log });
     for (const step of steps) {
-      runStep(step, { udid, appId });
+      runStep(bundle, step, { udid, appId });
     }
+    finalResult = "passed";
     log("ALL iOS E2E PASSED ✅");
   } finally {
-    clearIosSmokeDefaults({ udid, bundleId: appId, log });
-    lease.release();
+    if (udid && appId) {
+      try {
+        recordBundleArtifact(
+          bundle,
+          captureSimulatorScreenshot(bundle, udid),
+          "screenshot",
+        );
+      } catch (error) {
+        // error-policy:J7 Bundle capture is diagnostic; preserve the runner result.
+        bundle.warnings.push(
+          `final iOS screenshot failed: ${error?.message ?? error}`,
+        );
+      }
+      try {
+        const video = await recordSimulatorVideo(bundle, udid);
+        if (video) recordBundleArtifact(bundle, video, "video");
+      } catch (error) {
+        // error-policy:J7 Bundle capture is diagnostic; preserve the runner result.
+        bundle.warnings.push(
+          `final iOS video failed: ${error?.message ?? error}`,
+        );
+      }
+      try {
+        recordBundleArtifact(bundle, captureSimulatorLog(bundle, udid), "log");
+      } catch (error) {
+        // error-policy:J7 Bundle capture is diagnostic; preserve the runner result.
+        bundle.warnings.push(
+          `final iOS log capture failed: ${error?.message ?? error}`,
+        );
+      }
+    }
+    if (udid && appId) {
+      clearIosSmokeDefaults({ udid, bundleId: appId, log });
+    }
+    lease?.release();
+    const bundleRoot = finalizeDeviceE2eBundle(bundle, finalResult);
+    log(`bundle: ${bundleRoot}`);
   }
 }
 main().catch((error) => {

--- a/packages/app/scripts/lib/device-e2e-bundle.mjs
+++ b/packages/app/scripts/lib/device-e2e-bundle.mjs
@@ -1,0 +1,399 @@
+/**
+ * Device-e2e bundle assembly for the mobile runners.
+ *
+ * The runners exercise real devices and fail at many layers: build, install,
+ * device boot, local agent startup, WebView driving, and cloud provisioning.
+ * This module keeps those phases visible in one run directory even when the
+ * process exits non-zero, and prepares inline-friendly evidence files for PR
+ * comments without sending new output to the retired issue-evidence tree.
+ */
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const INLINE_EXTENSIONS = new Set([".jpg", ".jpeg", ".mp4"]);
+const IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg"]);
+const VIDEO_EXTENSIONS = new Set([".mp4", ".mov"]);
+const LOG_EXTENSIONS = new Set([".log", ".txt", ".json", ".jsonl"]);
+
+function timestampId(date = new Date()) {
+  return date.toISOString().replace(/[:.]/g, "-");
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function isFile(filePath) {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    // error-policy:J3 Artifact paths can disappear while a failing runner unwinds.
+    return false;
+  }
+}
+
+function isNonEmptyFile(filePath) {
+  try {
+    return fs.statSync(filePath).size > 0;
+  } catch {
+    // error-policy:J3 Missing conversion output is an invalid artifact signal.
+    return false;
+  }
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function xmlEscape(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function uniquePath(dir, filename) {
+  const parsed = path.parse(filename);
+  let candidate = path.join(dir, filename);
+  let index = 2;
+  while (fs.existsSync(candidate)) {
+    candidate = path.join(dir, `${parsed.name}-${index}${parsed.ext}`);
+    index += 1;
+  }
+  return candidate;
+}
+
+function walkFiles(root) {
+  if (!root || !fs.existsSync(root)) return [];
+  const files = [];
+  const stack = [root];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    let entries = [];
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      // error-policy:J3 Unreadable artifact roots are skipped, not reported as collected.
+      continue;
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(fullPath);
+      } else if (entry.isFile()) {
+        files.push(fullPath);
+      }
+    }
+  }
+  return files;
+}
+
+function shellAvailable(cmd) {
+  return spawnSync(cmd, ["-version"], { stdio: "ignore" }).status === 0;
+}
+
+function convertPngToJpg(src, dest) {
+  if (process.platform === "darwin") {
+    const sips = spawnSync(
+      "sips",
+      ["-s", "format", "jpeg", src, "--out", dest],
+      { stdio: "ignore" },
+    );
+    if (sips.status === 0 && isNonEmptyFile(dest)) return true;
+  }
+  if (shellAvailable("ffmpeg")) {
+    const ffmpeg = spawnSync(
+      "ffmpeg",
+      ["-y", "-i", src, "-frames:v", "1", "-q:v", "2", dest],
+      { stdio: "ignore" },
+    );
+    if (ffmpeg.status === 0 && isNonEmptyFile(dest)) return true;
+  }
+  return false;
+}
+
+function remuxMovToMp4(src, dest) {
+  if (!shellAvailable("ffmpeg")) return false;
+  const result = spawnSync(
+    "ffmpeg",
+    ["-y", "-i", src, "-c", "copy", "-movflags", "+faststart", dest],
+    { stdio: "ignore" },
+  );
+  return result.status === 0 && isNonEmptyFile(dest);
+}
+
+export function parseOutputDirArg(argv) {
+  const index = argv.indexOf("--output");
+  return index >= 0 && index + 1 < argv.length ? argv[index + 1] : undefined;
+}
+
+export function defaultDeviceE2eOutputDir({ appDir, lane, date = new Date() }) {
+  return path.join(appDir, "device-e2e-output", `${lane}-${timestampId(date)}`);
+}
+
+export function createDeviceE2eBundle({
+  appDir,
+  lane,
+  outputDir,
+  startedAt = new Date(),
+  device = {},
+  build = {},
+}) {
+  const root = path.resolve(
+    outputDir ?? defaultDeviceE2eOutputDir({ appDir, lane, date: startedAt }),
+  );
+  const bundle = {
+    root,
+    inlineDir: ensureDir(path.join(root, "inline")),
+    logsDir: ensureDir(path.join(root, "logs")),
+    rawDir: ensureDir(path.join(root, "raw")),
+    reportsDir: ensureDir(path.join(root, "reports")),
+    startedAt: startedAt.toISOString(),
+    lane,
+    device,
+    build,
+    steps: [],
+    artifacts: [],
+    warnings: [],
+    _activeStep: null,
+  };
+  ensureDir(root);
+  writeJson(path.join(root, "summary.json"), buildSummary(bundle, "running"));
+  return bundle;
+}
+
+export function setBundleDevice(bundle, device) {
+  bundle.device = { ...bundle.device, ...device };
+  return bundle.device;
+}
+
+export function setBundleBuild(bundle, build) {
+  bundle.build = { ...bundle.build, ...build };
+  return bundle.build;
+}
+
+export function startBundleStep(bundle, name) {
+  const step = {
+    name,
+    status: "running",
+    startedAt: new Date().toISOString(),
+    durationMs: 0,
+    artifacts: [],
+  };
+  bundle.steps.push(step);
+  bundle._activeStep = step;
+  return step;
+}
+
+export function finishBundleStep(bundle, step, status, error) {
+  const endedAt = new Date();
+  step.endedAt = endedAt.toISOString();
+  step.durationMs = Math.max(0, endedAt.getTime() - Date.parse(step.startedAt));
+  step.status = status;
+  if (error) step.error = String(error?.message ?? error);
+  if (bundle._activeStep === step) bundle._activeStep = null;
+  return step;
+}
+
+export function recordBundleArtifact(bundle, filePath, kind, step = null) {
+  const absolute = path.resolve(filePath);
+  if (!isFile(absolute)) return null;
+  const artifact = {
+    kind,
+    path: absolute,
+    relativePath: path.relative(bundle.root, absolute),
+    sizeBytes: fs.statSync(absolute).size,
+  };
+  bundle.artifacts.push(artifact);
+  const owner = step ?? bundle._activeStep;
+  if (owner) owner.artifacts.push(artifact.relativePath);
+  return artifact;
+}
+
+export function appendRunnerLog(bundle, chunk) {
+  fs.appendFileSync(path.join(bundle.logsDir, "runner.log"), chunk);
+}
+
+export function runBundledCommand(
+  bundle,
+  name,
+  cmd,
+  args,
+  { cwd, env = {} } = {},
+) {
+  const step = startBundleStep(bundle, name);
+  const result = spawnSync(cmd, args, {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+    maxBuffer: 128 * 1024 * 1024,
+  });
+  const stdout = result.stdout ?? "";
+  const stderr = result.stderr ?? "";
+  if (stdout) {
+    process.stdout.write(stdout);
+    appendRunnerLog(bundle, stdout);
+  }
+  if (stderr) {
+    process.stderr.write(stderr);
+    appendRunnerLog(bundle, stderr);
+  }
+  const ok = result.status === 0;
+  finishBundleStep(
+    bundle,
+    step,
+    ok ? "passed" : "failed",
+    ok
+      ? null
+      : `${cmd} ${args.join(" ")} ${
+          result.status === null
+            ? "terminated by signal"
+            : `exited with ${result.status}`
+        }`,
+  );
+  if (!ok) {
+    throw new Error(
+      `${cmd} ${args.join(" ")} ${
+        result.status === null
+          ? "terminated by signal"
+          : `exited with code ${result.status}`
+      }`,
+    );
+  }
+  return result;
+}
+
+export function collectBundleArtifacts(bundle, sourceDirs) {
+  const seen = new Set(bundle.artifacts.map((artifact) => artifact.path));
+  for (const sourceDir of sourceDirs.filter(Boolean)) {
+    for (const file of walkFiles(sourceDir)) {
+      const ext = path.extname(file).toLowerCase();
+      if (seen.has(path.resolve(file))) continue;
+      if (VIDEO_EXTENSIONS.has(ext)) {
+        recordBundleArtifact(bundle, file, "video");
+      } else if (IMAGE_EXTENSIONS.has(ext)) {
+        recordBundleArtifact(bundle, file, "screenshot");
+      } else if (
+        LOG_EXTENSIONS.has(ext) ||
+        path.basename(file) === "junit.xml"
+      ) {
+        recordBundleArtifact(bundle, file, "log");
+      }
+      seen.add(path.resolve(file));
+    }
+  }
+}
+
+export function prepareInlineArtifacts(bundle) {
+  for (const artifact of [...bundle.artifacts]) {
+    const ext = path.extname(artifact.path).toLowerCase();
+    if (INLINE_EXTENSIONS.has(ext)) {
+      const dest = uniquePath(bundle.inlineDir, path.basename(artifact.path));
+      if (path.resolve(artifact.path) !== path.resolve(dest)) {
+        fs.copyFileSync(artifact.path, dest);
+      }
+      recordBundleArtifact(bundle, dest, artifact.kind);
+      continue;
+    }
+    if (ext === ".png") {
+      const dest = uniquePath(
+        bundle.inlineDir,
+        `${path.basename(artifact.path, ext)}.jpg`,
+      );
+      if (convertPngToJpg(artifact.path, dest)) {
+        recordBundleArtifact(bundle, dest, "screenshot");
+      } else {
+        bundle.warnings.push(`could not convert PNG to JPG: ${artifact.path}`);
+      }
+      continue;
+    }
+    if (ext === ".mov") {
+      const dest = uniquePath(
+        bundle.inlineDir,
+        `${path.basename(artifact.path, ext)}.mp4`,
+      );
+      if (remuxMovToMp4(artifact.path, dest)) {
+        recordBundleArtifact(bundle, dest, "video");
+      } else {
+        bundle.warnings.push(`could not remux MOV to MP4: ${artifact.path}`);
+      }
+    }
+  }
+}
+
+export function writeBundleJunit(bundle, result) {
+  const failed = bundle.steps.filter((step) => step.status === "failed");
+  const tests = bundle.steps.length || 1;
+  const body =
+    bundle.steps.length === 0
+      ? `<testcase classname="${xmlEscape(bundle.lane)}" name="runner" />`
+      : bundle.steps
+          .map((step) => {
+            const seconds = (step.durationMs / 1000).toFixed(3);
+            const failure =
+              step.status === "failed"
+                ? `<failure message="${xmlEscape(step.error ?? "failed")}">${xmlEscape(step.error ?? "failed")}</failure>`
+                : "";
+            return `<testcase classname="${xmlEscape(bundle.lane)}" name="${xmlEscape(step.name)}" time="${seconds}">${failure}</testcase>`;
+          })
+          .join("\n");
+  const xml =
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<testsuite name="${xmlEscape(bundle.lane)}" tests="${tests}" failures="${failed.length}" errors="0" time="${(totalDurationMs(bundle) / 1000).toFixed(3)}" result="${xmlEscape(result)}">\n` +
+    `${body}\n` +
+    `</testsuite>\n`;
+  const junitPath = path.join(bundle.root, "junit.xml");
+  fs.writeFileSync(junitPath, xml);
+  recordBundleArtifact(bundle, junitPath, "junit");
+  return junitPath;
+}
+
+function totalDurationMs(bundle) {
+  return bundle.steps.reduce((sum, step) => sum + (step.durationMs ?? 0), 0);
+}
+
+function buildSummary(bundle, result) {
+  return {
+    lane: bundle.lane,
+    startedAt: bundle.startedAt,
+    finishedAt: new Date().toISOString(),
+    device: bundle.device,
+    build: bundle.build,
+    steps: bundle.steps.map((step) => ({
+      name: step.name,
+      status: step.status,
+      startedAt: step.startedAt,
+      endedAt: step.endedAt ?? null,
+      durationMs: step.durationMs,
+      artifacts: step.artifacts,
+      ...(step.error ? { error: step.error } : {}),
+    })),
+    artifacts: bundle.artifacts.map((artifact) => ({
+      kind: artifact.kind,
+      path: artifact.relativePath,
+      sizeBytes: artifact.sizeBytes,
+    })),
+    warnings: bundle.warnings,
+    result,
+  };
+}
+
+export function finalizeDeviceE2eBundle(bundle, result) {
+  collectBundleArtifacts(bundle, [
+    bundle.rawDir,
+    bundle.logsDir,
+    bundle.reportsDir,
+    path.join(bundle.root, "test-results"),
+  ]);
+  prepareInlineArtifacts(bundle);
+  writeBundleJunit(bundle, result);
+  writeJson(
+    path.join(bundle.root, "summary.json"),
+    buildSummary(bundle, result),
+  );
+  return bundle.root;
+}

--- a/packages/app/test/android/launcher-gesture-loop.android.spec.ts
+++ b/packages/app/test/android/launcher-gesture-loop.android.spec.ts
@@ -47,10 +47,14 @@ function repoRootFromCwd() {
 }
 
 const ARTIFACT_DIR = path.join(
-  repoRootFromCwd(),
-  ".github",
-  "issue-evidence",
-  ISSUE_EVIDENCE_DIR,
+  process.env.ELIZA_ANDROID_ARTIFACT_DIR ??
+    path.join(
+      repoRootFromCwd(),
+      ".github",
+      "issue-evidence",
+      ISSUE_EVIDENCE_DIR,
+    ),
+  "launcher-gesture-loop",
 );
 
 function writeJsonArtifact(filename: string, data: unknown) {

--- a/packages/app/test/android/lifecycle-reboot.android.spec.ts
+++ b/packages/app/test/android/lifecycle-reboot.android.spec.ts
@@ -30,13 +30,17 @@ import {
 } from "../../scripts/lib/android-device.mjs";
 
 const ARTIFACT_DIR = path.resolve(
-  process.cwd(),
-  "..",
-  "..",
-  ".github",
-  "issue-evidence",
-  "12185-device-lifecycle",
-  "android",
+  process.env.ELIZA_ANDROID_ARTIFACT_DIR ??
+    path.join(
+      process.cwd(),
+      "..",
+      "..",
+      ".github",
+      "issue-evidence",
+      "12185-device-lifecycle",
+      "android",
+    ),
+  "lifecycle-reboot",
 );
 
 const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));

--- a/packages/app/test/android/lifecycle.android.spec.ts
+++ b/packages/app/test/android/lifecycle.android.spec.ts
@@ -31,13 +31,17 @@ import {
 } from "./android-harness";
 
 const ARTIFACT_DIR = path.resolve(
-  process.cwd(),
-  "..",
-  "..",
-  ".github",
-  "issue-evidence",
-  "12185-device-lifecycle",
-  "android",
+  process.env.ELIZA_ANDROID_ARTIFACT_DIR ??
+    path.join(
+      process.cwd(),
+      "..",
+      "..",
+      ".github",
+      "issue-evidence",
+      "12185-device-lifecycle",
+      "android",
+    ),
+  "lifecycle",
 );
 
 const SETTINGS_ACTIVITY = "com.android.settings/.Settings";

--- a/packages/app/test/android/native-plugin-view-smoke.android.spec.ts
+++ b/packages/app/test/android/native-plugin-view-smoke.android.spec.ts
@@ -17,9 +17,9 @@ import {
 import { expect, test, waitForShellReady } from "./android-harness";
 
 const ARTIFACT_DIR = path.join(
-  process.cwd(),
-  "test-results",
-  "android-native-plugin-view-smoke",
+  process.env.ELIZA_ANDROID_ARTIFACT_DIR ??
+    path.join(process.cwd(), "test-results", "android"),
+  "native-plugin-view-smoke",
 );
 
 type NativePluginSmokeResult = {

--- a/packages/app/test/android/onboarding-to-home.android.spec.ts
+++ b/packages/app/test/android/onboarding-to-home.android.spec.ts
@@ -31,9 +31,9 @@ const FIRST_RUN_REMOTE_DEEPLINK = `${URL_SCHEME}://first-run/runtime/remote?api=
   HOST_AGENT_BASE,
 )}`;
 const ARTIFACT_DIR = path.join(
-  process.cwd(),
-  "test-results",
-  "android-onboarding-to-home",
+  process.env.ELIZA_ANDROID_ARTIFACT_DIR ??
+    path.join(process.cwd(), "test-results", "android"),
+  "onboarding-to-home",
 );
 
 test.describe

--- a/packages/app/test/android/sleep-wake.android.spec.ts
+++ b/packages/app/test/android/sleep-wake.android.spec.ts
@@ -27,12 +27,16 @@ import {
 
 const API = process.env.API ?? "http://127.0.0.1:31337";
 const ARTIFACT_DIR = path.resolve(
-  process.cwd(),
-  "..",
-  "..",
-  ".github",
-  "issue-evidence",
-  "9943-android-sleep-wake",
+  process.env.ELIZA_ANDROID_ARTIFACT_DIR ??
+    path.join(
+      process.cwd(),
+      "..",
+      "..",
+      ".github",
+      "issue-evidence",
+      "9943-android-sleep-wake",
+    ),
+  "sleep-wake",
 );
 
 const APP_PAUSE_EVENT = "eliza:app-pause";

--- a/packages/app/test/android/touch-gesture.android.spec.ts
+++ b/packages/app/test/android/touch-gesture.android.spec.ts
@@ -63,10 +63,14 @@ function repoRootFromCwd() {
 }
 
 const ARTIFACT_DIR = path.join(
-  repoRootFromCwd(),
-  ".github",
-  "issue-evidence",
-  ISSUE_EVIDENCE_DIR,
+  process.env.ELIZA_ANDROID_ARTIFACT_DIR ??
+    path.join(
+      repoRootFromCwd(),
+      ".github",
+      "issue-evidence",
+      ISSUE_EVIDENCE_DIR,
+    ),
+  "touch-gesture",
 );
 
 function writeStage(stage: string, extra: Record<string, unknown> = {}) {

--- a/packages/app/test/android/view-runtime-soak.android.spec.ts
+++ b/packages/app/test/android/view-runtime-soak.android.spec.ts
@@ -21,12 +21,16 @@ const FIRST_RUN_REMOTE_DEEPLINK = `elizaos://first-run/runtime/remote?api=${enco
   API,
 )}`;
 const ARTIFACT_DIR = path.resolve(
-  process.cwd(),
-  "..",
-  "..",
-  ".github",
-  "issue-evidence",
-  "10196-views-state",
+  process.env.ELIZA_ANDROID_ARTIFACT_DIR ??
+    path.join(
+      process.cwd(),
+      "..",
+      "..",
+      ".github",
+      "issue-evidence",
+      "10196-views-state",
+    ),
+  "view-runtime-soak",
 );
 
 interface ViewCatalogEntry {


### PR DESCRIPTION
## Summary
- add a shared device-e2e bundle assembler that writes `inline/`, `logs/`, `raw/`, `reports/`, `summary.json`, and `junit.xml`
- make `android-e2e.mjs` and `ios-e2e.mjs` accept `--output <dir>` and always finalize the bundle on normal pass/fail paths
- capture Android route-coverage screenrecord plus final screenshot/logcat into the bundle
- capture iOS simulator final screenshot/video/log into the bundle when a simulator is available
- point Android Playwright JUnit/JSON/HTML output into the bundle and let Android specs honor `ELIZA_ANDROID_ARTIFACT_DIR` instead of writing under `.github/issue-evidence` during runner-driven runs
- add deterministic bundle unit coverage for output parsing, summary/JUnit writing, inline artifact copies, and failed-step reporting

Relates to #14336.

Stacked on #14483 because it builds on the device lease/freshness runner work.

## Validation
- `node --check packages/app/scripts/lib/device-e2e-bundle.mjs && node --check packages/app/scripts/android-e2e.mjs && node --check packages/app/scripts/ios-e2e.mjs && node --check packages/app/scripts/ios-e2e-lib.mjs && git diff --check`
- `bunx @biomejs/biome check packages/app/scripts/lib/device-e2e-bundle.mjs packages/app/scripts/device-e2e-bundle.test.mjs packages/app/scripts/android-e2e.mjs packages/app/scripts/ios-e2e.mjs packages/app/scripts/ios-e2e-lib.mjs packages/app/scripts/ios-e2e-lib.test.mjs packages/app/playwright.android.config.ts packages/app/test/android/onboarding-to-home.android.spec.ts packages/app/test/android/lifecycle.android.spec.ts packages/app/test/android/touch-gesture.android.spec.ts packages/app/test/android/view-runtime-soak.android.spec.ts packages/app/test/android/lifecycle-reboot.android.spec.ts packages/app/test/android/sleep-wake.android.spec.ts packages/app/test/android/launcher-gesture-loop.android.spec.ts packages/app/test/android/native-plugin-view-smoke.android.spec.ts`
- `bunx vitest run --config packages/app/vitest.config.ts packages/app/scripts/device-e2e-bundle.test.mjs packages/app/scripts/ios-e2e-lib.test.mjs`
- `bunx playwright test --config packages/app/playwright.android.config.ts --list` (74 tests listed)

## Failure-path smoke
Linux host cannot run `xcrun simctl`, but the iOS runner now still finalizes its bundle before exiting non-zero:

```text
[ios-e2e] plan: build -> auth -> local-chat
[ios-e2e] bundle: /tmp/eliza-ios-bundle-smoke
[ios-e2e] FAILED: iOS e2e requires macOS (xcrun simctl).
```

The produced `summary.json` included:

```json
{
  "lane": "ios-sim",
  "steps": [
    {
      "name": "boot iOS Simulator",
      "status": "failed",
      "error": "iOS e2e requires macOS (xcrun simctl)."
    }
  ],
  "artifacts": [
    {
      "kind": "junit",
      "path": "junit.xml"
    }
  ],
  "result": "failed"
}
```

## Evidence still needed before merge
- One full Android route-coverage run with the generated bundle attached inline (`inline/*.mp4`, `inline/*.jpg`, `summary.json`, `junit.xml`).
- One macOS iOS-simulator run with the generated bundle attached inline.
- Manual GitHub drag/drop check that generated `inline/*.mp4` renders inline.