### PR TITLE
fix(core): remove benchmark chatter catalog gate

### DIFF
--- a/packages/core/src/features/basic-capabilities/providers/actions.ts
+++ b/packages/core/src/features/basic-capabilities/providers/actions.ts
@@ -4,11 +4,11 @@
  *
  * For each registered action it runs the action's `validate` against the
  * message plus the connector account-policy check, then keeps only survivors
- * whose contexts match the turn's active routing contexts. Non-actionable
- * chatter and relationship follow-up reminders narrow the visible set down to
- * generic chat actions (or follow-up-capable ones); grouped actions are
- * collapsed for main chat and re-expanded — with their subactions and dynamic
- * providers — when their context is engaged.
+ * whose contexts match the turn's active routing contexts. Relationship
+ * follow-up reminders narrow the visible set down to generic chat actions plus
+ * follow-up-capable actions; grouped actions are collapsed for main chat and
+ * re-expanded — with their subactions and dynamic providers — when their
+ * context is engaged.
  *
  * The result surfaces `actionNames`, `actionsWithDescriptions`, and a
  * `# Context Capabilities` block, and stashes the capability metadata under
@@ -43,10 +43,7 @@ import {
 } from "../../../utils/context-routing.ts";
 import { buildDeterministicSeed } from "../../../utils/deterministic";
 import { compressPromptDescription } from "../../../utils/prompt-compression.ts";
-import {
-	looksLikeNonActionableChatter,
-	looksLikeRelationshipFollowUpReminder,
-} from "./non-actionable-chatter.ts";
+import { looksLikeRelationshipFollowUpReminder } from "./non-actionable-chatter.ts";
 
 // Get text content from centralized specs
 const spec = requireProviderSpec("ACTIONS");
