### PR TITLE
fix(evidence): require certified evidence paths in bundle

### DIFF
--- a/.github/certification/README.md
+++ b/.github/certification/README.md
@@ -42,11 +42,11 @@ cannot be enabled. There is deliberately no default trust anchor in code:
 ```bash
 bun run --cwd packages/evidence certify:verify -- \
   --cert <path/to/certification.json> \
+  --bundle <bundle-dir> \
   --pubkey <base-branch-checkout>/.github/certification/certification-public-key.pem \
   --expected-commit <pr-head-sha> \
   --max-age-hours 72 \
   --required-tier full \
-  [--bundle <bundle-dir>] \
   [--requirements <requirements.json>] \
   --json
 ```
@@ -56,9 +56,15 @@ Exit 0 iff valid. `--json` prints the full report on stdout, including
 (`schema-invalid | unsigned | bad-signature | wrong-key | stale |
 commit-mismatch | bundle-tampered | verdict-failures | verdict-incomplete |
 tier-insufficient`); all detectable failures are reported together, not
-first-failure-only. The promotion gate must pass `--bundle` so the verifier
-can re-run the mechanical rollup and prove the signed verdicts cover every
-machine-derived subject. A mechanically non-pass subject may be signed as
+first-failure-only.
+
+For the required develop→main gate, `--bundle` is mandatory. Without the
+bundle, verification can only prove that the JSON was signed by the trusted
+key; it cannot prove the signed `bundleSha` matches real artifacts, that every
+mechanically-derived lane/analysis subject was reviewed, or that verdict
+evidence paths actually exist. Omitting `--bundle` is only for detached
+signature inspection, never for promotion. With a bundle, verification also
+re-runs the mechanical rollup: mechanically non-pass subjects may be signed as
 `fail` or `waived` with notes, but never omitted or signed as `pass`.
 
 ## Key rotation

--- a/packages/evidence/AGENTS.md
+++ b/packages/evidence/AGENTS.md
@@ -61,16 +61,20 @@ promotion claim. Full flow:
    `canonicalJsonBytes(payload-without-signature)`, writes
    `<bundle>/certification.json` (an envelope file, exempt from the
    unlisted-file sweep).
-5. **verify** — `certify:verify -- --cert <file> --pubkey <pem>
-   [--bundle <dir>] [--requirements <file>] [--expected-commit <sha>]
+5. **verify** — `certify:verify -- --cert <file> --bundle <dir>
+   --pubkey <pem> [--requirements <file>] [--expected-commit <sha>]
    [--max-age-hours N] [--required-tier T] [--json]` — the exact code the
-   #14547 gate runs, fully offline. With `--bundle`, verification re-runs the
-   mechanical rollup and fails if signed verdicts omit a rollup subject or mark
-   a mechanically non-pass subject as `pass` (waive with notes instead). Exit 0
-   iff valid; every failure is a distinct typed code (`schema-invalid |
-   unsigned | bad-signature | wrong-key | stale | commit-mismatch |
-   bundle-tampered | verdict-failures | verdict-incomplete |
-   tier-insufficient`) and ALL detectable failures are reported together.
+   #14547 gate runs, fully offline. `--bundle` is mandatory for the
+   develop→main gate: without it the tool can inspect the detached signature,
+   but cannot prove the signed bundle hash matches real artifacts, that every
+   mechanically rolled-up lane/analysis subject was reviewed, or that verdict
+   evidence paths exist. With a bundle, verification also rejects omitted
+   rollup subjects and mechanically non-pass subjects signed as `pass`
+   (waive with notes instead). Exit 0 iff valid; every failure is a distinct
+   typed code (`schema-invalid | unsigned | bad-signature | wrong-key | stale
+   | commit-mismatch | bundle-tampered | verdict-failures |
+   verdict-incomplete | tier-insufficient`) and ALL detectable failures are
+   reported together.
 
 **Threat model.** A valid signature proves a holder of the private key
 signed exactly these verdicts over exactly this bundle manifest for exactly
@@ -100,7 +104,7 @@ bun run --cwd packages/evidence bundle:verify -- evidence/runs/<run-id>
 bun run --cwd packages/evidence certify:keygen -- [--print-private-key]
 bun run --cwd packages/evidence certify:rollup -- --bundle <dir> [--requirements <file>] [--out <file>]
 bun run --cwd packages/evidence certify:sign -- --bundle <dir> --verdicts <file> --reviewer-id <id> --reviewer-kind <agent|human>
-bun run --cwd packages/evidence certify:verify -- --cert <file> --pubkey <pem> [--bundle <dir>] [--requirements <file>] [--json]
+bun run --cwd packages/evidence certify:verify -- --cert <file> --bundle <dir> --pubkey <pem> [--requirements <file>] [--json]
 ```
 
 Test-lane membership is declared via `elizaos.scripts.testLanes: ["server"]`

