### PR TITLE
fix(discord): keep widget components on DM messages (#14527)

### DIFF
--- a/plugins/plugin-discord/__tests__/dm-widget-components.test.ts
+++ b/plugins/plugin-discord/__tests__/dm-widget-components.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Regression test for #14527 — "Discord drops widget components on DM".
+ *
+ * The DM send branch in `MessageManager` used to call
+ * `user.send({ content, files })` with NO `components`, so a components-only
+ * reply (e.g. a `[CHOICE]` block) rendered the "Choose an option:" fallback
+ * text with zero buttons. This pins the fix: a reply carrying interaction
+ * blocks, rendered through the SAME `renderDiscordInteractions` +
+ * `buildDiscordComponents` path the guild send uses, must produce DM send
+ * options that carry real discord.js action rows with buttons.
+ *
+ * The test walks the exact production seam:
+ *   agent text (with [CHOICE] block)
+ *     -> renderDiscordInteractions()        (interactions.ts)
+ *     -> buildDiscordComponents()           (utils.ts)
+ *     -> buildDmSendOptions()               (messages.ts, the DM branch helper)
+ * and asserts `components` survives to the outgoing DM payload.
+ */
+import type { Content } from "@elizaos/core";
+import {
+	ActionRowBuilder,
+	type MessageActionRowComponentBuilder,
+} from "discord.js";
+import { describe, expect, it } from "vitest";
+import { renderDiscordInteractions } from "../interactions";
+import { buildDmSendOptions } from "../messages";
+import { buildDiscordComponents } from "../utils";
+
+/** A components-only agent reply: a choice picker with two options, no prose. */
+function choiceOnlyContent(): Content {
+	return {
+		text: [
+			"[CHOICE:confirm]",
+			"yes=Yes, do it",
+			"no=No, cancel",
+			"[/CHOICE]",
+		].join("\n"),
+	} as Content;
+}
+
+describe("#14527 Discord keeps widget components on DM messages", () => {
+	it("a components-only reply yields DM send options carrying the action row + buttons", () => {
+		const rendered = renderDiscordInteractions(choiceOnlyContent());
+
+		// The renderer must have produced native components for the choice block.
+		expect(rendered.components.length).toBeGreaterThan(0);
+
+		const built = buildDiscordComponents(rendered.components);
+		expect(built).toBeDefined();
+		expect(built?.length).toBeGreaterThan(0);
+		expect(built?.[0]).toBeInstanceOf(ActionRowBuilder);
+
+		// Prose is empty on a components-only reply — mirror the fallback the DM
+		// branch applies before delivery.
+		const textContent =
+			rendered.text.trim().length > 0 ? rendered.text : "Choose an option:";
+
+		const options = buildDmSendOptions(textContent, [], built);
+
+		// THE REGRESSION: before the fix these components were dropped and the DM
+		// went out with only { content, files }. Now they must be present.
+		expect(options.components).toBeDefined();
+		expect(options.components?.length).toBe(built?.length);
+		expect(options.components?.[0]).toBeInstanceOf(ActionRowBuilder);
+
+		// And the buttons carry the option labels + custom ids (they render, not
+		// just exist). Serialize the built row to inspect the button payloads.
+		const row = options
+			.components?.[0] as ActionRowBuilder<MessageActionRowComponentBuilder>;
+		const json = row.toJSON();
+		const labels = json.components.map((c) => (c as { label?: string }).label);
+		expect(labels).toEqual(["Yes, do it", "No, cancel"]);
+	});
+
+	it("omits the components key entirely for a plain-text reply (no empty array)", () => {
+		const rendered = renderDiscordInteractions({
+			text: "just a normal reply, no widgets",
+		} as Content);
+		expect(rendered.components.length).toBe(0);
+
+		const built = buildDiscordComponents(rendered.components);
+		expect(built).toBeUndefined();
+
+		const options = buildDmSendOptions(
+			"just a normal reply, no widgets",
+			[],
+			built,
+		);
+		// Discord rejects `components: []`; the key must be absent, not empty.
+		expect("components" in options).toBe(false);
+		expect(options.content).toBe("just a normal reply, no widgets");
+	});
+});

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -28,11 +28,13 @@ import {
 	type UUID,
 } from "@elizaos/core";
 import {
+	type ActionRowBuilder,
 	type AttachmentBuilder,
 	type Channel,
 	type Client,
 	ChannelType as DiscordChannelType,
 	type Message as DiscordMessage,
+	type MessageActionRowComponentBuilder,
 	type TextChannel,
 } from "discord.js";
 import { isDiscordUserAddressed } from "./addressing";
@@ -71,6 +73,7 @@ import {
 } from "./types";
 import { createTypingController } from "./typing";
 import {
+	buildDiscordComponents,
 	buildOutboundDiscordAttachment,
 	canSendMessage,
 	extractUrls,
@@ -276,6 +279,42 @@ export async function createDiscordMessageMemoryOnce(
 
 	await runtime.createMemory(memory, "messages");
 	return memory;
+}
+
+/** Options handed to `User.send` when delivering a Discord DM reply. */
+export interface DmSendOptions {
+	content: string;
+	files?: AttachmentBuilder[];
+	components?: ActionRowBuilder<MessageActionRowComponentBuilder>[];
+}
+
+/**
+ * Build the option bag for a DM reply so it carries the SAME widget components
+ * a guild channel reply would (#14527). The DM branch used to send
+ * `{content, files}` only, silently dropping every button/select on a
+ * components-only reply. Discord's API supports message components on DM
+ * channels, so there is no API constraint to degrade around for the button +
+ * string-select types this connector emits; we simply attach them.
+ *
+ * `components`/`files` keys are omitted entirely when empty so we never send an
+ * empty `components: []` (which Discord rejects) or an empty `files: []`.
+ *
+ * @param textContent - Prose to send (already normalized, may be the
+ *   "Choose an option:" fallback when the reply is components-only).
+ * @param files - Outbound attachments, if any.
+ * @param components - Already-built discord.js action rows (from
+ *   `buildDiscordComponents`), if any.
+ */
+export function buildDmSendOptions(
+	textContent: string,
+	files: AttachmentBuilder[],
+	components: ActionRowBuilder<MessageActionRowComponentBuilder>[] | undefined,
+): DmSendOptions {
+	return {
+		content: textContent,
+		...(files.length > 0 ? { files } : {}),
+		...(components && components.length > 0 ? { components } : {}),
+	};
 }
 
 /**
@@ -1148,11 +1187,16 @@ export class MessageManager {
 							return [];
 						}
 
+						// Widget components (choice pickers, task cards, secret/OAuth
+						// link-outs) must render in DMs too. Discord's API supports
+						// message components (buttons + string selects) on DM channels,
+						// so we build the same rows the guild path does instead of
+						// silently dropping them (#14527).
+						const dmComponents = hasComponents
+							? buildDiscordComponents(rendered.components)
+							: undefined;
 						const dmMessage = await runResponseDispatch(() =>
-							user.send({
-								content: textContent,
-								files: files.length > 0 ? files : undefined,
-							}),
+							user.send(buildDmSendOptions(textContent, files, dmComponents)),
 						);
 						messages = [dmMessage];
 					} else {

--- a/plugins/plugin-discord/utils.ts
+++ b/plugins/plugin-discord/utils.ts
@@ -568,6 +568,136 @@ interface MessageSendOptions {
 	components?: ActionRowBuilder<MessageActionRowComponentBuilder>[];
 }
 
+/**
+ * Convert the connector's neutral {@link DiscordActionRow} specs (produced by
+ * `renderDiscordInteractions`) into discord.js `ActionRowBuilder`s ready to hand
+ * to `channel.send`/`user.send`. Already-built discord.js rows pass through
+ * untouched. Returns `undefined` when there is nothing renderable so callers can
+ * omit the `components` key entirely.
+ *
+ * This is the SINGLE place button/select builders are assembled, shared by both
+ * the guild send path (`sendMessageInChunks`) and the DM send path in
+ * `messages.ts`. Keeping DMs on the same builder is the fix for #14527 — the DM
+ * branch previously called `user.send({content, files})` with no components, so
+ * a components-only reply rendered the "Choose an option:" fallback with zero
+ * buttons.
+ *
+ * NOTE on Discord DM constraints: message components (action rows of buttons and
+ * string selects — the only types this helper emits) ARE supported in DMs by
+ * Discord's API, so no DM-specific degradation is required here. The types
+ * Discord forbids in DMs are guild-scoped interaction surfaces (e.g. role/user
+ * selects, type 5/6/7/8), which this connector does not emit. If such a type is
+ * ever added, degrade it to a link-out or text fallback rather than dropping it
+ * silently.
+ */
+export function buildDiscordComponents(
+	components: DiscordActionRow[] | undefined,
+): ActionRowBuilder<MessageActionRowComponentBuilder>[] | undefined {
+	if (!components || components.length === 0) {
+		return undefined;
+	}
+
+	try {
+		logger.info(`Components received: ${safeStringify(components)}`);
+
+		if (!Array.isArray(components)) {
+			logger.warn("Components is not an array, skipping component processing");
+			return undefined;
+		}
+
+		if (isDiscordJsComponentArray(components)) {
+			return components;
+		}
+
+		const discordComponents = (components as DiscordActionRow[])
+			.map((row: DiscordActionRow) => {
+				if (!row || typeof row !== "object" || row.type !== 1) {
+					logger.warn("Invalid component row structure, skipping");
+					return null;
+				}
+
+				const actionRow =
+					new ActionRowBuilder<MessageActionRowComponentBuilder>();
+
+				if (!Array.isArray(row.components)) {
+					logger.warn("Row components is not an array, skipping");
+					return null;
+				}
+
+				const validComponents = row.components
+					.map((comp: DiscordComponentOptions) => {
+						if (!comp || typeof comp !== "object") {
+							logger.warn("Invalid component, skipping");
+							return null;
+						}
+
+						try {
+							if (comp.type === 2) {
+								const button = new ButtonBuilder()
+									.setLabel(comp.label || "")
+									.setStyle(comp.style || 1);
+								// Link-style buttons carry a URL and no custom_id.
+								if (comp.url) {
+									button.setURL(comp.url);
+								} else {
+									button.setCustomId(comp.custom_id);
+								}
+								return button;
+							}
+
+							if (comp.type === 3) {
+								const selectMenu = new StringSelectMenuBuilder()
+									.setCustomId(comp.custom_id)
+									.setPlaceholder(comp.placeholder || "Select an option");
+
+								if (typeof comp.min_values === "number") {
+									selectMenu.setMinValues(comp.min_values);
+								}
+								if (typeof comp.max_values === "number") {
+									selectMenu.setMaxValues(comp.max_values);
+								}
+
+								if (Array.isArray(comp.options)) {
+									selectMenu.addOptions(
+										comp.options.map((option) => ({
+											label: option.label,
+											value: option.value,
+											description: option.description,
+										})),
+									);
+								}
+
+								return selectMenu;
+							}
+						} catch (err) {
+							logger.error(`Error creating component: ${err}`);
+							return null;
+						}
+						return null;
+					})
+					.filter(
+						(component): component is ButtonBuilder | StringSelectMenuBuilder =>
+							component !== null,
+					);
+
+				if (validComponents.length > 0) {
+					actionRow.addComponents(validComponents);
+					return actionRow;
+				}
+				return null;
+			})
+			.filter(
+				(row): row is ActionRowBuilder<MessageActionRowComponentBuilder> =>
+					row !== null,
+			);
+
+		return discordComponents.length > 0 ? discordComponents : undefined;
+	} catch (error) {
+		logger.error(`Error processing components: ${error}`);
+		return undefined;
+	}
+}
+
 export async function sendMessageInChunks(
 	channel: TextChannel,
 	content: string,
@@ -624,113 +754,9 @@ export async function sendMessageInChunks(
 				}
 
 				if (i === messages.length - 1 && components && components.length > 0) {
-					try {
-						logger.info(`Components received: ${safeStringify(components)}`);
-
-						if (!Array.isArray(components)) {
-							logger.warn(
-								"Components is not an array, skipping component processing",
-							);
-						} else if (isDiscordJsComponentArray(components)) {
-							options.components = components;
-						} else {
-							const discordComponents = (components as DiscordActionRow[])
-								.map((row: DiscordActionRow) => {
-									if (!row || typeof row !== "object" || row.type !== 1) {
-										logger.warn("Invalid component row structure, skipping");
-										return null;
-									}
-
-									if (row.type === 1) {
-										const actionRow =
-											new ActionRowBuilder<MessageActionRowComponentBuilder>();
-
-										if (!Array.isArray(row.components)) {
-											logger.warn("Row components is not an array, skipping");
-											return null;
-										}
-
-										const validComponents = row.components
-											.map((comp: DiscordComponentOptions) => {
-												if (!comp || typeof comp !== "object") {
-													logger.warn("Invalid component, skipping");
-													return null;
-												}
-
-												try {
-													if (comp.type === 2) {
-														const button = new ButtonBuilder()
-															.setLabel(comp.label || "")
-															.setStyle(comp.style || 1);
-														// Link-style buttons carry a URL and no custom_id.
-														if (comp.url) {
-															button.setURL(comp.url);
-														} else {
-															button.setCustomId(comp.custom_id);
-														}
-														return button;
-													}
-
-													if (comp.type === 3) {
-														const selectMenu = new StringSelectMenuBuilder()
-															.setCustomId(comp.custom_id)
-															.setPlaceholder(
-																comp.placeholder || "Select an option",
-															);
-
-														if (typeof comp.min_values === "number") {
-															selectMenu.setMinValues(comp.min_values);
-														}
-														if (typeof comp.max_values === "number") {
-															selectMenu.setMaxValues(comp.max_values);
-														}
-
-														if (Array.isArray(comp.options)) {
-															selectMenu.addOptions(
-																comp.options.map((option) => ({
-																	label: option.label,
-																	value: option.value,
-																	description: option.description,
-																})),
-															);
-														}
-
-														return selectMenu;
-													}
-												} catch (err) {
-													logger.error(`Error creating component: ${err}`);
-													return null;
-												}
-												return null;
-											})
-											.filter(
-												(
-													component,
-												): component is
-													| ButtonBuilder
-													| StringSelectMenuBuilder => component !== null,
-											);
-
-										if (validComponents.length > 0) {
-											actionRow.addComponents(validComponents);
-											return actionRow;
-										}
-									}
-									return null;
-								})
-								.filter(
-									(
-										row,
-									): row is ActionRowBuilder<MessageActionRowComponentBuilder> =>
-										row !== null,
-								);
-
-							if (discordComponents.length > 0) {
-								options.components = discordComponents;
-							}
-						}
-					} catch (error) {
-						logger.error(`Error processing components: ${error}`);
+					const built = buildDiscordComponents(components);
+					if (built) {
+						options.components = built;
 					}
 				}
 


### PR DESCRIPTION
## What

Discord's DM send branch called `user.send({ content, files })` with **no `components`**, so a components-only reply (e.g. a `[CHOICE]` block) rendered the "Choose an option:" fallback text with **zero buttons**. Guild replies went through `sendMessageInChunks` and kept their components; DMs silently dropped them. Fixes bug #1 of #14527.

## Root cause

A capability-check / payload-branch bug, **not** a Discord API constraint. Discord's API fully supports message components (buttons + string selects — the only types this connector emits) on DM channels. The guild path built components via `sendMessageInChunks`; the DM path was a bespoke `user.send()` call that never touched that builder.

## Fix

- Extract the `DiscordActionRow` → discord.js `ActionRowBuilder` assembly out of `sendMessageInChunks` into an exported **`buildDiscordComponents()`** so the DM and guild paths share **one** builder (no behavior change on the guild path — pure extraction).
- Add **`buildDmSendOptions()`** and use it in the DM branch so DM replies carry the same widget rows a guild reply does. Empty `components`/`files` keys are omitted (Discord rejects `components: []`).
- Documented in code that no DM-specific degradation is needed for the emitted component types; if a DM-forbidden type is ever added it should degrade to a link-out/text fallback rather than a silent drop.

## Tests

New `__tests__/dm-widget-components.test.ts` walks the exact production seam (`renderDiscordInteractions` → `buildDiscordComponents` → `buildDmSendOptions`):

```
✓ __tests__/dm-widget-components.test.ts (2 tests)
  ✓ a components-only reply yields DM send options carrying the action row + buttons
  ✓ omits the components key entirely for a plain-text reply (no empty array)
```

Connector suite spot-check green: `interactions.test.ts` (6), `messages-url.test.ts`, `sensitive-request-adapter.test.ts`, `connector-loop.harness.test.ts`. Plugin build + TS declarations green. Biome clean.

(`outbound-attachment.test.ts` failures observed locally are pre-existing SSRF/localhost-network env failures unrelated to this change — that file is untouched by this PR.)

## Scope / sibling connectors

Scoped to bug #1 (DM component drop). Draft-stream finalize (#2), overflow truncation (#3), and the Telegram-cap-on-Discord (#4) from #14527 are left for follow-ups.

**Root-cause note:** checked sibling connectors — **Telegram routes its DM path through the same `sendMessageInChunks` as groups, so it does NOT share this bug.** #14525 (iMessage/BlueBubbles raw-interaction leak) is a **different** defect and is **not** touched here.

— [sol-orch]