### PR TITLE
fix(ui): normalize top/bottom padding across all views

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -137,8 +137,12 @@ import { confirmDesktopAction } from "./utils/desktop-dialogs";
 import { VoiceSelfTestShell } from "./voice/voice-selftest/VoiceSelfTestShell";
 import { VoiceWorkbenchShell } from "./voice/voice-selftest/VoiceWorkbenchShell";
 
-const MOBILE_NAV_PADDING_CLASS =
-  "pb-[calc(var(--eliza-mobile-nav-offset,0px)+max(var(--safe-area-bottom,0px),var(--android-gesture-inset-bottom,0px))+var(--eliza-continuous-chat-clearance,5.25rem))]";
+// NOTE (#view-padding-normalize): the full floating-composer + bottom-nav +
+// safe-area bottom clearance is owned EXACTLY ONCE by the scroll region a view
+// mounts into (`TabScrollView` / `TabContentView` inner scroller, complemented
+// by `AppWorkspaceChrome`'s safe-area floor). The routed `<main>`
+// (`routedShellMainClass`) deliberately does NOT re-apply that clearance —
+// doing so double-counted it and left an oversized empty band under every view.
 type ExtractComponent<TValue> =
   TValue extends ComponentType<infer Props> ? ComponentType<Props> : never;
 
@@ -1655,18 +1659,25 @@ function ChatRouteShellContent(props: ShellContentProps): ReactNode {
 }
 
 function routedShellMainClass(tab: string): string {
-  // One tight page gutter for every routed view: minimal top so headers sit
-  // right under the chrome, a small side gutter, modest bottom. Views that own
-  // their full surface (browser/apps/views/background) still get zero padding.
+  // One tight page gutter for every routed view: a small side gutter + the
+  // standard `--view-pad-top` content gutter, and NOTHING at the bottom. This
+  // `<main>` is `overflow-hidden` — the real scroll owner (and therefore the
+  // sole owner of the bottom safe-area + floating-composer clearance) is the
+  // view wrapper mounted inside it (`TabScrollView`/`TabContentView`/
+  // `AppWorkspaceChrome`). Adding a bottom pad here on a non-scrolling box
+  // double-counted the clearance the wrapper already reserves, leaving an
+  // oversized empty band under every view (the recurring "too much space at the
+  // bottom" report). Bottom clearance is reserved exactly once, downstream.
+  // Views that own their full surface (browser/apps/views/background) still get
+  // zero padding.
   const pagePadding =
     tab === "browser" ||
     tab === "apps" ||
     tab === "views" ||
     tab === "background"
       ? ""
-      : "px-2 sm:px-3 pt-2 pb-4";
-  const mobilePadding = tab === "browser" ? "" : MOBILE_NAV_PADDING_CLASS;
-  return `flex flex-1 min-h-0 min-w-0 overflow-hidden ${pagePadding} ${mobilePadding}`;
+      : "px-2 sm:px-3 pt-[var(--view-pad-top)]";
+  return `flex flex-1 min-h-0 min-w-0 overflow-hidden ${pagePadding}`;
 }
 
 /**

--- a/packages/ui/src/components/pages/AutomationsFeed.tsx
+++ b/packages/ui/src/components/pages/AutomationsFeed.tsx
@@ -466,7 +466,7 @@ export function AutomationsFeed({
       {/* Flat — no card/border. The shell owns the page's horizontal padding. */}
       <div
         data-testid="automations-shell"
