### PR TITLE
test(#14369): ratchet builtin view action coverage

### DIFF
--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -289,6 +289,12 @@ This package mostly reads config injected by the host, not raw env vars:
 - `ConnectionStatus` exists twice (cloud-ui string union vs. the composite
   component) — the cloud-ui one is intentionally NOT re-exported from the root
   barrel to avoid the collision (see comment in `index.ts`).
+- **Builtin view mutations need semantic action twins.** First-party shell views
+  are covered by `src/testing/builtin-view-action-ratchet.ts`: every local
+  mutation site in the baseline either maps to a semantic action (`SETTINGS`,
+  `SCHEDULED_TASKS`, `BACKGROUND`, etc.) or is explicitly exempt as a diagnostic
+  view. When adding a button/filter/toggle/form handler to a builtin view, add or
+  reuse the action first, then update the ratchet baseline with the reason.
 - Type root `src/types/index.ts` re-exports from `@elizaos/shared/types`; keep
   shared transport/domain types there rather than redefining them here.
 - **Files / attachments.** The "Files" tab (`components/pages/FilesView.tsx`,

--- a/packages/ui/CLAUDE.md
+++ b/packages/ui/CLAUDE.md
@@ -289,6 +289,12 @@ This package mostly reads config injected by the host, not raw env vars:
 - `ConnectionStatus` exists twice (cloud-ui string union vs. the composite
   component) — the cloud-ui one is intentionally NOT re-exported from the root
   barrel to avoid the collision (see comment in `index.ts`).
+- **Builtin view mutations need semantic action twins.** First-party shell views
+  are covered by `src/testing/builtin-view-action-ratchet.ts`: every local
+  mutation site in the baseline either maps to a semantic action (`SETTINGS`,
+  `SCHEDULED_TASKS`, `BACKGROUND`, etc.) or is explicitly exempt as a diagnostic
+  view. When adding a button/filter/toggle/form handler to a builtin view, add or
+  reuse the action first, then update the ratchet baseline with the reason.
 - Type root `src/types/index.ts` re-exports from `@elizaos/shared/types`; keep
   shared transport/domain types there rather than redefining them here.
 - **Files / attachments.** The "Files" tab (`components/pages/FilesView.tsx`,

--- a/packages/ui/src/testing/builtin-view-action-ratchet.test.ts
+++ b/packages/ui/src/testing/builtin-view-action-ratchet.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Guards the builtin view mutation ratchet: first-party pages with local
+ * mutation controls must have semantic action coverage, while diagnostic views
+ * stay explicitly exempt.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  BUILTIN_VIEW_MUTATION_BASELINE,
+  validateBuiltinViewMutationCoverage,
+} from "./builtin-view-action-ratchet";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../../../..");
+
+const REGISTERED_ACTIONS = new Set([
+  "APP",
+  "BACKGROUND",
+  "CHARACTER",
+  "CONNECTOR",
+  "CREDENTIALS",
+  "MODEL_SWITCH",
+  "RUNTIME",
+  "SCHEDULED_TASKS",
+  "SETTINGS",
+  "VIEW_CHARACTER_ADD_MESSAGE_EXAMPLE",
+  "VIEW_CHARACTER_ADD_STYLE_RULE",
+  "VIEW_CHARACTER_FILL_BIO",
+]);
+
+function readRepoSource(sourcePath: string): string {
+  return readFileSync(path.join(repoRoot, sourcePath), "utf8");
+}
+
+describe("builtin view action ratchet (#14369)", () => {
+  it("passes for the current builtin mutation baseline", () => {
+    const result = validateBuiltinViewMutationCoverage({
+      readSource: readRepoSource,
+      registeredActions: REGISTERED_ACTIONS,
+    });
+
+    expect(result.findings).toEqual([]);
+    expect(result.ok).toBe(true);
+    expect(result.coverage).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          viewId: "tasks",
+          semanticActions: ["SCHEDULED_TASKS"],
+        }),
+        expect.objectContaining({
+          viewId: "plugins-page",
+          semanticActions: [
+            "APP",
+            "SETTINGS",
+            "CONNECTOR",
+            "CREDENTIALS",
+            "RUNTIME",
+          ],
+        }),
+        expect.objectContaining({
+          viewId: "logs",
+          exempt: true,
+        }),
+      ]),
+    );
+  });
+
+  it("fails when a builtin view gains an unmapped local mutation", () => {
+    const tasks = BUILTIN_VIEW_MUTATION_BASELINE.find(
+      (entry) => entry.viewId === "tasks",
+    );
+    if (!tasks) throw new Error("tasks baseline entry missing");
+    const sourceWithNewButton = `${readRepoSource(tasks.sourceFiles[0])}
+      export function InjectedLocalOnlyButton() {
+        return <button onClick={() => window.localStorage.setItem("x", "1")}>Local only</button>;
+      }
+    `;
+
+    const result = validateBuiltinViewMutationCoverage({
+      baseline: [tasks],
+      readSource: () => sourceWithNewButton,
+      registeredActions: REGISTERED_ACTIONS,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        viewId: "tasks",
+        code: "new-local-mutation",
+      }),
+    ]);
+  });
+
+  it("fails when a non-exempt builtin mapping references an unregistered action", () => {
+    const result = validateBuiltinViewMutationCoverage({
+      baseline: [
+        {
+          viewId: "synthetic",
+          sourceFiles: ["synthetic.tsx"],
+          semanticActions: ["MISSING_ACTION"],
+          maxMutationSites: 1,
+        },
+      ],
+      readSource: () => "<button onClick={save}>Save</button>",
+      registeredActions: REGISTERED_ACTIONS,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.findings).toEqual([
+      expect.objectContaining({
+        viewId: "synthetic",
+        code: "missing-semantic-action",
+      }),
+    ]);
+  });
+});

