### PR TITLE
docs(ui): correct useWeather no-location comments (#14345 follow-up)

### DIFF
--- a/packages/ui/src/hooks/useWeather.ts
+++ b/packages/ui/src/hooks/useWeather.ts
@@ -153,7 +153,8 @@ function writeCache(value: CachedWeather): void {
 
 /** Has the user ALREADY granted geolocation? We never trigger the OS permission
  *  prompt from the home — precise device location is used only when it's already
- *  allowed; otherwise the coarse IP lookup is the no-prompt default. */
+ *  allowed; otherwise the widget degrades to its unavailable state (no prompt,
+ *  and no IP-lookup fallback — see {@link resolveCoords}). */
 async function geolocationAlreadyGranted(): Promise<boolean> {
   try {
     const perms = navigator.permissions;
@@ -162,7 +163,8 @@ async function geolocationAlreadyGranted(): Promise<boolean> {
     return status.state === "granted";
   } catch {
     // error-policy:J3 Permissions API unsupported (older WebKit) reads as
-    // "not granted" — the coarse IP lookup is the designed no-prompt default.
+    // "not granted" — the widget degrades to its unavailable state (the
+    // designed no-prompt path; no IP-lookup fallback).
     return false;
   }
 }


### PR DESCRIPTION
## What

Comment-only follow-up to the merged #14345 fix (PR #14497). Two comments in `useWeather.ts` `geolocationAlreadyGranted` still claimed *"the coarse IP lookup is the no-prompt default"* when geolocation isn't granted. That path was removed: `resolveCoords` throws `no-location` and the weather tile degrades to its `unavailable` state — which the `resolveCoords` docstring itself already documents (*"degrade to unavailable instead of making a browser-side IP lookup"*). The two stale comments contradicted the code; per the repo slop/comment doctrine a wrong comment is worse than none. Rewritten to match behavior.

## Scope

- `packages/ui/src/hooks/useWeather.ts` — 2 comment blocks. **Code token stream unchanged** (comment-only).

## Why this is safe

- No runtime behavior changes.
- `bun run --cwd packages/ui test src/hooks/useWeather.test.ts` -> 23 passed.
- Adversarial verification of the underlying #14345 fix (already merged into `develop`): implementation is real (locale °C/°F via `Intl.Locale().region`, 24/12h via `Intl…hourCycle` resolved at module load, visibility-gated TTL revalidation, tap-to-grant, dead city line removed), tests real (28 pass: 23 `useWeather` + 5 `DefaultHomeWidgets`, jsdom + boundary-mocked geolocation/fetch), no stubs/larp. This PR closes the one documentation-accuracy gap I found.

Follow-up to #14345 / PR #14497.
