### PR TITLE
fix(ci): enforce live scenario schedule

### DIFF
--- a/.github/workflows/live-scenarios.yml
+++ b/.github/workflows/live-scenarios.yml
@@ -2,10 +2,11 @@
 #
 # Executes the executive-assistant, connector certification, plugin-health, and
 # app-control scenarios against a live LLM runtime with real connector
-# credentials and uploads the JSON report. Scheduled/default dispatch runs are
-# report-only while this catalog is still being hardened; manual dispatch can opt
-# into failing when any scenario fails or the aggregate LLM-judge score falls below
-# LIFEOPS_JUDGE_THRESHOLD. Missing setup prerequisites still fail loudly.
+# credentials and uploads the JSON report. Scheduled runs are enforcing: once the
+# runner reaches scenario execution, any scenario failure or aggregate LLM-judge
+# score below LIFEOPS_JUDGE_THRESHOLD fails the lane. Manual dispatch can still opt
+# into report-only mode while debugging by leaving `enforce_gate` false. Missing
+# setup prerequisites fail loudly and still upload a placeholder report artifact.
 #
 # Required repo secrets (self-documented):
 #   LLM provider (at least one):
@@ -35,7 +36,7 @@
 # Optional:
 #   LIFEOPS_JUDGE_THRESHOLD (workflow input, default 0.8)
 #   SCENARIO_FILTER        (comma-separated scenario ids, default all)
-#   SCENARIO_ENFORCE_GATE  (workflow input, default false)
+#   SCENARIO_ENFORCE_GATE  (schedule: enforced; manual input default false)
 #   SKIP_REASON            (required if SCENARIO_SKIP is set)
 #
 # 1Password vault: this workflow's plain `*_API_KEY` secrets are sourced from the
@@ -113,6 +114,28 @@ jobs:
         run: |
           test -f packages/scenario-runner/src/cli.ts || \
             { echo "scenario-runner CLI missing"; exit 1; }
+
+      - name: Prepare live scenario report placeholder
+        run: |
+          mkdir -p artifacts/scenario-runs/live
+          node - <<'NODE'
+          const fs = require("node:fs");
+          const report = {
+            schema: "eliza_live_scenario_setup_v1",
+            status: "setup_not_completed",
+            generatedAt: new Date().toISOString(),
+            note:
+              "Placeholder written before build/setup. If this file is uploaded unchanged, the workflow failed before scenario execution and no live model trajectory was produced.",
+            scenarios: [],
+            totalCount: 0,
+            passedCount: 0,
+            failedCount: 0
+          };
+          fs.writeFileSync(
+            "artifacts/lifeops-scenario-report.json",
+            `${JSON.stringify(report, null, 2)}\n`,
+          );
+          NODE
 
       - name: Build live scenario runtime packages
         id: build
@@ -246,7 +269,7 @@ jobs:
           # Run controls
           SCENARIO_FILTER: ${{ inputs.scenario_filter }}
           LIFEOPS_JUDGE_THRESHOLD: ${{ inputs.judge_threshold || '0.8' }}
-          SCENARIO_ENFORCE_GATE: ${{ inputs.enforce_gate && '1' || '0' }}
+          SCENARIO_ENFORCE_GATE: ${{ github.event_name == 'schedule' && '1' || (inputs.enforce_gate && '1' || '0') }}
           SKIP_REASON: ${{ inputs.skip_reason }}
           REPORT_PATH: artifacts/lifeops-scenario-report.json
           RUN_DIR: artifacts/scenario-runs/live
@@ -270,7 +293,7 @@ jobs:
           SCENARIO_ROOT: plugins/plugin-health/test/scenarios
           SCENARIO_FILTER: ${{ inputs.scenario_filter }}
           LIFEOPS_JUDGE_THRESHOLD: ${{ inputs.judge_threshold || '0.8' }}
