### PR TITLE
feat(core): add EXPERIENCE update/delete action

### DIFF
--- a/packages/app/test/character-experience-action-surface.test.ts
+++ b/packages/app/test/character-experience-action-surface.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Static guard for the Character Experience view→action contract: the renderer's
+ * update/delete controls must have a registered semantic EXPERIENCE action twin.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "../../..");
+
+function readRepoFiles(files: readonly string[]): string {
+  const missing = files.filter(
+    (file) => !existsSync(path.join(REPO_ROOT, file)),
+  );
+  expect(missing, "owner files must exist").toEqual([]);
+  return files
+    .map((file) => readFileSync(path.join(REPO_ROOT, file), "utf8"))
+    .join("\n");
+}
+
+describe("Character Experience action surface", () => {
+  it("keeps view update/delete mutations backed by the EXPERIENCE action", () => {
+    const source = readRepoFiles([
+      "packages/ui/src/components/character/CharacterExperienceView.tsx",
+      "packages/ui/src/components/character/CharacterExperienceWorkspace.tsx",
+      "packages/core/src/features/advanced-capabilities/experience/actions/manage-experience.ts",
+      "packages/core/src/features/advanced-capabilities/index.ts",
+    ]);
+
+    expect(source).toContain("client.updateExperience(");
+    expect(source).toContain("client.deleteExperience(");
+    expect(source).toContain('const EXPERIENCE = "EXPERIENCE"');
+    expect(source).toContain("name: EXPERIENCE");
+    expect(source).toContain("withCanonicalActionDocs(manageExperienceAction)");
+  });
+});

