### PR TITLE
fix(#14344): harden wallet widget refresh guards

### DIFF
--- a/packages/ui/src/components/chat/widgets/wallet-balance.test.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.test.tsx
@@ -115,6 +115,7 @@ function setVisibility(state: "visible" | "hidden"): void {
 
 beforeEach(() => {
   authMock.authenticated = true;
+  setVisibility("visible");
   navOpenView.mockReset();
   getWalletBalances.mockReset();
   getWalletMarketOverview.mockReset();
@@ -123,11 +124,19 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   vi.clearAllMocks();
-  setVisibility("visible");
 });
 
 describe("WalletBalanceWidget (price-only, #10706)", () => {
+  it("renders nothing and fetches nothing while unauthenticated", () => {
+    authMock.authenticated = false;
+    const { container } = render(<WalletBalanceWidget />);
+    expect(container.firstChild).toBeNull();
+    expect(getWalletBalances).not.toHaveBeenCalled();
+    expect(getWalletMarketOverview).not.toHaveBeenCalled();
+  });
+
   it("renders a loading placeholder until the data resolves", () => {
     const d = deferred<WalletBalancesResponse>();
     getWalletBalances.mockReturnValue(d.promise);
@@ -231,81 +240,104 @@ describe("WalletBalanceWidget (price-only, #10706)", () => {
     expect(text).toContain("$3,000.00");
   });
 
+  it("shows BTC/SOL/ETH default rows when balances fail but prices load", async () => {
+    getWalletBalances.mockRejectedValue(new Error("balances 503"));
+    getWalletMarketOverview.mockResolvedValue(
+      overview([
+        { symbol: "BTC", priceUsd: 64000, change24hPct: 1.2 },
+        { symbol: "ETH", priceUsd: 3000, change24hPct: -0.5 },
+        { symbol: "SOL", priceUsd: 150, change24hPct: 2.1 },
+      ]),
+    );
+
+    render(<WalletBalanceWidget />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("chat-widget-wallet-prices")).toBeTruthy(),
+    );
+    expect(
+      screen.getAllByTestId(/^wallet-price-row-/).map((r) => r.dataset.testid),
+    ).toEqual([
+      "wallet-price-row-BTC",
+      "wallet-price-row-SOL",
+      "wallet-price-row-ETH",
+    ]);
+  });
+
   it("refreshes prices on the 60s visibility-gated interval (#14344)", async () => {
     vi.useFakeTimers();
-    try {
-      getWalletBalances.mockResolvedValue({ evm: null, solana: null });
-      getWalletMarketOverview
-        .mockResolvedValueOnce(overview([{ symbol: "BTC", priceUsd: 64000 }]))
-        .mockResolvedValue(overview([{ symbol: "BTC", priceUsd: 70000 }]));
-      render(<WalletBalanceWidget />);
-      // Flush the initial fetch.
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(0);
-      });
-      expect(
-        screen.getByTestId("chat-widget-wallet-prices").textContent,
-      ).toContain("$64,000.00");
-      expect(getWalletMarketOverview).toHaveBeenCalledTimes(1);
-      // One interval tick → a fresh fetch updates the displayed price.
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(60_000);
-      });
-      expect(getWalletMarketOverview).toHaveBeenCalledTimes(2);
-      expect(
-        screen.getByTestId("chat-widget-wallet-prices").textContent,
-      ).toContain("$70,000.00");
-    } finally {
-      vi.useRealTimers();
-    }
+    getWalletBalances.mockResolvedValue({ evm: null, solana: null });
+    getWalletMarketOverview
+      .mockResolvedValueOnce(overview([{ symbol: "BTC", priceUsd: 64000 }]))
+      .mockResolvedValue(overview([{ symbol: "BTC", priceUsd: 70000 }]));
+    render(<WalletBalanceWidget />);
+    // Flush the initial fetch.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(
+      screen.getByTestId("chat-widget-wallet-prices").textContent,
+    ).toContain("$64,000.00");
+    expect(getWalletMarketOverview).toHaveBeenCalledTimes(1);
+    // One interval tick → a fresh fetch updates the displayed price.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(getWalletMarketOverview).toHaveBeenCalledTimes(2);
+    expect(
+      screen.getByTestId("chat-widget-wallet-prices").textContent,
+    ).toContain("$70,000.00");
   });
 
   it("does not poll while the document is hidden", async () => {
     vi.useFakeTimers();
-    try {
-      setVisibility("hidden");
-      getWalletBalances.mockResolvedValue({ evm: null, solana: null });
-      getWalletMarketOverview.mockResolvedValue(
-        overview([{ symbol: "BTC", priceUsd: 64000 }]),
-      );
+    setVisibility("hidden");
+    getWalletBalances.mockResolvedValue({ evm: null, solana: null });
+    getWalletMarketOverview.mockResolvedValue(
+      overview([{ symbol: "BTC", priceUsd: 64000 }]),
+    );
 
-      render(<WalletBalanceWidget />);
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(0);
-      });
-      expect(getWalletMarketOverview).toHaveBeenCalledTimes(1);
+    render(<WalletBalanceWidget />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(getWalletMarketOverview).toHaveBeenCalledTimes(1);
 
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(180_000);
-      });
-      expect(getWalletMarketOverview).toHaveBeenCalledTimes(1);
-    } finally {
-      vi.useRealTimers();
-    }
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(180_000);
+    });
+    expect(getWalletMarketOverview).toHaveBeenCalledTimes(1);
   });
 
