### PR TITLE
fix(app-control): wire backup settings action

### DIFF
--- a/packages/scenario-runner/test/scenarios/_helpers/app-control-http-loopback.ts
+++ b/packages/scenario-runner/test/scenarios/_helpers/app-control-http-loopback.ts
@@ -83,8 +83,10 @@ function shouldHandle(url: URL | null): url is URL {
       url.pathname.startsWith("/api/plugins") ||
       // SETTINGS routes owned sections through their own backend endpoints
       // (e.g. permissions shell toggle → PUT /api/permissions/shell,
-      // auto-training toggle → POST /api/training/auto/config).
+      // auto-training toggle → POST /api/training/auto/config,
+      // local backups → POST /api/backups).
       url.pathname.startsWith("/api/permissions") ||
+      url.pathname.startsWith("/api/backups") ||
       url.pathname.startsWith("/api/training/auto/config"))
   );
 }

--- a/plugins/plugin-app-control/src/actions/settings.test.ts
+++ b/plugins/plugin-app-control/src/actions/settings.test.ts
@@ -101,6 +101,8 @@ describe("parseSettingsRequest", () => {
 			sectionId: "permissions",
 			key: "shell",
 			value: "off",
+			fileName: null,
+			confirm: null,
 		});
 	});
 
@@ -120,6 +122,24 @@ describe("parseSettingsRequest", () => {
 	it("returns null when neither verb nor section is present", () => {
 		expect(parseSettingsRequest({ value: "off" })).toBeNull();
 		expect(parseSettingsRequest(undefined)).toBeNull();
+	});
+
+	it("reads backup command parameters", () => {
+		expect(
+			parseSettingsRequest({
+				action: "set",
+				section: "advanced",
+				key: "restore-backup",
+				fileName: "agent-2026.agent-backup.json",
+				confirm: "true",
+			}),
+		).toMatchObject({
+			verb: "set",
+			sectionId: "advanced",
+			key: "restore-backup",
+			fileName: "agent-2026.agent-backup.json",
+			confirm: "true",
+		});
 	});
 });
 
@@ -158,6 +178,8 @@ describe("SETTINGS action: list", () => {
 		expect(permissions).toMatchObject({ writable: true, via: "SETTINGS" });
 		const capabilities = sections.find((s) => s.id === "capabilities");
 		expect(capabilities).toMatchObject({ writable: true, via: "SETTINGS" });
+		const advanced = sections.find((s) => s.id === "advanced");
+		expect(advanced).toMatchObject({ writable: true, via: "SETTINGS" });
 		const updates = sections.find((s) => s.id === "updates");
 		expect(updates).toMatchObject({ writable: false, via: "not-yet-wired" });
 	});
