### PR TITLE
fix(connectors): render text fallbacks for imessage widgets

### DIFF
--- a/packages/core/src/messaging/interactions/README.md
+++ b/packages/core/src/messaging/interactions/README.md
@@ -58,6 +58,8 @@ a malformed block is left as plain text, never a broken control.
   (rows of buttons / a select) — the shared projection each connector maps to its
   native primitive. A button carries exactly one of `callbackData` (round-trip) or
   `url` (link-out).
+- `toPlainTextFallback(block, { resolveUrl })` → concise prose for text-only
+  transports such as SMS/iMessage, where there is no native control surface.
 - `encodeReplyCallback(value)` / `decodeCallback(data)` — 64-byte-safe codec
   (Telegram's `callback_data` limit). Returns null when the answer is too big →
   caller links out or accepts a free-text reply.
@@ -71,13 +73,13 @@ FollowupsInteraction | TaskInteraction | SecretInteraction`) in
 
 ## Per-surface rendering matrix
 
-| Block | Dashboard | Telegram | Discord |
-|---|---|---|---|
-| choice | `ChoiceWidget` ✅ | inline-keyboard callback buttons ✅ | button action row ✅ |
-| followups | `FollowupsWidget` ✅ | callback buttons ✅ | button action row ✅ |
-| form | `FormRequest` ✅ | free-text fallback (by design) ✅ | free-text fallback (by design) ✅ |
-| task | `TaskWidget` (live poll) ✅ | link button + title ✅ (live status ⏳) | link button + title ✅ |
-| secret/oauth | `SensitiveRequestBlock` ✅ | DM link via `sensitive-request-adapter` ✅ | DM link via `sensitive-request-adapter` ✅ |
+| Block | Dashboard | Telegram | Discord | Text-only (SMS/iMessage) |
+|---|---|---|---|---|
+| choice | `ChoiceWidget` ✅ | inline-keyboard callback buttons ✅ | button action row ✅ | numbered reply list ✅ |
+| followups | `FollowupsWidget` ✅ | callback buttons ✅ | button action row ✅ | suggestions line ✅ |
+| form | `FormRequest` ✅ | free-text fallback (by design) ✅ | free-text fallback (by design) ✅ | title/description + free-text invite ✅ |
+| task | `TaskWidget` (live poll) ✅ | link button + title ✅ (live status ⏳) | link button + title ✅ | title + `/orchestrator?taskId=…` link ✅ |
+| secret/oauth | `SensitiveRequestBlock` ✅ | DM link via `sensitive-request-adapter` ✅ | DM link via `sensitive-request-adapter` ✅ | not inlined; requires secure adapter/failure surface |
 
 ✅ implemented · ⏳ remaining (seams below). Forms never link out on
 connectors **by design** (#14321): no hosted `/forms/:id` page exists (form

--- a/packages/core/src/messaging/interactions/interactions.test.ts
+++ b/packages/core/src/messaging/interactions/interactions.test.ts
@@ -23,6 +23,7 @@ import {
 	buildInteractionUrlResolver,
 	FORM_FREE_TEXT_INVITE,
 	toNeutralLayout,
+	toPlainTextFallback,
 } from "./layout";
 import {
 	normalizeContentInteractions,
@@ -419,6 +420,76 @@ describe("layout", () => {
 		const button = toNeutralLayout(block).rows[0]?.buttons?.[0];
 		expect(button?.url).toBeUndefined();
 		expect(button?.callbackData).toBeTruthy();
+	});
+});
+
+describe("plain text fallback", () => {
+	it("renders choice options as a numbered reply list", () => {
+		const block: ChoiceInteraction = {
+			kind: "choice",
+			id: "i",
+			scope: "s",
+			prompt: "Pick a lane",
+			allowCustom: true,
+			options: [
+				{ value: "ship", label: "Ship it" },
+				{ value: "hold", label: "Hold" },
+			],
+		};
+		expect(toPlainTextFallback(block)).toBe(
+			"Pick a lane\n1. Ship it\n2. Hold\nReply with a number or your own answer.",
+		);
+	});
+
+	it("renders forms as title, description, and the free-text invite", () => {
+		const block: FormInteraction = {
+			kind: "form",
+			id: "f",
+			title: "Schedule reminder",
+			description: "Tell me when to check in.",
+			fields: [{ name: "when", type: "datetime" }],
+		};
+		expect(toPlainTextFallback(block)).toBe(
+			`Schedule reminder\n\nTell me when to check in.\n\n${FORM_FREE_TEXT_INVITE}`,
+		);
+	});
+
+	it("renders task deep links and followup suggestions without markers", () => {
+		const task: TaskInteraction = {
+			kind: "task",
+			threadId: "task-1",
+			title: "Review launch checklist",
+		};
+		expect(
+			toPlainTextFallback(task, {
+				resolveUrl: () => "https://app.test/task-1",
+			}),
+		).toBe("Review launch checklist\nhttps://app.test/task-1");
+
+		const followups: FollowupsInteraction = {
+			kind: "followups",
+			id: "f1",
+			options: [
+				{ kind: "navigate", payload: "/tasks", label: "Tasks" },
+				{ kind: "reply", payload: "yes", label: "Yes" },
+				{ kind: "prompt", payload: "explain", label: "Explain" },
+			],
+		};
+		expect(
+			toPlainTextFallback(followups, {
+				resolveNavigateUrl: (payload) => `https://app.test${payload}`,
+			}),
+		).toBe("Suggestions: Tasks (https://app.test/tasks) / Yes / Explain");
+	});
+
+	it("does not inline sensitive requests on text-only transports", () => {
+		const block: SecretInteraction = {
+			kind: "secret",
+			id: "s1",
+			secretKind: "secret",
+			fields: [{ name: "apiKey", type: "secret" }],
+		};
+		expect(toPlainTextFallback(block)).toBeUndefined();
 	});
 });
 

