### PR TITLE
fix(scenarios): run app-control live corpus

### DIFF
--- a/.github/workflows/live-scenarios.yml
+++ b/.github/workflows/live-scenarios.yml
@@ -1,10 +1,10 @@
 # Live Scenario Runner (nightly)
 #
-# Executes the executive-assistant, connector certification, and plugin-health
-# scenarios against a live LLM runtime with real connector credentials and
-# uploads the JSON report. Scheduled/default dispatch runs are report-only
-# while this catalog is still being hardened; manual dispatch can opt into
-# failing when any scenario fails or the aggregate LLM-judge score falls below
+# Executes the executive-assistant, connector certification, plugin-health, and
+# app-control scenarios against a live LLM runtime with real connector
+# credentials and uploads the JSON report. Scheduled/default dispatch runs are
+# report-only while this catalog is still being hardened; manual dispatch can opt
+# into failing when any scenario fails or the aggregate LLM-judge score falls below
 # LIFEOPS_JUDGE_THRESHOLD. Missing setup prerequisites still fail loudly.
 #
 # Required repo secrets (self-documented):
@@ -88,7 +88,7 @@ permissions:
 
 jobs:
   live-scenarios:
-    name: Live scenarios (EA + connectors + health)
+    name: Live scenarios (EA + connectors + health + app-control)
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 120
     steps:
@@ -115,6 +115,7 @@ jobs:
             { echo "scenario-runner CLI missing"; exit 1; }
 
       - name: Build live scenario runtime packages
+        id: build
         # The live runner executes TypeScript sources directly, but several
         # workspace packages intentionally export dist/* entry points. Because
         # dependency installation ignores postinstall scripts, build only the
@@ -170,6 +171,7 @@ jobs:
 
           package_dirs=(
             plugins/plugin-sql
+            plugins/plugin-app-control
             plugins/plugin-agent-skills
             plugins/plugin-health
             plugins/plugin-pdf
@@ -275,6 +277,32 @@ jobs:
           EXPORT_NATIVE_PATH: artifacts/scenario-runs/plugin-health/native.jsonl
         run: node packages/scripts/run-live-scenarios.mjs --lane live-only
 
+      - name: Run app-control live scenarios
+        id: run-app-control
+        if: ${{ !cancelled() && steps.build.outcome == 'success' }}
+        env:
+          # LLM providers
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          # Independent LLM judge (#9310): judge on Cerebras, never the model
+          # under test.
+          CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+          SCENARIO_JUDGE_REQUIRE_INDEPENDENT: "1"
+          # Run controls
+          SCENARIO_ROOT: plugins/plugin-app-control/test/scenarios
+          SCENARIO_FILTER: ${{ inputs.scenario_filter }}
+          LIFEOPS_JUDGE_THRESHOLD: ${{ inputs.judge_threshold || '0.8' }}
+          SCENARIO_ENFORCE_GATE: ${{ inputs.enforce_gate && '1' || '0' }}
+          SKIP_REASON: ${{ inputs.skip_reason }}
+          REPORT_PATH: artifacts/app-control-scenario-report.json
+          RUN_DIR: artifacts/scenario-runs/app-control
+          EXPORT_NATIVE_PATH: artifacts/scenario-runs/app-control/native.jsonl
+        run: node packages/scripts/run-live-scenarios.mjs --lane live-only
+
       - name: Upload scenario report
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
@@ -283,7 +311,9 @@ jobs:
           path: |
             artifacts/lifeops-scenario-report.json
             artifacts/plugin-health-scenario-report.json
+            artifacts/app-control-scenario-report.json
             artifacts/scenario-runs/live/
             artifacts/scenario-runs/plugin-health/
+            artifacts/scenario-runs/app-control/
           if-no-files-found: warn
           retention-days: 30


### PR DESCRIPTION
## Summary
- Add the plugin-app-control live-only scenario corpus to the nightly `live-scenarios.yml` workflow.
- Build `plugins/plugin-app-control` before live scenario execution so dist-backed workspace exports are present.
- Emit app-control's report, run viewer, and native JSONL export into separate artifact paths beside the existing LifeOps report.

## Verification
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/live-scenarios.yml'); puts 'live-scenarios.yml yaml ok'"`
- `bun --conditions eliza-source --tsconfig-override tsconfig.json packages/scenario-runner/src/cli.ts list plugins/plugin-app-control/test/scenarios --lane live-only` -> exit 0, 21 scenario IDs listed
- `node packages/scripts/check-scenario-workflow-coverage.mjs --report-dir reports/scenarios/catalog-inventory-14698 --json` -> `pluginAppControlCount: 21`, `allScenarioCount: 1061`, `untaggedLaneScenarios: 0`, `missingDefaultIds: 0`
- `git diff --check`

## Evidence / N/A
- Screenshots/video: N/A - workflow coverage change, no user-facing UI surface changed.
- Live LLM trajectories: N/A locally - this PR wires the nightly live corpus so CI can produce the real app-control trajectories with repository secrets.

Fixes #14698.
