### PR TITLE
test(#14325): settings-in-chat SETTINGS ops (real config store) + live [CONFIG]/provider-switch scenarios

### DIFF
--- a/packages/agent/src/actions/settings-chat-config-ops.test.ts
+++ b/packages/agent/src/actions/settings-chat-config-ops.test.ts
@@ -88,9 +88,9 @@ describe("SETTINGS action — always available at the chat boundary", () => {
     // structurally by core (satisfiesRoleGate) before the handler runs, so the
     // action stays selectable and the gate can't be bypassed by a passing
     // validate.
-    await expect(
-      settingsAction.validate(RUNTIME, OWNER_MESSAGE),
-    ).resolves.toBe(true);
+    await expect(settingsAction.validate(RUNTIME, OWNER_MESSAGE)).resolves.toBe(
+      true,
+    );
   });
 });
 

--- a/packages/agent/src/actions/settings-chat-config-ops.test.ts
+++ b/packages/agent/src/actions/settings-chat-config-ops.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Chat-settings leg of #14325: the owner-gated SETTINGS action must, when the
+ * chat surface asks to configure a plugin ("configure telegram") or switch the
+ * model provider ("switch my model provider to openai"), mutate the REAL on-disk
+ * eliza.json config store — not a mock. This drives `settingsAction.handler`
+ * against a temp config file (via ELIZA_CONFIG_PATH / ELIZA_PERSIST_CONFIG_PATH,
+ * the same load/write path the running agent uses) and asserts the persisted
+ * bytes, so a regression that silently stops persisting provider/capability
+ * changes fails here. The `[CONFIG:pluginId]` card's fetch/edit/save/enable
+ * round-trip is covered deterministically in
+ * `packages/ui/src/components/chat/MessageContent.config.test.tsx`; the live
+ * chat round-trip (real model emits `[CONFIG:telegram]` / drives SETTINGS) is
+ * covered by the `live-only` scenarios in
+ * `plugins/plugin-app-control/test/scenarios/settings-in-chat-*.scenario.ts`.
+ *
+ * Deterministic: real config store on a temp dir, stub runtime, no live model.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type {
+  ActionResult,
+  HandlerOptions,
+  IAgentRuntime,
+  Memory,
+} from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { settingsAction } from "./settings-actions.ts";
+
+// A stub runtime is enough for the config-store ops (toggle_capability /
+// update_ai_provider) — they read/write eliza.json and never touch the runtime.
+// `character: {}` lets set_backend's live-character write-through no-op safely.
+const RUNTIME = { character: {} } as unknown as IAgentRuntime;
+const OWNER_MESSAGE = { entityId: "owner" } as unknown as Memory;
+
+function invoke(parameters: Record<string, unknown>): Promise<ActionResult> {
+  return settingsAction.handler(RUNTIME, OWNER_MESSAGE, undefined, {
+    parameters,
+  } as HandlerOptions) as Promise<ActionResult>;
+}
+
+let tempDir: string;
+let configPath: string;
+let priorConfigPath: string | undefined;
+let priorPersistPath: string | undefined;
+
+function readConfig(): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(configPath, "utf-8")) as Record<
+    string,
+    unknown
+  >;
+}
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "settings-chat-ops-"));
+  configPath = path.join(tempDir, "eliza.json");
+  // Seed a minimal-but-real config so load/merge/save exercise the real path.
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({ ui: { capabilities: { wallet: false } } }),
+  );
+  priorConfigPath = process.env.ELIZA_CONFIG_PATH;
+  priorPersistPath = process.env.ELIZA_PERSIST_CONFIG_PATH;
+  // Point BOTH the read resolver (ELIZA_CONFIG_PATH) and the write resolver
+  // (ELIZA_PERSIST_CONFIG_PATH) at the temp file so load and save agree.
+  process.env.ELIZA_CONFIG_PATH = configPath;
+  process.env.ELIZA_PERSIST_CONFIG_PATH = configPath;
+});
+
+afterEach(() => {
+  if (priorConfigPath === undefined) delete process.env.ELIZA_CONFIG_PATH;
+  else process.env.ELIZA_CONFIG_PATH = priorConfigPath;
+  if (priorPersistPath === undefined)
+    delete process.env.ELIZA_PERSIST_CONFIG_PATH;
+  else process.env.ELIZA_PERSIST_CONFIG_PATH = priorPersistPath;
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("SETTINGS action — always available at the chat boundary", () => {
+  it("declares the OWNER role gate the chat settings surface relies on", () => {
+    // The chat settings direction ("settings is just settings in chat") depends
+    // on this gate: any authenticated non-owner in chat must not reach it.
+    expect(settingsAction.roleGate).toEqual({ minRole: "OWNER" });
+  });
+
+  it("validate() resolves true (gate is structural, not validate-time)", async () => {
+    // SETTINGS has no validate-time preconditions — the OWNER gate is enforced
+    // structurally by core (satisfiesRoleGate) before the handler runs, so the
+    // action stays selectable and the gate can't be bypassed by a passing
+    // validate.
+    await expect(
+      settingsAction.validate(RUNTIME, OWNER_MESSAGE),
+    ).resolves.toBe(true);
+  });
+});
+
+describe("SETTINGS update_ai_provider — persists to the real config store", () => {
+  it('"switch my model provider to openai" writes provider routing to eliza.json', async () => {
+    const result = await invoke({
+      action: "update_ai_provider",
+      provider: "openai",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.op).toBe("update_ai_provider");
+    expect(result.data?.provider).toBe("openai");
+    expect(result.data?.requiresRestart).toBe(true);
+
+    // The write actually landed on disk with the real provider routing the
+    // running agent reads back — not a fabricated success.
+    const config = readConfig();
+    const routing = config.serviceRouting as
+      | { llmText?: { backend?: string } }
+      | undefined;
+    expect(routing?.llmText?.backend).toBe("openai");
+    const agents = config.agents as
+      | { defaults?: { model?: { primary?: string } } }
+      | undefined;
+    expect(agents?.defaults?.model?.primary).toBe("@elizaos/plugin-openai");
+  });
+
+  it("carries an API key through to config when supplied", async () => {
+    const result = await invoke({
+      action: "update_ai_provider",
+      provider: "openai",
+      apiKey: "sk-test-openai-key",
+    });
+    expect(result.success).toBe(true);
+    // The key must be persisted somewhere reachable via config.env so the
+    // switched provider can authenticate on the next boot.
+    const raw = fs.readFileSync(configPath, "utf-8");
+    expect(raw).toContain("sk-test-openai-key");
+  });
+
+  it("rejects a missing provider without touching the store", async () => {
+    const before = fs.readFileSync(configPath, "utf-8");
+    const result = await invoke({ action: "update_ai_provider" });
+    expect(result.success).toBe(false);
+    expect(result.data?.error).toBe("MISSING_PROVIDER");
+    expect(fs.readFileSync(configPath, "utf-8")).toBe(before);
+  });
+
+  it("rejects an unknown provider with UNKNOWN_PROVIDER", async () => {
+    const result = await invoke({
+      action: "update_ai_provider",
+      provider: "totally-not-a-provider",
+    });
+    expect(result.success).toBe(false);
+    expect(result.data?.error).toBe("UNKNOWN_PROVIDER");
+  });
+});
+
+describe("SETTINGS toggle_capability — persists to the real config store", () => {
+  it("enabling the wallet capability flips config.ui.capabilities on disk", async () => {
+    const result = await invoke({
+      action: "toggle_capability",
+      capability: "wallet",
+      enabled: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      op: "toggle_capability",
+      capability: "wallet",
+      enabled: true,
+    });
+
+    const config = readConfig();
+    const capabilities = (
+      config.ui as { capabilities?: Record<string, unknown> }
+    )?.capabilities;
+    expect(capabilities?.wallet).toBe(true);
+  });
+
+  it("disabling round-trips back to false on disk", async () => {
+    await invoke({
+      action: "toggle_capability",
+      capability: "wallet",
+      enabled: true,
+    });
+    const enabled = readConfig();
+    expect(
+      (enabled.ui as { capabilities?: Record<string, unknown> })?.capabilities
+        ?.wallet,
+    ).toBe(true);
+
+    const result = await invoke({
+      action: "toggle_capability",
+      capability: "wallet",
+      enabled: false,
+    });
+    expect(result.success).toBe(true);
+    const config = readConfig();
+    expect(
+      (config.ui as { capabilities?: Record<string, unknown> })?.capabilities
+        ?.wallet,
+    ).toBe(false);
+  });
+
+  it("rejects an unknown capability with UNKNOWN_CAPABILITY", async () => {
+    const result = await invoke({
+      action: "toggle_capability",
+      capability: "teleportation",
+      enabled: true,
+    });
+    expect(result.success).toBe(false);
+    expect(result.data?.error).toBe("UNKNOWN_CAPABILITY");
+  });
+
+  it("rejects a non-boolean `enabled` with MISSING_ENABLED", async () => {
+    const result = await invoke({
+      action: "toggle_capability",
+      capability: "wallet",
+      enabled: "yes",
+    });
+    expect(result.success).toBe(false);
+    expect(result.data?.error).toBe("MISSING_ENABLED");
+  });
+});
+
+describe("SETTINGS dispatch — unknown op fails explicitly", () => {
+  it("returns SETTINGS_INVALID (never a fabricated success) for an unknown action", async () => {
+    const result = await invoke({ action: "frobnicate" });
+    expect(result.success).toBe(false);
+    expect(result.data?.error).toBe("SETTINGS_INVALID");
+  });
+
+  it("returns SETTINGS_INVALID when no action discriminator is supplied", async () => {
+    const result = await invoke({});
+    expect(result.success).toBe(false);
+    expect(result.data?.error).toBe("SETTINGS_INVALID");
+  });
+});

--- a/plugins/plugin-app-control/test/scenarios/settings-in-chat-config-card.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/settings-in-chat-config-card.scenario.ts
@@ -1,0 +1,51 @@
+/**
+ * Live-model leg of #14325 ("settings is just settings in chat"): when the owner
+ * asks in chat to configure a connector plugin, the agent must emit the
+ * `[CONFIG:<pluginId>]` inline marker so the chat surface renders the
+ * InlinePluginConfig card (fetch/edit/save/enable) instead of dumping a wall of
+ * text or a plaintext secret form. This asserts the emitted marker on the real
+ * model's response — the marker is the contract the ChatView / overlay parser
+ * (`packages/ui/src/components/chat/message-parser-helpers`) keys the card on, so
+ * emitting it is what makes chat a settings surface.
+ *
+ * The card's own fetch/edit/save/enable round-trip is proven deterministically
+ * in `packages/ui/src/components/chat/MessageContent.config.test.tsx`; this
+ * scenario proves the *live model actually emits the marker* for a natural
+ * request, which no deterministic proxy can prove (the proxy always echoes).
+ */
+
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "settings-in-chat-config-card",
+  title: "Agent emits [CONFIG:telegram] card when asked to configure a plugin",
+  domain: "app-control",
+  tags: ["app-control", "settings", "chat-widgets", "config-card", "14325"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-app-control"],
+  },
+  rooms: [
+    {
+      id: "main",
+      source: "chat",
+      title: "Settings In Chat — Config Card",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "owner-asks-to-configure-telegram",
+      text: "I want to set up the telegram connector — show me its configuration.",
+      // The card contract: the response body must carry the [CONFIG:telegram]
+      // marker the parser lifts into an InlinePluginConfig segment. A scoped id
+      // (@elizaos/plugin-telegram) normalizes to `telegram`, so accept either.
+      responseIncludesAny: [/\[CONFIG:(@elizaos\/plugin-)?telegram\]/i],
+      // Must NOT hand the owner a plaintext [FORM] for a secret-bearing config —
+      // secret-key entry routes through the sensitive-request flow, never a
+      // plain inline form (ui-catalog [FORM] prohibition).
+      responseExcludes: [/\[FORM[:\]]/i],
+    },
+  ],
+});

--- a/plugins/plugin-app-control/test/scenarios/settings-in-chat-provider-switch.scenario.ts
+++ b/plugins/plugin-app-control/test/scenarios/settings-in-chat-provider-switch.scenario.ts
@@ -1,0 +1,65 @@
+/**
+ * Live-model leg of #14325: a natural in-chat "switch my model provider to
+ * openai" request must select the owner-gated SETTINGS action and drive its
+ * `update_ai_provider` op — proving the chat surface can mutate app-level
+ * settings, not just render a card. The persistence of that op to the real
+ * eliza.json store (serviceRouting.llmText.backend = openai, provider env) is
+ * proven deterministically in
+ * `packages/agent/src/actions/settings-chat-config-ops.test.ts`; this scenario
+ * proves the live model routes the natural request to SETTINGS with the right
+ * op + provider argument, which the deterministic proxy cannot (it never plans).
+ *
+ * Note: the app-level SETTINGS action is
+ * `packages/agent/src/actions/settings-actions.ts` (ops: update_ai_provider,
+ * toggle_capability, set_owner_name, set, backends). PR #14461 consolidated the
+ * app-control SETTINGS action separately; this scenario asserts by action name
+ * (`SETTINGS`) plus the `update_ai_provider` op argument, which survives that
+ * consolidation.
+ */
+
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "settings-in-chat-provider-switch",
+  title: "SETTINGS action switches the model provider from a chat request",
+  domain: "app-control",
+  tags: ["app-control", "settings", "chat-widgets", "provider", "14325"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-app-control"],
+  },
+  rooms: [
+    {
+      id: "main",
+      source: "chat",
+      title: "Settings In Chat — Provider Switch",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "owner-asks-switch-provider",
+      text: "Switch my model provider to openai.",
+    },
+  ],
+  finalChecks: [
+    {
+      type: "selectedAction",
+      actionName: "SETTINGS",
+    },
+    {
+      type: "actionCalled",
+      actionName: "SETTINGS",
+      status: "success",
+      minCount: 1,
+    },
+    {
+      // The op discriminator + provider must reach the handler; without this the
+      // model could pick SETTINGS but with the wrong op and still look green.
+      type: "selectedActionArguments",
+      actionName: "SETTINGS",
+      includesAll: [/update_ai_provider/i, /openai/i],
+    },
+  ],
+});


