### PR TITLE
fix(chat): harden FORM field names (#14489)

### DIFF
--- a/packages/core/src/messaging/interactions/interactions.test.ts
+++ b/packages/core/src/messaging/interactions/interactions.test.ts
@@ -115,14 +115,16 @@ describe("parse", () => {
 		})}\n[/FORM]`;
 		const { blocks } = parseInteractionBlocks(text);
 		const form = blocks[0] as FormInteraction;
-		expect(form.fields.map((f) => f.type)).toEqual(["date", "time", "datetime"]);
-		// parse ↔ serialize parity: the temporal types survive a round trip.
-		const rt = parseInteractionBlocks(serializeInteractionBlock(form));
-		expect((rt.blocks[0] as FormInteraction).fields.map((f) => f.type)).toEqual([
+		expect(form.fields.map((f) => f.type)).toEqual([
 			"date",
 			"time",
 			"datetime",
 		]);
+		// parse ↔ serialize parity: the temporal types survive a round trip.
+		const rt = parseInteractionBlocks(serializeInteractionBlock(form));
+		expect((rt.blocks[0] as FormInteraction).fields.map((f) => f.type)).toEqual(
+			["date", "time", "datetime"],
+		);
 	});
 
 	it("drops a field with an unknown type (core parser is strict)", () => {
@@ -135,6 +137,24 @@ describe("parse", () => {
 		const { blocks } = parseInteractionBlocks(text);
 		const form = blocks[0] as FormInteraction;
 		// unknown "color" is rejected; the valid "date" field survives.
+		expect(form.fields.map((f) => f.name)).toEqual(["ok"]);
+	});
+
+	it("drops Object-prototype form field names", () => {
+		const text = `[FORM]\n${JSON.stringify({
+			fields: [
+				{ name: "constructor", type: "text" },
+				{ name: "hasOwnProperty", type: "text" },
+				{ name: "propertyIsEnumerable", type: "text" },
+				{ name: "toString", type: "text" },
+				{ name: "valueOf", type: "text" },
+				{ name: "__proto__", type: "text" },
+				{ name: "constructor.prototype", type: "text" },
+				{ name: "ok", type: "text" },
+			],
+		})}\n[/FORM]`;
+		const { blocks } = parseInteractionBlocks(text);
+		const form = blocks[0] as FormInteraction;
 		expect(form.fields.map((f) => f.name)).toEqual(["ok"]);
 	});
 

--- a/packages/core/src/messaging/interactions/parse.ts
+++ b/packages/core/src/messaging/interactions/parse.ts
@@ -56,6 +56,22 @@ const FOLLOWUP_KINDS: ReadonlySet<FollowupKind> = new Set([
 	"navigate",
 	"prompt",
 ]);
+const UNSAFE_FORM_FIELD_NAME_SEGMENTS = new Set([
+	"__defineGetter__",
+	"__defineSetter__",
+	"__lookupGetter__",
+	"__lookupSetter__",
+	"__proto__",
+	"constructor",
+	"hasOwnProperty",
+	"isPrototypeOf",
+	"propertyIsEnumerable",
+	"prototype",
+	"toLocaleString",
+	"toString",
+	"valueOf",
+]);
+const SAFE_FORM_FIELD_NAME_RE = /^[\w.-]+$/;
 
 /** A parsed block together with the character region it occupied in the text. */
 export interface InteractionRegion {
@@ -72,6 +88,13 @@ function randomId(prefix: string): string {
 		return crypto.randomUUID();
 	}
 	return `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function isSafeFormFieldName(name: string): boolean {
+	if (!SAFE_FORM_FIELD_NAME_RE.test(name)) return false;
+	return !name
+		.split(".")
+		.some((segment) => UNSAFE_FORM_FIELD_NAME_SEGMENTS.has(segment));
 }
 
 /** `value=label` lines → options (shared by CHOICE). */
