### PR TITLE
fix(#14527): remove dead NeutralSelect seam

### DIFF
--- a/packages/core/src/messaging/interactions/layout.ts
+++ b/packages/core/src/messaging/interactions/layout.ts
@@ -1,9 +1,8 @@
 /**
  * Project an interaction block onto a platform-neutral control layout — rows of
- * buttons and select menus — that each connector maps to its native primitive
- * (Telegram inline keyboard, Discord action row / string select). Centralizing
- * the projection here keeps every connector's rendering consistent and the
- * per-connector glue thin.
+ * buttons that each connector maps to its native primitive (Telegram inline
+ * keyboard, Discord action rows). Centralizing the projection here keeps every
+ * connector's rendering consistent and the per-connector glue thin.
  *
  * Buttons round-trip via `callbackData` (the user's answer, re-injected as a
  * message) or open a `url` (link-out for secret entry and task views). A button
@@ -27,15 +26,8 @@ export interface NeutralButton {
 	style?: "primary" | "secondary" | "danger";
 }
 
-export interface NeutralSelect {
-	customId: string;
-	placeholder?: string;
-	options: InteractionOption[];
-}
-
 export interface NeutralRow {
 	buttons?: NeutralButton[];
-	select?: NeutralSelect;
 }
 
 export interface NeutralLayout {

--- a/plugins/plugin-discord/__tests__/outbound-attachment.test.ts
+++ b/plugins/plugin-discord/__tests__/outbound-attachment.test.ts
@@ -11,6 +11,16 @@ import { ContentType, type Media } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildOutboundDiscordAttachment } from "../utils.ts";
 
+const fetchRemoteMediaMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@elizaos/core", async (importActual) => {
+	const actual = await importActual<typeof import("@elizaos/core")>();
+	return {
+		...actual,
+		fetchRemoteMedia: fetchRemoteMediaMock,
+	};
+});
+
 function media(overrides: Partial<Media>): Media {
 	return {
 		id: "m1",
@@ -23,42 +33,43 @@ function media(overrides: Partial<Media>): Media {
 }
 
 afterEach(() => {
-	vi.unstubAllGlobals();
+	fetchRemoteMediaMock.mockReset();
 });
 
 describe("buildOutboundDiscordAttachment", () => {
 	it("byte-fetches VIDEO bytes into a Buffer-backed attachment on a 200", async () => {
 		const bytes = new Uint8Array([1, 2, 3, 4]);
-		const fetchMock = vi.fn().mockResolvedValue(
-			new Response(bytes, {
-				status: 200,
-				headers: { "content-type": "video/mp4" },
-			}),
-		);
-		vi.stubGlobal("fetch", fetchMock);
+		fetchRemoteMediaMock.mockResolvedValue({
+			buffer: Buffer.from(bytes),
+			contentType: "video/mp4",
+		});
 
 		const att = await buildOutboundDiscordAttachment(media({}));
-		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchRemoteMediaMock).toHaveBeenCalledTimes(1);
+		expect(fetchRemoteMediaMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url: "http://127.0.0.1:8080/v1/media/abc/content",
+			}),
+		);
 		expect(Buffer.isBuffer(att.attachment)).toBe(true);
 		expect(Buffer.from(att.attachment as Buffer)).toEqual(Buffer.from(bytes));
 	});
 
 	it("fails closed for private/internal generated-media URLs when the fetch is not ok", async () => {
-		const fetchMock = vi
-			.fn()
-			.mockResolvedValue(new Response("bad", { status: 502 }));
-		vi.stubGlobal("fetch", fetchMock);
+		fetchRemoteMediaMock.mockRejectedValue(new Error("HTTP 502"));
 
 		const url = "http://127.0.0.1:8080/v1/media/x/content";
 		await expect(
 			buildOutboundDiscordAttachment(media({ url })),
 		).rejects.toThrow("HTTP 502");
-		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchRemoteMediaMock).toHaveBeenCalledTimes(1);
+		expect(fetchRemoteMediaMock).toHaveBeenCalledWith(
+			expect.objectContaining({ url }),
+		);
 	});
 
 	it("fails closed for private/internal generated-media URLs when the fetch throws", async () => {
-		const fetchMock = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
-		vi.stubGlobal("fetch", fetchMock);
+		fetchRemoteMediaMock.mockRejectedValue(new Error("ECONNREFUSED"));
 
 		const url = "http://127.0.0.1:8080/v1/media/y/content";
 		await expect(
@@ -67,38 +78,32 @@ describe("buildOutboundDiscordAttachment", () => {
 	});
 
 	it("does not byte-fetch non-video/audio media (e.g. IMAGE)", async () => {
-		const fetchMock = vi.fn();
-		vi.stubGlobal("fetch", fetchMock);
-
 		const url = "https://cdn.example.com/pic.png";
 		const att = await buildOutboundDiscordAttachment(
 			media({ url, contentType: ContentType.IMAGE }),
 		);
-		expect(fetchMock).not.toHaveBeenCalled();
+		expect(fetchRemoteMediaMock).not.toHaveBeenCalled();
 		expect(att.attachment).toBe(url);
 	});
 
 	it("does not byte-fetch non-generated video/audio URLs", async () => {
-		const fetchMock = vi.fn();
-		vi.stubGlobal("fetch", fetchMock);
-
 		const url = "https://cdn.example.com/video.mp4";
 		const att = await buildOutboundDiscordAttachment(
 			media({ url, source: "user-upload" }),
 		);
-		expect(fetchMock).not.toHaveBeenCalled();
+		expect(fetchRemoteMediaMock).not.toHaveBeenCalled();
 		expect(att.attachment).toBe(url);
 	});
 
 	it("falls back to a URL attachment for public generated-media fetch failures", async () => {
-		const fetchMock = vi
-			.fn()
-			.mockResolvedValue(new Response("bad", { status: 502 }));
-		vi.stubGlobal("fetch", fetchMock);
+		fetchRemoteMediaMock.mockRejectedValue(new Error("HTTP 502"));
 
 		const url = "https://cdn.example.com/video.mp4";
 		const att = await buildOutboundDiscordAttachment(media({ url }));
-		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchRemoteMediaMock).toHaveBeenCalledTimes(1);
+		expect(fetchRemoteMediaMock).toHaveBeenCalledWith(
+			expect.objectContaining({ url }),
+		);
 		expect(att.attachment).toBe(url);
 	});
 });

--- a/plugins/plugin-discord/actions/messageConnector.outbound-media.test.ts
+++ b/plugins/plugin-discord/actions/messageConnector.outbound-media.test.ts
@@ -16,6 +16,16 @@ import { DEFAULT_ACCOUNT_ID } from "../accounts";
 import { DiscordService } from "../service";
 import { buildOutboundDiscordAttachment } from "../utils";
 
+const fetchRemoteMediaMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@elizaos/core", async (importActual) => {
+	const actual = await importActual<typeof import("@elizaos/core")>();
+	return {
+		...actual,
+		fetchRemoteMedia: fetchRemoteMediaMock,
+	};
+});
+
 // Outbound media coverage for the Discord connector (#8876): when the agent
 // generates/sends a message that carries `Media` attachments, the connector
 // send path must map each `Media` to a Discord `AttachmentBuilder` and pass it
@@ -108,7 +118,7 @@ function media(over: Partial<Media>): Media {
 
 describe("Discord connector outbound media", () => {
 	afterEach(() => {
-		vi.unstubAllGlobals();
+		fetchRemoteMediaMock.mockReset();
 	});
 
 	it("maps a Media attachment to a Discord AttachmentBuilder on send (with text)", async () => {
@@ -192,13 +202,10 @@ describe("Discord connector outbound media", () => {
 
 	it("uploads generated video bytes through the guarded media fetch path", async () => {
 		const runtime = createRuntime();
-		const fetchMock = vi.fn(async () => {
-			return new Response(Buffer.from("video-bytes"), {
-				status: 200,
-				headers: { "content-type": "video/mp4" },
-			});
+		fetchRemoteMediaMock.mockResolvedValue({
+			buffer: Buffer.from("video-bytes"),
+			contentType: "video/mp4",
 		});
-		vi.stubGlobal("fetch", fetchMock);
 
 		const file = await buildOutboundDiscordAttachment(
 			media({
@@ -211,7 +218,12 @@ describe("Discord connector outbound media", () => {
 			runtime,
 		);
 
-		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchRemoteMediaMock).toHaveBeenCalledTimes(1);
+		expect(fetchRemoteMediaMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url: "https://cdn.example.com/v1/videos/abc/content",
+			}),
+		);
 		expect(file).toBeInstanceOf(AttachmentBuilder);
 		expect(Buffer.isBuffer(file.attachment)).toBe(true);
 		expect((file.attachment as Buffer).toString()).toBe("video-bytes");
@@ -220,10 +232,6 @@ describe("Discord connector outbound media", () => {
 
 	it("does not fetch private non-generated media URLs server-side", async () => {
 		const runtime = createRuntime();
-		const fetchMock = vi.fn(async () => {
-			throw new Error("must not fetch");
-		});
-		vi.stubGlobal("fetch", fetchMock);
 
 		const privateUrl = "http://192.168.255.164:8080/private/clip.mp4";
 		const file = await buildOutboundDiscordAttachment(
@@ -236,7 +244,7 @@ describe("Discord connector outbound media", () => {
 			runtime,
 		);
 
-		expect(fetchMock).not.toHaveBeenCalled();
+		expect(fetchRemoteMediaMock).not.toHaveBeenCalled();
 		expect(file.attachment).toBe(privateUrl);
 	});
 });

--- a/plugins/plugin-discord/vitest.config.ts
+++ b/plugins/plugin-discord/vitest.config.ts
@@ -1,7 +1,7 @@
 /**
  * Vitest config for the Discord plugin's unit tests. Aliases unbuilt workspace
- * deps (`@elizaos/plugin-commands`, `@elizaos/plugin-meetings`) to their source
- * so tests resolve without a prebuild of those packages.
+ * deps and core interaction contracts to their source so tests resolve without
+ * a prebuild and exercise the current workspace code under review.
  */
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9,6 +9,7 @@ import { defineConfig } from "vitest/config";
 
 const pluginRoot = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(pluginRoot, "../..");
+const coreSrc = path.join(repoRoot, "packages/core/src");
 
 export default defineConfig({
 	resolve: {
@@ -39,6 +40,14 @@ export default defineConfig({
 					repoRoot,
 					"plugins/plugin-meetings/src/index.ts",
 				),
+			},
+			{
+				find: /^@elizaos\/core\/(.*)\.js$/,
+				replacement: path.join(coreSrc, "$1.ts"),
+			},
+			{
+				find: /^@elizaos\/core$/,
+				replacement: path.join(coreSrc, "index.node.ts"),
 			},
 		],
 	},


### PR DESCRIPTION
## Summary
- Remove the unused `NeutralSelect` / `NeutralRow.select` contract from the core neutral interaction layout.
- Update the layout header so the documented cross-platform contract matches the real producer/consumer behavior: button rows only.
- Source-resolve `@elizaos/core` in the Discord Vitest lane so widget tests exercise the current workspace source instead of stale `packages/core/dist` output.
- Tighten Discord outbound media tests to mock the `fetchRemoteMedia` boundary directly after source-resolving core.

Addresses one remaining #14527 acceptance item: `NeutralSelect either has a producer + consumer + tests, or is removed from the layout types.` It does not claim the DM path, overflow/select strategy, modal/embed/ephemeral parity, or live Discord evidence items.

## Verification
- `bun run --cwd packages/core typecheck` - pass.
- `bun run --cwd packages/core test src/messaging/interactions/interactions.test.ts` - pass, 49 tests.
- `bun run --cwd plugins/plugin-discord test` - pass, 38 files / 238 tests.
- `bunx @biomejs/biome check packages/core/src/messaging/interactions/layout.ts plugins/plugin-discord/vitest.config.ts plugins/plugin-discord/__tests__/outbound-attachment.test.ts plugins/plugin-discord/actions/messageConnector.outbound-media.test.ts` - pass.
- `git diff --check` - pass.
- `bun run audit:error-policy-ratchet --report` - pass; 1 changed production source file, no new fallback-slop.
- `rg -n "NeutralSelect|select\?:|row\.select" packages/core/src/messaging/interactions plugins/plugin-discord` - no matches after removal.

## Evidence
<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - no rendered app or Discord UI behavior changed in this lane; this is a type-contract removal plus deterministic connector test resolver update.

<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - no rendered app or Discord UI behavior changed in this lane; deterministic unit tests verify the affected interaction and connector paths.

<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no user-facing flow changed; the broader #14527 issue still needs live Discord capture before the whole issue can close.

<!-- evidence-row:backend-logs -->
- Backend logs: N/A - pure type/test-surface change; no server process or runtime message loop was started.

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A - no frontend, browser, or app route was exercised or changed.

<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no agent planning, prompt, provider, action, evaluator, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - no DB rows, memories, files, or external platform artifacts are produced by removing the dead layout type; static grep confirms no `NeutralSelect` / `row.select` references remain.

## Remaining #14527 Scope
- DM component path remains separately claimed.
- >25-option observable degradation / select strategy remains under the existing overflow lane.
- Discord modal/embed/ephemeral parity remains design/implementation work outside this narrow removal PR.
- Live Discord round-trip evidence remains required for the overall #14527 issue.

Refs #14527