### PR TITLE
perf(ui): smoother left-right swipe on installed PWA

### DIFF
--- a/packages/ui/src/hooks/useHorizontalPager.test.tsx
+++ b/packages/ui/src/hooks/useHorizontalPager.test.tsx
@@ -490,3 +490,108 @@ describe("useHorizontalPager — pointercancel abandonment", () => {
     expect(rail.style.transform).toContain("translate3d(0px");
   });
 });
+
+describe("useHorizontalPager — drag-scoped GPU promotion (#swipe-smoothness)", () => {
+  const touch = {
+    pointerId: 31,
+    pointerType: "touch",
+    isPrimary: true,
+    clientY: 300,
+  } as const;
+
+  /** Fire a transform `transitionend` on the rail, as WebKit does when a settle
+   *  transition finishes (jsdom never dispatches these itself). */
+  function endTransform(rail: HTMLElement) {
+    act(() => {
+      const ev = new Event("transitionend") as TransitionEvent;
+      Object.defineProperty(ev, "propertyName", { value: "transform" });
+      Object.defineProperty(ev, "target", { value: rail });
+      rail.dispatchEvent(ev);
+    });
+  }
+
+  it("promotes the rail to its own layer for the drag, drops it on settle end", () => {
+    const { getByTestId } = render(<Harness />);
+    const rail = getByTestId("rail");
+    act(() => {
+      clock = 1000;
+      fireEvent.pointerDown(rail, { ...touch, clientX: 800 });
+      // Axis still pending under the commit slop — no promotion yet.
+      expect(rail.style.willChange).toBe("");
+      // Cross the slop horizontally: the gesture commits to X and promotes.
+      fireEvent.pointerMove(rail, { ...touch, clientX: 770 });
+    });
+    expect(rail.style.willChange).toBe("transform");
+    // Held through the drag frames + the release settle.
+    act(() => {
+      fireEvent.pointerMove(rail, { ...touch, clientX: 400 });
+      clock = 1120;
+      fireEvent.pointerUp(rail, { ...touch, clientX: 400 });
+    });
+    expect(rail.style.willChange).toBe("transform");
+    // Dropped only once the settle transition has actually ended.
+    endTransform(rail);
+    expect(rail.style.willChange).toBe("");
+  });
+
+  it("never promotes the rail for a vertical-committed gesture", () => {
+    const { getByTestId } = render(<Harness />);
+    const rail = getByTestId("rail");
+    act(() => {
+      clock = 1000;
+      fireEvent.pointerDown(rail, { ...touch, clientX: 500 });
+      // Vertical-dominant move: axis commits to Y, the rail must stay unpromoted.
+      fireEvent.pointerMove(rail, { ...touch, clientX: 505, clientY: 400 });
+      fireEvent.pointerMove(rail, { ...touch, clientX: 505, clientY: 500 });
+      clock = 1120;
+      fireEvent.pointerUp(rail, { ...touch, clientX: 505, clientY: 500 });
+    });
+    expect(rail.style.willChange).toBe("");
+  });
+
+  it("drops the promotion when the surface unmounts mid-gesture", () => {
+    const { getByTestId, unmount } = render(<Harness />);
+    const rail = getByTestId("rail");
+    act(() => {
+      clock = 1000;
+      fireEvent.pointerDown(rail, { ...touch, clientX: 800 });
+      fireEvent.pointerMove(rail, { ...touch, clientX: 770 });
+    });
+    expect(rail.style.willChange).toBe("transform");
+    // Unmount before any settle transitionend: the cleanup effect drops the
+    // promoted layer so its GPU memory is not stranded.
+    unmount();
+    expect(rail.style.willChange).toBe("");
+  });
+
+  it("skips the promotion under prefers-reduced-motion (no layer to composite)", () => {
+    const original = window.matchMedia;
+    window.matchMedia = ((query: string) => ({
+      matches: query.includes("prefers-reduced-motion"),
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    })) as typeof window.matchMedia;
+    try {
+      const { getByTestId } = render(<Harness />);
+      const rail = getByTestId("rail");
+      act(() => {
+        clock = 1000;
+        fireEvent.pointerDown(rail, { ...touch, clientX: 800 });
+        fireEvent.pointerMove(rail, { ...touch, clientX: 770 });
+        fireEvent.pointerMove(rail, { ...touch, clientX: 400 });
+        clock = 1120;
+        fireEvent.pointerUp(rail, { ...touch, clientX: 400 });
+      });
+      // Reduced motion jumps the rail with no settle transition — there is no
+      // animated layer to composite, so the hint is never set.
+      expect(rail.style.willChange).toBe("");
+    } finally {
+      window.matchMedia = original;
+    }
+  });
+});

--- a/packages/ui/src/hooks/useHorizontalPager.ts
+++ b/packages/ui/src/hooks/useHorizontalPager.ts
@@ -268,6 +268,39 @@ export function useHorizontalPager<
     return Math.max(1, width);
   }, []);
 
