### PR TITLE
fix(core): retire v5 provider request plumbing

### DIFF
--- a/packages/core/src/features/basic-capabilities/providers/providers.ts
+++ b/packages/core/src/features/basic-capabilities/providers/providers.ts
@@ -1,11 +1,9 @@
 /**
- * PROVIDERS provider — injects the catalog of available data providers into the
- * planner prompt so the model can pick which context sources to pull on the next
- * turn. Renders each provider's (compressed) description alongside a set of
- * selection hints that map request kinds to provider names, and filters the list
- * to providers whose declared contexts match the turn's active routing contexts.
- * Suppresses the list entirely when the message looks like non-actionable
- * chatter. Part of the basic-capabilities bundle.
+ * Legacy provider-catalog renderer for composeState callers that explicitly ask
+ * for `PROVIDERS`. The v5 chat planner does not use a model-emitted
+ * request-by-name loop; it selects provider text before the model call through
+ * context gates plus `alwaysInResponseState`. This catalog stays out of v5
+ * planner composition so provider descriptions do not become prompt-stuffing.
  */
 
 import {

--- a/packages/core/src/services/message.planner-provider-selection.test.ts
+++ b/packages/core/src/services/message.planner-provider-selection.test.ts
@@ -104,6 +104,16 @@ describe("selectV5PlannerStateProviderNames — declared contextGate honored (#1
 		expect(select([declared], ["wallet"])).not.toContain("DECLARED_SIGNAL");
 	});
 
