### PR TITLE
fix(chat): sliding render window so infinite scroll-up actually shows older turns (#14329)

### DIFF
--- a/packages/ui/src/components/pages/__e2e__/chat-infinite-scroll-fixture.tsx
+++ b/packages/ui/src/components/pages/__e2e__/chat-infinite-scroll-fixture.tsx
@@ -1,18 +1,22 @@
 /**
- * REAL-browser fixture for the infinite upward scroll (#13532) — driven by
- * run-chat-infinite-scroll-e2e.mjs.
+ * REAL-browser fixture for the infinite upward scroll (#13532/#14329) — driven
+ * by run-chat-infinite-scroll-e2e.mjs.
  *
  * Mounts the PRODUCTION load-older engine — the real `useLoadOlderOnScroll`
- * hook and the real `loadOlderConversationMessages` orchestration — over a real
- * scroller in a real Chromium layout, so the pieces jsdom fakes (a genuine
- * IntersectionObserver, real scrollHeight/scrollTop geometry, a real `?before=`
- * network fetch) run for real. The `client` performs an actual `fetch()` to a
- * `?before=<cursor>` endpoint the runner stubs, so the request is observable on
- * the wire; the reducer prepend is the real dedupe/order contract.
+ * hook, the real `loadOlderConversationMessages` orchestration, AND the real
+ * `planScrollTopLoadOlder` render-window policy — over a real scroller in a real
+ * Chromium layout, so the pieces jsdom fakes (a genuine IntersectionObserver,
+ * real scrollHeight/scrollTop geometry, a real `?before=` network fetch) run for
+ * real. Crucially it renders through the SAME sliding render window the overlay
+ * uses (`messages.slice(-renderWindowSize)` growing via `planScrollTopLoadOlder`)
+ * rather than dumping every message — so the e2e guards #14329's actual bug: a
+ * fixed render cap that slices prepended older turns straight back off.
  *
  * Query params (set by the runner): `?empty` seeds an empty thread (no fetch
  * loop); `?fail` makes the first older-page fetch reject (error path — the guard
- * re-arms, no retry storm). Default is a multi-page thread.
+ * re-arms, no retry storm); `?big` mounts a thread far larger than the initial
+ * render window, so scroll-up must GROW the window to reveal already-loaded
+ * turns before any fetch. Default is a small multi-page thread.
  */
 
 import * as React from "react";
@@ -25,14 +29,14 @@ import {
   type LoadOlderClient,
   loadOlderConversationMessages,
 } from "../../../state/load-older-conversation-messages";
+import {
+  MAX_LOADED_SHELL_WINDOW,
+  MAX_RENDERED_SHELL_MESSAGES,
+  planScrollTopLoadOlder,
+} from "../../shell/shell-state";
 
 const CONVERSATION_ID = "conv-infinite";
 const PAGE_SIZE = 20;
-// The mounted tail is a full page taller than the viewport so the thread starts
-// scrolled to the BOTTOM with the top sentinel off-screen — no mount-time
-// prefetch. The reader (the runner) then scrolls to the top to trigger the one
-// older page deliberately, which is the behaviour under test.
-const TAIL_SIZE = 40;
 
 type Win = typeof window & {
   /** Every `?before=` cursor the client actually fetched, in order. */
@@ -41,11 +45,21 @@ type Win = typeof window & {
   __loadResolves?: number;
   /** Whether the last older-page fetch rejected. */
   __lastFetchFailed?: boolean;
+  /** Live render-window size, so the runner can assert it grows past the cap. */
+  __renderWindow?: number;
 };
 
 const params = new URLSearchParams(window.location.search);
 const MODE_EMPTY = params.has("empty");
 const MODE_FAIL = params.has("fail");
+const MODE_BIG = params.has("big");
+
+// `?big` mounts far more than the initial render window so scroll-up must reveal
+// already-loaded turns (the #14329 cap-growth path). The default/fail threads
+// mount a tail a full page taller than the viewport so the thread starts
+// scrolled to the BOTTOM with the top sentinel off-screen — no mount-time
+// prefetch — and the reader (the runner) then scrolls up deliberately.
+const TAIL_SIZE = MODE_BIG ? 200 : 40;
 
 /** Build the newest page (tail) the thread mounts with, oldest-first. */
 function initialMessages(): ConversationMessage[] {
@@ -100,9 +114,23 @@ function Harness(): React.JSX.Element {
     initialMessages,
   );
   const [hasMore, setHasMore] = useState(!MODE_EMPTY);
+  // The render window mirrors the overlay: start lean, grow a page per
+  // scroll-to-top (reveal-before-fetch), bounded by MAX_LOADED_SHELL_WINDOW.
+  const [renderWindowSize, setRenderWindowSize] = useState(
+    MAX_RENDERED_SHELL_MESSAGES,
+  );
   const scrollRef = useRef<HTMLDivElement>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
   const clientRef = useRef<LoadOlderClient>(makeClient());
+  // Refs so the scroll-up handler reads live values without re-subscribing the
+  // observer — mirrors the overlay wiring exactly.
+  const messagesRef = useRef(messages);
+  messagesRef.current = messages;
+  const windowRef = useRef(renderWindowSize);
+  windowRef.current = renderWindowSize;
+  const hasMoreRef = useRef(hasMore);
+  hasMoreRef.current = hasMore;
+  (window as Win).__renderWindow = renderWindowSize;
 
   const prependMessages = useCallback((older: ConversationMessage[]) => {
     setMessages((prev) => {
@@ -113,23 +141,52 @@ function Harness(): React.JSX.Element {
   }, []);
 
   const onLoadOlder = useCallback(async () => {
+    // Reveal-before-fetch, identical to ContinuousChatOverlay.loadOlderMessages:
+    // grow the render window to surface already-loaded turns before any network,
+    // and only page the next older server window once the window has drained.
+    const plan = planScrollTopLoadOlder(
+      windowRef.current,
+      messagesRef.current.length,
+      hasMoreRef.current,
+    );
+    if (plan.nextWindowSize !== windowRef.current) {
+      setRenderWindowSize(plan.nextWindowSize);
+    }
+    if (!plan.shouldFetch) {
+      (window as Win).__loadResolves = ((window as Win).__loadResolves ?? 0) + 1;
+      return;
+    }
     const result = await loadOlderConversationMessages({
       client: clientRef.current,
       conversationId: CONVERSATION_ID,
-      currentMessages: messages,
+      currentMessages: messagesRef.current,
       prependMessages,
       limit: PAGE_SIZE,
     });
     (window as Win).__loadResolves = ((window as Win).__loadResolves ?? 0) + 1;
     setHasMore(result.hasMore);
-  }, [messages, prependMessages]);
+    if (result.prependedCount > 0) {
+      setRenderWindowSize((n) =>
+        Math.min(n + result.prependedCount, MAX_LOADED_SHELL_WINDOW),
+      );
+    }
+  }, [prependMessages]);
+
+  const visible =
+    messages.length > renderWindowSize
+      ? messages.slice(-renderWindowSize)
+      : messages;
 
   useLoadOlderOnScroll<HTMLDivElement>({
     scrollRef,
     sentinelRef,
     onLoadOlder,
-    hasMore,
-    topItemKey: messages[0]?.id ?? "",
+    // Armed while older turns can still be revealed (window below the loaded
+    // count) OR paged (server has more), and latched off at the DOM bound.
+    hasMore:
+      renderWindowSize < MAX_LOADED_SHELL_WINDOW &&
+      (renderWindowSize < messages.length || hasMore),
+    topItemKey: visible[0]?.id ?? "",
     enabled: true,
   });
 
@@ -158,7 +215,7 @@ function Harness(): React.JSX.Element {
         style={{ flex: 1, minHeight: 0, overflowY: "auto", padding: 12 }}
       >
         <div ref={sentinelRef} data-testid="infinite-scroll-top-sentinel" />
-        {messages.map((m) => (
+        {visible.map((m) => (
           <div
             key={m.id}
             data-message-id={m.id}

--- a/packages/ui/src/components/pages/__e2e__/run-chat-infinite-scroll-e2e.mjs
+++ b/packages/ui/src/components/pages/__e2e__/run-chat-infinite-scroll-e2e.mjs
@@ -1,15 +1,22 @@
 /**
- * REAL-browser e2e for the infinite upward scroll (#13532).
+ * REAL-browser e2e for the infinite upward scroll (#13532/#14329).
  *
  * Mounts chat-infinite-scroll-fixture.tsx — the PRODUCTION `useLoadOlderOnScroll`
- * hook + `loadOlderConversationMessages` orchestration — in real Chromium and
- * drives the actual behaviour jsdom cannot:
+ * hook + `loadOlderConversationMessages` orchestration + `planScrollTopLoadOlder`
+ * render-window policy — in real Chromium and drives the actual behaviour jsdom
+ * cannot:
  *   1. Scroll to the top → a `GET .../messages?before=<cursor>` request FIRES
  *      (observed on the wire), older rows PREPEND, and the previously-top row's
  *      boundingBox stays put (scroll-anchor preservation, ±tolerance).
  *   2. Empty history → NO fetch loop (an empty thread has no cursor to page).
  *   3. Fetch failure → the error surfaces (guard re-arms), with NO retry storm
  *      (bounded resolves), and no fabricated/empty prepend.
+ *   4. #14329 render window: a thread far larger than the initial render cap
+ *      mounts showing only the newest window (NOT every loaded turn), and
+ *      scrolling up GROWS the window to reveal the already-loaded older turns —
+ *      network-free (no `?before=` fetch) until the window has drained. This
+ *      guards the actual bug: a fixed `slice(-80)` cap that sliced prepended
+ *      older turns straight back off, dead-ending scroll-up.
  *
  * A tiny in-process HTTP server serves the fixture HTML AND the mock
  * `?before=` messages endpoint, so the `fetch()` the client issues is genuine
@@ -360,6 +367,89 @@ try {
     );
     await screenshot(page, "05-fetch-failure");
     await closePageWithVideo(run, "03-fetch-failure");
+  }
+
+  // ── 4) #14329 render window grows past the initial cap on scroll-up ─────────
+  // A 200-turn thread mounts. It must render only the newest window (the initial
+  // cap), NOT all 200 — then scrolling up reveals the already-loaded older turns
+  // WITHOUT a network fetch. Under the old fixed `slice(-80)` cap the prepended /
+  // hidden older turns were sliced straight back off and scroll-up dead-ended.
+  {
+    const { page, requests } = await newPage("?big");
+    await page.waitForSelector(ROW);
+    await page.waitForTimeout(300);
+
+    const TOTAL_LOADED = 200;
+    const rowsAtMount = await page.locator(ROW).count();
+    const windowAtMount = await page.evaluate(() => window.__renderWindow ?? 0);
+    assert(
+      rowsAtMount > 0 && rowsAtMount < TOTAL_LOADED,
+      `big thread mounts capped to the render window, not all ${TOTAL_LOADED} turns (rendered ${rowsAtMount})`,
+    );
+    assert(
+      rowsAtMount === windowAtMount,
+      `rendered rows equal the render window at mount (${rowsAtMount} === ${windowAtMount})`,
+    );
+    // The oldest loaded turn is initially windowed OUT (this is the "before"
+    // state the bug report shows: scroll-up dead-ends before reaching it).
+    const oldestHiddenAtMount = await page.evaluate(
+      () => !document.querySelector('[data-message-id="tail-0"]'),
+    );
+    assert(
+      oldestHiddenAtMount,
+      "the oldest loaded turn (tail-0) is windowed out at mount",
+    );
+
+    // ONE scroll-to-top must GROW the window and reveal older loaded turns with
+    // NO `?before=` fetch — reveal-before-fetch, the network-free path.
+    await page.evaluate((sel) => {
+      const el = document.querySelector(sel);
+      if (el) el.scrollTop = 0;
+    }, SCROLLER);
+    await page
+      .waitForFunction(
+        ({ prev }) => (window.__renderWindow ?? 0) > prev,
+        { prev: windowAtMount },
+        { timeout: 8_000 },
+      )
+      .catch(() => {});
+    const windowAfterOne = await page.evaluate(() => window.__renderWindow ?? 0);
+    const rowsAfterOne = await page.locator(ROW).count();
+    assert(
+      windowAfterOne > windowAtMount && rowsAfterOne > rowsAtMount,
+      `scroll-up grew the render window (${windowAtMount}→${windowAfterOne}) and revealed rows (${rowsAtMount}→${rowsAfterOne})`,
+    );
+    assert(
+      requests.filter((u) => /\/messages\?before=/.test(u)).length === 0,
+      "revealing already-loaded turns issued NO ?before= fetch (reveal-before-fetch)",
+    );
+
+    // Keep scrolling to the top: the window keeps growing until every loaded
+    // turn — including the oldest (tail-0) — is rendered.
+    for (let i = 0; i < 8; i += 1) {
+      await page.evaluate((sel) => {
+        const el = document.querySelector(sel);
+        if (el) el.scrollTop = 0;
+      }, SCROLLER);
+      await page.waitForTimeout(150);
+      const done = await page.evaluate(
+        () => !!document.querySelector('[data-message-id="tail-0"]'),
+      );
+      if (done) break;
+    }
+    const oldestRevealed = await page.evaluate(
+      () => !!document.querySelector('[data-message-id="tail-0"]'),
+    );
+    assert(
+      oldestRevealed,
+      "scrolling up reveals the oldest loaded turn (tail-0) — scroll-up no longer dead-ends",
+    );
+    const rowsFinal = await page.locator(ROW).count();
+    assert(
+      rowsFinal >= TOTAL_LOADED,
+      `all ${TOTAL_LOADED} loaded turns are reachable by scrolling up (rendered ${rowsFinal})`,
+    );
+    await page.close();
   }
 } finally {
   await browser.close();

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -109,7 +109,13 @@ import {
   resolveChatPanelLayout,
 } from "./chat-panel-layout";
 import { SlashCommandMenu, useSlashMenu } from "./SlashCommandMenu";
-import { type ShellMessage, selectVisibleShellMessages } from "./shell-state";
+import {
+  filterRenderableShellMessages,
+  MAX_LOADED_SHELL_WINDOW,
+  MAX_RENDERED_SHELL_MESSAGES,
+  planScrollTopLoadOlder,
+  type ShellMessage,
+} from "./shell-state";
 import { TopicChipsBar } from "./TopicChipsBar";
 import { TopicGroup } from "./TopicGroup";
 import {
@@ -1466,12 +1472,28 @@ export function ContinuousChatOverlay({
   // after the user has moved on.
   const pendingExpandOnRevealRef = React.useRef(false);
   const focusThreadRef = React.useRef(false);
+  // The render window slides UP as the reader scrolls into history (#14329):
+  // it starts at MAX_RENDERED_SHELL_MESSAGES (lean idle/drag DOM) and grows a
+  // page per scroll-to-top — first revealing already-loaded turns, then paging
+  // older ones in — bounded by MAX_LOADED_SHELL_WINDOW so a long thread never
+  // unbounds the DOM. Reset when the active conversation changes (below).
+  const [renderWindowSize, setRenderWindowSize] = React.useState(
+    MAX_RENDERED_SHELL_MESSAGES,
+  );
   // Recomputed only when the thread or phase changes — NOT on every drag/draft
-  // re-render. Pure windowing (empty-turn filter + most-recent cap, with the
-  // streaming-assistant exception) lives in shell-state so it's unit-tested.
-  const visibleMessages = React.useMemo(
-    () => selectVisibleShellMessages(messages, phase),
+  // re-render. Pure windowing (empty-turn filter, with the streaming-assistant
+  // exception) lives in shell-state so it's unit-tested; the count of renderable
+  // turns drives the scroll-up reveal-before-fetch policy.
+  const renderableMessages = React.useMemo(
+    () => filterRenderableShellMessages(messages, phase),
     [messages, phase],
+  );
+  const visibleMessages = React.useMemo(
+    () =>
+      renderableMessages.length > renderWindowSize
+        ? renderableMessages.slice(-renderWindowSize)
+        : renderableMessages,
+    [renderableMessages, renderWindowSize],
   );
   const lastId = visibleMessages.at(-1)?.id ?? null;
   const lastContent = visibleMessages.at(-1)?.content ?? "";
@@ -1549,9 +1571,31 @@ export function ContinuousChatOverlay({
   // newly active one after a mid-flight switch.
   const loadOlderConversationIdRef = React.useRef(activeConversationId);
   loadOlderConversationIdRef.current = activeConversationId;
+  // Live copies for the scroll-up handler so its identity stays stable across
+  // window growth / message churn (the observer captures it through a ref).
+  const renderWindowSizeRef = React.useRef(renderWindowSize);
+  renderWindowSizeRef.current = renderWindowSize;
+  const renderableCountRef = React.useRef(renderableMessages.length);
+  renderableCountRef.current = renderableMessages.length;
+  const hasMoreOlderRef = React.useRef(hasMoreOlder);
+  hasMoreOlderRef.current = hasMoreOlder;
   const loadOlderMessages = React.useCallback(async () => {
     const conversationId = activeConversationId;
     if (!conversationId) return;
+    // Reveal-before-fetch: grow the render window a page to surface
+    // already-loaded older turns before hitting the network. Only when the
+    // window has consumed every loaded turn do we page the next older server
+    // window (and grow to render it). Both grows go through the SAME
+    // scrollHeight-delta anchor in useLoadOlderOnScroll, so the reader stays put.
+    const plan = planScrollTopLoadOlder(
+      renderWindowSizeRef.current,
+      renderableCountRef.current,
+      hasMoreOlderRef.current,
+    );
+    if (plan.nextWindowSize !== renderWindowSizeRef.current) {
+      setRenderWindowSize(plan.nextWindowSize);
+    }
+    if (!plan.shouldFetch) return;
     const result = await loadOlderConversationMessages({
       client,
       conversationId,
@@ -1564,12 +1608,19 @@ export function ContinuousChatOverlay({
     });
     if (loadOlderConversationIdRef.current === conversationId) {
       setHasMoreOlder(result.hasMore);
+      if (result.prependedCount > 0) {
+        setRenderWindowSize((n) =>
+          Math.min(n + result.prependedCount, MAX_LOADED_SHELL_WINDOW),
+        );
+      }
     }
   }, [activeConversationId, conversationMessages, prependConversationMessages]);
-  // A fresh/switched conversation may have older history — re-arm the loader.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: activeConversationId is the intentional re-arm trigger; the body only calls the stable setter.
+  // A fresh/switched conversation may have older history — re-arm the loader and
+  // collapse the render window back to the lean initial size.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: activeConversationId is the intentional re-arm trigger; the body only calls stable setters.
   React.useEffect(() => {
     setHasMoreOlder(true);
+    setRenderWindowSize(MAX_RENDERED_SHELL_MESSAGES);
   }, [activeConversationId]);
   useLoadOlderOnScroll<HTMLDivElement>({
     scrollRef: threadRef,
@@ -1578,8 +1629,13 @@ export function ContinuousChatOverlay({
     // Topic grouping wraps rows in collapsible segments, which breaks the
     // sentinel's flat-prepend anchor math; restrict load-older to the flat
     // transcript (the common case). A topic-grouped thread still shows its
-    // recent window; scroll-up paging there is a follow-up.
-    hasMore: hasMoreOlder && !hasTopics,
+    // recent window; scroll-up paging there is a follow-up. The observer stays
+    // armed while older turns can still be revealed (window below the loaded
+    // count) OR paged (server has more), and latches off at the DOM bound.
+    hasMore:
+      !hasTopics &&
+      renderWindowSize < MAX_LOADED_SHELL_WINDOW &&
+      (renderWindowSize < renderableMessages.length || hasMoreOlder),
     topItemKey: visibleMessages[0]?.id ?? "",
     enabled: threadPresented && !hasTopics,
   });

--- a/packages/ui/src/components/shell/shell-state.test.ts
+++ b/packages/ui/src/components/shell/shell-state.test.ts
@@ -5,7 +5,11 @@
 import { describe, expect, it } from "vitest";
 import type { ShellMessage, ShellPhase } from "./shell-state";
 import {
+  filterRenderableShellMessages,
+  MAX_LOADED_SHELL_WINDOW,
   MAX_RENDERED_SHELL_MESSAGES,
+  planScrollTopLoadOlder,
+  SHELL_RENDER_WINDOW_STEP,
   selectVisibleShellMessages,
 } from "./shell-state";
 
@@ -189,5 +193,110 @@ describe("selectVisibleShellMessages (#9141 gap 4 windowing)", () => {
         "idle",
       ).map((m) => m.id),
     ).toEqual(["u1"]);
+  });
+});
+
+describe("filterRenderableShellMessages", () => {
+  it("returns the same renderable set selectVisibleShellMessages keeps, uncapped", () => {
+    const thread = Array.from({ length: 300 }, (_, i) =>
+      i % 5 === 0
+        ? msg(`e${i}`, "assistant", "  ") // empty → dropped
+        : msg(`m${i}`, i % 2 === 0 ? "user" : "assistant", `t${i}`),
+    );
+    const renderable = filterRenderableShellMessages(thread, "idle");
+    // No cap here — every non-empty turn survives (240 of 300).
+    expect(renderable).toHaveLength(240);
+    // The capped selector is exactly the tail of the uncapped renderable set.
+    expect(selectVisibleShellMessages(thread, "idle").map((m) => m.id)).toEqual(
+      renderable.slice(-MAX_RENDERED_SHELL_MESSAGES).map((m) => m.id),
+    );
+  });
+});
+
+// Regression guard for #14329: the overlay's render window MUST grow past the
+// initial cap so scroll-up reveals older turns instead of dead-ending at 80.
+// Before this change the overlay rendered a fixed slice(-80); load-older loaded
+// pages into state that the cap immediately sliced back off, so scroll-up was
+// silently dead. This is the pure policy that overlay wiring drives.
+describe("planScrollTopLoadOlder (#14329 sliding render window)", () => {
+  it("reveals already-loaded turns first — grows a page, no fetch", () => {
+    // 200 loaded, window at the initial 80: there are 120 loaded-but-hidden
+    // turns, so a scroll-to-top must GROW the window (not hit the network).
+    const plan = planScrollTopLoadOlder(MAX_RENDERED_SHELL_MESSAGES, 200, true);
+    expect(plan.shouldFetch).toBe(false);
+    expect(plan.nextWindowSize).toBe(
+      MAX_RENDERED_SHELL_MESSAGES + SHELL_RENDER_WINDOW_STEP,
+    );
+  });
+
+  it("never grows the window past the loaded count", () => {
+    // 90 loaded, window 80: one more step would overshoot to 130, so clamp to
+    // the 90 that actually exist.
+    const plan = planScrollTopLoadOlder(MAX_RENDERED_SHELL_MESSAGES, 90, true);
+    expect(plan.shouldFetch).toBe(false);
+    expect(plan.nextWindowSize).toBe(90);
+  });
+
+  it("fetches once the window has consumed every loaded turn", () => {
+    // window == loaded: nothing left to reveal, so page the next older server
+    // window when the server reports more.
+    const plan = planScrollTopLoadOlder(120, 120, true);
+    expect(plan.shouldFetch).toBe(true);
+    expect(plan.nextWindowSize).toBe(120);
+  });
+
+  it("does NOT fetch when the window is drained and the server has no more", () => {
+    const plan = planScrollTopLoadOlder(120, 120, false);
+    expect(plan.shouldFetch).toBe(false);
+    expect(plan.nextWindowSize).toBe(120);
+  });
+
+  it("latches off at the DOM bound — neither grows nor fetches", () => {
+    // At the bound, more history may exist in state and on the server, but the
+    // window must not grow (bounded DOM) and must not spin the fetch loop.
+    const plan = planScrollTopLoadOlder(
+      MAX_LOADED_SHELL_WINDOW,
+      MAX_LOADED_SHELL_WINDOW + 500,
+      true,
+    );
+    expect(plan.shouldFetch).toBe(false);
+    expect(plan.nextWindowSize).toBe(MAX_LOADED_SHELL_WINDOW);
+  });
+
+  it("never grows past the DOM bound even mid-reveal", () => {
+    const plan = planScrollTopLoadOlder(
+      MAX_LOADED_SHELL_WINDOW - 10,
+      MAX_LOADED_SHELL_WINDOW + 500,
+      true,
+    );
+    expect(plan.shouldFetch).toBe(false);
+    expect(plan.nextWindowSize).toBe(MAX_LOADED_SHELL_WINDOW);
+  });
+
+  it("walks a >200-turn thread from the initial cap to full history", () => {
+    // Simulate the real scroll-up loop: repeatedly apply the policy, growing to
+    // reveal loaded turns then paging older ones, and assert it terminates at
+    // the DOM bound having surfaced far more than the initial 80.
+    let windowSize = MAX_RENDERED_SHELL_MESSAGES;
+    let loaded = 200; // initial server window
+    const serverPages = 6; // 6 older pages of 50 available beyond the first 200
+    let pagesLeft = serverPages;
+    let fetches = 0;
+    for (let i = 0; i < 100; i++) {
+      const plan = planScrollTopLoadOlder(windowSize, loaded, pagesLeft > 0);
+      if (plan.nextWindowSize === windowSize && !plan.shouldFetch) break;
+      windowSize = plan.nextWindowSize;
+      if (plan.shouldFetch) {
+        fetches += 1;
+        const page = 50;
+        loaded += page;
+        windowSize = Math.min(windowSize + page, MAX_LOADED_SHELL_WINDOW);
+        pagesLeft -= 1;
+      }
+    }
+    expect(windowSize).toBe(MAX_LOADED_SHELL_WINDOW);
+    expect(fetches).toBeGreaterThan(0);
+    // The window reached far beyond the dead-end-at-80 wall this issue fixes.
+    expect(windowSize).toBeGreaterThan(MAX_RENDERED_SHELL_MESSAGES);
   });
 });

--- a/packages/ui/src/components/shell/shell-state.ts
+++ b/packages/ui/src/components/shell/shell-state.ts
@@ -56,33 +56,50 @@ export interface ShellMessage {
 }
 
 /**
- * Max chat turns actually rendered in the shell transcript. Older turns stay in
- * state (the agent's context is untouched) — this only bounds DOM nodes so a
- * long thread can't jank scrolling, without pulling in a virtualizer. Gap 4 of
- * #9141 (transcript windowing) builds on this seam.
+ * Initial size of the shell transcript's render window — the newest N turns
+ * rendered when a conversation first opens. Older turns stay in state (the
+ * agent's context is untouched); the window GROWS a page at a time as the reader
+ * scrolls up ({@link planScrollTopLoadOlder}), bounded by
+ * {@link MAX_LOADED_SHELL_WINDOW}, so the idle/drag DOM stays lean while history
+ * browsing still reaches back. Gap 4 of #9141 (transcript windowing) built this
+ * seam; #13532/#14329 (infinite upward scroll) made it a sliding window.
  */
 export const MAX_RENDERED_SHELL_MESSAGES = 80;
 
 /**
- * Pure transcript-windowing decision (#9141 gap 4 seam). Drops empty turns —
- * EXCEPT turns that carry non-text content (attachments or a pending secret
- * request: an image-only send is a valid user turn and an assistant reply can
- * be a bare generated image), a FAILED assistant turn (failureKind carries the
- * retry / no-provider / insufficient-credits UI, which is often content-less —
- * a rate-limit or provider stall fails before any token streams, so dropping
- * it would hide the failure AND its retry affordance entirely), and the
- * in-flight assistant turn while a reply is streaming (phase === "responding"),
- * so its bubble can show the breathing dots anchored where the text will fill
- * in — then keeps only the most recent `max` turns to bound DOM nodes. Pure +
- * DOM-free so the cap + exceptions are unit-testable and any future virtualizer
- * can reuse the same predicate.
+ * Hard upper bound on the render window: however far the reader scrolls up, the
+ * transcript never renders more than this many turns at once, so a very long
+ * thread can't unbound the DOM and jank the per-frame `flexBasis` sheet drag
+ * (#14329 acceptance: bounded ~400, no virtualizer). State still holds every
+ * loaded turn.
  */
-export function selectVisibleShellMessages(
+export const MAX_LOADED_SHELL_WINDOW = 400;
+
+/**
+ * How many turns the render window grows per scroll-to-top — one older page, so
+ * revealing already-loaded-but-windowed-out turns matches the size of a fetched
+ * older page and the reader gets a full page of runway each time.
+ */
+export const SHELL_RENDER_WINDOW_STEP = 50;
+
+/**
+ * The renderable subset of a shell transcript: drops empty turns — EXCEPT turns
+ * that carry non-text content (attachments or a pending secret request: an
+ * image-only send is a valid user turn and an assistant reply can be a bare
+ * generated image), a FAILED assistant turn (failureKind carries the retry /
+ * no-provider / insufficient-credits UI, which is often content-less — a
+ * rate-limit or provider stall fails before any token streams, so dropping it
+ * would hide the failure AND its retry affordance entirely), and the in-flight
+ * assistant turn while a reply is streaming (phase === "responding"), so its
+ * bubble can show the breathing dots anchored where the text will fill in. Pure
+ * + DOM-free so the render window can measure the loaded-renderable count
+ * without a second filter definition.
+ */
+export function filterRenderableShellMessages(
   messages: readonly ShellMessage[],
   phase: ShellPhase,
-  max: number = MAX_RENDERED_SHELL_MESSAGES,
 ): ShellMessage[] {
-  const kept = messages.filter(
+  return messages.filter(
     (m) =>
       m.content.trim() ||
       (m.attachments?.length ?? 0) > 0 ||
@@ -90,5 +107,57 @@ export function selectVisibleShellMessages(
       m.failureKind !== undefined ||
       (m.role === "assistant" && phase === "responding"),
   );
+}
+
+/**
+ * Pure transcript-windowing decision (#9141 gap 4 seam): the renderable turns,
+ * capped to the newest `max` to bound DOM nodes. Pure + DOM-free so the cap +
+ * exceptions are unit-testable and any future virtualizer can reuse the same
+ * predicate.
+ */
+export function selectVisibleShellMessages(
+  messages: readonly ShellMessage[],
+  phase: ShellPhase,
+  max: number = MAX_RENDERED_SHELL_MESSAGES,
+): ShellMessage[] {
+  const kept = filterRenderableShellMessages(messages, phase);
   return max > 0 && kept.length > max ? kept.slice(-max) : [...kept];
+}
+
+/**
+ * Decide the render window's response to a scroll-to-top for the infinite
+ * upward scroll (#13532/#14329). Two moves, reveal-before-fetch:
+ *
+ *  1. If loaded-but-windowed-out older turns exist (`windowSize <
+ *     loadedRenderableCount`), GROW the window one page to reveal them — no
+ *     network. This is why the idle/drag DOM stays at the initial window while
+ *     only history browsing grows it.
+ *  2. Once the window has consumed every loaded turn, signal a FETCH of the next
+ *     older server page (when the server reports more) so the caller can prepend
+ *     and grow again.
+ *
+ * Never grows past {@link MAX_LOADED_SHELL_WINDOW}: at the bound it neither
+ * grows nor fetches, so the caller's observer latches off instead of spinning.
+ * Pure so the reveal-before-fetch policy is unit-tested independent of the
+ * overlay.
+ */
+export function planScrollTopLoadOlder(
+  windowSize: number,
+  loadedRenderableCount: number,
+  serverHasMore: boolean,
+): { nextWindowSize: number; shouldFetch: boolean } {
+  if (windowSize >= MAX_LOADED_SHELL_WINDOW) {
+    return { nextWindowSize: MAX_LOADED_SHELL_WINDOW, shouldFetch: false };
+  }
+  if (windowSize < loadedRenderableCount) {
+    return {
+      nextWindowSize: Math.min(
+        windowSize + SHELL_RENDER_WINDOW_STEP,
+        MAX_LOADED_SHELL_WINDOW,
+        loadedRenderableCount,
+      ),
+      shouldFetch: false,
+    };
+  }
+  return { nextWindowSize: windowSize, shouldFetch: serverHasMore };
 }


### PR DESCRIPTION
Closes #14329.

## The gap this fixes

The infinite-upward-scroll machinery already shipped in #13532 — server `?before=<createdAt>` cursor (`conversation-routes.ts`), client `loadOlderConversationMessages`, and `useLoadOlderOnScroll` (prepend + WebKit-safe scrollHeight-delta anchor). But `ContinuousChatOverlay` still rendered a **fixed** `selectVisibleShellMessages(messages, phase)` capped at the newest 80 turns (`slice(-80)`).

So load-older paged history into state that the cap immediately sliced back off:
- The initial 200-turn server window was never fully scrollable (only the newest 80 rendered).
- Scroll-up dead-ended at 80; the top sentinel then drained older pages **invisibly**.
- The e2e fixture rendered every message with no cap, so it never caught this — a mock standing in for the real render path.

## The change

Make the render window **slide** (issue Q1: *"grow by page, bounded ~400 rather than a hard `slice(-80)`"*):

- New pure policy `planScrollTopLoadOlder(windowSize, loadedRenderableCount, serverHasMore)` in `shell-state.ts` — **reveal-before-fetch**: grow the window a page to surface already-loaded turns network-free first; only page the next older server window once the window has drained; latch off at the DOM bound.
- Overlay tracks a `renderWindowSize` that starts lean at `MAX_RENDERED_SHELL_MESSAGES` (idle/drag DOM unchanged) and grows via the policy, bounded by `MAX_LOADED_SHELL_WINDOW` (400) so a long thread never unbounds the DOM. Both grows ride the **same** anchor in `useLoadOlderOnScroll`, so the reader stays put; tail-follow (`useThreadAutoScroll`) is untouched; the window resets on conversation switch.
- `filterRenderableShellMessages` extracted from `selectVisibleShellMessages` (no behavior change) so the overlay can measure the loaded-renderable count with one filter definition.

No server changes — the `?before=` cursor + fallback (`parseBeforeCursor` → recent window on a bad cursor) already satisfy the acceptance criteria.

## Acceptance criteria

- [x] Scroll-up loads older pages until history is exhausted; sentinel stops when there's no more (server `hasMore` + DOM-bound latch).
- [x] Prepending does NOT jump scroll — anchor preserved (e2e: **drift 0.0px**).
- [x] Sliding render window bounded ~400; tail-follow still snaps to latest.
- [x] Bad `?before=` cursor falls back to the recent window (server `parseBeforeCursor`, unchanged).
- [x] `chat-perf-gate` still green with the change.
- [x] Regression e2e: scrolls up, asserts the window grows past the cap and older rows render network-free (reveal-before-fetch), then a `?before=` fires + prepends + anchor-compensates.

## Evidence

See the linked issue comment for full logs. Summary:

- **Real-browser e2e** `run-chat-infinite-scroll-e2e.mjs` — all scenarios pass incl. the new #14329 render-window growth (big thread mounts capped to 80 not 200; scroll-up grows 80→130 and reveals rows network-free; oldest turn reachable; no dead-end).
- **chat-perf-gate** (real overlay, drag + pull-to-maximize) — 120fps, p95 10.0ms, 0/643 dropped frames, CLS 0.0000, pull-to-maximize/restore 4/4. #13531 gestures protected.
- **Unit** — 248 UI tests pass (shell-state policy: reveal-before-fetch, loaded-count clamp, DOM-bound latch, full >200-turn walk; + overlay/controller suites).

Video walkthrough + before/after screenshots: N/A in this environment (no live agent/dashboard boot); the render-window behavior is proven end-to-end by the real-browser e2e above, which drives the production hook + orchestration + policy in real Chromium with real geometry and a real `?before=` fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)