### PR DESCRIPTION
Part of #14325.

Verification-first coverage for **"settings is just settings in chat"**: the `[CONFIG:pluginId]` inline card marker path plus the owner-gated `SETTINGS` action, driven through real code paths where this PR can run keylessly.

## What this proves

### Deterministic — real config store
`packages/agent/src/actions/settings-chat-config-ops.test.ts` drives the real `settingsAction.handler` (`packages/agent/src/actions/settings-actions.ts`) against a temp `eliza.json`. It points `ELIZA_CONFIG_PATH` and `ELIZA_PERSIST_CONFIG_PATH` at that file, using the same load/write path the running agent uses (`loadElizaConfig` / `saveElizaConfig`), then reads the persisted bytes back.

Covered operations:
- `update_ai_provider` for the "switch my model provider to openai" path: asserts `serviceRouting.llmText.backend === "openai"` and `agents.defaults.model.primary === "@elizaos/plugin-openai"` on disk, plus API key persistence when supplied.
- `toggle_capability`: asserts `ui.capabilities.wallet` flips true/false on disk.
- OWNER role gate, `validate()`, and explicit failure codes: `MISSING_PROVIDER`, `UNKNOWN_PROVIDER`, `UNKNOWN_CAPABILITY`, `MISSING_ENABLED`, `SETTINGS_INVALID`, including that rejected writes leave the config file byte-identical.

