### PR TITLE
fix(app-control): wire auto-training settings action

### DIFF
--- a/packages/scenario-runner/test/scenarios/_helpers/app-control-http-loopback.ts
+++ b/packages/scenario-runner/test/scenarios/_helpers/app-control-http-loopback.ts
@@ -82,8 +82,10 @@ function shouldHandle(url: URL | null): url is URL {
       // VIEWS/delete now uninstalls via POST /api/plugins/uninstall.
       url.pathname.startsWith("/api/plugins") ||
       // SETTINGS routes owned sections through their own backend endpoints
-      // (e.g. permissions shell toggle → PUT /api/permissions/shell).
-      url.pathname.startsWith("/api/permissions"))
+      // (e.g. permissions shell toggle → PUT /api/permissions/shell,
+      // auto-training toggle → POST /api/training/auto/config).
+      url.pathname.startsWith("/api/permissions") ||
+      url.pathname.startsWith("/api/training/auto/config"))
   );
 }
 

--- a/plugins/plugin-app-control/src/actions/settings.test.ts
+++ b/plugins/plugin-app-control/src/actions/settings.test.ts
@@ -156,6 +156,8 @@ describe("SETTINGS action: list", () => {
 		expect(model).toMatchObject({ writable: true, via: "MODEL_SWITCH" });
 		const permissions = sections.find((s) => s.id === "permissions");
 		expect(permissions).toMatchObject({ writable: true, via: "SETTINGS" });
+		const capabilities = sections.find((s) => s.id === "capabilities");
+		expect(capabilities).toMatchObject({ writable: true, via: "SETTINGS" });
 		const updates = sections.find((s) => s.id === "updates");
 		expect(updates).toMatchObject({ writable: false, via: "not-yet-wired" });
 	});
@@ -192,6 +194,44 @@ describe("SETTINGS action: set on an owned route section", () => {
 			method: "PUT",
 			path: "/api/permissions/shell",
 			body: { enabled: true },
+		});
+	});
+
+	it("dispatches capabilities auto-training through the training config route", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({ ok: true }));
+		const { result, texts } = await invoke(
+			{
+				action: "set",
+				section: "capabilities",
+				key: "auto-training",
+				value: "on",
+			},
+			routeFetch,
+		);
+		expect(routeFetch).toHaveBeenCalledWith({
+			method: "POST",
+			path: "/api/training/auto/config",
+			body: { autoTrain: true },
+		});
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({
+			section: "capabilities",
+			key: "auto-training",
+			value: true,
+		});
+		expect(texts.join(" ")).toContain("Auto-training is on");
+	});
+
+	it("defaults capabilities to auto-training when key is omitted", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({ ok: true }));
+		await invoke(
+			{ action: "set", section: "capabilities", value: "off" },
+			routeFetch,
+		);
+		expect(routeFetch).toHaveBeenCalledWith({
+			method: "POST",
+			path: "/api/training/auto/config",
+			body: { autoTrain: false },
 		});
 	});
 

--- a/plugins/plugin-app-control/src/actions/settings.ts
+++ b/plugins/plugin-app-control/src/actions/settings.ts
@@ -119,6 +119,21 @@ const PERMISSIONS_SHELL_KEY: SettingsWritableKey = {
 			: "Shell access is off. The agent can no longer run shell commands.",
 };
 
