### PR TITLE
fix(#14489): FORM field named 'constructor' no longer crashes the chat

### DIFF
--- a/packages/ui/src/components/chat/message-form-parser.test.ts
+++ b/packages/ui/src/components/chat/message-form-parser.test.ts
@@ -104,6 +104,27 @@ describe("parseFormBody", () => {
     });
   });
 
+  it("admits Object.prototype-key names (constructor/hasOwnProperty); render stays safe (#14489)", () => {
+    // `__proto__` is dropped upstream (SAFE_FIELD_NAME_RE requires a leading
+    // letter), but `constructor`/`hasOwnProperty` are structurally valid names
+    // and are ACCEPTED here — the crash hazard they pose lives in the value/error
+    // lookup, which FormRequest neutralizes with null-prototype state, so the
+    // chosen behavior is "accept + render safely" rather than parser-reject.
+    const form = parseFormBody(
+      JSON.stringify({
+        fields: [
+          { name: "constructor", type: "text" },
+          { name: "hasOwnProperty", type: "number" },
+          { name: "__proto__", type: "text" },
+        ],
+      }),
+    );
+    expect(form?.fields.map((f) => f.name)).toEqual([
+      "constructor",
+      "hasOwnProperty",
+    ]);
+  });
+
   it("returns null for malformed or empty input rather than throwing", () => {
     expect(parseFormBody("not json")).toBeNull();
     expect(parseFormBody("[]")).toBeNull();

--- a/packages/ui/src/components/chat/widgets/form-request.test.tsx
+++ b/packages/ui/src/components/chat/widgets/form-request.test.tsx
@@ -65,3 +65,79 @@ describe("FormRequest temporal fields", () => {
     });
   });
 });
+
+// #14489: an agent-emitted field named after an Object.prototype key
+// (`constructor`, `hasOwnProperty`, `__proto__`) must not crash the transcript
+// — the null-prototype value/error state turns them into ordinary fields.
+describe("FormRequest prototype-polluting field names (#14489)", () => {
+  it("renders a field named `constructor` as a working field without crashing", () => {
+    const onSubmit = vi.fn();
+    render(
+      <FormRequest
+        form={{
+          id: "f",
+          submitLabel: "Send",
+          fields: [{ name: "constructor", type: "text", label: "Ctor" }],
+        }}
+        onSubmit={onSubmit}
+      />,
+    );
+    // Before the fix, rendering threw (errors["constructor"] → Object ctor → .map).
+    const input = screen.getByLabelText("Ctor") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "hello" } });
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    expect(onSubmit).toHaveBeenCalledWith("f", { constructor: "hello" });
+  });
+
+  it("renders `__proto__` / `hasOwnProperty` fields without polluting or crashing", () => {
+    const onSubmit = vi.fn();
+    render(
+      <FormRequest
+        form={{
+          id: "f2",
+          submitLabel: "Go",
+          fields: [
+            { name: "__proto__", type: "text", label: "Proto" },
+            { name: "hasOwnProperty", type: "text", label: "HasOwn" },
+          ],
+        }}
+        onSubmit={onSubmit}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText("Proto"), {
+      target: { value: "a" },
+    });
+    fireEvent.change(screen.getByLabelText("HasOwn"), {
+      target: { value: "b" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Go" }));
+    // No prototype pollution: a fresh plain object still has no own "a".
+    expect(Object.hasOwn({}, "polluted")).toBe(false);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const submitted = onSubmit.mock.calls[0][1] as Record<string, unknown>;
+    expect(submitted.__proto__).toBe("a");
+    expect(submitted.hasOwnProperty).toBe("b");
+  });
+
+  it("validates a required `constructor` field instead of crashing", () => {
+    const onSubmit = vi.fn();
+    render(
+      <FormRequest
+        form={{
+          id: "f3",
+          submitLabel: "Save",
+          fields: [
+            { name: "constructor", type: "text", label: "Ctor", required: true },
+          ],
+        }}
+        onSubmit={onSubmit}
+      />,
+    );
+    // Submitting empty must run validation (not crash) and block submit; the
+    // field + button stay rendered (a crash would unmount the whole subtree).
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByLabelText("Ctor")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Save" })).toBeTruthy();
+  });
+});

--- a/packages/ui/src/components/chat/widgets/form-request.tsx
+++ b/packages/ui/src/components/chat/widgets/form-request.tsx
@@ -65,15 +65,41 @@ function initialValueFor(field: FormFieldSpec): FormResultValue {
   return field.type === "checkbox" ? false : "";
 }
 
+/**
+ * Copy a null-prototype record and set one key, keeping the result null-proto
+ * (object spread `{ ...prev }` would re-inherit `Object.prototype`, reopening
+ * the field-named-`constructor` hazard). See the state comment in `FormRequest`.
+ */
+function mergeRecord<V>(
+  prev: Record<string, V>,
+  key: string,
+  value: V,
+): Record<string, V> {
+  const next: Record<string, V> = Object.assign(Object.create(null), prev);
+  next[key] = value;
+  return next;
+}
+
 export function FormRequest({ form, onSubmit }: FormRequestProps) {
+  // `values`/`errors` are keyed by attacker-controlled field names (the agent
+  // emits the form JSON). A plain `{}` inherits `Object.prototype`, so a field
+  // named `constructor` / `hasOwnProperty` / `__proto__` would make
+  // `errors[field.name]` return an inherited function (truthy, `.length===1`)
+  // and crash the transcript when `ConfigFieldErrors` calls `.map` on it — and
+  // `obj["__proto__"] = v` would pollute the prototype. Null-prototype records,
+  // preserved through every update, make every lookup an own-property read and
+  // turn such names into ordinary working fields (#14489). `mergeRecord` keeps
+  // the map null-proto across spreads (object spread would re-inherit).
   const [values, setValues] = useState<Record<string, FormResultValue>>(() => {
-    const initial: Record<string, FormResultValue> = {};
+    const initial: Record<string, FormResultValue> = Object.create(null);
     for (const field of form.fields) {
       initial[field.name] = initialValueFor(field);
     }
     return initial;
   });
-  const [errors, setErrors] = useState<Record<string, string[]>>({});
+  const [errors, setErrors] = useState<Record<string, string[]>>(() =>
+    Object.create(null),
+  );
   const [submitted, setSubmitted] = useState(false);
 
   const requiredFields = useMemo(
@@ -82,7 +108,7 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
   );
 
   const setValue = useCallback((name: string, value: FormResultValue) => {
-    setValues((prev) => ({ ...prev, [name]: value }));
+    setValues((prev) => mergeRecord(prev, name, value));
   }, []);
 
   const validateField = useCallback(
@@ -97,7 +123,7 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
         ],
         value,
       );
-      setErrors((prev) => ({ ...prev, [field.name]: fieldErrors }));
+      setErrors((prev) => mergeRecord(prev, field.name, fieldErrors));
     },
     [],
   );
