### PR TITLE
ci: nightly post-merge live sweep — give TEST_LANE=post-merge a CI home

### DIFF
--- a/.github/workflows/develop-live.yml
+++ b/.github/workflows/develop-live.yml
@@ -1,0 +1,143 @@
+# Nightly post-merge live sweep — the only place TEST_LANE=post-merge runs the
+# whole workspace matrix. The PR/develop gates are deliberately deterministic
+# and secret-free, which means every *.real.test.ts / *.live.test.ts suite is
+# excluded there; without this lane, live-API coverage exists only as a plan.
+# run-all-tests' post-merge lane prints the guarded-suite accounting (armed /
+# missing-creds / opt-in / blocked, from packages/scripts/lib/real-live-suites.mjs)
+# and hard-fails on manifest drift, so a missing secret is a loud named skip,
+# never a silent green.
+#
+# Scheduled runs are gated on vars.ELIZA_DEVELOP_LIVE_ENABLED == 'true' so the
+# lane can be armed org-side once runner capacity allows (#13309); manual
+# dispatch always works. Local operators get the same sweep interactively via
+# `bun run test:console` (packages/scripts/test-console).
+name: Develop Live Sweep
+
+on:
+  workflow_dispatch:
+    inputs:
+      filter:
+        description: "Optional --filter regex over task labels (default: whole matrix)"
+        type: string
+        default: ""
+  schedule:
+    # 04:30 UTC — clear of develop-exhaustive (06:00/18:00) and test.yml (09:17).
+    - cron: "30 4 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: develop-live
+  cancel-in-progress: false
+
+jobs:
+  live-sweep:
+    name: Post-merge live matrix
+    if: github.event_name == 'workflow_dispatch' || vars.ELIZA_DEVELOP_LIVE_ENABLED == 'true'
+    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
+    timeout-minutes: 480
+    env:
+      TEST_LANE: post-merge
+      ELIZA_LIVE_TEST: "1"
+      ELIZA_REAL_APIS: "1"
+      ELIZA_SKIP_ARTIFACT_SYNC: "1"
+      # Canonical post-merge secret set (packages/scripts/post-merge-secrets.txt).
+      # A missing secret self-skips its suites with a named accounting line.
+      CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+      GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+      ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
+      DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+      DISCORD_TEST_GUILD_ID: ${{ secrets.DISCORD_TEST_GUILD_ID }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_TEST_CHANNEL_ID: ${{ secrets.SLACK_TEST_CHANNEL_ID }}
+      TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+      TELEGRAM_TEST_CHAT_ID: ${{ secrets.TELEGRAM_TEST_CHAT_ID }}
+      WHATSAPP_TOKEN: ${{ secrets.WHATSAPP_TOKEN }}
+      WHATSAPP_PHONE_NUMBER_ID: ${{ secrets.WHATSAPP_PHONE_NUMBER_ID }}
+      X_BEARER_TOKEN: ${{ secrets.X_BEARER_TOKEN }}
+      # The ephemeral Actions token satisfies the read-only GitHub live suites.
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+      CALENDLY_API_KEY: ${{ secrets.CALENDLY_API_KEY }}
+      CALENDLY_ACCESS_TOKEN: ${{ secrets.CALENDLY_ACCESS_TOKEN }}
+      TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
+      TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
+      GOOGLE_OAUTH_REFRESH_TOKEN: ${{ secrets.GOOGLE_OAUTH_REFRESH_TOKEN }}
+      BLUESKY_PASSWORD: ${{ secrets.BLUESKY_PASSWORD }}
+      FARCASTER_NEYNAR_API_KEY: ${{ secrets.FARCASTER_NEYNAR_API_KEY }}
+      SHOPIFY_API_KEY: ${{ secrets.SHOPIFY_API_KEY }}
+      HYPERLIQUID_PRIVATE_KEY: ${{ secrets.HYPERLIQUID_PRIVATE_KEY }}
+      POLYMARKET_API_KEY: ${{ secrets.POLYMARKET_API_KEY }}
+      STRAVA_ACCESS_TOKEN: ${{ secrets.STRAVA_ACCESS_TOKEN }}
+      OURA_ACCESS_TOKEN: ${{ secrets.OURA_ACCESS_TOKEN }}
+      FITBIT_ACCESS_TOKEN: ${{ secrets.FITBIT_ACCESS_TOKEN }}
+      WITHINGS_ACCESS_TOKEN: ${{ secrets.WITHINGS_ACCESS_TOKEN }}
+      GOOGLE_CALENDAR_ACCESS_TOKEN: ${{ secrets.GOOGLE_CALENDAR_ACCESS_TOKEN }}
+      ATLASCLOUD_API_KEY: ${{ secrets.ATLASCLOUD_API_KEY }}
+      TAVILY_API_KEY: ${{ secrets.TAVILY_API_KEY }}
+      BIRDEYE_API_KEY: ${{ secrets.BIRDEYE_API_KEY }}
+      ELIZAOS_CLOUD_API_KEY: ${{ secrets.ELIZAOS_CLOUD_API_KEY }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24.15.0"
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: "1.3.14" # pinned: floating canary writes lockfileVersion 2 and breaks --frozen-lockfile (#11184/#9454)
+          install-command: bun install
+
+      - name: Build workspace
+        run: bun run build
+
+      # plugin-sql's RLS *.real.test.ts suites gate on POSTGRES_URL with the
+      # same URL run-all-tests auto-provisions locally. Best-effort: if the
+      # runner has no docker, the suites self-skip with a named accounting line.
+      - name: Provision Postgres (best-effort)
+        run: |
+          if command -v docker >/dev/null 2>&1; then
+            docker rm -f develop-live-postgres 2>/dev/null || true
+            docker run -d --name develop-live-postgres \
+              -e POSTGRES_USER=eliza_test -e POSTGRES_PASSWORD=test123 -e POSTGRES_DB=eliza_test \
+              -p 127.0.0.1:5433:5432 postgres:17
+            echo "POSTGRES_URL=postgresql://eliza_test:test123@127.0.0.1:5433/eliza_test" >> "$GITHUB_ENV"
+          else
+            echo "docker unavailable; plugin-sql Postgres real suites will self-skip"
+          fi
+
+      - name: Post-merge live matrix
+        env:
+          RUNNER_TEMP_LOG: ${{ runner.temp }}/develop-live-sweep.log
+        run: |
+          set -o pipefail
+          FILTER_ARG=""
+          if [ -n "${{ inputs.filter }}" ]; then FILTER_ARG="--filter=${{ inputs.filter }}"; fi
+          node packages/scripts/run-all-tests.mjs --all --no-cloud $FILTER_ARG 2>&1 | tee "$RUNNER_TEMP_LOG"
+
+      - name: Cloud unit suite
+        if: always()
+        run: bun run test:cloud
+
+      - name: Teardown Postgres
+        if: always()
+        run: docker rm -f develop-live-postgres 2>/dev/null || true
+
+      - name: Upload sweep log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: develop-live-sweep-log
+          path: ${{ runner.temp }}/develop-live-sweep.log
+          if-no-files-found: ignore

--- a/.github/workflows/develop-live.yml
+++ b/.github/workflows/develop-live.yml
@@ -120,11 +120,14 @@ jobs:
       - name: Post-merge live matrix
         env:
           RUNNER_TEMP_LOG: ${{ runner.temp }}/develop-live-sweep.log
+          TEST_FILTER: ${{ inputs.filter }}
         run: |
           set -o pipefail
-          FILTER_ARG=""
-          if [ -n "${{ inputs.filter }}" ]; then FILTER_ARG="--filter=${{ inputs.filter }}"; fi
-          node packages/scripts/run-all-tests.mjs --all --no-cloud $FILTER_ARG 2>&1 | tee "$RUNNER_TEMP_LOG"
+          filter_args=()
+          if [ -n "${TEST_FILTER:-}" ]; then
+            filter_args+=(--filter="$TEST_FILTER")
+          fi
+          node packages/scripts/run-all-tests.mjs --all --no-cloud "${filter_args[@]}" 2>&1 | tee "$RUNNER_TEMP_LOG"
 
       - name: Cloud unit suite
         if: always()


### PR DESCRIPTION
Part of the CI full-coverage review driven from #14572 (with #14597).

**Gap**: the repo's real/live suites (`*.real.test.ts` / `*.live.test.ts`, 49 guarded suites in `packages/scripts/lib/real-live-suites.mjs`) are excluded from every PR/develop gate by design — and `TEST_LANE=post-merge` ran **nowhere** on any push or schedule (its only reference was the dispatch-only `lifeops-live-validation-11632.yml`). `test:all`/`test:live` never executed in CI; develop-exhaustive validates the *plan*, not the matrix.

**This lane** (`develop-live.yml`):
- `workflow_dispatch` (always available, optional `--filter` input) + nightly cron **gated on `vars.ELIZA_DEVELOP_LIVE_ENABLED == 'true'`** — default-off scheduling per the `scenario-matrix.yml` precedent, so it cannot worsen runner starvation (#13309) until an org admin arms it.
- `TEST_LANE=post-merge` `run-all-tests.mjs --all --no-cloud` with the canonical secret set from `packages/scripts/post-merge-secrets.txt`; a missing secret yields a **named accounting line** (armed / missing-creds / opt-in / blocked), never silent green — plus the manifest drift hard-fail.
- Best-effort dockerized Postgres (same URL convention run-all-tests auto-provisions) so the plugin-sql RLS `*.real.test.ts` suites arm; self-skip loudly if docker is absent.
- `bun run test:cloud` after the sweep; full log uploaded as an artifact.
- hetzner-robot runner selection with the standard `HETZNER_FLEET_ONLINE` fallback; 8h timeout; non-cancelling concurrency group.

**Evidence**: YAML parse validated; a full local post-merge-semantics sweep is currently running via the new local test console (`bun run test:console`, merged in #14578) — timing/failure data will be posted on #14572. A dispatch run of this workflow is only possible once the file exists on the default branch; I'll trigger one post-merge and attach the run link + accounting output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)