### PR TITLE
fix(voice): wire web eliza-cloud ASR to POST audio to cloud STT (#14372)

### DIFF
--- a/packages/shared/src/elizacloud/server-cloud-stt.test.ts
+++ b/packages/shared/src/elizacloud/server-cloud-stt.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Cloud STT upstream URL resolution. `resolveCloudSttCandidateUrls` targets the
+ * `/voice/stt` route on the same base URL as TTS and fans out the www/apex host
+ * pair so a base written either way resolves; the ELIZAOS_CLOUD_BASE_URL env
+ * override takes precedence over the built-in default.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveCloudSttCandidateUrls } from "./server-cloud-tts";
+
+describe("resolveCloudSttCandidateUrls", () => {
+  afterEach(() => {
+    delete process.env.ELIZAOS_CLOUD_BASE_URL;
+  });
+
+  it("targets /voice/stt on the default cloud base", () => {
+    const urls = resolveCloudSttCandidateUrls({});
+    expect(urls).toContain("https://elizacloud.ai/api/v1/voice/stt");
+    for (const url of urls) {
+      expect(url.endsWith("/voice/stt")).toBe(true);
+    }
+  });
+
+  it("honors ELIZAOS_CLOUD_BASE_URL and fans out the www/apex pair", () => {
+    const urls = resolveCloudSttCandidateUrls({
+      ELIZAOS_CLOUD_BASE_URL: "https://staging.example.com/api/v1",
+    });
+    expect(urls).toContain("https://staging.example.com/api/v1/voice/stt");
+    expect(urls).toContain("https://www.staging.example.com/api/v1/voice/stt");
+  });
+
+  it("collapses a www base to include the apex host", () => {
+    const urls = resolveCloudSttCandidateUrls({
+      ELIZAOS_CLOUD_BASE_URL: "https://www.example.com/api/v1",
+    });
+    expect(urls).toContain("https://www.example.com/api/v1/voice/stt");
+    expect(urls).toContain("https://example.com/api/v1/voice/stt");
+  });
+});

--- a/packages/shared/src/elizacloud/server-cloud-tts.ts
+++ b/packages/shared/src/elizacloud/server-cloud-tts.ts
@@ -238,6 +238,35 @@ export function resolveCloudTtsCandidateUrls(
 }
 
 /**
+ * Upstream cloud STT endpoint (`POST /voice/stt`) candidates, derived from the
+ * same base URL as TTS. Interactive web capture posts a WAV here through the
+ * agent proxy (`/api/asr/cloud`) so `eliza-cloud` ASR is the real transcriber
+ * instead of the engine-dependent browser SpeechRecognition. The `www`/apex
+ * pairing mirrors the TTS resolver so a base URL written either way still
+ * resolves; there is no ElevenLabs-shaped legacy STT compat route (unlike TTS),
+ * so only the canonical `/voice/stt` path is queued.
+ */
+export function resolveCloudSttCandidateUrls(
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
+  const base = resolveCloudTtsBaseUrl(env).replace(/\/+$/, "");
+  const candidates = new Set<string>();
+  candidates.add(`${base}/voice/stt`);
+  try {
+    const parsed = new URL(base);
+    if (parsed.hostname.startsWith("www.")) {
+      parsed.hostname = parsed.hostname.slice(4);
+    } else {
+      parsed.hostname = `www.${parsed.hostname}`;
+    }
+    candidates.add(`${parsed.toString().replace(/\/$/, "")}/voice/stt`);
+  } catch {
+    // The base resolver already validated the default path.
+  }
+  return [...candidates];
+}
+
+/**
  * After a non-OK upstream response, only try the next URL for likely-transient /
  * wrong-route issues. Avoid retrying 401/402/429 etc. so we do not double-charge TTS.
  */