--- a/packages/core/src/features/advanced-capabilities/experience/actions/manage-experience.test.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/actions/manage-experience.test.ts
@@ -1,0 +1,357 @@
+/**
+ * EXPERIENCE action unit tests: confirm gating, id/score/field validation,
+ * update and delete against a map-backed fake EXPERIENCE service, and the
+ * delete-by-query strong-match/ambiguity contract. Deterministic — no model,
+ * no database; the fake service records exactly the calls the handler makes.
+ */
+import { describe, expect, it } from "vitest";
+import type {
+	ActionResult,
+	HandlerCallback,
+	HandlerOptions,
+} from "../../../../types/components.ts";
+import type { Memory } from "../../../../types/memory.ts";
+import type { UUID } from "../../../../types/primitives.ts";
+import type { IAgentRuntime } from "../../../../types/runtime.ts";
+import { type Experience, ExperienceType, OutcomeType } from "../types.ts";
+import { manageExperienceAction } from "./manage-experience.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000a1" as UUID;
+const EXPERIENCE_ID_1 = "00000000-0000-0000-0000-0000000000e1" as UUID;
+const EXPERIENCE_ID_2 = "00000000-0000-0000-0000-0000000000e2" as UUID;
+const MISSING_ID = "00000000-0000-0000-0000-0000000000ff" as UUID;
+
+function experience(seed: Partial<Experience> & { id: UUID }): Experience {
+	return {
+		agentId: AGENT_ID,
+		type: ExperienceType.LEARNING,
+		outcome: OutcomeType.NEUTRAL,
+		context: "",
+		action: "",
+		result: "",
+		learning: "",
+		tags: [],
+		domain: "general",
+		keywords: [],
+		associatedEntityIds: [],
+		confidence: 0.5,
+		importance: 0.5,
+		createdAt: 1,
+		updatedAt: 1,
+		accessCount: 0,
+		...seed,
+	};
+}
+
+function makeRuntime(seedExperiences: Experience[] = []) {
+	const store = new Map<string, Experience>(
+		seedExperiences.map((e) => [e.id, e]),
+	);
+	const updateCalls: Array<{ id: UUID; updates: Partial<Experience> }> = [];
+	const deleteCalls: UUID[] = [];
+	const service = {
+		updateExperience: async (id: UUID, updates: Partial<Experience>) => {
+			updateCalls.push({ id, updates });
+			const existing = store.get(id);
+			if (!existing) return null;
+			const next = { ...existing, ...updates, updatedAt: 2 };
+			store.set(id, next);
+			return next;
+		},
+		deleteExperience: async (id: UUID) => {
+			deleteCalls.push(id);
+			return store.delete(id);
+		},
+		queryExperiences: async () => Array.from(store.values()),
+	};
+	const runtime = {
+		agentId: AGENT_ID,
+		getService: (name: string) => (name === "EXPERIENCE" ? service : null),
+	} as unknown as IAgentRuntime;
+	return { runtime, store, updateCalls, deleteCalls };
+}
+
+function message(text = ""): Memory {
+	return {
+		entityId: AGENT_ID,
+		roomId: AGENT_ID,
+		content: { text, source: "test" },
+	} as Memory;
+}
+
+async function invoke(
+	runtime: IAgentRuntime,
+	parameters: Record<string, unknown>,
+	callback?: HandlerCallback,
+): Promise<ActionResult> {
+	const result = await manageExperienceAction.handler(
+		runtime,
+		message(),
+		undefined,
+		{ parameters } as HandlerOptions,
+		callback,
+	);
+	if (!result) throw new Error("handler returned no result");
+	return result;
+}
+
+describe("EXPERIENCE action shape", () => {
+	it("is OWNER-gated with an action discriminator and confirm parameter", () => {
+		expect(manageExperienceAction.name).toBe("EXPERIENCE");
+		expect(manageExperienceAction.roleGate).toEqual({ minRole: "OWNER" });
+		const names = (manageExperienceAction.parameters ?? []).map((p) => p.name);
+		expect(names).toContain("action");
+		expect(names).toContain("experienceId");
+		expect(names).toContain("confirm");
+	});
+});
+
+describe("EXPERIENCE validate", () => {
+	it("is unavailable without the EXPERIENCE service", async () => {
+		const runtime = {
+			getService: () => null,
+		} as unknown as IAgentRuntime;
+		expect(
+			await manageExperienceAction.validate(
+				runtime,
+				message("delete that experience"),
+			),
+		).toBe(false);
+	});
+
+	it("validates on structured params or mutation intent text", async () => {
+		const { runtime } = makeRuntime();
+		expect(
+			await manageExperienceAction.validate(runtime, message(), undefined, {
+				parameters: { action: "delete" },
+			} as HandlerOptions),
+		).toBe(true);
+		expect(
+			await manageExperienceAction.validate(
+				runtime,
+				message("forget that experience about docker builds"),
+			),
+		).toBe(true);
+		expect(
+			await manageExperienceAction.validate(
+				runtime,
+				message("what's the weather like"),
+			),
+		).toBe(false);
+	});
+});
+
+describe("EXPERIENCE confirm gating", () => {
+	it("refuses update and delete without confirm:true and touches nothing", async () => {
+		const { runtime, updateCalls, deleteCalls } = makeRuntime([
+			experience({ id: EXPERIENCE_ID_1, learning: "keep me" }),
+		]);
+		for (const action of ["update", "delete"] as const) {
+			const result = await invoke(runtime, {
+				action,
+				experienceId: EXPERIENCE_ID_1,
+				learning: "changed",
+			});
+			expect(result.success).toBe(false);
+			expect(result.data?.error).toBe("EXPERIENCE_CONFIRMATION_REQUIRED");
+		}
+		// A stringly "true" must not pass the strict-boolean bar.
+		const stringConfirm = await invoke(runtime, {
+			action: "delete",
+			experienceId: EXPERIENCE_ID_1,
+			confirm: "true",
+		});
+		expect(stringConfirm.success).toBe(false);
+		expect(updateCalls).toHaveLength(0);
+		expect(deleteCalls).toHaveLength(0);
+	});
+
+	it("rejects a missing or unknown op", async () => {
+		const { runtime } = makeRuntime();
+		const result = await invoke(runtime, { confirm: true });
+		expect(result.success).toBe(false);
+		expect(result.data?.error).toBe("EXPERIENCE_INVALID_OP");
+	});
+});
+
+describe("EXPERIENCE update", () => {
+	it("updates only the provided fields through the service", async () => {
+		const { runtime, updateCalls } = makeRuntime([
+			experience({
+				id: EXPERIENCE_ID_1,
+				learning: "old learning",
+				tags: ["old"],
+			}),
+		]);
+		const result = await invoke(runtime, {
+			action: "update",
+			experienceId: EXPERIENCE_ID_1,
+			learning: "new learning",
+			confidence: 0.9,
+			confirm: true,
+		});
+		expect(result.success).toBe(true);
+		expect(updateCalls).toEqual([
+			{
+				id: EXPERIENCE_ID_1,
+				updates: { learning: "new learning", confidence: 0.9 },
+			},
+		]);
+		expect(result.values?.experienceId).toBe(EXPERIENCE_ID_1);
+	});
+
+	it("normalizes comma-separated tags like the view's edit form", async () => {
+		const { runtime, updateCalls } = makeRuntime([
+			experience({ id: EXPERIENCE_ID_1, learning: "x" }),
+		]);
+		const result = await invoke(runtime, {
+			action: "update",
+			experienceId: EXPERIENCE_ID_1,
+			tags: "alpha, beta , ,gamma",
+			confirm: true,
+		});
+		expect(result.success).toBe(true);
+		expect(updateCalls[0]?.updates).toEqual({
+			tags: ["alpha", "beta", "gamma"],
+		});
+	});
+
+	it("rejects invalid ids, out-of-range scores, and empty updates", async () => {
+		const { runtime, updateCalls } = makeRuntime([
+			experience({ id: EXPERIENCE_ID_1, learning: "x" }),
+		]);
+		const badId = await invoke(runtime, {
+			action: "update",
+			experienceId: "not-a-uuid",
+			learning: "y",
+			confirm: true,
+		});
+		expect(badId.data?.error).toBe("EXPERIENCE_INVALID_ID");
+
+		const badScore = await invoke(runtime, {
+			action: "update",
+			experienceId: EXPERIENCE_ID_1,
+			importance: 1.5,
+			confirm: true,
+		});
+		expect(badScore.data?.error).toBe("EXPERIENCE_INVALID_SCORE");
+
+		const empty = await invoke(runtime, {
+			action: "update",
+			experienceId: EXPERIENCE_ID_1,
+			confirm: true,
+		});
+		expect(empty.data?.error).toBe("EXPERIENCE_NO_FIELDS");
+		expect(updateCalls).toHaveLength(0);
+	});
+
+	it("surfaces a not-found update as a failure", async () => {
+		const { runtime } = makeRuntime();
+		const result = await invoke(runtime, {
+			action: "update",
+			experienceId: MISSING_ID,
+			learning: "y",
+			confirm: true,
+		});
+		expect(result.success).toBe(false);
+		expect(result.data?.error).toBe("EXPERIENCE_NOT_FOUND");
+	});
+});
+
+describe("EXPERIENCE delete", () => {
+	it("deletes by id and reports the removal through the callback", async () => {
+		const { runtime, store, deleteCalls } = makeRuntime([
+			experience({ id: EXPERIENCE_ID_1, learning: "obsolete" }),
+		]);
+		const callbackTexts: string[] = [];
+		const callback: HandlerCallback = async (content) => {
+			callbackTexts.push(content.text ?? "");
+			return [];
+		};
+		const result = await invoke(
+			runtime,
+			{ action: "delete", experienceId: EXPERIENCE_ID_1, confirm: true },
+			callback,
+		);
+		expect(result.success).toBe(true);
+		expect(deleteCalls).toEqual([EXPERIENCE_ID_1]);
+		expect(store.has(EXPERIENCE_ID_1)).toBe(false);
+		expect(callbackTexts.join(" ")).toContain(EXPERIENCE_ID_1);
+	});
+
+	it("requires an id or query and surfaces not-found deletes", async () => {
+		const { runtime } = makeRuntime();
+		const missing = await invoke(runtime, { action: "delete", confirm: true });
+		expect(missing.data?.error).toBe("EXPERIENCE_MISSING_ID");
+
+		const notFound = await invoke(runtime, {
+			action: "delete",
+			experienceId: MISSING_ID,
+			confirm: true,
+		});
+		expect(notFound.data?.error).toBe("EXPERIENCE_NOT_FOUND");
+	});
+
+	it("deletes the single strong query match", async () => {
+		const { runtime, store } = makeRuntime([
+			experience({
+				id: EXPERIENCE_ID_1,
+				learning: "docker builds need buildkit enabled",
+				tags: ["docker"],
+			}),
+			experience({
+				id: EXPERIENCE_ID_2,
+				learning: "users prefer short answers",
+			}),
+		]);
+		const result = await invoke(runtime, {
+			action: "delete",
+			query: "docker builds",
+			confirm: true,
+		});
+		expect(result.success).toBe(true);
+		expect(store.has(EXPERIENCE_ID_1)).toBe(false);
+		expect(store.has(EXPERIENCE_ID_2)).toBe(true);
+	});
+
+	it("refuses an ambiguous query and lists candidate ids without deleting", async () => {
+		const { runtime, store, deleteCalls } = makeRuntime([
+			experience({
+				id: EXPERIENCE_ID_1,
+				learning: "docker builds need buildkit",
+			}),
+			experience({
+				id: EXPERIENCE_ID_2,
+				learning: "docker builds are slow on arm",
+			}),
+		]);
+		const result = await invoke(runtime, {
+			action: "delete",
+			query: "docker builds",
+			confirm: true,
+		});
+		expect(result.success).toBe(false);
+		expect(result.data?.error).toBe("EXPERIENCE_AMBIGUOUS_QUERY");
+		expect(result.text).toContain(EXPERIENCE_ID_1);
+		expect(result.text).toContain(EXPERIENCE_ID_2);
+		expect(deleteCalls).toHaveLength(0);
+		expect(store.size).toBe(2);
+	});
+
+	it("reports no match when the query only weakly matches", async () => {
+		const { runtime, store } = makeRuntime([
+			experience({
+				id: EXPERIENCE_ID_1,
+				learning: "docker builds need buildkit",
+			}),
+		]);
+		const result = await invoke(runtime, {
+			action: "delete",
+			query: "docker kubernetes helm",
+			confirm: true,
+		});
+		expect(result.success).toBe(false);
+		expect(result.data?.error).toBe("EXPERIENCE_NOT_FOUND");
+		expect(store.size).toBe(1);
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/experience/actions/manage-experience.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/actions/manage-experience.ts
@@ -1,0 +1,482 @@
+/**
+ * The EXPERIENCE action: model-driven update/delete over the agent's stored
+ * experience records, through the same EXPERIENCE service use cases the
+ * Character → Experience view drives via PATCH/DELETE
+ * `/api/character/experiences/:id` (#14623). SEARCH_EXPERIENCES owns reads;
+ * this action owns the two mutations, so chat/voice can edit or forget a
+ * learned experience without a raw selector.
+ *
+ * Both ops are destructive — update overwrites and re-embeds the record,
+ * delete removes it from the graph — so both refuse without `confirm:true`,
+ * mirroring the MEMORY update/delete contract
+ * (`packages/agent/src/actions/memories.ts`). Delete accepts a `query`
+ * fallback for "forget that experience about X": it resolves through the
+ * service's own search, requires a strong whole-phrase/all-terms match, and
+ * refuses ambiguous matches by listing candidate ids instead of guessing.
+ */
+import { logger } from "../../../../logger.ts";
+import type {
+	Action,
+	ActionExample,
+	ActionResult,
+	HandlerCallback,
+	HandlerOptions,
+} from "../../../../types/components.ts";
+import type { Memory } from "../../../../types/memory.ts";
+import type { IAgentRuntime } from "../../../../types/runtime.ts";
+import type { State } from "../../../../types/state.ts";
+import { hasActionContext } from "../../../../utils/action-validation.ts";
+import { validateUuid } from "../../../../utils.ts";
+import type { ExperienceService } from "../service.ts";
+import type { Experience } from "../types.ts";
+
+const EXPERIENCE = "EXPERIENCE";
+
+const EXPERIENCE_OPS = ["update", "delete"] as const;
+type ExperienceOp = (typeof EXPERIENCE_OPS)[number];
+
+function getActionParams(
+	options: HandlerOptions | undefined,
+): Record<string, unknown> {
+	const direct =
+		options && typeof options === "object"
+			? (options as Record<string, unknown>)
+			: {};
+	const parameters =
+		direct.parameters && typeof direct.parameters === "object"
+			? (direct.parameters as Record<string, unknown>)
+			: {};
+	return { ...direct, ...parameters };
+}
+
+function readStringParam(
+	params: Record<string, unknown>,
+	...keys: string[]
+): string | undefined {
+	for (const key of keys) {
+		const value = params[key];
+		if (typeof value === "string" && value.trim()) {
+			return value.trim();
+		}
+	}
+	return undefined;
+}
+
+function readScoreParam(
+	params: Record<string, unknown>,
+	key: string,
+): { value?: number; error?: string } {
+	const raw = params[key];
+	if (raw === undefined || raw === null) return {};
+	const parsed =
+		typeof raw === "number"
+			? raw
+			: typeof raw === "string" && raw.trim()
+				? Number(raw)
+				: Number.NaN;
+	if (!Number.isFinite(parsed)) {
+		return { error: `${key} must be a number between 0 and 1.` };
+	}
+	if (parsed < 0 || parsed > 1) {
+		return { error: `${key} must be between 0 and 1.` };
+	}
+	return { value: parsed };
+}
+
+/**
+ * Tags arrive either as a JSON array (planner) or as one comma-separated
+ * string (the same shape the view's edit form accepts before splitting).
+ */
+function readTagsParam(params: Record<string, unknown>): string[] | undefined {
+	const raw = params.tags;
+	if (raw === undefined || raw === null) return undefined;
+	const items = Array.isArray(raw)
+		? raw
+		: typeof raw === "string"
+			? raw.split(",")
+			: null;
+	if (!items) return undefined;
+	return items
+		.filter((item): item is string => typeof item === "string")
+		.map((item) => item.trim())
+		.filter(Boolean);
+}
+
+function normalizeOp(
+	params: Record<string, unknown>,
+): ExperienceOp | undefined {
+	const candidate = readStringParam(
+		params,
+		"action",
+		"subaction",
+		"op",
+	)?.toLowerCase();
+	return candidate && (EXPERIENCE_OPS as readonly string[]).includes(candidate)
+		? (candidate as ExperienceOp)
+		: undefined;
+}
+
+function fail(text: string, error: string): ActionResult {
+	return { success: false, text, data: { error } };
+}
+
+/**
+ * Same strong-match bar MEMORY's delete-by-query uses: 1 for a whole-phrase
+ * hit, plus the fraction of query terms present. Deletion requires >= 1
+ * (whole phrase, or every term) — search-style partial matches must not be
+ * enough to destroy a record.
+ */
+function scoreText(text: string, query: string): number {
+	const t = text.toLowerCase();
+	const q = query.toLowerCase();
+	if (!t || !q) return 0;
+	const terms = q
+		.split(/\s+/)
+		.map((s) => s.trim())
+		.filter((s) => s.length >= 2);
+	const whole = t.includes(q) ? 1 : 0;
+	if (terms.length === 0) return whole;
+	let matches = 0;
+	for (const term of terms) if (t.includes(term)) matches += 1;
+	return whole + matches / terms.length;
+}
+
+function experienceMatchText(experience: Experience): string {
+	return [
+		experience.learning,
+		experience.context,
+		experience.result,
+		...experience.tags,
+	]
+		.filter(Boolean)
+		.join("\n");
+}
+
+async function doUpdate(
+	experienceService: ExperienceService,
+	params: Record<string, unknown>,
+): Promise<ActionResult> {
+	const rawId = readStringParam(params, "experienceId", "id");
+	const experienceId = validateUuid(rawId);
+	if (!experienceId) {
+		return fail(
+			"experienceId is required and must be a valid UUID. Use SEARCH_EXPERIENCES to find the id first.",
+			"EXPERIENCE_INVALID_ID",
+		);
+	}
+
+	const updates: Partial<Experience> = {};
+	const learning = readStringParam(params, "learning");
+	if (learning) updates.learning = learning;
+	const importance = readScoreParam(params, "importance");
+	if (importance.error)
+		return fail(importance.error, "EXPERIENCE_INVALID_SCORE");
+	if (importance.value !== undefined) updates.importance = importance.value;
+	const confidence = readScoreParam(params, "confidence");
+	if (confidence.error)
+		return fail(confidence.error, "EXPERIENCE_INVALID_SCORE");
+	if (confidence.value !== undefined) updates.confidence = confidence.value;
+	const tags = readTagsParam(params);
+	if (tags !== undefined) updates.tags = tags;
+
+	if (Object.keys(updates).length === 0) {
+		return fail(
+			"Nothing to update: provide at least one of learning, importance, confidence, or tags.",
+			"EXPERIENCE_NO_FIELDS",
+		);
+	}
+
+	const updated = await experienceService.updateExperience(
+		experienceId,
+		updates,
+	);
+	if (!updated) {
+		return fail(
+			`Experience ${experienceId} was not found.`,
+			"EXPERIENCE_NOT_FOUND",
+		);
+	}
+
+	return {
+		success: true,
+		text: `Updated experience ${experienceId}: ${updated.learning.slice(0, 120)}`,
+		values: { experienceId },
+		data: {
+			actionName: EXPERIENCE,
+			op: "update" as const,
+			experienceId,
+			experience: updated,
+		},
+	};
+}
+
+async function doDelete(
+	experienceService: ExperienceService,
+	params: Record<string, unknown>,
+): Promise<ActionResult> {
+	const rawId = readStringParam(params, "experienceId", "id");
+	const query = readStringParam(params, "query");
+	if (!rawId && !query) {
+		return fail("experienceId or query is required.", "EXPERIENCE_MISSING_ID");
+	}
+
+	if (rawId) {
+		const experienceId = validateUuid(rawId);
+		if (!experienceId) {
+			return fail(
+				`experienceId "${rawId}" is not a valid UUID. Use SEARCH_EXPERIENCES to find the id first.`,
+				"EXPERIENCE_INVALID_ID",
+			);
+		}
+		const deleted = await experienceService.deleteExperience(experienceId);
+		if (!deleted) {
+			return fail(
+				`Experience ${experienceId} was not found.`,
+				"EXPERIENCE_NOT_FOUND",
+			);
+		}
+		return {
+			success: true,
+			text: `Deleted experience ${experienceId}.`,
+			values: { experienceId },
+			data: { actionName: EXPERIENCE, op: "delete" as const, experienceId },
+		};
+	}
+
+	if (!query) {
+		return fail("experienceId or query is required.", "EXPERIENCE_MISSING_ID");
+	}
+
+	const candidates = await experienceService.queryExperiences({
+		query,
+		limit: 25,
+	});
+	const matched = candidates.filter(
+		(experience) => scoreText(experienceMatchText(experience), query) >= 1,
+	);
+
+	if (matched.length === 0) {
+		return fail(
+			`No stored experience matches "${query}".`,
+			"EXPERIENCE_NOT_FOUND",
+		);
+	}
+	if (matched.length > 1) {
+		const lines = matched
+			.slice(0, 10)
+			.map((e) => `- ${e.id}: ${e.learning.slice(0, 120)}`);
+		return {
+			success: false,
+			text: [
+				`Query "${query}" matches ${matched.length} experiences. Delete by experienceId instead:`,
+				...lines,
+			].join("\n"),
+			data: { error: "EXPERIENCE_AMBIGUOUS_QUERY" },
+		};
+	}
+
+	const target = matched[0];
+	const deleted = await experienceService.deleteExperience(target.id);
+	if (!deleted) {
+		return fail(
+			`Experience ${target.id} was not found.`,
+			"EXPERIENCE_NOT_FOUND",
+		);
+	}
+	return {
+		success: true,
+		text: `Deleted experience ${target.id}: ${target.learning.slice(0, 120)}`,
+		values: { experienceId: target.id },
+		data: {
+			actionName: EXPERIENCE,
+			op: "delete" as const,
+			experienceId: target.id,
+			query,
+		},
+	};
+}
+
+export const manageExperienceAction: Action = {
+	name: EXPERIENCE,
+	contexts: ["memory", "documents", "agent_internal"],
+	roleGate: { minRole: "OWNER" },
+	similes: [
+		"UPDATE_EXPERIENCE",
+		"EDIT_EXPERIENCE",
+		"DELETE_EXPERIENCE",
+		"REMOVE_EXPERIENCE",
+		"FORGET_EXPERIENCE",
+	],
+	description:
+		"Edit or delete a stored experience record. action:update rewrites learning/importance/confidence/tags by experienceId (requires confirm:true); action:delete removes an experience by experienceId or by query text match (requires confirm:true).",
+	descriptionCompressed:
+		"edit or delete stored experience records; update by experienceId, delete by experienceId or query; both require confirm:true",
+	routingHint:
+		"edit or delete the agent's learned experience records -> EXPERIENCE (find ids via SEARCH_EXPERIENCES when unknown); do NOT use for general user-fact memories -> MEMORY",
+	parameters: [
+		{
+			name: "action",
+			description: "Operation to perform. One of: update, delete.",
+			required: true,
+			schema: { type: "string" as const, enum: [...EXPERIENCE_OPS] },
+		},
+		{
+			name: "experienceId",
+			description:
+				"update/delete: id of the experience to mutate. delete: optional when query is provided.",
+			required: false,
+			schema: { type: "string" as const },
+		},
+		{
+			name: "learning",
+			description: "update: replacement learning text for the experience.",
+			required: false,
+			schema: { type: "string" as const },
+		},
+		{
+			name: "importance",
+			description: "update: importance score from 0 to 1.",
+			required: false,
+			schema: { type: "number" as const, minimum: 0, maximum: 1 },
+		},
+		{
+			name: "confidence",
+			description: "update: confidence score from 0 to 1.",
+			required: false,
+			schema: { type: "number" as const, minimum: 0, maximum: 1 },
+		},
+		{
+			name: "tags",
+			description:
+				"update: replacement tag list (array or comma-separated string).",
+			required: false,
+			schema: { type: "array" as const, items: { type: "string" as const } },
+		},
+		{
+			name: "query",
+			description:
+				"delete: text match against experience learning/context/tags; resolves the record to remove when experienceId is unknown. Refuses ambiguous matches.",
+			required: false,
+			schema: { type: "string" as const },
+		},
+		{
+			name: "confirm",
+			description:
+				"update/delete: must be true to proceed with the destructive operation.",
+			required: false,
+			schema: { type: "boolean" as const },
+		},
+	],
+	examples: [
+		[
+			{
+				name: "{{user}}",
+				content: {
+					text: "Delete that experience about TypeScript build failures",
+					actions: [EXPERIENCE],
+				},
+			},
+			{
+				name: "{{agent}}",
+				content: { text: "Deleted experience abc-123." },
+			},
+		],
+		[
+			{
+				name: "{{user}}",
+				content: {
+					text: "Update that learning — lower its confidence, it turned out wrong",
+					actions: [EXPERIENCE],
+				},
+			},
+			{
+				name: "{{agent}}",
+				content: { text: "Updated experience abc-123." },
+			},
+		],
+	] as ActionExample[][],
+
+	validate: async (
+		runtime: IAgentRuntime,
+		message: Memory,
+		_state?: State,
+		_options?: HandlerOptions,
+	): Promise<boolean> => {
+		if (!runtime.getService("EXPERIENCE")) {
+			return false;
+		}
+		const params = getActionParams(_options);
+		if (normalizeOp(params) || readStringParam(params, "experienceId", "id")) {
+			return true;
+		}
+		const text =
+			typeof message.content.text === "string"
+				? message.content.text.toLowerCase()
+				: "";
+		return (
+			(/\b(experience|experiences|learning|learnings)\b/.test(text) &&
+				/\b(delete|remove|forget|edit|update|change|correct|revise)\b/.test(
+					text,
+				)) ||
+			hasActionContext(message, _state, {
+				contexts: ["memory", "documents", "agent_internal"],
+			})
+		);
+	},
+
+	async handler(
+		runtime: IAgentRuntime,
+		message: Memory,
+		_state?: State,
+		_options?: HandlerOptions,
+		callback?: HandlerCallback,
+	): Promise<ActionResult> {
+		const experienceService = runtime.getService(
+			"EXPERIENCE",
+		) as ExperienceService | null;
+		if (!experienceService) {
+			return fail(
+				"Experience service is unavailable.",
+				"EXPERIENCE_SERVICE_UNAVAILABLE",
+			);
+		}
+
+		const params = getActionParams(_options);
+		const op = normalizeOp(params);
+		if (!op) {
+			return fail(
+				`action is required and must be one of ${EXPERIENCE_OPS.join(", ")}. Use SEARCH_EXPERIENCES for reads.`,
+				"EXPERIENCE_INVALID_OP",
+			);
+		}
+		// Strict boolean, mirroring MEMORY: a planner that cannot produce a real
+		// `true` must not be able to mutate the experience graph.
+		if (params.confirm !== true) {
+			return fail(
+				`Refusing to ${op}: pass confirm:true to acknowledge this destructive action.`,
+				"EXPERIENCE_CONFIRMATION_REQUIRED",
+			);
+		}
+
+		const result =
+			op === "update"
+				? await doUpdate(experienceService, params)
+				: await doDelete(experienceService, params);
+
+		if (callback && result.text) {
+			await callback(
+				{
+					text: result.text,
+					actions: [EXPERIENCE],
+					source: message.content.source,
+				},
+				EXPERIENCE,
+			);
+		}
+
+		logger.info(
+			`[ManageExperienceAction] ${op} ${result.success ? "succeeded" : "failed"}: ${result.text?.slice(0, 200) ?? ""}`,
+		);
+		return result;
+	},
+};

--- a/packages/core/src/features/advanced-capabilities/experience/index.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/index.ts
@@ -2,6 +2,7 @@
  * Experience learning bundled with advanced capabilities.
  */
 
+export { manageExperienceAction } from "./actions/manage-experience.ts";
 export { searchExperiencesAction } from "./actions/search-experiences.ts";
 export { experiencePatternEvaluator } from "./evaluators/experience-items.ts";
 export { experienceProvider } from "./providers/experienceProvider.ts";
@@ -18,11 +19,13 @@ import { anchorBundleSafety } from "../../../bundle-safety.ts";
 // into an empty `init_X = () => {}`. Without this the on-device
 // mobile agent explodes with `ReferenceError: <name> is not defined`
 // when a consumer dereferences a re-exported binding at runtime.
+import { manageExperienceAction as _bs_0_manageExperienceAction } from "./actions/manage-experience.ts";
 import { searchExperiencesAction as _bs_1_searchExperiencesAction } from "./actions/search-experiences.ts";
 import { experiencePatternEvaluator as _bs_2_experiencePatternEvaluator } from "./evaluators/experience-items.ts";
 import { experienceProvider as _bs_3_experienceProvider } from "./providers/experienceProvider.ts";
 
 anchorBundleSafety("FEATURES_ADVANCED_CAPABILITIES_EXPERIENCE_INDEX", [
+	_bs_0_manageExperienceAction,
 	_bs_1_searchExperiencesAction,
 	_bs_2_experiencePatternEvaluator,
 	_bs_3_experienceProvider,

--- a/packages/core/src/features/advanced-capabilities/index.ts
+++ b/packages/core/src/features/advanced-capabilities/index.ts
@@ -22,6 +22,7 @@ import type { IAgentRuntime, RegisteredEvaluator } from "../../types/index.ts";
 import type { ServiceClass } from "../../types/plugin.ts";
 // Direct leaf-file imports — see comment lower in this file for the
 // Bun.build mis-rewrite that requires bypassing barrels.
+import { manageExperienceAction } from "./experience/actions/manage-experience.ts";
 import { searchExperiencesAction } from "./experience/actions/search-experiences.ts";
 import { experiencePatternEvaluator } from "./experience/evaluators/experience-items.ts";
 import { experienceProvider } from "./experience/providers/experienceProvider.ts";
@@ -91,6 +92,7 @@ export const advancedActions = [
 	...promoteSubactionsToActions(withCanonicalActionDocs(roomOpAction)),
 	withCanonicalActionDocs(updateRoleAction),
 	withCanonicalActionDocs(searchExperiencesAction),
+	withCanonicalActionDocs(manageExperienceAction),
 	...promoteSubactionsToActions(messageAction),
 	...promoteSubactionsToActions(postAction),
 	// Personality actions — keep CHARACTER (legacy) alongside the new

--- a/packages/scenario-runner/test/scenarios/live-experience-delete.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-experience-delete.scenario.ts
@@ -1,0 +1,110 @@
+/**
+ * Live-model proof for the Character Experience mutation twin: the user asks
+ * to delete a seeded experience by topic, not by id, and the model must route
+ * through EXPERIENCE with a query selector and confirmation.
+ */
+import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import type { ExperienceService } from "../../../core/src/features/advanced-capabilities/experience/service";
+import {
+  ExperienceType,
+  OutcomeType,
+} from "../../../core/src/features/advanced-capabilities/experience/types";
+import type { UUID } from "../../../core/src/types/primitives";
+
+const EXPERIENCE_TOPIC = "docker buildkit cache eviction";
+let seededExperienceId: UUID | null = null;
+
+function getExperienceService(ctx: ScenarioContext): ExperienceService | null {
+  const service = ctx.runtime.getService("EXPERIENCE");
+  return service && typeof service === "object"
+    ? (service as ExperienceService)
+    : null;
+}
+
+export default scenario({
+  id: "live-experience-delete-by-topic",
+  lane: "live-only",
+  title: "Character Experience delete by natural-language topic",
+  domain: "experience",
+  tags: ["live", "experience", "views-chat-integration", "mvp"],
+  isolation: "per-scenario",
+  seed: [
+    {
+      type: "custom",
+      name: "seed one uniquely identifiable experience",
+      apply: async (ctx) => {
+        const service = getExperienceService(ctx);
+        if (!service) return "EXPERIENCE service was not available";
+        const experience = await service.recordExperience({
+          agentId: ctx.runtime.agentId as UUID,
+          type: ExperienceType.LEARNING,
+          outcome: OutcomeType.NEUTRAL,
+          context:
+            "While reviewing a Docker build failure, the agent diagnosed a cache eviction issue.",
+          action: "Enabled BuildKit cache mounts and pruned stale layers.",
+          result: "The image build stabilized.",
+          learning: `Docker builds with ${EXPERIENCE_TOPIC} should use scoped BuildKit cache mounts.`,
+          tags: ["docker", "buildkit", "cache"],
+          domain: "coding",
+          confidence: 0.82,
+          importance: 0.7,
+        });
+        seededExperienceId = experience.id;
+        return undefined;
+      },
+    },
+  ],
+  rooms: [
+    {
+      id: "main",
+      source: "chat",
+      title: "Experience Delete",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "delete seeded experience by topic",
+      text: `Delete the experience about ${EXPERIENCE_TOPIC}; yes, confirm deleting it.`,
+      assertTurn: (execution) => {
+        const action = execution.actionsCalled.find(
+          (candidate) => candidate.actionName === "EXPERIENCE",
+        );
+        if (!action) {
+          return `expected EXPERIENCE action, saw ${execution.actionsCalled.map((candidate) => candidate.actionName).join(", ") || "none"}`;
+        }
+        if (action.result?.success !== true) {
+          return `expected EXPERIENCE success=true, saw ${JSON.stringify(action.result)}`;
+        }
+        return undefined;
+      },
+    },
+  ],
+  finalChecks: [
+    {
+      type: "actionCalled",
+      actionName: "EXPERIENCE",
+      status: "success",
+      minCount: 1,
+    },
+    {
+      type: "selectedActionArguments",
+      actionName: "EXPERIENCE",
+      includesAll: [/delete/i, /docker buildkit cache eviction/i, /confirm/i],
+    },
+    {
+      type: "custom",
+      name: "seeded experience was removed",
+      predicate: async (ctx) => {
+        const service = getExperienceService(ctx);
+        if (!service) return "EXPERIENCE service was not available";
+        if (!seededExperienceId) return "seeded experience id was not recorded";
+        const remaining = await service.getExperience(seededExperienceId);
+        return remaining
+          ? `expected ${seededExperienceId} to be deleted, but it still exists`
+          : undefined;
+      },
+    },
+  ],
+});


### PR DESCRIPTION
# Relates to

Part of #14623.

Definition of Done: full standard in [`PR_EVIDENCE.md`](../PR_EVIDENCE.md).

- [x] This PR targets `develop` and was rebased onto latest `origin/develop` before update.
- [x] Focused deterministic verification passed locally for the semantic action, app static guard, and scenario registration.
- [ ] Live-LLM trajectory evidence is still required before #14623 can close.

# What Changed

- Adds semantic `EXPERIENCE action=update|delete` for Character Experience parity with `client.updateExperience()` and `client.deleteExperience()`.
- Registers `EXPERIENCE` in advanced capabilities with canonical action docs and exports it from the experience bundle.
- Requires `confirm:true` for destructive updates/deletes, validates ids/scores/fields, and supports delete-by-query only when the query strongly resolves to exactly one experience.
- Adds deterministic action coverage, a static Character Experience view->action guard, and live-only scenario `live-experience-delete-by-topic` for “delete the experience about X” without a raw selector.

# Testing

```text
bun install --frozen-lockfile --ignore-scripts
bun run --cwd packages/shared build:i18n
bun run --cwd packages/logger build
bun run --cwd packages/cloud/routing build

bunx biome check packages/core/src/features/advanced-capabilities/experience/actions/manage-experience.ts packages/core/src/features/advanced-capabilities/experience/actions/manage-experience.test.ts packages/core/src/features/advanced-capabilities/experience/index.ts packages/core/src/features/advanced-capabilities/index.ts packages/app/test/character-experience-action-surface.test.ts packages/scenario-runner/test/scenarios/live-experience-delete.scenario.ts
# passed

bun run --cwd packages/core test src/features/advanced-capabilities/experience/actions/manage-experience.test.ts
# Test Files 1 passed (1); Tests 14 passed (14)

bun run --cwd packages/core typecheck
# passed

bun run --cwd packages/app test -- test/character-experience-action-surface.test.ts
# Test Files 1 passed (1); Tests 1 passed (1)

bun run --cwd packages/scenario-runner src/cli.ts list test/scenarios --scenario live-experience-delete-by-topic
# live-experience-delete-by-topic

bun run --cwd packages/scenario-runner test src/action-effect-ratchet.test.ts src/skippable-check-ratchet.test.ts src/echo-assertion-ratchet.test.ts
# Test Files 3 passed (3); Tests 5 passed (5)

git diff --check origin/develop...HEAD
# passed

bun run audit:error-policy-ratchet --report
# no new fallback-slop in touched files
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - no renderer behavior or visual UI changed; the `packages/app` change is a static Vitest guard only.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no renderer behavior or visual UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow changed; this PR adds the semantic action twin under existing Character Experience controls.
<!-- evidence-row:backend-logs -->
- [x] N/A - no long-running backend process was started; focused action tests, typecheck, scenario listing, and ratchets are listed above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response or runtime state path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - live provider credentials are unavailable in this environment. `live-experience-delete-by-topic` must still be run with a live model and reviewed before #14623 closes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persisted domain artifact is produced by deterministic tests; unit tests verify mutation payloads against a fake `EXPERIENCE` service, and the live-only scenario will produce the seeded/deleted experience artifact once run with provider keys.

# Known Gaps

- Live trajectory is not attached yet. The scenario is present and load-verified, but this environment has no live provider key configured.
- The issue names old `packages/scripts/view-action-ratchet.registry.json`, which is not present on current `develop`. The current replacement proof in this PR is `packages/app/test/character-experience-action-surface.test.ts`, which pins `client.updateExperience()` / `client.deleteExperience()` to the registered semantic `EXPERIENCE` action. #14369 owns broader view-ratchet evolution.
- App visual audit is N/A because no renderer/UI implementation files changed; only an app Vitest guard was added.


## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - core action/scenario behavior only; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [x] N/A - core action/scenario behavior only; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing renderer flow changed; this PR adds the semantic action behind existing Character Experience controls.

<!-- evidence-row:backend-logs -->
- [x] N/A - no long-running backend process was started; deterministic core/app/scenario tests and app audit output are listed in Verification.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response path changed; packages/app change is a static contract test only.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - live model provider keys are unavailable in this environment; the live-only scenario is registered for the live lane.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - deterministic fake-service tests verify mutation payloads locally; the live-only scenario will produce the seeded/deleted experience artifact when run with provider keys.

Additional local review evidence: `bun run --cwd packages/app audit:app` passed 365/365 Playwright cases after the final rebase.
