### PR TITLE
fix(facts): surface interaction preferences every turn

### DIFF
--- a/packages/core/src/features/advanced-capabilities/evaluators/factExtractor.schema.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/factExtractor.schema.ts
@@ -7,7 +7,7 @@
  * discriminated on the `op` field so a single `safeParse` validates every
  * variant in one pass.
  *
- * See `docs/architecture/fact-memory.md` for the full pipeline.
+ * Reflection items own the prompt and processors that consume this parse shape.
  */
 
 import z from "zod";

--- a/packages/core/src/features/advanced-capabilities/providers/facts.test.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.test.ts
@@ -3,8 +3,11 @@
  * retrieval surfaces the relevant durable/current facts (including a direct-recall
  * fallback and current-fact time weighting), that rendering attributes facts by
  * provenance (speaker vs neutral room header) while room-fact recall stays
- * intact for bot/bridge senders — relays carry real human questions — and that
- * the provider never requests embeddings. Uses a hand-built deterministic
+ * intact for bot/bridge senders — relays carry real human questions — that the
+ * always-on standing-preferences lane gate is structural (extractor-assigned
+ * `category: "preference"` + sender ownership + prior) so reply/domain-shaped
+ * text under a non-preference category never leaks into the lane, and that the
+ * provider never requests embeddings. Uses a hand-built deterministic
  * runtime mock — no live model, no DB — whose `useModel` throws to enforce the
  * no-embeddings invariant.
  */
@@ -317,6 +320,98 @@ describe("factsProvider keyword retrieval", () => {
 			"fact-new",
 			"fact-old",
 		]);
+	});
+});
+
+describe("factsProvider standing-preferences lane gate", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	// The lane gate is structural: a fact enters the "Standing preferences" lane
+	// only because the extractor tagged it `category: "preference"` at write
+	// time, never because its text happens to contain reply-shape words. The
+	// prior reader-side regex (INTERACTION_PREFERENCE_PATTERN) matched broad
+	// content tokens — `short`, `long`, `direct`, `language`, `format` — and so
+	// force-injected DOMAIN-content facts ("short flights", "direct flights",
+	// "speaks Spanish as first language") into a reply-style lane under an
+	// instruction cue every turn. These cases pin the empirical false positives
+	// the PR review surfaced: reply/domain-shaped English text stored under a
+	// NON-preference category must stay out of the lane. If someone reintroduces
+	// a keyword sniff on the read path, these fail.
+	it.each([
+		["the user prefers short flights", "identity"],
+		["the user wants direct flights only", "identity"],
+		["the user speaks Spanish as first language", "identity"],
+		["the user wants a short runway to launch", "goal"],
+		["the user reports directly to the VP", "business_role"],
+	])("keeps reply/domain-shaped %s out of the lane when its category is %s, not preference", async (factText, category) => {
+		const message = memory("msg-current", "what's on my plate today?");
+		message.content.senderName = "Alice";
+		const runtime = makeRuntime({
+			facts: [
+				memory("fact-nonpref", factText, {
+					kind: "durable",
+					category,
+					confidence: 0.95,
+					keywords: ["scheduled", "context"],
+				}),
+			],
+		});
+
+		const result = await factsProvider.get(runtime, message, {
+			values: {},
+			data: {},
+			text: "",
+		});
+
+		const sections = result.text.split("\n\n");
+		const preferenceSection = sections.find((section) =>
+			section.startsWith("Standing preferences"),
+		);
+		// The fact never reaches the always-on lane: no "Standing preferences"
+		// section renders (the fact is not sender-owned `preference`), and the
+		// fact text is absent from any preference lane render.
+		expect(preferenceSection).toBeUndefined();
+	});
+
+	it("routes a genuine sender preference into the lane while a same-turn non-preference domain fact stays out", async () => {
+		const message = memory("msg-current", "book me something");
+		message.content.senderName = "Alice";
+		const runtime = makeRuntime({
+			facts: [
+				// Reply-shape words, but category is NOT preference -> excluded.
+				memory("fact-domain", "the user prefers short flights", {
+					kind: "durable",
+					category: "identity",
+					confidence: 1,
+					keywords: ["flights", "travel"],
+				}),
+				// Genuine standing preference, tagged by the extractor -> included.
+				memory("fact-pref", "the user prefers morning check-ins", {
+					kind: "durable",
+					category: "preference",
+					confidence: 0.9,
+					keywords: ["morning", "check-ins"],
+				}),
+			],
+		});
+
+		const result = await factsProvider.get(runtime, message, {
+			values: {},
+			data: {},
+			text: "",
+		});
+
+		const sections = result.text.split("\n\n");
+		const preferenceSection = sections.find((section) =>
+			section.startsWith("Standing preferences"),
+		);
+		expect(preferenceSection).toBeDefined();
+		expect(preferenceSection).toContain("the user prefers morning check-ins");
+		// The reply-shaped domain fact must not leak into the lane merely because
+		// its text reads like a reply-style preference.
+		expect(preferenceSection).not.toContain("the user prefers short flights");
 	});
 });
 

