### PR TITLE
docs(scenario-runner): remove stale scenario count

### DIFF
--- a/packages/scenario-runner/AGENTS.md
+++ b/packages/scenario-runner/AGENTS.md
@@ -33,7 +33,7 @@ packages/scenario-runner/
       index.ts               # runFinalCheck — dispatches named final-check type handlers
     types/                   # Supporting internal type files
   test/
-    scenarios/               # 17 deterministic scenario files (*.scenario.ts)
+    scenarios/               # Runner-owned scenarios: deterministic-* PR fixtures plus live-* / live-only coverage
     fixtures/                # Misc test fixtures (e.g. mcp-stdio-fixture.mjs)
 ```
 

--- a/packages/scenario-runner/CLAUDE.md
+++ b/packages/scenario-runner/CLAUDE.md
@@ -33,7 +33,7 @@ packages/scenario-runner/
       index.ts               # runFinalCheck — dispatches named final-check type handlers
     types/                   # Supporting internal type files
   test/
-    scenarios/               # 17 deterministic scenario files (*.scenario.ts)
+    scenarios/               # Runner-owned scenarios: deterministic-* PR fixtures plus live-* / live-only coverage
     fixtures/                # Misc test fixtures (e.g. mcp-stdio-fixture.mjs)
 ```
 


### PR DESCRIPTION
## Summary

Closes #14701.

Updates `packages/scenario-runner/CLAUDE.md` and `AGENTS.md` identically so the `test/scenarios/` layout entry no longer claims there are "17 deterministic scenario files". The docs now describe the stable split instead: runner-owned deterministic PR fixtures plus live/live-only coverage.

## Verification

- Current `packages/scenario-runner/test/scenarios` count: `find packages/scenario-runner/test/scenarios -name '*.scenario.ts' | wc -l` → 50.
- `cmp -s packages/scenario-runner/CLAUDE.md packages/scenario-runner/AGENTS.md && echo identical` → `identical`.
- `rg -n "17 deterministic scenario files|deterministic scenario files" packages/scenario-runner/CLAUDE.md packages/scenario-runner/AGENTS.md || true` → no matches.
- `git diff --check` — passed.
- `bun run check:comment-only` — N/A for this doc-guide edit; the guard rejects Markdown guide files as non-source (`changed non-source file — comment cleanup touches source files only`).

## Evidence Notes

- UI screenshots/video: N/A — documentation-only change.
- Live LLM trajectory: N/A — documentation-only change.
