### PR TITLE
fix(onboarding): keep help tutorial guidance chat-native

### DIFF
--- a/packages/agent/src/runtime/__tests__/default-documents.test.ts
+++ b/packages/agent/src/runtime/__tests__/default-documents.test.ts
@@ -186,7 +186,9 @@ describe("bundled help documents", () => {
 
   it("stays durable: no screen-relative or widget-relative instructions", () => {
     for (const doc of HELP_DOCUMENTS) {
-      expect(doc.text).not.toMatch(/below|tap “|deepLink|start the tutorial”/i);
+      expect(doc.text).not.toMatch(
+        /below|tap “|deepLink|start the tutorial”|tutorial (tile|launcher|view)|launcher tile|open the tutorial/i,
+      );
     }
   });
 });

--- a/packages/agent/src/runtime/default-help-documents.ts
+++ b/packages/agent/src/runtime/default-help-documents.ts
@@ -40,7 +40,7 @@ function helpDocument(
 }
 
 export const HELP_DOCUMENTS: readonly DefaultDocumentDefinition[] = [
-  helpDocument("eliza-help-getting-started", "Eliza help: getting started", 1, [
+  helpDocument("eliza-help-getting-started", "Eliza help: getting started", 2, [
     {
       question: "What is Eliza?",
       answer:
@@ -49,7 +49,7 @@ export const HELP_DOCUMENTS: readonly DefaultDocumentDefinition[] = [
     {
       question: "I just opened Eliza — what do I do first?",
       answer:
-        'Take the interactive tutorial: type "start tutorial" in the chat (or open the Tutorial tile in the launcher). It walks you through the basics right in the conversation — sending messages, voice, navigating by asking — in about a minute, and you can stop it anytime by typing "stop tutorial".',
+        'Take the interactive tutorial: type "start tutorial" in the chat. It walks you through the basics right in the conversation — sending messages, voice, navigating by asking — in about a minute, and you can stop it anytime by typing "stop tutorial".',
     },
     {
       question: "What is the glowing pill at the bottom of the screen?",
@@ -177,7 +177,7 @@ export const HELP_DOCUMENTS: readonly DefaultDocumentDefinition[] = [
         "The Launcher is the home for every screen Eliza can show you — your tasks, documents, memories, settings, and specialized tools. Swipe right from the home dashboard to reach it, open any screen from there or by asking the chat, and Eliza can also open them for you.",
     },
   ]),
-  helpDocument("eliza-help-troubleshooting", "Eliza help: troubleshooting", 1, [
+  helpDocument("eliza-help-troubleshooting", "Eliza help: troubleshooting", 2, [
     {
       question: "Eliza isn't responding to my messages.",
       answer:
@@ -196,7 +196,7 @@ export const HELP_DOCUMENTS: readonly DefaultDocumentDefinition[] = [
     {
       question: "How do I see the tutorial again?",
       answer:
-        'Type "restart tutorial" in the chat any time, or open the Tutorial tile in the launcher. The tour runs right in the conversation and is always re-runnable — nothing is one-time-only.',
+        'Type "restart tutorial" in the chat any time. The tour runs right in the conversation and is always re-runnable — nothing is one-time-only.',
     },
   ]),
 ];

--- a/packages/docs/ongoing-development/research/04-onboarding-tutorial-help.md
+++ b/packages/docs/ongoing-development/research/04-onboarding-tutorial-help.md
@@ -73,7 +73,7 @@ carry the deleted spotlight tutorial and `HelpView`.
   a one-time post-onboarding character-select landing can still occur
   (#13396 product decision, `packages/ui/src/state/startup-phase-hydrate.ts:264-292`).
 - Getting-started notifications are seeded once per agent — "Take the tour"
-  (`/tutorial`), "Get help any time" (`/chat`), "Connect your calendar"
+  (`/chat`), "Get help any time" (`/chat`), "Connect your calendar"
   (`/connectors`) — `packages/agent/src/runtime/onboarding-notifications.ts:44-73`.
 - Post-login permission priming soft-ask modal
   (`packages/ui/src/components/permissions/permission-priming.ts`).
@@ -85,11 +85,11 @@ Chat-native, no overlay engine: `packages/ui/src/tutorial/tutorial-service.ts`
 `tutorial-script.ts` (six conversational steps: welcome, send-message, voice,
 navigate, new-chat, done; each auto-advances on the real action with a "Next"
 fallback), `TutorialConductor.tsx` seeds turns into the live transcript, and the
-`__tutorial__:` action channel carries choices. Entry points: the launcher tile
-(`packages/ui/src/components/pages/LauncherSurface.tsx:101`), the `/tutorial`
-builtin view (`packages/agent/src/api/builtin-views.ts:14-23`), typed
-"start/stop/restart tutorial" composer commands, and the seeded notification.
-The tour never auto-launches.
+`__tutorial__:` action channel carries choices. Entry points: the home tutorial
+card (`packages/ui/src/components/chat/widgets/tutorial-launch.tsx`), typed
+"start/stop/restart tutorial" composer commands, and the seeded notification
+that deep-links to chat. Historical `/tutorial` links are redirected to chat;
+the tour is not a routable view and never auto-launches.
 
 ### Help (post-#13394)
 
@@ -178,10 +178,11 @@ first-run for developers with keys. (Owner-confirmable, but the default is
 clear from "minimize scope".)
 
 **Q2. Should the tutorial auto-launch after onboarding?**
-A: No. Today it never auto-launches (tile, notification, typed command,
-`/tutorial` view) and the wrap-up copy points at it. That matches the views
-doctrine (no suggestion chips, agent-proactive is for view switches) and the
-no-special-rails constraint. Keep as-is; test discoverability instead.
+A: No. Today it never auto-launches (home card, notification, typed command,
+and historical `/tutorial` redirect to chat) and the wrap-up copy points at
+chat-native entry points. That matches the views doctrine (no suggestion chips,
+agent-proactive is for view switches) and the no-special-rails constraint. Keep
+as-is; test discoverability instead.
 
 **Q3. Keep the one-time character-select landing after cloud-only completion?**
 A: Default answer: remove it for MVP — cloud-only completion already lands in

--- a/packages/scenario-runner/test/scenarios/README.md
+++ b/packages/scenario-runner/test/scenarios/README.md
@@ -86,8 +86,9 @@ requires a real provider key for live natural-language planner runs.
 
 - `live-help-knowledge` covers the deleted-Help-view replacement: a real model
   must answer first-run help questions from the bundled help FAQ fragments,
-  mention the rerunnable tutorial/voice/privacy facts, and avoid stale "Help
-  view" or button-below instructions. Run it with
+  mention the chat-native rerunnable tutorial/voice/privacy facts, and avoid
+  stale "Help view", Tutorial launcher tile, or button-below instructions. Run
+  it with
   `eliza-scenarios run packages/scenario-runner/test/scenarios --scenario live-help-knowledge --report <out> --run-dir <dir>`
   and attach the report plus reviewed trajectories.
 

--- a/packages/scenario-runner/test/scenarios/live-help-knowledge.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-help-knowledge.scenario.ts
@@ -91,7 +91,7 @@ export default scenario({
       name: "new user asks what to do first",
       text: "What should I do first if I do not know where to start?",
       assertResponse: assertHelpAnswer([
-        [/start|restart|take/i],
+        [/start tutorial|restart tutorial/i],
         [/tutorial|tour/i],
         ["chat", "conversation"],
       ]),
@@ -155,7 +155,7 @@ export default scenario({
     {
       type: "modelCallOccurred",
       name: "trajectory includes getting-started help fragment",
-      includesAll: ["I just opened Eliza", "Take the interactive tutorial"],
+      includesAll: ["I just opened Eliza", 'type "start tutorial" in the chat'],
       minCount: 1,
     },
     {

--- a/packages/scenario-runner/test/scenarios/live-help-knowledge.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-help-knowledge.scenario.ts
@@ -14,6 +14,9 @@ const FORBIDDEN_UI_REFERENCES = [
   /help screen/i,
   /spotlight tour/i,
   /full[- ]screen help/i,
+  /tutorial (launcher|tile|view)/i,
+  /launcher tile/i,
+  /open (the )?tutorial/i,
   /tap (the )?button below/i,
   /click (the )?button below/i,
 ];
@@ -95,7 +98,7 @@ export default scenario({
       responseJudge: {
         minimumScore: 0.8,
         rubric:
-          'The answer must ground the first step in the bundled help: take/restart the interactive tutorial from chat by typing "start tutorial" or using the Tutorial launcher tile. It must not refer to a deleted Help view, spotlight-only tour, or a button below the response.',
+          'The answer must ground the first step in the bundled help: take/restart the interactive tutorial from chat by typing "start tutorial". It must not refer to a deleted Help view, tutorial launcher tile, spotlight-only tour, or a button below the response.',
       },
     },
     {
@@ -122,13 +125,13 @@ export default scenario({
       text: "Can I see the tutorial again later? How do I restart it?",
       assertResponse: assertHelpAnswer([
         [/restart tutorial|start tutorial/i],
-        ["chat", "launcher"],
+        ["chat"],
         [/rerunnable|again|any time|later/i],
       ]),
       responseJudge: {
         minimumScore: 0.8,
         rubric:
-          'The answer must say the tutorial is rerunnable and can be started from chat with "restart tutorial" or "start tutorial", or from the Tutorial launcher tile. It must not call it one-time-only.',
+          'The answer must say the tutorial is rerunnable and can be started from chat with "restart tutorial" or "start tutorial". It must not call it one-time-only or point to a tutorial launcher tile.',
       },
     },
     {

--- a/packages/ui/src/tutorial/tutorial-service.ts
+++ b/packages/ui/src/tutorial/tutorial-service.ts
@@ -6,7 +6,7 @@
  * conversational turns into the live chat transcript.
  *
  * Module-level store shared via globalThis (Symbol.for) so a single instance
- * survives HMR and is reachable from non-React callers (the launcher tile,
+ * survives HMR and is reachable from non-React callers (the home tutorial card,
  * the action channel) + useSyncExternalStore for React consumers. The store
  * key is the historical "elizaos.ui.tutorial-controller" symbol so state
  * carried across an HMR boundary from an older bundle keeps working; reads
@@ -183,7 +183,7 @@ function begin(): void {
 
 /**
  * Start the tour. Idle starts fresh; completed/stopped restart from the top
- * (the launcher tile and "start tutorial" both mean "show me the tour", not
+ * (the home card and "start tutorial" both mean "show me the tour", not
  * "resume some prior run"); an already-active tour is a no-op so a double-tap
  * or duplicate command can't yank the user back to the welcome turn.
  */


### PR DESCRIPTION
## Summary
- remove stale Tutorial launcher tile wording from seeded help knowledge now that tutorial/help views are removed
- bump the affected help document versions so stale fragments are pruned on reseed
- tighten `live-help-knowledge` to reject tutorial launcher/tile/view phrasing and require chat-based tutorial restart guidance
- update the onboarding research doc and tutorial-service comments to match the home-card/chat-native entry points
- add regression assertions so bundled help knowledge and the live scenario cannot reintroduce tutorial tile/view directions

Part of #14360. This does not close the issue because the live-model report, reviewed trajectory, and rendered app evidence are still required.

## Verification
- `bunx @biomejs/biome check packages/agent/src/runtime/default-help-documents.ts packages/agent/src/runtime/__tests__/default-documents.test.ts packages/scenario-runner/test/scenarios/live-help-knowledge.scenario.ts packages/ui/src/tutorial/tutorial-service.ts`
- `bun run --cwd packages/agent test src/runtime/__tests__/default-documents.test.ts` -> 1 file, 10 tests passed
- `bun run --cwd packages/scenario-runner test src/scenario-expansion.test.ts src/schema-strict.test.ts src/scenario-deferral.test.ts` -> 3 files, 23 tests passed
- `git diff --check`

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] N/A - copy, seeded knowledge, docs, and scenario assertion hardening only; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user workflow changed; this prevents stale help text and strengthens the existing live scenario.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime path changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path changed beyond comments in tutorial-service.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - this PR adds live-scenario assertions but does not run the live model; #14360 still requires that external trajectory evidence.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no separate domain artifact file; the domain proof is the focused seeded-document regression and scenario schema/expansion test output listed in Verification.