+const AUTO_TRAINING_KEY: SettingsWritableKey = {
+	description:
+		"Whether trajectory thresholds may automatically start the training pipeline.",
+	valueType: "boolean",
+	buildRequest: (enabled) => ({
+		method: "POST",
+		path: "/api/training/auto/config",
+		body: { autoTrain: enabled },
+	}),
+	successText: (enabled) =>
+		enabled
+			? "Auto-training is on. The training pipeline can start from trajectory thresholds."
+			: "Auto-training is off. Trajectory counters can still collect data, but automatic training will not start.",
+};
+
 /**
  * The single source of truth mapping every built-in settings section to its
  * write capability. Adding a built-in section without a matching entry fails the
@@ -182,9 +197,10 @@ export const SETTINGS_WRITE_REGISTRY: Readonly<
 			"Voice enable/config is not yet exposed as a semantic action; it currently lives behind the voice section controls.",
 	},
 	capabilities: {
-		kind: "unwired",
-		reason:
-			"Per-capability toggles route through plugin config, not a single-value settings write.",
+		kind: "route",
+		summary:
+			"Capability toggles that already have backend settings routes, including automatic training.",
+		keys: { "auto-training": AUTO_TRAINING_KEY },
 	},
 	apps: {
 		kind: "unwired",
@@ -522,13 +538,18 @@ export function createSettingsAction(deps: SettingsActionDeps = {}): Action {
 			"ENABLE_SHELL",
 			"REVOKE_SHELL_ACCESS",
 			"GRANT_SHELL_ACCESS",
+			"AUTO_TRAINING",
+			"AUTOMATIC_TRAINING",
+			"TOGGLE_AUTO_TRAINING",
+			"ENABLE_AUTO_TRAINING",
+			"DISABLE_AUTO_TRAINING",
 		],
 		description:
-			"Change a built-in settings VALUE from chat — most importantly turning OS/runtime permissions like shell access on or off (turn off / disable / revoke shell access, or turn it back on) via section=permissions key=shell. Also reads (`action=get`) or lists (`action=list`) which settings are changeable. `action=set` writes an owned section (permissions shell access) or points to the dedicated action that owns a delegated section (models→MODEL_SWITCH, background→BACKGROUND, identity→CHARACTER, connectors→CONNECTOR, secrets→CREDENTIALS). This CHANGES a setting's value; opening a settings page without changing anything is VIEWS. Never fill a settings field with agent-fill.",
+			"Change a built-in settings VALUE from chat — most importantly turning OS/runtime permissions like shell access on/off via section=permissions key=shell, and turning automatic training on/off via section=capabilities key=auto-training. Also reads (`action=get`) or lists (`action=list`) which settings are changeable. `action=set` writes an owned section (permissions shell access, capabilities auto-training) or points to the dedicated action that owns a delegated section (models→MODEL_SWITCH, background→BACKGROUND, identity→CHARACTER, connectors→CONNECTOR, secrets→CREDENTIALS). This CHANGES a setting's value; opening a settings page without changing anything is VIEWS. Never fill a settings field with agent-fill.",
 		descriptionCompressed:
-			"settings get|set|list section/key/value — CHANGE a setting VALUE from chat, incl. turning shell access / OS permissions on/off (section=permissions key=shell); delegates model/background/identity/connectors/secrets to their dedicated actions",
+			"settings get|set|list section/key/value — CHANGE a setting VALUE from chat, incl. shell access (section=permissions key=shell) and auto-training (section=capabilities key=auto-training); delegates model/background/identity/connectors/secrets",
 		routingHint:
-			"Semantic settings reads/writes that do NOT already have a dedicated action -> SETTINGS. Changing a PERMISSION or setting VALUE is SETTINGS action=set, NOT navigation: 'turn off shell permissions', 'disable shell access', 'turn off shell access', 'revoke shell access', 'stop the agent running shell commands', 'turn shell back on', 'change my permissions' -> SETTINGS section=permissions key=shell value=off|on. Also 'what settings can you change' / 'list settings' -> SETTINGS action=list. Do NOT use SETTINGS for changes a dedicated action owns: switching the model is MODEL_SWITCH, the background/theme is BACKGROUND, the agent identity is CHARACTER, connectors are CONNECTOR, secret/API keys are CREDENTIALS. The distinction from VIEWS is value-vs-navigation: changing/toggling a permission or setting VALUE is SETTINGS even though that permission lives on a settings page; merely OPENING or navigating to a settings page with no value change is VIEWS. SETTINGS never fills a form field with agent-fill.",
+			"Semantic settings reads/writes that do NOT already have a dedicated action -> SETTINGS. Changing a PERMISSION or setting VALUE is SETTINGS action=set, NOT navigation: 'turn off shell permissions', 'disable shell access', 'turn off shell access', 'revoke shell access', 'stop the agent running shell commands', 'turn shell back on', 'change my permissions' -> SETTINGS section=permissions key=shell value=off|on. 'turn on auto-training', 'enable automatic training', 'disable auto training' -> SETTINGS section=capabilities key=auto-training value=on|off. Also 'what settings can you change' / 'list settings' -> SETTINGS action=list. Do NOT use SETTINGS for changes a dedicated action owns: switching the model is MODEL_SWITCH, the background/theme is BACKGROUND, the agent identity is CHARACTER, connectors are CONNECTOR, secret/API keys are CREDENTIALS. The distinction from VIEWS is value-vs-navigation: changing/toggling a permission or setting VALUE is SETTINGS even though that permission lives on a settings page; merely OPENING or navigating to a settings page with no value change is VIEWS. SETTINGS never fills a form field with agent-fill.",
 		suppressPostActionContinuation: true,
 
 		parameters: [
@@ -541,14 +562,14 @@ export function createSettingsAction(deps: SettingsActionDeps = {}): Action {
 			{
 				name: "section",
 				description:
-					"Canonical settings section id or alias (e.g. permissions, ai-model, background, secrets). Required for get/set.",
+					"Canonical settings section id or alias (e.g. permissions, capabilities, ai-model, background, secrets). Required for get/set.",
 				required: false,
 				schema: { type: "string" },
 			},
 			{
 				name: "key",
 				description:
-					"The specific toggle within the section (e.g. shell for permissions). Optional; defaults to the section's primary key.",
+					"The specific toggle within the section (e.g. shell for permissions, auto-training for capabilities). Optional; defaults to the section's primary key.",
 				required: false,
 				schema: { type: "string" },
 			},

--- a/plugins/plugin-app-control/test/scenarios/settings-auto-training-toggle.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/settings-auto-training-toggle.scenario.ts
@@ -1,0 +1,104 @@
+/**
+ * Live-model SETTINGS scenario (#14624): a natural "turn on auto-training"
+ * request must select the semantic SETTINGS action and drive the Capabilities
+ * section's own backend route (POST /api/training/auto/config
+ * { autoTrain:true }) — the same endpoint the visible toggle uses.
+ */
+
+import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+	jsonResponse,
+	readAppControlHttpRequests,
+	registerAppControlHttpHandler,
+	resetAppControlHttpLoopback,
+} from "../../../../packages/scenario-runner/test/scenarios/_helpers/app-control-http-loopback";
+
+function autoTrainingWrites() {
+	return readAppControlHttpRequests(
+		(request) =>
+			request.method === "POST" &&
+			request.pathname === "/api/training/auto/config",
+	).map((request) => request.body ?? null);
+}
+
+export default scenario({
+	lane: "live-only",
+	id: "settings-auto-training-toggle",
+	title: "SETTINGS action enables auto-training via the capabilities route",
+	domain: "app-control",
+	tags: ["app-control", "settings", "set", "capabilities", "training"],
+	isolation: "per-scenario",
+	requires: {
+		plugins: ["@elizaos/plugin-app-control"],
+	},
+	seed: [
+		{
+			type: "custom",
+			name: "register auto-training loopback API",
+			apply: () => {
+				resetAppControlHttpLoopback();
+				registerAppControlHttpHandler((request) => {
+					if (
+						request.method === "POST" &&
+						request.pathname === "/api/training/auto/config"
+					) {
+						return jsonResponse({
+							config: {
+								autoTrain: true,
+								threshold: 50,
+								cooldownHours: 24,
+							},
+						});
+					}
+					return undefined;
+				});
+				return undefined;
+			},
+		},
+	],
+	rooms: [
+		{
+			id: "main",
+			source: "chat",
+			title: "Settings Auto-training Toggle",
+		},
+	],
+	turns: [
+		{
+			kind: "message",
+			name: "user-asks-enable-auto-training",
+			text: "turn on auto-training",
+		},
+	],
+	finalChecks: [
+		{
+			type: "selectedAction",
+			actionName: "SETTINGS",
+		},
+		{
+			type: "actionCalled",
+			actionName: "SETTINGS",
+			status: "success",
+			minCount: 1,
+		},
+		{
+			type: "custom",
+			name: "SETTINGS drove POST /api/training/auto/config { autoTrain:true }",
+			predicate: () => {
+				const expected = [{ autoTrain: true }];
+				const actual = autoTrainingWrites();
+				return JSON.stringify(actual) === JSON.stringify(expected)
+					? undefined
+					: `expected exactly one auto-training write ${JSON.stringify(expected)}, saw ${JSON.stringify(actual)}`;
+			},
+		},
+		{
+			type: "custom",
+			name: "cleanup auto-training loopback",
+			predicate: () => {
+				resetAppControlHttpLoopback();
+				return undefined;
+			},
+		},
+	],
+});


