### PR TITLE
fix(ui): decramp market spatial audit views

### DIFF
--- a/plugins/plugin-hyperliquid/src/HyperliquidView.test.tsx
+++ b/plugins/plugin-hyperliquid/src/HyperliquidView.test.tsx
@@ -195,42 +195,28 @@ describe("HyperliquidView — populated snapshot", () => {
 		expect(screen.getByText("ETH")).toBeTruthy();
 		// Read-ready header + market leverage decoration.
 		expect(screen.getByText("read-ready")).toBeTruthy();
-		expect(screen.getByText("50x")).toBeTruthy();
+		expect(screen.getByText("BTC 50x")).toBeTruthy();
 		// ETH maxLeverage null -> "n/a", isolated suffix.
 		const text = document.body.textContent ?? "";
 		expect(text).toContain("2m / 1p / 1o");
 	});
 
-	it("renders the readiness tiles and the credential-mode label", async () => {
+	it("renders a compact readiness summary", async () => {
 		render(React.createElement(HyperliquidView));
 		await screen.findByText("ETH");
-		expect(screen.getByText("Reads")).toBeTruthy();
-		expect(screen.getByText("Read-only")).toBeTruthy(); // credentialMode "none"
-		expect(screen.getByText("Account")).toBeTruthy();
+		expect(screen.getByText("read-ready")).toBeTruthy();
+		expect(screen.getByText("2m / 1p / 1o")).toBeTruthy();
 	});
 
-	it("surfaces the executionBlockedReason without duplicate vault guidance", async () => {
+	it("keeps setup warnings out of the compact snapshot", async () => {
 		render(React.createElement(HyperliquidView));
 		await screen.findByText("ETH");
 		expect(
-			screen.getByText(/Signed Hyperliquid exchange mutations are disabled/),
-		).toBeTruthy();
+			screen.queryByText(/Signed Hyperliquid exchange mutations are disabled/),
+		).toBeNull();
 		expect(
 			screen.queryByText("Connect a managed vault to enable signed requests."),
 		).toBeNull();
-	});
-
-	it("shows vault guidance when no specific execution block is present", async () => {
-		hyperliquidClient.hyperliquidStatus.mockResolvedValue({
-			...sampleStatus,
-			executionBlockedReason: null,
-		});
-
-		render(React.createElement(HyperliquidView));
-		await screen.findByText("ETH");
-		expect(
-			screen.getByText("Connect a managed vault to enable signed requests."),
-		).toBeTruthy();
 	});
 
 	it("renders the agent's own position row with its unrealized PnL", async () => {
@@ -303,7 +289,7 @@ describe("HyperliquidView — controls", () => {
 		await screen.findByText("ETH");
 		expect(hyperliquidClient.hyperliquidStatus).toHaveBeenCalledTimes(1);
 
-		fireEvent.click(agent("refresh"));
+		fireEvent.click(agent("hyperliquid-refresh"));
 		await waitFor(() =>
 			expect(hyperliquidClient.hyperliquidStatus).toHaveBeenCalledTimes(2),
 		);
@@ -318,7 +304,7 @@ describe("HyperliquidView — controls", () => {
 		const listener = (e: Event) => events.push(e as CustomEvent);
 		window.addEventListener(NAVIGATE_VIEW_EVENT, listener);
 		try {
-			fireEvent.click(agent("back"));
+			fireEvent.click(agent("hyperliquid-home"));
 		} finally {
 			window.removeEventListener(NAVIGATE_VIEW_EVENT, listener);
 		}

--- a/plugins/plugin-hyperliquid/src/components/HyperliquidSpatialView.test.tsx
+++ b/plugins/plugin-hyperliquid/src/components/HyperliquidSpatialView.test.tsx
@@ -105,7 +105,9 @@ describe("HyperliquidSpatialView one source, three modalities", () => {
 		for (const html of [gui, xr]) {
 			expect(html).toContain("BTC");
 			expect(html).toContain("read-ready");
-			expect(html).toContain('data-agent-id="refresh"');
+			expect(html).toContain('data-agent-id="market-BTC"');
+			expect(html).not.toContain('data-agent-id="refresh"');
+			expect(html).not.toContain('data-agent-id="back"');
 		}
 	});
 
@@ -170,7 +172,7 @@ describe("HyperliquidSpatialView account-health + position detail", () => {
 		// Position detail: side, derived liquidation distance, notional.
 		expect(html).toContain("long");
 		expect(html).toContain("25% to liq");
-		expect(html).toContain("30,000");
+		expect(html).toContain("$30.0k");
 	});
 
 	it("does not crash when distanceToLiquidationPct is a missing DTO field (#8796)", () => {

--- a/plugins/plugin-hyperliquid/src/components/HyperliquidSpatialView.tsx
+++ b/plugins/plugin-hyperliquid/src/components/HyperliquidSpatialView.tsx
@@ -17,6 +17,7 @@ import {
 	Card,
 	Divider,
 	HStack,
+	isEvaluatingToIR,
 	List,
 	type SpatialTone,
 	Text,
@@ -59,38 +60,6 @@ export interface HyperliquidSnapshot {
 	error?: string | null;
 }
 
-function credentialModeLabel(mode: HyperliquidCredentialMode): string {
-	switch (mode) {
-		case "managed_vault":
-			return "Managed vault";
-		case "local_key":
-			return "Local key";
-		default:
-			return "Read-only";
-	}
-}
-
-function readinessTone(ready: boolean): SpatialTone {
-	return ready ? "success" : "muted";
-}
-
-function readinessMark(ready: boolean): string {
-	return ready ? "[ok]" : "[--]";
-}
-
-function StatusTile({ label, ready }: { label: string; ready: boolean }) {
-	return (
-		<HStack gap={1} align="center" grow={1}>
-			<Text tone={readinessTone(ready)} wrap={false}>
-				{readinessMark(ready)}
-			</Text>
-			<Text bold grow={1} wrap={false}>
-				{label}
-			</Text>
-		</HStack>
-	);
-}
-
 function shortAddress(address: string | null): string {
 	if (!address) return "not configured";
 	if (address.length <= 13) return address;
@@ -98,6 +67,9 @@ function shortAddress(address: string | null): string {
 }
 
 const EMPTY_CELL = "·";
+const MAX_MARKET_ROWS = 4;
+const MAX_POSITION_ROWS = 2;
+const MAX_ORDER_ROWS = 2;
 
 function toNumber(value: string | number | null | undefined): number | null {
 	if (value === null || value === undefined) return null;
@@ -135,16 +107,6 @@ function formatUsd(
 				})
 			: abs.toFixed(2);
 	return `${sign}$${body}`;
-}
-
-function formatPrice(value: number | null): string {
-	if (value === null) return EMPTY_CELL;
-	const abs = Math.abs(value);
-	const decimals = abs >= 1000 ? 1 : abs >= 1 ? 2 : 5;
-	return value.toLocaleString("en-US", {
-		maximumFractionDigits: decimals,
-		minimumFractionDigits: decimals,
-	});
 }
 
 function formatSize(value: string): string {
@@ -185,8 +147,8 @@ export function HyperliquidSpatialView({
 	compactChatClearance = false,
 }: HyperliquidSpatialViewProps) {
 	const dispatch = (action: string) => () => onAction?.(action);
+	const showInlineControls = isEvaluatingToIR();
 	const { status } = snapshot;
-	const accountReady = Boolean(status.accountAddress);
 	const openPositions = snapshot.positions.filter(isOpenPosition);
 
 	if (snapshot.unavailable) {
@@ -327,82 +289,29 @@ export function HyperliquidSpatialView({
 				</Text>
 			) : null}
 
-			<Text style="caption" tone="muted">
-				status
-			</Text>
-			<VStack gap={0}>
-				<StatusTile label="Reads" ready={status.publicReadReady} />
-				<StatusTile
-					label={credentialModeLabel(status.credentialMode)}
-					ready={status.signerReady}
-				/>
-				<StatusTile label="Account" ready={accountReady} />
-			</VStack>
-
-			{status.executionBlockedReason ? (
-				<Text style="caption" tone="warning">
-					{status.executionBlockedReason}
-				</Text>
-			) : null}
-
-			{!status.vaultReady &&
-			status.credentialMode !== "local_key" &&
-			!status.executionBlockedReason &&
-			status.vaultGuidance ? (
-				<Text style="caption" tone="muted">
-					{status.vaultGuidance}
-				</Text>
-			) : null}
-
-			<Text style="caption" tone="muted">
-				markets
-			</Text>
 			{snapshot.markets.length === 0 ? (
 				<Text tone="muted" align="center" style="caption">
 					None
 				</Text>
 			) : (
-				<List gap={0}>
-					{snapshot.markets.slice(0, 12).map((market) => (
-						<HStack
+				<HStack gap={2} wrap>
+					{snapshot.markets.slice(0, MAX_MARKET_ROWS).map((market) => (
+						<Text
 							key={market.name}
-							gap={1}
-							align="center"
+							bold
+							wrap={false}
+							tone={market.isDelisted ? "muted" : "default"}
 							agent={`market-${market.name}`}
 						>
-							<Text
-								bold
-								grow={1}
-								wrap={false}
-								tone={market.isDelisted ? "muted" : "default"}
-							>
-								{market.name}
-							</Text>
-							<Text style="caption" tone="primary" wrap={false}>
-								{market.maxLeverage ? `${market.maxLeverage}x` : "n/a"}
-							</Text>
-							<Text style="caption" tone="muted" wrap={false}>
-								sz{market.szDecimals}
-								{market.onlyIsolated ? " iso" : ""}
-							</Text>
-						</HStack>
+							{market.name} {market.maxLeverage ? `${market.maxLeverage}x` : ""}
+						</Text>
 					))}
-				</List>
+				</HStack>
 			)}
 
-			<Text style="caption" tone="muted">
-				account
-			</Text>
 			<HStack gap={1} align="center">
 				<Text style="caption" tone="muted" grow={1} wrap={false}>
 					{shortAddress(status.accountAddress)}
-				</Text>
-				<Text
-					style="caption"
-					tone={status.executionReady ? "success" : "muted"}
-					wrap={false}
-				>
-					{status.executionReady ? "exec-ready" : "exec-off"}
 				</Text>
 			</HStack>
 
@@ -435,9 +344,6 @@ export function HyperliquidSpatialView({
 				</HStack>
 			) : null}
 
-			<Text style="caption" tone="primary">
-				positions
-			</Text>
 			{snapshot.positionsBlockedReason ? (
 				<Text style="caption" tone="warning" agent="positions-blocked">
 					{snapshot.positionsBlockedReason}
@@ -448,11 +354,10 @@ export function HyperliquidSpatialView({
 				</Text>
 			) : (
 				<List gap={0}>
-					{openPositions.slice(0, 6).map((position) => {
+					{openPositions.slice(0, MAX_POSITION_ROWS).map((position) => {
 						const long = isLongPosition(position.size);
 						const uPnl = toNumber(position.unrealizedPnl);
 						const notional = toNumber(position.positionValue);
-						const entry = toNumber(position.entryPx);
 						const liq = position.distanceToLiquidationPct;
 						return (
 							<VStack
@@ -471,26 +376,17 @@ export function HyperliquidSpatialView({
 									>
 										{long ? "long" : "short"}
 									</Text>
-									{position.leverageValue !== null ? (
-										<Text style="caption" tone="muted" wrap={false}>
-											{position.leverageValue}x
-										</Text>
-									) : null}
+									<Text style="caption" tone="muted" grow={1} wrap={false}>
+										sz {formatSize(position.size)}
+										{notional === null ? "" : ` ${formatUsdCompact(notional)}`}
+									</Text>
 									<Text
 										style="caption"
 										tone={pnlTone(uPnl)}
-										grow={1}
 										align="end"
 										wrap={false}
 									>
 										{uPnl === null ? "" : formatUsd(uPnl, { withSign: true })}
-									</Text>
-								</HStack>
-								<HStack gap={1} align="center">
-									<Text style="caption" tone="muted" grow={1} wrap={false}>
-										sz {formatSize(position.size)}
-										{notional === null ? "" : ` · ${formatUsd(notional)}`}
-										{entry === null ? "" : ` · @${formatPrice(entry)}`}
 									</Text>
 									{liq === null || liq === undefined ? null : (
 										<Text style="caption" tone="warning" wrap={false}>
@@ -504,9 +400,6 @@ export function HyperliquidSpatialView({
 				</List>
 			)}
 
-			<Text style="caption" tone="primary">
-				orders
-			</Text>
 			{snapshot.ordersBlockedReason ? (
 				<Text style="caption" tone="warning" agent="orders-blocked">
 					{snapshot.ordersBlockedReason}
@@ -517,7 +410,7 @@ export function HyperliquidSpatialView({
 				</Text>
 			) : (
 				<List gap={0}>
-					{snapshot.orders.slice(0, 6).map((order) => (
+					{snapshot.orders.slice(0, MAX_ORDER_ROWS).map((order) => (
 						<HStack
 							key={order.oid}
 							gap={1}
@@ -551,19 +444,21 @@ export function HyperliquidSpatialView({
 				</List>
 			)}
 
-			<HStack gap={1} wrap>
-				<Button grow={1} agent="refresh" onPress={dispatch("refresh")}>
-					Refresh
-				</Button>
-				<Button
-					variant="outline"
-					tone="default"
-					agent="back"
-					onPress={dispatch("back")}
-				>
-					Back
-				</Button>
-			</HStack>
+			{showInlineControls ? (
+				<HStack gap={1} wrap>
+					<Button grow={1} agent="refresh" onPress={dispatch("refresh")}>
+						Refresh
+					</Button>
+					<Button
+						variant="outline"
+						tone="default"
+						agent="back"
+						onPress={dispatch("back")}
+					>
+						Back
+					</Button>
+				</HStack>
+			) : null}
 		</Card>
 	);
 }

--- a/plugins/plugin-polymarket/src/PolymarketView.test.tsx
+++ b/plugins/plugin-polymarket/src/PolymarketView.test.tsx
@@ -216,12 +216,12 @@ describe("PolymarketView — populated markets", () => {
     expect(polymarketClient.polymarketMarkets).toHaveBeenCalledWith({
       limit: 25,
     });
-    // Auto-selected markets[0] => detail pane: outcomes + CLOB token ids.
+    // Auto-selected markets[0] => detail pane: compact outcome choices.
     await waitFor(() => expect(agent("detail-back")).toBeTruthy());
     const text = document.body.textContent ?? "";
-    expect(text).toContain("outcomes");
-    expect(text).toContain("orderbook tokens");
-    expect(text).toContain("token-yes");
+    expect(text).toContain("Yes");
+    expect(text).toContain("No");
+    expect(text).not.toContain("token-yes");
   });
 
   it("the markets list shows readiness chips + a DOM-clickable row Open control", async () => {
@@ -249,7 +249,7 @@ describe("PolymarketView — populated markets", () => {
 });
 
 describe("PolymarketView — list -> detail navigation", () => {
-  it("clicking a market row Open opens its detail with outcomes + CLOB token ids", async () => {
+  it("clicking a market row Open opens its detail with compact outcome choices", async () => {
     render(React.createElement(PolymarketView));
     await screen.findByText("Will BTC be above 100k?");
     await backToList();
@@ -258,15 +258,13 @@ describe("PolymarketView — list -> detail navigation", () => {
 
     await waitFor(() => expect(agent("detail-back")).toBeTruthy());
     const text = document.body.textContent ?? "";
-    expect(text).toContain("outcomes");
     expect(text).toContain("Yes");
     expect(text).toContain("No");
-    expect(text).toContain("orderbook tokens");
-    expect(text).toContain("token-yes");
-    expect(text).toContain("token-no");
+    expect(text).not.toContain("token-yes");
+    expect(text).not.toContain("token-no");
   });
 
-  it("a market with no CLOB token ids shows the fallback copy in detail", async () => {
+  it("a market with no orderbook tokens still opens compact detail", async () => {
     mockState({
       markets: [sampleMarket, secondMarket],
       source: sampleMarkets.source,
@@ -279,7 +277,7 @@ describe("PolymarketView — list -> detail navigation", () => {
     await waitFor(() =>
       expect(screen.getByText("Will ETH be above 5k?")).toBeTruthy(),
     );
-    expect(screen.getByText("no CLOB token ids")).toBeTruthy();
+    expect(screen.getByText("Yes 25%")).toBeTruthy();
   });
 
   it("the detail 'back' control returns to the markets list", async () => {
@@ -313,7 +311,7 @@ describe("PolymarketView — refresh + error path", () => {
     await screen.findByText("Will BTC be above 100k?");
     expect(polymarketClient.polymarketMarkets).toHaveBeenCalledTimes(1);
 
-    fireEvent.click(agent("refresh"));
+    fireEvent.click(agent("polymarket-refresh"));
     await waitFor(() =>
       expect(polymarketClient.polymarketMarkets).toHaveBeenCalledTimes(2),
     );

--- a/plugins/plugin-polymarket/src/components/PolymarketSpatialView.test.tsx
+++ b/plugins/plugin-polymarket/src/components/PolymarketSpatialView.test.tsx
@@ -122,15 +122,14 @@ describe("PolymarketSpatialView one source, three modalities", () => {
     expect(wide).toContain("Refresh");
   });
 
-  it("TUI: detail honors the width contract at 54 + 32 and shows outcomes + CLOB ids", () => {
+  it("TUI: detail honors the width contract at 54 + 32 and shows choices", () => {
     for (const width of [54, 32]) {
       const lines = renderViewToLines(detailView, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
       // Short markers survive the narrow layout.
       expect(flat).toContain("Yes");
-      expect(flat).toContain("outcomes");
-      expect(flat).toContain("111"); // CLOB token id
+      expect(flat).toContain("No");
     }
     const wide = renderViewToLines(detailView, 54).join("\n");
     expect(wide).toContain("Will it rain tomorrow?");
@@ -149,8 +148,8 @@ describe("PolymarketSpatialView one source, three modalities", () => {
     for (const html of [gui, xr]) {
       expect(html).toContain("Will it rain tomorrow?");
       expect(html).toContain("reads ready");
-      expect(html).toContain('data-agent-id="refresh"');
       expect(html).toContain('data-agent-id="market-m1"');
+      expect(html).not.toContain('data-agent-id="refresh"');
     }
   });
 

--- a/plugins/plugin-polymarket/src/components/PolymarketSpatialView.tsx
+++ b/plugins/plugin-polymarket/src/components/PolymarketSpatialView.tsx
@@ -16,6 +16,7 @@ import {
   Button,
   Card,
   HStack,
+  isEvaluatingToIR,
   List,
   type SpatialTone,
   Text,
@@ -42,8 +43,9 @@ export interface PolymarketSnapshot {
   lastAction?: string;
 }
 
-const MAX_LIST = 24;
-const MAX_OUTCOMES = 3;
+const MAX_LIST = 10;
+const MAX_OUTCOMES = 2;
+const MAX_POSITION_ROWS = 3;
 
 function priceToPercent(price: string | null): number | null {
   if (price == null) return null;
@@ -102,32 +104,6 @@ function ReadinessRow({ status }: { status: PolymarketStatusResponse | null }) {
       </Text>
       <Text style="caption" tone={readyTone(trading)}>
         {`trading ${trading ? "ready" : "off"}`}
-      </Text>
-    </HStack>
-  );
-}
-
-function OutcomeLine({
-  name,
-  percent,
-  lead,
-}: {
-  name: string;
-  percent: number | null;
-  lead: boolean;
-}) {
-  return (
-    <HStack gap={1} align="center">
-      <Text tone={lead ? "primary" : "default"} grow={1} wrap={false}>
-        {name}
-      </Text>
-      <Text
-        style="caption"
-        tone={lead ? "primary" : "muted"}
-        align="end"
-        width={6}
-      >
-        {percent != null ? `${percent}%` : "n/a"}
       </Text>
     </HStack>
   );
@@ -226,9 +202,8 @@ function MarketDetail({
   onAction?: (action: string) => void;
   compact?: boolean;
 }) {
-  const lastTrade = priceToPercent(market.lastTradePrice);
-
   if (compact) {
+    const lastTrade = priceToPercent(market.lastTradePrice);
     const compactMetrics = [
       `Vol ${shortNumber(market.volume) ?? "-"}`,
       `Liq ${shortNumber(market.liquidity) ?? "-"}`,
@@ -252,6 +227,7 @@ function MarketDetail({
     );
   }
 
+  const top = market.outcomes.slice(0, MAX_OUTCOMES);
   return (
     <VStack gap={1}>
       <Button
@@ -265,58 +241,20 @@ function MarketDetail({
       <Text style="subheading" wrap>
         {market.question ?? market.slug ?? market.id}
       </Text>
-      {market.category ? (
-        <Text style="caption" tone="muted">
-          {market.category}
-        </Text>
-      ) : null}
-
-      <HStack gap={2} align="center">
-        <Text style="caption" tone="muted" wrap={false}>
-          {`Volume ${shortNumber(market.volume) ?? "-"}`}
-        </Text>
-        <Text style="caption" tone="muted" wrap={false}>
-          {`Liquidity ${shortNumber(market.liquidity) ?? "-"}`}
-        </Text>
-        <Text style="caption" tone="muted" wrap={false}>
-          {`Last ${lastTrade != null ? `${lastTrade}%` : "-"}`}
-        </Text>
-      </HStack>
-
-      <VStack gap={0}>
-        <Text style="caption" tone="muted">
-          outcomes
-        </Text>
-        <List gap={0}>
-          {market.outcomes.map((outcome, i) => (
-            <OutcomeLine
+      {top.length > 0 ? (
+        <HStack gap={2} align="center" wrap>
+          {top.map((outcome, i) => (
+            <Text
               key={outcome.name}
-              name={outcome.name}
-              percent={priceToPercent(outcome.price)}
-              lead={i === 0}
-            />
+              style="caption"
+              tone={i === 0 ? "primary" : "muted"}
+              wrap={false}
+            >
+              {outcomeSummary(outcome)}
+            </Text>
           ))}
-        </List>
-      </VStack>
-
-      <VStack gap={0}>
-        <Text style="caption" tone="muted">
-          orderbook tokens
-        </Text>
-        {market.clobTokenIds.length > 0 ? (
-          <List gap={0}>
-            {market.clobTokenIds.map((tokenId) => (
-              <Text key={tokenId} style="caption" tone="muted" wrap={false}>
-                {tokenId}
-              </Text>
-            ))}
-          </List>
-        ) : (
-          <Text style="caption" tone="muted">
-            no CLOB token ids
-          </Text>
-        )}
-      </VStack>
+        </HStack>
+      ) : null}
     </VStack>
   );
 }
@@ -377,7 +315,7 @@ function PositionsSection({
         </Text>
       ) : (
         <List gap={0}>
-          {open.map((position) => (
+          {open.slice(0, MAX_POSITION_ROWS).map((position) => (
             <PositionRow
               key={`${position.conditionId ?? position.marketId ?? position.slug}-${position.outcome}`}
               position={position}
@@ -403,28 +341,35 @@ export function PolymarketSpatialView({
   compactChatClearance = false,
 }: PolymarketSpatialViewProps) {
   const { status, markets, selectedMarket, loading, error } = snapshot;
+  const showInlineControls = isEvaluatingToIR();
   const positions = snapshot.positions ?? [];
   const accountReady = status?.account?.ready ?? false;
   const selectedId = selectedMarket?.id ?? null;
   return (
     <Card gap={1} padding={1}>
-      <HStack gap={1} align="center" wrap>
-        <ReadinessRow status={status} />
-        <Text style="caption" tone="muted" grow={1}>
-          {loading ? "loading" : `${markets.length} markets`}
-        </Text>
-        {compactChatClearance ? null : (
-          <Button
-            variant="outline"
-            tone="default"
-            agent="refresh"
-            disabled={loading}
-            onPress={() => onAction?.("refresh")}
-          >
-            Refresh
-          </Button>
-        )}
-      </HStack>
+      {/* The header earns its place only on the list surface; detail mode gives
+          the question the full card. Inline Refresh renders only when evaluating
+          to terminal IR — the GUI agent-surface reaches refresh through the
+          wrapper's hidden control, and the chat composer drives user refresh. */}
+      {!selectedMarket ? (
+        <HStack gap={1} align="center" wrap>
+          <ReadinessRow status={status} />
+          <Text style="caption" tone="muted" grow={1}>
+            {loading ? "loading" : `${markets.length} markets`}
+          </Text>
+          {showInlineControls ? (
+            <Button
+              variant="outline"
+              tone="default"
+              agent="refresh"
+              disabled={loading}
+              onPress={() => onAction?.("refresh")}
+            >
+              Refresh
+            </Button>
+          ) : null}
+        </HStack>
+      ) : null}
 
       {error ? (
         <Text tone="danger" style="caption">

--- a/plugins/plugin-polymarket/vitest.config.ts
+++ b/plugins/plugin-polymarket/vitest.config.ts
@@ -10,6 +10,9 @@ import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../..");
+const uiSrc = path.join(repoRoot, "packages/ui/src");
+const tuiSrc = path.join(repoRoot, "packages/tui/src");
 const require = createRequire(import.meta.url);
 
 export default defineConfig({
@@ -52,10 +55,19 @@ export default defineConfig({
       },
       {
         find: /^@elizaos\/ui\/agent-surface$/,
-        replacement: path.resolve(
-          here,
-          "../../packages/ui/src/agent-surface/index.ts",
-        ),
+        replacement: path.join(uiSrc, "agent-surface/index.ts"),
+      },
+      {
+        find: /^@elizaos\/ui\/spatial$/,
+        replacement: path.join(uiSrc, "spatial/index.ts"),
+      },
+      {
+        find: /^@elizaos\/ui\/spatial\/tui$/,
+        replacement: path.join(uiSrc, "spatial/tui/index.ts"),
+      },
+      {
+        find: /^@elizaos\/tui$/,
+        replacement: path.join(tuiSrc, "index.ts"),
       },
       {
         find: /^@elizaos\/ui\/spatial\/tui$/,


### PR DESCRIPTION
## Summary

Follow-up for #14343 / the sparse-home audit chain. This rebases the market-spatial cleanup on current `develop` after #14656 merged and removes the remaining conflict/stale-evidence state from the draft PR.

- Keeps Hyperliquid GUI/XR compact by hiding duplicate inline Refresh/Back controls; TUI/IR rendering still gets terminal-friendly Refresh/Back.
- Keeps Polymarket GUI detail compact: visible detail back affordance + question + Yes/No prices only; raw CLOB token/status/refresh chrome stays off the visual surface. Refresh remains available to the GUI agent-surface via the hidden control, and TUI keeps inline refresh.
- Adds source aliases for `@elizaos/ui/spatial`, `@elizaos/ui/spatial/tui`, and `@elizaos/tui` in both plugin Vitest configs so spatial tests run against source instead of stale dist artifacts.

## Verification

```bash
bun run --cwd plugins/plugin-hyperliquid test -- src/components/HyperliquidSpatialView.test.tsx src/HyperliquidView.test.tsx
# 2 files passed, 25 tests passed
```

```bash
bun run --cwd plugins/plugin-polymarket test -- src/components/PolymarketSpatialView.test.tsx src/PolymarketView.test.tsx
# 2 files passed, 18 tests passed
```

```bash
bunx @biomejs/biome check plugins/plugin-hyperliquid/src/components/HyperliquidSpatialView.tsx plugins/plugin-hyperliquid/src/components/HyperliquidSpatialView.test.tsx plugins/plugin-hyperliquid/vitest.config.ts plugins/plugin-polymarket/src/components/PolymarketSpatialView.tsx plugins/plugin-polymarket/src/components/PolymarketSpatialView.test.tsx plugins/plugin-polymarket/src/PolymarketView.test.tsx plugins/plugin-polymarket/vitest.config.ts
# Checked 7 files. No fixes applied.

git diff --check origin/develop...HEAD
# no whitespace errors
```

```bash
ELIZA_NODE_PATH=/Users/shawwalters/.nvm/versions/node/v24.15.0/bin/node bun run --cwd packages/app test:e2e -- --project=audit-app --grep "plugin-(hyperliquid|polymarket)-gui mobile-(portrait|landscape)" test/ui-smoke/all-views-aesthetic-audit.spec.ts
# 4 passed
# [aesthetic-audit] 4 findings — broken=0 needs-work=2 needs-eyeball=0 good=2
# minimalism-budget-failures=0 minimalism-ratchet-failures=0 hover-probe-failures=0 density-probe-failures=0
```

Manual screenshot review from the generated audit captures:
- `packages/app/aesthetic-audit-output/mobile-portrait/plugin-hyperliquid-gui.png`: compact wallet/perps data; no duplicate inline Refresh/Back controls; composer does not cover content.
- `packages/app/aesthetic-audit-output/mobile-landscape/plugin-hyperliquid-gui.png`: content column is readable; composer sits in unused right/lower space.
- `packages/app/aesthetic-audit-output/mobile-portrait/plugin-polymarket-gui.png`: only Markets back affordance, market question, and Yes/No prices; raw CLOB tokens/status/refresh chrome absent.
- `packages/app/aesthetic-audit-output/mobile-landscape/plugin-polymarket-gui.png`: question/outcomes remain clear; composer does not overlap the market detail.

OCR/color heuristic readout from the same four captures:
- Hyperliquid portrait OCR includes `read-ready`, `BTC 50x ETH 25x`, `val $12.5k`, `BTC long`, `ETH B`; palette white 92.1%, neutral 7.7%, orange 0.1%.
- Hyperliquid landscape OCR includes the same wallet/perps rows; palette white 93.0%, neutral 6.8%, orange 0.1%.
- Polymarket portrait OCR includes `Markets`, `Will the UI smoke suite stay green?`, `Yes 87%`, `No 13%`; palette white 93.3%, neutral 6.2%, orange 0.5%.
- Polymarket landscape OCR includes `Markets`, question text, `Yes 87%`, `No 13%`; palette white 94.2%, neutral 5.3%, orange 0.5%.

## Evidence Matrix

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - this PR is a follow-up refinement on already-merged sparse-home work; regression context and current evidence notes are in [the evidence gist](https://gist.github.com/lalalune/c05dfb99ee8e18a9b8c7ac726fef1665), while the current audit captures above are the relevant final-state proof.

<!-- evidence-row:after-screenshots -->
- After screenshots: Generated by the focused app audit and manually reviewed: [Hyperliquid portrait](packages/app/aesthetic-audit-output/mobile-portrait/plugin-hyperliquid-gui.png), [Hyperliquid landscape](packages/app/aesthetic-audit-output/mobile-landscape/plugin-hyperliquid-gui.png), [Polymarket portrait](packages/app/aesthetic-audit-output/mobile-portrait/plugin-polymarket-gui.png), [Polymarket landscape](packages/app/aesthetic-audit-output/mobile-landscape/plugin-polymarket-gui.png). OCR/color metrics are listed above.

<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - scoped component/audit cleanup of static wallet plugin views; no multi-step user flow changed beyond existing route-shell navigation and agent-surface hidden controls. A screenshot-sequence walkthrough was generated locally and summarized in [the evidence gist](https://gist.github.com/lalalune/c05dfb99ee8e18a9b8c7ac726fef1665). A screenshot-sequence walkthrough was generated locally and summarized in [the evidence gist](https://gist.github.com/lalalune/c05dfb99ee8e18a9b8c7ac726fef1665).

<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no backend route, service, DB, or connector behavior changed.

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A - focused Playwright app audit completed all four affected rendered states with no broken captures; this change only alters presentational spatial view rendering and component-level agent hooks.

<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - visual component/audit cleanup only; no model, prompt, action, provider, or trajectory behavior changed.

<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - no memories, DB rows, scheduled tasks, wallet transactions, or generated domain files are produced by this visual cleanup.


