### PR TITLE
feat(roles): working owner binding across connectors — /eliza-pair backend, PAIR_OWNER_ACCOUNT action, owner identity-link guard, Telegram fail-open fix

### DIFF
--- a/packages/agent/src/actions/contact.owner-guard.test.ts
+++ b/packages/agent/src/actions/contact.owner-guard.test.ts
@@ -1,0 +1,216 @@
+/**
+ * CONTACT link/merge owner-authority guard: an ADMIN-rank sender must not be
+ * able to create a confirmed identity link that touches an owner-equivalent
+ * entity (configured canonical owner, deterministic fallback admin entity, or
+ * the message world's owner) — that link would make role resolution treat them
+ * as OWNER everywhere, bypassing canModifyRole's "ADMIN never grants OWNER"
+ * rule. Authorization resolves through the REAL core role machinery against a
+ * deterministic runtime stand-in; only the relationships graph service is a
+ * recording stub.
+ */
+import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
+import { stringToUuid } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { contactAction } from "./contact.ts";
+
+const AGENT_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" as UUID;
+const OWNER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" as UUID;
+const ADMIN_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc" as UUID;
+const OTHER_A = "11111111-1111-1111-1111-111111111111" as UUID;
+const OTHER_B = "22222222-2222-2222-2222-222222222222" as UUID;
+const ROOM_ID = "dddddddd-dddd-dddd-dddd-dddddddddddd" as UUID;
+const CANDIDATE_ID = "99999999-9999-9999-9999-999999999999" as UUID;
+
+type GraphStub = {
+  getGraphSnapshot: ReturnType<typeof vi.fn>;
+  getPersonDetail: ReturnType<typeof vi.fn>;
+  getCandidateMerges: ReturnType<typeof vi.fn>;
+  acceptMerge: ReturnType<typeof vi.fn>;
+  rejectMerge: ReturnType<typeof vi.fn>;
+  proposeMerge: ReturnType<typeof vi.fn>;
+};
+
+function makeGraphStub(candidatePair?: {
+  entityA: UUID;
+  entityB: UUID;
+}): GraphStub {
+  return {
+    getGraphSnapshot: vi.fn(async () => ({ people: [] })),
+    getPersonDetail: vi.fn(async () => null),
+    getCandidateMerges: vi.fn(async () =>
+      candidatePair
+        ? [
+            {
+              id: CANDIDATE_ID,
+              entityA: candidatePair.entityA,
+              entityB: candidatePair.entityB,
+              confidence: 1,
+              evidence: {},
+              status: "pending" as const,
+              proposedAt: new Date().toISOString(),
+            },
+          ]
+        : [],
+    ),
+    acceptMerge: vi.fn(async () => undefined),
+    rejectMerge: vi.fn(async () => undefined),
+    proposeMerge: vi.fn(async () => CANDIDATE_ID),
+  };
+}
+
+function makeRuntime(graph: GraphStub): IAgentRuntime {
+  const runtime = {
+    agentId: AGENT_ID,
+    character: { name: "Eliza" },
+    getSetting: (key: string) =>
+      key === "ELIZA_ADMIN_ENTITY_ID" ? OWNER_ID : undefined,
+    getService: (type: string) => (type === "relationships" ? graph : null),
+    getRoom: async () => null,
+    getEntityById: async () => null,
+    getRelationships: async () => [],
+    reportError: vi.fn(),
+    registerSearchCategory: () => undefined,
+  };
+  return runtime as unknown as IAgentRuntime;
+}
+
+function makeMessage(entityId: UUID, text = "link them"): Memory {
+  return {
+    id: "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee" as UUID,
+    entityId,
+    roomId: ROOM_ID,
+    content: { text, source: "client_chat" },
+  } as Memory;
+}
+
+async function runContact(
+  runtime: IAgentRuntime,
+  message: Memory,
+  parameters: Record<string, unknown>,
+) {
+  const result = await contactAction.handler(runtime, message, undefined, {
+    parameters,
+  } as never);
+  if (!result) {
+    throw new Error("handler returned no result");
+  }
+  return result;
+}
+
+describe("CONTACT link — owner identity-link guard", () => {
+  let graph: GraphStub;
+  let runtime: IAgentRuntime;
+
+  beforeEach(() => {
+    graph = makeGraphStub();
+    runtime = makeRuntime(graph);
+  });
+
+  it("denies a non-owner sender linking their entity to the configured owner", async () => {
+    const result = await runContact(runtime, makeMessage(ADMIN_ID), {
+      action: "link",
+      entityA: ADMIN_ID,
+      entityB: OWNER_ID,
+      confirmation: true,
+    });
+    expect(result.success).toBe(false);
+    expect(result.values).toMatchObject({ error: "OWNER_LINK_FORBIDDEN" });
+    expect(graph.proposeMerge).not.toHaveBeenCalled();
+    expect(graph.acceptMerge).not.toHaveBeenCalled();
+  });
+
+  it("denies a non-owner sender linking to the deterministic fallback admin entity", async () => {
+    const fallbackOwner = stringToUuid("Eliza-admin-entity") as UUID;
+    const result = await runContact(runtime, makeMessage(ADMIN_ID), {
+      action: "link",
+      entityA: fallbackOwner,
+      entityB: ADMIN_ID,
+      confirmation: true,
+    });
+    expect(result.success).toBe(false);
+    expect(result.values).toMatchObject({ error: "OWNER_LINK_FORBIDDEN" });
+    expect(graph.proposeMerge).not.toHaveBeenCalled();
+  });
+
+  it("allows the canonical owner to link their own connector entity", async () => {
+    const result = await runContact(runtime, makeMessage(OWNER_ID), {
+      action: "link",
+      entityA: OWNER_ID,
+      entityB: OTHER_A,
+      confirmation: true,
+    });
+    expect(result.success).toBe(true);
+    expect(graph.proposeMerge).toHaveBeenCalledWith(
+      OWNER_ID,
+      OTHER_A,
+      expect.anything(),
+    );
+    expect(graph.acceptMerge).toHaveBeenCalledWith(CANDIDATE_ID);
+  });
+
+  it("allows a non-owner sender to link two unrelated entities", async () => {
+    const result = await runContact(runtime, makeMessage(ADMIN_ID), {
+      action: "link",
+      entityA: OTHER_A,
+      entityB: OTHER_B,
+      confirmation: true,
+    });
+    expect(result.success).toBe(true);
+    expect(graph.proposeMerge).toHaveBeenCalledWith(
+      OTHER_A,
+      OTHER_B,
+      expect.anything(),
+    );
+  });
+});
+
+describe("CONTACT merge — owner identity-link guard", () => {
+  it("denies a non-owner sender accepting a merge candidate that touches the owner", async () => {
+    const graph = makeGraphStub({ entityA: ADMIN_ID, entityB: OWNER_ID });
+    const runtime = makeRuntime(graph);
+    const result = await runContact(runtime, makeMessage(ADMIN_ID), {
+      op: "merge",
+      candidateId: CANDIDATE_ID,
+      action: "accept",
+    });
+    expect(result.success).toBe(false);
+    expect(result.values).toMatchObject({ error: "OWNER_LINK_FORBIDDEN" });
+    expect(graph.acceptMerge).not.toHaveBeenCalled();
+  });
+
+  it("allows a non-owner sender to accept a merge between unrelated entities", async () => {
+    const graph = makeGraphStub({ entityA: OTHER_A, entityB: OTHER_B });
+    const runtime = makeRuntime(graph);
+    const result = await runContact(runtime, makeMessage(ADMIN_ID), {
+      op: "merge",
+      candidateId: CANDIDATE_ID,
+      action: "accept",
+    });
+    expect(result.success).toBe(true);
+    expect(graph.acceptMerge).toHaveBeenCalledWith(CANDIDATE_ID);
+  });
+
+  it("allows the owner to accept a merge candidate that touches the owner", async () => {
+    const graph = makeGraphStub({ entityA: ADMIN_ID, entityB: OWNER_ID });
+    const runtime = makeRuntime(graph);
+    const result = await runContact(runtime, makeMessage(OWNER_ID), {
+      op: "merge",
+      candidateId: CANDIDATE_ID,
+      action: "accept",
+    });
+    expect(result.success).toBe(true);
+    expect(graph.acceptMerge).toHaveBeenCalledWith(CANDIDATE_ID);
+  });
+
+  it("rejecting a candidate needs no owner authority", async () => {
+    const graph = makeGraphStub({ entityA: ADMIN_ID, entityB: OWNER_ID });
+    const runtime = makeRuntime(graph);
+    const result = await runContact(runtime, makeMessage(ADMIN_ID), {
+      op: "merge",
+      candidateId: CANDIDATE_ID,
+      action: "reject",
+    });
+    expect(result.success).toBe(true);
+    expect(graph.rejectMerge).toHaveBeenCalledWith(CANDIDATE_ID);
+  });
+});

--- a/packages/agent/src/actions/contact.ts
+++ b/packages/agent/src/actions/contact.ts
@@ -53,12 +53,16 @@ import type {
 import {
   FOLLOW_UP_CAPABLE_ACTION_TAG,
   findEntityByName,
+  getConfiguredOwnerEntityIds,
   logger,
   ModelType,
   parseJSONObjectFromText,
   requireConfirmation,
+  resolveWorldForMessage,
   stringToUuid,
 } from "@elizaos/core";
+import { resolveFallbackOwnerEntityId } from "../runtime/owner-entity.ts";
+import { hasOwnerAccess } from "../security/access.ts";
 import { resolveRelationshipsGraphService } from "../services/relationships-graph.ts";
 import { hasContextSignalSyncForKey } from "./context-signal.ts";
 import { extractActionParamsViaLlm } from "./extract-params.ts";
@@ -1383,6 +1387,68 @@ function linkExtractionPrompt(userText: string, peopleList: string): string {
   ].join("\n");
 }
 
