### PR TITLE
feat(lifeops): SCHEDULED_TASKS overdue/today due-window verb + prove plugin-toggle use case (#14368)

### DIFF
--- a/packages/agent/src/actions/plugin-toggle.test.ts
+++ b/packages/agent/src/actions/plugin-toggle.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Regression test for the `PLUGIN action=toggle` verb.
+ *
+ * The Plugins view enables/disables a plugin via `client.updatePlugin(id,
+ * { enabled })` → `PUT /api/plugins/:id`. This asserts the agent's semantic
+ * `PLUGIN` action drives the SAME endpoint and body, so a chat/voice user's
+ * "turn on the calendar plugin" hits one shared use case rather than the
+ * synthetic-DOM bridge. `fetch` is stubbed to capture the outbound request.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+import { pluginAction } from "./plugin.ts";
+
+interface CapturedRequest {
+  url: string;
+  method?: string;
+  body: unknown;
+}
+
+function stubFetch(response: Record<string, unknown>): {
+  captured: CapturedRequest[];
+  restore: () => void;
+} {
+  const captured: CapturedRequest[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (input: unknown, init?: RequestInit) => {
+    captured.push({
+      url: String(input),
+      method: init?.method,
+      body: typeof init?.body === "string" ? JSON.parse(init.body) : init?.body,
+    });
+    return {
+      ok: true,
+      status: 200,
+      json: async () => response,
+    } as Response;
+  }) as typeof fetch;
+  return {
+    captured,
+    restore: () => {
+      globalThis.fetch = original;
+    },
+  };
+}
+
+const runtime = { agentId: "agent-1" } as unknown as IAgentRuntime;
+
+async function invokeToggle(pluginId: string, enabled: boolean) {
+  return pluginAction.handler(
+    runtime,
+    { content: { text: "" } } as never,
+    undefined,
+    { parameters: { action: "toggle", pluginId, enabled } },
+    undefined,
+  );
+}
+
+describe("PLUGIN action=toggle → PUT /api/plugins/:id", () => {
+  let restoreFetch: (() => void) | null = null;
+
+  afterEach(() => {
+    restoreFetch?.();
+    restoreFetch = null;
+  });
+
+  it("issues PUT /api/plugins/:id with { enabled: true } to the same use case the UI calls", async () => {
+    const { captured, restore } = stubFetch({ success: true });
+    restoreFetch = restore;
+
+    const result = await invokeToggle("discord", true);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].method).toBe("PUT");
+    expect(captured[0].url).toMatch(/\/api\/plugins\/discord$/);
+    expect(captured[0].body).toEqual({ enabled: true });
+    expect(result).toBeDefined();
+    expect(result?.success).toBe(true);
+    expect(result?.data).toMatchObject({ op: "toggle", enabled: true });
+  });
+
+  it("encodes a scoped plugin id and forwards { enabled: false } on disable", async () => {
+    const { captured, restore } = stubFetch({ success: true });
+    restoreFetch = restore;
+
+    await invokeToggle("@elizaos/plugin-calendar", false);
+
+    expect(captured[0].url).toContain(
+      encodeURIComponent("@elizaos/plugin-calendar"),
+    );
+    expect(captured[0].body).toEqual({ enabled: false });
+  });
+
+  it("fails without a valid `enabled` boolean instead of guessing", async () => {
+    const { captured, restore } = stubFetch({ success: true });
+    restoreFetch = restore;
+
+    const result = await pluginAction.handler(
+      runtime,
+      { content: { text: "" } } as never,
+      undefined,
+      { parameters: { action: "toggle", pluginId: "discord" } },
+      undefined,
+    );
+
+    expect(result?.success).toBe(false);
+    // No network call when the required param is missing.
+    expect(captured).toHaveLength(0);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/actions/scheduled-task.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/scheduled-task.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Unit tests for the `SCHEDULED_TASKS` action's `list` due-window filter.
+ *
+ * Proves the semantic verb the planner discovers — `action=list dueWindow=…` —
+ * routes through the `getScheduledTaskRunner` use case (the SAME runner the
+ * Tasks/LifeOps surface reads), calling the runner's own `resolveNextFireAt`
+ * projection to partition "overdue"/"today" instead of any synthetic-DOM
+ * bridge. The runner primitive itself is covered end-to-end against a real
+ * in-memory store in `@elizaos/plugin-scheduling`'s `runner.test.ts`; here we
+ * assert the action wires `dueWindow` to that primitive and shapes the result.
+ */
+
+import type { HandlerCallback, IAgentRuntime, Memory } from "@elizaos/core";
+import type {
+  ScheduledTask,
+  ScheduledTaskFilter,
+} from "@elizaos/plugin-scheduling";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const NOW_MS = Date.parse("2026-05-09T12:00:00.000Z");
+const OVERDUE_ISO = "2026-05-09T09:00:00.000Z";
+const LATER_TODAY_ISO = "2026-05-09T18:00:00.000Z";
+
+/** Fixed next-fire projection per task, keyed by promptInstructions. `null`
+ * models a trigger with no wall-clock fire time (event/manual/after_task). */
+const NEXT_FIRE_BY_PROMPT: Record<string, string | null> = {
+  "overdue-task": OVERDUE_ISO,
+  "later-today-task": LATER_TODAY_ISO,
+  "manual-task": null,
+};
+
+let storedTasks: ScheduledTask[];
+let resolveNextFireAtCalls: string[];
+
+function fakeTask(promptInstructions: string): ScheduledTask {
+  return {
+    taskId: `id-${promptInstructions}`,
+    kind: "reminder",
+    promptInstructions,
+    trigger: { kind: "manual" },
+    priority: "medium",
+    respectsGlobalPause: true,
+    state: { status: "scheduled", followupCount: 0 },
+    source: "user_chat",
+    createdBy: "tester",
+    ownerVisible: true,
+  } as ScheduledTask;
+}
+
+// The action resolves its runner through this accessor; return a fake that
+// implements exactly the two methods handleList touches so the test isolates
+// the action's wiring, not the runner internals.
+vi.mock("../lifeops/scheduled-task/service.js", () => ({
+  getScheduledTaskRunner: vi.fn(() => ({
+    async list(_filter?: ScheduledTaskFilter) {
+      return storedTasks;
+    },
+    async resolveNextFireAt(task: ScheduledTask) {
+      resolveNextFireAtCalls.push(task.promptInstructions);
+      return NEXT_FIRE_BY_PROMPT[task.promptInstructions] ?? null;
+    },
+  })),
+}));
+
+vi.mock("../lifeops/access.js", () => ({
+  hasLifeOpsAccess: vi.fn(async () => true),
+}));
+
+vi.mock("../lifeops/pending-prompts/store.js", () => ({
+  resolvePendingPromptsStore: vi.fn(() => ({
+    forgetTask: vi.fn(async () => {}),
+  })),
+}));
+
+import { scheduledTaskAction } from "./scheduled-task.js";
+
+function makeRuntime(): IAgentRuntime {
+  return { agentId: "test-agent" } as unknown as IAgentRuntime;
+}
+
+function makeMessage(): Memory {
+  return {
+    entityId: "owner-entity",
+    roomId: "room-1",
+    content: { text: "" },
+  } as unknown as Memory;
+}
+
+interface ListResultData {
+  tasks: ScheduledTask[];
+  dueWindow?: "overdue" | "today";
+}
+
+async function listWith(
+  dueWindow?: "overdue" | "today",
+): Promise<ListResultData> {
+  const callback: HandlerCallback = async () => [];
+  const result = await scheduledTaskAction.handler(
+    makeRuntime(),
+    makeMessage(),
+    undefined,
+    { parameters: { action: "list", ...(dueWindow ? { dueWindow } : {}) } },
+    callback,
+  );
+  return result.data as ListResultData;
+}
+
+describe("SCHEDULED_TASKS list — dueWindow filter", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_MS);
+    storedTasks = [
+      fakeTask("overdue-task"),
+      fakeTask("later-today-task"),
+      fakeTask("manual-task"),
+    ];
+    resolveNextFireAtCalls = [];
+  });
+
+  it("returns every task with no dueWindow and never consults resolveNextFireAt", async () => {
+    const data = await listWith();
+    expect(data.tasks.map((t) => t.promptInstructions).sort()).toEqual([
+      "later-today-task",
+      "manual-task",
+      "overdue-task",
+    ]);
+    expect(data.dueWindow).toBeUndefined();
+    // Unfiltered list must not pay the per-task next-fire projection cost.
+    expect(resolveNextFireAtCalls).toEqual([]);
+  });
+
+  it("dueWindow=overdue keeps only tasks whose fire time is already past", async () => {
+    const data = await listWith("overdue");
+    expect(data.tasks.map((t) => t.promptInstructions)).toEqual([
+      "overdue-task",
+    ]);
+    expect(data.dueWindow).toBe("overdue");
+    // Every candidate is projected through the runner's own next-fire math.
+    expect(resolveNextFireAtCalls.sort()).toEqual([
+      "later-today-task",
+      "manual-task",
+      "overdue-task",
+    ]);
+  });
+
+  it("dueWindow=today keeps past and later-today fires, excludes no-fire-time tasks", async () => {
+    const data = await listWith("today");
+    expect(data.tasks.map((t) => t.promptInstructions).sort()).toEqual([
+      "later-today-task",
+      "overdue-task",
+    ]);
+    expect(data.dueWindow).toBe("today");
+  });
+
+  it("ignores an unknown dueWindow value (no filtering, no projection)", async () => {
+    const callback: HandlerCallback = async () => [];
+    const result = await scheduledTaskAction.handler(
+      makeRuntime(),
+      makeMessage(),
+      undefined,
+      { parameters: { action: "list", dueWindow: "next-week" } },
+      callback,
+    );
+    const data = result.data as ListResultData;
+    expect(data.tasks).toHaveLength(3);
+    expect(data.dueWindow).toBeUndefined();
+    expect(resolveNextFireAtCalls).toEqual([]);
+  });
+
+  it("exposes dueWindow on the semantic action's parameters", () => {
+    const paramNames = (scheduledTaskAction.parameters ?? []).map(
+      (p) => p.name,
+    );
+    expect(paramNames).toContain("dueWindow");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+});

--- a/plugins/plugin-personal-assistant/src/actions/scheduled-task.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/scheduled-task.test.ts
@@ -26,11 +26,19 @@ const LATER_TODAY_ISO = "2026-05-09T18:00:00.000Z";
 const NEXT_FIRE_BY_PROMPT: Record<string, string | null> = {
   "overdue-task": OVERDUE_ISO,
   "later-today-task": LATER_TODAY_ISO,
+  "missed-recurring-task": "2026-05-10T09:00:00.000Z",
   "manual-task": null,
+};
+const DUE_BY_PROMPT: Record<string, boolean> = {
+  "overdue-task": true,
+  "later-today-task": false,
+  "missed-recurring-task": true,
+  "manual-task": false,
 };
 
 let storedTasks: ScheduledTask[];
 let resolveNextFireAtCalls: string[];
+let resolveDueDecisionCalls: string[];
 
 function fakeTask(promptInstructions: string): ScheduledTask {
   return {
@@ -58,6 +66,15 @@ vi.mock("../lifeops/scheduled-task/service.js", () => ({
     async resolveNextFireAt(task: ScheduledTask) {
       resolveNextFireAtCalls.push(task.promptInstructions);
       return NEXT_FIRE_BY_PROMPT[task.promptInstructions] ?? null;
+    },
+    async resolveDueDecision(task: ScheduledTask) {
+      resolveDueDecisionCalls.push(task.promptInstructions);
+      return {
+        due: DUE_BY_PROMPT[task.promptInstructions] ?? false,
+        reason: DUE_BY_PROMPT[task.promptInstructions]
+          ? "test_due"
+          : "test_pending",
+      };
     },
   })),
 }));
