### PR TITLE
fix(types): restore the type-safety ratchet to baseline — bun run verify red on develop

### DIFF
--- a/packages/agent/src/actions/knowledge.ts
+++ b/packages/agent/src/actions/knowledge.ts
@@ -171,9 +171,7 @@ async function resolveItem(
   mimeType?: string;
   title: string;
 } | null> {
-  const { service } = await getDocumentsService(
-    runtime as unknown as Parameters<typeof getDocumentsService>[0],
-  );
+  const { service } = await getDocumentsService(runtime);
   const asId = asUuid(itemRef);
   let memory: Memory | null = null;
   if (asId) {
@@ -367,9 +365,7 @@ export const searchKnowledgeAction: Action = {
       {}) as Record<string, unknown>;
     const query = typeof params.query === "string" ? params.query.trim() : "";
 
-    const { service, reason } = await getDocumentsService(
-      runtime as unknown as Parameters<typeof getDocumentsService>[0],
-    );
+    const { service, reason } = await getDocumentsService(runtime);
     if (!service) {
       return fail(
         "Knowledge store is not available.",

--- a/packages/agent/src/api/documents-service-loader.ts
+++ b/packages/agent/src/api/documents-service-loader.ts
@@ -9,7 +9,7 @@
  */
 import type {
   AccessContext,
-  AgentRuntime,
+  IAgentRuntime,
   Memory,
   Service,
   UUID,
@@ -131,7 +131,7 @@ export function getDocumentsServiceTimeoutMs(): number {
 }
 
 export async function getDocumentsService(
-  runtime: AgentRuntime | null,
+  runtime: IAgentRuntime | null,
 ): Promise<DocumentsServiceResult> {
   if (!runtime) {
     return { service: null, reason: "runtime_unavailable" };

--- a/packages/agent/src/providers/ui-catalog.ts
+++ b/packages/agent/src/providers/ui-catalog.ts
@@ -204,15 +204,19 @@ const JSONL_PATCH_RE = /"op"\s*:\s*"(?:add|replace|remove)"/;
  * catalog. Fires only on dashboard/table/visualization intent so its ~150
  * lines never tax a plugin-setup or scheduling turn.
  */
+// Shared by the provider metadata and its own get() intent gate, so the gate
+// never has to reach back through the optional Provider field.
+const GENERATIVE_INTENT_KEYWORDS = getValidationKeywordTerms(
+  "provider.uiGenerative.relevance",
+  { includeAllLocales: true },
+);
+
 export const uiGenerativeProvider: Provider = {
   name: "uiGenerative",
   description:
     "How to render custom dashboards, tables, charts, and metrics views as generative UI (JSONL patches + component catalog)",
   dynamic: true,
-  relevanceKeywords: getValidationKeywordTerms(
-    "provider.uiGenerative.relevance",
-    { includeAllLocales: true },
-  ),
+  relevanceKeywords: GENERATIVE_INTENT_KEYWORDS,
   contexts: ["general"],
   contextGate: { anyOf: ["general"] },
   // Renders after uiWidgets (markers-first); composeState orders by
@@ -230,7 +234,7 @@ export const uiGenerativeProvider: Provider = {
     // generative UI is already mid-iteration (recent JSONL patches). This is
     // the sole guard on the hot path — the v5 planner composes context-gated
     // dynamic providers on every general ADMIN turn.
-    const keywords = uiGenerativeProvider.relevanceKeywords ?? [];
+    const keywords = GENERATIVE_INTENT_KEYWORDS;
     const texts = [
       message.content.text ?? "",
       ...getRecentMessagesData(state).map((m) => m.content.text ?? ""),

--- a/packages/ui/src/testing/widget-cert.ts
+++ b/packages/ui/src/testing/widget-cert.ts
@@ -211,22 +211,17 @@ export function certifyWidget(
     for (const el of collectScrollers(root)) {
       const box = provider.box(el);
       const cs = provider.computed(el);
-      const anyEl = el as unknown as {
-        scrollHeight: number;
-        scrollWidth: number;
-        scrollTop: number;
-      };
       const geo: ScrollerGeometry = {
-        scrollHeight: anyEl.scrollHeight,
+        scrollHeight: el.scrollHeight,
         clientHeight: box.height,
-        scrollWidth: anyEl.scrollWidth,
+        scrollWidth: el.scrollWidth,
         clientWidth: box.width,
         overflowY: cs.overflowY,
         overflowX: cs.overflowX,
         overscrollBehaviorY: cs.overscrollBehaviorY,
         midScrollTopSettled: provider.probeMidScrollTop
           ? provider.probeMidScrollTop(el)
-          : anyEl.scrollTop,
+          : el.scrollTop,
       };
       const loc = locate(el);
       violations.push(...certifyScrollGeometry(geo, loc));
@@ -316,12 +311,8 @@ export function liveGeometryProvider(win: Window): GeometryProvider {
       };
     },
     probeMidScrollTop(el) {
-      const node = el as unknown as {
-        scrollHeight: number;
-        scrollTop: number;
-      };
-      node.scrollTop = Math.round(node.scrollHeight / 2);
-      return node.scrollTop;
+      el.scrollTop = Math.round(el.scrollHeight / 2);
+      return el.scrollTop;
     },
   };
 }


### PR DESCRIPTION
`bun run verify` fails on current develop (and therefore on every branch) because the type-safety ratchet is over baseline: `?? []` 582>581 and `as unknown as` 77>73. Regressions landed via #14324 (`3a0c7c039de`), `65ad0992985`, and the widget-cert harness.

Fixes (all honest typing, no baseline bumps, no suppressions):
- **ui-catalog.ts**: the uiGenerative provider read its own optional `relevanceKeywords` field back through `?? []` inside its `get`. Hoist the keyword list to a module const shared by the provider field and the intent gate.
- **documents-service-loader.ts / knowledge.ts**: `getDocumentsService` demanded the concrete `AgentRuntime` while using only `getService`/`getServiceLoadPromise` — both on `IAgentRuntime` (packages/core/src/types/runtime.ts:649). Widen the parameter to the interface; delete the two `as unknown as Parameters<...>` casts at the interface-typed call sites.
- **widget-cert.ts**: `Element` already declares `scrollHeight`/`scrollWidth`/`scrollTop`; drop the two casts and read them directly.

## Evidence

- `bun run audit:type-safety-ratchet` → exit 0; report: `as unknown as: 73/73`, `?? []: 581/581`, several metrics now below baseline ("baseline can shrink: ! 515→501, ?? \"\" 615→580, ?? {} 377→370, ?? 0 375→371").
- `bun run verify` → exit 0 end-to-end on this branch (was failing at audit:type-safety-ratchet before these fixes).
- No behavior change: same keyword list instance feeds the provider field and the gate; `getDocumentsService` body untouched; widget-cert reads the same DOM properties without the detour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)