### PR TITLE
fix(discord): expose overflowed component options as reply text (#14527)

### DIFF
--- a/packages/core/src/messaging/interactions/interactions.test.ts
+++ b/packages/core/src/messaging/interactions/interactions.test.ts
@@ -329,6 +329,21 @@ describe("callback codec", () => {
 		expect(decodeCallback("discord:somethingelse")).toBeNull();
 		expect(isInteractionCallback(undefined)).toBe(false);
 	});
+
+	// #14527 — the 64-byte default is Telegram's cap, not a universal one.
+	// Discord's custom_id allows 100 chars; a value that fits the platform's
+	// own limit must encode and round-trip through the limit-agnostic decoder.
+	it("honors a per-platform limit larger than the Telegram default (#14527)", () => {
+		const value = "x".repeat(80);
+		expect(encodeReplyCallback(value)).toBeNull();
+		const data = encodeReplyCallback(value, { maxBytes: 100 });
+		expect(data).not.toBeNull();
+		expect(decodeCallback(data)).toEqual({ kind: "reply", value });
+	});
+
+	it("still rejects values past the custom limit", () => {
+		expect(encodeReplyCallback("x".repeat(120), { maxBytes: 100 })).toBeNull();
+	});
 });
 
 describe("layout", () => {
@@ -475,6 +490,46 @@ describe("layout", () => {
 		const button = toNeutralLayout(block).rows[0]?.buttons?.[0];
 		expect(button?.url).toBeUndefined();
 		expect(button?.callbackData).toBeTruthy();
+	});
+
+	// #14527 — connectors with a roomier callback budget (Discord: 100-char
+	// custom_id) pass maxCallbackBytes so long option values still render as
+	// native buttons instead of dropping to the free-text fallback.
+	it("renders long choice values as buttons under maxCallbackBytes (#14527)", () => {
+		const value = "y".repeat(80);
+		const block: ChoiceInteraction = {
+			kind: "choice",
+			id: "i",
+			scope: "s",
+			options: [{ value, label: "Long" }],
+		};
+		const capped = toNeutralLayout(block);
+		expect(capped.rows).toHaveLength(0);
+		expect(capped.needsFallback).toBe(true);
+
+		const layout = toNeutralLayout(block, { maxCallbackBytes: 100 });
+		const button = layout.rows[0]?.buttons?.[0];
+		expect(layout.needsFallback).toBeFalsy();
+		expect(decodeCallback(button?.callbackData)).toEqual({
+			kind: "reply",
+			value,
+		});
+	});
+
+	it("threads maxCallbackBytes through followup chips (#14527)", () => {
+		const payload = "z".repeat(80);
+		const block: FollowupsInteraction = {
+			kind: "followups",
+			id: "f1",
+			options: [{ kind: "reply", payload, label: "Big" }],
+		};
+		expect(toNeutralLayout(block).rows).toHaveLength(0);
+		const button = toNeutralLayout(block, { maxCallbackBytes: 100 }).rows[0]
+			?.buttons?.[0];
+		expect(decodeCallback(button?.callbackData)).toEqual({
+			kind: "reply",
+			value: payload,
+		});
 	});
 });
 

