### PR TITLE
fix(transcripts): enforce scope on transcript reads

### DIFF
--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -8,6 +8,7 @@ import type { AppPackageRouteContext } from "../api/route-helpers";
 import type { ConnectorSourceDefinition } from "../connectors";
 import type { ResponseHandlerEvaluator } from "../runtime/response-handler-evaluators";
 import type { ResponseHandlerFieldEvaluator } from "../runtime/response-handler-field-evaluator";
+import type { AccessContext } from "./access-context";
 import type { Character } from "./agent";
 import type { ChatPreHandler } from "./chat-pre-handler";
 import type { Action, AgentContext, Provider } from "./components";
@@ -109,6 +110,12 @@ export interface RouteHandlerContext {
 	inProcess: boolean;
 	/** true when the HTTP transport has verified this request as loopback/local. */
 	isTrustedLocal?: boolean;
+	/**
+	 * Optional requester identity resolved by the authenticated boundary. Omitted
+	 * means the route is running under today's single-owner local boundary and
+	 * must preserve existing unfiltered behavior.
+	 */
+	accessContext?: AccessContext;
 }
 
 /** Return-shape result produced by a {@link RouteHandler}. */

--- a/packages/shared/src/transcripts.ts
+++ b/packages/shared/src/transcripts.ts
@@ -55,6 +55,24 @@ export type TranscriptScope =
   | "global"
   | "agent-private";
 
+const TRANSCRIPT_SCOPES: ReadonlySet<string> = new Set<TranscriptScope>([
+  "owner-private",
+  "user-private",
+  "global",
+  "agent-private",
+]);
+
+/**
+ * Normalize a scope value read from an untyped row/JSON boundary. Unknown,
+ * missing, or corrupt values fail CLOSED to `"owner-private"` — a legacy row
+ * that predates scope stamping must never widen visibility.
+ */
+export function normalizeTranscriptScope(scope: unknown): TranscriptScope {
+  return typeof scope === "string" && TRANSCRIPT_SCOPES.has(scope)
+    ? (scope as TranscriptScope)
+    : "owner-private";
+}
+
 export type TranscriptStatus = "recording" | "processing" | "ready" | "failed";
 
 /** A recorded + transcribed session: audio + word-timed diarized segments. */

--- a/plugins/plugin-local-inference/src/routes/transcripts-routes.test.ts
+++ b/plugins/plugin-local-inference/src/routes/transcripts-routes.test.ts
@@ -3,7 +3,12 @@
  * shaping via `buildTranscriptFromRequest` and the handler contract.
  */
 
-import type { Memory, RouteHandlerContext, UUID } from "@elizaos/core";
+import type {
+	AccessContext,
+	Memory,
+	RouteHandlerContext,
+	UUID,
+} from "@elizaos/core";
 import { buildMeetingArtifactFixtures } from "@elizaos/shared";
 import type { TranscriptSegment } from "@elizaos/shared/transcripts";
 import { describe, expect, it } from "vitest";
