### PR TITLE
feat(widgets): up-next calendar 18h lookahead + countdown leaf

### DIFF
--- a/packages/ui/src/components/chat/widgets/calendar-countdown.test.tsx
+++ b/packages/ui/src/components/chat/widgets/calendar-countdown.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+//
+// CalendarCountdown leaf (§C.4, issue #14564): the "in 40 min" countdown owns
+// its OWN minute ticker so the minute tick re-renders only the <time> text
+// node, NEVER the card shell above it. These tests lock two things:
+//   1. the copy contract (sentence case, no em-dashes, the compact buckets), and
+//   2. the render-count isolation, a leaf tick must not commit the parent
+//      shell (the whole reason the timer was pushed down into the leaf).
+import { act, cleanup, render } from "@testing-library/react";
+import { useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  makeRenderCounter,
+  useRenderSpy,
+} from "../../../testing/render-counter";
+import { CalendarCountdown, formatCountdown } from "./calendar-countdown";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("formatCountdown", () => {
+  const now = 0;
+  it('reads "now" at or before the event start', () => {
+    expect(formatCountdown(new Date(now).toISOString(), now)).toBe("now");
+    // Already started (negative delta) still reads "now", never a negative.
+    expect(formatCountdown(new Date(now - 5 * 60_000).toISOString(), now)).toBe(
+      "now",
+    );
+  });
+
+  it("uses compact minute / hour / day buckets", () => {
+    const at = (ms: number) =>
+      formatCountdown(new Date(now + ms).toISOString(), now);
+    expect(at(25 * 60_000)).toBe("in 25m");
+    expect(at(3 * 60 * 60_000)).toBe("in 3h");
+    expect(at(24 * 60 * 60_000)).toBe("tomorrow");
+    expect(at(2 * 24 * 60 * 60_000)).toBe("in 2d");
+  });
+
+  it("emits no em-dashes and stays sentence case (copy law)", () => {
+    const samples = [0, 25 * 60_000, 3 * 60 * 60_000, 48 * 60 * 60_000].map(
+      (ms) => formatCountdown(new Date(now + ms).toISOString(), now),
+    );
+    for (const s of samples) {
+      expect(s).not.toContain(",");
+      expect(s).toBe(s.toLowerCase());
+    }
+  });
+
+  it("returns empty string for an unparseable date", () => {
+    expect(formatCountdown("not-a-date", now)).toBe("");
+  });
+});
+
+describe("CalendarCountdown leaf", () => {
+  it("holds empty text when the clock reads 0 (deterministic first-render guard)", () => {
+    // The `now === 0` first render is the determinism guard (useNow returns 0
+    // before its effect installs Date.now). We assert it via the injected-clock
+    // path since RTL flushes the mount effect synchronously in the un-injected
+    // path; injecting now === 0 pins that exact frame.
+    const startAt = new Date(1_000_000 + 40 * 60_000).toISOString();
+    const { container } = render(<CalendarCountdown date={startAt} now={0} />);
+    expect(container.querySelector("time")?.textContent).toBe("");
+  });
+
+  it("renders the countdown string and a machine-readable start once the clock is live", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-05T12:00:00Z"));
+    const startAt = new Date(Date.parse("2026-07-05T12:40:00Z")).toISOString();
+
+    let container!: HTMLElement;
+    // RTL flushes the mount effect (which installs the live clock) inside act.
+    act(() => {
+      ({ container } = render(<CalendarCountdown date={startAt} />));
+    });
+    expect(container.querySelector("time")?.textContent).toBe("in 40m");
+    // The <time> carries the machine-readable start for a11y.
+    expect(container.querySelector("time")?.getAttribute("datetime")).toBe(
+      startAt,
+    );
+  });
+
+  it("honors an injected `now` (deterministic tests/stories path) without a ticker", () => {
+    const startAt = new Date(1_000_000 + 90 * 60_000).toISOString();
+    const { container } = render(
+      <CalendarCountdown date={startAt} now={1_000_000} />,
+    );
+    // Injected clock wins immediately, no effect tick needed.
+    expect(container.querySelector("time")?.textContent).toBe("in 2h");
+  });
+
+  // The load-bearing test (§C.4): a minute tick inside the leaf must re-render
+  // ONLY the leaf, not the surrounding card shell. We wrap the leaf in a fake
+  // "shell" whose renders are counted; after advancing the leaf's ticker a full
+  // minute, the shell's render count must be unchanged while the leaf's text
+  // has advanced.
+  it("ticks without re-rendering the card shell (render-count lock)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-05T12:00:00Z"));
+    const startAt = new Date(Date.parse("2026-07-05T12:40:00Z")).toISOString();
+
+    const shellCounter = makeRenderCounter();
+
+    // A minimal stand-in for the card shell: it renders once and holds the leaf
+    // as a child. If the leaf's ticker leaked upward (e.g. useNow lived here),
+    // this counter would climb every minute, exactly the bug §C.4 forbids.
+    function FakeCardShell() {
+      useRenderSpy(shellCounter);
+      // Local state the shell controls; never touched by the leaf's ticker.
+      const [title] = useState("Design sync");
+      return (
+        <button type="button" data-testid="shell">
+          <span data-testid="title">{title}</span>
+          <CalendarCountdown date={startAt} />
+        </button>
+      );
+    }
+
+    const { container } = render(<FakeCardShell />);
+
+    // Flush the leaf's clock-install effect.
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(container.querySelector("time")?.textContent).toBe("in 40m");
+    const shellRendersAfterMount = shellCounter.count;
+
+    // Advance a full minute so the leaf's 60s ticker fires.
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    // The leaf re-rendered: the countdown string advanced by a minute.
+    expect(container.querySelector("time")?.textContent).toBe("in 39m");
+    // The shell did NOT re-render on the leaf's tick, the whole point.
+    expect(shellCounter.count).toBe(shellRendersAfterMount);
+  });
+});

