### PR TITLE
feat(testing): human-speed streaming reporter + honest skip surfacing for evidence matrix

### DIFF
--- a/scripts/evidence-review/reporter.mjs
+++ b/scripts/evidence-review/reporter.mjs
@@ -1,0 +1,152 @@
+/**
+ * Human-speed streaming reporter and admin summary for the evidence matrix
+ * runner (run-matrix.mjs). Where run-matrix owns lane execution, this module
+ * owns the operator's view of it: it turns each lane's lifecycle
+ * (pending -> running -> passed/failed/skipped) into readable terminal lines as
+ * the matrix advances, then renders one end-of-run summary table an admin — or a
+ * coding agent parsing stdout — reads to see what passed, what failed, what was
+ * skipped and why, and where every artifact landed.
+ *
+ * All output goes through an injected `write` sink and an injected `now` clock
+ * so the reporter's exact status transitions and summary text are asserted
+ * against fixtures without spawning a real lane. Honesty is the invariant: a
+ * lane that cannot run (no device, no live model) is reported `skipped` with a
+ * reason and never rendered as passing.
+ */
+
+const STATUS_GLYPH = {
+  pending: "[ ]",
+  running: "[>]",
+  passed: "[+]",
+  failed: "[x]",
+  skipped: "[-]",
+};
+
+const STATUS_LABEL = {
+  pending: "PENDING",
+  running: "RUNNING",
+  passed: "PASS",
+  failed: "FAIL",
+  skipped: "SKIP",
+};
+
+export function formatDuration(ms) {
+  if (!Number.isFinite(ms) || ms < 0) return "—";
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const minutes = Math.floor(seconds / 60);
+  const rest = Math.round(seconds - minutes * 60);
+  return `${minutes}m${String(rest).padStart(2, "0")}s`;
+}
+
+/**
+ * Streaming reporter that emits one line per lane state change so an operator
+ * watching the terminal sees the matrix advance at human speed. Construct once
+ * per run with the lanes to be executed; drive it with laneStart/laneEnd/
+ * laneSkip as the runner processes each lane.
+ */
+export function createMatrixReporter({
+  write,
+  now = () => Date.now(),
+  total,
+} = {}) {
+  if (typeof write !== "function") {
+    throw new Error("createMatrixReporter requires a write(line) function");
+  }
+  if (!Number.isInteger(total) || total <= 0) {
+    throw new Error("createMatrixReporter requires a positive integer total");
+  }
+
+  let index = 0;
+  const startedAt = new Map();
+
+  const emit = (status, id, label, suffix) => {
+    const position = `[${index}/${total}]`;
+    const glyph = STATUS_GLYPH[status];
+    const badge = STATUS_LABEL[status];
+    write(`${glyph} ${position} ${badge} ${id} — ${label}${suffix}`);
+  };
+
+  return {
+    header() {
+      write(
+        `Running ${total} evidence lane${total === 1 ? "" : "s"} at human speed.`,
+      );
+    },
+    laneStart(step) {
+      index += 1;
+      startedAt.set(step.id, now());
+      emit("running", step.id, step.label, "");
+    },
+    laneEnd(step, status) {
+      const started = startedAt.get(step.id);
+      const elapsed = started == null ? null : now() - started;
+      const timing = elapsed == null ? "" : `  (${formatDuration(elapsed)})`;
+      emit(status, step.id, step.label, timing);
+    },
+    laneSkip(step, reason) {
+      index += 1;
+      emit("skipped", step.id, step.label, `  — ${reason}`);
+    },
+  };
+}
+
+function padEnd(value, width) {
+  const text = String(value);
+  return text.length >= width ? text : text + " ".repeat(width - text.length);
+}
+
+/**
+ * Render the single end-of-run summary table. `steps` are the finished lane
+ * records from the manifest (each with id/status/durationMs and optional
+ * skipReason/artifactPath). Returns the full multi-line string so callers can
+ * both print it and assert it. A `failed` lane appears explicitly as FAIL in the
+ * table and drives the returned overall status — it is never swallowed into a
+ * green summary.
+ */
+export function renderMatrixSummary(
+  steps,
+  { dashboardPath, manifestPath } = {},
+) {
+  const counts = { passed: 0, failed: 0, skipped: 0, planned: 0 };
+  for (const step of steps) {
+    counts[step.status] = (counts[step.status] ?? 0) + 1;
+  }
+  const overall =
+    counts.failed > 0
+      ? "FAILED"
+      : counts.planned === steps.length && steps.length > 0
+        ? "PLANNED"
+        : "PASSED";
+
+  const idWidth = Math.max(4, ...steps.map((s) => s.id.length));
+  const lines = [];
+  lines.push("");
+  lines.push("Evidence matrix summary");
+  lines.push("=".repeat(72));
+  for (const step of steps) {
+    const badge = STATUS_LABEL[step.status] ?? step.status.toUpperCase();
+    const timing = padEnd(formatDuration(step.durationMs), 8);
+    const note =
+      step.status === "skipped" && step.skipReason
+        ? `skip: ${step.skipReason}`
+        : step.artifactPath
+          ? `artifacts: ${step.artifactPath}`
+          : "";
+    lines.push(
+      `${padEnd(badge, 5)}  ${padEnd(step.id, idWidth)}  ${timing}  ${note}`.trimEnd(),
+    );
+  }
+  lines.push("-".repeat(72));
+  const tally =
+    overall === "PLANNED"
+      ? `${counts.planned} planned`
+      : `${counts.passed} passed, ${counts.failed} failed, ${counts.skipped} skipped`;
+  lines.push(`${overall}: ${tally}`);
+  if (manifestPath) lines.push(`Manifest: ${manifestPath}`);
+  if (dashboardPath) lines.push(`Evidence dashboard: ${dashboardPath}`);
+  lines.push("");
+
+  return { text: lines.join("\n"), overall, counts };
+}

