### PR TITLE
perf(cloud): extend first-line TTS cache to the Kokoro branch (#14375)

### DIFF
--- a/packages/cloud/api/v1/voice/tts/__tests__/kokoro-first-line-cache.test.ts
+++ b/packages/cloud/api/v1/voice/tts/__tests__/kokoro-first-line-cache.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for the Kokoro first-line cache key/flag helper (#14375).
+ *
+ * Deterministic and DB-free: exercises the pure cache-key mapping, the flag
+ * gate, and provider-key parity against the shared `hashCloudCacheKey`. The
+ * live serve/populate round-trip through Railway + R2 is covered separately by
+ * `voice-kokoro-whisper-live.test.ts` (gated on a live service) — see the PR
+ * evidence table.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  fingerprintCloudVoiceSettings,
+  hashCloudCacheKey,
+} from "@elizaos/cloud-shared/lib/services/tts-first-line-cache";
+import { firstSentenceSnip } from "@elizaos/shared/voice/first-sentence-snip";
+import {
+  buildKokoroCacheKey,
+  isKokoroFirstLineCacheEnabled,
+  KOKORO_CACHE_SCOPE,
+  KOKORO_CODEC,
+  KOKORO_SAMPLE_RATE,
+  resolveKokoroVoiceRevision,
+} from "../kokoro-first-line-cache";
+
+describe("isKokoroFirstLineCacheEnabled — flag gate", () => {
+  test("default OFF (unset / empty)", () => {
+    expect(isKokoroFirstLineCacheEnabled(undefined)).toBe(false);
+    expect(isKokoroFirstLineCacheEnabled(null)).toBe(false);
+    expect(isKokoroFirstLineCacheEnabled("")).toBe(false);
+    expect(isKokoroFirstLineCacheEnabled("   ")).toBe(false);
+  });
+
+  test("falsy literals stay OFF", () => {
+    for (const v of ["0", "false", "no", "off", "disabled", "nope"]) {
+      expect(isKokoroFirstLineCacheEnabled(v)).toBe(false);
+    }
+  });
+
+  test("truthy literals turn ON (case/space-insensitive)", () => {
+    for (const v of ["1", "true", "yes", "on", "  TRUE ", "Yes", "ON"]) {
+      expect(isKokoroFirstLineCacheEnabled(v)).toBe(true);
+    }
+  });
+});
+
+describe("resolveKokoroVoiceRevision", () => {
+  test("folds voice, format, and deploy tag into the revision", () => {
+    expect(resolveKokoroVoiceRevision("af_heart", "img-abc123")).toBe(
+      `kokoro:af_heart:${KOKORO_SAMPLE_RATE}:${KOKORO_CODEC}:img-abc123`,
+    );
+  });
+
+  test("defaults the deploy tag to 'unpinned' when unset/blank", () => {
+    expect(resolveKokoroVoiceRevision("af_bella", undefined)).toBe(
+      `kokoro:af_bella:${KOKORO_SAMPLE_RATE}:${KOKORO_CODEC}:unpinned`,
+    );
+    expect(resolveKokoroVoiceRevision("af_bella", "   ")).toBe(
+      `kokoro:af_bella:${KOKORO_SAMPLE_RATE}:${KOKORO_CODEC}:unpinned`,
+    );
+  });
+
+  test("different deploy tags produce different revisions (rolls the cache)", () => {
+    const a = resolveKokoroVoiceRevision("af_heart", "img-v1");
+    const b = resolveKokoroVoiceRevision("af_heart", "img-v2");
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("buildKokoroCacheKey", () => {
+  test("maps a Kokoro opener onto the shared provider-keyed cache key", () => {
+    const snip = firstSentenceSnip("Got it.");
+    expect(snip).not.toBeNull();
+
+    const key = buildKokoroCacheKey({
+      kokoroVoice: "af_heart",
+      normalizedText: snip!.normalized,
+      imageTag: "img-abc",
+    });
+
+    expect(key.provider).toBe("kokoro");
+    expect(key.voiceId).toBe("af_heart");
+    expect(key.codec).toBe(KOKORO_CODEC);
+    expect(key.sampleRate).toBe(KOKORO_SAMPLE_RATE);
+    expect(key.scope).toBe(KOKORO_CACHE_SCOPE);
+    expect(key.normalizedText).toBe("got it");
+    expect(key.voiceRevision).toBe(
+      resolveKokoroVoiceRevision("af_heart", "img-abc"),
+    );
+    // algoVersion is the snip-version constant so a snip-logic change rolls it.
+    expect(key.algoVersion).toBe("1");
+    expect(key.voiceSettingsFingerprint).toBe(
+      fingerprintCloudVoiceSettings({ speed: 1 }),
+    );
+  });
+
+  test("hashes stably and matches the shared hash contract", () => {
+    const key = buildKokoroCacheKey({
+      kokoroVoice: "af_heart",
+      normalizedText: "got it",
+      imageTag: "img-abc",
+    });
+    // Same inputs → same hash (deterministic).
+    const again = buildKokoroCacheKey({
+      kokoroVoice: "af_heart",
+      normalizedText: "got it",
+      imageTag: "img-abc",
+    });
+    expect(hashCloudCacheKey(key)).toBe(hashCloudCacheKey(again));
+  });
+
+  test("provider-keyed MISS: kokoro hash != elevenlabs hash for the same opener", () => {
+    const kokoroKey = buildKokoroCacheKey({
+      kokoroVoice: "af_heart",
+      normalizedText: "got it",
+      imageTag: "img-abc",
+    });
+    // An ElevenLabs key over the same normalized text must not collide — this
+    // is the cross-provider safety guard the ElevenLabs path also relies on.
+    const elevenHash = hashCloudCacheKey({
+      algoVersion: "1",
+      provider: "elevenlabs",
+      voiceId: "EXAVITQu4vr4xnSDxMaL",
+      voiceRevision:
+        "elevenlabs:EXAVITQu4vr4xnSDxMaL:eleven_flash_v2_5:mp3_44100_128",
+      sampleRate: 44100,
+      codec: "mp3",
+      voiceSettingsFingerprint: fingerprintCloudVoiceSettings({}),
+      normalizedText: "got it",
+      scope: "global",
+    });
+    expect(hashCloudCacheKey(kokoroKey)).not.toBe(elevenHash);
+  });
+
+  test("different Kokoro voices for the same opener miss each other", () => {
+    const heart = buildKokoroCacheKey({
+      kokoroVoice: "af_heart",
+      normalizedText: "got it",
+      imageTag: "img-abc",
+    });
+    const bella = buildKokoroCacheKey({
+      kokoroVoice: "af_bella",
+      normalizedText: "got it",
+      imageTag: "img-abc",
+    });
+    expect(hashCloudCacheKey(heart)).not.toBe(hashCloudCacheKey(bella));
+  });
+
+  test("a deploy-tag bump changes the hash (image change rolls the cache)", () => {
+    const v1 = buildKokoroCacheKey({
+      kokoroVoice: "af_heart",
+      normalizedText: "got it",
+      imageTag: "img-v1",
+    });
+    const v2 = buildKokoroCacheKey({
+      kokoroVoice: "af_heart",
+      normalizedText: "got it",
+      imageTag: "img-v2",
+    });
+    expect(hashCloudCacheKey(v1)).not.toBe(hashCloudCacheKey(v2));
+  });
+});
+
+describe("whole-input opener gating (matches the route's cacheable rule)", () => {
+  const isCacheable = (text: string): boolean => {
+    const snip = firstSentenceSnip(text);
+    return snip !== null && snip.endOffset === text.trimEnd().length;
+  };
+
+  test("short whole-input openers are cacheable", () => {
+    expect(isCacheable("Got it.")).toBe(true);
+    expect(isCacheable("Sure.")).toBe(true);
+    expect(isCacheable("No problem!")).toBe(true);
+    expect(isCacheable("Got it.  ")).toBe(true); // trailing ws ignored
+  });
+
+  test("multi-sentence / trailing-remainder text is NOT cacheable (no concat)", () => {
+    expect(
+      isCacheable("Got it. Let me pull up your account details now."),
+    ).toBe(false);
+  });
+
+  test("unterminated text is NOT cacheable", () => {
+    expect(isCacheable("Got it")).toBe(false);
+  });
+
+  test(">10-word opener is NOT cacheable (snip refuses it)", () => {
+    expect(
+      isCacheable(
+        "Sure, I will go ahead and take care of that whole thing for you.",
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/cloud/api/v1/voice/tts/kokoro-first-line-cache.ts
+++ b/packages/cloud/api/v1/voice/tts/kokoro-first-line-cache.ts
@@ -1,0 +1,93 @@
+/**
+ * Cache-key resolution and flag gating for the Kokoro branch of the cloud TTS
+ * route (#14375). The Kokoro path is the free web default; short whole-input
+ * openers ("Got it.", "Sure.") otherwise pay full Railway synthesis every turn
+ * because the ElevenLabs first-line cache sits after the Kokoro early return.
+ *
+ * This module owns the pure pieces the route composes: how a Kokoro request
+ * maps onto the shared provider-keyed cache key (`provider: "kokoro"`, WAV
+ * codec, deploy-tagged `voiceRevision`) and whether the caching is enabled at
+ * all. It has no DB/R2/network dependency so the mapping and the flag gate are
+ * unit-testable in isolation; the route wires these into the existing
+ * `getCloudFirstLineCacheService` get/put paths.
+ */
+
+import { FIRST_SENTENCE_SNIP_VERSION } from "@elizaos/shared/voice/first-sentence-snip";
+import type { CloudFirstLineCacheKey } from "@/lib/services/tts-first-line-cache";
+import { fingerprintCloudVoiceSettings } from "@/lib/services/tts-first-line-cache";
+
+/**
+ * Kokoro synthesises 16-bit PCM WAV at 24 kHz. Both fields are part of the
+ * cache key, so they must match the bytes the service actually returns — a
+ * mismatch would let a differently-encoded entry masquerade as a hit.
+ */
+export const KOKORO_SAMPLE_RATE = 24000 as const;
+export const KOKORO_CODEC = "wav" as const;
+
+/**
+ * The Kokoro voice is the free default and has no per-org custom clones, so
+ * every entry lives in the shared `global` scope (same rule the ElevenLabs
+ * default voices follow).
+ */
+export const KOKORO_CACHE_SCOPE = "global" as const;
+
+/**
+ * Deploy tag folded into `voiceRevision` when `KOKORO_SERVICE_IMAGE_TAG` is
+ * unset. A stable literal (rather than a timestamp) keeps the cache warm across
+ * restarts; a deployment that changes audio output must set the env var so the
+ * revision — and therefore the key — rolls.
+ */
+const DEFAULT_KOKORO_IMAGE_TAG = "unpinned";
+
+/**
+ * Parse the `KOKORO_FIRST_LINE_CACHE` flag. Default off: the rollout is gated
+ * on the #14370 TTFB benchmark, which needs the live Railway service to
+ * measure, so caching stays disabled until an operator opts a deployment in.
+ */
+export function isKokoroFirstLineCacheEnabled(
+  flag: string | undefined | null,
+): boolean {
+  if (!flag) return false;
+  const v = flag.trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes" || v === "on";
+}
+
+/**
+ * Stable `voiceRevision` for a Kokoro voice. Includes the sample rate/codec so
+ * a future output-format change is a distinct revision, and the deploy tag so a
+ * service redeploy that alters audio invalidates only Kokoro entries.
+ */
+export function resolveKokoroVoiceRevision(
+  kokoroVoice: string,
+  imageTag: string | undefined | null,
+): string {
+  const tag = imageTag?.trim() || DEFAULT_KOKORO_IMAGE_TAG;
+  return `kokoro:${kokoroVoice}:${KOKORO_SAMPLE_RATE}:${KOKORO_CODEC}:${tag}`;
+}
+
+/**
+ * Build the shared cache key for a Kokoro opener. `normalizedText` is the
+ * snip's normalised form; the caller guarantees it is a cacheable whole-input
+ * opener before calling.
+ */
+export function buildKokoroCacheKey(args: {
+  kokoroVoice: string;
+  normalizedText: string;
+  imageTag: string | undefined | null;
+}): CloudFirstLineCacheKey {
+  return {
+    algoVersion: FIRST_SENTENCE_SNIP_VERSION,
+    provider: "kokoro",
+    voiceId: args.kokoroVoice,
+    voiceRevision: resolveKokoroVoiceRevision(args.kokoroVoice, args.imageTag),
+    sampleRate: KOKORO_SAMPLE_RATE,
+    codec: KOKORO_CODEC,
+    voiceSettingsFingerprint: fingerprintCloudVoiceSettings({
+      // speed is pinned to 1 in the route; folding it in keeps the key honest
+      // if that ever becomes a parameter.
+      speed: 1,
+    }),
+    normalizedText: args.normalizedText,
+    scope: KOKORO_CACHE_SCOPE,
+  };
+}

--- a/packages/cloud/api/v1/voice/tts/route.ts
+++ b/packages/cloud/api/v1/voice/tts/route.ts
@@ -52,6 +52,10 @@ import {
 } from "@/lib/services/tts-first-line-cache";
 import { usageService } from "@/lib/services/usage";
 import { logger } from "@/lib/utils/logger";
+import {
+  buildKokoroCacheKey,
+  isKokoroFirstLineCacheEnabled,
+} from "./kokoro-first-line-cache";
 
 /**
  * Default ElevenLabs output format. Must stay in sync with the ElevenLabs
@@ -164,6 +168,51 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
     const kokoroBaseUrl = env.KOKORO_TTS_URL?.trim();
     if (kokoroBaseUrl) {
       const kokoroVoice = resolveKokoroVoice(voiceId);
+
+      // First-line cache (#14375), gated on the #14370 TTFB benchmark and off by
+      // default. Only WHOLE-input short openers ("Got it.") are cacheable — the
+      // same whole-input-only rule the ElevenLabs path uses (no concat).
+      const kokoroCacheEnabled = isKokoroFirstLineCacheEnabled(
+        env.KOKORO_FIRST_LINE_CACHE,
+      );
+      const kokoroSnip = kokoroCacheEnabled ? firstSentenceSnip(text) : null;
+      const kokoroCacheable =
+        kokoroSnip !== null && kokoroSnip.endOffset === text.trimEnd().length;
+      const kokoroCacheKey =
+        kokoroCacheEnabled && kokoroCacheable && kokoroSnip
+          ? buildKokoroCacheKey({
+              kokoroVoice,
+              normalizedText: kokoroSnip.normalized,
+              imageTag: env.KOKORO_SERVICE_IMAGE_TAG,
+            })
+          : null;
+
+      if (kokoroCacheKey) {
+        try {
+          const cached =
+            await getCloudFirstLineCacheService().get(kokoroCacheKey);
+          if (cached) {
+            logger.info(
+              `[Voice TTS API] Kokoro first-line cache HIT (${cached.byteSize}B, hits=${cached.hitCount}, voice=${kokoroVoice}) — no upstream request`,
+            );
+            return new Response(cached.bytes as unknown as BodyInit, {
+              status: 200,
+              headers: {
+                "Content-Type": cached.contentType,
+                "Cache-Control": "no-cache",
+                "X-TTS-Cache": "hit; kokoro; first-sentence",
+              },
+            });
+          }
+        } catch (err) {
+          // error-policy:J4 cache lookup failure degrades to fresh synthesis;
+          // the upstream Railway request below is the source of truth.
+          logger.warn?.(
+            `[Voice TTS API] Kokoro first-line cache lookup failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+
       const kokoroStart = Date.now();
       const kokoroResponse = await fetch(
         `${kokoroBaseUrl.replace(/\/+$/, "")}/api/tts`,
@@ -184,14 +233,55 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
           { status: 502 },
         );
       }
+      const kokoroContentType =
+        kokoroResponse.headers.get("Content-Type") ?? "audio/wav";
       logger.info(
         `[Voice TTS API] Kokoro stream started in ${Date.now() - kokoroStart}ms (voice=${kokoroVoice}, free)`,
       );
+
+      // Cacheable opener MISS: buffer the (tiny, ≤10-word) WAV so we can serve
+      // it AND populate the cache. Non-cacheable text streams straight through
+      // to preserve time-to-first-byte on long responses.
+      if (kokoroCacheKey && kokoroSnip) {
+        const bytes = new Uint8Array(await kokoroResponse.arrayBuffer());
+        void getCloudFirstLineCacheService()
+          .put({
+            ...kokoroCacheKey,
+            bytes,
+            rawText: kokoroSnip.raw,
+            contentType: kokoroContentType,
+            durationMs: 0,
+            wordCount: kokoroSnip.wordCount,
+          })
+          .then((ok) => {
+            if (ok) {
+              logger.info(
+                `[Voice TTS API] Kokoro first-line cache POPULATE ok (${bytes.byteLength}B, "${kokoroSnip.normalized}")`,
+              );
+            }
+          })
+          .catch((err) => {
+            // error-policy:J7 populate is a background write; a failure must not
+            // affect the response the user already receives below.
+            logger.warn?.(
+              `[Voice TTS API] Kokoro first-line cache populate failed: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          });
+
+        return new Response(bytes as unknown as BodyInit, {
+          status: 200,
+          headers: {
+            "Content-Type": kokoroContentType,
+            "Cache-Control": "no-store",
+            "X-TTS-Cache": "miss; kokoro",
+          },
+        });
+      }
+
       return new Response(kokoroResponse.body, {
         status: 200,
         headers: {
-          "Content-Type":
-            kokoroResponse.headers.get("Content-Type") ?? "audio/wav",
+          "Content-Type": kokoroContentType,
           "Cache-Control": "no-store",
         },
       });

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -52,6 +52,22 @@ export interface Bindings {
    */
   KOKORO_TTS_URL?: string;
   /**
+   * Enables the first-line TTS cache on the free Kokoro branch (#14375). Short
+   * whole-input openers ("Got it.", "Sure.") are served from the provider-keyed
+   * cache instead of paying full Railway synthesis every turn. Truthy values:
+   * `"1"`/`"true"`/`"yes"`. Default off — the rollout is gated on the #14370
+   * TTFB benchmark (short-sentence TTFB above threshold), which needs the live
+   * Railway service to measure. ElevenLabs caching is unaffected by this flag.
+   */
+  KOKORO_FIRST_LINE_CACHE?: string;
+  /**
+   * Deploy identity of the Kokoro service, folded into the cache `voiceRevision`
+   * so a model/image change on the Railway side invalidates only Kokoro entries.
+   * Defaults to `"unpinned"` when unset — set it to the deployed image tag/digest
+   * so a redeploy that changes audio output rolls the Kokoro cache.
+   */
+  KOKORO_SERVICE_IMAGE_TAG?: string;
+  /**
    * Base URL of the self-hosted Whisper STT service (OpenAI-compatible
    * `/v1/audio/transcriptions`, e.g. the Railway deploy). When set, the cloud
    * STT endpoint serves Whisper for free; ElevenLabs STT is the fallback.


### PR DESCRIPTION
## What & why

The cloud **Kokoro** TTS branch (`packages/cloud/api/v1/voice/tts/route.ts`) returned early, **before** the first-line cache hit/populate paths, which were ElevenLabs-only. So on the free web-default voice, short whole-input openers ("Got it.", "Sure.", "No problem!") paid **full Railway synthesis + network latency on every single turn** — no caching at all.

This PR extends the existing provider-keyed cache (`getCloudFirstLineCacheService`, already keyed on `provider`) to the Kokoro branch:

- **HIT** → serve the cached WAV, **no upstream Railway request** (log line + `X-TTS-Cache: hit; kokoro; first-sentence`).
- **MISS on a cacheable opener** → buffer the tiny (≤10-word) WAV, serve it, and **populate the cache in the background**. Non-opener text still **streams straight through** (unchanged), preserving time-to-first-byte on long responses.
- **Whole-input-only** (`snip.endOffset === text.trimEnd().length`) — the same no-concat rule the ElevenLabs path uses.

### Conditional on the #14370 benchmark
Rollout is gated behind a new flag **`KOKORO_FIRST_LINE_CACHE` (default OFF)** because #14375 is explicitly *"conditional on the #14370 TTFB benchmark"*, which needs the live Railway service to measure. The caching is implemented and safe-by-default; an operator opts a deployment in only if the benchmark shows short-sentence TTFB above threshold. `KOKORO_SERVICE_IMAGE_TAG` folds the deploy identity into the `voiceRevision` so a redeploy that changes audio invalidates **only** Kokoro entries (ElevenLabs cache untouched).

Cache-key mapping + flag gate live in a pure, DB-free helper (`kokoro-first-line-cache.ts`) so they are unit-testable without Postgres/R2.

## Files changed
- `packages/cloud/api/v1/voice/tts/route.ts` — Kokoro branch HIT check + buffered-MISS populate; non-opener streaming preserved.
- `packages/cloud/api/v1/voice/tts/kokoro-first-line-cache.ts` — **new** pure helper: flag gate, `voiceRevision`/key mapping (`provider: "kokoro"`, `codec: "wav"`, `sampleRate: 24000`, `scope: "global"`).
- `packages/cloud/shared/src/types/cloud-worker-env.ts` — `KOKORO_FIRST_LINE_CACHE` + `KOKORO_SERVICE_IMAGE_TAG` bindings.
- `packages/cloud/api/v1/voice/tts/__tests__/kokoro-first-line-cache.test.ts` — **new** 15 unit tests.

## Verification

<details><summary><code>bun test kokoro-first-line-cache.test.ts</code> — 15 pass / 0 fail</summary>

```
bun test v1.3.14 (0d9b296a)
...............
15 pass
0 fail
42 expect() calls
Ran 15 tests across 1 file. [451.00ms]
```

Covers: flag gate (default OFF; falsy/truthy literals, case/space-insensitive), `resolveKokoroVoiceRevision` (deploy-tag fold + `unpinned` default + tag-bump rolls), `buildKokoroCacheKey` mapping, **provider-keyed MISS (kokoro hash != elevenlabs hash for same opener)**, per-voice miss, deploy-tag roll, and whole-input opener gating (multi-sentence / unterminated / >10-word all rejected — matches the route's cacheable rule).
</details>

<details><summary>Regression: existing parity + load suites still green</summary>

```
packages/cloud/shared/.../tts-cache-key-parity.test.ts + packages/cloud/api/__tests__/tts-cache-load.test.ts
 8 pass
 0 fail
```
</details>

<details><summary>Scoped typecheck — no errors in touched files</summary>

```
$ bunx tsc --noEmit -p packages/cloud/api/tsconfig.json | grep -E "kokoro-first-line-cache|voice/tts/route|voice/tts/__tests__|cloud-worker-env"
NO ERRORS IN OUR TOUCHED FILES
```
(Pre-existing unrelated errors on develop: `stripe-connect-webhook` Stripe-API-version string, `fal/proxy` hono version skew, `shared/i18n` generated-artifact — none in this diff.)
</details>

<details><summary>Biome</summary>

```
$ bunx biome check <4 touched files>
Checked 4 files in 21ms. No fixes applied.
```
</details>

## Evidence

| Evidence | Status |
| --- | --- |
| Unit tests (flag gate, key/revision mapping, provider-keyed miss, opener gating) | Attached inline above — 15 pass / 0 fail |
| Provider-keyed cache-key parity (kokoro vs elevenlabs) | Attached inline — regression suite green |
| Scoped typecheck + Biome | Attached inline |
| **Live before/after TTFB for a cached opener** | **N/A — needs the live Railway Kokoro service (#14370).** Owner runs with the service reachable: `ELIZA_VOICE_LIVE_RAILWAY=1 KOKORO_TTS_URL=<railway-url> KOKORO_FIRST_LINE_CACHE=1 bun test packages/cloud/api/__tests__/voice-kokoro-whisper-live.test.ts`, then POST the same short phrase twice and diff `X-TTS-Cache: miss; kokoro` (upstream fetch in logs) vs `hit; kokoro; first-sentence` (no upstream fetch). |
| Backend logs HIT (no upstream) vs MISS (upstream) | **N/A — same live-service dependency.** Log lines emitted by this PR: `Kokoro first-line cache HIT (...) — no upstream request` and `Kokoro first-line cache POPULATE ok (...)`. |
| Cached-audio playback (MP4) proving audible speech | **N/A — requires live synthesis to produce real WAV bytes.** |

Decision recorded per acceptance criteria: caching **implemented and default-OFF**; enabling it is the operator decision keyed on the #14370 benchmark row (close-as-unneeded remains valid if short-sentence TTFB ≤ ~1.5 s).

Closes #14375

🤖 Generated with [Claude Code](https://claude.com/claude-code)
