### PR TITLE
docs(lifeops): fix passive signal headers

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/owner/profile-extraction-evaluator.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/profile-extraction-evaluator.ts
@@ -1,7 +1,8 @@
 /**
  * Response-handler evaluator that extracts durable owner facts and relationship
- * edges from the agent's own responses and persists them to the owner-fact store
- * and relationship graph. Registered as the `owner.profile_extraction` evaluator.
+ * edges from the incoming owner message before planning, then persists them to
+ * the owner-fact store and relationship graph. Registered as the
+ * `owner.profile_extraction` evaluator.
  */
 import { hasOwnerAccess, resolveKnowledgeGraphService } from "@elizaos/agent";
 import type {

--- a/plugins/plugin-personal-assistant/src/lifeops/signals/bus.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/signals/bus.ts
@@ -1,11 +1,8 @@
 /**
- * ActivitySignalBus.
- *
- * Pub/sub fabric for `LifeOpsBusFamily` events. Producers (calendar
- * watcher, plugin-health, time-window emitter, manual-override gateway)
- * publish typed envelopes; consumers (the `ScheduledTaskRunner`'s
- * `ActivitySignalBusView`, plugin-health's recap aggregator) subscribe by
- * family and read recent events.
+ * In-memory pub/sub fabric for `LifeOpsBusFamily` events. The personal
+ * assistant runtime owns the bus, derived health-signal publishers write
+ * typed envelopes to it, and scheduled-task completion checks consume the
+ * read-side `ActivitySignalBusView`.
  *
  * The bus is intentionally narrow. It does NOT:
  *   - Persist events (that is `LifeOpsRepository.insertTelemetryEvent`).

--- a/plugins/plugin-personal-assistant/src/lifeops/telemetry-mapping.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/telemetry-mapping.ts
@@ -1,11 +1,11 @@
 /**
- * Shared mapper from a persisted `LifeOpsActivitySignal` into a
- * `LifeOpsTelemetryPayload`. Used by the live writer in
- * `LifeOpsRepository.createActivitySignal` so every signal is mirrored into
- * the canonical `life_telemetry_events` store with a dedupe-stable payload.
+ * Shared mapper from persisted `LifeOpsActivitySignal` records into
+ * `LifeOpsTelemetryPayload` rows. `LifeOpsRepository.createActivitySignal`
+ * calls this on writes so passive signals are mirrored into
+ * `life_telemetry_events` with a dedupe-stable payload.
  *
- * See `eliza/plugins/plugin-personal-assistant/docs/telemetry-event-families.md` §8 for the
- * canonical mapping table.
+ * This file is the canonical mapping table for current signal families; keep
+ * it aligned with the shared `LifeOpsTelemetryPayload` union.
  */
 
 import crypto from "node:crypto";


### PR DESCRIPTION
## Summary
- Fixes three stale LifeOps passive-signal headers called out in #14692.
- Replaces nonexistent producer/consumer claims in `signals/bus.ts` with the observed health-signal publisher and scheduled-task read-side consumer.
- Removes the nonexistent telemetry mapping doc reference and states that `telemetry-mapping.ts` is the current mapping table.
- Corrects `profile-extraction-evaluator.ts` to say it extracts facts from the incoming owner message before planning, not from the agent's own response.

## Verification
- `rg -n "\\.publish\\(" plugins/plugin-personal-assistant/src/lifeops plugins/plugin-health/src -g '*.ts'` -> only `health-signal-publisher.ts:49` publishes to the bus.
- `rg -n "calendar watcher|time-window emitter|manual-override gateway|telemetry-event-families|agent's own responses" <touched files>` -> no matches.
- `find plugins/plugin-personal-assistant -path '*telemetry-event-families.md' -print` -> no matching doc exists.
- `bun run check:comment-only` -> OK, 3 source files changed and every code token is identical to `origin/develop`.
- `bunx biome check plugins/plugin-personal-assistant/src/lifeops/signals/bus.ts plugins/plugin-personal-assistant/src/lifeops/telemetry-mapping.ts plugins/plugin-personal-assistant/src/lifeops/owner/profile-extraction-evaluator.ts` -> no fixes applied.
- `git diff --check` -> clean.

## Evidence
Comment-only documentation correction; no UI, runtime behavior, model trajectory, or screenshot evidence applies.

Closes #14692.
