### PR TITLE
fix(voice): dedup cloud STT/TTS candidate fan-out to drop the empty catch #14591 added

### DIFF
--- a/packages/shared/src/elizacloud/server-cloud-tts.ts
+++ b/packages/shared/src/elizacloud/server-cloud-tts.ts
@@ -198,6 +198,29 @@ export function resolveCloudTtsBaseUrl(
   }
 }
 
+/**
+ * A cloud base URL plus its `www`/apex sibling, so a base written either way
+ * still resolves. `elizacloud.ai` and `www.elizacloud.ai` are the same origin
+ * upstream; a user who configured one should still reach the other. The single
+ * `URL` parse lives here so the TTS and STT candidate resolvers share one
+ * validated fan-out instead of each carrying its own parse-guarded copy.
+ */
+function resolveWwwApexBaseSiblings(base: string): string[] {
+  const trimmed = base.replace(/\/+$/, "");
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    // A custom base URL may be a bare path the resolver already validated;
+    // without a parsable host there is no sibling to add.
+    return [trimmed];
+  }
+  parsed.hostname = parsed.hostname.startsWith("www.")
+    ? parsed.hostname.slice(4)
+    : `www.${parsed.hostname}`;
+  return [trimmed, parsed.toString().replace(/\/$/, "")];
+}
+
 export function resolveCloudTtsCandidateUrls(
   env: NodeJS.ProcessEnv = process.env,
 ): string[] {
@@ -220,18 +243,8 @@ export function resolveCloudTtsCandidateUrls(
     }
   };
 
