### PR TITLE
fix(inbox): remove small-group priority fallback

### DIFF
--- a/plugins/plugin-inbox/src/inbox/aggregate.ts
+++ b/plugins/plugin-inbox/src/inbox/aggregate.ts
@@ -4,9 +4,8 @@
  * Owns the read-side pipeline that turns raw `InboundMessage`s (chat memories
  * + Gmail + X DMs via `message-fetcher.ts`) into the `LifeOpsInbox` DTO the
  * dashboard renders: channel normalization, filtering, thread grouping, LLM
- * priority scoring (`priority-scoring.ts`) with a v1 small-group heuristic
- * fallback, the missed-message filter, and the cached read-through spine
- * (`InboxDomain`).
+ * priority scoring (`priority-scoring.ts`), the missed-message filter, and the
+ * cached read-through spine (`InboxDomain`).
  *
  * Source health is part of the DTO: every response carries a required
  * `sources` array (`LifeOpsInboxSourceStatus`) describing chat/gmail/x_dm
@@ -249,6 +248,7 @@ interface InboxBuildOptions {
   maxParticipants?: number;
   gmailAccountId?: string;
   phoneAccountIds?: ReadonlySet<string>;
+  /** User identity hint for LLM scoring; structural aggregation never ranks by name substrings. */
   ownerName?: string | null;
   missedOnly?: boolean;
   /**
@@ -260,57 +260,6 @@ interface InboxBuildOptions {
   sortByPriority?: boolean;
   /** Optional precomputed score map keyed by message id. */
   llmScores?: ReadonlyMap<string, PriorityScore>;
-}
-
-/**
- * Compute a v1 small-group importance score for a thread group. Used as the
- * fallback path when LLM priority scoring is disabled or fails. Returns a
- * number in [0, 100].
- */
-function scoreSmallGroupThread(
-  members: LifeOpsInboxMessage[],
-  ownerNameLower: string | null,
-  isMostRecentGroupActivity: boolean,
-): number {
-  let score = 0;
-  let mentionsOwner = false;
-  let hasQuestion = false;
-  let hasDateLike = false;
-  for (const member of members) {
-    const text = `${member.subject ?? ""} ${member.snippet}`;
-    if (!mentionsOwner) {
-      if (
-        ownerNameLower &&
-        ownerNameLower.length > 0 &&
-        text.toLowerCase().includes(ownerNameLower)
-      ) {
-        mentionsOwner = true;
-      } else if (/@me\b/i.test(text)) {
-        mentionsOwner = true;
-      }
-    }
-    if (!hasQuestion && text.includes("?")) {
-      hasQuestion = true;
-    }
-    if (!hasDateLike) {
-      // Catches "3pm", "3:30", "tomorrow", "Mon"-"Sun", "Jan-Dec".
-      if (
-        /\b(?:[01]?\d|2[0-3])(?::[0-5]\d)?\s*(?:am|pm)\b/i.test(text) ||
-        /\b(?:tomorrow|tonight|today|tmr|tmrw)\b/i.test(text) ||
-        /\b(?:mon|tue|tues|wed|thu|thur|thurs|fri|sat|sun)\b/i.test(text) ||
-        /\b(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)\b/i.test(
-          text,
-        )
-      ) {
-        hasDateLike = true;
-      }
-    }
-  }
-  if (mentionsOwner) score += 30;
-  if (hasQuestion) score += 20;
-  if (hasDateLike) score += 15;
-  if (isMostRecentGroupActivity) score += 10;
-  return Math.min(score, 100);
 }
 
 function applyLlmScores(
@@ -328,7 +277,6 @@ function applyLlmScores(
 
 function buildThreadGroups(
   messages: LifeOpsInboxMessage[],
-  ownerName: string | null,
   llmScores?: ReadonlyMap<string, PriorityScore>,
   sortByPriority = false,
 ): LifeOpsInboxThreadGroup[] {
@@ -339,25 +287,6 @@ function buildThreadGroups(
     bucket.push(message);
     buckets.set(key, bucket);
   }
-
-  // Identify the group thread with the most-recent activity to award the
-  // "most-recent group activity" heuristic point in the fallback path.
-  let mostRecentGroupKey: string | null = null;
-  let mostRecentGroupTs = -Infinity;
-  for (const [key, members] of buckets) {
-    const latest = members[0];
-    if (latest?.chatType !== "group") continue;
-    const ts = Date.parse(latest.receivedAt);
-    if (Number.isFinite(ts) && ts > mostRecentGroupTs) {
-      mostRecentGroupTs = ts;
-      mostRecentGroupKey = key;
-    }
-  }
-
-  const ownerNameLower =
-    typeof ownerName === "string" && ownerName.trim().length > 0
-      ? ownerName.trim().toLowerCase()
-      : null;
 
   const groups: LifeOpsInboxThreadGroup[] = [];
   for (const [key, members] of buckets) {
@@ -370,7 +299,7 @@ function buildThreadGroups(
       (m) => typeof m.participantCount === "number",
     )?.participantCount;
 
-    let priorityScores = members
+    const priorityScores = members
       .map((m) => m.priorityScore)
       .filter((value): value is number => typeof value === "number");
 
@@ -418,29 +347,6 @@ function buildThreadGroups(
           }
         }
         priorityCategory = topCategory;
-      }
-    }
-
-    // Fallback: only run the v1 heuristic for small groups when the LLM
-    // produced nothing for the latest message.
-    const latestHasLlmScore = llmScores?.has(latestMessage.id) === true;
-    if (
-      !latestHasLlmScore &&
-      latestMessage.chatType === "group" &&
-      typeof participantCount === "number" &&
-      participantCount <= 15
-    ) {
-      const heuristicScore = scoreSmallGroupThread(
-        members,
-        ownerNameLower,
-        key === mostRecentGroupKey,
-      );
-      if (heuristicScore > 0) {
-        latestMessage.priorityScore = Math.max(
-          latestMessage.priorityScore ?? 0,
-          heuristicScore,
-        );
-        priorityScores = [...priorityScores, heuristicScore];
       }
     }
 
@@ -578,7 +484,6 @@ export function buildInboxFromMessages(
   if (options.groupByThread) {
     threadGroups = buildThreadGroups(
       trimmed,
-      options.ownerName ?? null,
       options.llmScores,
       options.sortByPriority === true,
     );

--- a/plugins/plugin-inbox/src/inbox/priority-scoring.test.ts
+++ b/plugins/plugin-inbox/src/inbox/priority-scoring.test.ts
@@ -1,0 +1,60 @@
+/** Verifies inbox priority scorer failure handling at the model boundary. */
+import type { IAgentRuntime } from "@elizaos/core";
+import type { LifeOpsInboxMessage } from "@elizaos/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetPriorityScoringCacheForTests,
+  scoreInboxMessages,
+} from "./priority-scoring.ts";
+
+function message(id: string): LifeOpsInboxMessage {
+  return {
+    id,
+    channel: "discord",
+    sender: {
+      id: `sender-${id}`,
+      displayName: "Ada",
+      email: null,
+      avatarUrl: null,
+    },
+    subject: null,
+    snippet: "Can you review this tomorrow at 3pm?",
+    receivedAt: "2026-01-01T12:00:00.000Z",
+    unread: true,
+    deepLink: null,
+    sourceRef: { channel: "discord", externalId: id },
+  };
+}
+
+describe("scoreInboxMessages", () => {
+  beforeEach(() => {
+    __resetPriorityScoringCacheForTests();
+  });
+
+  it("reports model failures and leaves priorities unscored", async () => {
+    const error = new Error("model unavailable");
+    const reportError = vi.fn();
+    const runtime = {
+      useModel: vi.fn(async () => {
+        throw error;
+      }),
+      reportError,
+    } as unknown as IAgentRuntime;
+
+    const result = await scoreInboxMessages(
+      runtime,
+      [message("one"), message("two")],
+      { model: "test-model", concurrency: 1 },
+    );
+
+    expect(result).toEqual([null, null]);
+    expect(reportError).toHaveBeenCalledWith(
+      "lifeops.priority-scoring",
+      error,
+      expect.objectContaining({
+        count: 2,
+        modelId: "test-model",
+      }),
+    );
+  });
+});

--- a/plugins/plugin-inbox/src/inbox/priority-scoring.ts
+++ b/plugins/plugin-inbox/src/inbox/priority-scoring.ts
@@ -3,16 +3,16 @@
  *
  * The scorer asks a small, fast model to rate each message on a 0–100
  * importance scale and to bucket it into one of three categories
- * (`important` / `planning` / `casual`). The v1 small-group keyword heuristic
- * in `aggregate.ts:scoreSmallGroupThread` is the fallback path.
+ * (`important` / `planning` / `casual`). Missing scores stay missing so callers
+ * can distinguish an unavailable scorer from a genuinely low-priority message.
  *
  * Behavior:
  * - Batches up to ~10 messages per call to keep prompts small.
  * - Caches results in-memory keyed by `(messageId, contentHash, model)` so
  *   re-fetches inside a single runtime are free.
  * - Concurrency-capped to 4 parallel batches.
- * - If the LLM call or parser fails, returns `null` per message so the caller
- *   can fall back to the v1 heuristic.
+ * - If the LLM call or parser fails, reports the failure and returns `null` per
+ *   message instead of fabricating priorities.
  */
 import type { IAgentRuntime } from "@elizaos/core";
 import {
@@ -431,6 +431,10 @@ export async function scoreInboxMessages(
               },
               "[lifeops] priority scoring batch failed; leaving entries null",
             );
+            runtime.reportError("lifeops.priority-scoring", error, {
+              count: indices.length,
+              modelId,
+            });
           }
         }
       })(),