--- a/scripts/evidence-review/reporter.test.mjs
+++ b/scripts/evidence-review/reporter.test.mjs
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for the human-speed streaming reporter and admin summary. Output
+ * is captured through an injected write sink and a fake monotonic clock so the
+ * exact status-transition lines and summary text are asserted deterministically,
+ * with explicit coverage that a failed lane surfaces as FAIL and is not
+ * swallowed into a green summary.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createMatrixReporter,
+  formatDuration,
+  renderMatrixSummary,
+} from "./reporter.mjs";
+
+function collector() {
+  const lines = [];
+  return { lines, write: (line) => lines.push(line) };
+}
+
+test("formatDuration renders ms, seconds, and minutes", () => {
+  assert.equal(formatDuration(0), "0ms");
+  assert.equal(formatDuration(850), "850ms");
+  assert.equal(formatDuration(1500), "1.5s");
+  assert.equal(formatDuration(65000), "1m05s");
+  assert.equal(formatDuration(Number.NaN), "—");
+  assert.equal(formatDuration(-5), "—");
+});
+
+test("reporter streams pending->running->passed transitions with timing", () => {
+  const { lines, write } = collector();
+  let clock = 1000;
+  const reporter = createMatrixReporter({
+    write,
+    total: 2,
+    now: () => clock,
+  });
+  reporter.header();
+
+  reporter.laneStart({ id: "test-all", label: "Test matrix" });
+  clock = 3500; // 2.5s elapsed
+  reporter.laneEnd({ id: "test-all", label: "Test matrix" }, "passed");
+
+  reporter.laneStart({ id: "app-audit", label: "Visual audit" });
+  clock = 4200;
+  reporter.laneEnd({ id: "app-audit", label: "Visual audit" }, "passed");
+
+  assert.equal(lines[0], "Running 2 evidence lanes at human speed.");
+  assert.equal(lines[1], "[>] [1/2] RUNNING test-all — Test matrix");
+  assert.equal(lines[2], "[+] [1/2] PASS test-all — Test matrix  (2.5s)");
+  assert.equal(lines[3], "[>] [2/2] RUNNING app-audit — Visual audit");
+  assert.match(lines[4], /^\[\+\] \[2\/2\] PASS app-audit/);
+});
+
+test("reporter marks a failed lane as FAIL, not passed", () => {
+  const { lines, write } = collector();
+  const reporter = createMatrixReporter({ write, total: 1, now: () => 0 });
+  reporter.laneStart({ id: "e2e", label: "e2e" });
+  reporter.laneEnd({ id: "e2e", label: "e2e" }, "failed");
+  assert.match(lines.at(-1), /\[x\] \[1\/1\] FAIL e2e/);
+  assert.ok(!lines.some((l) => /PASS/.test(l)));
+});
+
+test("reporter surfaces a skipped lane with its reason", () => {
+  const { lines, write } = collector();
+  const reporter = createMatrixReporter({ write, total: 1, now: () => 0 });
+  reporter.laneSkip(
+    { id: "ios-sim-capture", label: "iOS capture" },
+    "no booted iOS Simulator",
+  );
+  assert.equal(
+    lines.at(-1),
+    "[-] [1/1] SKIP ios-sim-capture — iOS capture  — no booted iOS Simulator",
+  );
+});
+
+test("reporter rejects invalid construction", () => {
+  assert.throws(() => createMatrixReporter({ total: 1 }), /write/);
+  assert.throws(
+    () => createMatrixReporter({ write: () => {}, total: 0 }),
+    /positive integer total/,
+  );
+});
+
+test("summary tallies pass/fail/skip and reports overall FAILED on any failure", () => {
+  const steps = [
+    { id: "test-all", status: "passed", durationMs: 2500 },
+    {
+      id: "app-audit",
+      status: "failed",
+      durationMs: 900,
+      artifactPath: "packages/app/aesthetic-audit-output",
+    },
+    {
+      id: "ios-sim-capture",
+      status: "skipped",
+      durationMs: 0,
+      skipReason: "no booted iOS Simulator",
+    },
+  ];
+  const summary = renderMatrixSummary(steps, {
+    manifestPath: "/repo/evidence/matrix-run.json",
+    dashboardPath: "/repo/evidence/index.html",
+  });
+
+  assert.equal(summary.overall, "FAILED");
+  assert.deepEqual(summary.counts, {
+    passed: 1,
+    failed: 1,
+    skipped: 1,
+    planned: 0,
+  });
+  assert.match(summary.text, /FAIL {3}app-audit/);
+  assert.match(summary.text, /SKIP {3}ios-sim-capture/);
+  assert.match(summary.text, /skip: no booted iOS Simulator/);
+  assert.match(summary.text, /FAILED: 1 passed, 1 failed, 1 skipped/);
+  assert.match(
+    summary.text,
+    /Evidence dashboard: \/repo\/evidence\/index\.html/,
+  );
+});
+
+test("summary reads PASSED when no lane failed", () => {
+  const steps = [
+    { id: "test-all", status: "passed", durationMs: 10 },
+    { id: "app-audit", status: "skipped", durationMs: 0, skipReason: "off" },
+  ];
+  const summary = renderMatrixSummary(steps, {});
+  assert.equal(summary.overall, "PASSED");
+  assert.match(summary.text, /PASSED: 1 passed, 0 failed, 1 skipped/);
+});
+
+test("summary reads PLANNED when every lane is dry-run planned", () => {
+  const steps = [
+    { id: "test-all", status: "planned", durationMs: 0 },
+    { id: "app-audit", status: "planned", durationMs: 0 },
+  ];
+  const summary = renderMatrixSummary(steps, {});
+  assert.equal(summary.overall, "PLANNED");
+  assert.match(summary.text, /PLANNED: 2 planned/);
+});

