### PR TITLE
fix(discord): keep components on draft finalize

### DIFF
--- a/plugins/plugin-discord/__tests__/draft-stream-components.test.ts
+++ b/plugins/plugin-discord/__tests__/draft-stream-components.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Draft-stream finalization must preserve Discord component rows. The harness
+ * records the exact channel send/edit payloads so widget buttons cannot vanish
+ * when streaming drafts are enabled.
+ */
+import {
+	ActionRowBuilder,
+	ButtonBuilder,
+	ButtonStyle,
+	type MessageActionRowComponentBuilder,
+} from "discord.js";
+import { describe, expect, it } from "vitest";
+import { createDraftStreamController } from "../draft-stream";
+
+function buttonRow(): ActionRowBuilder<MessageActionRowComponentBuilder> {
+	return new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(
+		new ButtonBuilder()
+			.setCustomId("choice:yes")
+			.setLabel("Yes")
+			.setStyle(ButtonStyle.Primary),
+	);
+}
+
+function makeChannelHarness() {
+	const sends: unknown[] = [];
+	const edits: unknown[] = [];
+	let nextId = 0;
+	const channel = {
+		send: async (options: unknown) => {
+			sends.push(options);
+			nextId += 1;
+			return {
+				id: `msg-${nextId}`,
+				edit: async (editOptions: unknown) => {
+					edits.push(editOptions);
+					return {
+						id: `msg-${nextId}`,
+						edit: async (nextEditOptions: unknown) => {
+							edits.push(nextEditOptions);
+							return { id: `msg-${nextId}` };
+						},
+					};
+				},
+			};
+		},
+	};
+	return { channel, sends, edits };
+}
+
+describe("#14527 Discord draft stream preserves widget components", () => {
+	it("attaches components to the final draft message", async () => {
+		const { channel, sends } = makeChannelHarness();
+		const controller = createDraftStreamController();
+		const components = [buttonRow()];
+
+		await controller.start(channel as never);
+		await controller.finalize("Choose one:", components);
+
+		expect(sends).toHaveLength(1);
+		expect(sends[0]).toMatchObject({
+			content: "Choose one:",
+			components,
+		});
+	});
+
+	it("edits the last identical draft snapshot to add final components", async () => {
+		const { channel, sends, edits } = makeChannelHarness();
+		const controller = createDraftStreamController({
+			minInitialChars: 0,
+			throttleMs: 250,
+		});
+		const components = [buttonRow()];
+
+		await controller.start(channel as never);
+		controller.update("Choose one:");
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		await controller.finalize("Choose one:", components);
+
+		expect(sends).toHaveLength(1);
+		expect(edits).toHaveLength(1);
+		expect(edits[0]).toMatchObject({
+			content: "Choose one:",
+			components,
+		});
+	});
+});

--- a/plugins/plugin-discord/draft-stream.ts
+++ b/plugins/plugin-discord/draft-stream.ts
@@ -2,7 +2,12 @@
  * Streams an in-progress agent reply to Discord by editing a single message as
  * draft chunks arrive, using the draft-chunking break logic.
  */
-import type { Message as DiscordMessage, TextChannel } from "discord.js";
+import type {
+	ActionRowBuilder,
+	Message as DiscordMessage,
+	MessageActionRowComponentBuilder,
+	TextChannel,
+} from "discord.js";
 import {
 	DEFAULT_DRAFT_CHUNK_CONFIG,
 	type DraftChunkConfig,
@@ -27,7 +32,10 @@ export interface DraftStreamController {
 		replyToMode?: DraftReplyToMode,
 	) => Promise<DiscordMessage | null>;
 	update: (text: string) => void;
-	finalize: (text: string) => Promise<DiscordMessage[]>;
+	finalize: (
+		text: string,
+		components?: ActionRowBuilder<MessageActionRowComponentBuilder>[],
+	) => Promise<DiscordMessage[]>;
 	abort: (reason?: string) => Promise<void>;
 	messageId: () => string | undefined;
 	isStarted: () => boolean;
@@ -65,7 +73,10 @@ export function createDraftStreamController(
 		}
 	};
 
