### PR TITLE
fix(app-control): wire app permission settings action

### DIFF
--- a/plugins/plugin-app-control/src/actions/settings.test.ts
+++ b/plugins/plugin-app-control/src/actions/settings.test.ts
@@ -103,6 +103,8 @@ describe("parseSettingsRequest", () => {
 			value: "off",
 			fileName: null,
 			confirm: null,
+			app: null,
+			namespace: null,
 		});
 	});
 
@@ -139,6 +141,24 @@ describe("parseSettingsRequest", () => {
 			key: "restore-backup",
 			fileName: "agent-2026.agent-backup.json",
 			confirm: "true",
+		});
+	});
+
+	it("reads app and namespace options for app-permissions writes", () => {
+		expect(
+			parseSettingsRequest({
+				action: "set",
+				section: "app-permissions",
+				app: "weather",
+				namespace: "network",
+				value: "off",
+			}),
+		).toMatchObject({
+			verb: "set",
+			sectionId: "app-permissions",
+			app: "weather",
+			namespace: "network",
+			value: "off",
 		});
 	});
 });
@@ -180,6 +200,11 @@ describe("SETTINGS action: list", () => {
 		expect(capabilities).toMatchObject({ writable: true, via: "SETTINGS" });
 		const advanced = sections.find((s) => s.id === "advanced");
 		expect(advanced).toMatchObject({ writable: true, via: "SETTINGS" });
+		const appPermissions = sections.find((s) => s.id === "app-permissions");
+		expect(appPermissions).toMatchObject({
+			writable: true,
+			via: "SETTINGS",
+		});
 		const updates = sections.find((s) => s.id === "updates");
 		expect(updates).toMatchObject({ writable: false, via: "not-yet-wired" });
 	});
