### PR TITLE
fix(#14703): unify settings action surface

### DIFF
--- a/packages/agent/src/actions/settings-actions.ts
+++ b/packages/agent/src/actions/settings-actions.ts
@@ -201,9 +201,14 @@ function shouldUseSectionSettingsAction(
   const op = typeof rawOp === "string" ? rawOp.trim().toLowerCase() : "";
   if (SECTION_SETTINGS_OPS.has(op)) return true;
   if (op !== "set") return false;
+  // A `set` belongs to the section registry only when it addresses a resolvable
+  // built-in section. A legacy no-section set ({ action:"set", key, value })
+  // parses non-null too (sectionId:null), and routing it to the section handler
+  // would fail with "which section?" — it must stay on the worldSettings
+  // registry branch below.
   return (
-    parseSettingsRequest(options as Record<string, unknown> | undefined) !==
-    null
+    parseSettingsRequest(options as Record<string, unknown> | undefined)
+      ?.sectionId != null
   );
 }
 

--- a/packages/agent/src/actions/settings-actions.ts
+++ b/packages/agent/src/actions/settings-actions.ts
@@ -1,8 +1,10 @@
 /**
- * SETTINGS — single polymorphic owner-only action covering provider, capability,
- * training, owner-name, and worldSettings-registry mutations.
+ * SETTINGS — single polymorphic owner-only action covering built-in settings
+ * sections, provider, capability, training, owner-name, backend routing, and
+ * worldSettings-registry mutations.
  *
  * Ops:
+ *   - get/list           → section registry from @elizaos/plugin-app-control
  *   - update_ai_provider → applyFirstRunConnectionConfig + saveElizaConfig
  *   - toggle_capability  → config.ui.capabilities.{wallet|browser|computerUse}
  *   - toggle_training    → training plugin's TrainingConfigService (via registry)
@@ -28,6 +30,10 @@ import {
   type WorldSettings,
 } from "@elizaos/core";
 import {
+  createSettingsAction as createSectionSettingsAction,
+  parseSettingsRequest,
+} from "@elizaos/plugin-app-control/actions/settings";
+import {
   getFirstRunProviderOption,
   normalizeFirstRunProviderId,
 } from "@elizaos/shared";
@@ -45,6 +51,8 @@ import {
 // ── Op catalog ────────────────────────────────────────────────────────────
 
 export const SETTINGS_OPS = [
+  "get",
+  "list",
   "update_ai_provider",
   "toggle_capability",
   "toggle_training",
@@ -54,6 +62,8 @@ export const SETTINGS_OPS = [
   "set_backend",
 ] as const;
 export type SettingsOp = (typeof SETTINGS_OPS)[number];
+const SECTION_SETTINGS_OPS = new Set(["get", "list"]);
+const sectionSettingsAction = createSectionSettingsAction();
 
 // Coding sub-agent adapters the orchestrator can route to. Mirrors
 // KNOWN_ADAPTER_TYPES in plugin-agent-orchestrator (kept as a literal here so
@@ -181,6 +191,20 @@ function readParams(
 ): Record<string, unknown> {
   const raw = options?.parameters;
   return isRecord(raw) ? raw : {};
+}
+
+function shouldUseSectionSettingsAction(
+  options: HandlerOptions | undefined,
+  params: Record<string, unknown>,
+): boolean {
+  const rawOp = params.action ?? params.subaction ?? params.op;
+  const op = typeof rawOp === "string" ? rawOp.trim().toLowerCase() : "";
+  if (SECTION_SETTINGS_OPS.has(op)) return true;
+  if (op !== "set") return false;
+  return (
+    parseSettingsRequest(options as Record<string, unknown> | undefined) !==
+    null
+  );
 }
 
 // ── op: update_ai_provider ────────────────────────────────────────────────
@@ -815,9 +839,29 @@ function handleSetBackend(
 
 export const settingsAction: Action = {
   name: "SETTINGS",
-  contexts: ["settings", "admin", "agent_internal"],
+  contexts: ["general", "settings", "admin", "system", "agent_internal"],
+  contextGate: { anyOf: ["general", "settings", "admin", "system"] },
   roleGate: { minRole: "OWNER" },
   similes: [
+    "CHANGE_SETTING",
+    "UPDATE_SETTINGS",
+    "SETTINGS_WRITE",
+    "TOGGLE_SETTING",
+    "GET_SETTING",
+    "LIST_SETTINGS",
+    "PERMISSIONS",
+    "CHANGE_PERMISSION",
+    "CHANGE_PERMISSIONS",
+    "SET_PERMISSION",
+    "TOGGLE_PERMISSION",
+    "REVOKE_PERMISSION",
+    "GRANT_PERMISSION",
+    "SHELL_ACCESS",
+    "SHELL_PERMISSION",
+    "SHELL_PERMISSIONS",
+    "TOGGLE_SHELL_ACCESS",
+    "DISABLE_SHELL_ACCESS",
+    "ENABLE_SHELL_ACCESS",
     // Old leaf action names
     "UPDATE_AI_PROVIDER",
     "TOGGLE_CAPABILITY",
@@ -837,14 +881,11 @@ export const settingsAction: Action = {
     "ROUTE_BACKEND",
   ],
   description:
-    "Owner-only polymorphic settings mutation. Dispatches on `action` to update " +
-    "AI provider, toggle a capability, toggle/configure auto-training, set " +
-    "the owner display name, write to the world's settings registry, show the " +
-    "current backend routing (show_backends), or change which backend handles " +
-    "coding sub-agents / the chat brain (set_backend) — e.g. 'use codex for " +
-    "simple tasks and claude for hard ones', 'switch the brain to cerebras'.",
+    "Owner-only polymorphic settings action. Dispatches on `action` to read/list/change built-in settings sections (`get|set|list` with `section`/`key`/`value`, including permissions, app permissions, backups, and auto-training), update AI provider, toggle a capability, toggle/configure auto-training, set the owner display name, write to the world's settings registry, show the current backend routing (show_backends), or change which backend handles coding sub-agents / the chat brain (set_backend) — e.g. 'turn off shell access', 'what settings can you change', 'use codex for simple tasks and claude for hard ones', 'switch the brain to cerebras'. Opening a settings page without changing or reading a value is VIEWS, not SETTINGS.",
   descriptionCompressed:
-    "owner settings action: AI provider|capability|auto-train|display name|world registry|backend routing",
+    "owner settings action: get|set|list sections plus AI provider|capability|auto-train|display name|world registry|backend routing",
+  routingHint:
+    "Changing or reading a settings VALUE -> SETTINGS. Permissions/shell/app permissions/auto-training/backups use SETTINGS action=set section=<section> key=<key> value=on|off. Listing settings uses SETTINGS action=list. Legacy provider/capability/backend commands still use SETTINGS action=update_ai_provider|toggle_capability|toggle_training|set_owner_name|show_backends|set_backend. Pure navigation to a settings page is VIEWS.",
 
   validate: async () => true,
 
@@ -854,6 +895,41 @@ export const settingsAction: Action = {
       description: `Operation discriminator. One of: ${SETTINGS_OPS.join(", ")}.`,
       required: true,
       schema: { type: "string" as const, enum: [...SETTINGS_OPS] },
+    },
+    {
+      name: "section",
+      description:
+        "[get | set] Canonical settings section id or alias (e.g. permissions, capabilities, app-permissions, ai-model, background, secrets).",
+      required: false,
+      schema: { type: "string" as const },
+    },
+    {
+      name: "app",
+      description:
+        "[set, app-permissions] Registered app slug for app permission writes.",
+      required: false,
+      schema: { type: "string" as const },
+    },
+    {
+      name: "namespace",
+      description:
+        "[set, app-permissions] Permission namespace, e.g. fs/filesystem or net/network.",
+      required: false,
+      schema: { type: "string" as const },
+    },
+    {
+      name: "fileName",
+      description:
+        "[set, advanced restore-backup] Backup file name to restore.",
+      required: false,
+      schema: { type: "string" as const },
+    },
+    {
+      name: "confirm",
+      description:
+        "[set, destructive settings operations] Explicit confirmation token, usually true.",
+      required: false,
+      schema: { type: "string" as const },
     },
     {
       name: "provider",
@@ -948,9 +1024,24 @@ export const settingsAction: Action = {
     },
   ],
 
-  handler: async (runtime, message, _state, options) => {
+  handler: async (runtime, message, _state, options, callback) => {
     const params = readParams(options as HandlerOptions | undefined);
     const op = params.action ?? params.subaction ?? params.op;
+
+    if (
+      shouldUseSectionSettingsAction(
+        options as HandlerOptions | undefined,
+        params,
+      )
+    ) {
+      return sectionSettingsAction.handler(
+        runtime,
+        message,
+        _state,
+        options,
+        callback,
+      );
+    }
 
     switch (op) {
       case "update_ai_provider":

--- a/packages/agent/src/actions/settings-chat-config-ops.test.ts
+++ b/packages/agent/src/actions/settings-chat-config-ops.test.ts
@@ -13,16 +13,29 @@
  * covered by the `live-only` scenarios in
  * `plugins/plugin-app-control/test/scenarios/settings-in-chat-*.scenario.ts`.
  *
+ * Also pins the two `set` branches (#14703): a legacy no-section set
+ * ({ action:"set", key, value }) stays on the worldSettings-registry handler,
+ * while a section-addressed set routes into plugin-app-control's section
+ * registry — asserted against a loopback HTTP stub standing in for the
+ * agent server the section routes call.
+ *
  * Deterministic: real config store on a temp dir, stub runtime, no live model.
  */
 import fs from "node:fs";
+import http from "node:http";
 import os from "node:os";
 import path from "node:path";
-import type {
-  ActionResult,
-  HandlerOptions,
-  IAgentRuntime,
-  Memory,
+import {
+  type ActionResult,
+  getSalt,
+  type HandlerOptions,
+  type IAgentRuntime,
+  type Memory,
+  type Setting,
+  saltWorldSettings,
+  unsaltWorldSettings,
+  type World,
+  type WorldSettings,
 } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { settingsAction } from "./settings-actions.ts";
@@ -230,6 +243,183 @@ describe("SETTINGS toggle_capability — persists to the real config store", () 
     });
     expect(result.success).toBe(false);
     expect(result.data?.error).toBe("MISSING_ENABLED");
+  });
+});
+
+describe("SETTINGS set — legacy no-section branch (worldSettings registry)", () => {
+  // Seed a real salted registry the way production writes it, so the handler
+  // exercises the genuine unsalt → mutate → salt → updateWorld path.
+  const GREETING_SETTING: Setting = {
+    name: "Greeting",
+    description: "Greeting the agent uses",
+    usageDescription: "Greeting the agent uses",
+    required: false,
+    value: "hi",
+    dependsOn: [],
+  };
+
+  function makeOwnerWorldRuntime(): {
+    runtime: IAgentRuntime;
+    updatedWorlds: World[];
+  } {
+    const salt = getSalt();
+    const world = {
+      id: "world-1",
+      name: "Owner World",
+      agentId: "agent-1",
+      serverId: "server-1",
+      metadata: {
+        ownership: { ownerId: "owner" },
+        settings: saltWorldSettings(
+          { settings: { greeting: GREETING_SETTING } },
+          salt,
+        ),
+      },
+    } as unknown as World;
+    const updatedWorlds: World[] = [];
+    const runtime = {
+      character: {},
+      agentId: "agent-1",
+      getAllWorlds: async () => [world],
+      updateWorld: async (w: World) => {
+        updatedWorlds.push(w);
+      },
+    } as unknown as IAgentRuntime;
+    return { runtime, updatedWorlds };
+  }
+
+  it("routes { action:'set', key, value } to the worldSettings handler and persists (#14703 regression)", async () => {
+    const { runtime, updatedWorlds } = makeOwnerWorldRuntime();
+    const result = (await settingsAction.handler(
+      runtime,
+      OWNER_MESSAGE,
+      undefined,
+      {
+        parameters: { action: "set", key: "greeting", value: "hello" },
+      } as HandlerOptions,
+    )) as ActionResult;
+
+    // The regression routed this to the section handler, which failed with
+    // "Tell me which settings section to change". The legacy branch succeeds
+    // and reports the applied registry write.
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      actionName: "SETTINGS",
+      op: "set",
+      applied: [{ key: "greeting", value: "hello" }],
+    });
+
+    expect(updatedWorlds).toHaveLength(1);
+    const persisted = updatedWorlds[0].metadata?.settings as WorldSettings;
+    const unsalted = unsaltWorldSettings(persisted, getSalt());
+    expect(unsalted.settings?.greeting?.value).toBe("hello");
+  });
+
+  it("still fails with the legacy error shape for an unknown registry key", async () => {
+    const { runtime, updatedWorlds } = makeOwnerWorldRuntime();
+    const result = (await settingsAction.handler(
+      runtime,
+      OWNER_MESSAGE,
+      undefined,
+      {
+        parameters: { action: "set", key: "bogus", value: "x" },
+      } as HandlerOptions,
+    )) as ActionResult;
+    expect(result.success).toBe(false);
+    expect(result.data?.error).toBe("NO_VALID_UPDATES");
+    expect(updatedWorlds).toHaveLength(0);
+  });
+});
+
+describe("SETTINGS set — section-addressed branch (app-control registry)", () => {
+  interface RecordedRequest {
+    method: string | undefined;
+    url: string | undefined;
+    body: unknown;
+  }
+
+  let server: http.Server;
+  let recorded: RecordedRequest[];
+  let priorElizaPort: string | undefined;
+
+  beforeEach(async () => {
+    recorded = [];
+    server = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk: Buffer) => chunks.push(chunk));
+      req.on("end", () => {
+        const raw = Buffer.concat(chunks).toString("utf-8");
+        recorded.push({
+          method: req.method,
+          url: req.url,
+          body: raw ? JSON.parse(raw) : undefined,
+        });
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end("{}");
+      });
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const address = server.address();
+    if (!address || typeof address === "string")
+      throw new Error("stub server has no port");
+    priorElizaPort = process.env.ELIZA_PORT;
+    process.env.ELIZA_PORT = String(address.port);
+  });
+
+  afterEach(async () => {
+    if (priorElizaPort === undefined) delete process.env.ELIZA_PORT;
+    else process.env.ELIZA_PORT = priorElizaPort;
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    );
+  });
+
+  it("routes a section-addressed set to app-control's permissions route", async () => {
+    const result = (await invoke({
+      action: "set",
+      section: "permissions",
+      key: "shell",
+      value: "off",
+    })) as ActionResult;
+
+    expect(result.success).toBe(true);
+    expect(recorded).toEqual([
+      {
+        method: "PUT",
+        url: "/api/permissions/shell",
+        body: { enabled: false },
+      },
+    ]);
+    expect(result.values).toMatchObject({
+      section: "permissions",
+      key: "shell",
+      value: false,
+    });
+  });
+
+  it("set section=capabilities key=wallet value=false resolves through the registry (#14703 residual)", async () => {
+    const result = (await invoke({
+      action: "set",
+      section: "capabilities",
+      key: "wallet",
+      value: "false",
+    })) as ActionResult;
+
+    expect(result.success).toBe(true);
+    expect(recorded).toEqual([
+      {
+        method: "PUT",
+        url: "/api/config",
+        body: { ui: { capabilities: { wallet: false } } },
+      },
+    ]);
+    expect(result.values).toMatchObject({
+      section: "capabilities",
+      key: "wallet",
+      value: false,
+    });
   });
 });
 