--- a/packages/ui/src/api/request-timeout.ts
+++ b/packages/ui/src/api/request-timeout.ts
@@ -66,7 +66,10 @@ export function defaultFetchTimeoutMs(
   if (pathname === "/api/tts/local-inference") {
     return LOCAL_INFERENCE_TTS_FETCH_TIMEOUT_MS;
   }
-  if (pathname === "/api/asr/local-inference") {
+  if (
+    pathname === "/api/asr/local-inference" ||
+    pathname === "/api/asr/cloud"
+  ) {
     return LOCAL_INFERENCE_ASR_FETCH_TIMEOUT_MS;
   }
   if (pathname === "/api/agent/reset") {

--- a/packages/ui/src/voice/STT_SELECTION.md
+++ b/packages/ui/src/voice/STT_SELECTION.md
@@ -17,6 +17,12 @@ interim transcripts, and the one whose assets are staged on phones), ahead of
 any provider preference. So the mobile `eliza-cloud` default below is the
 server-side route — it is not what runs the live on-device capture.
 
+On web/desktop the two layers now **agree** for `eliza-cloud`: `resolveBackendKind`
+routes `eliza-cloud`/`openai` capture to the cloud STT proxy (`/api/asr/cloud`
+→ `<cloud-base>/voice/stt`) by recording a WAV and POSTing it, so interactive
+web STT is the real cloud transcriber. Browser `SpeechRecognition` is used only
+when WAV capture is unsupported (no `getUserMedia`/`AudioContext`).
+
 ## Candidate backends
 
 | Backend | What it is | Where it can run |
@@ -24,8 +30,8 @@ server-side route — it is not what runs the live on-device capture.
 | **fused local ASR** (`local-inference`) | eliza-1-asr GGUF (Qwen3-ASR family, ~1.0 GB main+mmproj) through the fused `libelizainference` FFI | Linux/macOS/Windows desktop, Android (heavy), iOS (heavy) |
 | **`SFSpeechRecognizer`** | Apple on-device recognizer (ANE/CPU, `requiresOnDeviceRecognition=true`) | macOS / iOS only (OS engine, not an `AsrProvider` — reachable via the native talkmode bridge) |
 | **Android `SpeechRecognizer`** | Android OS recognizer (NNAPI) | Android only (OS engine, not an `AsrProvider` — reachable via the native talkmode bridge) |
-| **Browser `SpeechRecognition`** | Web Speech API, engine-dependent (often server-backed) | any browser shell; capture-time fallback only |
-| **Eliza Cloud ASR** (`eliza-cloud`) | server-side transcription via the cloud API | anywhere with connectivity |
+| **Browser `SpeechRecognition`** | Web Speech API, engine-dependent (often server-backed) | any browser shell; used **only** when WAV capture is unsupported (no `getUserMedia`/`AudioContext`) |
+| **Eliza Cloud ASR** (`eliza-cloud`) | server-side transcription via the cloud API; interactive web capture reaches it through the `/api/asr/cloud` proxy | anywhere with connectivity |
 
 ## Measured numbers (committed evidence)
 
@@ -55,7 +61,7 @@ Apple rows are real recorded / OS-synthesized speech.
 | --- | --- | --- | --- | --- |
 | Desktop (Linux/macOS/Windows) | local / local-only | `local-inference` | **Fused eliza-1-asr wins where provisioned**: measured WER 0.008 at 3.8× realtime on plain desktop CPU, robust to ≥ 10 dB SNR noise, fully offline. No candidate beats it on quality here, and it's the only offline option on Linux/Windows. If the bundle isn't provisioned, `isLocalInferenceAsrReady` degrades capture to the browser engine at runtime. | ✅ yes |
 | Mobile (Android/iOS) | local / local-only | `eliza-cloud` | The 1.0 GB fused model **runs** on Android (Pixel 6a WER 0 bring-up) but the only on-device measurement is 31.3 s including load, with steady-state RTF/battery unmeasured — not evidence of a good interactive default. Cloud ASR keeps latency predictable while the on-device Stage-B numbers are missing. Revisit when the Stage-B matrix (below) lands measured on-device RTF/battery. **Provider layer only:** native-mobile *interactive capture* uses the OS TalkMode recognizer regardless (see the two-layers note above); this `eliza-cloud` value is the server-side transcription route. | ✅ yes (provider layer) |
-| Web shell | local | `eliza-cloud` | A browser tab hosting a local agent has no fused FFI runtime; the Web Speech API is engine-dependent and unmeasured. Cloud is the deterministic choice. | ✅ yes |
+| Web shell | local | `eliza-cloud` | A browser tab hosting a local agent has no fused FFI runtime; the Web Speech API is engine-dependent and unmeasured. Cloud is the deterministic choice. Interactive capture now POSTs the WAV to the cloud STT proxy (`/api/asr/cloud`) instead of the browser recognizer. | ✅ yes |
 | any | cloud / remote | `eliza-cloud` | Agent isn't on this machine; audio must go to the server anyway. | ✅ yes |
 | macOS/iOS wake-confirm (Stage-B) | — | `SFSpeechRecognizer` | Measured WER 0 quiet / RTF 0.168 on Apple silicon makes it the cheapest-correct confirm recognizer on Apple (VOICE_UX.md §7). This is a talkmode-bridge engine, not an `AsrProvider` value, so it does not change `pickDefaultVoiceProvider`. | n/a (outside the provider enum) |
 

--- a/packages/ui/src/voice/local-asr-transcribe.test.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+// Verifies the cloud STT client leg: the WAV → `/api/asr/cloud` POST payload
+// shape and the fail-loud contract. `fetchWithCsrf` + `resolveApiUrl` are
+// stubbed so the assertions run against the request the helper builds, not a
+// live server.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchWithCsrf } from "../api/csrf-client";
+import { resolveApiUrl } from "../utils";
+import { transcribeCloudWav } from "./local-asr-transcribe";
+
+vi.mock("../api/csrf-client", () => ({
+  fetchWithCsrf: vi.fn(),
+}));
+
+vi.mock("../utils", () => ({
+  resolveApiUrl: vi.fn((path: string) => `http://agent.local${path}`),
+}));
+
+const fetchWithCsrfMock = vi.mocked(fetchWithCsrf);
+const resolveApiUrlMock = vi.mocked(resolveApiUrl);
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+describe("transcribeCloudWav", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("POSTs the raw WAV bytes to /api/asr/cloud and returns the transcript", async () => {
+    fetchWithCsrfMock.mockResolvedValue(jsonResponse({ text: "  hello world " }));
+    const wav = new Uint8Array([82, 73, 70, 70]); // "RIFF"
+
+    const text = await transcribeCloudWav(wav);
+
+    expect(resolveApiUrlMock).toHaveBeenCalledWith("/api/asr/cloud");
+    const [url, init] = fetchWithCsrfMock.mock.calls[0] ?? [];
+    expect(url).toBe("http://agent.local/api/asr/cloud");
+    expect(init?.method).toBe("POST");
+    // The WAV is sent as raw audio bytes (Content-Type audio/wav), NOT base64
+    // JSON — the proxy reads the raw body and re-wraps it as multipart.
+    expect(
+      (init?.headers as Record<string, string>)["Content-Type"],
+    ).toBe("audio/wav");
+    expect(init?.body).toBe(wav);
+    // Transcript is trimmed.
+    expect(text).toBe("hello world");
+  });
+
+  it("throws on a non-2xx response (fail-loud, no silent empty result)", async () => {
+    fetchWithCsrfMock.mockResolvedValue(
+      jsonResponse({ error: "no api key" }, false, 401),
+    );
+    await expect(transcribeCloudWav(new Uint8Array([1]))).rejects.toThrow(
+      /Cloud ASR 401/,
+    );
+  });
+
+  it("throws on an empty transcript rather than returning ''", async () => {
+    fetchWithCsrfMock.mockResolvedValue(jsonResponse({ text: "   " }));
+    await expect(transcribeCloudWav(new Uint8Array([1]))).rejects.toThrow(
+      /empty transcript/,
+    );
+  });
+
+  it("forwards an abort signal to fetch", async () => {
+    fetchWithCsrfMock.mockResolvedValue(jsonResponse({ text: "ok" }));
+    const controller = new AbortController();
+    await transcribeCloudWav(new Uint8Array([1]), {
+      signal: controller.signal,
+    });
+    const [, init] = fetchWithCsrfMock.mock.calls[0] ?? [];
+    expect(init?.signal).toBe(controller.signal);
+  });
+});

--- a/packages/ui/src/voice/local-asr-transcribe.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.ts
@@ -95,6 +95,51 @@ function bytesToBase64(bytes: Uint8Array): string {
   return btoa(binary);
 }
 
+/**
+ * POST a captured WAV to the agent's cloud STT proxy (`POST /api/asr/cloud`),
+ * which forwards it to Eliza Cloud's `/voice/stt` route and returns `{ text }`.
+ *
+ * This is the cloud counterpart to {@link transcribeLocalInferenceWav}: the
+ * interactive `eliza-cloud` capture path records the same mono PCM16 WAV and
+ * routes it here so web STT is the deterministic cloud transcriber instead of
+ * the engine-dependent browser recognizer. The WAV is sent as raw bytes (the
+ * proxy reads the raw body and re-wraps it as multipart for the cloud); no
+ * per-word timings are returned by the cloud route, so this yields text only.
+ *
+ * Fails loud: a non-2xx response or an empty transcript throws, so the capture
+ * surface renders an error state rather than silently substituting browser STT.
+ */
+export async function transcribeCloudWav(
+  audio: Uint8Array,
+  options?: TranscribeWavOptions,
+): Promise<string> {
+  const res = await fetchWithCsrf(resolveApiUrl("/api/asr/cloud"), {
+    method: "POST",
+    headers: {
+      "Content-Type": "audio/wav",
+      Accept: "application/json",
+    },
+    // A Uint8Array is a valid BufferSource body; the cast bridges the DOM lib's
+    // stricter `ArrayBuffer` generic on BodyInit (the runtime accepts it as-is).
+    body: audio as BodyInit,
+    signal: options?.signal,
+  });
+  if (!res.ok) {
+    // error-policy:J6 best-effort error detail — the throw carries the status
+    const body = await res.text().catch(() => "");
+    throw new Error(`Cloud ASR ${res.status}: ${body.slice(0, 200)}`);
+  }
+  // error-policy:J3 unparseable body falls through to the empty-transcript throw
+  const parsed = (await res.json().catch(() => null)) as {
+    text?: unknown;
+  } | null;
+  const text = typeof parsed?.text === "string" ? parsed.text.trim() : "";
+  if (!text) {
+    throw new Error("Cloud ASR returned an empty transcript");
+  }
+  return text;
+}
+
 export async function transcribeLocalInferenceWav(
   audio: Uint8Array,
   options?: TranscribeWavOptions,

--- a/packages/ui/src/voice/voice-capture-factory.test.ts
+++ b/packages/ui/src/voice/voice-capture-factory.test.ts
@@ -11,6 +11,7 @@ import {
 } from "./local-asr-capture";
 import {
   isLocalInferenceAsrReady,
+  transcribeCloudWav,
   transcribeLocalInferenceWav,
 } from "./local-asr-transcribe";
 import { createVoiceCapture } from "./voice-capture-factory";
@@ -22,6 +23,7 @@ vi.mock("./local-asr-capture", () => ({
 
 vi.mock("./local-asr-transcribe", () => ({
   isLocalInferenceAsrReady: vi.fn(),
+  transcribeCloudWav: vi.fn(),
   transcribeLocalInferenceWav: vi.fn(),
 }));
 
@@ -37,6 +39,7 @@ vi.mock("../bridge/native-plugins", async (importOriginal) => ({
 const isLocalAsrCaptureSupportedMock = vi.mocked(isLocalAsrCaptureSupported);
 const startLocalAsrRecorderMock = vi.mocked(startLocalAsrRecorder);
 const isLocalInferenceAsrReadyMock = vi.mocked(isLocalInferenceAsrReady);
+const transcribeCloudWavMock = vi.mocked(transcribeCloudWav);
 const transcribeLocalInferenceWavMock = vi.mocked(transcribeLocalInferenceWav);
 const isNativePlatformMock = vi.spyOn(Capacitor, "isNativePlatform");
 const getTalkModePluginMock = vi.mocked(getTalkModePlugin);
@@ -72,6 +75,7 @@ describe("createVoiceCapture", () => {
       text: "Ada Lovelace",
       words: [],
     });
+    transcribeCloudWavMock.mockResolvedValue("Grace Hopper");
     isNativePlatformMock.mockReturnValue(false);
     getTalkModePluginMock.mockReturnValue({} as never);
   });
@@ -269,5 +273,108 @@ describe("createVoiceCapture", () => {
     // A hands-free toggle-off must not send a half-finished utterance.
     expect(onTranscript).not.toHaveBeenCalled();
     expect(talkMode.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("eliza-cloud ASR records a WAV and POSTs it to the cloud STT proxy (not Web Speech)", async () => {
+    // The documented web/cloud default: capture the WAV and route it to the
+    // cloud transcriber — NOT the browser recognizer.
+    const wav = new Uint8Array([1, 2, 3, 4]);
+    const stop = vi.fn().mockResolvedValue(wav);
+    startLocalAsrRecorderMock.mockResolvedValue({
+      stop,
+      cancel: vi.fn(),
+      analyser: null,
+    });
+    const onTranscript = vi.fn();
+    const onStateChange = vi.fn();
+    const capture = createVoiceCapture({
+      asrProvider: "eliza-cloud",
+      onTranscript,
+      onStateChange,
+    });
+
+    await capture.start();
+    // The WAV recorder is the capture engine (not browser SpeechRecognition);
+    // the local-inference readiness probe is never consulted for cloud.
+    expect(startLocalAsrRecorderMock).toHaveBeenCalledTimes(1);
+    expect(isLocalInferenceAsrReadyMock).not.toHaveBeenCalled();
+
+    await capture.stop();
+
+    // The recorded WAV is POSTed to the cloud proxy; local-inference transcribe
+    // is NOT used and the cloud transcript is the final segment.
+    expect(transcribeCloudWavMock).toHaveBeenCalledTimes(1);
+    expect(transcribeCloudWavMock).toHaveBeenCalledWith(wav);
+    expect(transcribeLocalInferenceWavMock).not.toHaveBeenCalled();
+    expect(onTranscript).toHaveBeenCalledWith({
+      text: "Grace Hopper",
+      final: true,
+      backend: "cloud",
+      audioWav: wav,
+    });
+    expect(onStateChange).toHaveBeenLastCalledWith("stopped", undefined);
+  });
+
+  it("openai ASR also routes through the cloud STT proxy", async () => {
+    const wav = new Uint8Array([9]);
+    startLocalAsrRecorderMock.mockResolvedValue({
+      stop: vi.fn().mockResolvedValue(wav),
+      cancel: vi.fn(),
+      analyser: null,
+    });
+    const onTranscript = vi.fn();
+    const capture = createVoiceCapture({
+      asrProvider: "openai",
+      onTranscript,
+    });
+
+    await capture.start();
+    await capture.stop();
+
+    expect(transcribeCloudWavMock).toHaveBeenCalledWith(wav);
+    expect(onTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({ backend: "cloud", text: "Grace Hopper" }),
+    );
+  });
+
+  it("cloud STT failure surfaces an error state — no silent browser downgrade", async () => {
+    startLocalAsrRecorderMock.mockResolvedValue({
+      stop: vi.fn().mockResolvedValue(new Uint8Array([1])),
+      cancel: vi.fn(),
+      analyser: null,
+    });
+    transcribeCloudWavMock.mockRejectedValue(new Error("Cloud ASR 502: down"));
+    const onTranscript = vi.fn();
+    const onStateChange = vi.fn();
+    const capture = createVoiceCapture({
+      asrProvider: "eliza-cloud",
+      onTranscript,
+      onStateChange,
+    });
+
+    await capture.start();
+    // Fail-loud: the proxy failure throws + renders the error state; it does NOT
+    // fall back to a browser-final transcript.
+    await expect(capture.stop()).rejects.toThrow(/Cloud ASR 502/);
+    expect(onStateChange).toHaveBeenLastCalledWith("error", expect.any(Error));
+    expect(onTranscript).not.toHaveBeenCalled();
+  });
+
+  it("falls back to browser ONLY when WAV capture is unsupported for eliza-cloud", async () => {
+    // No getUserMedia/AudioContext → no WAV path exists, so the honest fallback
+    // is the browser recognizer. jsdom has no SpeechRecognition, so start()
+    // rejects — the point is the cloud recorder was never started.
+    isLocalAsrCaptureSupportedMock.mockReturnValue(false);
+    const onStateChange = vi.fn();
+    const capture = createVoiceCapture({
+      asrProvider: "eliza-cloud",
+      onStateChange,
+      onTranscript: vi.fn(),
+    });
+
+    await expect(capture.start()).rejects.toThrow(/SpeechRecognition/);
+    expect(startLocalAsrRecorderMock).not.toHaveBeenCalled();
+    expect(transcribeCloudWavMock).not.toHaveBeenCalled();
+    expect(onStateChange).toHaveBeenLastCalledWith("error", expect.any(Error));
   });
 });

--- a/packages/ui/src/voice/voice-capture-factory.ts
+++ b/packages/ui/src/voice/voice-capture-factory.ts
@@ -10,8 +10,14 @@
  *    capture mic audio via {@link startLocalAsrRecorder}, POST the WAV to
  *    `/api/asr/local-inference`, and emit the resulting transcript as one
  *    `final: true` segment on stop.
- * 2. Otherwise fall back to the browser SpeechRecognition API, emitting
- *    interim and final segments as they arrive.
+ * 2. If the resolved provider is `eliza-cloud` / `openai` and WAV capture is
+ *    supported, capture the same WAV and POST it to the cloud STT proxy
+ *    (`/api/asr/cloud`) — the cloud transcript is the final. This is the real
+ *    web STT path for the documented `eliza-cloud` ASR default.
+ * 3. Otherwise fall back to the browser SpeechRecognition API, emitting
+ *    interim and final segments as they arrive — used only when WAV capture is
+ *    unsupported (no `getUserMedia` / `AudioContext`), which is the one case
+ *    where no cloud/local WAV path exists.
  *
  * Mic permission + AudioContext + MediaStream lifecycle is owned by the
  * underlying primitives ({@link startLocalAsrRecorder} + browser
@@ -34,6 +40,7 @@ import {
 } from "./local-asr-capture";
 import {
   isLocalInferenceAsrReady,
+  transcribeCloudWav,
   transcribeLocalInferenceWav,
 } from "./local-asr-transcribe";
 import {
@@ -44,7 +51,11 @@ import {
 } from "./voice-chat-types";
 
 /** Backend the factory ended up using for the current capture. */
-export type VoiceCaptureBackend = "local-inference" | "browser" | "talkmode";
+export type VoiceCaptureBackend =
+  | "local-inference"
+  | "cloud"
+  | "browser"
+  | "talkmode";
 
 /** Single transcript chunk delivered to the caller. */
 export interface VoiceCaptureTranscriptSegment {
@@ -60,9 +71,9 @@ export interface VoiceCaptureTranscriptSegment {
   backend: VoiceCaptureBackend;
   /**
    * The recorded utterance audio as a mono PCM16 WAV (RIFF header carries the
-   * sample rate) — attached ONLY to the local-inference final segment, where
-   * the WAV already exists for ASR. Absent for browser/talkmode (no PCM is
-   * exposed). Used by the transcript recorder to retain audio for playback.
+   * sample rate) — attached to the local-inference and cloud final segments,
+   * where the WAV already exists for ASR. Absent for browser/talkmode (no PCM
+   * is exposed). Used by the transcript recorder to retain audio for playback.
    */
   audioWav?: Uint8Array;
   /**
@@ -185,9 +196,19 @@ async function resolveBackendKind(
   ) {
     return "local-inference";
   }
-  // Eliza-cloud / OpenAI providers go through the local-inference route
-  // server-side today; until that changes, browser API is the only sane
-  // client-side fallback.
+  // Eliza-cloud / OpenAI ASR: capture the same WAV as the local path and POST
+  // it to the cloud STT proxy (`/api/asr/cloud`). This is the real transcriber
+  // for the documented web/cloud `eliza-cloud` default — the browser recognizer
+  // is engine-dependent (or absent) and is NOT the cloud path.
+  if (
+    (preferred === "eliza-cloud" || preferred === "openai") &&
+    isLocalAsrCaptureSupported()
+  ) {
+    return "cloud";
+  }
+  // Browser SpeechRecognition is the fallback ONLY where no WAV path exists —
+  // a renderer without `getUserMedia`/`AudioContext` can't record a WAV to POST,
+  // so the browser recognizer is the sole remaining client-side option.
   return "browser";
 }
 
@@ -223,7 +244,10 @@ export function createVoiceCapture(
     onStateChange?.(next, error);
   }
 
-  async function startLocalInference(): Promise<void> {
+  // Shared WAV-capture start for both the local-inference and cloud backends —
+  // identical mic setup; the backends diverge only at stop() (which route the
+  // WAV is POSTed to).
+  async function startWavRecorder(): Promise<void> {
     const next = await startLocalAsrRecorder({
       ...(localAsrAutoStop ? { autoStop: localAsrAutoStop } : {}),
       onAutoStop: () => {
@@ -367,8 +391,8 @@ export function createVoiceCapture(
       backendKind = await resolveBackendKind(asrProvider);
       if (backendKind === "talkmode") {
         await startTalkMode();
-      } else if (backendKind === "local-inference") {
-        await startLocalInference();
+      } else if (backendKind === "local-inference" || backendKind === "cloud") {
+        await startWavRecorder();
       } else {
         startBrowser();
       }
@@ -407,8 +431,9 @@ export function createVoiceCapture(
       return;
     }
 
-    if (backendKind === "local-inference") {
+    if (backendKind === "local-inference" || backendKind === "cloud") {
       const current = recorder;
+      const kind = backendKind;
       recorder = null;
       active = false;
       if (!current) {
@@ -417,18 +442,31 @@ export function createVoiceCapture(
       }
       try {
         const wav = await current.stop();
-        const { text, words } = await transcribeLocalInferenceWav(wav);
-        onTranscript({
-          text,
-          final: true,
-          backend: "local-inference",
-          audioWav: wav,
-          words,
-        });
+        if (kind === "cloud") {
+          // Cloud STT returns text only (no per-word timings); the WAV is still
+          // attached so the transcript recorder can retain the audio.
+          const text = await transcribeCloudWav(wav);
+          onTranscript({
+            text,
+            final: true,
+            backend: "cloud",
+            audioWav: wav,
+          });
+        } else {
+          const { text, words } = await transcribeLocalInferenceWav(wav);
+          onTranscript({
+            text,
+            final: true,
+            backend: "local-inference",
+            audioWav: wav,
+            words,
+          });
+        }
         setState("stopped");
       } catch (err) {
         // error-policy:J1 stop/transcribe boundary — the failure renders the
-        // voice error state and still propagates to the caller
+        // voice error state and still propagates to the caller. Cloud STT
+        // failures surface here (fail-loud): no silent downgrade to browser STT.
         const error = err instanceof Error ? err : new Error(String(err));
         setState("error", error);
         throw error;

--- a/packages/ui/src/voice/voice-provider-defaults.ts
+++ b/packages/ui/src/voice/voice-provider-defaults.ts
@@ -39,6 +39,12 @@
  * actually staged on phones) ahead of any provider preference. So on native
  * mobile the `eliza-cloud` value below governs server-side transcription, not
  * the live on-device capture path — the two layers are chosen independently.
+ *
+ * On web/desktop the two layers now agree for `eliza-cloud`: the capture
+ * factory records a WAV and POSTs it to the cloud STT proxy (`/api/asr/cloud`),
+ * so interactive `eliza-cloud` ASR is the real cloud transcriber. Browser
+ * SpeechRecognition is used only when WAV capture is unsupported (no
+ * `getUserMedia`/`AudioContext`).
  */
 
 import type { AsrProvider, VoiceProvider } from "../api/client-types-config";

--- a/plugins/plugin-elizacloud/__tests__/unit/server-cloud-stt.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/server-cloud-stt.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Agent-side cloud STT proxy (`POST /api/asr/cloud`). Verifies the WAV → cloud
+ * `/voice/stt` multipart forward and the fail-loud contract (401 with no cloud
+ * key, 502 on an unreachable upstream) using a fake req/res and a stubbed
+ * global `fetch` — no live cloud service.
+ */
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handleCloudSttRoute } from "../../src/lib/server-cloud-tts";
+
+function fakeRequest(body: Buffer, contentType = "audio/wav") {
+  const stream = new PassThrough();
+  stream.end(body);
+  return Object.assign(stream, {
+    headers: { "content-type": contentType },
+  }) as unknown as import("node:http").IncomingMessage;
+}
+
+function fakeResponse() {
+  const headers: Record<string, string> = {};
+  const res = {
+    statusCode: 0,
+    headersSent: false,
+    body: "",
+    setHeader(name: string, value: string) {
+      headers[name.toLowerCase()] = value;
+    },
+    end(chunk?: string) {
+      if (chunk) res.body += chunk;
+      res.headersSent = true;
+    },
+    headers,
+  };
+  return res as unknown as import("node:http").ServerResponse & {
+    body: string;
+    statusCode: number;
+  };
+}
+
+describe("handleCloudSttRoute", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.env.ELIZAOS_CLOUD_API_KEY = "test-cloud-key";
+    delete process.env.ELIZAOS_CLOUD_BASE_URL;
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    delete process.env.ELIZAOS_CLOUD_API_KEY;
+    fetchSpy.mockRestore();
+  });
+
+  it("forwards the WAV to the cloud /voice/stt route as multipart and returns { text }", async () => {
+    fetchSpy.mockResolvedValue(
+      new Response(JSON.stringify({ text: "  transcribed  " }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+    const wav = Buffer.from([82, 73, 70, 70, 1, 2, 3]); // "RIFF"..
+    const req = fakeRequest(wav);
+    const res = fakeResponse();
+
+    const handled = await handleCloudSttRoute(req, res);
+
+    expect(handled).toBe(true);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] ?? [];
+    expect(String(url)).toMatch(/\/voice\/stt$/);
+    expect((init as RequestInit).method).toBe("POST");
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer test-cloud-key");
+    // Multipart body: a FormData carrying the `audio` field.
+    const form = (init as RequestInit).body as FormData;
+    expect(form).toBeInstanceOf(FormData);
+    const audio = form.get("audio");
+    expect(audio).toBeInstanceOf(Blob);
+    expect((audio as Blob).size).toBe(wav.length);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ text: "transcribed" });
+  });
+
+  it("returns 401 when Eliza Cloud is not connected (no api key)", async () => {
+    delete process.env.ELIZAOS_CLOUD_API_KEY;
+    // Point config resolution at a path that does not exist so a real
+    // ~/.local/state config with a cloud key on the dev box can't leak in.
+    process.env.ELIZA_CONFIG_PATH = "/nonexistent/eliza-stt-test-no-key.json";
+    const res = fakeResponse();
+
+    await handleCloudSttRoute(fakeRequest(Buffer.from([1])), res);
+
+    delete process.env.ELIZA_CONFIG_PATH;
+    expect(res.statusCode).toBe(401);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an empty audio body", async () => {
+    const res = fakeResponse();
+    await handleCloudSttRoute(fakeRequest(Buffer.alloc(0)), res);
+    expect(res.statusCode).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("fails loud with 502 when the upstream is unreachable", async () => {
+    fetchSpy.mockResolvedValue(new Response("upstream down", { status: 503 }));
+    const res = fakeResponse();
+
+    await handleCloudSttRoute(fakeRequest(Buffer.from([1, 2])), res);
+
+    expect(res.statusCode).toBe(502);
+    expect(res.body).toMatch(/Eliza Cloud STT failed/);
+  });
+});

--- a/plugins/plugin-elizacloud/src/index.browser.ts
+++ b/plugins/plugin-elizacloud/src/index.browser.ts
@@ -22,6 +22,7 @@ export function getCloudSecret(
 export function clearCloudSecrets(): void {}
 
 export const ensureCloudTtsApiKeyAlias = unavailableBrowserExport;
+export const handleCloudSttRoute = unavailableBrowserExport;
 export const handleCloudTtsPreviewRoute = unavailableBrowserExport;
 export const mirrorCompatHeaders = unavailableBrowserExport;
 export const normalizeCloudSiteUrl = unavailableBrowserExport;

--- a/plugins/plugin-elizacloud/src/index.node.ts
+++ b/plugins/plugin-elizacloud/src/index.node.ts
@@ -51,6 +51,7 @@ export {
 export {
   __resetCloudBaseUrlCache,
   ensureCloudTtsApiKeyAlias,
+  handleCloudSttRoute,
   handleCloudTtsPreviewRoute,
   mirrorCompatHeaders,
   resolveCloudTtsBaseUrl,

--- a/plugins/plugin-elizacloud/src/index.ts
+++ b/plugins/plugin-elizacloud/src/index.ts
@@ -501,6 +501,7 @@ export {
 export {
   __resetCloudBaseUrlCache,
   ensureCloudTtsApiKeyAlias,
+  handleCloudSttRoute,
   handleCloudTtsPreviewRoute,
   mirrorCompatHeaders,
   resolveCloudTtsBaseUrl,

--- a/plugins/plugin-elizacloud/src/lib/server-cloud-tts.ts
+++ b/plugins/plugin-elizacloud/src/lib/server-cloud-tts.ts
@@ -10,11 +10,12 @@
  * it wires together the runtime route system.
  */
 import type http from "node:http";
-import { sanitizeSpeechText } from "@elizaos/core";
+import { logger, sanitizeSpeechText } from "@elizaos/core";
 import {
   _internalResolveCloudApiKey,
   ELIZA_CLOUD_TTS_MAX_TEXT_CHARS,
   resolveCloudProxyTtsModel,
+  resolveCloudSttCandidateUrls,
   resolveCloudTtsCandidateUrls,
   resolveElizaCloudTtsVoiceId,
   shouldRetryCloudTtsUpstream,
@@ -295,6 +296,153 @@ export async function handleCloudTtsPreviewRoute(
       res,
       502,
       `Eliza Cloud TTS request failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return true;
+  }
+}
+
+/** WAV bodies larger than this are rejected before proxying (cloud caps at 25MB). */
+const ELIZA_CLOUD_STT_MAX_BYTES = 25 * 1024 * 1024;
+
+/**
+ * Read the raw request body up to a byte cap, aborting past the limit. The STT
+ * body is opaque audio bytes (a WAV), so it is streamed straight through rather
+ * than JSON-parsed — the cap prevents an oversized upload from buffering
+ * unbounded before the cloud's own size check rejects it.
+ */
+async function readCappedRequestBody(
+  req: http.IncomingMessage,
+  maxBytes: number,
+): Promise<Buffer | null> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of req) {
+    const buf = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+    total += buf.length;
+    if (total > maxBytes) return null;
+    chunks.push(buf);
+  }
+  return Buffer.concat(chunks);
+}
+
+/**
+ * Agent-side proxy for interactive web STT (`POST /api/asr/cloud`). Interactive
+ * capture records a mono PCM16 WAV client-side and POSTs the raw bytes here;
+ * this forwards them as a multipart `audio` field to the same upstream cloud STT
+ * route (`<cloud-base>/voice/stt`) the server-side transcription model uses, and
+ * returns `{ text }`. It mirrors {@link handleCloudTtsPreviewRoute} exactly:
+ * same base-URL / api-key resolution, same www/apex candidate fan-out, same
+ * fail-loud contract — a missing key is 401 and an unreachable upstream is 502
+ * so the capture surface renders a distinguishable error state rather than
+ * silently downgrading to the browser recognizer.
+ */
+export async function handleCloudSttRoute(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+): Promise<boolean> {
+  const cloudApiKey = _internalResolveCloudApiKey();
+  if (!cloudApiKey) {
+    sendJsonErrorResponse(
+      res,
+      401,
+      "Eliza Cloud is not connected. Connect your Eliza Cloud account first.",
+    );
+    return true;
+  }
+
+  const rawBody = await readCappedRequestBody(req, ELIZA_CLOUD_STT_MAX_BYTES);
+  if (rawBody === null) {
+    sendJsonErrorResponse(res, 413, "Audio too large");
+    return true;
+  }
+  if (rawBody.length === 0) {
+    sendJsonErrorResponse(res, 400, "Missing audio body");
+    return true;
+  }
+
+  const contentType = req.headers["content-type"];
+  const mime =
+    typeof contentType === "string" && contentType.trim()
+      ? contentType.split(";", 1)[0]?.trim() || "audio/wav"
+      : "audio/wav";
+  const filename = mime.includes("wav") ? "recording.wav" : "recording.bin";
+
+  const cloudUrls = resolveCloudSttCandidateUrls();
+  logger.debug(
+    `[Cloud STT] proxying ${rawBody.length}B ${mime} to ${cloudUrls.length} candidate(s)`,
+  );
+
+  try {
+    let lastStatus = 0;
+    let lastDetails = "unknown error";
+    let cloudResponse: Response | null = null;
+    for (let i = 0; i < cloudUrls.length; i++) {
+      const cloudUrl = cloudUrls[i];
+      if (cloudUrl === undefined) continue;
+      const form = new FormData();
+      form.append(
+        "audio",
+        new Blob([new Uint8Array(rawBody)], { type: mime }),
+        filename,
+      );
+      const attempt = await fetch(cloudUrl, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${cloudApiKey}`,
+          "x-api-key": cloudApiKey,
+        },
+        body: form,
+      });
+      if (attempt.ok) {
+        cloudResponse = attempt;
+        break;
+      }
+      lastStatus = attempt.status;
+      lastDetails = await attempt.text().catch(() => "unknown error");
+      const hasMoreCandidates = i < cloudUrls.length - 1;
+      if (!hasMoreCandidates || !shouldRetryCloudTtsUpstream(attempt.status)) {
+        break;
+      }
+    }
+
+    if (!cloudResponse) {
+      logger.warn(`[Cloud STT] upstream failed (${lastStatus || 502})`);
+      if (
+        lastStatus === 400 ||
+        lastStatus === 401 ||
+        lastStatus === 402 ||
+        lastStatus === 403 ||
+        lastStatus === 429
+      ) {
+        forwardCloudTtsUpstreamError(res, lastStatus, lastDetails);
+        return true;
+      }
+      sendJsonErrorResponse(
+        res,
+        502,
+        `Eliza Cloud STT failed (${lastStatus || 502}): ${lastDetails}`,
+      );
+      return true;
+    }
+
+    const data = (await cloudResponse.json().catch(() => null)) as {
+      text?: unknown;
+      transcript?: unknown;
+    } | null;
+    const text =
+      typeof data?.text === "string"
+        ? data.text.trim()
+        : typeof data?.transcript === "string"
+          ? data.transcript.trim()
+          : "";
+    logger.debug(`[Cloud STT] transcript ${text.length} chars`);
+    sendJsonResponse(res, 200, { text });
+    return true;
+  } catch (err) {
+    sendJsonErrorResponse(
+      res,
+      502,
+      `Eliza Cloud STT request failed: ${err instanceof Error ? err.message : String(err)}`,
     );
     return true;
   }

--- a/plugins/plugin-elizacloud/src/plugin.ts
+++ b/plugins/plugin-elizacloud/src/plugin.ts
@@ -30,7 +30,10 @@ import {
   handleCloudRoute,
 } from "./routes/cloud-routes";
 import { handleCloudStatusRoutes } from "./routes/cloud-status-routes";
-import { handleCloudTtsPreviewRoute } from "./lib/server-cloud-tts";
+import {
+  handleCloudSttRoute,
+  handleCloudTtsPreviewRoute,
+} from "./lib/server-cloud-tts";
 import {
   handleXRelayRoute,
   type XRelayRouteState,
@@ -186,6 +189,13 @@ async function cloudTtsPreviewHandler(
   );
 }
 
+async function cloudSttHandler(req: unknown, res: unknown): Promise<void> {
+  await handleCloudSttRoute(
+    req as http.IncomingMessage,
+    res as http.ServerResponse,
+  );
+}
+
 const cloudRoutes: Route[] = [
   // Status surface (read-only). Note: server.ts may exempt this from auth on
   // cloud-provisioned containers BEFORE the plugin route system fires.
@@ -232,6 +242,14 @@ const cloudRoutes: Route[] = [
     modes: ["local", "cloud", "remote"],
     modeReason: "cloud TTS preview — hidden in local-only",
     handler: cloudTtsPreviewHandler,
+  },
+  {
+    type: "POST",
+    path: "/api/asr/cloud",
+    rawPath: true,
+    modes: ["local", "cloud", "remote"],
+    modeReason: "cloud STT proxy — no cloud account in local-only",
+    handler: cloudSttHandler,
   },
   ...(["GET", "POST", "PUT", "PATCH", "DELETE"] as const).map((type) => ({
     type,


### PR DESCRIPTION
## What & why

The documented web/cloud STT default is `eliza-cloud`, but `resolveBackendKind` in `voice-capture-factory.ts` resolved `eliza-cloud`/`openai` to the browser **Web Speech API** — interactive web capture never sent audio to the cloud STT route. Web STT was therefore engine-dependent (Chrome ships audio to Google's recognizer; some browsers have **no** Web Speech at all), unmeasured, and inconsistent with the provider setting users see.

This wires `eliza-cloud` ASR for real, mirroring the existing local-inference leg:

- **New agent proxy `POST /api/asr/cloud`** (`plugin-elizacloud` -> `handleCloudSttRoute`): forwards a captured WAV as multipart `audio` to `<cloud-base>/voice/stt` — the same upstream the server-side transcription model uses (`transcription.ts` `postApiV1VoiceSttRaw`). Mirrors `/api/tts/cloud` exactly: same base-URL / api-key resolution, same www/apex candidate fan-out, and the **fail-loud** contract (401 when no cloud key, 502 when the upstream is unreachable).
- **New shared `resolveCloudSttCandidateUrls`** (next to `resolveCloudTtsCandidateUrls`).
- **New client `transcribeCloudWav`** POSTs the recorded WAV to the proxy and returns the transcript (throws on non-2xx / empty).
- **`resolveBackendKind`** now routes `eliza-cloud`/`openai` to a new `cloud` backend: it records the same WAV as the local path (`startLocalAsrRecorder`), POSTs it to `/api/asr/cloud`, and emits the cloud transcript as the final segment. Browser SpeechRecognition remains **only** where WAV capture is genuinely unsupported (no `getUserMedia`/`AudioContext`).
- Cloud STT failure surfaces a distinguishable **error** state — no silent downgrade to a browser-final transcript (fail-fast doctrine).
- Docs aligned to reality: `voice-provider-defaults.ts` layering caveat + `STT_SELECTION.md` decision table.

Closes #14372

## Verification

<details><summary>Client + factory unit tests (vitest, jsdom) — 16 pass</summary>

```
$ cd packages/ui && vitest run src/voice/voice-capture-factory.test.ts src/voice/local-asr-transcribe.test.ts
 Test Files  2 passed (2)
      Tests  16 passed (16)
```
Covers: `eliza-cloud` -> cloud POST path (not Web Speech), `openai` -> cloud, cloud-STT failure -> error state (no browser downgrade), browser fallback ONLY when WAV capture unsupported, and the `transcribeCloudWav` POST payload shape (raw `audio/wav` body to `/api/asr/cloud`, trimmed transcript, fail-loud on non-2xx / empty, abort-signal forwarding).
</details>

<details><summary>Agent proxy handler unit tests (vitest) — 4 pass</summary>

```
$ cd plugins/plugin-elizacloud && vitest run __tests__/unit/server-cloud-stt.test.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)
```
Covers: WAV -> multipart `audio` forward to `<base>/voice/stt` with `Authorization: Bearer`, returns `{ text }`; 401 when no cloud key; 400 empty body; 502 fail-loud on unreachable upstream. Uses a stubbed global `fetch` (no live service).
</details>

<details><summary>Shared resolver unit tests (vitest) — 3 pass</summary>

```
$ cd packages/shared && vitest run src/elizacloud/server-cloud-stt.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
```
`resolveCloudSttCandidateUrls` targets `/voice/stt`, honors `ELIZAOS_CLOUD_BASE_URL`, fans out www/apex.
</details>

<details><summary>Scoped typecheck — touched files clean</summary>

```
$ cd plugins/plugin-elizacloud && tsc --noEmit -p tsconfig.json | grep -c 'error TS'
0
$ cd packages/shared && tsc --noEmit -p tsconfig.json | grep 'server-cloud'   # (no output)
$ cd packages/ui && tsc --noEmit -p tsconfig.json | grep -E 'voice-capture-factory|local-asr-transcribe|request-timeout|voice-provider-defaults'   # (no output)
```
(packages/ui has pre-existing repo-wide `@types/react` duplication errors under the worktree's shared node_modules, unrelated to these files and present on `develop`.)
</details>

## Evidence

| Evidence | Status |
| --- | --- |
| Unit tests (factory routing, POST payload shape, fail-loud, shared resolver, proxy handler) | Pasted above |
| Scoped typecheck of touched packages | Pasted above |
| MP4: web push-to-talk -> real cloud transcript + network tab showing `/api/asr/cloud` POST | N/A — requires the live Railway Whisper STT service + a connected Eliza Cloud account. Owner repro: `bun run dev`, connect Eliza Cloud, set ASR provider `eliza-cloud`, push-to-talk in the composer, observe `POST /api/asr/cloud` in the network tab and the `[Cloud STT]` backend debug line. |
| Full mic->cloud round-trip (real audio, backend `[Cloud STT]` log) | N/A — same live-service dependency; the `voice-realaudio` live variant (issue 2, #14371) exercises this end-to-end path against Railway. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
