### PR TITLE
fix(ui): quiet unauthenticated slash catalog loads

### DIFF
--- a/packages/ui/src/chat/useSlashCommandController.catalog.test.ts
+++ b/packages/ui/src/chat/useSlashCommandController.catalog.test.ts
@@ -20,6 +20,7 @@ import type {
   CommandSurface,
   SlashCommandCatalogItem,
 } from "../api/client-types-commands";
+import { ApiError } from "../api/client-types-core";
 
 const { listCommands, listCustomActions } = vi.hoisted(() => ({
   listCommands:
@@ -73,6 +74,15 @@ function cmd(
 }
 
 const GUI: CommandSurface = "gui";
+
+function apiError(status: number, message: string): ApiError {
+  return new ApiError({
+    kind: "http",
+    path: "/api/slash-command-catalog",
+    status,
+    message,
+  });
+}
 
 beforeEach(() => {
   listCommands.mockReset();
@@ -154,6 +164,22 @@ describe("useSlashCommandController — catalog load (#11112)", () => {
     consoleError.mockRestore();
   });
 
+  it("quietly treats unauthenticated catalog endpoints as an unavailable slash menu (#14663)", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    listCommands.mockRejectedValue(apiError(401, "Unauthorized"));
+    listCustomActions.mockRejectedValue(apiError(403, "Forbidden"));
+
+    const { result } = renderHook(() => useSlashCommandController());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.commands).toEqual([]);
+    expect(result.current.error).toBe(false);
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
   it("a failed catalog fetch degrades to an empty catalog AND surfaces the error", async () => {
     const consoleError = vi
       .spyOn(console, "error")
@@ -167,6 +193,25 @@ describe("useSlashCommandController — catalog load (#11112)", () => {
     expect(result.current.commands).toEqual([]);
     // #12784 three-state: a failed load must be distinguishable from a genuine
     // empty catalog — `error` is true, not a silent healthy-empty.
+    expect(result.current.error).toBe(true);
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining("[useSlashCommandController]"),
+      failure,
+    );
+    consoleError.mockRestore();
+  });
+
+  it("still surfaces non-auth API catalog failures", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const failure = apiError(500, "Internal server error");
+    listCommands.mockRejectedValue(failure);
+
+    const { result } = renderHook(() => useSlashCommandController());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.commands).toEqual([]);
     expect(result.current.error).toBe(true);
     expect(consoleError).toHaveBeenCalledWith(
       expect.stringContaining("[useSlashCommandController]"),

--- a/packages/ui/src/chat/useSlashCommandController.ts
+++ b/packages/ui/src/chat/useSlashCommandController.ts
@@ -13,6 +13,7 @@ import type {
   CommandArgSource,
   SlashCommandCatalogItem,
 } from "../api/client-types-commands";
+import { isApiError } from "../api/client-types-core";
 import {
   resolveSettingsSectionToken,
   SETTINGS_SECTION_SUGGESTIONS,
@@ -181,6 +182,10 @@ function savedCommandToCommand(name: string): SlashCommandCatalogItem {
   };
 }
 
+function isExpectedCatalogAuthError(error: unknown): boolean {
+  return isApiError(error) && (error.status === 401 || error.status === 403);
+}
+
 /** Merge catalogs, keeping the first definition for any duplicated alias. */
 function mergeByAlias(
   groups: SlashCommandCatalogItem[][],
@@ -252,6 +257,14 @@ export function useSlashCommandController(
         // error-policy:J4 degrade to an empty catalog with the failure logged
         // + flagged (not fabricated as a healthy-empty catalog).
         .catch((error: unknown) => {
+          // A 401/403 means the viewer isn't authenticated (or the agent
+          // session lapsed) — the catalog is legitimately unavailable, not a
+          // diagnosable failure. Degrade quietly rather than console.error-
+          // storming the logged-out agent app (#14663). Real failures still
+          // surface via loadFailed + the log below.
+          if (isExpectedCatalogAuthError(error)) {
+            return [];
+          }
           loadFailed = true;
           console.error(
             "[useSlashCommandController] Failed to load the slash-command catalog; slash menu will be empty",
@@ -263,6 +276,11 @@ export function useSlashCommandController(
         .listCustomActions()
         // error-policy:J4 omit custom actions with the failure logged + flagged.
         .catch((error: unknown) => {
+          // See above: an unauthenticated 401/403 is expected, not a failure —
+          // degrade quietly instead of logging (#14663).
+          if (isExpectedCatalogAuthError(error)) {
+            return [];
+          }
           loadFailed = true;
           console.error(
             "[useSlashCommandController] Failed to load custom actions; omitting them from the slash menu",


### PR DESCRIPTION
## Summary

Partial fix for #14663. `useSlashCommandController` fetches the slash-command catalog and custom actions when the logged-out agent app mounts. When the viewer has no valid session, those endpoints can legitimately return 401/403; that means the slash menu is unavailable, not that the app needs to emit console errors.

Changes:
- Treat catalog/custom-action 401 and 403 `ApiError`s as expected unauthenticated state.
- Return an empty slash menu without setting the degraded `error` flag or calling `console.error` for those auth failures.
- Preserve the existing degraded `error=true` plus `console.error` behavior for non-auth failures such as 500s.
- Add hook-level regression tests for both the quiet 401/403 path and preserved non-auth logging.

This only covers the slash-controller share of the logged-out console storm; the stale-agent boot polling noted in #14663 remains separate.

## Verification

- `bun run --cwd packages/ui test -- src/chat/useSlashCommandController.catalog.test.ts` -> 1 file passed, 10 tests passed.
- `bunx @biomejs/biome check packages/ui/src/chat/useSlashCommandController.ts packages/ui/src/chat/useSlashCommandController.catalog.test.ts --no-errors-on-unmatched` -> no fixes applied.
- `git diff --check origin/develop...HEAD` -> clean.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - hook-level console/error-state change only; no rendered UI layout changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - no rendered UI changed; the slash menu unavailable state is covered by the focused hook test`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no user-facing flow changed; this suppresses expected unauthenticated console noise`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no backend service path changed`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - not captured as browser artifact in this PR; regression test spies `console.error` and proves 401/403 auth failures do not log while 500 failures still do`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model/action/prompt behavior changed`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no persistent domain artifact is produced; the relevant artifact is the hook state/logging behavior covered by the test`.
