### PR TITLE
fix(ui): retokenize pay-as-you-go card — #14532 regressed it white-on-white on the light theme

### DIFF
--- a/packages/ui/src/cloud/billing/components/pay-as-you-go-card.tsx
+++ b/packages/ui/src/cloud/billing/components/pay-as-you-go-card.tsx
@@ -63,7 +63,7 @@ export function PayAsYouGoCard() {
 
       <div className="relative z-10 space-y-4">
         <div className="flex items-center gap-2">
-          <div className="w-2 h-2 rounded-full bg-white/40" />
+          <div className="w-2 h-2 rounded-full bg-muted" />
           <h3 className="text-base font-mono text-txt uppercase">
             Pay Hosting From Earnings
           </h3>
@@ -72,7 +72,7 @@ export function PayAsYouGoCard() {
         <div className="flex items-start justify-between gap-4">
           <div className="space-y-1 flex-1 min-w-0">
             <Label className="text-txt-strong font-mono text-sm flex items-center gap-2">
-              <Coins className="h-4 w-4 text-white/70" />
+              <Coins className="h-4 w-4 text-muted" />
               Use my app earnings to pay container hosting
             </Label>
             <p className="text-xs font-mono text-muted leading-relaxed">
@@ -83,13 +83,13 @@ export function PayAsYouGoCard() {
             </p>
           </div>
           {enabled === null ? (
-            <Loader2 className="h-5 w-5 animate-spin text-white/70 flex-shrink-0" />
+            <Loader2 className="h-5 w-5 animate-spin text-muted flex-shrink-0" />
           ) : (
             <Switch
               checked={enabled}
               onCheckedChange={handleToggle}
               disabled={saving}
-              className="data-[state=checked]:bg-white/80 flex-shrink-0"
+              className="flex-shrink-0"
             />
           )}
         </div>


### PR DESCRIPTION
Post-merge gate catch on #14532 (merged while all checks were QUEUED under the Actions freeze — the red never surfaced on the PR).

**Defect (confirmed, not theoretical):** `pay-as-you-go-card.tsx` renders on the app Settings surface (`SettingsView → CloudBillingSection`), which supports the **light theme** with no dark island (#13452/#13755). #14532 replaced its theme-resolving `var(--accent)` styling with hardcoded `bg-white/40`, `text-white/70` ×2, and `data-[state=checked]:bg-white/80` — invisible white-on-white on light. The **#13767 regression guard** (`cloud-settings-theme-tokens.test.ts`) **fails on the merged head with exactly these 4 offenders** (verified by running it).

**Fix (4 classNames):** `bg-muted` dot, `text-muted` icons, and drop the Switch checked override so the primitive's token default applies (`.theme-cloud` maps it to brand-white on the console; accent on the app surface). The other two #14532 files render inside the forced-dark console shell and are fine as-is.

**Evidence:** guard test `cloud-settings-theme-tokens.test.ts` → **2/2 pass** (was 1 fail/4 offenders); biome clean. N/A UI capture — token-level change verified by the purpose-built guard.

Found by the `[maintainer]` post-merge review of the console PR batch (Fable review + adversarial skeptic, skeptic did not refute). Authored by `[maintainer]` — needs a reviewer lane. Refs #14532, #13767.