### PR TITLE
test(cloud): verify STT model ownership

### DIFF
--- a/packages/cloud/api/__tests__/voice-kokoro-whisper-live.test.ts
+++ b/packages/cloud/api/__tests__/voice-kokoro-whisper-live.test.ts
@@ -33,8 +33,10 @@ async function transcribeAudio(
   mimeType: string,
   language?: string,
 ) {
+  const audioBytes = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(audioBytes).set(bytes);
   const form = new FormData();
-  form.append("file", new File([bytes], filename, { type: mimeType }));
+  form.append("file", new File([audioBytes], filename, { type: mimeType }));
   form.append("model", WHISPER_MODEL);
   if (language) form.append("language", language);
   const sttRes = await fetch(

--- a/plugins/plugin-elizacloud/__tests__/cloud-transcription-contract.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/cloud-transcription-contract.test.ts
@@ -102,7 +102,7 @@ describe("plugin-elizacloud TRANSCRIPTION param shapes", () => {
     expect(body.get("audio")).toBeInstanceOf(Blob);
   });
 
-  it("accepts { audio: Buffer, language, model } and forwards languageCode", async () => {
+  it("accepts { audio: Buffer, language } and forwards languageCode only", async () => {
     const fetchSpy = mockSttResponse({ text: "param object" });
     const text = await handleTranscription(makeRuntime(), {
       audio: Buffer.from("RIFF....WAVEfmt "),
@@ -113,6 +113,7 @@ describe("plugin-elizacloud TRANSCRIPTION param shapes", () => {
     expect(text).toBe("param object");
     const body = (fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined)?.body as FormData;
     expect(body.get("languageCode")).toBe("de");
+    expect(body.get("model")).toBeNull();
   });
 
   it("fetches a string audio URL through the SSRF guard", async () => {

--- a/plugins/plugin-elizacloud/src/models/transcription.ts
+++ b/plugins/plugin-elizacloud/src/models/transcription.ts
@@ -109,7 +109,7 @@ export async function handleTranscription(
     extraParams = params;
   } else {
     throw new Error(
-      "TRANSCRIPTION expects a Blob/File/Buffer, an http(s) audio URL string, { audioUrl }, or an object { audio: Blob/File/Buffer, mimeType?, language?, response_format?, timestampGranularities?, prompt?, temperature?, model? }"
+      "TRANSCRIPTION expects a Blob/File/Buffer, an http(s) audio URL string, { audioUrl }, or an object { audio: Blob/File/Buffer, mimeType?, language?, response_format?, timestampGranularities?, prompt?, temperature? }"
     );
   }
 


### PR DESCRIPTION
## Summary

Follow-up to merged #14511. This keeps the new Cloud STT model ownership contract mechanically checked:

- make the live Railway STT helper pass a plain ArrayBuffer into File so `packages/cloud/api typecheck` accepts the gated test
- assert plugin-elizacloud forwards `languageCode` but does not forward a client-side `model`, because the Worker deployment owns `WHISPER_STT_MODEL` after #14511

## Evidence

```
bun test packages/cloud/api/v1/voice/stt/whisper-model.test.ts packages/cloud/api/__tests__/voice-kokoro-whisper-live.test.ts
# 4 pass, 2 skip (live Railway paths gated by env)

bun run --cwd plugins/plugin-elizacloud test -- __tests__/cloud-transcription-contract.test.ts
# 12 passed

bun run --cwd packages/cloud/api typecheck
# tsgo --noEmit + check:worker-bundle dry-run passed

bunx @biomejs/biome check packages/cloud/api/__tests__/voice-kokoro-whisper-live.test.ts plugins/plugin-elizacloud/__tests__/cloud-transcription-contract.test.ts
# clean

bun run audit:error-policy-ratchet -- --report
# no new fallback-slop in touched files
```

## Evidence N/A

- Screenshots/video/frontend logs: N/A - backend test contract only; no UI path changed.
- Real-LLM trajectory: N/A - STT model selection/test plumbing only; no prompt/planner/generation behavior changed.
- Domain artifacts: N/A - no DB/memory/scheduled-task/wallet/file artifact is produced.
- Live Railway Spanish run: N/A in this host - still requires the provisioned `ELIZA_VOICE_LIVE_RAILWAY=1` fixture/env documented by #14511/#14373.