### PR TITLE
fix(scenarios): keep known-red widget cases pending

### DIFF
--- a/packages/scenario-runner/schema/index.js
+++ b/packages/scenario-runner/schema/index.js
@@ -143,6 +143,7 @@ export const DEFAULT_SCENARIO_LANE = "live-only";
 
 const SCENARIO_LANES = new Set(["pr-deterministic", "live-only"]);
 const SCENARIO_TIERS = new Set(["T1", "T2", "T3", "T4"]);
+const SCENARIO_STATUSES = new Set(["active", "pending"]);
 
 /** Resolve a scenario's effective lane, applying {@link DEFAULT_SCENARIO_LANE}. */
 export function scenarioLane(value) {
@@ -170,6 +171,19 @@ export function scenarioTier(value) {
     );
   }
   return tier;
+}
+
+function validateScenarioStatus(value) {
+  const status = value?.status;
+  if (status === undefined) {
+    return undefined;
+  }
+  if (!SCENARIO_STATUSES.has(status)) {
+    throw new Error(
+      `scenario "${value?.id ?? "<unknown>"}" has invalid status "${status}"; expected one of ${[...SCENARIO_STATUSES].join(", ")}`,
+    );
+  }
+  return status;
 }
 
 /**
@@ -217,6 +231,8 @@ export function scenario(value) {
     scenarioLane(value);
     // Validate optional LifeOps/persona tier metadata when authored.
     scenarioTier(value);
+    // Validate pending/active inventory status before loader filtering relies on it.
+    validateScenarioStatus(value);
     // Validate the deferral shape (and lane compatibility) eagerly too.
     scenarioDeferral(value);
   }

--- a/packages/scenario-runner/src/__tests__/loader-lane-filter.test.ts
+++ b/packages/scenario-runner/src/__tests__/loader-lane-filter.test.ts
@@ -3,16 +3,16 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { listScenarioMetadata } from "../loader";
+import { listScenarioMetadata, loadAllScenarios } from "../loader";
 
 let tempDirs: string[] = [];
 
 function makeScenarioDir(
-  files: Record<string, { id: string; lane?: string }>,
+  files: Record<string, { id: string; lane?: string; status?: string }>,
 ): string {
   const dir = mkdtempSync(path.join(tmpdir(), "scenario-lane-filter-"));
   tempDirs.push(dir);
-  for (const [fileName, { id, lane }] of Object.entries(files)) {
+  for (const [fileName, { id, lane, status }] of Object.entries(files)) {
     writeFileSync(
       path.join(dir, fileName),
       [
@@ -21,6 +21,7 @@ function makeScenarioDir(
         `  title: "${id}",`,
         '  domain: "loader-test",',
         ...(lane ? [`  lane: "${lane}",`] : []),
+        ...(status ? [`  status: "${status}",`] : []),
         "  turns: [],",
         "};",
         "",
@@ -87,5 +88,48 @@ describe("listScenarioMetadata lane filtering", () => {
       "lane-deterministic",
       "lane-undeclared",
     ]);
+  });
+
+  it("excludes pending scenarios from list and run inventories unless explicitly included", async () => {
+    const previous = process.env.SCENARIO_INCLUDE_PENDING;
+    const dir = makeScenarioDir({
+      "active.scenario.ts": {
+        id: "pending-active",
+        lane: "live-only",
+      },
+      "pending.scenario.ts": {
+        id: "pending-hidden",
+        lane: "live-only",
+        status: "pending",
+      },
+    });
+
+    try {
+      delete process.env.SCENARIO_INCLUDE_PENDING;
+
+      await expect(listScenarioMetadata(dir)).resolves.toMatchObject([
+        { id: "pending-active" },
+      ]);
+      await expect(loadAllScenarios(dir)).resolves.toHaveLength(1);
+
+      process.env.SCENARIO_INCLUDE_PENDING = "1";
+
+      await expect(
+        listScenarioMetadata(dir).then((scenarios) =>
+          scenarios.map((scenario) => scenario.id).sort(),
+        ),
+      ).resolves.toEqual(["pending-active", "pending-hidden"]);
+      await expect(
+        loadAllScenarios(dir).then((scenarios) =>
+          scenarios.map(({ scenario }) => scenario.id).sort(),
+        ),
+      ).resolves.toEqual(["pending-active", "pending-hidden"]);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.SCENARIO_INCLUDE_PENDING;
+      } else {
+        process.env.SCENARIO_INCLUDE_PENDING = previous;
+      }
+    }
   });
 });

--- a/packages/scenario-runner/src/schema-strict.test.ts
+++ b/packages/scenario-runner/src/schema-strict.test.ts
@@ -94,6 +94,24 @@ describe("scenario() strict finalCheck validation", () => {
   });
 });
 
+describe("scenario() strict scenario metadata validation", () => {
+  const base = {
+    id: "fixture.strict.metadata",
+    title: "Strict metadata fixture",
+    domain: "fixture",
+    turns: [{ kind: "message", name: "ask", text: "hello" }],
+  } satisfies ScenarioDefinition;
+
+  it("throws on an unknown top-level scenario status instead of running it", () => {
+    expect(() =>
+      scenario({
+        ...base,
+        status: "known-red",
+      } as unknown as ScenarioDefinition),
+    ).toThrow(/invalid status "known-red"/);
+  });
+});
+
 describe("loadScenarioFile strict validation", () => {
   it("hard-fails loading a plain-object scenario with an unknown finalCheck type", async () => {
     const dir = await makeTempScenarioDir();

--- a/packages/scenario-runner/test/scenarios/live-chat-widgets-choice-roundtrip.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-chat-widgets-choice-roundtrip.scenario.ts
@@ -59,6 +59,7 @@ const INSTALLED_APPS_FIXTURE = [
 export default scenario({
   id: "live-chat-widgets-choice-roundtrip",
   lane: "live-only",
+  status: "pending",
   title: "Real LLM surfaces a [CHOICE] picker, then honors the picked value",
   domain: "chat-widgets",
   tags: ["live", "real-llm", "chat-widgets", "choice", "app-control"],

--- a/packages/scenario-runner/test/scenarios/live-chat-widgets-form-roundtrip.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-chat-widgets-form-roundtrip.scenario.ts
@@ -47,6 +47,7 @@ const SUBMITTED_TOKEN_RE = /q3|budget|dana/i;
 export default scenario({
   id: "live-chat-widgets-form-roundtrip",
   lane: "live-only",
+  status: "pending",
   title: "Real LLM emits a [FORM], consumes the raw [form:submit] re-entry",
   domain: "chat-widgets",
   tags: ["live", "real-llm", "chat-widgets", "form", "lifeops"],


### PR DESCRIPTION
## Summary
- Mark the two #14322 KNOWN-RED chat-widget live scenarios as `status: "pending"` so scheduled live lanes do not intentionally run red cases by default.
- Keep them discoverable with `SCENARIO_INCLUDE_PENDING=1` for inventory/reproduction.
- Validate top-level scenario `status` values at definition/load time so a typo cannot silently become active coverage.
- Add a focused loader regression for pending list/run inventory filtering.

Refs #14322.

## Verification
- `bun run --cwd packages/scenario-runner test -- src/__tests__/loader-lane-filter.test.ts src/schema-strict.test.ts src/scenario-deferral.test.ts` -> 3 files, 20 tests passed.
- `bun run --cwd packages/scenario-runner src/cli.ts list test/scenarios --scenario live-chat-widgets-choice-roundtrip` -> no output, hidden by default.
- `bun run --cwd packages/scenario-runner src/cli.ts list test/scenarios --scenario live-chat-widgets-form-roundtrip` -> no output, hidden by default.
- `SCENARIO_INCLUDE_PENDING=1 bun run --cwd packages/scenario-runner src/cli.ts list test/scenarios --scenario live-chat-widgets-choice-roundtrip && SCENARIO_INCLUDE_PENDING=1 bun run --cwd packages/scenario-runner src/cli.ts list test/scenarios --scenario live-chat-widgets-form-roundtrip` -> listed both pending scenarios.
- `bunx @biomejs/biome check packages/scenario-runner/test/scenarios/live-chat-widgets-choice-roundtrip.scenario.ts packages/scenario-runner/test/scenarios/live-chat-widgets-form-roundtrip.scenario.ts packages/scenario-runner/schema/index.js packages/scenario-runner/src/__tests__/loader-lane-filter.test.ts packages/scenario-runner/src/schema-strict.test.ts` -> clean.
- `git diff --check` -> clean.

## Typecheck note
- `bun run --cwd packages/scenario-runner typecheck` currently fails before this patch on existing workspace/generated export resolution errors, including missing `@elizaos/plugin-xr`, `@elizaos/plugin-blocker/services/website-blocker/index`, `@elizaos/shared/*`, and related generated UI/shared exports.


## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - scenario metadata/schema change only; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [x] N/A - scenario metadata/schema change only; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing runtime flow changed; pending scenarios are inventory-filtered by CLI/loader behavior.

<!-- evidence-row:backend-logs -->
- [x] N/A - no long-running backend service was started; focused scenario-runner tests and CLI list output are summarized in Verification.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response path changed.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - this change prevents known-red live model scenarios from running by default; it does not alter model/action/prompt behavior.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifact is produced; CLI inventory output proves pending scenarios are hidden by default and visible with SCENARIO_INCLUDE_PENDING=1.

Additional local review note: `bun run --cwd packages/scenario-runner typecheck` still fails on existing workspace/generated module-resolution gaps (`@elizaos/plugin-xr`, plugin-blocker service export, personal-assistant exports, Capacitor UI packages), matching the Typecheck note above.
