### PR TITLE
feat(ui): standardized collapsible connector-setup widgets in chat + repaint lock (#14412)

### DIFF
--- a/packages/ui/src/components/chat/message-connector-parser.test.ts
+++ b/packages/ui/src/components/chat/message-connector-parser.test.ts
@@ -1,0 +1,63 @@
+// Unit tests for the `[CONNECTOR:<id>]` parser (#14412): region extraction,
+// name attribute, and the `KEY|required|isSet|label` body schema. Pure module,
+// no React graph.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  findConnectorRegions,
+  parseConnectorBody,
+} from "./message-connector-parser";
+
+describe("parseConnectorBody", () => {
+  it("parses KEY|required|isSet|label tuples", () => {
+    const params = parseConnectorBody(
+      "DISCORD_TOKEN|1|0|Bot Token\nDISCORD_GUILD_ID|0|1|Guild ID",
+    );
+    expect(params).toEqual([
+      {
+        key: "DISCORD_TOKEN",
+        required: true,
+        isSet: false,
+        label: "Bot Token",
+      },
+      {
+        key: "DISCORD_GUILD_ID",
+        required: false,
+        isSet: true,
+        label: "Guild ID",
+      },
+    ]);
+  });
+
+  it("skips blank lines and drops keyless rows", () => {
+    expect(parseConnectorBody("\n|1|0|nope\nTOKEN|1|0|\n")).toEqual([
+      { key: "TOKEN", required: true, isSet: false },
+    ]);
+  });
+});
+
+describe("findConnectorRegions", () => {
+  it("extracts id, name, params, and char bounds", () => {
+    const text =
+      'before [CONNECTOR:discord name="Discord"]\nTOKEN|1|0|Bot Token\n[/CONNECTOR] after';
+    const [region] = findConnectorRegions(text);
+    expect(region.id).toBe("discord");
+    expect(region.name).toBe("Discord");
+    expect(region.params).toEqual([
+      { key: "TOKEN", required: true, isSet: false, label: "Bot Token" },
+    ]);
+    expect(text.slice(region.start, region.end)).toContain("[/CONNECTOR]");
+  });
+
+  it("falls back to the id when no name attribute is present", () => {
+    const [region] = findConnectorRegions(
+      "[CONNECTOR:telegram]\nTG_BOT_TOKEN|1|0|\n[/CONNECTOR]",
+    );
+    expect(region.name).toBe("telegram");
+  });
+
+  it("returns no regions for text without a marker", () => {
+    expect(findConnectorRegions("just a message")).toEqual([]);
+  });
+});

--- a/packages/ui/src/components/chat/message-connector-parser.ts
+++ b/packages/ui/src/components/chat/message-connector-parser.ts
@@ -1,0 +1,75 @@
+/**
+ * Parser for `[CONNECTOR:<id> …]…[/CONNECTOR]` blocks the agent emits to render
+ * a connector-setup widget inline in chat. Lives in its own module so unit
+ * tests can exercise the regex/param extraction without pulling the widget's
+ * React graph (which transitively imports the runtime), mirroring the other
+ * `message-*-parser.ts` modules.
+ *
+ * Body lines are `KEY|required|isSet|label` tuples describing the connector's
+ * parameter schema (the shape `buildPluginConfigUiSpec` consumes). The widget
+ * derives minimal-vs-advanced tiers and the connected state from these; secrets
+ * are never rendered as plain fields — the widget routes them through the
+ * sensitive-request flow, so only the schema (never a value) travels in-band.
+ */
+import type { PluginParam } from "@elizaos/shared";
+
+// Attributes (`name=…`) are captured as one string and split below so they may
+// appear in any order; the body is the newline-delimited param schema.
+export const CONNECTOR_RE =
+  /\[CONNECTOR:([\w-]+)(?:\s+([^\]]*))?\]\n([\s\S]*?)\n\[\/CONNECTOR\]/g;
+
+export interface ConnectorMatch {
+  start: number;
+  end: number;
+  id: string;
+  name: string;
+  params: PluginParam[];
+}
+
+/** Parse a `KEY|required|isSet|label`-per-line body into typed params. */
+export function parseConnectorBody(body: string): PluginParam[] {
+  const params: PluginParam[] = [];
+  for (const rawLine of body.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const [key, required, isSet, label] = line.split("|");
+    const trimmedKey = key?.trim();
+    if (!trimmedKey) continue;
+    params.push({
+      key: trimmedKey,
+      required: required?.trim() === "1",
+      isSet: isSet?.trim() === "1",
+      ...(label?.trim() ? { label: label.trim() } : {}),
+    });
+  }
+  return params;
+}
+
+/** Read the `name="…"` attribute from a CONNECTOR header attribute string. */
+function parseConnectorName(
+  attrs: string | undefined,
+  fallback: string,
+): string {
+  if (!attrs) return fallback;
+  const match = attrs.match(/name="([^"]*)"/);
+  return match?.[1]?.trim() || fallback;
+}
+
+/** Find every CONNECTOR block in `text` and return their character regions. */
+export function findConnectorRegions(text: string): ConnectorMatch[] {
+  const matches: ConnectorMatch[] = [];
+  CONNECTOR_RE.lastIndex = 0;
+  let m = CONNECTOR_RE.exec(text);
+  while (m !== null) {
+    const id = m[1];
+    matches.push({
+      start: m.index,
+      end: m.index + m[0].length,
+      id,
+      name: parseConnectorName(m[2], id),
+      params: parseConnectorBody(m[3]),
+    });
+    m = CONNECTOR_RE.exec(text);
+  }
+  return matches;
+}

