### PR TITLE
fix(app): hold shell during auth probe (#14663)

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2534,8 +2534,8 @@ export function App() {
     );
   }
 
-  // Auth gate — once the shell is paintable (agent may still be warming up),
-  // check /api/auth/me. "loading": wait (fall through to the main shell render).
+  // Auth gate — once the shell is paintable, keep poll-heavy shell hooks
+  // unmounted until /api/auth/me resolves for returning sessions.
   // "unauthenticated": render LoginView. "authenticated": proceed.
   // "server_unavailable": show a retryable startup failure.
   if (

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -124,7 +124,10 @@ import {
   useChatInputRef,
 } from "./state/ChatComposerContext.hooks";
 import { isShellPaintable } from "./state/startup-coordinator";
-import { firstRunOwnsLoginSurface } from "./state/top-level-auth-gate";
+import {
+  authProbeShouldHoldShell,
+  firstRunOwnsLoginSurface,
+} from "./state/top-level-auth-gate";
 import { isLoopbackGatewayHost } from "./state/use-startup-shell-controller";
 import {
   SurfaceRealmScope,
@@ -2540,6 +2543,20 @@ export function App() {
     !isPopout &&
     !firstRunOwnsLoginSurface(startupCoordinator.phase, firstRunComplete)
   ) {
+    if (
+      authProbeShouldHoldShell(
+        startupCoordinator.phase,
+        firstRunComplete,
+        authState.phase,
+      )
+    ) {
+      return (
+        <BugReportProvider value={bugReport}>
+          <StartupScreen />
+          <BugReportModal />
+        </BugReportProvider>
+      );
+    }
     if (authState.phase === "server_unavailable") {
       return (
         <BugReportProvider value={bugReport}>
@@ -2575,8 +2592,8 @@ export function App() {
         </BugReportProvider>
       );
     }
-    // While loading the auth state we allow the main shell to continue
-    // rendering (avoids a flash of login screen on refresh when cookies are valid).
+    // The loading phase is handled above so the shell's poll-heavy hooks never
+    // mount until the session is known.
   }
 
   // OS kiosk window — the locked appliance shell: a fullscreen in-window

--- a/packages/ui/src/state/top-level-auth-gate.test.ts
+++ b/packages/ui/src/state/top-level-auth-gate.test.ts
@@ -1,8 +1,8 @@
 /**
- * Unit coverage for `firstRunOwnsLoginSurface`, the pure predicate that decides
- * whether the top-level LoginView owns the screen versus in-chat onboarding.
- * Guards the double-login window (onboarding incomplete but coordinator past
- * first-run-required). Pure function, no harness.
+ * Unit coverage for the pure top-level auth predicates. These gates decide
+ * whether the top-level LoginView owns the screen, whether in-chat onboarding
+ * owns it instead, and whether shell pollers must stay unmounted during the
+ * initial auth probe.
  */
 import { describe, expect, it } from "vitest";
 import {

--- a/packages/ui/src/state/top-level-auth-gate.test.ts
+++ b/packages/ui/src/state/top-level-auth-gate.test.ts
@@ -5,7 +5,10 @@
  * first-run-required). Pure function, no harness.
  */
 import { describe, expect, it } from "vitest";
-import { firstRunOwnsLoginSurface } from "./top-level-auth-gate";
+import {
+  authProbeShouldHoldShell,
+  firstRunOwnsLoginSurface,
+} from "./top-level-auth-gate";
 
 describe("firstRunOwnsLoginSurface — top-level LoginView vs in-chat onboarding", () => {
   it("yields the login surface while the coordinator is in first-run-required", () => {
@@ -38,5 +41,31 @@ describe("firstRunOwnsLoginSurface — top-level LoginView vs in-chat onboarding
     // or a normal session could be locked out of the top-level login.
     expect(firstRunOwnsLoginSurface("ready", undefined)).toBe(false);
     expect(firstRunOwnsLoginSurface("ready", null)).toBe(false);
+  });
+});
+
+describe("authProbeShouldHoldShell — pre-auth poll suppression", () => {
+  it("holds the shell while auth is loading for a completed returning session", () => {
+    expect(authProbeShouldHoldShell("ready", true, "loading")).toBe(true);
+    expect(authProbeShouldHoldShell("hydrating", true, "loading")).toBe(true);
+  });
+
+  it("does not hold the shell after auth resolves", () => {
+    expect(authProbeShouldHoldShell("ready", true, "authenticated")).toBe(
+      false,
+    );
+    expect(authProbeShouldHoldShell("ready", true, "unauthenticated")).toBe(
+      false,
+    );
+    expect(authProbeShouldHoldShell("ready", true, "server_unavailable")).toBe(
+      false,
+    );
+  });
+
+  it("does not steal the first-run login surface while onboarding owns it", () => {
+    expect(
+      authProbeShouldHoldShell("first-run-required", false, "loading"),
+    ).toBe(false);
+    expect(authProbeShouldHoldShell("ready", false, "loading")).toBe(false);
   });
 });

--- a/packages/ui/src/state/top-level-auth-gate.ts
+++ b/packages/ui/src/state/top-level-auth-gate.ts
@@ -27,3 +27,22 @@ export function firstRunOwnsLoginSurface(
     coordinatorPhase === "first-run-required" || firstRunComplete === false
   );
 }
+
+/**
+ * Whether the main shell should stay unmounted while the top-level auth probe is
+ * still deciding. Returning users with an expired Cloud session can have a
+ * persisted agent base in localStorage; mounting the shell before `/api/auth/me`
+ * resolves starts agent/status/chat pollers that all 401. First-run still owns
+ * its in-chat login surface, so this only applies to normal post-onboarding
+ * sessions.
+ */
+export function authProbeShouldHoldShell(
+  coordinatorPhase: string,
+  firstRunComplete: boolean | null | undefined,
+  authPhase: string,
+): boolean {
+  return (
+    authPhase === "loading" &&
+    !firstRunOwnsLoginSurface(coordinatorPhase, firstRunComplete)
+  );
+}


### PR DESCRIPTION
Closes #14663.

## Summary

A returning logged-out web user can have a stale Cloud agent base persisted in `localStorage`. Before this change, once startup became shell-paintable, `App` rendered the main shell while the top-level `/api/auth/me` probe was still `loading`. That mounted chat/status/data pollers against the stale agent and produced a burst of 401s before the login gate won.

This PR keeps the main shell unmounted while the top-level auth probe is still loading for normal post-onboarding sessions. First-run still owns its in-chat login surface, so onboarding is not stolen by the top-level gate. Once auth resolves, the existing paths still apply: authenticated users get the shell, unauthenticated users get `LoginView`, and server-unavailable gets the retryable startup failure.

## Implementation

- Added `authProbeShouldHoldShell()` beside `firstRunOwnsLoginSurface()` as the pure gate predicate.
- `App` now renders the startup screen during auth `loading` instead of mounting the poll-heavy shell.
- Added deterministic unit coverage for completed returning sessions, resolved auth phases, and first-run ownership.

## Required Evidence Rows

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: N/A - bug is request-loop behavior during auth probe, not a visual redesign. Issue includes live console capture from prod.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: `bun run --cwd packages/app audit:app` recaptured app screenshots across the audit matrix on the rebased branch; Playwright passed 365/365.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: N/A - local host lacks a prod-equivalent expired same-origin Steward cookie plus stale agent-localStorage browser profile; behavior is covered by pure gate tests and full app audit.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: N/A - frontend auth-gate change; no backend service changed.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A locally - prod reproduction requires the stale `app.elizacloud.ai` browser profile described in #14663. The fix prevents shell pollers from mounting until auth resolves.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - no agent/model/prompt behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - no persistent domain artifact is produced.

## Verification

<!-- evidence-row:tests -->
- Tests: `bun run --cwd packages/ui test src/state/top-level-auth-gate.test.ts src/state/useDataLoaders.auth-gate.test.tsx` passed after final rebase: 2 files, 9 tests.
<!-- evidence-row:app-audit -->
- App audit: `bun run --cwd packages/app audit:app` passed after final rebase: 365/365 Playwright tests passed. Report summary: `broken=0`, `minimalism-budget-failures=0`, `minimalism-ratchet-failures=0`, `density-probe-failures=0`; existing non-strict aesthetic debt remains (`needs-work=123`, `hover-probe-failures=64`) and did not fail the gate.
<!-- evidence-row:static-analysis -->
- Static analysis: `bunx @biomejs/biome check packages/ui/src/App.tsx packages/ui/src/state/top-level-auth-gate.ts packages/ui/src/state/top-level-auth-gate.test.ts --no-errors-on-unmatched` passed after final rebase.
<!-- evidence-row:diff-hygiene -->
- Diff hygiene: `git diff --check origin/develop...HEAD` passed after final rebase.
<!-- evidence-row:error-policy -->
- Error policy: `bun run audit:error-policy-ratchet --report` passed after final rebase: no new fallback slop in touched production files.
<!-- evidence-row:typecheck -->
- Typecheck: attempted `bun run --cwd packages/ui typecheck` and `bun run --cwd packages/app typecheck`; both are blocked by unrelated current-tree errors outside this patch. Examples: `packages/ui/src/components/chat/widgets/todo.test.tsx` fixture typed as `never`, `packages/ui/src/testing/__e2e__/widget-cert-fixture.tsx` importing non-exported `WidgetCertReport`, `packages/ui/src/voice/voice-selftest/voice-selftest-harness.test.ts` AudioContext/AudioBuffer casts, `packages/app` missing built workspace modules (`@elizaos/app-core`, `@elizaos/contracts`, `@elizaos/import-conversations/browser`, `@elizaos/tui`) plus pre-existing account type-field errors.