### PR TITLE
fix(cloud): unbreak cloud typecheck on develop (undefined readCookie + 2 test-type errors)

### DIFF
--- a/packages/cloud/api/__tests__/my-agents-claim-affiliate-characters.test.ts
+++ b/packages/cloud/api/__tests__/my-agents-claim-affiliate-characters.test.ts
@@ -77,7 +77,7 @@ mock.module("@/lib/utils/logger", () => ({
   },
 }));
 
-let route: { default: { fetch: (req: Request) => Promise<Response> } };
+let route: typeof import("../my-agents/claim-affiliate-characters/route");
 
 beforeAll(async () => {
   route = await import("../my-agents/claim-affiliate-characters/route");

--- a/packages/cloud/api/__tests__/redemptions-client-ip.test.ts
+++ b/packages/cloud/api/__tests__/redemptions-client-ip.test.ts
@@ -112,7 +112,7 @@ describe("POST /api/v1/redemptions client IP resolution", () => {
     });
 
     expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({
+    expect((await res.json()) as { success: boolean; error: string }).toEqual({
       success: false,
       error: ORIGIN_ERROR,
     });
@@ -126,7 +126,7 @@ describe("POST /api/v1/redemptions client IP resolution", () => {
     });
 
     expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({
+    expect((await res.json()) as { success: boolean; error: string }).toEqual({
       success: false,
       error: ORIGIN_ERROR,
     });
@@ -137,7 +137,7 @@ describe("POST /api/v1/redemptions client IP resolution", () => {
     const res = await postRedemption();
 
     expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({
+    expect((await res.json()) as { success: boolean; error: string }).toEqual({
       success: false,
       error: ORIGIN_ERROR,
     });

--- a/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
+++ b/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
@@ -16,6 +16,7 @@
 import type { UserWithOrganization } from "../../db/repositories/users";
 import type { AppContext, AuthedUser, Bindings } from "../../types/cloud-worker-env";
 import { ApiError, AuthenticationError, ForbiddenError } from "../api/cloud-worker-errors";
+import { getCookieValueFromHeader } from "../http/cookie-header";
 import { logger } from "../utils/logger";
 import { timingSafeEqualSecret } from "./cron";
 import {
@@ -126,7 +127,10 @@ function testAuthEnv(env: Bindings): PlaywrightTestAuthEnv {
 async function getPlaywrightTestUser(c: AppContext): Promise<AuthedUser | null> {
   if (c.env.PLAYWRIGHT_TEST_AUTH !== "true") return null;
 
-  const token = readCookie(c, PLAYWRIGHT_TEST_SESSION_COOKIE_NAME);
+  const token = getCookieValueFromHeader(
+    c.req.header("cookie") ?? null,
+    PLAYWRIGHT_TEST_SESSION_COOKIE_NAME,
+  );
   if (!token) return null;
 
   const claims = verifyPlaywrightTestSessionToken(token, testAuthEnv(c.env));


### PR DESCRIPTION
## Problem

`verify:cloud` (the cloud-tests.yml PR gate) is **red on develop tip** — every cloud PR fails typecheck through no fault of its own. 4 errors, all red-merged by the #14229 squash (`ee0f9d7782`) while branch rulesets are off (#14194 context).

## Fixes (4 errors → 0)

1. **`workers-hono-auth.ts:129` — call to undefined `readCookie`** (TS2304). The Playwright test-session path called a helper that was never defined or imported. Runtime-safe in prod (gated behind `PLAYWRIGHT_TEST_AUTH === "true"`, and esbuild doesn't typecheck — which is how it shipped), but a hard typecheck red. Fixed with the canonical `getCookieValueFromHeader(c.req.header("cookie") ?? null, …)`, exactly mirroring the sibling implementation in `lib/auth.ts:79`.
2. **`my-agents-claim-affiliate-characters.test.ts:83`** (TS2322) — the deferred route import was typed with a hand-narrowed `{ default: { fetch: (req: Request) => Promise<Response> } }` that Hono's fetch signature doesn't satisfy. Typed as `typeof import(...)`.
3. **`redemptions-client-ip.test.ts:115/129/140`** (TS2769 ×3) — `expect(await res.json()).toEqual({...})` fails under the workers `Response.json()` overloads; bound the parsed body to the asserted shape at each site.

## Evidence

- **Before:** `bun run --cwd packages/cloud/api typecheck` → 4 × `error TS…` (listed above), exit 1.
- **After:** same command → **0 errors**, exit 0.
- Runtime: `bun test` on the two touched test files in an ad-hoc worktree is strictly **better** with the fix (2 pass vs 0 pass pristine); the residual `mock.module` resolution error is pre-existing and reproduces identically **without** this change (fresh-worktree harness limitation, not a regression). N/A - UI/trajectory evidence (typecheck-only + test-type fixes, no behavior change on any prod path).

## Related

Unblocks the green baseline for #14432's follow-up PR-time Worker bundle gate (#14422 prevention).

https://claude.ai/code/session_01Y9PKm5MocuCmetfstCenBH