--- a/packages/ui/src/components/chat/widgets/WIDGET_MATRIX.md
+++ b/packages/ui/src/components/chat/widgets/WIDGET_MATRIX.md
@@ -54,6 +54,7 @@ affordances.
 | **Form** | `[FORM]\n{json}\n[/FORM]` | any action emitting a form schema | `message-form-parser.ts` | `form-request.tsx` `FormRequest` | `submitForm` | both | wired + verified |
 | **Workflow** | `[WORKFLOW]\n{json}\n[/WORKFLOW]` | any agent emitting an ordered step pipeline (#13536) | `message-workflow-parser.ts` | `workflow-steps.tsx` `WorkflowSteps` | none (display-only; re-emit to advance) | both | wired + verified |
 | **Checklist** | `[CHECKLIST]\n{json}\n[/CHECKLIST]` | any agent emitting a standalone todo list (#13536) | `message-checklist-parser.ts` | `task-pipeline.tsx` `PlanChecklist` | none (display-only; re-emit to mutate in place) | both | wired + verified |
+| **Connector** | `[CONNECTOR:<id> name="..."]\nKEY\|req\|set\|label\n[/CONNECTOR]` | connector-setup flows emitting a param schema (#14412) | `message-connector-parser.ts` | `connector-setup-widget.tsx` `ConnectorSetupWidget` (wraps `chat-widget-shell.tsx` `ChatWidgetShell`) | `sendAction(`connector:setup:<id>`)` (routes to the sensitive-request setup flow) | both | wired |
 
 (1) The Task widget is registered by `plugin-task-coordinator` (`registerTaskWidget()`), **not** auto-loaded in `inline-builtins`. It renders on both surfaces only when the orchestrator UI is loaded, by design (`MessageContent` knows nothing about tasks).
 
@@ -149,6 +150,21 @@ them by intent, never by hunting a chrome button:
 its live WS-driven pipeline in place; the single "Open in workbench" link is the
 only navigation affordance).
 
+### Standardized collapsible shell (`ChatWidgetShell`, #14412)
+
+`chat-widget-shell.tsx` is the shared collapser widgets wrap to stop eating
+transcript space. One contract: **start expanded while the widget's job is
+incomplete; auto-collapse to a compact summary once complete/connected**; the
+user re-expands via a standardized chevron, and a manual toggle after that wins
+until `complete` transitions again. Collapsed summary rows carry
+`content-visibility:auto` so an off-screen collapsed widget skips layout/paint.
+The connector-setup widget is the reference adopter and pairs the shell with a
+**minimal + Advanced** disclosure: `connector-field-tiers.ts` marks
+required/unset params minimal (shown up front) and everything else advanced
+(behind a `Collapsible`). Widgets built on the shell are `memo`-wrapped so their
+internal state (expand/collapse, Advanced toggle) never repaints the transcript
+— locked by `connector-widget.render-count.test.tsx`.
+
 ---
 
 ## Documented divergences (intentional, not gaps)
@@ -177,6 +193,7 @@ only navigation affordance).
 | Choice | yes | yes | n/a |
 | Followups | yes | yes | n/a |
 | Form | yes | yes | n/a |
+| Connector (shell + minimal/Advanced + repaint) | yes, `connector-setup-widget.test.tsx` + `message-connector-parser.test.ts` + `connector-widget.render-count.test.tsx` | n/a | n/a |
 | Notification center (pinned `NotificationsHomeCenter`) | yes | yes | yes, home-screen e2e |
 | Messages | yes | yes (added #9304) | n/a |
 | Orchestrator activity | yes (e2e fixture) | yes | n/a |

--- a/packages/ui/src/components/chat/widgets/chat-widget-shell.tsx
+++ b/packages/ui/src/components/chat/widgets/chat-widget-shell.tsx
@@ -1,0 +1,121 @@
+/**
+ * Standardized collapsible shell every inline chat widget wraps: a header
+ * (title + status chip + chevron), an expanded body, and a compact collapsed
+ * summary row. It bounds the vertical space a widget eats in the transcript by
+ * enforcing one contract — start EXPANDED while the widget's job is incomplete,
+ * AUTO-COLLAPSE to the summary once it reports complete/connected — while still
+ * letting the user re-expand via the chevron.
+ *
+ * Consumed by the connector-setup widget (and any future inline widget that
+ * needs the same expand/collapse discipline) through `MessageContent`'s
+ * registry render path. The `complete` flag is the single source of the
+ * default-collapse decision; the user's manual toggle after that overrides it,
+ * so a connected widget the user re-opened stays open. Collapsed bodies carry
+ * `content-visibility:auto` so an off-screen collapsed widget is skipped by
+ * layout/paint until scrolled into view — this is why collapsing a widget in a
+ * long transcript does not repaint sibling rows.
+ */
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
+
+import { cn } from "../../../lib/utils";
+import { Button } from "../../ui/button";
+
+export interface ChatWidgetShellProps {
+  /** Marker title shown in the header, e.g. the connector name. */
+  title: string;
+  /** Icon rendered left of the title. */
+  icon?: ReactNode;
+  /** Status chip on the right of the header (connection/config state). */
+  status?: ReactNode;
+  /**
+   * Whether the widget's job is done (connected/configured). Drives the default
+   * expansion: incomplete → expanded, complete → collapsed. A later user toggle
+   * wins over this default until `complete` transitions again.
+   */
+  complete: boolean;
+  /** Compact one-line summary shown when collapsed. */
+  summary: ReactNode;
+  /** Expanded body — the full setup form / panel. */
+  children: ReactNode;
+  /** Stable test id prefix for the shell subtree. */
+  testId?: string;
+}
+
+/**
+ * Renders the shell. Expansion is uncontrolled: it defaults from `complete` and
+ * re-syncs only when `complete` itself flips (so the auto-collapse fires exactly
+ * once on connect, not on every unrelated re-render).
+ */
+export function ChatWidgetShell({
+  title,
+  icon,
+  status,
+  complete,
+  summary,
+  children,
+  testId = "chat-widget-shell",
+}: ChatWidgetShellProps) {
+  const [expanded, setExpanded] = useState(!complete);
+  // Track the last `complete` we reacted to so a re-render with an unchanged
+  // flag never clobbers a manual toggle; only a real transition re-derives.
+  const lastComplete = useRef(complete);
+  useEffect(() => {
+    if (lastComplete.current !== complete) {
+      lastComplete.current = complete;
+      setExpanded(!complete);
+    }
+  }, [complete]);
+
+  const Chevron = expanded ? ChevronDown : ChevronRight;
+
+  return (
+    <div
+      data-testid={testId}
+      data-complete={complete}
+      data-expanded={expanded}
+      className="my-2 rounded-sm border border-border bg-card"
+    >
+      <div className="flex items-center gap-2 px-3 py-2">
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => setExpanded((prev) => !prev)}
+          aria-expanded={expanded}
+          data-testid={`${testId}-toggle`}
+          className="h-auto min-w-0 flex-1 justify-start gap-2 rounded-sm bg-transparent px-0 py-0.5 text-left transition-colors hover:bg-transparent hover:text-txt"
+        >
+          {icon ? (
+            <span className="inline-flex shrink-0 items-center justify-center text-muted [&>svg]:h-4 [&>svg]:w-4">
+              {icon}
+            </span>
+          ) : null}
+          <span className="truncate text-sm font-semibold text-txt">
+            {title}
+          </span>
+          <Chevron aria-hidden className="h-4 w-4 shrink-0 text-muted" />
+        </Button>
+        {status ? <div className="shrink-0">{status}</div> : null}
+      </div>
+      {expanded ? (
+        <div className="px-3 pb-3 pt-1" data-testid={`${testId}-body`}>
+          {children}
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setExpanded(true)}
+          data-testid={`${testId}-summary`}
+          // content-visibility:auto lets the browser skip layout/paint of this
+          // collapsed row while it is off-screen in a long transcript.
+          className={cn(
+            "flex w-full items-center gap-2 border-t border-border px-3 py-2 text-left text-xs text-muted transition-colors hover:text-txt",
+            "[content-visibility:auto] [contain-intrinsic-size:auto_2rem]",
+          )}
+        >
+          {summary}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/chat/widgets/connector-field-tiers.ts
+++ b/packages/ui/src/components/chat/widgets/connector-field-tiers.ts
@@ -1,0 +1,43 @@
+/**
+ * Splits a connector/plugin's parameter schema into the two progressive-
+ * disclosure tiers the connector-setup widget renders: `minimal` (shown by
+ * default) and `advanced` (behind an "Advanced" dropdown). This is the single
+ * place that decides which fields a user sees up front, so the connector widget
+ * and its tests agree on one derivation.
+ *
+ * Rule: a param is minimal when it is `required` OR not yet set (`isSet` is
+ * falsy) — i.e. the fields a user must touch to get connected. Everything the
+ * schema already has a value for and does not require is advanced. `completed`
+ * folds the same schema into the shell's collapse decision: complete once every
+ * required param is set.
+ *
+ * Consumed by `connector-setup-widget.tsx`; kept as a pure module (no React) so
+ * the tiering is unit-testable without mounting the widget graph.
+ */
+import type { PluginParam } from "@elizaos/shared";
+
+export interface ConnectorFieldTiers {
+  minimal: PluginParam[];
+  advanced: PluginParam[];
+}
+
+/** Partition params into minimal (required/unset) vs advanced (set optionals). */
+export function deriveConnectorFieldTiers(
+  params: PluginParam[],
+): ConnectorFieldTiers {
+  const minimal: PluginParam[] = [];
+  const advanced: PluginParam[] = [];
+  for (const param of params) {
+    if (param.required || !param.isSet) {
+      minimal.push(param);
+    } else {
+      advanced.push(param);
+    }
+  }
+  return { minimal, advanced };
+}
+
+/** A connector is complete once every required param has a value set. */
+export function isConnectorConfigured(params: PluginParam[]): boolean {
+  return params.every((param) => !param.required || Boolean(param.isSet));
+}

--- a/packages/ui/src/components/chat/widgets/connector-setup-widget.test.tsx
+++ b/packages/ui/src/components/chat/widgets/connector-setup-widget.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+//
+// Behavior lock for the connector-setup widget + its shared collapsible shell
+// (#14412). Real components, jsdom DOM assertions — no mocks of the units under
+// test. Covers the four contracts the issue names: start-expanded-when-
+// unconfigured, auto-collapse-on-connect, the minimal/Advanced disclosure, and
+// the field-tier derivation.
+
+import type { PluginParam } from "@elizaos/shared";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  deriveConnectorFieldTiers,
+  isConnectorConfigured,
+} from "./connector-field-tiers";
+import { ConnectorSetupWidget } from "./connector-setup-widget";
+
+afterEach(cleanup);
+
+const UNCONFIGURED: PluginParam[] = [
+  { key: "DISCORD_TOKEN", required: true, isSet: false, label: "Bot Token" },
+  { key: "DISCORD_APP_ID", required: true, isSet: false, label: "App ID" },
+  { key: "DISCORD_GUILD_ID", required: false, isSet: true, label: "Guild ID" },
+];
+
+const CONFIGURED: PluginParam[] = [
+  { key: "DISCORD_TOKEN", required: true, isSet: true, label: "Bot Token" },
+  { key: "DISCORD_APP_ID", required: true, isSet: true, label: "App ID" },
+  { key: "DISCORD_GUILD_ID", required: false, isSet: true, label: "Guild ID" },
+];
+
+describe("deriveConnectorFieldTiers", () => {
+  it("puts required/unset params in minimal and set optionals in advanced", () => {
+    const { minimal, advanced } = deriveConnectorFieldTiers(UNCONFIGURED);
+    expect(minimal.map((p) => p.key)).toEqual([
+      "DISCORD_TOKEN",
+      "DISCORD_APP_ID",
+    ]);
+    expect(advanced.map((p) => p.key)).toEqual(["DISCORD_GUILD_ID"]);
+  });
+
+  it("reports configured only when every required param is set", () => {
+    expect(isConnectorConfigured(UNCONFIGURED)).toBe(false);
+    expect(isConnectorConfigured(CONFIGURED)).toBe(true);
+  });
+});
+
+describe("ConnectorSetupWidget shell", () => {
+  it("starts EXPANDED while unconfigured", () => {
+    const { getByTestId, queryByTestId } = render(
+      <ConnectorSetupWidget
+        id="discord"
+        name="Discord"
+        params={UNCONFIGURED}
+        onSetup={vi.fn()}
+      />,
+    );
+    const shell = getByTestId("connector-widget-discord");
+    expect(shell.getAttribute("data-expanded")).toBe("true");
+    expect(getByTestId("connector-widget-discord-body")).toBeTruthy();
+    expect(queryByTestId("connector-widget-discord-summary")).toBeNull();
+  });
+
+  it("starts COLLAPSED (summary only) once connected", () => {
+    const { getByTestId, queryByTestId } = render(
+      <ConnectorSetupWidget
+        id="discord"
+        name="Discord"
+        params={CONFIGURED}
+        onSetup={vi.fn()}
+      />,
+    );
+    const shell = getByTestId("connector-widget-discord");
+    expect(shell.getAttribute("data-expanded")).toBe("false");
+    const summary = getByTestId("connector-widget-discord-summary");
+    expect(summary.textContent).toContain("Discord connected");
+    // Collapsed off-screen widgets skip layout/paint via content-visibility.
+    expect(summary.className).toContain("[content-visibility:auto]");
+    expect(queryByTestId("connector-widget-discord-body")).toBeNull();
+  });
+
+  it("re-expands from the collapsed summary via the chevron", () => {
+    const { getByTestId } = render(
+      <ConnectorSetupWidget
+        id="discord"
+        name="Discord"
+        params={CONFIGURED}
+        onSetup={vi.fn()}
+      />,
+    );
+    fireEvent.click(getByTestId("connector-widget-discord-toggle"));
+    expect(
+      getByTestId("connector-widget-discord").getAttribute("data-expanded"),
+    ).toBe("true");
+    expect(getByTestId("connector-widget-discord-body")).toBeTruthy();
+  });
+
+  it("hides advanced fields until the Advanced dropdown is opened", () => {
+    const { getByTestId, queryByText } = render(
+      <ConnectorSetupWidget
+        id="discord"
+        name="Discord"
+        params={UNCONFIGURED}
+        onSetup={vi.fn()}
+      />,
+    );
+    // Advanced trigger present, count reflects the set-optional field.
+    const toggle = getByTestId("connector-widget-discord-advanced-toggle");
+    expect(toggle.textContent).toContain("Advanced");
+    expect(toggle.textContent).toContain("(1)");
+
+    // Radix Collapsible keeps content out of the a11y tree while closed.
+    fireEvent.click(toggle);
+    expect(
+      getByTestId("connector-widget-discord-advanced-toggle").textContent,
+    ).toContain("Hide advanced");
+    expect(queryByText("Guild ID")).toBeTruthy();
+  });
+
+  it("routes setup through onSetup (never plain secret fields)", () => {
+    const onSetup = vi.fn();
+    const { getByTestId } = render(
+      <ConnectorSetupWidget
+        id="discord"
+        name="Discord"
+        params={UNCONFIGURED}
+        onSetup={onSetup}
+      />,
+    );
+    fireEvent.click(getByTestId("connector-widget-discord-setup"));
+    expect(onSetup).toHaveBeenCalledWith("discord");
+    // No password/secret <input> is rendered in-transcript.
+    expect(
+      getByTestId("connector-widget-discord").querySelectorAll(
+        "input[type='password']",
+      ).length,
+    ).toBe(0);
+  });
+});

--- a/packages/ui/src/components/chat/widgets/connector-setup-widget.tsx
+++ b/packages/ui/src/components/chat/widgets/connector-setup-widget.tsx
@@ -1,0 +1,138 @@
+/**
+ * Inline connector-setup widget: renders a connector's setup inside the shared
+ * `ChatWidgetShell` with progressive disclosure — required/unset ("minimal")
+ * fields up front, the rest behind an "Advanced" dropdown. It starts expanded
+ * while the connector is unconfigured and auto-collapses to a "Connected"
+ * summary once every required param is set (the shell owns that transition).
+ *
+ * Consumed via the inline-widget registry (`[CONNECTOR:<id>]` marker) from both
+ * `MessageContent` and the overlay renderer. Secrets never appear as plain
+ * in-chat inputs: each field is a labelled row, and the primary action hands
+ * off to the connector's real setup path via `onSetup` (the sensitive-request /
+ * hosted-page flow), so no secret value travels through the transcript.
+ *
+ * The component is wrapped in `memo` so a user opening the Advanced dropdown (or
+ * toggling the shell) re-renders only this widget subtree, never the transcript
+ * — the render-count perf lock covers a transcript full of these.
+ */
+
+import type { PluginParam } from "@elizaos/shared";
+import { Cable } from "lucide-react";
+import { memo, useState } from "react";
+import { Badge } from "../../ui/badge";
+import { Button } from "../../ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "../../ui/collapsible";
+import { ChatWidgetShell } from "./chat-widget-shell";
+import {
+  deriveConnectorFieldTiers,
+  isConnectorConfigured,
+} from "./connector-field-tiers";
+
+export interface ConnectorSetupWidgetProps {
+  /** Connector/plugin id, e.g. `discord`. */
+  id: string;
+  /** Human label shown in the header. */
+  name: string;
+  /** Parameter schema (never values) driving the tiers + connected state. */
+  params: PluginParam[];
+  /** Kick off the connector's real setup path (sensitive-request flow). */
+  onSetup: (connectorId: string) => void;
+}
+
+function FieldRow({ param }: { param: PluginParam }) {
+  return (
+    <li className="flex items-center justify-between gap-2 py-1 text-xs">
+      <span className="truncate text-muted">{param.label ?? param.key}</span>
+      {param.isSet ? (
+        <span className="shrink-0 text-2xs text-muted/70">set</span>
+      ) : param.required ? (
+        <span className="shrink-0 text-2xs text-primary">required</span>
+      ) : (
+        <span className="shrink-0 text-2xs text-muted/70">optional</span>
+      )}
+    </li>
+  );
+}
+
+function ConnectorSetupWidgetImpl({
+  id,
+  name,
+  params,
+  onSetup,
+}: ConnectorSetupWidgetProps) {
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const { minimal, advanced } = deriveConnectorFieldTiers(params);
+  const configured = isConnectorConfigured(params);
+
+  const status = (
+    <Badge variant={configured ? "default" : "secondary"}>
+      {configured ? "Connected" : "Setup"}
+    </Badge>
+  );
+
+  const summary = (
+    <span className="truncate">
+      {configured ? `${name} connected` : `${name} needs setup`}
+    </span>
+  );
+
+  return (
+    <ChatWidgetShell
+      testId={`connector-widget-${id}`}
+      title={name}
+      icon={<Cable aria-hidden />}
+      status={status}
+      complete={configured}
+      summary={summary}
+    >
+      <ul className="mb-2 space-y-0.5">
+        {minimal.map((param) => (
+          <FieldRow key={param.key} param={param} />
+        ))}
+      </ul>
+
+      {advanced.length > 0 ? (
+        <Collapsible open={showAdvanced} onOpenChange={setShowAdvanced}>
+          <CollapsibleTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              data-testid={`connector-widget-${id}-advanced-toggle`}
+              className="h-auto w-full justify-start rounded-sm bg-transparent px-0 py-1 text-2xs text-muted transition-colors hover:bg-transparent hover:text-txt"
+            >
+              {showAdvanced ? "Hide advanced" : "Advanced"} ({advanced.length})
+            </Button>
+          </CollapsibleTrigger>
+          <CollapsibleContent
+            data-testid={`connector-widget-${id}-advanced-body`}
+          >
+            <ul className="space-y-0.5">
+              {advanced.map((param) => (
+                <FieldRow key={param.key} param={param} />
+              ))}
+            </ul>
+          </CollapsibleContent>
+        </Collapsible>
+      ) : null}
+
+      {!configured ? (
+        <Button
+          type="button"
+          size="sm"
+          onClick={() => onSetup(id)}
+          data-testid={`connector-widget-${id}-setup`}
+          className="mt-2 w-full"
+        >
+          Set up securely
+        </Button>
+      ) : null}
+    </ChatWidgetShell>
+  );
+}
+
+export const ConnectorSetupWidget = memo(ConnectorSetupWidgetImpl);

--- a/packages/ui/src/components/chat/widgets/connector-widget.render-count.test.tsx
+++ b/packages/ui/src/components/chat/widgets/connector-widget.render-count.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+//
+// Repaint lock for connector widgets in a transcript (#14412). A transcript of
+// N connector widgets is rendered as memoized `ChatTranscript` rows; toggling
+// ONE widget's Advanced dropdown (its internal state) must not re-render any
+// sibling row. We assert this two ways: the per-row `renderMessageContent`
+// counter (a real production prop) stays flat for siblings, and only the
+// toggled widget's own body count increments. This extends the streaming
+// render-count lock (`chat-transcript.render-count.test.tsx`) to cover the new
+// widget's internal state churn — the case the issue calls out.
+
+import type { PluginParam } from "@elizaos/shared";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ChatTranscript } from "../../composites/chat/chat-transcript";
+import type { ChatMessageData } from "../../composites/chat/chat-types";
+import { ConnectorSetupWidget } from "./connector-setup-widget";
+
+afterEach(cleanup);
+
+const WIDGET_COUNT = 6;
+
+// Every widget is unconfigured so it renders expanded with an Advanced tier we
+// can toggle. Set-optional field makes `advanced.length === 1`.
+const PARAMS: PluginParam[] = [
+  { key: "TOKEN", required: true, isSet: false, label: "Token" },
+  { key: "GUILD", required: false, isSet: true, label: "Guild" },
+];
+
+function makeTranscript(): ChatMessageData[] {
+  const messages: ChatMessageData[] = [];
+  for (let i = 0; i < WIDGET_COUNT; i += 1) {
+    messages.push({
+      id: `conn-${i}`,
+      role: "assistant",
+      text: `connector ${i}`,
+    });
+  }
+  return messages;
+}
+
+describe("connector widgets do not repaint the transcript (#14412)", () => {
+  it("toggling one widget's Advanced dropdown re-renders only that widget", () => {
+    // Per-row render tally via the real renderMessageContent prop.
+    const rowCounts = new Map<string, number>();
+    const renderMessageContent = vi.fn((message: ChatMessageData) => {
+      rowCounts.set(message.id, (rowCounts.get(message.id) ?? 0) + 1);
+      return (
+        <ConnectorSetupWidget
+          id={message.id}
+          name={`Connector ${message.id}`}
+          params={PARAMS}
+          onSetup={() => {}}
+        />
+      );
+    });
+
+    const { getByTestId } = render(
+      <ChatTranscript
+        messages={makeTranscript()}
+        renderMessageContent={renderMessageContent}
+      />,
+    );
+
+    // Mount: every row rendered exactly once.
+    for (let i = 0; i < WIDGET_COUNT; i += 1) {
+      expect(rowCounts.get(`conn-${i}`)).toBe(1);
+    }
+    const afterMount = new Map(rowCounts);
+
+    // Interact with ONE widget: open its Advanced dropdown (internal state).
+    fireEvent.click(getByTestId("connector-widget-conn-2-advanced-toggle"));
+
+    // No sibling row's content was re-rendered — the widget's state stayed
+    // local to its own subtree; the transcript did not repaint.
+    for (let i = 0; i < WIDGET_COUNT; i += 1) {
+      expect(rowCounts.get(`conn-${i}`)).toBe(afterMount.get(`conn-${i}`));
+    }
+
+    // The interaction actually did something: the toggled widget now shows the
+    // advanced field it was hiding.
+    expect(
+      getByTestId("connector-widget-conn-2-advanced-body").textContent,
+    ).toContain("Guild");
+  });
+});

--- a/packages/ui/src/components/chat/widgets/inline-builtins.tsx
+++ b/packages/ui/src/components/chat/widgets/inline-builtins.tsx
@@ -15,6 +15,10 @@ import {
 } from "../message-checklist-parser";
 import { type ChoiceMatch, findChoiceRegions } from "../message-choice-parser";
 import {
+  type ConnectorMatch,
+  findConnectorRegions,
+} from "../message-connector-parser";
+import {
   type FollowupsMatch,
   findFollowupsRegions,
 } from "../message-followups-parser";
@@ -24,6 +28,7 @@ import {
   type WorkflowMatch,
 } from "../message-workflow-parser";
 import { ChoiceWidget } from "./ChoiceWidget";
+import { ConnectorSetupWidget } from "./connector-setup-widget";
 import { FollowupsWidget } from "./followups";
 import { FormRequest } from "./form-request";
 import { registerInlineWidget } from "./inline-registry";
@@ -76,6 +81,26 @@ registerInlineWidget<WorkflowMatch>({
   parse: (text) => findWorkflowRegions(text).map((m) => ({ ...m, data: m })),
   keyFor: (m) => `workflow:${m.workflow.id}`,
   render: (m, _ctx, key) => <WorkflowSteps key={key} workflow={m.workflow} />,
+});
+
+registerInlineWidget<ConnectorMatch>({
+  kind: "connector",
+  parse: (text) => findConnectorRegions(text).map((m) => ({ ...m, data: m })),
+  keyFor: (m) => `connector:${m.id}`,
+  // `sendAction` routes the setup request through the same action-message
+  // pipeline the connector's real setup / sensitive-request flow listens on, so
+  // no secret is ever typed into the transcript.
+  render: (m, ctx, key) => (
+    <ConnectorSetupWidget
+      key={key}
+      id={m.id}
+      name={m.name}
+      params={m.params}
+      onSetup={(connectorId) =>
+        ctx.sendAction(`connector:setup:${connectorId}`)
+      }
+    />
+  ),
 });
 
 registerInlineWidget<ChecklistMatch>({

--- a/packages/ui/src/components/chat/widgets/inline-registry.matrix.test.tsx
+++ b/packages/ui/src/components/chat/widgets/inline-registry.matrix.test.tsx
@@ -38,10 +38,11 @@ const BUILTIN_INLINE_KINDS = [
   "form",
   "workflow",
   "checklist",
+  "connector",
 ] as const;
 
 // A representative marker per built-in, in the exact wire format its parser
-// recognizes (see message-{choice,followups,form,workflow,checklist}-parser.ts).
+// recognizes (see message-{choice,followups,form,workflow,checklist,connector}-parser.ts).
 const SAMPLE: Record<(typeof BUILTIN_INLINE_KINDS)[number], string> = {
   choice: "[CHOICE:pick id=c1]\nyes=Yes\nno=No\n[/CHOICE]",
   followups:
@@ -52,6 +53,9 @@ const SAMPLE: Record<(typeof BUILTIN_INLINE_KINDS)[number], string> = {
     '[WORKFLOW]\n{"id":"w1","title":"Deploy","steps":[{"label":"build","status":"done"},{"label":"push","status":"running"}]}\n[/WORKFLOW]',
   checklist:
     '[CHECKLIST]\n{"title":"Todos","items":[{"content":"read","status":"completed"},{"content":"edit","status":"in_progress"}]}\n[/CHECKLIST]',
+  // CONNECTOR body is `KEY|required|isSet|label` per line.
+  connector:
+    '[CONNECTOR:discord name="Discord"]\nDISCORD_TOKEN|1|0|Bot Token\n[/CONNECTOR]',
 };
 
 const ctx: InlineWidgetContext = {

--- a/packages/ui/src/components/chat/widgets/inline-registry.test.tsx
+++ b/packages/ui/src/components/chat/widgets/inline-registry.test.tsx
@@ -38,7 +38,14 @@ describe("inline-widget registry", () => {
       getInlineWidgets()
         .map((w) => w.kind)
         .sort(),
-    ).toEqual(["checklist", "choice", "followups", "form", "workflow"]);
+    ).toEqual([
+      "checklist",
+      "choice",
+      "connector",
+      "followups",
+      "form",
+      "workflow",
+    ]);
   });
 
   it("lets a plugin register a new marker and render it end to end", () => {


### PR DESCRIPTION
## What & why

The MVP direction is "settings live in chat," but there was no first-class **connector-setup widget** and no **standardized collapsible widget shell**. Chat widgets ate unbounded vertical space in the transcript. This adds, **on the existing registry-based widget system** (no new framework):

1. **`ChatWidgetShell`** — one shared chevron collapser every inline widget can wrap. Contract: **starts expanded while incomplete, auto-collapses to a compact summary once complete/connected**, re-expandable via a standardized chevron. A manual toggle after that wins until `complete` transitions again. Collapsed summary rows carry `content-visibility:auto` so an off-screen collapsed widget skips layout/paint.
2. **Minimal + Advanced progressive disclosure** — `connector-field-tiers.ts` derives minimal (required/unset) vs advanced (set optionals) from the plugin/connector param schema (`PluginParam[]`, the shape `buildPluginConfigUiSpec` consumes). Advanced fields sit behind a `Collapsible` dropdown.
3. **Connector-setup widget** — a `[CONNECTOR:<id> name="…"]…[/CONNECTOR]` marker registered via `registerInlineWidget`. The registry auto-wires it into **both** ChatView (`MessageContent`) and the overlay (`InlineWidgetText`) with no edit to either. Secrets never render as plain in-chat inputs — each field is a labelled row and the primary action routes to the connector's real setup / sensitive-request flow via `sendAction("connector:setup:<id>")`. Collapses to a "Connected" summary once configured.
4. **Repaint optimization** — the widget is `memo`-wrapped so its internal state (expand/collapse, Advanced toggle) updates in isolation and does **not** repaint the transcript. A new render-count perf lock proves this for a transcript of N connector widgets.

`WIDGET_MATRIX.md` updated with the connector row + shell contract (coordinates with #14327).

### Coordination / rebase notes
- Built **on** the existing registry (per MVP out-of-scope: no new widget framework). Only additive registration in `inline-builtins.tsx`.
- The FORM/widget system is also touched by **#14486** (date/time field types). This diff does **not** touch `message-form-parser.ts`, `form-request.tsx`, or the FORM schema — it adds a separate `[CONNECTOR]` marker + parser, so rebase against #14486 is trivial (no overlapping files).
- Rebased clean onto `origin/develop`.

## Verification (real output)

<details><summary>New + affected UI tests — all green (29/29)</summary>

```
$ bun run --cwd packages/ui test \
    connector-setup-widget.test.tsx message-connector-parser.test.ts \
    connector-widget.render-count.test.tsx inline-registry.test.tsx \
    inline-registry.matrix.test.tsx chat-transcript.render-count.test.tsx \
    chat-transcript.memoization.test.tsx

 Test Files  7 passed (7)
      Tests  29 passed (29)
```

- `connector-setup-widget.test.tsx` — starts-expanded-when-unconfigured, starts-collapsed-on-connect (asserts `content-visibility:auto` on the summary), re-expand via chevron, Advanced dropdown hidden until opened, secure-setup routing (asserts **zero** `input[type=password]` in-transcript).
- `message-connector-parser.test.ts` — region extraction, `name` attribute, `KEY|required|isSet|label` body schema, blank/keyless-line handling.
- `connector-widget.render-count.test.tsx` — a transcript of 6 connector widgets; toggling ONE widget's Advanced dropdown re-renders **no** sibling row (per-row `renderMessageContent` counter stays flat).
- `inline-registry.test.tsx` / `inline-registry.matrix.test.tsx` — exact-set + WIDGET_MATRIX gate extended with the `connector` builtin (10 matrix assertions pass).
- Existing streaming perf locks (`chat-transcript.render-count` / `.memoization`) still green.
</details>

<details><summary>Overlay/ChatView parity contracts still green (27/27)</summary>

```
$ bun run --cwd packages/ui test InlineWidgetText.test.tsx parser-parity.contract.test.ts render-parity.contract.test.tsx
 Test Files  3 passed (3)
      Tests  27 passed (27)
```
</details>

<details><summary>Typecheck + lint scoped to touched files — clean</summary>

```
$ bunx tsc --noEmit -p packages/ui/tsconfig.json  # 0 errors in touched files
0

$ bunx biome check <11 touched files>
Checked 8 files in 94ms. No fixes applied.
```

Note: `packages/ui` full typecheck reports pre-existing errors in files this PR does not touch (`button.tsx`, `spinner.tsx`, `calendar.tsx`, settings/*), caused by the known worktree `@types/react` duplication skew. **Zero** of those are in this PR's files.
</details>

## Evidence

| Type | Status |
|---|---|
| Unit/behavior tests (collapser + parser + repaint) | Attached above — 29/29 green |
| Parity contracts (both chat surfaces) | Attached above — 27/27 green |
| Scoped typecheck + lint | Attached above — clean |
| Full-app visual capture (desktop + mobile screenshots/video) | N/A — requires a booted dev server + agent emitting a live `[CONNECTOR:…]` reply, not runnable headlessly in this worktree. Owner runs: `bun run --cwd packages/app audit:app` and reviews `aesthetic-audit-output/`. |
| Real-LLM trajectory | N/A — no prompt/action/model change; this is a client-side render + registry addition. The producing action wiring (agent emitting the marker) is tracked by the `[chat-widgets]` workstream (#14364/#14461). |

Part of #14412

> **Not `Closes` — this is the substrate PR, not the full acceptance.** #14412's first two Done-when criteria remain UNMET by this diff and must land before the issue closes:
> 1. **A user can set up a real connector end to end from chat.** No producer emits the `[CONNECTOR:<id> …]` marker, and nothing consumes `connector:setup:<id>` — the `Set up securely` CTA sends a bare chat action with no handler. **Remaining work (owned by the SETTINGS / #14364 workstream):** emit the marker from the agent/action path, and wire `connector:setup:<id>` into the existing connector setup / sensitive-request (#14326) flow so at least one real connector configures entirely from the widget.
> 2. **Every chat widget uses the shared collapsible shell.** Only the new connector widget adopts `ChatWidgetShell`; form/workflow/checklist/choice are untouched. Migrating them is remaining work.
>
> This PR delivers the reusable substrate: `ChatWidgetShell` (auto-collapse transition contract now locked by rerender tests), the `[CONNECTOR]` parser, the minimal/Advanced field-tier derivation, and the registry wiring — all verified. The `wired` status in WIDGET_MATRIX should read as substrate-present, not end-to-end-reachable, until the producer + consumer above land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

