### PR TITLE
refactor(ui): tighten home resident set

### DIFF
--- a/packages/ui/src/components/chat/widgets/WIDGET_MATRIX.md
+++ b/packages/ui/src/components/chat/widgets/WIDGET_MATRIX.md
@@ -4,6 +4,11 @@ The canonical map of every widget the chat surface can render: its producing
 action/marker (or data source), the surfaces it renders on, the interaction
 handlers it drives, and its wired/verified status.
 
+For home residents, the binding north-star is
+`docs/design/NOTIFICATIONS-WIDGETS-SYSTEM.md` §B / §E: ambient base + pinned
+notifications + at most five ranked cards. This matrix records the current code
+shape, but the spec owns home-resident eligibility.
+
 There are **two widget layers** and **two chat surfaces**. A widget belongs to
 exactly one layer; the layer determines how it is produced and which surfaces
 render it.
@@ -39,7 +44,7 @@ Both also render the non-registry segment kinds (`[CONFIG]`, permission / OAuth
 directly, and the overlay renders the same ones through `InlineWidgetText`
 (plus `SensitiveRequestBlock` for the secret card, mounted by the overlay body
 itself). Parity is intentional so a flow triggered on mobile is completable on
-mobile — see **Documented divergences** for the few remaining ChatView-only
+mobile - see **Documented divergences** for the few remaining ChatView-only
 affordances.
 
 ---
@@ -112,7 +117,7 @@ the shell as they are touched (#14327 tracks the matrix refresh).
 Notifications are NOT a slot widget: the dashboard notification center
 (`components/shell/NotificationsHomeCenter.tsx`, reading the notification
 store <- WS `agent_event` `stream:"notification"`) is pinned by HomeScreen
-directly below the time/weather base — a registry entry would double-render
+directly below the time/weather base - a registry entry would double-render
 the inbox.
 
 | Widget id | Slot | Data source / updates | Component | Host mount | Status |
@@ -122,26 +127,30 @@ the inbox.
 | `agent-orchestrator.accounts` | chat-sidebar | poll `listAccounts()`/`getOrchestratorAccounts()`/`getOrchestratorRooms()` 15s | `agent-orchestrator-accounts-view.tsx` | TasksEventsPanel | wired |
 | `browser.status` | chat-sidebar | browser-workspace status | `browser-status.tsx` | TasksEventsPanel | wired |
 | `music-player.stream` | chat-sidebar | music-player state | `music-player.tsx` | TasksEventsPanel | wired |
-| `todo.items` | home | todo store | `todo.tsx` | ViewCatalog | wired |
+| `todo.items` | home | todo store + goals store (one at-risk goal row) | `todo.tsx` | ViewCatalog | wired |
 | `calendar.upcoming` | home | calendar store | `calendar-upcoming.tsx` | ViewCatalog | wired |
-| `goals.attention` | home | goals store | `goals-attention.tsx` | ViewCatalog | wired |
-| `health.sleep` | home | health store | `health-sleep.tsx` | ViewCatalog | wired |
 | `music-library.playlists` | character | music-library state | n/a | CharacterHubView | wired |
+
+Demoted / merged per `docs/design/NOTIFICATIONS-WIDGETS-SYSTEM.md` §E items
+3-5: `wallet.balance` and `health.sleep` no longer declare `slot:"home"`
+(their routed surfaces stay), and `goals.attention` no longer stands alone on
+home because its at-risk row is rendered inside `todo.items`.
 
 ### Slots & host mounts
 
 | Slot | Host mounted? | Widgets registered? | Verdict |
 |---|---|---|---|
-| `home` | yes, HomeScreen | yes, many | active |
+| `home` | yes, HomeScreen | yes, curated ≤5 residents | active |
 | `chat-sidebar` | yes, TasksEventsPanel | yes, 5 | active |
 | `character` | yes, CharacterHubView | yes, 1 | active |
 | `nav-page` | no WidgetHost mount | no component widgets | active app-navigation contract |
 
 
 Retired slots pruned in #9448: `chat-inline`, `wallet`, `browser`,
-`heartbeats`, `settings`, `automations`. Browser and wallet status now render
-through active `chat-sidebar` / `home` declarations instead of their own dead
-slots.
+`heartbeats`, `settings`, `automations`. Browser status now renders through the
+active `chat-sidebar` declaration. Wallet remains a routed surface; its home
+resident was demoted by the home surface spec because balance state is not
+resting urgency.
 
 ---
 
@@ -190,7 +199,7 @@ only navigation affordance).
   surfaces: the overlay's `InlineWidgetText` handles `config` / `ui-spec` /
   `permission` / `code` and `ContinuousChatOverlay` mounts `SensitiveRequestBlock`
   for `message.secretRequest`. The old "ChatView-only, mobile flow uncompletable"
-  gap is closed and pinned by tests — see the D1-parity rows under Coverage. Kept
+  gap is closed and pinned by tests - see the D1-parity rows under Coverage. Kept
   here only as a pointer; there is no remaining segment-kind divergence.
 - **D2 - per-message rail.** ChatView owns edit/delete/speak/retry/suggest;
   the overlay exposes press-and-hold copy only (mobile-first). Intentional.

--- a/packages/ui/src/components/chat/widgets/goals-attention-data.ts
+++ b/packages/ui/src/components/chat/widgets/goals-attention-data.ts
@@ -1,0 +1,177 @@
+/**
+ * Shared goals-attention data layer.
+ *
+ * The single most-urgent LifeOps goal is surfaced in two places now:
+ *  - the routed Goals view still renders the standalone `GoalsAttentionWidget`
+ *    (goals-attention.tsx), and
+ *  - the home "Today" card (todo.tsx) absorbs the at-risk goal as one flagged
+ *    row (spec §B/§E item 5 - goals loses its standalone home resident).
+ *
+ * To keep those two consumers in lock-step, the wire parsing + urgency
+ * selection live here rather than duplicated in each. Kept dependency-light
+ * (no React) so it can be unit-tested and reused without pulling in a widget.
+ *
+ * Wire shape mirrors the JSON served by the PA goals route and parsed in
+ * plugins/plugin-goals/src/components/goals/GoalsView.tsx (GoalsWire /
+ * GoalRecordWire / GoalDefinitionWire). The canonical record type is
+ * LifeOpsGoalRecord (@elizaos/shared); the field literals below mirror
+ * GoalStatus / GoalReviewState in plugins/plugin-goals/src/types.ts. We only
+ * read the fields a glanceable surface needs.
+ */
+
+import { client } from "../../../api";
+import { supportsFullAppShellRoutes } from "../../../api/app-shell-capabilities";
+
+/** How often a home surface refreshes goals - matches GoalsView's 20s poll. */
+export const GOALS_REFRESH_INTERVAL_MS = 20_000;
+
+export type GoalStatus = "active" | "paused" | "archived" | "satisfied";
+export type GoalReviewState =
+  | "idle"
+  | "needs_attention"
+  | "on_track"
+  | "at_risk";
+
+const KNOWN_STATUSES: ReadonlySet<string> = new Set<GoalStatus>([
+  "active",
+  "paused",
+  "archived",
+  "satisfied",
+]);
+const KNOWN_REVIEW_STATES: ReadonlySet<string> = new Set<GoalReviewState>([
+  "idle",
+  "needs_attention",
+  "on_track",
+  "at_risk",
+]);
+
+/** A goal flattened for a glanceable surface. Mapped from a wire record. */
+export interface AttentionGoal {
+  id: string;
+  title: string;
+  status: GoalStatus;
+  reviewState: GoalReviewState;
+}
+
+function toStatus(value: unknown): GoalStatus {
+  return typeof value === "string" && KNOWN_STATUSES.has(value)
+    ? (value as GoalStatus)
+    : "active";
+}
+
+function toReviewState(value: unknown): GoalReviewState {
+  return typeof value === "string" && KNOWN_REVIEW_STATES.has(value)
+    ? (value as GoalReviewState)
+    : "idle";
+}
+
+/**
+ * Validate + flatten the untrusted `{ goals: [{ goal, links }] }` payload at
+ * the network boundary, dropping any record missing the fields we render.
+ */
+export function parseGoals(payload: unknown): AttentionGoal[] {
+  if (typeof payload !== "object" || payload === null) return [];
+  const records = (payload as { goals?: unknown }).goals;
+  if (!Array.isArray(records)) return [];
+
+  const goals: AttentionGoal[] = [];
+  for (const record of records) {
+    if (typeof record !== "object" || record === null) continue;
+    const goal = (record as { goal?: unknown }).goal;
+    if (typeof goal !== "object" || goal === null) continue;
+    const { id, title, status, reviewState } = goal as {
+      id?: unknown;
+      title?: unknown;
+      status?: unknown;
+      reviewState?: unknown;
+    };
+    if (typeof id !== "string" || typeof title !== "string") continue;
+    goals.push({
+      id,
+      title,
+      status: toStatus(status),
+      reviewState: toReviewState(reviewState),
+    });
+  }
+  return goals;
+}
+
+export async function fetchGoals(): Promise<AttentionGoal[]> {
+  const response = await fetch(`${client.getBaseUrl()}/api/lifeops/goals`);
+  if (!response.ok) {
+    throw new Error(`Goals request failed (${response.status})`);
+  }
+  return parseGoals(await response.json());
+}
+
+/** Goals that belong on a glance surface: live (non-archived, non-satisfied). */
+export function liveGoals(goals: AttentionGoal[]): AttentionGoal[] {
+  return goals.filter(
+    (goal) => goal.status !== "archived" && goal.status !== "satisfied",
+  );
+}
+
+/**
+ * The single most-urgent goal: the first at_risk goal, otherwise the first
+ * needs_attention goal, otherwise null. Ties broken by title so the surfaced
+ * goal is deterministic across polls.
+ */
+export function mostUrgentGoal(goals: AttentionGoal[]): AttentionGoal | null {
+  const live = liveGoals(goals);
+  const byTitle = (left: AttentionGoal, right: AttentionGoal) =>
+    left.title.localeCompare(right.title);
+  const atRisk = live
+    .filter((goal) => goal.reviewState === "at_risk")
+    .sort(byTitle);
+  if (atRisk.length > 0) return atRisk[0];
+  const needsAttention = live
+    .filter((goal) => goal.reviewState === "needs_attention")
+    .sort(byTitle);
+  if (needsAttention.length > 0) return needsAttention[0];
+  return null;
+}
+
+/** Count of live goals that need attention (at_risk or needs_attention). */
+export function attentionCount(goals: AttentionGoal[]): number {
+  return liveGoals(goals).filter(
+    (goal) =>
+      goal.reviewState === "at_risk" || goal.reviewState === "needs_attention",
+  ).length;
+}
+
+/** Shallow content equality so an unchanged 20s poll doesn't re-render. */
+export function goalsEqual(
+  a: AttentionGoal[] | null,
+  b: AttentionGoal[],
+): boolean {
+  if (!a || a.length !== b.length) return false;
+  return a.every((goal, i) => {
+    const other = b[i];
+    return (
+      goal.id === other.id &&
+      goal.title === other.title &&
+      goal.status === other.status &&
+      goal.reviewState === other.reviewState
+    );
+  });
+}
+
+/**
+ * Best-effort goals fetch for a glance surface: honors the auth gate and the
+ * limited-cloud-base guard, and swallows fetch errors (returns `null` so the
+ * caller keeps its last-good render, todo.tsx J4 pattern). Returns `[]` when
+ * gated so the caller resolves to "loaded, empty" rather than "still pending".
+ */
+export async function loadGoalsForGlance(
+  authenticated: boolean,
+): Promise<AttentionGoal[] | null> {
+  if (!authenticated || !supportsFullAppShellRoutes(client.getBaseUrl())) {
+    return [];
+  }
+  try {
+    return await fetchGoals();
+  } catch {
+    // error-policy:J4 glance surface - signal "keep last good" to the caller.
+    return null;
+  }
+}

--- a/packages/ui/src/components/chat/widgets/goals-attention.tsx
+++ b/packages/ui/src/components/chat/widgets/goals-attention.tsx
@@ -1,169 +1,46 @@
 /**
- * Icon-first home widget surfacing the single most-urgent LifeOps goal (see the
- * `GoalsAttentionWidget` JSDoc below). One of the home-attention widget family
- * ({goals,inbox,finances,relationships,needs}-attention) that publish into the
- * shared home-attention store to rank themselves on the home surface.
+ * Icon-first widget surfacing the single most-urgent LifeOps goal (see the
+ * `GoalsAttentionWidget` JSDoc below).
+ *
+ * As of spec §B/§E item 5 this widget no longer holds a `slot:"home"`
+ * declaration - the at-risk goal is absorbed into the home "Today" (todo) card
+ * as one flagged row (todo.tsx). This component stays as the standalone,
+ * routed-surface renderer; its data layer lives in `goals-attention-data.ts`
+ * and is shared with the Today card so both stay in lock-step.
  */
 import { Target } from "lucide-react";
 import type { ComponentType } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { client } from "../../../api";
-import { supportsFullAppShellRoutes } from "../../../api/app-shell-capabilities";
 import { useIntervalWhenDocumentVisible } from "../../../hooks";
 import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
 import { usePublishHomeAttention } from "../../../widgets/home-attention-store";
 import { HOME_SIGNAL_WEIGHTS } from "../../../widgets/home-priority";
 import type { WidgetProps } from "../../../widgets/types";
+import {
+  type AttentionGoal,
+  attentionCount,
+  GOALS_REFRESH_INTERVAL_MS,
+  goalsEqual,
+  loadGoalsForGlance,
+  mostUrgentGoal,
+} from "./goals-attention-data";
 import { HomeWidgetCard, useWidgetNavigation } from "./home-widget-card";
 
 const GOALS_WIDGET_KEY = "goals/goals.attention";
-const GOALS_REFRESH_INTERVAL_MS = 20_000; // matches GoalsView's 20s background poll
-
-// ---------------------------------------------------------------------------
-// Wire shape — mirrors the JSON served by the PA goals route and parsed in
-// plugins/plugin-goals/src/components/goals/GoalsView.tsx (GoalsWire /
-// GoalRecordWire / GoalDefinitionWire). The canonical record type is
-// LifeOpsGoalRecord (@elizaos/shared); the field literals below mirror
-// GoalStatus / GoalReviewState in plugins/plugin-goals/src/types.ts. We only
-// read the fields this glanceable widget needs.
-// ---------------------------------------------------------------------------
-
-type GoalStatus = "active" | "paused" | "archived" | "satisfied";
-type GoalReviewState = "idle" | "needs_attention" | "on_track" | "at_risk";
-
-const KNOWN_STATUSES: ReadonlySet<string> = new Set<GoalStatus>([
-  "active",
-  "paused",
-  "archived",
-  "satisfied",
-]);
-const KNOWN_REVIEW_STATES: ReadonlySet<string> = new Set<GoalReviewState>([
-  "idle",
-  "needs_attention",
-  "on_track",
-  "at_risk",
-]);
-
-/** A goal flattened for the home widget. Mapped from a wire record at fetch. */
-interface AttentionGoal {
-  id: string;
-  title: string;
-  status: GoalStatus;
-  reviewState: GoalReviewState;
-}
-
-function toStatus(value: unknown): GoalStatus {
-  return typeof value === "string" && KNOWN_STATUSES.has(value)
-    ? (value as GoalStatus)
-    : "active";
-}
-
-function toReviewState(value: unknown): GoalReviewState {
-  return typeof value === "string" && KNOWN_REVIEW_STATES.has(value)
-    ? (value as GoalReviewState)
-    : "idle";
-}
 
 /**
- * Validate + flatten the untrusted `{ goals: [{ goal, links }] }` payload at
- * the network boundary, dropping any record missing the fields we render.
- */
-function parseGoals(payload: unknown): AttentionGoal[] {
-  if (typeof payload !== "object" || payload === null) return [];
-  const records = (payload as { goals?: unknown }).goals;
-  if (!Array.isArray(records)) return [];
-
-  const goals: AttentionGoal[] = [];
-  for (const record of records) {
-    if (typeof record !== "object" || record === null) continue;
-    const goal = (record as { goal?: unknown }).goal;
-    if (typeof goal !== "object" || goal === null) continue;
-    const { id, title, status, reviewState } = goal as {
-      id?: unknown;
-      title?: unknown;
-      status?: unknown;
-      reviewState?: unknown;
-    };
-    if (typeof id !== "string" || typeof title !== "string") continue;
-    goals.push({
-      id,
-      title,
-      status: toStatus(status),
-      reviewState: toReviewState(reviewState),
-    });
-  }
-  return goals;
-}
-
-async function fetchGoals(): Promise<AttentionGoal[]> {
-  const response = await fetch(`${client.getBaseUrl()}/api/lifeops/goals`);
-  if (!response.ok) {
-    throw new Error(`Goals request failed (${response.status})`);
-  }
-  return parseGoals(await response.json());
-}
-
-/** Goals that belong on the home card: live (non-archived, non-satisfied). */
-function liveGoals(goals: AttentionGoal[]): AttentionGoal[] {
-  return goals.filter(
-    (goal) => goal.status !== "archived" && goal.status !== "satisfied",
-  );
-}
-
-/**
- * The single most-urgent goal for the home card: the first at_risk goal,
- * otherwise the first needs_attention goal, otherwise null. Ties broken by
- * title so the surfaced goal is deterministic across polls.
- */
-function mostUrgentGoal(goals: AttentionGoal[]): AttentionGoal | null {
-  const live = liveGoals(goals);
-  const byTitle = (left: AttentionGoal, right: AttentionGoal) =>
-    left.title.localeCompare(right.title);
-  const atRisk = live
-    .filter((goal) => goal.reviewState === "at_risk")
-    .sort(byTitle);
-  if (atRisk.length > 0) return atRisk[0];
-  const needsAttention = live
-    .filter((goal) => goal.reviewState === "needs_attention")
-    .sort(byTitle);
-  if (needsAttention.length > 0) return needsAttention[0];
-  return null;
-}
-
-/** Count of live goals that need attention (at_risk or needs_attention). */
-function attentionCount(goals: AttentionGoal[]): number {
-  return liveGoals(goals).filter(
-    (goal) =>
-      goal.reviewState === "at_risk" || goal.reviewState === "needs_attention",
-  ).length;
-}
-
-/** Shallow content equality so an unchanged 20s poll doesn't re-render. */
-function goalsEqual(a: AttentionGoal[] | null, b: AttentionGoal[]): boolean {
-  if (!a || a.length !== b.length) return false;
-  return a.every((goal, i) => {
-    const other = b[i];
-    return (
-      goal.id === other.id &&
-      goal.title === other.title &&
-      goal.status === other.status &&
-      goal.reviewState === other.reviewState
-    );
-  });
-}
-
-/**
- * Frontpage Goals widget (#9143). Glanceable, home-only, icon-first: surfaces
- * the SINGLE most-urgent goal (at_risk first, then needs_attention) as one
- * datum, with a count badge. Fetches the same `/api/lifeops/goals` endpoint
- * GoalsView reads and floats itself up via the home-attention store when any
- * goal is at risk or needs attention. Tapping the card opens the Goals view.
+ * Frontpage Goals widget (#9143). Glanceable, icon-first: surfaces the SINGLE
+ * most-urgent goal (at_risk first, then needs_attention) as one datum, with a
+ * count badge. Fetches the same `/api/lifeops/goals` endpoint GoalsView reads
+ * and floats itself up via the home-attention store when any goal is at risk or
+ * needs attention. Tapping the card opens the Goals view. No longer a home
+ * resident (§E item 5) - retained for the routed goals surface.
  */
 export function GoalsAttentionWidget({
   spanClassName = "col-span-2 row-span-1",
 }: Partial<WidgetProps>) {
   // `null` distinguishes "first load still pending" from "loaded, empty" so the
-  // home surface renders nothing (not a card) until we actually know the data.
+  // surface renders nothing (not a card) until we actually know the data.
   const [goals, setGoals] = useState<AttentionGoal[] | null>(null);
   const nav = useWidgetNavigation();
   // Auth gate (#11084): the widget mounts before the auth probe resolves, so
@@ -171,19 +48,11 @@ export function GoalsAttentionWidget({
   const authenticated = useIsAuthenticated();
 
   const load = useCallback(async () => {
-    if (!authenticated || !supportsFullAppShellRoutes(client.getBaseUrl())) {
-      setGoals([]);
-      return;
-    }
-
-    try {
-      const next = await fetchGoals();
-      // Skip the state update (and the re-render) when the poll is unchanged.
-      setGoals((prev) => (goalsEqual(prev, next) ? prev : next));
-    } catch {
-      // error-policy:J4 glance tile — keep the last good render on a poll
-      // failure (todo.tsx pattern); the next tick refreshes.
-    }
+    const next = await loadGoalsForGlance(authenticated);
+    // A null return means the fetch failed (J4) - keep the last good render.
+    if (next == null) return;
+    // Skip the state update (and the re-render) when the poll is unchanged.
+    setGoals((prev) => (goalsEqual(prev, next) ? prev : next));
   }, [authenticated]);
 
   useEffect(() => {
@@ -202,7 +71,7 @@ export function GoalsAttentionWidget({
   );
 
   // Render nothing until the first load resolves, and nothing once loaded if no
-  // goal needs attention — the home surface must not show empty placeholders or
+  // goal needs attention - the surface must not show empty placeholders or
   // on-track goals (#9143).
   if (goals == null || urgent == null) return null;
 

--- a/packages/ui/src/components/chat/widgets/todo.test.tsx
+++ b/packages/ui/src/components/chat/widgets/todo.test.tsx
@@ -9,7 +9,7 @@ const {
   mockState,
   publishHomeAttentionSpy,
 } = vi.hoisted(() => ({
-  // Auth gate (#11084) — mutable so tests can flip the session state.
+  // Auth gate (#11084) - mutable so tests can flip the session state.
   authMock: { authenticated: true },
   getBaseUrlMock: vi.fn(() => "http://localhost"),
   listWorkbenchTodosMock: vi.fn(async () => ({ todos: [] })),
@@ -57,6 +57,7 @@ vi.mock("../../../widgets/home-attention-store", () => ({
   usePublishHomeAttention: publishHomeAttentionSpy,
 }));
 
+import { HOME_SIGNAL_WEIGHTS } from "../../../widgets/home-priority";
 import { TODO_PLUGIN_WIDGETS } from "./todo";
 
 const TodoWidget = TODO_PLUGIN_WIDGETS.find(
@@ -71,12 +72,25 @@ beforeEach(() => {
   getBaseUrlMock.mockReset();
   getBaseUrlMock.mockReturnValue("http://localhost");
   listWorkbenchTodosMock.mockClear();
+  listWorkbenchTodosMock.mockResolvedValue({ todos: [] });
   publishHomeAttentionSpy.mockClear();
   authMock.authenticated = true;
+  mockState.workbench.todos = [
+    {
+      id: "cached-1",
+      name: "Cached todo",
+      description: "",
+      type: "task",
+      isCompleted: false,
+      isUrgent: false,
+      priority: null,
+    },
+  ];
 });
 
 afterEach(() => {
   cleanup();
+  vi.unstubAllGlobals();
 });
 
 describe("TodoSidebarWidget", () => {
@@ -92,7 +106,7 @@ describe("TodoSidebarWidget", () => {
     expect(listWorkbenchTodosMock).not.toHaveBeenCalled();
   });
 
-  // #11084 — the widget mounts before the auth probe resolves; its workbench
+  // #11084 - the widget mounts before the auth probe resolves; its workbench
   // poll must not fire a single request while the session is unauthenticated.
   it("does not poll workbench todos while unauthenticated", async () => {
     authMock.authenticated = false;
@@ -210,6 +224,80 @@ describe("TodoSidebarWidget", () => {
     );
     expect(await screen.findByText("Cached todo")).toBeTruthy();
     expect(container.firstElementChild?.className).toContain("col-span-2");
+  });
+
+  it("home slot: renders an at-risk goal as one flagged row inside Today (spec §E item 5)", async () => {
+    mockState.workbench.todos = [];
+    listWorkbenchTodosMock.mockResolvedValue({ todos: [] });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              goals: [
+                {
+                  goal: {
+                    id: "goal-at-risk",
+                    title: "Ship the release",
+                    status: "active",
+                    reviewState: "at_risk",
+                  },
+                  links: [],
+                },
+              ],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+      ),
+    );
+
+    render(<TodoWidget slot="home" events={[]} clearEvents={vi.fn()} />);
+
+    const row = await screen.findByTestId("todo-goal-attention-row");
+    expect(row.textContent).toContain("Ship the release");
+    expect(row.textContent).toContain("At risk");
+    expect(screen.queryByTestId("widget-goals-attention")).toBeNull();
+
+    await waitFor(() => {
+      expect(publishHomeAttentionSpy).toHaveBeenLastCalledWith(
+        "todo/todo.items",
+        HOME_SIGNAL_WEIGHTS.escalation,
+      );
+    });
+  });
+
+  it("home slot: preserves needs-attention goals in the merged Today row", async () => {
+    mockState.workbench.todos = [];
+    listWorkbenchTodosMock.mockResolvedValue({ todos: [] });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              goals: [
+                {
+                  goal: {
+                    id: "goal-needs-attention",
+                    title: "Reconnect with the team",
+                    status: "active",
+                    reviewState: "needs_attention",
+                  },
+                  links: [],
+                },
+              ],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+      ),
+    );
+
+    render(<TodoWidget slot="home" events={[]} clearEvents={vi.fn()} />);
+
+    const row = await screen.findByTestId("todo-goal-attention-row");
+    expect(row.textContent).toContain("Reconnect with the team");
+    expect(row.textContent).toContain("Needs attention");
   });
 
   it("chat-sidebar slot: does NOT wrap the section in a grid-span root (#11752)", async () => {

--- a/packages/ui/src/components/chat/widgets/todo.tsx
+++ b/packages/ui/src/components/chat/widgets/todo.tsx
@@ -3,8 +3,14 @@
  * seeded from the app store's `workbench.todos`, refreshed on live workbench
  * events, and backed by a visible-tab poll for missed events. Exports
  * `TODO_PLUGIN_WIDGETS`, the widget-registry entry consumed by the sidebar.
+ *
+ * On the home surface this is the "Today" card, and per spec §B/§E item 5 it
+ * absorbs the goals resident: when the goals store reports an at-risk (or
+ * needs-attention) goal, that goal renders as one flagged row inside this card
+ * rather than as a second standalone home widget. The card then self-publishes
+ * the goals escalation weight so the merged card floats up on goal urgency.
  */
-import { ListTodo } from "lucide-react";
+import { ListTodo, Target } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { client } from "../../../api";
 import { supportsFullAppShellRoutes } from "../../../api/app-shell-capabilities";
@@ -16,6 +22,14 @@ import type { TranslateFn } from "../../../types";
 import { usePublishHomeAttention } from "../../../widgets/home-attention-store";
 import { HOME_SIGNAL_WEIGHTS } from "../../../widgets/home-priority";
 import { Badge } from "../../ui/badge";
+import {
+  type AttentionGoal,
+  GOALS_REFRESH_INTERVAL_MS,
+  goalsEqual,
+  loadGoalsForGlance,
+  mostUrgentGoal,
+} from "./goals-attention-data";
+import { useWidgetNavigation } from "./home-widget-card";
 import { EmptyWidgetState, WidgetSection } from "./shared";
 import type {
   ChatSidebarWidgetDefinition,
@@ -120,23 +134,78 @@ function TodoRow({ todo }: { todo: WorkbenchTodo }) {
   );
 }
 
+/**
+ * The merged goal-attention row (§E item 5): renders the single urgent goal
+ * inline in the Today card. Whole-row button so the home 44px target rule holds;
+ * tapping opens the Goals view.
+ */
+function GoalAttentionRow({
+  goal,
+  onOpen,
+}: {
+  goal: AttentionGoal;
+  onOpen: () => void;
+}) {
+  const atRisk = goal.reviewState === "at_risk";
+  const status = atRisk ? "at risk" : "needs attention";
+  return (
+    <button
+      type="button"
+      data-testid="todo-goal-attention-row"
+      aria-label={`Goal "${goal.title}" ${status}. Open Goals.`}
+      onClick={onOpen}
+      className="flex min-h-11 w-full items-start gap-2 rounded-sm border border-border/50 bg-bg/70 p-3 text-left"
+    >
+      <Target
+        className={`mt-0.5 h-4 w-4 shrink-0 ${atRisk ? "text-danger" : "text-accent"}`}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="min-w-0 truncate text-xs font-semibold text-txt">
+            {goal.title}
+          </span>
+          <Badge
+            variant="secondary"
+            className={`text-3xs ${atRisk ? "text-danger" : "text-accent"}`}
+          >
+            {atRisk ? "At risk" : "Needs attention"}
+          </Badge>
+        </div>
+      </div>
+    </button>
+  );
+}
+
 function TodoItemsContent({
   todos,
   loading,
+  goal,
+  onOpenGoal,
 }: {
   todos: WorkbenchTodo[];
   loading: boolean;
+  goal: AttentionGoal | null;
+  onOpenGoal: () => void;
 }) {
   const openTodos = todos.filter((todo) => !todo.isCompleted);
   const hiddenCompletedCount = todos.length - openTodos.length;
   const visibleTodos = openTodos.slice(0, MAX_VISIBLE_TODOS);
   const remainingCount = openTodos.length - visibleTodos.length;
+  const goalRow = goal ? (
+    <GoalAttentionRow goal={goal} onOpen={onOpenGoal} />
+  ) : null;
 
-  if (loading && todos.length === 0) {
+  if (loading && todos.length === 0 && !goal) {
     return <div className="py-3 text-xs text-muted">Refreshing todos…</div>;
   }
 
   if (openTodos.length === 0) {
+    // A flagged goal alone still gives the card a reason to render; only a fully
+    // empty Today (no open todos AND no at-risk goal) shows the empty state
+    // (which the sidebar surface uses; the home surface hides entirely).
+    if (goalRow) {
+      return <div className="flex flex-col gap-2">{goalRow}</div>;
+    }
     return (
       <EmptyWidgetState
         icon={<ListTodo className="h-8 w-8" />}
@@ -147,6 +216,7 @@ function TodoItemsContent({
 
   return (
     <div className="flex flex-col gap-2">
+      {goalRow}
       {visibleTodos.map((todo) => (
         <TodoRow key={todo.id} todo={todo} />
       ))}
@@ -163,6 +233,49 @@ function TodoItemsContent({
       ) : null}
     </div>
   );
+}
+
+/**
+ * Fetch the single urgent goal for the merged Today card (§E item 5). Only
+ * active on the home surface; the chat-sidebar Todos widget never surfaces
+ * goals. Polls at the goals cadence, visibility-gated, and keeps its last-good
+ * value on a transient failure (J4). Returns `null` when there is no at-risk or
+ * needs-attention goal (or off-home), so it contributes nothing to the card.
+ */
+function useAtRiskGoal(active: boolean): AttentionGoal | null {
+  const authenticated = useIsAuthenticated();
+  const [goals, setGoals] = useState<AttentionGoal[] | null>(null);
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const load = useCallback(async () => {
+    if (!active) return;
+    const next = await loadGoalsForGlance(authenticated);
+    // A null return means the fetch failed (J4) - keep the last good value.
+    if (next == null || !mountedRef.current) return;
+    setGoals((prev) => (goalsEqual(prev, next) ? prev : next));
+  }, [active, authenticated]);
+
+  useEffect(() => {
+    if (!active) {
+      setGoals(null);
+      return;
+    }
+    void load();
+  }, [active, load]);
+  useIntervalWhenDocumentVisible(
+    () => void load(),
+    GOALS_REFRESH_INTERVAL_MS,
+    active,
+  );
+
+  if (!active || goals == null) return null;
+  return mostUrgentGoal(goals);
 }
 
 function TodoSidebarWidget({
@@ -219,7 +332,7 @@ function TodoSidebarWidget({
           setTodos(dedupeTodos(result.todos));
         }
       } catch {
-        // error-policy:J4 glance tile — fall back to the workbench snapshot
+        // error-policy:J4 glance tile - fall back to the workbench snapshot
         // already in view state rather than surfacing a broken card.
         if (mountedRef.current && (workbench?.todos?.length ?? 0) > 0) {
           setTodos(dedupeTodos(workbench?.todos ?? []));
@@ -249,7 +362,7 @@ function TodoSidebarWidget({
     void loadTodos(true);
   }, [events, loadTodos]);
 
-  // Refresh only while the document is visible — pause the silent poll in a
+  // Refresh only while the document is visible - pause the silent poll in a
   // backgrounded app/tab. Live workbench events do the normal foreground
   // refresh; this poll is just a missed-event repair path.
   useIntervalWhenDocumentVisible(
@@ -260,16 +373,29 @@ function TodoSidebarWidget({
   const openTodos = todos.filter((todo) => !todo.isCompleted);
   const hasUrgent = openTodos.some((todo) => todo.isUrgent);
   const onHome = slot === "home";
-  // Float the home card up when there are urgent open todos; clear otherwise.
-  usePublishHomeAttention(
-    TODO_WIDGET_KEY,
-    onHome && hasUrgent ? HOME_SIGNAL_WEIGHTS.reminder : null,
-  );
+  // The merged at-risk goal row (§E item 5) is home-only; the chat sidebar
+  // keeps the pure todo list.
+  const nav = useWidgetNavigation();
+  const attentionGoal = useAtRiskGoal(onHome);
+  // Float the merged Today card up on the STRONGER of its two signals: an
+  // at-risk goal contributes the goals escalation weight (higher than the todo
+  // reminder weight), so goal urgency dominates - matching the standalone goals
+  // card this absorbed (§E item 5). Both publish under the todo key because the
+  // ranker attributes a self-published weight to the declaration whose key
+  // matches, and the merged resident IS `todo/todo.items` now.
+  const homeAttentionWeight =
+    onHome && attentionGoal
+      ? HOME_SIGNAL_WEIGHTS.escalation
+      : onHome && hasUrgent
+        ? HOME_SIGNAL_WEIGHTS.reminder
+        : null;
+  usePublishHomeAttention(TODO_WIDGET_KEY, homeAttentionWeight);
 
-  // On the home grid, render nothing when there are no open todos — the home
-  // surface must not show empty-state placeholders (#9143). The chat sidebar
-  // keeps its empty state.
-  if (onHome && openTodos.length === 0) return null;
+  // On the home grid, render nothing when there are no open todos AND no at-risk
+  // goal - the home surface must not show empty-state placeholders (#9143). A
+  // flagged goal alone keeps the merged Today card alive. The chat sidebar keeps
+  // its empty state.
+  if (onHome && openTodos.length === 0 && !attentionGoal) return null;
 
   const section = (
     <WidgetSection
@@ -277,7 +403,12 @@ function TodoSidebarWidget({
       icon={<ListTodo className="h-4 w-4" />}
       testId="chat-widget-todos"
     >
-      <TodoItemsContent todos={todos} loading={todosLoading} />
+      <TodoItemsContent
+        todos={todos}
+        loading={todosLoading}
+        goal={attentionGoal}
+        onOpenGoal={() => nav.openView("/goals", "goals")}
+      />
     </WidgetSection>
   );
   // On the home 4-col grid the widget's root element must carry its grid-span

--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.api-stub.ts
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.api-stub.ts
@@ -29,6 +29,21 @@ export const client = {
   getRelationshipsCandidates: async () => [],
   getWalletBalances: async () => walletBalancesResponse(),
   getWalletMarketOverview: async () => walletMarketOverviewResponse(),
+  // Today (todo) home card: seed one open todo so the merged card renders with a
+  // todo row alongside its flagged at-risk goal row (spec §E item 5).
+  listWorkbenchTodos: async () => ({
+    todos: [
+      {
+        id: "todo-groceries",
+        name: "Buy groceries",
+        description: "",
+        type: "task",
+        isCompleted: false,
+        isUrgent: false,
+        priority: 2,
+      },
+    ],
+  }),
   // Notification store hydrate + live subscription.
   listNotifications: async () => homeWidgetNotificationsResponse(),
   onWsEvent: () => {},
@@ -46,7 +61,7 @@ export const client = {
   getOrchestratorAccounts: async () => ({ accounts: [] }),
   getOrchestratorRooms: async () => ({ rooms: [] }),
   listAccounts: async () => ({ accounts: [] }),
-  // Unified-tasks home widget (useUnifiedTasks) — empty so it self-hides. These
+  // Unified-tasks home widget (useUnifiedTasks) - empty so it self-hides. These
   // prototype methods are bare side-effect patches in production, dropped from
   // this esbuild bundle, so stub them here explicitly.
   listAutomations: async () => ({ automations: [] }),

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -1,5 +1,5 @@
 /**
- * Real-browser screenshot e2e for the iOS-style HomeScreen — no app server.
+ * Real-browser screenshot e2e for the iOS-style HomeScreen - no app server.
  * Bundles home-screen-fixture.tsx with esbuild (stubbing the data sources), loads
  * it in headless chromium, and asserts the Home/Launcher consolidation +
  * captures mobile + desktop screenshots plus a mobile interaction recording.
@@ -31,7 +31,7 @@ import {
   touchSwipe,
 } from "../../../testing/real-touch-gestures.ts";
 
-// Frame gate for the home↔launcher rail swipe — same factor-based thresholds as
+// Frame gate for the home↔launcher rail swipe - same factor-based thresholds as
 // the sibling real-overlay gates (run-perf-gate-e2e / run-chat-perf-gate): the
 // budget adapts to the runner's refresh rate instead of hard-coding a Hz.
 const FRAME_BUDGET = { targetFps: 60 };
@@ -70,9 +70,9 @@ const stubResolver = {
   setup(b) {
     // HomeScreen mounts the REAL unified home-slot WidgetHost (#9143). It resolves
     // its per-plugin widgets from the app-store plugins snapshot and renders them
-    // with injected data (seeded in home-screen-fixture.tsx). The data sources —
+    // with injected data (seeded in home-screen-fixture.tsx). The data sources -
     // the `client` (base URL + notification methods) and `window.fetch` (lifeops
-    // routes) — are stubbed below / in the fixture; the WidgetHost + widget
+    // routes) - are stubbed below / in the fixture; the WidgetHost + widget
     // components themselves are NOT stubbed.
     b.onResolve({ filter: /(\/api|\/api\/client)$/ }, () => ({
       path: join(here, "home-screen-fixture.api-stub.ts"),
@@ -116,7 +116,7 @@ const stubResolver = {
 // @elizaos/core: the WidgetHost + the (dead-in-browser) @elizaos/shared graph
 // import a wide named surface from it. Satisfy ANY named import with a no-op
 // Proxy, but override the handful the render path actually uses with REAL
-// implementations. These must be OWN enumerable keys of the exported object —
+// implementations. These must be OWN enumerable keys of the exported object -
 // esbuild's __toESM interop only copies own keys onto the ESM namespace, so a
 // value reachable only through the Proxy `get` trap reads back as undefined
 // ("resolveViewKind is not a function"). The launcher curation drives real
@@ -158,7 +158,7 @@ const stubElizaCore = {
 };
 
 // The REAL WidgetHost subtree transitively reaches server-only code (the hooks
-// barrel pulls @elizaos/logger / @elizaos/shared, which import node builtins) —
+// barrel pulls @elizaos/logger / @elizaos/shared, which import node builtins) -
 // DEAD in the browser (never executed at render; the home widgets fetch through
 // the mocked window.fetch + the stubbed client). The shared stubNodeBuiltins
 // no-op-proxies every node builtin so the browser bundle builds; if any of it
@@ -200,7 +200,7 @@ async function swipeLeft(locator) {
   await locator.page().mouse.up();
 }
 // Horizontal touch-swipes across an element, driven through Chromium's real
-// touch input path. These keep the mobile pagers honest — the inner launcher
+// touch input path. These keep the mobile pagers honest - the inner launcher
 // pager AND the outer home↔launcher rail: hit-testing, touch-action, implicit
 // capture, and pointer cancellation all stay in play.
 async function touchSwipeLeft(page, testId) {
@@ -240,12 +240,14 @@ async function readHomeDarkForegrounds(page) {
     };
     const luminance = ({ r, g, b }) =>
       0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+    // Home resident set after the spec §E cut: notifications, the merged Today
+    // card (with its flagged at-risk goal row), and calendar. wallet.balance +
+    // health.sleep left home; goals.attention folded into Today.
     const surfaces = [
       "home-notification-center",
-      "widget-goals-attention",
-      "widget-health-sleep",
+      "chat-widget-todos",
+      "todo-goal-attention-row",
       "chat-widget-calendar-upcoming",
-      "chat-widget-wallet-prices",
     ];
     const failures = [];
     for (const testId of surfaces) {
@@ -340,7 +342,7 @@ async function measureRailSwipeWindow(page) {
   }
 }
 try {
-  // Mobile (Pixel-ish) — the primary target.
+  // Mobile (Pixel-ish) - the primary target.
   const mobileContext = await browser.newContext({
     viewport: { width: 402, height: 874 },
     deviceScaleFactor: 2,
@@ -401,8 +403,8 @@ try {
     (await mobile.getByTestId("home-clock").count()) === 0,
     "no clock (home kept minimal)",
   );
-  // The home mounts the REAL unified home-slot WidgetHost (#9143) — the
-  // prioritized dynamic-priority home widgets — fed by the injected mock data
+  // The home mounts the REAL unified home-slot WidgetHost (#9143) - the
+  // prioritized dynamic-priority home widgets - fed by the injected mock data
   // (seeded in the fixture). Assert the host is mounted AND that each seeded
   // per-plugin widget card renders its populated content (each self-hides when
   // empty, so visibility proves the data flowed through real widget components).
@@ -427,13 +429,15 @@ try {
     { timeout: 5000 },
   );
   // Kept per-plugin home widgets render only when their injected data is
-  // attention-worthy. The removed autonomous/domain cards must stay absent even
-  // though the fixture still exposes their plugins/routes elsewhere.
+  // attention-worthy. Post spec §E cut, the resident set is Today (todos) - with
+  // the at-risk goal folded in as one flagged row - plus calendar. The removed
+  // autonomous/domain cards AND the demoted wallet/health cards must stay absent
+  // even though the fixture still exposes their plugins/routes elsewhere.
   const WIDGET_CARDS = [
-    ["widget-goals-attention", "Ship the release"],
+    ["chat-widget-todos", "Buy groceries"],
+    // The merged at-risk goal renders inside the Today card (§E item 5).
+    ["todo-goal-attention-row", "Ship the release"],
     ["chat-widget-calendar-upcoming", "Design review"],
-    ["widget-health-sleep", "Irregular"],
-    ["chat-widget-wallet-prices", "BTC"],
   ];
   for (const [testId, text] of WIDGET_CARDS) {
     const card = homeWidgetHost.getByTestId(testId);
@@ -446,17 +450,23 @@ try {
       );
     }
   }
+  // Demoted (wallet.balance, health.sleep) + previously-removed domain cards
+  // must not resurface as home residents. goals.attention no longer stands
+  // alone - its data now lives inside the Today card's flagged row above.
   for (const testId of [
+    "widget-goals-attention",
+    "widget-health-sleep",
+    "chat-widget-wallet-prices",
     "chat-widget-finances-alerts",
     "chat-widget-relationships",
     "chat-widget-inbox-unread",
   ]) {
     assert(
       (await homeWidgetHost.getByTestId(testId).count()) === 0,
-      `removed home widget ${testId} stays absent`,
+      `removed/demoted home widget ${testId} stays absent`,
     );
   }
-  // No home widget may fall back to the "Widget failed to render" boundary — an
+  // No home widget may fall back to the "Widget failed to render" boundary - an
   // ErrorBoundary catch is invisible to the page-error guard, so assert it here.
   {
     const errorCards = await mobile
@@ -468,7 +478,7 @@ try {
     );
   }
   // The dashboard notification center: HomeScreen pins NotificationsHomeCenter
-  // directly below the base widgets (it is NOT a ranked WidgetHost entry — a
+  // directly below the base widgets (it is NOT a ranked WidgetHost entry - a
   // registry declaration would double-render the inbox). The fixture seeds one
   // urgent unread notification, so the card must render with its populated row,
   // the unread badge, and its inbox actions.
@@ -520,7 +530,7 @@ try {
       (await mobile.getByTestId("notification-panel").count()) === 0,
     "no notification pull-zone / sheet / panel exists (dashboard center only)",
   );
-  // No general quick-access tiles anymore — Launcher is the adjacent
+  // No general quick-access tiles anymore - Launcher is the adjacent
   // launcher. The only tiles left are the AOSP native-OS surfaces, shown here
   // because the mobile page sets ?native (see HomeScreen.tsx HOME_TILES).
   for (const id of ["messages", "phone", "contacts", "camera"]) {
@@ -627,7 +637,7 @@ try {
 
   // Real touch left-swipe on the home half pages the outer rail to the
   // launcher (the halves are `touch-pan-y`, so a horizontal touch gesture is
-  // the rail's — exactly the phone input this profile emulates).
+  // the rail's - exactly the phone input this profile emulates).
   await touchSwipeLeft(mobile, "home-launcher-home-page");
   await waitForSurfacePageSettled(mobile, "launcher");
   assert(
@@ -638,7 +648,7 @@ try {
     "mobile coarse-pointer: no rail or launcher edge buttons on launcher",
   );
 
-  // ── Curated apps page — the everyday apps render as tiles, in curated order.
+  // ── Curated apps page - the everyday apps render as tiles, in curated order.
   for (const id of ["wallet", "automations", "browser", "settings"]) {
     assert(
       await mobile.getByTestId(`launcher-tile-${id}`).isVisible(),
@@ -669,7 +679,7 @@ try {
     "duplicate wallet registrations collapse to one tile",
   );
 
-  // ── Real image icons — curated tiles carry hero images, so each renders an
+  // ── Real image icons - curated tiles carry hero images, so each renders an
   // <img> tile (not the glyph fallback). On device the agent serves the branded
   // SVG at /api/views/:id/hero, resolved through the runtime API base so it
   // loads on native (file://) shells too.
@@ -688,7 +698,7 @@ try {
 
   await snap(mobile, "mobile-launcher");
 
-  // ── NO page indicator — the dots were removed (they collided with the chat
+  // ── NO page indicator - the dots were removed (they collided with the chat
   // composer). Navigation is swipe-only. Neither the rail indicator nor the
   // inner Launcher dot strip may render.
   assert(
@@ -702,7 +712,7 @@ try {
     "the inner Launcher dot strip is absent too",
   );
 
-  // ── Real per-view images — every tile shows a branded hero IMAGE (generated
+  // ── Real per-view images - every tile shows a branded hero IMAGE (generated
   // client-side as a data URI when no real hero exists). A deterministic glyph
   // may sit underneath the image as a decode fallback, but no tile may be glyph
   // only. Each view's hero is deterministic per id, so the srcs are distinct.
@@ -759,7 +769,7 @@ try {
 
   // ── Rail-swipe FPS gate: sample independent windows of REAL frames, each
   // covering three full home↔launcher round-trips (right swipe back home, left
-  // swipe to the launcher — the exact gesture the launcher redesign must keep
+  // swipe to the launcher - the exact gesture the launcher redesign must keep
   // smooth), and hard-fail on sustained jank via the same shared, meta-tested
   // frame-budget detectors the chat perf gates use. The rail paints via
   // rAF-paced translate3d, so a regression that moves work onto the drag path
@@ -810,7 +820,7 @@ try {
   // ── ONE page of views. Developer tools are NOT a separate swipeable page any
   // more: when Developer Mode is on they sit on the SAME single page after the
   // apps (this fixture enables developer mode, so they render). The launcher is
-  // one scrolling page window — there is no inter-page view paging to swipe to.
+  // one scrolling page window - there is no inter-page view paging to swipe to.
   for (const id of [
     "trajectories",
     "database",
@@ -831,7 +841,7 @@ try {
     (await mobile.getByTestId("launcher-page-1").count()) === 0,
     "there is no second launcher page (single curated page of views)",
   );
-  // A left-swipe on the single-page launcher has nowhere to go — it rubber-bands
+  // A left-swipe on the single-page launcher has nowhere to go - it rubber-bands
   // and never advances to a nonexistent page, staying on the launcher.
   await touchSwipeLeft(mobile, "launcher-page-window");
   await mobile.waitForTimeout(500);
@@ -873,7 +883,7 @@ try {
   await desktop.waitForSelector('[data-testid="home-launcher-surface"]');
   await desktop.waitForSelector('[data-testid="home-screen"]');
   await desktop.waitForTimeout(500);
-  // Off-AOSP: no pinned tiles at all — the tile grid is omitted entirely.
+  // Off-AOSP: no pinned tiles at all - the tile grid is omitted entirely.
   assert(
     (await desktop.getByTestId("home-tiles").count()) === 0,
     "no pinned tiles off-AOSP (grid omitted)",
@@ -882,7 +892,7 @@ try {
     (await desktop.getByTestId("home-tile-phone").count()) === 0,
     "phone tile hidden when native disabled",
   );
-  // Desktop gets the SAME pinned dashboard notification center — there is no
+  // Desktop gets the SAME pinned dashboard notification center - there is no
   // per-surface shell (no anchored panel, no pull-down sheet) any more.
   await desktop
     .getByTestId("home-notification-center")

--- a/packages/ui/src/widgets/HOME_CONTENT_TAXONOMY.md
+++ b/packages/ui/src/widgets/HOME_CONTENT_TAXONOMY.md
@@ -3,17 +3,19 @@
 The home surface is a *prioritized, self-pruning* dashboard, not a static grid.
 Every `slot:"home"` widget is ranked by `home-priority.ts` and capped at
 `HOME_RENDER_CAP` in `WidgetHost.tsx`; each widget self-hides (renders `null`)
-when it has nothing worth showing. This file is the single source of truth for
-*what kind of content* belongs on the home and how each tier behaves — previously
-this lived implicitly in the `slot:"home"` declarations in `registry.ts`.
+when it has nothing worth showing. The binding north-star is now
+`docs/design/NOTIFICATIONS-WIDGETS-SYSTEM.md` §B (Home surface spec): ambient
+base + pinned notification center + at most five ranked residents + chat bar.
+This file summarizes what kind of content belongs on the home and how each tier
+behaves; the spec wins if this taxonomy drifts.
 
 ## Tiers
 
-### Tier 1 — Ambient base (always present)
+### Tier 1 - Ambient base (always present)
 Clock + weather (`DefaultHomeWidgets`). Never ranked, never sunset; the calm
 backdrop a brand-new account still sees.
 
-### Tier 2 — Live agent work (ongoing, self-hiding)
+### Tier 2 - Live agent work (ongoing, self-hiding)
 Only work that needs the user's response belongs here:
 `needs-attention.pending`, plus setup-progress cards such as
 `model-download.status` and `agent-provisioning.status`. These rank by
@@ -21,16 +23,20 @@ Only work that needs the user's response belongs here:
 activity streams, app-run lists, and running workflow lists stay in the
 launcher/sidebar/routed views.
 
-### Tier 3 — Data attention (urgency from the widget's own data)
-Calendar, goals, health, todos, and wallet. Each fetches its own data,
-self-publishes a `home-attention` weight while a condition holds, and self-hides
-otherwise where appropriate. Finances, inbox, relationships, feed activity,
-workflow activity, and orchestrator app/activity cards do not live on home; use
-their launcher/routed surfaces.
+### Tier 3 - Data attention (urgency from the widget's own data)
+Calendar and Today (todo.items). Each fetches its own data, self-publishes a
+`home-attention` weight while a condition holds, and self-hides otherwise where
+appropriate. Today also absorbs goals attention: one at-risk goal renders as a
+flagged row inside the Today card, and the merged card publishes the stronger
+escalation weight. Wallet balance and sleep moved out of the resident set
+because state/daily-digest facts are not home urgency; material wallet deltas
+and health threshold crossings travel as notifications. Finances, inbox,
+relationships, feed activity, workflow activity, and orchestrator app/activity
+cards do not live on home; use their launcher/routed surfaces.
 
-### Tier 4 — Transient guidance (show-once-then-sunset)
+### Tier 4 - Transient guidance (show-once-then-sunset)
 FTU welcome, connector nudges, the tutorial nudge. These rank for a cold user
-but **retire permanently** once their job is done, via the sunset lifecycle —
+but **retire permanently** once their job is done, via the sunset lifecycle -
 they are the only tier that uses it.
 
 ## The sunset lifecycle (Tier 4)
@@ -62,8 +68,11 @@ sunset lifecycle rather than to live data.
 The following components/routes can still exist, but their `slot:"home"`
 declarations are removed: `agent-orchestrator.activity`,
 `agent-orchestrator.apps`, `feed.agent-activity`, `workflow.running`,
-`finances.alerts`, `relationships.attention`, and `inbox.unread`.
+`finances.alerts`, `relationships.attention`, `inbox.unread`,
+`wallet.balance`, and `health.sleep`.
 
-The old `messages.recent` card also remains removed. Follow-up-worthy messages
-surface through notifications, and conversation navigation lives in chat history
-instead of a resident home tile.
+`goals.attention` is no longer a standalone resident: its at-risk goal row lives
+inside Today (`todo.items`) per the spec's merge verdict. The old
+`messages.recent` card also remains removed. Follow-up-worthy messages surface
+through notifications, and conversation navigation lives in chat history instead
+of a resident home tile.

--- a/packages/ui/src/widgets/README.md
+++ b/packages/ui/src/widgets/README.md
@@ -13,7 +13,7 @@ grid (used by the home), or the default `"stack"`.
 
 ## Registering a widget
 
-A widget needs **two** things — a registered component and a declaration:
+A widget needs **two** things - a registered component and a declaration:
 
 ```ts
 import { registerWidgetComponent } from "@elizaos/ui/widgets";
@@ -58,6 +58,8 @@ The Home/Launcher surface mounts `<WidgetHost slot="home" layout="grid" …>`
 on the home page next to the launcher. Home is intentionally sparse: the
 ambient time/weather base and pinned notification center carry resting state,
 while only essential self-hiding cards live in the ranked widget host. The
+binding north-star is `docs/design/NOTIFICATIONS-WIDGETS-SYSTEM.md` §B: ambient
+base + pinned notifications + at most five ranked residents + chat bar. The
 notification inbox is NOT a host widget: HomeScreen pins the dashboard
 notification center
 (`components/shell/NotificationsHomeCenter.tsx`) directly below the
@@ -65,15 +67,17 @@ time/weather base, so a registry declaration would double-render it.
 
 **Frontpage presence is opt-in and curated, not mandated (#14349).** A plugin
 appears on home only by declaring a widget with `slot: "home"` that resolves to a
-bundled React component or a `uiSpec` — there is no breadth mandate that every
+bundled React component or a `uiSpec` - there is no breadth mandate that every
 app-manifest plugin be "frontpage-aware", and no shared default-sink
 participation record. Declare a home widget only when it is a keeper for the
 sparse home surface. Read your own store/API in the component; it receives
-`WidgetProps` (`pluginId`, `events?`, …). Keep it compact and self-hiding —
+`WidgetProps` (`pluginId`, `events?`, …). Keep it compact and self-hiding -
 domain dashboards belong in launcher/routed views, not resident home cards. A
 declaration with no registered component and no `uiSpec` simply does not render.
 
 The home is **priority-ranked**, not all-or-nothing: `home-priority.ts`
 (`rankHomeWidgets`) scores each home widget by base `order` plus decayed
-attention signals and returns the top-N, so the most important widgets bubble up
-the way a phone home screen does. Declare your widget; ranking decides placement.
+attention signals and returns the top-N, currently capped at five by
+`HOME_RENDER_CAP` in `WidgetHost.tsx`, so the most important widgets bubble up
+the way a phone home screen does. Declare your widget only if it matches the
+spec's resident bar; ranking decides placement.

--- a/packages/ui/src/widgets/WidgetHost.home-rank.test.tsx
+++ b/packages/ui/src/widgets/WidgetHost.home-rank.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { useEffect, useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   __resetHomeDismissalsForTests,
@@ -11,8 +12,9 @@ import { resolveWidgetsForSlot } from "./registry";
 import type { PluginWidgetDeclaration } from "./types";
 import { WidgetHost } from "./WidgetHost";
 
-// #9143 — the home slot must rank its declared widgets and render only the
-// top-N (HOME_MAX_VISIBLE = 6). Other slots render everything unchanged.
+// #9143 - the home slot must rank its declared widgets and render only the
+// top-N (HOME_RENDER_CAP = 5, spec §E item 2). Other slots render everything
+// unchanged.
 
 const mockAppState = {
   plugins: [{ id: "home-plugin", enabled: true, isActive: true }],
@@ -50,9 +52,9 @@ function homeDecl(id: string, order: number): PluginWidgetDeclaration {
 }
 
 // Ten home widgets with distinct base orders. Lower order = higher base score,
-// so the deterministic ranking surfaces w0..w5 (orders 0..50) and drops the
-// four with the highest orders. Declared out of order to prove the host ranks
-// rather than relying on resolver order.
+// so the deterministic ranking surfaces the top FIVE (w0..w4, orders 0..40) and
+// drops the five with the highest orders (HOME_RENDER_CAP = 5). Declared out of
+// order to prove the host ranks rather than relying on resolver order.
 const HOME_DECLS = [
   homeDecl("w7", 70),
   homeDecl("w2", 20),
@@ -95,19 +97,43 @@ afterEach(() => {
 function renderedIds(): string[] {
   return screen
     .getAllByTestId(/^widget-uispec-/)
+    .filter((el) => !el.hidden)
     .map((el) => el.getAttribute("data-testid")?.replace("widget-uispec-", ""))
     .filter((id): id is string => Boolean(id));
 }
 
+function mountedIds(): string[] {
+  return screen
+    .getAllByTestId(/^widget-uispec-/)
+    .map((el) => el.getAttribute("data-testid")?.replace("widget-uispec-", ""))
+    .filter((id): id is string => Boolean(id));
+}
+
+function visibleAsyncIds(): string[] {
+  return screen
+    .getAllByTestId(/^widget-async-/)
+    .filter((el) => !el.hidden)
+    .map((el) => el.getAttribute("data-testid")?.replace("widget-async-", ""))
+    .filter((id): id is string => Boolean(id));
+}
+
 describe("WidgetHost home-slot ranking (#9143)", () => {
-  it("renders every home widget, ranked by score (lower order first)", () => {
+  it("renders at most HOME_RENDER_CAP (5) home widgets, ranked by score", () => {
     render(<WidgetHost slot="home" />);
 
     const ids = renderedIds();
-    // The home surface renders all declared widgets ranked by importance — each
-    // widget self-hides when empty, so the cap is only a safety bound. These
-    // uiSpec widgets always render, so all 10 appear in base-order.
-    expect(ids).toEqual([
+    // The home surface ranks all declared widgets by importance and renders only
+    // the top five (spec §E item 2: wallpaper + base + notifications + ≤5 cards
+    // + chat bar is the whole surface). These uiSpec widgets always render, so
+    // the five lowest-order (highest base score) survive the cap in base-order,
+    // and the five highest-order are dropped.
+    expect(ids).toEqual(["w0", "w1", "w2", "w3", "w4"]);
+    expect(ids).not.toContain("w5");
+    expect(ids).not.toContain("w9");
+    // The lower-ranked declarations still mount so self-hiding/data widgets can
+    // fetch and publish attention; WidgetHost caps the actual DOM children after
+    // null-rendering widgets disappear.
+    expect(mountedIds()).toEqual([
       "w0",
       "w1",
       "w2",
@@ -121,7 +147,7 @@ describe("WidgetHost home-slot ranking (#9143)", () => {
     ]);
   });
 
-  it("is deterministic — the ranked order is stable across re-renders", () => {
+  it("is deterministic - the ranked order is stable across re-renders", () => {
     const { rerender } = render(<WidgetHost slot="home" />);
     const first = renderedIds();
 
@@ -165,7 +191,70 @@ describe("WidgetHost home-slot ranking (#9143)", () => {
     expect(ids[0]).toBe("w9");
   });
 
-  // #9959 — the show-once-then-sunset lifecycle: a home widget declaring a
+  it("never renders more than HOME_RENDER_CAP (5) cards under a heavy signal load", () => {
+    // Spec §A.4 / §E item 2: the home cap is a HARD ceiling, not just a base-order
+    // trim. Subscribe EVERY declared widget to `blocked` and feed a blocked
+    // event so all ten want to float to the top at once - the pathological
+    // all-active state the cap guards. At most five may render.
+    const allSubscribed = HOME_DECLS.map((d) => ({
+      ...d,
+      signalKinds: ["blocked"] as const,
+    }));
+    vi.mocked(resolveWidgetsForSlot).mockImplementation((slot: string) =>
+      (slot === "home" ? allSubscribed : []).map((declaration) => ({
+        declaration,
+        Component: null,
+      })),
+    );
+
+    render(
+      <WidgetHost
+        slot="home"
+        events={[
+          {
+            id: "e-storm",
+            eventType: "blocked",
+            timestamp: Date.now(),
+            summary: "Everything blocked",
+          },
+        ]}
+      />,
+    );
+
+    expect(renderedIds().length).toBeLessThanOrEqual(5);
+  });
+
+  it("reapplies the five-card cap when widgets render after async data arrives", async () => {
+    function AsyncWidget({ pluginId }: { pluginId: string }) {
+      const [visible, setVisible] = useState(false);
+      useEffect(() => {
+        const timer = setTimeout(() => setVisible(true), 0);
+        return () => clearTimeout(timer);
+      }, []);
+      return visible ? <div data-testid={`widget-async-${pluginId}`} /> : null;
+    }
+
+    const declarations = HOME_DECLS.slice(0, 7).map((decl, index) => ({
+      ...decl,
+      pluginId: `async-${index}`,
+      id: `async-${index}`,
+    }));
+    vi.mocked(resolveWidgetsForSlot).mockImplementation((slot: string) =>
+      (slot === "home" ? declarations : []).map((declaration) => ({
+        declaration,
+        Component: AsyncWidget,
+      })),
+    );
+
+    render(<WidgetHost slot="home" />);
+
+    await waitFor(() =>
+      expect(screen.getAllByTestId(/^widget-async-/)).toHaveLength(7),
+    );
+    await waitFor(() => expect(visibleAsyncIds()).toHaveLength(5));
+  });
+
+  // #9959 - the show-once-then-sunset lifecycle: a home widget declaring a
   // `sunset` policy must be dropped from the ranked home set once its condition
   // is met (here: a dismissible card the user dismissed), while non-sunset
   // widgets stay. This is the WidgetHost-level filter, complementing the

--- a/packages/ui/src/widgets/WidgetHost.tsx
+++ b/packages/ui/src/widgets/WidgetHost.tsx
@@ -1,5 +1,5 @@
 /**
- * WidgetHost — renders all enabled plugin widgets for a named slot.
+ * WidgetHost - renders all enabled plugin widgets for a named slot.
  *
  * Drop this into any page view:
  *   <WidgetHost slot="chat-sidebar" />
@@ -114,12 +114,16 @@ class WidgetErrorBoundary extends Component<
 // -- WidgetHost --------------------------------------------------------------
 
 /**
- * Safety bound on home cards. The home surface ranks every declared widget by
- * importance and renders them in order; each widget self-hides (renders `null`)
- * when it has nothing attention-worthy, so the *visible* count is naturally
- * small. This cap is just a guard against a pathological all-active state.
+ * Hard cap on ranked home residents (spec §A.4 / §B). The whole home surface is
+ * wallpaper + ambient base (clock/weather) + pinned notification center + at
+ * most FIVE ranked cards + the chat bar. The home surface ranks every declared
+ * widget by importance and renders them in order; each widget self-hides
+ * (renders `null`) when it has nothing attention-worthy, so the *visible* count
+ * is naturally smaller still. This cap enforces the ceiling: a phone viewport
+ * never shows more than five cards even in a pathological all-active state.
+ * (docs/design/NOTIFICATIONS-WIDGETS-SYSTEM.md §E item 2.)
  */
-const HOME_RENDER_CAP = 12;
+const HOME_RENDER_CAP = 5;
 const WIDGET_SLOTS: ReadonlySet<string> = new Set<WidgetSlot>([
   "chat-sidebar",
   "character",
@@ -266,7 +270,7 @@ export function WidgetHost({
   ]);
 
   // Notification → signal inputs, memoized so the `now` tick (which re-runs the
-  // component) doesn't rebuild this array each minute — it changes only when the
+  // component) doesn't rebuild this array each minute - it changes only when the
   // inbox itself changes.
   const notificationSignalInputs = useMemo(
     () =>
@@ -310,7 +314,11 @@ export function WidgetHost({
     );
     return rankHomeWidgets(declarations, signals, {
       now,
-      maxVisible: HOME_RENDER_CAP,
+      // Render every ranked declaration so self-hiding widgets can mount, fetch,
+      // and publish their own attention signals. The hard HOME_RENDER_CAP is
+      // applied to actual rendered DOM children below, after null-returning
+      // widgets have self-hidden.
+      maxVisible: renderable.length,
     }).flatMap((ranked) => {
       const entry = byKey.get(homeWidgetKey(ranked.declaration));
       return entry ? [entry] : [];
@@ -329,8 +337,8 @@ export function WidgetHost({
   // but the rendered *set and order* only change at discrete thresholds. Keep
   // the array reference stable across ticks that don't reorder: derive an
   // order-key from the resolved widget keys and only swap `displayed` when that
-  // key changes. This stops the `.map` below — and therefore the widget
-  // children — from rebuilding every minute when nothing moved (#9304). Order
+  // key changes. This stops the `.map` below - and therefore the widget
+  // children - from rebuilding every minute when nothing moved (#9304). Order
   // still updates the instant a signal changes the ranking.
   const orderKey = ranked
     .map(({ declaration }) => homeWidgetKey(declaration))
@@ -343,7 +351,7 @@ export function WidgetHost({
   // Refresh the held set when the order changes OR when the resolved widgets
   // change identity (a plugin reload could keep the order but swap a
   // declaration/Component). A bare `now` tick changes neither, so the reference
-  // — and the rendered children below — stay stable.
+  // - and the rendered children below - stay stable.
   if (
     displayedRef.current.key !== orderKey ||
     displayedRef.current.resolved !== resolved
@@ -358,7 +366,7 @@ export function WidgetHost({
     return map;
   }, [plugins]);
 
-  // The fields every widget shares this render — split out so the per-item props
+  // The fields every widget shares this render - split out so the per-item props
   // object is built from one stable base rather than re-derived inline.
   const widgetPropsBase = useMemo(
     () => ({ events, clearEvents, slot }),
@@ -421,7 +429,7 @@ export function WidgetHost({
 
   // Whether the resolved widgets actually rendered any visible DOM. `children`
   // counts RESOLVED widget elements, but each data widget self-hides (renders
-  // `null`) when it has nothing to show — so the home can resolve the
+  // `null`) when it has nothing to show - so the home can resolve the
   // always-visible cards (notifications, needs-response, …) yet paint nothing.
   // We measure the real rendered child count after layout and, when a `fallback`
   // is supplied (the home's default clock/calendar), show it whenever the
@@ -429,9 +437,30 @@ export function WidgetHost({
   const containerRef = useRef<HTMLDivElement>(null);
   const [renderedEmpty, setRenderedEmpty] = useState(false);
   useLayoutEffect(() => {
-    if (fallback == null) return;
     const el = containerRef.current;
-    setRenderedEmpty(el == null || el.childElementCount === 0);
+
+    const applyDomState = () => {
+      if (slot === "home" && el) {
+        Array.from(el.children).forEach((child, index) => {
+          // Cap ACTUAL DOM children, not declarations: home widgets self-hide by
+          // returning null, and data widgets must mount at least once to fetch
+          // and publish their self-attention. This keeps the visible surface at
+          // five cards without starving lower-order populated cards behind null
+          // ones. MutationObserver below reapplies the cap when async widgets
+          // later switch from null to DOM without rerendering WidgetHost.
+          (child as HTMLElement).hidden = index >= HOME_RENDER_CAP;
+        });
+      }
+      if (fallback != null) {
+        setRenderedEmpty(el == null || el.childElementCount === 0);
+      }
+    };
+
+    applyDomState();
+    if (!el || typeof MutationObserver === "undefined") return;
+    const observer = new MutationObserver(applyDomState);
+    observer.observe(el, { childList: true });
+    return () => observer.disconnect();
   });
 
   // No widget even resolved → render the fallback directly (or hide).

--- a/packages/ui/src/widgets/__fixtures__/home-widget-mock-data.ts
+++ b/packages/ui/src/widgets/__fixtures__/home-widget-mock-data.ts
@@ -2,12 +2,15 @@
  * Browser-safe mock data + installers for the home-slot WidgetHost (#9143).
  *
  * One source of truth for "the home dashboard, populated with attention-worthy
- * data" — shared between the home-screen e2e fixture and the Storybook story so
- * both render the REAL kept home widgets (calendar / goals / health) plus
- * notifications/approvals, fed by injected DATA only
- * (no stubbing of WidgetHost or the widget components).
+ * data" - shared between the home-screen e2e fixture and the Storybook story so
+ * both render the REAL kept home widgets (calendar / Today-todos, with the
+ * at-risk goal folded into the Today card per spec §E item 5) plus
+ * notifications/approvals, fed by injected DATA only (no stubbing of WidgetHost
+ * or the widget components). The goals payload now feeds the Today card's
+ * flagged row rather than a standalone goals resident; the sleep payload is
+ * retained for the routed health surface but no longer renders on home.
  *
- * NO node imports — this is bundled into a browser IIFE (e2e) and into the
+ * NO node imports - this is bundled into a browser IIFE (e2e) and into the
  * Storybook renderer (vite). Times are RELATIVE to `Date.now()` so the calendar
  * card lands inside its 2h urgent window, matching the live ranking the home
  * surface performs.
@@ -26,7 +29,7 @@ import {
 import type { AppContextValue } from "../../state/types";
 
 // ---------------------------------------------------------------------------
-// Plugin snapshot — plugin-gated home widgets resolve only when the matching
+// Plugin snapshot - plugin-gated home widgets resolve only when the matching
 // plugin id is enabled+active in the app-store plugins snapshot
 // (registry.ts `isWidgetEnabled`). Notifications are pinned outside WidgetHost.
 // Mirrors the ui-smoke spec's `pluginInfo()`.
@@ -57,7 +60,7 @@ export const HOME_WIDGET_MOCK_PLUGINS: PluginInfo[] = [
 ];
 
 // ---------------------------------------------------------------------------
-// Relative time helpers — keep the seeded data inside each widget's live
+// Relative time helpers - keep the seeded data inside each widget's live
 // attention window so the cards render AND float up.
 // ---------------------------------------------------------------------------
 
@@ -200,7 +203,7 @@ export function homeWidgetNotificationsResponse() {
 }
 
 // ---------------------------------------------------------------------------
-// Fetch mock — the widgets fetch on mount, so install this BEFORE first render.
+// Fetch mock - the widgets fetch on mount, so install this BEFORE first render.
 // Matches the URL substrings each widget requests (any base) and returns a
 // 200 JSON envelope. Unmatched routes resolve to an empty 200 body so the
 // widgets degrade to null rather than throwing.
@@ -270,7 +273,7 @@ export function installHomeWidgetFetchMock(): () => void {
 }
 
 // ---------------------------------------------------------------------------
-// App-store + notification seeding — the WidgetHost reads the plugins snapshot
+// App-store + notification seeding - the WidgetHost reads the plugins snapshot
 // from the app store (resolveWidgetsForSlot), and HomeScreen's pinned
 // NotificationsHomeCenter reads the notification store. Seed both BEFORE first
 // render.
@@ -280,7 +283,7 @@ const noop = () => {};
 
 /**
  * A minimal {@link AppContextValue} carrying just the slices the home widgets
- * read (`plugins`, `conversations`, `t`) — everything else resolves to a no-op
+ * read (`plugins`, `conversations`, `t`) - everything else resolves to a no-op
  * via the Proxy, mirroring the inert proxy `useApp()` returns in tests. Built
  * inline (no mock-providers import) to keep this module dependency-light and
  * browser-safe for the esbuild e2e bundle.

--- a/packages/ui/src/widgets/home-priority-integration.test.ts
+++ b/packages/ui/src/widgets/home-priority-integration.test.ts
@@ -12,7 +12,7 @@ import { resolveWidgetsForSlot, type WidgetPluginState } from "./registry";
 /**
  * End-to-end wiring scenario (#9143): the REAL home widget declarations (their
  * `signalKinds`) + the REAL ranker, fed realistic attention, must surface the
- * widgets that need attention FIRST — "the priority decides what shows up and
+ * widgets that need attention FIRST - "the priority decides what shows up and
  * when". This guards the declaration↔ranker contract (not individual widget
  * rendering, which the per-widget suites cover): if a future edit drops a
  * widget's `signalKinds` or mis-weights a signal, this scenario fails.
@@ -48,20 +48,24 @@ function rankedKeys(signals: HomeWidgetSignal[]): string[] {
   }).map((r) => homeWidgetKey(r.declaration));
 }
 
-describe("home priority — real declarations + ranker scenario (#9143)", () => {
+describe("home priority - real declarations + ranker scenario (#9143)", () => {
   it("registers only the kept home widgets with attention signalKinds", () => {
     const byKey = new Map(homeDeclarations().map((d) => [homeWidgetKey(d), d]));
-    // Kept cards resolve on the home slot…
+    // Kept cards resolve on the home slot (spec §B target resident set)…
     for (const key of [
       "calendar/calendar.upcoming",
-      "goals/goals.attention",
-      "health/health.sleep",
       "needs-attention/needs-attention.pending",
       "todo/todo.items",
     ]) {
       expect(byKey.has(key), `${key} should resolve on home`).toBe(true);
     }
+    // …while the demoted/merged residents no longer hold a home declaration:
+    // goals.attention merges into the Today (todo) card and health.sleep +
+    // wallet.balance move to their routed dashboards (spec §E items 3-5).
     for (const key of [
+      "goals/goals.attention",
+      "health/health.sleep",
+      "wallet/wallet.balance",
       "agent-orchestrator/agent-orchestrator.activity",
       "agent-orchestrator/agent-orchestrator.apps",
       "feed/feed.agent-activity",
@@ -72,10 +76,7 @@ describe("home priority — real declarations + ranker scenario (#9143)", () => 
     ]) {
       expect(byKey.has(key), `${key} should not resolve on home`).toBe(false);
     }
-    // Kept attention cards still subscribe to signal kinds so they can float up.
-    expect(byKey.get("goals/goals.attention")?.signalKinds).toContain(
-      "escalation",
-    );
+    // The kept calendar card still subscribes to signal kinds so it floats up.
     expect(byKey.get("calendar/calendar.upcoming")?.signalKinds).toContain(
       "reminder",
     );
@@ -83,14 +84,15 @@ describe("home priority — real declarations + ranker scenario (#9143)", () => 
 
   it("floats the widgets that need attention to the front", () => {
     // Realistic moment: an urgent notification arrived and a goal is at-risk.
-    // Both contribute high-weight signals while removed money/inbox widgets stay
-    // absent from the ranked declaration set.
+    // The at-risk goal now lives INSIDE the Today (todo) card (spec §E item 5),
+    // so the card self-publishes the goals escalation weight under its OWN key
+    // (`todo/todo.items`) - the merged resident, not a separate goals card.
     const signals: HomeWidgetSignal[] = [
       ...homeSignalsFromNotifications(
         [{ priority: "urgent", timestamp: NOW }],
         homeDeclarations(),
       ),
-      { widgetKey: "goals/goals.attention", weight: 10, timestamp: NOW },
+      { widgetKey: "todo/todo.items", weight: 10, timestamp: NOW },
     ];
 
     const order = rankedKeys(signals);
@@ -99,14 +101,17 @@ describe("home priority — real declarations + ranker scenario (#9143)", () => 
     // The two attention-worthy widgets occupy the front, ahead of every
     // quiet widget (which rank by static base order only). Needs-attention
     // floats via the urgent-notification derivation (urgent → escalation);
-    // goals rides its own self-published signal.
+    // the Today card rides its merged goal's self-published escalation signal.
     expect(top3).toContain("needs-attention/needs-attention.pending");
-    expect(top3).toContain("goals/goals.attention");
+    expect(top3).toContain("todo/todo.items");
 
     // A quiet widget (calendar with no upcoming-event signal) ranks behind them.
     const calendarRank = order.indexOf("calendar/calendar.upcoming");
-    const goalsRank = order.indexOf("goals/goals.attention");
-    expect(goalsRank).toBeLessThan(calendarRank);
+    const todoRank = order.indexOf("todo/todo.items");
+    expect(todoRank).toBeLessThan(calendarRank);
+
+    // The demoted goals card no longer appears as a standalone resident.
+    expect(order).not.toContain("goals/goals.attention");
   });
 
   it("does not route workflow lifecycle events to removed home cards", () => {

--- a/packages/ui/src/widgets/registry.home.test.ts
+++ b/packages/ui/src/widgets/registry.home.test.ts
@@ -40,7 +40,7 @@ describe("home frontpage widget slot (#9143)", () => {
 
   it("declares NO notifications widget for the home slot (the center is pinned by HomeScreen)", () => {
     // The dashboard notification center (NotificationsHomeCenter) is mounted by
-    // HomeScreen directly, not ranked through the registry — a `notifications.*`
+    // HomeScreen directly, not ranked through the registry - a `notifications.*`
     // home declaration would double-render the inbox.
     const resolved = resolveWidgetsForSlot("home", []);
     expect(
@@ -49,7 +49,7 @@ describe("home frontpage widget slot (#9143)", () => {
   });
 
   it("no longer resolves a standalone Recent conversations tile (#10697)", () => {
-    // The redundant Messages widget was removed — messages fold into the
+    // The redundant Messages widget was removed - messages fold into the
     // notification rail, so the home grid must not resurface a messages tile.
     const resolved = resolveWidgetsForSlot("home", []);
     expect(
@@ -81,5 +81,21 @@ describe("home frontpage widget slot (#9143)", () => {
     const todos = resolved.find((r) => r.declaration.id === "todo.items");
     expect(todos?.declaration.slot).toBe("home");
     expect(todos?.Component).toBeTruthy();
+  });
+
+  it("no longer resolves the demoted wallet / goals / health residents on home (spec §E items 3-5)", () => {
+    // wallet.balance + health.sleep moved to their routed dashboards, and
+    // goals.attention merged into the Today (todo) card, so none of the three
+    // holds a home declaration anymore. Their plugins are enabled here to prove
+    // the demotion is at the declaration level, not the plugin gate.
+    const resolved = resolveWidgetsForSlot("home", [
+      { id: "wallet", enabled: true, isActive: true },
+      { id: "goals", enabled: true, isActive: true },
+      { id: "health", enabled: true, isActive: true },
+    ]);
+    const ids = new Set(resolved.map((r) => r.declaration.id));
+    expect(ids).not.toContain("wallet.balance");
+    expect(ids).not.toContain("goals.attention");
+    expect(ids).not.toContain("health.sleep");
   });
 });

--- a/packages/ui/src/widgets/registry.ts
+++ b/packages/ui/src/widgets/registry.ts
@@ -33,14 +33,16 @@ import { AGENT_ORCHESTRATOR_PLUGIN_WIDGETS } from "../components/chat/widgets/ag
 import { AGENT_PROVISIONING_HOME_WIDGET } from "../components/chat/widgets/agent-provisioning";
 import { BROWSER_STATUS_WIDGET } from "../components/chat/widgets/browser-status.helpers";
 import { CALENDAR_HOME_WIDGET } from "../components/chat/widgets/calendar-upcoming";
-import { GOALS_HOME_WIDGET } from "../components/chat/widgets/goals-attention";
-import { HEALTH_HOME_WIDGET } from "../components/chat/widgets/health-sleep";
 import { MODEL_DOWNLOAD_HOME_WIDGET } from "../components/chat/widgets/model-download";
 import { MUSIC_PLAYER_WIDGET } from "../components/chat/widgets/music-player.helpers";
 import { NEEDS_ATTENTION_HOME_WIDGET } from "../components/chat/widgets/needs-attention";
 import { TODO_PLUGIN_WIDGETS } from "../components/chat/widgets/todo";
 import { TUTORIAL_LAUNCH_HOME_WIDGET } from "../components/chat/widgets/tutorial-launch";
-import { WalletBalanceWidget } from "../components/chat/widgets/wallet-balance";
+
+// The wallet / goals / sleep resident components are no longer registered
+// here: their home declarations were removed (spec §E items 3-5). The components
+// stay in the tree for routed surfaces, tests, and stories, not for the home
+// widget registry.
 
 // -- Seed bundled widgets into the registry ----------------------------------
 
@@ -55,16 +57,15 @@ registerWidgetComponent(
   MusicLibraryCharacterWidget,
 );
 // Curated home-grid widgets backed by core API surfaces. Each renders populated
-// data, a connected-but-empty state, or self-hides — always-visible so the home
+// data, a connected-but-empty state, or self-hides - always-visible so the home
 // grid can surface essential state before the runtime plugin snapshot arrives.
-// Activity, running workflow, inbox, finances, relationships, and orchestrator
-// cards are intentionally kept off home; those domains remain available through
-// launcher/routed views.
-registerWidgetComponent("wallet", "wallet.balance", WalletBalanceWidget);
+// Activity, running workflow, inbox, finances, relationships, wallet, and
+// orchestrator cards are intentionally kept off home; those domains remain
+// available through launcher/routed views.
 // Setup-progress home tiles: the local model download (LOCAL mode, backed by the
 // local-inference hub) and the cloud-agent provisioning handoff (CLOUD mode,
 // backed by the cloud handoff phase event). Neither is a loadable plugin, so
-// both are always-visible and self-hide when there's nothing in flight — the
+// both are always-visible and self-hide when there's nothing in flight - the
 // recommended model finishes downloading, or the dedicated cloud agent attaches.
 registerWidgetComponent(
   MODEL_DOWNLOAD_HOME_WIDGET.pluginId,
@@ -88,13 +89,10 @@ registerWidgetComponent(
 // of its plugin's own state on the home grid, self-hides when empty, and
 // self-publishes a home-attention signal so it floats up on its own data
 // urgency. They resolve only when the plugin is enabled+active in the runtime
-// snapshot.
-for (const w of [
-  CALENDAR_HOME_WIDGET,
-  GOALS_HOME_WIDGET,
-  HEALTH_HOME_WIDGET,
-  NEEDS_ATTENTION_HOME_WIDGET,
-]) {
+// snapshot. Goals + health left this set (spec §E items 4-5): the at-risk goal
+// is absorbed into the Today (todo) card and sleep moved to its routed dashboard,
+// so neither registers a home component here anymore.
+for (const w of [CALENDAR_HOME_WIDGET, NEEDS_ATTENTION_HOME_WIDGET]) {
   registerWidgetComponent(w.pluginId, w.id, w.Component);
 }
 
@@ -128,8 +126,8 @@ export function registerBuiltinWidgetDeclarations(
 
 export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
   // The first-time-user welcome card (greeting + "try saying…" suggestion
-  // chips) was removed deliberately: the agent is proactive on a cold home —
-  // no canned prompt suggestions anywhere on the dashboard.
+  // chips) was removed deliberately: the agent is proactive on a cold home,
+  // with no canned prompt suggestions anywhere on the dashboard.
   // Chat-native tutorial launch remains as the durable, explicit way to rerun
   // onboarding help from the home grid.
   {
@@ -140,7 +138,7 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     icon: "GraduationCap",
     order: TUTORIAL_LAUNCH_HOME_WIDGET.order,
     defaultEnabled: true,
-    // Core FTU surface, not a loadable plugin — always-visible, self-retires.
+    // Core FTU surface, not a loadable plugin - always-visible, self-retires.
     visibility: "always",
     signalKinds: TUTORIAL_LAUNCH_HOME_WIDGET.signalKinds,
     size: TUTORIAL_LAUNCH_HOME_WIDGET.size,
@@ -150,10 +148,10 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
   // notification center (NotificationsHomeCenter) is pinned by HomeScreen
   // directly below the time/weather base, so a registry entry here would
   // double-render the inbox.
-  // The standalone Recent-conversations tile was removed (#10697) — it
+  // The standalone Recent-conversations tile was removed (#10697) - it
   // duplicated the always-present chat overlay. Follow-up-worthy messages now
   // surface as `category: "message"` notifications in the notification rail.
-  // Agent Orchestrator — app runs
+  // Agent Orchestrator - app runs
   {
     id: "agent-orchestrator.apps",
     pluginId: "agent-orchestrator",
@@ -164,7 +162,7 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     defaultEnabled: true,
     visibility: "fallback",
   },
-  // Agent Orchestrator — activity
+  // Agent Orchestrator - activity
   {
     id: "agent-orchestrator.activity",
     pluginId: "agent-orchestrator",
@@ -175,7 +173,7 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     defaultEnabled: true,
     visibility: "fallback",
   },
-  // Todos — the todo plugin's curated LifeOps frontpage widget.
+  // Todos - the todo plugin's curated LifeOps frontpage widget.
   {
     id: "todo.items",
     pluginId: "todo",
@@ -195,7 +193,7 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
   // Home keeps only essential, low-noise cards. Rich domain surfaces like inbox,
   // finances, relationships, workflow activity, feed activity, and orchestrator
   // app runs remain available through launcher/routed views, not resident cards.
-  // Needs response — the canonical "actions requiring your response" card
+  // Needs response - the canonical "actions requiring your response" card
   // (#9449). Backed by the core ApprovalService (GET /api/approvals), not a
   // loadable plugin, so it is always-visible (declaration `visibility:
   // "always"`) and self-hides when nothing is pending. Floats up at
@@ -231,7 +229,7 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
   // Setup progress and wallet remain on home. Other app/domain views are
   // launcher destinations so an idle home does not poll those feature APIs.
   // Local model download (LOCAL mode): surfaces the recommended on-device text
-  // model downloading — queued / %-progress / loading / failed-with-retry — so a
+  // model downloading - queued / %-progress / loading / failed-with-retry - so a
   // fresh "This device" agent shows progress instead of a dead chat. Self-hides
   // when no local model is required (cloud/remote) or every slot is ready.
   {
@@ -243,7 +241,7 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     order: MODEL_DOWNLOAD_HOME_WIDGET.order,
     defaultEnabled: true,
     // Setup-progress tile backed by the local-inference hub, not a loadable
-    // plugin — always-visible, self-hides once the model is ready.
+    // plugin - always-visible, self-hides once the model is ready.
     visibility: "always",
     signalKinds: MODEL_DOWNLOAD_HOME_WIDGET.signalKinds,
     // Full-width, double-height: model download/activation is the one thing
@@ -264,45 +262,26 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     order: AGENT_PROVISIONING_HOME_WIDGET.order,
     defaultEnabled: true,
     // Setup-progress tile backed by the cloud handoff phase, not a loadable
-    // plugin — always-visible, self-hides once the dedicated agent attaches.
+    // plugin - always-visible, self-hides once the dedicated agent attaches.
     visibility: "always",
     signalKinds: AGENT_PROVISIONING_HOME_WIDGET.signalKinds,
     size: { cols: 2, rows: 1 },
   },
-  {
-    id: "wallet.balance",
-    pluginId: "wallet",
-    slot: "home",
-    label: "Wallet",
-    icon: "Wallet",
-    order: 140,
-    defaultEnabled: true,
-    // Core app-core surface, not a separately loadable plugin — always-visible.
-    visibility: "always",
-    signalKinds: ["activity"],
-    size: { cols: 2, rows: 1 },
-  },
-  {
-    id: GOALS_HOME_WIDGET.id,
-    pluginId: GOALS_HOME_WIDGET.pluginId,
-    slot: "home",
-    label: "Goals",
-    icon: "Target",
-    order: GOALS_HOME_WIDGET.order,
-    defaultEnabled: true,
-    signalKinds: GOALS_HOME_WIDGET.signalKinds,
-  },
-  {
-    id: HEALTH_HOME_WIDGET.id,
-    pluginId: HEALTH_HOME_WIDGET.pluginId,
-    slot: "home",
-    label: "Sleep",
-    icon: "Moon",
-    order: HEALTH_HOME_WIDGET.order,
-    defaultEnabled: true,
-    signalKinds: HEALTH_HOME_WIDGET.signalKinds,
-  },
-  // Browser workspace status — surfaces /browser state in the right rail.
+  // The wallet, sleep, and standalone goals residents are NO LONGER home
+  // residents (spec §B "Explicitly NOT residents" / §E items 3-5):
+  //  - wallet: a balance is state, not change. It fails the two-second "what
+  //    changed while I was gone?" rule. The wallet component + routed view stay;
+  //    a material balance delta becomes a producer-side notification instead.
+  //    (See the wallet producer follow-up note in PR #14560; the
+  //    balance-change hook lives store-side, not here.)
+  //  - sleep: yesterday's sleep score is a daily-digest fact, not resting
+  //    urgency; the threshold-crossed alert already travels as a `health`
+  //    notification category. The sleep component + routed dashboard stay; only
+  //    the home declaration is removed.
+  //  - goals: merged into the Today (todo.items) card. An at-risk goal renders
+  //    as one flagged row inside Today and the card self-publishes the goals
+  //    escalation weight. The goals component stays for routed use.
+  // Browser workspace status - surfaces /browser state in the right rail.
   {
     id: BROWSER_STATUS_WIDGET.id,
     pluginId: BROWSER_STATUS_WIDGET.pluginId,
@@ -311,7 +290,7 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     icon: "Globe",
     order: BROWSER_STATUS_WIDGET.order,
     defaultEnabled: BROWSER_STATUS_WIDGET.defaultEnabled,
-    // Core app-core surface (browser-workspace), not a loadable plugin — shows
+    // Core app-core surface (browser-workspace), not a loadable plugin - shows
     // even when the snapshot omits it.
     visibility: "fallback",
   },
@@ -323,7 +302,7 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
     icon: "Music",
     order: MUSIC_PLAYER_WIDGET.order,
     defaultEnabled: MUSIC_PLAYER_WIDGET.defaultEnabled,
-    // Core playback surface, not a loadable plugin — always-visible.
+    // Core playback surface, not a loadable plugin - always-visible.
     visibility: "always",
   },
   {
@@ -345,7 +324,7 @@ export type WidgetPluginState = Pick<PluginInfo, "id" | "enabled" | "isActive">;
 /**
  * Supplementary `fallback`-class plugin ids contributed by third-party callers via
  * `registerBuiltinWidgetDeclarations({ fallbackPluginIds })`. Built-in
- * declarations no longer rely on a hardcoded id set — each carries its own
+ * declarations no longer rely on a hardcoded id set - each carries its own
  * `visibility` flag (#12090 item 9) so a declaration cannot drift out of the
  * allow set when its plugin id changes (e.g. the historical `todo`/`todos`
  * split). This set only extends `fallback` behavior for declarations that don't
@@ -386,7 +365,7 @@ function isWidgetEnabled(
 
   // Some always-visible ids (calendar / health) ARE backed by
   // real loadable plugins, so an explicit "present + disabled" snapshot entry
-  // must still hide them — the always/fallback short-circuits are for core
+  // must still hide them - the always/fallback short-circuits are for core
   // surfaces with NO plugin package (welcome/notifications/needs-attention/
   // wallet/…), which never appear in the snapshot and so pass this check
   // untouched.
@@ -412,7 +391,7 @@ function isWidgetEnabled(
   // Server-provided declarations pre-date the `visibility` flag. Preserve the
   // pre-refactor semantics exactly: an EMPTY snapshot leaves them enabled (the
   // declaration only exists because its plugin sent it, and may have arrived
-  // before the snapshot entry — a race we don't want to hide it), but a
+  // before the snapshot entry - a race we don't want to hide it), but a
   // NON-empty snapshot that OMITS the plugin means the plugin is genuinely
   // absent, so hide it (the old `!plugin -> false` branch).
   if (source === "server") {

--- a/packages/ui/src/widgets/registry.visibility-drift.test.ts
+++ b/packages/ui/src/widgets/registry.visibility-drift.test.ts
@@ -10,7 +10,7 @@
  *   1. No hardcoded pluginId allow/block set survives in the resolver source.
  *   2. Every non-snapshot built-in declaration declares its class explicitly.
  *   3. The `visibility` field, not a set, drives `isWidgetEnabled` for the
- *      no-snapshot (fallback) and always-visible cases — including the exact
+ *      no-snapshot (fallback) and always-visible cases - including the exact
  *      `todo`-vs-`todos` drift that motivated the audit item.
  */
 import { readFileSync } from "node:fs";
@@ -84,7 +84,7 @@ describe("widget visibility drift guard (#12090 item 9)", () => {
     // The drift bug: the hardcoded fallback set held `"todo"` while the app
     // manifest plugin id is `todos`. The declaration uses pluginId `todo` and
     // now carries `visibility: "fallback"`, so it resolves on an empty snapshot
-    // via its own field — no id set to fall out of sync.
+    // via its own field - no id set to fall out of sync.
     const todoDecl = BUILTIN_WIDGET_DECLARATIONS.find(
       (d) => d.id === "todo.items" && d.slot === "home",
     );
@@ -111,7 +111,7 @@ describe("widget visibility drift guard (#12090 item 9)", () => {
 
   it("keeps always-visible core widgets on an empty snapshot but honors explicit disable", () => {
     // Needs-attention is backed by the core ApprovalService, not a loadable
-    // plugin — the canonical `always` core surface with no snapshot entry.
+    // plugin - the canonical `always` core surface with no snapshot entry.
     const emptyResolved = resolveWidgetsForSlot("home", []);
     expect(
       emptyResolved.find((r) => r.declaration.id === "needs-attention.pending"),
@@ -134,25 +134,38 @@ describe("widget visibility drift guard (#12090 item 9)", () => {
   });
 
   it("snapshot-class builtins stay hidden until their plugin is present+active", () => {
-    // A default (snapshot) builtin — health — must NOT appear on an empty
-    // snapshot, and must appear once its plugin is active.
-    const healthDecl = BUILTIN_WIDGET_DECLARATIONS.find(
-      (d) => d.slot === "home" && d.pluginId === "health",
-    );
-    if (!healthDecl) throw new Error("missing health home widget declaration");
-    expect(widgetVisibilityClass(healthDecl, "builtin")).toBe("snapshot");
+    // A default (snapshot) builtin - one that omits the `visibility` flag - must
+    // NOT appear on an empty snapshot, and must appear once its plugin is
+    // active. The prior fixture (health.sleep) left the home slot when goals +
+    // health were demoted (spec §E items 4-5), so this exercises the class via
+    // a temporary registered declaration rather than a live home widget.
+    const decl: PluginWidgetDeclaration = {
+      id: "snapshot-drift.card",
+      pluginId: "snapshot-drift",
+      slot: "home",
+      label: "Snapshot drift",
+      // no `visibility` field → snapshot-gated by default
+    };
+    expect(widgetVisibilityClass(decl, "builtin")).toBe("snapshot");
 
-    const empty = resolveWidgetsForSlot("home", []);
-    expect(
-      empty.find((r) => r.declaration.pluginId === "health"),
-    ).toBeUndefined();
+    registerWidgetComponent(decl.pluginId, decl.id, () => null);
+    BUILTIN_WIDGET_DECLARATIONS.push(decl);
+    try {
+      const empty = resolveWidgetsForSlot("home", []);
+      expect(
+        empty.find((r) => r.declaration.pluginId === "snapshot-drift"),
+      ).toBeUndefined();
 
-    const active = resolveWidgetsForSlot("home", [
-      { id: "health", enabled: true, isActive: true },
-    ]);
-    expect(
-      active.find((r) => r.declaration.pluginId === "health"),
-    ).toBeTruthy();
+      const active = resolveWidgetsForSlot("home", [
+        { id: "snapshot-drift", enabled: true, isActive: true },
+      ]);
+      expect(
+        active.find((r) => r.declaration.pluginId === "snapshot-drift"),
+      ).toBeTruthy();
+    } finally {
+      const i = BUILTIN_WIDGET_DECLARATIONS.indexOf(decl);
+      if (i >= 0) BUILTIN_WIDGET_DECLARATIONS.splice(i, 1);
+    }
   });
 
   it("still honors third-party `fallbackPluginIds` for declarations without a `visibility` flag", () => {
@@ -209,7 +222,7 @@ describe("widget visibility drift guard (#12090 item 9)", () => {
       },
     ];
 
-    // Empty snapshot: race exemption — shown.
+    // Empty snapshot: race exemption - shown.
     expect(
       resolveWidgetsForSlot("home", [], serverDecls).find(
         (r) => r.declaration.id === "srv-omit-test.card",


### PR DESCRIPTION
## Summary
- Tighten the home cap to five visible resident cards while still mounting lower-ranked widgets so self-hiding/data widgets can publish attention before the DOM cap is applied.
- Demote wallet.balance and health.sleep from home registry declarations; routed/widget components remain in-tree.
- Merge goals attention into Today: an at-risk or needs-attention goal renders as a flagged Today row and Today publishes the goals escalation weight under todo.items.
- Update registry/coverage tests, home e2e fixture expectations, taxonomy docs, README, and widget matrix to point at docs/design/NOTIFICATIONS-WIDGETS-SYSTEM.md as the home north-star.

## Wallet producer follow-up
- I did not add a producer-side material balance-change notification hook in this sweep; wiring it cleanly lives store/producer-side rather than in the home registry. The home demotion is in place and the wallet routed/component surface stays intact.

## Verification
- `NODE_OPTIONS="${NODE_OPTIONS:-} --no-experimental-webstorage --disable-warning=ExperimentalWarning" node ../../node_modules/vitest/vitest.mjs run --config ./vitest.config.ts src/components/chat/widgets/todo.test.tsx src/widgets/WidgetHost.home-rank.test.tsx src/widgets/home-priority-integration.test.ts src/widgets/registry.home.test.ts src/widgets/widget-coverage.test.ts src/components/chat/widgets/goals-attention.test.tsx`
  - Test Files 6 passed (6), Tests 42 passed (42)
- Re-ran affected tests after the async DOM-cap fix: `todo.test.tsx` + `WidgetHost.home-rank.test.tsx`
  - Test Files 2 passed (2), Tests 15 passed (15)
- `bun run --cwd packages/app build`
  - `✓ built in 58.08s`
  - process exited 0
- `node_modules/@biomejs/biome/bin/biome check ...changed code files...`
  - Checked 11 files in 145ms. No fixes applied.

## Review
- Ran `codex review --uncommitted`; first pass flagged the pre-self-hide cap starvation and needs-attention fallback. Fixed both. Second pass exceeded 100s and was killed, so I performed a self-review on the partial trace and added the MutationObserver cap reapplier + interval enabled gate.

Refs #14560

[sol-orch]