### PR TITLE
fix(lifeops): compose owner-facing scheduled copy

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.owner-facing-copy.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.owner-facing-copy.test.ts
@@ -1,0 +1,202 @@
+import { type IAgentRuntime, ServiceType } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { dailyRhythmPack } from "../../default-packs/daily-rhythm.js";
+import { morningBriefPack } from "../../default-packs/morning-brief.js";
+import {
+  createChannelRegistry,
+  registerChannelRegistry,
+} from "../channels/registry.js";
+import { createProductionScheduledTaskDispatcher } from "./runtime-wiring.js";
+
+const agentMocks = vi.hoisted(() => ({
+  eventService: { emit: vi.fn() },
+}));
+
+vi.mock("@elizaos/agent", () => ({
+  createLocalAgentBackup: vi.fn(),
+  getAgentEventService: vi.fn(() => agentMocks.eventService),
+}));
+
+const morningBriefMocks = vi.hoisted(() => ({
+  assembleMorningBrief: vi.fn(),
+}));
+
+vi.mock("../../default-packs/morning-brief.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../../default-packs/morning-brief.js")
+    >();
+  return {
+    ...actual,
+    assembleMorningBrief: morningBriefMocks.assembleMorningBrief,
+  };
+});
+
+function makeRuntime(
+  options: {
+    notify?: ReturnType<typeof vi.fn>;
+    reportError?: ReturnType<typeof vi.fn>;
+  } = {},
+): IAgentRuntime {
+  const notify = options.notify;
+  return {
+    agentId: "agent-test",
+    getService: vi.fn((serviceType: string) => {
+      if (serviceType === ServiceType.NOTIFICATION && notify) {
+        return { notify };
+      }
+      return null;
+    }),
+    getSetting: vi.fn(() => undefined),
+    reportError: options.reportError ?? vi.fn(),
+  } as unknown as IAgentRuntime;
+}
+
+describe("production scheduled-task dispatcher owner-facing copy", () => {
+  beforeEach(() => {
+    agentMocks.eventService.emit.mockClear();
+    morningBriefMocks.assembleMorningBrief.mockReset();
+  });
+
+  it("emits daily-rhythm owner-facing chat and notification copy instead of raw promptInstructions", async () => {
+    const notify = vi.fn().mockResolvedValue(undefined);
+    const runtime = makeRuntime({ notify });
+    const dispatcher = createProductionScheduledTaskDispatcher({ runtime });
+    const record = dailyRhythmPack.records.find(
+      (candidate) => candidate.metadata?.recordKey === "gn",
+    );
+    if (!record) throw new Error("daily-rhythm gn record missing");
+
+    const result = await dispatcher.dispatch({
+      taskId: record.taskId,
+      firedAtIso: "2026-07-06T03:00:00.000Z",
+      channelKey: "in_app",
+      intensity: "soft",
+      promptInstructions: record.promptInstructions,
+      contextRequest: record.contextRequest,
+      output: record.output,
+      metadata: record.metadata,
+    });
+
+    expect(result?.ok).toBe(true);
+    expect(agentMocks.eventService.emit).toHaveBeenCalledTimes(1);
+    const emitted = agentMocks.eventService.emit.mock.calls[0]?.[0];
+    if (!emitted) throw new Error("assistant event missing");
+    expect(emitted.data.text).toBe("Good night. Rest well.");
+    expect(emitted.data.text).not.toBe(record.promptInstructions);
+    expect(emitted.data.text).not.toContain("Send a gentle good-night");
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify.mock.calls[0]?.[0].body).toBe("Good night. Rest well.");
+    expect(notify.mock.calls[0]?.[0].body).not.toBe(record.promptInstructions);
+  });
+
+  it("uses the delegated morning checkin assembler summaryText for morning-brief delivery", async () => {
+    const summaryText =
+      "Good morning. You have two meetings today and one overdue todo.";
+    morningBriefMocks.assembleMorningBrief.mockResolvedValueOnce({
+      promptText: "internal prompt text",
+      report: { summaryText },
+    });
+    const notify = vi.fn().mockResolvedValue(undefined);
+    const runtime = makeRuntime({ notify });
+    const dispatcher = createProductionScheduledTaskDispatcher({ runtime });
+    const record = morningBriefPack.records[0];
+    if (!record) throw new Error("morning-brief record missing");
+
+    await dispatcher.dispatch({
+      taskId: record.taskId,
+      firedAtIso: "2026-07-06T14:00:00.000Z",
+      channelKey: "in_app",
+      intensity: "normal",
+      promptInstructions: record.promptInstructions,
+      contextRequest: record.contextRequest,
+      output: record.output,
+      metadata: record.metadata,
+    });
+
+    expect(morningBriefMocks.assembleMorningBrief).toHaveBeenCalledTimes(1);
+    expect(agentMocks.eventService.emit).toHaveBeenCalledTimes(1);
+    const emitted = agentMocks.eventService.emit.mock.calls[0]?.[0];
+    if (!emitted) throw new Error("assistant event missing");
+    expect(emitted.data.text).toBe(summaryText);
+    expect(emitted.data.text).not.toBe(record.promptInstructions);
+    expect(emitted.data.text).not.toContain(
+      "Assemble the owner's morning brief",
+    );
+    expect(notify.mock.calls[0]?.[0].body).toBe(summaryText);
+  });
+
+  it("sends owner-facing copy through connected channel payloads", async () => {
+    const runtime = makeRuntime();
+    const send = vi.fn().mockResolvedValue({ ok: true, messageId: "sent-1" });
+    const registry = createChannelRegistry();
+    registry.register({
+      kind: "telegram",
+      describe: { label: "Telegram" },
+      capabilities: {
+        send: true,
+        read: false,
+        reminders: true,
+        voice: false,
+        attachments: false,
+        quietHoursAware: true,
+      },
+      send,
+    });
+    registerChannelRegistry(runtime, registry);
+    const dispatcher = createProductionScheduledTaskDispatcher({ runtime });
+    const record = dailyRhythmPack.records.find(
+      (candidate) => candidate.metadata?.recordKey === "gm",
+    );
+    if (!record) throw new Error("daily-rhythm gm record missing");
+
+    await dispatcher.dispatch({
+      taskId: record.taskId,
+      firedAtIso: "2026-07-06T14:00:00.000Z",
+      channelKey: "telegram",
+      intensity: "soft",
+      promptInstructions: record.promptInstructions,
+      contextRequest: record.contextRequest,
+      output: record.output,
+      metadata: record.metadata,
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        message: "Good morning. Hope the day starts gently.",
+      }),
+    );
+    expect(send.mock.calls[0]?.[0].message).not.toBe(record.promptInstructions);
+  });
+
+  it("fails closed for unknown scheduled tasks without delivering promptInstructions verbatim", async () => {
+    const notify = vi.fn().mockResolvedValue(undefined);
+    const reportError = vi.fn();
+    const runtime = makeRuntime({ notify, reportError });
+    const dispatcher = createProductionScheduledTaskDispatcher({ runtime });
+    const promptInstructions =
+      "Send a gentle custom reminder with these internal instructions.";
+
+    await dispatcher.dispatch({
+      taskId: "task-custom",
+      firedAtIso: "2026-07-06T16:00:00.000Z",
+      channelKey: "in_app",
+      intensity: "normal",
+      promptInstructions,
+      contextRequest: undefined,
+      metadata: { packKey: "custom-pack", recordKey: "custom" },
+    });
+
+    const emitted = agentMocks.eventService.emit.mock.calls[0]?.[0];
+    if (!emitted) throw new Error("assistant event missing");
+    expect(emitted.data.text).toBe("Reminder.");
+    expect(emitted.data.text).not.toBe(promptInstructions);
+    expect(notify.mock.calls[0]?.[0].body).toBe("Reminder.");
+    expect(reportError).toHaveBeenCalledWith(
+      "lifeops:scheduled-task:owner-facing-copy",
+      expect.any(Error),
+      expect.objectContaining({ taskId: "task-custom" }),
+    );
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
@@ -46,6 +46,7 @@ import {
   type ScheduledTaskRunnerHandle,
   type ScheduledTaskStore,
 } from "@elizaos/plugin-scheduling";
+import { assembleMorningBrief } from "../../default-packs/morning-brief.js";
 import { getChannelRegistry } from "../channels/index.js";
 import type { DispatchResult } from "../connectors/contract.js";
 import { decideDispatchPolicy } from "../connectors/dispatch-policy.js";
@@ -295,6 +296,87 @@ function getNotifier(runtime: IAgentRuntime): NotificationEmitter | null {
   return svc && typeof svc.notify === "function" ? svc : null;
 }
 
+function reportScheduledTaskCompositionError(
+  runtime: IAgentRuntime,
+  error: unknown,
+  context: Record<string, unknown>,
+): void {
+  runtime.reportError?.("lifeops:scheduled-task:owner-facing-copy", error, {
+    agentId: runtime.agentId,
+    ...context,
+  });
+}
+
+function metadataString(
+  metadata: ScheduledTaskDispatchRecord["metadata"],
+  key: string,
+): string | null {
+  const value = metadata?.[key];
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+async function composeOwnerFacingScheduledTaskText(
+  runtime: IAgentRuntime,
+  record: ScheduledTaskDispatchRecord,
+): Promise<string> {
+  const delegatesAssemblyTo = metadataString(
+    record.metadata,
+    "delegatesAssemblyTo",
+  );
+
+  if (delegatesAssemblyTo === "lifeops:checkin:morning") {
+    try {
+      const assembled = await assembleMorningBrief(runtime, {
+        timezone: resolveDefaultTimeZone(),
+        now: new Date(record.firedAtIso),
+      });
+      const summaryText = assembled.report.summaryText.trim();
+      if (summaryText.length > 0) return summaryText;
+      throw new Error("Morning check-in assembler returned empty summaryText");
+    } catch (error) {
+      reportScheduledTaskCompositionError(runtime, error, {
+        taskId: record.taskId,
+        firedAtIso: record.firedAtIso,
+        delegatesAssemblyTo,
+      });
+      return "Your morning check-in is ready, but I couldn't assemble the full brief right now.";
+    }
+  }
+
+  const packKey = metadataString(record.metadata, "packKey");
+  const recordKey = metadataString(record.metadata, "recordKey");
+
+  if (packKey === "daily-rhythm" && recordKey === "gm") {
+    return "Good morning. Hope the day starts gently.";
+  }
+  if (packKey === "daily-rhythm" && recordKey === "gn") {
+    return "Good night. Rest well.";
+  }
+  if (packKey === "daily-rhythm" && recordKey === "checkin-followup") {
+    return "No rush if you're busy. I'm here whenever you're ready.";
+  }
+  if (packKey === "morning-brief") {
+    return "Your morning brief is ready, but I couldn't assemble the full details right now.";
+  }
+
+  const isUrgent = record.intensity === "urgent";
+  const fallback = isUrgent ? "Approval needed." : "Reminder.";
+  reportScheduledTaskCompositionError(
+    runtime,
+    new Error("No owner-facing scheduled-task composer registered"),
+    {
+      taskId: record.taskId,
+      firedAtIso: record.firedAtIso,
+      channelKey: record.channelKey,
+      packKey,
+      recordKey,
+    },
+  );
+  return fallback;
+}
+
 const LOCAL_AGENT_BACKUP_OPERATION = "agent.localBackup";
 
 function isLocalAgentBackupDispatch(
@@ -386,6 +468,10 @@ export function createProductionScheduledTaskDispatcher(opts: {
         };
       }
 
+      const ownerFacingText = await composeOwnerFacingScheduledTaskText(
+        opts.runtime,
+        record,
+      );
       const registry = getChannelRegistry(opts.runtime);
       const channel = registry?.get(record.channelKey) ?? null;
       if (!channel?.send) {
@@ -415,7 +501,7 @@ export function createProductionScheduledTaskDispatcher(opts: {
               stream: "assistant",
               agentId: opts.runtime.agentId,
               data: {
-                text: record.promptInstructions,
+                text: ownerFacingText,
                 source: "lifeops-scheduled-task",
                 taskId: record.taskId,
                 firedAtIso: record.firedAtIso,
@@ -438,7 +524,7 @@ export function createProductionScheduledTaskDispatcher(opts: {
             try {
               await notifier.notify({
                 title: isUrgent ? "Approval needed" : "Reminder",
-                body: record.promptInstructions,
+                body: ownerFacingText,
                 category: isUrgent ? "approval" : "reminder",
                 priority: isUrgent ? "urgent" : "normal",
                 source: "lifeops",
@@ -485,7 +571,7 @@ export function createProductionScheduledTaskDispatcher(opts: {
           record.channelKey,
           record.output?.target ?? record.channelKey,
         ),
-        message: record.promptInstructions,
+        message: ownerFacingText,
         metadata: {
           taskId: record.taskId,
           firedAtIso: record.firedAtIso,


### PR DESCRIPTION
## Summary
- Insert an owner-facing composition step in the production scheduled-task dispatcher before any chat event, notification body, or connected channel payload is sent.
- Route `delegatesAssemblyTo: lifeops:checkin:morning` through `assembleMorningBrief()` and deliver `report.summaryText`, preserving the morning-checkin parity contract.
- Fail closed for unsupported scheduled-task copy by emitting safe generic owner-facing text and reporting `lifeops:scheduled-task:owner-facing-copy` instead of leaking raw `promptInstructions`.

## Tests
- `bun run test src/lifeops/scheduled-task/runtime-wiring.owner-facing-copy.test.ts`
- `bunx @biomejs/biome check plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.owner-facing-copy.test.ts`
- `bun run build:js`

Notes:
- `bun run typecheck` was attempted, but the existing package-wide typecheck in this worktree fails on many pre-existing missing workspace/plugin declarations and unrelated LifeOps type errors before isolating this lane.
- `codex review --uncommitted` was attempted and exceeded the 100s lane limit, so I killed it and self-reviewed the scoped diff.

Fixes #14731

— [sol-orch]
