### PR TITLE
docs(voice): align E2E_LIVE_COVERAGE.md with current pipeline (#14420)

### DIFF
--- a/packages/app/docs/E2E_LIVE_COVERAGE.md
+++ b/packages/app/docs/E2E_LIVE_COVERAGE.md
@@ -105,37 +105,71 @@ persistence are all real; only token generation is deterministic. Wired into
 ## Real voice pipeline — STT and TTS, fully local, no mocks
 
 The voice stages are validated with real engines + real models, not the
-silent-WAV / shimmed-transcript stubs the keyless ui-smoke lane uses:
+silent-WAV / shimmed-transcript stubs the keyless ui-smoke lane uses. The
+on-device runtime is the **fused `libelizainference`** — whisper.cpp was
+removed and there is **no whisper fallback** (see
+`plugins/plugin-local-inference/src/services/voice/transcriber.ts`, the plugin
+`README.md`, and the decision record in
+`packages/ui/src/voice/STT_SELECTION.md`):
 
-- **Real STT** — `plugins/plugin-local-inference/src/services/voice/whisper-cpp-asr.real.test.ts`
-  transcribes a real speech WAV through the actual whisper.cpp FFI adapter + a
-  real ggml model (`bun test`, GPU). Build `native/build-whisper.mjs`.
-- **Real TTS → STT round-trip (gold standard)** —
-  `.../voice/voice-roundtrip.real.test.ts`: text → real **OmniVoice** TTS
-  (`omnivoice-tts` CLI + OmniVoice base/tokenizer GGUF) → real 24 kHz speech WAV
-  → assert non-silent real signal → ffmpeg resample → real whisper STT → assert
-  the transcript reads back the spoken words. Subprocess-based; self-skips
-  unless the built CLIs + GGUFs + whisper model + ffmpeg resolve.
-  Validated on GPU: *"And so my fellow Americans, ask not what your country can
-  do for you."* synthesizes and transcribes back verbatim.
+- **Real STT (fused eliza-1-asr)** —
+  `bun run --cwd plugins/plugin-local-inference test:asr:real`
+  (`plugins/plugin-local-inference/scripts/asr-real-smoke.ts`; runs under bun
+  directly for `bun:ffi`) loads the fused `libelizainference`, transcribes real
+  recorded speech (`plugins/plugin-local-inference/native/audio-fixtures/freeman.wav`),
+  and asserts a non-empty **multi-sentence** transcript — which also guards the
+  ASR sentence-final early-stop regression. The per-word-timings variant is
+  `plugins/plugin-local-inference/src/services/voice/asr-timed.real.test.ts`
+  (`bun test`; ABI v12 `asrTranscribeTimed` on the same real audio;
+  `*.real.test.ts` is excluded from the package's default vitest lane). Both
+  self-skip, never fake, when the lib/bundle aren't staged.
+- **Real STT WER (publish gate)** —
+  `plugins/plugin-local-inference/native/verify/asr_bench.ts` measures WER +
+  RTF against the fused lib. A WAV dir only counts as publish-gate ASR WER when
+  explicitly marked `--real-recorded` with ≥5 WAV+`.txt` pairs; generated TTS
+  audio stays loopback-only evidence
+  (`plugins/plugin-local-inference/native/verify/asr_bench_real_recorded_workflow.mjs`
+  scaffolds the fail-closed report until a real corpus is supplied).
+- **Real TTS → STT intelligibility (fully local round-trip)** —
+  `bun run --cwd plugins/plugin-local-inference test:kokoro:real`
+  (`plugins/plugin-local-inference/scripts/kokoro-real-smoke.ts`): the real
+  published Kokoro GGUF synthesizes a phrase through the fused lib, the test
+  asserts non-empty 24 kHz PCM with a speech-like amplitude envelope, and —
+  when `ELIZA_ASR_BUNDLE` is staged — round-trips the audio through fused
+  eliza-1-asr and gates intelligibility by WER. `KOKORO_SMOKE_REQUIRE=1` turns
+  every skip into a hard failure so a provisioned lane goes RED instead of
+  green-skipping. **Kokoro is the only on-device TTS engine**, folded into the
+  fused library itself — the old standalone OmniVoice CLI + separate native
+  voice-engine builds no longer exist.
+- **Mixed real round-trip (hybrid topology)** —
+  `bun run --cwd plugins/plugin-local-inference roundtrip:real`
+  (`plugins/plugin-local-inference/scripts/mixed-real-roundtrip.ts`): cloud TTS
+  (ElevenLabs) → **local fused STT** → fast cloud LLM (Cerebras) → cloud TTS,
+  printing per-stage latency + hybrid time-to-first-audio. Needs
+  `ELEVENLABS_API_KEY` + `CEREBRAS_API_KEY`; exits 2 (skip) otherwise.
+- **Rest of the acoustic stack** — `voicestack:real` (speaker recognition,
+  diarization, VAD, local TTS with real GGUFs), `agentvoice:real` (agent
+  self-voice rejection + overlapping speakers), `robustness:real` (WER under
+  noise/reverb/far-field/telephone) — all package scripts in
+  `plugins/plugin-local-inference`, all skip-on-missing-artifact,
+  fail-on-bad-result.
 
-Both on-device voice tests run via `bun run --cwd plugins/plugin-local-inference
-test:voice:real` (or `:test:voice:roundtrip` for just the round-trip). They run
-under **`bun test`, not vitest** — the package vitest config excludes
-`*.real.test.ts` (the round-trip script previously pointed at vitest and so
-silently ran nothing). The whisper STT half needs the model + WAV resolvable:
-either stage `ggml-base.en.bin` at `~/.cache/eliza/whisper/` (the production
-resolver path) or run with `ELIZA_WHISPER_MODEL=…/ggml-base.en.bin
-ELIZA_ASR_TEST_WAV=…/jfk.wav`.
+Staging: build + stage the fused lib with
+`node packages/app-core/scripts/stage-desktop-fused-lib.mjs` (the app-core
+`build:fused-desktop` script), point `ELIZA_INFERENCE_LIBRARY` /
+`ELIZA_INFERENCE_LIB_DIR` at it, and set `ELIZA_ASR_BUNDLE` to a bundle dir
+containing `asr/eliza-1-asr.gguf` + `asr/eliza-1-asr-mmproj.gguf` (default
+probe: `~/.eliza/local-inference/models/eliza-1-2b.bundle`). The Kokoro GGUF +
+voice pack stage from HF `elizaos/eliza-1` (`bundles/2b/tts/kokoro/…`) — the
+exact curl recipe is in `plugins/plugin-local-inference/README.md`.
 
-Build steps: `node plugins/plugin-local-inference/native/build-omnivoice.mjs`
-(+ `cmake --build native/omnivoice.cpp/build --target omnivoice-tts`) and
-`node .../native/build-whisper.mjs`; stage the OmniVoice GGUFs from HF
-`elizaos/eliza-1` (`voice/omnivoice/omnivoice-base-q4_k_m.gguf` +
-`omnivoice-tokenizer-q4_k_m.gguf`) under
-`<stateDir>/local-inference/models/omnivoice/` and a whisper ggml model under
-`~/.cache/eliza-whisper-models/`. The Kokoro GGUF path is `missing-from-local-staging`
-in the HF repo (`voice-models.ts`); OmniVoice is the available local TTS engine.
+CI: `.github/workflows/voice-live-e2e.yml` (nightly + dispatch, self-hosted,
+never on PRs) runs `test:asr:real` + `roundtrip:real` against the
+preprovisioned fused bundle, and the acoustic-matrix job runs
+`test:kokoro:real`, `voicestack:real`, `agentvoice:real`, and
+`robustness:real` in require-real mode (missing model/ABI/credential = hard
+failure, not green skip). `.github/workflows/kokoro-real-smoke.yml` is the
+dedicated Kokoro loader↔GGUF drift gate.
 
 ## Real LLM through the *shipped UI*, fully local + keyless (Ollama recipe)
 

--- a/packages/app/test/e2e-live-coverage-doc-paths.test.ts
+++ b/packages/app/test/e2e-live-coverage-doc-paths.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Guardrail for docs/E2E_LIVE_COVERAGE.md (#14420): every repo path the doc
+ * references must exist, and the removed whisper.cpp voice path must never
+ * creep back in.
+ *
+ * The doc previously kept documenting a deleted STT test
+ * (whisper-cpp-asr.real.test.ts) and a deleted build script
+ * (build-whisper.mjs) long after the runtime moved to the fused
+ * eliza-1-asr path. This boot-free vitest gate (file reads + existsSync,
+ * same style as chat-gesture-coverage.test.ts) makes that class of doc rot
+ * a CI failure instead of a scavenger hunt.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "../../..");
+const DOC_PATH = path.join(REPO_ROOT, "packages/app/docs/E2E_LIVE_COVERAGE.md");
+
+/**
+ * Backtick-quoted repo-rooted paths (packages/, plugins/, .github/). Paths
+ * under build/dist output dirs are runtime artifacts, not tracked sources, so
+ * they are excluded from the existence check.
+ */
+function referencedRepoPaths(doc: string): string[] {
+  const out = new Set<string>();
+  const re = /`((?:packages|plugins|\.github)\/[A-Za-z0-9_./-]+)`/g;
+  for (const match of doc.matchAll(re)) {
+    const p = match[1].replace(/\/$/, "");
+    if (/(^|\/)(build|dist|node_modules)(\/|$)/.test(p)) continue;
+    out.add(p);
+  }
+  return [...out].sort();
+}
+
+describe("E2E_LIVE_COVERAGE.md path integrity", () => {
+  const doc = readFileSync(DOC_PATH, "utf8");
+
+  it("references only paths that exist in the repo", () => {
+    const paths = referencedRepoPaths(doc);
+    // Sanity: a broken extraction regex must not silently empty the roster.
+    expect(paths.length).toBeGreaterThan(10);
+    const missing = paths.filter((p) => !existsSync(path.join(REPO_ROOT, p)));
+    expect(missing, `E2E_LIVE_COVERAGE.md references missing paths:\n${missing.join("\n")}`).toEqual([]);
+  });
+
+  it("does not reference the removed whisper.cpp voice path (#14420)", () => {
+    for (const banned of [
+      "whisper-cpp-asr.real.test.ts",
+      "build-whisper.mjs",
+      "ggml-base.en.bin",
+      "ELIZA_WHISPER_MODEL",
+      "build-omnivoice.mjs",
+    ]) {
+      expect(doc, `stale reference to removed voice path: ${banned}`).not.toContain(banned);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #14420

## What was stale

`packages/app/docs/E2E_LIVE_COVERAGE.md` ("Real voice pipeline" section) still documented the removed whisper.cpp path:

- **Real STT** pointed at `whisper-cpp-asr.real.test.ts` — deleted, no tracked file
- Build steps told engineers to run `native/build-whisper.mjs` — deleted
- Round-trip described `voice-roundtrip.real.test.ts` + the standalone `omnivoice-tts` CLI (`build-omnivoice.mjs`) — both gone
- Staging instructions: `ggml-base.en.bin` / `ELIZA_WHISPER_MODEL` — no longer a runtime concept (fused eliza-1-asr via `libelizainference`; no whisper.cpp fallback per `transcriber.ts`, plugin `README.md`, and `packages/ui/src/voice/STT_SELECTION.md`)
- Referenced package scripts `test:voice:real` / `test:voice:roundtrip` — no longer exist in `plugins/plugin-local-inference/package.json`

## What the doc says now (verified against the tree)

- **Real STT**: `bun run --cwd plugins/plugin-local-inference test:asr:real` (`scripts/asr-real-smoke.ts` on `native/audio-fixtures/freeman.wav`, multi-sentence assertion guarding the early-stop regression) + `src/services/voice/asr-timed.real.test.ts` (ABI v12 per-word timings, `bun test`)
- **WER publish gate**: `native/verify/asr_bench.ts` with the `--real-recorded` provenance rule (+ `asr_bench_real_recorded_workflow.mjs` fail-closed scaffold)
- **TTS→STT round-trip**: `test:kokoro:real` (`scripts/kokoro-real-smoke.ts`) — real Kokoro GGUF through the fused lib, WER-gated when `ELIZA_ASR_BUNDLE` is staged, `KOKORO_SMOKE_REQUIRE=1` fail-closed. Kokoro is the only on-device TTS engine (folded into the fused lib)
- **Hybrid round-trip**: `roundtrip:real` (`scripts/mixed-real-roundtrip.ts`: ElevenLabs → local fused STT → Cerebras → ElevenLabs)
- **Acoustic stack**: `voicestack:real` / `agentvoice:real` / `robustness:real`
- **Staging**: `packages/app-core/scripts/stage-desktop-fused-lib.mjs` (`build:fused-desktop`) + `asr/eliza-1-asr.gguf` bundle (default probe `~/.eliza/local-inference/models/eliza-1-2b.bundle`)
- **CI**: `.github/workflows/voice-live-e2e.yml` (runs exactly `test:asr:real` / `roundtrip:real` / the acoustic matrix in require-real mode) + `kokoro-real-smoke.yml`

Every script name was cross-checked against `plugins/plugin-local-inference/package.json` and every referenced repo path `ls`-verified.

## Guard

Added `packages/app/test/e2e-live-coverage-doc-paths.test.ts` (boot-free vitest, same style as `chat-gesture-coverage.test.ts`, runs in the default `packages/app` unit lane):
1. every backtick-quoted repo path in the doc must exist on disk (with a roster-size sanity floor so a broken regex can't silently pass)
2. the removed whisper identifiers (`whisper-cpp-asr.real.test.ts`, `build-whisper.mjs`, `ggml-base.en.bin`, `ELIZA_WHISPER_MODEL`, `build-omnivoice.mjs`) are banned from returning

```
✓ test/e2e-live-coverage-doc-paths.test.ts (2 tests) 7ms
```

## Grep proof (done-when)

```
$ grep -rn 'whisper-cpp-asr|build-whisper|ggml-base.en|ELIZA_WHISPER_MODEL|build-omnivoice' packages/app/docs/
(empty)
```

The two remaining "whisper" words in the doc are the sentence stating whisper.cpp was removed and has no fallback — the issue's own framing.

— [sol-orch]