### PR TITLE
fix(discord): fail closed slash roles and pairing (#14710)

### DIFF
--- a/packages/core/src/services/pairing-integration.test.ts
+++ b/packages/core/src/services/pairing-integration.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Pairing integration tests for channel connectors that gate DMs behind
+ * `dmPolicy="pairing"`. The missing-service path must fail closed so a host
+ * wiring mistake cannot silently turn pairing-gated DMs into open DMs.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { IAgentRuntime } from "../types";
+import { ServiceType } from "../types/service";
+import { checkPairingAllowed } from "./pairing-integration";
+
+describe("checkPairingAllowed", () => {
+	it("denies when PairingService is unavailable", async () => {
+		const runtime = {
+			getService: vi.fn(() => null),
+			logger: { warn: vi.fn() },
+		} as unknown as IAgentRuntime;
+
+		const result = await checkPairingAllowed(runtime, {
+			channel: "discord",
+			senderId: "1234567890",
+		});
+
+		expect(runtime.getService).toHaveBeenCalledWith(ServiceType.PAIRING);
+		expect(result).toMatchObject({
+			allowed: false,
+			idLabel: "userId",
+			replyMessage: "Access pairing is temporarily unavailable.",
+		});
+	});
+});

--- a/packages/core/src/services/pairing-integration.ts
+++ b/packages/core/src/services/pairing-integration.ts
@@ -88,12 +88,15 @@ export async function checkPairingAllowed(
 
 	const pairingService = await getPairingService(runtime);
 	if (!pairingService) {
-		// No pairing service available - allow by default (fallback behavior)
 		runtime.logger.warn(
 			{ src: "pairing-integration", channel },
-			"PairingService not available, allowing message by default",
+			"PairingService not available; denying pairing-gated sender",
 		);
-		return { allowed: true };
+		return {
+			allowed: false,
+			replyMessage: "Access pairing is temporarily unavailable.",
+			idLabel: getPairingIdLabel(channel),
+		};
 	}
 
 	// Check if already in allowlist

--- a/plugins/plugin-discord/__tests__/allowlist.test.ts
+++ b/plugins/plugin-discord/__tests__/allowlist.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Unit tests for Discord message allowlist policy defaults. This file exercises
+ * the exported synchronous helper directly so the fallback policy stays aligned
+ * with the live message manager's pairing-default behavior.
+ */
+import { describe, expect, it } from "vitest";
+import { validateMessageAllowed } from "../allowlist";
+
+const author = {
+	id: "1234567890",
+	username: "alice",
+	discriminator: "0001",
+} as never;
+
+describe("validateMessageAllowed DM policy", () => {
+	it("defaults direct messages to pairing and denies without an explicit allow", () => {
+		const result = validateMessageAllowed({
+			accountConfig: {},
+			isDirectMessage: true,
+			isGroupDm: false,
+			channelId: "dm-1",
+			author,
+		});
+
+		expect(result).toEqual({
+			allowed: false,
+			reason: "DM pairing required",
+		});
+	});
+
+	it("lets a static allowlist bypass pairing", () => {
+		const result = validateMessageAllowed({
+			accountConfig: { dm: { policy: "pairing", allowFrom: ["1234567890"] } },
+			isDirectMessage: true,
+			isGroupDm: false,
+			channelId: "dm-1",
+			author,
+		});
+
+		expect(result).toEqual({ allowed: true });
+	});
+});

--- a/plugins/plugin-discord/__tests__/slash-commands.test.ts
+++ b/plugins/plugin-discord/__tests__/slash-commands.test.ts
@@ -18,7 +18,9 @@ vi.mock("@elizaos/core", async (importOriginal) => {
 });
 
 import {
+	addCommand,
 	getRegisteredCommands,
+	handleSlashCommand,
 	registerSlashCommands,
 	type SlashCommand,
 } from "../slash-commands";
@@ -43,14 +45,24 @@ interface MockInteraction {
 	channelId: string;
 	user: { id: string; username: string };
 	reply: ReturnType<typeof vi.fn>;
+	editReply: ReturnType<typeof vi.fn>;
+	deferred: boolean;
+	replied: boolean;
+	commandName: string;
+	guild: { ownerId: string } | null;
 }
 
-function makeInteraction(): MockInteraction {
+function makeInteraction(commandName = "app"): MockInteraction {
 	return {
 		id: "interaction-1",
 		channelId: "987654321098765432",
 		user: { id: "123456789012345678", username: "tester" },
+		commandName,
 		reply: vi.fn(async () => undefined),
+		editReply: vi.fn(async () => undefined),
+		deferred: false,
+		replied: false,
+		guild: { ownerId: "guild-owner" },
 	};
 }
 
@@ -138,5 +150,94 @@ describe("/app embedded-app launch command (#9947)", () => {
 		expect(reply.ephemeral).toBe(true);
 		expect(reply.content).not.toContain("https://");
 		expect(reply.content).toMatch(/ELIZA_EMBED_URL/);
+	});
+});
+
+describe("slash command dispatcher role gates (#14710)", () => {
+	beforeEach(() => {
+		hasRoleAccess.mockReset();
+		hasRoleAccess.mockResolvedValue(true);
+	});
+
+	it("denies a role-gated command when dispatch context is missing", async () => {
+		const execute = vi.fn(async () => undefined);
+		addCommand({
+			name: "gated_missing_context",
+			description: "gated",
+			requiredRole: "ADMIN",
+			execute,
+		});
+		const interaction = makeInteraction("gated_missing_context");
+
+		await handleSlashCommand(interaction as never, makeRuntime());
+
+		expect(hasRoleAccess).not.toHaveBeenCalled();
+		expect(execute).not.toHaveBeenCalled();
+		expect(lastReply(interaction).content).toContain("Unable to verify");
+	});
+
+	it("denies a role-gated command when role resolution throws", async () => {
+		hasRoleAccess.mockRejectedValue(new Error("role backend down"));
+		const execute = vi.fn(async () => undefined);
+		addCommand({
+			name: "gated_role_error",
+			description: "gated",
+			requiredRole: "ADMIN",
+			execute,
+		});
+		const interaction = makeInteraction("gated_role_error");
+
+		await handleSlashCommand(interaction as never, makeRuntime(), {
+			entityId: "entity-1",
+			roomId: "room-1",
+		});
+
+		expect(hasRoleAccess).toHaveBeenCalled();
+		expect(execute).not.toHaveBeenCalled();
+		expect(lastReply(interaction).content).toContain("ADMIN");
+	});
+
+	it("does not execute when a denial reply fails", async () => {
+		hasRoleAccess.mockResolvedValue(false);
+		const execute = vi.fn(async () => undefined);
+		addCommand({
+			name: "gated_reply_failure",
+			description: "gated",
+			requiredRole: "ADMIN",
+			execute,
+		});
+		const interaction = makeInteraction("gated_reply_failure");
+		interaction.reply.mockRejectedValueOnce(new Error("interaction expired"));
+
+		await expect(
+			handleSlashCommand(interaction as never, makeRuntime(), {
+				entityId: "entity-1",
+				roomId: "room-1",
+			}),
+		).rejects.toThrow("interaction expired");
+
+		expect(execute).not.toHaveBeenCalled();
+	});
+
+	it("checks ownerOnly through the elizaOS OWNER role instead of Discord guild ownership", async () => {
+		hasRoleAccess.mockResolvedValue(false);
+		const execute = vi.fn(async () => undefined);
+		addCommand({
+			name: "owner_only",
+			description: "owner",
+			ownerOnly: true,
+			execute,
+		});
+		const interaction = makeInteraction("owner_only");
+		interaction.user.id = "guild-owner";
+
+		await handleSlashCommand(interaction as never, makeRuntime(), {
+			entityId: "entity-1",
+			roomId: "room-1",
+		});
+
+		expect(hasRoleAccess.mock.calls[0][2]).toBe("OWNER");
+		expect(execute).not.toHaveBeenCalled();
+		expect(lastReply(interaction).content).toContain("OWNER");
 	});
 });

--- a/plugins/plugin-discord/allowlist.ts
+++ b/plugins/plugin-discord/allowlist.ts
@@ -652,12 +652,16 @@ export function validateMessageAllowed(params: {
 			return { allowed: false, reason: "DMs disabled" };
 		}
 
-		const dmPolicy = dmConfig?.policy ?? "open";
+		const dmPolicy = dmConfig?.policy ?? "pairing";
 		if (dmPolicy === "disabled") {
 			return { allowed: false, reason: "DM policy disabled" };
 		}
 
-		if (dmPolicy === "allowlist" && dmConfig?.allowFrom) {
+		if (dmPolicy === "open") {
+			return { allowed: true };
+		}
+
+		if (dmConfig?.allowFrom) {
 			const isAllowed = resolveDiscordUserAllowed({
 				allowList: dmConfig.allowFrom,
 				userId: author.id,
@@ -665,12 +669,18 @@ export function validateMessageAllowed(params: {
 				userTag: formatDiscordUserTag(author),
 			});
 
-			if (!isAllowed) {
-				return { allowed: false, reason: "User not in DM allowlist" };
+			if (isAllowed) {
+				return { allowed: true };
 			}
 		}
 
-		return { allowed: true };
+		return {
+			allowed: false,
+			reason:
+				dmPolicy === "pairing"
+					? "DM pairing required"
+					: "User not in DM allowlist",
+		};
 	}
 
 	// Handle group DMs

--- a/plugins/plugin-discord/slash-commands.ts
+++ b/plugins/plugin-discord/slash-commands.ts
@@ -757,41 +757,51 @@ export async function handleSlashCommand(
 		}, command.cooldown * 1000);
 	}
 
-	// elizaOS role check — uses the agent's role hierarchy (OWNER > ADMIN > USER > GUEST)
-	if (command.requiredRole && command.requiredRole !== "GUEST") {
+	// One canonical role gate through hasRoleAccess for both `requiredRole` and
+	// `ownerOnly` — ownerOnly means the elizaOS OWNER role, and OWNER outranks
+	// every other role, so the single highest requirement covers commands that
+	// set both. Slash commands are a privileged surface: missing dispatch
+	// context or a throwing role backend denies, and the denial reply stays
+	// outside the try so a failed reply can never convert a deny into an
+	// execute (it propagates to the interaction boundary in discord-events.ts).
+	const requiredRole: SlashCommandRole | undefined = command.ownerOnly
+		? "OWNER"
+		: command.requiredRole && command.requiredRole !== "GUEST"
+			? command.requiredRole
+			: undefined;
+	if (requiredRole) {
 		if (!context) {
 			runtime.logger.warn(
 				{
 					src: "slash-commands",
 					commandName: command.name,
-					requiredRole: command.requiredRole,
+					requiredRole,
 				},
 				"Role-gated slash command missing dispatch context",
 			);
 			await replyEphemeral(
 				interaction,
-				`Unable to verify your **${command.requiredRole}** role for \`/${command.name}\`.`,
+				`Unable to verify your **${requiredRole}** role for \`/${command.name}\`.`,
 			);
 			return;
 		}
 
 		let allowed = false;
+		// error-policy:J1 role-backend failure translates to an explicit deny at
+		// the slash-command gate; it never falls through to execution.
 		try {
 			const memory = {
 				entityId: context.entityId,
 				roomId: context.roomId,
 				content: { text: `/${command.name}`, source: "discord" },
 			} satisfies Pick<Memory, "entityId" | "roomId" | "content">;
-			allowed = await hasRoleAccess(
-				runtime,
-				memory as Memory,
-				command.requiredRole,
-			);
+			allowed = await hasRoleAccess(runtime, memory as Memory, requiredRole);
 		} catch (error) {
 			runtime.logger.warn(
 				{
 					src: "slash-commands",
 					commandName: command.name,
+					requiredRole,
 					error: error instanceof Error ? error.message : String(error),
 				},
 				"Role check failed; denying slash command",
@@ -800,46 +810,7 @@ export async function handleSlashCommand(
 		if (!allowed) {
 			await replyEphemeral(
 				interaction,
-				`You need at least **${command.requiredRole}** role to use \`/${command.name}\`.`,
-			);
-			return;
-		}
-	}
-
-	if (command.ownerOnly) {
-		if (!context) {
-			runtime.logger.warn(
-				{ src: "slash-commands", commandName: command.name },
-				"Owner-only slash command missing dispatch context",
-			);
-			await replyEphemeral(
-				interaction,
-				`Unable to verify OWNER role for \`/${command.name}\`.`,
-			);
-			return;
-		}
-		const memory = {
-			entityId: context.entityId,
-			roomId: context.roomId,
-			content: { text: `/${command.name}`, source: "discord" },
-		} satisfies Pick<Memory, "entityId" | "roomId" | "content">;
-		let allowed = false;
-		try {
-			allowed = await hasRoleAccess(runtime, memory as Memory, "OWNER");
-		} catch (error) {
-			runtime.logger.warn(
-				{
-					src: "slash-commands",
-					commandName: command.name,
-					error: error instanceof Error ? error.message : String(error),
-				},
-				"Owner role check failed; denying slash command",
-			);
-		}
-		if (!allowed) {
-			await replyEphemeral(
-				interaction,
-				`You need OWNER role to use \`/${command.name}\`.`,
+				`You need at least **${requiredRole}** role to use \`/${command.name}\`.`,
 			);
 			return;
 		}

--- a/plugins/plugin-discord/slash-commands.ts
+++ b/plugins/plugin-discord/slash-commands.ts
@@ -43,6 +43,19 @@ export interface SlashCommandContext {
 	roomId: string;
 }
 
+async function replyEphemeral(
+	interaction: ChatInputCommandInteraction,
+	content: string,
+): Promise<void> {
+	if (interaction.deferred) {
+		await interaction.editReply({ content });
+		return;
+	}
+	if (!interaction.replied) {
+		await interaction.reply({ content, ephemeral: true });
+	}
+}
+
 export interface SlashCommandOption {
 	name: string;
 	description: string;
@@ -745,25 +758,35 @@ export async function handleSlashCommand(
 	}
 
 	// elizaOS role check — uses the agent's role hierarchy (OWNER > ADMIN > USER > GUEST)
-	if (command.requiredRole && command.requiredRole !== "GUEST" && context) {
+	if (command.requiredRole && command.requiredRole !== "GUEST") {
+		if (!context) {
+			runtime.logger.warn(
+				{
+					src: "slash-commands",
+					commandName: command.name,
+					requiredRole: command.requiredRole,
+				},
+				"Role-gated slash command missing dispatch context",
+			);
+			await replyEphemeral(
+				interaction,
+				`Unable to verify your **${command.requiredRole}** role for \`/${command.name}\`.`,
+			);
+			return;
+		}
+
+		let allowed = false;
 		try {
 			const memory = {
 				entityId: context.entityId,
 				roomId: context.roomId,
 				content: { text: `/${command.name}`, source: "discord" },
-			};
-			const allowed = await hasRoleAccess(
+			} satisfies Pick<Memory, "entityId" | "roomId" | "content">;
+			allowed = await hasRoleAccess(
 				runtime,
-				memory,
+				memory as Memory,
 				command.requiredRole,
 			);
-			if (!allowed) {
-				await interaction.reply({
-					content: `You need at least **${command.requiredRole}** role to use \`/${command.name}\`.`,
-					ephemeral: true,
-				});
-				return;
-			}
 		} catch (error) {
 			runtime.logger.warn(
 				{
@@ -771,18 +794,53 @@ export async function handleSlashCommand(
 					commandName: command.name,
 					error: error instanceof Error ? error.message : String(error),
 				},
-				"Role check failed, falling through",
+				"Role check failed; denying slash command",
 			);
+		}
+		if (!allowed) {
+			await replyEphemeral(
+				interaction,
+				`You need at least **${command.requiredRole}** role to use \`/${command.name}\`.`,
+			);
+			return;
 		}
 	}
 
 	if (command.ownerOnly) {
-		const guild = interaction.guild;
-		if (guild && interaction.user.id !== guild.ownerId) {
-			await interaction.reply({
-				content: "This command can only be used by the server owner.",
-				ephemeral: true,
-			});
+		if (!context) {
+			runtime.logger.warn(
+				{ src: "slash-commands", commandName: command.name },
+				"Owner-only slash command missing dispatch context",
+			);
+			await replyEphemeral(
+				interaction,
+				`Unable to verify OWNER role for \`/${command.name}\`.`,
+			);
+			return;
+		}
+		const memory = {
+			entityId: context.entityId,
+			roomId: context.roomId,
+			content: { text: `/${command.name}`, source: "discord" },
+		} satisfies Pick<Memory, "entityId" | "roomId" | "content">;
+		let allowed = false;
+		try {
+			allowed = await hasRoleAccess(runtime, memory as Memory, "OWNER");
+		} catch (error) {
+			runtime.logger.warn(
+				{
+					src: "slash-commands",
+					commandName: command.name,
+					error: error instanceof Error ? error.message : String(error),
+				},
+				"Owner role check failed; denying slash command",
+			);
+		}
+		if (!allowed) {
+			await replyEphemeral(
+				interaction,
+				`You need OWNER role to use \`/${command.name}\`.`,
+			);
 			return;
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes #14710.

This closes the fail-open paths in the Discord slash-command / DM pairing gate stack:

- Role-gated slash commands now deny when dispatch context is missing instead of skipping the role check.
- Role-check errors now deny instead of logging and falling through to command execution.
- A failed denial reply no longer lets the command execute.
- `ownerOnly` now checks the elizaOS OWNER role through `hasRoleAccess()` instead of Discord guild ownership, and DMs/missing context fail closed.
- `checkPairingAllowed()` now denies when `PairingService` is unavailable instead of silently allowing pairing-gated senders.
- The exported Discord allowlist helper now defaults DMs to `pairing` and denies pairing/allowlist DMs unless the sender is explicitly allowed.

## Evidence

- `bun run --cwd packages/core test src/services/pairing-integration.test.ts` — passed, 1 test.
- `bun run --cwd plugins/plugin-discord test __tests__/slash-commands.test.ts __tests__/allowlist.test.ts` — passed, 2 files / 11 tests.
- `bunx @biomejs/biome check plugins/plugin-discord/slash-commands.ts plugins/plugin-discord/__tests__/slash-commands.test.ts plugins/plugin-discord/allowlist.ts plugins/plugin-discord/__tests__/allowlist.test.ts packages/core/src/services/pairing-integration.ts packages/core/src/services/pairing-integration.test.ts --no-errors-on-unmatched` — passed after write pass made no changes.
- `bun run --cwd packages/core typecheck` — passed.
- `bun run --cwd plugins/plugin-discord typecheck` — passed after building fresh-worktree declarations for `plugins/plugin-sql`, `packages/vault`, and `plugins/plugin-commands`.
- `bun run --cwd plugins/plugin-discord build` — passed.
- `git diff --check origin/develop...HEAD` — passed.
- `bun run audit:error-policy-ratchet --report` — passed; no new fallback slop.

## Broader Test Note

- `bun run --cwd plugins/plugin-discord test` was attempted. It ran 36/38 files and 238/242 tests successfully, then failed in pre-existing outbound-media fetch mock tests:
  - `__tests__/outbound-attachment.test.ts` tried to fetch `http://127.0.0.1:8080/v1/media/...` and got `ECONNREFUSED` instead of the test's expected mocked HTTP result.
  - `actions/messageConnector.outbound-media.test.ts` expected its fetch mock to be called, but the guarded media fetch path did not hit that mock.

These failures are outside the slash-command / pairing gate code touched here; the focused affected tests and package build/typecheck gates pass.

## Evidence N/A

- Live Discord credentialed slash command / DM pairing proof: N/A locally because no Discord bot/application credentials are configured in this environment. The deterministic fail-closed behavior is covered with dispatcher and pairing unit tests.
- UI screenshots/video: N/A; no app UI changed.