-          SCENARIO_ENFORCE_GATE: ${{ inputs.enforce_gate && '1' || '0' }}
+          SCENARIO_ENFORCE_GATE: ${{ github.event_name == 'schedule' && '1' || (inputs.enforce_gate && '1' || '0') }}
           SKIP_REASON: ${{ inputs.skip_reason }}
           REPORT_PATH: artifacts/plugin-health-scenario-report.json
           RUN_DIR: artifacts/scenario-runs/plugin-health
@@ -296,7 +319,7 @@ jobs:
           SCENARIO_ROOT: plugins/plugin-app-control/test/scenarios
           SCENARIO_FILTER: ${{ inputs.scenario_filter }}
           LIFEOPS_JUDGE_THRESHOLD: ${{ inputs.judge_threshold || '0.8' }}
-          SCENARIO_ENFORCE_GATE: ${{ inputs.enforce_gate && '1' || '0' }}
+          SCENARIO_ENFORCE_GATE: ${{ github.event_name == 'schedule' && '1' || (inputs.enforce_gate && '1' || '0') }}
           SKIP_REASON: ${{ inputs.skip_reason }}
           REPORT_PATH: artifacts/app-control-scenario-report.json
           RUN_DIR: artifacts/scenario-runs/app-control


### PR DESCRIPTION
## Summary
- Makes scheduled `live-scenarios.yml` runs enforcing (`SCENARIO_ENFORCE_GATE=1`) once scenario execution is reached, while keeping manual dispatch report-only by default for debugging.
- Writes a placeholder `artifacts/lifeops-scenario-report.json` before build/setup so setup failures still upload a machine-readable artifact instead of a dark run with no report.
- Keeps `lifeops-bench.yml` pull_request coverage on `main`; the earlier develop retarget was dropped because #14194 deliberately kept that heavy suite off develop PRs.
- Applies the same schedule-enforcing gate expression to the plugin-health corpus step, so every corpus step in the lane has identical scheduled-run failure semantics.

Part of #14696. The current nightly `@elizaos/cloud-routing` build break and failure alerting remain open there.

## Live Run Verification
- `gh run list --repo elizaOS/eliza --workflow live-scenarios.yml --limit 10 --json ...` confirmed recent scheduled lane state:
  - 2026-07-05 run `28736276961`: failure
  - 2026-07-04 run `28701716050`: failure
  - 2026-07-03 run `28652043092`: success
  - 2026-07-02 run `28580346442`: success
  - 2026-06-26 through 2026-07-01: failures
- `gh run view 28736276961 --repo elizaOS/eliza --json jobs,conclusion,status,url` confirmed the latest failed before execution:
  - job: `Live scenarios (EA + connectors)`
  - failing step: `Build live scenario runtime packages`
  - `Run EA + connector live scenarios`: skipped
  - upload step completed, but prior issue evidence showed no report file existed; this PR adds the placeholder report before build/setup.

## Local Verification
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/live-scenarios.yml'); puts 'workflow yaml ok'"` — pass.
- `git diff origin/develop --check` — pass.
- Manual workflow review traced both `SCENARIO_ENFORCE_GATE` lines to the same schedule expression and checked `packages/scripts/run-live-scenarios.mjs` gate parsing: scheduled runs now propagate scenario failure exit codes; manual dispatch still honors `inputs.enforce_gate`.

## Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - workflow-only CI enforcement/reporting fix; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - workflow-only CI enforcement/reporting fix; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI/native workflow changed.
<!-- evidence-row:backend-logs -->
- [x] Backend logs / CI logs: https://github.com/elizaOS/eliza/actions/runs/28736276961 showed the pre-execution build failure and skipped scenario step; this PR adds a placeholder report before that failure point.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changed; this only changes scheduled CI gate semantics and artifact creation.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact: https://github.com/elizaOS/eliza/pull/14833/files updates the workflow to create `artifacts/lifeops-scenario-report.json` with `status: "setup_not_completed"` before build/setup, so pre-execution failures upload a machine-readable report.

## Known Gaps / Not Ready
- Still draft. Scope is reviewed as ready, but author/maintainer needs to mark ready-for-review.
- #14696 remains open for the current build failure and failure-alerting work; this PR only fixes enforcement semantics and dark-run artifact creation.

