### PR TITLE
fix(lifeops): rank check-in briefings structurally

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/checkin/checkin-briefing-ranking.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/checkin/checkin-briefing-ranking.ts
@@ -1,0 +1,100 @@
+/** Structural ranking helpers for check-in briefing items before they are serialized into the summary prompt. */
+import type { CheckinBriefingItem } from "./types.js";
+
+export const MAX_SECTION_ITEMS_FOR_PROMPT = 30;
+
+export type BriefingItemSignals = NonNullable<CheckinBriefingItem["signals"]>;
+export type BriefingSortSignals = BriefingItemSignals & {
+  occurredAt: string | null;
+};
+export type BriefingEngagement = NonNullable<BriefingItemSignals["engagement"]>;
+
+function parseMs(value: string | null | undefined): number | null {
+  if (!value) {
+    return null;
+  }
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+export function toFiniteNonNegativeNumber(value: unknown): number {
+  const number = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(number) && number > 0 ? number : 0;
+}
+
+export function buildBriefingSignals(args: {
+  occurredAt: string | null;
+  unread?: boolean;
+  inbound?: boolean;
+  replyNeeded?: boolean;
+  important?: boolean;
+  sourcePriority?: number;
+  engagement?: BriefingEngagement;
+}): { signals: BriefingItemSignals; reason: string | null } {
+  const reasons: string[] = [];
+  const occurredAtMs = parseMs(args.occurredAt);
+  const recent =
+    occurredAtMs !== null && Date.now() - occurredAtMs <= 24 * 60 * 60 * 1000;
+  if (args.inbound) {
+    reasons.push("incoming");
+  }
+  if (args.unread) {
+    reasons.push("unread");
+  }
+  if (args.replyNeeded) {
+    reasons.push("needs reply");
+  }
+  if (args.important) {
+    reasons.push("important");
+  }
+  if (recent) {
+    reasons.push("recent");
+  }
+  return {
+    signals: {
+      inbound: args.inbound || undefined,
+      unread: args.unread || undefined,
+      replyNeeded: args.replyNeeded || undefined,
+      important: args.important || undefined,
+      recent: recent || undefined,
+      sourcePriority: args.sourcePriority,
+      engagement: args.engagement,
+    },
+    reason: reasons.length > 0 ? reasons.join(", ") : null,
+  };
+}
+
+export function sortBriefingItems(
+  entries: Array<CheckinBriefingItem & { sort: BriefingSortSignals }>,
+): CheckinBriefingItem[] {
+  return entries
+    .sort((left, right) => {
+      for (const key of [
+        "replyNeeded",
+        "important",
+        "unread",
+        "inbound",
+        "recent",
+      ] as const) {
+        const diff =
+          Number(Boolean(right.sort[key])) - Number(Boolean(left.sort[key]));
+        if (diff !== 0) {
+          return diff;
+        }
+      }
+      const priorityDiff =
+        (right.sort.sourcePriority ?? 0) - (left.sort.sourcePriority ?? 0);
+      if (priorityDiff !== 0) {
+        return priorityDiff;
+      }
+      const engagementDiff =
+        (right.sort.engagement?.totalCount ?? 0) -
+        (left.sort.engagement?.totalCount ?? 0);
+      if (engagementDiff !== 0) {
+        return engagementDiff;
+      }
+      return (parseMs(right.occurredAt) ?? 0) - (parseMs(left.occurredAt) ?? 0);
+    })
+    .slice(0, MAX_SECTION_ITEMS_FOR_PROMPT)
+    .map(({ sort: _sort, ...item }) => item);
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/checkin/checkin-briefing.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/checkin/checkin-briefing.test.ts
@@ -1,0 +1,76 @@
+/** Verifies check-in briefing item ranking before the report is serialized for the summary model. */
+import { describe, expect, it } from "vitest";
+import {
+  type BriefingSortSignals,
+  buildBriefingSignals,
+  sortBriefingItems,
+  toFiniteNonNegativeNumber,
+} from "./checkin-briefing-ranking.js";
+import type { CheckinBriefingItem } from "./types.js";
+
+function item(
+  title: string,
+  occurredAt: string,
+  signals = buildBriefingSignals({ occurredAt }),
+): CheckinBriefingItem & {
+  sort: BriefingSortSignals;
+} {
+  return {
+    title,
+    detail: "urgent asap deadline please reply?",
+    occurredAt,
+    href: null,
+    reason: signals.reason,
+    signals: signals.signals,
+    sort: { ...signals.signals, occurredAt },
+  };
+}
+
+describe("check-in briefing ranking", () => {
+  it("does not promote keyword-only text before the summary model sees it", () => {
+    const ranked = buildBriefingSignals({
+      occurredAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    expect(ranked.reason).toBeNull();
+    expect(ranked.signals.replyNeeded).toBeUndefined();
+    expect(ranked.signals.important).toBeUndefined();
+  });
+
+  it("keeps collector-sized sections instead of silently cutting to eight items", () => {
+    const items = Array.from({ length: 10 }, (_, index) =>
+      item(
+        `message ${index}`,
+        `2026-01-${String(index + 1).padStart(2, "0")}T00:00:00.000Z`,
+      ),
+    );
+
+    expect(sortBriefingItems(items)).toHaveLength(10);
+  });
+
+  it("orders by typed reply-needed signal before recency", () => {
+    const olderReplyNeeded = item(
+      "older reply-needed",
+      "2026-01-01T00:00:00.000Z",
+      buildBriefingSignals({
+        occurredAt: "2026-01-01T00:00:00.000Z",
+        replyNeeded: true,
+      }),
+    );
+    const newerObservation = item(
+      "newer observation",
+      "2026-01-02T00:00:00.000Z",
+    );
+
+    expect(
+      sortBriefingItems([newerObservation, olderReplyNeeded])[0]?.title,
+    ).toBe("older reply-needed");
+  });
+
+  it("normalizes missing metric counts instead of producing NaN engagement", () => {
+    expect(toFiniteNonNegativeNumber(undefined)).toBe(0);
+    expect(toFiniteNonNegativeNumber(Number.NaN)).toBe(0);
+    expect(toFiniteNonNegativeNumber(-3)).toBe(0);
+    expect(toFiniteNonNegativeNumber(7)).toBe(7);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/checkin/checkin-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/checkin/checkin-service.ts
@@ -28,8 +28,13 @@ import {
 } from "../service-helpers-occurrence.js";
 import { executeRawSql, parseJsonRecord, sqlQuote, toText } from "../sql.js";
 import { buildUtcDateFromLocalParts, getZonedDateParts } from "../time.js";
+import {
+  type BriefingEngagement,
+  buildBriefingSignals,
+  sortBriefingItems,
+  toFiniteNonNegativeNumber,
+} from "./checkin-briefing-ranking.js";
 import type {
-  CheckinBriefingItem,
   CheckinBriefingSection,
   CheckinKind,
   CheckinReport,
@@ -57,10 +62,7 @@ import type {
 export const CHECKIN_REPORTS_TABLE = "app_lifeops.life_checkin_reports";
 
 const ACK_WINDOW_MS = 72 * 60 * 60 * 1000;
-const DEFAULT_SECTION_LIMIT = 8;
 const INTERNAL_URL = new URL("http://127.0.0.1/");
-const ACTION_TEXT_RE =
-  /\b(urgent|asap|blocked|deadline|today|tonight|tomorrow|confirm|review|send|reply|respond|need|please|important|agreement|agreed|promise|promised|follow up|circle back)\b/i;
 
 export interface CheckinSourceService {
   getInbox?(request?: GetLifeOpsInboxRequest): Promise<LifeOpsInbox>;
@@ -286,68 +288,6 @@ function localDayWindow(
     end,
     key: `${parts.year}-${String(parts.month).padStart(2, "0")}-${String(parts.day).padStart(2, "0")}`,
   };
-}
-
-function rankTextSignal(args: {
-  text: string;
-  occurredAt: string | null;
-  unread?: boolean;
-  inbound?: boolean;
-  replyNeeded?: boolean;
-  important?: boolean;
-}): { score: number; reason: string | null } {
-  const reasons: string[] = [];
-  let score = 0;
-  if (args.inbound) {
-    score += 20;
-    reasons.push("incoming");
-  }
-  if (args.unread) {
-    score += 15;
-    reasons.push("unread");
-  }
-  if (args.replyNeeded) {
-    score += 25;
-    reasons.push("needs reply");
-  }
-  if (args.important) {
-    score += 20;
-    reasons.push("important");
-  }
-  if (args.text.includes("?")) {
-    score += 10;
-    reasons.push("question");
-  }
-  if (ACTION_TEXT_RE.test(args.text)) {
-    score += 20;
-    reasons.push("action language");
-  }
-  const occurredAtMs = parseMs(args.occurredAt);
-  if (
-    occurredAtMs !== null &&
-    Date.now() - occurredAtMs <= 24 * 60 * 60 * 1000
-  ) {
-    score += 10;
-    reasons.push("recent");
-  }
-  return {
-    score,
-    reason: reasons.length > 0 ? reasons.join(", ") : null,
-  };
-}
-
-function sortBriefingItems(
-  entries: Array<CheckinBriefingItem & { score: number }>,
-): CheckinBriefingItem[] {
-  return entries
-    .sort((left, right) => {
-      if (right.score !== left.score) {
-        return right.score - left.score;
-      }
-      return (parseMs(right.occurredAt) ?? 0) - (parseMs(left.occurredAt) ?? 0);
-    })
-    .slice(0, DEFAULT_SECTION_LIMIT)
-    .map(({ score: _score, ...item }) => item);
 }
 
 function unavailableSection(
@@ -721,8 +661,7 @@ async function collectXDmSection(
     const dms = await source.getXDms({ limit: 30 });
     const items = sortBriefingItems(
       dms.map((dm) => {
-        const ranked = rankTextSignal({
-          text: dm.text,
+        const ranked = buildBriefingSignals({
           occurredAt: dm.receivedAt,
           inbound: dm.isInbound,
           unread: dm.readAt === null,
@@ -734,12 +673,13 @@ async function collectXDmSection(
           occurredAt: dm.receivedAt,
           href: null,
           reason: ranked.reason,
-          score: ranked.score,
+          signals: ranked.signals,
+          sort: { ...ranked.signals, occurredAt: dm.receivedAt },
         };
       }),
     );
-    const actionNeeded = items.filter((item) =>
-      item.reason?.includes("needs reply"),
+    const actionNeeded = items.filter(
+      (item) => item.signals?.replyNeeded,
     ).length;
     return {
       key: "x_dms",
@@ -784,16 +724,21 @@ async function collectXFeedSection(
           .filter((type): type is string => typeof type === "string");
         const isReply = referenceTypes.includes("replied_to");
         const metrics = raw.public_metrics ?? {};
-        const engagement =
-          metrics.like_count +
-          metrics.reply_count * 3 +
-          metrics.retweet_count * 2 +
-          metrics.quote_count * 2;
-        const ranked = rankTextSignal({
-          text: feedItem.text,
+        const engagement: BriefingEngagement = {
+          likeCount: toFiniteNonNegativeNumber(metrics.like_count),
+          replyCount: toFiniteNonNegativeNumber(metrics.reply_count),
+          repostCount: toFiniteNonNegativeNumber(metrics.retweet_count),
+          quoteCount: toFiniteNonNegativeNumber(metrics.quote_count),
+          totalCount:
+            toFiniteNonNegativeNumber(metrics.like_count) +
+            toFiniteNonNegativeNumber(metrics.reply_count) +
+            toFiniteNonNegativeNumber(metrics.retweet_count) +
+            toFiniteNonNegativeNumber(metrics.quote_count),
+        };
+        const ranked = buildBriefingSignals({
           occurredAt: feedItem.createdAtSource,
           replyNeeded: isReply,
-          important: engagement >= 25,
+          engagement,
         });
         return {
           title: feedItem.authorHandle
@@ -803,7 +748,8 @@ async function collectXFeedSection(
           occurredAt: feedItem.createdAtSource,
           href: `https://x.com/i/web/status/${feedItem.externalTweetId}`,
           reason: ranked.reason,
-          score: ranked.score + Math.min(30, engagement),
+          signals: ranked.signals,
+          sort: { ...ranked.signals, occurredAt: feedItem.createdAtSource },
         };
       }),
     );
@@ -843,9 +789,7 @@ async function collectInboxSection(
       );
     const items = sortBriefingItems(
       inbox.messages.map((message) => {
-        const text = `${message.subject ?? ""} ${message.snippet}`;
-        const ranked = rankTextSignal({
-          text,
+        const ranked = buildBriefingSignals({
           occurredAt: message.receivedAt,
           unread: message.unread,
           inbound: true,
@@ -860,7 +804,8 @@ async function collectInboxSection(
           occurredAt: message.receivedAt,
           href: message.deepLink,
           reason: ranked.reason,
-          score: ranked.score,
+          signals: ranked.signals,
+          sort: { ...ranked.signals, occurredAt: message.receivedAt },
         };
       }),
     );
@@ -899,14 +844,13 @@ async function collectGmailSection(
     );
     const items = sortBriefingItems(
       feed.messages.map((message) => {
-        const text = `${message.subject} ${message.snippet}`;
-        const ranked = rankTextSignal({
-          text,
+        const ranked = buildBriefingSignals({
           occurredAt: message.receivedAt,
           unread: message.isUnread,
           inbound: true,
           replyNeeded: message.likelyReplyNeeded,
           important: message.isImportant,
+          sourcePriority: message.triageScore,
         });
         return {
           title: `${message.from || "Unknown"}${
@@ -916,7 +860,8 @@ async function collectGmailSection(
           occurredAt: message.receivedAt,
           href: message.htmlLink,
           reason: ranked.reason ?? (message.triageReason || null),
-          score: ranked.score + message.triageScore,
+          signals: ranked.signals,
+          sort: { ...ranked.signals, occurredAt: message.receivedAt },
         };
       }),
     );
@@ -981,6 +926,10 @@ async function collectCalendarChangeSection(
             : isChanged
               ? "added or updated"
               : "on schedule";
+        const ranked = buildBriefingSignals({
+          occurredAt: updatedAt ?? toText(row.start_at),
+          important: status.toLowerCase() === "cancelled" || isChanged,
+        });
         return {
           title,
           detail: `${toText(row.start_at)} - ${toText(row.end_at)}${
@@ -989,7 +938,11 @@ async function collectCalendarChangeSection(
           occurredAt: updatedAt ?? toText(row.start_at),
           href: toText(row.html_link) || null,
           reason,
-          score: (isChanged ? 30 : 10) + (status === "cancelled" ? 30 : 0),
+          signals: ranked.signals,
+          sort: {
+            ...ranked.signals,
+            occurredAt: updatedAt ?? toText(row.start_at),
+          },
         };
       }),
     );
@@ -1045,14 +998,14 @@ async function collectGitHubSection(
       ),
     ]);
     const mailItems = mailRows.map((row) => {
-      const text = `${toText(row.subject)} ${toText(row.snippet)}`;
-      const ranked = rankTextSignal({
-        text,
+      const sourcePriority = Number(row.triage_score ?? 0);
+      const ranked = buildBriefingSignals({
         occurredAt: toText(row.received_at),
         unread: toBoolean(row.is_unread),
         important: toBoolean(row.is_important),
         replyNeeded: toBoolean(row.likely_reply_needed),
         inbound: true,
+        sourcePriority: Number.isFinite(sourcePriority) ? sourcePriority : 0,
       });
       return {
         title: `GitHub email: ${toText(row.subject) || "(no subject)"}`,
@@ -1060,20 +1013,36 @@ async function collectGitHubSection(
         occurredAt: toText(row.received_at) || null,
         href: toText(row.html_link) || null,
         reason: ranked.reason,
-        score: ranked.score + Number(row.triage_score ?? 0),
+        signals: ranked.signals,
+        sort: {
+          ...ranked.signals,
+          occurredAt: toText(row.received_at) || null,
+        },
       };
     });
     const screenItems = screenRows.map((row) => {
       const minutes = Math.round(Number(row.duration_seconds ?? 0) / 60);
+      const engagement: BriefingEngagement = {
+        likeCount: 0,
+        replyCount: 0,
+        repostCount: 0,
+        quoteCount: 0,
+        totalCount: Number.isFinite(minutes) && minutes > 0 ? minutes : 0,
+      };
+      const ranked = buildBriefingSignals({
+        occurredAt: toText(row.start_at) || null,
+        engagement,
+      });
       return {
         title: `GitHub activity: ${
           toText(row.display_name) || toText(row.identifier)
         }`,
-        detail: `${minutes}m active`,
+        detail: `${Number.isFinite(minutes) && minutes > 0 ? minutes : 0}m active`,
         occurredAt: toText(row.start_at) || null,
         href: null,
         reason: "workspace activity",
-        score: 10 + Math.min(30, minutes),
+        signals: ranked.signals,
+        sort: { ...ranked.signals, occurredAt: toText(row.start_at) || null },
       };
     });
     const items = sortBriefingItems([...mailItems, ...screenItems]);
@@ -1138,16 +1107,21 @@ async function collectContactSection(
     };
     const uniqueNames = new Set(rows.map(nameFor).filter(Boolean));
     const items = sortBriefingItems(
-      rows.map((row) => ({
-        title: `${nameFor(row) || "Unknown"} (${
-          toText(row.channel) || "unknown"
-        })`,
-        detail: clip(toText(row.summary) || toText(row.direction)),
-        occurredAt: toText(row.occurred_at) || null,
-        href: null,
-        reason: toText(row.direction) || null,
-        score: 20,
-      })),
+      rows.map((row) => {
+        const occurredAt = toText(row.occurred_at) || null;
+        const ranked = buildBriefingSignals({ occurredAt });
+        return {
+          title: `${nameFor(row) || "Unknown"} (${
+            toText(row.channel) || "unknown"
+          })`,
+          detail: clip(toText(row.summary) || toText(row.direction)),
+          occurredAt,
+          href: null,
+          reason: toText(row.direction) || ranked.reason,
+          signals: ranked.signals,
+          sort: { ...ranked.signals, occurredAt },
+        };
+      }),
     );
     return {
       key: "contacts",
@@ -1180,16 +1154,23 @@ async function collectPromiseSection(
     // separate LifeOps follow-up table.
     const digest = await computeOverdueFollowups(runtime, now.getTime());
     const items = sortBriefingItems(
-      digest.overdue.map((entry) => ({
-        title: `${entry.displayName}: ${entry.daysOverdue}d overdue`,
-        detail: clip(
-          `Last contacted ${entry.lastContactedAt} (cadence ${entry.thresholdDays}d)`,
-        ),
-        occurredAt: entry.lastContactedAt,
-        href: null,
-        reason: "overdue follow-up",
-        score: 40 + Math.min(20, entry.daysOverdue),
-      })),
+      digest.overdue.map((entry) => {
+        const ranked = buildBriefingSignals({
+          occurredAt: entry.lastContactedAt,
+          important: true,
+        });
+        return {
+          title: `${entry.displayName}: ${entry.daysOverdue}d overdue`,
+          detail: clip(
+            `Last contacted ${entry.lastContactedAt} (cadence ${entry.thresholdDays}d)`,
+          ),
+          occurredAt: entry.lastContactedAt,
+          href: null,
+          reason: "overdue follow-up",
+          signals: ranked.signals,
+          sort: { ...ranked.signals, occurredAt: entry.lastContactedAt },
+        };
+      }),
     );
     return {
       key: "promises",

--- a/plugins/plugin-personal-assistant/src/lifeops/checkin/types.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/checkin/types.ts
@@ -57,6 +57,21 @@ export interface CheckinBriefingItem {
   readonly occurredAt: string | null;
   readonly href: string | null;
   readonly reason: string | null;
+  readonly signals?: {
+    readonly inbound?: boolean;
+    readonly unread?: boolean;
+    readonly replyNeeded?: boolean;
+    readonly important?: boolean;
+    readonly recent?: boolean;
+    readonly sourcePriority?: number;
+    readonly engagement?: {
+      readonly likeCount: number;
+      readonly replyCount: number;
+      readonly repostCount: number;
+      readonly quoteCount: number;
+      readonly totalCount: number;
+    };
+  };
 }
 
 export interface CheckinBriefingSection {


### PR DESCRIPTION
## Summary

Closes #14718.

Removes the English keyword/checklist ranking path from LifeOps check-in briefing assembly. Briefing collectors now attach typed structural `signals` (`inbound`, `unread`, `replyNeeded`, `important`, `sourcePriority`, `engagement`) to items and sort from those fields before serializing the report for the summary model.

Key behavior changes:
- Deleted `ACTION_TEXT_RE`, `rankTextSignal`, the 8-item pre-model cutoff, question/action-language boosts, and fixed point scoring.
- Raised per-section prompt cap to the collector-sized 30 items so the model sees the same breadth the collectors fetch.
- Replaced `reason?.includes("needs reply")` with `item.signals?.replyNeeded` for X DM action-needed counts.
- Normalized missing X public metric counts to zero and removed weighted `reply*3/retweet*2/quote*2` engagement math.
- Split pure briefing ranking into `checkin-briefing-ranking.ts` so the behavior has cheap deterministic regression tests without importing the wider runtime/server graph.

## Verification

- `bun test plugins/plugin-personal-assistant/src/lifeops/checkin/checkin-briefing.test.ts` — 4 passed.
  - keyword-only text does not become important/reply-needed before the model sees it.
  - 10 items are retained instead of silently cutting to 8.
  - typed `replyNeeded` sorts before recency.
  - missing/NaN/negative metric counts normalize to zero.
- `bunx biome check plugins/plugin-personal-assistant/src/lifeops/checkin/checkin-service.ts plugins/plugin-personal-assistant/src/lifeops/checkin/types.ts plugins/plugin-personal-assistant/src/lifeops/checkin/checkin-briefing-ranking.ts plugins/plugin-personal-assistant/src/lifeops/checkin/checkin-briefing.test.ts` — passed.
- `git diff --check` — passed.
- `bun run --cwd plugins/plugin-personal-assistant build:types` — passed (`tsc --noCheck -p tsconfig.build.json`).
- `bun run audit:error-policy-ratchet` — passed; no new fallback-slop.
- Source scan: no remaining `ACTION_TEXT_RE`, `rankTextSignal`, `DEFAULT_SECTION_LIMIT`, `action language`, `reason?.includes`, weighted X engagement formula, or `Math.min(...)` ranking cap in `src/lifeops/checkin`.

## Known Verification Blockers

- `bun run --cwd plugins/plugin-personal-assistant typecheck` is blocked on current package-wide unresolved workspace/plugin declarations and existing strict errors unrelated to this slice, beginning with missing `@elizaos/plugin-blocker`, `@elizaos/plugin-calendar`, `@elizaos/agent`, `@elizaos/plugin-health`, and scheduled-task re-export errors.
- `bun test .../checkin-prompt.test.ts` currently imports `checkin-service.ts`, which pulls the wider agent server graph and fails before test execution on missing `@elizaos/plugin-wallet/diagnostic`. The new ranking regression is isolated specifically to avoid that unrelated import graph.

## Evidence Notes

- UI screenshots/video: N/A — this is a backend check-in report assembly change, not a rendered app UI change.
- Live LLM trajectory: N/A for this patch — the change is the pre-model filtering/ranking contract; deterministic tests verify the model now receives structural signals instead of keyword-derived labels.
