### PR TITLE
test(chat-perf-gate): triage CLS 0.80 + guard the perf gate against silent regression (#14333)

### DIFF
--- a/.github/workflows/chat-shell-gestures.yml
+++ b/.github/workflows/chat-shell-gestures.yml
@@ -22,6 +22,8 @@ name: Chat shell gestures
 # so CLS is now 0.0000 on develop (stable across runs, not timing-flaky). It is
 # re-enabled below (#14333) — CLS is structural so it will not flake on slower
 # fleet hardware, and the frame budget carries ~3x margin (p95 ~10ms ≤ 33ms).
+# Both gates self-verify their detector's teeth: each injects a real non-transient
+# shift and asserts it is flagged, so a 0.0000 can never be a dead-observer pass.
 #
 # Path-gated to packages/ui (and the app-side gate + matrix) so it only runs when
 # the surface it covers changes. The e2e runners bundle the fixtures with esbuild
@@ -181,9 +183,12 @@ jobs:
       - name: Chat ambient pulse e2e
         run: bun run --cwd packages/ui test:chat-ambient-e2e
 
-      # Perf gates: drive the overlay under scroll + swipe, feed real
-      # PerformanceObserver + rAF entries into the shared frame-budget +
-      # layout-stability detectors, hard-fail on dropped-frame % / p95 / CLS.
+      # Perf gates: drive the overlay under thread-scroll + pull-to-maximize /
+      # top-pull-restore, feed real PerformanceObserver + rAF entries into the
+      # shared frame-budget + layout-stability detectors, hard-fail on dropped-
+      # frame % / p95 / CLS. Each gate first proves its CLS detector has teeth by
+      # injecting a real non-transient shift and asserting it is flagged (#14333),
+      # so a true CLS of 0.0000 cannot be a vacuous pass from a dead observer.
       - name: Chat overlay perf gate
         run: bun run --cwd packages/ui test:chat-perf-gate
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -416,10 +416,13 @@ jobs:
           path: packages/ui/src/spatial/__e2e__/output-immersive/
           if-no-files-found: ignore
 
-      # Perf gate (#9954): drive REAL overlay-scroll + conversation-swipe in
-      # headless chromium, feed REAL rAF/longtask/layout-shift entries through the
-      # shared frame-budget + layout-stability detectors, HARD-FAIL on dropped
-      # frames, p95 frame time, or CLS. Previously ran in no workflow.
+      # Perf gate (#9954): drive REAL overlay thread-scroll + pull-to-maximize /
+      # top-pull-restore in headless chromium, feed REAL rAF/longtask/layout-shift
+      # entries through the shared frame-budget + layout-stability detectors,
+      # HARD-FAIL on dropped frames, p95 frame time, or CLS. The gate first proves
+      # its CLS detector has teeth by injecting a real non-transient shift and
+      # asserting it is flagged (#14333), so a true CLS of 0.0000 cannot be a
+      # vacuous pass from a dead observer or an over-broad transient marker.
       - name: Perf gate e2e (#9954)
         run: bun run --cwd packages/ui test:perf-gate-e2e
 

--- a/packages/ui/src/components/shell/__e2e__/run-chat-perf-gate.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-perf-gate.mjs
@@ -34,6 +34,7 @@ import {
   LAYOUT_SHIFT_OBSERVER_INIT,
   summarizeStability,
 } from "../../../testing/layout-stability.ts";
+import { measureInjectedNonTransientShift } from "../../../testing/layout-shift-teeth.ts";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const outDir = join(here, "output-perf-gate");
@@ -194,6 +195,20 @@ await runBrowserFixtureE2E(
     const check = gate.assert;
     await page.waitForTimeout(600);
 
+    // GUARD (#14333) — prove the CLS detector has teeth before trusting its green.
+    // CLS 0.0000 below could be a dead observer or an over-broad transient marker
+    // swallowing a real shift. Inject REAL non-transient shifts on the pilled
+    // fixture and assert the SAME observer + detector flag them.
+    const teeth = await measureInjectedNonTransientShift(page, {
+      rootSelector: '[data-testid="perf-gate-root"]',
+      maxCls: STABILITY_BUDGET.maxCls,
+    });
+    console.log(`teeth: injected non-transient cls ${teeth.cls.toFixed(4)} flagged ${teeth.flagged}`);
+    check(
+      teeth.flagged && teeth.cls > STABILITY_BUDGET.maxCls,
+      `gate catches a REAL non-transient shift (injected CLS ${teeth.cls.toFixed(4)} > ${STABILITY_BUDGET.maxCls})`,
+    );
+
     // Open the sheet to FULL so the thread (scroll surface) is mounted.
     await drag(page, '[data-testid="chat-sheet-grabber"]', 0, -120, { steps: 6 });
     await page.waitForTimeout(450);
@@ -270,6 +285,12 @@ await runBrowserFixtureE2E(
       `non-intentional CLS ${stability.cls.toFixed(4)} within ${STABILITY_BUDGET.maxCls}`,
     );
     check(!stability.flagged, "layout-stability detector does not flag the window");
+    // The maximize/restore transitions move the whole panel, so a CLS of 0 with
+    // ZERO raw shift entries is a dead observer, not a stable surface.
+    check(
+      shifts.length > 0,
+      `observer captured real layout-shift entries during the interaction (${shifts.length}) — CLS=0 is not a dead observer`,
+    );
     check(errors.length === 0, `no page errors (saw ${errors.length})`);
     if (errors.length) console.log(errors.join("\n"));
   },

--- a/packages/ui/src/components/shell/__e2e__/run-perf-gate-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-perf-gate-e2e.mjs
@@ -15,6 +15,15 @@
  * expressed as a factor over the 60fps budget so a 60Hz CI runner and a 120Hz dev
  * box both pass. Mechanics come from the shared e2e-runner.
  *
+ * The steady-state CLS is 0.0000 because every maximize/restore shift is inside
+ * the overlay's `data-eliza-layout-shift-intent="transient"` marker. A 0.0000
+ * that big an exclusion could hide a regression, so before trusting it the gate
+ * proves its detector has TEETH: it injects a REAL non-transient shift on the
+ * pilled fixture (measureInjectedNonTransientShift) and asserts the same observer
+ * + detector flag it. This is the exact class the removed horizontal
+ * conversation-swipe once produced here — CLS 0.80 (#14333) — before #13531
+ * deleted swipe and #13826 retargeted the gate onto scroll + maximize/restore.
+ *
  * Run: bun run --cwd packages/ui test:perf-gate-e2e
  */
 
@@ -35,6 +44,7 @@ import {
   LAYOUT_SHIFT_OBSERVER_INIT,
   summarizeStability,
 } from "../../../testing/layout-stability.ts";
+import { measureInjectedNonTransientShift } from "../../../testing/layout-shift-teeth.ts";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const outDir = join(here, "output-perf-gate-e2e");
@@ -225,6 +235,27 @@ await runBrowserFixtureE2E(
 
     await page.waitForTimeout(600);
 
+    // GUARD (#14333) — prove the gate has TEETH before trusting its green. A CLS
+    // of 0.0000 later can be a true "every shift was intentional" pass OR a silent
+    // regression: a dead PerformanceObserver, or an over-broad
+    // `data-eliza-layout-shift-intent="transient"` marker swallowing a genuine
+    // shift. Injecting REAL non-transient shifts on the still-pilled fixture (whole
+    // surface visible, so impact is large and the margin over 0.1 is comfortable)
+    // and asserting the SAME observer + detector flag them proves a re-introduced
+    // real shift — the exact class the removed horizontal conversation-swipe once
+    // produced here (CLS 0.80) — would red the gate, not hide behind the exclusion.
+    const teeth = await measureInjectedNonTransientShift(page, {
+      rootSelector: '[data-testid="perf-gate-root"]',
+      maxCls: MAX_CLS,
+    });
+    console.log(
+      `  [teeth] injected non-transient cls=${teeth.cls.toFixed(4)} shifts=${teeth.shiftCount} flagged=${teeth.flagged}`,
+    );
+    assert(
+      teeth.flagged && teeth.cls > MAX_CLS,
+      `the gate catches a REAL non-transient shift (injected CLS ${teeth.cls.toFixed(4)} > ${MAX_CLS}) — the transient-intent exclusion cannot silently swallow a regression`,
+    );
+
     // Open the sheet to FULL so `#continuous-thread` (the real scroll surface) is
     // mounted + bound. Two pull-ups: collapsed → half → full.
     await drag(page, '[data-testid="chat-sheet-grabber"]', 0, -120, { steps: 6 });
@@ -303,6 +334,16 @@ await runBrowserFixtureE2E(
     assert(
       !stability.flagged,
       `layout stable during scroll + maximize/restore (CLS ${stability.cls.toFixed(4)} ≤ ${MAX_CLS}, ${stability.shiftCount} shifts)`,
+    );
+
+    // The maximize/restore transitions move the whole panel, so the observer MUST
+    // have recorded real layout-shift entries — a CLS of 0 with ZERO raw entries
+    // is a dead observer, not a stable surface, and every future reading would be
+    // a vacuous pass. (The teeth-check above already proved the detector flags a
+    // real shift; this proves the observer was live for THIS interaction.)
+    assert(
+      shifts.length > 0,
+      `observer captured real layout-shift entries during the interaction (${shifts.length}) — CLS=0 is a true all-intentional pass, not a dead observer`,
     );
 
     assert(errors.length === 0, `no page errors (saw ${errors.length})`);

--- a/packages/ui/src/testing/layout-shift-teeth.ts
+++ b/packages/ui/src/testing/layout-shift-teeth.ts
@@ -1,0 +1,108 @@
+/**
+ * Teeth-check for the chat perf gates: proves the live layout-shift observer +
+ * CLS detector actually catch a real, non-intentional shift on the real surface.
+ *
+ * A perf gate that only asserts `CLS ≤ 0.1` can go green for the wrong reason —
+ * a dead PerformanceObserver, a surface that never re-lays-out, or an over-broad
+ * `data-eliza-layout-shift-intent="transient"` marker that swallows a genuine
+ * shift — all report CLS 0.0000 and pass vacuously. This injects real
+ * `layout-shift`-producing DOM mutations OUTSIDE any transient-intent marker
+ * (spacers pushed in above the fixture's static content) and returns the
+ * detector's verdict, so the gate can assert the injected shift IS flagged. It is
+ * the regression guard for the class of shift the removed horizontal
+ * conversation-swipe once produced here (CLS 0.80, #14333).
+ *
+ * Consumes `window.__ELIZA_LAYOUT_SHIFTS__`, populated by
+ * {@link LAYOUT_SHIFT_OBSERVER_INIT}; the caller must install that observer.
+ */
+import type { Page } from "playwright";
+import {
+  type LayoutShiftSample,
+  type StabilitySummary,
+  summarizeStability,
+} from "./layout-stability.ts";
+
+declare global {
+  interface Window {
+    /** Populated in the browser by {@link LAYOUT_SHIFT_OBSERVER_INIT}. */
+    __ELIZA_LAYOUT_SHIFTS__?: LayoutShiftSample[];
+  }
+}
+
+export interface TeethCheckOptions {
+  /** Selector of an in-flow container OUTSIDE the transient-marked overlay. A
+   * painted victim block is inserted at its top and then pushed down. */
+  rootSelector: string;
+  /** Number of spacers pushed in above the victim block; each move is one shift
+   * and CLS sums, so the tuned default clears 0.1 with a wide margin (~0.37). */
+  injections?: number;
+  /** Height of the painted victim block whose downward motion produces the
+   * large-impact shifts, in px. */
+  blockPx?: number;
+  /** Height of each spacer pushed above the block, in px (the per-shift move). */
+  spacerPx?: number;
+  /** CLS budget the detector flags against (mirrors the gate's own budget). */
+  maxCls?: number;
+}
+
+/**
+ * Insert a painted victim block into `rootSelector`, push it down with
+ * `injections` spacers to produce real non-transient layout shifts, harvest the
+ * observed `layout-shift` entries, remove every injected node, and return the
+ * detector's verdict. A flagged, over-budget result proves the gate has teeth.
+ * Call while the surface under the block is visible (impact fraction is largest);
+ * the tuned defaults yield a deterministic ~0.37 CLS on the 420×820 fixture.
+ */
+export async function measureInjectedNonTransientShift(
+  page: Page,
+  {
+    rootSelector,
+    injections = 6,
+    blockPx = 400,
+    spacerPx = 300,
+    maxCls = 0.1,
+  }: TeethCheckOptions,
+): Promise<StabilitySummary> {
+  await page.evaluate(
+    ({ rootSelector, blockPx }) => {
+      const root = document.querySelector(rootSelector);
+      if (!root)
+        throw new Error(`teeth-check: root "${rootSelector}" not found`);
+      const block = document.createElement("div");
+      block.style.cssText = `height:${blockPx}px;width:100%;background:#0a0a0a;`;
+      block.setAttribute("data-teeth", "block");
+      root.insertBefore(block, root.firstChild);
+    },
+    { rootSelector, blockPx },
+  );
+  await page.waitForTimeout(250); // let the victim block paint before it moves
+  await page.evaluate(() => {
+    window.__ELIZA_LAYOUT_SHIFTS__ = [];
+  });
+  // The observer excludes shifts within 500ms of user input; a gesture drive may
+  // have just finished, so wait past that window or every injected shift is
+  // discarded as input-caused.
+  await page.waitForTimeout(700);
+  for (let i = 0; i < injections; i += 1) {
+    await page.evaluate(
+      ({ rootSelector, spacerPx }) => {
+        const root = document.querySelector(rootSelector);
+        if (!root)
+          throw new Error(`teeth-check: root "${rootSelector}" not found`);
+        const spacer = document.createElement("div");
+        spacer.style.cssText = `height:${spacerPx}px;width:100%;`;
+        spacer.setAttribute("data-teeth", "spacer");
+        root.insertBefore(spacer, root.firstChild);
+      },
+      { rootSelector, spacerPx },
+    );
+    await page.waitForTimeout(180);
+  }
+  const injected: LayoutShiftSample[] = await page.evaluate(
+    () => window.__ELIZA_LAYOUT_SHIFTS__ ?? [],
+  );
+  await page.evaluate(() => {
+    for (const n of document.querySelectorAll("[data-teeth]")) n.remove();
+  });
+  return summarizeStability(injected, [], { maxCls });
+}


### PR DESCRIPTION
Closes #14333.

## Context — what was already done vs. what this PR adds

#14495 already reached the same triage conclusion and **re-enabled** `perf-gate-e2e`
in the `chat-shell-gestures` lane, and corrected the "known-red" comment. What it
did **not** add is the **guard** — the actual point of "make the perf gate green
**with a guard so it can't silently regress**." This PR adds that guard and fixes
the remaining stale comments.

## Root cause (fixture artifact vs real shift — element named)

The CLS **0.80 was a REAL layout shift**, not a fixture artifact. The shifting
element was the **whole conversation panel translated horizontally by the old
chat-to-chat conversation-swipe** — a horizontal pointer drag over
`#continuous-thread` with **no** `data-eliza-layout-shift-intent="transient"`
marker, so the CLS detector correctly counted it. #13531 removed swipe and #13826
retargeted both gates onto **thread-scroll + pull-to-maximize / top-pull-restore**,
whose panel motion **is** marked transient via `markLayoutShiftIntent`. Since that
retarget the real interaction reads a true **CLS 0.0000**. The `0.1` threshold is
**not** loosened; the real shift was eliminated at the source.

## The guard (so it can't silently regress)

A `0.0000` sitting behind that broad transient exclusion could pass **vacuously** —
a dead `PerformanceObserver`, a surface that never re-lays-out, or an over-broad
transient marker swallowing a genuine shift all report `0.0000`. Both gates now:

1. **Prove the detector has teeth first** — `measureInjectedNonTransientShift`
   (`packages/ui/src/testing/layout-shift-teeth.ts`) injects a **real
   non-transient** layout shift on the pilled fixture and asserts the *same*
   observer + detector flag it (deterministic **CLS 0.3652 > 0.1**). This is the
   exact class the removed swipe once produced (0.80).
2. **Assert the observer was live** — the maximize/restore transitions move the
   whole panel, so a `0.0000` with **zero** raw shift entries fails as a dead
   observer.

Plus: fix the stale `test.yml` "conversation-swipe" comment and the
`chat-shell-gestures.yml` inline "scroll + swipe" comment (both predate #13531).

## Evidence (live headless-chromium, REAL overlay — no mock; rebased on develop incl. pagination)

**`perf-gate-e2e` (the `test.yml` leg):**
```
[teeth] injected non-transient cls=0.3652 shifts=6 flagged=true
✓ the gate catches a REAL non-transient shift (injected CLS 0.3652 > 0.1)
[overlay-scroll]    fps=120.0 p95=9.2ms dropped=0/546 (0%)
[maximize-restore]  fps=120.0 p95=9.2ms dropped=0/356 (0%)
[layout] cls=0.0000 non-intentional-shifts=0
✓ observer captured real layout-shift entries during the interaction (10)
PERF GATE PASSED
```

**`chat-perf-gate` (healthy overlay gate, still passing):**
```
teeth: injected non-transient cls 0.3652 flagged true
frames: 673 | fps 120.0 | p95 9.1ms | dropped 0/673
layout: cls 0.0000 | non-intentional shifts 0
✓ observer captured real layout-shift entries during the interaction (8)
PERF GATE PASSED
```

**CLS before → after:** `0.80` (horizontal conversation-swipe panel) → `0.0000`
(real interaction), with the detector proven to still flag a `0.3652` injected shift.

## Acceptance criteria

- [x] Root cause documented (real shift, not fixture artifact; element = the
  horizontal conversation-swipe panel translation).
- [x] `test.yml` perf-gate leg honestly green — real shift eliminated by
  #13531/#13826; `0.1` threshold untouched.
- [x] `run-chat-perf-gate.mjs` still passes (frame + CLS budgets).
- [x] **Row containment NOT added** — re-run on the rebased tree that already
  contains pagination/infinite-scroll: budget did not regress (scroll p95 9.2ms,
  0% dropped over 546 frames), so `content-visibility` would be speculative.
- [x] No regression to detents/springs/pull-to-maximize/`flexBasis` — untouched;
  the gate still drives + asserts the real maximize/restore commits.

### Evidence table
| Type | Status |
| --- | --- |
| Perf-gate report (CLS before/after + attribution) | ✅ above |
| Video walkthrough of scroll+swipe path | N/A — swipe removed at source (#13531); current path is thread-scroll + maximize/restore, recorded by each gate's `.webm` artifact |
| Before/after chat-perf-gate frame numbers | ✅ above (0% dropped, p95 9.1–9.2ms) |
| CI screenshot of green perf-gate leg | ⏳ pending CI on this PR |
| Real-LLM trajectory | N/A — perf/CI only, no model in path |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
