### PR TITLE
fix(app): precise device-lease liveness probe + real pid-death/race tests (#14339)

### DIFF
--- a/packages/app/scripts/device-lease.test.mjs
+++ b/packages/app/scripts/device-lease.test.mjs
@@ -9,7 +9,7 @@ import { spawn } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   acquireDeviceLease,
   activeLeaseStatus,
@@ -17,6 +17,7 @@ import {
   deviceLeasePath,
   deviceLeaseStateDir,
   isDeviceLeased,
+  processIsAlive,
   readDeviceLease,
 } from "./lib/device-lease.mjs";
 
@@ -139,6 +140,19 @@ describe("device leases", () => {
         },
       ),
     ).toEqual({ active: false, reason: "expired" });
+  });
+
+  it("treats EPERM from signal-0 as alive, not reclaimable", () => {
+    const error = new Error("operation not permitted");
+    error.code = "EPERM";
+    const kill = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw error;
+    });
+    try {
+      expect(processIsAlive(12345)).toBe(true);
+    } finally {
+      kill.mockRestore();
+    }
   });
 
   it("reclaims an expired lease on the next acquire", async () => {

--- a/packages/app/scripts/device-lease.test.mjs
+++ b/packages/app/scripts/device-lease.test.mjs
@@ -1,8 +1,11 @@
 /**
- * Unit tests for host-local device leases. They use temp directories and fake
- * process liveness so crash reclaim and contention are deterministic without
- * touching real devices.
+ * Unit tests for host-local device leases. Most cases use temp directories and
+ * fake process liveness so crash reclaim and contention are deterministic, but
+ * the pid-death case spawns and kills a real child so the `process.kill(pid, 0)`
+ * ESRCH path is exercised for real, and the race case fires parallel acquires to
+ * prove the atomic `wx` create admits exactly one winner.
  */
+import { spawn } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -136,6 +139,90 @@ describe("device leases", () => {
         },
       ),
     ).toEqual({ active: false, reason: "expired" });
+  });
+
+  it("reclaims an expired lease on the next acquire", async () => {
+    const stateDir = tempDir();
+    let clock = Date.parse("2026-07-05T00:00:00.000Z");
+    await acquireDeviceLease("ios:stale", {
+      stateDir,
+      sessionId: "old",
+      pid: 401,
+      ttlMs: 1000,
+      now: () => clock,
+      isProcessAlive: () => true,
+    });
+
+    clock += 5000; // push past the 1s ttl so the prior lease is expired
+    const fresh = await acquireDeviceLease("ios:stale", {
+      stateDir,
+      sessionId: "new",
+      pid: 402,
+      now: () => clock,
+      isProcessAlive: () => true,
+    });
+
+    expect(readDeviceLease("ios:stale", { stateDir })).toMatchObject({
+      pid: 402,
+      sessionId: "new",
+    });
+    fresh.release();
+  });
+
+  it("reclaims a lease held by a real dead pid", async () => {
+    const stateDir = tempDir();
+    // A live child gives us a genuinely running pid; killing it makes
+    // process.kill(pid, 0) throw ESRCH, which is the reclaim trigger under test.
+    const child = spawn(process.execPath, [
+      "-e",
+      "setInterval(() => {}, 1000)",
+    ]);
+    await new Promise((resolve) => child.once("spawn", resolve));
+
+    const held = await acquireDeviceLease("android:crashed", {
+      stateDir,
+      sessionId: "doomed",
+      pid: child.pid,
+    });
+    expect(held.lease.pid).toBe(child.pid);
+
+    child.kill("SIGKILL");
+    await new Promise((resolve) => child.once("exit", resolve));
+
+    const reclaimed = await acquireDeviceLease("android:crashed", {
+      stateDir,
+      sessionId: "survivor",
+      waitMs: 0,
+    });
+    expect(reclaimed.lease.sessionId).toBe("survivor");
+    reclaimed.release();
+  });
+
+  it("admits exactly one winner under a parallel acquire race", async () => {
+    const stateDir = tempDir();
+    const contenders = Array.from({ length: 8 }, (_, index) =>
+      acquireDeviceLease("android:contested", {
+        stateDir,
+        sessionId: `racer-${index}`,
+        pid: 500 + index,
+        waitMs: 0,
+        isProcessAlive: () => true,
+      }).then(
+        (handle) => ({ ok: true, handle }),
+        (error) => ({ ok: false, error }),
+      ),
+    );
+
+    const results = await Promise.all(contenders);
+    const winners = results.filter((result) => result.ok);
+    expect(winners).toHaveLength(1);
+    for (const loser of results.filter((result) => !result.ok)) {
+      expect(loser.error.message).toMatch(/leased by pid 50\d/);
+    }
+
+    const persisted = readDeviceLease("android:contested", { stateDir });
+    expect(persisted.pid).toBe(winners[0].handle.lease.pid);
+    winners[0].handle.release();
   });
 
   it("reports active leases for status tooling", async () => {

--- a/packages/app/scripts/lib/device-lease.mjs
+++ b/packages/app/scripts/lib/device-lease.mjs
@@ -42,8 +42,13 @@ export function processIsAlive(pid) {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    // error-policy:J3 signal-0 is a liveness probe: ESRCH means the holder is
+    // gone (reclaim), but EPERM means it is alive under another owner (still
+    // held). Any other code is unexpected and must surface.
+    if (error?.code === "ESRCH") return false;
+    if (error?.code === "EPERM") return true;
+    throw error;
   }
 }
 
@@ -55,8 +60,13 @@ export function readDeviceLease(
   if (!fs.existsSync(leasePath)) return null;
   try {
     return JSON.parse(fs.readFileSync(leasePath, "utf8"));
-  } catch {
-    return null;
+  } catch (error) {
+    // error-policy:J3 a lease file can be observed mid-write during a race, or
+    // left truncated by a crashed writer. Both read as "no usable lease"; the
+    // caller then treats it as reclaimable rather than trusting garbage. A
+    // vanished file between existsSync and read is the same non-condition.
+    if (error?.code === "ENOENT" || error instanceof SyntaxError) return null;
+    throw error;
   }
 }
 
@@ -139,6 +149,9 @@ export async function acquireDeviceLease(
         },
       };
     } catch (error) {
+      // error-policy:J3 EEXIST is the atomic-create contention signal (someone
+      // else holds the lease); it drives the reclaim/wait branch below. Every
+      // other failure (permissions, full disk) is real and must surface.
       if (error?.code !== "EEXIST") throw error;
       const current = readDeviceLease(deviceKey, { stateDir });
       const status = activeLeaseStatus(current, {


### PR DESCRIPTION
Follow-up to #14483 (merged), completing issue #14339's test requirements and fixing a liveness-probe correctness bug.

## What

- **`processIsAlive` empty-catch bug**: any `process.kill(pid, 0)` error read as "holder dead". On a multi-user machine, `EPERM` means the holder is *alive* under another uid — the old probe would let a second session steal a held device. Now: `ESRCH` → dead (reclaim), `EPERM` → alive (still held), anything else rethrows.
- **Error-policy annotations** (`// error-policy:J3`) on the three kept catches: liveness probe, torn/corrupt lease read (mid-write race / crashed writer), `EEXIST` contention signal.
- **Real tests for the issue's collision/reclaim requirements**:
  - real spawned child process killed with `SIGKILL` → its lease is reclaimed by the next acquire (actual pid-death detection, not a fake pid);
  - direct `EPERM` signal-0 regression → another uid's active process remains held, not reclaimable;
  - 8-way parallel acquire race → exactly one winner;
  - `devices-status` helper coverage for displaying lease holders.

## Evidence

Latest evidence comment: https://github.com/elizaOS/eliza/pull/14598#issuecomment-4888343846

```bash
bunx vitest run scripts/device-lease.test.mjs scripts/devices-status.test.mjs
# Test Files  2 passed (2)
# Tests       17 passed (17)
```

```bash
bunx @biomejs/biome check packages/app/scripts/lib/device-lease.mjs packages/app/scripts/device-lease.test.mjs packages/app/scripts/devices-status.test.mjs packages/app/scripts/devices-status.mjs
# Checked 4 files. No fixes applied.
```

Trajectories / screenshots / video: N/A — host-local device runner coordination only; no UI or model surface changed.