### PR TITLE
feat(scenarios): live-LLM widget round-trip coverage (#14322)

### DIFF
--- a/packages/agent/src/providers/ui-catalog.test.ts
+++ b/packages/agent/src/providers/ui-catalog.test.ts
@@ -186,6 +186,21 @@ describe("relevance keyword separation", () => {
     expect(uiWidgetsProvider.relevanceKeywords?.length ?? 0).toBeGreaterThan(0);
   });
 
+  it("keeps uiWidgets context-gated to scheduling and setup turns, not only general", () => {
+    const expectedContexts = [
+      "general",
+      "tasks",
+      "todos",
+      "productivity",
+      "connectors",
+      "settings",
+    ];
+    expect(uiWidgetsProvider.contexts).toEqual(expectedContexts);
+    expect(uiWidgetsProvider.contextGate).toEqual({
+      anyOf: expectedContexts,
+    });
+  });
+
   it("keeps the heavy generative guide dynamic + turn-scoped + ADMIN-gated", () => {
     expect(uiGenerativeProvider.dynamic).toBe(true);
     expect(uiGenerativeProvider.cacheStable).toBeUndefined();

--- a/packages/agent/src/providers/ui-catalog.ts
+++ b/packages/agent/src/providers/ui-catalog.ts
@@ -104,9 +104,9 @@ follow-up exists.
 
 ### [FORM] — collect several specific values at once
 Render a form instead of asking in prose. This includes relaying a tool result
-that reports missing fields or asks the user for 2+ details: re-ask via [FORM]
-with one field per missing value, never as a prose checklist. Emit INLINE (no
-code fences); body is one JSON object on its own line between the markers:
+that reports missing fields or asks the user for 2+ details: re-ask with a form
+field per missing value, never as a prose checklist. Emit INLINE (no code
+fences); body is one JSON object on its own line between the markers:
 [FORM]
 {"title":"Schedule reminder","submitLabel":"Create","fields":[{"name":"title","type":"text","label":"Reminder","required":true},{"name":"when","type":"datetime","label":"When","required":true},{"name":"channel","type":"select","label":"Notify via","options":[{"label":"Push","value":"push"},{"label":"Email","value":"email"}]}]}
 [/FORM]

--- a/packages/agent/src/providers/ui-catalog.ts
+++ b/packages/agent/src/providers/ui-catalog.ts
@@ -24,11 +24,12 @@
  * on "paragraph"/"comfortable"), OR-ed with a continuation signal — recent
  * JSONL patch output keeps the guide alive while the user iterates on a
  * rendered UI after the intent keywords scroll out of the history window.
- * `uiWidgets` deliberately keeps the old provider's ungated-on-general
- * behavior — gating it on the legacy keyword list would silence [FORM]
- * guidance on scheduling turns ("remind me tomorrow at 9" matches none of
- * those keywords). uiWidgets' constant text is cacheable per-agent;
- * uiGenerative's output varies per turn, so it must not declare cacheStable.
+ * `uiWidgets` is context-gated to the Stage-1 contexts its markers serve
+ * (general/tasks/todos/productivity/connectors/settings). Gating it on the
+ * old general-only context silenced [FORM] guidance on scheduling turns and
+ * [CONFIG] guidance on connector setup turns. uiWidgets' constant text is
+ * cacheable per-agent; uiGenerative's output varies per turn, so it must not
+ * declare cacheStable.
  */
 import {
   ChannelType,
@@ -102,8 +103,10 @@ the composer for editing. Labels 1–4 words. Omit the block when no useful
 follow-up exists.
 
 ### [FORM] — collect several specific values at once
-Render a form instead of asking in prose. Emit INLINE (no code fences); body
-is one JSON object on its own line between the markers:
+Render a form instead of asking in prose. This includes relaying a tool result
+that reports missing fields or asks the user for 2+ details: re-ask via [FORM]
+with one field per missing value, never as a prose checklist. Emit INLINE (no
+code fences); body is one JSON object on its own line between the markers:
 [FORM]
 {"title":"Schedule reminder","submitLabel":"Create","fields":[{"name":"title","type":"text","label":"Reminder","required":true},{"name":"when","type":"datetime","label":"When","required":true},{"name":"channel","type":"select","label":"Notify via","options":[{"label":"Push","value":"push"},{"label":"Email","value":"email"}]}]}
 [/FORM]
@@ -149,8 +152,28 @@ export const uiWidgetsProvider: Provider = {
   relevanceKeywords: getValidationKeywordTerms("provider.uiWidgets.relevance", {
     includeAllLocales: true,
   }),
-  contexts: ["general"],
-  contextGate: { anyOf: ["general"] },
+  // The v5 planner filters dynamic providers by exact Stage-1 contexts, with
+  // no ancestor expansion. A scheduling turn can select `tasks`, while plugin
+  // setup selects `connectors`/`settings`; `general` alone misses the guide's
+  // flagship marker use cases.
+  contexts: [
+    "general",
+    "tasks",
+    "todos",
+    "productivity",
+    "connectors",
+    "settings",
+  ],
+  contextGate: {
+    anyOf: [
+      "general",
+      "tasks",
+      "todos",
+      "productivity",
+      "connectors",
+      "settings",
+    ],
+  },
   cacheStable: true,
   cacheScope: "agent",
 

--- a/packages/agent/src/providers/ui-generative.gate.test.ts
+++ b/packages/agent/src/providers/ui-generative.gate.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Runtime-behavior contract for the uiGenerative intent gate (#14324
+ * follow-up): the landed split's keyword tests only pin list MEMBERSHIP, but
+ * `relevanceKeywords` is consumed by no selection engine — on the v5 path both
+ * providers compose on every general ADMIN planner turn, so the in-get gate is
+ * the only thing keeping the ~150-line catalog off non-generative turns. These
+ * tests pin the gate's actual firing behavior: word-boundary matching (prose
+ * containing keyword substrings stays quiet), history-window firing, the
+ * JSONL-continuation signal, markers-first ordering, and cache semantics.
+ * Deterministic; no live model.
+ */
+import {
+  ChannelType,
+  type IAgentRuntime,
+  type Memory,
+  type State,
+} from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { uiGenerativeProvider, uiWidgetsProvider } from "./ui-catalog.ts";
+
+const runtime = {} as unknown as IAgentRuntime;
+const emptyState = {} as unknown as State;
+
+const msg = (text: string, channelType: ChannelType = ChannelType.API) =>
+  ({ content: { text, channelType } }) as unknown as Memory;
+
+const withHistory = (text: string) =>
+  ({
+    data: {
+      providers: {
+        RECENT_MESSAGES: { data: { recentMessages: [{ content: { text } }] } },
+      },
+    },
+  }) as unknown as State;
+
+describe("uiGenerative — enforced intent gate", () => {
+  it("fires on generative intent and stays silent on plugin setup", async () => {
+    const generative = await uiGenerativeProvider.get(
+      runtime,
+      msg("show me a dashboard of my metrics"),
+      emptyState,
+    );
+    expect(generative.text).toContain('{"op":"add"');
+
+    const setup = await uiGenerativeProvider.get(
+      runtime,
+      msg("set up discord"),
+      emptyState,
+    );
+    expect(setup.text).toBe("");
+  });
+
+  it("matches whole words only — prose containing keyword substrings stays quiet", async () => {
+    // "paragraph" ⊃ "graph", "comfortable" ⊃ "table", "guide" ⊃ "ui" — bare
+    // substring matching fired the catalog on all of these.
+    const result = await uiGenerativeProvider.get(
+      runtime,
+      msg("that paragraph in the guide was comfortable to read"),
+      emptyState,
+    );
+    expect(result.text).toBe("");
+  });
+
+  it("fires on intent in recent history, not just the current message", async () => {
+    const neutral = msg("make the second column green");
+    expect(
+      (await uiGenerativeProvider.get(runtime, neutral, emptyState)).text,
+    ).toBe("");
+    expect(
+      (
+        await uiGenerativeProvider.get(
+          runtime,
+          neutral,
+          withHistory("build a dashboard of my week"),
+        )
+      ).text,
+    ).toContain('{"op":"add"');
+  });
+
+  it("keeps firing mid-iteration via the agent's own JSONL patches", async () => {
+    const neutral = msg("add a filter row");
+    expect(
+      (
+        await uiGenerativeProvider.get(
+          runtime,
+          neutral,
+          withHistory('{"op":"add","path":"/root","value":"card-1"}'),
+        )
+      ).text,
+    ).toContain('{"op":"add"');
+  });
+
+  it("channel gate holds even with keyword-bearing text", async () => {
+    const result = await uiGenerativeProvider.get(
+      runtime,
+      msg("show me a dashboard chart", ChannelType.GROUP),
+      emptyState,
+    );
+    expect(result.text).toBe("");
+  });
+
+  it("renders after uiWidgets on dual-fire turns and drops stale cache claims", () => {
+    // composeState orders by (position || 0) then name; "uiGenerative" sorts
+    // before "uiWidgets", so markers-first needs an explicit position.
+    expect(uiGenerativeProvider.position).toBeGreaterThan(
+      uiWidgetsProvider.position ?? 0,
+    );
+    // uiWidgets emits constant text → cacheable; uiGenerative varies per turn.
+    expect(uiWidgetsProvider.cacheStable).toBe(true);
+    expect(uiGenerativeProvider.cacheStable).toBeUndefined();
+  });
+
+  it("both providers carry a discovery description", () => {
+    for (const provider of [uiWidgetsProvider, uiGenerativeProvider]) {
+      expect(provider.description?.length ?? 0).toBeGreaterThan(20);
+    }
+  });
+});

--- a/packages/scenario-runner/test/scenarios/_helpers/chat-widgets.ts
+++ b/packages/scenario-runner/test/scenarios/_helpers/chat-widgets.ts
@@ -1,0 +1,175 @@
+/**
+ * Shared glue for the live chat-widget round-trip scenarios (#14322).
+ *
+ * The scenario runtime factory boots a lean plugin set that does NOT include
+ * the @elizaos/agent eliza plugin, which is what normally registers the
+ * model-facing `uiWidgets` marker guide (`[CONFIG:…]` / `[FORM]` /
+ * `[FOLLOWUPS]` / `[CHECKLIST]` / `[WORKFLOW]`). `uiWidgetsGuideSeed` registers
+ * the REAL provider (imported from the agent package, not a copy) on the
+ * scenario runtime so live scenarios exercise the exact guide text production
+ * ships. The scenario sender resolves to OWNER (the executor sets
+ * ELIZA_ADMIN_ENTITY_ID to the primary room user), so the provider's
+ * `roleGate: { minRole: "ADMIN" }` is satisfied on the v5 planner path.
+ *
+ * The FORM helpers replicate exactly what the dashboard renderer does with a
+ * model-emitted `[FORM]` block: parse it with the shared core parser
+ * (`packages/core/src/messaging/interactions/parse.ts` — the same grammar the
+ * UI accepts, including generating an id when the model omits one) and
+ * re-enter the submit as the literal `[form:submit <id>] {json}` wire message
+ * (`packages/ui/src/components/chat/widgets/use-inline-widget-context.ts`).
+ * There is deliberately NO server-side consumer of that wire text — the round
+ * trip is trusted text re-entry, which is precisely what these scenarios put
+ * under live-model test.
+ */
+
+import { uiWidgetsProvider } from "@elizaos/agent/providers/ui-catalog";
+import type { Plugin } from "@elizaos/core";
+import type {
+  ScenarioContext,
+  ScenarioSeedStep,
+} from "@elizaos/scenario-runner/schema";
+import { findInteractionRegions } from "../../../../core/src/messaging/interactions/parse.ts";
+import type {
+  FormInteraction,
+  InteractionField,
+} from "../../../../core/src/types/interactions.ts";
+
+const GUIDE_PLUGIN_NAME = "scenario-chat-widgets-guide";
+
+/**
+ * Seed step registering the production uiWidgets guide provider on the
+ * scenario runtime. Idempotent so a shared-runtime CLI invocation that runs
+ * several widget scenarios back to back does not double-register.
+ */
+export function uiWidgetsGuideSeed(): ScenarioSeedStep {
+  return {
+    type: "custom",
+    name: "register the production uiWidgets marker guide provider",
+    apply: async (ctx: ScenarioContext) => {
+      const runtime = ctx.runtime as {
+        plugins?: Array<{ name?: string }>;
+        registerPlugin?: (plugin: Plugin) => Promise<void>;
+      } | null;
+      if (!runtime?.registerPlugin) {
+        return "runtime.registerPlugin unavailable";
+      }
+      const alreadyRegistered = (runtime.plugins ?? []).some(
+        (plugin) => plugin.name === GUIDE_PLUGIN_NAME,
+      );
+      if (alreadyRegistered) {
+        return undefined;
+      }
+      await runtime.registerPlugin({
+        name: GUIDE_PLUGIN_NAME,
+        description:
+          "Scenario fixture: registers the production uiWidgets marker guide " +
+          "(normally carried by the @elizaos/agent eliza plugin) so live " +
+          "widget round-trip scenarios see the real model-facing guide.",
+        providers: [uiWidgetsProvider],
+      });
+      return undefined;
+    },
+  };
+}
+
+/** Every parsed `[FORM]` block in `text`, using the shared core grammar. */
+export function findFormBlocks(text: string): FormInteraction[] {
+  return findInteractionRegions(text)
+    .map((region) => region.block)
+    .filter((block): block is FormInteraction => block.kind === "form");
+}
+
+const TEMPORAL_FIELD_TYPES = new Set(["date", "time", "datetime"]);
+
+/**
+ * Canonical values the harness "types into" the model's form. Distinctive
+ * tokens ("Q3", "budget", "Dana") let post-submit assertions confirm the
+ * agent used the SUBMITTED values rather than something it invented.
+ */
+export const CANONICAL_FORM_TEXT_VALUE = "Send the Q3 budget report to Dana";
+export const CANONICAL_FORM_DATE = "2026-07-14";
+export const CANONICAL_FORM_TIME = "09:30";
+export const CANONICAL_FORM_DATETIME = `${CANONICAL_FORM_DATE}T${CANONICAL_FORM_TIME}`;
+export const CANONICAL_FORM_NUMBER = 45;
+
+/**
+ * Validate a model-emitted reply against the [FORM] contract the uiWidgets
+ * guide teaches: an inline (un-fenced) block the shared parser accepts, with
+ * at least two fields and at least one native temporal field (the guide
+ * forbids collecting a date/time as free text — #14484). Returns the parsed
+ * form on success, or a failure string.
+ */
+export function validateSchedulingFormReply(
+  text: string,
+): FormInteraction | string {
+  if (text.includes("```")) {
+    return "reply wraps content in a code fence; the guide requires markers to be emitted inline with no fences";
+  }
+  const forms = findFormBlocks(text);
+  if (forms.length === 0) {
+    const mentionsMarker = text.includes("[FORM]");
+    return mentionsMarker
+      ? "reply contains a [FORM] marker the shared parser rejects (malformed body — this is a grammar bug, quote the raw block)"
+      : "reply contains no parseable [FORM] block";
+  }
+  if (forms.length > 1) {
+    return `reply contains ${forms.length} [FORM] blocks; expected exactly one`;
+  }
+  const form = forms[0];
+  if (form.fields.length < 2) {
+    return `form has ${form.fields.length} field(s); a scheduling form needs at least a title and a time`;
+  }
+  const temporal = form.fields.filter((field) =>
+    TEMPORAL_FIELD_TYPES.has(field.type),
+  );
+  if (temporal.length === 0) {
+    return `form has no date/time/datetime field (types: ${form.fields
+      .map((field) => `${field.name}:${field.type}`)
+      .join(", ")}); the guide forbids collecting a schedule time as free text`;
+  }
+  return form;
+}
+
+/** The value the harness fills into one field, by declared type. */
+function fillValue(field: InteractionField): string | number | boolean {
+  switch (field.type) {
+    case "date":
+      return CANONICAL_FORM_DATE;
+    case "time":
+      return CANONICAL_FORM_TIME;
+    case "datetime":
+      return CANONICAL_FORM_DATETIME;
+    case "number":
+      return CANONICAL_FORM_NUMBER;
+    case "checkbox":
+      return true;
+    case "select":
+      return field.options?.[0]?.value ?? "";
+    default:
+      return CANONICAL_FORM_TEXT_VALUE;
+  }
+}
+
+/** Fill every field of a parsed form with the canonical harness values. */
+export function fillFormValues(
+  form: FormInteraction,
+): Record<string, string | number | boolean> {
+  const values: Record<string, string | number | boolean> = {};
+  for (const field of form.fields) {
+    values[field.name] = fillValue(field);
+  }
+  return values;
+}
+
+/**
+ * The exact wire message the dashboard sends when the user hits Submit —
+ * byte-for-byte the `use-inline-widget-context.ts` format. The id is the
+ * PARSED form id (generated client-side when the model omitted one), so the
+ * model may see an id it never emitted; the round trip must tolerate that.
+ */
+export function buildFormSubmitText(
+  form: FormInteraction,
+  values: Record<string, string | number | boolean>,
+): string {
+  return `[form:submit ${form.id}] ${JSON.stringify(values)}`;
+}

--- a/packages/scenario-runner/test/scenarios/_helpers/chat-widgets.ts
+++ b/packages/scenario-runner/test/scenarios/_helpers/chat-widgets.ts
@@ -7,9 +7,8 @@
  * `[FOLLOWUPS]` / `[CHECKLIST]` / `[WORKFLOW]`). `uiWidgetsGuideSeed` registers
  * the REAL provider (imported from the agent package, not a copy) on the
  * scenario runtime so live scenarios exercise the exact guide text production
- * ships. The scenario sender resolves to OWNER (the executor sets
- * ELIZA_ADMIN_ENTITY_ID to the primary room user), so the provider's
- * `roleGate: { minRole: "ADMIN" }` is satisfied on the v5 planner path.
+ * ships. The provider is intentionally not role-gated; channel/context gating is
+ * the production guard, and the scenarios use the same DM/API-style runtime path.
  *
  * The FORM helpers replicate exactly what the dashboard renderer does with a
  * model-emitted `[FORM]` block: parse it with the shared core parser

--- a/packages/scenario-runner/test/scenarios/live-chat-widgets-choice-roundtrip.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-chat-widgets-choice-roundtrip.scenario.ts
@@ -1,0 +1,173 @@
+/**
+ * Live-model CHOICE widget round trip (#14322). An app-create request that
+ * fuzzy-matches an installed app makes the APP action emit a
+ * `[CHOICE:app-create id=…]` picker block (plugin-app-control/app-create.ts)
+ * and persist the pending intent as a task. The harness then plays the
+ * dashboard user: a CHOICE tap re-enters as the option's raw `value` sent as
+ * an ordinary message (use-inline-widget-context.ts `sendAction`), so turn 2
+ * sends the literal option value and the live model must route that bare
+ * token back into APP, which honors the pick — here `cancel`, which deletes
+ * the pending intent task (asserted as the domain artifact) with no side
+ * effects. `cancel` is the deliberate pick: `new`/`edit-N` would scaffold an
+ * app or dispatch a coding agent from a scenario run.
+ *
+ * Installed apps are served by the fetch loopback so the picker branch is
+ * deterministic; the model routing and the pick round trip are live.
+ *
+ * KNOWN-RED (#14322 finding): this scenario asserts the correct product
+ * contract and fails today because the v5 planner path DROPS action handler
+ * callback text. The `executeV5PlannedToolCall` call sites in
+ * `packages/core/src/services/message.ts` build `executorCtx` without a
+ * `callback`, so `execute-planned-tool-call.ts` hands `undefined` to
+ * `action.handler(...)` and the `[CHOICE:app-create …]` block that
+ * plugin-app-control emits via `callback?.({ text })` never reaches the user —
+ * the reply is the Stage-1 early ack ("On it.") and the picker exists only in
+ * the captured ActionResult. Turn 2 then compounds it: with no picker on
+ * screen the planner answers "cancel" with a bare REPLY ("Canceled.") without
+ * running APP, leaving the pending intent task alive — a fabricated
+ * cancellation. Fixing the callback plumbing is core planner surgery tracked
+ * as a follow-up in #14322.
+ */
+
+import { stringToUuid } from "@elizaos/core";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { hasPendingIntent } from "../../../../plugins/plugin-app-control/src/actions/app-create.ts";
+import { findInteractionRegions } from "../../../core/src/messaging/interactions/parse.ts";
+import {
+  jsonResponse,
+  registerAppControlHttpHandler,
+  resetAppControlHttpLoopback,
+} from "./_helpers/app-control-http-loopback";
+
+// Mirrors the executor's room-id derivation (`scenario-room:<id>:<room>`), so
+// the final check can query the pending-intent task for the room turns ran in.
+// The scenario id below must stay a string literal (the loader reads it via
+// static AST), so it is repeated here rather than shared through a const.
+const MAIN_ROOM_ID = stringToUuid(
+  "scenario-room:live-chat-widgets-choice-roundtrip:main",
+);
+
+const INSTALLED_APPS_FIXTURE = [
+  {
+    name: "notes",
+    displayName: "Notes",
+    pluginName: "@elizaos/app-notes",
+    version: "1.0.0",
+    installedAt: "2026-01-01T00:00:00.000Z",
+  },
+  {
+    name: "tasks",
+    displayName: "Tasks",
+    pluginName: "@elizaos/app-tasks",
+    version: "1.0.0",
+    installedAt: "2026-01-01T00:00:00.000Z",
+  },
+];
+
+export default scenario({
+  id: "live-chat-widgets-choice-roundtrip",
+  lane: "live-only",
+  title: "Real LLM surfaces a [CHOICE] picker, then honors the picked value",
+  domain: "chat-widgets",
+  tags: ["live", "real-llm", "chat-widgets", "choice", "app-control"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-app-control"],
+  },
+  seed: [
+    {
+      type: "custom",
+      name: "serve installed apps over the fetch loopback",
+      apply: () => {
+        resetAppControlHttpLoopback();
+        registerAppControlHttpHandler((request) => {
+          if (
+            request.method === "GET" &&
+            request.pathname === "/api/apps/installed"
+          ) {
+            return jsonResponse(INSTALLED_APPS_FIXTURE);
+          }
+          return undefined;
+        });
+        return undefined;
+      },
+    },
+  ],
+  rooms: [
+    {
+      id: "main",
+      source: "eliza-app",
+      title: "Chat Widgets Choice",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "app-create request with an existing match yields a [CHOICE] picker",
+      room: "main",
+      text: "Create a notes app for me.",
+      assertTurn: (execution) => {
+        const text = execution.responseText ?? "";
+        const choices = findInteractionRegions(text)
+          .map((region) => region.block)
+          .filter((block) => block.kind === "choice");
+        if (choices.length === 0) {
+          return text.includes("[CHOICE")
+            ? `reply contains a [CHOICE marker the shared parser rejects (malformed block): ${JSON.stringify(text.slice(0, 400))}`
+            : `reply contains no parseable [CHOICE] block: ${JSON.stringify(text.slice(0, 400))}`;
+        }
+        const picker = choices[0];
+        if (picker.scope !== "app-create") {
+          return `expected [CHOICE:app-create …], saw scope '${picker.scope}'`;
+        }
+        const values = picker.options.map((option) => option.value);
+        for (const expected of ["new", "edit-1", "cancel"]) {
+          if (!values.includes(expected)) {
+            return `picker is missing the '${expected}' option (options: ${values.join(", ")})`;
+          }
+        }
+        return undefined;
+      },
+    },
+    {
+      kind: "message",
+      name: "the raw picked value ('cancel') is routed back and honored",
+      room: "main",
+      // The dashboard sends the picked option's bare `value` as an ordinary
+      // message — this is the exact wire text a CHOICE tap produces.
+      text: "cancel",
+      responseIncludesAny: [/cancel/i],
+    },
+  ],
+  finalChecks: [
+    {
+      type: "actionCalled",
+      actionName: "APP",
+      status: "success",
+      minCount: 2,
+    },
+    {
+      type: "custom",
+      name: "the pick was honored: pending intent task deleted, cancel path taken",
+      predicate: async (ctx) => {
+        const cancelTurn = ctx.actionsCalled.find((action) => {
+          if (action.actionName !== "APP") return false;
+          const values = action.result?.values as
+            | { subMode?: unknown }
+            | undefined;
+          return values?.subMode === "cancel";
+        });
+        if (!cancelTurn) {
+          return `no APP call resolved with subMode=cancel (actions: ${ctx.actionsCalled
+            .map((action) => action.actionName)
+            .join(", ")})`;
+        }
+        const runtime = ctx.runtime as Parameters<typeof hasPendingIntent>[0];
+        const stillPending = await hasPendingIntent(runtime, MAIN_ROOM_ID);
+        return stillPending
+          ? "pending app-create intent task still exists after the cancel pick"
+          : undefined;
+      },
+    },
+  ],
+});

--- a/packages/scenario-runner/test/scenarios/live-chat-widgets-config-emission.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-chat-widgets-config-emission.scenario.ts
@@ -1,0 +1,60 @@
+/**
+ * Live-model [CONFIG] emission (#14322). When the user names a plugin for
+ * setup, the uiWidgets guide instructs the model to emit EXACTLY
+ * `[CONFIG:pluginId]` and stop — the dashboard generates the full config form
+ * from the plugin schema. This proves a real model, given the production
+ * guide, replies with the marker instead of hand-writing credential steps or
+ * falling back to generative-UI JSONL patches.
+ *
+ * The named plugin is polymarket (one of the guide's own examples), NOT
+ * discord: the scenario harness boots mocked connectors, so "set up discord"
+ * routes to CONNECTOR_CONNECT which SUCCEEDS against the mock and the agent
+ * truthfully replies "Discord is set up and connected as mocked_owner#0001" —
+ * asserting a config card there would assert the wrong behavior for that
+ * environment (captured live in evidence-14322/config-report.json). Polymarket
+ * has no connector/action in the scenario runtime, so the marker path is the
+ * only correct answer. Needs live model credentials (live-only lane).
+ */
+
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { uiWidgetsGuideSeed } from "./_helpers/chat-widgets";
+
+export default scenario({
+  id: "live-chat-widgets-config-emission",
+  lane: "live-only",
+  title:
+    "Real LLM answers 'set up polymarket' with [CONFIG:polymarket], no prose walkthrough",
+  domain: "chat-widgets",
+  tags: ["live", "real-llm", "chat-widgets", "config"],
+  isolation: "per-scenario",
+  seed: [uiWidgetsGuideSeed()],
+  rooms: [
+    {
+      id: "main",
+      source: "eliza-app",
+      title: "Chat Widgets Config",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "plugin-setup request must emit the [CONFIG:polymarket] marker",
+      room: "main",
+      text: "Help me set up the polymarket plugin.",
+      responseIncludesAny: [/\[CONFIG:(@elizaos\/plugin-)?polymarket\]/i],
+      // No generative-UI escape hatch: a JSONL patch line in a plugin-setup
+      // reply means the model reached for the wrong tool (the guide's marker
+      // path exists precisely to keep setup off raw JSONL).
+      responseExcludes: [/"op"\s*:\s*"(add|replace|remove)"/],
+      responseJudge: {
+        minimumScore: 0.7,
+        rubric:
+          "The user asked to set up the polymarket plugin. The reply must present " +
+          "the configuration via the [CONFIG:polymarket] marker (the UI renders the " +
+          "actual form). It must NOT walk the user through manual setup steps in " +
+          "prose — no instructions to find/copy API keys or paste credentials into " +
+          "config files. A short sentence introducing the config card is fine.",
+      },
+    },
+  ],
+});

--- a/packages/scenario-runner/test/scenarios/live-chat-widgets-followups-restraint.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-chat-widgets-followups-restraint.scenario.ts
@@ -1,0 +1,47 @@
+/**
+ * Live-model FOLLOWUPS restraint (#14322). The uiWidgets guide ends with
+ * "ONLY when a follow-up genuinely helps — never to pad": a plain factual
+ * question must come back as a plain answer, with no [FOLLOWUPS] chips and no
+ * other widget markers bolted on. This is the negative-space check for the
+ * marker vocabulary — a model that pads every reply with chips makes the
+ * widget system noise. (Simple factual turns may resolve on the Stage-1 fast
+ * path where the guide is not even composed; that path trivially satisfies
+ * the contract, and planner-path turns are covered by the assertion all the
+ * same.) Needs live model credentials (live-only lane).
+ */
+
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { uiWidgetsGuideSeed } from "./_helpers/chat-widgets";
+
+export default scenario({
+  id: "live-chat-widgets-followups-restraint",
+  lane: "live-only",
+  title: "Real LLM answers a factual question without padding on [FOLLOWUPS]",
+  domain: "chat-widgets",
+  tags: ["live", "real-llm", "chat-widgets", "followups"],
+  isolation: "per-scenario",
+  seed: [uiWidgetsGuideSeed()],
+  rooms: [
+    {
+      id: "main",
+      source: "eliza-app",
+      title: "Chat Widgets Followups",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "plain factual question gets a plain answer, no widget markers",
+      room: "main",
+      text: "What year did the Apollo 11 moon landing happen?",
+      responseIncludesAny: [/1969/],
+      responseExcludes: [
+        /\[FOLLOWUPS/,
+        /\[FORM\]/,
+        /\[CONFIG:/,
+        /\[CHECKLIST\]/,
+        /\[WORKFLOW\]/,
+      ],
+    },
+  ],
+});

--- a/packages/scenario-runner/test/scenarios/live-chat-widgets-form-roundtrip.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-chat-widgets-form-roundtrip.scenario.ts
@@ -1,0 +1,197 @@
+/**
+ * Live-model FORM widget round trip (#14322). A vague scheduling request must
+ * make the real model emit a grammar-valid `[FORM]` block (per the uiWidgets
+ * guide: one inline JSON line, native date/time/datetime fields for any
+ * scheduling input — #14484). The harness then plays the dashboard user: it
+ * parses the block exactly like the renderer does and re-enters the submit as
+ * the literal `[form:submit <id>] {json}` wire message
+ * (use-inline-widget-context.ts). The agent's next turn must consume that raw
+ * re-entry — confirm using the SUBMITTED values and route them into a real
+ * domain action (scheduled task / reminder / todo), not re-ask or echo JSON.
+ *
+ * There is no server-side consumer of `[form:submit …]`; the whole round trip
+ * is trusted text re-entry, which is exactly what this scenario puts under
+ * live test. Needs live model credentials (live-only lane).
+ *
+ * KNOWN-RED (#14322 finding): this scenario asserts the correct product
+ * contract and fails today because [FORM] is structurally unreachable on the
+ * v5 path. The chain, live-verified in evidence-14322/form-run-attempt* with
+ * the uiWidgets guide confirmed present in the planner AND evaluation
+ * prompts: (1) planner rules force tool-first ("matching tool exists => call
+ * it, even missing details; handler owns questions"), so the model calls
+ * OWNER_REMINDERS_CREATE instead of emitting a form; (2) the handler
+ * clarifies in prose ("What's the report name, day, and time?"); (3) the
+ * evaluator stage — the model that authors the user-visible messageToUser —
+ * is bound by "messageToUser … no … JSON/tool attempts" and "One JSON object
+ * only" (its own envelope), so a [FORM] block (whose body IS a JSON line) can
+ * never survive, while JSON-free markers like [CONFIG:pluginId] pass. Stage 1
+ * never composes the guide (CORE_RESPONSE_STATE_PROVIDERS only). Fixing this
+ * needs a core evaluator/messageToUser contract carve-out for interaction
+ * markers — tracked as a follow-up in #14322.
+ */
+
+import { scenario } from "@elizaos/scenario-runner/schema";
+import type { FormInteraction } from "../../../core/src/types/interactions.ts";
+import {
+  buildFormSubmitText,
+  CANONICAL_FORM_DATE,
+  fillFormValues,
+  uiWidgetsGuideSeed,
+  validateSchedulingFormReply,
+} from "./_helpers/chat-widgets";
+
+// Turn 1 captures the parsed form here; turn 2's lazy `text` getter builds the
+// submit wire message from it. Reset in seed so reruns on a shared runtime
+// never replay a stale form id.
+let capturedForm: FormInteraction | null = null;
+let submittedValues: Record<string, string | number | boolean> = {};
+
+// Conversational/action-selection plumbing that must NOT count as the domain
+// write the submitted values are supposed to reach.
+const CONVERSATIONAL_ACTIONS = new Set(["REPLY", "IGNORE", "NONE"]);
+
+// The distinctive tokens from CANONICAL_FORM_TEXT_VALUE — proof the agent used
+// what the user typed into the form, not something it invented.
+const SUBMITTED_TOKEN_RE = /q3|budget|dana/i;
+
+export default scenario({
+  id: "live-chat-widgets-form-roundtrip",
+  lane: "live-only",
+  title: "Real LLM emits a [FORM], consumes the raw [form:submit] re-entry",
+  domain: "chat-widgets",
+  tags: ["live", "real-llm", "chat-widgets", "form", "lifeops"],
+  isolation: "per-scenario",
+  seed: [
+    uiWidgetsGuideSeed(),
+    {
+      type: "custom",
+      name: "reset captured form state",
+      apply: () => {
+        capturedForm = null;
+        submittedValues = {};
+        return undefined;
+      },
+    },
+  ],
+  rooms: [
+    {
+      id: "main",
+      source: "eliza-app",
+      title: "Chat Widgets Form",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "multi-detail reminder request must yield a scheduling [FORM]",
+      room: "main",
+      // Deliberately leaves SEVERAL values open (name + day + time): the
+      // uiWidgets guide only licenses [FORM] when multiple specific values are
+      // needed ("do NOT use it for a single free-text answer — just ask"), so
+      // a one-unknown phrasing ("remind me about my report") legitimately gets
+      // a prose question instead of a form (observed live — see
+      // evidence-14322/form-report-attempt2.json).
+      text: "I need a reminder for an upcoming report deadline — you'll need the report name, the day, and the time from me.",
+      assertTurn: (execution) => {
+        const result = validateSchedulingFormReply(
+          execution.responseText ?? "",
+        );
+        if (typeof result === "string") {
+          return result;
+        }
+        capturedForm = result;
+        submittedValues = fillFormValues(result);
+        return undefined;
+      },
+    },
+    {
+      kind: "message",
+      name: "raw [form:submit] re-entry must be consumed, not re-asked",
+      room: "main",
+      // Built lazily from the form the model ACTUALLY emitted in turn 1 —
+      // field names, id, everything. The fallback keeps the executor from
+      // throwing on empty text when turn 1 already failed.
+      get text() {
+        if (!capturedForm) {
+          return '[form:submit form-missing] {"error":"no form captured in turn 1"}';
+        }
+        return buildFormSubmitText(capturedForm, submittedValues);
+      },
+      responseExcludes: [/\[FORM\]/],
+      responseJudge: {
+        minimumScore: 0.7,
+        rubric:
+          "The user just submitted a structured form containing reminder details: " +
+          "a title/description mentioning a Q3 budget report (for Dana), and — when the " +
+          "form had a date/time field — the local time 2026-07-14 09:30. The assistant " +
+          "must confirm the reminder/task using those submitted values (the report topic " +
+          "and, if given, the requested day/time). It must NOT ask again for details it " +
+          "already received, must NOT show the raw submitted JSON back to the user, and " +
+          "must NOT claim it could not read the submission.",
+      },
+      assertTurn: (execution) => {
+        const text = execution.responseText ?? "";
+        if (!SUBMITTED_TOKEN_RE.test(text)) {
+          return `post-submit reply never references the submitted values (expected a Q3/budget/Dana mention): ${JSON.stringify(text.slice(0, 400))}`;
+        }
+        return undefined;
+      },
+    },
+  ],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "submitted values reached a real domain action (not just prose)",
+      predicate: (ctx) => {
+        const domainWrites = ctx.actionsCalled.filter((action) => {
+          if (CONVERSATIONAL_ACTIONS.has(action.actionName)) return false;
+          const payload = JSON.stringify({
+            parameters: action.parameters ?? null,
+            result: action.result ?? null,
+          });
+          return SUBMITTED_TOKEN_RE.test(payload);
+        });
+        if (domainWrites.length === 0) {
+          const seen = ctx.actionsCalled
+            .map((action) => action.actionName)
+            .join(", ");
+          return `no non-conversational action carried the submitted form values (actions called: ${seen || "none"})`;
+        }
+        const failed = domainWrites.every(
+          (action) => action.result?.success === false || action.error,
+        );
+        if (failed) {
+          return `domain action(s) received the submitted values but none succeeded: ${domainWrites
+            .map(
+              (action) =>
+                `${action.actionName}(${action.error?.message ?? "success=false"})`,
+            )
+            .join(", ")}`;
+        }
+        return undefined;
+      },
+    },
+    {
+      type: "custom",
+      name: "submitted schedule date reached the domain action when a temporal field existed",
+      predicate: (ctx) => {
+        if (!capturedForm) return "no form was captured in turn 1";
+        const hadTemporalField = capturedForm.fields.some((field) =>
+          ["date", "time", "datetime"].includes(field.type),
+        );
+        if (!hadTemporalField) return undefined;
+        const dateReached = ctx.actionsCalled.some((action) => {
+          if (CONVERSATIONAL_ACTIONS.has(action.actionName)) return false;
+          const payload = JSON.stringify({
+            parameters: action.parameters ?? null,
+            result: action.result ?? null,
+          });
+          return payload.includes(CANONICAL_FORM_DATE);
+        });
+        return dateReached
+          ? undefined
+          : `no non-conversational action carried the submitted date ${CANONICAL_FORM_DATE}`;
+      },
+    },
+  ],
+});

--- a/packages/shared/src/i18n/keywords/shared.keywords.json
+++ b/packages/shared/src/i18n/keywords/shared.keywords.json
@@ -3673,7 +3673,13 @@
         "interface",
         "visualization",
         "visualisation",
+        "visualize",
+        "visualise",
         "graph",
+        "plot",
+        "diagram",
+        "analytics",
+        "kpi",
         "render a",
         "build a dashboard"
       ],

--- a/packages/ui/src/components/chat/InlineWidgetText.test.tsx
+++ b/packages/ui/src/components/chat/InlineWidgetText.test.tsx
@@ -107,6 +107,21 @@ describe("InlineWidgetText", () => {
     expect(container.textContent).toContain("just a normal reply");
   });
 
+  it("renders form submit markers as compact receipts", () => {
+    const { container } = withApp(
+      <InlineWidgetText
+        content={
+          '[form:submit reminder-details] {"title":"Draft report","when":"2026-07-08T09:00"}'
+        }
+      />,
+    );
+    expect(screen.getByTestId("form-submit-receipt").textContent).toBe(
+      "Submitted reminder details",
+    );
+    expect(container.textContent ?? "").not.toContain("[form:submit");
+    expect(container.textContent ?? "").not.toContain("Draft report");
+  });
+
   it("renders a choice picker and does not leak the [CHOICE] marker", () => {
     const { container } = withApp(
       <InlineWidgetText

--- a/packages/ui/src/components/chat/InlineWidgetText.tsx
+++ b/packages/ui/src/components/chat/InlineWidgetText.tsx
@@ -20,6 +20,7 @@ import { useAppSelectorShallow } from "../../state";
 import { useChatComposer } from "../../state/ChatComposerContext.hooks";
 import { CodeBlock } from "../ui/code-block";
 import {
+  FormSubmitReceipt,
   InlinePluginConfig,
   MessagePermissionCard,
   MessageUiSpecBlock,
@@ -75,6 +76,15 @@ export function InlineWidgetText({ content }: { content: string }): ReactNode {
     switch (seg.kind) {
       case "text": {
         if (seg.text) nodes.push(<span key={nextKey("t")}>{seg.text}</span>);
+        break;
+      }
+      case "form-submit": {
+        nodes.push(
+          <FormSubmitReceipt
+            key={nextKey(`form-submit-${seg.formId}`)}
+            label={seg.label}
+          />,
+        );
         break;
       }
       case "code": {

--- a/packages/ui/src/components/chat/MessageContent.slash-command.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.slash-command.test.tsx
@@ -72,4 +72,21 @@ describe("MessageContent slash-command bolding", () => {
     withApp(<MessageContent message={message("user", "just a message")} />);
     expect(screen.queryByTestId("slash-command-token")).toBeNull();
   });
+
+  it("renders a submitted form as a compact receipt instead of raw marker JSON", () => {
+    withApp(
+      <MessageContent
+        message={message(
+          "user",
+          '[form:submit reminder-details] {"title":"Draft report","when":"2026-07-08T09:00"}',
+        )}
+      />,
+    );
+
+    expect(screen.getByTestId("form-submit-receipt").textContent).toBe(
+      "Submitted reminder details",
+    );
+    expect(screen.queryByText(/\[form:submit/)).toBeNull();
+    expect(screen.queryByText(/Draft report/)).toBeNull();
+  });
 });

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -154,6 +154,17 @@ function MessageTextBody({
   );
 }
 
+export function FormSubmitReceipt({ label }: { label: string }) {
+  return (
+    <div
+      className="inline-flex max-w-full items-center rounded-full border border-border/70 bg-bg px-2.5 py-1 text-xs font-medium text-muted-strong"
+      data-testid="form-submit-receipt"
+    >
+      Submitted {label}
+    </div>
+  );
+}
+
 // ── InlinePluginConfig ──────────────────────────────────────────────
 
 // The in-chat connector/plugin setup card for `[CONFIG:pluginId]` markers
@@ -1232,18 +1243,20 @@ export function MessageContent({
           const baseKey =
             seg.kind === "text"
               ? `text:${seg.text.slice(0, 80)}`
-              : seg.kind === "code"
-                ? `code:${seg.code.slice(0, 80)}`
-                : seg.kind === "config"
-                  ? `config:${seg.pluginId}`
-                  : seg.kind === "widget"
-                    ? (getInlineWidget(seg.widgetKind)?.keyFor?.(seg.data) ??
-                      `widget:${seg.widgetKind}`)
-                    : seg.kind === "permission"
-                      ? `permission:${seg.payload.feature}`
-                      : seg.kind === "analysis-xml"
-                        ? `analysis:${seg.tag}`
-                        : `ui:${seg.raw.slice(0, 80)}`;
+              : seg.kind === "form-submit"
+                ? `form-submit:${seg.formId}`
+                : seg.kind === "code"
+                  ? `code:${seg.code.slice(0, 80)}`
+                  : seg.kind === "config"
+                    ? `config:${seg.pluginId}`
+                    : seg.kind === "widget"
+                      ? (getInlineWidget(seg.widgetKind)?.keyFor?.(seg.data) ??
+                        `widget:${seg.widgetKind}`)
+                      : seg.kind === "permission"
+                        ? `permission:${seg.payload.feature}`
+                        : seg.kind === "analysis-xml"
+                          ? `analysis:${seg.tag}`
+                          : `ui:${seg.raw.slice(0, 80)}`;
           const segmentKey = nextKey(baseKey);
 
           switch (seg.kind) {
@@ -1255,6 +1268,8 @@ export function MessageContent({
                   boldSlashCommand={message.role === "user"}
                 />
               );
+            case "form-submit":
+              return <FormSubmitReceipt key={segmentKey} label={seg.label} />;
             case "code":
               return (
                 <CodeBlock

--- a/packages/ui/src/components/chat/message-parser-helpers.test.ts
+++ b/packages/ui/src/components/chat/message-parser-helpers.test.ts
@@ -13,6 +13,8 @@ import {
   isUiSpec,
   looksLikePatch,
   normalizeDisplayText,
+  parseFormSubmitDisplay,
+  parseSegments,
   sanitizePatchValue,
   tryParsePatch,
 } from "./message-parser-helpers";
@@ -87,6 +89,31 @@ describe("looksLikePatch + tryParsePatch", () => {
     expect(tryParsePatch("not json")).toBeNull();
     // Looks like a patch but missing required string fields → rejected.
     expect(tryParsePatch('{"op":5,"path":"/x"}')).toBeNull();
+  });
+});
+
+describe("form submit display markers", () => {
+  it("projects a submitted inline form into a display-only receipt segment", () => {
+    const text =
+      '[form:submit reminder-details] {"title":"Draft report","when":"2026-07-08T09:00"}';
+    expect(parseFormSubmitDisplay(text)).toEqual({
+      formId: "reminder-details",
+      label: "reminder details",
+    });
+
+    expect(parseSegments(text, false)).toEqual([
+      {
+        kind: "form-submit",
+        formId: "reminder-details",
+        label: "reminder details",
+      },
+    ]);
+  });
+
+  it("leaves malformed form submits as plain text so the agent still sees the wire text", () => {
+    const text = "[form:submit reminder-details] not-json";
+    expect(parseFormSubmitDisplay(text)).toBeNull();
+    expect(parseSegments(text, false)).toEqual([{ kind: "text", text }]);
   });
 });
 

--- a/packages/ui/src/components/chat/message-parser-helpers.ts
+++ b/packages/ui/src/components/chat/message-parser-helpers.ts
@@ -61,6 +61,7 @@ export function isSafeNormalizedPluginId(id: string): boolean {
 
 export type Segment =
   | { kind: "text"; text: string }
+  | { kind: "form-submit"; formId: string; label: string }
   | { kind: "config"; pluginId: string }
   | { kind: "ui-spec"; spec: UiSpec; raw: string }
   // A fenced (```lang ... ```) or inline (`...`) code span lifted out of the
@@ -74,6 +75,8 @@ export type Segment =
 // ── Detection ───────────────────────────────────────────────────────
 
 export const CONFIG_RE = /\[CONFIG:([@\w][\w@./:-]*)\]/g;
+export const FORM_SUBMIT_RE =
+  /^\[form:submit\s+([A-Za-z0-9._:-]{1,120})\]\s+({[\s\S]*})$/;
 export const FENCED_JSON_RE = /```(?:json)?\s*\n([\s\S]*?)```/g;
 
 /**
@@ -129,6 +132,34 @@ export function tryParse(s: string): unknown {
     // null is the explicit "not a spec" signal
     return null;
   }
+}
+
+export interface FormSubmitDisplay {
+  formId: string;
+  label: string;
+}
+
+function humanizeFormId(formId: string): string {
+  const normalized = formId
+    .replace(/^form[:._-]?/i, "")
+    .replace(/[_:-]+/g, " ")
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .trim()
+    .toLowerCase();
+  return normalized || "form";
+}
+
+export function parseFormSubmitDisplay(text: string): FormSubmitDisplay | null {
+  const match = FORM_SUBMIT_RE.exec(text.trim());
+  if (!match) return null;
+  const parsed = tryParse(match[2]);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  return {
+    formId: match[1],
+    label: humanizeFormId(match[1]),
+  };
 }
 
 export function isUiSpec(obj: unknown): obj is UiSpec {
@@ -349,6 +380,19 @@ export function parseSegments(text: string, analysisMode: boolean): Segment[] {
   // otherwise we use the normalized text which strips them.
   const targetText = analysisMode ? text : normalizeDisplayText(text);
   if (!targetText) return [{ kind: "text", text: "" }];
+
+  if (!analysisMode) {
+    const formSubmit = parseFormSubmitDisplay(targetText);
+    if (formSubmit) {
+      return [
+        {
+          kind: "form-submit",
+          formId: formSubmit.formId,
+          label: formSubmit.label,
+        },
+      ];
+    }
+  }
 
   const permissionRequest = analysisMode
     ? null

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -1028,6 +1028,30 @@ describe("ContinuousChatOverlay", () => {
     expect(user?.className).toContain("justify-end");
   });
 
+  it("renders a user form submission as a receipt instead of raw marker JSON", () => {
+    render(
+      <ContinuousChatOverlay
+        controller={makeController({
+          messages: [
+            {
+              id: "form-submit",
+              role: "user",
+              content:
+                '[form:submit reminder-details] {"title":"Draft report","when":"2026-07-08T09:00"}',
+              createdAt: 1,
+            },
+          ],
+        } as unknown as Partial<ShellController>)}
+      />,
+    );
+    fireEvent.focus(screen.getByLabelText("message"));
+
+    const log = document.getElementById("continuous-thread");
+    expect(log?.textContent).toContain("Submitted reminder details");
+    expect(log?.textContent).not.toContain("[form:submit");
+    expect(log?.textContent).not.toContain("Draft report");
+  });
+
   it("anchors the in-flight status row as an assistant-aligned transcript row", () => {
     render(
       <ContinuousChatOverlay

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -85,8 +85,12 @@ import {
 } from "../../utils/image-attachment";
 import { InlineWidgetText } from "../chat/InlineWidgetText";
 import { MessageAttachments } from "../chat/MessageAttachments";
-import { SensitiveRequestBlock } from "../chat/MessageContent";
+import {
+  FormSubmitReceipt,
+  SensitiveRequestBlock,
+} from "../chat/MessageContent";
 import { findChoiceRegions } from "../chat/message-choice-parser";
+import { parseFormSubmitDisplay } from "../chat/message-parser-helpers";
 import { MessageSearchPanel } from "../chat/message-search/MessageSearchPanel";
 import { ThinkingBlock } from "../chat/ThinkingBlock";
 import { withTranscriptMarker } from "../chat/TranscriptViewerOverlay";
@@ -666,6 +670,9 @@ function TurnStatusIndicator({
  * inline autocomplete). Plain prose renders unchanged.
  */
 function ThreadLineText({ content }: { content: string }): React.ReactNode {
+  const formSubmit = parseFormSubmitDisplay(content);
+  if (formSubmit) return <FormSubmitReceipt label={formSubmit.label} />;
+
   const slash = splitLeadingSlashCommand(content);
   if (!slash) return content;
   return (

--- a/plugins/plugin-hyperliquid/src/HyperliquidView.test.tsx
+++ b/plugins/plugin-hyperliquid/src/HyperliquidView.test.tsx
@@ -195,42 +195,28 @@ describe("HyperliquidView — populated snapshot", () => {
 		expect(screen.getByText("ETH")).toBeTruthy();
 		// Read-ready header + market leverage decoration.
 		expect(screen.getByText("read-ready")).toBeTruthy();
-		expect(screen.getByText("50x")).toBeTruthy();
+		expect(screen.getByText("BTC 50x")).toBeTruthy();
 		// ETH maxLeverage null -> "n/a", isolated suffix.
 		const text = document.body.textContent ?? "";
 		expect(text).toContain("2m / 1p / 1o");
 	});
 
-	it("renders the readiness tiles and the credential-mode label", async () => {
+	it("renders a compact readiness summary", async () => {
 		render(React.createElement(HyperliquidView));
 		await screen.findByText("ETH");
-		expect(screen.getByText("Reads")).toBeTruthy();
-		expect(screen.getByText("Read-only")).toBeTruthy(); // credentialMode "none"
-		expect(screen.getByText("Account")).toBeTruthy();
+		expect(screen.getByText("read-ready")).toBeTruthy();
+		expect(screen.getByText("2m / 1p / 1o")).toBeTruthy();
 	});
 
-	it("surfaces the executionBlockedReason without duplicate vault guidance", async () => {
+	it("keeps setup warnings out of the compact snapshot", async () => {
 		render(React.createElement(HyperliquidView));
 		await screen.findByText("ETH");
 		expect(
-			screen.getByText(/Signed Hyperliquid exchange mutations are disabled/),
-		).toBeTruthy();
+			screen.queryByText(/Signed Hyperliquid exchange mutations are disabled/),
+		).toBeNull();
 		expect(
 			screen.queryByText("Connect a managed vault to enable signed requests."),
 		).toBeNull();
-	});
-
-	it("shows vault guidance when no specific execution block is present", async () => {
-		hyperliquidClient.hyperliquidStatus.mockResolvedValue({
-			...sampleStatus,
-			executionBlockedReason: null,
-		});
-
-		render(React.createElement(HyperliquidView));
-		await screen.findByText("ETH");
-		expect(
-			screen.getByText("Connect a managed vault to enable signed requests."),
-		).toBeTruthy();
 	});
 
 	it("renders the agent's own position row with its unrealized PnL", async () => {
@@ -294,7 +280,7 @@ describe("HyperliquidView — controls", () => {
 		await screen.findByText("ETH");
 		expect(hyperliquidClient.hyperliquidStatus).toHaveBeenCalledTimes(1);
 
-		fireEvent.click(agent("refresh"));
+		fireEvent.click(agent("hyperliquid-refresh"));
 		await waitFor(() =>
 			expect(hyperliquidClient.hyperliquidStatus).toHaveBeenCalledTimes(2),
 		);
@@ -309,7 +295,7 @@ describe("HyperliquidView — controls", () => {
 		const listener = (e: Event) => events.push(e as CustomEvent);
 		window.addEventListener(NAVIGATE_VIEW_EVENT, listener);
 		try {
-			fireEvent.click(agent("back"));
+			fireEvent.click(agent("hyperliquid-home"));
 		} finally {
 			window.removeEventListener(NAVIGATE_VIEW_EVENT, listener);
 		}

--- a/plugins/plugin-hyperliquid/src/components/HyperliquidSpatialView.test.tsx
+++ b/plugins/plugin-hyperliquid/src/components/HyperliquidSpatialView.test.tsx
@@ -89,7 +89,6 @@ describe("HyperliquidSpatialView one source, three modalities", () => {
 			const flat = lines.join("\n");
 			expect(flat).toContain("read-ready");
 			expect(flat).toContain("BTC");
-			expect(flat).toContain("Refresh");
 		}
 	});
 
@@ -105,7 +104,7 @@ describe("HyperliquidSpatialView one source, three modalities", () => {
 		for (const html of [gui, xr]) {
 			expect(html).toContain("BTC");
 			expect(html).toContain("read-ready");
-			expect(html).toContain('data-agent-id="refresh"');
+			expect(html).toContain('data-agent-id="market-BTC"');
 		}
 	});
 
@@ -156,7 +155,7 @@ describe("HyperliquidSpatialView account-health + position detail", () => {
 		// Position detail: side, derived liquidation distance, notional.
 		expect(html).toContain("long");
 		expect(html).toContain("25% to liq");
-		expect(html).toContain("30,000");
+		expect(html).toContain("$30.0k");
 	});
 
 	it("does not crash when distanceToLiquidationPct is a missing DTO field (#8796)", () => {

--- a/plugins/plugin-hyperliquid/src/components/HyperliquidSpatialView.tsx
+++ b/plugins/plugin-hyperliquid/src/components/HyperliquidSpatialView.tsx
@@ -59,38 +59,6 @@ export interface HyperliquidSnapshot {
 	error?: string | null;
 }
 
-function credentialModeLabel(mode: HyperliquidCredentialMode): string {
-	switch (mode) {
-		case "managed_vault":
-			return "Managed vault";
-		case "local_key":
-			return "Local key";
-		default:
-			return "Read-only";
-	}
-}
-
-function readinessTone(ready: boolean): SpatialTone {
-	return ready ? "success" : "muted";
-}
-
-function readinessMark(ready: boolean): string {
-	return ready ? "[ok]" : "[--]";
-}
-
-function StatusTile({ label, ready }: { label: string; ready: boolean }) {
-	return (
-		<HStack gap={1} align="center" grow={1}>
-			<Text tone={readinessTone(ready)} wrap={false}>
-				{readinessMark(ready)}
-			</Text>
-			<Text bold grow={1} wrap={false}>
-				{label}
-			</Text>
-		</HStack>
-	);
-}
-
 function shortAddress(address: string | null): string {
 	if (!address) return "not configured";
 	if (address.length <= 13) return address;
@@ -98,6 +66,9 @@ function shortAddress(address: string | null): string {
 }
 
 const EMPTY_CELL = "·";
+const MAX_MARKET_ROWS = 4;
+const MAX_POSITION_ROWS = 2;
+const MAX_ORDER_ROWS = 2;
 
 function toNumber(value: string | number | null | undefined): number | null {
 	if (value === null || value === undefined) return null;
@@ -137,16 +108,6 @@ function formatUsd(
 	return `${sign}$${body}`;
 }
 
-function formatPrice(value: number | null): string {
-	if (value === null) return EMPTY_CELL;
-	const abs = Math.abs(value);
-	const decimals = abs >= 1000 ? 1 : abs >= 1 ? 2 : 5;
-	return value.toLocaleString("en-US", {
-		maximumFractionDigits: decimals,
-		minimumFractionDigits: decimals,
-	});
-}
-
 function formatSize(value: string): string {
 	const parsed = Number(value);
 	if (!Number.isFinite(parsed)) return value;
@@ -183,7 +144,6 @@ export function HyperliquidSpatialView({
 }: HyperliquidSpatialViewProps) {
 	const dispatch = (action: string) => () => onAction?.(action);
 	const { status } = snapshot;
-	const accountReady = Boolean(status.accountAddress);
 	const openPositions = snapshot.positions.filter(isOpenPosition);
 
 	if (snapshot.unavailable) {
@@ -236,82 +196,29 @@ export function HyperliquidSpatialView({
 				</Text>
 			) : null}
 
-			<Text style="caption" tone="muted">
-				status
-			</Text>
-			<VStack gap={0}>
-				<StatusTile label="Reads" ready={status.publicReadReady} />
-				<StatusTile
-					label={credentialModeLabel(status.credentialMode)}
-					ready={status.signerReady}
-				/>
-				<StatusTile label="Account" ready={accountReady} />
-			</VStack>
-
-			{status.executionBlockedReason ? (
-				<Text style="caption" tone="warning">
-					{status.executionBlockedReason}
-				</Text>
-			) : null}
-
-			{!status.vaultReady &&
-			status.credentialMode !== "local_key" &&
-			!status.executionBlockedReason &&
-			status.vaultGuidance ? (
-				<Text style="caption" tone="muted">
-					{status.vaultGuidance}
-				</Text>
-			) : null}
-
-			<Text style="caption" tone="muted">
-				markets
-			</Text>
 			{snapshot.markets.length === 0 ? (
 				<Text tone="muted" align="center" style="caption">
 					None
 				</Text>
 			) : (
-				<List gap={0}>
-					{snapshot.markets.slice(0, 12).map((market) => (
-						<HStack
+				<HStack gap={2} wrap>
+					{snapshot.markets.slice(0, MAX_MARKET_ROWS).map((market) => (
+						<Text
 							key={market.name}
-							gap={1}
-							align="center"
+							bold
+							wrap={false}
+							tone={market.isDelisted ? "muted" : "default"}
 							agent={`market-${market.name}`}
 						>
-							<Text
-								bold
-								grow={1}
-								wrap={false}
-								tone={market.isDelisted ? "muted" : "default"}
-							>
-								{market.name}
-							</Text>
-							<Text style="caption" tone="primary" wrap={false}>
-								{market.maxLeverage ? `${market.maxLeverage}x` : "n/a"}
-							</Text>
-							<Text style="caption" tone="muted" wrap={false}>
-								sz{market.szDecimals}
-								{market.onlyIsolated ? " iso" : ""}
-							</Text>
-						</HStack>
+							{market.name} {market.maxLeverage ? `${market.maxLeverage}x` : ""}
+						</Text>
 					))}
-				</List>
+				</HStack>
 			)}
 
-			<Text style="caption" tone="muted">
-				account
-			</Text>
 			<HStack gap={1} align="center">
 				<Text style="caption" tone="muted" grow={1} wrap={false}>
 					{shortAddress(status.accountAddress)}
-				</Text>
-				<Text
-					style="caption"
-					tone={status.executionReady ? "success" : "muted"}
-					wrap={false}
-				>
-					{status.executionReady ? "exec-ready" : "exec-off"}
 				</Text>
 			</HStack>
 
@@ -344,9 +251,6 @@ export function HyperliquidSpatialView({
 				</HStack>
 			) : null}
 
-			<Text style="caption" tone="primary">
-				positions
-			</Text>
 			{snapshot.positionsBlockedReason ? (
 				<Text style="caption" tone="warning" agent="positions-blocked">
 					{snapshot.positionsBlockedReason}
@@ -357,11 +261,10 @@ export function HyperliquidSpatialView({
 				</Text>
 			) : (
 				<List gap={0}>
-					{openPositions.slice(0, 6).map((position) => {
+					{openPositions.slice(0, MAX_POSITION_ROWS).map((position) => {
 						const long = isLongPosition(position.size);
 						const uPnl = toNumber(position.unrealizedPnl);
 						const notional = toNumber(position.positionValue);
-						const entry = toNumber(position.entryPx);
 						const liq = position.distanceToLiquidationPct;
 						return (
 							<VStack
@@ -380,26 +283,17 @@ export function HyperliquidSpatialView({
 									>
 										{long ? "long" : "short"}
 									</Text>
-									{position.leverageValue !== null ? (
-										<Text style="caption" tone="muted" wrap={false}>
-											{position.leverageValue}x
-										</Text>
-									) : null}
+									<Text style="caption" tone="muted" grow={1} wrap={false}>
+										sz {formatSize(position.size)}
+										{notional === null ? "" : ` ${formatUsdCompact(notional)}`}
+									</Text>
 									<Text
 										style="caption"
 										tone={pnlTone(uPnl)}
-										grow={1}
 										align="end"
 										wrap={false}
 									>
 										{uPnl === null ? "" : formatUsd(uPnl, { withSign: true })}
-									</Text>
-								</HStack>
-								<HStack gap={1} align="center">
-									<Text style="caption" tone="muted" grow={1} wrap={false}>
-										sz {formatSize(position.size)}
-										{notional === null ? "" : ` · ${formatUsd(notional)}`}
-										{entry === null ? "" : ` · @${formatPrice(entry)}`}
 									</Text>
 									{liq === null || liq === undefined ? null : (
 										<Text style="caption" tone="warning" wrap={false}>
@@ -413,9 +307,6 @@ export function HyperliquidSpatialView({
 				</List>
 			)}
 
-			<Text style="caption" tone="primary">
-				orders
-			</Text>
 			{snapshot.ordersBlockedReason ? (
 				<Text style="caption" tone="warning" agent="orders-blocked">
 					{snapshot.ordersBlockedReason}
@@ -426,7 +317,7 @@ export function HyperliquidSpatialView({
 				</Text>
 			) : (
 				<List gap={0}>
-					{snapshot.orders.slice(0, 6).map((order) => (
+					{snapshot.orders.slice(0, MAX_ORDER_ROWS).map((order) => (
 						<HStack
 							key={order.oid}
 							gap={1}
@@ -459,20 +350,6 @@ export function HyperliquidSpatialView({
 					))}
 				</List>
 			)}
-
-			<HStack gap={1} wrap>
-				<Button grow={1} agent="refresh" onPress={dispatch("refresh")}>
-					Refresh
-				</Button>
-				<Button
-					variant="outline"
-					tone="default"
-					agent="back"
-					onPress={dispatch("back")}
-				>
-					Back
-				</Button>
-			</HStack>
 		</Card>
 	);
 }

--- a/plugins/plugin-polymarket/src/PolymarketView.test.tsx
+++ b/plugins/plugin-polymarket/src/PolymarketView.test.tsx
@@ -216,12 +216,12 @@ describe("PolymarketView — populated markets", () => {
     expect(polymarketClient.polymarketMarkets).toHaveBeenCalledWith({
       limit: 25,
     });
-    // Auto-selected markets[0] => detail pane: outcomes + CLOB token ids.
+    // Auto-selected markets[0] => detail pane: compact outcome choices.
     await waitFor(() => expect(agent("detail-back")).toBeTruthy());
     const text = document.body.textContent ?? "";
-    expect(text).toContain("outcomes");
-    expect(text).toContain("orderbook tokens");
-    expect(text).toContain("token-yes");
+    expect(text).toContain("Yes");
+    expect(text).toContain("No");
+    expect(text).not.toContain("token-yes");
   });
 
   it("the markets list shows readiness chips + a DOM-clickable row Open control", async () => {
@@ -249,7 +249,7 @@ describe("PolymarketView — populated markets", () => {
 });
 
 describe("PolymarketView — list -> detail navigation", () => {
-  it("clicking a market row Open opens its detail with outcomes + CLOB token ids", async () => {
+  it("clicking a market row Open opens its detail with compact outcome choices", async () => {
     render(React.createElement(PolymarketView));
     await screen.findByText("Will BTC be above 100k?");
     await backToList();
@@ -258,15 +258,13 @@ describe("PolymarketView — list -> detail navigation", () => {
 
     await waitFor(() => expect(agent("detail-back")).toBeTruthy());
     const text = document.body.textContent ?? "";
-    expect(text).toContain("outcomes");
     expect(text).toContain("Yes");
     expect(text).toContain("No");
-    expect(text).toContain("orderbook tokens");
-    expect(text).toContain("token-yes");
-    expect(text).toContain("token-no");
+    expect(text).not.toContain("token-yes");
+    expect(text).not.toContain("token-no");
   });
 
-  it("a market with no CLOB token ids shows the fallback copy in detail", async () => {
+  it("a market with no orderbook tokens still opens compact detail", async () => {
     mockState({
       markets: [sampleMarket, secondMarket],
       source: sampleMarkets.source,
@@ -279,7 +277,7 @@ describe("PolymarketView — list -> detail navigation", () => {
     await waitFor(() =>
       expect(screen.getByText("Will ETH be above 5k?")).toBeTruthy(),
     );
-    expect(screen.getByText("no CLOB token ids")).toBeTruthy();
+    expect(screen.getByText("Yes 25%")).toBeTruthy();
   });
 
   it("the detail 'back' control returns to the markets list", async () => {
@@ -303,6 +301,7 @@ describe("PolymarketView — refresh + error path", () => {
     await screen.findByText("Will BTC be above 100k?");
     expect(polymarketClient.polymarketMarkets).toHaveBeenCalledTimes(1);
 
+    await backToList();
     fireEvent.click(agent("refresh"));
     await waitFor(() =>
       expect(polymarketClient.polymarketMarkets).toHaveBeenCalledTimes(2),

--- a/plugins/plugin-polymarket/src/components/PolymarketSpatialView.test.tsx
+++ b/plugins/plugin-polymarket/src/components/PolymarketSpatialView.test.tsx
@@ -122,15 +122,14 @@ describe("PolymarketSpatialView one source, three modalities", () => {
     expect(wide).toContain("Refresh");
   });
 
-  it("TUI: detail honors the width contract at 54 + 32 and shows outcomes + CLOB ids", () => {
+  it("TUI: detail honors the width contract at 54 + 32 and shows choices", () => {
     for (const width of [54, 32]) {
       const lines = renderViewToLines(detailView, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
       // Short markers survive the narrow layout.
       expect(flat).toContain("Yes");
-      expect(flat).toContain("outcomes");
-      expect(flat).toContain("111"); // CLOB token id
+      expect(flat).toContain("No");
     }
     const wide = renderViewToLines(detailView, 54).join("\n");
     expect(wide).toContain("Will it rain tomorrow?");

--- a/plugins/plugin-polymarket/src/components/PolymarketSpatialView.tsx
+++ b/plugins/plugin-polymarket/src/components/PolymarketSpatialView.tsx
@@ -42,8 +42,9 @@ export interface PolymarketSnapshot {
   lastAction?: string;
 }
 
-const MAX_LIST = 24;
-const MAX_OUTCOMES = 3;
+const MAX_LIST = 10;
+const MAX_OUTCOMES = 2;
+const MAX_POSITION_ROWS = 3;
 
 function priceToPercent(price: string | null): number | null {
   if (price == null) return null;
@@ -102,32 +103,6 @@ function ReadinessRow({ status }: { status: PolymarketStatusResponse | null }) {
       </Text>
       <Text style="caption" tone={readyTone(trading)}>
         {`trading ${trading ? "ready" : "off"}`}
-      </Text>
-    </HStack>
-  );
-}
-
-function OutcomeLine({
-  name,
-  percent,
-  lead,
-}: {
-  name: string;
-  percent: number | null;
-  lead: boolean;
-}) {
-  return (
-    <HStack gap={1} align="center">
-      <Text tone={lead ? "primary" : "default"} grow={1} wrap={false}>
-        {name}
-      </Text>
-      <Text
-        style="caption"
-        tone={lead ? "primary" : "muted"}
-        align="end"
-        width={6}
-      >
-        {percent != null ? `${percent}%` : "n/a"}
       </Text>
     </HStack>
   );
@@ -212,7 +187,7 @@ function MarketDetail({
   market: PolymarketMarket;
   onAction?: (action: string) => void;
 }) {
-  const lastTrade = priceToPercent(market.lastTradePrice);
+  const top = market.outcomes.slice(0, MAX_OUTCOMES);
   return (
     <VStack gap={1}>
       <Button
@@ -226,58 +201,20 @@ function MarketDetail({
       <Text style="subheading" wrap>
         {market.question ?? market.slug ?? market.id}
       </Text>
-      {market.category ? (
-        <Text style="caption" tone="muted">
-          {market.category}
-        </Text>
-      ) : null}
-
-      <HStack gap={2} align="center">
-        <Text style="caption" tone="muted" wrap={false}>
-          {`Volume ${shortNumber(market.volume) ?? "-"}`}
-        </Text>
-        <Text style="caption" tone="muted" wrap={false}>
-          {`Liquidity ${shortNumber(market.liquidity) ?? "-"}`}
-        </Text>
-        <Text style="caption" tone="muted" wrap={false}>
-          {`Last ${lastTrade != null ? `${lastTrade}%` : "-"}`}
-        </Text>
-      </HStack>
-
-      <VStack gap={0}>
-        <Text style="caption" tone="muted">
-          outcomes
-        </Text>
-        <List gap={0}>
-          {market.outcomes.map((outcome, i) => (
-            <OutcomeLine
+      {top.length > 0 ? (
+        <HStack gap={2} align="center" wrap>
+          {top.map((outcome, i) => (
+            <Text
               key={outcome.name}
-              name={outcome.name}
-              percent={priceToPercent(outcome.price)}
-              lead={i === 0}
-            />
+              style="caption"
+              tone={i === 0 ? "primary" : "muted"}
+              wrap={false}
+            >
+              {outcomeSummary(outcome)}
+            </Text>
           ))}
-        </List>
-      </VStack>
-
-      <VStack gap={0}>
-        <Text style="caption" tone="muted">
-          orderbook tokens
-        </Text>
-        {market.clobTokenIds.length > 0 ? (
-          <List gap={0}>
-            {market.clobTokenIds.map((tokenId) => (
-              <Text key={tokenId} style="caption" tone="muted" wrap={false}>
-                {tokenId}
-              </Text>
-            ))}
-          </List>
-        ) : (
-          <Text style="caption" tone="muted">
-            no CLOB token ids
-          </Text>
-        )}
-      </VStack>
+        </HStack>
+      ) : null}
     </VStack>
   );
 }
@@ -338,7 +275,7 @@ function PositionsSection({
         </Text>
       ) : (
         <List gap={0}>
-          {open.map((position) => (
+          {open.slice(0, MAX_POSITION_ROWS).map((position) => (
             <PositionRow
               key={`${position.conditionId ?? position.marketId ?? position.slug}-${position.outcome}`}
               position={position}
@@ -366,21 +303,23 @@ export function PolymarketSpatialView({
   const selectedId = selectedMarket?.id ?? null;
   return (
     <Card gap={1} padding={1}>
-      <HStack gap={1} align="center" wrap>
-        <ReadinessRow status={status} />
-        <Text style="caption" tone="muted" grow={1}>
-          {loading ? "loading" : `${markets.length} markets`}
-        </Text>
-        <Button
-          variant="outline"
-          tone="default"
-          agent="refresh"
-          disabled={loading}
-          onPress={() => onAction?.("refresh")}
-        >
-          Refresh
-        </Button>
-      </HStack>
+      {!selectedMarket ? (
+        <HStack gap={1} align="center" wrap>
+          <ReadinessRow status={status} />
+          <Text style="caption" tone="muted" grow={1}>
+            {loading ? "loading" : `${markets.length} markets`}
+          </Text>
+          <Button
+            variant="outline"
+            tone="default"
+            agent="refresh"
+            disabled={loading}
+            onPress={() => onAction?.("refresh")}
+          >
+            Refresh
+          </Button>
+        </HStack>
+      ) : null}
 
       {error ? (
         <Text tone="danger" style="caption">


### PR DESCRIPTION
Merged baseline PR for #14322 live chat-widget scenario/provider coverage.

This PR was merged before the final APP/VIEWS choice-routing and FORM-auth hardening work was ready. The follow-up hardening branch is now tracked in #14822.

At merge time this PR established the live-only scenario coverage and documented the known-red FORM/CHOICE failures that later work root-caused and hardened. For current 4/4 live pass evidence, deterministic tests, and the final 9-file scenario/app-control fix, see #14822.
