### PR TITLE
fix(core): honor escalation admin message

### DIFF
--- a/packages/core/src/features/autonomy/action.test.ts
+++ b/packages/core/src/features/autonomy/action.test.ts
@@ -5,9 +5,41 @@
  * `owner` and `third_party` targets fail with the `unsupported_escalation_target`
  * error code rather than silently succeeding.
  */
-import { describe, expect, it } from "vitest";
-import type { IAgentRuntime, Memory } from "../../types";
+import { describe, expect, it, vi } from "vitest";
+import type { HandlerCallback, IAgentRuntime, Memory, UUID } from "../../types";
+import { stringToUuid } from "../../utils";
 import { escalateAction } from "./action";
+import { AUTONOMY_SERVICE_TYPE } from "./service";
+
+const agentId = stringToUuid("agent") as UUID;
+const autonomousRoomId = stringToUuid("autonomous-room") as UUID;
+
+function autonomousMessage(text: string): Memory {
+	return {
+		id: stringToUuid(`message-${text}`),
+		entityId: agentId,
+		roomId: autonomousRoomId,
+		content: { text },
+	};
+}
+
+function runtimeWithAdmin(captured: Memory[]): IAgentRuntime {
+	return {
+		agentId,
+		getService: vi.fn((serviceType: string) =>
+			serviceType === AUTONOMY_SERVICE_TYPE
+				? { getAutonomousRoomId: () => autonomousRoomId }
+				: null,
+		),
+		getSetting: vi.fn((key: string) =>
+			key === "ADMIN_USER_ID" ? "admin-user" : undefined,
+		),
+		createMemory: vi.fn(async (memory: Memory) => {
+			captured.push(memory);
+			return undefined;
+		}),
+	} as unknown as IAgentRuntime;
+}
 
 describe("escalateAction", () => {
 	it.each([
@@ -28,5 +60,70 @@ describe("escalateAction", () => {
 			errorCode: "unsupported_escalation_target",
 		});
 		expect(result.text).toContain("not supported");
+	});
+
+	it("sends the model-authored escalation message when provided", async () => {
+		const captured: Memory[] = [];
+		const callback = vi.fn() as HandlerCallback;
+		const result = await escalateAction.handler(
+			runtimeWithAdmin(captured),
+			autonomousMessage("Internal thought that should remain metadata."),
+			undefined,
+			{
+				parameters: {
+					action: "admin",
+					message: "Please review the delivery plan before I proceed.",
+				},
+			},
+			callback,
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.data).toMatchObject({
+			adminUserId: "admin-user",
+			targetRoomId: agentId,
+			messageContent: "Please review the delivery plan before I proceed.",
+			sent: true,
+			action: "admin",
+		});
+		expect(captured).toHaveLength(1);
+		expect(captured[0]?.roomId).toBe(agentId);
+		expect(captured[0]?.content.text).toBe(
+			"Please review the delivery plan before I proceed.",
+		);
+		expect(captured[0]?.content.metadata).toMatchObject({
+			type: "autonomous-to-admin-message",
+			originalThought: "Internal thought that should remain metadata.",
+		});
+		expect(callback).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					messageContent: "Please review the delivery plan before I proceed.",
+				}),
+			}),
+		);
+	});
+
+	it("falls back to the autonomous thought verbatim without keyword framing", async () => {
+		const captured: Memory[] = [];
+		const thought =
+			"No problems encountered; all finished, but I have a question.";
+		const result = await escalateAction.handler(
+			runtimeWithAdmin(captured),
+			autonomousMessage(thought),
+			undefined,
+			{ parameters: { action: "admin" } },
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.data).toMatchObject({
+			messageContent: thought,
+			targetRoomId: agentId,
+		});
+		expect(captured[0]?.content.text).toBe(thought);
+		expect(captured[0]?.content.text).not.toContain("I've completed a task");
+		expect(captured[0]?.content.text).not.toContain(
+			"might need your attention",
+		);
 	});
 });

--- a/packages/core/src/features/autonomy/action.ts
+++ b/packages/core/src/features/autonomy/action.ts
@@ -19,7 +19,6 @@ import type {
 	JsonValue,
 	Memory,
 	State,
-	UUID,
 } from "../../types";
 import { stringToUuid } from "../../utils";
 import { AUTONOMY_SERVICE_TYPE, type AutonomyService } from "./service";
