### PR TITLE
test(ui): resolve cloud routing source in vitest

### DIFF
--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -15,6 +15,7 @@ const importConversationsSrc = resolve(
   monorepoRoot,
   "packages/import-conversations/src",
 );
+const cloudRoutingSrc = resolve(monorepoRoot, "packages/cloud/routing/src");
 const cloudSharedSrc = resolve(monorepoRoot, "packages/cloud/shared/src");
 const loggerSrc = resolve(monorepoRoot, "packages/logger/src");
 const tuiSrc = resolve(monorepoRoot, "packages/tui/src");
@@ -88,6 +89,14 @@ export default defineConfig({
       {
         find: /^@elizaos\/shared\/(.+)$/,
         replacement: resolve(sharedSrc, "$1"),
+      },
+      {
+        find: /^@elizaos\/cloud-routing$/,
+        replacement: resolve(cloudRoutingSrc, "index.ts"),
+      },
+      {
+        find: /^@elizaos\/cloud-routing\/(.+)$/,
+        replacement: resolve(cloudRoutingSrc, "$1"),
       },
       {
         find: /^@elizaos\/cloud-shared$/,


### PR DESCRIPTION
## Summary
- Adds a UI Vitest source alias for `@elizaos/cloud-routing`, matching the existing aliases for other workspace packages whose `dist/` output is not present in clean test worktrees.
- This lets `ContinuousChatOverlay` tests import `@elizaos/core` source without failing on the cloud-routing package entry.

## Verification
- `bun install --ignore-scripts --frozen-lockfile`
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/ui test -- src/components/shell/ContinuousChatOverlay.firstrun.test.tsx` -> 1 file, 14 tests passed
- `bunx biome check packages/ui/vitest.config.ts packages/ui/src/components/shell/ContinuousChatOverlay.firstrun.test.tsx`
- `git diff --check`

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] N/A - test infrastructure only; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test infrastructure only; no rendered UI changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - test infrastructure only; no user workflow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime path changed; focused UI test log is listed in Verification.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path changed; focused UI test log is listed in Verification.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no separate domain artifact; domain proof is the focused Vitest run listed in Verification.
