### PR TITLE
fix(ui): repair develop-red wallpaper/background tests after #14632

### DIFF
--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -136,7 +136,14 @@ const sharedCanvasView = {
   path: "/shared-canvas",
   bundleUrl: "/api/views/shared-canvas/bundle.js",
   viewType: "gui" as const,
-  backgroundPolicy: "shared" as const,
+  // Sharing the Home/Launcher wallpaper is grant-gated (#13452): the surface
+  // manifest must declare `background: "shared"` AND the `wallpaper`
+  // capability. A bare `backgroundPolicy: "shared"` resolves to opaque by
+  // design (no view opts into the wallpaper by accident).
+  surface: {
+    background: "shared" as const,
+    capabilities: ["wallpaper"] as const,
+  },
 };
 
 const documentsView = {

--- a/packages/ui/src/App.screen-background-fuzz.test.tsx
+++ b/packages/ui/src/App.screen-background-fuzz.test.tsx
@@ -97,7 +97,8 @@ const dynamicViewLoaderMock = vi.hoisted(() => ({
 }));
 
 // A couple of registered remote views so the registry-resolution branches are
-// exercised by the fuzz too (one shares, one is opaque-by-default).
+// exercised by the fuzz too (one shares via a wallpaper-granted manifest —
+// the only way to share since the #13452 grant gate — one is opaque-by-default).
 const sharedCanvasView = {
   id: "shared-canvas",
   label: "Shared Canvas",
@@ -106,7 +107,10 @@ const sharedCanvasView = {
   path: "/shared-canvas",
   bundleUrl: "/api/views/shared-canvas/bundle.js",
   viewType: "gui" as const,
-  backgroundPolicy: "shared" as const,
+  surface: {
+    background: "shared" as const,
+    capabilities: ["wallpaper"] as const,
+  },
 };
 const documentsView = {
   id: "documents",
@@ -557,6 +561,18 @@ function readBackgroundLayer(container: HTMLElement): {
   return { kind: "opaque", el: opaque as HTMLElement };
 }
 
+// The color a wallpaper layer actually paints. The glsl layer paints a flat
+// `backgroundColor` behind its canvas; the "midnight ember" ShaderBackground
+// (#13466) paints the configured color as the leading stop of a
+// `backgroundImage` field gradient instead — jsdom normalizes that stop to
+// `rgb(...)`, so the first rgb() in the gradient IS the configured color.
+// Empty string when the layer hasn't painted a color yet (cold mount).
+function paintedWallpaperColor(el: HTMLElement): string {
+  if (el.style.backgroundColor) return el.style.backgroundColor;
+  const gradientStop = el.style.backgroundImage.match(/rgb\(\d+, \d+, \d+\)/);
+  return gradientStop ? gradientStop[0] : "";
+}
+
 describe("App screen-background fuzz — color invariant across view switching", () => {
   // Walking through EVERY view mounts real view content (PluginsView, LogsView,
   // …) whose deep data deps are not mocked here; those throw and are caught by
@@ -649,14 +665,13 @@ describe("App screen-background fuzz — color invariant across view switching",
       // cold-mount tolerance the mutation-isolation block below applies. The
       // color is asserted wherever it is populated (the steady state); the
       // wallpaper *kind* (asserted above) is the unconditional invariant.
-      if (
-        (layer.kind === "shader" || layer.kind === "glsl") &&
-        layer.el.style.backgroundColor
-      ) {
-        expect(
-          layer.el.style.backgroundColor,
-          `${label} ${where}: wallpaper color preserved`,
-        ).toBe(expectedRgb(bgState.config.color));
+      if (layer.kind === "shader" || layer.kind === "glsl") {
+        const painted = paintedWallpaperColor(layer.el);
+        if (painted) {
+          expect(painted, `${label} ${where}: wallpaper color preserved`).toBe(
+            expectedRgb(bgState.config.color),
+          );
+        }
       }
     };
 
@@ -701,14 +716,13 @@ describe("App screen-background fuzz — color invariant across view switching",
       // Invariant B everywhere a wallpaper shows AND its color is painted:
       // color is the persisted one (cold-mount empty-string tolerated, as in
       // assertWallpaper above).
-      if (
-        (layer.kind === "shader" || layer.kind === "glsl") &&
-        layer.el.style.backgroundColor
-      ) {
-        expect(
-          layer.el.style.backgroundColor,
-          `${label} ${key}: wallpaper color preserved`,
-        ).toBe(expectedRgb(bgState.config.color));
+      if (layer.kind === "shader" || layer.kind === "glsl") {
+        const painted = paintedWallpaperColor(layer.el);
+        if (painted) {
+          expect(painted, `${label} ${key}: wallpaper color preserved`).toBe(
+            expectedRgb(bgState.config.color),
+          );
+        }
       }
 
       // Invariant E: bounce back to the launcher — wallpaper always restored.
@@ -760,7 +774,11 @@ describe("App screen-background fuzz — color invariant across view switching",
 
     const layer = readBackgroundLayer(container);
     expect(layer.kind).toBe("shader");
-    expect(layer.el.style.backgroundColor).toBe(expectedRgb("#65a30d"));
+    // The plain ShaderBackground paints the configured color as the leading
+    // stop of its field gradient (#13466) — assert the fallback carries the
+    // persisted color through, not a flat backgroundColor.
+    expect(layer.el.style.backgroundImage).toContain("linear-gradient");
+    expect(paintedWallpaperColor(layer.el)).toBe(expectedRgb("#65a30d"));
   }, 60_000);
 
   it("never leaves the screen without a defined background on ANY builtin tab", async () => {


### PR DESCRIPTION
## What

Two `packages/ui` test cases were red on clean `origin/develop`:

1. `App.navigate-view-wiring.test.tsx > lets a view explicitly share the Home/Launcher background`
2. `App.screen-background-fuzz.test.tsx > falls back to the shader color field when the GLSL renderer signals onFallback`

Both are **stale tests pinning pre-redesign behavior** — the product code is correct. And notably, **neither was actually broken by #14632**: the wallpaper-gallery redesign (`2f0fd5ffe5e`) only touched the picker components (`BackgroundSettingsControls`, `HomeBackgroundQuickPicker`). Both cases were bisected and fail at `2f0fd5ffe5e~1` too. The real breakers landed earlier:

## Per-failure verdict

### 1. navigate-view-wiring "share the Home/Launcher background" — TEST stale
- **Broken by:** `887ce2650b6` (#14068, surface manifest + grant-gated wallpaper). Verified: the case passes at `887ce2650b6~1` (`45d76bebcf0`) and fails at `887ce2650b6`.
- **Why the test was wrong:** it declared the fixture view with a bare legacy `backgroundPolicy: "shared"`. Since #14068, sharing the wallpaper is grant-gated per issue #13452's acceptance ("no view can opt in by accident"): `resolveSurfaceManifest` (`packages/core/src/types/surface-manifest.ts`) forces `shared` → `opaque` unless the manifest also grants the `wallpaper` capability. That contract is deliberate and separately pinned by `App.surface-manifest-wallpaper.test.tsx` (added by #14068).
- **Fix:** the `sharedCanvasView` fixture now declares the explicit opt-in — `surface: { background: "shared", capabilities: ["wallpaper"] }` — which is exactly what the case name ("explicitly share") always meant. The grant-gate negative path (shared-without-grant → opaque) stays covered by the dedicated wallpaper-grant suite.

### 2. screen-background-fuzz "GLSL onFallback → shader color field" — TEST stale
- **Broken by:** `e42ebfabbe8` (#13466, "midnight ember" shader). That commit repainted `ShaderBackground` from a flat `backgroundColor: color` into a `backgroundImage` field gradient whose leading stop is the configured color — and updated `AppBackground.test.tsx` for gradient-vs-flat, but missed this fuzz-suite assertion.
- **Why the test was wrong:** the user-facing invariant (the GLSL fallback paints the plain color field in the persisted color) still holds; the assertion just read the now-always-empty `style.backgroundColor` instead of the gradient.
- **Fix:** a `paintedWallpaperColor` helper reads the painted color from either property (`backgroundColor` for the glsl layer, first `rgb()` gradient stop for the ember shader — same pattern `AppBackground.test.tsx` uses). The strict fallback case asserts kind + `linear-gradient` + the persisted color. Bonus: this **revives invariant B** (wallpaper color preserved across navigation) for shader layers in the fuzz walks — it had been silently dead since #13466 because `backgroundColor` was always empty, so the color-preservation check never fired on shader configs.

## Proof

- Both target files: **20/20 pass** (`bun x vitest run --config vitest.config.ts src/App.navigate-view-wiring.test.tsx src/App.screen-background-fuzz.test.tsx`).
- Neighboring App/background suites on the rebased tip: `App.chat-overlay-first-run`, `App.cloud-shell`, `App.surface-manifest-wallpaper`, `App.surface-mutation-fuzz`, `src/backgrounds/*` (incl. AppBackground, ProgrammableShaderBackground, apply-channel, shader presets/schema), `BackgroundSettingsControls`, `BackgroundSettingsSection`, `HomeBackgroundQuickPicker`: **all green (15 files / 118 tests across the two scoped runs)**.
- Biome clean on both changed files; no `packages/ui` tsc errors in the touched files.
- Test-only change — no runtime surface; evidence rows beyond test runs: N/A - no product code changed, behavior pinned is already shipped (#14068/#13466).
# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots `N/A - test-only repair; no product UI surface changed`.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots `N/A - test-only repair; no product UI surface changed`.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough `N/A - no user-facing flow changed; behavior is covered by UI unit/component suites`.
<!-- evidence-row:backend-logs -->
- [x] Backend logs `N/A - no backend/runtime service path changed`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console and network logs `N/A - no browser runtime flow changed; Vitest jsdom output is summarized in Proof`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory `N/A - no agent, provider, prompt, model, or action behavior changed`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts `N/A - no persisted domain data or generated user artifacts changed`.
