### PR TITLE
feat(test-console): local test console — every suite, connection-gated live lanes, saved credentials, persisted runs (#14572)

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "evidence:review:no-open": "node scripts/evidence-review/generate.mjs --no-open",
     "test:evidence-review": "node --test scripts/evidence-review/*.test.mjs",
     "test:all": "node packages/scripts/run-all-tests.mjs --all",
+    "test:console": "node packages/scripts/test-console/server.mjs",
     "test:release:contract": "bun run audit:apple-store-sandbox && bun run test:apple-entitlements && node packages/app-core/scripts/run-release-contract-suite.mjs",
     "test:regression-matrix:release": "node packages/app-core/scripts/run-eliza-app-core-script.mjs validate-regression-matrix.mjs --workflow release",
     "test:regression-matrix:release-contract": "node packages/app-core/scripts/run-eliza-app-core-script.mjs validate-regression-matrix.mjs --workflow release-contract",

--- a/packages/scripts/test-console/README.md
+++ b/packages/scripts/test-console/README.md
@@ -1,0 +1,61 @@
+# Local test console
+
+A one-command web console for running the repo's entire test surface locally:
+
+```bash
+bun run test:console        # → http://127.0.0.1:31338
+```
+
+It exists because most "needs-human" verification work is blocked on
+credentials: live suites need API keys, OAuth tokens, or an Eliza Cloud
+login that CI does not have. The console lets a human connect everything
+once, see exactly which suites those connections arm, run everything, and
+keep the artifacts.
+
+## What it does
+
+- **Enumerates every test task** from `run-all-tests.mjs --plan=json --all`
+  (unit, integration, e2e, ui, live, plus the cloud step) — the same source
+  of truth CI uses.
+- **Shows what's enabled/disabled and why.** Guarded live suites come from
+  `packages/scripts/lib/real-live-suites.mjs`; each task renders badges like
+  `armed`, `needs anthropic`, `opt-in`, `probe`, or `blocked`, computed with
+  the same `computeRealLiveAccounting` the post-merge lane prints.
+- **Connections panel**: save API keys and tokens for every service the
+  guarded suites need (LLM providers, Discord/Telegram/Slack/X/WhatsApp,
+  GitHub/Linear/Calendly/Twilio, health connectors, web3, Postgres, …), log
+  in to Eliza Cloud via the device-code flow, or mint Google OAuth refresh
+  tokens through the console's loopback callback. Each connection has a
+  read-only **Verify** probe that proves the credential against the real API
+  before any suite depends on it.
+- **Runs with live status** (queued → running → passed/failed/skipped) over
+  SSE, with per-task log streaming, run/re-run-failed/re-run-one/cancel, and
+  filterable results.
+- **Persists everything** under `~/.eliza/test-console/` (override with
+  `ELIZA_TEST_CONSOLE_DIR`, or `ELIZA_STATE_DIR/test-console`):
+  - `credentials.json` — saved connection values, `0600`
+  - `runs/<runId>/run.json` + `runs/<runId>/logs/*.log` — full run archives
+  - `history.json` — last status per task, so "Re-run failed" works across
+    restarts
+  - `settings.json` — opt-in gate toggles, cloud base URL
+
+## Lanes
+
+- **Deterministic (keyless)** — `TEST_LANE=pr` semantics: real-API suites
+  excluded, LLM proxy on. Everything runs without secrets.
+- **Live (real APIs)** — `TEST_LANE=post-merge` semantics: saved credentials
+  are injected into the child env, guarded suites arm/self-skip exactly as
+  the post-merge lane accounts for them. Opt-in gates (destructive/heavy
+  suites) stay off unless toggled explicitly.
+
+Each task executes as its own `run-all-tests.mjs --filter='^<label>$'`
+invocation, so lane env, Postgres auto-provisioning, and empty-suite skip
+logic stay identical to CI. Credentials never enter the console server's own
+environment; they are injected per child process.
+
+## Security
+
+The server binds `127.0.0.1` only and must stay that way: it stores raw
+keys and executes repo code. Saved secrets never reach the browser — the UI
+gets presence + last-4 hints. Private keys are never transmitted for
+verification (format check only).

--- a/packages/scripts/test-console/__tests__/connections-coverage.test.ts
+++ b/packages/scripts/test-console/__tests__/connections-coverage.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Drift guard: every env var a guarded live suite requires, and every secret
+ * the post-merge lane warns about, must be owned by a connection in the
+ * console catalog — otherwise the console renders a gate it cannot explain
+ * or configure. Runs with `bun test`; pure data, no network.
+ */
+
+import { describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { GUARDED_REAL_LIVE_SUITES } from "../../lib/real-live-suites.mjs";
+import {
+  CONNECTIONS,
+  OPT_IN_GATES,
+  varOwnership,
+} from "../lib/connections.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+describe("connection catalog coverage", () => {
+  const owners = varOwnership();
+
+  test("every guarded-suite env var maps to a connection", () => {
+    const unmapped: string[] = [];
+    for (const entry of GUARDED_REAL_LIVE_SUITES) {
+      const vars = [...(entry.requires ?? []), ...(entry.anyOf ?? []).flat()];
+      for (const key of vars) {
+        if (!owners.has(key)) unmapped.push(`${key} (${entry.file})`);
+      }
+    }
+    expect(unmapped).toEqual([]);
+  });
+
+  test("every guarded-suite opt-in gate is a console toggle", () => {
+    const toggles = new Set(OPT_IN_GATES.map((gate) => gate.key));
+    const missing = GUARDED_REAL_LIVE_SUITES.filter(
+      (entry) => entry.optIn && !toggles.has(entry.optIn),
+    ).map((entry) => `${entry.optIn} (${entry.file})`);
+    expect(missing).toEqual([]);
+  });
+
+  test("every post-merge secret maps to a connection", () => {
+    const secretsFile = path.resolve(here, "../../post-merge-secrets.txt");
+    const secrets = fs
+      .readFileSync(secretsFile, "utf8")
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith("#"));
+    const unmapped = secrets.filter((key) => !owners.has(key));
+    expect(unmapped).toEqual([]);
+  });
+
+  test("connection ids are unique and fields are non-empty", () => {
+    const ids = CONNECTIONS.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const connection of CONNECTIONS) {
+      expect(connection.fields.length).toBeGreaterThan(0);
+      expect(connection.fields.some((f) => f.required)).toBe(true);
+    }
+  });
+});

--- a/packages/scripts/test-console/__tests__/console-lib.test.ts
+++ b/packages/scripts/test-console/__tests__/console-lib.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Unit coverage for the console's own moving parts: result classification
+ * (log-line-first, exit-code fallback), the credential store roundtrip in a
+ * temp dir, and the registry's real plan discovery + credential gating (the
+ * one slow test — it shells the actual run-all-tests plan, no mocks).
+ */
+
+import { beforeAll, describe, expect, test } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { classifyResult, countStatuses } from "../lib/runner.mjs";
+
+const LABEL = "@elizaos/logger (packages/logger)#test";
+
+describe("classifyResult", () => {
+  test("FAIL line wins even with exit 0", () => {
+    expect(
+      classifyResult({
+        label: LABEL,
+        code: 0,
+        signal: null,
+        tail: `[eliza-test] FAIL ${LABEL} (10ms)`,
+        cancelled: false,
+      }),
+    ).toBe("failed");
+  });
+
+  test("PASS line classifies passed", () => {
+    expect(
+      classifyResult({
+        label: LABEL,
+        code: 0,
+        signal: null,
+        tail: `[eliza-test] PASS ${LABEL} (10ms)`,
+        cancelled: false,
+      }),
+    ).toBe("passed");
+  });
+
+  test("SKIP line classifies skipped", () => {
+    expect(
+      classifyResult({
+        label: LABEL,
+        code: 0,
+        signal: null,
+        tail: `[eliza-test] SKIP ${LABEL} (no local test files)`,
+        cancelled: false,
+      }),
+    ).toBe("skipped");
+  });
+
+  test("exit 3 without status lines is the vacuous-green skip", () => {
+    expect(
+      classifyResult({
+        label: LABEL,
+        code: 3,
+        signal: null,
+        tail: "",
+        cancelled: false,
+      }),
+    ).toBe("skipped");
+  });
+
+  test("signal death is failure; cancellation wins over everything", () => {
+    expect(
+      classifyResult({
+        label: LABEL,
+        code: null,
+        signal: "SIGTERM",
+        tail: "",
+        cancelled: false,
+      }),
+    ).toBe("failed");
+    expect(
+      classifyResult({
+        label: LABEL,
+        code: 1,
+        signal: null,
+        tail: "",
+        cancelled: true,
+      }),
+    ).toBe("cancelled");
+  });
+
+  test("countStatuses aggregates", () => {
+    expect(
+      countStatuses([
+        { status: "passed" },
+        { status: "passed" },
+        { status: "failed" },
+      ]),
+    ).toEqual({ passed: 2, failed: 1 });
+  });
+});
+
+describe("store roundtrip", () => {
+  let store: typeof import("../lib/store.mjs");
+
+  beforeAll(async () => {
+    process.env.ELIZA_TEST_CONSOLE_DIR = fs.mkdtempSync(
+      path.join(os.tmpdir(), "eliza-test-console-"),
+    );
+    store = await import("../lib/store.mjs");
+  });
+
+  test("credentials save with 0600 and merge into env", () => {
+    store.setConnection("openai", { OPENAI_API_KEY: "sk-test-123" });
+    store.setConnection("github", { GITHUB_TOKEN: "ghp_test" });
+    const file = path.join(
+      process.env.ELIZA_TEST_CONSOLE_DIR!,
+      "credentials.json",
+    );
+    expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+    expect(store.credentialsToEnv()).toEqual({
+      OPENAI_API_KEY: "sk-test-123",
+      GITHUB_TOKEN: "ghp_test",
+    });
+    store.removeConnection("github");
+    expect(store.credentialsToEnv()).toEqual({ OPENAI_API_KEY: "sk-test-123" });
+  });
+
+  test("run manifests and history persist and list", () => {
+    store.newRunDir("run-1");
+    store.saveRunManifest("run-1", {
+      runId: "run-1",
+      lane: "pr",
+      counts: { passed: 1 },
+    });
+    store.recordTaskStatus(LABEL, {
+      status: "failed",
+      runId: "run-1",
+      at: "now",
+    });
+    expect(store.listRuns()[0].runId).toBe("run-1");
+    expect(store.loadHistory()[LABEL].status).toBe("failed");
+  });
+});
+
+describe("registry (real plan discovery)", () => {
+  test("plan discovers the workspace and credentials flip suite gating", async () => {
+    const { buildRegistry } = await import("../lib/registry.mjs");
+
+    const without = buildRegistry({
+      savedCredentials: {},
+      optInToggles: {},
+      history: {},
+    });
+    expect(without.tasks.length).toBeGreaterThan(200);
+    expect(without.orphanSuites).toEqual([]);
+    expect(without.connections.length).toBeGreaterThan(30);
+
+    const webSearchTask = without.tasks.find((t) =>
+      t.liveSuites.some((s) => s.file.includes("plugin-web-search")),
+    );
+    expect(webSearchTask).toBeDefined();
+
+    const suiteState = (registry: ReturnType<typeof buildRegistry>) =>
+      registry.tasks
+        .flatMap((t) => t.liveSuites)
+        .find((s) => s.file.includes("webSearchService.real.test.ts"))!.state;
+
+    // Deterministic regardless of ambient env: with an explicit key the suite
+    // arms; the no-credentials expectation only holds on machines that don't
+    // already export TAVILY_API_KEY, so assert the armed side only.
+    const withKey = buildRegistry({
+      savedCredentials: { tavily: { TAVILY_API_KEY: "tvly-test" } },
+      optInToggles: {},
+      history: {},
+    });
+    expect(suiteState(withKey)).toBe("armed");
+  }, 30_000);
+});

