### PR TITLE
feat(ui): standardized collapsible connector-setup widgets in chat (#14412)

### DIFF
--- a/packages/ui/src/components/chat/InlinePluginConfig.stories.tsx
+++ b/packages/ui/src/components/chat/InlinePluginConfig.stories.tsx
@@ -1,0 +1,196 @@
+/**
+ * Storybook states for the in-chat connector-setup widget (#14412): the
+ * `[CONFIG:<pluginId>]` card (InlinePluginConfig) inside its standardized
+ * ChatWidgetShell. Three canonical states: fresh setup (expanded, minimal
+ * fields only), advanced-expanded (the optional params revealed behind the
+ * Advanced disclosure), and connected-collapsed (compact status row with the
+ * chevron re-expand affordance).
+ *
+ * Self-contained mocking: InlinePluginConfig fetches `/api/plugins` through
+ * the ElizaClient's global-fetch transport, so each story installs a
+ * window.fetch answering that route with a Telegram-shaped connector fixture.
+ */
+
+import type { PluginParamDef } from "@elizaos/shared";
+import type { Decorator, Meta, StoryObj } from "@storybook/react";
+import type { PluginInfo } from "../../api/client-types-config";
+import { assert, waitForTestId } from "../../storybook/home-widget-decorator";
+import { MockAppProvider } from "../../storybook/mock-providers";
+import { InlinePluginConfig } from "./MessageContent";
+
+function param(
+  over: Partial<PluginParamDef> & { key: string },
+): PluginParamDef {
+  return {
+    type: "string",
+    description: "",
+    required: false,
+    sensitive: false,
+    currentValue: null,
+    isSet: false,
+    ...over,
+  };
+}
+
+function telegram(over: Partial<PluginInfo> = {}): PluginInfo {
+  return {
+    id: "telegram",
+    name: "Telegram",
+    description: "Telegram bot connector",
+    enabled: false,
+    configured: false,
+    envKey: null,
+    category: "connector",
+    source: "bundled",
+    icon: "\u{1F4AC}",
+    parameters: [
+      param({
+        key: "TELEGRAM_BOT_TOKEN",
+        description: "Bot token from @BotFather",
+        required: true,
+        sensitive: true,
+      }),
+      param({ key: "TELEGRAM_API_ROOT", description: "API root override" }),
+      param({
+        key: "TELEGRAM_ALLOWED_CHATS",
+        description: "Comma-separated chat allowlist",
+      }),
+    ],
+    validationErrors: [],
+    validationWarnings: [],
+    ...over,
+  };
+}
+
+/** Install a window.fetch that answers `/api/plugins` with the fixture. */
+function withPlugins(plugin: PluginInfo): Decorator {
+  return (Story) => {
+    const originalFetch = window.fetch;
+    window.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      const body = url.includes("/api/plugins") ? { plugins: [plugin] } : {};
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof window.fetch;
+    // Delayed restore (not queueMicrotask) so the widget's mount fetch and the
+    // play-function interactions resolve against the mock; each story renders
+    // in its own iframe so this cannot leak across stories.
+    setTimeout(() => {
+      window.fetch = originalFetch;
+    }, 4_000);
+    return (
+      <MockAppProvider>
+        <div className="max-w-xl">
+          <Story />
+        </div>
+      </MockAppProvider>
+    );
+  };
+}
+
+const meta = {
+  title: "Chat/ConnectorSetupWidget",
+  component: InlinePluginConfig,
+  parameters: { layout: "padded" },
+  args: { pluginId: "telegram" },
+} satisfies Meta<typeof InlinePluginConfig>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Fresh setup: unconfigured connector mounts EXPANDED with only the required
+ * (minimal) field visible; the optional params sit behind the closed Advanced
+ * disclosure.
+ */
+export const FreshSetup: Story = {
+  decorators: [withPlugins(telegram())],
+  play: async ({ canvasElement }) => {
+    const chevron = await waitForTestId(
+      canvasElement,
+      "inline-plugin-config-chevron",
+    );
+    assert(
+      chevron.getAttribute("aria-expanded") === "true",
+      "fresh setup starts expanded",
+    );
+    assert(
+      canvasElement.querySelector(
+        'input[data-config-key="TELEGRAM_BOT_TOKEN"]',
+      ) !== null,
+      "required token field is in the minimal set",
+    );
+    assert(
+      canvasElement.querySelector(
+        'input[data-config-key="TELEGRAM_API_ROOT"]',
+      ) === null,
+      "optional field stays behind the Advanced disclosure",
+    );
+  },
+};
+
+/** Advanced disclosure open: the optional params are revealed below the fold. */
+export const AdvancedExpanded: Story = {
+  decorators: [withPlugins(telegram())],
+  play: async ({ canvasElement }) => {
+    await waitForTestId(canvasElement, "inline-plugin-config-body");
+    const advancedToggle = Array.from(
+      canvasElement.querySelectorAll("button"),
+    ).find((b) => b.textContent?.includes("Advanced"));
+    assert(advancedToggle, "the Advanced disclosure toggle renders");
+    advancedToggle.click();
+    const revealed = await new Promise<Element | null>((resolve) => {
+      setTimeout(
+        () =>
+          resolve(
+            canvasElement.querySelector(
+              'input[data-config-key="TELEGRAM_API_ROOT"]',
+            ),
+          ),
+        100,
+      );
+    });
+    assert(revealed !== null, "optional fields render once Advanced is open");
+  },
+};
+
+/**
+ * Connected: enabled + configured connector mounts COLLAPSED to the compact
+ * status row ("Telegram is enabled.") with the chevron as the re-expand
+ * affordance; the body stays mounted but costs no layout.
+ */
+export const ConnectedCollapsed: Story = {
+  decorators: [withPlugins(telegram({ enabled: true, configured: true }))],
+  play: async ({ canvasElement }) => {
+    const summary = await waitForTestId(
+      canvasElement,
+      "inline-plugin-config-summary",
+    );
+    // The story-smoke harness's mock translator returns the raw defaultValue
+    // without `{{name}}` interpolation, so match the stable suffix only.
+    assert(
+      summary.textContent?.includes("is enabled."),
+      "collapsed summary shows the connected status",
+    );
+    const chevron = await waitForTestId(
+      canvasElement,
+      "inline-plugin-config-chevron",
+    );
+    assert(
+      chevron.getAttribute("aria-expanded") === "false",
+      "connected card is collapsed",
+    );
+    const body = await waitForTestId(
+      canvasElement,
+      "inline-plugin-config-body",
+    );
+    assert(body.style.display === "none", "collapsed body is out of layout");
+  },
+};

--- a/packages/ui/src/components/chat/InlinePluginConfig.stories.tsx
+++ b/packages/ui/src/components/chat/InlinePluginConfig.stories.tsx
@@ -173,10 +173,8 @@ export const ConnectedCollapsed: Story = {
       canvasElement,
       "inline-plugin-config-summary",
     );
-    // The story-smoke harness's mock translator returns the raw defaultValue
-    // without `{{name}}` interpolation, so match the stable suffix only.
     assert(
-      summary.textContent?.includes("is enabled."),
+      summary.textContent?.includes("Telegram is enabled."),
       "collapsed summary shows the connected status",
     );
     const chevron = await waitForTestId(

--- a/packages/ui/src/components/chat/MessageContent.config-render-count.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.config-render-count.test.tsx
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+
+/**
+ * Repaint lock for the `[CONFIG:<pluginId>]` connector-setup widget (#14412),
+ * in the spirit of chat-transcript.render-count.test.tsx (#9141): a transcript
+ * parent re-rendering with unrelated state must NOT re-render the config-card
+ * subtree — `InlinePluginConfig` is memoized on its single primitive prop — and
+ * conversely a widget-internal update (a field edit) must re-render ONLY the
+ * widget, proving its state stays isolated from the transcript.
+ *
+ * HOW RENDERS ARE COUNTED: `ConfigRenderer` receives fresh props on every
+ * `InlinePluginConfig` render (rebuilt `values` / `hints` objects) and is not
+ * memoized, so it renders exactly once per InlinePluginConfig render. This
+ * suite replaces it with a counting probe that forwards `onChange` (a real
+ * production prop) to drive the field-edit case. The real form engine is
+ * covered by MessageContent.config.test.tsx / .connector-setup.test.tsx.
+ */
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { useState } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConversationMessage } from "../../api/client-types-chat";
+import type { PluginInfo } from "../../api/client-types-config";
+import { __setAppValueForTests } from "../../state/app-store";
+import { AppContext } from "../../state/useApp";
+
+const { clientMock, configRendererRenders } = vi.hoisted(() => ({
+  clientMock: {
+    getPlugins: vi.fn(),
+    updatePlugin: vi.fn(),
+  },
+  configRendererRenders: { count: 0 },
+}));
+
+vi.mock("../../api/client", () => ({ client: clientMock }));
+
+vi.mock("../config-ui/config-renderer", () => ({
+  ConfigRenderer: ({
+    onChange,
+  }: {
+    onChange?: (key: string, value: unknown) => void;
+  }) => {
+    configRendererRenders.count += 1;
+    return (
+      <button
+        type="button"
+        data-testid="probe-edit-field"
+        onClick={() => onChange?.("TELEGRAM_BOT_TOKEN", "12345:tok")}
+      >
+        probe
+      </button>
+    );
+  },
+}));
+
+import { MessageContent } from "./MessageContent";
+
+function plugin(): PluginInfo {
+  return {
+    id: "telegram",
+    name: "Telegram",
+    description: "",
+    enabled: false,
+    configured: false,
+    envKey: null,
+    category: "connector",
+    source: "bundled",
+    parameters: [
+      {
+        key: "TELEGRAM_BOT_TOKEN",
+        type: "string",
+        description: "Bot token",
+        required: true,
+        sensitive: true,
+        currentValue: null,
+        isSet: false,
+      },
+    ],
+    validationErrors: [],
+    validationWarnings: [],
+  };
+}
+
+const message: ConversationMessage = {
+  id: "m-render-count",
+  role: "assistant",
+  text: "Set it up: [CONFIG:telegram]",
+  timestamp: 1_700_000_000_000,
+} as ConversationMessage;
+
+/**
+ * Stand-in for the transcript row: `unrelated` state changes re-render the
+ * host (and MessageContent below it) exactly like a streaming tick or store
+ * update re-rendering the surrounding transcript would.
+ */
+function TranscriptHost() {
+  const [unrelated, setUnrelated] = useState(0);
+  return (
+    <div>
+      <button
+        type="button"
+        data-testid="unrelated-tick"
+        onClick={() => setUnrelated((n) => n + 1)}
+      >
+        tick {unrelated}
+      </button>
+      <MessageContent message={message} />
+    </div>
+  );
+}
+
+let appValue: never;
+
+beforeEach(() => {
+  configRendererRenders.count = 0;
+  clientMock.getPlugins.mockReset();
+  clientMock.updatePlugin.mockReset();
+  clientMock.getPlugins.mockResolvedValue({ plugins: [plugin()] });
+  appValue = {
+    t: (key: string, vars?: Record<string, unknown>) =>
+      String(vars?.defaultValue ?? key),
+    setActionNotice: vi.fn(),
+    loadPlugins: vi.fn(() => Promise.resolve()),
+    sendActionMessage: vi.fn(),
+    setTab: vi.fn(),
+    handleChatRetry: vi.fn(),
+  } as never;
+  __setAppValueForTests(appValue);
+});
+
+afterEach(() => {
+  cleanup();
+  __setAppValueForTests(null);
+});
+
+describe("InlinePluginConfig render isolation (#14412)", () => {
+  it("does not re-render on transcript-parent re-renders; re-renders alone on its own edits", async () => {
+    render(
+      <AppContext.Provider value={appValue}>
+        <TranscriptHost />
+      </AppContext.Provider>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("probe-edit-field")).toBeTruthy();
+    });
+    const afterMount = configRendererRenders.count;
+    expect(afterMount).toBeGreaterThan(0);
+
+    // Two unrelated transcript ticks: the memo boundary must swallow both.
+    fireEvent.click(screen.getByTestId("unrelated-tick"));
+    fireEvent.click(screen.getByTestId("unrelated-tick"));
+    expect(configRendererRenders.count).toBe(afterMount);
+
+    // A widget-internal field edit still flows: exactly one extra render of
+    // the widget subtree, none for the transcript parent.
+    fireEvent.click(screen.getByTestId("probe-edit-field"));
+    expect(configRendererRenders.count).toBe(afterMount + 1);
+    // The host's own state was untouched by the widget edit.
+    expect(screen.getByTestId("unrelated-tick").textContent).toContain(
+      "tick 2",
+    );
+  });
+
+  it("chevron collapse/expand repaints only the shell, not the widget body", async () => {
+    render(
+      <AppContext.Provider value={appValue}>
+        <TranscriptHost />
+      </AppContext.Provider>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("probe-edit-field")).toBeTruthy();
+    });
+    const afterMount = configRendererRenders.count;
+
+    // Expand/collapse state lives in ChatWidgetShell BELOW the memo boundary;
+    // toggling must not re-render the widget's body children.
+    fireEvent.click(screen.getByTestId("inline-plugin-config-chevron"));
+    fireEvent.click(screen.getByTestId("inline-plugin-config-chevron"));
+    expect(configRendererRenders.count).toBe(afterMount);
+  });
+});

