### PR TITLE
fix(cloud): voice live-lane URL fallbacks must survive empty-string repo vars

### DIFF
--- a/packages/cloud/api/__tests__/voice-kokoro-whisper-live.test.ts
+++ b/packages/cloud/api/__tests__/voice-kokoro-whisper-live.test.ts
@@ -16,11 +16,14 @@ import { resolveWhisperSttModel } from "../v1/voice/stt/whisper-model";
 const LIVE = process.env.ELIZA_VOICE_LIVE_RAILWAY === "1";
 const LIVE_SPANISH =
   LIVE && Boolean(process.env.ELIZA_VOICE_LIVE_SPANISH_AUDIO_URL);
+// `||`, not `??`: the CI workflow maps these from repo *variables*, and GitHub
+// injects an unset variable as the empty string — which must still fall back
+// to the provisioned Railway instances instead of fetch()ing an empty base.
 const KOKORO_TTS_URL =
-  process.env.KOKORO_TTS_URL ??
+  process.env.KOKORO_TTS_URL ||
   "https://kokoro-tts-production-aa4b.up.railway.app";
 const WHISPER_STT_URL =
-  process.env.WHISPER_STT_URL ??
+  process.env.WHISPER_STT_URL ||
   "https://whisper-stt-production-6fc7.up.railway.app";
 const WHISPER_MODEL = resolveWhisperSttModel(process.env.WHISPER_STT_MODEL);
 


### PR DESCRIPTION
Follow-up to #14574 (merged). One-line semantics fix caught in post-merge review.

## Bug

`voice-live-e2e.yml` maps `KOKORO_TTS_URL`/`WHISPER_STT_URL` from repo **variables** (`vars.ELIZA_VOICE_*`). When a repo variable is unset, GitHub injects the **empty string**, not an absent var. The live test's fallbacks used `?? "https://…railway.app"`, and `??` only catches null/undefined — so the first nightly run before an owner sets the vars would `fetch()` an empty base URL and fail red, defeating the lane's documented "falls back to the provisioned instances when unset" design.

## Fix

`??` → `||` on both URL fallbacks (empty string = unset for a base URL), with a comment anchoring the GitHub-variables rationale. `WHISPER_STT_MODEL` was already safe (`resolveWhisperSttModel` trims and defaults on empty).

## Evidence

Deterministic-only change to a skip-gated live test's constant resolution; the lane is schedule/dispatch-only. Biome clean. Trajectories/screenshots/video: N/A — no UI/model surface; one-line test-constant fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)