@@ -370,7 +367,6 @@ export const actionsProvider: Provider = {
 
 		const resolvedActions = await Promise.all(actionPromises);
 
-		const nonActionableChatter = looksLikeNonActionableChatter(message);
 		const relationshipFollowUpReminder =
 			looksLikeRelationshipFollowUpReminder(message);
 		const availableActions = resolvedActions.filter(Boolean) as Action[];
@@ -378,9 +374,6 @@ export const actionsProvider: Provider = {
 			isFollowUpCapableAction,
 		);
 		const visibleActions = availableActions.filter((action) => {
-			if (nonActionableChatter && !GENERIC_CHAT_ACTIONS.has(action.name)) {
-				return false;
-			}
 			if (
 				relationshipFollowUpReminder &&
 				hasContactFollowUpAction &&

--- a/packages/core/src/features/basic-capabilities/providers/non-actionable-chatter.test.ts
+++ b/packages/core/src/features/basic-capabilities/providers/non-actionable-chatter.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Regression coverage for benchmark-shaped chatter phrases that used to hide
+ * the provider/action catalog before model judgment could see an actual request.
+ * The remaining helper is only the relationship follow-up narrowing path.
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+	type Action,
+	FOLLOW_UP_CAPABLE_ACTION_TAG,
+	type Handler,
+	type Provider,
+} from "../../../types/components";
+import type { Memory } from "../../../types/memory";
+import type { UUID } from "../../../types/primitives";
+import type { IAgentRuntime } from "../../../types/runtime";
+import type { State } from "../../../types/state";
+import { actionsProvider } from "./actions";
+import { looksLikeRelationshipFollowUpReminder } from "./non-actionable-chatter";
+import { providersProvider } from "./providers";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000a1" as UUID;
+const ROOM_ID = "00000000-0000-0000-0000-0000000000b1" as UUID;
+const ENTITY_ID = "00000000-0000-0000-0000-0000000000c1" as UUID;
+
+const state = { values: {}, data: {}, text: "" } as State;
+
+function message(text: string): Memory {
+	return {
+		id: "00000000-0000-0000-0000-0000000000d1" as UUID,
+		entityId: ENTITY_ID,
+		agentId: AGENT_ID,
+		roomId: ROOM_ID,
+		content: { text },
+		createdAt: 1,
+	};
+}
+
+function action(name: string, tags: string[] = []): Action {
+	return {
+		name,
+		description: `${name} action`,
+		tags,
+		validate: vi.fn(async () => true),
+		handler: vi.fn(async () => undefined) as Handler,
+	};
+}
+
+function provider(name: string): Provider {
+	return {
+		name,
+		description: `${name} provider`,
+		contexts: ["general"],
+		get: vi.fn(async () => ({ text: "" })),
+	};
+}
+
+function runtime(overrides: Partial<IAgentRuntime> = {}): IAgentRuntime {
+	return {
+		agentId: AGENT_ID,
+		actions: [],
+		providers: [],
+		...overrides,
+	} as IAgentRuntime;
+}
+
+describe("catalog visibility for benchmark-shaped chatter phrases", () => {
+	it("keeps concrete actions visible when a benchmark-negative phrase also asks for work", async () => {
+		const archiveNewsletters = action("ARCHIVE_NEWSLETTERS");
+		const reply = action("REPLY");
+		const result = await actionsProvider.get(
+			runtime({ actions: [archiveNewsletters, reply] }),
+			message("I hate email - archive all my newsletters"),
+			state,
+		);
+
+		const names = (result.data?.actionsData as Action[]).map(
+			(item) => item.name,
+		);
+		expect(names).toContain("ARCHIVE_NEWSLETTERS");
+		expect(names).toContain("REPLY");
+	});
+
+	it("keeps provider catalog entries visible for the same false-positive phrase", async () => {
+		const result = await providersProvider.get(
+			runtime({ providers: [provider("INBOX")] }),
+			message("I hate email - summarize my inbox"),
+			state,
+		);
+
+		const names = (result.data?.allProviders as Array<{ name: string }>).map(
+			(item) => item.name,
+		);
+		expect(names).toContain("INBOX");
+	});
+
+	it("still recognizes one-off relationship follow-up reminders", () => {
+		expect(
+			looksLikeRelationshipFollowUpReminder(
+				message("follow up with Maya tomorrow"),
+			),
+		).toBe(true);
+		expect(
+			looksLikeRelationshipFollowUpReminder(
+				message("follow up with Maya every Friday"),
+			),
+		).toBe(false);
+	});
+
+	it("narrows relationship follow-up reminders to follow-up-capable actions when one is available", async () => {
+		const followUp = action("CONTACT_FOLLOW_UP", [
+			FOLLOW_UP_CAPABLE_ACTION_TAG,
+		]);
+		const calendar = action("CALENDAR_CREATE");
+		const reply = action("REPLY");
+		const result = await actionsProvider.get(
+			runtime({ actions: [followUp, calendar, reply] }),
+			message("follow up with Maya tomorrow"),
+			state,
+		);
+
+		const names = (result.data?.actionsData as Action[]).map(
+			(item) => item.name,
+		);
+		expect(names).toContain("CONTACT_FOLLOW_UP");
+		expect(names).toContain("REPLY");
+		expect(names).not.toContain("CALENDAR_CREATE");
+	});
+});

--- a/packages/core/src/features/basic-capabilities/providers/non-actionable-chatter.ts
+++ b/packages/core/src/features/basic-capabilities/providers/non-actionable-chatter.ts
@@ -1,30 +1,14 @@
 /**
- * Text heuristics that classify an inbound user message as non-actionable
- * chatter (idle small talk, venting, open-ended advice-seeking) or as a one-off
- * relationship follow-up reminder. The PROVIDERS and ACTIONS providers consume
- * these to suppress the full provider/action catalog for such messages — only
- * GENERIC_CHAT_ACTIONS survive (plus follow-up-capable actions for reminders) —
- * so the model isn't prompted to act on pure chatter. Matching runs over
- * normalized user message text.
+ * Text heuristic for one-off relationship follow-up reminders. The ACTIONS
+ * provider uses this to keep follow-up-capable actions visible when a user gives
+ * an informal reminder-like instruction without scheduling language broad
+ * enough to warrant the whole catalog. Matching runs over normalized user text.
  */
 import type { Memory } from "../../../types/index.ts";
 import { normalizeUserMessageText } from "../../../utils/message-text.ts";
 
 export function normalizeMessageText(message: Memory): string {
 	return normalizeUserMessageText(message);
-}
-
-export function looksLikeNonActionableChatter(message: Memory): boolean {
-	const text = normalizeMessageText(message);
-	return (
-		/\bi hate\b.*\b(email|gmail|inbox|mail)\b/.test(text) ||
-		/^my calendar has been\b/.test(text) ||
-		(/\b(any )?(tips|advice|suggestions?)\b/.test(text) &&
-			/\bgoals?\b/.test(text)) ||
-		/\bi think i spend\b.*\btoo much time\b.*\b(phone|screen)\b/.test(text) ||
-		/^do you think blocking websites\b/.test(text) ||
-		/^should i call .*\bor just email\b/.test(text)
-	);
 }
 
 export function looksLikeRelationshipFollowUpReminder(

--- a/packages/core/src/features/basic-capabilities/providers/providers.ts
+++ b/packages/core/src/features/basic-capabilities/providers/providers.ts
@@ -22,7 +22,6 @@ import {
 	shouldIncludeByContext,
 } from "../../../utils/context-routing.ts";
 import { compressPromptDescription } from "../../../utils/prompt-compression.ts";
-import { looksLikeNonActionableChatter } from "./non-actionable-chatter.ts";
 
 // Get text content from centralized specs
 const spec = requireProviderSpec("PROVIDERS");
@@ -45,10 +44,7 @@ export const providersProvider: Provider = {
 		const activeContexts = getActiveRoutingContextsForTurn(state, message);
 		const isInContext = (provider: Provider) =>
 			shouldIncludeByContext(resolveProviderContexts(provider), activeContexts);
-		const contextFilteredProviders = allProviders.filter(isInContext);
-		const visibleProviders = looksLikeNonActionableChatter(message)
-			? []
-			: contextFilteredProviders;
+		const visibleProviders = allProviders.filter(isInContext);
 		const selectionHints = [
 			"images, attachments, or visual content -> ATTACHMENTS",
 			"uploaded files or stored documents -> DOCUMENTS",


### PR DESCRIPTION
## Summary
Refs #14680.

Removes the benchmark-shaped `looksLikeNonActionableChatter` regex gate from the core provider/action catalog path. Those literal sentence patterns were suppressing all non-generic actions and all providers before the model could judge an actual request, producing real false positives like `I hate email - archive all my newsletters`.

The relationship follow-up helper remains because it is a separate narrowing path keyed to one-off follow-up reminders and follow-up-capable action metadata.

## Verification
- `bun run --cwd packages/core test src/features/basic-capabilities/providers/non-actionable-chatter.test.ts`
  - 1 file passed, 4 tests passed.
- `bunx @biomejs/biome check packages/core/src/features/basic-capabilities/providers/non-actionable-chatter.ts packages/core/src/features/basic-capabilities/providers/actions.ts packages/core/src/features/basic-capabilities/providers/providers.ts packages/core/src/features/basic-capabilities/providers/non-actionable-chatter.test.ts`
  - Clean.
- `git diff --check origin/develop...HEAD`
  - Clean.
- `bun run --cwd packages/core typecheck`
  - Passed.
- `bun run --cwd packages/core build`
  - Passed; Node, browser, edge, testing bundles, and declaration generation completed.
- `bun run audit:error-policy-ratchet --report`
  - Passed; touched production files add no empty catches and no server-side `console.*`.

## Evidence Notes
- New regression proves a benchmark-negative-looking phrase with concrete work (`I hate email - archive all my newsletters`) keeps `ARCHIVE_NEWSLETTERS` visible in `ACTIONS` provider data.
- New regression proves the same false-positive family keeps provider catalog entries visible in `PROVIDERS` provider data.
- New regression keeps the relationship follow-up behavior pinned: one-off follow-up reminders are recognized, recurring `every Friday` is rejected, and follow-up-capable actions remain while unrelated actions are narrowed out.

Live-LLM action-selection evidence is still needed before treating the MVP item as fully closed; this PR removes the deterministic hardcode and adds keyless provider-level proof.

## Evidence Rows
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: N/A - core provider catalog change only; no UI, frontend, desktop, mobile, or native surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: N/A - core provider catalog change only; no rendered UI state changed.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: N/A - no user-visible UI workflow changed; behavior is validated at provider catalog generation.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs: N/A - deterministic unit/provider tests exercise the affected runtime code path without starting a server process.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - no frontend code or network-facing UI path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - this PR removes a pre-model deterministic regex gate; live action-selection trajectory remains needed before closing the MVP issue.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - no persisted memory, DB rows, scheduled tasks, or external connector artifacts are produced by this provider-catalog fix.