### PR TITLE
chore(chat): format merged form fix

### DIFF
--- a/packages/core/src/messaging/interactions/interactions.test.ts
+++ b/packages/core/src/messaging/interactions/interactions.test.ts
@@ -115,14 +115,16 @@ describe("parse", () => {
 		})}\n[/FORM]`;
 		const { blocks } = parseInteractionBlocks(text);
 		const form = blocks[0] as FormInteraction;
-		expect(form.fields.map((f) => f.type)).toEqual(["date", "time", "datetime"]);
-		// parse ↔ serialize parity: the temporal types survive a round trip.
-		const rt = parseInteractionBlocks(serializeInteractionBlock(form));
-		expect((rt.blocks[0] as FormInteraction).fields.map((f) => f.type)).toEqual([
+		expect(form.fields.map((f) => f.type)).toEqual([
 			"date",
 			"time",
 			"datetime",
 		]);
+		// parse ↔ serialize parity: the temporal types survive a round trip.
+		const rt = parseInteractionBlocks(serializeInteractionBlock(form));
+		expect((rt.blocks[0] as FormInteraction).fields.map((f) => f.type)).toEqual(
+			["date", "time", "datetime"],
+		);
 	});
 
 	it("drops a field with an unknown type (core parser is strict)", () => {

--- a/packages/ui/src/components/chat/widgets/form-request.tsx
+++ b/packages/ui/src/components/chat/widgets/form-request.tsx
@@ -40,7 +40,9 @@ export type FormResultValue = string | boolean;
  * so no custom picker or dependency is added. Any other type is a plain text
  * box. Exported for the field-type unit test.
  */
-export function htmlInputTypeForField(fieldType: FormFieldSpec["type"]): string {
+export function htmlInputTypeForField(
+  fieldType: FormFieldSpec["type"],
+): string {
   switch (fieldType) {
     case "number":
       return "number";


### PR DESCRIPTION
# Relates to

Follow-up to #14530 / #14489.

Definition of Done: full standard in [`PR_EVIDENCE.md`](../PR_EVIDENCE.md).

- [x] This PR targets `develop` and is based on current `origin/develop`.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is documented below.
- [x] A reviewer can confirm the change works from the evidence below.

# Sync with develop

- [x] Based on current `origin/develop`; zero conflicts when branch was created.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low. Formatter-only cleanup after merged #14530; no behavior change.

# Background

## What does this PR do?

Runs Biome formatting on the two files from the merged #14530 constructor-field fix that currently fail `biome check` on `develop`:

- `packages/ui/src/components/chat/widgets/form-request.tsx`
- `packages/core/src/messaging/interactions/interactions.test.ts`

## What kind of change is this?

Chore / formatting cleanup.

# Documentation changes needed?

No documentation changes needed.

# Testing

## Where should a reviewer start?

Review the diff; it is formatter-only wrapping in `form-request.tsx` and `interactions.test.ts`.

## Detailed testing steps

- `bunx @biomejs/biome check packages/core/src/messaging/interactions/interactions.test.ts packages/ui/src/components/chat/widgets/form-request.tsx` — passed.
- `bun run --cwd packages/ui test -- src/components/chat/widgets/interaction-widgets.behavior.test.tsx src/components/chat/widgets/form-request.test.tsx src/components/chat/message-form-parser.test.ts` — passed, 3 files / 26 tests.
- `bun run --cwd packages/core test -- src/messaging/interactions/interactions.test.ts` — passed, 1 file / 34 tests.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - formatter-only change; no rendered pixels changed intentionally`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots are attached for every affected UI surface (desktop and mobile), or marked `N/A - formatter-only change; targeted render/parser tests passed`.
<!-- evidence-row:walkthrough-video -->
- [x] A video walkthrough of the complete user flow is attached, or marked `N/A - formatter-only change`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs show the real code path firing end to end, or are marked `N/A - no backend runtime behavior changed`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs show the request/response and state change, or are marked `N/A - no frontend runtime behavior changed`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory is attached for agent/action/provider/prompt/model changes, or marked `N/A - no agent/action/provider/prompt/model behavior changed`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts are attached where applicable, or marked `N/A - no domain artifacts produced`.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changed.

## Backend + frontend logs

N/A - formatter-only change.

## Screenshots (before / after) + video walkthrough

N/A - formatter-only change; no visual behavior changed.

## Audio / voice walkthrough

N/A - no voice/audio behavior changed.

## Known gaps / failures

Full `bun run verify` was already run during #14489 verification and currently fails before turbo typecheck/lint at the repo-wide type-safety ratchet:

```text
[type-safety-ratchet] unsafe cast baseline exceeded
  - as unknown as: 77 current > 73 baseline
```

This formatter-only PR does not add or touch any unsafe casts.