--- a/packages/scripts/test-console/lib/connections.mjs
+++ b/packages/scripts/test-console/lib/connections.mjs
@@ -1,0 +1,895 @@
+/**
+ * Connection catalog for the local test console: every credentialed service
+ * the repo's live/guarded test suites can consume, described as data.
+ *
+ * Each connection declares the env vars it provides (`fields`), where a human
+ * obtains the credential (`obtain`), and a cheap read-only HTTP probe
+ * (`verify`) the console runs to prove a saved credential actually works
+ * before any test depends on it. Gating is derived, not hand-mapped: a suite
+ * from GUARDED_REAL_LIVE_SUITES is enabled when every env var it `requires`
+ * is provided by some configured connection (or the ambient environment), so
+ * the catalog only has to keep var→connection ownership complete —
+ * __tests__/connections-coverage.test.ts enforces that mechanically against
+ * the manifest and packages/scripts/post-merge-secrets.txt.
+ *
+ * Verify probes are data, not code: `{ kind: "http", url, method?, headers?,
+ * body?, okStatus? }` with `{{VAR}}` placeholders substituted from the saved
+ * values. `kind: "format"` just pattern-checks locally (private keys we must
+ * never send anywhere); `kind: "none"` means the credential is only provable
+ * by running its suite.
+ */
+
+/** Deliberate operator opt-in gates (destructive/heavy suites). The console
+ * surfaces these as toggles, never auto-arms them. */
+export const OPT_IN_GATES = [
+  { key: "ELIZA_RUN_LIVE_TESTS", label: "Live model tests (core)" },
+  { key: "ELIZA_LIVE_EVM_RPC_TEST", label: "Live EVM RPC tests" },
+  { key: "ELIZA_LIVE_APPLE_REMINDERS_TEST", label: "Apple Reminders (macOS)" },
+  {
+    key: "ORCHESTRATOR_LIVE_MULTI_ACCOUNT",
+    label: "Orchestrator multi-account",
+  },
+  { key: "RUN_LIVE_NATIVE_ACP", label: "Native ACP smoke" },
+  { key: "RUN_LIVE_ACPX", label: "ACPX sub-agent router" },
+  { key: "FORCE_OSWORLD_BENCHMARK", label: "OSWorld benchmark" },
+];
+
+export const CONNECTIONS = [
+  // --- LLM providers -------------------------------------------------------
+  {
+    id: "openai",
+    label: "OpenAI",
+    category: "llm",
+    kind: "api-key",
+    obtain: "https://platform.openai.com/api-keys",
+    fields: [
+      { key: "OPENAI_API_KEY", label: "API key", secret: true, required: true },
+      {
+        key: "OPENAI_API_KEY_REAL",
+        label: "Real-drift API key (optional; defaults to API key)",
+        secret: true,
+        required: false,
+      },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://api.openai.com/v1/models",
+      headers: { Authorization: "Bearer {{OPENAI_API_KEY}}" },
+    },
+  },
+  {
+    id: "anthropic",
+    label: "Anthropic",
+    category: "llm",
+    kind: "api-key",
+    obtain: "https://console.anthropic.com/settings/keys",
+    fields: [
+      {
+        key: "ANTHROPIC_API_KEY",
+        label: "API key",
+        secret: true,
+        required: true,
+      },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://api.anthropic.com/v1/models",
+      headers: {
+        "x-api-key": "{{ANTHROPIC_API_KEY}}",
+        "anthropic-version": "2023-06-01",
+      },
+    },
+  },
+  {
+    id: "cerebras",
+    label: "Cerebras",
+    category: "llm",
+    kind: "api-key",
+    obtain: "https://cloud.cerebras.ai/",
+    fields: [
+      {
+        key: "CEREBRAS_API_KEY",
+        label: "API key",
+        secret: true,
+        required: true,
+      },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://api.cerebras.ai/v1/models",
+      headers: { Authorization: "Bearer {{CEREBRAS_API_KEY}}" },
+    },
+  },
+  {
+    id: "groq",
+    label: "Groq",
+    category: "llm",
+    kind: "api-key",
+    obtain: "https://console.groq.com/keys",
+    fields: [
+      { key: "GROQ_API_KEY", label: "API key", secret: true, required: true },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://api.groq.com/openai/v1/models",
+      headers: { Authorization: "Bearer {{GROQ_API_KEY}}" },
+    },
+  },
+  {
+    id: "google-genai",
+    label: "Google Generative AI",
+    category: "llm",
+    kind: "api-key",
+    obtain: "https://aistudio.google.com/apikey",
+    fields: [
+      {
+        key: "GOOGLE_GENERATIVE_AI_API_KEY",
+        label: "API key",
+        secret: true,
+        required: true,
+      },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://generativelanguage.googleapis.com/v1beta/models?key={{GOOGLE_GENERATIVE_AI_API_KEY}}",
+    },
+  },
+  {
+    id: "openrouter",
+    label: "OpenRouter",
+    category: "llm",
+    kind: "api-key",
+    obtain: "https://openrouter.ai/settings/keys",
+    fields: [
+      {
+        key: "OPENROUTER_API_KEY",
+        label: "API key",
+        secret: true,
+        required: true,
+      },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://openrouter.ai/api/v1/key",
+      headers: { Authorization: "Bearer {{OPENROUTER_API_KEY}}" },
+    },
+  },
+  {
+    id: "xai",
+    label: "xAI",
+    category: "llm",
+    kind: "api-key",
+    obtain: "https://console.x.ai/",
+    fields: [
+      { key: "XAI_API_KEY", label: "API key", secret: true, required: true },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://api.x.ai/v1/models",
+      headers: { Authorization: "Bearer {{XAI_API_KEY}}" },
+    },
+  },
+  {
+    id: "elevenlabs",
+    label: "ElevenLabs",
+    category: "llm",
+    kind: "api-key",
+    obtain: "https://elevenlabs.io/app/settings/api-keys",
+    fields: [
+      {
+        key: "ELEVENLABS_API_KEY",
+        label: "API key",
+        secret: true,
+        required: true,
+      },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://api.elevenlabs.io/v1/user",
+      headers: { "xi-api-key": "{{ELEVENLABS_API_KEY}}" },
+    },
+  },
+  {
+    id: "atlascloud",
+    label: "AtlasCloud (media generation)",
+    category: "llm",
+    kind: "api-key",
+    obtain: "https://www.atlascloud.ai/",
+    fields: [
+      {
+        key: "ATLASCLOUD_API_KEY",
+        label: "API key",
+        secret: true,
+        required: true,
+      },
+    ],
+    verify: { kind: "none" },
+  },
+  {
+    id: "ollama",
+    label: "Ollama (local)",
+    category: "llm",
+    kind: "endpoint",
+    obtain: "https://ollama.com/download — then `ollama serve`",
+    fields: [
+      {
+        key: "OLLAMA_API_ENDPOINT",
+        label: "API endpoint",
+        secret: false,
+        required: true,
+        placeholder: "http://127.0.0.1:11434",
+      },
+    ],
+    verify: { kind: "http", url: "{{OLLAMA_API_ENDPOINT}}/api/tags" },
+  },
+
+  // --- Messaging connectors ------------------------------------------------
+  {
+    id: "discord",
+    label: "Discord",
+    category: "messaging",
+    kind: "token",
+    obtain:
+      "https://discord.com/developers/applications — bot token; invite the bot to a throwaway test guild",
+    fields: [
+      {
+        key: "DISCORD_BOT_TOKEN",
+        label: "Bot token",
+        secret: true,
+        required: true,
+      },
+      {
+        key: "DISCORD_TEST_GUILD_ID",
+        label: "Test guild ID",
+        secret: false,
+        required: true,
+      },
+      {
+        key: "DISCORD_API_TOKEN",
+        label: "Runtime bot token (optional; defaults to bot token)",
+        secret: true,
+        required: false,
+      },
+      {
+        key: "DISCORD_APPLICATION_ID",
+        label: "Application ID (optional)",
+        secret: false,
+        required: false,
+      },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://discord.com/api/v10/users/@me",
+      headers: { Authorization: "Bot {{DISCORD_BOT_TOKEN}}" },
+    },
+  },
+  {
+    id: "telegram",
+    label: "Telegram",
+    category: "messaging",
+    kind: "token",
+    obtain: "https://t.me/BotFather — create a bot; add it to a test chat",
+    fields: [
+      {
+        key: "TELEGRAM_BOT_TOKEN",
+        label: "Bot token",
+        secret: true,
+        required: true,
+      },
+      {
+        key: "TELEGRAM_TEST_CHAT_ID",
+        label: "Test chat ID",
+        secret: false,
+        required: true,
+      },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://api.telegram.org/bot{{TELEGRAM_BOT_TOKEN}}/getMe",
+    },
+  },
+  {
+    id: "slack",
+    label: "Slack",
+    category: "messaging",
+    kind: "token",
+    obtain:
+      "https://api.slack.com/apps — bot token (xoxb-) with a test channel the app is in",
+    fields: [
+      {
+        key: "SLACK_BOT_TOKEN",
+        label: "Bot token (xoxb-)",
+        secret: true,
+        required: true,
+      },
+      {
+        key: "SLACK_TEST_CHANNEL_ID",
+        label: "Test channel ID",
+        secret: false,
+        required: true,
+      },
+      {
+        key: "SLACK_APP_TOKEN",
+        label: "App token (xapp-, Socket Mode; optional)",
+        secret: true,
+        required: false,
+      },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://slack.com/api/auth.test",
+      method: "POST",
+      headers: { Authorization: "Bearer {{SLACK_BOT_TOKEN}}" },
+      okBodyPattern: '"ok"\\s*:\\s*true',
+    },
+  },
+  {
+    id: "whatsapp",
+    label: "WhatsApp (Cloud API)",
+    category: "messaging",
+    kind: "token",
+    obtain:
+      "https://developers.facebook.com/apps — WhatsApp Cloud API access token",
+    fields: [
+      {
+        key: "WHATSAPP_TOKEN",
+        label: "Access token",
+        secret: true,
+        required: true,
+      },
+      {
+        key: "WHATSAPP_PHONE_NUMBER_ID",
+        label: "Phone number ID",
+        secret: false,
+        required: true,
+      },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://graph.facebook.com/v19.0/{{WHATSAPP_PHONE_NUMBER_ID}}",
+      headers: { Authorization: "Bearer {{WHATSAPP_TOKEN}}" },
+    },
+  },
+  {
+    id: "x",
+    label: "X (Twitter)",
+    category: "messaging",
+    kind: "token",
+    obtain: "https://developer.x.com/en/portal/dashboard — app bearer token",
+    fields: [
+      {
+        key: "X_BEARER_TOKEN",
+        label: "App bearer token",
+        secret: true,
+        required: true,
+      },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://api.x.com/2/users/by/username/x",
+      headers: { Authorization: "Bearer {{X_BEARER_TOKEN}}" },
+    },
+  },
+  {
+    id: "bluesky",
+    label: "Bluesky",
+    category: "messaging",
+    kind: "token",
+    obtain: "https://bsky.app/settings/app-passwords",
+    fields: [
+      {
+        key: "BLUESKY_HANDLE",
+        label: "Handle",
+        secret: false,
+        required: false,
+        placeholder: "example.bsky.social",
+      },
+      {
+        key: "BLUESKY_PASSWORD",
+        label: "App password",
+        secret: true,
+        required: true,
+      },
+    ],
+    verify: { kind: "none" },
+  },
+  {
+    id: "farcaster",
+    label: "Farcaster (Neynar)",
+    category: "messaging",
+    kind: "api-key",
+    obtain: "https://neynar.com/ — API key (+ signer for posting)",
+    fields: [
+      {
+        key: "FARCASTER_NEYNAR_API_KEY",
+        label: "Neynar API key",
+        secret: true,
+        required: true,
+      },
+      {
+        key: "FARCASTER_FID",
+        label: "FID (optional)",
+        secret: false,
+        required: false,
+      },
+      {
+        key: "FARCASTER_SIGNER_UUID",
+        label: "Signer UUID (optional)",
+        secret: true,
+        required: false,
+      },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://api.neynar.com/v2/farcaster/user/bulk?fids=3",
+      headers: { "x-api-key": "{{FARCASTER_NEYNAR_API_KEY}}" },
+    },
+  },
+
+  // --- SaaS ----------------------------------------------------------------
+  {
+    id: "github",
+    label: "GitHub",
+    category: "saas",
+    kind: "token",
+    obtain: "https://github.com/settings/tokens",
+    fields: [
+      {
+        key: "GITHUB_TOKEN",
+        label: "Personal access token",
+        secret: true,
+        required: true,
+      },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://api.github.com/rate_limit",
+      headers: {
+        Authorization: "Bearer {{GITHUB_TOKEN}}",
+        "User-Agent": "eliza-test-console",
+      },
+    },
+  },
+  {
+    id: "linear",
+    label: "Linear",
+    category: "saas",
+    kind: "api-key",
+    obtain: "https://linear.app/settings/api",
+    fields: [
+      { key: "LINEAR_API_KEY", label: "API key", secret: true, required: true },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://api.linear.app/graphql",
+      method: "POST",
+      headers: {
+        Authorization: "{{LINEAR_API_KEY}}",
+        "Content-Type": "application/json",
+      },
+      body: '{"query":"{ viewer { id } }"}',
+    },
+  },
+  {
+    id: "calendly",
+    label: "Calendly",
+    category: "saas",
+    kind: "token",
+    obtain:
+      "https://calendly.com/integrations/api_webhooks — personal access token",
+    fields: [
+      {
+        key: "CALENDLY_ACCESS_TOKEN",
+        label: "Personal access token",
+        secret: true,
+        required: true,
+      },
+      {
+        key: "CALENDLY_API_KEY",
+        label: "API key (legacy alias; optional)",
+        secret: true,
+        required: false,
+      },
+      {
+        key: "ELIZA_E2E_CALENDLY_ACCESS_TOKEN",
+        label: "Dedicated e2e token (optional; defaults to access token)",
+        secret: true,
+        required: false,
+      },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://api.calendly.com/users/me",
+      headers: { Authorization: "Bearer {{CALENDLY_ACCESS_TOKEN}}" },
+    },
+  },
+  {
+    id: "twilio",
+    label: "Twilio",
+    category: "saas",
+    kind: "api-key",
+    obtain: "https://console.twilio.com/ — account SID + auth token",
+    fields: [
+      {
+        key: "TWILIO_ACCOUNT_SID",
+        label: "Account SID",
+        secret: false,
+        required: true,
+      },
+      {
+        key: "TWILIO_AUTH_TOKEN",
+        label: "Auth token",
+        secret: true,
+        required: true,
+      },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://api.twilio.com/2010-04-01/Accounts/{{TWILIO_ACCOUNT_SID}}.json",
+      basicAuth: ["{{TWILIO_ACCOUNT_SID}}", "{{TWILIO_AUTH_TOKEN}}"],
+    },
+  },
+  {
+    id: "google-oauth",
+    label: "Google OAuth (Workspace APIs)",
+    category: "saas",
+    kind: "oauth",
+    obtain:
+      "https://console.cloud.google.com/apis/credentials — OAuth client (Desktop); the console's Connect button mints the refresh token via loopback",
+    oauth: "google",
+    fields: [
+      {
+        key: "GOOGLE_CLIENT_ID",
+        label: "OAuth client ID",
+        secret: false,
+        required: true,
+      },
+      {
+        key: "GOOGLE_CLIENT_SECRET",
+        label: "OAuth client secret",
+        secret: true,
+        required: true,
+      },
+      {
+        key: "GOOGLE_OAUTH_REFRESH_TOKEN",
+        label: "Refresh token (minted by Connect)",
+        secret: true,
+        required: true,
+      },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://oauth2.googleapis.com/token",
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: "client_id={{GOOGLE_CLIENT_ID}}&client_secret={{GOOGLE_CLIENT_SECRET}}&refresh_token={{GOOGLE_OAUTH_REFRESH_TOKEN}}&grant_type=refresh_token",
+    },
+  },
+  {
+    id: "google-calendar",
+    label: "Google Calendar (access token)",
+    category: "calendar",
+    kind: "oauth",
+    obtain:
+      "Minted from the Google OAuth connection (Connect button) or paste a short-lived access token",
+    oauth: "google-calendar",
+    fields: [
+      {
+        key: "GOOGLE_CALENDAR_ACCESS_TOKEN",
+        label: "Access token",
+        secret: true,
+        required: true,
+      },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://www.googleapis.com/calendar/v3/users/me/calendarList?maxResults=1",
+      headers: { Authorization: "Bearer {{GOOGLE_CALENDAR_ACCESS_TOKEN}}" },
+    },
+  },
+  {
+    id: "shopify",
+    label: "Shopify",
+    category: "saas",
+    kind: "api-key",
+    obtain: "https://admin.shopify.com/ — custom app admin API token",
+    fields: [
+      {
+        key: "SHOPIFY_API_KEY",
+        label: "API key",
+        secret: true,
+        required: true,
+      },
+    ],
+    verify: { kind: "none" },
+  },
+  {
+    id: "tavily",
+    label: "Tavily (web search)",
+    category: "saas",
+    kind: "api-key",
+    obtain: "https://app.tavily.com/",
+    fields: [
+      { key: "TAVILY_API_KEY", label: "API key", secret: true, required: true },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://api.tavily.com/search",
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: '{"api_key":"{{TAVILY_API_KEY}}","query":"ping","max_results":1}',
+    },
+  },
+
+  // --- Web3 ----------------------------------------------------------------
+  {
+    id: "birdeye",
+    label: "Birdeye",
+    category: "web3",
+    kind: "api-key",
+    obtain: "https://bds.birdeye.so/",
+    fields: [
+      {
+        key: "BIRDEYE_API_KEY",
+        label: "API key",
+        secret: true,
+        required: true,
+      },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://public-api.birdeye.so/defi/price?address=So11111111111111111111111111111111111111112",
+      headers: { "X-API-KEY": "{{BIRDEYE_API_KEY}}", "x-chain": "solana" },
+    },
+  },
+  {
+    id: "hyperliquid",
+    label: "Hyperliquid",
+    category: "web3",
+    kind: "private-key",
+    obtain: "Test wallet private key funded on Hyperliquid testnet",
+    fields: [
+      {
+        key: "HYPERLIQUID_PRIVATE_KEY",
+        label: "Private key",
+        secret: true,
+        required: true,
+      },
+    ],
+    // Never transmit private keys anywhere — local shape check only.
+    verify: { kind: "format", pattern: "^(0x)?[0-9a-fA-F]{64}$" },
+  },
+  {
+    id: "polymarket",
+    label: "Polymarket",
+    category: "web3",
+    kind: "api-key",
+    obtain: "https://docs.polymarket.com/ — API key",
+    fields: [
+      {
+        key: "POLYMARKET_API_KEY",
+        label: "API key",
+        secret: true,
+        required: true,
+      },
+    ],
+    verify: { kind: "none" },
+  },
+
+  // --- Health connectors ---------------------------------------------------
+  {
+    id: "strava",
+    label: "Strava",
+    category: "health",
+    kind: "token",
+    obtain: "https://www.strava.com/settings/api — OAuth access token",
+    fields: [
+      {
+        key: "STRAVA_ACCESS_TOKEN",
+        label: "Access token",
+        secret: true,
+        required: true,
+      },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://www.strava.com/api/v3/athlete",
+      headers: { Authorization: "Bearer {{STRAVA_ACCESS_TOKEN}}" },
+    },
+  },
+  {
+    id: "oura",
+    label: "Oura",
+    category: "health",
+    kind: "token",
+    obtain: "https://cloud.ouraring.com/personal-access-tokens",
+    fields: [
+      {
+        key: "OURA_ACCESS_TOKEN",
+        label: "Access token",
+        secret: true,
+        required: true,
+      },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://api.ouraring.com/v2/usercollection/personal_info",
+      headers: { Authorization: "Bearer {{OURA_ACCESS_TOKEN}}" },
+    },
+  },
+  {
+    id: "fitbit",
+    label: "Fitbit",
+    category: "health",
+    kind: "token",
+    obtain: "https://dev.fitbit.com/apps — OAuth access token",
+    fields: [
+      {
+        key: "FITBIT_ACCESS_TOKEN",
+        label: "Access token",
+        secret: true,
+        required: true,
+      },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://api.fitbit.com/1/user/-/profile.json",
+      headers: { Authorization: "Bearer {{FITBIT_ACCESS_TOKEN}}" },
+    },
+  },
+  {
+    id: "withings",
+    label: "Withings",
+    category: "health",
+    kind: "token",
+    obtain: "https://developer.withings.com/ — OAuth access token",
+    fields: [
+      {
+        key: "WITHINGS_ACCESS_TOKEN",
+        label: "Access token",
+        secret: true,
+        required: true,
+      },
+    ],
+    verify: {
+      kind: "http",
+      url: "https://wbsapi.withings.net/v2/user?action=getdevice",
+      headers: { Authorization: "Bearer {{WITHINGS_ACCESS_TOKEN}}" },
+      okBodyPattern: '"status"\\s*:\\s*0',
+    },
+  },
+
+  // --- Push delivery -------------------------------------------------------
+  {
+    id: "apns",
+    label: "Apple Push (APNs)",
+    category: "push",
+    kind: "api-key",
+    obtain: "https://developer.apple.com/account/resources/authkeys/list",
+    fields: [
+      {
+        key: "ELIZA_APNS_KEY_ID",
+        label: "Key ID",
+        secret: false,
+        required: true,
+      },
+      {
+        key: "ELIZA_APNS_TEAM_ID",
+        label: "Team ID",
+        secret: false,
+        required: false,
+      },
+      {
+        key: "ELIZA_APNS_PRIVATE_KEY",
+        label: "Private key (.p8 contents)",
+        secret: true,
+        required: false,
+      },
+    ],
+    verify: { kind: "none" },
+  },
+  {
+    id: "fcm",
+    label: "Firebase Cloud Messaging",
+    category: "push",
+    kind: "api-key",
+    obtain: "Firebase console — service account JSON",
+    fields: [
+      {
+        key: "ELIZA_FCM_SERVICE_ACCOUNT",
+        label: "Service account JSON",
+        secret: true,
+        required: true,
+        multiline: true,
+      },
+    ],
+    verify: { kind: "format", pattern: '"private_key"' },
+  },
+
+  // --- Infrastructure ------------------------------------------------------
+  {
+    id: "postgres",
+    label: "PostgreSQL",
+    category: "infra",
+    kind: "endpoint",
+    obtain:
+      "Local Postgres, e.g. `docker run -p 5432:5432 -e POSTGRES_PASSWORD=eliza postgres:17`",
+    fields: [
+      {
+        key: "POSTGRES_URL",
+        label: "Connection URL",
+        secret: true,
+        required: true,
+        placeholder: "postgres://postgres:eliza@127.0.0.1:5432/postgres",
+      },
+    ],
+    verify: { kind: "tcp", urlVar: "POSTGRES_URL" },
+  },
+  {
+    id: "eliza-cloud",
+    label: "Eliza Cloud",
+    category: "cloud",
+    kind: "cloud-login",
+    obtain:
+      "Log in with the Connect button (device-code flow) or paste an API key",
+    oauth: "eliza-cloud",
+    fields: [
+      {
+        key: "ELIZAOS_CLOUD_API_KEY",
+        label: "API key",
+        secret: true,
+        required: true,
+      },
+      {
+        key: "ELIZA_CLOUD_API_KEY",
+        label: "API key (legacy alias; optional, kept in sync)",
+        secret: true,
+        required: false,
+      },
+      {
+        key: "ELIZAOS_CLOUD_BASE_URL",
+        label: "Base URL (optional)",
+        secret: false,
+        required: false,
+        placeholder: "https://elizacloud.ai",
+      },
+    ],
+    verify: { kind: "none" },
+  },
+];
+
+export function connectionById(id) {
+  return CONNECTIONS.find((c) => c.id === id);
+}
+
+/** Map every provided env var to the connection(s) that own it. */
+export function varOwnership() {
+  const owners = new Map();
+  for (const connection of CONNECTIONS) {
+    for (const field of connection.fields) {
+      const list = owners.get(field.key) ?? [];
+      list.push(connection.id);
+      owners.set(field.key, list);
+    }
+  }
+  return owners;
+}
+
+/**
+ * A connection is "configured" when all its required fields have non-empty
+ * values from saved credentials or the ambient environment (so devs who
+ * already export keys in their shell get credit without re-entering them).
+ */
+export function connectionStatus(connection, savedValues, env = process.env) {
+  const values = {};
+  const missing = [];
+  for (const field of connection.fields) {
+    const value = savedValues?.[field.key] ?? env[field.key] ?? "";
+    if (typeof value === "string" && value.trim() !== "") {
+      values[field.key] = value;
+    } else if (field.required) {
+      missing.push(field.key);
+    }
+  }
+  return { configured: missing.length === 0, missing, values };
+}