@@ -348,6 +373,130 @@ describe("SETTINGS action: set on an owned route section", () => {
 		expect(routeFetch).not.toHaveBeenCalled();
 		expect(result?.success).toBe(false);
 		expect(texts.join(" ")).toContain("fileName");
+	});
+
+	it("read-modify-writes app permission namespace grants through the app route", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async (request) => {
+			if (request.method === "GET") {
+				return {
+					ok: true,
+					data: {
+						slug: "weather",
+						trust: "external",
+						isolation: "worker",
+						requestedPermissions: {
+							fs: { read: ["state/weather/**"] },
+							net: { outbound: ["https://api.weather.test"] },
+						},
+						recognisedNamespaces: ["fs", "net"],
+						grantedNamespaces: ["fs", "net"],
+						grantedAt: "2026-01-01T00:00:00.000Z",
+					},
+				};
+			}
+			return { ok: true };
+		});
+		const { result, texts } = await invoke(
+			{
+				action: "set",
+				section: "app-permissions",
+				app: "weather",
+				key: "net",
+				value: "off",
+			},
+			routeFetch,
+		);
+		expect(routeFetch).toHaveBeenNthCalledWith(1, {
+			method: "GET",
+			path: "/api/apps/permissions/weather",
+		});
+		expect(routeFetch).toHaveBeenNthCalledWith(2, {
+			method: "PUT",
+			path: "/api/apps/permissions/weather",
+			body: { namespaces: ["fs"] },
+		});
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({
+			section: "app-permissions",
+			key: "net",
+			value: false,
+			app: "weather",
+		});
+		expect(texts.join(" ")).toContain("weather net permission is revoked");
+	});
+
+	it("accepts namespace aliases for app permissions", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async (request) => {
+			if (request.method === "GET") {
+				return {
+					ok: true,
+					data: {
+						slug: "weather",
+						trust: "external",
+						isolation: "worker",
+						requestedPermissions: {
+							fs: { read: ["state/weather/**"] },
+							net: { outbound: ["https://api.weather.test"] },
+						},
+						recognisedNamespaces: ["fs", "net"],
+						grantedNamespaces: ["fs"],
+						grantedAt: "2026-01-01T00:00:00.000Z",
+					},
+				};
+			}
+			return { ok: true };
+		});
+		const { result } = await invoke(
+			{
+				action: "set",
+				section: "app-permissions",
+				app: "weather",
+				namespace: "network",
+				value: "on",
+			},
+			routeFetch,
+		);
+		expect(routeFetch).toHaveBeenNthCalledWith(2, {
+			method: "PUT",
+			path: "/api/apps/permissions/weather",
+			body: { namespaces: ["fs", "net"] },
+		});
+		expect(result?.values).toMatchObject({ key: "net", value: true });
+	});
+
+	it("refuses app permission writes without an app slug", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({ ok: true }));
+		const { result, texts } = await invoke(
+			{
+				action: "set",
+				section: "app-permissions",
+				key: "net",
+				value: "off",
+			},
+			routeFetch,
+		);
+		expect(routeFetch).not.toHaveBeenCalled();
+		expect(result?.success).toBe(false);
+		expect(texts.join(" ")).toContain("app=<slug>");
+	});
+
+	it("refuses app permission writes when the route shape is invalid", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({
+			ok: true,
+			data: { slug: "weather" },
+		}));
+		const { result, texts } = await invoke(
+			{
+				action: "set",
+				section: "app-permissions",
+				app: "weather",
+				key: "net",
+				value: "off",
+			},
+			routeFetch,
+		);
+		expect(result?.success).toBe(false);
+		expect(texts.join(" ")).toContain("invalid permission view");
 	});
 
 	it("rejects a non-boolean value without calling the route", async () => {

--- a/plugins/plugin-app-control/src/actions/settings.ts
+++ b/plugins/plugin-app-control/src/actions/settings.ts
@@ -30,6 +30,7 @@ import type {
 	State,
 } from "@elizaos/core";
 import { logger, resolveServerOnlyPort } from "@elizaos/core";
+import { AppPermissionsViewSchema } from "@elizaos/shared";
 import { SETTINGS_SECTION_META } from "@elizaos/ui/components/settings/settings-section-meta";
 import { normalizeActionOptions, readStringOption } from "../params.js";
 
@@ -41,8 +42,14 @@ export interface SettingsRouteOutcome {
 	ok: boolean;
 	/** Human-facing confirmation or failure detail. */
 	detail?: string;
-	/** Parsed JSON body for command-style settings routes. */
+	/** Parsed JSON body for command/read-modify-write settings routes. */
 	data?: unknown;
+}
+
+export interface SettingsRouteRequest {
+	method: "GET" | "PUT" | "POST";
+	path: string;
+	body?: unknown;
 }
 
 /**
@@ -50,11 +57,9 @@ export interface SettingsRouteOutcome {
  * route. Injectable so unit tests exercise routing/validation without a live
  * server; the default hits `127.0.0.1:<server port>`.
  */
-export type SettingsRouteFetch = (request: {
-	method: "PUT" | "POST";
-	path: string;
-	body: unknown;
-}) => Promise<SettingsRouteOutcome>;
+export type SettingsRouteFetch = (
+	request: SettingsRouteRequest,
+) => Promise<SettingsRouteOutcome>;
 
 /**
  * A single writable key on an owned (`route`) section: how to parse the value,
@@ -70,21 +75,20 @@ export interface SettingsWritableKey {
 	 */
 	valueType: "boolean" | "command";
 	/** Build the backend request for a parsed value. */
-	buildRequest?: (value: boolean) => {
-		method: "PUT" | "POST";
-		path: string;
-		body: unknown;
-	};
-	/** Execute a non-toggle operation through the section's backend route. */
+	buildRequest?: (value: boolean) => SettingsRouteRequest;
+	/** Execute command or multi-step route-backed writes. */
 	apply?: (args: {
+		keyName: string;
 		request: SettingsRequest;
 		routeFetch: SettingsRouteFetch;
+		value: boolean | null;
 	}) => Promise<SettingsRouteOutcome>;
 	/** Confirmation text once the route returns ok. */
 	successText: (
 		value: boolean | null,
 		request: SettingsRequest,
 		outcome: SettingsRouteOutcome,
+		keyName: string,
 	) => string;
 }
 
@@ -198,6 +202,92 @@ const RESTORE_BACKUP_KEY: SettingsWritableKey = {
 		`Restored local agent backup ${request.fileName}. Restart the agent to activate it.`,
 };
 
+function encodePathSegment(value: string): string {
+	return encodeURIComponent(value);
+}
+
+const PERMISSION_NAMESPACE_ALIASES: ReadonlyMap<string, string> = new Map([
+	["fs", "fs"],
+	["file", "fs"],
+	["files", "fs"],
+	["filesystem", "fs"],
+	["storage", "fs"],
+	["net", "net"],
+	["network", "net"],
+	["internet", "net"],
+	["web", "net"],
+]);
+
+function resolvePermissionNamespace(token: string | null): string | null {
+	if (!token) return null;
+	return PERMISSION_NAMESPACE_ALIASES.get(token.trim().toLowerCase()) ?? null;
+}
+
+const APP_PERMISSION_NAMESPACE_KEY: SettingsWritableKey = {
+	description:
+		"Grant or revoke one recognised permission namespace for a registered app. Requires app=<slug>; key/namespace is fs or net.",
+	valueType: "boolean",
+	apply: async ({ request, routeFetch, value }) => {
+		const appSlug = request.app;
+		if (!appSlug) {
+			return {
+				ok: false,
+				detail:
+					"provide the app slug with app=<slug> (for example, app=my-app)",
+			};
+		}
+		const namespace = resolvePermissionNamespace(
+			request.namespace ?? request.key,
+		);
+		if (!namespace) {
+			return {
+				ok: false,
+				detail: "provide namespace/key as fs or net",
+			};
+		}
+		if (value === null) {
+			return {
+				ok: false,
+				detail: "provide value=on or value=off for the app permission",
+			};
+		}
+
+		const path = `/api/apps/permissions/${encodePathSegment(appSlug)}`;
+		const current = await routeFetch({ method: "GET", path });
+		if (!current.ok) return current;
+
+		const parsed = AppPermissionsViewSchema.safeParse(current.data);
+		if (!parsed.success) {
+			return {
+				ok: false,
+				detail: "app permissions route returned an invalid permission view",
+			};
+		}
+		const view = parsed.data;
+		if (!view.recognisedNamespaces.includes(namespace as "fs" | "net")) {
+			return {
+				ok: false,
+				detail: `${appSlug} does not declare the ${namespace} permission namespace`,
+			};
+		}
+
+		const next = new Set(view.grantedNamespaces);
+		if (value) next.add(namespace as "fs" | "net");
+		else next.delete(namespace as "fs" | "net");
+		return routeFetch({
+			method: "PUT",
+			path,
+			body: { namespaces: [...next] },
+		});
+	},
+	successText: (enabled, request, _outcome, keyName) => {
+		const appSlug = request.app ?? "the app";
+		return enabled
+			? `${appSlug} ${keyName} permission is granted.`
+			: `${appSlug} ${keyName} permission is revoked.`;
+	},
+};
+
 /**
  * The single source of truth mapping every built-in settings section to its
  * write capability. Adding a built-in section without a matching entry fails the
@@ -298,9 +388,12 @@ export const SETTINGS_WRITE_REGISTRY: Readonly<
 		},
 	},
 	"app-permissions": {
-		kind: "unwired",
-		reason:
-			"Per-app namespace grants are a multi-value structure, deferred to a dedicated flow.",
+		kind: "route",
+		summary: "Grant or revoke app permission namespaces for a registered app.",
+		keys: {
+			fs: APP_PERMISSION_NAMESPACE_KEY,
+			net: APP_PERMISSION_NAMESPACE_KEY,
+		},
 	},
 };
 
@@ -352,6 +445,8 @@ export interface SettingsRequest {
 	value: string | null;
 	fileName: string | null;
 	confirm: string | null;
+	app: string | null;
+	namespace: string | null;
 }
 
 const VERB_TOKENS: ReadonlyMap<string, SettingsVerb> = new Map([
@@ -387,6 +482,9 @@ export function parseSettingsRequest(
 	const value = readStringOption(options, "value");
 	const fileName = readStringOption(options, "fileName");
 	const confirm = readStringOption(options, "confirm");
+	const app =
+		readStringOption(options, "app") ?? readStringOption(options, "slug");
+	const namespace = readStringOption(options, "namespace");
 
 	if (!verb) {
 		// A bare `section` with a `value` but no verb reads as an implicit `set`;
@@ -400,21 +498,21 @@ export function parseSettingsRequest(
 			value,
 			fileName,
 			confirm,
+			app,
+			namespace,
 		};
 	}
-	return { verb, sectionId, key, value, fileName, confirm };
+	return { verb, sectionId, key, value, fileName, confirm, app, namespace };
 }
 
-async function defaultRouteFetch(request: {
-	method: "PUT" | "POST";
-	path: string;
-	body: unknown;
-}): Promise<SettingsRouteOutcome> {
+async function defaultRouteFetch(
+	request: SettingsRouteRequest,
+): Promise<SettingsRouteOutcome> {
 	const port = resolveServerOnlyPort(process.env);
 	const response = await fetch(`http://127.0.0.1:${port}${request.path}`, {
 		method: request.method,
 		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify(request.body),
+		body: request.body === undefined ? undefined : JSON.stringify(request.body),
 		signal: AbortSignal.timeout(30_000),
 	});
 	// error-policy:J3 an unparseable body is treated as no detail; the caller
@@ -514,7 +612,12 @@ async function handleSet(
 	}
 
 	// cap.kind === "route"
-	const keyName = request.key ?? Object.keys(cap.keys)[0];
+	const requestedKeyName =
+		request.namespace ?? request.key ?? Object.keys(cap.keys)[0];
+	const keyName =
+		request.sectionId === "app-permissions"
+			? (resolvePermissionNamespace(requestedKeyName) ?? requestedKeyName)
+			: requestedKeyName;
 	const writable = keyName ? cap.keys[keyName] : undefined;
 	if (!writable) {
 		const known = Object.keys(cap.keys).join(", ");
@@ -535,7 +638,12 @@ async function handleSet(
 		`[SettingsAction] set section=${request.sectionId} key=${keyName} value=${parsedValue}`,
 	);
 	const outcome = writable.apply
-		? await writable.apply({ request, routeFetch })
+		? await writable.apply({
+				keyName,
+				request,
+				routeFetch,
+				value: parsedValue,
+			})
 		: writable.buildRequest && parsedValue !== null
 			? await routeFetch(writable.buildRequest(parsedValue))
 			: {
@@ -547,7 +655,7 @@ async function handleSet(
 		await callback?.({ text: reply });
 		return { success: false, text: reply };
 	}
-	const reply = writable.successText(parsedValue, request, outcome);
+	const reply = writable.successText(parsedValue, request, outcome, keyName);
 	await callback?.({ text: reply });
 	return {
 		success: true,
@@ -557,12 +665,14 @@ async function handleSet(
 			key: keyName,
 			...(parsedValue === null ? {} : { value: parsedValue }),
 			...(request.fileName ? { fileName: request.fileName } : {}),
+			...(request.app ? { app: request.app } : {}),
 		},
 		data: {
 			section: request.sectionId,
 			key: keyName,
 			...(parsedValue === null ? {} : { value: parsedValue }),
 			...(request.fileName ? { fileName: request.fileName } : {}),
+			...(request.app ? { app: request.app } : {}),
 		},
 	};
 }
@@ -644,13 +754,17 @@ export function createSettingsAction(deps: SettingsActionDeps = {}): Action {
 			"BACKUP_AGENT",
 			"CREATE_AGENT_BACKUP",
 			"RESTORE_AGENT_BACKUP",
+			"APP_PERMISSIONS",
+			"APP_PERMISSION",
+			"GRANT_APP_PERMISSION",
+			"REVOKE_APP_PERMISSION",
 		],
 		description:
-			"Change a built-in settings VALUE or run a built-in settings operation from chat — most importantly turning OS/runtime permissions like shell access on/off via section=permissions key=shell, turning automatic training on/off via section=capabilities key=auto-training, and creating/restoring local agent backups via section=advanced key=create-backup|restore-backup. Restore requires fileName and confirm=true. Also reads (`action=get`) or lists (`action=list`) which settings are changeable. `action=set` writes an owned section or points to the dedicated action that owns a delegated section (models→MODEL_SWITCH, background→BACKGROUND, identity→CHARACTER, connectors→CONNECTOR, secrets→CREDENTIALS). This CHANGES a setting's value or runs an explicit settings operation; opening a settings page without changing anything is VIEWS. Never fill a settings field with agent-fill.",
+			"Change a built-in settings VALUE or run a built-in settings operation from chat — most importantly turning OS/runtime permissions like shell access on/off via section=permissions key=shell, turning automatic training on/off via section=capabilities key=auto-training, granting/revoking an app permission namespace via section=app-permissions app=<slug> key=fs|net value=on|off, and creating/restoring local agent backups via section=advanced key=create-backup|restore-backup. Restore requires fileName and confirm=true. Also reads (`action=get`) or lists (`action=list`) which settings are changeable. `action=set` writes an owned section or points to the dedicated action that owns a delegated section (models→MODEL_SWITCH, background→BACKGROUND, identity→CHARACTER, connectors→CONNECTOR, secrets→CREDENTIALS). This CHANGES a setting's value or runs an explicit settings operation; opening a settings page without changing anything is VIEWS. Never fill a settings field with agent-fill.",
 		descriptionCompressed:
-			"settings get|set|list section/key/value — CHANGE a setting VALUE or run a settings operation, incl. shell access, auto-training, and local backups (section=advanced key=create-backup|restore-backup)",
+			"settings get|set|list section/key/value — CHANGE a setting VALUE or run a settings operation, incl. shell access, auto-training, app permissions, and local backups",
 		routingHint:
-			"Semantic settings reads/writes that do NOT already have a dedicated action -> SETTINGS. Changing a PERMISSION or setting VALUE is SETTINGS action=set, NOT navigation: 'turn off shell permissions', 'disable shell access', 'turn off shell access', 'revoke shell access', 'stop the agent running shell commands', 'turn shell back on', 'change my permissions' -> SETTINGS section=permissions key=shell value=off|on. 'turn on auto-training', 'enable automatic training', 'disable auto training' -> SETTINGS section=capabilities key=auto-training value=on|off. 'back up my agent', 'create a local backup' -> SETTINGS section=advanced key=create-backup. 'restore backup <file>' -> SETTINGS section=advanced key=restore-backup fileName=<file> confirm=true; if confirm is absent, ask for confirmation. Also 'what settings can you change' / 'list settings' -> SETTINGS action=list. Do NOT use SETTINGS for changes a dedicated action owns: switching the model is MODEL_SWITCH, the background/theme is BACKGROUND, the agent identity is CHARACTER, connectors are CONNECTOR, secret/API keys are CREDENTIALS. The distinction from VIEWS is value-vs-navigation: changing/toggling a permission or setting VALUE, or running a backup operation, is SETTINGS even though it lives on a settings page; merely OPENING or navigating to a settings page with no value change is VIEWS. SETTINGS never fills a form field with agent-fill.",
+			"Semantic settings reads/writes that do NOT already have a dedicated action -> SETTINGS. Changing a PERMISSION or setting VALUE is SETTINGS action=set, NOT navigation: 'turn off shell permissions', 'disable shell access', 'turn off shell access', 'revoke shell access', 'stop the agent running shell commands', 'turn shell back on', 'change my permissions' -> SETTINGS section=permissions key=shell value=off|on. 'turn on auto-training', 'enable automatic training', 'disable auto training' -> SETTINGS section=capabilities key=auto-training value=on|off. 'revoke network access for my-app', 'grant filesystem access to sample-app' -> SETTINGS section=app-permissions app=<slug> key=net|fs value=off|on. 'back up my agent', 'create a local backup' -> SETTINGS section=advanced key=create-backup. 'restore backup <file>' -> SETTINGS section=advanced key=restore-backup fileName=<file> confirm=true; if confirm is absent, ask for confirmation. Also 'what settings can you change' / 'list settings' -> SETTINGS action=list. Do NOT use SETTINGS for changes a dedicated action owns: switching the model is MODEL_SWITCH, the background/theme is BACKGROUND, the agent identity is CHARACTER, connectors are CONNECTOR, secret/API keys are CREDENTIALS. The distinction from VIEWS is value-vs-navigation: changing/toggling a permission or setting VALUE, or running a backup operation, is SETTINGS even though it lives on a settings page; merely OPENING or navigating to a settings page with no value change is VIEWS. SETTINGS never fills a form field with agent-fill.",
 		suppressPostActionContinuation: true,
 
 		parameters: [
@@ -663,14 +777,28 @@ export function createSettingsAction(deps: SettingsActionDeps = {}): Action {
 			{
 				name: "section",
 				description:
-					"Canonical settings section id or alias (e.g. permissions, capabilities, ai-model, background, secrets). Required for get/set.",
+					"Canonical settings section id or alias (e.g. permissions, capabilities, app-permissions, ai-model, background, secrets). Required for get/set.",
 				required: false,
 				schema: { type: "string" },
 			},
 			{
 				name: "key",
 				description:
-					"The specific toggle or operation within the section (e.g. shell, auto-training, create-backup, restore-backup). Optional; defaults to the section's primary key.",
+					"The specific toggle or operation within the section (e.g. shell, auto-training, fs/net, create-backup, restore-backup). Optional; defaults to the section's primary key.",
+				required: false,
+				schema: { type: "string" },
+			},
+			{
+				name: "app",
+				description:
+					"Registered app slug when section=app-permissions (for example my-app).",
+				required: false,
+				schema: { type: "string" },
+			},
+			{
+				name: "namespace",
+				description:
+					"Permission namespace when section=app-permissions; accepted values are fs/filesystem or net/network.",
 				required: false,
 				schema: { type: "string" },
 			},

--- a/plugins/plugin-app-control/test/scenarios/settings-app-permissions-toggle.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/settings-app-permissions-toggle.scenario.ts
@@ -1,0 +1,127 @@
+/**
+ * Live-model SETTINGS scenario (#14622): a natural app-permission revoke
+ * request must select the semantic SETTINGS action and drive the same
+ * read-modify-write route sequence the Settings toggle uses.
+ */
+
+import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+	jsonResponse,
+	readAppControlHttpRequests,
+	registerAppControlHttpHandler,
+	resetAppControlHttpLoopback,
+} from "../../../../packages/scenario-runner/test/scenarios/_helpers/app-control-http-loopback";
+
+const APP_SLUG = "weather";
+
+function appPermissionWrites() {
+	return readAppControlHttpRequests(
+		(request) =>
+			request.method === "PUT" &&
+			request.pathname === `/api/apps/permissions/${APP_SLUG}`,
+	).map((request) => request.body ?? null);
+}
+
+export default scenario({
+	lane: "live-only",
+	id: "settings-app-permissions-toggle",
+	title: "SETTINGS action revokes an app permission namespace",
+	domain: "app-control",
+	tags: ["app-control", "settings", "set", "app-permissions"],
+	isolation: "per-scenario",
+	requires: {
+		plugins: ["@elizaos/plugin-app-control"],
+	},
+	seed: [
+		{
+			type: "custom",
+			name: "register app-permissions loopback API",
+			apply: () => {
+				resetAppControlHttpLoopback();
+				registerAppControlHttpHandler((request) => {
+					if (
+						request.method === "GET" &&
+						request.pathname === `/api/apps/permissions/${APP_SLUG}`
+					) {
+						return jsonResponse({
+							slug: APP_SLUG,
+							trust: "external",
+							isolation: "worker",
+							requestedPermissions: {
+								fs: { read: ["state/weather/**"] },
+								net: { outbound: ["https://api.weather.test"] },
+							},
+							recognisedNamespaces: ["fs", "net"],
+							grantedNamespaces: ["fs", "net"],
+							grantedAt: "2026-01-01T00:00:00.000Z",
+						});
+					}
+					if (
+						request.method === "PUT" &&
+						request.pathname === `/api/apps/permissions/${APP_SLUG}`
+					) {
+						return jsonResponse({
+							slug: APP_SLUG,
+							trust: "external",
+							isolation: "worker",
+							requestedPermissions: {
+								fs: { read: ["state/weather/**"] },
+								net: { outbound: ["https://api.weather.test"] },
+							},
+							recognisedNamespaces: ["fs", "net"],
+							grantedNamespaces: ["fs"],
+							grantedAt: "2026-01-01T00:00:00.000Z",
+						});
+					}
+					return undefined;
+				});
+				return undefined;
+			},
+		},
+	],
+	rooms: [
+		{
+			id: "main",
+			source: "chat",
+			title: "Settings App Permissions Toggle",
+		},
+	],
+	turns: [
+		{
+			kind: "message",
+			name: "user-asks-revoke-network",
+			text: `revoke network access for the ${APP_SLUG} app`,
+		},
+	],
+	finalChecks: [
+		{
+			type: "selectedAction",
+			actionName: "SETTINGS",
+		},
+		{
+			type: "actionCalled",
+			actionName: "SETTINGS",
+			status: "success",
+			minCount: 1,
+		},
+		{
+			type: "custom",
+			name: "SETTINGS drove PUT /api/apps/permissions/weather { namespaces:[fs] }",
+			predicate: () => {
+				const expected = [{ namespaces: ["fs"] }];
+				const actual = appPermissionWrites();
+				return JSON.stringify(actual) === JSON.stringify(expected)
+					? undefined
+					: `expected exactly one app permission write ${JSON.stringify(expected)}, saw ${JSON.stringify(actual)}`;
+			},
+		},
+		{
+			type: "custom",
+			name: "cleanup app-permissions loopback",
+			predicate: () => {
+				resetAppControlHttpLoopback();
+				return undefined;
+			},
+		},
+	],
+});


