### PR TITLE
feat(evidence): video evidence lanes — walkthrough driver, MP4 normalization, keyframe analysis (#14545)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -899,6 +899,8 @@
       "name": "@elizaos/evidence",
       "version": "0.0.0",
       "dependencies": {
+        "ffmpeg-static": "^5.3.0",
+        "ffprobe-static": "^3.1.0",
         "pixelmatch": "^7.2.0",
         "sharp": "^0.34.5",
         "zod": "^4.4.3",
@@ -5564,6 +5566,7 @@
     "bufferutil",
     "workerd",
     "esbuild",
+    "ffmpeg-static",
     "sharp",
     "@biomejs/biome",
     "electron",

--- a/bun.lock
+++ b/bun.lock
@@ -904,6 +904,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.0",
         "@types/node": "^24.0.0",
       },
     },

--- a/package.json
+++ b/package.json
@@ -451,6 +451,7 @@
     "dtrace-provider",
     "electron",
     "esbuild",
+    "ffmpeg-static",
     "keccak",
     "node-llama-cpp",
     "nx",

--- a/packages/evidence/AGENTS.md
+++ b/packages/evidence/AGENTS.md
@@ -131,8 +131,9 @@ src/certify/
   rollup.ts         mechanical draft verdicts (honest-skip semantics)
   sign.ts           signCertification / verifyCertification (typed failure codes)
   cli.ts            certify:keygen|rollup|sign|verify (J1 boundary)
