### PR TITLE
style(console): complete black-and-white sweep — neutralize all remaining brand-orange tints (56 files)

### DIFF
--- a/packages/ui/src/cloud-ui/components/analytics/cost-alerts.tsx
+++ b/packages/ui/src/cloud-ui/components/analytics/cost-alerts.tsx
@@ -64,8 +64,8 @@ export function CostAlerts({ costTrending }: CostAlertsProps) {
   }
 
   const toneClasses: Record<"warning" | "error" | "info", string> = {
-    warning: "border-[var(--accent)]/40 bg-[var(--accent)]/10 text-white",
-    error: "border-[var(--accent)] bg-[var(--accent)] text-black",
+    warning: "border-border bg-muted text-txt",
+    error: "border-border bg-txt text-bg",
     info: "border-border bg-surface text-txt",
   };
 

--- a/packages/ui/src/cloud-ui/components/analytics/cost-insights-card.tsx
+++ b/packages/ui/src/cloud-ui/components/analytics/cost-insights-card.tsx
@@ -32,13 +32,13 @@ export function CostInsightsCard({
         : `${costTrending.daysUntilBalanceZero}d`;
 
   return (
-    <BrandCard corners={false} className="border-[var(--accent)]/40 bg-[var(--accent)]/10">
+    <BrandCard corners={false} className="border-border bg-card">
       <div className="flex flex-col gap-2 p-6 pb-4">
         <div className="flex items-center gap-3">
           <h3 className="text-base font-semibold text-white">Cost outlook</h3>
           <Badge
             variant="outline"
-            className="border-[var(--accent)]/30 bg-[var(--accent)]/10 text-xs font-medium text-[var(--accent)]"
+            className="border-border bg-muted text-xs font-medium text-txt-strong"
           >
             {costTrending.burnChangePercent > 0 ? "+" : ""}
             {costTrending.burnChangePercent.toFixed(1)}%
@@ -47,7 +47,7 @@ export function CostInsightsCard({
       </div>
       <div className="flex flex-col gap-5 p-6 pt-2">
         <div className="grid gap-4">
-          <div className="grid gap-2 rounded-sm border border-orange-500/20 bg-black/35 p-4">
+          <div className="grid gap-2 rounded-sm border border-border bg-black/35 p-4">
             <p className="text-xs uppercase tracking-wide text-white/50">
               Daily burn
             </p>
@@ -67,13 +67,13 @@ export function CostInsightsCard({
           </div>
 
           <div className="grid grid-cols-2 gap-3">
-            <div className="rounded-sm border border-orange-500/20 bg-black/35 p-3">
+            <div className="rounded-sm border border-border bg-black/35 p-3">
               <p className="text-xs uppercase tracking-wide text-white/50">
                 Runway
               </p>
               <p className="text-lg font-semibold text-white">{runwayLabel}</p>
             </div>
-            <div className="rounded-sm border border-orange-500/20 bg-black/35 p-3">
+            <div className="rounded-sm border border-border bg-black/35 p-3">
               <p className="text-xs uppercase tracking-wide text-white/50">
                 Balance
               </p>

--- a/packages/ui/src/cloud-ui/components/api-key-empty-state.tsx
+++ b/packages/ui/src/cloud-ui/components/api-key-empty-state.tsx
@@ -12,7 +12,7 @@ interface ApiKeyEmptyStateProps {
 export function ApiKeyEmptyState({ onCreateKey }: ApiKeyEmptyStateProps) {
   return (
     <EmptyState
-      icon={<KeyRound className="h-7 w-7 text-[var(--accent)]" />}
+      icon={<KeyRound className="h-7 w-7 text-muted" />}
       title="No API keys yet"
       description="Create your first API key to start authenticating requests and tracking usage across the platform."
       action={

--- a/packages/ui/src/cloud-ui/components/auth/authorize-content.tsx
+++ b/packages/ui/src/cloud-ui/components/auth/authorize-content.tsx
@@ -361,7 +361,7 @@ function AuthorizeFlow({
   if (status === "validating" || authLoading) {
     return (
       <Frame>
-        <Loader2 className="h-12 w-12 animate-spin text-[var(--accent)]" />
+        <Loader2 className="h-12 w-12 animate-spin text-muted" />
         <h3 className="text-lg font-semibold text-white">
           Verifying application...
         </h3>
@@ -382,7 +382,7 @@ function AuthorizeFlow({
   if (status === "authorizing") {
     return (
       <Frame>
-        <Loader2 className="h-12 w-12 animate-spin text-[var(--accent)]" />
+        <Loader2 className="h-12 w-12 animate-spin text-muted" />
         <h3 className="text-lg font-semibold text-white">Authorizing...</h3>
         <p className="text-sm text-white/60">
           Redirecting you back to {appInfo.name}
@@ -481,8 +481,8 @@ function AppHeader({ appInfo }: { appInfo: AppInfo }) {
           unoptimized
         />
       ) : (
-        <div className="h-16 w-16 rounded-sm bg-gradient-to-br from-[var(--accent)] to-[#FF8800] flex items-center justify-center">
-          <span className="text-2xl font-bold text-white">
+        <div className="h-16 w-16 rounded-sm bg-muted flex items-center justify-center">
+          <span className="text-2xl font-bold text-txt-strong">
             {appInfo.name.charAt(0)}
           </span>
         </div>
@@ -617,7 +617,7 @@ function SignedOutActions({
         </>
       ) : (
         <div className="flex flex-col items-center gap-3 py-6">
-          <Loader2 className="h-6 w-6 animate-spin text-[var(--accent)]" />
+          <Loader2 className="h-6 w-6 animate-spin text-muted" />
           <p className="text-sm text-white/60">Loading sign-in options...</p>
         </div>
       )}

--- a/packages/ui/src/cloud-ui/components/data-list/apps-list-view.tsx
+++ b/packages/ui/src/cloud-ui/components/data-list/apps-list-view.tsx
@@ -105,7 +105,7 @@ export function AppsListView({
                 {renderAppLink({
                   app,
                   className:
-                    "min-w-0 truncate text-sm font-medium text-white transition-colors hover:text-[var(--accent)]",
+                    "min-w-0 truncate text-sm font-medium text-white transition-colors hover:text-txt-strong",
                   children: app.name,
                 })}
                 <StatusBadge
@@ -114,7 +114,7 @@ export function AppsListView({
                   className="px-1.5 py-0 text-[10px]"
                 />
                 {app.affiliate_code ? (
-                  <Badge className="shrink-0 rounded-sm border-accent/30 bg-accent-subtle px-1.5 py-0 text-2xs text-accent">
+                  <Badge className="shrink-0 rounded-sm border-border bg-surface px-1.5 py-0 text-2xs text-muted">
                     Affiliate
                   </Badge>
                 ) : null}

--- a/packages/ui/src/cloud-ui/components/docs/api-route-explorer-client.tsx
+++ b/packages/ui/src/cloud-ui/components/docs/api-route-explorer-client.tsx
@@ -54,7 +54,7 @@ const GROUP_LABELS: Record<string, string> = {
 // The brand palette is black/white/orange + one status-green, so methods are
 // differentiated by the tokenized status ramp rather than arbitrary colors:
 //   GET    -> success (safe, read-only)
-//   POST   -> accent (the brand action color)
+//   POST   -> neutral strong (bordered, no brand tint)
 //   PUT    -> warning (mutating)
 //   PATCH  -> info (neutral, partial update)
 //   DELETE -> destructive (orange-by-design in this system)
@@ -65,7 +65,7 @@ function methodBadgeClass(method: HttpMethod) {
     case "GET":
       return `${base} bg-status-success-bg text-status-success border-status-success/30`;
     case "POST":
-      return `${base} bg-accent-subtle text-accent border-accent/30`;
+      return `${base} bg-bg-muted text-txt-strong border-border`;
     case "PUT":
       return `${base} bg-status-warning-bg text-status-warning border-status-warning/30`;
     case "PATCH":
@@ -109,7 +109,11 @@ function CopyButton({ text }: { text: string }) {
       className="absolute top-2 right-2 inline-flex min-h-touch items-center gap-1.5 rounded-sm border border-border bg-bg-elevated px-2.5 py-1 text-2xs font-medium uppercase tracking-wider text-muted transition-colors hover:border-border-strong hover:bg-bg-hover hover:text-txt"
     >
       {copied ? (
-        <Check aria-hidden="true" className="size-3.5 text-status-success" strokeWidth={2} />
+        <Check
+          aria-hidden="true"
+          className="size-3.5 text-status-success"
+          strokeWidth={2}
+        />
       ) : (
         <Copy aria-hidden="true" className="size-3.5" strokeWidth={2} />
       )}
@@ -212,7 +216,7 @@ export function ApiRouteExplorerClient({
             <div className="border-b border-border p-4 bg-bg-elevated">
               <div className="flex items-center justify-between gap-3 mb-3">
                 <div className="flex items-center gap-2">
-                  <div className="w-2 h-2 rounded-full bg-accent" />
+                  <div className="w-2 h-2 rounded-full bg-muted" />
                   <span className="text-xs font-bold uppercase tracking-[0.18em] text-muted">
                     Route Explorer
                   </span>
@@ -226,7 +230,7 @@ export function ApiRouteExplorerClient({
                     type="checkbox"
                     checked={showAll}
                     onChange={(e) => setShowAll(e.target.checked)}
-                    className="accent-[var(--accent)] w-3.5 h-3.5"
+                    className="accent-txt w-3.5 h-3.5"
                   />
                   Show all
                 </label>
@@ -290,7 +294,7 @@ export function ApiRouteExplorerClient({
                             className={cn(
                               "w-full min-h-touch text-left rounded-sm border px-3 py-2.5 transition-colors my-1",
                               active
-                                ? "bg-accent-subtle border-accent/40"
+                                ? "bg-bg-muted border-border-strong"
                                 : "border-transparent hover:bg-bg-hover hover:border-border",
                             )}
                           >
@@ -319,7 +323,9 @@ export function ApiRouteExplorerClient({
                                 <div
                                   className={cn(
                                     "text-sm font-medium truncate transition-colors",
-                                    active ? "text-txt-strong" : "text-muted-strong",
+                                    active
+                                      ? "text-txt-strong"
+                                      : "text-muted-strong",
                                   )}
                                 >
                                   {title}
@@ -385,7 +391,11 @@ export function ApiRouteExplorerClient({
                         key={tag}
                         className="inline-flex items-center gap-1 text-2xs font-medium uppercase tracking-wider rounded-sm px-2 py-1 bg-bg-muted border border-border text-muted"
                       >
-                        <Tag aria-hidden="true" className="size-3" strokeWidth={2} />
+                        <Tag
+                          aria-hidden="true"
+                          className="size-3"
+                          strokeWidth={2}
+                        />
                         {tag}
                       </span>
                     ))}
@@ -484,7 +494,7 @@ export function ApiRouteExplorerClient({
                   <div className="flex items-center gap-2">
                     <Terminal
                       aria-hidden="true"
-                      className="size-4 text-accent"
+                      className="size-4 text-muted"
                       strokeWidth={2}
                     />
                     <span className="text-xs font-bold uppercase tracking-wider text-muted">
@@ -524,7 +534,7 @@ export function ApiRouteExplorerClient({
                           <span className="text-muted"> \</span>
                           {"\n"}
                           <span className="text-muted"> -d </span>
-                          <span className="text-accent">
+                          <span className="text-txt-strong">
                             &apos;{"{}"}&apos;
                           </span>
                         </>
@@ -536,12 +546,12 @@ export function ApiRouteExplorerClient({
 
                 <p className="mt-3 text-xs text-muted">
                   Replace{" "}
-                  <code className="text-accent bg-accent-subtle rounded-sm px-1.5 py-0.5">
+                  <code className="text-txt-strong bg-bg-muted rounded-sm px-1.5 py-0.5">
                     YOUR_API_KEY
                   </code>{" "}
                   with your actual API key from{" "}
                   <a
-                    className="text-accent hover:underline"
+                    className="text-txt-strong hover:underline"
                     href="/dashboard/api-keys"
                   >
                     Dashboard → API Keys
@@ -567,10 +577,10 @@ export function ApiRouteExplorerClient({
           ) : (
             /* Empty state */
             <div className="flex flex-col items-center justify-center h-full min-h-[400px] p-8 text-center">
-              <div className="w-16 h-16 rounded-full bg-accent-subtle flex items-center justify-center mb-4">
+              <div className="w-16 h-16 rounded-full bg-bg-muted flex items-center justify-center mb-4">
                 <Terminal
                   aria-hidden="true"
-                  className="size-8 text-accent"
+                  className="size-8 text-muted"
                   strokeWidth={1.5}
                 />
               </div>

--- a/packages/ui/src/cloud-ui/components/docs/endpoint-card.tsx
+++ b/packages/ui/src/cloud-ui/components/docs/endpoint-card.tsx
@@ -43,8 +43,8 @@ export interface EndpointCardProps<
 function getPricingTextStyle(pricing: ApiEndpointCardPricing | undefined) {
   if (!pricing) return "text-neutral-500";
   if (pricing.isFree) return "text-green-400";
-  if (pricing.isVariable) return "text-orange-400";
-  return "text-[var(--accent)]";
+  if (pricing.isVariable) return "text-txt";
+  return "text-txt";
 }
 
 function fallbackPricingLabel(pricing: ApiEndpointCardPricing) {
@@ -75,7 +75,7 @@ export function EndpointCard<
       className="group relative w-full min-w-0 overflow-hidden rounded-sm border border-white/5 bg-neutral-900/50 p-4 text-left transition-all hover:border-white/10 hover:bg-neutral-900/70"
     >
       <div className="absolute right-4 top-4 opacity-0 transition-all duration-200 group-hover:opacity-100">
-        <div className="flex items-center gap-1 text-xs font-medium text-[var(--accent)]">
+        <div className="flex items-center gap-1 text-xs font-medium text-txt-strong">
           Test <ChevronRight className="h-3 w-3" />
         </div>
       </div>
@@ -86,7 +86,7 @@ export function EndpointCard<
             <span className="text-neutral-500">
               {getCategoryIcon(endpoint.category)}
             </span>
-            <h3 className="pr-16 text-sm font-semibold text-white transition-colors group-hover:text-[var(--accent)]">
+            <h3 className="pr-16 text-sm font-semibold text-white transition-colors group-hover:text-txt-strong">
               {endpoint.name}
             </h3>
           </div>

--- a/packages/ui/src/cloud-ui/components/layout/dashboard-sidebar-item.tsx
+++ b/packages/ui/src/cloud-ui/components/layout/dashboard-sidebar-item.tsx
@@ -143,7 +143,7 @@ export function DashboardSidebarNavigationItem({
     "relative flex items-center border-l-2 transition-colors duration-150",
     "hover:bg-white/[0.06] hover:text-white",
     isActive
-      ? "border-l-[var(--accent)] bg-white/[0.06] text-white"
+      ? "border-l-border bg-white/[0.06] text-white"
       : "border-l-transparent text-white/70",
     isCollapsed ? "justify-center p-2.5" : "gap-3 px-3 py-2.5",
   );
@@ -158,8 +158,8 @@ export function DashboardSidebarNavigationItem({
             <span
               className="px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide"
               style={{
-                backgroundColor: "rgba(255, 138, 36, 0.2)",
-                color: "#fff7ee",
+                backgroundColor: "rgba(255, 255, 255, 0.1)",
+                color: "#ffffff",
                 border: "1px solid rgba(255, 255, 255, 0.28)",
               }}
             >

--- a/packages/ui/src/cloud-ui/components/log-viewer.tsx
+++ b/packages/ui/src/cloud-ui/components/log-viewer.tsx
@@ -240,7 +240,7 @@ export function LogViewer({
         <div className="flex flex-col gap-4 border-b border-border pb-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
             <div className="mb-1 flex flex-wrap items-center gap-2">
-              <span className="inline-block h-2 w-2 rounded-full bg-[var(--accent)]" />
+              <span className="inline-block h-2 w-2 rounded-full bg-txt" />
               <h2
                 className="text-xl font-normal text-white"
                 style={{ fontFamily: "var(--font-roboto-mono)" }}

--- a/packages/ui/src/cloud-ui/components/monetization/earnings-simulator.tsx
+++ b/packages/ui/src/cloud-ui/components/monetization/earnings-simulator.tsx
@@ -152,11 +152,11 @@ export function EarningsSimulator({
 
         {/* Purchase earnings */}
         <div className="flex items-center justify-between text-sm">
-          <span className="text-amber-400 flex items-center gap-1.5">
+          <span className="text-white/90 flex items-center gap-1.5">
             <Coins className="h-3 w-3" />
             Purchase ({purchaseSharePercentage}%)
           </span>
-          <span className="font-mono text-amber-400">
+          <span className="font-mono text-white/90">
             +${calculations.purchaseEarnings.toFixed(2)}
           </span>
         </div>
@@ -167,7 +167,7 @@ export function EarningsSimulator({
         {/* Total */}
         <div className="flex items-center justify-between">
           <span className="text-white font-medium">Your Earnings</span>
-          <span className="text-xl font-semibold text-[var(--accent)]">
+          <span className="text-xl font-semibold text-white">
             ${calculations.totalEarnings.toFixed(2)}
           </span>
         </div>

--- a/packages/ui/src/cloud-ui/components/monetization/milestone-progress.tsx
+++ b/packages/ui/src/cloud-ui/components/monetization/milestone-progress.tsx
@@ -55,7 +55,7 @@ export function MilestoneProgress({
         <div
           className={cn(
             "absolute inset-y-0 left-0 rounded-full transition-all duration-700 ease-out",
-            isComplete ? "bg-emerald-500" : "bg-[var(--accent)]",
+            isComplete ? "bg-emerald-500" : "bg-txt",
           )}
           style={{ width: `${animatedProgress}%` }}
         />

--- a/packages/ui/src/cloud-ui/components/monetization/revenue-flow-diagram.tsx
+++ b/packages/ui/src/cloud-ui/components/monetization/revenue-flow-diagram.tsx
@@ -72,8 +72,8 @@ export function RevenueFlowDiagram({
             icon={<Wallet className="h-5 w-5" />}
             label="You"
             value={`Earn $${markup.toFixed(2)}`}
-            color="text-[var(--accent)]"
-            bgColor="bg-[var(--accent)]/10"
+            color="text-txt-strong"
+            bgColor="bg-muted"
             highlight
           />
         </div>
@@ -97,13 +97,13 @@ export function RevenueFlowDiagram({
             sublabel="(base cost)"
           />
           <div className="flex justify-center">
-            <ArrowRight className="h-4 w-4 text-[var(--accent)] rotate-90" />
+            <ArrowRight className="h-4 w-4 text-txt-strong rotate-90" />
           </div>
           <FlowNodeMobile
             icon={<Wallet className="h-4 w-4" />}
             label="You earn"
             value={`$${markup.toFixed(2)}`}
-            color="text-[var(--accent)]"
+            color="text-txt-strong"
             sublabel={`(${markupPercentage}% markup)`}
             highlight
           />
@@ -114,9 +114,9 @@ export function RevenueFlowDiagram({
       <div className="mt-auto pt-4 border-t border-white/10">
         <div className="space-y-3 text-xs">
           <div className="flex items-start gap-2">
-            <Zap className="h-3 w-3 text-accent mt-0.5" />
+            <Zap className="h-3 w-3 text-muted mt-0.5" />
             <div>
-              <p className="font-medium text-accent">Inference Markup</p>
+              <p className="font-medium text-txt-strong">Inference Markup</p>
               <p className="text-neutral-500 mt-0.5">
                 You set {markupPercentage}% markup on AI costs. More usage =
                 more earnings.
@@ -124,9 +124,9 @@ export function RevenueFlowDiagram({
             </div>
           </div>
           <div className="flex items-start gap-2">
-            <Coins className="h-3 w-3 text-amber-400 mt-0.5" />
+            <Coins className="h-3 w-3 text-muted mt-0.5" />
             <div>
-              <p className="font-medium text-amber-400">Purchase Share</p>
+              <p className="font-medium text-txt-strong">Purchase Share</p>
               <p className="text-neutral-500 mt-0.5">
                 Earn {purchaseSharePercentage}% when users buy credits in your
                 app.
@@ -160,7 +160,7 @@ function FlowNode({
     <div
       className={cn(
         "flex flex-col items-center gap-2 p-3 rounded-sm border transition-colors w-[90px]",
-        highlight ? "border-[var(--accent)]/30" : "border-white/10",
+        highlight ? "border-border" : "border-white/10",
         bgColor,
       )}
     >
@@ -184,13 +184,13 @@ function FlowArrow({ label, highlight }: FlowArrowProps) {
       <ArrowRight
         className={cn(
           "h-4 w-4",
-          highlight ? "text-[var(--accent)]" : "text-neutral-600",
+          highlight ? "text-txt-strong" : "text-neutral-600",
         )}
       />
       <span
         className={cn(
           "text-[10px] font-mono",
-          highlight ? "text-[var(--accent)]" : "text-neutral-500",
+          highlight ? "text-txt-strong" : "text-neutral-500",
         )}
       >
         {label}
@@ -220,9 +220,7 @@ function FlowNodeMobile({
     <div
       className={cn(
         "flex items-center justify-between p-3 rounded-sm border",
-        highlight
-          ? "border-[var(--accent)]/30 bg-[var(--accent)]/10"
-          : "border-white/10 bg-black/30",
+        highlight ? "border-border bg-muted" : "border-white/10 bg-black/30",
       )}
     >
       <div className="flex items-center gap-2">

--- a/packages/ui/src/cloud-ui/components/voice/voice-empty-state.tsx
+++ b/packages/ui/src/cloud-ui/components/voice/voice-empty-state.tsx
@@ -14,7 +14,7 @@ interface VoiceEmptyStateProps {
 export function VoiceEmptyState({ onCreateClick }: VoiceEmptyStateProps) {
   return (
     <EmptyState
-      icon={<Mic className="h-7 w-7 text-[var(--accent)]" />}
+      icon={<Mic className="h-7 w-7 text-muted" />}
       title="Create a Voice Clone"
       action={
         <Button onClick={onCreateClick} size="lg" className="h-12 px-8">

--- a/packages/ui/src/cloud/account-security/components/api-keys-link.tsx
+++ b/packages/ui/src/cloud/account-security/components/api-keys-link.tsx
@@ -14,8 +14,8 @@ export function ApiKeysLink() {
       <CornerBrackets size="sm" className="opacity-50" />
       <div className="relative z-10 flex items-start justify-between gap-3">
         <div className="flex items-start gap-3">
-          <div className="rounded-sm border border-[var(--brand-orange)]/40 bg-[var(--brand-orange)]/15 p-2">
-            <KeyRound className="h-4 w-4 text-[var(--brand-orange)]" />
+          <div className="rounded-sm border border-border bg-muted p-2">
+            <KeyRound className="h-4 w-4 text-txt-strong" />
           </div>
           <div className="space-y-0.5">
             <p className="text-sm font-medium text-txt-strong">

--- a/packages/ui/src/cloud/account-security/components/incident-report-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/incident-report-panel.tsx
@@ -77,7 +77,7 @@ export function IncidentReportPanel() {
             {t("cloud.incidentReport.emailPre", { defaultValue: "Email" })}{" "}
             <a
               href={`mailto:${SECURITY_EMAIL}`}
-              className="text-[var(--brand-orange)] underline"
+              className="text-txt-strong underline"
             >
               {SECURITY_EMAIL}
             </a>{" "}

--- a/packages/ui/src/cloud/account-security/components/mfa-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/mfa-panel.tsx
@@ -66,7 +66,7 @@ export function MfaPanel() {
       <CornerBrackets size="sm" className="opacity-50" />
       <div className="relative z-10 space-y-3">
         <div className="flex items-center gap-2">
-          <Lock className="h-5 w-5 text-[var(--brand-orange)]" />
+          <Lock className="h-5 w-5 text-muted" />
           <h3 className="text-lg font-bold text-txt-strong">
             {t("cloud.mfaPanel.title", {
               defaultValue: "Two-factor authentication",

--- a/packages/ui/src/cloud/account-security/components/plugin-permissions-page-client.tsx
+++ b/packages/ui/src/cloud/account-security/components/plugin-permissions-page-client.tsx
@@ -105,7 +105,7 @@ export function PluginPermissionsPageClient() {
         <CornerBrackets size="sm" className="opacity-50" />
         <div className="relative z-10 space-y-4">
           <div className="flex items-center gap-2">
-            <Puzzle className="h-5 w-5 text-[var(--brand-orange)]" />
+            <Puzzle className="h-5 w-5 text-muted" />
             <h3 className="text-lg font-bold text-txt-strong">Active grants</h3>
           </div>
           {state.kind === "loading" ? (

--- a/packages/ui/src/cloud/account-security/components/privacy-panel.tsx
+++ b/packages/ui/src/cloud/account-security/components/privacy-panel.tsx
@@ -95,8 +95,8 @@ export function PrivacyPanel() {
         {/* Trajectory logging toggle */}
         <div className="flex items-start justify-between gap-3 rounded-sm border border-border bg-surface p-4">
           <div className="flex items-start gap-3">
-            <div className="rounded-sm border border-[var(--brand-orange)]/40 bg-[var(--brand-orange)]/15 p-2">
-              <ScrollText className="h-4 w-4 text-[var(--brand-orange)]" />
+            <div className="rounded-sm border border-border bg-muted p-2">
+              <ScrollText className="h-4 w-4 text-muted" />
             </div>
             <div className="space-y-1">
               <p className="text-sm font-medium text-txt-strong">

--- a/packages/ui/src/cloud/analytics/_components/analytics-page-client.tsx
+++ b/packages/ui/src/cloud/analytics/_components/analytics-page-client.tsx
@@ -136,7 +136,6 @@ export function AnalyticsPageClient({
             }
           : undefined,
       icon: Activity,
-      accent: "amber" as const,
     },
     {
       label: t("cloud.analytics.metric.totalCost", {
@@ -156,7 +155,6 @@ export function AnalyticsPageClient({
             }
           : undefined,
       icon: Coins,
-      accent: "amber" as const,
     },
     {
       label: t("cloud.analytics.metric.successRate", {
@@ -197,7 +195,6 @@ export function AnalyticsPageClient({
             }
           : undefined,
       icon: BarChart3,
-      accent: "amber" as const,
     },
   ];
 
@@ -207,7 +204,7 @@ export function AnalyticsPageClient({
         <div className="min-w-0 space-y-5 lg:max-w-3xl">
           <div className="flex flex-wrap items-center gap-2 gap-y-3 text-xs font-medium text-white/60">
             <span className="flex min-w-0 max-w-full items-center gap-1 rounded-sm border border-white/20 bg-white/10 px-3 py-1">
-              <CalendarRange className="h-3.5 w-3.5 shrink-0 text-[var(--accent)]" />
+              <CalendarRange className="h-3.5 w-3.5 shrink-0 text-muted" />
               <span className="min-w-0 break-words">{rangeLabel}</span>
             </span>
             <span className="max-w-full break-words rounded-sm border border-white/20 bg-white/10 px-3 py-1">

--- a/packages/ui/src/cloud/analytics/_components/filters.tsx
+++ b/packages/ui/src/cloud/analytics/_components/filters.tsx
@@ -134,7 +134,7 @@ export function AnalyticsFilters() {
 
         {activeRange === "custom" ? (
           <span className="flex min-w-0 max-w-full items-center gap-1 rounded-sm border border-white/20 bg-white/10 px-3 py-1 text-xs">
-            <Sparkles className="h-3.5 w-3.5 shrink-0 text-[var(--accent)]" />
+            <Sparkles className="h-3.5 w-3.5 shrink-0 text-muted" />
             <span className="min-w-0 break-words">
               {t("cloud.analytics.filters.customRange", {
                 defaultValue: "Custom range detected",

--- a/packages/ui/src/cloud/analytics/_components/projections-chart.tsx
+++ b/packages/ui/src/cloud/analytics/_components/projections-chart.tsx
@@ -47,13 +47,13 @@ export function ProjectionsChart({ data }: ProjectionsChartProps) {
       label: t("cloud.projectionsChart.historical", {
         defaultValue: "Historical",
       }),
-      color: "var(--accent)",
+      color: "var(--txt)",
     },
     projected: {
       label: t("cloud.projectionsChart.projected", {
         defaultValue: "Projected",
       }),
-      color: "#F59E0B",
+      color: "var(--muted)",
     },
   } as const;
 

--- a/packages/ui/src/cloud/analytics/_components/usage-chart.tsx
+++ b/packages/ui/src/cloud/analytics/_components/usage-chart.tsx
@@ -40,7 +40,7 @@ export function UsageChart({ data, granularity }: UsageChartProps) {
       label: t("cloud.analytics.usageChart.requests", {
         defaultValue: "Requests",
       }),
-      color: "var(--accent)",
+      color: "var(--txt)",
     },
     cost: {
       label: t("cloud.analytics.usageChart.costUsd", {

--- a/packages/ui/src/cloud/api-explorer/ApiExplorerPage.tsx
+++ b/packages/ui/src/cloud/api-explorer/ApiExplorerPage.tsx
@@ -96,7 +96,7 @@ function getMethodColor(method: string) {
     case "POST":
       return "bg-white/10 text-white/80";
     case "PUT":
-      return "bg-orange-500/20 text-orange-400";
+      return "bg-muted text-txt";
     case "DELETE":
       return "bg-red-500/20 text-red-400";
     case "PATCH":
@@ -118,16 +118,15 @@ function formatPrice(pricing: ApiEndpoint["pricing"]) {
 function getPricingIcon(pricing: ApiEndpoint["pricing"]) {
   if (!pricing) return null;
   if (pricing.isFree) return <Sparkles className="h-4 w-4 text-green-400" />;
-  if (pricing.isVariable)
-    return <TrendingUp className="h-4 w-4 text-orange-400" />;
-  return <Coins className="h-4 w-4 text-[var(--accent)]" />;
+  if (pricing.isVariable) return <TrendingUp className="h-4 w-4 text-muted" />;
+  return <Coins className="h-4 w-4 text-muted" />;
 }
 
 function getPricingStyle(pricing: ApiEndpoint["pricing"]) {
   if (!pricing) return "";
   if (pricing.isFree) return "bg-green-500/20 text-green-400";
-  if (pricing.isVariable) return "bg-orange-500/20 text-orange-400";
-  return "bg-[var(--accent)]/20 text-[var(--accent)]";
+  if (pricing.isVariable) return "bg-muted text-txt";
+  return "bg-muted text-txt";
 }
 
 function resolveApiUrl() {
@@ -370,7 +369,7 @@ export function ApiExplorerSurface() {
                     className={cn(
                       "flex h-7 shrink-0 items-center gap-1 rounded-sm border px-2 text-[11px] font-medium transition-colors sm:h-9 sm:gap-2 sm:rounded-sm sm:px-3 sm:text-xs",
                       selectedCategory === category
-                        ? "bg-[var(--accent)]/10 text-[var(--accent)] border-[var(--accent)]/30"
+                        ? "bg-muted text-txt-strong border-border"
                         : "bg-neutral-900/50 text-neutral-400 border-white/5 hover:text-white hover:border-white/10",
                     )}
                   >
@@ -379,7 +378,7 @@ export function ApiExplorerSurface() {
                       className={cn(
                         "text-[11px] sm:text-xs font-semibold",
                         selectedCategory === category
-                          ? "text-[var(--accent)]"
+                          ? "text-txt-strong"
                           : "text-neutral-500",
                       )}
                     >
@@ -474,7 +473,7 @@ export function ApiExplorerSurface() {
                 variant="ghost"
                 type="button"
                 onClick={handleCopyJson}
-                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-[#FF5800] text-black rounded-sm hover:bg-[#e54f00] transition-colors"
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-txt text-bg rounded-sm hover:bg-txt/90 transition-colors"
               >
                 {copied === "json" ? (
                   <Check className="h-3.5 w-3.5" />

--- a/packages/ui/src/cloud/api-explorer/api-tester.tsx
+++ b/packages/ui/src/cloud/api-explorer/api-tester.tsx
@@ -580,26 +580,26 @@ export function ApiTester({
       {endpoint.pricing && (
         <Card className="border-border/60 bg-background/60 rounded-sm overflow-hidden">
           <div
-            className={`h-1 w-full ${endpoint.pricing.isFree ? "bg-green-500" : endpoint.pricing.isVariable ? "bg-orange-500" : "bg-[#FF5800]"}`}
+            className={`h-1 w-full ${endpoint.pricing.isFree ? "bg-green-500" : endpoint.pricing.isVariable ? "bg-muted" : "bg-muted"}`}
           />
           <CardContent className="pt-4">
             <div className="flex items-start justify-between gap-4">
               <div className="flex items-center gap-3">
                 <div
-                  className={`p-2.5 rounded-sm ${endpoint.pricing.isFree ? "bg-green-500/10" : endpoint.pricing.isVariable ? "bg-orange-500/10" : "bg-[#FF5800]/10"}`}
+                  className={`p-2.5 rounded-sm ${endpoint.pricing.isFree ? "bg-green-500/10" : endpoint.pricing.isVariable ? "bg-surface" : "bg-surface"}`}
                 >
                   {endpoint.pricing.isFree ? (
                     <Sparkles className={`h-5 w-5 text-green-400`} />
                   ) : endpoint.pricing.isVariable ? (
-                    <TrendingUp className={`h-5 w-5 text-orange-400`} />
+                    <TrendingUp className={`h-5 w-5 text-muted`} />
                   ) : (
-                    <Coins className={`h-5 w-5 text-[#FF5800]`} />
+                    <Coins className={`h-5 w-5 text-muted`} />
                   )}
                 </div>
                 <div>
                   <div className="flex items-center gap-2">
                     <span
-                      className={`text-xl font-bold ${endpoint.pricing.isFree ? "text-green-400" : endpoint.pricing.isVariable ? "text-orange-400" : "text-[#FF5800]"}`}
+                      className={`text-xl font-bold ${endpoint.pricing.isFree ? "text-green-400" : endpoint.pricing.isVariable ? "text-txt-strong" : "text-txt-strong"}`}
                     >
                       {formatEndpointPrice(endpoint.pricing)}
                     </span>
@@ -617,9 +617,9 @@ export function ApiTester({
                 </div>
               </div>
               {endpoint.pricing.isVariable && !endpoint.pricing.isFree && (
-                <div className="flex items-center gap-1.5 px-2.5 py-1 bg-orange-500/10 border border-orange-500/20 rounded-sm">
-                  <Info className="h-3.5 w-3.5 text-orange-400" />
-                  <span className="text-xs text-orange-400 font-medium">
+                <div className="flex items-center gap-1.5 px-2.5 py-1 bg-surface border border-border rounded-sm">
+                  <Info className="h-3.5 w-3.5 text-muted" />
+                  <span className="text-xs text-muted font-medium">
                     Variable pricing
                   </span>
                 </div>
@@ -633,7 +633,7 @@ export function ApiTester({
         <Button
           onClick={executeTest}
           disabled={isLoading || (endpoint.requiresAuth && isAuthLoading)}
-          className="gap-2 bg-[#471E08] text-[#FF5800] hover:bg-[#5A2610] active:bg-[#6B2E18] border-0"
+          className="gap-2 bg-txt text-bg hover:bg-txt/90 active:bg-txt/80 border-0"
         >
           {isLoading ? (
             <LoaderIcon className="h-4 w-4 animate-spin" />

--- a/packages/ui/src/cloud/api-explorer/auth-manager.tsx
+++ b/packages/ui/src/cloud/api-explorer/auth-manager.tsx
@@ -150,8 +150,8 @@ export function AuthManager({
       </div>
 
       {/* Billed-calls notice */}
-      <div className="flex items-center gap-2 px-3 py-2 rounded-sm bg-orange-500/10 border border-orange-500/20">
-        <span className="text-xs text-orange-400">
+      <div className="flex items-center gap-2 px-3 py-2 rounded-sm bg-muted border border-border">
+        <span className="text-xs text-muted">
           API calls are billed to your account
         </span>
       </div>

--- a/packages/ui/src/cloud/applications/ApplicationsPage.tsx
+++ b/packages/ui/src/cloud/applications/ApplicationsPage.tsx
@@ -41,7 +41,7 @@ export default function ApplicationsPage() {
               defaultValue: "Total Apps",
             })}
             value={apps.length}
-            icon={<Grid3x3 className="h-5 w-5 text-[var(--accent)]" />}
+            icon={<Grid3x3 className="h-5 w-5 text-muted" />}
           />
           <DashboardStatCard
             label={t("cloud.apps.stat.activeApps", {

--- a/packages/ui/src/cloud/applications/components/BuyDomainCard.tsx
+++ b/packages/ui/src/cloud/applications/components/BuyDomainCard.tsx
@@ -172,7 +172,7 @@ export function BuyDomainCard({ appId, onPurchased }: BuyDomainCardProps) {
     <div className="bg-card rounded-sm p-4 space-y-4">
       <div>
         <h3 className="text-sm font-medium text-txt flex items-center gap-2">
-          <ShoppingCart className="h-4 w-4 text-[var(--accent)]" />
+          <ShoppingCart className="h-4 w-4 text-muted" />
           {t("cloud.appDomains.buyTitle", { defaultValue: "Buy a Domain" })}
         </h3>
         <p className="text-xs text-neutral-500 mt-1">
@@ -208,7 +208,7 @@ export function BuyDomainCard({ appId, onPurchased }: BuyDomainCardProps) {
           type="submit"
           size="sm"
           disabled={!isValid || checking}
-          className="bg-[#FF5800] hover:bg-[#e54f00] text-black rounded-sm shrink-0"
+          className="bg-txt hover:bg-txt/90 text-bg rounded-sm shrink-0"
         >
           {checking ? (
             <Loader2 className="h-4 w-4 animate-spin" />
@@ -237,7 +237,7 @@ export function BuyDomainCard({ appId, onPurchased }: BuyDomainCardProps) {
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 p-3 rounded-sm bg-surface">
           <div className="min-w-0">
             <div className="flex items-center gap-2">
-              <CheckCircle2 className="h-4 w-4 text-[var(--accent)] shrink-0" />
+              <CheckCircle2 className="h-4 w-4 text-txt shrink-0" />
               <span className="text-sm font-medium text-txt truncate">
                 {result.domain}
               </span>
@@ -264,7 +264,7 @@ export function BuyDomainCard({ appId, onPurchased }: BuyDomainCardProps) {
               <Button
                 size="sm"
                 disabled={buying}
-                className="bg-[#FF5800] hover:bg-[#e54f00] text-black rounded-sm shrink-0"
+                className="bg-txt hover:bg-txt/90 text-bg rounded-sm shrink-0"
               >
                 {buying ? (
                   <Loader2 className="h-4 w-4 animate-spin" />
@@ -304,7 +304,7 @@ export function BuyDomainCard({ appId, onPurchased }: BuyDomainCardProps) {
                 </AlertDialogCancel>
                 <AlertDialogAction
                   onClick={() => void handleBuy()}
-                  className="bg-[#FF5800] hover:bg-[#e54f00] text-black"
+                  className="bg-txt hover:bg-txt/90 text-bg"
                 >
                   {t("cloud.appDomains.buyConfirmAction", {
                     defaultValue: "Buy domain",

--- a/packages/ui/src/cloud/applications/components/app-analytics.tsx
+++ b/packages/ui/src/cloud/applications/components/app-analytics.tsx
@@ -5,7 +5,6 @@
  */
 
 import { toRatePercent } from "@elizaos/cloud-shared/lib/services/analytics-derived";
-import { BRAND_COLORS } from "@elizaos/shared/brand";
 import { formatDistanceToNow } from "date-fns";
 import {
   Activity,
@@ -166,9 +165,9 @@ interface RequestLogsResponse {
 }
 
 const SOURCE_COLORS: Record<string, string> = {
-  api_key: BRAND_COLORS.orange,
+  api_key: "var(--txt)",
   sandbox_preview: "#e11d48",
-  embed: "var(--accent)",
+  embed: "var(--muted)",
 };
 
 const SOURCE_LABELS: Record<string, string> = {
@@ -179,10 +178,10 @@ const SOURCE_LABELS: Record<string, string> = {
 
 const TYPE_COLORS: Record<string, string> = {
   pageview: "#10b981",
-  chat: BRAND_COLORS.orange,
+  chat: "var(--txt)",
   image: "#e11d48",
-  video: "var(--accent)",
-  voice: "#f59e0b",
+  video: "var(--muted)",
+  voice: "#9ca3af",
   agent: "#ec4899",
 };
 
@@ -343,7 +342,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <Loader2 className="h-8 w-8 animate-spin text-[var(--brand-orange)]" />
+        <Loader2 className="h-8 w-8 animate-spin text-muted" />
       </div>
     );
   }
@@ -455,7 +454,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
 
           <div className="bg-card rounded-sm p-4">
             <h3 className="text-sm font-medium text-txt mb-4 flex items-center gap-2">
-              <BarChart3 className="h-4 w-4 text-[var(--brand-orange)]" />
+              <BarChart3 className="h-4 w-4 text-muted" />
               Requests Over Time
             </h3>
             {chartData.length > 0 ? (
@@ -486,9 +485,9 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                   <Line
                     type="monotone"
                     dataKey="requests"
-                    stroke={BRAND_COLORS.orange}
+                    stroke={"var(--txt)"}
                     strokeWidth={2}
-                    dot={{ fill: BRAND_COLORS.orange, r: 3 }}
+                    dot={{ fill: "var(--txt)", r: 3 }}
                   />
                 </LineChart>
               </ResponsiveContainer>
@@ -527,11 +526,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                     }}
                   />
                   <Bar dataKey="newUsers" fill="#e11d48" name="New Users" />
-                  <Bar
-                    dataKey="users"
-                    fill="var(--accent)"
-                    name="Total Users"
-                  />
+                  <Bar dataKey="users" fill="var(--muted)" name="Total Users" />
                 </BarChart>
               </ResponsiveContainer>
             ) : (
@@ -548,7 +543,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
         <div className="space-y-4">
           {isLoadingStats ? (
             <div className="flex items-center justify-center py-12">
-              <Loader2 className="h-8 w-8 animate-spin text-[var(--brand-orange)]" />
+              <Loader2 className="h-8 w-8 animate-spin text-muted" />
             </div>
           ) : requestStats ? (
             <>
@@ -566,7 +561,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                     requestStats.totalRequests -
                     (requestStats.byType?.pageview || 0)
                   ).toLocaleString("en-US")}
-                  color="text-[var(--brand-orange)]"
+                  color="text-txt"
                 />
                 <MiniStatCard
                   label="Unique Visitors"
@@ -663,7 +658,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                                   style={{
                                     width: `${toRatePercent(count, requestStats.totalRequests)}%`,
                                     backgroundColor:
-                                      TYPE_COLORS[type] || BRAND_COLORS.orange,
+                                      TYPE_COLORS[type] || "var(--txt)",
                                   }}
                                 />
                               </div>
@@ -696,7 +691,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
         <div className="space-y-4">
           {isLoadingStats ? (
             <div className="flex items-center justify-center py-12">
-              <Loader2 className="h-8 w-8 animate-spin text-[var(--brand-orange)]" />
+              <Loader2 className="h-8 w-8 animate-spin text-muted" />
             </div>
           ) : (
             <>
@@ -705,9 +700,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                   <DashboardStatCard
                     label="Unique IPs"
                     value={requestStats.uniqueIps.toLocaleString("en-US")}
-                    icon={
-                      <Globe className="h-5 w-5 text-[var(--brand-orange)]" />
-                    }
+                    icon={<Globe className="h-5 w-5 text-muted" />}
                   />
                   <DashboardStatCard
                     label="Unique Users"
@@ -804,7 +797,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
         <div className="space-y-4">
           {isLoadingStats ? (
             <div className="flex items-center justify-center py-12">
-              <Loader2 className="h-8 w-8 animate-spin text-[var(--brand-orange)]" />
+              <Loader2 className="h-8 w-8 animate-spin text-muted" />
             </div>
           ) : sessionAnalytics ? (
             <>
@@ -814,7 +807,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                   value={sessionAnalytics.summary.totalSessions.toLocaleString(
                     "en-US",
                   )}
-                  color="text-[var(--brand-orange)]"
+                  color="text-txt"
                 />
                 <MiniStatCard
                   label="Visitors"
@@ -845,7 +838,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
               <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)]">
                 <div className="bg-card rounded-sm p-4">
                   <h3 className="text-sm font-medium text-txt mb-4 flex items-center gap-2">
-                    <GitBranch className="h-4 w-4 text-[var(--brand-orange)]" />
+                    <GitBranch className="h-4 w-4 text-muted" />
                     Funnel
                   </h3>
                   {sessionAnalytics.funnel.steps.length > 0 ? (
@@ -862,7 +855,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
                           </div>
                           <div className="h-2 bg-surface rounded-full overflow-hidden">
                             <div
-                              className="h-full bg-[var(--brand-orange)]"
+                              className="h-full bg-txt"
                               style={{
                                 width: `${Math.min(100, step.conversionFromStartPercent)}%`,
                               }}
@@ -976,7 +969,7 @@ export function AppAnalytics({ appId }: AppAnalyticsProps) {
 
           {isLoadingLogs ? (
             <div className="flex items-center justify-center py-12">
-              <Loader2 className="h-8 w-8 animate-spin text-[var(--brand-orange)]" />
+              <Loader2 className="h-8 w-8 animate-spin text-muted" />
             </div>
           ) : requestLogs.length > 0 ? (
             <>

--- a/packages/ui/src/cloud/applications/components/app-earnings-dashboard.tsx
+++ b/packages/ui/src/cloud/applications/components/app-earnings-dashboard.tsx
@@ -171,7 +171,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <Loader2 className="h-8 w-8 animate-spin text-[var(--accent)]" />
+        <Loader2 className="h-8 w-8 animate-spin text-muted" />
       </div>
     );
   }
@@ -203,9 +203,9 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
   return (
     <div className="space-y-4">
       {isTestData && (
-        <div className="flex items-center gap-2 p-3 bg-orange-500/10 border border-orange-500/20 rounded-sm">
-          <FlaskConical className="h-4 w-4 text-orange-400" />
-          <p className="text-sm text-orange-400">
+        <div className="flex items-center gap-2 p-3 bg-surface border border-border rounded-sm">
+          <FlaskConical className="h-4 w-4 text-muted" />
+          <p className="text-sm text-muted">
             Test Data Mode - Showing sample earnings data
           </p>
         </div>
@@ -248,7 +248,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
                 onClick={() => {
                   navigate(`/dashboard/apps/${appId}?tab=monetization`);
                 }}
-                className="bg-[#FF5800] hover:bg-[#e54f00] text-black"
+                className="bg-txt hover:bg-txt/90 text-bg"
               >
                 Enable Monetization
               </Button>
@@ -277,7 +277,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
                   </p>
                 )}
               </div>
-              <TrendingUp className="h-5 w-5 text-[var(--accent)]" />
+              <TrendingUp className="h-5 w-5 text-muted" />
             </div>
           </div>
 
@@ -368,7 +368,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
                   <Zap className="h-3 w-3" />$
                   {data.inferenceEarnings.toFixed(2)}
                 </span>
-                <span className="text-orange-400 flex items-center gap-1">
+                <span className="text-muted flex items-center gap-1">
                   <Coins className="h-3 w-3" />$
                   {data.purchaseEarnings.toFixed(2)}
                 </span>
@@ -426,7 +426,7 @@ export function AppEarningsDashboard({ appId }: AppEarningsDashboardProps) {
               />
               <Bar
                 dataKey="purchaseEarnings"
-                fill="#f59e0b"
+                fill="var(--muted)"
                 name="Purchase Share"
                 stackId="a"
                 radius={[4, 4, 0, 0]}
@@ -532,7 +532,7 @@ function TransactionBadge({ type }: { type: string }) {
       );
     case "purchase_share":
       return (
-        <Badge className="bg-orange-500/20 text-orange-400 border-orange-500/30 text-[10px]">
+        <Badge className="bg-surface text-muted border-border text-[10px]">
           Purchase
         </Badge>
       );

--- a/packages/ui/src/cloud/applications/components/app-monetization-settings.tsx
+++ b/packages/ui/src/cloud/applications/components/app-monetization-settings.tsx
@@ -284,7 +284,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <Loader2 className="h-8 w-8 animate-spin text-[var(--brand-orange)]" />
+        <Loader2 className="h-8 w-8 animate-spin text-muted" />
       </div>
     );
   }
@@ -335,7 +335,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
                 type="button"
                 onClick={submitForReview}
                 disabled={isSubmittingReview}
-                className="shrink-0 bg-[var(--brand-orange)] text-txt hover:bg-[#e54f00]"
+                className="shrink-0 bg-txt text-bg hover:bg-txt/90"
               >
                 {isSubmittingReview ? (
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -530,7 +530,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
                     </TooltipContent>
                   </Tooltip>
                 </div>
-                <span className="text-lg font-mono font-semibold text-orange-400">
+                <span className="text-lg font-mono font-semibold text-txt-strong">
                   {settings.purchaseSharePercentage}%
                 </span>
               </div>
@@ -553,7 +553,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
                     className={cn(
                       "px-2.5 py-1 text-xs rounded-sm transition-colors",
                       settings.purchaseSharePercentage === preset
-                        ? "bg-orange-500/20 text-txt border border-orange-500/30"
+                        ? "bg-muted text-txt border border-border"
                         : "bg-surface text-neutral-400 hover:bg-bg-hover border border-transparent",
                     )}
                     onClick={() =>
@@ -571,7 +571,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
               <Button
                 onClick={handleSave}
                 disabled={!hasChanges || isSaving}
-                className="w-full bg-[var(--brand-orange)] hover:bg-[#e54f00] text-white disabled:bg-surface disabled:text-muted"
+                className="w-full bg-txt text-bg hover:bg-txt/90 disabled:bg-surface disabled:text-muted"
               >
                 {isSaving ? (
                   <Loader2 className="h-4 w-4 animate-spin mr-2" />
@@ -637,7 +637,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
                   })}
                 </li>
               </ul>
-              <p className="pt-2 text-[var(--brand-orange)]">
+              <p className="pt-2 text-txt">
                 {t("cloud.monetization.enableDialogNote", {
                   defaultValue:
                     "You can adjust markup and purchase share after enabling.",
@@ -653,7 +653,7 @@ export function AppMonetizationSettings({ app }: AppMonetizationSettingsProps) {
                   toggleMonetization(true);
                   setShowEnableDialog(false);
                 }}
-                className="bg-[var(--brand-orange)] hover:bg-[#e54f00] text-txt px-6"
+                className="bg-txt text-bg hover:bg-txt/90 px-6"
               >
                 {t("cloud.monetization.startEarning", {
                   defaultValue: "Start Earning",
@@ -714,10 +714,10 @@ function getReviewStatusLabel(
 function SelfHostCTA() {
   const t = useCloudT();
   return (
-    <div className="border border-[var(--brand-orange)]/30 bg-[var(--brand-orange)]/10 p-5">
+    <div className="border border-border bg-card p-5">
       <div className="flex items-start gap-4">
-        <div className="hidden sm:flex items-center justify-center w-10 h-10 rounded-sm border border-[var(--brand-orange)]/40 bg-[var(--brand-orange)]/10 shrink-0">
-          <Server className="h-5 w-5 text-[var(--brand-orange)]" />
+        <div className="hidden sm:flex items-center justify-center w-10 h-10 rounded-sm border border-border bg-surface shrink-0">
+          <Server className="h-5 w-5 text-muted" />
         </div>
         <div className="flex-1 min-w-0">
           <h3 className="text-base font-mono text-txt mb-1">
@@ -741,7 +741,7 @@ function SelfHostCTA() {
                   e.preventDefault();
                 }
               }}
-              className="inline-flex items-center gap-2 px-4 py-2 bg-[var(--brand-orange)] hover:bg-[#e54f00] text-txt text-sm font-mono transition-colors"
+              className="inline-flex items-center gap-2 px-4 py-2 bg-txt text-bg hover:bg-txt/90 text-sm font-mono transition-colors"
             >
               <Server className="h-4 w-4" />
               {t("cloud.monetization.deployAgent", {

--- a/packages/ui/src/cloud/applications/components/app-overview.tsx
+++ b/packages/ui/src/cloud/applications/components/app-overview.tsx
@@ -325,9 +325,9 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
     <div className="space-y-4">
       {/* New API Key Alert */}
       {showKey && displayApiKey && (
-        <div className="p-4 rounded-sm bg-[var(--accent)]/10 border border-[var(--accent)]/20">
+        <div className="p-4 rounded-sm bg-card border border-border">
           <div className="flex items-start gap-3">
-            <Key className="h-5 w-5 text-[var(--accent)] mt-0.5 shrink-0" />
+            <Key className="h-5 w-5 text-muted mt-0.5 shrink-0" />
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium text-txt mb-2">
                 {t("cloud.apps.overview.apiKeyOnce", {
@@ -413,7 +413,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
       <div className="bg-card rounded-sm p-4 space-y-3">
         <div className="flex items-center justify-between">
           <h3 className="text-sm font-medium text-txt flex items-center gap-2">
-            <Rocket className="h-4 w-4 text-[var(--accent)]" />
+            <Rocket className="h-4 w-4 text-muted" />
             {t("cloud.apps.overview.deployment", {
               defaultValue: "Deployment",
             })}
@@ -527,7 +527,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
         <div className="bg-card rounded-sm p-4 space-y-4">
           <div className="flex items-center justify-between">
             <h3 className="text-sm font-medium text-txt flex items-center gap-2">
-              <Key className="h-4 w-4 text-[var(--accent)]" />
+              <Key className="h-4 w-4 text-muted" />
               {t("cloud.apps.overview.apiKey", { defaultValue: "API Key" })}
             </h3>
             <AlertDialog>
@@ -570,7 +570,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
                   </AlertDialogCancel>
                   <AlertDialogAction
                     onClick={handleRegenerateApiKey}
-                    className="bg-[var(--accent)] hover:bg-[#e54f00]"
+                    className="bg-txt text-bg hover:bg-txt/90"
                   >
                     {t("cloud.apps.overview.regenerate", {
                       defaultValue: "Regenerate",
@@ -627,7 +627,7 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
         {/* Basic Info Card */}
         <div className="bg-card rounded-sm p-4 space-y-4">
           <h3 className="text-sm font-medium text-txt flex items-center gap-2">
-            <Globe className="h-4 w-4 text-[var(--accent)]" />
+            <Globe className="h-4 w-4 text-muted" />
             {t("cloud.apps.overview.appInformation", {
               defaultValue: "App Information",
             })}
@@ -688,8 +688,8 @@ export function AppOverview({ app, showApiKey }: AppOverviewProps) {
         <div className="bg-card rounded-sm p-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
-              <div className="p-2 rounded-sm bg-orange-500/10">
-                <Coins className="h-5 w-5 text-orange-400" />
+              <div className="p-2 rounded-sm bg-surface">
+                <Coins className="h-5 w-5 text-muted" />
               </div>
               <div>
                 <h3 className="text-sm font-medium text-txt">Monetization</h3>

--- a/packages/ui/src/cloud/applications/components/app-promote.tsx
+++ b/packages/ui/src/cloud/applications/components/app-promote.tsx
@@ -106,7 +106,7 @@ export function AppPromote({ app }: AppPromoteProps) {
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
         <div>
           <h3 className="text-sm font-medium text-txt flex items-center gap-2">
-            <Megaphone className="h-4 w-4 text-[var(--accent)]" />
+            <Megaphone className="h-4 w-4 text-muted" />
             {t("cloud.appPromote.title", {
               name: app.name,
               defaultValue: "Promote {{name}}",
@@ -146,7 +146,7 @@ export function AppPromote({ app }: AppPromoteProps) {
           <Button
             onClick={() => setShowPromoteDialog(true)}
             size="sm"
-            className="bg-[#FF5800] hover:bg-[#e54f00] text-black rounded-sm"
+            className="bg-txt hover:bg-txt/90 text-bg rounded-sm"
           >
             <Megaphone className="h-4 w-4 mr-1.5" />
             {t("cloud.appPromote.launch", { defaultValue: "Launch Promotion" })}
@@ -170,8 +170,8 @@ export function AppPromote({ app }: AppPromoteProps) {
           <div className="space-y-2">
             {suggestions.tips.map((tip, index) => (
               <div key={tip} className="flex items-start gap-2">
-                <div className="w-5 h-5 rounded-full bg-[var(--accent)]/10 flex items-center justify-center shrink-0 mt-0.5">
-                  <span className="text-[var(--accent)] text-[10px] font-semibold">
+                <div className="w-5 h-5 rounded-full bg-muted flex items-center justify-center shrink-0 mt-0.5">
+                  <span className="text-txt text-[10px] font-semibold">
                     {index + 1}
                   </span>
                 </div>

--- a/packages/ui/src/cloud/applications/components/app-settings.tsx
+++ b/packages/ui/src/cloud/applications/components/app-settings.tsx
@@ -194,7 +194,7 @@ export function AppSettings({ app }: AppSettingsProps) {
       {/* Basic Settings */}
       <div className="bg-card rounded-sm p-4 space-y-4">
         <h3 className="text-sm font-medium text-txt flex items-center gap-2">
-          <Settings className="h-4 w-4 text-[var(--brand-orange)]" />
+          <Settings className="h-4 w-4 text-muted" />
           {t("cloud.appSettings.basicSettings", {
             defaultValue: "Basic Settings",
           })}
@@ -384,7 +384,7 @@ export function AppSettings({ app }: AppSettingsProps) {
         <Button
           onClick={handleSave}
           disabled={isLoading}
-          className="bg-[var(--brand-orange)] hover:bg-[#e54f00] text-txt"
+          className="bg-txt text-bg hover:bg-txt/90"
         >
           {isLoading ? (
             <>

--- a/packages/ui/src/cloud/applications/components/withdraw-dialog.tsx
+++ b/packages/ui/src/cloud/applications/components/withdraw-dialog.tsx
@@ -109,7 +109,7 @@ export function WithdrawDialog({
           <>
             <DialogHeader>
               <DialogTitle className="flex items-center gap-2 text-txt">
-                <Wallet className="h-5 w-5 text-[var(--brand-orange)]" />
+                <Wallet className="h-5 w-5 text-muted" />
                 Withdraw Earnings
               </DialogTitle>
               <DialogDescription className="text-neutral-400">
@@ -189,7 +189,7 @@ export function WithdrawDialog({
               <Button
                 onClick={handleWithdraw}
                 disabled={!isValidAmount}
-                className="bg-[var(--brand-orange)] hover:bg-[#e54f00] text-txt disabled:opacity-50"
+                className="bg-txt hover:bg-txt/90 text-bg disabled:opacity-50"
               >
                 <ArrowRight className="h-4 w-4 mr-2" />
                 Withdraw ${parsedAmount.toFixed(2)}
@@ -201,7 +201,7 @@ export function WithdrawDialog({
         {state === "processing" && (
           <div className="py-12 text-center">
             <div className="mx-auto w-16 h-16 mb-4 flex items-center justify-center">
-              <Loader2 className="h-8 w-8 text-[var(--brand-orange)] animate-spin" />
+              <Loader2 className="h-8 w-8 text-muted animate-spin" />
             </div>
             <h3 className="text-lg font-medium text-txt-strong mb-2">
               Processing Withdrawal
@@ -243,7 +243,7 @@ export function WithdrawDialog({
             <DialogFooter className="mt-6">
               <Button
                 onClick={handleClose}
-                className="w-full bg-[var(--brand-orange)] hover:bg-[#e54f00] text-txt"
+                className="w-full bg-txt hover:bg-txt/90 text-bg"
               >
                 Done
               </Button>

--- a/packages/ui/src/cloud/billing/components/auto-top-up-card.tsx
+++ b/packages/ui/src/cloud/billing/components/auto-top-up-card.tsx
@@ -151,7 +151,7 @@ export function AutoTopUpCard() {
       <BrandCard className="relative">
         <CornerBrackets size="sm" className="opacity-50" />
         <div className="flex items-center justify-center py-12">
-          <Loader2 className="h-5 w-5 animate-spin text-[var(--accent)]" />
+          <Loader2 className="h-5 w-5 animate-spin text-muted" />
         </div>
       </BrandCard>
     );
@@ -166,7 +166,7 @@ export function AutoTopUpCard() {
       <div className="relative z-10 space-y-6">
         <div className="flex flex-col gap-2">
           <div className="flex items-center gap-2">
-            <div className="w-2 h-2 rounded-full bg-[var(--accent)]" />
+            <div className="w-2 h-2 rounded-full bg-muted" />
             <h3 className="text-base font-mono text-txt uppercase">
               {t("cloud.autoTopUp.title", {
                 defaultValue: "Auto Top-Up (Card)",
@@ -204,7 +204,7 @@ export function AutoTopUpCard() {
             checked={enabled}
             onCheckedChange={setEnabled}
             disabled={saving || !!noPaymentMethod}
-            className="data-[state=checked]:bg-[var(--accent)] flex-shrink-0"
+            className="data-[state=checked]:bg-txt flex-shrink-0"
           />
         </div>
 
@@ -259,7 +259,7 @@ export function AutoTopUpCard() {
             type="button"
             onClick={handleSave}
             disabled={saving || !!validationError || !!noPaymentMethod}
-            className="bg-[#FF5800] hover:bg-[#e54f00] text-black font-mono"
+            className="bg-txt hover:bg-txt/90 text-bg font-mono"
           >
             {saving ? (
               <>

--- a/packages/ui/src/cloud/billing/components/billing-tab.selected-state.test.ts
+++ b/packages/ui/src/cloud/billing/components/billing-tab.selected-state.test.ts
@@ -7,9 +7,11 @@
  * everything in `.theme-cloud`, where `--accent` resolves to `--brand-white`.
  * The result was `bg:white + text-white` — a blank white box (invisible label).
  *
- * The fix pairs the accent fill with `text-accent-foreground` (black under
- * `.theme-cloud`) so the selected label stays readable in every theme scope,
- * and drops the raw white-opacity ladder for theme-aware border/muted tokens.
+ * The selected fill is the neutral invert pair `bg-txt text-bg` (fill = theme
+ * text color, label = theme background color) so the selected label stays
+ * readable in every theme scope without depending on `--accent` — which is
+ * brand-orange in the app shell and white under `.theme-cloud`. The unselected
+ * state keeps theme-aware border/muted tokens (no raw white-opacity ladder).
  *
  * This is a source-contract test (the full BillingTab needs api/router/i18n/
  * wallet providers to render); it guards the exact className regression.
@@ -32,12 +34,12 @@ describe("billing payment-method selected state (#13406 finding 2)", () => {
     expect(source).not.toContain("bg-accent border-accent text-white");
   });
 
-  it("uses accent-foreground for the selected label so it is readable on the accent fill", () => {
-    const selectedMatches = source.match(
-      /bg-accent border-accent text-accent-foreground/g,
-    );
+  it("uses the theme-inverting txt/bg pair for the selected fill so the label is readable in every theme", () => {
+    const selectedMatches = source.match(/bg-txt border-txt text-bg/g);
     // Two toggles: Card + Crypto.
     expect(selectedMatches?.length).toBe(2);
+    // No accent-fill dependence remains (orange in-app, white under .theme-cloud).
+    expect(source).not.toContain("bg-accent border-accent");
   });
 
   it("uses theme-aware tokens for the unselected toggle (no raw white-opacity ladder)", () => {

--- a/packages/ui/src/cloud/billing/components/billing-tab.tsx
+++ b/packages/ui/src/cloud/billing/components/billing-tab.tsx
@@ -241,7 +241,7 @@ export function BillingTab({ user }: BillingTabProps) {
 
         <div className="relative z-10 space-y-6">
           <div className="flex items-center gap-2">
-            <div className="w-2 h-2 rounded-full bg-[var(--accent)]" />
+            <div className="w-2 h-2 rounded-full bg-muted" />
             <h3 className="text-base font-mono text-txt uppercase">
               {t("cloud.billingTab.creditBalance", {
                 defaultValue: "Credit Balance",
@@ -293,7 +293,7 @@ export function BillingTab({ user }: BillingTabProps) {
                       aria-pressed={paymentMethod === "card"}
                       className={`flex items-center gap-2 px-4 py-2 font-mono text-sm border transition-colors ${
                         paymentMethod === "card"
-                          ? "bg-accent border-accent text-accent-foreground"
+                          ? "bg-txt border-txt text-bg"
                           : "bg-transparent border-border text-muted hover:border-border-strong"
                       }`}
                     >
@@ -307,7 +307,7 @@ export function BillingTab({ user }: BillingTabProps) {
                       aria-pressed={paymentMethod === "crypto"}
                       className={`flex items-center gap-2 px-4 py-2 font-mono text-sm border transition-colors ${
                         paymentMethod === "crypto"
-                          ? "bg-accent border-accent text-accent-foreground"
+                          ? "bg-txt border-txt text-bg"
                           : "bg-transparent border-border text-muted hover:border-border-strong"
                       }`}
                     >
@@ -438,7 +438,7 @@ export function BillingTab({ user }: BillingTabProps) {
         <div className="relative z-10 space-y-6">
           <div className="flex flex-col gap-2">
             <div className="flex items-center gap-2">
-              <div className="w-2 h-2 rounded-full bg-[var(--accent)]" />
+              <div className="w-2 h-2 rounded-full bg-muted" />
               <h3 className="text-base font-mono text-txt uppercase">
                 {t("cloud.billingTab.invoices", { defaultValue: "Invoices" })}
               </h3>
@@ -484,7 +484,7 @@ export function BillingTab({ user }: BillingTabProps) {
 
               {loadingInvoices ? (
                 <div className="flex items-center justify-center p-8 border-l border-r border-b border-brand-surface">
-                  <Loader2 className="h-6 w-6 animate-spin text-[var(--accent)]" />
+                  <Loader2 className="h-6 w-6 animate-spin text-muted" />
                 </div>
               ) : invoicesError ? (
                 <div className="flex items-start gap-3 p-8 border-l border-r border-b border-brand-surface bg-red-500/5">

--- a/packages/ui/src/cloud/connectors/google-connection.tsx
+++ b/packages/ui/src/cloud/connectors/google-connection.tsx
@@ -109,8 +109,8 @@ export function GoogleConnection() {
             {activeConnections.map((connection) => (
               <ConnectionIdentityPanel
                 key={connection.id}
-                icon={<Mail className="h-6 w-6 text-[var(--accent)]" />}
-                iconClassName="bg-[var(--accent)]/10"
+                icon={<Mail className="h-6 w-6 text-txt" />}
+                iconClassName="bg-muted"
                 title={
                   connection.email || connection.displayName || connection.id
                 }
@@ -186,7 +186,7 @@ export function GoogleConnection() {
               </p>
             </div>
             <div className="p-3 bg-muted rounded-sm text-center">
-              <Calendar className="h-6 w-6 mx-auto mb-2 text-[var(--accent)]" />
+              <Calendar className="h-6 w-6 mx-auto mb-2 text-txt" />
               <p className="text-sm font-medium">
                 {t("cloud.google.calendar", { defaultValue: "Calendar" })}
               </p>

--- a/packages/ui/src/cloud/connectors/microsoft-connection.tsx
+++ b/packages/ui/src/cloud/connectors/microsoft-connection.tsx
@@ -113,8 +113,8 @@ export function MicrosoftConnection() {
       connectedContent={
         <div className="space-y-4">
           <ConnectionIdentityPanel
-            icon={<Mail className="h-6 w-6 text-[var(--accent)]" />}
-            iconClassName="bg-[var(--accent)]/10"
+            icon={<Mail className="h-6 w-6 text-txt-strong" />}
+            iconClassName="bg-muted"
             title={activeConnection?.email}
             subtitle={t("cloud.microsoft.connectedSubtitle", {
               defaultValue: "Microsoft Account Connected",
@@ -185,7 +185,7 @@ export function MicrosoftConnection() {
         <div className="space-y-4">
           <div className="grid grid-cols-2 gap-3">
             <div className="p-3 bg-muted rounded-sm text-center">
-              <Mail className="h-6 w-6 mx-auto mb-2 text-[var(--accent)]" />
+              <Mail className="h-6 w-6 mx-auto mb-2 text-muted" />
               <p className="text-sm font-medium">
                 {t("cloud.microsoft.outlook", { defaultValue: "Outlook" })}
               </p>
@@ -196,7 +196,7 @@ export function MicrosoftConnection() {
               </p>
             </div>
             <div className="p-3 bg-muted rounded-sm text-center">
-              <Calendar className="h-6 w-6 mx-auto mb-2 text-[var(--accent)]" />
+              <Calendar className="h-6 w-6 mx-auto mb-2 text-muted" />
               <p className="text-sm font-medium">
                 {t("cloud.microsoft.calendar", { defaultValue: "Calendar" })}
               </p>

--- a/packages/ui/src/cloud/connectors/whatsapp-connection.tsx
+++ b/packages/ui/src/cloud/connectors/whatsapp-connection.tsx
@@ -279,7 +279,7 @@ export function WhatsAppConnection() {
                   href="https://developers.facebook.com/apps"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-[var(--accent)] hover:underline inline-flex items-center gap-1"
+                  className="text-txt-strong hover:underline inline-flex items-center gap-1"
                 >
                   {t("cloud.whatsapp.metaDashboard", {
                     defaultValue: "Meta App Dashboard",

--- a/packages/ui/src/cloud/instances/components/agent-actions.tsx
+++ b/packages/ui/src/cloud/instances/components/agent-actions.tsx
@@ -240,7 +240,7 @@ export function ElizaAgentActions({
     <BrandCard className="relative" cornerSize="md">
       <div className="relative z-10 space-y-4">
         <div className="flex items-center gap-2 pb-4 border-b border-white/10">
-          <span className="inline-block w-2 h-2 rounded-full bg-[var(--accent)]" />
+          <span className="inline-block w-2 h-2 rounded-full bg-muted" />
           <h2
             className="text-xl font-normal text-white"
             style={{ fontFamily: "var(--font-roboto-mono)" }}

--- a/packages/ui/src/cloud/instances/components/eliza-agent-logs-viewer.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agent-logs-viewer.tsx
@@ -66,7 +66,7 @@ const STATUS_BADGE_STYLES: Record<string, string> = {
   provisioning: "border-white/20 bg-white/5 text-white/80",
   pending: "border-yellow-500/40 bg-yellow-500/10 text-yellow-400",
   stopped: "border-white/20 bg-white/5 text-white/70",
-  disconnected: "border-orange-500/40 bg-orange-500/10 text-orange-400",
+  disconnected: "border-white/20 bg-white/5 text-white/70",
   error: "border-red-500/40 bg-red-500/10 text-red-400",
 };
 
@@ -298,7 +298,7 @@ export function ElizaAgentLogsViewer({
           )}
           {statusHint && status !== "running" && (
             <div className="flex items-start gap-3 border border-white/10 bg-black/30 p-4">
-              <FileText className="mt-0.5 h-4 w-4 shrink-0 text-[var(--accent)]" />
+              <FileText className="mt-0.5 h-4 w-4 shrink-0 text-muted" />
               <p className="text-sm text-white/70">{statusHint}</p>
             </div>
           )}

--- a/packages/ui/src/cloud/instances/components/eliza-agent-tabs.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agent-tabs.tsx
@@ -47,13 +47,13 @@ export function ElizaAgentTabs({ agentId, children }: ElizaAgentTabsProps) {
             onClick={() => setActiveTab(tab)}
             className={`relative shrink-0 px-5 py-3 font-mono text-[11px] uppercase tracking-[0.2em] transition-colors ${
               activeTab === tab
-                ? "text-[var(--accent)]"
+                ? "text-txt-strong"
                 : "text-white/40 hover:text-white/70"
             }`}
           >
             {labels[tab]}
             {activeTab === tab && (
-              <span className="absolute bottom-0 left-0 right-0 h-px bg-[var(--accent)]" />
+              <span className="absolute bottom-0 left-0 right-0 h-px bg-txt" />
             )}
           </Button>
         ))}

--- a/packages/ui/src/cloud/instances/components/eliza-policies-section.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-policies-section.tsx
@@ -81,10 +81,10 @@ export function ElizaPoliciesSection({ agentId }: ElizaPoliciesSectionProps) {
 
   if (error) {
     return (
-      <div className="flex items-start gap-3 p-4 bg-orange-950/20 border border-orange-500/20">
-        <span className="w-2 h-2 rounded-full bg-orange-500 shrink-0 mt-1" />
+      <div className="flex items-start gap-3 p-4 bg-surface border border-border">
+        <span className="w-2 h-2 rounded-full bg-txt shrink-0 mt-1" />
         <div>
-          <p className="font-mono text-xs text-orange-400">{error}</p>
+          <p className="font-mono text-xs text-txt">{error}</p>
           <Button
             variant="ghost"
             type="button"

--- a/packages/ui/src/cloud/instances/components/my-agents.tsx
+++ b/packages/ui/src/cloud/instances/components/my-agents.tsx
@@ -111,7 +111,7 @@ function AgentConsoleOverview({
       <div className="border border-white/10 bg-black p-5">
         <div className="flex flex-col gap-5 md:flex-row md:items-start md:justify-between">
           <div className="max-w-2xl space-y-3">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[var(--accent)]">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted">
               {t("cloud.myAgents.agentConsole", {
                 defaultValue: "Agent console",
               })}
@@ -138,7 +138,7 @@ function AgentConsoleOverview({
           <div className="flex shrink-0 flex-col gap-2 sm:flex-row md:flex-col">
             <Link
               to={chatPath}
-              className="inline-flex h-10 items-center justify-center gap-2 bg-[var(--accent)] px-4 text-sm font-medium text-black transition-colors hover:bg-[#e54f00]"
+              className="inline-flex h-10 items-center justify-center gap-2 bg-txt px-4 text-sm font-medium text-bg transition-colors hover:bg-txt/90"
             >
               <MessageCircle className="h-4 w-4" />
               {primaryAgent
@@ -203,7 +203,7 @@ function AgentConsoleOverview({
             "group flex items-start gap-3 bg-black p-4 transition-colors hover:bg-white/5";
           const sectionInner = (
             <>
-              <span className="flex h-9 w-9 shrink-0 items-center justify-center border border-white/10 bg-black text-[var(--accent)]">
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center border border-white/10 bg-black text-muted">
                 <Icon className="h-4 w-4" />
               </span>
               <span className="min-w-0 flex-1">

--- a/packages/ui/src/cloud/join/JoinPage.tsx
+++ b/packages/ui/src/cloud/join/JoinPage.tsx
@@ -156,7 +156,7 @@ export default function JoinPage(): React.JSX.Element {
               variant="ghost"
               type="button"
               onClick={handleRetry}
-              className="bg-[#FF5800] px-6 py-2.5 font-semibold text-black transition-colors hover:bg-[#e54f00]"
+              className="bg-txt px-6 py-2.5 font-semibold text-bg transition-colors hover:bg-txt/90"
             >
               {t("cloud.join.retry", { defaultValue: "Try again" })}
             </Button>

--- a/packages/ui/src/cloud/organization/OrganizationSection.tsx
+++ b/packages/ui/src/cloud/organization/OrganizationSection.tsx
@@ -22,7 +22,7 @@ export function OrganizationSection() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-16">
-        <Loader2 className="h-8 w-8 animate-spin text-[var(--accent)]" />
+        <Loader2 className="h-8 w-8 animate-spin text-muted" />
       </div>
     );
   }

--- a/packages/ui/src/cloud/organization/contribute-credential-dialog.tsx
+++ b/packages/ui/src/cloud/organization/contribute-credential-dialog.tsx
@@ -160,7 +160,7 @@ export function ContributeCredentialDialog({
           <>
             <DialogHeader>
               <DialogTitle className="flex items-center gap-2 text-txt-strong font-mono">
-                <KeyRound className="h-5 w-5 text-[var(--accent)]" />
+                <KeyRound className="h-5 w-5 text-muted" />
                 {t("cloud.contributeCredential.title", {
                   defaultValue: "Contribute an API Key",
                 })}

--- a/packages/ui/src/cloud/organization/credentials-list.tsx
+++ b/packages/ui/src/cloud/organization/credentials-list.tsx
@@ -56,7 +56,7 @@ function healthDotClass(health: string): string {
     case "ok":
       return "bg-green-500";
     case "rate-limited":
-      return "bg-[var(--accent)]";
+      return "bg-yellow-500";
     default:
       // needs-reauth / invalid / unknown
       return "bg-[#EB4335]";
@@ -131,7 +131,7 @@ export function CredentialsList({
                   <span className="font-mono font-semibold text-sm md:text-base text-txt-strong truncate">
                     {credential.label}
                   </span>
-                  <span className="px-2 py-0.5 border border-[var(--accent)]/40 bg-[var(--accent)]/10 text-[var(--accent)] text-xs font-mono uppercase">
+                  <span className="px-2 py-0.5 border border-border bg-muted text-txt-strong text-xs font-mono uppercase">
                     {providerDisplayName(credential.provider)}
                   </span>
                 </div>

--- a/packages/ui/src/cloud/organization/credentials-tab.tsx
+++ b/packages/ui/src/cloud/organization/credentials-tab.tsx
@@ -147,7 +147,7 @@ export function CredentialsTab({
       {/* Credentials list */}
       {credentialsQuery.isLoading ? (
         <div className="flex items-center justify-center py-12">
-          <Loader2 className="h-8 w-8 animate-spin text-[var(--accent)]" />
+          <Loader2 className="h-8 w-8 animate-spin text-muted" />
         </div>
       ) : (
         <CredentialsList

--- a/packages/ui/src/cloud/organization/invite-member-dialog.tsx
+++ b/packages/ui/src/cloud/organization/invite-member-dialog.tsx
@@ -124,7 +124,7 @@ export function InviteMemberDialog({
           <>
             <DialogHeader>
               <DialogTitle className="flex items-center gap-2 text-txt-strong font-mono">
-                <Link2 className="h-5 w-5 text-[var(--accent)]" />
+                <Link2 className="h-5 w-5 text-muted" />
                 Invitation Created
               </DialogTitle>
               <DialogDescription className="text-muted font-mono text-xs md:text-sm">
@@ -174,7 +174,7 @@ export function InviteMemberDialog({
           <>
             <DialogHeader>
               <DialogTitle className="flex items-center gap-2 text-txt-strong font-mono">
-                <Mail className="h-5 w-5 text-[var(--accent)]" />
+                <Mail className="h-5 w-5 text-muted" />
                 Invite Team Member
               </DialogTitle>
               <DialogDescription className="text-muted font-mono text-xs md:text-sm">
@@ -226,7 +226,7 @@ export function InviteMemberDialog({
                   htmlFor="role"
                   className="flex items-center gap-2 text-txt-strong font-mono text-sm"
                 >
-                  <UserCog className="h-4 w-4 text-[var(--accent)]" />
+                  <UserCog className="h-4 w-4 text-muted" />
                   Role
                 </Label>
                 <Select

--- a/packages/ui/src/cloud/organization/members-list.tsx
+++ b/packages/ui/src/cloud/organization/members-list.tsx
@@ -132,7 +132,7 @@ export function MembersList({
         >
           <div className="flex flex-col sm:flex-row items-start gap-4">
             {/* Avatar */}
-            <div className="flex items-center justify-center bg-[rgba(var(--accent-rgb), 0.25)] size-10 md:size-12 flex-shrink-0">
+            <div className="flex items-center justify-center bg-muted size-10 md:size-12 flex-shrink-0">
               <span className="text-txt-strong text-sm md:text-base font-mono font-medium">
                 {getInitials(member)}
               </span>
@@ -230,7 +230,7 @@ export function MembersList({
                     </Select>
                   ) : (
                     <span
-                      className={`px-2 py-1 border text-xs font-mono uppercase flex items-center gap-1.5 ${member.role === "owner" ? "bg-[var(--accent)]/20 text-[var(--accent)] border-[var(--accent)]/40" : member.role === "admin" ? "bg-surface text-txt-strong border-border-strong" : "bg-surface text-muted border-border"}`}
+                      className={`px-2 py-1 border text-xs font-mono uppercase flex items-center gap-1.5 ${member.role === "owner" ? "bg-muted text-txt-strong border-border-strong" : member.role === "admin" ? "bg-surface text-txt-strong border-border-strong" : "bg-surface text-muted border-border"}`}
                     >
                       {getRoleIcon(member.role)}
                       <span className="capitalize">{member.role}</span>

--- a/packages/ui/src/cloud/organization/members-tab.tsx
+++ b/packages/ui/src/cloud/organization/members-tab.tsx
@@ -167,7 +167,7 @@ export function MembersTab({ user }: MembersTabProps) {
         {/* Members List */}
         {membersQuery.isLoading ? (
           <div className="flex items-center justify-center py-12">
-            <Loader2 className="h-8 w-8 animate-spin text-[var(--accent)]" />
+            <Loader2 className="h-8 w-8 animate-spin text-muted" />
           </div>
         ) : (
           <MembersList
@@ -190,7 +190,7 @@ export function MembersTab({ user }: MembersTabProps) {
             </h3>
             {invitesQuery.isLoading ? (
               <div className="flex items-center justify-center py-8">
-                <Loader2 className="h-6 w-6 animate-spin text-[var(--accent)]" />
+                <Loader2 className="h-6 w-6 animate-spin text-muted" />
               </div>
             ) : (
               <PendingInvitesList

--- a/packages/ui/src/cloud/organization/organization-general-tab.tsx
+++ b/packages/ui/src/cloud/organization/organization-general-tab.tsx
@@ -26,7 +26,7 @@ export function OrganizationGeneralTab({
         <div className="relative z-10 space-y-4">
           <div>
             <div className="flex items-center gap-2 mb-2">
-              <div className="w-2 h-2 rounded-full bg-[var(--accent)]" />
+              <div className="w-2 h-2 rounded-full bg-muted" />
               <h3 className="text-sm md:text-base font-mono text-txt uppercase">
                 Organization Details
               </h3>
@@ -69,7 +69,7 @@ export function OrganizationGeneralTab({
                 Created
               </p>
               <p className="mt-1 text-sm font-mono flex items-center gap-1.5 text-txt-strong">
-                <Calendar className="h-3.5 w-3.5 text-[var(--accent)]" />
+                <Calendar className="h-3.5 w-3.5 text-muted" />
                 {format(new Date(organization.created_at), "MMM d, yyyy")}
               </p>
             </div>
@@ -82,7 +82,7 @@ export function OrganizationGeneralTab({
         <div className="relative z-10 space-y-4">
           <div>
             <div className="flex items-center gap-2 mb-2">
-              <div className="w-2 h-2 rounded-full bg-[var(--accent)]" />
+              <div className="w-2 h-2 rounded-full bg-muted" />
               <h3 className="text-sm md:text-base font-mono text-txt uppercase">
                 Billing Information
               </h3>

--- a/packages/ui/src/cloud/organization/organization-tab.tsx
+++ b/packages/ui/src/cloud/organization/organization-tab.tsx
@@ -72,7 +72,7 @@ export function OrganizationTab({ user }: OrganizationTabProps) {
         <div className="relative z-10 flex flex-col sm:flex-row items-start justify-between gap-4">
           <div className="flex-1">
             <div className="flex items-center gap-2 mb-2">
-              <div className="w-2 h-2 rounded-full bg-[var(--accent)]" />
+              <div className="w-2 h-2 rounded-full bg-muted" />
               <h2 className="text-base md:text-xl font-mono font-semibold text-txt uppercase">
                 {user.organization.name}
               </h2>

--- a/packages/ui/src/cloud/organization/pending-invites-list.tsx
+++ b/packages/ui/src/cloud/organization/pending-invites-list.tsx
@@ -154,7 +154,7 @@ export function PendingInvitesList({
 
                 {/* Expiration Warning */}
                 {isExpiringSoon && (
-                  <div className="flex items-center gap-1.5 text-xs font-mono text-[var(--accent)]">
+                  <div className="flex items-center gap-1.5 text-xs font-mono text-txt-strong">
                     <Clock className="h-3.5 w-3.5" />
                     <span>
                       Expires{" "}


### PR DESCRIPTION
## What
Completes the console's **black-and-white** pass: sweeps every remaining brand-orange/brown tint across **56 files** (account-security, applications, organization, billing, connectors, analytics, api-explorer, instances, docs, dashboard layout, cloud-ui shared) to theme-aware design-system tokens.

Beyond classNames, this also neutralizes the layers a class sweep misses:
- **recharts stroke/fill + chart color constants** (`var(--accent)` / `#FF5800` / `#F59E0B` → `var(--txt)` / `var(--muted)` / neutral grays)
- **inline-style badges** (sidebar "NEW" badge `rgba(255,138,36,…)` → neutral)
- the **`accent="amber"` → `--warn` → brand-orange indirection** in KeyMetricsGrid metric cards (prop dropped)
- status colors: `rate-limited` dot → `yellow-500`, logs-viewer `disconnected` → neutral (label carries meaning)

## Palette rule (consistent with #14532/#14566/#14601)
Color is reserved for **meaning**: green = success/running/verified, red = danger/error, yellow = pending/limited. **Theme-adaptive surfaces get semantic tokens** (`text-muted`/`text-txt`/`bg-muted`/`border-border`) — never hardcoded white (the #14566 regression class). **Forced-dark surfaces** (`bg-neutral-900` islands) keep white-family text on purpose.

## Verification
- **#13767 theme-token guard: green** (the gate that caught the #14532 regression)
- Each of the 57 swept files **adversarially verified** by an independent reviewer pass (remaining-brown / hardcoded-white / functional-color preservation); the 9 flagged files hand-fixed with per-surface treatment
- biome clean; full `build:web` green
- Orphaned `BRAND_COLORS` import removed

## Deferred (deliberate)
`StewardProviderRuntime`'s login-widget accent (`primaryColor: var(--accent)`) — restyling the **auth widget** is a product/contrast decision; flagged for a deliberate call rather than swept blind.

https://claude.ai/code/session_01CpnRyFUuGvzz61SsrnC3Sd
