### PR TITLE
fix(ui): surface cloud agent cap honestly instead of a false create toast (#14487)

### DIFF
--- a/packages/ui/src/api/client-cloud-select-or-provision.test.ts
+++ b/packages/ui/src/api/client-cloud-select-or-provision.test.ts
@@ -182,6 +182,78 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
     expect(result.agentId).toBe("agent-forced-new");
   });
 
+  it("reports created:false when the backend reused an existing agent despite forceCreate (org at per-org cap #11023) so the UI cannot claim a fresh agent (#14487)", async () => {
+    const { client, createCloudCompatAgent } = fakeClient();
+    // Backend hit the per-org cap: the reuse guard handed back the existing
+    // agent and the create route returned 200 `created: false`. The client
+    // must propagate that, not hardcode `created: true`.
+    createCloudCompatAgent.mockResolvedValue({
+      success: true,
+      created: false,
+      data: {
+        agentId: "agent-existing",
+        agentName: "Launch Verify Dedicated",
+        jobId: "",
+        status: "running",
+        nodeId: null,
+        message: "Agent created",
+      },
+    });
+    (client.getCloudCompatAgent as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: makeAgent({
+        agent_id: "agent-existing",
+        agent_name: "Launch Verify Dedicated",
+        status: "running",
+        web_ui_url: "https://agent-existing.example.test",
+        webUiUrl: "https://agent-existing.example.test",
+      }),
+    });
+
+    const result = await client.selectOrProvisionCloudAgent({
+      ...BASE_OPTS,
+      name: "Demo Fresh",
+      forceCreate: true,
+    });
+
+    expect(result.created).toBe(false);
+    expect(result.agentId).toBe("agent-existing");
+  });
+
+  it("keeps created:true when the create response omits the flag (older worker / non-direct path) so the pre-existing UX is unchanged", async () => {
+    const { client, createCloudCompatAgent } = fakeClient();
+    // No `created` field at all — the client must not demote a normal create.
+    createCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: {
+        agentId: "agent-legacy",
+        agentName: "Eliza",
+        jobId: "",
+        status: "provisioning",
+        nodeId: null,
+        message: "",
+      },
+    });
+    (client.getCloudCompatAgent as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: makeAgent({
+        agent_id: "agent-legacy",
+        status: "provisioning",
+        web_ui_url: "https://agent-legacy.example.test",
+        webUiUrl: "https://agent-legacy.example.test",
+      }),
+    });
+
+    const result = await client.selectOrProvisionCloudAgent({
+      ...BASE_OPTS,
+      name: "Eliza",
+      forceCreate: true,
+    });
+
+    expect(result.created).toBe(true);
+    expect(result.agentId).toBe("agent-legacy");
+  });
+
   // First-run handoff: a freshly-created dedicated agent whose container is still
   // provisioning must start on the SHARED REST adapter base (the always-on
   // in-Worker runtime serves the first turn instantly) — NOT on the dedicated

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -1076,6 +1076,15 @@ declare module "./client-base" {
       forceCreate?: boolean;
     }): Promise<{
       success: boolean;
+      /**
+       * Whether the backend actually MINTED a fresh agent (201/202) versus
+       * handing back an existing non-terminal one via the idempotent reuse
+       * guard (200, `created: false`), e.g. the org is at its per-org agent
+       * cap (#11023). Callers surfacing a "created" affordance must not claim a
+       * fresh agent when this is false (#14487). Undefined when the response
+       * omits the flag (older worker / non-direct path); treat as unknown.
+       */
+      created?: boolean;
       data: {
         agentId: string;
         agentName: string;
@@ -1722,6 +1731,10 @@ ElizaClient.prototype.createCloudCompatAgent = async function (
   const tierFields = opts.preferSharedTier ? {} : { alwaysOn: true };
   const direct = await directCloudRequest<{
     success: boolean;
+    // `created: false` means the backend reused an existing non-terminal agent
+    // (idempotent 200) instead of minting a fresh one, e.g. the org hit its
+    // per-org cap (#11023). Thread it up so the UI can tell the truth (#14487).
+    created?: boolean;
     data: unknown;
     error?: string;
   }>(this, "/api/v1/eliza/agents", {
@@ -1748,6 +1761,7 @@ ElizaClient.prototype.createCloudCompatAgent = async function (
     const data = parseDirectCloudAgentCreateData(direct.data, opts.agentName);
     return {
       success: direct.success,
+      created: direct.created,
       data: {
         agentId: data.id,
         agentName: data.agentName,
@@ -1776,6 +1790,8 @@ ElizaClient.prototype.createCloudCompatAgent = async function (
   if (isDirectCloudBase(this)) {
     const response = await this.fetch<{
       success: boolean;
+      // See the direct-path note: `created: false` = idempotent reuse (#14487).
+      created?: boolean;
       data: unknown;
       error?: string;
     }>("/api/v1/eliza/agents", {
@@ -1797,6 +1813,7 @@ ElizaClient.prototype.createCloudCompatAgent = async function (
     const data = parseDirectCloudAgentCreateData(response.data, opts.agentName);
     return {
       success: response.success,
+      created: response.created,
       data: {
         agentId: data.id,
         agentName: data.agentName,
@@ -3231,7 +3248,13 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
     agentName: created.data.agentName || name,
     apiBase,
     bridgeUrl: detailAgent?.bridge_url ?? null,
-    created: true,
+    // Report what the backend ACTUALLY did, not what we asked for. When the org
+    // is at its per-org cap (#11023) the create POST returns 200 `created:
+    // false` (the reuse guard handed back the existing agent), and the caller's
+    // "created a new agent" affordance must not lie about it (#14487). Only an
+    // explicit `false` demotes to reuse; an absent flag (older worker) stays
+    // `true` so the pre-existing create UX is unchanged.
+    created: created.created !== false,
   };
 };
 

--- a/packages/ui/src/components/settings/CloudAgentsSection.tsx
+++ b/packages/ui/src/components/settings/CloudAgentsSection.tsx
@@ -152,7 +152,7 @@ export function CloudAgentsSection() {
   }, []);
 
   const bindAndReload = useCallback(
-    (agentId: string, apiBase: string, label: string) => {
+    (agentId: string, apiBase: string, label: string, notice?: string) => {
       const token = currentCloudToken();
       const persisted = createPersistedActiveServer({
         kind: "cloud",
@@ -173,7 +173,11 @@ export function CloudAgentsSection() {
           : {}),
         ...(token ? { accessToken: token } : {}),
       });
-      setActionNotice(`Switched to ${label}. Reloading…`, "success", 3000);
+      setActionNotice(
+        notice ?? `Switched to ${label}. Reloading…`,
+        "success",
+        3000,
+      );
       // Re-boot the web app so startup restore re-binds the client + chat to
       // the newly-selected agent (same path a returning user takes).
       setTimeout(() => window.location.reload(), 250);
@@ -288,7 +292,22 @@ export function CloudAgentsSection() {
         forceCreate: true,
         onProgress: () => {},
       });
-      bindAndReload(result.agentId, result.apiBase, name);
+      // Honest outcome (#14487): with forceCreate the backend still reuses the
+      // org's existing agent when the org is at its per-org agent cap (#11023),
+      // returning `created: false`. Do NOT claim a fresh agent was made: bind
+      // to the (existing) agent we got back but tell the user why no new one
+      // appeared, so "Create a new agent" never silently lies.
+      const label = result.agentName || name;
+      if (result.created === false) {
+        bindAndReload(
+          result.agentId,
+          result.apiBase,
+          label,
+          `You've reached your agent limit, so we opened your existing agent “${label}” instead. Delete an agent or add credits to create another.`,
+        );
+      } else {
+        bindAndReload(result.agentId, result.apiBase, name);
+      }
     } catch (err) {
       setActionNotice(
         err instanceof Error ? err.message : "Failed to create agent.",


### PR DESCRIPTION
Fixes hypothesis-#1 of #14487 (cap/reuse UX honesty). Complementary to the merged #14496, which fixed hypothesis-#2 (forceCreate flag propagation).

## Problem
"Settings → Cloud → Agents → Create a new agent" could silently rebind to the existing agent while showing a "Switched to <name>. Reloading…" success toast — telling the user a fresh agent was created when it was not.

Even after #14496 correctly propagates `forceCreate: true` to the backend, the backend still legitimately reuses the org's existing agent when the org is at its **per-org agent cap** (#11023) — returning `200 { created: false, ... }`. The client threw that signal away:
- `createCloudCompatAgent`'s inline response type omitted `created`, so it always returned `message: "Agent created"`.
- `selectOrProvisionCloudAgent`'s create branch hardcoded `created: true` regardless of the backend's real answer.
- `CloudAgentsSection.createAgent` then fired the success toast even on a cap-reuse.

## Fix
- Thread the backend `created` flag through `createCloudCompatAgent` (both direct-cloud fetch paths) and `selectOrProvisionCloudAgent`'s create branch.
- Only an explicit `created === false` demotes to reuse; an absent flag (older worker / non-direct path) keeps `created: true` so the pre-existing create UX is byte-for-byte unchanged.
- `CloudAgentsSection.createAgent` surfaces an honest "you've reached your agent limit, opened your existing agent instead. Delete an agent or add credits to create another." notice on reuse, and still binds to the (existing) agent it got back.

## Verify (real pasted output)
```
$ vitest run src/api/client-cloud-select-or-provision.test.ts
 ✓ src/api/client-cloud-select-or-provision.test.ts (9 tests) 13ms
 Test Files  1 passed (1)
      Tests  9 passed (9)
```
(added 2 regression tests: cap-reuse → `created:false`; omitted-flag → `created:true`)
```
$ vitest run src/components/settings/CloudAgentsSection.test.tsx src/api/client-cloud-direct-auth.test.ts
 ✓ src/api/client-cloud-direct-auth.test.ts (29 tests) 92ms
 ✓ src/components/settings/CloudAgentsSection.test.tsx (24 tests) 12703ms
 Test Files  2 passed (2)
      Tests  53 passed (53)
```
(`bindAndReload` gained an optional `notice?` arg — backward-compatible; all existing switch/wake/suspend/delete tests still green.)
```
$ biome check <3 files> → Checked 3 files. No fixes applied.
```

Codex review hung >130s on this box; killed per fleet protocol and self-reviewed the diff (minimal, additive, no behavior change on the non-cap path).

## Scope / collision
- Files: `packages/ui/src/api/client-cloud.ts`, `.../client-cloud-select-or-provision.test.ts`, `.../settings/CloudAgentsSection.tsx`.
- Collision-checked vs #14496 (merged, disjoint region) and #14168 (onboarding UX polish — touches CloudAgentsSection but not `createAgent`/`bindAndReload`).
- No money-path / billing code touched. UI + client-transport only.

— [sol-cloud]
