### PR TITLE
fix(app): remove duplicate finance plugin toolbars

### DIFF
--- a/plugins/plugin-hyperliquid/src/HyperliquidView.test.tsx
+++ b/plugins/plugin-hyperliquid/src/HyperliquidView.test.tsx
@@ -10,6 +10,12 @@
 // retired HyperliquidTuiView surface. Also covers the unchanged `interact`
 // terminal capability handler the view bundle re-exports.
 
+import {
+	type AgentElementSnapshot,
+	AgentSurfaceProvider,
+	getViewRegistry,
+	handleAgentSurfaceCapability,
+} from "@elizaos/ui/agent-surface";
 import { NAVIGATE_VIEW_EVENT } from "@elizaos/ui/events";
 import {
 	cleanup,
@@ -411,6 +417,112 @@ describe("HyperliquidView — terminal interact capabilities", () => {
 	it("throws on an unsupported capability", async () => {
 		await expect(interact("terminal-hyperliquid-unknown")).rejects.toThrow(
 			'Unsupported capability "terminal-hyperliquid-unknown"',
+		);
+	});
+});
+
+// The visible orange toolbar was removed (#14594); the refresh/home controls now
+// live in an aria-hidden, off-screen wrapper. These assert the agent-surface path
+// still drives them — they remain real registered buttons, keep their handlers,
+// and fire when the agent activates them through the capability bridge (the same
+// `agent-click` route the pill/automation uses), independent of any visible pixel.
+describe("HyperliquidView — hidden agent-surface controls fire for the agent", () => {
+	const VIEW = "hyperliquid-agent-surface-test";
+
+	function renderWithSurface() {
+		return render(
+			<AgentSurfaceProvider viewId={VIEW} viewType="gui">
+				<HyperliquidView />
+			</AgentSurfaceProvider>,
+		);
+	}
+
+	it("keeps refresh + home in the DOM but visually + a11y hidden", async () => {
+		renderWithSurface();
+		await screen.findByText("ETH");
+
+		const refreshBtn = document.querySelector<HTMLElement>(
+			'[data-agent-id="hyperliquid-refresh"]',
+		);
+		const homeBtn = document.querySelector<HTMLElement>(
+			'[data-agent-id="hyperliquid-home"]',
+		);
+		expect(refreshBtn?.tagName).toBe("BUTTON");
+		expect(homeBtn?.tagName).toBe("BUTTON");
+		// Clipped off-screen inside an aria-hidden wrapper — not display:none, so
+		// the node stays activatable for the agent surface.
+		expect(refreshBtn?.closest('[aria-hidden="true"]')).toBeTruthy();
+		expect(homeBtn?.closest('[aria-hidden="true"]')).toBeTruthy();
+		expect(refreshBtn?.style.clipPath).toContain("inset");
+	});
+
+	it("registers both controls as clickable buttons on the surface", async () => {
+		renderWithSurface();
+		await screen.findByText("ETH");
+		const registry = getViewRegistry(VIEW, "gui");
+		if (!registry) throw new Error("registry missing");
+		const elements = handleAgentSurfaceCapability(
+			registry,
+			"list-elements",
+			undefined,
+		) as AgentElementSnapshot[];
+		const ids = elements.map((e) => e.id);
+		expect(ids).toContain("hyperliquid-refresh");
+		expect(ids).toContain("hyperliquid-home");
+		const refresh = elements.find((e) => e.id === "hyperliquid-refresh");
+		expect(refresh?.role).toBe("button");
+		expect(refresh?.clickable).toBe(true);
+	});
+
+	it("re-fetches when the agent activates the hidden refresh control", async () => {
+		renderWithSurface();
+		await screen.findByText("ETH");
+		expect(hyperliquidClient.hyperliquidStatus).toHaveBeenCalledTimes(1);
+		const registry = getViewRegistry(VIEW, "gui");
+		if (!registry) throw new Error("registry missing");
+
+		const result = handleAgentSurfaceCapability(registry, "agent-click", {
+			id: "hyperliquid-refresh",
+		});
+		expect(result).toMatchObject({ ok: true, id: "hyperliquid-refresh" });
+		await waitFor(() =>
+			expect(hyperliquidClient.hyperliquidStatus).toHaveBeenCalledTimes(2),
+		);
+		expect(hyperliquidClient.hyperliquidMarkets).toHaveBeenCalledTimes(2);
+	});
+
+	it("navigates home when the agent activates the hidden home control", async () => {
+		renderWithSurface();
+		await screen.findByText("ETH");
+		const registry = getViewRegistry(VIEW, "gui");
+		if (!registry) throw new Error("registry missing");
+
+		const events: CustomEvent[] = [];
+		const listener = (e: Event) => events.push(e as CustomEvent);
+		window.addEventListener(NAVIGATE_VIEW_EVENT, listener);
+		try {
+			const result = handleAgentSurfaceCapability(registry, "agent-click", {
+				id: "hyperliquid-home",
+			});
+			expect(result).toMatchObject({ ok: true, id: "hyperliquid-home" });
+		} finally {
+			window.removeEventListener(NAVIGATE_VIEW_EVENT, listener);
+		}
+		expect(events).toHaveLength(1);
+		expect(events[0]?.detail).toMatchObject({ viewId: "home", viewPath: "/" });
+	});
+
+	it("still fires the hidden control's own onClick when clicked directly", async () => {
+		renderWithSurface();
+		await screen.findByText("ETH");
+		expect(hyperliquidClient.hyperliquidStatus).toHaveBeenCalledTimes(1);
+		const refreshBtn = document.querySelector<HTMLElement>(
+			'[data-agent-id="hyperliquid-refresh"]',
+		);
+		if (!refreshBtn) throw new Error("hidden refresh control missing");
+		fireEvent.click(refreshBtn);
+		await waitFor(() =>
+			expect(hyperliquidClient.hyperliquidStatus).toHaveBeenCalledTimes(2),
 		);
 	});
 });

--- a/plugins/plugin-hyperliquid/src/HyperliquidView.test.tsx
+++ b/plugins/plugin-hyperliquid/src/HyperliquidView.test.tsx
@@ -4,7 +4,7 @@
 // the rendered DOM: the same component the bundle exports for the "gui", "xr",
 // and (via the spatial terminal registry) "tui" modalities. Asserts the
 // populated markets/positions/orders snapshot, the readiness tiles, the
-// executionBlockedReason + vault-guidance banners, the positions/orders
+// executionBlockedReason and vault-guidance banners, the positions/orders
 // read-blocked surfaces, the DOM-clickable Refresh / Back controls, the
 // read-blocked + error + unavailable branches — functional parity with the
 // retired HyperliquidTuiView surface. Also covers the unchanged `interact`
@@ -203,13 +203,25 @@ describe("HyperliquidView — populated snapshot", () => {
 		expect(screen.getByText("Account")).toBeTruthy();
 	});
 
-	it("surfaces the executionBlockedReason and vault guidance banners", async () => {
+	it("surfaces the executionBlockedReason without duplicate vault guidance", async () => {
 		render(React.createElement(HyperliquidView));
 		await screen.findByText("ETH");
 		expect(
 			screen.getByText(/Signed Hyperliquid exchange mutations are disabled/),
 		).toBeTruthy();
-		// vault.ready=false and credentialMode!=local_key -> vault guidance shows.
+		expect(
+			screen.queryByText("Connect a managed vault to enable signed requests."),
+		).toBeNull();
+	});
+
+	it("shows vault guidance when no specific execution block is present", async () => {
+		hyperliquidClient.hyperliquidStatus.mockResolvedValue({
+			...sampleStatus,
+			executionBlockedReason: null,
+		});
+
+		render(React.createElement(HyperliquidView));
+		await screen.findByText("ETH");
 		expect(
 			screen.getByText("Connect a managed vault to enable signed requests."),
 		).toBeTruthy();

--- a/plugins/plugin-hyperliquid/src/HyperliquidView.tsx
+++ b/plugins/plugin-hyperliquid/src/HyperliquidView.tsx
@@ -12,7 +12,6 @@
  */
 
 import { useAgentElement } from "@elizaos/ui/agent-surface";
-import { Button } from "@elizaos/ui/components/ui/button";
 import { dispatchNavigateViewEvent } from "@elizaos/ui/events";
 import { type CSSProperties, useCallback } from "react";
 import {
@@ -27,32 +26,16 @@ function navigateHome(): void {
 	dispatchNavigateViewEvent({ viewId: "home", viewPath: "/" });
 }
 
-const AGENT_TOOLBAR_STYLE: CSSProperties = {
-	display: "flex",
-	gap: "0.5rem",
-	alignItems: "center",
-	flexWrap: "wrap",
-	padding: "0.4rem 0.5rem",
-};
-
-const AGENT_BUTTON_STYLE: CSSProperties = {
-	display: "inline-flex",
-	alignItems: "center",
-	justifyContent: "center",
-	padding: "0.4rem 0.85rem",
-	borderRadius: "0.4rem",
-	border: "1px solid var(--primary, #d2691e)",
-	background: "var(--primary, #d2691e)",
-	color: "var(--primary-foreground, #fff)",
-	fontWeight: 600,
-	fontSize: "0.85rem",
-	cursor: "pointer",
-};
-
-const AGENT_BUTTON_OUTLINE_STYLE: CSSProperties = {
-	...AGENT_BUTTON_STYLE,
-	background: "transparent",
-	color: "var(--primary, #d2691e)",
+const AGENT_HIDDEN_CONTROL_STYLE: CSSProperties = {
+	position: "absolute",
+	width: 1,
+	height: 1,
+	margin: -1,
+	padding: 0,
+	overflow: "hidden",
+	clipPath: "inset(50%)",
+	whiteSpace: "nowrap",
+	border: 0,
 };
 
 export function HyperliquidView() {
@@ -129,36 +112,24 @@ export function HyperliquidView() {
 
 	return (
 		<>
-			<div
-				role="toolbar"
-				aria-label="Hyperliquid controls"
-				style={AGENT_TOOLBAR_STYLE}
-			>
-				<Button
-					unstyled
+			<div aria-hidden="true">
+				<button
 					ref={refreshControl.ref}
 					{...refreshControl.agentProps}
 					type="button"
 					onClick={() => void refresh()}
 					disabled={loading}
-					style={{
-						...AGENT_BUTTON_STYLE,
-						opacity: loading ? 0.6 : 1,
-						cursor: loading ? "not-allowed" : "pointer",
-					}}
-				>
-					{loading ? "Refreshing…" : "Refresh"}
-				</Button>
-				<Button
-					unstyled
+					tabIndex={-1}
+					style={AGENT_HIDDEN_CONTROL_STYLE}
+				/>
+				<button
 					ref={homeControl.ref}
 					{...homeControl.agentProps}
 					type="button"
 					onClick={navigateHome}
-					style={AGENT_BUTTON_OUTLINE_STYLE}
-				>
-					Home
-				</Button>
+					tabIndex={-1}
+					style={AGENT_HIDDEN_CONTROL_STYLE}
+				/>
 			</div>
 			<HyperliquidSpatialView snapshot={snapshot} onAction={onAction} />
 		</>

--- a/plugins/plugin-hyperliquid/src/components/HyperliquidSpatialView.tsx
+++ b/plugins/plugin-hyperliquid/src/components/HyperliquidSpatialView.tsx
@@ -254,6 +254,7 @@ export function HyperliquidSpatialView({
 
 			{!status.vaultReady &&
 			status.credentialMode !== "local_key" &&
+			!status.executionBlockedReason &&
 			status.vaultGuidance ? (
 				<Text style="caption" tone="muted">
 					{status.vaultGuidance}

--- a/plugins/plugin-polymarket/src/PolymarketView.test.tsx
+++ b/plugins/plugin-polymarket/src/PolymarketView.test.tsx
@@ -10,6 +10,12 @@
 // capability handler the view bundle re-exports.
 
 import {
+  type AgentElementSnapshot,
+  AgentSurfaceProvider,
+  getViewRegistry,
+  handleAgentSurfaceCapability,
+} from "@elizaos/ui/agent-surface";
+import {
   cleanup,
   fireEvent,
   render,
@@ -373,6 +379,110 @@ describe("PolymarketView — terminal interact capabilities", () => {
           size: 1,
         }),
       }),
+    );
+  });
+});
+
+// The visible orange toolbar was removed (#14594); the refresh/detail-back
+// controls now live in an aria-hidden, off-screen wrapper. These assert the
+// agent-surface path still drives them — they remain real registered buttons,
+// keep their handlers, and fire when the agent activates them through the
+// capability bridge (the same `agent-click` route the pill/automation uses),
+// independent of any visible pixel.
+describe("PolymarketView — hidden agent-surface controls fire for the agent", () => {
+  const VIEW = "polymarket-agent-surface-test";
+
+  function renderWithSurface() {
+    return render(
+      <AgentSurfaceProvider viewId={VIEW} viewType="gui">
+        <PolymarketView />
+      </AgentSurfaceProvider>,
+    );
+  }
+
+  it("keeps refresh + detail-back in the DOM but visually + a11y hidden", async () => {
+    renderWithSurface();
+    // Auto-select opens the detail pane, so the detail-back control renders.
+    await screen.findByText("Will BTC be above 100k?");
+    await waitFor(() => expect(agent("detail-back")).toBeTruthy());
+
+    const refreshBtn = document.querySelector<HTMLElement>(
+      '[data-agent-id="polymarket-refresh"]',
+    );
+    const backBtn = document.querySelector<HTMLElement>(
+      '[data-agent-id="polymarket-detail-back"]',
+    );
+    expect(refreshBtn?.tagName).toBe("BUTTON");
+    expect(backBtn?.tagName).toBe("BUTTON");
+    // Clipped off-screen inside an aria-hidden wrapper — not display:none, so the
+    // node stays activatable for the agent surface.
+    expect(refreshBtn?.closest('[aria-hidden="true"]')).toBeTruthy();
+    expect(backBtn?.closest('[aria-hidden="true"]')).toBeTruthy();
+    expect(refreshBtn?.style.clipPath).toContain("inset");
+  });
+
+  it("registers refresh + detail-back as clickable buttons on the surface", async () => {
+    renderWithSurface();
+    await screen.findByText("Will BTC be above 100k?");
+    const registry = getViewRegistry(VIEW, "gui");
+    if (!registry) throw new Error("registry missing");
+    const elements = handleAgentSurfaceCapability(
+      registry,
+      "list-elements",
+      undefined,
+    ) as AgentElementSnapshot[];
+    const ids = elements.map((e) => e.id);
+    expect(ids).toContain("polymarket-refresh");
+    expect(ids).toContain("polymarket-detail-back");
+    const refresh = elements.find((e) => e.id === "polymarket-refresh");
+    expect(refresh?.role).toBe("button");
+    expect(refresh?.clickable).toBe(true);
+  });
+
+  it("re-fetches when the agent activates the hidden refresh control", async () => {
+    renderWithSurface();
+    await screen.findByText("Will BTC be above 100k?");
+    expect(polymarketClient.polymarketMarkets).toHaveBeenCalledTimes(1);
+    const registry = getViewRegistry(VIEW, "gui");
+    if (!registry) throw new Error("registry missing");
+
+    const result = handleAgentSurfaceCapability(registry, "agent-click", {
+      id: "polymarket-refresh",
+    });
+    expect(result).toMatchObject({ ok: true, id: "polymarket-refresh" });
+    await waitFor(() =>
+      expect(polymarketClient.polymarketMarkets).toHaveBeenCalledTimes(2),
+    );
+    expect(polymarketClient.polymarketStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it("closes the open market detail when the agent activates the hidden detail-back control", async () => {
+    renderWithSurface();
+    await screen.findByText("Will BTC be above 100k?");
+    // Mounts on the auto-selected detail pane.
+    await waitFor(() => expect(agent("detail-back")).toBeTruthy());
+    const registry = getViewRegistry(VIEW, "gui");
+    if (!registry) throw new Error("registry missing");
+
+    const result = handleAgentSurfaceCapability(registry, "agent-click", {
+      id: "polymarket-detail-back",
+    });
+    expect(result).toMatchObject({ ok: true, id: "polymarket-detail-back" });
+    // setSelectedMarket(null) returns to the list — the row Open control appears.
+    await waitFor(() => expect(agent("market:market-1")).toBeTruthy());
+  });
+
+  it("still fires the hidden refresh control's own onClick when clicked directly", async () => {
+    renderWithSurface();
+    await screen.findByText("Will BTC be above 100k?");
+    expect(polymarketClient.polymarketMarkets).toHaveBeenCalledTimes(1);
+    const refreshBtn = document.querySelector<HTMLElement>(
+      '[data-agent-id="polymarket-refresh"]',
+    );
+    if (!refreshBtn) throw new Error("hidden refresh control missing");
+    fireEvent.click(refreshBtn);
+    await waitFor(() =>
+      expect(polymarketClient.polymarketMarkets).toHaveBeenCalledTimes(2),
     );
   });
 });

--- a/plugins/plugin-polymarket/src/PolymarketView.tsx
+++ b/plugins/plugin-polymarket/src/PolymarketView.tsx
@@ -11,7 +11,6 @@
  */
 
 import { useAgentElement } from "@elizaos/ui/agent-surface";
-import { Button } from "@elizaos/ui/components/ui/button";
 import { type CSSProperties, useCallback, useEffect } from "react";
 import {
   type PolymarketSnapshot,
@@ -19,32 +18,16 @@ import {
 } from "./components/PolymarketSpatialView.tsx";
 import { usePolymarketState } from "./usePolymarketState.ts";
 
-const AGENT_TOOLBAR_STYLE: CSSProperties = {
-  display: "flex",
-  gap: "0.5rem",
-  alignItems: "center",
-  flexWrap: "wrap",
-  padding: "0.4rem 0.5rem",
-};
-
-const AGENT_BUTTON_STYLE: CSSProperties = {
-  display: "inline-flex",
-  alignItems: "center",
-  justifyContent: "center",
-  padding: "0.4rem 0.85rem",
-  borderRadius: "0.4rem",
-  border: "1px solid var(--primary, #d2691e)",
-  background: "var(--primary, #d2691e)",
-  color: "var(--primary-foreground, #fff)",
-  fontWeight: 600,
-  fontSize: "0.85rem",
-  cursor: "pointer",
-};
-
-const AGENT_BUTTON_OUTLINE_STYLE: CSSProperties = {
-  ...AGENT_BUTTON_STYLE,
-  background: "transparent",
-  color: "var(--primary, #d2691e)",
+const AGENT_HIDDEN_CONTROL_STYLE: CSSProperties = {
+  position: "absolute",
+  width: 1,
+  height: 1,
+  margin: -1,
+  padding: 0,
+  overflow: "hidden",
+  clipPath: "inset(50%)",
+  whiteSpace: "nowrap",
+  border: 0,
 };
 
 export function PolymarketView() {
@@ -124,37 +107,25 @@ export function PolymarketView() {
 
   return (
     <>
-      <div
-        role="toolbar"
-        aria-label="Polymarket controls"
-        style={AGENT_TOOLBAR_STYLE}
-      >
-        <Button
-          unstyled
+      <div aria-hidden="true">
+        <button
           ref={refreshControl.ref}
           {...refreshControl.agentProps}
           type="button"
           onClick={() => void refresh()}
           disabled={loading}
-          style={{
-            ...AGENT_BUTTON_STYLE,
-            opacity: loading ? 0.6 : 1,
-            cursor: loading ? "not-allowed" : "pointer",
-          }}
-        >
-          {loading ? "Refreshing…" : "Refresh"}
-        </Button>
+          tabIndex={-1}
+          style={AGENT_HIDDEN_CONTROL_STYLE}
+        />
         {selectedMarket ? (
-          <Button
-            unstyled
+          <button
             ref={backToMarketsControl.ref}
             {...backToMarketsControl.agentProps}
             type="button"
             onClick={() => setSelectedMarket(null)}
-            style={AGENT_BUTTON_OUTLINE_STYLE}
-          >
-            All markets
-          </Button>
+            tabIndex={-1}
+            style={AGENT_HIDDEN_CONTROL_STYLE}
+          />
         ) : null}
       </div>
       <PolymarketSpatialView snapshot={snapshot} onAction={onAction} />


### PR DESCRIPTION
Closes #14594.

## Summary

- remove the duplicate visible wrapper toolbars from the Hyperliquid and Polymarket GUI app views
- keep the agent-surface actions registered through inert hidden DOM controls so chat/automation can still activate refresh/back-style actions
- suppress the secondary Hyperliquid vault guidance line when a specific execution-blocked reason is already displayed, reducing mobile read-only clutter without hiding the actionable status

## Verification

- PASS `bunx @biomejs/biome check --write plugins/plugin-hyperliquid/src/HyperliquidView.tsx plugins/plugin-hyperliquid/src/components/HyperliquidSpatialView.tsx plugins/plugin-polymarket/src/PolymarketView.tsx`
- PASS `bun run --cwd plugins/plugin-hyperliquid build:views`
- PASS `bun run --cwd plugins/plugin-polymarket build:views`
- PASS Hyperliquid audit slice: `ELIZA_NODE_PATH=/Users/shawwalters/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node bun run --cwd packages/app audit:app -- --grep "plugin-hyperliquid-gui mobile-portrait"`
  - moved `plugin-hyperliquid-gui @ mobile-portrait` from whitespace `0.5879` / text density `11.3015` to whitespace `0.5967` / text density `9.9951`, clearing the ratchet
- PASS Full app visual audit: `ELIZA_NODE_PATH=/Users/shawwalters/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node bun run --cwd packages/app audit:app`
  - `369 passed`
  - `broken=0`, `minimalism-budget-failures=0`, `minimalism-ratchet-failures=0`, `density-probe-failures=0`
  - changed-view metrics from `aesthetic-audit-output/report.json`:
    - `plugin-hyperliquid-gui mobile-portrait`: readable `412`, textDensity `9.9951`, whitespace `0.5967`, ratchet `0`
    - `plugin-polymarket-gui mobile-portrait`: readable `279`, textDensity `6.5014`, whitespace `0.6706`, ratchet `0`
    - `plugin-polymarket-gui mobile-landscape`: readable `279`, textDensity `5.9849`, whitespace `0.4796`, ratchet `0`
- PASS Manual screenshot review of generated mobile captures:
  - Hyperliquid mobile portrait no longer shows the duplicate wrapper toolbar; remaining blocked-state reason and Refresh/Back controls are visible.
  - Polymarket mobile portrait/landscape no longer shows the duplicate wrapper toolbar; Refresh and Markets affordances remain in the spatial surface.
- PASS `bun run --cwd packages/app mvp:visual-verify` completed and wrote `368` state reports with `overflow states: 0`. It reports six unrelated expectation failures in built-in views: `builtin-automations desktop-landscape`, `builtin-character desktop-landscape`, and `builtin-settings` all viewports. No touched finance plugin state failed this verifier.
- PASS `git diff --check`

## Known unrelated blockers observed

- `bun run --cwd plugins/plugin-hyperliquid typecheck` and `bun run --cwd plugins/plugin-polymarket typecheck` currently fail before reaching this change because those plugin typecheck configs cannot resolve workspace declarations for `@elizaos/ui` / `@elizaos/app-core`; Hyperliquid also has an existing `caught is of type unknown` diagnostic in `useHyperliquidState.ts`. The view-bundle and full app-audit paths both compile and render the touched UI surface.

## Notes

The mobile-landscape Polymarket screenshot is now ratchet-clean, but the floating chat composer still consumes a lot of vertical space in that short viewport. I left that as follow-up UX debt rather than expanding this PR into a spatial responsive layout redesign.