+	it("keeps the legacy PROVIDERS catalog out of v5 planner composition", () => {
+		const catalog = provider({
+			name: "PROVIDERS",
+			contextGate: { anyOf: ["general"] },
+		});
+		const selected = select([catalog], ["general"]);
+
+		expect(selected).not.toContain("PROVIDERS");
+	});
+
 	it("keeps an undeclared, uncataloged plugin provider on narrow turns (#13204 follow-up)", () => {
 		// TWITTER_IDENTITY shape: a plugin provider with no contexts, no
 		// contextGate, and no catalog entry. Hosts that bypass the wrapped

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -9,7 +9,6 @@
  * to replace it wholesale.
  */
 import { v4 } from "uuid";
-import z from "zod";
 import { formatActionNames, formatActions } from "../actions";
 import {
 	actionToTool,
@@ -696,138 +695,6 @@ function resolvePlannerActionNameFromLookup(
 	return [];
 }
 
-function isStructuredPlannerIdentifier(value: string): boolean {
-	const unwrapped = unwrapPlannerIdentifier(value).trim();
-	return /^[A-Za-z][A-Za-z0-9_:-]*$/u.test(unwrapped);
-}
-
-function extractStructuredProviderList(rawProviders: string): string[] {
-	const safe =
-		rawProviders.length > 10_000 ? rawProviders.slice(0, 10_000) : rawProviders;
-	const tokens = safe
-		.split(/[\n,;]/)
-		.map((providerName) =>
-			providerName.replace(/^[\s"'[\](){}]+|[\s"'[\](){}]+$/g, ""),
-		)
-		.map((providerName) => unwrapPlannerIdentifier(providerName).trim())
-		.filter((providerName) => providerName.length > 0);
-	if (tokens.length === 0 || !tokens.every(isStructuredPlannerIdentifier)) {
-		return [];
-	}
-	return tokens;
-}
-
-// Schemas for LLM-emitted provider lists embedded as JSON strings inside the
-// planner output. The planner sometimes returns providers as a JSON array of
-// strings or as a `{ providers: string[] }` object.
-// We coerce non-string entries to string and validate downstream.
-const ProviderJsonArraySchema = z.array(z.unknown());
-const ProviderJsonEnvelopeSchema = z.object({
-	providers: z.array(z.unknown()),
-});
-
-export function extractPlannerProviderNames(
-	parsedPlanner: Record<string, unknown>,
-): string[] {
-	const rawProviders = parsedPlanner.providers;
-	if (typeof rawProviders === "string") {
-		const trimmedProviders = rawProviders.trim();
-		if (!trimmedProviders) {
-			return [];
-		}
-		if (
-			(trimmedProviders.startsWith("[") && trimmedProviders.endsWith("]")) ||
-			(trimmedProviders.startsWith("{") && trimmedProviders.endsWith("}"))
-		) {
-			try {
-				const parsedJson: unknown = JSON.parse(trimmedProviders);
-				const arrayResult = ProviderJsonArraySchema.safeParse(parsedJson);
-				if (arrayResult.success) {
-					return arrayResult.data
-						.map((providerName) => String(providerName).trim())
-						.filter(
-							(providerName): providerName is string =>
-								providerName.length > 0 &&
-								isStructuredPlannerIdentifier(providerName),
-						);
-				}
-				const envelopeResult = ProviderJsonEnvelopeSchema.safeParse(parsedJson);
-				if (envelopeResult.success) {
-					return envelopeResult.data.providers
-						.map((providerName) => String(providerName).trim())
-						.filter(
-							(providerName): providerName is string =>
-								providerName.length > 0 &&
-								isStructuredPlannerIdentifier(providerName),
-						);
-				}
-				logger.warn(
-					{
-						raw: trimmedProviders,
-						arrayErr: arrayResult.error.issues,
-						envelopeErr: envelopeResult.error.issues,
-					},
-					"[message] LLM response failed schema validation",
-				);
-			} catch (err) {
-				logger.warn(
-					{ raw: trimmedProviders, err },
-					"[message] LLM response failed schema validation",
-				);
-			}
-		}
-
-		return extractStructuredProviderList(trimmedProviders);
-	}
-
-	if (Array.isArray(rawProviders)) {
-		return rawProviders.flatMap((providerName) => {
-			if (typeof providerName !== "string") {
-				const normalized = String(providerName).trim();
-				return normalized.length > 0 &&
-					isStructuredPlannerIdentifier(normalized)
-					? [normalized]
-					: [];
-			}
-
-			const trimmedProvider = providerName.trim();
-			if (!trimmedProvider) {
-				return [];
-			}
-			if (
-				(trimmedProvider.startsWith("[") && trimmedProvider.endsWith("]")) ||
-				(trimmedProvider.startsWith("{") && trimmedProvider.endsWith("}"))
-			) {
-				try {
-					const parsedJson: unknown = JSON.parse(trimmedProvider);
-					const arrayResult = ProviderJsonArraySchema.safeParse(parsedJson);
-					if (arrayResult.success) {
-						return arrayResult.data
-							.map((entry) => String(entry).trim())
-							.filter(
-								(entry): entry is string =>
-									entry.length > 0 && isStructuredPlannerIdentifier(entry),
-							);
-					}
-					logger.warn(
-						{ raw: trimmedProvider, err: arrayResult.error.issues },
-						"[message] LLM response failed schema validation",
-					);
-				} catch (err) {
-					logger.warn(
-						{ raw: trimmedProvider, err },
-						"[message] LLM response failed schema validation",
-					);
-				}
-			}
-
-			return extractStructuredProviderList(trimmedProvider);
-		});
-	}
-
-	return [];
-}
-
 const CORE_RESPONSE_STATE_PROVIDERS = [
 	"RUNTIME_MODEL_CONTEXT",
 	"UI_CONTEXT",
@@ -928,8 +795,6 @@ const STAGE1_EXTRA_PROVIDER_EXCLUSIONS = [
 	"DOCUMENTS",
 ] as const;
 
-const STRUCTURED_RESPONSE_STATE_PROVIDERS = ["ACTIONS", "PROVIDERS"];
-
 function isCurrentTimeQuestion(message: Memory): boolean {
 	const text = message.content.text?.toLowerCase() ?? "";
 	if (!text) return false;
@@ -946,8 +811,6 @@ function stage1ProviderExclusionsForMessage(message: Memory): string[] {
 	}
 	return exclusions;
 }
-const FOCUSED_PROVIDER_REPLY_STATE_PROVIDERS = ["CHARACTER", "RECENT_MESSAGES"];
-
 function hasInboundBenchmarkContext(message: Memory): boolean {
 	const metadata = message.metadata as Record<string, unknown> | undefined;
 	const benchmarkContext = metadata?.benchmarkContext;
@@ -1159,43 +1022,6 @@ async function composeResponseState(
 	);
 }
 
-function _composeStructuredResponseState(
-	runtime: IAgentRuntime,
-	message: Memory,
-	skipCache = false,
-): Promise<State> {
-	return runtime.composeState(
-		message,
-		STRUCTURED_RESPONSE_STATE_PROVIDERS,
-		false,
-		skipCache,
-	);
-}
-
-async function composeProviderGroundedResponseState(
-	runtime: IAgentRuntime,
-	message: Memory,
-	providers: string[],
-	skipCache = false,
-): Promise<State> {
-	const state = await runtime.composeState(
-		message,
-		[
-			...CORE_RESPONSE_STATE_PROVIDERS,
-			...alwaysOnResponseStateProviderNames(runtime),
-			...providers,
-		],
-		false,
-		skipCache,
-	);
-	return applyMessageHistoryCompactionHook(
-		runtime,
-		message,
-		state,
-		"provider-grounded-state",
-	);
-}
-
 export function selectV5PlannerStateProviderNames(args: {
 	runtime: IAgentRuntime;
 	message: Memory;
@@ -1236,20 +1062,6 @@ export function selectV5PlannerStateProviderNames(args: {
 	}
 
 	return [...providerNames];
-}
-
-function _composeFocusedProviderReplyState(
-	runtime: IAgentRuntime,
-	message: Memory,
-	providers: string[],
-	skipCache = false,
-): Promise<State> {
-	return runtime.composeState(
-		message,
-		[...FOCUSED_PROVIDER_REPLY_STATE_PROVIDERS, ...providers],
-		true,
-		skipCache,
-	);
 }
 
 function _ensureActionStateValues(
@@ -1842,7 +1654,6 @@ function createV5ReplyStrategyResult(args: {
 	const responseContent: Content = {
 		thought: args.thought,
 		actions: ["REPLY"],
-		providers: [],
 		text: restorePiiInUserReplyText(args.text),
 		simple: args.mode !== "actions",
 		responseId: args.responseId,
@@ -9395,7 +9206,6 @@ export class DefaultMessageService implements IMessageService {
 					const earlyContent: Content = {
 						thought: event.messageHandler.thought,
 						actions: ["REPLY"],
-						providers: [],
 						text,
 						responseId: earlyResponseId,
 						inReplyTo: createUniqueUuid(runtime, message.id),
@@ -9801,23 +9611,6 @@ export class DefaultMessageService implements IMessageService {
 				responseContent.inReplyTo = createUniqueUuid(runtime, message.id);
 			}
 
-			const providerStateValues = {
-				[AVAILABLE_CONTEXTS_STATE_KEY]:
-					state.values?.[AVAILABLE_CONTEXTS_STATE_KEY],
-				[CONTEXT_ROUTING_STATE_KEY]: state.values?.[CONTEXT_ROUTING_STATE_KEY],
-			};
-
-			if (responseContent?.providers && responseContent.providers.length > 0) {
-				state = withContextRoutingValues(
-					await composeProviderGroundedResponseState(
-						runtime,
-						message,
-						responseContent.providers,
-					),
-					providerStateValues,
-				);
-			}
-
 			// Save response memory to database.
 			// - simple mode: persists after hooks in the branch below.
 			// - actions mode: do NOT persist the initial LLM text here.
@@ -9864,19 +9657,6 @@ export class DefaultMessageService implements IMessageService {
 
 			if (responseContent) {
 				if (mode === "simple") {
-					// Log provider usage for simple responses
-					if (
-						responseContent.providers &&
-						responseContent.providers.length > 0
-					) {
-						runtime.logger.debug(
-							{
-								src: "service:message",
-								providers: responseContent.providers,
-							},
-							"Simple response used providers",
-						);
-					}
 					// Keep content hooks and DB write before delivery so the wire
 					// response and stored memory match. Do not put MESSAGE_SENT
 					// handlers or post-turn evaluators before the callback; they are
@@ -10782,7 +10562,6 @@ export class DefaultMessageService implements IMessageService {
 			elizaSyntheticFailure: true,
 			transient: true,
 			doNotPersist: true,
-			providers: [],
 			text: replyText,
 			responseId,
 		};
@@ -10836,7 +10615,6 @@ export class DefaultMessageService implements IMessageService {
 			thought: `No LLM provider configured during ${stage}.`,
 			actions: ["REPLY"],
 			failureKind: "no_provider",
-			providers: [],
 			text: replyText,
 			responseId,
 		};

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -632,10 +632,15 @@ export interface Provider {
 	/** Provider name */
 	name: string;
 
-	/** Description of the provider */
+	/**
+	 * Human-readable metadata for catalogs and diagnostics. The v5 chat planner
+	 * does not see this text unless a caller explicitly composes the provider;
+	 * route provider prompt text with `contexts`/`contextGate` or
+	 * `alwaysInResponseState`.
+	 */
 	description?: string;
 
-	/** Compressed description for prompt-optimized rendering */
+	/** Compressed description for legacy catalog rendering and diagnostics. */
 	descriptionCompressed?: string;
 	/** Alias accepted for plugin compatibility; canonical output uses descriptionCompressed */
 	compressedDescription?: string;
@@ -661,7 +666,10 @@ export interface Provider {
 	 */
 	private?: boolean;
 
-	/** Keywords used to determine relevance for action filtering */
+	/**
+	 * Advisory keywords for provider-owned self-gates and catalogs. Core does
+	 * not run a global keyword selector over providers.
+	 */
 	relevanceKeywords?: string[];
 
 	/**
@@ -723,16 +731,6 @@ export interface Provider {
 
 	/** Child provider/action names exposed beneath this provider, if any. */
 	subActions?: string[];
-
-	/** Whether this provider should be composed through a sub-planner. */
-	subPlanner?: boolean | { name?: string; description?: string };
-
-	/**
-	 * Additional providers that should run alongside this provider when it is
-	 * selected by the planner. Use this for provider composition, not semantic
-	 * routing.
-	 */
-	companionProviders?: string[];
 
 	/** Data retrieval function */
 	get: (

--- a/packages/core/src/types/primitives.ts
+++ b/packages/core/src/types/primitives.ts
@@ -105,7 +105,11 @@ export interface Content {
 	/** Actions to be performed */
 	actions?: string[];
 
-	/** Providers to use for context generation */
+	/**
+	 * Legacy serialized provider names from pre-v5 planner replies. The v5
+	 * message loop does not use model-emitted content to select providers;
+	 * providers enter prompts through context routing or `alwaysInResponseState`.
+	 */
 	providers?: string[];
 
 	/** Source/origin of the content (e.g., 'discord', 'telegram') */


### PR DESCRIPTION
## Summary
- choose the explicit context-gating contract for v5 provider discovery: providers reach prompts through `contexts`/`contextGate` or `alwaysInResponseState`, not model-emitted provider requests
- remove the unreachable `extractPlannerProviderNames` parser and post-response provider recomposition branch from the v5 message service
- remove provider-only `subPlanner` / `companionProviders` fields that had no runtime consumers
- document `Provider.description`, `relevanceKeywords`, `Content.providers`, and the legacy `PROVIDERS` catalog around the actual v5 behavior
- add a selector regression test keeping the legacy `PROVIDERS` catalog out of v5 planner composition

Fixes #14528

## Verification
- `bun run --cwd packages/core test src/services/message.planner-provider-selection.test.ts`
- `bun run --cwd packages/core test src/__tests__/stage1-provider-execution.test.ts`
- `bun run --cwd packages/core test src/__tests__/message-runtime-stage1.test.ts`
- `bunx @biomejs/biome check packages/core/src/services/message.ts packages/core/src/services/message.planner-provider-selection.test.ts packages/core/src/types/components.ts packages/core/src/types/primitives.ts packages/core/src/features/basic-capabilities/providers/providers.ts`
- `bun run --cwd packages/core typecheck`
- `git diff --check`
- `bun run audit:error-policy-ratchet --report`

## Evidence notes
- Live-LLM trajectory: N/A for this cleanup PR; the deleted path was unreachable from the v5 planner schema, and the regression coverage pins provider composition before the model call.
- UI/video/screenshots: N/A, no user-facing UI change.
- Generated keyword files and local `node_modules`/`dist` artifacts were created only to run tests/typecheck in the fresh worktree and are ignored.