### PR TITLE
fix(evidence): honor explicit GPU OCR unset

### DIFF
--- a/packages/evidence/src/analyzers/ocr/engines.ts
+++ b/packages/evidence/src/analyzers/ocr/engines.ts
@@ -221,7 +221,9 @@ export class UnlimitedOcrEngine implements OcrEngine {
       fetchImpl?: FetchLike;
     } = {},
   ) {
-    this.baseUrl = options.baseUrl ?? process.env.ELIZA_GPU_VISION_URL;
+    this.baseUrl = Object.hasOwn(options, "baseUrl")
+      ? options.baseUrl
+      : process.env.ELIZA_GPU_VISION_URL;
     this.model =
       options.model ?? process.env.ELIZA_GPU_VISION_MODEL ?? "unlimited-ocr";
     this.fetchImpl = options.fetchImpl ?? (fetch as unknown as FetchLike);

--- a/packages/evidence/src/analyzers/ocr/ocr.test.ts
+++ b/packages/evidence/src/analyzers/ocr/ocr.test.ts
@@ -103,6 +103,24 @@ describe("ocr.unlimited (GPU client against a stub server)", () => {
       expect(availability.reason).toMatch(/ELIZA_GPU_VISION_URL/);
   });
 
+  it("lets an explicit unset override ELIZA_GPU_VISION_URL", async () => {
+    const previous = process.env.ELIZA_GPU_VISION_URL;
+    process.env.ELIZA_GPU_VISION_URL = "http://127.0.0.1:9";
+    try {
+      const engine = new UnlimitedOcrEngine({ baseUrl: undefined });
+      const availability = await engine.available();
+      expect(availability.available).toBe(false);
+      if (!availability.available)
+        expect(availability.reason).toMatch(/ELIZA_GPU_VISION_URL/);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.ELIZA_GPU_VISION_URL;
+      } else {
+        process.env.ELIZA_GPU_VISION_URL = previous;
+      }
+    }
+  });
+
   it("reports available when health returns 200 and parses a completion", async () => {
     await start();
     const engine = new UnlimitedOcrEngine({ baseUrl, model: "unlimited-ocr" });


### PR DESCRIPTION
## Summary
- make `UnlimitedOcrEngine({ baseUrl: undefined })` explicitly disable the GPU OCR endpoint instead of falling back to `ELIZA_GPU_VISION_URL`
- add a regression test that sets `ELIZA_GPU_VISION_URL` and verifies the explicit unset still reports the endpoint as unconfigured

## Verification
- `bun run --cwd packages/evidence test -- src/analyzers/ocr/ocr.test.ts`
- `bun run --cwd packages/evidence test`
- `bun run --cwd packages/evidence typecheck`
- `bun run --cwd packages/evidence lint`
- `bunx @biomejs/biome check packages/evidence/src/analyzers/ocr/engines.ts packages/evidence/src/analyzers/ocr/ocr.test.ts`
- `bun run audit:error-policy-ratchet`

## Evidence
N/A - library-only config/test fix; no rendered UI or live model path changed.
