### PR TITLE
ci(evidence): add certification verify gate (#14547)

### DIFF
--- a/.github/certification/README.md
+++ b/.github/certification/README.md
@@ -13,9 +13,10 @@ caller of `certify:verify` and perform no verification logic of its own
 generates the production keypair on a trusted machine and lands
 `certification-public-key.pem` — recording its fingerprint (first 16 hex of
 sha256 over the SPKI DER) here — in a dedicated reviewed PR; merging that PR
-is the act of trusting the key. Until it lands, the promotion gate (#14547)
-cannot be enabled. There is deliberately no default trust anchor in code:
-`certify:verify` requires an explicit `--pubkey`.
+is the act of trusting the key. Until it lands, the promotion gate workflow
+fails `trust-anchor-missing` and must not be marked required. There is
+deliberately no default trust anchor in code: `certify:verify` requires an
+explicit `--pubkey`.
 
 ## Trust model — binding rules for the CI gate (#14547)
 
@@ -38,6 +39,9 @@ cannot be enabled. There is deliberately no default trust anchor in code:
   payload and must be surfaced in the gate's check summary.
 
 ## Verify contract (what the workflow calls)
+
+The workflow check name for branch protection is
+`Certification Verify / certification-verify`.
 
 ```bash
 bun run --cwd packages/evidence certify:verify -- \
@@ -82,8 +86,9 @@ the one on `main`.
 
 Push to `main` is a production deploy, so the gate must be watertight — but
 it must not brick emergencies. The break-glass path is **not a code path**:
-a repository admin bypasses the required `certification-verify` check via
-branch-protection admin override. Every such bypass is visible in the
+a repository admin bypasses the required
+`Certification Verify / certification-verify` check via branch-protection
+admin override. Every such bypass is visible in the
 GitHub audit log; there is deliberately no in-repo flag, env var, or
 alternate verification mode that skips signature checks. #14547 must
 document the required-check name it registers so admins know exactly which

--- a/.github/scripts/verify-certification.mjs
+++ b/.github/scripts/verify-certification.mjs
@@ -1,0 +1,352 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, "../..");
+const PUBLIC_KEY_RELPATH =
+  ".github/certification/certification-public-key.pem";
+
+process.chdir(REPO_ROOT);
+
+function env(name, fallback = undefined) {
+  const value = process.env[name];
+  return value === undefined || value === "" ? fallback : value;
+}
+
+function relative(filePath) {
+  return path.relative(REPO_ROOT, filePath) || ".";
+}
+
+function escapeAnnotation(value) {
+  return String(value)
+    .replaceAll("%", "%25")
+    .replaceAll("\r", "%0D")
+    .replaceAll("\n", "%0A")
+    .slice(0, 1000);
+}
+
+function writeSummary(markdown) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (summaryPath !== undefined && summaryPath !== "") {
+    fs.appendFileSync(summaryPath, `${markdown}\n`);
+    return;
+  }
+  process.stdout.write(`${markdown}\n`);
+}
+
+function emitFailureAnnotations(failures) {
+  for (const failure of failures) {
+    process.stderr.write(
+      `::error title=${escapeAnnotation(failure.code)}::${escapeAnnotation(
+        failure.message,
+      )}\n`,
+    );
+  }
+}
+
+function finishFailure(context, failures) {
+  writeSummary(renderSummary("FAIL", context, failures));
+  emitFailureAnnotations(failures);
+  process.exitCode = 1;
+}
+
+function finishPass(context) {
+  writeSummary(renderSummary("PASS", context, []));
+  process.exitCode = 0;
+}
+
+function resolveInputPath(input) {
+  return path.isAbsolute(input) ? input : path.join(REPO_ROOT, input);
+}
+
+function walkFiles(root, basename, out = []) {
+  if (!fs.existsSync(root)) return out;
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const filePath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(filePath, basename, out);
+      continue;
+    }
+    if (entry.isFile() && entry.name === basename) out.push(filePath);
+  }
+  return out;
+}
+
+function locateCertification() {
+  const configured = env("CERTIFICATION_PATH");
+  if (configured !== undefined) {
+    const filePath = resolveInputPath(configured);
+    return fs.existsSync(filePath) ? { filePath } : { missing: filePath };
+  }
+
+  const candidates = [];
+  const rootCert = path.join(REPO_ROOT, "certification.json");
+  if (fs.existsSync(rootCert)) candidates.push(rootCert);
+  candidates.push(
+    ...walkFiles(path.join(REPO_ROOT, "evidence", "runs"), "certification.json"),
+  );
+  candidates.sort();
+
+  if (candidates.length === 0) return { none: true };
+  if (candidates.length > 1) return { multiple: candidates };
+  return { filePath: candidates[0] };
+}
+
+function locateBundle(certPath) {
+  const configured = env("CERTIFICATION_BUNDLE_PATH");
+  const bundleDir =
+    configured !== undefined ? resolveInputPath(configured) : path.dirname(certPath);
+  const manifest = path.join(bundleDir, "manifest.json");
+  if (!fs.existsSync(manifest)) return { missing: bundleDir };
+  return { bundleDir };
+}
+
+function baseRefSpec() {
+  const baseRef = env("BASE_REF", env("GITHUB_BASE_REF", "main"));
+  if (!/^[A-Za-z0-9._/-]+$/.test(baseRef)) {
+    return { error: `unsafe base ref: ${baseRef}` };
+  }
+  return { ref: `refs/remotes/origin/${baseRef}`, baseRef };
+}
+
+function materializeBasePublicKey() {
+  const spec = baseRefSpec();
+  if (spec.error !== undefined) return { error: spec.error };
+
+  const show = spawnSync(
+    "git",
+    ["show", `${spec.ref}:${PUBLIC_KEY_RELPATH}`],
+    { encoding: "utf8", cwd: REPO_ROOT },
+  );
+  if (show.status !== 0) {
+    return {
+      error:
+        `trusted certification public key is missing on base branch ${spec.baseRef}: ` +
+        PUBLIC_KEY_RELPATH,
+      baseRef: spec.baseRef,
+    };
+  }
+
+  const keyDir = fs.mkdtempSync(path.join(os.tmpdir(), "cert-trust-anchor-"));
+  const keyPath = path.join(keyDir, "certification-public-key.pem");
+  fs.writeFileSync(keyPath, show.stdout);
+  return { keyPath, keyDir, baseRef: spec.baseRef };
+}
+
+function runVerifier({ certPath, bundleDir, keyPath }) {
+  const args = [
+    "packages/evidence/src/certify/cli.ts",
+    "verify",
+    "--cert",
+    certPath,
+    "--pubkey",
+    keyPath,
+    "--bundle",
+    bundleDir,
+    "--max-age-hours",
+    env("CERT_MAX_AGE_HOURS", "72"),
+    "--required-tier",
+    env("CERT_REQUIRED_TIER", "full"),
+    "--json",
+  ];
+  const expectedCommit = env("PR_HEAD_SHA", env("GITHUB_SHA"));
+  if (expectedCommit !== undefined) {
+    args.splice(args.length - 1, 0, "--expected-commit", expectedCommit);
+  }
+  const requirementsPath = env("CERT_REQUIREMENTS_PATH");
+  if (requirementsPath !== undefined) {
+    args.splice(args.length - 1, 0, "--requirements", resolveInputPath(requirementsPath));
+  }
+
+  const result = spawnSync("bun", args, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+    maxBuffer: 10 * 1024 * 1024,
+  });
+
+  let report;
+  try {
+    report = JSON.parse(result.stdout);
+  } catch {
+    return {
+      report: undefined,
+      failures: [
+        {
+          code: "verification-error",
+          message:
+            "certify:verify did not emit a JSON report" +
+            (result.stderr ? `: ${result.stderr.trim().slice(0, 500)}` : ""),
+        },
+      ],
+    };
+  }
+
+  return {
+    report,
+    failures: Array.isArray(report.failures) ? [...report.failures] : [],
+  };
+}
+
+function applyPromotionPolicy(report, failures) {
+  const expectedCommit = env("PR_HEAD_SHA", env("GITHUB_SHA"));
+  if (
+    expectedCommit !== undefined &&
+    report?.payload?.commit !== undefined &&
+    report.payload.commit !== expectedCommit &&
+    !failures.some((failure) => failure.code === "commit-mismatch")
+  ) {
+    failures.push({
+      code: "commit-mismatch",
+      message: `certification commit ${report.payload.commit} does not match PR head ${expectedCommit}`,
+      context: { expectedCommit, actualCommit: report.payload.commit },
+    });
+  }
+}
+
+function verdictCounts(report) {
+  const counts = { pass: 0, fail: 0, waived: 0 };
+  for (const verdict of report?.payload?.verdicts ?? []) {
+    if (verdict.verdict in counts) counts[verdict.verdict] += 1;
+  }
+  return counts;
+}
+
+function renderSummary(status, context, failures) {
+  const report = context.report;
+  const payload = report?.payload;
+  const counts = verdictCounts(report);
+  const lines = [
+    "# Certification Verify",
+    "",
+    `**Status:** ${status}`,
+    "",
+    "| Field | Value |",
+    "| --- | --- |",
+    `| Base ref | \`${context.baseRef ?? "(unknown)"}\` |`,
+    `| Certificate | \`${context.certPath ? relative(context.certPath) : "(missing)"}\` |`,
+    `| Bundle | \`${context.bundleDir ? relative(context.bundleDir) : "(missing)"}\` |`,
+    `| Required tier | \`${env("CERT_REQUIRED_TIER", "full")}\` |`,
+    `| Max age | \`${env("CERT_MAX_AGE_HOURS", "72")}h\` |`,
+  ];
+
+  if (payload !== undefined) {
+    lines.push(
+      `| Certified commit | \`${payload.commit}\` |`,
+      `| Branch/base | \`${payload.branch} -> ${payload.baseRef}\` |`,
+      `| Tier | \`${payload.tier}\` |`,
+      `| Reviewer | \`${payload.reviewer.kind}:${payload.reviewer.id}\` |`,
+      `| Verdicts | pass=${counts.pass}, fail=${counts.fail}, waived=${counts.waived} |`,
+      `| Created at | \`${payload.createdAt}\` |`,
+    );
+  }
+
+  if (failures.length > 0) {
+    lines.push("", "## Failures", "", "| Code | Message |", "| --- | --- |");
+    for (const failure of failures) {
+      lines.push(
+        `| \`${failure.code}\` | ${String(failure.message).replaceAll("|", "\\|")} |`,
+      );
+    }
+  }
+
+  const verdicts = payload?.verdicts ?? [];
+  if (verdicts.length > 0) {
+    lines.push("", "## Verdicts", "", "| Subject | Verdict | Notes |", "| --- | --- | --- |");
+    for (const verdict of verdicts.slice(0, 50)) {
+      lines.push(
+        `| \`${verdict.subject}\` | \`${verdict.verdict}\` | ${
+          verdict.notes === undefined ? "" : String(verdict.notes).replaceAll("|", "\\|")
+        } |`,
+      );
+    }
+    if (verdicts.length > 50) {
+      lines.push(`| ... | ... | ${verdicts.length - 50} more verdict(s) omitted |`);
+    }
+  }
+
+  if (failures.length > 0 && context.trustAnchorMissing) {
+    lines.push(
+      "",
+      "The certification public key must be committed on the protected base branch before this check is made required.",
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+const context = {};
+const trustAnchor = materializeBasePublicKey();
+context.baseRef = trustAnchor.baseRef ?? env("BASE_REF", env("GITHUB_BASE_REF", "main"));
+if (trustAnchor.error !== undefined) {
+  context.trustAnchorMissing = true;
+  finishFailure(context, [
+    { code: "trust-anchor-missing", message: trustAnchor.error },
+  ]);
+} else {
+  try {
+    const cert = locateCertification();
+    if (cert.none) {
+      finishFailure(context, [
+        {
+          code: "certification-missing",
+          message:
+            "no certification.json found; commit evidence/runs/<run-id>/certification.json on the promotion branch",
+        },
+      ]);
+    } else if (cert.missing !== undefined) {
+      finishFailure(context, [
+        {
+          code: "certification-missing",
+          message: `configured certification path does not exist: ${cert.missing}`,
+        },
+      ]);
+    } else if (cert.multiple !== undefined) {
+      finishFailure(context, [
+        {
+          code: "certification-ambiguous",
+          message:
+            "multiple certification.json files found; set CERTIFICATION_PATH to the intended file: " +
+            cert.multiple.map(relative).join(", "),
+        },
+      ]);
+    } else {
+      context.certPath = cert.filePath;
+      const bundle = locateBundle(cert.filePath);
+      if (bundle.missing !== undefined) {
+        context.bundleDir = bundle.missing;
+        finishFailure(context, [
+          {
+            code: "bundle-missing",
+            message: `certification bundle is missing manifest.json: ${bundle.missing}`,
+          },
+        ]);
+      } else {
+        context.bundleDir = bundle.bundleDir;
+        const verification = runVerifier({
+          certPath: cert.filePath,
+          bundleDir: bundle.bundleDir,
+          keyPath: trustAnchor.keyPath,
+        });
+        context.report = verification.report;
+        const failures = verification.failures;
+        applyPromotionPolicy(verification.report, failures);
+        if (verification.report?.ok === false && failures.length === 0) {
+          failures.push({
+            code: "verification-error",
+            message: "certify:verify returned ok:false without failures",
+          });
+        }
+        if (failures.length > 0) finishFailure(context, failures);
+        else finishPass(context);
+      }
+    }
+  } finally {
+    if (trustAnchor.keyDir !== undefined) {
+      fs.rmSync(trustAnchor.keyDir, { recursive: true, force: true });
+    }
+  }
+}

--- a/.github/workflows/certification-verify.yml
+++ b/.github/workflows/certification-verify.yml
@@ -1,0 +1,52 @@
+name: Certification Verify
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: certification-verify-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  certification-verify:
+    name: certification-verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+
+      - name: Fetch protected base branch
+        run: >
+          git fetch --no-tags origin
+          "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24.15.0"
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: "1.3.14"
+          install-command: bun install
+          install-native-deps: "false"
+          install-protoc: "false"
+          setup-python: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Verify signed certification
+        run: node .github/scripts/verify-certification.mjs
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CERT_REQUIRED_TIER: full
+          CERT_MAX_AGE_HOURS: "72"


### PR DESCRIPTION

Refs #14547.

## What changed

- Added `Certification Verify / certification-verify`, a PR-to-`main` workflow that checks signed evidence certifications before develop-to-main promotion.
- Added `.github/scripts/verify-certification.mjs`, a thin wrapper that:
  - reads `.github/certification/certification-public-key.pem` from `refs/remotes/origin/<base>`, never from the PR checkout;
  - locates exactly one committed `certification.json` under `evidence/runs/**` or accepts `CERTIFICATION_PATH`;
  - requires the bundle manifest beside the cert, then calls `bun packages/evidence/src/certify/cli.ts verify --json` with `--bundle`, `--expected-commit`, `--max-age-hours 72`, and `--required-tier full`;
  - writes a check summary with reviewer/tier/verdicts/failures and emits typed error annotations.
- Updated `.github/certification/README.md` with the branch-protection check name and the current trust-anchor prerequisite.

## Important setup note

The real public key is still not committed on the protected base branch. Until `.github/certification/certification-public-key.pem` lands on `main`, this workflow fails explicitly with `trust-anchor-missing` and should not be marked required.

## Verification

- `node --check .github/scripts/verify-certification.mjs` PASS
- `actionlint .github/workflows/certification-verify.yml` PASS
- `BASE_REF=develop PR_HEAD_SHA=64efa64fdfd80af8e2e3dfeefc843d73c141a56c node .github/scripts/verify-certification.mjs` -> expected FAIL with `trust-anchor-missing`
- `git diff --check` PASS
