### PR TITLE
fix(#14479): drop redundant Chat launcher tile; gate Relationships to Developer Mode

### DIFF
--- a/packages/ui/src/components/pages/launcher-curation.test.ts
+++ b/packages/ui/src/components/pages/launcher-curation.test.ts
@@ -92,7 +92,7 @@ describe("curateLauncherPages", () => {
     expect(ids(page)).toEqual(["settings", "wallet"]);
   });
 
-  it("drops removed apps and non-launcher shell surfaces", () => {
+  it("drops removed apps and non-launcher shell surfaces (incl. chat)", () => {
     const page = curateLauncherPages(
       [
         entry("wallet"),
@@ -110,7 +110,41 @@ describe("curateLauncherPages", () => {
       { isAosp: false, enabledKinds: ENABLED, cloudActive: true },
     );
 
-    expect(ids(page)).toEqual(["chat", "wallet"]);
+    // chat is the home surface — never a launcher tile (#14479).
+    expect(ids(page)).toEqual(["wallet"]);
+  });
+
+  it("never shows a chat launcher tile, even with Developer Mode on (#14479)", () => {
+    const page = curateLauncherPages(
+      [entry("chat"), entry("settings"), entry("wallet")],
+      { isAosp: false, enabledKinds: ENABLED, cloudActive: true },
+    );
+    expect(ids(page)).not.toContain("chat");
+    expect(ids(page)).toEqual(["settings", "wallet"]);
+  });
+
+  it("hides relationships by default, shows it only in Developer Mode (#14479)", () => {
+    const views = [entry("wallet"), entry("relationships"), entry("settings")];
+    // Default (no developer/preview): relationships is developer-gated → hidden.
+    expect(
+      ids(
+        curateLauncherPages(views, {
+          isAosp: false,
+          enabledKinds: APPS_ONLY,
+          cloudActive: true,
+        }),
+      ),
+    ).toEqual(["settings", "wallet"]);
+    // Developer Mode on: relationships reappears (kept, not deleted).
+    expect(
+      ids(
+        curateLauncherPages(views, {
+          isAosp: false,
+          enabledKinds: ENABLED,
+          cloudActive: true,
+        }),
+      ),
+    ).toContain("relationships");
   });
 
   it("keeps wallet-group sub-pages out of the launcher", () => {
@@ -366,18 +400,16 @@ describe("curateLauncherPages — full realistic view set", () => {
         }),
       ),
     ).toEqual([
-      "chat",
+      // chat is the home surface — no launcher tile (#14479).
       "settings",
       "wallet",
       "tasks",
       "automations",
       "browser",
       "character",
-      "relationships",
       "documents",
       "character-skills",
       "experience",
-      "transcripts",
       "memories",
       "feed",
       "stream",
@@ -388,6 +420,8 @@ describe("curateLauncherPages — full realistic view set", () => {
       "skills",
       "plugins",
       "fine-tuning",
+      // relationships is developer-gated (#14479) — shows in the dev section.
+      "relationships",
     ]);
   });
 
@@ -401,27 +435,23 @@ describe("curateLauncherPages — full realistic view set", () => {
         }),
       ),
     ).toEqual([
-      "chat",
+      // chat + relationships are not everyday grid tiles (#14479).
       "settings",
       "wallet",
       "tasks",
       "automations",
       "browser",
       "character",
-      "relationships",
       "documents",
       "character-skills",
       "experience",
-      "transcripts",
       "memories",
     ]);
   });
 
-  it("forces feed/stream to preview and fine-tuning to developer regardless of declared kind", () => {
-    // Preview on, developer off: the preview surfaces come back, the training
-    // UI stays hidden (it is developer, not preview). Relationships is now an
-    // everyday tile (promoted out of the character hub), so it is present in
-    // every profile — not gated on preview.
+  it("forces feed/stream to preview and fine-tuning + relationships to developer regardless of declared kind", () => {
+    // Preview on, developer off: the preview surfaces come back, the training UI
+    // and relationships stay hidden (they are developer-gated, not preview).
     const previewOnly = ids(
       curateLauncherPages(REAL_VIEWS, {
         isAosp: false,
@@ -429,15 +459,15 @@ describe("curateLauncherPages — full realistic view set", () => {
         cloudActive: true,
       }),
     );
-    for (const id of ["feed", "stream", "relationships"]) {
+    for (const id of ["feed", "stream"]) {
       expect(previewOnly).toContain(id);
     }
     expect(previewOnly).not.toContain("fine-tuning");
     expect(previewOnly).not.toContain("trajectories");
+    expect(previewOnly).not.toContain("relationships");
 
-    // Developer on, preview off: the training UI shows with the dev tools, the
-    // preview surfaces (feed/stream) stay hidden. Relationships still shows — it
-    // is a normal everyday tile, not preview-gated.
+    // Developer on, preview off: the training UI + relationships show with the
+    // dev tools, the preview surfaces (feed/stream) stay hidden.
     const developerOnly = ids(
       curateLauncherPages(REAL_VIEWS, {
         isAosp: false,
@@ -595,13 +625,13 @@ describe("normalizeLauncherLabel", () => {
   it("is applied to curated tile labels so a spaced registration renders normalized", () => {
     const page = curateLauncherPages(
       [
-        entry("chat", { label: "  Chat  " }),
+        entry("settings", { label: "  Settings  " }),
         entry("wallet", { label: "Wallet" }),
       ],
       { isAosp: false, enabledKinds: ENABLED, cloudActive: true },
     );
-    const chat = page.find((e) => e.id === "chat");
-    expect(chat?.label).toBe("Chat");
+    const settings = page.find((e) => e.id === "settings");
+    expect(settings?.label).toBe("Settings");
   });
 });
 

--- a/packages/ui/src/components/pages/launcher-curation.ts
+++ b/packages/ui/src/components/pages/launcher-curation.ts
@@ -35,7 +35,10 @@ import { getInternalToolAppTargetTab } from "../apps/internal-tool-apps";
 /** Everyday apps, in display order. They lead the single launcher page; other
  *  loaded apps append after (alphabetically). */
 export const LAUNCHER_APPS_ORDER: readonly string[] = [
-  "chat",
+  // `chat` is intentionally NOT here — chat is the app's home/primary surface,
+  // so a launcher tile for it is pure redundancy; it lives in
+  // LAUNCHER_HIDDEN_IDS instead (#14479). The home chat + default landing are
+  // untouched.
   "settings",
   "wallet",
   "tasks",
@@ -43,7 +46,8 @@ export const LAUNCHER_APPS_ORDER: readonly string[] = [
   "browser",
   // Character family — the old single Character hub, split into top-level tiles.
   "character",
-  "relationships",
+  // `relationships` moved to LAUNCHER_DEVELOPER_ORDER (#14479) — empty in the
+  // MVP, so hidden from the default grid but still reachable in Developer Mode.
   "documents",
   "character-skills",
   "experience",
@@ -52,9 +56,13 @@ export const LAUNCHER_APPS_ORDER: readonly string[] = [
   "stream",
 ];
 
-/** Developer tools, in display order. Shown on the same launcher page after the
- *  apps, only when Developer Mode is on. `fine-tuning` (model training) is a
- *  developer surface, not an everyday app — it hides with the rest of the set. */
+/** Developer-gated launcher surfaces, in display order. Shown on the same
+ *  launcher page after the apps, only when Developer Mode is on. Mostly tools
+ *  (trajectory viewer, database, runtime, logs, skills, plugins) plus
+ *  `fine-tuning` (model training, a developer surface not an everyday app) and
+ *  `relationships` — a real view that renders empty in the MVP (#14479), so it
+ *  is developer-gated (hidden from the everyday grid) but kept and reachable,
+ *  not deleted. The whole set hides together under the Developer Mode toggle. */
 export const LAUNCHER_DEVELOPER_ORDER: readonly string[] = [
   "trajectories",
   "database",
@@ -63,6 +71,7 @@ export const LAUNCHER_DEVELOPER_ORDER: readonly string[] = [
   "skills",
   "plugins",
   "fine-tuning",
+  "relationships",
 ];
 
 /**
@@ -100,6 +109,9 @@ export const LAUNCHER_HIDDEN_IDS: ReadonlySet<string> = new Set([
   "voice",
   "character-select",
   "desktop",
+  // `chat` is the home/primary surface, not a launcher tile — a Chat tile is
+  // pure redundancy next to the always-present home chat (#14479).
+  "chat",
   // Removed apps.
   "companion",
   "model-tester",


### PR DESCRIPTION
## What

Closes **#14479** — two chat-first launcher cleanups (research `04-onboarding-tutorial-help.md`: everything happens in chat; views assist in the background; simplify over add).

1. **Remove the redundant "Chat" launcher tile.** Chat is the app's home/primary surface, so a Chat tile duplicates the always-present home chat. Removed `chat` from `LAUNCHER_APPS_ORDER` and added it to `LAUNCHER_HIDDEN_IDS`, so `curateLauncherPages` never emits it. The default landing (`resolveDefaultLandingTab` → `"chat"`) and the home/floating chat are **untouched** — this only drops the redundant tile.
2. **Gate "Relationships" to Developer Mode** (hidden, not deleted). It renders empty in the MVP, so it moved from the everyday apps to `LAUNCHER_DEVELOPER_ORDER` — hidden from the default grid, shown only when Developer Mode is on, still fully reachable via its route.

## Evidence — pure-function curation, GREEN

The launcher renders from `curateLauncherPages` (`LauncherSurface`), a pure function fully covered by unit tests.

<details><summary>launcher-curation.test.ts (35) + Launcher.test.tsx + navigation (27) — all pass</summary>

```
 launcher-curation.test.ts   35 passed (35)
 Launcher.test.tsx + navigation/index.test.ts   27 passed (27)
```
New cases:
- `never shows a chat launcher tile, even with Developer Mode on (#14479)` — asserts `chat` is absent from the curated page in every profile.
- `hides relationships by default, shows it only in Developer Mode (#14479)` — absent with dev off, present with dev on (kept, not deleted).
- The full-realistic-layout expectations are updated for the two moves. (Also corrected a **pre-existing** stale `transcripts` expectation — it canonicalizes onto `documents` via the alias table, so it was never a separate tile; the assertion was already red on `develop`.)
</details>

## Evidence rows

| Evidence | Status |
| --- | --- |
| Curation unit tests (real pure function) | ✅ 35 + 27 pass |
| Before/after launcher screenshots | N/A - the launcher tile set is a pure list computed by `curateLauncherPages`; presence/absence of the `chat` and `relationships` tiles is exactly what the unit tests assert (a screenshot would render precisely that list). Chat/home surface unchanged (`resolveDefaultLandingTab` untouched). |

Closes #14479.