--- a/packages/evidence/CLAUDE.md
+++ b/packages/evidence/CLAUDE.md
@@ -61,16 +61,20 @@ promotion claim. Full flow:
    `canonicalJsonBytes(payload-without-signature)`, writes
    `<bundle>/certification.json` (an envelope file, exempt from the
    unlisted-file sweep).
-5. **verify** — `certify:verify -- --cert <file> --pubkey <pem>
-   [--bundle <dir>] [--requirements <file>] [--expected-commit <sha>]
+5. **verify** — `certify:verify -- --cert <file> --bundle <dir>
+   --pubkey <pem> [--requirements <file>] [--expected-commit <sha>]
    [--max-age-hours N] [--required-tier T] [--json]` — the exact code the
-   #14547 gate runs, fully offline. With `--bundle`, verification re-runs the
-   mechanical rollup and fails if signed verdicts omit a rollup subject or mark
-   a mechanically non-pass subject as `pass` (waive with notes instead). Exit 0
-   iff valid; every failure is a distinct typed code (`schema-invalid |
-   unsigned | bad-signature | wrong-key | stale | commit-mismatch |
-   bundle-tampered | verdict-failures | verdict-incomplete |
-   tier-insufficient`) and ALL detectable failures are reported together.
+   #14547 gate runs, fully offline. `--bundle` is mandatory for the
+   develop→main gate: without it the tool can inspect the detached signature,
+   but cannot prove the signed bundle hash matches real artifacts, that every
+   mechanically rolled-up lane/analysis subject was reviewed, or that verdict
+   evidence paths exist. With a bundle, verification also rejects omitted
+   rollup subjects and mechanically non-pass subjects signed as `pass`
+   (waive with notes instead). Exit 0 iff valid; every failure is a distinct
+   typed code (`schema-invalid | unsigned | bad-signature | wrong-key | stale
+   | commit-mismatch | bundle-tampered | verdict-failures |
+   verdict-incomplete | tier-insufficient`) and ALL detectable failures are
+   reported together.
 
 **Threat model.** A valid signature proves a holder of the private key
 signed exactly these verdicts over exactly this bundle manifest for exactly
@@ -100,7 +104,7 @@ bun run --cwd packages/evidence bundle:verify -- evidence/runs/<run-id>
 bun run --cwd packages/evidence certify:keygen -- [--print-private-key]
 bun run --cwd packages/evidence certify:rollup -- --bundle <dir> [--requirements <file>] [--out <file>]
 bun run --cwd packages/evidence certify:sign -- --bundle <dir> --verdicts <file> --reviewer-id <id> --reviewer-kind <agent|human>
-bun run --cwd packages/evidence certify:verify -- --cert <file> --pubkey <pem> [--bundle <dir>] [--requirements <file>] [--json]
+bun run --cwd packages/evidence certify:verify -- --cert <file> --bundle <dir> --pubkey <pem> [--requirements <file>] [--json]
 ```
 
 Test-lane membership is declared via `elizaos.scripts.testLanes: ["server"]`

--- a/packages/evidence/src/certify/sign.test.ts
+++ b/packages/evidence/src/certify/sign.test.ts
@@ -466,6 +466,35 @@ describe("verifyCertification — tamper matrix", () => {
     expect(report.rollup?.verdicts[0].verdict).toBe("fail");
   });
 
