### PR TITLE
feat(evidence): bundle schema, provenance manifest, and silo ingestors (#14552)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -894,6 +894,16 @@
         "vitest": "^4.0.17",
       },
     },
+    "packages/evidence": {
+      "name": "@elizaos/evidence",
+      "version": "0.0.0",
+      "dependencies": {
+        "zod": "^4.4.3",
+      },
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+      },
+    },
     "packages/examples/_plugin": {
       "name": "@elizaos/plugin-starter",
       "version": "2.0.0-beta.0",
@@ -5541,6 +5551,7 @@
     "@elizaos/plugin-starter",
     "utf-8-validate",
     "@swc/core",
+    "tesseract.js",
     "protobufjs",
     "keccak",
     "secp256k1",
@@ -5552,7 +5563,6 @@
     "electron",
     "nx",
     "bigint-buffer",
-    "tesseract.js",
   ],
   "patchedDependencies": {
     "@solana/rpc-subscriptions-spec@5.5.1": "patches/@solana%2Frpc-subscriptions-spec@5.5.1.patch",
@@ -6279,6 +6289,8 @@
     "@elizaos/docs-elizacloud-redirect": ["@elizaos/docs-elizacloud-redirect@workspace:packages/cloud/docs-redirect"],
 
     "@elizaos/electrobun": ["@elizaos/electrobun@workspace:packages/app-core/platforms/electrobun"],
+
+    "@elizaos/evidence": ["@elizaos/evidence@workspace:packages/evidence"],
 
     "@elizaos/example-a2a-server": ["@elizaos/example-a2a-server@workspace:packages/examples/a2a"],
 

--- a/packages/evidence/AGENTS.md
+++ b/packages/evidence/AGENTS.md
@@ -1,0 +1,58 @@
+# @elizaos/evidence — agent guide
+
+Evidence-bundle foundation for the unified evidence harness (epic #14541,
+issue #14552). Read `README.md` for the schema contract, bundle layout, silo
+table, and CLI; read the design doc at
+`packages/docs/ongoing-development/unified-evidence-harness.md` for how the
+whole pipeline (analyzers → VLM Q&A → certify → CI gate) fits together.
+
+## Hard rules
+
+- **`src/schema.ts` is a frozen contract.** `ArtifactEntry`, `BundleManifest`,
+  `BundleMeta`, and the `ArtifactKind`/`RunnerKind`/`Tier` unions are what
+  #14542/#14544/#14546 build against. Widen only additively, and only under a
+  `schema` version bump. The zod validators are held mutually assignable with
+  the interfaces at compile time — keep that guard intact.
+- **Manifest bytes are signed.** `finalize()` must stay byte-stable: artifacts
+  sorted by path, canonical JSON (sorted keys, no whitespace, one trailing
+  newline — `src/canonical.ts`). Any change to serialization is a
+  certification-breaking change.
+- **Producers are not touched.** Ingestors (`src/ingest.ts`) only discover and
+  copy. `packages/app/scripts/**` and `scripts/evidence-review/**` are hot
+  zones with in-flight PRs; this package deliberately lives outside them.
+- **Absent ≠ empty.** An ingestor returns `status: 'absent'` when no silo root
+  exists and `status: 'ingested'` with `artifactCount: 0` when a root exists
+  but is empty. Never conflate them and never fabricate an empty success.
+- **Fail fast, typed.** Throw `EvidenceError`/`EvidenceValidationError`
+  (mirrors core's `ElizaError` shape without depending on the framework —
+  this package must run in minimal CI/vast containers). No `?? <default>` for
+  failed/missing data. The library never logs; the CLI is the only output
+  boundary.
+- **Tests are real.** Vitest against real tmp-dir filesystems and real
+  `git init` repos; the only injected seams are the clock (byte-stability)
+  and the link function (EXDEV cannot be created portably in one tmp volume).
+
+## Commands
+
+```bash
+bun run --cwd packages/evidence test         # vitest suite
+bun run --cwd packages/evidence typecheck    # tsgo --noEmit
+bun run --cwd packages/evidence lint         # biome
+bun run --cwd packages/evidence bundle:create -- --tier cpu
+bun run --cwd packages/evidence bundle:verify -- evidence/runs/<run-id>
+```
+
+Test-lane membership is declared via `elizaos.scripts.testLanes: ["server"]`
+in `package.json` (discovered by `packages/scripts/run-all-tests.mjs`).
+
+## Layout
+
+```
+src/schema.ts       frozen schema-1 types + zod validation (J3 typed invalid)
+src/canonical.ts    canonical JSON bytes (signed form)
+src/bundle.ts       EvidenceBundle builder + verifyBundle integrity report
+src/provenance.ts   git facts (fail loud), runner kind, env fingerprint allowlist
+src/ingest.ts       silo definitions + ingestAllSilos / ingestNamedSilo
+src/cli.ts          thin argv/formatting layer over the lib (J1 boundary)
+src/errors.ts       EvidenceError / EvidenceValidationError
+```

--- a/packages/evidence/CLAUDE.md
+++ b/packages/evidence/CLAUDE.md
@@ -1,0 +1,58 @@
+# @elizaos/evidence — agent guide
+
+Evidence-bundle foundation for the unified evidence harness (epic #14541,
+issue #14552). Read `README.md` for the schema contract, bundle layout, silo
+table, and CLI; read the design doc at
+`packages/docs/ongoing-development/unified-evidence-harness.md` for how the
+whole pipeline (analyzers → VLM Q&A → certify → CI gate) fits together.
+
+## Hard rules
+
+- **`src/schema.ts` is a frozen contract.** `ArtifactEntry`, `BundleManifest`,
+  `BundleMeta`, and the `ArtifactKind`/`RunnerKind`/`Tier` unions are what
+  #14542/#14544/#14546 build against. Widen only additively, and only under a
+  `schema` version bump. The zod validators are held mutually assignable with
+  the interfaces at compile time — keep that guard intact.
+- **Manifest bytes are signed.** `finalize()` must stay byte-stable: artifacts
+  sorted by path, canonical JSON (sorted keys, no whitespace, one trailing
+  newline — `src/canonical.ts`). Any change to serialization is a
+  certification-breaking change.
+- **Producers are not touched.** Ingestors (`src/ingest.ts`) only discover and
+  copy. `packages/app/scripts/**` and `scripts/evidence-review/**` are hot
+  zones with in-flight PRs; this package deliberately lives outside them.
+- **Absent ≠ empty.** An ingestor returns `status: 'absent'` when no silo root
+  exists and `status: 'ingested'` with `artifactCount: 0` when a root exists
+  but is empty. Never conflate them and never fabricate an empty success.
+- **Fail fast, typed.** Throw `EvidenceError`/`EvidenceValidationError`
+  (mirrors core's `ElizaError` shape without depending on the framework —
+  this package must run in minimal CI/vast containers). No `?? <default>` for
+  failed/missing data. The library never logs; the CLI is the only output
+  boundary.
+- **Tests are real.** Vitest against real tmp-dir filesystems and real
+  `git init` repos; the only injected seams are the clock (byte-stability)
+  and the link function (EXDEV cannot be created portably in one tmp volume).
+
+## Commands
+
+```bash
+bun run --cwd packages/evidence test         # vitest suite
+bun run --cwd packages/evidence typecheck    # tsgo --noEmit
+bun run --cwd packages/evidence lint         # biome
+bun run --cwd packages/evidence bundle:create -- --tier cpu
+bun run --cwd packages/evidence bundle:verify -- evidence/runs/<run-id>
+```
+
+Test-lane membership is declared via `elizaos.scripts.testLanes: ["server"]`
+in `package.json` (discovered by `packages/scripts/run-all-tests.mjs`).
+
+## Layout
+
+```
+src/schema.ts       frozen schema-1 types + zod validation (J3 typed invalid)
+src/canonical.ts    canonical JSON bytes (signed form)
+src/bundle.ts       EvidenceBundle builder + verifyBundle integrity report
+src/provenance.ts   git facts (fail loud), runner kind, env fingerprint allowlist
+src/ingest.ts       silo definitions + ingestAllSilos / ingestNamedSilo
+src/cli.ts          thin argv/formatting layer over the lib (J1 boundary)
+src/errors.ts       EvidenceError / EvidenceValidationError
+```

--- a/packages/evidence/README.md
+++ b/packages/evidence/README.md
@@ -1,0 +1,124 @@
+# @elizaos/evidence
+
+Evidence-bundle foundation for the unified evidence harness and develop→main
+certification pipeline (epic #14541, design doc:
+`packages/docs/ongoing-development/unified-evidence-harness.md`).
+
+One harness run produces one bundle: `evidence/runs/<run-id>/` with a
+`manifest.json` listing every artifact and a `meta.json` recording provenance
+(commit, branch, runner, tier, env fingerprint). Existing evidence producers
+are **not rewritten** — ingestors copy/hardlink their output into the bundle
+and stamp provenance at ingest time. Certification (#14546) signs
+sha256(manifest bytes), which is why the manifest is written in a canonical,
+byte-stable form.
+
+## Schema contract (frozen, `schema: 1`)
+
+```ts
+type ArtifactKind = 'screenshot'|'video'|'keyframe'|'log'|'trajectory'
+                  | 'report'|'analysis'|'qa'|'html-tree'|'other';
+type RunnerKind   = 'local'|'vast'|'ci';
+type Tier         = 'cpu'|'gpu'|'full';
+
+interface ArtifactEntry {
+  path: string;        // bundle-relative posix; `..`/absolute/backslash rejected
+  sha256: string;      // lowercase hex, hashed as stored in the bundle
+  bytes: number;
+  kind: ArtifactKind;
+  source: string;      // producer id, e.g. 'aesthetic-audit'
+  lane?: string;       // e2e | scenario | native | …, when known
+  producedBy: string;  // tool/script that produced the artifact
+  createdAt: string;   // ISO-8601
+}
+
+interface BundleManifest { schema: 1; runId: string; createdAt: string; artifacts: ArtifactEntry[] }
+
+interface BundleMeta {
+  schema: 1; runId: string; commit: string; branch: string;
+  runner: RunnerKind; tier: Tier; startedAt: string; finishedAt?: string;
+  envFingerprint: Record<string, string>;   // small allowlist, never full env
+  timings?: Record<string, number>;         // milliseconds per phase
+}
+```
+
+Later harness pieces (analyzers #14542, VLM Q&A #14544, certify #14546) build
+against these exact names and semantics. Widen only additively under a schema
+version bump. Reading a manifest/meta from disk goes through `parseManifest` /
+`parseMeta`, which throw `EvidenceValidationError` with per-field issues —
+never a silently-repaired object.
+
+## Bundle layout
+
+`runId` is `<utc yyyymmdd-hhmmss>-<shortsha>-<tier>`. Default placement is a
+deterministic kind→family mapping; `bundlePath` overrides it for exact
+placement (analyzers writing `analysis.json` beside pixels):
+
+```
+evidence/runs/<run-id>/
+  manifest.json  meta.json  certification.json (certifier-only, later)
+  lanes/<lane>/…            report kind (logs under lanes/<lane>/logs/…)
+  trajectories/<source>/…   trajectory kind
+  visual/<source>/…         screenshot kind
+  video/<source>/…          video kind (keyframes under video/<source>/keyframes/…)
+  html-trees/…              html-tree kind
+  misc/<source>/…           analysis / qa / other, and lane-less logs/reports
+```
+
+Manifest canonicalization (hard requirement — certification signs these
+bytes): artifacts sorted by `path` (UTF-16 code-unit order), object keys
+sorted, no whitespace, UTF-8, one trailing newline. See `src/canonical.ts`.
+
+## Ingestors
+
+Pure discovery + copy; producers untouched. Each silo reports honestly:
+`absent` (no root exists) is a different result from `ingested` with zero
+artifacts (root exists but is empty).
+
+| silo | roots | lane |
+| --- | --- | --- |
+| `e2e-recordings` | `e2e-recordings/` | e2e |
+| `aesthetic-audit` | `packages/app/aesthetic-audit-output/` | — |
+| `device-e2e` | `device-e2e-output/`, `packages/app/device-e2e-output/` | native |
+| `playwright-test-results` | `packages/app/test-results/` | e2e |
+| `walkthrough-reports` | `reports/walkthrough/`, `packages/app/reports/walkthrough/` | — |
+| `live-test-runs` | `reports/live-test-runs/` | — |
+| `scenario-runner` | `packages/scenario-runner/reports/`, `reports/scenarios/` | scenario |
+
+Multi-root silos namespace bundle paths by a per-root label so roots cannot
+collide. Artifacts are hardlinked when the silo shares a volume with the
+bundle, copied otherwise, and hashed **as stored** so a corrupt copy fails at
+add time.
+
+## CLI
+
+```bash
+bun run --cwd packages/evidence bundle:create -- --tier cpu [--out evidence/runs] [--repo-root <dir>]
+bun run --cwd packages/evidence bundle:verify -- evidence/runs/<run-id>
+```
+
+`create` collects git provenance (fails loud outside a repo), resolves the
+runner (`ELIZA_EVIDENCE_RUNNER` ∈ local|vast|ci, else `CI` env, else local),
+ingests every silo, finalizes, and prints a per-silo summary plus the manifest
+sha256. `verify` re-hashes every artifact and reports `missing` /
+`size-mismatch` / `hash-mismatch` / `unlisted` findings; non-zero exit on any
+issue.
+
+## How later pieces slot in
+
+- **Analyzers (#14542):** consume `manifest.json`, write
+  `analysis.json` fragments back via `addArtifact` with `bundlePath` beside
+  the analyzed artifact (`kind: 'analysis'`).
+- **VLM Q&A (#14544):** same pattern, `kind: 'qa'`, `qa.json` beside pixels.
+- **Certify (#14546):** runs the matrix, ingests, calls `verifyBundle`, signs
+  `FinalizeResult.manifestSha256`, writes `certification.json` (an envelope
+  file, exempt from the unlisted-file sweep).
+- **CI gate (#14547):** verifies the signature against the committed public
+  key and re-runs `verifyBundle` when the bundle is available.
+
+## Development
+
+```bash
+bun run --cwd packages/evidence test        # vitest, real tmp-dir filesystem
+bun run --cwd packages/evidence typecheck
+bun run --cwd packages/evidence lint
+```

--- a/packages/evidence/package.json
+++ b/packages/evidence/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@elizaos/evidence",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Evidence-bundle foundation: versioned manifest schema, provenance-stamped bundle builder, integrity verification, and silo ingestors for the unified evidence harness (#14541).",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "bundle:create": "bun src/cli.ts create",
+    "bundle:verify": "bun src/cli.ts verify",
+    "test": "node ../scripts/run-vitest.mjs run --config ./vitest.config.ts",
+    "typecheck": "tsgo --noEmit -p tsconfig.json",
+    "lint": "bunx @biomejs/biome check src",
+    "lint:fix": "bunx @biomejs/biome check --write src",
+    "format": "bunx @biomejs/biome format --write src",
+    "format:check": "bunx @biomejs/biome format src"
+  },
+  "dependencies": {
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0"
+  },
+  "elizaos": {
+    "scripts": {
+      "testLanes": ["server"]
+    }
+  }
+}

--- a/packages/evidence/package.json
+++ b/packages/evidence/package.json
@@ -26,7 +26,9 @@
   },
   "elizaos": {
     "scripts": {
-      "testLanes": ["server"]
+      "testLanes": [
+        "server"
+      ]
     }
   }
 }

--- a/packages/evidence/src/bundle.test.ts
+++ b/packages/evidence/src/bundle.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Real-filesystem tests for the bundle builder and verifier: byte-stable
+ * manifests under an injected clock, hardlink vs copy materialization, path
+ * collision/traversal refusal, single-use lifecycle, and tamper detection.
+ * Everything runs against tmp dirs — no mocks of the code under test; the
+ * only injected seam is the link function (the EXDEV condition cannot be
+ * created portably inside one tmp volume).
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { BundleProvenance } from "./bundle.ts";
+import {
+  createBundle,
+  EvidenceBundle,
+  formatRunId,
+  verifyBundle,
+} from "./bundle.ts";
+import { EvidenceError, EvidenceValidationError } from "./errors.ts";
+
+const COMMIT = "abcdef0123456789abcdef0123456789abcdef01";
+
+const PROVENANCE: BundleProvenance = {
+  commit: COMMIT,
+  branch: "feat/test",
+  runner: "local",
+  tier: "cpu",
+  envFingerprint: {
+    node: "v24.0.0",
+    platform: "linux",
+    arch: "x64",
+    tier: "cpu",
+  },
+};
+
+const tmpDirs: string[] = [];
+
+function tmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "evidence-bundle-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/** Deterministic clock: starts at a fixed instant, advances 1 s per call. */
+function fixedClock(
+  startMs = Date.parse("2026-07-05T12:00:00.000Z"),
+): () => Date {
+  let calls = 0;
+  return () => new Date(startMs + 1000 * calls++);
+}
+
+function writeFixture(dir: string, name: string, content: string): string {
+  const filePath = path.join(dir, name);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+  return filePath;
+}
+
+async function buildSampleBundle(root: string, sources: string) {
+  const bundle = createBundle({
+    rootDir: root,
+    provenance: PROVENANCE,
+    now: fixedClock(),
+  });
+  await bundle.addArtifact(writeFixture(sources, "shot.png", "png-bytes"), {
+    kind: "screenshot",
+    source: "aesthetic-audit",
+    producedBy: "audit:app",
+    relativePath: "desktop/shot.png",
+  });
+  await bundle.addArtifact(writeFixture(sources, "run.jsonl", "{}\n"), {
+    kind: "trajectory",
+    source: "scenario-runner",
+    lane: "scenario",
+    producedBy: "eliza-scenarios",
+  });
+  await bundle.addArtifact(writeFixture(sources, "server.log", "log line\n"), {
+    kind: "log",
+    source: "e2e-recordings",
+    lane: "e2e",
+    producedBy: "run-all.mjs",
+  });
+  return bundle;
+}
+
+describe("formatRunId", () => {
+  it("derives <utc stamp>-<shortsha>-<tier>", () => {
+    const id = formatRunId(new Date("2026-07-05T18:32:45.123Z"), COMMIT, "gpu");
+    expect(id).toBe("20260705-183245-abcdef0-gpu");
+  });
+});
+
+describe("EvidenceBundle", () => {
+  it("places artifacts by the documented kind→family mapping", async () => {
+    const bundle = await buildSampleBundle(tmpDir(), tmpDir());
+    const result = await bundle.finalize();
+    expect(result.manifest.artifacts.map((entry) => entry.path)).toEqual([
+      "lanes/e2e/logs/server.log",
+      "trajectories/scenario-runner/run.jsonl",
+      "visual/aesthetic-audit/desktop/shot.png",
+    ]);
+    for (const entry of result.manifest.artifacts) {
+      const stored = path.join(bundle.dir, ...entry.path.split("/"));
+      expect(fs.statSync(stored).size).toBe(entry.bytes);
+    }
+  });
+
+  it("honors an explicit bundlePath override", async () => {
+    const sources = tmpDir();
+    const bundle = createBundle({
+      rootDir: tmpDir(),
+      provenance: PROVENANCE,
+      now: fixedClock(),
+    });
+    const entry = await bundle.addArtifact(
+      writeFixture(sources, "analysis.json", "{}"),
+      {
+        kind: "analysis",
+        source: "analyzer",
+        producedBy: "analyzer",
+        bundlePath: "visual/aesthetic-audit/desktop/analysis.json",
+      },
+    );
+    expect(entry.path).toBe("visual/aesthetic-audit/desktop/analysis.json");
+  });
+
+  it("rejects relativePath + bundlePath together", async () => {
+    const sources = tmpDir();
+    const bundle = createBundle({
+      rootDir: tmpDir(),
+      provenance: PROVENANCE,
+      now: fixedClock(),
+    });
+    await expect(
+      bundle.addArtifact(writeFixture(sources, "x.png", "x"), {
+        kind: "screenshot",
+        source: "s",
+        producedBy: "p",
+        relativePath: "a.png",
+        bundlePath: "visual/s/a.png",
+      }),
+    ).rejects.toMatchObject({ code: "ARTIFACT_PLACEMENT_AMBIGUOUS" });
+  });
+
+  it("produces byte-identical manifests across two runs with the same inputs", async () => {
+    const sourcesA = tmpDir();
+    const sourcesB = tmpDir();
+    const bundleA = await buildSampleBundle(tmpDir(), sourcesA);
+    const bundleB = await buildSampleBundle(tmpDir(), sourcesB);
+    const resultA = await bundleA.finalize();
+    const resultB = await bundleB.finalize();
+    const bytesA = fs.readFileSync(resultA.manifestPath);
+    const bytesB = fs.readFileSync(resultB.manifestPath);
+    expect(bytesA.equals(bytesB)).toBe(true);
+    expect(resultA.manifestSha256).toBe(resultB.manifestSha256);
+    expect(
+      fs
+        .readFileSync(resultA.metaPath)
+        .equals(fs.readFileSync(resultB.metaPath)),
+    ).toBe(true);
+  });
+
+  it("hardlinks on the same volume in auto mode", async () => {
+    const sources = tmpDir();
+    const bundle = createBundle({
+      rootDir: tmpDir(),
+      provenance: PROVENANCE,
+      now: fixedClock(),
+    });
+    const sourcePath = writeFixture(sources, "video.mp4", "mp4-bytes");
+    const entry = await bundle.addArtifact(sourcePath, {
+      kind: "video",
+      source: "e2e-recordings",
+      producedBy: "run-all.mjs",
+    });
+    const stored = path.join(bundle.dir, ...entry.path.split("/"));
+    expect(fs.statSync(stored).ino).toBe(fs.statSync(sourcePath).ino);
+  });
+
+  it("copies when linkMode is copy", async () => {
+    const sources = tmpDir();
+    const bundle = createBundle({
+      rootDir: tmpDir(),
+      provenance: PROVENANCE,
+      now: fixedClock(),
+      linkMode: "copy",
+    });
+    const sourcePath = writeFixture(sources, "video.mp4", "mp4-bytes");
+    const entry = await bundle.addArtifact(sourcePath, {
+      kind: "video",
+      source: "e2e-recordings",
+      producedBy: "run-all.mjs",
+    });
+    const stored = path.join(bundle.dir, ...entry.path.split("/"));
+    expect(fs.statSync(stored).ino).not.toBe(fs.statSync(sourcePath).ino);
+    expect(fs.readFileSync(stored, "utf8")).toBe("mp4-bytes");
+  });
+
+  it("falls back to copy when the link fails with EXDEV", async () => {
+    const sources = tmpDir();
+    const exdev = Object.assign(new Error("cross-device link"), {
+      code: "EXDEV",
+    });
+    const bundle = new EvidenceBundle({
+      rootDir: tmpDir(),
+      provenance: PROVENANCE,
+      now: fixedClock(),
+      link: () => {
+        throw exdev;
+      },
+    });
+    const sourcePath = writeFixture(sources, "video.mp4", "mp4-bytes");
+    const entry = await bundle.addArtifact(sourcePath, {
+      kind: "video",
+      source: "e2e-recordings",
+      producedBy: "run-all.mjs",
+    });
+    const stored = path.join(bundle.dir, ...entry.path.split("/"));
+    expect(fs.statSync(stored).ino).not.toBe(fs.statSync(sourcePath).ino);
+    expect(fs.readFileSync(stored, "utf8")).toBe("mp4-bytes");
+  });
+
+  it("rethrows non-EXDEV link failures", async () => {
+    const sources = tmpDir();
+    const eperm = Object.assign(new Error("operation not permitted"), {
+      code: "EPERM",
+    });
+    const bundle = new EvidenceBundle({
+      rootDir: tmpDir(),
+      provenance: PROVENANCE,
+      now: fixedClock(),
+      link: () => {
+        throw eperm;
+      },
+    });
+    await expect(
+      bundle.addArtifact(writeFixture(sources, "x.png", "x"), {
+        kind: "screenshot",
+        source: "s",
+        producedBy: "p",
+      }),
+    ).rejects.toBe(eperm);
+  });
+
+  it("throws typed errors for missing sources, collisions, and traversal", async () => {
+    const sources = tmpDir();
+    const bundle = createBundle({
+      rootDir: tmpDir(),
+      provenance: PROVENANCE,
+      now: fixedClock(),
+    });
+    await expect(
+      bundle.addArtifact(path.join(sources, "nope.png"), {
+        kind: "screenshot",
+        source: "s",
+        producedBy: "p",
+      }),
+    ).rejects.toMatchObject({ code: "ARTIFACT_MISSING" });
+
+    const filePath = writeFixture(sources, "a.png", "a");
+    await bundle.addArtifact(filePath, {
+      kind: "screenshot",
+      source: "s",
+      producedBy: "p",
+    });
+    await expect(
+      bundle.addArtifact(filePath, {
+        kind: "screenshot",
+        source: "s",
+        producedBy: "p",
+      }),
+    ).rejects.toMatchObject({ code: "ARTIFACT_PATH_COLLISION" });
+
+    await expect(
+      bundle.addArtifact(filePath, {
+        kind: "screenshot",
+        source: "s",
+        producedBy: "p",
+        relativePath: "../escape.png",
+      }),
+    ).rejects.toMatchObject({ code: "ARTIFACT_PATH_INVALID" });
+  });
+
+  it("is single-use: refuses adds and finalize after finalize", async () => {
+    const bundle = await buildSampleBundle(tmpDir(), tmpDir());
+    await bundle.finalize();
+    await expect(
+      bundle.addArtifact(writeFixture(tmpDir(), "late.png", "late"), {
+        kind: "screenshot",
+        source: "s",
+        producedBy: "p",
+      }),
+    ).rejects.toMatchObject({ code: "BUNDLE_FINALIZED" });
+    await expect(bundle.finalize()).rejects.toMatchObject({
+      code: "BUNDLE_FINALIZED",
+    });
+  });
+
+  it("refuses to reuse an existing run dir", async () => {
+    const root = tmpDir();
+    const options = {
+      rootDir: root,
+      provenance: PROVENANCE,
+      now: fixedClock(),
+      runId: "fixed-run-id",
+    };
+    createBundle(options);
+    expect(() => createBundle(options)).toThrow(EvidenceError);
+  });
+});
+
+describe("verifyBundle", () => {
+  it("passes a pristine bundle and reports the stored manifest sha", async () => {
+    const bundle = await buildSampleBundle(tmpDir(), tmpDir());
+    const finalized = await bundle.finalize();
+    const report = await verifyBundle(bundle.dir);
+    expect(report.ok).toBe(true);
+    expect(report.artifactCount).toBe(3);
+    expect(report.verifiedCount).toBe(3);
+    expect(report.issues).toEqual([]);
+    expect(report.manifestSha256).toBe(finalized.manifestSha256);
+  });
+
+  it("catches a tampered file, a deleted file, and an unlisted file", async () => {
+    const bundle = await buildSampleBundle(tmpDir(), tmpDir());
+    await bundle.finalize();
+    // Tamper preserving size so the hash check itself is exercised.
+    const tampered = path.join(
+      bundle.dir,
+      "lanes",
+      "e2e",
+      "logs",
+      "server.log",
+    );
+    fs.writeFileSync(tampered, "LOG LINE\n");
+    fs.rmSync(
+      path.join(bundle.dir, "visual", "aesthetic-audit", "desktop", "shot.png"),
+    );
+    fs.writeFileSync(path.join(bundle.dir, "stray.txt"), "not in manifest");
+
+    const report = await verifyBundle(bundle.dir);
+    expect(report.ok).toBe(false);
+    expect(report.verifiedCount).toBe(1);
+    const byIssue = Object.fromEntries(
+      report.issues.map((issue) => [issue.issue, issue.path]),
+    );
+    expect(byIssue["hash-mismatch"]).toBe("lanes/e2e/logs/server.log");
+    expect(byIssue.missing).toBe("visual/aesthetic-audit/desktop/shot.png");
+    expect(byIssue.unlisted).toBe("stray.txt");
+  });
+
+  it("reports size-mismatch when the stored byte count changed", async () => {
+    const bundle = await buildSampleBundle(tmpDir(), tmpDir());
+    await bundle.finalize();
+    const target = path.join(bundle.dir, "lanes", "e2e", "logs", "server.log");
+    fs.appendFileSync(target, "extra");
+    const report = await verifyBundle(bundle.dir);
+    expect(
+      report.issues.some(
+        (issue) =>
+          issue.issue === "size-mismatch" &&
+          issue.path === "lanes/e2e/logs/server.log",
+      ),
+    ).toBe(true);
+  });
+
+  it("throws typed errors for a missing or malformed manifest", async () => {
+    const empty = tmpDir();
+    await expect(verifyBundle(empty)).rejects.toMatchObject({
+      code: "MANIFEST_UNREADABLE",
+    });
+
+    fs.writeFileSync(path.join(empty, "manifest.json"), "not json{");
+    await expect(verifyBundle(empty)).rejects.toMatchObject({
+      code: "MANIFEST_INVALID",
+    });
+
+    fs.writeFileSync(
+      path.join(empty, "manifest.json"),
+      JSON.stringify({ schema: 1, runId: "", createdAt: "x", artifacts: [] }),
+    );
+    await expect(verifyBundle(empty)).rejects.toBeInstanceOf(
+      EvidenceValidationError,
+    );
+  });
+});

--- a/packages/evidence/src/bundle.ts
+++ b/packages/evidence/src/bundle.ts
@@ -100,7 +100,11 @@ export interface VerifyReport {
 }
 
 /** Files at the bundle root that are part of the envelope, not artifacts. */
-const ENVELOPE_FILES = new Set(["manifest.json", "meta.json", "certification.json"]);
+const ENVELOPE_FILES = new Set([
+  "manifest.json",
+  "meta.json",
+  "certification.json",
+]);
 
 function utcStamp(date: Date): string {
   const pad = (value: number) => String(value).padStart(2, "0");
@@ -115,7 +119,9 @@ export function formatRunId(date: Date, commit: string, tier: Tier): string {
   return `${utcStamp(date)}-${commit.slice(0, 7)}-${tier}`;
 }
 
-async function sha256File(filePath: string): Promise<{ sha256: string; bytes: number }> {
+async function sha256File(
+  filePath: string,
+): Promise<{ sha256: string; bytes: number }> {
   const hash = createHash("sha256");
   let bytes = 0;
   for await (const chunk of fs.createReadStream(filePath)) {
@@ -161,9 +167,13 @@ function familyPath(options: AddArtifactOptions, rel: string): string {
     case "html-tree":
       return `html-trees/${rel}`;
     case "log":
-      return lane !== undefined ? `lanes/${lane}/logs/${rel}` : `misc/${source}/${rel}`;
+      return lane !== undefined
+        ? `lanes/${lane}/logs/${rel}`
+        : `misc/${source}/${rel}`;
     case "report":
-      return lane !== undefined ? `lanes/${lane}/${rel}` : `misc/${source}/${rel}`;
+      return lane !== undefined
+        ? `lanes/${lane}/${rel}`
+        : `misc/${source}/${rel}`;
     default:
       return `misc/${source}/${rel}`;
   }
@@ -229,7 +239,10 @@ export class EvidenceBundle {
     options: AddArtifactOptions,
   ): Promise<ArtifactEntry> {
     this.assertOpen("addArtifact");
-    if (options.relativePath !== undefined && options.bundlePath !== undefined) {
+    if (
+      options.relativePath !== undefined &&
+      options.bundlePath !== undefined
+    ) {
       throw new EvidenceError(
         "addArtifact accepts relativePath or bundlePath, not both",
         { code: "ARTIFACT_PLACEMENT_AMBIGUOUS", context: { filePath } },
@@ -290,9 +303,9 @@ export class EvidenceBundle {
    * Sort artifacts, write canonical `manifest.json` and `meta.json`, and seal
    * the bundle. Returns the sha256 of the manifest bytes for signing.
    */
-  async finalize(options: {
-    timings?: Record<string, number>;
-  } = {}): Promise<FinalizeResult> {
+  async finalize(
+    options: { timings?: Record<string, number> } = {},
+  ): Promise<FinalizeResult> {
     this.assertOpen("finalize");
     this.finalized = true;
     const artifacts = [...this.entries].sort((a, b) =>
@@ -374,11 +387,14 @@ export async function verifyBundle(dir: string): Promise<VerifyReport> {
   } catch (error) {
     // error-policy:J3 untrusted disk input — malformed JSON is a typed
     // invalid-manifest failure, never a silently-empty manifest.
-    throw new EvidenceError(`bundle manifest is not valid JSON: ${manifestPath}`, {
-      code: "MANIFEST_INVALID",
-      cause: error,
-      context: { dir },
-    });
+    throw new EvidenceError(
+      `bundle manifest is not valid JSON: ${manifestPath}`,
+      {
+        code: "MANIFEST_INVALID",
+        cause: error,
+        context: { dir },
+      },
+    );
   }
   const manifest = parseManifest(parsed, manifestPath);
 

--- a/packages/evidence/src/bundle.ts
+++ b/packages/evidence/src/bundle.ts
@@ -1,0 +1,436 @@
+/**
+ * Evidence-bundle builder and integrity verifier. One harness run produces one
+ * `evidence/runs/<run-id>/` directory; artifacts are hardlinked (same volume)
+ * or copied in, hashed as stored, and inventoried in `manifest.json` beside a
+ * provenance `meta.json`. Certification (#14546) signs sha256(manifest bytes),
+ * so `finalize()` writes the manifest canonically: artifacts sorted by path
+ * (UTF-16 code-unit order), object keys sorted, no whitespace variance, one
+ * trailing newline — see `canonical.ts`. Byte-stability given identical inputs
+ * is a hard requirement, which is why the clock is injectable rather than
+ * ambient. Default artifact placement is a deterministic kind→family mapping
+ * (below); callers needing exact placement (wave-2 analyzers writing
+ * `analysis.json` beside pixels) pass `bundlePath` explicitly.
+ *
+ *   screenshot → visual/<source>/<rel>      keyframe → video/<source>/keyframes/<rel>
+ *   video      → video/<source>/<rel>       trajectory → trajectories/<source>/<rel>
+ *   html-tree  → html-trees/<rel>           log  → lanes/<lane>/logs/<rel> (lane-less: misc)
+ *   report     → lanes/<lane>/<rel> (lane-less: misc)
+ *   analysis | qa | other → misc/<source>/<rel>
+ */
+
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { canonicalJsonBytes } from "./canonical.ts";
+import { EvidenceError } from "./errors.ts";
+import {
+  type ArtifactEntry,
+  type ArtifactKind,
+  type BundleManifest,
+  type BundleMeta,
+  isBundleRelativePath,
+  parseManifest,
+  type RunnerKind,
+  type Tier,
+} from "./schema.ts";
+
+/** Provenance facts the caller must supply when opening a bundle. */
+export interface BundleProvenance {
+  commit: string;
+  branch: string;
+  runner: RunnerKind;
+  tier: Tier;
+  envFingerprint: Record<string, string>;
+}
+
+/** Options for {@link createBundle}. */
+export interface CreateBundleOptions {
+  /** Directory that holds run dirs, e.g. `<repo>/evidence/runs`. */
+  rootDir: string;
+  provenance: BundleProvenance;
+  /** Injectable clock so tests produce byte-identical manifests. */
+  now?: () => Date;
+  /** Override the derived `<utc stamp>-<shortsha>-<tier>` run id (tests). */
+  runId?: string;
+  /** `auto` hardlinks and falls back to copy across volumes; `copy` always copies. */
+  linkMode?: "auto" | "copy";
+}
+
+/** Options for {@link EvidenceBundle.addArtifact}. */
+export interface AddArtifactOptions {
+  kind: ArtifactKind;
+  /** Producer id recorded on the entry, e.g. `aesthetic-audit`. */
+  source: string;
+  lane?: string;
+  /** Tool or script that produced the artifact. */
+  producedBy: string;
+  /** Path within the kind's family dir; defaults to the file's basename. */
+  relativePath?: string;
+  /** Exact bundle-relative destination, bypassing the family mapping. */
+  bundlePath?: string;
+}
+
+/** Result of {@link EvidenceBundle.finalize}. */
+export interface FinalizeResult {
+  manifest: BundleManifest;
+  meta: BundleMeta;
+  manifestPath: string;
+  metaPath: string;
+  /** sha256 of the canonical manifest bytes — the value certification signs. */
+  manifestSha256: string;
+}
+
+/** One integrity problem found by {@link verifyBundle}. */
+export interface VerifyIssue {
+  path: string;
+  issue: "missing" | "size-mismatch" | "hash-mismatch" | "unlisted";
+  expected?: string;
+  actual?: string;
+}
+
+/** Result of {@link verifyBundle}. */
+export interface VerifyReport {
+  ok: boolean;
+  runId: string;
+  artifactCount: number;
+  verifiedCount: number;
+  issues: VerifyIssue[];
+  /** sha256 of the manifest bytes exactly as stored on disk. */
+  manifestSha256: string;
+}
+
+/** Files at the bundle root that are part of the envelope, not artifacts. */
+const ENVELOPE_FILES = new Set(["manifest.json", "meta.json", "certification.json"]);
+
+function utcStamp(date: Date): string {
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return (
+    `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}` +
+    `-${pad(date.getUTCHours())}${pad(date.getUTCMinutes())}${pad(date.getUTCSeconds())}`
+  );
+}
+
+/** Derive the canonical run id: `<utc yyyymmdd-hhmmss>-<shortsha>-<tier>`. */
+export function formatRunId(date: Date, commit: string, tier: Tier): string {
+  return `${utcStamp(date)}-${commit.slice(0, 7)}-${tier}`;
+}
+
+async function sha256File(filePath: string): Promise<{ sha256: string; bytes: number }> {
+  const hash = createHash("sha256");
+  let bytes = 0;
+  for await (const chunk of fs.createReadStream(filePath)) {
+    hash.update(chunk as Buffer);
+    bytes += (chunk as Buffer).length;
+  }
+  return { sha256: hash.digest("hex"), bytes };
+}
+
+function materialize(
+  sourcePath: string,
+  destPath: string,
+  linkMode: "auto" | "copy",
+  link: (source: string, dest: string) => void = fs.linkSync,
+): void {
+  if (linkMode === "copy") {
+    fs.copyFileSync(sourcePath, destPath);
+    return;
+  }
+  try {
+    link(sourcePath, destPath);
+  } catch (error) {
+    // error-policy:J4 EXDEV means the silo lives on a different volume than the
+    // bundle; copying is the designed fallback. Every other failure rethrows.
+    if ((error as NodeJS.ErrnoException).code !== "EXDEV") {
+      throw error;
+    }
+    fs.copyFileSync(sourcePath, destPath);
+  }
+}
+
+function familyPath(options: AddArtifactOptions, rel: string): string {
+  const { kind, source, lane } = options;
+  switch (kind) {
+    case "screenshot":
+      return `visual/${source}/${rel}`;
+    case "keyframe":
+      return `video/${source}/keyframes/${rel}`;
+    case "video":
+      return `video/${source}/${rel}`;
+    case "trajectory":
+      return `trajectories/${source}/${rel}`;
+    case "html-tree":
+      return `html-trees/${rel}`;
+    case "log":
+      return lane !== undefined ? `lanes/${lane}/logs/${rel}` : `misc/${source}/${rel}`;
+    case "report":
+      return lane !== undefined ? `lanes/${lane}/${rel}` : `misc/${source}/${rel}`;
+    default:
+      return `misc/${source}/${rel}`;
+  }
+}
+
+/**
+ * A bundle being built. Add artifacts, then `finalize()` exactly once; the
+ * builder is single-use and refuses writes after finalization.
+ */
+export class EvidenceBundle {
+  readonly runId: string;
+  readonly dir: string;
+  private readonly now: () => Date;
+  private readonly linkMode: "auto" | "copy";
+  private readonly provenance: BundleProvenance;
+  private readonly startedAt: string;
+  private readonly entries: ArtifactEntry[] = [];
+  private readonly claimedPaths = new Set<string>();
+  private finalized = false;
+  /** Test-only seam for simulating cross-volume link failures (EXDEV). */
+  private readonly link?: (source: string, dest: string) => void;
+
+  constructor(
+    options: CreateBundleOptions & {
+      link?: (source: string, dest: string) => void;
+    },
+  ) {
+    this.now = options.now ?? (() => new Date());
+    this.linkMode = options.linkMode ?? "auto";
+    this.provenance = options.provenance;
+    this.link = options.link;
+    const started = this.now();
+    this.startedAt = started.toISOString();
+    this.runId =
+      options.runId ??
+      formatRunId(started, options.provenance.commit, options.provenance.tier);
+    this.dir = path.join(options.rootDir, this.runId);
+    if (fs.existsSync(this.dir)) {
+      throw new EvidenceError(`bundle directory already exists: ${this.dir}`, {
+        code: "BUNDLE_DIR_EXISTS",
+        context: { dir: this.dir },
+      });
+    }
+    fs.mkdirSync(this.dir, { recursive: true });
+  }
+
+  private assertOpen(operation: string): void {
+    if (this.finalized) {
+      throw new EvidenceError(`${operation} called after finalize()`, {
+        code: "BUNDLE_FINALIZED",
+        context: { runId: this.runId },
+      });
+    }
+  }
+
+  /**
+   * Copy/hardlink `filePath` into the bundle and record its manifest entry.
+   * The hash is computed from the bytes as stored in the bundle, so a corrupt
+   * copy is caught at add time rather than at certification time.
+   */
+  async addArtifact(
+    filePath: string,
+    options: AddArtifactOptions,
+  ): Promise<ArtifactEntry> {
+    this.assertOpen("addArtifact");
+    if (options.relativePath !== undefined && options.bundlePath !== undefined) {
+      throw new EvidenceError(
+        "addArtifact accepts relativePath or bundlePath, not both",
+        { code: "ARTIFACT_PLACEMENT_AMBIGUOUS", context: { filePath } },
+      );
+    }
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(filePath);
+    } catch (error) {
+      // error-policy:J2 context-adding rethrow — a vanished source file must
+      // fail the ingest, not silently shrink the bundle.
+      throw new EvidenceError(`artifact source file missing: ${filePath}`, {
+        code: "ARTIFACT_MISSING",
+        cause: error,
+        context: { filePath },
+      });
+    }
+    if (!stat.isFile()) {
+      throw new EvidenceError(`artifact source is not a file: ${filePath}`, {
+        code: "ARTIFACT_MISSING",
+        context: { filePath },
+      });
+    }
+    const rel = options.relativePath ?? path.basename(filePath);
+    const bundlePath = options.bundlePath ?? familyPath(options, rel);
+    if (!isBundleRelativePath(bundlePath)) {
+      throw new EvidenceError(
+        `artifact bundle path is not bundle-relative posix: ${bundlePath}`,
+        { code: "ARTIFACT_PATH_INVALID", context: { bundlePath, filePath } },
+      );
+    }
+    if (this.claimedPaths.has(bundlePath)) {
+      throw new EvidenceError(
+        `artifact bundle path already claimed: ${bundlePath}`,
+        { code: "ARTIFACT_PATH_COLLISION", context: { bundlePath, filePath } },
+      );
+    }
+    const destPath = path.join(this.dir, ...bundlePath.split("/"));
+    fs.mkdirSync(path.dirname(destPath), { recursive: true });
+    materialize(filePath, destPath, this.linkMode, this.link);
+    const { sha256, bytes } = await sha256File(destPath);
+    const entry: ArtifactEntry = {
+      path: bundlePath,
+      sha256,
+      bytes,
+      kind: options.kind,
+      source: options.source,
+      ...(options.lane !== undefined ? { lane: options.lane } : {}),
+      producedBy: options.producedBy,
+      createdAt: this.now().toISOString(),
+    };
+    this.claimedPaths.add(bundlePath);
+    this.entries.push(entry);
+    return entry;
+  }
+
+  /**
+   * Sort artifacts, write canonical `manifest.json` and `meta.json`, and seal
+   * the bundle. Returns the sha256 of the manifest bytes for signing.
+   */
+  async finalize(options: {
+    timings?: Record<string, number>;
+  } = {}): Promise<FinalizeResult> {
+    this.assertOpen("finalize");
+    this.finalized = true;
+    const artifacts = [...this.entries].sort((a, b) =>
+      a.path < b.path ? -1 : a.path > b.path ? 1 : 0,
+    );
+    const finishedAt = this.now().toISOString();
+    const manifest: BundleManifest = {
+      schema: 1,
+      runId: this.runId,
+      createdAt: finishedAt,
+      artifacts,
+    };
+    const meta: BundleMeta = {
+      schema: 1,
+      runId: this.runId,
+      commit: this.provenance.commit,
+      branch: this.provenance.branch,
+      runner: this.provenance.runner,
+      tier: this.provenance.tier,
+      startedAt: this.startedAt,
+      finishedAt,
+      envFingerprint: this.provenance.envFingerprint,
+      ...(options.timings !== undefined ? { timings: options.timings } : {}),
+    };
+    const manifestBytes = canonicalJsonBytes(manifest);
+    const manifestPath = path.join(this.dir, "manifest.json");
+    const metaPath = path.join(this.dir, "meta.json");
+    fs.writeFileSync(manifestPath, manifestBytes);
+    fs.writeFileSync(metaPath, canonicalJsonBytes(meta));
+    return {
+      manifest,
+      meta,
+      manifestPath,
+      metaPath,
+      manifestSha256: createHash("sha256").update(manifestBytes).digest("hex"),
+    };
+  }
+}
+
+/** Open a new bundle run dir under `options.rootDir`. */
+export function createBundle(options: CreateBundleOptions): EvidenceBundle {
+  return new EvidenceBundle(options);
+}
+
+function* walkFiles(root: string, relBase = ""): Generator<string> {
+  const entries = fs.readdirSync(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const rel = relBase === "" ? entry.name : `${relBase}/${entry.name}`;
+    if (entry.isDirectory()) {
+      yield* walkFiles(path.join(root, entry.name), rel);
+    } else if (entry.isFile()) {
+      yield rel;
+    }
+  }
+}
+
+/**
+ * Re-hash every manifest artifact and sweep for unlisted files. Structural
+ * problems (unreadable/invalid manifest) throw typed errors; per-artifact
+ * integrity problems land in the report so certification can show all of them.
+ */
+export async function verifyBundle(dir: string): Promise<VerifyReport> {
+  const manifestPath = path.join(dir, "manifest.json");
+  let raw: Buffer;
+  try {
+    raw = fs.readFileSync(manifestPath);
+  } catch (error) {
+    // error-policy:J2 context-adding rethrow — no manifest means nothing to
+    // verify against; that is a structural failure, not an empty report.
+    throw new EvidenceError(`bundle manifest unreadable: ${manifestPath}`, {
+      code: "MANIFEST_UNREADABLE",
+      cause: error,
+      context: { dir },
+    });
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw.toString("utf8"));
+  } catch (error) {
+    // error-policy:J3 untrusted disk input — malformed JSON is a typed
+    // invalid-manifest failure, never a silently-empty manifest.
+    throw new EvidenceError(`bundle manifest is not valid JSON: ${manifestPath}`, {
+      code: "MANIFEST_INVALID",
+      cause: error,
+      context: { dir },
+    });
+  }
+  const manifest = parseManifest(parsed, manifestPath);
+
+  const issues: VerifyIssue[] = [];
+  let verifiedCount = 0;
+  for (const artifact of manifest.artifacts) {
+    const artifactPath = path.join(dir, ...artifact.path.split("/"));
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(artifactPath);
+    } catch {
+      // error-policy:J3 a listed-but-absent artifact is exactly what this
+      // report exists to surface; recorded as an issue, not swallowed.
+      issues.push({ path: artifact.path, issue: "missing" });
+      continue;
+    }
+    if (stat.size !== artifact.bytes) {
+      issues.push({
+        path: artifact.path,
+        issue: "size-mismatch",
+        expected: String(artifact.bytes),
+        actual: String(stat.size),
+      });
+      continue;
+    }
+    const { sha256 } = await sha256File(artifactPath);
+    if (sha256 !== artifact.sha256) {
+      issues.push({
+        path: artifact.path,
+        issue: "hash-mismatch",
+        expected: artifact.sha256,
+        actual: sha256,
+      });
+      continue;
+    }
+    verifiedCount += 1;
+  }
+
+  const listed = new Set(manifest.artifacts.map((artifact) => artifact.path));
+  for (const rel of walkFiles(dir)) {
+    if (ENVELOPE_FILES.has(rel)) continue;
+    if (!listed.has(rel)) {
+      issues.push({ path: rel, issue: "unlisted" });
+    }
+  }
+
+  return {
+    ok: issues.length === 0,
+    runId: manifest.runId,
+    artifactCount: manifest.artifacts.length,
+    verifiedCount,
+    issues,
+    manifestSha256: createHash("sha256").update(raw).digest("hex"),
+  };
+}

--- a/packages/evidence/src/canonical.test.ts
+++ b/packages/evidence/src/canonical.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Byte-stability tests for canonical JSON: key order independence, exact byte
+ * form, and hard rejection of values JSON cannot represent deterministically.
+ */
+
+import { describe, expect, it } from "vitest";
+import { canonicalJson, canonicalJsonBytes } from "./canonical.ts";
+import { EvidenceError } from "./errors.ts";
+
+describe("canonicalJson", () => {
+  it("produces identical text for differently-ordered keys", () => {
+    const a = { b: 1, a: { d: [1, 2], c: "x" } };
+    const b = { a: { c: "x", d: [1, 2] }, b: 1 };
+    expect(canonicalJson(a)).toBe(canonicalJson(b));
+    expect(canonicalJson(a)).toBe('{"a":{"c":"x","d":[1,2]},"b":1}');
+  });
+
+  it("preserves array order", () => {
+    expect(canonicalJson([3, 1, 2])).toBe("[3,1,2]");
+  });
+
+  it("skips undefined object values like JSON.stringify", () => {
+    expect(canonicalJson({ a: 1, b: undefined })).toBe('{"a":1}');
+  });
+
+  it("escapes strings via JSON string rules", () => {
+    expect(canonicalJson({ "a\nb": 'q"' })).toBe('{"a\\nb":"q\\""}');
+  });
+
+  it.each([
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["bigint", 1n],
+    ["function", () => 1],
+    ["undefined root", undefined],
+    ["undefined array element", [1, undefined]],
+  ])("throws CANONICAL_UNSERIALIZABLE for %s", (_label, value) => {
+    try {
+      canonicalJson(value);
+      expect.unreachable("should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(EvidenceError);
+      expect((error as EvidenceError).code).toBe("CANONICAL_UNSERIALIZABLE");
+    }
+  });
+});
+
+describe("canonicalJsonBytes", () => {
+  it("is the canonical text plus exactly one trailing newline, UTF-8", () => {
+    const bytes = canonicalJsonBytes({ a: "é" });
+    expect(bytes.equals(Buffer.from('{"a":"é"}\n', "utf8"))).toBe(true);
+  });
+});

--- a/packages/evidence/src/canonical.ts
+++ b/packages/evidence/src/canonical.ts
@@ -1,0 +1,73 @@
+/**
+ * Canonical JSON serialization for signed evidence files. Certification signs
+ * sha256(manifest bytes), so the byte form must be a pure function of the
+ * value: object keys sorted by UTF-16 code unit, arrays in caller order, no
+ * insignificant whitespace, UTF-8 encoding, and exactly one trailing newline
+ * (the newline is part of the signed bytes). Values JSON cannot represent
+ * deterministically (non-finite numbers, bigint, functions, symbols) throw
+ * instead of degrading to `null` — a fabricated `null` in a signed manifest
+ * would be silent data loss.
+ */
+
+import { EvidenceError } from "./errors.ts";
+
+function canonicalize(value: unknown, path: string): string {
+  if (value === null) return "null";
+  switch (typeof value) {
+    case "string":
+      return JSON.stringify(value);
+    case "boolean":
+      return value ? "true" : "false";
+    case "number":
+      if (!Number.isFinite(value)) {
+        throw new EvidenceError(
+          `canonical JSON cannot represent non-finite number at ${path}`,
+          { code: "CANONICAL_UNSERIALIZABLE", context: { path } },
+        );
+      }
+      return JSON.stringify(value);
+    case "object": {
+      if (Array.isArray(value)) {
+        const items = value.map((item, index) => {
+          if (item === undefined) {
+            throw new EvidenceError(
+              `canonical JSON cannot represent undefined array element at ${path}[${index}]`,
+              { code: "CANONICAL_UNSERIALIZABLE", context: { path, index } },
+            );
+          }
+          return canonicalize(item, `${path}[${index}]`);
+        });
+        return `[${items.join(",")}]`;
+      }
+      const record = value as Record<string, unknown>;
+      const keys = Object.keys(record)
+        .filter((key) => record[key] !== undefined)
+        .sort();
+      const members = keys.map(
+        (key) =>
+          `${JSON.stringify(key)}:${canonicalize(record[key], `${path}.${key}`)}`,
+      );
+      return `{${members.join(",")}}`;
+    }
+    default:
+      throw new EvidenceError(
+        `canonical JSON cannot represent ${typeof value} at ${path}`,
+        { code: "CANONICAL_UNSERIALIZABLE", context: { path, kind: typeof value } },
+      );
+  }
+}
+
+/** Serialize `value` to its canonical JSON text (no trailing newline). */
+export function canonicalJson(value: unknown): string {
+  if (value === undefined) {
+    throw new EvidenceError("canonical JSON cannot represent undefined", {
+      code: "CANONICAL_UNSERIALIZABLE",
+    });
+  }
+  return canonicalize(value, "$");
+}
+
+/** Canonical UTF-8 bytes of `value`: canonical JSON plus one trailing newline. */
+export function canonicalJsonBytes(value: unknown): Buffer {
+  return Buffer.from(`${canonicalJson(value)}\n`, "utf8");
+}

--- a/packages/evidence/src/canonical.ts
+++ b/packages/evidence/src/canonical.ts
@@ -52,7 +52,10 @@ function canonicalize(value: unknown, path: string): string {
     default:
       throw new EvidenceError(
         `canonical JSON cannot represent ${typeof value} at ${path}`,
-        { code: "CANONICAL_UNSERIALIZABLE", context: { path, kind: typeof value } },
+        {
+          code: "CANONICAL_UNSERIALIZABLE",
+          context: { path, kind: typeof value },
+        },
       );
   }
 }

--- a/packages/evidence/src/cli.test.ts
+++ b/packages/evidence/src/cli.test.ts
@@ -1,0 +1,197 @@
+/**
+ * End-to-end CLI tests: `runCli` driven against a real tmp git repository
+ * with real fixture silos — create a bundle, verify it, tamper with it, and
+ * confirm usage errors exit non-zero. Output is captured through the injected
+ * writer instead of spawning a child process; everything else is real.
+ */
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { verifyBundle } from "./bundle.ts";
+import { runCli } from "./cli.ts";
+import { parseManifest, parseMeta } from "./schema.ts";
+
+const tmpDirs: string[] = [];
+
+function tmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "evidence-cli-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function capture(): {
+  io: { out(l: string): void; err(l: string): void };
+  outLines: string[];
+  errLines: string[];
+} {
+  const outLines: string[] = [];
+  const errLines: string[] = [];
+  return {
+    io: {
+      out: (l: string) => outLines.push(l),
+      err: (l: string) => errLines.push(l),
+    },
+    outLines,
+    errLines,
+  };
+}
+
+function initFixtureRepo(): string {
+  const repo = tmpDir();
+  execFileSync("git", ["init", "--initial-branch", "feat/cli-test"], {
+    cwd: repo,
+  });
+  execFileSync("git", ["config", "user.email", "evidence-test@example.com"], {
+    cwd: repo,
+  });
+  execFileSync("git", ["config", "user.name", "Evidence Test"], { cwd: repo });
+  const auditDir = path.join(
+    repo,
+    "packages",
+    "app",
+    "aesthetic-audit-output",
+    "desktop",
+  );
+  fs.mkdirSync(auditDir, { recursive: true });
+  fs.writeFileSync(path.join(auditDir, "home.png"), "png-bytes");
+  fs.writeFileSync(path.join(auditDir, "home--hover.png"), "png-hover-bytes");
+  const scenarioDir = path.join(repo, "reports", "scenarios", "live");
+  fs.mkdirSync(scenarioDir, { recursive: true });
+  fs.writeFileSync(path.join(scenarioDir, "native.jsonl"), "{}\n");
+  fs.writeFileSync(path.join(repo, "tracked.txt"), "tracked\n");
+  execFileSync("git", ["add", "tracked.txt"], { cwd: repo });
+  execFileSync("git", ["commit", "-m", "initial", "--no-gpg-sign"], {
+    cwd: repo,
+  });
+  return repo;
+}
+
+function bundleDirFrom(outLines: string[]): string {
+  const manifestLine = outLines.find((line) => line.includes("manifest:"));
+  expect(manifestLine).toBeDefined();
+  return path.dirname((manifestLine as string).split("manifest:")[1].trim());
+}
+
+describe("runCli create", () => {
+  it("creates a verified bundle from real silos and reports honest statuses", async () => {
+    const repo = initFixtureRepo();
+    const out = tmpDir();
+    const { io, outLines } = capture();
+    const code = await runCli(
+      ["create", "--tier", "cpu", "--out", out, "--repo-root", repo],
+      io,
+    );
+    expect(code).toBe(0);
+
+    const rendered = outLines.join("\n");
+    expect(rendered).toContain("aesthetic-audit");
+    expect(rendered).toMatch(/aesthetic-audit\s+ingested\s+2/);
+    expect(rendered).toMatch(/scenario-runner\s+ingested\s+1/);
+    expect(rendered).toMatch(/e2e-recordings\s+absent\s+-/);
+    expect(rendered).toContain("artifacts: 3");
+
+    const dir = bundleDirFrom(outLines);
+    const manifest = parseManifest(
+      JSON.parse(fs.readFileSync(path.join(dir, "manifest.json"), "utf8")),
+      "cli test",
+    );
+    expect(manifest.artifacts.map((entry) => entry.path)).toEqual([
+      "trajectories/scenario-runner/repo/live/native.jsonl",
+      "visual/aesthetic-audit/desktop/home--hover.png",
+      "visual/aesthetic-audit/desktop/home.png",
+    ]);
+
+    const meta = parseMeta(
+      JSON.parse(fs.readFileSync(path.join(dir, "meta.json"), "utf8")),
+      "cli test",
+    );
+    const head = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: repo,
+      encoding: "utf8",
+    }).trim();
+    expect(meta.commit).toBe(head);
+    expect(meta.branch).toBe("feat/cli-test");
+    expect(meta.tier).toBe("cpu");
+    expect(meta.runId).toBe(manifest.runId);
+    expect(dir.endsWith(manifest.runId)).toBe(true);
+    expect(meta.timings?.["ingest.all"]).toBeTypeOf("number");
+
+    const report = await verifyBundle(dir);
+    expect(report.ok).toBe(true);
+    expect(report.verifiedCount).toBe(3);
+  });
+
+  it("fails loud outside a git repository", async () => {
+    const notRepo = tmpDir();
+    const { io, errLines } = capture();
+    const code = await runCli(
+      ["create", "--tier", "cpu", "--out", tmpDir(), "--repo-root", notRepo],
+      io,
+    );
+    expect(code).toBe(1);
+    expect(errLines.join("\n")).toContain("GIT_PROVENANCE_UNAVAILABLE");
+  });
+
+  it.each([
+    ["missing tier", ["create"]],
+    ["bad tier", ["create", "--tier", "quantum"]],
+    ["unknown flag", ["create", "--tier", "cpu", "--wat"]],
+    ["unknown command", ["bogus"]],
+  ])("exits non-zero on %s", async (_label, argv) => {
+    const { io } = capture();
+    expect(await runCli(argv, io)).toBe(1);
+  });
+
+  it("prints usage and exits zero with no command or --help", async () => {
+    const bare = capture();
+    expect(await runCli([], bare.io)).toBe(0);
+    expect(bare.errLines.join("\n")).toContain("Usage:");
+    const help = capture();
+    expect(await runCli(["--help"], help.io)).toBe(0);
+  });
+});
+
+describe("runCli verify", () => {
+  it("passes a pristine bundle and fails a tampered one", async () => {
+    const repo = initFixtureRepo();
+    const out = tmpDir();
+    const created = capture();
+    expect(
+      await runCli(
+        ["create", "--tier", "cpu", "--out", out, "--repo-root", repo],
+        created.io,
+      ),
+    ).toBe(0);
+    const dir = bundleDirFrom(created.outLines);
+
+    const pristine = capture();
+    expect(await runCli(["verify", dir], pristine.io)).toBe(0);
+    expect(pristine.outLines.join("\n")).toContain("OK");
+
+    fs.writeFileSync(
+      path.join(dir, "visual", "aesthetic-audit", "desktop", "home.png"),
+      "TAMPERED!!",
+    );
+    const tampered = capture();
+    expect(await runCli(["verify", dir], tampered.io)).toBe(1);
+    expect(tampered.outLines.join("\n")).toContain("FAILED");
+    expect(tampered.errLines.join("\n")).toContain(
+      "visual/aesthetic-audit/desktop/home.png",
+    );
+  });
+
+  it("requires exactly one bundle directory", async () => {
+    const { io } = capture();
+    expect(await runCli(["verify"], io)).toBe(1);
+    expect(await runCli(["verify", "a", "b"], io)).toBe(1);
+  });
+});

--- a/packages/evidence/src/cli.ts
+++ b/packages/evidence/src/cli.ts
@@ -1,0 +1,183 @@
+/**
+ * Thin CLI over the bundle library: `create` opens a bundle, runs every silo
+ * ingestor, and finalizes; `verify` re-hashes an existing bundle. All logic
+ * lives in the library modules — this file only parses argv, wires provenance,
+ * and formats output. It is a process boundary, so writing to the injected
+ * stdout/stderr (console-backed when run as a script) is the product here, not
+ * server logging; the library itself never logs. Tests call `runCli` directly
+ * with a captured writer instead of spawning a child process.
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createBundle, verifyBundle } from "./bundle.ts";
+import { EvidenceError } from "./errors.ts";
+import { ingestAllSilos } from "./ingest.ts";
+import {
+  buildEnvFingerprint,
+  collectGitProvenance,
+  resolveRunnerKind,
+} from "./provenance.ts";
+import { TIERS, type Tier } from "./schema.ts";
+
+const USAGE = `Usage:
+  bundle:create -- --tier <cpu|gpu|full> [--out <dir>] [--repo-root <dir>]
+  bundle:verify -- <bundle-dir>
+
+create   Open a new evidence bundle, ingest every known silo, finalize.
+verify   Re-hash every artifact in an existing bundle and report integrity.`;
+
+/** Output sinks; injectable so tests capture instead of spawning. */
+export interface CliIo {
+  out(line: string): void;
+  err(line: string): void;
+}
+
+function parseCreateArgs(argv: string[]): {
+  tier: Tier;
+  outDir?: string;
+  repoRoot?: string;
+} {
+  let tier: Tier | undefined;
+  let outDir: string | undefined;
+  let repoRoot: string | undefined;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const value = () => {
+      const next = argv[index + 1];
+      if (next === undefined) {
+        throw new EvidenceError(`${arg} requires a value`, {
+          code: "CLI_USAGE",
+        });
+      }
+      index += 1;
+      return next;
+    };
+    if (arg === "--tier") {
+      const raw = value();
+      if (!(TIERS as readonly string[]).includes(raw)) {
+        throw new EvidenceError(
+          `--tier must be one of ${TIERS.join("|")}, got: ${raw}`,
+          { code: "CLI_USAGE" },
+        );
+      }
+      tier = raw as Tier;
+    } else if (arg === "--out") {
+      outDir = value();
+    } else if (arg === "--repo-root") {
+      repoRoot = value();
+    } else {
+      throw new EvidenceError(`unknown argument: ${arg}`, { code: "CLI_USAGE" });
+    }
+  }
+  if (tier === undefined) {
+    throw new EvidenceError("--tier is required", { code: "CLI_USAGE" });
+  }
+  return { tier, outDir, repoRoot };
+}
+
+function defaultRepoRoot(): string {
+  // src/cli.ts → src → packages/evidence → packages → repo root.
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+}
+
+async function runCreate(argv: string[], io: CliIo): Promise<number> {
+  const args = parseCreateArgs(argv);
+  const repoRoot = path.resolve(args.repoRoot ?? defaultRepoRoot());
+  const rootDir = path.resolve(
+    args.outDir ?? path.join(repoRoot, "evidence", "runs"),
+  );
+  const git = collectGitProvenance(repoRoot);
+  const runner = resolveRunnerKind(process.env);
+  const bundle = createBundle({
+    rootDir,
+    provenance: {
+      commit: git.commit,
+      branch: git.branch,
+      runner,
+      tier: args.tier,
+      envFingerprint: buildEnvFingerprint(args.tier),
+    },
+  });
+  const ingestStart = Date.now();
+  const results = await ingestAllSilos(bundle, repoRoot);
+  const finalized = await bundle.finalize({
+    timings: { "ingest.all": Date.now() - ingestStart },
+  });
+
+  const siloWidth = Math.max(...results.map((result) => result.silo.length));
+  io.out(`bundle ${bundle.runId}`);
+  io.out(`  commit ${git.commit} (${git.branch}) runner=${runner} tier=${args.tier}`);
+  io.out("");
+  for (const result of results) {
+    io.out(
+      `  ${result.silo.padEnd(siloWidth)}  ${result.status.padEnd(8)}  ${
+        result.status === "absent" ? "-" : String(result.artifactCount)
+      }`,
+    );
+  }
+  const total = results.reduce((sum, result) => sum + result.artifactCount, 0);
+  io.out("");
+  io.out(`  artifacts: ${total}`);
+  io.out(`  manifest:  ${finalized.manifestPath}`);
+  io.out(`  sha256:    ${finalized.manifestSha256}`);
+  return 0;
+}
+
+async function runVerify(argv: string[], io: CliIo): Promise<number> {
+  const [dir, ...rest] = argv;
+  if (dir === undefined || rest.length > 0) {
+    throw new EvidenceError("verify takes exactly one bundle directory", {
+      code: "CLI_USAGE",
+    });
+  }
+  const report = await verifyBundle(path.resolve(dir));
+  io.out(`bundle ${report.runId}`);
+  io.out(
+    `  artifacts: ${report.artifactCount}  verified: ${report.verifiedCount}  issues: ${report.issues.length}`,
+  );
+  io.out(`  manifest sha256: ${report.manifestSha256}`);
+  for (const issue of report.issues) {
+    const detail =
+      issue.expected !== undefined
+        ? ` (expected ${issue.expected}, actual ${issue.actual})`
+        : "";
+    io.err(`  ${issue.issue}: ${issue.path}${detail}`);
+  }
+  io.out(report.ok ? "  OK" : "  FAILED");
+  return report.ok ? 0 : 1;
+}
+
+/** Parse argv (without node/script prefix) and run; returns the exit code. */
+export async function runCli(argv: string[], io: CliIo): Promise<number> {
+  const [command, ...rest] = argv;
+  try {
+    if (command === "create") return await runCreate(rest, io);
+    if (command === "verify") return await runVerify(rest, io);
+    io.err(USAGE);
+    return command === undefined || command === "--help" || command === "-h"
+      ? 0
+      : 1;
+  } catch (error) {
+    // error-policy:J1 process boundary — translate typed failures into a
+    // structured stderr line + non-zero exit for the invoking harness.
+    if (error instanceof EvidenceError) {
+      io.err(`error [${error.code}]: ${error.message}`);
+      if (error.code === "CLI_USAGE") io.err(USAGE);
+      return 1;
+    }
+    throw error;
+  }
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  const io: CliIo = {
+    out: (line) => process.stdout.write(`${line}\n`),
+    err: (line) => process.stderr.write(`${line}\n`),
+  };
+  process.exitCode = await runCli(process.argv.slice(2), io);
+}

--- a/packages/evidence/src/cli.ts
+++ b/packages/evidence/src/cli.ts
@@ -67,7 +67,9 @@ function parseCreateArgs(argv: string[]): {
     } else if (arg === "--repo-root") {
       repoRoot = value();
     } else {
-      throw new EvidenceError(`unknown argument: ${arg}`, { code: "CLI_USAGE" });
+      throw new EvidenceError(`unknown argument: ${arg}`, {
+        code: "CLI_USAGE",
+      });
     }
   }
   if (tier === undefined) {
@@ -107,7 +109,9 @@ async function runCreate(argv: string[], io: CliIo): Promise<number> {
 
   const siloWidth = Math.max(...results.map((result) => result.silo.length));
   io.out(`bundle ${bundle.runId}`);
-  io.out(`  commit ${git.commit} (${git.branch}) runner=${runner} tier=${args.tier}`);
+  io.out(
+    `  commit ${git.commit} (${git.branch}) runner=${runner} tier=${args.tier}`,
+  );
   io.out("");
   for (const result of results) {
     io.out(

--- a/packages/evidence/src/errors.ts
+++ b/packages/evidence/src/errors.ts
@@ -1,0 +1,66 @@
+/**
+ * Typed errors for the evidence-bundle pipeline. This package is a leaf
+ * certification tool that must run in minimal CI/vast containers, so it does
+ * not depend on the framework runtime; `EvidenceError` mirrors the shape of
+ * `ElizaError` (`packages/core/src/errors.ts`: `code`, `context`, preserved
+ * `cause`) so throw sites stay machine-classifiable without pulling in
+ * `@elizaos/core`. Validation failures at runtime boundaries (reading a
+ * manifest from disk) surface as `EvidenceValidationError` carrying the exact
+ * per-field issues — never a silently-repaired object (error-policy J3).
+ */
+
+/** Options accepted by the {@link EvidenceError} constructor. */
+export interface EvidenceErrorOptions {
+  /** Stable, grep-able classification key (e.g. `MANIFEST_INVALID`). */
+  code: string;
+  /** Underlying error being wrapped; preserved on `.cause`. */
+  cause?: unknown;
+  /** Structured, serializable context for logs. */
+  context?: Record<string, unknown>;
+}
+
+/** Structured error with a classification `code` and preserved `cause` chain. */
+export class EvidenceError extends Error {
+  override readonly name: string = "EvidenceError";
+  readonly code: string;
+  readonly context?: Record<string, unknown>;
+
+  constructor(message: string, options: EvidenceErrorOptions) {
+    super(
+      message,
+      options.cause !== undefined ? { cause: options.cause } : undefined,
+    );
+    this.code = options.code;
+    this.context = options.context;
+    // Restore the prototype chain for reliable `instanceof` across the
+    // transpiled ES target boundary.
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/** One concrete reason a value failed schema validation. */
+export interface ValidationIssue {
+  /** Dotted path into the offending value (e.g. `artifacts.3.sha256`). */
+  path: string;
+  message: string;
+}
+
+/**
+ * Thrown when an untrusted value (manifest/meta read from disk, CLI input)
+ * fails schema validation. Carries every issue so callers can report the full
+ * failure instead of the first field encountered.
+ */
+export class EvidenceValidationError extends EvidenceError {
+  override readonly name: string = "EvidenceValidationError";
+  readonly issues: readonly ValidationIssue[];
+
+  constructor(
+    message: string,
+    issues: readonly ValidationIssue[],
+    options: EvidenceErrorOptions,
+  ) {
+    super(message, options);
+    this.issues = issues;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/packages/evidence/src/index.ts
+++ b/packages/evidence/src/index.ts
@@ -1,0 +1,48 @@
+/** Public surface of @elizaos/evidence: schema, bundle builder, provenance, ingestors. */
+
+export {
+  type AddArtifactOptions,
+  type BundleProvenance,
+  createBundle,
+  type CreateBundleOptions,
+  EvidenceBundle,
+  type FinalizeResult,
+  formatRunId,
+  verifyBundle,
+  type VerifyIssue,
+  type VerifyReport,
+} from "./bundle.ts";
+export { canonicalJson, canonicalJsonBytes } from "./canonical.ts";
+export {
+  EvidenceError,
+  type EvidenceErrorOptions,
+  EvidenceValidationError,
+  type ValidationIssue,
+} from "./errors.ts";
+export {
+  ingestAllSilos,
+  ingestNamedSilo,
+  type IngestResult,
+  SILO_NAMES,
+} from "./ingest.ts";
+export {
+  buildEnvFingerprint,
+  collectGitProvenance,
+  type GitProvenance,
+  type ProcessFacts,
+  resolveRunnerKind,
+} from "./provenance.ts";
+export {
+  ARTIFACT_KINDS,
+  type ArtifactEntry,
+  type ArtifactKind,
+  type BundleManifest,
+  type BundleMeta,
+  isBundleRelativePath,
+  parseManifest,
+  parseMeta,
+  RUNNER_KINDS,
+  type RunnerKind,
+  type Tier,
+  TIERS,
+} from "./schema.ts";

--- a/packages/evidence/src/index.ts
+++ b/packages/evidence/src/index.ts
@@ -3,14 +3,14 @@
 export {
   type AddArtifactOptions,
   type BundleProvenance,
-  createBundle,
   type CreateBundleOptions,
+  createBundle,
   EvidenceBundle,
   type FinalizeResult,
   formatRunId,
-  verifyBundle,
   type VerifyIssue,
   type VerifyReport,
+  verifyBundle,
 } from "./bundle.ts";
 export { canonicalJson, canonicalJsonBytes } from "./canonical.ts";
 export {
@@ -20,9 +20,9 @@ export {
   type ValidationIssue,
 } from "./errors.ts";
 export {
+  type IngestResult,
   ingestAllSilos,
   ingestNamedSilo,
-  type IngestResult,
   SILO_NAMES,
 } from "./ingest.ts";
 export {
@@ -43,6 +43,6 @@ export {
   parseMeta,
   RUNNER_KINDS,
   type RunnerKind,
-  type Tier,
   TIERS,
+  type Tier,
 } from "./schema.ts";

--- a/packages/evidence/src/ingest.test.ts
+++ b/packages/evidence/src/ingest.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Silo-ingestor tests against fixture trees replicating each silo's real
+ * on-disk shape (e2e-recordings run dirs, aesthetic-audit output, device-e2e
+ * bundle dirs from packages/app/scripts/lib/device-e2e-bundle.mjs, Playwright
+ * test-results, walkthrough/live-run reports, scenario-runner reports). Also
+ * pins the honesty contract: an absent silo reports `absent`, an existing but
+ * empty silo reports `ingested` with zero artifacts — never the same result.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createBundle, type EvidenceBundle } from "./bundle.ts";
+import { EvidenceError } from "./errors.ts";
+import { ingestAllSilos, ingestNamedSilo, SILO_NAMES } from "./ingest.ts";
+import type { ArtifactEntry } from "./schema.ts";
+
+const tmpDirs: string[] = [];
+
+function tmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "evidence-ingest-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function write(repoRoot: string, relPath: string, content: string): void {
+  const filePath = path.join(repoRoot, ...relPath.split("/"));
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+}
+
+/** Fixture repo mirroring the real silo layouts inspected on develop. */
+function buildFixtureRepo(): string {
+  const repo = tmpDir();
+  // scripts/e2e-recordings/run-all.mjs output: per-package Playwright results.
+  write(
+    repo,
+    "e2e-recordings/app-ui/test-results/chat-flow/video.webm",
+    "webm",
+  );
+  write(repo, "e2e-recordings/app-ui/test-results/chat-flow/final.png", "png");
+  write(repo, "e2e-recordings/contact-sheet.html", "<html></html>");
+  // packages/app audit:app output.
+  write(repo, "packages/app/aesthetic-audit-output/desktop/chat.png", "png-d");
+  write(
+    repo,
+    "packages/app/aesthetic-audit-output/desktop/chat--hover.png",
+    "png-h",
+  );
+  write(repo, "packages/app/aesthetic-audit-output/mobile/chat.png", "png-m");
+  write(
+    repo,
+    "packages/app/aesthetic-audit-output/manual-review/chat.md",
+    "verdict: good",
+  );
+  write(repo, "packages/app/aesthetic-audit-output/report.json", "{}");
+  // device-e2e bundle dir shape (summary.json + junit.xml + inline/).
+  const deviceRun =
+    "packages/app/device-e2e-output/android-2026-07-05T01-02-03-004Z";
+  write(repo, `${deviceRun}/summary.json`, "{}");
+  write(repo, `${deviceRun}/junit.xml`, "<testsuite/>");
+  write(repo, `${deviceRun}/inline/screen.jpg`, "jpg");
+  write(repo, `${deviceRun}/inline/walkthrough.mp4`, "mp4");
+  // Playwright test-results.
+  write(
+    repo,
+    "packages/app/test-results/chat-smoke/test-failed-1.png",
+    "png-f",
+  );
+  write(repo, "packages/app/test-results/.last-run.json", "{}");
+  // Walkthrough reports exist under BOTH roots — exercises namespacing.
+  write(repo, "reports/walkthrough/desktop.mp4", "mp4-repo");
+  write(repo, "packages/app/reports/walkthrough/mobile.mp4", "mp4-app");
+  // Live test runs.
+  write(repo, "reports/live-test-runs/run-1/server.log", "log");
+  // scenario-runner reports + repo-level scenario reports.
+  write(repo, "packages/scenario-runner/reports/report.json", "{}");
+  write(repo, "reports/scenarios/live/native.jsonl", "{}\n");
+  // Noise that must never be ingested.
+  write(repo, "e2e-recordings/node_modules/pkg/index.js", "js");
+  return repo;
+}
+
+async function build(repo: string): Promise<{
+  bundle: EvidenceBundle;
+  results: Awaited<ReturnType<typeof ingestAllSilos>>;
+  artifacts: ArtifactEntry[];
+}> {
+  const bundle = createBundle({
+    rootDir: tmpDir(),
+    provenance: {
+      commit: "abcdef0123456789abcdef0123456789abcdef01",
+      branch: "feat/test",
+      runner: "local",
+      tier: "cpu",
+      envFingerprint: {
+        node: "v24",
+        platform: "linux",
+        arch: "x64",
+        tier: "cpu",
+      },
+    },
+  });
+  const results = await ingestAllSilos(bundle, repo);
+  const { manifest } = await bundle.finalize();
+  return { bundle, results, artifacts: manifest.artifacts };
+}
+
+describe("ingestAllSilos", () => {
+  it("ingests every fixture silo with honest per-silo counts", async () => {
+    const { results } = await build(buildFixtureRepo());
+    expect(Object.fromEntries(results.map((r) => [r.silo, r]))).toEqual({
+      "e2e-recordings": {
+        silo: "e2e-recordings",
+        status: "ingested",
+        artifactCount: 3,
+      },
+      "aesthetic-audit": {
+        silo: "aesthetic-audit",
+        status: "ingested",
+        artifactCount: 5,
+      },
+      "device-e2e": {
+        silo: "device-e2e",
+        status: "ingested",
+        artifactCount: 4,
+      },
+      "playwright-test-results": {
+        silo: "playwright-test-results",
+        status: "ingested",
+        artifactCount: 2,
+      },
+      "walkthrough-reports": {
+        silo: "walkthrough-reports",
+        status: "ingested",
+        artifactCount: 2,
+      },
+      "live-test-runs": {
+        silo: "live-test-runs",
+        status: "ingested",
+        artifactCount: 1,
+      },
+      "scenario-runner": {
+        silo: "scenario-runner",
+        status: "ingested",
+        artifactCount: 2,
+      },
+    });
+  });
+
+  it("classifies kinds, lanes, and sources per silo", async () => {
+    const { artifacts } = await build(buildFixtureRepo());
+    const byPath = Object.fromEntries(
+      artifacts.map((entry) => [entry.path, entry]),
+    );
+
+    // Manual-review markdown is analysis, not a generated report.
+    const review = byPath["misc/aesthetic-audit/manual-review/chat.md"];
+    expect(review).toMatchObject({
+      kind: "analysis",
+      source: "aesthetic-audit",
+    });
+    expect(review.lane).toBeUndefined();
+
+    expect(
+      byPath["visual/aesthetic-audit/desktop/chat--hover.png"],
+    ).toMatchObject({
+      kind: "screenshot",
+    });
+    expect(
+      byPath["video/e2e-recordings/app-ui/test-results/chat-flow/video.webm"],
+    ).toMatchObject({ kind: "video", lane: "e2e" });
+    expect(byPath["lanes/e2e/contact-sheet.html"]).toMatchObject({
+      kind: "report",
+      source: "e2e-recordings",
+    });
+    expect(
+      byPath["trajectories/scenario-runner/repo/live/native.jsonl"],
+    ).toMatchObject({ kind: "trajectory", lane: "scenario" });
+    expect(byPath["lanes/scenario/runner/report.json"]).toMatchObject({
+      kind: "report",
+      source: "scenario-runner",
+    });
+    expect(
+      byPath["lanes/native/app/android-2026-07-05T01-02-03-004Z/summary.json"],
+    ).toMatchObject({ kind: "report", source: "device-e2e" });
+    expect(
+      byPath[
+        "visual/device-e2e/app/android-2026-07-05T01-02-03-004Z/inline/screen.jpg"
+      ],
+    ).toMatchObject({ kind: "screenshot", lane: "native" });
+    expect(
+      byPath["visual/playwright/chat-smoke/test-failed-1.png"],
+    ).toMatchObject({
+      kind: "screenshot",
+      lane: "e2e",
+    });
+
+    // Multi-root walkthrough silo namespaces by root label.
+    expect(byPath["video/walkthrough/repo/desktop.mp4"]).toBeDefined();
+    expect(byPath["video/walkthrough/app/mobile.mp4"]).toBeDefined();
+
+    // node_modules content is never evidence.
+    expect(artifacts.some((entry) => entry.path.includes("node_modules"))).toBe(
+      false,
+    );
+  });
+
+  it("copies real bytes into the bundle", async () => {
+    const repo = buildFixtureRepo();
+    const { bundle, artifacts } = await build(repo);
+    const review = artifacts.find(
+      (entry) => entry.path === "misc/aesthetic-audit/manual-review/chat.md",
+    );
+    expect(review).toBeDefined();
+    const stored = path.join(
+      bundle.dir,
+      ...(review as ArtifactEntry).path.split("/"),
+    );
+    expect(fs.readFileSync(stored, "utf8")).toBe("verdict: good");
+  });
+
+  it("distinguishes an absent silo from an empty one", async () => {
+    const repo = tmpDir();
+    // aesthetic-audit dir exists but is empty; every other silo is absent.
+    fs.mkdirSync(path.join(repo, "packages", "app", "aesthetic-audit-output"), {
+      recursive: true,
+    });
+    const { results } = await build(repo);
+    const byName = Object.fromEntries(results.map((r) => [r.silo, r]));
+    expect(byName["aesthetic-audit"]).toEqual({
+      silo: "aesthetic-audit",
+      status: "ingested",
+      artifactCount: 0,
+    });
+    expect(byName["e2e-recordings"]).toEqual({
+      silo: "e2e-recordings",
+      status: "absent",
+      artifactCount: 0,
+    });
+    for (const name of SILO_NAMES) {
+      if (name === "aesthetic-audit") continue;
+      expect(byName[name].status).toBe("absent");
+    }
+  });
+});
+
+describe("ingestNamedSilo", () => {
+  it("runs a single silo by name", async () => {
+    const repo = buildFixtureRepo();
+    const bundle = createBundle({
+      rootDir: tmpDir(),
+      provenance: {
+        commit: "abcdef0123456789abcdef0123456789abcdef01",
+        branch: "feat/test",
+        runner: "local",
+        tier: "cpu",
+        envFingerprint: {
+          node: "v24",
+          platform: "linux",
+          arch: "x64",
+          tier: "cpu",
+        },
+      },
+    });
+    const result = await ingestNamedSilo(bundle, repo, "live-test-runs");
+    expect(result).toEqual({
+      silo: "live-test-runs",
+      status: "ingested",
+      artifactCount: 1,
+    });
+  });
+
+  it("throws a typed error for an unknown silo name", async () => {
+    const bundle = createBundle({
+      rootDir: tmpDir(),
+      provenance: {
+        commit: "abcdef0123456789abcdef0123456789abcdef01",
+        branch: "feat/test",
+        runner: "local",
+        tier: "cpu",
+        envFingerprint: {
+          node: "v24",
+          platform: "linux",
+          arch: "x64",
+          tier: "cpu",
+        },
+      },
+    });
+    await expect(
+      ingestNamedSilo(bundle, tmpDir(), "nope"),
+    ).rejects.toMatchObject({
+      code: "SILO_UNKNOWN",
+    });
+    await expect(
+      ingestNamedSilo(bundle, tmpDir(), "nope"),
+    ).rejects.toBeInstanceOf(EvidenceError);
+  });
+});

--- a/packages/evidence/src/ingest.ts
+++ b/packages/evidence/src/ingest.ts
@@ -1,0 +1,211 @@
+/**
+ * Silo ingestors: pure discovery + copy from the repo's existing evidence
+ * silos into a bundle, with provenance stamped at ingest time. Producers are
+ * never touched (#14552 hard constraint — `packages/app/scripts/**` is a hot
+ * zone); each ingestor maps a silo's on-disk shape to `addArtifact` calls with
+ * the correct kind/source/lane. An ingestor reports `absent` when none of its
+ * roots exist and `ingested` (possibly with zero artifacts) when a root exists
+ * but is empty — absent and empty are different results and are never
+ * conflated. Silo roots mirror `scripts/evidence-review/generate.mjs`
+ * DEFAULT_SCAN_DIRS so the bundle sees the same evidence the dashboard does.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import type { EvidenceBundle } from "./bundle.ts";
+import { EvidenceError } from "./errors.ts";
+import type { ArtifactKind } from "./schema.ts";
+
+/** Honest per-silo outcome of an ingest pass. */
+export interface IngestResult {
+  silo: string;
+  status: "ingested" | "absent";
+  artifactCount: number;
+}
+
+/** A silo root, relative to the repo root; `label` namespaces multi-root silos. */
+interface SiloRoot {
+  label: string;
+  dir: string;
+}
+
+interface SiloDefinition {
+  silo: string;
+  source: string;
+  producedBy: string;
+  lane?: string;
+  roots: SiloRoot[];
+  /** Per-silo kind override; receives the root-relative posix path. */
+  classify?: (relPath: string, defaultKind: ArtifactKind) => ArtifactKind;
+}
+
+// Directory names that never contain evidence; everything else in a silo is
+// treated as an artifact so nothing silently disappears from the bundle.
+const SKIP_DIR_NAMES = new Set(["node_modules", ".git", ".turbo"]);
+
+const KIND_BY_EXTENSION: Record<string, ArtifactKind> = {
+  ".png": "screenshot",
+  ".jpg": "screenshot",
+  ".jpeg": "screenshot",
+  ".gif": "screenshot",
+  ".webp": "screenshot",
+  ".mp4": "video",
+  ".mov": "video",
+  ".webm": "video",
+  ".jsonl": "trajectory",
+  ".log": "log",
+  ".txt": "log",
+  ".json": "report",
+  ".xml": "report",
+  ".html": "report",
+  ".md": "report",
+};
+
+function classifyByExtension(relPath: string): ArtifactKind {
+  return KIND_BY_EXTENSION[path.posix.extname(relPath).toLowerCase()] ?? "other";
+}
+
+function* walkSiloFiles(root: string, relBase = ""): Generator<string> {
+  const entries = fs.readdirSync(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const rel = relBase === "" ? entry.name : `${relBase}/${entry.name}`;
+    if (entry.isDirectory()) {
+      if (SKIP_DIR_NAMES.has(entry.name)) continue;
+      yield* walkSiloFiles(path.join(root, entry.name), rel);
+    } else if (entry.isFile()) {
+      yield rel;
+    }
+  }
+}
+
+async function ingestSilo(
+  bundle: EvidenceBundle,
+  repoRoot: string,
+  definition: SiloDefinition,
+): Promise<IngestResult> {
+  const presentRoots = definition.roots.filter((root) =>
+    fs.existsSync(path.join(repoRoot, root.dir)),
+  );
+  if (presentRoots.length === 0) {
+    return { silo: definition.silo, status: "absent", artifactCount: 0 };
+  }
+  const namespace = definition.roots.length > 1;
+  let artifactCount = 0;
+  for (const root of presentRoots) {
+    const rootDir = path.join(repoRoot, root.dir);
+    for (const rel of walkSiloFiles(rootDir)) {
+      const defaultKind = classifyByExtension(rel);
+      const kind = definition.classify?.(rel, defaultKind) ?? defaultKind;
+      await bundle.addArtifact(path.join(rootDir, ...rel.split("/")), {
+        kind,
+        source: definition.source,
+        ...(definition.lane !== undefined ? { lane: definition.lane } : {}),
+        producedBy: definition.producedBy,
+        relativePath: namespace ? `${root.label}/${rel}` : rel,
+      });
+      artifactCount += 1;
+    }
+  }
+  return { silo: definition.silo, status: "ingested", artifactCount };
+}
+
+/**
+ * The known silos, in ingest order. Sources are stable producer ids that
+ * downstream analyzers key on; changing one is a schema-level decision.
+ */
+const SILO_DEFINITIONS: SiloDefinition[] = [
+  {
+    silo: "e2e-recordings",
+    source: "e2e-recordings",
+    producedBy: "scripts/e2e-recordings/run-all.mjs",
+    lane: "e2e",
+    roots: [{ label: "repo", dir: "e2e-recordings" }],
+  },
+  {
+    silo: "aesthetic-audit",
+    source: "aesthetic-audit",
+    producedBy: "packages/app audit:app",
+    roots: [{ label: "app", dir: "packages/app/aesthetic-audit-output" }],
+    // Manual-review markdown is a per-page reviewer verdict, not a generated
+    // report; downstream certification treats it as analysis input.
+    classify: (relPath, defaultKind) =>
+      relPath.startsWith("manual-review/") && relPath.endsWith(".md")
+        ? "analysis"
+        : defaultKind,
+  },
+  {
+    silo: "device-e2e",
+    source: "device-e2e",
+    producedBy: "packages/app/scripts/lib/device-e2e-bundle.mjs",
+    lane: "native",
+    roots: [
+      { label: "repo", dir: "device-e2e-output" },
+      { label: "app", dir: "packages/app/device-e2e-output" },
+    ],
+  },
+  {
+    silo: "playwright-test-results",
+    source: "playwright",
+    producedBy: "packages/app test:e2e",
+    lane: "e2e",
+    roots: [{ label: "app", dir: "packages/app/test-results" }],
+  },
+  {
+    silo: "walkthrough-reports",
+    source: "walkthrough",
+    producedBy: "walkthrough capture lanes",
+    roots: [
+      { label: "repo", dir: "reports/walkthrough" },
+      { label: "app", dir: "packages/app/reports/walkthrough" },
+    ],
+  },
+  {
+    silo: "live-test-runs",
+    source: "live-test-runs",
+    producedBy: "reports/live-test-runs producers",
+    roots: [{ label: "repo", dir: "reports/live-test-runs" }],
+  },
+  {
+    silo: "scenario-runner",
+    source: "scenario-runner",
+    producedBy: "packages/scenario-runner/bin/eliza-scenarios",
+    lane: "scenario",
+    roots: [
+      { label: "runner", dir: "packages/scenario-runner/reports" },
+      { label: "repo", dir: "reports/scenarios" },
+    ],
+  },
+];
+
+/** Silo names, exported for CLI help and downstream orchestration. */
+export const SILO_NAMES: readonly string[] = SILO_DEFINITIONS.map(
+  (definition) => definition.silo,
+);
+
+/** Run every known silo ingestor against `repoRoot`, in declaration order. */
+export async function ingestAllSilos(
+  bundle: EvidenceBundle,
+  repoRoot: string,
+): Promise<IngestResult[]> {
+  const results: IngestResult[] = [];
+  for (const definition of SILO_DEFINITIONS) {
+    results.push(await ingestSilo(bundle, repoRoot, definition));
+  }
+  return results;
+}
+
+/** Run a single named silo ingestor; unknown names are a caller bug. */
+export async function ingestNamedSilo(
+  bundle: EvidenceBundle,
+  repoRoot: string,
+  silo: string,
+): Promise<IngestResult> {
+  const definition = SILO_DEFINITIONS.find((entry) => entry.silo === silo);
+  if (definition === undefined) {
+    throw new EvidenceError(`unknown evidence silo: ${silo}`, {
+      code: "SILO_UNKNOWN",
+      context: { silo, known: [...SILO_NAMES] },
+    });
+  }
+  return ingestSilo(bundle, repoRoot, definition);
+}

--- a/packages/evidence/src/ingest.ts
+++ b/packages/evidence/src/ingest.ts
@@ -62,7 +62,9 @@ const KIND_BY_EXTENSION: Record<string, ArtifactKind> = {
 };
 
 function classifyByExtension(relPath: string): ArtifactKind {
-  return KIND_BY_EXTENSION[path.posix.extname(relPath).toLowerCase()] ?? "other";
+  return (
+    KIND_BY_EXTENSION[path.posix.extname(relPath).toLowerCase()] ?? "other"
+  );
 }
 
 function* walkSiloFiles(root: string, relBase = ""): Generator<string> {

--- a/packages/evidence/src/provenance.test.ts
+++ b/packages/evidence/src/provenance.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Provenance tests against real git repositories in tmp dirs (git init +
+ * commit, no mocks) plus pure runner/fingerprint resolution over explicit env
+ * records.
+ */
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { EvidenceError } from "./errors.ts";
+import {
+  buildEnvFingerprint,
+  collectGitProvenance,
+  resolveRunnerKind,
+} from "./provenance.ts";
+
+const tmpDirs: string[] = [];
+
+function tmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "evidence-prov-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function initRepo(branch: string): string {
+  const dir = tmpDir();
+  git(dir, "init", "--initial-branch", branch);
+  git(dir, "config", "user.email", "evidence-test@example.com");
+  git(dir, "config", "user.name", "Evidence Test");
+  fs.writeFileSync(path.join(dir, "file.txt"), "content\n");
+  git(dir, "add", "file.txt");
+  git(dir, "commit", "-m", "initial", "--no-gpg-sign");
+  return dir;
+}
+
+describe("collectGitProvenance", () => {
+  it("collects the real HEAD commit and branch", () => {
+    const repo = initRepo("feat/evidence-test");
+    const provenance = collectGitProvenance(repo);
+    expect(provenance.commit).toBe(git(repo, "rev-parse", "HEAD"));
+    expect(provenance.commit).toMatch(/^[0-9a-f]{40}$/);
+    expect(provenance.branch).toBe("feat/evidence-test");
+  });
+
+  it("reports branch HEAD when detached, without repair", () => {
+    const repo = initRepo("main");
+    git(repo, "checkout", "--detach");
+    expect(collectGitProvenance(repo).branch).toBe("HEAD");
+  });
+
+  it("fails loud outside a git repository", () => {
+    const dir = tmpDir();
+    try {
+      collectGitProvenance(dir);
+      expect.unreachable("should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(EvidenceError);
+      expect((error as EvidenceError).code).toBe("GIT_PROVENANCE_UNAVAILABLE");
+      expect((error as EvidenceError).cause).toBeDefined();
+    }
+  });
+});
+
+describe("resolveRunnerKind", () => {
+  it("honors an explicit valid ELIZA_EVIDENCE_RUNNER", () => {
+    expect(resolveRunnerKind({ ELIZA_EVIDENCE_RUNNER: "vast" })).toBe("vast");
+    expect(
+      resolveRunnerKind({ ELIZA_EVIDENCE_RUNNER: "local", CI: "true" }),
+    ).toBe("local");
+  });
+
+  it("rejects an invalid explicit runner instead of downgrading", () => {
+    expect(() =>
+      resolveRunnerKind({ ELIZA_EVIDENCE_RUNNER: "docker" }),
+    ).toThrow(EvidenceError);
+  });
+
+  it("infers ci from a truthy CI env", () => {
+    expect(resolveRunnerKind({ CI: "true" })).toBe("ci");
+    expect(resolveRunnerKind({ CI: "1" })).toBe("ci");
+  });
+
+  it("defaults to local when CI is unset or falsy", () => {
+    expect(resolveRunnerKind({})).toBe("local");
+    expect(resolveRunnerKind({ CI: "" })).toBe("local");
+    expect(resolveRunnerKind({ CI: "false" })).toBe("local");
+    expect(resolveRunnerKind({ CI: "0" })).toBe("local");
+  });
+});
+
+describe("buildEnvFingerprint", () => {
+  const facts = {
+    nodeVersion: "v24.1.0",
+    bunVersion: "1.3.0",
+    platform: "linux",
+    arch: "x64",
+  };
+
+  it("contains exactly the allowlisted keys and never dumps env", () => {
+    const fingerprint = buildEnvFingerprint(
+      "gpu",
+      { TEST_LANE: "post-merge", SECRET_API_KEY: "leak-me" },
+      facts,
+    );
+    expect(fingerprint).toEqual({
+      node: "v24.1.0",
+      bun: "1.3.0",
+      platform: "linux",
+      arch: "x64",
+      tier: "gpu",
+      testLane: "post-merge",
+    });
+  });
+
+  it("omits bun and testLane when not applicable", () => {
+    const fingerprint = buildEnvFingerprint(
+      "cpu",
+      {},
+      { nodeVersion: "v24.1.0", platform: "darwin", arch: "arm64" },
+    );
+    expect(fingerprint).toEqual({
+      node: "v24.1.0",
+      platform: "darwin",
+      arch: "arm64",
+      tier: "cpu",
+    });
+  });
+});

--- a/packages/evidence/src/provenance.ts
+++ b/packages/evidence/src/provenance.ts
@@ -1,0 +1,120 @@
+/**
+ * Provenance collection for evidence bundles: which commit, branch, runner,
+ * and environment produced a run. Git facts come from `git rev-parse` via
+ * execFile and fail loud when the directory is not a repo — a bundle without
+ * real provenance is worthless to the certification gate, so nothing here
+ * degrades to a placeholder. The env fingerprint is a small allowlist (runtime
+ * versions, platform, lane, tier); the full environment is never captured
+ * because it contains secrets.
+ */
+
+import { execFileSync } from "node:child_process";
+import { EvidenceError } from "./errors.ts";
+import { RUNNER_KINDS, type RunnerKind, type Tier } from "./schema.ts";
+
+/** Commit + branch facts collected from the repository at `repoRoot`. */
+export interface GitProvenance {
+  /** Full 40-hex commit sha of HEAD. */
+  commit: string;
+  /** Current branch name; `HEAD` when detached (honest, not repaired). */
+  branch: string;
+}
+
+function gitOutput(repoRoot: string, args: string[]): string {
+  try {
+    return execFileSync("git", args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch (error) {
+    // error-policy:J2 context-adding rethrow — git failing means no real
+    // provenance exists; the bundle must not be created with fabricated facts.
+    throw new EvidenceError(
+      `git provenance unavailable: \`git ${args.join(" ")}\` failed in ${repoRoot}`,
+      { code: "GIT_PROVENANCE_UNAVAILABLE", cause: error, context: { repoRoot } },
+    );
+  }
+}
+
+/** Collect HEAD commit and branch from the git repository at `repoRoot`. */
+export function collectGitProvenance(repoRoot: string): GitProvenance {
+  const commit = gitOutput(repoRoot, ["rev-parse", "HEAD"]);
+  if (!/^[0-9a-f]{40}$/.test(commit)) {
+    throw new EvidenceError(
+      `git rev-parse HEAD returned a non-sha value: ${commit}`,
+      { code: "GIT_PROVENANCE_UNAVAILABLE", context: { repoRoot, commit } },
+    );
+  }
+  const branch = gitOutput(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"]);
+  return { commit, branch };
+}
+
+/**
+ * Resolve the runner kind: explicit `ELIZA_EVIDENCE_RUNNER` wins (and must be
+ * valid — a typo must not silently downgrade a vast run to `local`), then a
+ * truthy `CI` env means `ci`, else `local`.
+ */
+export function resolveRunnerKind(
+  env: Record<string, string | undefined>,
+): RunnerKind {
+  const explicit = env.ELIZA_EVIDENCE_RUNNER;
+  if (explicit !== undefined && explicit !== "") {
+    if (!(RUNNER_KINDS as readonly string[]).includes(explicit)) {
+      throw new EvidenceError(
+        `ELIZA_EVIDENCE_RUNNER must be one of ${RUNNER_KINDS.join("|")}, got: ${explicit}`,
+        { code: "RUNNER_KIND_INVALID", context: { explicit } },
+      );
+    }
+    return explicit as RunnerKind;
+  }
+  const ci = env.CI;
+  if (ci !== undefined && ci !== "" && ci !== "false" && ci !== "0") {
+    return "ci";
+  }
+  return "local";
+}
+
+/** Process facts used by {@link buildEnvFingerprint}; injectable for tests. */
+export interface ProcessFacts {
+  nodeVersion: string;
+  bunVersion?: string;
+  platform: string;
+  arch: string;
+}
+
+function defaultProcessFacts(): ProcessFacts {
+  return {
+    nodeVersion: process.version,
+    ...(process.versions.bun !== undefined
+      ? { bunVersion: process.versions.bun }
+      : {}),
+    platform: process.platform,
+    arch: process.arch,
+  };
+}
+
+/**
+ * Build the allowlisted env fingerprint for `meta.json`. Keys are stable:
+ * `node`, `bun` (only under a bun runtime), `platform`, `arch`, `tier`, and
+ * `testLane` (only when `TEST_LANE` is set).
+ */
+export function buildEnvFingerprint(
+  tier: Tier,
+  env: Record<string, string | undefined> = process.env,
+  facts: ProcessFacts = defaultProcessFacts(),
+): Record<string, string> {
+  const fingerprint: Record<string, string> = {
+    node: facts.nodeVersion,
+    platform: facts.platform,
+    arch: facts.arch,
+    tier,
+  };
+  if (facts.bunVersion !== undefined) {
+    fingerprint.bun = facts.bunVersion;
+  }
+  if (env.TEST_LANE !== undefined && env.TEST_LANE !== "") {
+    fingerprint.testLane = env.TEST_LANE;
+  }
+  return fingerprint;
+}

--- a/packages/evidence/src/provenance.ts
+++ b/packages/evidence/src/provenance.ts
@@ -32,7 +32,11 @@ function gitOutput(repoRoot: string, args: string[]): string {
     // provenance exists; the bundle must not be created with fabricated facts.
     throw new EvidenceError(
       `git provenance unavailable: \`git ${args.join(" ")}\` failed in ${repoRoot}`,
-      { code: "GIT_PROVENANCE_UNAVAILABLE", cause: error, context: { repoRoot } },
+      {
+        code: "GIT_PROVENANCE_UNAVAILABLE",
+        cause: error,
+        context: { repoRoot },
+      },
     );
   }
 }

--- a/packages/evidence/src/schema.test.ts
+++ b/packages/evidence/src/schema.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Contract tests for the schema-1 manifest/meta validators: round-trips,
+ * per-field rejection, and path-traversal hardening. Real values only — no
+ * mocks; the validators under test are the runtime boundary itself.
+ */
+
+import { describe, expect, it } from "vitest";
+import { EvidenceValidationError } from "./errors.ts";
+import {
+  type ArtifactEntry,
+  type BundleManifest,
+  type BundleMeta,
+  isBundleRelativePath,
+  parseManifest,
+  parseMeta,
+} from "./schema.ts";
+
+const SHA = "a".repeat(64);
+
+function validEntry(overrides: Partial<ArtifactEntry> = {}): ArtifactEntry {
+  return {
+    path: "visual/aesthetic-audit/desktop/home.png",
+    sha256: SHA,
+    bytes: 1234,
+    kind: "screenshot",
+    source: "aesthetic-audit",
+    lane: "e2e",
+    producedBy: "packages/app audit:app",
+    createdAt: "2026-07-05T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function validManifest(
+  overrides: Partial<BundleManifest> = {},
+): BundleManifest {
+  return {
+    schema: 1,
+    runId: "20260705-120000-abcdef0-cpu",
+    createdAt: "2026-07-05T12:00:00.000Z",
+    artifacts: [validEntry()],
+    ...overrides,
+  };
+}
+
+function validMeta(overrides: Partial<BundleMeta> = {}): BundleMeta {
+  return {
+    schema: 1,
+    runId: "20260705-120000-abcdef0-cpu",
+    commit: "abcdef0123456789abcdef0123456789abcdef01",
+    branch: "feat/14552-evidence-bundle",
+    runner: "local",
+    tier: "cpu",
+    startedAt: "2026-07-05T12:00:00.000Z",
+    finishedAt: "2026-07-05T12:05:00.000Z",
+    envFingerprint: {
+      node: "v24.0.0",
+      platform: "darwin",
+      arch: "arm64",
+      tier: "cpu",
+    },
+    timings: { "ingest.all": 1500 },
+    ...overrides,
+  };
+}
+
+describe("parseManifest", () => {
+  it("round-trips a valid manifest through JSON", () => {
+    const manifest = validManifest();
+    const parsed = parseManifest(JSON.parse(JSON.stringify(manifest)), "test");
+    expect(parsed).toEqual(manifest);
+  });
+
+  it("accepts an entry without the optional lane", () => {
+    const entry = validEntry();
+    delete (entry as Partial<ArtifactEntry>).lane;
+    const parsed = parseManifest(
+      JSON.parse(JSON.stringify(validManifest({ artifacts: [entry] }))),
+      "test",
+    );
+    expect(parsed.artifacts[0].lane).toBeUndefined();
+  });
+
+  it.each([
+    ["missing runId", () => ({ ...validManifest(), runId: undefined })],
+    ["wrong schema version", () => ({ ...validManifest(), schema: 2 })],
+    ["non-array artifacts", () => ({ ...validManifest(), artifacts: {} })],
+    ["unknown top-level key", () => ({ ...validManifest(), extra: true })],
+  ])("rejects a manifest with %s", (_label, make) => {
+    expect(() =>
+      parseManifest(JSON.parse(JSON.stringify(make())), "test"),
+    ).toThrow(EvidenceValidationError);
+  });
+
+  it.each([
+    ["bad kind", validEntry({ kind: "gif" as ArtifactEntry["kind"] })],
+    ["uppercase sha256", validEntry({ sha256: "A".repeat(64) })],
+    ["short sha256", validEntry({ sha256: "abc123" })],
+    ["negative bytes", validEntry({ bytes: -1 })],
+    ["fractional bytes", validEntry({ bytes: 1.5 })],
+    ["empty source", validEntry({ source: "" })],
+    ["empty producedBy", validEntry({ producedBy: "" })],
+    ["non-timestamp createdAt", validEntry({ createdAt: "yesterday" })],
+  ])("rejects an entry with %s", (_label, entry) => {
+    expect(() =>
+      parseManifest(
+        JSON.parse(JSON.stringify(validManifest({ artifacts: [entry] }))),
+        "test",
+      ),
+    ).toThrow(EvidenceValidationError);
+  });
+
+  it.each([
+    ["traversal", "../escape.png"],
+    ["nested traversal", "visual/../../escape.png"],
+    ["absolute", "/etc/passwd"],
+    ["backslash", "visual\\home.png"],
+    ["dot segment", "visual/./home.png"],
+    ["empty segment", "visual//home.png"],
+    ["empty path", ""],
+  ])("rejects an entry path with %s (%s)", (_label, badPath) => {
+    expect(isBundleRelativePath(badPath)).toBe(false);
+    expect(() =>
+      parseManifest(
+        JSON.parse(
+          JSON.stringify(
+            validManifest({ artifacts: [validEntry({ path: badPath })] }),
+          ),
+        ),
+        "test",
+      ),
+    ).toThrow(EvidenceValidationError);
+  });
+
+  it("rejects duplicate artifact paths", () => {
+    const manifest = validManifest({ artifacts: [validEntry(), validEntry()] });
+    expect(() =>
+      parseManifest(JSON.parse(JSON.stringify(manifest)), "test"),
+    ).toThrow(/duplicate artifact path/);
+  });
+
+  it("reports every issue with its dotted path", () => {
+    const manifest = validManifest({
+      artifacts: [validEntry({ sha256: "nope", bytes: -2 })],
+    });
+    try {
+      parseManifest(JSON.parse(JSON.stringify(manifest)), "test");
+      expect.unreachable("should have thrown");
+    } catch (error) {
+      const validation = error as EvidenceValidationError;
+      expect(validation).toBeInstanceOf(EvidenceValidationError);
+      expect(validation.code).toBe("MANIFEST_INVALID");
+      const paths = validation.issues.map((issue) => issue.path);
+      expect(paths).toContain("artifacts.0.sha256");
+      expect(paths).toContain("artifacts.0.bytes");
+    }
+  });
+});
+
+describe("parseMeta", () => {
+  it("round-trips valid meta through JSON", () => {
+    const meta = validMeta();
+    expect(parseMeta(JSON.parse(JSON.stringify(meta)), "test")).toEqual(meta);
+  });
+
+  it("accepts meta without optional finishedAt/timings", () => {
+    const meta = validMeta();
+    delete (meta as Partial<BundleMeta>).finishedAt;
+    delete (meta as Partial<BundleMeta>).timings;
+    expect(parseMeta(JSON.parse(JSON.stringify(meta)), "test")).toEqual(meta);
+  });
+
+  it.each([
+    ["bad runner", validMeta({ runner: "docker" as BundleMeta["runner"] })],
+    ["bad tier", validMeta({ tier: "tpu" as BundleMeta["tier"] })],
+    ["non-hex commit", validMeta({ commit: "not-a-sha" })],
+    ["empty branch", validMeta({ branch: "" })],
+    [
+      "non-string fingerprint value",
+      validMeta({
+        envFingerprint: { node: 24 } as unknown as Record<string, string>,
+      }),
+    ],
+  ])("rejects meta with %s", (_label, meta) => {
+    expect(() => parseMeta(JSON.parse(JSON.stringify(meta)), "test")).toThrow(
+      EvidenceValidationError,
+    );
+  });
+});

--- a/packages/evidence/src/schema.ts
+++ b/packages/evidence/src/schema.ts
@@ -1,0 +1,203 @@
+/**
+ * Versioned evidence-bundle contract: manifest and provenance-meta types plus
+ * runtime validation. This is the FROZEN schema-1 contract the rest of the
+ * unified evidence harness (#14541) builds against — analyzers, VLM Q&A, and
+ * the certify orchestrator all consume these exact names and semantics; widen
+ * only additively under a schema bump. Interfaces are declared explicitly (the
+ * contract) and the zod schemas are held mutually assignable at compile time,
+ * so type and validator cannot drift apart. Parsing untrusted disk input
+ * produces `EvidenceValidationError` with per-field issues (error-policy J3);
+ * nothing is silently repaired. Artifact paths are bundle-relative posix and
+ * traversal (`..`, absolute, backslash) is rejected at validation time so a
+ * hostile manifest can never direct reads or writes outside its bundle dir.
+ */
+
+import { z } from "zod";
+import { EvidenceValidationError } from "./errors.ts";
+
+export const ARTIFACT_KINDS = [
+  "screenshot",
+  "video",
+  "keyframe",
+  "log",
+  "trajectory",
+  "report",
+  "analysis",
+  "qa",
+  "html-tree",
+  "other",
+] as const;
+export type ArtifactKind = (typeof ARTIFACT_KINDS)[number];
+
+export const RUNNER_KINDS = ["local", "vast", "ci"] as const;
+export type RunnerKind = (typeof RUNNER_KINDS)[number];
+
+export const TIERS = ["cpu", "gpu", "full"] as const;
+export type Tier = (typeof TIERS)[number];
+
+/** One file recorded in a bundle manifest. */
+export interface ArtifactEntry {
+  /** Bundle-relative posix path (no `..`, no leading `/`, no backslashes). */
+  path: string;
+  /** Lowercase hex sha256 of the artifact bytes as stored in the bundle. */
+  sha256: string;
+  bytes: number;
+  kind: ArtifactKind;
+  /** Producer id, e.g. `aesthetic-audit`. */
+  source: string;
+  /** Test lane the artifact belongs to (e2e, scenario, native, …), if known. */
+  lane?: string;
+  /** Tool or script that produced the artifact. */
+  producedBy: string;
+  /** ISO-8601 timestamp of when the artifact was added to the bundle. */
+  createdAt: string;
+}
+
+/** `manifest.json`: the signed inventory of every artifact in a bundle. */
+export interface BundleManifest {
+  schema: 1;
+  runId: string;
+  createdAt: string;
+  artifacts: ArtifactEntry[];
+}
+
+/** `meta.json`: provenance for the run that produced the bundle. */
+export interface BundleMeta {
+  schema: 1;
+  runId: string;
+  commit: string;
+  branch: string;
+  runner: RunnerKind;
+  tier: Tier;
+  startedAt: string;
+  finishedAt?: string;
+  envFingerprint: Record<string, string>;
+  /** Wall-clock durations in milliseconds, keyed by phase (e.g. `ingest.reports`). */
+  timings?: Record<string, number>;
+}
+
+/**
+ * Bundle-relative posix path validator. Rejects traversal because manifest
+ * paths are joined onto the bundle dir by `verifyBundle` and future consumers.
+ */
+export function isBundleRelativePath(value: string): boolean {
+  if (value.length === 0 || value.includes("\\") || value.startsWith("/")) {
+    return false;
+  }
+  return value
+    .split("/")
+    .every((segment) => segment !== "" && segment !== "." && segment !== "..");
+}
+
+const bundleRelativePath = z
+  .string()
+  .refine(isBundleRelativePath, {
+    message:
+      "must be a bundle-relative posix path with no empty, `.`, or `..` segments",
+  });
+
+const sha256Hex = z
+  .string()
+  .regex(/^[0-9a-f]{64}$/, "must be 64 lowercase hex characters");
+
+const isoTimestamp = z
+  .string()
+  .refine((value) => !Number.isNaN(Date.parse(value)), {
+    message: "must be an ISO-8601 timestamp",
+  });
+
+const artifactEntrySchema = z.strictObject({
+  path: bundleRelativePath,
+  sha256: sha256Hex,
+  bytes: z.number().int().nonnegative(),
+  kind: z.enum(ARTIFACT_KINDS),
+  source: z.string().min(1),
+  lane: z.string().min(1).optional(),
+  producedBy: z.string().min(1),
+  createdAt: isoTimestamp,
+});
+
+const bundleManifestSchema = z
+  .strictObject({
+    schema: z.literal(1),
+    runId: z.string().min(1),
+    createdAt: isoTimestamp,
+    artifacts: z.array(artifactEntrySchema),
+  })
+  .superRefine((manifest, ctx) => {
+    const seen = new Set<string>();
+    for (const [index, artifact] of manifest.artifacts.entries()) {
+      if (seen.has(artifact.path)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["artifacts", index, "path"],
+          message: `duplicate artifact path: ${artifact.path}`,
+        });
+      }
+      seen.add(artifact.path);
+    }
+  });
+
+const bundleMetaSchema = z.strictObject({
+  schema: z.literal(1),
+  runId: z.string().min(1),
+  commit: z.string().regex(/^[0-9a-f]{7,40}$/, "must be a hex commit sha"),
+  branch: z.string().min(1),
+  runner: z.enum(RUNNER_KINDS),
+  tier: z.enum(TIERS),
+  startedAt: isoTimestamp,
+  finishedAt: isoTimestamp.optional(),
+  envFingerprint: z.record(z.string(), z.string()),
+  timings: z.record(z.string(), z.number()).optional(),
+});
+
+// Compile-time drift guards: the zod schemas must stay mutually assignable
+// with the frozen contract interfaces above.
+type MutuallyAssignable<A, B> = A extends B ? (B extends A ? true : never) : never;
+const _entryContract: MutuallyAssignable<
+  z.infer<typeof artifactEntrySchema>,
+  ArtifactEntry
+> = true;
+const _manifestContract: MutuallyAssignable<
+  z.infer<typeof bundleManifestSchema>,
+  BundleManifest
+> = true;
+const _metaContract: MutuallyAssignable<
+  z.infer<typeof bundleMetaSchema>,
+  BundleMeta
+> = true;
+void _entryContract;
+void _manifestContract;
+void _metaContract;
+
+function throwInvalid(
+  what: string,
+  described: string,
+  error: z.ZodError,
+): never {
+  const issues = error.issues.map((issue) => ({
+    path: issue.path.map(String).join(".") || "$",
+    message: issue.message,
+  }));
+  throw new EvidenceValidationError(
+    `invalid ${what} (${described}): ${issues
+      .map((issue) => `${issue.path}: ${issue.message}`)
+      .join("; ")}`,
+    issues,
+    { code: what === "bundle manifest" ? "MANIFEST_INVALID" : "META_INVALID" },
+  );
+}
+
+/** Validate an untrusted value as a schema-1 manifest; throws typed invalid. */
+export function parseManifest(value: unknown, described: string): BundleManifest {
+  const result = bundleManifestSchema.safeParse(value);
+  if (!result.success) throwInvalid("bundle manifest", described, result.error);
+  return result.data;
+}
+
+/** Validate an untrusted value as schema-1 provenance meta; throws typed invalid. */
+export function parseMeta(value: unknown, described: string): BundleMeta {
+  const result = bundleMetaSchema.safeParse(value);
+  if (!result.success) throwInvalid("bundle meta", described, result.error);
+  return result.data;
+}

--- a/packages/evidence/src/schema.ts
+++ b/packages/evidence/src/schema.ts
@@ -89,12 +89,10 @@ export function isBundleRelativePath(value: string): boolean {
     .every((segment) => segment !== "" && segment !== "." && segment !== "..");
 }
 
-const bundleRelativePath = z
-  .string()
-  .refine(isBundleRelativePath, {
-    message:
-      "must be a bundle-relative posix path with no empty, `.`, or `..` segments",
-  });
+const bundleRelativePath = z.string().refine(isBundleRelativePath, {
+  message:
+    "must be a bundle-relative posix path with no empty, `.`, or `..` segments",
+});
 
 const sha256Hex = z
   .string()
@@ -153,7 +151,11 @@ const bundleMetaSchema = z.strictObject({
 
 // Compile-time drift guards: the zod schemas must stay mutually assignable
 // with the frozen contract interfaces above.
-type MutuallyAssignable<A, B> = A extends B ? (B extends A ? true : never) : never;
+type MutuallyAssignable<A, B> = A extends B
+  ? B extends A
+    ? true
+    : never
+  : never;
 const _entryContract: MutuallyAssignable<
   z.infer<typeof artifactEntrySchema>,
   ArtifactEntry
@@ -189,7 +191,10 @@ function throwInvalid(
 }
 
 /** Validate an untrusted value as a schema-1 manifest; throws typed invalid. */
-export function parseManifest(value: unknown, described: string): BundleManifest {
+export function parseManifest(
+  value: unknown,
+  described: string,
+): BundleManifest {
   const result = bundleManifestSchema.safeParse(value);
   if (!result.success) throwInvalid("bundle manifest", described, result.error);
   return result.data;

--- a/packages/evidence/tsconfig.json
+++ b/packages/evidence/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "useUnknownInCatchVariables": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node"],
+    "typeRoots": [
+      "../../node_modules/@types",
+      "../../node_modules/.bun/node_modules/@types"
+    ]
+  },
+  "include": ["src"]
+}

--- a/packages/evidence/vitest.config.ts
+++ b/packages/evidence/vitest.config.ts
@@ -1,0 +1,13 @@
+/**
+ * Vitest config for @elizaos/evidence: node environment, real-filesystem unit
+ * and integration tests under `src`.
+ */
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    exclude: ["**/node_modules/**"],
+  },
+});


### PR DESCRIPTION
Implements #14552 (part of epic #14541 — unified evidence harness + develop→main certification). Design doc: `packages/docs/ongoing-development/unified-evidence-harness.md` (PR #14555, merged).

## What

New `packages/evidence` (`@elizaos/evidence`, private, ESM, no framework dependency — it must run in minimal CI/vast containers):

- **`src/schema.ts` — frozen schema-1 contract.** `ArtifactEntry` / `BundleManifest` / `BundleMeta` + `ArtifactKind`/`RunnerKind`/`Tier` unions, exactly as specced in the issue. Explicit interfaces are the contract; zod validators are held mutually assignable at compile time so type and validator cannot drift. Reading untrusted manifests/meta from disk throws `EvidenceValidationError` with per-field issues (error-policy J3) — never a silently-repaired object. Path traversal (`..`, absolute, backslash, `.`/empty segments) is rejected at validation time.
- **`src/canonical.ts` — signed byte form.** Canonical JSON: keys sorted (UTF-16 code-unit order), arrays in caller order, no whitespace, UTF-8, exactly one trailing newline (part of the signed bytes). Non-representable values (NaN/Infinity/bigint/function/undefined-in-array) throw instead of degrading to `null`.
- **`src/bundle.ts` — builder + verifier.** `createBundle` opens `evidence/runs/<utc yyyymmdd-hhmmss>-<shortsha>-<tier>/`; `addArtifact` hardlinks (same volume) or copies (EXDEV fallback, annotated J4), hashes **as stored**, and places by a deterministic kind→family mapping (`lanes/<lane>/…`, `visual/<source>/…`, `video/…`, `trajectories/…`, `html-trees/…`, `misc/<source>/…`) with a `bundlePath` escape hatch for wave-2 analyzers to sit `analysis.json`/`qa.json` beside pixels. `finalize()` sorts artifacts by path and writes canonical `manifest.json` + `meta.json`, returning `manifestSha256` (the value certification signs). `verifyBundle(dir)` re-hashes everything and reports `missing` / `size-mismatch` / `hash-mismatch` / `unlisted` findings. Clock and runId are injectable → byte-stable manifests are testable. Bundle paths are NFC-normalized at ingress (macOS NFD vs linux NFC). `finalize()` writes+hashes `meta.json` first and embeds `manifest.metaSha256`, binding provenance into the signed envelope; `verifyBundle` is lstat-based and additionally reports `symlink` (symlinked artifact = mutable after signing; symlinked dir = unswept external tree) and `meta-mismatch` findings.
- **`src/provenance.ts`.** Commit/branch via `git rev-parse` (execFile, fails loud with a typed error outside a repo — no fabricated provenance); runner from `ELIZA_EVIDENCE_RUNNER` ∈ local|vast|ci (invalid value throws instead of downgrading), inferred `ci` from `CI` env, default `local`; env fingerprint is a small allowlist (node/bun versions, platform, arch, tier, TEST_LANE) — full env is never captured.
- **`src/ingest.ts` — 7 silo ingestors, producers untouched.** e2e-recordings, aesthetic-audit-output, device-e2e-output (both roots; the #14494 bundle-dir shape), packages/app/test-results, reports/walkthrough (+ app mirror), reports/live-test-runs, scenario-runner reports (+ reports/scenarios). Roots mirror `scripts/evidence-review/generate.mjs` DEFAULT_SCAN_DIRS. Each returns `{silo, status: 'ingested'|'absent', artifactCount}` — an absent silo and an empty silo are different results, never conflated.
- **`src/cli.ts` — thin.** `bundle:create -- --tier cpu|gpu|full [--out] [--repo-root]` and `bundle:verify -- <dir>`; all logic in the lib, J1 boundary translation at the process edge.
- Registered in the `server` test lane via `elizaos.scripts.testLanes` (verified in `run-all-tests.mjs --plan`).

## Schema contract summary (for wave-2 agents)

```ts
import {
  // schema
  ArtifactKind, RunnerKind, Tier, ArtifactEntry, BundleManifest, BundleMeta,
  ARTIFACT_KINDS, RUNNER_KINDS, TIERS, parseManifest, parseMeta, isBundleRelativePath,
  // bundle
  createBundle, EvidenceBundle, verifyBundle, formatRunId,
  // provenance
  collectGitProvenance, resolveRunnerKind, buildEnvFingerprint,
  // ingest
  ingestAllSilos, ingestNamedSilo, SILO_NAMES,
  // errors
  EvidenceError, EvidenceValidationError,
} from "@elizaos/evidence";
```

No deviations from the issue/spec schema. Two additions (additive, documented): `AddArtifactOptions.bundlePath` for exact placement (needed by #14542/#14544), and — from the fable review round — `BundleManifest.metaSha256` (required, 64-hex) binding `meta.json` bytes into the signed envelope so forged commit/branch/runner fails verification. Schema stays 1 (unreleased).

Deliberately **not** in this PR (hot-zone guard per the design doc — `scripts/evidence-review/**` has in-flight PRs): pointing `evidence-review/generate.mjs` at a bundle via `--bundle`. That lands with consolidation (#14550).

## Evidence

### Tests — 97/97 green, real filesystem + real `git init` repos, no mocks of the code under test

`bun run --cwd packages/evidence test`

<details><summary>Full verbose test list (6 files, 97 tests)</summary>

```
 ✓ src/canonical.test.ts > canonicalJson > produces identical text for differently-ordered keys 1ms
 ✓ src/canonical.test.ts > canonicalJson > preserves array order 0ms
 ✓ src/canonical.test.ts > canonicalJson > skips undefined object values like JSON.stringify 0ms
 ✓ src/canonical.test.ts > canonicalJson > escapes strings via JSON string rules 0ms
 ✓ src/canonical.test.ts > canonicalJson > throws CANONICAL_UNSERIALIZABLE for NaN 0ms
 ✓ src/canonical.test.ts > canonicalJson > throws CANONICAL_UNSERIALIZABLE for Infinity 0ms
 ✓ src/canonical.test.ts > canonicalJson > throws CANONICAL_UNSERIALIZABLE for bigint 0ms
 ✓ src/canonical.test.ts > canonicalJson > throws CANONICAL_UNSERIALIZABLE for function 0ms
 ✓ src/canonical.test.ts > canonicalJson > throws CANONICAL_UNSERIALIZABLE for undefined root 0ms
 ✓ src/canonical.test.ts > canonicalJson > throws CANONICAL_UNSERIALIZABLE for undefined array element 0ms
 ✓ src/canonical.test.ts > canonicalJson > throws CANONICAL_UNSERIALIZABLE for non-plain object Date 0ms
 ✓ src/canonical.test.ts > canonicalJson > throws CANONICAL_UNSERIALIZABLE for non-plain object Map 0ms
 ✓ src/canonical.test.ts > canonicalJson > throws CANONICAL_UNSERIALIZABLE for non-plain object Set 0ms
 ✓ src/canonical.test.ts > canonicalJson > throws CANONICAL_UNSERIALIZABLE for non-plain object class instance 0ms
 ✓ src/canonical.test.ts > canonicalJson > throws CANONICAL_UNSERIALIZABLE for non-plain object nested non-plain object 0ms
 ✓ src/canonical.test.ts > canonicalJson > accepts plain objects and null-prototype objects 0ms
 ✓ src/canonical.test.ts > canonicalJsonBytes > is the canonical text plus exactly one trailing newline, UTF-8 0ms
 ✓ src/schema.test.ts > parseManifest > round-trips a valid manifest through JSON 4ms
 ✓ src/schema.test.ts > parseManifest > accepts an entry without the optional lane 0ms
 ✓ src/schema.test.ts > parseManifest > rejects a manifest with missing runId 1ms
 ✓ src/schema.test.ts > parseManifest > rejects a manifest with wrong schema version 0ms
 ✓ src/schema.test.ts > parseManifest > rejects a manifest with non-array artifacts 0ms
 ✓ src/schema.test.ts > parseManifest > rejects a manifest with unknown top-level key 0ms
 ✓ src/schema.test.ts > parseManifest > rejects a manifest with missing metaSha256 0ms
 ✓ src/schema.test.ts > parseManifest > rejects a manifest with non-hex metaSha256 0ms
 ✓ src/schema.test.ts > parseManifest > rejects an entry with bad kind 0ms
 ✓ src/schema.test.ts > parseManifest > rejects an entry with uppercase sha256 1ms
 ✓ src/schema.test.ts > parseManifest > rejects an entry with short sha256 1ms
 ✓ src/schema.test.ts > parseManifest > rejects an entry with negative bytes 0ms
 ✓ src/schema.test.ts > parseManifest > rejects an entry with fractional bytes 0ms
 ✓ src/schema.test.ts > parseManifest > rejects an entry with empty source 0ms
 ✓ src/schema.test.ts > parseManifest > rejects an entry with empty producedBy 0ms
 ✓ src/schema.test.ts > parseManifest > rejects an entry with non-timestamp createdAt 0ms
 ✓ src/schema.test.ts > parseManifest > rejects an entry path with traversal (../escape.png) 0ms
 ✓ src/schema.test.ts > parseManifest > rejects an entry path with nested traversal (visual/../../escape.png) 0ms
 ✓ src/schema.test.ts > parseManifest > rejects an entry path with absolute (/etc/passwd) 0ms
 ✓ src/schema.test.ts > parseManifest > rejects an entry path with backslash (visual\home.png) 0ms
 ✓ src/schema.test.ts > parseManifest > rejects an entry path with dot segment (visual/./home.png) 0ms
 ✓ src/schema.test.ts > parseManifest > rejects an entry path with empty segment (visual//home.png) 0ms
 ✓ src/schema.test.ts > parseManifest > rejects an entry path with empty path () 0ms
 ✓ src/schema.test.ts > parseManifest > rejects duplicate artifact paths 1ms
 ✓ src/schema.test.ts > parseManifest > reports every issue with its dotted path 1ms
 ✓ src/schema.test.ts > parseMeta > round-trips valid meta through JSON 1ms
 ✓ src/schema.test.ts > parseMeta > accepts meta without optional finishedAt/timings 0ms
 ✓ src/schema.test.ts > parseMeta > rejects meta with bad runner 0ms
 ✓ src/schema.test.ts > parseMeta > rejects meta with bad tier 0ms
 ✓ src/schema.test.ts > parseMeta > rejects meta with non-hex commit 0ms
 ✓ src/schema.test.ts > parseMeta > rejects meta with empty branch 0ms
 ✓ src/schema.test.ts > parseMeta > rejects meta with non-string fingerprint value 0ms
 ✓ src/bundle.test.ts > formatRunId > derives <utc stamp>-<shortsha>-<tier> 2ms
 ✓ src/bundle.test.ts > EvidenceBundle > places artifacts by the documented kind→family mapping 17ms
 ✓ src/bundle.test.ts > EvidenceBundle > honors an explicit bundlePath override 5ms
 ✓ src/bundle.test.ts > EvidenceBundle > rejects relativePath + bundlePath together 3ms
 ✓ src/bundle.test.ts > EvidenceBundle > NFC-normalizes bundle paths so NFD input cannot drift manifest bytes 5ms
 ✓ src/bundle.test.ts > EvidenceBundle > binds meta.json into the manifest via metaSha256 9ms
 ✓ src/bundle.test.ts > EvidenceBundle > produces byte-identical manifests across two runs with the same inputs 16ms
 ✓ src/bundle.test.ts > EvidenceBundle > hardlinks on the same volume in auto mode 3ms
 ✓ src/bundle.test.ts > EvidenceBundle > copies when linkMode is copy 3ms
 ✓ src/bundle.test.ts > EvidenceBundle > falls back to copy when the link fails with EXDEV 2ms
 ✓ src/bundle.test.ts > EvidenceBundle > rethrows non-EXDEV link failures 2ms
 ✓ src/bundle.test.ts > EvidenceBundle > throws typed errors for missing sources, collisions, and traversal 3ms
 ✓ src/bundle.test.ts > EvidenceBundle > is single-use: refuses adds and finalize after finalize 7ms
 ✓ src/bundle.test.ts > EvidenceBundle > refuses to reuse an existing run dir 1ms
 ✓ src/bundle.test.ts > verifyBundle > passes a pristine bundle and reports the stored manifest sha 9ms
 ✓ src/bundle.test.ts > verifyBundle > catches a tampered file, a deleted file, and an unlisted file 9ms
 ✓ src/ingest.test.ts > ingestAllSilos > ingests every fixture silo with honest per-silo counts 54ms
 ✓ src/ingest.test.ts > ingestAllSilos > classifies kinds, lanes, and sources per silo 36ms
 ✓ src/bundle.test.ts > verifyBundle > reports size-mismatch when the stored byte count changed 8ms
 ✓ src/bundle.test.ts > verifyBundle > throws typed errors for a missing or malformed manifest 1ms
 ✓ src/bundle.test.ts > verifyBundle > fails when meta.json provenance is forged (commit flip) 8ms
 ✓ src/bundle.test.ts > verifyBundle > fails when meta.json is missing 8ms
 ✓ src/bundle.test.ts > verifyBundle > flags an unlisted file symlink instead of ignoring it 8ms
 ✓ src/bundle.test.ts > verifyBundle > flags a directory symlink instead of following it 10ms
 ✓ src/bundle.test.ts > verifyBundle > fails a listed artifact replaced by a symlink to matching external bytes 9ms
 ✓ src/bundle.test.ts > verifyBundle > still reports a plain unlisted regular file as unlisted (control) 7ms
 ✓ src/ingest.test.ts > ingestAllSilos > copies real bytes into the bundle 38ms
 ✓ src/ingest.test.ts > ingestAllSilos > distinguishes an absent silo from an empty one 3ms
 ✓ src/ingest.test.ts > ingestNamedSilo > runs a single silo by name 12ms
 ✓ src/ingest.test.ts > ingestNamedSilo > throws a typed error for an unknown silo name 2ms
 ✓ src/provenance.test.ts > collectGitProvenance > collects the real HEAD commit and branch 187ms
 ✓ src/provenance.test.ts > collectGitProvenance > reports branch HEAD when detached, without repair 149ms
 ✓ src/provenance.test.ts > collectGitProvenance > fails loud outside a git repository 16ms
 ✓ src/provenance.test.ts > resolveRunnerKind > honors an explicit valid ELIZA_EVIDENCE_RUNNER 0ms
 ✓ src/provenance.test.ts > resolveRunnerKind > rejects an invalid explicit runner instead of downgrading 0ms
 ✓ src/provenance.test.ts > resolveRunnerKind > infers ci from a truthy CI env 0ms
 ✓ src/provenance.test.ts > resolveRunnerKind > defaults to local when CI is unset or falsy 0ms
 ✓ src/provenance.test.ts > buildEnvFingerprint > contains exactly the allowlisted keys and never dumps env 0ms
 ✓ src/provenance.test.ts > buildEnvFingerprint > omits bun and testLane when not applicable 0ms
 ✓ src/cli.test.ts > runCli create > creates a verified bundle from real silos and reports honest statuses 196ms
 ✓ src/cli.test.ts > runCli create > fails loud outside a git repository 18ms
 ✓ src/cli.test.ts > runCli create > exits non-zero on missing tier 0ms
 ✓ src/cli.test.ts > runCli create > exits non-zero on bad tier 0ms
 ✓ src/cli.test.ts > runCli create > exits non-zero on unknown flag 0ms
 ✓ src/cli.test.ts > runCli create > exits non-zero on unknown command 0ms
 ✓ src/cli.test.ts > runCli create > prints usage and exits zero with no command or --help 0ms
 ✓ src/cli.test.ts > runCli verify > passes a pristine bundle and fails a tampered one 140ms
 ✓ src/cli.test.ts > runCli verify > requires exactly one bundle directory 0ms
 Test Files  6 passed (6)
      Tests  97 passed (97)
```
</details>

### Real CLI run in this worktree (fixture screenshots dropped into the gitignored silos, per-silo honest statuses)

```
$ bun run --cwd packages/evidence bundle:create -- --tier cpu
bundle 20260706-005705-6822c95-cpu
  commit 6822c95cb3ca2b9aa08c19d32e9eb6e932c7c820 (feat/14552-evidence-bundle) runner=local tier=cpu

  e2e-recordings           absent    -
  aesthetic-audit          ingested  5
  device-e2e               absent    -
  playwright-test-results  absent    -
  walkthrough-reports      absent    -
  live-test-runs           absent    -
  scenario-runner          ingested  1

  artifacts: 6
  manifest:  .../evidence/runs/20260706-005705-6822c95-cpu/manifest.json
  sha256:    98308f8818853c592ea7a00de572065699c3093aa6cac8d8c476fd7c48822f22

$ bun run --cwd packages/evidence bundle:verify -- ../../evidence/runs/20260706-005705-6822c95-cpu
bundle 20260706-005705-6822c95-cpu
  artifacts: 6  verified: 6  issues: 0
  manifest sha256: 98308f8818853c592ea7a00de572065699c3093aa6cac8d8c476fd7c48822f22
  OK        (exit 0)
```

Then tampered (appended bytes to a screenshot, deleted report.json, added a stray file):

```
$ bun run --cwd packages/evidence bundle:verify -- ../../evidence/runs/20260706-005705-6822c95-cpu
bundle 20260706-005705-6822c95-cpu
  artifacts: 6  verified: 4  issues: 3
  missing: misc/aesthetic-audit/report.json
  size-mismatch: visual/aesthetic-audit/desktop/chat.png (expected 15324, actual 15330)
  unlisted: stray.txt
  FAILED    (exit 1)
```

<details><summary>manifest.json excerpt (canonical form, pretty-printed here for review) + full meta.json</summary>

```json
{
  "artifacts": [
    {
      "bytes": 22,
      "createdAt": "2026-07-06T00:57:05.280Z",
      "kind": "analysis",
      "path": "misc/aesthetic-audit/manual-review/chat.md",
      "producedBy": "packages/app audit:app",
      "sha256": "c2b82fb9cf86775277d819955625107406bdd01ed05452c73cd745128533a166",
      "source": "aesthetic-audit"
    },
    {
      "bytes": 29,
      "createdAt": "2026-07-06T00:57:05.281Z",
      "kind": "trajectory",
      "lane": "scenario",
      "path": "trajectories/scenario-runner/repo/demo/native.jsonl",
      "producedBy": "packages/scenario-runner/bin/eliza-scenarios",
      "sha256": "b4a7f4d457c4491c0aaec02585a7509edffb77ab8c950dc9ad4175b43f73cc3a",
      "source": "scenario-runner"
    },
    {
      "bytes": 15327,
      "createdAt": "2026-07-06T00:57:05.278Z",
      "kind": "screenshot",
      "path": "visual/aesthetic-audit/desktop/chat--hover.png",
      "producedBy": "packages/app audit:app",
      "sha256": "cd36ee7fb80f191592bb227fd81415e51af966e61a97000a3cfed83005673a67",
      "source": "aesthetic-audit"
    }
  ]
}
```

```json
{
  "branch": "feat/14552-evidence-bundle",
  "commit": "6822c95cb3ca2b9aa08c19d32e9eb6e932c7c820",
  "envFingerprint": {
    "arch": "arm64",
    "bun": "1.3.14",
    "node": "v24.3.0",
    "platform": "darwin",
    "tier": "cpu"
  },
  "finishedAt": "2026-07-06T00:57:05.281Z",
  "runId": "20260706-005705-6822c95-cpu",
  "runner": "local",
  "schema": 1,
  "startedAt": "2026-07-06T00:57:05.273Z",
  "tier": "cpu",
  "timings": { "ingest.all": 8 }
}
```
</details>

### Review-round hardening (fable review), demonstrated on a real bundle

Forged provenance (runner flipped local→vast in meta.json) + a symlink dropped into the bundle:

```
$ bun run --cwd packages/evidence bundle:verify -- ../../evidence/runs/20260706-011818-4d072e2-cpu
  meta-mismatch: meta.json (expected fd29118f…, actual 78dbe04c…)
  symlink: evil-link
  FAILED    (exit 1)
```

Covered by 16 new tests: 4 symlink scenarios (unlisted file symlink, directory symlink not followed, listed artifact replaced by a symlink to byte-identical external content, plain-unlisted control), meta forge/missing, metaSha256 binding, NFC path normalization, canonical rejection of Date/Map/Set/class instances (+ plain/null-proto acceptance), and metaSha256 schema validation.

### Static checks

```
$ tsgo --noEmit -p tsconfig.json                       → clean
$ bunx @biomejs/biome check packages/evidence          → Checked 17 files. No fixes applied.
$ bun run audit:error-policy-ratchet                   → 8 changed files, emptyCatch 0->0, serverConsole 0->0, no new fallback-slop
$ node packages/scripts/run-all-tests.mjs --plan --lane server
    [eliza-test] PLAN parallel @elizaos/evidence (packages/evidence)#test
```

Every kept catch carries an `// error-policy:J<N>` annotation (J1 CLI boundary, J2 context-adding rethrows, J3 untrusted disk input, J4 EXDEV copy fallback).

Note: the `bun.lock` diff includes a tesseract.js trusted-dependency reordering — incidental churn from `bun install` registering the new workspace, not a dependency change.

### Evidence N/A rows

- Video walkthrough: **N/A — backend-only library/CLI, no UI surface; CLI transcripts above are the full user-visible behavior.**
- Before/after UI screenshots (desktop + mobile): **N/A — no rendered UI is touched; `packages/app` untouched.**
- Frontend console/network logs: **N/A — no frontend code path.**
- Real-LLM trajectories: **N/A — no agent/action/provider/prompt/model behavior changes; pure filesystem/git tooling.**
- Audio: **N/A — no voice surface.**

Domain artifacts (the bundle dir, manifest, meta, verify reports) are shown above and were inspected by hand.

Closes #14552.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