@@ -107,7 +133,7 @@ export function FormRequest({ form, onSubmit }: FormRequestProps) {
       event.preventDefault();
       if (submitted) return;
 
-      const nextErrors: Record<string, string[]> = {};
+      const nextErrors: Record<string, string[]> = Object.create(null);
       for (const field of requiredFields) {
         const fieldErrors = runValidation(
           [


### PR DESCRIPTION
Closes #14489.

## The bug (prototype pollution → transcript crash)

An agent-emitted `[FORM]` field named after an `Object.prototype` key crashed the whole chat message render:
```
[FORM]
{"id":"f","fields":[{"name":"constructor","type":"text"}]}
[/FORM]
```
`SAFE_FIELD_NAME_RE` (`^[A-Za-z][\w-]*$`) admits `constructor` / `hasOwnProperty` (leading letter), and `FormRequest`'s plain-object `errors` state then did an **inherited-property lookup**: `errors["constructor"]` on `{}` returns the `Object` constructor function — truthy, `.length === 1` — so `ConfigFieldErrors` called `.map` on a function → `TypeError` → the transcript crashed. `obj["__proto__"] = v` on the plain object was also a pollution vector.

Found by an adversarial pass over #14323 (pre-existing, **not** introduced there).

## Fix

Back the `values`/`errors` state with **null-prototype records** (`Object.create(null)`), preserved across every update via a `mergeRecord` helper (object spread `{ ...prev }` would re-inherit `Object.prototype` and reopen the hole). Now every lookup is an own-property read and `obj["__proto__"] = v` sets an ordinary own key — so such names render as **working fields** rather than crashing (satisfies the AC's "working field or designed degrade"). No parser change needed: `__proto__` is already dropped upstream (fails the leading-letter regex), and `constructor`/`hasOwnProperty` are structurally valid names whose only hazard was the lookup this fixes.

## Acceptance criteria

- [x] A `[FORM]` with a field named `constructor` / `hasOwnProperty` / `__proto__` renders safely on both chat surfaces (both render the same `FormRequest`) — component tests below.
- [x] Regression tests in `message-form-parser.test.ts` (parser admits `constructor`/`hasOwnProperty`, drops `__proto__`) **and** `form-request.test.tsx` (render + submit + validate without crash/pollution).
- [x] Parity contract unchanged — the accepted-name sets are not narrowed (the fix is at the render layer), so no parser-parity drift.

## Evidence — real test runs (ran locally, green)

```
bun run --cwd packages/ui test --run src/components/chat/widgets/form-request src/components/chat/message-form-parser
  → Test Files  2 passed (2)
     Tests  16 passed (16)
```
New cases:
- `form-request.test.tsx` — "renders a field named `constructor` as a working field without crashing" (types + submits `{constructor:"hello"}`); "renders `__proto__` / `hasOwnProperty` fields without polluting or crashing" (asserts no prototype pollution + verbatim submit); "validates a required `constructor` field instead of crashing" (blocks submit, subtree stays mounted).
- `message-form-parser.test.ts` — "admits Object.prototype-key names (constructor/hasOwnProperty); render stays safe".

**Screenshots / MP4 / live-LLM: N/A** — a crash-on-render bug; the component tests (both surfaces render the same `FormRequest`) that fail on the old code and pass on the fix are the complete proof. No model/prompt or visual-styling surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