--- a/scripts/evidence-review/run-matrix.mjs
+++ b/scripts/evidence-review/run-matrix.mjs
@@ -2,14 +2,21 @@
 /**
  * Full evidence matrix runner for end-of-work verification. It executes the
  * repo's real test, recording, audit, and device-capture lanes in sequence,
- * writes one run manifest, then opens the local evidence reviewer so the
- * generated artifacts are inspected as part of the same workflow.
+ * streams each lane's status through the human-speed reporter (reporter.mjs) so
+ * an operator watches the run advance, writes one run manifest, opens the local
+ * evidence reviewer, and prints a single admin-readable summary of what passed,
+ * failed, or was skipped and where the artifacts landed.
+ *
+ * Device lanes whose simulator/emulator is unreachable are reported `skipped`
+ * with a reason (probeRequirement) — never dropped silently and never faked
+ * green — so the manifest is an honest record of what actually ran.
  */
 
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { createMatrixReporter, renderMatrixSummary } from "./reporter.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -40,14 +47,62 @@ export const MATRIX_STEPS = [
     label: "iOS simulator capture",
     command: ["bun", "run", "--cwd", "packages/app", "capture:ios-sim"],
     tags: ["device", "ios"],
+    // Requires a booted iOS Simulator; probed via `xcrun simctl` so the lane is
+    // honestly skipped (not silently dropped) on a host without one.
+    requires: "ios-simulator",
   },
   {
     id: "android-emu-capture",
     label: "Android emulator capture",
     command: ["bun", "run", "--cwd", "packages/app", "capture:android-emu"],
     tags: ["device", "android"],
+    requires: "android-emulator",
   },
 ];
