### PR TITLE
ci: certification-verify gate on develop→main — verify signed evidence certification (#14547)

### DIFF
--- a/.github/certification/README.md
+++ b/.github/certification/README.md
@@ -44,7 +44,7 @@ bun run --cwd packages/evidence certify:verify -- \
   --cert <path/to/certification.json> \
   --bundle <bundle-dir> \
   --pubkey <base-branch-checkout>/.github/certification/certification-public-key.pem \
-  --expected-commit <pr-head-sha> \
+  --expected-commit <cert.commit> \
   --max-age-hours 72 \
   --required-tier full \
   [--requirements <requirements.json>] \
@@ -84,6 +84,76 @@ Compromise response is the same procedure, performed immediately; the old
 key needs no explicit revocation because the gate trusts exactly one key —
 the one on `main`.
 
+## The CI gate (#14547): `certification-verify.yml`
+
+`.github/workflows/certification-verify.yml` runs on every non-draft PR
+targeting `main` and is the promotion gate. What it does, in order:
+
+1. Checks out the PR head commit (not the synthetic merge ref) and reads the
+   trusted public key from the **base branch** per the trust model above.
+2. Locates the certification and bundle: **`certification.json` committed at
+   the repo root of the promotion branch** and the signed evidence bundle
+   committed at **`evidence/bundle/`**. Missing either file = red, with
+   remediation instructions in the check summary. The gate always passes
+   `--bundle evidence/bundle` so artifact integrity, rollup completeness, and
+   signed evidence-path membership are re-derived from the committed bundle.
+3. Runs `scripts/certification/check-commit-drift.mjs`: the certified commit
+   must equal the PR head, or be an ancestor whose diff to head touches only
+   the docs/template allowlist — `docs/**`, `packages/docs/**`, any `*.md`,
+   plus the certification artifacts themselves (`certification.json`,
+   `evidence/bundle/**` — those necessarily land after the signed commit and
+   are protected by the signature and `bundleSha`, not by the drift rule). Any
+   other source, workflow, policy, or config drift = re-certify.
+4. Runs `certify:verify` (the contract above) with
+   `--expected-commit <cert.commit> --max-age-hours 72 --required-tier full`.
+5. Writes a check summary with the reviewer identity, tier, age, signed
+   verdict table (waived rows surfaced with notes), drifted paths, trusted
+   key fingerprint, and every failure code verbatim. Verification only — the
+   gate never performs evidence *review*.
+
+### Branch protection (admins)
+
+Add the required status check **`verify-certification`** (the job name in
+`certification-verify.yml`) to `main`'s branch protection. This is a manual
+admin step — the workflow does not (and must not) edit branch protection.
+Keep the name stable; renaming the job orphans the required check and blocks
+every promotion. The companion `certification-verify-selftest` job is CI for
+the gate's own plumbing (runs only on PRs touching it) and must **not** be
+made a required check.
+
+**Bootstrap:** until this directory's public key and `packages/evidence`
+exist on `main`, the gate fails closed on every promotion PR ("no trusted
+public key on main"). The first promotion that carries the certification
+stack to `main` needs a one-time admin bypass; every promotion after it is
+fully gated.
+
+**Residual risk (accepted):** `pull_request`-triggered workflows execute the
+PR's own merged workflow definition, so a promotion PR that edits the gate
+files could neuter the check. The drift check refuses to allowlist those
+paths, the diff is plainly visible to the human merger, and promotion PRs
+are human-reviewed by definition. Hardening to `pull_request_target` (base
+branch runs the workflow) is a possible follow-up.
+
+### Remediation runbook (gate is red)
+
+1. Preferred: dispatch the vast certification workflow for the promoted
+   commit; it produces the bundle, review, and signed `certification.json`.
+2. Local fallback (requires a certifier holding `ELIZA_CERT_SIGNING_KEY`):
+
+   ```bash
+   bun run --cwd packages/evidence bundle:create -- --tier full
+   bun run --cwd packages/evidence certify:rollup -- --bundle <bundle-dir> --out verdicts.json
+   # review verdicts.json by hand — waivers require notes
+   bun run --cwd packages/evidence certify:sign -- --bundle <bundle-dir> \
+     --verdicts verdicts.json --reviewer-id <you> --reviewer-kind human
+   cp <bundle-dir>/certification.json ./certification.json  # commit on the promotion branch
+   rm -rf evidence/bundle && mkdir -p evidence && cp -R <bundle-dir> evidence/bundle
+   ```
+
+3. `stale` (>72h) or `commit-mismatch`/drift failures always mean the same
+   thing: re-run certification at the current head. There is no override
+   flag by design.
+
 ## Break-glass (emergencies)
 
 Push to `main` is a production deploy, so the gate must be watertight — but
@@ -91,6 +161,6 @@ it must not brick emergencies. The break-glass path is **not a code path**:
 a repository admin bypasses the required `certification-verify` check via
 branch-protection admin override. Every such bypass is visible in the
 GitHub audit log; there is deliberately no in-repo flag, env var, or
-alternate verification mode that skips signature checks. #14547 must
-document the required-check name it registers so admins know exactly which
-check they are bypassing and auditors know what to grep for.
+alternate verification mode that skips signature checks. The required check
+being bypassed is **`verify-certification`** (see the CI gate section
+above) — that is the exact string admins bypass and auditors grep for.

--- a/.github/workflows/certification-verify.yml
+++ b/.github/workflows/certification-verify.yml
@@ -1,0 +1,265 @@
+# certification-verify — the develop→main promotion gate (#14547, epic #14541).
+#
+# PRs targeting `main` (a production deploy) must carry a `certification.json`
+# at the repo root: an Ed25519-signed claim (produced by
+# `packages/evidence certify:sign`, protocol in #14546) that a trusted
+# keyholder reviewed the evidence bundle for the promoted commit. This
+# workflow is a THIN CALLER of `certify:verify` — zero verification logic
+# lives here — plus a docs/template-only commit-drift check
+# (scripts/certification/check-commit-drift.mjs) and a human-readable check
+# summary showing WHO certified WHAT.
+#
+# Required-check name for main's branch protection: `verify-certification`
+# (admin wiring + break-glass runbook: .github/certification/README.md).
+#
+# The `certification-verify-selftest` job runs on PRs (to main or develop)
+# that touch the gate's own plumbing: it generates a throwaway keypair, signs
+# a fixture bundle with the real CLIs, and asserts green-verifies + tampered
+# fails — so gate changes are CI-tested without a real certification. It is
+# NOT the required check; skipping its steps on unrelated PRs is safe.
+
+name: certification-verify
+
+on:
+  pull_request:
+    # `main` for the gate itself; `develop` only so the selftest job covers
+    # PRs that change the gate's plumbing (which target develop).
+    branches: [main, develop]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: certification-verify-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify-certification:
+    name: verify-certification
+    # Draft promotion PRs skip the gate: GitHub cannot merge a draft, and the
+    # ready_for_review trigger re-runs the check the moment it matters.
+    if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      BASE_REF: ${{ github.event.pull_request.base.ref }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      ELIZA_SKIP_ARTIFACT_SYNC: "1"
+    steps:
+      - name: Checkout PR head
+        # actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          # The exact head commit, not the synthetic merge ref: the
+          # certification binds to a real commit sha, and the drift check
+          # compares that sha against this head.
+          ref: ${{ github.event.pull_request.head.sha }}
+          # Full history so `git diff cert.commit..head` and the ancestry
+          # check resolve however far back the certified commit sits.
+          fetch-depth: 0
+
+      # TRUST ANCHOR — read the public key from the BASE branch (main), never
+      # from the PR head. If this step read the PR's own copy of the key, an
+      # attacker could swap the key and a matching self-signed
+      # certification.json in a single promotion PR and the gate would happily
+      # verify their own signature. Reading main's copy means a key only
+      # becomes trusted after it lands on main through review; until then a
+      # foreign-key certification fails `wrong-key`. (Rotation + bootstrap:
+      # .github/certification/README.md.)
+      - name: Read trusted public key from the base branch
+        run: |
+          set -euo pipefail
+          git fetch --quiet --no-tags origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          if ! git show "refs/remotes/origin/${BASE_REF}:.github/certification/certification-public-key.pem" \
+              > "$RUNNER_TEMP/trusted-public-key.pem"; then
+            echo "::error title=certification-verify::No trusted public key at .github/certification/certification-public-key.pem on ${BASE_REF}. Until the certification stack lands on ${BASE_REF}, this gate cannot pass (bootstrap: see .github/certification/README.md)."
+            exit 1
+          fi
+
+      # Artifact convention: `certification.json` committed at the repo root,
+      # with the signed evidence bundle committed at `evidence/bundle/`.
+      # Checked before dependency install so missing artifacts fail in seconds,
+      # with remediation.
+      - name: Locate certification and evidence bundle
+        run: |
+          set -euo pipefail
+          if [ ! -f certification.json ]; then
+            {
+              echo "## certification-verify"
+              echo ""
+              echo "**Result:** ❌ no \`certification.json\` at the repo root of this promotion branch."
+              echo ""
+              echo "Produce one by running the vast certification workflow for this commit, or locally:"
+              echo ""
+              echo '```bash'
+              echo "bun run --cwd packages/evidence bundle:create -- --tier full"
+              echo "bun run --cwd packages/evidence certify:rollup -- --bundle <bundle-dir> --out verdicts.json"
+              echo "# review + edit verdicts.json, then (requires the ELIZA_CERT_SIGNING_KEY secret):"
+              echo "bun run --cwd packages/evidence certify:sign -- --bundle <bundle-dir> --verdicts verdicts.json --reviewer-id <you> --reviewer-kind human"
+              echo "cp <bundle-dir>/certification.json ./certification.json"
+              echo "rm -rf evidence/bundle && mkdir -p evidence && cp -R <bundle-dir> evidence/bundle"
+              echo '```'
+              echo ""
+              echo "Full runbook: [.github/certification/README.md](https://github.com/${GITHUB_REPOSITORY}/blob/${BASE_REF}/.github/certification/README.md)"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error title=certification-verify::certification.json missing at the repo root — run the vast certification workflow or local certify:sign; see .github/certification/README.md"
+            exit 1
+          fi
+          if [ ! -f evidence/bundle/manifest.json ]; then
+            {
+              echo "## certification-verify"
+              echo ""
+              echo "**Result:** ❌ no evidence bundle at \`evidence/bundle/\` on this promotion branch."
+              echo ""
+              echo "The promotion gate always passes \`--bundle evidence/bundle\` to \`certify:verify\` so artifact integrity, rollup completeness, and signed evidence-path membership are re-derived from the committed bundle."
+              echo ""
+              echo '```bash'
+              echo "bun run --cwd packages/evidence bundle:create -- --tier full"
+              echo "bun run --cwd packages/evidence certify:rollup -- --bundle <bundle-dir> --out verdicts.json"
+              echo "bun run --cwd packages/evidence certify:sign -- --bundle <bundle-dir> --verdicts verdicts.json --reviewer-id <you> --reviewer-kind human"
+              echo "cp <bundle-dir>/certification.json ./certification.json"
+              echo "rm -rf evidence/bundle && mkdir -p evidence && cp -R <bundle-dir> evidence/bundle"
+              echo '```'
+              echo ""
+              echo "Full runbook: [.github/certification/README.md](https://github.com/${GITHUB_REPOSITORY}/blob/${BASE_REF}/.github/certification/README.md)"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error title=certification-verify::evidence/bundle/manifest.json missing — commit the signed evidence bundle and re-run the gate"
+            exit 1
+          fi
+          echo "certification.json present"
+          echo "evidence/bundle present"
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: "1.3.14" # pinned: floating canary rewrites bun.lock (#11184/#9454)
+          install-native-deps: "false"
+          install-protoc: "false"
+          setup-python: "false"
+          run-postinstall: "false" # certify:verify needs only zod; skips the multi-GB artifact sync
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      # The certification may sit a few commits behind head when only docs
+      # moved after signing. The helper passes iff head == cert.commit, or
+      # cert.commit is an ancestor and every drifted path is docs/template-only
+      # (docs/**, packages/docs/**, *.md, plus signed certification artifacts).
+      # Any source, workflow, policy, or config drift forces re-certification.
+      - name: Check commit drift (certification commit vs PR head)
+        id: drift
+        run: |
+          set -euo pipefail
+          status=0
+          node scripts/certification/check-commit-drift.mjs \
+            --cert "$GITHUB_WORKSPACE/certification.json" \
+            --head "$HEAD_SHA" \
+            --repo "$GITHUB_WORKSPACE" \
+            --json-out "$RUNNER_TEMP/drift.json" \
+            --github-output "$GITHUB_OUTPUT" || status=$?
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+
+      - name: Verify certification (certify:verify)
+        id: verify
+        env:
+          CERT_COMMIT: ${{ steps.drift.outputs.cert-commit }}
+        run: |
+          set -euo pipefail
+          args=(
+            --cert "$GITHUB_WORKSPACE/certification.json"
+            --pubkey "$RUNNER_TEMP/trusted-public-key.pem"
+            --max-age-hours 72
+            --required-tier full
+            --json
+          )
+          # The commit binding: certify:verify checks the SIGNED commit; the
+          # drift step above already bound that commit to this PR head.
+          if [ -n "$CERT_COMMIT" ]; then
+            args+=( --expected-commit "$CERT_COMMIT" )
+          fi
+          # Required committed bundle: verify re-hashes every artifact and
+          # re-derives the mechanical rollup and evidence-path membership
+          # (bundle-tampered / verdict-incomplete).
+          args+=( --bundle "$GITHUB_WORKSPACE/evidence/bundle" )
+          status=0
+          bun run --cwd packages/evidence certify:verify -- "${args[@]}" \
+            > "$RUNNER_TEMP/certification-report.json" || status=$?
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+
+      - name: Render check summary
+        if: ${{ !cancelled() }}
+        run: |
+          set -euo pipefail
+          node scripts/certification/render-check-summary.mjs \
+            --mode summary \
+            --report "$RUNNER_TEMP/certification-report.json" \
+            --drift "$RUNNER_TEMP/drift.json" \
+            --pubkey "$RUNNER_TEMP/trusted-public-key.pem" \
+            --cert-path "certification.json (repo root, head ${HEAD_SHA})" \
+            >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Enforce gate result
+        env:
+          DRIFT_STATUS: ${{ steps.drift.outputs.status }}
+          VERIFY_STATUS: ${{ steps.verify.outputs.status }}
+        run: |
+          set -euo pipefail
+          node scripts/certification/render-check-summary.mjs \
+            --mode annotations \
+            --report "$RUNNER_TEMP/certification-report.json" \
+            --drift "$RUNNER_TEMP/drift.json"
+          if [ "$DRIFT_STATUS" != "0" ] || [ "$VERIFY_STATUS" != "0" ]; then
+            echo "::error title=certification-verify::gate failed (commit-drift status=$DRIFT_STATUS, certify:verify status=$VERIFY_STATUS) — failure codes above and in the step summary"
+            exit 1
+          fi
+          echo "certification verified"
+
+  certification-verify-selftest:
+    name: certification-verify-selftest
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Detect gate-relevant changes
+        id: changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          files="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')"
+          if printf '%s\n' "$files" | grep -Eq '^(\.github/workflows/certification-verify\.yml$|scripts/certification/|packages/evidence/|\.github/certification/)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "gate plumbing untouched by this PR; selftest not needed"
+          fi
+
+      - name: Checkout
+        if: steps.changes.outputs.relevant == 'true'
+        # actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Setup workspace dependencies
+        if: steps.changes.outputs.relevant == 'true'
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: "1.3.14" # pinned: floating canary rewrites bun.lock (#11184/#9454)
+          install-native-deps: "false"
+          install-protoc: "false"
+          setup-python: "false"
+          run-postinstall: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+        env:
+          ELIZA_SKIP_ARTIFACT_SYNC: "1"
+
+      - name: Commit-drift helper tests
+        if: steps.changes.outputs.relevant == 'true'
+        run: node --test scripts/certification/check-commit-drift.test.mjs
+
+      - name: Gate plumbing selftest (keygen → sign → verify → tamper)
+        if: steps.changes.outputs.relevant == 'true'
+        run: node scripts/certification/selftest.mjs

--- a/scripts/certification/check-commit-drift.mjs
+++ b/scripts/certification/check-commit-drift.mjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+/**
+ * Commit-drift check for the develop→main certification gate (#14547). A
+ * certification signs one exact commit, but a promotion branch may pick up
+ * non-source commits after signing (README and docs touch-ups). This
+ * helper decides whether the PR head is still covered by the certification:
+ * pass iff head == cert.commit, or cert.commit is an ancestor of head and
+ * every path in `git diff cert.commit..head` matches the docs-only allowlist.
+ *
+ * The allowlist is deliberately narrow: docs/**, packages/docs/**, any *.md,
+ * and the certification artifacts. GitHub workflow/policy/config drift must
+ * force re-certification, never ride the docs allowlist.
+ *
+ * Consumed by .github/workflows/certification-verify.yml; it reads the
+ * certification only to extract `commit` — all cryptographic and schema
+ * verification stays in `packages/evidence certify:verify`.
+ */
+
+import { execFileSync } from "node:child_process";
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+/** Paths that may change after certification without re-certifying. */
+export function isAllowedDriftPath(filePath) {
+  // Trust anchor and gate plumbing: never allowed as post-certification drift.
+  if (filePath.startsWith(".github/certification/")) return false;
+  if (filePath === ".github/workflows/certification-verify.yml") return false;
+  if (filePath.startsWith("scripts/certification/")) return false;
+
+  // The certification artifacts themselves necessarily land AFTER the
+  // certified commit (the signature covers the commit sha, so the commit that
+  // adds the file can never be the signed one). Their integrity is enforced
+  // cryptographically — signature over the payload, bundleSha over the bundle
+  // — not by the drift rule, so allowing them here weakens nothing.
+  if (filePath === "certification.json") return true;
+  if (filePath.startsWith("evidence/bundle/")) return true;
+
+  if (filePath.startsWith("docs/")) return true;
+  if (filePath.startsWith("packages/docs/")) return true;
+  if (filePath.endsWith(".md")) return true;
+  return false;
+}
+
+const SHA_RE = /^[0-9a-f]{40}$/;
+
+function git(repoDir, args) {
+  return execFileSync("git", args, {
+    cwd: repoDir,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+/** Read `commit` out of a certification.json without validating anything else. */
+export function readCertCommit(certPath) {
+  let raw;
+  try {
+    raw = readFileSync(certPath, "utf8");
+  } catch (error) {
+    return { error: `certification unreadable: ${error.message}` };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    return { error: `certification is not valid JSON: ${error.message}` };
+  }
+  const commit = parsed?.commit;
+  if (typeof commit !== "string" || !SHA_RE.test(commit)) {
+    return {
+      error: `certification \`commit\` is not a full 40-hex sha: ${JSON.stringify(commit)}`,
+    };
+  }
+  return { commit };
+}
+
+/**
+ * Evaluate drift between the certified commit and the PR head.
+ * Result shape: { result, certCommit, headCommit, driftPaths, disallowedPaths, detail }
+ * where result is one of:
+ *   match | allowed-drift             → covered by the certification
+ *   cert-commit-unknown | not-ancestor | disallowed-drift  → not covered
+ */
+export function evaluateCommitDrift({ certCommit, headCommit, repoDir }) {
+  const base = {
+    certCommit,
+    headCommit,
+    driftPaths: [],
+    disallowedPaths: [],
+  };
+  if (certCommit === headCommit) {
+    return {
+      ...base,
+      result: "match",
+      detail: "certification commit equals the PR head",
+    };
+  }
+
+  try {
+    git(repoDir, ["cat-file", "-e", `${certCommit}^{commit}`]);
+  } catch {
+    // A cert for a commit this repository has never seen (or outside the
+    // fetched history window) cannot cover this head. Shallow clones can
+    // produce this for very old certs — that fails safe: stale certs must
+    // re-certify anyway.
+    return {
+      ...base,
+      result: "cert-commit-unknown",
+      detail: `certified commit ${certCommit} is not present in this repository's fetched history`,
+    };
+  }
+
+  let isAncestor = true;
+  try {
+    git(repoDir, ["merge-base", "--is-ancestor", certCommit, headCommit]);
+  } catch (error) {
+    if (error.status === 1) {
+      isAncestor = false;
+    } else {
+      throw error;
+    }
+  }
+  if (!isAncestor) {
+    return {
+      ...base,
+      result: "not-ancestor",
+      detail: `certified commit ${certCommit} is not an ancestor of head ${headCommit} — the certified tree was never part of this branch`,
+    };
+  }
+
+  const driftPaths = git(repoDir, [
+    "diff",
+    "--name-only",
+    "-z",
+    certCommit,
+    headCommit,
+  ])
+    .split("\0")
+    .filter((entry) => entry.length > 0);
+  const disallowedPaths = driftPaths.filter(
+    (entry) => !isAllowedDriftPath(entry),
+  );
+  if (disallowedPaths.length > 0) {
+    return {
+      ...base,
+      driftPaths,
+      disallowedPaths,
+      result: "disallowed-drift",
+      detail: `${disallowedPaths.length} of ${driftPaths.length} drifted path(s) fall outside the docs-only allowlist — re-certify at the current head`,
+    };
+  }
+  return {
+    ...base,
+    driftPaths,
+    result: "allowed-drift",
+    detail: `${driftPaths.length} drifted path(s), all inside the docs-only allowlist`,
+  };
+}
+
+function parseArgs(argv) {
+  const args = { repoDir: process.cwd() };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const value = () => {
+      const next = argv[index + 1];
+      if (next === undefined) {
+        console.error(`${flag} requires a value`);
+        process.exit(2);
+      }
+      index += 1;
+      return next;
+    };
+    if (flag === "--cert") args.certPath = value();
+    else if (flag === "--head") args.headCommit = value();
+    else if (flag === "--repo") args.repoDir = value();
+    else if (flag === "--json-out") args.jsonOut = value();
+    else if (flag === "--github-output") args.githubOutput = value();
+    else {
+      console.error(`unknown argument: ${flag}`);
+      process.exit(2);
+    }
+  }
+  if (args.certPath === undefined || args.headCommit === undefined) {
+    console.error(
+      "Usage: check-commit-drift.mjs --cert <certification.json> --head <sha> [--repo <dir>] [--json-out <file>] [--github-output <file>]",
+    );
+    process.exit(2);
+  }
+  if (!SHA_RE.test(args.headCommit)) {
+    console.error(`--head must be a full 40-hex sha, got: ${args.headCommit}`);
+    process.exit(2);
+  }
+  return args;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const certRead = readCertCommit(args.certPath);
+  const outcome =
+    "error" in certRead
+      ? {
+          result: "cert-unreadable",
+          certCommit: null,
+          headCommit: args.headCommit,
+          driftPaths: [],
+          disallowedPaths: [],
+          detail: certRead.error,
+        }
+      : evaluateCommitDrift({
+          certCommit: certRead.commit,
+          headCommit: args.headCommit,
+          repoDir: args.repoDir,
+        });
+
+  if (args.jsonOut !== undefined) {
+    writeFileSync(args.jsonOut, `${JSON.stringify(outcome, null, 2)}\n`);
+  }
+  if (args.githubOutput !== undefined) {
+    appendFileSync(
+      args.githubOutput,
+      `cert-commit=${outcome.certCommit ?? ""}\nresult=${outcome.result}\n`,
+    );
+  }
+
+  const ok = outcome.result === "match" || outcome.result === "allowed-drift";
+  console.log(`[check-commit-drift] ${outcome.result}: ${outcome.detail}`);
+  for (const entry of outcome.driftPaths) {
+    const marker = outcome.disallowedPaths.includes(entry)
+      ? "DISALLOWED"
+      : "allowed   ";
+    console.log(`  ${marker} ${entry}`);
+  }
+  process.exit(ok ? 0 : 1);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/scripts/certification/check-commit-drift.test.mjs
+++ b/scripts/certification/check-commit-drift.test.mjs
@@ -1,0 +1,244 @@
+/**
+ * Tests for the certification commit-drift check. Fixture repositories are
+ * real `git init` repos built in a temp dir per test — no mocked git — so the
+ * ancestor and diff semantics under test are exactly what CI runs.
+ */
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { after, describe, it } from "node:test";
+import {
+  evaluateCommitDrift,
+  isAllowedDriftPath,
+  readCertCommit,
+} from "./check-commit-drift.mjs";
+
+const roots = [];
+after(() => {
+  for (const root of roots) rmSync(root, { recursive: true, force: true });
+});
+
+function git(repoDir, args) {
+  return execFileSync("git", args, {
+    cwd: repoDir,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function makeRepo() {
+  const repoDir = mkdtempSync(join(tmpdir(), "cert-drift-test-"));
+  roots.push(repoDir);
+  git(repoDir, ["init", "-b", "main"]);
+  git(repoDir, ["config", "user.email", "drift-test@example.invalid"]);
+  git(repoDir, ["config", "user.name", "drift test"]);
+  return repoDir;
+}
+
+function commitFiles(repoDir, message, files) {
+  for (const [relPath, content] of Object.entries(files)) {
+    const filePath = join(repoDir, ...relPath.split("/"));
+    mkdirSync(dirname(filePath), { recursive: true });
+    writeFileSync(filePath, content);
+  }
+  git(repoDir, ["add", "-A"]);
+  git(repoDir, ["commit", "-m", message]);
+  return git(repoDir, ["rev-parse", "HEAD"]);
+}
+
+describe("isAllowedDriftPath", () => {
+  const allowed = [
+    "docs/promotion-notes.md",
+    "docs/nested/deep/guide.txt",
+    "packages/docs/src/pages/index.tsx",
+    "README.md",
+    "packages/core/CHANGELOG.md",
+    ".github/pull_request_template.md",
+    // The certification artifacts land after the signed commit by necessity;
+    // signature + bundleSha protect their content, not the drift rule.
+    "certification.json",
+    "evidence/bundle/manifest.json",
+    "evidence/bundle/lanes/e2e/result.json",
+  ];
+  const disallowed = [
+    "packages/core/src/runtime.ts",
+    "scripts/run-anything.mjs",
+    ".github/certification/certification-public-key.pem",
+    ".github/certification/README.md",
+    ".github/workflows/certification-verify.yml",
+    ".github/workflows/ci.yaml",
+    ".github/actions/setup/action.yml",
+    ".github/CODEOWNERS",
+    ".github/ISSUE_TEMPLATE/config.yml",
+    "scripts/certification/check-commit-drift.mjs",
+    "package.json",
+    "bun.lock",
+    "docsish/trap.ts",
+    "nested/certification.json",
+    "evidence/other/file.json",
+  ];
+  for (const path of allowed) {
+    it(`allows ${path}`, () => assert.equal(isAllowedDriftPath(path), true));
+  }
+  for (const path of disallowed) {
+    it(`rejects ${path}`, () => assert.equal(isAllowedDriftPath(path), false));
+  }
+});
+
+describe("readCertCommit", () => {
+  it("extracts a full 40-hex commit", () => {
+    const dir = mkdtempSync(join(tmpdir(), "cert-drift-cert-"));
+    roots.push(dir);
+    const sha = "a".repeat(40);
+    const certPath = join(dir, "certification.json");
+    writeFileSync(certPath, JSON.stringify({ schema: 1, commit: sha }));
+    assert.deepEqual(readCertCommit(certPath), { commit: sha });
+  });
+
+  it("reports a missing file instead of throwing", () => {
+    const read = readCertCommit(join(tmpdir(), "does-not-exist-cert.json"));
+    assert.match(read.error, /certification unreadable/);
+  });
+
+  it("reports malformed JSON", () => {
+    const dir = mkdtempSync(join(tmpdir(), "cert-drift-cert-"));
+    roots.push(dir);
+    const certPath = join(dir, "certification.json");
+    writeFileSync(certPath, "{not json");
+    assert.match(readCertCommit(certPath).error, /not valid JSON/);
+  });
+
+  it("rejects short or missing commit fields", () => {
+    const dir = mkdtempSync(join(tmpdir(), "cert-drift-cert-"));
+    roots.push(dir);
+    const certPath = join(dir, "certification.json");
+    writeFileSync(certPath, JSON.stringify({ commit: "abc123" }));
+    assert.match(readCertCommit(certPath).error, /40-hex/);
+    writeFileSync(certPath, JSON.stringify({ schema: 1 }));
+    assert.match(readCertCommit(certPath).error, /40-hex/);
+  });
+});
+
+describe("evaluateCommitDrift", () => {
+  it("matches when the certification commit equals head", () => {
+    const repoDir = makeRepo();
+    const sha = commitFiles(repoDir, "base", {
+      "packages/core/src/index.ts": "export {};\n",
+    });
+    const outcome = evaluateCommitDrift({
+      certCommit: sha,
+      headCommit: sha,
+      repoDir,
+    });
+    assert.equal(outcome.result, "match");
+    assert.deepEqual(outcome.driftPaths, []);
+  });
+
+  it("allows docs-only drift after the certified commit", () => {
+    const repoDir = makeRepo();
+    const certSha = commitFiles(repoDir, "certified tree", {
+      "packages/core/src/index.ts": "export {};\n",
+    });
+    const headSha = commitFiles(repoDir, "docs drift", {
+      "docs/promotion-notes.md": "# notes\n",
+      "packages/docs/guide.mdx": "guide\n",
+      "README.md": "# readme\n",
+      ".github/pull_request_template.md": "# template\n",
+    });
+    const outcome = evaluateCommitDrift({
+      certCommit: certSha,
+      headCommit: headSha,
+      repoDir,
+    });
+    assert.equal(outcome.result, "allowed-drift");
+    assert.equal(outcome.driftPaths.length, 4);
+    assert.deepEqual(outcome.disallowedPaths, []);
+  });
+
+  it("fails when drift touches source paths, listing the offenders", () => {
+    const repoDir = makeRepo();
+    const certSha = commitFiles(repoDir, "certified tree", {
+      "packages/core/src/index.ts": "export {};\n",
+    });
+    const headSha = commitFiles(repoDir, "mixed drift", {
+      "docs/ok.md": "fine\n",
+      "packages/core/src/runtime.ts": "export const x = 1;\n",
+    });
+    const outcome = evaluateCommitDrift({
+      certCommit: certSha,
+      headCommit: headSha,
+      repoDir,
+    });
+    assert.equal(outcome.result, "disallowed-drift");
+    assert.deepEqual(outcome.disallowedPaths, ["packages/core/src/runtime.ts"]);
+  });
+
+  it("fails when drift touches GitHub workflow or policy paths", () => {
+    const repoDir = makeRepo();
+    const certSha = commitFiles(repoDir, "certified tree", {
+      "packages/core/src/index.ts": "export {};\n",
+    });
+    const headSha = commitFiles(repoDir, "github policy drift", {
+      ".github/workflows/ci.yaml": "name: ci\n",
+      ".github/CODEOWNERS": "* @elizaOS/core\n",
+    });
+    const outcome = evaluateCommitDrift({
+      certCommit: certSha,
+      headCommit: headSha,
+      repoDir,
+    });
+    assert.equal(outcome.result, "disallowed-drift");
+    assert.deepEqual([...outcome.disallowedPaths].sort(), [
+      ".github/CODEOWNERS",
+      ".github/workflows/ci.yaml",
+    ]);
+  });
+
+  it("fails when drift swaps the trusted public key (the attack the base-key rule exists for)", () => {
+    const repoDir = makeRepo();
+    const certSha = commitFiles(repoDir, "certified tree", {
+      "packages/core/src/index.ts": "export {};\n",
+    });
+    const headSha = commitFiles(repoDir, "key swap", {
+      ".github/certification/certification-public-key.pem": "FAKE KEY\n",
+    });
+    const outcome = evaluateCommitDrift({
+      certCommit: certSha,
+      headCommit: headSha,
+      repoDir,
+    });
+    assert.equal(outcome.result, "disallowed-drift");
+    assert.deepEqual(outcome.disallowedPaths, [
+      ".github/certification/certification-public-key.pem",
+    ]);
+  });
+
+  it("fails when the certified commit is not an ancestor of head", () => {
+    const repoDir = makeRepo();
+    commitFiles(repoDir, "trunk base", { "a.txt": "a\n" });
+    git(repoDir, ["checkout", "-b", "side"]);
+    const sideSha = commitFiles(repoDir, "side work", { "side.txt": "s\n" });
+    git(repoDir, ["checkout", "main"]);
+    const headSha = commitFiles(repoDir, "trunk head", { "b.txt": "b\n" });
+    const outcome = evaluateCommitDrift({
+      certCommit: sideSha,
+      headCommit: headSha,
+      repoDir,
+    });
+    assert.equal(outcome.result, "not-ancestor");
+  });
+
+  it("fails when the certified commit does not exist in the repository", () => {
+    const repoDir = makeRepo();
+    const headSha = commitFiles(repoDir, "only commit", { "a.txt": "a\n" });
+    const outcome = evaluateCommitDrift({
+      certCommit: "f".repeat(40),
+      headCommit: headSha,
+      repoDir,
+    });
+    assert.equal(outcome.result, "cert-commit-unknown");
+  });
+});

--- a/scripts/certification/render-check-summary.mjs
+++ b/scripts/certification/render-check-summary.mjs
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+/**
+ * Render the certification-verify gate result for humans. Consumes the
+ * `certify:verify --json` report plus the commit-drift outcome and emits
+ * either GitHub step-summary markdown (`--mode summary`) or `::error`
+ * workflow-command annotations (`--mode annotations`). Display only — every
+ * pass/fail decision was already made by `certify:verify` and
+ * check-commit-drift.mjs; this file must never turn a red input green.
+ *
+ * The point of the summary is the trust handoff: the human merging to main
+ * sees WHO certified WHAT (reviewer identity is part of the signed payload
+ * precisely because a signature proves custody, not diligence).
+ */
+
+import { createHash, createPublicKey } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+/**
+ * Display-only fingerprint (first 16 hex of sha256 over the SPKI DER) so the
+ * summary names which trusted key was used. The canonical implementation the
+ * verifier trusts lives in packages/evidence/src/certify/keys.ts.
+ */
+export function fingerprintPem(pem) {
+  const der = createPublicKey(pem).export({ type: "spki", format: "der" });
+  return createHash("sha256").update(der).digest("hex").slice(0, 16);
+}
+
+function readJsonIfPossible(filePath) {
+  if (filePath === undefined) return undefined;
+  try {
+    return JSON.parse(readFileSync(filePath, "utf8"));
+  } catch {
+    return undefined;
+  }
+}
+
+function formatAge(createdAt, now = Date.now()) {
+  const createdMs = Date.parse(createdAt);
+  if (Number.isNaN(createdMs)) return "unparseable createdAt";
+  const hours = (now - createdMs) / 3_600_000;
+  return `${hours.toFixed(1)}h old`;
+}
+
+function escapeCell(text) {
+  return String(text).replace(/\|/g, "\\|").replace(/\r?\n/g, " ");
+}
+
+const VERDICT_ICONS = { pass: "✅", fail: "❌", waived: "⚠️" };
+
+export function renderSummary({ report, drift, trustedFingerprint, certPath }) {
+  const lines = ["## certification-verify", ""];
+  const verifyOk = report?.ok === true;
+  // No drift outcome supplied (e.g. the selftest's direct render) means drift
+  // was not part of this evaluation; the workflow always passes one.
+  const driftOk =
+    drift === undefined ||
+    drift.result === "match" ||
+    drift.result === "allowed-drift";
+  lines.push(
+    `**Result:** ${verifyOk && driftOk ? "✅ certification verified" : "❌ certification rejected"}`,
+    "",
+  );
+  lines.push(`- Certification: \`${certPath}\``);
+  lines.push(
+    `- Trusted public key (from the base branch): fingerprint \`${trustedFingerprint}\``,
+  );
+
+  const payload = report?.payload;
+  if (payload !== undefined) {
+    const reviewer = payload.reviewer ?? {};
+    const model = reviewer.model !== undefined ? ` (${reviewer.model})` : "";
+    lines.push(
+      `- Reviewer: **${reviewer.kind}:${reviewer.id}**${model}`,
+      `- Tier: \`${payload.tier}\` · Commit: \`${payload.commit}\` (\`${payload.branch}\` → \`${payload.baseRef}\`)`,
+      `- Created: \`${payload.createdAt}\` (${formatAge(payload.createdAt)})`,
+    );
+  } else {
+    lines.push(
+      "- Reviewer/tier/commit: unavailable — the certification payload did not parse",
+    );
+  }
+  if (report !== undefined) {
+    lines.push(
+      report.bundle !== undefined
+        ? `- Bundle: re-hashed ${report.bundle.artifactCount} artifact(s); rollup completeness re-derived`
+        : "- Bundle: not supplied to verifier — promotion gate requires `evidence/bundle` and should fail before this point",
+    );
+  }
+
+  if (drift !== undefined) {
+    lines.push("", "### Commit drift", "");
+    lines.push(
+      `- ${driftOk ? "✅" : "❌"} \`${drift.result}\`: ${drift.detail}`,
+    );
+    if ((drift.driftPaths ?? []).length > 0) {
+      lines.push("", "<details><summary>Drifted paths</summary>", "");
+      for (const entry of drift.driftPaths) {
+        const bad = (drift.disallowedPaths ?? []).includes(entry);
+        lines.push(`- ${bad ? "❌" : "✅"} \`${entry}\``);
+      }
+      lines.push("", "</details>");
+    }
+  }
+
+  if ((payload?.verdicts ?? []).length > 0) {
+    lines.push("", "### Signed verdicts", "");
+    lines.push("| Subject | Verdict | Notes |", "| --- | --- | --- |");
+    for (const verdict of payload.verdicts) {
+      lines.push(
+        `| \`${escapeCell(verdict.subject)}\` | ${VERDICT_ICONS[verdict.verdict] ?? ""} ${escapeCell(verdict.verdict)} | ${escapeCell(verdict.notes ?? "")} |`,
+      );
+    }
+  }
+
+  const failures = report?.failures ?? [];
+  if (failures.length > 0) {
+    lines.push("", "### Verification failures", "");
+    for (const failure of failures) {
+      lines.push(`- \`${failure.code}\`: ${failure.message}`);
+    }
+  }
+  if (report === undefined) {
+    lines.push(
+      "",
+      "### Verification failures",
+      "",
+      "- verify report missing — `certify:verify` did not produce output; see the job log",
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+export function renderAnnotations({ report, drift }) {
+  const lines = [];
+  for (const failure of report?.failures ?? []) {
+    lines.push(
+      `::error title=certification-verify (${failure.code})::${failure.message}`,
+    );
+  }
+  if (report === undefined) {
+    lines.push(
+      "::error title=certification-verify::certify:verify produced no report; see the job log",
+    );
+  }
+  if (
+    drift !== undefined &&
+    drift.result !== "match" &&
+    drift.result !== "allowed-drift"
+  ) {
+    lines.push(
+      `::error title=certification-verify (${drift.result})::${drift.detail}`,
+    );
+  }
+  return lines.join("\n");
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const value = () => {
+      const next = argv[index + 1];
+      if (next === undefined) {
+        console.error(`${flag} requires a value`);
+        process.exit(2);
+      }
+      index += 1;
+      return next;
+    };
+    if (flag === "--report") args.reportPath = value();
+    else if (flag === "--drift") args.driftPath = value();
+    else if (flag === "--pubkey") args.pubkeyPath = value();
+    else if (flag === "--cert-path") args.certPath = value();
+    else if (flag === "--mode") args.mode = value();
+    else {
+      console.error(`unknown argument: ${flag}`);
+      process.exit(2);
+    }
+  }
+  if (args.mode !== "summary" && args.mode !== "annotations") {
+    console.error(
+      "Usage: render-check-summary.mjs --mode <summary|annotations> --report <verify.json> --drift <drift.json> --pubkey <pem> --cert-path <display path>",
+    );
+    process.exit(2);
+  }
+
+  const report = readJsonIfPossible(args.reportPath);
+  const drift = readJsonIfPossible(args.driftPath);
+  let trustedFingerprint = "unavailable";
+  if (args.pubkeyPath !== undefined) {
+    try {
+      trustedFingerprint = fingerprintPem(
+        readFileSync(args.pubkeyPath, "utf8"),
+      );
+    } catch {
+      trustedFingerprint = "unreadable public key";
+    }
+  }
+
+  const output =
+    args.mode === "summary"
+      ? renderSummary({
+          report,
+          drift,
+          trustedFingerprint,
+          certPath: args.certPath ?? "certification.json",
+        })
+      : renderAnnotations({ report, drift });
+  if (output.length > 0) process.stdout.write(`${output}\n`);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main();
+}

--- a/scripts/certification/selftest.mjs
+++ b/scripts/certification/selftest.mjs
@@ -1,0 +1,345 @@
+#!/usr/bin/env node
+/**
+ * End-to-end self-test of the certification gate plumbing, used by the
+ * `certification-verify-selftest` CI job and runnable locally. It exercises
+ * the REAL CLIs (`certify:keygen` → `bundle:create` → `certify:rollup` →
+ * `certify:sign` → `certify:verify`) against a throwaway keypair and a
+ * throwaway fixture repo — no reimplementation of any verification logic —
+ * and asserts:
+ *
+ *   1. a freshly signed certification verifies green (exit 0, ok:true),
+ *   2. a tampered payload fails `bad-signature`,
+ *   3. a missing committed bundle fails `bundle-tampered`,
+ *   4. a tampered bundle artifact fails `bundle-tampered`,
+ *   5. verification against a different trusted key fails `wrong-key`,
+ *   6. an out-of-window certification fails `stale`,
+ *   7. the commit-drift helper passes on match and rejects source drift,
+ *   8. the summary renderer produces markdown from the real report.
+ *
+ * The throwaway private key exists only in this process's memory and child
+ * env (ELIZA_CERT_SIGNING_KEY) — never on disk — matching the custody rules
+ * in .github/certification/README.md.
+ */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  appendFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const EVIDENCE_PKG = join(REPO_ROOT, "packages", "evidence");
+
+const failures = [];
+function step(name, ok, detail) {
+  const marker = ok ? "ok  " : "FAIL";
+  console.log(`[selftest] ${marker} ${name}${detail ? ` — ${detail}` : ""}`);
+  if (!ok) failures.push(name);
+}
+
+function runCli(scriptName, args, { env = {}, expectExit = 0 } = {}) {
+  const result = spawnSync(
+    "bun",
+    ["run", "--cwd", EVIDENCE_PKG, scriptName, "--", ...args],
+    { encoding: "utf8", env: { ...process.env, ...env } },
+  );
+  if (result.error) throw result.error;
+  const label = `${scriptName} ${args.join(" ")}`;
+  console.log(`[selftest] $ bun run --cwd packages/evidence ${label}`);
+  if (result.status !== expectExit) {
+    console.log(result.stdout);
+    console.error(result.stderr);
+  }
+  return result;
+}
+
+function failureCodes(stdout) {
+  return JSON.parse(stdout).failures.map((failure) => failure.code);
+}
+
+function git(cwd, args) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+const work = mkdtempSync(join(tmpdir(), "certification-selftest-"));
+try {
+  // -- keygen: throwaway trusted keypair + a second (wrong) keypair ---------
+  const pubkeyPath = join(work, "trusted-public-key.pem");
+  const keygen = runCli("certify:keygen", [
+    "--print-private-key",
+    "--pubkey-out",
+    pubkeyPath,
+  ]);
+  const privatePem = keygen.stdout.slice(
+    keygen.stdout.indexOf("-----BEGIN PRIVATE KEY-----"),
+  );
+  step("keygen produced a private key", privatePem.includes("PRIVATE KEY"));
+  const signingEnv = {
+    ELIZA_CERT_SIGNING_KEY: Buffer.from(privatePem).toString("base64"),
+  };
+  const wrongPubkeyPath = join(work, "wrong-public-key.pem");
+  runCli("certify:keygen", ["--pubkey-out", wrongPubkeyPath]);
+
+  // -- fixture repo: one lane result the e2e-recordings silo will ingest ----
+  const fixtureRepo = join(work, "fixture-repo");
+  mkdirSync(join(fixtureRepo, "e2e-recordings"), { recursive: true });
+  writeFileSync(
+    join(fixtureRepo, "e2e-recordings", "result.json"),
+    JSON.stringify({ passed: 3, failed: 0, skipped: 0 }),
+  );
+  writeFileSync(join(fixtureRepo, "src.ts"), "export {};\n");
+  git(fixtureRepo, ["init", "-b", "main"]);
+  git(fixtureRepo, ["config", "user.email", "selftest@example.invalid"]);
+  git(fixtureRepo, ["config", "user.name", "certification selftest"]);
+  git(fixtureRepo, ["add", "-A"]);
+  git(fixtureRepo, ["commit", "-m", "fixture tree"]);
+  const fixtureCommit = git(fixtureRepo, ["rev-parse", "HEAD"]);
+
+  // -- bundle + rollup + sign ------------------------------------------------
+  const runsDir = join(work, "runs");
+  const create = runCli("bundle:create", [
+    "--tier",
+    "full",
+    "--repo-root",
+    fixtureRepo,
+    "--out",
+    runsDir,
+  ]);
+  step("bundle:create succeeded", create.status === 0);
+  const bundleDir = join(runsDir, readdirSync(runsDir)[0]);
+
+  const verdictsPath = join(work, "verdicts.json");
+  const rollup = runCli("certify:rollup", [
+    "--bundle",
+    bundleDir,
+    "--out",
+    verdictsPath,
+  ]);
+  step("certify:rollup succeeded", rollup.status === 0);
+
+  const sign = runCli(
+    "certify:sign",
+    [
+      "--bundle",
+      bundleDir,
+      "--verdicts",
+      verdictsPath,
+      "--reviewer-id",
+      "certification-selftest",
+      "--reviewer-kind",
+      "agent",
+    ],
+    { env: signingEnv },
+  );
+  step("certify:sign succeeded", sign.status === 0);
+  const certPath = join(bundleDir, "certification.json");
+
+  const baseVerifyArgs = [
+    "--cert",
+    certPath,
+    "--pubkey",
+    pubkeyPath,
+    "--expected-commit",
+    fixtureCommit,
+    "--max-age-hours",
+    "72",
+    "--required-tier",
+    "full",
+    "--bundle",
+    bundleDir,
+    "--json",
+  ];
+
+  // -- 1. green path ----------------------------------------------------------
+  const green = runCli("certify:verify", baseVerifyArgs);
+  step("valid certification verifies (exit 0)", green.status === 0);
+  step("report.ok is true", JSON.parse(green.stdout).ok === true);
+  const greenReportPath = join(work, "verify-report.json");
+  writeFileSync(greenReportPath, green.stdout);
+
+  // -- 2. tampered payload → bad-signature ------------------------------------
+  const tamperedCertPath = join(work, "tampered-certification.json");
+  const cert = JSON.parse(readFileSync(certPath, "utf8"));
+  writeFileSync(
+    tamperedCertPath,
+    JSON.stringify({ ...cert, branch: "attacker-branch" }),
+  );
+  const tampered = runCli(
+    "certify:verify",
+    ["--cert", tamperedCertPath, "--pubkey", pubkeyPath, "--json"],
+    { expectExit: 1 },
+  );
+  step("tampered payload exits 1", tampered.status === 1);
+  step(
+    "tampered payload reports bad-signature",
+    failureCodes(tampered.stdout).includes("bad-signature"),
+    failureCodes(tampered.stdout).join(","),
+  );
+
+  // -- 3. missing committed bundle → bundle-tampered ---------------------------
+  const missingBundle = runCli(
+    "certify:verify",
+    [
+      "--cert",
+      certPath,
+      "--pubkey",
+      pubkeyPath,
+      "--expected-commit",
+      fixtureCommit,
+      "--max-age-hours",
+      "72",
+      "--required-tier",
+      "full",
+      "--bundle",
+      join(work, "missing-bundle"),
+      "--json",
+    ],
+    { expectExit: 1 },
+  );
+  step("missing committed bundle exits 1", missingBundle.status === 1);
+  step(
+    "missing committed bundle reports bundle-tampered",
+    failureCodes(missingBundle.stdout).includes("bundle-tampered"),
+    failureCodes(missingBundle.stdout).join(","),
+  );
+
+  // -- 4. tampered bundle artifact → bundle-tampered ---------------------------
+  appendFileSync(join(bundleDir, "lanes", "e2e", "result.json"), " ");
+  const bundleTampered = runCli("certify:verify", baseVerifyArgs, {
+    expectExit: 1,
+  });
+  step("tampered bundle exits 1", bundleTampered.status === 1);
+  step(
+    "tampered bundle reports bundle-tampered",
+    failureCodes(bundleTampered.stdout).includes("bundle-tampered"),
+    failureCodes(bundleTampered.stdout).join(","),
+  );
+
+  // -- 5. different trusted key → wrong-key ------------------------------------
+  const wrongKey = runCli(
+    "certify:verify",
+    ["--cert", certPath, "--pubkey", wrongPubkeyPath, "--json"],
+    { expectExit: 1 },
+  );
+  step("wrong trusted key exits 1", wrongKey.status === 1);
+  step(
+    "wrong trusted key reports wrong-key",
+    failureCodes(wrongKey.stdout).includes("wrong-key"),
+    failureCodes(wrongKey.stdout).join(","),
+  );
+
+  // -- 6. out-of-window certification → stale ----------------------------------
+  await new Promise((resolveSleep) => setTimeout(resolveSleep, 1500));
+  const stale = runCli(
+    "certify:verify",
+    [
+      "--cert",
+      certPath,
+      "--pubkey",
+      pubkeyPath,
+      // ~0.36s window: the 1.5s sleep above guarantees the cert is outside it.
+      "--max-age-hours",
+      "0.0001",
+      "--json",
+    ],
+    { expectExit: 1 },
+  );
+  step("out-of-window certification exits 1", stale.status === 1);
+  step(
+    "out-of-window certification reports stale",
+    failureCodes(stale.stdout).includes("stale"),
+    failureCodes(stale.stdout).join(","),
+  );
+
+  // -- 7. drift helper: match passes, source drift fails ------------------------
+  const driftScript = join(
+    REPO_ROOT,
+    "scripts",
+    "certification",
+    "check-commit-drift.mjs",
+  );
+  const driftMatch = spawnSync(
+    "node",
+    [
+      driftScript,
+      "--cert",
+      certPath,
+      "--head",
+      fixtureCommit,
+      "--repo",
+      fixtureRepo,
+    ],
+    { encoding: "utf8" },
+  );
+  step("drift helper passes on commit match", driftMatch.status === 0);
+
+  writeFileSync(join(fixtureRepo, "src.ts"), "export const drift = 1;\n");
+  git(fixtureRepo, ["add", "-A"]);
+  git(fixtureRepo, ["commit", "-m", "source drift"]);
+  const driftedHead = git(fixtureRepo, ["rev-parse", "HEAD"]);
+  const driftBad = spawnSync(
+    "node",
+    [
+      driftScript,
+      "--cert",
+      certPath,
+      "--head",
+      driftedHead,
+      "--repo",
+      fixtureRepo,
+    ],
+    { encoding: "utf8" },
+  );
+  step("drift helper rejects source drift", driftBad.status === 1);
+
+  // -- 8. renderer produces markdown from the real report -----------------------
+  const renderScript = join(
+    REPO_ROOT,
+    "scripts",
+    "certification",
+    "render-check-summary.mjs",
+  );
+  const summary = spawnSync(
+    "node",
+    [
+      renderScript,
+      "--mode",
+      "summary",
+      "--report",
+      greenReportPath,
+      "--pubkey",
+      pubkeyPath,
+      "--cert-path",
+      "selftest certification.json",
+    ],
+    { encoding: "utf8" },
+  );
+  step(
+    "renderer emits the verdict table",
+    summary.status === 0 &&
+      summary.stdout.includes("certification verified") &&
+      summary.stdout.includes("lane:e2e"),
+  );
+  console.log("\n[selftest] rendered summary preview:\n");
+  console.log(summary.stdout);
+} finally {
+  rmSync(work, { recursive: true, force: true });
+}
+
+if (failures.length > 0) {
+  console.error(`\n[selftest] FAILED: ${failures.join("; ")}`);
+  process.exit(1);
+}
+console.log("\n[selftest] all certification gate plumbing checks passed");


### PR DESCRIPTION
Part of #14547 and epic #14541. This PR adds the develop-to-main certification verification gate; it should not be treated as fully operational until the trusted public key lands from a custodian-generated keypair and main branch protection requires `verify-certification`.

## Summary

- Adds `.github/workflows/certification-verify.yml`.
- `verify-certification` runs on non-draft PRs targeting `main` and reads the trusted Ed25519 public key from the base branch, never the PR head.
- Promotion branches must commit `certification.json` at repo root and the signed evidence bundle at `evidence/bundle/`; the job always passes `--bundle evidence/bundle` to `certify:verify` so artifact integrity, mechanical rollup completeness, and signed evidence-path membership are re-derived from the committed bundle.
- Adds `scripts/certification/check-commit-drift.mjs` so a certification commit must equal the PR head or be an ancestor with only docs/template drift plus signed certification artifacts. Source, workflow, policy, or config drift forces recertification.
- Adds `render-check-summary.mjs` for human-readable gate summaries and annotations.
- Adds `selftest.mjs`, which exercises the real CLIs: keygen -> bundle -> rollup -> sign -> verify -> tamper checks.
- Documents branch-protection wiring, bootstrap, remediation, and break-glass behavior in `.github/certification/README.md`.

## Current boundary

- #14650 is blocked/draft because its private key was described as having transited agent reports/session transcript. A clean custodian-generated keypair is still required before the gate can be trusted on `main`.
- This PR targets `develop`, so the main-only `verify-certification` job is expected to skip here. The relevant CI job for this PR is `certification-verify-selftest`.
- Main branch protection still needs an admin to add required status check `verify-certification` after the workflow lands.

## Verification

- `node --check scripts/certification/check-commit-drift.mjs scripts/certification/render-check-summary.mjs scripts/certification/selftest.mjs` -> passed.
- `node --test scripts/certification/check-commit-drift.test.mjs` -> 35 tests passed.
- `actionlint .github/workflows/certification-verify.yml` -> passed.
- `node scripts/certification/selftest.mjs` -> passed: valid cert verifies; tampered payload, tampered bundle, wrong key, stale cert, and source drift all fail.
- `git diff --check` -> passed.

## Evidence

Selftest excerpt from current cleaned head:

```text
[selftest] ok   valid certification verifies (exit 0)
[selftest] ok   report.ok is true
[selftest] ok   tampered payload exits 1
[selftest] ok   tampered payload reports bad-signature — bad-signature
[selftest] ok   tampered bundle exits 1
[selftest] ok   tampered bundle reports bundle-tampered — bundle-tampered
[selftest] ok   wrong trusted key exits 1
[selftest] ok   wrong trusted key reports wrong-key — wrong-key
[selftest] ok   out-of-window certification exits 1
[selftest] ok   out-of-window certification reports stale — stale
[selftest] ok   drift helper passes on commit match
[selftest] ok   drift helper rejects source drift
[selftest] ok   renderer emits the verdict table
[selftest] all certification gate plumbing checks passed
```

Commit-drift tests use real git fixture repos and cover docs drift, source drift, workflow/policy drift, key-swap drift, non-ancestor commits, and unknown certified commits.

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - CI workflow + Node scripts only; no UI surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - CI workflow + Node scripts only; rendered check summary is text output covered by selftest`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no user-facing flow; the behavior matrix is covered by the CLI selftest transcript`.

<!-- evidence-row:backend-logs -->
- [x] N/A - no backend service runtime path changed; local selftest output from the real certify CLIs is summarized in Evidence Details.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend runtime path changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model/provider/prompt/agent behavior changed`.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - no separate external domain artifact upload; the checked domain artifacts are the check-commit-drift test suite and certification selftest outputs summarized in Evidence Details.

