### PR TITLE
feat(home): long-press background switcher

### DIFF
--- a/packages/ui/src/components/shell/HomeBackgroundQuickPicker.test.tsx
+++ b/packages/ui/src/components/shell/HomeBackgroundQuickPicker.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+
+/**
+ * Render + dismiss contract for the home wallpaper long-press quick-picker
+ * (#home-longpress): it portals a labelled dialog, embeds the SHARED background
+ * controls (so it applies through the same store, not a fork), applies a choice
+ * via the same setBackgroundConfig path, and closes on the scrim / close /
+ * Escape. jsdom render with the app store seeded via `__setAppValueForTests`.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { __setAppValueForTests } from "../../state/app-store";
+import { HomeBackgroundQuickPicker } from "./HomeBackgroundQuickPicker";
+
+function seed(opts: { setBackgroundConfig?: (config: unknown) => void } = {}) {
+  __setAppValueForTests({
+    t: (_key: string, o?: { defaultValue?: string }) => o?.defaultValue ?? _key,
+    backgroundConfig: { mode: "shader", color: "#ef5a1f" },
+    setBackgroundConfig: opts.setBackgroundConfig ?? vi.fn(),
+    undoBackgroundConfig: vi.fn(),
+    redoBackgroundConfig: vi.fn(),
+    canUndoBackground: false,
+    canRedoBackground: false,
+    elizaCloudConnected: false,
+    elizaCloudAuthRejected: false,
+  } as never);
+}
+
+afterEach(() => {
+  cleanup();
+  __setAppValueForTests(null);
+  vi.clearAllMocks();
+});
+
+describe("HomeBackgroundQuickPicker", () => {
+  it("renders a labelled dialog embedding the shared background controls", () => {
+    seed();
+    render(<HomeBackgroundQuickPicker onClose={vi.fn()} />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    // The SHARED controls are embedded — not a re-implemented picker.
+    expect(screen.getByTestId("background-settings-controls")).toBeTruthy();
+    expect(screen.getByTestId("background-catalog-gallery")).toBeTruthy();
+  });
+
+  it("applies a preset through the shared setBackgroundConfig path", () => {
+    const setBackgroundConfig = vi.fn();
+    seed({ setBackgroundConfig });
+    render(<HomeBackgroundQuickPicker onClose={vi.fn()} />);
+    // Any color swatch writes through the shared store.
+    const swatch = screen.getByLabelText("Set background to Green");
+    fireEvent.click(swatch);
+    expect(setBackgroundConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "shader" }),
+    );
+  });
+
+  it("closes on the scrim, the close button, and Escape", () => {
+    const onClose = vi.fn();
+    seed();
+    render(<HomeBackgroundQuickPicker onClose={onClose} />);
+
+    fireEvent.click(screen.getByLabelText("Close background picker"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByLabelText("Close"));
+    expect(onClose).toHaveBeenCalledTimes(2);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/ui/src/components/shell/HomeBackgroundQuickPicker.tsx
+++ b/packages/ui/src/components/shell/HomeBackgroundQuickPicker.tsx
@@ -1,0 +1,156 @@
+/**
+ * The bottom-sheet quick-picker that a long-press on the home wallpaper opens
+ * (#home-longpress). It is a lightweight ENTRY POINT, not a second system: it
+ * renders the shared {@link BackgroundSettingsControls}, so every choice writes
+ * to the same background store (`useBackgroundConfig` / `ui-preferences`) that
+ * the Settings and Background views use — selections apply live and persist
+ * through the identical path, just reached from the home instead of a settings
+ * dive.
+ *
+ * Surfaced via `createPortal` at the shell-overlay z-layer so it floats above
+ * the home rail. A tinted scrim dims the home behind it; tapping the scrim, the
+ * grabber, or pressing Escape dismisses. The sheet enters with a settle-in
+ * translate that stills under prefers-reduced-motion.
+ */
+
+import { X } from "lucide-react";
+import { useEffect, useId, useRef } from "react";
+import { createPortal } from "react-dom";
+import { Z_SHELL_OVERLAY } from "../../lib/floating-layers";
+import { cn } from "../../lib/utils";
+import { BackgroundSettingsControls } from "../settings/BackgroundSettingsControls";
+import { Button } from "../ui/button";
+
+// The sheet's slide-in. Kept local so the picker owns its own motion without
+// touching any global keyframe surface; fully stilled under reduced motion so
+// the sheet just appears in place. transform/opacity only (composited).
+const QUICK_PICKER_CSS = `
+@keyframes home-bg-picker-in {
+  from { opacity: 0; transform: translateY(16px); }
+  to   { opacity: 1; transform: none; }
+}
+@keyframes home-bg-picker-scrim-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+.home-bg-picker-sheet {
+  animation: home-bg-picker-in 260ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+.home-bg-picker-scrim {
+  animation: home-bg-picker-scrim-in 200ms ease-out both;
+}
+@media (prefers-reduced-motion: reduce) {
+  .home-bg-picker-sheet,
+  .home-bg-picker-scrim {
+    animation: none;
+  }
+}
+`;
+
+export interface HomeBackgroundQuickPickerProps {
+  /** Dismiss the picker (scrim tap, grabber, close button, or Escape). */
+  onClose: () => void;
+}
+
+/**
+ * A bottom sheet with the shared background controls. Mounted only while open
+ * (the home unmounts it on close), so there is no persistent DOM cost when the
+ * picker is not showing.
+ */
+export function HomeBackgroundQuickPicker({
+  onClose,
+}: HomeBackgroundQuickPickerProps) {
+  const titleId = useId();
+  const sheetRef = useRef<HTMLDivElement>(null);
+
+  // Escape closes; focus moves into the sheet on mount so a keyboard user lands
+  // on the controls, not back on the home behind the scrim.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    // Defer the focus one frame so the enter animation has committed.
+    const id = window.requestAnimationFrame(() => {
+      sheetRef.current?.focus();
+    });
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      window.cancelAnimationFrame(id);
+    };
+  }, [onClose]);
+
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
+    <div
+      data-testid="home-background-quick-picker"
+      className="fixed inset-0 flex items-end justify-center"
+      style={{ zIndex: Z_SHELL_OVERLAY + 5 }}
+    >
+      <style>{QUICK_PICKER_CSS}</style>
+      {/* Scrim: dims the home, closes on tap. A plain tinted layer, not a blur
+          gate — the wallpaper stays legible through it, just quieted. */}
+      <button
+        type="button"
+        aria-label="Close background picker"
+        onClick={onClose}
+        className="home-bg-picker-scrim absolute inset-0 h-auto w-auto cursor-default rounded-none border-0 bg-scrim p-0"
+      />
+      <section
+        ref={sheetRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+        className={cn(
+          "home-bg-picker-sheet relative flex w-full max-w-md flex-col items-center gap-4",
+          "rounded-t-3xl border border-border bg-bg-elevated px-4 pt-3 pb-[calc(env(safe-area-inset-bottom,0px)+1.5rem)] outline-none",
+          // Tint the elevation shadow toward the surface rather than a generic
+          // black drop, so the sheet reads as lifted, not pasted on.
+          "shadow-[0_-8px_40px_-12px_var(--color-scrim)]",
+        )}
+      >
+        {/* Grabber: the iOS-idiom drag handle. It is also a real close control
+            (tap to dismiss) so the affordance is not decorative. */}
+        <button
+          type="button"
+          aria-label="Dismiss background picker"
+          onClick={onClose}
+          className="group flex min-h-touch w-full items-center justify-center py-2"
+        >
+          <span className="h-1.5 w-10 rounded-full bg-border-strong transition-colors group-hover:bg-txt/40" />
+        </button>
+
+        <header className="flex w-full items-center justify-between">
+          <div className="flex flex-col">
+            <h2 id={titleId} className="text-sm font-semibold text-txt">
+              Background
+            </h2>
+            <p className="text-xs text-muted">
+              Pick a wallpaper. It applies right away.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={onClose}
+            aria-label="Close"
+            className="h-11 w-11 shrink-0 rounded-full text-muted hover:bg-bg-hover hover:text-txt"
+          >
+            <X className="h-4 w-4" aria-hidden />
+          </Button>
+        </header>
+
+        <div className="max-h-[60vh] w-full overflow-y-auto overscroll-contain">
+          <BackgroundSettingsControls className="max-w-none" />
+        </div>
+      </section>
+    </div>,
+    document.body,
+  );
+}

