### PR TITLE
fix(connectors): deliver imessage sensitive requests

### DIFF
--- a/plugins/plugin-bluebubbles/src/index.ts
+++ b/plugins/plugin-bluebubbles/src/index.ts
@@ -13,6 +13,7 @@ import {
 } from "@elizaos/core";
 import { createBlueBubblesConnectorAccountProvider } from "./connector-account-provider.js";
 import { blueBubblesDataRoutes } from "./data-routes.js";
+import { registerBlueBubblesDmSensitiveRequestAdapter } from "./sensitive-request-adapter.js";
 import { BlueBubblesService } from "./service.js";
 import {
 	blueBubblesSetupRoutes,
@@ -39,6 +40,10 @@ export {
 	createBlueBubblesConnectorAccountProvider,
 } from "./connector-account-provider.js";
 export * from "./constants.js";
+export {
+	blueBubblesDmSensitiveRequestAdapter,
+	registerBlueBubblesDmSensitiveRequestAdapter,
+} from "./sensitive-request-adapter.js";
 // Re-export types and service
 export * from "./types.js";
 export {
@@ -81,6 +86,7 @@ const blueBubblesPlugin: Plugin = {
 		runtime: IAgentRuntime,
 	): Promise<void> => {
 		logger.info("Initializing BlueBubbles plugin...");
+		registerBlueBubblesDmSensitiveRequestAdapter(runtime);
 
 		// Register the BlueBubbles provider with the ConnectorAccountManager so
 		// the HTTP CRUD surface (packages/agent/src/api/connector-account-routes.ts)

--- a/plugins/plugin-bluebubbles/src/sensitive-request-adapter.test.ts
+++ b/plugins/plugin-bluebubbles/src/sensitive-request-adapter.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Unit tests for the BlueBubbles sensitive-request adapter. The BlueBubbles
+ * service is stubbed so no macOS bridge or REST server is required.
+ */
+
+import type { IAgentRuntime, SensitiveRequest } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { BLUEBUBBLES_SERVICE_NAME } from "./constants";
+import { blueBubblesDmSensitiveRequestAdapter } from "./sensitive-request-adapter";
+
+function makeRequest(
+	overrides: Partial<SensitiveRequest> = {},
+): SensitiveRequest {
+	return {
+		id: "req-1",
+		kind: "oauth",
+		status: "pending",
+		agentId: "agent-1",
+		requesterEntityId: "iMessage;-;+14155552671",
+		target: { kind: "oauth", provider: "GitHub", scopes: ["repo"] },
+		policy: {
+			actor: "owner_or_linked_identity",
+			requirePrivateDelivery: true,
+			requireAuthenticatedLink: true,
+			allowInlineOwnerAppEntry: true,
+			allowPublicLink: false,
+			allowDmFallback: true,
+			allowTunnelLink: true,
+			allowCloudLink: true,
+		},
+		delivery: {
+			kind: "oauth",
+			source: "dm",
+			mode: "private_dm",
+			policy: {
+				actor: "owner_or_linked_identity",
+				requirePrivateDelivery: true,
+				requireAuthenticatedLink: true,
+				allowInlineOwnerAppEntry: true,
+				allowPublicLink: false,
+				allowDmFallback: true,
+				allowTunnelLink: true,
+				allowCloudLink: true,
+			},
+			privateRouteRequired: true,
+			publicLinkAllowed: false,
+			authenticated: false,
+			canCollectValueInCurrentChannel: true,
+			reason: "current channel is private",
+			instruction: "Open the app.",
+		},
+		callback: { url: "https://app.test/oauth/req-1" },
+		expiresAt: "2099-01-01T00:00:00.000Z",
+		createdAt: "2026-05-10T00:00:00.000Z",
+		updatedAt: "2026-05-10T00:00:00.000Z",
+		...overrides,
+	} as SensitiveRequest;
+}
+
+function makeRuntime(service: unknown): IAgentRuntime {
+	return {
+		getService: vi.fn((name: string) =>
+			name === BLUEBUBBLES_SERVICE_NAME ? service : null,
+		),
+	} as unknown as IAgentRuntime;
+}
+
+describe("blueBubblesDmSensitiveRequestAdapter", () => {
+	it("sends secure-link prose and returns delivered=true", async () => {
+		const sendMessage = vi.fn(async () => ({ guid: "bb-1" }));
+		const runtime = makeRuntime({ sendMessage });
+		const request = makeRequest();
+
+		const result = await blueBubblesDmSensitiveRequestAdapter.deliver({
+			request,
+			runtime,
+		});
+
+		expect(result).toEqual({
+			delivered: true,
+			target: "dm",
+			channelId: "iMessage;-;+14155552671",
+			url: "https://app.test/oauth/req-1",
+			expiresAt: request.expiresAt,
+		});
+		expect(sendMessage).toHaveBeenCalledWith(
+			"iMessage;-;+14155552671",
+			expect.stringContaining("https://app.test/oauth/req-1"),
+		);
+	});
+
+	it("returns delivered=false when no target is available", async () => {
+		const sendMessage = vi.fn();
+		const runtime = makeRuntime({ sendMessage });
+		const request = makeRequest({
+			requesterEntityId: null,
+			originUserId: null,
+		});
+
+		const result = await blueBubblesDmSensitiveRequestAdapter.deliver({
+			request,
+			runtime,
+		});
+
+		expect(result.delivered).toBe(false);
+		expect(result.error).toMatch(/no bluebubbles chat target/i);
+		expect(sendMessage).not.toHaveBeenCalled();
+	});
+
+	it("returns delivered=false when the service throws", async () => {
+		const runtime = makeRuntime({
+			sendMessage: vi.fn(async () => {
+				throw new Error("bridge down");
+			}),
+		});
+
+		const result = await blueBubblesDmSensitiveRequestAdapter.deliver({
+			request: makeRequest(),
+			runtime,
+		});
+
+		expect(result).toMatchObject({
+			delivered: false,
+			target: "dm",
+			channelId: "iMessage;-;+14155552671",
+			error: "bridge down",
+		});
+	});
+});

--- a/plugins/plugin-bluebubbles/src/sensitive-request-adapter.ts
+++ b/plugins/plugin-bluebubbles/src/sensitive-request-adapter.ts
@@ -95,6 +95,7 @@ async function deliverViaBlueBubbles(args: {
 			expiresAt: request.expiresAt,
 		};
 	} catch (err) {
+		// error-policy:J1 boundary translation — adapter delivery reports a typed failure result.
 		const message = err instanceof Error ? err.message : String(err);
 		logger.warn(
 			{ src: "bluebubbles:sensitive-request-adapter", err: message },
@@ -137,6 +138,7 @@ export function registerBlueBubblesDmSensitiveRequestAdapter(
 			registry.register(blueBubblesDmSensitiveRequestAdapter);
 			return true;
 		} catch (err) {
+			// error-policy:J1 boundary translation — plugin init must continue while the registry observes no adapter.
 			logger.warn(
 				{
 					src: "bluebubbles:sensitive-request-adapter",

--- a/plugins/plugin-bluebubbles/src/sensitive-request-adapter.ts
+++ b/plugins/plugin-bluebubbles/src/sensitive-request-adapter.ts
@@ -1,0 +1,155 @@
+/**
+ * BlueBubbles delivery adapter for sensitive requests.
+ *
+ * The bridge can only send text through iMessage/SMS, so the adapter delivers
+ * secure-link prose and reports explicit failures instead of letting secret or
+ * OAuth requests disappear when targeted at a BlueBubbles-backed DM.
+ */
+
+import {
+	type DeliveryResult,
+	type DispatchSensitiveRequest,
+	type IAgentRuntime,
+	logger,
+	type SensitiveRequest,
+	type SensitiveRequestDeliveryAdapter,
+} from "@elizaos/core";
+import { BLUEBUBBLES_SERVICE_NAME } from "./constants";
+import type { BlueBubblesService } from "./service";
+
+type BlueBubblesDispatchRequest = DispatchSensitiveRequest &
+	Partial<SensitiveRequest>;
+
+const SENSITIVE_REQUEST_DISPATCH_REGISTRY_SERVICE_NAME =
+	"SensitiveRequestDispatchRegistry";
+
+function resolveTarget(
+	request: BlueBubblesDispatchRequest,
+	channelId?: string,
+): string | undefined {
+	const candidate =
+		channelId ?? request.requesterEntityId ?? request.originUserId;
+	return typeof candidate === "string" && candidate.trim().length > 0
+		? candidate.trim()
+		: undefined;
+}
+
+function resolveLink(request: BlueBubblesDispatchRequest): string | undefined {
+	return request.callback?.url ?? request.delivery?.linkBaseUrl ?? undefined;
+}
+
+function buildSensitiveRequestText(
+	request: BlueBubblesDispatchRequest,
+): string {
+	const reason = request.delivery?.reason ?? "A sensitive value is required.";
+	const instruction =
+		request.delivery?.instruction ??
+		"Please open the Eliza app to provide this value.";
+	const link = resolveLink(request);
+	const lines = ["A sensitive value is needed to continue.", reason];
+	lines.push(
+		link ? `Open this secure link to provide it: ${link}` : instruction,
+	);
+	if (request.expiresAt) {
+		lines.push(`This request expires at ${request.expiresAt}.`);
+	}
+	return lines.join("\n");
+}
+
+async function deliverViaBlueBubbles(args: {
+	request: DispatchSensitiveRequest;
+	channelId?: string;
+	runtime: unknown;
+}): Promise<DeliveryResult> {
+	const runtime = args.runtime as IAgentRuntime;
+	const request = args.request as BlueBubblesDispatchRequest;
+	const target = resolveTarget(request, args.channelId);
+	if (!target) {
+		return {
+			delivered: false,
+			target: "dm",
+			error:
+				"No BlueBubbles chat target available (need targetChannelId or originUserId)",
+		};
+	}
+
+	const service = runtime.getService?.(BLUEBUBBLES_SERVICE_NAME) as
+		| BlueBubblesService
+		| null
+		| undefined;
+	if (!service) {
+		return {
+			delivered: false,
+			target: "dm",
+			error: "BlueBubbles service unavailable",
+		};
+	}
+
+	try {
+		await service.sendMessage(target, buildSensitiveRequestText(request));
+		return {
+			delivered: true,
+			target: "dm",
+			channelId: target,
+			url: resolveLink(request),
+			expiresAt: request.expiresAt,
+		};
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		logger.warn(
+			{ src: "bluebubbles:sensitive-request-adapter", err: message },
+			"Failed to deliver sensitive request via BlueBubbles",
+		);
+		return {
+			delivered: false,
+			target: "dm",
+			channelId: target,
+			error: message,
+		};
+	}
+}
+
+export const blueBubblesDmSensitiveRequestAdapter: SensitiveRequestDeliveryAdapter =
+	{
+		target: "dm",
+		supportsChannel: (_channelId, runtime) =>
+			Boolean(
+				(runtime as IAgentRuntime | undefined)?.getService?.(
+					BLUEBUBBLES_SERVICE_NAME,
+				),
+			),
+		deliver: (args) => deliverViaBlueBubbles(args),
+	};
+
+interface DispatchRegistryLike {
+	register: (adapter: SensitiveRequestDeliveryAdapter) => void;
+}
+
+export function registerBlueBubblesDmSensitiveRequestAdapter(
+	runtime: IAgentRuntime,
+): void {
+	const tryRegister = (): boolean => {
+		const registry = runtime.getService?.(
+			SENSITIVE_REQUEST_DISPATCH_REGISTRY_SERVICE_NAME,
+		) as DispatchRegistryLike | null | undefined;
+		if (!registry || typeof registry.register !== "function") return false;
+		try {
+			registry.register(blueBubblesDmSensitiveRequestAdapter);
+			return true;
+		} catch (err) {
+			logger.warn(
+				{
+					src: "bluebubbles:sensitive-request-adapter",
+					err: err instanceof Error ? err.message : String(err),
+				},
+				"Failed to register BlueBubbles DM adapter with SensitiveRequestDispatchRegistry",
+			);
+			return true;
+		}
+	};
+
+	if (tryRegister()) return;
+	setImmediate(() => {
+		tryRegister();
+	});
+}

--- a/plugins/plugin-imessage/src/index.ts
+++ b/plugins/plugin-imessage/src/index.ts
@@ -9,6 +9,7 @@ import { platform } from "node:os";
 import { getConnectorAccountManager, type IAgentRuntime, logger, type Plugin } from "@elizaos/core";
 import { createIMessageConnectorAccountProvider } from "./connector-account-provider.js";
 import { imessageDataRoutes } from "./data-routes.js";
+import { registerIMessageDmSensitiveRequestAdapter } from "./sensitive-request-adapter.js";
 // No send action is registered here: outbound delivery is the MessageConnector
 // registered by IMessageService.registerSendHandlers, driven via MESSAGE
 // operation=send.
@@ -87,6 +88,10 @@ export {
   probeIMessageRpc,
   sendIMessageRpc,
 } from "./rpc.js";
+export {
+  imessageDmSensitiveRequestAdapter,
+  registerIMessageDmSensitiveRequestAdapter,
+} from "./sensitive-request-adapter.js";
 // Re-export types and service
 export * from "./types.js";
 export {
@@ -145,6 +150,7 @@ const imessagePlugin: Plugin = {
 
     // Register the cross-connector triage adapter for the "imessage" source.
     registerIMessageTriageAdapter();
+    registerIMessageDmSensitiveRequestAdapter(runtime);
 
     const isMacOS = platform() === "darwin";
 

--- a/plugins/plugin-imessage/src/sensitive-request-adapter.test.ts
+++ b/plugins/plugin-imessage/src/sensitive-request-adapter.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for the iMessage sensitive-request adapter. The service is stubbed
+ * so the tests verify dispatch behavior without macOS Messages.app.
+ */
+
+import type { IAgentRuntime, SensitiveRequest } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core", async () => await vi.importActual("@elizaos/core"));
+
+import { imessageDmSensitiveRequestAdapter } from "./sensitive-request-adapter";
+import { IMessageService } from "./service";
+
+function makeRequest(overrides: Partial<SensitiveRequest> = {}): SensitiveRequest {
+  return {
+    id: "req-1",
+    kind: "secret",
+    status: "pending",
+    agentId: "agent-1",
+    requesterEntityId: "+14155552671",
+    target: { kind: "secret", key: "OPENAI_API_KEY" },
+    policy: {
+      actor: "owner_or_linked_identity",
+      requirePrivateDelivery: true,
+      requireAuthenticatedLink: true,
+      allowInlineOwnerAppEntry: true,
+      allowPublicLink: false,
+      allowDmFallback: true,
+      allowTunnelLink: true,
+      allowCloudLink: true,
+    },
+    delivery: {
+      kind: "secret",
+      source: "dm",
+      mode: "private_dm",
+      policy: {
+        actor: "owner_or_linked_identity",
+        requirePrivateDelivery: true,
+        requireAuthenticatedLink: true,
+        allowInlineOwnerAppEntry: true,
+        allowPublicLink: false,
+        allowDmFallback: true,
+        allowTunnelLink: true,
+        allowCloudLink: true,
+      },
+      privateRouteRequired: true,
+      publicLinkAllowed: false,
+      authenticated: false,
+      canCollectValueInCurrentChannel: true,
+      reason: "current channel is private",
+      instruction: "Open the app.",
+    },
+    callback: { url: "https://app.test/secret/req-1" },
+    expiresAt: "2099-01-01T00:00:00.000Z",
+    createdAt: "2026-05-10T00:00:00.000Z",
+    updatedAt: "2026-05-10T00:00:00.000Z",
+    ...overrides,
+  } as SensitiveRequest;
+}
+
+function makeRuntime(service: unknown): IAgentRuntime {
+  return {
+    getService: vi.fn((name: string) => (name === IMessageService.serviceType ? service : null)),
+  } as unknown as IAgentRuntime;
+}
+
+describe("imessageDmSensitiveRequestAdapter", () => {
+  it("sends only secure-link prose and returns delivered=true", async () => {
+    const sendMessage = vi.fn(async () => ({ success: true, messageId: "m-1" }));
+    const runtime = makeRuntime({ sendMessage });
+    const request = makeRequest();
+
+    const result = await imessageDmSensitiveRequestAdapter.deliver({
+      request,
+      runtime,
+    });
+
+    expect(result).toEqual({
+      delivered: true,
+      target: "dm",
+      channelId: "+14155552671",
+      url: "https://app.test/secret/req-1",
+      expiresAt: request.expiresAt,
+    });
+    expect(sendMessage).toHaveBeenCalledWith(
+      "+14155552671",
+      expect.stringContaining("https://app.test/secret/req-1")
+    );
+    expect(sendMessage.mock.calls[0]?.[1]).not.toContain("OPENAI_API_KEY=");
+  });
+
+  it("returns delivered=false when no target handle is available", async () => {
+    const sendMessage = vi.fn();
+    const runtime = makeRuntime({ sendMessage });
+    const request = makeRequest({ requesterEntityId: null, originUserId: null });
+
+    const result = await imessageDmSensitiveRequestAdapter.deliver({
+      request,
+      runtime,
+    });
+
+    expect(result.delivered).toBe(false);
+    expect(result.error).toMatch(/no imessage handle/i);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns delivered=false when the service send fails", async () => {
+    const runtime = makeRuntime({
+      sendMessage: vi.fn(async () => ({ success: false, error: "not delivered" })),
+    });
+
+    const result = await imessageDmSensitiveRequestAdapter.deliver({
+      request: makeRequest(),
+      runtime,
+    });
+
+    expect(result).toMatchObject({
+      delivered: false,
+      target: "dm",
+      channelId: "+14155552671",
+      error: "not delivered",
+    });
+  });
+});

--- a/plugins/plugin-imessage/src/sensitive-request-adapter.ts
+++ b/plugins/plugin-imessage/src/sensitive-request-adapter.ts
@@ -90,6 +90,7 @@ async function deliverViaIMessage(args: {
       expiresAt: request.expiresAt,
     };
   } catch (err) {
+    // error-policy:J1 boundary translation — adapter delivery reports a typed failure result.
     const message = err instanceof Error ? err.message : String(err);
     logger.warn(
       { src: "imessage:sensitive-request-adapter", err: message },
@@ -121,6 +122,7 @@ export function registerIMessageDmSensitiveRequestAdapter(runtime: IAgentRuntime
       registry.register(imessageDmSensitiveRequestAdapter);
       return true;
     } catch (err) {
+      // error-policy:J1 boundary translation — plugin init must continue while the registry observes no adapter.
       logger.warn(
         {
           src: "imessage:sensitive-request-adapter",

--- a/plugins/plugin-imessage/src/sensitive-request-adapter.ts
+++ b/plugins/plugin-imessage/src/sensitive-request-adapter.ts
@@ -1,0 +1,139 @@
+/**
+ * iMessage delivery adapter for sensitive requests.
+ *
+ * Secrets and OAuth grants must never be collected through the chat text
+ * transport. This adapter sends only the secure entry link or fallback
+ * instruction through the existing iMessage service and reports explicit
+ * delivery failures when no handle or service is available.
+ */
+
+import {
+  type DeliveryResult,
+  type DispatchSensitiveRequest,
+  type IAgentRuntime,
+  logger,
+  type SensitiveRequest,
+  type SensitiveRequestDeliveryAdapter,
+} from "@elizaos/core";
+import { IMessageService } from "./service.js";
+
+type IMessageDispatchRequest = DispatchSensitiveRequest & Partial<SensitiveRequest>;
+
+const SENSITIVE_REQUEST_DISPATCH_REGISTRY_SERVICE_NAME = "SensitiveRequestDispatchRegistry";
+
+function resolveTargetHandle(
+  request: IMessageDispatchRequest,
+  channelId?: string
+): string | undefined {
+  const candidate = channelId ?? request.requesterEntityId ?? request.originUserId;
+  return typeof candidate === "string" && candidate.trim().length > 0
+    ? candidate.trim()
+    : undefined;
+}
+
+function resolveLink(request: IMessageDispatchRequest): string | undefined {
+  return request.callback?.url ?? request.delivery?.linkBaseUrl ?? undefined;
+}
+
+function buildSensitiveRequestText(request: IMessageDispatchRequest): string {
+  const reason = request.delivery?.reason ?? "A sensitive value is required.";
+  const instruction =
+    request.delivery?.instruction ?? "Please open the Eliza app to provide this value.";
+  const link = resolveLink(request);
+  const lines = ["A sensitive value is needed to continue.", reason];
+  lines.push(link ? `Open this secure link to provide it: ${link}` : instruction);
+  if (request.expiresAt) {
+    lines.push(`This request expires at ${request.expiresAt}.`);
+  }
+  return lines.join("\n");
+}
+
+async function deliverViaIMessage(args: {
+  request: DispatchSensitiveRequest;
+  channelId?: string;
+  runtime: unknown;
+}): Promise<DeliveryResult> {
+  const runtime = args.runtime as IAgentRuntime;
+  const request = args.request as IMessageDispatchRequest;
+  const target = resolveTargetHandle(request, args.channelId);
+  if (!target) {
+    return {
+      delivered: false,
+      target: "dm",
+      error: "No iMessage handle available (need targetChannelId or originUserId)",
+    };
+  }
+
+  const service = runtime.getService?.(IMessageService.serviceType) as
+    | IMessageService
+    | null
+    | undefined;
+  if (!service) {
+    return { delivered: false, target: "dm", error: "iMessage service unavailable" };
+  }
+
+  try {
+    const result = await service.sendMessage(target, buildSensitiveRequestText(request));
+    if (!result.success) {
+      return {
+        delivered: false,
+        target: "dm",
+        channelId: target,
+        error: result.error ?? "iMessage send failed",
+      };
+    }
+    return {
+      delivered: true,
+      target: "dm",
+      channelId: target,
+      url: resolveLink(request),
+      expiresAt: request.expiresAt,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warn(
+      { src: "imessage:sensitive-request-adapter", err: message },
+      "Failed to deliver sensitive request via iMessage"
+    );
+    return { delivered: false, target: "dm", channelId: target, error: message };
+  }
+}
+
+export const imessageDmSensitiveRequestAdapter: SensitiveRequestDeliveryAdapter = {
+  target: "dm",
+  supportsChannel: (_channelId, runtime) =>
+    Boolean((runtime as IAgentRuntime | undefined)?.getService?.(IMessageService.serviceType)),
+  deliver: (args) => deliverViaIMessage(args),
+};
+
+interface DispatchRegistryLike {
+  register: (adapter: SensitiveRequestDeliveryAdapter) => void;
+}
+
+export function registerIMessageDmSensitiveRequestAdapter(runtime: IAgentRuntime): void {
+  const tryRegister = (): boolean => {
+    const registry = runtime.getService?.(SENSITIVE_REQUEST_DISPATCH_REGISTRY_SERVICE_NAME) as
+      | DispatchRegistryLike
+      | null
+      | undefined;
+    if (!registry || typeof registry.register !== "function") return false;
+    try {
+      registry.register(imessageDmSensitiveRequestAdapter);
+      return true;
+    } catch (err) {
+      logger.warn(
+        {
+          src: "imessage:sensitive-request-adapter",
+          err: err instanceof Error ? err.message : String(err),
+        },
+        "Failed to register iMessage DM adapter with SensitiveRequestDispatchRegistry"
+      );
+      return true;
+    }
+  };
+
+  if (tryRegister()) return;
+  setImmediate(() => {
+    tryRegister();
+  });
+}


### PR DESCRIPTION
## Summary
- Register iMessage and BlueBubbles `dm` sensitive-request adapters.
- Deliver only secure-link/instruction prose through existing connector services; no secret/OAuth value is collected in chat text.
- Return explicit `delivered:false` results for missing targets, missing services, and send failures.

Refs #14525. This completes the sensitive-request adapter side when paired with #14553's marker fallback work. Keep #14525 open until both PRs merge and real platform evidence is attached.

## Validation
- `bun run --cwd plugins/plugin-imessage test src/sensitive-request-adapter.test.ts` - pass, 3 tests.
- `bun run --cwd plugins/plugin-bluebubbles test src/sensitive-request-adapter.test.ts` - pass, 3 tests.
- `bunx @biomejs/biome check plugins/plugin-imessage/src/index.ts plugins/plugin-imessage/src/sensitive-request-adapter.ts plugins/plugin-imessage/src/sensitive-request-adapter.test.ts plugins/plugin-bluebubbles/src/index.ts plugins/plugin-bluebubbles/src/sensitive-request-adapter.ts plugins/plugin-bluebubbles/src/sensitive-request-adapter.test.ts` - pass.
- `git diff --check origin/develop...HEAD` - pass.
- `bun run audit:error-policy-ratchet --report` - pass; no new empty catches or server console calls in touched production files.
- `bun run --cwd plugins/plugin-imessage typecheck` - pass after resolving this worktree's `@elizaos/core` to local source/dist.
- `bun run --cwd plugins/plugin-bluebubbles typecheck` - pass after resolving this worktree's `@elizaos/core` to local source/dist.

## Evidence Gate
<!-- evidence-row:before-screenshots -->
- [ ] N/A - no macOS Messages/BlueBubbles account is reachable from this host to capture the missing sensitive-request delivery before state.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - deterministic adapter tests prove the text sent to the service; real platform screenshots remain required before closing #14525.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no real iMessage/BlueBubbles service is available in this environment for a platform walkthrough.
<!-- evidence-row:backend-logs -->
- [ ] N/A - this adapter is exercised through focused unit tests with stubbed connector services; real service logs should be attached from the fleet run before closing #14525.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser frontend path is touched.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent prompt/model/provider/action selection behavior changes; this is connector delivery plumbing for an existing sensitive-request dispatch envelope.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - domain artifact is the outbound connector text body and `DeliveryResult`; tests assert secure-link prose and explicit failure results for no target/service/send failure.

## Notes
The branch was rebased so the diff is limited to six files: adapter + adapter tests + plugin registrations for iMessage and BlueBubbles.