@@ -16,6 +21,7 @@ import {
 const WORLD = "00000000-0000-0000-0000-0000000000ww" as UUID;
 const ROOM = "11111111-1111-1111-1111-111111111111" as UUID;
 const ENTITY = "22222222-2222-2222-2222-222222222222" as UUID;
+const OTHER_ENTITY = "33333333-3333-3333-3333-333333333333" as UUID;
 
 const segments: TranscriptSegment[] = [
 	{
@@ -78,6 +84,12 @@ function handlerFor(type: string, path: string) {
 	if (!r?.routeHandler) throw new Error(`no route ${type} ${path}`);
 	return r.routeHandler;
 }
+
+const access = (requesterEntityId: UUID): AccessContext => ({
+	requesterEntityId,
+	worldId: WORLD,
+	role: "USER",
+});
 
 describe("buildTranscriptFromRequest", () => {
 	it("derives duration + speaker count + defaults", () => {
@@ -273,5 +285,87 @@ describe("transcripts routes", () => {
 			"/api/transcripts/:id",
 		)(ctx({ runtime: runtime as never, params: { id: "x" }, body: {} }));
 		expect(res.status).toBe(400);
+	});
+
+	it("filters GET list and get-by-id for a non-owner requester", async () => {
+		const { runtime } = fakeRuntime();
+		const post = handlerFor("POST", "/api/transcripts");
+		const list = handlerFor("GET", "/api/transcripts");
+		const get = handlerFor("GET", "/api/transcripts/:id");
+
+		const ownerPrivate = await post(
+			ctx({
+				runtime: runtime as never,
+				body: {
+					title: "Owner private",
+					roomId: ROOM,
+					entityId: ENTITY,
+					scope: "owner-private",
+					segments,
+				},
+			}),
+		);
+		await post(
+			ctx({
+				runtime: runtime as never,
+				body: {
+					title: "Global",
+					roomId: ROOM,
+					entityId: OTHER_ENTITY,
+					scope: "global",
+					segments,
+				},
+			}),
+		);
+		await post(
+			ctx({
+				runtime: runtime as never,
+				body: {
+					title: "User owned",
+					roomId: ROOM,
+					entityId: ENTITY,
+					scope: "user-private",
+					segments,
+				},
+			}),
+		);
+		await post(
+			ctx({
+				runtime: runtime as never,
+				body: {
+					title: "Other user",
+					roomId: ROOM,
+					entityId: OTHER_ENTITY,
+					scope: "user-private",
+					segments,
+				},
+			}),
+		);
+
+		const unfiltered = await list(ctx({ runtime: runtime as never }));
+		expect(
+			(unfiltered.body as { transcripts: Array<{ title: string }> })
+				.transcripts,
+		).toHaveLength(4);
+
+		const filtered = await list(
+			ctx({ runtime: runtime as never, accessContext: access(ENTITY) }),
+		);
+		expect(
+			(filtered.body as { transcripts: Array<{ title: string }> }).transcripts
+				.map((t) => t.title)
+				.sort(),
+		).toEqual(["Global", "User owned"]);
+
+		const id = (ownerPrivate.body as { transcript: { id: string } }).transcript
+			.id;
+		const hidden = await get(
+			ctx({
+				runtime: runtime as never,
+				params: { id },
+				accessContext: access(ENTITY),
+			}),
+		);
+		expect(hidden.status).toBe(404);
 	});
 });

--- a/plugins/plugin-local-inference/src/routes/transcripts-routes.ts
+++ b/plugins/plugin-local-inference/src/routes/transcripts-routes.ts
@@ -109,7 +109,11 @@ const listRoute: Route = {
 	rawPath: true,
 	routeHandler: async (ctx): Promise<RouteHandlerResult> => {
 		const roomId = (ctx.query.roomId as string | undefined) || undefined;
-		const transcripts = await service(ctx).list(roomId as UUID | undefined);
+		const transcripts = await service(ctx).list(
+			roomId as UUID | undefined,
+			undefined,
+			ctx.accessContext,
+		);
 		return { status: 200, body: { transcripts } };
 	},
 };
@@ -119,7 +123,10 @@ const getRoute: Route = {
 	path: "/api/transcripts/:id",
 	rawPath: true,
 	routeHandler: async (ctx): Promise<RouteHandlerResult> => {
-		const transcript = await service(ctx).get(ctx.params.id as UUID);
+		const transcript = await service(ctx).get(
+			ctx.params.id as UUID,
+			ctx.accessContext,
+		);
 		if (!transcript) return { status: 404, body: { error: "not found" } };
 		return { status: 200, body: { transcript } };
 	},

--- a/plugins/plugin-local-inference/src/services/voice/transcript-service.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcript-service.test.ts
@@ -1,5 +1,5 @@
 /** Covers `TranscriptService` transcript lifecycle. Deterministic. */
-import type { Memory, UUID } from "@elizaos/core";
+import type { AccessContext, Memory, UUID } from "@elizaos/core";
 import type { Transcript } from "@elizaos/shared/transcripts";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -11,8 +11,9 @@ import {
 const WORLD = "00000000-0000-0000-0000-0000000000ww" as UUID;
 const ROOM = "11111111-1111-1111-1111-111111111111" as UUID;
 const ENTITY = "22222222-2222-2222-2222-222222222222" as UUID;
+const OTHER_ENTITY = "33333333-3333-3333-3333-333333333333" as UUID;
 
-function makeTranscript(): Transcript {
+function makeTranscript(over: Partial<Transcript> = {}): Transcript {
 	return {
 		id: "aaaaaaaa-0000-0000-0000-000000000001",
 		title: "Standup",
@@ -33,6 +34,7 @@ function makeTranscript(): Transcript {
 				words: [],
 			},
 		],
+		...over,
 	};
 }
 
@@ -83,6 +85,16 @@ const input = (transcript: Transcript): CreateTranscriptInput => ({
 	roomId: ROOM,
 	entityId: ENTITY,
 	transcript,
+});
+
+const access = (
+	requesterEntityId: UUID,
+	role: AccessContext["role"] = "USER",
+): AccessContext => ({
+	requesterEntityId,
+	worldId: WORLD,
+	role,
+	isOwner: role === "OWNER",
 });
 
 describe("TranscriptService", () => {
@@ -192,5 +204,79 @@ describe("TranscriptService", () => {
 			},
 		);
 		expect(result).toBeNull();
+	});
+
+	it("filters list/get by transcript scope when a requester context is supplied", async () => {
+		const rt = fakeRuntime({ withDocuments: false });
+		const svc = new TranscriptService(rt);
+		const records = [
+			makeTranscript({
+				id: "aaaaaaaa-0000-0000-0000-0000000000a1",
+				title: "Owner private",
+				scope: "owner-private",
+			}),
+			makeTranscript({
+				id: "aaaaaaaa-0000-0000-0000-0000000000a2",
+				title: "Agent private",
+				scope: "agent-private",
+			}),
+			makeTranscript({
+				id: "aaaaaaaa-0000-0000-0000-0000000000a3",
+				title: "Global",
+				scope: "global",
+			}),
+			makeTranscript({
+				id: "aaaaaaaa-0000-0000-0000-0000000000a4",
+				title: "User owned",
+				scope: "user-private",
+			}),
+			makeTranscript({
+				id: "aaaaaaaa-0000-0000-0000-0000000000a5",
+				title: "Other user",
+				scope: "user-private",
+			}),
+		];
+		for (const record of records.slice(0, 4)) {
+			await svc.create(input(record));
+		}
+		await svc.create({
+			worldId: WORLD,
+			roomId: ROOM,
+			entityId: OTHER_ENTITY,
+			transcript: records[4],
+		});
+
+		expect((await svc.list(ROOM)).map((t) => t.title).sort()).toEqual([
+			"Agent private",
+			"Global",
+			"Other user",
+			"Owner private",
+			"User owned",
+		]);
+		expect(
+			(await svc.list(ROOM, undefined, access(ENTITY)))
+				.map((t) => t.title)
+				.sort(),
+		).toEqual(["Global", "User owned"]);
+		expect(
+			(await svc.list(ROOM, undefined, access(OTHER_ENTITY)))
+				.map((t) => t.title)
+				.sort(),
+		).toEqual(["Global", "Other user"]);
+		expect(
+			(await svc.list(ROOM, undefined, access("owner" as UUID, "OWNER"))).map(
+				(t) => t.title,
+			),
+		).toHaveLength(5);
+		expect(
+			(await svc.list(ROOM, undefined, access(rt.agentId, "USER"))).map(
+				(t) => t.title,
+			),
+		).toHaveLength(5);
+
+		expect(await svc.get(records[0].id as UUID, access(ENTITY))).toBeNull();
+		expect((await svc.get(records[3].id as UUID, access(ENTITY)))?.title).toBe(
+			"User owned",
+		);
 	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/transcript-service.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcript-service.ts
@@ -7,7 +7,7 @@
  * link. Delete removes the mirror too.
  */
 
-import { logger, type UUID } from "@elizaos/core";
+import { type AccessContext, logger, type UUID } from "@elizaos/core";
 import type {
 	Transcript,
 	TranscriptScope,
@@ -84,12 +84,16 @@ export class TranscriptService {
 		return this.store.create({ roomId, entityId, transcript: record });
 	}
 
-	list(roomId?: UUID, limit?: number): Promise<TranscriptSummary[]> {
-		return this.store.list(roomId, limit);
+	list(
+		roomId?: UUID,
+		limit?: number,
+		accessContext?: AccessContext,
+	): Promise<TranscriptSummary[]> {
+		return this.store.list(roomId, limit, accessContext);
 	}
 
-	get(id: UUID): Promise<Transcript | null> {
-		return this.store.get(id);
+	get(id: UUID, accessContext?: AccessContext): Promise<Transcript | null> {
+		return this.store.get(id, accessContext);
 	}
 
 	/**

--- a/plugins/plugin-local-inference/src/services/voice/transcript-store.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcript-store.ts
@@ -11,7 +11,15 @@
  * `metadata.type` keeps it clear of the document/fragment CHECK constraints.
  */
 
-import type { Memory, MemoryMetadata, UUID } from "@elizaos/core";
+import {
+	type AccessContext,
+	actorFromAccessContext,
+	canReadScope,
+	type Memory,
+	type MemoryMetadata,
+	type MemoryScope,
+	type UUID,
+} from "@elizaos/core";
 import type {
 	Transcript,
 	TranscriptSummary,
@@ -25,6 +33,12 @@ import {
 export const TRANSCRIPTS_TABLE = "transcripts";
 /** `metadata.type` marker — NOT "document"/"fragment", so no CHECK fires. */
 export const TRANSCRIPT_METADATA_TYPE = "transcript";
+const TRANSCRIPT_SCOPES = new Set<MemoryScope>([
+	"owner-private",
+	"user-private",
+	"global",
+	"agent-private",
+]);
 
 /** The subset of `IAgentRuntime` the store needs (real runtime satisfies it). */
 export interface TranscriptStoreRuntime {
@@ -69,6 +83,48 @@ function rowToTranscript(row: Memory): Transcript | null {
 	}
 }
 
+function normalizeTranscriptScope(scope: unknown): MemoryScope {
+	return typeof scope === "string" &&
+		TRANSCRIPT_SCOPES.has(scope as MemoryScope)
+		? (scope as MemoryScope)
+		: "owner-private";
+}
+
+export function canAccessTranscriptRecord(
+	transcript: Pick<Transcript, "scope">,
+	scopedEntityId: UUID | undefined,
+	accessContext: AccessContext | undefined,
+	agentId: UUID,
+): boolean {
+	if (!accessContext) return true;
+	if (accessContext.requesterEntityId === agentId) return true;
+	const actor = actorFromAccessContext(accessContext, agentId);
+	if (actor.role === "OWNER") return true;
+	return canReadScope(
+		normalizeTranscriptScope(transcript.scope),
+		scopedEntityId,
+		actor,
+	);
+}
+
+function canAccessTranscriptRow(
+	row: Memory,
+	transcript: Pick<Transcript, "scope">,
+	accessContext: AccessContext | undefined,
+	agentId: UUID,
+): boolean {
+	const metadata = row.metadata as Record<string, unknown> | undefined;
+	const scopedTo = metadata?.scopedToEntityId;
+	const scopedEntityId =
+		typeof scopedTo === "string" ? (scopedTo as UUID) : row.entityId;
+	return canAccessTranscriptRecord(
+		transcript,
+		scopedEntityId,
+		accessContext,
+		agentId,
+	);
+}
+
 /** CRUD for transcript records over the runtime memory partition. */
 export class TranscriptStore {
 	constructor(private readonly runtime: TranscriptStoreRuntime) {}
@@ -79,6 +135,8 @@ export class TranscriptStore {
 		const metadata: MemoryMetadata = {
 			type: "custom",
 			source: TRANSCRIPT_METADATA_TYPE,
+			scope: transcript.scope,
+			scopedToEntityId: entityId,
 			timestamp: transcript.createdAt,
 			transcriptId: transcript.id,
 			durationMs: transcript.durationMs,
@@ -106,7 +164,11 @@ export class TranscriptStore {
 	}
 
 	/** List recent transcripts (newest first) as compact summaries. */
-	async list(roomId?: UUID, limit = 100): Promise<TranscriptSummary[]> {
+	async list(
+		roomId?: UUID,
+		limit = 100,
+		accessContext?: AccessContext,
+	): Promise<TranscriptSummary[]> {
 		const rows = await this.runtime.getMemories({
 			tableName: TRANSCRIPTS_TABLE,
 			roomId,
@@ -117,15 +179,33 @@ export class TranscriptStore {
 		const summaries: TranscriptSummary[] = [];
 		for (const row of rows) {
 			const t = rowToTranscript(row);
-			if (t) summaries.push(summarizeTranscript(t));
+			if (
+				t &&
+				canAccessTranscriptRow(row, t, accessContext, this.runtime.agentId)
+			) {
+				summaries.push(summarizeTranscript(t));
+			}
 		}
 		return summaries;
 	}
 
 	/** Load one full transcript record by id. */
-	async get(id: UUID): Promise<Transcript | null> {
+	async get(
+		id: UUID,
+		accessContext?: AccessContext,
+	): Promise<Transcript | null> {
 		const row = await this.runtime.getMemoryById(id);
-		return row ? rowToTranscript(row) : null;
+		if (!row) return null;
+		const transcript = rowToTranscript(row);
+		if (!transcript) return null;
+		return canAccessTranscriptRow(
+			row,
+			transcript,
+			accessContext,
+			this.runtime.agentId,
+		)
+			? transcript
+			: null;
 	}
 
 	/**
@@ -135,6 +215,7 @@ export class TranscriptStore {
 	 * consumers and the list stay consistent. Returns the record as stored.
 	 */
 	async update(transcript: Transcript): Promise<Transcript> {
+		const existing = await this.runtime.getMemoryById(transcript.id as UUID);
 		const ok = await this.runtime.updateMemory({
 			id: transcript.id as UUID,
 			content: {
@@ -144,6 +225,8 @@ export class TranscriptStore {
 			metadata: {
 				type: "custom",
 				source: TRANSCRIPT_METADATA_TYPE,
+				scope: transcript.scope,
+				scopedToEntityId: existing?.entityId,
 				timestamp: transcript.createdAt,
 				transcriptId: transcript.id,
 				durationMs: transcript.durationMs,

--- a/plugins/plugin-local-inference/src/services/voice/transcript-store.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcript-store.ts
@@ -17,7 +17,6 @@ import {
 	canReadScope,
 	type Memory,
 	type MemoryMetadata,
-	type MemoryScope,
 	type UUID,
 } from "@elizaos/core";
 import type {
@@ -25,6 +24,7 @@ import type {
 	TranscriptSummary,
 } from "@elizaos/shared/transcripts";
 import {
+	normalizeTranscriptScope,
 	summarizeTranscript,
 	transcriptPreview,
 } from "@elizaos/shared/transcripts";
@@ -33,12 +33,6 @@ import {
 export const TRANSCRIPTS_TABLE = "transcripts";
 /** `metadata.type` marker — NOT "document"/"fragment", so no CHECK fires. */
 export const TRANSCRIPT_METADATA_TYPE = "transcript";
-const TRANSCRIPT_SCOPES = new Set<MemoryScope>([
-	"owner-private",
-	"user-private",
-	"global",
-	"agent-private",
-]);
 
 /** The subset of `IAgentRuntime` the store needs (real runtime satisfies it). */
 export interface TranscriptStoreRuntime {
@@ -81,13 +75,6 @@ function rowToTranscript(row: Memory): Transcript | null {
 	} catch {
 		return null;
 	}
-}
-
-function normalizeTranscriptScope(scope: unknown): MemoryScope {
-	return typeof scope === "string" &&
-		TRANSCRIPT_SCOPES.has(scope as MemoryScope)
-		? (scope as MemoryScope)
-		: "owner-private";
 }
 
 export function canAccessTranscriptRecord(

--- a/plugins/plugin-meetings/src/routes/meetings-routes.test.ts
+++ b/plugins/plugin-meetings/src/routes/meetings-routes.test.ts
@@ -3,7 +3,7 @@
  * guards), list, fetch-one, and graceful leave. Deterministic: fake runtime plus
  * scripted adapter, no browser.
  */
-import type { RouteHandlerContext } from "@elizaos/core";
+import type { AccessContext, RouteHandlerContext, UUID } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { MeetingService } from "../service.js";
 import {
@@ -15,6 +15,12 @@ import {
 import { meetingsRoutes } from "./meetings-routes.js";
 
 const MEET_URL = "https://meet.google.com/abc-defg-hij";
+const USER = "22222222-2222-2222-2222-222222222222" as UUID;
+
+const userAccess: AccessContext = {
+  requesterEntityId: USER,
+  role: "USER",
+};
 
 function route(method: string, path: string) {
   const found = meetingsRoutes.find(
@@ -153,6 +159,34 @@ describe("/api/meetings routes", () => {
     expect(
       (await del(ctx({ params: { id: crypto.randomUUID() } }))).status,
     ).toBe(404);
+  });
+
+  it("redacts transcriptId from meeting sessions when the requester cannot read the transcript", async () => {
+    const { ctx, adapter } = makeHarness();
+    const post = route("POST", "/api/meetings");
+    const list = route("GET", "/api/meetings");
+    const get = route("GET", "/api/meetings/:id");
+
+    const created = await post(ctx({ body: { meetingUrl: MEET_URL } }));
+    const session = (
+      created.body as { session: { id: string; transcriptId?: string } }
+    ).session;
+    expect(session.transcriptId).toBeTypeOf("string");
+    await adapter.started;
+
+    const filteredList = await list(ctx({ accessContext: userAccess }));
+    const filteredSession = (
+      filteredList.body as { sessions: Array<{ transcriptId?: string }> }
+    ).sessions[0];
+    expect(filteredSession.transcriptId).toBeUndefined();
+
+    const filteredGet = await get(
+      ctx({ params: { id: session.id }, accessContext: userAccess }),
+    );
+    expect(
+      (filteredGet.body as { session: { transcriptId?: string } }).session
+        .transcriptId,
+    ).toBeUndefined();
   });
 
   it("answers 503 when the meetings service is not running", async () => {

--- a/plugins/plugin-meetings/src/routes/meetings-routes.ts
+++ b/plugins/plugin-meetings/src/routes/meetings-routes.ts
@@ -9,12 +9,23 @@
  */
 
 import type {
+  AccessContext,
+  Memory,
   Route,
   RouteHandlerContext,
   RouteHandlerResult,
   UUID,
 } from "@elizaos/core";
-import type { MeetingJoinRequest, MeetingPlatform } from "@elizaos/shared";
+import {
+  actorFromAccessContext,
+  canReadScope,
+  type MemoryScope,
+} from "@elizaos/core";
+import type {
+  MeetingJoinRequest,
+  MeetingPlatform,
+  MeetingSession,
+} from "@elizaos/shared";
 import { parseMeetingUrl } from "@elizaos/shared";
 import { MeetingJoinError, type MeetingService } from "../service.js";
 
@@ -22,10 +33,75 @@ function service(ctx: RouteHandlerContext): MeetingService | null {
   return ctx.runtime.getService<MeetingService>("meetings");
 }
 
+type TranscriptAccessRouteContext = RouteHandlerContext & {
+  accessContext?: AccessContext;
+};
+
 const unavailable: RouteHandlerResult = {
   status: 503,
   body: { error: "meetings service is not running" },
 };
+
+const TRANSCRIPT_SCOPES = new Set<MemoryScope>([
+  "owner-private",
+  "user-private",
+  "global",
+  "agent-private",
+]);
+
+function normalizeTranscriptScope(scope: unknown): MemoryScope {
+  return typeof scope === "string" &&
+    TRANSCRIPT_SCOPES.has(scope as MemoryScope)
+    ? (scope as MemoryScope)
+    : "owner-private";
+}
+
+function transcriptScopeFromRow(row: Memory): MemoryScope {
+  const raw = (row.content as { transcript?: unknown } | undefined)?.transcript;
+  if (typeof raw !== "string") return "owner-private";
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return normalizeTranscriptScope(
+      parsed && typeof parsed === "object"
+        ? (parsed as { scope?: unknown }).scope
+        : undefined,
+    );
+  } catch {
+    return "owner-private";
+  }
+}
+
+function canAccessTranscriptRow(
+  row: Memory,
+  accessContext: AccessContext,
+  agentId: UUID,
+): boolean {
+  if (accessContext.requesterEntityId === agentId) return true;
+  const metadata = row.metadata as Record<string, unknown> | undefined;
+  const scopedTo = metadata?.scopedToEntityId;
+  const scopedEntityId =
+    typeof scopedTo === "string" ? (scopedTo as UUID) : row.entityId;
+  const actor = actorFromAccessContext(accessContext, agentId);
+  if (actor.role === "OWNER") return true;
+  return canReadScope(transcriptScopeFromRow(row), scopedEntityId, actor);
+}
+
+async function redactSessionTranscriptDisclosure(
+  ctx: RouteHandlerContext,
+  session: MeetingSession,
+): Promise<MeetingSession> {
+  const accessContext = (ctx as TranscriptAccessRouteContext).accessContext;
+  if (!accessContext || !session.transcriptId) return session;
+  const row = await ctx.runtime.getMemoryById(session.transcriptId as UUID);
+  if (
+    row &&
+    canAccessTranscriptRow(row, accessContext, ctx.runtime.agentId as UUID)
+  ) {
+    return session;
+  }
+  const { transcriptId: _transcriptId, ...redacted } = session;
+  return redacted;
+}
 
 /** The body POST /api/meetings accepts. */
 export interface CreateMeetingRequest {
@@ -115,7 +191,12 @@ const listRoute: Route = {
     const activeParam = ctx.query.active;
     const active =
       activeParam === "1" || activeParam === "true" ? true : undefined;
-    return { status: 200, body: { sessions: svc.listSessions({ active }) } };
+    const sessions = await Promise.all(
+      svc
+        .listSessions({ active })
+        .map((session) => redactSessionTranscriptDisclosure(ctx, session)),
+    );
+    return { status: 200, body: { sessions } };
   },
 };
 
@@ -128,7 +209,10 @@ const getRoute: Route = {
     if (!svc) return unavailable;
     const session = svc.getSession(ctx.params.id as UUID);
     if (!session) return { status: 404, body: { error: "not found" } };
-    return { status: 200, body: { session } };
+    return {
+      status: 200,
+      body: { session: await redactSessionTranscriptDisclosure(ctx, session) },
+    };
   },
 };
 

--- a/plugins/plugin-meetings/src/routes/meetings-routes.ts
+++ b/plugins/plugin-meetings/src/routes/meetings-routes.ts
@@ -16,47 +16,27 @@ import type {
   RouteHandlerResult,
   UUID,
 } from "@elizaos/core";
-import {
-  actorFromAccessContext,
-  canReadScope,
-  type MemoryScope,
-} from "@elizaos/core";
+import { actorFromAccessContext, canReadScope } from "@elizaos/core";
 import type {
   MeetingJoinRequest,
   MeetingPlatform,
   MeetingSession,
 } from "@elizaos/shared";
 import { parseMeetingUrl } from "@elizaos/shared";
+import type { TranscriptScope } from "@elizaos/shared/transcripts";
+import { normalizeTranscriptScope } from "@elizaos/shared/transcripts";
 import { MeetingJoinError, type MeetingService } from "../service.js";
 
 function service(ctx: RouteHandlerContext): MeetingService | null {
   return ctx.runtime.getService<MeetingService>("meetings");
 }
 
-type TranscriptAccessRouteContext = RouteHandlerContext & {
-  accessContext?: AccessContext;
-};
-
 const unavailable: RouteHandlerResult = {
   status: 503,
   body: { error: "meetings service is not running" },
 };
 
-const TRANSCRIPT_SCOPES = new Set<MemoryScope>([
-  "owner-private",
-  "user-private",
-  "global",
-  "agent-private",
-]);
-
-function normalizeTranscriptScope(scope: unknown): MemoryScope {
-  return typeof scope === "string" &&
-    TRANSCRIPT_SCOPES.has(scope as MemoryScope)
-    ? (scope as MemoryScope)
-    : "owner-private";
-}
-
-function transcriptScopeFromRow(row: Memory): MemoryScope {
+function transcriptScopeFromRow(row: Memory): TranscriptScope {
   const raw = (row.content as { transcript?: unknown } | undefined)?.transcript;
   if (typeof raw !== "string") return "owner-private";
   try {
@@ -67,6 +47,8 @@ function transcriptScopeFromRow(row: Memory): MemoryScope {
         : undefined,
     );
   } catch {
+    // error-policy:J3 untrusted stored JSON — an unparseable transcript row
+    // fails CLOSED to owner-private so corruption can never widen visibility.
     return "owner-private";
   }
 }
@@ -90,7 +72,7 @@ async function redactSessionTranscriptDisclosure(
   ctx: RouteHandlerContext,
   session: MeetingSession,
 ): Promise<MeetingSession> {
-  const accessContext = (ctx as TranscriptAccessRouteContext).accessContext;
+  const accessContext = ctx.accessContext;
   if (!accessContext || !session.transcriptId) return session;
   const row = await ctx.runtime.getMemoryById(session.transcriptId as UUID);
   if (


### PR DESCRIPTION
## Summary

Fixes #14752 by enforcing stored `Transcript.scope` on transcript read paths when a requester access context is supplied. The current local dashboard remains unchanged because route calls without `accessContext` preserve the existing single-owner behavior.

## Changes

- Adds optional `accessContext` to `RouteHandlerContext` for future authenticated-boundary requester propagation.
- Threads `accessContext` through `/api/transcripts` list/get into `TranscriptService` and `TranscriptStore`.
- Applies transcript visibility rules:
  - no `accessContext` = existing unfiltered local-owner behavior,
  - agent self and OWNER/Admin = full access,
  - `global` = visible,
  - `owner-private`/`agent-private` = hidden from ordinary users,
  - `user-private` = visible only to the transcript row's scoped/owning entity.
- Stamps transcript rows with `metadata.scope` and `metadata.scopedToEntityId` so generic memory filters have the same facts without parsing the transcript JSON.
- Redacts `transcriptId` from `/api/meetings` list/get session DTOs when a supplied requester cannot read the referenced transcript row.

## Verification

- `bunx @biomejs/biome check --write packages/core/src/types/plugin.ts plugins/plugin-local-inference/src/services/voice/transcript-store.ts plugins/plugin-local-inference/src/services/voice/transcript-service.ts plugins/plugin-local-inference/src/routes/transcripts-routes.ts plugins/plugin-local-inference/src/services/voice/transcript-service.test.ts plugins/plugin-local-inference/src/routes/transcripts-routes.test.ts plugins/plugin-meetings/src/routes/meetings-routes.ts plugins/plugin-meetings/src/routes/meetings-routes.test.ts` passed.
- `bun run --cwd plugins/plugin-local-inference test src/services/voice/transcript-service.test.ts src/routes/transcripts-routes.test.ts` passed: 2 files, 16 tests.
- `bun run --cwd plugins/plugin-meetings test src/routes/meetings-routes.test.ts` passed: 1 file, 7 tests.
- `bun run --cwd plugins/plugin-local-inference typecheck` passed.
- `bun run --cwd plugins/plugin-meetings typecheck` passed.
- `bun run --cwd packages/core typecheck` passed.
- `git diff --check` passed.
- `bun run audit:error-policy-ratchet --report` passed: no new fallback slop in touched files.

<details>
<summary>Scope matrix covered by tests</summary>

```text
No accessContext: list/get remain unfiltered for today's local owner dashboard.
USER requester A: sees global + A's user-private transcript only.
USER requester B: sees global + B's user-private transcript only.
OWNER requester: sees owner-private, agent-private, global, own user-private, other user-private.
Agent self requester: sees every transcript.
/api/transcripts/:id as non-owner against owner-private: 404.
/api/meetings as non-owner against unreadable transcript row: session remains, transcriptId is omitted.
```
</details>

## Evidence

<!-- evidence-row:before-screenshots -->
N/A - backend API authorization bug; no UI pixels changed.

<!-- evidence-row:after-screenshots -->
N/A - backend API authorization bug; no UI pixels changed.

<!-- evidence-row:walkthrough-video -->
N/A - backend API authorization bug; deterministic route/service tests provide the API trace evidence above.

<!-- evidence-row:backend-logs -->
N/A - no long-running backend server was started; route handlers were invoked directly in package tests with synthetic requester contexts.

<!-- evidence-row:frontend-logs -->
N/A - no frontend code or browser surface changed.

<!-- evidence-row:llm-trajectory -->
N/A - no prompt, action, provider, model, or LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
N/A - domain artifacts are in-memory transcript rows with stored scopes; the matrix above describes the rows and read results asserted by the tests.
