### PR TITLE
fix(ios): brand-orange window tint so native system UI stops rendering blue

### DIFF
--- a/packages/app-core/platforms/ios/App/App/AppDelegate.swift
+++ b/packages/app-core/platforms/ios/App/App/AppDelegate.swift
@@ -19,6 +19,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // `devicectl device copy from` — no console required.
         ElizaStartupTrace.bootstrap()
         ElizaHomeIndicator.install()
+
+        // Brand tint on native surfaces the WebView can't reach. elizaOS ships
+        // orange as its single accent and never blue; without an app tint iOS
+        // falls back to system blue for system-presented UIKit — the deep-link
+        // "Open in Eliza?" UIAlertController buttons (verified blue on device),
+        // share sheets, and any default-tinted control. #FF5800 mirrors shared
+        // brand `--eliza-brand-orange`. Appearance proxy covers windows created
+        // later; the direct set covers the Capacitor key window already up.
+        let elizaBrandOrange = UIColor(red: 1.0, green: 0x58 / 255.0, blue: 0.0, alpha: 1.0)
+        UIWindow.appearance().tintColor = elizaBrandOrange
+        window?.tintColor = elizaBrandOrange
+
         UNUserNotificationCenter.current().delegate = self
         BackgroundRunnerPlugin.registerBackgroundTask()
         BackgroundRunnerPlugin.handleApplicationDidFinishLaunching(launchOptions: launchOptions)


### PR DESCRIPTION
## The bug (found by verifying from device, not the web audit)

Launched the installed Eliza app on a **booted iPhone 16 Pro simulator** and captured native states. The deep-link **"Open in 'Eliza'?" UIAlertController renders [Cancel]/[Open] in iOS default blue (#007AFF)** over the brand-orange splash. This is the single place blue appears in the whole experience, and it is **structurally invisible to `audit:app` / the web capture** — it is a native system alert, not WebView UI. (My web sweep measured `blue=0.000` across 19 states precisely because it never sees native system chrome.)

**Root cause:** the iOS app defines no `AccentColor` asset (only `AppIcon`/`Splash` in `Assets.xcassets`) and never sets a window `tintColor`, and the xcodeproj sets no `ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME` — so iOS falls back to system blue for every system-presented / default-tinted UIKit surface (alerts, share sheets, default controls).

## The fix

Set the window + appearance `tintColor` to brand orange (`#FF5800`, = shared `--eliza-brand-orange`) in `AppDelegate.didFinishLaunchingWithOptions`, next to the existing `ElizaHomeIndicator.install()`. Appearance proxy covers later windows; the direct set covers the Capacitor key window already up.

## Evidence
| Evidence | Status |
|---|---|
| **Before (device):** native iOS "Open in Eliza?" alert with blue buttons | ✅ captured on iPhone 16 Pro sim — in the session admin-review artifact |
| Root-cause (no AccentColor asset / no window tint / no build-setting) | ✅ verified in `Assets.xcassets` + `project.pbxproj` |
| **After (device):** same alert with orange buttons | ⚠️ **N/A — needs an iOS rebuild+reinstall.** Owner runs: `bun run --cwd packages/app build:ios:local:sim && bun run --cwd packages/app cap:sync:ios`, reinstall on the sim, re-trigger a deep link, and capture the alert (buttons should be orange). The Swift change is standard UIKit; not build-verified headlessly. |

## Notes
- Touches the canonical iOS template (`packages/app-core/platforms/ios`); `cap sync` materializes it into the gitignored `packages/app/ios`.
- Native-only brand-consistency fix; complements the web no-blue invariant now gated by `audit:live --strict` (#14818).

🤖 Generated with [Claude Code](https://claude.com/claude-code)