--- a/packages/ui/src/components/chat/widgets/calendar-countdown.tsx
+++ b/packages/ui/src/components/chat/widgets/calendar-countdown.tsx
@@ -1,0 +1,85 @@
+/**
+ * CalendarCountdown, a leaf that renders the "in 40 min" countdown string for
+ * the Up Next home card and owns its OWN minute ticker, so the card shell never
+ * re-renders on the tick (§C.4 of NOTIFICATIONS-WIDGETS-SYSTEM.md: timers live
+ * in `<RelativeTime>`-class leaves only, never above them).
+ *
+ * COORDINATION (#14559): the shared `<RelativeTime>` leaf is being built in a
+ * parallel lane. This leaf deliberately mirrors its props shape (`date` +
+ * optional injected `now` for tests) so the swap is a one-liner once #14559
+ * lands: replace the import and pass `date={next.startAt}`. Until then this is
+ * a self-contained, visibility-gated ticker, NOT a competing shared-ticker
+ * infrastructure.
+ */
+import { type JSX, useEffect, useState } from "react";
+import { useDocumentVisibility } from "../../../hooks";
+
+// The countdown re-formats on the same calm 60s cadence the calendar feed polls.
+// A per-minute string is precise enough for "in 40 min" and burns one local
+// timer only while the document is visible.
+const COUNTDOWN_TICK_MS = 60_000;
+
+function useVisibilityGatedNow(intervalMs: number): number {
+  const documentVisible = useDocumentVisibility();
+  const [now, setNow] = useState(0);
+
+  useEffect(() => {
+    if (!documentVisible) return;
+    setNow(Date.now());
+    const id = window.setInterval(() => setNow(Date.now()), intervalMs);
+    return () => window.clearInterval(id);
+  }, [documentVisible, intervalMs]);
+
+  return now;
+}
+
+/**
+ * Compact relative time until an event, e.g. "now", "in 25m", "in 3h",
+ * "tomorrow", "in 2d". Sentence case, no em-dashes (spec copy law). Exported so
+ * the card's `ariaLabel` can render the same string without mounting the leaf.
+ */
+export function formatCountdown(date: string, now: number): string {
+  const deltaMs = Date.parse(date) - now;
+  if (!Number.isFinite(deltaMs)) return "";
+  const minutes = Math.round(deltaMs / 60_000);
+  if (minutes <= 0) return "now";
+  if (minutes < 60) return `in ${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `in ${hours}h`;
+  const days = Math.round(hours / 24);
+  if (days === 1) return "tomorrow";
+  return `in ${days}d`;
+}
+
+export interface CalendarCountdownProps {
+  /** ISO start timestamp of the event to count down to. */
+  date: string;
+  /**
+   * Injected clock (epoch-ms) for deterministic tests/stories. Omitted in the
+   * app so the leaf's own visibility-gated ticker drives it, this is the exact
+   * prop shape the shared `<RelativeTime now?>` leaf (#14559) exposes, keeping
+   * the swap trivial.
+   */
+  now?: number;
+}
+
+/**
+ * Renders ONLY the relative-time text node. Because the ticker lives here (not
+ * in the card), the minute tick re-renders this `<time>` alone, the card shell,
+ * icon, title and grid tile stay put (§C.4 render-count lock).
+ */
+export function CalendarCountdown({
+  date,
+  now: injectedNow,
+}: CalendarCountdownProps): JSX.Element {
+  // Own clock: returns 0 on first render (deterministic) then ticks every minute
+  // while visible. A caller-injected `now` wins for tests/stories.
+  const tickNow = useVisibilityGatedNow(COUNTDOWN_TICK_MS);
+  const now = injectedNow ?? tickNow;
+  const label = now === 0 ? "" : formatCountdown(date, now);
+  return (
+    <time dateTime={date} suppressHydrationWarning>
+      {label}
+    </time>
+  );
+}

--- a/packages/ui/src/components/chat/widgets/calendar-upcoming.test.tsx
+++ b/packages/ui/src/components/chat/widgets/calendar-upcoming.test.tsx
@@ -13,7 +13,7 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Auth gate (#11084) — mutable so tests can flip the session state. Default
+// Auth gate (#11084), mutable so tests can flip the session state. Default
 // authenticated so the pre-gate behavior tests exercise the live poll path.
 const { authMock } = vi.hoisted(() => ({
   authMock: { authenticated: true },
@@ -56,7 +56,7 @@ import type { WidgetProps } from "../../../widgets/types";
 import { CalendarUpcomingWidget } from "./calendar-upcoming";
 
 // Minimal wire event matching LifeOpsCalendarEvent (@elizaos/shared
-// contracts/calendar.ts) — only the fields the widget reads.
+// contracts/calendar.ts), only the fields the widget reads.
 function event(
   overrides: Partial<{
     id: string;
@@ -147,7 +147,7 @@ describe("CalendarUpcomingWidget", () => {
     expect(globalThis.fetch as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
   });
 
-  it("renders NOTHING when no Google account is linked — no connect-CTA tile", async () => {
+  it("renders NOTHING when no Google account is linked, no connect-CTA tile", async () => {
     disconnectedGoogle();
     mockFeed([]);
     const { container } = render(<CalendarUpcomingWidget {...homeProps} />);
@@ -165,9 +165,9 @@ describe("CalendarUpcomingWidget", () => {
     ).toBeNull();
   });
 
-  it("renders NOTHING when connected but no upcoming events — the row must earn its place", async () => {
+  it("renders NOTHING when connected but no upcoming events, the row must earn its place", async () => {
     connectedGoogle();
-    // A past event only — filtered out (startAt < now).
+    // A past event only, filtered out (startAt < now).
     mockFeed([
       event({
         id: "past",
@@ -185,7 +185,7 @@ describe("CalendarUpcomingWidget", () => {
     expect(screen.queryByTestId("chat-widget-calendar-upcoming")).toBeNull();
   });
 
-  it("shows ONE high-priority datum — the soonest event — with a +N more badge", async () => {
+  it("shows ONE high-priority datum, the soonest event, with a +N more badge", async () => {
     connectedGoogle();
     mockFeed([
       event({
@@ -208,7 +208,104 @@ describe("CalendarUpcomingWidget", () => {
     expect(widget.textContent).not.toContain("Lunch");
     expect(widget.textContent).toContain("+1");
     expect(widget.getAttribute("aria-label")).toMatch(/Standup/);
-    expect(widget.getAttribute("aria-label")).toMatch(/Open Calendar/);
+    // Sentence-case copy law (spec §copy): "Open calendar.", not "Open Calendar".
+    expect(widget.getAttribute("aria-label")).toMatch(/Open calendar/);
+  });
+
+  // --- 18h lookahead gate (§B "Up Next", issue #14564) -----------------------
+  // The card earns its home slot ONLY when the next event starts within 18h; a
+  // more-distant event yields the slot (renders null). "An event next Tuesday is
+  // not glanceable urgency." The feed is queried 14d wide, but the render gate
+  // is the narrower 18h window.
+
+  it("renders the card when the next event is just inside the 18h gate (17h59m)", async () => {
+    connectedGoogle();
+    mockFeed([
+      event({
+        id: "soon",
+        title: "Design sync",
+        startAt: new Date(Date.now() + (17 * 60 + 59) * 60_000).toISOString(),
+      }),
+    ]);
+    render(<CalendarUpcomingWidget {...homeProps} />);
+
+    const card = await screen.findByTestId("chat-widget-calendar-upcoming");
+    expect(card.textContent).toContain("Design sync");
+  });
+
+  it("yields its slot (renders null) when the next event is just past the 18h gate (18h01m)", async () => {
+    connectedGoogle();
+    // A real upcoming event, but beyond the 18h glance window: the feed returns
+    // it (14d query) yet the render gate holds the card null.
+    mockFeed([
+      event({
+        id: "far",
+        title: "Next Tuesday",
+        startAt: new Date(Date.now() + (18 * 60 + 1) * 60_000).toISOString(),
+      }),
+    ]);
+    const { container } = render(<CalendarUpcomingWidget {...homeProps} />);
+
+    // The connector probe + feed both run (the event exists), but the card is
+    // gated out, no tile occupies the home grid.
+    await waitFor(() => {
+      expect(listConnectorAccountsMock).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(globalThis.fetch as ReturnType<typeof vi.fn>).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+    expect(screen.queryByTestId("chat-widget-calendar-upcoming")).toBeNull();
+  });
+
+  it("does not publish home attention for a beyond-18h event (no card = no signal)", async () => {
+    connectedGoogle();
+    mockFeed([
+      event({
+        id: "far",
+        title: "Next Tuesday",
+        startAt: new Date(Date.now() + 20 * 60 * 60_000).toISOString(),
+      }),
+    ]);
+    render(<CalendarUpcomingWidget {...homeProps} />);
+
+    await waitFor(() => {
+      expect(globalThis.fetch as ReturnType<typeof vi.fn>).toHaveBeenCalled();
+    });
+    // A gated-out card must never float the tile up; every publish call is null.
+    await waitFor(() => {
+      expect(publishMock).toHaveBeenCalled();
+    });
+    for (const call of publishMock.mock.calls) {
+      expect(call).toEqual(["calendar/calendar.upcoming", null]);
+    }
+  });
+
+  it("holds null on the deterministic first render (now === 0), before the clock installs", async () => {
+    // useNow returns 0 on first render (no Date.now in render, determinism
+    // convention). With a real upcoming event queued, the FIRST synchronous
+    // render must still be null (the `now === 0` guard), the card only appears
+    // after the effect installs the live clock. We assert the pre-effect frame,
+    // then let the async probe/feed settle so nothing leaks past the test.
+    connectedGoogle();
+    mockFeed([
+      event({
+        id: "soon",
+        title: "Design sync",
+        startAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+      }),
+    ]);
+    const { container } = render(<CalendarUpcomingWidget {...homeProps} />);
+    // Synchronous first paint: feed not loaded + now === 0 → null.
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByTestId("chat-widget-calendar-upcoming")).toBeNull();
+
+    // Once the clock + feed install, the card appears (proving the null above
+    // was the first-render guard, not a permanent self-hide) and the effects
+    // are flushed under act.
+    await screen.findByTestId("chat-widget-calendar-upcoming");
   });
 
   it("applies the grid span to its single root element", async () => {
@@ -255,7 +352,7 @@ describe("CalendarUpcomingWidget", () => {
     expect(navEvents).toContain("/calendar");
   });
 
-  // #11084 — the widget mounts before the auth probe resolves; the connector
+  // #11084, the widget mounts before the auth probe resolves; the connector
   // probe and the calendar feed must stay dormant while unauthenticated.
   it("does not probe the connector or fetch the feed while unauthenticated", async () => {
     authMock.authenticated = false;

--- a/packages/ui/src/components/chat/widgets/calendar-upcoming.tsx
+++ b/packages/ui/src/components/chat/widgets/calendar-upcoming.tsx
@@ -1,22 +1,29 @@
 /**
- * Icon-first home Calendar widget: surfaces the single most imminent upcoming
- * event with a tight relative-time meta ("in 45m") and self-hides when nothing
- * is near. Polls the calendar feed only while the document is visible and the
- * session is authenticated, and publishes a home-attention weight so the tile
- * rises on the home grid when an event is imminent. Registered as
+ * Icon-first home Calendar widget ("Up Next", §B of
+ * NOTIFICATIONS-WIDGETS-SYSTEM.md): surfaces the single most imminent upcoming
+ * event with a tight countdown meta ("in 45m") and self-hides when the next
+ * event is beyond the 18h lookahead gate (an event next Tuesday is not
+ * glanceable urgency). The countdown lives in the <CalendarCountdown> leaf,
+ * which owns its own minute ticker so the card shell never re-renders on the
+ * tick (§C.4). Polls the calendar feed only while the document is visible and
+ * the session is authenticated, and publishes a home-attention weight so the
+ * tile rises on the home grid as an event approaches. Registered as
  * `CALENDAR_HOME_WIDGET`; tapping navigates to the full calendar surface.
  */
 import { CalendarClock } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { client } from "../../../api";
 import { supportsFullAppShellRoutes } from "../../../api/app-shell-capabilities";
-import { useIntervalWhenDocumentVisible } from "../../../hooks";
+import {
+  useDocumentVisibility,
+  useIntervalWhenDocumentVisible,
+} from "../../../hooks";
 import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
-import { useNow } from "../../../hooks/useNow";
 import { withTimeout } from "../../../utils/with-timeout";
 import { usePublishHomeAttention } from "../../../widgets/home-attention-store";
 import { HOME_SIGNAL_WEIGHTS } from "../../../widgets/home-priority";
 import type { WidgetProps } from "../../../widgets/types";
+import { CalendarCountdown, formatCountdown } from "./calendar-countdown";
 import { HomeWidgetCard, useWidgetNavigation } from "./home-widget-card";
 
 const CALENDAR_WIDGET_KEY = "calendar/calendar.upcoming";
@@ -27,16 +34,25 @@ const DEFAULT_SPAN = "col-span-4 row-span-1";
 const PROBE_TIMEOUT_MS = 6_000;
 const FEED_TIMEOUT_MS = 8_000;
 
-// The home glanceable widget refreshes on a calm 60s cadence — the calendar
+// The home glanceable widget refreshes on a calm 60s cadence, the calendar
 // feed is far less volatile than the todo list.
 const CALENDAR_REFRESH_INTERVAL_MS = 60_000;
 // "Urgent" self-signal threshold: an event starting within the next 2 hours.
 const URGENT_WINDOW_MS = 2 * 60 * 60_000;
-// How far ahead the home widget looks for upcoming events.
-const LOOKAHEAD_MS = 14 * 24 * 60 * 60_000;
+// How far ahead the FEED is queried (the calendar API window). The narrower
+// render-time gate below decides what actually earns the home slot.
+const FEED_LOOKAHEAD_MS = 14 * 24 * 60 * 60_000;
+// Render gate (§B "Up Next"): the card only earns its home slot when the next
+// event starts within 18h. An event next Tuesday is not glanceable urgency, so
+// beyond this window the card yields its slot (returns null) to a sibling.
+const LOOKAHEAD_GATE_MS = 18 * 60 * 60_000;
+// Nudge threshold timers just past the boundary so integer comparisons flip on
+// the scheduled render (18h → visible, T-2h → urgent, start → filtered out).
+const THRESHOLD_EPSILON_MS = 1_000;
+const MAX_TIMEOUT_MS = 2_147_483_647;
 
 /**
- * Minimal wire shape of the `/api/lifeops/calendar/feed` response — the fields
+ * Minimal wire shape of the `/api/lifeops/calendar/feed` response, the fields
  * this widget reads from `LifeOpsCalendarEvent` (`@elizaos/shared`
  * contracts/calendar.ts). Defined locally rather than imported so the widget
  * does not couple `@elizaos/ui` to the plugin's client augmentation; validated
@@ -87,20 +103,6 @@ function upcomingEvents(
     .sort((a, b) => a.startAt.localeCompare(b.startAt));
 }
 
-/** Compact relative time, e.g. "now", "in 25m", "in 3h", "tomorrow", "in 2d". */
-function relativeTime(startAt: string, now: number): string {
-  const deltaMs = Date.parse(startAt) - now;
-  if (!Number.isFinite(deltaMs)) return "";
-  const minutes = Math.round(deltaMs / 60_000);
-  if (minutes <= 0) return "now";
-  if (minutes < 60) return `in ${minutes}m`;
-  const hours = Math.round(minutes / 60);
-  if (hours < 24) return `in ${hours}h`;
-  const days = Math.round(hours / 24);
-  if (days === 1) return "tomorrow";
-  return `in ${days}d`;
-}
-
 /** Shallow content equality so an unchanged 60s poll doesn't re-render. */
 function eventsEqual(
   a: CalendarFeedEventWire[],
@@ -119,9 +121,74 @@ function eventsEqual(
 }
 
 /**
+ * Next shell-level clock boundary. The shell never needs minute ticks: it only
+ * changes when an event crosses the 18h render gate, the T-2h urgent threshold,
+ * or its start time (so it drops out of `upcomingEvents`). The visible
+ * per-minute countdown belongs to <CalendarCountdown>.
+ */
+function nextShellThresholdDelayMs(
+  events: CalendarFeedEventWire[],
+  now: number,
+): number | null {
+  const next = upcomingEvents(events, now)[0];
+  if (next == null) return null;
+  const startMs = Date.parse(next.startAt);
+  if (!Number.isFinite(startMs)) return null;
+
+  const untilMs = startMs - now;
+  let thresholdMs: number;
+  if (untilMs > LOOKAHEAD_GATE_MS) {
+    thresholdMs = startMs - LOOKAHEAD_GATE_MS + THRESHOLD_EPSILON_MS;
+  } else if (!next.isAllDay && untilMs > URGENT_WINDOW_MS) {
+    thresholdMs = startMs - URGENT_WINDOW_MS + THRESHOLD_EPSILON_MS;
+  } else {
+    thresholdMs = startMs + THRESHOLD_EPSILON_MS;
+  }
+
+  return Math.min(
+    Math.max(thresholdMs - now, THRESHOLD_EPSILON_MS),
+    MAX_TIMEOUT_MS,
+  );
+}
+
+/**
+ * Deterministic shell clock for calendar thresholds. It returns 0 on the first
+ * render (no Date.now during render), syncs to live time in an effect, then
+ * schedules exactly one visibility-gated timeout for the next threshold. This
+ * keeps countdown minute ticks isolated in <CalendarCountdown>.
+ */
+function useCalendarShellNow(events: CalendarFeedEventWire[]): number {
+  const documentVisible = useDocumentVisibility();
+  const [now, setNow] = useState(0);
+
+  useEffect(() => {
+    if (!documentVisible) return;
+    let cancelled = false;
+    let timeoutId: number | undefined;
+
+    const syncAndSchedule = () => {
+      if (cancelled) return;
+      const current = Date.now();
+      setNow((prev) => (prev === current ? prev : current));
+      const delayMs = nextShellThresholdDelayMs(events, current);
+      if (delayMs == null) return;
+      timeoutId = window.setTimeout(syncAndSchedule, delayMs);
+    };
+
+    syncAndSchedule();
+    return () => {
+      cancelled = true;
+      if (timeoutId != null) window.clearTimeout(timeoutId);
+    };
+  }, [documentVisible, events]);
+
+  return now;
+}
+
+/**
  * CALENDAR "Next event" home widget (id `calendar.upcoming`). A full-width row
  * that shows the SINGLE soonest upcoming event (title + relative time + a
- * "+N more" badge) — and renders ONLY when such an event exists. No connected
+ * "+N more" badge), and renders ONLY when such an event exists. No connected
  * calendar, still probing, or nothing upcoming → `null` (the home self-hide
  * rule); connecting a calendar lives in Settings → Connectors.
  *
@@ -159,7 +226,7 @@ export function CalendarUpcomingWidget({
         client.listConnectorAccounts(GOOGLE_PROVIDER),
         PROBE_TIMEOUT_MS,
       );
-      // Linked ONLY when an account is actually connected — a "needs-reauth" /
+      // Linked ONLY when an account is actually connected, a "needs-reauth" /
       // "pending" account is NOT usable, and treating it as linked left the tile
       // stuck on "Loading…" forever (the feed never returns), instead of showing
       // the "Connect calendar" affordance (matching the connectors strip).
@@ -181,7 +248,7 @@ export function CalendarUpcomingWidget({
   const loadEvents = useCallback(async () => {
     const now = new Date();
     const timeMin = now.toISOString();
-    const timeMax = new Date(now.getTime() + LOOKAHEAD_MS).toISOString();
+    const timeMax = new Date(now.getTime() + FEED_LOOKAHEAD_MS).toISOString();
     const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const params = new URLSearchParams({
       side: "owner",
@@ -202,7 +269,7 @@ export function CalendarUpcomingWidget({
       // Skip the state update (and the re-render) when the poll is unchanged.
       setEvents((prev) => (eventsEqual(prev, next) ? prev : next));
     } catch {
-      // error-policy:J4 timeout / network — settle via the finally so the
+      // error-policy:J4 timeout / network, settle via the finally so the
       // glance tile shows
       // "No events today" instead of spinning on "Loading…".
     } finally {
@@ -226,40 +293,63 @@ export function CalendarUpcomingWidget({
     if (authenticated && connection === "connected") void loadEvents();
   }, CALENDAR_REFRESH_INTERVAL_MS);
 
-  // `useNow` is 0 on first render (deterministic render path — no Date.now in
-  // render) then the live clock, ticking each minute to drive relative-time /
-  // urgency math. The `now === 0` first render is held below as "Loading…".
-  const now = useNow(CALENDAR_REFRESH_INTERVAL_MS);
+  // The shell clock is THRESHOLD-ONLY by design: it updates when the 18h render
+  // gate, T-2h urgency ramp, or event-start boundary flips. The per-minute
+  // "in 40 min" string is NOT read from here; it lives in <CalendarCountdown>,
+  // which owns its own ticker so the minute tick re-renders one <time> node, not
+  // this body (§C.4). `useCalendarShellNow` is 0 on the first render
+  // (deterministic, no Date.now in render); held as null below.
+  const now = useCalendarShellNow(events);
   const visible = useMemo(() => upcomingEvents(events, now), [events, now]);
   const onHome = slot === "home";
   const next = visible[0];
+
+  // Milliseconds until the next event starts (>= 0 for a real upcoming event).
+  const startMs = next != null ? Date.parse(next.startAt) : Number.NaN;
+  const untilMs = Number.isFinite(startMs) ? startMs - now : Number.NaN;
+
+  // 18h lookahead gate (§B "Up Next"): the card earns its slot only when the
+  // next event starts within 18h. `isAllDay` events count from their start too
+  // (an all-day event today is glanceable; one next week is not).
+  const withinLookahead =
+    next != null && Number.isFinite(untilMs) && untilMs <= LOOKAHEAD_GATE_MS;
 
   // Urgent when the next timed event starts within the next 2 hours.
   const urgent =
     next != null &&
     !next.isAllDay &&
-    Number.isFinite(Date.parse(next.startAt)) &&
-    Date.parse(next.startAt) - now >= 0 &&
-    Date.parse(next.startAt) - now <= URGENT_WINDOW_MS;
+    Number.isFinite(untilMs) &&
+    untilMs >= 0 &&
+    untilMs <= URGENT_WINDOW_MS;
 
-  // Float the home card up while an event is imminent; clear otherwise.
+  // Float the home card up while an event is imminent AND inside the gate; a
+  // beyond-18h event must not publish attention for a card that isn't showing.
   usePublishHomeAttention(
     CALENDAR_WIDGET_KEY,
-    onHome && urgent ? HOME_SIGNAL_WEIGHTS.reminder : null,
+    onHome && withinLookahead && urgent ? HOME_SIGNAL_WEIGHTS.reminder : null,
   );
 
-  // The calendar row earns its place ONLY when it has an event to show
-  // (matching the home self-hide rule every sibling widget follows): no
-  // connect-CTA tile, no "Loading…" tile, no "No events today" tile. The
-  // connect flow stays reachable via Settings → Connectors (and the onboarding
-  // notification deep-link); an unlinked or empty calendar simply doesn't
-  // occupy the grid.
-  if (connection !== "connected" || now === 0 || !feedLoaded || next == null) {
+  // The calendar row earns its place ONLY when it has an event to show inside
+  // the 18h window (matching the home self-hide rule every sibling follows): no
+  // connect-CTA tile, no "Loading…" tile, no "No events today" tile, and no card
+  // for an event that is still more than 18h out, that card yields its slot.
+  // The connect flow stays reachable via Settings → Connectors (and the
+  // onboarding notification deep-link).
+  if (
+    connection !== "connected" ||
+    now === 0 ||
+    !feedLoaded ||
+    next == null ||
+    !withinLookahead
+  ) {
     return null;
   }
 
   const title = next.title.trim().length > 0 ? next.title : "(untitled)";
-  const when = next.isAllDay ? "all day" : relativeTime(next.startAt, now);
+  const isAllDay = next.isAllDay;
+  // Screen-reader copy uses the coarse shell clock (per-minute precision is not
+  // meaningful in an aria-label); the visible countdown ticks in the leaf.
+  const whenLabel = isAllDay ? "all day" : formatCountdown(next.startAt, now);
   const more = visible.length - 1;
 
   return (
@@ -268,11 +358,11 @@ export function CalendarUpcomingWidget({
         icon={<CalendarClock />}
         label="Next"
         value={title}
-        meta={when}
+        meta={isAllDay ? "all day" : <CalendarCountdown date={next.startAt} />}
         badge={more > 0 ? `+${more}` : undefined}
         tone={urgent ? "warn" : "default"}
         testId="chat-widget-calendar-upcoming"
-        ariaLabel={`Next event: ${title} ${when}${more > 0 ? ` (+${more} more upcoming)` : ""}. Open Calendar.`}
+        ariaLabel={`Next event: ${title} ${whenLabel}${more > 0 ? ` (+${more} more upcoming)` : ""}. Open calendar.`}
         onActivate={() => nav.openView("/calendar", "calendar")}
       />
     </div>


### PR DESCRIPTION
## Summary
- Gate `calendar.upcoming` so the home card renders only when the next event starts within 18h, otherwise it returns `null` and yields the slot.
- Add a self-contained `<CalendarCountdown>` leaf with a visibility-gated minute ticker, keeping the card shell on threshold-only time updates.
- Update calendar widget copy to sentence case and add Vitest coverage for the 18h gate, first-render null guard, and countdown leaf render-count isolation.

## Notes
- Follow-up for #14559: once the shared `<RelativeTime>` lands, `CalendarCountdown` is intentionally shaped for a one-line swap: replace the import and pass `date={next.startAt}`.
- Codex review was attempted on commit `38bf89903fa`; it hung past 100s with no output twice, so I killed it per lane protocol and self-reviewed the committed diff with `git diff --check`, explicit file list review, and no-em-dash scan.

## Verification
```text
$ NODE_OPTIONS="--no-experimental-webstorage --disable-warning=ExperimentalWarning" npx vitest run --config ./vitest.config.ts src/components/chat/widgets/calendar-upcoming.test.tsx src/components/chat/widgets/calendar-countdown.test.tsx
✓ src/components/chat/widgets/calendar-countdown.test.tsx (8 tests) 61ms
✓ src/components/chat/widgets/calendar-upcoming.test.tsx (13 tests) 228ms

Test Files  2 passed (2)
Tests       21 passed (21)
```

```text
$ NODE_OPTIONS="--no-experimental-webstorage --disable-warning=ExperimentalWarning" npx vitest run --config ./vitest.config.ts src/components/chat/widgets/
Test Files  27 passed (27)
Tests       190 passed (190)
```

```text
$ ../../node_modules/.bin/biome check src/components/chat/widgets/calendar-upcoming.tsx src/components/chat/widgets/calendar-countdown.tsx src/components/chat/widgets/calendar-upcoming.test.tsx src/components/chat/widgets/calendar-countdown.test.tsx
Checked 4 files in 174ms. No fixes applied.
```

```text
$ bun run --cwd packages/shared build
EXIT_SHARED=0
$ bun run --cwd packages/cloud/routing build
EXIT_ROUTING=0
$ bun run --cwd packages/core build
CORE_EXIT=0
```

```text
$ bun run build:web
✓ built in 2m 10s
[verify-chunk-safety] OK: bn.js/crypto graph is confined to lazy vendor chunks (450 current chunks scanned).
[verify-chunk-safety] OK: entry static closure (4 chunks from index-DLLw3bTa.js) contains no lazy-by-design vendor chunk.
BUILD_EXIT=0
```

Closes #14564

— [sol-orch]
