### PR TITLE
style(console): neutralize brown/orange accent tints to black-and-white (visible nav)

### DIFF
--- a/packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx
+++ b/packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx
@@ -93,7 +93,7 @@ export function DashboardActionCards({
     <div className={cn("grid gap-3 sm:grid-cols-2 xl:grid-cols-5", className)}>
       <Link
         to="/dashboard/my-agents"
-        className="group relative flex min-h-[148px] flex-col justify-between rounded-sm border border-white/10 bg-[var(--accent)] p-5 text-black transition-colors hover:bg-black hover:text-white sm:col-span-2 xl:col-span-1"
+        className="group relative flex min-h-[148px] flex-col justify-between rounded-sm border border-white/10 bg-white p-5 text-black transition-colors hover:bg-black hover:text-white sm:col-span-2 xl:col-span-1"
       >
         <div className="mb-4 flex items-center justify-between">
           <Rocket className="h-5 w-5" />
@@ -109,21 +109,21 @@ export function DashboardActionCards({
           <div className="mt-2 flex flex-wrap items-center gap-3 text-xs font-medium">
             <Link
               to="/dashboard/api-keys"
-              className="inline-flex items-center gap-1.5 hover:text-[var(--accent)]"
+              className="inline-flex items-center gap-1.5 hover:text-white"
             >
               <KeyRound className="h-3 w-3" />
               Keys
             </Link>
             <Link
               to="/docs"
-              className="inline-flex items-center gap-1.5 hover:text-[var(--accent)]"
+              className="inline-flex items-center gap-1.5 hover:text-white"
             >
               <BookOpen className="h-3 w-3" />
               Docs
             </Link>
             <Link
               to="/dashboard/api-explorer"
-              className="inline-flex items-center gap-1.5 hover:text-[var(--accent)]"
+              className="inline-flex items-center gap-1.5 hover:text-white"
             >
               <Bot className="h-3 w-3" />
               Explorer
@@ -138,7 +138,7 @@ export function DashboardActionCards({
       >
         <div className="flex items-center justify-between">
           <Wallet className="h-5 w-5" />
-          <span className="rounded-sm bg-[var(--accent)] px-2 py-0.5 text-xs font-semibold text-black">
+          <span className="rounded-sm border border-white/15 bg-white/10 px-2 py-0.5 text-xs font-semibold text-white">
             {formattedBalance}
           </span>
         </div>

--- a/packages/ui/src/cloud/billing/components/pay-as-you-go-card.tsx
+++ b/packages/ui/src/cloud/billing/components/pay-as-you-go-card.tsx
@@ -63,7 +63,7 @@ export function PayAsYouGoCard() {
 
       <div className="relative z-10 space-y-4">
         <div className="flex items-center gap-2">
-          <div className="w-2 h-2 rounded-full bg-[var(--accent)]" />
+          <div className="w-2 h-2 rounded-full bg-white/40" />
           <h3 className="text-base font-mono text-txt uppercase">
             Pay Hosting From Earnings
           </h3>
@@ -72,7 +72,7 @@ export function PayAsYouGoCard() {
         <div className="flex items-start justify-between gap-4">
           <div className="space-y-1 flex-1 min-w-0">
             <Label className="text-txt-strong font-mono text-sm flex items-center gap-2">
-              <Coins className="h-4 w-4 text-[var(--accent)]" />
+              <Coins className="h-4 w-4 text-white/70" />
               Use my app earnings to pay container hosting
             </Label>
             <p className="text-xs font-mono text-muted leading-relaxed">
@@ -83,13 +83,13 @@ export function PayAsYouGoCard() {
             </p>
           </div>
           {enabled === null ? (
-            <Loader2 className="h-5 w-5 animate-spin text-[var(--accent)] flex-shrink-0" />
+            <Loader2 className="h-5 w-5 animate-spin text-white/70 flex-shrink-0" />
           ) : (
             <Switch
               checked={enabled}
               onCheckedChange={handleToggle}
               disabled={saving}
-              className="data-[state=checked]:bg-[var(--accent)] flex-shrink-0"
+              className="data-[state=checked]:bg-white/80 flex-shrink-0"
             />
           )}
         </div>

--- a/packages/ui/src/cloud/instances/components/eliza-agent-pricing-banner.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agent-pricing-banner.tsx
@@ -52,8 +52,8 @@ export function ElizaAgentPricingBanner({
         {/* Header */}
         <div className="flex items-center justify-between mb-5">
           <div className="flex items-center gap-2">
-            <div className="flex items-center justify-center w-7 h-7 bg-[var(--accent)]/10 border border-[var(--accent)]/20">
-              <DollarSign className="h-3.5 w-3.5 text-[var(--accent)]" />
+            <div className="flex items-center justify-center w-7 h-7 bg-white/5 border border-white/10">
+              <DollarSign className="h-3.5 w-3.5 text-white/70" />
             </div>
             <p className="text-sm font-medium text-white">
               {t("cloud.containers.pricingBanner.usageRates", {
@@ -64,7 +64,7 @@ export function ElizaAgentPricingBanner({
           {isLowBalance && hasAgents && (
             <Badge
               variant="outline"
-              className="bg-orange-500/10 border-orange-500/30 text-orange-400 text-[10px] px-2"
+              className="bg-red-500/10 border-red-500/30 text-red-400 text-[10px] px-2"
             >
               {t("cloud.containers.pricingBanner.lowBalance", {
                 defaultValue: "Low balance",
@@ -114,7 +114,7 @@ export function ElizaAgentPricingBanner({
           {/* Current burn */}
           <div className="bg-black/60 p-3.5 space-y-1.5">
             <div className="flex items-center gap-1.5">
-              <DollarSign className="h-3 w-3 text-[var(--accent)]" />
+              <DollarSign className="h-3 w-3 text-white/70" />
               <p className="text-[10px] uppercase tracking-[0.2em] text-white/40">
                 {t("cloud.containers.pricingBanner.yourCost", {
                   defaultValue: "Your Cost",
@@ -149,7 +149,7 @@ export function ElizaAgentPricingBanner({
             </div>
             <p
               className={`text-base font-mono font-semibold tabular-nums ${
-                isLowBalance && hasAgents ? "text-orange-400" : "text-white"
+                isLowBalance && hasAgents ? "text-red-400" : "text-white"
               }`}
             >
               {hoursRemaining !== null ? formatDuration(hoursRemaining) : "—"}


### PR DESCRIPTION
## What
The console is meant to read **black-and-white**, but scattered brand-orange accent tints (`bg-[var(--accent)]`, `orange-500`, `--accent` over black) render as a **brown wash** that clashes with it. This neutralizes the decorative tints on the **visible nav** surfaces to white/neutral-gray:

- **Agents → pricing banner**: `$` icon box + cost icon (orange → white/neutral); "Low balance" badge + remaining-time (orange → **red**, since it's a real "agents will suspend" warning).
- **Overview → hero cards**: solid-orange "My Agent" CTA → white card (inverts to black on hover); orange balance pill → neutral chip; orange quick-link hovers → white.
- **Billing → pay-as-you-go card**: status dot, coins/spinner icons, toggle on-state (orange → white/neutral).

## Palette rule
Color is reserved for **meaning only** — green stays for *running*, red for *danger/low-balance*. Everything decorative goes black/white/neutral-gray.

## Scope
- **Account page** is also orange-tinted but is being reworked in #14418 — left there to avoid a merge conflict.
- The **hidden** Apps / docs / api-explorer surfaces (~60 more tint sites) are a follow-up sweep, not user-visible in the current nav.

No behavior change; className-only. Biome clean.

https://claude.ai/code/session_01CpnRyFUuGvzz61SsrnC3Sd