+/**
+ * The entity ids that role resolution treats as "the app owner": configured
+ * canonical owners, the deterministic fallback admin entity the app/connector
+ * surfaces share, and the message world's recorded owner. Linking any of them
+ * to another entity is an OWNER grant (confirmed identity links inherit the
+ * owner role in `resolveOwnershipRole`), so it needs owner authority.
+ */
+async function collectOwnerEquivalentEntityIds(
+  runtime: IAgentRuntime,
+  message: Memory,
+): Promise<Set<string>> {
+  const ownerIds = new Set<string>(getConfiguredOwnerEntityIds(runtime));
+  ownerIds.add(resolveFallbackOwnerEntityId(runtime));
+  try {
+    const resolved = await resolveWorldForMessage(runtime, message);
+    const worldOwnerId = resolved?.metadata?.ownership?.ownerId;
+    if (typeof worldOwnerId === "string" && worldOwnerId.length > 0) {
+      ownerIds.add(worldOwnerId);
+    }
+  } catch (err) {
+    // error-policy:J7 diagnostics-must-not-kill-the-loop — a failed world
+    // lookup must not skip the guard entirely; the configured/fallback owner
+    // ids above still apply, and the failure is surfaced for repair.
+    runtime.reportError("CONTACT:owner-link-guard", err, {
+      messageId: message.id,
+    });
+  }
+  return ownerIds;
+}
+
+/**
+ * Deny a link/merge that touches an owner-equivalent entity unless the sender
+ * has OWNER authority. Without this, `canModifyRole`'s "ADMIN may never grant
+ * OWNER" rule is bypassable: an ADMIN links their own connector entity to the
+ * owner entity, the merge engine records a confirmed `identity_link`, and role
+ * resolution then treats them as OWNER everywhere.
+ * Returns a failure ActionResult to short-circuit with, or null when allowed.
+ */
+async function guardOwnerIdentityLink(
+  runtime: IAgentRuntime,
+  message: Memory,
+  entityIds: readonly string[],
+  op: "link" | "merge",
+): Promise<ActionResult | null> {
+  const ownerIds = await collectOwnerEquivalentEntityIds(runtime, message);
+  const touchesOwner = entityIds.some((entityId) => ownerIds.has(entityId));
+  if (!touchesOwner) {
+    return null;
+  }
+  if (await hasOwnerAccess(runtime, message)) {
+    return null;
+  }
+  logger.warn(
+    `[CONTACT:${op}] Denied owner-identity link for sender ${message.entityId}: pair touches an owner entity`,
+  );
+  return fail(
+    "Linking an identity to the app owner requires OWNER authority.",
+    "OWNER_LINK_FORBIDDEN",
+    op,
+  );
+}
+
 async function handleLink(
   runtime: IAgentRuntime,
   message: Memory,
@@ -1473,6 +1539,16 @@ async function handleLink(
     );
   }
 
