### PR TITLE
test(cloud): require real sensitive request public view

### DIFF
--- a/packages/cloud/shared/src/lib/services/sensitive-request-hosted-page-e2e.test.ts
+++ b/packages/cloud/shared/src/lib/services/sensitive-request-hosted-page-e2e.test.ts
@@ -448,7 +448,7 @@ describe("#14326 secret flow stores the value without leaking it into transport"
     // Invariant: the secret value is absent from every redacted surface and
     // from the connector DM payload. Search the full serialized blobs.
     const publicView = JSON.stringify(
-      await service.getPublicByToken(created.request.id, created.submitToken).catch(() => ({})),
+      await service.getPublicByToken(created.request.id, created.submitToken),
     );
     const privateView = JSON.stringify(submitted);
     const deliveryPayloads = capturedDeliveries.map((d) => d.payload).join("|");


### PR DESCRIPTION
## Summary
- remove the fallback `{}` in the sensitive-request hosted-page no-leak assertion
- require `getPublicByToken()` to return the real redacted public view before asserting the secret is absent

## Verification
- `bun test --coverage-reporter=lcov --coverage-dir=/tmp/c packages/cloud/shared/src/lib/services/sensitive-request-hosted-page-e2e.test.ts` → 9 pass, 1 skip, 0 fail
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/services/sensitive-request-hosted-page-e2e.test.ts`
- `bun run --cwd packages/cloud/shared typecheck`

## Evidence
N/A - test-only hardening of the cloud sensitive-request e2e; no rendered UI or production behavior changed.
