### PR TITLE
fix(app): one deploy ledger + one bundle framework for the physical-iPhone lane

### DIFF
--- a/packages/app/scripts/devices-status.mjs
+++ b/packages/app/scripts/devices-status.mjs
@@ -6,8 +6,6 @@
  * before a runner starts.
  */
 import { execFileSync, spawnSync } from "node:child_process";
-import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { readDevicectlDeviceList } from "./ios-device-devicectl.mjs";
@@ -25,6 +23,10 @@ import {
   hasNonFreshDevice,
 } from "./lib/devices-status.mjs";
 import {
+  readDeployLedger,
+  resolveDeployLedgerPath,
+} from "./lib/ios-deploy-ledger.mjs";
+import {
   readRendererManifest,
   rendererManifestPathFromAppPath,
 } from "./lib/ios-renderer-stamp.mjs";
@@ -32,7 +34,6 @@ import {
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const appRoot = path.resolve(scriptDir, "..");
 const repoRoot = path.resolve(appRoot, "..", "..");
-export const IOS_DEVICE_DEPLOY_LEDGER = "ios-device-deploy-ledger.jsonl";
 
 function hasArg(name) {
   return process.argv.includes(name);
@@ -48,42 +49,6 @@ function runText(command, args, options = {}) {
   } catch {
     return null;
   }
-}
-
-export function devicesStatusStateDir(env = process.env) {
-  return path.resolve(
-    env.ELIZA_DEVICES_STATUS_DIR?.trim() ||
-      env.ELIZA_STATE_DIR?.trim() ||
-      path.join(os.homedir(), ".local", "state", "eliza"),
-  );
-}
-
-export function devicesStatusLedgerPath(env = process.env) {
-  return path.join(devicesStatusStateDir(env), IOS_DEVICE_DEPLOY_LEDGER);
-}
-
-export function appendIosDeviceDeployLedger(entry, env = process.env) {
-  const ledgerPath = devicesStatusLedgerPath(env);
-  fs.mkdirSync(path.dirname(ledgerPath), { recursive: true });
-  fs.appendFileSync(ledgerPath, `${JSON.stringify(entry)}\n`);
-  return ledgerPath;
-}
-
-function readIosDeviceDeployLedger(env = process.env) {
-  const ledgerPath = devicesStatusLedgerPath(env);
-  if (!fs.existsSync(ledgerPath)) return [];
-  return fs
-    .readFileSync(ledgerPath, "utf8")
-    .split(/\r?\n/)
-    .filter(Boolean)
-    .map((line) => {
-      try {
-        return JSON.parse(line);
-      } catch {
-        return null;
-      }
-    })
-    .filter(Boolean);
 }
 
 function latestLedgerEntryForDevice(device, entries) {
@@ -230,15 +195,11 @@ function iosPhysicalRows(developHead) {
       }),
     ];
   }
