### PR TITLE
fix(voice): voice-session WAVs invisible to media GC — dual reference keys + regression test

### DIFF
--- a/packages/agent/src/api/media-runtime.test.ts
+++ b/packages/agent/src/api/media-runtime.test.ts
@@ -209,6 +209,26 @@ describe("collectReferencedMedia", () => {
     expect(referenced.size).toBe(0);
   });
 
+  it("collects a file referenced only via memory.metadata.audioUrl", () => {
+    const memories = [
+      {
+        // Voice-session transcript knowledge doc: the retained WAV is anchored
+        // by `metadata.audioUrl` (what transcript readers look up) with no
+        // content.attachments entry — it must still be a live referent.
+        content: { text: "Alice: ship the build\nBob: on it" },
+        metadata: {
+          type: "document",
+          source: "transcript",
+          audioUrl: `/api/media/${HASH_A}.wav`,
+        },
+      },
+    ] as unknown as Memory[];
+
+    const referenced = collectReferencedMedia(memories);
+
+    expect(referenced.has(`${HASH_A}.wav`)).toBe(true);
+  });
+
   it("collects an attachment's thumbnailUrl alongside its full-image url", () => {
     // Full image and its downscaled preview are two separate stored files.
     const memories = [
@@ -272,6 +292,46 @@ describe("thumbnail GC protection (data-loss regression)", () => {
     // otherwise the inline preview 404s once GC sweeps the orphaned thumbnail.
     expect(fs.existsSync(mediaPath(full.fileName))).toBe(true);
     expect(fs.existsSync(mediaPath(thumb.fileName))).toBe(true);
+  });
+});
+
+describe("voice-session WAV GC protection (data-loss regression)", () => {
+  function mediaPath(fileName: string): string {
+    return path.join(stateDir, "media", fileName);
+  }
+
+  it("keeps a voice-session WAV referenced only by a transcript document's metadata.audioUrl", () => {
+    // A finished voice session persists its WAV into the media store and
+    // mirrors the transcript into knowledge with `metadata.audioUrl` pointing
+    // at it (plugin-local-inference transcript-knowledge). That document row
+    // is the only reference — there is no content.attachments entry — so the
+    // referenced-set scan must count `audioUrl` or the daily GC deletes the
+    // recording after the grace window (#14806).
+    const wav = persistMediaBytes(
+      Buffer.from("RIFF-voice-session-wav-regression"),
+      "audio/wav",
+    );
+
+    const memories = [
+      {
+        content: { text: "Alice: ship the build\nBob: on it" },
+        metadata: {
+          type: "document",
+          source: "transcript",
+          transcriptId: "t-123",
+          textBacked: true,
+          audioUrl: wav.url,
+        },
+      },
+    ] as unknown as Memory[];
+
+    // Age past the 1h grace window so only the reference set protects it.
+    const old = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    fs.utimesSync(mediaPath(wav.fileName), old, old);
+
+    gcUnreferencedMedia(collectReferencedMedia(memories));
+
+    expect(fs.existsSync(mediaPath(wav.fileName))).toBe(true);
   });
 });
 

--- a/packages/agent/src/api/media-runtime.ts
+++ b/packages/agent/src/api/media-runtime.ts
@@ -190,7 +190,15 @@ export function collectReferencedMedia(memories: Memory[]): Set<string> {
     // Document-linked original-bytes files: a knowledge document references its
     // stored original via `metadata.mediaUrl` (no content.attachments entry).
     // Collect it so the file survives GC while the document still references it.
-    addUrl((memory.metadata as { mediaUrl?: unknown } | undefined)?.mediaUrl);
+    // Transcript documents (voice sessions, meetings) additionally anchor the
+    // retained recording via `metadata.audioUrl` — the key transcript readers
+    // look up. Collect it too so a producer that set only `audioUrl` doesn't
+    // leave its WAV invisible to the sweep and deleted after the grace window.
+    const metadata = memory.metadata as
+      | { mediaUrl?: unknown; audioUrl?: unknown }
+      | undefined;
+    addUrl(metadata?.mediaUrl);
+    addUrl(metadata?.audioUrl);
   }
   return referenced;
 }