### PR DESCRIPTION
## Summary
- route the SETTINGS capabilities section through `POST /api/training/auto/config` for the `auto-training` boolean key
- update SETTINGS planner hints/listing coverage so auto-training is a semantic settings write instead of an unwired gap
- add a live-only app-control scenario that asserts “turn on auto-training” selects SETTINGS and posts `{ autoTrain: true }` to the same backend route the UI toggle uses

Fixes #14624.

## Verification
- `bun run --cwd plugins/plugin-app-control test -- src/actions/settings.test.ts`
- `bun run --cwd plugins/plugin-app-control typecheck`
- `bun src/cli.ts list ../../plugins/plugin-app-control/test/scenarios --scenario settings-auto-training-toggle` from `packages/scenario-runner`
- `bun run --cwd packages/scenario-runner test src/action-effect-ratchet.test.ts src/skippable-check-ratchet.test.ts src/echo-assertion-ratchet.test.ts`
- `git diff --check origin/develop...HEAD`
- `bun run audit:error-policy-ratchet --report`

## Evidence notes
- Live LLM trajectory: N/A locally. `OPENAI_API_KEY`, `GROQ_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, `OPENROUTER_API_KEY`, and `CEREBRAS_API_KEY` are unset in this environment. The PR adds `settings-auto-training-toggle` as a live-only scenario for keyed CI/manual evidence.
- App visual audit: N/A. No renderer/UI files were changed; this wires the semantic action twin and scenario coverage only.