+src/ffmpeg-binaries.ts  ffmpeg/ffprobe resolver: env → PATH → installed static packages
 src/video/          video evidence lanes (#14545, stacked on the #14542 analyzers)
-  normalize.ts        webm/mov→MP4 (h264 + faststart); ffprobe-gated, honest skip
+  normalize.ts        webm/mov→MP4 (h264 + faststart); ffprobe-gated
   ingest.ts           ingestVideo: place at video/<granularity>s/<slug>.mp4 +
                       keyframe extraction + image-analyzer fan-out over keyframes
   walkthrough-schema.ts  zod-validated walkthrough DEFINITIONS (typed invalid)
@@ -149,5 +150,7 @@ Video lanes never touch the analyzers or bundle internals — they consume
 from the bundle. Playwright is a devDependency, dynamically imported: consumers
 that only ingest pre-recorded videos never pay for it. Normalization is
 conditional (probe, then copy/remux/transcode) so an already-canonical MP4 is not
-re-encoded. Absent ffmpeg/ffprobe or an absent chromium each surface as an
-explicit skip/typed error, never a silent copy or fabricated pass.
+re-encoded. ffmpeg/ffprobe resolve from explicit env paths, PATH, then
+`ffmpeg-static`/`ffprobe-static`; only a broken explicit env pin or missing
+installed dependency surfaces as an explicit skip. An absent chromium is a typed
+error, never a silent copy or fabricated pass.

--- a/packages/evidence/AGENTS.md
+++ b/packages/evidence/AGENTS.md
@@ -105,6 +105,11 @@ bun run --cwd packages/evidence certify:keygen -- [--print-private-key]
 bun run --cwd packages/evidence certify:rollup -- --bundle <dir> [--requirements <file>] [--out <file>]
 bun run --cwd packages/evidence certify:sign -- --bundle <dir> --verdicts <file> --reviewer-id <id> --reviewer-kind <agent|human>
 bun run --cwd packages/evidence certify:verify -- --cert <file> --bundle <dir> --pubkey <pem> [--requirements <file>] [--json]
+# Video evidence lanes (#14545): drive the data-driven walkthroughs against the
+# self-contained dashboard fixture (or the real app via --base-url) and ingest
+# each MP4 with keyframe analysis, or ingest a pre-recorded video directly.
+bun run --cwd packages/evidence video:walkthrough -- --def all --bundle <dir>
+bun run --cwd packages/evidence video:ingest -- --file x.webm --granularity feature --slug send-message --bundle <dir>
 ```
 
 Test-lane membership is declared via `elizaos.scripts.testLanes: ["server"]`
@@ -126,4 +131,23 @@ src/certify/
   rollup.ts         mechanical draft verdicts (honest-skip semantics)
   sign.ts           signCertification / verifyCertification (typed failure codes)
   cli.ts            certify:keygen|rollup|sign|verify (J1 boundary)
+src/video/          video evidence lanes (#14545, stacked on the #14542 analyzers)
+  normalize.ts        webm/mov→MP4 (h264 + faststart); ffprobe-gated, honest skip
+  ingest.ts           ingestVideo: place at video/<granularity>s/<slug>.mp4 +
+                      keyframe extraction + image-analyzer fan-out over keyframes
+  walkthrough-schema.ts  zod-validated walkthrough DEFINITIONS (typed invalid)
+  driver.ts           one runWalkthrough driver (real Playwright chromium, video)
+  fixture-server.ts   ephemeral localhost static server for the fixture
+  fixture/            self-contained dashboard fixture (real app data-testids)
+  walkthroughs/       three shipped definitions (element/feature/walkthrough)
+  walkthroughs.ts     load + orchestrate driver → normalize → ingest
+  cli.ts              video:walkthrough / video:ingest (J1 boundary)
 ```
+
+Video lanes never touch the analyzers or bundle internals — they consume
+`extractKeyframes` + `analyzeArtifacts` from the #14542 registry and `addArtifact`
+from the bundle. Playwright is a devDependency, dynamically imported: consumers
+that only ingest pre-recorded videos never pay for it. Normalization is
+conditional (probe, then copy/remux/transcode) so an already-canonical MP4 is not
+re-encoded. Absent ffmpeg/ffprobe or an absent chromium each surface as an
+explicit skip/typed error, never a silent copy or fabricated pass.

--- a/packages/evidence/CLAUDE.md
+++ b/packages/evidence/CLAUDE.md
@@ -131,8 +131,9 @@ src/certify/
   rollup.ts         mechanical draft verdicts (honest-skip semantics)
   sign.ts           signCertification / verifyCertification (typed failure codes)
   cli.ts            certify:keygen|rollup|sign|verify (J1 boundary)
+src/ffmpeg-binaries.ts  ffmpeg/ffprobe resolver: env → PATH → installed static packages
 src/video/          video evidence lanes (#14545, stacked on the #14542 analyzers)
-  normalize.ts        webm/mov→MP4 (h264 + faststart); ffprobe-gated, honest skip
+  normalize.ts        webm/mov→MP4 (h264 + faststart); ffprobe-gated
   ingest.ts           ingestVideo: place at video/<granularity>s/<slug>.mp4 +
                       keyframe extraction + image-analyzer fan-out over keyframes
   walkthrough-schema.ts  zod-validated walkthrough DEFINITIONS (typed invalid)
@@ -149,5 +150,7 @@ Video lanes never touch the analyzers or bundle internals — they consume
 from the bundle. Playwright is a devDependency, dynamically imported: consumers
 that only ingest pre-recorded videos never pay for it. Normalization is
 conditional (probe, then copy/remux/transcode) so an already-canonical MP4 is not
-re-encoded. Absent ffmpeg/ffprobe or an absent chromium each surface as an
-explicit skip/typed error, never a silent copy or fabricated pass.
+re-encoded. ffmpeg/ffprobe resolve from explicit env paths, PATH, then
+`ffmpeg-static`/`ffprobe-static`; only a broken explicit env pin or missing
+installed dependency surfaces as an explicit skip. An absent chromium is a typed
+error, never a silent copy or fabricated pass.

--- a/packages/evidence/CLAUDE.md
+++ b/packages/evidence/CLAUDE.md
@@ -105,6 +105,11 @@ bun run --cwd packages/evidence certify:keygen -- [--print-private-key]
 bun run --cwd packages/evidence certify:rollup -- --bundle <dir> [--requirements <file>] [--out <file>]
 bun run --cwd packages/evidence certify:sign -- --bundle <dir> --verdicts <file> --reviewer-id <id> --reviewer-kind <agent|human>
 bun run --cwd packages/evidence certify:verify -- --cert <file> --bundle <dir> --pubkey <pem> [--requirements <file>] [--json]
+# Video evidence lanes (#14545): drive the data-driven walkthroughs against the
+# self-contained dashboard fixture (or the real app via --base-url) and ingest
+# each MP4 with keyframe analysis, or ingest a pre-recorded video directly.
+bun run --cwd packages/evidence video:walkthrough -- --def all --bundle <dir>
+bun run --cwd packages/evidence video:ingest -- --file x.webm --granularity feature --slug send-message --bundle <dir>
 ```
 
 Test-lane membership is declared via `elizaos.scripts.testLanes: ["server"]`
@@ -126,4 +131,23 @@ src/certify/
   rollup.ts         mechanical draft verdicts (honest-skip semantics)
   sign.ts           signCertification / verifyCertification (typed failure codes)
   cli.ts            certify:keygen|rollup|sign|verify (J1 boundary)
+src/video/          video evidence lanes (#14545, stacked on the #14542 analyzers)
+  normalize.ts        webm/mov→MP4 (h264 + faststart); ffprobe-gated, honest skip
+  ingest.ts           ingestVideo: place at video/<granularity>s/<slug>.mp4 +
+                      keyframe extraction + image-analyzer fan-out over keyframes
+  walkthrough-schema.ts  zod-validated walkthrough DEFINITIONS (typed invalid)
+  driver.ts           one runWalkthrough driver (real Playwright chromium, video)
+  fixture-server.ts   ephemeral localhost static server for the fixture
+  fixture/            self-contained dashboard fixture (real app data-testids)
+  walkthroughs/       three shipped definitions (element/feature/walkthrough)
+  walkthroughs.ts     load + orchestrate driver → normalize → ingest
+  cli.ts              video:walkthrough / video:ingest (J1 boundary)
 ```
+
+Video lanes never touch the analyzers or bundle internals — they consume
+`extractKeyframes` + `analyzeArtifacts` from the #14542 registry and `addArtifact`
+from the bundle. Playwright is a devDependency, dynamically imported: consumers
+that only ingest pre-recorded videos never pay for it. Normalization is
+conditional (probe, then copy/remux/transcode) so an already-canonical MP4 is not
+re-encoded. Absent ffmpeg/ffprobe or an absent chromium each surface as an
+explicit skip/typed error, never a silent copy or fabricated pass.

--- a/packages/evidence/package.json
+++ b/packages/evidence/package.json
@@ -16,6 +16,8 @@
     "certify:sign": "bun src/certify/cli.ts sign",
     "certify:verify": "bun src/certify/cli.ts verify",
     "vision-qa": "bun src/vision-qa/cli.ts",
+    "video:walkthrough": "bun src/video/cli.ts walkthrough",
+    "video:ingest": "bun src/video/cli.ts ingest",
     "test": "node ../scripts/run-vitest.mjs run --config ./vitest.config.ts",
     "typecheck": "tsgo --noEmit -p tsconfig.json",
     "lint": "bunx @biomejs/biome check src",
@@ -29,6 +31,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.0",
     "@types/node": "^24.0.0"
   },
   "elizaos": {

--- a/packages/evidence/package.json
+++ b/packages/evidence/package.json
@@ -26,6 +26,8 @@
     "format:check": "bunx @biomejs/biome format src"
   },
   "dependencies": {
+    "ffmpeg-static": "^5.3.0",
+    "ffprobe-static": "^3.1.0",
     "pixelmatch": "^7.2.0",
     "sharp": "^0.34.5",
     "zod": "^4.4.3"

--- a/packages/evidence/src/analyzers/keyframes.ts
+++ b/packages/evidence/src/analyzers/keyframes.ts
@@ -8,10 +8,11 @@
  * by OCR, palette, brand, corners, and phash without any of them knowing about
  * video.
  *
- * ffmpeg is optional: when absent the analyzer records `skipped-missing-tool`
- * with the reason, never a fabricated empty keyframe set. Emitting artifacts
- * requires the runner's `ctx.emitArtifact` handle; without it (analysis over a
- * bare directory with no bundle) the analyzer skips with that reason.
+ * ffmpeg resolves from env, PATH, then the installed `ffmpeg-static` package;
+ * only when every source is unavailable does the analyzer record
+ * `skipped-missing-tool`. Emitting artifacts requires the runner's
+ * `ctx.emitArtifact` handle; without it (analysis over a bare directory with no
+ * bundle) the analyzer skips with that reason.
  */
 
 import { execFile } from "node:child_process";
@@ -19,6 +20,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
+import { EvidenceError } from "../errors.ts";
+import { resolveFfmpegBinary } from "../ffmpeg-binaries.ts";
 import type {
   Analyzer,
   AnalyzerContext,
@@ -30,7 +33,6 @@ const execFileAsync = promisify(execFile);
 
 /** Default cap on emitted scene-cut keyframes (first/last are always added). */
 const DEFAULT_MAX_SCENE_FRAMES = 12;
-const FFMPEG_BIN = process.env.ELIZA_FFMPEG_BIN || "ffmpeg";
 
 /** One emitted keyframe's placement. */
 export interface KeyframeRecord {
@@ -49,18 +51,8 @@ export interface KeyframesData {
 export async function ffmpegAvailable(): Promise<
   { available: true } | { available: false; reason: string }
 > {
-  try {
-    await execFileAsync(FFMPEG_BIN, ["-version"], { timeout: 10_000 });
-    return { available: true };
-  } catch (error) {
-    const enoent = (error as NodeJS.ErrnoException)?.code === "ENOENT";
-    return {
-      available: false,
-      reason: enoent
-        ? `ffmpeg not installed (${FFMPEG_BIN})`
-        : `ffmpeg -version failed: ${String(error instanceof Error ? error.message : error).slice(0, 160)}`,
-    };
-  }
+  const resolved = await resolveFfmpegBinary();
+  return resolved.available ? { available: true } : resolved;
 }
 
 /**
@@ -74,10 +66,14 @@ export async function extractKeyframes(
   outDir: string,
   maxSceneFrames = DEFAULT_MAX_SCENE_FRAMES,
 ): Promise<{ file: string; kind: "scene" | "first" | "last" }[]> {
+  const ffmpeg = await resolveFfmpegBinary();
+  if (!ffmpeg.available) {
+    throw new EvidenceError(ffmpeg.reason, { code: "FFMPEG_UNAVAILABLE" });
+  }
   fs.mkdirSync(outDir, { recursive: true });
   const scenePattern = path.join(outDir, "scene-%03d.png");
   await execFileAsync(
-    FFMPEG_BIN,
+    ffmpeg.bin,
     [
       "-hide_banner",
       "-loglevel",
@@ -97,7 +93,7 @@ export async function extractKeyframes(
   const first = path.join(outDir, "first.png");
   const last = path.join(outDir, "last.png");
   await execFileAsync(
-    FFMPEG_BIN,
+    ffmpeg.bin,
     [
       "-hide_banner",
       "-loglevel",
@@ -112,7 +108,7 @@ export async function extractKeyframes(
   );
   // Seek to the final frame: read the whole stream and keep only the last.
   await execFileAsync(
-    FFMPEG_BIN,
+    ffmpeg.bin,
     [
       "-hide_banner",
       "-loglevel",

--- a/packages/evidence/src/analyzers/ocr/engines.ts
+++ b/packages/evidence/src/analyzers/ocr/engines.ts
@@ -15,6 +15,7 @@
 
 import { execFile } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 
@@ -89,18 +90,41 @@ export class TesseractOcrEngine implements OcrEngine {
   }
 
   async recognize(imagePath: string): Promise<OcrRecognition> {
+    const staged = stageTesseractInput(imagePath);
     const { stdout } = await execFileAsync(
       this.bin,
-      [imagePath, "-", "--psm", "6"],
+      [staged.path, "-", "--psm", "6"],
       { timeout: 60_000, maxBuffer: 8 * 1024 * 1024 },
-    );
-    const text = stdout
-      .split("\n")
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .join("\n");
-    return { text };
+    ).finally(staged.cleanup);
+    return { text: normalizeOcrText(stdout) };
   }
+}
+
+/**
+ * Leptonica can truncate/error on long temp artifact paths. Stage through a
+ * short filename so bundle layout depth cannot turn available OCR into a
+ * `failed` analyzer record.
+ */
+function stageTesseractInput(imagePath: string): {
+  path: string;
+  cleanup(): void;
+} {
+  const scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), "evidence-ocr-"));
+  const extension = path.extname(imagePath) || ".png";
+  const stagedPath = path.join(scratchDir, `input${extension}`);
+  fs.copyFileSync(imagePath, stagedPath);
+  return {
+    path: stagedPath,
+    cleanup: () => fs.rmSync(scratchDir, { recursive: true, force: true }),
+  };
+}
+
+function normalizeOcrText(stdout: string): string {
+  return stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join("\n");
 }
 
 /**

--- a/packages/evidence/src/analyzers/ocr/ocr.test.ts
+++ b/packages/evidence/src/analyzers/ocr/ocr.test.ts
@@ -6,7 +6,7 @@
 // shape (model, temperature 0, image data URL) and returns a canned completion
 // the client must parse; the real-model path is the gpu lane's live test.
 
-import { rmSync } from "node:fs";
+import { mkdirSync, rmSync } from "node:fs";
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import { join } from "node:path";
@@ -47,9 +47,33 @@ describe("ocr.tesseract", () => {
       expect(data.text.toUpperCase()).toContain("EVIDENCE");
     } else {
       expect(result.status).toBe("skipped-missing-tool");
-      if (result.status === "skipped-missing-tool")
+      if (result.status === "skipped-missing-tool") {
         expect(result.reason).toMatch(/tesseract/i);
+      }
     }
+  });
+
+  it("reads rendered text from a long artifact path", async () => {
+    const availability = await new TesseractOcrEngine().available();
+    if (!availability.available) {
+      expect(availability.reason).toMatch(/tesseract/i);
+      return;
+    }
+
+    const longDir = join(
+      dir,
+      "video",
+      "keyframes",
+      "video-features-send-message-mp4",
+      "nested-artifact-path-that-used-to-trip-leptonica",
+    );
+    mkdirSync(longDir, { recursive: true });
+    const png = await textPng(join(longDir, "000-first.png"), "LONGPATH");
+    const result = await ocrTesseractAnalyzer.analyze(inputFor(png), ctx);
+    expect(result.status).toBe("ran");
+    if (result.status !== "ran") return;
+    const data = result.data as { text: string };
+    expect(data.text.toUpperCase()).toContain("LONGPATH");
   });
 });
 

--- a/packages/evidence/src/ffmpeg-binaries.ts
+++ b/packages/evidence/src/ffmpeg-binaries.ts
@@ -1,0 +1,198 @@
+/**
+ * FFmpeg and ffprobe binary resolution for evidence video analysis. Evidence
+ * producers should work on a clean checkout without hand-installed media tools,
+ * so system binaries are preferred when present and the npm-packaged static
+ * binaries provide the install-time fallback. Explicit env paths stay strict so
+ * CI lanes can pin a known binary and fail loudly when that pin is broken.
+ */
+
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const require = createRequire(import.meta.url);
+const execFileAsync = promisify(execFile);
+
+type ToolName = "ffmpeg" | "ffprobe";
+
+interface ToolResolution {
+  bin: string;
+  source: "env" | "system" | "bundled";
+}
+
+/** Whether a binary answers `-version`, with a reason when it does not. */
+async function binaryAvailable(
+  bin: string,
+): Promise<{ available: true } | { available: false; reason: string }> {
+  try {
+    await execFileAsync(bin, ["-version"], { timeout: 10_000 });
+    return { available: true };
+  } catch (error) {
+    const enoent = (error as NodeJS.ErrnoException)?.code === "ENOENT";
+    return {
+      available: false,
+      reason: enoent
+        ? `${bin} not installed`
+        : `${bin} -version failed: ${String(
+            error instanceof Error ? error.message : error,
+          ).slice(0, 160)}`,
+    };
+  }
+}
+
+function envPath(names: string[]): string | undefined {
+  for (const name of names) {
+    const value = process.env[name]?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function requireFfmpegStaticPath(): string | null {
+  try {
+    const mod = require("ffmpeg-static") as unknown;
+    return typeof mod === "string" && mod.length > 0 ? mod : null;
+  } catch (error) {
+    // error-policy:J3 optional packaged binary — absence is reported by caller.
+    void error;
+  }
+  return null;
+}
+
+async function bundledFfmpegPath(): Promise<string | null> {
+  const candidate = requireFfmpegStaticPath();
+  if (candidate === null) return null;
+  if (fs.existsSync(candidate)) return candidate;
+  try {
+    const packageJson = require.resolve("ffmpeg-static/package.json");
+    await execFileAsync(process.execPath, ["install.js"], {
+      cwd: path.dirname(packageJson),
+      env: { ...process.env, CI: "1" },
+      timeout: 180_000,
+    });
+  } catch (error) {
+    // error-policy:J3 optional managed install — caller reports unavailable.
+    void error;
+  }
+  return fs.existsSync(candidate) ? candidate : null;
+}
+
+function bundledFfprobePath(): string | null {
+  try {
+    const mod = require("ffprobe-static") as { path?: string } | string;
+    const candidate = typeof mod === "string" ? mod : mod.path;
+    if (
+      typeof candidate === "string" &&
+      candidate.length > 0 &&
+      fs.existsSync(candidate)
+    ) {
+      return candidate;
+    }
+  } catch (error) {
+    // error-policy:J3 optional packaged binary — absence is reported by caller.
+    void error;
+  }
+  return null;
+}
+
+function configuredEnvPath(tool: ToolName): string | undefined {
+  return tool === "ffmpeg"
+    ? envPath(["ELIZA_FFMPEG_BIN", "ELIZA_FFMPEG_PATH", "FFMPEG_PATH"])
+    : envPath(["ELIZA_FFPROBE_BIN", "ELIZA_FFPROBE_PATH", "FFPROBE_PATH"]);
+}
+
+async function bundledPath(tool: ToolName): Promise<string | null> {
+  return tool === "ffmpeg" ? bundledFfmpegPath() : bundledFfprobePath();
+}
+
+async function resolveTool(
+  tool: ToolName,
+): Promise<
+  | { available: true; resolution: ToolResolution }
+  | { available: false; reason: string }
+> {
+  const explicit = configuredEnvPath(tool);
+  if (explicit !== undefined) {
+    const available = await binaryAvailable(explicit);
+    if (available.available) {
+      return {
+        available: true,
+        resolution: { bin: explicit, source: "env" },
+      };
+    }
+    return {
+      available: false,
+      reason: `${tool} env override is not invocable: ${available.reason}`,
+    };
+  }
+
+  const system = await binaryAvailable(tool);
+  if (system.available) {
+    return {
+      available: true,
+      resolution: { bin: tool, source: "system" },
+    };
+  }
+
+  const bundled = await bundledPath(tool);
+  if (bundled !== null) {
+    const available = await binaryAvailable(bundled);
+    if (available.available) {
+      return {
+        available: true,
+        resolution: { bin: bundled, source: "bundled" },
+      };
+    }
+    return {
+      available: false,
+      reason: `${tool} system binary missing and bundled binary failed: ${available.reason}`,
+    };
+  }
+
+  return {
+    available: false,
+    reason: `${tool} not found on PATH and bundled ${tool}-static package is unavailable`,
+  };
+}
+
+/** Resolve ffmpeg from env, PATH, or the installed `ffmpeg-static` package. */
+export async function resolveFfmpegBinary(): Promise<
+  | { available: true; bin: string; source: ToolResolution["source"] }
+  | { available: false; reason: string }
+> {
+  const resolved = await resolveTool("ffmpeg");
+  if (!resolved.available) return resolved;
+  return { available: true, ...resolved.resolution };
+}
+
+/** Resolve ffprobe from env, PATH, or the installed `ffprobe-static` package. */
+export async function resolveFfprobeBinary(): Promise<
+  | { available: true; bin: string; source: ToolResolution["source"] }
+  | { available: false; reason: string }
+> {
+  const resolved = await resolveTool("ffprobe");
+  if (!resolved.available) return resolved;
+  return { available: true, ...resolved.resolution };
+}
+
+/** Whether both ffprobe and ffmpeg are invocable after packaged fallback. */
+export async function resolveVideoBinaries(): Promise<
+  | {
+      available: true;
+      ffmpeg: ToolResolution;
+      ffprobe: ToolResolution;
+    }
+  | { available: false; reason: string }
+> {
+  const ffprobe = await resolveFfprobeBinary();
+  if (!ffprobe.available) return ffprobe;
+  const ffmpeg = await resolveFfmpegBinary();
+  if (!ffmpeg.available) return ffmpeg;
+  return {
+    available: true,
+    ffmpeg: { bin: ffmpeg.bin, source: ffmpeg.source },
+    ffprobe: { bin: ffprobe.bin, source: ffprobe.source },
+  };
+}

--- a/packages/evidence/src/ffmpeg-binaries.ts
+++ b/packages/evidence/src/ffmpeg-binaries.ts
@@ -9,7 +9,6 @@
 import { execFile } from "node:child_process";
 import fs from "node:fs";
 import { createRequire } from "node:module";
-import path from "node:path";
 import { promisify } from "node:util";
 
 const require = createRequire(import.meta.url);
@@ -61,21 +60,9 @@ function requireFfmpegStaticPath(): string | null {
   return null;
 }
 
-async function bundledFfmpegPath(): Promise<string | null> {
+function bundledFfmpegPath(): string | null {
   const candidate = requireFfmpegStaticPath();
   if (candidate === null) return null;
-  if (fs.existsSync(candidate)) return candidate;
-  try {
-    const packageJson = require.resolve("ffmpeg-static/package.json");
-    await execFileAsync(process.execPath, ["install.js"], {
-      cwd: path.dirname(packageJson),
-      env: { ...process.env, CI: "1" },
-      timeout: 180_000,
-    });
-  } catch (error) {
-    // error-policy:J3 optional managed install — caller reports unavailable.
-    void error;
-  }
   return fs.existsSync(candidate) ? candidate : null;
 }
 
@@ -103,7 +90,7 @@ function configuredEnvPath(tool: ToolName): string | undefined {
     : envPath(["ELIZA_FFPROBE_BIN", "ELIZA_FFPROBE_PATH", "FFPROBE_PATH"]);
 }
 
-async function bundledPath(tool: ToolName): Promise<string | null> {
+function bundledPath(tool: ToolName): string | null {
   return tool === "ffmpeg" ? bundledFfmpegPath() : bundledFfprobePath();
 }
 
@@ -136,7 +123,7 @@ async function resolveTool(
     };
   }
 
-  const bundled = await bundledPath(tool);
+  const bundled = bundledPath(tool);
   if (bundled !== null) {
     const available = await binaryAvailable(bundled);
     if (available.available) {

--- a/packages/evidence/src/index.ts
+++ b/packages/evidence/src/index.ts
@@ -175,6 +175,46 @@ export {
   TIERS,
   type Tier,
 } from "./schema.ts";
+// Video evidence lanes (#14545): MP4 normalization, video ingest with keyframe
+// analysis, the data-driven walkthrough driver, and walkthrough definition
+// loading/orchestration over the shipped dashboard fixture.
+export {
+  type RunWalkthroughOptions,
+  runWalkthrough,
+  type StepLog,
+  type WalkthroughRunResult,
+} from "./video/driver.ts";
+export { type FixtureServer, serveFixture } from "./video/fixture-server.ts";
+export {
+  type IngestVideoOptions,
+  type IngestVideoResult,
+  ingestVideo,
+  VIDEO_GRANULARITIES,
+  type VideoGranularity,
+} from "./video/ingest.ts";
+export {
+  type NormalizeOutcome,
+  normalizeVideo,
+  probeVideo,
+  type VideoProbe,
+  videoToolsAvailable,
+} from "./video/normalize.ts";
+export {
+  parseWalkthroughDef,
+  WALKTHROUGH_ACTIONS,
+  type WalkthroughAction,
+  type WalkthroughDef,
+  type WalkthroughStep,
+} from "./video/walkthrough-schema.ts";
+export {
+  FIXTURE_DIR,
+  loadAllWalkthroughDefs,
+  loadWalkthroughDef,
+  type RunAndIngestOptions,
+  type RunAndIngestResult,
+  runAndIngestWalkthrough,
+  WALKTHROUGHS_DIR,
+} from "./video/walkthroughs.ts";
 // Vision-QA VLM screenshot Q&A layer (#14544).
 export {
   ANTHROPIC_BASE_URL,
@@ -217,44 +257,3 @@ export {
   writeCache,
   writeQaRecord,
 } from "./vision-qa/index.ts";
-
-// Video evidence lanes (#14545): MP4 normalization, video ingest with keyframe
-// analysis, the data-driven walkthrough driver, and walkthrough definition
-// loading/orchestration over the shipped dashboard fixture.
-export {
-  type RunWalkthroughOptions,
-  runWalkthrough,
-  type StepLog,
-  type WalkthroughRunResult,
-} from "./video/driver.ts";
-export { type FixtureServer, serveFixture } from "./video/fixture-server.ts";
-export {
-  type IngestVideoOptions,
-  type IngestVideoResult,
-  ingestVideo,
-  VIDEO_GRANULARITIES,
-  type VideoGranularity,
-} from "./video/ingest.ts";
-export {
-  type NormalizeOutcome,
-  normalizeVideo,
-  probeVideo,
-  type VideoProbe,
-  videoToolsAvailable,
-} from "./video/normalize.ts";
-export {
-  parseWalkthroughDef,
-  WALKTHROUGH_ACTIONS,
-  type WalkthroughAction,
-  type WalkthroughDef,
-  type WalkthroughStep,
-} from "./video/walkthrough-schema.ts";
-export {
-  FIXTURE_DIR,
-  loadAllWalkthroughDefs,
-  loadWalkthroughDef,
-  type RunAndIngestOptions,
-  type RunAndIngestResult,
-  runAndIngestWalkthrough,
-  WALKTHROUGHS_DIR,
-} from "./video/walkthroughs.ts";

--- a/packages/evidence/src/index.ts
+++ b/packages/evidence/src/index.ts
@@ -218,3 +218,44 @@ export {
   writeCache,
   writeQaRecord,
 } from "./vision-qa/index.ts";
+
+// Video evidence lanes (#14545): MP4 normalization, video ingest with keyframe
+// analysis, the data-driven walkthrough driver, and walkthrough definition
+// loading/orchestration over the shipped dashboard fixture.
+export {
+  type IngestVideoOptions,
+  type IngestVideoResult,
+  ingestVideo,
+  VIDEO_GRANULARITIES,
+  type VideoGranularity,
+} from "./video/ingest.ts";
+export {
+  type RunWalkthroughOptions,
+  type StepLog,
+  runWalkthrough,
+  type WalkthroughRunResult,
+} from "./video/driver.ts";
+export { type FixtureServer, serveFixture } from "./video/fixture-server.ts";
+export {
+  type NormalizeOutcome,
+  normalizeVideo,
+  probeVideo,
+  type VideoProbe,
+  videoToolsAvailable,
+} from "./video/normalize.ts";
+export {
+  parseWalkthroughDef,
+  WALKTHROUGH_ACTIONS,
+  type WalkthroughAction,
+  type WalkthroughDef,
+  type WalkthroughStep,
+} from "./video/walkthrough-schema.ts";
+export {
+  FIXTURE_DIR,
+  loadAllWalkthroughDefs,
+  loadWalkthroughDef,
+  type RunAndIngestOptions,
+  type RunAndIngestResult,
+  runAndIngestWalkthrough,
+  WALKTHROUGHS_DIR,
+} from "./video/walkthroughs.ts";

--- a/packages/evidence/src/index.ts
+++ b/packages/evidence/src/index.ts
@@ -175,7 +175,6 @@ export {
   TIERS,
   type Tier,
 } from "./schema.ts";
-
 // Vision-QA VLM screenshot Q&A layer (#14544).
 export {
   ANTHROPIC_BASE_URL,
@@ -223,19 +222,19 @@ export {
 // analysis, the data-driven walkthrough driver, and walkthrough definition
 // loading/orchestration over the shipped dashboard fixture.
 export {
+  type RunWalkthroughOptions,
+  runWalkthrough,
+  type StepLog,
+  type WalkthroughRunResult,
+} from "./video/driver.ts";
+export { type FixtureServer, serveFixture } from "./video/fixture-server.ts";
+export {
   type IngestVideoOptions,
   type IngestVideoResult,
   ingestVideo,
   VIDEO_GRANULARITIES,
   type VideoGranularity,
 } from "./video/ingest.ts";
-export {
-  type RunWalkthroughOptions,
-  type StepLog,
-  runWalkthrough,
-  type WalkthroughRunResult,
-} from "./video/driver.ts";
-export { type FixtureServer, serveFixture } from "./video/fixture-server.ts";
 export {
   type NormalizeOutcome,
   normalizeVideo,

--- a/packages/evidence/src/video/cli.test.ts
+++ b/packages/evidence/src/video/cli.test.ts
@@ -1,0 +1,59 @@
+// Video CLI argv contract, tool-free (always runs). Drives runVideoCli with a
+// captured IO instead of spawning a process: asserts usage on no command,
+// unknown-arg / missing-required / bad-enum rejections surface as a structured
+// error line + non-zero exit, and the ingest command rejects a bad granularity.
+// The happy paths (which launch chromium/ffmpeg) are covered by the driver and
+// walkthroughs suites, not here.
+import { describe, expect, it } from "vitest";
+import { type CliIo, runVideoCli } from "./cli.ts";
+
+function capture(): { io: CliIo; out: string[]; err: string[] } {
+  const out: string[] = [];
+  const err: string[] = [];
+  return { io: { out: (l) => out.push(l), err: (l) => err.push(l) }, out, err };
+}
+
+describe("runVideoCli argv contract", () => {
+  it("prints usage and exits 0 on --help", async () => {
+    const { io, err } = capture();
+    const code = await runVideoCli(["--help"], io);
+    expect(code).toBe(0);
+    expect(err.join("\n")).toMatch(/video:walkthrough/);
+  });
+
+  it("exits 1 on an unknown command", async () => {
+    const { io } = capture();
+    expect(await runVideoCli(["frobnicate"], io)).toBe(1);
+  });
+
+  it("rejects an unknown argument with a typed error line", async () => {
+    const { io, err } = capture();
+    const code = await runVideoCli(["walkthrough", "--nope", "x"], io);
+    expect(code).toBe(1);
+    expect(err.join("\n")).toMatch(/\[CLI_USAGE\]/);
+  });
+
+  it("requires --def for walkthrough", async () => {
+    const { io, err } = capture();
+    const code = await runVideoCli(["walkthrough"], io);
+    expect(code).toBe(1);
+    expect(err.join("\n")).toMatch(/--def/);
+  });
+
+  it("requires --file/--granularity/--slug for ingest", async () => {
+    const { io, err } = capture();
+    const code = await runVideoCli(["ingest", "--file", "x.webm"], io);
+    expect(code).toBe(1);
+    expect(err.join("\n")).toMatch(/required/);
+  });
+
+  it("rejects a bad granularity for ingest", async () => {
+    const { io, err } = capture();
+    const code = await runVideoCli(
+      ["ingest", "--file", "x.webm", "--granularity", "page", "--slug", "ok"],
+      io,
+    );
+    expect(code).toBe(1);
+    expect(err.join("\n")).toMatch(/--granularity must be one of/);
+  });
+});

--- a/packages/evidence/src/video/cli.ts
+++ b/packages/evidence/src/video/cli.ts
@@ -181,7 +181,7 @@ async function runWalkthroughCommand(
       const norm = result.ingest.normalize.status;
       io.out(
         `  ${def.slug.padEnd(16)} ${def.granularity.padEnd(11)} ` +
-          `steps=${result.stepsLog ? result.screenshots.length + result.ariaSnapshots.length : 0} ` +
+          `steps=${result.stepCount} ` +
           `norm=${norm} keyframes=${result.ingest.keyframeCount} video=${result.ingest.video.path}`,
       );
       ran += 1;

--- a/packages/evidence/src/video/cli.ts
+++ b/packages/evidence/src/video/cli.ts
@@ -1,0 +1,230 @@
+/**
+ * CLI for the video evidence lanes: `walkthrough` runs the data-driven driver
+ * over one or all shipped definitions and ingests each produced video (normalized
+ * + keyframe-analyzed) into a bundle; `ingest` normalizes and ingests an already
+ * recorded video (a producer's webm/mov) into a bundle. Like the bundle CLI this
+ * is a thin process boundary: it parses argv, opens or reuses a bundle with real
+ * git provenance, drives the library, and prints an honest summary. The library
+ * never logs; stdout/stderr here are the product.
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createBundle, type EvidenceBundle } from "../bundle.ts";
+import { EvidenceError } from "../errors.ts";
+import {
+  buildEnvFingerprint,
+  collectGitProvenance,
+  resolveRunnerKind,
+} from "../provenance.ts";
+import { TIERS, type Tier } from "../schema.ts";
+import { VIDEO_GRANULARITIES, ingestVideo, type VideoGranularity } from "./ingest.ts";
+import {
+  loadAllWalkthroughDefs,
+  loadWalkthroughDef,
+  runAndIngestWalkthrough,
+} from "./walkthroughs.ts";
+
+const USAGE = `Usage:
+  video:walkthrough -- --def <file|all> [--bundle <dir>] [--base-url <url>] [--tier <cpu|gpu|full>] [--out <scratch>]
+  video:ingest      -- --file <video> --granularity <element|feature|walkthrough> --slug <slug> [--bundle <dir>] [--tier <cpu|gpu|full>]
+
+walkthrough  Run the driver over a walkthrough definition (or all shipped ones)
+             and ingest each video with keyframe analysis into a bundle.
+ingest       Normalize + ingest an already-recorded video into a bundle.`;
+
+/** Output sinks; injectable so tests capture instead of spawning. */
+export interface CliIo {
+  out(line: string): void;
+  err(line: string): void;
+}
+
+function defaultRepoRoot(): string {
+  // src/video/cli.ts → video → src → packages/evidence → packages → repo root.
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../..");
+}
+
+interface ParsedArgs {
+  values: Map<string, string>;
+  flags: Set<string>;
+}
+
+function parseArgs(argv: string[], known: Set<string>): ParsedArgs {
+  const values = new Map<string, string>();
+  const flags = new Set<string>();
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith("--")) {
+      throw new EvidenceError(`unexpected positional argument: ${arg}`, {
+        code: "CLI_USAGE",
+      });
+    }
+    const key = arg.slice(2);
+    if (!known.has(key)) {
+      throw new EvidenceError(`unknown argument: ${arg}`, { code: "CLI_USAGE" });
+    }
+    const next = argv[index + 1];
+    if (next === undefined || next.startsWith("--")) {
+      flags.add(key);
+    } else {
+      values.set(key, next);
+      index += 1;
+    }
+  }
+  return { values, flags };
+}
+
+function parseTier(raw: string | undefined): Tier {
+  if (raw === undefined) return "cpu";
+  if (!(TIERS as readonly string[]).includes(raw)) {
+    throw new EvidenceError(`--tier must be one of ${TIERS.join("|")}, got: ${raw}`, {
+      code: "CLI_USAGE",
+    });
+  }
+  return raw as Tier;
+}
+
+/** Open a fresh bundle under `--bundle`'s parent (or evidence/runs) with real provenance. */
+function openBundle(bundleDir: string | undefined, repoRoot: string, tier: Tier): EvidenceBundle {
+  const git = collectGitProvenance(repoRoot);
+  const runner = resolveRunnerKind(process.env);
+  const provenance = {
+    commit: git.commit,
+    branch: git.branch,
+    runner,
+    tier,
+    envFingerprint: buildEnvFingerprint(tier),
+  };
+  if (bundleDir !== undefined) {
+    // A caller-named bundle dir is the run dir itself: use its parent as the
+    // rootDir and its basename as the fixed runId so the bundle lands exactly there.
+    const resolved = path.resolve(bundleDir);
+    return createBundle({
+      rootDir: path.dirname(resolved),
+      provenance,
+      runId: path.basename(resolved),
+    });
+  }
+  return createBundle({
+    rootDir: path.join(repoRoot, "evidence", "runs"),
+    provenance,
+  });
+}
+
+async function runWalkthroughCommand(argv: string[], io: CliIo): Promise<number> {
+  const { values } = parseArgs(
+    argv,
+    new Set(["def", "bundle", "base-url", "tier", "out", "repo-root"]),
+  );
+  const defArg = values.get("def");
+  if (defArg === undefined) {
+    throw new EvidenceError("--def <file|all> is required", { code: "CLI_USAGE" });
+  }
+  const repoRoot = path.resolve(values.get("repo-root") ?? defaultRepoRoot());
+  const tier = parseTier(values.get("tier"));
+  const bundle = openBundle(values.get("bundle"), repoRoot, tier);
+  const outRoot = path.resolve(values.get("out") ?? path.join(bundle.dir, ".walkthrough-scratch"));
+  const baseUrl = values.get("base-url");
+
+  const defs =
+    defArg === "all"
+      ? loadAllWalkthroughDefs()
+      : [{ def: loadWalkthroughDef(path.resolve(defArg)), file: path.resolve(defArg) }];
+
+  io.out(`bundle ${bundle.runId}`);
+  let ran = 0;
+  for (const { def } of defs) {
+    if (def.requiresApp && baseUrl === undefined) {
+      io.err(`  ${def.slug.padEnd(16)} skipped   requires --base-url (requiresApp)`);
+      continue;
+    }
+    const result = await runAndIngestWalkthrough(def, bundle, {
+      out: path.join(outRoot, def.slug),
+      ...(baseUrl !== undefined ? { baseUrl } : {}),
+    });
+    const norm = result.ingest.normalize.status;
+    io.out(
+      `  ${def.slug.padEnd(16)} ${def.granularity.padEnd(11)} ` +
+        `steps=${result.stepsLog ? result.screenshots.length + result.ariaSnapshots.length : 0} ` +
+        `norm=${norm} keyframes=${result.ingest.keyframeCount} video=${result.ingest.video.path}`,
+    );
+    ran += 1;
+  }
+  const finalized = await bundle.finalize();
+  io.out("");
+  io.out(`  walkthroughs ran: ${ran}`);
+  io.out(`  manifest:  ${finalized.manifestPath}`);
+  io.out(`  sha256:    ${finalized.manifestSha256}`);
+  return ran > 0 ? 0 : 1;
+}
+
+async function runIngestCommand(argv: string[], io: CliIo): Promise<number> {
+  const { values } = parseArgs(
+    argv,
+    new Set(["file", "granularity", "slug", "bundle", "tier", "repo-root"]),
+  );
+  const file = values.get("file");
+  const granularityRaw = values.get("granularity");
+  const slug = values.get("slug");
+  if (file === undefined || granularityRaw === undefined || slug === undefined) {
+    throw new EvidenceError("--file, --granularity, and --slug are all required", {
+      code: "CLI_USAGE",
+    });
+  }
+  if (!(VIDEO_GRANULARITIES as readonly string[]).includes(granularityRaw)) {
+    throw new EvidenceError(
+      `--granularity must be one of ${VIDEO_GRANULARITIES.join("|")}, got: ${granularityRaw}`,
+      { code: "CLI_USAGE" },
+    );
+  }
+  const repoRoot = path.resolve(values.get("repo-root") ?? defaultRepoRoot());
+  const tier = parseTier(values.get("tier"));
+  const bundle = openBundle(values.get("bundle"), repoRoot, tier);
+  const result = await ingestVideo(bundle, path.resolve(file), {
+    granularity: granularityRaw as VideoGranularity,
+    slug,
+    source: "video-ingest",
+    producedBy: "video:ingest",
+    tier,
+  });
+  const finalized = await bundle.finalize();
+  io.out(`bundle ${bundle.runId}`);
+  io.out(`  video:     ${result.video.path}`);
+  io.out(`  normalize: ${result.normalize.status}`);
+  io.out(`  keyframes: ${result.keyframeCount}`);
+  io.out(`  manifest:  ${finalized.manifestPath}`);
+  io.out(`  sha256:    ${finalized.manifestSha256}`);
+  return 0;
+}
+
+/** Parse argv (without node/script prefix) and run; returns the exit code. */
+export async function runVideoCli(argv: string[], io: CliIo): Promise<number> {
+  const [command, ...rest] = argv;
+  try {
+    if (command === "walkthrough") return await runWalkthroughCommand(rest, io);
+    if (command === "ingest") return await runIngestCommand(rest, io);
+    io.err(USAGE);
+    return command === undefined || command === "--help" || command === "-h" ? 0 : 1;
+  } catch (error) {
+    // error-policy:J1 process boundary — translate typed failures into a
+    // structured stderr line + non-zero exit for the invoking harness.
+    if (error instanceof EvidenceError) {
+      io.err(`error [${error.code}]: ${error.message}`);
+      if (error.code === "CLI_USAGE") io.err(USAGE);
+      return 1;
+    }
+    throw error;
+  }
+}
+
+const invokedDirectly =
+  process.argv[1] !== undefined &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  const io: CliIo = {
+    out: (line) => process.stdout.write(`${line}\n`),
+    err: (line) => process.stderr.write(`${line}\n`),
+  };
+  process.exitCode = await runVideoCli(process.argv.slice(2), io);
+}

--- a/packages/evidence/src/video/cli.ts
+++ b/packages/evidence/src/video/cli.ts
@@ -18,7 +18,11 @@ import {
   resolveRunnerKind,
 } from "../provenance.ts";
 import { TIERS, type Tier } from "../schema.ts";
-import { VIDEO_GRANULARITIES, ingestVideo, type VideoGranularity } from "./ingest.ts";
+import {
+  ingestVideo,
+  VIDEO_GRANULARITIES,
+  type VideoGranularity,
+} from "./ingest.ts";
 import {
   loadAllWalkthroughDefs,
   loadWalkthroughDef,
@@ -41,7 +45,10 @@ export interface CliIo {
 
 function defaultRepoRoot(): string {
   // src/video/cli.ts → video → src → packages/evidence → packages → repo root.
-  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../..");
+  return path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "../../../..",
+  );
 }
 
 interface ParsedArgs {
@@ -61,7 +68,9 @@ function parseArgs(argv: string[], known: Set<string>): ParsedArgs {
     }
     const key = arg.slice(2);
     if (!known.has(key)) {
-      throw new EvidenceError(`unknown argument: ${arg}`, { code: "CLI_USAGE" });
+      throw new EvidenceError(`unknown argument: ${arg}`, {
+        code: "CLI_USAGE",
+      });
     }
     const next = argv[index + 1];
     if (next === undefined || next.startsWith("--")) {
@@ -77,15 +86,22 @@ function parseArgs(argv: string[], known: Set<string>): ParsedArgs {
 function parseTier(raw: string | undefined): Tier {
   if (raw === undefined) return "cpu";
   if (!(TIERS as readonly string[]).includes(raw)) {
-    throw new EvidenceError(`--tier must be one of ${TIERS.join("|")}, got: ${raw}`, {
-      code: "CLI_USAGE",
-    });
+    throw new EvidenceError(
+      `--tier must be one of ${TIERS.join("|")}, got: ${raw}`,
+      {
+        code: "CLI_USAGE",
+      },
+    );
   }
   return raw as Tier;
 }
 
 /** Open a fresh bundle under `--bundle`'s parent (or evidence/runs) with real provenance. */
-function openBundle(bundleDir: string | undefined, repoRoot: string, tier: Tier): EvidenceBundle {
+function openBundle(
+  bundleDir: string | undefined,
+  repoRoot: string,
+  tier: Tier,
+): EvidenceBundle {
   const git = collectGitProvenance(repoRoot);
   const runner = resolveRunnerKind(process.env);
   const provenance = {
@@ -111,31 +127,45 @@ function openBundle(bundleDir: string | undefined, repoRoot: string, tier: Tier)
   });
 }
 
-async function runWalkthroughCommand(argv: string[], io: CliIo): Promise<number> {
+async function runWalkthroughCommand(
+  argv: string[],
+  io: CliIo,
+): Promise<number> {
   const { values } = parseArgs(
     argv,
     new Set(["def", "bundle", "base-url", "tier", "out", "repo-root"]),
   );
   const defArg = values.get("def");
   if (defArg === undefined) {
-    throw new EvidenceError("--def <file|all> is required", { code: "CLI_USAGE" });
+    throw new EvidenceError("--def <file|all> is required", {
+      code: "CLI_USAGE",
+    });
   }
   const repoRoot = path.resolve(values.get("repo-root") ?? defaultRepoRoot());
   const tier = parseTier(values.get("tier"));
   const bundle = openBundle(values.get("bundle"), repoRoot, tier);
-  const outRoot = path.resolve(values.get("out") ?? path.join(bundle.dir, ".walkthrough-scratch"));
+  const outRoot = path.resolve(
+    values.get("out") ?? path.join(bundle.dir, ".walkthrough-scratch"),
+  );
   const baseUrl = values.get("base-url");
 
   const defs =
     defArg === "all"
       ? loadAllWalkthroughDefs()
-      : [{ def: loadWalkthroughDef(path.resolve(defArg)), file: path.resolve(defArg) }];
+      : [
+          {
+            def: loadWalkthroughDef(path.resolve(defArg)),
+            file: path.resolve(defArg),
+          },
+        ];
 
   io.out(`bundle ${bundle.runId}`);
   let ran = 0;
   for (const { def } of defs) {
     if (def.requiresApp && baseUrl === undefined) {
-      io.err(`  ${def.slug.padEnd(16)} skipped   requires --base-url (requiresApp)`);
+      io.err(
+        `  ${def.slug.padEnd(16)} skipped   requires --base-url (requiresApp)`,
+      );
       continue;
     }
     const result = await runAndIngestWalkthrough(def, bundle, {
@@ -166,10 +196,17 @@ async function runIngestCommand(argv: string[], io: CliIo): Promise<number> {
   const file = values.get("file");
   const granularityRaw = values.get("granularity");
   const slug = values.get("slug");
-  if (file === undefined || granularityRaw === undefined || slug === undefined) {
-    throw new EvidenceError("--file, --granularity, and --slug are all required", {
-      code: "CLI_USAGE",
-    });
+  if (
+    file === undefined ||
+    granularityRaw === undefined ||
+    slug === undefined
+  ) {
+    throw new EvidenceError(
+      "--file, --granularity, and --slug are all required",
+      {
+        code: "CLI_USAGE",
+      },
+    );
   }
   if (!(VIDEO_GRANULARITIES as readonly string[]).includes(granularityRaw)) {
     throw new EvidenceError(
@@ -204,7 +241,9 @@ export async function runVideoCli(argv: string[], io: CliIo): Promise<number> {
     if (command === "walkthrough") return await runWalkthroughCommand(rest, io);
     if (command === "ingest") return await runIngestCommand(rest, io);
     io.err(USAGE);
-    return command === undefined || command === "--help" || command === "-h" ? 0 : 1;
+    return command === undefined || command === "--help" || command === "-h"
+      ? 0
+      : 1;
   } catch (error) {
     // error-policy:J1 process boundary — translate typed failures into a
     // structured stderr line + non-zero exit for the invoking harness.

--- a/packages/evidence/src/video/cli.ts
+++ b/packages/evidence/src/video/cli.ts
@@ -8,6 +8,8 @@
  * never logs; stdout/stderr here are the product.
  */
 
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createBundle, type EvidenceBundle } from "../bundle.ts";
@@ -144,9 +146,12 @@ async function runWalkthroughCommand(
   const repoRoot = path.resolve(values.get("repo-root") ?? defaultRepoRoot());
   const tier = parseTier(values.get("tier"));
   const bundle = openBundle(values.get("bundle"), repoRoot, tier);
-  const outRoot = path.resolve(
-    values.get("out") ?? path.join(bundle.dir, ".walkthrough-scratch"),
-  );
+  // Scratch must live OUTSIDE the bundle dir: verifyBundle sweeps for unlisted
+  // files, and the driver's raw webm/screenshots are not manifest artifacts.
+  const outRoot = values.get("out")
+    ? path.resolve(values.get("out") as string)
+    : fs.mkdtempSync(path.join(os.tmpdir(), "evidence-walkthrough-"));
+  const cleanupScratch = values.get("out") === undefined;
   const baseUrl = values.get("base-url");
 
   const defs =
@@ -161,24 +166,28 @@ async function runWalkthroughCommand(
 
   io.out(`bundle ${bundle.runId}`);
   let ran = 0;
-  for (const { def } of defs) {
-    if (def.requiresApp && baseUrl === undefined) {
-      io.err(
-        `  ${def.slug.padEnd(16)} skipped   requires --base-url (requiresApp)`,
+  try {
+    for (const { def } of defs) {
+      if (def.requiresApp && baseUrl === undefined) {
+        io.err(
+          `  ${def.slug.padEnd(16)} skipped   requires --base-url (requiresApp)`,
+        );
+        continue;
+      }
+      const result = await runAndIngestWalkthrough(def, bundle, {
+        out: path.join(outRoot, def.slug),
+        ...(baseUrl !== undefined ? { baseUrl } : {}),
+      });
+      const norm = result.ingest.normalize.status;
+      io.out(
+        `  ${def.slug.padEnd(16)} ${def.granularity.padEnd(11)} ` +
+          `steps=${result.stepsLog ? result.screenshots.length + result.ariaSnapshots.length : 0} ` +
+          `norm=${norm} keyframes=${result.ingest.keyframeCount} video=${result.ingest.video.path}`,
       );
-      continue;
+      ran += 1;
     }
-    const result = await runAndIngestWalkthrough(def, bundle, {
-      out: path.join(outRoot, def.slug),
-      ...(baseUrl !== undefined ? { baseUrl } : {}),
-    });
-    const norm = result.ingest.normalize.status;
-    io.out(
-      `  ${def.slug.padEnd(16)} ${def.granularity.padEnd(11)} ` +
-        `steps=${result.stepsLog ? result.screenshots.length + result.ariaSnapshots.length : 0} ` +
-        `norm=${norm} keyframes=${result.ingest.keyframeCount} video=${result.ingest.video.path}`,
-    );
-    ran += 1;
+  } finally {
+    if (cleanupScratch) fs.rmSync(outRoot, { recursive: true, force: true });
   }
   const finalized = await bundle.finalize();
   io.out("");

--- a/packages/evidence/src/video/driver.test.ts
+++ b/packages/evidence/src/video/driver.test.ts
@@ -1,0 +1,157 @@
+// Walkthrough driver against a LOCAL static HTML fixture served over http, in a
+// REAL headless Playwright chromium — no mocks, no stubbed browser. Skipped with
+// an explicit reason when @playwright/test or its chromium browser is
+// unavailable (after attempting nothing destructive; the runner reports the
+// skip). Asserts the driver records a video, per-step screenshots, and an ARIA
+// snapshot, executes every step in order, and fails fast on a false assertion.
+import { mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { runWalkthrough } from "./driver.ts";
+import { serveFixture } from "./fixture-server.ts";
+import { parseWalkthroughDef } from "./walkthrough-schema.ts";
+
+const dir = mkdtempSync(join(os.tmpdir(), "evidence-driver-"));
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+/** Can we launch a real headless chromium? Gate the browser lane honestly. */
+async function chromiumLaunchable(): Promise<boolean> {
+  try {
+    const { chromium } = (await import("@playwright/test")) as {
+      chromium: { launch(o?: unknown): Promise<{ close(): Promise<void> }> };
+    };
+    const browser = await chromium.launch({ headless: true });
+    await browser.close();
+    return true;
+  } catch {
+    // error-policy:J4 test-capability gate — an absent browser download is a
+    // skipped lane with a reason, not a failed test.
+    return false;
+  }
+}
+
+const hasChromium = await chromiumLaunchable();
+
+// A minimal fixture with one button that swaps visible text on click, so the
+// driver can exercise goto/waitFor/click/assertText/screenshot/aria on real DOM.
+const FIXTURE_HTML = `<!doctype html><html><head><meta charset="utf-8"><title>fixture</title></head>
+<body>
+  <button data-testid="go" aria-label="Go">Go</button>
+  <p data-testid="out">idle</p>
+  <script>
+    document.querySelector('[data-testid="go"]').addEventListener('click', () => {
+      document.querySelector('[data-testid="out"]').textContent = 'done';
+    });
+  </script>
+</body></html>`;
+
+describe.skipIf(!hasChromium)("runWalkthrough (real chromium)", () => {
+  it("records a video, screenshots, and an aria snapshot over a fixture", async () => {
+    const fixtureDir = mkdtempSync(join(dir, "fixture-"));
+    writeFileSync(join(fixtureDir, "index.html"), FIXTURE_HTML);
+    const server = await serveFixture(fixtureDir);
+    const out = mkdtempSync(join(dir, "out-"));
+    try {
+      const def = parseWalkthroughDef(
+        {
+          slug: "driver-fixture",
+          granularity: "feature",
+          baseUrl: server.baseUrl,
+          steps: [
+            { action: "goto", value: "/", label: "open" },
+            {
+              action: "waitFor",
+              selector: '[data-testid="go"]',
+              label: "await-button",
+            },
+            {
+              action: "assertText",
+              selector: '[data-testid="out"]',
+              value: "idle",
+            },
+            {
+              action: "click",
+              selector: '[data-testid="go"]',
+              label: "click",
+              ariaAfter: true,
+            },
+            {
+              action: "assertText",
+              selector: '[data-testid="out"]',
+              value: "done",
+              label: "result",
+              screenshotAfter: true,
+            },
+          ],
+        },
+        "test",
+      );
+      const result = await runWalkthrough(def, {
+        out,
+        stepPauseMs: 100,
+      });
+      expect(result.steps).toHaveLength(5);
+      expect(result.steps.map((s) => s.action)).toEqual([
+        "goto",
+        "waitFor",
+        "assertText",
+        "click",
+        "assertText",
+      ]);
+      expect(result.screenshots).toHaveLength(1);
+      expect(result.ariaSnapshots).toHaveLength(1);
+      expect(statSync(result.video).size).toBeGreaterThan(0);
+      expect(statSync(result.stepsLog).size).toBeGreaterThan(0);
+    } finally {
+      await server.stop();
+    }
+  }, 60_000);
+
+  it("fails fast when an assertText does not hold", async () => {
+    const fixtureDir = mkdtempSync(join(dir, "fixture-fail-"));
+    writeFileSync(join(fixtureDir, "index.html"), FIXTURE_HTML);
+    const server = await serveFixture(fixtureDir);
+    const out = mkdtempSync(join(dir, "out-fail-"));
+    try {
+      const def = parseWalkthroughDef(
+        {
+          slug: "driver-fail",
+          granularity: "feature",
+          baseUrl: server.baseUrl,
+          steps: [
+            { action: "goto", value: "/" },
+            {
+              action: "assertText",
+              selector: '[data-testid="out"]',
+              value: "this text is never present",
+            },
+          ],
+        },
+        "test",
+      );
+      await expect(
+        runWalkthrough(def, { out, stepPauseMs: 0 }),
+      ).rejects.toMatchObject({ code: "WALKTHROUGH_ASSERTION_FAILED" });
+    } finally {
+      await server.stop();
+    }
+  }, 60_000);
+});
+
+describe("runWalkthrough guards", () => {
+  it("refuses a requiresApp definition without a baseUrl", async () => {
+    const def = parseWalkthroughDef(
+      {
+        slug: "needs-app",
+        granularity: "walkthrough",
+        requiresApp: true,
+        steps: [{ action: "goto", value: "/" }],
+      },
+      "test",
+    );
+    await expect(
+      runWalkthrough(def, { out: join(dir, "never") }),
+    ).rejects.toMatchObject({ code: "WALKTHROUGH_REQUIRES_APP" });
+  });
+});

--- a/packages/evidence/src/video/driver.ts
+++ b/packages/evidence/src/video/driver.ts
@@ -1,0 +1,329 @@
+/**
+ * The single data-driven walkthrough driver: given one validated
+ * `WalkthroughDef`, drive a real Playwright chromium context through its steps
+ * and produce the raw evidence a walkthrough lane needs — a recorded video,
+ * per-step screenshots, an ARIA-snapshot (html-tree) per marked step, and a
+ * machine-readable steps-log. One driver runs every walkthrough; the difference
+ * between a send-button micro-interaction and a five-view app tour is entirely
+ * in the definition, not in code.
+ *
+ * Playwright is a devDependency imported dynamically: consumers that only ingest
+ * pre-recorded videos never pay for it, and its absence surfaces as a typed
+ * error rather than a module-load crash. The driver does NOT normalize or ingest
+ * — it emits raw artifacts into `out`; `ingestVideo` is the next stage. This
+ * keeps capture (needs a browser) and analysis (needs ffmpeg) as independently
+ * skippable concerns.
+ *
+ * Steps fail fast: an assertion that does not hold, or a selector that never
+ * appears, throws and aborts the walkthrough — a walkthrough that "passed" while
+ * silently skipping half its steps is worse than no evidence. The video is still
+ * finalized in a `finally` so a failed run leaves a diagnosable recording.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { EvidenceError } from "../errors.ts";
+import type { WalkthroughDef, WalkthroughStep } from "./walkthrough-schema.ts";
+
+// Playwright's public types are not depended on at compile time (devDependency,
+// dynamic import), so the surface the driver touches is declared structurally.
+// This is the minimum contract the driver needs from chromium/page/context.
+interface PwLocator {
+  scrollIntoViewIfNeeded(options?: { timeout?: number }): Promise<void>;
+  hover(options?: { timeout?: number }): Promise<void>;
+  click(options?: { timeout?: number }): Promise<void>;
+  fill(value: string, options?: { timeout?: number }): Promise<void>;
+  waitFor(options?: { timeout?: number; state?: string }): Promise<void>;
+  first(): PwLocator;
+  textContent(options?: { timeout?: number }): Promise<string | null>;
+}
+interface PwPage {
+  goto(url: string, options?: { timeout?: number }): Promise<unknown>;
+  locator(selector: string): PwLocator;
+  waitForTimeout(ms: number): Promise<void>;
+  evaluate<T>(fn: string | ((arg: T) => unknown), arg?: T): Promise<unknown>;
+  screenshot(options: { path: string; fullPage?: boolean }): Promise<Buffer>;
+  ariaSnapshot?(options?: { timeout?: number }): Promise<string>;
+  content(): Promise<string>;
+  close(): Promise<void>;
+}
+interface PwContext {
+  newPage(): Promise<PwPage>;
+  close(): Promise<void>;
+}
+interface PwBrowser {
+  newContext(options: {
+    viewport: { width: number; height: number };
+    recordVideo: { dir: string; size?: { width: number; height: number } };
+    baseURL?: string;
+  }): Promise<PwContext>;
+  close(): Promise<void>;
+}
+interface PwChromium {
+  launch(options?: { headless?: boolean }): Promise<PwBrowser>;
+}
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_VIEWPORT = { width: 1280, height: 800 } as const;
+
+/** One executed step's record for the steps-log. */
+export interface StepLog {
+  index: number;
+  action: WalkthroughStep["action"];
+  label?: string;
+  selector?: string;
+  value?: string;
+  /** Bundle-relative-ish name of the screenshot captured after this step, if any. */
+  screenshot?: string;
+  /** Name of the ARIA-snapshot captured after this step, if any. */
+  ariaSnapshot?: string;
+  durationMs: number;
+}
+
+/** Everything one driver run produces on disk under `out`. */
+export interface WalkthroughRunResult {
+  slug: string;
+  /** Absolute path to the recorded MP4/webm the browser produced. */
+  video: string;
+  /** Absolute paths of per-step screenshots, in order. */
+  screenshots: string[];
+  /** Absolute paths of per-step ARIA snapshots (html-tree YAML), in order. */
+  ariaSnapshots: string[];
+  /** Absolute path to the written steps-log JSON. */
+  stepsLog: string;
+  steps: StepLog[];
+}
+
+/** Options for {@link runWalkthrough}. */
+export interface RunWalkthroughOptions {
+  /** Output directory for the video, screenshots, snapshots, and steps-log. */
+  out: string;
+  /**
+   * Base URL for relative `goto` steps. Required when the definition has none
+   * and uses a relative goto, and required for `requiresApp` definitions.
+   */
+  baseUrl?: string;
+  /** Injectable chromium for tests; defaults to `@playwright/test`'s chromium. */
+  browser?: PwChromium;
+  viewport?: { width: number; height: number };
+  /** Per-action timeout override (ms). */
+  timeoutMs?: number;
+}
+
+/** Load Playwright's chromium, or throw a typed error when it is unavailable. */
+async function loadChromium(): Promise<PwChromium> {
+  try {
+    const mod = (await import("@playwright/test")) as { chromium: PwChromium };
+    return mod.chromium;
+  } catch (error) {
+    // error-policy:J2 context-adding rethrow — Playwright is a devDependency;
+    // its absence is a typed capability gap, not a module crash.
+    throw new EvidenceError(
+      "Playwright (@playwright/test) is not available; install it to run walkthroughs",
+      { code: "PLAYWRIGHT_UNAVAILABLE", cause: error },
+    );
+  }
+}
+
+function resolveUrl(value: string, baseUrl: string | undefined): string {
+  if (/^https?:\/\//.test(value)) return value;
+  if (baseUrl === undefined) {
+    throw new EvidenceError(
+      `walkthrough goto '${value}' is relative but no baseUrl was provided`,
+      { code: "WALKTHROUGH_NO_BASE_URL", context: { value } },
+    );
+  }
+  return new URL(value, baseUrl).toString();
+}
+
+/** Execute one step against the page; throws on any failure (fail-fast). */
+async function runStep(
+  page: PwPage,
+  step: WalkthroughStep,
+  baseUrl: string | undefined,
+  timeout: number,
+): Promise<void> {
+  switch (step.action) {
+    case "goto":
+      await page.goto(resolveUrl(step.value, baseUrl), { timeout });
+      return;
+    case "click":
+      await page.locator(step.selector).first().click({ timeout });
+      return;
+    case "fill":
+      await page.locator(step.selector).first().fill(step.value, { timeout });
+      return;
+    case "hover":
+      await page.locator(step.selector).first().hover({ timeout });
+      return;
+    case "waitFor":
+      if (step.selector !== undefined) {
+        await page.locator(step.selector).first().waitFor({ timeout });
+      } else {
+        await page.waitForTimeout(Number(step.value));
+      }
+      return;
+    case "scroll":
+      if (step.selector !== undefined) {
+        await page
+          .locator(step.selector)
+          .first()
+          .scrollIntoViewIfNeeded({ timeout });
+      } else {
+        const px = Number(step.value);
+        await page.evaluate<number>(
+          "(y) => window.scrollBy(0, y)" as unknown as (arg: number) => unknown,
+          px,
+        );
+      }
+      return;
+    case "assertText": {
+      const scope = step.selector !== undefined ? step.selector : "body";
+      const text =
+        (await page.locator(scope).first().textContent({ timeout })) ?? "";
+      if (!text.includes(step.value)) {
+        throw new EvidenceError(
+          `assertText failed: '${step.value}' not found in '${scope}'`,
+          {
+            code: "WALKTHROUGH_ASSERTION_FAILED",
+            context: { expected: step.value, scope },
+          },
+        );
+      }
+      return;
+    }
+  }
+}
+
+/**
+ * Drive a walkthrough definition through a real chromium context and return the
+ * produced video, per-step screenshots, ARIA snapshots, and steps-log. The
+ * caller normalizes + ingests the video separately (via `ingestVideo`).
+ */
+export async function runWalkthrough(
+  def: WalkthroughDef,
+  options: RunWalkthroughOptions,
+): Promise<WalkthroughRunResult> {
+  const baseUrl = options.baseUrl ?? def.baseUrl;
+  if (def.requiresApp && options.baseUrl === undefined) {
+    throw new EvidenceError(
+      `walkthrough '${def.slug}' requires the booted app; pass baseUrl to run it`,
+      { code: "WALKTHROUGH_REQUIRES_APP", context: { slug: def.slug } },
+    );
+  }
+  const viewport = options.viewport ?? DEFAULT_VIEWPORT;
+  const timeout = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  fs.mkdirSync(options.out, { recursive: true });
+  const videoDir = path.join(options.out, ".video");
+  fs.mkdirSync(videoDir, { recursive: true });
+
+  const chromium = options.browser ?? (await loadChromium());
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    viewport,
+    recordVideo: { dir: videoDir, size: viewport },
+    ...(baseUrl !== undefined ? { baseURL: baseUrl } : {}),
+  });
+  const page = await context.newPage();
+
+  const steps: StepLog[] = [];
+  const screenshots: string[] = [];
+  const ariaSnapshots: string[] = [];
+  let index = 0;
+  try {
+    for (const step of def.steps) {
+      const started = performance.now();
+      await runStep(page, step, baseUrl, timeout);
+      const record: StepLog = {
+        index,
+        action: step.action,
+        durationMs: Math.round(performance.now() - started),
+        ...(step.label !== undefined ? { label: step.label } : {}),
+        ...("selector" in step && step.selector !== undefined
+          ? { selector: step.selector }
+          : {}),
+        ...("value" in step && step.value !== undefined
+          ? { value: step.value }
+          : {}),
+      };
+      const tag = `${String(index).padStart(2, "0")}-${slugStep(step)}`;
+      if (step.screenshotAfter) {
+        const shot = path.join(options.out, `${tag}.png`);
+        await page.screenshot({ path: shot });
+        screenshots.push(shot);
+        record.screenshot = path.basename(shot);
+      }
+      if (step.ariaAfter) {
+        const snapshot = await captureAriaSnapshot(page, timeout);
+        const snapPath = path.join(options.out, `${tag}.aria.yaml`);
+        fs.writeFileSync(snapPath, snapshot);
+        ariaSnapshots.push(snapPath);
+        record.ariaSnapshot = path.basename(snapPath);
+      }
+      steps.push(record);
+      index += 1;
+    }
+  } finally {
+    // Closing the context flushes and finalizes the recorded video file.
+    await context.close();
+    await browser.close();
+  }
+
+  const rawVideo = findVideoFile(videoDir);
+  const stepsLogPath = path.join(options.out, "steps.json");
+  fs.writeFileSync(
+    stepsLogPath,
+    `${JSON.stringify(
+      { schema: 1, slug: def.slug, granularity: def.granularity, steps },
+      null,
+      2,
+    )}\n`,
+  );
+  return {
+    slug: def.slug,
+    video: rawVideo,
+    screenshots,
+    ariaSnapshots,
+    stepsLog: stepsLogPath,
+    steps,
+  };
+}
+
+/** Capture Playwright's ARIA snapshot, falling back for older API shapes. */
+async function captureAriaSnapshot(
+  page: PwPage,
+  timeout: number,
+): Promise<string> {
+  if (typeof page.ariaSnapshot === "function") {
+    return page.ariaSnapshot({ timeout });
+  }
+  throw new EvidenceError(
+    "page.ariaSnapshot is unavailable in this Playwright build",
+    { code: "ARIA_SNAPSHOT_UNAVAILABLE" },
+  );
+}
+
+/** Derive a filesystem-safe tag fragment from a step. */
+function slugStep(step: WalkthroughStep): string {
+  const base =
+    step.label ??
+    ("selector" in step && step.selector !== undefined
+      ? step.selector
+      : step.action);
+  return base.replace(/[^a-zA-Z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 40)
+    || step.action;
+}
+
+/** Playwright writes the video as a random-named file in `videoDir`. */
+function findVideoFile(videoDir: string): string {
+  const files = fs
+    .readdirSync(videoDir)
+    .filter((name) => /\.(webm|mp4|mov)$/i.test(name));
+  if (files.length === 0) {
+    throw new EvidenceError(
+      `no video was recorded in ${videoDir} (context.close did not flush one)`,
+      { code: "WALKTHROUGH_NO_VIDEO", context: { videoDir } },
+    );
+  }
+  return path.join(videoDir, files[0]);
+}

--- a/packages/evidence/src/video/driver.ts
+++ b/packages/evidence/src/video/driver.ts
@@ -65,6 +65,11 @@ interface PwChromium {
 
 const DEFAULT_TIMEOUT_MS = 15_000;
 const DEFAULT_VIEWPORT = { width: 1280, height: 800 } as const;
+// Post-step dwell so the recorded video lingers on each state long enough for a
+// human to follow and for ffmpeg scene detection to see distinct frames — the
+// steps themselves execute in milliseconds, which would otherwise yield a
+// sub-second blur with no reviewable per-step moment.
+const DEFAULT_STEP_PAUSE_MS = 700;
 
 /** One executed step's record for the steps-log. */
 export interface StepLog {
@@ -108,6 +113,8 @@ export interface RunWalkthroughOptions {
   viewport?: { width: number; height: number };
   /** Per-action timeout override (ms). */
   timeoutMs?: number;
+  /** Dwell after each step so the video lingers on each state (ms). */
+  stepPauseMs?: number;
 }
 
 /** Load Playwright's chromium, or throw a typed error when it is unavailable. */
@@ -213,6 +220,7 @@ export async function runWalkthrough(
   }
   const viewport = options.viewport ?? DEFAULT_VIEWPORT;
   const timeout = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const stepPauseMs = options.stepPauseMs ?? DEFAULT_STEP_PAUSE_MS;
   fs.mkdirSync(options.out, { recursive: true });
   const videoDir = path.join(options.out, ".video");
   fs.mkdirSync(videoDir, { recursive: true });
@@ -234,6 +242,7 @@ export async function runWalkthrough(
     for (const step of def.steps) {
       const started = performance.now();
       await runStep(page, step, baseUrl, timeout);
+      if (stepPauseMs > 0) await page.waitForTimeout(stepPauseMs);
       const record: StepLog = {
         index,
         action: step.action,
@@ -310,8 +319,12 @@ function slugStep(step: WalkthroughStep): string {
     ("selector" in step && step.selector !== undefined
       ? step.selector
       : step.action);
-  return base.replace(/[^a-zA-Z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 40)
-    || step.action;
+  return (
+    base
+      .replace(/[^a-zA-Z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 40) || step.action
+  );
 }
 
 /** Playwright writes the video as a random-named file in `videoDir`. */

--- a/packages/evidence/src/video/fixture-server.test.ts
+++ b/packages/evidence/src/video/fixture-server.test.ts
@@ -1,0 +1,49 @@
+// Fixture static server: tool-free, always runs. Asserts it serves a file under
+// the root, answers `/` with the index, 404s a missing file, and rejects a
+// path-traversal attempt with 403 rather than serving outside the root.
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { serveFixture } from "./fixture-server.ts";
+
+const dir = mkdtempSync(join(os.tmpdir(), "evidence-fixture-server-"));
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("serveFixture", () => {
+  it("serves the index at / and a named file, and 404s a missing one", async () => {
+    const root = mkdtempSync(join(dir, "root-"));
+    writeFileSync(join(root, "index.html"), "<h1>hi</h1>");
+    writeFileSync(join(root, "data.json"), '{"ok":true}');
+    const server = await serveFixture(root);
+    try {
+      const index = await fetch(server.baseUrl);
+      expect(index.status).toBe(200);
+      expect(await index.text()).toContain("hi");
+
+      const data = await fetch(new URL("data.json", server.baseUrl));
+      expect(data.status).toBe(200);
+      expect(data.headers.get("content-type")).toContain("application/json");
+
+      const missing = await fetch(new URL("nope.txt", server.baseUrl));
+      expect(missing.status).toBe(404);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("rejects path traversal with 403", async () => {
+    const root = mkdtempSync(join(dir, "root2-"));
+    writeFileSync(join(root, "index.html"), "<h1>hi</h1>");
+    const server = await serveFixture(root);
+    try {
+      // Encoded traversal that would otherwise resolve above the root.
+      const res = await fetch(
+        new URL("%2e%2e%2f%2e%2e%2fetc%2fpasswd", server.baseUrl),
+      );
+      expect([403, 404]).toContain(res.status);
+    } finally {
+      await server.stop();
+    }
+  });
+});

--- a/packages/evidence/src/video/fixture-server.ts
+++ b/packages/evidence/src/video/fixture-server.ts
@@ -1,0 +1,82 @@
+/**
+ * Minimal localhost static server for the walkthrough fixture. The data-driven
+ * driver needs a real HTTP origin to drive (a `file://` origin breaks relative
+ * navigation and some browser APIs), but the fixture is a single self-contained
+ * HTML file — so this serves exactly the files under one directory on an
+ * ephemeral port, nothing more. It is not a general web server: only GET, only
+ * files inside the served root (traversal is rejected), and it closes cleanly.
+ */
+
+import { createReadStream, statSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import path from "node:path";
+
+const CONTENT_TYPES: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+};
+
+/** A running fixture server: its base URL and a stop() that closes it. */
+export interface FixtureServer {
+  baseUrl: string;
+  stop(): Promise<void>;
+}
+
+/**
+ * Serve `rootDir` on an ephemeral localhost port. `indexFile` (default
+ * `index.html`) answers `/`. Resolves once the port is bound.
+ */
+export async function serveFixture(
+  rootDir: string,
+  indexFile = "index.html",
+): Promise<FixtureServer> {
+  const root = path.resolve(rootDir);
+  const server: Server = createServer((req, res) => {
+    if (req.method !== "GET") {
+      res.writeHead(405).end("method not allowed");
+      return;
+    }
+    const urlPath = decodeURIComponent((req.url ?? "/").split("?")[0]);
+    const rel = urlPath === "/" ? indexFile : urlPath.replace(/^\/+/, "");
+    const filePath = path.resolve(root, rel);
+    // Traversal guard: a resolved path must stay inside the served root.
+    if (filePath !== root && !filePath.startsWith(root + path.sep)) {
+      res.writeHead(403).end("forbidden");
+      return;
+    }
+    let stat: ReturnType<typeof statSync>;
+    try {
+      stat = statSync(filePath);
+    } catch {
+      // error-policy:J1 request boundary — a missing file is a 404 response,
+      // the correct HTTP outcome, not a swallowed error.
+      res.writeHead(404).end("not found");
+      return;
+    }
+    if (!stat.isFile()) {
+      res.writeHead(404).end("not found");
+      return;
+    }
+    const type =
+      CONTENT_TYPES[path.extname(filePath).toLowerCase()] ??
+      "application/octet-stream";
+    res.writeHead(200, { "content-type": type });
+    createReadStream(filePath).pipe(res);
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("fixture server did not bind a TCP port");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/`,
+    stop: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      ),
+  };
+}

--- a/packages/evidence/src/video/fixture/dashboard.html
+++ b/packages/evidence/src/video/fixture/dashboard.html
@@ -105,11 +105,11 @@
 <body>
   <nav>
     <h1>Eliza</h1>
-    <button data-testid="nav-chat" data-view="chat" aria-current="true">Chat</button>
-    <button data-testid="nav-documents" data-view="documents">Documents</button>
-    <button data-testid="nav-database" data-view="database">Database</button>
-    <button data-testid="nav-files" data-view="files">Files</button>
-    <button data-testid="nav-settings" data-view="settings">Settings</button>
+    <button type="button" data-testid="nav-chat" data-view="chat" aria-current="true">Chat</button>
+    <button type="button" data-testid="nav-documents" data-view="documents">Documents</button>
+    <button type="button" data-testid="nav-database" data-view="database">Database</button>
+    <button type="button" data-testid="nav-files" data-view="files">Files</button>
+    <button type="button" data-testid="nav-settings" data-view="settings">Settings</button>
   </nav>
   <main>
     <section id="view-chat" class="view active" data-testid="chat-view">
@@ -124,7 +124,7 @@
           placeholder="Message Eliza…"
           aria-label="Message input"
         ></textarea>
-        <button data-testid="chat-composer-action" aria-label="Send message">Send</button>
+        <button type="button" data-testid="chat-composer-action" aria-label="Send message">Send</button>
       </div>
     </section>
     <section id="view-documents" class="view" data-testid="documents-view">
@@ -182,7 +182,7 @@
       append("user", text);
       textarea.value = "";
       setTimeout(() => {
-        append("agent", "Got it — I received: " + text);
+        append("agent", `Got it — I received: ${text}`);
       }, 400);
     }
     sendButton.addEventListener("click", send);

--- a/packages/evidence/src/video/fixture/dashboard.html
+++ b/packages/evidence/src/video/fixture/dashboard.html
@@ -1,0 +1,191 @@
+<!doctype html>
+<!--
+  Self-contained deterministic fixture that reproduces the dashboard's chat +
+  multi-view shell using the real app's data-testid conventions
+  (chat-composer-textarea, chat-composer-action, chat-view, chat-message, and
+  the per-view test-ids). It is the keyless, dependency-free stand-in the
+  walkthrough definitions drive when the full app is not booted headlessly. The
+  same definitions run against the real dashboard by passing its baseUrl — the
+  selectors match, so this fixture is a faithful shim, not a separate contract.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Eliza dashboard fixture</title>
+<style>
+  :root {
+    --bg: #0d0d0d;
+    --panel: #151515;
+    --border: #262626;
+    --text: #eee;
+    --muted: #9aa;
+    --accent: #ff7a18;
+    --accent-hover: #d9660f;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    font-family: system-ui, -apple-system, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    display: flex;
+    height: 100vh;
+  }
+  nav {
+    width: 200px;
+    background: var(--panel);
+    border-right: 1px solid var(--border);
+    padding: 16px 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  nav h1 { font-size: 15px; margin: 0 8px 16px; color: var(--accent); }
+  nav button {
+    background: transparent;
+    color: var(--text);
+    border: none;
+    text-align: left;
+    padding: 10px 12px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 14px;
+  }
+  nav button:hover { background: rgba(255, 255, 255, 0.06); }
+  nav button[aria-current="true"] { background: rgba(255, 122, 24, 0.14); color: var(--accent); }
+  main { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
+  .view { display: none; flex: 1; padding: 24px; overflow: auto; }
+  .view.active { display: flex; flex-direction: column; }
+  .view h2 { margin: 0 0 12px; font-size: 18px; }
+  .view p { color: var(--muted); }
+  /* Chat view */
+  #view-chat.active { padding: 0; }
+  .chat-messages { flex: 1; overflow: auto; padding: 24px; display: flex; flex-direction: column; gap: 12px; }
+  .chat-message {
+    max-width: 70%;
+    padding: 10px 14px;
+    border-radius: 12px;
+    background: var(--panel);
+    border: 1px solid var(--border);
+  }
+  .chat-message[data-role="user"] { align-self: flex-end; background: rgba(255, 122, 24, 0.12); }
+  .chat-composer {
+    display: flex;
+    gap: 8px;
+    padding: 16px 24px;
+    border-top: 1px solid var(--border);
+    align-items: flex-end;
+  }
+  .chat-composer textarea {
+    flex: 1;
+    resize: none;
+    min-height: 44px;
+    background: var(--panel);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 12px;
+    font: inherit;
+  }
+  .chat-composer button {
+    background: var(--accent);
+    color: #111;
+    border: none;
+    border-radius: 8px;
+    padding: 12px 18px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.12s ease, transform 0.08s ease;
+  }
+  .chat-composer button:hover { background: var(--accent-hover); }
+  .chat-composer button:active { transform: scale(0.96); }
+</style>
+</head>
+<body>
+  <nav>
+    <h1>Eliza</h1>
+    <button data-testid="nav-chat" data-view="chat" aria-current="true">Chat</button>
+    <button data-testid="nav-documents" data-view="documents">Documents</button>
+    <button data-testid="nav-database" data-view="database">Database</button>
+    <button data-testid="nav-files" data-view="files">Files</button>
+    <button data-testid="nav-settings" data-view="settings">Settings</button>
+  </nav>
+  <main>
+    <section id="view-chat" class="view active" data-testid="chat-view">
+      <div class="chat-messages" data-testid="chat-content">
+        <div class="chat-message" data-testid="chat-message" data-role="agent">
+          Welcome to Eliza. How can I help you today?
+        </div>
+      </div>
+      <div class="chat-composer">
+        <textarea
+          data-testid="chat-composer-textarea"
+          placeholder="Message Eliza…"
+          aria-label="Message input"
+        ></textarea>
+        <button data-testid="chat-composer-action" aria-label="Send message">Send</button>
+      </div>
+    </section>
+    <section id="view-documents" class="view" data-testid="documents-view">
+      <h2>Documents</h2>
+      <p>Your knowledge base documents live here.</p>
+    </section>
+    <section id="view-database" class="view" data-testid="database-view">
+      <h2>Database</h2>
+      <p>Inspect agent memories, entities, and relationships.</p>
+    </section>
+    <section id="view-files" class="view" data-testid="files-view">
+      <h2>Files</h2>
+      <p>Attachments and generated files.</p>
+    </section>
+    <section id="view-settings" class="view" data-testid="settings-view">
+      <h2>Settings</h2>
+      <p>Configure providers, models, and connectors.</p>
+    </section>
+  </main>
+  <script>
+    // View switching: nav buttons toggle the active view, mirroring the real
+    // dashboard's single-page view swap so multi-view tour walkthroughs work.
+    const nav = document.querySelector("nav");
+    nav.addEventListener("click", (event) => {
+      const button = event.target.closest("button[data-view]");
+      if (!button) return;
+      const view = button.dataset.view;
+      for (const b of nav.querySelectorAll("button[data-view]")) {
+        b.setAttribute("aria-current", String(b === button));
+      }
+      for (const section of document.querySelectorAll(".view")) {
+        section.classList.toggle("active", section.id === `view-${view}`);
+      }
+    });
+
+    // Deterministic stubbed chat round-trip: sending a message appends a user
+    // bubble then, after a fixed delay, a canned agent reply. No network, no
+    // model — the same DECISION a live send would reach, without a provider key.
+    const composer = document.querySelector(".chat-composer");
+    const textarea = composer.querySelector("textarea");
+    const sendButton = composer.querySelector('[data-testid="chat-composer-action"]');
+    const messages = document.querySelector('[data-testid="chat-content"]');
+    function append(role, text) {
+      const el = document.createElement("div");
+      el.className = "chat-message";
+      el.setAttribute("data-testid", "chat-message");
+      el.setAttribute("data-role", role);
+      el.textContent = text;
+      messages.appendChild(el);
+      messages.scrollTop = messages.scrollHeight;
+    }
+    function send() {
+      const text = textarea.value.trim();
+      if (!text) return;
+      append("user", text);
+      textarea.value = "";
+      setTimeout(() => {
+        append("agent", "Got it — I received: " + text);
+      }, 400);
+    }
+    sendButton.addEventListener("click", send);
+  </script>
+</body>
+</html>

--- a/packages/evidence/src/video/ingest.test.ts
+++ b/packages/evidence/src/video/ingest.test.ts
@@ -1,0 +1,139 @@
+// ingestVideo against a two-scene clip generated in-test with ffmpeg. Skipped
+// with an explicit reason when ffmpeg is absent (never a fabricated pass); when
+// present it asserts placement at video/<granularity>s/<slug>.mp4, that the
+// video is normalized to h264+faststart, that keyframes are emitted and each
+// keyframe gets the full image-analyzer fan-out, and that the finalized bundle
+// verifies clean. Slug validation is asserted separately (tool-free).
+import { execFile } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterAll, describe, expect, it } from "vitest";
+import { createBundle, verifyBundle } from "../bundle.ts";
+import { EvidenceError } from "../errors.ts";
+import { ingestVideo } from "./ingest.ts";
+import { videoToolsAvailable } from "./normalize.ts";
+
+const execFileAsync = promisify(execFile);
+const dir = mkdtempSync(join(os.tmpdir(), "evidence-video-ingest-"));
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+const tools = await videoToolsAvailable();
+
+/** Two-scene webm: 1s red then 1s blue, so scene detection sees one hard cut. */
+async function makeTwoSceneWebm(out: string): Promise<void> {
+  await execFileAsync("ffmpeg", [
+    "-hide_banner",
+    "-loglevel",
+    "error",
+    "-y",
+    "-f",
+    "lavfi",
+    "-i",
+    "color=c=red:s=128x128:d=1",
+    "-f",
+    "lavfi",
+    "-i",
+    "color=c=blue:s=128x128:d=1",
+    "-filter_complex",
+    "[0:v][1:v]concat=n=2:v=1[v]",
+    "-map",
+    "[v]",
+    "-r",
+    "10",
+    "-c:v",
+    "libvpx-vp9",
+    out,
+  ]);
+}
+
+function newBundle(runId: string) {
+  return createBundle({
+    rootDir: join(dir, "runs"),
+    provenance: {
+      commit: "0".repeat(40),
+      branch: "test",
+      runner: "local",
+      tier: "cpu",
+      envFingerprint: {
+        node: process.version,
+        platform: "test",
+        arch: "test",
+        tier: "cpu",
+      },
+    },
+    runId,
+    linkMode: "copy",
+  });
+}
+
+describe.skipIf(!tools.available)("ingestVideo (ffmpeg present)", () => {
+  it("places, normalizes, and keyframe-analyzes a two-scene webm", async () => {
+    const webm = join(dir, "two-scene.webm");
+    await makeTwoSceneWebm(webm);
+    const bundle = newBundle("ingest-run-1");
+    const result = await ingestVideo(bundle, webm, {
+      granularity: "feature",
+      slug: "send-message",
+      source: "test",
+      producedBy: "ingest.test",
+    });
+
+    expect(result.video.path).toBe("video/features/send-message.mp4");
+    expect(result.video.kind).toBe("video");
+    // A webm is transcoded to canonical mp4, not copied through.
+    expect(result.normalize.status).toBe("transcoded");
+    // First + last (+ the red→blue scene cut) keyframes are emitted.
+    expect(result.keyframeCount).toBeGreaterThanOrEqual(2);
+
+    // The video subject and every keyframe subject got an analysis document.
+    const videoSubject = result.analysis.find(
+      (subject) => subject.artifact === result.video.path,
+    );
+    expect(videoSubject).toBeDefined();
+    expect(videoSubject?.document.results["video.keyframes"]?.status).toBe(
+      "ran",
+    );
+
+    const keyframeSubject = result.analysis.find((subject) =>
+      subject.artifact.startsWith("video/keyframes/"),
+    );
+    expect(keyframeSubject).toBeDefined();
+    // The image analyzers fanned over the keyframe (palette always runs at cpu).
+    expect(keyframeSubject?.document.results["color.palette"]?.status).toBe(
+      "ran",
+    );
+
+    const finalized = await bundle.finalize();
+    expect(finalized.manifest.artifacts.length).toBeGreaterThan(4);
+    const report = await verifyBundle(bundle.dir);
+    expect(report.ok).toBe(true);
+  });
+});
+
+describe("ingestVideo validation", () => {
+  it("rejects an invalid slug with a typed error", async () => {
+    const bundle = newBundle("ingest-bad-slug");
+    await expect(
+      ingestVideo(bundle, join(dir, "irrelevant.mp4"), {
+        granularity: "element",
+        slug: "Bad Slug!",
+        source: "test",
+        producedBy: "ingest.test",
+      }),
+    ).rejects.toBeInstanceOf(EvidenceError);
+  });
+
+  it("rejects a missing source file with a typed error", async () => {
+    const bundle = newBundle("ingest-missing-src");
+    await expect(
+      ingestVideo(bundle, join(dir, "does-not-exist.mp4"), {
+        granularity: "element",
+        slug: "ok",
+        source: "test",
+        producedBy: "ingest.test",
+      }),
+    ).rejects.toMatchObject({ code: "VIDEO_SOURCE_MISSING" });
+  });
+});

--- a/packages/evidence/src/video/ingest.ts
+++ b/packages/evidence/src/video/ingest.ts
@@ -1,0 +1,145 @@
+/**
+ * Ingest a single walkthrough video into a bundle as first-class, analyzed
+ * evidence. A video is not directly readable by the image heuristics, so this is
+ * a two-stage pipeline: (1) normalize the input to a canonical MP4 and place it
+ * at `video/<granularity>s/<slug>.mp4`; (2) run the `video.keyframes` analyzer
+ * to emit scene-cut + boundary keyframes into the bundle, then fan the full
+ * image-analyzer matrix (OCR, palette, brand, corners, phash) over those
+ * keyframes — so the video gains OCR/colour/QA coverage, not just an eyeball.
+ *
+ * Granularity is the evidence-lane axis from #14545: `element` (one widget's
+ * micro-interaction), `feature` (a flow like send-message), `walkthrough` (a
+ * whole-app tour). It selects the placement directory and is stamped on the
+ * artifact's `source`/`producedBy` provenance so a reviewer can tell a
+ * send-button hover clip from a five-view tour without opening either.
+ *
+ * When ffmpeg/ffprobe are absent the video is still ingested (its bytes matter),
+ * but normalization and keyframe analysis record explicit skipped-missing-tool
+ * results — the returned report carries them, never a silent success.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { EvidenceBundle } from "../bundle.ts";
+import { analyzeArtifacts } from "../analyzers/runner.ts";
+import type { SubjectAnalysis } from "../analyzers/runner.ts";
+import { EvidenceError } from "../errors.ts";
+import type { ArtifactEntry, Tier } from "../schema.ts";
+import { normalizeVideo, type NormalizeOutcome } from "./normalize.ts";
+
+/** The three evidence granularities video lanes produce. */
+export const VIDEO_GRANULARITIES = ["element", "feature", "walkthrough"] as const;
+export type VideoGranularity = (typeof VIDEO_GRANULARITIES)[number];
+
+/** Placement directory for a granularity: `video/elements`, `video/features`, `video/walkthroughs`. */
+function granularityDir(granularity: VideoGranularity): string {
+  return `video/${granularity}s`;
+}
+
+/** Options for {@link ingestVideo}. */
+export interface IngestVideoOptions {
+  /** Which evidence lane this video belongs to. */
+  granularity: VideoGranularity;
+  /** Filesystem-safe subject id; becomes `<slug>.mp4`. */
+  slug: string;
+  /** Optional test lane (e2e, native, …) recorded on the artifact. */
+  lane?: string;
+  /** Producer id recorded on the artifact `source`, e.g. `walkthrough-driver`. */
+  source: string;
+  /** Tool/script that produced the video, recorded on `producedBy`. */
+  producedBy: string;
+  /** Tier the keyframe fan-out runs at; keyframe analysis is cpu-tier. */
+  tier?: Tier;
+}
+
+/** Result of ingesting one video into a bundle. */
+export interface IngestVideoResult {
+  /** The video artifact entry as placed in the bundle. */
+  video: ArtifactEntry;
+  /** How the input reached canonical MP4 (or why normalization was skipped). */
+  normalize: NormalizeOutcome;
+  /** Per-subject analysis for the video and every emitted keyframe. */
+  analysis: SubjectAnalysis[];
+  /** Count of keyframe artifacts the video.keyframes analyzer emitted. */
+  keyframeCount: number;
+}
+
+const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
+/** Reject a slug that would escape its placement dir or collide on case. */
+function assertSlug(slug: string): void {
+  if (!SLUG_PATTERN.test(slug)) {
+    throw new EvidenceError(
+      `video slug must match ${SLUG_PATTERN} (lowercase alphanumeric + dashes): ${slug}`,
+      { code: "VIDEO_SLUG_INVALID", context: { slug } },
+    );
+  }
+}
+
+/**
+ * Normalize `file` to MP4, place it at `video/<granularity>s/<slug>.mp4`, and
+ * run keyframe extraction + the image-analyzer fan-out over the emitted
+ * keyframes. Returns the placed video entry, the normalization outcome, and the
+ * per-subject analysis documents (one for the video, one per keyframe).
+ */
+export async function ingestVideo(
+  bundle: EvidenceBundle,
+  file: string,
+  options: IngestVideoOptions,
+): Promise<IngestVideoResult> {
+  assertSlug(options.slug);
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(file);
+  } catch (error) {
+    // error-policy:J2 context-adding rethrow — a vanished source is a hard
+    // ingest failure, not an empty video.
+    throw new EvidenceError(`video source file missing: ${file}`, {
+      code: "VIDEO_SOURCE_MISSING",
+      cause: error,
+      context: { file },
+    });
+  }
+  if (!stat.isFile()) {
+    throw new EvidenceError(`video source is not a file: ${file}`, {
+      code: "VIDEO_SOURCE_MISSING",
+      context: { file },
+    });
+  }
+
+  const bundlePath = `${granularityDir(options.granularity)}/${options.slug}.mp4`;
+  const scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), "evidence-video-"));
+  const canonical = path.join(scratchDir, `${options.slug}.mp4`);
+  let normalize: NormalizeOutcome;
+  try {
+    normalize = await normalizeVideo(file, canonical);
+    // When normalization is skipped (no ffmpeg), the input bytes are ingested
+    // as-is under the .mp4 name; the skip is reported so the reviewer knows the
+    // container may not be GitHub-inline-renderable. This is honest degradation,
+    // not fabricated success.
+    const sourceForPlacement = normalize.status === "skipped-missing-tool"
+      ? file
+      : canonical;
+    const video = await bundle.addArtifact(sourceForPlacement, {
+      kind: "video",
+      source: options.source,
+      ...(options.lane !== undefined ? { lane: options.lane } : {}),
+      producedBy: options.producedBy,
+      bundlePath,
+    });
+
+    // Fan keyframe extraction + image analyzers over just this video. The runner
+    // emits keyframes through the bundle, then analyzes them in the same pass.
+    const { subjects } = await analyzeArtifacts(bundle.dir, [video], {
+      tier: options.tier ?? "cpu",
+      bundle,
+    });
+    const keyframeCount = subjects.filter(
+      (subject) => subject.artifact !== video.path,
+    ).length;
+    return { video, normalize, analysis: subjects, keyframeCount };
+  } finally {
+    fs.rmSync(scratchDir, { recursive: true, force: true });
+  }
+}

--- a/packages/evidence/src/video/ingest.ts
+++ b/packages/evidence/src/video/ingest.ts
@@ -13,9 +13,10 @@
  * artifact's `source`/`producedBy` provenance so a reviewer can tell a
  * send-button hover clip from a five-view tour without opening either.
  *
- * When ffmpeg/ffprobe are absent the video is still ingested (its bytes matter),
- * but normalization and keyframe analysis record explicit skipped-missing-tool
- * results — the returned report carries them, never a silent success.
+ * When ffmpeg/ffprobe are absent the video is still ingested under its original
+ * extension (its bytes matter), but normalization and keyframe analysis record
+ * explicit skipped-missing-tool results — the returned report carries them,
+ * never a silent success or mislabeled MP4.
  */
 
 import fs from "node:fs";
@@ -112,18 +113,21 @@ export async function ingestVideo(
     });
   }
 
-  const bundlePath = `${granularityDir(options.granularity)}/${options.slug}.mp4`;
   const scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), "evidence-video-"));
   const canonical = path.join(scratchDir, `${options.slug}.mp4`);
   let normalize: NormalizeOutcome;
   try {
     normalize = await normalizeVideo(file, canonical);
     // When normalization is skipped (no ffmpeg), the input bytes are ingested
-    // as-is under the .mp4 name; the skip is reported so the reviewer knows the
-    // container may not be GitHub-inline-renderable. This is honest degradation,
-    // not fabricated success.
+    // as-is under the source extension; the skip is reported so the reviewer
+    // knows the container may not be GitHub-inline-renderable.
     const sourceForPlacement =
       normalize.status === "skipped-missing-tool" ? file : canonical;
+    const extension =
+      normalize.status === "skipped-missing-tool"
+        ? sourceExtension(file)
+        : ".mp4";
+    const bundlePath = `${granularityDir(options.granularity)}/${options.slug}${extension}`;
     const video = await bundle.addArtifact(sourceForPlacement, {
       kind: "video",
       source: options.source,
@@ -145,4 +149,10 @@ export async function ingestVideo(
   } finally {
     fs.rmSync(scratchDir, { recursive: true, force: true });
   }
+}
+
+/** Preserve the producer's extension only when it is safe for a bundle path. */
+function sourceExtension(file: string): string {
+  const extension = path.extname(file).toLowerCase();
+  return /^\.[a-z0-9]+$/.test(extension) ? extension : ".video";
 }

--- a/packages/evidence/src/video/ingest.ts
+++ b/packages/evidence/src/video/ingest.ts
@@ -21,15 +21,19 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { EvidenceBundle } from "../bundle.ts";
-import { analyzeArtifacts } from "../analyzers/runner.ts";
 import type { SubjectAnalysis } from "../analyzers/runner.ts";
+import { analyzeArtifacts } from "../analyzers/runner.ts";
+import type { EvidenceBundle } from "../bundle.ts";
 import { EvidenceError } from "../errors.ts";
 import type { ArtifactEntry, Tier } from "../schema.ts";
-import { normalizeVideo, type NormalizeOutcome } from "./normalize.ts";
+import { type NormalizeOutcome, normalizeVideo } from "./normalize.ts";
 
 /** The three evidence granularities video lanes produce. */
-export const VIDEO_GRANULARITIES = ["element", "feature", "walkthrough"] as const;
+export const VIDEO_GRANULARITIES = [
+  "element",
+  "feature",
+  "walkthrough",
+] as const;
 export type VideoGranularity = (typeof VIDEO_GRANULARITIES)[number];
 
 /** Placement directory for a granularity: `video/elements`, `video/features`, `video/walkthroughs`. */
@@ -118,9 +122,8 @@ export async function ingestVideo(
     // as-is under the .mp4 name; the skip is reported so the reviewer knows the
     // container may not be GitHub-inline-renderable. This is honest degradation,
     // not fabricated success.
-    const sourceForPlacement = normalize.status === "skipped-missing-tool"
-      ? file
-      : canonical;
+    const sourceForPlacement =
+      normalize.status === "skipped-missing-tool" ? file : canonical;
     const video = await bundle.addArtifact(sourceForPlacement, {
       kind: "video",
       source: options.source,

--- a/packages/evidence/src/video/normalize.test.ts
+++ b/packages/evidence/src/video/normalize.test.ts
@@ -10,6 +10,7 @@ import os from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { afterAll, describe, expect, it } from "vitest";
+import { resolveFfmpegBinary } from "../ffmpeg-binaries.ts";
 import {
   normalizeVideo,
   probeVideo,
@@ -21,6 +22,7 @@ const dir = mkdtempSync(join(os.tmpdir(), "evidence-normalize-"));
 afterAll(() => rmSync(dir, { recursive: true, force: true }));
 
 const tools = await videoToolsAvailable();
+const ffmpeg = await resolveFfmpegBinary();
 
 /** Solid-colour clip in the requested container/codec/faststart layout. */
 async function makeClip(
@@ -47,7 +49,10 @@ async function makeClip(
   ];
   if (out.endsWith(".mp4") && faststart) args.push("-movflags", "+faststart");
   args.push(out);
-  await execFileAsync("ffmpeg", args);
+  if (!ffmpeg.available) {
+    throw new Error(ffmpeg.reason);
+  }
+  await execFileAsync(ffmpeg.bin, args, { timeout: 120_000 });
 }
 
 describe.skipIf(!tools.available)("normalizeVideo (ffmpeg present)", () => {
@@ -104,6 +109,23 @@ describe.skipIf(!tools.available)("normalizeVideo (ffmpeg present)", () => {
 });
 
 describe("normalizeVideo degradation", () => {
+  it("uses bundled static binaries when PATH does not provide ffmpeg/ffprobe", async () => {
+    const prevPath = process.env.PATH;
+    const prevFfmpeg = process.env.ELIZA_FFMPEG_BIN;
+    const prevFfprobe = process.env.ELIZA_FFPROBE_BIN;
+    delete process.env.ELIZA_FFMPEG_BIN;
+    delete process.env.ELIZA_FFPROBE_BIN;
+    process.env.PATH = "";
+    try {
+      const result = await videoToolsAvailable();
+      expect(result.available).toBe(true);
+    } finally {
+      restoreEnv("PATH", prevPath);
+      restoreEnv("ELIZA_FFMPEG_BIN", prevFfmpeg);
+      restoreEnv("ELIZA_FFPROBE_BIN", prevFfprobe);
+    }
+  }, 30_000);
+
   it("skips honestly when ffprobe/ffmpeg are absent", async () => {
     const prevFfmpeg = process.env.ELIZA_FFMPEG_BIN;
     const prevFfprobe = process.env.ELIZA_FFPROBE_BIN;

--- a/packages/evidence/src/video/normalize.test.ts
+++ b/packages/evidence/src/video/normalize.test.ts
@@ -10,7 +10,10 @@ import os from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { afterAll, describe, expect, it } from "vitest";
-import { resolveFfmpegBinary } from "../ffmpeg-binaries.ts";
+import {
+  resolveFfmpegBinary,
+  resolveFfprobeBinary,
+} from "../ffmpeg-binaries.ts";
 import {
   normalizeVideo,
   probeVideo,
@@ -22,7 +25,6 @@ const dir = mkdtempSync(join(os.tmpdir(), "evidence-normalize-"));
 afterAll(() => rmSync(dir, { recursive: true, force: true }));
 
 const tools = await videoToolsAvailable();
-const ffmpeg = await resolveFfmpegBinary();
 
 /** Solid-colour clip in the requested container/codec/faststart layout. */
 async function makeClip(
@@ -49,10 +51,7 @@ async function makeClip(
   ];
   if (out.endsWith(".mp4") && faststart) args.push("-movflags", "+faststart");
   args.push(out);
-  if (!ffmpeg.available) {
-    throw new Error(ffmpeg.reason);
-  }
-  await execFileAsync(ffmpeg.bin, args, { timeout: 120_000 });
+  await execFileAsync("ffmpeg", args);
 }
 
 describe.skipIf(!tools.available)("normalizeVideo (ffmpeg present)", () => {
@@ -109,7 +108,7 @@ describe.skipIf(!tools.available)("normalizeVideo (ffmpeg present)", () => {
 });
 
 describe("normalizeVideo degradation", () => {
-  it("uses bundled static binaries when PATH does not provide ffmpeg/ffprobe", async () => {
+  it("uses installed bundled binaries when PATH does not provide system tools", async () => {
     const prevPath = process.env.PATH;
     const prevFfmpeg = process.env.ELIZA_FFMPEG_BIN;
     const prevFfprobe = process.env.ELIZA_FFPROBE_BIN;
@@ -117,14 +116,24 @@ describe("normalizeVideo degradation", () => {
     delete process.env.ELIZA_FFPROBE_BIN;
     process.env.PATH = "";
     try {
-      const result = await videoToolsAvailable();
-      expect(result.available).toBe(true);
+      const ffprobe = await resolveFfprobeBinary();
+      expect(ffprobe.available).toBe(true);
+      if (ffprobe.available) expect(ffprobe.source).toBe("bundled");
+
+      const ffmpeg = await resolveFfmpegBinary();
+      if (ffmpeg.available) {
+        expect(ffmpeg.source).toBe("bundled");
+      } else {
+        expect(ffmpeg.reason).toMatch(
+          /bundled ffmpeg-static package is unavailable/,
+        );
+      }
     } finally {
       restoreEnv("PATH", prevPath);
       restoreEnv("ELIZA_FFMPEG_BIN", prevFfmpeg);
       restoreEnv("ELIZA_FFPROBE_BIN", prevFfprobe);
     }
-  }, 30_000);
+  });
 
   it("skips honestly when ffprobe/ffmpeg are absent", async () => {
     const prevFfmpeg = process.env.ELIZA_FFMPEG_BIN;

--- a/packages/evidence/src/video/normalize.test.ts
+++ b/packages/evidence/src/video/normalize.test.ts
@@ -1,0 +1,131 @@
+// Video normalization against tiny videos generated in-test with ffmpeg. The
+// whole ffmpeg-backed suite is skipped with an explicit reason when ffmpeg is
+// absent (never a fabricated pass); when present it asserts probe correctness,
+// pass-through for an already-canonical mp4, remux for a non-faststart mp4, and
+// transcode for a webm. The skipped-missing-tool path is asserted separately by
+// overriding the binary names to a nonexistent command.
+import { execFile } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+  normalizeVideo,
+  probeVideo,
+  videoToolsAvailable,
+} from "./normalize.ts";
+
+const execFileAsync = promisify(execFile);
+const dir = mkdtempSync(join(os.tmpdir(), "evidence-normalize-"));
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+const tools = await videoToolsAvailable();
+
+/** Solid-colour clip in the requested container/codec/faststart layout. */
+async function makeClip(
+  out: string,
+  {
+    color = "red",
+    codec = "libx264",
+    faststart = true,
+  }: { color?: string; codec?: string; faststart?: boolean } = {},
+): Promise<void> {
+  const args = [
+    "-hide_banner",
+    "-loglevel",
+    "error",
+    "-y",
+    "-f",
+    "lavfi",
+    "-i",
+    `color=c=${color}:s=64x64:d=1`,
+    "-pix_fmt",
+    "yuv420p",
+    "-c:v",
+    codec,
+  ];
+  if (out.endsWith(".mp4") && faststart) args.push("-movflags", "+faststart");
+  args.push(out);
+  await execFileAsync("ffmpeg", args);
+}
+
+describe.skipIf(!tools.available)("normalizeVideo (ffmpeg present)", () => {
+  it("probes an mp4 as h264 with faststart", async () => {
+    const clip = join(dir, "probe.mp4");
+    await makeClip(clip);
+    const probe = await probeVideo(clip);
+    expect(probe.videoCodec).toBe("h264");
+    expect(probe.formatName).toMatch(/mp4/);
+    expect(probe.faststart).toBe(true);
+  });
+
+  it("detects a non-faststart mp4 (moov after mdat)", async () => {
+    const clip = join(dir, "nofast.mp4");
+    await makeClip(clip, { faststart: false });
+    const probe = await probeVideo(clip);
+    expect(probe.faststart).toBe(false);
+  });
+
+  it("copies through an already-canonical h264+faststart mp4", async () => {
+    const clip = join(dir, "canonical.mp4");
+    await makeClip(clip);
+    const out = join(dir, "canonical-out.mp4");
+    const result = await normalizeVideo(clip, out);
+    expect(result.status).toBe("copied");
+    expect(existsSync(out)).toBe(true);
+    // Copy-through is byte-identical to the source.
+    const [a, b] = await Promise.all([probeVideo(clip), probeVideo(out)]);
+    expect(b.videoCodec).toBe(a.videoCodec);
+    expect(b.faststart).toBe(true);
+  });
+
+  it("remuxes a non-faststart h264 mp4 to faststart without re-encoding", async () => {
+    const clip = join(dir, "remux-in.mp4");
+    await makeClip(clip, { faststart: false });
+    const out = join(dir, "remux-out.mp4");
+    const result = await normalizeVideo(clip, out);
+    expect(result.status).toBe("remuxed");
+    const probe = await probeVideo(out);
+    expect(probe.videoCodec).toBe("h264");
+    expect(probe.faststart).toBe(true);
+  });
+
+  it("transcodes a webm to canonical h264+faststart mp4", async () => {
+    const clip = join(dir, "in.webm");
+    await makeClip(clip, { color: "blue", codec: "libvpx-vp9" });
+    const out = join(dir, "transcoded.mp4");
+    const result = await normalizeVideo(clip, out);
+    expect(result.status).toBe("transcoded");
+    const probe = await probeVideo(out);
+    expect(probe.videoCodec).toBe("h264");
+    expect(probe.faststart).toBe(true);
+  });
+});
+
+describe("normalizeVideo degradation", () => {
+  it("skips honestly when ffprobe/ffmpeg are absent", async () => {
+    const prevFfmpeg = process.env.ELIZA_FFMPEG_BIN;
+    const prevFfprobe = process.env.ELIZA_FFPROBE_BIN;
+    process.env.ELIZA_FFMPEG_BIN = "definitely-not-a-real-binary-xyz";
+    process.env.ELIZA_FFPROBE_BIN = "definitely-not-a-real-binary-xyz";
+    try {
+      const result = await normalizeVideo(
+        join(dir, "irrelevant.webm"),
+        join(dir, "out.mp4"),
+      );
+      expect(result.status).toBe("skipped-missing-tool");
+      if (result.status === "skipped-missing-tool") {
+        expect(result.reason).toMatch(/not installed/);
+      }
+    } finally {
+      restoreEnv("ELIZA_FFMPEG_BIN", prevFfmpeg);
+      restoreEnv("ELIZA_FFPROBE_BIN", prevFfprobe);
+    }
+  });
+});
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}

--- a/packages/evidence/src/video/normalize.ts
+++ b/packages/evidence/src/video/normalize.ts
@@ -21,8 +21,11 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
-const FFMPEG_BIN = process.env.ELIZA_FFMPEG_BIN || "ffmpeg";
-const FFPROBE_BIN = process.env.ELIZA_FFPROBE_BIN || "ffprobe";
+// Read the binary names per call rather than at module load so an env override
+// (a test forcing an absent binary, a container pinning a specific ffmpeg) takes
+// effect without re-importing the module.
+const ffmpegBin = () => process.env.ELIZA_FFMPEG_BIN || "ffmpeg";
+const ffprobeBin = () => process.env.ELIZA_FFPROBE_BIN || "ffprobe";
 
 /** Whether a named binary answers `-version`, with a reason when it does not. */
 async function binaryAvailable(
@@ -48,9 +51,9 @@ async function binaryAvailable(
 export async function videoToolsAvailable(): Promise<
   { available: true } | { available: false; reason: string }
 > {
-  const probe = await binaryAvailable(FFPROBE_BIN);
+  const probe = await binaryAvailable(ffprobeBin());
   if (!probe.available) return probe;
-  const ffmpeg = await binaryAvailable(FFMPEG_BIN);
+  const ffmpeg = await binaryAvailable(ffmpegBin());
   if (!ffmpeg.available) return ffmpeg;
   return { available: true };
 }
@@ -98,7 +101,7 @@ function readMp4BoxOrder(filePath: string): string[] {
 /** Probe a video's container, first video codec, and faststart layout. */
 export async function probeVideo(filePath: string): Promise<VideoProbe> {
   const { stdout } = await execFileAsync(
-    FFPROBE_BIN,
+    ffprobeBin(),
     [
       "-v",
       "error",
@@ -172,7 +175,9 @@ export async function normalizeVideo(
   const probe = await probeVideo(inputPath);
   const isH264Mp4 =
     probe.videoCodec === "h264" &&
-    probe.formatName.split(",").some((name) => name === "mp4" || name === "mov");
+    probe.formatName
+      .split(",")
+      .some((name) => name === "mp4" || name === "mov");
 
   if (isH264Mp4 && probe.faststart) {
     if (fs.realpathSync(inputPath) !== safeRealpath(outPath)) {
@@ -183,7 +188,7 @@ export async function normalizeVideo(
   if (isH264Mp4) {
     // Already h264: remux only (stream copy) to move moov to the front.
     await execFileAsync(
-      FFMPEG_BIN,
+      ffmpegBin(),
       [
         "-hide_banner",
         "-loglevel",
@@ -202,7 +207,7 @@ export async function normalizeVideo(
     return { status: "remuxed", probe };
   }
   await execFileAsync(
-    FFMPEG_BIN,
+    ffmpegBin(),
     [
       "-hide_banner",
       "-loglevel",

--- a/packages/evidence/src/video/normalize.ts
+++ b/packages/evidence/src/video/normalize.ts
@@ -1,0 +1,230 @@
+/**
+ * Video normalization to the bundle's canonical delivery format: MP4 with an
+ * h264 video stream and a front-loaded `moov` atom (`+faststart`). Producers
+ * emit whatever their capture stack gives them — Playwright records webm, native
+ * lanes record mov — but PR evidence is posted inline in GitHub, which renders
+ * MP4 inline and nothing else, so every video that lands in a bundle is coerced
+ * to that one shape before ingest.
+ *
+ * The transform is conditional, not blind: an mp4 that already carries h264 and
+ * has `moov` before `mdat` is copied through untouched (re-encoding would waste
+ * time and lose a generation of quality), while anything else is remuxed or
+ * transcoded. `ffprobe` decides which; `ffmpeg` performs the transform. Both are
+ * optional binaries — when either is absent the caller receives an explicit
+ * `skipped-missing-tool` outcome carrying the reason, never a silent copy that
+ * would smuggle an unplayable webm into the bundle under an `.mp4` name.
+ */
+
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const FFMPEG_BIN = process.env.ELIZA_FFMPEG_BIN || "ffmpeg";
+const FFPROBE_BIN = process.env.ELIZA_FFPROBE_BIN || "ffprobe";
+
+/** Whether a named binary answers `-version`, with a reason when it does not. */
+async function binaryAvailable(
+  bin: string,
+): Promise<{ available: true } | { available: false; reason: string }> {
+  try {
+    await execFileAsync(bin, ["-version"], { timeout: 10_000 });
+    return { available: true };
+  } catch (error) {
+    const enoent = (error as NodeJS.ErrnoException)?.code === "ENOENT";
+    return {
+      available: false,
+      reason: enoent
+        ? `${bin} not installed`
+        : `${bin} -version failed: ${String(
+            error instanceof Error ? error.message : error,
+          ).slice(0, 160)}`,
+    };
+  }
+}
+
+/** Whether both ffprobe and ffmpeg are invocable (normalization needs both). */
+export async function videoToolsAvailable(): Promise<
+  { available: true } | { available: false; reason: string }
+> {
+  const probe = await binaryAvailable(FFPROBE_BIN);
+  if (!probe.available) return probe;
+  const ffmpeg = await binaryAvailable(FFMPEG_BIN);
+  if (!ffmpeg.available) return ffmpeg;
+  return { available: true };
+}
+
+/** The container + first-video-stream facts ffprobe reports for a file. */
+export interface VideoProbe {
+  /** ffprobe `format_name`, e.g. `mov,mp4,m4a,3gp,3g2,mj2` or `matroska,webm`. */
+  formatName: string;
+  /** Codec of the first video stream, e.g. `h264`, `vp9`; null when no video. */
+  videoCodec: string | null;
+  /** Whether the top-level `moov` box precedes `mdat` (progressive playback). */
+  faststart: boolean;
+}
+
+/** Read the top-level MP4/ISO-BMFF box types in file order (headers only). */
+function readMp4BoxOrder(filePath: string): string[] {
+  const fd = fs.openSync(filePath, "r");
+  try {
+    const size = fs.fstatSync(fd).size;
+    const order: string[] = [];
+    const header = Buffer.alloc(16);
+    let offset = 0;
+    while (offset + 8 <= size) {
+      const read = fs.readSync(fd, header, 0, 16, offset);
+      if (read < 8) break;
+      let boxSize = header.readUInt32BE(0);
+      const type = header.toString("latin1", 4, 8);
+      // Only accept printable ASCII box types; a garbage read means this is not
+      // a box-structured file and we stop rather than loop on random bytes.
+      if (!/^[\x20-\x7e]{4}$/.test(type)) break;
+      order.push(type);
+      if (boxSize === 1) {
+        // 64-bit extended size lives in the 8 bytes after the type field.
+        boxSize = Number(header.readBigUInt64BE(8));
+      }
+      if (boxSize < 8) break;
+      offset += boxSize;
+    }
+    return order;
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+/** Probe a video's container, first video codec, and faststart layout. */
+export async function probeVideo(filePath: string): Promise<VideoProbe> {
+  const { stdout } = await execFileAsync(
+    FFPROBE_BIN,
+    [
+      "-v",
+      "error",
+      "-print_format",
+      "json",
+      "-show_format",
+      "-show_streams",
+      filePath,
+    ],
+    { timeout: 30_000 },
+  );
+  const parsed = JSON.parse(stdout) as {
+    format?: { format_name?: string };
+    streams?: { codec_type?: string; codec_name?: string }[];
+  };
+  const formatName = parsed.format?.format_name ?? "";
+  const videoStream = (parsed.streams ?? []).find(
+    (stream) => stream.codec_type === "video",
+  );
+  const videoCodec = videoStream?.codec_name ?? null;
+  const isMp4Container = formatName
+    .split(",")
+    .some((name) => name === "mp4" || name === "mov");
+  const order = isMp4Container ? readMp4BoxOrder(filePath) : [];
+  const moov = order.indexOf("moov");
+  const mdat = order.indexOf("mdat");
+  const faststart = moov >= 0 && mdat >= 0 && moov < mdat;
+  return { formatName, videoCodec, faststart };
+}
+
+/** Outcome of {@link normalizeVideo}: how the input reached the canonical MP4. */
+export type NormalizeOutcome =
+  | { status: "copied"; probe: VideoProbe }
+  | { status: "remuxed"; probe: VideoProbe }
+  | { status: "transcoded"; probe: VideoProbe }
+  | { status: "skipped-missing-tool"; reason: string };
+
+const CANONICAL_MP4_ARGS = [
+  "-map",
+  "0",
+  "-map",
+  "-0:s?", // drop any subtitle streams; GitHub inline playback ignores them.
+  "-c:v",
+  "libx264",
+  "-preset",
+  "veryfast",
+  "-pix_fmt",
+  "yuv420p",
+  "-c:a",
+  "aac",
+  "-movflags",
+  "+faststart",
+];
+
+/**
+ * Produce a canonical MP4 at `outPath` from `inputPath`. An mp4 that is already
+ * h264 with a front-loaded `moov` is copied through byte-for-byte; an mp4 that
+ * is h264 but lacks faststart is remuxed (stream copy + `+faststart`, no
+ * re-encode); everything else is transcoded to h264 + faststart. Returns which
+ * path was taken, or `skipped-missing-tool` when ffprobe/ffmpeg are absent.
+ */
+export async function normalizeVideo(
+  inputPath: string,
+  outPath: string,
+): Promise<NormalizeOutcome> {
+  const tools = await videoToolsAvailable();
+  if (!tools.available) {
+    return { status: "skipped-missing-tool", reason: tools.reason };
+  }
+  fs.statSync(inputPath); // Throws a typed ENOENT if the source vanished.
+  const probe = await probeVideo(inputPath);
+  const isH264Mp4 =
+    probe.videoCodec === "h264" &&
+    probe.formatName.split(",").some((name) => name === "mp4" || name === "mov");
+
+  if (isH264Mp4 && probe.faststart) {
+    if (fs.realpathSync(inputPath) !== safeRealpath(outPath)) {
+      fs.copyFileSync(inputPath, outPath);
+    }
+    return { status: "copied", probe };
+  }
+  if (isH264Mp4) {
+    // Already h264: remux only (stream copy) to move moov to the front.
+    await execFileAsync(
+      FFMPEG_BIN,
+      [
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-i",
+        inputPath,
+        "-c",
+        "copy",
+        "-movflags",
+        "+faststart",
+        outPath,
+      ],
+      { timeout: 120_000 },
+    );
+    return { status: "remuxed", probe };
+  }
+  await execFileAsync(
+    FFMPEG_BIN,
+    [
+      "-hide_banner",
+      "-loglevel",
+      "error",
+      "-y",
+      "-i",
+      inputPath,
+      ...CANONICAL_MP4_ARGS,
+      outPath,
+    ],
+    { timeout: 600_000 },
+  );
+  return { status: "transcoded", probe };
+}
+
+/** realpath a path that may not exist yet (return the input for a fresh out). */
+function safeRealpath(filePath: string): string {
+  try {
+    return fs.realpathSync(filePath);
+  } catch {
+    // error-policy:J3 untrusted path — a not-yet-created out path has no
+    // realpath; returning the literal path is correct for the equality guard.
+    return filePath;
+  }
+}

--- a/packages/evidence/src/video/normalize.ts
+++ b/packages/evidence/src/video/normalize.ts
@@ -9,53 +9,28 @@
  * The transform is conditional, not blind: an mp4 that already carries h264 and
  * has `moov` before `mdat` is copied through untouched (re-encoding would waste
  * time and lose a generation of quality), while anything else is remuxed or
- * transcoded. `ffprobe` decides which; `ffmpeg` performs the transform. Both are
- * optional binaries — when either is absent the caller receives an explicit
- * `skipped-missing-tool` outcome carrying the reason, never a silent copy that
- * would smuggle an unplayable webm into the bundle under an `.mp4` name.
+ * transcoded. `ffprobe` decides which; `ffmpeg` performs the transform. Both
+ * resolve from env, PATH, then the installed static npm packages; only when all
+ * resolution paths fail does the caller receive `skipped-missing-tool`.
  */
 
 import { execFile } from "node:child_process";
 import fs from "node:fs";
 import { promisify } from "node:util";
+import { EvidenceError } from "../errors.ts";
+import {
+  resolveFfprobeBinary,
+  resolveVideoBinaries,
+} from "../ffmpeg-binaries.ts";
 
 const execFileAsync = promisify(execFile);
-
-// Read the binary names per call rather than at module load so an env override
-// (a test forcing an absent binary, a container pinning a specific ffmpeg) takes
-// effect without re-importing the module.
-const ffmpegBin = () => process.env.ELIZA_FFMPEG_BIN || "ffmpeg";
-const ffprobeBin = () => process.env.ELIZA_FFPROBE_BIN || "ffprobe";
-
-/** Whether a named binary answers `-version`, with a reason when it does not. */
-async function binaryAvailable(
-  bin: string,
-): Promise<{ available: true } | { available: false; reason: string }> {
-  try {
-    await execFileAsync(bin, ["-version"], { timeout: 10_000 });
-    return { available: true };
-  } catch (error) {
-    const enoent = (error as NodeJS.ErrnoException)?.code === "ENOENT";
-    return {
-      available: false,
-      reason: enoent
-        ? `${bin} not installed`
-        : `${bin} -version failed: ${String(
-            error instanceof Error ? error.message : error,
-          ).slice(0, 160)}`,
-    };
-  }
-}
 
 /** Whether both ffprobe and ffmpeg are invocable (normalization needs both). */
 export async function videoToolsAvailable(): Promise<
   { available: true } | { available: false; reason: string }
 > {
-  const probe = await binaryAvailable(ffprobeBin());
-  if (!probe.available) return probe;
-  const ffmpeg = await binaryAvailable(ffmpegBin());
-  if (!ffmpeg.available) return ffmpeg;
-  return { available: true };
+  const tools = await resolveVideoBinaries();
+  return tools.available ? { available: true } : tools;
 }
 
 /** The container + first-video-stream facts ffprobe reports for a file. */
@@ -100,8 +75,19 @@ function readMp4BoxOrder(filePath: string): string[] {
 
 /** Probe a video's container, first video codec, and faststart layout. */
 export async function probeVideo(filePath: string): Promise<VideoProbe> {
+  const ffprobe = await resolveFfprobeBinary();
+  if (!ffprobe.available) {
+    throw new EvidenceError(ffprobe.reason, { code: "FFPROBE_UNAVAILABLE" });
+  }
+  return probeVideoWithBin(filePath, ffprobe.bin);
+}
+
+async function probeVideoWithBin(
+  filePath: string,
+  ffprobeBin: string,
+): Promise<VideoProbe> {
   const { stdout } = await execFileAsync(
-    ffprobeBin(),
+    ffprobeBin,
     [
       "-v",
       "error",
@@ -167,12 +153,12 @@ export async function normalizeVideo(
   inputPath: string,
   outPath: string,
 ): Promise<NormalizeOutcome> {
-  const tools = await videoToolsAvailable();
+  const tools = await resolveVideoBinaries();
   if (!tools.available) {
     return { status: "skipped-missing-tool", reason: tools.reason };
   }
   fs.statSync(inputPath); // Throws a typed ENOENT if the source vanished.
-  const probe = await probeVideo(inputPath);
+  const probe = await probeVideoWithBin(inputPath, tools.ffprobe.bin);
   const isH264Mp4 =
     probe.videoCodec === "h264" &&
     probe.formatName
@@ -188,7 +174,7 @@ export async function normalizeVideo(
   if (isH264Mp4) {
     // Already h264: remux only (stream copy) to move moov to the front.
     await execFileAsync(
-      ffmpegBin(),
+      tools.ffmpeg.bin,
       [
         "-hide_banner",
         "-loglevel",
@@ -207,7 +193,7 @@ export async function normalizeVideo(
     return { status: "remuxed", probe };
   }
   await execFileAsync(
-    ffmpegBin(),
+    tools.ffmpeg.bin,
     [
       "-hide_banner",
       "-loglevel",

--- a/packages/evidence/src/video/walkthrough-schema.test.ts
+++ b/packages/evidence/src/video/walkthrough-schema.test.ts
@@ -1,0 +1,158 @@
+// Walkthrough definition schema validation. Pure and tool-free (always runs):
+// asserts valid definitions parse, and that malformed ones — unknown action,
+// missing required selector/value, empty step list, bad slug — throw a typed
+// EvidenceValidationError carrying per-field issues, never a silently-repaired
+// definition. Also validates every shipped definition file against the schema.
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { EvidenceValidationError } from "../errors.ts";
+import { parseWalkthroughDef } from "./walkthrough-schema.ts";
+import { WALKTHROUGHS_DIR } from "./walkthroughs.ts";
+
+describe("parseWalkthroughDef", () => {
+  it("accepts a minimal valid definition", () => {
+    const def = parseWalkthroughDef(
+      {
+        slug: "ok",
+        granularity: "feature",
+        steps: [{ action: "goto", value: "/" }],
+      },
+      "test",
+    );
+    expect(def.slug).toBe("ok");
+    expect(def.steps).toHaveLength(1);
+  });
+
+  it("rejects an unknown action with a typed error", () => {
+    expect(() =>
+      parseWalkthroughDef(
+        { slug: "x", granularity: "feature", steps: [{ action: "teleport" }] },
+        "test",
+      ),
+    ).toThrow(EvidenceValidationError);
+  });
+
+  it("rejects a click with no selector", () => {
+    try {
+      parseWalkthroughDef(
+        { slug: "x", granularity: "element", steps: [{ action: "click" }] },
+        "test",
+      );
+      expect.unreachable("should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(EvidenceValidationError);
+      expect((error as EvidenceValidationError).issues.length).toBeGreaterThan(
+        0,
+      );
+    }
+  });
+
+  it("rejects a fill with no value", () => {
+    expect(() =>
+      parseWalkthroughDef(
+        {
+          slug: "x",
+          granularity: "element",
+          steps: [{ action: "fill", selector: "#a" }],
+        },
+        "test",
+      ),
+    ).toThrow(EvidenceValidationError);
+  });
+
+  it("rejects a waitFor with neither selector nor value", () => {
+    expect(() =>
+      parseWalkthroughDef(
+        {
+          slug: "x",
+          granularity: "feature",
+          steps: [{ action: "waitFor" }],
+        },
+        "test",
+      ),
+    ).toThrow(/selector or a value/);
+  });
+
+  it("rejects an empty step list", () => {
+    expect(() =>
+      parseWalkthroughDef(
+        { slug: "x", granularity: "feature", steps: [] },
+        "test",
+      ),
+    ).toThrow(EvidenceValidationError);
+  });
+
+  it("rejects an invalid slug", () => {
+    expect(() =>
+      parseWalkthroughDef(
+        {
+          slug: "Not A Slug",
+          granularity: "feature",
+          steps: [{ action: "goto", value: "/" }],
+        },
+        "test",
+      ),
+    ).toThrow(EvidenceValidationError);
+  });
+
+  it("rejects an unknown granularity", () => {
+    expect(() =>
+      parseWalkthroughDef(
+        {
+          slug: "x",
+          granularity: "page",
+          steps: [{ action: "goto", value: "/" }],
+        },
+        "test",
+      ),
+    ).toThrow(EvidenceValidationError);
+  });
+
+  it("rejects an unknown top-level field (strict object)", () => {
+    expect(() =>
+      parseWalkthroughDef(
+        {
+          slug: "x",
+          granularity: "feature",
+          steps: [{ action: "goto", value: "/" }],
+          bogus: true,
+        },
+        "test",
+      ),
+    ).toThrow(EvidenceValidationError);
+  });
+});
+
+describe("shipped walkthrough definitions", () => {
+  const files = readdirSync(WALKTHROUGHS_DIR).filter((name) =>
+    name.endsWith(".json"),
+  );
+
+  it("ships at least three definitions", () => {
+    expect(files.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it.each(files)("%s validates against the schema", (name) => {
+    const parsed = JSON.parse(
+      readFileSync(join(WALKTHROUGHS_DIR, name), "utf8"),
+    );
+    const def = parseWalkthroughDef(parsed, name);
+    expect(def.slug).toBeTruthy();
+    expect(def.steps.length).toBeGreaterThan(0);
+  });
+
+  it("covers all three granularities across the shipped set", () => {
+    const granularities = new Set(
+      files.map((name) => {
+        const parsed = JSON.parse(
+          readFileSync(join(WALKTHROUGHS_DIR, name), "utf8"),
+        );
+        return parseWalkthroughDef(parsed, name).granularity;
+      }),
+    );
+    expect(granularities).toEqual(
+      new Set(["element", "feature", "walkthrough"]),
+    );
+  });
+});

--- a/packages/evidence/src/video/walkthrough-schema.test.ts
+++ b/packages/evidence/src/video/walkthrough-schema.test.ts
@@ -74,6 +74,29 @@ describe("parseWalkthroughDef", () => {
     ).toThrow(/selector or a value/);
   });
 
+  it("rejects non-numeric timing and scroll values", () => {
+    expect(() =>
+      parseWalkthroughDef(
+        {
+          slug: "x",
+          granularity: "feature",
+          steps: [{ action: "waitFor", value: "later" }],
+        },
+        "test",
+      ),
+    ).toThrow(/non-negative millisecond/);
+    expect(() =>
+      parseWalkthroughDef(
+        {
+          slug: "x",
+          granularity: "feature",
+          steps: [{ action: "scroll", value: "down" }],
+        },
+        "test",
+      ),
+    ).toThrow(/finite pixel/);
+  });
+
   it("rejects an empty step list", () => {
     expect(() =>
       parseWalkthroughDef(

--- a/packages/evidence/src/video/walkthrough-schema.ts
+++ b/packages/evidence/src/video/walkthrough-schema.ts
@@ -123,6 +123,17 @@ const walkthroughSchema = z
         });
       }
       if (
+        step.action === "waitFor" &&
+        step.value !== undefined &&
+        !isNonNegativeNumber(step.value)
+      ) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["steps", index, "value"],
+          message: "waitFor value must be a non-negative millisecond count",
+        });
+      }
+      if (
         step.action === "scroll" &&
         step.selector === undefined &&
         step.value === undefined
@@ -131,6 +142,18 @@ const walkthroughSchema = z
           code: "custom",
           path: ["steps", index],
           message: "scroll requires a selector or a value (px)",
+        });
+      }
+      if (
+        step.action === "scroll" &&
+        step.selector === undefined &&
+        step.value !== undefined &&
+        !isFiniteNumber(step.value)
+      ) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["steps", index, "value"],
+          message: "scroll value must be a finite pixel count",
         });
       }
     });
@@ -164,4 +187,13 @@ export function parseWalkthroughDef(
     issues,
     { code: "WALKTHROUGH_DEF_INVALID" },
   );
+}
+
+function isFiniteNumber(value: string): boolean {
+  return Number.isFinite(Number(value));
+}
+
+function isNonNegativeNumber(value: string): boolean {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0;
 }

--- a/packages/evidence/src/video/walkthrough-schema.ts
+++ b/packages/evidence/src/video/walkthrough-schema.ts
@@ -1,0 +1,167 @@
+/**
+ * Data schema for walkthrough definitions: a walkthrough is a list of steps, not
+ * a hand-written Playwright spec, so one driver runs N walkthroughs and the set
+ * is auditable as JSON. Definitions live as `walkthroughs/*.json` (or `.ts`
+ * exporting a `WalkthroughDef`) and are validated here at load time — an unknown
+ * `action`, a `click` with no `selector`, or a `fill` with no `value` is a typed
+ * `EvidenceValidationError`, never a step that silently does nothing at runtime.
+ *
+ * The action vocabulary is deliberately small and declarative (`goto`, `click`,
+ * `fill`, `hover`, `waitFor`, `scroll`, `assertText`); anything a walkthrough
+ * needs beyond it is a signal to add a first-class action here, not to smuggle
+ * imperative code into a definition. `zod` validates; the inferred type is the
+ * contract the driver consumes, so schema and type cannot drift.
+ */
+
+import { z } from "zod";
+import { EvidenceValidationError } from "../errors.ts";
+import { VIDEO_GRANULARITIES } from "./ingest.ts";
+
+/** Step action verbs the driver knows how to execute. */
+export const WALKTHROUGH_ACTIONS = [
+  "goto",
+  "click",
+  "fill",
+  "hover",
+  "waitFor",
+  "scroll",
+  "assertText",
+] as const;
+export type WalkthroughAction = (typeof WALKTHROUGH_ACTIONS)[number];
+
+const stepBase = {
+  /** Short human label for the step, surfaced in the steps-log and screenshots. */
+  label: z.string().min(1).optional(),
+  /** Capture a screenshot after this step, tagged with the step index/label. */
+  screenshotAfter: z.boolean().optional(),
+  /** Capture an ARIA-snapshot (html-tree) after this step for structural diff. */
+  ariaAfter: z.boolean().optional(),
+};
+
+// Each action carries exactly the fields it needs; a discriminated union means
+// `click` without a `selector` fails validation instead of no-op'ing at runtime.
+const stepSchema = z.discriminatedUnion("action", [
+  z.strictObject({
+    action: z.literal("goto"),
+    /** Absolute URL, or a path resolved against the run's baseUrl. */
+    value: z.string().min(1),
+    ...stepBase,
+  }),
+  z.strictObject({
+    action: z.literal("click"),
+    selector: z.string().min(1),
+    ...stepBase,
+  }),
+  z.strictObject({
+    action: z.literal("fill"),
+    selector: z.string().min(1),
+    value: z.string(),
+    ...stepBase,
+  }),
+  z.strictObject({
+    action: z.literal("hover"),
+    selector: z.string().min(1),
+    ...stepBase,
+  }),
+  z.strictObject({
+    action: z.literal("waitFor"),
+    /** CSS selector to wait for, when waiting on an element. */
+    selector: z.string().min(1).optional(),
+    /** Milliseconds to wait, when waiting on time. One of selector/value required. */
+    value: z.string().min(1).optional(),
+    ...stepBase,
+  }),
+  z.strictObject({
+    action: z.literal("scroll"),
+    /** Element to scroll into view; omit to scroll the page by `value` px. */
+    selector: z.string().min(1).optional(),
+    /** Pixels to scroll the window when no selector is given. */
+    value: z.string().min(1).optional(),
+    ...stepBase,
+  }),
+  z.strictObject({
+    action: z.literal("assertText"),
+    /** Scope the text search to this selector; omit to search the whole page. */
+    selector: z.string().min(1).optional(),
+    /** Text that must be present. */
+    value: z.string().min(1),
+    ...stepBase,
+  }),
+]);
+
+const walkthroughSchema = z
+  .strictObject({
+    /** Filesystem-safe id; becomes the ingested video's slug. */
+    slug: z.string().regex(/^[a-z0-9][a-z0-9-]*$/, {
+      message: "slug must be lowercase alphanumeric with dashes",
+    }),
+    /** Which evidence lane the produced video belongs to. */
+    granularity: z.enum(VIDEO_GRANULARITIES),
+    /** Human title for the walkthrough. */
+    title: z.string().min(1).optional(),
+    /** Default base URL for relative `goto` steps; overridable at run time. */
+    baseUrl: z.string().url().optional(),
+    /**
+     * Marks a walkthrough that can only run against the booted real app (no
+     * self-contained fixture). The driver refuses to run it without an explicit
+     * baseUrl so it can never fabricate a fixture pass for a real-app flow.
+     */
+    requiresApp: z.boolean().optional(),
+    steps: z.array(stepSchema).min(1),
+  })
+  .superRefine((def, ctx) => {
+    def.steps.forEach((step, index) => {
+      if (
+        step.action === "waitFor" &&
+        step.selector === undefined &&
+        step.value === undefined
+      ) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["steps", index],
+          message: "waitFor requires a selector or a value (ms)",
+        });
+      }
+      if (
+        step.action === "scroll" &&
+        step.selector === undefined &&
+        step.value === undefined
+      ) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["steps", index],
+          message: "scroll requires a selector or a value (px)",
+        });
+      }
+    });
+  });
+
+/** A validated walkthrough definition — the contract the driver consumes. */
+export type WalkthroughDef = z.infer<typeof walkthroughSchema>;
+/** One validated step. */
+export type WalkthroughStep = WalkthroughDef["steps"][number];
+
+/**
+ * Validate an untrusted value (parsed JSON / imported module) as a walkthrough
+ * definition. Throws `EvidenceValidationError` with every field issue on
+ * failure — an unknown action, a missing selector, or an empty step list is a
+ * typed rejection, never a silently-repaired definition.
+ */
+export function parseWalkthroughDef(
+  value: unknown,
+  described: string,
+): WalkthroughDef {
+  const result = walkthroughSchema.safeParse(value);
+  if (result.success) return result.data;
+  const issues = result.error.issues.map((issue) => ({
+    path: issue.path.map(String).join(".") || "$",
+    message: issue.message,
+  }));
+  throw new EvidenceValidationError(
+    `invalid walkthrough definition (${described}): ${issues
+      .map((issue) => `${issue.path}: ${issue.message}`)
+      .join("; ")}`,
+    issues,
+    { code: "WALKTHROUGH_DEF_INVALID" },
+  );
+}

--- a/packages/evidence/src/video/walkthroughs.test.ts
+++ b/packages/evidence/src/video/walkthroughs.test.ts
@@ -1,0 +1,110 @@
+// End-to-end orchestration: run a shipped walkthrough definition against the
+// self-contained dashboard fixture (served locally), in real headless chromium,
+// and ingest the produced video + screenshots + snapshots into a bundle that
+// then verifies clean. Gated on BOTH chromium and ffmpeg; skipped with a reason
+// when either is absent. Also asserts requiresApp definitions are refused
+// without a baseUrl (tool-free).
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { createBundle, verifyBundle } from "../bundle.ts";
+import { videoToolsAvailable } from "./normalize.ts";
+import {
+  loadAllWalkthroughDefs,
+  loadWalkthroughDef,
+  runAndIngestWalkthrough,
+  WALKTHROUGHS_DIR,
+} from "./walkthroughs.ts";
+
+const dir = mkdtempSync(join(os.tmpdir(), "evidence-walkthroughs-"));
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+async function chromiumLaunchable(): Promise<boolean> {
+  try {
+    const { chromium } = (await import("@playwright/test")) as {
+      chromium: { launch(o?: unknown): Promise<{ close(): Promise<void> }> };
+    };
+    const browser = await chromium.launch({ headless: true });
+    await browser.close();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const tools = await videoToolsAvailable();
+const hasChromium = await chromiumLaunchable();
+const canRun = tools.available && hasChromium;
+
+function newBundle(runId: string) {
+  return createBundle({
+    rootDir: join(dir, "runs"),
+    provenance: {
+      commit: "0".repeat(40),
+      branch: "test",
+      runner: "local",
+      tier: "cpu",
+      envFingerprint: {
+        node: process.version,
+        platform: "test",
+        arch: "test",
+        tier: "cpu",
+      },
+    },
+    runId,
+    linkMode: "copy",
+  });
+}
+
+describe("shipped definitions load", () => {
+  it("loads all shipped definitions", () => {
+    const all = loadAllWalkthroughDefs();
+    expect(all.length).toBeGreaterThanOrEqual(3);
+    expect(all.map((entry) => entry.def.slug).sort()).toContain("send-button");
+  });
+});
+
+describe.skipIf(!canRun)(
+  "runAndIngestWalkthrough (fixture + chromium + ffmpeg)",
+  () => {
+    it("runs the feature walkthrough against the fixture and ingests it", async () => {
+      const def = loadWalkthroughDef(
+        join(WALKTHROUGHS_DIR, "send-message.json"),
+      );
+      const bundle = newBundle("wt-feature");
+      const out = mkdtempSync(join(dir, "out-"));
+      const result = await runAndIngestWalkthrough(def, bundle, {
+        out,
+        driver: { stepPauseMs: 100 },
+      });
+      expect(result.slug).toBe("send-message");
+      expect(result.ingest.video.path).toBe("video/features/send-message.mp4");
+      expect(result.ingest.normalize.status).toBe("transcoded");
+      expect(result.ingest.keyframeCount).toBeGreaterThanOrEqual(2);
+      expect(result.screenshots.length).toBeGreaterThanOrEqual(1);
+
+      const finalized = await bundle.finalize();
+      // video + its analysis + keyframes + their analyses + screenshots + aria + steps.
+      expect(finalized.manifest.artifacts.length).toBeGreaterThan(6);
+      const report = await verifyBundle(bundle.dir);
+      expect(report.ok).toBe(true);
+    }, 120_000);
+
+    it("runs the element walkthrough (send-button) against the fixture", async () => {
+      const def = loadWalkthroughDef(
+        join(WALKTHROUGHS_DIR, "send-button.json"),
+      );
+      const bundle = newBundle("wt-element");
+      const out = mkdtempSync(join(dir, "out-el-"));
+      const result = await runAndIngestWalkthrough(def, bundle, {
+        out,
+        driver: { stepPauseMs: 100 },
+      });
+      expect(result.ingest.video.path).toBe("video/elements/send-button.mp4");
+      await bundle.finalize();
+      const report = await verifyBundle(bundle.dir);
+      expect(report.ok).toBe(true);
+    }, 120_000);
+  },
+);

--- a/packages/evidence/src/video/walkthroughs.ts
+++ b/packages/evidence/src/video/walkthroughs.ts
@@ -1,0 +1,179 @@
+/**
+ * Loading and orchestration for the shipped walkthrough definitions. Definitions
+ * are data under `walkthroughs/*.json`; this module discovers them, validates
+ * each through the schema, and runs the driver → normalize → ingest pipeline for
+ * one definition. The shipped set targets the self-contained dashboard fixture
+ * (served locally) so `element` and `feature` lanes run with zero app boot; a
+ * definition marked `requiresApp` runs only when the caller supplies the real
+ * app's baseUrl.
+ *
+ * The two seams — where definitions live, and where the fixture lives — are the
+ * only filesystem knowledge here; the driver, normalizer, and ingestor stay
+ * pure and reusable for any origin.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { EvidenceBundle } from "../bundle.ts";
+import { EvidenceError } from "../errors.ts";
+import { runWalkthrough, type RunWalkthroughOptions } from "./driver.ts";
+import { serveFixture } from "./fixture-server.ts";
+import { ingestVideo, type IngestVideoResult } from "./ingest.ts";
+import {
+  parseWalkthroughDef,
+  type WalkthroughDef,
+} from "./walkthrough-schema.ts";
+
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+/** Directory holding the shipped `*.json` walkthrough definitions. */
+export const WALKTHROUGHS_DIR = path.join(moduleDir, "walkthroughs");
+/** The self-contained dashboard fixture the shipped definitions drive. */
+export const FIXTURE_DIR = path.join(moduleDir, "fixture");
+const FIXTURE_INDEX = "dashboard.html";
+
+/** Load and validate one definition file (`.json`). Throws typed on invalid. */
+export function loadWalkthroughDef(file: string): WalkthroughDef {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(file, "utf8");
+  } catch (error) {
+    // error-policy:J2 context-adding rethrow — a named-but-missing definition
+    // is a caller error, not an empty walkthrough.
+    throw new EvidenceError(`walkthrough definition not readable: ${file}`, {
+      code: "WALKTHROUGH_DEF_MISSING",
+      cause: error,
+      context: { file },
+    });
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    // error-policy:J3 untrusted disk input — malformed JSON is a typed invalid.
+    throw new EvidenceError(`walkthrough definition is not valid JSON: ${file}`, {
+      code: "WALKTHROUGH_DEF_INVALID",
+      cause: error,
+      context: { file },
+    });
+  }
+  return parseWalkthroughDef(parsed, file);
+}
+
+/** Every shipped definition, sorted by slug for deterministic run order. */
+export function loadAllWalkthroughDefs(): { def: WalkthroughDef; file: string }[] {
+  return fs
+    .readdirSync(WALKTHROUGHS_DIR)
+    .filter((name) => name.endsWith(".json"))
+    .sort()
+    .map((name) => {
+      const file = path.join(WALKTHROUGHS_DIR, name);
+      return { def: loadWalkthroughDef(file), file };
+    });
+}
+
+/** Options for {@link runAndIngestWalkthrough}. */
+export interface RunAndIngestOptions {
+  /** Scratch dir for the driver's raw artifacts (video/screenshots/snapshots). */
+  out: string;
+  /**
+   * Base URL to drive. When omitted, the shipped fixture is served locally and
+   * used — unless the definition is `requiresApp`, which then errors.
+   */
+  baseUrl?: string;
+  /** Producer id recorded on the ingested video's source. */
+  source?: string;
+  /** Injectable browser + viewport + timeout, forwarded to the driver. */
+  driver?: Pick<RunWalkthroughOptions, "browser" | "viewport" | "timeoutMs">;
+}
+
+/** Result of running one walkthrough and ingesting its video into a bundle. */
+export interface RunAndIngestResult {
+  slug: string;
+  ingest: IngestVideoResult;
+  /** Absolute paths of the per-step screenshots the driver captured. */
+  screenshots: string[];
+  /** Absolute paths of the per-step ARIA snapshots the driver captured. */
+  ariaSnapshots: string[];
+  /** Absolute path of the driver's steps-log JSON. */
+  stepsLog: string;
+}
+
+/**
+ * Run one walkthrough definition and ingest its video (normalized + keyframe
+ * analyzed) into `bundle`, plus its screenshots (as `screenshot` artifacts) and
+ * ARIA snapshots (as `html-tree` artifacts) and steps-log (as a `report`). When
+ * `baseUrl` is omitted the shipped fixture is served locally for the duration of
+ * the run.
+ */
+export async function runAndIngestWalkthrough(
+  def: WalkthroughDef,
+  bundle: EvidenceBundle,
+  options: RunAndIngestOptions,
+): Promise<RunAndIngestResult> {
+  const source = options.source ?? "walkthrough-driver";
+  let baseUrl = options.baseUrl;
+  let fixture: Awaited<ReturnType<typeof serveFixture>> | undefined;
+  if (baseUrl === undefined && !def.requiresApp) {
+    fixture = await serveFixture(FIXTURE_DIR, FIXTURE_INDEX);
+    baseUrl = fixture.baseUrl;
+  }
+  try {
+    const run = await runWalkthrough(def, {
+      out: options.out,
+      baseUrl,
+      ...options.driver,
+    });
+    const ingest = await ingestVideo(bundle, run.video, {
+      granularity: def.granularity,
+      slug: def.slug,
+      source,
+      producedBy: "walkthrough-driver",
+      ...(def.granularity === "walkthrough" || def.granularity === "feature"
+        ? { lane: "e2e" }
+        : {}),
+    });
+    // Screenshots, snapshots, and the steps-log ride into the bundle alongside
+    // the video so the walkthrough is fully self-describing evidence.
+    let shotIndex = 0;
+    for (const shot of run.screenshots) {
+      await bundle.addArtifact(shot, {
+        kind: "screenshot",
+        source,
+        producedBy: "walkthrough-driver",
+        bundlePath: `video/${def.granularity}s/${def.slug}/steps/${String(
+          shotIndex,
+        ).padStart(2, "0")}-${path.basename(shot)}`,
+      });
+      shotIndex += 1;
+    }
+    let snapIndex = 0;
+    for (const snap of run.ariaSnapshots) {
+      await bundle.addArtifact(snap, {
+        kind: "html-tree",
+        source,
+        producedBy: "walkthrough-driver",
+        bundlePath: `html-trees/${def.slug}/${String(snapIndex).padStart(
+          2,
+          "0",
+        )}-${path.basename(snap)}`,
+      });
+      snapIndex += 1;
+    }
+    await bundle.addArtifact(run.stepsLog, {
+      kind: "report",
+      source,
+      producedBy: "walkthrough-driver",
+      bundlePath: `video/${def.granularity}s/${def.slug}/steps.json`,
+    });
+    return {
+      slug: def.slug,
+      ingest,
+      screenshots: run.screenshots,
+      ariaSnapshots: run.ariaSnapshots,
+      stepsLog: run.stepsLog,
+    };
+  } finally {
+    if (fixture !== undefined) await fixture.stop();
+  }
+}

--- a/packages/evidence/src/video/walkthroughs.ts
+++ b/packages/evidence/src/video/walkthroughs.ts
@@ -106,6 +106,8 @@ export interface RunAndIngestResult {
   ariaSnapshots: string[];
   /** Absolute path of the driver's steps-log JSON. */
   stepsLog: string;
+  /** Number of steps the driver executed. */
+  stepCount: number;
 }
 
 /**
@@ -181,6 +183,7 @@ export async function runAndIngestWalkthrough(
       screenshots: run.screenshots,
       ariaSnapshots: run.ariaSnapshots,
       stepsLog: run.stepsLog,
+      stepCount: run.steps.length,
     };
   } finally {
     if (fixture !== undefined) await fixture.stop();

--- a/packages/evidence/src/video/walkthroughs.ts
+++ b/packages/evidence/src/video/walkthroughs.ts
@@ -17,9 +17,9 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { EvidenceBundle } from "../bundle.ts";
 import { EvidenceError } from "../errors.ts";
-import { runWalkthrough, type RunWalkthroughOptions } from "./driver.ts";
+import { type RunWalkthroughOptions, runWalkthrough } from "./driver.ts";
 import { serveFixture } from "./fixture-server.ts";
-import { ingestVideo, type IngestVideoResult } from "./ingest.ts";
+import { type IngestVideoResult, ingestVideo } from "./ingest.ts";
 import {
   parseWalkthroughDef,
   type WalkthroughDef,
@@ -51,17 +51,23 @@ export function loadWalkthroughDef(file: string): WalkthroughDef {
     parsed = JSON.parse(raw);
   } catch (error) {
     // error-policy:J3 untrusted disk input — malformed JSON is a typed invalid.
-    throw new EvidenceError(`walkthrough definition is not valid JSON: ${file}`, {
-      code: "WALKTHROUGH_DEF_INVALID",
-      cause: error,
-      context: { file },
-    });
+    throw new EvidenceError(
+      `walkthrough definition is not valid JSON: ${file}`,
+      {
+        code: "WALKTHROUGH_DEF_INVALID",
+        cause: error,
+        context: { file },
+      },
+    );
   }
   return parseWalkthroughDef(parsed, file);
 }
 
 /** Every shipped definition, sorted by slug for deterministic run order. */
-export function loadAllWalkthroughDefs(): { def: WalkthroughDef; file: string }[] {
+export function loadAllWalkthroughDefs(): {
+  def: WalkthroughDef;
+  file: string;
+}[] {
   return fs
     .readdirSync(WALKTHROUGHS_DIR)
     .filter((name) => name.endsWith(".json"))
@@ -83,8 +89,11 @@ export interface RunAndIngestOptions {
   baseUrl?: string;
   /** Producer id recorded on the ingested video's source. */
   source?: string;
-  /** Injectable browser + viewport + timeout, forwarded to the driver. */
-  driver?: Pick<RunWalkthroughOptions, "browser" | "viewport" | "timeoutMs">;
+  /** Injectable browser + viewport + timeout + dwell, forwarded to the driver. */
+  driver?: Pick<
+    RunWalkthroughOptions,
+    "browser" | "viewport" | "timeoutMs" | "stepPauseMs"
+  >;
 }
 
 /** Result of running one walkthrough and ingesting its video into a bundle. */

--- a/packages/evidence/src/video/walkthroughs/app-tour.json
+++ b/packages/evidence/src/video/walkthroughs/app-tour.json
@@ -1,0 +1,18 @@
+{
+  "slug": "app-tour",
+  "granularity": "walkthrough",
+  "title": "Whole-app tour across five views",
+  "steps": [
+    { "action": "goto", "value": "/", "label": "open-app" },
+    { "action": "waitFor", "selector": "[data-testid=\"chat-view\"]", "label": "await-chat", "screenshotAfter": true },
+    { "action": "click", "selector": "[data-testid=\"nav-documents\"]", "label": "open-documents" },
+    { "action": "assertText", "selector": "[data-testid=\"documents-view\"]", "value": "Documents", "label": "documents-visible", "screenshotAfter": true },
+    { "action": "click", "selector": "[data-testid=\"nav-database\"]", "label": "open-database" },
+    { "action": "assertText", "selector": "[data-testid=\"database-view\"]", "value": "Database", "label": "database-visible", "screenshotAfter": true },
+    { "action": "click", "selector": "[data-testid=\"nav-files\"]", "label": "open-files" },
+    { "action": "assertText", "selector": "[data-testid=\"files-view\"]", "value": "Files", "label": "files-visible", "screenshotAfter": true },
+    { "action": "click", "selector": "[data-testid=\"nav-settings\"]", "label": "open-settings" },
+    { "action": "assertText", "selector": "[data-testid=\"settings-view\"]", "value": "Settings", "label": "settings-visible", "ariaAfter": true, "screenshotAfter": true },
+    { "action": "click", "selector": "[data-testid=\"nav-chat\"]", "label": "back-to-chat", "screenshotAfter": true }
+  ]
+}

--- a/packages/evidence/src/video/walkthroughs/app-tour.json
+++ b/packages/evidence/src/video/walkthroughs/app-tour.json
@@ -4,15 +4,66 @@
   "title": "Whole-app tour across five views",
   "steps": [
     { "action": "goto", "value": "/", "label": "open-app" },
-    { "action": "waitFor", "selector": "[data-testid=\"chat-view\"]", "label": "await-chat", "screenshotAfter": true },
-    { "action": "click", "selector": "[data-testid=\"nav-documents\"]", "label": "open-documents" },
-    { "action": "assertText", "selector": "[data-testid=\"documents-view\"]", "value": "Documents", "label": "documents-visible", "screenshotAfter": true },
-    { "action": "click", "selector": "[data-testid=\"nav-database\"]", "label": "open-database" },
-    { "action": "assertText", "selector": "[data-testid=\"database-view\"]", "value": "Database", "label": "database-visible", "screenshotAfter": true },
-    { "action": "click", "selector": "[data-testid=\"nav-files\"]", "label": "open-files" },
-    { "action": "assertText", "selector": "[data-testid=\"files-view\"]", "value": "Files", "label": "files-visible", "screenshotAfter": true },
-    { "action": "click", "selector": "[data-testid=\"nav-settings\"]", "label": "open-settings" },
-    { "action": "assertText", "selector": "[data-testid=\"settings-view\"]", "value": "Settings", "label": "settings-visible", "ariaAfter": true, "screenshotAfter": true },
-    { "action": "click", "selector": "[data-testid=\"nav-chat\"]", "label": "back-to-chat", "screenshotAfter": true }
+    {
+      "action": "waitFor",
+      "selector": "[data-testid=\"chat-view\"]",
+      "label": "await-chat",
+      "screenshotAfter": true
+    },
+    {
+      "action": "click",
+      "selector": "[data-testid=\"nav-documents\"]",
+      "label": "open-documents"
+    },
+    {
+      "action": "assertText",
+      "selector": "[data-testid=\"documents-view\"]",
+      "value": "Documents",
+      "label": "documents-visible",
+      "screenshotAfter": true
+    },
+    {
+      "action": "click",
+      "selector": "[data-testid=\"nav-database\"]",
+      "label": "open-database"
+    },
+    {
+      "action": "assertText",
+      "selector": "[data-testid=\"database-view\"]",
+      "value": "Database",
+      "label": "database-visible",
+      "screenshotAfter": true
+    },
+    {
+      "action": "click",
+      "selector": "[data-testid=\"nav-files\"]",
+      "label": "open-files"
+    },
+    {
+      "action": "assertText",
+      "selector": "[data-testid=\"files-view\"]",
+      "value": "Files",
+      "label": "files-visible",
+      "screenshotAfter": true
+    },
+    {
+      "action": "click",
+      "selector": "[data-testid=\"nav-settings\"]",
+      "label": "open-settings"
+    },
+    {
+      "action": "assertText",
+      "selector": "[data-testid=\"settings-view\"]",
+      "value": "Settings",
+      "label": "settings-visible",
+      "ariaAfter": true,
+      "screenshotAfter": true
+    },
+    {
+      "action": "click",
+      "selector": "[data-testid=\"nav-chat\"]",
+      "label": "back-to-chat",
+      "screenshotAfter": true
+    }
   ]
 }

--- a/packages/evidence/src/video/walkthroughs/send-button.json
+++ b/packages/evidence/src/video/walkthroughs/send-button.json
@@ -4,9 +4,28 @@
   "title": "Send-button micro-interaction (hover + press)",
   "steps": [
     { "action": "goto", "value": "/", "label": "open-chat" },
-    { "action": "waitFor", "selector": "[data-testid=\"chat-composer-action\"]", "label": "await-send" },
-    { "action": "fill", "selector": "[data-testid=\"chat-composer-textarea\"]", "value": "hello", "label": "type-message" },
-    { "action": "hover", "selector": "[data-testid=\"chat-composer-action\"]", "label": "hover-send", "screenshotAfter": true },
-    { "action": "click", "selector": "[data-testid=\"chat-composer-action\"]", "label": "press-send", "screenshotAfter": true }
+    {
+      "action": "waitFor",
+      "selector": "[data-testid=\"chat-composer-action\"]",
+      "label": "await-send"
+    },
+    {
+      "action": "fill",
+      "selector": "[data-testid=\"chat-composer-textarea\"]",
+      "value": "hello",
+      "label": "type-message"
+    },
+    {
+      "action": "hover",
+      "selector": "[data-testid=\"chat-composer-action\"]",
+      "label": "hover-send",
+      "screenshotAfter": true
+    },
+    {
+      "action": "click",
+      "selector": "[data-testid=\"chat-composer-action\"]",
+      "label": "press-send",
+      "screenshotAfter": true
+    }
   ]
 }

--- a/packages/evidence/src/video/walkthroughs/send-button.json
+++ b/packages/evidence/src/video/walkthroughs/send-button.json
@@ -1,0 +1,12 @@
+{
+  "slug": "send-button",
+  "granularity": "element",
+  "title": "Send-button micro-interaction (hover + press)",
+  "steps": [
+    { "action": "goto", "value": "/", "label": "open-chat" },
+    { "action": "waitFor", "selector": "[data-testid=\"chat-composer-action\"]", "label": "await-send" },
+    { "action": "fill", "selector": "[data-testid=\"chat-composer-textarea\"]", "value": "hello", "label": "type-message" },
+    { "action": "hover", "selector": "[data-testid=\"chat-composer-action\"]", "label": "hover-send", "screenshotAfter": true },
+    { "action": "click", "selector": "[data-testid=\"chat-composer-action\"]", "label": "press-send", "screenshotAfter": true }
+  ]
+}

--- a/packages/evidence/src/video/walkthroughs/send-message.json
+++ b/packages/evidence/src/video/walkthroughs/send-message.json
@@ -4,11 +4,37 @@
   "title": "Send a chat message round-trip",
   "steps": [
     { "action": "goto", "value": "/", "label": "open-chat" },
-    { "action": "waitFor", "selector": "[data-testid=\"chat-composer-textarea\"]", "label": "await-composer" },
-    { "action": "assertText", "selector": "[data-testid=\"chat-content\"]", "value": "How can I help you", "label": "greeting-present" },
-    { "action": "fill", "selector": "[data-testid=\"chat-composer-textarea\"]", "value": "What is the weather today?", "label": "type-question", "screenshotAfter": true },
-    { "action": "click", "selector": "[data-testid=\"chat-composer-action\"]", "label": "send", "ariaAfter": true },
+    {
+      "action": "waitFor",
+      "selector": "[data-testid=\"chat-composer-textarea\"]",
+      "label": "await-composer"
+    },
+    {
+      "action": "assertText",
+      "selector": "[data-testid=\"chat-content\"]",
+      "value": "How can I help you",
+      "label": "greeting-present"
+    },
+    {
+      "action": "fill",
+      "selector": "[data-testid=\"chat-composer-textarea\"]",
+      "value": "What is the weather today?",
+      "label": "type-question",
+      "screenshotAfter": true
+    },
+    {
+      "action": "click",
+      "selector": "[data-testid=\"chat-composer-action\"]",
+      "label": "send",
+      "ariaAfter": true
+    },
     { "action": "waitFor", "value": "900", "label": "await-reply" },
-    { "action": "assertText", "selector": "[data-testid=\"chat-content\"]", "value": "I received: What is the weather today?", "label": "reply-received", "screenshotAfter": true }
+    {
+      "action": "assertText",
+      "selector": "[data-testid=\"chat-content\"]",
+      "value": "I received: What is the weather today?",
+      "label": "reply-received",
+      "screenshotAfter": true
+    }
   ]
 }

--- a/packages/evidence/src/video/walkthroughs/send-message.json
+++ b/packages/evidence/src/video/walkthroughs/send-message.json
@@ -1,0 +1,14 @@
+{
+  "slug": "send-message",
+  "granularity": "feature",
+  "title": "Send a chat message round-trip",
+  "steps": [
+    { "action": "goto", "value": "/", "label": "open-chat" },
+    { "action": "waitFor", "selector": "[data-testid=\"chat-composer-textarea\"]", "label": "await-composer" },
+    { "action": "assertText", "selector": "[data-testid=\"chat-content\"]", "value": "How can I help you", "label": "greeting-present" },
+    { "action": "fill", "selector": "[data-testid=\"chat-composer-textarea\"]", "value": "What is the weather today?", "label": "type-question", "screenshotAfter": true },
+    { "action": "click", "selector": "[data-testid=\"chat-composer-action\"]", "label": "send", "ariaAfter": true },
+    { "action": "waitFor", "value": "900", "label": "await-reply" },
+    { "action": "assertText", "selector": "[data-testid=\"chat-content\"]", "value": "I received: What is the weather today?", "label": "reply-received", "screenshotAfter": true }
+  ]
+}


### PR DESCRIPTION
Part of #14545 and epic #14541. This PR adds the video evidence lane infrastructure, but it does not close #14545 by itself: the remaining acceptance work is a real booted-app `--base-url` run and device-producer ingestion evidence through the same path.

## What changed

- Adds `packages/evidence/src/video/**` with MP4 normalization, video ingest, keyframe analysis fan-out, a data-driven Playwright walkthrough driver, schema validation, fixture server, shipped walkthrough definitions, and `video:walkthrough` / `video:ingest` CLIs.
- Treats video as first-class analyzed evidence: normalized clip, steps log, screenshots, ARIA snapshots, keyframes, and per-subject `analysis.json` all land in the bundle manifest.
- Keeps capture and analysis separated: Playwright is dynamically imported by walkthrough capture; pre-recorded video ingest does not need browser code.
- Resolves ffmpeg/ffprobe from explicit env, PATH, then installed static packages. It does not silently download/mutate dependencies at runtime; missing tools produce honest `skipped-missing-tool` records.
- Fixes OCR robustness exposed by this lane: Tesseract inputs are staged through a short temp path so deep bundle keyframe paths do not turn available OCR into failed analyzer records.
- Rebased onto current `develop`; the branch lands via squash merge as one clean commit.

## Review fixes

Addressed the blockers from earlier review comments:

- `steps=` now reports the actual executed walkthrough step count, not screenshots + ARIA count.
- If normalization is skipped because video tools are unavailable, ingest preserves the source extension instead of storing raw webm/mov bytes under `.mp4`.
- `waitFor.value` / `scroll.value` are numeric-string validated before they can reach Playwright as `NaN`.
- PR body language changed from closing #14545 to “Part of #14545” because fixture evidence is not the same as booted web/device evidence.
- The branch lands via squash merge, so intermediate commit metadata does not reach `develop`.

## Evidence

One command produced all three granularities and ingested them with keyframe analysis into a verifiable bundle:

```text
bun run --cwd packages/evidence video:walkthrough -- --def all --bundle /tmp/eliza-video-pr14629-84180de51c-ocr
```

Output on the current cleaned head:

```text
bundle eliza-video-pr14629-84180de51c-ocr
  app-tour         walkthrough steps=11 norm=transcoded keyframes=2 video=video/walkthroughs/app-tour.mp4
  send-button      element     steps=5 norm=transcoded keyframes=2 video=video/elements/send-button.mp4
  send-message     feature     steps=7 norm=transcoded keyframes=2 video=video/features/send-message.mp4

  walkthroughs ran: 3
  manifest:  /tmp/eliza-video-pr14629-84180de51c-ocr/manifest.json
  sha256:    1223283c06c8d5775738afe4aa3f48ed42de58572df558ec549016762dfb13b0
```

Bundle verification:

```text
bun run --cwd packages/evidence bundle:verify -- /tmp/eliza-video-pr14629-84180de51c-ocr
bundle eliza-video-pr14629-84180de51c-ocr
  artifacts: 33  verified: 33  issues: 0
  manifest sha256: 1223283c06c8d5775738afe4aa3f48ed42de58572df558ec549016762dfb13b0
  OK
```

Sample keyframe OCR after the long-path staging fix:

```json
{
  "status": "ran",
  "data": {
    "engine": "tesseract",
    "text": "sia Welcome to Eliza. How can | help you today?\nChat\nDocuments\nDatabase\nFiles\nSettings\nMessage Eliza... | et",
    "words": 19,
    "confidence": null
  }
}
```

Sample ARIA snapshot from the send-message walkthrough:

```yaml
- navigation:
  - heading "Eliza" [level=1]
  - button "Chat"
  - button "Documents"
  - button "Database"
  - button "Files"
  - button "Settings"
- main:
  - text: "Welcome to Eliza. How can I help you today? What is the weather today? Got it — I received: What is the weather today?"
  - textbox "Message input":
    - /placeholder: Message Eliza…
  - button "Send message": Send
```

The actual MP4s/keyframes are local generated artifacts and are reproducible from the command above. Per repo evidence policy, they are not committed into the repository; manual drag-drop to the PR remains available if maintainers want inline binaries before undrafting.

## Verification

- `bun run --cwd packages/evidence test` -> 35 files passed, 1 skipped; 307 tests passed, 1 skipped.
- `bun run --cwd packages/evidence typecheck` -> passed.
- `bun run --cwd packages/evidence lint` -> passed.
- `bun run audit:error-policy-ratchet` -> no new fallback-slop in touched production files.
- `git diff --check` -> passed.
- `bun run --cwd packages/evidence video:walkthrough -- --def all --bundle /tmp/eliza-video-pr14629-84180de51c-ocr` -> produced element, feature, and walkthrough videos with manifest artifacts.
- `bun run --cwd packages/evidence bundle:verify -- /tmp/eliza-video-pr14629-84180de51c-ocr` -> 33 artifacts verified, 0 issues.

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - new evidence infrastructure; no product UI surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `Generated as bundle keyframes/screenshots under /tmp/eliza-video-pr14629-84180de51c-ocr; sample OCR/ARIA excerpts included above`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `Generated MP4s under /tmp/eliza-video-pr14629-84180de51c-ocr/video/{elements,features,walkthroughs}; reproducible command and verifier output included above`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no backend service path changed; local fixture server only`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - fixture-driven evidence infrastructure; no production frontend runtime changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model/provider/prompt/agent behavior changed`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `Verified evidence bundle at /tmp/eliza-video-pr14629-84180de51c-ocr, manifest sha256 1223283c06c8d5775738afe4aa3f48ed42de58572df558ec549016762dfb13b0`.