@@ -45,6 +44,20 @@ function readEscalateSubaction(
 	return "admin";
 }
 
+function readEscalationMessage(
+	options: HandlerOptions | undefined,
+): string | null {
+	const params = options?.parameters as
+		| Record<string, JsonValue | undefined>
+		| undefined;
+	const value = params?.message;
+	if (typeof value !== "string") {
+		return null;
+	}
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
 function unsupportedEscalationTarget(
 	subaction: Exclude<EscalateSubaction, "admin">,
 ): ActionResult {
@@ -64,6 +77,7 @@ function unsupportedEscalationTarget(
 async function escalateToAdmin(
 	runtime: IAgentRuntime,
 	message: Memory,
+	options: HandlerOptions | undefined,
 	callback: HandlerCallback | undefined,
 ): Promise<ActionResult> {
 	// Double-check we're in autonomous context
@@ -97,45 +111,9 @@ async function escalateToAdmin(
 		};
 	}
 
-	// Find target room
-	const adminMessages = await runtime.getMemories({
-		roomId: runtime.agentId,
-		limit: 10,
-		tableName: "memories",
-	});
-
-	let targetRoomId: UUID;
-	if (adminMessages && adminMessages.length > 0) {
-		const lastMessage = adminMessages[adminMessages.length - 1];
-		targetRoomId = lastMessage.roomId;
-	} else {
-		targetRoomId = runtime.agentId;
-	}
-
-	// Extract message content
+	const targetRoomId = runtime.agentId;
 	const autonomousThought = message.content.text || "";
-
-	// Generate message to admin
-	let messageToAdmin: string;
-	if (
-		autonomousThought.includes("completed") ||
-		autonomousThought.includes("finished")
-	) {
-		messageToAdmin = `I've completed a task and wanted to update you. My thoughts: ${autonomousThought}`;
-	} else if (
-		autonomousThought.includes("problem") ||
-		autonomousThought.includes("issue") ||
-		autonomousThought.includes("error")
-	) {
-		messageToAdmin = `I encountered something that might need your attention: ${autonomousThought}`;
-	} else if (
-		autonomousThought.includes("question") ||
-		autonomousThought.includes("unsure")
-	) {
-		messageToAdmin = `I have a question and would appreciate your guidance: ${autonomousThought}`;
-	} else {
-		messageToAdmin = `Autonomous update: ${autonomousThought}`;
-	}
+	const messageToAdmin = readEscalationMessage(options) ?? autonomousThought;
 
 	// Create and store message
 	const now = Date.now();
@@ -284,7 +262,7 @@ export const escalateAction: Action = {
 	): Promise<ActionResult> => {
 		const subaction = readEscalateSubaction(options);
 		if (subaction === "admin") {
-			return escalateToAdmin(runtime, message, callback);
+			return escalateToAdmin(runtime, message, options, callback);
 		}
 		return unsupportedEscalationTarget(subaction);
 	},


### PR DESCRIPTION
## Summary

Closes #14719.

Removes the hardcoded `.includes()` framing cascade from `ESCALATE action=admin`. The action now sends the model-authored `parameters.message` when present, or the autonomous thought verbatim when no message parameter is provided. It also removes the dead admin-room memory lookup that always collapsed back to `runtime.agentId`.

## Verification

- `bun test packages/core/src/features/autonomy/action.test.ts` — 4 passed, including regression coverage for `parameters.message` and mixed success/problem/question wording stored verbatim.
- `bunx biome check packages/core/src/features/autonomy/action.ts packages/core/src/features/autonomy/action.test.ts` — passed.
- `git diff --check` — passed.
- `bun run --cwd packages/core typecheck` — passed.
- `bun run --cwd packages/core build:node` — passed.
- `bun run audit:error-policy-ratchet` — passed; no new fallback-slop.

## Evidence Notes

- UI screenshots/video: N/A — core action behavior only, no rendered UI surface changed.
- Live LLM trajectory: N/A for this patch — the regression drives the action contract directly and verifies that model-authored action parameters are no longer discarded by deterministic post-processing.
