### PR TITLE
ci(evidence): block committed issue evidence files (#14618)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,11 +23,18 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
+      - name: Compute changed files
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          git diff --name-status "$BASE_SHA" "$GITHUB_SHA" > "$RUNNER_TEMP/pr-files.txt"
+
       - name: Validate PR evidence rows
         run: |
           jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH" > "$RUNNER_TEMP/pr-body.md"
           PR_LABELS=$(jq -r '.pull_request.labels | map(.name) | join(",")' "$GITHUB_EVENT_PATH")
-          node scripts/check-pr-evidence.mjs --body-file "$RUNNER_TEMP/pr-body.md" --labels "$PR_LABELS"
+          node scripts/check-pr-evidence.mjs --body-file "$RUNNER_TEMP/pr-body.md" --labels "$PR_LABELS" --changed-files "$RUNNER_TEMP/pr-files.txt"
 
   check-pr-title:
     runs-on: ubuntu-latest

--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -80,6 +80,26 @@ export function hasArtifactReference(text) {
   return false;
 }
 
+export function findRetiredRepoEvidenceDiffViolations(nameStatusText) {
+  return String(nameStatusText ?? "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .flatMap((line) => {
+      const [status, ...paths] = line.split(/\t+/);
+      if (!status || status.startsWith("D")) return [];
+      const candidatePaths =
+        status.startsWith("R") || status.startsWith("C")
+          ? paths.slice(-1)
+          : paths;
+      return candidatePaths.filter(
+        (path) =>
+          path === RETIRED_REPO_EVIDENCE_PATH ||
+          path.startsWith(`${RETIRED_REPO_EVIDENCE_PATH}/`),
+      );
+    });
+}
+
 export function isChecked(rowText) {
   return /^\s*[-*]\s*\[\s*[xX]\s*\]/m.test(rowText);
 }
@@ -198,6 +218,9 @@ Options:
   --body-file <path>  Read the PR body from a file (default: stdin).
   --labels <labels>   Comma-separated PR labels; ui/frontend/native require
                       concrete screenshot/video artifacts.
+  --changed-files <path>
+                      Validate git name-status diff output and fail if the PR
+                      adds or moves files under .github/issue-evidence/.
   --json              Print machine-readable findings JSON.
   --self-test         Run the planted-fixture self-check.
   --help, -h          Show this help.
