### PR TITLE
fix(ui): isolate relative time ticks in home widgets

### DIFF
--- a/packages/ui/src/components/shell/DefaultHomeWidgets.render-count.test.tsx
+++ b/packages/ui/src/components/shell/DefaultHomeWidgets.render-count.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+/**
+ * Render-count lock for the `DefaultHomeWidgets` half of #14559 (spec §C.4).
+ *
+ * BEFORE: `DefaultHomeWidgets` called `useNow(60_000)` at the top, so every
+ * minute the whole base grid re-rendered - the clock AND the sibling
+ * `WeatherTile` (which fetches + renders conditions) - just to move the minutes
+ * digit.
+ *
+ * AFTER: the live clock content is a `<HomeClock>` LEAF that owns the shared,
+ * visibility-gated ticker. The minute tick re-renders only the clock stack; the
+ * `WeatherTile` does not re-render. This test proves it with a Profiler count
+ * on the weather subtree across a minute roll - re-introducing a top-level
+ * `useNow` makes the "weather did not re-render on the tick" assertion go red.
+ */
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { weatherState, weatherRenderCounter } = vi.hoisted(() => ({
+  weatherState: {
+    status: "ready" as "ready" | "loading" | "unavailable",
+    temp: 68 as number | null,
+    unit: "°F",
+    condition: "Clear",
+    kind: "clear" as const,
+    requestLocation: (() => {}) as () => void,
+  },
+  // A render counter incremented by the mocked `useWeather` - it runs once per
+  // render of any component that calls it (here, only `WeatherTile`). So a bump
+  // means the weather tile re-rendered.
+  weatherRenderCounter: { count: 0 },
+}));
+
+vi.mock("../../hooks/useWeather", () => ({
+  useWeather: () => {
+    weatherRenderCounter.count += 1;
+    return weatherState;
+  },
+  prefers24HourClock: () => false,
+}));
+
+import { __resetSharedNowForTests, MINUTE_MS } from "../../hooks/useSharedNow";
+import { __setAppValueForTests } from "../../state/app-store";
+import { DefaultHomeWidgets } from "./DefaultHomeWidgets";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  // 2026-06-25 14:30Z, TZ=UTC → 2:30 PM.
+  vi.setSystemTime(new Date("2026-06-25T14:30:00Z"));
+  weatherRenderCounter.count = 0;
+  Object.assign(weatherState, {
+    status: "ready",
+    temp: 68,
+    unit: "°F",
+    condition: "Clear",
+    kind: "clear",
+    requestLocation: () => {},
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  __resetSharedNowForTests();
+  __setAppValueForTests(null);
+  vi.useRealTimers();
+});
+
+describe("DefaultHomeWidgets render count (#14559)", () => {
+  it("the minute tick advances the clock but does NOT re-render the weather tile", () => {
+    render(<DefaultHomeWidgets />);
+    // Flush the shared-ticker subscribe effect (installs the live clock).
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    const root = screen.getByTestId("default-home-widgets");
+    expect(root.textContent).toContain("2:30");
+    expect(root.textContent).toContain("PM");
+
+    // Weather rendered on mount. Zero it, then roll a full minute.
+    const weatherAtMount = weatherRenderCounter.count;
+    expect(weatherAtMount).toBeGreaterThan(0);
+    weatherRenderCounter.count = 0;
+
+    act(() => {
+      // Cross the minute boundary: 14:30 → 14:31.
+      vi.advanceTimersByTime(MINUTE_MS);
+    });
+
+    // The clock text advanced…
+    expect(screen.getByTestId("default-home-widgets").textContent).toContain(
+      "2:31",
+    );
+    // …but the weather tile did NOT re-render on the tick (it is a sibling of
+    // the `<HomeClock>` leaf, not a child of the clock's ticker). A top-level
+    // `useNow` regression re-renders the whole grid and bumps this above 0.
+    expect(weatherRenderCounter.count).toBe(0);
+  });
+
+  it("holds the deterministic first-render (no epoch flash) then shows the live clock", () => {
+    // The clock leaf starts at `useSharedNow() === 0` and keeps its text
+    // `invisible` until the live clock ticks - never flashing 1970. The tile
+    // footprint is still reserved (no layout pop).
+    render(<DefaultHomeWidgets />);
+    // Before flushing the subscribe effect there is no live time yet, but the
+    // time tile footprint exists.
+    expect(screen.getByTestId("home-time-widget")).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(screen.getByTestId("default-home-widgets").textContent).toContain(
+      "2:30",
+    );
+  });
+});

--- a/packages/ui/src/components/shell/DefaultHomeWidgets.tsx
+++ b/packages/ui/src/components/shell/DefaultHomeWidgets.tsx
@@ -11,7 +11,8 @@ import {
   Sun,
 } from "lucide-react";
 import type * as React from "react";
-import { useNow } from "../../hooks/useNow";
+import { memo } from "react";
+import { useSharedNow } from "../../hooks/useSharedNow";
 import {
   prefers24HourClock,
   useWeather,
@@ -22,13 +23,13 @@ import { useAppSelector } from "../../state";
 
 /**
  * The home dashboard's always-on base widgets: a deterministic 4-column grid
- * with the time and weather as 2×2 neighbours. They have no card — white text
+ * with the time and weather as 2×2 neighbours. They have no card - white text
  * sits directly on the ambient orange field with a soft shadow for legibility
  * ("background gone" per the home redesign). The time needs only the device
  * clock (offline-safe); weather fetches current conditions from Open-Meteo +
  * device location (see {@link useWeather}) and degrades gracefully.
  *
- * Always rendered as the base of the home surface — the data-driven WidgetHost
+ * Always rendered as the base of the home surface - the data-driven WidgetHost
  * cards flow in below it, so the dashboard is never bare.
  */
 
@@ -82,7 +83,7 @@ function greeting(hour: number): string {
 }
 
 /**
- * The weather half of the time/weather pair — a naked 2×2 tile that mirrors the
+ * The weather half of the time/weather pair - a naked 2×2 tile that mirrors the
  * time tile's footprint (bottom-aligned so the reading settles against the same
  * baseline band as the greeting, giving the pair a shared horizon).
  */
@@ -138,34 +139,68 @@ function WeatherTile(): React.JSX.Element {
   );
 }
 