--- a/packages/agent/src/actions/settings-chat-config-ops.test.ts
+++ b/packages/agent/src/actions/settings-chat-config-ops.test.ts
@@ -92,6 +92,21 @@ describe("SETTINGS action — always available at the chat boundary", () => {
       true,
     );
   });
+
+  it("lists built-in settings sections through the consolidated registry", async () => {
+    const result = await invoke({ action: "list" });
+
+    expect(result.success).toBe(true);
+    expect(result.data?.sections).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "permissions",
+          writable: true,
+          via: "SETTINGS",
+        }),
+      ]),
+    );
+  });
 });
 
 describe("SETTINGS update_ai_provider — persists to the real config store", () => {

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -43,6 +43,7 @@ import {
   OPTIONAL_STATIC_PLUGIN_REGISTRATIONS,
   optionalPluginImportSpecifier,
 } from "./optional-plugins.ts";
+import { deduplicatePluginActions } from "./plugin-action-dedupe.ts";
 import {
   isWorkspacePluginSourceFallbackAllowed,
   type PluginResolutionPhase,
@@ -55,6 +56,7 @@ import {
 } from "./plugin-types.ts";
 import { shouldLoadRemoteCodingRunnerForBoot } from "./remote-coding-runner-gate.ts";
 
+export { deduplicatePluginActions } from "./plugin-action-dedupe.ts";
 export {
   CHANNEL_PLUGIN_MAP,
   collectPluginNames,
@@ -1570,31 +1572,6 @@ export async function shutdownRuntime(
 
   if (firstError) {
     throw firstError;
-  }
-}
-
-/**
- * Remove duplicate actions across an ordered list of plugins.
- *
- * When multiple plugins define an action with the same `name`, only the first
- * occurrence is kept.  This prevents "Action already registered" warnings from
- * elizaOS core.  The function mutates each plugin's `actions` array in-place.
- */
-export function deduplicatePluginActions(plugins: Plugin[]): void {
-  const seen = new Set<string>();
-  for (const plugin of plugins) {
-    if (plugin.actions) {
-      plugin.actions = plugin.actions.filter((action) => {
-        if (seen.has(action.name)) {
-          logger.debug(
-            `[eliza] Skipping duplicate action "${action.name}" from plugin "${plugin.name}"`,
-          );
-          return false;
-        }
-        seen.add(action.name);
-        return true;
-      });
-    }
   }
 }
 

--- a/packages/agent/src/runtime/plugin-action-dedupe.ts
+++ b/packages/agent/src/runtime/plugin-action-dedupe.ts
@@ -1,0 +1,32 @@
+/**
+ * Action-name dedupe for the ordered plugin set assembled during agent boot.
+ * The runtime registers actions by name, so boot composition removes later
+ * duplicates deterministically before registration while preserving the first
+ * plugin's action surface.
+ */
+import { logger, type Plugin } from "@elizaos/core";
+
+/**
+ * Remove duplicate actions across an ordered list of plugins.
+ *
+ * When multiple plugins define an action with the same `name`, only the first
+ * occurrence is kept. This prevents "Action already registered" warnings from
+ * elizaOS core. The function mutates each plugin's `actions` array in place.
+ */
+export function deduplicatePluginActions(plugins: Plugin[]): void {
+  const seen = new Set<string>();
+  for (const plugin of plugins) {
+    if (plugin.actions) {
+      plugin.actions = plugin.actions.filter((action) => {
+        if (seen.has(action.name)) {
+          logger.debug(
+            `[eliza] Skipping duplicate action "${action.name}" from plugin "${plugin.name}"`,
+          );
+          return false;
+        }
+        seen.add(action.name);
+        return true;
+      });
+    }
+  }
+}

--- a/packages/agent/src/runtime/settings-action-composition.test.ts
+++ b/packages/agent/src/runtime/settings-action-composition.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression coverage for the production SETTINGS action composition. The
+ * default runtime loads the built-in eliza plugin before plugin-app-control, so
+ * this test pins the one-action contract that keeps both settings operation
+ * families reachable after plugin action dedupe.
+ */
+
+import type {
+  Action,
+  HandlerOptions,
+  IAgentRuntime,
+  Memory,
+  Plugin,
+} from "@elizaos/core";
+import { appControlPlugin } from "@elizaos/plugin-app-control";
+import { describe, expect, it } from "vitest";
+import { createElizaPlugin } from "./eliza-plugin.ts";
+import { deduplicatePluginActions } from "./plugin-action-dedupe.ts";
+
+const RUNTIME = {
+  character: {},
+  getSetting: () => null,
+} as unknown as IAgentRuntime;
+const MESSAGE = { entityId: "owner" } as unknown as Memory;
+
+function clonePlugin(plugin: Plugin): Plugin {
+  return {
+    ...plugin,
+    actions: plugin.actions ? [...plugin.actions] : undefined,
+  };
+}
+
+function actionParameter(settingsAction: Action, name: string) {
+  return settingsAction.parameters?.find(
+    (parameter) => parameter.name === name,
+  );
+}
+
+describe("default SETTINGS action composition", () => {
+  it("keeps exactly one SETTINGS action with legacy and section-registry operations", async () => {
+    const plugins = [
+      createElizaPlugin(),
+      clonePlugin(appControlPlugin),
+    ] satisfies Plugin[];
+    deduplicatePluginActions(plugins);
+
+    const settingsActions = plugins.flatMap((plugin) =>
+      (plugin.actions ?? []).filter((action) => action.name === "SETTINGS"),
+    );
+    expect(settingsActions).toHaveLength(1);
+    const [settingsAction] = settingsActions;
+
+    const actionSchema = actionParameter(settingsAction, "action")?.schema;
+    expect(actionSchema?.enum).toEqual(
+      expect.arrayContaining([
+        "list",
+        "get",
+        "set",
+        "update_ai_provider",
+        "show_backends",
+      ]),
+    );
+    expect(actionParameter(settingsAction, "section")).toBeDefined();
+    expect(actionParameter(settingsAction, "capability")).toBeDefined();
+    expect(actionParameter(settingsAction, "backend")).toBeDefined();
+
+    const listed = await settingsAction.handler(RUNTIME, MESSAGE, undefined, {
+      parameters: { action: "list" },
+    } as HandlerOptions);
+    if (!listed) throw new Error("SETTINGS action returned no list result");
+    expect(listed.success).toBe(true);
+    expect(listed.data?.sections).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "permissions", via: "SETTINGS" }),
+      ]),
+    );
+
+    const backends = await settingsAction.handler(RUNTIME, MESSAGE, undefined, {
+      parameters: { action: "show_backends" },
+    } as HandlerOptions);
+    if (!backends)
+      throw new Error("SETTINGS action returned no backend result");
+    expect(backends.success).toBe(true);
+    expect(backends.data).toMatchObject({ op: "show_backends" });
+  });
+});

