### PR TITLE
fix(discord): use custom id callback budget (#14527)

### DIFF
--- a/packages/core/src/messaging/interactions/README.md
+++ b/packages/core/src/messaging/interactions/README.md
@@ -56,15 +56,18 @@ a malformed block is left as plain text, never a broken control.
 - `findInteractionRegions(text)` → regions with char bounds (for interleaved rendering).
 - `serializeInteractionBlock(block)` / `appendInteractionBlock(text, block)` — build
   markers programmatically (inverse of parse for the text-borne blocks).
-- `toNeutralLayout(block, { resolveUrl, maxButtonsPerRow })` → `NeutralLayout`
+- `toNeutralLayout(block, { resolveUrl, maxButtonsPerRow, maxCallbackBytes })` →
+  `NeutralLayout`
   (rows of buttons / a select) — the shared projection each connector maps to its
   native primitive. A button carries exactly one of `callbackData` (round-trip) or
   `url` (link-out).
 - `toPlainTextFallback(block, { resolveUrl })` → concise prose for text-only
   transports such as SMS/iMessage, where there is no native control surface.
-- `encodeReplyCallback(value)` / `decodeCallback(data)` — 64-byte-safe codec
-  (Telegram's `callback_data` limit). Returns null when the answer is too big →
-  caller links out or accepts a free-text reply.
+- `encodeReplyCallback(value, { maxBytes })` / `decodeCallback(data)` —
+  callback codec that defaults to Telegram's 64-byte `callback_data` limit.
+  Connectors with a larger native budget, such as Discord custom IDs, pass their
+  own limit. Returns null when the answer is too big → caller links out or
+  accepts a free-text reply.
 - `normalizeContentInteractions(content)` — attach parsed blocks to
   `Content.interactions` **without** mutating `text` (so the dashboard's own
   segment renderer keeps interleaving). `stripInteractionMarkers(text)` for prose.

--- a/packages/core/src/messaging/interactions/callback.ts
+++ b/packages/core/src/messaging/interactions/callback.ts
@@ -1,9 +1,10 @@
 /**
  * Compact codec for the answer a connector round-trips when the user taps a
  * native control (a choice button, a followup chip). The encoded string becomes
- * the platform's callback payload — Telegram caps `callback_data` at 64 bytes,
- * so encoding fails (returns null) when the answer is too large and the caller
- * falls back to a link-out or a free-text reply.
+ * the platform's callback payload. Telegram caps `callback_data` at 64 bytes
+ * while Discord custom IDs allow a larger budget, so callers pass their native
+ * limit and encoding fails (returns null) only when that surface cannot carry
+ * the answer.
  *
  * The decoded answer is re-injected as an ordinary inbound user message, exactly
  * mirroring the dashboard's `sendActionMessage(value)` behavior, so downstream
@@ -15,6 +16,11 @@ const PREFIX = "ia1:";
 /** Telegram's hard limit on `callback_data`. */
 export const MAX_CALLBACK_BYTES = 64;
 
+export interface EncodeReplyCallbackOptions {
+	/** Maximum encoded callback payload length for the target platform. */
+	maxBytes?: number;
+}
+
 function byteLength(s: string): number {
 	return new TextEncoder().encode(s).length;
 }
@@ -24,9 +30,13 @@ function byteLength(s: string): number {
  * the payload would exceed the platform limit — the caller should then link out
  * or accept a free-text reply instead of rendering a tappable control.
  */
-export function encodeReplyCallback(value: string): string | null {
+export function encodeReplyCallback(
+	value: string,
+	options: EncodeReplyCallbackOptions = {},
+): string | null {
 	const data = `${PREFIX}${value}`;
-	return byteLength(data) <= MAX_CALLBACK_BYTES ? data : null;
+	const maxBytes = options.maxBytes ?? MAX_CALLBACK_BYTES;
+	return byteLength(data) <= maxBytes ? data : null;
 }
 
 export interface DecodedCallback {

--- a/packages/core/src/messaging/interactions/interactions.test.ts
+++ b/packages/core/src/messaging/interactions/interactions.test.ts
@@ -318,6 +318,13 @@ describe("callback codec", () => {
 		expect(encodeReplyCallback(big)).toBeNull();
 	});
 
+	it("uses a caller-provided platform callback limit", () => {
+		const value = "x".repeat(MAX_CALLBACK_BYTES + 10);
+		const data = encodeReplyCallback(value, { maxBytes: 100 });
+		expect(data).not.toBeNull();
+		expect(decodeCallback(data)).toEqual({ kind: "reply", value });
+	});
+
 	it("ignores foreign callback payloads", () => {
 		expect(decodeCallback("discord:somethingelse")).toBeNull();
 		expect(isInteractionCallback(undefined)).toBe(false);
@@ -357,6 +364,29 @@ describe("layout", () => {
 			options: [{ value: "a", label: "A" }],
 		};
 		expect(toNeutralLayout(block).needsFallback).toBe(true);
+	});
+
+	it("keeps the default Telegram-safe callback cap unless a platform overrides it", () => {
+		const value = "x".repeat(MAX_CALLBACK_BYTES + 10);
+		const block: ChoiceInteraction = {
+			kind: "choice",
+			id: "i",
+			scope: "s",
+			options: [{ value, label: "Long value" }],
+		};
+
+		const defaultLayout = toNeutralLayout(block);
+		expect(defaultLayout.rows).toEqual([]);
+		expect(defaultLayout.needsFallback).toBe(true);
+
+		const discordLayout = toNeutralLayout(block, { maxCallbackBytes: 100 });
+		const button = discordLayout.rows[0]?.buttons?.[0];
+		expect(button?.label).toBe("Long value");
+		expect(decodeCallback(button?.callbackData)).toEqual({
+			kind: "reply",
+			value,
+		});
+		expect(discordLayout.needsFallback).toBe(false);
 	});
 
 	it("links out a secret block to a resolved url", () => {

--- a/packages/core/src/messaging/interactions/layout.ts
+++ b/packages/core/src/messaging/interactions/layout.ts
@@ -74,6 +74,12 @@ export interface LayoutOptions {
 	resolveNavigateUrl?: (payload: string) => string | undefined;
 	/** Buttons per row before wrapping (Telegram ~8, Discord 5). Default 3. */
 	maxButtonsPerRow?: number;
+	/**
+	 * Native callback payload budget for reply buttons. Defaults to Telegram's
+	 * 64-byte `callback_data` limit; Discord passes its 100-character custom_id
+	 * budget so valid Discord buttons are not forced into free-text fallback.
+	 */
+	maxCallbackBytes?: number;
 }
 
 /**
@@ -103,11 +109,14 @@ function chunk<T>(items: T[], size: number): T[][] {
 function optionButtons(
 	options: InteractionOption[],
 	perRow: number,
+	maxCallbackBytes?: number,
 ): { rows: NeutralRow[]; anyDropped: boolean } {
 	let anyDropped = false;
 	const buttons: NeutralButton[] = [];
 	for (const o of options) {
-		const callbackData = encodeReplyCallback(o.value);
+		const callbackData = encodeReplyCallback(o.value, {
+			maxBytes: maxCallbackBytes,
+		});
 		if (!callbackData) {
 			anyDropped = true;
 			continue;
@@ -127,10 +136,15 @@ export function toNeutralLayout(
 ): NeutralLayout {
 	const perRow = opts.maxButtonsPerRow ?? 3;
 	const resolveUrl = opts.resolveUrl;
+	const maxCallbackBytes = opts.maxCallbackBytes;
 
 	switch (block.kind) {
 		case "choice": {
-			const { rows, anyDropped } = optionButtons(block.options, perRow);
+			const { rows, anyDropped } = optionButtons(
+				block.options,
+				perRow,
+				maxCallbackBytes,
+			);
 			return {
 				text: block.prompt,
 				rows,
@@ -147,7 +161,9 @@ export function toNeutralLayout(
 						continue;
 					}
 				}
-				const callbackData = encodeReplyCallback(o.payload);
+				const callbackData = encodeReplyCallback(o.payload, {
+					maxBytes: maxCallbackBytes,
+				});
 				if (callbackData)
 					buttons.push({ label: o.label, callbackData, style: "secondary" });
 			}

--- a/plugins/plugin-discord/__tests__/interactions.test.ts
+++ b/plugins/plugin-discord/__tests__/interactions.test.ts
@@ -40,6 +40,24 @@ describe("renderDiscordInteractions", () => {
 		});
 	});
 
+	it("uses Discord's 100-byte custom_id budget for longer callback values", () => {
+		const value = "x".repeat(74);
+		const content: Content = {
+			text: `Approve?\n[CHOICE:approve id=c1]\n${value}=Long callback\n[/CHOICE]`,
+		};
+
+		const out = renderDiscordInteractions(content);
+		expect(out.needsFreeTextReply).toBe(false);
+		expect(out.components).toHaveLength(1);
+		const button = out.components[0]?.components[0];
+		expect(button?.label).toBe("Long callback");
+		expect(button?.custom_id.length).toBe(78);
+		expect(decodeCallback(button?.custom_id)).toEqual({
+			kind: "reply",
+			value,
+		});
+	});
+
 	it("renders a task card as a link button when a url resolver is provided", () => {
 		const id = "abc12345-def6-7890-abcd-ef1234567890";
 		const out = renderDiscordInteractions(

--- a/plugins/plugin-discord/interactions.ts
+++ b/plugins/plugin-discord/interactions.ts
@@ -23,6 +23,7 @@ import type { DiscordActionRow, DiscordComponentOptions } from "./types";
 /** Discord allows ≤5 buttons per action row and ≤5 action rows per message. */
 const MAX_BUTTONS_PER_ROW = 5;
 const MAX_ROWS = 5;
+const MAX_CUSTOM_ID_BYTES = 100;
 
 /** discord.js ButtonStyle numeric values. */
 const BUTTON_STYLE = { primary: 1, secondary: 2, danger: 4 } as const;
@@ -93,6 +94,7 @@ export function renderDiscordInteractions(
 			resolveUrl: opts.resolveUrl,
 			resolveNavigateUrl: opts.resolveNavigateUrl,
 			maxButtonsPerRow: MAX_BUTTONS_PER_ROW,
+			maxCallbackBytes: MAX_CUSTOM_ID_BYTES,
 		});
 		let producedButton = false;
 		for (const row of layout.rows) {


### PR DESCRIPTION
Fixes #14527 bug 4 only: Discord no longer inherits Telegram's 64-byte callback payload cap for interaction reply buttons.

## What changed
- Added an optional callback payload budget to the shared interaction callback/layout helpers; the default remains Telegram-safe at 64 bytes.
- Passed Discord's 100-byte `custom_id` budget from the Discord interaction renderer.
- Added core regressions proving the default cap still falls back while a platform override round-trips a longer answer.
- Added a Discord regression proving a 74-character choice value renders as a real button and decodes back to the same reply value.
- Updated the interaction README for the new per-platform budget option.

## Verification
- `bun run --cwd packages/core test src/messaging/interactions/interactions.test.ts` -> pass, 45 tests.
- `bun run --cwd packages/core typecheck` -> pass.
- `bun run --cwd plugins/plugin-discord test __tests__/interactions.test.ts` -> pass, 7 tests.
- `bunx @biomejs/biome check packages/core/src/messaging/interactions/callback.ts packages/core/src/messaging/interactions/layout.ts packages/core/src/messaging/interactions/interactions.test.ts packages/core/src/messaging/interactions/README.md plugins/plugin-discord/interactions.ts plugins/plugin-discord/__tests__/interactions.test.ts` -> pass.
- `git diff --check` -> pass.
- `bun run audit:error-policy-ratchet --report` -> pass; no new fallback-slop in touched production files.

## Not run / N/A
- `bun run --cwd plugins/plugin-discord typecheck` still fails on unrelated workspace dependency-resolution issues: missing `@elizaos/plugin-sql`, `fast-redact` declarations, `@elizaos/vault`, `drizzle-orm/pg-core`, `puppeteer-core`, and `@elizaos/plugin-commands` in adjacent package references.
- Live Discord round-trip: N/A for this scoped codec/layout change; the unit regression asserts the exact outgoing Discord component payload and callback decode path.

## Still open in #14527
- DM component-drop path (claimed separately by 0xSolace).
- Overflow/select strategy for >25 options.
- NeutralSelect producer/consumer decision.
- Modal, embed, and ephemeral behavior.