### PR TITLE
fix(core): remove dead neutral select layout (#14527)

### DIFF
--- a/packages/core/src/messaging/interactions/README.md
+++ b/packages/core/src/messaging/interactions/README.md
@@ -58,9 +58,9 @@ a malformed block is left as plain text, never a broken control.
   markers programmatically (inverse of parse for the text-borne blocks).
 - `toNeutralLayout(block, { resolveUrl, maxButtonsPerRow, maxCallbackBytes })` →
   `NeutralLayout`
-  (rows of buttons / a select) — the shared projection each connector maps to its
-  native primitive. A button carries exactly one of `callbackData` (round-trip) or
-  `url` (link-out).
+  (rows of buttons) — the shared projection each connector maps to its native
+  primitive. A button carries exactly one of `callbackData` (round-trip) or `url`
+  (link-out).
 - `toPlainTextFallback(block, { resolveUrl })` → concise prose for text-only
   transports such as SMS/iMessage, where there is no native control surface.
 - `encodeReplyCallback(value, { maxBytes })` / `decodeCallback(data)` —

--- a/packages/core/src/messaging/interactions/interactions.test.ts
+++ b/packages/core/src/messaging/interactions/interactions.test.ts
@@ -363,6 +363,10 @@ describe("layout", () => {
 		const layout = toNeutralLayout(block, { maxButtonsPerRow: 3 });
 		expect(layout.text).toBe("Pick");
 		expect(layout.rows).toHaveLength(2);
+		expect(layout.rows).toEqual([
+			{ buttons: expect.any(Array) },
+			{ buttons: expect.any(Array) },
+		]);
 		const first = layout.rows[0].buttons?.[0];
 		expect(decodeCallback(first?.callbackData)).toEqual({
 			kind: "reply",

--- a/packages/core/src/messaging/interactions/layout.ts
+++ b/packages/core/src/messaging/interactions/layout.ts
@@ -1,9 +1,8 @@
 /**
- * Project an interaction block onto a platform-neutral control layout — rows of
- * buttons and select menus — that each connector maps to its native primitive
- * (Telegram inline keyboard, Discord action row / string select). Centralizing
- * the projection here keeps every connector's rendering consistent and the
- * per-connector glue thin.
+ * Project an interaction block onto platform-neutral button rows that each
+ * connector maps to its native primitive (Telegram inline keyboard, Discord
+ * action rows). Centralizing the projection here keeps every connector's
+ * rendering consistent and the per-connector glue thin.
  *
  * Buttons round-trip via `callbackData` (the user's answer, re-injected as a
  * message) or open a `url` (link-out for secret entry and task views). A button
@@ -27,15 +26,8 @@ export interface NeutralButton {
 	style?: "primary" | "secondary" | "danger";
 }
 
-export interface NeutralSelect {
-	customId: string;
-	placeholder?: string;
-	options: InteractionOption[];
-}
-
 export interface NeutralRow {
 	buttons?: NeutralButton[];
-	select?: NeutralSelect;
 }
 
 export interface NeutralLayout {


### PR DESCRIPTION
Part of #14527.

## Summary

The shared interaction layout contract advertised a `NeutralSelect` and a `NeutralRow.select` slot, but no block projection produced it and no connector consumed it. Discord now has observable overflow/fallback behavior for over-cap choices, so keeping the dead select seam misrepresented the current connector contract.

This PR removes the unused neutral select type/field and updates the interaction protocol docs to describe the actual shared projection: button rows only. The existing layout regression test now asserts that choice layout rows are button rows.

## Scope

- Remove `NeutralSelect` from `packages/core/src/messaging/interactions/layout.ts`.
- Remove `NeutralRow.select` from the exported neutral layout type.
- Update the interaction README to stop documenting a select projection that does not exist.
- Tighten the deterministic layout test around button-only rows.

Left untouched: Discord DM component delivery, Discord native string-select implementation, modals, embeds, ephemeral behavior, and live Discord evidence.

## Required Evidence Rows

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: N/A - shared TypeScript contract/docs cleanup; no UI rendering path changed.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: N/A - shared TypeScript contract/docs cleanup; no UI rendering path changed.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: N/A - no user-facing flow changed in this PR.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: N/A - no long-running backend service was started; deterministic unit tests cover the changed contract.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - no frontend surface changed.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - no agent/model/prompt behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - no persistent domain artifact is produced.

## Verification

<!-- evidence-row:tests -->
- Tests: `bun run --cwd packages/core test src/messaging/interactions/interactions.test.ts` passed after rebase: 1 file, 49 tests.
<!-- evidence-row:typecheck -->
- Typecheck: `bun run --cwd packages/core typecheck` passed after rebase.
<!-- evidence-row:build -->
- Build: `bun run --cwd packages/core build` passed after rebase across Node, browser, edge, testing bundles, and declarations.
<!-- evidence-row:static-analysis -->
- Static analysis: `bunx @biomejs/biome check --write packages/core/src/messaging/interactions/layout.ts packages/core/src/messaging/interactions/interactions.test.ts packages/core/src/messaging/interactions/README.md` passed; no fixes applied.
<!-- evidence-row:diff-hygiene -->
- Diff hygiene: `git diff --check origin/develop...HEAD` passed after rebase.
<!-- evidence-row:error-policy -->
- Error policy: `bun run audit:error-policy-ratchet --report` passed after rebase: no new fallback slop in touched production files.
<!-- evidence-row:build-prereq -->
- Build prerequisite: local worktree needed `bun install --ignore-scripts`, `node packages/shared/scripts/generate-keywords.mjs --target ts`, and `bun run --cwd packages/cloud/routing build` before core typecheck.