### PR TITLE
fix(ui): keep home Today card readable

### DIFF
--- a/packages/ui/src/components/chat/widgets/shared.tsx
+++ b/packages/ui/src/components/chat/widgets/shared.tsx
@@ -7,6 +7,8 @@
 import type { ReactNode } from "react";
 import { Button } from "../../ui/button";
 
+type WidgetSectionTone = "default" | "home";
+
 export function WidgetSection({
   title,
   icon,
@@ -14,6 +16,7 @@ export function WidgetSection({
   children,
   testId,
   onTitleClick,
+  tone = "default",
 }: {
   title: string;
   icon: ReactNode;
@@ -22,26 +25,46 @@ export function WidgetSection({
   testId: string;
   /** When set, the title area becomes a button navigating elsewhere. */
   onTitleClick?: () => void;
+  /** Home widgets sit directly on the ember field and need a glass/white skin. */
+  tone?: WidgetSectionTone;
 }) {
+  const isHome = tone === "home";
   const titleContent = (
     <>
-      <span className="inline-flex shrink-0 items-center justify-center text-muted [&>svg]:h-3.5 [&>svg]:w-3.5">
+      <span
+        className={`inline-flex shrink-0 items-center justify-center [&>svg]:h-3.5 [&>svg]:w-3.5 ${
+          isHome ? "text-white/65" : "text-muted"
+        }`}
+      >
         {icon}
       </span>
-      <span className="truncate text-xs-tight leading-none font-semibold text-muted">
+      <span
+        className={`truncate text-xs-tight leading-none font-semibold ${
+          isHome ? "text-white/65" : "text-muted"
+        }`}
+      >
         {title}
       </span>
     </>
   );
   return (
-    <section data-testid={testId} className="space-y-0.5">
+    <section
+      data-testid={testId}
+      className={
+        isHome
+          ? "space-y-1 rounded-2xl border border-white/55 bg-black/35 px-3.5 py-3 text-white backdrop-blur-xl"
+          : "space-y-0.5"
+      }
+    >
       <div className="flex items-center justify-between gap-2 pr-1">
         {onTitleClick ? (
           <Button
             variant="ghost"
             size="sm"
             onClick={onTitleClick}
-            className="h-auto min-w-0 flex-1 justify-start gap-1.5 rounded-sm bg-transparent px-0.5 py-1 text-left transition-colors hover:bg-transparent hover:text-txt"
+            className={`h-auto min-w-0 flex-1 justify-start gap-1.5 rounded-sm bg-transparent px-0.5 py-1 text-left transition-colors hover:bg-transparent ${
+              isHome ? "text-white/65 hover:text-white" : "hover:text-txt"
+            }`}
           >
             {titleContent}
           </Button>
@@ -52,7 +75,7 @@ export function WidgetSection({
         )}
         {action}
       </div>
-      <div className="px-3 text-xs">{children}</div>
+      <div className={isHome ? "text-xs" : "px-3 text-xs"}>{children}</div>
     </section>
   );
 }

--- a/packages/ui/src/components/chat/widgets/todo.tsx
+++ b/packages/ui/src/components/chat/widgets/todo.tsx
@@ -85,13 +85,33 @@ function isWorkbenchTodoChangeEvent(
   );
 }
 
-function TodoRow({ todo }: { todo: WorkbenchTodo }) {
+function homeBadgeClassName(tone: "default" | "home", accent?: string): string {
+  if (tone !== "home") return accent ? `text-3xs ${accent}` : "text-3xs";
+  return accent
+    ? `border-white/15 bg-white/12 text-3xs ${accent}`
+    : "border-white/15 bg-white/12 text-3xs text-white/80";
+}
+
+function TodoRow({
+  todo,
+  tone = "default",
+}: {
+  todo: WorkbenchTodo;
+  tone?: "default" | "home";
+}) {
   const showDescription =
     todo.description.trim().length > 0 && todo.description !== todo.name;
   const showType = todo.type.trim().length > 0 && todo.type !== "task";
+  const isHome = tone === "home";
 
   return (
-    <div className="rounded-sm border border-border/50 bg-bg/70 p-3">
+    <div
+      className={`rounded-sm border p-3 ${
+        isHome
+          ? "border-white/15 bg-white/10 text-white"
+          : "border-border/50 bg-bg/70"
+      }`}
+    >
       <div className="flex items-start gap-2">
         <span
           className={`mt-1.5 inline-block h-2 w-2 shrink-0 rounded-full ${
@@ -104,27 +124,38 @@ function TodoRow({ todo }: { todo: WorkbenchTodo }) {
         />
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-1.5">
-            <span className="min-w-0 truncate text-xs font-semibold text-txt">
+            <span
+              className={`min-w-0 truncate text-xs font-semibold ${
+                isHome ? "text-white" : "text-txt"
+              }`}
+            >
               {todo.name}
             </span>
             {todo.isUrgent ? (
-              <Badge variant="secondary" className="text-3xs text-danger">
+              <Badge
+                variant="secondary"
+                className={homeBadgeClassName(tone, "text-danger")}
+              >
                 Urgent
               </Badge>
             ) : null}
             {todo.priority != null ? (
-              <Badge variant="secondary" className="text-3xs">
+              <Badge variant="secondary" className={homeBadgeClassName(tone)}>
                 P{todo.priority}
               </Badge>
             ) : null}
             {showType ? (
-              <Badge variant="secondary" className="text-3xs">
+              <Badge variant="secondary" className={homeBadgeClassName(tone)}>
                 {todo.type}
               </Badge>
             ) : null}
           </div>
           {showDescription ? (
-            <p className="mt-1 line-clamp-2 text-xs-tight leading-5 text-muted">
+            <p
+              className={`mt-1 line-clamp-2 text-xs-tight leading-5 ${
+                isHome ? "text-white/70" : "text-muted"
+              }`}
+            >
               {todo.description}
             </p>
           ) : null}
@@ -142,31 +173,45 @@ function TodoRow({ todo }: { todo: WorkbenchTodo }) {
 function GoalAttentionRow({
   goal,
   onOpen,
+  tone = "default",
 }: {
   goal: AttentionGoal;
   onOpen: () => void;
+  tone?: "default" | "home";
 }) {
   const atRisk = goal.reviewState === "at_risk";
   const status = atRisk ? "at risk" : "needs attention";
+  const isHome = tone === "home";
   return (
     <button
       type="button"
       data-testid="todo-goal-attention-row"
       aria-label={`Goal "${goal.title}" ${status}. Open Goals.`}
       onClick={onOpen}
-      className="flex min-h-11 w-full items-start gap-2 rounded-sm border border-border/50 bg-bg/70 p-3 text-left"
+      className={`flex min-h-11 w-full items-start gap-2 rounded-sm border p-3 text-left ${
+        isHome
+          ? "border-white/15 bg-white/10 text-white"
+          : "border-border/50 bg-bg/70"
+      }`}
     >
       <Target
         className={`mt-0.5 h-4 w-4 shrink-0 ${atRisk ? "text-danger" : "text-accent"}`}
       />
       <div className="min-w-0 flex-1">
         <div className="flex flex-wrap items-center gap-1.5">
-          <span className="min-w-0 truncate text-xs font-semibold text-txt">
+          <span
+            className={`min-w-0 truncate text-xs font-semibold ${
+              isHome ? "text-white" : "text-txt"
+            }`}
+          >
             {goal.title}
           </span>
           <Badge
             variant="secondary"
-            className={`text-3xs ${atRisk ? "text-danger" : "text-accent"}`}
+            className={homeBadgeClassName(
+              tone,
+              atRisk ? "text-danger" : "text-accent",
+            )}
           >
             {atRisk ? "At risk" : "Needs attention"}
           </Badge>
@@ -181,22 +226,30 @@ function TodoItemsContent({
   loading,
   goal,
   onOpenGoal,
+  tone = "default",
 }: {
   todos: WorkbenchTodo[];
   loading: boolean;
   goal: AttentionGoal | null;
   onOpenGoal: () => void;
+  tone?: "default" | "home";
 }) {
   const openTodos = todos.filter((todo) => !todo.isCompleted);
   const hiddenCompletedCount = todos.length - openTodos.length;
   const visibleTodos = openTodos.slice(0, MAX_VISIBLE_TODOS);
   const remainingCount = openTodos.length - visibleTodos.length;
   const goalRow = goal ? (
-    <GoalAttentionRow goal={goal} onOpen={onOpenGoal} />
+    <GoalAttentionRow goal={goal} onOpen={onOpenGoal} tone={tone} />
   ) : null;
 
   if (loading && todos.length === 0 && !goal) {
-    return <div className="py-3 text-xs text-muted">Refreshing todos…</div>;
+    return (
+      <div
+        className={`py-3 text-xs ${tone === "home" ? "text-white/70" : "text-muted"}`}
+      >
+        Refreshing todos…
+      </div>
+    );
   }
 
   if (openTodos.length === 0) {
@@ -218,15 +271,19 @@ function TodoItemsContent({
     <div className="flex flex-col gap-2">
       {goalRow}
       {visibleTodos.map((todo) => (
-        <TodoRow key={todo.id} todo={todo} />
+        <TodoRow key={todo.id} todo={todo} tone={tone} />
       ))}
       {remainingCount > 0 ? (
-        <p className="px-1 text-xs-tight text-muted">
+        <p
+          className={`px-1 text-xs-tight ${tone === "home" ? "text-white/70" : "text-muted"}`}
+        >
           +{remainingCount} more open todo{remainingCount === 1 ? "" : "s"}
         </p>
       ) : null}
       {hiddenCompletedCount > 0 ? (
-        <p className="px-1 text-xs-tight text-muted">
+        <p
+          className={`px-1 text-xs-tight ${tone === "home" ? "text-white/70" : "text-muted"}`}
+        >
           {hiddenCompletedCount} completed todo
           {hiddenCompletedCount === 1 ? "" : "s"} hidden
         </p>
@@ -402,12 +459,14 @@ function TodoSidebarWidget({
       title={t("taskseventspanel.Todos", { defaultValue: "Todos" })}
       icon={<ListTodo className="h-4 w-4" />}
       testId="chat-widget-todos"
+      tone={onHome ? "home" : "default"}
     >
       <TodoItemsContent
         todos={todos}
         loading={todosLoading}
         goal={attentionGoal}
         onOpenGoal={() => nav.openView("/goals", "goals")}
+        tone={onHome ? "home" : "default"}
       />
     </WidgetSection>
   );


### PR DESCRIPTION
## Summary

- Applies the home glass/white foreground treatment to the shared widget section when used on the home surface.
- Passes that home tone through the Today/Todos rows and merged goal-attention row so child text no longer resolves black on the dark ember home field.

## Why

#14669 merged the home resident-set refactor, but the home-screen e2e caught black text in the Today card before this fix landed. This PR is the small follow-up repair.

## Verification

- `bun run --cwd packages/ui test -- src/components/chat/widgets/todo.test.tsx src/widgets/WidgetHost.home-rank.test.tsx src/widgets/home-priority-integration.test.ts src/widgets/registry.home.test.ts src/widgets/widget-coverage.test.ts src/components/chat/widgets/goals-attention.test.tsx` -> 6 files passed, 42 tests passed.
- `bunx @biomejs/biome check packages/ui/src/components/chat/widgets/shared.tsx packages/ui/src/components/chat/widgets/todo.tsx --no-errors-on-unmatched` -> no fixes applied.
- `git diff --check origin/develop...HEAD` -> clean.
- `bun run audit:error-policy-ratchet` -> no new fallback-slop.
- `bun run --cwd packages/ui test:home-screen-e2e` -> `HOME-SCREEN E2E PASSED`; includes `home card foregrounds stay readable on the dark ember field ([])` and no page errors.
- Manually reviewed generated `packages/ui/src/components/shell/__e2e__/output-home/01-mobile-home.png`; the Todos card title, goal row, todo row, and badges render in light foregrounds on the dark field. Generated output was restored from the worktree after review and is not committed.

## App audit note

- The broader `packages/app audit:app` run from the earlier validation passed through 252 app audit cases before the audit web server began returning `UI dist unavailable after retries` from its temporary dist path. That infrastructure-broken run was stopped rather than treating later zero-finding captures as valid.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - pre-fix artifact was the failing home-screen e2e from #14669/#14810 context; no GitHub-hosted before image is available in this PR body`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - generated locally by passing test:home-screen-e2e and manually reviewed, but not attached as a GitHub-hosted artifact from this environment`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - generated locally by test:home-screen-e2e at output-home/mobile-launcher-flow.webm, but not attached as a GitHub-hosted artifact from this environment`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - UI-only styling fix`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no standalone browser log artifact attached; home-screen e2e reported no page errors and the focused assertions are listed above`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model/action/provider behavior changed`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no persisted domain artifact changed`.
