### PR TITLE
fix(core): report the winning provider's model in RUNTIME_MODEL_CONTEXT

### DIFF
--- a/packages/core/src/features/basic-capabilities/providers/runtimeModelContext.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/runtimeModelContext.test.ts
@@ -183,6 +183,95 @@ describe("runtimeModelContextProvider", () => {
 		expect(result.data?.responseHandlerModel).toBeUndefined();
 	});
 
+	it("reports the winning provider's declared model, not a losing provider's default", async () => {
+		// Live multi-provider scenario: elizaOSCloud (priority 50) wins every slot
+		// and declares the concrete model it resolves (ELIZAOS_CLOUD_*_MODEL) via
+		// `metadata.displayModel` at registration. plugin-anthropic (a losing,
+		// lower-priority registration) also has ANTHROPIC_*_MODEL set, so the fixed
+		// OLLAMA_/OPENAI_/ANTHROPIC_/'' resolver walk (mirrored below) leaks
+		// claude-opus-4-6 for TEXT_LARGE. The provider must report the winner's
+		// declared model, never the losing resolver leak. The provider name
+		// "elizaOSCloud" deliberately does NOT map to the env prefix ELIZAOS_CLOUD_
+		// by string transform — proving the fix keys off the registration metadata,
+		// not a derived prefix.
+		const settings: Record<string, string> = {
+			ANTHROPIC_LARGE_MODEL: "claude-opus-4-6",
+			ANTHROPIC_SMALL_MODEL: "claude-sonnet-4-6",
+		};
+		const suffixOf: Record<string, string> = {
+			[ModelType.TEXT_LARGE]: "LARGE_MODEL",
+			[ModelType.TEXT_SMALL]: "SMALL_MODEL",
+			[ModelType.RESPONSE_HANDLER]: "RESPONSE_HANDLER_MODEL",
+			[ModelType.ACTION_PLANNER]: "ACTION_PLANNER_MODEL",
+		};
+		const runtime = makeRuntime(settings, {
+			// mirror the real runtime resolver: fixed OLLAMA_/OPENAI_/ANTHROPIC_/''
+			// walk that would leak ANTHROPIC_LARGE_MODEL for TEXT_LARGE.
+			resolveProviderModelString: (modelType: string) => {
+				const suffix = suffixOf[modelType];
+				if (!suffix) return modelType;
+				for (const p of ["OLLAMA_", "OPENAI_", "ANTHROPIC_", ""]) {
+					const v = settings[`${p}${suffix}`];
+					if (v) return v;
+				}
+				return modelType;
+			},
+			// elizaOSCloud wins each slot (index 0) and declares its resolved model
+			// via metadata.displayModel — exactly as registerTextInferenceModels does.
+			models: new Map([
+				[
+					ModelType.TEXT_LARGE,
+					[
+						{
+							provider: "elizaOSCloud",
+							metadata: { displayModel: "cerebras:zai-glm-4.7" },
+						},
+						{ provider: "anthropic" },
+					],
+				],
+				[
+					ModelType.TEXT_SMALL,
+					[
+						{
+							provider: "elizaOSCloud",
+							metadata: { displayModel: "gemma-4-31b" },
+						},
+						{ provider: "anthropic" },
+					],
+				],
+				[
+					ModelType.RESPONSE_HANDLER,
+					[
+						{
+							provider: "elizaOSCloud",
+							metadata: { displayModel: "cerebras:zai-glm-4.7" },
+						},
+					],
+				],
+				[
+					ModelType.ACTION_PLANNER,
+					[
+						{
+							provider: "elizaOSCloud",
+							metadata: { displayModel: "cerebras:zai-glm-4.7" },
+						},
+					],
+				],
+			]),
+		} as unknown as Partial<IAgentRuntime>);
+
+		const result = await runtimeModelContextProvider.get(
+			runtime,
+			makeMessage("what models are you using?"),
+			{} as never,
+		);
+		expect(result.data?.textLargeModel).toBe("cerebras:zai-glm-4.7");
+		expect(result.data?.textSmallModel).toBe("gemma-4-31b");
+		expect(result.text).not.toContain("claude-opus-4-6");
+		expect(result.text).not.toContain("claude-sonnet-4-6");
+		expect(result.data?.responseHandlerModel).toBe("cerebras:zai-glm-4.7");
+	});
+
 	it("stays silent for unrelated live-data questions", async () => {
 		const runtime = makeRuntime({
 			OPENAI_LARGE_MODEL: "gpt-oss-120b",

--- a/packages/core/src/features/basic-capabilities/providers/runtimeModelContext.ts
+++ b/packages/core/src/features/basic-capabilities/providers/runtimeModelContext.ts
@@ -129,14 +129,23 @@ function configuredModelString(
 	runtime: RuntimeWithModelHelpers,
 	modelType: ModelTypeName,
 ): string | undefined {
+	// Consult the WINNING (highest-priority) provider's own registration first.
+	// It declares the concrete model it will call via `metadata.displayModel`
+	// (or `displayModelSetting`), resolved from the provider's own config keys
+	// (e.g. plugin-elizacloud's ELIZAOS_CLOUD_LARGE_MODEL). This must come BEFORE
+	// resolveProviderModelString / the generic fallback walk, which only know a
+	// fixed OLLAMA_/OPENAI_/ANTHROPIC_/"" prefix list: on a multi-provider
+	// deployment those report a LOSING provider's configured model
+	// (ANTHROPIC_LARGE_MODEL) for a slot a higher-priority provider actually
+	// owns, because the winning provider's own prefix is invisible to that walk.
+	const registration = registeredModelFor(runtime, modelType);
+	const displayModel = displayModelFor(runtime, registration?.metadata);
+	if (displayModel) return displayModel;
 	const resolved =
 		typeof runtime.resolveProviderModelString === "function"
 			? runtime.resolveProviderModelString(modelType)
 			: undefined;
 	if (resolved && resolved !== String(modelType)) return resolved;
-	const registration = registeredModelFor(runtime, modelType);
-	const displayModel = displayModelFor(runtime, registration?.metadata);
-	if (displayModel) return displayModel;
 	// Otherwise resolve from the configured *_MODEL keys along the fallback chain
 	// (e.g. ANTHROPIC_LARGE_MODEL). If still unresolvable, return undefined so the
 	// caller OMITS the line rather than leaking the raw slot name to the user.


### PR DESCRIPTION
## Symptom

On a multi-provider deployment the `RUNTIME_MODEL_CONTEXT` provider answers "what models are you using?" with the **wrong** model for `TEXT_LARGE` / `TEXT_SMALL`: it reports `claude-opus-4-6` / `claude-sonnet-4-6` (plugin-anthropic's configured `ANTHROPIC_*_MODEL`) even though `elizaOSCloud` (priority 50) wins those slots and the real configured models are `ELIZAOS_CLOUD_LARGE_MODEL` / `ELIZAOS_CLOUD_SMALL_MODEL` (e.g. `cerebras:zai-glm-4.7` / `gemma-4-31b`). `RESPONSE_HANDLER` / `ACTION_PLANNER` report correctly, which is the tell.

## Root cause

`configuredModelString` (`packages/core/src/features/basic-capabilities/providers/runtimeModelContext.ts`) resolved the slot via `runtime.resolveProviderModelString(modelType)` **first**. That resolver (`packages/core/src/runtime.ts:3052`) walks a hardcoded prefix list `["OLLAMA_", "OPENAI_", "ANTHROPIC_", ""]`. For `TEXT_LARGE` the fallback chain is just `[TEXT_LARGE]` (suffix `LARGE_MODEL`), so it tries `ANTHROPIC_LARGE_MODEL` — which is set — and returns the **losing** provider's model before ever reaching the winning provider's own `ELIZAOS_CLOUD_LARGE_MODEL` (a key that fixed list can never reach). The subsequent `displayModel`-metadata and fallback steps never run.

## Fix

`plugin-elizacloud` already registers each chat-brain slot with `metadata.displayModel` set to the concrete model it resolves (`plugins/plugin-elizacloud/src/index.ts:137`, `registerTextInferenceModels`). Consult the **winning registration's** `displayModel` / `displayModelSetting` metadata **before** `resolveProviderModelString` and the generic fallback walk. The winning registration is the highest-priority provider for the slot, so this reports the model that provider will actually call — provider-agnostic, and it does not touch model routing (`resolveProviderModelString` is unchanged).

This keys off registration metadata rather than deriving an env prefix from the provider name: the provider name `elizaOSCloud` does not string-transform to the env prefix `ELIZAOS_CLOUD_`, so a name-derived prefix walk cannot resolve it — the metadata is the reliable source, and `develop` already provides it.

## Verification

`bun run --cwd packages/core typecheck` → clean (exit 0).

`bun run --cwd packages/core test -- runtimeModelContext`:
```
 Test Files  1 passed (1)
      Tests  8 passed (8)
```
Added test reproduces the live multi-provider scenario: `elizaOSCloud` wins each slot and declares its model via `metadata.displayModel`, while `ANTHROPIC_*_MODEL` is also set and the mirrored fixed-prefix resolver leaks `claude-opus-4-6` — the provider must report the winner (`cerebras:zai-glm-4.7` / `gemma-4-31b`), never the anthropic leak. The 5 pre-existing tests (per-slot resolution, resolver fallthrough, displayModelSetting, no-false-CODEX, anthropic-large + undefined-response-handler) still pass.

Evidence note: this is a read-only display provider; a live self-model trajectory is the ideal supplemental evidence and can be captured on the live bot, but behavior is fully pinned by the deterministic multi-provider reproduction above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)