### PR TITLE
fix(ci): unbreak develop verify + chat-sheet-e2e gates

### DIFF
--- a/packages/ui/CLAUDE.md
+++ b/packages/ui/CLAUDE.md
@@ -190,6 +190,49 @@ component should ship at least a `*.stories.tsx` (states) **and** a `*.test.tsx`
 (behaviour). The live full-app visual audit lives in `packages/app`
 (`audit:app`) and `packages/cloud-frontend` (`audit:cloud`).
 
+### Scroll + tap-target certification (`src/testing/scroll-cert.ts`, #14380)
+
+A UI-library-wide certification harness holds every scrollable / interactive
+widget to four device-review guarantees: **scroll stability**, **keyboard
+interaction geometry**, **safe-area clearance**, and **tap-target minimums**
+(44x44 CSS px). It is two layers, same split as the rest of `src/testing`:
+
+- **Pure verdict math** — `scroll-cert.ts` is `(measurements) -> Violation[]`,
+  proven both ways (RED on a violation, GREEN when it holds) in
+  `scroll-cert.test.ts`. This is the always-trustworthy detector.
+- **DOM sweep** — `widget-cert.ts` walks a rendered widget for interactive
+  controls + scroll containers, reads their boxes through a pluggable
+  `GeometryProvider`, and runs the verdicts into a per-widget `WidgetCertReport`
+  (JSON + rendered summary). Under jsdom (`widget-cert.test.tsx`) geometry is
+  injected via `mapGeometryProvider`; a real browser supplies
+  `liveGeometryProvider` (getBoundingClientRect + getComputedStyle).
+- **Deep layer** — `src/testing/__e2e__/run-widget-cert-e2e.mjs`
+  (`bun run test:widget-cert-e2e`) mounts the widgets in real Chromium/WebKit
+  and runs the SAME sweep against real layout, emitting evidence
+  (`output-widget-cert/{widget-cert.json,widget-cert.txt,<engine>.png}`).
+  Playwright is flaky in CI — the runner SKIPs (exit 0) if the browser can't
+  launch; the vitest static layer is the always-green gate.
+
+**To certify a NEW widget:**
+
+1. Give the widget's scroll container a `data-scroll-cert-scroller` attribute
+   (or reuse `#continuous-thread` / `[data-testid="chat-thread"]`), and make sure
+   every interactive control is a native control / has a `role` / is
+   `tabindex>=0` (the sweep only enforces the tap floor on real controls). A
+   control with an expanded hit area (padding / hitSlop) should report an
+   effective hit box via the provider; a genuinely non-pointer affordance opts
+   out with `data-tap-target="ignore"`.
+2. Add a `certifyWidget("my-widget", root, provider, { dimensions: [...] })` case
+   to `widget-cert.test.tsx` (static, always runs) — pick the dimensions that
+   apply (`scroll`, `tap-target`, `safe-area`, `keyboard`). Inject known-good and
+   known-broken geometry so the cert is proven, not just green-because-empty.
+3. Optionally add the widget to the deep fixture
+   (`__e2e__/widget-cert-fixture.tsx`) so it is also certified against real
+   layout when playwright can run.
+4. A cert FAILURE is an actionable per-control report (code + selector +
+   measurement). This harness only DETECTS — component sizing/layout fixes are
+   owned by the component's lane; route findings there.
+
 ## Config / env vars
 
 This package mostly reads config injected by the host, not raw env vars:

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -324,12 +324,14 @@ async function runDragSuite(p, pointer, tag) {
     grabberBarOpacity === "1",
     `[${pointer}] grabber bar paints (inner-span opacity "${grabberBarOpacity}" === "1", not opacity-0) (#9142)`,
   );
