### PR TITLE
fix(core): surface prompt runner task output

### DIFF
--- a/packages/core/src/features/basic-capabilities/prompt-runner-task.test.ts
+++ b/packages/core/src/features/basic-capabilities/prompt-runner-task.test.ts
@@ -97,6 +97,54 @@ describe("prompt-runner TaskWorker", () => {
 		expect(assistantMemory.content.inReplyTo).toBe(capturedMessage?.id);
 	});
 
+	it("does not duplicate simple responses already persisted by the message service", async () => {
+		let capturedMessage: Memory | null = null;
+		const { runtime, useModel, createMemory } = makeRuntime();
+		const responseMemory: Memory = {
+			id: crypto.randomUUID() as UUID,
+			entityId: AGENT_ID,
+			agentId: AGENT_ID,
+			roomId: crypto.randomUUID() as UUID,
+			content: {
+				text: "I sent the morning summary.",
+				actions: ["REPLY"],
+			},
+			createdAt: Date.now(),
+		};
+		const messageService = {
+			handleMessage: vi.fn(
+				async (
+					_runtime: IAgentRuntime,
+					message: Memory,
+					callback?: HandlerCallback,
+				) => {
+					capturedMessage = message;
+					await createMemory(responseMemory, "messages");
+					await callback?.(responseMemory.content);
+					return {
+						didRespond: true,
+						responseContent: responseMemory.content,
+						responseMessages: [responseMemory],
+						mode: "simple" as const,
+					};
+				},
+			),
+		} as unknown as IMessageService;
+		runtime.messageService = messageService;
+
+		await promptRunnerTaskWorker.execute(
+			runtime,
+			{},
+			makeTask("send the morning summary"),
+		);
+
+		expect(useModel).not.toHaveBeenCalled();
+		expect(messageService.handleMessage).toHaveBeenCalledTimes(1);
+		expect(capturedMessage?.content.source).toBe("prompt-runner");
+		expect(createMemory).toHaveBeenCalledTimes(1);
+		expect(createMemory).toHaveBeenCalledWith(responseMemory, "messages");
+	});
+
 	it("falls back to TEXT_LARGE and stores the generated text when no message service is available", async () => {
 		const { runtime, useModel, createMemory } = makeRuntime();
 

--- a/packages/core/src/features/basic-capabilities/prompt-runner-task.test.ts
+++ b/packages/core/src/features/basic-capabilities/prompt-runner-task.test.ts
@@ -1,12 +1,16 @@
 /**
  * Unit coverage for the prompt-runner `TaskWorker` (`promptRunnerTaskWorker`):
- * it wraps a scheduled task's `metadata.prompt` in the system prompt, calls
- * `TEXT_LARGE` with `background` priority, and rejects a missing or empty
- * prompt. Deterministic harness — a stub runtime whose `useModel` is a `vi.fn`,
- * no live model.
+ * it runs scheduled prompt tasks through the message-service loop when present,
+ * persists produced assistant text, falls back to background `TEXT_LARGE` when
+ * no message service is available, and rejects a missing or empty prompt.
+ * Deterministic harness — stub runtime functions, no live model.
  */
 import { describe, expect, it, vi } from "vitest";
+import type { HandlerCallback } from "../../types/components";
+import type { Memory } from "../../types/memory";
+import type { IMessageService } from "../../types/message-service";
 import { ModelType } from "../../types/model";
+import type { UUID } from "../../types/primitives";
 import type { IAgentRuntime } from "../../types/runtime";
 import type { Task } from "../../types/task";
 import {
@@ -27,14 +31,74 @@ function makeTask(prompt: unknown): Task {
 	} satisfies Task;
 }
 
-function runtimeWithModel(useModel: IAgentRuntime["useModel"]): IAgentRuntime {
-	return { useModel } as IAgentRuntime;
+const AGENT_ID = "00000000-0000-0000-0000-000000000001" as UUID;
+
+function makeRuntime(overrides: Partial<IAgentRuntime> = {}) {
+	const useModel = vi.fn(async () => "the scheduled report is done");
+	const createMemory = vi.fn(async () => crypto.randomUUID() as UUID);
+	const runtime = {
+		agentId: AGENT_ID,
+		useModel,
+		createMemory,
+		messageService: null,
+		...overrides,
+	} as unknown as IAgentRuntime;
+	return { runtime, useModel, createMemory };
 }
 
 describe("prompt-runner TaskWorker", () => {
-	it("invokes TEXT_LARGE with the system prompt wrapping the task prompt", async () => {
-		const useModel = vi.fn(async () => "ok");
-		const runtime = runtimeWithModel(useModel as IAgentRuntime["useModel"]);
+	it("runs prompt tasks through the message service and persists the callback response", async () => {
+		let capturedMessage: Memory | null = null;
+		const messageService = {
+			handleMessage: vi.fn(
+				async (
+					_runtime: IAgentRuntime,
+					message: Memory,
+					callback?: HandlerCallback,
+				) => {
+					capturedMessage = message;
+					await callback?.({
+						text: "I sent the morning summary.",
+						actions: ["SEND_MESSAGE"],
+					});
+					return {
+						didRespond: true,
+						responseContent: { text: "I sent the morning summary." },
+						responseMessages: [],
+					};
+				},
+			),
+		} as unknown as IMessageService;
+		const { runtime, useModel, createMemory } = makeRuntime({
+			messageService,
+		});
+
+		await promptRunnerTaskWorker.execute(
+			runtime,
+			{},
+			makeTask("send the morning summary"),
+		);
+
+		expect(useModel).not.toHaveBeenCalled();
+		expect(messageService.handleMessage).toHaveBeenCalledTimes(1);
+		expect(capturedMessage?.content.text).toContain("scheduled task");
+		expect(capturedMessage?.content.text).toContain("send the morning summary");
+		expect(capturedMessage?.content.source).toBe("prompt-runner");
+		expect(createMemory).toHaveBeenCalledTimes(1);
+		const [assistantMemory, table] = createMemory.mock.calls[0] as [
+			Memory,
+			string,
+		];
+		expect(table).toBe("messages");
+		expect(assistantMemory.entityId).toBe(AGENT_ID);
+		expect(assistantMemory.content.text).toBe("I sent the morning summary.");
+		expect(assistantMemory.content.actions).toEqual(["SEND_MESSAGE"]);
+		expect(assistantMemory.content.source).toBe("prompt-runner");
+		expect(assistantMemory.content.inReplyTo).toBe(capturedMessage?.id);
+	});
+
+	it("falls back to TEXT_LARGE and stores the generated text when no message service is available", async () => {
+		const { runtime, useModel, createMemory } = makeRuntime();
 
 		await promptRunnerTaskWorker.execute(
 			runtime,
@@ -45,46 +109,40 @@ describe("prompt-runner TaskWorker", () => {
 		expect(useModel).toHaveBeenCalledTimes(1);
 		const [modelType, params] = useModel.mock.calls[0] as [
 			string,
-			{ prompt: string },
+			{ prompt: string; priority?: string },
 		];
 		expect(modelType).toBe(ModelType.TEXT_LARGE);
 		expect(params.prompt).toContain("scheduled task");
 		expect(params.prompt).toContain("send the morning summary");
-	});
-
-	it("marks the scheduled generation background so single-lane local backends deprioritize and budget it (#11914)", async () => {
-		const useModel = vi.fn(async () => "ok");
-		const runtime = runtimeWithModel(useModel as IAgentRuntime["useModel"]);
-
-		await promptRunnerTaskWorker.execute(
-			runtime,
-			{},
-			makeTask("summarize the day"),
-		);
-
-		const [, params] = useModel.mock.calls[0] as [
-			string,
-			{ priority?: string },
-		];
 		expect(params.priority).toBe("background");
+		expect(createMemory).toHaveBeenCalledTimes(2);
+		const [inputMemory] = createMemory.mock.calls[0] as [Memory, string];
+		const [assistantMemory, table] = createMemory.mock.calls[1] as [
+			Memory,
+			string,
+		];
+		expect(table).toBe("messages");
+		expect(inputMemory.content.source).toBe("prompt-runner");
+		expect(assistantMemory.content.text).toBe("the scheduled report is done");
+		expect(assistantMemory.content.inReplyTo).toBe(inputMemory.id);
 	});
 
 	it("throws if metadata.prompt is missing", async () => {
-		const useModel = vi.fn();
-		const runtime = runtimeWithModel(useModel as IAgentRuntime["useModel"]);
+		const { runtime, useModel, createMemory } = makeRuntime();
 		await expect(
 			promptRunnerTaskWorker.execute(runtime, {}, makeTask(undefined)),
 		).rejects.toThrow(/missing metadata.prompt/);
 		expect(useModel).not.toHaveBeenCalled();
+		expect(createMemory).not.toHaveBeenCalled();
 	});
 
 	it("throws if metadata.prompt is empty string", async () => {
-		const useModel = vi.fn();
-		const runtime = runtimeWithModel(useModel as IAgentRuntime["useModel"]);
+		const { runtime, useModel, createMemory } = makeRuntime();
 		await expect(
-			promptRunnerTaskWorker.execute(runtime, {}, makeTask("")),
+			promptRunnerTaskWorker.execute(runtime, {}, makeTask("  ")),
 		).rejects.toThrow(/missing metadata.prompt/);
 		expect(useModel).not.toHaveBeenCalled();
+		expect(createMemory).not.toHaveBeenCalled();
 	});
 
 	it("exports a stable worker name", () => {

--- a/packages/core/src/features/basic-capabilities/prompt-runner-task.ts
+++ b/packages/core/src/features/basic-capabilities/prompt-runner-task.ts
@@ -2,9 +2,11 @@
  * Prompt-runner TaskWorker.
  *
  * A canonical "scheduled prompt" task: a recurring or one-shot Task whose
- * metadata.prompt is fed to TEXT_LARGE through a generic task-handler system
- * prompt. Lets users (and the UI) schedule arbitrary natural-language jobs
- * without authoring a bespoke worker per prompt.
+ * metadata.prompt enters the normal message-service loop with a generic
+ * task-handler system prompt, so scheduled natural-language jobs can use tools
+ * and persist visible results without authoring a bespoke worker per prompt.
+ * Headless runtimes without a message service fall back to TEXT_LARGE and still
+ * record the generated result as message memory.
  *
  * Tasks created for this worker should use:
  *   {
@@ -14,9 +16,12 @@
  *   }
  */
 
+import type { Memory } from "../../types/memory.ts";
 import { ModelType } from "../../types/model.ts";
+import { asUUID } from "../../types/primitives.ts";
 import type { IAgentRuntime } from "../../types/runtime.ts";
 import type { Task, TaskWorker } from "../../types/task.ts";
+import { stringToUuid } from "../../utils.ts";
 
 export const PROMPT_RUNNER_TASK_WORKER_NAME = "prompt.run";
 
@@ -34,12 +39,136 @@ export interface PromptRunnerTaskMetadata {
 
 const PROMPT_RUNNER_SYSTEM_PROMPT =
 	"Process the scheduled task below. Execute the user's intent and report what you did.\n\nTask: {{prompt}}";
+const PROMPT_RUNNER_SOURCE = "prompt-runner";
 
 function readPrompt(task: Task): string | null {
 	const meta = task.metadata as Record<string, unknown> | undefined;
 	if (!meta) return null;
 	const prompt = meta.prompt;
-	return typeof prompt === "string" && prompt.length > 0 ? prompt : null;
+	if (typeof prompt !== "string") return null;
+	const trimmed = prompt.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+function promptRunnerRoomId(runtime: IAgentRuntime, task: Task) {
+	return task.roomId ?? stringToUuid(`prompt-runner-room:${runtime.agentId}`);
+}
+
+function promptRunnerEntityId(runtime: IAgentRuntime, task: Task) {
+	return (
+		task.entityId ??
+		stringToUuid(`prompt-runner-entity:${runtime.agentId}:${task.id ?? "task"}`)
+	);
+}
+
+function promptRunnerMemoryMetadata(
+	task: Task,
+	role: "user" | "assistant",
+): Memory["metadata"] {
+	return {
+		type: "message",
+		source: PROMPT_RUNNER_SOURCE,
+		taskId: task.id,
+		taskName: task.name,
+		role,
+	};
+}
+
+async function persistPromptRunnerResponse(
+	runtime: IAgentRuntime,
+	task: Task,
+	inputMemory: Memory,
+	response: Memory["content"],
+): Promise<Memory[]> {
+	const text = typeof response.text === "string" ? response.text : "";
+	const responseMemory: Memory = {
+		id: asUUID(crypto.randomUUID()),
+		entityId: runtime.agentId,
+		agentId: runtime.agentId,
+		roomId: inputMemory.roomId,
+		worldId: inputMemory.worldId,
+		content: {
+			...response,
+			text,
+			source: PROMPT_RUNNER_SOURCE,
+			inReplyTo: inputMemory.id,
+		},
+		createdAt: Date.now(),
+		metadata: promptRunnerMemoryMetadata(task, "assistant"),
+	};
+	await runtime.createMemory(responseMemory, "messages");
+	return [responseMemory];
+}
+
+async function runPromptThroughMessageService(
+	runtime: IAgentRuntime,
+	task: Task,
+	composedPrompt: string,
+): Promise<boolean> {
+	if (!runtime.messageService) return false;
+	const inputMemory: Memory = {
+		id: asUUID(crypto.randomUUID()),
+		entityId: promptRunnerEntityId(runtime, task),
+		agentId: runtime.agentId,
+		roomId: promptRunnerRoomId(runtime, task),
+		worldId: task.worldId,
+		content: {
+			text: composedPrompt,
+			source: PROMPT_RUNNER_SOURCE,
+		},
+		createdAt: Date.now(),
+		metadata: promptRunnerMemoryMetadata(task, "user"),
+	};
+
+	await runtime.messageService.handleMessage(
+		runtime,
+		inputMemory,
+		(response) =>
+			persistPromptRunnerResponse(runtime, task, inputMemory, response),
+		{ keepExistingResponses: true },
+	);
+	return true;
+}
+
+function textFromModelResult(result: unknown): string {
+	if (typeof result === "string") return result;
+	if (
+		result &&
+		typeof result === "object" &&
+		"text" in result &&
+		typeof (result as { text?: unknown }).text === "string"
+	) {
+		return (result as { text: string }).text;
+	}
+	return String(result ?? "");
+}
+
+async function runPromptDirectly(
+	runtime: IAgentRuntime,
+	task: Task,
+	composedPrompt: string,
+): Promise<void> {
+	const result = await runtime.useModel(ModelType.TEXT_LARGE, {
+		prompt: composedPrompt,
+		priority: "background",
+	});
+	const text = textFromModelResult(result).trim();
+	if (!text) return;
+	const inputMemory: Memory = {
+		id: asUUID(crypto.randomUUID()),
+		entityId: promptRunnerEntityId(runtime, task),
+		agentId: runtime.agentId,
+		roomId: promptRunnerRoomId(runtime, task),
+		worldId: task.worldId,
+		content: {
+			text: composedPrompt,
+			source: PROMPT_RUNNER_SOURCE,
+		},
+		createdAt: Date.now(),
+		metadata: promptRunnerMemoryMetadata(task, "user"),
+	};
+	await runtime.createMemory(inputMemory, "messages");
+	await persistPromptRunnerResponse(runtime, task, inputMemory, { text });
 }
 
 export const promptRunnerTaskWorker: TaskWorker = {
@@ -54,13 +183,17 @@ export const promptRunnerTaskWorker: TaskWorker = {
 
 		const composed = PROMPT_RUNNER_SYSTEM_PROMPT.replace("{{prompt}}", prompt);
 
-		// Scheduled jobs are background work: on single-lane local backends this
-		// lets interactive chat turns jump the model lane and caps the job by the
-		// device-class background budget (#11914).
-		await runtime.useModel(ModelType.TEXT_LARGE, {
-			prompt: composed,
-			priority: "background",
-		});
+		const handled = await runPromptThroughMessageService(
+			runtime,
+			task,
+			composed,
+		);
+		if (!handled) {
+			// Scheduled jobs are background work: on single-lane local backends this
+			// lets interactive chat turns jump the model lane and caps the job by the
+			// device-class background budget (#11914).
+			await runPromptDirectly(runtime, task, composed);
+		}
 		return undefined;
 	},
 };

--- a/packages/core/src/features/basic-capabilities/prompt-runner-task.ts
+++ b/packages/core/src/features/basic-capabilities/prompt-runner-task.ts
@@ -64,6 +64,7 @@ function promptRunnerEntityId(runtime: IAgentRuntime, task: Task) {
 function promptRunnerMemoryMetadata(
 	task: Task,
 	role: "user" | "assistant",
+	actionName?: string,
 ): Memory["metadata"] {
 	return {
 		type: "message",
@@ -71,6 +72,7 @@ function promptRunnerMemoryMetadata(
 		taskId: task.id,
 		taskName: task.name,
 		role,
+		actionName,
 	};
 }
 
@@ -79,6 +81,7 @@ async function persistPromptRunnerResponse(
 	task: Task,
 	inputMemory: Memory,
 	response: Memory["content"],
+	actionName?: string,
 ): Promise<Memory[]> {
 	const text = typeof response.text === "string" ? response.text : "";
 	const responseMemory: Memory = {
@@ -94,10 +97,37 @@ async function persistPromptRunnerResponse(
 			inReplyTo: inputMemory.id,
 		},
 		createdAt: Date.now(),
-		metadata: promptRunnerMemoryMetadata(task, "assistant"),
+		metadata: promptRunnerMemoryMetadata(task, "assistant", actionName),
 	};
 	await runtime.createMemory(responseMemory, "messages");
 	return [responseMemory];
+}
+
+function hasVisibleResponse(response: Memory["content"]): boolean {
+	const text = typeof response.text === "string" ? response.text.trim() : "";
+	return text.length > 0 || (response.attachments?.length ?? 0) > 0;
+}
+
+function sameResponseContent(
+	left: Memory["content"],
+	right: Memory["content"],
+): boolean {
+	const leftText = typeof left.text === "string" ? left.text.trim() : "";
+	const rightText = typeof right.text === "string" ? right.text.trim() : "";
+	if (leftText !== rightText) return false;
+	const leftActions = left.actions ?? [];
+	const rightActions = right.actions ?? [];
+	if (leftActions.length !== rightActions.length) return false;
+	return leftActions.every((action, index) => action === rightActions[index]);
+}
+
+function wasPersistedByMessageService(
+	response: Memory["content"],
+	persistedMessages: Memory[],
+): boolean {
+	return persistedMessages.some((memory) =>
+		sameResponseContent(response, memory.content),
+	);
 }
 
 async function runPromptThroughMessageService(
@@ -106,6 +136,10 @@ async function runPromptThroughMessageService(
 	composedPrompt: string,
 ): Promise<boolean> {
 	if (!runtime.messageService) return false;
+	const callbackResponses: Array<{
+		response: Memory["content"];
+		actionName?: string;
+	}> = [];
 	const inputMemory: Memory = {
 		id: asUUID(crypto.randomUUID()),
 		entityId: promptRunnerEntityId(runtime, task),
@@ -120,13 +154,28 @@ async function runPromptThroughMessageService(
 		metadata: promptRunnerMemoryMetadata(task, "user"),
 	};
 
-	await runtime.messageService.handleMessage(
+	const result = await runtime.messageService.handleMessage(
 		runtime,
 		inputMemory,
-		(response) =>
-			persistPromptRunnerResponse(runtime, task, inputMemory, response),
+		async (response, actionName) => {
+			callbackResponses.push({ response, actionName });
+			return [];
+		},
 		{ keepExistingResponses: true },
 	);
+	for (const { response, actionName } of callbackResponses) {
+		if (!hasVisibleResponse(response)) continue;
+		if (wasPersistedByMessageService(response, result.responseMessages)) {
+			continue;
+		}
+		await persistPromptRunnerResponse(
+			runtime,
+			task,
+			inputMemory,
+			response,
+			actionName,
+		);
+	}
 	return true;
 }
 


### PR DESCRIPTION
## Summary
Refs #14681.

`promptRunnerTaskWorker` no longer discards scheduled prompt output. When a runtime has `messageService`, the worker injects the scheduled prompt through the normal message-service loop so the planner/action path can run and the assistant response is stored as message memory. Headless runtimes without `messageService` still use background `TEXT_LARGE`, but now persist both the prompt-runner input and the generated assistant result instead of throwing the text away.

Follow-up review fix: the worker now treats `messageService.handleMessage()` returned `responseMessages` as canonical and only backfills callback content that the service did not already persist. That avoids duplicate assistant memories for normal simple replies while still preserving visible action-callback artifacts.

The `TaskWorker` return contract stays unchanged (`undefined | { nextInterval }`), so output is surfaced as a real domain artifact rather than smuggled through the cadence-control return value.

## Required Evidence Rows
<!-- evidence-row:before-screenshots -->
- N/A - core scheduled-task worker only; no app-rendered surface changed.

<!-- evidence-row:after-screenshots -->
- N/A - core scheduled-task worker only; no app-rendered surface changed.

<!-- evidence-row:walkthrough-video -->
- N/A - no UI or native workflow changed; verification is through focused worker tests and core build/typecheck.

<!-- evidence-row:backend-logs -->
- N/A - no server process was started; this PR changes a core worker and validates behavior with deterministic unit tests.

<!-- evidence-row:frontend-logs -->
- N/A - no frontend runtime path changed.

<!-- evidence-row:llm-trajectory -->
- N/A - no live provider key is configured in this workspace. The PR remains draft until a live scheduled-prompt trajectory can be captured.

<!-- evidence-row:domain-artifacts -->
- Domain artifacts are persisted message memories produced by the worker; the regression coverage is in the [PR diff](https://github.com/elizaOS/eliza/pull/14739/files) and verifies message-service, fallback, and duplicate-prevention persistence paths.

## Verification
<!-- evidence-row:focused-tests -->
- `bun run --cwd packages/core test src/features/basic-capabilities/prompt-runner-task.test.ts` PASS: `1 file passed`, `6 tests passed`. Coverage includes message-service routing, callback backfill persistence, duplicate prevention for simple responses already persisted by the message service, fallback `TEXT_LARGE` persistence, missing prompt, empty prompt, and worker name.

<!-- evidence-row:format-typecheck-build -->
- `bunx @biomejs/biome check packages/core/src/features/basic-capabilities/prompt-runner-task.ts packages/core/src/features/basic-capabilities/prompt-runner-task.test.ts` PASS: `Checked 2 files. No fixes applied`.
- `bun run --cwd packages/core typecheck` PASS.
- `bun run --cwd packages/core build:node` PASS; Node build, testing module build, and declaration generation completed.

<!-- evidence-row:diff-policy -->
- `git diff --check` PASS.
- `bun run audit:error-policy-ratchet --report` PASS: `packages/core/src/features/basic-capabilities/prompt-runner-task.ts: emptyCatch 0->0, serverConsole 0->0`; no new fallback-slop in touched files.

## Evidence Notes
- Keyless regression test proves the message-service path calls `handleMessage`, tags source as `prompt-runner`, and persists callback-only content when no `responseMessages` were returned.
- New duplicate-prevention regression simulates `DefaultMessageService` simple mode: the service persists and returns the response, then invokes the callback; the worker does not create a second assistant memory.
- Fallback regression test proves the no-message-service path still uses `TEXT_LARGE` with `priority: "background"` and persists generated text instead of discarding it.
- Live-LLM scheduled prompt trajectory is still needed before this should be marked MVP-complete; this workspace currently has no live provider key configured.