-  addEndpointsForApiV1Base(base);
-  try {
-    const parsed = new URL(base);
-    if (parsed.hostname.startsWith("www.")) {
-      parsed.hostname = parsed.hostname.slice(4);
-      addEndpointsForApiV1Base(parsed.toString().replace(/\/$/, ""));
-    } else {
-      parsed.hostname = `www.${parsed.hostname}`;
-      addEndpointsForApiV1Base(parsed.toString().replace(/\/$/, ""));
-    }
-  } catch {
-    // The base resolver already validated the default path.
+  for (const siblingBase of resolveWwwApexBaseSiblings(base)) {
+    addEndpointsForApiV1Base(siblingBase);
   }
 
   return [...candidates];
@@ -242,26 +255,18 @@ export function resolveCloudTtsCandidateUrls(
  * same base URL as TTS. Interactive web capture posts a WAV here through the
  * agent proxy (`/api/asr/cloud`) so `eliza-cloud` ASR is the real transcriber
  * instead of the engine-dependent browser SpeechRecognition. The `www`/apex
- * pairing mirrors the TTS resolver so a base URL written either way still
- * resolves; there is no ElevenLabs-shaped legacy STT compat route (unlike TTS),
- * so only the canonical `/voice/stt` path is queued.
+ * pairing mirrors the TTS resolver (both use `resolveWwwApexBaseSiblings`) so a
+ * base URL written either way still resolves; there is no ElevenLabs-shaped
+ * legacy STT compat route (unlike TTS), so only the canonical `/voice/stt` path
+ * is queued.
  */
 export function resolveCloudSttCandidateUrls(
   env: NodeJS.ProcessEnv = process.env,
 ): string[] {
   const base = resolveCloudTtsBaseUrl(env).replace(/\/+$/, "");
   const candidates = new Set<string>();
-  candidates.add(`${base}/voice/stt`);
-  try {
-    const parsed = new URL(base);
-    if (parsed.hostname.startsWith("www.")) {
-      parsed.hostname = parsed.hostname.slice(4);
-    } else {
-      parsed.hostname = `www.${parsed.hostname}`;
-    }
-    candidates.add(`${parsed.toString().replace(/\/$/, "")}/voice/stt`);
-  } catch {
-    // The base resolver already validated the default path.
+  for (const siblingBase of resolveWwwApexBaseSiblings(base)) {
+    candidates.add(`${siblingBase}/voice/stt`);
   }
   return [...candidates];
 }

--- a/packages/ui/src/voice/local-asr-transcribe.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.ts
@@ -125,7 +125,8 @@ export async function transcribeCloudWav(
     signal: options?.signal,
   });
   if (!res.ok) {
-    // error-policy:J6 best-effort error detail — the throw carries the status
+    // error-policy:J6 the error body is diagnostic-only; a failed read must not
+    // mask the real signal (the HTTP status the throw below already carries).
     const body = await res.text().catch(() => "");
     throw new Error(`Cloud ASR ${res.status}: ${body.slice(0, 200)}`);
   }
@@ -158,7 +159,8 @@ export async function transcribeLocalInferenceWav(
     signal: options?.signal,
   });
   if (!res.ok) {
-    // error-policy:J6 best-effort error detail — the throw carries the status
+    // error-policy:J6 the error body is diagnostic-only; a failed read must not
+    // mask the real signal (the HTTP status the throw below already carries).
     const body = await res.text().catch(() => "");
     throw new Error(`Local inference ASR ${res.status}: ${body.slice(0, 200)}`);
   }


### PR DESCRIPTION
Follow-up to merged **#14591** (#14372 web eliza-cloud ASR wiring). That PR was already merged and its branch deleted, so this lands the fable must-fix as a fresh PR against `develop`.

## The defect
`resolveCloudSttCandidateUrls` (`packages/shared/src/elizacloud/server-cloud-tts.ts`) copied the `www`/apex candidate fan-out from `resolveCloudTtsCandidateUrls` verbatim — the identical `try { new URL(base); toggle www } catch {}` block. That added a **second parse-guarded empty catch** to the file: it went from **6 → 7** empty catches vs its pre-#14591 content.

`bun run audit:error-policy-ratchet` (part of `bun run verify`) fails when a touched file *adds* an empty catch, and its check is `block.statements.length === 0` — a `// J<N>` annotation does not help (comments are trivia, not statements). So any branch touching this file after #14591 reds `verify` for everyone.

## The fix
Extract the shared `www`/apex sibling fan-out into one `resolveWwwApexBaseSiblings(base)` helper that both resolvers call, so the `URL` parse + its catch exist **once**. The file is back to **6** empty catches; both resolvers keep identical `www`/apex behavior (verified by the existing STT resolver test + the TTS candidate path).

Also relabeled the two ASR error-body reads in `packages/ui/src/voice/local-asr-transcribe.ts`: a `res.text().catch(() => "")` feeding a thrown error is a **diagnostic-only** best-effort read (matching #14591's own chore cleanup of the proxy handler, which annotated the identical `attempt.text().catch()` as `J6 diagnostic-only`), not the teardown the prior "the throw carries the status" J6 wording implied. The un-annotated `.catch(() => 'unknown error')` in the proxy handler was already fixed on `develop` by the `chore(voice): clean cloud ASR error handling` commit (6f45bfcde5a).

## Verification (real output)

`bun run audit:error-policy-ratchet`:
```
[error-policy-ratchet] base origin/develop (10ad528656); 2 changed production source file(s)
[error-policy-ratchet]   packages/shared/src/elizacloud/server-cloud-tts.ts: emptyCatch 4->2, serverConsole 0->0
[error-policy-ratchet]   packages/ui/src/voice/local-asr-transcribe.ts: emptyCatch 0->0, serverConsole 0->0
[error-policy-ratchet] no new fallback-slop in touched files
```
(`} catch {` count in the file: **7 → 6**.)

Touched tests — `bunx vitest run <shared STT> <base-url> <ui transcribe> <ui capture-factory> <plugin proxy>`:
```
Test Files  5 passed (5)
     Tests  30 passed (30)
```

`bunx @biomejs/biome check <both files>`: `Checked 2 files in 44ms. No fixes applied.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)