### PR TITLE
fix(#14525): iMessage/BlueBubbles render interaction markers as plain text, never bracket soup

### DIFF
--- a/packages/core/src/messaging/interactions/interactions.test.ts
+++ b/packages/core/src/messaging/interactions/interactions.test.ts
@@ -22,6 +22,8 @@ import {
 import {
 	buildInteractionUrlResolver,
 	FORM_FREE_TEXT_INVITE,
+	renderContentInteractionsAsPlainText,
+	renderInteractionsAsPlainText,
 	toNeutralLayout,
 	toPlainTextFallback,
 } from "./layout";
@@ -506,13 +508,81 @@ describe("plain text fallback", () => {
 	});
 
 	it("does not inline sensitive requests on text-only transports", () => {
-		const block: SecretInteraction = {
+		const withUrl: SecretInteraction = {
 			kind: "secret",
 			id: "s1",
+			secretKind: "oauth",
+			reason: "Connect GitHub to continue",
+			url: "https://oauth.test/consent",
+		};
+		expect(toPlainTextFallback(withUrl)).toBe(
+			"Connect GitHub to continue\nhttps://oauth.test/consent",
+		);
+
+		const withoutUrl: SecretInteraction = {
+			kind: "secret",
+			id: "s2",
 			secretKind: "secret",
+			reason: "Enter your API key",
 			fields: [{ name: "apiKey", type: "secret" }],
 		};
-		expect(toPlainTextFallback(block)).toBeUndefined();
+		expect(toPlainTextFallback(withoutUrl)).toBe(
+			"Enter your API key\nA secure link for this is not available here yet.",
+		);
+	});
+});
+
+describe("renderInteractionsAsPlainText", () => {
+	it("passes plain text through unchanged", () => {
+		expect(renderInteractionsAsPlainText("just a normal reply")).toEqual({
+			text: "just a normal reply",
+			hadBlocks: false,
+		});
+		expect(renderInteractionsAsPlainText(undefined)).toEqual({
+			text: "",
+			hadBlocks: false,
+		});
+	});
+
+	it("strips a long form before downstream chunking can split marker JSON", () => {
+		const bigForm = JSON.stringify({
+			title: "Trip",
+			description: "Tell me what changed.",
+			fields: [{ name: "a", type: "text", label: "x".repeat(6000) }],
+		});
+		const { text, hadBlocks } = renderInteractionsAsPlainText(
+			`Let's set this up.\n[FORM]\n${bigForm}\n[/FORM]`,
+		);
+
+		expect(hadBlocks).toBe(true);
+		expect(text).not.toContain("[FORM]");
+		expect(text).not.toContain('"fields"');
+		expect(text).not.toContain("xxxx");
+		expect(text).toContain("Trip");
+		expect(text).toContain("Tell me what changed.");
+		expect(text).toContain(FORM_FREE_TEXT_INVITE);
+	});
+});
+
+describe("renderContentInteractionsAsPlainText", () => {
+	it("renders typed secret interactions that have no bracket-marker text form", () => {
+		const { text, hadBlocks } = renderContentInteractionsAsPlainText({
+			text: "Connect this account.",
+			interactions: [
+				{
+					kind: "secret",
+					id: "s1",
+					secretKind: "oauth",
+					reason: "Connect GitHub to continue",
+					url: "https://oauth.test/consent",
+				},
+			],
+		});
+
+		expect(hadBlocks).toBe(true);
+		expect(text).toBe(
+			"Connect this account.\n\nConnect GitHub to continue\nhttps://oauth.test/consent",
+		);
 	});
 });
 

--- a/packages/core/src/messaging/interactions/layout.ts
+++ b/packages/core/src/messaging/interactions/layout.ts
@@ -14,7 +14,9 @@ import type {
 	InteractionBlock,
 	InteractionOption,
 } from "../../types/interactions";
+import type { Content } from "../../types/primitives";
 import { encodeReplyCallback } from "./callback";
+import { parseInteractionBlocks } from "./parse";
 
 export interface NeutralButton {
 	label: string;
@@ -251,13 +253,75 @@ export function toPlainTextFallback(
 				.filter((part): part is string => Boolean(part));
 			return [...prose, FORM_FREE_TEXT_INVITE].join("\n\n");
 		}
-		case "secret":
-			return undefined;
+		case "secret": {
+			const url = opts.resolveUrl?.(block) ?? block.url;
+			const reason = firstNonBlankText(block.reason);
+			return url
+				? [reason, url].filter(Boolean).join("\n")
+				: [reason, "A secure link for this is not available here yet."]
+						.filter(Boolean)
+						.join("\n");
+		}
 		default: {
 			const _exhaustive: never = block;
 			return _exhaustive;
 		}
 	}
+}
+
+/**
+ * Render interaction-bearing text for button-less transports before their own
+ * chunking layer sees the message. This strips every marker body and appends
+ * the text fallback for each parsed block, so long form JSON cannot be split
+ * into user-visible bracket fragments.
+ */
+export function renderInteractionsAsPlainText(
+	text: string | undefined | null,
+	opts: PlainTextFallbackOptions = {},
+): { text: string; hadBlocks: boolean } {
+	const source = text ?? "";
+	const { blocks, cleanedText } = parseInteractionBlocks(source);
+	if (blocks.length === 0) {
+		return { text: source, hadBlocks: false };
+	}
+	const fallbacks = blocks
+		.map((block) => toPlainTextFallback(block, opts))
+		.filter((part): part is string => Boolean(part?.trim()));
+	return {
+		text: [cleanedText, ...fallbacks]
+			.filter((part) => part.trim().length > 0)
+			.join("\n\n"),
+		hadBlocks: true,
+	};
+}
+
+/**
+ * Render a full `Content` object for a text-only transport. When the runtime has
+ * already normalized typed `interactions`, those blocks are authoritative; this
+ * preserves out-of-band secret/OAuth requests that do not have a bracket-marker
+ * text representation.
+ */
+export function renderContentInteractionsAsPlainText(
+	content: Pick<Content, "text" | "interactions"> | undefined | null,
+	opts: PlainTextFallbackOptions = {},
+): { text: string; hadBlocks: boolean } {
+	const source = typeof content?.text === "string" ? content.text : "";
+	const interactions = Array.isArray(content?.interactions)
+		? content.interactions
+		: [];
+	if (interactions.length === 0) {
+		return renderInteractionsAsPlainText(source, opts);
+	}
+	const { cleanedText } = parseInteractionBlocks(source);
+	const fallbacks = interactions
+		.map((block) => toPlainTextFallback(block, opts))
+		.filter((part): part is string => Boolean(part?.trim()));
+	return {
+		text: [cleanedText, ...fallbacks]
+			.filter((part) => part.trim().length > 0)
+			.join("\n\n"),
+		hadBlocks: true,
+	};
 }
 
 /**

--- a/plugins/plugin-bluebubbles/src/interactions.test.ts
+++ b/plugins/plugin-bluebubbles/src/interactions.test.ts
@@ -42,4 +42,23 @@ describe("renderBlueBubblesInteractionText", () => {
 			"Open task\nhttps://app.test/orchestrator?taskId=def67890",
 		);
 	});
+
+	it("renders direct secret interactions as secure-link text", () => {
+		const rendered = renderBlueBubblesInteractionText({
+			text: "Connect this account.",
+			interactions: [
+				{
+					kind: "secret",
+					id: "s1",
+					secretKind: "oauth",
+					reason: "Connect GitHub to continue",
+					url: "https://oauth.test/consent",
+				},
+			],
+		});
+
+		expect(rendered).toBe(
+			"Connect this account.\n\nConnect GitHub to continue\nhttps://oauth.test/consent",
+		);
+	});
 });

--- a/plugins/plugin-bluebubbles/src/interactions.ts
+++ b/plugins/plugin-bluebubbles/src/interactions.ts
@@ -9,26 +9,15 @@
 import {
 	buildInteractionUrlResolver,
 	type Content,
-	parseInteractionBlocks,
-	toPlainTextFallback,
+	renderContentInteractionsAsPlainText,
 } from "@elizaos/core";
 
 export function renderBlueBubblesInteractionText(
 	content: Content,
 	appBaseUrl?: string,
 ): string {
-	const text = typeof content.text === "string" ? content.text : "";
-	const { blocks, cleanedText } = parseInteractionBlocks(text);
-	if (blocks.length === 0) {
-		return text;
-	}
-
-	const resolver = buildInteractionUrlResolver(appBaseUrl);
-	const fallbackLines = blocks
-		.map((block) => toPlainTextFallback(block, resolver))
-		.filter((line): line is string => Boolean(line?.trim()));
-
-	return [cleanedText, ...fallbackLines]
-		.filter((part) => part.trim().length > 0)
-		.join("\n\n");
+	return renderContentInteractionsAsPlainText(
+		content,
+		buildInteractionUrlResolver(appBaseUrl),
+	).text;
 }

--- a/plugins/plugin-imessage/src/interactions.test.ts
+++ b/plugins/plugin-imessage/src/interactions.test.ts
@@ -56,4 +56,23 @@ describe("renderIMessageInteractionText", () => {
 
     expect(rendered).toBe("Review the device lane\nhttps://app.test/orchestrator?taskId=abc12345");
   });
+
+  it("renders direct secret interactions as secure-link text", () => {
+    const rendered = renderIMessageInteractionText({
+      text: "Connect this account.",
+      interactions: [
+        {
+          kind: "secret",
+          id: "s1",
+          secretKind: "oauth",
+          reason: "Connect GitHub to continue",
+          url: "https://oauth.test/consent",
+        },
+      ],
+    });
+
+    expect(rendered).toBe(
+      "Connect this account.\n\nConnect GitHub to continue\nhttps://oauth.test/consent"
+    );
+  });
 });

--- a/plugins/plugin-imessage/src/interactions.ts
+++ b/plugins/plugin-imessage/src/interactions.ts
@@ -11,21 +11,10 @@
 import {
   buildInteractionUrlResolver,
   type Content,
-  parseInteractionBlocks,
-  toPlainTextFallback,
+  renderContentInteractionsAsPlainText,
 } from "@elizaos/core";
 
 export function renderIMessageInteractionText(content: Content, appBaseUrl?: string): string {
-  const text = typeof content.text === "string" ? content.text : "";
-  const { blocks, cleanedText } = parseInteractionBlocks(text);
-  if (blocks.length === 0) {
-    return text;
-  }
-
-  const resolver = buildInteractionUrlResolver(appBaseUrl);
-  const fallbackLines = blocks
-    .map((block) => toPlainTextFallback(block, resolver))
-    .filter((line): line is string => Boolean(line?.trim()));
-
-  return [cleanedText, ...fallbackLines].filter((part) => part.trim().length > 0).join("\n\n");
+  return renderContentInteractionsAsPlainText(content, buildInteractionUrlResolver(appBaseUrl))
+    .text;
 }


### PR DESCRIPTION
## What

Refs #14525. This PR fixes the raw interaction-marker leak for iMessage and BlueBubbles text-only sends. The remaining sensitive-request adapter acceptance is handled in #14570, so this PR intentionally does not auto-close #14525 by itself.

Both iMessage connectors bypassed the interaction engine, so `[CHOICE]` / `[FORM]` / `[TASK]` / `[FOLLOWUPS]` / `[SECRET]` blocks could reach a real iMessage contact as raw marker text, and the iMessage chunker could split a long `[FORM]` JSON body mid-block across bubbles.

## Fix

- Core (`layout.ts`) adds shared text-only projection helpers:
  - `toPlainTextFallback(block, opts)` projects choices, forms, tasks, followups, and secrets into readable prose for transports without buttons/forms.
  - `renderInteractionsAsPlainText(text, opts)` strips marker bodies before connector chunking and appends fallbacks.
  - `renderContentInteractionsAsPlainText(content, opts)` also preserves typed `content.interactions`, including secret/OAuth requests that may not have bracket-marker text.
- `plugin-imessage` and `plugin-bluebubbles` render outbound reply callbacks and send handlers through those helpers before sending.
- A secret value is never inlined; text-only output shows the reason plus a secure URL when one exists, or an explicit “secure link is not available here yet” message.

## Validation

- `bunx vitest run packages/core/src/messaging/interactions/interactions.test.ts` - pass, 42 tests.
- `bun run --cwd packages/shared build:i18n` - generated local keyword data needed by the fresh worktree.
- `bun run --cwd packages/core build:node` - JS bundles built; declaration phase failed locally only because this isolated worktree lacks local `@types/node` / `bun-types` resolution.
- Added a worktree-local ignored `node_modules/@elizaos/core` symlink so plugin tests resolve this branch's core dist instead of the main checkout's stale dist.
- `bun run --cwd plugins/plugin-imessage test src/interactions.test.ts` - pass, 4 tests.
- `bun run --cwd plugins/plugin-bluebubbles test src/interactions.test.ts` - pass, 4 tests.
- `bunx @biomejs/biome check packages/core/src/messaging/interactions/layout.ts packages/core/src/messaging/interactions/interactions.test.ts plugins/plugin-imessage/src/interactions.ts plugins/plugin-imessage/src/interactions.test.ts plugins/plugin-bluebubbles/src/interactions.ts plugins/plugin-bluebubbles/src/interactions.test.ts` - pass.

## Evidence Gate
<!-- evidence-row:before-screenshots -->
- [ ] N/A - no macOS Messages/BlueBubbles account is reachable from this host to capture the prior bracket-soup state.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - deterministic tests prove the exact text handed to the send path; real platform screenshots remain required before closing #14525.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no real iMessage/BlueBubbles service is available in this environment for a platform walkthrough.
<!-- evidence-row:backend-logs -->
- [ ] N/A - this is pure outbound text projection before connector send; focused tests assert the sendable text and chunk-safety behavior.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser frontend path is touched.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent prompt/model/provider/action selection behavior changes; this is connector rendering of already-produced content.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - domain artifact is the outbound text body; tests assert choices, long forms, task links, followups, and secrets render without raw markers.

## Notes

The local plugin tests initially failed because they resolved `@elizaos/core` from the main checkout's stale `packages/core/dist`, not from this PR worktree. After building this branch's core JS and adding an ignored worktree-local package symlink, the connector tests passed against the new export.
