### PR TITLE
fix(pwa): reclaim the bottom strip — full-bleed #root to 100lvh + safe-area composer padding

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2609,6 +2609,17 @@ export function App() {
           // is what lets every view fill edge-to-edge under the notch while the
           // `paddingTop` below keeps CONTENT notch-aware. Locked by
           // App.safe-area-fill.test.ts.
+          //
+          // RECLAIM THE BOTTOM STRIP (#14411): the base height is `h-[100dvh]`
+          // (correct for a desktop browser tab / popout where dvh == the full
+          // window). In the INSTALLED PWA the styles.css standalone blocks pin
+          // #root to 100lvh and reclaim THIS column to 100lvh too (via the
+          // `[data-app-shell-root]` selector), so the app fills full-bleed to
+          // the physical bottom edge instead of leaving the ~59px lvh–dvh strip
+          // as #root's near-black --launch-bg band. The home-indicator safe
+          // area is padded INSIDE the app (the floating composer clears it), so
+          // background content bleeds under the indicator, native-app style.
+          data-app-shell-root=""
           className="relative flex h-[100dvh] w-full max-w-full flex-col overflow-hidden"
           // Reserve a TIGHT status-bar inset: enough to clear the notch/Dynamic
           // Island but no oversized empty band above the content (the repeated

--- a/packages/ui/src/platform/standalone-pwa-lockdown.test.ts
+++ b/packages/ui/src/platform/standalone-pwa-lockdown.test.ts
@@ -74,7 +74,11 @@ describe("isStandalonePwa", () => {
       configurable: true,
       writable: true,
       value: () =>
-        ({ matches: false, addEventListener() {}, removeEventListener() {} }) as unknown as MediaQueryList,
+        ({
+          matches: false,
+          addEventListener() {},
+          removeEventListener() {},
+        }) as unknown as MediaQueryList,
     });
     Object.defineProperty(navigator, "standalone", {
       configurable: true,
@@ -132,12 +136,43 @@ describe("CSS lockdown contract — base.css / styles.css cover body.pwa-standal
     expect(panYBlock?.[0]).toContain("body.pwa-standalone");
   });
 
-  it("locks #root to the viewport for the installed PWA too (styles.css)", () => {
+  it("reclaims #root to the LARGE viewport (100lvh) for the installed PWA too (styles.css)", () => {
+    // RECLAIM THE BOTTOM STRIP (#14411): #root now fills 100lvh (the true
+    // physical bottom), not the old 100dvh clamp that left a ~59px ember-floor
+    // strip below it. The class-path rule must carry pwa-standalone and pin the
+    // large-viewport height (with 100dvh/100vh progressive fallbacks).
     const rootBlock = stylesCss.match(
-      /body\.native #root,[\s\S]*?max-height: 100dvh;/,
+      /body\.native #root,[\s\S]*?max-height: 100lvh;/,
     );
     expect(rootBlock).not.toBeNull();
     expect(rootBlock?.[0]).toContain("body.pwa-standalone #root");
+    // Large-viewport reclaim + progressive-enhancement fallbacks.
+    expect(rootBlock?.[0]).toContain("100lvh");
+    expect(rootBlock?.[0]).toContain("100dvh");
+    expect(rootBlock?.[0]).toContain("100vh");
+    // The old hard 100dvh clamp (min AND max pinned to dvh) must be gone.
+    expect(rootBlock?.[0]).not.toMatch(
+      /min-height:\s*100dvh;\s*max-height:\s*100dvh;/,
+    );
+  });
+
+  it("reclaims the app shell column to 100lvh in the installed PWA (styles.css)", () => {
+    // RECLAIM THE BOTTOM STRIP (#14411): App.tsx's shell column carries a base
+    // `h-[100dvh]` (correct for a desktop tab / popout). In the installed PWA a
+    // CSS override must lift it to the LARGE viewport so it fills the 100lvh
+    // #root above and doesn't stop ~59px short (which would expose #root's
+    // --launch-bg as a near-black band). Targets the stable
+    // `[data-app-shell-root]` hook on the column.
+    const columnBlock = stylesCss.match(
+      /body\.native \[data-app-shell-root\],[\s\S]*?height: 100lvh;/,
+    );
+    expect(columnBlock).not.toBeNull();
+    expect(columnBlock?.[0]).toContain(
+      "body.pwa-standalone [data-app-shell-root]",
+    );
+    expect(columnBlock?.[0]).toContain("100lvh");
+    expect(columnBlock?.[0]).toContain("100dvh");
+    expect(columnBlock?.[0]).toContain("100vh");
   });
 });
 
@@ -338,13 +373,69 @@ describe("CSS-FIRST contract — media-query lockdown is detection-independent",
     expect(block ?? "").toContain("--launch-bg");
   });
 
-  it("styles.css media block locks #root to the viewport too", () => {
+  it("styles.css media block reclaims #root to the LARGE viewport (100lvh)", () => {
+    // RECLAIM THE BOTTOM STRIP (#14411): the media-query #root rule now pins the
+    // large viewport so the app fills full-bleed to the true bottom, not the old
+    // 100dvh clamp.
     const block = mediaBlock(
       stylesCss,
       ["display-mode: standalone", "pointer: coarse"],
       "100lvh",
     );
     expect(block).not.toBeNull();
-    expect(block ?? "").toMatch(/#root\s*\{[\s\S]*?max-height:\s*100dvh/);
+    expect(block ?? "").toMatch(/#root\s*\{[\s\S]*?max-height:\s*100lvh/);
+    // The app shell column reclaim must ride the same media block.
+    expect(block ?? "").toMatch(
+      /\[data-app-shell-root\]\s*\{[\s\S]*?height:\s*100lvh/,
+    );
+  });
+});
+
+describe("App shell reclaim contract — the shell column carries the reclaim hook", () => {
+  // RECLAIM THE BOTTOM STRIP (#14411): the CSS reclaim of the shell column
+  // targets `[data-app-shell-root]`; that hook must exist on the App.tsx shell
+  // column (the `position: relative` safe-area-fill root) or the CSS override
+  // matches nothing and the column stays clamped at its base h-[100dvh].
+  it("App.tsx tags the shell column with data-app-shell-root", () => {
+    const appTsx = readFileSync(resolve(process.cwd(), "src/App.tsx"), "utf8");
+    expect(appTsx).toContain("data-app-shell-root");
+  });
+});
+
+describe("Keyboard-lift geometry contract — reclaim does NOT shift the composer lift", () => {
+  // RECLAIM THE BOTTOM STRIP (#14411) regression guard: the composer overlay is
+  // a `position: fixed` element anchored to the fixed-body ICB (already pinned
+  // to 100lvh by the #14319 geometry), NOT to #root. Its keyboard lift comes
+  // from `bottom: effectiveKeyboardInset`, a VISUAL-VIEWPORT delta, and its
+  // panel height is bounded by `viewportH` (the visual viewport). None of these
+  // read #root's height, so lifting #root from 100dvh to 100lvh cannot change
+  // where the composer rests or how far it lifts above the keyboard — the
+  // lvh–dvh (~59px) delta never enters the lift math. Pin those invariants so a
+  // future refactor that couples the lift to #root/dvh trips this test.
+  const overlaySrc = readFileSync(
+    resolve(process.cwd(), "src/components/shell/ContinuousChatOverlay.tsx"),
+    "utf8",
+  );
+  const layoutSrc = readFileSync(
+    resolve(process.cwd(), "src/components/shell/chat-panel-layout.ts"),
+    "utf8",
+  );
+
+  it("lifts the composer by effectiveKeyboardInset (visual-viewport delta), not a #root/lvh measure", () => {
+    expect(overlaySrc).toContain("bottom: effectiveKeyboardInset");
+    // effectiveKeyboardInset is derived from the visual viewport + native
+    // keyboard plugin, never from 100lvh / #root height.
+    expect(overlaySrc).toContain(
+      "effectiveKeyboardInset = Math.max(keyboardInset, nativeLift)",
+    );
+    expect(overlaySrc).not.toContain("100lvh");
+  });
+
+  it("bounds the panel height by the visual viewport, not #root/lvh", () => {
+    // resolveChatPanelLayout caps panelMaxH by viewportH (the visual viewport),
+    // so a taller 100lvh #root does not let the panel top shoot off-screen.
+    expect(layoutSrc).toContain("viewportH -");
+    expect(layoutSrc).not.toContain("100lvh");
+    expect(layoutSrc).not.toContain("100dvh");
   });
 });

--- a/packages/ui/src/styles/base.css
+++ b/packages/ui/src/styles/base.css
@@ -330,9 +330,12 @@ body.desktop {
    The native shell is a fixed-viewport app: no pinch zoom, no rubber-band
    bounce, no two-finger drag, no callout/long-press menu, no scrollbars.
    Safe-area padding is applied at `#root` (see `styles.css`) instead of
-   here — `#root` is locked to `100dvh` so body-level padding wouldn't
-   shrink the React tree's flex container, and inner shells would still
-   render under the status bar. */
+   here — `#root` is pinned to the LARGE viewport (`100lvh`, reclaiming the
+   bottom strip per #14411) so body-level padding wouldn't shrink the React
+   tree's flex container, and inner shells would still render under the status
+   bar. The home-indicator safe area is padded INSIDE the app (composer/bottom
+   rows respect env(safe-area-inset-bottom)), so content bleeds full-height to
+   the true bottom while interactive controls stay above the indicator. */
 /* `body.pwa-standalone` (added from platform/init.ts) covers the INSTALLED
    iOS/Android PWA running on the `web` Capacitor platform: it is NOT the
    native App Store / Play Store build (which takes the `native`/`platform-ios`

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -96,8 +96,9 @@ html.eliza-chat-overlay-shell .shell-assistant-overlay-panel {
 /* `body.pwa-standalone` mirrors the native mobile lockdown for an INSTALLED
    PWA on the web platform (iOS home-screen app): `touch-action: pan-y` hands
    every horizontal drag to the app's rail/grabber gestures (only vertical pan
-   stays native), and the `#root` 100dvh lock keeps a stray drag from scrolling
-   the whole app off-screen — without this the home-screen swipes are eaten by
+   stays native), and the `#root` 100lvh lock (full-bleed to the true bottom,
+   #14411) keeps a stray drag from scrolling the whole app off-screen while the
+   React tree reaches the physical screen edge — without this the home-screen swipes are eaten by
    iOS WebKit's own page pan. See platform/init.ts isStandalonePwa(). */
 body.native,
 body.pwa-standalone {
@@ -151,12 +152,42 @@ body.pwa-standalone {
   background-color: color-mix(in srgb, var(--launch-bg, #160d07) 82%, #ef5a1f);
 }
 
+/* RECLAIM THE BOTTOM STRIP (#14411): #root fills the LARGE viewport (100lvh),
+   not the small/dynamic one (100dvh). Previously #root clamped to 100dvh (the
+   collapsed layout viewport, ~873px on a home-indicator phone) and the ~59px
+   strip down to 100lvh (~932px, the true screen bottom) was only the body's
+   decorative ember floor — dead space the app never reached. Now the React
+   tree paints full-bleed to the physical bottom edge, like a native app. The
+   home-indicator safe area is handled as PADDING *inside* the app (the
+   composer + bottom rows already respect `env(safe-area-inset-bottom)` via
+   --safe-area-bottom), so interactive controls still sit above the indicator
+   while background content bleeds under it. Height stack (100vh → 100dvh →
+   100lvh) is the same progressive-enhancement trick the fixed body uses: older
+   engines without `lvh` fall back to `dvh`, then `vh`. */
 body.native #root,
 body.pwa-standalone #root {
+  min-height: 100vh;
   min-height: 100dvh;
+  min-height: 100lvh;
+  max-height: 100vh;
   max-height: 100dvh;
+  max-height: 100lvh;
   padding: 0;
   box-sizing: border-box;
+}
+
+/* RECLAIM THE BOTTOM STRIP (#14411): the app shell column (App.tsx) carries a
+   base `h-[100dvh]` that is correct for a desktop browser tab / popout, but in
+   the installed PWA it must fill the 100lvh #root above — otherwise the column
+   stops ~59px short of the true bottom and #root's own --launch-bg paints a
+   near-black band there. Pin it to the LARGE viewport (100lvh) with the same
+   100vh→100dvh→100lvh progressive-enhancement stack; height governs so the
+   column reaches the physical screen edge, full-bleed. */
+body.native [data-app-shell-root],
+body.pwa-standalone [data-app-shell-root] {
+  height: 100vh;
+  height: 100dvh;
+  height: 100lvh;
 }
 
 body.native textarea,
@@ -172,7 +203,8 @@ body.pwa-standalone textarea {
    tags the body — see base.css note + issue). Same three rules the class path
    applies: `pan-y` (hand horizontal drags to the app rail/grabber), the #14319
    large-viewport (100lvh) fixed-body geometry (kills the residual bottom black
-   band + restores the swipe-up flick zone), and the #root 100dvh lock. Desktop
+   band + restores the swipe-up flick zone), and the #root 100lvh lock (#14411:
+   full-bleed to the true bottom, reclaiming the ember-floor strip). Desktop
    fullscreen (fine pointer) is excluded by `(pointer: coarse)`. */
 @media all and (display-mode: standalone) and (pointer: coarse),
   all and (display-mode: fullscreen) and (pointer: coarse) {
@@ -196,11 +228,34 @@ body.pwa-standalone textarea {
   }
 
   /* biome-ignore lint/style/noDescendingSpecificity: intentional bare #root lock mirroring body.pwa-standalone #root. */
+  /* RECLAIM THE BOTTOM STRIP (#14411): #root fills the LARGE viewport (100lvh)
+     so the app paints full-bleed to the physical bottom edge instead of
+     clamping to 100dvh and leaving the ~59px lvh–dvh strip as a dead ember
+     floor. Mirror of the class-path `body.pwa-standalone #root` rule; the
+     home-indicator safe area is padded INSIDE the app (composer/bottom rows
+     use env(safe-area-inset-bottom)), not left as void below #root. Same
+     100vh→100dvh→100lvh progressive-enhancement stack the body uses. */
   body #root {
+    min-height: 100vh;
     min-height: 100dvh;
+    min-height: 100lvh;
+    max-height: 100vh;
     max-height: 100dvh;
+    max-height: 100lvh;
     padding: 0;
     box-sizing: border-box;
+  }
+
+  /* biome-ignore lint/style/noDescendingSpecificity: intentional app-shell-column reclaim mirroring the class-path [data-app-shell-root] rule. */
+  /* RECLAIM THE BOTTOM STRIP (#14411): the app shell column (App.tsx) carries a
+     base `h-[100dvh]`; in the installed PWA it must fill the 100lvh #root or it
+     stops ~59px short and #root's --launch-bg paints a near-black band there.
+     Pin it to 100lvh (100vh→100dvh→100lvh progressive-enhancement) so the
+     column reaches the physical screen edge, full-bleed. */
+  body [data-app-shell-root] {
+    height: 100vh;
+    height: 100dvh;
+    height: 100lvh;
   }
 
   body textarea {


### PR DESCRIPTION
## What

On the installed iOS PWA the app currently **clamps** its content (`#root`) to the small/dynamic viewport (`100dvh` ≈ 873px on a home-indicator phone) and paints the remaining ~59px down to the large viewport (`100lvh` ≈ 932px, the true physical bottom) as a decorative **ember floor** on the `body` — dead space the app never reaches.

Shadow's directive:

> **"no we need to reclaim the whole thing"**

This reclaims that whole strip: the app surface is now **full-bleed to the physical bottom edge (932px)**, with the composer/bottom UI padded by `safe-area-inset-bottom` (34px) so interactive elements sit above the home indicator — like a native app.

## How

- **`packages/ui/src/styles/styles.css`** — `#root` goes from a hard `100dvh` clamp to `100lvh` in **both** standalone-PWA geometry paths (the `body.pwa-standalone` class path *and* the `display-mode` media-query path), using the same `100vh → 100dvh → 100lvh` progressive-enhancement stack the fixed body already uses (older engines fall back). The app shell column (`App.tsx`, base `h-[100dvh]`) is reclaimed to `100lvh` via a new `[data-app-shell-root]` hook so it fills the taller `#root` instead of stopping ~59px short and exposing `#root`'s `--launch-bg` as a near-black band.
- **`packages/ui/src/App.tsx`** — tag the shell column with `data-app-shell-root` (no `className` / inline-style change, so the `App.safe-area-fill.test.ts` containing-block invariant still holds).
- **`packages/ui/src/styles/base.css`** — comment now reflects the `100lvh` reclaim.
- The home-indicator safe area stays **padding inside the app**: the floating composer + bottom rows already respect `env(safe-area-inset-bottom)` via `--safe-area-bottom`, so interactive controls sit above the indicator while background content bleeds under it. The body ember-floor `background-color` is **kept as a fallback seam-guard**.

## Keyboard interaction — NO regression (analyzed + test-pinned)

The composer overlay (`ContinuousChatOverlay`) is a `position: fixed` element anchored to the **fixed-body ICB** — already pinned to `100lvh` by the #14319 geometry — **not** to `#root`. Its keyboard lift is `bottom: effectiveKeyboardInset` (a *visual-viewport* delta) and its panel height is bounded by `viewportH` (the visual viewport, via `resolveChatPanelLayout`). Neither reads `#root`'s height, so lifting `#root` from `100dvh` to `100lvh` **cannot** change where the composer rests or how far it lifts above the keyboard — the `lvh − dvh` (~59px) delta never enters the lift math. New contract tests pin exactly this so a future refactor coupling the lift to `#root`/`dvh` trips CI.

## Tests / build

- `standalone-pwa-lockdown.test.ts` — evolved (not deleted) to pin the **new** reclaimed geometry (`100lvh` `#root` + `[data-app-shell-root]` column) instead of the old `100dvh` clamp, plus new keyboard-lift-independence + shell-hook guards. **22/22 green.**
- `chat-panel-layout.test.ts` (17), `App.safe-area-fill.test.ts` (5), `App.cloud-shell.test.tsx` (13) — all green (57 total across the touched suites).
- `packages/app` `bun run build` — green (`✓ built in 1m 5s`, 786 assets).
- biome: no **new** lint category vs `develop`; the only additions are more instances of the identical `100vh→100dvh→100lvh` progressive-enhancement idiom `develop` already ships (and `noDescendingSpecificity` is `off` for `styles.css` via the biome override).

Refs #14411.

— [sol-orch]