### PR TITLE
fix: require packaged OCR for evidence review

### DIFF
--- a/.github/workflows/app-aesthetic-audit.yml
+++ b/.github/workflows/app-aesthetic-audit.yml
@@ -111,6 +111,8 @@ jobs:
           path: packages/app/aesthetic-audit-output
 
       - name: Run pixel OCR content audit
+        env:
+          ELIZA_MVP_OCR_ENGINE: packaged
         run: bun run --cwd packages/app audit:ocr
 
       - name: Upload OCR audit artifacts

--- a/PR_EVIDENCE.md
+++ b/PR_EVIDENCE.md
@@ -123,8 +123,8 @@ bun run test:e2e:record:sheets           # regenerate contact sheets + viewer
 bun run test:e2e:audit-ui                # coverage of which routes are recorded
 
 # Local manual evidence reviewer: scans screenshots, videos, logs, reports, and
-# trajectories, computes screenshot color heuristics/OCR when available, and
-# opens evidence/index.html for the required hand review pass.
+# trajectories, computes screenshot color heuristics, runs packaged OCR by
+# default, and opens evidence/index.html for the required hand review pass.
 bun run evidence:review
 bun run evidence:review:no-open
 

--- a/bun.lock
+++ b/bun.lock
@@ -80,6 +80,7 @@
         "pure-rand": "^8.4.0",
         "react-test-renderer": "^19.0.0",
         "secp256k1": "^5.0.1",
+        "tesseract.js": "^6.0.1",
         "tsx": "^4.21.0",
         "turbo": "^2.9.16",
         "typescript": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -292,6 +292,7 @@
     "pure-rand": "^8.4.0",
     "react-test-renderer": "^19.0.0",
     "secp256k1": "^5.0.1",
+    "tesseract.js": "^6.0.1",
     "tsx": "^4.21.0",
     "turbo": "^2.9.16",
     "typescript": "^6.0.3",