-export function DefaultHomeWidgets(): React.JSX.Element | null {
-  // The time/date tile is on by default but hideable from Appearance settings
-  // (#10706); weather is independent and always shown. Select a strict boolean
-  // so the tile hides only when the pref is explicitly set (default: shown).
-  const timeHidden = useAppSelector((s) => s.homeTimeWidgetHidden === true);
-  // `useNow` is 0 on first render (deterministic render path — no Date.now in
-  // render) then the live clock, ticking each minute. Hold until it's live so
-  // we never flash the epoch (1970) — but only when the time tile is shown; a
-  // hidden clock must not gate the weather tile.
-  const now = useNow(60_000);
-  // Reserve the time tile's footprint whenever it's shown (not hidden by the
-  // user), even on the first render when `now` is still 0 — only the time TEXT
-  // waits for the live clock. Returning null on frame 1 popped the whole base
-  // grid (incl. weather) in a frame later: a guaranteed layout shift on every
-  // home mount.
-  const showTime = !timeHidden;
+/**
+ * The clock's live content - the leaf of the binding pattern (spec §C.4) for
+ * the home base. It owns the shared, visibility-gated minute ticker so the
+ * minute roll re-renders ONLY this clock stack, never the sibling `WeatherTile`
+ * or the base grid. (Before: `DefaultHomeWidgets` called `useNow(60s)` at the
+ * top, so every minute the whole base grid - clock AND weather tile -
+ * re-rendered just to move the minutes digit.)
+ *
+ * `useSharedNow` is `0` on the first render (deterministic render path - no
+ * `Date.now()` in render) then the live clock. The tile footprint is reserved
+ * by the parent regardless; this leaf only toggles the text `invisible` until
+ * the live clock ticks, so nothing reflows when the epoch (1970) resolves.
+ */
+const HomeClock = memo(function HomeClock(): React.JSX.Element {
+  const now = useSharedNow();
   const timeReady = now > 0;
 
   const d = new Date(now);
   const hours = d.getHours();
   const minutes = d.getMinutes();
   // Hour cycle follows the locale (resolved once at module load, not per render
-  // — the determinism gate forbids Intl in the render path). 24-hour locales
+  // - the determinism gate forbids Intl in the render path). 24-hour locales
   // drop the AM/PM suffix entirely (#14345).
   const displayHour = CLOCK_24H ? hours : hours % 12 || 12;
   const ampm = CLOCK_24H ? "" : hours < 12 ? "AM" : "PM";
   const time = `${displayHour}:${String(minutes).padStart(2, "0")}`;
   const dateLabel = `${WEEKDAYS_LONG[d.getDay()]}, ${MONTHS[d.getMonth()]} ${d.getDate()}`;
+
+  return (
+    <div className={cn("flex flex-col", !timeReady && "invisible")}>
+      <div className="flex items-baseline gap-1.5">
+        <span className="text-6xl font-semibold leading-[0.9] tabular-nums tracking-tighter">
+          {time}
+        </span>
+        {ampm ? (
+          <span className="text-base font-semibold uppercase tracking-wide text-white/60">
+            {ampm}
+          </span>
+        ) : null}
+      </div>
+      <div className="mt-3 text-base font-medium text-white/85">
+        {dateLabel}
+      </div>
+      <div className="mt-1 text-sm font-medium text-accent/90">
+        {greeting(hours)}
+      </div>
+    </div>
+  );
+});
+HomeClock.displayName = "HomeClock";
+
+export function DefaultHomeWidgets(): React.JSX.Element | null {
+  // The time/date tile is on by default but hideable from Appearance settings
+  // (#10706); weather is independent and always shown. Select a strict boolean
+  // so the tile hides only when the pref is explicitly set (default: shown).
+  const timeHidden = useAppSelector((s) => s.homeTimeWidgetHidden === true);
+  // No `useNow` at this level (binding pattern, spec §C.4): the minute tick is
+  // owned by the `<HomeClock>` leaf, so the tick re-renders the clock text only,
+  // not this grid and not the sibling `<WeatherTile>`. The time tile's footprint
+  // is reserved immediately whenever it's shown - the leaf holds its own text
+  // invisible until the live clock ticks - so nothing reflows on home mount.
+  const showTime = !timeHidden;
 
   return (
     <div
@@ -189,24 +224,7 @@ export function DefaultHomeWidgets(): React.JSX.Element | null {
             FLOAT_SHADOW,
           )}
         >
-          <div className={cn("flex flex-col", !timeReady && "invisible")}>
-            <div className="flex items-baseline gap-1.5">
-              <span className="text-6xl font-semibold leading-[0.9] tabular-nums tracking-tighter">
-                {time}
-              </span>
-              {ampm ? (
-                <span className="text-base font-semibold uppercase tracking-wide text-white/60">
-                  {ampm}
-                </span>
-              ) : null}
-            </div>
-            <div className="mt-3 text-base font-medium text-white/85">
-              {dateLabel}
-            </div>
-            <div className="mt-1 text-sm font-medium text-accent/90">
-              {greeting(hours)}
-            </div>
-          </div>
+          <HomeClock />
         </div>
       ) : null}
 

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.render-count.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.render-count.test.tsx
@@ -1,0 +1,263 @@
+// @vitest-environment jsdom
+
+/**
+ * Render-count lock for elizaOS/eliza issue #14559 - the `useNow(60s)`
+ * full-inbox re-render fix (binding pattern, spec §C.4).
+ *
+ * BEFORE: `NotificationsHomeCenter` called `useNow(60_000)` at the component
+ * top, so every minute the entire inbox (up to 100 rows, each with buttons,
+ * over a `backdrop-blur` glass surface) re-rendered just to refresh "5m ago"
+ * strings; `NotificationRow` was intentionally un-memoized to keep those
+ * strings live.
+ *
+ * AFTER: the relative timestamp lives in a `<RelativeTime>` LEAF that owns the
+ * shared, visibility-gated ticker. The minute tick re-renders ONLY the `<time>`
+ * text nodes; the rows (now `React.memo`'d) and the list container do not
+ * re-render. This test proves exactly that with real React commit counts
+ * (`RenderProbe`/`useRenderSpy`) - re-introducing a list-level `useNow`, or
+ * un-memoizing the row, makes the "rows do not re-render on tick" assertion go
+ * red.
+ */
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../api/client", () => ({
+  client: {
+    listNotifications: vi.fn(async () => ({
+      notifications: [],
+      unreadCount: 0,
+    })),
+    onWsEvent: vi.fn(),
+    markNotificationRead: vi.fn(async () => ({})),
+    markAllNotificationsRead: vi.fn(async () => ({})),
+    removeNotification: vi.fn(async () => ({})),
+    clearNotifications: vi.fn(async () => ({})),
+  },
+}));
+
+vi.mock("../../state/notifications/navigate-deep-link", async (orig) => ({
+  ...(await orig()),
+  navigateDeepLink: vi.fn(),
+}));
+
+import type { AgentNotification } from "@elizaos/core";
+import { __resetSharedNowForTests, MINUTE_MS } from "../../hooks/useSharedNow";
+import {
+  __ingestNotificationForTests,
+  __resetNotificationStoreForTests,
+} from "../../state/notifications/notification-store";
+import {
+  __setNotificationRowRenderObserverForTests,
+  __setNotificationsHomeCenterRenderObserverForTests,
+  NotificationsHomeCenter,
+  rowPropsEqual,
+} from "./NotificationsHomeCenter";
+
+let seq = 0;
+function makeNotification(
+  overrides: Partial<AgentNotification> = {},
+): AgentNotification {
+  seq += 1;
+  const hex = String(seq).padStart(12, "0");
+  return {
+    id: `00000000-0000-4000-8000-${hex}` as AgentNotification["id"],
+    title: `Notification ${seq}`,
+    category: "general",
+    priority: "normal",
+    source: "test",
+    // Spread across the last hour so the rows render distinct "Nm ago" strings
+    // that actually change as the clock advances (a real relative-time surface).
+    createdAt: Date.now() - seq * 5 * MINUTE_MS,
+    readAt: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  seq = 0;
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-06-25T14:30:00Z"));
+});
+
+afterEach(() => {
+  cleanup();
+  __resetNotificationStoreForTests();
+  __resetSharedNowForTests();
+  __setNotificationRowRenderObserverForTests(null);
+  __setNotificationsHomeCenterRenderObserverForTests(null);
+  vi.useRealTimers();
+});
+
+describe("NotificationsHomeCenter render count (#14559)", () => {
+  it("the minute tick re-renders only RelativeTime leaves, not the list container", () => {
+    for (let i = 0; i < 8; i++) {
+      __ingestNotificationForTests(makeNotification());
+    }
+
+    let listRenders = 0;
+    __setNotificationsHomeCenterRenderObserverForTests(() => {
+      listRenders += 1;
+    });
+
+    render(<NotificationsHomeCenter />);
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+
+    expect(listRenders).toBe(1);
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(8);
+    const times = () =>
+      screen
+        .getAllByTestId("notification-row-time")
+        .map((el) => el.textContent);
+    const before = times();
+
+    listRenders = 0;
+    act(() => {
+      vi.advanceTimersByTime(MINUTE_MS);
+    });
+
+    const after = times();
+    // The relative strings advanced by ~1 minute (leaves re-rendered).
+    expect(after).not.toEqual(before);
+    // But the list component body did not execute, so no re-slice/re-sort and
+    // no remapping up to 100 rows. Re-introducing list-level `useNow(60s)` makes
+    // this count jump to 1 on the minute tick.
+    expect(listRenders).toBe(0);
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(8);
+  });
+
+  it("rows are memoized: minute tick re-renders zero NotificationRow bodies", () => {
+    for (let i = 0; i < 30; i++) {
+      __ingestNotificationForTests(makeNotification({ title: `Row ${i}` }));
+    }
+
+    let rowRenders = 0;
+    __setNotificationRowRenderObserverForTests(() => {
+      rowRenders += 1;
+    });
+
+    render(<NotificationsHomeCenter />);
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(rowRenders).toBe(30);
+
+    const timeBefore = screen.getAllByTestId("notification-row-time")[0]
+      .textContent;
+    rowRenders = 0;
+    act(() => {
+      vi.advanceTimersByTime(MINUTE_MS);
+    });
+
+    // This is the failing-when-broken proof for #14559: the minute roll updates
+    // the leaf time text, but it does NOT execute any NotificationRow render
+    // body. Re-introducing list-level `useNow(60s)` or removing React.memo makes
+    // this count jump to the rendered row count.
+    expect(rowRenders).toBe(0);
+    expect(
+      screen.getAllByTestId("notification-row-time")[0].textContent,
+    ).not.toBe(timeBefore);
+  });
+
+  it("rowPropsEqual: skips re-render on a createdAt-only change, re-renders on identity change", () => {
+    // The memo's equality function is the surgical part of the fix: `createdAt`
+    // is excluded (it feeds only the leaf), so the once-a-minute newer-timestamp
+    // never re-renders the row; but any field that changes the row's OWN markup
+    // (readAt/unread, priority/rail, title, body, deepLink) does.
+    const base = makeNotification({
+      title: "T",
+      body: "B",
+      priority: "normal",
+      readAt: null,
+      deepLink: "/x",
+    });
+    const onOpen = () => {};
+    const onDismiss = () => {};
+    const props = { notification: base, onOpen, onDismiss };
+
+    // createdAt-only delta → equal → memo SKIPS (no row re-render on the minute).
+    expect(
+      rowPropsEqual(props, {
+        ...props,
+        notification: { ...base, createdAt: base.createdAt + MINUTE_MS },
+      }),
+    ).toBe(true);
+
+    // Each identity field flips it to a real re-render.
+    expect(
+      rowPropsEqual(props, {
+        ...props,
+        notification: { ...base, readAt: Date.now() },
+      }),
+    ).toBe(false);
+    expect(
+      rowPropsEqual(props, {
+        ...props,
+        notification: { ...base, priority: "urgent" },
+      }),
+    ).toBe(false);
+    expect(
+      rowPropsEqual(props, {
+        ...props,
+        notification: { ...base, title: "T2" },
+      }),
+    ).toBe(false);
+    expect(
+      rowPropsEqual(props, {
+        ...props,
+        notification: { ...base, body: "B2" },
+      }),
+    ).toBe(false);
+    // A new callback identity (parent lost its useCallback) also re-renders.
+    expect(rowPropsEqual(props, { ...props, onOpen: () => {} })).toBe(false);
+  });
+
+  it("rows still show live relative times (no 'just now' pin regression)", () => {
+    // The old comment warned a stable-props memo would "pin just now forever".
+    // With the leaf pattern that risk is gone: the row is memoized on identity
+    // fields but the time still advances because it lives in the leaf.
+    __ingestNotificationForTests(
+      makeNotification({ title: "Fresh", createdAt: Date.now() }),
+    );
+    render(<NotificationsHomeCenter />);
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(screen.getByTestId("notification-row-time").textContent).toBe(
+      "just now",
+    );
+
+    // 3 minutes later the SAME row (memoized) shows "3m ago" - not pinned.
+    act(() => {
+      vi.advanceTimersByTime(3 * MINUTE_MS);
+    });
+    expect(screen.getByTestId("notification-row-time").textContent).toBe(
+      "3m ago",
+    );
+  });
+
+  it("tap-marks-read still never reorders rows (stable-order invariant)", () => {
+    const urgent = makeNotification({ priority: "urgent", title: "First" });
+    __ingestNotificationForTests(makeNotification({ title: "Second" }));
+    __ingestNotificationForTests(urgent);
+    render(<NotificationsHomeCenter />);
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    const titles = () =>
+      screen
+        .getAllByTestId("notification-row")
+        .map((el) => el.textContent ?? "");
+    expect(titles()[0]).toContain("First");
+    fireEvent.click(screen.getAllByTestId("notification-row")[0]);
+    expect(titles()[0]).toContain("First");
+  });
+});

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -1,8 +1,8 @@
 /**
  * The dashboard notification center: a home-surface widget pinned directly
  * below the time/weather base that IS the app's notification inbox. It replaced
- * the pull-down sheet/panel shells — notifications live on the dashboard, not
- * behind a gesture — so this card renders the full inbox with its actions
+ * the pull-down sheet/panel shells - notifications live on the dashboard, not
+ * behind a gesture - so this card renders the full inbox with its actions
  * (open/deep-link, dismiss, mark-all-read, clear) and self-hides when empty.
  *
  * The list is height-capped and scrolls internally: edge fades mask the
@@ -18,8 +18,7 @@
  */
 import type { AgentNotification } from "@elizaos/core";
 import { CheckCheck, Trash2, X } from "lucide-react";
