### PR TITLE
fix(scenarios): require chat-native tutorial help guidance (#14360)

### DIFF
--- a/packages/agent/src/runtime/__tests__/default-documents.test.ts
+++ b/packages/agent/src/runtime/__tests__/default-documents.test.ts
@@ -186,7 +186,9 @@ describe("bundled help documents", () => {
 
   it("stays durable: no screen-relative or widget-relative instructions", () => {
     for (const doc of HELP_DOCUMENTS) {
-      expect(doc.text).not.toMatch(/below|tap “|deepLink|start the tutorial”/i);
+      expect(doc.text).not.toMatch(
+        /below|tap “|deepLink|start the tutorial”|tutorial (tile|launcher|view)|launcher tile|open the tutorial/i,
+      );
     }
   });
 });

--- a/packages/agent/src/runtime/default-help-documents.ts
+++ b/packages/agent/src/runtime/default-help-documents.ts
@@ -40,7 +40,7 @@ function helpDocument(
 }
 
 export const HELP_DOCUMENTS: readonly DefaultDocumentDefinition[] = [
-  helpDocument("eliza-help-getting-started", "Eliza help: getting started", 1, [
+  helpDocument("eliza-help-getting-started", "Eliza help: getting started", 2, [
     {
       question: "What is Eliza?",
       answer:
@@ -49,7 +49,7 @@ export const HELP_DOCUMENTS: readonly DefaultDocumentDefinition[] = [
     {
       question: "I just opened Eliza — what do I do first?",
       answer:
-        'Take the interactive tutorial: type "start tutorial" in the chat (or open the Tutorial tile in the launcher). It walks you through the basics right in the conversation — sending messages, voice, navigating by asking — in about a minute, and you can stop it anytime by typing "stop tutorial".',
+        'Take the interactive tutorial: type "start tutorial" in the chat, or use the tutorial card when it appears in chat. It walks you through the basics right in the conversation — sending messages, voice, navigating by asking — in about a minute, and you can stop it anytime by typing "stop tutorial".',
     },
     {
       question: "What is the glowing pill at the bottom of the screen?",
@@ -177,7 +177,7 @@ export const HELP_DOCUMENTS: readonly DefaultDocumentDefinition[] = [
         "The Launcher is the home for every screen Eliza can show you — your tasks, documents, memories, settings, and specialized tools. Swipe right from the home dashboard to reach it, open any screen from there or by asking the chat, and Eliza can also open them for you.",
     },
   ]),
-  helpDocument("eliza-help-troubleshooting", "Eliza help: troubleshooting", 1, [
+  helpDocument("eliza-help-troubleshooting", "Eliza help: troubleshooting", 2, [
     {
       question: "Eliza isn't responding to my messages.",
       answer:
@@ -196,7 +196,7 @@ export const HELP_DOCUMENTS: readonly DefaultDocumentDefinition[] = [
     {
       question: "How do I see the tutorial again?",
       answer:
-        'Type "restart tutorial" in the chat any time, or open the Tutorial tile in the launcher. The tour runs right in the conversation and is always re-runnable — nothing is one-time-only.',
+        'Type "restart tutorial" in the chat any time, or use the tutorial card when it appears in chat. The tour runs right in the conversation and is always re-runnable — nothing is one-time-only.',
     },
   ]),
 ];

--- a/packages/docs/ongoing-development/research/04-onboarding-tutorial-help.md
+++ b/packages/docs/ongoing-development/research/04-onboarding-tutorial-help.md
@@ -73,7 +73,7 @@ carry the deleted spotlight tutorial and `HelpView`.
   a one-time post-onboarding character-select landing can still occur
   (#13396 product decision, `packages/ui/src/state/startup-phase-hydrate.ts:264-292`).
 - Getting-started notifications are seeded once per agent — "Take the tour"
-  (`/tutorial`), "Get help any time" (`/chat`), "Connect your calendar"
+  (`/chat`), "Get help any time" (`/chat`), "Connect your calendar"
   (`/connectors`) — `packages/agent/src/runtime/onboarding-notifications.ts:44-73`.
 - Post-login permission priming soft-ask modal
   (`packages/ui/src/components/permissions/permission-priming.ts`).
@@ -85,11 +85,11 @@ Chat-native, no overlay engine: `packages/ui/src/tutorial/tutorial-service.ts`
 `tutorial-script.ts` (six conversational steps: welcome, send-message, voice,
 navigate, new-chat, done; each auto-advances on the real action with a "Next"
 fallback), `TutorialConductor.tsx` seeds turns into the live transcript, and the
-`__tutorial__:` action channel carries choices. Entry points: the launcher tile
-(`packages/ui/src/components/pages/LauncherSurface.tsx:101`), the `/tutorial`
-builtin view (`packages/agent/src/api/builtin-views.ts:14-23`), typed
-"start/stop/restart tutorial" composer commands, and the seeded notification.
-The tour never auto-launches.
+`__tutorial__:` action channel carries choices. Entry points: the home tutorial
+card (`packages/ui/src/components/chat/widgets/tutorial-launch.tsx`), typed
+"start/stop/restart tutorial" composer commands, and the seeded notification
+that deep-links to chat. Historical `/tutorial` links are redirected to chat;
+the tour is not a routable view and never auto-launches.
 
 ### Help (post-#13394)
 
@@ -178,10 +178,11 @@ first-run for developers with keys. (Owner-confirmable, but the default is
 clear from "minimize scope".)
 
 **Q2. Should the tutorial auto-launch after onboarding?**
-A: No. Today it never auto-launches (tile, notification, typed command,
-`/tutorial` view) and the wrap-up copy points at it. That matches the views
-doctrine (no suggestion chips, agent-proactive is for view switches) and the
-no-special-rails constraint. Keep as-is; test discoverability instead.
+A: No. Today it never auto-launches (home card, notification, typed command,
+and historical `/tutorial` redirect to chat) and the wrap-up copy points at
+chat-native entry points. That matches the views doctrine (no suggestion chips,
+agent-proactive is for view switches) and the no-special-rails constraint. Keep
+as-is; test discoverability instead.
 
 **Q3. Keep the one-time character-select landing after cloud-only completion?**
 A: Default answer: remove it for MVP — cloud-only completion already lands in

--- a/packages/scenario-runner/test/scenarios/README.md
+++ b/packages/scenario-runner/test/scenarios/README.md
@@ -86,8 +86,9 @@ requires a real provider key for live natural-language planner runs.
 
 - `live-help-knowledge` covers the deleted-Help-view replacement: a real model
   must answer first-run help questions from the bundled help FAQ fragments,
-  mention the rerunnable tutorial/voice/privacy facts, and avoid stale "Help
-  view" or button-below instructions. Run it with
+  mention the chat-native rerunnable tutorial/voice/privacy facts, and avoid
+  stale "Help view", Tutorial launcher tile, or button-below instructions. Run
+  it with
   `eliza-scenarios run packages/scenario-runner/test/scenarios --scenario live-help-knowledge --report <out> --run-dir <dir>`
   and attach the report plus reviewed trajectories.
 

--- a/packages/scenario-runner/test/scenarios/live-help-knowledge.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-help-knowledge.scenario.ts
@@ -14,6 +14,9 @@ const FORBIDDEN_UI_REFERENCES = [
   /help screen/i,
   /spotlight tour/i,
   /full[- ]screen help/i,
+  /tutorial (launcher )?tile/i,
+  /tutorial view/i,
+  /launcher tile/i,
   /tap (the )?button below/i,
   /click (the )?button below/i,
 ];
@@ -88,14 +91,14 @@ export default scenario({
       name: "new user asks what to do first",
       text: "What should I do first if I do not know where to start?",
       assertResponse: assertHelpAnswer([
-        [/start|restart|take/i],
+        [/start tutorial|restart tutorial|tutorial card|tutorial widget/i],
         [/tutorial|tour/i],
-        ["chat", "conversation"],
+        ["chat", "conversation", "in-chat"],
       ]),
       responseJudge: {
         minimumScore: 0.8,
         rubric:
-          'The answer must ground the first step in the bundled help: take/restart the interactive tutorial from chat by typing "start tutorial" or using the Tutorial launcher tile. It must not refer to a deleted Help view, spotlight-only tour, or a button below the response.',
+          'The answer must ground the first step in the bundled help: take/restart the interactive tutorial from chat by typing "start tutorial" or using an in-chat tutorial card/widget. It must not refer to a Tutorial launcher tile, deleted Help view, spotlight-only tour, separate Tutorial view, or a button below the response.',
       },
     },
     {
@@ -121,14 +124,14 @@ export default scenario({
       name: "user asks how to restart the tour",
       text: "Can I see the tutorial again later? How do I restart it?",
       assertResponse: assertHelpAnswer([
-        [/restart tutorial|start tutorial/i],
-        ["chat", "launcher"],
+        [/restart tutorial|start tutorial|tutorial card|tutorial widget/i],
+        ["chat", "conversation", "in-chat"],
         [/rerunnable|again|any time|later/i],
       ]),
       responseJudge: {
         minimumScore: 0.8,
         rubric:
-          'The answer must say the tutorial is rerunnable and can be started from chat with "restart tutorial" or "start tutorial", or from the Tutorial launcher tile. It must not call it one-time-only.',
+          'The answer must say the tutorial is rerunnable and can be started from chat with "restart tutorial" or "start tutorial", or from an in-chat tutorial card/widget. It must not mention a Tutorial launcher tile or a separate Tutorial view, and must not call it one-time-only.',
       },
     },
     {
@@ -152,7 +155,7 @@ export default scenario({
     {
       type: "modelCallOccurred",
       name: "trajectory includes getting-started help fragment",
-      includesAll: ["I just opened Eliza", "Take the interactive tutorial"],
+      includesAll: ["I just opened Eliza", 'type "start tutorial" in the chat'],
       minCount: 1,
     },
     {

--- a/packages/ui/src/tutorial/tutorial-service.ts
+++ b/packages/ui/src/tutorial/tutorial-service.ts
@@ -6,7 +6,7 @@
  * conversational turns into the live chat transcript.
  *
  * Module-level store shared via globalThis (Symbol.for) so a single instance
- * survives HMR and is reachable from non-React callers (the launcher tile,
+ * survives HMR and is reachable from non-React callers (the home tutorial card,
  * the action channel) + useSyncExternalStore for React consumers. The store
  * key is the historical "elizaos.ui.tutorial-controller" symbol so state
  * carried across an HMR boundary from an older bundle keeps working; reads
@@ -183,7 +183,7 @@ function begin(): void {
 
 /**
  * Start the tour. Idle starts fresh; completed/stopped restart from the top
- * (the launcher tile and "start tutorial" both mean "show me the tour", not
+ * (the home card and "start tutorial" both mean "show me the tour", not
  * "resume some prior run"); an already-active tour is a no-op so a double-tap
  * or duplicate command can't yank the user back to the welcome turn.
  */


### PR DESCRIPTION
## Summary

Part of #14360. Follow-up from the #14621/#14360 post-merge review: the live help-knowledge scenario still allowed stale Tutorial launcher tile / Tutorial view language even though the current product direction is chat-native tutorial guidance.

Changes:
- Updates bundled help FAQ fragments to describe starting/restarting the tutorial from chat or an in-chat tutorial card/widget, not a launcher tile.
- Bumps the affected help document versions so stale fragments are pruned/reseeded.
- Tightens `live-help-knowledge` assertions and judge rubrics to require chat-native tutorial guidance and forbid Tutorial launcher tile/view phrasing.
- Adds a bundled-help regression assertion so help knowledge cannot reintroduce tutorial tile/view/open-tutorial directions.
- Updates the scenario README entry, onboarding MVP research doc, and tutorial-service comments so future evidence requests and code comments point at chat-native/home-card entry points.

This does not close #14360 by itself. A live provider run still needs to attach the report plus reviewed trajectories/response evidence.

## Verification

- `bunx @biomejs/biome check packages/agent/src/runtime/default-help-documents.ts packages/agent/src/runtime/__tests__/default-documents.test.ts packages/scenario-runner/test/scenarios/live-help-knowledge.scenario.ts packages/scenario-runner/test/scenarios/README.md packages/docs/ongoing-development/research/04-onboarding-tutorial-help.md packages/ui/src/tutorial/tutorial-service.ts`
  - Passed: checked 4 files, no fixes applied. Markdown files are ignored by the local Biome config.
- `bun run --cwd packages/agent test -- src/runtime/__tests__/default-documents.test.ts`
  - Passed: 1 file, 10 tests.
  - Non-blocking existing warning: package export `types` condition appears after `default`.
- `bun run --cwd packages/scenario-runner test src/scenario-expansion.test.ts src/schema-strict.test.ts src/scenario-deferral.test.ts`
  - First attempt failed before code execution because the isolated worktree had no `node_modules/zod`; linked the worktree to the existing workspace install.
  - Second attempt failed before code execution because generated validation keyword data was absent; ran `bun run --cwd packages/shared build:i18n`.
  - Passed after those worktree setup steps: 3 files, 23 tests.
- `bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/cli.ts list test/scenarios --scenario live-help-knowledge` from `packages/scenario-runner`
  - Passed: listed `live-help-knowledge`.
  - Non-blocking Bun internal warning after output: `directory mismatch for directory .../tsconfig.json`.
- `bun run --cwd packages/docs test`
  - Passed: 15 tests.
- `git diff --check`
  - Passed.
- Live provider run:
  - Not run in this environment; no `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GROQ_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, `OPENROUTER_API_KEY`, `CEREBRAS_API_KEY`, or `ELIZAOS_CLOUD_API_KEY` is set. #14360 remains open for the live report and reviewed trajectory evidence.

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - scenario/help-copy/docs/comment hardening only; no rendered UI surface changed in this PR`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - scenario/help-copy/docs/comment hardening only; no rendered UI surface changed in this PR`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no interactive UI flow changed; the remaining live chat evidence is tracked on #14360 and still required before closing the issue`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no backend runtime path executed; targeted package tests and scenario loader checks above exercise the changed seeded-doc and scenario contracts`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend runtime behavior changed; tutorial-service edits are comments only`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - live provider credentials are unavailable in this environment; #14360 remains open and explicitly requires the live scenario report plus reviewed trajectories before completion`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no persisted app/domain artifact is produced by this hardening PR; verification artifact is the inline command transcript above showing the seeded-help regression and scenario loader/tests pass`.
