### PR TITLE
fix: persist reminder nudges in chat

### DIFF
--- a/packages/agent/src/api/server-helpers-swarm.test.ts
+++ b/packages/agent/src/api/server-helpers-swarm.test.ts
@@ -556,6 +556,88 @@ describe("routeAutonomyTextToUser", () => {
     );
   });
 
+  it("persists reminder nudges because their notification deep-links to chat", async () => {
+    const createMemory = vi.fn();
+    const broadcastWs = vi.fn();
+    const state = {
+      runtime: {
+        agentId: "00000000-0000-0000-0000-000000000001",
+        createMemory,
+      },
+      activeConversationId: "conv-1",
+      conversations: new Map([
+        [
+          "conv-1",
+          {
+            id: "conv-1",
+            roomId: "00000000-0000-0000-0000-000000000002",
+            updatedAt: "2026-05-07T00:00:00.000Z",
+          },
+        ],
+      ]),
+      broadcastWs,
+      deliveryDedupe: createDeliveryDedupeState(),
+    } as never;
+
+    await routeAutonomyTextToUser(state, "Take your meds", "reminder");
+
+    expect(createMemory).toHaveBeenCalledTimes(1);
+    expect(createMemory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.objectContaining({
+          text: "Take your meds",
+          source: "reminder",
+        }),
+      }),
+      "messages",
+    );
+    expect(broadcastWs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "proactive-message",
+        message: expect.objectContaining({
+          text: "Take your meds",
+          source: "reminder",
+        }),
+      }),
+    );
+  });
+
+  it("still suppresses activity/feed-only autonomy sources that have chat-visible siblings", async () => {
+    const createMemory = vi.fn();
+    const broadcastWs = vi.fn();
+    const state = {
+      runtime: {
+        agentId: "00000000-0000-0000-0000-000000000001",
+        createMemory,
+      },
+      activeConversationId: "conv-1",
+      conversations: new Map([
+        [
+          "conv-1",
+          {
+            id: "conv-1",
+            roomId: "00000000-0000-0000-0000-000000000002",
+            updatedAt: "2026-05-07T00:00:00.000Z",
+          },
+        ],
+      ]),
+      broadcastWs,
+      deliveryDedupe: createDeliveryDedupeState(),
+    } as never;
+
+    for (const source of [
+      "workflow",
+      "proactive-gm",
+      "proactive-gn",
+      "proactive-nudge",
+    ]) {
+      await routeAutonomyTextToUser(state, `hidden ${source}`, source);
+    }
+
+    expect(createMemory).not.toHaveBeenCalled();
+    expect(broadcastWs).not.toHaveBeenCalled();
+  });
+
   it("Bug A: a duplicate relay of an already-delivered reply is suppressed (one memory + one broadcast)", async () => {
     const createMemory = vi.fn();
     const broadcastWs = vi.fn();

--- a/packages/agent/src/api/server-helpers-swarm.ts
+++ b/packages/agent/src/api/server-helpers-swarm.ts
@@ -45,8 +45,12 @@ type TaskContext = SwarmCoordinatorTaskContext;
 // ---------------------------------------------------------------------------
 
 const CHAT_SUPPRESSED_AUTONOMY_SOURCES = new Set([
-  "reminder",
+  // Workflow run nudges are mirrored in the activity/notification rail; do not
+  // also inject their raw assistant event into chat.
   "workflow",
+  // GM/GN/nudge planner events have first-class chat-visible siblings (for
+  // example LifeOps check-ins) and activity-feed plaintext artifacts. Keep the
+  // feed-only events out of the transcript so the sibling remains canonical.
   "proactive-gm",
   "proactive-gn",
   "proactive-nudge",

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.in-app-nudge.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.in-app-nudge.test.ts
@@ -1,0 +1,80 @@
+import { ServiceType } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { type RemindersDeps, RemindersDomain } from "./reminders-service.js";
+
+class TestRemindersDomain extends RemindersDomain {
+  emitTestNudge(
+    args: Parameters<RemindersDomain["emitInAppReminderNudge"]>[0],
+  ) {
+    this.emitInAppReminderNudge(args);
+  }
+}
+
+function makeDeps(): RemindersDeps {
+  return {
+    runDueWorkflows: vi.fn(),
+    runDueEventWorkflows: vi.fn(),
+    snoozeOccurrence: vi.fn(),
+    checkinSource: {} as RemindersDeps["checkinSource"],
+  };
+}
+
+describe("RemindersDomain.emitInAppReminderNudge", () => {
+  it("emits a chat-visible reminder with choice chips while keeping the interrupt notification deep-linked to chat", () => {
+    const emitAssistantEvent = vi.fn();
+    const notify = vi.fn().mockResolvedValue(undefined);
+    const domain = new TestRemindersDomain(
+      {
+        emitAssistantEvent,
+        runtime: {
+          getService(serviceType: unknown) {
+            return serviceType === ServiceType.NOTIFICATION ? { notify } : null;
+          },
+        },
+      } as never,
+      makeDeps(),
+    );
+
+    domain.emitTestNudge({
+      text: "Take your meds.",
+      ownerType: "occurrence",
+      ownerId: "occurrence-1",
+      subjectType: "owner",
+      scheduledFor: "2026-07-06T12:00:00.000Z",
+      dueAt: "2026-07-06T12:00:00.000Z",
+    });
+
+    expect(emitAssistantEvent).toHaveBeenCalledWith(
+      expect.stringContaining("Take your meds.\n\n[CHOICE:lifeops-reminder"),
+      "reminder",
+      expect.objectContaining({
+        ownerType: "occurrence",
+        ownerId: "occurrence-1",
+        subjectType: "owner",
+        scheduledFor: "2026-07-06T12:00:00.000Z",
+        dueAt: "2026-07-06T12:00:00.000Z",
+      }),
+    );
+    const chatText = emitAssistantEvent.mock.calls[0]?.[0] as string;
+    expect(chatText).toContain("done=Done");
+    expect(chatText).toContain("10 minutes=Snooze 10m");
+    expect(chatText).toContain("skip=Skip");
+
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Reminder",
+        body: "Take your meds.",
+        category: "reminder",
+        source: "lifeops",
+        deepLink: "/chat",
+        groupKey: "reminder:occurrence:occurrence-1",
+        data: expect.objectContaining({
+          ownerType: "occurrence",
+          ownerId: "occurrence-1",
+          subjectType: "owner",
+        }),
+      }),
+    );
+    expect(notify.mock.calls[0]?.[0].body).not.toContain("[CHOICE");
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
@@ -381,6 +381,39 @@ type ScheduledWorkflowRunner = {
   }): Promise<LifeOpsWorkflowRun[]>;
 };
 
+function reminderChoiceId(args: {
+  ownerType: "occurrence" | "calendar_event";
+  ownerId: string;
+  scheduledFor: string;
+}): string {
+  const digest = crypto
+    .createHash("sha1")
+    .update(`${args.ownerType}:${args.ownerId}:${args.scheduledFor}`)
+    .digest("hex")
+    .slice(0, 12);
+  return `reminder-${digest}`;
+}
+
+function appendReminderChoiceChips(
+  text: string,
+  args: {
+    ownerType: "occurrence" | "calendar_event";
+    ownerId: string;
+    scheduledFor: string;
+  },
+): string {
+  const choiceId = reminderChoiceId(args);
+  return [
+    text.trim(),
+    "",
+    `[CHOICE:lifeops-reminder id=${choiceId}]`,
+    "done=Done",
+    "10 minutes=Snooze 10m",
+    "skip=Skip",
+    "[/CHOICE]",
+  ].join("\n");
+}
+
 export interface LifeOpsReminderService {
   getReminderPreference(
     definitionId?: string | null,
@@ -1082,13 +1115,15 @@ export class RemindersDomain {
     scheduledFor: string;
     dueAt: string | null;
   }): void {
-    this.ctx.emitAssistantEvent(args.text, "reminder", {
+    const metadata = {
       ownerType: args.ownerType,
       ownerId: args.ownerId,
       subjectType: args.subjectType,
       scheduledFor: args.scheduledFor,
       dueAt: args.dueAt,
-    });
+    };
+    const chatText = appendReminderChoiceChips(args.text, args);
+    this.ctx.emitAssistantEvent(chatText, "reminder", metadata);
     // Also push onto the unified notification rail so the reminder lands in
     // the notification center and reaches desktop/mobile (focus-gated) — not
     // just the in-app assistant stream. groupKey collapses repeat nudges for
@@ -1111,13 +1146,7 @@ export class RemindersDomain {
       source: "lifeops",
       deepLink: "/chat",
       groupKey: `reminder:${args.ownerType}:${args.ownerId}`,
-      data: {
-        ownerType: args.ownerType,
-        ownerId: args.ownerId,
-        subjectType: args.subjectType,
-        scheduledFor: args.scheduledFor,
-        dueAt: args.dueAt,
-      },
+      data: metadata,
     });
   }
 


### PR DESCRIPTION
## Summary
- Fixes #14732 by allowing `source: "reminder"` autonomy events to persist into chat instead of being swallowed by `CHAT_SUPPRESSED_AUTONOMY_SOURCES`.
- Keeps reminder notifications as the interrupt tier with `deepLink: "/chat"`, while the chat-visible reminder carries code-emitted `[CHOICE:lifeops-reminder]` chips.
- Adds `Done`, `Snooze 10m`, and `Skip` chips whose values flow through the existing chat action-message path and reminder reply classifier/server ops (`done`, `10 minutes`, `skip`).
- Leaves feed-only/chat-sibling sources suppressed and documents why each remaining suppression stays.

## Notes
- This intentionally does not touch #14733's broader chip grammar sweep.
- The persisted chat message is the canonical visible sibling for reminder notification taps.

## Tests
- `bunx vitest run packages/agent/src/api/server-helpers-swarm.test.ts`
  - `Test Files 1 passed (1)`
  - `Tests 15 passed (15)`
- `cd plugins/plugin-personal-assistant && bunx vitest run --config vitest.config.ts src/lifeops/domains/reminders-service.in-app-nudge.test.ts`
  - `Test Files 1 passed (1)`
  - `Tests 1 passed (1)`
- `bunx @biomejs/biome check packages/agent/src/api/server-helpers-swarm.ts packages/agent/src/api/server-helpers-swarm.test.ts plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.in-app-nudge.test.ts`
  - `Checked 4 files in 135ms. No fixes applied.`
- `bun run --cwd packages/agent build`
  - `agent build: [rewrite-dist-relative-imports] rewrote 178 file(s)`
- `bun run --cwd plugins/plugin-personal-assistant build`
  - `ESM ⚡️ Build success in 594ms`

## Review
- `codex review --uncommitted` exited 0; no blocking findings emitted.

[sol-orch]