@@ -310,6 +333,21 @@ function runSelfTest() {
   }
 
   {
+    const violations = findRetiredRepoEvidenceDiffViolations(
+      [
+        `A\t${RETIRED_REPO_EVIDENCE_PATH}/new-proof.md`,
+        `D\t${RETIRED_REPO_EVIDENCE_PATH}/old-proof.md`,
+        `R100\tdocs/proof.md\t${RETIRED_REPO_EVIDENCE_PATH}/renamed-proof.md`,
+      ].join("\n"),
+    );
+    if (violations.length !== 2) {
+      failures.push(
+        "retired repo evidence diff guard should fail additions and rename destinations",
+      );
+    }
+  }
+
+  {
     const body = REQUIRED_EVIDENCE_ROWS.slice(1)
       .map(
         ({ id }) =>
@@ -343,6 +381,28 @@ function main() {
   if (args.includes("--self-test")) {
     runSelfTest();
     return;
+  }
+
+  const changedFilesIdx = args.indexOf("--changed-files");
+  if (changedFilesIdx !== -1) {
+    const file = args[changedFilesIdx + 1];
+    if (!file) {
+      console.error("--changed-files requires a path argument");
+      process.exit(2);
+    }
+    const violations = findRetiredRepoEvidenceDiffViolations(
+      readFileSync(file, "utf8"),
+    );
+    if (violations.length > 0) {
+      console.error(
+        "Evidence gate FAILED: retired repo-local evidence files may not be added under .github/issue-evidence/.",
+      );
+      for (const violation of violations) console.error(`  - ${violation}`);
+      console.error(
+        "Attach evidence inline to the GitHub PR or issue instead of committing it.",
+      );
+      process.exit(1);
+    }
   }
 
   const body = readBody(args);

--- a/scripts/check-pr-evidence.test.mjs
+++ b/scripts/check-pr-evidence.test.mjs
@@ -13,6 +13,7 @@ import {
   boundRowBlock,
   evaluatePrEvidence,
   extractEvidenceRows,
+  findRetiredRepoEvidenceDiffViolations,
   hasArtifactReference,
   hasNaWithReason,
   isChecked,
@@ -316,6 +317,34 @@ describe("check-pr-evidence marker extraction", () => {
     const bounded = boundRowBlock(block);
     assert.ok(bounded.includes("continued indented line"));
     assert.ok(!bounded.includes("example.com"));
+  });
+});
+
+describe("check-pr-evidence retired repo path guard", () => {
+  it("flags added, copied, and renamed files under the retired evidence path", () => {
+    const violations = findRetiredRepoEvidenceDiffViolations(
+      [
+        `A\t${RETIRED_REPO_EVIDENCE_PATH}/new-proof.md`,
+        `C100\tdocs/proof.md\t${RETIRED_REPO_EVIDENCE_PATH}/copied-proof.md`,
+        `R100\tdocs/proof.md\t${RETIRED_REPO_EVIDENCE_PATH}/renamed-proof.md`,
+        "A\tdocs/real-pr-evidence.md",
+      ].join("\n"),
+    );
+    assert.deepEqual(violations, [
+      `${RETIRED_REPO_EVIDENCE_PATH}/new-proof.md`,
+      `${RETIRED_REPO_EVIDENCE_PATH}/copied-proof.md`,
+      `${RETIRED_REPO_EVIDENCE_PATH}/renamed-proof.md`,
+    ]);
+  });
+
+  it("allows deletions from the retired evidence path", () => {
+    const violations = findRetiredRepoEvidenceDiffViolations(
+      [
+        `D\t${RETIRED_REPO_EVIDENCE_PATH}/old-proof.md`,
+        "M\t.github/workflows/pr.yaml",
+      ].join("\n"),
+    );
+    assert.deepEqual(violations, []);
   });
 });
 


### PR DESCRIPTION
Relates to #14618.

## What

Adds the missing diff-level guard from #14618 after #14627 purged the resurrected `.github/issue-evidence/` tree:

- `scripts/check-pr-evidence.mjs --changed-files <name-status-file>` now fails if a PR adds, copies, or renames files into `.github/issue-evidence/`.
- Deletions from the retired path are allowed, so cleanup PRs still work.
- `.github/workflows/pr.yaml` now computes the PR name-status diff and feeds it into the evidence gate before validating PR body rows.
- `scripts/check-pr-evidence.test.mjs` covers added, copied, renamed, and deleted retired-path entries.

## Verification

- `node scripts/check-pr-evidence.test.mjs` -> pass, 25 tests.
- `node scripts/check-pr-evidence.mjs --self-test` -> pass, 8 planted cases.
- Forbidden diff proof:
  ```text
  A\t.github/issue-evidence/regression.md
  Evidence gate FAILED: retired repo-local evidence files may not be added under .github/issue-evidence/.
    - .github/issue-evidence/regression.md
  Attach evidence inline to the GitHub PR or issue instead of committing it.
  ```
- Allowed cleanup proof:
  ```text
  D\t.github/issue-evidence/old.md
  Evidence gate passed: all required rows satisfied.
  ```
- `bunx @biomejs/biome check .github/workflows/pr.yaml scripts/check-pr-evidence.mjs scripts/check-pr-evidence.test.mjs` -> pass for the two script files; workflow YAML is ignored by Biome config.
- `git diff --check` -> pass.
- `git ls-tree -r --name-only origin/develop -- .github/issue-evidence | wc -l` -> `0`.

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - CI/tooling-only guard; no UI surface or visual state changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - CI/tooling-only guard; no UI surface or visual state changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no interactive user-facing flow; command transcript above proves the guard behavior`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no runtime/backend code path executes; this is a PR workflow and Node script change`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend code changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent/action/provider/prompt/model behavior changed`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no app domain artifact is produced; verification artifact is the inline command transcript showing forbidden committed evidence now fails and deletion cleanup still passes`.