--- a/plugins/plugin-inbox/test/inbox-aggregate.real-runtime.test.ts
+++ b/plugins/plugin-inbox/test/inbox-aggregate.real-runtime.test.ts
@@ -364,6 +364,64 @@ describe("aggregate builders", () => {
     // Latest message wins the group headline.
     expect(discordGroup?.latestMessage.snippet).toBe("second in thread");
   });
+
+  it("does not fabricate small-group priority scores when LLM scores are missing", () => {
+    const now = Date.now();
+    const inbox = buildInbox(
+      [
+        inboundChat({
+          id: "group-1",
+          text: "Ada, can you review this tomorrow at 3pm?",
+          threadId: "group-thread",
+          timestamp: now - 1000,
+          chatType: "group",
+          participantCount: 4,
+        }),
+      ],
+      {
+        limit: 10,
+        allowed: new Set<LifeOpsInboxChannel>(["discord"]),
+        sources: [{ source: "chat", state: "ok", degradations: [] }],
+        groupByThread: true,
+        ownerName: "Ada",
+        sortByPriority: true,
+      },
+    );
+
+    const group = inbox.threadGroups?.[0];
+    expect(group?.maxPriorityScore).toBeUndefined();
+    expect(group?.priorityCategory).toBeUndefined();
+    expect(group?.latestMessage.priorityScore).toBeUndefined();
+    expect(inbox.messages[0]?.priorityScore).toBeUndefined();
+  });
+
+  it("missedOnly requires a real priority score instead of keyword fallback", () => {
+    const old = Date.now() - 25 * 60 * 60 * 1000;
+    const inbox = buildInbox(
+      [
+        inboundChat({
+          id: "missed-group-1",
+          text: "Ada, are you free tomorrow at 3pm?",
+          threadId: "missed-group-thread",
+          timestamp: old,
+          chatType: "group",
+          participantCount: 5,
+        }),
+      ],
+      {
+        limit: 10,
+        allowed: new Set<LifeOpsInboxChannel>(["discord"]),
+        sources: [{ source: "chat", state: "ok", degradations: [] }],
+        groupByThread: true,
+        ownerName: "Ada",
+        missedOnly: true,
+        sortByPriority: true,
+      },
+    );
+
+    expect(inbox.messages).toEqual([]);
+    expect(inbox.threadGroups).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #14721.

Removes the plugin-inbox small-group keyword fallback that fabricated priority scores when LLM scoring was disabled or failed. Missing scores now remain missing, so callers can distinguish an unavailable scorer from a genuinely low-priority group chat.

What changed:
- Deleted `scoreSmallGroupThread` and the owner-name/question/date-like regex path from `src/inbox/aggregate.ts`.
- Thread groups now compute `maxPriorityScore` only from persisted/current LLM scores.
- `missedOnly` no longer treats benchmark-shaped group text as missed without a real priority score.
- Priority scoring batch failures now call `runtime.reportError("lifeops.priority-scoring", ...)` in addition to warning, so scorer outages surface through the runtime error provider/escalation path.
- Updated stale file headers that described the deleted fallback.

## Verification

- `bun test plugins/plugin-inbox/test/inbox-aggregate.real-runtime.test.ts plugins/plugin-inbox/src/inbox/priority-scoring.test.ts` — 16 passed.
  - Added coverage that small-group text like `Ada, can you review this tomorrow at 3pm?` does not get a fabricated priority score without `llmScores`.
  - Added coverage that `missedOnly` requires a real priority score instead of keyword fallback.
  - Added coverage that scorer model failures return `[null, null]` and call `runtime.reportError` with `lifeops.priority-scoring`.
- `bunx biome check plugins/plugin-inbox/src/inbox/aggregate.ts plugins/plugin-inbox/src/inbox/priority-scoring.ts plugins/plugin-inbox/src/inbox/priority-scoring.test.ts plugins/plugin-inbox/test/inbox-aggregate.real-runtime.test.ts` — passed.
- `git diff --check` — passed.
- `bun run --cwd plugins/plugin-inbox build:types` — passed.
- `bun run audit:error-policy-ratchet` — passed; no new fallback-slop.
- Source scan over `plugins/plugin-inbox/src/inbox` found no remaining `scoreSmallGroupThread`, owner-name/date-like/question fallback terms, or stale fallback wording.

## Known Verification Blockers

- `bun run --cwd plugins/plugin-inbox typecheck` is blocked by an existing workspace dependency resolution issue outside this patch: `../../packages/agent/src/runtime/operations/vault-bridge.ts(17,64): error TS2307: Cannot find module '@elizaos/vault' or its corresponding type declarations.` After fixing the local fixture/type compatibility, this was the only remaining typecheck error.

## Evidence Notes

- UI screenshots/video: N/A — backend aggregation/scoring behavior only, no rendered UI surface changed.
- Live LLM trajectory: N/A for this patch — deterministic tests exercise the behavior at the LLM boundary: missing/failed model scoring remains unscored and reported instead of being replaced by a regex score.
