### PR TITLE
chore(chat): fix latent-broken chat gesture + onboarding smoke assertions (#14332)

### DIFF
--- a/packages/app/test/ui-smoke/chat-thread-gestures.spec.ts
+++ b/packages/app/test/ui-smoke/chat-thread-gestures.spec.ts
@@ -11,9 +11,10 @@
 //   3. ArrowDown on the restore zone → same restore path (WCAG 2.1.1 operable).
 //   4. Escape from MAXIMIZED collapses the WHOLE sheet (not a restore) — the
 //      documented back/Escape semantics.
-//   5. REMOVAL guards: no `chat-full-clear` / `chat-full-maximize` control
-//      anywhere, and a horizontal drag on the OPEN thread does NOT switch
-//      conversations (swipe-to-switch removed; `swipeEnabled: !sheetOpen`).
+//   5. Header contract: the live new-chat control remains present, the removed
+//      maximize button stays absent, and a horizontal drag on the OPEN thread
+//      does NOT switch conversations (swipe-to-switch removed;
+//      `swipeEnabled: !sheetOpen`).
 //
 // The conversation is mocked statefully at the network layer for determinism.
 // Record a video with E2E_RECORD=1.
@@ -98,7 +99,7 @@ async function installConversationRoutes(page: Page): Promise<void> {
   });
 
   await page.route(
-    `**/api/conversations/${CONVERSATION_ID}/messages`,
+    `**/api/conversations/${CONVERSATION_ID}/messages**`,
     async (route) => {
       if (route.request().method() === "GET") {
         await route.fulfill({
@@ -149,6 +150,45 @@ async function pointerDrag(
     await page.mouse.move(cx + (dx * i) / steps, cy + (dy * i) / steps);
   }
   await page.mouse.up();
+}
+
+async function cdpTouchDrag(
+  page: Page,
+  selector: string,
+  dx: number,
+  dy: number,
+  steps = 20,
+  startXRatio = 0.5,
+  startYRatio = 0.5,
+): Promise<void> {
+  const box = await page.locator(selector).first().boundingBox();
+  if (!box) throw new Error(`no bounding box for ${selector}`);
+  const cx = box.x + box.width * startXRatio;
+  const cy = box.y + box.height * startYRatio;
+  const client = await page.context().newCDPSession(page);
+  try {
+    await client.send("Emulation.setTouchEmulationEnabled", {
+      enabled: true,
+      maxTouchPoints: 1,
+    });
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchStart",
+      touchPoints: [{ x: cx, y: cy }],
+    });
+    for (let i = 1; i <= steps; i += 1) {
+      await client.send("Input.dispatchTouchEvent", {
+        type: "touchMove",
+        touchPoints: [{ x: cx + (dx * i) / steps, y: cy + (dy * i) / steps }],
+      });
+      await page.waitForTimeout(6);
+    }
+    await client.send("Input.dispatchTouchEvent", {
+      type: "touchEnd",
+      touchPoints: [],
+    });
+  } finally {
+    await client.detach();
+  }
 }
 
 /** Drive a genuine finger drag on `selector` by (dx, dy) via CDP touch. */
@@ -360,21 +400,22 @@ test("Escape from maximized collapses the whole sheet (not just restore)", async
   await expectNoPageDiagnostics(page, testInfo.title);
 });
 
-test("removed controls: no clear/maximize header buttons and no swipe-to-switch on the open thread", async ({
+test("header controls: new-chat exists, maximize is removed, and open-thread swipe does not switch", async ({
   page,
 }, testInfo) => {
   await openAppPath(page, "/chat");
   await openSheetToFull(page);
   const sheet = page.locator(SHEET);
 
-  // The removed single-thread controls (#13531) exist nowhere in the shell.
-  await expect(page.getByTestId("chat-full-clear")).toHaveCount(0);
+  // The new-chat control was restored after #13531; only the maximize button is
+  // genuinely removed because over-pull owns full-bleed maximize.
+  await expect(page.getByTestId("chat-full-clear")).toHaveCount(1);
   await expect(page.getByTestId("chat-full-maximize")).toHaveCount(0);
 
   // A horizontal drag across the OPEN thread must NOT switch conversations —
   // swipe-between-chats was removed (`swipeEnabled: !sheetOpen`).
   const convBefore = await sheet.getAttribute("data-conversation-id");
-  await pointerDrag(page, "#continuous-thread", -200, 0, 14);
+  await cdpTouchDrag(page, "#continuous-thread", -200, 0, 14, 0.9, 0.35);
   await page.waitForTimeout(500);
   await expect(sheet).toHaveAttribute("data-conversation-id", convBefore ?? "");
   await expect(page.getByText(LAST_TEXT)).toBeVisible();

--- a/packages/app/test/ui-smoke/helpers.ts
+++ b/packages/app/test/ui-smoke/helpers.ts
@@ -1748,6 +1748,22 @@ function smokeDatabaseQuery(sql: string) {
 
 /** Installs baseline API routes for smoke tests before flow-specific overrides. */
 export async function installDefaultAppRoutes(page: Page): Promise<void> {
+  await page.route("**/build-info.json", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        generatedAt: SMOKE_GENERATED_AT,
+        commit: "ui-smoke",
+        branch: "ui-smoke",
+      }),
+    });
+  });
+
   await page.route(/\/(?:brand|app-heroes)\//, async (route) => {
     if (await fulfillPublicAsset(route)) return;
     await route.fallback();

--- a/packages/app/test/ui-smoke/walkthrough/walkthrough-capture-smoke.spec.ts
+++ b/packages/app/test/ui-smoke/walkthrough/walkthrough-capture-smoke.spec.ts
@@ -97,7 +97,7 @@ async function installWalkthroughConversationStore(page: Page): Promise<void> {
   });
 
   await page.route(
-    "**/api/conversations/walkthrough-conversation/messages",
+    "**/api/conversations/walkthrough-conversation/messages**",
     async (route) => {
       if (route.request().method() === "GET") {
         await fulfillJson(route, 200, { messages });
@@ -227,7 +227,9 @@ test.describe("walkthrough capture smoke", () => {
     const onboarding = page.getByTestId("continuous-chat-overlay");
     await expect(onboarding).toBeVisible({ timeout: 20_000 });
     await expect(
-      page.getByText("First, where should your agent run?", { exact: false }),
+      page.getByText("Sign in to Eliza Cloud and I'll get you set up.", {
+        exact: false,
+      }),
     ).toBeVisible({ timeout: 15_000 });
     await expect(page.getByTestId("first-run-runtime-chooser")).toHaveCount(0);
     await expect(
@@ -235,12 +237,10 @@ test.describe("walkthrough capture smoke", () => {
     ).toBeVisible();
     await expect(
       page.getByTestId("choice-__first_run__:runtime:local"),
-    ).toBeVisible();
-    // Remote (connect to an existing agent) is the third location chip.
+    ).toHaveCount(0);
     await expect(
       page.getByTestId("choice-__first_run__:runtime:remote"),
-    ).toBeVisible();
-    // runtime:other ("Bring your own keys") stays removed as a location (#11509).
+    ).toHaveCount(0);
     await expect(
       page.getByTestId("choice-__first_run__:runtime:other"),
     ).toHaveCount(0);
@@ -253,6 +253,11 @@ test.describe("walkthrough capture smoke", () => {
     await openAppPath(page, "/chat");
     const overlay = page.getByTestId("continuous-chat-overlay");
     await expect(overlay).toBeVisible({ timeout: 60_000 });
+    const setupSkip = page.getByRole("button", { name: "Skip for now" });
+    if (await setupSkip.isVisible().catch(() => false)) {
+      await setupSkip.click();
+      await expect(setupSkip).toBeHidden({ timeout: 10_000 });
+    }
     await captureState(page, testInfo, "walkthrough-02-chat-ready.png");
 
     const composer = page.locator(CHAT_COMPOSER_SELECTOR).first();


### PR DESCRIPTION
Follow-up to #14332 (parent PR #14455 already **merged** as `cedf65ba79c`, which rewrote `journey.ts` + `walkthrough-capture-smoke.spec.ts` step-09 to reach the FULL detent via the pull gesture instead of the removed `chat-full-maximize` button).

This PR finishes the cleanup by repairing two **latent-broken, un-gated** ui-smoke specs whose assertions had drifted from live behavior — they aren't named in any active workflow lane, so the contradictions merged to develop unnoticed.

## What was wrong on develop

1. **`chat-thread-gestures.spec.ts:371` asserted the LIVE new-chat control absent.** `chat-full-clear` is a shipped header "new chat" button (`ContinuousChatOverlay.tsx:4211`, `RotateCcw` → `clearConversation`), re-added after #13531 per #14279. The unit suite (`ContinuousChatOverlay.test.tsx:2518`) and `chat-clear-swipe.spec.ts:262` both assert it **present** (`toHaveCount(1)`), but this spec still asserted `toHaveCount(0)` — the exact unit-vs-e2e contradiction #14332 was filed to remove. Would fail the moment the spec ran.
2. **`walkthrough-capture-smoke.spec.ts` asserted the removed runtime-chooser onboarding.** Develop ships **cloud-only onboarding** (#13377): `isRuntimeChooserEnabled()` is `false` by default everywhere, so first-run shows `CLOUD_SIGN_IN_GREETING` ("Sign in to Eliza Cloud and I'll get you set up.") with only the `runtime:cloud` chip — the `runtime:local` / `runtime:remote` chips do not render. The spec still expected the old "where should your agent run?" copy with local/remote chips visible.

## Change (test-only)

- `chat-thread-gestures.spec.ts`: `chat-full-clear` → `toHaveCount(1)` (present); rename the guard test to the accurate "new-chat exists, maximize removed, open-thread swipe does not switch"; drive the swipe-no-switch check with a real **CDP touch** drag (`cdpTouchDrag`) instead of a mouse drag; widen the mocked messages route glob to match query params (`…/messages**`).
- `walkthrough-capture-smoke.spec.ts`: assert the live cloud-only onboarding copy + absent local/remote chips; add a defensive tutorial "Skip for now" click so the flow proceeds; same route-glob widening.
- `helpers.ts`: stub `/build-info.json` in `installDefaultAppRoutes` so `BuildBadge`'s fetch is deterministic in smoke runs.

Net: `chat-full-maximize` now appears **only** as absence-assertions (`toHaveCount(0)` / `toBeNull()` / `.count()===0`) + explanatory comments; `verticalScrollPriority` stays grep-clean (removed on develop via #14473). No production/gesture behavior touched.

## Evidence

**grep — `chat-full-clear` in `chat-thread-gestures.spec.ts`:**
```
develop (WRONG — live control asserted absent):
  371:  await expect(page.getByTestId("chat-full-clear")).toHaveCount(0);
branch (FIXED):
  412:  await expect(page.getByTestId("chat-full-clear")).toHaveCount(1);
```

**grep — `chat-full-maximize` (source, post-change): only absence-asserts + docs, no driver:**
```
chat-thread-gestures.spec.ts:413      toHaveCount(0)      (absence assert)
ContinuousChatOverlay.test.tsx:2505   toBeNull()          (absence assert)
run-chat-sheet-e2e.mjs:331,354        .count() === 0      (absence assert)
walkthrough-capture-smoke.spec.ts:183 comment (doc)
journey.ts:634                        comment (doc)
```

**grep — `verticalScrollPriority` in `packages/{ui/src,app/src,app/test}`:** _(none — grep-clean)_

**Live-source cross-checks:**
- `chat-full-clear` rendered: `ContinuousChatOverlay.tsx:4211`.
- Cloud-only onboarding copy `CLOUD_SIGN_IN_GREETING`: `use-first-run-conductor.ts:90`; chooser off by default: `first-run-runtime-flag.ts` (`isRuntimeChooserEnabled()` returns build default `false`).
- `Skip for now` affordance real: `use-first-run-conductor.ts:201` (`tutorial:skip`).
- `/build-info.json` consumer real: `BuildBadge.tsx:24`.

`biome check` on the 3 touched files: clean.

**Local full-app Playwright run: N/A** — the dev host is at 100% disk (ENOSPC on the workspace build), so the app dist cannot rebuild locally; authoritative execution is CI. Real-LLM trajectory + device capture: **N/A** (test-only cleanup — no agent/model/prompt/native path touched).

Closes #14332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
