### PR TITLE
ci(#14333): re-enable the scroll/maximize perf gate — CLS 0.80 was the removed swipe

### DIFF
--- a/.github/workflows/chat-shell-gestures.yml
+++ b/.github/workflows/chat-shell-gestures.yml
@@ -10,16 +10,18 @@ name: Chat shell gestures
 # runs the boot-free coverage gate that fails when a gesture-handler site lacks a
 # matrix row, and uploads every runner's video + screenshots.
 #
-# Two shell runners are intentionally NOT in this lane:
+# One shell runner is intentionally NOT in this lane:
 #   - run-fused-wake-integration-e2e drives the REAL native desktop wake producer
 #     (libwakeword + the wakeword-cpp build), which this lane does not compile
 #     (install-native-deps:false) — it self-skips without the lib, so it lives in
 #     the native-desktop build lane.
-#   - run-perf-gate-e2e has a PRE-EXISTING CLS-gate failure (the perf-gate fixture
-#     layout shifts 0.80 during scroll+swipe — reproduces identically on develop
-#     before this issue's migration; its frame-budget checks pass). It is tracked
-#     independently of #12188; adding it here would red the lane over an unrelated
-#     bug. The overlay perf frame budget is still gated below via chat-perf-gate.
+#
+# run-perf-gate-e2e USED to be excluded here for a CLS 0.80 failure, but that
+# shift was the conversation-swipe layout thrash: #13531 removed swipe (one
+# infinite thread) and #13826 retargeted the gate onto scroll + maximize/restore,
+# so CLS is now 0.0000 on develop (stable across runs, not timing-flaky). It is
+# re-enabled below (#14333) — CLS is structural so it will not flake on slower
+# fleet hardware, and the frame budget carries ~3x margin (p95 ~10ms ≤ 33ms).
 #
 # Path-gated to packages/ui (and the app-side gate + matrix) so it only runs when
 # the surface it covers changes. The e2e runners bundle the fixtures with esbuild
@@ -184,6 +186,13 @@ jobs:
       # layout-stability detectors, hard-fail on dropped-frame % / p95 / CLS.
       - name: Chat overlay perf gate
         run: bun run --cwd packages/ui test:chat-perf-gate
+
+      # Scroll + maximize/restore perf gate over the REAL overlay (#9954 item 5,
+      # retargeted off the removed swipe path by #13826). Hard-fails on
+      # dropped-frame % / p95 frame time / CLS ≤ 0.1. Re-enabled in this lane by
+      # #14333 now that the swipe-CLS 0.80 is gone (CLS 0.0000 on develop).
+      - name: Chat overlay scroll/maximize perf gate
+        run: bun run --cwd packages/ui test:perf-gate-e2e
 
       # #9142 Part 2: capture a dense CDP frame burst across the pill→open spring
       # (animations ON) and run the single-frame-flash + two-pills-crossfade


### PR DESCRIPTION
Closes #14333.

## Triage conclusion: the CLS 0.80 is already gone (root cause + evidence)
The "pre-existing, untriaged CLS 0.80" was **the conversation-swipe layout thrash**. The perf-gate fixture used to drive scroll **+ swipe**, and the swipe path shifted layout by 0.80. Two already-merged changes eliminated it:
- **#13531** removed conversation-swipe entirely (one infinite thread).
- **#13826** (`db19f67a18`) retargeted `run-perf-gate-e2e` onto **scroll + maximize/restore**.

So on current `develop` the gate is **honestly green**, measuring the real overlay:
```
[overlay-scroll]     fps=120.0 p95=10.1ms dropped=0/571 (0%)
[maximize-restore]   fps=119.8 p95=9.9ms  dropped=0/489 (0%)
[layout] cls=0.0000 non-intentional-shifts=0
PERF GATE PASSED
```
Stable across 3 consecutive local runs (CLS 0.0000 every time — it is a structural measure, not timing-flaky). **The 0.1 threshold is NOT loosened.**

## Change
The only residual was stale documentation + an unnecessary exclusion: `chat-shell-gestures.yml` still carried a comment claiming `run-perf-gate-e2e` "has a PRE-EXISTING CLS-gate failure (layout shifts 0.80)… reproduces identically on develop," and excluded it from the lane on that basis. This PR:
1. Corrects that comment to reflect the resolution (#13531 + #13826 → CLS 0.0000).
2. **Re-enables the gate in the gesture lane** — the exclusion reason is gone, CLS won't flake on slower fleet hardware (structural), and the frame budget carries ~3× margin (p95 ~10ms ≤ 33ms).

## Acceptance criteria
- [x] Root cause documented (swipe layout thrash; named the shifting path) — fixture drove the removed swipe; not a real overlay shift anymore.
- [x] `test.yml` perf-gate leg honestly green (CLS 0.0000), threshold not loosened — and now also gated in `chat-shell-gestures.yml`.
- [x] Healthy `run-chat-perf-gate.mjs` still passes (unchanged).
- [x] No row `content-visibility` added — the frame budget shows no regression (0% dropped, p95 10ms), so per the issue it is NOT added speculatively.

## Evidence not applicable
- **Real-LLM trajectory / screenshots** — N/A: CI-config + perf-measurement triage; the perf numbers above are the artifact.