--- a/packages/scripts/test-console/lib/oauth.mjs
+++ b/packages/scripts/test-console/lib/oauth.mjs
@@ -1,0 +1,136 @@
+/**
+ * Interactive credential flows the console can drive end-to-end: the Eliza
+ * Cloud device-code login and a Google OAuth loopback flow. Everything else
+ * in the catalog is paste-a-token.
+ *
+ * Cloud login speaks the same protocol as ElizaCloudClient.startCliLogin /
+ * waitForCliLogin in packages/cloud/sdk/src/client.ts (POST
+ * /api/auth/cli-session, then poll /api/auth/cli-session/:id until
+ * `authenticated`), reimplemented over bare fetch so the console keeps zero
+ * workspace imports and works in a half-built checkout — protocol drift there
+ * is an API-versioning event, not a refactor hazard.
+ *
+ * The Google flow leans on the console being an HTTP server already: the
+ * redirect URI is the console's own /oauth/google/callback route, so no
+ * second loopback listener is needed. It requests offline access and returns
+ * a refresh token (GOOGLE_OAUTH_REFRESH_TOKEN) plus a fresh calendar access
+ * token (GOOGLE_CALENDAR_ACCESS_TOKEN) — the two vars the live suites gate on.
+ */
+
+import crypto from "node:crypto";
+
+export const DEFAULT_CLOUD_BASE_URL = "https://elizacloud.ai";
+
+const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const GOOGLE_SCOPES = [
+  "https://www.googleapis.com/auth/calendar",
+  "https://www.googleapis.com/auth/userinfo.email",
+].join(" ");
+
+/** Pending interactive flows keyed by opaque state token. */
+const pendingFlows = new Map();
+
+export async function startCloudLogin({
+  baseUrl = DEFAULT_CLOUD_BASE_URL,
+} = {}) {
+  const response = await fetch(`${baseUrl}/api/auth/cli-session`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ client: "eliza-test-console" }),
+  });
+  if (!response.ok) {
+    throw new Error(`cloud cli-session failed: HTTP ${response.status}`);
+  }
+  const { sessionId, browserUrl } = await response.json();
+  return { sessionId, browserUrl };
+}
+
+export async function pollCloudLogin({
+  sessionId,
+  baseUrl = DEFAULT_CLOUD_BASE_URL,
+}) {
+  const response = await fetch(`${baseUrl}/api/auth/cli-session/${sessionId}`);
+  if (!response.ok) {
+    throw new Error(`cloud cli-session poll failed: HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+export function startGoogleFlow({ clientId, clientSecret, redirectUri }) {
+  const state = crypto.randomBytes(24).toString("hex");
+  pendingFlows.set(state, {
+    provider: "google",
+    clientId,
+    clientSecret,
+    redirectUri,
+    createdAt: Date.now(),
+    result: null,
+  });
+  // Flows are single-use and short-lived; sweep anything older than 10 min.
+  for (const [key, flow] of pendingFlows) {
+    if (Date.now() - flow.createdAt > 600_000) pendingFlows.delete(key);
+  }
+  const url = new URL(GOOGLE_AUTH_URL);
+  url.searchParams.set("client_id", clientId);
+  url.searchParams.set("redirect_uri", redirectUri);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("scope", GOOGLE_SCOPES);
+  url.searchParams.set("access_type", "offline");
+  url.searchParams.set("prompt", "consent");
+  url.searchParams.set("state", state);
+  return { authorizeUrl: url.toString(), state };
+}
+
+export async function completeGoogleFlow({ state, code }) {
+  const flow = pendingFlows.get(state);
+  if (!flow) throw new Error("unknown or expired OAuth state");
+  pendingFlows.delete(state);
+  const body = new URLSearchParams({
+    client_id: flow.clientId,
+    client_secret: flow.clientSecret,
+    code,
+    grant_type: "authorization_code",
+    redirect_uri: flow.redirectUri,
+  });
+  const response = await fetch(GOOGLE_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  const payload = await response.json();
+  if (!response.ok || !payload.access_token) {
+    throw new Error(
+      `google token exchange failed: HTTP ${response.status} ${JSON.stringify(payload).slice(0, 300)}`,
+    );
+  }
+  return {
+    refreshToken: payload.refresh_token ?? null,
+    accessToken: payload.access_token,
+    expiresIn: payload.expires_in,
+  };
+}
+
+/** Mint a fresh access token from a saved refresh token. */
+export async function refreshGoogleAccessToken({
+  clientId,
+  clientSecret,
+  refreshToken,
+}) {
+  const body = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    refresh_token: refreshToken,
+    grant_type: "refresh_token",
+  });
+  const response = await fetch(GOOGLE_TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  const payload = await response.json();
+  if (!response.ok || !payload.access_token) {
+    throw new Error(`google refresh failed: HTTP ${response.status}`);
+  }
+  return { accessToken: payload.access_token, expiresIn: payload.expires_in };
+}

--- a/packages/scripts/test-console/lib/registry.mjs
+++ b/packages/scripts/test-console/lib/registry.mjs
@@ -1,0 +1,199 @@
+/**
+ * Test registry for the console: the discovered run-all-tests task plan,
+ * joined with the guarded live-suite manifest and the connection catalog.
+ *
+ * Nothing here re-derives what committed sources of truth already know. The
+ * task list is `run-all-tests.mjs --plan=json --all` verbatim; live gating is
+ * `GUARDED_REAL_LIVE_SUITES` + `computeRealLiveAccounting` from
+ * packages/scripts/lib/real-live-suites.mjs (the same accounting the
+ * post-merge lane prints); connection ownership comes from connections.mjs.
+ * The join key is the repo-relative directory: a guarded suite belongs to the
+ * plan task whose `relativeDir` prefixes its path.
+ */
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  computeRealLiveAccounting,
+  GUARDED_REAL_LIVE_SUITES,
+} from "../../lib/real-live-suites.mjs";
+import {
+  CONNECTIONS,
+  connectionStatus,
+  OPT_IN_GATES,
+  varOwnership,
+} from "./connections.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = path.resolve(here, "..", "..", "..", "..");
+
+let cachedPlan = null;
+
+/** Discover the full task plan (cached per process; ~1s cold). */
+export function discoverPlan({ force = false } = {}) {
+  if (cachedPlan && !force) return cachedPlan;
+  const result = spawnSync(
+    process.execPath,
+    [
+      path.join(REPO_ROOT, "packages/scripts/run-all-tests.mjs"),
+      "--plan=json",
+      "--all",
+    ],
+    { cwd: REPO_ROOT, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `plan discovery failed (exit ${result.status}): ${result.stderr?.slice(0, 2000)}`,
+    );
+  }
+  cachedPlan = JSON.parse(result.stdout);
+  return cachedPlan;
+}
+
+/**
+ * Effective env for gating decisions: ambient process env, overlaid with the
+ * operator's saved credentials and opt-in toggles. Saved values win so the
+ * console UI always reflects what a console-launched run would actually use.
+ */
+export function effectiveEnv(savedEnv, optInToggles = {}) {
+  const env = { ...process.env, ...savedEnv };
+  for (const [gate, on] of Object.entries(optInToggles)) {
+    if (on) env[gate] = "1";
+    else delete env[gate];
+  }
+  return env;
+}
+
+function suiteStatusIndex(env) {
+  const accounting = computeRealLiveAccounting(env);
+  const byFile = new Map();
+  for (const s of accounting.armed)
+    byFile.set(s.file, { state: "armed", notes: s.notes });
+  for (const s of accounting.probed)
+    byFile.set(s.file, { state: "probe", probe: s.probe });
+  for (const s of accounting.optIn)
+    byFile.set(s.file, { state: "opt-in", gate: s.gate });
+  for (const s of accounting.missingCreds)
+    byFile.set(s.file, { state: "missing-creds", missing: s.missing });
+  for (const s of accounting.blocked)
+    byFile.set(s.file, { state: "blocked", reason: s.reason });
+  return byFile;
+}
+
+/** Which connections own each missing var (for "configure X to enable"). */
+function missingToConnections(missing, owners) {
+  const ids = new Set();
+  for (const key of missing ?? []) {
+    for (const id of owners.get(key) ?? []) ids.add(id);
+  }
+  return [...ids];
+}
+
+/**
+ * Build the full console state: tasks annotated with their guarded live
+ * suites, connection statuses, and the opt-in gate toggles.
+ */
+export function buildRegistry({
+  savedCredentials = {},
+  optInToggles = {},
+  history = {},
+}) {
+  const plan = discoverPlan();
+  const owners = varOwnership();
+
+  const savedEnv = {};
+  for (const values of Object.values(savedCredentials)) {
+    Object.assign(savedEnv, values);
+  }
+  const env = effectiveEnv(savedEnv, optInToggles);
+  const suiteIndex = suiteStatusIndex(env);
+
+  // Attach each guarded suite to the deepest plan task dir that contains it.
+  const tasksByDir = [...plan.tasks].sort(
+    (a, b) => b.relativeDir.length - a.relativeDir.length,
+  );
+  const suitesByTaskLabel = new Map();
+  const orphanSuites = [];
+  for (const entry of GUARDED_REAL_LIVE_SUITES) {
+    const status = suiteIndex.get(entry.file) ?? { state: "unknown" };
+    const owner = tasksByDir.find((t) =>
+      entry.file.startsWith(`${t.relativeDir}/`),
+    );
+    const annotated = {
+      file: entry.file,
+      ...status,
+      requires: entry.requires ?? [],
+      anyOf: entry.anyOf ?? [],
+      optIn: entry.optIn,
+      connections: missingToConnections(
+        status.state === "missing-creds"
+          ? status.missing
+          : [...(entry.requires ?? []), ...(entry.anyOf ?? []).flat()],
+        owners,
+      ),
+    };
+    if (owner) {
+      const list = suitesByTaskLabel.get(owner.label) ?? [];
+      list.push(annotated);
+      suitesByTaskLabel.set(owner.label, list);
+    } else {
+      orphanSuites.push(annotated);
+    }
+  }
+
+  const tasks = plan.tasks.map((task) => ({
+    ...task,
+    liveSuites: suitesByTaskLabel.get(task.label) ?? [],
+    last: history[task.label] ?? null,
+  }));
+
+  const connections = CONNECTIONS.map((connection) => {
+    const saved = savedCredentials[connection.id] ?? {};
+    const { configured, missing } = connectionStatus(connection, saved);
+    // Count what this connection unlocks so the UI can rank setup impact.
+    const unlocks = GUARDED_REAL_LIVE_SUITES.filter((entry) => {
+      const needed = [...(entry.requires ?? []), ...(entry.anyOf ?? []).flat()];
+      return needed.some((key) => connection.fields.some((f) => f.key === key));
+    }).length;
+    return {
+      id: connection.id,
+      label: connection.label,
+      category: connection.category,
+      kind: connection.kind,
+      obtain: connection.obtain,
+      oauth: connection.oauth ?? null,
+      fields: connection.fields.map((f) => ({
+        ...f,
+        // Never ship raw secrets to the browser — presence + suffix only.
+        set: Boolean((saved[f.key] ?? process.env[f.key] ?? "").trim()),
+        hint: maskValue(saved[f.key] ?? process.env[f.key] ?? ""),
+      })),
+      configured,
+      missing,
+      unlocks,
+    };
+  });
+
+  return {
+    summary: plan.summary,
+    tasks,
+    orphanSuites,
+    connections,
+    optInGates: OPT_IN_GATES.map((gate) => ({
+      ...gate,
+      on:
+        Boolean(optInToggles[gate.key]) ||
+        (process.env[gate.key] ?? "") === "1",
+    })),
+    cloudStep: plan.cloudStep,
+  };
+}
+
+function maskValue(value) {
+  const trimmed = (value ?? "").trim();
+  if (!trimmed) return "";
+  if (trimmed.length <= 8) return "•••";
+  return `…${trimmed.slice(-4)}`;
+}

--- a/packages/scripts/test-console/lib/runner.mjs
+++ b/packages/scripts/test-console/lib/runner.mjs
@@ -1,0 +1,345 @@
+/**
+ * Run orchestrator for the test console: executes selected plan tasks as
+ * child processes, streams status transitions to subscribers, and persists
+ * every byte of output under the console state dir.
+ *
+ * Each task runs as its own `run-all-tests.mjs --filter='^<label>$'`
+ * invocation rather than one big sweep. That keeps full parity with CI lane
+ * semantics (lane env, Postgres auto-provision, empty-suite skip logic live
+ * in run-all-tests, not here) while giving the console per-task exit codes,
+ * per-task logs, targeted re-runs, and cancellation. Discovery costs ~0.2s
+ * per spawn — noise against real suite runtimes.
+ *
+ * Result classification: run-all-tests prints `[eliza-test] PASS/SKIP/FAIL
+ * <label>` lines. A self-skipping task exits 3 (the vacuous-green floor with
+ * --min-tasks=1), so classification parses the log tail first and only falls
+ * back to the exit code — exit 0 alone is not proof a test ran.
+ */
+
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import path from "node:path";
+
+import { REPO_ROOT } from "./registry.mjs";
+import {
+  newRunDir,
+  recordTaskStatus,
+  runLogPath,
+  saveRunManifest,
+} from "./store.mjs";
+
+function escapeRegex(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function taskSlug(label) {
+  return label.replace(/[^a-zA-Z0-9._-]+/g, "_").slice(0, 180);
+}
+
+const CLOUD_LABEL = "cloud#test";
+
+export class RunManager extends EventEmitter {
+  constructor() {
+    super();
+    this.current = null;
+  }
+
+  isRunning() {
+    return Boolean(this.current && !this.current.finished);
+  }
+
+  /**
+   * Start a run over the given plan tasks. `lane` is "pr" (deterministic,
+   * keyless) or "live" (post-merge semantics). Extra env carries saved
+   * credentials + opt-in gates; it is injected only into child processes,
+   * never into this server's own process.env.
+   */
+  startRun({ tasks, lane = "pr", extraEnv = {}, concurrency = 3 }) {
+    if (this.isRunning()) throw new Error("a run is already in progress");
+    const runId = `${new Date().toISOString().replace(/[:.]/g, "-")}-${lane}`;
+    newRunDir(runId);
+
+    const entries = tasks.map((task) => ({
+      label: task.label,
+      relativeDir: task.relativeDir,
+      scriptName: task.scriptName,
+      parallelSafe: Boolean(task.parallelSafe) && lane === "pr",
+      status: "queued",
+      exitCode: null,
+      durationMs: null,
+      startedAt: null,
+      finishedAt: null,
+      log: path.relative(REPO_ROOT, runLogPath(runId, taskSlug(task.label))),
+    }));
+
+    const run = {
+      runId,
+      lane,
+      startedAt: new Date().toISOString(),
+      finishedAt: null,
+      cancelled: false,
+      finished: false,
+      tasks: entries,
+      children: new Set(),
+    };
+    this.current = run;
+    this.persist();
+    this.emit("event", {
+      type: "run-started",
+      runId,
+      lane,
+      total: entries.length,
+    });
+
+    void this.drive(run, { extraEnv, concurrency }).catch((error) => {
+      this.emit("event", {
+        type: "run-error",
+        runId,
+        message: String(error?.message ?? error),
+      });
+    });
+    return runId;
+  }
+
+  async drive(run, { extraEnv, concurrency }) {
+    const queue = [...run.tasks];
+    const parallel = queue.filter(
+      (t) => t.parallelSafe && t.label !== CLOUD_LABEL,
+    );
+    const serial = queue.filter(
+      (t) => !t.parallelSafe || t.label === CLOUD_LABEL,
+    );
+
+    const workers = Array.from(
+      { length: Math.max(1, Math.min(concurrency, parallel.length || 1)) },
+      async () => {
+        while (parallel.length > 0 && !run.cancelled) {
+          const entry = parallel.shift();
+          await this.executeTask(run, entry, extraEnv);
+        }
+      },
+    );
+    await Promise.all(workers);
+    for (const entry of serial) {
+      if (run.cancelled) break;
+      await this.executeTask(run, entry, extraEnv);
+    }
+
+    for (const entry of run.tasks) {
+      if (entry.status === "queued") entry.status = "cancelled";
+    }
+    run.finished = true;
+    run.finishedAt = new Date().toISOString();
+    this.persist();
+    this.emit("event", {
+      type: "run-finished",
+      runId: run.runId,
+      cancelled: run.cancelled,
+      counts: countStatuses(run.tasks),
+    });
+  }
+
+  buildCommand(entry, lane) {
+    if (entry.label === CLOUD_LABEL) {
+      return { cmd: "bun", args: ["run", "test:cloud"] };
+    }
+    const args = [
+      "packages/scripts/run-all-tests.mjs",
+      `--filter=^${escapeRegex(entry.label)}$`,
+      "--min-tasks=1",
+      "--no-cloud",
+    ];
+    // Non-`test` scripts (test:e2e, test:live, …) need --all so the extra
+    // script lanes are collected; plain `test` stays scoped to --only=test.
+    args.push(entry.scriptName === "test" ? "--only=test" : "--all");
+    return { cmd: process.execPath, args };
+  }
+
+  laneEnv(lane) {
+    if (lane === "live") {
+      return {
+        TEST_LANE: "post-merge",
+        ELIZA_LIVE_TEST: "1",
+        ELIZA_REAL_APIS: "1",
+      };
+    }
+    return {
+      TEST_LANE: "pr",
+      ELIZA_LIVE_TEST: "0",
+      SCENARIO_USE_LLM_PROXY: "1",
+    };
+  }
+
+  executeTask(run, entry, extraEnv) {
+    return new Promise((resolvePromise) => {
+      const logFile = path.join(REPO_ROOT, entry.log);
+      const logStream = fs.createWriteStream(logFile);
+      const { cmd, args } = this.buildCommand(entry, run.lane);
+      entry.status = "running";
+      entry.startedAt = new Date().toISOString();
+      this.persist();
+      this.emit("event", {
+        type: "task",
+        runId: run.runId,
+        label: entry.label,
+        status: "running",
+      });
+
+      const started = Date.now();
+      // Own process group so cancel can kill the whole spawn tree (vitest
+      // workers, browsers, emulators) rather than just the wrapper.
+      const child = spawn(cmd, args, {
+        cwd: REPO_ROOT,
+        env: {
+          ...process.env,
+          ...this.laneEnv(run.lane),
+          ...extraEnv,
+          FORCE_COLOR: "0",
+        },
+        detached: true,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      run.children.add(child);
+
+      let tail = "";
+      const capture = (chunk) => {
+        logStream.write(chunk);
+        tail = (tail + chunk.toString()).slice(-16_384);
+        this.emit("event", {
+          type: "log",
+          runId: run.runId,
+          label: entry.label,
+          chunk: chunk.toString(),
+        });
+      };
+      child.stdout.on("data", capture);
+      child.stderr.on("data", capture);
+
+      child.once("close", (code, signal) => {
+        run.children.delete(child);
+        logStream.end();
+        entry.exitCode = code;
+        entry.durationMs = Date.now() - started;
+        entry.finishedAt = new Date().toISOString();
+        entry.status = classifyResult({
+          label: entry.label,
+          code,
+          signal,
+          tail,
+          cancelled: run.cancelled,
+        });
+        recordTaskStatus(entry.label, {
+          status: entry.status,
+          runId: run.runId,
+          at: entry.finishedAt,
+          durationMs: entry.durationMs,
+        });
+        this.persist();
+        this.emit("event", {
+          type: "task",
+          runId: run.runId,
+          label: entry.label,
+          status: entry.status,
+          exitCode: code,
+          durationMs: entry.durationMs,
+        });
+        resolvePromise();
+      });
+    });
+  }
+
+  cancel() {
+    const run = this.current;
+    if (!run || run.finished) return false;
+    run.cancelled = true;
+    for (const child of run.children) {
+      try {
+        process.kill(-child.pid, "SIGTERM");
+      } catch {
+        // error-policy:J6 best-effort teardown — the group may already be gone.
+      }
+    }
+    this.emit("event", { type: "run-cancelling", runId: run.runId });
+    return true;
+  }
+
+  persist() {
+    const run = this.current;
+    if (!run) return;
+    saveRunManifest(run.runId, {
+      runId: run.runId,
+      lane: run.lane,
+      startedAt: run.startedAt,
+      finishedAt: run.finishedAt,
+      cancelled: run.cancelled,
+      counts: countStatuses(run.tasks),
+      tasks: run.tasks.map(
+        ({
+          label,
+          relativeDir,
+          scriptName,
+          status,
+          exitCode,
+          durationMs,
+          startedAt,
+          finishedAt,
+          log,
+        }) => ({
+          label,
+          relativeDir,
+          scriptName,
+          status,
+          exitCode,
+          durationMs,
+          startedAt,
+          finishedAt,
+          log,
+        }),
+      ),
+    });
+  }
+
+  snapshot() {
+    const run = this.current;
+    if (!run) return null;
+    return {
+      runId: run.runId,
+      lane: run.lane,
+      startedAt: run.startedAt,
+      finishedAt: run.finishedAt,
+      cancelled: run.cancelled,
+      finished: run.finished,
+      counts: countStatuses(run.tasks),
+      tasks: run.tasks.map(({ label, status, exitCode, durationMs }) => ({
+        label,
+        status,
+        exitCode,
+        durationMs,
+      })),
+    };
+  }
+}
+
+export function classifyResult({ label, code, signal, tail, cancelled }) {
+  if (cancelled) return "cancelled";
+  if (signal) return "failed";
+  const labelPattern = escapeRegex(label);
+  if (new RegExp(`\\[eliza-test\\] FAIL ${labelPattern}`).test(tail))
+    return "failed";
+  if (new RegExp(`\\[eliza-test\\] PASS ${labelPattern}`).test(tail))
+    return "passed";
+  if (new RegExp(`\\[eliza-test\\] SKIP ${labelPattern}`).test(tail))
+    return "skipped";
+  // Exit 3 is run-all-tests' vacuous-green floor: the only task collected
+  // self-skipped. Anything else nonzero without a status line is a failure.
+  if (code === 3) return "skipped";
+  return code === 0 ? "passed" : "failed";
+}
+
+export function countStatuses(tasks) {
+  const counts = {};
+  for (const task of tasks)
+    counts[task.status] = (counts[task.status] ?? 0) + 1;
+  return counts;
+}

--- a/packages/scripts/test-console/lib/store.mjs
+++ b/packages/scripts/test-console/lib/store.mjs
@@ -1,0 +1,137 @@
+/**
+ * Persistent state for the local test console under `~/.eliza/test-console/`.
+ *
+ * Owns three things: the operator's saved credentials (`credentials.json`,
+ * written 0600 because it holds raw API keys and OAuth tokens), the per-run
+ * archives (`runs/<runId>/run.json` + one log file per task), and the rolling
+ * last-status map (`history.json`) that survives server restarts so "re-run
+ * failed" works across sessions. Everything is plain JSON on disk — the
+ * console is a single-operator dev tool, so file locking is out of scope.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Dir precedence mirrors the repo's two state-dir conventions: an explicit
+// override wins, then the core ELIZA_STATE_DIR root, then the `~/.eliza`
+// home used by the CLI auth flows (register.auth.ts) — the human-facing
+// default the console advertises. Resolved lazily so tests can point the
+// store at a temp dir after import.
+export function consoleDir() {
+  return (
+    process.env.ELIZA_TEST_CONSOLE_DIR ||
+    (process.env.ELIZA_STATE_DIR
+      ? path.join(process.env.ELIZA_STATE_DIR, "test-console")
+      : path.join(os.homedir(), ".eliza", "test-console"))
+  );
+}
+
+const CREDENTIALS_FILE = () => path.join(consoleDir(), "credentials.json");
+const HISTORY_FILE = () => path.join(consoleDir(), "history.json");
+const RUNS_DIR = () => path.join(consoleDir(), "runs");
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function readJson(file, fallback) {
+  if (!fs.existsSync(file)) return fallback;
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+// Atomic-ish write: rename over the target so a crash mid-write never leaves
+// truncated JSON behind (the console re-reads these files on every boot).
+function writeJson(file, value, { mode } = {}) {
+  ensureDir(path.dirname(file));
+  const tmp = `${file}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, `${JSON.stringify(value, null, 2)}\n`, { mode });
+  fs.renameSync(tmp, file);
+  if (mode !== undefined) fs.chmodSync(file, mode);
+}
+
+/** Credentials: `{ [connectionId]: { [ENV_VAR]: value } }`. */
+export function loadCredentials() {
+  return readJson(CREDENTIALS_FILE(), {});
+}
+
+export function saveCredentials(credentials) {
+  writeJson(CREDENTIALS_FILE(), credentials, { mode: 0o600 });
+}
+
+export function setConnection(connectionId, values) {
+  const all = loadCredentials();
+  all[connectionId] = values;
+  saveCredentials(all);
+  return all;
+}
+
+export function removeConnection(connectionId) {
+  const all = loadCredentials();
+  delete all[connectionId];
+  saveCredentials(all);
+  return all;
+}
+
+/** Flatten every saved connection's vars into one env object for test runs. */
+export function credentialsToEnv(credentials = loadCredentials()) {
+  const env = {};
+  for (const values of Object.values(credentials)) {
+    for (const [key, value] of Object.entries(values)) {
+      if (typeof value === "string" && value.length > 0) env[key] = value;
+    }
+  }
+  return env;
+}
+
+/** Console settings: opt-in gate toggles, cloud base URL, UI prefs. */
+export function loadSettings() {
+  return readJson(path.join(consoleDir(), "settings.json"), {
+    optInToggles: {},
+  });
+}
+
+export function saveSettings(settings) {
+  writeJson(path.join(consoleDir(), "settings.json"), settings);
+}
+
+/** Last-known task status by label: `{ [label]: { status, runId, at } }`. */
+export function loadHistory() {
+  return readJson(HISTORY_FILE(), {});
+}
+
+export function recordTaskStatus(label, entry) {
+  const history = loadHistory();
+  history[label] = entry;
+  writeJson(HISTORY_FILE(), history);
+}
+
+export function newRunDir(runId) {
+  const dir = path.join(RUNS_DIR(), runId);
+  ensureDir(path.join(dir, "logs"));
+  return dir;
+}
+
+export function saveRunManifest(runId, manifest) {
+  writeJson(path.join(RUNS_DIR(), runId, "run.json"), manifest);
+}
+
+export function listRuns() {
+  if (!fs.existsSync(RUNS_DIR())) return [];
+  return fs
+    .readdirSync(RUNS_DIR())
+    .filter((name) => fs.existsSync(path.join(RUNS_DIR(), name, "run.json")))
+    .sort()
+    .reverse()
+    .map((name) => readJson(path.join(RUNS_DIR(), name, "run.json"), null))
+    .filter(Boolean);
+}
+
+export function loadRun(runId) {
+  return readJson(path.join(RUNS_DIR(), runId, "run.json"), null);
+}
+
+export function runLogPath(runId, taskSlug) {
+  return path.join(RUNS_DIR(), runId, "logs", `${taskSlug}.log`);
+}

--- a/packages/scripts/test-console/lib/verify.mjs
+++ b/packages/scripts/test-console/lib/verify.mjs
@@ -1,0 +1,131 @@
+/**
+ * Credential probe engine: executes a connection's declarative `verify` spec
+ * against saved values and reports pass/fail with the upstream status line.
+ *
+ * Probes are read-only by design (models lists, whoami endpoints, token
+ * refreshes) so verifying never mutates a connected account; the one paid
+ * exception (Tavily search) burns a single credit. Private keys use
+ * `kind: "format"` — they must never leave the machine. Network failures are
+ * reported as `error` (distinct from `invalid`) so the operator can tell "bad
+ * key" from "no internet".
+ */
+
+import net from "node:net";
+
+function substitute(template, values) {
+  return template.replace(
+    /\{\{([A-Z0-9_]+)\}\}/g,
+    (_, key) => values[key] ?? "",
+  );
+}
+
+async function httpProbe(spec, values) {
+  const url = substitute(spec.url, values);
+  const headers = {};
+  for (const [name, template] of Object.entries(spec.headers ?? {})) {
+    headers[name] = substitute(template, values);
+  }
+  if (spec.basicAuth) {
+    const [user, pass] = spec.basicAuth.map((t) => substitute(t, values));
+    headers.Authorization = `Basic ${Buffer.from(`${user}:${pass}`).toString("base64")}`;
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 15_000);
+  try {
+    const response = await fetch(url, {
+      method: spec.method ?? "GET",
+      headers,
+      body: spec.body ? substitute(spec.body, values) : undefined,
+      signal: controller.signal,
+    });
+    const bodyText = await response.text();
+    const okStatus = response.status >= 200 && response.status < 300;
+    const okBody = spec.okBodyPattern
+      ? new RegExp(spec.okBodyPattern).test(bodyText)
+      : true;
+    if (okStatus && okBody) {
+      return { ok: true, status: "valid", detail: `HTTP ${response.status}` };
+    }
+    return {
+      ok: false,
+      status: "invalid",
+      detail: `HTTP ${response.status}: ${bodyText.slice(0, 300)}`,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function tcpProbe(spec, values) {
+  const raw = values[spec.urlVar] ?? "";
+  let host;
+  let port;
+  try {
+    const url = new URL(raw);
+    host = url.hostname;
+    port = Number(url.port || 5432);
+  } catch {
+    return Promise.resolve({
+      ok: false,
+      status: "invalid",
+      detail: `${spec.urlVar} is not a parseable URL`,
+    });
+  }
+  return new Promise((resolvePromise) => {
+    const socket = net.connect({ host, port, timeout: 5_000 });
+    socket.once("connect", () => {
+      socket.destroy();
+      resolvePromise({
+        ok: true,
+        status: "valid",
+        detail: `TCP ${host}:${port} reachable (auth checked by suites)`,
+      });
+    });
+    const fail = (why) => () => {
+      socket.destroy();
+      resolvePromise({
+        ok: false,
+        status: "invalid",
+        detail: `${host}:${port} ${why}`,
+      });
+    };
+    socket.once("timeout", fail("timed out"));
+    socket.once("error", fail("refused/unreachable"));
+  });
+}
+
+/** Returns { ok, status: valid|invalid|error|unchecked, detail }. */
+export async function verifyConnection(connection, values) {
+  const spec = connection.verify ?? { kind: "none" };
+  try {
+    if (spec.kind === "http") return await httpProbe(spec, values);
+    if (spec.kind === "tcp") return await tcpProbe(spec, values);
+    if (spec.kind === "format") {
+      const primary = connection.fields.find((f) => f.required);
+      const value = values[primary.key] ?? "";
+      const ok = new RegExp(spec.pattern).test(value);
+      return ok
+        ? {
+            ok: true,
+            status: "valid",
+            detail: "format check passed (not sent anywhere)",
+          }
+        : {
+            ok: false,
+            status: "invalid",
+            detail: "value does not match expected format",
+          };
+    }
+    return {
+      ok: true,
+      status: "unchecked",
+      detail: "no probe for this connection; its suites are the proof",
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      status: "error",
+      detail: `probe failed: ${error?.message ?? error}`,
+    };
+  }
+}

--- a/packages/scripts/test-console/server.mjs
+++ b/packages/scripts/test-console/server.mjs
@@ -1,0 +1,353 @@
+#!/usr/bin/env node
+/**
+ * Local test console server: one process that serves the console UI, holds
+ * the operator's saved credentials, and drives test runs with live status.
+ *
+ * Launched via `bun run test:console`. Binds 127.0.0.1 only — it holds raw
+ * API keys and can execute repo code, so it must never listen on a routable
+ * interface; there is deliberately no auth layer beyond that. The browser
+ * gets presence/suffix hints for saved secrets, never the values.
+ *
+ * Surface:
+ *   GET  /                      console UI (ui/index.html, self-contained)
+ *   GET  /api/state             registry + connections + run snapshot + history
+ *   GET  /api/events            SSE stream of run/task/log events
+ *   POST /api/connections/:id   save credential values     DELETE — remove
+ *   POST /api/connections/:id/verify   live probe
+ *   POST /api/gates             toggle an opt-in gate
+ *   POST /api/run               start a run {mode, lane, labels?, concurrency?}
+ *   POST /api/run/cancel        cancel the active run
+ *   GET  /api/runs/:id/log?task=<label>  persisted log text
+ *   POST /api/cloud/login/start + GET /api/cloud/login/poll   device-code login
+ *   GET  /oauth/google/start + /oauth/google/callback         loopback OAuth
+ */
+
+import fs from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { connectionById, connectionStatus } from "./lib/connections.mjs";
+import {
+  completeGoogleFlow,
+  DEFAULT_CLOUD_BASE_URL,
+  pollCloudLogin,
+  refreshGoogleAccessToken,
+  startCloudLogin,
+  startGoogleFlow,
+} from "./lib/oauth.mjs";
+import { buildRegistry, discoverPlan } from "./lib/registry.mjs";
+import { RunManager } from "./lib/runner.mjs";
+import {
+  consoleDir,
+  credentialsToEnv,
+  listRuns,
+  loadCredentials,
+  loadHistory,
+  loadRun,
+  loadSettings,
+  removeConnection,
+  runLogPath,
+  saveSettings,
+  setConnection,
+} from "./lib/store.mjs";
+import { verifyConnection } from "./lib/verify.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const PORT = Number(process.env.ELIZA_TEST_CONSOLE_PORT || 31338);
+const HOST = "127.0.0.1";
+
+const runManager = new RunManager();
+const sseClients = new Set();
+
+runManager.on("event", (event) => {
+  const frame = `data: ${JSON.stringify(event)}\n\n`;
+  for (const client of sseClients) client.write(frame);
+});
+
+function json(res, status, body) {
+  const text = JSON.stringify(body);
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(text),
+  });
+  res.end(text);
+}
+
+async function readBody(req) {
+  let data = "";
+  for await (const chunk of req) {
+    data += chunk;
+    if (data.length > 1_000_000) throw new Error("body too large");
+  }
+  return data ? JSON.parse(data) : {};
+}
+
+function currentState() {
+  const settings = loadSettings();
+  const registry = buildRegistry({
+    savedCredentials: loadCredentials(),
+    optInToggles: settings.optInToggles ?? {},
+    history: loadHistory(),
+  });
+  return {
+    consoleDir: consoleDir(),
+    registry,
+    settings: {
+      optInToggles: settings.optInToggles ?? {},
+      cloudBaseUrl: settings.cloudBaseUrl ?? DEFAULT_CLOUD_BASE_URL,
+    },
+    run: runManager.snapshot(),
+    runs: listRuns()
+      .slice(0, 25)
+      .map(({ runId, lane, startedAt, finishedAt, cancelled, counts }) => ({
+        runId,
+        lane,
+        startedAt,
+        finishedAt,
+        cancelled,
+        counts,
+      })),
+  };
+}
+
+function selectTasks({ mode, labels }) {
+  const plan = discoverPlan();
+  const history = loadHistory();
+  const all = [...plan.tasks];
+  if (plan.cloudStep) {
+    all.push({
+      label: plan.cloudStep.label,
+      relativeDir: "packages/cloud",
+      scriptName: "test",
+      parallelSafe: false,
+    });
+  }
+  if (mode === "selection") {
+    const wanted = new Set(labels ?? []);
+    return all.filter((t) => wanted.has(t.label));
+  }
+  if (mode === "failed") {
+    return all.filter((t) => history[t.label]?.status === "failed");
+  }
+  return all;
+}
+
+const routes = {
+  "GET /api/state": (req, res) => json(res, 200, currentState()),
+
+  "POST /api/gates": async (req, res) => {
+    const { key, on } = await readBody(req);
+    const settings = loadSettings();
+    settings.optInToggles = { ...settings.optInToggles, [key]: Boolean(on) };
+    saveSettings(settings);
+    json(res, 200, { ok: true });
+  },
+
+  "POST /api/run": async (req, res) => {
+    const {
+      mode = "all",
+      lane = "pr",
+      labels,
+      concurrency,
+    } = await readBody(req);
+    if (runManager.isRunning())
+      return json(res, 409, { error: "run already in progress" });
+    const tasks = selectTasks({ mode, labels });
+    if (tasks.length === 0)
+      return json(res, 400, { error: "no tasks selected" });
+    const settings = loadSettings();
+    const extraEnv = credentialsToEnv();
+    for (const [gate, on] of Object.entries(settings.optInToggles ?? {})) {
+      if (on) extraEnv[gate] = "1";
+    }
+    // Google access tokens expire hourly; a saved refresh token lets live
+    // runs re-mint GOOGLE_CALENDAR_ACCESS_TOKEN so the calendar suite stays
+    // armed without the operator re-pasting a token every hour.
+    const google = loadCredentials()["google-oauth"] ?? {};
+    if (
+      lane === "live" &&
+      google.GOOGLE_CLIENT_ID &&
+      google.GOOGLE_CLIENT_SECRET &&
+      google.GOOGLE_OAUTH_REFRESH_TOKEN
+    ) {
+      try {
+        const { accessToken } = await refreshGoogleAccessToken({
+          clientId: google.GOOGLE_CLIENT_ID,
+          clientSecret: google.GOOGLE_CLIENT_SECRET,
+          refreshToken: google.GOOGLE_OAUTH_REFRESH_TOKEN,
+        });
+        setConnection("google-calendar", {
+          GOOGLE_CALENDAR_ACCESS_TOKEN: accessToken,
+        });
+        extraEnv.GOOGLE_CALENDAR_ACCESS_TOKEN = accessToken;
+      } catch (error) {
+        // error-policy:J4 explicit user-facing degrade — the run proceeds and
+        // the calendar suite self-skips loudly; the operator sees why here.
+        runManager.emit("event", {
+          type: "warning",
+          message: `Google token refresh failed: ${error?.message ?? error}`,
+        });
+      }
+    }
+    const runId = runManager.startRun({
+      tasks,
+      lane,
+      extraEnv,
+      concurrency: Number(concurrency) || 3,
+    });
+    json(res, 200, { runId, taskCount: tasks.length });
+  },
+
+  "POST /api/run/cancel": (req, res) =>
+    json(res, 200, { cancelled: runManager.cancel() }),
+
+  "POST /api/cloud/login/start": async (req, res) => {
+    const settings = loadSettings();
+    const result = await startCloudLogin({
+      baseUrl: settings.cloudBaseUrl ?? DEFAULT_CLOUD_BASE_URL,
+    });
+    json(res, 200, result);
+  },
+
+  "GET /api/cloud/login/poll": async (req, res, url) => {
+    const settings = loadSettings();
+    const result = await pollCloudLogin({
+      sessionId: url.searchParams.get("sessionId"),
+      baseUrl: settings.cloudBaseUrl ?? DEFAULT_CLOUD_BASE_URL,
+    });
+    if (result.status === "authenticated" && result.apiKey) {
+      setConnection("eliza-cloud", {
+        ELIZAOS_CLOUD_API_KEY: result.apiKey,
+        ELIZA_CLOUD_API_KEY: result.apiKey,
+      });
+    }
+    json(res, 200, { status: result.status });
+  },
+
+  "GET /oauth/google/start": (req, res, url) => {
+    const saved = loadCredentials()["google-oauth"] ?? {};
+    const clientId = saved.GOOGLE_CLIENT_ID ?? process.env.GOOGLE_CLIENT_ID;
+    const clientSecret =
+      saved.GOOGLE_CLIENT_SECRET ?? process.env.GOOGLE_CLIENT_SECRET;
+    if (!clientId || !clientSecret) {
+      return json(res, 400, {
+        error:
+          "save GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET on the Google OAuth connection first",
+      });
+    }
+    const { authorizeUrl } = startGoogleFlow({
+      clientId,
+      clientSecret,
+      redirectUri: `http://${HOST}:${PORT}/oauth/google/callback`,
+    });
+    res.writeHead(302, { Location: authorizeUrl });
+    res.end();
+  },
+
+  "GET /oauth/google/callback": async (req, res, url) => {
+    const code = url.searchParams.get("code");
+    const state = url.searchParams.get("state");
+    const tokens = await completeGoogleFlow({ state, code });
+    const saved = loadCredentials()["google-oauth"] ?? {};
+    setConnection("google-oauth", {
+      ...saved,
+      ...(tokens.refreshToken
+        ? { GOOGLE_OAUTH_REFRESH_TOKEN: tokens.refreshToken }
+        : {}),
+    });
+    setConnection("google-calendar", {
+      GOOGLE_CALENDAR_ACCESS_TOKEN: tokens.accessToken,
+    });
+    res.writeHead(200, { "Content-Type": "text/html" });
+    res.end(
+      "<body style='font-family:system-ui;background:#111;color:#eee;display:grid;place-items:center;height:100vh'><div>Google connected — you can close this tab and return to the test console.</div></body>",
+    );
+  },
+};
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, `http://${HOST}:${PORT}`);
+
+  try {
+    if (url.pathname === "/" || url.pathname === "/index.html") {
+      const html = fs.readFileSync(path.join(here, "ui", "index.html"));
+      res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+      return res.end(html);
+    }
+
+    if (url.pathname === "/api/events") {
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      });
+      res.write(`data: ${JSON.stringify({ type: "hello" })}\n\n`);
+      sseClients.add(res);
+      req.on("close", () => sseClients.delete(res));
+      return;
+    }
+
+    // Connection CRUD + verify (path-parameterized, matched by prefix).
+    const connectionMatch = url.pathname.match(
+      /^\/api\/connections\/([a-z0-9-]+)(\/verify)?$/,
+    );
+    if (connectionMatch) {
+      const [, id, verifySuffix] = connectionMatch;
+      const connection = connectionById(id);
+      if (!connection)
+        return json(res, 404, { error: `unknown connection ${id}` });
+      if (req.method === "POST" && verifySuffix) {
+        const saved = loadCredentials()[id] ?? {};
+        const { values } = connectionStatus(connection, saved);
+        const result = await verifyConnection(connection, values);
+        return json(res, 200, result);
+      }
+      if (req.method === "POST") {
+        const { values } = await readBody(req);
+        // Merge over what's saved: the browser only ever sends fields the
+        // operator typed (it never holds raw saved secrets to echo back),
+        // so a blank field means "keep the existing value".
+        const merged = { ...(loadCredentials()[id] ?? {}) };
+        for (const field of connection.fields) {
+          const value = values?.[field.key];
+          if (typeof value === "string" && value.trim() !== "")
+            merged[field.key] = value.trim();
+        }
+        setConnection(id, merged);
+        return json(res, 200, { ok: true });
+      }
+      if (req.method === "DELETE") {
+        removeConnection(id);
+        return json(res, 200, { ok: true });
+      }
+    }
+
+    const logMatch = url.pathname.match(/^\/api\/runs\/([^/]+)\/log$/);
+    if (logMatch && req.method === "GET") {
+      const runId = decodeURIComponent(logMatch[1]);
+      const run = loadRun(runId);
+      const label = url.searchParams.get("task");
+      const entry = run?.tasks?.find((t) => t.label === label);
+      if (!entry) return json(res, 404, { error: "unknown run/task" });
+      const file = runLogPath(runId, path.basename(entry.log, ".log"));
+      if (!fs.existsSync(file)) return json(res, 404, { error: "log missing" });
+      res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8" });
+      return fs.createReadStream(file).pipe(res);
+    }
+
+    const handler = routes[`${req.method} ${url.pathname}`];
+    if (handler) return await handler(req, res, url);
+
+    json(res, 404, { error: "not found" });
+  } catch (error) {
+    // error-policy:J1 boundary translation — every route failure becomes a
+    // structured 500 so the UI renders an error state instead of hanging.
+    json(res, 500, { error: String(error?.message ?? error) });
+  }
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`[TestConsole] listening on http://${HOST}:${PORT}`);
+  console.log(`[TestConsole] state dir: ${consoleDir()}`);
+});

