### PR TITLE
feat(app): add seeded live visual-QA sweep

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -26,6 +26,7 @@
     "test:e2e:walkthrough:android": "node scripts/walkthrough-e2e.mjs --platform android",
     "test:e2e:walkthrough:device": "node scripts/walkthrough-e2e.mjs --platform device",
     "audit:app": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts --project=audit-app",
+    "audit:live": "node scripts/visual-qa-live.mjs",
     "audit:cloud": "VITE_PLAYWRIGHT_TEST_AUTH=true node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts --project=audit-cloud",
     "audit:app:minimalism:update": "bun scripts/update-minimalism-baseline.mjs",
     "mvp:visual-verify": "node scripts/mvp-visual-verify.mjs",

--- a/packages/app/scripts/visual-qa-live.mjs
+++ b/packages/app/scripts/visual-qa-live.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+/**
+ * Live visual-QA sweep against a running dashboard dev server. Complements the
+ * heavier `audit:app` (which prebuilds every plugin-view bundle and walks the
+ * full route matrix): this tool points a headless Chromium at an *already
+ * running* server, captures a small matrix of the states that actually matter
+ * for the MVP — the pre-auth onboarding gate, the keyboard-adjacent mobile
+ * composer, and (by seeding a session) the post-onboarding shell + its designed
+ * error render — and runs each capture through the repo's own `visual-qa.mjs`
+ * analyzer (OCR + dominant palette + brand-colour fractions). One report.json +
+ * a terminal summary come out; `--strict` turns the brand-colour invariant
+ * ("no blue", elizaOS orange is accent-only) into a non-zero exit so a lane can
+ * gate on it.
+ *
+ * Why seeding: onboarding gates every route behind "Sign in to Eliza Cloud",
+ * so a fresh browser only ever sees the gate. Injecting the canonical
+ * `steward_session_token` + `eliza:first-run-complete=1` into an *isolated*
+ * Playwright context (its own localStorage — it never touches the running
+ * server's state or other users) lets the sweep reach the post-onboarding shell
+ * and, when no backend is reachable, the designed failure state — which is the
+ * three-state-rule render worth verifying (see #14415).
+ *
+ * Consumed by: an operator or coding agent doing a fast pre-PR visual pass
+ * without the multi-minute `audit:app` prebuild. Not a CI gate unless a lane
+ * opts in with `--strict`.
+ *
+ * Usage:
+ *   node scripts/visual-qa-live.mjs --base http://127.0.0.1:2138 [--out DIR] [--strict]
+ */
+import { chromium } from "@playwright/test";
+import { analyzeScreenshot } from "./lib/visual-qa.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Mirrors the canonical Steward seed contract in
+// `test/ui-smoke/helpers/test-auth.ts` (STEWARD_SESSION_TOKEN_KEY + the
+// alg:none/exp:4102444800 JWT shape) and the first-run flag written by
+// `state/persistence.ts` (`"1"`). Playwright specs import that helper directly;
+// this is a standalone node script and cannot import the .ts helper at runtime,
+// so the shape is duplicated here on purpose — keep the two in sync.
+export const STEWARD_SESSION_TOKEN_KEY = "steward_session_token";
+export const FIRST_RUN_COMPLETE_KEY = "eliza:first-run-complete";
+
+/** base64url without padding — matches the renderer's test-auth JWT shape. */
+function base64Url(input) {
+  return Buffer.from(input, "utf8")
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/**
+ * An unsigned-but-decodable Steward JWT plus the first-run-complete flag. The
+ * token is decodable (renderer reads its claims) but unsigned, so it never
+ * passes real API auth — which is exactly why the seeded sweep surfaces the
+ * designed "backend unreachable" error state rather than live data.
+ */
+export function buildOnboardedSeed({ subject = "visual-qa-user" } = {}) {
+  const header = base64Url(JSON.stringify({ alg: "none", typ: "JWT" }));
+  const payload = base64Url(
+    JSON.stringify({
+      sub: subject,
+      userId: subject,
+      email: "visual-qa@example.test",
+      exp: 4102444800, // 2100-01-01 — never triggers a refresh mid-sweep.
+    }),
+  );
+  return {
+    [STEWARD_SESSION_TOKEN_KEY]: `${header}.${payload}.unsigned`,
+    [FIRST_RUN_COMPLETE_KEY]: "1",
+  };
+}
+
+/**
+ * The state matrix. Each entry is one capture: a viewport, a seed profile
+ * (fresh = onboarding gate, onboarded = seeded shell), a route, and an optional
+ * `focusComposer` step to exercise the keyboard-adjacent mobile layout.
+ */
+export const VIEWPORTS = {
+  desktop: { width: 1280, height: 800, isMobile: false, hasTouch: false },
+  mobile: { width: 390, height: 844, isMobile: true, hasTouch: true },
+};
+
+export function buildStateMatrix() {
+  const states = [];
+  for (const [vpName, vp] of Object.entries(VIEWPORTS)) {
+    states.push({
+      id: `${vpName}-onboarding`,
+      viewport: vpName,
+      seed: "fresh",
+      route: "/",
+    });
+    states.push({
+      id: `${vpName}-shell`,
+      viewport: vpName,
+      seed: "onboarded",
+      route: "/views",
+    });
+    states.push({
+      id: `${vpName}-chat`,
+      viewport: vpName,
+      seed: "onboarded",
+      route: "/chat",
+    });
+    if (vp.isMobile) {
+      states.push({
+        id: `${vpName}-composer-focused`,
+        viewport: vpName,
+        seed: "fresh",
+        route: "/",
+        focusComposer: true,
+      });
+    }
+  }
+  return states;
+}
+
+/**
+ * Fold per-capture analyzer reports into a pass/fail. The brand invariant is
+ * the only hard gate: blue must stay under the ceiling on every state (elizaOS
+ * ships zero blue; orange is accent-only). Returns the failing state ids so the
+ * caller can report *which* screen broke, not just that something did.
+ */
+export function aggregateVerdict(reports, { blueCeiling = 0.02 } = {}) {
+  const offenders = reports
+    .filter((r) => (r.color_fractions?.blue_fraction ?? 0) > blueCeiling)
+    .map((r) => ({
+      id: r.id,
+      blue: r.color_fractions?.blue_fraction ?? 0,
+    }));
+  return { pass: offenders.length === 0, offenders, blueCeiling };
+}
+
+async function focusAndType(page) {
+  const box = page
+    .locator('textarea, [contenteditable="true"], input[type="text"]')
+    .first();
+  await box.click({ timeout: 4000 });
+  await box.type("remind me to call the pharmacy before 5", { delay: 8 });
+  await page.waitForTimeout(600);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const opt = (flag, dflt) => {
+    const i = args.indexOf(flag);
+    return i >= 0 && args[i + 1] ? args[i + 1] : dflt;
+  };
+  const base = opt("--base", "http://127.0.0.1:2138");
+  const outDir = opt(
+    "--out",
+    path.join(
+      __dirname,
+      "..",
+      "test",
+      "ui-smoke",
+      "output",
+      "visual-qa-live-output",
+    ),
+  );
+  const strict = args.includes("--strict");
+  mkdirSync(outDir, { recursive: true });
+
+  const onboardedSeed = buildOnboardedSeed();
+  const matrix = buildStateMatrix();
+  const browser = await chromium.launch();
+  const reports = [];
+
+  try {
+    for (const state of matrix) {
+      const vp = VIEWPORTS[state.viewport];
+      const ctx = await browser.newContext({
+        viewport: { width: vp.width, height: vp.height },
+        isMobile: vp.isMobile,
+        hasTouch: vp.hasTouch,
+        deviceScaleFactor: 2,
+      });
+      try {
+        if (state.seed === "onboarded") {
+          await ctx.addInitScript((seed) => {
+            for (const [k, v] of Object.entries(seed))
+              window.localStorage.setItem(k, v);
+          }, onboardedSeed);
+        }
+        const page = await ctx.newPage();
+        const url = new URL(state.route, base).toString();
+        await page.goto(url, { waitUntil: "domcontentloaded", timeout: 20000 });
+        await page.waitForTimeout(1500);
+        if (state.focusComposer) await focusAndType(page);
+
+        const file = path.join(outDir, `${state.id}.png`);
+        await page.screenshot({ path: file });
+        const report = await analyzeScreenshot(file, {});
+        const entry = {
+          id: state.id,
+          route: state.route,
+          seed: state.seed,
+          image: file,
+          size: report.size,
+          dominant_palette: report.dominant_palette,
+          color_fractions: report.color_fractions,
+          ocr_text: (report.ocr_text || "")
+            .replace(/\s+/g, " ")
+            .trim()
+            .slice(0, 240),
+        };
+        reports.push(entry);
+        const blue = (entry.color_fractions?.blue_fraction ?? 0).toFixed(3);
+        console.log(
+          `■ ${state.id.padEnd(26)} blue=${blue}  ${entry.ocr_text.slice(0, 70)}`,
+        );
+      } finally {
+        await ctx.close();
+      }
+    }
+  } finally {
+    await browser.close();
+  }
+
+  const verdict = aggregateVerdict(reports);
+  writeFileSync(
+    path.join(outDir, "report.json"),
+    JSON.stringify({ base, verdict, reports }, null, 2),
+  );
+  console.log(
+    `\n${verdict.pass ? "PASS" : "FAIL"} — no-blue invariant (ceiling ${verdict.blueCeiling}); ${reports.length} states → ${outDir}/report.json`,
+  );
+  if (verdict.offenders.length)
+    console.log(
+      `  offenders: ${verdict.offenders.map((o) => `${o.id}=${o.blue.toFixed(3)}`).join(", ")}`,
+    );
+
+  if (strict && !verdict.pass) process.exit(1);
+}
+
+// Only run when invoked directly, so the pure helpers stay importable by tests.
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  await main();
+}

