### PR TITLE
fix(pwa): reclaim dead band under home composer

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -401,16 +401,16 @@ describe("ContinuousChatOverlay", () => {
     expect(overlay.style.paddingBottom).toBe(initialPadding);
   });
 
-  it("seats the resting composer low: 40% of the gesture inset with a 0.5rem floor", () => {
-    // Lock-screen anchoring: at rest the overlay clears only what the home
-    // indicator occupies — 40% of the reported safe-area/gesture inset (≈13.6px
-    // of a 34px iOS inset) — not the whole inset (r3.3 hover) nor 60% (still
-    // ~20px up on device). The 0.5rem floor keeps breathing room on devices
-    // reporting no inset, and the nav offset still stacks on top.
+  it("seats the resting composer above the home indicator: full gesture inset plus a small gap", () => {
+    // Lock-screen anchoring: with the overlay reclaimed to the true physical
+    // bottom, the resting composer should clear the whole home-indicator/
+    // Android gesture inset plus a small visual gap (~34px + 10px on iOS), not
+    // the old 40% inset compensation that was tuned around the collapsed-ICB
+    // float and left a dead band under the composer.
     render(<ContinuousChatOverlay controller={makeController()} />);
     const overlay = screen.getByTestId("continuous-chat-overlay");
     expect(overlay.style.paddingBottom).toBe(
-      "calc(var(--eliza-mobile-nav-offset, 0px) + max(max(var(--safe-area-bottom, 0px), var(--android-gesture-inset-bottom, 0px)) * 0.4, 0.5rem))",
+      "calc(var(--eliza-mobile-nav-offset, 0px) + max(var(--safe-area-bottom, 0px), var(--android-gesture-inset-bottom, 0px)) + 0.625rem)",
     );
   });
 

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -3833,29 +3833,42 @@ export function ContinuousChatOverlay({
       // chat low without touching that zone.
       style={{
         zIndex: Z_SHELL_OVERLAY,
-        bottom: effectiveKeyboardInset,
+        // RECLAIM THE DEAD BAND UNDER THE HOME COMPOSER (device r36): at rest the
+        // overlay is anchored `bottom: 0`, but on the installed iOS Safari
+        // standalone PWA a `position: fixed` descendant of the `position: fixed`
+        // body takes the LAYOUT (small, ~873px) viewport as its containing block
+        // — ~59px short of the physical bottom (100lvh ~932px) — so `bottom: 0`
+        // floated the composer ~59px UP over a dead band down to the home
+        // indicator. Drop it by the lvh−dvh collapse delta so it seats at the
+        // TRUE physical bottom. `max(0px, 100lvh - 100dvh)` is 0 on every
+        // viewport where the two agree (desktop, Android, non-collapsed), so
+        // this is a no-op except on the exact iOS-standalone geometry that
+        // collapses. When the keyboard is up the visual viewport shrinks and
+        // `effectiveKeyboardInset` drives the lift instead — no delta applied —
+        // so the keyboard-lift math (contract-tested) is untouched.
+        bottom: keyboardLiftActive
+          ? effectiveKeyboardInset
+          : "calc(-1 * max(0px, 100lvh - 100dvh))",
         // Full-bleed fills the screen edge-to-edge: NO overlay bottom padding,
         // so the glass panel reaches the true bottom (no orange gap). The
         // gesture-zone clearance moves INSIDE the composer row (below) so the
         // input still sits above the home-gesture bar. Non-full-bleed anchors
-        // the composer LOW, lock-screen style. The OS reports a ~34px bottom
-        // safe-area on a home-indicator phone, but the indicator itself is a
-        // thin (~5px) bar whose TOP edge sits only ~13px off the true bottom
-        // (5px bar + ~8px own margin) — clearing the WHOLE safe-area floats
-        // the pill ~34px up over a dead band, and 60% (device round: still
-        // reads too high) leaves it hovering ~20px up. So clear exactly what
-        // the indicator occupies: 40% of the reported inset (34px * 0.4 ≈
-        // 13.6px — the pill seats right on the indicator's top edge without
-        // ever overlapping the bar or the OS gesture zone), with a 0.5rem
-        // floor so a device with NO inset still keeps a hair of breathing
-        // room. The same factor holds for Android gesture pills (their inset
-        // reports similarly padded). Everything below the composer is the
-        // full-bleed wallpaper / app floor — no cosmetic strip repaints it.
+        // the composer LOW, lock-screen style, CLEARING the home indicator: now
+        // that the overlay itself seats at the TRUE physical bottom (the `bottom`
+        // reclaim above), the resting padding must clear the WHOLE home-indicator
+        // safe area (env(safe-area-inset-bottom) ~34px) plus a small gap, so the
+        // composer rests ~42–46px off the physical edge — above the indicator,
+        // not floating in a dead band above it. (Previously this multiplied the
+        // inset by 0.4 to sit the pill ~13px up; that tuning was compensating
+        // for the collapsed-ICB float — with the overlay now correctly at the
+        // true bottom, the full inset + gap is the right, native-app clearance.)
+        // The same holds for Android gesture pills. Everything below the composer
+        // is the full-bleed wallpaper / app floor — no cosmetic strip repaints it.
         paddingBottom: fullBleed
           ? 0
           : keyboardLiftActive
             ? "0.75rem"
-            : "calc(var(--eliza-mobile-nav-offset, 0px) + max(max(var(--safe-area-bottom, 0px), var(--android-gesture-inset-bottom, 0px)) * 0.4, 0.5rem))",
+            : "calc(var(--eliza-mobile-nav-offset, 0px) + max(var(--safe-area-bottom, 0px), var(--android-gesture-inset-bottom, 0px)) + 0.625rem)",
       }}
       data-testid="continuous-chat-overlay"
       data-open={sheetOpen ? "true" : undefined}

--- a/packages/ui/src/platform/standalone-pwa-lockdown.test.ts
+++ b/packages/ui/src/platform/standalone-pwa-lockdown.test.ts
@@ -403,15 +403,15 @@ describe("App shell reclaim contract — the shell column carries the reclaim ho
 });
 
 describe("Keyboard-lift geometry contract — reclaim does NOT shift the composer lift", () => {
-  // RECLAIM THE BOTTOM STRIP (#14411) regression guard: the composer overlay is
-  // a `position: fixed` element anchored to the fixed-body ICB (already pinned
-  // to 100lvh by the #14319 geometry), NOT to #root. Its keyboard lift comes
-  // from `bottom: effectiveKeyboardInset`, a VISUAL-VIEWPORT delta, and its
-  // panel height is bounded by `viewportH` (the visual viewport). None of these
-  // read #root's height, so lifting #root from 100dvh to 100lvh cannot change
-  // where the composer rests or how far it lifts above the keyboard — the
-  // lvh–dvh (~59px) delta never enters the lift math. Pin those invariants so a
-  // future refactor that couples the lift to #root/dvh trips this test.
+  // RECLAIM THE BOTTOM STRIP (#14411/#r36) regression guard: the composer overlay
+  // is a `position: fixed` descendant of the fixed body. In an installed iOS PWA,
+  // `bottom: 0` for that fixed descendant anchors to the layout/small viewport
+  // (~873px), while the true physical bottom is the large viewport (~932px). At
+  // REST the overlay must compensate by the lvh−dvh delta so the composer sits
+  // above the home indicator instead of floating over a dead band. With the
+  // KEYBOARD up, the existing `effectiveKeyboardInset` visual-viewport delta is
+  // still the sole lift path: no lvh compensation is applied during keyboard
+  // lift, and panel height remains bounded by `viewportH`.
   const overlaySrc = readFileSync(
     resolve(process.cwd(), "src/components/shell/ContinuousChatOverlay.tsx"),
     "utf8",
@@ -421,14 +421,25 @@ describe("Keyboard-lift geometry contract — reclaim does NOT shift the compose
     "utf8",
   );
 
-  it("lifts the composer by effectiveKeyboardInset (visual-viewport delta), not a #root/lvh measure", () => {
-    expect(overlaySrc).toContain("bottom: effectiveKeyboardInset");
+  it("reclaims the resting composer by the standalone lvh−dvh bottom delta", () => {
+    expect(overlaySrc).toContain('"calc(-1 * max(0px, 100lvh - 100dvh))"');
+    expect(overlaySrc).toContain("keyboardLiftActive");
+    // Resting clearance should be the full safe-area/gesture inset plus a small
+    // visual gap, so on a 34px home-indicator device the composer rests ~44px
+    // from the physical edge (34px + 0.625rem), not ~90px up.
+    expect(overlaySrc).toContain(
+      "max(var(--safe-area-bottom, 0px), var(--android-gesture-inset-bottom, 0px)) + 0.625rem",
+    );
+  });
+
+  it("lifts the composer by effectiveKeyboardInset (visual-viewport delta) when the keyboard is active", () => {
+    expect(overlaySrc).toContain("? effectiveKeyboardInset");
+    expect(overlaySrc).toContain(': "calc(-1 * max(0px, 100lvh - 100dvh))"');
     // effectiveKeyboardInset is derived from the visual viewport + native
-    // keyboard plugin, never from 100lvh / #root height.
+    // keyboard plugin.
     expect(overlaySrc).toContain(
       "effectiveKeyboardInset = Math.max(keyboardInset, nativeLift)",
     );
-    expect(overlaySrc).not.toContain("100lvh");
   });
 
   it("bounds the panel height by the visual viewport, not #root/lvh", () => {


### PR DESCRIPTION
## Summary
- drop the resting continuous chat overlay by the standalone iOS lvh-dvh delta so `bottom: 0` no longer anchors to the collapsed layout viewport
- restore full home-indicator / Android gesture clearance plus a 0.625rem visual gap at rest (~44px on a 34px safe-area device)
- keep keyboard lift gated on `effectiveKeyboardInset`, so visualViewport keyboard behavior stays unchanged

## Evidence
- before device screenshot saved: `/mnt/HC_Volume_106234565/eliza-workers/wt-strip-r2/_shots/before-device-r36-strip-still.png`
- after headless screenshot saved: `/mnt/HC_Volume_106234565/eliza-workers/wt-strip-r2/_shots/after-headless-home-reclaimed.png`
- before device estimate: composer-bottom-to-physical-bottom ~74px, band ~#321308
- headless forensic stack before fix identified the band painter below the composer as the fixed body ember floor: `body` background `color(srgb 0.239451 0.105333 0.0443922)` ≈ rgb(61,27,11) / #3d1b0b
- after headless capture: no large dead band below the composer; visible panel seats at the bottom edge in the non-safe-area headless environment. On device, source contract now yields safe-area 34px + 0.625rem = ~44px physical-edge clearance.

## Tests
- `npx vitest run src/components/shell/ContinuousChatOverlay.test.tsx src/platform/standalone-pwa-lockdown.test.ts` -> 180 passed
- `npx vitest run src/App.safe-area-fill.test.ts src/App.cloud-shell.test.tsx src/backgrounds/AppBackground.test.tsx` -> 27 passed
- `npx vitest run src/platform/standalone-pwa-lockdown.test.ts` -> 23 passed
- `bun run build` in `packages/app` -> built in 1m 1s, buildId=fe90e082e7b1
- `bunx @biomejs/biome check src/components/shell/ContinuousChatOverlay.tsx src/components/shell/ContinuousChatOverlay.test.tsx src/platform/standalone-pwa-lockdown.test.ts` -> no errors, existing unused-suppression warnings in standalone-pwa-lockdown.test.ts

## Review
- `codex review --uncommitted` hung >100s and was killed per lane protocol; self-review found no staged-path issues.

— [sol-orch]