### PR TITLE
fix(evidence): review hardening — symlink-aware verify, metaSha256 binding, strict canonical (#14552)

### DIFF
--- a/packages/evidence/AGENTS.md
+++ b/packages/evidence/AGENTS.md
@@ -15,8 +15,14 @@ whole pipeline (analyzers → VLM Q&A → certify → CI gate) fits together.
   the interfaces at compile time — keep that guard intact.
 - **Manifest bytes are signed.** `finalize()` must stay byte-stable: artifacts
   sorted by path, canonical JSON (sorted keys, no whitespace, one trailing
-  newline — `src/canonical.ts`). Any change to serialization is a
-  certification-breaking change.
+  newline — `src/canonical.ts`; non-plain objects throw, `toJSON` is not
+  honored), bundle paths NFC-normalized at ingress. Any change to
+  serialization is a certification-breaking change.
+- **Provenance is bound.** `finalize()` writes + hashes `meta.json` before
+  building the manifest and embeds `metaSha256`; `verifyBundle` re-checks it
+  (`meta-mismatch`). A verified bundle contains no symlinks anywhere —
+  verification is lstat-based and reports `symlink` findings instead of
+  following links (mutable-after-signing / unswept-tree exploits).
 - **Producers are not touched.** Ingestors (`src/ingest.ts`) only discover and
   copy. `packages/app/scripts/**` and `scripts/evidence-review/**` are hot
   zones with in-flight PRs; this package deliberately lives outside them.

--- a/packages/evidence/CLAUDE.md
+++ b/packages/evidence/CLAUDE.md
@@ -15,8 +15,14 @@ whole pipeline (analyzers → VLM Q&A → certify → CI gate) fits together.
   the interfaces at compile time — keep that guard intact.
 - **Manifest bytes are signed.** `finalize()` must stay byte-stable: artifacts
   sorted by path, canonical JSON (sorted keys, no whitespace, one trailing
-  newline — `src/canonical.ts`). Any change to serialization is a
-  certification-breaking change.
+  newline — `src/canonical.ts`; non-plain objects throw, `toJSON` is not
+  honored), bundle paths NFC-normalized at ingress. Any change to
+  serialization is a certification-breaking change.
+- **Provenance is bound.** `finalize()` writes + hashes `meta.json` before
+  building the manifest and embeds `metaSha256`; `verifyBundle` re-checks it
+  (`meta-mismatch`). A verified bundle contains no symlinks anywhere —
+  verification is lstat-based and reports `symlink` findings instead of
+  following links (mutable-after-signing / unswept-tree exploits).
 - **Producers are not touched.** Ingestors (`src/ingest.ts`) only discover and
   copy. `packages/app/scripts/**` and `scripts/evidence-review/**` are hot
   zones with in-flight PRs; this package deliberately lives outside them.

--- a/packages/evidence/README.md
+++ b/packages/evidence/README.md
@@ -31,7 +31,11 @@ interface ArtifactEntry {
   createdAt: string;   // ISO-8601
 }
 
