### PR TITLE
fix(launcher): wallet widget to doctrine — BTC/SOL/ETH baseline + 60s refresh (#14344)

### DIFF
--- a/packages/ui/src/components/chat/widgets/wallet-balance.test.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.test.tsx
@@ -1,14 +1,17 @@
 // @vitest-environment jsdom
 //
-// WalletBalanceWidget (price-only): loading placeholder until data resolves,
-// price-only rows for held assets (no amounts/holding value), skipping holdings
-// under $1, self-hide on empty balances, and opening the wallet view on tap.
-// jsdom render with the wallet balances/market API mocked (no backend).
+// WalletBalanceWidget (price-only, #10706 + #14344 doctrine): loading placeholder
+// until data resolves; top-3 held rows (no amounts/holding value) when the account
+// holds priced assets; the BTC/SOL/ETH baseline when it holds nothing or balances
+// are unavailable; self-hide ONLY when both endpoints fail; a 60s visibility-gated
+// price refresh; and opening the wallet view on tap. jsdom render with the wallet
+// balances/market API mocked (no backend).
 import type {
   WalletBalancesResponse,
   WalletMarketOverviewResponse,
 } from "@elizaos/shared";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -95,6 +98,15 @@ function overview(
   } as unknown as WalletMarketOverviewResponse;
 }
 