+  // A GPU-compositing hint scoped to an ACTIVE drag/settle only, mirroring the
+  // vertical overlay's `will-change` playbook (#14501) on the horizontal axis.
+  // The rail is `w-[200%]` — two full-viewport panes, one of which carries a
+  // `backdrop-blur-xl` + `mask-image` notification stack (NotificationsHome
+  // Center). Without a promotion hint WebKit/iOS Safari rasterizes the rail into
+  // its parent layer, so every frame of a horizontal pan re-rasterizes the
+  // blurred/masked subtree as it translates (the installed-PWA left↔right
+  // micro-stutter). Hinting `will-change: transform` on the rail up front lets
+  // the compositor promote the whole surface to its own layer and translate it
+  // without a per-frame repaint. Deliberately NOT permanent — a resident hint
+  // keeps a promoted layer (and its GPU memory) alive at rest for no benefit, so
+  // it is dropped the instant the settle transition ends (see `armRailPromotion`
+  // / `dropRailPromotion` below). Written imperatively on the same element as
+  // the transform (the pager already bypasses React for the per-frame drag), so
+  // it never triggers a re-render.
+  const railPromotedRef = React.useRef(false);
+  const dropRailPromotion = React.useCallback(() => {
+    const rail = railRef.current;
+    if (!railPromotedRef.current) return;
+    railPromotedRef.current = false;
+    if (rail) rail.style.willChange = "";
+  }, []);
+  const armRailPromotion = React.useCallback(() => {
+    const rail = railRef.current;
+    if (!rail || railPromotedRef.current) return;
+    // Reduced motion has no animated settle to composite — a pan that jumps
+    // page-to-page never runs the transition, so the promotion would only ever
+    // be dropped by the next drag. Skip it entirely (matches #14501).
+    if (prefersReducedMotion()) return;
+    railPromotedRef.current = true;
+    rail.style.willChange = "transform";
+  }, []);
+
   const writeOffset = React.useCallback(
     (offset: number, transitionMs: number | null) => {
       const rail = railRef.current;
@@ -370,6 +403,39 @@ export function useHorizontalPager<
     return () => observer.disconnect();
   }, [measureWidth, writeOffset]);
 
+  // Drop the drag-scoped GPU promotion (#swipe-smoothness, horizontal twin of
+  // #14501) only once the settle transition has actually ENDED — clearing it on
+  // pointerup would strip `will-change` mid settle-transition and repaint exactly
+  // when the rail is still moving. A fresh drag re-arms it before the next
+  // transition, and a chained swipe that interrupts the settle keeps the layer
+  // resident (armRailPromotion is a no-op while already promoted). Only the
+  // transform transition on the rail itself clears it (guard against a bubbled
+  // child transition, and against a `transitionend` for some other property).
+  React.useEffect(() => {
+    const rail = railRef.current;
+    if (!rail) return;
+    const onTransitionEnd = (event: TransitionEvent) => {
+      if (event.target !== rail || event.propertyName !== "transform") return;
+      if (dragRef.current) return; // a new drag is live — keep the promotion
+      dropRailPromotion();
+    };
+    rail.addEventListener("transitionend", onTransitionEnd);
+    return () => rail.removeEventListener("transitionend", onTransitionEnd);
+  }, [dropRailPromotion]);
+
+  // Release the promoted layer (and its GPU memory) if the surface unmounts
+  // mid-gesture, before any settle transition could fire its `transitionend`.
+  // Capture the rail element on mount so the cleanup can still clear the hint
+  // even though React has nulled `railRef.current` by unmount time.
+  React.useEffect(() => {
+    const rail = railRef.current;
+    return () => {
+      if (!railPromotedRef.current) return;
+      railPromotedRef.current = false;
+      if (rail) rail.style.willChange = "";
+    };
+  }, []);
+
   // (useRafCoalescer cancels its own in-flight frame on unmount.)
 
   const finish = React.useCallback(
@@ -408,11 +474,18 @@ export function useHorizontalPager<
           : state.baseOffset;
       // Velocity-aware momentum: settle duration scales with how fast the finger
       // left, not a fixed rate — a flick lands quick, a slow drag eases in.
-      const settleTo = (offset: number) =>
+      const settleTo = (offset: number) => {
         writeOffset(
           offset,
           momentumSettleMs(Math.abs(offset - lastVisual), velocity),
         );
+        // If the rail is released exactly where it rests (a horizontal-committed
+        // gesture that dragged out and back to 0), the transform doesn't change,
+        // so no settle `transitionend` fires to drop the drag-scoped GPU
+        // promotion. Drop it here for that zero-delta case; the normal path lets
+        // the transition run and clears on its `transitionend`.
+        if (Math.abs(offset - lastVisual) < 1) dropRailPromotion();
+      };
 
       // A page only advances for a committed horizontal drag that can actually
       // move in the drag direction; anything else settles back.
@@ -469,6 +542,7 @@ export function useHorizontalPager<
       canMove,
       cancelScheduledOffset,
       clickSuppression,
+      dropRailPromotion,
       measureWidth,
       releaseCapture,
       visualDragOffset,
@@ -560,6 +634,14 @@ export function useHorizontalPager<
         const ay = Math.abs(dy);
         if (Math.max(ax, ay) < AXIS_COMMIT_SLOP) return;
         state.axis = ax > ay * AXIS_DOMINANCE_RATIO ? "horizontal" : "vertical";
+        // The gesture is now known to be a horizontal pan: promote the rail to
+        // its own compositor layer for the rest of the drag + settle so the
+        // finger-tracked translate (and the blurred/masked notification stack it
+        // carries) composites instead of repainting per frame (#swipe-
+        // smoothness). Armed here (first horizontal-committed frame), not on
+        // pointerdown, so a purely vertical scroll of the home widget list never
+        // needlessly promotes the rail. Dropped on the settle `transitionend`.
+        if (state.axis === "horizontal") armRailPromotion();
       }
       if (state.axis !== "horizontal") return;
 