--- a/packages/app/scripts/mvp-visual-verify/ocr.mjs
+++ b/packages/app/scripts/mvp-visual-verify/ocr.mjs
@@ -13,6 +13,9 @@
  */
 
 import { spawn, spawnSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 /** @type {{ path: string | null } | null} */
 let probe = null;
@@ -21,6 +24,7 @@ let packagedProbe = null;
 /** @type {Map<string, Promise<any>>} */
 let packagedWorkers = new Map();
 const TESSERACT_JS_PACKAGE = "tesseract.js";
+const TESSERACT_JS_CACHE_DIR = join(tmpdir(), "elizaos-tesseract-cache");
 
 /**
  * Resolve the `tesseract` binary path once per process. Uses `which` (POSIX) —
@@ -175,8 +179,9 @@ async function getPackagedWorker(lang, timeoutMs) {
     if (!tesseract?.createWorker) {
       throw new Error("tesseract.js createWorker export is unavailable");
     }
+    mkdirSync(TESSERACT_JS_CACHE_DIR, { recursive: true });
     return withTimeout(
-      tesseract.createWorker(lang),
+      tesseract.createWorker(lang, 1, { cachePath: TESSERACT_JS_CACHE_DIR }),
       timeoutMs,
       `tesseract.js worker initialization timed out after ${timeoutMs}ms`,
     );

--- a/packages/app/scripts/ocr-triage.ts
+++ b/packages/app/scripts/ocr-triage.ts
@@ -101,16 +101,7 @@ async function runPackagedOcr(paths: string[]): Promise<OcrRecord[]> {
   for (const path of paths) {
     const result = await ocrImage(path);
     if (!result.available) {
-      out.push({
-        path,
-        ok: false,
-        text: "",
-        lines: [],
-        words: 0,
-        meanConfidence: 0,
-        reason: result.reason,
-      });
-      continue;
+      throw new Error(`OCR failed for ${path}: ${result.reason}`);
     }
     out.push({
       path,

--- a/scripts/evidence-review/generate.mjs
+++ b/scripts/evidence-review/generate.mjs
@@ -2,7 +2,7 @@
 /**
  * Local evidence reviewer for screenshots, videos, logs, trajectories, and
  * reports produced by the repo's existing verification lanes. It scans the
- * evidence silos, computes deterministic image heuristics, optionally runs OCR,
+ * evidence silos, computes deterministic image heuristics, runs packaged OCR,
  * writes `evidence/manifest.json`, and generates a single browser dashboard for
  * the manual "capturing is not reviewing" pass.
  */
@@ -12,6 +12,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import sharp from "sharp";
+import {
+  closeOcrEngines,
+  ocrImage,
+  resolveOcrEngine,
+} from "../../packages/app/scripts/mvp-visual-verify/ocr.mjs";
 import {
   analyzeImageFile,
   classifyArtifactPath,
@@ -56,7 +61,7 @@ function parseArgs(argv) {
   const options = {
     outputDir: DEFAULT_OUTPUT_DIR,
     open: false,
-    ocr: "auto",
+    ocr: "on",
     maxArtifacts: 900,
     maxImages: 240,
     maxFilesPerDir: 6000,
@@ -119,18 +124,10 @@ Options:
   --no-open               Do not open the dashboard.
   --out=<dir>             Output directory. Default: evidence/
   --source=<dir>          Scan a specific directory. Repeatable.
-  --ocr=auto|on|off       Run OCR when a local tesseract binary is available.
+  --ocr=on|auto|off       Run OCR with the packaged tesseract.js engine. Default: on.
   --max-artifacts=<n>     Limit total artifacts in the dashboard. Default: 900.
   --max-images=<n>        Limit image heuristic work. Default: 240.
   --max-files-per-dir=<n> Bound each scan root. Default: 6000.`);
-}
-
-function fileExists(filePath) {
-  try {
-    return fs.statSync(filePath).isFile();
-  } catch {
-    return false;
-  }
 }
 
 function dirExists(dirPath) {
@@ -149,45 +146,22 @@ function resolveScanDirs(options) {
     .filter((dir) => dirExists(dir));
 }
 
-function findExecutable(command) {
-  const pathValue = process.env.PATH ?? "";
-  for (const dir of pathValue.split(path.delimiter)) {
-    if (!dir) continue;
-    const candidate = path.join(dir, command);
-    if (fileExists(candidate)) return candidate;
-  }
-  return null;
-}
-
-function runOcr(filePath, options, tesseractPath) {
+async function runOcr(filePath, options) {
   if (options.ocr === "off") {
     return { status: "disabled", text: "" };
   }
-  if (!tesseractPath) {
-    if (options.ocr === "on") {
-      return {
-        status: "unavailable",
-        text: "",
-        error: "tesseract binary was not found on PATH",
-      };
-    }
-    return { status: "unavailable", text: "" };
-  }
-  const result = spawnSync(
-    tesseractPath,
-    [filePath, "stdout", "-l", "eng", "--psm", "6"],
-    { encoding: "utf8", maxBuffer: 4 * 1024 * 1024 },
-  );
-  if (result.status !== 0) {
+  const result = await ocrImage(filePath);
+  if (!result.available) {
     return {
-      status: "failed",
+      status: options.ocr === "on" ? "failed" : "unavailable",
       text: "",
-      error: (result.stderr || result.stdout || `exit ${result.status}`).trim(),
+      error: result.reason,
     };
   }
   return {
     status: "ok",
-    text: summarizeTextPreview(result.stdout, 1800).trim(),
+    engine: result.engine,
+    text: summarizeTextPreview(result.text, 1800).trim(),
   };
 }
 
@@ -237,9 +211,19 @@ function walkFiles(scanRoot, maxFiles) {
 
 async function collectArtifacts(options) {
   const scanDirs = resolveScanDirs(options);
-  const tesseractPath = findExecutable("tesseract");
+  const ocrEngine =
+    options.ocr === "off"
+      ? { available: false, kind: "disabled", label: null, reason: null }
+      : await resolveOcrEngine();
+  if (options.ocr === "on" && !ocrEngine.available) {
+    throw new Error(
+      `OCR is required but unavailable: ${ocrEngine.reason}. Run \`bun install\` so the packaged tesseract.js dependency is available, or set ELIZA_TESSERACT_BIN to a system tesseract binary.`,
+    );
+  }
   const artifacts = [];
   let imageAnalysisCount = 0;
+  let ocrFailureCount = 0;
+  let ocrOkCount = 0;
 
   for (const scanRoot of scanDirs) {
     if (artifacts.length >= options.maxArtifacts) break;
@@ -257,11 +241,17 @@ async function collectArtifacts(options) {
         bytes: stat.size,
         mtime: stat.mtime.toISOString(),
       };
+      if (type === "image") {
+        if (options.ocr !== "off") {
+          artifact.ocr = await runOcr(full, options);
+          if (artifact.ocr.status === "ok") ocrOkCount += 1;
+          else if (options.ocr === "on") ocrFailureCount += 1;
+        }
+      }
       if (type === "image" && imageAnalysisCount < options.maxImages) {
         imageAnalysisCount += 1;
         try {
           artifact.image = await analyzeImageFile(full, sharp);
-          artifact.ocr = runOcr(full, options, tesseractPath);
         } catch (error) {
           artifact.imageError = error?.message || String(error);
         }
@@ -286,8 +276,10 @@ async function collectArtifacts(options) {
     scanDirs: scanDirs.map((dir) => toPosixPath(path.relative(REPO_ROOT, dir))),
     ocr: {
       mode: options.ocr,
-      executable: tesseractPath,
-      available: Boolean(tesseractPath),
+      engine: ocrEngine.available ? ocrEngine.label : null,
+      available: options.ocr === "off" ? false : Boolean(ocrEngine.available),
+      ok: ocrOkCount,
+      failures: ocrFailureCount,
     },
     artifacts,
   };
@@ -406,8 +398,8 @@ function buildHtml(manifest) {
   ].sort();
   const ocrLabel =
     manifest.ocr.mode === "off"
-      ? `off${manifest.ocr.available ? " (available)" : ""}`
-      : `${manifest.ocr.mode}${manifest.ocr.available ? " available" : " unavailable"}`;
+      ? "off"
+      : `${manifest.ocr.mode}${manifest.ocr.available ? ` available (${manifest.ocr.engine})` : " unavailable"}`;
 
   return `<!doctype html>
 <html lang="en">
@@ -555,13 +547,22 @@ async function main() {
   );
   if (!manifest.ocr.available && options.ocr !== "off") {
     console.log(
-      "OCR: unavailable locally. Install tesseract or rerun with --ocr=off to silence this note.",
+      "OCR: unavailable. Run `bun install` so packaged tesseract.js is installed, or set ELIZA_TESSERACT_BIN.",
     );
+  }
+  if (options.ocr === "on" && manifest.ocr.failures > 0) {
+    console.error(`OCR: ${manifest.ocr.failures} screenshot(s) failed OCR.`);
+    process.exitCode = 1;
   }
   if (options.open) openFile(indexPath);
 }
 
-main().catch((error) => {
-  console.error(error?.stack || error?.message || String(error));
-  process.exit(1);
-});
+main()
+  .catch((error) => {
+    console.error(error?.stack || error?.message || String(error));
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await closeOcrEngines();
+    if (process.exitCode) process.exit(process.exitCode);
+  });

--- a/scripts/evidence-review/run-matrix.mjs
+++ b/scripts/evidence-review/run-matrix.mjs
@@ -113,7 +113,7 @@ Options:
   --out=<dir>              Output directory for matrix-run.json and reviewer.
   --review / --no-review   Generate the evidence reviewer after the matrix.
   --open / --no-open       Open the reviewer after generation. Default: no-open.
-  --review-ocr=auto|on|off OCR mode passed to evidence:review. Default: off.
+  --review-ocr=on|auto|off OCR mode passed to evidence:review. Default: on.
   --stop-on-failure        Stop after the first failed step.
   --dry-run                Write a planned manifest without executing commands.
   --help, -h               Show this help.`);
@@ -126,7 +126,7 @@ export function parseMatrixArgs(argv) {
     outputDir: DEFAULT_OUTPUT_DIR,
     review: true,
     open: false,
-    reviewOcr: "off",
+    reviewOcr: "on",
     stopOnFailure: false,
     dryRun: false,
   };

--- a/scripts/evidence-review/run-matrix.test.mjs
+++ b/scripts/evidence-review/run-matrix.test.mjs
@@ -60,6 +60,7 @@ test("selects all real matrix lanes by default", () => {
   );
   assert.equal(options.review, true);
   assert.equal(options.open, false);
+  assert.equal(options.reviewOcr, "on");
 });
 
 test("can skip device lanes while keeping test and visual evidence lanes", () => {


### PR DESCRIPTION
## Summary
- Makes OCR required by default for `scripts/evidence-review/generate.mjs` and `test:matrix` review generation instead of defaulting to `off`/best-effort.
- Adds root `tesseract.js` dependency so normal `bun install` packages OCR for the evidence reviewer.
- Forces the app OCR CI lane to use the packaged OCR engine and fails `ocr-triage` if any screenshot OCR cannot run.
- Moves `tesseract.js` traineddata cache into the OS temp directory so OCR verification does not leave `eng.traineddata` in the repo.

Follow-up to merged PR #14490 / issue #14447: OCR must be enforced, not skipped.

## Verification
- `bun install --frozen-lockfile --ignore-scripts` completed and installed `tesseract.js@6.0.1` from the lockfile.
- `bunx @biomejs/biome check scripts/evidence-review/generate.mjs scripts/evidence-review/run-matrix.mjs scripts/evidence-review/run-matrix.test.mjs packages/app/scripts/mvp-visual-verify/ocr.mjs packages/app/scripts/ocr-triage.ts PR_EVIDENCE.md .github/workflows/app-aesthetic-audit.yml package.json bun.lock`
- `node --test scripts/evidence-review/*.test.mjs` -> 21 passed.
- `bun test packages/app/test/audit/ocr-content-rules.test.ts` -> 14 passed, 100% for `ocr-content-rules.ts`.
- Packaged evidence reviewer OCR smoke: generated `/tmp/evidence-review-ocr-smoke/ocr-smoke.png`, ran `node scripts/evidence-review/generate.mjs --no-open --out=/tmp/evidence-review-ocr-smoke-out --source=/tmp/evidence-review-ocr-smoke --ocr=on --max-artifacts=100 --max-images=100 --max-files-per-dir=100`; manifest showed `mode:on`, `engine:tesseract.js package`, `available:true`, `ok:1`, `failures:0`, text `Ask Eliza OCR smoke`.
- Packaged app OCR triage smoke: generated `/tmp/app-ocr-triage-smoke/desktop/builtin-chat.png`, ran `ELIZA_MVP_OCR_ENGINE=packaged bun scripts/ocr-triage.ts --audit-dir /tmp/app-ocr-triage-smoke --baseline test/ui-smoke/ocr-triage-baseline.json --out /tmp/app-ocr-triage-smoke/ocr-triage.json`; summary showed `verified:1`, `newRegressions:0`.
- `rg --files -g 'eng.traineddata' -g '!node_modules' -g '!packages/**/node_modules' -g '!plugins/**/node_modules'` returned no repo residue after both OCR smokes.
- `git diff --check`