--- a/packages/app/scripts/visual-qa-live.mjs
+++ b/packages/app/scripts/visual-qa-live.mjs
@@ -31,7 +31,7 @@ import { fileURLToPath } from "node:url";
  *   node scripts/visual-qa-live.mjs --base http://127.0.0.1:2138 [--out DIR] [--strict]
  */
 import { chromium } from "@playwright/test";
-import { analyzeScreenshot } from "./lib/visual-qa.mjs";
+import { analyzeScreenshot, changeMetric } from "./lib/visual-qa.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -126,23 +126,55 @@ export function buildCaptureUrl(base, route) {
 /**
  * Fold per-capture analyzer reports into a pass/fail. The brand invariant is
  * the only hard gate: blue must stay under the ceiling on every state (elizaOS
- * ships zero blue; orange is accent-only). Returns the failing state ids so the
+ * ships zero blue; orange is accent-only). A capture with no measured
+ * `blue_fraction` is a broken analyzer run, not a clean screen — it fails
+ * closed (never read "unmeasured" as 0). Returns the failing state ids so the
  * caller can report *which* screen broke, not just that something did.
  */
 export function aggregateVerdict(reports, { blueCeiling = 0.02 } = {}) {
-  const offenders = reports
-    .filter((r) => (r.color_fractions?.blue_fraction ?? 0) > blueCeiling)
-    .map((r) => ({
-      id: r.id,
-      blue: r.color_fractions?.blue_fraction ?? 0,
-    }));
+  const offenders = [];
+  for (const r of reports) {
+    const blue = r.color_fractions?.blue_fraction;
+    if (!Number.isFinite(blue)) {
+      offenders.push({
+        id: r.id,
+        blue: null,
+        reason: "blue_fraction not measured",
+      });
+    } else if (blue > blueCeiling) {
+      offenders.push({
+        id: r.id,
+        blue,
+        reason: `blue over ceiling ${blueCeiling}`,
+      });
+    }
+  }
   return { pass: offenders.length === 0, offenders, blueCeiling };
 }
 