@@ -591,7 +673,7 @@ export function useHorizontalPager<
       }
       scheduleOffset(state.baseOffset + visualDragOffset(state, dx));
     },
-    [abandonDrag, scheduleOffset, visualDragOffset],
+    [abandonDrag, armRailPromotion, scheduleOffset, visualDragOffset],
   );
 
   const onPointerUp = React.useCallback(


### PR DESCRIPTION
## What

Smooths the **left↔right swipe on the installed iOS PWA** — the home↔launcher rail (`useHorizontalPager`). Applies the exact playbook that shipped for the vertical axis in #14501 to the horizontal axis.

## Root cause (same class #14501 killed, horizontal axis)

The rail already drives its per-frame pan on the rail transform via rAF (no React re-render per frame) and animates with `translate3d` — but nothing promotes the moving surface to its own GPU layer. WebKit rasterizes the rail into its parent layer and repaints it every frame of the pan.

The rail is `w-[200%]` — two full-viewport panes. The home pane carries a `backdrop-blur-xl` + `mask-image` notification stack (`NotificationsHomeCenter`). A CSS mask + backdrop-blur force that subtree off WebKit's fast compositing path, so while the rail translates each frame the blurred/masked layer **re-rasterizes per frame** — the visible left↔right micro-stutter on the installed PWA.

## Fix

- **Arm `will-change: transform` on the rail** the instant the gesture commits to the horizontal axis (first horizontal-committed frame, *not* pointerdown — a purely vertical widget-list scroll never promotes the rail). WebKit/iOS Safari rasterizes the rail (and the blurred/masked notification stack it carries) onto its own compositor layer up front, so the finger-tracked translate + release settle composite without a per-frame repaint.
- **Drop the hint only once the settle transition has ENDED** (`transitionend` for `transform` on the rail) — clearing it on pointerup would strip `will-change` mid-settle and repaint exactly when the rail is still moving. Chained swipes keep the layer resident; a zero-delta release and an unmount both drop it directly so no promoted layer (or GPU memory) is stranded at rest.
- Written imperatively on the same element as the transform (the pager already bypasses React for the drag), so it never triggers a re-render. Reduced-motion skips the hint (no settle transition to composite).

## Release feel — deliberately NOT re-tuned

The vertical sheet uses a Motion spring (critically-damped, Apple-style); the horizontal pager uses the velocity-aware iOS scroll-decel bezier `(0.32, 0.72, 0, 1)` — the correct curve for a discrete page snap (a spring would overshoot). Both are Apple-derived and velocity-aware, so the motion *language* stays consistent while each *mechanism* fits its surface. Left untouched on purpose.

## Before / after

Scoped to the **horizontal** rail. The surviving `chat-perf-gate` is vertical-only (chat-to-chat swipe was removed in #13531), so it measures that the vertical baseline is intact, not the horizontal gain:

```
chat-perf-gate (vertical, headless Chromium):
  fps 60.0  p95 16.8ms  worst 16.8ms  dropped 0/386  CLS 0.0000
  → #14501's gains preserved (worst-frame clean, 0 dropped)
```

The horizontal gain is validated by the **promotion-lifecycle unit tests** (arm on horizontal commit / drop on settle-end / never on a vertical gesture / drop on unmount / skip under reduced-motion) and the **axis-lock e2e** (no judder from axis-lock hysteresis; horizontal scroll stays isolated). The real iOS win is larger than any headless number — mask + backdrop-blur re-raster is far more expensive on the mobile GPU.

## Verify

```
vitest run useHorizontalPager                → 20/20 passed
test:chat-scroll-axis-lock-e2e                → all axis-lock assertions passed
test:chat-perf-gate                           → PERF GATE PASSED (0/386 dropped)
HomeLauncherSurface.test.tsx                  → 15/15 passed
packages/app build                            → ✓ built in 1m 4s (786 assets)
biome check useHorizontalPager.ts/.test.tsx   → clean
```

## Scope discipline

Touches **only** `useHorizontalPager.ts` (+ its test). Vertical drag path (#14501), root geometry, per-view padding, settings, home long-press — all untouched.

> Pre-existing, unrelated to this diff: `HomeLauncherSurface.composed.test.tsx` fails on `origin/develop` with a stale `getFrontendPlatform` platform-guards mock — verified failing **without** this change.

— [sol-orch]
