### PR TITLE
fix(#14374): repin whisper-stt to real ghcr tag (0.6.5 was a 404)

### DIFF
--- a/packages/cloud/services/voice-whisper-stt/Dockerfile
+++ b/packages/cloud/services/voice-whisper-stt/Dockerfile
@@ -18,8 +18,11 @@
 # Pin: Speaches publishes CPU/CUDA variants under ghcr.io/speaches-ai/speaches.
 # CPU is the Railway default (free tier has no GPU); override WHISPER_IMAGE at
 # build time for a CUDA variant on a GPU-backed plan. Bump the tag deliberately —
-# an unpinned :latest is exactly the drift this issue removes.
-ARG WHISPER_IMAGE=ghcr.io/speaches-ai/speaches:0.6.5-cpu
+# an unpinned :latest is exactly the drift this issue removes. The tag must be a
+# real published manifest AND still expose the contract below (0.8.x keeps
+# POST /v1/audio/transcriptions with multipart field `file` and GET /health);
+# verify the ghcr manifest exists before bumping.
+ARG WHISPER_IMAGE=ghcr.io/speaches-ai/speaches:0.8.2-cpu
 
 FROM ${WHISPER_IMAGE}
 

--- a/packages/cloud/services/voice-whisper-stt/README.md
+++ b/packages/cloud/services/voice-whisper-stt/README.md
@@ -36,7 +36,7 @@ CUDA variant on a GPU-backed plan:
 
 ```bash
 railway up --service whisper-stt \
-  --build-arg WHISPER_IMAGE=ghcr.io/speaches-ai/speaches:0.6.5-cuda
+  --build-arg WHISPER_IMAGE=ghcr.io/speaches-ai/speaches:0.8.2-cuda
 ```
 
 ## Scheduled live contract lane

--- a/packages/scripts/__tests__/voice-railway-service-defs.test.ts
+++ b/packages/scripts/__tests__/voice-railway-service-defs.test.ts
@@ -36,12 +36,19 @@ const SERVICES = [
     contractPath: "/api/tts",
     deployCmd: "railway up --service kokoro-tts",
     urlVar: "ELIZA_VOICE_KOKORO_TTS_URL",
+    // Exact `FROM` tag the Dockerfile ARG defaults to. Pinned to a manifest that
+    // is verified to exist on ghcr — a bad tag (`railway up` fails at FROM) is
+    // caught here instead of only at deploy. Re-verify the manifest before bumping.
+    imageTag: "ghcr.io/remsky/kokoro-fastapi-cpu:v0.2.2",
   },
   {
     dir: "packages/cloud/services/voice-whisper-stt",
     contractPath: "/v1/audio/transcriptions",
     deployCmd: "railway up --service whisper-stt",
     urlVar: "ELIZA_VOICE_WHISPER_STT_URL",
+    // 0.8.2-cpu is a real ghcr manifest that still serves the transcription +
+    // /health contract; the prior 0.6.5-cpu was a 404 (`railway up` died at FROM).
+    imageTag: "ghcr.io/speaches-ai/speaches:0.8.2-cpu",
   },
 ] as const;
 
@@ -65,6 +72,10 @@ describe("Railway voice service definitions (#14374)", () => {
         const argImage = dockerfile.match(/^ARG\s+\w*IMAGE=(\S+)/m)?.[1] ?? "";
         expect(argImage).toMatch(/:[^:@\s]+$/);
         expect(argImage).not.toMatch(/:latest$/);
+        // Pin the exact tag: a version that is present-but-nonexistent-on-ghcr
+        // (the 0.6.5-cpu 404 that made `railway up` fail at FROM) passes the
+        // generic "has a tag" checks above, so assert the manifest-verified tag.
+        expect(argImage).toBe(svc.imageTag);
       });
 
       test("ships a valid railway.toml (Dockerfile builder + /health)", () => {


### PR DESCRIPTION
Follow-up to #14574 (merged) — fixes the fable must-fixes on the in-repo Railway voice service defs (#14374).

## Must-fix 1 (CRITICAL): whisper-stt pinned a nonexistent ghcr tag → `railway up` fails at FROM

`packages/cloud/services/voice-whisper-stt/Dockerfile` pinned `ghcr.io/speaches-ai/speaches:0.6.5-cpu`, which **does not exist** on ghcr. The 0.6.x line ends at `0.6.2`; latest is `0.8.x`. `railway up` from the committed config dies at `FROM`.

Manifest-existence check (ghcr token flow):

```
0.6.5-cpu  -> HTTP 404   (the broken pin)
0.6.2-cpu  -> HTTP 200
0.8.2-cpu  -> HTTP 200   (chosen — newest whose contract still matches)
0.8.2-cuda -> HTTP 200   (chosen for the README GPU example)
0.6.5-cuda -> HTTP 404   (the broken README pin)
```

**Contract verified before picking 0.8.2** (speaches renamed/changed endpoints across the 0.6→0.8 line, so this was checked against the source, not assumed):

| Contract the live test + route depend on | 0.8.2 source |
|---|---|
| `POST /v1/audio/transcriptions` | present (`routers/stt.py`) |
| multipart audio field named `file` | present (`dependencies.py`: `file: Annotated[UploadFile, Form()]`) |
| `model`, optional `language` form fields | present |
| `GET /health` -> 200 | present (`routers/misc.py`: `Response(status_code=200, content="OK")`) |

So the route (`packages/cloud/api/v1/voice/stt/*`) and live test (`voice-kokoro-whisper-live.test.ts`) are unchanged — 0.8.2 keeps the same paths and field names.

**Changes:**
- `voice-whisper-stt/Dockerfile`: `WHISPER_IMAGE` ARG `0.6.5-cpu` → `0.8.2-cpu`
- `voice-whisper-stt/README.md`: GPU example `0.6.5-cuda` → `0.8.2-cuda`
- `packages/scripts/__tests__/voice-railway-service-defs.test.ts`: now asserts each service's **exact manifest-verified tag** (`imageTag`), not just "has a tag / not `:latest`" — a present-but-nonexistent-on-ghcr tag passed the old generic checks. (kokoro `v0.2.2` also verified present on ghcr and pinned in the assertion.)

Config-lint run:
```
bun test packages/scripts/__tests__/voice-railway-service-defs.test.ts
 12 pass  0 fail  39 expect() calls
```
`bunx @biomejs/biome check` on the touched test: clean.

## Must-fix 2: deploy-proof acceptance is **N/A (owner action)** — do NOT fully close #14374 without it

The #14374 acceptance (one fresh `railway up` from committed config for **both** services + a green scheduled `voice-railway-contract` run + the intentionally-red bogus-URL dispatch run) requires **Railway credentials + the deploy fleet** and **cannot be produced headlessly**. It is not fabricated here.

Owner commands to attach the deploy proof:
```bash
# from packages/cloud/services/voice-whisper-stt
railway up --service whisper-stt
# from packages/cloud/services/voice-kokoro-tts
railway up --service kokoro-tts
# then set the public URLs as repo variables:
#   ELIZA_VOICE_WHISPER_STT_URL, ELIZA_VOICE_KOKORO_TTS_URL
# green scheduled contract run:
gh workflow run voice-live-e2e.yml -f run_railway_contract=true   # expect PASS
# intentionally-red bogus-URL dispatch (point a URL var at a dead host) -> expect FAIL
```

**#14374 should stay open until an owner attaches that live deploy proof.** This PR only removes the guaranteed-fail-at-FROM defect and hardens the lint gate against tag-drift.
