### PR TITLE
feat(observability): reportError coverage audit + wire top gaps (#14415)

### DIFF
--- a/packages/agent/src/api/connector-routes.test.ts
+++ b/packages/agent/src/api/connector-routes.test.ts
@@ -103,4 +103,66 @@ describe("connector routes", () => {
     });
     expect(onConnectorDisconnect).not.toHaveBeenCalled();
   });
+
+  // ── #14415 observability: disconnect-path failures must be reported ──────
+  it("reports (not swallows) a disconnect event-bus failure on DELETE", async () => {
+    const reportError = vi.fn();
+    const runtime = {
+      agentId: "agent-1",
+      emitEvent: vi.fn(() => Promise.reject(new Error("event bus down"))),
+      reportError,
+    } as unknown as NonNullable<ConnectorRouteContext["state"]["runtime"]>;
+    const config: ConnectorRouteContext["state"]["config"] = {
+      connectors: { slack: { enabled: true } },
+    };
+    const { ctx, captured } = createHarness({
+      method: "DELETE",
+      pathname: "/api/connectors/slack",
+      state: { config, runtime },
+      saveElizaConfig: vi.fn(),
+    });
+
+    await expect(handleConnectorRoutes(ctx)).resolves.toBe(true);
+
+    // The response still succeeds — a broken event bus must not block the
+    // disconnect (fail-open on the response, per the existing contract) …
+    expect(captured.status).toBe(200);
+    // … but the failure is now observable via reportError instead of a silent
+    // empty catch, with structured context identifying the connector + op.
+    expect(reportError).toHaveBeenCalledTimes(1);
+    expect(reportError).toHaveBeenCalledWith(
+      "connector.disconnect.emitEvent",
+      expect.any(Error),
+      expect.objectContaining({ connector: "slack", op: "DELETE" }),
+    );
+  });
+
+  it("reports (not swallows) a host disconnect-callback failure on POST enabled:false", async () => {
+    const reportError = vi.fn();
+    const runtime = {
+      agentId: "agent-1",
+      emitEvent: vi.fn(() => Promise.resolve()),
+      reportError,
+    } as unknown as NonNullable<ConnectorRouteContext["state"]["runtime"]>;
+    const onConnectorDisconnect = vi.fn(() => {
+      throw new Error("cache purge failed");
+    });
+    const { ctx, captured } = createHarness({
+      method: "POST",
+      pathname: "/api/connectors",
+      body: { name: "slack", config: { enabled: false } },
+      state: { config: { connectors: { slack: { enabled: true } } }, runtime },
+      saveElizaConfig: vi.fn(),
+      onConnectorDisconnect,
+    });
+
+    await expect(handleConnectorRoutes(ctx)).resolves.toBe(true);
+
+    expect(captured.status).toBe(200);
+    expect(reportError).toHaveBeenCalledWith(
+      "connector.disconnect.hostCallback",
+      expect.any(Error),
+      expect.objectContaining({ connector: "slack", op: "POST-disconnect" }),
+    );
+  });
 });