--- a/packages/scripts/test-console/ui/index.html
+++ b/packages/scripts/test-console/ui/index.html
@@ -1,0 +1,429 @@
+<!doctype html>
+<!--
+  Test console UI: a single self-contained page (no framework, no build step)
+  served by ../server.mjs. Renders the task registry with live statuses over
+  SSE, the connection cards with save/verify/connect flows, opt-in gates, and
+  a per-task log drawer. Self-contained so the console works in a checkout
+  where node_modules or the app build is broken — that is its whole job.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>elizaOS test console</title>
+<style>
+  :root {
+    --bg: #0d0d0f; --panel: #17171b; --panel2: #1f1f24; --line: #2a2a31;
+    --text: #e8e6e3; --dim: #9b988f; --accent: #ff7a1a; --accent-hover: #cc5f0e;
+    --pass: #3fbf5f; --fail: #e5484d; --skip: #8a8780; --warn: #e0a83c;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--text); font: 14px/1.45 system-ui, sans-serif; }
+  header { display: flex; align-items: center; gap: 12px; padding: 10px 16px; border-bottom: 1px solid var(--line); position: sticky; top: 0; background: var(--bg); z-index: 5; flex-wrap: wrap; }
+  header h1 { font-size: 15px; margin: 0 8px 0 0; font-weight: 650; }
+  header h1 span { color: var(--accent); }
+  .dirhint { color: var(--dim); font-size: 11px; }
+  button { background: var(--panel2); color: var(--text); border: 1px solid var(--line); border-radius: 6px; padding: 6px 12px; cursor: pointer; font: inherit; }
+  button:hover { border-color: var(--accent); }
+  button.primary { background: var(--accent); border-color: var(--accent); color: #14100b; font-weight: 650; }
+  button.primary:hover { background: var(--accent-hover); border-color: var(--accent-hover); }
+  button:disabled { opacity: .45; cursor: not-allowed; }
+  select, input[type=text], input[type=password], textarea { background: var(--panel2); color: var(--text); border: 1px solid var(--line); border-radius: 6px; padding: 6px 8px; font: inherit; }
+  main { display: grid; grid-template-columns: minmax(0, 1fr) 380px; gap: 0; }
+  @media (max-width: 1100px) { main { grid-template-columns: 1fr; } }
+  #left { padding: 12px 16px; min-width: 0; }
+  #right { border-left: 1px solid var(--line); padding: 12px 16px; }
+  .counts { display: flex; gap: 8px; flex-wrap: wrap; margin: 4px 0 10px; }
+  .counts .chip { padding: 3px 10px; border-radius: 999px; background: var(--panel); border: 1px solid var(--line); font-size: 12px; }
+  .chip b { font-weight: 700; }
+  .toolbar { display: flex; gap: 8px; margin-bottom: 10px; flex-wrap: wrap; align-items: center; }
+  #filter { flex: 1; min-width: 160px; }
+  table { width: 100%; border-collapse: collapse; }
+  th { text-align: left; color: var(--dim); font-size: 11px; text-transform: uppercase; letter-spacing: .05em; padding: 6px 8px; border-bottom: 1px solid var(--line); position: sticky; top: 53px; background: var(--bg); }
+  td { padding: 5px 8px; border-bottom: 1px solid #1c1c21; vertical-align: top; }
+  tr.task:hover { background: var(--panel); cursor: pointer; }
+  .status { display: inline-block; min-width: 74px; text-align: center; padding: 2px 8px; border-radius: 999px; font-size: 11px; font-weight: 650; }
+  .status.idle { background: #222; color: var(--dim); }
+  .status.queued { background: #2b2b31; color: var(--dim); }
+  .status.running { background: rgba(255,122,26,.15); color: var(--accent); animation: pulse 1.2s infinite; }
+  .status.passed { background: rgba(63,191,95,.14); color: var(--pass); }
+  .status.failed { background: rgba(229,72,77,.15); color: var(--fail); }
+  .status.skipped, .status.cancelled { background: #232323; color: var(--skip); }
+  @keyframes pulse { 50% { opacity: .55; } }
+  .lbl { font-family: ui-monospace, monospace; font-size: 12.5px; word-break: break-all; }
+  .badges { margin-top: 2px; display: flex; gap: 4px; flex-wrap: wrap; }
+  .badge { font-size: 10px; padding: 1px 6px; border-radius: 4px; border: 1px solid var(--line); color: var(--dim); }
+  .badge.armed { color: var(--pass); border-color: rgba(63,191,95,.4); }
+  .badge.missing { color: var(--warn); border-color: rgba(224,168,60,.4); }
+  .badge.blocked { color: var(--fail); border-color: rgba(229,72,77,.35); }
+  .dur { color: var(--dim); font-size: 12px; white-space: nowrap; }
+  h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .06em; color: var(--dim); margin: 18px 0 8px; }
+  .conn { background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 10px 12px; margin-bottom: 8px; }
+  .conn .head { display: flex; align-items: center; gap: 8px; }
+  .conn .head .name { font-weight: 650; flex: 1; }
+  .dot { width: 9px; height: 9px; border-radius: 50%; background: #3a3a41; }
+  .dot.on { background: var(--pass); }
+  .dot.err { background: var(--fail); }
+  .unlocks { color: var(--dim); font-size: 11px; }
+  .conn form { display: none; margin-top: 8px; }
+  .conn.open form { display: block; }
+  .conn label { display: block; font-size: 11px; color: var(--dim); margin: 6px 0 2px; }
+  .conn input, .conn textarea { width: 100%; }
+  .conn .row { display: flex; gap: 6px; margin-top: 8px; }
+  .conn .verify-result { font-size: 11px; margin-top: 6px; word-break: break-all; }
+  .gate { display: flex; align-items: center; gap: 8px; padding: 4px 0; font-size: 13px; }
+  #drawer { position: fixed; inset: auto 0 0 0; height: 42vh; background: var(--panel); border-top: 2px solid var(--accent); display: none; flex-direction: column; z-index: 20; }
+  #drawer.open { display: flex; }
+  #drawer .bar { display: flex; align-items: center; gap: 10px; padding: 6px 12px; border-bottom: 1px solid var(--line); }
+  #drawer pre { flex: 1; overflow: auto; margin: 0; padding: 10px 14px; font: 12px/1.5 ui-monospace, monospace; white-space: pre-wrap; word-break: break-all; }
+  .runhist { font-size: 12px; color: var(--dim); padding: 3px 0; }
+  a { color: var(--accent); }
+  #toast { position: fixed; top: 12px; right: 12px; background: var(--panel2); border: 1px solid var(--accent); border-radius: 8px; padding: 8px 14px; display: none; z-index: 30; }
+</style>
+</head>
+<body>
+<header>
+  <h1>eliza<span>OS</span> test console</h1>
+  <select id="lane" title="Lane">
+    <option value="pr">Deterministic (keyless)</option>
+    <option value="live">Live (real APIs)</option>
+  </select>
+  <button type="button" class="primary" id="runAll">Run all</button>
+  <button type="button" id="runSel">Run selected</button>
+  <button type="button" id="runFailed">Re-run failed</button>
+  <button type="button" id="cancel">Cancel</button>
+  <button type="button" id="clearSel">Clear</button>
+  <span class="dirhint" id="dirhint"></span>
+</header>
+<main>
+  <section id="left">
+    <div class="counts" id="counts"></div>
+    <div class="toolbar">
+      <input type="text" id="filter" placeholder="Filter tasks (name, dir, script)…" />
+      <select id="statusFilter">
+        <option value="">All statuses</option>
+        <option>passed</option><option>failed</option><option>running</option>
+        <option>queued</option><option>skipped</option><option>idle</option>
+      </select>
+      <label style="font-size:12px;color:var(--dim)"><input type="checkbox" id="liveOnly" /> live-gated only</label>
+    </div>
+    <table>
+      <thead><tr><th style="width:24px"></th><th style="width:100px">Status</th><th>Task</th><th style="width:80px">Time</th></tr></thead>
+      <tbody id="rows"></tbody>
+    </table>
+  </section>
+  <aside id="right">
+    <h2>Connections</h2>
+    <div id="conns"></div>
+    <h2>Opt-in gates</h2>
+    <div id="gates"></div>
+    <h2>Recent runs</h2>
+    <div id="runs"></div>
+  </aside>
+</main>
+<div id="drawer">
+  <div class="bar">
+    <span class="status" id="drawerStatus">idle</span>
+    <span class="lbl" id="drawerLabel" style="flex:1"></span>
+    <button type="button" id="rerunOne">Re-run</button>
+    <button type="button" id="closeDrawer">Close</button>
+  </div>
+  <pre id="drawerLog"></pre>
+</div>
+<div id="toast"></div>
+<script>
+"use strict";
+const $ = (sel) => document.querySelector(sel);
+let state = null;            // /api/state payload
+let statuses = new Map();    // label -> {status, durationMs}
+const selected = new Set();
+const openConns = new Set();   // connection cards kept open across re-renders
+let drawerTask = null;
+let drawerRunId = null;
+
+function toast(msg) {
+  const el = $("#toast");
+  el.textContent = msg;
+  el.style.display = "block";
+  clearTimeout(el._t);
+  el._t = setTimeout(() => { el.style.display = "none"; }, 4000);
+}
+
+async function api(method, url, body) {
+  const res = await fetch(url, {
+    method,
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(data.error || res.statusText);
+  return data;
+}
+
+function fmtMs(ms) {
+  if (ms == null) return "";
+  if (ms < 1000) return ms + "ms";
+  if (ms < 120000) return (ms / 1000).toFixed(1) + "s";
+  return Math.round(ms / 60000) + "m";
+}
+
+function taskStatus(task) {
+  const live = statuses.get(task.label);
+  if (live) return live;
+  if (task.last) return { status: task.last.status, durationMs: task.last.durationMs };
+  return { status: "idle", durationMs: null };
+}
+
+function renderCounts() {
+  const counts = {};
+  for (const t of allTasks()) {
+    const s = taskStatus(t).status;
+    counts[s] = (counts[s] || 0) + 1;
+  }
+  $("#counts").innerHTML = Object.entries(counts)
+    .sort()
+    .map(([s, n]) => `<span class="chip"><b>${n}</b> ${s}</span>`)
+    .join("") + `<span class="chip">${allTasks().length} tasks total</span>`;
+}
+
+function allTasks() {
+  const tasks = [...(state?.registry.tasks ?? [])];
+  if (state?.registry.cloudStep) {
+    tasks.push({ label: state.registry.cloudStep.label, relativeDir: "packages/cloud", scriptName: "test", parallelSafe: false, liveSuites: [], last: null, cloud: true });
+  }
+  return tasks;
+}
+
+function suiteBadge(suite) {
+  const cls = suite.state === "armed" ? "armed" : suite.state === "blocked" ? "blocked" : suite.state === "missing-creds" ? "missing" : "";
+  const text = suite.state === "missing-creds"
+    ? `needs ${(suite.connections || []).join(", ") || (suite.missing || []).join(", ")}`
+    : suite.state;
+  const title = suite.file.split("/").pop() + (suite.missing ? " — missing " + suite.missing.join(", ") : suite.reason ? " — " + suite.reason : "");
+  return `<span class="badge ${cls}" title="${title.replace(/"/g, "&quot;")}">${text}</span>`;
+}
+
+function renderRows() {
+  const q = $("#filter").value.toLowerCase();
+  const sf = $("#statusFilter").value;
+  const liveOnly = $("#liveOnly").checked;
+  const rows = [];
+  for (const task of allTasks()) {
+    if (q && !task.label.toLowerCase().includes(q)) continue;
+    const st = taskStatus(task);
+    if (sf && st.status !== sf) continue;
+    if (liveOnly && !(task.liveSuites || []).length) continue;
+    const badges = (task.liveSuites || []).map(suiteBadge).join("");
+    rows.push(`<tr class="task" data-label="${encodeURIComponent(task.label)}">
+      <td><input type="checkbox" data-sel="${encodeURIComponent(task.label)}" ${selected.has(task.label) ? "checked" : ""}></td>
+      <td><span class="status ${st.status}">${st.status}</span></td>
+      <td><div class="lbl">${task.label}</div>${badges ? `<div class="badges">${badges}</div>` : ""}</td>
+      <td class="dur">${fmtMs(st.durationMs)}</td>
+    </tr>`);
+  }
+  $("#rows").innerHTML = rows.join("");
+  renderCounts();
+}
+
+function renderConnections() {
+  const groups = {};
+  for (const conn of state.registry.connections) {
+    (groups[conn.category] ??= []).push(conn);
+  }
+  const order = ["llm", "messaging", "saas", "calendar", "health", "web3", "push", "infra", "cloud"];
+  $("#conns").innerHTML = order.filter((c) => groups[c]).map((cat) =>
+    `<div style="margin-bottom:4px;color:var(--dim);font-size:11px;text-transform:uppercase">${cat}</div>` +
+    groups[cat].map((conn) => `
+    <div class="conn ${openConns.has(conn.id) ? "open" : ""}" data-conn="${conn.id}">
+      <div class="head">
+        <span class="dot ${conn.configured ? "on" : ""}" id="dot-${conn.id}"></span>
+        <span class="name">${conn.label}</span>
+        <span class="unlocks">${conn.unlocks ? conn.unlocks + (conn.unlocks === 1 ? " suite" : " suites") : ""}</span>
+        <button data-open="${conn.id}">${conn.configured ? "Edit" : "Set up"}</button>
+      </div>
+      <form data-form="${conn.id}">
+        <div style="font-size:11px;color:var(--dim);margin-top:4px">${conn.obtain}</div>
+        ${conn.fields.map((f) => `
+          <label>${f.label}${f.set ? ` <span style="color:var(--pass)">(saved ${f.hint})</span>` : ""}</label>
+          ${f.multiline
+            ? `<textarea name="${f.key}" rows="3" placeholder="${f.placeholder || (f.set ? "leave blank to keep" : "")}"></textarea>`
+            : `<input type="${f.secret ? "password" : "text"}" name="${f.key}" placeholder="${f.placeholder || (f.set ? "leave blank to keep" : "")}" autocomplete="off" />`}
+        `).join("")}
+        <div class="row">
+          <button type="submit" class="primary">Save</button>
+          <button type="button" data-verify="${conn.id}">Verify</button>
+          ${conn.oauth === "google" || conn.oauth === "google-calendar" ? `<button type="button" data-google="${conn.id}">Connect Google</button>` : ""}
+          ${conn.oauth === "eliza-cloud" ? `<button type="button" data-cloud="${conn.id}">Log in</button>` : ""}
+          <button type="button" data-remove="${conn.id}">Remove</button>
+        </div>
+        <div class="verify-result" data-vr="${conn.id}"></div>
+      </form>
+    </div>`).join("")
+  ).join("");
+}
+
+function renderGates() {
+  $("#gates").innerHTML = state.registry.optInGates.map((g) => `
+    <label class="gate"><input type="checkbox" data-gate="${g.key}" ${g.on ? "checked" : ""}/> ${g.label} <span style="color:var(--dim);font-size:11px">${g.key}</span></label>
+  `).join("");
+}
+
+function renderRuns() {
+  $("#runs").innerHTML = (state.runs || []).map((r) => {
+    const counts = Object.entries(r.counts || {}).map(([s, n]) => `${n} ${s}`).join(", ");
+    return `<div class="runhist">${r.runId} — ${counts}${r.cancelled ? " (cancelled)" : ""}</div>`;
+  }).join("") || "<div class='runhist'>none yet</div>";
+}
+
+async function refresh() {
+  state = await api("GET", "/api/state");
+  $("#dirhint").textContent = state.consoleDir;
+  if (state.run) {
+    drawerRunId = state.run.runId;
+    for (const t of state.run.tasks) statuses.set(t.label, { status: t.status, durationMs: t.durationMs });
+  }
+  renderRows();
+  renderConnections();
+  renderGates();
+  renderRuns();
+}
+
+function openDrawer(label) {
+  drawerTask = label;
+  $("#drawerLabel").textContent = label;
+  const st = statuses.get(label) || { status: "idle" };
+  $("#drawerStatus").textContent = st.status;
+  $("#drawerStatus").className = "status " + st.status;
+  $("#drawerLog").textContent = "";
+  $("#drawer").classList.add("open");
+  if (drawerRunId) {
+    fetch(`/api/runs/${encodeURIComponent(drawerRunId)}/log?task=${encodeURIComponent(label)}`)
+      .then((r) => (r.ok ? r.text() : ""))
+      .then((text) => { if (drawerTask === label && text) { $("#drawerLog").textContent = text; scrollLog(); } });
+  }
+}
+
+function scrollLog() {
+  const pre = $("#drawerLog");
+  pre.scrollTop = pre.scrollHeight;
+}
+
+// --- event wiring ----------------------------------------------------------
+document.addEventListener("click", async (event) => {
+  const el = event.target;
+  if (el.dataset.open) {
+    const id = el.dataset.open;
+    if (openConns.has(id)) openConns.delete(id); else openConns.add(id);
+    document.querySelector(`.conn[data-conn="${id}"]`).classList.toggle("open");
+    return;
+  }
+  if (el.dataset.verify) {
+    const vr = document.querySelector(`[data-vr="${el.dataset.verify}"]`);
+    vr.textContent = "verifying…";
+    try {
+      const result = await api("POST", `/api/connections/${el.dataset.verify}/verify`);
+      vr.textContent = `${result.status}: ${result.detail}`;
+      vr.style.color = result.ok ? "var(--pass)" : "var(--fail)";
+      $(`#dot-${el.dataset.verify}`).className = "dot " + (result.ok ? "on" : "err");
+    } catch (error) { vr.textContent = String(error.message); vr.style.color = "var(--fail)"; }
+    return;
+  }
+  if (el.dataset.remove) {
+    await api("DELETE", `/api/connections/${el.dataset.remove}`);
+    await refresh();
+    return;
+  }
+  if (el.dataset.google) { window.open("/oauth/google/start", "_blank"); return; }
+  if (el.dataset.cloud) {
+    try {
+      const { sessionId, browserUrl } = await api("POST", "/api/cloud/login/start");
+      window.open(browserUrl, "_blank");
+      toast("Complete the login in the opened tab…");
+      const poll = setInterval(async () => {
+        const { status } = await api("GET", `/api/cloud/login/poll?sessionId=${encodeURIComponent(sessionId)}`);
+        if (status === "authenticated") { clearInterval(poll); toast("Eliza Cloud connected"); refresh(); }
+        if (status === "expired" || status === "error") { clearInterval(poll); toast("Cloud login " + status); }
+      }, 2500);
+    } catch (error) { toast("Cloud login failed: " + error.message); }
+    return;
+  }
+  const row = el.closest("tr.task");
+  if (row && el.type !== "checkbox") openDrawer(decodeURIComponent(row.dataset.label));
+});
+
+document.addEventListener("change", async (event) => {
+  const el = event.target;
+  if (el.dataset.sel) {
+    const label = decodeURIComponent(el.dataset.sel);
+    if (el.checked) selected.add(label); else selected.delete(label);
+  }
+  if (el.dataset.gate) {
+    await api("POST", "/api/gates", { key: el.dataset.gate, on: el.checked });
+    await refresh();
+  }
+});
+
+document.addEventListener("submit", async (event) => {
+  const form = event.target.closest("form[data-form]");
+  if (!form) return;
+  event.preventDefault();
+  const values = {};
+  for (const input of form.querySelectorAll("input[name],textarea[name]")) {
+    if (input.value.trim()) values[input.name] = input.value.trim();
+  }
+  // Only typed fields are sent; the server merges over saved values, so a
+  // blank field means "keep what's saved".
+  await api("POST", `/api/connections/${form.dataset.form}`, { values });
+  toast("Saved");
+  await refresh();
+});
+
+async function startRun(mode) {
+  const lane = $("#lane").value;
+  const labels = mode === "selection" ? [...selected] : undefined;
+  try {
+    const { runId, taskCount } = await api("POST", "/api/run", { mode, lane, labels });
+    statuses = new Map();
+    drawerRunId = runId;
+    toast(`Run started: ${taskCount} tasks (${lane})`);
+    await refresh();
+  } catch (error) { toast(error.message); }
+}
+
+$("#runAll").onclick = () => startRun("all");
+$("#runSel").onclick = () => (selected.size ? startRun("selection") : toast("nothing selected"));
+$("#runFailed").onclick = () => startRun("failed");
+$("#cancel").onclick = () => api("POST", "/api/run/cancel").then(() => toast("cancelling…"));
+$("#clearSel").onclick = () => { selected.clear(); statuses = new Map(); renderRows(); };
+$("#closeDrawer").onclick = () => $("#drawer").classList.remove("open");
+$("#rerunOne").onclick = () => drawerTask && api("POST", "/api/run", { mode: "selection", lane: $("#lane").value, labels: [drawerTask] }).then(refresh).catch((e) => toast(e.message));
+$("#filter").oninput = renderRows;
+$("#statusFilter").onchange = renderRows;
+$("#liveOnly").onchange = renderRows;
+
+// --- SSE -------------------------------------------------------------------
+const events = new EventSource("/api/events");
+events.onmessage = (message) => {
+  const event = JSON.parse(message.data);
+  if (event.type === "task") {
+    statuses.set(event.label, { status: event.status, durationMs: event.durationMs ?? null });
+    renderRows();
+    if (drawerTask === event.label) {
+      $("#drawerStatus").textContent = event.status;
+      $("#drawerStatus").className = "status " + event.status;
+    }
+  } else if (event.type === "log" && drawerTask === event.label) {
+    $("#drawerLog").textContent += event.chunk;
+    scrollLog();
+  } else if (event.type === "run-started") {
+    drawerRunId = event.runId;
+  } else if (event.type === "run-finished") {
+    toast(`Run finished: ${Object.entries(event.counts).map(([s, n]) => `${n} ${s}`).join(", ")}`);
+    refresh();
+  }
+};
+
+refresh().catch((error) => toast("load failed: " + error.message));
+</script>
+</body>
+</html>


### PR DESCRIPTION
Resolves #14572.

`bun run test:console` → self-contained local web console at `127.0.0.1:31338` (zero new dependencies, no build step — it must work in a half-broken checkout, since running tests when things fail is its job).

- **Registry**: every task from `run-all-tests.mjs --plan=json --all` (263 tasks: test/e2e/ui/integration/live + cloud step) — the same source of truth CI's lane-manifest proof checks.
- **Gating**: guarded live suites joined from `packages/scripts/lib/real-live-suites.mjs` and classified with the same `computeRealLiveAccounting` the post-merge lane prints; per-task badges `armed` / `needs <connection>` / `opt-in` / `probe` / `blocked`.
- **Connections**: 36 services (all guarded-suite vars + the full `post-merge-secrets.txt` set — drift-guarded by a test); real read-only verify probes; Eliza Cloud device-code login (same protocol as `ElizaCloudClient.startCliLogin`); Google OAuth refresh-token mint via the console's own loopback callback, with hourly calendar-token re-mint before live runs.
- **Runner**: per-task `run-all-tests.mjs --filter='^<label>$' --min-tasks=1` spawns (keeps CI lane env/Postgres-provision/skip semantics), own process group for cancel, SSE live status, log-line-first result classification (exit 0 alone is not proof; exit 3 = vacuous-green skip).
- **Persistence**: `~/.eliza/test-console/` — `credentials.json` (0600), `runs/<id>/run.json` + per-task logs, `history.json` (re-run-failed survives restarts), `settings.json` (opt-in gates).

## Evidence

**Video walkthrough** (MP4, hosted on the evidence gist — CLI cannot upload to GitHub's media CDN): [console-walkthrough.mp4](https://gist.githubusercontent.com/lalalune/6fb89e0e2ed13d83787835ce1b1b89e9/raw/console-walkthrough.mp4)

**Screenshots** (desktop 1440×900, mobile 390×844; "before" is N/A — new tool, no prior page):

| | |
|---|---|
| Home — 264 tasks, statuses, connections | ![home](https://gist.githubusercontent.com/lalalune/6fb89e0e2ed13d83787835ce1b1b89e9/raw/01-home-desktop.jpg) |
| Connection form (OpenAI) | ![form](https://gist.githubusercontent.com/lalalune/6fb89e0e2ed13d83787835ce1b1b89e9/raw/02-connection-form.jpg) |
| Verify probe → real upstream 401 rendered as invalid | ![verify](https://gist.githubusercontent.com/lalalune/6fb89e0e2ed13d83787835ce1b1b89e9/raw/03-verify-invalid.jpg) |
| Run selected → passed 2.6s | ![passed](https://gist.githubusercontent.com/lalalune/6fb89e0e2ed13d83787835ce1b1b89e9/raw/05-passed.jpg) |
| Log drawer — real `[eliza-test]` + vitest output | ![drawer](https://gist.githubusercontent.com/lalalune/6fb89e0e2ed13d83787835ce1b1b89e9/raw/06-log-drawer.jpg) |
| Live-gated view — armed / needs-X / blocked / probe / opt-in badges | ![gated](https://gist.githubusercontent.com/lalalune/6fb89e0e2ed13d83787835ce1b1b89e9/raw/07-live-gated.jpg) |
| Mobile | ![mobile](https://gist.githubusercontent.com/lalalune/6fb89e0e2ed13d83787835ce1b1b89e9/raw/08-mobile.jpg) |

**Real behavior proven by hand** (not mocks):
- Saving `TAVILY_API_KEY` via the API flips `webSearchService.real.test.ts` from `missing-creds` to `armed` in `/api/state`.
- Verify probe against api.openai.com with a bad key returns the real HTTP 401 body (screenshot 3).
- A real `@elizaos/logger#test` run through the console: spawn → SSE `running` → vitest 5/5 → `PASS` line parsed → `passed` persisted (screenshot 5/6). The earlier deliberate no-deps failure classified `failed` — both sides of the classifier exercised.

<details><summary>Backend logs — persisted run manifest + task log (domain artifacts, inspected)</summary>

```
credentials.json mode: 0600
run.json: {"runId":"2026-07-06T00-39-19-293Z-pr","lane":"pr","counts":{"passed":1},
  "tasks":[{"label":"@elizaos/logger (packages/logger)#test","status":"passed","exitCode":0,"durationMs":1302}]}
task log tail:
  [eliza-test] START @elizaos/logger (packages/logger)#test
  Test Files  1 passed (1) / Tests  5 passed (5)
  [eliza-test] PASS @elizaos/logger (packages/logger)#test (2413ms)
```
</details>

**Unit tests**: `bun test packages/scripts/test-console/__tests__/` — 13 pass, 0 fail (93 assertions): result classifier (PASS/FAIL/SKIP/exit-3/signal/cancel), 0600 store roundtrip, real plan discovery (no mocks — shells the actual planner), credential→gating flip, and drift guards (every guarded-suite var + post-merge secret + opt-in gate must map to a catalog connection).

**Frontend console/network logs**: playwright walkthrough ran with console/pageerror hooks — zero errors emitted.

**Real-LLM trajectories**: N/A — dev tooling; no agent/action/provider/prompt/model behavior changed.

**Biome**: 0 errors at `--diagnostic-level=error` (remaining warnings match the `packages/scripts` baseline, e.g. `noUndeclaredEnvVars` on `process.env` reads, same as `run-all-tests.mjs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)