### PR TITLE
test(ui): guard sparse home wallet and chat tile (#14343)

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -433,6 +433,7 @@ try {
     ["widget-goals-attention", "Ship the release"],
     ["chat-widget-calendar-upcoming", "Design review"],
     ["widget-health-sleep", "Irregular"],
+    ["chat-widget-wallet-prices", "BTC"],
   ];
   for (const [testId, text] of WIDGET_CARDS) {
     const card = homeWidgetHost.getByTestId(testId);
@@ -649,6 +650,10 @@ try {
   assert(
     (await mobile.getByTestId("launcher-dock").count()) === 0,
     "the launcher renders no dock (featured-views header removed)",
+  );
+  assert(
+    (await mobile.getByTestId("launcher-tile-chat").count()) === 0,
+    "Chat is not duplicated as a launcher tile (home rail is the chat surface)",
   );
   // ── Removed / hidden surfaces never tile: removed apps, wallet sub-views,
   // and the deduped duplicate registrations.


### PR DESCRIPTION
Follow-up for #14343 after #14533/#14588.

## What changed

- Adds the kept Wallet home widget to the real-browser home-screen e2e populated-content assertions.
- Adds an explicit launcher assertion that Chat is not duplicated as a launcher tile; the home rail is the chat surface.

## Verification

```bash
node --check packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
# PASS
```

```bash
bun run --cwd packages/ui test:home-screen-e2e
# HOME-SCREEN E2E PASSED
```

Key assertions from the run:
- Wallet home widget renders and shows `BTC`.
- Removed home widgets `chat-widget-finances-alerts`, `chat-widget-relationships`, and `chat-widget-inbox-unread` stay absent.
- Home card foreground probe reports `[]` dark foreground failures.
- Chat is not duplicated as `launcher-tile-chat`.
- No page errors; rail swipe median p95 `10.2ms`, dropped `0%`.

```bash
bun run --cwd packages/app test -- test/audit/mvp-visual-verify.test.ts
# 1 file passed, 24 tests passed
```

```bash
git diff --check origin/develop...HEAD
# PASS
```

Biome note: `packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs` is ignored by the repo Biome config, so `biome check <file>` processes 0 files. `node --check` covers syntax for this script.

## Screenshot / OCR Review

Generated by `test:home-screen-e2e` under `packages/ui/src/components/shell/__e2e__/output-home/` and manually opened/reviewed:

- `01-mobile-home.png`: sparse home contains notifications, goals, sleep, calendar, wallet, and native Messages/Phone/Contacts/Camera only. Wallet rows show `BTC`, `SOL`, `ETH`; removed finance alert, relationship attention, and inbox unread widgets are absent. Cards are readable against the dark ember field and do not overlap.
- `02-mobile-launcher.png`: launcher is curated app/developer tiles; no `Chat` tile is present. The page has visual breathing room and no dock/page dots.
- `04-desktop-home.png` and `05-desktop-launcher.png`: desktop equivalents preserve the same sparse-home and no-duplicate-chat behavior.

OCR readout from the generated screenshots included expected home text: `Payment failed`, `Ship the release`, `Irregular`, `Design review`, `Wallet`, `BTC`, `SOL`, `ETH`, `Messages`, `Phone`, `Contacts`, `Camera`. Launcher OCR included `Settings`, `Wallet`, `Automations`, `Browser`, `Character`, `Knowledge`, `Memories`, `Feed`, `Stream`, `Trajectories`, `Databases`, `Runtime`, `Logs`, `Skills`, `Plugins`, `Relationships`; `Chat` was absent.

Image statistics from the generated screenshots:
- `01-mobile-home.png`: `804x1748`, mean RGB `37,24,16`, stdev `41.6,40.9,41.8`.
- `02-mobile-launcher.png`: `804x1748`, mean RGB `60,41,31`, stdev `64.5,56.5,56.6`.
- `04-desktop-home.png`: `1180x900`, mean RGB `33,19,10`, stdev `27.8,24.7,24.7`.
- `05-desktop-launcher.png`: `1180x900`, mean RGB `41,25,15`, stdev `41.4,34.7,34.2`.

## Full App Audit Note

`bun run --cwd packages/app audit:app` was reported by the original branch author as 365 checks with 364 passed before final ratchet assertion, failing only unrelated Hyperliquid/Polymarket whitespace-ratio ratchets outside this one-file UI e2e diff. I did not rerun the full app audit for this review because this PR changes only the isolated home-screen e2e harness and the branch-specific real browser harness passed.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - test-harness-only change; no product UI implementation changed`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - test-harness-only change; generated screenshots were reviewed locally and summarized above`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - test-harness-only change; generated WebM was produced by the e2e and the asserted flow is summarized above`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no backend path changed`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - isolated UI e2e harness change; run asserted no page errors and no network-backed runtime path changed`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent/action/provider/prompt/model behavior changed`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no DB, memory, scheduled-task, wallet, chain, generated-file, audio, or other domain artifact is produced`.

## Known Gaps / Failures

- `bunx @biomejs/biome check packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs` exits non-zero because the file is ignored by config and Biome processes 0 files. This is not a code failure; `node --check` passed.
- The first `test:home-screen-e2e` attempt in a clean worktree failed before test execution because the shared install was missing the `@tailwindcss/postcss` symlink and generated i18n data. I repaired the local install/link, ran `bun run --cwd packages/shared build:i18n`, and reran the e2e successfully.
