### PR TITLE
fix(core): relay a successful tool result when the post-tool evaluator throws

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop-post-tool-evaluator-failure.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-post-tool-evaluator-failure.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Covers the planner loop's post-tool evaluator-failure recovery: when the
+ * in-loop evaluator model call throws AFTER a non-terminal tool already
+ * succeeded, the loop relays the tool's truthful output instead of discarding
+ * the turn — but still rethrows when nothing succeeded. Deterministic —
+ * vitest-mocked `useModel` + injected `executeToolCall`/`evaluate`; no live model.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { runPlannerLoop } from "../planner-loop";
+
+// Planner turn that emits exactly one non-terminal FILE tool call and no
+// messageToUser — the shape from trajectory tj-dc0181fe5c9075 where FILE wrote
+// the file, then the evaluator's model call 400'd.
+function plannerEmitsFileCall() {
+	return {
+		useModel: vi.fn().mockResolvedValueOnce({
+			text: "",
+			toolCalls: [{ id: "call-1", name: "FILE", arguments: {} }],
+			usage: { promptTokens: 100, completionTokens: 10, totalTokens: 110 },
+		}),
+	};
+}
+
+describe("planner-loop — post-tool evaluator failure recovery", () => {
+	it("relays the successful tool result when the evaluator throws transiently", async () => {
+		const wrote = "Wrote 16 bytes to /home/milady/hello-elizacode.txt";
+		const executeToolCall = vi.fn(async () => ({
+			success: true,
+			text: wrote,
+		}));
+		// The in-loop evaluator model call fails exactly as elizaOS Cloud did
+		// (HTTP 400 Bad Request) after FILE already wrote the file.
+		const evaluate = vi.fn(async () => {
+			throw new Error("Bad Request");
+		});
+
+		const result = await runPlannerLoop({
+			runtime: plannerEmitsFileCall(),
+			context: { id: "ctx" },
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage ?? "").toContain(wrote);
+	});
+
+	it("does NOT mask a genuine failure — rethrows when no tool succeeded", async () => {
+		const executeToolCall = vi.fn(async () => ({
+			success: false,
+			error: "disk full",
+			text: "FILE failed: disk full",
+		}));
+		const evaluate = vi.fn(async () => {
+			throw new Error("Bad Request");
+		});
+
+		await expect(
+			runPlannerLoop({
+				runtime: plannerEmitsFileCall(),
+				context: { id: "ctx" },
+				executeToolCall,
+				evaluate,
+			}),
+		).rejects.toThrow("Bad Request");
+	});
+
+	it("does not regress the happy path — returns the evaluator's message on FINISH", async () => {
+		const evaluatorMessage = "Created hello-elizacode.txt with ELIZA CODE WORKS.";
+		const executeToolCall = vi.fn(async () => ({
+			success: true,
+			text: "Wrote 16 bytes to /home/milady/hello-elizacode.txt",
+		}));
+		const evaluate = vi.fn(async () => ({
+			success: true,
+			decision: "FINISH" as const,
+			messageToUser: evaluatorMessage,
+			thought: "Done.",
+		}));
+
+		const result = await runPlannerLoop({
+			runtime: plannerEmitsFileCall(),
+			context: { id: "ctx" },
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(evaluatorMessage);
+	});
+});

--- a/packages/core/src/runtime/__tests__/planner-loop-post-tool-evaluator-failure.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-post-tool-evaluator-failure.test.ts
@@ -66,7 +66,8 @@ describe("planner-loop — post-tool evaluator failure recovery", () => {
 	});
 
 	it("does not regress the happy path — returns the evaluator's message on FINISH", async () => {
-		const evaluatorMessage = "Created hello-elizacode.txt with ELIZA CODE WORKS.";
+		const evaluatorMessage =
+			"Created hello-elizacode.txt with ELIZA CODE WORKS.";
 		const executeToolCall = vi.fn(async () => ({
 			success: true,
 			text: "Wrote 16 bytes to /home/milady/hello-elizacode.txt",

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -793,7 +793,32 @@ export async function runPlannerLoop(
 			};
 		}
 
-		const evaluator = await evaluateTrajectory(params, trajectory, iteration);
+		let evaluator: EvaluatorOutput;
+		try {
+			evaluator = await evaluateTrajectory(params, trajectory, iteration);
+		} catch (err) {
+			// The in-loop evaluator is a MODEL call: it decides FINISH/CONTINUE and
+			// synthesizes the user-facing reply from the tool results. When it fails
+			// transiently (a provider 400/429/5xx) AFTER a non-terminal tool already
+			// executed successfully this turn, propagating the error discards the
+			// completed work and surfaces the generic "something went wrong" apology —
+			// a lie, because the tool did the work (e.g. FILE wrote the file). Relay
+			// the successful tool's own truthful output deterministically (no further
+			// model call, so the same provider failure cannot recur). With no
+			// successful non-terminal tool to relay, rethrow so a genuine failure
+			// still surfaces honestly — never mask a real failure.
+			const relay = deterministicSuccessfulToolRelay(trajectory);
+			if (!relay) throw err;
+			params.runtime.logger?.warn?.(
+				{ iteration, err: err instanceof Error ? err.message : String(err) },
+				"[planner-loop] post-tool evaluator model call failed; relaying the completed tool result instead of discarding the turn",
+			);
+			return {
+				status: "finished",
+				trajectory,
+				finalMessage: userSafeFinalMessage(relay, trajectory),
+			};
+		}
 		trajectory.evaluatorOutputs.push(evaluator);
 		appendEvaluatorContextEvent(trajectory, evaluator, iteration);
 
@@ -2727,6 +2752,30 @@ function latestToolResultText(
 		if (text) {
 			return text;
 		}
+	}
+	return undefined;
+}
+
+/**
+ * Deterministic (no model call) relay of the most recent SUCCESSFUL non-terminal
+ * tool result. Used when a model call LATER in the turn (the post-tool evaluator
+ * synthesis/decision call) fails transiently AFTER a tool already did real work:
+ * relay the tool's own truthful output — the path it wrote, the count it returned
+ * — instead of discarding the work and telling the user "something went wrong".
+ * Prefers the tool's opt-in `userFacingText`, then its `text`, then its `summary`.
+ * Returns undefined when nothing succeeded, so genuine failures still surface.
+ */
+function deterministicSuccessfulToolRelay(
+	trajectory: PlannerTrajectory,
+): string | undefined {
+	for (const step of [...trajectory.steps].reverse()) {
+		if (!step.toolCall || step.result?.success !== true) continue;
+		if (isTerminalToolCall(step.toolCall)) continue;
+		const candidate =
+			getNonEmptyString(step.result.userFacingText) ??
+			getNonEmptyString(step.result.text) ??
+			getNonEmptyString(step.result.summary);
+		if (candidate) return candidate;
 	}
 	return undefined;
 }

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -797,6 +797,8 @@ export async function runPlannerLoop(
 		try {
 			evaluator = await evaluateTrajectory(params, trajectory, iteration);
 		} catch (err) {
+			// error-policy:J4 explicit user-facing degrade - when the tool already
+			// succeeded, return that truthful result instead of a generic failure.
 			// The in-loop evaluator is a MODEL call: it decides FINISH/CONTINUE and
 			// synthesizes the user-facing reply from the tool results. When it fails
 			// transiently (a provider 400/429/5xx) AFTER a non-terminal tool already


### PR DESCRIPTION
## Symptom

A successful non-terminal tool result can be discarded and turned into the generic transient failure reply when the in-loop trajectory evaluator throws after the tool already completed. In the observed trajectory, the `FILE` tool returned `{ success: true, text: "Wrote 16 bytes to .../hello-elizacode.txt" }`, then the evaluator model call returned an HTTP error. The file existed, but the user saw an apology.

## Fix

Two edits in `packages/core/src/runtime/planner-loop.ts`:

- Add `deterministicSuccessfulToolRelay(trajectory)`, a no-model-call helper that returns the latest successful non-terminal tool result's `userFacingText`, `text`, or `summary`.
- Wrap the post-tool evaluator call. If it throws and a successful non-terminal tool result exists, finish the loop with the tool's truthful output. If there is nothing successful to relay, rethrow so genuine failures still surface.

The happy path remains unchanged: when the evaluator resolves, its `messageToUser` still wins.

## Required Evidence Rows

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: N/A - core planner-loop behavior only; no UI pixels changed.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: N/A - core planner-loop behavior only; no UI pixels changed.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: N/A - no interactive UI flow changed in this PR.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: N/A - no long-running backend service was started; deterministic planner-loop tests exercise the failure path directly.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - this PR adds deterministic regression coverage for a model-call failure path; no live provider credentials are available on this host.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - no persistent domain artifact is produced by the local deterministic tests.

## Verification

<!-- evidence-row:tests -->
- Tests: `bun run --cwd packages/core test -- planner-loop-post-tool-evaluator-failure` passed: 1 file, 3 tests.
<!-- evidence-row:tests -->
- Tests: `bun run --cwd packages/core test -- planner-loop` passed: 9 files, 96 tests.
<!-- evidence-row:typecheck -->
- Typecheck: `bun run --cwd packages/core typecheck` passed.
<!-- evidence-row:static-analysis -->
- Static analysis: `bunx @biomejs/biome check packages/core/src/runtime/planner-loop.ts packages/core/src/runtime/__tests__/planner-loop-post-tool-evaluator-failure.test.ts --no-errors-on-unmatched` passed.
<!-- evidence-row:diff-hygiene -->
- Diff hygiene: `git diff --check origin/develop...HEAD` passed.
<!-- evidence-row:error-policy -->
- Error policy: `bun run audit:error-policy-ratchet` passed; the intentional catch is annotated `error-policy:J4`.
<!-- evidence-row:build -->
- Build prerequisite: `bun install --frozen-lockfile --ignore-scripts`, `bun run --cwd packages/shared build:i18n`, and `bun run --cwd packages/logger build` passed in the isolated worktree before running tests.
