### PR TITLE
fix(core): thread v5 action callbacks into planned tools (#14658)

### DIFF
--- a/packages/core/src/services/__tests__/message-v5-executor-context.test.ts
+++ b/packages/core/src/services/__tests__/message-v5-executor-context.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Regression coverage for the v5 planner action-execution context. Interactive
+ * actions emit widgets through the action callback, so every v5 planned-tool
+ * path must preserve the message-service callback when it invokes handlers.
+ */
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import { executePlannedToolCall } from "../../runtime/execute-planned-tool-call";
+import type {
+	Action,
+	ActionResult,
+	AgentContext,
+	HandlerCallback,
+	IAgentRuntime,
+	Memory,
+} from "../../types";
+import { __buildV5ExecutorContextForTests } from "../message";
+
+describe("v5 planner executor context", () => {
+	it("preserves the visible action callback and previous planner results", async () => {
+		const callback: HandlerCallback = vi.fn(async () => []);
+		const previousResults: ActionResult[] = [
+			{ success: true, text: "selected app candidate" },
+		];
+		const message = {
+			id: "message",
+			roomId: "room",
+			entityId: "user",
+			content: { text: "create a notes app" },
+		} as unknown as Memory;
+
+		const ctx = __buildV5ExecutorContextForTests({
+			message,
+			state: { values: {}, data: {}, text: "" },
+			selectedContexts: ["apps" as AgentContext],
+			senderRole: "USER",
+			previousResults,
+			callback,
+		});
+
+		expect(ctx.message).toBe(message);
+		expect(ctx.activeContexts).toEqual(["apps"]);
+		expect(ctx.userRoles).toEqual(["USER"]);
+		expect(ctx.previousResults).toBe(previousResults);
+
+		await ctx.callback?.(
+			{ text: "[CHOICE:app-create id=abc]\nnew=New app\n[/CHOICE]" },
+			"APP",
+		);
+
+		expect(callback).toHaveBeenCalledWith(
+			{ text: "[CHOICE:app-create id=abc]\nnew=New app\n[/CHOICE]" },
+			"APP",
+		);
+	});
+
+	it("lets planned-tool handlers emit visible widget callbacks", async () => {
+		const callback: HandlerCallback = vi.fn(async () => []);
+		const widgetText = "[CHOICE:app-create id=abc]\nnew=New app\n[/CHOICE]";
+		const action: Action = {
+			name: "APP",
+			description: "Application manager",
+			validate: async () => true,
+			handler: async (_runtime, _message, _state, _options, actionCallback) => {
+				await actionCallback?.({ text: widgetText });
+				return { success: true, text: "choice emitted" };
+			},
+		};
+		const runtime = {
+			actions: [action],
+			logger: {
+				debug: vi.fn(),
+				warn: vi.fn(),
+				error: vi.fn(),
+			},
+		} as unknown as IAgentRuntime;
+		const message = {
+			id: "message",
+			roomId: "room",
+			entityId: "user",
+			content: { text: "create a notes app" },
+		} as unknown as Memory;
+
+		const result = await executePlannedToolCall(
+			runtime,
+			__buildV5ExecutorContextForTests({
+				message,
+				state: { values: {}, data: {}, text: "" },
+				selectedContexts: ["apps" as AgentContext],
+				senderRole: "USER",
+				previousResults: [],
+				callback,
+			}),
+			{ name: "APP", params: {} },
+			{ actions: [action] },
+		);
+
+		expect(result.success).toBe(true);
+		expect(callback).toHaveBeenCalledWith({ text: widgetText }, "APP");
+	});
+
+	it("keeps both v5 executeV5PlannedToolCall call sites on the shared context builder", () => {
+		const source = readFileSync(
+			new URL("../message.ts", import.meta.url),
+			"utf8",
+		);
+		expect(source.match(/executorCtx:\s*buildV5ExecutorContext/g)).toHaveLength(
+			2,
+		);
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -4965,6 +4965,34 @@ interface ExecuteV5PlannedToolCallParams {
 	plannerLoopConfig?: PlannerLoopParams["config"];
 }
 
+interface BuildV5ExecutorContextParams {
+	message: Memory;
+	state: State;
+	selectedContexts: AgentContext[];
+	senderRole: RoleGateRole;
+	previousResults: readonly ActionResult[];
+	callback?: HandlerCallback;
+}
+
+function buildV5ExecutorContext(
+	args: BuildV5ExecutorContextParams,
+): ExecutePlannedToolCallContext {
+	return {
+		message: args.message,
+		state: args.state,
+		activeContexts: args.selectedContexts,
+		userRoles: [args.senderRole],
+		previousResults: args.previousResults,
+		...(args.callback ? { callback: args.callback } : {}),
+	};
+}
+
+export function __buildV5ExecutorContextForTests(
+	args: BuildV5ExecutorContextParams,
+): ExecutePlannedToolCallContext {
+	return buildV5ExecutorContext(args);
+}
+
 function plannerErrorLooksTransient(error: unknown): boolean {
 	const message =
 		error instanceof Error
@@ -5050,6 +5078,7 @@ async function runDeterministicPlannerFallback(args: {
 	recorder?: TrajectoryRecorder;
 	trajectoryId?: string;
 	plannerLoopConfig?: PlannerLoopParams["config"];
+	callback?: HandlerCallback;
 	plannerError: unknown;
 }): Promise<PlannerLoopResult | null> {
 	if (!plannerErrorLooksTransient(args.plannerError)) {
@@ -5118,13 +5147,14 @@ async function runDeterministicPlannerFallback(args: {
 		runtime: args.runtime,
 		toolCall,
 		plannerContext: trajectory.context,
-		executorCtx: {
+		executorCtx: buildV5ExecutorContext({
 			message: args.message,
 			state: args.plannerState,
-			activeContexts: args.selectedContexts,
-			userRoles: [args.senderRole],
+			selectedContexts: args.selectedContexts,
+			senderRole: args.senderRole,
 			previousResults: [],
-		},
+			...(args.callback ? { callback: args.callback } : {}),
+		}),
 		plannerRuntime: args.plannerRuntime,
 		executorOptions: { actions: args.actions },
 		evaluatorEffects: args.evaluatorEffects,
@@ -5743,6 +5773,7 @@ export async function runV5MessageRuntimeStage1(args: {
 	message: Memory;
 	state: State;
 	responseId: UUID;
+	callback?: HandlerCallback;
 	plannerLoopConfig?: PlannerLoopParams["config"];
 	onResponseHandlerEarlyReply?: (
 		event: ResponseHandlerEarlyReplyEvent,
@@ -6710,13 +6741,14 @@ export async function runV5MessageRuntimeStage1(args: {
 						runtime: args.runtime,
 						toolCall,
 						plannerContext: plannerContextAfterEarlyReply,
-						executorCtx: {
+						executorCtx: buildV5ExecutorContext({
 							message: args.message,
 							state: plannerState,
-							activeContexts: selectedContexts,
-							userRoles: [senderRole],
+							selectedContexts,
+							senderRole,
 							previousResults: collectPreviousActionResults(ctx.trajectory),
-						},
+							...(args.callback ? { callback: args.callback } : {}),
+						}),
 						plannerRuntime,
 						executorOptions: { actions: exposedPlannerActions },
 						evaluatorEffects,
@@ -6748,6 +6780,7 @@ export async function runV5MessageRuntimeStage1(args: {
 				recorder,
 				trajectoryId,
 				plannerLoopConfig: args.plannerLoopConfig,
+				...(args.callback ? { callback: args.callback } : {}),
 				plannerError: error,
 			});
 			if (!fallbackResult) {
@@ -9322,6 +9355,7 @@ export class DefaultMessageService implements IMessageService {
 						message,
 						state,
 						responseId,
+						...(callback ? { callback } : {}),
 						onResponseHandlerEarlyReply: deliverResponseHandlerEarlyReply,
 					}),
 					runtime.applyPipelineHooks(


### PR DESCRIPTION
Part of #14658.

## Summary

The v5 planner already had a low-level `executePlannedToolCall` callback slot, but the message-service v5 execution paths never populated it. Interactive actions such as APP therefore emitted `[CHOICE]` widget text into `undefined`, and the user only saw the planner/evaluator prose.

This PR threads the message-service callback into both v5 planned-tool paths:

- normal planner-loop tool execution
- deterministic planner fallback execution

The callback passed from `processMessage` is already the instrumented/wrapped callback, so action callback text still goes through the existing single-turn voice rewrite and action attribution behavior.

## Implementation

- Added a single `buildV5ExecutorContext` helper in `packages/core/src/services/message.ts` that builds v5 `ExecutePlannedToolCallContext` with message, state, selected contexts, sender role, previous results, and callback.
- Switched both `executeV5PlannedToolCall` call sites to use the helper.
- Added `message-v5-executor-context.test.ts`, which proves the v5 context preserves callback/previous results and that a real planned-tool handler can emit a `[CHOICE]` callback through that context.
- Added a source-level ratchet in the test so both v5 call sites stay on the shared context builder.

## Required Evidence Rows

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: N/A - core message-service behavior only; no UI pixels changed.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: N/A - core message-service behavior only; no UI pixels changed.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: N/A - no interactive UI surface changed in this PR.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: N/A - no long-running backend service was started; deterministic unit tests exercise the action callback path directly.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - provider credentials/session for rerunning #14656 live choice trajectory are unavailable on this host.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - no persistent domain artifact is produced by the local deterministic tests.

## Verification

<!-- evidence-row:tests -->
- Tests: `bun run --cwd packages/core test -- message-v5-executor-context` passed: 1 file, 3 tests.
<!-- evidence-row:tests -->
- Tests: `bun run --cwd packages/core test -- execute-planned-tool-call`: 1 file, 31 tests.
<!-- evidence-row:typecheck -->
- Typecheck: `bun run --cwd packages/core typecheck` passed after final rebase.
<!-- evidence-row:static-analysis -->
- Static analysis: `bunx @biomejs/biome check packages/core/src/services/message.ts packages/core/src/services/__tests__/message-v5-executor-context.test.ts --no-errors-on-unmatched` passed after final rebase.
<!-- evidence-row:diff-hygiene -->
- Diff hygiene: `git diff --check origin/develop...HEAD` passed after final rebase.
<!-- evidence-row:error-policy -->
- Error policy: `bun run audit:error-policy-ratchet` passed after final rebase: no new fallback slop in touched files.
<!-- evidence-row:build -->
- Build prerequisite: `bun install --frozen-lockfile --ignore-scripts`, `bun run --cwd packages/shared build:i18n`, and `bun run --cwd packages/logger build` passed in the isolated worktree before tests.

## Remaining #14658 Evidence

#14658 should remain open until the live-only `live-chat-widgets-choice-roundtrip` scenario from #14656 is rerun with provider credentials and the trajectory proves that the APP callback-emitted `[CHOICE]` reaches the user and the follow-up `cancel` resolves through APP rather than fabricated REPLY.
