### PR TITLE
fix(openrouter): cache Anthropic prompts at message level

### DIFF
--- a/plugins/plugin-openrouter/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-openrouter/__tests__/native-plumbing.shape.test.ts
@@ -8,16 +8,17 @@
 import type { IAgentRuntime } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-function createRuntime() {
+function createRuntime(settings: Record<string, string> = {}) {
   const runtime = {
     character: { system: "system prompt" },
     emitEvent: vi.fn(async () => undefined),
     getSetting: vi.fn((key: string) => {
-      const settings: Record<string, string> = {
+      const defaultSettings: Record<string, string> = {
         OPENROUTER_API_KEY: "test-key",
         OPENROUTER_SMALL_MODEL: "openrouter-small",
+        ...settings,
       };
-      return settings[key] ?? null;
+      return defaultSettings[key] ?? null;
     }),
   };
 
@@ -249,6 +250,100 @@ describe("OpenRouter native text plumbing", () => {
       promptCacheRetention: "24h",
     });
     expect(providerOptions.gateway).toEqual({ caching: "auto" });
+  });
+
+  it("moves Anthropic cache control onto a prompt-only system message", async () => {
+    const generateText = vi.fn(async () => ({
+      text: "ok",
+      finishReason: "stop",
+      usage: { inputTokens: 5, outputTokens: 2, totalTokens: 7 },
+    }));
+    vi.doMock("ai", () => ({
+      generateText,
+      streamText: vi.fn(),
+    }));
+    vi.doMock("../providers", () => ({
+      createOpenRouterProvider: () => ({
+        chat: (modelName: string) => ({ modelName }),
+      }),
+    }));
+
+    const { handleTextSmall } = await import("../models/text");
+    await handleTextSmall(
+      createRuntime({ OPENROUTER_SMALL_MODEL: "anthropic/claude-sonnet-4.5" }),
+      {
+        prompt: "prompt with caching",
+        providerOptions: {
+          anthropic: { cacheControl: { type: "ephemeral", ttl: "5m" } },
+          gateway: { caching: "auto" },
+        },
+      } as never
+    );
+
+    const call = generateText.mock.calls[0][0] as Record<string, unknown>;
+    expect(call).not.toHaveProperty("prompt");
+    expect(call).not.toHaveProperty("system");
+    expect(call.messages).toEqual([
+      {
+        role: "system",
+        content: "system prompt",
+        providerOptions: {
+          anthropic: { cacheControl: { type: "ephemeral", ttl: "5m" } },
+        },
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "prompt with caching" }],
+      },
+    ]);
+    expect(call.providerOptions).toEqual({ gateway: { caching: "auto" } });
+  });
+
+  it("uses cacheSystem true as an Anthropic ephemeral cache signal for native messages", async () => {
+    const generateText = vi.fn(async () => ({
+      text: "ok",
+      finishReason: "stop",
+      usage: { inputTokens: 5, outputTokens: 2, totalTokens: 7 },
+    }));
+    vi.doMock("ai", () => ({
+      generateText,
+      streamText: vi.fn(),
+    }));
+    vi.doMock("../providers", () => ({
+      createOpenRouterProvider: () => ({
+        chat: (modelName: string) => ({ modelName }),
+      }),
+    }));
+
+    const { handleTextSmall } = await import("../models/text");
+    await handleTextSmall(
+      createRuntime({ OPENROUTER_SMALL_MODEL: "anthropic/claude-sonnet-4.5" }),
+      {
+        messages: [
+          { role: "system", content: "system prompt" },
+          { role: "user", content: "hello" },
+        ],
+        providerOptions: {
+          anthropic: { cacheSystem: true, thinking: { type: "enabled" } },
+        },
+      } as never
+    );
+
+    const call = generateText.mock.calls[0][0] as Record<string, unknown>;
+    expect(call).not.toHaveProperty("system");
+    expect(call.messages).toEqual([
+      {
+        role: "system",
+        content: "system prompt",
+        providerOptions: {
+          anthropic: { cacheControl: { type: "ephemeral" } },
+        },
+      },
+      { role: "user", content: "hello" },
+    ]);
+    expect(call.providerOptions).toEqual({
+      anthropic: { thinking: { type: "enabled" } },
+    });
   });
 
   it("does not inject empty providerOptions when none are provided", async () => {

--- a/plugins/plugin-openrouter/models/text.ts
+++ b/plugins/plugin-openrouter/models/text.ts
@@ -246,6 +246,22 @@ function buildCacheableSystemMessage(
   } as unknown as ModelMessage;
 }
 
+function readAnthropicCacheControl(
+  anthropicOptions: Record<string, unknown> | undefined
+): AnthropicCacheControl | undefined {
+  if (!anthropicOptions) {
+    return undefined;
+  }
+  const cacheControl = anthropicOptions.cacheControl;
+  if (isRecord(cacheControl) && cacheControl.type === "ephemeral") {
+    return {
+      type: "ephemeral",
+      ...(cacheControl.ttl === "5m" || cacheControl.ttl === "1h" ? { ttl: cacheControl.ttl } : {}),
+    };
+  }
+  return anthropicOptions.cacheSystem === true ? { type: "ephemeral" } : undefined;
+}
+
 function stripLocalAnthropicCacheOptions(
   anthropicOptions: Record<string, unknown> | undefined
 ): Record<string, unknown> | undefined {
@@ -485,24 +501,20 @@ function buildGenerateParams(
   // Detect if we need to inject Anthropic message-level cache control
   const isAnthropic = isAnthropicModel(modelName);
   const rawProviderOptions = paramsWithAttachments.providerOptions;
-  const anthropicOptions = rawProviderOptions?.anthropic as Record<string, unknown> | undefined;
-  const anthropicCacheControl = anthropicOptions?.cacheControl as
-    | AnthropicCacheControl
-    | undefined;
+  const anthropicOptions = isRecord(rawProviderOptions?.anthropic)
+    ? rawProviderOptions.anthropic
+    : undefined;
+  const anthropicCacheControl = readAnthropicCacheControl(anthropicOptions);
   const anthropicCacheSystem = anthropicOptions?.cacheSystem !== false;
-  const shouldInjectMessageLevelCache =
-    isAnthropic &&
-    anthropicCacheSystem &&
-    anthropicCacheControl &&
-    paramsWithAttachments.messages;
+  const cacheSystemMessage =
+    isAnthropic && anthropicCacheSystem
+      ? buildCacheableSystemMessage(systemPrompt, anthropicCacheControl)
+      : undefined;
+  const shouldInjectMessageLevelCache = Boolean(cacheSystemMessage);
 
-  // Build wire messages with optional message-level cache control for Anthropic
   let finalWireMessages = wireMessages;
-  if (shouldInjectMessageLevelCache) {
-    const cacheSystemMessage = buildCacheableSystemMessage(systemPrompt, anthropicCacheControl);
-    if (cacheSystemMessage) {
-      finalWireMessages = [cacheSystemMessage, ...(wireMessages || [])];
-    }
+  if (cacheSystemMessage && paramsWithAttachments.messages) {
+    finalWireMessages = [cacheSystemMessage, ...(wireMessages || [])];
   }
 
   const promptOrMessages: NativePrompt = paramsWithAttachments.messages
@@ -521,19 +533,38 @@ function buildGenerateParams(
                 "OpenRouter text generation requires prompt, messages, or attachments"
               );
             })()
-    : userContent
-      ? { messages: [{ role: "user" as const, content: userContent }] }
-      : prompt !== undefined
-        ? { prompt }
+    : shouldInjectMessageLevelCache && cacheSystemMessage
+      ? userContent || prompt !== undefined
+        ? {
+            messages: [
+              cacheSystemMessage,
+              {
+                role: "user" as const,
+                content: userContent ?? buildUserContent(paramsWithAttachments),
+              },
+            ],
+          }
         : (() => {
             throw new Error("OpenRouter text generation requires prompt, messages, or attachments");
-          })();
+          })()
+      : userContent
+        ? { messages: [{ role: "user" as const, content: userContent }] }
+        : prompt !== undefined
+          ? { prompt }
+          : (() => {
+              throw new Error(
+                "OpenRouter text generation requires prompt, messages, or attachments"
+              );
+            })();
 
   // Resolve providerOptions: forward any caller-supplied options and merge in
   // the openrouter.promptCacheKey when present. OpenRouter passes prompt_cache_key
   // through to the underlying model provider for prefix caching.
-  const { openrouter: rawOpenrouterOptions, anthropic: _, ...restProviderOptions } =
-    rawProviderOptions ?? {};
+  const {
+    openrouter: rawOpenrouterOptions,
+    anthropic: _,
+    ...restProviderOptions
+  } = rawProviderOptions ?? {};
   const openrouterOptions: Record<string, unknown> = {
     ...(rawOpenrouterOptions ?? {}),
   };


### PR DESCRIPTION
Supersedes #14538.

This keeps the contributor's Anthropic/OpenRouter cache-control change, then fixes the review gaps:

- prompt-only Anthropic calls with cache control now use message form so `providerOptions.anthropic.cacheControl` sits on the system message instead of the call-level options
- `cacheSystem: true` now maps to `{ type: "ephemeral" }` instead of requiring an explicit cacheControl object
- call-level local cache flags are stripped after message-level injection while unrelated provider options are preserved
- malformed `providerOptions.anthropic` values are not treated as records

Verification run locally:

```
bun run --cwd plugins/plugin-openrouter test:unit
bun run --cwd plugins/plugin-openrouter typecheck
```

Both passed on the rebased branch.