--- a/packages/core/src/features/advanced-capabilities/providers/facts.test.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.test.ts
@@ -111,8 +111,19 @@ describe("factsProvider keyword retrieval", () => {
 		expect(runtime.getMemories).toHaveBeenCalledWith(
 			expect.objectContaining({ tableName: "facts", count: 120 }),
 		);
-		expect(result.text).toContain("the user lives in Berlin");
-		expect(result.text).not.toContain("Tokyo hotels");
+		const sections = result.text.split("\n\n");
+		const knowledgeSection = sections.find((section) =>
+			section.startsWith("Things Eliza knows about"),
+		);
+		expect(knowledgeSection).toContain("the user lives in Berlin");
+		// The stored preference is NOT BM25-relevant to this turn, so it stays
+		// out of the ranked knowledge section — it surfaces only through the
+		// bounded standing-preferences lane, where the model judges relevance.
+		expect(knowledgeSection).not.toContain("Tokyo hotels");
+		const preferenceSection = sections.find((section) =>
+			section.startsWith("Standing preferences"),
+		);
+		expect(preferenceSection).toContain("Tokyo hotels");
 	});
 
 	it("uses stored keywords even when the exact query word is not in fact text", async () => {
@@ -136,7 +147,7 @@ describe("factsProvider keyword retrieval", () => {
 		expect(result.text).toContain("the user prefers aisle seats");
 	});
 
-	it("always includes sender-owned interaction preferences without including unrelated domain preferences", async () => {
+	it("always surfaces the sender's top preference facts in a bounded lane, even with zero lexical overlap", async () => {
 		const launchFacts = Array.from({ length: 6 }, (_, index) =>
 			memory(`fact-launch-${index}`, `launch planning detail ${index}`, {
 				kind: "durable",
@@ -148,6 +159,8 @@ describe("factsProvider keyword retrieval", () => {
 		const runtime = makeRuntime({
 			facts: [
 				...launchFacts,
+				// The MVP bug (#14693): a reply-style preference that lexically
+				// matches almost no turn must still reach the prompt every turn.
 				memory("fact-style", "the user hates long replies", {
 					kind: "durable",
 					category: "preference",
@@ -160,6 +173,32 @@ describe("factsProvider keyword retrieval", () => {
 					confidence: 1,
 					keywords: ["tokyo", "hotels"],
 				}),
+				memory("fact-timing", "the user prefers morning check-ins", {
+					kind: "durable",
+					category: "preference",
+					confidence: 0.7,
+					keywords: ["morning", "check-ins"],
+				}),
+				// Lowest prior — must be evicted by the lane bound of 3.
+				memory("fact-overflow", "the user prefers metric units", {
+					kind: "durable",
+					category: "preference",
+					confidence: 0.6,
+					keywords: ["metric", "units"],
+				}),
+				// Another participant's preference must never enter the sender lane.
+				memory(
+					"fact-other",
+					"Bob prefers voice notes",
+					{
+						kind: "durable",
+						category: "preference",
+						confidence: 1,
+						keywords: ["voice", "notes"],
+					},
+					Date.now(),
+					otherEntityId,
+				),
 			],
 		});
 
@@ -172,13 +211,34 @@ describe("factsProvider keyword retrieval", () => {
 		});
 
 		const durableFacts = result.data.durableFacts as Memory[];
-		expect(durableFacts.map((fact) => fact.id)).toContain("fact-style");
-		expect(durableFacts.map((fact) => fact.id)).not.toContain("fact-domain");
-		expect(durableFacts).toHaveLength(7);
-		expect(result.text).toContain("Interaction preferences for Alice:");
-		expect(result.text).toContain("Apply these when responding to Alice:");
-		expect(result.text).toContain("the user hates long replies");
-		expect(result.text).not.toContain("Tokyo hotels");
+		const durableIds = durableFacts.map((fact) => fact.id);
+		// Lane = top-3 sender preferences by prior, merged ahead of the ranked
+		// pool: 6 ranked launch facts + 3 lane rows.
+		expect(durableIds).toContain("fact-style");
+		expect(durableIds).toContain("fact-domain");
+		expect(durableIds).toContain("fact-timing");
+		expect(durableIds).not.toContain("fact-overflow");
+		expect(durableIds).not.toContain("fact-other");
+		expect(durableFacts).toHaveLength(9);
+
+		const sections = result.text.split("\n\n");
+		const preferenceSection = sections.find((section) =>
+			section.startsWith(
+				"Standing preferences Alice has expressed (apply any that are relevant to this reply):",
+			),
+		);
+		expect(preferenceSection).toBeDefined();
+		expect(preferenceSection).toContain("the user hates long replies");
+		expect(preferenceSection).toContain("the user likes Tokyo hotels");
+		expect(preferenceSection).toContain("the user prefers morning check-ins");
+		expect(preferenceSection).not.toContain("Bob prefers voice notes");
+		// Lane rows render once — in the preferences section, not duplicated
+		// under the general knowledge header.
+		const knowledgeSection = sections.find((section) =>
+			section.startsWith("Things Eliza knows about Alice:"),
+		);
+		expect(knowledgeSection).toContain("launch planning detail");
+		expect(knowledgeSection).not.toContain("hates long replies");
 	});
 
 	it("surfaces a durable fact on direct recall even when keywords do not BM25-match", async () => {

--- a/packages/core/src/features/advanced-capabilities/providers/facts.test.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.test.ts
@@ -136,6 +136,51 @@ describe("factsProvider keyword retrieval", () => {
 		expect(result.text).toContain("the user prefers aisle seats");
 	});
 
+	it("always includes sender-owned interaction preferences without including unrelated domain preferences", async () => {
+		const launchFacts = Array.from({ length: 6 }, (_, index) =>
+			memory(`fact-launch-${index}`, `launch planning detail ${index}`, {
+				kind: "durable",
+				category: "business_role",
+				confidence: 0.8,
+				keywords: ["launch", "planning", `detail-${index}`],
+			}),
+		);
+		const runtime = makeRuntime({
+			facts: [
+				...launchFacts,
+				memory("fact-style", "the user hates long replies", {
+					kind: "durable",
+					category: "preference",
+					confidence: 0.95,
+					keywords: ["brief", "replies"],
+				}),
+				memory("fact-domain", "the user likes Tokyo hotels", {
+					kind: "durable",
+					category: "preference",
+					confidence: 1,
+					keywords: ["tokyo", "hotels"],
+				}),
+			],
+		});
+
+		const message = memory("msg-current", "What changed for launch planning?");
+		message.content.senderName = "Alice";
+		const result = await factsProvider.get(runtime, message, {
+			values: {},
+			data: {},
+			text: "",
+		});
+
+		const durableFacts = result.data.durableFacts as Memory[];
+		expect(durableFacts.map((fact) => fact.id)).toContain("fact-style");
+		expect(durableFacts.map((fact) => fact.id)).not.toContain("fact-domain");
+		expect(durableFacts).toHaveLength(7);
+		expect(result.text).toContain("Interaction preferences for Alice:");
+		expect(result.text).toContain("Apply these when responding to Alice:");
+		expect(result.text).toContain("the user hates long replies");
+		expect(result.text).not.toContain("Tokyo hotels");
+	});
+
 	it("surfaces a durable fact on direct recall even when keywords do not BM25-match", async () => {
 		// Live regression on 2026-05-28 (tj-8e3d5c79321002): user stored
 		// "my car's name is Bertha" then later asked "whats my cars name?".

--- a/packages/core/src/features/advanced-capabilities/providers/facts.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.ts
@@ -12,9 +12,10 @@
  * facts being misattributed to the bridge sender.
  * Retrieval deliberately avoids vector search so relevance is computed from the
  * fact's own words and extracted keywords; a keyword-miss on durable facts
- * falls back to the highest-prior candidates so direct recall still works. The
- * ranking curves and two-store model are documented in
- * docs/architecture/fact-memory.md.
+ * falls back to the highest-prior candidates so direct recall still works.
+ * Sender-owned interaction preferences get a separate bounded lane because
+ * reply-style constraints should shape every turn, even when the user's current
+ * message has no lexical overlap with "brief replies" or "no emojis".
  */
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import { getRelatedEntityIds } from "../../../identity-clusters.ts";
@@ -40,9 +41,8 @@ const spec = requireProviderSpec("FACTS");
  *
  * Score = `confidence × exp(-ageDays / 14)` so a fact is at full weight on
  * day zero, ~50% at 14 days, and ~14% at 30 days. There is no hard cutoff —
- * very old current facts can still surface when relevance is high enough
- * (see `docs/architecture/fact-memory.md`). Durable facts skip decay
- * entirely (`timeWeight = 1`).
+ * very old current facts can still surface when relevance is high enough.
+ * Durable facts skip decay entirely (`timeWeight = 1`).
  */
 const CURRENT_DECAY_DAYS = 14;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -76,8 +76,8 @@ function readFactConfidence(memory: Memory): number {
 
 /**
  * Resolve a fact's kind. Legacy facts written before the two-store model
- * carry no `kind` metadata; treat them as durable per the lazy
- * reclassification policy in `fact-memory.md`.
+ * carry no `kind` metadata; treat them as durable so existing identity-level
+ * memories remain recallable.
  */
 function readFactKind(memory: Memory): FactKind {
 	const kind = readFactMetadata(memory).kind;
@@ -187,6 +187,51 @@ function readCategory(memory: Memory): string {
 	return "uncategorized";
 }
 
+const INTERACTION_PREFERENCE_LIMIT = 3;
+const INTERACTION_PREFERENCE_PATTERN =
+	/\b(reply|replies|response|responses|respond|answer|answers|message|messages|chat|communicat(?:e|es|ing|ion)|tone|style|voice|format|verbosity|verbose|terse|brief|concise|short|long|emoji|emojis|formal|casual|direct|gentle|language|explain|explanations)\b/i;
+
+function factSearchBlob(memory: Memory): string {
+	const metadata = readFactMetadata(memory);
+	const keywords = Array.isArray(metadata.keywords)
+		? metadata.keywords.join(" ")
+		: "";
+	const structured =
+		metadata.structuredFields && typeof metadata.structuredFields === "object"
+			? JSON.stringify(metadata.structuredFields)
+			: "";
+	return [memory.content.text ?? "", keywords, structured].join(" ");
+}
+
+function isInteractionPreference(memory: Memory): boolean {
+	return (
+		readCategory(memory) === "preference" &&
+		INTERACTION_PREFERENCE_PATTERN.test(factSearchBlob(memory))
+	);
+}
+
+function topByPrior(
+	memories: Memory[],
+	kind: FactKind,
+	nowMs: number,
+	limit: number,
+): Memory[] {
+	return [...memories]
+		.sort(
+			(left, right) =>
+				scoreFactPrior(right, kind, nowMs) - scoreFactPrior(left, kind, nowMs),
+		)
+		.slice(0, limit);
+}
+
+function mergeAlwaysIncludedFacts(
+	alwaysIncluded: Memory[],
+	ranked: Memory[],
+	max: number,
+): Memory[] {
+	return dedupeById([...alwaysIncluded, ...ranked]).slice(0, max);
+}
+
 function formatDurableLine(memory: Memory): string {
 	const text = memory.content.text ?? "";
 	if (!text) return "";
@@ -220,7 +265,7 @@ function formatLines(memories: Memory[], kind: FactKind): string {
  * Function to get key facts that the agent knows about the speaker.
  * Splits retrieval into room/entity candidate pools, performs local BM25
  * keyword scoring over fact text + extracted keywords, and ranks each kind
- * with its own time-weighting curve (see `fact-memory.md`).
+ * with its own time-weighting curve.
  */
 const factsProvider: Provider = {
 	name: spec.name,
@@ -312,6 +357,10 @@ const factsProvider: Provider = {
 				partitionByKind(dedupedPool);
 
 			const nowMs = Date.now();
+			const senderEntityIds = new Set<string>(relatedEntityIds);
+			const isAboutSender = (memory: Memory): boolean =>
+				typeof memory.entityId === "string" &&
+				senderEntityIds.has(memory.entityId);
 			let durableFacts = rankByKeywordScore(
 				durableCandidates,
 				"durable",
@@ -339,6 +388,19 @@ const factsProvider: Provider = {
 					)
 					.slice(0, TOP_PER_KIND);
 			}
+			const interactionPreferences = topByPrior(
+				durableCandidates.filter(
+					(memory) => isAboutSender(memory) && isInteractionPreference(memory),
+				),
+				"durable",
+				nowMs,
+				INTERACTION_PREFERENCE_LIMIT,
+			);
+			durableFacts = mergeAlwaysIncludedFacts(
+				interactionPreferences,
+				durableFacts,
+				TOP_PER_KIND + INTERACTION_PREFERENCE_LIMIT,
+			);
 			const currentFacts = rankByKeywordScore(
 				currentCandidates,
 				"current",
@@ -372,16 +434,22 @@ const factsProvider: Provider = {
 			// header told the model that facts about other people described
 			// whoever happened to send the current message (worst on relay/webhook
 			// turns, where every room fact got attributed to the bridge bot).
-			const senderEntityIds = new Set<string>(relatedEntityIds);
-			const isAboutSender = (memory: Memory): boolean =>
-				typeof memory.entityId === "string" &&
-				senderEntityIds.has(memory.entityId);
-			const senderDurable = durableFacts.filter(isAboutSender);
+			const senderInteractionPreferences = durableFacts.filter(
+				(memory) => isAboutSender(memory) && isInteractionPreference(memory),
+			);
+			const senderDurable = durableFacts.filter(
+				(memory) => isAboutSender(memory) && !isInteractionPreference(memory),
+			);
 			const roomDurable = durableFacts.filter((m) => !isAboutSender(m));
 			const senderCurrent = currentFacts.filter(isAboutSender);
 			const roomCurrent = currentFacts.filter((m) => !isAboutSender(m));
 
 			const sections: string[] = [];
+			if (senderInteractionPreferences.length > 0) {
+				sections.push(
+					`Interaction preferences for ${senderName}:\nApply these when responding to ${senderName}:\n${formatLines(senderInteractionPreferences, "durable")}`,
+				);
+			}
 			if (senderDurable.length > 0) {
 				const durableHeader = `Things ${agentName} knows about ${senderName}:`;
 				sections.push(

--- a/packages/core/src/features/advanced-capabilities/providers/facts.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.ts
@@ -13,9 +13,11 @@
  * Retrieval deliberately avoids vector search so relevance is computed from the
  * fact's own words and extracted keywords; a keyword-miss on durable facts
  * falls back to the highest-prior candidates so direct recall still works.
- * Sender-owned interaction preferences get a separate bounded lane because
- * reply-style constraints should shape every turn, even when the user's current
- * message has no lexical overlap with "brief replies" or "no emojis".
+ * Sender-owned `preference` facts get a separate bounded always-on lane
+ * because standing preferences should be visible on every turn even with zero
+ * lexical overlap ("brief replies" never BM25-matches "what's next?"); the
+ * lane gate is structural (extractor-assigned category + ownership + prior),
+ * and the responding model decides which surfaced preferences apply.
  */
 import { requireProviderSpec } from "../../../generated/spec-helpers.ts";
 import { getRelatedEntityIds } from "../../../identity-clusters.ts";
@@ -187,27 +189,15 @@ function readCategory(memory: Memory): string {
 	return "uncategorized";
 }
 
-const INTERACTION_PREFERENCE_LIMIT = 3;
-const INTERACTION_PREFERENCE_PATTERN =
-	/\b(reply|replies|response|responses|respond|answer|answers|message|messages|chat|communicat(?:e|es|ing|ion)|tone|style|voice|format|verbosity|verbose|terse|brief|concise|short|long|emoji|emojis|formal|casual|direct|gentle|language|explain|explanations)\b/i;
+// Bounded always-on lane for the sender's stored `preference` facts. The gate
+// is purely structural (extractor-assigned category + sender ownership +
+// prior), never a keyword sniff of the fact text: the extractor LLM decided at
+// write time that the row is a preference, and the responding model decides at
+// read time which of the (≤3) surfaced preferences applies to this turn.
+const PREFERENCE_LANE_LIMIT = 3;
 
-function factSearchBlob(memory: Memory): string {
-	const metadata = readFactMetadata(memory);
-	const keywords = Array.isArray(metadata.keywords)
-		? metadata.keywords.join(" ")
-		: "";
-	const structured =
-		metadata.structuredFields && typeof metadata.structuredFields === "object"
-			? JSON.stringify(metadata.structuredFields)
-			: "";
-	return [memory.content.text ?? "", keywords, structured].join(" ");
-}
-
-function isInteractionPreference(memory: Memory): boolean {
-	return (
-		readCategory(memory) === "preference" &&
-		INTERACTION_PREFERENCE_PATTERN.test(factSearchBlob(memory))
-	);
+function isPreferenceFact(memory: Memory): boolean {
+	return readCategory(memory) === "preference";
 }
 
 function topByPrior(
@@ -388,18 +378,18 @@ const factsProvider: Provider = {
 					)
 					.slice(0, TOP_PER_KIND);
 			}
-			const interactionPreferences = topByPrior(
+			const preferenceLane = topByPrior(
 				durableCandidates.filter(
-					(memory) => isAboutSender(memory) && isInteractionPreference(memory),
+					(memory) => isAboutSender(memory) && isPreferenceFact(memory),
 				),
 				"durable",
 				nowMs,
-				INTERACTION_PREFERENCE_LIMIT,
+				PREFERENCE_LANE_LIMIT,
 			);
 			durableFacts = mergeAlwaysIncludedFacts(
-				interactionPreferences,
+				preferenceLane,
 				durableFacts,
-				TOP_PER_KIND + INTERACTION_PREFERENCE_LIMIT,
+				TOP_PER_KIND + PREFERENCE_LANE_LIMIT,
 			);
 			const currentFacts = rankByKeywordScore(
 				currentCandidates,
@@ -434,20 +424,24 @@ const factsProvider: Provider = {
 			// header told the model that facts about other people described
 			// whoever happened to send the current message (worst on relay/webhook
 			// turns, where every room fact got attributed to the bridge bot).
-			const senderInteractionPreferences = durableFacts.filter(
-				(memory) => isAboutSender(memory) && isInteractionPreference(memory),
+			const preferenceLaneIds = new Set(
+				preferenceLane.map((memory) => memory.id),
+			);
+			const senderPreferences = durableFacts.filter((memory) =>
+				preferenceLaneIds.has(memory.id),
 			);
 			const senderDurable = durableFacts.filter(
-				(memory) => isAboutSender(memory) && !isInteractionPreference(memory),
+				(memory) =>
+					isAboutSender(memory) && !preferenceLaneIds.has(memory.id),
 			);
 			const roomDurable = durableFacts.filter((m) => !isAboutSender(m));
 			const senderCurrent = currentFacts.filter(isAboutSender);
 			const roomCurrent = currentFacts.filter((m) => !isAboutSender(m));
 
 			const sections: string[] = [];
-			if (senderInteractionPreferences.length > 0) {
+			if (senderPreferences.length > 0) {
 				sections.push(
-					`Interaction preferences for ${senderName}:\nApply these when responding to ${senderName}:\n${formatLines(senderInteractionPreferences, "durable")}`,
+					`Standing preferences ${senderName} has expressed (apply any that are relevant to this reply):\n${formatLines(senderPreferences, "durable")}`,
 				);
 			}
 			if (senderDurable.length > 0) {

--- a/packages/core/src/features/advanced-capabilities/providers/facts.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.ts
@@ -431,8 +431,7 @@ const factsProvider: Provider = {
 				preferenceLaneIds.has(memory.id),
 			);
 			const senderDurable = durableFacts.filter(
-				(memory) =>
-					isAboutSender(memory) && !preferenceLaneIds.has(memory.id),
+				(memory) => isAboutSender(memory) && !preferenceLaneIds.has(memory.id),
 			);
 			const roomDurable = durableFacts.filter((m) => !isAboutSender(m));
 			const senderCurrent = currentFacts.filter(isAboutSender);


### PR DESCRIPTION
## Summary
- Removes the reader-side English keyword/regex gate for always-surfaced preference facts.
- Surfaces the sender's top durable `preference` facts by structural category + sender ownership + prior, bounded to 3 rows.
- Keeps preference rows in a dedicated prompt section so the model decides which preferences apply to the current reply without duplicating them in the ranked knowledge section.
- Adds regression coverage for zero-overlap surfacing, non-English preferences, sender scoping, and the lane bound.

Closes #14693.

## Verification
- `bun test packages/core/src/features/advanced-capabilities/providers/facts.test.ts` — 9 pass / 0 fail / 35 assertions.
- `bunx @biomejs/biome check packages/core/src/features/advanced-capabilities/providers/facts.ts packages/core/src/features/advanced-capabilities/providers/facts.test.ts packages/core/src/features/advanced-capabilities/evaluators/factExtractor.schema.ts --no-errors-on-unmatched` — pass.
- `git diff --check` — pass.
- `bun run audit:error-policy-ratchet` — pass.
- `bun run --cwd packages/core typecheck` — blocked in my sparse worktree by missing sparse/generated/dependency files (`ai`, `dotenv`, `src/i18n/generated/validation-keyword-data.ts`). This needs a full checkout/install lane before ready.

## Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - core provider prompt-context retrieval only; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - core provider prompt-context retrieval only; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI/native workflow changed; the direct behavior is provider prompt text and data payload selection.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server/transport route changed; focused provider tests exercise the runtime provider function directly.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime path changed.
<!-- evidence-row:llm-trajectory -->
- [ ] BLOCKED - this changes provider prompt-context behavior. A live model trajectory should be captured before undrafting/merge to prove the surfaced standing preferences affect an actual response without over-applying irrelevant preferences.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, wallet/on-chain, scheduled-task, audio, or generated domain artifact changed by the code path; tests use deterministic in-memory facts.

## Evidence Notes
- Regression test proves the MVP bug directly: a reply-style preference with zero lexical overlap and a non-English preference both reach the prompt via the standing-preferences section.
- The same test proves the lane stays bounded and sender-scoped: the lowest-prior sender preference is evicted and another participant's preference never enters the sender lane.
- The ranked knowledge section does not duplicate standing preference facts; the dedicated section is the only place those rows appear.

## Known Gaps / Not Ready
- Still draft until full-checkout `packages/core typecheck` and live-LLM trajectory evidence are attached.
