### PR TITLE
fix(telegram): stamp stable role identity metadata (#14711)

### DIFF
--- a/packages/core/src/roles.test.ts
+++ b/packages/core/src/roles.test.ts
@@ -33,6 +33,7 @@ import {
 	ROLE_RANK,
 	recordOwnerGrant,
 	recordRoleGrant,
+	resolveEntityRole,
 	resolveWorldForMessage,
 } from "./roles.ts";
 import {
@@ -484,6 +485,43 @@ describe("connector metadata is registry-driven, not Discord-special-cased (#120
 		expect(getLiveEntityMetadataFromMessage(message)).toBeUndefined();
 	});
 
+	it("falls back to declared flat mapping when nested connector metadata has no stable id", () => {
+		const owner = "test:telegram-connector";
+		try {
+			registerConnectorSourceMetadata(
+				"telegram",
+				{
+					identityMetadataMapping: {
+						userIdField: "fromId",
+						nameField: "entityName",
+					},
+				},
+				owner,
+			);
+			const message = {
+				entityId: "e-1",
+				roomId: "room-1",
+				content: { text: "hi", source: "telegram" },
+				metadata: {
+					telegram: { chatId: "chat-1", messageId: "message-1" },
+					fromId: "user-123",
+					entityName: "Ada",
+				},
+			} as unknown as Memory;
+
+			expect(getLiveEntityMetadataFromMessage(message)).toEqual({
+				telegram: {
+					userId: "user-123",
+					id: "user-123",
+					name: "Ada",
+					username: "Ada",
+				},
+			});
+		} finally {
+			unregisterConnectorSourceMetadataOwner(owner);
+		}
+	});
+
 	it("works for a NEW connector purely by registering mapping metadata (no core edit)", () => {
 		const owner = "test:matrix-connector";
 		try {
@@ -514,6 +552,35 @@ describe("connector metadata is registry-driven, not Discord-special-cased (#120
 		} finally {
 			unregisterConnectorSourceMetadataOwner(owner);
 		}
+	});
+
+	it("uses stored sender metadata when live connector metadata has no stable id", async () => {
+		const ownerEntityId = "owner-entity";
+		const senderEntityId = "sender-entity";
+		const runtime = {
+			agentId: "agent-1",
+			getSetting: () => undefined,
+			getRelationships: async () => [],
+			getEntityById: async (id: string) => {
+				if (id === ownerEntityId || id === senderEntityId) {
+					return {
+						id,
+						metadata: { telegram: { id: "telegram-owner" } },
+					};
+				}
+				return null;
+			},
+		} as unknown as IAgentRuntime;
+
+		await expect(
+			resolveEntityRole(
+				runtime,
+				null,
+				{ ownership: { ownerId: ownerEntityId } } as never,
+				senderEntityId,
+				{ liveEntityMetadata: { telegram: { chatId: "chat-1" } } },
+			),
+		).resolves.toBe("OWNER");
 	});
 
 	it("derives the world id from the declared world-id keys (first present wins)", async () => {

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -251,6 +251,30 @@ export function getUnresolvedSenderRoleFloor(message: Memory): RoleName {
 	return "GUEST";
 }
 
+function hasConnectorStableIdentity(
+	metadata: Record<string, unknown> | null | undefined,
+): boolean {
+	if (!metadata) {
+		return false;
+	}
+
+	for (const rawConnector of Object.values(metadata)) {
+		const connector = asRecord(rawConnector);
+		if (!connector) {
+			continue;
+		}
+
+		for (const field of CONNECTOR_STABLE_ID_FIELDS) {
+			const value = connector[field];
+			if (typeof value === "string" && value.trim().length > 0) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
 function getConnectorMetadataFromMemory(
 	message: Memory,
 ): Record<string, unknown> | undefined {
@@ -262,7 +286,10 @@ function getConnectorMetadataFromMemory(
 
 	const sourceMetadata = asRecord(memoryMetadata?.[source]);
 	if (sourceMetadata) {
-		return { [source]: sourceMetadata };
+		const nestedMetadata = { [source]: sourceMetadata };
+		if (hasConnectorStableIdentity(nestedMetadata)) {
+			return nestedMetadata;
+		}
 	}
 
 	// No nested `metadata[source]` object present. Fall back to the connector's
@@ -497,8 +524,10 @@ async function resolveOwnershipRole(
 		return null;
 	}
 
-	const senderMetadata =
-		options?.liveEntityMetadata ?? (await getEntityMetadata(runtime, entityId));
+	const liveEntityMetadata = options?.liveEntityMetadata;
+	const senderMetadata = hasConnectorStableIdentity(liveEntityMetadata)
+		? liveEntityMetadata
+		: await getEntityMetadata(runtime, entityId);
 
 	for (const ownerId of ownerIds) {
 		if (ownerId === entityId) {

--- a/plugins/plugin-telegram/__tests__/core-test-mock.ts
+++ b/plugins/plugin-telegram/__tests__/core-test-mock.ts
@@ -94,9 +94,20 @@ vi.mock("@elizaos/core", async () => {
     }
   }
 
+  class CommandRegistryService extends Service {
+    static readonly serviceType = "commands";
+
+    register(): void {}
+
+    list(): unknown[] {
+      return [];
+    }
+  }
+
   return {
     ...interactions,
     ChannelType,
+    CommandRegistryService,
     EventType,
     ModelType,
     Role,

--- a/plugins/plugin-telegram/src/index.ts
+++ b/plugins/plugin-telegram/src/index.ts
@@ -34,6 +34,11 @@ const telegramPlugin: Plugin = {
       aliases: ["telegram", "telegram-account", "telegramaccount"],
       sourceKind: "passive",
       isPassive: true,
+      identityMetadataMapping: {
+        userIdField: "fromId",
+        nameField: "entityName",
+      },
+      worldIdMetadataKeys: ["telegramChatId"],
     },
   ],
   // TelegramService must come before TelegramOwnerPairingServiceImpl so the

--- a/plugins/plugin-telegram/src/messageManager.ts
+++ b/plugins/plugin-telegram/src/messageManager.ts
@@ -133,6 +133,19 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
+function telegramIdentityMetadata(
+  telegramUserId: string,
+  name?: string,
+  username?: string,
+): Record<string, string> {
+  return {
+    userId: telegramUserId,
+    id: telegramUserId,
+    ...(name ? { name } : {}),
+    ...(username ? { username } : {}),
+  };
+}
+
 function isCompactProgressContent(
   content: Content,
 ): content is Content & { text: string } {
@@ -1411,6 +1424,11 @@ export class MessageManager {
             username: ctx.from.username,
           },
           telegram: {
+            ...telegramIdentityMetadata(
+              telegramUserId,
+              ctx.from.first_name,
+              ctx.from.username,
+            ),
             chatId: telegramChatId,
             messageId: telegramMessageId,
             threadId,
@@ -1688,6 +1706,11 @@ export class MessageManager {
           username: ctx.from.username,
         },
         telegram: {
+          ...telegramIdentityMetadata(
+            telegramUserId,
+            ctx.from.first_name,
+            ctx.from.username,
+          ),
           chatId: telegramChatId,
           messageId: callbackKey,
           threadId,
@@ -1784,6 +1807,11 @@ export class MessageManager {
           username: args.ctx.from.username,
         },
         telegram: {
+          ...telegramIdentityMetadata(
+            actorTelegramUserId,
+            args.ctx.from.first_name,
+            args.ctx.from.username,
+          ),
           chatId: args.chat.id.toString(),
           messageId: `cua-${queryId}`,
         },
@@ -1972,10 +2000,27 @@ export class MessageManager {
           source: "telegram",
           accountId: this.accountId,
           provider: "telegram",
+          entityName: ctx.from.first_name,
+          entityUserName: ctx.from.username,
+          fromBot: ctx.from.is_bot,
+          fromId: ctx.from.id.toString(),
+          sourceId: entityId,
+          sender: {
+            id: ctx.from.id.toString(),
+            name: ctx.from.first_name,
+            username: ctx.from.username,
+          },
           telegram: {
+            ...telegramIdentityMetadata(
+              ctx.from.id.toString(),
+              ctx.from.first_name,
+              ctx.from.username,
+            ),
             chatId: reaction.chat.id.toString(),
             messageId: reaction.message_id.toString(),
           },
+          telegramUserId: ctx.from.id.toString(),
+          telegramChatId: reaction.chat.id.toString(),
         } satisfies Memory["metadata"],
         createdAt: Date.now(),
       };


### PR DESCRIPTION
## Summary

Fixes #14711.

Telegram-originated memories now carry stable user identity metadata instead of relying on chat-only nested metadata, and the connector declares the flat-field mapping core needs for role resolution:

- `plugins/plugin-telegram/src/index.ts` registers `identityMetadataMapping` (`fromId` + `entityName`) and `worldIdMetadataKeys` (`telegramChatId`) for the `telegram` connector source.
- `plugins/plugin-telegram/src/messageManager.ts` stamps `userId` and `id` inside nested `metadata.telegram` for normal inbound messages, button callbacks, computer-use approvals, and reactions.
- `packages/core/src/roles.ts` ignores idless nested connector metadata for identity resolution, so declared flat mapping or stored entity metadata can still identify the sender.
- `plugins/plugin-telegram/__tests__/core-test-mock.ts` exposes the core `CommandRegistryService` contract needed by the Telegram test suite after command plugin loading.

## Verification

```text
bun run --cwd packages/core test src/roles.test.ts
Test Files 1 passed (1), Tests 44 passed (44)

bunx @biomejs/biome check packages/core/src/roles.ts packages/core/src/roles.test.ts plugins/plugin-telegram/src/index.ts plugins/plugin-telegram/src/messageManager.ts plugins/plugin-telegram/__tests__/core-test-mock.ts --no-errors-on-unmatched
clean

bun run --cwd packages/core typecheck
clean

bun run --cwd packages/core build
clean; Node, browser, edge, and testing bundles built

bun run --cwd plugins/plugin-commands build
clean; dependency prep for Telegram tests

bun run --cwd plugins/plugin-x402 build
clean; dependency prep for Telegram route tests

bun run --cwd plugins/plugin-telegram test
Test Files 14 passed (14), Tests 110 passed (110)

bun run --cwd plugins/plugin-telegram build
clean

bun run audit:error-policy-ratchet --report
clean; 3 changed production files, no new fallback slop

git diff --check origin/develop...HEAD
clean
```

Manual review: checked the final role-resolution diff and Telegram metadata stamps. The new tests cover both key regressions: idless nested Telegram metadata falls back to declared flat mapping, and idless live metadata no longer blocks stored sender metadata from matching the owner.

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - no UI surface changed; this is connector/runtime metadata behavior`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - no UI surface changed; this is connector/runtime metadata behavior`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no UI walkthrough applies, and no Telegram bot credentials are configured in this environment for a live conversation recording`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no live Telegram bot/runtime process was run; deterministic core and Telegram tests assert the inbound memory metadata and role-resolution outcomes directly`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend/client code changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - this change does not alter model prompting or action routing, and no live Telegram credentials are configured for an agent turn trajectory`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no persistent DB artifact was produced locally; the domain artifact shape is Telegram Memory.metadata, asserted in packages/core/src/roles.test.ts and the Telegram unit suite`.