-interface BundleManifest { schema: 1; runId: string; createdAt: string; artifacts: ArtifactEntry[] }
+interface BundleManifest {
+  schema: 1; runId: string; createdAt: string;
+  metaSha256: string;  // sha256 of meta.json bytes — binds provenance into the signed envelope
+  artifacts: ArtifactEntry[];
+}
 
 interface BundleMeta {
   schema: 1; runId: string; commit: string; branch: string;
@@ -66,7 +70,14 @@ evidence/runs/<run-id>/
 
 Manifest canonicalization (hard requirement — certification signs these
 bytes): artifacts sorted by `path` (UTF-16 code-unit order), object keys
-sorted, no whitespace, UTF-8, one trailing newline. See `src/canonical.ts`.
+sorted, no whitespace, UTF-8, one trailing newline. Non-plain objects
+(Date/Map/Set/class instances) throw rather than silently serializing as
+`{}`; `toJSON` is not honored — callers pre-serialize. See `src/canonical.ts`.
+
+Bundle paths are NFC-normalized at `addArtifact` ingress so macOS (NFD) and
+linux (NFC) produce identical manifest bytes for the same logical filename.
+`finalize()` writes and hashes `meta.json` first, then embeds that hash as
+`manifest.metaSha256` — forged provenance fails verification.
 
 ## Ingestors
 
@@ -100,8 +111,10 @@ bun run --cwd packages/evidence bundle:verify -- evidence/runs/<run-id>
 runner (`ELIZA_EVIDENCE_RUNNER` ∈ local|vast|ci, else `CI` env, else local),
 ingests every silo, finalizes, and prints a per-silo summary plus the manifest
 sha256. `verify` re-hashes every artifact and reports `missing` /
-`size-mismatch` / `hash-mismatch` / `unlisted` findings; non-zero exit on any
-issue.
+`size-mismatch` / `hash-mismatch` / `unlisted` / `symlink` / `meta-mismatch`
+findings; non-zero exit on any issue. Verification is lstat-based: a verified
+bundle contains no symlinks anywhere — a symlinked artifact would be mutable
+after signing, and a symlinked directory would mount an unswept external tree.
 
 ## How later pieces slot in
 

--- a/packages/evidence/src/bundle.test.ts
+++ b/packages/evidence/src/bundle.test.ts
@@ -7,6 +7,7 @@
  * created portably inside one tmp volume).
  */
 
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -148,6 +149,41 @@ describe("EvidenceBundle", () => {
         bundlePath: "visual/s/a.png",
       }),
     ).rejects.toMatchObject({ code: "ARTIFACT_PLACEMENT_AMBIGUOUS" });
