### PR TITLE
fix(core): fail closed unresolved connector roles (#14709)

### DIFF
--- a/packages/core/src/roles.test.ts
+++ b/packages/core/src/roles.test.ts
@@ -170,12 +170,21 @@ describe("hasRoleAccess — fail-closed on unresolved role", () => {
 
 	it("uses USER only for local unresolved sources", () => {
 		expect(getUnresolvedSenderRoleFloor(guestMessage)).toBe("USER");
-		expect(
-			getUnresolvedSenderRoleFloor({
-				...guestMessage,
-				content: { text: "from local API", source: "api" },
-			} as unknown as Memory),
-		).toBe("USER");
+		for (const source of [
+			"api",
+			"dashboard",
+			"owner_app",
+			"local-voice",
+			"sub_agent",
+			"coding-agent",
+		]) {
+			expect(
+				getUnresolvedSenderRoleFloor({
+					...guestMessage,
+					content: { text: `from ${source}`, source },
+				} as unknown as Memory),
+			).toBe("USER");
+		}
 	});
 
 	it("uses GUEST for unresolved connector sources", () => {

--- a/packages/core/src/roles.test.ts
+++ b/packages/core/src/roles.test.ts
@@ -23,6 +23,7 @@ import {
 	canModifyRole,
 	getEntityRole,
 	getLiveEntityMetadataFromMessage,
+	getUnresolvedSenderRoleFloor,
 	hasAtLeastRole,
 	hasRoleAccess,
 	isAdminRank,
@@ -141,11 +142,9 @@ describe("isAgentSelf", () => {
 describe("hasRoleAccess — fail-closed on unresolved role", () => {
 	// A message with a real entity/room but no resolvable world (deleted or
 	// inaccessible world, or a source that yields no world id) makes
-	// checkSenderRole return null. That path used to `return true` (fail-OPEN) —
-	// a guest whose world resolution failed cleared the OWNER gate and reached
-	// owner-gated capabilities (e.g. SHELL). It must fail closed to USER rank
-	// (matching the pre-handler default), denying ADMIN/OWNER while still
-	// allowing basic USER actions.
+	// checkSenderRole return null. Connector-originated senders must fall to
+	// GUEST so they do not outrank a fully resolved stranger; local/API harness
+	// traffic keeps USER so no-world local usage still works.
 	const makeRuntime = (settings: Record<string, string> = {}) =>
 		({
 			agentId: "agent-1",
@@ -163,6 +162,31 @@ describe("hasRoleAccess — fail-closed on unresolved role", () => {
 		roomId: "room-1",
 		content: { text: "run df -h on the server", source: "test" },
 	} as unknown as Memory;
+	const connectorMessage = {
+		entityId: "guest-entity-1",
+		roomId: "room-1",
+		content: { text: "run df -h on the server", source: "discord" },
+	} as unknown as Memory;
+
+	it("uses USER only for local unresolved sources", () => {
+		expect(getUnresolvedSenderRoleFloor(guestMessage)).toBe("USER");
+		expect(
+			getUnresolvedSenderRoleFloor({
+				...guestMessage,
+				content: { text: "from local API", source: "api" },
+			} as unknown as Memory),
+		).toBe("USER");
+	});
+
+	it("uses GUEST for unresolved connector sources", () => {
+		expect(getUnresolvedSenderRoleFloor(connectorMessage)).toBe("GUEST");
+		expect(
+			getUnresolvedSenderRoleFloor({
+				...connectorMessage,
+				content: { text: "from Telegram", source: "telegram" },
+			} as unknown as Memory),
+		).toBe("GUEST");
+	});
 
 	it("denies OWNER and ADMIN when the sender role cannot be resolved", async () => {
 		const runtime = makeRuntime();
@@ -170,10 +194,16 @@ describe("hasRoleAccess — fail-closed on unresolved role", () => {
 		expect(await hasRoleAccess(runtime, guestMessage, "ADMIN")).toBe(false);
 	});
 
-	it("still allows USER (matches the pre-handler ['USER'] default) and GUEST", async () => {
+	it("still allows USER for unresolved local/API traffic and always allows GUEST", async () => {
 		const runtime = makeRuntime();
 		expect(await hasRoleAccess(runtime, guestMessage, "USER")).toBe(true);
 		expect(await hasRoleAccess(runtime, guestMessage, "GUEST")).toBe(true);
+	});
+
+	it("denies USER for an unresolved connector sender", async () => {
+		const runtime = makeRuntime();
+		expect(await hasRoleAccess(runtime, connectorMessage, "USER")).toBe(false);
+		expect(await hasRoleAccess(runtime, connectorMessage, "GUEST")).toBe(true);
 	});
 
 	it("still allows the canonical owner through the OWNER gate", async () => {

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -29,7 +29,12 @@ import {
 import { createUniqueUuid } from "./entities";
 import { logger } from "./logger";
 import type { IAgentRuntime, Memory, UUID, World } from "./types";
-import { MESSAGE_SOURCE_CLIENT_CHAT } from "./types/message-source";
+import {
+	MESSAGE_SOURCE_AGENT_GREETING,
+	MESSAGE_SOURCE_CLIENT_CHAT,
+	MESSAGE_SOURCE_CODING_AGENT,
+	MESSAGE_SOURCE_SUB_AGENT,
+} from "./types/message-source";
 import { formatError } from "./utils/format-error";
 import { asRecordOrUndefined as asRecord } from "./utils/type-guards";
 
@@ -218,16 +223,25 @@ function getMessageSource(message: Memory): string | undefined {
 
 const LOCAL_UNRESOLVED_ROLE_SOURCES = new Set([
 	MESSAGE_SOURCE_CLIENT_CHAT,
+	MESSAGE_SOURCE_SUB_AGENT,
+	MESSAGE_SOURCE_CODING_AGENT,
+	MESSAGE_SOURCE_AGENT_GREETING,
 	"api",
 	"benchmark",
+	"dashboard",
+	"deep-link",
+	"event",
+	"ios-local",
+	"local-voice",
+	"owner_app",
 	"test",
 ]);
 
 /**
  * Role floor used when a real sender exists but no world role can be resolved.
- * Connector messages must not outrank a fully resolved stranger, so they fall to
- * GUEST; local/API harness traffic keeps USER so headless usage without a world
- * is not broken by connector hardening.
+ * Connector messages must not outrank a fully resolved stranger, so unknown
+ * non-local sources fall to GUEST. Local, owner-app, and harness traffic keeps
+ * USER so no-world control surfaces keep their historical behavior.
  */
 export function getUnresolvedSenderRoleFloor(message: Memory): RoleName {
 	const source = getMessageSource(message)?.trim().toLowerCase();
@@ -997,7 +1011,8 @@ async function isCanonicalOwner(
  * When there is no access context at all (no runtime / no sender entity — for
  * example local API calls), allow through so local-only usage follows the same
  * lenient path as plugin role gating. But when there IS a real sender whose
- * role simply cannot be resolved, fail CLOSED to USER rank — see below.
+ * role simply cannot be resolved, use the same source-aware floor as Stage 1
+ * context filtering.
  */
 export async function hasRoleAccess(
 	runtime: IAgentRuntime | undefined,

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -17,8 +17,9 @@
  * both resolution paths agree (#12087 Item 6); resolution trusts ONLY connector
  * identity stamped into the Memory, never client-supplied content.metadata; and
  * every access check fails CLOSED — an unknown role ranks below GUEST and an
- * unresolvable sender is treated as USER, never a higher tier. Owner and role
- * grants are recorded explicitly with their source so they stay auditable.
+ * unresolvable connector sender is treated as GUEST while local/API messages
+ * keep the USER fallback they historically used. Owner and role grants are
+ * recorded explicitly with their source so they stay auditable.
  */
 import {
 	getConnectorIdentityMetadataMapping,
@@ -28,6 +29,7 @@ import {
 import { createUniqueUuid } from "./entities";
 import { logger } from "./logger";
 import type { IAgentRuntime, Memory, UUID, World } from "./types";
+import { MESSAGE_SOURCE_CLIENT_CHAT } from "./types/message-source";
 import { formatError } from "./utils/format-error";
 import { asRecordOrUndefined as asRecord } from "./utils/type-guards";
 
@@ -212,6 +214,27 @@ function getMessageSource(message: Memory): string | undefined {
 	return typeof message.content.source === "string"
 		? message.content.source
 		: undefined;
+}
+
+const LOCAL_UNRESOLVED_ROLE_SOURCES = new Set([
+	MESSAGE_SOURCE_CLIENT_CHAT,
+	"api",
+	"benchmark",
+	"test",
+]);
+
+/**
+ * Role floor used when a real sender exists but no world role can be resolved.
+ * Connector messages must not outrank a fully resolved stranger, so they fall to
+ * GUEST; local/API harness traffic keeps USER so headless usage without a world
+ * is not broken by connector hardening.
+ */
+export function getUnresolvedSenderRoleFloor(message: Memory): RoleName {
+	const source = getMessageSource(message)?.trim().toLowerCase();
+	if (!source || LOCAL_UNRESOLVED_ROLE_SOURCES.has(source)) {
+		return "USER";
+	}
+	return "GUEST";
 }
 
 function getConnectorMetadataFromMemory(
@@ -1009,14 +1032,8 @@ export async function hasRoleAccess(
 	try {
 		const result = await checkRoleFn(context.runtime, context.message);
 		if (!result) {
-			// Fail CLOSED. When the sender's role cannot be resolved (missing or
-			// inaccessible world, no world id on the message), treat them as USER —
-			// the same default the pre-handler tool-call gate uses. Returning `true`
-			// here was fail-OPEN: a real sender whose world resolution failed
-			// cleared an OWNER gate and reached owner-gated capabilities (e.g.
-			// SHELL). Defaulting to USER denies privileged (ADMIN/OWNER) actions to
-			// an unresolvable sender while still allowing basic USER actions.
-			const senderRank = ROLE_RANK.USER;
+			const senderRank =
+				ROLE_RANK[getUnresolvedSenderRoleFloor(context.message)];
 			const requiredRank = ROLE_RANK[requiredRole] ?? 0;
 			return senderRank >= requiredRank;
 		}

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -41,7 +41,12 @@ import { logger } from "../logger";
 import { describeImageCached } from "../media";
 import { fetchRemoteMedia } from "../media/fetch";
 import { imageDescriptionTemplate, messageHandlerTemplate } from "../prompts";
-import { checkSenderRole, hasAtLeastRole, isAdminRank } from "../roles";
+import {
+	checkSenderRole,
+	getUnresolvedSenderRoleFloor,
+	hasAtLeastRole,
+	isAdminRank,
+} from "../roles";
 import {
 	type ActionCatalog,
 	buildActionCatalog,
@@ -4903,9 +4908,9 @@ function synthesizeStage1TruncationReply(): MessageHandlerResult {
 /**
  * Resolve the calling sender's role for context-catalog filtering.
  *
- * This is best-effort: when there is no world context (DM-only sessions,
- * benchmarks, tests), `checkSenderRole` returns null and we fall through to a
- * conservative default. Owner-only messages always pass the agent's own
+ * This is best-effort: when there is no world context, `checkSenderRole`
+ * returns null and we fall through to the same source-aware floor that
+ * `hasRoleAccess` uses. Owner-only messages always pass the agent's own
  * messages without a world lookup.
  */
 async function resolveStage1SenderRole(
@@ -4926,12 +4931,10 @@ async function resolveStage1SenderRole(
 	} catch (error) {
 		runtime.logger.debug(
 			{ src: "service:message", error },
-			"Stage 1 sender role lookup failed; defaulting to USER",
+			"Stage 1 sender role lookup failed; using unresolved role floor",
 		);
 	}
-	// No world metadata — fall back to USER. This matches the lenient default
-	// in plugin-role-gating so local-only usage isn't blocked.
-	return "USER";
+	return getUnresolvedSenderRoleFloor(message);
 }
 
 function listAvailableContextsForRole(


### PR DESCRIPTION
## Summary

Fixes #14709.

Unresolved connector-originated senders now fall to `GUEST` instead of `USER`, so a sender whose world/role lookup fails no longer outranks a fully resolved stranger. Local/API/no-world traffic keeps the historical `USER` floor for headless and test harness usage.

The fallback is centralized in `getUnresolvedSenderRoleFloor()` and reused by both `hasRoleAccess()` and Stage 1 context-catalog sender-role filtering so action authorization and context filtering stay aligned.

## Evidence

- `bun run --cwd packages/core test src/roles.test.ts` — passed, 42 tests.
- `bunx @biomejs/biome check packages/core/src/roles.ts packages/core/src/roles.test.ts packages/core/src/services/message.ts --no-errors-on-unmatched` — passed.
- `bun run --cwd packages/core typecheck` — passed.
- `bun run --cwd packages/core build` — passed; Node, browser, edge, and testing bundles built.
- `git diff --check origin/develop...HEAD` — passed.
- `bun run audit:error-policy-ratchet --report` — passed; 2 changed production files, no new fallback slop.

## Manual Review

- Reviewed the diff after formatting: only `packages/core/src/roles.ts`, `packages/core/src/services/message.ts`, and `packages/core/src/roles.test.ts` changed.
- Confirmed the regression coverage asserts both sides of the floor: unresolved `test`/`api` messages remain `USER`, unresolved `discord`/`telegram` messages become `GUEST`, and unresolved connector senders no longer clear a `USER` gate.

## Evidence N/A

- Live connector trajectory/log evidence: N/A locally because no Discord/Telegram credentials are available in this environment. This change is a deterministic authorization fallback covered by unit tests over the real role resolver helpers.
- Screenshots/video: N/A; no UI surface changed.