--- a/packages/ui/src/testing/builtin-view-action-ratchet.ts
+++ b/packages/ui/src/testing/builtin-view-action-ratchet.ts
@@ -149,7 +149,8 @@ export function validateBuiltinViewMutationCoverage(args: {
   readSource: (path: string) => string | null | undefined;
   registeredActions: ReadonlySet<string>;
 }): BuiltinViewMutationValidationResult {
-  const baseline = args.baseline ?? BUILTIN_VIEW_MUTATION_BASELINE;
+  const baseline: readonly BuiltinViewMutationBaselineEntry[] =
+    args.baseline ?? BUILTIN_VIEW_MUTATION_BASELINE;
   const registeredActions = new Set(
     [...args.registeredActions].map((action) => action.toUpperCase()),
   );

--- a/packages/ui/src/testing/builtin-view-action-ratchet.ts
+++ b/packages/ui/src/testing/builtin-view-action-ratchet.ts
@@ -1,0 +1,214 @@
+/**
+ * Diff-scoped ratchet for the chat-first builtin-view contract.
+ *
+ * Builtin shell views may render buttons, toggles, filters, drag/drop handlers,
+ * and form controls, but a user must be able to drive the same mutation through
+ * a semantic agent action. Third-party plugin views use the generic
+ * agent-surface bridge and are audited elsewhere; this file tracks only the
+ * first-party pages bundled into the shell.
+ */
+
+export interface BuiltinViewMutationBaselineEntry {
+  viewId: string;
+  sourceFiles: readonly string[];
+  semanticActions: readonly string[];
+  maxMutationSites: number;
+  exemptReason?: string;
+  notes?: string;
+}
+
+export interface BuiltinViewMutationFinding {
+  viewId: string;
+  code: "missing-source" | "missing-semantic-action" | "new-local-mutation";
+  message: string;
+}
+
+export interface BuiltinViewMutationCoverage {
+  viewId: string;
+  observedMutationSites: number;
+  maxMutationSites: number;
+  semanticActions: readonly string[];
+  exempt: boolean;
+}
+
+export interface BuiltinViewMutationValidationResult {
+  ok: boolean;
+  coverage: BuiltinViewMutationCoverage[];
+  findings: BuiltinViewMutationFinding[];
+}
+
+export const BUILTIN_VIEW_MUTATION_BASELINE = [
+  {
+    viewId: "tasks",
+    sourceFiles: ["packages/ui/src/components/pages/TasksPageView.tsx"],
+    semanticActions: ["SCHEDULED_TASKS"],
+    maxMutationSites: 0,
+    notes:
+      "Task list filters and row selection are covered by the scheduled-task semantic action.",
+  },
+  {
+    viewId: "plugins-page",
+    sourceFiles: [
+      "packages/ui/src/components/pages/PluginsPageView.tsx",
+      "packages/ui/src/components/pages/PluginsView.tsx",
+      "packages/ui/src/components/pages/PluginCard.tsx",
+      "packages/ui/src/components/pages/PluginConfigForm.tsx",
+    ],
+    semanticActions: ["APP", "SETTINGS", "CONNECTOR", "CREDENTIALS", "RUNTIME"],
+    maxMutationSites: 14,
+    notes:
+      "Plugin enable/config/reorder/setup flows are covered by app/settings/connector/credential/runtime actions; the count ratchets local-only control growth.",
+  },
+  {
+    viewId: "settings",
+    sourceFiles: [
+      "packages/ui/src/components/pages/SettingsView.tsx",
+      "packages/ui/src/components/pages/ConfigPageView.tsx",
+      "packages/ui/src/components/pages/PluginConfigForm.tsx",
+    ],
+    semanticActions: [
+      "SETTINGS",
+      "MODEL_SWITCH",
+      "BACKGROUND",
+      "CHARACTER",
+      "CONNECTOR",
+      "CREDENTIALS",
+    ],
+    maxMutationSites: 18,
+    notes:
+      "Settings sections delegate to SETTINGS or to the dedicated action that owns the section.",
+  },
+  {
+    viewId: "background",
+    sourceFiles: ["packages/ui/src/components/pages/BackgroundView.tsx"],
+    semanticActions: ["BACKGROUND"],
+    maxMutationSites: 0,
+  },
+  {
+    viewId: "character",
+    sourceFiles: [
+      "packages/ui/src/components/character/CharacterEditor.tsx",
+      "packages/ui/src/components/character/CharacterEditorPanels.tsx",
+    ],
+    semanticActions: [
+      "CHARACTER",
+      "VIEW_CHARACTER_FILL_BIO",
+      "VIEW_CHARACTER_ADD_STYLE_RULE",
+      "VIEW_CHARACTER_ADD_MESSAGE_EXAMPLE",
+    ],
+    maxMutationSites: 53,
+  },
+  {
+    viewId: "logs",
+    sourceFiles: ["packages/ui/src/components/pages/LogsView.tsx"],
+    semanticActions: [],
+    maxMutationSites: 10,
+    exemptReason:
+      "read-only diagnostic view; controls are local inspect/filter affordances",
+  },
+  {
+    viewId: "runtime",
+    sourceFiles: ["packages/ui/src/components/pages/RuntimeView.tsx"],
+    semanticActions: [],
+    maxMutationSites: 12,
+    exemptReason: "read-only diagnostic view",
+  },
+  {
+    viewId: "database",
+    sourceFiles: [
+      "packages/ui/src/components/pages/DatabasePageView.tsx",
+      "packages/ui/src/components/pages/DatabaseView.tsx",
+      "packages/ui/src/components/pages/SqlEditorPanel.tsx",
+    ],
+    semanticActions: [],
+    maxMutationSites: 15,
+    exemptReason:
+      "developer diagnostic view; SQL/editor controls are not MVP chat mutations",
+  },
+  {
+    viewId: "trajectories",
+    sourceFiles: [
+      "packages/ui/src/components/pages/TrajectoriesView.tsx",
+      "packages/ui/src/components/pages/TrajectoryDetailView.tsx",
+    ],
+    semanticActions: [],
+    maxMutationSites: 12,
+    exemptReason: "read-only trajectory inspection view",
+  },
+] as const satisfies readonly BuiltinViewMutationBaselineEntry[];
+
+const MUTATION_SITE_RE =
+  /\b(?:onClick|onSubmit|onChange|onCheckedChange|onValueChange|onDragEnd|onDrop|onKeyDown|onPointerDown|onPointerUp)\s*=|\buseAgentElement(?:<[^>]*>)?\(/g;
+
+export function countBuiltinViewMutationSites(source: string): number {
+  return source.match(MUTATION_SITE_RE)?.length ?? 0;
+}
+
+export function validateBuiltinViewMutationCoverage(args: {
+  baseline?: readonly BuiltinViewMutationBaselineEntry[];
+  readSource: (path: string) => string | null | undefined;
+  registeredActions: ReadonlySet<string>;
+}): BuiltinViewMutationValidationResult {
+  const baseline = args.baseline ?? BUILTIN_VIEW_MUTATION_BASELINE;
+  const registeredActions = new Set(
+    [...args.registeredActions].map((action) => action.toUpperCase()),
+  );
+  const findings: BuiltinViewMutationFinding[] = [];
+  const coverage: BuiltinViewMutationCoverage[] = [];
+
+  for (const entry of baseline) {
+    let observedMutationSites = 0;
+    for (const sourceFile of entry.sourceFiles) {
+      const source = args.readSource(sourceFile);
+      if (source == null) {
+        findings.push({
+          viewId: entry.viewId,
+          code: "missing-source",
+          message: `${entry.viewId}: missing source ${sourceFile}`,
+        });
+        continue;
+      }
+      observedMutationSites += countBuiltinViewMutationSites(source);
+    }
+
+    const exempt = Boolean(entry.exemptReason);
+    coverage.push({
+      viewId: entry.viewId,
+      observedMutationSites,
+      maxMutationSites: entry.maxMutationSites,
+      semanticActions: entry.semanticActions,
+      exempt,
+    });
+
+    if (observedMutationSites > entry.maxMutationSites) {
+      findings.push({
+        viewId: entry.viewId,
+        code: "new-local-mutation",
+        message: `${entry.viewId}: observed ${observedMutationSites} mutation sites exceeds baseline ${entry.maxMutationSites}; add a semantic action mapping or deliberately update the baseline`,
+      });
+    }
+
+    if (exempt) continue;
+    for (const action of entry.semanticActions) {
+      if (registeredActions.has(action.toUpperCase())) continue;
+      findings.push({
+        viewId: entry.viewId,
+        code: "missing-semantic-action",
+        message: `${entry.viewId}: semantic action ${action} is not registered in the action catalog used by the ratchet`,
+      });
+    }
+    if (entry.semanticActions.length === 0) {
+      findings.push({
+        viewId: entry.viewId,
+        code: "missing-semantic-action",
+        message: `${entry.viewId}: mutating builtin view is not exempt and declares no semantic action mapping`,
+      });
+    }
+  }
+
+  return {
+    ok: findings.length === 0,
+    coverage,
+    findings,
+  };
+}


### PR DESCRIPTION
## Summary
- Add a builtin-view mutation ratchet for first-party shell pages: each tracked local mutation site must map to semantic actions or carry a diagnostic-view exemption.
- Baseline current mutation-site counts exactly, so newly added local-only handlers fail until the semantic action mapping/baseline is updated intentionally.
- Document the rule in `packages/ui/CLAUDE.md` and mirrored `AGENTS.md`.

Part of #14369.

## Verification
- `bun run --cwd packages/ui test src/testing/builtin-view-action-ratchet.test.ts` — passed, 3 tests.
  - Green path: current baseline has no findings.
  - Red path: injected local-only button on `tasks` returns `new-local-mutation`.
  - Red path: missing semantic action mapping returns `missing-semantic-action`.
- `git diff --check` — passed.
- `bun run audit:error-policy-ratchet --report` — passed; touched production source stayed emptyCatch 0->0 and serverConsole 0->0.
- `cmp -s packages/ui/CLAUDE.md packages/ui/AGENTS.md` — passed.

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - test/documentation-only UI package change; no rendered UI changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - test/documentation-only UI package change; no rendered UI changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no user-facing UI flow changed; this is a static ratchet with focused red/green tests`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no backend runtime involved; focused Vitest output above is the execution evidence`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no browser UI or network surface changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model/action prompt behavior changed; static view/action coverage guard only`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no domain data produced; the artifact is the baseline diff plus red/green test output`.
