### PR TITLE
fix(ci): gate lifeops persona catalogs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -923,6 +923,9 @@ jobs:
       - name: Scenario catalog coverage gate
         run: node packages/scripts/check-scenario-workflow-coverage.mjs --report-dir reports/scenarios/catalog-inventory
 
+      - name: Persona catalog coverage gate
+        run: node packages/scripts/check-lifeops-persona-catalog-coverage.mjs
+
       - name: Build workspace packages for scenario resolution
         run: bunx turbo run build --filter=@elizaos/scenario-runner...
 


### PR DESCRIPTION
## Summary
- Wire `check-lifeops-persona-catalog-coverage.mjs` into the zero-key scenario runner CI job.
- Keep the persona ledger guard beside the existing scenario catalog coverage gate, before scenario resolution/build work.

## Verification
Ran after rebasing onto current `origin/develop` (`b7247c66c7a`) on 2026-07-06:

- `node packages/scripts/check-lifeops-persona-catalog-coverage.mjs` -> `216/286 authored`, `134/286 verified`, `0 errors`
- `node packages/scripts/check-lifeops-persona-catalog-coverage.mjs --json` -> `target: 286`, `authored: 216`, `verified: 134`, `errors: []`
- `node packages/scripts/check-scenario-workflow-coverage.mjs --report-dir reports/scenarios/catalog-inventory-14700 --json` -> `allScenarioCount: 1074`, `untaggedLaneScenarios: 0`, `missingDefaultIds: 0`, `pluginLifeopsCount: 276`, `pluginAppControlCount: 21`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/test.yml'); puts 'test.yml yaml ok'"` -> `test.yml yaml ok`
- `git diff --check origin/develop...HEAD` -> clean

The catalog totals changed from the earlier PR body because current `develop` added additional persona catalog files; the guard still exits cleanly and now covers those ledgers in CI as well.

## Evidence Matrix
<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - CI workflow/catalog guard only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - CI workflow/catalog guard only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no browser/mobile workflow changed; the relevant artifact is the CI catalog guard output.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no backend service changed or ran; this is a keyless filesystem catalog check.
<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A - no frontend runtime path changed.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no model/prompt/action/provider behavior changed.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - no production DB/memory/domain artifact is produced; the durable proof is the catalog guard output and workflow wiring.

Fixes #14700.