--- a/plugins/plugin-discord/__tests__/draft-stream.test.ts
+++ b/plugins/plugin-discord/__tests__/draft-stream.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for the draft-stream controller's finalize path — the final
+ * streamed message must carry the reply's rendered components (#14527).
+ * Hand-rolled channel/message stubs capture the exact discord.js send/edit
+ * payloads; no network, no discord.com.
+ */
+import type {
+	ActionRowBuilder,
+	MessageActionRowComponentBuilder,
+	TextChannel,
+} from "discord.js";
+import { describe, expect, it } from "vitest";
+import { createDraftStreamController } from "../draft-stream";
+import type { DiscordActionRow } from "../types";
+import { buildDiscordComponents } from "../utils";
+
+interface CapturedSend {
+	content?: string;
+	components?: ActionRowBuilder<MessageActionRowComponentBuilder>[];
+}
+
+function makeChannel() {
+	const sends: CapturedSend[] = [];
+	const edits: CapturedSend[] = [];
+	const channel = {
+		send: async (options: CapturedSend) => {
+			sends.push(options);
+			return {
+				id: `msg-${sends.length}`,
+				content: options.content ?? "",
+				createdTimestamp: Date.now(),
+				attachments: { size: 0 },
+				edit: async (editOptions: CapturedSend) => {
+					edits.push(editOptions);
+					return { id: `msg-${sends.length}` };
+				},
+			};
+		},
+	} as unknown as TextChannel;
+	return { channel, sends, edits };
+}
+
+const choiceRow: DiscordActionRow = {
+	type: 1,
+	components: [
+		{ type: 2, custom_id: "ia1:yes", label: "Yes", style: 2 },
+		{ type: 2, custom_id: "ia1:no", label: "No", style: 2 },
+	],
+};
+
+function choiceComponents() {
+	const components = buildDiscordComponents([choiceRow]);
+	if (components?.length !== 1) {
+		throw new Error("choice row did not build into a Discord component");
+	}
+	return components;
+}
+
+function rowJson(component: unknown): {
+	type: number;
+	components: Array<{ custom_id?: string; label?: string }>;
+} {
+	return (component as { toJSON: () => ReturnType<typeof rowJson> }).toJSON();
+}
+
+describe("draft-stream finalize components (#14527)", () => {
+	it("attaches components to the finalized message", async () => {
+		const { channel, sends } = makeChannel();
+		const controller = createDraftStreamController();
+		await controller.start(channel);
+
+		const messages = await controller.finalize("Pick one", choiceComponents());
+
+		expect(messages).toHaveLength(1);
+		expect(sends).toHaveLength(1);
+		expect(sends[0].components).toHaveLength(1);
+		const row = rowJson(sends[0].components?.[0]);
+		expect(row.type).toBe(1);
+		expect(row.components.map((c) => c.custom_id)).toEqual([
+			"ia1:yes",
+			"ia1:no",
+		]);
+	});
+
+	it("edits the last snapshot to attach components when the final text already streamed", async () => {
+		const { channel, sends, edits } = makeChannel();
+		const controller = createDraftStreamController({
+			throttleMs: 250,
+			minInitialChars: 1,
+		});
+		await controller.start(channel);
+
+		controller.update("Pick one");
+		// Let the throttled snapshot flush so the full final text is already out.
+		await new Promise((resolve) => setTimeout(resolve, 400));
+		expect(sends).toHaveLength(1);
+
+		await controller.finalize("Pick one", choiceComponents());
+
+		// No duplicate message; the streamed snapshot gained the components.
+		expect(sends).toHaveLength(1);
+		expect(edits).toHaveLength(1);
+		expect(edits[0].content).toBe("Pick one");
+		const row = rowJson(edits[0].components?.[0]);
+		expect(row.components.map((c) => c.label)).toEqual(["Yes", "No"]);
+	});
+
+	it("attaches components only to the last chunk of a multi-message finalize", async () => {
+		const { channel, sends } = makeChannel();
+		const controller = createDraftStreamController({ maxChars: 60 });
+		await controller.start(channel);
+
+		const longText = Array.from(
+			{ length: 8 },
+			(_, i) => `Sentence number ${i} pads the reply.`,
+		).join(" ");
+		expect(longText.length).toBeGreaterThan(60);
+
+		await controller.finalize(longText, choiceComponents());
+
+		expect(sends.length).toBeGreaterThan(1);
+		const last = sends[sends.length - 1];
+		expect(last.components).toHaveLength(1);
+		for (const earlier of sends.slice(0, -1)) {
+			expect(earlier.components).toBeUndefined();
+		}
+	});
+
+	it("finalize without components stays component-free", async () => {
+		const { channel, sends } = makeChannel();
+		const controller = createDraftStreamController();
+		await controller.start(channel);
+
+		await controller.finalize("Just prose");
+
+		expect(sends).toHaveLength(1);
+		expect(sends[0].components).toBeUndefined();
+	});
+});

