### PR TITLE
fix(scenarios): keep widget roundtrips active

### DIFF
--- a/packages/scenario-runner/test/scenarios/live-chat-widgets-choice-roundtrip.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-chat-widgets-choice-roundtrip.scenario.ts
@@ -59,7 +59,6 @@ const INSTALLED_APPS_FIXTURE = [
 export default scenario({
   id: "live-chat-widgets-choice-roundtrip",
   lane: "live-only",
-  status: "pending",
   title: "Real LLM surfaces a [CHOICE] picker, then honors the picked value",
   domain: "chat-widgets",
   tags: ["live", "real-llm", "chat-widgets", "choice", "app-control"],

--- a/packages/scenario-runner/test/scenarios/live-chat-widgets-form-roundtrip.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-chat-widgets-form-roundtrip.scenario.ts
@@ -47,7 +47,6 @@ const SUBMITTED_TOKEN_RE = /q3|budget|dana/i;
 export default scenario({
   id: "live-chat-widgets-form-roundtrip",
   lane: "live-only",
-  status: "pending",
   title: "Real LLM emits a [FORM], consumes the raw [form:submit] re-entry",
   domain: "chat-widgets",
   tags: ["live", "real-llm", "chat-widgets", "form", "lifeops"],


### PR DESCRIPTION
## Summary
- Restores `live-chat-widgets-choice-roundtrip` and `live-chat-widgets-form-roundtrip` to active live-only coverage by removing the accidental `status: "pending"` flags introduced in #14741.
- Keeps the #14741 schema/status hardening on develop.
- Matches #14743’s intent: these are now active regression scenarios for landed #14322 core fixes, not known-red cases.

## Verification
- `bun run --cwd packages/scenario-runner src/cli.ts list test/scenarios --scenario live-chat-widgets-choice-roundtrip && bun run --cwd packages/scenario-runner src/cli.ts list test/scenarios --scenario live-chat-widgets-form-roundtrip` -> listed both scenarios by default.
- `bunx @biomejs/biome check packages/scenario-runner/test/scenarios/live-chat-widgets-choice-roundtrip.scenario.ts packages/scenario-runner/test/scenarios/live-chat-widgets-form-roundtrip.scenario.ts && git diff --check` -> clean.


## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - scenario metadata change only; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [x] N/A - scenario metadata change only; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing runtime flow changed; this restores scenario inventory visibility.

<!-- evidence-row:backend-logs -->
- [x] N/A - no long-running backend service was started; CLI list output verifies both scenarios are active by default.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend request/response path changed.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/action/prompt behavior changed; this only removes accidental pending metadata.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifact is produced; the domain proof is the scenario-runner CLI inventory output listing both widget scenarios by default.