@@ -246,6 +268,86 @@ describe("SETTINGS action: set on an owned route section", () => {
 		);
 		expect(result?.success).toBe(false);
 		expect(texts.join(" ")).toContain("runtime restart refused");
+	});
+
+	it("creates a local agent backup through the backup route", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({
+			ok: true,
+			data: { backup: { fileName: "agent-2026.agent-backup.json" } },
+		}));
+		const { result, texts } = await invoke(
+			{ action: "set", section: "advanced", key: "create-backup" },
+			routeFetch,
+		);
+		expect(routeFetch).toHaveBeenCalledWith({
+			method: "POST",
+			path: "/api/backups",
+			body: {},
+		});
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({
+			section: "advanced",
+			key: "create-backup",
+		});
+		expect(texts.join(" ")).toContain("agent-2026.agent-backup.json");
+	});
+
+	it("restores a local agent backup only with fileName and confirmation", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({ ok: true }));
+		const { result, texts } = await invoke(
+			{
+				action: "set",
+				section: "advanced",
+				key: "restore-backup",
+				fileName: "agent-2026.agent-backup.json",
+				confirm: "true",
+			},
+			routeFetch,
+		);
+		expect(routeFetch).toHaveBeenCalledWith({
+			method: "POST",
+			path: "/api/backups/restore",
+			body: { fileName: "agent-2026.agent-backup.json" },
+		});
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({
+			section: "advanced",
+			key: "restore-backup",
+			fileName: "agent-2026.agent-backup.json",
+		});
+		expect(texts.join(" ")).toContain("Restart the agent");
+	});
+
+	it("refuses restore without explicit confirmation", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({ ok: true }));
+		const { result, texts } = await invoke(
+			{
+				action: "set",
+				section: "advanced",
+				key: "restore-backup",
+				fileName: "agent-2026.agent-backup.json",
+			},
+			routeFetch,
+		);
+		expect(routeFetch).not.toHaveBeenCalled();
+		expect(result?.success).toBe(false);
+		expect(texts.join(" ")).toContain("confirm=true");
+	});
+
+	it("refuses restore without a backup file name", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({ ok: true }));
+		const { result, texts } = await invoke(
+			{
+				action: "set",
+				section: "advanced",
+				key: "restore-backup",
+				confirm: "true",
+			},
+			routeFetch,
+		);
+		expect(routeFetch).not.toHaveBeenCalled();
+		expect(result?.success).toBe(false);
+		expect(texts.join(" ")).toContain("fileName");
 	});
 
 	it("rejects a non-boolean value without calling the route", async () => {

--- a/plugins/plugin-app-control/src/actions/settings.ts
+++ b/plugins/plugin-app-control/src/actions/settings.ts
@@ -41,6 +41,8 @@ export interface SettingsRouteOutcome {
 	ok: boolean;
 	/** Human-facing confirmation or failure detail. */
 	detail?: string;
+	/** Parsed JSON body for command-style settings routes. */
+	data?: unknown;
 }
 
 /**
@@ -62,16 +64,28 @@ export type SettingsRouteFetch = (request: {
  */
 export interface SettingsWritableKey {
 	description: string;
-	/** Accepted value shape. `boolean` accepts on/off/true/false/enable/disable. */
-	valueType: "boolean";
+	/**
+	 * Accepted value shape. `boolean` accepts on/off/true/false/enable/disable;
+	 * `command` executes an operation whose parameters are carried separately.
+	 */
+	valueType: "boolean" | "command";
 	/** Build the backend request for a parsed value. */
-	buildRequest: (value: boolean) => {
+	buildRequest?: (value: boolean) => {
 		method: "PUT" | "POST";
 		path: string;
 		body: unknown;
 	};
+	/** Execute a non-toggle operation through the section's backend route. */
+	apply?: (args: {
+		request: SettingsRequest;
+		routeFetch: SettingsRouteFetch;
+	}) => Promise<SettingsRouteOutcome>;
 	/** Confirmation text once the route returns ok. */
-	successText: (value: boolean) => string;
+	successText: (
+		value: boolean | null,
+		request: SettingsRequest,
+		outcome: SettingsRouteOutcome,
+	) => string;
 }
 
 /**
@@ -132,6 +146,56 @@ const AUTO_TRAINING_KEY: SettingsWritableKey = {
 		enabled
 			? "Auto-training is on. The training pipeline can start from trajectory thresholds."
 			: "Auto-training is off. Trajectory counters can still collect data, but automatic training will not start.",
+};
+
+function readBackupFileName(data: unknown): string | null {
+	if (!data || typeof data !== "object") return null;
+	const backup = (data as { backup?: unknown }).backup;
+	if (!backup || typeof backup !== "object") return null;
+	const fileName = (backup as { fileName?: unknown }).fileName;
+	return typeof fileName === "string" ? fileName : null;
+}
+
+const CREATE_BACKUP_KEY: SettingsWritableKey = {
+	description:
+		"Create an encrypted local backup of the current agent state through the same route as the Back Up Agent button.",
+	valueType: "command",
+	apply: ({ routeFetch }) =>
+		routeFetch({ method: "POST", path: "/api/backups", body: {} }),
+	successText: (_value, _request, outcome) => {
+		const fileName = readBackupFileName(outcome.data);
+		return fileName
+			? `Created local agent backup ${fileName}.`
+			: "Created a local agent backup.";
+	},
+};
+
+const RESTORE_BACKUP_KEY: SettingsWritableKey = {
+	description:
+		"Restore a named local agent backup. Requires fileName=<backup> and confirm=true because restore overwrites local state and requires restart.",
+	valueType: "command",
+	apply: ({ request, routeFetch }) => {
+		if (!request.fileName) {
+			return Promise.resolve({
+				ok: false,
+				detail: "provide fileName=<backup file name> to restore",
+			});
+		}
+		if (parseBooleanValue(request.confirm) !== true) {
+			return Promise.resolve({
+				ok: false,
+				detail:
+					"confirm=true is required before restoring a backup because it overwrites local state",
+			});
+		}
+		return routeFetch({
+			method: "POST",
+			path: "/api/backups/restore",
+			body: { fileName: request.fileName },
+		});
+	},
+	successText: (_value, request) =>
+		`Restored local agent backup ${request.fileName}. Restart the agent to activate it.`,
 };
 
 /**
@@ -223,9 +287,15 @@ export const SETTINGS_WRITE_REGISTRY: Readonly<
 			"Update check/apply is an asynchronous job surface, not a settings value.",
 	},
 	advanced: {
-		kind: "unwired",
-		reason:
-			"Backup and reset are destructive one-shot operations that require a dedicated confirmation flow.",
+		kind: "route",
+		summary:
+			"Local agent backup create/restore operations. Restore requires explicit confirmation.",
+		keys: {
+			"create-backup": CREATE_BACKUP_KEY,
+			backup: CREATE_BACKUP_KEY,
+			"restore-backup": RESTORE_BACKUP_KEY,
+			restore: RESTORE_BACKUP_KEY,
+		},
 	},
 	"app-permissions": {
 		kind: "unwired",
@@ -280,6 +350,8 @@ export interface SettingsRequest {
 	sectionId: string | null;
 	key: string | null;
 	value: string | null;
+	fileName: string | null;
+	confirm: string | null;
 }
 
 const VERB_TOKENS: ReadonlyMap<string, SettingsVerb> = new Map([
@@ -313,15 +385,24 @@ export function parseSettingsRequest(
 	const sectionId = resolveSectionId(sectionToken);
 	const key = readStringOption(options, "key");
 	const value = readStringOption(options, "value");
+	const fileName = readStringOption(options, "fileName");
+	const confirm = readStringOption(options, "confirm");
 
 	if (!verb) {
 		// A bare `section` with a `value` but no verb reads as an implicit `set`;
 		// a bare `section` alone reads as `get`. No section and no verb -> not a
 		// SETTINGS turn.
 		if (!sectionId) return null;
-		return { verb: value ? "set" : "get", sectionId, key, value };
+		return {
+			verb: value || key ? "set" : "get",
+			sectionId,
+			key,
+			value,
+			fileName,
+			confirm,
+		};
 	}
-	return { verb, sectionId, key, value };
+	return { verb, sectionId, key, value, fileName, confirm };
 }
 
 async function defaultRouteFetch(request: {
@@ -349,7 +430,7 @@ async function defaultRouteFetch(request: {
 				: `route ${request.path} returned ${response.status}`;
 		return { ok: false, detail };
 	}
-	return { ok: true };
+	return { ok: true, data: parsed };
 }
 
 export interface SettingsActionDeps {
@@ -442,8 +523,9 @@ async function handleSet(
 		return { success: false, text: reply };
 	}
 
-	const parsedValue = parseBooleanValue(request.value);
-	if (parsedValue === null) {
+	const parsedValue =
+		writable.valueType === "boolean" ? parseBooleanValue(request.value) : null;
+	if (writable.valueType === "boolean" && parsedValue === null) {
 		const reply = `Tell me on or off for ${request.sectionId} ${keyName}.`;
 		await callback?.({ text: reply });
 		return { success: false, text: reply };
@@ -452,20 +534,36 @@ async function handleSet(
 	logger.info(
 		`[SettingsAction] set section=${request.sectionId} key=${keyName} value=${parsedValue}`,
 	);
-	const req = writable.buildRequest(parsedValue);
-	const outcome = await routeFetch(req);
+	const outcome = writable.apply
+		? await writable.apply({ request, routeFetch })
+		: writable.buildRequest && parsedValue !== null
+			? await routeFetch(writable.buildRequest(parsedValue))
+			: {
+					ok: false,
+					detail: `no route handler is registered for ${request.sectionId} ${keyName}`,
+				};
 	if (!outcome.ok) {
 		const reply = `I couldn't change ${request.sectionId} ${keyName}: ${outcome.detail ?? "the settings route failed"}.`;
 		await callback?.({ text: reply });
 		return { success: false, text: reply };
 	}
-	const reply = writable.successText(parsedValue);
+	const reply = writable.successText(parsedValue, request, outcome);
 	await callback?.({ text: reply });
 	return {
 		success: true,
 		text: reply,
-		values: { section: request.sectionId, key: keyName, value: parsedValue },
-		data: { section: request.sectionId, key: keyName, value: parsedValue },
+		values: {
+			section: request.sectionId,
+			key: keyName,
+			...(parsedValue === null ? {} : { value: parsedValue }),
+			...(request.fileName ? { fileName: request.fileName } : {}),
+		},
+		data: {
+			section: request.sectionId,
+			key: keyName,
+			...(parsedValue === null ? {} : { value: parsedValue }),
+			...(request.fileName ? { fileName: request.fileName } : {}),
+		},
 	};
 }
 
@@ -543,13 +641,16 @@ export function createSettingsAction(deps: SettingsActionDeps = {}): Action {
 			"TOGGLE_AUTO_TRAINING",
 			"ENABLE_AUTO_TRAINING",
 			"DISABLE_AUTO_TRAINING",
+			"BACKUP_AGENT",
+			"CREATE_AGENT_BACKUP",
+			"RESTORE_AGENT_BACKUP",
 		],
 		description:
-			"Change a built-in settings VALUE from chat — most importantly turning OS/runtime permissions like shell access on/off via section=permissions key=shell, and turning automatic training on/off via section=capabilities key=auto-training. Also reads (`action=get`) or lists (`action=list`) which settings are changeable. `action=set` writes an owned section (permissions shell access, capabilities auto-training) or points to the dedicated action that owns a delegated section (models→MODEL_SWITCH, background→BACKGROUND, identity→CHARACTER, connectors→CONNECTOR, secrets→CREDENTIALS). This CHANGES a setting's value; opening a settings page without changing anything is VIEWS. Never fill a settings field with agent-fill.",
+			"Change a built-in settings VALUE or run a built-in settings operation from chat — most importantly turning OS/runtime permissions like shell access on/off via section=permissions key=shell, turning automatic training on/off via section=capabilities key=auto-training, and creating/restoring local agent backups via section=advanced key=create-backup|restore-backup. Restore requires fileName and confirm=true. Also reads (`action=get`) or lists (`action=list`) which settings are changeable. `action=set` writes an owned section or points to the dedicated action that owns a delegated section (models→MODEL_SWITCH, background→BACKGROUND, identity→CHARACTER, connectors→CONNECTOR, secrets→CREDENTIALS). This CHANGES a setting's value or runs an explicit settings operation; opening a settings page without changing anything is VIEWS. Never fill a settings field with agent-fill.",
 		descriptionCompressed:
-			"settings get|set|list section/key/value — CHANGE a setting VALUE from chat, incl. shell access (section=permissions key=shell) and auto-training (section=capabilities key=auto-training); delegates model/background/identity/connectors/secrets",
+			"settings get|set|list section/key/value — CHANGE a setting VALUE or run a settings operation, incl. shell access, auto-training, and local backups (section=advanced key=create-backup|restore-backup)",
 		routingHint:
-			"Semantic settings reads/writes that do NOT already have a dedicated action -> SETTINGS. Changing a PERMISSION or setting VALUE is SETTINGS action=set, NOT navigation: 'turn off shell permissions', 'disable shell access', 'turn off shell access', 'revoke shell access', 'stop the agent running shell commands', 'turn shell back on', 'change my permissions' -> SETTINGS section=permissions key=shell value=off|on. 'turn on auto-training', 'enable automatic training', 'disable auto training' -> SETTINGS section=capabilities key=auto-training value=on|off. Also 'what settings can you change' / 'list settings' -> SETTINGS action=list. Do NOT use SETTINGS for changes a dedicated action owns: switching the model is MODEL_SWITCH, the background/theme is BACKGROUND, the agent identity is CHARACTER, connectors are CONNECTOR, secret/API keys are CREDENTIALS. The distinction from VIEWS is value-vs-navigation: changing/toggling a permission or setting VALUE is SETTINGS even though that permission lives on a settings page; merely OPENING or navigating to a settings page with no value change is VIEWS. SETTINGS never fills a form field with agent-fill.",
+			"Semantic settings reads/writes that do NOT already have a dedicated action -> SETTINGS. Changing a PERMISSION or setting VALUE is SETTINGS action=set, NOT navigation: 'turn off shell permissions', 'disable shell access', 'turn off shell access', 'revoke shell access', 'stop the agent running shell commands', 'turn shell back on', 'change my permissions' -> SETTINGS section=permissions key=shell value=off|on. 'turn on auto-training', 'enable automatic training', 'disable auto training' -> SETTINGS section=capabilities key=auto-training value=on|off. 'back up my agent', 'create a local backup' -> SETTINGS section=advanced key=create-backup. 'restore backup <file>' -> SETTINGS section=advanced key=restore-backup fileName=<file> confirm=true; if confirm is absent, ask for confirmation. Also 'what settings can you change' / 'list settings' -> SETTINGS action=list. Do NOT use SETTINGS for changes a dedicated action owns: switching the model is MODEL_SWITCH, the background/theme is BACKGROUND, the agent identity is CHARACTER, connectors are CONNECTOR, secret/API keys are CREDENTIALS. The distinction from VIEWS is value-vs-navigation: changing/toggling a permission or setting VALUE, or running a backup operation, is SETTINGS even though it lives on a settings page; merely OPENING or navigating to a settings page with no value change is VIEWS. SETTINGS never fills a form field with agent-fill.",
 		suppressPostActionContinuation: true,
 
 		parameters: [
@@ -569,7 +670,21 @@ export function createSettingsAction(deps: SettingsActionDeps = {}): Action {
 			{
 				name: "key",
 				description:
-					"The specific toggle within the section (e.g. shell for permissions, auto-training for capabilities). Optional; defaults to the section's primary key.",
+					"The specific toggle or operation within the section (e.g. shell, auto-training, create-backup, restore-backup). Optional; defaults to the section's primary key.",
+				required: false,
+				schema: { type: "string" },
+			},
+			{
+				name: "fileName",
+				description:
+					"Backup file name when section=advanced key=restore-backup.",
+				required: false,
+				schema: { type: "string" },
+			},
+			{
+				name: "confirm",
+				description:
+					"Explicit confirmation for destructive operations. Restore requires true.",
 				required: false,
 				schema: { type: "string" },
 			},

--- a/plugins/plugin-app-control/test/scenarios/settings-backup-create.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/settings-backup-create.scenario.ts
@@ -1,0 +1,101 @@
+/**
+ * Live-model SETTINGS scenario (#14620): a natural backup request must select
+ * the semantic SETTINGS action and drive the same local-backup route the
+ * Advanced settings button uses.
+ */
+
+import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+	jsonResponse,
+	readAppControlHttpRequests,
+	registerAppControlHttpHandler,
+	resetAppControlHttpLoopback,
+} from "../../../../packages/scenario-runner/test/scenarios/_helpers/app-control-http-loopback";
+
+function backupWrites() {
+	return readAppControlHttpRequests(
+		(request) =>
+			request.method === "POST" && request.pathname === "/api/backups",
+	).map((request) => request.body ?? null);
+}
+
+export default scenario({
+	lane: "live-only",
+	id: "settings-backup-create",
+	title: "SETTINGS action creates a local agent backup",
+	domain: "app-control",
+	tags: ["app-control", "settings", "advanced", "backup"],
+	isolation: "per-scenario",
+	requires: {
+		plugins: ["@elizaos/plugin-app-control"],
+	},
+	seed: [
+		{
+			type: "custom",
+			name: "register local backup loopback API",
+			apply: () => {
+				resetAppControlHttpLoopback();
+				registerAppControlHttpHandler((request) => {
+					if (request.method === "POST" && request.pathname === "/api/backups") {
+						return jsonResponse({
+							backup: {
+								fileName: "agent-2026.agent-backup.json",
+								createdAt: "2026-01-01T00:00:00.000Z",
+								sizeBytes: 1024,
+								stateSha256:
+									"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+							},
+						});
+					}
+					return undefined;
+				});
+				return undefined;
+			},
+		},
+	],
+	rooms: [
+		{
+			id: "main",
+			source: "chat",
+			title: "Settings Backup Create",
+		},
+	],
+	turns: [
+		{
+			kind: "message",
+			name: "user-asks-backup-agent",
+			text: "back up my agent",
+		},
+	],
+	finalChecks: [
+		{
+			type: "selectedAction",
+			actionName: "SETTINGS",
+		},
+		{
+			type: "actionCalled",
+			actionName: "SETTINGS",
+			status: "success",
+			minCount: 1,
+		},
+		{
+			type: "custom",
+			name: "SETTINGS drove POST /api/backups",
+			predicate: () => {
+				const expected = [{}];
+				const actual = backupWrites();
+				return JSON.stringify(actual) === JSON.stringify(expected)
+					? undefined
+					: `expected exactly one backup write ${JSON.stringify(expected)}, saw ${JSON.stringify(actual)}`;
+			},
+		},
+		{
+			type: "custom",
+			name: "cleanup backup loopback",
+			predicate: () => {
+				resetAppControlHttpLoopback();
+				return undefined;
+			},
+		},
+	],
+});


### PR DESCRIPTION
## Summary
- Wires the Advanced backups section into the semantic `SETTINGS` action.
- Adds `SETTINGS section=advanced key=create-backup` to call `POST /api/backups` and report the returned backup file name when present.
- Adds `SETTINGS section=advanced key=restore-backup fileName=<backup> confirm=true` to call `POST /api/backups/restore`, with explicit file-name and confirmation validation before any route write.
- Extends the app-control HTTP loopback and adds a live-only scenario that proves the backup route effect is observable by the scenario runner.

Fixes #14620.

## Verification
- `bun run --cwd plugins/plugin-app-control test -- src/actions/settings.test.ts` — 40 tests passed.
- `bun run --cwd plugins/plugin-app-control typecheck` — passed.
- `bun src/cli.ts list ../../plugins/plugin-app-control/test/scenarios --scenario settings-backup-create` — listed `settings-backup-create`.
- `bun run --cwd packages/scenario-runner test src/action-effect-ratchet.test.ts src/skippable-check-ratchet.test.ts src/echo-assertion-ratchet.test.ts` — 3 files / 5 tests passed.
- `git diff --check origin/develop...HEAD` — passed.
- `bun run audit:error-policy-ratchet --report` — no new fallback-slop in touched files.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - semantic action/server-route wiring only; no rendered UI surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - semantic action/server-route wiring only; no rendered UI surface changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no interactive UI flow changed in this PR; the same backup use case is covered through action route tests`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no long-running backend service path was started; route-effect command output is listed in Verification`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend request/response or state change changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - live provider credentials are unavailable in this environment; the PR adds the live-only settings-backup-create scenario for keyed CI/manual evidence`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - deterministic route tests verify the backup mutation; no persisted external artifact is produced by local verification`.

## Evidence Notes
- Live trajectory: N/A locally because no live model provider keys are set in this environment (`OPENAI_API_KEY`, `GROQ_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, `OPENROUTER_API_KEY`, `CEREBRAS_API_KEY` are unset).
- App visual audit: N/A — this changes semantic action/server-route coverage and test harness only; no renderer/UI files in `packages/app` were changed.
