### PR TITLE
chore(#14374): commit in-repo Railway voice service defs + scheduled live contract lane

### DIFF
--- a/.github/workflows/voice-live-e2e.yml
+++ b/.github/workflows/voice-live-e2e.yml
@@ -6,6 +6,9 @@ name: Voice Live E2E
 # self-hosted model-heavy nightly / workflow_dispatch lane.
 #
 # What it proves (no mocks at any stage):
+#   - Live Railway voice contract: the free-cloud Kokoro TTS + Whisper STT
+#     services (packages/cloud/services/voice-*) satisfy the exact request shapes
+#     the cloud-api voice routes send, so a dead/drifted service is a red run.
 #   - Real fused ASR: the provisioned libelizainference + ASR bundle
 #     transcribes real speech.
 #   - Real fused Kokoro TTS: the provisioned libelizainference loads the
@@ -39,6 +42,11 @@ on:
     - cron: "30 8 * * *"
   workflow_dispatch:
     inputs:
+      run_railway_contract:
+        description: "Run the Railway Kokoro/Whisper live contract lane"
+        required: false
+        default: true
+        type: boolean
       run_macos_electrobun:
         description: "Attempt the macOS Electrobun live-voice matrix lane"
         required: false
@@ -100,6 +108,40 @@ jobs:
           name: voice-platform-matrix-index
           path: ${{ runner.temp }}/voice-platform-matrix
           if-no-files-found: error
+
+  # Live contract against the two Railway voice services (Kokoro TTS + Whisper
+  # STT). It runs the in-repo round-trip test (voice-kokoro-whisper-live.test.ts,
+  # which was referenced by zero workflows) so a dead or drifted service pages as
+  # a red run instead of a silent user report. Hits public HTTPS only, so it runs
+  # on a cheap GitHub-hosted runner — no GPU/self-hosted staging. The service URLs
+  # come from repo variables set at deploy time (see the two service READMEs under
+  # packages/cloud/services/voice-*); the test falls back to its own defaults when
+  # they are unset, so the lane still exercises the provisioned instances.
+  voice-railway-contract:
+    name: Railway Kokoro/Whisper live contract
+    if: ${{ github.event_name == 'schedule' || inputs.run_railway_contract }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    env:
+      ELIZA_VOICE_LIVE_RAILWAY: "1"
+      KOKORO_TTS_URL: ${{ vars.ELIZA_VOICE_KOKORO_TTS_URL }}
+      WHISPER_STT_URL: ${{ vars.ELIZA_VOICE_WHISPER_STT_URL }}
+      WHISPER_STT_MODEL: ${{ vars.ELIZA_VOICE_WHISPER_STT_MODEL }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          show-progress: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Run live Railway voice contract
+        run: |
+          set -euo pipefail
+          bun test packages/cloud/api/__tests__/voice-kokoro-whisper-live.test.ts
 
   voice-roundtrip:
     name: Real fused ASR + optional mixed round-trip (self-hosted)

--- a/packages/cloud/infra/cloud/RAILWAY.md
+++ b/packages/cloud/infra/cloud/RAILWAY.md
@@ -11,6 +11,8 @@ is heading.
 | `cloud-api` (REST + auth + billing) | Cloudflare Worker | `packages/cloud/api/` | `apps/api/wrangler.toml` (env vars, secrets via `wrangler secret`) |
 | `headscale` (Tailscale coordination server for agents + customer tunnels) | Hetzner control-plane VM | `packages/cloud/services/headscale/` | armed via `arm-headscale-control-plane.yml` (ACL `acl.hujson`) |
 | `tunnel-proxy` (public HTTPS -> tailnet bridge, customer-tunnel path) | Railway | `packages/cloud/services/tunnel-proxy/` | `railway.toml`, `Dockerfile` |
+| `voice-kokoro-tts` (free-cloud TTS behind `/api/v1/voice/tts`) | Railway | `packages/cloud/services/voice-kokoro-tts/` | `railway.toml`, `Dockerfile` |
+| `voice-whisper-stt` (free-cloud STT behind `/api/v1/voice/stt`) | Railway | `packages/cloud/services/voice-whisper-stt/` | `railway.toml`, `Dockerfile` |
 | `gateway-discord` | Cloudflare Worker | `packages/cloud/services/gateway-discord/` | own `wrangler.toml` |
 | `gateway-webhook` | Cloudflare Worker | `packages/cloud/services/gateway-webhook/` | own `wrangler.toml` |
 | `agent-server` (per-customer agent runtime) | Hetzner containers | `packages/cloud/services/agent-server/` | provisioned via `container-control-plane` |

--- a/packages/cloud/services/voice-kokoro-tts/Dockerfile
+++ b/packages/cloud/services/voice-kokoro-tts/Dockerfile
@@ -1,0 +1,25 @@
+# Reproducible build of the free-cloud Kokoro TTS service that lives behind the
+# cloud-api /api/v1/voice/tts route (the `KOKORO_TTS_URL` branch). It wraps the
+# upstream Kokoro-FastAPI image so the deploy is a pinned, in-repo artifact
+# instead of an unreproducible Railway pet: the previously-provisioned instance
+# (kokoro-tts-production-aa4b.up.railway.app) existed only as a test-default URL.
+#
+# Contract this image MUST satisfy (asserted by
+# packages/cloud/api/__tests__/voice-kokoro-whisper-live.test.ts):
+#   POST /api/tts  { text, voice, speed } -> audio/wav (RIFF/WAVE)
+#   GET  /health   -> 200 (Railway healthcheck, see railway.toml)
+# The eleven allowlisted voice presets (af_heart default, …) are the Kokoro
+# voice ids the route sends; they ship with the upstream image's voice pack.
+#
+# Pin: upstream publishes CPU/GPU variants under ghcr.io/remsky/kokoro-fastapi-*.
+# CPU is the Railway default (the free tier has no GPU); override KOKORO_IMAGE at
+# build time to repoint at a GPU variant on a GPU-backed Railway plan. Bump the
+# tag deliberately — an unpinned :latest is exactly the drift this issue removes.
+ARG KOKORO_IMAGE=ghcr.io/remsky/kokoro-fastapi-cpu:v0.2.2
+
+FROM ${KOKORO_IMAGE}
+
+# Railway injects PORT; the upstream server reads it. Kept explicit so the
+# healthcheck URL in railway.toml and the EXPOSE line agree with the runtime.
+ENV PORT=8880
+EXPOSE 8880

--- a/packages/cloud/services/voice-kokoro-tts/README.md
+++ b/packages/cloud/services/voice-kokoro-tts/README.md
@@ -1,0 +1,40 @@
+# voice-kokoro-tts (free-cloud Kokoro TTS)
+
+Self-hosted Kokoro TTS behind the cloud-api `/api/v1/voice/tts` route (the
+`KOKORO_TTS_URL` branch — the free, unbilled default voice path). It wraps the
+upstream [Kokoro-FastAPI](https://github.com/remsky/Kokoro-FastAPI) image; the
+weights ship in the image, so there are no secrets.
+
+## Contract (do not break — the live test asserts it)
+
+| Method | Path | Request | Response |
+|---|---|---|---|
+| `POST` | `/api/tts` | JSON `{ text, voice, speed }` | `audio/wav` (RIFF/WAVE) |
+| `GET` | `/health` | — | `200` |
+
+The eleven allowlisted `voice` presets (default `af_heart`) are the Kokoro voice
+ids `packages/cloud/api/v1/voice/tts/route.ts` sends. The exact round-trip is
+asserted by `packages/cloud/api/__tests__/voice-kokoro-whisper-live.test.ts`,
+run in the scheduled **Voice Live E2E → voice-railway-contract** lane
+(`.github/workflows/voice-live-e2e.yml`).
+
+## Deploy (owner action)
+
+The service is pinned in-repo (`Dockerfile` + `railway.toml`). To deploy or
+redeploy from this directory:
+
+```bash
+railway up --service kokoro-tts       # from packages/cloud/services/voice-kokoro-tts
+```
+
+After deploy, point cloud-api at it by setting `KOKORO_TTS_URL` (Worker env /
+`wrangler secret`) to the service's public URL, and set the same URL as the repo
+variable `ELIZA_VOICE_KOKORO_TTS_URL` so the scheduled contract lane targets the
+live deploy (see `../voice-whisper-stt/README.md` for the shared lane wiring).
+
+Build a GPU variant on a GPU-backed plan by overriding the pinned image:
+
+```bash
+railway up --service kokoro-tts \
+  --build-arg KOKORO_IMAGE=ghcr.io/remsky/kokoro-fastapi-gpu:v0.2.2
+```

--- a/packages/cloud/services/voice-kokoro-tts/railway.toml
+++ b/packages/cloud/services/voice-kokoro-tts/railway.toml
@@ -1,0 +1,19 @@
+# Railway deploy config for the free-cloud Kokoro TTS service.
+#
+# Consumed by the cloud-api /api/v1/voice/tts route via the KOKORO_TTS_URL env
+# var; serves POST /api/tts { text, voice, speed } -> WAV. No secrets required —
+# the free voice path is unauthenticated at the service boundary (cloud-api owns
+# auth/billing upstream) and the model weights ship in the image.
+#
+# healthcheckTimeout is generous: the first request after a cold deploy loads the
+# Kokoro voice pack into memory, so early /health probes can be slow.
+
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+healthcheckPath = "/health"
+healthcheckTimeout = 300
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10

--- a/packages/cloud/services/voice-whisper-stt/Dockerfile
+++ b/packages/cloud/services/voice-whisper-stt/Dockerfile
@@ -1,0 +1,34 @@
+# Reproducible build of the free-cloud Whisper STT service that lives behind the
+# cloud-api /api/v1/voice/stt route (the `WHISPER_STT_URL` branch). It wraps the
+# upstream Speaches (formerly faster-whisper-server) image so the deploy is a
+# pinned, in-repo artifact instead of an unreproducible Railway pet: the
+# previously-provisioned instance (whisper-stt-production-6fc7.up.railway.app)
+# existed only as a test-default URL.
+#
+# Contract this image MUST satisfy (asserted by
+# packages/cloud/api/__tests__/voice-kokoro-whisper-live.test.ts):
+#   POST /v1/audio/transcriptions  (multipart: file, model, [language])
+#        -> { text }   (OpenAI-compatible transcription response)
+#   GET  /health       -> 200 (Railway healthcheck, see railway.toml)
+# The `model` id the route sends is resolveWhisperSttModel(WHISPER_STT_MODEL),
+# defaulting to the multilingual Systran/faster-whisper-small — Speaches lazily
+# downloads that CTranslate2 model on first use, so WHISPER__MODEL below warms it
+# at boot to keep the first live request from timing out.
+#
+# Pin: Speaches publishes CPU/CUDA variants under ghcr.io/speaches-ai/speaches.
+# CPU is the Railway default (free tier has no GPU); override WHISPER_IMAGE at
+# build time for a CUDA variant on a GPU-backed plan. Bump the tag deliberately —
+# an unpinned :latest is exactly the drift this issue removes.
+ARG WHISPER_IMAGE=ghcr.io/speaches-ai/speaches:0.6.5-cpu
+
+FROM ${WHISPER_IMAGE}
+
+# Warm the default multilingual model at boot so the first transcription does not
+# eat a cold model download. Must track DEFAULT_WHISPER_STT_MODEL in
+# packages/cloud/api/v1/voice/stt/whisper-model.ts.
+ENV WHISPER__MODEL=Systran/faster-whisper-small
+
+# Railway injects PORT; kept explicit so the railway.toml healthcheck and EXPOSE
+# agree with the runtime bind.
+ENV PORT=8000
+EXPOSE 8000

--- a/packages/cloud/services/voice-whisper-stt/README.md
+++ b/packages/cloud/services/voice-whisper-stt/README.md
@@ -1,0 +1,50 @@
+# voice-whisper-stt (free-cloud Whisper STT)
+
+Self-hosted Whisper STT behind the cloud-api `/api/v1/voice/stt` route (the
+`WHISPER_STT_URL` branch — the free, unbilled default transcription path). It
+wraps the upstream [Speaches](https://github.com/speaches-ai/speaches) image
+(OpenAI-compatible, formerly faster-whisper-server); the CTranslate2 model is
+fetched from Hugging Face at boot, so there are no secrets.
+
+## Contract (do not break — the live test asserts it)
+
+| Method | Path | Request | Response |
+|---|---|---|---|
+| `POST` | `/v1/audio/transcriptions` | multipart: `file`, `model`, optional `language` | JSON `{ text }` |
+| `GET` | `/health` | — | `200` |
+
+The `model` id is `resolveWhisperSttModel(WHISPER_STT_MODEL)`, defaulting to the
+multilingual `Systran/faster-whisper-small`
+(`packages/cloud/api/v1/voice/stt/whisper-model.ts`). The Dockerfile's
+`WHISPER__MODEL` warms that same model at boot — keep the two in sync. The exact
+request shape is asserted by
+`packages/cloud/api/__tests__/voice-kokoro-whisper-live.test.ts`.
+
+## Deploy (owner action)
+
+The service is pinned in-repo (`Dockerfile` + `railway.toml`):
+
+```bash
+railway up --service whisper-stt      # from packages/cloud/services/voice-whisper-stt
+```
+
+After deploy, set `WHISPER_STT_URL` (cloud-api Worker env / `wrangler secret`)
+to the public URL, optionally `WHISPER_STT_MODEL` to pin a different hosted
+model, and set the repo variable `ELIZA_VOICE_WHISPER_STT_URL` to the same URL.
+
+CUDA variant on a GPU-backed plan:
+
+```bash
+railway up --service whisper-stt \
+  --build-arg WHISPER_IMAGE=ghcr.io/speaches-ai/speaches:0.6.5-cuda
+```
+
+## Scheduled live contract lane
+
+`voice-kokoro-whisper-live.test.ts` was referenced by zero workflows, so a dead
+service surfaced only as a user report. It now runs in the **voice-railway-contract**
+job of `.github/workflows/voice-live-e2e.yml` (nightly + `workflow_dispatch`),
+env-gated on `ELIZA_VOICE_LIVE_RAILWAY=1`. The job reads the two service URLs
+from repo variables `ELIZA_VOICE_KOKORO_TTS_URL` / `ELIZA_VOICE_WHISPER_STT_URL`
+(falling back to the test defaults), so drift or death of either service is a red
+run instead of a silent outage.

--- a/packages/cloud/services/voice-whisper-stt/railway.toml
+++ b/packages/cloud/services/voice-whisper-stt/railway.toml
@@ -1,0 +1,19 @@
+# Railway deploy config for the free-cloud Whisper STT service.
+#
+# Consumed by the cloud-api /api/v1/voice/stt route via the WHISPER_STT_URL env
+# var; serves POST /v1/audio/transcriptions (OpenAI-compatible) -> { text }. No
+# secrets required — cloud-api owns auth/billing upstream and the model is fetched
+# from Hugging Face at boot (WHISPER__MODEL in the Dockerfile).
+#
+# healthcheckTimeout is generous: the first boot downloads the CTranslate2 model
+# weights, so early /health probes can be slow on a cold deploy.
+
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+healthcheckPath = "/health"
+healthcheckTimeout = 300
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10

--- a/packages/scripts/__tests__/voice-railway-service-defs.test.ts
+++ b/packages/scripts/__tests__/voice-railway-service-defs.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Contract test for the in-repo Railway voice service definitions (#14374) and
+ * the scheduled lane that keeps them alive. It guards two things that were pure
+ * tribal knowledge before: (1) the free-cloud Kokoro TTS + Whisper STT services
+ * exist as reproducible Dockerfile + railway.toml pairs under
+ * packages/cloud/services/voice-*, and (2) the once-orphaned live contract test
+ * (voice-kokoro-whisper-live.test.ts, previously referenced by zero workflows)
+ * is wired into voice-live-e2e.yml with correct env gating, so a dead or drifted
+ * Railway service surfaces as a red run rather than a silent user report.
+ *
+ * Deterministic: parses committed files only (Bun.TOML / Bun.YAML), no network,
+ * no Railway. Actually deploying is an owner action — the READMEs carry the
+ * `railway up` commands this test asserts are documented.
+ */
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+
+const repoRoot = new URL("../../../", import.meta.url);
+function read(rel: string): string {
+  return readFileSync(new URL(rel, repoRoot), "utf8");
+}
+function exists(rel: string): boolean {
+  return existsSync(new URL(rel, repoRoot));
+}
+
+const LIVE_TEST_PATH =
+  "packages/cloud/api/__tests__/voice-kokoro-whisper-live.test.ts";
+const WORKFLOW_PATH = ".github/workflows/voice-live-e2e.yml";
+const CONTRACT_JOB = "voice-railway-contract";
+
+const SERVICES = [
+  {
+    dir: "packages/cloud/services/voice-kokoro-tts",
+    // The route contract these files exist to serve; the strings must appear in
+    // the README so the contract is legible without reading the route code.
+    contractPath: "/api/tts",
+    deployCmd: "railway up --service kokoro-tts",
+    urlVar: "ELIZA_VOICE_KOKORO_TTS_URL",
+  },
+  {
+    dir: "packages/cloud/services/voice-whisper-stt",
+    contractPath: "/v1/audio/transcriptions",
+    deployCmd: "railway up --service whisper-stt",
+    urlVar: "ELIZA_VOICE_WHISPER_STT_URL",
+  },
+] as const;
+
+interface RailwayToml {
+  build?: { builder?: string; dockerfilePath?: string };
+  deploy?: { healthcheckPath?: string; healthcheckTimeout?: number };
+}
+
+describe("Railway voice service definitions (#14374)", () => {
+  for (const svc of SERVICES) {
+    describe(svc.dir, () => {
+      test("ships a Dockerfile that pins an upstream image by tag", () => {
+        expect(exists(`${svc.dir}/Dockerfile`)).toBe(true);
+        const dockerfile = read(`${svc.dir}/Dockerfile`);
+        // A concrete FROM referencing an image arg — never a hard-coded literal.
+        const from = dockerfile.match(/^FROM\s+(\S+)/m)?.[1] ?? "";
+        expect(from.length).toBeGreaterThan(0);
+        // The image is parameterised via an ARG default so a GPU variant is a
+        // build-arg override, not an edit. Assert the ARG image line only (not
+        // comment prose) so a version tag is present and never an unpinned :latest.
+        const argImage = dockerfile.match(/^ARG\s+\w*IMAGE=(\S+)/m)?.[1] ?? "";
+        expect(argImage).toMatch(/:[^:@\s]+$/);
+        expect(argImage).not.toMatch(/:latest$/);
+      });
+
+      test("ships a valid railway.toml (Dockerfile builder + /health)", () => {
+        expect(exists(`${svc.dir}/railway.toml`)).toBe(true);
+        const toml = Bun.TOML.parse(
+          read(`${svc.dir}/railway.toml`),
+        ) as RailwayToml;
+        expect(toml.build?.builder).toBe("DOCKERFILE");
+        expect(toml.build?.dockerfilePath).toBe("Dockerfile");
+        // The healthcheck path must match what railway probes AND what the live
+        // test's services expose; the round-trip contract depends on /health.
+        expect(toml.deploy?.healthcheckPath).toBe("/health");
+        expect(typeof toml.deploy?.healthcheckTimeout).toBe("number");
+      });
+
+      test("documents the route contract and the owner deploy command", () => {
+        expect(exists(`${svc.dir}/README.md`)).toBe(true);
+        const readme = read(`${svc.dir}/README.md`);
+        expect(readme).toContain(svc.contractPath);
+        expect(readme).toContain(svc.deployCmd);
+        // The README must name the repo var the scheduled lane reads, so the
+        // deploy→lane wiring is discoverable from the service dir.
+        expect(readme).toContain(svc.urlVar);
+      });
+    });
+  }
+
+  test("both services are recorded in the canonical Railway topology doc", () => {
+    const railwayDoc = read("packages/cloud/infra/cloud/RAILWAY.md");
+    for (const svc of SERVICES) {
+      expect(railwayDoc).toContain(svc.dir);
+    }
+  });
+});
+
+interface WorkflowJob {
+  "runs-on"?: unknown;
+  if?: string;
+  env?: Record<string, string>;
+  steps?: Array<{ name?: string; run?: string }>;
+}
+interface Workflow {
+  on?: { workflow_dispatch?: { inputs?: Record<string, unknown> } };
+  jobs?: Record<string, WorkflowJob>;
+}
+
+describe("scheduled live contract lane (voice-live-e2e.yml)", () => {
+  const workflow = Bun.YAML.parse(read(WORKFLOW_PATH)) as Workflow;
+
+  test("the once-orphaned live test is now referenced by this workflow", () => {
+    expect(exists(LIVE_TEST_PATH)).toBe(true);
+    expect(read(WORKFLOW_PATH)).toContain(LIVE_TEST_PATH);
+  });
+
+  test(`defines the ${CONTRACT_JOB} job that runs the live test`, () => {
+    const job = workflow.jobs?.[CONTRACT_JOB];
+    expect(job).toBeDefined();
+    const runsTest = (job?.steps ?? []).some((s) =>
+      s.run?.includes(LIVE_TEST_PATH),
+    );
+    expect(runsTest).toBe(true);
+  });
+
+  test("gates the live test with ELIZA_VOICE_LIVE_RAILWAY=1", () => {
+    // Without the flag the test self-skips (test.skip), which would make the lane
+    // vacuously green — the whole point is to hit the real services.
+    expect(workflow.jobs?.[CONTRACT_JOB]?.env?.ELIZA_VOICE_LIVE_RAILWAY).toBe(
+      "1",
+    );
+  });
+
+  test("wires the service URLs from repo variables", () => {
+    const env = workflow.jobs?.[CONTRACT_JOB]?.env ?? {};
+    for (const svc of SERVICES) {
+      const wired = Object.values(env).some((v) => v.includes(svc.urlVar));
+      expect(wired).toBe(true);
+    }
+  });
+
+  test("runs on schedule and is dispatchable", () => {
+    // The lane must not require GPU/self-hosted staging — it hits public HTTPS,
+    // so a GitHub-hosted runner is correct and keeps it cheap + always-available.
+    expect(workflow.jobs?.[CONTRACT_JOB]?.["runs-on"]).toBe("ubuntu-24.04");
+    expect(
+      workflow.on?.workflow_dispatch?.inputs?.run_railway_contract,
+    ).toBeDefined();
+  });
+});


### PR DESCRIPTION
## What + why

The free-cloud voice path — Kokoro TTS and Whisper STT behind the cloud-api `/api/v1/voice/tts` and `/api/v1/voice/stt` routes — ran on two Railway services that existed **only as test-default URLs** (`kokoro-tts-production-aa4b`, `whisper-stt-production-6fc7`) with **no reproducible definition** in the repo. On top of that, the live round-trip contract test (`voice-kokoro-whisper-live.test.ts`) was **referenced by zero workflows**, so if either service died or drifted it surfaced as a user report, not a red run. (Research doc `packages/docs/ongoing-development/research/07-voice-pipeline.md` Q6: "Who owns keeping the Railway services alive? Nobody, today — that is the problem.")

This PR **codifies the two existing services** (no new services invented) and wires the orphaned test into a scheduled lane:

- **`packages/cloud/services/voice-kokoro-tts/`** and **`voice-whisper-stt/`** — each with a pinned `Dockerfile` (wraps upstream Kokoro-FastAPI / Speaches by version tag, image overridable via a build ARG for GPU variants), a `railway.toml` (Dockerfile builder + `/health` probe, matching the pattern of the existing `tunnel-proxy` / `gateway-webhook` services), and a `README.md` documenting the **exact route contract** and the owner `railway up` deploy command.
- Both services recorded in the canonical topology doc `packages/cloud/infra/cloud/RAILWAY.md`.
- New **`voice-railway-contract`** job in `.github/workflows/voice-live-e2e.yml` (nightly `schedule` + `workflow_dispatch`, cheap GitHub-hosted `ubuntu-24.04` runner since it hits public HTTPS), gated on `ELIZA_VOICE_LIVE_RAILWAY=1`, reading service URLs from repo vars `ELIZA_VOICE_KOKORO_TTS_URL` / `ELIZA_VOICE_WHISPER_STT_URL` (falling back to the test defaults).
- A deterministic contract test that fails if the defs go invalid or the lane stops referencing the live test with correct env gating.

The service contracts are transcribed from the routes, not invented: Kokoro `POST /api/tts {text,voice,speed}→WAV` (`tts/route.ts:164-198`), Whisper `POST /v1/audio/transcriptions` multipart with `resolveWhisperSttModel(WHISPER_STT_MODEL)` defaulting to `Systran/faster-whisper-small` (`stt/route.ts:188-219`, `whisper-model.ts`).

## Verification

<details>
<summary>Contract test — 12 pass</summary>

```
$ bun test packages/scripts/__tests__/voice-railway-service-defs.test.ts
bun test v1.3.14 (0d9b296a)

 12 pass
 0 fail
 37 expect() calls
Ran 12 tests across 1 file. [723.00ms]
```
</details>

<details>
<summary>Live test still self-skips without the env flag (no network in CI/PR)</summary>

```
$ bun test packages/cloud/api/__tests__/voice-kokoro-whisper-live.test.ts
 0 pass
 2 skip
 0 fail
Ran 2 tests across 1 file.
```
</details>

<details>
<summary>Workflow YAML parses; job wiring correct</summary>

```
$ bun -e "const w=Bun.YAML.parse(...); const j=w.jobs['voice-railway-contract']; ..."
job runs-on: ubuntu-24.04 | env keys: ELIZA_VOICE_LIVE_RAILWAY,KOKORO_TTS_URL,WHISPER_STT_URL,WHISPER_STT_MODEL | if: ${{ github.event_name == 'schedule' || inputs.run_railway_contract }}
```
</details>

<details>
<summary>Both railway.toml parse (Bun.TOML) + biome lint clean</summary>

```
$ bun -e "Bun.TOML.parse(fs.readFileSync('.../voice-kokoro-tts/railway.toml'))"
{"build":{"builder":"DOCKERFILE","dockerfilePath":"Dockerfile"},"deploy":{"healthcheckPath":"/health",...}}

$ biome lint packages/scripts/__tests__/voice-railway-service-defs.test.ts
Checked 1 file in 10ms. No fixes applied.
```
</details>

## Tests added

- `packages/scripts/__tests__/voice-railway-service-defs.test.ts` — asserts both service dirs ship a version-pinned Dockerfile + valid `railway.toml` (`/health`) + README with the route contract & deploy command, both services appear in `RAILWAY.md`, and the `voice-railway-contract` lane references the live test, sets `ELIZA_VOICE_LIVE_RAILWAY=1`, and wires the URL repo vars.

## Evidence

| Type | Status |
|---|---|
| Config/lint contract test | Attached inline above (12 pass) |
| Live test self-skip proof | Attached inline above |
| Workflow YAML validation | Attached inline above |
| Actual Railway deploy of the two services | **N/A — owner action.** Deploy per service README: `cd packages/cloud/services/voice-kokoro-tts && railway up --service kokoro-tts` and `cd packages/cloud/services/voice-whisper-stt && railway up --service whisper-stt`, then set repo vars `ELIZA_VOICE_KOKORO_TTS_URL` / `ELIZA_VOICE_WHISPER_STT_URL`. |
| Live round-trip against deployed services | **N/A — needs the deployed services + network.** Owner runs: `ELIZA_VOICE_LIVE_RAILWAY=1 bun test packages/cloud/api/__tests__/voice-kokoro-whisper-live.test.ts`, or dispatch the `Voice Live E2E` workflow (`run_railway_contract=true`). |
| Frontend/rendered UI | N/A — infra/CI + service definitions only, no UI surface. |

Closes #14374

🤖 Generated with [Claude Code](https://claude.com/claude-code)