--- a/packages/agent/src/api/connector-routes.ts
+++ b/packages/agent/src/api/connector-routes.ts
@@ -231,14 +231,26 @@ export async function handleConnectorRoutes(
     if (isDisconnect) {
       try {
         await emitConnectorDisconnected(state.runtime, connectorName);
-      } catch {
-        /* don't let event-bus failure block the response */
+      } catch (err) {
+        // error-policy:#14415 — don't let event-bus failure block the response,
+        // but don't let it vanish either: a failed disconnect broadcast leaves
+        // service caches (workflow credential store, etc.) holding stale creds
+        // for a connector the user just disconnected. Surface it.
+        state.runtime?.reportError("connector.disconnect.emitEvent", err, {
+          connector: connectorName,
+          op: "POST-disconnect",
+        });
       }
       if (onConnectorDisconnect) {
         try {
           await onConnectorDisconnect(connectorName);
-        } catch {
-          /* don't let host callback failure block the response */
+        } catch (err) {
+          // error-policy:#14415 — host cache-invalidation callback failed; report
+          // rather than swallow so the stale-cache risk is observable.
+          state.runtime?.reportError("connector.disconnect.hostCallback", err, {
+            connector: connectorName,
+            op: "POST-disconnect",
+          });
         }
       }
     }
@@ -298,14 +310,23 @@ export async function handleConnectorRoutes(
     }
     try {
       await emitConnectorDisconnected(state.runtime, name);
-    } catch {
-      /* don't let event-bus failure block the response */
+    } catch (err) {
+      // error-policy:#14415 — see POST-disconnect: a failed disconnect broadcast
+      // must not block the DELETE response but must remain observable.
+      state.runtime?.reportError("connector.disconnect.emitEvent", err, {
+        connector: name,
+        op: "DELETE",
+      });
     }
     if (onConnectorDisconnect) {
       try {
         await onConnectorDisconnect(name);
-      } catch {
-        /* don't let host callback failure block the response */
+      } catch (err) {
+        // error-policy:#14415 — host cache-invalidation callback failed; report.
+        state.runtime?.reportError("connector.disconnect.hostCallback", err, {
+          connector: name,
+          op: "DELETE",
+        });
       }
     }
     json(res, {

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -5147,9 +5147,18 @@ export async function startEliza(
             `[eliza] deferred: ✓ ${plugin.name} registered (${Date.now() - startedAt}ms)`,
           );
         } catch (err) {
+          // error-policy:#14415 — a deferred plugin that fails to register
+          // silently drops every capability it provides (its actions,
+          // providers, connectors). Report it so the failure is agent-visible
+          // via RECENT_ERRORS and escalates when a plugin fails repeatedly,
+          // rather than only landing in a boot-log warning the user never sees.
           logger.warn(
             `[eliza] deferred: Plugin ${plugin.name} registration failed: ${formatError(err)}`,
           );
+          runtime.reportError("eliza.deferredPluginRegistration", err, {
+            plugin: plugin.name,
+            phase: "deferred-boot",
+          });
         }
       }),
     );
@@ -5378,7 +5387,16 @@ export async function startEliza(
   // wave's awaited work cannot starve the API bind off the event loop.
   const kickoffDeferredBoot = (): void => {
     void runDeferredBoot().catch((err) => {
+      // error-policy:#14415 — deferred boot registers connectors + feature
+      // plugins after the runtime is chat-ready. A swallowed failure here left
+      // capabilities silently absent (the device-review class of bug: the user
+      // sees an empty feature, not an error). Surface it via reportError so it
+      // reaches RECENT_ERRORS (agent-visible) and escalates on repeat, in
+      // addition to the boot-log warning.
       logger.warn(`[eliza] Deferred boot failed: ${formatError(err)}`);
+      runtime.reportError("eliza.deferredBoot", err, {
+        phase: "deferred-boot",
+      });
     });
   };
 

--- a/plugins/plugin-elizacloud/__tests__/reconnect-exhaustion-report.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/reconnect-exhaustion-report.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Coverage for #14415 (observability): when the cloud ConnectionMonitor
+ * exhausts every reconnect attempt, the link is durably down — a failure that
+ * previously vanished into a single `logger.error` line. This drives the
+ * monitor to full exhaustion with a client whose heartbeat + provision always
+ * fail and asserts:
+ *   1. `onReconnectExhausted` fires exactly once (report-once, no per-attempt
+ *      spam — the #14387 idempotency class of bug).
+ *   2. It carries the attempt count so the host can wire it into
+ *      `runtime.reportError` with structured context.
+ *   3. A throwing exhaustion handler cannot break the monitor.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConnectionMonitor } from "../src/cloud/reconnect";
+
+/** Minimal client stub: heartbeat + provision both always fail. */
+function deadClient() {
+  return {
+    heartbeat: vi.fn().mockResolvedValue(false),
+    provision: vi.fn().mockRejectedValue(new Error("provision failed")),
+  } as unknown as ConstructorParameters<typeof ConnectionMonitor>[0];
+}
+
+describe("ConnectionMonitor reconnect-exhaustion observability (#14415)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("fires onReconnectExhausted exactly once with the attempt count", async () => {
+    const onReconnectExhausted = vi.fn();
+    // Tiny heartbeat interval + maxFailures=1 so a single failed tick trips
+    // the reconnect loop immediately.
+    const monitor = new ConnectionMonitor(
+      deadClient(),
+      "agent-1",
+      {
+        onDisconnect: vi.fn(),
+        onReconnect: vi.fn(),
+        onStatusChange: vi.fn(),
+        onReconnectExhausted,
+      },
+      10, // heartbeatIntervalMs
+      1 // maxFailures
+    );
+
+    monitor.start();
+    // Fire the first heartbeat tick (heartbeat resolves false → reconnect).
+    await vi.advanceTimersByTimeAsync(10);
+    // Drive all 10 reconnect attempts + their exponential backoff sleeps to
+    // completion. Backoff is capped at 60s/attempt; advancing well past the
+    // worst-case total flushes the loop.
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+
+    expect(onReconnectExhausted).toHaveBeenCalledTimes(1);
+    expect(onReconnectExhausted).toHaveBeenCalledWith({ attempts: 10 });
+
+    monitor.stop();
+  });
+
+  it("a throwing onReconnectExhausted handler does not break the monitor", async () => {
+    const onReconnectExhausted = vi.fn(() => {
+      throw new Error("host handler blew up");
+    });
+    const onStatusChange = vi.fn();
+    const monitor = new ConnectionMonitor(
+      deadClient(),
+      "agent-2",
+      {
+        onDisconnect: vi.fn(),
+        onReconnect: vi.fn(),
+        onStatusChange,
+        onReconnectExhausted,
+      },
+      10,
+      1
+    );
+
+    monitor.start();
+    await vi.advanceTimersByTimeAsync(10);
+    // Must not throw out of the monitor's own timer callback (the try/catch in
+    // attemptReconnect absorbs the host handler's throw).
+    let threw = false;
+    try {
+      await vi.advanceTimersByTimeAsync(10 * 60_000);
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(false);
+
+    expect(onReconnectExhausted).toHaveBeenCalledTimes(1);
+    // The monitor still reached the terminal "disconnected" status despite the
+    // handler throwing.
+    expect(onStatusChange).toHaveBeenCalledWith("disconnected");
+
+    monitor.stop();
+  });
+});

