### PR TITLE
feat(app): one-command physical-iPhone e2e lane + deploy ledger (#14337)

### DIFF
--- a/packages/app/.gitignore
+++ b/packages/app/.gitignore
@@ -44,5 +44,6 @@ test/ui-smoke/output/
 # Local platform capture output; PR evidence is attached inline from generated files.
 capture-output/
 
-# Device-e2e bundles are regenerated per run and posted inline to PRs/issues.
+# Run-scoped device-e2e triage bundles (ios-device-e2e.mjs / android runners):
+# MP4/JPG + logs + summary.json posted inline to PRs, never committed.
 device-e2e-output/

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -99,6 +99,8 @@
     "ios:device:deploy": "node scripts/ios-device-deploy.mjs",
     "ios:device:logs": "node scripts/ios-device-logs.mjs",
     "ios:device:capture": "node scripts/ios-device-capture.mjs --platform device",
+    "ios:device:e2e": "node scripts/ios-device-e2e.mjs",
+    "test:e2e:ios:physical": "node scripts/ios-device-e2e.mjs",
     "capture:ios-sim:boot": "node scripts/ios-device-capture.mjs --platform sim",
     "build:android": "node ../../packages/app-core/scripts/run-mobile-build.mjs android",
     "build:android:cloud": "node ../../packages/app-core/scripts/run-mobile-build.mjs android-cloud",

--- a/packages/app/scripts/ios-device-deploy.mjs
+++ b/packages/app/scripts/ios-device-deploy.mjs
@@ -37,20 +37,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { appendIosDeviceDeployLedger } from "./devices-status.mjs";
 import {
   readDevicectlDeviceList,
   readDevicectlDeviceLockState,
 } from "./ios-device-devicectl.mjs";
-import {
-  appendDeployRecord,
-  buildDeployRecord,
-  evaluateStagedRendererFreshness,
-  freshRendererManifestPath,
-  readRendererManifest,
-  resolveDeployLedgerPath,
-  stagedRendererManifestPath,
-} from "./lib/ios-deploy-ledger.mjs";
 import {
   assertDeviceUnlocked,
   buildCodesignPlan,
@@ -67,6 +57,13 @@ import {
   selectSigningIdentity,
 } from "./ios-device-lib.mjs";
 import {
+  appendDeployRecord,
+  buildDeployRecord,
+  evaluateStagedRendererFreshness,
+  resolveDeployLedgerPath,
+} from "./lib/ios-deploy-ledger.mjs";
+import {
+  freshRendererManifestPath,
   readRendererManifest,
   rendererManifestPathFromAppPath,
 } from "./lib/ios-renderer-stamp.mjs";
@@ -485,14 +482,20 @@ async function main() {
   // footgun (a cached dist grafted over a fresh one). --allow-stale-renderer is
   // the explicit escape hatch for an operator staging a deliberately older
   // bundle. Read the staged stamp now (also feeds the deploy-ledger row below).
-  const stagedManifestPath = stagedRendererManifestPath(stagedApp);
-  const stagedManifest = readRendererManifest(stagedManifestPath, "staged App.app");
-  const freshManifestPath = freshRendererManifestPath(
-    repoRoot,
-    process.env.ELIZA_SMOKE_RENDERER_DIST,
+  const stagedManifestPath = rendererManifestPathFromAppPath(stagedApp);
+  const stagedManifest = readRendererManifest(
+    stagedManifestPath,
+    "staged App.app",
   );
+  const freshManifestPath = freshRendererManifestPath({
+    repoRoot,
+    rendererDist: process.env.ELIZA_SMOKE_RENDERER_DIST,
+  });
   if (!args["allow-stale-renderer"]) {
-    const freshManifest = readRendererManifest(freshManifestPath, "freshly built");
+    const freshManifest = readRendererManifest(
+      freshManifestPath,
+      "freshly built",
+    );
     const freshness = evaluateStagedRendererFreshness(
       stagedManifest,
       freshManifest,
@@ -531,22 +534,6 @@ async function main() {
     device.identifier,
     stagedApp,
   ]);
-  const rendererStamp = readRendererManifest(
-    rendererManifestPathFromAppPath(stagedApp),
-    "staged iOS device app",
-  );
-  const ledgerPath = appendIosDeviceDeployLedger({
-    identifier: device.identifier,
-    udid: device.udid,
-    name: device.name,
-    bundleId,
-    buildId: rendererStamp.buildId,
-    commit: rendererStamp.commit ?? null,
-    builtAt: rendererStamp.builtAt ?? null,
-    deployedAt: new Date().toISOString(),
-  });
-  log(`deploy ledger: ${ledgerPath}`);
-
   // Record the deploy: one JSONL row keyed by device UDID with the renderer
   // buildId/commit just installed, so `devices:status` (#14338) can report this
   // phone's build without reading its sandboxed container. Written only after a

--- a/packages/app/scripts/ios-device-deploy.mjs
+++ b/packages/app/scripts/ios-device-deploy.mjs
@@ -43,6 +43,15 @@ import {
   readDevicectlDeviceLockState,
 } from "./ios-device-devicectl.mjs";
 import {
+  appendDeployRecord,
+  buildDeployRecord,
+  evaluateStagedRendererFreshness,
+  freshRendererManifestPath,
+  readRendererManifest,
+  resolveDeployLedgerPath,
+  stagedRendererManifestPath,
+} from "./lib/ios-deploy-ledger.mjs";
+import {
   assertDeviceUnlocked,
   buildCodesignPlan,
   buildPlistXml,
@@ -358,11 +367,17 @@ function signApp({
 
 async function main() {
   const args = parseCliArgs(process.argv.slice(2), {
-    booleans: ["skip-build", "no-launch", "skip-appexes", "help"],
+    booleans: [
+      "skip-build",
+      "no-launch",
+      "skip-appexes",
+      "allow-stale-renderer",
+      "help",
+    ],
   });
   if (args.help) {
     console.log(
-      "Usage: node scripts/ios-device-deploy.mjs [--device <id>] [--skip-build] [--no-launch] [--skip-appexes] [--staging <dir>] [--identity <sha1>] [--derived-data <dir>] [--bundle-id <id>] [--configuration Debug|Release]",
+      "Usage: node scripts/ios-device-deploy.mjs [--device <id>] [--skip-build] [--no-launch] [--skip-appexes] [--allow-stale-renderer] [--staging <dir>] [--identity <sha1>] [--derived-data <dir>] [--bundle-id <id>] [--configuration Debug|Release]",
     );
     return;
   }
@@ -464,6 +479,37 @@ async function main() {
     }
   }
 
+  // Renderer-freshness assert: the staged bundle carries a renderer build stamp
+  // (public/eliza-renderer-build.json). Refuse to install one whose buildId does
+  // not match the freshly built dist — a device booting a stale UI is the #9309
+  // footgun (a cached dist grafted over a fresh one). --allow-stale-renderer is
+  // the explicit escape hatch for an operator staging a deliberately older
+  // bundle. Read the staged stamp now (also feeds the deploy-ledger row below).
+  const stagedManifestPath = stagedRendererManifestPath(stagedApp);
+  const stagedManifest = readRendererManifest(stagedManifestPath, "staged App.app");
+  const freshManifestPath = freshRendererManifestPath(
+    repoRoot,
+    process.env.ELIZA_SMOKE_RENDERER_DIST,
+  );
+  if (!args["allow-stale-renderer"]) {
+    const freshManifest = readRendererManifest(freshManifestPath, "freshly built");
+    const freshness = evaluateStagedRendererFreshness(
+      stagedManifest,
+      freshManifest,
+    );
+    if (!freshness.fresh) {
+      fail(
+        `renderer-freshness assert failed: ${freshness.reason}\n` +
+          "Pass --allow-stale-renderer to deploy an intentionally older bundle.",
+      );
+    }
+    log(`renderer freshness OK: ${freshness.reason}`);
+  } else {
+    log(
+      `--allow-stale-renderer: skipping the renderer-freshness assert (staged buildId ${String(stagedManifest.buildId).slice(0, 12)})`,
+    );
+  }
+
   // 3–4. Profile graft + explicit nested signing + verify.
   signApp({
     stagedApp,
@@ -500,6 +546,26 @@ async function main() {
     deployedAt: new Date().toISOString(),
   });
   log(`deploy ledger: ${ledgerPath}`);
+
+  // Record the deploy: one JSONL row keyed by device UDID with the renderer
+  // buildId/commit just installed, so `devices:status` (#14338) can report this
+  // phone's build without reading its sandboxed container. Written only after a
+  // successful install — a failed install must not leave a false FRESH row.
+  const ledgerPath = resolveDeployLedgerPath();
+  const record = buildDeployRecord({
+    udid: device.udid,
+    buildId: stagedManifest.buildId,
+    name: device.name,
+    identifier: device.identifier,
+    commit: stagedManifest.commit,
+    variant: stagedManifest.variant,
+    runtimeMode: stagedManifest.runtimeMode,
+    skippedAppexes: Boolean(args["skip-appexes"]),
+  });
+  appendDeployRecord(ledgerPath, record);
+  log(
+    `ledger: recorded buildId ${String(record.buildId).slice(0, 12)} (commit ${record.commit ? record.commit.slice(0, 12) : "unknown"}) for ${device.name} → ${ledgerPath}`,
+  );
 
   // 6. Launch (default on; --no-launch to skip). Console capture is
   //    ios-device-logs.mjs's job — this launch does not hold the terminal.

--- a/packages/app/scripts/ios-device-e2e.mjs
+++ b/packages/app/scripts/ios-device-e2e.mjs
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+/**
+ * One-command physical-iPhone e2e lane: build + deploy the current tree to the
+ * plugged-in iPhone, assert it boots on-device, capture the filmstrip, pull the
+ * boot-trace, and collapse everything into one run-scoped triage bundle whose
+ * absolute path is printed as the last line (issue #14337).
+ *
+ * Chains four already-proven scripts through the pure step-runner in
+ * `lib/ios-device-e2e-lib.mjs`:
+ *   1. ios-device-deploy.mjs  --skip-appexes  (build → sign → devicectl install;
+ *      appex surfaces excluded — logged loudly by the deploy script). The deploy
+ *      also writes the renderer-freshness assert + the deploy ledger row.
+ *   2. ios-device-capture.mjs --platform device  (BootCapture — the ON-DEVICE
+ *      assertion: did the freshly deployed app reach home or the error card?
+ *      `mobile-local-chat-smoke` is simulator-only, so BootCapture is the
+ *      device assertion of record).
+ *   3. ios-device-capture.mjs --platform device  again into capture/ for the
+ *      watchable filmstrip artifact.
+ *   4. ios-device-logs.mjs --no-console --pull-boot-trace  (full-Bun engine
+ *      observability; attached --console SIGTRAPs the no-JIT engine, #11515).
+ *
+ * Every step's exit is loud: a non-zero child fails the lane non-zero. The bundle
+ * (research doc 08 Q2/Q3 shape: inline/ logs/ summary.json) is written under a
+ * gitignored run-scoped dir and its path is the final stdout line so an agent
+ * can post inline/ to a PR.
+ *
+ * Device id: --device flag or ELIZA_IOS_DEVICE_ID.
+ *
+ * Usage:
+ *   node scripts/ios-device-e2e.mjs [--device <id>] [--skip-appexes]
+ *     [--no-skip-appexes] [--skip-capture] [--skip-logs] [--require-chat]
+ *     [--bundle-id <id>] [--output <dir>]
+ */
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  freshRendererManifestPath,
+  readRendererManifest,
+} from "./lib/ios-deploy-ledger.mjs";
+import {
+  buildDeviceCaptureCommand,
+  buildDeviceDeployCommand,
+  buildDeviceLogsCommand,
+  buildDeviceSmokeCommand,
+  buildRunSummary,
+  classifyStepStatus,
+  formatRunId,
+  planIosDeviceE2eSteps,
+} from "./lib/ios-device-e2e-lib.mjs";
+import {
+  findDeviceRecord,
+  parseCliArgs,
+  resolveDeviceId,
+} from "./ios-device-lib.mjs";
+import { readDevicectlDeviceList } from "./ios-device-devicectl.mjs";
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+const appRoot = path.resolve(scriptsDir, "..");
+const repoRoot = path.resolve(appRoot, "..", "..");
+
+const log = (message) => console.log(`[ios-device-e2e] ${message}`);
+const fail = (message) => {
+  console.error(`[ios-device-e2e] ERROR: ${message}`);
+  process.exit(1);
+};
+
+function runStep(step, { cmd, args }) {
+  log(`${step.id}: ${step.label}`);
+  log(`  $ ${cmd} ${args.join(" ")}`);
+  const startedAt = Date.now();
+  const result = spawnSync(cmd, args, { cwd: appRoot, stdio: "inherit" });
+  const durationMs = Date.now() - startedAt;
+  const verdict = classifyStepStatus(result.status);
+  return { verdict, durationMs, status: result.status };
+}
+
+async function main() {
+  const args = parseCliArgs(process.argv.slice(2), {
+    booleans: [
+      "skip-appexes",
+      "no-skip-appexes",
+      "skip-capture",
+      "skip-logs",
+      "require-chat",
+      "help",
+    ],
+  });
+  if (args.help) {
+    console.log(
+      "Usage: node scripts/ios-device-e2e.mjs [--device <id>] [--no-skip-appexes] [--skip-capture] [--skip-logs] [--require-chat] [--bundle-id <id>] [--output <dir>]",
+    );
+    return;
+  }
+  if (process.platform !== "darwin") fail("iOS device e2e requires macOS.");
+
+  const deviceId = resolveDeviceId({ flagValue: args.device ?? null });
+  if (!deviceId) {
+    fail(
+      "no device given. Pass --device <devicectl-id|udid|name> or set ELIZA_IOS_DEVICE_ID.\n" +
+        "List devices with: xcrun devicectl list devices",
+    );
+  }
+  const device = findDeviceRecord(readDevicectlDeviceList(), deviceId);
+  if (!device) {
+    fail(
+      `device "${deviceId}" not found via devicectl. List: xcrun devicectl list devices ` +
+        "(pair the phone: Finder → device → Trust, and enable Developer Mode).",
+    );
+  }
+  log(`device: ${device.name} (identifier ${device.identifier}, udid ${device.udid})`);
+
+  // --skip-appexes is the default unattended posture (PR #13174); --no-skip-appexes
+  // opts back in when per-appex profiles exist.
+  const skipAppexes = !args["no-skip-appexes"];
+  const bundleId = args["bundle-id"] || null;
+
+  const runId = formatRunId();
+  const startedAtIso = new Date().toISOString();
+  const bundleDir = path.resolve(
+    args.output || path.join(appRoot, "device-e2e-output", `ios-${runId}`),
+  );
+  const smokeDir = path.join(bundleDir, "smoke");
+  const captureDir = path.join(bundleDir, "capture");
+  const logsDir = path.join(bundleDir, "logs");
+  for (const dir of [bundleDir, smokeDir, captureDir, logsDir]) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  const steps = planIosDeviceE2eSteps({
+    skipCapture: Boolean(args["skip-capture"]),
+    skipLogs: Boolean(args["skip-logs"]),
+  });
+  log(`plan: ${steps.map((s) => s.id).join(" → ")}`);
+  log(`bundle: ${bundleDir}`);
+
+  const commandFor = (step) => {
+    switch (step.id) {
+      case "deploy":
+        return {
+          command: buildDeviceDeployCommand({
+            scriptsDir,
+            deviceId,
+            skipAppexes,
+            bundleId,
+          }),
+          artifacts: [],
+        };
+      case "smoke":
+        return {
+          command: buildDeviceSmokeCommand({
+            scriptsDir,
+            deviceId,
+            outputDir: smokeDir,
+            requireChat: Boolean(args["require-chat"]),
+            bundleId,
+          }),
+          artifacts: [smokeDir],
+        };
+      case "capture":
+        return {
+          command: buildDeviceCaptureCommand({
+            scriptsDir,
+            deviceId,
+            outputDir: captureDir,
+            bundleId,
+          }),
+          artifacts: [captureDir],
+        };
+      case "logs":
+        return {
+          command: buildDeviceLogsCommand({
+            scriptsDir,
+            deviceId,
+            // ios-device-logs derives its own trace filename from
+            // path.dirname(--output), so point --output at a file inside logsDir.
+            outputFile: path.join(logsDir, "boot-trace-run"),
+            bundleId,
+          }),
+          artifacts: [logsDir],
+        };
+      default:
+        throw new Error(`unknown step: ${step.id}`);
+    }
+  };
+
+  const recorded = [];
+  let firstFailure = null;
+  for (const step of steps) {
+    const { command, artifacts } = commandFor(step);
+    const { verdict, durationMs } = runStep(step, command);
+    recorded.push({
+      id: step.id,
+      label: step.label,
+      status: verdict.status,
+      durationMs,
+      artifacts,
+    });
+    if (!verdict.ok) {
+      firstFailure = step.id;
+      break;
+    }
+  }
+
+  // The deploy step writes the renderer stamp into the ledger; surface the
+  // buildId/commit into the summary by reading the freshly built dist stamp
+  // (the exact bundle the deploy installed). A missing stamp is not fatal to
+  // the summary — the deploy step's own assert already gated on it — so this is
+  // best-effort metadata, recorded as null when unreadable.
+  let build = { buildId: null, commit: null };
+  try {
+    const fresh = readRendererManifest(
+      freshRendererManifestPath(repoRoot),
+      "freshly built",
+    );
+    build = { buildId: fresh.buildId, commit: fresh.commit };
+  } catch (error) {
+    // error-policy:J7 diagnostics-must-not-kill-the-loop — the summary's build
+    // metadata is informational; the deploy already asserted freshness. Warn
+    // and record null rather than failing an otherwise-complete run.
+    log(`summary build metadata unavailable: ${error?.message ?? error}`);
+  }
+
+  const summary = buildRunSummary({
+    runId,
+    startedAt: startedAtIso,
+    finishedAt: new Date().toISOString(),
+    bundleDir,
+    device,
+    build,
+    skippedAppexes: skipAppexes,
+    steps: recorded,
+  });
+  const summaryPath = path.join(bundleDir, "summary.json");
+  fs.writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+
+  if (firstFailure) {
+    log(`FAILED at step "${firstFailure}". Bundle (partial) written.`);
+    // The bundle path is the machine-readable handoff even on failure.
+    console.log(bundleDir);
+    process.exit(1);
+  }
+
+  log(`ALL iOS DEVICE E2E PASSED ✅ (${skipAppexes ? "appexes SKIPPED — widget/keyboard/device-activity surfaces UNTESTED" : "appexes included"})`);
+  // Last line: the absolute bundle path (contract with #14337 — agents post inline/).
+  console.log(bundleDir);
+}
+
+main().catch((error) => fail(error?.stack ?? String(error)));

--- a/packages/app/scripts/ios-device-e2e.mjs
+++ b/packages/app/scripts/ios-device-e2e.mjs
@@ -5,7 +5,7 @@
  * boot-trace, and collapse everything into one run-scoped triage bundle whose
  * absolute path is printed as the last line (issue #14337).
  *
- * Chains four already-proven scripts through the pure step-runner in
+ * Chains three already-proven scripts through the pure step-runner in
  * `lib/ios-device-e2e-lib.mjs`:
  *   1. ios-device-deploy.mjs  --skip-appexes  (build → sign → devicectl install;
  *      appex surfaces excluded — logged loudly by the deploy script). The deploy
@@ -13,34 +13,34 @@
  *   2. ios-device-capture.mjs --platform device  (BootCapture — the ON-DEVICE
  *      assertion: did the freshly deployed app reach home or the error card?
  *      `mobile-local-chat-smoke` is simulator-only, so BootCapture is the
- *      device assertion of record).
- *   3. ios-device-capture.mjs --platform device  again into capture/ for the
- *      watchable filmstrip artifact.
- *   4. ios-device-logs.mjs --no-console --pull-boot-trace  (full-Bun engine
+ *      device assertion of record). Its filmstrip attachments land in smoke/, so
+ *      the one on-device boot yields both the verdict and the watchable artifact.
+ *   3. ios-device-logs.mjs --no-console --pull-boot-trace  (full-Bun engine
  *      observability; attached --console SIGTRAPs the no-JIT engine, #11515).
  *
  * Every step's exit is loud: a non-zero child fails the lane non-zero. The bundle
- * (research doc 08 Q2/Q3 shape: inline/ logs/ summary.json) is written under a
+ * (research doc 08 Q2/Q3 shape: smoke/ logs/ summary.json) is written under a
  * gitignored run-scoped dir and its path is the final stdout line so an agent
- * can post inline/ to a PR.
+ * can post the smoke filmstrip + boot-trace to a PR.
  *
  * Device id: --device flag or ELIZA_IOS_DEVICE_ID.
  *
  * Usage:
  *   node scripts/ios-device-e2e.mjs [--device <id>] [--skip-appexes]
- *     [--no-skip-appexes] [--skip-capture] [--skip-logs] [--require-chat]
+ *     [--no-skip-appexes] [--skip-logs] [--require-chat]
  *     [--bundle-id <id>] [--output <dir>]
  */
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { readDevicectlDeviceList } from "./ios-device-devicectl.mjs";
 import {
-  freshRendererManifestPath,
-  readRendererManifest,
-} from "./lib/ios-deploy-ledger.mjs";
+  findDeviceRecord,
+  parseCliArgs,
+  resolveDeviceId,
+} from "./ios-device-lib.mjs";
 import {
-  buildDeviceCaptureCommand,
   buildDeviceDeployCommand,
   buildDeviceLogsCommand,
   buildDeviceSmokeCommand,
@@ -50,11 +50,9 @@ import {
   planIosDeviceE2eSteps,
 } from "./lib/ios-device-e2e-lib.mjs";
 import {
-  findDeviceRecord,
-  parseCliArgs,
-  resolveDeviceId,
-} from "./ios-device-lib.mjs";
-import { readDevicectlDeviceList } from "./ios-device-devicectl.mjs";
+  freshRendererManifestPath,
+  readRendererManifest,
+} from "./lib/ios-renderer-stamp.mjs";
 
 const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
 const appRoot = path.resolve(scriptsDir, "..");
@@ -81,7 +79,6 @@ async function main() {
     booleans: [
       "skip-appexes",
       "no-skip-appexes",
-      "skip-capture",
       "skip-logs",
       "require-chat",
       "help",
@@ -89,7 +86,7 @@ async function main() {
   });
   if (args.help) {
     console.log(
-      "Usage: node scripts/ios-device-e2e.mjs [--device <id>] [--no-skip-appexes] [--skip-capture] [--skip-logs] [--require-chat] [--bundle-id <id>] [--output <dir>]",
+      "Usage: node scripts/ios-device-e2e.mjs [--device <id>] [--no-skip-appexes] [--skip-logs] [--require-chat] [--bundle-id <id>] [--output <dir>]",
     );
     return;
   }
@@ -109,7 +106,9 @@ async function main() {
         "(pair the phone: Finder → device → Trust, and enable Developer Mode).",
     );
   }
-  log(`device: ${device.name} (identifier ${device.identifier}, udid ${device.udid})`);
+  log(
+    `device: ${device.name} (identifier ${device.identifier}, udid ${device.udid})`,
+  );
 
   // --skip-appexes is the default unattended posture (PR #13174); --no-skip-appexes
   // opts back in when per-appex profiles exist.
@@ -122,14 +121,12 @@ async function main() {
     args.output || path.join(appRoot, "device-e2e-output", `ios-${runId}`),
   );
   const smokeDir = path.join(bundleDir, "smoke");
-  const captureDir = path.join(bundleDir, "capture");
   const logsDir = path.join(bundleDir, "logs");
-  for (const dir of [bundleDir, smokeDir, captureDir, logsDir]) {
+  for (const dir of [bundleDir, smokeDir, logsDir]) {
     fs.mkdirSync(dir, { recursive: true });
   }
 
   const steps = planIosDeviceE2eSteps({
-    skipCapture: Boolean(args["skip-capture"]),
     skipLogs: Boolean(args["skip-logs"]),
   });
   log(`plan: ${steps.map((s) => s.id).join(" → ")}`);
@@ -157,16 +154,6 @@ async function main() {
             bundleId,
           }),
           artifacts: [smokeDir],
-        };
-      case "capture":
-        return {
-          command: buildDeviceCaptureCommand({
-            scriptsDir,
-            deviceId,
-            outputDir: captureDir,
-            bundleId,
-          }),
-          artifacts: [captureDir],
         };
       case "logs":
         return {
@@ -211,7 +198,7 @@ async function main() {
   let build = { buildId: null, commit: null };
   try {
     const fresh = readRendererManifest(
-      freshRendererManifestPath(repoRoot),
+      freshRendererManifestPath({ repoRoot }),
       "freshly built",
     );
     build = { buildId: fresh.buildId, commit: fresh.commit };
@@ -242,8 +229,11 @@ async function main() {
     process.exit(1);
   }
 
-  log(`ALL iOS DEVICE E2E PASSED ✅ (${skipAppexes ? "appexes SKIPPED — widget/keyboard/device-activity surfaces UNTESTED" : "appexes included"})`);
-  // Last line: the absolute bundle path (contract with #14337 — agents post inline/).
+  log(
+    `ALL iOS DEVICE E2E PASSED ✅ (${skipAppexes ? "appexes SKIPPED — widget/keyboard/device-activity surfaces UNTESTED" : "appexes included"})`,
+  );
+  // Last line: the absolute bundle path (contract with #14337 — agents post the
+  // smoke/ filmstrip + logs/ boot-trace inline to the PR).
   console.log(bundleDir);
 }
 

--- a/packages/app/scripts/lib/ios-deploy-ledger.mjs
+++ b/packages/app/scripts/lib/ios-deploy-ledger.mjs
@@ -1,0 +1,324 @@
+/**
+ * Deploy ledger for physical-iPhone sideloads: records which renderer buildId +
+ * git commit was last installed on which device, so `devices:status` can answer
+ * "is this phone running develop HEAD?" without reading the app's sandboxed
+ * container (a physical iOS device does not expose it).
+ *
+ * `ios-device-deploy.mjs` stages `App.app` locally before install, so the ledger
+ * is written deploy-side: it reads the staged renderer stamp
+ * (`public/eliza-renderer-build.json`, produced by the vite
+ * `renderer-build-manifest` plugin) and appends one JSONL record per successful
+ * install. `devices:status` (issue #14338) is the sole reader; when a device has
+ * no ledger row it reports "unknown — no ledger entry" honestly rather than
+ * guessing (a phone flashed by other means was never recorded here). The
+ * boot-trace pull remains the ground-truth cross-check.
+ *
+ * Everything here is pure or takes the filesystem edge as the JSONL path, so the
+ * append/read/latest-per-device logic is unit-tested against fixtures without a
+ * device. The stamp comparison is the deploy-side renderer-freshness assert:
+ * the deploy refuses a staged bundle whose buildId does not match the freshly
+ * built dist (a stale UI would otherwise ship silently — issue #9309's failure
+ * mode, on the device lane).
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Resolve the per-user state dir for the ledger, honoring the documented
+ * branded-first precedence (`MILADY_STATE_DIR` > `ELIZA_STATE_DIR` >
+ * `$XDG_STATE_HOME/<namespace>` > `~/.local/state/<namespace>`). Mirrors
+ * `packages/core/src/utils/state-dir.ts` — that module is TypeScript and cannot
+ * be imported from a plain build script, so the precedence is reproduced here.
+ * Kept in lockstep: any change to the canonical resolver must land here too.
+ *
+ * @param {{ env?: Record<string, string | undefined>, homedir?: () => string }} [options]
+ * @returns {string}
+ */
+export function resolveLedgerStateDir({
+  env = process.env,
+  homedir = os.homedir,
+} = {}) {
+  const explicit = (env.MILADY_STATE_DIR ?? env.ELIZA_STATE_DIR)?.trim();
+  if (explicit) return path.resolve(explicit);
+  const namespace = env.ELIZA_NAMESPACE?.trim() || "eliza";
+  const xdg = env.XDG_STATE_HOME?.trim();
+  if (xdg) {
+    return path.isAbsolute(xdg)
+      ? path.join(xdg, namespace)
+      : path.join(homedir(), xdg, namespace);
+  }
+  return path.join(homedir(), ".local", "state", namespace);
+}
+
+/**
+ * Absolute path to the deploy-ledger JSONL. One file for all devices; each line
+ * is a self-contained deploy record (see {@link appendDeployRecord}).
+ *
+ * @param {{ env?: Record<string, string | undefined>, homedir?: () => string }} [options]
+ * @returns {string}
+ */
+export function resolveDeployLedgerPath(options = {}) {
+  return path.join(
+    resolveLedgerStateDir(options),
+    "device-deploy-ledger.jsonl",
+  );
+}
+
+export const DEPLOY_LEDGER_SCHEMA = "elizaos.device.deploy-ledger/v1";
+
+/**
+ * Build a validated deploy record. `udid` + `buildId` are required — a record
+ * that cannot identify the device or the renderer it received is useless to the
+ * status reader, so this throws rather than writing a hole. `deployedAt`
+ * defaults to now (ISO 8601). `commit` is nullable only because the renderer
+ * stamp itself carries a nullable commit (a build outside a git checkout).
+ *
+ * @param {{
+ *   udid: string,
+ *   buildId: string,
+ *   name?: string | null,
+ *   identifier?: string | null,
+ *   commit?: string | null,
+ *   variant?: string | null,
+ *   runtimeMode?: string | null,
+ *   skippedAppexes?: boolean,
+ *   deployedAt?: string,
+ * }} input
+ * @returns {{
+ *   schema: string, udid: string, buildId: string, name: string | null,
+ *   identifier: string | null, commit: string | null, variant: string | null,
+ *   runtimeMode: string | null, skippedAppexes: boolean, deployedAt: string,
+ * }}
+ */
+export function buildDeployRecord(input) {
+  const udid = input?.udid?.trim();
+  const buildId = input?.buildId?.trim();
+  if (!udid) throw new Error("buildDeployRecord: udid is required");
+  if (!buildId) throw new Error("buildDeployRecord: buildId is required");
+  return {
+    schema: DEPLOY_LEDGER_SCHEMA,
+    udid,
+    buildId,
+    name: input.name?.trim() || null,
+    identifier: input.identifier?.trim() || null,
+    commit: input.commit?.trim() || null,
+    variant: input.variant?.trim() || null,
+    runtimeMode: input.runtimeMode?.trim() || null,
+    skippedAppexes: input.skippedAppexes === true,
+    deployedAt: input.deployedAt?.trim() || new Date().toISOString(),
+  };
+}
+
+/**
+ * Parse a ledger JSONL string into records, skipping only blank lines. A line
+ * that fails to parse throws with its line number — a corrupt ledger is a real
+ * problem the operator must see, not silently dropped (that would let a status
+ * check read a truncated history as authoritative).
+ *
+ * @param {string} text
+ * @returns {Array<ReturnType<typeof buildDeployRecord>>}
+ */
+export function parseDeployLedger(text) {
+  const records = [];
+  const lines = String(text ?? "").split("\n");
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    try {
+      records.push(JSON.parse(line));
+    } catch (error) {
+      // error-policy:J3 untrusted-input — a corrupt ledger line is an explicit
+      // failure (not a fabricated-empty history); name the line for the operator.
+      throw new Error(
+        `parseDeployLedger: malformed JSONL at line ${i + 1}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+  return records;
+}
+
+/**
+ * Read the ledger from disk. A missing file is an empty history (no deploys
+ * recorded yet) — that is a legitimate empty result, not a masked failure, so
+ * it returns `[]`. Any other read error propagates.
+ *
+ * @param {string} ledgerPath
+ * @returns {Array<ReturnType<typeof buildDeployRecord>>}
+ */
+export function readDeployLedger(ledgerPath) {
+  if (!fs.existsSync(ledgerPath)) return [];
+  return parseDeployLedger(fs.readFileSync(ledgerPath, "utf8"));
+}
+
+/**
+ * Append one record to the ledger, creating the state dir + file if absent.
+ * JSONL is append-only by construction — concurrent deploys from separate
+ * sessions each add their own line without a read-modify-write race.
+ *
+ * @param {string} ledgerPath
+ * @param {ReturnType<typeof buildDeployRecord>} record
+ * @returns {ReturnType<typeof buildDeployRecord>}
+ */
+export function appendDeployRecord(ledgerPath, record) {
+  fs.mkdirSync(path.dirname(ledgerPath), { recursive: true });
+  fs.appendFileSync(ledgerPath, `${JSON.stringify(record)}\n`);
+  return record;
+}
+
+/**
+ * Latest record per device UDID from a record list. JSONL is append-ordered, so
+ * the last row for a UDID is its current install; this collapses the history to
+ * one row per phone (what `devices:status` renders). Records missing a `udid`
+ * are dropped — they cannot be attributed to a device.
+ *
+ * @param {Array<ReturnType<typeof buildDeployRecord>>} records
+ * @returns {Map<string, ReturnType<typeof buildDeployRecord>>}
+ */
+export function latestDeployByUdid(records) {
+  const latest = new Map();
+  for (const record of records ?? []) {
+    const udid = record?.udid;
+    if (typeof udid !== "string" || !udid) continue;
+    latest.set(udid, record);
+  }
+  return latest;
+}
+
+/**
+ * The honest status of one device against the deploy ledger. `known: false` is
+ * the "unknown — no ledger entry" path the design doc (Q7) requires: a device
+ * we never recorded a deploy for is reported as unknown, never guessed.
+ *
+ * @param {Array<ReturnType<typeof buildDeployRecord>>} records
+ * @param {string} udid
+ * @returns {{ known: false, udid: string, reason: string }
+ *          | { known: true, udid: string, record: ReturnType<typeof buildDeployRecord> }}
+ */
+export function deployStatusForDevice(records, udid) {
+  const wanted = udid?.trim();
+  if (!wanted) throw new Error("deployStatusForDevice: udid is required");
+  const record = latestDeployByUdid(records).get(wanted);
+  if (!record) {
+    return {
+      known: false,
+      udid: wanted,
+      reason:
+        "unknown — no ledger entry (device was flashed by other means; " +
+        "cross-check with `ios:device:logs --pull-boot-trace`)",
+    };
+  }
+  return { known: true, udid: wanted, record };
+}
+
+/**
+ * Renderer-freshness verdict for a deploy: does the buildId the staged bundle
+ * carries match the freshly built dist? A device install of a stale renderer is
+ * the #9309 footgun (a cached dist copied over a fresh one); the deploy asserts
+ * on this before install so the phone never boots yesterday's UI.
+ *
+ * Both manifests are required — a missing/parse-less stamp is a broken pipeline,
+ * not a pass, so the caller throws when it cannot read one. This function is the
+ * pure comparison over the two already-read manifests.
+ *
+ * @param {{ buildId?: string | null, commit?: string | null } | null} staged
+ * @param {{ buildId?: string | null, commit?: string | null } | null} fresh
+ * @returns {{ fresh: boolean, stagedBuildId: string | null,
+ *            freshBuildId: string | null, reason: string }}
+ */
+export function evaluateStagedRendererFreshness(staged, fresh) {
+  const stagedBuildId = staged?.buildId?.trim() || null;
+  const freshBuildId = fresh?.buildId?.trim() || null;
+  if (!stagedBuildId) {
+    return {
+      fresh: false,
+      stagedBuildId,
+      freshBuildId,
+      reason:
+        "staged App.app has no renderer buildId (public/eliza-renderer-build.json " +
+        "missing or unstamped) — rebuild the device lane before deploying",
+    };
+  }
+  if (!freshBuildId) {
+    return {
+      fresh: false,
+      stagedBuildId,
+      freshBuildId,
+      reason:
+        "freshly built dist has no renderer buildId (packages/app/dist/" +
+        "eliza-renderer-build.json missing) — run the ios-local build before deploying",
+    };
+  }
+  if (stagedBuildId !== freshBuildId) {
+    return {
+      fresh: false,
+      stagedBuildId,
+      freshBuildId,
+      reason:
+        `staged renderer buildId ${stagedBuildId.slice(0, 12)} != freshly built ` +
+        `${freshBuildId.slice(0, 12)} — the device would boot a STALE UI (issue #9309). ` +
+        "Rebuild without --skip-build, or re-stage from a matching dist.",
+    };
+  }
+  return {
+    fresh: true,
+    stagedBuildId,
+    freshBuildId,
+    reason: `renderer buildId ${stagedBuildId.slice(0, 12)} matches freshly built dist`,
+  };
+}
+
+const RENDERER_MANIFEST_FILENAME = "eliza-renderer-build.json";
+
+/**
+ * Path to the renderer stamp inside a staged `App.app` (cap sync copies the web
+ * bundle under `public/`).
+ * @param {string} appPath
+ * @returns {string}
+ */
+export function stagedRendererManifestPath(appPath) {
+  return path.join(appPath, "public", RENDERER_MANIFEST_FILENAME);
+}
+
+/**
+ * Path to the freshly built renderer stamp in dist.
+ * @param {string} repoRoot
+ * @param {string} [rendererDist] explicit dist override
+ * @returns {string}
+ */
+export function freshRendererManifestPath(repoRoot, rendererDist) {
+  const base = rendererDist
+    ? path.resolve(rendererDist)
+    : path.join(repoRoot, "packages", "app", "dist");
+  return path.join(base, RENDERER_MANIFEST_FILENAME);
+}
+
+/**
+ * Read + parse a renderer manifest, requiring a non-empty buildId. A manifest
+ * with no buildId is not a usable stamp — throwing here keeps the deploy from
+ * treating an unstamped build as fresh.
+ *
+ * @param {string} manifestPath
+ * @param {string} label
+ * @returns {{ buildId: string, commit: string | null, variant: string | null,
+ *            runtimeMode: string | null, builtAt: string | null }}
+ */
+export function readRendererManifest(manifestPath, label) {
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error(`${label} renderer manifest is missing: ${manifestPath}`);
+  }
+  const parsed = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  if (typeof parsed.buildId !== "string" || parsed.buildId.length === 0) {
+    throw new Error(`${label} renderer manifest has no buildId: ${manifestPath}`);
+  }
+  return {
+    buildId: parsed.buildId,
+    commit: typeof parsed.commit === "string" ? parsed.commit : null,
+    variant: typeof parsed.variant === "string" ? parsed.variant : null,
+    runtimeMode:
+      typeof parsed.runtimeMode === "string" ? parsed.runtimeMode : null,
+    builtAt: typeof parsed.builtAt === "string" ? parsed.builtAt : null,
+  };
+}

--- a/packages/app/scripts/lib/ios-deploy-ledger.mjs
+++ b/packages/app/scripts/lib/ios-deploy-ledger.mjs
@@ -15,10 +15,13 @@
  *
  * Everything here is pure or takes the filesystem edge as the JSONL path, so the
  * append/read/latest-per-device logic is unit-tested against fixtures without a
- * device. The stamp comparison is the deploy-side renderer-freshness assert:
- * the deploy refuses a staged bundle whose buildId does not match the freshly
- * built dist (a stale UI would otherwise ship silently — issue #9309's failure
- * mode, on the device lane).
+ * device. The renderer stamp itself — path resolution and typed read — lives in
+ * `lib/ios-renderer-stamp.mjs` (the single source of truth the simulator lanes
+ * also use); this module owns only the deploy-side, non-throwing freshness
+ * *verdict* ({@link evaluateStagedRendererFreshness}) the device deploy renders
+ * before install to refuse a staged bundle whose buildId does not match the
+ * freshly built dist (a stale UI would otherwise ship silently — issue #9309's
+ * failure mode, on the device lane).
  */
 import fs from "node:fs";
 import os from "node:os";
@@ -267,58 +270,5 @@ export function evaluateStagedRendererFreshness(staged, fresh) {
     stagedBuildId,
     freshBuildId,
     reason: `renderer buildId ${stagedBuildId.slice(0, 12)} matches freshly built dist`,
-  };
-}
-
-const RENDERER_MANIFEST_FILENAME = "eliza-renderer-build.json";
-
-/**
- * Path to the renderer stamp inside a staged `App.app` (cap sync copies the web
- * bundle under `public/`).
- * @param {string} appPath
- * @returns {string}
- */
-export function stagedRendererManifestPath(appPath) {
-  return path.join(appPath, "public", RENDERER_MANIFEST_FILENAME);
-}
-
-/**
- * Path to the freshly built renderer stamp in dist.
- * @param {string} repoRoot
- * @param {string} [rendererDist] explicit dist override
- * @returns {string}
- */
-export function freshRendererManifestPath(repoRoot, rendererDist) {
-  const base = rendererDist
-    ? path.resolve(rendererDist)
-    : path.join(repoRoot, "packages", "app", "dist");
-  return path.join(base, RENDERER_MANIFEST_FILENAME);
-}
-
-/**
- * Read + parse a renderer manifest, requiring a non-empty buildId. A manifest
- * with no buildId is not a usable stamp — throwing here keeps the deploy from
- * treating an unstamped build as fresh.
- *
- * @param {string} manifestPath
- * @param {string} label
- * @returns {{ buildId: string, commit: string | null, variant: string | null,
- *            runtimeMode: string | null, builtAt: string | null }}
- */
-export function readRendererManifest(manifestPath, label) {
-  if (!fs.existsSync(manifestPath)) {
-    throw new Error(`${label} renderer manifest is missing: ${manifestPath}`);
-  }
-  const parsed = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
-  if (typeof parsed.buildId !== "string" || parsed.buildId.length === 0) {
-    throw new Error(`${label} renderer manifest has no buildId: ${manifestPath}`);
-  }
-  return {
-    buildId: parsed.buildId,
-    commit: typeof parsed.commit === "string" ? parsed.commit : null,
-    variant: typeof parsed.variant === "string" ? parsed.variant : null,
-    runtimeMode:
-      typeof parsed.runtimeMode === "string" ? parsed.runtimeMode : null,
-    builtAt: typeof parsed.builtAt === "string" ? parsed.builtAt : null,
   };
 }

--- a/packages/app/scripts/lib/ios-deploy-ledger.test.mjs
+++ b/packages/app/scripts/lib/ios-deploy-ledger.test.mjs
@@ -1,0 +1,270 @@
+/**
+ * Unit tests for the physical-iPhone deploy ledger and the deploy-side
+ * renderer-freshness compare (issue #14337). Exercises the real read/write/
+ * update round-trip against a temp JSONL file and the pure stamp comparison
+ * against fresh/stale manifest fixtures — no device, no simulator. Runs in the
+ * packages/app vitest suite (`bun run --cwd packages/app test`, root
+ * test:client lane).
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  appendDeployRecord,
+  buildDeployRecord,
+  deployStatusForDevice,
+  evaluateStagedRendererFreshness,
+  freshRendererManifestPath,
+  latestDeployByUdid,
+  parseDeployLedger,
+  readDeployLedger,
+  readRendererManifest,
+  resolveDeployLedgerPath,
+  resolveLedgerStateDir,
+  stagedRendererManifestPath,
+} from "./ios-deploy-ledger.mjs";
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "deploy-ledger-"));
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("resolveLedgerStateDir precedence", () => {
+  const home = () => "/home/tester";
+  it("prefers MILADY_STATE_DIR over ELIZA_STATE_DIR", () => {
+    expect(
+      resolveLedgerStateDir({
+        env: { MILADY_STATE_DIR: "/m/state", ELIZA_STATE_DIR: "/e/state" },
+        homedir: home,
+      }),
+    ).toBe("/m/state");
+  });
+  it("falls back to ELIZA_STATE_DIR", () => {
+    expect(
+      resolveLedgerStateDir({ env: { ELIZA_STATE_DIR: "/e/state" }, homedir: home }),
+    ).toBe("/e/state");
+  });
+  it("honors XDG_STATE_HOME + namespace", () => {
+    expect(
+      resolveLedgerStateDir({
+        env: { XDG_STATE_HOME: "/xdg", ELIZA_NAMESPACE: "milady" },
+        homedir: home,
+      }),
+    ).toBe(path.join("/xdg", "milady"));
+  });
+  it("defaults to ~/.local/state/eliza", () => {
+    expect(resolveLedgerStateDir({ env: {}, homedir: home })).toBe(
+      path.join("/home/tester", ".local", "state", "eliza"),
+    );
+  });
+  it("resolveDeployLedgerPath appends the ledger filename", () => {
+    expect(
+      resolveDeployLedgerPath({ env: { ELIZA_STATE_DIR: "/e/state" }, homedir: home }),
+    ).toBe(path.join("/e/state", "device-deploy-ledger.jsonl"));
+  });
+});
+
+describe("buildDeployRecord validation", () => {
+  it("throws without a udid", () => {
+    expect(() => buildDeployRecord({ buildId: "abc" })).toThrow(/udid is required/);
+  });
+  it("throws without a buildId", () => {
+    expect(() => buildDeployRecord({ udid: "UDID-1" })).toThrow(
+      /buildId is required/,
+    );
+  });
+  it("normalizes optionals and stamps deployedAt", () => {
+    const record = buildDeployRecord({
+      udid: "  UDID-1  ",
+      buildId: " build-abc ",
+      name: " iPhone 16 ",
+      commit: "  ",
+      skippedAppexes: true,
+    });
+    expect(record.udid).toBe("UDID-1");
+    expect(record.buildId).toBe("build-abc");
+    expect(record.name).toBe("iPhone 16");
+    expect(record.commit).toBeNull();
+    expect(record.skippedAppexes).toBe(true);
+    expect(typeof record.deployedAt).toBe("string");
+    expect(record.schema).toBe("elizaos.device.deploy-ledger/v1");
+  });
+});
+
+describe("ledger write → read → update round-trip", () => {
+  it("appends, reads back, and collapses to the latest per device", () => {
+    const ledgerPath = path.join(tmpDir, "state", "device-deploy-ledger.jsonl");
+    expect(readDeployLedger(ledgerPath)).toEqual([]); // missing file = empty
+
+    appendDeployRecord(
+      ledgerPath,
+      buildDeployRecord({
+        udid: "UDID-A",
+        buildId: "build-1",
+        commit: "commit-1",
+        deployedAt: "2026-01-01T00:00:00.000Z",
+      }),
+    );
+    appendDeployRecord(
+      ledgerPath,
+      buildDeployRecord({
+        udid: "UDID-B",
+        buildId: "build-9",
+        deployedAt: "2026-01-01T01:00:00.000Z",
+      }),
+    );
+    // Re-deploy to UDID-A with a newer build — the update path.
+    appendDeployRecord(
+      ledgerPath,
+      buildDeployRecord({
+        udid: "UDID-A",
+        buildId: "build-2",
+        commit: "commit-2",
+        deployedAt: "2026-01-02T00:00:00.000Z",
+      }),
+    );
+
+    const records = readDeployLedger(ledgerPath);
+    expect(records).toHaveLength(3);
+
+    const latest = latestDeployByUdid(records);
+    expect(latest.get("UDID-A").buildId).toBe("build-2");
+    expect(latest.get("UDID-A").commit).toBe("commit-2");
+    expect(latest.get("UDID-B").buildId).toBe("build-9");
+  });
+
+  it("creates the state dir if absent", () => {
+    const ledgerPath = path.join(tmpDir, "nested", "deep", "ledger.jsonl");
+    appendDeployRecord(
+      ledgerPath,
+      buildDeployRecord({ udid: "UDID-C", buildId: "b" }),
+    );
+    expect(fs.existsSync(ledgerPath)).toBe(true);
+  });
+});
+
+describe("deployStatusForDevice honest unknown path", () => {
+  it("reports unknown for a device with no ledger entry", () => {
+    const records = [buildDeployRecord({ udid: "UDID-A", buildId: "b1" })];
+    const status = deployStatusForDevice(records, "UDID-UNSEEN");
+    expect(status.known).toBe(false);
+    expect(status.reason).toMatch(/unknown — no ledger entry/);
+  });
+  it("reports the latest record for a known device", () => {
+    const records = [
+      buildDeployRecord({ udid: "UDID-A", buildId: "b1", deployedAt: "2026-01-01T00:00:00Z" }),
+      buildDeployRecord({ udid: "UDID-A", buildId: "b2", deployedAt: "2026-01-02T00:00:00Z" }),
+    ];
+    const status = deployStatusForDevice(records, "UDID-A");
+    expect(status.known).toBe(true);
+    expect(status.record.buildId).toBe("b2");
+  });
+  it("throws on an empty udid", () => {
+    expect(() => deployStatusForDevice([], "  ")).toThrow(/udid is required/);
+  });
+});
+
+describe("parseDeployLedger fail-closed on corruption", () => {
+  it("skips blank lines only", () => {
+    const text = '{"udid":"A","buildId":"b"}\n\n  \n{"udid":"B","buildId":"c"}\n';
+    expect(parseDeployLedger(text)).toHaveLength(2);
+  });
+  it("throws with a line number on malformed JSONL", () => {
+    const text = '{"udid":"A","buildId":"b"}\nnot-json\n';
+    expect(() => parseDeployLedger(text)).toThrow(/line 2/);
+  });
+});
+
+describe("evaluateStagedRendererFreshness", () => {
+  it("passes when buildIds match", () => {
+    const v = evaluateStagedRendererFreshness(
+      { buildId: "build-abc" },
+      { buildId: "build-abc" },
+    );
+    expect(v.fresh).toBe(true);
+    expect(v.reason).toMatch(/matches freshly built/);
+  });
+  it("fails on a stale staged buildId with an actionable message", () => {
+    const v = evaluateStagedRendererFreshness(
+      { buildId: "build-OLD0" },
+      { buildId: "build-NEW9" },
+    );
+    expect(v.fresh).toBe(false);
+    expect(v.reason).toMatch(/STALE UI/);
+    expect(v.reason).toMatch(/#9309/);
+  });
+  it("fails when the staged bundle has no buildId", () => {
+    const v = evaluateStagedRendererFreshness(null, { buildId: "build-NEW9" });
+    expect(v.fresh).toBe(false);
+    expect(v.reason).toMatch(/no renderer buildId/);
+  });
+  it("fails when the fresh dist has no buildId", () => {
+    const v = evaluateStagedRendererFreshness({ buildId: "build-abc" }, null);
+    expect(v.fresh).toBe(false);
+    expect(v.reason).toMatch(/freshly built dist has no renderer buildId/);
+  });
+});
+
+describe("readRendererManifest against fixtures", () => {
+  function writeManifest(dir, manifest) {
+    const target = path.join(dir, "eliza-renderer-build.json");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(target, JSON.stringify(manifest));
+    return target;
+  }
+
+  it("reads a valid staged manifest and the fresh manifest, then compares", () => {
+    const appPublic = path.join(tmpDir, "App.app", "public");
+    const dist = path.join(tmpDir, "dist");
+    const stagedPath = writeManifest(appPublic, {
+      buildId: "build-XYZ",
+      commit: "deadbeef",
+      variant: "device",
+      runtimeMode: "local",
+      builtAt: "2026-01-01T00:00:00Z",
+    });
+    writeManifest(dist, {
+      buildId: "build-XYZ",
+      commit: "deadbeef",
+      variant: "device",
+      runtimeMode: "local",
+    });
+
+    expect(stagedRendererManifestPath(path.join(tmpDir, "App.app"))).toBe(
+      stagedPath,
+    );
+    const staged = readRendererManifest(stagedPath, "staged");
+    const fresh = readRendererManifest(
+      freshRendererManifestPath("/unused-repo-root", dist),
+      "fresh",
+    );
+    expect(staged.buildId).toBe("build-XYZ");
+    expect(staged.commit).toBe("deadbeef");
+    expect(evaluateStagedRendererFreshness(staged, fresh).fresh).toBe(true);
+  });
+
+  it("throws on a missing manifest", () => {
+    expect(() => readRendererManifest(path.join(tmpDir, "nope.json"), "staged")).toThrow(
+      /is missing/,
+    );
+  });
+  it("throws on a manifest with no buildId", () => {
+    const p = path.join(tmpDir, "eliza-renderer-build.json");
+    fs.writeFileSync(p, JSON.stringify({ commit: "x" }));
+    expect(() => readRendererManifest(p, "staged")).toThrow(/has no buildId/);
+  });
+
+  it("freshRendererManifestPath honors an explicit dist override", () => {
+    expect(freshRendererManifestPath("/repo", "/custom/dist")).toBe(
+      path.join("/custom", "dist", "eliza-renderer-build.json"),
+    );
+    expect(freshRendererManifestPath("/repo")).toBe(
+      path.join("/repo", "packages", "app", "dist", "eliza-renderer-build.json"),
+    );
+  });
+});

--- a/packages/app/scripts/lib/ios-deploy-ledger.test.mjs
+++ b/packages/app/scripts/lib/ios-deploy-ledger.test.mjs
@@ -15,15 +15,17 @@ import {
   buildDeployRecord,
   deployStatusForDevice,
   evaluateStagedRendererFreshness,
-  freshRendererManifestPath,
   latestDeployByUdid,
   parseDeployLedger,
   readDeployLedger,
-  readRendererManifest,
   resolveDeployLedgerPath,
   resolveLedgerStateDir,
-  stagedRendererManifestPath,
 } from "./ios-deploy-ledger.mjs";
+import {
+  freshRendererManifestPath,
+  readRendererManifest,
+  rendererManifestPathFromAppPath,
+} from "./ios-renderer-stamp.mjs";
 
 let tmpDir;
 
@@ -46,7 +48,10 @@ describe("resolveLedgerStateDir precedence", () => {
   });
   it("falls back to ELIZA_STATE_DIR", () => {
     expect(
-      resolveLedgerStateDir({ env: { ELIZA_STATE_DIR: "/e/state" }, homedir: home }),
+      resolveLedgerStateDir({
+        env: { ELIZA_STATE_DIR: "/e/state" },
+        homedir: home,
+      }),
     ).toBe("/e/state");
   });
   it("honors XDG_STATE_HOME + namespace", () => {
@@ -64,14 +69,19 @@ describe("resolveLedgerStateDir precedence", () => {
   });
   it("resolveDeployLedgerPath appends the ledger filename", () => {
     expect(
-      resolveDeployLedgerPath({ env: { ELIZA_STATE_DIR: "/e/state" }, homedir: home }),
+      resolveDeployLedgerPath({
+        env: { ELIZA_STATE_DIR: "/e/state" },
+        homedir: home,
+      }),
     ).toBe(path.join("/e/state", "device-deploy-ledger.jsonl"));
   });
 });
 
 describe("buildDeployRecord validation", () => {
   it("throws without a udid", () => {
-    expect(() => buildDeployRecord({ buildId: "abc" })).toThrow(/udid is required/);
+    expect(() => buildDeployRecord({ buildId: "abc" })).toThrow(
+      /udid is required/,
+    );
   });
   it("throws without a buildId", () => {
     expect(() => buildDeployRecord({ udid: "UDID-1" })).toThrow(
@@ -157,8 +167,16 @@ describe("deployStatusForDevice honest unknown path", () => {
   });
   it("reports the latest record for a known device", () => {
     const records = [
-      buildDeployRecord({ udid: "UDID-A", buildId: "b1", deployedAt: "2026-01-01T00:00:00Z" }),
-      buildDeployRecord({ udid: "UDID-A", buildId: "b2", deployedAt: "2026-01-02T00:00:00Z" }),
+      buildDeployRecord({
+        udid: "UDID-A",
+        buildId: "b1",
+        deployedAt: "2026-01-01T00:00:00Z",
+      }),
+      buildDeployRecord({
+        udid: "UDID-A",
+        buildId: "b2",
+        deployedAt: "2026-01-02T00:00:00Z",
+      }),
     ];
     const status = deployStatusForDevice(records, "UDID-A");
     expect(status.known).toBe(true);
@@ -171,7 +189,8 @@ describe("deployStatusForDevice honest unknown path", () => {
 
 describe("parseDeployLedger fail-closed on corruption", () => {
   it("skips blank lines only", () => {
-    const text = '{"udid":"A","buildId":"b"}\n\n  \n{"udid":"B","buildId":"c"}\n';
+    const text =
+      '{"udid":"A","buildId":"b"}\n\n  \n{"udid":"B","buildId":"c"}\n';
     expect(parseDeployLedger(text)).toHaveLength(2);
   });
   it("throws with a line number on malformed JSONL", () => {
@@ -210,7 +229,7 @@ describe("evaluateStagedRendererFreshness", () => {
   });
 });
 
-describe("readRendererManifest against fixtures", () => {
+describe("evaluateStagedRendererFreshness against real stamp fixtures", () => {
   function writeManifest(dir, manifest) {
     const target = path.join(dir, "eliza-renderer-build.json");
     fs.mkdirSync(dir, { recursive: true });
@@ -218,7 +237,10 @@ describe("readRendererManifest against fixtures", () => {
     return target;
   }
 
-  it("reads a valid staged manifest and the fresh manifest, then compares", () => {
+  // Reads real staged + fresh stamps through the shared ios-renderer-stamp lib,
+  // then runs the ledger's freshness verdict over them — the end-to-end deploy
+  // path (read staged, read fresh, decide) without a device.
+  it("verdicts fresh when a real staged stamp matches the fresh dist stamp", () => {
     const appPublic = path.join(tmpDir, "App.app", "public");
     const dist = path.join(tmpDir, "dist");
     const stagedPath = writeManifest(appPublic, {
@@ -235,36 +257,19 @@ describe("readRendererManifest against fixtures", () => {
       runtimeMode: "local",
     });
 
-    expect(stagedRendererManifestPath(path.join(tmpDir, "App.app"))).toBe(
+    expect(rendererManifestPathFromAppPath(path.join(tmpDir, "App.app"))).toBe(
       stagedPath,
     );
     const staged = readRendererManifest(stagedPath, "staged");
     const fresh = readRendererManifest(
-      freshRendererManifestPath("/unused-repo-root", dist),
+      freshRendererManifestPath({
+        repoRoot: "/unused-repo-root",
+        rendererDist: dist,
+      }),
       "fresh",
     );
     expect(staged.buildId).toBe("build-XYZ");
     expect(staged.commit).toBe("deadbeef");
     expect(evaluateStagedRendererFreshness(staged, fresh).fresh).toBe(true);
-  });
-
-  it("throws on a missing manifest", () => {
-    expect(() => readRendererManifest(path.join(tmpDir, "nope.json"), "staged")).toThrow(
-      /is missing/,
-    );
-  });
-  it("throws on a manifest with no buildId", () => {
-    const p = path.join(tmpDir, "eliza-renderer-build.json");
-    fs.writeFileSync(p, JSON.stringify({ commit: "x" }));
-    expect(() => readRendererManifest(p, "staged")).toThrow(/has no buildId/);
-  });
-
-  it("freshRendererManifestPath honors an explicit dist override", () => {
-    expect(freshRendererManifestPath("/repo", "/custom/dist")).toBe(
-      path.join("/custom", "dist", "eliza-renderer-build.json"),
-    );
-    expect(freshRendererManifestPath("/repo")).toBe(
-      path.join("/repo", "packages", "app", "dist", "eliza-renderer-build.json"),
-    );
   });
 });

--- a/packages/app/scripts/lib/ios-device-e2e-lib.mjs
+++ b/packages/app/scripts/lib/ios-device-e2e-lib.mjs
@@ -1,0 +1,271 @@
+/**
+ * Pure step-sequencing and command-argument construction for the one-command
+ * physical-iPhone e2e lane (`ios-device-e2e.mjs`, issue #14337), plus the
+ * run-scoped triage-bundle summary shape.
+ *
+ * The lane chains four already-proven scripts — deploy → on-device BootCapture
+ * assertion → capture filmstrip → boot-trace logs — into one command. This
+ * module owns the deterministic decisions (which steps run, exactly which
+ * argv each gets, how a step's exit becomes a verdict, what the summary.json
+ * looks like); the script owns the impure edges (spawning node, reading files,
+ * writing the bundle). Keeping the argv construction here means the exact flags
+ * the lane hands each child are unit-tested against fixtures without a device.
+ *
+ * The on-device assertion is BootCapture, NOT `mobile-local-chat-smoke`: that
+ * smoke targets the iOS Simulator, so on a physical iPhone the XCUITest
+ * BootCapture harness ("did the freshly deployed app boot to home or an error
+ * card") is the on-device assertion of record (issue #14337, research doc 08 §4).
+ *
+ * Bundle shape mirrors research doc 08 Q2/Q3: a gitignored run-scoped dir with
+ * `inline/` (post-ready MP4/JPG), `logs/`, and a JSON-canonical `summary.json`
+ * carrying lane, device identity, installed buildId/commit, and per-step
+ * status/duration/artifact paths. The device-e2e bundle library
+ * (`lib/device-e2e-bundle.mjs`) is owned by a sibling PR (#14336); this lane
+ * ships a minimal local emitter matching that documented shape and is
+ * reconciled onto the shared lib when it lands.
+ */
+import path from "node:path";
+
+/** Canonical step ids, in execution order. */
+export const IOS_DEVICE_E2E_STEP_IDS = Object.freeze([
+  "deploy",
+  "smoke",
+  "capture",
+  "logs",
+]);
+
+/**
+ * Plan the ordered steps for a physical-iPhone e2e run. Every step is always
+ * present — this lane has no "vacuous" mode: a run that skipped the on-device
+ * assertion would print success without proving the phone booted the new build.
+ * `--skip-capture` / `--skip-logs` exist only to trim the (non-assertion)
+ * artifact-collection steps for tight iteration; deploy + smoke are mandatory.
+ *
+ * @param {{ skipCapture?: boolean, skipLogs?: boolean }} [flags]
+ * @returns {Array<{ id: string, label: string }>}
+ */
+export function planIosDeviceE2eSteps({ skipCapture = false, skipLogs = false } = {}) {
+  const steps = [
+    { id: "deploy", label: "deploy signed App.app to the device (--skip-appexes)" },
+    { id: "smoke", label: "on-device BootCapture assertion (boots to home or error card)" },
+  ];
+  if (!skipCapture) {
+    steps.push({ id: "capture", label: "capture the boot filmstrip for the bundle" });
+  }
+  if (!skipLogs) {
+    steps.push({ id: "logs", label: "pull the full-Bun boot-trace (--no-console)" });
+  }
+  return steps;
+}
+
+/**
+ * Absolute node argv for the deploy step. `--skip-appexes` is the default
+ * unattended posture (PR #13174, research doc Q6): per-appex profiles need an
+ * ASC API key, so widget/keyboard/device-activity surfaces are stripped and the
+ * deploy logs that loudly. `--device` is always passed through so the whole lane
+ * pins one phone.
+ *
+ * @param {{ scriptsDir: string, deviceId: string, skipAppexes?: boolean,
+ *           skipBuild?: boolean, noLaunch?: boolean, bundleId?: string | null }} opts
+ * @returns {{ cmd: string, args: string[] }}
+ */
+export function buildDeviceDeployCommand({
+  scriptsDir,
+  deviceId,
+  skipAppexes = true,
+  skipBuild = false,
+  noLaunch = false,
+  bundleId = null,
+}) {
+  if (!deviceId) throw new Error("buildDeviceDeployCommand: deviceId is required");
+  const args = [
+    path.join(scriptsDir, "ios-device-deploy.mjs"),
+    "--device",
+    deviceId,
+  ];
+  if (skipAppexes) args.push("--skip-appexes");
+  if (skipBuild) args.push("--skip-build");
+  if (noLaunch) args.push("--no-launch");
+  if (bundleId) args.push("--bundle-id", bundleId);
+  return { cmd: "node", args };
+}
+
+/**
+ * Absolute node argv for the on-device BootCapture assertion. `--skip-build`
+ * is forced: deploy already built + installed the current tree, so the capture
+ * must reuse that install, never rebuild a second bundle. `--output` targets the
+ * run bundle's `smoke/` subdir so the assertion's attachments land inside the
+ * triage bundle.
+ *
+ * @param {{ scriptsDir: string, deviceId: string, outputDir: string,
+ *           requireChat?: boolean, bundleId?: string | null }} opts
+ * @returns {{ cmd: string, args: string[] }}
+ */
+export function buildDeviceSmokeCommand({
+  scriptsDir,
+  deviceId,
+  outputDir,
+  requireChat = false,
+  bundleId = null,
+}) {
+  if (!deviceId) throw new Error("buildDeviceSmokeCommand: deviceId is required");
+  if (!outputDir) throw new Error("buildDeviceSmokeCommand: outputDir is required");
+  const args = [
+    path.join(scriptsDir, "ios-device-capture.mjs"),
+    "--platform",
+    "device",
+    "--device",
+    deviceId,
+    "--skip-build",
+    "--output",
+    outputDir,
+  ];
+  if (requireChat) args.push("--require-chat");
+  if (bundleId) args.push("--bundle-id", bundleId);
+  return { cmd: "node", args };
+}
+
+/**
+ * Absolute node argv for the filmstrip capture step. Same BootCapture script as
+ * the smoke assertion but into the bundle's `capture/` subdir — this is the
+ * watchable artifact, separate from the pass/fail assertion output so a green
+ * run still yields a filmstrip to eyeball.
+ *
+ * @param {{ scriptsDir: string, deviceId: string, outputDir: string,
+ *           bundleId?: string | null }} opts
+ * @returns {{ cmd: string, args: string[] }}
+ */
+export function buildDeviceCaptureCommand({
+  scriptsDir,
+  deviceId,
+  outputDir,
+  bundleId = null,
+}) {
+  if (!deviceId) throw new Error("buildDeviceCaptureCommand: deviceId is required");
+  if (!outputDir) throw new Error("buildDeviceCaptureCommand: outputDir is required");
+  const args = [
+    path.join(scriptsDir, "ios-device-capture.mjs"),
+    "--platform",
+    "device",
+    "--device",
+    deviceId,
+    "--skip-build",
+    "--output",
+    outputDir,
+  ];
+  if (bundleId) args.push("--bundle-id", bundleId);
+  return { cmd: "node", args };
+}
+
+/**
+ * Absolute node argv for the boot-trace logs step. `--no-console
+ * --pull-boot-trace` is the ONLY engine-observability path on the full-Bun
+ * build: an attached `--console` launch SIGTRAPs the no-JIT engine host at load
+ * (#11515). `--output` writes the pulled trace into the bundle's `logs/` dir.
+ *
+ * @param {{ scriptsDir: string, deviceId: string, outputFile: string,
+ *           bundleId?: string | null }} opts
+ * @returns {{ cmd: string, args: string[] }}
+ */
+export function buildDeviceLogsCommand({
+  scriptsDir,
+  deviceId,
+  outputFile,
+  bundleId = null,
+}) {
+  if (!deviceId) throw new Error("buildDeviceLogsCommand: deviceId is required");
+  if (!outputFile) throw new Error("buildDeviceLogsCommand: outputFile is required");
+  const args = [
+    path.join(scriptsDir, "ios-device-logs.mjs"),
+    "--device",
+    deviceId,
+    "--no-console",
+    "--pull-boot-trace",
+    "--output",
+    outputFile,
+  ];
+  if (bundleId) args.push("--bundle-id", bundleId);
+  return { cmd: "node", args };
+}
+
+/**
+ * Classify a step's process exit into a bundle verdict. A null status is a
+ * spawn that never produced an exit code (the child could not be launched) —
+ * treated as failure, never as success. Only exit 0 passes.
+ *
+ * @param {number | null} status
+ * @returns {{ status: 'passed' | 'failed', ok: boolean }}
+ */
+export function classifyStepStatus(status) {
+  const ok = status === 0;
+  return { status: ok ? "passed" : "failed", ok };
+}
+
+export const IOS_DEVICE_E2E_SUMMARY_SCHEMA = "elizaos.device-e2e.summary/v1";
+
+/**
+ * Assemble the run-scoped `summary.json` (JSON-canonical machine-readable
+ * artifact, research doc Q3). `steps` are the recorded per-step results;
+ * `overallStatus` is `passed` iff every executed step passed. The `bundleDir`
+ * is echoed so a consumer that only has the summary can locate the artifacts.
+ *
+ * @param {{
+ *   runId: string,
+ *   startedAt: string,
+ *   finishedAt: string,
+ *   bundleDir: string,
+ *   device: { udid: string | null, identifier: string | null, name: string | null },
+ *   build: { buildId: string | null, commit: string | null },
+ *   skippedAppexes: boolean,
+ *   steps: Array<{ id: string, label: string, status: 'passed' | 'failed',
+ *                  durationMs: number, artifacts: string[] }>,
+ * }} input
+ * @returns {Record<string, unknown>}
+ */
+export function buildRunSummary(input) {
+  if (!input?.runId) throw new Error("buildRunSummary: runId is required");
+  const steps = input.steps ?? [];
+  const overallStatus = steps.every((step) => step.status === "passed")
+    ? "passed"
+    : "failed";
+  return {
+    schema: IOS_DEVICE_E2E_SUMMARY_SCHEMA,
+    lane: "ios-device-e2e",
+    runId: input.runId,
+    overallStatus,
+    startedAt: input.startedAt,
+    finishedAt: input.finishedAt,
+    bundleDir: input.bundleDir,
+    device: {
+      udid: input.device?.udid ?? null,
+      identifier: input.device?.identifier ?? null,
+      name: input.device?.name ?? null,
+    },
+    build: {
+      buildId: input.build?.buildId ?? null,
+      commit: input.build?.commit ?? null,
+    },
+    skippedAppexes: input.skippedAppexes === true,
+    steps: steps.map((step) => ({
+      id: step.id,
+      label: step.label,
+      status: step.status,
+      durationMs: step.durationMs,
+      artifacts: step.artifacts ?? [],
+    })),
+  };
+}
+
+/**
+ * A run id from a Date: `YYYYMMDD-HHMMSS` in UTC. Stable, sortable, filesystem
+ * safe — used as the run-scoped bundle directory suffix.
+ *
+ * @param {Date} [now]
+ * @returns {string}
+ */
+export function formatRunId(now = new Date()) {
+  const iso = now.toISOString();
+  return `${iso.slice(0, 10).replaceAll("-", "")}-${iso
+    .slice(11, 19)
+    .replaceAll(":", "")}`;
+}

--- a/packages/app/scripts/lib/ios-device-e2e-lib.mjs
+++ b/packages/app/scripts/lib/ios-device-e2e-lib.mjs
@@ -3,26 +3,30 @@
  * physical-iPhone e2e lane (`ios-device-e2e.mjs`, issue #14337), plus the
  * run-scoped triage-bundle summary shape.
  *
- * The lane chains four already-proven scripts — deploy → on-device BootCapture
- * assertion → capture filmstrip → boot-trace logs — into one command. This
- * module owns the deterministic decisions (which steps run, exactly which
- * argv each gets, how a step's exit becomes a verdict, what the summary.json
- * looks like); the script owns the impure edges (spawning node, reading files,
- * writing the bundle). Keeping the argv construction here means the exact flags
- * the lane hands each child are unit-tested against fixtures without a device.
+ * The lane chains three already-proven scripts — deploy → on-device BootCapture
+ * assertion → boot-trace logs — into one command. This module owns the
+ * deterministic decisions (which steps run, exactly which argv each gets, how a
+ * step's exit becomes a verdict, what the summary.json looks like); the script
+ * owns the impure edges (spawning node, reading files, writing the bundle).
+ * Keeping the argv construction here means the exact flags the lane hands each
+ * child are unit-tested against fixtures without a device.
  *
  * The on-device assertion is BootCapture, NOT `mobile-local-chat-smoke`: that
  * smoke targets the iOS Simulator, so on a physical iPhone the XCUITest
  * BootCapture harness ("did the freshly deployed app boot to home or an error
  * card") is the on-device assertion of record (issue #14337, research doc 08 §4).
+ * BootCapture writes its filmstrip attachments into the smoke step's output dir,
+ * so that one on-device boot yields both the pass/fail verdict and the watchable
+ * filmstrip — there is no separate capture boot (a second identical BootCapture
+ * run would only re-boot the phone to produce bytes the smoke step already has).
  *
  * Bundle shape mirrors research doc 08 Q2/Q3: a gitignored run-scoped dir with
- * `inline/` (post-ready MP4/JPG), `logs/`, and a JSON-canonical `summary.json`
- * carrying lane, device identity, installed buildId/commit, and per-step
- * status/duration/artifact paths. The device-e2e bundle library
- * (`lib/device-e2e-bundle.mjs`) is owned by a sibling PR (#14336); this lane
- * ships a minimal local emitter matching that documented shape and is
- * reconciled onto the shared lib when it lands.
+ * `smoke/` (the BootCapture MP4/JPG the assertion produced), `logs/`, and a
+ * JSON-canonical `summary.json` carrying lane, device identity, installed
+ * buildId/commit, and per-step status/duration/artifact paths. The device-e2e
+ * bundle library (`lib/device-e2e-bundle.mjs`) is owned by a sibling PR
+ * (#14336); this lane ships a minimal local emitter matching that documented
+ * shape and is reconciled onto the shared lib when it lands.
  */
 import path from "node:path";
 
@@ -30,30 +34,37 @@ import path from "node:path";
 export const IOS_DEVICE_E2E_STEP_IDS = Object.freeze([
   "deploy",
   "smoke",
-  "capture",
   "logs",
 ]);
 
 /**
- * Plan the ordered steps for a physical-iPhone e2e run. Every step is always
- * present — this lane has no "vacuous" mode: a run that skipped the on-device
+ * Plan the ordered steps for a physical-iPhone e2e run. Deploy + smoke are
+ * mandatory — this lane has no "vacuous" mode: a run that skipped the on-device
  * assertion would print success without proving the phone booted the new build.
- * `--skip-capture` / `--skip-logs` exist only to trim the (non-assertion)
- * artifact-collection steps for tight iteration; deploy + smoke are mandatory.
+ * The smoke step's BootCapture run already emits the watchable filmstrip, so
+ * there is no separate capture step. `--skip-logs` exists only to trim the
+ * (non-assertion) boot-trace pull for tight iteration.
  *
- * @param {{ skipCapture?: boolean, skipLogs?: boolean }} [flags]
+ * @param {{ skipLogs?: boolean }} [flags]
  * @returns {Array<{ id: string, label: string }>}
  */
-export function planIosDeviceE2eSteps({ skipCapture = false, skipLogs = false } = {}) {
+export function planIosDeviceE2eSteps({ skipLogs = false } = {}) {
   const steps = [
-    { id: "deploy", label: "deploy signed App.app to the device (--skip-appexes)" },
-    { id: "smoke", label: "on-device BootCapture assertion (boots to home or error card)" },
+    {
+      id: "deploy",
+      label: "deploy signed App.app to the device (--skip-appexes)",
+    },
+    {
+      id: "smoke",
+      label:
+        "on-device BootCapture assertion + filmstrip (boots to home or error card)",
+    },
   ];
-  if (!skipCapture) {
-    steps.push({ id: "capture", label: "capture the boot filmstrip for the bundle" });
-  }
   if (!skipLogs) {
-    steps.push({ id: "logs", label: "pull the full-Bun boot-trace (--no-console)" });
+    steps.push({
+      id: "logs",
+      label: "pull the full-Bun boot-trace (--no-console)",
+    });
   }
   return steps;
 }
@@ -77,7 +88,8 @@ export function buildDeviceDeployCommand({
   noLaunch = false,
   bundleId = null,
 }) {
-  if (!deviceId) throw new Error("buildDeviceDeployCommand: deviceId is required");
+  if (!deviceId)
+    throw new Error("buildDeviceDeployCommand: deviceId is required");
   const args = [
     path.join(scriptsDir, "ios-device-deploy.mjs"),
     "--device",
@@ -108,8 +120,10 @@ export function buildDeviceSmokeCommand({
   requireChat = false,
   bundleId = null,
 }) {
-  if (!deviceId) throw new Error("buildDeviceSmokeCommand: deviceId is required");
-  if (!outputDir) throw new Error("buildDeviceSmokeCommand: outputDir is required");
+  if (!deviceId)
+    throw new Error("buildDeviceSmokeCommand: deviceId is required");
+  if (!outputDir)
+    throw new Error("buildDeviceSmokeCommand: outputDir is required");
   const args = [
     path.join(scriptsDir, "ios-device-capture.mjs"),
     "--platform",
@@ -121,38 +135,6 @@ export function buildDeviceSmokeCommand({
     outputDir,
   ];
   if (requireChat) args.push("--require-chat");
-  if (bundleId) args.push("--bundle-id", bundleId);
-  return { cmd: "node", args };
-}
-
-/**
- * Absolute node argv for the filmstrip capture step. Same BootCapture script as
- * the smoke assertion but into the bundle's `capture/` subdir — this is the
- * watchable artifact, separate from the pass/fail assertion output so a green
- * run still yields a filmstrip to eyeball.
- *
- * @param {{ scriptsDir: string, deviceId: string, outputDir: string,
- *           bundleId?: string | null }} opts
- * @returns {{ cmd: string, args: string[] }}
- */
-export function buildDeviceCaptureCommand({
-  scriptsDir,
-  deviceId,
-  outputDir,
-  bundleId = null,
-}) {
-  if (!deviceId) throw new Error("buildDeviceCaptureCommand: deviceId is required");
-  if (!outputDir) throw new Error("buildDeviceCaptureCommand: outputDir is required");
-  const args = [
-    path.join(scriptsDir, "ios-device-capture.mjs"),
-    "--platform",
-    "device",
-    "--device",
-    deviceId,
-    "--skip-build",
-    "--output",
-    outputDir,
-  ];
   if (bundleId) args.push("--bundle-id", bundleId);
   return { cmd: "node", args };
 }
@@ -173,8 +155,10 @@ export function buildDeviceLogsCommand({
   outputFile,
   bundleId = null,
 }) {
-  if (!deviceId) throw new Error("buildDeviceLogsCommand: deviceId is required");
-  if (!outputFile) throw new Error("buildDeviceLogsCommand: outputFile is required");
+  if (!deviceId)
+    throw new Error("buildDeviceLogsCommand: deviceId is required");
+  if (!outputFile)
+    throw new Error("buildDeviceLogsCommand: outputFile is required");
   const args = [
     path.join(scriptsDir, "ios-device-logs.mjs"),
     "--device",

--- a/packages/app/scripts/lib/ios-device-e2e-lib.test.mjs
+++ b/packages/app/scripts/lib/ios-device-e2e-lib.test.mjs
@@ -1,0 +1,210 @@
+/**
+ * Unit tests for the pure step-sequencing, command-argument construction, and
+ * run-summary assembly behind the one-command physical-iPhone e2e lane
+ * (issue #14337). Asserts the exact argv each chained script receives and the
+ * summary schema, with the device calls left at the process boundary (never
+ * spawned here). Runs in the packages/app vitest suite.
+ */
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  buildDeviceCaptureCommand,
+  buildDeviceDeployCommand,
+  buildDeviceLogsCommand,
+  buildDeviceSmokeCommand,
+  buildRunSummary,
+  classifyStepStatus,
+  formatRunId,
+  IOS_DEVICE_E2E_STEP_IDS,
+  planIosDeviceE2eSteps,
+} from "./ios-device-e2e-lib.mjs";
+
+const scriptsDir = "/repo/packages/app/scripts";
+const deviceId = "UDID-1";
+
+describe("planIosDeviceE2eSteps", () => {
+  it("always includes deploy + smoke as the mandatory assertion pair", () => {
+    const ids = planIosDeviceE2eSteps().map((s) => s.id);
+    expect(ids).toEqual(["deploy", "smoke", "capture", "logs"]);
+    expect(ids).toEqual([...IOS_DEVICE_E2E_STEP_IDS]);
+  });
+  it("--skip-capture drops only the capture step", () => {
+    expect(planIosDeviceE2eSteps({ skipCapture: true }).map((s) => s.id)).toEqual([
+      "deploy",
+      "smoke",
+      "logs",
+    ]);
+  });
+  it("--skip-logs drops only the logs step", () => {
+    expect(planIosDeviceE2eSteps({ skipLogs: true }).map((s) => s.id)).toEqual([
+      "deploy",
+      "smoke",
+      "capture",
+    ]);
+  });
+  it("keeps deploy + smoke even with both artifact steps skipped", () => {
+    expect(
+      planIosDeviceE2eSteps({ skipCapture: true, skipLogs: true }).map((s) => s.id),
+    ).toEqual(["deploy", "smoke"]);
+  });
+});
+
+describe("buildDeviceDeployCommand", () => {
+  it("passes --skip-appexes by default plus the device", () => {
+    const { cmd, args } = buildDeviceDeployCommand({ scriptsDir, deviceId });
+    expect(cmd).toBe("node");
+    expect(args).toEqual([
+      path.join(scriptsDir, "ios-device-deploy.mjs"),
+      "--device",
+      deviceId,
+      "--skip-appexes",
+    ]);
+  });
+  it("omits --skip-appexes when opted out and threads optional flags", () => {
+    const { args } = buildDeviceDeployCommand({
+      scriptsDir,
+      deviceId,
+      skipAppexes: false,
+      skipBuild: true,
+      noLaunch: true,
+      bundleId: "ai.elizaos.app",
+    });
+    expect(args).not.toContain("--skip-appexes");
+    expect(args).toContain("--skip-build");
+    expect(args).toContain("--no-launch");
+    expect(args).toContain("--bundle-id");
+    expect(args).toContain("ai.elizaos.app");
+  });
+  it("throws without a deviceId", () => {
+    expect(() => buildDeviceDeployCommand({ scriptsDir })).toThrow(/deviceId is required/);
+  });
+});
+
+describe("buildDeviceSmokeCommand", () => {
+  it("forces --skip-build and targets the smoke output dir", () => {
+    const { args } = buildDeviceSmokeCommand({
+      scriptsDir,
+      deviceId,
+      outputDir: "/bundle/smoke",
+    });
+    expect(args).toEqual([
+      path.join(scriptsDir, "ios-device-capture.mjs"),
+      "--platform",
+      "device",
+      "--device",
+      deviceId,
+      "--skip-build",
+      "--output",
+      "/bundle/smoke",
+    ]);
+  });
+  it("threads --require-chat when asked", () => {
+    const { args } = buildDeviceSmokeCommand({
+      scriptsDir,
+      deviceId,
+      outputDir: "/bundle/smoke",
+      requireChat: true,
+    });
+    expect(args).toContain("--require-chat");
+  });
+  it("throws without an output dir", () => {
+    expect(() => buildDeviceSmokeCommand({ scriptsDir, deviceId })).toThrow(
+      /outputDir is required/,
+    );
+  });
+});
+
+describe("buildDeviceCaptureCommand", () => {
+  it("captures into the capture dir with --skip-build", () => {
+    const { args } = buildDeviceCaptureCommand({
+      scriptsDir,
+      deviceId,
+      outputDir: "/bundle/capture",
+    });
+    expect(args).toContain("--skip-build");
+    expect(args[args.indexOf("--output") + 1]).toBe("/bundle/capture");
+  });
+});
+
+describe("buildDeviceLogsCommand", () => {
+  it("uses --no-console --pull-boot-trace (the #11515 engine path)", () => {
+    const { args } = buildDeviceLogsCommand({
+      scriptsDir,
+      deviceId,
+      outputFile: "/bundle/logs/boot-trace-run",
+    });
+    expect(args).toEqual([
+      path.join(scriptsDir, "ios-device-logs.mjs"),
+      "--device",
+      deviceId,
+      "--no-console",
+      "--pull-boot-trace",
+      "--output",
+      "/bundle/logs/boot-trace-run",
+    ]);
+  });
+  it("throws without an output file", () => {
+    expect(() => buildDeviceLogsCommand({ scriptsDir, deviceId })).toThrow(
+      /outputFile is required/,
+    );
+  });
+});
+
+describe("classifyStepStatus", () => {
+  it("only exit 0 passes", () => {
+    expect(classifyStepStatus(0)).toEqual({ status: "passed", ok: true });
+    expect(classifyStepStatus(1)).toEqual({ status: "failed", ok: false });
+    // A null status (child never launched) is a failure, never a pass.
+    expect(classifyStepStatus(null)).toEqual({ status: "failed", ok: false });
+  });
+});
+
+describe("buildRunSummary", () => {
+  const base = {
+    runId: "20260101-000000",
+    startedAt: "2026-01-01T00:00:00Z",
+    finishedAt: "2026-01-01T00:05:00Z",
+    bundleDir: "/bundle/ios-20260101-000000",
+    device: { udid: "UDID-1", identifier: "ID-1", name: "iPhone 16" },
+    build: { buildId: "build-XYZ", commit: "deadbeef" },
+    skippedAppexes: true,
+  };
+
+  it("marks passed only when every step passed", () => {
+    const summary = buildRunSummary({
+      ...base,
+      steps: [
+        { id: "deploy", label: "d", status: "passed", durationMs: 10, artifacts: [] },
+        { id: "smoke", label: "s", status: "passed", durationMs: 20, artifacts: ["/a"] },
+      ],
+    });
+    expect(summary.overallStatus).toBe("passed");
+    expect(summary.schema).toBe("elizaos.device-e2e.summary/v1");
+    expect(summary.lane).toBe("ios-device-e2e");
+    expect(summary.device.udid).toBe("UDID-1");
+    expect(summary.build.buildId).toBe("build-XYZ");
+    expect(summary.skippedAppexes).toBe(true);
+    expect(summary.steps).toHaveLength(2);
+  });
+  it("marks failed when any step failed", () => {
+    const summary = buildRunSummary({
+      ...base,
+      steps: [
+        { id: "deploy", label: "d", status: "passed", durationMs: 10, artifacts: [] },
+        { id: "smoke", label: "s", status: "failed", durationMs: 20, artifacts: [] },
+      ],
+    });
+    expect(summary.overallStatus).toBe("failed");
+  });
+  it("throws without a runId", () => {
+    expect(() => buildRunSummary({ ...base, runId: "", steps: [] })).toThrow(
+      /runId is required/,
+    );
+  });
+});
+
+describe("formatRunId", () => {
+  it("produces a sortable YYYYMMDD-HHMMSS from a Date", () => {
+    expect(formatRunId(new Date("2026-07-05T13:04:09.000Z"))).toBe("20260705-130409");
+  });
+});

--- a/packages/app/scripts/lib/ios-device-e2e-lib.test.mjs
+++ b/packages/app/scripts/lib/ios-device-e2e-lib.test.mjs
@@ -8,7 +8,6 @@
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
-  buildDeviceCaptureCommand,
   buildDeviceDeployCommand,
   buildDeviceLogsCommand,
   buildDeviceSmokeCommand,
@@ -23,29 +22,16 @@ const scriptsDir = "/repo/packages/app/scripts";
 const deviceId = "UDID-1";
 
 describe("planIosDeviceE2eSteps", () => {
-  it("always includes deploy + smoke as the mandatory assertion pair", () => {
+  it("includes deploy + smoke + logs in order; no separate capture boot", () => {
     const ids = planIosDeviceE2eSteps().map((s) => s.id);
-    expect(ids).toEqual(["deploy", "smoke", "capture", "logs"]);
+    expect(ids).toEqual(["deploy", "smoke", "logs"]);
     expect(ids).toEqual([...IOS_DEVICE_E2E_STEP_IDS]);
   });
-  it("--skip-capture drops only the capture step", () => {
-    expect(planIosDeviceE2eSteps({ skipCapture: true }).map((s) => s.id)).toEqual([
-      "deploy",
-      "smoke",
-      "logs",
-    ]);
-  });
-  it("--skip-logs drops only the logs step", () => {
+  it("--skip-logs drops only the logs step, keeping the deploy + smoke pair", () => {
     expect(planIosDeviceE2eSteps({ skipLogs: true }).map((s) => s.id)).toEqual([
       "deploy",
       "smoke",
-      "capture",
     ]);
-  });
-  it("keeps deploy + smoke even with both artifact steps skipped", () => {
-    expect(
-      planIosDeviceE2eSteps({ skipCapture: true, skipLogs: true }).map((s) => s.id),
-    ).toEqual(["deploy", "smoke"]);
   });
 });
 
@@ -76,7 +62,9 @@ describe("buildDeviceDeployCommand", () => {
     expect(args).toContain("ai.elizaos.app");
   });
   it("throws without a deviceId", () => {
-    expect(() => buildDeviceDeployCommand({ scriptsDir })).toThrow(/deviceId is required/);
+    expect(() => buildDeviceDeployCommand({ scriptsDir })).toThrow(
+      /deviceId is required/,
+    );
   });
 });
 
@@ -111,18 +99,6 @@ describe("buildDeviceSmokeCommand", () => {
     expect(() => buildDeviceSmokeCommand({ scriptsDir, deviceId })).toThrow(
       /outputDir is required/,
     );
-  });
-});
-
-describe("buildDeviceCaptureCommand", () => {
-  it("captures into the capture dir with --skip-build", () => {
-    const { args } = buildDeviceCaptureCommand({
-      scriptsDir,
-      deviceId,
-      outputDir: "/bundle/capture",
-    });
-    expect(args).toContain("--skip-build");
-    expect(args[args.indexOf("--output") + 1]).toBe("/bundle/capture");
   });
 });
 
@@ -174,8 +150,20 @@ describe("buildRunSummary", () => {
     const summary = buildRunSummary({
       ...base,
       steps: [
-        { id: "deploy", label: "d", status: "passed", durationMs: 10, artifacts: [] },
-        { id: "smoke", label: "s", status: "passed", durationMs: 20, artifacts: ["/a"] },
+        {
+          id: "deploy",
+          label: "d",
+          status: "passed",
+          durationMs: 10,
+          artifacts: [],
+        },
+        {
+          id: "smoke",
+          label: "s",
+          status: "passed",
+          durationMs: 20,
+          artifacts: ["/a"],
+        },
       ],
     });
     expect(summary.overallStatus).toBe("passed");
@@ -190,8 +178,20 @@ describe("buildRunSummary", () => {
     const summary = buildRunSummary({
       ...base,
       steps: [
-        { id: "deploy", label: "d", status: "passed", durationMs: 10, artifacts: [] },
-        { id: "smoke", label: "s", status: "failed", durationMs: 20, artifacts: [] },
+        {
+          id: "deploy",
+          label: "d",
+          status: "passed",
+          durationMs: 10,
+          artifacts: [],
+        },
+        {
+          id: "smoke",
+          label: "s",
+          status: "failed",
+          durationMs: 20,
+          artifacts: [],
+        },
       ],
     });
     expect(summary.overallStatus).toBe("failed");
@@ -205,6 +205,8 @@ describe("buildRunSummary", () => {
 
 describe("formatRunId", () => {
   it("produces a sortable YYYYMMDD-HHMMSS from a Date", () => {
-    expect(formatRunId(new Date("2026-07-05T13:04:09.000Z"))).toBe("20260705-130409");
+    expect(formatRunId(new Date("2026-07-05T13:04:09.000Z"))).toBe(
+      "20260705-130409",
+    );
   });
 });

--- a/packages/app/scripts/lib/ios-renderer-stamp.mjs
+++ b/packages/app/scripts/lib/ios-renderer-stamp.mjs
@@ -1,3 +1,18 @@
+/**
+ * Renderer build-stamp helpers for the iOS lanes: resolve the
+ * `eliza-renderer-build.json` stamp inside a staged/installed `App.app` and in
+ * the freshly built dist, read it as a typed manifest, and assert the two
+ * buildIds match. This is the single source of truth for the stale-UI guard
+ * (#9309): a Capacitor app bakes the web bundle into the `.app` at build time,
+ * so an install of a cached dist over a fresh one silently ships yesterday's UI
+ * unless the buildIds are compared before install.
+ *
+ * Consumed by the simulator smoke lanes (`ios-e2e`, `ios-onboarding-smoke`,
+ * `mobile-local-chat-smoke`) via the throwing `assertIosAppRendererFresh`, and
+ * by the physical-device deploy/e2e lane (`ios-device-deploy`, `ios-device-e2e`,
+ * `lib/ios-deploy-ledger`) which reuses the path/read helpers here and layers its
+ * own non-throwing freshness verdict on top.
+ */
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
@@ -30,6 +45,19 @@ export function freshRendererManifestPath({ repoRoot, rendererDist }) {
   );
 }
 
+/**
+ * Read + parse a renderer stamp, requiring a non-empty buildId (an unstamped
+ * build is not a usable manifest — throwing here keeps a consumer from treating
+ * it as fresh). Returns a normalized shape so callers get typed access to the
+ * fields the stamp carries (`commit`/`variant`/`runtimeMode` drive the
+ * deploy-ledger row; `builtAt` is echoed in freshness logs) rather than reaching
+ * into a raw JSON blob.
+ *
+ * @param {string} manifestPath
+ * @param {string} label
+ * @returns {{ buildId: string, commit: string | null, variant: string | null,
+ *            runtimeMode: string | null, builtAt: string | null }}
+ */
 export function readRendererManifest(manifestPath, label) {
   if (!fs.existsSync(manifestPath)) {
     throw new Error(`${label} renderer manifest is missing: ${manifestPath}`);
@@ -40,7 +68,14 @@ export function readRendererManifest(manifestPath, label) {
       `${label} renderer manifest has no buildId: ${manifestPath}`,
     );
   }
-  return parsed;
+  return {
+    buildId: parsed.buildId,
+    commit: typeof parsed.commit === "string" ? parsed.commit : null,
+    variant: typeof parsed.variant === "string" ? parsed.variant : null,
+    runtimeMode:
+      typeof parsed.runtimeMode === "string" ? parsed.runtimeMode : null,
+    builtAt: typeof parsed.builtAt === "string" ? parsed.builtAt : null,
+  };
 }
 
 export function compareRendererBuildIds({

--- a/packages/app/test/ios-renderer-stamp.test.ts
+++ b/packages/app/test/ios-renderer-stamp.test.ts
@@ -6,6 +6,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   assertIosAppRendererFresh,
   compareRendererBuildIds,
+  freshRendererManifestPath,
+  readRendererManifest,
   rendererManifestPathFromAppPath,
 } from "../scripts/lib/ios-renderer-stamp.mjs";
 
@@ -67,5 +69,80 @@ describe("iOS renderer stamp", () => {
       buildId: "same",
       builtAt: "later",
     });
+  });
+});
+
+describe("readRendererManifest", () => {
+  it("normalizes the stamp to typed buildId/commit/variant/runtimeMode/builtAt", () => {
+    const dir = tempDir();
+    const target = path.join(dir, "eliza-renderer-build.json");
+    writeFileSync(
+      target,
+      JSON.stringify({
+        buildId: "build-XYZ",
+        commit: "deadbeef",
+        variant: "device",
+        runtimeMode: "local",
+        builtAt: "2026-01-01T00:00:00Z",
+      }),
+    );
+    expect(readRendererManifest(target, "staged")).toEqual({
+      buildId: "build-XYZ",
+      commit: "deadbeef",
+      variant: "device",
+      runtimeMode: "local",
+      builtAt: "2026-01-01T00:00:00Z",
+    });
+  });
+
+  it("defaults absent optional fields to null (not the raw undefined)", () => {
+    const dir = tempDir();
+    const target = path.join(dir, "eliza-renderer-build.json");
+    writeFileSync(target, JSON.stringify({ buildId: "only-build-id" }));
+    expect(readRendererManifest(target, "staged")).toEqual({
+      buildId: "only-build-id",
+      commit: null,
+      variant: null,
+      runtimeMode: null,
+      builtAt: null,
+    });
+  });
+
+  it("throws on a missing manifest", () => {
+    const dir = tempDir();
+    expect(() =>
+      readRendererManifest(path.join(dir, "nope.json"), "staged"),
+    ).toThrow(/is missing/);
+  });
+
+  it("throws on a manifest with no buildId", () => {
+    const dir = tempDir();
+    const target = path.join(dir, "eliza-renderer-build.json");
+    writeFileSync(target, JSON.stringify({ commit: "x" }));
+    expect(() => readRendererManifest(target, "staged")).toThrow(
+      /has no buildId/,
+    );
+  });
+});
+
+describe("freshRendererManifestPath", () => {
+  it("honors an explicit dist override", () => {
+    expect(
+      freshRendererManifestPath({
+        repoRoot: "/repo",
+        rendererDist: "/custom/dist",
+      }),
+    ).toBe(path.join("/custom", "dist", "eliza-renderer-build.json"));
+  });
+  it("defaults to packages/app/dist under the repo root", () => {
+    expect(freshRendererManifestPath({ repoRoot: "/repo" })).toBe(
+      path.join(
+        "/repo",
+        "packages",
+        "app",
+        "dist",
+        "eliza-renderer-build.json",
+      ),
+    );
   });
 });


### PR DESCRIPTION
Closes #14337.

## What & why

`test:e2e:ios` is simulator-only. Running the app on a **plugged-in physical iPhone** took four separate commands with hand-carried flags, and nothing recorded what was deployed to which phone. This adds a single command that chains the three already-proven physical-iPhone scripts and writes a deploy ledger.

**New lane** (`packages/app/scripts/ios-device-e2e.mjs`, `bun run --cwd packages/app ios:device:e2e` / `test:e2e:ios:physical`):
1. `ios-device-deploy.mjs --skip-appexes` (default unattended posture, PR #13174) — build → sign → `devicectl install`. Widget/keyboard/device-activity surfaces are stripped and logged loudly.
2. **On-device BootCapture assertion** (`ios-device-capture.mjs --platform device`) — did the freshly deployed app boot to home or the error card? `mobile-local-chat-smoke` is simulator-only, so BootCapture is the on-device assertion of record. Its filmstrip attachments land in the bundle's `smoke/` — one on-device boot yields both the verdict and the watchable artifact (no separate capture boot).
3. `ios-device-logs.mjs --no-console --pull-boot-trace` — the only full-Bun engine-observability path (attached `--console` SIGTRAPs the no-JIT engine, #11515).

Each step's non-zero exit fails the lane non-zero; the **absolute bundle path is printed as the last stdout line** (contract with the issue — an agent posts the `smoke/` filmstrip + `logs/` boot-trace inline to the PR). Bundle shape (`summary.json` + `smoke/` + `logs/`) matches research doc 08 Q2/Q3.

**Deploy ledger + renderer-freshness assert** (`packages/app/scripts/lib/ios-deploy-ledger.mjs`, wired into `ios-device-deploy.mjs`):
- Before install: read the staged `App.app`'s renderer stamp (`public/eliza-renderer-build.json`) and **refuse a stale bundle** whose buildId ≠ freshly built dist (#9309 stale-UI footgun). `--allow-stale-renderer` is the explicit escape hatch. The deploy script had **zero** renderer/stale/fresh checks before this.
- After a successful install: append `{udid, buildId, commit, name, deployedAt, skippedAppexes, …}` to a state-dir JSONL ledger (`$MILADY_STATE_DIR`/`$ELIZA_STATE_DIR` → `~/.local/state/eliza/device-deploy-ledger.jsonl`). `devices:status` (#14338) reads it and honestly reports **"unknown — no ledger entry"** for a phone flashed by other means.

### Reconcile note
`lib/device-e2e-bundle.mjs` (issue #14336) is not on this base and is owned by a sibling PR. This lane ships a **minimal local bundle emitter** in `lib/ios-device-e2e-lib.mjs` matching research doc Q2's documented shape (`summary.json` schema `elizaos.device-e2e.summary/v1`, `smoke/`+`logs/`); it should be reconciled onto the shared lib when #14336 lands. I deliberately did **not** touch `android-e2e.mjs` or any shared bundle lib.

## Verification

<details><summary>New unit tests (41) + existing device-lib tests (97) — all green</summary>

```
$ bun run --cwd packages/app test (scoped to the three files)
 Test Files  3 passed (3)
      Tests  138 passed (138)
```
</details>

<details><summary>Ledger + renderer-stamp logic executed end-to-end against fixtures</summary>

```
ledger path (MILADY_STATE_DIR): /var/folders/.../device-deploy-ledger.jsonl
records written: 2
latest FRESH buildId for device: build-bbb222 commit facade
status known device: "build-bbb222"
status UNKNOWN device: unknown — no ledger entry (device was flashed by other means; cross-check with `ios:device:logs --pull-boot-trace`)
freshness match: true
freshness STALE: staged renderer buildId old != freshly built new — the device would bo…
```
</details>

<details><summary>Lane fails fast with no device (no hang)</summary>

```
$ node scripts/ios-device-e2e.mjs           # no --device, no ELIZA_IOS_DEVICE_ID
[ios-device-e2e] ERROR: no device given. Pass --device <devicectl-id|udid|name> or set ELIZA_IOS_DEVICE_ID.

$ node scripts/ios-device-e2e.mjs --device NONEXISTENT-DEVICE-XYZ
[ios-device-e2e] ERROR: device "NONEXISTENT-DEVICE-XYZ" not found via devicectl. List: xcrun devicectl list devices (pair the phone: Finder → device → Trust, and enable Developer Mode).
```
</details>

<details><summary>Scoped typecheck + biome — clean for touched files</summary>

```
$ tsgo --noEmit -p tsconfig.typecheck.json → 0 errors referencing the new files
  (pre-existing errors are unbuilt generated i18n data + an optional plugin, unrelated)
$ biome lint <5 new files> + ios-device-deploy.mjs → No fixes applied.
```
</details>

## Evidence

| Evidence | Status |
| --- | --- |
| Unit tests (ledger round-trip, unknown path, stamp fresh/stale, lane arg-construction) | ✅ 41 new tests, above |
| Ledger + stamp logic run against fixtures | ✅ stdout above |
| Fail-fast (no device / bogus device, no hang) | ✅ above |
| Scoped typecheck + lint | ✅ above |
| MP4 of the phone booting the freshly deployed app | ⛔ N/A — requires a plugged-in, unlocked, paired iPhone (unavailable headlessly). Owner runs on the fleet: `ELIZA_IOS_DEVICE_ID=<udid> bun run --cwd packages/app ios:device:e2e` and posts `<bundle>/smoke/**/*.mp4`. |
| JPG of `devices:status` showing the phone FRESH post-run | ⛔ N/A — depends on `devices:status` (#14338) + a real deploy on the fleet; this PR writes the ledger row it consumes. |
| Pulled boot-trace JSONL excerpt | ⛔ N/A — produced by step 4 on a real device; owner captures from `<bundle>/logs/boot-trace-*.jsonl` on the fleet. |
| Appex surfaces under `--skip-appexes` | ⛔ Untested by design — widget/keyboard/device-activity are stripped for unattended signing (research doc Q6); minting per-appex profiles needs an ASC API key (owner decision). |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