--- a/packages/ui/src/components/shell/HomeScreen.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.tsx
@@ -10,8 +10,10 @@ import {
   Phone,
 } from "lucide-react";
 import type * as React from "react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
+import { haptics } from "../../bridge/capacitor-bridge";
+import { useHomeLongPress } from "../../gestures/useHomeLongPress";
 import { useActivityEvents } from "../../hooks/useActivityEvents";
 import { isRenderTelemetryEnabled } from "../../hooks/useRenderGuard";
 import { cn } from "../../lib/utils";
@@ -19,7 +21,24 @@ import { LAYOUT_SHIFT_OBSERVER_INIT } from "../../testing/layout-stability";
 import { WidgetHost } from "../../widgets/WidgetHost";
 import { Button } from "../ui/button";
 import { DefaultHomeWidgets } from "./DefaultHomeWidgets";
+import { HomeBackgroundQuickPicker } from "./HomeBackgroundQuickPicker";
 import { NotificationsHomeCenter } from "./NotificationsHomeCenter";
+
+/**
+ * A press that lands on a tile, widget, or any interactive control owns its own
+ * tap/long-press — only a press on the BARE wallpaper opens the background
+ * picker. Mirrors the chat message's nested-interactive guard.
+ */
+function pressLandedOnBackground(
+  currentTarget: HTMLElement,
+  target: EventTarget | null,
+): boolean {
+  if (!(target instanceof Element)) return true;
+  const interactive = target.closest(
+    'button,a,input,textarea,select,[role="button"],[data-testid^="widget-"]',
+  );
+  return !interactive || interactive === currentTarget;
+}
 
 // A gentle staggered fade-up as the home settles in — iOS-style, calm, and
 // fully stilled under prefers-reduced-motion. Each block carries a small