+  const linkGuard = await guardOwnerIdentityLink(
+    runtime,
+    message,
+    [entityA, entityB],
+    "link",
+  );
+  if (linkGuard) {
+    return linkGuard;
+  }
+
   try {
     const evidence: RelationshipsMergeProposalEvidence = {
       notes: reason || "user-requested manual link",
@@ -1528,6 +1604,7 @@ async function handleLink(
 
 async function handleMerge(
   runtime: IAgentRuntime,
+  message: Memory,
   params: ContactParams,
 ): Promise<ActionResult> {
   const candidateId =
@@ -1562,6 +1639,23 @@ async function handleMerge(
 
   try {
     if (action === "accept") {
+      // Accepting a merge writes a confirmed identity_link — same OWNER-grant
+      // hazard as op:link, so the same owner-authority guard applies to the
+      // candidate's pair.
+      const candidate = (await graphService.getCandidateMerges()).find(
+        (entry) => entry.id === candidateId,
+      );
+      if (candidate) {
+        const mergeGuard = await guardOwnerIdentityLink(
+          runtime,
+          message,
+          [candidate.entityA, candidate.entityB],
+          "merge",
+        );
+        if (mergeGuard) {
+          return mergeGuard;
+        }
+      }
       await graphService.acceptMerge(candidateId as UUID);
     } else {
       await graphService.rejectMerge(candidateId as UUID);
@@ -2188,7 +2282,13 @@ export const contactAction: Action = {
     callback?: HandlerCallback,
   ): Promise<ActionResult> => {
     const params = getParams(options);
-    const op = readOp(params.action ?? params.subaction ?? params.op);
+    // Resolve each discriminator key through readOp rather than ??-chaining
+    // the raw values: `action` doubles as merge's accept/reject decision, so a
+    // raw chain short-circuits on "accept" and makes `op:merge action:accept`
+    // undispatchable (the ?? chain returns "accept", readOp rejects it, and
+    // the fallback keys are never consulted).
+    const op =
+      readOp(params.action) ?? readOp(params.subaction) ?? readOp(params.op);
     if (!op) {
       return fail(
         `action is required and must be one of ${CONTACT_OPS.join(", ")}.`,
@@ -2210,7 +2310,7 @@ export const contactAction: Action = {
       case "link":
         return handleLink(runtime, message, params);
       case "merge":
-        return handleMerge(runtime, params);
+        return handleMerge(runtime, message, params);
       case "activity":
         return handleActivity(runtime, params);
       case "followup":

--- a/packages/agent/src/actions/pair-owner-account.test.ts
+++ b/packages/agent/src/actions/pair-owner-account.test.ts
@@ -1,0 +1,227 @@
+/**
+ * PAIR_OWNER_ACCOUNT action coverage: intent matching, connector resolution,
+ * and the handler's authorization + issuance paths. Authorization runs through
+ * the REAL core role machinery (hasOwnerAccess → hasRoleAccess →
+ * resolveCanonicalOwnerId) against a deterministic runtime stand-in, so the
+ * owner/non-owner split is resolved, not stubbed.
+ */
+import type {
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  UUID,
+} from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { OwnerBindingService } from "../services/owner-binding.ts";
+import {
+  messageWantsOwnerPairing,
+  pairOwnerAccountAction,
+  resolveRequestedPairConnector,
+} from "./pair-owner-account.ts";
+
+async function runHandler(
+  runtime: IAgentRuntime,
+  message: Memory,
+  callback?: HandlerCallback,
+): Promise<ActionResult> {
+  const result = await pairOwnerAccountAction.handler(
+    runtime,
+    message,
+    undefined,
+    undefined,
+    callback,
+  );
+  if (!result) {
+    throw new Error("handler returned no result");
+  }
+  return result;
+}
+
+const AGENT_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" as UUID;
+const OWNER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" as UUID;
+const STRANGER_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc" as UUID;
+const ROOM_ID = "dddddddd-dddd-dddd-dddd-dddddddddddd" as UUID;
+
+function makeRuntime(options?: {
+  ownerConfigured?: boolean;
+  service?: unknown;
+}): IAgentRuntime {
+  const ownerConfigured = options?.ownerConfigured ?? true;
+  const runtime = {
+    agentId: AGENT_ID,
+    character: { name: "Eliza" },
+    getSetting: (key: string) =>
+      ownerConfigured && key === "ELIZA_ADMIN_ENTITY_ID" ? OWNER_ID : undefined,
+    getService: (type: string) =>
+      type === "OWNER_BIND_VERIFY" ? (options?.service ?? null) : null,
+    getRoom: async () => null,
+    getEntityById: async () => null,
+    createEntity: async () => true,
+    updateEntity: async () => undefined,
+    getRelationships: async () => [],
+    reportError: vi.fn(),
+  };
+  return runtime as unknown as IAgentRuntime;
+}
+
+function makeMessage(text: string, entityId: UUID): Memory {
+  return {
+    id: "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee" as UUID,
+    entityId,
+    roomId: ROOM_ID,
+    content: { text, source: "client_chat" },
+  } as Memory;
+}
+
+describe("messageWantsOwnerPairing", () => {
+  it("matches pair/link intent naming a supported connector", () => {
+    expect(messageWantsOwnerPairing("link my discord")).toBe(true);
+    expect(messageWantsOwnerPairing("pair my Telegram account")).toBe(true);
+    expect(messageWantsOwnerPairing("verify my discord so you know me")).toBe(
+      true,
+    );
+  });
+
+  it("does not match unrelated link/connect phrasing", () => {
+    expect(messageWantsOwnerPairing("link this doc to the report")).toBe(false);
+    expect(messageWantsOwnerPairing("connect the printer")).toBe(false);
+    expect(messageWantsOwnerPairing("discord is down today")).toBe(false);
+    expect(messageWantsOwnerPairing("")).toBe(false);
+  });
+});
+
+describe("resolveRequestedPairConnector", () => {
+  it("resolves a single named connector", () => {
+    expect(resolveRequestedPairConnector("link my discord")?.connector).toBe(
+      "discord",
+    );
+    expect(resolveRequestedPairConnector("pair telegram")?.connector).toBe(
+      "telegram",
+    );
+  });
+
+  it("returns null when no or multiple connectors are named", () => {
+    expect(resolveRequestedPairConnector("link my account")).toBeNull();
+    expect(
+      resolveRequestedPairConnector("link my discord and telegram"),
+    ).toBeNull();
+  });
+});
+
+describe("pairOwnerAccountAction.validate", () => {
+  it("gates on pairing intent in the message text", async () => {
+    const runtime = makeRuntime();
+    expect(
+      await pairOwnerAccountAction.validate(
+        runtime,
+        makeMessage("link my discord", OWNER_ID),
+      ),
+    ).toBe(true);
+    expect(
+      await pairOwnerAccountAction.validate(
+        runtime,
+        makeMessage("what's the weather", OWNER_ID),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("pairOwnerAccountAction.handler", () => {
+  it("issues a discord code for the canonical owner with the exact command", async () => {
+    const runtime = makeRuntime();
+    const service = new OwnerBindingService(runtime);
+    const runtimeWithService = makeRuntime({ service });
+    const callback = vi.fn();
+
+    const result = await runHandler(
+      runtimeWithService,
+      makeMessage("link my discord", OWNER_ID),
+      callback,
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.text).toMatch(/\/eliza-pair \d{6}/);
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringMatching(/\d{6}/) }),
+    );
+    expect(result.data).toMatchObject({ connector: "discord" });
+  });
+
+  it("uses the underscore command for telegram", async () => {
+    const runtime = makeRuntime();
+    const service = new OwnerBindingService(runtime);
+    const runtimeWithService = makeRuntime({ service });
+
+    const result = await runHandler(
+      runtimeWithService,
+      makeMessage("pair my telegram", OWNER_ID),
+    );
+    expect(result.success).toBe(true);
+    expect(result.text).toMatch(/\/eliza_pair \d{6}/);
+  });
+
+  it("refuses a sender who does not resolve to the owner (imposter)", async () => {
+    const runtime = makeRuntime();
+    const service = new OwnerBindingService(runtime);
+    const runtimeWithService = makeRuntime({ service });
+    const callback = vi.fn();
+
+    const result = await runHandler(
+      runtimeWithService,
+      makeMessage("link my discord", STRANGER_ID),
+      callback,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.values).toMatchObject({ error: "NOT_OWNER" });
+    // No code is ever revealed to a non-owner.
+    expect(result.text).not.toMatch(/\d{6}/);
+  });
+
+  it("asks which connector when the request is ambiguous", async () => {
+    const runtime = makeRuntime();
+    const service = new OwnerBindingService(runtime);
+    const runtimeWithService = makeRuntime({ service });
+
+    const result = await runHandler(
+      runtimeWithService,
+      makeMessage("link my discord and telegram", OWNER_ID),
+    );
+    expect(result.success).toBe(false);
+    expect(result.values).toMatchObject({ error: "CONNECTOR_AMBIGUOUS" });
+  });
+
+  it("fails with a designed message when the pairing service is absent", async () => {
+    const runtime = makeRuntime();
+    const result = await runHandler(
+      runtime,
+      makeMessage("link my discord", OWNER_ID),
+    );
+    expect(result.success).toBe(false);
+    expect(result.values).toMatchObject({ error: "SERVICE_UNAVAILABLE" });
+  });
+
+  it("surfaces issuance failures without leaking internals", async () => {
+    const throwingService = {
+      beginOwnerBind: () => {
+        throw new Error("no canonical owner");
+      },
+    };
+    const runtime = makeRuntime({ service: throwingService });
+    const result = await runHandler(
+      runtime,
+      makeMessage("link my discord", OWNER_ID),
+    );
+    expect(result.success).toBe(false);
+    expect(result.values).toMatchObject({ error: "ISSUE_FAILED" });
+    expect(
+      (runtime as unknown as { reportError: ReturnType<typeof vi.fn> })
+        .reportError,
+    ).toHaveBeenCalled();
+  });
+
+  it("declares an OWNER role gate for planner exposure", () => {
+    expect(pairOwnerAccountAction.roleGate).toEqual({ minRole: "OWNER" });
+  });
+});

--- a/packages/agent/src/actions/pair-owner-account.ts
+++ b/packages/agent/src/actions/pair-owner-account.ts
@@ -1,0 +1,257 @@
+/**
+ * PAIR_OWNER_ACCOUNT — the owner-side entry point of the connector
+ * owner-pairing flow. When the app owner asks to link/verify their Discord or
+ * Telegram account ("link my discord", "pair my telegram account"), this
+ * action issues a one-time 6-digit code via {@link OwnerBindingService} and
+ * replies with the exact connector command to run (`/eliza-pair <code>` on
+ * Discord, `/eliza_pair <code>` on Telegram). The connector relays the code
+ * back to the `OWNER_BIND_VERIFY` service, which binds the proven platform
+ * identity to the canonical owner entity — after which role resolution treats
+ * that platform user as OWNER everywhere.
+ *
+ * Authorization is double-gated: the declared `roleGate` keeps the action out
+ * of non-owner planner surfaces, and the handler re-checks `hasOwnerAccess`
+ * so a bypassed gate still fails closed. The code is revealed only in the
+ * reply to the requesting (owner) surface, never pushed to the connector.
+ */
+import type {
+  Action,
+  ActionExample,
+  ActionResult,
+  HandlerCallback,
+  HandlerOptions,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import { hasOwnerAccess } from "../security/access.ts";
+import {
+  type OwnerBindConnector,
+  resolveOwnerBindingService,
+} from "../services/owner-binding.ts";
+
+const PAIR_OWNER_ACCOUNT = "PAIR_OWNER_ACCOUNT";
+
+/** Connectors that ship a pairing command today, with the command to run. */
+const PAIRABLE_CONNECTORS: ReadonlyArray<{
+  connector: OwnerBindConnector;
+  displayName: string;
+  /** Exact command the owner runs on the platform (naming differs because
+   *  Telegram bot commands cannot contain hyphens). */
+  command: string;
+  /** Terms in the owner's message that select this connector. */
+  terms: readonly string[];
+}> = [
+  {
+    connector: "discord",
+    displayName: "Discord",
+    command: "/eliza-pair",
+    terms: ["discord"],
+  },
+  {
+    connector: "telegram",
+    displayName: "Telegram",
+    command: "/eliza_pair",
+    terms: ["telegram"],
+  },
+];
+
+/** Verbs that signal a link/pair/verify intent. */
+const PAIR_INTENT_TERMS = [
+  "link",
+  "pair",
+  "bind",
+  "verify",
+  "connect",
+  "prove",
+];
+
+function normalize(text: string): string {
+  return text.toLowerCase();
+}
+
+/** The pairable connector named in the text, or null when none/ambiguous. */
+export function resolveRequestedPairConnector(
+  text: string,
+): (typeof PAIRABLE_CONNECTORS)[number] | null {
+  const normalized = normalize(text);
+  const mentioned = PAIRABLE_CONNECTORS.filter((entry) =>
+    entry.terms.some((term) => normalized.includes(term)),
+  );
+  return mentioned.length === 1 ? (mentioned[0] ?? null) : null;
+}
+
+/**
+ * True when the message expresses intent to pair/link an owner platform
+ * account. Requires both a pair-style verb AND a supported connector name so
+ * unrelated "link this doc" / "connect the printer" text does not match.
+ */
+export function messageWantsOwnerPairing(text: string): boolean {
+  const normalized = normalize(text);
+  const hasVerb = PAIR_INTENT_TERMS.some((term) => normalized.includes(term));
+  if (!hasVerb) return false;
+  return PAIRABLE_CONNECTORS.some((entry) =>
+    entry.terms.some((term) => normalized.includes(term)),
+  );
+}
+
+function failure(text: string, error: string): ActionResult {
+  return {
+    success: false,
+    text,
+    values: { success: false, error },
+    data: { actionName: PAIR_OWNER_ACCOUNT, error },
+  };
+}
+
+export const pairOwnerAccountAction: Action = {
+  name: PAIR_OWNER_ACCOUNT,
+  contexts: ["settings", "messaging"],
+  roleGate: { minRole: "OWNER" },
+  similes: [
+    "LINK_MY_DISCORD",
+    "LINK_MY_TELEGRAM",
+    "PAIR_DISCORD_ACCOUNT",
+    "PAIR_TELEGRAM_ACCOUNT",
+    "VERIFY_OWNER_ACCOUNT",
+    "BIND_OWNER_ACCOUNT",
+  ],
+  description:
+    "Link the app owner's Discord or Telegram account to their owner " +
+    "identity. Issues a one-time pairing code and tells the owner which " +
+    "command to run on the platform; once verified, messages from that " +
+    "platform account are recognized as the owner. Owner-only.",
+  validate: async (
+    _runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+    _options?: HandlerOptions,
+  ): Promise<boolean> => {
+    const text =
+      typeof message.content.text === "string" ? message.content.text : "";
+    if (!text.trim()) return false;
+    return messageWantsOwnerPairing(text);
+  },
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+    _options?: HandlerOptions,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    // Defense in depth: the roleGate already scopes planner exposure, but the
+    // pairing code grants OWNER to whoever redeems it, so the handler itself
+    // must refuse any sender that does not resolve to the owner.
+    if (!(await hasOwnerAccess(runtime, message))) {
+      const text =
+        "Only the app owner can link an owner account. Ask the owner to run this from their own chat.";
+      if (callback) {
+        await callback({ text, action: PAIR_OWNER_ACCOUNT });
+      }
+      return failure(text, "NOT_OWNER");
+    }
+
+    const messageText =
+      typeof message.content.text === "string" ? message.content.text : "";
+    const target = resolveRequestedPairConnector(messageText);
+    if (!target) {
+      const names = PAIRABLE_CONNECTORS.map((c) => c.displayName).join(" or ");
+      const text = `Which account should I link — ${names}?`;
+      if (callback) {
+        await callback({ text, action: PAIR_OWNER_ACCOUNT });
+      }
+      return failure(text, "CONNECTOR_AMBIGUOUS");
+    }
+
+    const service = resolveOwnerBindingService(runtime);
+    if (!service) {
+      const text =
+        "Owner pairing is not available right now (the pairing service is not running).";
+      if (callback) {
+        await callback({ text, action: PAIR_OWNER_ACCOUNT });
+      }
+      return failure(text, "SERVICE_UNAVAILABLE");
+    }
+
+    let issued: ReturnType<typeof service.beginOwnerBind>;
+    try {
+      issued = service.beginOwnerBind({ connector: target.connector });
+    } catch (err) {
+      // error-policy:J4 explicit user-facing degrade — the one expected
+      // failure is "no canonical owner configured", surfaced as a designed
+      // unavailable reply; every failure is also reported for repair.
+      runtime.reportError("agent:pair-owner-account", err, {
+        connector: target.connector,
+      });
+      const text =
+        "I couldn't issue a pairing code. Finish app setup first so an owner identity exists, then try again.";
+      if (callback) {
+        await callback({ text, action: PAIR_OWNER_ACCOUNT });
+      }
+      return failure(text, "ISSUE_FAILED");
+    }
+
+    const minutes = Math.round((issued.expiresAt - Date.now()) / 60_000);
+    const replyText =
+      `Here's your ${target.displayName} pairing code: **${issued.code}**\n\n` +
+      `Run \`${target.command} ${issued.code}\` ${
+        target.connector === "discord"
+          ? "in any server or DM with me on Discord"
+          : "in your Telegram chat with me"
+      }. The code is single-use and expires in ${minutes > 0 ? minutes : 5} minutes. ` +
+      "Don't share it — whoever redeems it is recognized as the owner.";
+
+    if (callback) {
+      await callback({ text: replyText, action: PAIR_OWNER_ACCOUNT });
+    }
+
+    logger.info(
+      {
+        src: "agent:pair-owner-account",
+        agentId: runtime.agentId,
+        connector: target.connector,
+      },
+      "Issued owner pairing code via chat",
+    );
+
+    return {
+      success: true,
+      text: replyText,
+      values: { success: true, connector: target.connector },
+      data: {
+        actionName: PAIR_OWNER_ACCOUNT,
+        connector: target.connector,
+        expiresAt: issued.expiresAt,
+      },
+    };
+  },
+  examples: [
+    [
+      {
+        name: "{{name1}}",
+        content: { text: "link my discord account" },
+      },
+      {
+        name: "{{agentName}}",
+        content: {
+          text: "Here's your Discord pairing code: **123456** — run `/eliza-pair 123456` in any server or DM with me on Discord.",
+          action: PAIR_OWNER_ACCOUNT,
+        },
+      },
+    ],
+    [
+      {
+        name: "{{name1}}",
+        content: { text: "pair my telegram so you know it's me" },
+      },
+      {
+        name: "{{agentName}}",
+        content: {
+          text: "Here's your Telegram pairing code: **654321** — run `/eliza_pair 654321` in your Telegram chat with me.",
+          action: PAIR_OWNER_ACCOUNT,
+        },
+      },
+    ],
+  ] as ActionExample[][],
+};

--- a/packages/agent/src/runtime/eliza-plugin.ts
+++ b/packages/agent/src/runtime/eliza-plugin.ts
@@ -28,6 +28,7 @@ import { logsAction } from "../actions/logs.ts";
 import { memoryAction } from "../actions/memories.ts";
 import { notifyAction } from "../actions/notify.ts";
 import { pageDelegateAction } from "../actions/page-action-groups.ts";
+import { pairOwnerAccountAction } from "../actions/pair-owner-account.ts";
 import { pluginAction } from "../actions/plugin.ts";
 import { runtimeAction } from "../actions/runtime.ts";
 import { settingsAction } from "../actions/settings-actions.ts";
@@ -78,6 +79,7 @@ import {
   knowledgeGraphSchema,
 } from "../services/knowledge-graph/index.ts";
 import { AgentMediaGenerationService } from "../services/media-generation.ts";
+import { OwnerBindingService } from "../services/owner-binding.ts";
 import { PendingPromptsService } from "../services/pending-prompts/index.ts";
 import { PermissionRegistry } from "../services/permissions-registry.ts";
 import { NotificationPushService } from "../services/push/notification-push-service.ts";
@@ -157,6 +159,10 @@ export function createElizaPlugin(config?: ElizaPluginConfig): Plugin {
       GlobalPauseService as ServiceClass,
       HandoffService as ServiceClass,
       ApprovalService as ServiceClass,
+      // OWNER_BIND_VERIFY: backend authority for the connector /eliza-pair
+      // commands. Registered here (before connector plugins start) so the
+      // Discord/Telegram pairing services find it and register their commands.
+      OwnerBindingService as ServiceClass,
     ],
 
     init: async (_pluginConfig, runtime: IAgentRuntime) => {
@@ -268,6 +274,7 @@ export function createElizaPlugin(config?: ElizaPluginConfig): Plugin {
       ...promoteSubactionsToActions(databaseAction),
       compactConversationAction,
       connectAccountAction,
+      pairOwnerAccountAction,
       notifyAction,
       ...promoteSubactionsToActions(memoryAction),
       filesAction,

--- a/packages/agent/src/services/owner-binding.test.ts
+++ b/packages/agent/src/services/owner-binding.test.ts
@@ -1,0 +1,351 @@
+/**
+ * OwnerBindingService (OWNER_BIND_VERIFY) unit coverage: code issuance, the
+ * verification state machine (single-use, expiry, attempt caps, connector
+ * isolation), and the owner-entity metadata write that role resolution keys
+ * on. Runs against a deterministic in-memory runtime stand-in with an
+ * injectable clock — the code/hash/compare logic under test is real.
+ */
+import type { Entity, IAgentRuntime, UUID } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  OWNER_BIND_CODE_TTL_MS,
+  OWNER_BIND_MAX_ATTEMPTS,
+  OwnerBindingService,
+} from "./owner-binding.ts";
+
+const AGENT_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" as UUID;
+const OWNER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" as UUID;
+
+type TestRuntime = IAgentRuntime & {
+  _entities: Map<string, Entity>;
+  reportError: ReturnType<typeof vi.fn>;
+};
+
+function makeRuntime(options?: {
+  ownerConfigured?: boolean;
+  updateEntityError?: Error;
+}): TestRuntime {
+  const entities = new Map<string, Entity>();
+  const ownerConfigured = options?.ownerConfigured ?? true;
+  const runtime = {
+    agentId: AGENT_ID,
+    _entities: entities,
+    getSetting: (key: string) =>
+      ownerConfigured && key === "ELIZA_ADMIN_ENTITY_ID" ? OWNER_ID : undefined,
+    getEntityById: async (id: UUID) => entities.get(id) ?? null,
+    createEntity: async (entity: Entity) => {
+      entities.set(entity.id as string, entity);
+      return true;
+    },
+    updateEntity: async (entity: Entity) => {
+      if (options?.updateEntityError) {
+        throw options.updateEntityError;
+      }
+      entities.set(entity.id as string, entity);
+    },
+    reportError: vi.fn(),
+  };
+  return runtime as unknown as TestRuntime;
+}
+
+function makeService(
+  runtime: TestRuntime,
+  clock: { now: number } = { now: 1_000_000 },
+): { service: OwnerBindingService; clock: { now: number } } {
+  const service = new OwnerBindingService(
+    runtime as IAgentRuntime,
+    () => clock.now,
+  );
+  return { service, clock };
+}
+
+describe("OwnerBindingService.beginOwnerBind", () => {
+  it("issues a crypto-random 6-digit code with a 5-minute expiry", () => {
+    const { service, clock } = makeService(makeRuntime());
+    const issued = service.beginOwnerBind({ connector: "discord" });
+    expect(issued.connector).toBe("discord");
+    expect(issued.code).toMatch(/^\d{6}$/);
+    expect(issued.expiresAt).toBe(clock.now + OWNER_BIND_CODE_TTL_MS);
+  });
+
+  it("fails closed when no canonical owner is configured", () => {
+    const { service } = makeService(makeRuntime({ ownerConfigured: false }));
+    expect(() => service.beginOwnerBind({ connector: "discord" })).toThrowError(
+      /no canonical owner/i,
+    );
+  });
+
+  it("rejects unsupported connectors", () => {
+    const { service } = makeService(makeRuntime());
+    expect(() =>
+      service.beginOwnerBind({
+        connector: "slack" as unknown as "discord",
+      }),
+    ).toThrowError(/unsupported/i);
+  });
+
+  it("re-issuing replaces the previous pending code", async () => {
+    const runtime = makeRuntime();
+    const { service } = makeService(runtime);
+    const first = service.beginOwnerBind({ connector: "discord" });
+    const second = service.beginOwnerBind({ connector: "discord" });
+
+    const staleResult = await service.verifyOwnerBindFromConnector({
+      connector: "discord",
+      externalId: "111",
+      displayHandle: "owner#1",
+      code: first.code,
+    });
+    // The first code is only "invalid" if it differs from the second; on the
+    // 1-in-a-million collision the verify legitimately succeeds.
+    if (first.code !== second.code) {
+      expect(staleResult).toEqual({ success: false, error: "invalid_code" });
+    }
+  });
+});
+
+describe("OwnerBindingService.verifyOwnerBindFromConnector", () => {
+  let runtime: TestRuntime;
+  let service: OwnerBindingService;
+  let clock: { now: number };
+
+  beforeEach(() => {
+    runtime = makeRuntime();
+    ({ service, clock } = makeService(runtime));
+  });
+
+  it("verifies a valid code and binds the platform identity to the owner entity", async () => {
+    const { code } = service.beginOwnerBind({ connector: "discord" });
+    const result = await service.verifyOwnerBindFromConnector({
+      connector: "discord",
+      externalId: "123456789012345678",
+      displayHandle: "shaw",
+      code,
+    });
+    expect(result).toEqual({ success: true });
+
+    const owner = runtime._entities.get(OWNER_ID);
+    expect(owner).toBeDefined();
+    const discord = owner?.metadata?.discord as Record<string, unknown>;
+    expect(discord.id).toBe("123456789012345678");
+    expect(discord.userId).toBe("123456789012345678");
+    expect(discord.username).toBe("shaw");
+    expect(discord.name).toBe("shaw");
+  });
+
+  it("merges into an existing owner entity without dropping other metadata", async () => {
+    runtime._entities.set(OWNER_ID, {
+      id: OWNER_ID,
+      names: ["Owner"],
+      agentId: AGENT_ID,
+      metadata: { default: { name: "Owner" } },
+    });
+    const { code } = service.beginOwnerBind({ connector: "telegram" });
+    const result = await service.verifyOwnerBindFromConnector({
+      connector: "telegram",
+      externalId: "424242",
+      displayHandle: "shaw_tg",
+      code,
+    });
+    expect(result.success).toBe(true);
+    const owner = runtime._entities.get(OWNER_ID);
+    expect(owner?.metadata?.default).toEqual({ name: "Owner" });
+    expect((owner?.metadata?.telegram as Record<string, unknown>).userId).toBe(
+      "424242",
+    );
+  });
+
+  it("falls back to the externalId as display fields for a blank handle", async () => {
+    const { code } = service.beginOwnerBind({ connector: "discord" });
+    await service.verifyOwnerBindFromConnector({
+      connector: "discord",
+      externalId: "42",
+      displayHandle: "  ",
+      code,
+    });
+    const discord = runtime._entities.get(OWNER_ID)?.metadata
+      ?.discord as Record<string, unknown>;
+    expect(discord.username).toBe("42");
+  });
+
+  it("is single-use: a replayed code after success is rejected", async () => {
+    const { code } = service.beginOwnerBind({ connector: "discord" });
+    const first = await service.verifyOwnerBindFromConnector({
+      connector: "discord",
+      externalId: "111",
+      displayHandle: "owner",
+      code,
+    });
+    expect(first.success).toBe(true);
+
+    // An imposter replaying the observed code binds nothing.
+    const replay = await service.verifyOwnerBindFromConnector({
+      connector: "discord",
+      externalId: "666",
+      displayHandle: "imposter",
+      code,
+    });
+    expect(replay).toEqual({ success: false, error: "no_pending_bind" });
+    const discord = runtime._entities.get(OWNER_ID)?.metadata
+      ?.discord as Record<string, unknown>;
+    expect(discord.id).toBe("111");
+  });
+
+  it("rejects a wrong code but allows a later correct attempt", async () => {
+    const { code } = service.beginOwnerBind({ connector: "discord" });
+    const wrongCode = code === "000000" ? "000001" : "000000";
+    const wrong = await service.verifyOwnerBindFromConnector({
+      connector: "discord",
+      externalId: "666",
+      displayHandle: "imposter",
+      code: wrongCode,
+    });
+    expect(wrong).toEqual({ success: false, error: "invalid_code" });
+    expect(runtime._entities.has(OWNER_ID)).toBe(false);
+
+    const right = await service.verifyOwnerBindFromConnector({
+      connector: "discord",
+      externalId: "111",
+      displayHandle: "owner",
+      code,
+    });
+    expect(right.success).toBe(true);
+  });
+
+  it("invalidates the code after the attempt cap is exhausted", async () => {
+    const { code } = service.beginOwnerBind({ connector: "discord" });
+    const wrongCode = code === "000000" ? "000001" : "000000";
+
+    for (let attempt = 1; attempt < OWNER_BIND_MAX_ATTEMPTS; attempt++) {
+      const result = await service.verifyOwnerBindFromConnector({
+        connector: "discord",
+        externalId: "666",
+        displayHandle: "imposter",
+        code: wrongCode,
+      });
+      expect(result).toEqual({ success: false, error: "invalid_code" });
+    }
+    const last = await service.verifyOwnerBindFromConnector({
+      connector: "discord",
+      externalId: "666",
+      displayHandle: "imposter",
+      code: wrongCode,
+    });
+    expect(last).toEqual({ success: false, error: "too_many_attempts" });
+
+    // Even the REAL code is dead now — brute force burns the bind.
+    const real = await service.verifyOwnerBindFromConnector({
+      connector: "discord",
+      externalId: "111",
+      displayHandle: "owner",
+      code,
+    });
+    expect(real).toEqual({ success: false, error: "no_pending_bind" });
+  });
+
+  it("rejects an expired code", async () => {
+    const { code } = service.beginOwnerBind({ connector: "discord" });
+    clock.now += OWNER_BIND_CODE_TTL_MS + 1;
+    const result = await service.verifyOwnerBindFromConnector({
+      connector: "discord",
+      externalId: "111",
+      displayHandle: "owner",
+      code,
+    });
+    expect(result).toEqual({ success: false, error: "code_expired" });
+  });
+
+  it("isolates pending codes per connector", async () => {
+    const { code } = service.beginOwnerBind({ connector: "discord" });
+    const crossConnector = await service.verifyOwnerBindFromConnector({
+      connector: "telegram",
+      externalId: "111",
+      displayHandle: "owner",
+      code,
+    });
+    expect(crossConnector).toEqual({
+      success: false,
+      error: "no_pending_bind",
+    });
+  });
+
+  it("rejects malformed input without consuming attempts", async () => {
+    const { code } = service.beginOwnerBind({ connector: "discord" });
+
+    expect(
+      await service.verifyOwnerBindFromConnector({
+        connector: "discord",
+        externalId: "111",
+        displayHandle: "owner",
+        code: "12345",
+      }),
+    ).toEqual({ success: false, error: "invalid_code_format" });
+    expect(
+      await service.verifyOwnerBindFromConnector({
+        connector: "discord",
+        externalId: "",
+        displayHandle: "owner",
+        code,
+      }),
+    ).toEqual({ success: false, error: "invalid_external_id" });
+    expect(
+      await service.verifyOwnerBindFromConnector({
+        connector: "slack" as unknown as "discord",
+        externalId: "111",
+        displayHandle: "owner",
+        code,
+      }),
+    ).toEqual({ success: false, error: "invalid_connector" });
+
+    // None of the malformed submissions burned the pending bind.
+    const real = await service.verifyOwnerBindFromConnector({
+      connector: "discord",
+      externalId: "111",
+      displayHandle: "owner",
+      code,
+    });
+    expect(real.success).toBe(true);
+  });
+
+  it("verifying with no pending bind fails", async () => {
+    const result = await service.verifyOwnerBindFromConnector({
+      connector: "discord",
+      externalId: "111",
+      displayHandle: "owner",
+      code: "123456",
+    });
+    expect(result).toEqual({ success: false, error: "no_pending_bind" });
+  });
+
+  it("consumes the code and reports when the binding write fails", async () => {
+    const failingRuntime = makeRuntime({
+      updateEntityError: new Error("db down"),
+    });
+    failingRuntime._entities.set(OWNER_ID, {
+      id: OWNER_ID,
+      names: ["Owner"],
+      agentId: AGENT_ID,
+      metadata: {},
+    });
+    const { service: failingService } = makeService(failingRuntime);
+    const { code } = failingService.beginOwnerBind({ connector: "discord" });
+
+    const result = await failingService.verifyOwnerBindFromConnector({
+      connector: "discord",
+      externalId: "111",
+      displayHandle: "owner",
+      code,
+    });
+    expect(result).toEqual({ success: false, error: "binding_write_failed" });
+    expect(failingRuntime.reportError).toHaveBeenCalled();
+
+    // Fail closed: the consumed code cannot be retried.
+    const retry = await failingService.verifyOwnerBindFromConnector({
+      connector: "discord",
+      externalId: "111",
+      displayHandle: "owner",
+      code,
+    });
+    expect(retry).toEqual({ success: false, error: "no_pending_bind" });
+  });
+});

--- a/packages/agent/src/services/owner-binding.ts
+++ b/packages/agent/src/services/owner-binding.ts
@@ -1,0 +1,332 @@
+/**
+ * Backend authority for the connector owner-pairing flow: registers the
+ * `OWNER_BIND_VERIFY` service that plugin-discord's `/eliza-pair` and
+ * plugin-telegram's `/eliza_pair` commands relay codes to. The connectors are
+ * pure relays (they never decide whether a binding succeeds); this service owns
+ * the one-time pair codes and, on a successful verification, writes the proven
+ * platform identity into the canonical owner entity's metadata. Role resolution
+ * then recognizes the paired platform user as OWNER through core's
+ * `connectorIdentityMatches` path (`packages/core/src/roles.ts`,
+ * resolveOwnershipRole) — no core change and no per-connector special case.
+ *
+ * Security invariants:
+ *   - A code can only be issued while a canonical owner is configured
+ *     (`ELIZA_ADMIN_ENTITY_ID` / owner contacts); with no configured owner,
+ *     "the app owner" is undefined and pairing would be a promotion vector.
+ *   - Codes are 6 crypto-random digits, hashed at rest, single-use, expire
+ *     after 5 minutes, and allow 5 verification attempts before invalidation.
+ *   - Comparison is constant-time; failures return typed error strings and
+ *     never leak whether a pending code exists for another connector.
+ */
+import { createHash, randomInt, timingSafeEqual } from "node:crypto";
+import {
+  ElizaError,
+  getConfiguredOwnerEntityIds,
+  type IAgentRuntime,
+  logger,
+  Service,
+  type UUID,
+} from "@elizaos/core";
+
+/** Service registry key the connector pairing services look up. */
+export const OWNER_BIND_VERIFY_SERVICE = "OWNER_BIND_VERIFY";
+
+/** Connectors the pairing relays support (mirrors the connector-side union). */
+export const OWNER_BIND_CONNECTORS = [
+  "discord",
+  "telegram",
+  "wechat",
+  "matrix",
+] as const;
+
+export type OwnerBindConnector = (typeof OWNER_BIND_CONNECTORS)[number];
+
+/** Pair codes expire after this window. */
+export const OWNER_BIND_CODE_TTL_MS = 5 * 60_000;
+/** Verification attempts allowed per issued code before it is invalidated. */
+export const OWNER_BIND_MAX_ATTEMPTS = 5;
+
+export interface OwnerBindVerifyParams {
+  connector: OwnerBindConnector;
+  /** Stable platform user id (Discord snowflake, Telegram numeric id, …). */
+  externalId: string;
+  /** Human-readable handle for logs and the owner entity's display fields. */
+  displayHandle: string;
+  code: string;
+}
+
+export interface OwnerBindVerifyResult {
+  success: boolean;
+  error?: string;
+}
+
+export interface OwnerBindIssueResult {
+  connector: OwnerBindConnector;
+  /** The one-time 6-digit code — shown to the owner exactly once. */
+  code: string;
+  expiresAt: number;
+}
+
+type PendingBind = {
+  connector: OwnerBindConnector;
+  codeHash: Buffer;
+  expiresAt: number;
+  attemptsRemaining: number;
+  /** Owner entity captured at issuance so verify binds to the same identity
+   *  even if settings change mid-flow. */
+  ownerEntityId: UUID;
+};
+
+function hashCode(code: string): Buffer {
+  return createHash("sha256").update(code, "utf8").digest();
+}
+
+function isSupportedConnector(value: unknown): value is OwnerBindConnector {
+  return (
+    typeof value === "string" &&
+    (OWNER_BIND_CONNECTORS as readonly string[]).includes(value)
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+export class OwnerBindingService extends Service {
+  static override serviceType = OWNER_BIND_VERIFY_SERVICE;
+
+  override capabilityDescription =
+    "Issues and verifies one-time owner pairing codes so a connector user " +
+    "(Discord/Telegram/…) can be proven to be the app owner; successful " +
+    "verification binds the platform identity to the canonical owner entity";
+
+  // Pending codes are process-local on purpose: a restart voids outstanding
+  // codes (the owner just requests a new one), which is strictly safer than
+  // persisting secrets, and the 5-minute TTL makes loss inconsequential.
+  private readonly pending = new Map<OwnerBindConnector, PendingBind>();
+  private readonly now: () => number;
+
+  constructor(runtime: IAgentRuntime, now: () => number = Date.now) {
+    super(runtime);
+    this.now = now;
+  }
+
+  static async start(runtime: IAgentRuntime): Promise<OwnerBindingService> {
+    logger.info(
+      { src: "agent:owner-binding", agentId: runtime.agentId },
+      "OwnerBindingService started (OWNER_BIND_VERIFY registered)",
+    );
+    return new OwnerBindingService(runtime);
+  }
+
+  async stop(): Promise<void> {
+    this.pending.clear();
+  }
+
+  /**
+   * Issue a one-time pair code for `connector`, replacing any code previously
+   * pending for it. Throws when no canonical owner is configured — pairing
+   * binds a platform identity TO the owner, so without a configured owner
+   * there is nothing safe to bind to.
+   */
+  beginOwnerBind(params: {
+    connector: OwnerBindConnector;
+  }): OwnerBindIssueResult {
+    if (!isSupportedConnector(params.connector)) {
+      throw new ElizaError("Unsupported owner-pairing connector", {
+        code: "OWNER_BIND_UNSUPPORTED_CONNECTOR",
+        context: { connector: String(params.connector) },
+      });
+    }
+
+    const ownerIds = getConfiguredOwnerEntityIds(this.runtime);
+    const ownerEntityId = ownerIds[0];
+    if (!ownerEntityId) {
+      throw new ElizaError(
+        "Cannot issue an owner pairing code: no canonical owner is configured",
+        { code: "OWNER_BIND_NO_CANONICAL_OWNER" },
+      );
+    }
+
+    // randomInt is crypto-strong; pad to keep leading zeros.
+    const code = String(randomInt(0, 1_000_000)).padStart(6, "0");
+    const expiresAt = this.now() + OWNER_BIND_CODE_TTL_MS;
+    this.pending.set(params.connector, {
+      connector: params.connector,
+      codeHash: hashCode(code),
+      expiresAt,
+      attemptsRemaining: OWNER_BIND_MAX_ATTEMPTS,
+      ownerEntityId: ownerEntityId as UUID,
+    });
+
+    logger.info(
+      {
+        src: "agent:owner-binding",
+        agentId: this.runtime.agentId,
+        connector: params.connector,
+        expiresAt,
+      },
+      "Issued owner pairing code",
+    );
+
+    return { connector: params.connector, code, expiresAt };
+  }
+
+  /**
+   * Verify a code relayed by a connector pairing command. Interface contract
+   * with the connector relays: resolves to a result object, never throws — the
+   * relay turns `success:false` into a user-facing "invalid or expired" reply
+   * without distinguishing failure causes (that detail stays in server logs).
+   */
+  async verifyOwnerBindFromConnector(
+    params: OwnerBindVerifyParams,
+  ): Promise<OwnerBindVerifyResult> {
+    const fail = (error: string): OwnerBindVerifyResult => {
+      logger.warn(
+        {
+          src: "agent:owner-binding",
+          agentId: this.runtime.agentId,
+          connector: String(params.connector),
+          externalId: String(params.externalId),
+          error,
+        },
+        "Owner pairing verification failed",
+      );
+      return { success: false, error };
+    };
+
+    if (!isSupportedConnector(params.connector)) {
+      return fail("invalid_connector");
+    }
+    if (
+      typeof params.externalId !== "string" ||
+      params.externalId.trim().length === 0
+    ) {
+      return fail("invalid_external_id");
+    }
+    if (
+      typeof params.code !== "string" ||
+      !/^\d{6}$/.test(params.code.trim())
+    ) {
+      return fail("invalid_code_format");
+    }
+
+    const bind = this.pending.get(params.connector);
+    if (!bind) {
+      return fail("no_pending_bind");
+    }
+    if (this.now() > bind.expiresAt) {
+      this.pending.delete(params.connector);
+      return fail("code_expired");
+    }
+
+    bind.attemptsRemaining -= 1;
+    const candidate = hashCode(params.code.trim());
+    const matches =
+      candidate.length === bind.codeHash.length &&
+      timingSafeEqual(candidate, bind.codeHash);
+
+    if (!matches) {
+      if (bind.attemptsRemaining <= 0) {
+        this.pending.delete(params.connector);
+        return fail("too_many_attempts");
+      }
+      return fail("invalid_code");
+    }
+
+    // Single-use: consume the code before the binding write so a concurrent
+    // or repeated submission of the same code can never bind twice.
+    this.pending.delete(params.connector);
+
+    try {
+      await this.writeOwnerConnectorIdentity(
+        bind.ownerEntityId,
+        params.connector,
+        params.externalId.trim(),
+        params.displayHandle,
+      );
+    } catch (err) {
+      // error-policy:J1 boundary translation — this method is the service
+      // contract with the connector relays (result object, never a throw).
+      // The code is already consumed (fail closed); the owner re-issues one.
+      this.runtime.reportError("agent:owner-binding", err, {
+        connector: params.connector,
+        externalId: params.externalId,
+      });
+      return fail("binding_write_failed");
+    }
+
+    logger.info(
+      {
+        src: "agent:owner-binding",
+        agentId: this.runtime.agentId,
+        connector: params.connector,
+        externalId: params.externalId,
+        displayHandle: params.displayHandle,
+      },
+      "Owner pairing verified; platform identity bound to owner entity",
+    );
+    return { success: true };
+  }
+
+  /**
+   * Record the verified platform identity on the canonical owner entity. Role
+   * resolution (`resolveOwnershipRole` → `connectorIdentityMatches`) compares
+   * the stable `userId`/`id` fields of the sender's connector-stamped metadata
+   * against the owner entity's, so this write is exactly what makes messages
+   * from the paired platform user resolve to OWNER — across every connector.
+   */
+  private async writeOwnerConnectorIdentity(
+    ownerEntityId: UUID,
+    connector: OwnerBindConnector,
+    externalId: string,
+    displayHandle: string,
+  ): Promise<void> {
+    const existing = await this.runtime.getEntityById(ownerEntityId);
+    const handle =
+      typeof displayHandle === "string" && displayHandle.trim().length > 0
+        ? displayHandle.trim()
+        : externalId;
+    const connectorIdentity = {
+      ...(asRecord(existing?.metadata?.[connector]) ?? {}),
+      id: externalId,
+      userId: externalId,
+      username: handle,
+      name: handle,
+      ownerBindVerifiedAt: this.now(),
+    };
+
+    if (existing) {
+      await this.runtime.updateEntity({
+        ...existing,
+        metadata: {
+          ...(existing.metadata ?? {}),
+          [connector]: connectorIdentity,
+        },
+      });
+      return;
+    }
+
+    const created = await this.runtime.createEntity({
+      id: ownerEntityId,
+      names: [handle],
+      agentId: this.runtime.agentId,
+      metadata: { [connector]: connectorIdentity },
+    });
+    if (!created) {
+      throw new ElizaError("Failed to create owner entity for pairing", {
+        code: "OWNER_BIND_ENTITY_CREATE_FAILED",
+        context: { ownerEntityId, connector },
+      });
+    }
+  }
+}
+
+/** Resolve the registered {@link OwnerBindingService}, or null when absent. */
+export function resolveOwnerBindingService(
+  runtime: IAgentRuntime,
+): OwnerBindingService | null {
+  return runtime.getService<OwnerBindingService>(OWNER_BIND_VERIFY_SERVICE);
+}

--- a/packages/core/src/roles.resolution.test.ts
+++ b/packages/core/src/roles.resolution.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Cross-connector owner resolution through resolveEntityRole: the paths that
+ * decide whether a connector-originated sender (Discord/Telegram/…) is the app
+ * owner. Driven over a deterministic fake runtime (no DB, no live model):
+ * configured-owner identity, connector-identity matching against the owner
+ * entity's metadata (the owner-pairing bridge), confirmed identity links, the
+ * connector-admin whitelist ceiling (ADMIN, never OWNER), and the fail-closed
+ * defaults for unlinked strangers and stale world OWNER grants.
+ */
+import { describe, expect, it } from "vitest";
+import { type RolesWorldMetadata, resolveEntityRole } from "./roles.ts";
+import type { Entity, IAgentRuntime, Relationship, UUID } from "./types";
+
+const OWNER_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const SENDER_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+const OWNER_DISCORD_ID = "123456789012345678";
+const IMPOSTER_DISCORD_ID = "876543210987654321";
+
+type FakeRuntimeOptions = {
+	settings?: Record<string, string>;
+	entities?: Record<string, Entity>;
+	relationships?: Relationship[];
+};
+
+function makeRuntime(options: FakeRuntimeOptions = {}): IAgentRuntime {
+	const settings = options.settings ?? {};
+	const entities = options.entities ?? {};
+	return {
+		agentId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+		getSetting: (key: string) => settings[key],
+		getEntityById: async (id: UUID) => entities[id] ?? null,
+		getRelationships: async () => options.relationships ?? [],
+	} as unknown as IAgentRuntime;
+}
+
+function ownerEntity(discordId: string): Entity {
+	return {
+		id: OWNER_ID as UUID,
+		names: ["Owner"],
+		agentId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" as UUID,
+		metadata: {
+			discord: { id: discordId, userId: discordId, username: "owner" },
+		},
+	};
+}
+
+function senderEntity(discordId: string, username = "someone"): Entity {
+	return {
+		id: SENDER_ID as UUID,
+		names: [username],
+		agentId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" as UUID,
+		metadata: {
+			discord: { id: discordId, userId: discordId, username },
+		},
+	};
+}
+
+describe("resolveEntityRole — configured canonical owner", () => {
+	it("resolves the configured owner id itself to OWNER", async () => {
+		const runtime = makeRuntime({
+			settings: { ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
+		});
+		expect(await resolveEntityRole(runtime, null, {}, OWNER_ID)).toBe("OWNER");
+	});
+
+	it("resolves an unlinked connector sender to GUEST", async () => {
+		const runtime = makeRuntime({
+			settings: { ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
+			entities: {
+				[OWNER_ID]: ownerEntity(OWNER_DISCORD_ID),
+				[SENDER_ID]: senderEntity(IMPOSTER_DISCORD_ID),
+			},
+		});
+		expect(await resolveEntityRole(runtime, null, {}, SENDER_ID)).toBe("GUEST");
+	});
+});
+
+describe("resolveEntityRole — connector identity binding (owner pairing)", () => {
+	it("grants OWNER when the sender entity's stable platform id matches the owner entity's", async () => {
+		// This is exactly the state the OWNER_BIND_VERIFY pairing flow writes:
+		// the verified snowflake recorded on the owner entity's metadata.
+		const runtime = makeRuntime({
+			settings: { ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
+			entities: {
+				[OWNER_ID]: ownerEntity(OWNER_DISCORD_ID),
+				[SENDER_ID]: senderEntity(OWNER_DISCORD_ID, "owner"),
+			},
+		});
+		expect(await resolveEntityRole(runtime, null, {}, SENDER_ID)).toBe("OWNER");
+	});
+
+	it("grants OWNER from live connector-stamped metadata on the message", async () => {
+		const runtime = makeRuntime({
+			settings: { ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
+			entities: { [OWNER_ID]: ownerEntity(OWNER_DISCORD_ID) },
+		});
+		const role = await resolveEntityRole(runtime, null, {}, SENDER_ID, {
+			liveEntityMetadata: {
+				discord: { id: OWNER_DISCORD_ID, userId: OWNER_DISCORD_ID },
+			},
+			liveEntityId: SENDER_ID,
+		});
+		expect(role).toBe("OWNER");
+	});
+
+	it("an imposter matching only the display name stays GUEST", async () => {
+		const runtime = makeRuntime({
+			settings: { ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
+			entities: {
+				[OWNER_ID]: ownerEntity(OWNER_DISCORD_ID),
+				// Same username as the owner, different snowflake — mutable display
+				// fields must never participate in owner matching.
+				[SENDER_ID]: senderEntity(IMPOSTER_DISCORD_ID, "owner"),
+			},
+		});
+		expect(await resolveEntityRole(runtime, null, {}, SENDER_ID)).toBe("GUEST");
+	});
+});
+
+describe("resolveEntityRole — confirmed identity links (merge engine)", () => {
+	function identityLink(status: string): Relationship {
+		return {
+			id: "99999999-9999-9999-9999-999999999999" as UUID,
+			sourceEntityId: SENDER_ID as UUID,
+			targetEntityId: OWNER_ID as UUID,
+			agentId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" as UUID,
+			tags: ["identity_link"],
+			metadata: { status },
+		} as Relationship;
+	}
+
+	it("a confirmed identity link to the owner inherits OWNER", async () => {
+		const runtime = makeRuntime({
+			settings: { ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
+			relationships: [identityLink("confirmed")],
+		});
+		expect(await resolveEntityRole(runtime, null, {}, SENDER_ID)).toBe("OWNER");
+	});
+
+	it("an unconfirmed identity link grants nothing", async () => {
+		const runtime = makeRuntime({
+			settings: { ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
+			relationships: [identityLink("pending")],
+		});
+		expect(await resolveEntityRole(runtime, null, {}, SENDER_ID)).toBe("GUEST");
+	});
+});
+
+describe("resolveEntityRole — stored grants under a configured owner", () => {
+	it("demotes a stored world OWNER grant for a non-owner to GUEST", async () => {
+		// Connectors write world-level OWNER grants (Discord guild owner,
+		// Telegram chat creator). Once a canonical owner is configured those
+		// grants must not outrank it.
+		const runtime = makeRuntime({
+			settings: { ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
+		});
+		const metadata: RolesWorldMetadata = {
+			roles: { [SENDER_ID]: "OWNER" },
+		};
+		expect(await resolveEntityRole(runtime, null, metadata, SENDER_ID)).toBe(
+			"GUEST",
+		);
+	});
+
+	it("honors a manual ADMIN grant (no escalation to OWNER)", async () => {
+		const runtime = makeRuntime({
+			settings: { ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
+		});
+		const metadata: RolesWorldMetadata = {
+			roles: { [SENDER_ID]: "ADMIN" },
+			roleSources: { [SENDER_ID]: "manual" },
+		};
+		expect(await resolveEntityRole(runtime, null, metadata, SENDER_ID)).toBe(
+			"ADMIN",
+		);
+	});
+});
+
+describe("resolveEntityRole — connector-admin whitelist ceiling", () => {
+	const whitelistSettings = {
+		ELIZA_ADMIN_ENTITY_ID: OWNER_ID,
+		ELIZA_ROLES_CONNECTOR_ADMINS_JSON: JSON.stringify({
+			discord: [IMPOSTER_DISCORD_ID],
+		}),
+	};
+
+	it("grants a whitelisted connector user ADMIN, never OWNER", async () => {
+		const runtime = makeRuntime({
+			settings: whitelistSettings,
+			entities: { [SENDER_ID]: senderEntity(IMPOSTER_DISCORD_ID) },
+		});
+		expect(await resolveEntityRole(runtime, null, {}, SENDER_ID)).toBe("ADMIN");
+	});
+
+	it("revokes a connector_admin-sourced grant when the whitelist empties", async () => {
+		const runtime = makeRuntime({
+			settings: { ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
+			entities: { [SENDER_ID]: senderEntity(IMPOSTER_DISCORD_ID) },
+		});
+		const metadata: RolesWorldMetadata = {
+			roles: { [SENDER_ID]: "ADMIN" },
+			roleSources: { [SENDER_ID]: "connector_admin" },
+		};
+		expect(await resolveEntityRole(runtime, null, metadata, SENDER_ID)).toBe(
+			"GUEST",
+		);
+	});
+});

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -63,6 +63,7 @@ import {
   TelegramEventTypes,
   type TelegramWorldPayload,
 } from "./types";
+import { buildTelegramWorldOwnership } from "./world-ownership";
 
 const CANONICAL_OWNER_SETTING_KEYS = ["ELIZA_ADMIN_ENTITY_ID"] as const;
 const TELEGRAM_CONNECTOR_CONTEXTS = ["social", "connectors"];
@@ -1349,13 +1350,6 @@ export class TelegramService extends Service {
       return;
     }
 
-    const userId = ctx.from
-      ? (createUniqueUuid(
-          this.runtime,
-          this.scopedTelegramKey(ctx.from.id.toString(), accountId),
-        ) as UUID)
-      : null;
-
     // Fetch admin information for proper role assignment
     let admins: (ChatMemberOwner | ChatMemberAdministrator)[] = [];
     let owner: ChatMemberOwner | null = null;
@@ -1385,14 +1379,19 @@ export class TelegramService extends Service {
     }
 
     const canonicalOwnerId = getCanonicalOwnerId(this.runtime);
-    let ownerId = canonicalOwnerId ?? userId;
-
-    if (!canonicalOwnerId && owner) {
-      ownerId = createUniqueUuid(
-        this.runtime,
-        this.scopedTelegramKey(String(owner.user.id), accountId),
-      ) as UUID;
-    }
+    // Ownership may fall back to the chat CREATOR (groups only, mirroring
+    // Discord's guild-owner grant) but never to the arbitrary message sender —
+    // see world-ownership.ts for why that default was a privilege escalation.
+    const chatCreatorEntityId = owner
+      ? (createUniqueUuid(
+          this.runtime,
+          this.scopedTelegramKey(String(owner.user.id), accountId),
+        ) as UUID)
+      : null;
+    const worldOwnership = buildTelegramWorldOwnership(
+      canonicalOwnerId,
+      chatCreatorEntityId,
+    );
 
     // Build world representation
     const world: World = {
@@ -1403,12 +1402,7 @@ export class TelegramService extends Service {
       metadata: {
         source: "telegram",
         accountId,
-        ...(ownerId && { ownership: { ownerId } }),
-        roles: ownerId
-          ? {
-              [ownerId]: Role.OWNER,
-            }
-          : {},
+        ...worldOwnership,
         chatType: chat.type,
         isForumEnabled: chat.type === "supergroup" && chat.is_forum,
       },

--- a/plugins/plugin-telegram/src/world-ownership.test.ts
+++ b/plugins/plugin-telegram/src/world-ownership.test.ts
@@ -1,0 +1,44 @@
+/**
+ * buildTelegramWorldOwnership: pure decision table for who may own a Telegram
+ * world. Guards the fail-open regression where the arbitrary DM sender became
+ * `ownership.ownerId` (and therefore OWNER) whenever no canonical owner was
+ * configured.
+ */
+import { Role } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { buildTelegramWorldOwnership } from "./world-ownership";
+
+const CANONICAL = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const CREATOR = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+describe("buildTelegramWorldOwnership", () => {
+  it("grants the configured canonical owner when present", () => {
+    expect(buildTelegramWorldOwnership(CANONICAL, null)).toEqual({
+      ownership: { ownerId: CANONICAL },
+      roles: { [CANONICAL]: Role.OWNER },
+    });
+  });
+
+  it("prefers the canonical owner over the chat creator", () => {
+    expect(buildTelegramWorldOwnership(CANONICAL, CREATOR)).toEqual({
+      ownership: { ownerId: CANONICAL },
+      roles: { [CANONICAL]: Role.OWNER },
+    });
+  });
+
+  it("falls back to the chat creator only (group chats)", () => {
+    expect(buildTelegramWorldOwnership(null, CREATOR)).toEqual({
+      ownership: { ownerId: CREATOR },
+      roles: { [CREATOR]: Role.OWNER },
+    });
+  });
+
+  it("records NO ownership when neither identity exists (DM from a stranger)", () => {
+    // The regression this guards: `canonicalOwnerId ?? senderId` made every DM
+    // sender OWNER of their own DM world in unconfigured deployments.
+    expect(buildTelegramWorldOwnership(null, null)).toEqual({ roles: {} });
+    expect(buildTelegramWorldOwnership(undefined, undefined)).toEqual({
+      roles: {},
+    });
+  });
+});

--- a/plugins/plugin-telegram/src/world-ownership.ts
+++ b/plugins/plugin-telegram/src/world-ownership.ts
@@ -1,0 +1,45 @@
+/**
+ * Ownership metadata for Telegram worlds. Decides which entity, if any, is
+ * recorded as `ownership.ownerId` (and granted the world-level OWNER role)
+ * when a Telegram chat's world is first created.
+ *
+ * Only two identities may ever own a Telegram world: the configured canonical
+ * owner of the deployment, or — for group chats — the chat's creator (the
+ * Telegram-side analogue of Discord's guild owner). The arbitrary message
+ * sender must NEVER be the fallback: the previous `canonicalOwnerId ?? userId`
+ * default made every DM sender the OWNER of their own DM world in deployments
+ * without a configured canonical owner, clearing every `minRole: OWNER` gate
+ * (SHELL, SECRETS, …) for any stranger who could DM the bot — the same
+ * fail-open that #12087 Item 2 removed from core's `buildDmWorldMetadata`.
+ * When neither identity exists, the world carries no ownership metadata and
+ * senders resolve through the normal role machinery (GUEST unless granted).
+ */
+import { Role } from "@elizaos/core";
+
+export type TelegramWorldOwnership = {
+  ownership?: { ownerId: string };
+  roles: Record<string, Role>;
+};
+
+/**
+ * Resolve the ownership + role grants for a new Telegram world.
+ *
+ * @param canonicalOwnerId configured deployment owner (ELIZA_ADMIN_ENTITY_ID),
+ *   if any — always wins.
+ * @param chatCreatorEntityId runtime entity id of the chat's creator (group /
+ *   supergroup / channel "creator" admin), if known — used only when no
+ *   canonical owner is configured, mirroring Discord's guild-owner grant.
+ */
+export function buildTelegramWorldOwnership(
+  canonicalOwnerId: string | null | undefined,
+  chatCreatorEntityId: string | null | undefined,
+): TelegramWorldOwnership {
+  const ownerId = canonicalOwnerId ?? chatCreatorEntityId ?? null;
+  if (!ownerId) {
+    return { roles: {} };
+  }
+  return {
+    ownership: { ownerId },
+    roles: { [ownerId]: Role.OWNER },
+  };
+}


### PR DESCRIPTION
Closes #14705. Closes #14704. Closes #14706. (Part of the cross-connector roles validation lane; #14707/#14710/#14711/#14712 remain open with follow-up notes below.)

## What this fixes

The "Discord owner = app owner" story was half-built dead code plus two privilege-escalation holes (all adversarially verified on develop before implementation):

1. **`OWNER_BIND_VERIFY` had no producer (#14705)** — both connectors have shipped `/eliza-pair` / `/eliza_pair` pairing commands since the v2.0.4 baseline, relaying to a backend service **nothing registered**: every deployment logged "started without /eliza-pair" and the flow documented in plugin-discord's CLAUDE.md could never run.
2. **Telegram fail-open world ownership (#14704)** — `service.ts:1388` had `ownerId = canonicalOwnerId ?? userId`: with no canonical owner configured, **any DM sender became OWNER of their DM world**, clearing every `minRole: OWNER` gate (SHELL, SECRETS). Same hole class #12087 Item 2 closed in core.
3. **ADMIN → OWNER escalation via identity merge (#14706)** — CONTACT link/merge (ADMIN-gated) could link an ADMIN's entity to the owner entity; the confirmed `identity_link` then resolves to OWNER everywhere, bypassing `canModifyRole`'s "ADMIN never grants OWNER".

## Implementation

- **`packages/agent/src/services/owner-binding.ts`** — `OwnerBindingService` registers `OWNER_BIND_VERIFY` (wired in `eliza-plugin.ts`, boots before connectors so the pairing commands now register). Crypto-random 6-digit codes, sha256 at rest, constant-time compare, single-use, 5-min TTL, 5-attempt cap, issuance refused when no canonical owner. On verify it writes the platform identity onto the **owner entity's metadata** — the exact shape `connectorIdentityMatches` already resolves to OWNER. Generic across connectors; zero core changes.
- **`packages/agent/src/actions/pair-owner-account.ts`** — `PAIR_OWNER_ACCOUNT` (roleGate OWNER + in-handler recheck): owner says "link my discord" in the app → gets the code + the exact `/eliza-pair` command; codes never revealed to non-owners.
- **`packages/agent/src/actions/contact.ts`** — `guardOwnerIdentityLink`: link/merge touching an owner-equivalent entity (configured owners ∪ fallback admin entity ∪ world owner) is denied unless the sender is OWNER (`OWNER_LINK_FORBIDDEN`). Also fixes the op-dispatch so `op:merge action:accept` is reachable.
- **`plugins/plugin-telegram/src/world-ownership.ts`** — ownership falls back only to the group creator, never the message sender.

## Tests — 50 new, all green; adjacent suites green

- `owner-binding.test.ts` (15): replay-after-success, brute-force burn, expiry, cross-connector isolation, imposter with wrong code, malformed input, write-failure fail-closed, metadata merge.
- `pair-owner-account.test.ts` (12): imposter denied through the **real** role machinery, no code leakage, per-connector commands, ambiguous/unavailable/failure paths.
- `contact.owner-guard.test.ts` (8): ADMIN denied linking/merging to owner + fallback entity, OWNER allowed, unrelated pairs unaffected, reject needs no authority.
- `world-ownership.test.ts` (4): decision table incl. the fail-open regression.
- `packages/core/src/roles.resolution.test.ts` (11): pairing bridge → OWNER, live-stamp match, imposter-by-name stays GUEST, confirmed vs pending links, stale world-OWNER demotion, whitelist ADMIN ceiling + revocation.
- Regression suites green: roles.test.ts, entities.trusted-components, plugin-role-gating(+chokepoint), dm-owner-grant, dm-world-metadata, full plugin-telegram/src (110). Typecheck zero errors in touched files; biome + error-policy ratchet clean.

## Explicitly NOT fixed here (open issues carry them)

- Guild-owner / group-creator world-OWNER grants in unconfigured deployments (#14707) — product decision needed.
- All Discord application **team members** aliasing to the owner entity (#14712).
- Slash-command fail-open paths (#14710) and Telegram metadata identity stamps (#14711).
- Live end-to-end `/eliza-pair` walkthrough on a real Discord bot: **N/A on this host (no bot credentials)** — the full protocol (issue→relay→verify→role-flip) is pinned by the 50 deterministic tests through the real service + real role resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)