+/** Override jsdom's document visibility so the refresh gate can be exercised. */
+function setVisibility(state: "visible" | "hidden"): void {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
 beforeEach(() => {
   authMock.authenticated = true;
   navOpenView.mockReset();
@@ -106,6 +118,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  setVisibility("visible");
 });
 
 describe("WalletBalanceWidget (price-only, #10706)", () => {
@@ -151,20 +164,55 @@ describe("WalletBalanceWidget (price-only, #10706)", () => {
     expect(text).not.toContain("2,000");
   });
 
-  it("skips holdings under $1 and renders nothing when none qualify", async () => {
+  it("shows the BTC/SOL/ETH baseline when the account holds nothing priced", async () => {
+    // Dust-only holdings + empty overview earlier rendered nothing; doctrine
+    // (#14344) now shows the fixed baseline once the overview loads it.
     getWalletBalances.mockResolvedValue(
       balances([{ symbol: "SHIB", valueUsd: "0.40" }]),
     );
     getWalletMarketOverview.mockResolvedValue(
-      overview([{ symbol: "SHIB", priceUsd: 0.00001 }]),
+      overview([
+        { symbol: "BTC", priceUsd: 64000, change24hPct: -0.5 },
+        { symbol: "SOL", priceUsd: 150, change24hPct: 2.2 },
+        { symbol: "ETH", priceUsd: 3000, change24hPct: 1.1 },
+      ]),
     );
-    const { container } = render(<WalletBalanceWidget />);
-    await waitFor(() => expect(getWalletBalances).toHaveBeenCalled());
-    await waitFor(() => expect(container.firstChild).toBeNull());
+    render(<WalletBalanceWidget />);
+    await waitFor(() =>
+      expect(screen.getByTestId("chat-widget-wallet-prices")).toBeTruthy(),
+    );
+    const rows = screen.getAllByTestId(/^wallet-price-row-/);
+    expect(rows.map((r) => r.dataset.testid)).toEqual([
+      "wallet-price-row-BTC",
+      "wallet-price-row-SOL",
+      "wallet-price-row-ETH",
+    ]);
   });
 
-  it("renders nothing when balances are empty", async () => {
-    getWalletBalances.mockResolvedValue({ evm: null, solana: null });
+  it("shows the baseline when balances fail but the overview loads", async () => {
+    getWalletBalances.mockRejectedValue(new Error("balances down"));
+    getWalletMarketOverview.mockResolvedValue(
+      overview([
+        { symbol: "BTC", priceUsd: 64000 },
+        { symbol: "SOL", priceUsd: 150 },
+        { symbol: "ETH", priceUsd: 3000 },
+      ]),
+    );
+    render(<WalletBalanceWidget />);
+    await waitFor(() =>
+      expect(screen.getByTestId("chat-widget-wallet-prices")).toBeTruthy(),
+    );
+    const rows = screen.getAllByTestId(/^wallet-price-row-/);
+    expect(rows.map((r) => r.dataset.testid)).toEqual([
+      "wallet-price-row-BTC",
+      "wallet-price-row-SOL",
+      "wallet-price-row-ETH",
+    ]);
+  });
+
+  it("renders nothing (no error chrome) when BOTH endpoints fail", async () => {
+    getWalletBalances.mockRejectedValue(new Error("balances down"));
+    getWalletMarketOverview.mockRejectedValue(new Error("overview down"));
     const { container } = render(<WalletBalanceWidget />);
     await waitFor(() => expect(getWalletBalances).toHaveBeenCalled());
     await waitFor(() => expect(container.firstChild).toBeNull());
@@ -183,5 +231,56 @@ describe("WalletBalanceWidget (price-only, #10706)", () => {
     );
     fireEvent.click(screen.getByTestId("chat-widget-wallet-prices"));
     expect(navOpenView).toHaveBeenCalledWith("/wallet", "wallet");
+  });
+});
+
+describe("WalletBalanceWidget price refresh (visibility-gated 60s, #14344)", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("refetches every 60s while visible and updates displayed prices", async () => {
+    getWalletBalances.mockResolvedValue({ evm: null, solana: null });
+    getWalletMarketOverview
+      .mockResolvedValueOnce(overview([{ symbol: "BTC", priceUsd: 64000 }]))
+      .mockResolvedValue(overview([{ symbol: "BTC", priceUsd: 70000 }]));
+
+    render(<WalletBalanceWidget />);
+    // Flush the initial mount load.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(getWalletMarketOverview).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByTestId("chat-widget-wallet-prices").textContent,
+    ).toContain("$64,000.00");
+
+    // One interval tick → refetch + re-render with the new price.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(getWalletMarketOverview).toHaveBeenCalledTimes(2);
+    expect(
+      screen.getByTestId("chat-widget-wallet-prices").textContent,
+    ).toContain("$70,000.00");
+  });
+
+  it("does not poll while the document is hidden", async () => {
+    setVisibility("hidden");
+    getWalletBalances.mockResolvedValue({ evm: null, solana: null });
+    getWalletMarketOverview.mockResolvedValue(
+      overview([{ symbol: "BTC", priceUsd: 64000 }]),
+    );
+
+    render(<WalletBalanceWidget />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    // The initial mount load still fires once; the interval never starts.
+    expect(getWalletMarketOverview).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(180_000);
+    });
+    expect(getWalletMarketOverview).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/ui/src/components/chat/widgets/wallet-balance.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.tsx
@@ -1,27 +1,38 @@
 /**
  * WALLET home widget. A glanceable, chromeless tile on the orange home field
- * listing the top cryptocurrencies the user HOLDS by **unit price only** — never
- * the amount held or the holding value (#10706). Tapping opens the wallet view.
+ * listing cryptocurrencies by **unit price only** — never the amount held or
+ * the holding value (#10706). Tapping opens the wallet view.
  *
- * Holdings-gated: when there is no qualifying priced holding (nothing held worth
- * ≥ $1 that also has a market price), the widget renders nothing rather than a
- * connect affordance — an empty wallet is not actionable here.
+ * Doctrine (#14344): the widget is a resting-home keeper, so it shows the user's
+ * top-3 priced holdings when they hold ≥1 qualifying asset (≥ $1 with a market
+ * price), and otherwise the BTC/SOL/ETH baseline — it does not hide on an empty
+ * wallet. Prices are refreshed on a 60s visibility-gated interval (the
+ * market-overview route is cached server-side, so the poll is cheap). The tile
+ * self-hides ONLY when both the balances and overview endpoints are
+ * unavailable; the wallet view itself owns the visible error state (J4).
  */
 
-import type { WalletBalancesResponse } from "@elizaos/shared";
+import type {
+  WalletBalancesResponse,
+  WalletMarketOverviewResponse,
+} from "@elizaos/shared";
 import { Wallet } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { client } from "../../../api";
 import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
+import { useIntervalWhenDocumentVisible } from "../../../hooks/useDocumentVisibility";
 import type { WidgetProps } from "../../../widgets/types";
 import { Button } from "../../ui/button";
 import { useWidgetNavigation } from "./home-widget-card";
 import {
   type PricedHolding,
-  selectPricedHoldings,
+  selectWalletWidgetRows,
 } from "./wallet-price-holdings";
 
 const DEFAULT_SPAN = "col-span-2 row-span-1";
+
+/** Price refresh cadence while the home is foregrounded (server cache = 120s). */
+const WALLET_REFRESH_INTERVAL_MS = 60_000;
 
 /** Format a unit price: more decimals for sub-dollar assets, 2 for the rest. */
 function formatPrice(priceUsd: number): string {
@@ -51,45 +62,52 @@ export function WalletBalanceWidget(
   props: Partial<WidgetProps>,
 ): React.JSX.Element | null {
   const spanClassName = props.spanClassName ?? DEFAULT_SPAN;
-  const [holdings, setHoldings] = useState<PricedHolding[] | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [rows, setRows] = useState<PricedHolding[] | null>(null);
+  const [loaded, setLoaded] = useState(false);
   const nav = useWidgetNavigation();
   // Auth gate (#11084): the widget mounts before the auth probe resolves, so
-  // the one-shot balances/prices fetch must stay dormant until the session is
+  // the balances/overview fetch must stay dormant until the session is
   // authenticated (it fires once the phase flips).
   const authenticated = useIsAuthenticated();
+  // Guards against a state write after unmount when a poll is in flight.
+  const activeRef = useRef(true);
+  useEffect(() => {
+    activeRef.current = true;
+    return () => {
+      activeRef.current = false;
+    };
+  }, []);
+
+  const load = useCallback(async () => {
+    // The two endpoints fail independently: a balances outage still leaves the
+    // BTC/SOL/ETH baseline from the overview, and vice versa. selectWalletWidgetRows
+    // returns [] only when both are null, which is the sole self-hide case.
+    // error-policy:J4 designed home-surface degrade — the wallet view owns the
+    // visible error state; the home tile never renders error chrome.
+    const [balances, overview] = await Promise.all([
+      client
+        .getWalletBalances()
+        .catch(() => null) as Promise<WalletBalancesResponse | null>,
+      client
+        .getWalletMarketOverview()
+        .catch(() => null) as Promise<WalletMarketOverviewResponse | null>,
+    ]);
+    if (!activeRef.current) return;
+    setRows(selectWalletWidgetRows(balances, overview));
+    setLoaded(true);
+  }, []);
 
   useEffect(() => {
     if (!authenticated) return;
-    let cancelled = false;
-    void (async () => {
-      try {
-        // Prices come from a separate endpoint; fetch both together. The widget
-        // shows prices only, so a balances failure means "nothing to show".
-        const [balances, overview] = await Promise.all([
-          client.getWalletBalances() as Promise<WalletBalancesResponse>,
-          // error-policy:J4 prices are the widget's optional decoration; the
-          // hide-on-failure degrade below covers a missing overview too
-          client.getWalletMarketOverview().catch(() => null),
-        ]);
-        if (cancelled) return;
-        setHoldings(selectPricedHoldings(balances, overview?.prices));
-      } catch {
-        // error-policy:J4 home-grid tiles self-hide rather than surface error
-        // chrome (designed home-surface degrade); the wallet page itself owns
-        // the visible error state for a broken balances endpoint.
-        if (!cancelled) setHoldings(null);
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [authenticated]);
+    void load();
+  }, [authenticated, load]);
+
+  useIntervalWhenDocumentVisible(() => {
+    if (authenticated) void load();
+  }, WALLET_REFRESH_INTERVAL_MS);
 
   // First load pending: a quiet placeholder keeps the grid cell stable.
-  if (loading && holdings == null) {
+  if (!loaded && rows == null) {
     return (
       <div
         data-testid="chat-widget-wallet-balance-loading"
@@ -99,13 +117,13 @@ export function WalletBalanceWidget(
     );
   }
 
-  // Holdings-gated empty: no qualifying priced holding → render nothing.
-  if (!holdings || holdings.length === 0) return null;
+  // Both endpoints unavailable → nothing to show; self-hide without error chrome.
+  if (!rows || rows.length === 0) return null;
 
   return (
     <Button
       data-testid="chat-widget-wallet-prices"
-      aria-label={`Wallet prices: ${holdings
+      aria-label={`Wallet prices: ${rows
         .map((h) => `${h.symbol} ${formatPrice(h.priceUsd)}`)
         .join(", ")}. Open wallet.`}
       onClick={() => nav.openView("/wallet", "wallet")}
@@ -116,7 +134,7 @@ export function WalletBalanceWidget(
         <Wallet />
         Wallet
       </span>
-      {holdings.map((h) => {
+      {rows.map((h) => {
         const change = formatChange(h.change24hPct);
         return (
           <span

--- a/packages/ui/src/components/chat/widgets/wallet-price-holdings.test.ts
+++ b/packages/ui/src/components/chat/widgets/wallet-price-holdings.test.ts
@@ -1,9 +1,13 @@
-// `selectPricedHoldings` selection logic: empty on missing balances, price-only
-// rows with no amount/holding value leaked, dust (<$1) skipped, capped at the top
-// 5 by holding value, only priced symbols included, same symbol aggregated across
-// chains (case-insensitive), native SOL/ETH counted. Pure function — no jsdom.
+// Wallet-widget row selection: `selectPricedHoldings` (held path — empty on
+// missing balances, price-only rows with no amount/holding value leaked, dust
+// (<$1) skipped, capped at the top 3 by holding value, only priced symbols
+// included, same symbol aggregated across chains, native SOL/ETH counted);
+// `selectDefaultPriceRows` (BTC/SOL/ETH baseline + trending fill); and
+// `selectWalletWidgetRows` (the doctrine composition, #14344). Pure — no jsdom.
 import type {
   WalletBalancesResponse,
+  WalletMarketMover,
+  WalletMarketOverviewResponse,
   WalletMarketPriceSnapshot,
 } from "@elizaos/contracts";
 import { describe, expect, it } from "vitest";
@@ -11,7 +15,9 @@ import {
   MAX_PRICED_HOLDINGS,
   MIN_HOLDING_USD,
   type PricedHolding,
+  selectDefaultPriceRows,
   selectPricedHoldings,
+  selectWalletWidgetRows,
 } from "./wallet-price-holdings.ts";
 
 /**
@@ -112,7 +118,7 @@ describe("selectPricedHoldings", () => {
     expect(MIN_HOLDING_USD).toBe(1);
   });
 
-  it("caps the list at the top 5 by holding value (ranked desc)", () => {
+  it("caps the list at the top 3 by holding value (ranked desc)", () => {
     const held = [
       { symbol: "A", valueUsd: "10" },
       { symbol: "B", valueUsd: "60" },
@@ -127,8 +133,9 @@ describe("selectPricedHoldings", () => {
       held.map((h) => price(h.symbol, 1)),
     );
     expect(rows).toHaveLength(MAX_PRICED_HOLDINGS);
-    // top 5 by value: G(70) B(60) D(50) F(40) C(30)
-    expect(rows.map((r) => r.symbol)).toEqual(["G", "B", "D", "F", "C"]);
+    expect(MAX_PRICED_HOLDINGS).toBe(3);
+    // top 3 by value: G(70) B(60) D(50)
+    expect(rows.map((r) => r.symbol)).toEqual(["G", "B", "D"]);
   });
 
   it("only includes symbols that have a unit price in the market overview", () => {
@@ -169,5 +176,106 @@ describe("selectPricedHoldings", () => {
         price("SHIB", 0.00001),
       ]),
     ).toEqual([]);
+  });
+});
+
+const mover = (
+  symbol: string,
+  priceUsd: number,
+  change24hPct = 0,
+): WalletMarketMover => ({
+  id: symbol.toLowerCase(),
+  symbol,
+  name: symbol,
+  priceUsd,
+  change24hPct,
+  marketCapRank: null,
+  imageUrl: null,
+});
+
+/** Build a market overview from fixed price snapshots + optional movers. */
+function overview(
+  prices: WalletMarketPriceSnapshot[],
+  movers: WalletMarketMover[] = [],
+): WalletMarketOverviewResponse {
+  return { prices, movers } as unknown as WalletMarketOverviewResponse;
+}
+
+describe("selectDefaultPriceRows", () => {
+  it("returns [] when there is no overview", () => {
+    expect(selectDefaultPriceRows(null)).toEqual([]);
+    expect(selectDefaultPriceRows(undefined)).toEqual([]);
+  });
+
+  it("returns BTC/SOL/ETH in doctrine order from the fixed snapshots", () => {
+    // Provided out of order — output must be BTC, SOL, ETH regardless.
+    const rows = selectDefaultPriceRows(
+      overview([
+        price("ETH", 3000, 1.1),
+        price("BTC", 64000, -0.5),
+        price("SOL", 150, 2.2),
+      ]),
+    );
+    expect(rows).toEqual<PricedHolding[]>([
+      { symbol: "BTC", priceUsd: 64000, change24hPct: -0.5 },
+      { symbol: "SOL", priceUsd: 150, change24hPct: 2.2 },
+      { symbol: "ETH", priceUsd: 3000, change24hPct: 1.1 },
+    ]);
+  });
+
+  it("fills a missing fixed snapshot from trending movers, up to 3 rows", () => {
+    // Partial-source response: SOL snapshot dropped → fill one trending row,
+    // never a duplicate of an already-shown fixed symbol.
+    const rows = selectDefaultPriceRows(
+      overview(
+        [price("BTC", 64000), price("ETH", 3000)],
+        [mover("BTC", 64000), mover("DOGE", 0.2, 12)],
+      ),
+    );
+    expect(rows.map((r) => r.symbol)).toEqual(["BTC", "ETH", "DOGE"]);
+  });
+
+  it("never exceeds MAX_PRICED_HOLDINGS even with many movers", () => {
+    const rows = selectDefaultPriceRows(
+      overview(
+        [],
+        [mover("A", 1), mover("B", 2), mover("C", 3), mover("D", 4)],
+      ),
+    );
+    expect(rows).toHaveLength(MAX_PRICED_HOLDINGS);
+    expect(rows.map((r) => r.symbol)).toEqual(["A", "B", "C"]);
+  });
+});
+
+describe("selectWalletWidgetRows (doctrine composition, #14344)", () => {
+  it("shows top-3 held when the account holds ≥1 priced asset", () => {
+    const rows = selectWalletWidgetRows(
+      balances([
+        { symbol: "USDC", valueUsd: "500" },
+        { symbol: "WBTC", valueUsd: "2000" },
+      ]),
+      overview([price("USDC", 1), price("WBTC", 64000)]),
+    );
+    expect(rows.map((r) => r.symbol)).toEqual(["WBTC", "USDC"]);
+  });
+
+  it("falls back to the BTC/SOL/ETH baseline when nothing is held", () => {
+    const rows = selectWalletWidgetRows(
+      balances([]),
+      overview([price("BTC", 64000), price("SOL", 150), price("ETH", 3000)]),
+    );
+    expect(rows.map((r) => r.symbol)).toEqual(["BTC", "SOL", "ETH"]);
+  });
+
+  it("shows the baseline when balances are unavailable but overview loaded", () => {
+    const rows = selectWalletWidgetRows(
+      null,
+      overview([price("BTC", 64000), price("SOL", 150), price("ETH", 3000)]),
+    );
+    expect(rows.map((r) => r.symbol)).toEqual(["BTC", "SOL", "ETH"]);
+  });
+
+  it("returns [] (self-hide) only when both balances and overview are null", () => {
+    expect(selectWalletWidgetRows(null, null)).toEqual([]);
   });
 });

--- a/packages/ui/src/components/chat/widgets/wallet-price-holdings.ts
+++ b/packages/ui/src/components/chat/widgets/wallet-price-holdings.ts
@@ -4,6 +4,8 @@
  */
 import type {
   WalletBalancesResponse,
+  WalletMarketMover,
+  WalletMarketOverviewResponse,
   WalletMarketPriceSnapshot,
 } from "@elizaos/contracts";
 
@@ -21,15 +23,23 @@ import type {
  *      for ranking, never surfaced),
  *   4. keep only symbols that have a unit price in the market overview,
  *   5. rank by aggregated holding value (desc; ties broken by symbol), take
- *      top 5,
+ *      the top {@link MAX_PRICED_HOLDINGS},
  *   6. return price-only rows — `{ symbol, priceUsd, change24hPct }`, with NO
  *      balance, holding value, or portfolio total.
  */
 
 /** The minimum holding value (USD) a position must be worth to appear. */
 export const MIN_HOLDING_USD = 1;
-/** Max assets shown in the price-only widget. */
-export const MAX_PRICED_HOLDINGS = 5;
+/** Max assets shown in the price-only widget (held OR baseline). */
+export const MAX_PRICED_HOLDINGS = 3;
+
+/**
+ * The baseline assets shown when the user holds nothing priced, in doctrine
+ * order (#14344). The market-overview `prices` array is exactly these three
+ * fixed snapshots, upper-cased (`market-overview.ts`), so this is a
+ * zero-ambiguity default rather than an attention-grabby trending feed.
+ */
+const DEFAULT_SYMBOLS = ["BTC", "SOL", "ETH"] as const;
 
 /** A price-only row — deliberately carries no amount/holding value. */
 export interface PricedHolding {
@@ -113,4 +123,70 @@ export function selectPricedHoldings(
       change24hPct: price.change24hPct,
     };
   });
+}
+
+function toRow(
+  snap: WalletMarketPriceSnapshot | WalletMarketMover,
+): PricedHolding {
+  return {
+    symbol: snap.symbol,
+    priceUsd: snap.priceUsd,
+    change24hPct: snap.change24hPct,
+  };
+}
+
+/**
+ * The BTC/SOL/ETH baseline rows for an account that holds nothing priced
+ * (#14344). Fixed snapshots come from `overview.prices` in {@link
+ * DEFAULT_SYMBOLS} order; if a partial-source response dropped one of the
+ * three, the gap is filled from `overview.movers` (trending) so the widget
+ * still shows up to {@link MAX_PRICED_HOLDINGS} rows rather than collapsing.
+ * Pure + deterministic.
+ */
+export function selectDefaultPriceRows(
+  overview: WalletMarketOverviewResponse | null | undefined,
+): PricedHolding[] {
+  if (!overview) return [];
+
+  const bySymbol = new Map<string, WalletMarketPriceSnapshot>();
+  for (const p of overview.prices ?? []) {
+    const key = p.symbol.trim().toUpperCase();
+    if (key && !bySymbol.has(key)) bySymbol.set(key, p);
+  }
+
+  const rows: PricedHolding[] = [];
+  const seen = new Set<string>();
+  for (const symbol of DEFAULT_SYMBOLS) {
+    const snap = bySymbol.get(symbol);
+    if (!snap) continue;
+    rows.push(toRow(snap));
+    seen.add(symbol);
+  }
+
+  if (rows.length < MAX_PRICED_HOLDINGS) {
+    for (const mover of overview.movers ?? []) {
+      const key = mover.symbol.trim().toUpperCase();
+      if (!key || seen.has(key)) continue;
+      rows.push(toRow(mover));
+      seen.add(key);
+      if (rows.length >= MAX_PRICED_HOLDINGS) break;
+    }
+  }
+
+  return rows.slice(0, MAX_PRICED_HOLDINGS);
+}
+
+/**
+ * The rows the wallet home widget renders (#14344): the user's top-3 priced
+ * holdings when they hold ≥1 qualifying asset, otherwise the BTC/SOL/ETH
+ * baseline. Returns `[]` only when neither balances nor overview data is
+ * available — the widget self-hides on that, and on nothing else.
+ */
+export function selectWalletWidgetRows(
+  balances: WalletBalancesResponse | null | undefined,
+  overview: WalletMarketOverviewResponse | null | undefined,
+): PricedHolding[] {
+  const held = selectPricedHoldings(balances, overview?.prices);
+  if (held.length > 0) return held;
+  return selectDefaultPriceRows(overview);
 }


### PR DESCRIPTION
Resolves #14344.

## Problem
The wallet home tile contradicted the resting-home doctrine (`03-launcher-widgets.md`): it **hid entirely on an empty wallet** and fetched prices **once on mount**, so displayed prices went stale for the whole session.

## Change (no new server plumbing)
- `selectWalletWidgetRows` composes the doctrine in `wallet-price-holdings.ts`: **top-3 held** (`MAX_PRICED_HOLDINGS` 5→3) when the account holds ≥1 priced asset ≥$1, else the **BTC/SOL/ETH baseline** from `overview.prices`, filling a missing fixed snapshot from `overview.movers` (trending) up to 3 rows.
- Widget **self-hides ONLY when both** `getWalletBalances` and `getWalletMarketOverview` are unavailable; a balances-only outage still shows the baseline (J4 home degrade — the wallet view owns the visible error state).
- One-shot mount fetch replaced with a **60s `useIntervalWhenDocumentVisible` poll** (server cache is 120s); no requests fire while the document is hidden.
- Unchanged: price-only invariant (#10706), auth gate (#11084), tap → `/wallet`, loading placeholder. Uses only the existing `market-overview` route + `getWalletBalances`.

## Acceptance criteria
- [x] Fresh account with no holdings sees BTC, SOL, ETH price rows.
- [x] Account holding ≥1 priced token ≥$1 sees its top-3 held by unit price (no amounts/totals — #10706 preserved).
- [x] Prices update within ~60s while the home is visible; silent while hidden.
- [x] Renders nothing (no error chrome) when both endpoints fail.
- [x] `bun run --cwd packages/ui test` (24 tests) + verify pass.

## Evidence
Test states: held / baseline / trending-fill / balances-fail / both-fail + visibility-gated refresh tick. Screenshots + `mvp:visual-verify` report in the issue evidence comment.