### PR TITLE
fix(scenarios): catalog plugin-health live corpus

### DIFF
--- a/.github/workflows/live-scenarios.yml
+++ b/.github/workflows/live-scenarios.yml
@@ -1,6 +1,6 @@
 # Live Scenario Runner (nightly)
 #
-# Executes the executive-assistant and connector certification
+# Executes the executive-assistant, connector certification, and plugin-health
 # scenarios against a live LLM runtime with real connector credentials and
 # uploads the JSON report. Scheduled/default dispatch runs are report-only
 # while this catalog is still being hardened; manual dispatch can opt into
@@ -88,7 +88,7 @@ permissions:
 
 jobs:
   live-scenarios:
-    name: Live scenarios (EA + connectors)
+    name: Live scenarios (EA + connectors + health)
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 120
     steps:
@@ -171,6 +171,7 @@ jobs:
           package_dirs=(
             plugins/plugin-sql
             plugins/plugin-agent-skills
+            plugins/plugin-health
             plugins/plugin-pdf
             plugins/plugin-telegram
             plugins/plugin-whatsapp
@@ -249,6 +250,31 @@ jobs:
           RUN_DIR: artifacts/scenario-runs/live
         run: node packages/scripts/run-live-scenarios.mjs
 
+      - name: Run plugin-health live scenarios
+        id: run-health
+        env:
+          # LLM providers
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          # Independent LLM judge (#9310): judge on Cerebras, never the model
+          # under test.
+          CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+          SCENARIO_JUDGE_REQUIRE_INDEPENDENT: "1"
+          # Run controls
+          SCENARIO_ROOT: plugins/plugin-health/test/scenarios
+          SCENARIO_FILTER: ${{ inputs.scenario_filter }}
+          LIFEOPS_JUDGE_THRESHOLD: ${{ inputs.judge_threshold || '0.8' }}
+          SCENARIO_ENFORCE_GATE: ${{ inputs.enforce_gate && '1' || '0' }}
+          SKIP_REASON: ${{ inputs.skip_reason }}
+          REPORT_PATH: artifacts/plugin-health-scenario-report.json
+          RUN_DIR: artifacts/scenario-runs/plugin-health
+          EXPORT_NATIVE_PATH: artifacts/scenario-runs/plugin-health/native.jsonl
+        run: node packages/scripts/run-live-scenarios.mjs --lane live-only
+
       - name: Upload scenario report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -256,6 +282,8 @@ jobs:
           name: lifeops-scenario-report
           path: |
             artifacts/lifeops-scenario-report.json
+            artifacts/plugin-health-scenario-report.json
             artifacts/scenario-runs/live/
+            artifacts/scenario-runs/plugin-health/
           if-no-files-found: warn
           retention-days: 30

--- a/packages/scripts/check-scenario-workflow-coverage.mjs
+++ b/packages/scripts/check-scenario-workflow-coverage.mjs
@@ -605,6 +605,7 @@ function scenarioCatalogHtml() {
       ["defaultScenarios", "Default package scenarios"],
       ["includePendingScenarios", "Including pending"],
       ["pluginLifeopsScenarios", "plugin-personal-assistant"],
+      ["pluginHealthScenarios", "plugin-health"],
       ["pluginAppControlScenarios", "plugin-app-control"],
       ["pluginAgentOrchestratorScenarios", "plugin-agent-orchestrator"],
       ["scenarioRunnerScenarios", "scenario-runner tests"],
@@ -616,6 +617,7 @@ function scenarioCatalogHtml() {
         ["Default", s.defaultScenarioCount || 0],
         ["Include pending", s.includePendingScenarioCount || 0],
         ["plugin-personal-assistant", s.pluginLifeopsCount || 0],
+        ["plugin-health", s.pluginHealthCount || 0],
         ["plugin-app-control", s.pluginAppControlCount || 0],
         ["plugin-agent-orchestrator", s.pluginAgentOrchestratorCount || 0],
         ["runner tests", s.scenarioRunnerCount || 0],
@@ -713,6 +715,7 @@ function renderMarkdown(summary, runArtifacts = []) {
     `Default packages/test scenarios: ${summary.defaultScenarioCount}`,
     `With pending included: ${summary.includePendingScenarioCount}`,
     `plugin-personal-assistant scenarios: ${summary.pluginLifeopsCount}`,
+    `plugin-health scenarios: ${summary.pluginHealthCount}`,
     `plugin-app-control scenarios: ${summary.pluginAppControlCount}`,
     `plugin-agent-orchestrator scenarios: ${summary.pluginAgentOrchestratorCount}`,
     `scenario-runner test scenarios: ${summary.scenarioRunnerCount}`,
@@ -812,6 +815,9 @@ function main() {
   const pluginLifeopsIds = listScenarioMetadata(
     "plugins/plugin-personal-assistant/test/scenarios",
   ).map((metadata) => metadata.id);
+  const pluginHealthIds = listScenarioMetadata(
+    "plugins/plugin-health/test/scenarios",
+  ).map((metadata) => metadata.id);
   const pluginAppControlIds = listScenarioMetadata(
     "plugins/plugin-app-control/test/scenarios",
   ).map((metadata) => metadata.id);
@@ -826,6 +832,10 @@ function main() {
     ...scopedScenarioRows(
       "plugins/plugin-personal-assistant/test/scenarios",
       pluginLifeopsIds,
+    ),
+    ...scopedScenarioRows(
+      "plugins/plugin-health/test/scenarios",
+      pluginHealthIds,
     ),
     ...scopedScenarioRows(
       "plugins/plugin-app-control/test/scenarios",
@@ -847,6 +857,7 @@ function main() {
   const laneScanRoots = [
     "packages/test/scenarios",
     "plugins/plugin-personal-assistant/test/scenarios",
+    "plugins/plugin-health/test/scenarios",
     "plugins/plugin-app-control/test/scenarios",
     "plugins/plugin-agent-orchestrator/test/scenarios",
     "packages/scenario-runner/test/scenarios",
@@ -936,6 +947,7 @@ function main() {
     defaultScenarioCount: defaultIds.length,
     includePendingScenarioCount: includePendingIds.length,
     pluginLifeopsCount: pluginLifeopsIds.length,
+    pluginHealthCount: pluginHealthIds.length,
     pluginAppControlCount: pluginAppControlIds.length,
     pluginAgentOrchestratorCount: pluginAgentOrchestratorIds.length,
     scenarioRunnerCount: scenarioRunnerIds.length,
@@ -961,6 +973,7 @@ function main() {
     "plugin-personal-assistant.txt",
     pluginLifeopsIds,
   );
+  writeList(options.reportDir, "plugin-health.txt", pluginHealthIds);
   writeList(options.reportDir, "plugin-app-control.txt", pluginAppControlIds);
   writeList(
     options.reportDir,
@@ -983,6 +996,7 @@ function main() {
     defaultScenarios: defaultIds,
     includePendingScenarios: includePendingIds,
     pluginLifeopsScenarios: pluginLifeopsIds,
+    pluginHealthScenarios: pluginHealthIds,
     pluginAppControlScenarios: pluginAppControlIds,
     pluginAgentOrchestratorScenarios: pluginAgentOrchestratorIds,
     scenarioRunnerScenarios: scenarioRunnerIds,

--- a/plugins/plugin-health/package.json
+++ b/plugins/plugin-health/package.json
@@ -68,7 +68,7 @@
   "scripts": {
     "typecheck": "tsgo --noEmit -p tsconfig.json",
     "test": "vitest run --config vitest.config.ts",
-    "test:scenarios": "cd ../.. && bun packages/scenario-runner/src/cli.ts list plugins/plugin-health/test/scenarios",
+    "test:scenarios": "cd ../.. && bun --conditions eliza-source --tsconfig-override tsconfig.json packages/scenario-runner/src/cli.ts run plugins/plugin-health/test/scenarios --lane live-only --report-dir reports/scenarios/live-health --run-dir reports/scenarios/live-health --export-native reports/scenarios/live-health/native.jsonl",
     "build": "bun run build:js && bun run build:views && bun run build:types",
     "clean": "node ../../packages/scripts/rm-path-recursive.mjs dist",
     "build:js": "tsup --config ../tsup.plugin-packages.shared.ts",


### PR DESCRIPTION
## Summary
- change `plugins/plugin-health`'s `test:scenarios` script from a list-only command to an executable live-only scenario run with report, run-dir, and native JSONL outputs
- add `plugins/plugin-health/test/scenarios` to the scenario catalog and lane-tag inventory so the 8 live-only health scenarios are visible in coverage reports and untagged-lane enforcement
- add a plugin-health leg to `live-scenarios.yml`, with its own report/run directory and artifact upload, so the corpus has a live executor without joining PR deterministic lanes

Closes #14697.

## Verification
- `node -e "JSON.parse(require('fs').readFileSync('plugins/plugin-health/package.json','utf8')); console.log('plugin-health package.json ok')"` — passed
- `bun --conditions eliza-source --tsconfig-override tsconfig.json packages/scenario-runner/src/cli.ts list plugins/plugin-health/test/scenarios --lane live-only` — listed all 8 health scenarios
- `node packages/scripts/check-scenario-workflow-coverage.mjs --report-dir reports/scenarios/catalog-inventory-14697 --json` — passed; compact result:
  - `pluginHealthCount: 8`
  - `corpusLaneSplit.total: 1075`
  - `corpusLaneSplit.liveOnlyCount: 956`
  - `untaggedLaneScenarios: 0`
  - `missingDefaultIds: 0`
- `bun test packages/scripts/__tests__/real-live-suites.test.ts` — 7 pass / 0 fail
- `bun test packages/scenario-runner/src/echo-assertion-ratchet.test.ts packages/scenario-runner/src/skippable-check-ratchet.test.ts packages/scenario-runner/src/corpus-assertion-guard.test.ts packages/scenario-runner/src/action-effect-ratchet.test.ts` — 14 pass / 0 fail
- `bunx biome check packages/scripts/check-scenario-workflow-coverage.mjs plugins/plugin-health/package.json .github/workflows/live-scenarios.yml` — passed for the JS/JSON files Biome checks (YAML ignored by repo config)
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/live-scenarios.yml'); puts 'live-scenarios.yml yaml ok'"` — passed
- `git diff --check` — passed

## Known unrelated failure
- `bun test packages/scenario-runner/src/scenario-pr-workflow.test.ts packages/scripts/__tests__/real-live-suites.test.ts` fails in `scenario-pr-workflow.test.ts` on a pre-existing stale expectation that `.github/workflows/scenario-pr.yml` contains `bunx vitest run --config test/mocks/vitest.config.ts test/mocks/__tests__/llm-proxy-plugin.test.ts`. This branch does not touch `scenario-pr.yml`; the targeted live/health and catalog checks above pass.

## Evidence notes
- UI screenshots/video: N/A — this is CI/catalog/live-scenario wiring, not an app-rendered change.
- Live health trajectory: not captured locally because the scenarios are intentionally `live-only` and require live LLM credentials; this PR wires the nightly/manual executor and makes the corpus visible to the catalog gate.