--- a/plugins/plugin-discord/__tests__/interactions.test.ts
+++ b/plugins/plugin-discord/__tests__/interactions.test.ts
@@ -86,6 +86,43 @@ describe("renderDiscordInteractions", () => {
 		expect(out.components.length).toBeLessThanOrEqual(5);
 	});
 
+	// #14527 — Discord's 5-row cap truncates overflow, but the dropped options
+	// must surface as prose + a free-text invite, never disappear silently.
+	it("surfaces options dropped past the 5-row cap as prose (#14527)", () => {
+		const options = Array.from(
+			{ length: 30 },
+			(_, i) => `o${i}=Option ${i}`,
+		).join("\n");
+		const out = renderDiscordInteractions({
+			text: `Pick one\n[CHOICE:s id=c]\n${options}\n[/CHOICE]`,
+		} as Content);
+		// 5 rows x 5 buttons render natively; options 25-29 overflow to prose.
+		expect(out.components).toHaveLength(5);
+		expect(out.needsFreeTextReply).toBe(true);
+		expect(out.text).toContain("More options (reply with one):");
+		for (let i = 25; i < 30; i++) {
+			expect(out.text).toContain(`Option ${i}`);
+		}
+		expect(out.text).not.toContain("Option 24");
+	});
+
+	// #14527 — Discord's custom_id budget is 100 chars, not Telegram's 64
+	// bytes. A value that fits Discord's own cap must render as a real button
+	// and round-trip through the callback decoder.
+	it("renders option values up to Discord's 100-char custom_id cap (#14527)", () => {
+		const value = "v".repeat(80);
+		const out = renderDiscordInteractions({
+			text: `Pick\n[CHOICE:s id=c1]\n${value}=Long option\n[/CHOICE]`,
+		} as Content);
+		const button = out.components[0]?.components[0];
+		expect(button?.label).toBe("Long option");
+		expect(decodeCallback(button?.custom_id)).toEqual({
+			kind: "reply",
+			value,
+		});
+		expect(out.needsFreeTextReply).toBe(false);
+	});
+
 	it("renders a navigate followup as a link button via resolveNavigateUrl (#8908)", () => {
 		const out = renderDiscordInteractions(
 			{

--- a/plugins/plugin-discord/__tests__/messages-component-delivery.test.ts
+++ b/plugins/plugin-discord/__tests__/messages-component-delivery.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Discord outbound delivery preserves rendered interaction components across
+ * direct-message and draft-stream paths. These tests exercise the manager layer
+ * because that is where connector policy, streaming, chunking, and transport
+ * payload construction converge.
+ *
+ * Drives the REAL `MessageManager.handleMessage` (inbound guards, DM policy,
+ * memory build, response callback) with a stub runtime whose message service
+ * invokes the response callback with a `[CHOICE]` reply, and captures the
+ * exact `user.send` / `channel.send` payloads. Only the discord.js SDK
+ * objects are stubbed; no bot token, no network.
+ */
+import type { Content, Memory, UUID } from "@elizaos/core";
+import { ChannelType, decodeCallback } from "@elizaos/core";
+import type {
+	ActionRowBuilder,
+	Message as DiscordMessage,
+	MessageActionRowComponentBuilder,
+} from "discord.js";
+import { ChannelType as DiscordChannelType } from "discord.js";
+import { describe, expect, it } from "vitest";
+import { MessageManager } from "../messages.ts";
+import type { ICompatRuntime, IDiscordService } from "../types.ts";
+
+interface CapturedSend {
+	content?: string;
+	files?: unknown[];
+	components?: ActionRowBuilder<MessageActionRowComponentBuilder>[];
+}
+
+const AGENT_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" as UUID;
+const noop = () => {};
+
+const CHOICE_REPLY: Content = {
+	text: "Pick one:\n[CHOICE:approve id=c1]\nyes=Yes, ship it\nno=Cancel\n[/CHOICE]",
+	channelType: "DM",
+};
+
+function makeRuntime(
+	replyContent: Content,
+	settings: Record<string, string> = {},
+): { runtime: ICompatRuntime; errors: string[] } {
+	const errors: string[] = [];
+	const runtime = {
+		agentId: AGENT_ID,
+		character: { name: "Eliza" },
+		logger: {
+			debug: noop,
+			info: noop,
+			warn: noop,
+			// A callback failure surfaces as logger.error + a "please retry"
+			// fallback send; collecting errors lets tests assert the delivery
+			// path completed cleanly instead of silently degrading.
+			error: (...args: unknown[]) => {
+				errors.push(JSON.stringify(args));
+			},
+		},
+		getSetting: (key: string) =>
+			key === "ELIZA_LIFEOPS_PASSIVE_CONNECTORS"
+				? "false"
+				: (settings[key] ?? undefined),
+		getService: () => null,
+		ensureConnection: async () => {},
+		// The callback persists outbound memories via createDiscordMessageMemoryOnce.
+		getMemoryById: async () => null,
+		createMemory: async (memory: Memory) => memory.id,
+		// Invoking the production response callback with a crafted reply reaches
+		// the same outbound branches that connector messages use at runtime.
+		messageService: {
+			handleMessage: async (
+				_runtime: unknown,
+				_message: Memory,
+				callback: (content: Content) => Promise<unknown>,
+			) => {
+				await callback(replyContent);
+			},
+		},
+	} as unknown as ICompatRuntime;
+	return { runtime, errors };
+}
+
+function makeSentMessage(id: string, options: CapturedSend) {
+	return {
+		id,
+		content: options.content ?? "",
+		url: `https://discord.com/channels/@me/1/${id}`,
+		createdTimestamp: Date.now(),
+		attachments: { size: 0 },
+		edit: async () => ({ id }),
+	};
+}
+
+function makeInbound(channel: unknown, authorId: string): DiscordMessage {
+	return {
+		id: "666000000000000000",
+		content: "which one?",
+		createdTimestamp: Date.now(),
+		author: {
+			id: authorId,
+			bot: false,
+			username: "tester",
+			globalName: "Tester",
+			displayName: "Tester",
+			discriminator: "0",
+		},
+		member: null,
+		channel,
+		guild: undefined,
+		interaction: null,
+		reference: undefined,
+		embeds: [],
+		stickers: { size: 0 },
+		attachments: { size: 0 },
+		mentions: { users: new Map(), repliedUser: undefined },
+	} as unknown as DiscordMessage;
+}
+
+const INBOUND_MEMORY: Memory = {
+	id: "12345678-1234-1234-1234-123456789abc" as UUID,
+	entityId: "87654321-4321-4321-4321-cba987654321" as UUID,
+	agentId: AGENT_ID,
+	roomId: "11111111-2222-3333-4444-555555555555" as UUID,
+	content: { text: "which one?", source: "discord" },
+};
+
+function makeDiscordService(client: unknown): IDiscordService {
+	return {
+		client,
+		accountId: "default",
+		getChannelType: async () => ChannelType.DM,
+		discordSettings: {
+			autoReply: true,
+			dmPolicy: "open",
+			shouldIgnoreBotMessages: true,
+			shouldIgnoreDirectMessages: false,
+			replyToMode: "first",
+		},
+		buildMemoryFromMessage: async () => INBOUND_MEMORY,
+	} as unknown as IDiscordService;
+}
+
+function rowJson(component: unknown): {
+	type: number;
+	components: Array<{ custom_id: string; label: string }>;
+} {
+	return (component as { toJSON: () => ReturnType<typeof rowJson> }).toJSON();
+}
+
+describe("Discord outbound component delivery (#14527)", () => {
+	it("carries rendered components on a DM send", async () => {
+		const dmSends: CapturedSend[] = [];
+		const dmUser = {
+			id: "555000111222333444",
+			send: async (options: CapturedSend) => {
+				dmSends.push(options);
+				return makeSentMessage("990000000000000001", options);
+			},
+		};
+
+		const client = {
+			user: { id: "888000000000000000" },
+			users: { fetch: async () => dmUser },
+		};
+
+		const channel = {
+			id: "777000000000000000",
+			type: DiscordChannelType.DM,
+			isThread: () => false,
+			send: async () => {
+				throw new Error(
+					"DM replies must go through user.send, not channel.send",
+				);
+			},
+		};
+
+		const { runtime, errors } = makeRuntime(CHOICE_REPLY);
+		const manager = new MessageManager(makeDiscordService(client), runtime);
+		await manager.handleMessage(makeInbound(channel, dmUser.id));
+
+		expect(errors).toEqual([]);
+		expect(dmSends).toHaveLength(1);
+		const sent = dmSends[0];
+		expect(sent.content).toBe("Pick one:");
+		expect(sent.components).toHaveLength(1);
+		const row = rowJson(sent.components?.[0]);
+		expect(row.type).toBe(1);
+		expect(row.components.map((c) => c.label)).toEqual([
+			"Yes, ship it",
+			"Cancel",
+		]);
+		expect(decodeCallback(row.components[0].custom_id)).toEqual({
+			kind: "reply",
+			value: "yes",
+		});
+	});
+
+	it("carries rendered components through draft-stream finalize", async () => {
+		const channelSends: CapturedSend[] = [];
+		const channel = {
+			id: "777000000000000000",
+			type: DiscordChannelType.DM,
+			isThread: () => false,
+			send: async (options: CapturedSend) => {
+				channelSends.push(options);
+				return makeSentMessage(
+					`99000000000000000${channelSends.length}`,
+					options,
+				);
+			},
+		};
+
+		const client = {
+			user: { id: "888000000000000000" },
+			users: {
+				fetch: async () => {
+					throw new Error(
+						"draft-stream replies must finalize on the channel, not re-fetch the user",
+					);
+				},
+			},
+		};
+
+		const { runtime, errors } = makeRuntime(CHOICE_REPLY, {
+			DISCORD_DRAFT_STREAMING: "true",
+		});
+		const manager = new MessageManager(makeDiscordService(client), runtime);
+		await manager.handleMessage(makeInbound(channel, "555000111222333444"));
+
+		expect(errors).toEqual([]);
+		expect(channelSends).toHaveLength(1);
+		const sent = channelSends[0];
+		expect(sent.content).toBe("Pick one:");
+		expect(sent.components).toHaveLength(1);
+		const row = rowJson(sent.components?.[0]);
+		expect(row.components.map((c) => c.label)).toEqual([
+			"Yes, ship it",
+			"Cancel",
+		]);
+	});
+});

--- a/plugins/plugin-discord/interactions.ts
+++ b/plugins/plugin-discord/interactions.ts
@@ -110,8 +110,29 @@ export function renderDiscordInteractions(
 		if (!producedButton && layout.text) extraLines.push(layout.text);
 	}
 
+	// Discord hard-caps a message at 5 action rows. When controls overflow the
+	// cap, surface the dropped options as prose and invite a typed reply so no
+	// option is silently unreachable.
+	const visibleRows = rows.slice(0, MAX_ROWS);
+	const droppedButtons = rows.slice(MAX_ROWS).flatMap((row) => row.components);
+	if (droppedButtons.length > 0) {
+		needsFreeTextReply = true;
+		const droppedLabels = droppedButtons
+			.map((button) =>
+				button.url && button.label
+					? `${button.label} (${button.url})`
+					: (button.label ?? ""),
+			)
+			.filter((label) => label.trim().length > 0);
+		if (droppedLabels.length > 0) {
+			extraLines.push(
+				`More options (reply with one): ${droppedLabels.join(", ")}`,
+			);
+		}
+	}
+
 	const text = [cleanedText, ...extraLines]
 		.filter((s) => s.trim().length > 0)
 		.join("\n\n");
-	return { text, components: rows.slice(0, MAX_ROWS), needsFreeTextReply };
+	return { text, components: visibleRows, needsFreeTextReply };
 }


### PR DESCRIPTION
Part of #14527. This rebased branch keeps the remaining production change that is not already on `develop`: Discord no longer silently drops options past the 5-action-row cap. Overflowed buttons now surface as prose and set `needsFreeTextReply`, so a user can still reply with an option that cannot fit as a native component.

`develop` already contains the DM component delivery, draft-stream finalize component delivery, and Discord 100-character callback budget fixes from earlier MVP PRs. This PR keeps focused regression tests for those paths so the current behavior is proven at the codec/layout, renderer, draft-stream, and message-manager delivery layers.

## Scope

- `plugins/plugin-discord/interactions.ts`: when native action rows exceed Discord's 5-row limit, append `More options (reply with one): ...` for the dropped labels and mark the reply as needing a free-text fallback.
- `packages/core/src/messaging/interactions/interactions.test.ts`: prove the per-platform callback budget and layout threading for Discord-sized callback payloads.
- `plugins/plugin-discord/__tests__/interactions.test.ts`: prove overflow is observable and Discord-sized callback IDs round-trip.
- `plugins/plugin-discord/__tests__/draft-stream.test.ts`: prove finalized draft-stream messages preserve built Discord components.
- `plugins/plugin-discord/__tests__/messages-component-delivery.test.ts`: drive the real `MessageManager.handleMessage` with stubs at the Discord SDK boundary and assert the captured `user.send` / `channel.send` payloads carry decodable action rows.

## Required Evidence Rows

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: N/A - connector backend behavior only; no app UI pixels changed.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: N/A - connector backend behavior only; no app UI pixels changed.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: N/A - no Discord bot credentials or live Discord workspace are available on this host.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: N/A - no live Discord service was started; focused tests capture Discord SDK send payloads directly.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - no model/action/prompt behavior changed; this is connector rendering and transport payload handling.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - no persistent domain artifacts are produced by these pure/unit connector tests.

## Verification

<!-- evidence-row:tests -->
- Tests: `bun run --cwd packages/core test src/messaging/interactions/interactions.test.ts` passed: 1 file, 49 tests.
<!-- evidence-row:tests -->
- Tests: `bun run --cwd plugins/plugin-discord test __tests__/interactions.test.ts __tests__/draft-stream.test.ts __tests__/messages-component-delivery.test.ts` passed: 3 files, 15 tests.
<!-- evidence-row:static-analysis -->
- Static analysis: `bunx @biomejs/biome check packages/core/src/messaging/interactions/interactions.test.ts plugins/plugin-discord/interactions.ts plugins/plugin-discord/__tests__/interactions.test.ts plugins/plugin-discord/__tests__/draft-stream.test.ts plugins/plugin-discord/__tests__/messages-component-delivery.test.ts --no-errors-on-unmatched` passed.
<!-- evidence-row:diff-hygiene -->
- Diff hygiene: `git diff --check origin/develop...HEAD` passed.
<!-- evidence-row:error-policy -->
- Error policy: `bun run audit:error-policy-ratchet` passed: no new fallback slop in touched files.
<!-- evidence-row:build -->
- Build prerequisite: `bun run --cwd packages/shared build:i18n`, `bun run --cwd packages/cloud/routing build`, and `bun run --cwd packages/core build:node` passed so plugin tests used this worktree's generated data and built workspace dependencies.
<!-- evidence-row:typecheck -->
- Typecheck: `bun run --cwd plugins/plugin-discord typecheck` is blocked by existing workspace resolution errors outside this diff: missing `@elizaos/plugin-sql`, `@elizaos/vault`, and `@elizaos/plugin-commands` type entries, plus an existing implicit-any in `catalog-commands.ts`.

## Remaining #14527 Work

#14527 should stay open after this PR until live Discord bot evidence is captured and reviewed, and until the broader residual items in the issue are explicitly resolved or split: select/modal/embed/ephemeral parity and any real-client screenshots/video requested for MVP evidence.