--- a/plugins/plugin-local-inference/src/services/voice/transcript-knowledge.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcript-knowledge.test.ts
@@ -51,7 +51,11 @@ describe("transcriptKnowledgePayload", () => {
 		expect(p.metadata.source).toBe(TRANSCRIPT_DOCUMENT_TAG);
 		expect(p.metadata.transcriptId).toBe("t-123");
 		expect(p.metadata.title).toBe("Standup — June 20");
+		// Both audio keys must be set: `mediaUrl` is what the daily media GC's
+		// referenced-set scan counts on document rows; `audioUrl` is what
+		// transcript readers look up. Missing `mediaUrl` gets the WAV swept.
 		expect(p.metadata.audioUrl).toBe("/api/media/abc.wav");
+		expect(p.metadata.mediaUrl).toBe("/api/media/abc.wav");
 		expect(p.metadata.durationMs).toBe(4000);
 		expect(p.metadata.speakerCount).toBe(2);
 		expect(p.metadata.textBacked).toBe(true);
@@ -64,6 +68,7 @@ describe("transcriptKnowledgePayload", () => {
 			audioUrl: undefined,
 		});
 		expect(p.metadata.audioUrl).toBeUndefined();
+		expect(p.metadata.mediaUrl).toBeUndefined();
 		expect(p.filename).toBe("transcript.txt");
 	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/transcript-knowledge.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcript-knowledge.ts
@@ -63,7 +63,14 @@ export function transcriptKnowledgePayload(
 		// text rather than an opaque binary upload.
 		textBacked: true,
 	};
-	if (transcript.audioUrl) metadata.audioUrl = transcript.audioUrl;
+	if (transcript.audioUrl) {
+		// `mediaUrl` is the key the daily media GC scans on document rows;
+		// `audioUrl` alone would leave the retained WAV unreferenced and it
+		// would be swept. Set both: mediaUrl anchors the media store handle,
+		// audioUrl is what transcript readers look up.
+		metadata.mediaUrl = transcript.audioUrl;
+		metadata.audioUrl = transcript.audioUrl;
+	}
 
 	return {
 		content: transcriptPlainText(transcript.segments),


### PR DESCRIPTION
## Bug

Voice-session recordings are silently deleted by the daily media GC.

- `plugins/plugin-local-inference/src/services/voice/transcript-knowledge.ts` — `transcriptKnowledgePayload` set **only** `metadata.audioUrl` on the mirrored knowledge document.
- `packages/agent/src/api/media-runtime.ts` — `collectReferencedMedia` scanned only `content.attachments[].url` / `thumbnailUrl` and `metadata.mediaUrl`.

Result: the transcript document is the WAV's only reference, the referenced-set scan never sees it, and the daily `MEDIA_GC` task sweeps the recording once it ages past the 1h grace window. `plugins/plugin-meetings/src/transcripts/meeting-transcript-writer.ts:425-432` already documents exactly this hazard and sets both keys — the voice-session path didn't.

## Fix (both sides, belt + suspenders)

1. **Producer:** `transcriptKnowledgePayload` now sets `metadata.mediaUrl = audioUrl` alongside `audioUrl`, matching the meeting writer's pattern and comment.
2. **Collector:** `collectReferencedMedia` additionally collects `metadata.audioUrl` — additive, protects any other producer that anchored a recording via `audioUrl` alone.

## Regression test — failing then passing

New `media-runtime.test.ts` cases: real temp content-addressed media store (`ELIZA_STATE_DIR` tmpdir, `persistMediaBytes`), a seeded voice-session transcript document memory whose **only** reference to the WAV is `metadata.audioUrl`, WAV aged 2h past the grace window, then `gcUnreferencedMedia(collectReferencedMedia(memories))`. Plus a `collectReferencedMedia` unit case and dual-key assertions in `transcript-knowledge.test.ts`. No mock of the thing under test.

**Pre-fix (fix stashed out — tests written first, run against develop's source):**

```
 FAIL  src/api/media-runtime.test.ts > voice-session WAV GC protection (data-loss regression) > keeps a voice-session WAV referenced only by a transcript document's metadata.audioUrl
AssertionError: expected false to be true
 ❯ src/api/media-runtime.test.ts:334:52
      Tests  2 failed | 13 passed (15)

 FAIL  src/services/voice/transcript-knowledge.test.ts
 expect(p.metadata.mediaUrl).toBe("/api/media/abc.wav")  → Received: undefined
      Tests  1 failed | 1 passed (2)
```

**Post-fix:**

```
packages/agent src/api/media-runtime.test.ts            Tests  15 passed (15)
plugin-local-inference transcript-knowledge.test.ts     Tests   2 passed (2)
packages/agent src/services/agent-export.media.test.ts  Tests   9 passed (9)  (other collectReferencedMedia consumer)
```

`tsgo --noEmit` clean on `packages/agent` + `plugins/plugin-local-inference`; `biome check` clean on all four touched files.

## Evidence notes

- Screenshots / video: N/A — no UI surface; behavior is a background GC task. Domain artifact is the WAV file surviving the sweep in the real temp store, asserted by the regression test above.
- Live-LLM trajectory: N/A — no agent/action/prompt/model behavior change; pure data-retention fix.

Prerequisite of #14806; found by the multimodal-PII research pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)