--- a/plugins/plugin-app-control/src/actions/settings.test.ts
+++ b/plugins/plugin-app-control/src/actions/settings.test.ts
@@ -282,6 +282,57 @@ describe("SETTINGS action: set on an owned route section", () => {
 		});
 	});
 
+	it("dispatches capabilities wallet through the config route (#14703 residual)", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({ ok: true }));
+		const { result, texts } = await invoke(
+			{ action: "set", section: "capabilities", key: "wallet", value: "false" },
+			routeFetch,
+		);
+		expect(routeFetch).toHaveBeenCalledWith({
+			method: "PUT",
+			path: "/api/config",
+			body: { ui: { capabilities: { wallet: false } } },
+		});
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({
+			section: "capabilities",
+			key: "wallet",
+			value: false,
+		});
+		expect(texts.join(" ")).toContain("wallet capability is off");
+	});
+
+	it("dispatches capabilities browser on through the config route", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({ ok: true }));
+		const { result } = await invoke(
+			{ action: "set", section: "capabilities", key: "browser", value: "on" },
+			routeFetch,
+		);
+		expect(routeFetch).toHaveBeenCalledWith({
+			method: "PUT",
+			path: "/api/config",
+			body: { ui: { capabilities: { browser: true } } },
+		});
+		expect(result?.success).toBe(true);
+	});
+
+	it.each([
+		"computerUse",
+		"computer-use",
+	])("accepts %s as the computer-use capability key", async (key) => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({ ok: true }));
+		const { result } = await invoke(
+			{ action: "set", section: "capabilities", key, value: "off" },
+			routeFetch,
+		);
+		expect(routeFetch).toHaveBeenCalledWith({
+			method: "PUT",
+			path: "/api/config",
+			body: { ui: { capabilities: { computerUse: false } } },
+		});
+		expect(result?.success).toBe(true);
+	});
+
 	it("surfaces a backend failure instead of fabricating success", async () => {
 		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({
 			ok: false,

--- a/plugins/plugin-app-control/src/actions/settings.ts
+++ b/plugins/plugin-app-control/src/actions/settings.ts
@@ -152,6 +152,39 @@ const AUTO_TRAINING_KEY: SettingsWritableKey = {
 			: "Auto-training is off. Trajectory counters can still collect data, but automatic training will not start.",
 };
 
+/**
+ * Wallet / browser / computer-use toggles persist as `ui.capabilities.<name>`
+ * in the agent config store — the same field the on-screen Capabilities
+ * switches sync (`client.updateConfig`) and the legacy TOGGLE_CAPABILITY op
+ * writes. Routed through the deep-merging `PUT /api/config` loopback route so
+ * the chat action and the view control are twins on one write path.
+ */
+function makeCapabilityConfigKey(
+	name: "wallet" | "browser" | "computerUse",
+	label: string,
+): SettingsWritableKey {
+	return {
+		description: `Whether the agent's ${label} capability is enabled.`,
+		valueType: "boolean",
+		buildRequest: (enabled) => ({
+			method: "PUT",
+			path: "/api/config",
+			body: { ui: { capabilities: { [name]: enabled } } },
+		}),
+		successText: (enabled) =>
+			enabled
+				? `The ${label} capability is on.`
+				: `The ${label} capability is off.`,
+	};
+}
+
+const WALLET_CAPABILITY_KEY = makeCapabilityConfigKey("wallet", "wallet");
+const BROWSER_CAPABILITY_KEY = makeCapabilityConfigKey("browser", "browser");
+const COMPUTER_USE_CAPABILITY_KEY = makeCapabilityConfigKey(
+	"computerUse",
+	"computer-use",
+);
+
 function readBackupFileName(data: unknown): string | null {
 	if (!data || typeof data !== "object") return null;
 	const backup = (data as { backup?: unknown }).backup;
@@ -353,8 +386,14 @@ export const SETTINGS_WRITE_REGISTRY: Readonly<
 	capabilities: {
 		kind: "route",
 		summary:
-			"Capability toggles that already have backend settings routes, including automatic training.",
-		keys: { "auto-training": AUTO_TRAINING_KEY },
+			"Capability toggles that already have backend settings routes: wallet, browser, computer use, and automatic training.",
+		keys: {
+			"auto-training": AUTO_TRAINING_KEY,
+			wallet: WALLET_CAPABILITY_KEY,
+			browser: BROWSER_CAPABILITY_KEY,
+			computerUse: COMPUTER_USE_CAPABILITY_KEY,
+			"computer-use": COMPUTER_USE_CAPABILITY_KEY,
+		},
 	},
 	apps: {
 		kind: "unwired",
@@ -760,11 +799,11 @@ export function createSettingsAction(deps: SettingsActionDeps = {}): Action {
 			"REVOKE_APP_PERMISSION",
 		],
 		description:
-			"Change a built-in settings VALUE or run a built-in settings operation from chat — most importantly turning OS/runtime permissions like shell access on/off via section=permissions key=shell, turning automatic training on/off via section=capabilities key=auto-training, granting/revoking an app permission namespace via section=app-permissions app=<slug> key=fs|net value=on|off, and creating/restoring local agent backups via section=advanced key=create-backup|restore-backup. Restore requires fileName and confirm=true. Also reads (`action=get`) or lists (`action=list`) which settings are changeable. `action=set` writes an owned section or points to the dedicated action that owns a delegated section (models→MODEL_SWITCH, background→BACKGROUND, identity→CHARACTER, connectors→CONNECTOR, secrets→CREDENTIALS). This CHANGES a setting's value or runs an explicit settings operation; opening a settings page without changing anything is VIEWS. Never fill a settings field with agent-fill.",
+			"Change a built-in settings VALUE or run a built-in settings operation from chat — most importantly turning OS/runtime permissions like shell access on/off via section=permissions key=shell, turning automatic training on/off via section=capabilities key=auto-training, toggling the wallet/browser/computer-use capabilities via section=capabilities key=wallet|browser|computer-use value=on|off, granting/revoking an app permission namespace via section=app-permissions app=<slug> key=fs|net value=on|off, and creating/restoring local agent backups via section=advanced key=create-backup|restore-backup. Restore requires fileName and confirm=true. Also reads (`action=get`) or lists (`action=list`) which settings are changeable. `action=set` writes an owned section or points to the dedicated action that owns a delegated section (models→MODEL_SWITCH, background→BACKGROUND, identity→CHARACTER, connectors→CONNECTOR, secrets→CREDENTIALS). This CHANGES a setting's value or runs an explicit settings operation; opening a settings page without changing anything is VIEWS. Never fill a settings field with agent-fill.",
 		descriptionCompressed:
 			"settings get|set|list section/key/value — CHANGE a setting VALUE or run a settings operation, incl. shell access, auto-training, app permissions, and local backups",
 		routingHint:
-			"Semantic settings reads/writes that do NOT already have a dedicated action -> SETTINGS. Changing a PERMISSION or setting VALUE is SETTINGS action=set, NOT navigation: 'turn off shell permissions', 'disable shell access', 'turn off shell access', 'revoke shell access', 'stop the agent running shell commands', 'turn shell back on', 'change my permissions' -> SETTINGS section=permissions key=shell value=off|on. 'turn on auto-training', 'enable automatic training', 'disable auto training' -> SETTINGS section=capabilities key=auto-training value=on|off. 'revoke network access for my-app', 'grant filesystem access to sample-app' -> SETTINGS section=app-permissions app=<slug> key=net|fs value=off|on. 'back up my agent', 'create a local backup' -> SETTINGS section=advanced key=create-backup. 'restore backup <file>' -> SETTINGS section=advanced key=restore-backup fileName=<file> confirm=true; if confirm is absent, ask for confirmation. Also 'what settings can you change' / 'list settings' -> SETTINGS action=list. Do NOT use SETTINGS for changes a dedicated action owns: switching the model is MODEL_SWITCH, the background/theme is BACKGROUND, the agent identity is CHARACTER, connectors are CONNECTOR, secret/API keys are CREDENTIALS. The distinction from VIEWS is value-vs-navigation: changing/toggling a permission or setting VALUE, or running a backup operation, is SETTINGS even though it lives on a settings page; merely OPENING or navigating to a settings page with no value change is VIEWS. SETTINGS never fills a form field with agent-fill.",
+			"Semantic settings reads/writes that do NOT already have a dedicated action -> SETTINGS. Changing a PERMISSION or setting VALUE is SETTINGS action=set, NOT navigation: 'turn off shell permissions', 'disable shell access', 'turn off shell access', 'revoke shell access', 'stop the agent running shell commands', 'turn shell back on', 'change my permissions' -> SETTINGS section=permissions key=shell value=off|on. 'turn on auto-training', 'enable automatic training', 'disable auto training' -> SETTINGS section=capabilities key=auto-training value=on|off. 'turn off the wallet capability', 'enable the browser capability', 'disable computer use' -> SETTINGS section=capabilities key=wallet|browser|computer-use value=on|off. 'revoke network access for my-app', 'grant filesystem access to sample-app' -> SETTINGS section=app-permissions app=<slug> key=net|fs value=off|on. 'back up my agent', 'create a local backup' -> SETTINGS section=advanced key=create-backup. 'restore backup <file>' -> SETTINGS section=advanced key=restore-backup fileName=<file> confirm=true; if confirm is absent, ask for confirmation. Also 'what settings can you change' / 'list settings' -> SETTINGS action=list. Do NOT use SETTINGS for changes a dedicated action owns: switching the model is MODEL_SWITCH, the background/theme is BACKGROUND, the agent identity is CHARACTER, connectors are CONNECTOR, secret/API keys are CREDENTIALS. The distinction from VIEWS is value-vs-navigation: changing/toggling a permission or setting VALUE, or running a backup operation, is SETTINGS even though it lives on a settings page; merely OPENING or navigating to a settings page with no value change is VIEWS. SETTINGS never fills a form field with agent-fill.",
 		suppressPostActionContinuation: true,
 
 		parameters: [


### PR DESCRIPTION
## Summary
Closes #14703.

Unifies the production `SETTINGS` action surface so default boot no longer silently drops the consolidated app-control settings action behind the older agent action.

What changed:
- The built-in agent `SETTINGS` action now exposes section-level `get` / `list` / section-addressed `set` by delegating to the consolidated `@elizaos/plugin-app-control` settings registry.
- Existing legacy operations remain on the same action: `update_ai_provider`, `toggle_capability`, `toggle_training`, `set_owner_name`, world-settings `set`, `show_backends`, and `set_backend`.
- The boot action-dedupe helper moved into a lightweight module so the production composition contract can be tested without importing the full runtime boot orchestrator.
- Added a default-composition regression proving `createElizaPlugin()` + `appControlPlugin` dedupe to exactly one `SETTINGS` action that still carries both operation families.

## Verification
- `bun run --cwd packages/agent test src/actions/settings-chat-config-ops.test.ts src/runtime/settings-action-composition.test.ts`
  - 2 files passed, 14 tests passed.
- `bun run --cwd plugins/plugin-app-control test src/actions/settings.test.ts src/actions/settings-routing.test.ts`
  - 2 files passed, 53 tests passed.
- `bun run --cwd plugins/plugin-app-control typecheck`
  - Passed.
- `bun run --cwd packages/agent build`
  - Passed, including `assert-package-boundary-imports`.
- `git diff --check`
  - Clean.
- `bun run audit:error-policy-ratchet --report`
  - Passed; touched production files add no empty catches and no server-side `console.*`.

## Known Baseline
- `bun run --cwd packages/agent typecheck` still fails on missing local declaration builds for optional packages unrelated to this PR: `@elizaos/plugin-streaming`, `@elizaos/plugin-vision`, `@elizaos/plugin-background-runner`, `@elizaos/plugin-native-filesystem`, and `@elizaos/plugin-inbox/plugin`. The prior SETTINGS/app-control import errors are gone after building `plugin-app-control`; remaining errors are the optional-plugin dist baseline.

## Evidence Rows
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: N/A - agent/runtime action catalog fix only; no UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: N/A - agent/runtime action catalog fix only; no rendered UI changed.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: N/A - no user-visible UI workflow changed in this PR; behavior is validated through action composition and handler tests.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs: N/A - deterministic unit tests exercise the boot action composition and SETTINGS handler path without starting the HTTP server.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - no frontend code or network-facing UI path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - this PR repairs the deterministic action catalog before model selection; live chat trajectory for settings changes should be captured before closing the broader MVP lane.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - no persistent domain rows are produced by the composition fix itself; existing config-write tests still inspect the real temp `eliza.json` bytes for provider/capability operations.