--- a/packages/ui/src/components/chat/MessageContent.connector-setup.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.connector-setup.test.tsx
@@ -1,0 +1,290 @@
+// @vitest-environment jsdom
+
+/**
+ * Connector-setup widget behavior for the `[CONFIG:<pluginId>]` chat card
+ * (#14412): the standardized ChatWidgetShell integration on top of
+ * InlinePluginConfig. Covers the minimal-vs-advanced field split (required
+ * params render immediately; optional params sit behind ConfigRenderer's
+ * Advanced disclosure), the disclosure toggle, collapse-on-connect (a card
+ * mounts collapsed for an already-connected plugin and auto-collapses when the
+ * enable flow reaches connected status), chevron re-expansion, and field-edit
+ * preservation across a collapse/expand round-trip. Runs against the real
+ * ConfigRenderer + a mocked ElizaClient, mirroring
+ * MessageContent.config.test.tsx.
+ */
+
+import type { PluginParamDef } from "@elizaos/shared";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import type * as React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withFrozenClock, withSeededRandom } from "../../../test/determinism";
+import type { ConversationMessage } from "../../api/client-types-chat";
+import type { PluginInfo } from "../../api/client-types-config";
+import { __setAppValueForTests } from "../../state/app-store";
+import { AppContext } from "../../state/useApp";
+
+const { clientMock } = vi.hoisted(() => ({
+  clientMock: {
+    getPlugins: vi.fn(),
+    updatePlugin: vi.fn(),
+  },
+}));
+
+vi.mock("../../api/client", () => ({ client: clientMock }));
+
+import { MessageContent } from "./MessageContent";
+
+// ── fixtures ────────────────────────────────────────────────────────
+
+function param(
+  over: Partial<PluginParamDef> & { key: string },
+): PluginParamDef {
+  return {
+    type: "string",
+    description: "",
+    required: false,
+    sensitive: false,
+    currentValue: null,
+    isSet: false,
+    ...over,
+  };
+}
+
+/** A Telegram-shaped connector: one required token + optional extras. */
+function telegram(over: Partial<PluginInfo> = {}): PluginInfo {
+  return {
+    id: "telegram",
+    name: "Telegram",
+    description: "",
+    enabled: false,
+    configured: false,
+    envKey: null,
+    category: "connector",
+    source: "bundled",
+    parameters: [
+      param({
+        key: "TELEGRAM_BOT_TOKEN",
+        description: "Bot token",
+        required: true,
+      }),
+      param({ key: "TELEGRAM_API_ROOT", description: "API root override" }),
+      param({ key: "TELEGRAM_ALLOWED_CHATS", description: "Chat filter" }),
+    ],
+    validationErrors: [],
+    validationWarnings: [],
+    ...over,
+  };
+}
+
+function assistant(text: string): ConversationMessage {
+  return {
+    id: "m-connector",
+    role: "assistant",
+    text,
+    timestamp: 1_700_000_000_000,
+  } as ConversationMessage;
+}
+
+function withApp(node: React.ReactElement) {
+  const t = (key: string, vars?: Record<string, unknown>) => {
+    const template = String(vars?.defaultValue ?? key);
+    return template.replace(/\{\{(\w+)\}\}/g, (whole, name) =>
+      vars && name in vars ? String(vars[name]) : whole,
+    );
+  };
+  const appValue = {
+    t,
+    setActionNotice: vi.fn(),
+    loadPlugins: vi.fn(() => Promise.resolve()),
+    sendActionMessage: vi.fn(),
+  } as never;
+  __setAppValueForTests(appValue);
+  return render(
+    <AppContext.Provider value={appValue}>{node}</AppContext.Provider>,
+  );
+}
+
+function widgetBody() {
+  return screen.getByTestId("inline-plugin-config-body");
+}
+
+function chevron() {
+  return screen.getByTestId("inline-plugin-config-chevron");
+}
+
+function tokenInput(container: HTMLElement) {
+  return container.querySelector(
+    'input[data-config-key="TELEGRAM_BOT_TOKEN"]',
+  ) as HTMLInputElement | null;
+}
+
+beforeEach(() => {
+  withFrozenClock();
+  withSeededRandom();
+  clientMock.getPlugins.mockReset();
+  clientMock.updatePlugin.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  __setAppValueForTests(null);
+});
+
+// ── minimal vs advanced ─────────────────────────────────────────────
+
+describe("connector-setup card — minimal + Advanced split", () => {
+  it("renders required params immediately and moves optional params behind Advanced", async () => {
+    clientMock.getPlugins.mockResolvedValue({ plugins: [telegram()] });
+    const { container } = withApp(
+      <MessageContent message={assistant("[CONFIG:telegram]")} />,
+    );
+
+    await screen.findByText("Telegram Configuration");
+    // Minimal set: the schema-required token field is present.
+    expect(tokenInput(container)).toBeTruthy();
+    // Optional params are NOT rendered until the Advanced disclosure opens.
+    expect(
+      container.querySelector('input[data-config-key="TELEGRAM_API_ROOT"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector(
+        'input[data-config-key="TELEGRAM_ALLOWED_CHATS"]',
+      ),
+    ).toBeNull();
+    // The disclosure advertises how many fields it holds.
+    const advancedToggle = screen.getByRole("button", { name: /Advanced/ });
+    expect(advancedToggle.textContent).toContain("2");
+  });
+
+  it("the Advanced toggle reveals the optional fields", async () => {
+    clientMock.getPlugins.mockResolvedValue({ plugins: [telegram()] });
+    const { container } = withApp(
+      <MessageContent message={assistant("[CONFIG:telegram]")} />,
+    );
+    await screen.findByText("Telegram Configuration");
+
+    fireEvent.click(screen.getByRole("button", { name: /Advanced/ }));
+
+    expect(
+      container.querySelector('input[data-config-key="TELEGRAM_API_ROOT"]'),
+    ).toBeTruthy();
+    expect(
+      container.querySelector(
+        'input[data-config-key="TELEGRAM_ALLOWED_CHATS"]',
+      ),
+    ).toBeTruthy();
+    // Required field stays in place.
+    expect(tokenInput(container)).toBeTruthy();
+  });
+
+  it("keeps every field minimal when the plugin declares no required params", async () => {
+    clientMock.getPlugins.mockResolvedValue({
+      plugins: [
+        telegram({
+          parameters: [
+            param({ key: "TELEGRAM_API_ROOT", description: "API root" }),
+          ],
+        }),
+      ],
+    });
+    const { container } = withApp(
+      <MessageContent message={assistant("[CONFIG:telegram]")} />,
+    );
+    await screen.findByText("Telegram Configuration");
+
+    // No required params → no promotion; an all-Advanced card would be empty.
+    expect(
+      container.querySelector('input[data-config-key="TELEGRAM_API_ROOT"]'),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Advanced/ })).toBeNull();
+  });
+});
+
+// ── collapse-on-connect ─────────────────────────────────────────────
+
+describe("connector-setup card — collapse-on-connect", () => {
+  it("mounts collapsed to a compact status row when already connected", async () => {
+    clientMock.getPlugins.mockResolvedValue({
+      plugins: [telegram({ enabled: true, configured: true })],
+    });
+    withApp(<MessageContent message={assistant("[CONFIG:telegram]")} />);
+
+    await screen.findByText("Telegram Configuration");
+    expect(chevron().getAttribute("aria-expanded")).toBe("false");
+    // Compact summary row + hidden (but mounted) body.
+    expect(
+      screen.getByTestId("inline-plugin-config-summary").textContent,
+    ).toContain("Telegram is enabled.");
+    expect(widgetBody().style.display).toBe("none");
+    expect(widgetBody().style.contentVisibility).toBe("hidden");
+  });
+
+  it("the chevron re-expands a connected card to the full form", async () => {
+    clientMock.getPlugins.mockResolvedValue({
+      plugins: [telegram({ enabled: true, configured: true })],
+    });
+    const { container } = withApp(
+      <MessageContent message={assistant("[CONFIG:telegram]")} />,
+    );
+    await screen.findByText("Telegram Configuration");
+
+    fireEvent.click(chevron());
+
+    expect(chevron().getAttribute("aria-expanded")).toBe("true");
+    expect(widgetBody().style.display).toBe("");
+    expect(tokenInput(container)).toBeTruthy();
+    // The connected card remains fully operable — Disable is reachable.
+    expect(screen.getByRole("button", { name: "Disable" })).toBeTruthy();
+  });
+
+  it("auto-collapses when the enable flow reaches connected status", async () => {
+    clientMock.getPlugins.mockResolvedValue({
+      plugins: [telegram({ parameters: [] })],
+    });
+    clientMock.updatePlugin.mockResolvedValue({ ok: true });
+    withApp(<MessageContent message={assistant("[CONFIG:telegram]")} />);
+
+    const enableButton = await screen.findByRole("button", {
+      name: "Enable plugin",
+    });
+    // Unconfigured connector starts expanded.
+    expect(chevron().getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.click(enableButton);
+
+    // Connected status collapses the card to the compact summary.
+    await waitFor(() => {
+      expect(chevron().getAttribute("aria-expanded")).toBe("false");
+    });
+    expect(
+      screen.getByTestId("inline-plugin-config-summary").textContent,
+    ).toContain("Telegram is enabled.");
+    expect(widgetBody().style.display).toBe("none");
+  });
+
+  it("preserves in-progress field edits across a collapse/expand round-trip", async () => {
+    clientMock.getPlugins.mockResolvedValue({ plugins: [telegram()] });
+    const { container } = withApp(
+      <MessageContent message={assistant("[CONFIG:telegram]")} />,
+    );
+    await screen.findByText("Telegram Configuration");
+
+    fireEvent.change(tokenInput(container) as HTMLInputElement, {
+      target: { value: "12345:draft-token" },
+    });
+    fireEvent.click(chevron()); // manual collapse mid-setup
+    expect(widgetBody().style.display).toBe("none");
+    fireEvent.click(chevron()); // re-expand
+
+    // The body never unmounted, so the draft survived.
+    expect((tokenInput(container) as HTMLInputElement).value).toBe(
+      "12345:draft-token",
+    );
+  });
+});

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -15,6 +15,7 @@
  */
 import {
   type FormEvent,
+  memo,
   type ReactNode,
   useCallback,
   useEffect,
@@ -62,6 +63,7 @@ import {
   splitInlineCode,
 } from "./message-parser-helpers";
 import { ThinkingBlock } from "./ThinkingBlock";
+import { ChatWidgetShell } from "./widgets/chat-widget-shell";
 // Side effect: registers the built-in inline widgets (choice/followups/form/task).
 import "./widgets/inline-builtins";
 import { getInlineWidget } from "./widgets/inline-registry";
@@ -154,7 +156,14 @@ function MessageTextBody({
 
 // ── InlinePluginConfig ──────────────────────────────────────────────
 
-export function InlinePluginConfig({
+// The in-chat connector/plugin setup card for `[CONFIG:pluginId]` markers
+// (#14412). All state (fetch status, field edits, mutations) is internal and
+// the only prop is a primitive, so `memo` makes a transcript-parent re-render
+// (streaming ticks, unrelated store updates) bail out before this subtree —
+// the widget repaints only when its own state changes. Connection status is
+// fetched inside, never derived from props at render, so memo cannot pin a
+// stale status (the NotificationRow lesson).
+export const InlinePluginConfig = memo(function InlinePluginConfig({
   pluginId: rawPluginId,
 }: {
   pluginId: string;
@@ -167,7 +176,6 @@ export function InlinePluginConfig({
   const [saved, setSaved] = useState(false);
   const [enabling, setEnabling] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [dismissed, setDismissed] = useState(false);
   const mountedRef = useRef(true);
   const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { setActionNotice, loadPlugins, t } = useAppSelectorShallow((s) => ({
@@ -291,7 +299,13 @@ export function InlinePluginConfig({
             "success",
             4000,
           );
-          setDismissed(true);
+          // Optimistic connect: flip the local status so the shell collapses
+          // to its compact summary immediately. The delayed refetch below
+          // reconciles with the server and re-expands the card if the plugin
+          // actually still needs configuration.
+          setPlugin((prev) =>
+            prev ? { ...prev, enabled: true, configured: true } : prev,
+          );
         }
         // Wait for agent restart then refresh (with cleanup on unmount)
         refreshTimerRef.current = setTimeout(() => void fetchPlugin(), 3000);
@@ -317,17 +331,6 @@ export function InlinePluginConfig({
     [pluginId, plugin, values, fetchPlugin, loadPlugins, setActionNotice, t],
   );
 
-  if (dismissed) {
-    return (
-      <div className="my-2 px-3 py-2 border border-ok/30 bg-ok/5 text-xs text-ok">
-        {t("messagecontent.PluginEnabledInlineNotice", {
-          defaultValue: "{{name}} is enabled.",
-          name: plugin?.name ?? pluginId,
-        })}
-      </div>
-    );
-  }
-
   if (loading) {
     return (
       <div className="my-2 px-3 py-2 border border-border bg-card text-xs text-muted italic">
@@ -351,25 +354,28 @@ export function InlinePluginConfig({
   }
 
   const isEnabled = plugin.enabled;
+  // "Connected" is the server's own setup verdict: enabled AND configured.
+  // It drives the shell's collapse-on-connect \u2014 the card mounts collapsed for
+  // an already-connected plugin and auto-collapses when the status flips.
+  const connected = isEnabled && plugin.configured;
 
   return (
-    <div className="my-2 border border-border bg-card overflow-hidden">
-      {/* Header */}
-      <div className="flex items-center justify-between px-3 py-2 bg-bg-hover">
-        <div className="flex items-center gap-2 text-xs font-bold text-txt">
-          {plugin.icon ? (
-            <span className="text-sm">{plugin.icon}</span>
-          ) : (
-            <span className="text-sm opacity-60">{"\u2699\uFE0F"}</span>
-          )}
-          <span>
-            {t("messagecontent.PluginConfigurationTitle", {
-              defaultValue: "{{name}} Configuration",
-              name: plugin.name,
-            })}
-          </span>
-        </div>
-        <div className="flex items-center gap-2">
+    <ChatWidgetShell
+      testId="inline-plugin-config"
+      complete={connected}
+      icon={
+        plugin.icon ? (
+          <span className="text-sm">{plugin.icon}</span>
+        ) : (
+          <span className="text-sm opacity-60">{"\u2699\uFE0F"}</span>
+        )
+      }
+      title={t("messagecontent.PluginConfigurationTitle", {
+        defaultValue: "{{name}} Configuration",
+        name: plugin.name,
+      })}
+      status={
+        <>
           {plugin.configured && (
             <span className="text-2xs text-ok font-medium">
               {t("config-field.Configured")}
@@ -386,9 +392,17 @@ export function InlinePluginConfig({
                   defaultValue: "Inactive",
                 })}
           </span>
-        </div>
-      </div>
-
+        </>
+      }
+      summary={
+        <span className="text-ok">
+          {t("messagecontent.PluginEnabledInlineNotice", {
+            defaultValue: "{{name}} is enabled.",
+            name: plugin.name ?? pluginId,
+          })}
+        </span>
+      }
+    >
       {/* Form — always shown so user can configure before enabling */}
       {schema && hasConfigurableParams ? (
         <div className="p-3">
@@ -463,9 +477,9 @@ export function InlinePluginConfig({
         {saved && <span className="text-xs text-ok">{t("common.saved")}</span>}
         {error && <span className="text-xs text-danger">{error}</span>}
       </div>
-    </div>
+    </ChatWidgetShell>
   );
-}
+});
 
 // ── UiSpec block ────────────────────────────────────────────────────
 

--- a/packages/ui/src/components/chat/message-parser-helpers.ts
+++ b/packages/ui/src/components/chat/message-parser-helpers.ts
@@ -573,6 +573,21 @@ export function buildInlinePluginConfigModel(
     }
   }
 
+  // Progressive disclosure for the in-chat setup card (#14412): when the
+  // plugin declares required params, those are the minimal setup set — every
+  // optional param moves behind ConfigRenderer's existing Advanced disclosure.
+  // The schema's own `required` flag is the minimal-vs-advanced signal; a
+  // server-provided `advanced: false` hint explicitly pins an optional field
+  // in the minimal set. Plugins with no required params keep the heuristic
+  // split from paramsToSchema (an all-Advanced card would render empty).
+  if (pluginParams.some((p) => p.required)) {
+    for (const param of pluginParams) {
+      if (param.required) continue;
+      if (plugin.configUiHints?.[param.key]?.advanced === false) continue;
+      auto.hints[param.key] = { ...auto.hints[param.key], advanced: true };
+    }
+  }
+
   const initialValues: Record<string, unknown> = {};
   const setKeys = new Set<string>();
   for (const param of pluginParams) {

--- a/packages/ui/src/components/chat/widgets/WIDGET_MATRIX.md
+++ b/packages/ui/src/components/chat/widgets/WIDGET_MATRIX.md
@@ -67,11 +67,43 @@ for the overlay (importing the same renderers from `MessageContent`). The
 
 | Segment | Marker | Producing source | ChatView renderer | Overlay renderer |
 |---|---|---|---|---|
-| Plugin config | `[CONFIG:<pluginId>]` | plugin-config flows | `InlinePluginConfig` | `InlinePluginConfig` (`InlineWidgetText.tsx` case `config`) |
+| Plugin config / connector setup | `[CONFIG:<pluginId>]` | plugin-config flows | `InlinePluginConfig` (in `ChatWidgetShell`) | `InlinePluginConfig` (`InlineWidgetText.tsx` case `config`) |
 | Permission card | `__permission:...` | mobile/desktop permission requests | `MessagePermissionCard` | `MessagePermissionCard` (case `permission`) |
 | Secret / OAuth request | `message.secretRequest` passthrough | credential/OAuth actions | `SensitiveRequestBlock` | `SensitiveRequestBlock` (mounted by `ContinuousChatOverlay` body) |
 | Code block | fenced ``` ``` ``` ``` | any | `CodeBlock` | `CodeBlock` (case `code`) |
 | GenUI ui-spec | fenced JSON / JSONL patches | Chat-Mode / Generate-Mode GenUI | `MessageUiSpecBlock` (wraps `UiRenderer`) | `MessageUiSpecBlock` (case `ui-spec`) |
+
+### ChatWidgetShell — the standardized collapsible widget shell (#14412)
+
+`chat-widget-shell.tsx` is the shared collapser for chat-transcript widgets:
+header (icon + title + status chips + chevron), an expanded body, and a compact
+collapsed summary row. Contract:
+
+- **Start expanded while incomplete; auto-collapse to the summary once
+  `complete` flips true** (connector connected, form submitted). A later
+  `complete` → false transition (disconnect) auto-expands. The chevron
+  re-expands/collapses at any time and a user toggle sticks until the next
+  transition.
+- **The collapsed body stays mounted** — hidden via `display:none` +
+  `content-visibility:hidden` — so in-progress field edits survive a
+  collapse/expand round-trip and the collapsed subtree costs no layout/paint.
+  `contain:content` on the root isolates internal relayouts from the
+  transcript. Contract lock: `chat-widget-shell.test.tsx`.
+
+**Connector-setup widget** = the `[CONFIG:<pluginId>]` card wrapped in the
+shell (the "`[CONFIG]` variant" of #14412; no separate `[CONNECTOR:]` marker).
+`buildInlinePluginConfigModel` derives minimal-vs-advanced from the param
+schema: when a plugin declares `required` params those are the minimal set and
+every optional param moves behind `ConfigRenderer`'s Advanced disclosure (a
+server `configUiHints[key].advanced: false` pins a field in the minimal set;
+plugins with no required params keep the heuristic split). "Connected" =
+`enabled && configured` from the plugins DTO — that drives collapse-on-connect.
+Secrets keep routing through the sensitive-request flow (`SensitiveRequestBlock`,
+#14326), never plain in-chat fields. Repaint lock: `InlinePluginConfig` is
+memoized on its primitive `pluginId` prop so transcript re-renders bail out
+before the card subtree (`MessageContent.config-render-count.test.tsx`);
+behavior: `MessageContent.connector-setup.test.tsx`. Other widgets should adopt
+the shell as they are touched (#14327 tracks the matrix refresh).
 
 ---
 

--- a/packages/ui/src/components/chat/widgets/chat-widget-shell.test.tsx
+++ b/packages/ui/src/components/chat/widgets/chat-widget-shell.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+
+/**
+ * Contract tests for {@link ChatWidgetShell} (#14412) — the standardized
+ * collapsible shell every chat widget wraps. Pins the lifecycle contract:
+ * starts expanded while incomplete, mounts collapsed when already complete,
+ * auto-collapses/auto-expands on `complete` transitions, and stays
+ * re-expandable via the chevron with user toggles sticking between
+ * transitions. Also pins the repaint design: the collapsed body remains
+ * MOUNTED (field state survives a collapse/expand round-trip) but carries
+ * `display:none` + `content-visibility:hidden` so it costs no layout.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { __setAppValueForTests } from "../../../state/app-store";
+import { ChatWidgetShell } from "./chat-widget-shell";
+
+beforeEach(() => {
+  // The shell reads only `t` from the app store (chevron aria-labels).
+  __setAppValueForTests({
+    t: (key: string, vars?: Record<string, unknown>) =>
+      String(vars?.defaultValue ?? key),
+  } as never);
+});
+
+afterEach(() => {
+  cleanup();
+  __setAppValueForTests(null);
+});
+
+function shell(complete: boolean) {
+  return (
+    <ChatWidgetShell
+      testId="shell"
+      title="Discord Configuration"
+      status={<span>Inactive</span>}
+      summary="Discord is enabled."
+      complete={complete}
+    >
+      <input data-testid="shell-field" defaultValue="" />
+    </ChatWidgetShell>
+  );
+}
+
+function body() {
+  return screen.getByTestId("shell-body");
+}
+
+function chevron() {
+  return screen.getByTestId("shell-chevron");
+}
+
+describe("ChatWidgetShell — initial expansion", () => {
+  it("starts expanded while incomplete: visible body, no summary row", () => {
+    render(shell(false));
+    expect(chevron().getAttribute("aria-expanded")).toBe("true");
+    expect(body().style.display).toBe("");
+    expect(body().getAttribute("aria-hidden")).toBe("false");
+    expect(screen.queryByTestId("shell-summary")).toBeNull();
+  });
+
+  it("mounts collapsed when already complete: summary row + hidden body", () => {
+    render(shell(true));
+    expect(chevron().getAttribute("aria-expanded")).toBe("false");
+    expect(screen.getByTestId("shell-summary").textContent).toContain(
+      "Discord is enabled.",
+    );
+    // The body is hidden, not unmounted: display none removes it from layout
+    // universally, content-visibility documents the render-skip intent.
+    expect(body().style.display).toBe("none");
+    expect(body().style.contentVisibility).toBe("hidden");
+    expect(body().getAttribute("aria-hidden")).toBe("true");
+    expect(screen.getByTestId("shell-field")).toBeTruthy();
+  });
+});
+
+describe("ChatWidgetShell — complete transitions", () => {
+  it("auto-collapses on incomplete → complete and preserves body field state", () => {
+    const { rerender } = render(shell(false));
+    fireEvent.change(screen.getByTestId("shell-field"), {
+      target: { value: "draft token" },
+    });
+
+    rerender(shell(true));
+
+    expect(chevron().getAttribute("aria-expanded")).toBe("false");
+    expect(body().style.display).toBe("none");
+    // The in-progress edit survived the collapse because the body never
+    // unmounted.
+    expect((screen.getByTestId("shell-field") as HTMLInputElement).value).toBe(
+      "draft token",
+    );
+  });
+
+  it("auto-expands on complete → incomplete (disconnect reopens setup)", () => {
+    const { rerender } = render(shell(true));
+    expect(chevron().getAttribute("aria-expanded")).toBe("false");
+
+    rerender(shell(false));
+
+    expect(chevron().getAttribute("aria-expanded")).toBe("true");
+    expect(body().style.display).toBe("");
+    expect(screen.queryByTestId("shell-summary")).toBeNull();
+  });
+});
+
+describe("ChatWidgetShell — chevron toggle", () => {
+  it("re-expands a collapsed complete widget and collapses it back", () => {
+    render(shell(true));
+
+    fireEvent.click(chevron());
+    expect(chevron().getAttribute("aria-expanded")).toBe("true");
+    expect(body().style.display).toBe("");
+    expect(screen.queryByTestId("shell-summary")).toBeNull();
+
+    fireEvent.click(chevron());
+    expect(chevron().getAttribute("aria-expanded")).toBe("false");
+    expect(body().style.display).toBe("none");
+    expect(screen.getByTestId("shell-summary")).toBeTruthy();
+  });
+
+  it("a user toggle sticks across re-renders that do not change `complete`", () => {
+    const { rerender } = render(shell(true));
+    fireEvent.click(chevron());
+    expect(chevron().getAttribute("aria-expanded")).toBe("true");
+
+    // Unrelated parent re-render (same complete value) must not undo the
+    // user's expansion — only a `complete` transition resets it.
+    rerender(shell(true));
+    expect(chevron().getAttribute("aria-expanded")).toBe("true");
+  });
+});

--- a/packages/ui/src/components/chat/widgets/chat-widget-shell.tsx
+++ b/packages/ui/src/components/chat/widgets/chat-widget-shell.tsx
@@ -1,0 +1,121 @@
+/**
+ * Standardized collapsible shell for chat-transcript widgets (#14412): a header
+ * row (icon + title + status slot + chevron), an expanded body, and a compact
+ * collapsed summary row, so a widget stops eating transcript height once its
+ * job is done.
+ *
+ * Contract: the widget starts expanded while its job is incomplete and
+ * auto-collapses to the summary when `complete` flips true (a connector
+ * reaching connected status, a form submitted). The chevron re-expands it at
+ * any time, and a user toggle sticks until the next `complete` transition.
+ *
+ * The body stays MOUNTED while collapsed — hidden with `display:none` plus a
+ * `content-visibility:hidden` hint — so in-progress field edits survive a
+ * collapse/expand round-trip and the collapsed subtree costs no layout/paint
+ * per transcript frame. `contain:content` on the root keeps a widget's
+ * internal relayouts from propagating into the transcript (only the shell's
+ * own size changes reach the flow, which is exactly the expand/collapse case).
+ */
+import { ChevronDown } from "lucide-react";
+import { type CSSProperties, type ReactNode, useId, useState } from "react";
+import { useAppSelector } from "../../../state";
+
+export interface ChatWidgetShellProps {
+  /** Header title (plain text or inline nodes); truncates rather than wraps. */
+  title: ReactNode;
+  /** Optional leading icon/emoji slot rendered before the title. */
+  icon?: ReactNode;
+  /** Status chips rendered on the header's trailing edge, before the chevron. */
+  status?: ReactNode;
+  /** Compact one-row content shown instead of the body while collapsed. */
+  summary?: ReactNode;
+  /**
+   * True once the widget's job is done (connected / submitted / resolved).
+   * Drives the initial expansion and the auto-collapse/auto-expand transitions.
+   */
+  complete: boolean;
+  /** The full widget body. Stays mounted (hidden) while collapsed. */
+  children: ReactNode;
+  testId?: string;
+}
+
+// Kept inert so unsupporting engines simply ignore the hint; `display:none`
+// is what universally removes the collapsed body from layout.
+const COLLAPSED_BODY_STYLE: CSSProperties = {
+  display: "none",
+  contentVisibility: "hidden",
+};
+
+export function ChatWidgetShell({
+  title,
+  icon,
+  status,
+  summary,
+  complete,
+  children,
+  testId,
+}: ChatWidgetShellProps) {
+  const t = useAppSelector((s) => s.t);
+  const bodyId = useId();
+  const [expanded, setExpanded] = useState(!complete);
+  // Render-time adjustment (not an effect) so a completion transition never
+  // paints one expanded frame before collapsing. A transition in either
+  // direction resets the user's manual toggle: connect collapses, a later
+  // disconnect re-opens the setup form.
+  const [prevComplete, setPrevComplete] = useState(complete);
+  if (prevComplete !== complete) {
+    setPrevComplete(complete);
+    setExpanded(!complete);
+  }
+
+  return (
+    <div
+      className="my-2 border border-border bg-card overflow-hidden [contain:content]"
+      data-testid={testId}
+      data-expanded={expanded}
+    >
+      <div className="flex items-center justify-between gap-2 px-3 py-2 bg-bg-hover">
+        <div className="flex min-w-0 items-center gap-2 text-xs font-bold text-txt">
+          {icon}
+          <span className="truncate">{title}</span>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {status}
+          <button
+            type="button"
+            aria-expanded={expanded}
+            aria-controls={bodyId}
+            aria-label={
+              expanded
+                ? t("chatwidget.Collapse", { defaultValue: "Collapse" })
+                : t("chatwidget.Expand", { defaultValue: "Expand" })
+            }
+            data-testid={testId ? `${testId}-chevron` : undefined}
+            className="flex size-5 items-center justify-center text-muted transition-colors hover:text-txt"
+            onClick={() => setExpanded((v) => !v)}
+          >
+            <ChevronDown
+              className={`size-3.5 transition-transform duration-200 ${expanded ? "" : "-rotate-90"}`}
+            />
+          </button>
+        </div>
+      </div>
+      {!expanded && summary != null && (
+        <div
+          className="truncate px-3 py-2 text-xs text-muted"
+          data-testid={testId ? `${testId}-summary` : undefined}
+        >
+          {summary}
+        </div>
+      )}
+      <div
+        id={bodyId}
+        aria-hidden={!expanded}
+        style={expanded ? undefined : COLLAPSED_BODY_STYLE}
+        data-testid={testId ? `${testId}-body` : undefined}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -525,6 +525,8 @@
   "chat.toolCallChip.DELETE_WORKFLOW": "Deleting workflow…",
   "chat.uncached": "uncached",
   "chat.voiceInput": "Voice input",
+  "chatwidget.Collapse": "Collapse",
+  "chatwidget.Expand": "Expand",
   "chatmessage.ResponseInterrupte": "(Response interrupted)",
   "chatmessage.SaveAndResend": "Save and resend",
   "chatmessage.suggestion": "Suggestion",

--- a/packages/ui/src/i18n/locales/es.json
+++ b/packages/ui/src/i18n/locales/es.json
@@ -521,6 +521,8 @@
   "chat.toolCallChip.DELETE_WORKFLOW": "Eliminando flujo…",
   "chat.uncached": "sin caché",
   "chat.voiceInput": "Entrada de voz",
+  "chatwidget.Collapse": "Contraer",
+  "chatwidget.Expand": "Expandir",
   "chatmessage.ResponseInterrupte": "(Respuesta interrumpida)",
   "chatmessage.SaveAndResend": "Guardar y reenviar",
   "chatsidebar.launchApp": "Iniciar {{name}}",

--- a/packages/ui/src/i18n/locales/ja.json
+++ b/packages/ui/src/i18n/locales/ja.json
@@ -521,6 +521,8 @@
   "chat.toolCallChip.DELETE_WORKFLOW": "ワークフローを削除中…",
   "chat.uncached": "未キャッシュ",
   "chat.voiceInput": "音声入力",
+  "chatwidget.Collapse": "折りたたむ",
+  "chatwidget.Expand": "展開",
   "chatmessage.ResponseInterrupte": "(応答が中断されました)",
   "chatmessage.SaveAndResend": "保存して再送信",
   "chatsidebar.launchApp": "{{name}}を起動",

--- a/packages/ui/src/i18n/locales/ko.json
+++ b/packages/ui/src/i18n/locales/ko.json
@@ -521,6 +521,8 @@
   "chat.toolCallChip.DELETE_WORKFLOW": "워크플로우 삭제 중…",
   "chat.uncached": "캐시되지 않음",
   "chat.voiceInput": "음성 입력",
+  "chatwidget.Collapse": "접기",
+  "chatwidget.Expand": "펼치기",
   "chatmessage.ResponseInterrupte": "(응답이 중단됨)",
   "chatmessage.SaveAndResend": "저장하고 다시 보내기",
   "chatsidebar.launchApp": "{{name}} 실행",

--- a/packages/ui/src/i18n/locales/pt.json
+++ b/packages/ui/src/i18n/locales/pt.json
@@ -521,6 +521,8 @@
   "chat.toolCallChip.DELETE_WORKFLOW": "Excluindo fluxo de trabalho…",
   "chat.uncached": "fora do cache",
   "chat.voiceInput": "Entrada de voz",
+  "chatwidget.Collapse": "Recolher",
+  "chatwidget.Expand": "Expandir",
   "chatmessage.ResponseInterrupte": "(Resposta interrompida)",
   "chatmessage.SaveAndResend": "Salvar e reenviar",
   "chatsidebar.launchApp": "Abrir {{name}}",

--- a/packages/ui/src/i18n/locales/tl.json
+++ b/packages/ui/src/i18n/locales/tl.json
@@ -521,6 +521,8 @@
   "chat.toolCallChip.DELETE_WORKFLOW": "Binubura ang workflow…",
   "chat.uncached": "hindi naka-cache",
   "chat.voiceInput": "Input ng boses",
+  "chatwidget.Collapse": "I-collapse",
+  "chatwidget.Expand": "Palawakin",
   "chatmessage.ResponseInterrupte": "(Na-interrupt ang tugon)",
   "chatmessage.SaveAndResend": "I-save at ipadala ulit",
   "chatsidebar.launchApp": "Buksan ang {{name}}",

--- a/packages/ui/src/i18n/locales/vi.json
+++ b/packages/ui/src/i18n/locales/vi.json
@@ -521,6 +521,8 @@
   "chat.toolCallChip.DELETE_WORKFLOW": "Đang xóa workflow…",
   "chat.uncached": "chưa cache",
   "chat.voiceInput": "Nhập giọng nói",
+  "chatwidget.Collapse": "Thu gọn",
+  "chatwidget.Expand": "Mở rộng",
   "chatmessage.ResponseInterrupte": "(Phản hồi bị gián đoạn)",
   "chatmessage.SaveAndResend": "Lưu và gửi lại",
   "chatsidebar.launchApp": "Mở {{name}}",

--- a/packages/ui/src/i18n/locales/zh-CN.json
+++ b/packages/ui/src/i18n/locales/zh-CN.json
@@ -521,6 +521,8 @@
   "chat.toolCallChip.DELETE_WORKFLOW": "正在删除工作流…",
   "chat.uncached": "未缓存",
   "chat.voiceInput": "语音输入",
+  "chatwidget.Collapse": "折叠",
+  "chatwidget.Expand": "展开",
   "chatmessage.ResponseInterrupte": "（反应中断）",
   "chatmessage.SaveAndResend": "保存并重新发送",
   "chatsidebar.launchApp": "启动 {{name}}",

--- a/packages/ui/src/storybook/mock-providers.tsx
+++ b/packages/ui/src/storybook/mock-providers.tsx
@@ -63,15 +63,17 @@ const baseMockApp: Partial<AppContextValue> = {
   pendingRestartReasons: [],
   restartBannerDismissed: false,
   systemWarnings: [],
-  t: (key, values) => values?.defaultValue?.toString() ?? key,
   triggerRestart: noopAsync,
   uiLanguage: "en",
 };
 
 function createMockApp(overrides: MockAppOptions = {}): AppContextValue {
+  const uiLanguage = overrides.uiLanguage ?? baseMockApp.uiLanguage ?? "en";
   const value = {
     ...baseMockApp,
+    t: createTranslator(uiLanguage),
     ...overrides,
+    uiLanguage,
     agentStatus:
       overrides.agentStatus === null
         ? null


### PR DESCRIPTION
Refs #14412.

## What

Makes `[CONFIG:pluginId]` the standardized connector-setup widget: minimal fields first, an **Advanced** disclosure for the rest, and **collapse-on-connect** — plus the repaint optimization the issue asked for.

- **`ChatWidgetShell`** (new): the standardized collapsible chat-card shell — header (icon + title + status slot + chevron), expanded body, compact collapsed summary row. Built fresh because `PagePanelCollapsibleSection` unmounts collapsed children, which would destroy in-progress field edits; the collapsed body instead stays mounted under `display:none` + `content-visibility:hidden` (zero layout cost, edits survive), with `contain:content` isolating relayouts. Contract documented in `WIDGET_MATRIX.md` for incremental adoption by other widgets (#14327 coordination).
- **Minimal vs Advanced derives from the schema's existing `required` flag** — no new schema field. Optional params route into ConfigRenderer's existing Advanced disclosure (collapsed, count badge); `configUiHints[key].advanced: false` is the explicit pin-to-minimal opt-out; zero-required plugins keep the full form (an all-Advanced card would render empty).
- **Collapse-on-connect** uses the server's own verdict (`plugin.enabled && plugin.configured` from the plugins DTO): already-connected cards mount collapsed; in-card enable optimistically collapses (replacing the old terminal `dismissed` state) and the existing 3s refetch reconciles — re-expanding if config is actually still needed; disconnect auto-expands; user chevron toggles stick.
- **Repaint**: `InlinePluginConfig` is `memo`ized on its single primitive prop; expand/collapse state lives below the memo boundary so toggling never re-renders the form; transcript re-renders bail out before the subtree.
- 2 new i18n keys (chevron aria-labels) across all 8 locales.

## Tests

- New: `chat-widget-shell.test.tsx` **6/6**; `MessageContent.connector-setup.test.tsx` **7/7** (split, toggle, no-required fallback, mounts-collapsed, re-expand, auto-collapse-on-connect, edit survives collapse round-trip); `MessageContent.config-render-count.test.tsx` **2/2** — mutation-verified (stripping `memo` fails it).
- Kept green: `MessageContent.config.test.tsx` 12/12; full `src/components/chat` sweep **59 files / 559 tests** including render-parity, parser-parity, inline-registry.matrix, and `chat-stories-smoke` 154/154 which executes the three new Storybook stories' play functions (`FreshSetup`, `AdvancedExpanded`, `ConnectedCollapsed`).
- Lint clean; typecheck zero errors in touched files.

## Scope notes

- Shell adoption across the other ~20 widgets is deliberately incremental (documented contract; migrating all under their individual perf locks in one PR is regression bait).
- Per-connector QR/account panels stay page-level; the chat card + sensitive-request flow covers set-up-from-chat, and deeper embedding intersects #14326.
- Live-LLM round-trip evidence: tracked by #14325/#14322 (in flight).

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] N/A - pure renderer change verified by deterministic jsdom component tests; the three visual states (FreshSetup / AdvancedExpanded / ConnectedCollapsed) are executed as Storybook play functions in `chat-stories-smoke` (154/154). No packaged-app capture was produced in the authoring session (`audit:app` breaks in linked worktrees).
<!-- evidence-row:after-screenshots -->
- [ ] N/A - same as above; the collapsed/expanded/Advanced states are pinned by `MessageContent.connector-setup.test.tsx` DOM assertions plus the three new stories.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no packaged app run in the authoring worktree; states covered by story play functions + rerender-driven transition tests.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no server-side code path touched; the card drives the existing `client.updatePlugin` mutations, asserted at the network boundary in tests.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - deterministic jsdom tests assert the exact client calls (`{config}` then `{enabled:true}`) and the resulting DOM state transitions.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt/provider/action change (the `[CONFIG:pluginId]` producer contract is unchanged); live-LLM widget round-trip evidence is owned by #14325/#14322.

### Post-merge re-verification (2026-07-06, fable lane)

Re-ran the new + guarded suites against merged `develop` @ `62ad9ba4a4` in a clean worktree:

```
$ bun run --cwd packages/ui test \
    src/components/chat/widgets/chat-widget-shell.test.tsx \
    src/components/chat/MessageContent.connector-setup.test.tsx \
    src/components/chat/MessageContent.config-render-count.test.tsx \
    src/components/chat/MessageContent.config.test.tsx \
    src/components/chat/widgets/inline-registry.matrix.test.tsx \
    src/components/chat/render-parity.contract.test.tsx

 Test Files  6 passed (6)
      Tests  49 passed (49)
```

Noted for the record: the PR merged while its CI checks were pending/cancelled (merge-gate wedge), so this re-run is the verification of record for the merged state.