-  // The sheet header shows at HALF and up now, not only at FULL. Maximize and
-  // clear are gesture/state contracts, not header buttons.
+  // The sheet header shows at HALF and up now, not only at FULL. It carries the
+  // search + new-chat (clear) buttons and the launcher; maximize stays a
+  // gesture/state contract (over-pull), not a header button. #14300 restored the
+  // new-chat control, so chat-full-clear is present here.
   assert(
     (await p.getByTestId("chat-full-launcher").count()) === 1 &&
       (await p.getByTestId("chat-full-maximize").count()) === 0 &&
-      (await p.getByTestId("chat-full-clear").count()) === 0,
+      (await p.getByTestId("chat-full-clear").count()) === 1,
     `[${pointer}] HALF detent shows the sheet header`,
   );
 
@@ -346,14 +348,14 @@ async function runDragSuite(p, pointer, tag) {
   );
   await snap(p, `${tag}-full`);
 
-  // Header (post #13531/#9450): no maximize/minimize/new-chat buttons, only the
-  // launcher remains. The old Home/Views/Settings trio collapsed into that one
-  // launcher target.
+  // Header (post #13531/#9450, #14300): search + new-chat (clear) + launcher.
+  // There is no maximize/minimize header button — maximize is an over-pull
+  // gesture. The old Home/Views/Settings trio collapsed into the one launcher.
   assert(
     (await p.getByTestId("chat-full-launcher").count()) === 1 &&
       (await p.getByTestId("chat-full-maximize").count()) === 0 &&
-      (await p.getByTestId("chat-full-clear").count()) === 0,
-    `[${pointer}] header shows launcher without removed maximize/clear controls`,
+      (await p.getByTestId("chat-full-clear").count()) === 1,
+    `[${pointer}] header shows launcher + new-chat without a maximize button`,
   );
   // Maximize → full-bleed (edge-to-edge): a deliberate over-pull flips
   // data-maximized and the panel reaches x=0.


### PR DESCRIPTION
## What & why

Two independent CI gates are **red on `develop`** right now (found during an independent verify-closed sweep of the MVP board). Both are small, deterministic staleness fixes.

### 1. `bun run verify` is red (`check:agents-claude`, the first step)
`packages/ui/AGENTS.md` carries the **Scroll + tap-target certification** section (added for #14380 / PR #14457) that `packages/ui/CLAUDE.md` does **not** — so `scripts/assert-agents-claude-identical.mjs` exits 1, failing the very first step of `bun run verify` (blocks typecheck/lint CI repo-wide). The scroll-cert doc is legitimate and belongs in both; brought `CLAUDE.md` to parity.

```
BEFORE: [assert-agents-claude-identical] FAIL — packages/ui: CLAUDE.md and AGENTS.md differ
AFTER:  [assert-agents-claude-identical] PASS: 295 tracked CLAUDE.md/AGENTS.md pair(s) are byte-identical.
```

### 2. `test:chat-sheet-e2e` is red (`chat-shell-gestures` + `ui-e2e-gate` lanes)
The HALF and FULL header assertions in `run-chat-sheet-e2e.mjs:332,355` still require `chat-full-clear` **count === 0**, but #14300 **restored** the new-chat (clear) control — it is live at `ContinuousChatOverlay.tsx:4317` (RotateCcw, unconditional, next to `chat-full-search`). Flipped both to `=== 1` and corrected the now-wrong "no new-chat buttons" comments.

```
AFTER (re-run in-lane, mouse pass):
  ✓ [mouse] HALF detent shows the sheet header
  ✓ [mouse] header shows launcher + new-chat without a maximize button
  (all 26 mouse-pass assertions green)
```

## Evidence
- `check:agents-claude` before/after above (terminal).
- Full `test:chat-sheet-e2e` mouse pass green in-lane (the two previously-failing assertions now pass). Note: one *unrelated, pre-existing* flake was observed once (a `remove shot.png` click intercepted by the grabber's expanded `before:` hit-area) that passed on re-run — separate from this fix; not introduced here.
- Screenshots/video/trajectory: **N/A** — this is a docs-parity + stale-e2e-assertion CI fix, no product-behavior or UI change.

Refs #14332, #14341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)