### PR TITLE
fix: keep live help tutorial guidance chat-native

### DIFF
--- a/packages/agent/src/runtime/__tests__/default-documents.test.ts
+++ b/packages/agent/src/runtime/__tests__/default-documents.test.ts
@@ -186,7 +186,9 @@ describe("bundled help documents", () => {
 
   it("stays durable: no screen-relative or widget-relative instructions", () => {
     for (const doc of HELP_DOCUMENTS) {
-      expect(doc.text).not.toMatch(/below|tap “|deepLink|start the tutorial”/i);
+      expect(doc.text).not.toMatch(
+        /below|tap “|deepLink|start the tutorial|tutorial (tile|launcher)|launcher tile/i,
+      );
     }
   });
 });

--- a/packages/agent/src/runtime/default-help-documents.ts
+++ b/packages/agent/src/runtime/default-help-documents.ts
@@ -40,7 +40,7 @@ function helpDocument(
 }
 
 export const HELP_DOCUMENTS: readonly DefaultDocumentDefinition[] = [
-  helpDocument("eliza-help-getting-started", "Eliza help: getting started", 1, [
+  helpDocument("eliza-help-getting-started", "Eliza help: getting started", 2, [
     {
       question: "What is Eliza?",
       answer:
@@ -49,7 +49,7 @@ export const HELP_DOCUMENTS: readonly DefaultDocumentDefinition[] = [
     {
       question: "I just opened Eliza — what do I do first?",
       answer:
-        'Take the interactive tutorial: type "start tutorial" in the chat (or open the Tutorial tile in the launcher). It walks you through the basics right in the conversation — sending messages, voice, navigating by asking — in about a minute, and you can stop it anytime by typing "stop tutorial".',
+        'Take the interactive tutorial: type "start tutorial" in the chat. It walks you through the basics right in the conversation — sending messages, voice, navigating by asking — in about a minute, and you can stop it anytime by typing "stop tutorial".',
     },
     {
       question: "What is the glowing pill at the bottom of the screen?",
@@ -177,7 +177,7 @@ export const HELP_DOCUMENTS: readonly DefaultDocumentDefinition[] = [
         "The Launcher is the home for every screen Eliza can show you — your tasks, documents, memories, settings, and specialized tools. Swipe right from the home dashboard to reach it, open any screen from there or by asking the chat, and Eliza can also open them for you.",
     },
   ]),
-  helpDocument("eliza-help-troubleshooting", "Eliza help: troubleshooting", 1, [
+  helpDocument("eliza-help-troubleshooting", "Eliza help: troubleshooting", 2, [
     {
       question: "Eliza isn't responding to my messages.",
       answer:
@@ -196,7 +196,7 @@ export const HELP_DOCUMENTS: readonly DefaultDocumentDefinition[] = [
     {
       question: "How do I see the tutorial again?",
       answer:
-        'Type "restart tutorial" in the chat any time, or open the Tutorial tile in the launcher. The tour runs right in the conversation and is always re-runnable — nothing is one-time-only.',
+        'Type "restart tutorial" in the chat any time. The tour runs right in the conversation and is always re-runnable — nothing is one-time-only.',
     },
   ]),
 ];

--- a/packages/scenario-runner/test/scenarios/README.md
+++ b/packages/scenario-runner/test/scenarios/README.md
@@ -86,8 +86,8 @@ requires a real provider key for live natural-language planner runs.
 
 - `live-help-knowledge` covers the deleted-Help-view replacement: a real model
   must answer first-run help questions from the bundled help FAQ fragments,
-  mention the rerunnable tutorial/voice/privacy facts, and avoid stale "Help
-  view" or button-below instructions. Run it with
+  mention the chat-started rerunnable tutorial/voice/privacy facts, and avoid
+  stale "Help view", tutorial launcher tile, or button-below instructions. Run it with
   `eliza-scenarios run packages/scenario-runner/test/scenarios --scenario live-help-knowledge --report <out> --run-dir <dir>`
   and attach the report plus reviewed trajectories.
 

--- a/packages/scenario-runner/test/scenarios/live-help-knowledge.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-help-knowledge.scenario.ts
@@ -14,6 +14,8 @@ const FORBIDDEN_UI_REFERENCES = [
   /help screen/i,
   /spotlight tour/i,
   /full[- ]screen help/i,
+  /tutorial (launcher|tile)/i,
+  /launcher tile/i,
   /tap (the )?button below/i,
   /click (the )?button below/i,
 ];
@@ -95,7 +97,7 @@ export default scenario({
       responseJudge: {
         minimumScore: 0.8,
         rubric:
-          'The answer must ground the first step in the bundled help: take/restart the interactive tutorial from chat by typing "start tutorial" or using the Tutorial launcher tile. It must not refer to a deleted Help view, spotlight-only tour, or a button below the response.',
+          'The answer must ground the first step in the bundled help: take/restart the interactive tutorial from chat by typing "start tutorial". It must not refer to a deleted Help view, launcher tile, spotlight-only tour, or a button below the response.',
       },
     },
     {
@@ -122,13 +124,13 @@ export default scenario({
       text: "Can I see the tutorial again later? How do I restart it?",
       assertResponse: assertHelpAnswer([
         [/restart tutorial|start tutorial/i],
-        ["chat", "launcher"],
+        ["chat", "conversation"],
         [/rerunnable|again|any time|later/i],
       ]),
       responseJudge: {
         minimumScore: 0.8,
         rubric:
-          'The answer must say the tutorial is rerunnable and can be started from chat with "restart tutorial" or "start tutorial", or from the Tutorial launcher tile. It must not call it one-time-only.',
+          'The answer must say the tutorial is rerunnable and can be started from chat with "restart tutorial" or "start tutorial". It must not call it one-time-only or send the user to a launcher tile.',
       },
     },
     {


### PR DESCRIPTION
## Summary

Part of #14360. This keeps the live-help MVP contract chat-native by removing stale Tutorial launcher tile guidance from bundled help knowledge and tightening `live-help-knowledge` so model replies may not send users to a launcher tile or tutorial view.

Changes:
- Bumps the changed bundled help documents so stale fragments are pruned on seed.
- Makes tutorial start/restart guidance use chat commands only.
- Extends the bundled-help durability test to reject tutorial launcher/tile/view copy.
- Extends `live-help-knowledge` forbidden UI references and rubrics to reject launcher-tile answers.
- Updates the scenario catalog note to match the chat-native contract.

This does not close #14360. A real provider-key run still needs to attach the JSON report, run viewer/native JSONL, and manually reviewed trajectories showing the model answers from the updated chat-native help fragments.

## Verification

- `bun run --cwd packages/agent test -- src/runtime/__tests__/default-documents.test.ts` -> 1 file passed, 10 tests passed.
- `bun run --cwd packages/scenario-runner test -- src/scenario-expansion.test.ts src/schema-strict.test.ts src/scenario-deferral.test.ts` -> 3 files passed, 24 tests passed.
- `bunx @biomejs/biome check packages/agent/src/runtime/default-help-documents.ts packages/agent/src/runtime/__tests__/default-documents.test.ts packages/scenario-runner/test/scenarios/live-help-knowledge.scenario.ts packages/scenario-runner/test/scenarios/README.md --no-errors-on-unmatched` -> no fixes applied.
- `bun run --cwd packages/scenario-runner src/cli.ts list test/scenarios --scenario live-help-knowledge` -> listed `live-help-knowledge`.
- `git diff --check origin/develop...HEAD` -> clean.
- `bun run --cwd plugins/plugin-local-inference build` -> built the ignored `dist/voice-workbench.js` export needed for the scenario CLI in this worktree.
- `env -u GROQ_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u GOOGLE_GENERATIVE_AI_API_KEY -u OPENROUTER_API_KEY -u CEREBRAS_API_KEY bun run --cwd packages/scenario-runner src/cli.ts run test/scenarios --scenario live-help-knowledge --report /tmp/eliza-live-help-knowledge-report --run-dir /tmp/eliza-live-help-knowledge-run` -> correctly failed loud because no live provider key is set: `no LLM provider API key set; refusing to run (WS7 policy: fail loudly on silent credential skips)`.

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - seeded help knowledge and live scenario assertion contract only; no rendered UI changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - no rendered UI changed; targeted doc/scenario tests listed above`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - code-contract follow-up only; #14360 still requires a future live provider scenario run with report and reviewed trajectories`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no backend service runtime path changed`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend runtime path changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - not produced by this PR; attempted live run failed loudly due no provider key, and #14360 remains open for provider-key report plus reviewed trajectories`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no separate artifact file in this PR; targeted bundled-document and scenario-runner tests passed, while final #14360 artifacts remain the live report, native JSONL, and reviewed trajectories`.
