### PR TITLE
fix(#14708): resolve scheduled task owner channel targets

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
@@ -9,7 +9,14 @@
  */
 
 import crypto from "node:crypto";
-import { createLocalAgentBackup, getAgentEventService } from "@elizaos/agent";
+import {
+  createLocalAgentBackup,
+  getAgentEventService,
+  loadOwnerContactRoutingHints,
+  loadOwnerContactsConfig,
+  resolveOwnerContactWithFallback,
+  resolveOwnerEntityId,
+} from "@elizaos/agent";
 import { getHostExecutionCapabilities } from "@elizaos/app-core/services/task-host-capabilities";
 import { type IAgentRuntime, logger, ServiceType } from "@elizaos/core";
 import type {
@@ -360,11 +367,86 @@ async function composeOwnerFacingScheduledTaskText(
 }
 
 const LOCAL_AGENT_BACKUP_OPERATION = "agent.localBackup";
+const LIFEOPS_OWNER_CONTACTS_LOAD_CONTEXT = {
+  boundary: "lifeops.owner_contacts",
+  operation: "load_owner_contacts",
+  message:
+    "[lifeops] Failed to load owner contacts; using empty owner contacts config.",
+} as const;
 
 function isLocalAgentBackupDispatch(
   record: ScheduledTaskDispatchRecord,
 ): boolean {
   return record.metadata?.systemOperation === LOCAL_AGENT_BACKUP_OPERATION;
+}
+
+function targetNeedsOwnerResolution(
+  channelKey: string,
+  target: string | undefined,
+): boolean {
+  const normalized = normalizeChannelTarget(channelKey, target);
+  return !normalized || normalized === channelKey;
+}
+
+async function resolveOwnerChannelTarget(
+  runtime: IAgentRuntime,
+  channelKey: string,
+): Promise<string | null> {
+  const ownerContacts = loadOwnerContactsConfig(
+    LIFEOPS_OWNER_CONTACTS_LOAD_CONTEXT,
+  );
+  const hints = await loadOwnerContactRoutingHints(runtime, ownerContacts);
+  const hint = hints[channelKey] ?? null;
+  let contactResolution =
+    resolveOwnerContactWithFallback({
+      ownerContacts,
+      source: hint?.source ?? channelKey,
+      ownerEntityId: null,
+    }) ??
+    resolveOwnerContactWithFallback({
+      ownerContacts,
+      source: channelKey,
+      ownerEntityId: null,
+    });
+  if (!contactResolution) {
+    const ownerEntityId = await resolveOwnerEntityId(runtime);
+    contactResolution =
+      resolveOwnerContactWithFallback({
+        ownerContacts,
+        source: hint?.source ?? channelKey,
+        ownerEntityId,
+      }) ??
+      resolveOwnerContactWithFallback({
+        ownerContacts,
+        source: channelKey,
+        ownerEntityId,
+      });
+  }
+  const contact =
+    contactResolution?.contact ??
+    (hint?.source ? ownerContacts[hint.source] : undefined) ??
+    ownerContacts[channelKey];
+  return (
+    hint?.channelId ??
+    contact?.channelId ??
+    hint?.roomId ??
+    contact?.roomId ??
+    hint?.entityId ??
+    contact?.entityId ??
+    null
+  );
+}
+
+async function resolveScheduledTaskChannelTarget(
+  runtime: IAgentRuntime,
+  record: ScheduledTaskDispatchRecord,
+): Promise<string | null> {
+  if (!targetNeedsOwnerResolution(record.channelKey, record.output?.target)) {
+    return (
+      normalizeChannelTarget(record.channelKey, record.output?.target) ?? null
+    );
+  }
+  return resolveOwnerChannelTarget(runtime, record.channelKey);
 }
 
 function deniedDecisionToDispatchResult(
@@ -570,11 +652,21 @@ export function createProductionScheduledTaskDispatcher(opts: {
         };
       }
 
+      const target = await resolveScheduledTaskChannelTarget(
+        opts.runtime,
+        record,
+      );
+      if (!target) {
+        return applyDispatchPolicy({
+          ok: false,
+          reason: "disconnected",
+          userActionable: true,
+          message: `Channel "${record.channelKey}" has no resolvable owner target for scheduled task delivery.`,
+        });
+      }
+
       const payload = {
-        target: normalizeChannelTarget(
-          record.channelKey,
-          record.output?.target ?? record.channelKey,
-        ),
+        target,
         message,
         metadata: {
           taskId: record.taskId,

--- a/plugins/plugin-personal-assistant/test/sensitive-request-delivery.test.ts
+++ b/plugins/plugin-personal-assistant/test/sensitive-request-delivery.test.ts
@@ -3,6 +3,9 @@
  * status-only public text, a typed DM-failure with public fallback text, and the production
  * scheduled-task dispatcher path. Deterministic.
  */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import type { IAgentRuntime } from "@elizaos/core";
 import type { ScheduledTask } from "@elizaos/plugin-scheduling";
 import {
@@ -83,6 +86,35 @@ const request: LifeOpsSensitiveRequestDeliveryRecord = {
   },
   expiresAt: "2026-05-10T13:00:00.000Z",
 };
+
+async function withOwnerContactsConfig(
+  ownerContacts: Record<
+    string,
+    { entityId?: string; channelId?: string; roomId?: string }
+  >,
+  run: () => Promise<void>,
+): Promise<void> {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "lifeops-contacts-"));
+  const configPath = path.join(tempDir, "eliza.json");
+  const priorConfigPath = process.env.ELIZA_CONFIG_PATH;
+  const priorPersistPath = process.env.ELIZA_PERSIST_CONFIG_PATH;
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({ agents: { defaults: { ownerContacts } } }),
+  );
+  process.env.ELIZA_CONFIG_PATH = configPath;
+  process.env.ELIZA_PERSIST_CONFIG_PATH = configPath;
+  try {
+    await run();
+  } finally {
+    if (priorConfigPath === undefined) delete process.env.ELIZA_CONFIG_PATH;
+    else process.env.ELIZA_CONFIG_PATH = priorConfigPath;
+    if (priorPersistPath === undefined)
+      delete process.env.ELIZA_PERSIST_CONFIG_PATH;
+    else process.env.ELIZA_PERSIST_CONFIG_PATH = priorPersistPath;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
 
 const baseTask = (
   overrides: Partial<Omit<ScheduledTask, "taskId" | "state">> = {},
@@ -297,6 +329,79 @@ describe("scheduled task production dispatcher", () => {
     ).resolves.toEqual(failure);
   });
 
+  it("resolves a bare connector channel target through owner contact config", async () => {
+    const runtime = makeDispatchRuntime();
+    const sent: unknown[] = [];
+    const registry = createChannelRegistry();
+    registry.register(
+      sendCapableChannel(async (payload) => {
+        sent.push(payload);
+        return { ok: true, messageId: "msg_owner_contact" };
+      }),
+    );
+    registerChannelRegistry(runtime, registry);
+    const dispatcher = createProductionScheduledTaskDispatcher({ runtime });
+
+    await withOwnerContactsConfig(
+      { telegram: { channelId: "123456789" } },
+      async () => {
+        await expect(
+          dispatcher.dispatch({
+            taskId: "task_owner_target",
+            firedAtIso: "2026-05-10T12:00:00.000Z",
+            channelKey: "telegram",
+            promptInstructions: "internal owner reminder instructions",
+            contextRequest: undefined,
+            output: { destination: "channel", target: "telegram" },
+            metadata: {
+              packKey: "daily-rhythm",
+              recordKey: "checkin-followup",
+            },
+          }),
+        ).resolves.toEqual({
+          ok: true,
+          messageId: "msg_owner_contact",
+        });
+      },
+    );
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      target: "123456789",
+      message: RENDERED_MESSAGE,
+    });
+  });
+
+  it("fails typed instead of sending a bare connector channel name when owner target is missing", async () => {
+    const runtime = {
+      ...(makeDispatchRuntime() as unknown as Record<string, unknown>),
+      character: { name: "Test Agent" },
+      getRoomsForParticipant: vi.fn(async () => []),
+    } as unknown as IAgentRuntime;
+    const send = vi.fn(async () => ({ ok: true as const }));
+    const registry = createChannelRegistry();
+    registry.register(sendCapableChannel(send));
+    registerChannelRegistry(runtime, registry);
+
+    await expect(
+      createProductionScheduledTaskDispatcher({ runtime }).dispatch({
+        taskId: "task_missing_owner_target",
+        firedAtIso: "2026-05-10T12:00:00.000Z",
+        channelKey: "telegram",
+        promptInstructions: "owner reminder",
+        contextRequest: undefined,
+        output: { destination: "channel", target: "telegram" },
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      reason: "disconnected",
+      userActionable: true,
+      message:
+        'Channel "telegram" has no resolvable owner target for scheduled task delivery.',
+    });
+    expect(send).not.toHaveBeenCalled();
+  });
+
   it("evaluates send policy before channel send", async () => {
     const runtime = makeDispatchRuntime();
     const registry = createChannelRegistry();
@@ -355,6 +460,10 @@ describe("scheduled task production dispatcher", () => {
     const task = await runner.schedule(
       baseTask({
         output: { destination: "channel", target: "telegram:owner-dm" },
+        metadata: {
+          packKey: "daily-rhythm",
+          recordKey: "checkin-followup",
+        },
       }),
     );
     const fired = await runner.fire(task.taskId);

--- a/plugins/plugin-personal-assistant/test/stubs/agent.ts
+++ b/plugins/plugin-personal-assistant/test/stubs/agent.ts
@@ -3,6 +3,8 @@
  * plus a mutable agent-backup state, so PA tests run without pulling in the full agent
  * package.
  */
+
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -255,14 +257,98 @@ export function loadElizaConfig(): Record<string, unknown> {
   return {};
 }
 
-export function loadOwnerContactsConfig(): Record<string, unknown> {
-  return {};
+function readTestElizaConfig(): Record<string, unknown> {
+  const configPath = process.env.ELIZA_CONFIG_PATH?.trim();
+  if (!configPath) return {};
+  try {
+    return JSON.parse(fs.readFileSync(configPath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+  } catch {
+    return {};
+  }
 }
 
-export async function loadOwnerContactRoutingHints(): Promise<
-  Record<string, unknown>
+export function loadOwnerContactsConfig(): Record<
+  string,
+  { entityId?: string; channelId?: string; roomId?: string }
 > {
-  return {};
+  const config = readTestElizaConfig();
+  const agents = config.agents as
+    | { defaults?: { ownerContacts?: Record<string, unknown> } }
+    | undefined;
+  return (agents?.defaults?.ownerContacts ?? {}) as Record<
+    string,
+    { entityId?: string; channelId?: string; roomId?: string }
+  >;
+}
+
+export async function loadOwnerContactRoutingHints(
+  _runtime: unknown,
+  ownerContacts: Record<
+    string,
+    { entityId?: string; channelId?: string; roomId?: string }
+  >,
+): Promise<Record<string, unknown>> {
+  return Object.fromEntries(
+    Object.entries(ownerContacts).map(([source, contact]) => [
+      source,
+      {
+        source,
+        entityId: contact.entityId ?? null,
+        channelId: contact.channelId ?? null,
+        roomId: contact.roomId ?? null,
+        preferredCommunicationChannel: null,
+        platformIdentities: [],
+        lastResponseAt: null,
+        lastResponseChannel: null,
+        resolvedFrom: "config",
+      },
+    ]),
+  );
+}
+
+export function resolveOwnerContactWithFallback(args: {
+  ownerContacts: Record<
+    string,
+    { entityId?: string; channelId?: string; roomId?: string }
+  >;
+  source: string | null | undefined;
+  ownerEntityId: string | null | undefined;
+}): {
+  source: string;
+  contact: { entityId?: string; channelId?: string; roomId?: string };
+  resolvedFrom: "config" | "owner_entity";
+} | null {
+  const source = typeof args.source === "string" ? args.source.trim() : "";
+  const candidates =
+    source === "telegram"
+      ? ["telegram", "telegram-account", "telegramAccount"]
+      : source === "telegram-account"
+        ? ["telegram-account", "telegramAccount", "telegram"]
+        : source
+          ? [source]
+          : [];
+  for (const candidate of candidates) {
+    const contact = args.ownerContacts[candidate];
+    if (contact) {
+      return {
+        source:
+          candidate === "telegramAccount" ? "telegram-account" : candidate,
+        contact,
+        resolvedFrom: "config",
+      };
+    }
+  }
+  if (source === "discord" && args.ownerEntityId) {
+    return {
+      source,
+      contact: { entityId: args.ownerEntityId },
+      resolvedFrom: "owner_entity",
+    };
+  }
+  return null;
 }
 
 export function saveElizaConfig(): void {}


### PR DESCRIPTION
## Summary
- Resolve bare scheduled-task connector targets like `telegram` through configured owner contact routing before dispatch.
- Return a typed `disconnected` `DispatchResult` when no owner channel can be resolved, instead of sending to the literal connector key.
- Extend the PA delivery tests and agent test stub so proactive channel dispatch proves owner contact config routing and preserves composed owner-facing copy instead of raw task instructions.

Fixes #14708

## Verification
- `bun run --cwd plugins/plugin-personal-assistant test test/sensitive-request-delivery.test.ts` — passed, 10 tests.
- `git diff --check` — passed.
- `bun run audit:error-policy-ratchet --report` — passed; touched production file stayed at emptyCatch 0->0 and serverConsole 0->0.
- `bun run --cwd plugins/plugin-personal-assistant typecheck` — fails on existing package baseline: missing sibling plugin declaration modules such as `@elizaos/plugin-blocker`, `@elizaos/plugin-calendar`, `@elizaos/plugin-finances`, `@elizaos/plugin-health`, `@elizaos/plugin-inbox`, `@elizaos/plugin-scheduling`, plus pre-existing strictness/export errors outside this diff.

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - backend scheduler dispatch wiring and deterministic tests only; no UI surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - backend scheduler dispatch wiring and deterministic tests only; no UI surface changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no user-facing UI flow changed; behavior is connector dispatch routing covered by focused tests`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no long-running backend was started; deterministic Vitest output above is the relevant execution evidence for the dispatcher`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend or network surface changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no prompt/model/action behavior changed; the scheduler dispatcher resolves connector targets before send`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no persistent domain artifact is produced; the test creates a temporary `eliza.json` ownerContacts config and asserts the connector payload target is the resolved owner channel id`.
