### PR TITLE
test(lifeops): register relationship persona catalogs

### DIFF
--- a/packages/benchmarks/lifeops-bench/eliza_lifeops_bench/scenarios/_personas.py
+++ b/packages/benchmarks/lifeops-bench/eliza_lifeops_bench/scenarios/_personas.py
@@ -46,6 +46,28 @@ PERSONA_MAYA_PARENT = Persona(
     patience_turns=18,
 )
 
+PERSONA_JORDAN_COPARENT = Persona(
+    id="jordan_coparent",
+    name="Jordan Ellis",
+    traits=[
+        "separated-parent",
+        "civil-but-tense",
+        "logistics-heavy",
+        "kid-privacy-protective",
+    ],
+    background=(
+        "Separated parent sharing custody of one middle-schooler. Coordinates "
+        "school pickups, activity handoffs, expense splits, and last-minute "
+        "schedule swaps with a co-parent where the relationship is civil but "
+        "easily tense. Needs help staying factual, timely, and kid-private."
+    ),
+    communication_style=(
+        "practical and brief, careful about wording, wants neutral logistics "
+        "drafts and reminders, rejects legal advice or therapy framing"
+    ),
+    patience_turns=16,
+)
+
 PERSONA_DEV_FREELANCER = Persona(
     id="dev_freelancer",
     name="Devon Park",
@@ -320,6 +342,7 @@ ALL_PERSONAS: list[Persona] = [
     PERSONA_RIA_PM,
     PERSONA_SAM_FOUNDER,
     PERSONA_MAYA_PARENT,
+    PERSONA_JORDAN_COPARENT,
     PERSONA_DEV_FREELANCER,
     PERSONA_NORA_CONSULTANT,
     PERSONA_OWEN_RETIREE,

--- a/packages/benchmarks/lifeops-bench/eliza_lifeops_bench/scenarios/personas/__init__.py
+++ b/packages/benchmarks/lifeops-bench/eliza_lifeops_bench/scenarios/personas/__init__.py
@@ -5,13 +5,18 @@ programmatically from ``_persona_specs.py`` (mirrors the proven
 ``scenarios/expanded`` builder). Total: **240** new base scenarios.
 
 Splice into the corpus via ``scenarios/__init__.py`` (``PERSONA_SCENARIOS``
-is added to ``CORE_SCENARIOS``).
+is added to ``CORE_SCENARIOS``). Planned relationship personas are exported
+separately so catalog authors can share ids before executable builders land.
 """
 
 from __future__ import annotations
 
 from ...types import Scenario
-from ._persona_specs import PERSONA_AREA_SPECS, build_persona_area
+from ._persona_specs import (
+    PERSONA_AREA_SPECS,
+    RELATIONSHIP_EXPANSION_PERSONAS,
+    build_persona_area,
+)
 from .schema_check import check_action_shape, check_scenario_actions
 
 ADHD_SCENARIOS: list[Scenario] = build_persona_area(PERSONA_AREA_SPECS[0])
@@ -34,6 +39,7 @@ __all__ = [
     "LOW_ENERGY_SCENARIOS",
     "NIGHT_OWL_SCENARIOS",
     "PERSONA_SCENARIOS",
+    "RELATIONSHIP_EXPANSION_PERSONAS",
     "TRAVEL_SCENARIOS",
     "check_action_shape",
     "check_scenario_actions",

--- a/packages/benchmarks/lifeops-bench/eliza_lifeops_bench/scenarios/personas/_persona_specs.py
+++ b/packages/benchmarks/lifeops-bench/eliza_lifeops_bench/scenarios/personas/_persona_specs.py
@@ -9,6 +9,7 @@ specializes it to the five target persona axes from issue #12186:
 - high-travel / timezone              (``tao_travel``)
 - high-comms-overwhelm                (``cam_comms``)
 - overwhelmed / depressed / low-energy (``del_low``)
+- co-parenting logistics              (``jordan_coparent`` planned)
 
 Each persona pack is **30 STATIC + 18 LIVE = 48** base scenarios
 (6 static families × 5 variants + 3 live families × 6 variants), for a total
@@ -61,6 +62,7 @@ from .._personas import (
     PERSONA_ARI_ADHD,
     PERSONA_CAM_COMMS,
     PERSONA_DEL_LOW,
+    PERSONA_JORDAN_COPARENT,
     PERSONA_NOA_NIGHTOWL,
     PERSONA_TAO_TRAVEL,
 )
@@ -1223,6 +1225,11 @@ _DEL = PersonaAreaSpec(
 
 
 PERSONA_AREA_SPECS: tuple[PersonaAreaSpec, ...] = (_ARI, _NOA, _TAO, _CAM, _DEL)
+
+# Planned relationship/corpus packs (G-K) share the catalog ledger and authoring
+# contract before executable scenario builders land. Keep the persona reference
+# here so J1 authors use the same benchmark persona id from the start.
+RELATIONSHIP_EXPANSION_PERSONAS: tuple[Persona, ...] = (PERSONA_JORDAN_COPARENT,)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/docs/ongoing-development/research/01-mvp-product-personas.md
+++ b/packages/docs/ongoing-development/research/01-mvp-product-personas.md
@@ -6,7 +6,7 @@ The MVP (GitHub project 15) is: **chat, onboarding, the current views, and centr
 
 The guiding constraint is **minimize additional scope**: turn what exists into an MVP by fixing, testing, verifying and validating the important stuff; prefer deleting/simplifying over adding.
 
-**Decision this doc lands:** the feature surface is already sufficient for the MVP. The persona *machinery* is also already built — an eight-pack, 212-scenario persona corpus with a tier rubric and a coverage gate. What is missing is (a) **verification** — 78 of 212 catalog scenarios are authored-but-unverified, concentrated exactly in the neurodivergent packs (ADHD capture 8/28 verified, ADHD follow-through 5/24, shift-rotation 4/22); (b) **two persona voices with zero coverage** — a child as the user, and a student's "report due for class" deadline; (c) **the onboarding journey itself has no live scenario at all**; and (d) goals coverage is sleep-only. The plan below is verification-first and adds only scenario tests, never features.
+**Decision this doc lands:** the feature surface is already sufficient for the MVP. The persona *machinery* is also already built — a base eight-pack, 212-scenario persona corpus with a tier rubric and a coverage gate, now extended by planned G-K relationship/corpus ledgers before those scenario files land. What is missing is (a) **verification** — the base catalog still has authored-but-unverified scenarios concentrated exactly in the neurodivergent packs (ADHD capture, ADHD follow-through, shift-rotation); (b) **two persona voices with zero coverage** — a child as the user, and a student's "report due for class" deadline; (c) **the onboarding journey itself has no live scenario at all**; and (d) goals coverage is sleep-only. The plan below is verification-first and adds only scenario tests, never features.
 
 ## Current state (verified in code)
 
@@ -16,7 +16,7 @@ The guiding constraint is **minimize additional scope**: turn what exists into a
 
 **Onboarding — real, thin, untested at journey level.** First-run runs **in the live chat** (`packages/ui/src/hooks/useAvailableViews.ts:388-391`), with two paths: fast-start (defaults) and customize — five questions (name, timezone+windows, categories multi-select, nudge channel, relationships cadence) with per-question persistence and resume (`plugins/plugin-personal-assistant/src/lifeops/first-run/questions.ts:1-75`, `first-run/service.ts:448-500`). Coverage today is jsdom component tests (`packages/ui/src/components/shell/ContinuousChatOverlay.firstrun.test.tsx`, `packages/ui/src/App.chat-overlay-first-run.test.tsx`) and first-run unit tests. **Zero scenarios in the whole corpus touch first-run/onboarding** (grep of `plugins/plugin-personal-assistant/test/scenarios/*.scenario.ts` and `packages/scenario-runner/test/scenarios/`).
 
-**Scenario corpus — large, persona-organized, partially verified.** 271 `.scenario.ts` files in `plugins/plugin-personal-assistant/test/scenarios/`, all `lane: "live-only"` (`test/scenarios/README.md:3-7`). Keyless merge-blocking coverage lives in `packages/test/scenarios/reminders/` (13 deterministic reminder-ladder scenarios driving the real `/api/lifeops/reminders/process`) and `packages/scenario-runner/test/scenarios/deterministic-lifeops-*.scenario.ts` (5 spine scenarios through the real scheduler tick). The eight persona packs are tracked in `test/scenarios/_catalogs/*.catalog.json` with a tier rubric (T1 extraction → T4 adversarial) and a mechanical gate (`node packages/scripts/check-lifeops-persona-catalog-coverage.mjs --json`). Current output: **target 212, authored 212, verified 134**. Per pack:
+**Scenario corpus — large, persona-organized, partially verified.** 271 `.scenario.ts` files in `plugins/plugin-personal-assistant/test/scenarios/`, all `lane: "live-only"` (`test/scenarios/README.md:3-7`). Keyless merge-blocking coverage lives in `packages/test/scenarios/reminders/` (13 deterministic reminder-ladder scenarios driving the real `/api/lifeops/reminders/process`) and `packages/scenario-runner/test/scenarios/deterministic-lifeops-*.scenario.ts` (5 spine scenarios through the real scheduler tick). The base eight persona packs are tracked in `test/scenarios/_catalogs/*.catalog.json` with a tier rubric (T1 extraction → T4 adversarial) and a mechanical gate (`node packages/scripts/check-lifeops-persona-catalog-coverage.mjs --json`). Base-pack output at the time of the original audit: **target 212, authored 212, verified 134**. Planned G-K ledgers add relationship/corpus coverage targets before scenario files land. Per base pack:
 
 | Pack | Persona | Verified / target |
 |---|---|---|
@@ -62,7 +62,7 @@ The guiding constraint is **minimize additional scope**: turn what exists into a
 - **Children and elderly need the same interface, gentler defaults.** The elderly persona scenario proves rambling non-technical phrasing works for one appointment; children need the same proof for their real life (homework, morning routine) in child-plain language. In-app + push are the child-safe channels (no email/finance surface needed).
 - **Verification is the scarce resource.** A live-verified scenario with a hand-read trajectory is worth more to the MVP than any new capability. The catalog `status` field + coverage gate already give us a mechanical definition of done.
 
-## Personas (7)
+## Personas (8)
 
 Each: context → journey (first-open → onboarding → first win → week 2) → loves / struggles → intuitiveness fix. Struggles are grounded in the current UX, not hypotheticals. Where a bench persona already exists, reuse its name for continuity with `packages/benchmarks/lifeops-bench/eliza_lifeops_bench/scenarios/_personas.py`.
 
@@ -121,6 +121,14 @@ Each: context → journey (first-open → onboarding → first win → week 2) �
 - *Loves:* comms-flood triage (D1 24/26 verified) and the approval queue's conservative no-reply defaults.
 - *Struggles:* nothing structural — she is the best-covered persona. Her risk is regression while the neurodivergent packs get attention, which is F1's whole job (24/32 verified).
 - *More intuitive:* keep F1 green; no changes.
+
+**P8 — Jordan, 39, separated co-parent** (iPhone + desktop; iMessage/Calendar; maps to planned pack J1 and bench persona `jordan_coparent`).
+- *First-open → onboarding:* fast-start, then connects calendar and messages once the custody cadence becomes the immediate pain.
+- *First win:* "Can you keep me from missing swap days?" → recurring exchange reminders and a neutral calendar view of the custody rhythm.
+- *Week 2:* a last-minute swap request becomes an owner-approved, civil logistics draft; kid details stay private and no legal/therapy advice appears.
+- *Loves:* factual language, neutral tone, no extra emotional interpretation, and reminders that keep both households coordinated.
+- *Struggles:* co-parenting work blends scheduling, money, messaging, and child privacy; without a dedicated scenario ledger it is too easy to test each domain separately and miss the real cross-domain handoff.
+- *More intuitive:* author J1 scenarios from the planned catalog, asserting custody rhythm, swap approvals, expense splits, and kid-privacy firebreaks as structural outcomes.
 
 ## Open questions → answers
 

--- a/packages/scripts/check-lifeops-persona-catalog-coverage.mjs
+++ b/packages/scripts/check-lifeops-persona-catalog-coverage.mjs
@@ -34,6 +34,14 @@ const EXPECTED_CATALOGS = [
   ["comms-flood-triage.catalog.json", "D1", 26],
   ["low-activation-reengagement.catalog.json", "E1", 28],
   ["neurotypical-control-adversarial.catalog.json", "F1", 32],
+  ["overdue-comms-apology.catalog.json", "G1", 10],
+  ["reconnect-old-friends.catalog.json", "G2", 8],
+  ["relationship-type-inference.catalog.json", "H1", 10],
+  ["kg-live-capture.catalog.json", "H2", 8],
+  ["rupture-repair.catalog.json", "I1", 10],
+  ["mediation-logistics.catalog.json", "I2", 8],
+  ["co-parenting.catalog.json", "J1", 10],
+  ["third-party-support.catalog.json", "K1", 10],
 ];
 
 const VALID_TIERS = new Set(["T1", "T2", "T3", "T4"]);

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/LIFEOPS_PERSONA_SCENARIO_AUTHORING.md
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/LIFEOPS_PERSONA_SCENARIO_AUTHORING.md
@@ -1,8 +1,11 @@
 # LifeOps Persona Scenario Authoring
 
-This guide is the shared contract for the eight LifeOps persona scenario packs
-tracked by the catalog JSON files in this directory. It covers both surfaces:
-LifeOpsBench Python scenarios and scenario-runner `.scenario.ts` trajectories.
+This guide is the shared contract for the LifeOps persona scenario packs tracked
+by the catalog JSON files in this directory. The original A-F packs cover the
+MVP persona axes; the planned G-K packs extend the same ledger and verification
+rules to owner-directed corpus, relationship, co-parenting, and third-party
+support scenarios. It covers both surfaces: LifeOpsBench Python scenarios and
+scenario-runner `.scenario.ts` trajectories.
 
 ## Tier Rubric
 
@@ -59,6 +62,21 @@ may branch on `promptInstructions` text or a persona id string.
    comment naming the code path whose regression would make the scenario fail.
 8. Every authored scenario gets exactly one entry in its pack catalog, with
    `status` moving from `planned` to `authored` to `verified` as evidence lands.
+
+## Relationship / Support Pack Rules
+
+Packs G1/G2/H1/H2/I1/I2/J1/K1 inherit every rule above and add two binding
+constraints:
+
+1. **No therapy framing.** The assistant may support logistics, drafting,
+   reminders, factual summaries, and owner-approved sends. It must not roleplay
+   as a therapist, diagnose people, adjudicate relationship disputes, or offer
+   clinical treatment plans. Scenario assertions should fail on coaching copy
+   that turns practical support into therapy language.
+2. **Never assert 988 by default (#12780).** Do not escalate sadness, low focus,
+   rupture repair, co-parenting stress, or third-party support into hotline /
+   988 / emergency language unless the user explicitly reports imminent danger.
+   K1 scenarios should include negative assertions for false crisis framing.
 
 ## Surface Decision Tree
 

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/co-parenting.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/co-parenting.catalog.json
@@ -1,0 +1,87 @@
+{
+  "catalogId": "co-parenting",
+  "title": "Pack J1 - Co-parenting obligations scenario catalog",
+  "source": {
+    "parentIssue": "#14747",
+    "foundationIssue": "#14789",
+    "packId": "J1",
+    "persona": "jordan_coparent",
+    "targetCount": 10,
+    "notes": [
+      "Planned ledger for custody rhythm, swaps, expense splits, and kid-privacy firebreaks.",
+      "Uses jordan_coparent as the benchmark persona; scenarios must stay logistics-focused and non-therapeutic."
+    ]
+  },
+  "scenarios": [
+    {
+      "id": "j1.coparenting.custody_rhythm_capture",
+      "pack": "J1",
+      "tier": "T1",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "j1.coparenting.swap_request_approval",
+      "pack": "J1",
+      "tier": "T2",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "j1.coparenting.school_pickup_conflict",
+      "pack": "J1",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "j1.coparenting.expense_split_tracking",
+      "pack": "J1",
+      "tier": "T2",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "j1.coparenting.kid_privacy_firebreak",
+      "pack": "J1",
+      "tier": "T4",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "j1.coparenting.civil_but_tense_tone",
+      "pack": "J1",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "j1.coparenting.recurring_exchange_reminder",
+      "pack": "J1",
+      "tier": "T3",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "j1.coparenting.no_legal_advice",
+      "pack": "J1",
+      "tier": "T4",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "j1.coparenting.multi_household_calendar",
+      "pack": "J1",
+      "tier": "T3",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "j1.coparenting.last_minute_swap_fail_closed",
+      "pack": "J1",
+      "tier": "T4",
+      "surface": "scenario-runner",
+      "status": "planned"
+    }
+  ]
+}

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/kg-live-capture.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/kg-live-capture.catalog.json
@@ -1,0 +1,73 @@
+{
+  "catalogId": "kg-live-capture",
+  "title": "Pack H2 - Live memory, fact, and relationship capture scenario catalog",
+  "source": {
+    "parentIssue": "#14747",
+    "foundationIssue": "#14786",
+    "packId": "H2",
+    "persona": "knowledge graph live capture",
+    "targetCount": 8,
+    "notes": [
+      "Planned ledger for on-the-fly memory/fact/relationship capture into runtime primitives.",
+      "Every authored scenario must assert persisted primitives, not chat paraphrases."
+    ]
+  },
+  "scenarios": [
+    {
+      "id": "h2.kg_capture.new_contact_fact",
+      "pack": "H2",
+      "tier": "T1",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "h2.kg_capture.relationship_update_live",
+      "pack": "H2",
+      "tier": "T2",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "h2.kg_capture.preference_with_source",
+      "pack": "H2",
+      "tier": "T1",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "h2.kg_capture.conflicting_fact_resolution",
+      "pack": "H2",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "h2.kg_capture.no_private_leak_to_third_party",
+      "pack": "H2",
+      "tier": "T4",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "h2.kg_capture.identity_merge_uses_engine",
+      "pack": "H2",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "h2.kg_capture.forwarded_context_as_data",
+      "pack": "H2",
+      "tier": "T4",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "h2.kg_capture.audit_trail_survives_restart",
+      "pack": "H2",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "planned"
+    }
+  ]
+}

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/mediation-logistics.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/mediation-logistics.catalog.json
@@ -1,0 +1,73 @@
+{
+  "catalogId": "mediation-logistics",
+  "title": "Pack I2 - Mediation logistics scenario catalog",
+  "source": {
+    "parentIssue": "#14747",
+    "foundationIssue": "#14788",
+    "packId": "I2",
+    "persona": "neutral logistics",
+    "targetCount": 8,
+    "notes": [
+      "Planned ledger for factual summaries and neutral logistics in disagreements.",
+      "The assistant must never adjudicate who is right."
+    ]
+  },
+  "scenarios": [
+    {
+      "id": "i2.mediation.factual_summary_only",
+      "pack": "I2",
+      "tier": "T1",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "i2.mediation.neutral_schedule_options",
+      "pack": "I2",
+      "tier": "T2",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "i2.mediation.no_adjudication",
+      "pack": "I2",
+      "tier": "T4",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "i2.mediation.consent_before_group_message",
+      "pack": "I2",
+      "tier": "T4",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "i2.mediation.extract_action_items",
+      "pack": "I2",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "i2.mediation.private_fact_firebreak",
+      "pack": "I2",
+      "tier": "T4",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "i2.mediation.followup_without_pressure",
+      "pack": "I2",
+      "tier": "T3",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "i2.mediation.conflicting_claims_label_uncertain",
+      "pack": "I2",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "planned"
+    }
+  ]
+}

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/overdue-comms-apology.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/overdue-comms-apology.catalog.json
@@ -1,0 +1,97 @@
+{
+  "catalogId": "overdue-comms-apology",
+  "title": "Pack G1 - Overdue communications and apology drafts scenario catalog",
+  "source": {
+    "parentIssue": "#14747",
+    "foundationIssue": "#14783",
+    "packId": "G1",
+    "persona": "high-comms / owner-directed corpus",
+    "targetCount": 10,
+    "notes": [
+      "Planned ledger for overdue-reply backlog triage and batched apology drafts.",
+      "Both surfaces are represented before scenario files land; planned rows flip to authored only when the concrete scenario exists."
+    ]
+  },
+  "scenarios": [
+    {
+      "id": "g1.overdue_comms.identify_overdue_thread",
+      "pack": "G1",
+      "tier": "T1",
+      "surface": "lifeops-bench",
+      "status": "planned",
+      "notes": "SCEN-A: identify one genuinely overdue reply from message history without fabricating urgency."
+    },
+    {
+      "id": "g1.overdue_comms.apology_draft_requires_approval",
+      "pack": "G1",
+      "tier": "T2",
+      "surface": "scenario-runner",
+      "status": "planned",
+      "notes": "SCEN-B: draft a brief apology and hold for owner approval; never send automatically."
+    },
+    {
+      "id": "g1.overdue_comms.batch_apology_drafts",
+      "pack": "G1",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "planned",
+      "notes": "SCEN-C: batch several overdue replies into reviewable drafts ordered by priority."
+    },
+    {
+      "id": "g1.overdue_comms.do_not_over_apologize",
+      "pack": "G1",
+      "tier": "T4",
+      "surface": "scenario-runner",
+      "status": "planned",
+      "notes": "SCEN-D: avoid guilt/over-apology language when the thread does not warrant it."
+    },
+    {
+      "id": "g1.overdue_comms.channel_appropriate_tone",
+      "pack": "G1",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "planned",
+      "notes": "SCEN-E: adapt apology draft tone to email vs chat without exposing hidden policy text."
+    },
+    {
+      "id": "g1.overdue_comms.vip_overdue_first",
+      "pack": "G1",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "planned",
+      "notes": "SCEN-F: prioritize the overdue VIP reply while preserving lower-priority backlog context."
+    },
+    {
+      "id": "g1.overdue_comms.no_send_without_owner",
+      "pack": "G1",
+      "tier": "T4",
+      "surface": "lifeops-bench",
+      "status": "planned",
+      "notes": "SCEN-G: fail closed on any external send until the owner explicitly approves."
+    },
+    {
+      "id": "g1.overdue_comms.followup_cadence_reset",
+      "pack": "G1",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "planned",
+      "notes": "SCEN-H: once a draft is approved or sent, reset the follow-up cadence structurally."
+    },
+    {
+      "id": "g1.overdue_comms.stale_thread_archive",
+      "pack": "G1",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "planned",
+      "notes": "SCEN-I: distinguish stale no-action threads from overdue obligations."
+    },
+    {
+      "id": "g1.overdue_comms.cross_channel_summary",
+      "pack": "G1",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "planned",
+      "notes": "SCEN-J: summarize cross-channel context before proposing a draft."
+    }
+  ]
+}

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/reconnect-old-friends.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/reconnect-old-friends.catalog.json
@@ -1,0 +1,73 @@
+{
+  "catalogId": "reconnect-old-friends",
+  "title": "Pack G2 - Reconnecting with old friends scenario catalog",
+  "source": {
+    "parentIssue": "#14747",
+    "foundationIssue": "#14784",
+    "packId": "G2",
+    "persona": "relationship maintenance",
+    "targetCount": 8,
+    "notes": [
+      "Planned ledger for cadence watcher and grounded reconnect drafts.",
+      "The assistant must use real relationship/history context and approval gates, never generic outreach spam."
+    ]
+  },
+  "scenarios": [
+    {
+      "id": "g2.reconnect.identify_lapsed_friend",
+      "pack": "G2",
+      "tier": "T1",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "g2.reconnect.grounded_reconnect_draft",
+      "pack": "G2",
+      "tier": "T2",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "g2.reconnect.no_generic_blast",
+      "pack": "G2",
+      "tier": "T4",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "g2.reconnect.cadence_watcher_due",
+      "pack": "G2",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "g2.reconnect.respect_recent_silence",
+      "pack": "G2",
+      "tier": "T3",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "g2.reconnect.ask_before_sensitive_memory",
+      "pack": "G2",
+      "tier": "T4",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "g2.reconnect.choose_best_channel",
+      "pack": "G2",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "g2.reconnect.post_send_followup",
+      "pack": "G2",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "planned"
+    }
+  ]
+}

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/relationship-type-inference.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/relationship-type-inference.catalog.json
@@ -1,0 +1,87 @@
+{
+  "catalogId": "relationship-type-inference",
+  "title": "Pack H1 - Relationship type inference scenario catalog",
+  "source": {
+    "parentIssue": "#14747",
+    "foundationIssue": "#14785",
+    "packId": "H1",
+    "persona": "relationship graph",
+    "targetCount": 10,
+    "notes": [
+      "Planned ledger for relationship-type inference from message history and relationship vocabulary additions.",
+      "Assertions must land in relationship primitives, not reply text."
+    ]
+  },
+  "scenarios": [
+    {
+      "id": "h1.relationship_type.parent_from_history",
+      "pack": "H1",
+      "tier": "T1",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "h1.relationship_type.manager_vs_client",
+      "pack": "H1",
+      "tier": "T2",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "h1.relationship_type.school_contact",
+      "pack": "H1",
+      "tier": "T1",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "h1.relationship_type.coparent_detected",
+      "pack": "H1",
+      "tier": "T2",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "h1.relationship_type.old_friend_not_vip",
+      "pack": "H1",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "h1.relationship_type.ambiguous_requires_clarifier",
+      "pack": "H1",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "h1.relationship_type.contradiction_reconciled",
+      "pack": "H1",
+      "tier": "T3",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "h1.relationship_type.private_label_not_shared",
+      "pack": "H1",
+      "tier": "T4",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "h1.relationship_type.bulk_history_inference",
+      "pack": "H1",
+      "tier": "T3",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "h1.relationship_type.injection_ignored",
+      "pack": "H1",
+      "tier": "T4",
+      "surface": "scenario-runner",
+      "status": "planned"
+    }
+  ]
+}

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/rupture-repair.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/rupture-repair.catalog.json
@@ -1,0 +1,87 @@
+{
+  "catalogId": "rupture-repair",
+  "title": "Pack I1 - Interpersonal rupture repair scenario catalog",
+  "source": {
+    "parentIssue": "#14747",
+    "foundationIssue": "#14787",
+    "packId": "I1",
+    "persona": "relationship repair",
+    "targetCount": 10,
+    "notes": [
+      "Planned ledger for grounded apology drafts and approval-gated repair logistics.",
+      "Scenarios must stay non-clinical: no therapy roleplay, diagnosis, or crisis framing."
+    ]
+  },
+  "scenarios": [
+    {
+      "id": "i1.rupture_repair.extract_what_happened",
+      "pack": "I1",
+      "tier": "T1",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "i1.rupture_repair.grounded_apology_draft",
+      "pack": "I1",
+      "tier": "T2",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "i1.rupture_repair.no_coaching_or_diagnosis",
+      "pack": "I1",
+      "tier": "T4",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "i1.rupture_repair.approval_before_send",
+      "pack": "I1",
+      "tier": "T4",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "i1.rupture_repair.repair_followup_cadence",
+      "pack": "I1",
+      "tier": "T3",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "i1.rupture_repair.wrong_recipient_guard",
+      "pack": "I1",
+      "tier": "T4",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "i1.rupture_repair.private_context_minimized",
+      "pack": "I1",
+      "tier": "T3",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "i1.rupture_repair.owner_declines_no_side_effect",
+      "pack": "I1",
+      "tier": "T4",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "i1.rupture_repair.rewrite_same_themes",
+      "pack": "I1",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "i1.rupture_repair.sensitive_event_defer",
+      "pack": "I1",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "planned"
+    }
+  ]
+}

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/third-party-support.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/third-party-support.catalog.json
@@ -1,0 +1,87 @@
+{
+  "catalogId": "third-party-support",
+  "title": "Pack K1 - Supporting a sad or unfocused third party scenario catalog",
+  "source": {
+    "parentIssue": "#14747",
+    "foundationIssue": "#14790",
+    "packId": "K1",
+    "persona": "friend-of-owner support",
+    "targetCount": 10,
+    "notes": [
+      "Planned ledger for supportive, non-clinical help directed at a third party.",
+      "Bound by the no-therapy rule and the never-assert-988 rule unless the user explicitly reports imminent danger."
+    ]
+  },
+  "scenarios": [
+    {
+      "id": "k1.third_party_support.supportive_checkin_draft",
+      "pack": "K1",
+      "tier": "T1",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "k1.third_party_support.no_clinical_claims",
+      "pack": "K1",
+      "tier": "T4",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "k1.third_party_support.practical_offer_options",
+      "pack": "K1",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "k1.third_party_support.owner_approval_before_send",
+      "pack": "K1",
+      "tier": "T4",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "k1.third_party_support.friend_privacy_minimized",
+      "pack": "K1",
+      "tier": "T3",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "k1.third_party_support.no_988_without_danger",
+      "pack": "K1",
+      "tier": "T4",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "k1.third_party_support.followup_cadence_gentle",
+      "pack": "K1",
+      "tier": "T3",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "k1.third_party_support.summarize_context_without_gossip",
+      "pack": "K1",
+      "tier": "T3",
+      "surface": "scenario-runner",
+      "status": "planned"
+    },
+    {
+      "id": "k1.third_party_support.redirect_to_owner_task",
+      "pack": "K1",
+      "tier": "T2",
+      "surface": "lifeops-bench",
+      "status": "planned"
+    },
+    {
+      "id": "k1.third_party_support.boundary_respected",
+      "pack": "K1",
+      "tier": "T4",
+      "surface": "scenario-runner",
+      "status": "planned"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Registers planned G1/G2/H1/H2/I1/I2/J1/K1 LifeOps persona-pack catalogs with both `lifeops-bench` and `scenario-runner` surfaces represented.
- Adds the `jordan_coparent` benchmark persona and exports the planned relationship expansion persona tuple separately from executable persona scenarios.
- Updates the catalog coverage gate, authoring rules, and MVP persona research doc so G-K authoring inherits the no-therapy and #12780 never-assert-988 constraints.

Closes #14753
Part of #14747

## Required Evidence Rows
<!-- evidence-row:before-screenshots -->
- N/A - catalog ledgers, Python benchmark persona metadata, and docs only; no app-rendered surface existed before this change.

<!-- evidence-row:after-screenshots -->
- N/A - catalog ledgers, Python benchmark persona metadata, and docs only; no app-rendered surface exists after this change.

<!-- evidence-row:walkthrough-video -->
- N/A - no UI or native workflow changed; the executable verification path is the catalog/persona checker output below.

<!-- evidence-row:backend-logs -->
- N/A - no server runtime path changed; this PR only registers planned catalog metadata and benchmark persona/docs.

<!-- evidence-row:frontend-logs -->
- N/A - no frontend runtime path changed; this PR only registers planned catalog metadata and benchmark persona/docs.

<!-- evidence-row:llm-trajectory -->
- N/A - this registers planned scenario ledgers only and does not add executable scenarios, prompts, actions, providers, or model behavior. SCEN-A..H scenario implementation PRs will carry live trajectory evidence when rows move from `planned` to `authored`/`verified`.

<!-- evidence-row:domain-artifacts -->
- Domain artifacts are the planned catalog ledgers and co-parent persona metadata in the [PR file diff](https://github.com/elizaOS/eliza/pull/14843/files), validated by the coverage and persona checks below.

## Verification
<!-- evidence-row:catalog-coverage -->
- `node packages/scripts/check-lifeops-persona-catalog-coverage.mjs` PASS. Output: G1 `0/10`, G2 `0/8`, H1 `0/10`, H2 `0/8`, I1 `0/10`, I2 `0/8`, J1 `0/10`, K1 `0/10`; total `212/286 authored`, `134/286 verified`; no errors. These are planned ledger rows by design.

<!-- evidence-row:catalog-coverage-json -->
- `node packages/scripts/check-lifeops-persona-catalog-coverage.mjs --json` PASS. JSON summary: `target: 286`, `authored: 212`, `verified: 134`, `errors: []`.

<!-- evidence-row:persona-schema -->
- `python -m eliza_lifeops_bench.scenarios.personas.schema_check` PASS. Python emitted the existing runpy warning from executing an already-imported module, then exited 0.

<!-- evidence-row:bench-corpus -->
- `python -m pytest tests/test_scenarios_corpus.py -q` PASS after regenerating ignored local LifeWorld snapshots with `python -m eliza_lifeops_bench.lifeworld.snapshots --rebuild`: `21 passed`.

<!-- evidence-row:format-compile -->
- `bunx @biomejs/biome check packages/scripts/check-lifeops-persona-catalog-coverage.mjs plugins/plugin-personal-assistant/test/scenarios/_catalogs/*.catalog.json plugins/plugin-personal-assistant/test/scenarios/_catalogs/LIFEOPS_PERSONA_SCENARIO_AUTHORING.md packages/docs/ongoing-development/research/01-mvp-product-personas.md` PASS: `Checked 18 files. No fixes applied`.
- `python -m compileall -q packages/benchmarks/lifeops-bench/eliza_lifeops_bench/scenarios/_personas.py packages/benchmarks/lifeops-bench/eliza_lifeops_bench/scenarios/personas/_persona_specs.py packages/benchmarks/lifeops-bench/eliza_lifeops_bench/scenarios/personas/__init__.py` PASS.

<!-- evidence-row:diff-policy -->
- `git diff --check` PASS.
- `bun run audit:error-policy-ratchet --report` PASS: base `origin/develop (d5fd5d3d02)`, `0 changed production source file(s)`, `no new fallback-slop in touched files`.

<!-- evidence-row:verify -->
- `bun run verify` BLOCKED before branch-specific typecheck/lint by the repo-wide type-safety ratchet: `as unknown as: 76 / 73`, `unsafe cast baseline exceeded`. The reported files are unrelated to this PR (for example `packages/ui/src/components/shell/__e2e__/chat-sheet-fixture.tsx`, feed services, app-core test support, plugin-personal-assistant service). This PR adds no TypeScript unsafe casts.