### PR TITLE
feat(app): capture device e2e failure forensics

### DIFF
--- a/packages/app/scripts/android-e2e.mjs
+++ b/packages/app/scripts/android-e2e.mjs
@@ -41,9 +41,11 @@ import {
   resolveSerial,
 } from "./lib/android-device.mjs";
 import {
+  captureFailureForensics,
   createDeviceE2eBundle,
   finalizeDeviceE2eBundle,
   finishBundleStep,
+  formatFailureForensicsBlock,
   parseOutputDirArg,
   recordBundleArtifact,
   runBundledCommand,
@@ -185,7 +187,55 @@ function stageVoiceModels(adb, serial) {
 }
 
 function run(bundle, name, cmd, args, env = {}) {
-  return runBundledCommand(bundle, name, cmd, args, { cwd: appDir, env });
+  return runBundledCommand(bundle, name, cmd, args, {
+    cwd: appDir,
+    env,
+    onFailure: (step, error) => captureAndroidFailure(bundle, step, error),
+  });
+}
+
+let activeAndroidContext = { adb: null, serial: null };
+
+function captureAndroidFailure(bundle, step, error) {
+  const { adb, serial } = activeAndroidContext;
+  return captureFailureForensics(
+    bundle,
+    step,
+    ({ failureDir }) => {
+      const files = [];
+      const causePath = path.join(failureDir, "failure-cause.txt");
+      fs.writeFileSync(causePath, `${error?.message ?? error}\n`);
+      files.push(causePath);
+      if (adb && serial) {
+        files.push(
+          captureAndroidScreenshot({
+            adb,
+            serial,
+            artifactDir: failureDir,
+            filename: "screen.png",
+            log,
+          }),
+        );
+        files.push(
+          captureAndroidLogcat({
+            adb,
+            serial,
+            artifactDir: failureDir,
+            filename: "logcat.txt",
+            lines: 2000,
+            log,
+          }),
+        );
+      }
+      return files;
+    },
+    error,
+  );
+}
+
+function failAndroidStep(bundle, step, error) {
+  captureAndroidFailure(bundle, step, error);
+  finishBundleStep(bundle, step, "failed", error);
 }
 
 function currentHeadCommit() {
@@ -298,7 +348,7 @@ function ensureFreshApkInstalled(bundle, adb, serial) {
       installApk(adb, serial, apk);
       finishBundleStep(bundle, step, "passed");
     } catch (error) {
-      finishBundleStep(bundle, step, "failed", error);
+      failAndroidStep(bundle, step, error);
       throw error;
     }
     const readback = readInstalledRendererStamp(adb, serial, { log });
@@ -358,10 +408,21 @@ async function main() {
   let serial;
   let lease = null;
   let finalResult = "failed";
+  let finalError = null;
   let routeRecording = null;
 
   try {
-    adb = resolveAdb();
+    {
+      const step = startBundleStep(bundle, "resolve Android SDK");
+      try {
+        adb = resolveAdb();
+        activeAndroidContext = { adb, serial: null };
+        finishBundleStep(bundle, step, "passed");
+      } catch (error) {
+        failAndroidStep(bundle, step, error);
+        throw error;
+      }
+    }
     {
       const step = startBundleStep(bundle, "resolve Android device");
       try {
@@ -387,13 +448,15 @@ async function main() {
           }
         }
         serial = resolveSerial(adb, serial);
+        activeAndroidContext = { adb, serial };
         finishBundleStep(bundle, step, "passed");
       } catch (error) {
-        finishBundleStep(bundle, step, "failed", error);
+        failAndroidStep(bundle, step, error);
         throw error;
       }
     }
     process.env.ANDROID_SERIAL = serial;
+    activeAndroidContext = { adb, serial };
     setBundleDevice(bundle, { serial, kind: "android" });
     log(`device serial=${serial}`);
     lease = await acquireDeviceLease(`android:${serial}`, {
@@ -407,7 +470,7 @@ async function main() {
         await ensureEmulatorPermissive(adb, serial, { log });
         finishBundleStep(bundle, step, "passed");
       } catch (error) {
-        finishBundleStep(bundle, step, "failed", error);
+        failAndroidStep(bundle, step, error);
         throw error;
       }
     }
@@ -447,7 +510,7 @@ async function main() {
           stageVoiceModels(adb, serial);
           finishBundleStep(bundle, step, "passed");
         } catch (error) {
-          finishBundleStep(bundle, step, "failed", error);
+          failAndroidStep(bundle, step, error);
           throw error;
         }
       }
@@ -545,6 +608,9 @@ async function main() {
     }
     finalResult = "passed";
     log("ALL ANDROID E2E PASSED ✅");
+  } catch (error) {
+    finalError = error;
+    throw error;
   } finally {
     if (routeRecording) {
       const videoPath = await routeRecording.stop();
@@ -590,6 +656,10 @@ async function main() {
     }
     lease?.release();
     const bundleRoot = finalizeDeviceE2eBundle(bundle, finalResult);
+    if (finalError) {
+      const block = formatFailureForensicsBlock(bundle, finalError);
+      if (block) process.stderr.write(`\n${block}`);
+    }
     log(`bundle: ${bundleRoot}`);
   }
 }

--- a/packages/app/scripts/device-e2e-bundle.test.mjs
+++ b/packages/app/scripts/device-e2e-bundle.test.mjs
@@ -10,11 +10,13 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  captureFailureForensics,
   collectBundleArtifacts,
   createDeviceE2eBundle,
   defaultDeviceE2eOutputDir,
   finalizeDeviceE2eBundle,
   finishBundleStep,
+  formatFailureForensicsBlock,
   parseOutputDirArg,
   recordBundleArtifact,
   runBundledCommand,
@@ -176,5 +178,71 @@ describe("device-e2e bundle assembly", () => {
     expect(
       fs.readFileSync(path.join(bundle.logsDir, "runner.log"), "utf8"),
     ).toContain("nope");
+  });
+
+  it("records step failure forensics and formats a compact stderr block", () => {
+    const root = tempRoot();
+    const bundle = createDeviceE2eBundle({
+      appDir: root,
+      lane: "android",
+      outputDir: path.join(root, "bundle"),
+    });
+    const step = startBundleStep(bundle, "Android route coverage");
+    const error = new Error("route failed");
+
+    captureFailureForensics(
+      bundle,
+      step,
+      ({ failureDir }) => {
+        const cause = path.join(failureDir, "failure-cause.txt");
+        const log = path.join(failureDir, "logcat.txt");
+        const screen = path.join(failureDir, "screen.png");
+        fs.writeFileSync(cause, "route failed\n");
+        fs.writeFileSync(log, "log tail\n");
+        fs.writeFileSync(screen, ONE_BY_ONE_PNG);
+        return [cause, log, screen];
+      },
+      error,
+    );
+    finishBundleStep(bundle, step, "failed", error);
+    finalizeDeviceE2eBundle(bundle, "failed");
+
+    const summary = JSON.parse(
+      fs.readFileSync(path.join(bundle.root, "summary.json"), "utf8"),
+    );
+    const block = formatFailureForensicsBlock(bundle, error);
+
+    expect(summary.steps[0].failureDir).toBe("failure/android-route-coverage");
+    expect(summary.steps[0].artifacts).toEqual([
+      "failure/android-route-coverage/failure-cause.txt",
+      "failure/android-route-coverage/logcat.txt",
+      "failure/android-route-coverage/screen.png",
+    ]);
+    expect(block).toContain("DEVICE E2E FAILURE FORENSICS");
+    expect(block).toContain("step: Android route coverage");
+    expect(block).toContain("screen.png");
+  });
+
+  it("keeps the original failed step when forensic capture fails", () => {
+    const root = tempRoot();
+    const bundle = createDeviceE2eBundle({
+      appDir: root,
+      lane: "ios-sim",
+      outputDir: path.join(root, "bundle"),
+    });
+    const step = startBundleStep(bundle, "boot iOS Simulator");
+
+    captureFailureForensics(bundle, step, () => {
+      throw new Error("simulator disconnected");
+    });
+    finishBundleStep(bundle, step, "failed", new Error("boot failed"));
+    finalizeDeviceE2eBundle(bundle, "failed");
+
+    const summary = JSON.parse(
+      fs.readFileSync(path.join(bundle.root, "summary.json"), "utf8"),
+    );
+    expect(summary.result).toBe("failed");
+    expect(summary.steps[0].error).toBe("boot failed");
+    expect(summary.warnings[0]).toContain("simulator disconnected");
   });
 });