@@ -122,7 +145,7 @@ function parseFormField(raw: unknown): InteractionField | null {
 	const name = typeof r.name === "string" ? r.name.trim() : "";
 	const type =
 		typeof r.type === "string" ? (r.type as InteractionFieldType) : "text";
-	if (!name || !/^[\w.-]+$/.test(name)) return null;
+	if (!name || !isSafeFormFieldName(name)) return null;
 	if (!FIELD_TYPES.has(type)) return null;
 	const field: InteractionField = { name, type };
 	if (typeof r.label === "string") field.label = r.label;

--- a/packages/ui/CLAUDE.md
+++ b/packages/ui/CLAUDE.md
@@ -190,6 +190,49 @@ component should ship at least a `*.stories.tsx` (states) **and** a `*.test.tsx`
 (behaviour). The live full-app visual audit lives in `packages/app`
 (`audit:app`) and `packages/cloud-frontend` (`audit:cloud`).
 
+### Scroll + tap-target certification (`src/testing/scroll-cert.ts`, #14380)
+
+A UI-library-wide certification harness holds every scrollable / interactive
+widget to four device-review guarantees: **scroll stability**, **keyboard
+interaction geometry**, **safe-area clearance**, and **tap-target minimums**
+(44x44 CSS px). It is two layers, same split as the rest of `src/testing`:
+
+- **Pure verdict math** — `scroll-cert.ts` is `(measurements) -> Violation[]`,
+  proven both ways (RED on a violation, GREEN when it holds) in
+  `scroll-cert.test.ts`. This is the always-trustworthy detector.
+- **DOM sweep** — `widget-cert.ts` walks a rendered widget for interactive
+  controls + scroll containers, reads their boxes through a pluggable
+  `GeometryProvider`, and runs the verdicts into a per-widget `WidgetCertReport`
+  (JSON + rendered summary). Under jsdom (`widget-cert.test.tsx`) geometry is
+  injected via `mapGeometryProvider`; a real browser supplies
+  `liveGeometryProvider` (getBoundingClientRect + getComputedStyle).
+- **Deep layer** — `src/testing/__e2e__/run-widget-cert-e2e.mjs`
+  (`bun run test:widget-cert-e2e`) mounts the widgets in real Chromium/WebKit
+  and runs the SAME sweep against real layout, emitting evidence
+  (`output-widget-cert/{widget-cert.json,widget-cert.txt,<engine>.png}`).
+  Playwright is flaky in CI — the runner SKIPs (exit 0) if the browser can't
+  launch; the vitest static layer is the always-green gate.
+
+**To certify a NEW widget:**
+
+1. Give the widget's scroll container a `data-scroll-cert-scroller` attribute
+   (or reuse `#continuous-thread` / `[data-testid="chat-thread"]`), and make sure
+   every interactive control is a native control / has a `role` / is
+   `tabindex>=0` (the sweep only enforces the tap floor on real controls). A
+   control with an expanded hit area (padding / hitSlop) should report an
+   effective hit box via the provider; a genuinely non-pointer affordance opts
+   out with `data-tap-target="ignore"`.
+2. Add a `certifyWidget("my-widget", root, provider, { dimensions: [...] })` case
+   to `widget-cert.test.tsx` (static, always runs) — pick the dimensions that
+   apply (`scroll`, `tap-target`, `safe-area`, `keyboard`). Inject known-good and
+   known-broken geometry so the cert is proven, not just green-because-empty.
+3. Optionally add the widget to the deep fixture
+   (`__e2e__/widget-cert-fixture.tsx`) so it is also certified against real
+   layout when playwright can run.
+4. A cert FAILURE is an actionable per-control report (code + selector +
+   measurement). This harness only DETECTS — component sizing/layout fixes are
+   owned by the component's lane; route findings there.
+
 ## Config / env vars
 
 This package mostly reads config injected by the host, not raw env vars:

--- a/packages/ui/src/components/chat/message-form-parser.test.ts
+++ b/packages/ui/src/components/chat/message-form-parser.test.ts
@@ -84,11 +84,16 @@ describe("parseFormBody", () => {
     });
   });
 
