### PR TITLE
fix(ui): preserve forceCreate in cloud agent create

### DIFF
--- a/packages/ui/src/api/client-cloud-select-or-provision.test.ts
+++ b/packages/ui/src/api/client-cloud-select-or-provision.test.ts
@@ -140,6 +140,48 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
     expect(createCloudCompatAgent).toHaveBeenCalledTimes(1);
   });
 
+  it("forwards forceCreate through the create branch so explicit new-agent requests cannot reuse an existing backend row", async () => {
+    const { client, getCloudCompatAgents, createCloudCompatAgent } =
+      fakeClient();
+    createCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: {
+        agentId: "agent-forced-new",
+        agentName: "Demo Fresh",
+        jobId: "job-1",
+        status: "provisioning",
+        nodeId: null,
+        message: "",
+      },
+    });
+    (client.getCloudCompatAgent as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: makeAgent({
+        agent_id: "agent-forced-new",
+        agent_name: "Demo Fresh",
+        status: "provisioning",
+        web_ui_url: "https://agent-forced-new.example.test",
+        webUiUrl: "https://agent-forced-new.example.test",
+      }),
+    });
+
+    const result = await client.selectOrProvisionCloudAgent({
+      ...BASE_OPTS,
+      name: "Demo Fresh",
+      forceCreate: true,
+    });
+
+    expect(getCloudCompatAgents).not.toHaveBeenCalled();
+    expect(createCloudCompatAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentName: "Demo Fresh",
+        forceCreate: true,
+      }),
+    );
+    expect(result.created).toBe(true);
+    expect(result.agentId).toBe("agent-forced-new");
+  });
+
   // First-run handoff: a freshly-created dedicated agent whose container is still
   // provisioning must start on the SHARED REST adapter base (the always-on
   // in-Worker runtime serves the first turn instantly) — NOT on the dedicated

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -3194,6 +3194,7 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
   const created = await this.createCloudCompatAgent({
     agentName: name,
     ...(bio?.length ? { agentConfig: { bio } } : {}),
+    ...(forceCreate ? { forceCreate: true } : {}),
     ...(preferSharedTier ? { preferSharedTier: true } : {}),
   });
   if (!created.success || !created.data.agentId) {


### PR DESCRIPTION
Relates to #14487.

## Summary
- preserve `forceCreate: true` when `selectOrProvisionCloudAgent` reaches the create branch
- add a regression test proving explicit create-new requests skip list reuse and call `createCloudCompatAgent` with `forceCreate: true`

## Root Cause
`CloudAgentsSection` correctly called `selectOrProvisionCloudAgent({ forceCreate: true })`, and the lower-level `createCloudCompatAgent` already serialized `forceCreate` into the backend POST body. The middle layer dropped the flag when it called `createCloudCompatAgent`, so the backend received a normal create request and could legally return the existing non-terminal agent through its reuse guard.

## Verification
- [x] `bun run --cwd packages/ui test -- src/api/client-cloud-select-or-provision.test.ts src/api/client-cloud-direct-auth.test.ts` — 36 passed
- [x] `bunx biome check packages/ui/src/api/client-cloud.ts packages/ui/src/api/client-cloud-select-or-provision.test.ts`
- [x] `git diff --check`

Attempted but blocked by current worktree/develop setup:
- [ ] `bun test packages/cloud/api/__tests__/eliza-agents-create-idempotency.test.ts` failed before assertions with `SyntaxError: Export named 'AgentImageNotAllowedError' not found in module .../eliza-sandbox.ts`. The backend path is not changed in this PR; existing tests already cover backend forceCreate semantics when runnable.

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - client request propagation bug; no visual UI layout changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - client request propagation bug; no visual UI layout changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no local live Cloud/Seeker credentials available in this worktree; #14487 still needs on-device re-verification after this lands`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - backend behavior was already correct when forceCreate is received; this PR changes only the UI client forwarding path`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no live app session captured in this worktree; unit regression asserts the outgoing client call contract`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent, prompt, provider, model, or action behavior changed`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no live Cloud/Seeker domain artifact captured in this worktree; focused regression in packages/ui/src/api/client-cloud-select-or-provision.test.ts proves forceCreate reaches the lower create call. Live #14487 artifact still required: create a fresh Seeker cloud agent and verify the org agent count/api base change`.

## Notes
This PR should stay draft until CI and the live Seeker create flow are verified. The code fix removes the identified propagation gap, but the issue should remain In progress until real on-device Cloud evidence confirms the create path no longer rebinds to the existing agent.