--- a/packages/app/scripts/ios-e2e.mjs
+++ b/packages/app/scripts/ios-e2e.mjs
@@ -30,9 +30,11 @@ import {
   selectBootedUdid,
 } from "./ios-e2e-lib.mjs";
 import {
+  captureFailureForensics,
   createDeviceE2eBundle,
   finalizeDeviceE2eBundle,
   finishBundleStep,
+  formatFailureForensicsBlock,
   recordBundleArtifact,
   runBundledCommand,
   setBundleBuild,
@@ -59,7 +61,62 @@ function readAppId() {
 }
 
 function run(bundle, name, cmd, args, env = {}) {
-  runBundledCommand(bundle, name, cmd, args, { cwd: appDir, env });
+  runBundledCommand(bundle, name, cmd, args, {
+    cwd: appDir,
+    env,
+    onFailure: (step, error) => captureIosFailure(bundle, step, error),
+  });
+}
+
+let activeIosContext = { udid: null };
+
+function captureIosFailure(bundle, step, error) {
+  const { udid } = activeIosContext;
+  return captureFailureForensics(
+    bundle,
+    step,
+    ({ failureDir }) => {
+      const files = [];
+      const causePath = path.join(failureDir, "failure-cause.txt");
+      fs.writeFileSync(causePath, `${error?.message ?? error}\n`);
+      files.push(causePath);
+      if (udid) {
+        const screenshotPath = path.join(failureDir, "screen.png");
+        simctl(["io", udid, "screenshot", "--type=png", screenshotPath]);
+        files.push(screenshotPath);
+        const logPath = path.join(failureDir, "ios-sim.log");
+        const result = spawnSync(
+          "xcrun",
+          [
+            "simctl",
+            "spawn",
+            udid,
+            "log",
+            "show",
+            "--style",
+            "compact",
+            "--last",
+            "2m",
+          ],
+          { encoding: "utf8", maxBuffer: 32 * 1024 * 1024 },
+        );
+        fs.writeFileSync(
+          logPath,
+          result.status === 0
+            ? result.stdout
+            : result.stderr || `simctl log show exited with ${result.status}\n`,
+        );
+        files.push(logPath);
+      }
+      return files;
+    },
+    error,
+  );
+}
+
+function failIosStep(bundle, step, error) {
+  captureIosFailure(bundle, step, error);
+  finishBundleStep(bundle, step, "failed", error);
 }
 
 function simctl(args) {
@@ -207,7 +264,7 @@ function runStep(bundle, step, { udid, appId }) {
         });
         finishBundleStep(bundle, installStep, "passed");
       } catch (error) {
-        finishBundleStep(bundle, installStep, "failed", error);
+        failIosStep(bundle, installStep, error);
         throw error;
       }
       return;