-        className="device-layout mx-auto flex w-full max-w-5xl flex-col gap-4 px-4 py-4 lg:px-6"
+        className="device-layout mx-auto flex w-full max-w-5xl flex-col gap-4 px-4 pt-[var(--view-pad-top)] pb-[var(--view-pad-bottom)] lg:px-6"
       >
         <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
           {overviewStats.map((stat) => (
@@ -951,7 +951,7 @@ function WorkflowEditorLoader({
     );
   }
   return (
-    <div className="device-layout mx-auto flex h-full w-full max-w-7xl flex-col gap-4 px-4 py-4 lg:px-6">
+    <div className="device-layout mx-auto flex h-full w-full max-w-7xl flex-col gap-4 px-4 pt-[var(--view-pad-top)] pb-[var(--view-pad-bottom)] lg:px-6">
       <WorkflowEditor
         initial={fetchState.data}
         onSaved={onSaved}

--- a/packages/ui/src/components/pages/BackgroundView.tsx
+++ b/packages/ui/src/components/pages/BackgroundView.tsx
@@ -13,7 +13,11 @@ import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
 export function BackgroundView() {
   return (
     <ShellViewAgentSurface viewId="background">
-      <div className="relative flex min-h-0 flex-1 flex-col items-center justify-center px-4 pb-28 pt-6">
+      {/* This view renders WITHOUT a shell scroll wrapper (the `background` tab
+          is full-bleed on the transparent shell), so it owns its own bottom
+          clearance: the floating-composer + bottom-nav + safe-area stack, plus
+          the standard `--view-pad-top` gutter. No magic `pb-28`. */}
+      <div className="relative flex min-h-0 flex-1 flex-col items-center justify-center px-4 pt-[var(--view-pad-top)] pb-[calc(var(--eliza-mobile-nav-offset,0px)+max(var(--safe-area-bottom,0px),var(--android-gesture-inset-bottom,0px))+var(--eliza-continuous-chat-clearance,5.25rem)+1rem)]">
         <h1 className="sr-only">Background</h1>
         <BackgroundSettingsControls />
       </div>

--- a/packages/ui/src/components/pages/FilesView.tsx
+++ b/packages/ui/src/components/pages/FilesView.tsx
@@ -513,7 +513,7 @@ function FilesViewBody() {
 
   return (
     <section
-      className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4 py-5 sm:px-6"
+      className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4 pt-[var(--view-pad-top)] pb-[var(--view-pad-bottom)] sm:px-6"
       data-testid="files-view"
       aria-label={t("filesview.title", { defaultValue: "Files" })}
       aria-busy={loading}

--- a/packages/ui/src/components/pages/KnowledgeView.tsx
+++ b/packages/ui/src/components/pages/KnowledgeView.tsx
@@ -12,7 +12,7 @@ export function KnowledgeView() {
   return (
     <ShellViewAgentSurface viewId="documents">
       <div className="flex h-full min-h-0 w-full flex-col">
-        <div className="mx-auto flex min-h-0 w-full min-w-0 max-w-4xl flex-1 flex-col px-4 pb-4 sm:px-5 lg:px-6">
+        <div className="mx-auto flex min-h-0 w-full min-w-0 max-w-4xl flex-1 flex-col px-4 pb-[var(--view-pad-bottom)] sm:px-5 lg:px-6">
           <DocumentsView standalone fileInputId="knowledge-hub-upload" />
         </div>
       </div>

--- a/packages/ui/src/styles/base.css
+++ b/packages/ui/src/styles/base.css
@@ -146,6 +146,19 @@
   --min-touch-target: 2.75rem;
   --eliza-mobile-nav-offset: 0px;
 
+  /* ── Per-view content padding (#14-view-padding-normalize) ──────────────
+     The STANDARD top/bottom gutter a routed view puts around its OWN content.
+     Deliberately small: the app FRAME already reserves the status-bar safe
+     area (App.tsx app-column `padding-top`) and the shared view wrappers
+     (`TabScrollView`/`TabContentView`/`AppWorkspaceChrome`) already reserve the
+     bottom safe-area + floating-composer clearance. So a view must NOT re-add
+     `env(safe-area-*)`, `--safe-area-top/bottom`, `--eliza-mobile-nav-offset`,
+     or `--eliza-continuous-chat-clearance` itself — that double-pads. It only
+     adds these tight content gutters on top of the frame the shell gives it.
+     One token per axis so the whole app breathes on one rhythm. */
+  --view-pad-top: 0.5rem;
+  --view-pad-bottom: 1rem;
+
   /* Plugin UI Design Tokens */
   --plugin-field-gap: 1rem;
   --plugin-group-gap: 1.5rem;


### PR DESCRIPTION
## What

Normalizes top/bottom padding across all routed app views. There was inconsistent/excess padding that read as sloppy layout on the installed PWA — the recurring "too much space at the top/bottom" report.

## Root cause

Bottom padding was **double/triple-counted**:

- The app **frame** (`App.tsx` app-column) reserves the status-bar safe area (`padding-top`).
- The routed `<main>` (`routedShellMainClass`) is `overflow-hidden` and ALSO added `pb-4` + the full `MOBILE_NAV_PADDING_CLASS` (nav-offset + safe-area-bottom + composer clearance).
- The view scroll wrappers (`TabScrollView` / `TabContentView` inner scroller + `AppWorkspaceChrome`'s safe-area floor) ALSO reserve that exact bottom clearance.

So the non-scrolling `<main>` reserved a bottom band the wrapper already reserved → an oversized empty gap under every view. Top padding was similarly uneven (`pt-2` on main + per-view `pt-6`/`py-4`/`py-5`).

## The standard (documented in `base.css`)

Safe-area + composer clearance is the **frame's job**, owned exactly once by the scroll region. Views only add tight content gutters via two new tokens:

- `--view-pad-top: 0.5rem`
- `--view-pad-bottom: 1rem`

Views must **not** re-add `env(safe-area-*)`, `--safe-area-top/bottom`, `--eliza-mobile-nav-offset`, or `--eliza-continuous-chat-clearance` themselves.

## Changes (per-view padding only)

| File | Before | After |
|---|---|---|
| `App.tsx` `routedShellMainClass` | `px-2 sm:px-3 pt-2 pb-4` + `MOBILE_NAV_PADDING_CLASS` (bottom clearance) | `px-2 sm:px-3 pt-[var(--view-pad-top)]` — bottom clearance dropped (owned by wrapper) |
| `AutomationsFeed` (feed + editor) | `px-4 py-4` | `px-4 pt-[--view-pad-top] pb-[--view-pad-bottom]` |
| `FilesView` | `px-4 py-5` | `px-4 pt-[--view-pad-top] pb-[--view-pad-bottom]` |
| `KnowledgeView` | `px-4 pb-4` | `px-4 pb-[--view-pad-bottom]` |
| `BackgroundView` (wrapper-less full-bleed) | `px-4 pb-28 pt-6` (magic `pb-28`) | `px-4 pt-[--view-pad-top] pb-[composer+navoffset+safe-area+1rem]` (proper formula, no magic px) |
| `base.css` | — | new `--view-pad-top` / `--view-pad-bottom` tokens + standard doc comment |

## Scope discipline

- Did NOT touch root geometry / safe-area frame (reclaim-bottom lane): `base.css` body/#root blocks, `App.tsx` composer safe-area padding, and the scroll wrappers' own clearance are untouched. My `base.css` change is a new token block only.
- Did NOT touch settings IA (settings-overhaul) or the background picker (bg-longpress) — only `BackgroundView`'s own container padding.
- Full-bleed surfaces (browser/apps/views/background) keep zero shell padding.

## Verify

- `cd packages/app && bun run build` → green (`✓ built in 1m 2s`, exit 0)
- biome clean on all 6 changed files
- Pre-existing failures NOT caused by this lane (confirmed on pristine `origin/develop`): `no-backdrop-blur-gate` (BuildBadge/ContinuousChatOverlay/NotificationsHomeCenter — untouched) and `App.navigate-view-wiring` `useIntervalWhenDocumentVisible` hooks-mock gap.

— [sol-orch]