-	const sendSnapshot = async (text: string): Promise<boolean> => {
+	const sendSnapshot = async (
+		text: string,
+		components?: ActionRowBuilder<MessageActionRowComponentBuilder>[],
+	): Promise<boolean> => {
 		if (done || !channel) {
 			return false;
 		}
@@ -80,12 +91,52 @@ export function createDraftStreamController(
 				? `${trimmed.slice(0, maxChars - 3)}...`
 				: trimmed;
 		if (displayText === lastSentText) {
+			if (components && components.length > 0 && lastSentMessage) {
+				try {
+					const edited = await lastSentMessage.edit({
+						content: displayText,
+						components,
+					});
+					lastSentMessage = edited;
+					const lastIndex = sentMessages.length - 1;
+					if (lastIndex >= 0) {
+						sentMessages[lastIndex] = edited;
+					}
+				} catch (error) {
+					const errorMessage =
+						error instanceof Error ? error.message : String(error);
+					warn(`draft-stream: final component edit failed: ${errorMessage}`);
+					try {
+						const sent = await channel.send({
+							content: displayText,
+							components,
+							...(draftReplyToMessageId && draftReplyToMode !== "off"
+								? {
+										reply: { messageReference: draftReplyToMessageId },
+									}
+								: {}),
+						});
+						lastSentMessage = sent;
+						sentMessages.push(sent);
+					} catch (sendError) {
+						const sendErrorMessage =
+							sendError instanceof Error
+								? sendError.message
+								: String(sendError);
+						warn(
+							`draft-stream: final component resend failed: ${sendErrorMessage}`,
+						);
+						return false;
+					}
+				}
+			}
 			return true;
 		}
 
 		try {
 			const sent = await channel.send({
 				content: displayText,
+				...(components && components.length > 0 ? { components } : {}),
 				...(draftReplyToMessageId && draftReplyToMode !== "off"
 					? {
 							reply: { messageReference: draftReplyToMessageId },
@@ -151,7 +202,10 @@ export function createDraftStreamController(
 		scheduleUpdate(text);
 	};
 
-	const finalize = async (text: string): Promise<DiscordMessage[]> => {
+	const finalize = async (
+		text: string,
+		components?: ActionRowBuilder<MessageActionRowComponentBuilder>[],
+	): Promise<DiscordMessage[]> => {
 		if (done) {
 			return sentMessages;
 		}
@@ -172,7 +226,7 @@ export function createDraftStreamController(
 		}
 
 		if (trimmed.length <= maxChars) {
-			await sendSnapshot(trimmed);
+			await sendSnapshot(trimmed, components);
 			done = true;
 			log("draft-stream: finalized (single message)");
 			return sentMessages;
@@ -204,8 +258,12 @@ export function createDraftStreamController(
 				continue;
 			}
 			try {
+				const isLastChunk = remaining.length === 0;
 				const overflowMessage = await channel.send({
 					content: chunk,
+					...(isLastChunk && components && components.length > 0
+						? { components }
+						: {}),
 					...(draftReplyToMessageId && draftReplyToMode === "all"
 						? {
 								reply: { messageReference: draftReplyToMessageId },

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -1136,8 +1136,11 @@ export class MessageManager {
 					let messages: DiscordMessage[] = [];
 					if (draftStream?.isStarted() && !draftStream.isDone()) {
 						if (hasText || files.length === 0) {
+							const draftComponents = hasComponents
+								? buildDiscordComponents(rendered.components)
+								: undefined;
 							messages = await runResponseDispatch(() =>
-								draftStream.finalize(textContent),
+								draftStream.finalize(textContent, draftComponents),
 							);
 						} else {
 							await finalizePendingDraft();


### PR DESCRIPTION
## Summary
- thread built Discord action rows into `draftStream.finalize(...)` so streaming final replies keep widget buttons/selects
- edit the last identical draft snapshot to add final components; if edit fails, send a final component-bearing message instead of silently losing buttons
- add a payload-level regression test for both final send and identical-snapshot edit paths

Partial fix for #14527 (bug 2 only: draft-stream finalize drops components). This intentionally does not touch the DM send path already claimed on the issue, overflow truncation, callback caps, selects, embeds, or modals.

## Verification
- `bun run --cwd plugins/plugin-discord test __tests__/draft-stream-components.test.ts`
- `bun run --cwd plugins/plugin-discord test __tests__/draft-stream-components.test.ts __tests__/dm-widget-components.test.ts __tests__/interactions.test.ts`
- `bunx @biomejs/biome check plugins/plugin-discord/draft-stream.ts plugins/plugin-discord/messages.ts plugins/plugin-discord/__tests__/draft-stream-components.test.ts`
- `git diff --check`
- `bun run audit:error-policy-ratchet --report`

## Not run
- `bun run --cwd plugins/plugin-discord typecheck` does not complete in this fresh worktree because unrelated workspace/package resolution issues remain: `@elizaos/plugin-sql`, `@elizaos/vault`, `@elizaos/plugin-commands`, `fast-redact` declarations, plus the existing `catalog-commands.ts` implicit-any diagnostic.
- Live Discord round-trip/screenshot: N/A for this unit-level follow-up; the regression records the exact outbound `channel.send` / `message.edit` payloads that previously dropped components.