@@ -245,6 +302,7 @@ async function main() {
     outputDir: flags.output,
   });
   let finalResult = "failed";
+  let finalError = null;
   let lease = null;
   let udid = null;
   let appId = null;
@@ -259,9 +317,10 @@ async function main() {
     const bootStep = startBundleStep(bundle, "boot iOS Simulator");
     try {
       udid = ensureSimulatorBooted(flags.device);
+      activeIosContext = { udid };
       finishBundleStep(bundle, bootStep, "passed");
     } catch (error) {
-      finishBundleStep(bundle, bootStep, "failed", error);
+      failIosStep(bundle, bootStep, error);
       throw error;
     }
     log(`simulator udid=${udid}`);
@@ -277,6 +336,9 @@ async function main() {
     }
     finalResult = "passed";
     log("ALL iOS E2E PASSED ✅");
+  } catch (error) {
+    finalError = error;
+    throw error;
   } finally {
     if (udid && appId) {
       try {
@@ -314,6 +376,10 @@ async function main() {
     }
     lease?.release();
     const bundleRoot = finalizeDeviceE2eBundle(bundle, finalResult);
+    if (finalError) {
+      const block = formatFailureForensicsBlock(bundle, finalError);
+      if (block) process.stderr.write(`\n${block}`);
+    }
     log(`bundle: ${bundleRoot}`);
   }
 }

--- a/packages/app/scripts/lib/device-e2e-bundle.mjs
+++ b/packages/app/scripts/lib/device-e2e-bundle.mjs
@@ -67,6 +67,14 @@ function uniquePath(dir, filename) {
   return candidate;
 }
 
+function slugifyStepName(name) {
+  return String(name)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 80);
+}
+
 function walkFiles(root) {
   if (!root || !fs.existsSync(root)) return [];
   const files = [];
@@ -199,6 +207,11 @@ export function finishBundleStep(bundle, step, status, error) {
   return step;
 }
 
+export function failureDirForStep(bundle, step) {
+  const slug = slugifyStepName(step.name) || "step";
+  return ensureDir(path.join(bundle.root, "failure", slug));
+}
+
 export function recordBundleArtifact(bundle, filePath, kind, step = null) {
   const absolute = path.resolve(filePath);
   if (!isFile(absolute)) return null;
@@ -214,6 +227,54 @@ export function recordBundleArtifact(bundle, filePath, kind, step = null) {
   return artifact;
 }
 
+export function captureFailureForensics(bundle, step, capture, error) {
+  const failureDir = failureDirForStep(bundle, step);
+  step.failureDir = path.relative(bundle.root, failureDir);
+  try {
+    const captured = capture({ failureDir, error }) ?? [];
+    const files = Array.isArray(captured) ? captured : [captured];
+    for (const file of files.filter(Boolean)) {
+      const ext = path.extname(file).toLowerCase();
+      const kind = VIDEO_EXTENSIONS.has(ext)
+        ? "video"
+        : IMAGE_EXTENSIONS.has(ext)
+          ? "screenshot"
+          : "log";
+      recordBundleArtifact(bundle, file, kind, step);
+    }
+  } catch (captureError) {
+    // error-policy:J6 failure forensics is teardown/diagnostic work; preserve
+    // the original runner failure and record the capture problem as a warning.
+    bundle.warnings.push(
+      `failure forensics failed for ${step.name}: ${captureError?.message ?? captureError}`,
+    );
+  }
+  return failureDir;
+}
+
+export function formatFailureForensicsBlock(bundle, error) {
+  const failedStep = [...bundle.steps]
+    .reverse()
+    .find((step) => step.status === "failed");
+  if (!failedStep) return "";
+  const artifactPaths = failedStep.artifacts.map((relativePath) =>
+    path.join(bundle.root, relativePath),
+  );
+  const lines = [
+    "DEVICE E2E FAILURE FORENSICS",
+    `step: ${failedStep.name}`,
+    `cause: ${error?.message ?? failedStep.error ?? error}`,
+  ];
+  if (failedStep.failureDir) {
+    lines.push(`failureDir: ${path.join(bundle.root, failedStep.failureDir)}`);
+  }
+  if (artifactPaths.length > 0) {
+    lines.push("artifacts:");
+    for (const artifactPath of artifactPaths) lines.push(`  - ${artifactPath}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
 export function appendRunnerLog(bundle, chunk) {
   fs.appendFileSync(path.join(bundle.logsDir, "runner.log"), chunk);
 }
@@ -223,7 +284,7 @@ export function runBundledCommand(
   name,
   cmd,
   args,
-  { cwd, env = {} } = {},
+  { cwd, env = {}, onFailure } = {},
 ) {
   const step = startBundleStep(bundle, name);
   const result = spawnSync(cmd, args, {
@@ -243,18 +304,15 @@ export function runBundledCommand(
     appendRunnerLog(bundle, stderr);
   }
   const ok = result.status === 0;
-  finishBundleStep(
-    bundle,
-    step,
-    ok ? "passed" : "failed",
-    ok
-      ? null
-      : `${cmd} ${args.join(" ")} ${
-          result.status === null
-            ? "terminated by signal"
-            : `exited with ${result.status}`
-        }`,
-  );
+  const failure = ok
+    ? null
+    : `${cmd} ${args.join(" ")} ${
+        result.status === null
+          ? "terminated by signal"
+          : `exited with ${result.status}`
+      }`;
+  if (!ok && onFailure) onFailure(step, failure);
+  finishBundleStep(bundle, step, ok ? "passed" : "failed", failure);
   if (!ok) {
     throw new Error(
       `${cmd} ${args.join(" ")} ${
@@ -370,6 +428,7 @@ function buildSummary(bundle, result) {
       endedAt: step.endedAt ?? null,
       durationMs: step.durationMs,
       artifacts: step.artifacts,
+      ...(step.failureDir ? { failureDir: step.failureDir } : {}),
       ...(step.error ? { error: step.error } : {}),
     })),
     artifacts: bundle.artifacts.map((artifact) => ({


### PR DESCRIPTION
## Summary
- Add bundle-level failure forensics helpers that create `failure/<step>/`, attach files to the failed step, expose `steps[].failureDir`, and format a compact stderr block.
- Capture Android runner failures with `failure-cause.txt`, `screen.png`, and a 2000-line `logcat.txt` when a device is known.
- Capture iOS runner failures with `failure-cause.txt`, `screen.png`, and a two-minute simulator log tail when a simulator UDID is known.
- Wire command-step and manual-step failures through the same capture path without replacing the original error.
- Add deterministic unit coverage for failure directories, step artifact references, summary output, forensics warnings, and stderr block formatting.

Relates to #14338.

## Validation
- `bun run --cwd packages/app test -- scripts/device-e2e-bundle.test.mjs scripts/ios-e2e-lib.test.mjs` - pass, 2 files / 48 tests.
- `bunx @biomejs/biome check packages/app/scripts/lib/device-e2e-bundle.mjs packages/app/scripts/device-e2e-bundle.test.mjs packages/app/scripts/android-e2e.mjs packages/app/scripts/ios-e2e.mjs` - pass.
- `node --check packages/app/scripts/lib/device-e2e-bundle.mjs && node --check packages/app/scripts/android-e2e.mjs && node --check packages/app/scripts/ios-e2e.mjs && node --check packages/app/scripts/device-e2e-bundle.test.mjs` - pass.

## Evidence Gate
<!-- evidence-row:before-screenshots -->
- [ ] N/A - this changes device-e2e runner failure artifact capture, not an end-user UI surface with a before state.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - the runner now writes failure screenshots into the run-scoped bundle; no new persistent app UI was introduced.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - deterministic runner failure behavior is covered by unit tests here; a real device failure bundle remains the required fleet follow-up for #14338.
<!-- evidence-row:backend-logs -->
- [ ] N/A - this is a local device runner script path; validation is the command output above plus generated bundle summary assertions in tests.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser frontend console/network path is touched.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model behavior changes.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - run-scoped artifacts are intentionally written under the device-e2e bundle output directory, not committed to the repo; real Android/iOS device bundles should be attached inline on #14338 from the fleet run.

## Failure Artifact Shape
A failed step now records artifacts under the run bundle, for example:

```text
failure/<step>/failure-cause.txt
failure/<step>/screen.png
failure/<step>/logcat.txt
```

The compact stderr block keeps the original failure visible:

```text
DEVICE E2E FAILURE FORENSICS
step: resolve Android SDK
cause: adb not found. Install Android SDK platform-tools or set ANDROID_HOME / ANDROID_SDK_ROOT / ADB so adb is resolvable.
failureDir: /tmp/eliza-14338-fast-forensics/failure/resolve-android-sdk
artifacts:
  - /tmp/eliza-14338-fast-forensics/failure/resolve-android-sdk/failure-cause.txt
[android-e2e] bundle: /tmp/eliza-14338-fast-forensics
[android-e2e] FAILED: adb not found. Install Android SDK platform-tools or set ANDROID_HOME / ANDROID_SDK_ROOT / ADB so adb is resolvable.
EXIT_STATUS=1
```

## Known Limitation
This host cannot produce the real macOS iOS-simulator screenshot/log-tail evidence or a fresh physical Android/iOS bundle. The code path is covered by deterministic tests; before closing #14338, run an induced failure on the device fleet and attach the resulting bundle screenshots/log excerpts inline to the issue.