+/**
+ * Seed-vacuity gate: if the onboarded-seed contract drifts (renamed key, new
+ * gate), every "seeded" capture silently re-renders the onboarding gate and
+ * the sweep passes on the wrong pixels. Requiring the gate and the seeded
+ * shell to differ materially per viewport turns that silent drift into a hard
+ * failure. `deltas` is `[{ viewport, changedFraction }]` from `changeMetric`.
+ */
+export function seedDriftOffenders(deltas, { minChangedFraction = 0.02 } = {}) {
+  return deltas
+    .filter((d) => !(d.changedFraction > minChangedFraction))
+    .map((d) => ({ viewport: d.viewport, changedFraction: d.changedFraction }));
+}
+
 async function focusAndType(page) {
-  const box = page
-    .locator('textarea, [contenteditable="true"], input[type="text"]')
-    .first();
+  // Prefer the canonical chat composer; the generic fallback keeps the capture
+  // meaningful on gates that render a plain input. No match fails the sweep —
+  // a keyboard-adjacent capture without a focused field proves nothing.
+  const composer = page.locator('[data-testid="chat-composer-textarea"]');
+  const box = (await composer.count())
+    ? composer.first()
+    : page
+        .locator('textarea, [contenteditable="true"], input[type="text"]')
+        .first();
   await box.click({ timeout: 4000 });
   await box.type("remind me to call the pharmacy before 5", { delay: 8 });
   await page.waitForTimeout(600);
@@ -210,6 +242,9 @@ async function main() {
         }
         await page
           .waitForLoadState("networkidle", { timeout: 5000 })
+          // error-policy:J6 best-effort settle — SPAs holding long-poll/WS
+          // connections never reach networkidle; the fixed wait below is the
+          // real settle gate and the screenshot still fails loudly on its own.
           .catch(() => {});
         await page.waitForTimeout(1500);
         if (state.focusComposer) await focusAndType(page);
@@ -231,7 +266,10 @@ async function main() {
             .slice(0, 240),
         };
         reports.push(entry);
-        const blue = (entry.color_fractions?.blue_fraction ?? 0).toFixed(3);
+        const measured = entry.color_fractions?.blue_fraction;
+        const blue = Number.isFinite(measured)
+          ? measured.toFixed(3)
+          : "unmeasured";
         console.log(
           `■ ${state.id.padEnd(26)} blue=${blue}  ${entry.ocr_text.slice(0, 70)}`,
         );
@@ -243,17 +281,41 @@ async function main() {
     await browser.close();
   }
 
+  const seedDeltas = [];
+  for (const vpName of Object.keys(VIEWPORTS)) {
+    const gate = reports.find((r) => r.id === `${vpName}-onboarding`);
+    const shell = reports.find((r) => r.id === `${vpName}-shell`);
+    if (!gate || !shell) continue;
+    const delta = await changeMetric(shell.image, gate.image);
+    seedDeltas.push({
+      viewport: vpName,
+      changedFraction: delta.changed_fraction,
+    });
+  }
+  const driftOffenders = seedDriftOffenders(seedDeltas);
+  if (driftOffenders.length) {
+    throw new Error(
+      `Onboarded seed did not take effect — seeded shell renders the onboarding gate's pixels: ${driftOffenders
+        .map((o) => `${o.viewport} (changed_fraction=${o.changedFraction})`)
+        .join(", ")}`,
+    );
+  }
+
   const verdict = aggregateVerdict(reports);
   writeFileSync(
     path.join(outDir, "report.json"),
-    JSON.stringify({ base, verdict, reports }, null, 2),
+    JSON.stringify({ base, verdict, seedDeltas, reports }, null, 2),
   );
   console.log(
     `\n${verdict.pass ? "PASS" : "FAIL"} — no-blue invariant (ceiling ${verdict.blueCeiling}); ${reports.length} states → ${outDir}/report.json`,
   );
   if (verdict.offenders.length)
     console.log(
-      `  offenders: ${verdict.offenders.map((o) => `${o.id}=${o.blue.toFixed(3)}`).join(", ")}`,
+      `  offenders: ${verdict.offenders
+        .map(
+          (o) => `${o.id}=${o.blue == null ? "unmeasured" : o.blue.toFixed(3)}`,
+        )
+        .join(", ")}`,
     );
 
   if (strict && !verdict.pass) process.exit(1);

--- a/packages/app/scripts/visual-qa-live.mjs
+++ b/packages/app/scripts/visual-qa-live.mjs
@@ -119,6 +119,10 @@ export function buildStateMatrix() {
   return states;
 }
 
+export function buildCaptureUrl(base, route) {
+  return new URL(route, base.endsWith("/") ? base : `${base}/`).toString();
+}
+
 /**
  * Fold per-capture analyzer reports into a pass/fail. The brand invariant is
  * the only hard gate: blue must stay under the ceiling on every state (elizaOS
@@ -187,8 +191,26 @@ async function main() {
           }, onboardedSeed);
         }
         const page = await ctx.newPage();
-        const url = new URL(state.route, base).toString();
-        await page.goto(url, { waitUntil: "domcontentloaded", timeout: 20000 });
+        const targetUrl = buildCaptureUrl(base, state.route);
+        let response;
+        try {
+          response = await page.goto(targetUrl, {
+            waitUntil: "domcontentloaded",
+            timeout: 20000,
+          });
+        } catch (error) {
+          throw new Error(
+            `Failed to load ${state.id} at ${targetUrl}: ${error?.message ?? error}`,
+          );
+        }
+        if (!response?.ok()) {
+          throw new Error(
+            `Failed to load ${state.id} at ${targetUrl}: HTTP ${response?.status() ?? "unknown"}`,
+          );
+        }
+        await page
+          .waitForLoadState("networkidle", { timeout: 5000 })
+          .catch(() => {});
         await page.waitForTimeout(1500);
         if (state.focusComposer) await focusAndType(page);
 

--- a/packages/app/scripts/visual-qa-live.test.mjs
+++ b/packages/app/scripts/visual-qa-live.test.mjs
@@ -8,6 +8,7 @@
 import { describe, expect, it } from "vitest";
 import {
   aggregateVerdict,
+  buildCaptureUrl,
   buildOnboardedSeed,
   buildStateMatrix,
   FIRST_RUN_COMPLETE_KEY,
@@ -57,6 +58,17 @@ describe("buildStateMatrix", () => {
   it("gives every state a unique id", () => {
     const ids = matrix.map((s) => s.id);
     expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("buildCaptureUrl", () => {
+  it("joins routes against a base with or without a trailing slash", () => {
+    expect(buildCaptureUrl("http://127.0.0.1:2138", "/views")).toBe(
+      "http://127.0.0.1:2138/views",
+    );
+    expect(buildCaptureUrl("http://127.0.0.1:2138/", "/chat")).toBe(
+      "http://127.0.0.1:2138/chat",
+    );
   });
 });
 

--- a/packages/app/scripts/visual-qa-live.test.mjs
+++ b/packages/app/scripts/visual-qa-live.test.mjs
@@ -1,0 +1,83 @@
+/**
+ * Unit coverage for the pure logic of the live visual-QA sweep: the seed the
+ * renderer reads to skip onboarding, the state matrix, and the no-blue verdict
+ * fold. The capture/analyze shell is not exercised here (it needs a running
+ * server + Chromium); these are the decision functions a broken change would
+ * silently corrupt.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  aggregateVerdict,
+  buildOnboardedSeed,
+  buildStateMatrix,
+  FIRST_RUN_COMPLETE_KEY,
+  STEWARD_SESSION_TOKEN_KEY,
+} from "./visual-qa-live.mjs";
+
+describe("buildOnboardedSeed", () => {
+  it("sets both keys the renderer gates on and a decodable-but-unsigned JWT", () => {
+    const seed = buildOnboardedSeed();
+    expect(seed[FIRST_RUN_COMPLETE_KEY]).toBe("1");
+    const token = seed[STEWARD_SESSION_TOKEN_KEY];
+    const [header, payload, sig] = token.split(".");
+    expect(sig).toBe("unsigned"); // never passes real API auth — surfaces the error state
+    const claims = JSON.parse(Buffer.from(payload, "base64").toString("utf8"));
+    expect(claims.sub).toBe("visual-qa-user");
+    expect(JSON.parse(Buffer.from(header, "base64").toString("utf8")).alg).toBe(
+      "none",
+    );
+  });
+
+  it("honours a custom subject", () => {
+    const token = buildOnboardedSeed({ subject: "elderly-dot" })[
+      STEWARD_SESSION_TOKEN_KEY
+    ];
+    const claims = JSON.parse(
+      Buffer.from(token.split(".")[1], "base64").toString("utf8"),
+    );
+    expect(claims.sub).toBe("elderly-dot");
+  });
+});
+
+describe("buildStateMatrix", () => {
+  const matrix = buildStateMatrix();
+  it("covers both viewports with fresh (gate) and onboarded (shell) profiles", () => {
+    expect(
+      matrix.some((s) => s.id === "desktop-onboarding" && s.seed === "fresh"),
+    ).toBe(true);
+    expect(
+      matrix.some((s) => s.id === "mobile-shell" && s.seed === "onboarded"),
+    ).toBe(true);
+  });
+  it("only exercises the keyboard-adjacent composer on mobile", () => {
+    const focused = matrix.filter((s) => s.focusComposer);
+    expect(focused).toHaveLength(1);
+    expect(focused[0].viewport).toBe("mobile");
+  });
+  it("gives every state a unique id", () => {
+    const ids = matrix.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("aggregateVerdict", () => {
+  it("passes when every state is under the blue ceiling", () => {
+    const v = aggregateVerdict([
+      { id: "a", color_fractions: { blue_fraction: 0 } },
+      { id: "b", color_fractions: { blue_fraction: 0.01 } },
+    ]);
+    expect(v.pass).toBe(true);
+    expect(v.offenders).toEqual([]);
+  });
+  it("fails and names the offending state when blue exceeds the ceiling", () => {
+    const v = aggregateVerdict([
+      { id: "clean", color_fractions: { blue_fraction: 0.0 } },
+      { id: "bluish", color_fractions: { blue_fraction: 0.15 } },
+    ]);
+    expect(v.pass).toBe(false);
+    expect(v.offenders.map((o) => o.id)).toEqual(["bluish"]);
+  });
+  it("treats a missing color_fractions as zero blue (no false failure)", () => {
+    expect(aggregateVerdict([{ id: "x" }]).pass).toBe(true);
+  });
+});

--- a/packages/app/scripts/visual-qa-live.test.mjs
+++ b/packages/app/scripts/visual-qa-live.test.mjs
@@ -13,6 +13,7 @@ import {
   buildStateMatrix,
   FIRST_RUN_COMPLETE_KEY,
   STEWARD_SESSION_TOKEN_KEY,
+  seedDriftOffenders,
 } from "./visual-qa-live.mjs";
 
 describe("buildOnboardedSeed", () => {
@@ -89,7 +90,34 @@ describe("aggregateVerdict", () => {
     expect(v.pass).toBe(false);
     expect(v.offenders.map((o) => o.id)).toEqual(["bluish"]);
   });
-  it("treats a missing color_fractions as zero blue (no false failure)", () => {
-    expect(aggregateVerdict([{ id: "x" }]).pass).toBe(true);
+  it("fails closed when a capture has no measured blue fraction", () => {
+    const v = aggregateVerdict([{ id: "x" }]);
+    expect(v.pass).toBe(false);
+    expect(v.offenders).toEqual([
+      { id: "x", blue: null, reason: "blue_fraction not measured" },
+    ]);
+  });
+});
+
+describe("seedDriftOffenders", () => {
+  it("passes when the seeded shell differs materially from the gate", () => {
+    expect(
+      seedDriftOffenders([
+        { viewport: "desktop", changedFraction: 0.41 },
+        { viewport: "mobile", changedFraction: 0.35 },
+      ]),
+    ).toEqual([]);
+  });
+  it("flags a viewport whose seeded shell re-rendered the gate", () => {
+    const offenders = seedDriftOffenders([
+      { viewport: "desktop", changedFraction: 0.41 },
+      { viewport: "mobile", changedFraction: 0.001 },
+    ]);
+    expect(offenders).toEqual([{ viewport: "mobile", changedFraction: 0.001 }]);
+  });
+  it("treats an unmeasured delta as drift, never as a pass", () => {
+    expect(seedDriftOffenders([{ viewport: "desktop" }])).toEqual([
+      { viewport: "desktop", changedFraction: undefined },
+    ]);
   });
 });


### PR DESCRIPTION
# Relates to

- Follow-up visual evidence tooling for #14415.

Definition of Done: full standard in [`PR_EVIDENCE.md`](../PR_EVIDENCE.md).

- [x] This PR targets `develop` and is rebased onto `origin/develop` with zero conflicts.
- [ ] `bun install` and `bun run verify` were not run; focused verification is listed below.
- [x] A reviewer can confirm the change works from the command output and generated report summary below.

# Sync with develop

- [x] Rebased onto current `origin/develop`; PR is mergeable after the rebase.
- [ ] `bun run verify` not run because this is a narrow app-script change; focused checks and a live run are listed below.

# Risks

Low. This adds a local operator/audit script and package script only. It does not change shipped runtime UI behavior. Main risks are false positives/false negatives in the visual harness, addressed by unit coverage and a strict live run.

# Background

## What does this PR do?

Adds `bun run --cwd packages/app audit:live`, a lightweight visual-QA sweep that points Playwright at an already-running app dev server and captures the states that matter for the MVP:

- fresh onboarding gate on desktop and mobile
- seeded post-onboarding shell and chat routes
- designed backend-unreachable error render when no backend is available
- mobile keyboard-adjacent composer state with typed text

The sweep writes screenshots plus `report.json`, runs each capture through the repo's `visual-qa.mjs` analyzer, and lets `--strict` fail on the no-blue brand invariant.

Review fixes included in this update:

- Preserved the newer branch behavior that writes default output under the existing ignored `test/ui-smoke/output/visual-qa-live-output/` tree, so no `.gitignore` change is needed.
- Kept the no-blue gate on `color_fractions.blue_fraction`, which is the field emitted by `visual-qa.mjs`.
- Made navigation fail closed on page load errors and non-OK HTTP responses.
- Made mobile composer focus/type failures fail the capture instead of silently passing.
- Added a pure URL-join helper and unit coverage for it.

## What kind of change is this?

Improvements: local visual-audit tooling for the app package.

# Documentation changes needed?

No project documentation change required. The script has usage notes in its file header and is exposed through `packages/app/package.json`.

# Testing

## Where should a reviewer start?

Start with `packages/app/scripts/visual-qa-live.mjs`, then `packages/app/scripts/visual-qa-live.test.mjs` for the pure decision logic.

## Detailed testing steps

```bash
bunx @biomejs/biome check packages/app/scripts/visual-qa-live.mjs packages/app/scripts/visual-qa-live.test.mjs packages/app/package.json
node --check packages/app/scripts/visual-qa-live.mjs packages/app/scripts/visual-qa-live.test.mjs
bunx vitest run packages/app/scripts/visual-qa-live.test.mjs
git diff --check
```

Result:

```text
Checked 3 files in 99ms. No fixes applied.
Test Files  1 passed (1)
Tests       9 passed (9)
```

Live run:

```bash
ELIZA_UI_PORT=42138 bun run --cwd packages/app dev
bun run --cwd packages/app audit:live -- --base http://127.0.0.1:42138 --out /tmp/eliza-pr14818-visual-qa-live-a5 --strict
```

Result:

```text
■ desktop-onboarding         blue=0.000
■ desktop-shell              blue=0.003
■ desktop-chat               blue=0.000
■ mobile-onboarding          blue=0.000
■ mobile-shell               blue=0.000
■ mobile-chat                blue=0.000
■ mobile-composer-focused    blue=0.000

PASS - no-blue invariant (ceiling 0.02); 7 states -> /tmp/eliza-pr14818-visual-qa-live-a5/report.json
```

# Evidence Gate

Any change testable on the frontend is not mergeable without a video walkthrough, before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - this PR does not change a product UI surface; it adds a harness that captures existing surfaces.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - no product UI surface changed; generated local verification screenshots are listed below but are not committed to the repo.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - CLI audit harness, no user-facing click-through flow changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no backend code path changed; the seeded states intentionally render the backend-unreachable UI when no API is running.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: N/A - no frontend runtime code changed; expected local dev-server warnings from the harness run are summarized below.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - generated local report and screenshots are intentionally gitignored; exact verification output is summarized below.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changed.

## Backend + frontend logs

Backend logs: N/A - no backend was started for this lane. That is intentional because the seeded post-onboarding states should surface the designed `Backend Unreachable` UI.

Frontend/dev-server log summary from the live run:

```text
VITE v8.0.16 ready on http://localhost:42138/
http proxy error: /api/apps, /api/plugins, /api/conversations, /api/local-inference/*
[usePluginsSkillsState] failed to load plugins (error=API server unavailable)
[useSlashCommandController] Failed to load the slash-command catalog; slash menu will be empty
```

These warnings match the expected no-backend verification mode and the screenshot report still passed the strict no-blue invariant.

## Screenshots (before / after) + video walkthrough

### Before

N/A - no product UI surface changed.

### After

Generated locally by the live run:

```text
/tmp/eliza-pr14818-visual-qa-live-a5/desktop-onboarding.png
/tmp/eliza-pr14818-visual-qa-live-a5/desktop-shell.png
/tmp/eliza-pr14818-visual-qa-live-a5/desktop-chat.png
/tmp/eliza-pr14818-visual-qa-live-a5/mobile-onboarding.png
/tmp/eliza-pr14818-visual-qa-live-a5/mobile-shell.png
/tmp/eliza-pr14818-visual-qa-live-a5/mobile-chat.png
/tmp/eliza-pr14818-visual-qa-live-a5/mobile-composer-focused.png
/tmp/eliza-pr14818-visual-qa-live-a5/report.json
```

### Walkthrough video

N/A - CLI audit harness, no interactive product flow changed.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, or STT changes.

## Known gaps / failures

- Full `bun run verify` was not run; focused checks and one strict live run were run instead.
- Port `2138` was already in use locally, so the live run used `ELIZA_UI_PORT=42138` and passed `--base http://127.0.0.1:42138`.
- The fresh worktree lacked local workspace dist artifacts for config-time app startup. Built `@elizaos/shared`, `@elizaos/cloud-routing`, and runtime artifacts for `@elizaos/core` to start Vite. The worktree remained clean afterward; generated `dist/` outputs are ignored.