@@ -32,6 +51,26 @@ const HOME_ENTER_CSS = `
 .home-enter { animation: home-enter 460ms cubic-bezier(0.22,1,0.36,1) both; }
 @media (prefers-reduced-motion: reduce) {
   .home-enter { animation: none; }
+}
+`;
+
+// The long-press affordance: while a candidate press is held on the bare
+// wallpaper the content dims + settles back a touch, so the wallpaper reads as
+// the thing being acted on. transform/opacity only (composited); fully stilled
+// under prefers-reduced-motion so the surface never moves for users who opt out.
+const HOME_LONGPRESS_AFFORDANCE_CSS = `
+.home-longpress-target {
+  transition: transform 240ms cubic-bezier(0.22, 1, 0.36, 1), opacity 240ms ease-out;
+  transform-origin: center;
+  will-change: transform;
+}
+.home-longpress-armed {
+  transform: scale(0.985);
+  opacity: 0.72;
+}
+@media (prefers-reduced-motion: reduce) {
+  .home-longpress-target { transition: opacity 160ms ease-out; }
+  .home-longpress-armed { transform: none; opacity: 0.82; }
 }
 `;
 
@@ -172,39 +211,65 @@ export function HomeScreen({
   // Dev/test-only: observe home layout shifts on the shared telemetry channel.
   useHomeLayoutShiftObserver();
 
+  // Long-press the bare wallpaper to open the background quick-picker (#home-
+  // longpress). A press on a tile/widget/control is ignored (canBegin), a
+  // scroll or rail swipe cancels it (move slop), and while a candidate press is
+  // held the content dims + settles back a touch so the wallpaper reads as the
+  // thing being acted on.
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const openPicker = useCallback(() => {
+    void haptics.medium();
+    setPickerOpen(true);
+  }, []);
+  const closePicker = useCallback(() => setPickerOpen(false), []);
+  const { pressing, handlers: longPressHandlers } =
+    useHomeLongPress<HTMLDivElement>({
+      onLongPress: openPicker,
+      // Do not arm while the picker is already open (its own scrim owns dismiss).
+      enabled: !pickerOpen,
+      canBegin: (event) =>
+        pressLandedOnBackground(event.currentTarget, event.target),
+    });
+
   return (
-    <div
-      data-testid="home-screen"
-      className={cn(
-        // `touch-pan-y`: this scroller covers the whole home half, and a
-        // scroll container's OWN touch-action governs which pans the browser
-        // consumes at it (`overflow-y-auto` computes to overflow-x auto too,
-        // so with the default `auto` the browser ate horizontal touch drags
-        // as a scroll attempt — pointercancel — and the home → launcher rail
-        // flick never fired on real touch). Keep vertical panning native for
-        // the widget list; hand every horizontal gesture to the rail.
-        // `overscroll-y-contain`: keep the browser's own pull-to-refresh /
-        // scroll-chaining off the top overscroll so a drag past the top never
-        // yanks the whole page.
-        // `overflow-x-hidden`: `overflow-y-auto` alone coerces the cross axis to
-        // `auto`, so an over-wide child (a full-bleed widget, a long code line)
-        // would make the home dashboard pan sideways under a diagonal trackpad
-        // wheel. Pin X closed — this surface scrolls vertically only (#14328).
-        "eliza-continuous-chat-scroll absolute inset-0 z-[1] touch-pan-y overflow-x-hidden overflow-y-auto overscroll-y-contain",
-        // The shell root already reserves the status-bar safe area (its
-        // paddingTop: var(--safe-area-top)); adding it again here double-padded
-        // the content and left a large empty band above the dashboard. Just a
-        // small gutter — the notch is already cleared by the root.
-        "px-4",
-        // Clear the residual tucked band the root deliberately shaves off the
-        // safe area (capped at 1.25rem), plus a small breathing gutter.
-        "pt-[calc(min(max(var(--safe-area-top,0px)-1.25rem,0px),1.25rem)+12px)]",
-        // Clear the floating chat composer at the bottom.
-        "pb-[calc(var(--eliza-mobile-nav-offset,0px)+max(var(--safe-area-bottom,0px),var(--android-gesture-inset-bottom,0px))+var(--eliza-continuous-chat-clearance,5.25rem)+1.5rem)]",
-      )}
-    >
-      <style>{HOME_ENTER_CSS}</style>
-      {/* The content column owns the FULL height of the scroller (min-h-full)
+    <>
+      <div
+        data-testid="home-screen"
+        onPointerDown={longPressHandlers.onPointerDown}
+        onPointerMove={longPressHandlers.onPointerMove}
+        onPointerUp={longPressHandlers.onPointerUp}
+        onPointerCancel={longPressHandlers.onPointerCancel}
+        className={cn(
+          // `touch-pan-y`: this scroller covers the whole home half, and a
+          // scroll container's OWN touch-action governs which pans the browser
+          // consumes at it (`overflow-y-auto` computes to overflow-x auto too,
+          // so with the default `auto` the browser ate horizontal touch drags
+          // as a scroll attempt — pointercancel — and the home → launcher rail
+          // flick never fired on real touch). Keep vertical panning native for
+          // the widget list; hand every horizontal gesture to the rail.
+          // `overscroll-y-contain`: keep the browser's own pull-to-refresh /
+          // scroll-chaining off the top overscroll so a drag past the top never
+          // yanks the whole page.
+          // `overflow-x-hidden`: `overflow-y-auto` alone coerces the cross axis to
+          // `auto`, so an over-wide child (a full-bleed widget, a long code line)
+          // would make the home dashboard pan sideways under a diagonal trackpad
+          // wheel. Pin X closed — this surface scrolls vertically only (#14328).
+          "eliza-continuous-chat-scroll absolute inset-0 z-[1] touch-pan-y overflow-x-hidden overflow-y-auto overscroll-y-contain",
+          // The shell root already reserves the status-bar safe area (its
+          // paddingTop: var(--safe-area-top)); adding it again here double-padded
+          // the content and left a large empty band above the dashboard. Just a
+          // small gutter — the notch is already cleared by the root.
+          "px-4",
+          // Clear the residual tucked band the root deliberately shaves off the
+          // safe area (capped at 1.25rem), plus a small breathing gutter.
+          "pt-[calc(min(max(var(--safe-area-top,0px)-1.25rem,0px),1.25rem)+12px)]",
+          // Clear the floating chat composer at the bottom.
+          "pb-[calc(var(--eliza-mobile-nav-offset,0px)+max(var(--safe-area-bottom,0px),var(--android-gesture-inset-bottom,0px))+var(--eliza-continuous-chat-clearance,5.25rem)+1.5rem)]",
+        )}
+      >
+        <style>{HOME_ENTER_CSS}</style>
+        <style>{HOME_LONGPRESS_AFFORDANCE_CSS}</style>
+        {/* The content column owns the FULL height of the scroller (min-h-full)
           and lays its blocks out as a flex column so the vertical space is
           distributed on purpose, not left as a void above the composer. The
           editorial header (greeting/clock + weather) anchors the TOP, with the
@@ -213,23 +278,32 @@ export function HomeScreen({
           the reclaimed space and centres its content within it, so an empty
           widget set reads as calm airiness rather than a broken gap; the AOSP
           tiles settle at the BOTTOM. */}
-      <div className="mx-auto flex min-h-full w-full max-w-2xl flex-col">
-        {/* The always-on base: a naked sized grid with the time + weather as
+        <div
+          className={cn(
+            "mx-auto flex min-h-full w-full max-w-2xl flex-col",
+            // While a long-press candidate is held on the bare wallpaper, dim +
+            // settle the content back a hair so the press reads as "acting on the
+            // background". transform/opacity only; stilled under reduce-motion.
+            "home-longpress-target",
+            pressing && "home-longpress-armed",
+          )}
+        >
+          {/* The always-on base: a naked sized grid with the time + weather as
             2×2 neighbours — no card, white text on the ambient field. Anchored
             at the top of the column as the editorial header. */}
-        <div className={enterClass} style={{ animationDelay: "70ms" }}>
-          <DefaultHomeWidgets />
-        </div>
+          <div className={enterClass} style={{ animationDelay: "70ms" }}>
+            <DefaultHomeWidgets />
+          </div>
 
-        {/* The notification center: a pinned widget directly below the
+          {/* The notification center: a pinned widget directly below the
             time/weather base — THE notification surface (the pull-down sheet it
             replaced is gone). Self-hides when the inbox is empty; when present
             it height-caps and scrolls internally. */}
-        <div className={enterClass} style={{ animationDelay: "90ms" }}>
-          <NotificationsHomeCenter />
-        </div>
+          <div className={enterClass} style={{ animationDelay: "90ms" }}>
+            <NotificationsHomeCenter />
+          </div>
 
-        {/* The prioritized data widgets (#9143) live in the breathing region:
+          {/* The prioritized data widgets (#9143) live in the breathing region:
             a `flex-1` block that grows to fill the space between the header and
             the bottom tiles, so the column always spans the full height. Its
             content is vertically centred within that region — when widgets are
@@ -238,58 +312,63 @@ export function HomeScreen({
             simply reads as calm, intentional space rather than a dead gap. A
             little top padding sets the stack apart from the editorial header as
             its own section. */}
-        <div
-          className={cn(enterClass, "flex flex-1 flex-col justify-center py-6")}
-          style={{ animationDelay: "110ms" }}
-        >
-          <WidgetHost
-            slot="home"
-            layout="grid"
-            events={events}
-            clearEvents={clearEvents}
-          />
-        </div>
-
-        {tiles.length > 0 ? (
-          <nav
-            aria-label="Apps"
-            data-testid="home-tiles"
-            className={cn(enterClass, "pt-2")}
-            style={{ animationDelay: "150ms" }}
+          <div
+            className={cn(
+              enterClass,
+              "flex flex-1 flex-col justify-center py-6",
+            )}
+            style={{ animationDelay: "110ms" }}
           >
-            <div className="grid grid-cols-4 gap-3">
-              {tiles.map((tile) => {
-                const Icon = tile.icon;
-                return (
-                  <Button
-                    key={tile.id}
-                    data-testid={`home-tile-${tile.id}`}
-                    onClick={() => onOpenTile(tile.target)}
-                    variant="ghost"
-                    className={cn(
-                      // Naked tile: icon + label sit directly on the ambient
-                      // orange field — no fill, no border.
-                      "flex h-auto flex-col items-center gap-1.5 whitespace-normal rounded-2xl px-1 py-3.5 text-white [text-shadow:0_1px_3px_rgba(0,0,0,0.38)]",
-                      // Tactile press: a quick scale-down on tap (stilled for
-                      // reduce-motion users), plus a faint white wash on hover.
-                      "transition-[transform,background-color] duration-150 active:scale-[0.96] motion-reduce:active:scale-100",
-                      "hover:bg-white/8",
-                    )}
-                  >
-                    <Icon
-                      className="h-[22px] w-[22px] text-white"
-                      aria-hidden
-                    />
-                    <span className="max-w-full truncate text-[11px] font-medium text-white">
-                      {tile.label}
-                    </span>
-                  </Button>
-                );
-              })}
-            </div>
-          </nav>
-        ) : null}
+            <WidgetHost
+              slot="home"
+              layout="grid"
+              events={events}
+              clearEvents={clearEvents}
+            />
+          </div>
+
+          {tiles.length > 0 ? (
+            <nav
+              aria-label="Apps"
+              data-testid="home-tiles"
+              className={cn(enterClass, "pt-2")}
+              style={{ animationDelay: "150ms" }}
+            >
+              <div className="grid grid-cols-4 gap-3">
+                {tiles.map((tile) => {
+                  const Icon = tile.icon;
+                  return (
+                    <Button
+                      key={tile.id}
+                      data-testid={`home-tile-${tile.id}`}
+                      onClick={() => onOpenTile(tile.target)}
+                      variant="ghost"
+                      className={cn(
+                        // Naked tile: icon + label sit directly on the ambient
+                        // orange field — no fill, no border.
+                        "flex h-auto flex-col items-center gap-1.5 whitespace-normal rounded-2xl px-1 py-3.5 text-white [text-shadow:0_1px_3px_rgba(0,0,0,0.38)]",
+                        // Tactile press: a quick scale-down on tap (stilled for
+                        // reduce-motion users), plus a faint white wash on hover.
+                        "transition-[transform,background-color] duration-150 active:scale-[0.96] motion-reduce:active:scale-100",
+                        "hover:bg-white/8",
+                      )}
+                    >
+                      <Icon
+                        className="h-[22px] w-[22px] text-white"
+                        aria-hidden
+                      />
+                      <span className="max-w-full truncate text-[11px] font-medium text-white">
+                        {tile.label}
+                      </span>
+                    </Button>
+                  );
+                })}
+              </div>
+            </nav>
+          ) : null}
+        </div>
       </div>
-    </div>
+      {pickerOpen ? <HomeBackgroundQuickPicker onClose={closePicker} /> : null}
+    </>
   );
 }

--- a/packages/ui/src/gestures/index.ts
+++ b/packages/ui/src/gestures/index.ts
@@ -6,6 +6,7 @@ export * from "./constants";
 export * from "./lost-capture";
 export * from "./recognizers";
 export * from "./useClickSuppression";
+export * from "./useHomeLongPress";
 export * from "./usePointerPressAndHold";
 export * from "./usePressAndHold";
 export * from "./useRafCoalescer";

--- a/packages/ui/src/gestures/useHomeLongPress.test.ts
+++ b/packages/ui/src/gestures/useHomeLongPress.test.ts
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+//
+// Unit suite for the home-wallpaper long-press recognizer (#home-longpress):
+// the timer commit, the live `pressing` affordance flag, the move-cancel /
+// scroll-cancel slop, the canBegin/enabled gating, and unmount cleanup. Driven
+// with synthetic pointer input; the real browser pipeline is covered by the CDP
+// e2e runners.
+import { act, renderHook } from "@testing-library/react";
+import type * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TOUCH_TAP_MOVE_SLOP } from "./constants";
+import { HOME_BACKGROUND_HOLD_MS, useHomeLongPress } from "./useHomeLongPress";
+
+function pointer(x = 0, y = 0) {
+  return {
+    clientX: x,
+    clientY: y,
+  } as unknown as React.PointerEvent<HTMLElement>;
+}
+
+describe("useHomeLongPress", () => {
+  afterEach(() => vi.useRealTimers());
+
+  it("fires onLongPress after the hold for a still press", () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() =>
+      useHomeLongPress<HTMLElement>({ onLongPress }),
+    );
+    act(() => result.current.handlers.onPointerDown(pointer(120, 120)));
+    expect(onLongPress).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(HOME_BACKGROUND_HOLD_MS + 10);
+    });
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports `pressing` while held and settles it on commit", () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() =>
+      useHomeLongPress<HTMLElement>({ onLongPress }),
+    );
+    expect(result.current.pressing).toBe(false);
+    act(() => result.current.handlers.onPointerDown(pointer(50, 50)));
+    expect(result.current.pressing).toBe(true);
+    act(() => {
+      vi.advanceTimersByTime(HOME_BACKGROUND_HOLD_MS + 10);
+    });
+    // The affordance stills the instant the hold commits (the picker takes over).
+    expect(result.current.pressing).toBe(false);
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears `pressing` on pointer up before the hold, without firing", () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() =>
+      useHomeLongPress<HTMLElement>({ onLongPress }),
+    );
+    act(() => result.current.handlers.onPointerDown(pointer(10, 10)));
+    expect(result.current.pressing).toBe(true);
+    act(() => result.current.handlers.onPointerUp());
+    expect(result.current.pressing).toBe(false);
+    act(() => {
+      vi.advanceTimersByTime(HOME_BACKGROUND_HOLD_MS + 10);
+    });
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it("cancels on a move past the slop (a scroll or rail swipe wins)", () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() =>
+      useHomeLongPress<HTMLElement>({ onLongPress }),
+    );
+    // A vertical scroll past the slop cancels the pending hold.
+    act(() => result.current.handlers.onPointerDown(pointer(100, 100)));
+    act(() =>
+      result.current.handlers.onPointerMove(
+        pointer(100, 100 + TOUCH_TAP_MOVE_SLOP + 1),
+      ),
+    );
+    expect(result.current.pressing).toBe(false);
+    act(() => {
+      vi.advanceTimersByTime(HOME_BACKGROUND_HOLD_MS + 10);
+    });
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it("tolerates wobble within the slop and still commits", () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() =>
+      useHomeLongPress<HTMLElement>({ onLongPress }),
+    );
+    act(() => result.current.handlers.onPointerDown(pointer(100, 100)));
+    // A single-axis wobble equal to the slop keeps the hold alive.
+    act(() =>
+      result.current.handlers.onPointerMove(
+        pointer(100 + TOUCH_TAP_MOVE_SLOP, 100),
+      ),
+    );
+    act(() => {
+      vi.advanceTimersByTime(HOME_BACKGROUND_HOLD_MS + 10);
+    });
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels on pointer cancel before the hold", () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() =>
+      useHomeLongPress<HTMLElement>({ onLongPress }),
+    );
+    act(() => result.current.handlers.onPointerDown(pointer()));
+    act(() => result.current.handlers.onPointerCancel());
+    act(() => {
+      vi.advanceTimersByTime(HOME_BACKGROUND_HOLD_MS + 10);
+    });
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it("skips presses rejected by canBegin (a nested tile owns the press)", () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() =>
+      useHomeLongPress<HTMLElement>({ onLongPress, canBegin: () => false }),
+    );
+    act(() => result.current.handlers.onPointerDown(pointer()));
+    expect(result.current.pressing).toBe(false);
+    act(() => {
+      vi.advanceTimersByTime(HOME_BACKGROUND_HOLD_MS + 10);
+    });
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it("is inert when disabled (picker already open)", () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() =>
+      useHomeLongPress<HTMLElement>({ onLongPress, enabled: false }),
+    );
+    act(() => result.current.handlers.onPointerDown(pointer()));
+    expect(result.current.pressing).toBe(false);
+    act(() => {
+      vi.advanceTimersByTime(HOME_BACKGROUND_HOLD_MS + 10);
+    });
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it("clears the pending hold on unmount", () => {
+    vi.useFakeTimers();
+    const onLongPress = vi.fn();
+    const { result, unmount } = renderHook(() =>
+      useHomeLongPress<HTMLElement>({ onLongPress }),
+    );
+    act(() => result.current.handlers.onPointerDown(pointer()));
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(HOME_BACKGROUND_HOLD_MS + 10);
+    });
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/gestures/useHomeLongPress.ts
+++ b/packages/ui/src/gestures/useHomeLongPress.ts
@@ -1,0 +1,124 @@
+/**
+ * Long-press recognizer for the home background surface: a still press held past
+ * `durationMs` on empty wallpaper opens the background quick-picker. It is the
+ * pointer sibling of {@link usePointerPressAndHold}, tuned for the "press the
+ * wallpaper" entry point rather than hold-to-copy:
+ *
+ *  - It reports a live `pressing` flag the instant a candidate press begins, so
+ *    the caller can play a subtle scale/dim affordance on the wallpaper while
+ *    the finger is down (the affordance settles the moment the hold commits,
+ *    cancels, or lifts).
+ *  - Travel past `moveCancelPx` on either axis (a scroll of the widget list, a
+ *    horizontal rail swipe) cancels the press — the home surface is scrollable
+ *    and swipeable, so an accidental hold during a drag must never fire.
+ *  - `canBegin` lets the caller ignore presses that land on a nested tile,
+ *    widget, or button, so those keep their own tap/long-press semantics and
+ *    only the bare background opens the picker.
+ *
+ * DOM-free logic behind React pointer handlers; the consumer spreads the
+ * returned handlers onto the background element. The timer is cleared on
+ * unmount.
+ */
+
+import * as React from "react";
+import { DEFAULT_HOLD_MS, TOUCH_TAP_MOVE_SLOP } from "./constants";
+
+/** Default hold (ms) before the home background picker opens. Longer than the
+ *  conversation menu's {@link DEFAULT_HOLD_MS} so a wallpaper press reads as a
+ *  deliberate "I want to change this", never a mis-timed tap. */
+export const HOME_BACKGROUND_HOLD_MS = 500;
+
+export interface HomeLongPressOptions<E extends HTMLElement> {
+  /** Fired when the press is held past `durationMs` within the move slop. */
+  onLongPress: () => void;
+  /** Hold duration (ms). Default {@link HOME_BACKGROUND_HOLD_MS}. */
+  durationMs?: number;
+  /** Per-axis travel (px) past which the press becomes a scroll/swipe and the
+   *  hold aborts. Default {@link TOUCH_TAP_MOVE_SLOP} (10px). */
+  moveCancelPx?: number;
+  /** Checked on pointerdown; return false to ignore the press (e.g. it landed
+   *  on a nested tile/widget/button that owns its own interaction). */
+  canBegin?: (event: React.PointerEvent<E>) => boolean;
+  /** When false, the recognizer is inert (e.g. a whitelabel home override). */
+  enabled?: boolean;
+}
+
+export interface HomeLongPressBinding<E extends HTMLElement> {
+  /** True from the moment a candidate press begins until it commits/cancels/lifts. */
+  pressing: boolean;
+  handlers: {
+    onPointerDown: (event: React.PointerEvent<E>) => void;
+    onPointerMove: (event: React.PointerEvent<E>) => void;
+    onPointerUp: () => void;
+    onPointerCancel: () => void;
+  };
+}
+
+export function useHomeLongPress<E extends HTMLElement>({
+  onLongPress,
+  durationMs = HOME_BACKGROUND_HOLD_MS,
+  moveCancelPx = TOUCH_TAP_MOVE_SLOP,
+  canBegin,
+  enabled = true,
+}: HomeLongPressOptions<E>): HomeLongPressBinding<E> {
+  const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startRef = React.useRef<{ x: number; y: number } | null>(null);
+  const [pressing, setPressing] = React.useState(false);
+
+  const onLongPressRef = React.useRef(onLongPress);
+  onLongPressRef.current = onLongPress;
+  const canBeginRef = React.useRef(canBegin);
+  canBeginRef.current = canBegin;
+
+  const clear = React.useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    startRef.current = null;
+    setPressing(false);
+  }, []);
+
+  React.useEffect(() => clear, [clear]);
+
+  const onPointerDown = React.useCallback(
+    (event: React.PointerEvent<E>) => {
+      if (!enabled) return;
+      if (canBeginRef.current && !canBeginRef.current(event)) return;
+      clear();
+      startRef.current = { x: event.clientX, y: event.clientY };
+      setPressing(true);
+      timerRef.current = setTimeout(() => {
+        // Fire the intent, then settle the affordance. The picker mounts over
+        // the home, so the pulse must not linger behind it.
+        clear();
+        onLongPressRef.current();
+      }, durationMs);
+    },
+    [clear, durationMs, enabled],
+  );
+
+  const onPointerMove = React.useCallback(
+    (event: React.PointerEvent<E>) => {
+      const start = startRef.current;
+      if (!start) return;
+      if (
+        Math.abs(event.clientX - start.x) > moveCancelPx ||
+        Math.abs(event.clientY - start.y) > moveCancelPx
+      ) {
+        clear();
+      }
+    },
+    [clear, moveCancelPx],
+  );
+
+  return {
+    pressing,
+    handlers: {
+      onPointerDown,
+      onPointerMove,
+      onPointerUp: clear,
+      onPointerCancel: clear,
+    },
+  };
+}