+  it("verdict-incomplete: signed evidence paths must exist in the bundle manifest", async () => {
+    const fixture = await fixtureBundle();
+    const keypair = generateCertificationKeypair();
+    const certification = signCertification(
+      payloadFor(fixture, {
+        verdicts: [
+          {
+            subject: "lane:server",
+            verdict: "pass",
+            evidence: ["lanes/server/result.json", "lanes/server/missing.log"],
+          },
+        ],
+      }),
+      keypair.privateKeyPem,
+    );
+    const report = await verifyCertification(writeCert(certification), {
+      publicKeyPem: keypair.publicKeyPem,
+      bundleDir: fixture.bundleDir,
+      now: NOW,
+    });
+    expect(codes(report)).toEqual(["verdict-incomplete"]);
+    expect(report.failures[0].message).toContain("evidence path");
+    expect(report.failures[0].context).toMatchObject({
+      missingEvidence: [
+        { subject: "lane:server", path: "lanes/server/missing.log" },
+      ],
+    });
+  });
+
   it("schema-invalid: waived-without-notes signed by hand cannot verify clean", async () => {
     const fixture = await fixtureBundle();
     const keypair = generateCertificationKeypair();

--- a/packages/evidence/src/certify/sign.ts
+++ b/packages/evidence/src/certify/sign.ts
@@ -24,7 +24,7 @@ import path from "node:path";
 import { type VerifyReport, verifyBundle } from "../bundle.ts";
 import { canonicalJsonBytes } from "../canonical.ts";
 import { EvidenceError, EvidenceValidationError } from "../errors.ts";
-import type { Tier } from "../schema.ts";
+import { parseManifest, type Tier } from "../schema.ts";
 import {
   derivePublicKeyPem,
   fingerprintPublicKey,
@@ -182,6 +182,34 @@ function verdictCompletenessFailure(
   };
 }
 
+function missingEvidencePathsFailure(
+  payload: CertificationPayload,
+  artifactPaths: Set<string>,
+): CertificationFailure | undefined {
+  const missingEvidence: Array<{ subject: string; path: string }> = [];
+
+  for (const verdict of payload.verdicts) {
+    for (const evidencePath of verdict.evidence) {
+      if (!artifactPaths.has(evidencePath)) {
+        missingEvidence.push({
+          subject: verdict.subject,
+          path: evidencePath,
+        });
+      }
+    }
+  }
+
+  if (missingEvidence.length === 0) {
+    return undefined;
+  }
+
+  return {
+    code: "verdict-incomplete",
+    message: `${missingEvidence.length} verdict evidence path(s) are not in the bundle manifest`,
+    context: { missingEvidence },
+  };
+}
+
 /**
  * Verify a certification file offline. Collects every determinable failure;
  * only an unreadable/unparseable certification file short-circuits (there is
@@ -205,6 +233,7 @@ export async function verifyCertification(
     certPath,
     failures,
   };
+  let manifestArtifactPaths: Set<string> | undefined;
 
   let rawText: string;
   try {
@@ -341,6 +370,24 @@ export async function verifyCertification(
           });
         }
         try {
+          const manifest = parseManifest(
+            JSON.parse(manifestBytes.toString("utf8")),
+            manifestPath,
+          );
+          manifestArtifactPaths = new Set(
+            manifest.artifacts.map((artifact) => artifact.path),
+          );
+        } catch (error) {
+          failures.push({
+            code: "bundle-tampered",
+            message: `bundle manifest cannot be parsed for verdict completeness: ${(error as Error).message}`,
+            context:
+              error instanceof EvidenceValidationError
+                ? validationIssues(error)
+                : {},
+          });
+        }
+        try {
           const bundleReport = await verifyBundle(options.bundleDir);
           report.bundle = bundleReport;
           if (!bundleReport.ok) {
@@ -352,6 +399,15 @@ export async function verifyCertification(
               context: { issues: bundleReport.issues },
             });
           } else {
+            if (manifestArtifactPaths !== undefined) {
+              const evidenceFailure = missingEvidencePathsFailure(
+                payload,
+                manifestArtifactPaths,
+              );
+              if (evidenceFailure !== undefined) {
+                failures.push(evidenceFailure);
+              }
+            }
             const rollup = rollupBundle(options.bundleDir, {
               requirements: options.requirements,
             });


### PR DESCRIPTION
## Summary
- require every signed certification verdict evidence path to exist in the bundle manifest
- keep rollup completeness checks from #14610 while closing the detached-evidence gap
- document that develop-to-main verification must pass `--bundle` for promotion, while preserving the pending trust-anchor PEM note

Follow-up to merged #14610 / issue #14546: signature verification already proved bundle hash and mechanical subject coverage, but a signed verdict could still cite an evidence path that was not in the manifest. This makes the offline gate prove the cited evidence actually belongs to the certified bundle.

## Verification
- `bun run --cwd packages/evidence test -- src/certify/sign.test.ts src/certify/cli.test.ts` -> 2 files, 29 tests passed
- `bun run --cwd packages/evidence typecheck` -> passed
- `bunx @biomejs/biome check packages/evidence/src/certify/sign.ts packages/evidence/src/certify/sign.test.ts packages/evidence/AGENTS.md packages/evidence/CLAUDE.md .github/certification/README.md --no-errors-on-unmatched` -> passed

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] N/A - no UI surface changed; certification verifier/library docs only.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user workflow or rendered app path changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend service runtime path changed; this is deterministic certification verification logic.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no separate domain artifact file; the domain proof is the new `verdict-incomplete` tamper test for missing signed evidence paths plus targeted certification tests listed in Verification.
