### PR TITLE
test(app): complete sparse-home OCR guard coverage for all seven removed widgets (#14343)

### DIFF
--- a/packages/app/scripts/mvp-visual-verify/expectations.json
+++ b/packages/app/scripts/mvp-visual-verify/expectations.json
@@ -41,7 +41,10 @@
         "Agent activity",
         "App runs",
         "Bills & Balance",
-        "Overdrawn"
+        "Overdrawn",
+        "Reach out",
+        "Inbox",
+        "Automations"
       ]
     }
   }

--- a/packages/app/test/audit/mvp-visual-verify.test.ts
+++ b/packages/app/test/audit/mvp-visual-verify.test.ts
@@ -373,7 +373,10 @@ describe("sparse-home OCR regression guard (#14343)", () => {
     return result.checks.find((c) => c.name === "ocr-text");
   }
 
-  it("declares expected-absent removed-widget tokens on builtin-chat", () => {
+  it("declares expected-absent tokens for all seven removed widgets on builtin-chat", () => {
+    // One signature token per removed widget so a regression re-mounting any of
+    // the seven on the home slot trips the guard: orchestrator activity, apps,
+    // feed activity, finances, relationships, inbox, workflow automations.
     expect(homeSpec.ocr.absent).toEqual(
       expect.arrayContaining([
         "orchestrator",
@@ -381,6 +384,9 @@ describe("sparse-home OCR regression guard (#14343)", () => {
         "App runs",
         "Bills & Balance",
         "Overdrawn",
+        "Reach out",
+        "Inbox",
+        "Automations",
       ]),
     );
   });
@@ -403,6 +409,9 @@ describe("sparse-home OCR regression guard (#14343)", () => {
       "App runs 2 live", // agent-orchestrator.apps
       "Bills & Balance overdue", // finances.alerts
       "Overdrawn by 40", // finances.alerts
+      "Reach out to Dana", // relationships.attention
+      "Inbox 3 unread", // inbox.unread
+      "Automations 2 running", // workflow.running
     ]) {
       const check = ocrCheck(`Good evening ${regressed}`);
       expect(check?.status, regressed).toBe("fail");


### PR DESCRIPTION
## Summary

Closes the remaining OCR-guard gap for #14343. The sparse home guard already existed on `develop`, but it only enforced signatures for five removed home-widget families. This completes the `builtin-chat` expected-absent list and its evaluator test so relationship, inbox, and workflow widgets also trip the guard if they reappear on the resting home.

## Change

- Adds `Reach out`, `Inbox`, and `Automations` to the `builtin-chat` forbidden OCR tokens.
- Extends the real `evaluateExpectations` regression test to prove all seven removed widget families fail when their signature text appears.

## Verification

```bash
bunx @biomejs/biome check packages/app/scripts/mvp-visual-verify/expectations.json packages/app/test/audit/mvp-visual-verify.test.ts
# Checked 2 files. No fixes applied.
```

```bash
bun run --cwd packages/app test -- test/audit/mvp-visual-verify.test.ts
# 1 file passed, 24 tests passed
```

```bash
bun run --cwd packages/app mvp:visual-verify -- --input ../../.codex-chat-audit --strict
# real builtin-chat screenshot subset: desktop-landscape, ipad-portrait, mobile-landscape, mobile-portrait
# OCR engine: system tesseract (/opt/homebrew/bin/tesseract)
# expectation failures: 0 | expectation skips: 0 | overflow states: 0 | new baselines: 0
```

Manual review of the targeted real-screenshot report:
- OCR did not contain any removed-widget signatures: `Reach out`, `Inbox`, `Automations`, `Agent activity`, `orchestrator`, `App runs`, `Bills & Balance`, or `Overdrawn`.
- On-screen text was the expected sparse chat/home surface: date/greeting, starter prompts, Ask Eliza composer, and weather prompt.
- Dominant palette stayed orange/neutral with no blue: orange ranged from 38.56% on mobile portrait to 84.10% on desktop landscape.
- Horizontal overflow was 0px in all four viewports.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - verification-rule-only change; rendered UI pixels are unchanged from the captured sparse-home baseline`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - verification-rule-only change; targeted real-screenshot OCR/palette/overflow verification is summarized above`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no user-facing interaction or rendered UI flow changed`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no backend path changed`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend runtime path changed; this only hardens the visual verifier expectation data and test`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent/action/provider/prompt/model behavior changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no DB, memory, scheduled-task, wallet, chain, generated-file, audio, or other domain artifact is produced`.

## Known gaps / failures

A full all-state `mvp:visual-verify --strict` over the reused main-worktree audit corpus was stopped because OCR across the full historical screenshot tree was too slow for this narrow patch. I reran strict verification against the four real `builtin-chat` screenshots from the newer audit corpus that includes `horizontalOverflowPx`; that is the affected state for this expectation change.