-  const ledger = readIosDeviceDeployLedger();
+  const ledger = readDeployLedger(resolveDeployLedgerPath());
   return physicalIosDevices().map((device) => {
     const entry = latestLedgerEntryForDevice(device, ledger);
     const stamp = entry
-      ? {
-          buildId: entry.buildId,
-          commit: entry.commit,
-          builtAt: entry.builtAt,
-        }
+      ? { buildId: entry.buildId, commit: entry.commit }
       : null;
     return buildDeviceStatusRow({
       platform: "ios-device",

--- a/packages/app/scripts/ios-device-e2e.mjs
+++ b/packages/app/scripts/ios-device-e2e.mjs
@@ -5,7 +5,7 @@
  * boot-trace, and collapse everything into one run-scoped triage bundle whose
  * absolute path is printed as the last line (issue #14337).
  *
- * Chains three already-proven scripts through the pure step-runner in
+ * Chains three already-proven scripts through the argv builders in
  * `lib/ios-device-e2e-lib.mjs`:
  *   1. ios-device-deploy.mjs  --skip-appexes  (build → sign → devicectl install;
  *      appex surfaces excluded — logged loudly by the deploy script). The deploy
@@ -18,10 +18,14 @@
  *   3. ios-device-logs.mjs --no-console --pull-boot-trace  (full-Bun engine
  *      observability; attached --console SIGTRAPs the no-JIT engine, #11515).
  *
- * Every step's exit is loud: a non-zero child fails the lane non-zero. The bundle
- * (research doc 08 Q2/Q3 shape: smoke/ logs/ summary.json) is written under a
- * gitignored run-scoped dir and its path is the final stdout line so an agent
- * can post the smoke filmstrip + boot-trace to a PR.
+ * Run assembly — per-step timing, artifact collection, PNG→JPG / MOV→MP4 inline
+ * conversion, junit, and the machine-readable `summary.json` — goes through the
+ * shared `lib/device-e2e-bundle.mjs` framework, the same one `android-e2e.mjs`
+ * and `ios-e2e.mjs` use, so all three device lanes emit one summary shape
+ * (PR #14509 reconciliation). Every step's exit is loud: a non-zero child fails
+ * the lane non-zero and the partial bundle is still finalized. The bundle's
+ * absolute path is the final stdout line so an agent can post the smoke/
+ * filmstrip + logs/ boot-trace inline to the PR.
  *
  * Device id: --device flag or ELIZA_IOS_DEVICE_ID.
  *
@@ -30,7 +34,6 @@
  *     [--no-skip-appexes] [--skip-logs] [--require-chat]
  *     [--bundle-id <id>] [--output <dir>]
  */
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -41,12 +44,19 @@ import {
   resolveDeviceId,
 } from "./ios-device-lib.mjs";
 import {
+  captureFailureForensics,
+  collectBundleArtifacts,
+  createDeviceE2eBundle,
+  finalizeDeviceE2eBundle,
+  formatFailureForensicsBlock,
+  runBundledCommand,
+  setBundleBuild,
+  setBundleDevice,
+} from "./lib/device-e2e-bundle.mjs";
+import {
   buildDeviceDeployCommand,
   buildDeviceLogsCommand,
   buildDeviceSmokeCommand,
-  buildRunSummary,
-  classifyStepStatus,
-  formatRunId,
   planIosDeviceE2eSteps,
 } from "./lib/ios-device-e2e-lib.mjs";
 import {
@@ -64,14 +74,20 @@ const fail = (message) => {
   process.exit(1);
 };
 
-function runStep(step, { cmd, args }) {
-  log(`${step.id}: ${step.label}`);
-  log(`  $ ${cmd} ${args.join(" ")}`);
-  const startedAt = Date.now();
-  const result = spawnSync(cmd, args, { cwd: appRoot, stdio: "inherit" });
-  const durationMs = Date.now() - startedAt;
-  const verdict = classifyStepStatus(result.status);
-  return { verdict, durationMs, status: result.status };
+// Failure forensics for a chained-child step: the child script already wrote its
+// own artifacts into smoke/ or logs/; this records the cause so the triage
+// bundle names why the lane stopped.
+function captureDeviceFailure(bundle, step, error) {
+  return captureFailureForensics(
+    bundle,
+    step,
+    ({ failureDir }) => {
+      const causePath = path.join(failureDir, "failure-cause.txt");
+      fs.writeFileSync(causePath, `${error?.message ?? error}\n`);
+      return [causePath];
+    },
+    error,
+  );
 }
 
 async function main() {
@@ -115,117 +131,117 @@ async function main() {
   const skipAppexes = !args["no-skip-appexes"];
   const bundleId = args["bundle-id"] || null;
 
-  const runId = formatRunId();
-  const startedAtIso = new Date().toISOString();
-  const bundleDir = path.resolve(
-    args.output || path.join(appRoot, "device-e2e-output", `ios-${runId}`),
-  );
-  const smokeDir = path.join(bundleDir, "smoke");
-  const logsDir = path.join(bundleDir, "logs");
-  for (const dir of [bundleDir, smokeDir, logsDir]) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
+  const bundle = createDeviceE2eBundle({
+    appDir: appRoot,
+    lane: "ios-device",
+    outputDir: args.output,
+  });
+  setBundleDevice(bundle, {
+    udid: device.udid,
+    identifier: device.identifier,
+    name: device.name,
+    kind: "ios-device",
+  });
+  // skippedAppexes is run configuration that scopes what the build proves; carry
+  // it on the build metadata (buildId/commit are filled in after the deploy).
+  setBundleBuild(bundle, { skippedAppexes: skipAppexes });
+
+  // BootCapture attachments land in smoke/ (per-#14337 bundle layout); the shared
+  // finalize collects logs/ + raw/ + reports/, so smoke/ is collected explicitly.
+  const smokeDir = path.join(bundle.root, "smoke");
+  fs.mkdirSync(smokeDir, { recursive: true });
 
   const steps = planIosDeviceE2eSteps({
     skipLogs: Boolean(args["skip-logs"]),
   });
   log(`plan: ${steps.map((s) => s.id).join(" → ")}`);
-  log(`bundle: ${bundleDir}`);
+  log(`bundle: ${bundle.root}`);
 
   const commandFor = (step) => {
     switch (step.id) {
       case "deploy":
-        return {
-          command: buildDeviceDeployCommand({
-            scriptsDir,
-            deviceId,
-            skipAppexes,
-            bundleId,
-          }),
-          artifacts: [],
-        };
+        return buildDeviceDeployCommand({
+          scriptsDir,
+          deviceId,
+          skipAppexes,
+          bundleId,
+        });
       case "smoke":
-        return {
-          command: buildDeviceSmokeCommand({
-            scriptsDir,
-            deviceId,
-            outputDir: smokeDir,
-            requireChat: Boolean(args["require-chat"]),
-            bundleId,
-          }),
-          artifacts: [smokeDir],
-        };
+        return buildDeviceSmokeCommand({
+          scriptsDir,
+          deviceId,
+          outputDir: smokeDir,
+          requireChat: Boolean(args["require-chat"]),
+          bundleId,
+        });
       case "logs":
-        return {
-          command: buildDeviceLogsCommand({
-            scriptsDir,
-            deviceId,
-            // ios-device-logs derives its own trace filename from
-            // path.dirname(--output), so point --output at a file inside logsDir.
-            outputFile: path.join(logsDir, "boot-trace-run"),
-            bundleId,
-          }),
-          artifacts: [logsDir],
-        };
+        return buildDeviceLogsCommand({
+          scriptsDir,
+          deviceId,
+          // ios-device-logs derives its own trace filename from
+          // path.dirname(--output), so point --output at a file inside logsDir.
+          outputFile: path.join(bundle.logsDir, "boot-trace-run"),
+          bundleId,
+        });
       default:
         throw new Error(`unknown step: ${step.id}`);
     }
   };
 
-  const recorded = [];
-  let firstFailure = null;
-  for (const step of steps) {
-    const { command, artifacts } = commandFor(step);
-    const { verdict, durationMs } = runStep(step, command);
-    recorded.push({
-      id: step.id,
-      label: step.label,
-      status: verdict.status,
-      durationMs,
-      artifacts,
-    });
-    if (!verdict.ok) {
-      firstFailure = step.id;
-      break;
-    }
-  }
-
-  // The deploy step writes the renderer stamp into the ledger; surface the
-  // buildId/commit into the summary by reading the freshly built dist stamp
-  // (the exact bundle the deploy installed). A missing stamp is not fatal to
-  // the summary — the deploy step's own assert already gated on it — so this is
-  // best-effort metadata, recorded as null when unreadable.
-  let build = { buildId: null, commit: null };
+  let finalResult = "failed";
+  let finalError = null;
   try {
-    const fresh = readRendererManifest(
-      freshRendererManifestPath({ repoRoot }),
-      "freshly built",
-    );
-    build = { buildId: fresh.buildId, commit: fresh.commit };
+    for (const step of steps) {
+      const { cmd, args: cmdArgs } = commandFor(step);
+      runBundledCommand(bundle, step.label, cmd, cmdArgs, {
+        cwd: appRoot,
+        onFailure: (bundleStep, error) =>
+          captureDeviceFailure(bundle, bundleStep, error),
+      });
+      if (step.id === "deploy") {
+        // The deploy step installs the freshly built bundle; surface its
+        // buildId/commit into the summary by reading the fresh dist stamp (the
+        // exact bundle the deploy installed). The deploy already asserted
+        // renderer freshness, so this is informational metadata only.
+        try {
+          const fresh = readRendererManifest(
+            freshRendererManifestPath({ repoRoot }),
+            "freshly built",
+          );
+          setBundleBuild(bundle, {
+            buildId: fresh.buildId,
+            commit: fresh.commit,
+          });
+        } catch (error) {
+          // error-policy:J7 diagnostics-must-not-kill-the-loop — the summary's
+          // build metadata is informational; the deploy already asserted
+          // freshness. Warn and leave it null rather than failing a good run.
+          bundle.warnings.push(
+            `summary build metadata unavailable: ${error?.message ?? error}`,
+          );
+          log(`summary build metadata unavailable: ${error?.message ?? error}`);
+        }
+      }
+    }
+    finalResult = "passed";
   } catch (error) {
-    // error-policy:J7 diagnostics-must-not-kill-the-loop — the summary's build
-    // metadata is informational; the deploy already asserted freshness. Warn
-    // and record null rather than failing an otherwise-complete run.
-    log(`summary build metadata unavailable: ${error?.message ?? error}`);
+    // runBundledCommand already recorded the step as failed and ran the failure
+    // forensics; this stops the chain at the first failing step.
+    finalError = error;
   }
 
-  const summary = buildRunSummary({
-    runId,
-    startedAt: startedAtIso,
-    finishedAt: new Date().toISOString(),
-    bundleDir,
-    device,
-    build,
-    skippedAppexes: skipAppexes,
-    steps: recorded,
-  });
-  const summaryPath = path.join(bundleDir, "summary.json");
-  fs.writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+  collectBundleArtifacts(bundle, [smokeDir]);
+  const bundleRoot = finalizeDeviceE2eBundle(bundle, finalResult);
 
-  if (firstFailure) {
-    log(`FAILED at step "${firstFailure}". Bundle (partial) written.`);
-    // The bundle path is the machine-readable handoff even on failure.
-    console.log(bundleDir);
+  if (finalError) {
+    log(
+      `FAILED: ${finalError.message ?? finalError}. Bundle (partial) written.`,
+    );
+    const block = formatFailureForensicsBlock(bundle, finalError);
+    if (block) process.stderr.write(`\n${block}`);
+    // Last line: the absolute bundle path — the machine-readable handoff even on
+    // failure (contract with #14337).
+    console.log(bundleRoot);
     process.exit(1);
   }
 
@@ -234,7 +250,7 @@ async function main() {
   );
   // Last line: the absolute bundle path (contract with #14337 — agents post the
   // smoke/ filmstrip + logs/ boot-trace inline to the PR).
-  console.log(bundleDir);
+  console.log(bundleRoot);
 }
 
 main().catch((error) => fail(error?.stack ?? String(error)));

--- a/packages/app/scripts/lib/ios-deploy-ledger.mjs
+++ b/packages/app/scripts/lib/ios-deploy-ledger.mjs
@@ -13,6 +13,13 @@
  * guessing (a phone flashed by other means was never recorded here). The
  * boot-trace pull remains the ground-truth cross-check.
  *
+ * This module is the single owner of the ledger's filename, its state-dir
+ * resolution, its schema, and its read/write path — `devices-status.mjs` (the
+ * reader) and `ios-device-deploy.mjs` (the writer) both go through it, so there
+ * is exactly one canonical file for the two ends to agree on (a prior split —
+ * two filenames + two resolvers — made every deployed phone read back as
+ * "unknown, no ledger entry"; issues #14337/#14335, PR #14509 reconciliation).
+ *
  * Everything here is pure or takes the filesystem edge as the JSONL path, so the
  * append/read/latest-per-device logic is unit-tested against fixtures without a
  * device. The renderer stamp itself — path resolution and typed read — lives in
@@ -28,12 +35,19 @@ import os from "node:os";
 import path from "node:path";
 
 /**
- * Resolve the per-user state dir for the ledger, honoring the documented
- * branded-first precedence (`MILADY_STATE_DIR` > `ELIZA_STATE_DIR` >
- * `$XDG_STATE_HOME/<namespace>` > `~/.local/state/<namespace>`). Mirrors
- * `packages/core/src/utils/state-dir.ts` — that module is TypeScript and cannot
- * be imported from a plain build script, so the precedence is reproduced here.
- * Kept in lockstep: any change to the canonical resolver must land here too.
+ * Resolve the per-user state dir for the ledger. Precedence, highest first:
+ *   1. `ELIZA_DEVICES_STATUS_DIR` — the device-status lane's explicit override
+ *      (the reader honored this before consolidation; kept so a caller can pin
+ *      both ends of the ledger at one dir for a test or a scoped run).
+ *   2. `MILADY_STATE_DIR` — the repo-wide branded state prefix
+ *      (`packages/core/src/utils/state-dir.ts` and every alias-aware reader
+ *      honor it first; the device deploy lane inherits it).
+ *   3. `ELIZA_STATE_DIR` — the unbranded state override.
+ *   4. `$XDG_STATE_HOME/<namespace>` — XDG base-dir, absolute or home-relative.
+ *   5. `~/.local/state/<namespace>` — the default.
+ * This is the superset of the two resolvers that previously disagreed; the
+ * canonical TypeScript resolver cannot be imported from a plain build script, so
+ * the branded/XDG precedence is reproduced here and kept in lockstep with it.
  *
  * @param {{ env?: Record<string, string | undefined>, homedir?: () => string }} [options]
  * @returns {string}
@@ -42,7 +56,11 @@ export function resolveLedgerStateDir({
   env = process.env,
   homedir = os.homedir,
 } = {}) {
-  const explicit = (env.MILADY_STATE_DIR ?? env.ELIZA_STATE_DIR)?.trim();
+  const explicit = (
+    env.ELIZA_DEVICES_STATUS_DIR ??
+    env.MILADY_STATE_DIR ??
+    env.ELIZA_STATE_DIR
+  )?.trim();
   if (explicit) return path.resolve(explicit);
   const namespace = env.ELIZA_NAMESPACE?.trim() || "eliza";
   const xdg = env.XDG_STATE_HOME?.trim();
@@ -55,6 +73,13 @@ export function resolveLedgerStateDir({
 }
 
 /**
+ * Basename of the deploy-ledger JSONL. `devices:status` reads this exact file, so
+ * the writer must produce it under the same name — one canonical file, no
+ * per-name split (issues #14337/#14335).
+ */
+export const DEPLOY_LEDGER_FILENAME = "ios-device-deploy-ledger.jsonl";
+
+/**
  * Absolute path to the deploy-ledger JSONL. One file for all devices; each line
  * is a self-contained deploy record (see {@link appendDeployRecord}).
  *
@@ -62,10 +87,7 @@ export function resolveLedgerStateDir({
  * @returns {string}
  */
 export function resolveDeployLedgerPath(options = {}) {
-  return path.join(
-    resolveLedgerStateDir(options),
-    "device-deploy-ledger.jsonl",
-  );
+  return path.join(resolveLedgerStateDir(options), DEPLOY_LEDGER_FILENAME);
 }
 
 export const DEPLOY_LEDGER_SCHEMA = "elizaos.device.deploy-ledger/v1";

--- a/packages/app/scripts/lib/ios-deploy-ledger.test.mjs
+++ b/packages/app/scripts/lib/ios-deploy-ledger.test.mjs
@@ -38,6 +38,18 @@ afterEach(() => {
 
 describe("resolveLedgerStateDir precedence", () => {
   const home = () => "/home/tester";
+  it("prefers ELIZA_DEVICES_STATUS_DIR over every other source", () => {
+    expect(
+      resolveLedgerStateDir({
+        env: {
+          ELIZA_DEVICES_STATUS_DIR: "/d/state",
+          MILADY_STATE_DIR: "/m/state",
+          ELIZA_STATE_DIR: "/e/state",
+        },
+        homedir: home,
+      }),
+    ).toBe("/d/state");
+  });
   it("prefers MILADY_STATE_DIR over ELIZA_STATE_DIR", () => {
     expect(
       resolveLedgerStateDir({
@@ -67,13 +79,13 @@ describe("resolveLedgerStateDir precedence", () => {
       path.join("/home/tester", ".local", "state", "eliza"),
     );
   });
-  it("resolveDeployLedgerPath appends the ledger filename", () => {
+  it("resolveDeployLedgerPath appends the canonical ledger filename", () => {
     expect(
       resolveDeployLedgerPath({
         env: { ELIZA_STATE_DIR: "/e/state" },
         homedir: home,
       }),
-    ).toBe(path.join("/e/state", "device-deploy-ledger.jsonl"));
+    ).toBe(path.join("/e/state", "ios-device-deploy-ledger.jsonl"));
   });
 });
 

--- a/packages/app/scripts/lib/ios-device-e2e-lib.mjs
+++ b/packages/app/scripts/lib/ios-device-e2e-lib.mjs
@@ -1,13 +1,15 @@
 /**
- * Pure step-sequencing and command-argument construction for the one-command
- * physical-iPhone e2e lane (`ios-device-e2e.mjs`, issue #14337), plus the
- * run-scoped triage-bundle summary shape.
+ * Pure step-planning and command-argument construction for the one-command
+ * physical-iPhone e2e lane (`ios-device-e2e.mjs`, issue #14337).
  *
  * The lane chains three already-proven scripts — deploy → on-device BootCapture
- * assertion → boot-trace logs — into one command. This module owns the
- * deterministic decisions (which steps run, exactly which argv each gets, how a
- * step's exit becomes a verdict, what the summary.json looks like); the script
- * owns the impure edges (spawning node, reading files, writing the bundle).
+ * assertion → boot-trace logs — into one command. This module owns only the
+ * decisions unique to the physical-device lane: which steps run and the exact
+ * argv each chained child gets. Run assembly and reporting (step timing, the
+ * triage bundle, `summary.json`, artifact collection, inline conversion, junit)
+ * are the shared `lib/device-e2e-bundle.mjs` framework's job — the same one
+ * `android-e2e.mjs` and `ios-e2e.mjs` use — so all three lanes emit one
+ * summary shape (PR #14509 reconciliation onto the sibling bundle lib #14336).
  * Keeping the argv construction here means the exact flags the lane hands each
  * child are unit-tested against fixtures without a device.
  *
@@ -19,14 +21,6 @@
  * so that one on-device boot yields both the pass/fail verdict and the watchable
  * filmstrip — there is no separate capture boot (a second identical BootCapture
  * run would only re-boot the phone to produce bytes the smoke step already has).
- *
- * Bundle shape mirrors research doc 08 Q2/Q3: a gitignored run-scoped dir with
- * `smoke/` (the BootCapture MP4/JPG the assertion produced), `logs/`, and a
- * JSON-canonical `summary.json` carrying lane, device identity, installed
- * buildId/commit, and per-step status/duration/artifact paths. The device-e2e
- * bundle library (`lib/device-e2e-bundle.mjs`) is owned by a sibling PR
- * (#14336); this lane ships a minimal local emitter matching that documented
- * shape and is reconciled onto the shared lib when it lands.
  */
 import path from "node:path";
 
@@ -170,86 +164,4 @@ export function buildDeviceLogsCommand({
   ];
   if (bundleId) args.push("--bundle-id", bundleId);
   return { cmd: "node", args };
-}
-
-/**
- * Classify a step's process exit into a bundle verdict. A null status is a
- * spawn that never produced an exit code (the child could not be launched) —
- * treated as failure, never as success. Only exit 0 passes.
- *
- * @param {number | null} status
- * @returns {{ status: 'passed' | 'failed', ok: boolean }}
- */
-export function classifyStepStatus(status) {
-  const ok = status === 0;
-  return { status: ok ? "passed" : "failed", ok };
-}
-
-export const IOS_DEVICE_E2E_SUMMARY_SCHEMA = "elizaos.device-e2e.summary/v1";
-
-/**
- * Assemble the run-scoped `summary.json` (JSON-canonical machine-readable
- * artifact, research doc Q3). `steps` are the recorded per-step results;
- * `overallStatus` is `passed` iff every executed step passed. The `bundleDir`
- * is echoed so a consumer that only has the summary can locate the artifacts.
- *
- * @param {{
- *   runId: string,
- *   startedAt: string,
- *   finishedAt: string,
- *   bundleDir: string,
- *   device: { udid: string | null, identifier: string | null, name: string | null },
- *   build: { buildId: string | null, commit: string | null },
- *   skippedAppexes: boolean,
- *   steps: Array<{ id: string, label: string, status: 'passed' | 'failed',
- *                  durationMs: number, artifacts: string[] }>,
- * }} input
- * @returns {Record<string, unknown>}
- */
-export function buildRunSummary(input) {
-  if (!input?.runId) throw new Error("buildRunSummary: runId is required");
-  const steps = input.steps ?? [];
-  const overallStatus = steps.every((step) => step.status === "passed")
-    ? "passed"
-    : "failed";
-  return {
-    schema: IOS_DEVICE_E2E_SUMMARY_SCHEMA,
-    lane: "ios-device-e2e",
-    runId: input.runId,
-    overallStatus,
-    startedAt: input.startedAt,
-    finishedAt: input.finishedAt,
-    bundleDir: input.bundleDir,
-    device: {
-      udid: input.device?.udid ?? null,
-      identifier: input.device?.identifier ?? null,
-      name: input.device?.name ?? null,
-    },
-    build: {
-      buildId: input.build?.buildId ?? null,
-      commit: input.build?.commit ?? null,
-    },
-    skippedAppexes: input.skippedAppexes === true,
-    steps: steps.map((step) => ({
-      id: step.id,
-      label: step.label,
-      status: step.status,
-      durationMs: step.durationMs,
-      artifacts: step.artifacts ?? [],
-    })),
-  };
-}
-
-/**
- * A run id from a Date: `YYYYMMDD-HHMMSS` in UTC. Stable, sortable, filesystem
- * safe — used as the run-scoped bundle directory suffix.
- *
- * @param {Date} [now]
- * @returns {string}
- */
-export function formatRunId(now = new Date()) {
-  const iso = now.toISOString();
-  return `${iso.slice(0, 10).replaceAll("-", "")}-${iso
-    .slice(11, 19)
-    .replaceAll(":", "")}`;
 }

--- a/packages/app/scripts/lib/ios-device-e2e-lib.test.mjs
+++ b/packages/app/scripts/lib/ios-device-e2e-lib.test.mjs
@@ -1,9 +1,10 @@
 /**
- * Unit tests for the pure step-sequencing, command-argument construction, and
- * run-summary assembly behind the one-command physical-iPhone e2e lane
- * (issue #14337). Asserts the exact argv each chained script receives and the
- * summary schema, with the device calls left at the process boundary (never
- * spawned here). Runs in the packages/app vitest suite.
+ * Unit tests for the pure step-planning and command-argument construction behind
+ * the one-command physical-iPhone e2e lane (issue #14337). Asserts the exact argv
+ * each chained script receives, with the device calls left at the process
+ * boundary (never spawned here). Run assembly + summary live in the shared
+ * `device-e2e-bundle.mjs` framework (tested by its own suite). Runs in the
+ * packages/app vitest suite.
  */
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -11,9 +12,6 @@ import {
   buildDeviceDeployCommand,
   buildDeviceLogsCommand,
   buildDeviceSmokeCommand,
-  buildRunSummary,
-  classifyStepStatus,
-  formatRunId,
   IOS_DEVICE_E2E_STEP_IDS,
   planIosDeviceE2eSteps,
 } from "./ios-device-e2e-lib.mjs";
@@ -122,91 +120,6 @@ describe("buildDeviceLogsCommand", () => {
   it("throws without an output file", () => {
     expect(() => buildDeviceLogsCommand({ scriptsDir, deviceId })).toThrow(
       /outputFile is required/,
-    );
-  });
-});
-
-describe("classifyStepStatus", () => {
-  it("only exit 0 passes", () => {
-    expect(classifyStepStatus(0)).toEqual({ status: "passed", ok: true });
-    expect(classifyStepStatus(1)).toEqual({ status: "failed", ok: false });
-    // A null status (child never launched) is a failure, never a pass.
-    expect(classifyStepStatus(null)).toEqual({ status: "failed", ok: false });
-  });
-});
-
-describe("buildRunSummary", () => {
-  const base = {
-    runId: "20260101-000000",
-    startedAt: "2026-01-01T00:00:00Z",
-    finishedAt: "2026-01-01T00:05:00Z",
-    bundleDir: "/bundle/ios-20260101-000000",
-    device: { udid: "UDID-1", identifier: "ID-1", name: "iPhone 16" },
-    build: { buildId: "build-XYZ", commit: "deadbeef" },
-    skippedAppexes: true,
-  };
-
-  it("marks passed only when every step passed", () => {
-    const summary = buildRunSummary({
-      ...base,
-      steps: [
-        {
-          id: "deploy",
-          label: "d",
-          status: "passed",
-          durationMs: 10,
-          artifacts: [],
-        },
-        {
-          id: "smoke",
-          label: "s",
-          status: "passed",
-          durationMs: 20,
-          artifacts: ["/a"],
-        },
-      ],
-    });
-    expect(summary.overallStatus).toBe("passed");
-    expect(summary.schema).toBe("elizaos.device-e2e.summary/v1");
-    expect(summary.lane).toBe("ios-device-e2e");
-    expect(summary.device.udid).toBe("UDID-1");
-    expect(summary.build.buildId).toBe("build-XYZ");
-    expect(summary.skippedAppexes).toBe(true);
-    expect(summary.steps).toHaveLength(2);
-  });
-  it("marks failed when any step failed", () => {
-    const summary = buildRunSummary({
-      ...base,
-      steps: [
-        {
-          id: "deploy",
-          label: "d",
-          status: "passed",
-          durationMs: 10,
-          artifacts: [],
-        },
-        {
-          id: "smoke",
-          label: "s",
-          status: "failed",
-          durationMs: 20,
-          artifacts: [],
-        },
-      ],
-    });
-    expect(summary.overallStatus).toBe("failed");
-  });
-  it("throws without a runId", () => {
-    expect(() => buildRunSummary({ ...base, runId: "", steps: [] })).toThrow(
-      /runId is required/,
-    );
-  });
-});
-
-describe("formatRunId", () => {
-  it("produces a sortable YYYYMMDD-HHMMSS from a Date", () => {
-    expect(formatRunId(new Date("2026-07-05T13:04:09.000Z"))).toBe(
-      "20260705-130409",
     );
   });
 });


### PR DESCRIPTION
## Split-brain fix

PR #14509 landed the one-command physical-iPhone e2e lane without reconciling against two sibling PRs that merged into `develop` first — **#14493** (`devices:status`) and **#14494 / #14502** (the shared device-e2e bundle). That left two duplicated subsystems on `develop`, each with its own contract, so the two halves silently disagreed. This is the failure that issues **#14337 / #14335** built the deploy ledger to prevent.

### 1. Two deploy ledgers → every deployed iPhone read back "unknown"

- `devices-status.mjs` owned its own filename (`ios-device-deploy-ledger.jsonl`), its own state-dir resolver (`ELIZA_DEVICES_STATUS_DIR` > `ELIZA_STATE_DIR` > `~/.local/state/eliza`), and its own writer/reader.
- `lib/ios-deploy-ledger.mjs` (used by the actual writer, `ios-device-deploy.mjs`) wrote a **different** file (`device-deploy-ledger.jsonl`) with a **different** resolver (`MILADY_STATE_DIR` > `ELIZA_STATE_DIR` > `XDG_STATE_HOME` > `~/.local/state/eliza`).

Writer and reader never pointed at the same file, so `devices:status` always reported paired phones as **"unknown — no ledger entry."**

### 2. Two bundle frameworks

`ios-device-e2e.mjs` assembled its run via a parallel `runStep` / `buildRunSummary` / `formatRunId` / summary-schema emitter in `ios-device-e2e-lib.mjs`, instead of the shared `lib/device-e2e-bundle.mjs` that `android-e2e.mjs` and `ios-e2e.mjs` already use. Its `summary.json` shape diverged from the sibling lanes'. (The lib's own header even flagged this: *"reconciled onto the shared lib when it lands."*)

## What this PR does

**One ledger module.** `lib/ios-deploy-ledger.mjs` is now the single owner of filename + state-dir resolution + schema + read + write.
- One canonical file: **`ios-device-deploy-ledger.jsonl`** (what `devices:status` already reads). No legacy-file migration — the feature is a day old, single canonical file.
- One superset resolver, precedence documented in the header: `ELIZA_DEVICES_STATUS_DIR` > `MILADY_STATE_DIR` > `ELIZA_STATE_DIR` > `$XDG_STATE_HOME/<ns>` > `~/.local/state/<ns>`. `MILADY_STATE_DIR` is kept because it is the repo-wide branded state prefix honored by `packages/core/src/utils/state-dir.ts` and every alias-aware reader (grepped), and the device deploy lane already inherited it.
- `devices-status.mjs` now reads/resolves through the lib.

**One bundle framework.** `ios-device-e2e.mjs` assembles its run through `lib/device-e2e-bundle.mjs` — same `createDeviceE2eBundle` / `runBundledCommand` / `finalizeDeviceE2eBundle` path, same `summary.json` shape as `android-e2e` / `ios-e2e`. The BootCapture filmstrip still lands in `smoke/` (the #14337 bundle layout) and is collected explicitly; the boot-trace goes into the bundle's `logs/`.

### Deleted duplicates

- `devices-status.mjs`: `IOS_DEVICE_DEPLOY_LEDGER` const, `devicesStatusStateDir`, `devicesStatusLedgerPath`, `appendIosDeviceDeployLedger`, and the silent-catch `readIosDeviceDeployLedger` (the lib's `readDeployLedger` fails closed on a corrupt line instead of dropping it).
- `ios-device-e2e-lib.mjs`: `classifyStepStatus`, `IOS_DEVICE_E2E_SUMMARY_SCHEMA`, `buildRunSummary`, `formatRunId` — all superseded by the shared bundle framework. Kept the lane-unique `planIosDeviceE2eSteps` + the three argv builders.

### Kept intact

`evaluateStagedRendererFreshness` (renderer-freshness gate), `buildDeployRecord` required-field throws, and the honest no-device `exit 1` (the platform + device checks run before the bundle is created).

## Evidence

### Found-entry proof (the split-brain fix)

Ran a scratch script that writes a record exactly as `ios-device-deploy.mjs` does (`resolveDeployLedgerPath` → `buildDeployRecord` → `appendDeployRecord`) into a temp state dir, then reads it back exactly as `devices-status.mjs` does (`readDeployLedger(resolveDeployLedgerPath())` → `deployStatusForDevice`):

```
writer  resolves ledger -> /var/folders/.../ledger-proof-1se2ff/ios-device-deploy-ledger.jsonl
writer  appended record for udid 00008120-000A1B2C3D4E
reader  resolves ledger -> /var/folders/.../ledger-proof-1se2ff/ios-device-deploy-ledger.jsonl
paths identical (no split-brain): YES

--- devices:status verdict for the deployed phone ---
RESULT: FOUND ✅ (NOT 'unknown — no ledger entry')
  buildId: build-abc123def456
  commit : 97476be081aa
  name   : Shaw's iPhone 16 Pro
```

Before this PR the two `resolves ledger ->` lines pointed at different filenames and the verdict was `unknown — no ledger entry`.

`devices:status --json` also runs clean end-to-end against the consolidated reader (no paired phone on this host, so the iOS-device section is empty as expected):

```
$ ELIZA_STATE_DIR=$(mktemp -d) node packages/app/scripts/devices-status.mjs --json
[
  {
    "platform": "android",
    "id": "adb",
    "name": "adb not available",
    "kind": "n/a",
    "verdict": "UNKNOWN",
    "reason": "no installed renderer stamp",
    "source": "adb",
    "lease": null
  }
]
```

### Unit tests (every touched test file)

```
$ bunx vitest run scripts/lib/ios-deploy-ledger.test.mjs scripts/lib/ios-device-e2e-lib.test.mjs scripts/devices-status.test.mjs
 Test Files  3 passed (3)
      Tests  37 passed (37)
```

Per-file: `ios-deploy-ledger.test.mjs` 21 passed (adds an `ELIZA_DEVICES_STATUS_DIR`-precedence case and the canonical-filename assertion), `ios-device-e2e-lib.test.mjs` 10 passed (dropped the deleted-function suites), `devices-status.test.mjs` 6 passed.

### Lint

```
$ bunx biome check <all 7 touched files>
Checked 7 files in 55ms. No fixes applied.
```

### Typecheck

`N/A` — `@elizaos/app`'s `tsconfig.typecheck.json` includes only `src/**/*.{ts,tsx}`; every file in this PR is a `scripts/*.mjs`, so Biome is the gate for them (no TS surface changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