-import { useCallback, useEffect, useRef } from "react";
-import { useNow } from "../../hooks/useNow";
+import { memo, useCallback, useEffect, useRef } from "react";
 import { cn } from "../../lib/utils";
 import {
   isSafeDeepLink,
@@ -32,9 +31,9 @@ import {
   removeNotification,
   useNotifications,
 } from "../../state/notifications/notification-store";
-import { formatRelativeTime } from "../../utils/format";
 import { NOTIFICATION_PRIORITY_RANK } from "../../widgets/home-priority";
 import { Button } from "../ui/button";
+import { RelativeTime } from "./RelativeTime";
 
 /**
  * Height cap for the scrolling list (the header stays pinned above it). Sized
@@ -51,14 +50,14 @@ const LIST_MAX_HEIGHT = "max-h-[min(45dvh,19.5rem)]";
 const MAX_RENDERED_ROWS = 100;
 
 /**
- * Scroll polish for the capped list, in one inline block (house pattern —
+ * Scroll polish for the capped list, in one inline block (house pattern -
  * see HOME_ENTER_CSS in HomeScreen):
  *
  *  - `.eliza-notif-scroll` carries the top/bottom edge fade masks, toggled by
  *    the `data-fade-top` / `data-fade-bottom` attributes the scroll handler
  *    maintains, so rows dissolve at the clipped edges instead of hard-cutting.
  *  - Where `animation-timeline: view()` is supported, each row also scales and
- *    fades slightly while crossing the scrollport edges — the depth cue of a
+ *    fades slightly while crossing the scrollport edges - the depth cue of a
  *    platform notification shade. Progressive enhancement only; the fallback
  *    is the plain masked scroll.
  *  - New rows (live arrivals) slide in from the top.
@@ -116,7 +115,7 @@ const NOTIF_SCROLL_CSS = `
 
 /**
  * Stable dashboard order: priority bucket, then recency, then id as the total
- * tiebreak. Read state styles rows but never orders them — marking a row read
+ * tiebreak. Read state styles rows but never orders them - marking a row read
  * on tap must not move it (the inbox-style unread-first rank reshuffles).
  */
 export function orderDashboardNotifications(
@@ -135,26 +134,69 @@ export function orderDashboardNotifications(
 /**
  * One notification row: a whole-row open button (mark read + scheme-checked
  * deep link) plus an always-visible dismiss X sized to the touch token on
- * coarse pointers. Deliberately NOT memoized: the parent re-renders on the
- * shared 60s clock tick precisely so each row's relative timestamp refreshes —
- * a memo with stable props would pin "just now" forever. Rows are cheap and
- * capped, so the once-a-minute re-render is negligible.
+ * coarse pointers.
+ *
+ * Memoized (binding pattern, spec §C.4): the relative timestamp now lives in a
+ * `<RelativeTime>` leaf that owns the minute tick, so the row no longer has to
+ * re-render every minute to keep "5m ago" honest. With time rendering out of
+ * the row's render path, a stable-props memo is correct - it re-renders only
+ * when the row's actual content changes, and `arePropsEqual` compares the
+ * identity fields that drive its markup: `id`, `readAt` (unread styling),
+ * `priority` (rail), `title`, `body`, plus the two callbacks (stable via the
+ * parent's `useCallback`). `createdAt` is intentionally NOT compared: it feeds
+ * only the leaf, which subscribes to the tick itself.
  */
-function NotificationRow({
-  notification,
-  onOpen,
-  onDismiss,
-}: {
+export function rowPropsEqual(
+  prev: NotificationRowProps,
+  next: NotificationRowProps,
+): boolean {
+  const a = prev.notification;
+  const b = next.notification;
+  return (
+    a.id === b.id &&
+    a.readAt === b.readAt &&
+    a.priority === b.priority &&
+    a.title === b.title &&
+    a.body === b.body &&
+    a.deepLink === b.deepLink &&
+    prev.onOpen === next.onOpen &&
+    prev.onDismiss === next.onDismiss
+  );
+}
+
+export interface NotificationRowProps {
   notification: AgentNotification;
   onOpen: (n: AgentNotification) => void;
   onDismiss: (id: string) => void;
-}): React.JSX.Element {
+}
+
+let notificationRowRenderObserverForTests: (() => void) | null = null;
+let notificationsHomeCenterRenderObserverForTests: (() => void) | null = null;
+
+export function __setNotificationRowRenderObserverForTests(
+  observer: (() => void) | null,
+): void {
+  notificationRowRenderObserverForTests = observer;
+}
+
+export function __setNotificationsHomeCenterRenderObserverForTests(
+  observer: (() => void) | null,
+): void {
+  notificationsHomeCenterRenderObserverForTests = observer;
+}
+
+const NotificationRow = memo(function NotificationRow({
+  notification,
+  onOpen,
+  onDismiss,
+}: NotificationRowProps): React.JSX.Element {
+  notificationRowRenderObserverForTests?.();
   const unread = !notification.readAt;
   const urgent = notification.priority === "urgent";
   const high = notification.priority === "high";
   // Lock-screen restraint: NO per-row icon chip (a box inside a box inside the
-  // card). Priority is carried by a hairline accent rail on the leading edge —
-  // present only for urgent/high — and an unread state by a single dot, so a
+  // card). Priority is carried by a hairline accent rail on the leading edge -
+  // present only for urgent/high - and an unread state by a single dot, so a
   // quiet normal notification is just its line + time, like an iOS lock note.
   const accent = urgent || high ? "bg-white/75" : null;
   return (
@@ -166,7 +208,7 @@ function NotificationRow({
         )}
       >
         {/* Priority rail: a 2px edge tint, urgent/high only. The row without
-            it reads as ordinary — restraint over decoration. */}
+            it reads as ordinary - restraint over decoration. */}
         {accent ? (
           <span
             aria-hidden
@@ -208,12 +250,11 @@ function NotificationRow({
             >
               {notification.title}
             </span>
-            <time
+            <RelativeTime
+              ts={notification.createdAt}
               className="ml-auto shrink-0 pl-2 text-2xs tabular-nums text-white/60"
               data-testid="notification-row-time"
-            >
-              {formatRelativeTime(notification.createdAt)}
-            </time>
+            />
           </span>
           {notification.body ? (
             <span className="line-clamp-2 text-xs leading-snug text-white/62">
@@ -221,7 +262,7 @@ function NotificationRow({
             </span>
           ) : null}
         </button>
-        {/* Visible at rest (dimmed) — on touch there is no hover, and an
+        {/* Visible at rest (dimmed) - on touch there is no hover, and an
             invisible dismiss silently ate near-edge taps in the old center. */}
         <Button
           variant="ghost"
@@ -236,7 +277,8 @@ function NotificationRow({
       </div>
     </li>
   );
-}
+}, rowPropsEqual);
+NotificationRow.displayName = "NotificationRow";
 
 /**
  * The dashboard notification center card. Self-hiding: renders nothing until
@@ -244,9 +286,12 @@ function NotificationRow({
  * clock/weather base. Mounted once by HomeScreen below DefaultHomeWidgets.
  */
 export function NotificationsHomeCenter(): React.JSX.Element | null {
+  notificationsHomeCenterRenderObserverForTests?.();
   const { notifications, unreadCount } = useNotifications();
-  // Coarse tick so relative timestamps stay honest while the card is visible.
-  useNow(60_000);
+  // No list-level clock tick here (binding pattern, spec §C.4): relative
+  // timestamps live in the `<RelativeTime>` leaf inside each row, which owns the
+  // shared visibility-gated ticker. The minute roll re-renders those text nodes
+  // only - not this list, not the rows, not the glass surface.
   const scrollRef = useRef<HTMLUListElement | null>(null);
 
   // Maintain the edge-fade attributes from real scroll geometry. Runs on
@@ -266,7 +311,7 @@ export function NotificationsHomeCenter(): React.JSX.Element | null {
 
   const openNotification = useCallback((n: AgentNotification) => {
     if (!n.readAt) void markNotificationRead(n.id);
-    // deepLink is producer/LLM-influenceable — only scheme-checked links
+    // deepLink is producer/LLM-influenceable - only scheme-checked links
     // navigate; anything else the tap is just "mark read".
     if (n.deepLink && isSafeDeepLink(n.deepLink)) {
       navigateDeepLink(n.deepLink);
@@ -298,11 +343,18 @@ export function NotificationsHomeCenter(): React.JSX.Element | null {
       // faintly translucent surface over the wallpaper (backdrop-blur where
       // supported), no heavy filled card. This reads as an iOS lock-screen
       // notification stack sitting on the home field rather than an app card.
-      className="mt-4 flex flex-col overflow-hidden rounded-2xl border border-white/55 bg-black/35 text-white backdrop-blur-xl supports-[backdrop-filter]:bg-black/30"
+      //
+      // Blur audit (spec §C.4 item 4): stepped `backdrop-blur-xl` →
+      // `backdrop-blur-md`. A full-strength blur over the animated wallpaper is
+      // a per-frame compositing cost on iOS Safari that the always-mounted home
+      // pays forever; `md` still reads as glass. The `supports-[backdrop-filter]`
+      // translucency stays the primary low-end path (an opaque-enough surface
+      // where blur is unsupported), so legibility never depends on the blur.
+      className="mt-4 flex flex-col overflow-hidden rounded-2xl border border-white/55 bg-black/35 text-white backdrop-blur-md supports-[backdrop-filter]:bg-black/30"
     >
       <style>{NOTIF_SCROLL_CSS}</style>
       {/* Pinned header: a quiet eyebrow + unread count, actions to the right.
-          No boxed bell chip — the label alone names the surface. */}
+          No boxed bell chip - the label alone names the surface. */}
       <div className="flex shrink-0 items-center gap-1.5 px-3.5 pb-1 pt-2.5">
         <span className="text-2xs font-medium uppercase tracking-[0.1em] text-white/70">
           Notifications

--- a/packages/ui/src/components/shell/RelativeTime.tsx
+++ b/packages/ui/src/components/shell/RelativeTime.tsx
@@ -1,0 +1,81 @@
+/**
+ * `<RelativeTime>` - the leaf of the binding pattern (spec §C.4).
+ *
+ * A relative timestamp ("5m ago") has to refresh as time passes, but nothing
+ * *around* it does. The old shape put a `useNow(60s)` at the top of
+ * `NotificationsHomeCenter`, so the whole inbox (up to 100 rows, each with
+ * buttons, over a blurred glass surface) re-rendered every minute just to move
+ * a few text nodes. This leaf inverts that: it is the ONLY thing subscribed to
+ * the minute tick, so the tick re-renders the `<time>` text node and nothing
+ * else. Its parent row can then be `React.memo`'d on stable props.
+ *
+ * It reads the single, module-level, visibility-gated ticker (`useSharedNow`),
+ * so N leaves on screen share ONE interval that pauses while the tab is hidden.
+ *
+ * Render-path determinism: `useSharedNow` returns `0` on the first render (no
+ * `Date.now()` in render - the UI determinism convention). At the epoch we
+ * still render a correct string because `formatRelativeTime` reads the wall
+ * clock itself; the `now` subscription exists purely to trigger the re-render
+ * when the minute rolls over. We depend on `now` (via the `key`-free re-render)
+ * so the lint/compile can't see it as unused - it is the tick signal.
+ */
+
+import { memo } from "react";
+import { useSharedNow } from "../../hooks/useSharedNow";
+import { formatRelativeTime } from "../../utils/format";
+
+type RelativeTimeTranslator = (
+  key: string,
+  vars?: Record<string, string | number | boolean | null | undefined>,
+) => string;
+
+export interface RelativeTimeProps {
+  /** The timestamp to render relative to now (epoch-ms, ISO string, or Date). */
+  ts: string | number | Date;
+  /** Optional i18n translator forwarded to `formatRelativeTime`. */
+  t?: RelativeTimeTranslator;
+  /** Extra classes for the `<time>` element. */
+  className?: string;
+  /** Test hook / a11y hook passthrough. */
+  "data-testid"?: string;
+}
+
+/**
+ * The relative-time text node. Subscribes to the shared minute ticker so it
+ * (and only it) re-renders when the minute rolls over; the formatted string is
+ * derived from the wall clock at render time.
+ *
+ * Memoized on `(ts, className, testid)`: a parent re-render with the same props
+ * does not re-render the leaf, and a tick re-renders the leaf without touching
+ * the parent - the two directions of the binding pattern.
+ */
+function RelativeTimeImpl({
+  ts,
+  t,
+  className,
+  "data-testid": testId,
+}: RelativeTimeProps): React.JSX.Element {
+  // Subscribe to the shared ticker purely for the re-render signal. The value
+  // is intentionally not read into the label - `formatRelativeTime` reads the
+  // clock itself - but subscribing is what makes the minute roll re-render this
+  // node (and nothing above it). `void` marks it as an intentional tick sink.
+  void useSharedNow();
+
+  const date = ts instanceof Date ? ts : new Date(ts);
+  const iso = Number.isFinite(date.getTime()) ? date.toISOString() : undefined;
+
+  return (
+    <time className={className} dateTime={iso} data-testid={testId}>
+      {formatRelativeTime(ts, t)}
+    </time>
+  );
+}
+
+/**
+ * `React.memo` so a parent (row) re-render with unchanged props is a no-op for
+ * the leaf. `t` is compared by reference - callers should pass a stable
+ * translator (the i18n `t` is stable per render tree); an inline `t` would
+ * defeat the memo but callers on the home surface pass none.
+ */
+export const RelativeTime = memo(RelativeTimeImpl);
+RelativeTime.displayName = "RelativeTime";

--- a/packages/ui/src/hooks/useSharedNow.test.tsx
+++ b/packages/ui/src/hooks/useSharedNow.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+
+/**
+ * Unit lock for the shared, visibility-gated minute ticker (spec §C.4 item 3).
+ *
+ * The three properties the binding pattern relies on:
+ *  1. ONE interval for N subscribers (not one per leaf) - proven by spying on
+ *     `setInterval` and mounting many consumers.
+ *  2. The tick is **visibility-gated**: the interval is cleared while
+ *     `document.hidden` and re-armed (with an immediate resync) on show.
+ *  3. Deterministic render path: the first snapshot is `0` (never `Date.now()`),
+ *     the live clock installs after subscribe.
+ */
+
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetSharedNowForTests,
+  MINUTE_MS,
+  useSharedNow,
+} from "./useSharedNow";
+
+// A tiny consumer that surfaces the current snapshot for assertions.
+function NowProbe({ label }: { label: string }): React.JSX.Element {
+  const now = useSharedNow();
+  return <span data-testid={`now-${label}`}>{now}</span>;
+}
+
+/** Force `document.hidden` / `visibilityState` and fire the event. */
+function setHidden(hidden: boolean): void {
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    get: () => hidden,
+  });
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => (hidden ? "hidden" : "visible"),
+  });
+  act(() => {
+    document.dispatchEvent(new Event("visibilitychange"));
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-06-25T14:30:00Z"));
+  setHidden(false);
+});
+
+afterEach(() => {
+  cleanup();
+  __resetSharedNowForTests();
+  vi.useRealTimers();
+});
+
+describe("useSharedNow - shared visibility-gated ticker", () => {
+  it("arms exactly ONE interval no matter how many leaves subscribe", () => {
+    const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+
+    render(
+      <>
+        <NowProbe label="a" />
+        <NowProbe label="b" />
+        <NowProbe label="c" />
+        <NowProbe label="d" />
+      </>,
+    );
+    // Flush subscribe effects.
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+
+    // Four subscribers, one interval. The naive `useNow`-per-leaf shape would
+    // arm four here - this is the whole point of the shared ticker.
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    setIntervalSpy.mockRestore();
+  });
+
+  it("returns 0 on first render, then the live clock after subscribe", () => {
+    // getServerSnapshot / first snapshot is the deterministic epoch. React may
+    // commit the effect synchronously in the test env, so assert the live value
+    // after flushing rather than trying to freeze the pre-effect frame.
+    const { getByTestId } = render(<NowProbe label="live" />);
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(getByTestId("now-live").textContent).toBe(String(Date.now()));
+  });
+
+  it("advances every subscriber on the minute tick", () => {
+    const { getByTestId } = render(
+      <>
+        <NowProbe label="a" />
+        <NowProbe label="b" />
+      </>,
+    );
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    const t0 = getByTestId("now-a").textContent;
+    expect(getByTestId("now-b").textContent).toBe(t0);
+
+    act(() => {
+      vi.advanceTimersByTime(MINUTE_MS);
+    });
+    const t1 = getByTestId("now-a").textContent;
+    expect(Number(t1)).toBe(Number(t0) + MINUTE_MS);
+    // Both leaves saw the same new value from the single shared tick.
+    expect(getByTestId("now-b").textContent).toBe(t1);
+  });
+
+  it("stops ticking while document.hidden and resyncs on show", () => {
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+    const { getByTestId } = render(<NowProbe label="vis" />);
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    const visible0 = Number(getByTestId("now-vis").textContent);
+
+    // Hide the tab: the interval must be torn down (zero timer wakeups).
+    setHidden(true);
+    expect(clearIntervalSpy).toHaveBeenCalled();
+
+    // Time passes while hidden - advancing timers must NOT move the snapshot,
+    // because the interval is cleared.
+    act(() => {
+      vi.advanceTimersByTime(MINUTE_MS * 5);
+    });
+    expect(Number(getByTestId("now-vis").textContent)).toBe(visible0);
+
+    // Show again: it resyncs immediately to the real (advanced) clock…
+    setHidden(false);
+    const afterShow = Number(getByTestId("now-vis").textContent);
+    expect(afterShow).toBe(Date.now());
+    expect(afterShow).toBeGreaterThan(visible0);
+
+    // …and resumes ticking.
+    act(() => {
+      vi.advanceTimersByTime(MINUTE_MS);
+    });
+    expect(Number(getByTestId("now-vis").textContent)).toBe(
+      afterShow + MINUTE_MS,
+    );
+    clearIntervalSpy.mockRestore();
+  });
+
+  it("tears the interval down when the last subscriber unmounts", () => {
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+    const { unmount } = render(<NowProbe label="only" />);
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    clearIntervalSpy.mockClear();
+
+    unmount();
+    // Last leaf gone → the shared interval is cleared (no orphaned timer on the
+    // always-mounted home once every relative-time leaf is off screen).
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    clearIntervalSpy.mockRestore();
+  });
+});

--- a/packages/ui/src/hooks/useSharedNow.ts
+++ b/packages/ui/src/hooks/useSharedNow.ts
@@ -1,0 +1,170 @@
+/**
+ * A single, module-level, visibility-gated "current time" ticker shared by
+ * every relative-timestamp leaf in the app (see the binding pattern, spec
+ * §C.4 of NOTIFICATIONS-WIDGETS-SYSTEM.md).
+ *
+ * Why a shared ticker instead of one `useNow` per component:
+ *  - `useNow` installs its own `setInterval` per calling component. A home
+ *    surface with a notification inbox (up to 100 rows) + clock + calendar card
+ *    would otherwise arm dozens-to-hundreds of independent minute timers, all
+ *    firing on their own phase. This module arms exactly ONE interval for the
+ *    whole app and fans the tick out to every subscriber via
+ *    `useSyncExternalStore`.
+ *  - It is **visibility-gated**: the interval is cleared while `document.hidden`
+ *    and re-armed (with an immediate resync) on show. A backgrounded PWA burns
+ *    zero timer wakeups - the exact cost the spec forbids ("tickers pause when
+ *    the document is hidden", §A.6).
+ *
+ * The subscription is lazy: the interval only runs while there is at least one
+ * subscriber, and is torn down when the last leaf unmounts. So the always-mounted
+ * home pays for the ticker only while a relative-time leaf is actually on screen.
+ *
+ * Render-path determinism: like `useNow`, the server/first-commit snapshot is
+ * `0` (never `Date.now()` during render - the UI determinism convention). The
+ * real clock is installed after subscribe, in the store, not in render.
+ */
+
+import { useSyncExternalStore } from "react";
+
+/** Default cadence for relative "n minutes ago" surfaces. */
+export const MINUTE_MS = 60_000;
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+
+/**
+ * The current tick value (epoch-ms), or `0` before the ticker has installed the
+ * real clock. Read via `getSnapshot` so `useSyncExternalStore` can memoize
+ * against it (a stable reference between ticks means no spurious re-render).
+ */
+let currentNow = 0;
+
+/** The live interval id while the document is visible and we have subscribers. */
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+/** Whether the visibility listener is installed (matches `listeners.size > 0`). */
+let visibilityBound = false;
+
+function isHidden(): boolean {
+  return (
+    typeof document !== "undefined" &&
+    typeof document.visibilityState === "string" &&
+    document.hidden === true
+  );
+}
+
+/** Push the current clock to `currentNow` and notify subscribers if it moved. */
+function tick(): void {
+  const next = Date.now();
+  if (next === currentNow) return;
+  currentNow = next;
+  for (const listener of listeners) listener();
+}
+
+/** Arm the interval iff visible + subscribed + not already armed. */
+function armInterval(): void {
+  if (intervalId !== null) return;
+  if (isHidden()) return;
+  if (listeners.size === 0) return;
+  intervalId = setInterval(tick, MINUTE_MS);
+}
+
+/** Clear the interval (used on hide + on last-unsubscribe). */
+function clearIntervalIfArmed(): void {
+  if (intervalId === null) return;
+  clearInterval(intervalId);
+  intervalId = null;
+}
+
+/**
+ * Visibility handler: on hide, stop burning timers; on show, resync the clock
+ * immediately (so a leaf that was hidden for an hour jumps straight to the
+ * right string) and re-arm the interval.
+ */
+function handleVisibility(): void {
+  if (isHidden()) {
+    clearIntervalIfArmed();
+    return;
+  }
+  tick();
+  armInterval();
+}
+
+function bindVisibility(): void {
+  if (visibilityBound) return;
+  if (typeof document === "undefined") return;
+  document.addEventListener("visibilitychange", handleVisibility);
+  visibilityBound = true;
+}
+
+function unbindVisibility(): void {
+  if (!visibilityBound) return;
+  if (typeof document === "undefined") return;
+  document.removeEventListener("visibilitychange", handleVisibility);
+  visibilityBound = false;
+}
+
+/**
+ * `useSyncExternalStore` subscribe: register the listener, install the real
+ * clock on the FIRST subscriber, and arm the shared interval. Returns the
+ * unsubscribe that tears the interval down when the last leaf unmounts.
+ */
+function subscribe(listener: Listener): () => void {
+  const wasEmpty = listeners.size === 0;
+  listeners.add(listener);
+  if (wasEmpty) {
+    // First subscriber: install the real clock (leave `getSnapshot` returning
+    // the epoch until this commit so render stays deterministic), then start
+    // ticking. `tick()` bumps `currentNow` off 0 and notifies, so the leaf
+    // shows a live time on its first effect flush.
+    bindVisibility();
+    tick();
+    armInterval();
+  }
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) {
+      clearIntervalIfArmed();
+      unbindVisibility();
+      // Reset the snapshot so a later remount re-enters the deterministic
+      // `0` first-render path rather than flashing a stale timestamp.
+      currentNow = 0;
+    }
+  };
+}
+
+function getSnapshot(): number {
+  return currentNow;
+}
+
+/** SSR/first-commit snapshot: always the deterministic epoch (never Date.now). */
+function getServerSnapshot(): number {
+  return 0;
+}
+
+/**
+ * Subscribe to the shared, visibility-gated minute ticker. Returns the current
+ * time in epoch-ms, or `0` on the first render (deterministic render path - the
+ * real clock is installed in the store after subscribe, never during render).
+ *
+ * Use this in **leaf** components only (a `<RelativeTime>`, a clock text node),
+ * never at a list level - the whole point of the binding pattern is that the
+ * tick re-renders the text node, not its parent row/list.
+ *
+ */
+export function useSharedNow(): number {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
+/**
+ * Test-only: fully reset the module ticker between cases so one test's mounted
+ * leaves can't leak an interval / stale snapshot into the next. Not part of the
+ * production surface.
+ */
+export function __resetSharedNowForTests(): void {
+  clearIntervalIfArmed();
+  unbindVisibility();
+  listeners.clear();
+  currentNow = 0;
+}


### PR DESCRIPTION
[sol-orch]

Fixes #14559.

## Summary
- Removed the list-level `useNow(60_000)` from `NotificationsHomeCenter`.
- Added a memoized `<RelativeTime>` leaf that owns timestamp refreshes.
- Added `useSharedNow`, a single module-level ticker shared by all leaves, lazy-subscribed and paused while `document.hidden`.
- Memoized `NotificationRow` with a stable prop comparator so minute ticks do not re-render row bodies or the list.
- Moved `DefaultHomeWidgets` clock ticking into a `<HomeClock>` leaf so the weather tile does not re-render every minute.
- Audited existing glass cost and reduced `backdrop-blur-xl` to `backdrop-blur-md`; no new backdrop blur added.

## Perf proof
- Render-count test proves one minute tick updates relative-time text but executes zero `NotificationsHomeCenter` renders and zero `NotificationRow` renders.
- Render-count test proves the home clock advances while `WeatherTile` render count stays at zero after mount.
- Ticker unit test proves one interval for multiple subscribers, pause on hidden, resync on show, and cleanup on last unsubscribe.

## Verification
```
NODE_OPTIONS="--no-experimental-webstorage --disable-warning=ExperimentalWarning" ./node_modules/.bin/vitest run --config ./vitest.config.ts src/hooks/useSharedNow.test.tsx src/components/shell/NotificationsHomeCenter.render-count.test.tsx src/components/shell/DefaultHomeWidgets.render-count.test.tsx src/components/shell/NotificationsHomeCenter.test.tsx src/components/shell/DefaultHomeWidgets.test.tsx

Test Files  5 passed (5)
Tests       31 passed (31)
```

```
./node_modules/.bin/biome check packages/ui/src/hooks/useSharedNow.ts packages/ui/src/hooks/useSharedNow.test.tsx packages/ui/src/components/shell/RelativeTime.tsx packages/ui/src/components/shell/NotificationsHomeCenter.tsx packages/ui/src/components/shell/NotificationsHomeCenter.render-count.test.tsx packages/ui/src/components/shell/DefaultHomeWidgets.tsx packages/ui/src/components/shell/DefaultHomeWidgets.render-count.test.tsx

Checked 7 files in 153ms. No fixes applied.
```

```
cd packages/app && bun run build

EXIT:0
✓ built in 1m 1s
[plugin renderer-build-manifest] [renderer-build-manifest] wrote eliza-renderer-build.json buildId=463a2608beff (787 assets)
```

## Notes
- `codex review --uncommitted` was run with a 105s timeout per lane protocol. It timed out with exit 124 and only dumped raw file context, so I performed self-review and tightened the render-count proof before commit.
- Broader `packages/ui/src/components/shell/` suite has a pre-existing unrelated failure in `HomeLauncherSurface.composed.test.tsx`: mocked `../../platform/platform-guards` lacks `getFrontendPlatform`. Confirmed it fails on pristine develop before these changes.