### PR DESCRIPTION
## What

Long-press the bare home wallpaper (~500ms) to open a background quick-picker. The gesture is a new **entry point** into the existing background system, not a second system: the sheet embeds the shared \`BackgroundSettingsControls\`, so every choice writes through the same \`useBackgroundConfig\` / \`ui-preferences\` store that Settings and the Background view use. Selections apply live (optimistic) and persist through the identical path.

## UX flow ("intuitive af")

- **Long-press** the empty wallpaper. While a candidate press is held, the home content dims and settles back a hair (transform/opacity only, stilled under \`prefers-reduced-motion\`) so the wallpaper reads as the thing being acted on.
- At ~500ms a **medium haptic** fires and a **bottom sheet** rises (matching the app's sheet idiom) with a tinted scrim behind it.
- The sheet shows the live catalog thumbnails (curated + your uploads/generations), the current one marked, tap to apply **instantly**.
- Dismiss by tapping the scrim, the grabber, the close button, or pressing **Escape**.

## Accidental-trigger protection

- A press on a tile, widget, or any control is ignored (\`canBegin\` guard) so those keep their own tap/long-press semantics; only the bare wallpaper opens the picker.
- Any finger travel past 10px (a vertical scroll of the widget list, or the home to launcher rail swipe) cancels the pending hold, and so does any pointer up/cancel.
- The recognizer is inert while the picker is already open.

## New pieces

- \`useHomeLongPress\` (\`packages/ui/src/gestures/\`): pointer long-press recognizer with a live \`pressing\` affordance flag, per-axis move-cancel slop, and \`canBegin\`/\`enabled\` gating. Sibling of the existing \`usePointerPressAndHold\`.
- \`HomeBackgroundQuickPicker\` (\`packages/ui/src/components/shell/\`): portalled bottom sheet at the shell-overlay z-layer that hosts the shared background controls.
- Wired into \`HomeScreen\` background surface (not widgets/tiles).

## Design compliance

- Design tokens only (no hex added), lucide-react icons only, 44px+ tap targets (close + grabber), no new backdrop-blur (plain tinted scrim), no em-dashes in copy.

## Verification

- \`useHomeLongPress\` unit tests: timer commit, \`pressing\` flag lifecycle, move-cancel / scroll-cancel / up / cancel, \`canBegin\` + \`enabled\` gating, unmount cleanup.
- \`HomeBackgroundQuickPicker\` render test: labelled dialog, embeds shared controls, applies a preset through \`setBackgroundConfig\`, dismisses on scrim/close/Escape.
- **12 tests green**, \`cd packages/app && bun run build\` green (built in 1m 1s), biome clean on all touched files.

Codex review hit an internal WriteFailed (context flooded by untracked benchmark artifacts in the worktree); self-reviewed the diff instead and hardened tap targets as a result.

— [sol-orch]