### PR TITLE
test(settings): avoid secret-like fixture token

### DIFF
--- a/packages/agent/src/actions/settings-chat-config-ops.test.ts
+++ b/packages/agent/src/actions/settings-chat-config-ops.test.ts
@@ -123,13 +123,13 @@ describe("SETTINGS update_ai_provider — persists to the real config store", ()
     const result = await invoke({
       action: "update_ai_provider",
       provider: "openai",
-      apiKey: "sk-test-openai-key",
+      apiKey: "fixture-openai-api-token",
     });
     expect(result.success).toBe(true);
     // The key must be persisted somewhere reachable via config.env so the
     // switched provider can authenticate on the next boot.
     const raw = fs.readFileSync(configPath, "utf-8");
-    expect(raw).toContain("sk-test-openai-key");
+    expect(raw).toContain("fixture-openai-api-token");
   });
 
   it("rejects a missing provider without touching the store", async () => {


### PR DESCRIPTION
## Summary
- Replaces the `sk-`-prefixed fake OpenAI key in the merged settings-chat config-store test with a scanner-safe fixture token.
- The handler only needs a non-empty API-key string for this persistence assertion, so the test coverage is unchanged.

## Verification
- `bun run --cwd packages/agent vitest run src/actions/settings-chat-config-ops.test.ts` -> 1 file, 12 tests passed
- `bunx @biomejs/biome check packages/agent/src/actions/settings-chat-config-ops.test.ts --no-errors-on-unmatched`
- `git diff --check`

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] N/A - test fixture text only; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test fixture text only; no rendered UI changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user workflow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime path changed; focused agent test log is listed in Verification.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no separate domain artifact; domain proof is the focused real config-store test listed in Verification.