+
+/**
+ * Report whether a lane's external dependency (a device fleet member) is
+ * reachable. Returns `{ reachable, reason }`; `reason` is the operator-facing
+ * skip explanation when a device is absent. Kept side-effect-free apart from the
+ * cheap probe command so device lanes degrade to an honest SKIP rather than a
+ * fake pass or a silent drop.
+ */
+export function probeRequirement(requirement, { runProbe = spawnSync } = {}) {
+  if (!requirement) return { reachable: true, reason: null };
+  if (requirement === "ios-simulator") {
+    const result = runProbe("xcrun", ["simctl", "list", "devices", "booted"], {
+      encoding: "utf8",
+    });
+    const out = `${result.stdout ?? ""}`;
+    if (result.status === 0 && /\(Booted\)/.test(out)) {
+      return { reachable: true, reason: null };
+    }
+    return {
+      reachable: false,
+      reason: "no booted iOS Simulator (run `xcrun simctl boot <udid>`)",
+    };
+  }
+  if (requirement === "android-emulator") {
+    const result = runProbe("adb", ["devices"], { encoding: "utf8" });
+    const out = `${result.stdout ?? ""}`;
+    const hasDevice = out
+      .split("\n")
+      .slice(1)
+      .some((line) => /\tdevice$/.test(line.trim()));
+    if (result.status === 0 && hasDevice) {
+      return { reachable: true, reason: null };
+    }
+    return {
+      reachable: false,
+      reason:
+        "no attached Android device/emulator (run `emulator -avd <name>`)",
+    };
+  }
+  return {
+    reachable: false,
+    reason: `unknown requirement '${requirement}'`,
+  };
+}
 
 function printHelp() {
   console.log(`Usage: node scripts/evidence-review/run-matrix.mjs [options]
@@ -166,6 +221,19 @@ function plannedStep(step) {
   };
 }
 
+function skippedStep(step, reason) {
+  return {
+    ...step,
+    command: formatCommand(step.command),
+    startedAt: null,
+    finishedAt: null,
+    durationMs: 0,
+    exitCode: null,
+    status: "skipped",
+    skipReason: reason,
+  };
+}
+
 function writeManifest(options, steps, reviewer) {
   fs.mkdirSync(options.outputDir, { recursive: true });
   const manifest = {
@@ -222,9 +290,39 @@ function runReviewer(options) {
   };
 }
 
-function banner(text) {
-  const line = "-".repeat(72);
-  console.log(`\n${line}\n${text}\n${line}`);
+/**
+ * Execute the selected lanes, driving the streaming reporter through each
+ * lane's lifecycle. Device lanes whose requirement is unreachable are recorded
+ * as `skipped` with the probe reason rather than run. Extracted from main() so
+ * the ordering of reporter transitions and lane records is unit-testable with
+ * injected reporter and probe.
+ */
+export function executeSteps(
+  steps,
+  options,
+  { reporter, probe = probeRequirement } = {},
+) {
+  const results = [];
+  for (const step of steps) {
+    if (options.dryRun) {
+      results.push(plannedStep(step));
+      continue;
+    }
+
+    const requirement = probe(step.requires);
+    if (!requirement.reachable) {
+      reporter?.laneSkip(step, requirement.reason);
+      results.push(skippedStep(step, requirement.reason));
+      continue;
+    }
+
+    reporter?.laneStart(step);
+    const result = runStep(step);
+    reporter?.laneEnd(step, result.status);
+    results.push(result);
+    if (result.status === "failed" && options.stopOnFailure) break;
+  }
+  return results;
 }
 
 async function main() {
@@ -235,26 +333,27 @@ async function main() {
   }
 
   const steps = selectMatrixSteps(MATRIX_STEPS, options);
-  const results = [];
 
-  if (options.dryRun) {
-    for (const step of steps) results.push(plannedStep(step));
-  } else {
-    for (const step of steps) {
-      banner(`${step.id}: ${step.label}`);
-      const result = runStep(step);
-      results.push(result);
-      if (result.status === "failed" && options.stopOnFailure) break;
-    }
+  let reporter = null;
+  if (!options.dryRun) {
+    reporter = createMatrixReporter({
+      write: (line) => console.log(line),
+      total: steps.length,
+    });
+    reporter.header();
   }
+
+  const results = executeSteps(steps, options, { reporter });
 
   writeManifest(options, results, null);
   const reviewer = runReviewer(options);
   const { manifest, manifestPath } = writeManifest(options, results, reviewer);
-  console.log(`\nMatrix manifest: ${manifestPath}`);
-  if (reviewer?.dashboardPath) {
-    console.log(`Evidence review: ${reviewer.dashboardPath}`);
-  }
+
+  const summary = renderMatrixSummary(results, {
+    manifestPath,
+    dashboardPath: reviewer?.dashboardPath ?? null,
+  });
+  console.log(summary.text);
 
   if (
     manifest.status === "failed" ||

--- a/scripts/evidence-review/run-matrix.test.mjs
+++ b/scripts/evidence-review/run-matrix.test.mjs
@@ -1,16 +1,49 @@
 /**
- * Unit tests for the evidence matrix runner's planning logic. The real command
- * executes expensive test and device lanes; these tests keep the option parser
- * and step selector deterministic without spawning the matrix itself.
+ * Unit tests for the evidence matrix runner's planning and execution logic. The
+ * option parser and step selector are exercised with no side effects; execution
+ * is proven against lightweight fixture lanes — one that exits 0 and one that
+ * exits non-zero — driven through the real spawn path so the streamed reporter
+ * transitions, the honest device-lane skip, and the not-swallowed failure are
+ * all asserted without the expensive real matrix.
  */
 
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  executeSteps,
   MATRIX_STEPS,
   parseMatrixArgs,
+  probeRequirement,
   selectMatrixSteps,
 } from "./run-matrix.mjs";
+
+function fixtureLane(id, exitCode) {
+  return {
+    id,
+    label: `fixture ${id}`,
+    command: ["node", "-e", `process.exit(${exitCode})`],
+    tags: ["fixture"],
+  };
+}
+
+function recordingReporter() {
+  const events = [];
+  return {
+    events,
+    header() {
+      events.push(["header"]);
+    },
+    laneStart(step) {
+      events.push(["start", step.id]);
+    },
+    laneEnd(step, status) {
+      events.push(["end", step.id, status]);
+    },
+    laneSkip(step, reason) {
+      events.push(["skip", step.id, reason]);
+    },
+  };
+}
 
 test("selects all real matrix lanes by default", () => {
   const options = parseMatrixArgs([]);
@@ -58,4 +91,114 @@ test("validates explicit step ids and OCR mode", () => {
     () => parseMatrixArgs(["--review-ocr=yes"]),
     /--review-ocr must be auto, on, or off/,
   );
+});
+
+test("probeRequirement passes lanes with no external dependency", () => {
+  assert.deepEqual(probeRequirement(null), { reachable: true, reason: null });
+  assert.deepEqual(probeRequirement(undefined), {
+    reachable: true,
+    reason: null,
+  });
+});
+
+test("probeRequirement reports an honest skip reason when no device is booted", () => {
+  const noBooted = probeRequirement("ios-simulator", {
+    runProbe: () => ({ status: 0, stdout: "== Devices ==\n" }),
+  });
+  assert.equal(noBooted.reachable, false);
+  assert.match(noBooted.reason, /no booted iOS Simulator/);
+
+  const booted = probeRequirement("ios-simulator", {
+    runProbe: () => ({ status: 0, stdout: "iPhone 16 (ABC) (Booted)\n" }),
+  });
+  assert.deepEqual(booted, { reachable: true, reason: null });
+
+  const noAndroid = probeRequirement("android-emulator", {
+    runProbe: () => ({ status: 0, stdout: "List of devices attached\n\n" }),
+  });
+  assert.equal(noAndroid.reachable, false);
+  assert.match(noAndroid.reason, /no attached Android device/);
+
+  const android = probeRequirement("android-emulator", {
+    runProbe: () => ({
+      status: 0,
+      stdout: "List of devices attached\nemulator-5554\tdevice\n",
+    }),
+  });
+  assert.deepEqual(android, { reachable: true, reason: null });
+});
+
+test("executeSteps runs real fixture lanes and streams pass/fail transitions", () => {
+  const reporter = recordingReporter();
+  const steps = [fixtureLane("green-lane", 0), fixtureLane("red-lane", 3)];
+  const results = executeSteps(steps, parseMatrixArgs([]), {
+    reporter,
+    probe: () => ({ reachable: true, reason: null }),
+  });
+
+  assert.deepEqual(
+    results.map((r) => [r.id, r.status, r.exitCode]),
+    [
+      ["green-lane", "passed", 0],
+      ["red-lane", "failed", 3],
+    ],
+  );
+  // The failure is surfaced as a real FAIL transition, never swallowed.
+  assert.deepEqual(reporter.events, [
+    ["start", "green-lane"],
+    ["end", "green-lane", "passed"],
+    ["start", "red-lane"],
+    ["end", "red-lane", "failed"],
+  ]);
+});
+
+test("executeSteps stops after first failure when --stop-on-failure is set", () => {
+  const reporter = recordingReporter();
+  const steps = [fixtureLane("red-lane", 1), fixtureLane("never-runs", 0)];
+  const results = executeSteps(steps, parseMatrixArgs(["--stop-on-failure"]), {
+    reporter,
+    probe: () => ({ reachable: true, reason: null }),
+  });
+  assert.equal(results.length, 1);
+  assert.equal(results[0].status, "failed");
+  assert.ok(!reporter.events.some((e) => e[1] === "never-runs"));
+});
+
+test("executeSteps skips an unreachable device lane with a reason, never runs it", () => {
+  const reporter = recordingReporter();
+  const steps = [
+    fixtureLane("green-lane", 0),
+    { ...fixtureLane("ios-sim-capture", 1), requires: "ios-simulator" },
+  ];
+  const results = executeSteps(steps, parseMatrixArgs([]), {
+    reporter,
+    probe: (req) =>
+      req === "ios-simulator"
+        ? { reachable: false, reason: "no booted iOS Simulator" }
+        : { reachable: true, reason: null },
+  });
+
+  const ios = results.find((r) => r.id === "ios-sim-capture");
+  assert.equal(ios.status, "skipped");
+  assert.equal(ios.skipReason, "no booted iOS Simulator");
+  assert.equal(ios.exitCode, null);
+  assert.deepEqual(reporter.events, [
+    ["start", "green-lane"],
+    ["end", "green-lane", "passed"],
+    ["skip", "ios-sim-capture", "no booted iOS Simulator"],
+  ]);
+});
+
+test("executeSteps writes planned records without running under --dry-run", () => {
+  const reporter = recordingReporter();
+  const steps = [fixtureLane("green-lane", 0)];
+  const results = executeSteps(steps, parseMatrixArgs(["--dry-run"]), {
+    reporter,
+    probe: () => {
+      throw new Error("probe must not run in dry-run");
+    },
+  });
+  assert.equal(results[0].status, "planned");
+  assert.equal(results[0].exitCode, null);
+  assert.deepEqual(reporter.events, []);
 });


### PR DESCRIPTION
# Relates to

Closes #14413. Builds on the unified evidence reviewer merged in #14452 (which delivered the `evidence:review` dashboard, `test:watch-human`, and `test:matrix:review`) by adding the operator-facing layer that PR still lacked: the human-speed streaming reporter, a single admin summary, and honest skipped-lane surfacing.

# What changed & why

#14452 wired the real lanes into `run-matrix.mjs` but drove them with a plain banner + `stdio:inherit` and printed only two path lines at the end; device lanes were silently filtered out by `--skip-devices`. There was no per-lane streamed status, no admin-readable pass/fail/skip summary, and no honest record of device lanes that could not run.

This PR adds exactly that, in-place (no parallel system):

- **`scripts/evidence-review/reporter.mjs`** (new) — a streaming reporter that emits one readable line per lane lifecycle transition (`RUNNING -> PASS/FAIL/SKIP`) with timing as the matrix advances ("agentex"), and `renderMatrixSummary()` which produces the single end-of-run summary table an admin — or a coding agent parsing stdout — reads to see what passed, failed, or was skipped and where the artifacts landed. Output goes through an injected `write` sink + `now` clock so every line is deterministically testable.
- **`scripts/evidence-review/run-matrix.mjs`** — `probeRequirement()` checks device-lane reachability (booted iOS Simulator via `xcrun simctl`, attached Android device via `adb`). An unreachable device lane is recorded **`skipped` with a reason** in the manifest, never dropped silently and never faked green. `executeSteps()` is extracted from `main()` and drives the reporter, so lane ordering, the honest skip, and the not-swallowed failure are all unit-testable. `main()` now streams via the reporter and prints the summary.

No new root script is needed — the enhancement flows through the already-wired `test:matrix:review` / `test:matrix`.

# Tests added

`scripts/evidence-review/reporter.test.mjs` (new) + extended `run-matrix.test.mjs`. They assert the streaming reporter's exact status transitions, the summary schema/rendering (including PLANNED for dry-run), `probeRequirement` skip reasons, and — driving **real fixture lanes** (one exits 0, one exits non-zero) through the real spawn path — that a failed lane surfaces as FAIL and drives overall FAILED (not swallowed), and that an unreachable device lane is skipped-with-reason and never executed.

# Verification

<details><summary><code>node --test scripts/evidence-review/*.test.mjs</code></summary>

```text
ℹ tests 20
ℹ pass 20
ℹ fail 0
```

</details>

<details><summary>Runner executed end-to-end against fixture lanes (green / red / unreachable-device) — streamed feedback + final summary</summary>

```text
Running 3 evidence lanes at human speed.
[>] [1/3] RUNNING green-unit — Fake unit lane
  unit ok
[+] [1/3] PASS green-unit — Fake unit lane  (37ms)
[>] [2/3] RUNNING red-e2e — Fake e2e lane
  e2e boom
[x] [2/3] FAIL red-e2e — Fake e2e lane  (28ms)
[-] [3/3] SKIP ios-sim-capture — iOS simulator capture  — no booted iOS Simulator (run `xcrun simctl boot <udid>`)

Evidence matrix summary
========================================================================
PASS   green-unit       37ms
FAIL   red-e2e          28ms
SKIP   ios-sim-capture  0ms       skip: no booted iOS Simulator (run `xcrun simctl boot <udid>`)
------------------------------------------------------------------------
FAILED: 1 passed, 1 failed, 1 skipped
Manifest: /repo/evidence/matrix-run.json
Evidence dashboard: /repo/evidence/index.html
```

</details>

<details><summary><code>node scripts/evidence-review/run-matrix.mjs --dry-run --no-review</code> (real wired runner)</summary>

```text
Evidence matrix summary
========================================================================
PLANNED  test-all             0ms
PLANNED  e2e-recordings       0ms
PLANNED  app-audit            0ms
PLANNED  ios-sim-capture      0ms
PLANNED  android-emu-capture  0ms
------------------------------------------------------------------------
PLANNED: 5 planned
Manifest: .../evidence/matrix-dry/matrix-run.json
```

</details>

<details><summary><code>bunx @biomejs/biome check scripts/evidence-review/*.mjs</code></summary>

```text
Checked 7 files in 15ms. No fixes applied.
```

</details>

# Evidence Gate

| Evidence | Status |
| --- | --- |
| Real-LLM trajectory | N/A — local dev tooling; no agent/action/provider/prompt/model behavior changed |
| Before/after screenshots (desktop+mobile) | N/A — terminal CLI change; no rendered UI surface; behavior shown by the pasted streamed output + summary above |
| Walkthrough video | N/A — CLI-only; the streamed transitions + summary above are the walkthrough |
| Backend logs | N/A — no backend service path changed |
| Frontend console/network logs | N/A — no app frontend runtime path changed |
| Domain artifacts | The `matrix-run.json` manifest with per-lane status/durationMs and `skipReason` for skipped device lanes is generated by the runner and summarized above |

# Known gaps / owner-run commands

- Full real-lane execution is heavy and needs the device fleet / live services. This PR proves the runner/reporter/manifest/skip logic headlessly with fixture lanes. To run the real matrix an owner runs `bun run test:matrix:review` (or `bun run test:matrix` for no auto-open). On a host with a booted iOS Simulator / attached Android device those lanes execute; without one they now report `SKIP` with the exact boot command in the summary — never a fake pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
