### PR TITLE
fix(core): add semantic experience mutation action

### DIFF
--- a/packages/core/src/features/advanced-capabilities/experience/actions/experience.test.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/actions/experience.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Unit tests for the EXPERIENCE mutation action. They use a fake
+ * ExperienceService so the assertions stay focused on action routing,
+ * confirmation safety, query targeting, and view-field update payloads rather
+ * than a live model or database.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type {
+	HandlerOptions,
+	IAgentRuntime,
+	Memory,
+} from "../../../../types/index.ts";
+import type { UUID } from "../../../../types/primitives.ts";
+import { type Experience, ExperienceType, OutcomeType } from "../types.ts";
+import { experienceAction } from "./experience.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000aa" as UUID;
+const USER_ID = "00000000-0000-0000-0000-0000000000bb" as UUID;
+const ROOM_ID = "00000000-0000-0000-0000-0000000000cc" as UUID;
+const EXP_ONE = "00000000-0000-0000-0000-00000000e001" as UUID;
+const EXP_TWO = "00000000-0000-0000-0000-00000000e002" as UUID;
+
+function makeExperience(id: UUID, learning: string): Experience {
+	return {
+		id,
+		agentId: AGENT_ID,
+		type: ExperienceType.LEARNING,
+		outcome: OutcomeType.NEUTRAL,
+		context: "The agent reviewed onboarding guidance.",
+		action: "Answered a help request.",
+		result: "The response mentioned stale tutorial tiles.",
+		learning,
+		tags: ["onboarding"],
+		domain: "product",
+		keywords: ["onboarding", "tutorial"],
+		associatedEntityIds: [],
+		confidence: 0.7,
+		importance: 0.6,
+		createdAt: 1_000,
+		updatedAt: 1_000,
+		accessCount: 0,
+	};
+}
+
+function makeHarness(initial: Experience[]) {
+	const store = new Map(
+		initial.map((experience) => [experience.id, experience]),
+	);
+	const service = {
+		getExperience: vi.fn(async (id: UUID) => store.get(id) ?? null),
+		queryExperiences: vi.fn(async ({ query }: { query?: string }) =>
+			[...store.values()].filter((experience) =>
+				`${experience.learning} ${experience.context} ${experience.result}`
+					.toLowerCase()
+					.includes((query ?? "").toLowerCase()),
+			),
+		),
+		updateExperience: vi.fn(async (id: UUID, updates: Partial<Experience>) => {
+			const existing = store.get(id);
+			if (!existing) return null;
+			const updated = { ...existing, ...updates, updatedAt: 2_000 };
+			store.set(id, updated);
+			return updated;
+		}),
+		deleteExperience: vi.fn(async (id: UUID) => store.delete(id)),
+	};
+	const runtime = {
+		agentId: AGENT_ID,
+		getService: vi.fn((name: string) =>
+			name === "EXPERIENCE" ? service : null,
+		),
+	} as unknown as IAgentRuntime;
+	const message = {
+		entityId: USER_ID,
+		roomId: ROOM_ID,
+		content: { text: "delete that experience", source: "test" },
+	} as Memory;
+	const run = (parameters: Record<string, unknown>) =>
+		experienceAction.handler?.(runtime, message, undefined, {
+			parameters,
+		} as HandlerOptions);
+	return { service, runtime, run };
+}
+
+describe("EXPERIENCE action", () => {
+	it("requires confirm:true before deleting", async () => {
+		const { service, run } = makeHarness([
+			makeExperience(EXP_ONE, "Use chat-native tutorial guidance."),
+		]);
+
+		const result = await run({ op: "delete", experienceId: EXP_ONE });
+
+		expect(result?.success).toBe(false);
+		expect(result?.data).toMatchObject({
+			error: "EXPERIENCE_CONFIRMATION_REQUIRED",
+		});
+		expect(service.deleteExperience).not.toHaveBeenCalled();
+	});
+
+	it("deletes a uniquely resolved experience by query without a raw selector", async () => {
+		const { service, run } = makeHarness([
+			makeExperience(EXP_ONE, "Use chat-native tutorial guidance."),
+		]);
+
+		const result = await run({
+			op: "delete",
+			query: "chat-native tutorial",
+			confirm: true,
+		});
+
+		expect(result?.success).toBe(true);
+		expect(service.queryExperiences).toHaveBeenCalledWith(
+			expect.objectContaining({ query: "chat-native tutorial" }),
+		);
+		expect(service.deleteExperience).toHaveBeenCalledWith(EXP_ONE);
+		expect(result?.data).toMatchObject({
+			actionName: "EXPERIENCE",
+			op: "delete",
+			experienceId: EXP_ONE,
+		});
+	});
+
+	it("refuses an ambiguous query instead of guessing which experience to delete", async () => {
+		const { service, run } = makeHarness([
+			makeExperience(EXP_ONE, "Use chat-native tutorial guidance."),
+			makeExperience(EXP_TWO, "Prefer chat-native onboarding cards."),
+		]);
+
+		const result = await run({
+			op: "delete",
+			query: "chat-native",
+			confirm: true,
+		});
+
+		expect(result?.success).toBe(false);
+		expect(result?.data).toMatchObject({
+			error: "EXPERIENCE_AMBIGUOUS_QUERY",
+		});
+		expect(service.deleteExperience).not.toHaveBeenCalled();
+		expect(result?.text).toContain(EXP_ONE);
+		expect(result?.text).toContain(EXP_TWO);
+	});
+
+	it("updates the same editable fields the Character Experience view saves", async () => {
+		const { service, run } = makeHarness([
+			makeExperience(EXP_ONE, "Use chat-native tutorial guidance."),
+		]);
+
+		const result = await run({
+			op: "update",
+			experienceId: EXP_ONE,
+			learning: "Prefer chat-native tutorial cards over launcher tiles.",
+			importance: "0.9",
+			confidence: 0.85,
+			tags: "onboarding, tutorial, chat-native",
+			confirm: true,
+		});
+
+		expect(result?.success).toBe(true);
+		expect(service.updateExperience).toHaveBeenCalledWith(
+			EXP_ONE,
+			expect.objectContaining({
+				learning: "Prefer chat-native tutorial cards over launcher tiles.",
+				importance: 0.9,
+				confidence: 0.85,
+				tags: ["onboarding", "tutorial", "chat-native"],
+			}),
+		);
+		expect(result?.data).toMatchObject({
+			actionName: "EXPERIENCE",
+			op: "update",
+			experienceId: EXP_ONE,
+		});
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/experience/actions/experience.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/actions/experience.ts
@@ -1,0 +1,468 @@
+/**
+ * Semantic mutation action for the experience capability. The Character
+ * Experience view edits these same records through HTTP routes; this action
+ * gives chat and voice the same use case without asking the model to target a
+ * mounted DOM control or raw selector.
+ */
+import { logger } from "../../../../logger.ts";
+import type {
+	Action,
+	ActionExample,
+	ActionResult,
+	HandlerCallback,
+	HandlerOptions,
+	IAgentRuntime,
+	Memory,
+	State,
+} from "../../../../types/index.ts";
+import { hasActionContext } from "../../../../utils/action-validation.ts";
+import { validateUuid } from "../../../../utils.ts";
+import type { ExperienceService } from "../service.ts";
+import { type Experience, ExperienceType, OutcomeType } from "../types.ts";
+
+const EXPERIENCE = "EXPERIENCE";
+const EXPERIENCE_OPS = ["update", "delete"] as const;
+type ExperienceOp = (typeof EXPERIENCE_OPS)[number];
+
+interface ExperienceParams {
+	action?: ExperienceOp;
+	op?: ExperienceOp;
+	subaction?: ExperienceOp;
+	experienceId?: string;
+	id?: string;
+	query?: string;
+	confirm?: boolean;
+	learning?: string;
+	importance?: number | string;
+	confidence?: number | string;
+	tags?: string[] | string;
+	context?: string;
+	result?: string;
+	domain?: string;
+	type?: ExperienceType | string;
+	outcome?: OutcomeType | string;
+}
+
+function fail(text: string, error: string): ActionResult {
+	return { success: false, text, data: { error } };
+}
+
+function isActionResult(value: unknown): value is ActionResult {
+	return Boolean(
+		value && typeof value === "object" && "success" in value && "text" in value,
+	);
+}
+
+function getActionParams(
+	options: HandlerOptions | undefined,
+): Record<string, unknown> {
+	const direct =
+		options && typeof options === "object"
+			? (options as Record<string, unknown>)
+			: {};
+	const parameters =
+		direct.parameters && typeof direct.parameters === "object"
+			? (direct.parameters as Record<string, unknown>)
+			: {};
+	return { ...direct, ...parameters };
+}
+
+function normalizeExperienceOp(
+	params: ExperienceParams,
+): ExperienceOp | undefined {
+	const candidate = params.action ?? params.subaction ?? params.op;
+	return candidate && EXPERIENCE_OPS.includes(candidate)
+		? candidate
+		: undefined;
+}
+
+function readString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+	if (typeof value === "number" && Number.isFinite(value)) return value;
+	if (typeof value === "string" && value.trim()) {
+		const parsed = Number(value);
+		if (Number.isFinite(parsed)) return parsed;
+	}
+	return undefined;
+}
+
+function readScore(
+	value: unknown,
+	name: string,
+): number | ActionResult | undefined {
+	const parsed = readNumber(value);
+	if (parsed === undefined) return undefined;
+	if (parsed < 0 || parsed > 1) {
+		return fail(
+			`${name} must be a number from 0 to 1.`,
+			"EXPERIENCE_INVALID_SCORE",
+		);
+	}
+	return parsed;
+}
+
+function readTags(value: unknown): string[] | undefined {
+	if (Array.isArray(value)) {
+		return value
+			.filter((item): item is string => typeof item === "string")
+			.map((tag) => tag.trim())
+			.filter(Boolean);
+	}
+	if (typeof value === "string") {
+		return value
+			.split(",")
+			.map((tag) => tag.trim())
+			.filter(Boolean);
+	}
+	return undefined;
+}
+
+function isExperienceType(value: unknown): value is ExperienceType {
+	return Object.values(ExperienceType).includes(value as ExperienceType);
+}
+
+function isOutcomeType(value: unknown): value is OutcomeType {
+	return Object.values(OutcomeType).includes(value as OutcomeType);
+}
+
+function getExperienceService(
+	runtime: IAgentRuntime,
+): ExperienceService | null {
+	return runtime.getService("EXPERIENCE") as ExperienceService | null;
+}
+
+async function resolveExperienceTarget(
+	service: ExperienceService,
+	params: ExperienceParams,
+): Promise<Experience | ActionResult> {
+	const rawId = readString(params.experienceId) ?? readString(params.id);
+	if (rawId) {
+		const id = validateUuid(rawId);
+		if (!id) {
+			return fail(
+				`experienceId "${rawId}" is not a valid UUID. Use an id from EXPERIENCE search results or provide a query.`,
+				"EXPERIENCE_INVALID_ID",
+			);
+		}
+		const experience = await service.getExperience(id);
+		if (!experience) {
+			return fail(`Experience ${id} was not found.`, "EXPERIENCE_NOT_FOUND");
+		}
+		return experience;
+	}
+
+	const query = readString(params.query);
+	if (!query) {
+		return fail(
+			"experienceId or query is required.",
+			"EXPERIENCE_MISSING_TARGET",
+		);
+	}
+
+	const matches = await service.queryExperiences({
+		query,
+		limit: 5,
+		minConfidence: 0,
+		includeRelated: false,
+	});
+	if (matches.length === 0) {
+		return fail(`No experience matches "${query}".`, "EXPERIENCE_NOT_FOUND");
+	}
+	if (matches.length > 1) {
+		const candidates = matches
+			.map((experience) =>
+				`- ${experience.id}: ${experience.learning || experience.result || experience.context}`.slice(
+					0,
+					180,
+				),
+			)
+			.join("\n");
+		return {
+			success: false,
+			text: `Query "${query}" matches multiple experiences. Choose one by experienceId:\n${candidates}`,
+			data: { error: "EXPERIENCE_AMBIGUOUS_QUERY", query, candidates: matches },
+		};
+	}
+	return matches[0];
+}
+
+function buildExperienceUpdates(
+	params: ExperienceParams,
+): Partial<Experience> | ActionResult {
+	const updates: Partial<Experience> = {};
+
+	const learning = readString(params.learning);
+	if (learning !== undefined) updates.learning = learning;
+	const context = readString(params.context);
+	if (context !== undefined) updates.context = context;
+	const result = readString(params.result);
+	if (result !== undefined) updates.result = result;
+	const domain = readString(params.domain);
+	if (domain !== undefined) updates.domain = domain;
+
+	const tags = readTags(params.tags);
+	if (tags !== undefined) updates.tags = tags;
+
+	const importance = readScore(params.importance, "importance");
+	if (typeof importance === "object") return importance;
+	if (importance !== undefined) updates.importance = importance;
+
+	const confidence = readScore(params.confidence, "confidence");
+	if (typeof confidence === "object") return confidence;
+	if (confidence !== undefined) updates.confidence = confidence;
+
+	if (params.type !== undefined) {
+		if (!isExperienceType(params.type)) {
+			return fail(
+				`type must be one of ${Object.values(ExperienceType).join(", ")}.`,
+				"EXPERIENCE_INVALID_TYPE",
+			);
+		}
+		updates.type = params.type;
+	}
+
+	if (params.outcome !== undefined) {
+		if (!isOutcomeType(params.outcome)) {
+			return fail(
+				`outcome must be one of ${Object.values(OutcomeType).join(", ")}.`,
+				"EXPERIENCE_INVALID_OUTCOME",
+			);
+		}
+		updates.outcome = params.outcome;
+	}
+
+	if (Object.keys(updates).length === 0) {
+		return fail(
+			"At least one editable experience field is required.",
+			"EXPERIENCE_EMPTY_UPDATE",
+		);
+	}
+
+	return updates;
+}
+
+async function doUpdate(
+	service: ExperienceService,
+	params: ExperienceParams,
+): Promise<ActionResult> {
+	if (params.confirm !== true) {
+		return fail(
+			"Refusing to update: pass confirm:true to acknowledge overwriting an existing experience.",
+			"EXPERIENCE_CONFIRMATION_REQUIRED",
+		);
+	}
+
+	const target = await resolveExperienceTarget(service, params);
+	if (isActionResult(target)) return target;
+	const updates = buildExperienceUpdates(params);
+	if (isActionResult(updates)) return updates;
+
+	const updated = await service.updateExperience(target.id, updates);
+	if (!updated) {
+		return fail(
+			`Experience ${target.id} was not found.`,
+			"EXPERIENCE_NOT_FOUND",
+		);
+	}
+
+	return {
+		success: true,
+		text: `Updated experience ${updated.id}: ${updated.learning || updated.result || updated.context}`,
+		values: { experienceId: updated.id },
+		data: {
+			actionName: EXPERIENCE,
+			op: "update" as const,
+			experienceId: updated.id,
+			experience: updated,
+		},
+	};
+}
+
+async function doDelete(
+	service: ExperienceService,
+	params: ExperienceParams,
+): Promise<ActionResult> {
+	if (params.confirm !== true) {
+		return fail(
+			"Refusing to delete: pass confirm:true to acknowledge this destructive action.",
+			"EXPERIENCE_CONFIRMATION_REQUIRED",
+		);
+	}
+
+	const target = await resolveExperienceTarget(service, params);
+	if (isActionResult(target)) return target;
+
+	const deleted = await service.deleteExperience(target.id);
+	if (!deleted) {
+		return fail(
+			`Experience ${target.id} was not found.`,
+			"EXPERIENCE_NOT_FOUND",
+		);
+	}
+
+	return {
+		success: true,
+		text: `Deleted experience ${target.id}: ${target.learning || target.result || target.context}`,
+		values: { experienceId: target.id },
+		data: {
+			actionName: EXPERIENCE,
+			op: "delete" as const,
+			experienceId: target.id,
+			deletedExperience: target,
+		},
+	};
+}
+
+export const experienceAction: Action = {
+	name: EXPERIENCE,
+	contexts: ["memory", "settings", "agent_internal"],
+	roleGate: { minRole: "OWNER" },
+	similes: [
+		"UPDATE_EXPERIENCE",
+		"DELETE_EXPERIENCE",
+		"EDIT_EXPERIENCE",
+		"REMOVE_EXPERIENCE",
+		"FORGET_EXPERIENCE",
+	],
+	description:
+		"Update or delete an agent experience record. Use op=update to edit learning/importance/confidence/tags/context/result/domain/type/outcome, or op=delete to remove an experience. Mutations require confirm:true and can target either experienceId or a unique query.",
+	descriptionCompressed:
+		"edit/delete agent experiences; target by experienceId or unique query; update/delete require confirm:true",
+	routingHint:
+		"edit/delete the agent's own learned experience records shown in Character > Experience -> EXPERIENCE; search/read experiences -> SEARCH_EXPERIENCES; ordinary chat facts -> MEMORY",
+	validate: async (runtime, message, state, options) => {
+		if (!getExperienceService(runtime)) return false;
+		const params = getActionParams(options);
+		if (normalizeExperienceOp(params as ExperienceParams)) return true;
+		const text =
+			typeof message.content.text === "string"
+				? message.content.text.toLowerCase()
+				: "";
+		return (
+			(/\b(experience|experiences|learning|learnings)\b/.test(text) &&
+				/\b(delete|remove|forget|edit|update|change|revise)\b/.test(text)) ||
+			hasActionContext(message, state, {
+				contexts: ["memory", "settings", "agent_internal"],
+			})
+		);
+	},
+	async handler(
+		runtime: IAgentRuntime,
+		message: Memory,
+		state?: State,
+		options?: HandlerOptions,
+		callback?: HandlerCallback,
+	): Promise<ActionResult> {
+		void message;
+		void state;
+		void callback;
+		const service = getExperienceService(runtime);
+		if (!service) {
+			return fail(
+				"Experience service is unavailable.",
+				"EXPERIENCE_UNAVAILABLE",
+			);
+		}
+
+		const params = getActionParams(options) as ExperienceParams;
+		const op = normalizeExperienceOp(params);
+		if (!op) {
+			return fail(
+				`op/subaction is required and must be one of ${EXPERIENCE_OPS.join(", ")}.`,
+				"EXPERIENCE_INVALID_OP",
+			);
+		}
+
+		try {
+			switch (op) {
+				case "update":
+					return await doUpdate(service, params);
+				case "delete":
+					return await doDelete(service, params);
+			}
+		} catch (error) {
+			// error-policy:J1 action boundary translates internal mutation failures into model-visible action failure.
+			const messageText =
+				error instanceof Error ? error.message : String(error);
+			logger.warn(`[experience:${op}] failed: ${messageText}`);
+			return fail(
+				`Failed to ${op} experience: ${messageText}`,
+				`EXPERIENCE_${op.toUpperCase()}_FAILED`,
+			);
+		}
+	},
+	parameters: [
+		{
+			name: "op",
+			description: "Operation to perform. One of: update, delete.",
+			required: true,
+			schema: { type: "string" as const, enum: [...EXPERIENCE_OPS] },
+		},
+		{
+			name: "experienceId",
+			description:
+				"ID of the experience to mutate. Optional when query uniquely resolves one experience.",
+			required: false,
+			schema: { type: "string" as const },
+		},
+		{
+			name: "query",
+			description:
+				"Natural-language target used when experienceId is unknown; must resolve to exactly one experience.",
+			required: false,
+			schema: { type: "string" as const },
+		},
+		{
+			name: "confirm",
+			description:
+				"Must be true for update/delete to acknowledge the destructive mutation.",
+			required: true,
+			schema: { type: "boolean" as const },
+		},
+		{
+			name: "learning",
+			description: "update: replacement learning text.",
+			required: false,
+			schema: { type: "string" as const },
+		},
+		{
+			name: "importance",
+			description: "update: importance score from 0 to 1.",
+			required: false,
+			schema: { type: "number" as const, minimum: 0, maximum: 1 },
+		},
+		{
+			name: "confidence",
+			description: "update: confidence score from 0 to 1.",
+			required: false,
+			schema: { type: "number" as const, minimum: 0, maximum: 1 },
+		},
+		{
+			name: "tags",
+			description:
+				"update: replacement tags as an array or comma-separated text.",
+			required: false,
+			schema: { type: "array" as const, items: { type: "string" as const } },
+		},
+	],
+	examples: [
+		[
+			{
+				name: "{{user}}",
+				content: {
+					text: "Delete the experience about the stale onboarding tile.",
+					actions: [EXPERIENCE],
+				},
+			},
+			{
+				name: "{{agent}}",
+				content: {
+					text: "Deleted the matching experience.",
+				},
+			},
+		],
+	] as ActionExample[][],
+};

--- a/packages/core/src/features/advanced-capabilities/experience/index.ts
+++ b/packages/core/src/features/advanced-capabilities/experience/index.ts
@@ -2,6 +2,7 @@
  * Experience learning bundled with advanced capabilities.
  */
 
+export { experienceAction } from "./actions/experience.ts";
 export { searchExperiencesAction } from "./actions/search-experiences.ts";
 export { experiencePatternEvaluator } from "./evaluators/experience-items.ts";
 export { experienceProvider } from "./providers/experienceProvider.ts";
@@ -13,17 +14,19 @@ export * from "./types.ts";
 // Path-derived symbol so parents that `export *` two of these don't
 // collide on a shared `__BUNDLE_SAFETY__` name.
 import { anchorBundleSafety } from "../../../bundle-safety.ts";
+import { experienceAction as _bs_2_experienceAction } from "./actions/experience.ts";
 // Bundle-safety: force binding identities into the module's init
 // function so Bun.build's tree-shake doesn't collapse this barrel
 // into an empty `init_X = () => {}`. Without this the on-device
 // mobile agent explodes with `ReferenceError: <name> is not defined`
 // when a consumer dereferences a re-exported binding at runtime.
 import { searchExperiencesAction as _bs_1_searchExperiencesAction } from "./actions/search-experiences.ts";
-import { experiencePatternEvaluator as _bs_2_experiencePatternEvaluator } from "./evaluators/experience-items.ts";
-import { experienceProvider as _bs_3_experienceProvider } from "./providers/experienceProvider.ts";
+import { experiencePatternEvaluator as _bs_3_experiencePatternEvaluator } from "./evaluators/experience-items.ts";
+import { experienceProvider as _bs_4_experienceProvider } from "./providers/experienceProvider.ts";
 
 anchorBundleSafety("FEATURES_ADVANCED_CAPABILITIES_EXPERIENCE_INDEX", [
 	_bs_1_searchExperiencesAction,
-	_bs_2_experiencePatternEvaluator,
-	_bs_3_experienceProvider,
+	_bs_2_experienceAction,
+	_bs_3_experiencePatternEvaluator,
+	_bs_4_experienceProvider,
 ]);

--- a/packages/core/src/features/advanced-capabilities/index.ts
+++ b/packages/core/src/features/advanced-capabilities/index.ts
@@ -20,6 +20,7 @@ import { promoteSubactionsToActions } from "../../actions/promote-subactions.ts"
 import { createService } from "../../services.ts";
 import type { IAgentRuntime, RegisteredEvaluator } from "../../types/index.ts";
 import type { ServiceClass } from "../../types/plugin.ts";
+import { experienceAction } from "./experience/actions/experience.ts";
 // Direct leaf-file imports — see comment lower in this file for the
 // Bun.build mis-rewrite that requires bypassing barrels.
 import { searchExperiencesAction } from "./experience/actions/search-experiences.ts";
@@ -91,6 +92,7 @@ export const advancedActions = [
 	...promoteSubactionsToActions(withCanonicalActionDocs(roomOpAction)),
 	withCanonicalActionDocs(updateRoleAction),
 	withCanonicalActionDocs(searchExperiencesAction),
+	withCanonicalActionDocs(experienceAction),
 	...promoteSubactionsToActions(messageAction),
 	...promoteSubactionsToActions(postAction),
 	// Personality actions — keep CHARACTER (legacy) alongside the new

--- a/packages/test/scenarios/experience/experience.delete-by-query.scenario.ts
+++ b/packages/test/scenarios/experience/experience.delete-by-query.scenario.ts
@@ -1,0 +1,96 @@
+/** Live scenario for deleting an experience by natural language without a raw selector. */
+import {
+  type ExperienceService,
+  ExperienceServiceType,
+  ExperienceType,
+  type IAgentRuntime,
+  OutcomeType,
+  type UUID,
+} from "@elizaos/core";
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+let seededExperienceId: UUID | undefined;
+
+function getExperienceService(
+  runtime: IAgentRuntime,
+): ExperienceService | undefined {
+  return runtime.getService(ExperienceServiceType.EXPERIENCE) as
+    | ExperienceService
+    | undefined;
+}
+
+async function seedDeleteTarget(ctx: {
+  runtime?: unknown;
+}): Promise<string | undefined> {
+  const runtime = ctx.runtime as IAgentRuntime | undefined;
+  if (!runtime) return "scenario runtime unavailable";
+  const service = getExperienceService(runtime);
+  if (!service) return "EXPERIENCE service unavailable";
+
+  const experience = await service.recordExperience({
+    type: ExperienceType.LEARNING,
+    outcome: OutcomeType.NEUTRAL,
+    context: "The agent answered onboarding help with outdated launcher copy.",
+    action: "Suggested opening a stale Tutorial launcher tile.",
+    result: "The user corrected that tutorial guidance must be chat-native.",
+    learning:
+      "Do not tell users to open a Tutorial launcher tile; use chat-native tutorial cards instead.",
+    domain: "onboarding",
+    tags: ["onboarding", "tutorial", "chat-native"],
+    confidence: 0.92,
+    importance: 0.83,
+  });
+  seededExperienceId = experience.id;
+  return undefined;
+}
+
+export default scenario({
+  lane: "live-only",
+  id: "experience.delete-by-query",
+  title: "Experience action deletes a uniquely matched experience by topic",
+  domain: "experience",
+  tags: ["experience", "views-chat-integration", "mvp"],
+  isolation: "per-scenario",
+  rooms: [
+    {
+      id: "main",
+      source: "telegram",
+      title: "Experience Action",
+    },
+  ],
+  seed: [
+    {
+      type: "custom",
+      name: "seed-delete-target-experience",
+      apply: seedDeleteTarget,
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "delete-experience-by-topic",
+      text: "Delete the experience about stale Tutorial launcher tile guidance. Yes, confirm deleting that experience.",
+      expectedActions: ["EXPERIENCE"],
+      responseIncludesAny: ["Deleted experience", "deleted the experience"],
+    },
+  ],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "seeded-experience-was-deleted",
+      predicate: async (ctx) => {
+        const runtime = ctx.runtime as IAgentRuntime | undefined;
+        if (!runtime) return "scenario runtime unavailable";
+        const service = getExperienceService(runtime);
+        if (!service) return "EXPERIENCE service unavailable";
+        if (!seededExperienceId) return "seeded experience id missing";
+
+        const remaining = await service.getExperience(seededExperienceId);
+        if (remaining) {
+          return `expected seeded experience ${seededExperienceId} to be deleted`;
+        }
+        return undefined;
+      },
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
- Adds a semantic `EXPERIENCE` action for `op=update|delete`, owner-gated and `confirm:true` gated, backed by the existing `ExperienceService.updateExperience` / `deleteExperience` methods.
- Targets by `experienceId` or by a unique natural-language `query`; ambiguous query matches return candidates instead of guessing.
- Registers the action in `advancedActions` and the experience barrel/bundle-safety list so chat/voice can discover it when advanced capabilities are enabled.
- Adds deterministic action coverage for confirmation gating, delete-by-query without a raw selector, ambiguity refusal, and updating the same fields the Character Experience view saves.
- Adds live-only scenario `experience.delete-by-query` for the acceptance flow: seed an experience, ask to delete it by topic, assert `EXPERIENCE` fires, and verify the seeded record is gone.

Addresses #14623.

## Verification
- `bunx @biomejs/biome check packages/core/src/features/advanced-capabilities/index.ts packages/core/src/features/advanced-capabilities/experience/index.ts packages/core/src/features/advanced-capabilities/experience/actions/experience.ts packages/core/src/features/advanced-capabilities/experience/actions/experience.test.ts packages/test/scenarios/experience/experience.delete-by-query.scenario.ts` — passed.
- `bun run --cwd packages/core test -- src/features/advanced-capabilities/experience/actions/experience.test.ts` — 1 file / 4 tests passed.
- `bun run --cwd packages/core typecheck` — passed.
- `bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/cli.ts list ../../packages/test/scenarios --scenario experience.delete-by-query` from `packages/scenario-runner` — listed `experience.delete-by-query`; Bun printed its known internal `directory mismatch` warning after output.
- `git diff --check` — passed.
- `bun run audit:error-policy-ratchet --report` — no new fallback-slop in touched production files.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - action/scenario-only change; no rendered UI surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - action/scenario-only change; no rendered UI surface changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no interactive UI flow changed; this PR adds the semantic action twin beneath the existing Character Experience view controls`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no long-running backend process was started; focused action test, typecheck, scenario list, and ratchet command output are listed in Verification`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend request/response or state change changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - live provider credentials are unavailable in this environment; draft remains blocked on running experience.delete-by-query with a live model and reviewing the trajectory`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - deterministic fake-service tests verify the mutation payloads locally; the live-only scenario will produce the real seeded/deleted experience artifact once run with provider keys`.

## Evidence Notes
- Live trajectory is not attached yet. The scenario is present and load-verified, but this environment has no live provider key configured.
- The issue mentions `packages/scripts/view-action-ratchet.registry.json`, but that file is not present on current `origin/develop` (`64efa64fdf`). I did not fabricate a registry entry; #14369 appears to own landing that ratchet/baseline. Once the ratchet exists, `updateExperience` / `deleteExperience` should map to the new `EXPERIENCE` action.
- App visual audit is N/A because no `packages/app` renderer/UI files changed.