--- a/plugins/plugin-elizacloud/src/cloud/cloud-manager.ts
+++ b/plugins/plugin-elizacloud/src/cloud/cloud-manager.ts
@@ -21,6 +21,13 @@ export type CloudConnectionStatus =
 
 export interface CloudManagerCallbacks {
   onStatusChange?: (status: CloudConnectionStatus) => void;
+  /**
+   * error-policy:#14415 — forwarded from the connection monitor when every
+   * reconnect attempt is exhausted (the cloud link is durably down). A host
+   * that owns an `IAgentRuntime` can wire this into `runtime.reportError` so
+   * the dead link surfaces via RECENT_ERRORS + owner escalation. Best-effort.
+   */
+  onReconnectExhausted?: (context: { attempts: number }) => void;
 }
 
 export class CloudManager {
@@ -87,6 +94,8 @@ export class CloudManager {
             else if (s === "reconnecting") this.setStatus("reconnecting");
             else this.setStatus("error");
           },
+          onReconnectExhausted: (ctx) =>
+            this.callbacks.onReconnectExhausted?.(ctx),
         },
         this.cloudConfig.bridge?.heartbeatIntervalMs ?? 30_000,
       );

--- a/plugins/plugin-elizacloud/src/cloud/reconnect.ts
+++ b/plugins/plugin-elizacloud/src/cloud/reconnect.ts
@@ -11,6 +11,15 @@ export interface ConnectionMonitorCallbacks {
   onStatusChange?: (
     status: "connected" | "reconnecting" | "disconnected",
   ) => void;
+  /**
+   * error-policy:#14415 — fired once when every reconnect attempt is exhausted
+   * (the connection is now durably down, not transiently reconnecting). Lets a
+   * host wire this into `runtime.reportError` so a silently-dead cloud link
+   * surfaces via RECENT_ERRORS + owner escalation instead of only a log line.
+   * Best-effort: a throwing handler must never break the monitor, so callers
+   * are invoked inside a try/catch.
+   */
+  onReconnectExhausted?: (context: { attempts: number }) => void;
 }
 
 export class ConnectionMonitor {
@@ -107,5 +116,17 @@ export class ConnectionMonitor {
     logger.error("[cloud-monitor] Failed to reconnect after 10 attempts");
     this.reconnecting = false;
     this.callbacks.onStatusChange?.("disconnected");
+    // error-policy:#14415 — the link is now durably down. Report exactly once
+    // per exhaustion (not per failed attempt) so this is observable without
+    // spamming. A throwing handler must not re-break the monitor.
+    try {
+      this.callbacks.onReconnectExhausted?.({ attempts: 10 });
+    } catch (err) {
+      logger.warn(
+        `[cloud-monitor] onReconnectExhausted handler threw: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
   }
 }


### PR DESCRIPTION
Closes #14415.

## What

Audit of `runtime.reportError` / `RECENT_ERRORS` coverage on the highest-stakes device + cloud failure paths, plus code wiring the top gaps + failure-injection tests. Per the error-policy doctrine: a failure must surface **observably** (agent sees it via `RECENT_ERRORS`, or it escalates to the owner via `ERROR_REPORTED` when systemic), and the UI must render a distinct error state, **idempotently** (report once, no #14387-style spam).

## Coverage audit

| Flow | Error path (before) | Covered? | Action |
| --- | --- | --- | --- |
| **Boot — deferred boot kickoff** (`eliza.ts`) | `.catch` → `logger.warn` only; swallowed failure left connectors + feature plugins silently absent | ❌ log-only | ✅ wired `reportError("eliza.deferredBoot", …)` |
| **Boot — per-plugin deferred registration** (`eliza.ts`) | per-plugin `catch` → `logger.warn` only; failed plugin silently drops all its actions/providers/connectors | ❌ log-only | ✅ wired `reportError("eliza.deferredPluginRegistration", …, {plugin})` |
| **Cloud — reconnect exhaustion** (`plugin-elizacloud/reconnect.ts`) | after 10 failed attempts → `logger.error` only; durably-dead link never surfaced | ❌ log-only | ✅ added `onReconnectExhausted({attempts})` (report-once, throw-safe), forwarded through `CloudManager` so a host runtime can wire it into `reportError` |
| **Connector-connect — disconnect broadcast** (`connector-routes.ts` POST/DELETE) | empty `catch {}` on `connector_disconnected` emit → service caches hold stale creds silently | ❌ empty catch | ✅ wired `state.runtime?.reportError("connector.disconnect.emitEvent", …, {connector, op})` (still fail-open on the response) |
| **Connector-connect — host disconnect callback** | empty `catch {}` | ❌ empty catch | ✅ wired `reportError("connector.disconnect.hostCallback", …)` |
| **Cloud login (device-code flow)** (`plugin-elizacloud/auth.ts`) | throws structured `Error`; caller renders distinct `elizaCloudLoginError` UI state | ✅ throws + UI error state | no change (already covered end-to-end) |
| **Onboarding chat-spam** (`use-first-run-conductor.ts`) | non-idempotent `seedError` loop | ✅ fixed in #14387 (merged) | out of scope here |
| **First-run config save** (`first-run-routes.ts`) | `catch` → `logger.error` + `error(res, …, 500)`; UI gets distinct 500 | ⚠️ UI-covered | **deferred** — `state.runtime` here is a narrowed shim type, not a full `IAgentRuntime`; wiring `reportError` would widen that type across the server coercion boundary. Failure is already UI-observable (distinct 500), three-state UI satisfied |

## Tests (failure-injection)

- `plugins/plugin-elizacloud/__tests__/reconnect-exhaustion-report.test.ts` — drives the monitor to full reconnect exhaustion; asserts `onReconnectExhausted` fires **exactly once** with `{attempts:10}`, and a throwing handler can't break the monitor.
- `packages/agent/src/api/connector-routes.test.ts` (+2 cases) — injects a runtime whose `emitEvent` rejects (DELETE) and a host callback that throws (POST `enabled:false`); asserts the response still succeeds (fail-open) **and** `reportError` is called once with structured `{connector, op}` context, instead of the previous silent empty catch.

## Verification

- `cd packages/app && bun run build` → **green** (`✓ built in 1m 3s`, 786 assets) — compiles + bundles the modified agent + plugin code.
- `bunx vitest run reconnect-exhaustion-report.test.ts` → **2 passed**
- `bunx vitest run connector-routes.test.ts` → **4 passed** (2 existing + 2 new)
- `bunx vitest run eliza-embedding-boot-order.test.ts` → **5 passed** (no regression on the deferred-boot ordering lock)
- biome clean on all modified src files.
- codex review: hung >100s exploring without converging to a verdict → killed per lane protocol + self-reviewed (all edits confirmed: `runtime`/`reportError` in scope at every site, optional-chained where nullable, report-once + throw-safe on the reconnect path).

## Scope guardrails honored

- No behavior changes to fail-closed money/auth paths — additive reporting only.
- No wholesale error-handling refactor; no new telemetry service (reuses the existing `reportError` / `RECENT_ERRORS` / `ERROR_REPORTED` foundation).

— [sol-orch]