--- a/packages/core/src/messaging/interactions/layout.ts
+++ b/packages/core/src/messaging/interactions/layout.ts
@@ -48,6 +48,13 @@ export interface NeutralLayout {
 	needsFallback?: boolean;
 }
 
+export interface PlainTextFallbackOptions {
+	/** Resolve an external entry URL for task or navigate blocks. */
+	resolveUrl?: (block: InteractionBlock) => string | undefined;
+	/** Resolve an external URL for a `navigate` followup chip. */
+	resolveNavigateUrl?: (payload: string) => string | undefined;
+}
+
 export interface LayoutOptions {
 	/**
 	 * Resolve an external entry URL for blocks that link out: secret/OAuth entry
@@ -195,6 +202,57 @@ export function toNeutralLayout(
 				needsFallback: !url,
 			};
 		}
+		default: {
+			const _exhaustive: never = block;
+			return _exhaustive;
+		}
+	}
+}
+
+/** Project a block onto text-only transports such as SMS/iMessage. */
+export function toPlainTextFallback(
+	block: InteractionBlock,
+	opts: PlainTextFallbackOptions = {},
+): string | undefined {
+	switch (block.kind) {
+		case "choice": {
+			const prompt = firstNonBlankText(block.prompt);
+			const options = block.options.map(
+				(option, index) => `${index + 1}. ${option.label}`,
+			);
+			const invite = block.allowCustom
+				? "Reply with a number or your own answer."
+				: "Reply with a number.";
+			return [prompt, options.join("\n"), invite]
+				.filter((part): part is string => Boolean(part?.trim()))
+				.join("\n");
+		}
+		case "followups": {
+			const suggestions = block.options
+				.map((option) => {
+					const label = option.label.trim();
+					if (!label) return "";
+					if (option.kind !== "navigate") return label;
+					const url = opts.resolveNavigateUrl?.(option.payload);
+					return url ? `${label} (${url})` : label;
+				})
+				.filter((label) => label.length > 0);
+			return suggestions.length > 0
+				? `Suggestions: ${suggestions.join(" / ")}`
+				: undefined;
+		}
+		case "task": {
+			const url = opts.resolveUrl?.(block);
+			return [block.title, url].filter(Boolean).join("\n");
+		}
+		case "form": {
+			const prose = [block.title, block.description]
+				.map((part) => part?.trim())
+				.filter((part): part is string => Boolean(part));
+			return [...prose, FORM_FREE_TEXT_INVITE].join("\n\n");
+		}
+		case "secret":
+			return undefined;
 		default: {
 			const _exhaustive: never = block;
 			return _exhaustive;

--- a/plugins/plugin-bluebubbles/__tests__/message-connector.test.ts
+++ b/plugins/plugin-bluebubbles/__tests__/message-connector.test.ts
@@ -201,6 +201,40 @@ describe("BlueBubbles message connector registration", () => {
 		);
 	});
 
+	it("strips interaction markers before sending connector replies", async () => {
+		const registrations: MessageConnectorRegistration[] = [];
+		const runtime = {
+			...makeRuntime(registrations),
+			getSetting: vi.fn((key: string) =>
+				key === "ELIZA_APP_URL" ? "https://app.test" : undefined,
+			),
+		} as unknown as IAgentRuntime;
+		const service = {
+			getIsRunning: vi.fn(() => true),
+			listChats: vi.fn(async () => []),
+			sendMessage: vi.fn(async () => ({ guid: "bb-3", dateCreated: 789 })),
+		} as unknown as BlueBubblesService;
+
+		BlueBubblesService.registerSendHandlers(runtime, service);
+
+		const connector = registrations.find(
+			(registration) => registration.source === "bluebubbles",
+		);
+		await connector?.sendHandler(
+			runtime,
+			{ source: "bluebubbles", channelId: "+14155552671" },
+			{
+				text: "Pick:\n[CHOICE:next id=c1]\ny=Yes\nn=No\n[/CHOICE]",
+			} as ConnectorContent,
+		);
+
+		expect(service.sendMessage).toHaveBeenCalledWith(
+			"+14155552671",
+			"Pick:\n\n1. Yes\n2. No\nReply with a number.",
+			undefined,
+		);
+	});
+
 	it("rejects reaction mutations missing chat, message, or reaction values", async () => {
 		const registrations: MessageConnectorRegistration[] = [];
 		const runtime = makeRuntime(registrations);

--- a/plugins/plugin-bluebubbles/src/interactions.test.ts
+++ b/plugins/plugin-bluebubbles/src/interactions.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Deterministic coverage for BlueBubbles' text-only interaction rendering.
+ * These tests cover the pure transport projection without requiring a macOS
+ * BlueBubbles server.
+ */
+
+import { describe, expect, it } from "vitest";
+import { renderBlueBubblesInteractionText } from "./interactions";
+
+describe("renderBlueBubblesInteractionText", () => {
+	it("strips markers and appends plain choice options", () => {
+		const rendered = renderBlueBubblesInteractionText({
+			text: "Pick:\n[CHOICE:next id=c1]\na=Alpha\nb=Beta\n[/CHOICE]",
+		});
+
+		expect(rendered).toBe("Pick:\n\n1. Alpha\n2. Beta\nReply with a number.");
+		expect(rendered).not.toContain("[CHOICE");
+	});
+
+	it("keeps form fallbacks as prose only", () => {
+		const rendered = renderBlueBubblesInteractionText({
+			text: `[FORM]\n${JSON.stringify({
+				title: "Reminder details",
+				description: "Send the schedule.",
+				fields: [{ name: "when", type: "datetime" }],
+			})}\n[/FORM]`,
+		});
+
+		expect(rendered).toBe(
+			"Reminder details\n\nSend the schedule.\n\nReply with your answer.",
+		);
+		expect(rendered).not.toContain("[FORM]");
+	});
+
+	it("renders task deep links against the app base url", () => {
+		const rendered = renderBlueBubblesInteractionText(
+			{ text: "[TASK:def67890]Open task[/TASK]" },
+			"https://app.test/",
+		);
+
+		expect(rendered).toBe(
+			"Open task\nhttps://app.test/orchestrator?taskId=def67890",
+		);
+	});
+});

--- a/plugins/plugin-bluebubbles/src/interactions.ts
+++ b/plugins/plugin-bluebubbles/src/interactions.ts
@@ -1,0 +1,34 @@
+/**
+ * Text-only projection for interaction blocks sent through BlueBubbles.
+ *
+ * BlueBubbles ultimately delivers SMS/iMessage text, so it cannot carry the
+ * dashboard's bracket-marker widgets directly. This helper strips markers and
+ * appends readable fallbacks before the REST send path sees the message body.
+ */
+
+import {
+	buildInteractionUrlResolver,
+	type Content,
+	parseInteractionBlocks,
+	toPlainTextFallback,
+} from "@elizaos/core";
+
+export function renderBlueBubblesInteractionText(
+	content: Content,
+	appBaseUrl?: string,
+): string {
+	const text = typeof content.text === "string" ? content.text : "";
+	const { blocks, cleanedText } = parseInteractionBlocks(text);
+	if (blocks.length === 0) {
+		return text;
+	}
+
+	const resolver = buildInteractionUrlResolver(appBaseUrl);
+	const fallbackLines = blocks
+		.map((block) => toPlainTextFallback(block, resolver))
+		.filter((line): line is string => Boolean(line?.trim()));
+
+	return [cleanedText, ...fallbackLines]
+		.filter((part) => part.trim().length > 0)
+		.join("\n\n");
+}

--- a/plugins/plugin-bluebubbles/src/service.ts
+++ b/plugins/plugin-bluebubbles/src/service.ts
@@ -32,6 +32,7 @@ import {
 import { BlueBubblesClient } from "./client";
 import { BLUEBUBBLES_SERVICE_NAME, DEFAULT_WEBHOOK_PATH } from "./constants";
 import { isHandleAllowed, normalizeHandle } from "./environment";
+import { renderBlueBubblesInteractionText } from "./interactions";
 import type {
 	BlueBubblesChat,
 	BlueBubblesChatState,
@@ -49,6 +50,15 @@ const DEFAULT_AUTOSTART_ARGS = ["-a", "BlueBubbles"];
 
 function delay(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function resolveInteractionAppBaseUrl(
+	runtime: IAgentRuntime,
+): string | undefined {
+	const rawAppUrl =
+		runtime.getSetting?.("ELIZA_APP_URL") ||
+		runtime.getSetting?.("ELIZA_CLOUD_URL");
+	return typeof rawAppUrl === "string" ? rawAppUrl : undefined;
 }
 
 type BlueBubblesAutoStartConfig = {
@@ -714,8 +724,10 @@ export class BlueBubblesService extends Service {
 					target: ConnectorTargetInfo,
 					content: ConnectorContent,
 				) => {
-					const text =
-						typeof content.text === "string" ? content.text.trim() : "";
+					const text = renderBlueBubblesInteractionText(
+						content,
+						resolveInteractionAppBaseUrl(runtime),
+					).trim();
 					if (!text) {
 						return;
 					}
@@ -1405,8 +1417,10 @@ export class BlueBubblesService extends Service {
 		const callback: HandlerCallback = async (
 			response: Content,
 		): Promise<Memory[]> => {
-			const responseText =
-				typeof response.text === "string" ? response.text.trim() : "";
+			const responseText = renderBlueBubblesInteractionText(
+				response,
+				resolveInteractionAppBaseUrl(this.runtime),
+			).trim();
 			if (!responseText) {
 				return [];
 			}

--- a/plugins/plugin-imessage/__tests__/core-test-mock.ts
+++ b/plugins/plugin-imessage/__tests__/core-test-mock.ts
@@ -1,9 +1,8 @@
 /**
- * Vitest setup file that mocks `@elizaos/core` so the iMessage suites run
- * without the real runtime: a stub `Service` base class, a no-op `logger`, and
- * deterministic `stringToUuid` / `createUniqueUuid` implementations (SHA1 of the
- * value) so id-mapping assertions stay stable. Referenced from
- * `vitest.config.ts` `setupFiles`.
+ * Vitest setup file that keeps iMessage suites off the real runtime while still
+ * exposing pure core helpers such as the interaction parser. Runtime-heavy
+ * pieces are replaced with a stub `Service`, no-op logger, and deterministic
+ * UUID mapping so connector id assertions stay stable.
  */
 import { createHash } from "node:crypto";
 import { vi } from "vitest";
@@ -25,7 +24,8 @@ function stringToUuid(value: string | number): string {
   )}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
-vi.mock("@elizaos/core", () => {
+vi.mock("@elizaos/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@elizaos/core")>();
   const logger = {
     debug: vi.fn(),
     error: vi.fn(),
@@ -44,6 +44,7 @@ vi.mock("@elizaos/core", () => {
   }
 
   return {
+    ...actual,
     ChannelType: {
       DM: "DM",
       GROUP: "GROUP",

--- a/plugins/plugin-imessage/src/interactions.test.ts
+++ b/plugins/plugin-imessage/src/interactions.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Deterministic coverage for iMessage's text-only interaction rendering. The
+ * tests assert markers are stripped before iMessage chunking, so a large form
+ * JSON body cannot be split into user-visible bracket fragments.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core", async () => await vi.importActual("@elizaos/core"));
+
+import { renderIMessageInteractionText } from "./interactions";
+import { splitMessageForIMessage } from "./types";
+
+describe("renderIMessageInteractionText", () => {
+  it("strips choice markers and appends a numbered fallback", () => {
+    const rendered = renderIMessageInteractionText({
+      text: "Choose:\n[CHOICE:approval id=c1 allow_custom]\nyes=Approve\nno=Decline\n[/CHOICE]",
+    });
+
+    expect(rendered).toBe(
+      "Choose:\n\n1. Approve\n2. Decline\nReply with a number or your own answer."
+    );
+    expect(rendered).not.toContain("[CHOICE");
+  });
+
+  it("strips form JSON before chunking", () => {
+    const fields = Array.from({ length: 20 }, (_, index) => ({
+      name: `field_${index}`,
+      type: "text",
+      label: "x".repeat(250),
+    }));
+    const raw = `Please fill this out.\n[FORM]\n${JSON.stringify({
+      title: "Long intake",
+      description: "Tell me what changed.",
+      fields,
+    })}\n[/FORM]`;
+
+    const rendered = renderIMessageInteractionText({ text: raw });
+    const chunks = splitMessageForIMessage(rendered, 160);
+
+    expect(rendered).toContain("Long intake");
+    expect(rendered).toContain("Reply with your answer.");
+    expect(rendered).not.toContain("[FORM]");
+    expect(rendered).not.toContain("[/FORM]");
+    expect(chunks.every((chunk) => !chunk.includes("[FORM]"))).toBe(true);
+    expect(chunks.every((chunk) => !chunk.includes("[/FORM]"))).toBe(true);
+  });
+
+  it("adds task links when an app base url is configured", () => {
+    const rendered = renderIMessageInteractionText(
+      {
+        text: "[TASK:abc12345]Review the device lane[/TASK]",
+      },
+      "https://app.test/"
+    );
+
+    expect(rendered).toBe("Review the device lane\nhttps://app.test/orchestrator?taskId=abc12345");
+  });
+});

--- a/plugins/plugin-imessage/src/interactions.ts
+++ b/plugins/plugin-imessage/src/interactions.ts
@@ -1,0 +1,31 @@
+/**
+ * Text-only projection for interaction blocks sent through iMessage.
+ *
+ * Messages.app has no structured button or form primitive for agent replies, so
+ * outbound content strips bracket markers and appends concise prose fallbacks
+ * before the normal iMessage chunking step. Keeping this as a pure helper lets
+ * the send handler and inbound reply callback share the same transport-safe
+ * rendering.
+ */
+
+import {
+  buildInteractionUrlResolver,
+  type Content,
+  parseInteractionBlocks,
+  toPlainTextFallback,
+} from "@elizaos/core";
+
+export function renderIMessageInteractionText(content: Content, appBaseUrl?: string): string {
+  const text = typeof content.text === "string" ? content.text : "";
+  const { blocks, cleanedText } = parseInteractionBlocks(text);
+  if (blocks.length === 0) {
+    return text;
+  }
+
+  const resolver = buildInteractionUrlResolver(appBaseUrl);
+  const fallbackLines = blocks
+    .map((block) => toPlainTextFallback(block, resolver))
+    .filter((line): line is string => Boolean(line?.trim()));
+
+  return [cleanedText, ...fallbackLines].filter((part) => part.trim().length > 0).join("\n\n");
+}

--- a/plugins/plugin-imessage/src/message-connector.test.ts
+++ b/plugins/plugin-imessage/src/message-connector.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Covers the iMessage message-connector send registration without touching
+ * Messages.app. A stub service captures the outbound body so marker stripping is
+ * tested on the same path production connector sends use.
+ */
+
+import type { Content, IAgentRuntime, MessageConnectorRegistration, UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core", async () => await vi.importActual("@elizaos/core"));
+
+import { IMessageService } from "./service";
+import type { IMessageServiceStatus } from "./types";
+
+const connectedStatus: IMessageServiceStatus = {
+  available: true,
+  connected: true,
+  chatDbAvailable: true,
+  sendOnly: false,
+  chatDbPath: "/tmp/chat.db",
+  reason: null,
+  permissionAction: null,
+};
+
+function makeRuntime(registrations: MessageConnectorRegistration[]): IAgentRuntime {
+  return {
+    agentId: "agent-1" as UUID,
+    getSetting: vi.fn((key: string) => (key === "ELIZA_APP_URL" ? "https://app.test" : undefined)),
+    getRoom: vi.fn(async () => null),
+    registerMessageConnector: vi.fn((registration: MessageConnectorRegistration) => {
+      registrations.push(registration);
+    }),
+    registerSendHandler: vi.fn(),
+  } as unknown as IAgentRuntime;
+}
+
+describe("iMessage message connector registration", () => {
+  it("strips interaction markers before sending connector replies", async () => {
+    const registrations: MessageConnectorRegistration[] = [];
+    const sent: Array<{ to: string; text: string }> = [];
+    const runtime = makeRuntime(registrations);
+    const service = {
+      getStatus: vi.fn(() => connectedStatus),
+      getContacts: vi.fn(() => new Map()),
+      sendMessage: vi.fn(async (to: string, text: string) => {
+        sent.push({ to, text });
+        return { success: true, messageId: "im-1", chatId: "chat-1" };
+      }),
+    } as unknown as IMessageService;
+
+    IMessageService.registerSendHandlers(runtime, service);
+    const connector = registrations.find((registration) => registration.source === "imessage");
+
+    await connector?.sendHandler?.(runtime, { source: "imessage", channelId: "+14155552671" }, {
+      text: "Pick:\n[CHOICE:next id=c1]\ny=Yes\nn=No\n[/CHOICE]",
+    } as Content);
+
+    expect(sent).toEqual([
+      {
+        to: "+14155552671",
+        text: "Pick:\n\n1. Yes\n2. No\nReply with a number.",
+      },
+    ]);
+  });
+});

--- a/plugins/plugin-imessage/src/service.ts
+++ b/plugins/plugin-imessage/src/service.ts
@@ -53,6 +53,7 @@ import {
   normalizeContactHandle,
   updateContact,
 } from "./contacts-reader.js";
+import { renderIMessageInteractionText } from "./interactions.js";
 import {
   DEFAULT_POLL_INTERVAL_MS,
   formatPhoneNumber,
@@ -78,6 +79,12 @@ import {
 } from "./types.js";
 
 const execFileAsync = promisify(execFile);
+
+function resolveInteractionAppBaseUrl(runtime: IAgentRuntime): string | undefined {
+  const rawAppUrl =
+    runtime.getSetting?.("ELIZA_APP_URL") || runtime.getSetting?.("ELIZA_CLOUD_URL");
+  return typeof rawAppUrl === "string" ? rawAppUrl : undefined;
+}
 
 function appleScriptStringLiteral(value: string): string {
   return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
@@ -566,7 +573,7 @@ export class IMessageService extends Service implements IIMessageService {
       },
       sendHandler: async (_runtime: IAgentRuntime, target: TargetInfo, content: Content) => {
         const accountId = assertLocalIMessageAccount(readTargetAccountId(target));
-        const text = typeof content.text === "string" ? content.text : "";
+        const text = renderIMessageInteractionText(content, resolveInteractionAppBaseUrl(runtime));
         const mediaUrl = firstAttachmentUrl(content);
         if (!text.trim() && !mediaUrl) {
           return;
@@ -1660,8 +1667,14 @@ export class IMessageService extends Service implements IIMessageService {
     const replyTarget = row.chatType === "group" ? `chat_id:${row.chatId}` : row.handle;
 
     const callback: HandlerCallback = async (content) => {
-      const replyText = content.text?.trim();
-      if (!replyText || !this.runtime) {
+      if (!this.runtime) {
+        return [];
+      }
+      const replyText = renderIMessageInteractionText(
+        content,
+        resolveInteractionAppBaseUrl(this.runtime)
+      ).trim();
+      if (!replyText) {
         return [];
       }
 
@@ -1678,6 +1691,7 @@ export class IMessageService extends Service implements IIMessageService {
         roomId,
         content: {
           ...content,
+          text: replyText,
           source: "imessage",
           channelType,
           inReplyTo: messageId,


### PR DESCRIPTION
## Summary
- add `toPlainTextFallback` for text-only interaction surfaces and document SMS/iMessage rendering
- strip interaction markers and append plain prose fallbacks in iMessage and BlueBubbles direct send + reply callback paths
- cover core projection, iMessage chunking/order, and both connector send handlers

Fixes #14525.

## Verification
- `bun run --cwd packages/core test src/messaging/interactions/interactions.test.ts`
- `bun run --cwd plugins/plugin-imessage test src/interactions.test.ts src/message-connector.test.ts`
- `bun run --cwd plugins/plugin-bluebubbles test src/interactions.test.ts __tests__/message-connector.test.ts`
- `bun run --cwd plugins/plugin-imessage typecheck`
- `bun run --cwd plugins/plugin-bluebubbles typecheck`
- `bunx @biomejs/biome check packages/core/src/messaging/interactions/layout.ts packages/core/src/messaging/interactions/interactions.test.ts packages/core/src/messaging/interactions/README.md plugins/plugin-imessage/__tests__/core-test-mock.ts plugins/plugin-imessage/src/interactions.ts plugins/plugin-imessage/src/interactions.test.ts plugins/plugin-imessage/src/message-connector.test.ts plugins/plugin-imessage/src/service.ts plugins/plugin-bluebubbles/src/interactions.ts plugins/plugin-bluebubbles/src/interactions.test.ts plugins/plugin-bluebubbles/src/service.ts plugins/plugin-bluebubbles/__tests__/message-connector.test.ts`
- `git diff --check`
- `bun run audit:error-policy-ratchet --report`

## Not run
- `bun run --cwd packages/core typecheck` could not run in this worktree because the shared dependency install is missing `drizzle-orm`; it fails before this change at `packages/shared/src/db/drizzle-database.ts` and `packages/shared/src/utils/sql-compat.ts`.