### PR TITLE
test(evidence): tolerate absent bundled video binaries

### DIFF
--- a/packages/evidence/src/video/normalize.test.ts
+++ b/packages/evidence/src/video/normalize.test.ts
@@ -108,7 +108,7 @@ describe.skipIf(!tools.available)("normalizeVideo (ffmpeg present)", () => {
 });
 
 describe("normalizeVideo degradation", () => {
-  it("uses installed bundled binaries when PATH does not provide system tools", async () => {
+  it("uses bundled binaries when installed and otherwise reports honest unavailability", async () => {
     const prevPath = process.env.PATH;
     const prevFfmpeg = process.env.ELIZA_FFMPEG_BIN;
     const prevFfprobe = process.env.ELIZA_FFPROBE_BIN;
@@ -117,8 +117,13 @@ describe("normalizeVideo degradation", () => {
     process.env.PATH = "";
     try {
       const ffprobe = await resolveFfprobeBinary();
-      expect(ffprobe.available).toBe(true);
-      if (ffprobe.available) expect(ffprobe.source).toBe("bundled");
+      if (ffprobe.available) {
+        expect(ffprobe.source).toBe("bundled");
+      } else {
+        expect(ffprobe.reason).toMatch(
+          /ffprobe not found on PATH and bundled ffprobe-static package is unavailable/,
+        );
+      }
 
       const ffmpeg = await resolveFfmpegBinary();
       if (ffmpeg.available) {


### PR DESCRIPTION
## Summary
- Fix the video normalization degradation test for clean installs where the static media packages are present in the lockfile but their optional binaries are not materialized on disk.
- Still asserts the resolver selects `source: bundled` when bundled binaries are available.
- Otherwise requires the explicit `skipped-missing-tool` style unavailability reason, matching the runtime fallback behavior.

## Verification
- `bun run --cwd packages/evidence test src/video/ingest.test.ts src/video/walkthrough-schema.test.ts src/video/normalize.test.ts` -> 3 files, 25 tests passed.
- `bunx @biomejs/biome check packages/evidence/src/video/normalize.test.ts packages/evidence/src/video/ingest.test.ts packages/evidence/src/video/walkthrough-schema.test.ts --no-errors-on-unmatched` -> clean.
- `git diff --check` -> clean.

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] N/A - test-only evidence package change; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - test-only evidence package change; no rendered UI changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user workflow changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime path changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - domain proof is the focused passing evidence video test run listed in Verification.
