### PR TITLE
fix(ui): summarize submitted form commands in chat

### DIFF
--- a/packages/ui/src/components/chat/MessageContent.slash-command.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.slash-command.test.tsx
@@ -72,4 +72,22 @@ describe("MessageContent slash-command bolding", () => {
     withApp(<MessageContent message={message("user", "just a message")} />);
     expect(screen.queryByTestId("slash-command-token")).toBeNull();
   });
+
+  it("renders a submitted form as a compact receipt instead of raw marker JSON", () => {
+    const { container } = withApp(
+      <MessageContent
+        message={message(
+          "user",
+          '[form:submit reminder-details] {"title":"Draft report","when":"2026-07-08T09:00"}',
+        )}
+      />,
+    );
+
+    expect(screen.getByTestId("form-submit-receipt").textContent).toBe(
+      "Submitted reminder details",
+    );
+    expect(container.textContent ?? "").not.toContain("[form:submit");
+    expect(container.textContent ?? "").not.toContain("Draft report");
+    expect(container.textContent ?? "").not.toContain("2026-07-08T09:00");
+  });
 });

--- a/packages/ui/src/components/chat/MessageContent.stories.tsx
+++ b/packages/ui/src/components/chat/MessageContent.stories.tsx
@@ -4,6 +4,7 @@
  */
 import type { Meta, StoryObj } from "@storybook/react";
 import type { ConversationMessage } from "../../api/client-types-chat";
+import { assert } from "../../storybook/home-widget-decorator";
 import { mockApp } from "../../storybook/mock-providers.helpers";
 import { MessageContent } from "./MessageContent";
 
@@ -52,6 +53,26 @@ export const Multiline: Story = {
     message: makeMessage({
       text: "Here is the plan:\n\n1. Confirm the venue\n2. Send invites\n3. Lock the menu by Friday",
     }),
+  },
+};
+
+/** Submitted inline forms render as a receipt, never raw transport syntax. */
+export const SubmittedInlineForm: Story = {
+  args: {
+    message: makeMessage({
+      role: "user",
+      text: '[form:submit reminder] {"title":"Quarterly report","time":"5pm"}',
+    }),
+  },
+  play: async ({ canvasElement }) => {
+    const text = canvasElement.textContent ?? "";
+    assert(
+      /submitted reminder/i.test(text),
+      "submitted form receipt is visible",
+    );
+    assert(!text.includes("[form:submit"), "transport marker is hidden");
+    assert(!text.includes("Quarterly report"), "field values are hidden");
+    assert(!text.includes("5pm"), "time value is hidden");
   },
 };
 

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -57,6 +57,7 @@ import {
   buildInlinePluginConfigModel,
   isSafeNormalizedPluginId,
   normalizePluginId,
+  parseFormSubmitDisplay,
   parseSegments,
   sensitiveRequestStatusLabel,
   sensitiveRequestTitleLabel,
@@ -134,6 +135,14 @@ function MessageTextBody({
   text: string;
   boldSlashCommand: boolean;
 }) {
+  const formSubmit = boldSlashCommand ? parseFormSubmitDisplay(text) : null;
+  if (formSubmit) {
+    return (
+      <div className="whitespace-normal">
+        <FormSubmitReceipt label={formSubmit.label} />
+      </div>
+    );
+  }
   const slash = boldSlashCommand ? splitLeadingSlashCommand(text) : null;
   return (
     <div className="whitespace-pre-wrap">
@@ -150,6 +159,17 @@ function MessageTextBody({
       ) : (
         renderInlineText(text)
       )}
+    </div>
+  );
+}
+
+export function FormSubmitReceipt({ label }: { label: string }) {
+  return (
+    <div
+      className="inline-flex max-w-full items-center rounded-full border border-border/70 bg-bg px-2.5 py-1 text-xs font-medium text-muted-strong"
+      data-testid="form-submit-receipt"
+    >
+      Submitted {label}
     </div>
   );
 }

--- a/packages/ui/src/components/chat/message-parser-helpers.test.ts
+++ b/packages/ui/src/components/chat/message-parser-helpers.test.ts
@@ -13,6 +13,7 @@ import {
   isUiSpec,
   looksLikePatch,
   normalizeDisplayText,
+  parseFormSubmitDisplay,
   sanitizePatchValue,
   tryParsePatch,
 } from "./message-parser-helpers";
@@ -87,6 +88,26 @@ describe("looksLikePatch + tryParsePatch", () => {
     expect(tryParsePatch("not json")).toBeNull();
     // Looks like a patch but missing required string fields → rejected.
     expect(tryParsePatch('{"op":5,"path":"/x"}')).toBeNull();
+  });
+});
+
+describe("parseFormSubmitDisplay", () => {
+  it("humanizes submitted form commands without exposing values", () => {
+    expect(
+      parseFormSubmitDisplay(
+        '[form:submit reminder-details] {"title":"Draft report"}',
+      ),
+    ).toEqual({ formId: "reminder-details", label: "reminder details" });
+    expect(parseFormSubmitDisplay("[form:submit reminder_details] {}")).toEqual(
+      { formId: "reminder_details", label: "reminder details" },
+    );
+  });
+
+  it("ignores ordinary prose and assistant form widgets", () => {
+    expect(
+      parseFormSubmitDisplay("hello [form:submit reminder] {}"),
+    ).toBeNull();
+    expect(parseFormSubmitDisplay("[FORM]\n{}")).toBeNull();
   });
 });
 