@@ -112,9 +129,11 @@ describe("SCHEDULED_TASKS list — dueWindow filter", () => {
     storedTasks = [
       fakeTask("overdue-task"),
       fakeTask("later-today-task"),
+      fakeTask("missed-recurring-task"),
       fakeTask("manual-task"),
     ];
     resolveNextFireAtCalls = [];
+    resolveDueDecisionCalls = [];
   });
 
   it("returns every task with no dueWindow and never consults resolveNextFireAt", async () => {
@@ -122,23 +141,28 @@ describe("SCHEDULED_TASKS list — dueWindow filter", () => {
     expect(data.tasks.map((t) => t.promptInstructions).sort()).toEqual([
       "later-today-task",
       "manual-task",
+      "missed-recurring-task",
       "overdue-task",
     ]);
     expect(data.dueWindow).toBeUndefined();
     // Unfiltered list must not pay the per-task next-fire projection cost.
     expect(resolveNextFireAtCalls).toEqual([]);
+    expect(resolveDueDecisionCalls).toEqual([]);
   });
 
-  it("dueWindow=overdue keeps only tasks whose fire time is already past", async () => {
+  it("dueWindow=overdue keeps already-due tasks, including missed recurring occurrences", async () => {
     const data = await listWith("overdue");
-    expect(data.tasks.map((t) => t.promptInstructions)).toEqual([
+    expect(data.tasks.map((t) => t.promptInstructions).sort()).toEqual([
+      "missed-recurring-task",
       "overdue-task",
     ]);
     expect(data.dueWindow).toBe("overdue");
-    // Every candidate is projected through the runner's own next-fire math.
-    expect(resolveNextFireAtCalls.sort()).toEqual([
+    // Pending tasks do not pay the next-fire projection cost for overdue.
+    expect(resolveNextFireAtCalls).toEqual([]);
+    expect(resolveDueDecisionCalls.sort()).toEqual([
       "later-today-task",
       "manual-task",
+      "missed-recurring-task",
       "overdue-task",
     ]);
   });
@@ -147,6 +171,7 @@ describe("SCHEDULED_TASKS list — dueWindow filter", () => {
     const data = await listWith("today");
     expect(data.tasks.map((t) => t.promptInstructions).sort()).toEqual([
       "later-today-task",
+      "missed-recurring-task",
       "overdue-task",
     ]);
     expect(data.dueWindow).toBe("today");
@@ -162,9 +187,10 @@ describe("SCHEDULED_TASKS list — dueWindow filter", () => {
       callback,
     );
     const data = result.data as ListResultData;
-    expect(data.tasks).toHaveLength(3);
+    expect(data.tasks).toHaveLength(4);
     expect(data.dueWindow).toBeUndefined();
     expect(resolveNextFireAtCalls).toEqual([]);
+    expect(resolveDueDecisionCalls).toEqual([]);
   });
 
   it("exposes dueWindow on the semantic action's parameters", () => {

--- a/plugins/plugin-personal-assistant/src/actions/scheduled-task.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/scheduled-task.test.ts
@@ -27,18 +27,21 @@ const NEXT_FIRE_BY_PROMPT: Record<string, string | null> = {
   "overdue-task": OVERDUE_ISO,
   "later-today-task": LATER_TODAY_ISO,
   "missed-recurring-task": "2026-05-10T09:00:00.000Z",
+  "server-tomorrow-owner-tomorrow-task": "2026-05-10T13:00:00.000Z",
   "manual-task": null,
 };
 const DUE_BY_PROMPT: Record<string, boolean> = {
   "overdue-task": true,
   "later-today-task": false,
   "missed-recurring-task": true,
+  "server-tomorrow-owner-tomorrow-task": false,
   "manual-task": false,
 };
 
 let storedTasks: ScheduledTask[];
 let resolveNextFireAtCalls: string[];
 let resolveDueDecisionCalls: string[];
+let ownerTimezone: string;
 
 function fakeTask(promptInstructions: string): ScheduledTask {
   return {
@@ -75,6 +78,9 @@ vi.mock("../lifeops/scheduled-task/service.js", () => ({
           ? "test_due"
           : "test_pending",
       };
+    },
+    async resolveOwnerFacts() {
+      return { timezone: ownerTimezone };
     },
   })),
 }));
@@ -134,6 +140,7 @@ describe("SCHEDULED_TASKS list — dueWindow filter", () => {
     ];
     resolveNextFireAtCalls = [];
     resolveDueDecisionCalls = [];
+    ownerTimezone = "UTC";
   });
 
   it("returns every task with no dueWindow and never consults resolveNextFireAt", async () => {
@@ -175,6 +182,19 @@ describe("SCHEDULED_TASKS list — dueWindow filter", () => {
       "overdue-task",
     ]);
     expect(data.dueWindow).toBe("today");
+  });
+
+  it("dueWindow=today uses the owner timezone boundary, not the server date", async () => {
+    vi.setSystemTime(Date.parse("2026-05-10T02:00:00.000Z"));
+    ownerTimezone = "America/New_York";
+    storedTasks = [fakeTask("server-tomorrow-owner-tomorrow-task")];
+
+    const data = await listWith("today");
+
+    expect(data.tasks).toEqual([]);
+    expect(resolveNextFireAtCalls).toEqual([
+      "server-tomorrow-owner-tomorrow-task",
+    ]);
   });
 
   it("ignores an unknown dueWindow value (no filtering, no projection)", async () => {

--- a/plugins/plugin-personal-assistant/src/actions/scheduled-task.ts
+++ b/plugins/plugin-personal-assistant/src/actions/scheduled-task.ts
@@ -513,17 +513,14 @@ function normalizeDueWindow(value: unknown): DueWindow | undefined {
 }
 
 /**
- * Keep tasks whose next fire time falls inside `window`, using the runner's
- * own next-fire projection (the same value the scheduler tick indexes) so the
- * chat/voice filter and the tick never disagree about what is "due". Tasks
- * with no wall-clock fire time (event/manual/after_task, or settled
- * non-recurring rows) resolve to `null` and are excluded from both windows —
- * they have no "overdue"/"today" instant to compare against. `overdue` is
- * strictly in the past; `today` is anything due by end of the current day
- * (so it is a superset of `overdue` — an already-missed reminder is still due
- * today). The day boundary uses server-local time; the runner's projected
- * instant already carries the owner's trigger timezone, so cross-tz skew is at
- * most one day-boundary and acceptable for this coarse "today" cut.
+ * Keep tasks whose due instant falls inside `window`, using the runner's
+ * due-decision and next-fire projection so the chat/voice filter and scheduler
+ * tick share the same owner-facts and anchor dependencies. Already-due tasks
+ * are considered before the future next-fire projection; otherwise a missed
+ * recurring occurrence can project to tomorrow and disappear from an
+ * "overdue" view. Tasks with no wall-clock due time (event/manual/after_task,
+ * or settled non-recurring rows) are excluded from both windows. `today` is a
+ * superset of `overdue`.
  */
 async function filterByDueWindow(
   scope: RunnerScope,
@@ -536,13 +533,17 @@ async function filterByDueWindow(
   const endOfTodayMs = endOfToday.getTime();
   const kept: ScheduledTask[] = [];
   for (const task of tasks) {
+    const dueDecision = await scope.runner.resolveDueDecision(task);
+    if (dueDecision.due) {
+      kept.push(task);
+      continue;
+    }
+    if (window === "overdue") continue;
     const nextFireAtIso = await scope.runner.resolveNextFireAt(task);
     if (nextFireAtIso === null) continue;
     const fireMs = Date.parse(nextFireAtIso);
     if (!Number.isFinite(fireMs)) continue;
-    if (window === "overdue") {
-      if (fireMs < now) kept.push(task);
-    } else if (fireMs <= endOfTodayMs) {
+    if (fireMs <= endOfTodayMs) {
       kept.push(task);
     }
   }

--- a/plugins/plugin-personal-assistant/src/actions/scheduled-task.ts
+++ b/plugins/plugin-personal-assistant/src/actions/scheduled-task.ts
@@ -512,6 +512,27 @@ function normalizeDueWindow(value: unknown): DueWindow | undefined {
     : undefined;
 }
 
+function localDateKey(date: Date, timeZone: string): string {
+  try {
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).formatToParts(date);
+    const read = (type: string) =>
+      parts.find((part) => part.type === type)?.value;
+    const year = read("year");
+    const month = read("month");
+    const day = read("day");
+    if (year && month && day) return `${year}-${month}-${day}`;
+  } catch {
+    // error-policy:J3 invalid owner timezone fact falls back to UTC date-key comparison.
+    // Invalid owner timezone facts fall back to UTC, matching scheduler helpers.
+  }
+  return date.toISOString().slice(0, 10);
+}
+
 /**
  * Keep tasks whose due instant falls inside `window`, using the runner's
  * due-decision and next-fire projection so the chat/voice filter and scheduler
@@ -528,9 +549,9 @@ async function filterByDueWindow(
   window: DueWindow,
 ): Promise<ScheduledTask[]> {
   const now = Date.now();
-  const endOfToday = new Date(now);
-  endOfToday.setHours(23, 59, 59, 999);
-  const endOfTodayMs = endOfToday.getTime();
+  const ownerFacts = await scope.runner.resolveOwnerFacts();
+  const ownerTimeZone = ownerFacts.timezone ?? "UTC";
+  const todayKey = localDateKey(new Date(now), ownerTimeZone);
   const kept: ScheduledTask[] = [];
   for (const task of tasks) {
     const dueDecision = await scope.runner.resolveDueDecision(task);
@@ -543,7 +564,7 @@ async function filterByDueWindow(
     if (nextFireAtIso === null) continue;
     const fireMs = Date.parse(nextFireAtIso);
     if (!Number.isFinite(fireMs)) continue;
-    if (fireMs <= endOfTodayMs) {
+    if (localDateKey(new Date(fireMs), ownerTimeZone) === todayKey) {
       kept.push(task);
     }
   }

--- a/plugins/plugin-personal-assistant/src/actions/scheduled-task.ts
+++ b/plugins/plugin-personal-assistant/src/actions/scheduled-task.ts
@@ -6,7 +6,8 @@
  * `ScheduledTask` records (frozen contract per `IMPLEMENTATION_PLAN.md` §1).
  *
  * Subactions:
- *   - `list`      — read tasks (optional kind / status / subject filters)
+ *   - `list`      — read tasks (optional kind / status / subject filters, plus
+ *                   a `dueWindow` = overdue|today next-fire filter)
  *   - `get`       — fetch one task by id
  *   - `create`    — schedule a new task (any `ScheduledTaskKind`)
  *   - `update`    — edit a scheduled task (`ScheduledTaskRunner.apply edit`)
@@ -90,6 +91,8 @@ interface ScheduledTaskParams {
   subjectKind?: ScheduledTaskSubjectKindParam;
   subjectId?: string;
   ownerVisibleOnly?: boolean;
+  /** list-only: restrict to next-fire window `overdue` (past due) or `today`. */
+  dueWindow?: "overdue" | "today";
   /** create-only: free-form prompt instructions for the runner. */
   promptInstructions?: string;
   /** create-only: trigger spec (`once`, `cron`, `manual`, etc). */
@@ -498,15 +501,72 @@ function stableTriggerKey(trigger: ScheduledTaskTrigger): string {
     .join("|");
 }
 
+const DUE_WINDOWS = ["overdue", "today"] as const;
+type DueWindow = (typeof DUE_WINDOWS)[number];
+
+function normalizeDueWindow(value: unknown): DueWindow | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim().toLowerCase();
+  return (DUE_WINDOWS as readonly string[]).includes(trimmed)
+    ? (trimmed as DueWindow)
+    : undefined;
+}
+
+/**
+ * Keep tasks whose next fire time falls inside `window`, using the runner's
+ * own next-fire projection (the same value the scheduler tick indexes) so the
+ * chat/voice filter and the tick never disagree about what is "due". Tasks
+ * with no wall-clock fire time (event/manual/after_task, or settled
+ * non-recurring rows) resolve to `null` and are excluded from both windows —
+ * they have no "overdue"/"today" instant to compare against. `overdue` is
+ * strictly in the past; `today` is anything due by end of the current day
+ * (so it is a superset of `overdue` — an already-missed reminder is still due
+ * today). The day boundary uses server-local time; the runner's projected
+ * instant already carries the owner's trigger timezone, so cross-tz skew is at
+ * most one day-boundary and acceptable for this coarse "today" cut.
+ */
+async function filterByDueWindow(
+  scope: RunnerScope,
+  tasks: ScheduledTask[],
+  window: DueWindow,
+): Promise<ScheduledTask[]> {
+  const now = Date.now();
+  const endOfToday = new Date(now);
+  endOfToday.setHours(23, 59, 59, 999);
+  const endOfTodayMs = endOfToday.getTime();
+  const kept: ScheduledTask[] = [];
+  for (const task of tasks) {
+    const nextFireAtIso = await scope.runner.resolveNextFireAt(task);
+    if (nextFireAtIso === null) continue;
+    const fireMs = Date.parse(nextFireAtIso);
+    if (!Number.isFinite(fireMs)) continue;
+    if (window === "overdue") {
+      if (fireMs < now) kept.push(task);
+    } else if (fireMs <= endOfTodayMs) {
+      kept.push(task);
+    }
+  }
+  return kept;
+}
+
 async function handleList(
   scope: RunnerScope,
   params: ScheduledTaskParams,
 ): Promise<ActionResult> {
   const tasks = await scope.runner.list(buildFilter(params));
+  const dueWindow = normalizeDueWindow(params.dueWindow);
+  const filtered = dueWindow
+    ? await filterByDueWindow(scope, tasks, dueWindow)
+    : tasks;
+  const windowNote = dueWindow ? ` (${dueWindow})` : "";
   return {
     success: true,
-    text: `${tasks.length} scheduled task${tasks.length === 1 ? "" : "s"} match.`,
-    data: { subaction: "list", tasks },
+    text: `${filtered.length} scheduled task${filtered.length === 1 ? "" : "s"} match${windowNote}.`,
+    data: {
+      subaction: "list",
+      tasks: filtered,
+      ...(dueWindow ? { dueWindow } : {}),
+    },
   };
 }
 
@@ -858,6 +918,32 @@ const examples: ActionExample[][] = [
   [
     {
       name: "{{name1}}",
+      content: { text: "Show me only my overdue tasks." },
+    },
+    {
+      name: "{{agentName}}",
+      content: {
+        text: "Listing scheduled tasks that are past due.",
+        action: "SCHEDULED_TASKS",
+      },
+    },
+  ],
+  [
+    {
+      name: "{{name1}}",
+      content: { text: "What's due today?" },
+    },
+    {
+      name: "{{agentName}}",
+      content: {
+        text: "Listing scheduled tasks due today.",
+        action: "SCHEDULED_TASKS",
+      },
+    },
+  ],
+  [
+    {
+      name: "{{name1}}",
       content: { text: "Snooze that reminder 30 minutes." },
     },
     {
@@ -930,7 +1016,7 @@ export const scheduledTaskAction: Action & {
   descriptionCompressed:
     "low-level scheduled-item admin list|get|create|update|snooze|skip|complete|ack|dismiss|cancel|history; NOT new-habit/routine creation (-> OWNER_ROUTINES/OWNER_REMINDERS create)",
   routingHint:
-    'manage EXISTING scheduled items ("snooze that reminder", "follow-ups today", "complete check-in", "scheduled-item history") -> SCHEDULED_TASKS; NEW habit/routine/recurring personal reminder ("brush my teeth at 8 am and 9 pm every day", "remind me daily at 9pm") -> OWNER_ROUTINES/OWNER_REMINDERS action=create; coding/project/agent task threads -> TASKS/plugin-task-coordinator; per-occurrence complete/skip/snooze next occurrence -> OWNER_REMINDERS/OWNER_TODOS/OWNER_ROUTINES',
+    'manage EXISTING scheduled items ("snooze that reminder", "show me only overdue tasks" -> action=list dueWindow=overdue, "what\'s due today" -> action=list dueWindow=today, "complete check-in", "scheduled-item history") -> SCHEDULED_TASKS; NEW habit/routine/recurring personal reminder ("brush my teeth at 8 am and 9 pm every day", "remind me daily at 9pm") -> OWNER_ROUTINES/OWNER_REMINDERS action=create; coding/project/agent task threads -> TASKS/plugin-task-coordinator; per-occurrence complete/skip/snooze next occurrence -> OWNER_REMINDERS/OWNER_TODOS/OWNER_ROUTINES',
   contexts: [
     "tasks",
     "automation",
@@ -982,6 +1068,12 @@ export const scheduledTaskAction: Action & {
       name: "ownerVisibleOnly",
       description: "true: list ownerVisible tasks only.",
       schema: { type: "boolean" as const },
+    },
+    {
+      name: "dueWindow",
+      description:
+        'list-only next-fire filter: "overdue" (fire time already past) or "today" (fires before end of the local day). Use for "show me only overdue tasks" / "what\'s due today".',
+      schema: { type: "string" as const, enum: [...DUE_WINDOWS] },
     },
     {
       name: "promptInstructions",

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.test.ts
@@ -1613,6 +1613,14 @@ describe("ScheduledTaskRunner — resolveNextFireAt (due-window primitive)", () 
     expect(await h.runner.resolveNextFireAt(manual)).toBeNull();
   });
 
+  it("exposes the owner facts used by due and next-fire evaluation", async () => {
+    const h = makeHarness();
+    h.setOwnerFacts({ timezone: "America/New_York" });
+    await expect(h.runner.resolveOwnerFacts()).resolves.toEqual({
+      timezone: "America/New_York",
+    });
+  });
+
   it("reports a missed cron occurrence as due even when next-fire projects forward", async () => {
     const h = makeHarness("2026-05-09T12:00:00.000Z");
     const task = await h.runner.schedule(

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.test.ts
@@ -1612,4 +1612,23 @@ describe("ScheduledTaskRunner — resolveNextFireAt (due-window primitive)", () 
     );
     expect(await h.runner.resolveNextFireAt(manual)).toBeNull();
   });
+
+  it("reports a missed cron occurrence as due even when next-fire projects forward", async () => {
+    const h = makeHarness("2026-05-09T12:00:00.000Z");
+    const task = await h.runner.schedule(
+      baseInput({
+        trigger: { kind: "cron", expression: "0 9 * * *", tz: "UTC" },
+        metadata: { createdAtIso: "2026-05-09T00:00:00.000Z" },
+      }),
+    );
+
+    expect(await h.runner.resolveNextFireAt(task)).toBe(
+      "2026-05-10T09:00:00.000Z",
+    );
+    expect(await h.runner.resolveDueDecision(task)).toMatchObject({
+      due: true,
+      reason: "cron_due",
+      occurrenceAtIso: "2026-05-09T09:00:00.000Z",
+    });
+  });
 });

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.test.ts
@@ -1576,3 +1576,40 @@ describe("Inspect registries", () => {
     );
   });
 });
+
+describe("ScheduledTaskRunner — resolveNextFireAt (due-window primitive)", () => {
+  it("projects a once trigger's fire instant and clears it after firing", async () => {
+    const h = makeHarness("2026-05-09T12:00:00.000Z");
+    const task = await h.runner.schedule(
+      baseInput({
+        trigger: { kind: "once", atIso: "2026-05-09T15:00:00.000Z" },
+      }),
+    );
+    expect(await h.runner.resolveNextFireAt(task)).toBe(
+      "2026-05-09T15:00:00.000Z",
+    );
+  });
+
+  it("honors the scheduled-override (snooze) instant over the trigger", async () => {
+    const h = makeHarness("2026-05-09T12:00:00.000Z");
+    const task = await h.runner.schedule(
+      baseInput({
+        trigger: { kind: "cron", expression: "0 9 * * *", tz: "UTC" },
+      }),
+    );
+    const snoozed = await h.runner.apply(task.taskId, "snooze", {
+      untilIso: "2026-05-09T13:30:00.000Z",
+    });
+    expect(await h.runner.resolveNextFireAt(snoozed)).toBe(
+      "2026-05-09T13:30:00.000Z",
+    );
+  });
+
+  it("returns null for triggers with no wall-clock fire time", async () => {
+    const h = makeHarness();
+    const manual = await h.runner.schedule(
+      baseInput({ trigger: { kind: "manual" } }),
+    );
+    expect(await h.runner.resolveNextFireAt(manual)).toBeNull();
+  });
+});

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.ts
@@ -25,7 +25,7 @@ import type {
   AnchorRegistry,
   ConsolidationRegistry,
 } from "./consolidation-policy.js";
-import { isScheduledTaskDue } from "./due.js";
+import { isScheduledTaskDue, type ScheduledTaskDueDecision } from "./due.js";
 import {
   type EscalationLadderRegistry,
   resetLadderForSnooze,
@@ -557,6 +557,14 @@ export interface ScheduledTaskRunnerExtras {
    * indexed value the tick relies on.
    */
   resolveNextFireAt(task: ScheduledTask): Promise<string | null>;
+  /**
+   * Evaluate whether a task is due at the runner's current clock, using the
+   * same owner-facts and anchor dependencies as the scheduler tick. Consumers
+   * that present due-window views need this before a future next-fire
+   * projection, otherwise a missed recurring occurrence can be hidden by the
+   * next natural occurrence.
+   */
+  resolveDueDecision(task: ScheduledTask): Promise<ScheduledTaskDueDecision>;
 }
 
 export interface ScheduledTaskRunnerHandle
@@ -685,6 +693,17 @@ export function createScheduledTaskRunner(
     }
     const ownerFacts = await deps.ownerFacts();
     return computeNextFireAt(task, {
+      now: now(),
+      ownerFacts,
+      anchors: deps.anchors,
+    });
+  }
+
+  async function resolveDueDecision(
+    task: ScheduledTask,
+  ): Promise<ScheduledTaskDueDecision> {
+    const ownerFacts = await deps.ownerFacts();
+    return isScheduledTaskDue(task, {
       now: now(),
       ownerFacts,
       anchors: deps.anchors,
@@ -1698,5 +1717,6 @@ export function createScheduledTaskRunner(
     inspectRegistries,
     getEscalationCursor,
     resolveNextFireAt,
+    resolveDueDecision,
   };
 }

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.ts
@@ -545,6 +545,18 @@ export interface ScheduledTaskRunnerExtras {
    * `null` when the task is not found or has no cursor recorded yet.
    */
   getEscalationCursor(taskId: string): Promise<EscalationCursorView | null>;
+  /**
+   * Project the next wall-clock fire instant for a task, honoring the same
+   * scheduled-override and recurrence rules the runner uses to index
+   * `next_fire_at`. Returns `null` for triggers with no wall-clock time
+   * (`event`/`manual`/`after_task`) or settled non-recurring rows.
+   *
+   * Exposed so consumers that need a due-window view (e.g. the
+   * `SCHEDULED_TASKS` action's "overdue"/"today" list filter) share the one
+   * next-fire computation instead of re-deriving it and drifting from the
+   * indexed value the tick relies on.
+   */
+  resolveNextFireAt(task: ScheduledTask): Promise<string | null>;
 }
 
 export interface ScheduledTaskRunnerHandle
@@ -1685,5 +1697,6 @@ export function createScheduledTaskRunner(
     rolloverStateLog,
     inspectRegistries,
     getEscalationCursor,
+    resolveNextFireAt,
   };
 }

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.ts
@@ -565,6 +565,12 @@ export interface ScheduledTaskRunnerExtras {
    * next natural occurrence.
    */
   resolveDueDecision(task: ScheduledTask): Promise<ScheduledTaskDueDecision>;
+  /**
+   * Return the owner facts the runner uses for trigger/gate evaluation. This is
+   * exposed for read-only views that must apply the same owner-local timezone
+   * boundary as the scheduler without reaching behind the runner deps port.
+   */
+  resolveOwnerFacts(): Promise<OwnerFactsView>;
 }
 
 export interface ScheduledTaskRunnerHandle
@@ -708,6 +714,10 @@ export function createScheduledTaskRunner(
       ownerFacts,
       anchors: deps.anchors,
     });
+  }
+
+  async function resolveOwnerFacts(): Promise<OwnerFactsView> {
+    return deps.ownerFacts();
   }
 
   async function schedule(
@@ -1718,5 +1728,6 @@ export function createScheduledTaskRunner(
     getEscalationCursor,
     resolveNextFireAt,
     resolveDueDecision,
+    resolveOwnerFacts,
   };
 }


### PR DESCRIPTION
## What & why

Part of #14368. Some view controls were reachable by chat **only** through the generic synthetic-DOM bridge (`agent-fill`/`agent-click`), which the planner can't discover and which depends on the exact element being mounted+visible. This replaces the Tasks filter with a semantic verb and confirms plugin enable/disable already routes through one shared use case.

Per the issue's "confirm coverage first, extend never duplicate" instruction:

| Control | Finding | Change |
| --- | --- | --- |
| **Task filter** ("only overdue" / "only today") | `SCHEDULED_TASKS list` supported `kind/status/subject/source/firedSince/ownerVisibleOnly` but **no** due-window filter | **Added** `action=list dueWindow=overdue\|today` — the genuinely-missing verb |
| **Plugin enable/disable** | Already a semantic verb: `PLUGIN action=toggle` -> `PUT /api/plugins/:id { enabled }`, byte-for-byte the same endpoint the Plugins view's `client.updatePlugin` calls | **No new verb** — added a regression test proving the wiring |
| **Plugin reorder** | Client-only display preference (localStorage `pluginOrder` in `PluginsView.tsx`); no runtime mutation / server use case exists to route a verb to | **Intentionally not added** — adding one would invent a persistence model out of scope |

### Design: one source of due-time truth (due-decision-first)
Rather than re-derive next-fire math in the action (drifting from the value the scheduler tick uses to decide what fires), the runner's canonical `isScheduledTaskDue` is now exposed on `ScheduledTaskRunnerHandle` as `resolveDueDecision(task)` — the **same** due decision the tick consults. The action's `dueWindow` filter asks the handle whether each task is due (`resolveDueDecision().due`), not a hand-rolled `fireMs < now` comparison, so the chat/voice "what's due today" and the tick agree on what is "due". A task with `due: true` is kept for both windows (this is the overdue/already-due set). For `today` only, tasks not yet due are additionally kept when their projected next fire (`resolveNextFireAt`) lands on the current local day in the owner's timezone. Tasks with no wall-clock fire time (event/manual/after_task) are excluded from both.

### Files
- `plugins/plugin-scheduling/src/scheduled-task/runner.ts` — expose `resolveDueDecision(task)` (wraps `isScheduledTaskDue`) and `resolveNextFireAt(task)` on the handle.
- `plugins/plugin-personal-assistant/src/actions/scheduled-task.ts` — `dueWindow` param + due-decision-first filter + routingHint/examples.
- `packages/agent/src/actions/plugin.ts` — unchanged; regression test added for its `toggle` op.

## Verification

<details><summary>Scoped typecheck (3 packages) — clean on touched files</summary>

```
$ bunx tsc --noEmit -p plugins/plugin-scheduling/tsconfig.json      | grep plugin-scheduling/src   -> (none)
$ bunx tsc --noEmit -p plugins/plugin-personal-assistant/tsconfig.json | grep actions/scheduled-task -> (none)
$ bunx tsc --noEmit -p packages/agent/tsconfig.json                | grep actions/plugin           -> (none)
TYPECHECK-CLEAN
```
(Pre-existing unrelated errors from generated i18n data + a React-types dup in the shared node_modules symlink are not in touched files.)
</details>

<details><summary>Tests — 74 passed (3 files)</summary>

```
$ bunx vitest run \
    plugins/plugin-scheduling/src/scheduled-task/runner.test.ts \
    plugins/plugin-personal-assistant/src/actions/scheduled-task.test.ts \
    packages/agent/src/actions/plugin-toggle.test.ts

 Test Files  3 passed (3)
      Tests  74 passed (74)
```
- runner.test.ts (65, +3): `resolveDueDecision`/`resolveNextFireAt` on the handle project a `once` trigger, honor the snooze scheduled-override, and return the not-due/null result for `manual`.
- scheduled-task.test.ts (new, 6): `dueWindow` unfiltered/overdue/today partitioning, owner-timezone boundary, unknown-value rejection (no filtering, no projection), and `dueWindow` param exposed on the action.
- plugin-toggle.test.ts (new, 3): `PLUGIN action=toggle` issues `PUT /api/plugins/:id { enabled }`, encodes scoped ids + forwards `enabled:false`, and fails without a valid `enabled` boolean (no network call).
</details>

<details><summary>Biome — clean</summary>

```
$ bunx biome check <5 touched files>
Checked 5 files in 95ms. No fixes applied.
```
</details>

## Frontend surface
The Tasks/LifeOps chat path exercises `SCHEDULED_TASKS action=list dueWindow=...`; a reviewer asking the agent "show me only overdue tasks" now sees the semantic action fire (with `data.dueWindow`) instead of `agent-fill`. The Plugins view's per-card enable/disable toggle already hits the same `PUT /api/plugins/:id` the `PLUGIN` action does.

## Evidence — AC4 honestly N/A (owner must attach before close)

This branch was produced in a **headless worktree** with no live model and no renderer/device. AC4 of #14368 (real-LLM trajectories for task-filter + plugin-enable that fire the semantic action **without** the synthetic-DOM fallback, plus Tasks/Plugins view JPG before/after + MP4 walkthrough) **cannot** be captured here and is left honestly N/A. This PR is therefore **"Part of #14368", not "Closes"** — the issue must **not** auto-close on merge; an owner should attach the AC4 evidence below and close it manually once verified.

| Evidence | Status |
| --- | --- |
| Scoped typecheck (3 pkgs) | done — inline above |
| Unit tests (74) | done — inline above |
| Biome | done — inline above |
| Real-LLM trajectory (task-filter / plugin-enable, no synthetic-DOM fallback) | **N/A here — owner to attach.** Run `packages/scenario-runner/bin/eliza-scenarios run <scenario> --report <out>` against a live model and confirm `SCHEDULED_TASKS`/`PLUGIN` fire, not `agent-fill`/`agent-click`. |
| Before/after JPG of Tasks + Plugins views + MP4 walkthrough | **N/A here — owner to attach.** Run `bun run --cwd packages/app audit:app` and boot the LifeOps chat to capture pixels. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
