### PR TITLE
fix(#14674): persist personality slots

### DIFF
--- a/packages/core/src/features/advanced-capabilities/evaluators/preference-items.test.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/preference-items.test.ts
@@ -235,7 +235,7 @@ describe("applyPreferenceOps trait policy", () => {
 
 	it("never overwrites an explicitly-set trait, even at confidence 1", async () => {
 		const fake = makeFakeRuntime({ agentId: AGENT });
-		fake.store.applyTrait({
+		await fake.store.applyTrait({
 			scope: "user",
 			userId: USER,
 			agentId: AGENT,
@@ -257,7 +257,7 @@ describe("applyPreferenceOps trait policy", () => {
 
 	it("may overwrite a previously inferred trait", async () => {
 		const fake = makeFakeRuntime({ agentId: AGENT });
-		fake.store.applyTrait({
+		await fake.store.applyTrait({
 			scope: "user",
 			userId: USER,
 			agentId: AGENT,
@@ -284,7 +284,7 @@ describe("applyPreferenceOps trait policy", () => {
 
 	it("gates every trait op against the pre-run slot: one inferred write cannot unlock overwriting an explicit trait in the same run", async () => {
 		const fake = makeFakeRuntime({ agentId: AGENT });
-		fake.store.applyTrait({
+		await fake.store.applyTrait({
 			scope: "user",
 			userId: USER,
 			agentId: AGENT,
@@ -296,14 +296,14 @@ describe("applyPreferenceOps trait policy", () => {
 			fake,
 			mustParse({
 				ops: [
-					// This null-trait fill flips slot.source to agent_inferred...
+					// This null-trait fill marks only verbosity as inferred...
 					{
 						op: "set_trait",
 						trait: "verbosity",
 						value: "terse",
 						confidence: 0.9,
 					},
-					// ...which must NOT let this op overwrite the explicit tone.
+					// ...and must NOT let this op overwrite the explicit tone.
 					{ op: "set_trait", trait: "tone", value: "cold", confidence: 0.95 },
 				],
 			}),
@@ -316,7 +316,7 @@ describe("applyPreferenceOps trait policy", () => {
 
 	it("retracts an inferred trait but never an explicit one", async () => {
 		const inferred = makeFakeRuntime({ agentId: AGENT });
-		inferred.store.applyTrait({
+		await inferred.store.applyTrait({
 			scope: "user",
 			userId: USER,
 			agentId: AGENT,
@@ -332,7 +332,7 @@ describe("applyPreferenceOps trait policy", () => {
 		expect(inferred.store.getSlot(USER, AGENT).verbosity).toBeNull();
 
 		const explicit = makeFakeRuntime({ agentId: AGENT });
-		explicit.store.applyTrait({
+		await explicit.store.applyTrait({
 			scope: "user",
 			userId: USER,
 			agentId: AGENT,
@@ -346,6 +346,75 @@ describe("applyPreferenceOps trait policy", () => {
 		);
 		expect(explicit.store.getSlot(USER, AGENT).verbosity).toBe("terse");
 		expect(result?.data).toMatchObject({ traitsRetracted: 0, skipped: 1 });
+	});
+});
+
+describe("applyPreferenceOps cross-turn provenance", () => {
+	it("a prior inferred directive write cannot unlock overwriting an explicit trait on a later turn (#14857 wave-2)", async () => {
+		const fake = makeFakeRuntime({ agentId: AGENT });
+		// Turn 0: the user explicitly sets tone.
+		await fake.store.applyTrait({
+			scope: "user",
+			userId: USER,
+			agentId: AGENT,
+			actorId: USER,
+			trait: "tone",
+			value: "warm",
+		});
+		// Turn 1: inference adds only a directive. The slot's last-writer
+		// source flips to agent_inferred, but tone's provenance must not.
+		await processOps(
+			fake,
+			mustParse({
+				ops: [{ op: "add_directive", text: "no emojis", confidence: 0.9 }],
+			}),
+		);
+		expect(fake.store.getSlot(USER, AGENT).source).toBe("agent_inferred");
+
+		// Turn 2: a high-confidence inferred set_trait against the explicit
+		// tone — the per-trait gate must refuse it.
+		const result = await processOps(
+			fake,
+			mustParse({
+				ops: [{ op: "set_trait", trait: "tone", value: "cold", confidence: 1 }],
+			}),
+			{ slot: fake.store.getSlot(USER, AGENT) },
+		);
+		const slot = fake.store.getSlot(USER, AGENT);
+		expect(slot.tone).toBe("warm");
+		expect(slot.trait_sources.tone).toBe("user");
+		expect(result?.data).toMatchObject({ traitsSet: 0, skipped: 1 });
+	});
+
+	it("retracts an inferred trait even when another trait on the slot is explicit", async () => {
+		const fake = makeFakeRuntime({ agentId: AGENT });
+		await fake.store.applyTrait({
+			scope: "user",
+			userId: USER,
+			agentId: AGENT,
+			actorId: USER,
+			trait: "tone",
+			value: "warm",
+		});
+		await fake.store.applyTrait({
+			scope: "user",
+			userId: USER,
+			agentId: AGENT,
+			actorId: AGENT,
+			trait: "verbosity",
+			value: "terse",
+			source: "agent_inferred",
+		});
+		const result = await processOps(
+			fake,
+			mustParse({ ops: [{ op: "retract_trait", trait: "verbosity" }] }),
+			{ slot: fake.store.getSlot(USER, AGENT) },
+		);
+		const slot = fake.store.getSlot(USER, AGENT);
+		expect(slot.verbosity).toBeNull();
+		expect(slot.tone).toBe("warm");
+		expect(slot.trait_sources.tone).toBe("user");
+		expect(result?.data).toMatchObject({ traitsRetracted: 1 });
 	});
 });
 
@@ -371,7 +440,7 @@ describe("applyPreferenceOps directives", () => {
 
 	it("dedupes a lexically similar directive instead of appending a near-copy", async () => {
 		const fake = makeFakeRuntime({ agentId: AGENT });
-		fake.store.addDirective({
+		await fake.store.addDirective({
 			userId: USER,
 			agentId: AGENT,
 			actorId: USER,
@@ -447,6 +516,32 @@ describe("applyPreferenceOps preference facts", () => {
 		expect(
 			(rows[0].metadata as { confidence?: number }).confidence,
 		).toBeCloseTo(0.8);
+		expect(result?.data).toMatchObject({ factsAdded: 0, factsStrengthened: 1 });
+	});
+
+	it("dedupes against a preference row the fact evaluator inserted in the same turn (post-prepare)", async () => {
+		const fake = makeFakeRuntime({ agentId: AGENT });
+		const insertedAfterPrepare = preferenceFact(
+			"00000000-0000-4000-8000-0000000000b0",
+			"the user prefers morning check-ins",
+			["morning", "check", "ins"],
+		);
+		fake.memories.set("facts", [insertedAfterPrepare]);
+		// prepared snapshot predates the row — the processor must re-fetch.
+		const result = await processOps(
+			fake,
+			mustParse({
+				ops: [
+					{
+						op: "add_preference_fact",
+						claim: "prefers morning check-ins",
+						keywords: ["morning", "check-ins"],
+					},
+				],
+			}),
+			{ knownPreferenceFacts: [] },
+		);
+		expect(fake.memories.get("facts") ?? []).toHaveLength(1);
 		expect(result?.data).toMatchObject({ factsAdded: 0, factsStrengthened: 1 });
 	});
 

--- a/packages/core/src/features/advanced-capabilities/evaluators/preference-items.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/preference-items.ts
@@ -15,15 +15,15 @@
  * by the FACTS provider and downstream systems (LifeOps scheduling, view
  * actions) exactly like fact-extractor rows.
  *
- * Safety invariants: inference never overwrites an explicitly-set trait (slot
- * source "user"/"admin" — explicit beats inferred), never touches `reply_gate`
- * (silencing the agent off an inferred signal is a hazard; the op is not even
- * representable in the schema), and never writes global scope. Trait gates are
- * evaluated against the slot snapshot taken before any write this run, so one
- * inferred write cannot unlock overwriting an explicit trait in the same run.
- * Slot provenance is slot-level, not per-trait, so an inferred write marks the
- * whole slot "agent_inferred"; per-trait provenance is deferred to the slot
- * persistence work (#14674). On runtimes without the PersonalityStore service
+ * Safety invariants: inference never overwrites an explicitly-set trait —
+ * gates read the per-trait provenance in `slot.trait_sources`, so explicit
+ * beats inferred at any confidence and across turns (a lone inferred directive
+ * write cannot relabel the slot and unlock a later overwrite). `reply_gate` is
+ * never touched (silencing the agent off an inferred signal is a hazard; the
+ * op is not even representable in the schema), and global scope is never
+ * written. Trait gates read the slot snapshot taken before any write this run,
+ * so one inferred write cannot change another op's gate in the same run.
+ * On runtimes without the PersonalityStore service
  * (advanced capabilities off), the fact lane still works and slot ops are
  * dropped with a debug log — the counters in the processor result record it.
  */
@@ -230,26 +230,30 @@ type SlotOpOutcome =
 	| "skipped_explicit";
 
 /**
- * Gate reads `gateSlot` — the pre-run snapshot — never the live slot: writing
- * an inferred trait flips the whole slot's source to "agent_inferred" (slot
- * provenance is not per-trait), and gating on the live slot would let that
- * first write unlock overwriting an explicitly-set trait later in the same run.
+ * Gates read per-trait provenance (`trait_sources[trait]`), never the
+ * slot-level `source`: `source` records only the last writer, so one inferred
+ * directive write would relabel the whole slot and unlock overwriting an
+ * explicitly-set trait on a later turn. `gateSlot` is the pre-run snapshot so
+ * one run's writes cannot change another op's gate inside the same run.
  */
-function applySetTrait(
+async function applySetTrait(
 	store: PersonalityStore,
 	runtime: IAgentRuntime,
 	userId: UUID,
 	gateSlot: PersonalitySlot,
 	op: SetTraitOp,
-): SlotOpOutcome {
+): Promise<SlotOpOutcome> {
 	if (op.confidence < SLOT_CONFIDENCE_THRESHOLD)
 		return "skipped_low_confidence";
 	const current = gateSlot[op.trait];
 	if (current === op.value) return "unchanged";
-	if (current !== null && gateSlot.source !== "agent_inferred") {
+	if (
+		current !== null &&
+		gateSlot.trait_sources[op.trait] !== "agent_inferred"
+	) {
 		return "skipped_explicit";
 	}
-	store.applyTrait({
+	await store.applyTrait({
 		scope: "user",
 		userId,
 		agentId: runtime.agentId,
@@ -261,18 +265,21 @@ function applySetTrait(
 	return "applied";
 }
 
-function applyRetractTrait(
+async function applyRetractTrait(
 	store: PersonalityStore,
 	runtime: IAgentRuntime,
 	userId: UUID,
 	gateSlot: PersonalitySlot,
 	op: RetractTraitOp,
-): SlotOpOutcome {
-	// Retraction only undoes inference. An explicit trait (source user/admin)
-	// is cleared through the PERSONALITY action, never by the extractor.
-	if (gateSlot.source !== "agent_inferred") return "skipped_explicit";
+): Promise<SlotOpOutcome> {
+	// Retraction only undoes inference. An explicitly-set trait (per-trait
+	// source user/admin) is cleared through the PERSONALITY action, never by
+	// the extractor.
 	if (gateSlot[op.trait] === null) return "unchanged";
-	store.applyTrait({
+	if (gateSlot.trait_sources[op.trait] !== "agent_inferred") {
+		return "skipped_explicit";
+	}
+	await store.applyTrait({
 		scope: "user",
 		userId,
 		agentId: runtime.agentId,
@@ -284,12 +291,12 @@ function applyRetractTrait(
 	return "applied";
 }
 
-function applyAddDirective(
+async function applyAddDirective(
 	store: PersonalityStore,
 	runtime: IAgentRuntime,
 	userId: UUID,
 	op: AddDirectiveOp,
-): "added" | "deduped" | "skipped_low_confidence" {
+): Promise<"added" | "deduped" | "skipped_low_confidence"> {
 	if (op.confidence < SLOT_CONFIDENCE_THRESHOLD)
 		return "skipped_low_confidence";
 	// Dedupe against the LIVE slot (unlike trait gates) so two near-identical
@@ -301,7 +308,7 @@ function applyAddDirective(
 			DEDUP_SIMILARITY_THRESHOLD,
 	);
 	if (isDuplicate) return "deduped";
-	store.addDirective({
+	await store.addDirective({
 		userId,
 		agentId: runtime.agentId,
 		actorId: runtime.agentId,
@@ -354,7 +361,9 @@ async function applyAddPreferenceFact(
 	const metadata: MemoryMetadata = {
 		type: MemoryType.CUSTOM,
 		source: "preference_extractor",
-		confidence: NEW_FACT_CONFIDENCE,
+		// The model's own confidence when it gave one (the schema advertises
+		// it); the shared default only backfills its absence.
+		confidence: clamp01(op.confidence ?? NEW_FACT_CONFIDENCE),
 		lastConfirmedAt: nowIso(),
 		kind: "durable",
 		category: "preference",
@@ -443,9 +452,29 @@ ${formatRecentMessages(prepared.recentMessages)}`;
 				const userId = message.entityId;
 				// Pre-run snapshot for trait gates — see applySetTrait.
 				const gateSlot = store ? store.getSlot(userId) : null;
-				const candidates: FactCandidate[] = prepared.knownPreferenceFacts.map(
-					(memory) => ({ memory, searchText: buildFactSearchText(memory) }),
+				// Re-fetch dedupe candidates at process() time: the fact evaluator
+				// (priority 100) runs in the same merged post-turn call BEFORE this
+				// processor and may have just inserted `preference` rows the
+				// prepare-time snapshot cannot see — deduping against the snapshot
+				// would double-store the same preference in one turn.
+				const hasFactOps = output.ops.some(
+					(op) => op.op === "add_preference_fact",
 				);
+				const freshFacts = hasFactOps
+					? (
+							await runtime.getMemories({
+								tableName: "facts",
+								roomId: message.roomId,
+								entityId: message.entityId,
+								limit: PREFERENCE_FACT_LOOKBACK,
+								unique: false,
+							})
+						).filter(isDurablePreferenceFact)
+					: prepared.knownPreferenceFacts;
+				const candidates: FactCandidate[] = freshFacts.map((memory) => ({
+					memory,
+					searchText: buildFactSearchText(memory),
+				}));
 				let traitsSet = 0;
 				let traitsRetracted = 0;
 				let directivesAdded = 0;
@@ -470,18 +499,24 @@ ${formatRecentMessages(prepared.recentMessages)}`;
 						continue;
 					}
 					if (op.op === "set_trait") {
-						const outcome = applySetTrait(store, runtime, userId, gateSlot, op);
+						const outcome = await applySetTrait(
+							store,
+							runtime,
+							userId,
+							gateSlot,
+							op,
+						);
 						if (outcome === "applied") traitsSet += 1;
 						else skipped += 1;
 						continue;
 					}
 					if (op.op === "add_directive") {
-						const outcome = applyAddDirective(store, runtime, userId, op);
+						const outcome = await applyAddDirective(store, runtime, userId, op);
 						if (outcome === "added") directivesAdded += 1;
 						else skipped += 1;
 						continue;
 					}
-					const outcome = applyRetractTrait(
+					const outcome = await applyRetractTrait(
 						store,
 						runtime,
 						userId,

--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-provider.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-provider.test.ts
@@ -35,7 +35,7 @@ describe("userPersonalityProvider", () => {
 
 	test("renders structured user slot when present", async () => {
 		const userId = "00000000-0000-4000-8000-0000000000fb" as UUID;
-		fake.store.applyTrait({
+		await fake.store.applyTrait({
 			scope: "user",
 			userId,
 			agentId: fake.runtime.agentId,
@@ -43,7 +43,7 @@ describe("userPersonalityProvider", () => {
 			trait: "verbosity",
 			value: "terse",
 		});
-		fake.store.applyTrait({
+		await fake.store.applyTrait({
 			scope: "user",
 			userId,
 			agentId: fake.runtime.agentId,
@@ -51,7 +51,7 @@ describe("userPersonalityProvider", () => {
 			trait: "tone",
 			value: "direct",
 		});
-		fake.store.addDirective({
+		await fake.store.addDirective({
 			userId,
 			agentId: fake.runtime.agentId,
 			actorId: userId,
@@ -75,7 +75,7 @@ describe("userPersonalityProvider", () => {
 
 	test("renders global slot too, distinct from user slot", async () => {
 		const userId = "00000000-0000-4000-8000-0000000000fc" as UUID;
-		fake.store.applyTrait({
+		await fake.store.applyTrait({
 			scope: "global",
 			userId,
 			agentId: fake.runtime.agentId,
@@ -113,7 +113,7 @@ describe("userPersonalityProvider", () => {
 
 	test("omits reply_gate=always from the rendered block", async () => {
 		const userId = "00000000-0000-4000-8000-0000000000fd" as UUID;
-		fake.store.applyReplyGate({
+		await fake.store.applyReplyGate({
 			scope: "user",
 			userId,
 			agentId: fake.runtime.agentId,
@@ -136,7 +136,7 @@ describe("userPersonalityProvider", () => {
 
 	test("renders reply_gate when non-default", async () => {
 		const userId = "00000000-0000-4000-8000-0000000000fe" as UUID;
-		fake.store.applyReplyGate({
+		await fake.store.applyReplyGate({
 			scope: "user",
 			userId,
 			agentId: fake.runtime.agentId,
@@ -176,7 +176,7 @@ describe("userPersonalityProvider — backward compatibility", () => {
 			"user_personality_preferences",
 		);
 
-		fake.store.applyTrait({
+		await fake.store.applyTrait({
 			scope: "user",
 			userId,
 			agentId: fake.runtime.agentId,

--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-store.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-store.test.ts
@@ -228,6 +228,51 @@ describe("PersonalityStore", () => {
 		).toBe("direct");
 	});
 
+	test("concurrent same-slot mutations serialize — no lost update across the persist await", async () => {
+		const fake = makeFakeRuntime({ agentId: AGENT as never });
+		await initStore(fake);
+		// Slow the durable upsert down so unserialized read-modify-write
+		// mutations WOULD interleave (both read the empty slot, last write
+		// wins) — the per-slot chain must prevent exactly that.
+		const runtimeWithUpsert = fake.runtime as unknown as {
+			upsertMemory(memory: unknown, table: string): Promise<void>;
+		};
+		const originalUpsert = runtimeWithUpsert.upsertMemory.bind(fake.runtime);
+		runtimeWithUpsert.upsertMemory = async (memory, table) => {
+			await new Promise((resolve) => setTimeout(resolve, 5));
+			await originalUpsert(memory, table);
+		};
+
+		await Promise.all([
+			fake.store.applyTrait({
+				scope: "user",
+				userId: USER_A as never,
+				agentId: AGENT as never,
+				actorId: USER_A as never,
+				trait: "verbosity",
+				value: "terse",
+			}),
+			fake.store.addDirective({
+				userId: USER_A as never,
+				agentId: AGENT as never,
+				actorId: USER_A as never,
+				directive: "no emojis",
+			}),
+		]);
+
+		const slot = fake.store.getSlot(USER_A as never, AGENT as never);
+		expect(slot.verbosity).toBe("terse");
+		expect(slot.custom_directives).toEqual(["no emojis"]);
+		// The durable mirror must carry both changes too, in one row.
+		const rows = fake.memories.get(PERSONALITY_SLOT_TABLE) ?? [];
+		expect(rows).toHaveLength(1);
+		const persisted = (
+			rows[0].metadata as { slot?: Record<string, unknown> } | undefined
+		)?.slot;
+		expect(persisted?.verbosity).toBe("terse");
+		expect(persisted?.custom_directives).toEqual(["no emojis"]);
+	});
+
 	test("clear removes mirrored slot memories", async () => {
 		const fake = makeFakeRuntime({ agentId: AGENT as never });
 		await initStore(fake);

--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-store.test.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/personality-store.test.ts
@@ -9,9 +9,10 @@ import { defaultProfiles } from "../profiles/index.ts";
 import {
 	GLOBAL_PERSONALITY_SCOPE,
 	MAX_CUSTOM_DIRECTIVES,
+	PERSONALITY_SLOT_TABLE,
 	type PersonalityProfile,
 } from "../types.ts";
-import { makeFakeRuntime } from "./test-helpers.ts";
+import { initStore, makeFakeRuntime } from "./test-helpers.ts";
 
 const AGENT = "00000000-0000-4000-8000-000000000aaa" as const;
 const USER_A = "00000000-0000-4000-8000-000000000aab" as const;
@@ -37,9 +38,9 @@ describe("PersonalityStore", () => {
 		expect(slot.custom_directives).toEqual([]);
 	});
 
-	test("applyTrait writes user-scope slot and audit entry", () => {
+	test("applyTrait writes user-scope slot and audit entry", async () => {
 		const store = bareStore();
-		const { after } = store.applyTrait({
+		const { after } = await store.applyTrait({
 			scope: "user",
 			userId: USER_A as never,
 			agentId: AGENT as never,
@@ -55,9 +56,9 @@ describe("PersonalityStore", () => {
 		expect(audit[0].targetId).toBe(USER_A);
 	});
 
-	test("user scope writes do not leak into global slot", () => {
+	test("user scope writes do not leak into global slot", async () => {
 		const store = bareStore();
-		store.applyTrait({
+		await store.applyTrait({
 			scope: "user",
 			userId: USER_A as never,
 			agentId: AGENT as never,
@@ -69,9 +70,9 @@ describe("PersonalityStore", () => {
 		expect(globalSlot.tone).toBeNull();
 	});
 
-	test("two users keep independent slots", () => {
+	test("two users keep independent slots", async () => {
 		const store = bareStore();
-		store.applyTrait({
+		await store.applyTrait({
 			scope: "user",
 			userId: USER_A as never,
 			agentId: AGENT as never,
@@ -79,7 +80,7 @@ describe("PersonalityStore", () => {
 			trait: "verbosity",
 			value: "terse",
 		});
-		store.applyTrait({
+		await store.applyTrait({
 			scope: "user",
 			userId: USER_B as never,
 			agentId: AGENT as never,
@@ -95,9 +96,9 @@ describe("PersonalityStore", () => {
 		);
 	});
 
-	test("global scope write applies across users via getSlot('global')", () => {
+	test("global scope write applies across users via getSlot('global')", async () => {
 		const store = bareStore();
-		store.applyTrait({
+		await store.applyTrait({
 			scope: "global",
 			userId: USER_A as never, // ignored for global scope
 			agentId: AGENT as never,
@@ -110,10 +111,10 @@ describe("PersonalityStore", () => {
 		);
 	});
 
-	test("addDirective evicts FIFO at the cap", () => {
+	test("addDirective evicts FIFO at the cap", async () => {
 		const store = bareStore();
 		for (let i = 0; i < MAX_CUSTOM_DIRECTIVES + 3; i++) {
-			store.addDirective({
+			await store.addDirective({
 				userId: USER_A as never,
 				agentId: AGENT as never,
 				actorId: USER_A as never,
@@ -129,15 +130,15 @@ describe("PersonalityStore", () => {
 		);
 	});
 
-	test("clearDirectives wipes the list", () => {
+	test("clearDirectives wipes the list", async () => {
 		const store = bareStore();
-		store.addDirective({
+		await store.addDirective({
 			userId: USER_A as never,
 			agentId: AGENT as never,
 			actorId: USER_A as never,
 			directive: "one",
 		});
-		store.clearDirectives({
+		await store.clearDirectives({
 			scope: "user",
 			userId: USER_A as never,
 			agentId: AGENT as never,
@@ -148,7 +149,7 @@ describe("PersonalityStore", () => {
 		).toEqual([]);
 	});
 
-	test("loadProfileIntoGlobal applies all trait fields atomically", () => {
+	test("loadProfileIntoGlobal applies all trait fields atomically", async () => {
 		const store = bareStore();
 		const profile: PersonalityProfile = {
 			name: "test",
@@ -160,7 +161,7 @@ describe("PersonalityStore", () => {
 			custom_directives: ["directive a"],
 		};
 		store.saveProfile(profile);
-		store.loadProfileIntoGlobal(profile, AGENT as never, USER_A as never);
+		await store.loadProfileIntoGlobal(profile, AGENT as never, USER_A as never);
 		const slot = store.getSlot(GLOBAL_PERSONALITY_SCOPE, AGENT as never);
 		expect(slot.verbosity).toBe("terse");
 		expect(slot.tone).toBe("direct");
@@ -177,5 +178,74 @@ describe("PersonalityStore", () => {
 		expect(names).toContain("aggressive");
 		expect(names).toContain("gentle");
 		expect(names).toContain("terse");
+	});
+
+	test("hydrates persisted user and global slots into a fresh store", async () => {
+		const fake = makeFakeRuntime({ agentId: AGENT as never });
+		await initStore(fake);
+		await fake.store.applyTrait({
+			scope: "user",
+			userId: USER_A as never,
+			agentId: AGENT as never,
+			actorId: USER_A as never,
+			trait: "verbosity",
+			value: "terse",
+		});
+		await fake.store.applyTrait({
+			scope: "user",
+			userId: USER_A as never,
+			agentId: AGENT as never,
+			actorId: USER_A as never,
+			trait: "formality",
+			value: "casual",
+		});
+		await fake.store.applyTrait({
+			scope: "global",
+			userId: USER_A as never,
+			agentId: AGENT as never,
+			actorId: USER_A as never,
+			trait: "tone",
+			value: "direct",
+		});
+
+		expect(fake.memories.get(PERSONALITY_SLOT_TABLE)).toHaveLength(2);
+
+		const reloaded = makeFakeRuntime({ agentId: AGENT as never });
+		reloaded.memories.set(
+			PERSONALITY_SLOT_TABLE,
+			fake.memories.get(PERSONALITY_SLOT_TABLE) ?? [],
+		);
+		await initStore(reloaded);
+
+		expect(
+			reloaded.store.getSlot(USER_A as never, AGENT as never).verbosity,
+		).toBe("terse");
+		expect(
+			reloaded.store.getSlot(USER_A as never, AGENT as never).formality,
+		).toBe("casual");
+		expect(
+			reloaded.store.getSlot(GLOBAL_PERSONALITY_SCOPE, AGENT as never).tone,
+		).toBe("direct");
+	});
+
+	test("clear removes mirrored slot memories", async () => {
+		const fake = makeFakeRuntime({ agentId: AGENT as never });
+		await initStore(fake);
+		await fake.store.applyTrait({
+			scope: "user",
+			userId: USER_A as never,
+			agentId: AGENT as never,
+			actorId: USER_A as never,
+			trait: "verbosity",
+			value: "terse",
+		});
+		expect(fake.memories.get(PERSONALITY_SLOT_TABLE)).toHaveLength(1);
+
+		await fake.store.clear();
+
+		expect(
+			fake.store.getSlot(USER_A as never, AGENT as never).verbosity,
+		).toBeNull();
+		expect(fake.memories.get(PERSONALITY_SLOT_TABLE)).toEqual([]);
 	});
 });

--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/test-helpers.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/test-helpers.ts
@@ -23,6 +23,20 @@ function nextUuid(): UUID {
 	return `00000000-0000-4000-8000-${hex}0000000000`.slice(0, 36) as UUID;
 }
 
+function metadataMatches(
+	memory: Memory,
+	filter?: Record<string, unknown>,
+): boolean {
+	if (!filter) return true;
+	if (!memory.metadata) return false;
+	const metadata = memory.metadata as Record<string, unknown>;
+	for (const [key, value] of Object.entries(filter)) {
+		if (!(key in metadata)) return false;
+		if (JSON.stringify(metadata[key]) !== JSON.stringify(value)) return false;
+	}
+	return true;
+}
+
 export interface FakeRuntimeOptions {
 	agentId?: UUID;
 	character?: Partial<Character>;
@@ -86,16 +100,35 @@ export function makeFakeRuntime(options: FakeRuntimeOptions = {}): FakeRuntime {
 			memories.set(table, list);
 			return withId.id as UUID;
 		},
+		async upsertMemory(memory: Memory, table: string): Promise<void> {
+			const list = memories.get(table) ?? [];
+			const memoryId = memory.id ?? nextUuid();
+			const withId: Memory = { ...memory, id: memoryId };
+			const existingIndex = list.findIndex((stored) => stored.id === memoryId);
+			if (existingIndex === -1) {
+				list.push(withId);
+			} else {
+				list[existingIndex] = {
+					...list[existingIndex],
+					...withId,
+				};
+			}
+			memories.set(table, list);
+		},
 		async getMemories(opts: {
 			tableName: string;
 			entityId?: UUID;
+			agentId?: UUID;
 			roomId?: UUID;
 			count?: number;
+			metadata?: Record<string, unknown>;
 		}): Promise<Memory[]> {
 			const list = memories.get(opts.tableName) ?? [];
 			return list
 				.filter((m) => !opts.entityId || m.entityId === opts.entityId)
+				.filter((m) => !opts.agentId || m.agentId === opts.agentId)
 				.filter((m) => !opts.roomId || m.roomId === opts.roomId)
+				.filter((m) => metadataMatches(m, opts.metadata))
 				.slice(0, opts.count ?? list.length);
 		},
 		async updateMemory(patch: Partial<Memory> & { id: UUID }): Promise<void> {
@@ -139,13 +172,9 @@ export function makeFakeRuntime(options: FakeRuntimeOptions = {}): FakeRuntime {
 }
 
 export async function initStore(fake: FakeRuntime): Promise<void> {
-	// Bypass private init; we call loadProfilesFromDisk explicitly to seed
-	// default profiles (without static start which would re-construct).
-	// We treat the in-memory list as the source of truth.
-	const profiles = await import("../profiles/index.ts");
-	for (const profile of profiles.defaultProfiles) {
-		fake.store.saveProfile(profile);
-	}
+	const store = await PersonalityStore.start(fake.runtime);
+	fake.runtime.registerService(PersonalityStore.serviceType, store);
+	fake.store = store;
 }
 
 export function makeMessage(args: {

--- a/packages/core/src/features/advanced-capabilities/personality/actions/personality.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/actions/personality.ts
@@ -554,7 +554,7 @@ async function runSetTrait(
 		return paramError("set_trait", text);
 	}
 
-	const { before, after } = args.store.applyTrait({
+	const { before, after } = await args.store.applyTrait({
 		scope: args.scope,
 		userId: args.userId,
 		agentId: args.agentId,
@@ -601,7 +601,7 @@ async function runClearTrait(
 		await args.callback?.({ text, thought: "Missing trait" });
 		return paramError("clear_trait", text);
 	}
-	const { before, after } = args.store.applyTrait({
+	const { before, after } = await args.store.applyTrait({
 		scope: args.scope,
 		userId: args.userId,
 		agentId: args.agentId,
@@ -642,7 +642,7 @@ async function runSetReplyGate(
 		await args.callback?.({ text, thought: "Missing mode" });
 		return paramError("set_reply_gate", text);
 	}
-	const { before, after } = args.store.applyReplyGate({
+	const { before, after } = await args.store.applyReplyGate({
 		scope: args.scope,
 		userId: args.userId,
 		agentId: args.agentId,
@@ -690,7 +690,7 @@ async function runSetReplyGate(
 async function runLiftReplyGate(
 	args: OpArgs & { scope: PersonalityScope },
 ): Promise<ActionResult> {
-	const { before, after } = args.store.applyReplyGate({
+	const { before, after } = await args.store.applyReplyGate({
 		scope: args.scope,
 		userId: args.userId,
 		agentId: args.agentId,
@@ -740,7 +740,7 @@ async function runAddDirective(
 		await args.callback?.({ text, thought: "Directive too long" });
 		return paramError("add_directive", text);
 	}
-	const { before, after } = args.store.addDirective({
+	const { before, after } = await args.store.addDirective({
 		userId: args.userId,
 		agentId: args.agentId,
 		actorId: args.actorId,
@@ -777,7 +777,7 @@ async function runAddDirective(
 async function runClearDirectives(
 	args: OpArgs & { scope: PersonalityScope },
 ): Promise<ActionResult> {
-	const { before, after } = args.store.clearDirectives({
+	const { before, after } = await args.store.clearDirectives({
 		scope: args.scope,
 		userId: args.userId,
 		agentId: args.agentId,
@@ -825,7 +825,7 @@ async function runLoadProfile(args: {
 		await args.callback?.({ text, thought: "Unknown profile" });
 		return paramError("load_profile", text);
 	}
-	const { before, after } = args.store.loadProfileIntoGlobal(
+	const { before, after } = await args.store.loadProfileIntoGlobal(
 		profile,
 		args.agentId,
 		args.actorId,

--- a/packages/core/src/features/advanced-capabilities/personality/providers/user-personality.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/providers/user-personality.ts
@@ -40,12 +40,18 @@ function renderSlot(
 		});
 	}
 	if (lines.length === 0) return null;
-	if (slot.source === "agent_inferred") {
-		// Provenance is slot-level (last writer), so this annotates the block,
-		// not individual traits. The model should treat inferred style as an
-		// observation it can explain and offer to undo, not a user order.
+	const inferredTraits = Object.entries(slot.trait_sources)
+		.filter(([, source]) => source === "agent_inferred")
+		.map(([trait]) => trait);
+	if (inferredTraits.length > 0 || slot.source === "agent_inferred") {
+		// Name the inferred traits when per-trait provenance identifies them
+		// (directive-only inference falls back to a blanket note). The model
+		// should treat inferred style as an observation it can explain and
+		// offer to undo, not a user order.
+		const what =
+			inferredTraits.length > 0 ? inferredTraits.join(", ") : "some of these";
 		lines.push(
-			"- provenance: inferred from conversation, not explicitly set; offer to adjust if the user objects",
+			`- provenance: ${what} inferred from conversation, not explicitly set; offer to adjust if the user objects`,
 		);
 	}
 	return [header, ...lines, footer].join("\n");

--- a/packages/core/src/features/advanced-capabilities/personality/services/personality-store.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/services/personality-store.ts
@@ -138,6 +138,11 @@ export class PersonalityStore extends Service {
 	private slots: Map<SlotKey, PersonalitySlot> = new Map();
 	private profiles: Map<string, PersonalityProfile> = new Map();
 	private audit: PersonalityAuditEntry[] = [];
+	// Every slot mutation is read-modify-write across the durable upsert await,
+	// so concurrent same-slot writers (PERSONALITY action, preference inference,
+	// bench seeding) could interleave and silently drop a change. This chain
+	// serializes writers per slot; readers stay synchronous on the cache.
+	private slotWriteChains: Map<SlotKey, Promise<unknown>> = new Map();
 
 	static async start(runtime: IAgentRuntime): Promise<PersonalityStore> {
 		const store = new PersonalityStore(runtime);
@@ -230,6 +235,65 @@ export class PersonalityStore extends Service {
 		);
 	}
 
+	/**
+	 * Append a write to the slot's chain so read-modify-write mutations never
+	 * interleave. The returned promise carries the write's own outcome
+	 * (including rejection) to its caller; the stored tail is settled so one
+	 * failed write cannot poison every later write to the same slot.
+	 */
+	private enqueueSlotWrite<T>(
+		key: SlotKey,
+		write: () => Promise<T>,
+	): Promise<T> {
+		const previous = this.slotWriteChains.get(key) ?? Promise.resolve();
+		const next = previous.then(write, write);
+		// error-policy:J5 the rejection is observed by this write's caller via
+		// `next`; the stored tail exists only to sequence the next writer.
+		this.slotWriteChains.set(
+			key,
+			next.catch(() => {}),
+		);
+		return next;
+	}
+
+	private async persistAndCache(slot: PersonalitySlot): Promise<void> {
+		await this.persistSlot(slot);
+		this.cacheSlot(slot);
+	}
+
+	/**
+	 * One canonical serialized mutation path: read the current slot, build the
+	 * next one, persist durably, cache, audit. All public mutators route here
+	 * so the write ordering and audit discipline cannot diverge per operation.
+	 */
+	private mutateSlot(args: {
+		scope: PersonalityScope;
+		targetId: UUID | typeof GLOBAL_PERSONALITY_SCOPE;
+		agentId: UUID;
+		actorId: UUID;
+		build: (before: PersonalitySlot) => PersonalitySlot;
+		action: (after: PersonalitySlot) => string;
+	}): Promise<{ before: PersonalitySlot; after: PersonalitySlot }> {
+		return this.enqueueSlotWrite(
+			slotKey(args.agentId, args.targetId),
+			async () => {
+				const before = this.getSlot(args.targetId, args.agentId);
+				const after = args.build(before);
+				await this.persistAndCache(after);
+				this.recordAudit({
+					actorId: args.actorId,
+					scope: args.scope,
+					targetId: args.targetId,
+					action: args.action(after),
+					before,
+					after,
+					timestamp: after.updated_at,
+				});
+				return { before, after };
+			},
+		);
+	}
+
 	getSlot(
 		userId: UUID | typeof GLOBAL_PERSONALITY_SCOPE,
 		agentId: UUID = this.runtime.agentId,
@@ -240,8 +304,9 @@ export class PersonalityStore extends Service {
 	}
 
 	async setSlot(slot: PersonalitySlot): Promise<void> {
-		await this.persistSlot(slot);
-		this.cacheSlot(slot);
+		await this.enqueueSlotWrite(slotKey(slot.agentId, slot.userId), () =>
+			this.persistAndCache(slot),
+		);
 	}
 
 	listProfiles(): PersonalityProfile[] {
@@ -269,29 +334,24 @@ export class PersonalityStore extends Service {
 		agentId: UUID = this.runtime.agentId,
 		actorId: UUID = this.runtime.agentId,
 	): Promise<{ before: PersonalitySlot; after: PersonalitySlot }> {
-		const before = this.getSlot(GLOBAL_PERSONALITY_SCOPE, agentId);
-		const after: PersonalitySlot = {
-			userId: GLOBAL_PERSONALITY_SCOPE,
-			agentId,
-			verbosity: profile.verbosity,
-			tone: profile.tone,
-			formality: profile.formality,
-			reply_gate: profile.reply_gate,
-			custom_directives: [...profile.custom_directives],
-			updated_at: new Date().toISOString(),
-			source: "admin",
-		};
-		await this.setSlot(after);
-		this.recordAudit({
-			actorId,
+		return this.mutateSlot({
 			scope: "global",
 			targetId: GLOBAL_PERSONALITY_SCOPE,
-			action: `load_profile:${profile.name}`,
-			before,
-			after,
-			timestamp: after.updated_at,
+			agentId,
+			actorId,
+			build: () => ({
+				userId: GLOBAL_PERSONALITY_SCOPE,
+				agentId,
+				verbosity: profile.verbosity,
+				tone: profile.tone,
+				formality: profile.formality,
+				reply_gate: profile.reply_gate,
+				custom_directives: [...profile.custom_directives],
+				updated_at: new Date().toISOString(),
+				source: "admin",
+			}),
+			action: () => `load_profile:${profile.name}`,
 		});
-		return { before, after };
 	}
 
 	snapshotSlotAsProfile(
@@ -334,6 +394,10 @@ export class PersonalityStore extends Service {
 	 * scenario sharing the same runtime process.
 	 */
 	async clear(): Promise<void> {
+		// Drain in-flight slot writes first so a racing mutation cannot
+		// re-persist a slot after the wipe below (stored tails never reject).
+		await Promise.all([...this.slotWriteChains.values()]);
+		this.slotWriteChains.clear();
 		const memories = await this.runtime.getMemories({
 			tableName: PERSONALITY_SLOT_TABLE,
 			roomId: this.runtime.agentId,
@@ -359,26 +423,20 @@ export class PersonalityStore extends Service {
 		value: string | null;
 		source?: PersonalitySlot["source"];
 	}): Promise<{ before: PersonalitySlot; after: PersonalitySlot }> {
-		const targetId =
-			args.scope === "global" ? GLOBAL_PERSONALITY_SCOPE : args.userId;
-		const before = this.getSlot(targetId, args.agentId);
-		const after: PersonalitySlot = {
-			...before,
-			[args.trait]: args.value,
-			updated_at: new Date().toISOString(),
-			source: args.source ?? (args.scope === "global" ? "admin" : "user"),
-		};
-		await this.setSlot(after);
-		this.recordAudit({
-			actorId: args.actorId,
+		return this.mutateSlot({
 			scope: args.scope,
-			targetId,
-			action: `set_trait:${args.trait}=${args.value ?? "null"}`,
-			before,
-			after,
-			timestamp: after.updated_at,
+			targetId:
+				args.scope === "global" ? GLOBAL_PERSONALITY_SCOPE : args.userId,
+			agentId: args.agentId,
+			actorId: args.actorId,
+			build: (before) => ({
+				...before,
+				[args.trait]: args.value,
+				updated_at: new Date().toISOString(),
+				source: args.source ?? (args.scope === "global" ? "admin" : "user"),
+			}),
+			action: () => `set_trait:${args.trait}=${args.value ?? "null"}`,
 		});
-		return { before, after };
 	}
 
 	async applyReplyGate(args: {
@@ -389,26 +447,20 @@ export class PersonalityStore extends Service {
 		mode: PersonalitySlot["reply_gate"];
 		source?: PersonalitySlot["source"];
 	}): Promise<{ before: PersonalitySlot; after: PersonalitySlot }> {
-		const targetId =
-			args.scope === "global" ? GLOBAL_PERSONALITY_SCOPE : args.userId;
-		const before = this.getSlot(targetId, args.agentId);
-		const after: PersonalitySlot = {
-			...before,
-			reply_gate: args.mode,
-			updated_at: new Date().toISOString(),
-			source: args.source ?? (args.scope === "global" ? "admin" : "user"),
-		};
-		await this.setSlot(after);
-		this.recordAudit({
-			actorId: args.actorId,
+		return this.mutateSlot({
 			scope: args.scope,
-			targetId,
-			action: `set_reply_gate:${args.mode ?? "null"}`,
-			before,
-			after,
-			timestamp: after.updated_at,
+			targetId:
+				args.scope === "global" ? GLOBAL_PERSONALITY_SCOPE : args.userId,
+			agentId: args.agentId,
+			actorId: args.actorId,
+			build: (before) => ({
+				...before,
+				reply_gate: args.mode,
+				updated_at: new Date().toISOString(),
+				source: args.source ?? (args.scope === "global" ? "admin" : "user"),
+			}),
+			action: () => `set_reply_gate:${args.mode ?? "null"}`,
 		});
-		return { before, after };
 	}
 
 	async addDirective(args: {
@@ -418,27 +470,24 @@ export class PersonalityStore extends Service {
 		directive: string;
 		source?: PersonalitySlot["source"];
 	}): Promise<{ before: PersonalitySlot; after: PersonalitySlot }> {
-		const before = this.getSlot(args.userId, args.agentId);
-		const next = [...before.custom_directives, args.directive];
-		// FIFO eviction at MAX_CUSTOM_DIRECTIVES
-		while (next.length > MAX_CUSTOM_DIRECTIVES) next.shift();
-		const after: PersonalitySlot = {
-			...before,
-			custom_directives: next,
-			updated_at: new Date().toISOString(),
-			source: args.source ?? "user",
-		};
-		await this.setSlot(after);
-		this.recordAudit({
-			actorId: args.actorId,
+		return this.mutateSlot({
 			scope: "user",
 			targetId: args.userId,
-			action: `add_directive:${args.directive}`,
-			before,
-			after,
-			timestamp: after.updated_at,
+			agentId: args.agentId,
+			actorId: args.actorId,
+			build: (before) => {
+				const next = [...before.custom_directives, args.directive];
+				// FIFO eviction at MAX_CUSTOM_DIRECTIVES
+				while (next.length > MAX_CUSTOM_DIRECTIVES) next.shift();
+				return {
+					...before,
+					custom_directives: next,
+					updated_at: new Date().toISOString(),
+					source: args.source ?? "user",
+				};
+			},
+			action: () => `add_directive:${args.directive}`,
 		});
-		return { before, after };
 	}
 
 	async clearDirectives(args: {
@@ -447,26 +496,20 @@ export class PersonalityStore extends Service {
 		agentId: UUID;
 		actorId: UUID;
 	}): Promise<{ before: PersonalitySlot; after: PersonalitySlot }> {
-		const targetId =
-			args.scope === "global" ? GLOBAL_PERSONALITY_SCOPE : args.userId;
-		const before = this.getSlot(targetId, args.agentId);
-		const after: PersonalitySlot = {
-			...before,
-			custom_directives: [],
-			updated_at: new Date().toISOString(),
-			source: args.scope === "global" ? "admin" : "user",
-		};
-		await this.setSlot(after);
-		this.recordAudit({
-			actorId: args.actorId,
+		return this.mutateSlot({
 			scope: args.scope,
-			targetId,
-			action: "clear_directives",
-			before,
-			after,
-			timestamp: after.updated_at,
+			targetId:
+				args.scope === "global" ? GLOBAL_PERSONALITY_SCOPE : args.userId,
+			agentId: args.agentId,
+			actorId: args.actorId,
+			build: (before) => ({
+				...before,
+				custom_directives: [],
+				updated_at: new Date().toISOString(),
+				source: args.scope === "global" ? "admin" : "user",
+			}),
+			action: () => "clear_directives",
 		});
-		return { before, after };
 	}
 
 	async stop(): Promise<void> {

--- a/packages/core/src/features/advanced-capabilities/personality/services/personality-store.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/services/personality-store.ts
@@ -22,12 +22,15 @@ import {
 	MAX_CUSTOM_DIRECTIVES,
 	PERSONALITY_SLOT_TABLE,
 	type PersonalityAuditEntry,
+	type PersonalityGatedTrait,
 	type PersonalityProfile,
 	type PersonalityScope,
 	PersonalityServiceType,
 	type PersonalitySlot,
+	type PersonalitySource,
 	REPLY_GATE_VALUES,
 	TONE_VALUES,
+	TRAIT_VALUES,
 	VERBOSITY_VALUES,
 } from "../types.ts";
 
@@ -45,12 +48,30 @@ function clone(slot: PersonalitySlot): PersonalitySlot {
 	return {
 		...slot,
 		custom_directives: [...slot.custom_directives],
+		trait_sources: { ...slot.trait_sources },
 	};
+}
+
+/**
+ * Next per-trait provenance map after writing `trait`. Setting a value stamps
+ * the writer; clearing a value (null) drops the key so an unset trait carries
+ * no provenance.
+ */
+function nextTraitSources(
+	before: PersonalitySlot,
+	trait: PersonalityGatedTrait,
+	value: unknown,
+	source: PersonalitySource,
+): PersonalitySlot["trait_sources"] {
+	const next = { ...before.trait_sources };
+	if (value === null) delete next[trait];
+	else next[trait] = source;
+	return next;
 }
 
 function serializeSlotForMemory(
 	slot: PersonalitySlot,
-): Record<string, string | string[] | null> {
+): Record<string, string | string[] | null | Record<string, string>> {
 	return {
 		userId: slot.userId,
 		agentId: slot.agentId,
@@ -61,6 +82,7 @@ function serializeSlotForMemory(
 		custom_directives: [...slot.custom_directives],
 		updated_at: slot.updated_at,
 		source: slot.source,
+		trait_sources: { ...slot.trait_sources } as Record<string, string>,
 	};
 }
 
@@ -74,6 +96,16 @@ function slotMemoryId(
 function slotMemoryEntityId(slot: PersonalitySlot): UUID {
 	return slot.userId === GLOBAL_PERSONALITY_SCOPE ? slot.agentId : slot.userId;
 }
+
+const PERSONALITY_SOURCES: readonly PersonalitySource[] = [
+	"user",
+	"admin",
+	"agent_inferred",
+] as const;
+const GATED_TRAITS: readonly PersonalityGatedTrait[] = [
+	...TRAIT_VALUES,
+	"reply_gate",
+] as const;
 
 function isOneOf<T extends string>(
 	value: unknown,
@@ -116,11 +148,20 @@ function isValidPersistedSlot(value: unknown): value is PersonalitySlot {
 		return false;
 	}
 	if (typeof slot.updated_at !== "string") return false;
-	return (
-		slot.source === "user" ||
-		slot.source === "admin" ||
-		slot.source === "agent_inferred"
-	);
+	if (!isOneOf(slot.source, PERSONALITY_SOURCES)) return false;
+	const traitSources = slot.trait_sources;
+	if (
+		traitSources === null ||
+		typeof traitSources !== "object" ||
+		Array.isArray(traitSources)
+	) {
+		return false;
+	}
+	for (const [trait, source] of Object.entries(traitSources)) {
+		if (!isOneOf(trait, GATED_TRAITS)) return false;
+		if (!isOneOf(source, PERSONALITY_SOURCES)) return false;
+	}
+	return true;
 }
 
 /**
@@ -339,17 +380,25 @@ export class PersonalityStore extends Service {
 			targetId: GLOBAL_PERSONALITY_SCOPE,
 			agentId,
 			actorId,
-			build: () => ({
-				userId: GLOBAL_PERSONALITY_SCOPE,
-				agentId,
-				verbosity: profile.verbosity,
-				tone: profile.tone,
-				formality: profile.formality,
-				reply_gate: profile.reply_gate,
-				custom_directives: [...profile.custom_directives],
-				updated_at: new Date().toISOString(),
-				source: "admin",
-			}),
+			build: () => {
+				const trait_sources: PersonalitySlot["trait_sources"] = {};
+				if (profile.verbosity !== null) trait_sources.verbosity = "admin";
+				if (profile.tone !== null) trait_sources.tone = "admin";
+				if (profile.formality !== null) trait_sources.formality = "admin";
+				if (profile.reply_gate !== null) trait_sources.reply_gate = "admin";
+				return {
+					userId: GLOBAL_PERSONALITY_SCOPE,
+					agentId,
+					verbosity: profile.verbosity,
+					tone: profile.tone,
+					formality: profile.formality,
+					reply_gate: profile.reply_gate,
+					custom_directives: [...profile.custom_directives],
+					updated_at: new Date().toISOString(),
+					source: "admin",
+					trait_sources,
+				};
+			},
 			action: () => `load_profile:${profile.name}`,
 		});
 	}
@@ -429,12 +478,22 @@ export class PersonalityStore extends Service {
 				args.scope === "global" ? GLOBAL_PERSONALITY_SCOPE : args.userId,
 			agentId: args.agentId,
 			actorId: args.actorId,
-			build: (before) => ({
-				...before,
-				[args.trait]: args.value,
-				updated_at: new Date().toISOString(),
-				source: args.source ?? (args.scope === "global" ? "admin" : "user"),
-			}),
+			build: (before) => {
+				const source =
+					args.source ?? (args.scope === "global" ? "admin" : "user");
+				return {
+					...before,
+					[args.trait]: args.value,
+					updated_at: new Date().toISOString(),
+					source,
+					trait_sources: nextTraitSources(
+						before,
+						args.trait,
+						args.value,
+						source,
+					),
+				};
+			},
 			action: () => `set_trait:${args.trait}=${args.value ?? "null"}`,
 		});
 	}
@@ -453,12 +512,22 @@ export class PersonalityStore extends Service {
 				args.scope === "global" ? GLOBAL_PERSONALITY_SCOPE : args.userId,
 			agentId: args.agentId,
 			actorId: args.actorId,
-			build: (before) => ({
-				...before,
-				reply_gate: args.mode,
-				updated_at: new Date().toISOString(),
-				source: args.source ?? (args.scope === "global" ? "admin" : "user"),
-			}),
+			build: (before) => {
+				const source =
+					args.source ?? (args.scope === "global" ? "admin" : "user");
+				return {
+					...before,
+					reply_gate: args.mode,
+					updated_at: new Date().toISOString(),
+					source,
+					trait_sources: nextTraitSources(
+						before,
+						"reply_gate",
+						args.mode,
+						source,
+					),
+				};
+			},
 			action: () => `set_reply_gate:${args.mode ?? "null"}`,
 		});
 	}

--- a/packages/core/src/features/advanced-capabilities/personality/services/personality-store.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/services/personality-store.ts
@@ -8,22 +8,31 @@
  * reload). `getPersonalityStore` is the runtime accessor; the store backs the
  * personality provider and the PERSONALITY action.
  */
+import { ElizaError } from "../../../../errors.ts";
 import { logger } from "../../../../logger.ts";
-import type { IAgentRuntime } from "../../../../types/index.ts";
+import type { IAgentRuntime, Memory } from "../../../../types/index.ts";
+import { MemoryType } from "../../../../types/memory.ts";
 import type { UUID } from "../../../../types/primitives.ts";
 import { Service } from "../../../../types/service.ts";
+import { stringToUuid, validateUuid } from "../../../../utils.ts";
 import {
 	emptyPersonalitySlot,
+	FORMALITY_VALUES,
 	GLOBAL_PERSONALITY_SCOPE,
 	MAX_CUSTOM_DIRECTIVES,
+	PERSONALITY_SLOT_TABLE,
 	type PersonalityAuditEntry,
 	type PersonalityProfile,
 	type PersonalityScope,
 	PersonalityServiceType,
 	type PersonalitySlot,
+	REPLY_GATE_VALUES,
+	TONE_VALUES,
+	VERBOSITY_VALUES,
 } from "../types.ts";
 
 type SlotKey = string;
+const PERSONALITY_SLOT_MEMORY_SOURCE = "personality_slot";
 
 function slotKey(
 	agentId: UUID,
@@ -37,6 +46,81 @@ function clone(slot: PersonalitySlot): PersonalitySlot {
 		...slot,
 		custom_directives: [...slot.custom_directives],
 	};
+}
+
+function serializeSlotForMemory(
+	slot: PersonalitySlot,
+): Record<string, string | string[] | null> {
+	return {
+		userId: slot.userId,
+		agentId: slot.agentId,
+		verbosity: slot.verbosity,
+		tone: slot.tone,
+		formality: slot.formality,
+		reply_gate: slot.reply_gate,
+		custom_directives: [...slot.custom_directives],
+		updated_at: slot.updated_at,
+		source: slot.source,
+	};
+}
+
+function slotMemoryId(
+	agentId: UUID,
+	userId: UUID | typeof GLOBAL_PERSONALITY_SCOPE,
+): UUID {
+	return stringToUuid(`personality-slot:${agentId}:${userId}`);
+}
+
+function slotMemoryEntityId(slot: PersonalitySlot): UUID {
+	return slot.userId === GLOBAL_PERSONALITY_SCOPE ? slot.agentId : slot.userId;
+}
+
+function isOneOf<T extends string>(
+	value: unknown,
+	values: readonly T[],
+): value is T {
+	return typeof value === "string" && values.includes(value as T);
+}
+
+function isValidPersistedSlot(value: unknown): value is PersonalitySlot {
+	if (!value || typeof value !== "object") return false;
+	const slot = value as Partial<PersonalitySlot>;
+	if (
+		slot.userId !== GLOBAL_PERSONALITY_SCOPE &&
+		(typeof slot.userId !== "string" || validateUuid(slot.userId) === null)
+	) {
+		return false;
+	}
+	if (typeof slot.agentId !== "string" || validateUuid(slot.agentId) === null) {
+		return false;
+	}
+	if (slot.verbosity !== null && !isOneOf(slot.verbosity, VERBOSITY_VALUES)) {
+		return false;
+	}
+	if (slot.tone !== null && !isOneOf(slot.tone, TONE_VALUES)) {
+		return false;
+	}
+	if (slot.formality !== null && !isOneOf(slot.formality, FORMALITY_VALUES)) {
+		return false;
+	}
+	if (
+		slot.reply_gate !== null &&
+		!isOneOf(slot.reply_gate, REPLY_GATE_VALUES)
+	) {
+		return false;
+	}
+	if (
+		!Array.isArray(slot.custom_directives) ||
+		!slot.custom_directives.every((directive) => typeof directive === "string")
+	) {
+		return false;
+	}
+	if (typeof slot.updated_at !== "string") return false;
+	return (
+		slot.source === "user" ||
+		slot.source === "admin" ||
+		slot.source === "agent_inferred"
+	);
 }
 
 /**
@@ -63,9 +147,11 @@ export class PersonalityStore extends Service {
 
 	private async initialize(): Promise<void> {
 		await this.loadProfilesFromDisk();
+		await this.hydrateSlotsFromMemory();
 		logger.debug(
 			{
 				profileCount: this.profiles.size,
+				slotCount: this.slots.size,
 			},
 			"PersonalityStore initialized",
 		);
@@ -81,6 +167,69 @@ export class PersonalityStore extends Service {
 		}
 	}
 
+	private async hydrateSlotsFromMemory(): Promise<void> {
+		const memories = await this.runtime.getMemories({
+			tableName: PERSONALITY_SLOT_TABLE,
+			roomId: this.runtime.agentId,
+			metadata: { source: PERSONALITY_SLOT_MEMORY_SOURCE },
+			count: 10_000,
+		});
+		for (const memory of memories) {
+			const slot = this.slotFromMemory(memory);
+			if (slot.agentId !== this.runtime.agentId) continue;
+			this.cacheSlot(slot);
+		}
+	}
+
+	private slotFromMemory(memory: Memory): PersonalitySlot {
+		const metadata = memory.metadata as Record<string, unknown> | undefined;
+		const slot = metadata?.slot;
+		if (!isValidPersistedSlot(slot)) {
+			throw new ElizaError("Invalid persisted personality slot memory", {
+				code: "PERSONALITY_SLOT_MEMORY_INVALID",
+				severity: "fatal",
+				context: {
+					memoryId: memory.id,
+					agentId: this.runtime.agentId,
+				},
+			});
+		}
+		return clone(slot);
+	}
+
+	private cacheSlot(slot: PersonalitySlot): void {
+		this.slots.set(slotKey(slot.agentId, slot.userId), clone(slot));
+	}
+
+	private async persistSlot(slot: PersonalitySlot): Promise<void> {
+		const persisted = clone(slot);
+		const timestamp = Date.parse(persisted.updated_at);
+		const createdAt = Number.isFinite(timestamp) ? timestamp : Date.now();
+		await this.runtime.upsertMemory(
+			{
+				id: slotMemoryId(persisted.agentId, persisted.userId),
+				entityId: slotMemoryEntityId(persisted),
+				roomId: persisted.agentId,
+				agentId: persisted.agentId,
+				content: {
+					text: `personality_slot ${persisted.userId}`,
+					source: PERSONALITY_SLOT_MEMORY_SOURCE,
+				},
+				metadata: {
+					type: MemoryType.CUSTOM,
+					source: PERSONALITY_SLOT_MEMORY_SOURCE,
+					timestamp: createdAt,
+					personalitySlotKey: slotKey(persisted.agentId, persisted.userId),
+					personalityUserId: persisted.userId,
+					personalityAgentId: persisted.agentId,
+					slot: serializeSlotForMemory(persisted),
+				},
+				createdAt,
+			},
+			PERSONALITY_SLOT_TABLE,
+		);
+	}
+
 	getSlot(
 		userId: UUID | typeof GLOBAL_PERSONALITY_SCOPE,
 		agentId: UUID = this.runtime.agentId,
@@ -90,8 +239,9 @@ export class PersonalityStore extends Service {
 		return emptyPersonalitySlot(userId, agentId);
 	}
 
-	setSlot(slot: PersonalitySlot): void {
-		this.slots.set(slotKey(slot.agentId, slot.userId), clone(slot));
+	async setSlot(slot: PersonalitySlot): Promise<void> {
+		await this.persistSlot(slot);
+		this.cacheSlot(slot);
 	}
 
 	listProfiles(): PersonalityProfile[] {
@@ -114,11 +264,11 @@ export class PersonalityStore extends Service {
 		});
 	}
 
-	loadProfileIntoGlobal(
+	async loadProfileIntoGlobal(
 		profile: PersonalityProfile,
 		agentId: UUID = this.runtime.agentId,
 		actorId: UUID = this.runtime.agentId,
-	): { before: PersonalitySlot; after: PersonalitySlot } {
+	): Promise<{ before: PersonalitySlot; after: PersonalitySlot }> {
 		const before = this.getSlot(GLOBAL_PERSONALITY_SCOPE, agentId);
 		const after: PersonalitySlot = {
 			userId: GLOBAL_PERSONALITY_SCOPE,
@@ -131,7 +281,7 @@ export class PersonalityStore extends Service {
 			updated_at: new Date().toISOString(),
 			source: "admin",
 		};
-		this.setSlot(after);
+		await this.setSlot(after);
 		this.recordAudit({
 			actorId,
 			scope: "global",
@@ -175,15 +325,24 @@ export class PersonalityStore extends Service {
 	}
 
 	/**
-	 * Drop every in-memory personality slot and audit entry. Bundled profile
-	 * defaults are preserved (they are loaded from disk on initialize and
-	 * never mutated by slot operations).
+	 * Drop every personality slot and audit entry. Bundled profile defaults are
+	 * preserved (they are loaded from disk on initialize and never mutated by
+	 * slot operations).
 	 *
 	 * Used by the benchmark harness's `/api/benchmark/reset` route so that
 	 * personality state seeded by one scenario does not leak into the next
 	 * scenario sharing the same runtime process.
 	 */
-	clear(): void {
+	async clear(): Promise<void> {
+		const memories = await this.runtime.getMemories({
+			tableName: PERSONALITY_SLOT_TABLE,
+			roomId: this.runtime.agentId,
+			metadata: { source: PERSONALITY_SLOT_MEMORY_SOURCE },
+			count: 10_000,
+		});
+		for (const memory of memories) {
+			if (memory.id) await this.runtime.deleteMemory(memory.id);
+		}
 		this.slots.clear();
 		this.audit.length = 0;
 	}
@@ -191,7 +350,7 @@ export class PersonalityStore extends Service {
 	/**
 	 * Apply a trait change with audit. Returns the slot before and after.
 	 */
-	applyTrait(args: {
+	async applyTrait(args: {
 		scope: PersonalityScope;
 		userId: UUID;
 		agentId: UUID;
@@ -199,7 +358,7 @@ export class PersonalityStore extends Service {
 		trait: "verbosity" | "tone" | "formality";
 		value: string | null;
 		source?: PersonalitySlot["source"];
-	}): { before: PersonalitySlot; after: PersonalitySlot } {
+	}): Promise<{ before: PersonalitySlot; after: PersonalitySlot }> {
 		const targetId =
 			args.scope === "global" ? GLOBAL_PERSONALITY_SCOPE : args.userId;
 		const before = this.getSlot(targetId, args.agentId);
@@ -209,7 +368,7 @@ export class PersonalityStore extends Service {
 			updated_at: new Date().toISOString(),
 			source: args.source ?? (args.scope === "global" ? "admin" : "user"),
 		};
-		this.setSlot(after);
+		await this.setSlot(after);
 		this.recordAudit({
 			actorId: args.actorId,
 			scope: args.scope,
@@ -222,14 +381,14 @@ export class PersonalityStore extends Service {
 		return { before, after };
 	}
 
-	applyReplyGate(args: {
+	async applyReplyGate(args: {
 		scope: PersonalityScope;
 		userId: UUID;
 		agentId: UUID;
 		actorId: UUID;
 		mode: PersonalitySlot["reply_gate"];
 		source?: PersonalitySlot["source"];
-	}): { before: PersonalitySlot; after: PersonalitySlot } {
+	}): Promise<{ before: PersonalitySlot; after: PersonalitySlot }> {
 		const targetId =
 			args.scope === "global" ? GLOBAL_PERSONALITY_SCOPE : args.userId;
 		const before = this.getSlot(targetId, args.agentId);
@@ -239,7 +398,7 @@ export class PersonalityStore extends Service {
 			updated_at: new Date().toISOString(),
 			source: args.source ?? (args.scope === "global" ? "admin" : "user"),
 		};
-		this.setSlot(after);
+		await this.setSlot(after);
 		this.recordAudit({
 			actorId: args.actorId,
 			scope: args.scope,
@@ -252,13 +411,13 @@ export class PersonalityStore extends Service {
 		return { before, after };
 	}
 
-	addDirective(args: {
+	async addDirective(args: {
 		userId: UUID;
 		agentId: UUID;
 		actorId: UUID;
 		directive: string;
 		source?: PersonalitySlot["source"];
-	}): { before: PersonalitySlot; after: PersonalitySlot } {
+	}): Promise<{ before: PersonalitySlot; after: PersonalitySlot }> {
 		const before = this.getSlot(args.userId, args.agentId);
 		const next = [...before.custom_directives, args.directive];
 		// FIFO eviction at MAX_CUSTOM_DIRECTIVES
@@ -269,7 +428,7 @@ export class PersonalityStore extends Service {
 			updated_at: new Date().toISOString(),
 			source: args.source ?? "user",
 		};
-		this.setSlot(after);
+		await this.setSlot(after);
 		this.recordAudit({
 			actorId: args.actorId,
 			scope: "user",
@@ -282,12 +441,12 @@ export class PersonalityStore extends Service {
 		return { before, after };
 	}
 
-	clearDirectives(args: {
+	async clearDirectives(args: {
 		scope: PersonalityScope;
 		userId: UUID;
 		agentId: UUID;
 		actorId: UUID;
-	}): { before: PersonalitySlot; after: PersonalitySlot } {
+	}): Promise<{ before: PersonalitySlot; after: PersonalitySlot }> {
 		const targetId =
 			args.scope === "global" ? GLOBAL_PERSONALITY_SCOPE : args.userId;
 		const before = this.getSlot(targetId, args.agentId);
@@ -297,7 +456,7 @@ export class PersonalityStore extends Service {
 			updated_at: new Date().toISOString(),
 			source: args.scope === "global" ? "admin" : "user",
 		};
-		this.setSlot(after);
+		await this.setSlot(after);
 		this.recordAudit({
 			actorId: args.actorId,
 			scope: args.scope,

--- a/packages/core/src/features/advanced-capabilities/personality/types.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/types.ts
@@ -85,6 +85,12 @@ export const MAX_DIRECTIVE_CHARS = 200;
 /** Hard token cap for terse verbosity responses (post-generation truncation). */
 export const MAX_TERSE_TOKENS = 60;
 
+/** Who authored a personality write. Explicit (user/admin) beats inference. */
+export type PersonalitySource = "user" | "admin" | "agent_inferred";
+
+/** Slot fields that carry per-trait provenance in `trait_sources`. */
+export type PersonalityGatedTrait = PersonalityTrait | "reply_gate";
+
 /**
  * Structured per-user (or global) personality slot.
  *
@@ -100,7 +106,16 @@ export interface PersonalitySlot {
 	reply_gate: ReplyGateMode | null;
 	custom_directives: string[];
 	updated_at: string;
-	source: "user" | "admin" | "agent_inferred";
+	/** Last writer of ANY field — display/audit only, never a safety gate. */
+	source: PersonalitySource;
+	/**
+	 * Per-trait provenance: who set each currently-set trait (keys exist only
+	 * for set traits). Inference gates MUST read this, not `source`: `source`
+	 * is just the last writer, so a single inferred directive write would
+	 * otherwise relabel the whole slot and let a later inferred set_trait
+	 * overwrite an explicitly-set trait cross-turn.
+	 */
+	trait_sources: Partial<Record<PersonalityGatedTrait, PersonalitySource>>;
 }
 
 /** A named global profile (admin loadable). */
@@ -140,5 +155,6 @@ export function emptyPersonalitySlot(
 		custom_directives: [],
 		updated_at: new Date(0).toISOString(),
 		source: "user",
+		trait_sources: {},
 	};
 }

--- a/packages/lifeops-bench/src/__tests__/role-seeding.test.ts
+++ b/packages/lifeops-bench/src/__tests__/role-seeding.test.ts
@@ -45,8 +45,8 @@ interface FakeStore {
     custom_directives: string[];
     updated_at: string;
     source: string;
-  }): void;
-  clear(): void;
+  }): Promise<void>;
+  clear(): Promise<void>;
   cleared: number;
   slots: RecordedSlot[];
 }
@@ -55,7 +55,7 @@ function fakeStore(): FakeStore {
   const store: FakeStore = {
     cleared: 0,
     slots: [],
-    setSlot(slot) {
+    async setSlot(slot) {
       this.slots.push({
         userId: slot.userId,
         agentId: slot.agentId,
@@ -63,7 +63,7 @@ function fakeStore(): FakeStore {
         source: slot.source,
       });
     },
-    clear() {
+    async clear() {
       this.cleared += 1;
       this.slots.length = 0;
     },
@@ -153,19 +153,19 @@ describe("isScopeSeedMode", () => {
 });
 
 describe("clearPersonalityStateOnReset", () => {
-  it("calls clear() on the runtime's PersonalityStore", () => {
+  it("calls clear() on the runtime's PersonalityStore", async () => {
     const store = fakeStore();
     const runtime = fakeRuntime(store);
-    const cleared = clearPersonalityStateOnReset(
+    const cleared = await clearPersonalityStateOnReset(
       runtime as unknown as Parameters<typeof clearPersonalityStateOnReset>[0],
     );
     expect(cleared).toBe(true);
     expect(store.cleared).toBe(1);
   });
 
-  it("returns false when the runtime has no PersonalityStore service", () => {
+  it("returns false when the runtime has no PersonalityStore service", async () => {
     const runtime = fakeRuntime(null);
-    const cleared = clearPersonalityStateOnReset(
+    const cleared = await clearPersonalityStateOnReset(
       runtime as unknown as Parameters<typeof clearPersonalityStateOnReset>[0],
     );
     expect(cleared).toBe(false);
@@ -173,10 +173,10 @@ describe("clearPersonalityStateOnReset", () => {
 });
 
 describe("applyRoleSeedPayload", () => {
-  it("seeds a global directive into the GLOBAL slot when scopeMode=global_wins", () => {
+  it("seeds a global directive into the GLOBAL slot when scopeMode=global_wins", async () => {
     const store = fakeStore();
     const runtime = fakeRuntime(store);
-    const result = applyRoleSeedPayload(
+    const result = await applyRoleSeedPayload(
       runtime as unknown as Parameters<typeof applyRoleSeedPayload>[0],
       {
         globalDirective: "always respond in metric units",
@@ -195,10 +195,10 @@ describe("applyRoleSeedPayload", () => {
     expect(store.slots[0].source).toBe("admin");
   });
 
-  it("seeds a user directive into the per-user slot when scopeMode=user_wins", () => {
+  it("seeds a user directive into the per-user slot when scopeMode=user_wins", async () => {
     const store = fakeStore();
     const runtime = fakeRuntime(store);
-    const result = applyRoleSeedPayload(
+    const result = await applyRoleSeedPayload(
       runtime as unknown as Parameters<typeof applyRoleSeedPayload>[0],
       {
         userDirective: "I prefer imperial units",
@@ -214,10 +214,10 @@ describe("applyRoleSeedPayload", () => {
     expect(store.slots[0].source).toBe("user");
   });
 
-  it("seeds BOTH slots when both directives are set", () => {
+  it("seeds BOTH slots when both directives are set", async () => {
     const store = fakeStore();
     const runtime = fakeRuntime(store);
-    const result = applyRoleSeedPayload(
+    const result = await applyRoleSeedPayload(
       runtime as unknown as Parameters<typeof applyRoleSeedPayload>[0],
       {
         globalDirective: "always respond in metric units",
@@ -236,10 +236,10 @@ describe("applyRoleSeedPayload", () => {
     expect(user?.source).toBe("user");
   });
 
-  it("does not seed a user directive when userId is missing", () => {
+  it("does not seed a user directive when userId is missing", async () => {
     const store = fakeStore();
     const runtime = fakeRuntime(store);
-    const result = applyRoleSeedPayload(
+    const result = await applyRoleSeedPayload(
       runtime as unknown as Parameters<typeof applyRoleSeedPayload>[0],
       {
         userDirective: "I prefer imperial",
@@ -250,10 +250,10 @@ describe("applyRoleSeedPayload", () => {
     expect(store.slots).toHaveLength(0);
   });
 
-  it("no-ops cleanly when payload has only a scopeMode tag", () => {
+  it("no-ops cleanly when payload has only a scopeMode tag", async () => {
     const store = fakeStore();
     const runtime = fakeRuntime(store);
-    const result = applyRoleSeedPayload(
+    const result = await applyRoleSeedPayload(
       runtime as unknown as Parameters<typeof applyRoleSeedPayload>[0],
       { scopeMode: "conflict_implicit" } as RoleSeedPayload,
     );
@@ -263,9 +263,9 @@ describe("applyRoleSeedPayload", () => {
     expect(store.slots).toHaveLength(0);
   });
 
-  it("throws when the runtime cannot serve PersonalityStore but the payload carries a directive", () => {
+  it("throws when the runtime cannot serve PersonalityStore but the payload carries a directive", async () => {
     const runtime = fakeRuntime(null);
-    expect(() =>
+    await expect(
       applyRoleSeedPayload(
         runtime as unknown as Parameters<typeof applyRoleSeedPayload>[0],
         {
@@ -273,6 +273,6 @@ describe("applyRoleSeedPayload", () => {
           scopeMode: "global_wins",
         },
       ),
-    ).toThrow(/PersonalityStore service unavailable/);
+    ).rejects.toThrow(/PersonalityStore service unavailable/);
   });
 });

--- a/packages/lifeops-bench/src/__tests__/role-seeding.test.ts
+++ b/packages/lifeops-bench/src/__tests__/role-seeding.test.ts
@@ -45,6 +45,7 @@ interface FakeStore {
     custom_directives: string[];
     updated_at: string;
     source: string;
+    trait_sources: Record<string, string>;
   }): Promise<void>;
   clear(): Promise<void>;
   cleared: number;

--- a/packages/lifeops-bench/src/server-utils.ts
+++ b/packages/lifeops-bench/src/server-utils.ts
@@ -1171,8 +1171,8 @@ interface BenchPersonalityStore {
     custom_directives: string[];
     updated_at: string;
     source: "user" | "admin" | "agent_inferred";
-  }): void;
-  clear(): void;
+  }): Promise<void>;
+  clear(): Promise<void>;
 }
 
 const PERSONALITY_STORE_SERVICE = "PERSONALITY_STORE";
@@ -1227,15 +1227,19 @@ export function parseRoleSeedPayload(
 }
 
 /**
- * Always-clear the in-memory PersonalityStore so stale slots do not bleed
- * across benchmark scenarios sharing one runtime process (synthesis P1-14).
- * Returns true when the store was cleared; false when the runtime did not
- * load advanced capabilities.
+ * Always-clear the PersonalityStore (durable slot memories + in-memory cache)
+ * so stale slots do not bleed across benchmark scenarios sharing one runtime
+ * process (synthesis P1-14). Returns true when the store was cleared; false
+ * when the runtime did not load advanced capabilities. The clear is awaited —
+ * reporting "cleared" before the wipe lands would reintroduce the exact
+ * cross-scenario bleed this helper exists to prevent.
  */
-export function clearPersonalityStateOnReset(runtime: AgentRuntime): boolean {
+export async function clearPersonalityStateOnReset(
+  runtime: AgentRuntime,
+): Promise<boolean> {
   const store = getBenchPersonalityStore(runtime);
   if (!store) return false;
-  store.clear();
+  await store.clear();
   return true;
 }
 
@@ -1245,14 +1249,14 @@ export function clearPersonalityStateOnReset(runtime: AgentRuntime): boolean {
  * something concrete to apply — callers should surface that as a 4xx since
  * the scenario asked for a guarantee the server can't provide.
  */
-export function applyRoleSeedPayload(
+export async function applyRoleSeedPayload(
   runtime: AgentRuntime,
   payload: RoleSeedPayload,
-): {
+): Promise<{
   appliedGlobalDirective: boolean;
   appliedUserDirective: boolean;
   scopeMode: ScopeSeedMode | null;
-} {
+}> {
   const hasDirective = Boolean(
     payload.globalDirective || payload.userDirective,
   );
@@ -1277,7 +1281,7 @@ export function applyRoleSeedPayload(
   let appliedUserDirective = false;
 
   if (payload.globalDirective) {
-    store.setSlot({
+    await store.setSlot({
       userId: PERSONALITY_GLOBAL_SCOPE,
       agentId,
       verbosity: null,
@@ -1292,7 +1296,7 @@ export function applyRoleSeedPayload(
   }
 
   if (payload.userDirective && payload.userId) {
-    store.setSlot({
+    await store.setSlot({
       userId: payload.userId,
       agentId,
       verbosity: null,

--- a/packages/lifeops-bench/src/server-utils.ts
+++ b/packages/lifeops-bench/src/server-utils.ts
@@ -1171,6 +1171,7 @@ interface BenchPersonalityStore {
     custom_directives: string[];
     updated_at: string;
     source: "user" | "admin" | "agent_inferred";
+    trait_sources: Record<string, "user" | "admin" | "agent_inferred">;
   }): Promise<void>;
   clear(): Promise<void>;
 }
@@ -1291,6 +1292,7 @@ export async function applyRoleSeedPayload(
       custom_directives: [payload.globalDirective],
       updated_at: now,
       source: "admin",
+      trait_sources: {},
     });
     appliedGlobalDirective = true;
   }
@@ -1306,6 +1308,7 @@ export async function applyRoleSeedPayload(
       custom_directives: [payload.userDirective],
       updated_at: now,
       source: "user",
+      trait_sources: {},
     });
     appliedUserDirective = true;
   }


### PR DESCRIPTION
## Summary
- Mirror each structured personality slot into `PERSONALITY_SLOT_TABLE` with a deterministic memory id per `agentId:userId` slot.
- Hydrate `PersonalityStore` from mirrored slot memories during service startup instead of treating missing in-memory state as a real empty preference set.
- Make slot mutations await the durable upsert before updating the in-memory cache or returning action success.
- Delete mirrored slot memories during `clear()` so benchmark/reset flows do not rehydrate stale preferences later.
- Extend the fake runtime harness with upsert + metadata-filter behavior and add regression coverage for restart hydration, same-slot upsert behavior, and clear cleanup.

This fixes #14674. It intentionally does not broaden into named profile persistence or the passive preference-evaluator companion issue.

## Verification
- `bun run --cwd packages/core test src/features/advanced-capabilities/personality/__tests__/personality-store.test.ts src/features/advanced-capabilities/personality/__tests__/personality-provider.test.ts src/features/advanced-capabilities/personality/__tests__/personality-action.test.ts` - pass, 3 files / 34 tests.
- `bun run --cwd packages/core typecheck` - pass.
- `bun run --cwd packages/core build` - pass; Node, browser, edge, testing bundle, declarations.
- `bunx @biomejs/biome check packages/core/src/features/advanced-capabilities/personality/services/personality-store.ts packages/core/src/features/advanced-capabilities/personality/actions/personality.ts packages/core/src/features/advanced-capabilities/personality/__tests__/test-helpers.ts packages/core/src/features/advanced-capabilities/personality/__tests__/personality-store.test.ts packages/core/src/features/advanced-capabilities/personality/__tests__/personality-provider.test.ts` - pass.
- `git diff --check` - pass.
- `bun run audit:error-policy-ratchet --report` - pass; touched production files add no empty catches or server console calls.

## Evidence
<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - this is a core runtime persistence fix with no rendered app or connector UI surface.

<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - no rendered UI changed; deterministic tests verify persisted memory rows and provider hydration.

<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no user-facing screen flow changed in this PR.

<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no long-running backend was started; `bun run --cwd packages/core build` and focused Vitest logs exercise the runtime service path locally.

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A - no frontend route, browser surface, or network flow changed.

<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no model prompt/selection behavior changed, and no live provider credentials are available in this local environment. The action path is covered deterministically.

<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - no external DB artifact is attached from this local run; regression tests assert the domain artifact shape directly: two mirrored `PERSONALITY_SLOT_TABLE` rows for user+global slots, one row after same-slot upsert, hydration into a fresh store, and deletion on `clear()`.

## Notes
- The first post-rebase focused test attempt failed before running tests because `@elizaos/logger` dist was missing in the freshly rebased workspace. Running `bun run --cwd packages/core build` rebuilt logger/contracts/core; the same focused test command then passed.

Closes #14674