--- a/packages/ui/src/components/chat/message-parser-helpers.ts
+++ b/packages/ui/src/components/chat/message-parser-helpers.ts
@@ -90,6 +90,7 @@ export const FENCED_CODE_RE = /```([^\n`]*)\n([\s\S]*?)```/g;
  * must be non-empty so a stray pair of backticks isn't lifted out.
  */
 export const INLINE_CODE_RE = /`([^`\n]+)`/g;
+export const FORM_SUBMIT_DISPLAY_RE = /^\[form:submit\s+([^\]\s]+)\]/;
 
 export const HIDDEN_TAG_BLOCK_RE =
   /<(think|analysis|reasoning|tool_calls?|tools?)\b[^>]*>[\s\S]*?(?:<\/\1>|$)/gi;
@@ -119,6 +120,27 @@ export function normalizeDisplayText(text: string): string {
 
   normalized = stripAssistantStageDirections(normalized);
   return normalized.trim();
+}
+
+export interface FormSubmitDisplay {
+  formId: string;
+  label: string;
+}
+
+export function humanizeFormSubmitId(formId: string): string {
+  return formId.replace(/[-_]+/g, " ").trim() || "form";
+}
+
+/**
+ * User form submissions are transport commands stored in the transcript so the
+ * agent can consume them. Display surfaces render a receipt instead of echoing
+ * the protocol marker or submitted values back to the user.
+ */
+export function parseFormSubmitDisplay(text: string): FormSubmitDisplay | null {
+  const match = FORM_SUBMIT_DISPLAY_RE.exec(text.trimStart());
+  if (!match) return null;
+  const formId = match[1];
+  return { formId, label: humanizeFormSubmitId(formId) };
 }
 
 export function tryParse(s: string): unknown {

--- a/packages/ui/src/components/shell/ChatSurface.test.tsx
+++ b/packages/ui/src/components/shell/ChatSurface.test.tsx
@@ -57,6 +57,22 @@ describe("ChatSurface composer (shared core)", () => {
     expect(scroller?.className).toContain("overflow-x-hidden");
   });
 
+  it("renders user form submissions as a compact summary without protocol values", () => {
+    const raw =
+      '[form:submit reminder] {"title":"Quarterly report","time":"5pm"}';
+    const { container } = render(
+      surface({
+        messages: [{ id: "u1", role: "user", content: raw, createdAt: 1 }],
+      }),
+    );
+    expect(screen.getByTestId("form-submit-receipt").textContent).toBe(
+      "Submitted reminder",
+    );
+    expect(container.textContent ?? "").not.toContain("[form:submit");
+    expect(container.textContent ?? "").not.toContain("Quarterly report");
+    expect(container.textContent ?? "").not.toContain("5pm");
+  });
+
   it("never sends on the Enter that commits an IME composition (#9148)", () => {
     const onSend = vi.fn();
     render(surface({ onSend }));

--- a/packages/ui/src/components/shell/ChatSurface.tsx
+++ b/packages/ui/src/components/shell/ChatSurface.tsx
@@ -20,6 +20,8 @@ import { cn } from "../../lib/utils";
 import { useChatComposerOrLocal } from "../../state/ChatComposerContext.hooks";
 import { useTranslation } from "../../state/TranslationContext.hooks";
 import { InlineWidgetText } from "../chat/InlineWidgetText";
+import { FormSubmitReceipt } from "../chat/MessageContent";
+import { parseFormSubmitDisplay } from "../chat/message-parser-helpers";
 import { ChatBubble } from "../composites/chat/chat-bubble";
 import { TypingIndicator } from "../composites/chat/chat-typing-indicator";
 import { Input } from "../ui/input";
@@ -47,6 +49,12 @@ export interface ChatSurfaceProps {
   onVision?: () => void;
   /** Reflects an in-flight vision capture (pulses the VISION button). */
   visionActive?: boolean;
+}
+
+function UserMessageContent({ content }: { content: string }) {
+  const formSubmit = parseFormSubmitDisplay(content);
+  if (formSubmit) return <FormSubmitReceipt label={formSubmit.label} />;
+  return content;
 }
 
 export function ChatSurface({
@@ -156,7 +164,7 @@ export function ChatSurface({
                         className="text-sm"
                       >
                         {isUser ? (
-                          message.content
+                          <UserMessageContent content={message.content} />
                         ) : (
                           <InlineWidgetText content={message.content} />
                         )}

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -85,8 +85,12 @@ import {
 } from "../../utils/image-attachment";
 import { InlineWidgetText } from "../chat/InlineWidgetText";
 import { MessageAttachments } from "../chat/MessageAttachments";
-import { SensitiveRequestBlock } from "../chat/MessageContent";
+import {
+  FormSubmitReceipt,
+  SensitiveRequestBlock,
+} from "../chat/MessageContent";
 import { findChoiceRegions } from "../chat/message-choice-parser";
+import { parseFormSubmitDisplay } from "../chat/message-parser-helpers";
 import { MessageSearchPanel } from "../chat/message-search/MessageSearchPanel";
 import { ThinkingBlock } from "../chat/ThinkingBlock";
 import { withTranscriptMarker } from "../chat/TranscriptViewerOverlay";
@@ -666,6 +670,8 @@ function TurnStatusIndicator({
  * inline autocomplete). Plain prose renders unchanged.
  */
 function ThreadLineText({ content }: { content: string }): React.ReactNode {
+  const formSubmit = parseFormSubmitDisplay(content);
+  if (formSubmit) return <FormSubmitReceipt label={formSubmit.label} />;
   const slash = splitLeadingSlashCommand(content);
   if (!slash) return content;
   return (

--- a/packages/ui/src/components/shell/__tests__/ContinuousChatOverlay.suggestion.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/ContinuousChatOverlay.suggestion.test.tsx
@@ -100,6 +100,20 @@ describe("ContinuousChatOverlay ThreadLine proactive suggestion (#8792)", () => 
     ).toBeNull();
   });
 
+  it("renders user form submissions as a compact summary without protocol values", () => {
+    const raw =
+      '[form:submit reminder] {"title":"Quarterly report","time":"5pm"}';
+    const { container } = withApp(
+      __renderThreadLineForParity(makeMessage({ role: "user", content: raw })),
+    );
+    expect(screen.getByTestId("form-submit-receipt").textContent).toBe(
+      "Submitted reminder",
+    );
+    expect(container.textContent ?? "").not.toContain("[form:submit");
+    expect(container.textContent ?? "").not.toContain("Quarterly report");
+    expect(container.textContent ?? "").not.toContain("5pm");
+  });
+
   it("dismiss removes by id; accept receives the full message", () => {
     const onAcceptSuggestion = vi.fn();
     const onDismissSuggestion = vi.fn();


### PR DESCRIPTION
## Summary
Refs #14322.

This keeps raw `[form:submit <id>] {json}` messages available to the agent while rendering user transcript bubbles as a compact receipt instead of protocol syntax. The display now shows `Submitted <humanized form id>` across the full chat message renderer, continuous overlay thread line, and shared `ChatSurface` renderer, without echoing submitted field values back onto screen.

After rebasing onto current `develop`, this PR keeps submitted-form display as a small user-transport parser (`parseFormSubmitDisplay`) separate from assistant inline widgets. That matches the current registry-driven assistant widget parser while still hiding user-side transport syntax in every chat surface.

## Verification
- `bun install --frozen-lockfile --ignore-scripts`
  - Passed in the fresh PR worktree.
- `bun run --cwd packages/shared build:i18n`
  - Passed.
- `bun run --cwd packages/logger build`
  - Passed.
- `bun run --cwd packages/cloud/routing build`
  - Passed; needed before UI tests in a fresh worktree.
- `bun run --cwd packages/ui test -- src/components/chat/message-parser-helpers.test.ts src/components/chat/MessageContent.slash-command.test.tsx src/components/shell/__tests__/ContinuousChatOverlay.suggestion.test.tsx src/components/shell/ChatSurface.test.tsx`
  - 4 files passed, 35 tests passed.
- `bunx biome check packages/ui/src/components/chat/message-parser-helpers.ts packages/ui/src/components/chat/message-parser-helpers.test.ts packages/ui/src/components/chat/MessageContent.tsx packages/ui/src/components/chat/MessageContent.stories.tsx packages/ui/src/components/chat/MessageContent.slash-command.test.tsx packages/ui/src/components/shell/ChatSurface.tsx packages/ui/src/components/shell/ChatSurface.test.tsx packages/ui/src/components/shell/ContinuousChatOverlay.tsx packages/ui/src/components/shell/__tests__/ContinuousChatOverlay.suggestion.test.tsx`
  - Clean.
- `bun run --cwd packages/ui build-storybook --output-dir storybook-static --quiet`
  - Passed with existing Vite warnings.
- `node packages/ui/test/story-gate/run-story-gate.mjs --static-dir packages/ui/storybook-static --out test/story-gate/output-14322-submitted-form --concurrency 1 --grep "Chat/MessageContent/Submitted Inline Form"`
  - 1 story, good=1, broken=0, console errors=0, a11y=0, play=1/1.
  - Story play asserts the receipt is visible and `[form:submit`, `Quarterly report`, and `5pm` are not rendered.
- `ELIZA_NODE_PATH="$(bunx --bun node@24 -p 'process.execPath')" bun run --cwd packages/app audit:app`
  - 365 Playwright checks passed in 13.8m on the latest `develop` base.
  - Built-in chat viewports were all `good`: mobile portrait, mobile landscape, desktop landscape, iPad portrait.
  - Whole-audit computed summary: broken=0, strict failures=0; existing non-strict backlog remains needs-work=123, needs-eyeball=33, hover-probe-failures=64.
- `git diff --check origin/develop...HEAD`
  - Clean.
- `bun run audit:error-policy-ratchet --report`
  - Passed: no new fallback-slop in touched files.

## Manual visual review
- Storybook screenshot reviewed by eye: expected a terse receipt pill, no raw transport marker, no submitted values, and no added buttons/clutter. Actual: `Submitted reminder` rendered as a compact chip on the existing dark chat surface.
- OCR/color heuristic over `packages/ui/test/story-gate/output-14322-submitted-form/screenshots/chat-messagecontent--submitted-inline-form.png`: 1280x800; OCR text `Submitted reminder`; dominant quantized bucket `rgb(16,16,0)` at 99.18%; no raw marker/value text visible.
- App audit screenshots reviewed for `/chat` desktop and mobile: desktop content/composer were clear; mobile portrait’s only noted overlap was the small `ui-smoke` test badge, with computed chat verdict still `good`, no console errors, no blue colors, and no horizontal overflow.

## Evidence Rows
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - this PR covers an isolated regression state; the pre-fix failure is represented by tests asserting raw [form:submit] syntax and submitted values are no longer rendered.`

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: generated by Storybook story-gate at [submitted-form screenshot](packages/ui/test/story-gate/output-14322-submitted-form/screenshots/chat-messagecontent--submitted-inline-form.png) and by app audit at [desktop chat screenshot](packages/app/aesthetic-audit-output/desktop-landscape/builtin-chat.png), [mobile portrait chat screenshot](packages/app/aesthetic-audit-output/mobile-portrait/builtin-chat.png), [mobile landscape chat screenshot](packages/app/aesthetic-audit-output/mobile-landscape/builtin-chat.png), and [iPad chat screenshot](packages/app/aesthetic-audit-output/ipad-portrait/builtin-chat.png).

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - static transcript render-state fix; Storybook play assertions and app audit screenshots cover the exercised UI state without a multi-step user flow.`

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - UI render-only change; no backend request path changed or required for the submitted-form receipt.`

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: [story-gate report](packages/ui/test/story-gate/output-14322-submitted-form/report.json) recorded consoleMessages=0, consoleErrors=0, pageErrors=0, failedResponses=0, requestFailures=0 for `chat-messagecontent--submitted-inline-form`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent planner/model behavior changed; the raw form-submit command remains the same transcript input and only the renderer presentation changed.`

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no database, memory, scheduled-task, wallet, file-store, or connector artifact is produced by this display-only change.`
