### PR TITLE
fix(scenarios,inbox): memory seeds must land or fail loudly — the #14631 'ignored VIP fact' was never seeded; add uncertain-keep triage outcome

### DIFF
--- a/packages/scenario-runner/schema/index.d.ts
+++ b/packages/scenario-runner/schema/index.d.ts
@@ -98,6 +98,14 @@ export type ScenarioContext = {
   scenarioId?: string;
   runId?: string;
   now?: string;
+  /**
+   * Primary (default) scenario room + simulated owner entity, set by the
+   * executor before seeds run. Seeds and custom checks use these to write
+   * and read state attributed to the owner's conversation (e.g. plain-text
+   * memory seeds land as durable facts in this room for this entity).
+   */
+  primaryRoomId?: string;
+  primaryUserId?: string;
   actionsCalled: CapturedAction[];
   turns?: ScenarioTurnExecution[];
   approvalRequests?: CapturedApprovalRequest[];

--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -2102,6 +2102,11 @@ export async function runScenario(
   let interceptor = attachInterceptor(runtime);
   const rooms = resolveScenarioRooms(scenario);
   const primaryRoom = getDefaultScenarioRoom(rooms);
+  // Expose the owner conversation identity to seeds and custom checks:
+  // plain-text memory seeds write durable facts attributed to this room +
+  // entity so the core FACTS provider can surface them during turns.
+  ctx.primaryRoomId = primaryRoom.roomId;
+  ctx.primaryUserId = primaryRoom.userId;
   const variables: ScenarioVariableState = {
     baseNow: new Date(startedAt),
     capturesByName: new Map<string, unknown>(),

--- a/packages/scenario-runner/src/seeds.test.ts
+++ b/packages/scenario-runner/src/seeds.test.ts
@@ -163,6 +163,13 @@ function createSeedHarness() {
     recordInteraction: vi.fn(async () => undefined),
     setRelationshipGoal: vi.fn(async () => undefined),
   };
+  const createMemory = vi.fn(
+    async (
+      _memory: Record<string, unknown>,
+      _tableName: string,
+      _unique?: boolean,
+    ) => "fact-id" as UUID,
+  );
   const runtime = {
     agentId: "00000000-0000-0000-0000-000000000001" as UUID,
     getService: vi.fn((serviceName: string) =>
@@ -170,11 +177,18 @@ function createSeedHarness() {
     ),
     getEntityById: vi.fn(async () => null),
     createEntity: vi.fn(async () => undefined),
+    createMemory,
   } as unknown as AgentRuntime;
   return {
-    ctx: { runtime } as ScenarioContext,
+    ctx: {
+      runtime,
+      scenarioId: "seed-test",
+      primaryRoomId: "00000000-0000-0000-0000-0000000000aa",
+      primaryUserId: "00000000-0000-0000-0000-0000000000bb",
+    } as ScenarioContext,
     relationships,
     runtime,
+    createMemory,
   };
 }
 
@@ -378,8 +392,37 @@ describe("scenario memory seeds", () => {
     );
   });
 
-  it("continues to ignore unsupported memory seed kinds", async () => {
-    const { ctx, relationships, runtime } = createSeedHarness();
+  it("writes plain-text memory seeds as durable owner facts in the facts table", async () => {
+    const { ctx, createMemory } = createSeedHarness();
+
+    const result = await applyScenarioSeedStep(ctx, {
+      type: "memory",
+      content: {
+        text: "Owner fact: largest account is Halcyon Freight; their contact sometimes messages from a plain personal address with no signature.",
+      },
+    } satisfies ScenarioSeedStep);
+
+    expect(result).toBeUndefined();
+    expect(createMemory).toHaveBeenCalledTimes(1);
+    const [memory, tableName, unique] = createMemory.mock.calls[0];
+    expect(tableName).toBe("facts");
+    expect(unique).toBe(true);
+    expect(memory.roomId).toBe(ctx.primaryRoomId);
+    expect(memory.entityId).toBe(ctx.primaryUserId);
+    expect(memory.content).toEqual({
+      text: "Owner fact: largest account is Halcyon Freight; their contact sometimes messages from a plain personal address with no signature.",
+    });
+    // Durable kind is load-bearing: the FACTS provider's keyword-miss
+    // fallback only applies to durable facts, which is what guarantees a
+    // seeded fact surfaces even without lexical overlap with the turn text.
+    expect(memory.metadata).toMatchObject({
+      kind: "durable",
+      source: "scenario-seed",
+    });
+  });
+
+  it("fails the seed (never silently no-ops) on unsupported memory kinds", async () => {
+    const { ctx, relationships, createMemory } = createSeedHarness();
 
     const result = await applyScenarioSeedStep(ctx, {
       type: "memory",
@@ -389,9 +432,34 @@ describe("scenario memory seeds", () => {
       },
     } satisfies ScenarioSeedStep);
 
-    expect(result).toBeUndefined();
-    expect(runtime.getService).not.toHaveBeenCalled();
+    expect(result).toMatch(/unsupported memory seed kind "inbound-message"/);
+    expect(createMemory).not.toHaveBeenCalled();
     expect(relationships.addContact).not.toHaveBeenCalled();
+  });
+
+  it("fails the seed when memory content has neither text nor a contact kind", async () => {
+    const { ctx, createMemory } = createSeedHarness();
+
+    const result = await applyScenarioSeedStep(ctx, {
+      type: "memory",
+      content: {},
+    } satisfies ScenarioSeedStep);
+
+    expect(result).toMatch(/non-empty text or a contact-like kind/);
+    expect(createMemory).not.toHaveBeenCalled();
+  });
+
+  it("fails the seed when the executor did not provide the primary room identity", async () => {
+    const { ctx, createMemory } = createSeedHarness();
+    delete (ctx as { primaryRoomId?: string }).primaryRoomId;
+
+    const result = await applyScenarioSeedStep(ctx, {
+      type: "memory",
+      content: { text: "Owner fact: something important." },
+    } satisfies ScenarioSeedStep);
+
+    expect(result).toMatch(/primaryRoomId/);
+    expect(createMemory).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/scenario-runner/src/seeds.ts
+++ b/packages/scenario-runner/src/seeds.ts
@@ -7,7 +7,7 @@
  * executor between setup and the first turn.
  */
 import type { AgentRuntime, UUID } from "@elizaos/core";
-import { stringToUuid } from "@elizaos/core";
+import { MemoryType, stringToUuid } from "@elizaos/core";
 import type {
   ScenarioContext,
   ScenarioSeedStep,
@@ -686,7 +686,7 @@ async function seedMemory(
 ): Promise<string | undefined> {
   const content = seed.content as MemoryContactSeed | undefined;
   if (!content || typeof content !== "object") {
-    return undefined;
+    return "memory seed requires a content object";
   }
   const memoryType =
     readNonEmptyString(content.kind) ?? readNonEmptyString(content.type);
@@ -697,6 +697,48 @@ async function seedMemory(
   ) {
     return seedContact(ctx, memoryEntityToContactSeed(content, memoryType));
   }
+  if (memoryType !== null) {
+    // A seed the runner cannot land must fail the scenario, never no-op:
+    // a silently dropped seed fabricates the premise the checks grade
+    // against (#14631 — the "seeded VIP fact" the model never received).
+    return `unsupported memory seed kind "${memoryType}" — supported: contact/rolodex-entity/merged-entity, or plain { text } for a durable owner fact`;
+  }
+  const text = readNonEmptyString((content as { text?: unknown }).text);
+  if (!text) {
+    return "memory seed content must carry non-empty text or a contact-like kind";
+  }
+  // Plain-text memory seeds are owner facts: write a real durable row in the
+  // `facts` table, attributed to the primary room + simulated owner entity,
+  // in the exact shape the fact extractor persists — so the core FACTS
+  // provider retrieves and renders it during turns (durable facts fall back
+  // to highest-prior when keyword relevance misses, so seeded facts surface
+  // even without lexical overlap with the turn text).
+  const runtime = requireRuntime(ctx);
+  const roomId = readNonEmptyString(ctx.primaryRoomId);
+  const entityId = readNonEmptyString(ctx.primaryUserId);
+  if (!roomId || !entityId) {
+    return "memory seed requires ctx.primaryRoomId/primaryUserId (set by the executor before seeds run)";
+  }
+  await runtime.createMemory(
+    {
+      id: stringToUuid(`scenario-fact:${ctx.scenarioId ?? "unknown"}:${text}`),
+      entityId: entityId as UUID,
+      agentId: runtime.agentId,
+      roomId: roomId as UUID,
+      content: { text },
+      metadata: {
+        type: MemoryType.CUSTOM,
+        source: "scenario-seed",
+        confidence: 0.95,
+        kind: "durable",
+        category: "seeded",
+        keywords: [],
+      },
+      createdAt: Date.now(),
+    },
+    "facts",
+    true,
+  );
   return undefined;
 }
 

--- a/packages/scenario-runner/test/scenarios/deterministic-seeded-fact-recall.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-seeded-fact-recall.scenario.ts
@@ -1,0 +1,106 @@
+/**
+ * Deterministic (keyless) proof for the #14631 seed pipeline: a plain-text
+ * `type: "memory"` scenario seed must land as a REAL durable row in the
+ * `facts` table and be surfaced by the core FACTS provider for the owner's
+ * conversation. Before this pipeline existed, such seeds were silently
+ * dropped — scenarios like `f1-adversarial-vip-misfile-cross-persona` graded
+ * the model on a "seeded VIP fact" the model never received, which is how an
+ * ambiguous possibly-VIP message could be confidently dismissed as junk.
+ *
+ * Runs zero turns: the assertion is on the seed → store → provider pipeline,
+ * driven through the real runtime (real DB write, real FACTS retrieval and
+ * render), no LLM calls.
+ *
+ * Fail-without-fix anchor: with the old no-op seedMemory the fact row never
+ * exists, so the FACTS render check fails.
+ */
+import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+const SEEDED_FACT =
+  "Owner fact: largest account is Halcyon Freight; their contact sometimes messages from a plain personal address with no signature.";
+
+interface ProviderResultLike {
+  text: string;
+}
+
+interface ProviderLike {
+  name: string;
+  get(
+    runtime: unknown,
+    message: Record<string, unknown>,
+    state: Record<string, unknown>,
+  ): Promise<ProviderResultLike>;
+}
+
+interface RuntimeLike {
+  agentId: string;
+  providers: ProviderLike[];
+}
+
+async function expectSeededFactSurfaced(
+  ctx: ScenarioContext,
+): Promise<string | undefined> {
+  const runtime = ctx.runtime as RuntimeLike | undefined;
+  if (!runtime) return "scenario runtime unavailable";
+  const facts = runtime.providers.find((p) => p.name === "FACTS");
+  if (!facts) return "core FACTS provider is not registered on the runtime";
+  if (!ctx.primaryRoomId || !ctx.primaryUserId) {
+    return "executor did not expose primaryRoomId/primaryUserId to checks";
+  }
+  // The owner's triage ask from the live scenario this pipeline feeds: no
+  // lexical overlap requirement — durable facts fall back to highest-prior
+  // when keyword relevance misses.
+  const result = await facts.get(
+    runtime,
+    {
+      id: crypto.randomUUID(),
+      entityId: ctx.primaryUserId,
+      agentId: runtime.agentId,
+      roomId: ctx.primaryRoomId,
+      content: {
+        text: "Quick triage: I got this with no subject from an address I don't recognize — is that anything or junk?",
+      },
+      createdAt: Date.now(),
+    },
+    { values: {}, data: {}, text: "" },
+  );
+  if (!result.text.includes("Halcyon Freight")) {
+    return `seeded owner fact never reached the FACTS render; got: ${result.text || "(empty)"}`;
+  }
+  return undefined;
+}
+
+export default scenario({
+  lane: "pr-deterministic",
+  id: "deterministic-seeded-fact-recall",
+  title:
+    "A plain-text memory seed lands as a durable fact the FACTS provider surfaces",
+  domain: "scenario-runner",
+  tags: ["pr", "deterministic", "zero-cost", "seeds", "facts", "14631"],
+  status: "active",
+  isolation: "per-scenario",
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Seeded fact recall",
+    },
+  ],
+  seed: [
+    {
+      type: "memory",
+      name: "seed that the owner's largest client is Halcyon Freight",
+      content: { text: SEEDED_FACT },
+    },
+  ],
+  turns: [],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "seeded owner fact surfaces through the real FACTS provider",
+      predicate: expectSeededFactSurfaced,
+    },
+  ],
+});

--- a/plugins/plugin-inbox/src/inbox/triage-classifier.ts
+++ b/plugins/plugin-inbox/src/inbox/triage-classifier.ts
@@ -122,6 +122,8 @@ export const INBOX_TRIAGE_INSTRUCTIONS = [
   "- needs_reply: someone is asking a question or expects a response from the owner",
   "- urgent: time-sensitive, critical, or from a priority contact — needs immediate attention",
   "",
+  "When you cannot tell whether a message matters — terse, unsigned, no subject, or an unrecognized address that could still be a real person or client — do NOT classify it as ignore. Choose the least-dismissive plausible category (notify or needs_reply), lower the confidence, and state the uncertainty in reasoning so the owner sees the message and decides. Misfiling a real contact as spam costs far more than surfacing one junk message.",
+  "",
   "For each message, also provide:",
   "- urgency: low / medium / high",
   "- confidence: 0.0 to 1.0 (how sure you are about this classification)",

--- a/plugins/plugin-inbox/test/triage-optimized-prompt.test.ts
+++ b/plugins/plugin-inbox/test/triage-optimized-prompt.test.ts
@@ -48,6 +48,18 @@ describe("inbox triage — OptimizedPromptService routing", () => {
     expect(prompt).toContain("Sam Rivera");
   });
 
+  it("carries the uncertain-keep affordance so ambiguous messages are never filed as ignore (#14631)", () => {
+    // The over-dismissal failure mode: a terse, unsigned note from an
+    // unrecognized address confidently labeled junk. The baseline must give
+    // the model an explicit uncertainty outcome — keep it visible, lower
+    // confidence — instead of leaving "ignore" as the only junk-shaped bucket.
+    expect(INBOX_TRIAGE_INSTRUCTIONS).toContain("do NOT classify it as ignore");
+    expect(INBOX_TRIAGE_INSTRUCTIONS).toContain(
+      "least-dismissive plausible category",
+    );
+    expect(INBOX_TRIAGE_INSTRUCTIONS).toContain("state the uncertainty");
+  });
+
   it("uses the inline baseline when the runtime has no optimized prompt", () => {
     const prompt = buildTriagePrompt(MESSAGES, {
       runtime: runtimeWithOptimizedPrompt({}),


### PR DESCRIPTION
Closes #14631.

## Root cause — the issue's premise was fabricated by the harness

`packages/scenario-runner/src/seeds.ts:683-701` — `seedMemory` **silently no-opped** for plain-text seeds. The scenario's "Owner fact: largest account is Halcyon Freight…" never landed in any store; the model triaged blind and the failure was attributed to model judgment. This is exactly the scenario-meta class the goal called out: the scenarios themselves must be tested, validated, verified.

Secondary real gap: the inbox-triage vocabulary (`plugins/plugin-inbox/src/inbox/triage-classifier.ts:116`) had no uncertainty outcome — `ignore` was the only junk-shaped bucket, so an unsure model had no honest option.

## Fix (context + affordance, zero keyword guards)

- Plain-text memory seeds now write a **real durable row in the `facts` table** (primary room + owner entity, fact-extractor shape; `durable` kind is load-bearing — the FACTS provider's keyword-miss fallback guarantees a seeded fact surfaces even without lexical overlap).
- **Unsupported memory-seed kinds now fail the scenario with a typed error** instead of silently fabricating premises (fail-fast doctrine applied to the test harness itself).
- Executor exposes `primaryRoomId`/`primaryUserId` on `ScenarioContext`.
- Triage baseline gains an explicit **uncertain-keep** outcome: never `ignore` when unsure; least-dismissive category, lower confidence, state the uncertainty.
- Net ≈ +250/−7 (source ~+63).

## Verification

- `seeds.test.ts` 14 green (4 new, each fails without the fix: fact write shape/table/attribution, unsupported-kind error, no-text error, missing-room error).
- `triage-optimized-prompt.test.ts` 4 (1 new affordance pin); executor + schema-strict 48; training-side baseline consumers 17.
- New pr-deterministic scenario `deterministic-seeded-fact-recall`: seeds the Halcyon fact, asserts the **real FACTS provider** renders it for the owner's triage ask — passes keyless, fails against the old no-op path.

## Flagged for follow-up (not in this PR)

- ~30 live-only scenarios seed structured memory kinds (`profile`, `trip`, `inbound-message`, `calendar-event`, …) that were **always silent no-ops** — their premises never landed. They now fail loudly at seed time; each kind needs a real store realization. Filing separately.
- `origin/fix/14631-triage-over-dismissal` (a sibling lane's branch, not this one) is a regex-matched canned-reply guard that string-matches the scenario's exact phrasing — it fakes the judge pass without the fact ever being seeded and hijacks legitimate turns. Recommend dropping it in favor of this PR.
- Live-model re-runs of the two F1 scenarios remain `authored` pending credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)