### PR TITLE
fix(scenarios): clean widget coverage merge drift

### DIFF
--- a/packages/scenario-runner/test/scenarios/live-chat-widgets-choice-roundtrip.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-chat-widgets-choice-roundtrip.scenario.ts
@@ -14,19 +14,11 @@
  * Installed apps are served by the fetch loopback so the picker branch is
  * deterministic; the model routing and the pick round trip are live.
  *
- * KNOWN-RED (#14322 finding): this scenario asserts the correct product
- * contract and fails today because the v5 planner path DROPS action handler
- * callback text. The `executeV5PlannedToolCall` call sites in
- * `packages/core/src/services/message.ts` build `executorCtx` without a
- * `callback`, so `execute-planned-tool-call.ts` hands `undefined` to
- * `action.handler(...)` and the `[CHOICE:app-create …]` block that
- * plugin-app-control emits via `callback?.({ text })` never reaches the user —
- * the reply is the Stage-1 early ack ("On it.") and the picker exists only in
- * the captured ActionResult. Turn 2 then compounds it: with no picker on
- * screen the planner answers "cancel" with a bare REPLY ("Canceled.") without
- * running APP, leaving the pending intent task alive — a fabricated
- * cancellation. Fixing the callback plumbing is core planner surgery tracked
- * as a follow-up in #14322.
+ * Regression target: #14322 found that the v5 planned-tool path could drop
+ * action handler callback text, so the `[CHOICE:app-create ...]` block emitted
+ * by plugin-app-control never reached the user. The callback plumbing fix
+ * landed separately; this live-only scenario keeps the visible picker plus
+ * bare-value re-entry contract pinned end to end.
  */
 
 import { stringToUuid } from "@elizaos/core";

--- a/packages/scenario-runner/test/scenarios/live-chat-widgets-form-roundtrip.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-chat-widgets-form-roundtrip.scenario.ts
@@ -13,21 +13,11 @@
  * is trusted text re-entry, which is exactly what this scenario puts under
  * live test. Needs live model credentials (live-only lane).
  *
- * KNOWN-RED (#14322 finding): this scenario asserts the correct product
- * contract and fails today because [FORM] is structurally unreachable on the
- * v5 path. The chain, live-verified in evidence-14322/form-run-attempt* with
- * the uiWidgets guide confirmed present in the planner AND evaluation
- * prompts: (1) planner rules force tool-first ("matching tool exists => call
- * it, even missing details; handler owns questions"), so the model calls
- * OWNER_REMINDERS_CREATE instead of emitting a form; (2) the handler
- * clarifies in prose ("What's the report name, day, and time?"); (3) the
- * evaluator stage — the model that authors the user-visible messageToUser —
- * is bound by "messageToUser … no … JSON/tool attempts" and "One JSON object
- * only" (its own envelope), so a [FORM] block (whose body IS a JSON line) can
- * never survive, while JSON-free markers like [CONFIG:pluginId] pass. Stage 1
- * never composes the guide (CORE_RESPONSE_STATE_PROVIDERS only). Fixing this
- * needs a core evaluator/messageToUser contract carve-out for interaction
- * markers — tracked as a follow-up in #14322.
+ * Regression target: #14322 found that the v5 evaluator message-to-user path
+ * could reject JSON-bodied interaction markers, making `[FORM]` unreachable
+ * even when the guide was present. The evaluator contract fix landed
+ * separately; this live-only scenario keeps grammar-valid form emission,
+ * raw submit re-entry, and submitted-value consumption pinned end to end.
  */
 
 import { scenario } from "@elizaos/scenario-runner/schema";

--- a/packages/ui/src/components/chat/InlineWidgetText.test.tsx
+++ b/packages/ui/src/components/chat/InlineWidgetText.test.tsx
@@ -107,21 +107,6 @@ describe("InlineWidgetText", () => {
     expect(container.textContent).toContain("just a normal reply");
   });
 
-  it("renders form submit markers as compact receipts", () => {
-    const { container } = withApp(
-      <InlineWidgetText
-        content={
-          '[form:submit reminder-details] {"title":"Draft report","when":"2026-07-08T09:00"}'
-        }
-      />,
-    );
-    expect(screen.getByTestId("form-submit-receipt").textContent).toBe(
-      "Submitted reminder details",
-    );
-    expect(container.textContent ?? "").not.toContain("[form:submit");
-    expect(container.textContent ?? "").not.toContain("Draft report");
-  });
-
   it("renders a choice picker and does not leak the [CHOICE] marker", () => {
     const { container } = withApp(
       <InlineWidgetText

--- a/packages/ui/src/components/chat/InlineWidgetText.tsx
+++ b/packages/ui/src/components/chat/InlineWidgetText.tsx
@@ -20,7 +20,6 @@ import { useAppSelectorShallow } from "../../state";
 import { useChatComposer } from "../../state/ChatComposerContext.hooks";
 import { CodeBlock } from "../ui/code-block";
 import {
-  FormSubmitReceipt,
   InlinePluginConfig,
   MessagePermissionCard,
   MessageUiSpecBlock,
@@ -76,15 +75,6 @@ export function InlineWidgetText({ content }: { content: string }): ReactNode {
     switch (seg.kind) {
       case "text": {
         if (seg.text) nodes.push(<span key={nextKey("t")}>{seg.text}</span>);
-        break;
-      }
-      case "form-submit": {
-        nodes.push(
-          <FormSubmitReceipt
-            key={nextKey(`form-submit-${seg.formId}`)}
-            label={seg.label}
-          />,
-        );
         break;
       }
       case "code": {

--- a/packages/ui/src/components/chat/MessageContent.slash-command.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.slash-command.test.tsx
@@ -72,21 +72,4 @@ describe("MessageContent slash-command bolding", () => {
     withApp(<MessageContent message={message("user", "just a message")} />);
     expect(screen.queryByTestId("slash-command-token")).toBeNull();
   });
-
-  it("renders a submitted form as a compact receipt instead of raw marker JSON", () => {
-    withApp(
-      <MessageContent
-        message={message(
-          "user",
-          '[form:submit reminder-details] {"title":"Draft report","when":"2026-07-08T09:00"}',
-        )}
-      />,
-    );
-
-    expect(screen.getByTestId("form-submit-receipt").textContent).toBe(
-      "Submitted reminder details",
-    );
-    expect(screen.queryByText(/\[form:submit/)).toBeNull();
-    expect(screen.queryByText(/Draft report/)).toBeNull();
-  });
 });

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -154,17 +154,6 @@ function MessageTextBody({
   );
 }
 
-export function FormSubmitReceipt({ label }: { label: string }) {
-  return (
-    <div
-      className="inline-flex max-w-full items-center rounded-full border border-border/70 bg-bg px-2.5 py-1 text-xs font-medium text-muted-strong"
-      data-testid="form-submit-receipt"
-    >
-      Submitted {label}
-    </div>
-  );
-}
-
 // ── InlinePluginConfig ──────────────────────────────────────────────
 
 // The in-chat connector/plugin setup card for `[CONFIG:pluginId]` markers
@@ -1243,20 +1232,18 @@ export function MessageContent({
           const baseKey =
             seg.kind === "text"
               ? `text:${seg.text.slice(0, 80)}`
-              : seg.kind === "form-submit"
-                ? `form-submit:${seg.formId}`
-                : seg.kind === "code"
-                  ? `code:${seg.code.slice(0, 80)}`
-                  : seg.kind === "config"
-                    ? `config:${seg.pluginId}`
-                    : seg.kind === "widget"
-                      ? (getInlineWidget(seg.widgetKind)?.keyFor?.(seg.data) ??
-                        `widget:${seg.widgetKind}`)
-                      : seg.kind === "permission"
-                        ? `permission:${seg.payload.feature}`
-                        : seg.kind === "analysis-xml"
-                          ? `analysis:${seg.tag}`
-                          : `ui:${seg.raw.slice(0, 80)}`;
+              : seg.kind === "code"
+                ? `code:${seg.code.slice(0, 80)}`
+                : seg.kind === "config"
+                  ? `config:${seg.pluginId}`
+                  : seg.kind === "widget"
+                    ? (getInlineWidget(seg.widgetKind)?.keyFor?.(seg.data) ??
+                      `widget:${seg.widgetKind}`)
+                    : seg.kind === "permission"
+                      ? `permission:${seg.payload.feature}`
+                      : seg.kind === "analysis-xml"
+                        ? `analysis:${seg.tag}`
+                        : `ui:${seg.raw.slice(0, 80)}`;
           const segmentKey = nextKey(baseKey);
 
           switch (seg.kind) {
@@ -1268,8 +1255,6 @@ export function MessageContent({
                   boldSlashCommand={message.role === "user"}
                 />
               );
-            case "form-submit":
-              return <FormSubmitReceipt key={segmentKey} label={seg.label} />;
             case "code":
               return (
                 <CodeBlock

--- a/packages/ui/src/components/chat/message-parser-helpers.test.ts
+++ b/packages/ui/src/components/chat/message-parser-helpers.test.ts
@@ -13,8 +13,6 @@ import {
   isUiSpec,
   looksLikePatch,
   normalizeDisplayText,
-  parseFormSubmitDisplay,
-  parseSegments,
   sanitizePatchValue,
   tryParsePatch,
 } from "./message-parser-helpers";
@@ -89,31 +87,6 @@ describe("looksLikePatch + tryParsePatch", () => {
     expect(tryParsePatch("not json")).toBeNull();
     // Looks like a patch but missing required string fields → rejected.
     expect(tryParsePatch('{"op":5,"path":"/x"}')).toBeNull();
-  });
-});
-
-describe("form submit display markers", () => {
-  it("projects a submitted inline form into a display-only receipt segment", () => {
-    const text =
-      '[form:submit reminder-details] {"title":"Draft report","when":"2026-07-08T09:00"}';
-    expect(parseFormSubmitDisplay(text)).toEqual({
-      formId: "reminder-details",
-      label: "reminder details",
-    });
-
-    expect(parseSegments(text, false)).toEqual([
-      {
-        kind: "form-submit",
-        formId: "reminder-details",
-        label: "reminder details",
-      },
-    ]);
-  });
-
-  it("leaves malformed form submits as plain text so the agent still sees the wire text", () => {
-    const text = "[form:submit reminder-details] not-json";
-    expect(parseFormSubmitDisplay(text)).toBeNull();
-    expect(parseSegments(text, false)).toEqual([{ kind: "text", text }]);
   });
 });
 

--- a/packages/ui/src/components/chat/message-parser-helpers.ts
+++ b/packages/ui/src/components/chat/message-parser-helpers.ts
@@ -61,7 +61,6 @@ export function isSafeNormalizedPluginId(id: string): boolean {
 
 export type Segment =
   | { kind: "text"; text: string }
-  | { kind: "form-submit"; formId: string; label: string }
   | { kind: "config"; pluginId: string }
   | { kind: "ui-spec"; spec: UiSpec; raw: string }
   // A fenced (```lang ... ```) or inline (`...`) code span lifted out of the
@@ -75,8 +74,6 @@ export type Segment =
 // ── Detection ───────────────────────────────────────────────────────
 
 export const CONFIG_RE = /\[CONFIG:([@\w][\w@./:-]*)\]/g;
-export const FORM_SUBMIT_RE =
-  /^\[form:submit\s+([A-Za-z0-9._:-]{1,120})\]\s+({[\s\S]*})$/;
 export const FENCED_JSON_RE = /```(?:json)?\s*\n([\s\S]*?)```/g;
 
 /**
@@ -132,34 +129,6 @@ export function tryParse(s: string): unknown {
     // null is the explicit "not a spec" signal
     return null;
   }
-}
-
-export interface FormSubmitDisplay {
-  formId: string;
-  label: string;
-}
-
-function humanizeFormId(formId: string): string {
-  const normalized = formId
-    .replace(/^form[:._-]?/i, "")
-    .replace(/[_:-]+/g, " ")
-    .replace(/([a-z])([A-Z])/g, "$1 $2")
-    .trim()
-    .toLowerCase();
-  return normalized || "form";
-}
-
-export function parseFormSubmitDisplay(text: string): FormSubmitDisplay | null {
-  const match = FORM_SUBMIT_RE.exec(text.trim());
-  if (!match) return null;
-  const parsed = tryParse(match[2]);
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return null;
-  }
-  return {
-    formId: match[1],
-    label: humanizeFormId(match[1]),
-  };
 }
 
 export function isUiSpec(obj: unknown): obj is UiSpec {
@@ -380,19 +349,6 @@ export function parseSegments(text: string, analysisMode: boolean): Segment[] {
   // otherwise we use the normalized text which strips them.
   const targetText = analysisMode ? text : normalizeDisplayText(text);
   if (!targetText) return [{ kind: "text", text: "" }];
-
-  if (!analysisMode) {
-    const formSubmit = parseFormSubmitDisplay(targetText);
-    if (formSubmit) {
-      return [
-        {
-          kind: "form-submit",
-          formId: formSubmit.formId,
-          label: formSubmit.label,
-        },
-      ];
-    }
-  }
 
   const permissionRequest = analysisMode
     ? null

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -1028,30 +1028,6 @@ describe("ContinuousChatOverlay", () => {
     expect(user?.className).toContain("justify-end");
   });
 
-  it("renders a user form submission as a receipt instead of raw marker JSON", () => {
-    render(
-      <ContinuousChatOverlay
-        controller={makeController({
-          messages: [
-            {
-              id: "form-submit",
-              role: "user",
-              content:
-                '[form:submit reminder-details] {"title":"Draft report","when":"2026-07-08T09:00"}',
-              createdAt: 1,
-            },
-          ],
-        } as unknown as Partial<ShellController>)}
-      />,
-    );
-    fireEvent.focus(screen.getByLabelText("message"));
-
-    const log = document.getElementById("continuous-thread");
-    expect(log?.textContent).toContain("Submitted reminder details");
-    expect(log?.textContent).not.toContain("[form:submit");
-    expect(log?.textContent).not.toContain("Draft report");
-  });
-
   it("anchors the in-flight status row as an assistant-aligned transcript row", () => {
     render(
       <ContinuousChatOverlay

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -85,12 +85,8 @@ import {
 } from "../../utils/image-attachment";
 import { InlineWidgetText } from "../chat/InlineWidgetText";
 import { MessageAttachments } from "../chat/MessageAttachments";
-import {
-  FormSubmitReceipt,
-  SensitiveRequestBlock,
-} from "../chat/MessageContent";
+import { SensitiveRequestBlock } from "../chat/MessageContent";
 import { findChoiceRegions } from "../chat/message-choice-parser";
-import { parseFormSubmitDisplay } from "../chat/message-parser-helpers";
 import { MessageSearchPanel } from "../chat/message-search/MessageSearchPanel";
 import { ThinkingBlock } from "../chat/ThinkingBlock";
 import { withTranscriptMarker } from "../chat/TranscriptViewerOverlay";
@@ -670,9 +666,6 @@ function TurnStatusIndicator({
  * inline autocomplete). Plain prose renders unchanged.
  */
 function ThreadLineText({ content }: { content: string }): React.ReactNode {
-  const formSubmit = parseFormSubmitDisplay(content);
-  if (formSubmit) return <FormSubmitReceipt label={formSubmit.label} />;
-
   const slash = splitLeadingSlashCommand(content);
   if (!slash) return content;
   return (

--- a/plugins/plugin-hyperliquid/src/HyperliquidView.test.tsx
+++ b/plugins/plugin-hyperliquid/src/HyperliquidView.test.tsx
@@ -195,28 +195,42 @@ describe("HyperliquidView — populated snapshot", () => {
 		expect(screen.getByText("ETH")).toBeTruthy();
 		// Read-ready header + market leverage decoration.
 		expect(screen.getByText("read-ready")).toBeTruthy();
-		expect(screen.getByText("BTC 50x")).toBeTruthy();
+		expect(screen.getByText("50x")).toBeTruthy();
 		// ETH maxLeverage null -> "n/a", isolated suffix.
 		const text = document.body.textContent ?? "";
 		expect(text).toContain("2m / 1p / 1o");
 	});
 
-	it("renders a compact readiness summary", async () => {
+	it("renders the readiness tiles and the credential-mode label", async () => {
 		render(React.createElement(HyperliquidView));
 		await screen.findByText("ETH");
-		expect(screen.getByText("read-ready")).toBeTruthy();
-		expect(screen.getByText("2m / 1p / 1o")).toBeTruthy();
+		expect(screen.getByText("Reads")).toBeTruthy();
+		expect(screen.getByText("Read-only")).toBeTruthy(); // credentialMode "none"
+		expect(screen.getByText("Account")).toBeTruthy();
 	});
 
-	it("keeps setup warnings out of the compact snapshot", async () => {
+	it("surfaces the executionBlockedReason without duplicate vault guidance", async () => {
 		render(React.createElement(HyperliquidView));
 		await screen.findByText("ETH");
 		expect(
-			screen.queryByText(/Signed Hyperliquid exchange mutations are disabled/),
-		).toBeNull();
+			screen.getByText(/Signed Hyperliquid exchange mutations are disabled/),
+		).toBeTruthy();
 		expect(
 			screen.queryByText("Connect a managed vault to enable signed requests."),
 		).toBeNull();
+	});
+
+	it("shows vault guidance when no specific execution block is present", async () => {
+		hyperliquidClient.hyperliquidStatus.mockResolvedValue({
+			...sampleStatus,
+			executionBlockedReason: null,
+		});
+
+		render(React.createElement(HyperliquidView));
+		await screen.findByText("ETH");
+		expect(
+			screen.getByText("Connect a managed vault to enable signed requests."),
+		).toBeTruthy();
 	});
 
 	it("renders the agent's own position row with its unrealized PnL", async () => {
@@ -280,7 +294,7 @@ describe("HyperliquidView — controls", () => {
 		await screen.findByText("ETH");
 		expect(hyperliquidClient.hyperliquidStatus).toHaveBeenCalledTimes(1);
 
-		fireEvent.click(agent("hyperliquid-refresh"));
+		fireEvent.click(agent("refresh"));
 		await waitFor(() =>
 			expect(hyperliquidClient.hyperliquidStatus).toHaveBeenCalledTimes(2),
 		);
@@ -295,7 +309,7 @@ describe("HyperliquidView — controls", () => {
 		const listener = (e: Event) => events.push(e as CustomEvent);
 		window.addEventListener(NAVIGATE_VIEW_EVENT, listener);
 		try {
-			fireEvent.click(agent("hyperliquid-home"));
+			fireEvent.click(agent("back"));
 		} finally {
 			window.removeEventListener(NAVIGATE_VIEW_EVENT, listener);
 		}

--- a/plugins/plugin-hyperliquid/src/components/HyperliquidSpatialView.test.tsx
+++ b/plugins/plugin-hyperliquid/src/components/HyperliquidSpatialView.test.tsx
@@ -89,6 +89,7 @@ describe("HyperliquidSpatialView one source, three modalities", () => {
 			const flat = lines.join("\n");
 			expect(flat).toContain("read-ready");
 			expect(flat).toContain("BTC");
+			expect(flat).toContain("Refresh");
 		}
 	});
 
@@ -104,7 +105,7 @@ describe("HyperliquidSpatialView one source, three modalities", () => {
 		for (const html of [gui, xr]) {
 			expect(html).toContain("BTC");
 			expect(html).toContain("read-ready");
-			expect(html).toContain('data-agent-id="market-BTC"');
+			expect(html).toContain('data-agent-id="refresh"');
 		}
 	});
 
@@ -155,7 +156,7 @@ describe("HyperliquidSpatialView account-health + position detail", () => {
 		// Position detail: side, derived liquidation distance, notional.
 		expect(html).toContain("long");
 		expect(html).toContain("25% to liq");
-		expect(html).toContain("$30.0k");
+		expect(html).toContain("30,000");
 	});
 
 	it("does not crash when distanceToLiquidationPct is a missing DTO field (#8796)", () => {

--- a/plugins/plugin-hyperliquid/src/components/HyperliquidSpatialView.tsx
+++ b/plugins/plugin-hyperliquid/src/components/HyperliquidSpatialView.tsx
@@ -59,6 +59,38 @@ export interface HyperliquidSnapshot {
 	error?: string | null;
 }
 
+function credentialModeLabel(mode: HyperliquidCredentialMode): string {
+	switch (mode) {
+		case "managed_vault":
+			return "Managed vault";
+		case "local_key":
+			return "Local key";
+		default:
+			return "Read-only";
+	}
+}
+
+function readinessTone(ready: boolean): SpatialTone {
+	return ready ? "success" : "muted";
+}
+
+function readinessMark(ready: boolean): string {
+	return ready ? "[ok]" : "[--]";
+}
+
+function StatusTile({ label, ready }: { label: string; ready: boolean }) {
+	return (
+		<HStack gap={1} align="center" grow={1}>
+			<Text tone={readinessTone(ready)} wrap={false}>
+				{readinessMark(ready)}
+			</Text>
+			<Text bold grow={1} wrap={false}>
+				{label}
+			</Text>
+		</HStack>
+	);
+}
+
 function shortAddress(address: string | null): string {
 	if (!address) return "not configured";
 	if (address.length <= 13) return address;
@@ -66,9 +98,6 @@ function shortAddress(address: string | null): string {
 }
 
 const EMPTY_CELL = "·";
-const MAX_MARKET_ROWS = 4;
-const MAX_POSITION_ROWS = 2;
-const MAX_ORDER_ROWS = 2;
 
 function toNumber(value: string | number | null | undefined): number | null {
 	if (value === null || value === undefined) return null;
@@ -108,6 +137,16 @@ function formatUsd(
 	return `${sign}$${body}`;
 }
 
+function formatPrice(value: number | null): string {
+	if (value === null) return EMPTY_CELL;
+	const abs = Math.abs(value);
+	const decimals = abs >= 1000 ? 1 : abs >= 1 ? 2 : 5;
+	return value.toLocaleString("en-US", {
+		maximumFractionDigits: decimals,
+		minimumFractionDigits: decimals,
+	});
+}
+
 function formatSize(value: string): string {
 	const parsed = Number(value);
 	if (!Number.isFinite(parsed)) return value;
@@ -144,6 +183,7 @@ export function HyperliquidSpatialView({
 }: HyperliquidSpatialViewProps) {
 	const dispatch = (action: string) => () => onAction?.(action);
 	const { status } = snapshot;
+	const accountReady = Boolean(status.accountAddress);
 	const openPositions = snapshot.positions.filter(isOpenPosition);
 
 	if (snapshot.unavailable) {
@@ -196,29 +236,82 @@ export function HyperliquidSpatialView({
 				</Text>
 			) : null}
 
+			<Text style="caption" tone="muted">
+				status
+			</Text>
+			<VStack gap={0}>
+				<StatusTile label="Reads" ready={status.publicReadReady} />
+				<StatusTile
+					label={credentialModeLabel(status.credentialMode)}
+					ready={status.signerReady}
+				/>
+				<StatusTile label="Account" ready={accountReady} />
+			</VStack>
+
+			{status.executionBlockedReason ? (
+				<Text style="caption" tone="warning">
+					{status.executionBlockedReason}
+				</Text>
+			) : null}
+
+			{!status.vaultReady &&
+			status.credentialMode !== "local_key" &&
+			!status.executionBlockedReason &&
+			status.vaultGuidance ? (
+				<Text style="caption" tone="muted">
+					{status.vaultGuidance}
+				</Text>
+			) : null}
+
+			<Text style="caption" tone="muted">
+				markets
+			</Text>
 			{snapshot.markets.length === 0 ? (
 				<Text tone="muted" align="center" style="caption">
 					None
 				</Text>
 			) : (
-				<HStack gap={2} wrap>
-					{snapshot.markets.slice(0, MAX_MARKET_ROWS).map((market) => (
-						<Text
+				<List gap={0}>
+					{snapshot.markets.slice(0, 12).map((market) => (
+						<HStack
 							key={market.name}
-							bold
-							wrap={false}
-							tone={market.isDelisted ? "muted" : "default"}
+							gap={1}
+							align="center"
 							agent={`market-${market.name}`}
 						>
-							{market.name} {market.maxLeverage ? `${market.maxLeverage}x` : ""}
-						</Text>
+							<Text
+								bold
+								grow={1}
+								wrap={false}
+								tone={market.isDelisted ? "muted" : "default"}
+							>
+								{market.name}
+							</Text>
+							<Text style="caption" tone="primary" wrap={false}>
+								{market.maxLeverage ? `${market.maxLeverage}x` : "n/a"}
+							</Text>
+							<Text style="caption" tone="muted" wrap={false}>
+								sz{market.szDecimals}
+								{market.onlyIsolated ? " iso" : ""}
+							</Text>
+						</HStack>
 					))}
-				</HStack>
+				</List>
 			)}
 
+			<Text style="caption" tone="muted">
+				account
+			</Text>
 			<HStack gap={1} align="center">
 				<Text style="caption" tone="muted" grow={1} wrap={false}>
 					{shortAddress(status.accountAddress)}
+				</Text>
+				<Text
+					style="caption"
+					tone={status.executionReady ? "success" : "muted"}
+					wrap={false}
+				>
+					{status.executionReady ? "exec-ready" : "exec-off"}
 				</Text>
 			</HStack>
 
@@ -251,6 +344,9 @@ export function HyperliquidSpatialView({
 				</HStack>
 			) : null}
 
+			<Text style="caption" tone="primary">
+				positions
+			</Text>
 			{snapshot.positionsBlockedReason ? (
 				<Text style="caption" tone="warning" agent="positions-blocked">
 					{snapshot.positionsBlockedReason}
@@ -261,10 +357,11 @@ export function HyperliquidSpatialView({
 				</Text>
 			) : (
 				<List gap={0}>
-					{openPositions.slice(0, MAX_POSITION_ROWS).map((position) => {
+					{openPositions.slice(0, 6).map((position) => {
 						const long = isLongPosition(position.size);
 						const uPnl = toNumber(position.unrealizedPnl);
 						const notional = toNumber(position.positionValue);
+						const entry = toNumber(position.entryPx);
 						const liq = position.distanceToLiquidationPct;
 						return (
 							<VStack
@@ -283,17 +380,26 @@ export function HyperliquidSpatialView({
 									>
 										{long ? "long" : "short"}
 									</Text>
-									<Text style="caption" tone="muted" grow={1} wrap={false}>
-										sz {formatSize(position.size)}
-										{notional === null ? "" : ` ${formatUsdCompact(notional)}`}
-									</Text>
+									{position.leverageValue !== null ? (
+										<Text style="caption" tone="muted" wrap={false}>
+											{position.leverageValue}x
+										</Text>
+									) : null}
 									<Text
 										style="caption"
 										tone={pnlTone(uPnl)}
+										grow={1}
 										align="end"
 										wrap={false}
 									>
 										{uPnl === null ? "" : formatUsd(uPnl, { withSign: true })}
+									</Text>
+								</HStack>
+								<HStack gap={1} align="center">
+									<Text style="caption" tone="muted" grow={1} wrap={false}>
+										sz {formatSize(position.size)}
+										{notional === null ? "" : ` · ${formatUsd(notional)}`}
+										{entry === null ? "" : ` · @${formatPrice(entry)}`}
 									</Text>
 									{liq === null || liq === undefined ? null : (
 										<Text style="caption" tone="warning" wrap={false}>
@@ -307,6 +413,9 @@ export function HyperliquidSpatialView({
 				</List>
 			)}
 
+			<Text style="caption" tone="primary">
+				orders
+			</Text>
 			{snapshot.ordersBlockedReason ? (
 				<Text style="caption" tone="warning" agent="orders-blocked">
 					{snapshot.ordersBlockedReason}
@@ -317,7 +426,7 @@ export function HyperliquidSpatialView({
 				</Text>
 			) : (
 				<List gap={0}>
-					{snapshot.orders.slice(0, MAX_ORDER_ROWS).map((order) => (
+					{snapshot.orders.slice(0, 6).map((order) => (
 						<HStack
 							key={order.oid}
 							gap={1}
@@ -350,6 +459,20 @@ export function HyperliquidSpatialView({
 					))}
 				</List>
 			)}
+
+			<HStack gap={1} wrap>
+				<Button grow={1} agent="refresh" onPress={dispatch("refresh")}>
+					Refresh
+				</Button>
+				<Button
+					variant="outline"
+					tone="default"
+					agent="back"
+					onPress={dispatch("back")}
+				>
+					Back
+				</Button>
+			</HStack>
 		</Card>
 	);
 }

--- a/plugins/plugin-polymarket/src/PolymarketView.test.tsx
+++ b/plugins/plugin-polymarket/src/PolymarketView.test.tsx
@@ -216,12 +216,12 @@ describe("PolymarketView — populated markets", () => {
     expect(polymarketClient.polymarketMarkets).toHaveBeenCalledWith({
       limit: 25,
     });
-    // Auto-selected markets[0] => detail pane: compact outcome choices.
+    // Auto-selected markets[0] => detail pane: outcomes + CLOB token ids.
     await waitFor(() => expect(agent("detail-back")).toBeTruthy());
     const text = document.body.textContent ?? "";
-    expect(text).toContain("Yes");
-    expect(text).toContain("No");
-    expect(text).not.toContain("token-yes");
+    expect(text).toContain("outcomes");
+    expect(text).toContain("orderbook tokens");
+    expect(text).toContain("token-yes");
   });
 
   it("the markets list shows readiness chips + a DOM-clickable row Open control", async () => {
@@ -249,7 +249,7 @@ describe("PolymarketView — populated markets", () => {
 });
 
 describe("PolymarketView — list -> detail navigation", () => {
-  it("clicking a market row Open opens its detail with compact outcome choices", async () => {
+  it("clicking a market row Open opens its detail with outcomes + CLOB token ids", async () => {
     render(React.createElement(PolymarketView));
     await screen.findByText("Will BTC be above 100k?");
     await backToList();
@@ -258,13 +258,15 @@ describe("PolymarketView — list -> detail navigation", () => {
 
     await waitFor(() => expect(agent("detail-back")).toBeTruthy());
     const text = document.body.textContent ?? "";
+    expect(text).toContain("outcomes");
     expect(text).toContain("Yes");
     expect(text).toContain("No");
-    expect(text).not.toContain("token-yes");
-    expect(text).not.toContain("token-no");
+    expect(text).toContain("orderbook tokens");
+    expect(text).toContain("token-yes");
+    expect(text).toContain("token-no");
   });
 
-  it("a market with no orderbook tokens still opens compact detail", async () => {
+  it("a market with no CLOB token ids shows the fallback copy in detail", async () => {
     mockState({
       markets: [sampleMarket, secondMarket],
       source: sampleMarkets.source,
@@ -277,7 +279,7 @@ describe("PolymarketView — list -> detail navigation", () => {
     await waitFor(() =>
       expect(screen.getByText("Will ETH be above 5k?")).toBeTruthy(),
     );
-    expect(screen.getByText("Yes 25%")).toBeTruthy();
+    expect(screen.getByText("no CLOB token ids")).toBeTruthy();
   });
 
   it("the detail 'back' control returns to the markets list", async () => {
@@ -301,7 +303,6 @@ describe("PolymarketView — refresh + error path", () => {
     await screen.findByText("Will BTC be above 100k?");
     expect(polymarketClient.polymarketMarkets).toHaveBeenCalledTimes(1);
 
-    await backToList();
     fireEvent.click(agent("refresh"));
     await waitFor(() =>
       expect(polymarketClient.polymarketMarkets).toHaveBeenCalledTimes(2),

--- a/plugins/plugin-polymarket/src/components/PolymarketSpatialView.test.tsx
+++ b/plugins/plugin-polymarket/src/components/PolymarketSpatialView.test.tsx
@@ -122,14 +122,15 @@ describe("PolymarketSpatialView one source, three modalities", () => {
     expect(wide).toContain("Refresh");
   });
 
-  it("TUI: detail honors the width contract at 54 + 32 and shows choices", () => {
+  it("TUI: detail honors the width contract at 54 + 32 and shows outcomes + CLOB ids", () => {
     for (const width of [54, 32]) {
       const lines = renderViewToLines(detailView, width);
       for (const line of lines) expect(visibleWidth(line)).toBe(width);
       const flat = lines.join("\n");
       // Short markers survive the narrow layout.
       expect(flat).toContain("Yes");
-      expect(flat).toContain("No");
+      expect(flat).toContain("outcomes");
+      expect(flat).toContain("111"); // CLOB token id
     }
     const wide = renderViewToLines(detailView, 54).join("\n");
     expect(wide).toContain("Will it rain tomorrow?");

--- a/plugins/plugin-polymarket/src/components/PolymarketSpatialView.tsx
+++ b/plugins/plugin-polymarket/src/components/PolymarketSpatialView.tsx
@@ -42,9 +42,8 @@ export interface PolymarketSnapshot {
   lastAction?: string;
 }
 
-const MAX_LIST = 10;
-const MAX_OUTCOMES = 2;
-const MAX_POSITION_ROWS = 3;
+const MAX_LIST = 24;
+const MAX_OUTCOMES = 3;
 
 function priceToPercent(price: string | null): number | null {
   if (price == null) return null;
@@ -103,6 +102,32 @@ function ReadinessRow({ status }: { status: PolymarketStatusResponse | null }) {
       </Text>
       <Text style="caption" tone={readyTone(trading)}>
         {`trading ${trading ? "ready" : "off"}`}
+      </Text>
+    </HStack>
+  );
+}
+
+function OutcomeLine({
+  name,
+  percent,
+  lead,
+}: {
+  name: string;
+  percent: number | null;
+  lead: boolean;
+}) {
+  return (
+    <HStack gap={1} align="center">
+      <Text tone={lead ? "primary" : "default"} grow={1} wrap={false}>
+        {name}
+      </Text>
+      <Text
+        style="caption"
+        tone={lead ? "primary" : "muted"}
+        align="end"
+        width={6}
+      >
+        {percent != null ? `${percent}%` : "n/a"}
       </Text>
     </HStack>
   );
@@ -187,7 +212,7 @@ function MarketDetail({
   market: PolymarketMarket;
   onAction?: (action: string) => void;
 }) {
-  const top = market.outcomes.slice(0, MAX_OUTCOMES);
+  const lastTrade = priceToPercent(market.lastTradePrice);
   return (
     <VStack gap={1}>
       <Button
@@ -201,20 +226,58 @@ function MarketDetail({
       <Text style="subheading" wrap>
         {market.question ?? market.slug ?? market.id}
       </Text>
-      {top.length > 0 ? (
-        <HStack gap={2} align="center" wrap>
-          {top.map((outcome, i) => (
-            <Text
-              key={outcome.name}
-              style="caption"
-              tone={i === 0 ? "primary" : "muted"}
-              wrap={false}
-            >
-              {outcomeSummary(outcome)}
-            </Text>
-          ))}
-        </HStack>
+      {market.category ? (
+        <Text style="caption" tone="muted">
+          {market.category}
+        </Text>
       ) : null}
+
+      <HStack gap={2} align="center">
+        <Text style="caption" tone="muted" wrap={false}>
+          {`Volume ${shortNumber(market.volume) ?? "-"}`}
+        </Text>
+        <Text style="caption" tone="muted" wrap={false}>
+          {`Liquidity ${shortNumber(market.liquidity) ?? "-"}`}
+        </Text>
+        <Text style="caption" tone="muted" wrap={false}>
+          {`Last ${lastTrade != null ? `${lastTrade}%` : "-"}`}
+        </Text>
+      </HStack>
+
+      <VStack gap={0}>
+        <Text style="caption" tone="muted">
+          outcomes
+        </Text>
+        <List gap={0}>
+          {market.outcomes.map((outcome, i) => (
+            <OutcomeLine
+              key={outcome.name}
+              name={outcome.name}
+              percent={priceToPercent(outcome.price)}
+              lead={i === 0}
+            />
+          ))}
+        </List>
+      </VStack>
+
+      <VStack gap={0}>
+        <Text style="caption" tone="muted">
+          orderbook tokens
+        </Text>
+        {market.clobTokenIds.length > 0 ? (
+          <List gap={0}>
+            {market.clobTokenIds.map((tokenId) => (
+              <Text key={tokenId} style="caption" tone="muted" wrap={false}>
+                {tokenId}
+              </Text>
+            ))}
+          </List>
+        ) : (
+          <Text style="caption" tone="muted">
+            no CLOB token ids
+          </Text>
+        )}
+      </VStack>
     </VStack>
   );
 }
@@ -275,7 +338,7 @@ function PositionsSection({
         </Text>
       ) : (
         <List gap={0}>
-          {open.slice(0, MAX_POSITION_ROWS).map((position) => (
+          {open.map((position) => (
             <PositionRow
               key={`${position.conditionId ?? position.marketId ?? position.slug}-${position.outcome}`}
               position={position}
@@ -303,23 +366,21 @@ export function PolymarketSpatialView({
   const selectedId = selectedMarket?.id ?? null;
   return (
     <Card gap={1} padding={1}>
-      {!selectedMarket ? (
-        <HStack gap={1} align="center" wrap>
-          <ReadinessRow status={status} />
-          <Text style="caption" tone="muted" grow={1}>
-            {loading ? "loading" : `${markets.length} markets`}
-          </Text>
-          <Button
-            variant="outline"
-            tone="default"
-            agent="refresh"
-            disabled={loading}
-            onPress={() => onAction?.("refresh")}
-          >
-            Refresh
-          </Button>
-        </HStack>
-      ) : null}
+      <HStack gap={1} align="center" wrap>
+        <ReadinessRow status={status} />
+        <Text style="caption" tone="muted" grow={1}>
+          {loading ? "loading" : `${markets.length} markets`}
+        </Text>
+        <Button
+          variant="outline"
+          tone="default"
+          agent="refresh"
+          disabled={loading}
+          onPress={() => onAction?.("refresh")}
+        >
+          Refresh
+        </Button>
+      </HStack>
 
       {error ? (
         <Text tone="danger" style="caption">


### PR DESCRIPTION
## Summary
- Keep the #14322 scenario/provider coverage that landed in #14656.
- Remove unrelated chat transcript rendering and wallet-view compaction changes that rode into the scenario PR. Those changes should remain separate, focused UI PRs.
- Update the FORM and CHOICE live scenario headers so they describe current regression coverage for the landed core fixes instead of stale failure status.

## Verification
- `bun run --cwd packages/ui test -- src/components/chat/message-parser-helpers.test.ts src/components/chat/MessageContent.slash-command.test.tsx src/components/shell/ContinuousChatOverlay.test.tsx` -> 3 files, 171 tests passed.
- `bunx @biomejs/biome check ...changed files... --no-errors-on-unmatched` -> clean.
- `git diff --check` -> clean.
- `bun --conditions eliza-source --tsconfig-override tsconfig.json packages/scenario-runner/src/cli.ts list packages/scenario-runner/test/scenarios --lane live-only` -> lists the four live chat-widget scenarios.
- `bun --conditions eliza-source --tsconfig-override tsconfig.json packages/scenario-runner/src/cli.ts list packages/scenario-runner/test/scenarios --lane pr-deterministic --scenario live-chat-widgets-config-emission` -> no scenario listed, confirming live-only exclusion.
- Attempted direct Hyperliquid/Polymarket package tests; they failed before assertions because this clean worktree has no built dist entries or test aliases for `@elizaos/ui/agent-surface`, `@elizaos/tui`, and `@elizaos/app-core`.

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] N/A - cleanup restores files to the pre-#14656 UI/plugin state; no new rendered surface is introduced.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - cleanup restores files to the pre-#14656 UI/plugin state; focused tests cover the touched chat rendering paths.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no new user workflow is introduced.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime path changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - focused UI test output is listed in Verification; no browser runtime was started.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model behavior changed; live-only scenarios remain as coverage definitions.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - domain proof is the scenario discovery/exclusion check plus the cleanup diff.