-  it("does not fetch or install the refresh poll before authentication", async () => {
+  it("ignores an older refresh response that resolves after a newer one", async () => {
     vi.useFakeTimers();
-    try {
-      authMock.authenticated = false;
-      getWalletBalances.mockResolvedValue({ evm: null, solana: null });
-      getWalletMarketOverview.mockResolvedValue(
-        overview([{ symbol: "BTC", priceUsd: 64000 }]),
-      );
+    const firstOverview = deferred<WalletMarketOverviewResponse>();
+    const secondOverview = deferred<WalletMarketOverviewResponse>();
+    getWalletBalances.mockResolvedValue({ evm: null, solana: null });
+    getWalletMarketOverview
+      .mockReturnValueOnce(firstOverview.promise)
+      .mockReturnValueOnce(secondOverview.promise);
 
-      render(<WalletBalanceWidget />);
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(180_000);
-      });
+    render(<WalletBalanceWidget />);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
 
-      expect(getWalletBalances).not.toHaveBeenCalled();
-      expect(getWalletMarketOverview).not.toHaveBeenCalled();
-      expect(
-        screen.getByTestId("chat-widget-wallet-balance-loading"),
-      ).toBeTruthy();
-    } finally {
-      vi.useRealTimers();
-    }
+    secondOverview.resolve(overview([{ symbol: "BTC", priceUsd: 70000 }]));
+    await act(async () => {
+      await secondOverview.promise;
+    });
+    expect(
+      screen.getByTestId("chat-widget-wallet-prices").textContent,
+    ).toContain("$70,000.00");
+
+    firstOverview.resolve(overview([{ symbol: "BTC", priceUsd: 64000 }]));
+    await act(async () => {
+      await firstOverview.promise;
+    });
+    expect(
+      screen.getByTestId("chat-widget-wallet-prices").textContent,
+    ).toContain("$70,000.00");
   });
 
   it("hides (no error chrome) when the overview is unavailable", async () => {

--- a/packages/ui/src/components/chat/widgets/wallet-balance.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.tsx
@@ -14,7 +14,7 @@
 
 import type { WalletBalancesResponse } from "@elizaos/shared";
 import { Wallet } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { client } from "../../../api";
 import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
 import { useIntervalWhenDocumentVisible } from "../../../hooks/useDocumentVisibility";
@@ -66,12 +66,30 @@ export function WalletBalanceWidget(
   // Auth gate (#11084): the widget mounts before the auth probe resolves, so
   // fetching stays dormant until the session is authenticated.
   const authenticated = useIsAuthenticated();
+  const activeRef = useRef(true);
+  const refreshSeqRef = useRef(0);
+
+  useEffect(() => {
+    activeRef.current = true;
+    return () => {
+      activeRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (authenticated) return;
+    refreshSeqRef.current += 1;
+    setHoldings(null);
+    setLoading(true);
+  }, [authenticated]);
 
   // Prices (BTC/SOL/ETH + trending) come from the market-overview endpoint;
   // balances decide the held-vs-default branch. Both are fetched together and
   // best-effort (J4): a null overview means prices are unavailable → hide; a
   // null balances alone still shows the default rows.
   const refresh = useCallback(async () => {
+    refreshSeqRef.current += 1;
+    const seq = refreshSeqRef.current;
     const [balances, overview] = await Promise.all([
       // error-policy:J4 balances failure ⇒ no held rows; default rows still show
       (client.getWalletBalances() as Promise<WalletBalancesResponse>).catch(
@@ -80,6 +98,7 @@ export function WalletBalanceWidget(
       // error-policy:J4 overview failure ⇒ no prices at all ⇒ widget hides
       client.getWalletMarketOverview().catch(() => null),
     ]);
+    if (!activeRef.current || seq !== refreshSeqRef.current) return;
     const held = selectPricedHoldings(balances, overview?.prices);
     const next = held.length > 0 ? held : selectDefaultPriceRows(overview);
     // A failed refresh (next empty) keeps the last-good rows so a transient
@@ -102,6 +121,8 @@ export function WalletBalanceWidget(
     REFRESH_INTERVAL_MS,
     authenticated,
   );
+
+  if (!authenticated) return null;
 
   // First load pending: a quiet placeholder keeps the grid cell stable.
   if (loading && holdings == null) {


### PR DESCRIPTION
# Relates To

Follow-up to #14478 / #14344.

Definition of Done: full standard in [`PR_EVIDENCE.md`](../PR_EVIDENCE.md).

- [x] This PR targets `develop` and is rebased onto current `origin/develop`.
- [ ] `bun run verify` was run after sync, or any failure is recorded below.
- [x] A reviewer can confirm the changed behavior from focused tests and rendered widget screenshots.

# What Changed

The merged #14478 implemented the wallet widget doctrine. This follow-up tightens the edge states around that behavior:

- Unauthenticated state now renders nothing and performs no wallet/market fetches, instead of leaving a loading placeholder on the home surface.
- In-flight refreshes are invalidated on auth loss, unmount, and newer refresh start, so a slow older market response cannot roll back fresher prices.
- Tests now prove balances-failure still renders BTC/SOL/ETH when market prices load, hidden documents stay quiet, and stale responses are ignored.

# Testing

```text
bun run --cwd packages/ui test -- src/components/chat/widgets/wallet-price-holdings.test.ts src/components/chat/widgets/wallet-balance.test.tsx
Test Files  2 passed (2)
Tests  24 passed (24)

bun run --cwd packages/ui test -- src/components/chat/widgets
Test Files  26 passed (26)
Tests  177 passed (177)

bun run --cwd packages/ui test:wallet-widget-e2e
✓ DEFAULT state shows BTC/SOL/ETH rows
✓ HELD state shows top-3 held by value ETH/SOL/USDC
✓ HELD state leaks no holding values (price-only #10706)
✓ no page errors (0)
All wallet-widget assertions passed.

bunx @biomejs/biome check packages/ui/src/components/chat/widgets/wallet-balance.tsx packages/ui/src/components/chat/widgets/wallet-balance.test.tsx
Checked 2 files. No fixes applied.
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before state: covered by merged #14478 evidence showing the prior empty-wallet self-hide; this PR is a guard hardening follow-up.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: regenerated by `test:wallet-widget-e2e` as `wallet-default.png` and `wallet-held.png`; manually opened and reviewed locally.
<!-- evidence-row:walkthrough-video -->
- [ ] Video walkthrough: N/A - no new user flow beyond #14478; this PR changes auth/refresh race guards covered by tests.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: N/A - no backend path changed.
<!-- evidence-row:frontend-logs -->
- [x] Frontend/browser logs: `test:wallet-widget-e2e` reported zero page errors while rendering default and held states.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: rendered wallet-widget screenshots plus OCR/color heuristics below.

# Visual/OCR Heuristics

Tesseract OCR on regenerated screenshots:

```text
DEFAULT — no holdings
Wallet
BTC $64,000.00 +1.2%
SOL $150.00 +2.1%
ETH $3,000.00 -0.5%

HELD — top-3 by holding value
Wallet
ETH $3,000.00 -0.5%
SOL $150.00 +2.1%
USDC $1.00
```

Dominant screen color was `rgb(232, 89, 12)` for both screenshots. Content bounding boxes were stable (`wallet-default`: `85,101,754,334`; `wallet-held`: `85,101,754,331`). Estimated white-on-orange contrast was `3.58:1`, acceptable for the large row text; the broader muted-label contrast pattern belongs to a separate token audit rather than this guard PR.

# Known Gaps

- `bun run verify` was not run in this follow-up; scoped tests, browser render proof, OCR/color heuristics, and Biome were run on the pushed branch.