### PR TITLE
test(app): shared onboarding liveness contract for every onboarding e2e (#14359)

### DIFF
--- a/packages/app/scripts/ios-onboarding-smoke.mjs
+++ b/packages/app/scripts/ios-onboarding-smoke.mjs
@@ -5,11 +5,17 @@
 // first-run remote-connect handler used by the OS deep-link path. The verifier
 // proves the app landed on home and reports back via Preferences. No onboarding
 // DOM is driven, so the lane survives the in-chat redesign.
+//
+// Liveness contract (#14359): STUB-BACKED by default. Point the host at a
+// live-provider backend and set `ELIZA_ONBOARDING_LIVENESS=1` to have the
+// verifier drive one real post-onboarding chat turn; the harness then enforces
+// the shared non-stub assertion (`assertLiveReply`) on the reported reply.
 import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { assertLiveReply } from "../test/liveness-contract.mjs";
 import {
   DEFAULT_HOST_AGENT_PORT,
   startDeviceE2eHostAgent,
@@ -498,7 +504,13 @@ async function main() {
       extraKeys: FIRST_RUN_STATE_KEYS,
       log,
     });
-    defaultsWriteString(udid, appId, REQUEST_KEY, JSON.stringify({ apiBase }));
+    const requestLiveness = process.env.ELIZA_ONBOARDING_LIVENESS === "1";
+    defaultsWriteString(
+      udid,
+      appId,
+      REQUEST_KEY,
+      JSON.stringify({ apiBase, liveness: requestLiveness }),
+    );
     defaultsWriteString(
       udid,
       appId,
@@ -559,6 +571,13 @@ async function main() {
       throw new Error(
         `iOS onboarding smoke did not persist active server ${apiBase}: ${JSON.stringify(result.storage)}`,
       );
+    }
+    // Liveness contract (#14359): when a live host was requested, the reported
+    // post-onboarding reply must pass the shared non-stub assertion. Throws with
+    // the lane label if the reply is empty or carries the stub fixture marker.
+    if (requestLiveness) {
+      assertLiveReply(result.livenessReply, { label: "ios-onboarding" });
+      log(`liveness reply OK: ${JSON.stringify(result.livenessReply)}`);
     }
     const mixedContentResult = await pollMixedContentResult(udid, appId);
     if (

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -809,16 +809,36 @@ function renderIosFullBunSmokeStatus(message: string): void {
 
 function parseIosOnboardingSmokeRequest(raw: string | null): {
   apiBase: string;
+  // Liveness contract (#14359): when the harness points the lane at a
+  // live-provider host it sets `liveness: true` so the verifier drives one real
+  // chat turn after landing on home and reports the reply for the shared
+  // non-stub assertion. Default false — the deterministic host is stub-backed.
+  liveness: boolean;
+  livenessPrompt: string;
 } {
-  const fallback = { apiBase: "http://127.0.0.1:31338" };
+  const fallback = {
+    apiBase: "http://127.0.0.1:31338",
+    liveness: false,
+    livenessPrompt: "In one short sentence, say hello.",
+  };
   if (!raw || raw === "1") return fallback;
   try {
-    const parsed = JSON.parse(raw) as { apiBase?: unknown };
+    const parsed = JSON.parse(raw) as {
+      apiBase?: unknown;
+      liveness?: unknown;
+      livenessPrompt?: unknown;
+    };
     return {
       apiBase:
         typeof parsed.apiBase === "string" && parsed.apiBase.trim()
           ? parsed.apiBase.trim()
           : fallback.apiBase,
+      liveness: parsed.liveness === true,
+      livenessPrompt:
+        typeof parsed.livenessPrompt === "string" &&
+        parsed.livenessPrompt.trim()
+          ? parsed.livenessPrompt.trim()
+          : fallback.livenessPrompt,
     };
   } catch {
     // error-policy:J3 corrupt smoke-request blob — run with the defaults
@@ -910,6 +930,69 @@ async function waitForIosOnboardingSmokeStorageSnapshot(
   }
   throw new Error(
     `Timed out waiting for iOS onboarding active server ${apiBase}: ${JSON.stringify(snapshot)}`,
+  );
+}
+
+const IOS_LIVENESS_ASSISTANT_SELECTOR =
+  '[data-role="assistant"], [data-testid="chat-message-assistant"], [data-testid="thread-line"][data-role="assistant"]';
+
+// Set a React-controlled textarea's value so React's onChange fires. Assigning
+// `.value` directly bypasses React's synthetic value tracker, so we call the
+// native prototype setter first, then dispatch a bubbling `input` event — the
+// canonical way to drive a controlled input from outside React.
+function setReactTextareaValue(el: HTMLTextAreaElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    "value",
+  )?.set;
+  if (!setter) {
+    throw new Error("HTMLTextAreaElement value setter unavailable");
+  }
+  setter.call(el, value);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+/**
+ * Drive one real chat turn in-app and return the rendered assistant reply, so
+ * the harness can enforce the shared liveness contract (#14359) against a
+ * live-provider host. Only invoked when the smoke request opts in
+ * (`liveness: true`); against the deterministic stub host it is skipped.
+ */
+async function driveIosLivenessChatTurn(prompt: string): Promise<string> {
+  const composer = await waitForIosOnboardingElement<HTMLTextAreaElement>(
+    '[data-testid="chat-composer-textarea"]',
+    { visible: true },
+  );
+  const priorReplies = document.querySelectorAll(
+    IOS_LIVENESS_ASSISTANT_SELECTOR,
+  ).length;
+
+  composer.focus();
+  setReactTextareaValue(composer, prompt);
+  const send = document.querySelector<HTMLButtonElement>(
+    '[data-testid="chat-composer-action"], button[aria-label="Send"], button[aria-label="Send message"]',
+  );
+  if (send && !send.disabled) {
+    send.click();
+  } else {
+    composer.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+  }
+
+  const deadline = Date.now() + IOS_ONBOARDING_SMOKE_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const replies = document.querySelectorAll<HTMLElement>(
+      IOS_LIVENESS_ASSISTANT_SELECTOR,
+    );
+    if (replies.length > priorReplies) {
+      const text = replies[replies.length - 1]?.textContent?.trim() ?? "";
+      if (text.length > 0) return text;
+    }
+    await new Promise((resolve) => window.setTimeout(resolve, 250));
+  }
+  throw new Error(
+    "iOS liveness chat turn: assistant never produced a reply within the timeout",
   );
 }
 
@@ -1113,6 +1196,13 @@ async function runIosOnboardingSmokeIfRequested(): Promise<boolean> {
     );
     await runIosMixedContentSmokeIfRequested({ apiBase: request.apiBase });
 
+    // Liveness contract (#14359): against a live-provider host, end the lane
+    // with one real chat turn and report the reply for the harness's shared
+    // non-stub assertion. Skipped for the default deterministic (stub) host.
+    const livenessReply = request.liveness
+      ? await driveIosLivenessChatTurn(request.livenessPrompt)
+      : null;
+
     await writeIosOnboardingSmokeResult({
       ok: true,
       phase: "complete",
@@ -1122,6 +1212,8 @@ async function runIosOnboardingSmokeIfRequested(): Promise<boolean> {
       composerVisible: Boolean(composer),
       onboardingHidden,
       storage,
+      livenessRequested: request.liveness,
+      livenessReply,
     });
   } catch (error) {
     // error-policy:J1 smoke boundary — the failure is written to the

--- a/packages/app/test/android/onboarding-to-home.android.spec.ts
+++ b/packages/app/test/android/onboarding-to-home.android.spec.ts
@@ -13,6 +13,12 @@
 //
 // The deterministic host agent is reachable at 127.0.0.1:31337 through
 // `adb reverse`; 127.0.0.1 is loopback, so the connect needs no confirm prompt.
+//
+// Liveness contract (#14359): this lane is STUB-BACKED by default — the host
+// agent is the deterministic ui-smoke stub, so a "real model" reply cannot be
+// asserted and the lane ends by proving the stub reply renders. Point the host
+// at a live-provider backend and set `ELIZA_ONBOARDING_LIVENESS=1` to promote
+// the final turn to the shared liveness assertion (non-empty, non-stub reply).
 import path from "node:path";
 import { startAndroidScreenRecord } from "../../scripts/lib/android-capture.mjs";
 import {
@@ -21,7 +27,17 @@ import {
   adbReverse,
   resolveAdb,
 } from "../../scripts/lib/android-device.mjs";
+import {
+  assertOnboardingLiveness,
+  STUB_FIXTURE_MARKER,
+  sendChatAndReadReply,
+} from "../liveness-contract";
 import { expect, ORIGIN, test } from "./android-harness";
+
+// When the host is a live-provider backend, the final onboarding turn must
+// prove a real model answered. Off by default because the shared host agent is
+// the deterministic stub.
+const LIVENESS_ENABLED = process.env.ELIZA_ONBOARDING_LIVENESS === "1";
 
 const HOST_AGENT_BASE = "http://127.0.0.1:31337";
 // app.config.ts `desktop.urlScheme`; the Android manifest registers it as the
@@ -136,6 +152,33 @@ test.describe
           path: screenshotPath,
           contentType: "image/png",
         });
+
+        // Every onboarding lane ends with the liveness contract (#14359): send a
+        // real chat turn. Against a live-provider host it must be a real
+        // (non-stub) reply; against the default deterministic host it must be the
+        // stub fixture (proving the connected agent actually answers, without
+        // claiming a real model).
+        if (LIVENESS_ENABLED) {
+          const reply = await assertOnboardingLiveness(page, {
+            label: "android-onboarding",
+          });
+          await testInfo.attach("liveness reply (real model)", {
+            body: reply,
+            contentType: "text/plain",
+          });
+        } else {
+          const stubReply = await sendChatAndReadReply(page, {
+            label: "android-onboarding",
+          });
+          expect(
+            stubReply,
+            "stub-backed host must render its deterministic reply",
+          ).toContain(STUB_FIXTURE_MARKER);
+          await testInfo.attach("liveness reply (stub-backed)", {
+            body: stubReply,
+            contentType: "text/plain",
+          });
+        }
       } finally {
         const videoPath = await recording.stop();
         if (videoPath) {

--- a/packages/app/test/liveness-contract.mjs
+++ b/packages/app/test/liveness-contract.mjs
@@ -1,0 +1,84 @@
+/**
+ * The onboarding liveness contract: the single, surface-agnostic rule that a
+ * post-onboarding chat reply came from a REAL model and not the deterministic
+ * stub. Consumed by the Playwright wrapper (`liveness-contract.ts`), the iOS
+ * simulator harness (`scripts/ios-onboarding-smoke.mjs`), and the in-app iOS
+ * verifier (`src/main.tsx`) — every onboarding surface asserts liveness through
+ * this one implementation so the check cannot drift between lanes (#14359).
+ *
+ * This module is intentionally pure and dependency-free (plain `.mjs`) so it is
+ * importable from both the bundled renderer and the un-bundled Node harness
+ * without a build step. All DOM/Playwright driving lives in the `.ts` wrapper.
+ */
+
+/**
+ * The deterministic keyless stub tags every reply with this fixture id. A real
+ * model turn must never contain it — that is how liveness is proven. Kept here
+ * as the one source of truth; the stub emitter
+ * (`packages/app-core/scripts/playwright-ui-smoke-api-stub.mjs`) writes the same
+ * literal, so if that fixture id ever changes both sides update together.
+ */
+export const STUB_FIXTURE_MARKER = "ui-smoke-assistant-v1";
+
+/**
+ * Thrown when a reply fails the liveness contract. Distinct type so harnesses
+ * can attribute a failure to liveness rather than a generic timeout/DOM error.
+ */
+export class LivenessAssertionError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "LivenessAssertionError";
+  }
+}
+
+/**
+ * Assert a rendered assistant reply proves a real model answered.
+ *
+ * A live reply must be a non-empty string that does not carry the stub fixture
+ * marker. Empty/whitespace-only conflates "model never answered" with a real
+ * turn; the stub marker conflates the deterministic fixture with a real turn —
+ * both are false-green failures this contract exists to catch. Throws
+ * `LivenessAssertionError` on failure; returns the trimmed reply on success.
+ *
+ * @param {unknown} reply the assistant reply text as rendered in the UI
+ * @param {{ label?: string }} [options] label for error attribution (lane name)
+ * @returns {string} the trimmed, validated reply
+ */
+export function assertLiveReply(reply, options = {}) {
+  const label = options.label ? `${options.label}: ` : "";
+  if (typeof reply !== "string") {
+    throw new LivenessAssertionError(
+      `${label}liveness reply must be a string, got ${reply === null ? "null" : typeof reply}`,
+    );
+  }
+  const text = reply.trim();
+  if (text.length === 0) {
+    throw new LivenessAssertionError(
+      `${label}liveness reply was empty — the model produced no answer`,
+    );
+  }
+  if (text.includes(STUB_FIXTURE_MARKER)) {
+    throw new LivenessAssertionError(
+      `${label}liveness reply carried the stub fixture marker "${STUB_FIXTURE_MARKER}" — a real model did not answer`,
+    );
+  }
+  return text;
+}
+
+/**
+ * Non-throwing predicate form of {@link assertLiveReply}, for harnesses that
+ * branch on liveness rather than fail. Returns true only for a real reply.
+ *
+ * @param {unknown} reply
+ * @returns {boolean}
+ */
+export function isLiveReply(reply) {
+  try {
+    assertLiveReply(reply);
+    return true;
+  } catch {
+    // error-policy:J3 predicate form — a rejected reply is a definite "not live"
+    // signal, never a swallowed error (the throwing form is the enforcement path)
+    return false;
+  }
+}

--- a/packages/app/test/liveness-contract.test.ts
+++ b/packages/app/test/liveness-contract.test.ts
@@ -1,0 +1,45 @@
+// Unit test for the onboarding liveness contract (#14359). Exercises the pure,
+// surface-agnostic core (`assertLiveReply` / `isLiveReply`) — the rule every
+// onboarding lane shares — with no DOM/Playwright harness: a stub-marker reply
+// must fail, a real reply must pass, and empty/non-string replies must fail.
+import { describe, expect, it } from "vitest";
+
+import {
+  assertLiveReply,
+  isLiveReply,
+  LivenessAssertionError,
+  STUB_FIXTURE_MARKER,
+} from "./liveness-contract.mjs";
+
+describe("onboarding liveness contract", () => {
+  it("passes a real, non-empty reply and returns it trimmed", () => {
+    expect(assertLiveReply("  Hello there!  ")).toBe("Hello there!");
+    expect(isLiveReply("Hello there!")).toBe(true);
+  });
+
+  it("fails a reply carrying the stub fixture marker", () => {
+    const stubbed = `{"fixture":"${STUB_FIXTURE_MARKER}","transport":"sse"}`;
+    expect(() => assertLiveReply(stubbed)).toThrowError(LivenessAssertionError);
+    expect(() => assertLiveReply(stubbed)).toThrow(/stub fixture marker/);
+    expect(isLiveReply(stubbed)).toBe(false);
+  });
+
+  it("fails an empty or whitespace-only reply (model never answered)", () => {
+    expect(() => assertLiveReply("")).toThrow(/empty/);
+    expect(() => assertLiveReply("   \n\t ")).toThrow(/empty/);
+    expect(isLiveReply("")).toBe(false);
+  });
+
+  it("fails a non-string reply", () => {
+    expect(() => assertLiveReply(null)).toThrow(/must be a string/);
+    expect(() => assertLiveReply(undefined)).toThrow(/must be a string/);
+    expect(() => assertLiveReply(42)).toThrow(/must be a string/);
+    expect(isLiveReply(null)).toBe(false);
+  });
+
+  it("attributes the failure to the lane label when provided", () => {
+    expect(() =>
+      assertLiveReply(STUB_FIXTURE_MARKER, { label: "android-onboarding" }),
+    ).toThrow(/android-onboarding: /);
+  });
+});

--- a/packages/app/test/liveness-contract.ts
+++ b/packages/app/test/liveness-contract.ts
@@ -1,0 +1,82 @@
+/**
+ * Playwright wrapper for the onboarding liveness contract (#14359): drive one
+ * post-onboarding chat turn through the real UI and assert the rendered reply
+ * came from a real model. The surface-agnostic rule (empty / stub-marker →
+ * fail) lives in the dependency-free `liveness-contract.mjs`; this file only
+ * adds the DOM driving so browser-based onboarding lanes (cloud-live and the
+ * web/desktop paths) end the same way: send a message, wait for the assistant
+ * reply, assert liveness.
+ */
+import { expect, type Locator, type Page } from "@playwright/test";
+import { assertLiveReply } from "./liveness-contract.mjs";
+
+export {
+  assertLiveReply,
+  isLiveReply,
+  LivenessAssertionError,
+  STUB_FIXTURE_MARKER,
+} from "./liveness-contract.mjs";
+
+const CHAT_COMPOSER_SELECTOR =
+  '[data-testid="chat-composer-textarea"], textarea[aria-label="message"]';
+const CHAT_SEND_SELECTOR =
+  '[data-testid="chat-composer-action"], button[aria-label="Send"], button[aria-label="Send message"]';
+const ASSISTANT_MESSAGE_SELECTOR =
+  '[data-role="assistant"], [data-testid="chat-message-assistant"], [data-testid="thread-line"][data-role="assistant"]';
+
+const DEFAULT_PROMPT = "In one short sentence, say hello.";
+const DEFAULT_REPLY_TIMEOUT_MS = 120_000;
+
+export interface LivenessChatOptions {
+  /** Prompt to send; defaults to a short, tool-free hello. */
+  prompt?: string;
+  /** How long to wait for the assistant reply to render. */
+  replyTimeoutMs?: number;
+  /** Lane name used to attribute a liveness failure. */
+  label?: string;
+}
+
+function chatComposer(page: Page): Locator {
+  return page.locator(CHAT_COMPOSER_SELECTOR).first();
+}
+
+function chatSendButton(page: Page): Locator {
+  return page.locator(CHAT_SEND_SELECTOR).first();
+}
+
+/**
+ * Send one chat turn on the already-open chat surface and return the raw
+ * rendered assistant reply text. Assumes the composer is visible (the caller
+ * has navigated to /chat post-onboarding). Kept separate from the assertion so
+ * a caller can inspect the reply before enforcing the contract.
+ */
+export async function sendChatAndReadReply(
+  page: Page,
+  options: LivenessChatOptions = {},
+): Promise<string> {
+  const composer = chatComposer(page);
+  await expect(composer).toBeVisible({ timeout: 60_000 });
+  await composer.fill(options.prompt ?? DEFAULT_PROMPT);
+  await expect(chatSendButton(page)).toBeEnabled();
+  await chatSendButton(page).click();
+
+  const assistant = page.locator(ASSISTANT_MESSAGE_SELECTOR).last();
+  await expect(assistant).toBeVisible({
+    timeout: options.replyTimeoutMs ?? DEFAULT_REPLY_TIMEOUT_MS,
+  });
+  return (await assistant.textContent())?.trim() ?? "";
+}
+
+/**
+ * End an onboarding lane with the liveness contract: send a real chat turn and
+ * assert the reply is non-empty and free of the stub fixture marker. Throws
+ * (fails the test) when the reply is empty or stubbed. Returns the validated
+ * reply so a caller can attach it as evidence.
+ */
+export async function assertOnboardingLiveness(
+  page: Page,
+  options: LivenessChatOptions = {},
+): Promise<string> {
+  const reply = await sendChatAndReadReply(page, options);
+  return assertLiveReply(reply, { label: options.label });
+}

--- a/packages/app/test/ui-smoke/cloud-live.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-live.spec.ts
@@ -18,6 +18,7 @@
 // only into the nightly/dispatch app-live-e2e.yml workflow.
 
 import { expect, type Locator, type Page, test } from "@playwright/test";
+import { assertOnboardingLiveness } from "../liveness-contract";
 import { openAppPath, seedAppStorage } from "./helpers";
 
 const CLOUD_LIVE_ENABLED =
@@ -25,23 +26,7 @@ const CLOUD_LIVE_ENABLED =
   process.env.ELIZA_UI_SMOKE_LIVE_STACK === "1";
 const HAS_CLOUD_KEY = Boolean(process.env.ELIZAOS_CLOUD_API_KEY?.trim());
 
-const CHAT_COMPOSER_SELECTOR =
-  '[data-testid="chat-composer-textarea"], textarea[aria-label="message"]';
-const CHAT_SEND_SELECTOR =
-  '[data-testid="chat-composer-action"], button[aria-label="Send"], button[aria-label="Send message"]';
-// The deterministic stub tags every reply with this fixture id. A real cloud
-// agent must NOT produce it — that is how we prove the turn was not a stub.
-const STUB_FIXTURE_MARKER = "ui-smoke-assistant-v1";
-
 const PROVISION_TIMEOUT_MS = 180_000;
-
-function chatComposer(page: Page): Locator {
-  return page.locator(CHAT_COMPOSER_SELECTOR).first();
-}
-
-function chatSendButton(page: Page): Locator {
-  return page.locator(CHAT_SEND_SELECTOR).first();
-}
 
 async function clickIfVisible(
   locator: Locator,
@@ -129,27 +114,9 @@ test.describe("real cloud login + provisioning + chat", () => {
       15_000,
     );
 
-    // Real chat turn against the provisioned cloud agent.
+    // Real chat turn against the provisioned cloud agent — the shared liveness
+    // contract (#14359) proves a real model answered (non-empty, no stub marker).
     await openAppPath(page, "/chat");
-    const composer = chatComposer(page);
-    await expect(composer).toBeVisible({ timeout: 60_000 });
-    const prompt = "In one short sentence, say hello.";
-    await composer.fill(prompt);
-    await expect(chatSendButton(page)).toBeEnabled();
-    await chatSendButton(page).click();
-
-    const assistant = page
-      .locator(
-        '[data-role="assistant"], [data-testid="chat-message-assistant"]',
-      )
-      .last();
-    await expect(assistant).toBeVisible({ timeout: 120_000 });
-    const text = (await assistant.textContent())?.trim() ?? "";
-    expect(
-      text.length,
-      "cloud agent must produce a non-empty reply",
-    ).toBeGreaterThan(0);
-    // Prove it was a real model turn, not the deterministic stub fixture.
-    expect(text).not.toContain(STUB_FIXTURE_MARKER);
+    await assertOnboardingLiveness(page, { label: "cloud-live" });
   });
 });


### PR DESCRIPTION
## What & why

Closes #14359.

Most onboarding e2e lanes stopped at "landed on home" — that proves navigation, not the MVP promise (after onboarding a **real model answers**). The negative-assertion pattern existed exactly once, inline in `cloud-live.spec.ts`. This PR extracts it into **one surface-agnostic liveness contract** and wires it into the onboarding lanes that only reached home, so every live onboarding path ends the same way: send one chat turn, assert the reply is non-empty and free of the stub fixture marker.

### The contract (single source of truth)
- **`packages/app/test/liveness-contract.mjs`** — pure, dependency-free core: `STUB_FIXTURE_MARKER`, `assertLiveReply(reply, {label})` (throws `LivenessAssertionError` on empty / non-string / stub-marker; returns the trimmed reply), `isLiveReply`. Plain `.mjs` so it is importable from both the bundled renderer **and** the un-bundled Node iOS harness with no build step.
- **`packages/app/test/liveness-contract.ts`** — thin Playwright wrapper: `sendChatAndReadReply` + `assertOnboardingLiveness(page)` (drives the chat composer, waits for the assistant reply, applies the pure assertion). Re-exports the core.

### Wiring (every lane now ends with the contract)
| Lane | Before | After |
| --- | --- | --- |
| `cloud-live.spec.ts` | inline `STUB_FIXTURE_MARKER` + hand-rolled assertion | uses `assertOnboardingLiveness(page, { label: "cloud-live" })` — **duplicate marker/logic deleted** |
| `android/onboarding-to-home.android.spec.ts` | stopped at home | ends with a chat turn: real (non-stub) reply under `ELIZA_ONBOARDING_LIVENESS=1` (live host), else the **stub reply must render** (lane labeled stub-backed in header) |
| `scripts/ios-onboarding-smoke.mjs` + `src/main.tsx` verifier | reported home only | verifier drives one real chat turn and reports `livenessReply` when `liveness:true`; harness enforces `assertLiveReply` |

No mocked lane gained a fake liveness assertion — the stub-backed Android default asserts stub behavior, clearly labeled.

## Verification

<details><summary>Unit test — pure liveness core (stub → fail, real → pass, empty/non-string → fail)</summary>

```
$ bunx vitest run --config vitest.config.ts test/liveness-contract.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)
```
</details>

<details><summary>Runtime import of the shared .mjs (node, no build step)</summary>

```
$ node --input-type=module -e "import {assertLiveReply, STUB_FIXTURE_MARKER} from './test/liveness-contract.mjs'; ..."
marker: ui-smoke-assistant-v1
real reply ok: Hello!
stub rejected: LivenessAssertionError
empty rejected: LivenessAssertionError
$ node --check scripts/ios-onboarding-smoke.mjs
ios-onboarding-smoke.mjs OK
```
</details>

<details><summary>Typecheck (tsgo -p tsconfig.typecheck.json) + biome — my files clean</summary>

```
$ bunx tsgo --noEmit -p tsconfig.typecheck.json | grep -iE "liveness|cloud-live|onboarding-to-home|main.tsx"
(no output — no errors in touched files)

$ bunx @biomejs/biome check test/liveness-contract.* test/ui-smoke/cloud-live.spec.ts test/android/onboarding-to-home.android.spec.ts scripts/ios-onboarding-smoke.mjs src/main.tsx
Checked 7 files in 38ms. No fixes applied.
```
The only remaining tsgo errors are pre-existing `../core` / `../shared` **generated** i18n artifacts (`validation-keyword-data`) absent in a fresh worktree — unrelated to this change.
</details>

<details><summary>Coverage classifier + mobile-smoke-scripts regression checks still green</summary>

```
$ bunx vitest run --config vitest.config.ts test/ui-smoke-coverage.test.ts      → 6 passed
$ bunx vitest run --config vitest.config.ts test/mobile-smoke-scripts.test.ts   → 5 passed
```
</details>

## Evidence

| Type | Status |
| --- | --- |
| Unit test (pure contract core) | Attached above — 5 passed |
| Typecheck + biome + runtime import proof | Attached above |
| MP4 of a full live onboarding→message→real reply run | **N/A — requires the physical/simulator fleet + a live provider key.** Android: `ELIZA_ONBOARDING_LIVENESS=1 ELIZA_ANDROID_BACKEND=host bun run --cwd packages/app test:e2e:android:onboarding` against a live-provider host. iOS: `ELIZA_ONBOARDING_LIVENESS=1 node packages/app/scripts/ios-onboarding-smoke.mjs` against a live-provider host. Cloud: nightly `app-live-e2e.yml` (`ELIZA_UI_SMOKE_CLOUD_LIVE=1 ELIZA_UI_SMOKE_LIVE_STACK=1 ELIZAOS_CLOUD_API_KEY=…`). |
| Trajectory / server log of the real model turn | **N/A — same live-fleet requirement as above.** |

The **contract (shared helper + wiring)** is the deliverable of this issue; the live device/cloud runs are gated on the physical fleet and are marked N/A with the exact per-platform command an owner runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
