### PR TITLE
feat(notifications): add triage tiers and coalescing

### DIFF
--- a/packages/agent/src/api/notification-routes.test.ts
+++ b/packages/agent/src/api/notification-routes.test.ts
@@ -77,7 +77,7 @@ describe("handleNotificationRoute", () => {
   });
 
   it("GET returns the inbox and unread count", async () => {
-    await service.notify({ title: "Hello", category: "system" });
+    await service.notify({ title: "Hello", category: "task" });
     const helpers = makeHelpers();
     await handleNotificationRoute(
       req("/api/notifications"),

--- a/packages/agent/src/services/approval/service.test.ts
+++ b/packages/agent/src/services/approval/service.test.ts
@@ -15,6 +15,7 @@
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
+import { ServiceType } from "@elizaos/core";
 import { createMockRuntime } from "@elizaos/core/testing";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -153,7 +154,22 @@ function parseSet(setSql: string): Record<string, string | null> {
   return out;
 }
 
-function createApprovalTableRuntime(agentId: string): IAgentRuntime {
+interface NotifierSpy {
+  notify: ReturnType<typeof vi.fn>;
+  markReadByGroupKey: ReturnType<typeof vi.fn>;
+}
+
+function createNotifierSpy(): NotifierSpy {
+  return {
+    notify: vi.fn(async () => ({})),
+    markReadByGroupKey: vi.fn(async () => 1),
+  };
+}
+
+function createApprovalTableRuntime(
+  agentId: string,
+  notifier: NotifierSpy | null = null,
+): IAgentRuntime {
   const rows = new Map<string, Record<string, unknown>>();
 
   const execute = (
@@ -227,7 +243,10 @@ function createApprovalTableRuntime(agentId: string): IAgentRuntime {
           execute(chunks.__sql ?? ""),
       },
     },
-    getService: () => null,
+    // The store resolves the NotificationService via ServiceType.NOTIFICATION;
+    // return the spy when one is supplied so enqueue/resolve wiring is testable.
+    getService: (type: string) =>
+      notifier && type === ServiceType.NOTIFICATION ? notifier : null,
   } as unknown as IAgentRuntime;
 }
 
@@ -297,6 +316,69 @@ describe("ApprovalService", () => {
     expect(pendingList.every((r) => r.id !== enqueued.id)).toBe(true);
   });
 
+  it("enqueue surfaces an approval notification under the approval:<id> groupKey", async () => {
+    const notifier = createNotifierSpy();
+    const runtime = createApprovalTableRuntime("agent-notif", notifier);
+    const queue = (await ApprovalService.start(runtime)).getQueue();
+
+    const enqueued = await queue.enqueue(messageInput());
+    expect(notifier.notify).toHaveBeenCalledTimes(1);
+    const arg = notifier.notify.mock.calls[0][0];
+    expect(arg.category).toBe("approval");
+    expect(arg.priority).toBe("high"); // interrupt tier (§C.1)
+    expect(arg.groupKey).toBe(`approval:${enqueued.id}`);
+  });
+
+  it("approving an approval auto-reads its notification by groupKey (§C.5)", async () => {
+    const notifier = createNotifierSpy();
+    const runtime = createApprovalTableRuntime("agent-autoread", notifier);
+    const queue = (await ApprovalService.start(runtime)).getQueue();
+
+    const enqueued = await queue.enqueue(messageInput());
+    expect(notifier.markReadByGroupKey).not.toHaveBeenCalled();
+
+    await queue.approve(enqueued.id, {
+      resolvedBy: "owner-123",
+      resolutionReason: "ok",
+    });
+    // The done thing must not keep nagging: the pointing notification is read.
+    expect(notifier.markReadByGroupKey).toHaveBeenCalledWith(
+      `approval:${enqueued.id}`,
+    );
+  });
+
+  it("rejecting an approval also auto-reads its notification (§C.5)", async () => {
+    const notifier = createNotifierSpy();
+    const runtime = createApprovalTableRuntime("agent-reject-read", notifier);
+    const queue = (await ApprovalService.start(runtime)).getQueue();
+
+    const enqueued = await queue.enqueue(messageInput());
+    await queue.reject(enqueued.id, {
+      resolvedBy: "owner-123",
+      resolutionReason: "no",
+    });
+    expect(notifier.markReadByGroupKey).toHaveBeenCalledWith(
+      `approval:${enqueued.id}`,
+    );
+  });
+
+  it("resolve does not throw when the notifier predates markReadByGroupKey", async () => {
+    // An older NotificationService exposes notify but not markReadByGroupKey.
+    const legacy = { notify: vi.fn(async () => ({})) };
+    const runtime = createApprovalTableRuntime(
+      "agent-legacy",
+      legacy as unknown as NotifierSpy,
+    );
+    const queue = (await ApprovalService.start(runtime)).getQueue();
+    const enqueued = await queue.enqueue(messageInput());
+    // Must resolve cleanly even though markReadByGroupKey is absent.
+    const approved = await queue.approve(enqueued.id, {
+      resolvedBy: "owner-123",
+      resolutionReason: "ok",
+    });
+    expect(approved.state).toBe("approved");
+  });
+
   it("enqueue → reject records the resolver", async () => {
     const runtime = createApprovalTableRuntime("agent-1");
     const queue = (await ApprovalService.start(runtime)).getQueue();
@@ -312,7 +394,8 @@ describe("ApprovalService", () => {
   });
 
   it("purgeExpired moves past-due pending rows to expired", async () => {
-    const runtime = createApprovalTableRuntime("agent-1");
+    const notifier = createNotifierSpy();
+    const runtime = createApprovalTableRuntime("agent-1", notifier);
     const queue = (await ApprovalService.start(runtime)).getQueue();
     const enqueued = await queue.enqueue(
       messageInput({
@@ -324,12 +407,16 @@ describe("ApprovalService", () => {
     expect(purgedIds).toContain(enqueued.id);
     const after = await queue.byId(enqueued.id);
     expect(after?.state).toBe("expired");
+    expect(notifier.markReadByGroupKey).toHaveBeenCalledWith(
+      `approval:${enqueued.id}`,
+    );
   });
 
   it("a lapsed pending request is refused and expired at the transition boundary (#11092)", async () => {
     // No purge runs: the lazy guard alone must keep an expired approval from
     // ever executing — nothing calls purgeExpired periodically in production.
-    const runtime = createApprovalTableRuntime("agent-1");
+    const notifier = createNotifierSpy();
+    const runtime = createApprovalTableRuntime("agent-1", notifier);
     const queue = (await ApprovalService.start(runtime)).getQueue();
     const enqueued = await queue.enqueue(
       messageInput({
@@ -349,6 +436,9 @@ describe("ApprovalService", () => {
     const after = await queue.byId(enqueued.id);
     expect(after?.state).toBe("expired");
     expect(after?.resolvedBy).toBeNull();
+    expect(notifier.markReadByGroupKey).toHaveBeenCalledWith(
+      `approval:${enqueued.id}`,
+    );
   });
 
   it("a fresh pending request still approves normally under the expiry guard (#11092)", async () => {

--- a/packages/agent/src/services/approval/store.ts
+++ b/packages/agent/src/services/approval/store.ts
@@ -557,6 +557,12 @@ interface NotificationEmitter {
     groupKey?: string;
     data?: Record<string, unknown>;
   }) => Promise<unknown>;
+  /**
+   * §C.5 acted-upon auto-read: mark the notification(s) for a groupKey read
+   * without removing them. Optional — an older NotificationService may not
+   * expose it, so callers guard on its presence.
+   */
+  markReadByGroupKey?: (groupKey: string) => Promise<number>;
 }
 
 function getNotifier(runtime: IAgentRuntime): NotificationEmitter | null {
@@ -564,6 +570,31 @@ function getNotifier(runtime: IAgentRuntime): NotificationEmitter | null {
     ServiceType.NOTIFICATION,
   ) as NotificationEmitter | null;
   return svc && typeof svc.notify === "function" ? svc : null;
+}
+
+/** The inbox groupKey an approval's notification is filed under. */
+function approvalGroupKey(id: string): string {
+  return `approval:${id}`;
+}
+
+/**
+ * §C.5 acted-upon auto-read: once an approval is resolved (approved/rejected/
+ * expired), the "Approval needed" notification that pointed at it is a done
+ * thing — mark it read so the inbox stops nagging. Fire-and-forget: a notifier
+ * that predates this method, or a failed write, must never fail the resolve.
+ */
+function markApprovalNotificationRead(
+  runtime: IAgentRuntime,
+  id: string,
+): void {
+  const notifier = getNotifier(runtime);
+  if (!notifier?.markReadByGroupKey) return;
+  void notifier.markReadByGroupKey(approvalGroupKey(id)).catch((error) => {
+    logger.warn(
+      { error, id },
+      "[ApprovalQueue] failed to auto-read resolved approval notification",
+    );
+  });
 }
 
 export class PgApprovalQueue implements ApprovalQueue {
@@ -621,7 +652,7 @@ export class PgApprovalQueue implements ApprovalQueue {
         priority: "high",
         source: "lifeops",
         deepLink: "/chat",
-        groupKey: `approval:${id}`,
+        groupKey: approvalGroupKey(id),
         data: { requestId: id, kind: input.action },
       })
       .catch(() => {});
@@ -691,6 +722,9 @@ export class PgApprovalQueue implements ApprovalQueue {
     const ids = rows.map((row) => toText(row.id));
     if (ids.length > 0) {
       logger.info(`[ApprovalQueue] purged ${ids.length} expired requests`);
+      for (const id of ids) {
+        markApprovalNotificationRead(this.runtime, id);
+      }
     }
     return ids;
   }
@@ -752,6 +786,9 @@ export class PgApprovalQueue implements ApprovalQueue {
     logger.info(
       `[ApprovalQueue] ${current.state} -> ${target} (${id}) by ${resolution.resolvedBy}`,
     );
+    // §C.5: the approval is now resolved — the owner acted, so auto-read the
+    // "Approval needed" notification (fire-and-forget; never blocks resolve).
+    markApprovalNotificationRead(this.runtime, id);
     return rowToRequest(rows[0]);
   }
 
@@ -776,6 +813,11 @@ export class PgApprovalQueue implements ApprovalQueue {
       return this.throwLostRace(id, target);
     }
     logger.info(`[ApprovalQueue] ${current.state} -> ${target} (${id})`);
+    if (target === "expired") {
+      // Terminal expiry also resolves the thing the notification pointed at;
+      // auto-read so a dead approval cannot keep nagging (§C.5).
+      markApprovalNotificationRead(this.runtime, id);
+    }
     return rowToRequest(rows[0]);
   }
 

--- a/packages/core/src/services/notification.test.ts
+++ b/packages/core/src/services/notification.test.ts
@@ -166,7 +166,8 @@ describe("NotificationService", () => {
 		const list = restarted.list();
 		expect(list).toHaveLength(1);
 		expect(list[0].title).toBe("Persisted");
-		expect(restarted.getUnreadCount()).toBe(1);
+		// system defaults to low/silent (§C.1): inbox history, no badge weight.
+		expect(restarted.getUnreadCount()).toBe(0);
 	});
 
 	it("excludes a notification whose explicit expiresAt has passed", async () => {
@@ -230,5 +231,195 @@ describe("NotificationService", () => {
 	it("uses vi spies without leaking timers", () => {
 		// Guard: the suite must not depend on fake timers.
 		expect(vi.isFakeTimers()).toBe(false);
+	});
+
+	// ── §C.1 Triage tiers: category → priority producer defaults ────────────
+
+	it("defaults an approval notification to the interrupt tier (high)", async () => {
+		const n = await service.notify({
+			title: "Approve send",
+			category: "approval",
+		});
+		expect(n.priority).toBe("high");
+	});
+
+	it("defaults task/workflow notifications to the digest tier (normal)", async () => {
+		const task = await service.notify({ title: "Task done", category: "task" });
+		const wf = await service.notify({
+			title: "Run done",
+			category: "workflow",
+		});
+		expect(task.priority).toBe("normal");
+		expect(wf.priority).toBe("normal");
+	});
+
+	it("defaults a routine system notification to the silent tier (low)", async () => {
+		const n = await service.notify({
+			title: "Backup done",
+			category: "system",
+		});
+		expect(n.priority).toBe("low");
+	});
+
+	it("does not include silent-tier notifications in unread badge counts", async () => {
+		await service.notify({ title: "Routine", priority: "low" });
+		expect(service.list({ unreadOnly: true })).toHaveLength(1); // inbox history
+		expect(service.getUnreadCount()).toBe(0); // no badge weight (§C.1)
+		await service.notify({ title: "Digest", priority: "normal" });
+		expect(service.getUnreadCount()).toBe(1);
+	});
+
+	it("lets a producer override the category default priority", async () => {
+		// A system notification the producer deems urgent (e.g. disk full) keeps its
+		// explicit priority; the category default only applies when none is given.
+		const n = await service.notify({
+			title: "Disk full",
+			category: "system",
+			priority: "urgent",
+		});
+		expect(n.priority).toBe("urgent");
+	});
+
+	// ── §C.1 Silent-tier default expiry ─────────────────────────────────────
+
+	it("defaults a low-priority notification to a 24h expiry", async () => {
+		const before = Date.now();
+		const n = await service.notify({ title: "Routine", priority: "low" });
+		const after = Date.now();
+		expect(n.expiresAt).toBeGreaterThanOrEqual(before + 24 * 60 * 60 * 1000);
+		expect(n.expiresAt).toBeLessThanOrEqual(after + 24 * 60 * 60 * 1000);
+	});
+
+	it("defaults expiry for a category that maps to the silent tier", async () => {
+		// system → low → silent, so a bare system notification self-expires too.
+		const n = await service.notify({
+			title: "Log rotated",
+			category: "system",
+		});
+		expect(n.priority).toBe("low");
+		expect(n.expiresAt).toBeGreaterThan(Date.now());
+	});
+
+	it("never overrides a producer-set expiresAt on a low notification", async () => {
+		const explicit = Date.now() + 5 * 60 * 1000;
+		const n = await service.notify({
+			title: "Quick note",
+			priority: "low",
+			expiresAt: explicit,
+		});
+		expect(n.expiresAt).toBe(explicit);
+	});
+
+	it("honors explicit null expiresAt on a low notification", async () => {
+		const n = await service.notify({
+			title: "Pinned silent note",
+			priority: "low",
+			expiresAt: null,
+		});
+		expect(n.expiresAt).toBeNull();
+	});
+
+	it("does NOT default an expiry for interrupt/digest tiers", async () => {
+		const high = await service.notify({ title: "Approve", priority: "high" });
+		const urgent = await service.notify({
+			title: "Blocked",
+			priority: "urgent",
+		});
+		const normal = await service.notify({ title: "Done", priority: "normal" });
+		expect(high.expiresAt).toBeUndefined();
+		expect(urgent.expiresAt).toBeUndefined();
+		expect(normal.expiresAt).toBeUndefined();
+	});
+
+	// ── §C.3 Count-aware groupKey supersede ─────────────────────────────────
+
+	it("carries data.count across same-groupKey supersede", async () => {
+		await service.notify({ title: "1 new file", groupKey: "files" });
+		await service.notify({ title: "another file", groupKey: "files" });
+		await service.notify({ title: "3 new files", groupKey: "files" });
+		const list = service.list();
+		expect(list).toHaveLength(1);
+		expect(list[0].title).toBe("3 new files");
+		expect(list[0].data?.count).toBe(3);
+	});
+
+	it("leaves count absent for a first, un-superseded notification", async () => {
+		const n = await service.notify({ title: "solo", groupKey: "once" });
+		expect(n.data?.count).toBeUndefined();
+	});
+
+	it("honors a producer-set data.count instead of auto-incrementing", async () => {
+		await service.notify({ title: "a", groupKey: "g" });
+		const n = await service.notify({
+			title: "b",
+			groupKey: "g",
+			data: { count: 12 },
+		});
+		expect(n.data?.count).toBe(12);
+		expect(service.list()[0].data?.count).toBe(12);
+	});
+
+	it("does not add a count to notifications without a groupKey", async () => {
+		await service.notify({ title: "x" });
+		const n = await service.notify({ title: "y" });
+		expect(n.data?.count).toBeUndefined();
+		expect(service.list()).toHaveLength(2);
+	});
+
+	it("resets the count for a reused groupKey after the record expired away", async () => {
+		// A prior record that has already expired should not seed the count of a
+		// fresh notification reusing the same key.
+		await service.notify({
+			title: "old",
+			groupKey: "reuse",
+			expiresAt: Date.now() - 1000,
+		});
+		const n = await service.notify({ title: "new", groupKey: "reuse" });
+		expect(n.data?.count).toBeUndefined();
+		expect(service.list()).toHaveLength(1);
+		expect(service.list()[0].title).toBe("new");
+	});
+
+	// ── §C.5 Acted-upon auto-read (markReadByGroupKey) ──────────────────────
+
+	it("marks the notification for a groupKey read when its action completes", async () => {
+		await service.notify({
+			title: "Approval needed",
+			category: "approval",
+			groupKey: "approval:42",
+		});
+		expect(service.getUnreadCount()).toBe(1);
+		const changed = await service.markReadByGroupKey("approval:42");
+		expect(changed).toBe(1);
+		expect(service.getUnreadCount()).toBe(0);
+		expect(service.list()).toHaveLength(1); // read, not removed (§C.5)
+		expect(service.list()[0].readAt).toBeTruthy();
+	});
+
+	it("broadcasts non-interruptive updates when marking a groupKey read", async () => {
+		await service.notify({ title: "Approval", groupKey: "approval:7" });
+		ctx.emitted.length = 0;
+		await service.markReadByGroupKey("approval:7");
+		expect(ctx.emitted).toHaveLength(1);
+		expect(ctx.emitted[0].data.type).toBe("notification_update");
+		expect(ctx.emitted[0].data.unreadCount).toBe(0);
+		const notification = ctx.emitted[0].data.notification as AgentNotification;
+		expect(notification.readAt).toBeTruthy();
+	});
+
+	it("markReadByGroupKey returns 0 for an unknown or already-read group", async () => {
+		expect(await service.markReadByGroupKey("nope")).toBe(0);
+		await service.notify({ title: "done", groupKey: "g1" });
+		await service.markReadByGroupKey("g1");
+		// Second call: already read, nothing changes.
+		expect(await service.markReadByGroupKey("g1")).toBe(0);
+	});
+
+	it("markReadByGroupKey does not reorder the inbox (§C.2)", async () => {
+		await service.notify({ title: "A", groupKey: "ga" });
+		await service.notify({ title: "B", groupKey: "gb" });
+		await service.notify({ title: "C", groupKey: "gc" });
+		await service.markReadByGroupKey("ga"); // read the oldest
+		expect(service.list().map((n) => n.title)).toEqual(["C", "B", "A"]);
 	});
 });

--- a/packages/core/src/services/notification.ts
+++ b/packages/core/src/services/notification.ts
@@ -21,12 +21,16 @@ import { logger } from "../logger.ts";
 import {
 	type AgentNotification,
 	DEFAULT_NOTIFICATION_CATEGORY,
-	DEFAULT_NOTIFICATION_PRIORITY,
 	DEFAULT_NOTIFICATION_SOURCE,
+	defaultPriorityForCategory,
+	NOTIFICATION_COUNT_KEY,
 	NOTIFICATION_STREAM,
 	type NotificationEventData,
 	type NotificationInput,
+	type NotificationPriority,
 	type NotificationQuery,
+	SILENT_TIER_DEFAULT_EXPIRY_MS,
+	tierForPriority,
 } from "../types/notification.ts";
 import { asUUID, type UUID } from "../types/primitives.ts";
 import type { IAgentRuntime } from "../types/runtime.ts";
@@ -128,33 +132,60 @@ export class NotificationService extends Service {
 			throw new Error("[NotificationService] notification.title is required");
 		}
 
+		const category = input.category ?? DEFAULT_NOTIFICATION_CATEGORY;
+		// §C.1: an explicit priority always wins; otherwise the category names the
+		// tier (approval→interrupt, task/workflow→digest, system→silent).
+		const priority: NotificationPriority =
+			input.priority ?? defaultPriorityForCategory(category);
+
+		const createdAt = Date.now();
+		const groupKey = input.groupKey;
+
+		// Drop any entries whose explicit expiry has passed before we inspect the
+		// group for supersede/count — an expired prior must not seed a new count.
+		this.notifications = this.notifications.filter(
+			(n) => !isExpired(n, createdAt),
+		);
+
+		// §C.3 Count-aware supersede: a same-groupKey notify replaces the prior
+		// record and carries the coalesced count so the row can render "3 new
+		// files" instead of the last event silently eating the earlier ones. The
+		// producer may set data.count explicitly to override the auto-increment.
+		let superseded: AgentNotification | undefined;
+		if (groupKey) {
+			superseded = this.notifications.find((n) => n.groupKey === groupKey);
+			this.notifications = this.notifications.filter(
+				(n) => n.groupKey !== groupKey,
+			);
+		}
+		const data = this.resolveCoalescedData(input.data, superseded);
+
+		// §C.1 Silent-tier default expiry: a `low` (silent) notification with no
+		// producer-set expiry ages out after 24h so the inbox self-cleans.
+		// Interrupt/digest tiers never default an expiry (an unread approval must
+		// not evaporate).
+		let expiresAt = input.expiresAt;
+		if (expiresAt === undefined && tierForPriority(priority) === "silent") {
+			expiresAt = createdAt + SILENT_TIER_DEFAULT_EXPIRY_MS;
+		}
+
 		const notification: AgentNotification = {
 			id: newNotificationId(),
 			title,
 			body: input.body?.trim() || undefined,
-			category: input.category ?? DEFAULT_NOTIFICATION_CATEGORY,
-			priority: input.priority ?? DEFAULT_NOTIFICATION_PRIORITY,
+			category,
+			priority,
 			source: input.source ?? DEFAULT_NOTIFICATION_SOURCE,
 			deepLink: input.deepLink,
 			icon: input.icon,
-			groupKey: input.groupKey,
-			data: input.data,
-			createdAt: Date.now(),
+			groupKey,
+			data,
+			createdAt,
 			readAt: null,
-			expiresAt: input.expiresAt ?? undefined,
+			expiresAt,
 			agentId: input.agentId ?? (this.runtime.agentId as UUID),
 		};
 
-		// Collapse by groupKey: a newer notification supersedes an older one for
-		// the same logical thing instead of stacking duplicates.
-		if (notification.groupKey) {
-			this.notifications = this.notifications.filter(
-				(n) => n.groupKey !== notification.groupKey,
-			);
-		}
-		// Drop any entries whose explicit expiry has passed before appending.
-		const nowMs = Date.now();
-		this.notifications = this.notifications.filter((n) => !isExpired(n, nowMs));
 		this.notifications.push(notification);
 		if (this.notifications.length > MAX_NOTIFICATIONS) {
 			this.notifications = this.notifications.slice(-MAX_NOTIFICATIONS);
@@ -176,13 +207,16 @@ export class NotificationService extends Service {
 		return notification;
 	}
 
-	private broadcast(notification: AgentNotification): void {
+	private broadcast(
+		notification: AgentNotification,
+		type: NotificationEventData["type"] = "notification",
+	): void {
 		const bus = this.runtime.getService(ServiceType.AGENT_EVENT);
 		if (!isEventBus(bus)) {
 			return; // No live bus (headless/test) — inbox API still serves it.
 		}
 		const data: NotificationEventData = {
-			type: "notification",
+			type,
 			notification,
 			unreadCount: this.getUnreadCount(),
 		};
@@ -216,9 +250,34 @@ export class NotificationService extends Service {
 		const now = Date.now();
 		let count = 0;
 		for (const n of this.notifications) {
-			if (!n.readAt && !isExpired(n, now)) count++;
+			// §C.1 Silent tier (`low`) is inbox-only with no badge weight.
+			if (!n.readAt && n.priority !== "low" && !isExpired(n, now)) count++;
 		}
 		return count;
+	}
+
+	/**
+	 * Compute the `data` for a notification that may be coalescing onto a prior
+	 * same-`groupKey` record (§C.3). A producer-set `data.count` always wins; a
+	 * bare supersede increments the surviving count (prior `count`, defaulting to
+	 * 1, plus one). A first (un-superseded) notification carries no count key.
+	 */
+	private resolveCoalescedData(
+		inputData: AgentNotification["data"],
+		superseded: AgentNotification | undefined,
+	): AgentNotification["data"] {
+		const producerCount = inputData?.[NOTIFICATION_COUNT_KEY];
+		// Producer stated the count explicitly — honor it verbatim.
+		if (typeof producerCount === "number") {
+			return inputData;
+		}
+		// No supersede — nothing to coalesce; leave data untouched (no count key).
+		if (!superseded) {
+			return inputData;
+		}
+		const priorCount = superseded.data?.[NOTIFICATION_COUNT_KEY];
+		const nextCount = (typeof priorCount === "number" ? priorCount : 1) + 1;
+		return { ...(inputData ?? {}), [NOTIFICATION_COUNT_KEY]: nextCount };
 	}
 
 	/** Mark one notification read. Returns true if it existed and changed. */
@@ -230,6 +289,37 @@ export class NotificationService extends Service {
 		notification.readAt = Date.now();
 		await this.persist();
 		return true;
+	}
+
+	/**
+	 * §C.5 Acted-upon auto-read: mark every unread notification pointing at a
+	 * given `groupKey` read, without removing it (read is history, not deletion).
+	 * A producer whose action completed — an approval approved, a task opened —
+	 * calls this so the inbox never nags about a done thing. Returns the number of
+	 * records changed (0 for an unknown/already-read group). Never reorders the
+	 * inbox (§C.2): read state styles rows but does not move them.
+	 */
+	async markReadByGroupKey(groupKey: string): Promise<number> {
+		if (!groupKey) {
+			return 0;
+		}
+		const now = Date.now();
+		const changedNotifications: AgentNotification[] = [];
+		for (const n of this.notifications) {
+			if (n.groupKey === groupKey && !n.readAt) {
+				n.readAt = now;
+				changedNotifications.push(n);
+			}
+		}
+		if (changedNotifications.length > 0) {
+			await this.persist();
+			for (const n of changedNotifications) {
+				// Push a non-interruptive update so open clients clear unread state without
+				// re-toasting/re-alerting the notification that just became read.
+				this.broadcast(n, "notification_update");
+			}
+		}
+		return changedNotifications.length;
 	}
 
 	/** Mark every notification read. Returns the number changed. */

--- a/packages/core/src/types/notification.test.ts
+++ b/packages/core/src/types/notification.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Type-seam coverage for the notification triage model (spec §C.1): the
+ * priority→tier mapping and the category→priority producer defaults. These are
+ * pure functions with no runtime dependency, so they live next to the types.
+ */
+import { describe, expect, it } from "vitest";
+import {
+	defaultPriorityForCategory,
+	type NotificationCategory,
+	type NotificationPriority,
+	type NotificationTier,
+	SILENT_TIER_DEFAULT_EXPIRY_MS,
+	tierForPriority,
+} from "./notification.ts";
+
+describe("notification triage model (§C.1)", () => {
+	describe("tierForPriority", () => {
+		it("maps urgent/high to the interrupt tier", () => {
+			expect(tierForPriority("urgent")).toBe<NotificationTier>("interrupt");
+			expect(tierForPriority("high")).toBe<NotificationTier>("interrupt");
+		});
+
+		it("maps normal to the digest tier", () => {
+			expect(tierForPriority("normal")).toBe<NotificationTier>("digest");
+		});
+
+		it("maps low to the silent tier", () => {
+			expect(tierForPriority("low")).toBe<NotificationTier>("silent");
+		});
+
+		it("covers every priority", () => {
+			const priorities: NotificationPriority[] = [
+				"low",
+				"normal",
+				"high",
+				"urgent",
+			];
+			const tiers = new Set<NotificationTier>([
+				"interrupt",
+				"digest",
+				"silent",
+			]);
+			for (const p of priorities) {
+				expect(tiers.has(tierForPriority(p))).toBe(true);
+			}
+		});
+	});
+
+	describe("defaultPriorityForCategory", () => {
+		it("defaults approval to an interrupt-tier priority", () => {
+			expect(tierForPriority(defaultPriorityForCategory("approval"))).toBe(
+				"interrupt",
+			);
+		});
+
+		it("defaults task/workflow to the digest tier", () => {
+			expect(tierForPriority(defaultPriorityForCategory("task"))).toBe(
+				"digest",
+			);
+			expect(tierForPriority(defaultPriorityForCategory("workflow"))).toBe(
+				"digest",
+			);
+		});
+
+		it("defaults routine system to the silent tier", () => {
+			expect(tierForPriority(defaultPriorityForCategory("system"))).toBe(
+				"silent",
+			);
+		});
+
+		it("returns a valid priority for every category", () => {
+			const categories: NotificationCategory[] = [
+				"reminder",
+				"task",
+				"workflow",
+				"agent",
+				"approval",
+				"message",
+				"health",
+				"system",
+				"general",
+			];
+			const valid = new Set<NotificationPriority>([
+				"low",
+				"normal",
+				"high",
+				"urgent",
+			]);
+			for (const c of categories) {
+				expect(valid.has(defaultPriorityForCategory(c))).toBe(true);
+			}
+		});
+	});
+
+	it("exposes a 24h silent-tier default expiry window", () => {
+		expect(SILENT_TIER_DEFAULT_EXPIRY_MS).toBe(24 * 60 * 60 * 1000);
+	});
+});

--- a/packages/core/src/types/notification.ts
+++ b/packages/core/src/types/notification.ts
@@ -23,6 +23,22 @@ import type { JsonValue, UUID } from "./primitives.ts";
 export type NotificationPriority = "low" | "normal" | "high" | "urgent";
 
 /**
+ * Triage tier (spec §C.1). A derived, human-facing name for the delivery
+ * behavior a `NotificationPriority` binds to. Producers still pass a priority;
+ * the tier is what the priority *means*:
+ *
+ * | Tier        | Priority        | Behavior                                             |
+ * |-------------|-----------------|------------------------------------------------------|
+ * | `interrupt` | `urgent`,`high` | OS notification (even focused for `urgent`), toast, inbox, badge |
+ * | `digest`    | `normal`        | inbox + unread badge, no OS interrupt while focused  |
+ * | `silent`    | `low`           | inbox only, no badge weight, auto-expires            |
+ *
+ * The tier is never stored on the record — it is a pure function of priority so
+ * the two can never drift. Use {@link tierForPriority} to name it.
+ */
+export type NotificationTier = "interrupt" | "digest" | "silent";
+
+/**
  * What produced the notification. Lets clients group, filter, and icon
  * notifications without parsing free text.
  */
@@ -67,7 +83,16 @@ export interface AgentNotification {
 	 * same task). Omit for independent notifications.
 	 */
 	groupKey?: string;
-	/** Structured metadata for renderers / deep-link handlers. */
+	/**
+	 * Structured metadata for renderers / deep-link handlers.
+	 *
+	 * Reserved key `count` (see {@link NOTIFICATION_COUNT_KEY}): when a producer
+	 * emits N notifications sharing a `groupKey` in a window, the surviving
+	 * (superseding) record carries `data.count = N` so the row can render "3 new
+	 * files" instead of the last event silently eating the earlier ones (§C.3).
+	 * The service increments this automatically on same-`groupKey` supersede
+	 * unless the producer set `data.count` explicitly.
+	 */
 	data?: Record<string, JsonValue>;
 	/** Unix ms when created. */
 	createdAt: number;
@@ -114,7 +139,7 @@ export interface NotificationQuery {
 
 /** The shape the notification stream carries over the agent event bus. */
 export interface NotificationEventData {
-	type: "notification";
+	type: "notification" | "notification_update";
 	notification: AgentNotification;
 	/** Total unread after this notification, so clients can update a badge. */
 	unreadCount: number;
@@ -131,3 +156,63 @@ export const DEFAULT_NOTIFICATION_SOURCE = "agent";
 
 /** The agent event stream notifications ride on. */
 export const NOTIFICATION_STREAM = "notification" as const;
+
+/**
+ * Reserved `data` key carrying the coalesced count of same-`groupKey`
+ * notifications (§C.3). `data.count > 1` means the row should render a count
+ * chip ("3 new files"). Absent or `1` means a single event.
+ */
+export const NOTIFICATION_COUNT_KEY = "count" as const;
+
+/**
+ * Default self-destroy window for silent-tier (`low`) notifications (§C.1): 24h.
+ * A `low` notification with no producer-set `expiresAt` ages out so the inbox
+ * self-cleans. Interrupt-tier notifications never default an expiry.
+ */
+export const SILENT_TIER_DEFAULT_EXPIRY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Name the triage tier (§C.1) a priority binds to. Pure function of priority so
+ * the tier can never drift from the stored record.
+ */
+export function tierForPriority(
+	priority: NotificationPriority,
+): NotificationTier {
+	switch (priority) {
+		case "urgent":
+		case "high":
+			return "interrupt";
+		case "normal":
+			return "digest";
+		case "low":
+			return "silent";
+	}
+}
+
+/**
+ * Category → default priority (§C.1 producer rule). A producer that omits an
+ * explicit priority gets the tier the category implies:
+ *
+ * - `approval` → `high` (interrupt — the user must act)
+ * - `task` / `workflow` → `normal` (digest — completions worth surfacing)
+ * - `system` → `low` (silent — routine confirmations, self-expiring)
+ * - everything else → {@link DEFAULT_NOTIFICATION_PRIORITY} (`normal`/digest)
+ *
+ * A producer can always downgrade by passing an explicit priority; these are
+ * only the defaults applied when none is given.
+ */
+export function defaultPriorityForCategory(
+	category: NotificationCategory,
+): NotificationPriority {
+	switch (category) {
+		case "approval":
+			return "high";
+		case "task":
+		case "workflow":
+			return "normal";
+		case "system":
+			return "low";
+		default:
+			return DEFAULT_NOTIFICATION_PRIORITY;
+	}
+}

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -236,4 +236,24 @@ describe("NotificationsHomeCenter", () => {
     expect(card.className).toContain("backdrop-blur");
     expect(card.className).not.toContain("border-border");
   });
+
+  it("renders a count chip when data.count > 1 (§C.3 coalescing)", () => {
+    __ingestNotificationForTests(
+      makeNotification({ title: "3 new files", data: { count: 3 } }),
+    );
+    render(<NotificationsHomeCenter />);
+    const chip = screen.getByTestId("notification-count-chip");
+    // The visible glyph is the count; a visually-hidden suffix names it for AT.
+    expect(chip.textContent).toContain("3");
+    expect(chip.querySelector(".sr-only")?.textContent).toContain("grouped");
+  });
+
+  it("omits the count chip for a single (count ≤ 1 or absent) notification", () => {
+    __ingestNotificationForTests(
+      makeNotification({ title: "one", data: { count: 1 } }),
+    );
+    __ingestNotificationForTests(makeNotification({ title: "plain" }));
+    render(<NotificationsHomeCenter />);
+    expect(screen.queryByTestId("notification-count-chip")).toBeNull();
+  });
 });

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -142,7 +142,7 @@ export function orderDashboardNotifications(
  * the row's render path, a stable-props memo is correct - it re-renders only
  * when the row's actual content changes, and `arePropsEqual` compares the
  * identity fields that drive its markup: `id`, `readAt` (unread styling),
- * `priority` (rail), `title`, `body`, plus the two callbacks (stable via the
+ * `priority` (rail), `title`, `body`, `data.count`, plus the two callbacks (stable via the
  * parent's `useCallback`). `createdAt` is intentionally NOT compared: it feeds
  * only the leaf, which subscribes to the tick itself.
  */
@@ -159,6 +159,7 @@ export function rowPropsEqual(
     a.title === b.title &&
     a.body === b.body &&
     a.deepLink === b.deepLink &&
+    a.data?.count === b.data?.count &&
     prev.onOpen === next.onOpen &&
     prev.onDismiss === next.onDismiss
   );
@@ -194,6 +195,11 @@ const NotificationRow = memo(function NotificationRow({
   const unread = !notification.readAt;
   const urgent = notification.priority === "urgent";
   const high = notification.priority === "high";
+  // §C.3 count-aware coalescing: a superseding same-groupKey notification carries
+  // data.count so the row reads "3 new files" via a small chip instead of the
+  // inbox silently keeping only the last of the batch. Only surfaced for N > 1.
+  const rawCount = notification.data?.count;
+  const count = typeof rawCount === "number" && rawCount > 1 ? rawCount : null;
   // Lock-screen restraint: NO per-row icon chip (a box inside a box inside the
   // card). Priority is carried by a hairline accent rail on the leading edge -
   // present only for urgent/high - and an unread state by a single dot, so a
@@ -250,6 +256,20 @@ const NotificationRow = memo(function NotificationRow({
             >
               {notification.title}
             </span>
+            {count ? (
+              <span
+                data-testid="notification-count-chip"
+                className={cn(
+                  "shrink-0 rounded-full px-1.5 text-2xs font-semibold tabular-nums leading-[1.15rem]",
+                  unread
+                    ? "bg-white/18 text-white"
+                    : "bg-white/10 text-white/70",
+                )}
+              >
+                {count}
+                <span className="sr-only"> grouped notifications</span>
+              </span>
+            ) : null}
             <RelativeTime
               ts={notification.createdAt}
               className="ml-auto shrink-0 pl-2 text-2xs tabular-nums text-white/60"

--- a/packages/ui/src/state/notifications/notification-store.test.ts
+++ b/packages/ui/src/state/notifications/notification-store.test.ts
@@ -102,6 +102,15 @@ describe("notification-store", () => {
     expect(showNativeNotification).not.toHaveBeenCalled(); // focused + normal → no OS
   });
 
+  it("keeps silent-tier notifications in the inbox without badge weight", () => {
+    __ingestNotificationForTests(
+      makeNotification({ title: "Silent", priority: "low" }),
+    );
+    const state = __getStateForTests();
+    expect(state.notifications).toHaveLength(1);
+    expect(state.unreadCount).toBe(0);
+  });
+
   it("fires desktop + native sinks when the window is unfocused", () => {
     vi.spyOn(document, "hasFocus").mockReturnValue(false);
     __ingestNotificationForTests(makeNotification({ priority: "normal" }), 1);
@@ -122,6 +131,20 @@ describe("notification-store", () => {
     __ingestNotificationForTests(makeNotification({ priority: "low" }), 1);
     expect(invokeDesktopBridgeRequest).not.toHaveBeenCalled();
     expect(showNativeNotification).not.toHaveBeenCalled();
+  });
+
+  it("keeps silent-tier notifications out of OS sinks even while unfocused", () => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
+    __ingestNotificationForTests(makeNotification({ priority: "low" }));
+    expect(invokeDesktopBridgeRequest).not.toHaveBeenCalled();
+    expect(showNativeNotification).not.toHaveBeenCalled();
+  });
+
+  it("keeps silent-tier notifications out of the toast sink", () => {
+    const sink = vi.fn();
+    registerNotificationToastSink(sink);
+    __ingestNotificationForTests(makeNotification({ priority: "low" }));
+    expect(sink).not.toHaveBeenCalled();
   });
 
   it("routes a toast through the registered sink", () => {
@@ -230,6 +253,137 @@ describe("notification-store", () => {
     expect(stored?.category).toBe("general");
     expect(stored?.priority).toBe("normal");
     expect(typeof stored?.createdAt).toBe("number");
+  });
+
+  it("WS handler applies notification_update without re-delivering sinks", () => {
+    initNotifications();
+    const handler = onWsEvent.mock.calls[0][1] as (
+      d: Record<string, unknown>,
+    ) => void;
+    const sink = vi.fn();
+    registerNotificationToastSink(sink);
+    handler({
+      stream: "notification",
+      payload: {
+        type: "notification_update",
+        notification: makeNotification({
+          id: "update-1",
+          title: "Approval needed",
+          priority: "high",
+          readAt: 123,
+        }),
+        unreadCount: 0,
+      },
+    });
+    const stored = __getStateForTests().notifications.find(
+      (n) => n.id === "update-1",
+    );
+    expect(stored?.readAt).toBe(123);
+    expect(__getStateForTests().unreadCount).toBe(0);
+    expect(sink).not.toHaveBeenCalled();
+    expect(showNativeNotification).not.toHaveBeenCalled();
+  });
+
+  it("WS handler applies notification_update without reordering existing rows", () => {
+    initNotifications();
+    const handler = onWsEvent.mock.calls[0][1] as (
+      d: Record<string, unknown>,
+    ) => void;
+    __ingestNotificationForTests(makeNotification({ id: "old", title: "Old" }));
+    __ingestNotificationForTests(makeNotification({ id: "new", title: "New" }));
+    expect(__getStateForTests().notifications.map((n) => n.id)).toEqual([
+      "new",
+      "old",
+    ]);
+
+    handler({
+      stream: "notification",
+      payload: {
+        type: "notification_update",
+        notification: makeNotification({
+          id: "old",
+          title: "Old",
+          readAt: 123,
+        }),
+      },
+    });
+    expect(__getStateForTests().notifications.map((n) => n.id)).toEqual([
+      "new",
+      "old",
+    ]);
+    expect(
+      __getStateForTests().notifications.find((n) => n.id === "old")?.readAt,
+    ).toBe(123);
+  });
+
+  it("WS handler carries data.count through for the coalesced count chip (§C.3)", () => {
+    initNotifications();
+    const handler = onWsEvent.mock.calls[0][1] as (
+      d: Record<string, unknown>,
+    ) => void;
+    handler({
+      stream: "notification",
+      payload: {
+        notification: {
+          id: "count-1",
+          title: "3 new files",
+          groupKey: "files",
+          data: { count: 3 },
+        },
+      },
+    });
+    const stored = __getStateForTests().notifications.find(
+      (n) => n.id === "count-1",
+    );
+    expect(stored?.data?.count).toBe(3);
+  });
+
+  it("WS handler drops a non-object data field rather than passing garbage", () => {
+    initNotifications();
+    const handler = onWsEvent.mock.calls[0][1] as (
+      d: Record<string, unknown>,
+    ) => void;
+    handler({
+      stream: "notification",
+      payload: {
+        notification: { id: "bad-data", title: "x", data: "nope" },
+      },
+    });
+    const stored = __getStateForTests().notifications.find(
+      (n) => n.id === "bad-data",
+    );
+    expect(stored).toBeTruthy();
+    expect(stored?.data).toBeUndefined();
+  });
+
+  it("WS handler collapses same-groupKey, surviving the newer count (§C.3)", () => {
+    initNotifications();
+    const handler = onWsEvent.mock.calls[0][1] as (
+      d: Record<string, unknown>,
+    ) => void;
+    handler({
+      stream: "notification",
+      payload: {
+        notification: { id: "c1", title: "1 file", groupKey: "g" },
+      },
+    });
+    handler({
+      stream: "notification",
+      payload: {
+        notification: {
+          id: "c2",
+          title: "2 files",
+          groupKey: "g",
+          data: { count: 2 },
+        },
+      },
+    });
+    const list = __getStateForTests().notifications.filter(
+      (n) => n.groupKey === "g",
+    );
+    expect(list).toHaveLength(1);
+    expect(list[0].id).toBe("c2");
+    expect(list[0].data?.count).toBe(2);
   });
 
   it("markNotificationRead calls the API optimistically", async () => {

--- a/packages/ui/src/state/notifications/notification-store.ts
+++ b/packages/ui/src/state/notifications/notification-store.ts
@@ -64,17 +64,36 @@ function setState(next: Partial<NotificationState>): void {
 
 function countUnread(list: AgentNotification[]): number {
   let count = 0;
-  for (const n of list) if (!n.readAt) count++;
+  for (const n of list) {
+    // §C.1 Silent tier (`low`) lands in the inbox but carries no badge weight.
+    if (!n.readAt && n.priority !== "low") count++;
+  }
   return count;
 }
 
 /** Insert/replace a notification (collapsing by groupKey), newest-first. */
-function upsert(notification: AgentNotification): AgentNotification[] {
-  const withoutDuplicate = state.notifications.filter(
-    (n) =>
-      n.id !== notification.id &&
-      !(notification.groupKey && n.groupKey === notification.groupKey),
-  );
+function upsert(
+  notification: AgentNotification,
+  options: { preserveOrder?: boolean } = {},
+): AgentNotification[] {
+  const matches = (n: AgentNotification): boolean =>
+    n.id === notification.id ||
+    !!(notification.groupKey && n.groupKey === notification.groupKey);
+
+  // Read-state / metadata updates must not move the row under the user's finger
+  // (§C.2). Replace in place when the row already exists; only insert if this
+  // client missed the original notification.
+  if (options.preserveOrder) {
+    let replaced = false;
+    const next = state.notifications.map((n) => {
+      if (!matches(n)) return n;
+      replaced = true;
+      return notification;
+    });
+    return (replaced ? next : [notification, ...next]).slice(0, 300);
+  }
+
+  const withoutDuplicate = state.notifications.filter((n) => !matches(n));
   return [notification, ...withoutDuplicate].slice(0, 300);
 }
 
@@ -111,6 +130,9 @@ async function fireDesktopNotification(
  * separately; this only decides whether to also raise an OS/toast alert.
  */
 function deliver(notification: AgentNotification): void {
+  // §C.1 Silent tier is inbox-only: no OS/native interrupt, no toast, no badge.
+  if (notification.priority === "low") return;
+
   const focused = isWindowFocused();
   const interruptive =
     notification.priority === "high" || notification.priority === "urgent";
@@ -148,8 +170,14 @@ function deliver(notification: AgentNotification): void {
   }
 }
 
-function ingest(notification: AgentNotification, unreadCount?: number): void {
-  const notifications = upsert(notification);
+function ingest(
+  notification: AgentNotification,
+  unreadCount?: number,
+  options: { deliver?: boolean } = {},
+): void {
+  const notifications = upsert(notification, {
+    preserveOrder: options.deliver === false,
+  });
   setState({
     notifications,
     unreadCount:
@@ -157,7 +185,9 @@ function ingest(notification: AgentNotification, unreadCount?: number): void {
         ? unreadCount
         : countUnread(notifications),
   });
-  deliver(notification);
+  if (options.deliver !== false) {
+    deliver(notification);
+  }
 }
 
 interface WsAgentEvent {
@@ -187,6 +217,19 @@ function optionalTimestamp(value: unknown): number | null | undefined {
   if (value === null) return null;
   return typeof value === "number" && Number.isFinite(value)
     ? value
+    : undefined;
+}
+
+/**
+ * Pass through the producer `data` bag only when it is a plain object (the wire
+ * is untrusted). Carries reserved keys like `count` (§C.3) to the row; a scalar
+ * or array `data` is malformed and dropped rather than rendered as garbage.
+ */
+function optionalDataObject(
+  value: unknown,
+): AgentNotification["data"] | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as AgentNotification["data"])
     : undefined;
 }
 
@@ -226,6 +269,7 @@ function validateWsNotification(value: unknown): AgentNotification | null {
     deepLink: optionalString(raw.deepLink),
     icon: optionalString(raw.icon),
     groupKey: optionalString(raw.groupKey),
+    data: optionalDataObject(raw.data),
     readAt: optionalTimestamp(raw.readAt),
     expiresAt: optionalTimestamp(raw.expiresAt),
   };
@@ -236,13 +280,18 @@ function handleWsAgentEvent(data: Record<string, unknown>): void {
   if (event.stream !== "notification") return;
   const payload =
     event.payload && typeof event.payload === "object"
-      ? (event.payload as { notification?: unknown; unreadCount?: unknown })
+      ? (event.payload as {
+          notification?: unknown;
+          unreadCount?: unknown;
+          type?: unknown;
+        })
       : undefined;
   const notification = validateWsNotification(payload?.notification);
   if (!notification) return;
   const unreadCount =
     typeof payload?.unreadCount === "number" ? payload.unreadCount : undefined;
-  ingest(notification, unreadCount);
+  const deliverUpdate = payload?.type !== "notification_update";
+  ingest(notification, unreadCount, { deliver: deliverUpdate });
 }
 
 async function hydrate(): Promise<void> {


### PR DESCRIPTION
## Summary

Implements notification spec §C.1/C.3/C.5 and migration map item 6 for #14562.

- Adds the explicit triage tier model helpers (`interrupt` / `digest` / `silent`) and category→priority defaults:
  - `approval` → `high` / interrupt
  - `task` and `workflow` → `normal` / digest
  - routine `system` → `low` / silent
- Adds count-aware same-`groupKey` supersede in `NotificationService.notify`, carrying/incrementing `data.count` unless producer set it explicitly.
- Adds silent-tier default expiry: `low` notifications default `expiresAt` to +24h only when omitted, while explicit `expiresAt` values including `null` are preserved.
- Enforces silent semantics in client state: no badge weight, no OS/native sinks, no toast.
- Adds acted-upon auto-read via `NotificationService.markReadByGroupKey`, including live `notification_update` fan-out that updates open clients without re-alerting or reordering rows.
- Wires approval queue notifications under `approval:<id>` and auto-reads them on approve/reject/expiry/purge expiry.
- Adds minimal `data.count > 1` count chip in `NotificationRow`, without touching #14559 render internals.

## Verification

```text
packages/core:
✓ src/services/notification.test.ts (36 tests)
✓ src/types/notification.test.ts (9 tests)
Test Files 2 passed (2)
Tests 45 passed (45)
```

```text
packages/ui:
✓ src/state/notifications/notification-store.test.ts (25 tests)
✓ src/components/shell/NotificationsHomeCenter.test.tsx (16 tests)
Test Files 2 passed (2)
Tests 41 passed (41)
```

```text
packages/agent notification/approval suites:
✓ src/services/approval/service.test.ts (16 tests)
✓ src/api/notification-routes.test.ts (13 tests)
✓ src/api/notification-lazy-route.test.ts (4 tests)
✓ src/runtime/onboarding-notifications.test.ts (3 tests)
✓ src/services/push/notification-push-service.test.ts (8 tests)
Test Files 5 passed (5)
Tests 44 passed (44)
```

```text
biome:
Checked 11 files in 67ms. No fixes applied.
```

```text
packages/app build:
EXIT=0
✓ built in 1m
[plugin renderer-build-manifest] [renderer-build-manifest] wrote eliza-renderer-build.json buildId=089d3eef700c (787 assets)
```

## Review

- Codex review was run repeatedly. It produced two rounds of P2 findings, which were fixed:
  - silent badge/sink semantics
  - observed auto-read failures
  - expired approval auto-read
  - explicit null `expiresAt`
  - live non-reordering auto-read updates
- Final codex review exceeded the 105s guard and was killed per protocol; I performed self-review afterward, found a notification update ordering issue, fixed it, and re-ran the focused suites/build above.

[sol-orch]