### PR DESCRIPTION
## Summary
- Route `SETTINGS section=app-permissions` through the existing `/api/apps/permissions/:slug` app-permissions use case.
- Add read-modify-write handling so grant/revoke preserves other granted namespaces while PUTing the full namespace list expected by the route.
- Add deterministic route tests plus a live-only scenario for "revoke network access for the weather app".

Fixes #14622.

## Verification
- `bun run --cwd plugins/plugin-app-control test -- src/actions/settings.test.ts`
- `bun run --cwd plugins/plugin-app-control typecheck`
- `bun src/cli.ts list ../../plugins/plugin-app-control/test/scenarios --scenario settings-app-permissions-toggle` from `packages/scenario-runner`
- `bun run --cwd packages/scenario-runner test src/action-effect-ratchet.test.ts src/skippable-check-ratchet.test.ts src/echo-assertion-ratchet.test.ts`
- `git diff --check origin/develop...HEAD`
- `bun run audit:error-policy-ratchet --report`

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - semantic action/server-route wiring only; no rendered UI surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - semantic action/server-route wiring only; no rendered UI surface changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no interactive UI flow changed in this PR; the same settings use case is covered through action route tests`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no long-running backend service path was started; route-effect command output is listed in Verification`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend request/response or state change changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - live provider credentials are unavailable in this environment; the PR adds the live-only settings-app-permissions-toggle scenario for keyed CI/manual evidence`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - deterministic route tests verify the namespace grant mutation; no persisted external artifact is produced by local verification`.

## Evidence Notes
- Live LLM trajectory: N/A locally. `OPENAI_API_KEY`, `GROQ_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, `OPENROUTER_API_KEY`, and `CEREBRAS_API_KEY` are unset in this environment.
- App visual audit: N/A. No renderer/UI files were changed; this wires the semantic action twin and scenario coverage only.
