### PR TITLE
feat(app): add physical ios device e2e lane

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -97,6 +97,7 @@
     "install:ios:cloud:sideload": "node scripts/ios-sideload-helper.mjs --cloud --build-device",
     "ios:device:provision": "node scripts/ios-device-provision.mjs",
     "ios:device:deploy": "node scripts/ios-device-deploy.mjs",
+    "ios:device:e2e": "node scripts/ios-device-e2e.mjs",
     "ios:device:logs": "node scripts/ios-device-logs.mjs",
     "ios:device:capture": "node scripts/ios-device-capture.mjs --platform device",
     "capture:ios-sim:boot": "node scripts/ios-device-capture.mjs --platform sim",

--- a/packages/app/scripts/ios-device-e2e-plan.test.mjs
+++ b/packages/app/scripts/ios-device-e2e-plan.test.mjs
@@ -1,0 +1,119 @@
+/**
+ * Unit coverage for the physical iOS device e2e command planner.
+ *
+ * The real lane needs macOS, signing material, and a paired phone. These tests
+ * pin the no-device contract: deploy is main-app-only by default, capture uses
+ * the freshly staged app path, and logs use the boot-trace path that avoids the
+ * console-mode full-Bun SIGTRAP.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  buildPhysicalIosDevicePlan,
+  parseIosDeviceE2eArgs,
+} from "./lib/ios-device-e2e-plan.mjs";
+
+const PATHS = {
+  stagingDir: "/tmp/bundle/raw/device-deploy-stage",
+  stagedApp: "/tmp/bundle/raw/device-deploy-stage/App.app",
+  captureDir: "/tmp/bundle/raw/ios-device-capture",
+  bootTraceOutput: "/tmp/bundle/logs/ios-device-boot-trace.log",
+};
+
+describe("parseIosDeviceE2eArgs", () => {
+  it("defaults to the unattended main-app physical lane", () => {
+    expect(parseIosDeviceE2eArgs([])).toEqual({
+      device: undefined,
+      output: undefined,
+      skipBuild: false,
+      noLaunch: false,
+      includeAppexes: false,
+      noWait: false,
+      bundleId: undefined,
+      identity: undefined,
+      derivedData: undefined,
+      configuration: undefined,
+      onlyTesting: undefined,
+    });
+  });
+
+  it("parses device, output, signing, and test narrowing flags", () => {
+    const parsed = parseIosDeviceE2eArgs([
+      "--device",
+      "phone",
+      "--output",
+      "/tmp/out",
+      "--skip-build",
+      "--no-launch",
+      "--include-appexes",
+      "--no-wait",
+      "--bundle-id",
+      "ai.elizaos.app",
+      "--identity",
+      "ABC",
+      "--derived-data",
+      "/tmp/dd",
+      "--configuration",
+      "Release",
+      "--only-testing",
+      "AppUITests/BootCaptureUITests",
+    ]);
+    expect(parsed).toMatchObject({
+      device: "phone",
+      output: "/tmp/out",
+      skipBuild: true,
+      noLaunch: true,
+      includeAppexes: true,
+      noWait: true,
+      bundleId: "ai.elizaos.app",
+      identity: "ABC",
+      derivedData: "/tmp/dd",
+      configuration: "Release",
+      onlyTesting: "AppUITests/BootCaptureUITests",
+    });
+  });
+});
+
+describe("buildPhysicalIosDevicePlan", () => {
+  it("deploys with --skip-appexes by default, captures staged app, and pulls boot trace", () => {
+    const plan = buildPhysicalIosDevicePlan(
+      parseIosDeviceE2eArgs(["--device", "phone"]),
+      PATHS,
+    );
+    expect(plan.map((step) => step.id)).toEqual(["deploy", "capture", "logs"]);
+    expect(plan[0].args).toContain("--skip-appexes");
+    expect(plan[0].args).toEqual(
+      expect.arrayContaining([
+        "--staging",
+        PATHS.stagingDir,
+        "--device",
+        "phone",
+      ]),
+    );
+    expect(plan[1].args).toEqual(
+      expect.arrayContaining([
+        "--platform",
+        "device",
+        "--app-path",
+        PATHS.stagedApp,
+        "--strict-gate",
+        "--require-chat",
+      ]),
+    );
+    expect(plan[2].args).toEqual(
+      expect.arrayContaining([
+        "--no-console",
+        "--pull-boot-trace",
+        "--output",
+        PATHS.bootTraceOutput,
+      ]),
+    );
+  });
+
+  it("keeps appexes when explicitly requested", () => {
+    const plan = buildPhysicalIosDevicePlan(
+      parseIosDeviceE2eArgs(["--include-appexes"]),
+      PATHS,
+    );
+    expect(plan[0].args).not.toContain("--skip-appexes");
+  });
+});

--- a/packages/app/scripts/ios-device-e2e.mjs
+++ b/packages/app/scripts/ios-device-e2e.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * Physical iPhone end-to-end orchestrator for the app package.
+ *
+ * This is the one-command lane for paired phones: deploy the current tree with
+ * the unattended signing recipe, drive the committed BootCapture XCUITest
+ * harness, pull the boot trace without console-mode SIGTRAPs, and assemble the
+ * same triage bundle used by the simulator/Android e2e runners.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  captureFailureForensics,
+  collectBundleArtifacts,
+  createDeviceE2eBundle,
+  finalizeDeviceE2eBundle,
+  formatFailureForensicsBlock,
+  runBundledCommand,
+} from "./lib/device-e2e-bundle.mjs";
+import { acquireDeviceLease } from "./lib/device-lease.mjs";
+import {
+  buildPhysicalIosDevicePlan,
+  parseIosDeviceE2eArgs,
+} from "./lib/ios-device-e2e-plan.mjs";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const appDir = path.resolve(scriptDir, "..");
+const log = (message) => console.log(`[ios-device-e2e] ${message}`);
+
+function capturePhysicalFailure(bundle, step, error) {
+  return captureFailureForensics(
+    bundle,
+    step,
+    ({ failureDir }) => {
+      const causePath = path.join(failureDir, "failure-cause.txt");
+      fs.writeFileSync(causePath, `${error?.message ?? error}\n`);
+      return [causePath];
+    },
+    error,
+  );
+}
+
+async function main() {
+  const flags = parseIosDeviceE2eArgs(process.argv.slice(2));
+  const bundle = createDeviceE2eBundle({
+    appDir,
+    lane: "ios-device",
+    outputDir: flags.output,
+    device: {
+      kind: "ios-device",
+      id: flags.device ?? process.env.ELIZA_IOS_DEVICE_ID ?? null,
+    },
+  });
+  const paths = {
+    stagingDir: path.join(bundle.rawDir, "device-deploy-stage"),
+    stagedApp: path.join(bundle.rawDir, "device-deploy-stage", "App.app"),
+    captureDir: path.join(bundle.rawDir, "ios-device-capture"),
+    bootTraceOutput: path.join(bundle.logsDir, "ios-device-boot-trace.log"),
+  };
+  const plan = buildPhysicalIosDevicePlan(flags, paths);
+  let finalResult = "failed";
+  let finalError = null;
+  let lease = null;
+
+  if (!flags.includeAppexes) {
+    log(
+      "--skip-appexes is enabled by default: widgets/keyboard/device-activity extensions are excluded from this physical smoke install.",
+    );
+  }
+  log(`bundle root: ${bundle.root}`);
+
+  try {
+    const deviceKey = flags.device ?? process.env.ELIZA_IOS_DEVICE_ID ?? null;
+    if (deviceKey) {
+      lease = await acquireDeviceLease(`ios-device:${deviceKey}`, {
+        waitMs: flags.noWait ? 0 : undefined,
+        log,
+      });
+    }
+    for (const step of plan) {
+      log(`${step.label}…`);
+      runBundledCommand(bundle, step.label, step.cmd, step.args, {
+        cwd: appDir,
+        onFailure: (bundleStep, error) =>
+          capturePhysicalFailure(bundle, bundleStep, error),
+      });
+    }
+    finalResult = "passed";
+    log("ALL PHYSICAL iOS E2E PASSED");
+  } catch (error) {
+    finalError = error;
+    throw error;
+  } finally {
+    collectBundleArtifacts(bundle, [
+      bundle.rawDir,
+      bundle.logsDir,
+      paths.captureDir,
+      path.dirname(paths.bootTraceOutput),
+    ]);
+    const bundleRoot = finalizeDeviceE2eBundle(bundle, finalResult);
+    if (finalError) {
+      const block = formatFailureForensicsBlock(bundle, finalError);
+      if (block) process.stderr.write(`\n${block}`);
+    }
+    lease?.release();
+    log(`bundle: ${bundleRoot}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(`[ios-device-e2e] FAILED: ${error?.message ?? error}`);
+  process.exit(1);
+});

--- a/packages/app/scripts/ios-e2e-lib.mjs
+++ b/packages/app/scripts/ios-e2e-lib.mjs
@@ -40,6 +40,7 @@ export function parseIosE2eArgs(argv) {
     device: val("--device"),
     appPath: val("--app-path"),
     output: val("--output"),
+    physical: has("--physical"),
     skipBuild: has("--skip-build"),
     skipAuth: has("--skip-auth"),
     skipLocalChat: has("--skip-local-chat"),

--- a/packages/app/scripts/ios-e2e-lib.test.mjs
+++ b/packages/app/scripts/ios-e2e-lib.test.mjs
@@ -34,6 +34,7 @@ describe("parseIosE2eArgs", () => {
       device: undefined,
       appPath: undefined,
       output: undefined,
+      physical: false,
       skipBuild: false,
       skipAuth: false,
       skipLocalChat: false,
@@ -49,12 +50,14 @@ describe("parseIosE2eArgs", () => {
       "--skip-local-chat",
       "--cloud",
       "--no-wait",
+      "--physical",
     ]);
     expect(f.skipBuild).toBe(true);
     expect(f.skipAuth).toBe(true);
     expect(f.skipLocalChat).toBe(true);
     expect(f.cloud).toBe(true);
     expect(f.noWait).toBe(true);
+    expect(f.physical).toBe(true);
   });
 
   it("captures --device, --app-path, and --output values", () => {

--- a/packages/app/scripts/ios-e2e.mjs
+++ b/packages/app/scripts/ios-e2e.mjs
@@ -296,6 +296,22 @@ function runStep(bundle, step, { udid, appId }) {
 }
 
 async function main() {
+  if (flags.physical) {
+    const forwarded = process.argv
+      .slice(2)
+      .filter((arg) => arg !== "--physical");
+    const result = spawnSync(
+      "node",
+      [path.join(appDir, "scripts", "ios-device-e2e.mjs"), ...forwarded],
+      {
+        cwd: appDir,
+        stdio: "inherit",
+        env: process.env,
+      },
+    );
+    process.exit(result.status ?? 1);
+  }
+
   const bundle = createDeviceE2eBundle({
     appDir,
     lane: "ios-sim",

--- a/packages/app/scripts/lib/ios-device-e2e-plan.mjs
+++ b/packages/app/scripts/lib/ios-device-e2e-plan.mjs
@@ -1,0 +1,95 @@
+/**
+ * Pure command planning for the physical iOS device e2e lane.
+ *
+ * The runner itself is all device side effects: build, sign, install, XCUITest
+ * capture, and boot-trace pull. Keeping the argv parsing and command assembly
+ * here lets tests pin the lane contract without needing macOS or a paired
+ * phone.
+ */
+
+export function parseIosDeviceE2eArgs(argv) {
+  const has = (flag) => argv.includes(flag);
+  const val = (flag) => {
+    const index = argv.indexOf(flag);
+    return index >= 0 && index + 1 < argv.length ? argv[index + 1] : undefined;
+  };
+  return {
+    device: val("--device"),
+    output: val("--output"),
+    skipBuild: has("--skip-build"),
+    noLaunch: has("--no-launch"),
+    includeAppexes: has("--include-appexes"),
+    noWait: has("--no-wait"),
+    bundleId: val("--bundle-id"),
+    identity: val("--identity"),
+    derivedData: val("--derived-data"),
+    configuration: val("--configuration"),
+    onlyTesting: val("--only-testing"),
+  };
+}
+
+function pushValue(args, flag, value) {
+  if (value) args.push(flag, value);
+}
+
+export function buildPhysicalIosDevicePlan(flags, paths) {
+  const deployArgs = [
+    "scripts/ios-device-deploy.mjs",
+    "--staging",
+    paths.stagingDir,
+  ];
+  if (!flags.includeAppexes) deployArgs.push("--skip-appexes");
+  if (flags.skipBuild) deployArgs.push("--skip-build");
+  if (flags.noLaunch) deployArgs.push("--no-launch");
+  pushValue(deployArgs, "--device", flags.device);
+  pushValue(deployArgs, "--bundle-id", flags.bundleId);
+  pushValue(deployArgs, "--identity", flags.identity);
+  pushValue(deployArgs, "--derived-data", flags.derivedData);
+  pushValue(deployArgs, "--configuration", flags.configuration);
+
+  const captureArgs = [
+    "scripts/ios-device-capture.mjs",
+    "--platform",
+    "device",
+    "--output",
+    paths.captureDir,
+    "--app-path",
+    paths.stagedApp,
+    "--strict-gate",
+    "--require-chat",
+  ];
+  pushValue(captureArgs, "--device", flags.device);
+  pushValue(captureArgs, "--bundle-id", flags.bundleId);
+  pushValue(captureArgs, "--only-testing", flags.onlyTesting);
+
+  const logsArgs = [
+    "scripts/ios-device-logs.mjs",
+    "--no-console",
+    "--pull-boot-trace",
+    "--output",
+    paths.bootTraceOutput,
+  ];
+  pushValue(logsArgs, "--device", flags.device);
+  pushValue(logsArgs, "--bundle-id", flags.bundleId);
+
+  return [
+    {
+      id: "deploy",
+      label: "deploy physical iOS app",
+      cmd: "node",
+      args: deployArgs,
+    },
+    {
+      id: "capture",
+      label: "capture physical iOS boot",
+      cmd: "node",
+      args: captureArgs,
+    },
+    {
+      id: "logs",
+      label: "pull physical iOS boot trace",
+      cmd: "node",
+      args: logsArgs,
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- add `ios:device:e2e` plus `test:e2e:ios -- --physical` forwarding for a one-command physical-iPhone lane
- plan deploy -> BootCapture device capture -> boot-trace pull into the shared device-e2e bundle
- default physical deploys to `--skip-appexes` and log that extension surfaces are excluded from the unattended smoke install
- carry `--device`, `--output`, signing, bundle-id, and test-narrowing flags through the lane
- use the shared device lease and failure-forensics bundle behavior
- add pure planner coverage for the no-device contract

Relates to #14337.

Stacked on #14502 because it uses the shared bundle and failure-forensics runner machinery.

## Validation
- `bun run --cwd packages/app test -- scripts/ios-device-e2e-plan.test.mjs scripts/ios-e2e-lib.test.mjs scripts/devices-status.test.mjs` -> 51 tests passed
- `bunx @biomejs/biome check packages/app/scripts/ios-device-e2e.mjs packages/app/scripts/lib/ios-device-e2e-plan.mjs packages/app/scripts/ios-device-e2e-plan.test.mjs packages/app/scripts/ios-e2e.mjs packages/app/scripts/ios-e2e-lib.mjs packages/app/scripts/ios-e2e-lib.test.mjs packages/app/scripts/ios-device-deploy.mjs packages/app/scripts/devices-status.mjs packages/app/package.json`
- `node --check packages/app/scripts/ios-device-deploy.mjs && node --check packages/app/scripts/ios-device-e2e.mjs && node --check packages/app/scripts/lib/ios-device-e2e-plan.mjs && node --check packages/app/scripts/devices-status.mjs`

## Linux failure-path smoke
This host is Linux, so the physical deploy correctly fails at the macOS deploy boundary while still proving the wrapper, lease, bundle, and forensics path:

```text
$ node scripts/ios-e2e.mjs --physical --output /tmp/eliza-14337-ios-device-smoke --device example-phone
[ios-device-e2e] --skip-appexes is enabled by default: widgets/keyboard/device-activity extensions are excluded from this physical smoke install.
[ios-device-e2e] bundle root: /tmp/eliza-14337-ios-device-smoke
[ios-device-e2e] device lease acquired: ios-device:example-phone
[ios-device-e2e] deploy physical iOS app…
[ios-device-deploy] ERROR: iOS device deploys require macOS.

DEVICE E2E FAILURE FORENSICS
step: deploy physical iOS app
cause: node scripts/ios-device-deploy.mjs --staging /tmp/eliza-14337-ios-device-smoke/raw/device-deploy-stage --skip-appexes --device example-phone exited with code 1
failureDir: /tmp/eliza-14337-ios-device-smoke/failure/deploy-physical-ios-app
artifacts:
  - /tmp/eliza-14337-ios-device-smoke/failure/deploy-physical-ios-app/failure-cause.txt
[ios-device-e2e] device lease released: ios-device:example-phone
[ios-device-e2e] bundle: /tmp/eliza-14337-ios-device-smoke
[ios-device-e2e] FAILED: node scripts/ios-device-deploy.mjs --staging /tmp/eliza-14337-ios-device-smoke/raw/device-deploy-stage --skip-appexes --device example-phone exited with code 1
EXIT_STATUS=1
```

The produced summary marked the physical deploy step failed and included `junit.xml`, `logs/runner.log`, and `failure/deploy-physical-ios-app/failure-cause.txt`.

## Known limitation
I do not have a paired physical iPhone/macOS signing environment on this host, so the required MP4/JPG/FRESH-status/boot-trace evidence still needs to be captured on a Mac with a trusted phone before merge.