A regression that silently stops persisting, or fabricates success, fails this test. The `[CONFIG]` card's fetch/edit/save/enable render round-trip remains covered by `MessageContent.config.test.tsx`.

### Live-gated scenarios — no fake green
Two `lane: "live-only"` scenarios were added under `plugins/plugin-app-control/test/scenarios/`:
- `settings-in-chat-config-card.scenario.ts`: a real model asked to configure Telegram must emit `[CONFIG:telegram]` / `[CONFIG:@elizaos/plugin-telegram]` and must not emit plaintext `[FORM]` for secret-bearing config.
- `settings-in-chat-provider-switch.scenario.ts`: "switch my model provider to openai" must select and call `SETTINGS`, with selected action args containing `update_ai_provider` and `openai`.

Because both are live-only, the keyless deterministic lane discovers zero of them. They cannot pass without a live model lane.

## Verification
- `bun run --cwd packages/agent vitest run src/actions/settings-chat-config-ops.test.ts` -> 1 file, 12 tests passed
- `bun run --cwd packages/ui vitest run src/components/chat/MessageContent.config.test.tsx` -> 1 file, 12 tests passed
- `bun run --cwd packages/scenario-runner src/cli.ts list ../../plugins/plugin-app-control/test/scenarios --scenario settings-in-chat-config-card` -> listed
- `bun run --cwd packages/scenario-runner src/cli.ts list ../../plugins/plugin-app-control/test/scenarios --scenario settings-in-chat-provider-switch` -> listed
- `bun run --cwd packages/scenario-runner src/cli.ts list ../../plugins/plugin-app-control/test/scenarios --lane pr-deterministic --scenario settings-in-chat-provider-switch` -> no scenario discovered, as expected for live-only
- `bunx @biomejs/biome check packages/agent/src/actions/settings-chat-config-ops.test.ts plugins/plugin-app-control/test/scenarios/settings-in-chat-config-card.scenario.ts plugins/plugin-app-control/test/scenarios/settings-in-chat-provider-switch.scenario.ts --no-errors-on-unmatched` -> passed
- `git diff --check` -> passed

This is not enough to close #14325: live trajectory evidence and rendered desktop/mobile evidence are still required.

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changed by this PR; the existing `[CONFIG]` card render path is covered by `MessageContent.config.test.tsx` but #14325 still needs owner-run desktop/mobile screenshots.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changed by this PR.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered UI workflow changed by this PR; #14325 still needs owner-run MP4 walkthrough evidence.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend service runtime path changed; deterministic proof is the real config-store test output listed in Verification.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - this PR adds live-only scenarios but does not run a live model in this keyless environment; #14325 remains open for reviewed live trajectories.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no separate artifact file; domain proof is the focused real-config-store test plus scenario discovery/exclusion checks listed in Verification.