+  });
+
+  it("NFC-normalizes bundle paths so NFD input cannot drift manifest bytes", async () => {
+    const sources = tmpDir();
+    const bundle = createBundle({
+      rootDir: tmpDir(),
+      provenance: PROVENANCE,
+      now: fixedClock(),
+    });
+    // "caf\u00e9.png" in decomposed NFD form (e + combining acute), the way
+    // macOS reports filenames; the manifest must carry the precomposed NFC.
+    const nfdName = "cafe\u0301.png";
+    const nfcName = "caf\u00e9.png";
+    expect(nfdName).not.toBe(nfcName);
+    const entry = await bundle.addArtifact(
+      writeFixture(sources, "shot.png", "png"),
+      {
+        kind: "screenshot",
+        source: "s",
+        producedBy: "p",
+        relativePath: nfdName,
+      },
+    );
+    expect(entry.path).toBe(`visual/s/${nfcName}`);
+    const { manifest } = await bundle.finalize();
+    expect(manifest.artifacts[0].path).toBe(`visual/s/${nfcName}`);
+  });
+
+  it("binds meta.json into the manifest via metaSha256", async () => {
+    const bundle = await buildSampleBundle(tmpDir(), tmpDir());
+    const { manifest, metaPath } = await bundle.finalize();
+    const metaHash = createHash("sha256")
+      .update(fs.readFileSync(metaPath))
+      .digest("hex");
+    expect(manifest.metaSha256).toBe(metaHash);
   });
 
   it("produces byte-identical manifests across two runs with the same inputs", async () => {
@@ -390,5 +426,110 @@ describe("verifyBundle", () => {
     await expect(verifyBundle(empty)).rejects.toBeInstanceOf(
       EvidenceValidationError,
     );
+  });
+
+  it("fails when meta.json provenance is forged (commit flip)", async () => {
+    const bundle = await buildSampleBundle(tmpDir(), tmpDir());
+    await bundle.finalize();
+    const metaPath = path.join(bundle.dir, "meta.json");
+    const forged = fs
+      .readFileSync(metaPath, "utf8")
+      .replace(COMMIT, "f".repeat(40));
+    expect(forged).not.toBe(fs.readFileSync(metaPath, "utf8"));
+    fs.writeFileSync(metaPath, forged);
+
+    const report = await verifyBundle(bundle.dir);
+    expect(report.ok).toBe(false);
+    const metaIssue = report.issues.find((i) => i.issue === "meta-mismatch");
+    expect(metaIssue).toMatchObject({ path: "meta.json" });
+    expect(metaIssue?.expected).toMatch(/^[0-9a-f]{64}$/);
+    expect(metaIssue?.actual).toMatch(/^[0-9a-f]{64}$/);
+    expect(metaIssue?.actual).not.toBe(metaIssue?.expected);
+  });
+
+  it("fails when meta.json is missing", async () => {
+    const bundle = await buildSampleBundle(tmpDir(), tmpDir());
+    await bundle.finalize();
+    fs.rmSync(path.join(bundle.dir, "meta.json"));
+    const report = await verifyBundle(bundle.dir);
+    expect(report.ok).toBe(false);
+    expect(
+      report.issues.some(
+        (i) => i.issue === "meta-mismatch" && i.actual === "missing",
+      ),
+    ).toBe(true);
+  });
+
+  // The four symlink scenarios the security review proved exploitable when the
+  // walk was isFile()/isDirectory()-based and the verify loop followed links.
+  it("flags an unlisted file symlink instead of ignoring it", async () => {
+    const external = tmpDir();
+    const externalFile = path.join(external, "external.txt");
+    fs.writeFileSync(externalFile, "outside the bundle");
+    const bundle = await buildSampleBundle(tmpDir(), tmpDir());
+    await bundle.finalize();
+    fs.symlinkSync(externalFile, path.join(bundle.dir, "sneaky-link.txt"));
+
+    const report = await verifyBundle(bundle.dir);
+    expect(report.ok).toBe(false);
+    expect(report.issues).toContainEqual({
+      path: "sneaky-link.txt",
+      issue: "symlink",
+    });
+  });
+
+  it("flags a directory symlink instead of following it", async () => {
+    const external = tmpDir();
+    fs.writeFileSync(path.join(external, "mounted.txt"), "external tree");
+    const bundle = await buildSampleBundle(tmpDir(), tmpDir());
+    await bundle.finalize();
+    fs.symlinkSync(external, path.join(bundle.dir, "mounted-dir"));
+
+    const report = await verifyBundle(bundle.dir);
+    expect(report.ok).toBe(false);
+    expect(report.issues).toContainEqual({
+      path: "mounted-dir",
+      issue: "symlink",
+    });
+    // The external tree behind the link must not be walked.
+    expect(report.issues.some((i) => i.path.includes("mounted.txt"))).toBe(
+      false,
+    );
+  });
+
+  it("fails a listed artifact replaced by a symlink to matching external bytes", async () => {
+    const bundle = await buildSampleBundle(tmpDir(), tmpDir());
+    await bundle.finalize();
+    const artifactRel = ["lanes", "e2e", "logs", "server.log"];
+    const artifactPath = path.join(bundle.dir, ...artifactRel);
+    // Byte-identical external copy: stat-based verification would pass this.
+    const external = tmpDir();
+    const externalCopy = path.join(external, "server.log");
+    fs.copyFileSync(artifactPath, externalCopy);
+    fs.rmSync(artifactPath);
+    fs.symlinkSync(externalCopy, artifactPath);
+
+    const report = await verifyBundle(bundle.dir);
+    expect(report.ok).toBe(false);
+    expect(report.issues).toContainEqual({
+      path: "lanes/e2e/logs/server.log",
+      issue: "symlink",
+    });
+    // Flagged exactly once (verify loop), not duplicated by the sweep.
+    expect(
+      report.issues.filter((i) => i.path === "lanes/e2e/logs/server.log"),
+    ).toHaveLength(1);
+  });
+
+  it("still reports a plain unlisted regular file as unlisted (control)", async () => {
+    const bundle = await buildSampleBundle(tmpDir(), tmpDir());
+    await bundle.finalize();
+    fs.writeFileSync(path.join(bundle.dir, "plain-stray.txt"), "stray");
+    const report = await verifyBundle(bundle.dir);
+    expect(report.issues).toContainEqual({
+      path: "plain-stray.txt",
+      issue: "unlisted",
+    });
+    expect(report.issues.some((i) => i.issue === "symlink")).toBe(false);
   });
 });

