### PR TITLE
fix(core): allow FORM markers in evaluator replies (#14659)

### DIFF
--- a/packages/core/src/prompts/evaluator.ts
+++ b/packages/core/src/prompts/evaluator.ts
@@ -22,7 +22,8 @@ rules:
 - you cannot call tools; emit no tool args, URL-open JSON, document JSON, or JSON except evaluator result
 - if answer needs unexecuted tool/action side effect to be true => CONTINUE; do not imagine result
 - messageToUser optional progress/diagnosis/question/final
-- messageToUser user-visible; no internal thoughts, tool names, function syntax, JSON/tool attempts, analysis
+- messageToUser user-visible; no internal thoughts, tool names, function syntax, arbitrary JSON/tool attempts, analysis
+- Structured chat markers are allowed in messageToUser when they are the actual user-visible interaction payload: [FORM]\\n{json}\\n[/FORM], [CHOICE:scope id=id]\\nvalue=Label\\n[/CHOICE], [FOLLOWUPS id=id]\\nvalue=Label\\n[/FOLLOWUPS], or [TASK:threadId]Title[/TASK]. The JSON inside [FORM] is form data, not a tool attempt; keep JSON inside the marker and do not emit unrelated JSON.
 - messageToUser human teammate voice; no session ids (pty-*), auto task labels, or sub-agent name lists; speak as agent doing work
 - FINISH after tool use => include concise grounded messageToUser
 - no raw transcripts/banners/logs unless user asked raw output

--- a/packages/core/src/prompts/planner.ts
+++ b/packages/core/src/prompts/planner.ts
@@ -19,7 +19,8 @@ rules:
 - no empty strings/placeholders/invented required args; gather via grounded tool or no tool
 - matching tool exists => call it, even missing details; handler owns questions/drafts/confirm/refusal
 - no messageToUser follow-up when matching tool exists
-- messageToUser is user-visible only; no thoughts, analysis, tool names, function syntax, JSON/tool attempts, "call MESSAGE"
+- messageToUser is user-visible only; no thoughts, analysis, tool names, function syntax, arbitrary JSON/tool attempts, "call MESSAGE"
+- Structured chat markers are allowed in messageToUser when they are the actual user-visible interaction payload: [FORM]\\n{json}\\n[/FORM], [CHOICE:scope id=id]\\nvalue=Label\\n[/CHOICE], [FOLLOWUPS id=id]\\nvalue=Label\\n[/FOLLOWUPS], or [TASK:threadId]Title[/TASK]. The JSON inside [FORM] is form data, not a tool attempt; keep JSON inside the marker and do not emit unrelated JSON.
 - more tool work => native toolCalls only; never narrate/simulate calls
 - partial after tool result => next grounded tool, not messageToUser
 - tool-required router decision => run at least one exposed non-terminal tool before terminal answer

--- a/packages/core/src/runtime/__tests__/evaluator.test.ts
+++ b/packages/core/src/runtime/__tests__/evaluator.test.ts
@@ -5,10 +5,20 @@
  * canned strings, no live model or DB.
  */
 import { describe, expect, it, vi } from "vitest";
+import { evaluatorTemplate } from "../../prompts/evaluator";
 import { ModelType } from "../../types/model";
 import { parseEvaluatorOutput, runEvaluator } from "../evaluator";
 
 describe("v5 evaluator skeleton", () => {
+	it("allows structured chat markers while still banning arbitrary JSON/tool attempts", () => {
+		expect(evaluatorTemplate).toContain("arbitrary JSON/tool attempts");
+		expect(evaluatorTemplate).toContain(
+			"Structured chat markers are allowed in messageToUser",
+		);
+		expect(evaluatorTemplate).toContain("[FORM]\\n{json}\\n[/FORM]");
+		expect(evaluatorTemplate).toContain("The JSON inside [FORM] is form data");
+	});
+
 	it("normalizes evaluator routes and next tool recommendations", () => {
 		const output = parseEvaluatorOutput(`{
   "success": true,
@@ -41,6 +51,22 @@ describe("v5 evaluator skeleton", () => {
 		expect(output.decision).toBe("CONTINUE");
 		expect(output.parseError).toBe("response is not a single JSON object");
 		expect(output.thought).toContain("Invalid evaluator output");
+	});
+
+	it("preserves a form interaction marker with a JSON body in messageToUser", () => {
+		const form =
+			'[FORM]\n{"title":"Connect Discord","fields":[{"name":"token","type":"secret"}]}\n[/FORM]';
+		const output = parseEvaluatorOutput(
+			JSON.stringify({
+				success: false,
+				decision: "FINISH",
+				thought: "Need user input.",
+				messageToUser: form,
+			}),
+		);
+
+		expect(output.messageToUser).toBe(form);
+		expect(output.decision).toBe("FINISH");
 	});
 
 	it("does not salvage claimed success from malformed evaluator text", () => {

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -218,6 +218,15 @@ describe("v5 planner loop skeleton", () => {
 		);
 	});
 
+	it("allows structured chat markers while still banning arbitrary JSON/tool attempts", () => {
+		expect(plannerTemplate).toContain("arbitrary JSON/tool attempts");
+		expect(plannerTemplate).toContain(
+			"Structured chat markers are allowed in messageToUser",
+		);
+		expect(plannerTemplate).toContain("[FORM]\\n{json}\\n[/FORM]");
+		expect(plannerTemplate).toContain("The JSON inside [FORM] is form data");
+	});
+
 	it("forbids phantom in-flight investigative claims in messageToUser/REPLY (planner side)", () => {
 		// Live regression on 2026-05-26: user asked
 		// "look it up bitch" after the bot honestly declined a current-news
@@ -284,6 +293,10 @@ describe("v5 planner loop skeleton", () => {
 			"Optimized planner without bundled safety policy",
 		);
 		expect(systemContent).toContain("mandatory planner policy:");
+		expect(systemContent).toContain(
+			"Structured chat markers are allowed in messageToUser",
+		);
+		expect(systemContent).toContain("[FORM]\\n{json}\\n[/FORM]");
 		expect(systemContent).toContain(
 			"SHELL is for filesystem/process work, not a fallback for chat-message search/recall",
 		);

--- a/packages/core/src/runtime/__tests__/planner-output-safety.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-output-safety.test.ts
@@ -61,6 +61,21 @@ describe("planner output user-visible safety", () => {
 		expect(output.toolCalls).toEqual([]);
 	});
 
+	it("preserves a form interaction marker with a JSON body as visible message text", () => {
+		const form =
+			'[FORM]\n{"title":"Connect Discord","fields":[{"name":"token","type":"secret"}]}\n[/FORM]';
+		const output = parsePlannerOutput(
+			JSON.stringify({
+				thought: "Need the user to provide the connector token.",
+				toolCalls: [],
+				messageToUser: form,
+			}),
+		);
+
+		expect(output.messageToUser).toBe(form);
+		expect(output.toolCalls).toEqual([]);
+	});
+
 	it("classifies raw evaluator envelopes as control JSON, plain JSON as not", () => {
 		expect(
 			looksLikeEvaluatorEnvelopeJson(

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -993,11 +993,13 @@ const MANDATORY_PLANNER_POLICY_LINES = [
 	"SHELL is for filesystem/process work, not a fallback for chat-message search/recall, memory queries, or agent-history lookups.",
 	"candidateActions naming a tool that is not in this turn's exposed tools list is a dead hint",
 	"TASKS_SPAWN_AGENT is for delegating coding/build/repo work",
+	"Structured chat markers are allowed in messageToUser",
 	"messageToUser and REPLY text must NEVER claim or imply",
 ];
 
 const MANDATORY_PLANNER_POLICY = [
 	"mandatory planner policy:",
+	"- Structured chat markers are allowed in messageToUser when they are the actual user-visible interaction payload: [FORM]\\n{json}\\n[/FORM], [CHOICE:scope id=id]\\nvalue=Label\\n[/CHOICE], [FOLLOWUPS id=id]\\nvalue=Label\\n[/FOLLOWUPS], or [TASK:threadId]Title[/TASK]. The JSON inside [FORM] is form data, not a tool attempt; keep JSON inside the marker and do not emit unrelated JSON.",
 	"- SHELL is for filesystem/process work, not a fallback for chat-message search/recall, memory queries, or agent-history lookups. When the user wants chat-message search/recall, memory queries, or agent-history lookups and no dedicated search action (e.g. SEARCH_MESSAGES, MESSAGE_SEARCH, MEMORY_SEARCH) is exposed, do not run shell greps, echo placeholders, or simulate the search — set messageToUser explaining that the capability is not available this turn.",
 	'- candidateActions naming a tool that is not in this turn\'s exposed tools list is a dead hint — do not invent SHELL/BROWSER/TASKS workarounds to fulfill it. Either an exposed tool genuinely resolves the user\'s intent (call it), or no tool fits (set messageToUser). Never emit echo-placeholder SHELL commands such as: echo "<intent-name>" / echo "placeholder for <ACTION>" / echo "search <X>" as a way to "trigger" a missing capability — placeholder echoes burn cost and produce no progress.',
 	'- TASKS_SPAWN_AGENT is for delegating coding/build/repo work to a coding sub-agent (file edits, shell tooling, building/deploying apps, running tests, opening PRs). It is not a fallback for chat-message recall, memory queries, or agent-history lookups. Spawning a coding sub-agent to "search the Discord channel for messages mentioning X" routinely ends in sub-agent error/timeout and a generic "Sorry, something went wrong" reply to the user. When the user wants chat-message recall and no dedicated search action is exposed, set messageToUser explaining the capability is not available — do not spawn a sub-agent for it.',


### PR DESCRIPTION
# Relates to

Part of #14659.

Definition of Done: full standard in [`PR_EVIDENCE.md`](../PR_EVIDENCE.md).

- [x] This PR targets `develop` and was rebased onto latest `origin/develop` before update.
- [x] Focused deterministic verification passed locally for the touched core prompt/runtime path.
- [x] A reviewer can confirm the changed behavior from prompt-contract and parser-preservation tests below.

# What Changed

- Adds an explicit structured-chat-marker carve-out to the planner and evaluator `messageToUser` contracts.
- Keeps the ban on arbitrary JSON/tool attempts; JSON is allowed only as the `[FORM]` marker body, which is the cross-connector interaction payload.
- Extends the optimized-planner mandatory policy append so optimized prompt artifacts also receive the marker carve-out.
- Adds deterministic coverage that `[FORM]\n{json}\n[/FORM]` survives planner/evaluator parsing and remains distinct from internal evaluator/control JSON.

# Testing

```text
bun install --frozen-lockfile --ignore-scripts
# passed

bun run --cwd packages/shared build:i18n
# passed

bun run --cwd packages/logger build
# passed

bun run --cwd packages/core test -- src/runtime/__tests__/planner-loop.test.ts src/runtime/__tests__/planner-output-safety.test.ts src/runtime/__tests__/evaluator.test.ts
# Test Files 3 passed (3); Tests 86 passed (86)

bun run --cwd packages/core typecheck
# passed

bunx biome check packages/core/src/prompts/planner.ts packages/core/src/prompts/evaluator.ts packages/core/src/runtime/planner-loop.ts packages/core/src/runtime/__tests__/planner-loop.test.ts packages/core/src/runtime/__tests__/planner-output-safety.test.ts packages/core/src/runtime/__tests__/evaluator.test.ts
# passed

git diff --check origin/develop...HEAD
# passed

bun run audit:error-policy-ratchet
# no new fallback-slop in touched files
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - no UI renderer changed; this is core prompt/runtime behavior.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI renderer changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend click path changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend process or server log is involved; deterministic Vitest output above proves planner/evaluator prompt contract and parser preservation.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend/network path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no live provider key is present in this shell. The known-red `live-chat-widgets-form-roundtrip` scenario from #14322/#14656 still needs a credentialed live run to capture final model trajectory evidence.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persisted domain artifact is produced by this core prompt/parser change; tests preserve a concrete `[FORM]` interaction marker with JSON body as `messageToUser` through planner/evaluator parsing instead of classifying it as internal JSON/control output.

# Known Gaps

- Live LLM trajectory for `live-chat-widgets-form-roundtrip` was not captured locally because no live provider key is available. This PR removes the structural prompt/parser blocker; #14659 should remain open until a credentialed #14656 scenario run proves form emission and submit consumption end to end.
