### PR TITLE
fix(ui): reject prototype form field names

### DIFF
--- a/packages/core/src/messaging/interactions/interactions.test.ts
+++ b/packages/core/src/messaging/interactions/interactions.test.ts
@@ -115,14 +115,16 @@ describe("parse", () => {
 		})}\n[/FORM]`;
 		const { blocks } = parseInteractionBlocks(text);
 		const form = blocks[0] as FormInteraction;
-		expect(form.fields.map((f) => f.type)).toEqual(["date", "time", "datetime"]);
-		// parse ↔ serialize parity: the temporal types survive a round trip.
-		const rt = parseInteractionBlocks(serializeInteractionBlock(form));
-		expect((rt.blocks[0] as FormInteraction).fields.map((f) => f.type)).toEqual([
+		expect(form.fields.map((f) => f.type)).toEqual([
 			"date",
 			"time",
 			"datetime",
 		]);
+		// parse ↔ serialize parity: the temporal types survive a round trip.
+		const rt = parseInteractionBlocks(serializeInteractionBlock(form));
+		expect((rt.blocks[0] as FormInteraction).fields.map((f) => f.type)).toEqual(
+			["date", "time", "datetime"],
+		);
 	});
 
 	it("drops a field with an unknown type (core parser is strict)", () => {
@@ -136,6 +138,32 @@ describe("parse", () => {
 		const form = blocks[0] as FormInteraction;
 		// unknown "color" is rejected; the valid "date" field survives.
 		expect(form.fields.map((f) => f.name)).toEqual(["ok"]);
+	});
+
+	it("drops inherited Object field names from form blocks (#14489)", () => {
+		const text = `[FORM]\n${JSON.stringify({
+			fields: [
+				{ name: "constructor", type: "text" },
+				{ name: "hasOwnProperty", type: "text" },
+				{ name: "propertyIsEnumerable", type: "text" },
+				{ name: "__proto__", type: "text" },
+				{ name: "ok", type: "text" },
+			],
+		})}\n[/FORM]`;
+		const { blocks } = parseInteractionBlocks(text);
+		const form = blocks[0] as FormInteraction;
+		expect(form.fields.map((f) => f.name)).toEqual(["ok"]);
+
+		const onlyUnsafe = `[FORM]\n${JSON.stringify({
+			fields: [
+				{ name: "constructor", type: "text" },
+				{ name: "hasOwnProperty", type: "text" },
+			],
+		})}\n[/FORM]`;
+		const { blocks: unsafeBlocks, cleanedText } =
+			parseInteractionBlocks(onlyUnsafe);
+		expect(unsafeBlocks).toHaveLength(0);
+		expect(cleanedText).toContain("[FORM]");
 	});
 
 	it("rejects malformed form JSON (left as text)", () => {

--- a/packages/core/src/messaging/interactions/parse.ts
+++ b/packages/core/src/messaging/interactions/parse.ts
@@ -51,6 +51,20 @@ const FIELD_TYPES: ReadonlySet<InteractionFieldType> = new Set([
 	"time",
 	"datetime",
 ]);
+const UNSAFE_OBJECT_FIELD_NAMES: ReadonlySet<string> = new Set([
+	"__defineGetter__",
+	"__defineSetter__",
+	"__lookupGetter__",
+	"__lookupSetter__",
+	"__proto__",
+	"constructor",
+	"hasOwnProperty",
+	"isPrototypeOf",
+	"propertyIsEnumerable",
+	"toLocaleString",
+	"toString",
+	"valueOf",
+]);
 const FOLLOWUP_KINDS: ReadonlySet<FollowupKind> = new Set([
 	"reply",
 	"navigate",
@@ -122,7 +136,9 @@ function parseFormField(raw: unknown): InteractionField | null {
 	const name = typeof r.name === "string" ? r.name.trim() : "";
 	const type =
 		typeof r.type === "string" ? (r.type as InteractionFieldType) : "text";
-	if (!name || !/^[\w.-]+$/.test(name)) return null;
+	if (!name || !/^[\w.-]+$/.test(name) || UNSAFE_OBJECT_FIELD_NAMES.has(name)) {
+		return null;
+	}
 	if (!FIELD_TYPES.has(type)) return null;
 	const field: InteractionField = { name, type };
 	if (typeof r.label === "string") field.label = r.label;

--- a/packages/ui/src/components/chat/message-form-parser.test.ts
+++ b/packages/ui/src/components/chat/message-form-parser.test.ts
@@ -104,25 +104,28 @@ describe("parseFormBody", () => {
     });
   });
 
-  it("admits Object.prototype-key names (constructor/hasOwnProperty); render stays safe (#14489)", () => {
-    // `__proto__` is dropped upstream (SAFE_FIELD_NAME_RE requires a leading
-    // letter), but `constructor`/`hasOwnProperty` are structurally valid names
-    // and are ACCEPTED here — the crash hazard they pose lives in the value/error
-    // lookup, which FormRequest neutralizes with null-prototype state, so the
-    // chosen behavior is "accept + render safely" rather than parser-reject.
+  it("rejects inherited Object field names so malformed blocks degrade to text", () => {
     const form = parseFormBody(
       JSON.stringify({
         fields: [
           { name: "constructor", type: "text" },
-          { name: "hasOwnProperty", type: "number" },
-          { name: "__proto__", type: "text" },
+          { name: "hasOwnProperty", type: "text" },
+          { name: "propertyIsEnumerable", type: "text" },
+          { name: "toString", type: "text" },
+          { name: "safeName", type: "text" },
         ],
       }),
     );
-    expect(form?.fields.map((f) => f.name)).toEqual([
-      "constructor",
-      "hasOwnProperty",
-    ]);
+    expect(form?.fields.map((field) => field.name)).toEqual(["safeName"]);
+
+    const onlyUnsafe = JSON.stringify({
+      fields: [
+        { name: "constructor", type: "text" },
+        { name: "hasOwnProperty", type: "text" },
+      ],
+    });
+    expect(parseFormBody(onlyUnsafe)).toBeNull();
+    expect(findFormRegions(`[FORM]\n${onlyUnsafe}\n[/FORM]`)).toEqual([]);
   });
 
   it("returns null for malformed or empty input rather than throwing", () => {

--- a/packages/ui/src/components/chat/message-form-parser.ts
+++ b/packages/ui/src/components/chat/message-form-parser.ts
@@ -76,6 +76,20 @@ const FORM_FIELD_TYPES = new Set<FormFieldType>([
 
 /** Field names become state-path segments + result keys; keep them safe. */
 const SAFE_FIELD_NAME_RE = /^[A-Za-z][\w-]*$/;
+const UNSAFE_OBJECT_FIELD_NAMES = new Set([
+  "__defineGetter__",
+  "__defineSetter__",
+  "__lookupGetter__",
+  "__lookupSetter__",
+  "__proto__",
+  "constructor",
+  "hasOwnProperty",
+  "isPrototypeOf",
+  "propertyIsEnumerable",
+  "toLocaleString",
+  "toString",
+  "valueOf",
+]);
 
 export const FORM_RE = /\[FORM\]\n([\s\S]*?)\n\[\/FORM\]/g;
 
@@ -93,7 +107,13 @@ function parseField(raw: unknown): FormFieldSpec | null {
   if (!raw || typeof raw !== "object") return null;
   const record = raw as Record<string, unknown>;
   const name = record.name;
-  if (typeof name !== "string" || !SAFE_FIELD_NAME_RE.test(name)) return null;
+  if (
+    typeof name !== "string" ||
+    !SAFE_FIELD_NAME_RE.test(name) ||
+    UNSAFE_OBJECT_FIELD_NAMES.has(name)
+  ) {
+    return null;
+  }
   const type =
     typeof record.type === "string" &&
     FORM_FIELD_TYPES.has(record.type as FormFieldType)

--- a/packages/ui/src/components/chat/parser-parity.contract.test.ts
+++ b/packages/ui/src/components/chat/parser-parity.contract.test.ts
@@ -12,8 +12,8 @@
  *      (region count, scope, options, kinds) — so a future edit to either side
  *      that breaks parity fails here; and
  *   2. PINS the known FORM field-name divergence (UI `^[A-Za-z][\w-]*$` vs core
- *      `^[\w.-]+$`) as an explicit, tracked expectation, so reconciling it is a
- *      conscious change (update this test) rather than silent drift.
+ *      `^[\w.-]+$`) while requiring both parsers to reject Object-prototype
+ *      keys that would be hazardous for plain-object form state.
  *
  * If/when the UI parsers are made to delegate to core, the divergence assertion
  * flips to agreement and this file documents that the contract is now exact.
@@ -133,5 +133,16 @@ describe("parser parity — UI per-marker parsers vs @elizaos/core findInteracti
     // UI drops the field (none valid) → no region; core accepts the dotted name.
     expect(ui).toHaveLength(0);
     expect(core).toHaveLength(1);
+  });
+
+  it("FORM inherited Object field names are rejected by both parsers", () => {
+    const unsafe =
+      '[FORM]\n{"id":"f","fields":[{"name":"constructor","type":"text"},{"name":"hasOwnProperty","type":"text"}]}\n[/FORM]';
+    const ui = findFormRegions(unsafe);
+    const core = findInteractionRegions(unsafe)
+      .map((r) => r.block)
+      .filter((b) => b.kind === "form");
+    expect(ui).toHaveLength(0);
+    expect(core).toHaveLength(0);
   });
 });

--- a/packages/ui/src/components/chat/widgets/form-request.test.tsx
+++ b/packages/ui/src/components/chat/widgets/form-request.test.tsx
@@ -38,7 +38,9 @@ describe("FormRequest temporal fields", () => {
 
   it("renders native date/time/datetime-local inputs", () => {
     render(<FormRequest form={form} onSubmit={() => {}} />);
-    expect((screen.getByLabelText("Day") as HTMLInputElement).type).toBe("date");
+    expect((screen.getByLabelText("Day") as HTMLInputElement).type).toBe(
+      "date",
+    );
     expect((screen.getByLabelText("At") as HTMLInputElement).type).toBe("time");
     expect((screen.getByLabelText("When") as HTMLInputElement).type).toBe(
       "datetime-local",
@@ -115,8 +117,9 @@ describe("FormRequest prototype-polluting field names (#14489)", () => {
     expect(Object.hasOwn({}, "polluted")).toBe(false);
     expect(onSubmit).toHaveBeenCalledTimes(1);
     const submitted = onSubmit.mock.calls[0][1] as Record<string, unknown>;
-    expect(submitted.__proto__).toBe("a");
-    expect(submitted.hasOwnProperty).toBe("b");
+    expect(Object.hasOwn(submitted, "__proto__")).toBe(true);
+    expect(Reflect.get(submitted, "__proto__")).toBe("a");
+    expect(Reflect.get(submitted, "hasOwnProperty")).toBe("b");
   });
 
   it("validates a required `constructor` field instead of crashing", () => {
@@ -127,7 +130,12 @@ describe("FormRequest prototype-polluting field names (#14489)", () => {
           id: "f3",
           submitLabel: "Save",
           fields: [
-            { name: "constructor", type: "text", label: "Ctor", required: true },
+            {
+              name: "constructor",
+              type: "text",
+              label: "Ctor",
+              required: true,
+            },
           ],
         }}
         onSubmit={onSubmit}

--- a/packages/ui/src/components/chat/widgets/form-request.tsx
+++ b/packages/ui/src/components/chat/widgets/form-request.tsx
@@ -40,7 +40,9 @@ export type FormResultValue = string | boolean;
  * so no custom picker or dependency is added. Any other type is a plain text
  * box. Exported for the field-type unit test.
  */
-export function htmlInputTypeForField(fieldType: FormFieldSpec["type"]): string {
+export function htmlInputTypeForField(
+  fieldType: FormFieldSpec["type"],
+): string {
   switch (fieldType) {
     case "number":
       return "number";
@@ -61,44 +63,42 @@ export type FormRequestProps = {
   onSubmit: (formId: string, values: Record<string, FormResultValue>) => void;
 };
 
+type FormValueRecord = Record<string, FormResultValue>;
+type FormErrorRecord = Record<string, string[]>;
+
 function initialValueFor(field: FormFieldSpec): FormResultValue {
   return field.type === "checkbox" ? false : "";
 }
 
-/**
- * Copy a null-prototype record and set one key, keeping the result null-proto
- * (object spread `{ ...prev }` would re-inherit `Object.prototype`, reopening
- * the field-named-`constructor` hazard). See the state comment in `FormRequest`.
- */
-function mergeRecord<V>(
-  prev: Record<string, V>,
-  key: string,
-  value: V,
-): Record<string, V> {
-  const next: Record<string, V> = Object.assign(Object.create(null), prev);
-  next[key] = value;
-  return next;
+function createFormRecord<T>(): Record<string, T> {
+  return Object.create(null) as Record<string, T>;
+}
+
+function copyFormRecord<T>(record: Record<string, T>): Record<string, T> {
+  return Object.assign(createFormRecord<T>(), record);
+}
+
+function getOwnRecordValue<T>(
+  record: Record<string, T>,
+  name: string,
+): T | undefined {
+  return Object.hasOwn(record, name) ? record[name] : undefined;
+}
+
+function toSubmitPayload(values: FormValueRecord): FormValueRecord {
+  return copyFormRecord(values);
 }
 
 export function FormRequest({ form, onSubmit }: FormRequestProps) {
-  // `values`/`errors` are keyed by attacker-controlled field names (the agent
-  // emits the form JSON). A plain `{}` inherits `Object.prototype`, so a field
-  // named `constructor` / `hasOwnProperty` / `__proto__` would make
-  // `errors[field.name]` return an inherited function (truthy, `.length===1`)
-  // and crash the transcript when `ConfigFieldErrors` calls `.map` on it — and
-  // `obj["__proto__"] = v` would pollute the prototype. Null-prototype records,
-  // preserved through every update, make every lookup an own-property read and
-  // turn such names into ordinary working fields (#14489). `mergeRecord` keeps
-  // the map null-proto across spreads (object spread would re-inherit).
-  const [values, setValues] = useState<Record<string, FormResultValue>>(() => {
-    const initial: Record<string, FormResultValue> = Object.create(null);
+  const [values, setValues] = useState<FormValueRecord>(() => {
+    const initial = createFormRecord<FormResultValue>();
     for (const field of form.fields) {
       initial[field.name] = initialValueFor(field);
     }
     return initial;
   });
-  const [errors, setErrors] = useState<Record<string, string[]>>(() =>
-    Object.create(null),
+  const [errors, setErrors] = useState<FormErrorRecord>(() =>
+    createFormRecord<string[]>(),
   );
   const [submitted, setSubmitted] = useState(false);
 
@@ -108,11 +108,15 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
   );
 
   const setValue = useCallback((name: string, value: FormResultValue) => {
-    setValues((prev) => mergeRecord(prev, name, value));
+    setValues((prev) => {
+      const next = copyFormRecord(prev);
+      next[name] = value;
+      return next;
+    });
   }, []);
 
   const validateField = useCallback(
-    (field: FormFieldSpec, value: FormResultValue) => {
+    (field: FormFieldSpec, value: FormResultValue | undefined) => {
       if (!field.required || field.type === "checkbox") return;
       const fieldErrors = runValidation(
         [
@@ -123,7 +127,11 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
         ],
         value,
       );
-      setErrors((prev) => mergeRecord(prev, field.name, fieldErrors));
+      setErrors((prev) => {
+        const next = copyFormRecord(prev);
+        next[field.name] = fieldErrors;
+        return next;
+      });
     },
     [],
   );
@@ -133,7 +141,7 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
       event.preventDefault();
       if (submitted) return;
 
-      const nextErrors: Record<string, string[]> = Object.create(null);
+      const nextErrors = createFormRecord<string[]>();
       for (const field of requiredFields) {
         const fieldErrors = runValidation(
           [
@@ -142,7 +150,7 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
               message: `${field.label ?? field.name} is required`,
             },
           ],
-          values[field.name],
+          getOwnRecordValue(values, field.name),
         );
         if (fieldErrors.length > 0) nextErrors[field.name] = fieldErrors;
       }
@@ -150,7 +158,7 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
       if (Object.keys(nextErrors).length > 0) return;
 
       setSubmitted(true);
-      onSubmit(form.id, values);
+      onSubmit(form.id, toSubmitPayload(values));
     },
     [form.id, onSubmit, requiredFields, submitted, values],
   );
@@ -169,7 +177,8 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
 
       {form.fields.map((field) => {
         const label = field.label ?? field.name;
-        const fieldErrors = errors[field.name];
+        const value = getOwnRecordValue(values, field.name);
+        const fieldErrors = getOwnRecordValue(errors, field.name);
         if (field.type === "checkbox") {
           const checkboxId = `${form.id}-${field.name}`;
           return (
@@ -180,7 +189,7 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
             >
               <Checkbox
                 id={checkboxId}
-                checked={Boolean(values[field.name])}
+                checked={Boolean(value)}
                 disabled={submitted}
                 onCheckedChange={(checked) => setValue(field.name, !!checked)}
               />
@@ -190,7 +199,7 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
         }
         if (field.type === "select") {
           const options = field.options ?? [];
-          const current = String(values[field.name] ?? "");
+          const current = String(value ?? "");
           return (
             <div key={field.name} className="flex flex-col gap-1 text-xs">
               <span className="font-semibold">{label}</span>
@@ -244,11 +253,13 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
               type={htmlInputTypeForField(field.type)}
               name={field.name}
               placeholder={field.placeholder ?? ""}
-              value={String(values[field.name] ?? "")}
+              value={String(value ?? "")}
               disabled={submitted}
               required={field.required}
               onChange={(e) => setValue(field.name, e.currentTarget.value)}
-              onBlur={() => validateField(field, values[field.name])}
+              onBlur={() =>
+                validateField(field, getOwnRecordValue(values, field.name))
+              }
             />
             <ConfigFieldErrors errors={fieldErrors} />
           </div>

--- a/packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx
+++ b/packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx
@@ -94,6 +94,36 @@ describe("FormRequest — every input + submit", () => {
     expect(screen.getByText(/Repo URL is required/i)).toBeTruthy();
   });
 
+  it("does not crash when a direct form spec uses inherited Object field names", () => {
+    const onSubmit = vi.fn();
+    const inheritedNames: FormRequestSpec = {
+      id: "unsafe-names",
+      submitLabel: "Save",
+      fields: [
+        { name: "constructor", type: "text", label: "Constructor" },
+        { name: "hasOwnProperty", type: "text", label: "Has own property" },
+      ],
+    };
+    render(<FormRequest form={inheritedNames} onSubmit={onSubmit} />);
+
+    fireEvent.change(screen.getByLabelText("Constructor"), {
+      target: { value: "ctor" },
+    });
+    fireEvent.change(screen.getByLabelText("Has own property"), {
+      target: { value: "own" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const payload = onSubmit.mock.calls[0]?.[1];
+    expect(Object.hasOwn(payload, "constructor")).toBe(true);
+    expect(Object.hasOwn(payload, "hasOwnProperty")).toBe(true);
+    expect(payload).toMatchObject({
+      constructor: "ctor",
+      hasOwnProperty: "own",
+    });
+  });
+
   it("locks after a successful submit (no double-send)", () => {
     const onSubmit = vi.fn();
     render(<FormRequest form={form} onSubmit={onSubmit} />);


### PR DESCRIPTION
## Summary
- Reject Object-prototype field names (`constructor`, `hasOwnProperty`, `__proto__`, etc.) in both the UI `[FORM]` parser and the core interaction parser, so malformed blocks degrade to text instead of rendering hazardous state keys.
- Harden `FormRequest` to use own-property reads and null-prototype internal records, so direct/bypassed specs cannot crash on inherited keys.
- Add parser, parser-parity, core interaction, and render behavior regressions for #14489.

Fixes #14489.

## Evidence
- `bun run --cwd packages/ui test src/components/chat/message-form-parser.test.ts src/components/chat/parser-parity.contract.test.ts src/components/chat/widgets/interaction-widgets.behavior.test.tsx src/components/chat/widgets/form-request.test.tsx` passed: 4 files, 29 tests.
- `bun run --cwd packages/core test src/messaging/interactions/interactions.test.ts` passed: 35 tests.
- `bun run --cwd packages/core typecheck` passed.
- `bunx @biomejs/biome check packages/ui/src/components/chat/message-form-parser.ts packages/ui/src/components/chat/message-form-parser.test.ts packages/ui/src/components/chat/parser-parity.contract.test.ts packages/ui/src/components/chat/widgets/form-request.tsx packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx packages/core/src/messaging/interactions/parse.ts packages/core/src/messaging/interactions/interactions.test.ts` passed.
- `git diff --cached --check` passed before commit.

## Notes
- `bun run --cwd packages/ui typecheck` still fails on unrelated existing package errors in `todo.test.tsx`, `home-screen-fixture.api-stub.ts`, `startup-phase-poll.test.ts`, `widget-cert-fixture.tsx`, and `voice-selftest-harness.test.ts`. None are in the touched files.
- Real LLM trajectories: N/A - parser/render safety fix for deterministic malformed widget markup; no model/action/provider behavior changed.
- App visual audit: N/A - no app-shell visual styling/layout change; behavior is covered by jsdom render tests.