--- a/packages/evidence/src/bundle.ts
+++ b/packages/evidence/src/bundle.ts
@@ -16,6 +16,14 @@
  *   html-tree  → html-trees/<rel>           log  → lanes/<lane>/logs/<rel> (lane-less: misc)
  *   report     → lanes/<lane>/<rel> (lane-less: misc)
  *   analysis | qa | other → misc/<source>/<rel>
+ *
+ * Integrity invariants: bundle paths are NFC-normalized at ingress (macOS NFD
+ * vs linux NFC must not change manifest bytes for the same logical name);
+ * `manifest.metaSha256` binds the meta.json bytes into the signed envelope
+ * (forged provenance fails verification); and a verified bundle contains no
+ * symlinks anywhere — `verifyBundle` lstat-classifies so a symlinked artifact
+ * (mutable after signing) or a symlinked directory (mounting an unswept
+ * external tree) is reported, never silently followed.
  */
 
 import { createHash } from "node:crypto";
@@ -83,7 +91,13 @@ export interface FinalizeResult {
 /** One integrity problem found by {@link verifyBundle}. */
 export interface VerifyIssue {
   path: string;
-  issue: "missing" | "size-mismatch" | "hash-mismatch" | "unlisted";
+  issue:
+    | "missing"
+    | "size-mismatch"
+    | "hash-mismatch"
+    | "unlisted"
+    | "symlink"
+    | "meta-mismatch";
   expected?: string;
   actual?: string;
 }
@@ -144,8 +158,10 @@ function materialize(
   try {
     link(sourcePath, destPath);
   } catch (error) {
-    // error-policy:J4 EXDEV means the silo lives on a different volume than the
-    // bundle; copying is the designed fallback. Every other failure rethrows.
+    // Not error suppression: EXDEV (silo on a different volume than the
+    // bundle) is an expected condition that selects the copy strategy — the
+    // artifact is still fully materialized and hashed, nothing is lost or
+    // defaulted. Every other failure rethrows untouched.
     if ((error as NodeJS.ErrnoException).code !== "EXDEV") {
       throw error;
     }
@@ -267,7 +283,11 @@ export class EvidenceBundle {
       });
     }
     const rel = options.relativePath ?? path.basename(filePath);
-    const bundlePath = options.bundlePath ?? familyPath(options, rel);
+    // NFC-normalize at ingress: macOS reports NFD filenames, linux NFC; the
+    // same logical name must produce identical manifest bytes on both.
+    const bundlePath = (
+      options.bundlePath ?? familyPath(options, rel)
+    ).normalize("NFC");
     if (!isBundleRelativePath(bundlePath)) {
       throw new EvidenceError(
         `artifact bundle path is not bundle-relative posix: ${bundlePath}`,
@@ -312,12 +332,6 @@ export class EvidenceBundle {
       a.path < b.path ? -1 : a.path > b.path ? 1 : 0,
     );
     const finishedAt = this.now().toISOString();
-    const manifest: BundleManifest = {
-      schema: 1,
-      runId: this.runId,
-      createdAt: finishedAt,
-      artifacts,
-    };
     const meta: BundleMeta = {
       schema: 1,
       runId: this.runId,
@@ -330,11 +344,21 @@ export class EvidenceBundle {
       envFingerprint: this.provenance.envFingerprint,
       ...(options.timings !== undefined ? { timings: options.timings } : {}),
     };
+    // Order matters: meta bytes are written and hashed BEFORE the manifest is
+    // built, so `metaSha256` binds provenance into the signed envelope.
+    const metaBytes = canonicalJsonBytes(meta);
+    const metaPath = path.join(this.dir, "meta.json");
+    fs.writeFileSync(metaPath, metaBytes);
+    const manifest: BundleManifest = {
+      schema: 1,
+      runId: this.runId,
+      createdAt: finishedAt,
+      metaSha256: createHash("sha256").update(metaBytes).digest("hex"),
+      artifacts,
+    };
     const manifestBytes = canonicalJsonBytes(manifest);
     const manifestPath = path.join(this.dir, "manifest.json");
-    const metaPath = path.join(this.dir, "meta.json");
     fs.writeFileSync(manifestPath, manifestBytes);
-    fs.writeFileSync(metaPath, canonicalJsonBytes(meta));
     return {
       manifest,
       meta,
@@ -350,14 +374,22 @@ export function createBundle(options: CreateBundleOptions): EvidenceBundle {
   return new EvidenceBundle(options);
 }
 
-function* walkFiles(root: string, relBase = ""): Generator<string> {
+// lstat-based classification: symlinks (file or directory targets) are yielded
+// as their own kind and never followed — following one would let a bundle
+// reference mutable-after-signing external bytes or mount an unswept tree.
+function* walkEntries(
+  root: string,
+  relBase = "",
+): Generator<{ rel: string; kind: "file" | "symlink" }> {
   const entries = fs.readdirSync(root, { withFileTypes: true });
   for (const entry of entries) {
     const rel = relBase === "" ? entry.name : `${relBase}/${entry.name}`;
-    if (entry.isDirectory()) {
-      yield* walkFiles(path.join(root, entry.name), rel);
+    if (entry.isSymbolicLink()) {
+      yield { rel, kind: "symlink" };
+    } else if (entry.isDirectory()) {
+      yield* walkEntries(path.join(root, entry.name), rel);
     } else if (entry.isFile()) {
-      yield rel;
+      yield { rel, kind: "file" };
     }
   }
 }
@@ -399,15 +431,28 @@ export async function verifyBundle(dir: string): Promise<VerifyReport> {
   const manifest = parseManifest(parsed, manifestPath);
 
   const issues: VerifyIssue[] = [];
+  const symlinkFlagged = new Set<string>();
   let verifiedCount = 0;
   for (const artifact of manifest.artifacts) {
     const artifactPath = path.join(dir, ...artifact.path.split("/"));
     let stat: fs.Stats;
     try {
-      stat = fs.statSync(artifactPath);
+      // lstat, not stat: a listed artifact replaced by a symlink to an
+      // external file with matching bytes must fail, not verify green.
+      stat = fs.lstatSync(artifactPath);
     } catch {
-      // error-policy:J3 a listed-but-absent artifact is exactly what this
-      // report exists to surface; recorded as an issue, not swallowed.
+      // error-policy:J1 boundary translation — verify IS the integrity
+      // boundary; a listed-but-absent artifact becomes a structured
+      // "missing" finding in the report, never a swallowed failure.
+      issues.push({ path: artifact.path, issue: "missing" });
+      continue;
+    }
+    if (stat.isSymbolicLink()) {
+      issues.push({ path: artifact.path, issue: "symlink" });
+      symlinkFlagged.add(artifact.path);
+      continue;
+    }
+    if (!stat.isFile()) {
       issues.push({ path: artifact.path, issue: "missing" });
       continue;
     }
@@ -433,11 +478,44 @@ export async function verifyBundle(dir: string): Promise<VerifyReport> {
     verifiedCount += 1;
   }
 
+  // Bind provenance: meta.json bytes must hash to manifest.metaSha256.
+  const metaPath = path.join(dir, "meta.json");
+  let metaBytes: Buffer | undefined;
+  try {
+    metaBytes = fs.readFileSync(metaPath);
+  } catch {
+    // error-policy:J1 boundary translation — absent provenance is a
+    // structured "meta-mismatch" finding, part of the integrity report.
+    issues.push({
+      path: "meta.json",
+      issue: "meta-mismatch",
+      expected: manifest.metaSha256,
+      actual: "missing",
+    });
+  }
+  if (metaBytes !== undefined) {
+    const metaSha256 = createHash("sha256").update(metaBytes).digest("hex");
+    if (metaSha256 !== manifest.metaSha256) {
+      issues.push({
+        path: "meta.json",
+        issue: "meta-mismatch",
+        expected: manifest.metaSha256,
+        actual: metaSha256,
+      });
+    }
+  }
+
   const listed = new Set(manifest.artifacts.map((artifact) => artifact.path));
-  for (const rel of walkFiles(dir)) {
-    if (ENVELOPE_FILES.has(rel)) continue;
-    if (!listed.has(rel)) {
-      issues.push({ path: rel, issue: "unlisted" });
+  for (const entry of walkEntries(dir)) {
+    if (entry.kind === "symlink") {
+      if (!symlinkFlagged.has(entry.rel)) {
+        issues.push({ path: entry.rel, issue: "symlink" });
+      }
+      continue;
+    }
+    if (ENVELOPE_FILES.has(entry.rel)) continue;
+    if (!listed.has(entry.rel)) {
+      issues.push({ path: entry.rel, issue: "unlisted" });
     }
   }
 

--- a/packages/evidence/src/canonical.test.ts
+++ b/packages/evidence/src/canonical.test.ts
@@ -43,6 +43,31 @@ describe("canonicalJson", () => {
       expect((error as EvidenceError).code).toBe("CANONICAL_UNSERIALIZABLE");
     }
   });
+
+  // On a signing surface a Date/Map/Set/class instance silently serializing
+  // as "{}" would be silent data loss; toJSON is deliberately not honored.
+  it.each([
+    ["Date", new Date(0)],
+    ["Map", new Map([["a", 1]])],
+    ["Set", new Set([1])],
+    ["class instance", new (class Payload {})()],
+    ["nested non-plain object", { outer: new Date(0) }],
+  ])("throws CANONICAL_UNSERIALIZABLE for non-plain object %s", (_label, value) => {
+    try {
+      canonicalJson(value);
+      expect.unreachable("should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(EvidenceError);
+      expect((error as EvidenceError).code).toBe("CANONICAL_UNSERIALIZABLE");
+    }
+  });
+
+  it("accepts plain objects and null-prototype objects", () => {
+    expect(canonicalJson({ a: 1 })).toBe('{"a":1}');
+    const nullProto = Object.create(null) as Record<string, unknown>;
+    nullProto.a = 1;
+    expect(canonicalJson(nullProto)).toBe('{"a":1}');
+  });
 });
 
 describe("canonicalJsonBytes", () => {

--- a/packages/evidence/src/canonical.ts
+++ b/packages/evidence/src/canonical.ts
@@ -4,9 +4,14 @@
  * value: object keys sorted by UTF-16 code unit, arrays in caller order, no
  * insignificant whitespace, UTF-8 encoding, and exactly one trailing newline
  * (the newline is part of the signed bytes). Values JSON cannot represent
- * deterministically (non-finite numbers, bigint, functions, symbols) throw
- * instead of degrading to `null` — a fabricated `null` in a signed manifest
- * would be silent data loss.
+ * deterministically throw instead of degrading — non-finite numbers, bigint,
+ * functions, symbols, AND any object whose prototype is not `Object.prototype`
+ * or `null` (Date/Map/Set/class instances would silently serialize as `{}`,
+ * and `toJSON` is deliberately not honored: strictness beats convenience on a
+ * signing surface; callers pre-serialize to plain data). JCS-style caveat: no
+ * general string normalization is performed here — only artifact *paths* are
+ * NFC-normalized, at ingress in `bundle.ts` addArtifact, so macOS NFD vs
+ * linux NFC filenames cannot yield different manifest bytes.
  */
 
 import { EvidenceError } from "./errors.ts";
@@ -38,6 +43,16 @@ function canonicalize(value: unknown, path: string): string {
           return canonicalize(item, `${path}[${index}]`);
         });
         return `[${items.join(",")}]`;
+      }
+      const proto = Object.getPrototypeOf(value);
+      if (proto !== Object.prototype && proto !== null) {
+        throw new EvidenceError(
+          `canonical JSON cannot represent a non-plain object at ${path}`,
+          {
+            code: "CANONICAL_UNSERIALIZABLE",
+            context: { path, constructor: proto?.constructor?.name },
+          },
+        );
       }
       const record = value as Record<string, unknown>;
       const keys = Object.keys(record)

--- a/packages/evidence/src/schema.test.ts
+++ b/packages/evidence/src/schema.test.ts
@@ -38,6 +38,7 @@ function validManifest(
     schema: 1,
     runId: "20260705-120000-abcdef0-cpu",
     createdAt: "2026-07-05T12:00:00.000Z",
+    metaSha256: "b".repeat(64),
     artifacts: [validEntry()],
     ...overrides,
   };
@@ -86,6 +87,14 @@ describe("parseManifest", () => {
     ["wrong schema version", () => ({ ...validManifest(), schema: 2 })],
     ["non-array artifacts", () => ({ ...validManifest(), artifacts: {} })],
     ["unknown top-level key", () => ({ ...validManifest(), extra: true })],
+    [
+      "missing metaSha256",
+      () => ({ ...validManifest(), metaSha256: undefined }),
+    ],
+    [
+      "non-hex metaSha256",
+      () => ({ ...validManifest(), metaSha256: "Z".repeat(64) }),
+    ],
   ])("rejects a manifest with %s", (_label, make) => {
     expect(() =>
       parseManifest(JSON.parse(JSON.stringify(make())), "test"),

--- a/packages/evidence/src/schema.ts
+++ b/packages/evidence/src/schema.ts
@@ -58,6 +58,11 @@ export interface BundleManifest {
   schema: 1;
   runId: string;
   createdAt: string;
+  /**
+   * sha256 of the `meta.json` bytes, binding provenance into the signed
+   * envelope — a forged commit/branch/runner in meta.json fails verification.
+   */
+  metaSha256: string;
   artifacts: ArtifactEntry[];
 }
 
@@ -120,6 +125,7 @@ const bundleManifestSchema = z
     schema: z.literal(1),
     runId: z.string().min(1),
     createdAt: isoTimestamp,
+    metaSha256: sha256Hex,
     artifacts: z.array(artifactEntrySchema),
   })
   .superRefine((manifest, ctx) => {


### PR DESCRIPTION
Follow-up to #14589, which was squash-merged before the fable-review hardening commit landed on the branch. This PR delivers exactly that delta (c902a6a5fe6):

- **verifyBundle is now symlink-aware** (lstat-based walk + per-artifact lstat): unlisted symlinks, directory symlinks, and listed-artifact-replaced-by-symlink all fail verification with a distinct `symlink` issue. Closes a proven integrity gap where certified bundles could reference mutable bytes outside the bundle.
- **meta.json bound into the signed envelope**: `BundleManifest.metaSha256` (required); `finalize()` hashes meta bytes into the manifest before manifest hashing; `verifyBundle` reports `meta-mismatch` on forged/missing provenance.
- **canonicalJson strictness**: throws `CANONICAL_UNSERIALIZABLE` on Date/Map/Set/class instances instead of silently serializing `{}` — signing surface rejects lossy input.
- **NFC path normalization** at addArtifact ingress (macOS NFD vs linux NFC byte-drift).
- 16 new tests (97 total in the package): four symlink tamper scenarios + control, meta forge/missing, canonical rejections, NFC.

The three stacked wave-1 PRs (#14609, #14610, #14611) already contain these file versions; merging this first shrinks their diffs to their own additions.

Evidence: full package test output and the real-bundle tamper transcripts are in the #14589 PR-body hardening section (produced on this exact commit). Backend-only library — UI/video/trajectory rows N/A.

Part of #14552 / epic #14541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)