### PR TITLE
fix(cloud): repair 3 typecheck blockers breaking cloud-api / cloud-shared on develop

### DIFF
--- a/packages/cloud/api/__tests__/my-agents-claim-affiliate-characters.test.ts
+++ b/packages/cloud/api/__tests__/my-agents-claim-affiliate-characters.test.ts
@@ -77,7 +77,7 @@ mock.module("@/lib/utils/logger", () => ({
   },
 }));
 
-let route: { default: { fetch: (req: Request) => Promise<Response> } };
+let route: typeof import("../my-agents/claim-affiliate-characters/route");
 
 beforeAll(async () => {
   route = await import("../my-agents/claim-affiliate-characters/route");

--- a/packages/cloud/api/__tests__/redemptions-client-ip.test.ts
+++ b/packages/cloud/api/__tests__/redemptions-client-ip.test.ts
@@ -112,7 +112,8 @@ describe("POST /api/v1/redemptions client IP resolution", () => {
     });
 
     expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body).toEqual({
       success: false,
       error: ORIGIN_ERROR,
     });
@@ -126,7 +127,8 @@ describe("POST /api/v1/redemptions client IP resolution", () => {
     });
 
     expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body).toEqual({
       success: false,
       error: ORIGIN_ERROR,
     });
@@ -137,7 +139,8 @@ describe("POST /api/v1/redemptions client IP resolution", () => {
     const res = await postRedemption();
 
     expect(res.status).toBe(400);
-    expect(await res.json()).toEqual({
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body).toEqual({
       success: false,
       error: ORIGIN_ERROR,
     });

--- a/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
+++ b/packages/cloud/shared/src/lib/auth/workers-hono-auth.ts
@@ -13,6 +13,7 @@
  * NOT from `@/lib/auth`, which still pulls Next.
  */
 
+import { getCookie } from "hono/cookie";
 import type { UserWithOrganization } from "../../db/repositories/users";
 import type { AppContext, AuthedUser, Bindings } from "../../types/cloud-worker-env";
 import { ApiError, AuthenticationError, ForbiddenError } from "../api/cloud-worker-errors";
@@ -126,7 +127,7 @@ function testAuthEnv(env: Bindings): PlaywrightTestAuthEnv {
 async function getPlaywrightTestUser(c: AppContext): Promise<AuthedUser | null> {
   if (c.env.PLAYWRIGHT_TEST_AUTH !== "true") return null;
 
-  const token = readCookie(c, PLAYWRIGHT_TEST_SESSION_COOKIE_NAME);
+  const token = getCookie(c, PLAYWRIGHT_TEST_SESSION_COOKIE_NAME);
   if (!token) return null;
 
   const claims = verifyPlaywrightTestSessionToken(token, testAuthEnv(c.env));


### PR DESCRIPTION
## What

`develop` had three pre-existing TypeScript errors breaking `@elizaos/cloud-shared` and `@elizaos/cloud-api` typecheck (and therefore the turbo build — these two packages fail `bun run build`). All three are fixed here; both packages now typecheck clean (exit 0) and the affected suites pass.

### 1. `workers-hono-auth.ts` — orphaned `readCookie` (TS2304)
`getPlaywrightTestUser` still called `readCookie`, a helper deleted by the steward-cookie scoping refactor (#13865 / `407cb39b9ac` / `f6eb1bcf047`) which left this one callsite behind. Replaced with `getCookie` from `hono/cookie` — behaviorally identical to the removed helper (parse Cookie header → `decodeURIComponent` → value-or-nullish) and the convention every other cloud route already uses.

### 2. `my-agents-claim-affiliate-characters.test.ts` — bad `route` annotation (TS2322)
`route` was hand-annotated with a `fetch` signature that can't match a real Hono app's `fetch` (Hono returns `Response | Promise<Response>` and takes the CF `Request`), so `route = await import(...)` failed. Typed `route` as `typeof import(...)` so the annotation tracks the real module export.

### 3. `redemptions-client-ip.test.ts` — untyped `res.json()` (TS2769 ×3)
Landed today in #14260. `expect(await res.json()).toEqual(...)` has no type on the parsed body; the CF `Response.json()` generic resolves the result to `undefined`, rejecting the `.toEqual` argument. Read the body as `(await res.json()) as { success: boolean; error: string }` — the pattern used by ~200 sibling cloud-api response-body assertions.

## Why these are safe
- All three are typing-only fixes; no runtime/behavior change.
- #1 swaps a deleted helper for its exact equivalent already used repo-wide.
- #2/#3 only correct test type annotations.

## Verification
- `bun run --cwd packages/cloud/shared typecheck` → exit 0, 0 errors
- `bun run --cwd packages/cloud/api typecheck` → exit 0, 0 errors
- `bun test packages/cloud/api/__tests__/my-agents-claim-affiliate-characters.test.ts` → 2 pass / 0 fail
- `bun test packages/cloud/api/__tests__/redemptions-client-ip.test.ts` → 5 pass / 0 fail

Branch is rebased on the latest `origin/develop` (0 behind).

### Evidence
| Type | Status |
| --- | --- |
| Backend logs | N/A - typing-only fix; no code path changes. Test output shows the real handler firing (`[Redemption API] Missing trusted client IP`). |
| Frontend / screenshots / video | N/A - no UI surface touched (cloud Worker auth helper + two test files). |
| Real-LLM trajectories | N/A - no agent/action/prompt/model behavior changes. |
| Typecheck + unit tests | ✅ both packages exit 0; affected suites 2/2 and 5/5 green (above). |

🤖 Generated with [Claude Code](https://claude.com/claude-code)