-  it("drops fields with unsafe or missing names and dedupes by name", () => {
+  it("drops fields with unsafe, Object-prototype, or missing names and dedupes by name", () => {
     const form = parseFormBody(
       JSON.stringify({
         fields: [
           { name: "__proto__", type: "text" },
+          { name: "constructor", type: "text" },
+          { name: "hasOwnProperty", type: "text" },
+          { name: "propertyIsEnumerable", type: "text" },
+          { name: "toString", type: "text" },
+          { name: "valueOf", type: "text" },
           { name: "1bad", type: "text" },
           { type: "text" },
           { name: "ok", type: "text", label: "First" },
@@ -102,6 +107,20 @@ describe("parseFormBody", () => {
       type: "text",
       label: "First",
     });
+  });
+
+  it("returns null when every field name is unsafe", () => {
+    expect(
+      parseFormBody(
+        JSON.stringify({
+          fields: [
+            { name: "constructor", type: "text" },
+            { name: "hasOwnProperty", type: "text" },
+            { name: "__proto__", type: "text" },
+          ],
+        }),
+      ),
+    ).toBeNull();
   });
 
   it("returns null for malformed or empty input rather than throwing", () => {
@@ -136,5 +155,12 @@ describe("findFormRegions", () => {
 
   it("ignores a FORM block with a malformed body", () => {
     expect(findFormRegions("[FORM]\nnot json\n[/FORM]")).toEqual([]);
+  });
+
+  it("ignores a FORM block whose only field names are inherited object keys", () => {
+    const body = JSON.stringify({
+      fields: [{ name: "constructor", type: "text" }],
+    });
+    expect(findFormRegions(`[FORM]\n${body}\n[/FORM]`)).toEqual([]);
   });
 });

--- a/packages/ui/src/components/chat/message-form-parser.ts
+++ b/packages/ui/src/components/chat/message-form-parser.ts
@@ -74,6 +74,22 @@ const FORM_FIELD_TYPES = new Set<FormFieldType>([
   "datetime",
 ]);
 
+const UNSAFE_FIELD_NAME_SEGMENTS = new Set([
+  "__defineGetter__",
+  "__defineSetter__",
+  "__lookupGetter__",
+  "__lookupSetter__",
+  "__proto__",
+  "constructor",
+  "hasOwnProperty",
+  "isPrototypeOf",
+  "propertyIsEnumerable",
+  "prototype",
+  "toLocaleString",
+  "toString",
+  "valueOf",
+]);
+
 /** Field names become state-path segments + result keys; keep them safe. */
 const SAFE_FIELD_NAME_RE = /^[A-Za-z][\w-]*$/;
 
@@ -89,11 +105,18 @@ export function generateFormId(): string {
   return `form-${Math.random().toString(36).slice(2, 10)}-${Date.now().toString(36)}`;
 }
 
+export function isSafeFormFieldName(name: string): boolean {
+  if (!SAFE_FIELD_NAME_RE.test(name)) return false;
+  return !name
+    .split(".")
+    .some((segment) => UNSAFE_FIELD_NAME_SEGMENTS.has(segment));
+}
+
 function parseField(raw: unknown): FormFieldSpec | null {
   if (!raw || typeof raw !== "object") return null;
   const record = raw as Record<string, unknown>;
   const name = record.name;
-  if (typeof name !== "string" || !SAFE_FIELD_NAME_RE.test(name)) return null;
+  if (typeof name !== "string" || !isSafeFormFieldName(name)) return null;
   const type =
     typeof record.type === "string" &&
     FORM_FIELD_TYPES.has(record.type as FormFieldType)

--- a/packages/ui/src/components/chat/parser-parity.contract.test.ts
+++ b/packages/ui/src/components/chat/parser-parity.contract.test.ts
@@ -12,8 +12,9 @@
  *      (region count, scope, options, kinds) — so a future edit to either side
  *      that breaks parity fails here; and
  *   2. PINS the known FORM field-name divergence (UI `^[A-Za-z][\w-]*$` vs core
- *      `^[\w.-]+$`) as an explicit, tracked expectation, so reconciling it is a
- *      conscious change (update this test) rather than silent drift.
+ *      `^[\w.-]+$`) as an explicit, tracked expectation while asserting both
+ *      reject Object-prototype field-name segments, so reconciling the broader
+ *      regex difference is a conscious change rather than silent drift.
  *
  * If/when the UI parsers are made to delegate to core, the divergence assertion
  * flips to agreement and this file documents that the contract is now exact.
@@ -115,6 +116,26 @@ describe("parser parity — UI per-marker parsers vs @elizaos/core findInteracti
     ]) {
       expect(uiChoices(text)).toEqual(coreChoices(text));
       expect(findFormRegions(text)).toHaveLength(0);
+    }
+  });
+
+  it("FORM: both impls reject Object-prototype field names", () => {
+    for (const name of [
+      "constructor",
+      "hasOwnProperty",
+      "propertyIsEnumerable",
+      "toString",
+      "valueOf",
+      "__proto__",
+      "constructor.prototype",
+    ]) {
+      const text = `[FORM]\n{"id":"f","fields":[{"name":"${name}","type":"text"}]}\n[/FORM]`;
+      const ui = findFormRegions(text);
+      const core = findInteractionRegions(text)
+        .map((r) => r.block)
+        .filter((b) => b.kind === "form");
+      expect(ui, `UI form regions for ${name}`).toHaveLength(0);
+      expect(core, `core form regions for ${name}`).toHaveLength(0);
     }
   });
 

--- a/packages/ui/src/components/chat/widgets/form-request.tsx
+++ b/packages/ui/src/components/chat/widgets/form-request.tsx
@@ -40,7 +40,9 @@ export type FormResultValue = string | boolean;
  * so no custom picker or dependency is added. Any other type is a plain text
  * box. Exported for the field-type unit test.
  */
-export function htmlInputTypeForField(fieldType: FormFieldSpec["type"]): string {
+export function htmlInputTypeForField(
+  fieldType: FormFieldSpec["type"],
+): string {
   switch (fieldType) {
     case "number":
       return "number";
@@ -65,15 +67,61 @@ function initialValueFor(field: FormFieldSpec): FormResultValue {
   return field.type === "checkbox" ? false : "";
 }
 
+function createFormRecord<T>(): Record<string, T> {
+  return Object.create(null) as Record<string, T>;
+}
+
+function hasFormRecordValue<T>(
+  record: Record<string, T>,
+  name: string,
+): boolean {
+  return Object.hasOwn(record, name);
+}
+
+function getFormRecordValue<T>(
+  record: Record<string, T>,
+  name: string,
+): T | undefined {
+  return hasFormRecordValue(record, name) ? record[name] : undefined;
+}
+
+function withFormRecordValue<T>(
+  record: Record<string, T>,
+  name: string,
+  value: T,
+): Record<string, T> {
+  const next = createFormRecord<T>();
+  Object.assign(next, record);
+  next[name] = value;
+  return next;
+}
+
+function toPlainResult(
+  values: Record<string, FormResultValue>,
+): Record<string, FormResultValue> {
+  const result: Record<string, FormResultValue> = {};
+  for (const [name, value] of Object.entries(values)) {
+    Object.defineProperty(result, name, {
+      configurable: true,
+      enumerable: true,
+      value,
+      writable: true,
+    });
+  }
+  return result;
+}
+
 export function FormRequest({ form, onSubmit }: FormRequestProps) {
   const [values, setValues] = useState<Record<string, FormResultValue>>(() => {
-    const initial: Record<string, FormResultValue> = {};
+    const initial = createFormRecord<FormResultValue>();
     for (const field of form.fields) {
       initial[field.name] = initialValueFor(field);
     }
     return initial;
   });
-  const [errors, setErrors] = useState<Record<string, string[]>>({});
+  const [errors, setErrors] = useState<Record<string, string[]>>(() =>
+    createFormRecord<string[]>(),
+  );
   const [submitted, setSubmitted] = useState(false);
 
   const requiredFields = useMemo(
@@ -82,7 +130,7 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
   );
 
   const setValue = useCallback((name: string, value: FormResultValue) => {
-    setValues((prev) => ({ ...prev, [name]: value }));
+    setValues((prev) => withFormRecordValue(prev, name, value));
   }, []);
 
   const validateField = useCallback(
@@ -97,7 +145,7 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
         ],
         value,
       );
-      setErrors((prev) => ({ ...prev, [field.name]: fieldErrors }));
+      setErrors((prev) => withFormRecordValue(prev, field.name, fieldErrors));
     },
     [],
   );
@@ -107,7 +155,7 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
       event.preventDefault();
       if (submitted) return;
 
-      const nextErrors: Record<string, string[]> = {};
+      const nextErrors = createFormRecord<string[]>();
       for (const field of requiredFields) {
         const fieldErrors = runValidation(
           [
@@ -116,7 +164,7 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
               message: `${field.label ?? field.name} is required`,
             },
           ],
-          values[field.name],
+          getFormRecordValue(values, field.name),
         );
         if (fieldErrors.length > 0) nextErrors[field.name] = fieldErrors;
       }
@@ -124,7 +172,7 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
       if (Object.keys(nextErrors).length > 0) return;
 
       setSubmitted(true);
-      onSubmit(form.id, values);
+      onSubmit(form.id, toPlainResult(values));
     },
     [form.id, onSubmit, requiredFields, submitted, values],
   );
@@ -143,7 +191,8 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
 
       {form.fields.map((field) => {
         const label = field.label ?? field.name;
-        const fieldErrors = errors[field.name];
+        const fieldErrors = getFormRecordValue(errors, field.name);
+        const fieldValue = getFormRecordValue(values, field.name);
         if (field.type === "checkbox") {
           const checkboxId = `${form.id}-${field.name}`;
           return (
@@ -154,7 +203,7 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
             >
               <Checkbox
                 id={checkboxId}
-                checked={Boolean(values[field.name])}
+                checked={Boolean(fieldValue)}
                 disabled={submitted}
                 onCheckedChange={(checked) => setValue(field.name, !!checked)}
               />
@@ -164,7 +213,7 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
         }
         if (field.type === "select") {
           const options = field.options ?? [];
-          const current = String(values[field.name] ?? "");
+          const current = String(fieldValue ?? "");
           return (
             <div key={field.name} className="flex flex-col gap-1 text-xs">
               <span className="font-semibold">{label}</span>
@@ -218,11 +267,11 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
               type={htmlInputTypeForField(field.type)}
               name={field.name}
               placeholder={field.placeholder ?? ""}
-              value={String(values[field.name] ?? "")}
+              value={String(fieldValue ?? "")}
               disabled={submitted}
               required={field.required}
               onChange={(e) => setValue(field.name, e.currentTarget.value)}
-              onBlur={() => validateField(field, values[field.name])}
+              onBlur={(e) => validateField(field, e.currentTarget.value)}
             />
             <ConfigFieldErrors errors={fieldErrors} />
           </div>

--- a/packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx
+++ b/packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx
@@ -132,6 +132,74 @@ describe("FormRequest — every input + submit", () => {
     expect(screen.getAllByText("GitHub").length).toBeGreaterThan(0);
     expect(screen.getAllByText("GitLab").length).toBeGreaterThan(0);
   });
+
+  it("handles Object-prototype field names when a malformed spec bypasses the parser", () => {
+    const onSubmit = vi.fn();
+    const inheritedNameForm: FormRequestSpec = {
+      id: "dangerous-fields",
+      submitLabel: "Save",
+      fields: [
+        {
+          name: "constructor",
+          type: "text",
+          label: "Constructor",
+          required: true,
+        },
+        {
+          name: "hasOwnProperty",
+          type: "text",
+          label: "Has own",
+        },
+        {
+          name: "__proto__",
+          type: "text",
+          label: "Prototype",
+        },
+        {
+          name: "propertyIsEnumerable",
+          type: "checkbox",
+          label: "Enumerable",
+        },
+      ],
+    };
+
+    render(<FormRequest form={inheritedNameForm} onSubmit={onSubmit} />);
+    fireEvent.submit(screen.getByTestId("form-request"));
+    expect(screen.getByText(/Constructor is required/i)).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText("Constructor"), {
+      target: { value: "ok" },
+    });
+    fireEvent.change(screen.getByLabelText("Has own"), {
+      target: { value: "yes" },
+    });
+    fireEvent.change(screen.getByLabelText("Prototype"), {
+      target: { value: "safe" },
+    });
+    fireEvent.click(screen.getByLabelText("Enumerable"));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const submitted = onSubmit.mock.calls[0]?.[1] as Record<
+      string,
+      string | boolean
+    >;
+    const submittedValue = (name: string) =>
+      Object.getOwnPropertyDescriptor(submitted, name)?.value;
+    expect(submittedValue("constructor")).toBe("ok");
+    expect(submittedValue("hasOwnProperty")).toBe("yes");
+    expect(submittedValue("__proto__")).toBe("safe");
+    expect(submittedValue("propertyIsEnumerable")).toBe(true);
+    expect(Object.getPrototypeOf(submitted)).toBe(Object.prototype);
+    for (const name of [
+      "constructor",
+      "hasOwnProperty",
+      "__proto__",
+      "propertyIsEnumerable",
+    ]) {
+      expect(Object.hasOwn(submitted, name)).toBe(true);
+    }
+  });
 });
 
 describe("ChoiceWidget — pick an option", () => {


### PR DESCRIPTION
# Relates to

Fixes #14489.

Definition of Done: full standard in [`PR_EVIDENCE.md`](../PR_EVIDENCE.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` was run after sync. `bun run verify` was run after sync and
      the unrelated ratchet blocker is recorded below.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. The parser now rejects `Object.prototype` / prototype-mutating form field names as malformed `[FORM]` output, which already degrades to plain text. `FormRequest` is also hardened with null-prototype value/error records so direct malformed specs cannot crash the render path.

# Background

## What does this PR do?

- Rejects unsafe FORM field-name segments (`constructor`, `hasOwnProperty`, `propertyIsEnumerable`, `__proto__`, `constructor.prototype`, etc.) in both the UI parser and core interaction parser.
- Hardens `FormRequest` value/error state so inherited object keys are never read as field state.
- Adds parser, parity, core, and render regression coverage for the crash class.
- Repairs the stale `packages/ui/CLAUDE.md` copy so it matches `packages/ui/AGENTS.md`; root verify was failing on that package-local instruction invariant before reaching code checks.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

Package-local docs were updated only to restore the required `CLAUDE.md` / `AGENTS.md` parity in `packages/ui`.

# Testing

## Where should a reviewer start?

Start with `packages/ui/src/components/chat/message-form-parser.ts`, `packages/core/src/messaging/interactions/parse.ts`, and `packages/ui/src/components/chat/widgets/form-request.tsx`. The acceptance tests are in `message-form-parser.test.ts`, `parser-parity.contract.test.ts`, `interaction-widgets.behavior.test.tsx`, and `packages/core/src/messaging/interactions/interactions.test.ts`.

## Detailed testing steps

- `bun install` — passed after syncing artifacts; install side-effect artifact files were cleaned from the branch.
- `bun run --cwd packages/cloud/routing build` — passed; needed after install so the UI parity test can resolve `@elizaos/cloud-routing` through package exports.
- `bunx @biomejs/biome check packages/core/src/messaging/interactions/parse.ts packages/core/src/messaging/interactions/interactions.test.ts packages/ui/src/components/chat/message-form-parser.ts packages/ui/src/components/chat/message-form-parser.test.ts packages/ui/src/components/chat/parser-parity.contract.test.ts packages/ui/src/components/chat/widgets/form-request.tsx packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx` — passed.
- `bun run --cwd packages/ui test -- src/components/chat/message-form-parser.test.ts src/components/chat/widgets/interaction-widgets.behavior.test.tsx src/components/chat/parser-parity.contract.test.ts src/components/chat/widgets/form-request.test.tsx` — passed, 4 files / 30 tests.
- `bun run --cwd packages/core test -- src/messaging/interactions/interactions.test.ts` — passed, 1 file / 35 tests.
- `bun run --cwd packages/core typecheck` — passed.
- `bun run check:agents-claude` — passed, 295 tracked pairs byte-identical.
- `git diff --check` — passed.
- `bun run --cwd packages/ui typecheck` — failed on unrelated existing test/type issues listed below.
- `bun run verify` — failed on unrelated type-safety ratchet baseline drift listed below.

# Evidence Gate

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no visual/layout change; this is a parser/render crash fix and the before state is the documented constructor FORM crash in #14489`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface
      (desktop and mobile), or marked `N/A - no visual/layout change; post-fix behavior is proven by the real React render regression test that submits constructor, hasOwnProperty, __proto__, and propertyIsEnumerable fields without crashing`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked
      `N/A - no visual flow changed; deterministic render/parser tests exercise the crash path directly`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked
      `N/A - no backend runtime path changed; core parser behavior is covered by bun run --cwd packages/core test -- src/messaging/interactions/interactions.test.ts`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state
      change, or are marked
      `N/A - no network request/state API changed; frontend render safety is covered by Testing Library interaction tests`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model
      changes, or marked `N/A - no agent/action/provider/prompt/model behavior changed`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable (DB rows, memories,
      scheduled tasks, wallet/on-chain output, generated files, audio, etc.), or
      marked `N/A - no persistent domain artifact is produced by this parser/widget hardening`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changed.

## Backend + frontend logs

N/A - no backend route or frontend network flow changed. Verification is the parser/render test output above.

## Screenshots (before / after) + video walkthrough

### Before

N/A - #14489 documents the before crash repro; this PR does not change visual layout.

### After

N/A - no visual layout change. The after state is a non-crashing render/submission path in `interaction-widgets.behavior.test.tsx`.

### Walkthrough video

N/A - no user-visible flow changed beyond preventing the crash.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or omnivoice behavior changed.

## Known gaps / failures

`bun run verify` was run after `bun install` and after restoring `packages/ui/CLAUDE.md` / `AGENTS.md` parity. It now fails at the repo-wide type-safety ratchet before turbo typecheck/lint:

```text
[type-safety-ratchet] unsafe cast baseline exceeded
  - as unknown as: 77 current > 73 baseline
[type-safety-ratchet] scanned 10283 tracked production source files
```

The ratchet output points at existing files outside this patch, including `packages/ui/src/components/shell/__e2e__/chat-sheet-fixture.tsx`, `packages/agent/src/actions/knowledge.ts`, feed package files, `packages/ui/src/testing/widget-cert.ts`, personal-assistant, training, wallet, and app-core files. This PR does not add `as unknown as` casts.

`bun run --cwd packages/ui typecheck` still fails on unrelated existing files after install:

```text
src/components/chat/widgets/todo.test.tsx(123,11): Type ... is not assignable to type 'never'.
src/components/chat/widgets/todo.test.tsx(136,11): Type ... is not assignable to type 'never'.
src/components/shell/__e2e__/home-screen-fixture.api-stub.ts(11,3): missing export homeWidgetRelationshipsCandidates.
src/components/shell/__e2e__/home-screen-fixture.api-stub.ts(12,3): missing export homeWidgetRelationshipsPeople.
src/state/startup-phase-poll.test.ts(2027,11): null is not assignable to PersistedActiveServer.
src/testing/__e2e__/widget-cert-fixture.tsx(17,8): WidgetCertReport is declared locally but not exported.
src/voice/voice-selftest/voice-selftest-harness.test.ts(186,19): AudioContext fixture cast mismatch.
src/voice/voice-selftest/voice-selftest-harness.test.ts(192,13): AudioBuffer fixture cast mismatch.
```