### PR TITLE
fix(scenarios): validate pending scenario status

### DIFF
--- a/packages/scenario-runner/schema/index.js
+++ b/packages/scenario-runner/schema/index.js
@@ -143,6 +143,7 @@ export const DEFAULT_SCENARIO_LANE = "live-only";
 
 const SCENARIO_LANES = new Set(["pr-deterministic", "live-only"]);
 const SCENARIO_TIERS = new Set(["T1", "T2", "T3", "T4"]);
+const SCENARIO_STATUSES = new Set(["active", "pending"]);
 
 /** Resolve a scenario's effective lane, applying {@link DEFAULT_SCENARIO_LANE}. */
 export function scenarioLane(value) {
@@ -170,6 +171,19 @@ export function scenarioTier(value) {
     );
   }
   return tier;
+}
+
+function validateScenarioStatus(value) {
+  const status = value?.status;
+  if (status === undefined) {
+    return undefined;
+  }
+  if (!SCENARIO_STATUSES.has(status)) {
+    throw new Error(
+      `scenario "${value?.id ?? "<unknown>"}" has invalid status "${status}"; expected one of ${[...SCENARIO_STATUSES].join(", ")}`,
+    );
+  }
+  return status;
 }
 
 /**
@@ -217,6 +231,8 @@ export function scenario(value) {
     scenarioLane(value);
     // Validate optional LifeOps/persona tier metadata when authored.
     scenarioTier(value);
+    // Validate pending/active inventory status before loader filtering relies on it.
+    validateScenarioStatus(value);
     // Validate the deferral shape (and lane compatibility) eagerly too.
     scenarioDeferral(value);
   }

--- a/packages/scenario-runner/src/__tests__/loader-lane-filter.test.ts
+++ b/packages/scenario-runner/src/__tests__/loader-lane-filter.test.ts
@@ -3,16 +3,16 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { listScenarioMetadata } from "../loader";
+import { listScenarioMetadata, loadAllScenarios } from "../loader";
 
 let tempDirs: string[] = [];
 
 function makeScenarioDir(
-  files: Record<string, { id: string; lane?: string }>,
+  files: Record<string, { id: string; lane?: string; status?: string }>,
 ): string {
   const dir = mkdtempSync(path.join(tmpdir(), "scenario-lane-filter-"));
   tempDirs.push(dir);
-  for (const [fileName, { id, lane }] of Object.entries(files)) {
+  for (const [fileName, { id, lane, status }] of Object.entries(files)) {
     writeFileSync(
       path.join(dir, fileName),
       [
@@ -21,6 +21,7 @@ function makeScenarioDir(
         `  title: "${id}",`,
         '  domain: "loader-test",',
         ...(lane ? [`  lane: "${lane}",`] : []),
+        ...(status ? [`  status: "${status}",`] : []),
         "  turns: [],",
         "};",
         "",
@@ -87,5 +88,48 @@ describe("listScenarioMetadata lane filtering", () => {
       "lane-deterministic",
       "lane-undeclared",
     ]);
+  });
+
+  it("excludes pending scenarios from list and run inventories unless explicitly included", async () => {
+    const previous = process.env.SCENARIO_INCLUDE_PENDING;
+    const dir = makeScenarioDir({
+      "active.scenario.ts": {
+        id: "pending-active",
+        lane: "live-only",
+      },
+      "pending.scenario.ts": {
+        id: "pending-hidden",
+        lane: "live-only",
+        status: "pending",
+      },
+    });
+
+    try {
+      delete process.env.SCENARIO_INCLUDE_PENDING;
+
+      await expect(listScenarioMetadata(dir)).resolves.toMatchObject([
+        { id: "pending-active" },
+      ]);
+      await expect(loadAllScenarios(dir)).resolves.toHaveLength(1);
+
+      process.env.SCENARIO_INCLUDE_PENDING = "1";
+
+      await expect(
+        listScenarioMetadata(dir).then((scenarios) =>
+          scenarios.map((scenario) => scenario.id).sort(),
+        ),
+      ).resolves.toEqual(["pending-active", "pending-hidden"]);
+      await expect(
+        loadAllScenarios(dir).then((scenarios) =>
+          scenarios.map(({ scenario }) => scenario.id).sort(),
+        ),
+      ).resolves.toEqual(["pending-active", "pending-hidden"]);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.SCENARIO_INCLUDE_PENDING;
+      } else {
+        process.env.SCENARIO_INCLUDE_PENDING = previous;
+      }
+    }
   });
 });

--- a/packages/scenario-runner/src/schema-strict.test.ts
+++ b/packages/scenario-runner/src/schema-strict.test.ts
@@ -94,6 +94,24 @@ describe("scenario() strict finalCheck validation", () => {
   });
 });
 
+describe("scenario() strict scenario metadata validation", () => {
+  const base = {
+    id: "fixture.strict.metadata",
+    title: "Strict metadata fixture",
+    domain: "fixture",
+    turns: [{ kind: "message", name: "ask", text: "hello" }],
+  } satisfies ScenarioDefinition;
+
+  it("throws on an unknown top-level scenario status instead of running it", () => {
+    expect(() =>
+      scenario({
+        ...base,
+        status: "known-red",
+      } as unknown as ScenarioDefinition),
+    ).toThrow(/invalid status "known-red"/);
+  });
+});
+
 describe("loadScenarioFile strict validation", () => {
   it("hard-fails loading a plain-object scenario with an unknown finalCheck type", async () => {
     const dir = await makeTempScenarioDir();


### PR DESCRIPTION
## Summary

Adds a narrow scenario-runner hardening for the existing pending-scenario inventory behavior:

- Validates top-level scenario `status` values at definition/load time so typos cannot silently become active coverage.
- Adds a focused loader regression proving `status: "pending"` scenarios are hidden from list/run inventories by default and visible with `SCENARIO_INCLUDE_PENDING=1`.
- Leaves the current live chat-widget regression scenarios active by default; this PR does not mark any corpus scenario pending.

Refs #14322.

## Verification

- `bun run --cwd packages/scenario-runner test -- src/__tests__/loader-lane-filter.test.ts src/schema-strict.test.ts src/scenario-deferral.test.ts` -> 3 files passed, 20 tests passed.
- `bunx @biomejs/biome check packages/scenario-runner/schema/index.js packages/scenario-runner/src/__tests__/loader-lane-filter.test.ts packages/scenario-runner/src/schema-strict.test.ts --no-errors-on-unmatched` -> no fixes applied.
- `bun run --cwd packages/scenario-runner src/cli.ts list test/scenarios --scenario live-chat-widgets-choice-roundtrip && bun run --cwd packages/scenario-runner src/cli.ts list test/scenarios --scenario live-chat-widgets-form-roundtrip` -> listed both scenarios, confirming this PR does not hide the widget regression contracts.
- `git diff --check` -> clean.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - scenario metadata/schema validation only; no rendered UI surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - no rendered UI changed; focused scenario-runner tests and CLI inventory output are listed above`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no user-facing runtime flow changed; this only validates scenario inventory metadata`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no long-running backend service path changed`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend request/response path changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - this does not alter model/action/prompt behavior and does not mark live model scenarios pending`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no persistent domain artifact is produced; the domain artifact is the scenario inventory behavior covered by the focused tests and CLI list output`.
