### PR TITLE
fix(discord): record guild owner role provenance (#14707)

### DIFF
--- a/plugins/plugin-discord/__tests__/identity.test.ts
+++ b/plugins/plugin-discord/__tests__/identity.test.ts
@@ -6,6 +6,7 @@
  */
 import { describe, expect, it } from "vitest";
 import {
+	buildDiscordWorldMetadata,
 	extractDiscordOwnerUserIds,
 	extractDiscordTeamAdminUserIds,
 	parseDiscordOwnerUserIds,
@@ -103,5 +104,45 @@ describe("parseDiscordOwnerUserIds", () => {
 		expect(parseDiscordOwnerUserIds("not json")).toEqual([]);
 		expect(parseDiscordOwnerUserIds("")).toEqual([]);
 		expect(parseDiscordOwnerUserIds(42)).toEqual([]);
+	});
+});
+
+describe("buildDiscordWorldMetadata", () => {
+	it("records the app owner as OWNER with owner provenance", () => {
+		const metadata = buildDiscordWorldMetadata(
+			{
+				agentId: "00000000-0000-0000-0000-000000000001",
+				character: { name: "Agent" },
+				getSetting: () => undefined,
+			} as never,
+			undefined,
+		);
+
+		const ownerId = metadata?.ownership?.ownerId;
+		expect(ownerId).toBeTruthy();
+		expect(metadata?.roles?.[ownerId as string]).toBe("OWNER");
+		expect(metadata?.roleSources?.[ownerId as string]).toBe("owner");
+	});
+
+	it("records Discord guild owners as connector-admin sourced ADMIN, not bare OWNER", () => {
+		const metadata = buildDiscordWorldMetadata(
+			{
+				agentId: "00000000-0000-0000-0000-000000000001",
+				character: { name: "Agent" },
+				getSetting: () => undefined,
+			} as never,
+			SNOWFLAKE_A,
+		);
+
+		const ownerId = metadata?.ownership?.ownerId;
+		const guildOwnerEntityId = Object.keys(metadata?.roles ?? {}).find(
+			(entityId) => entityId !== ownerId,
+		);
+
+		expect(guildOwnerEntityId).toBeTruthy();
+		expect(metadata?.roles?.[guildOwnerEntityId as string]).toBe("ADMIN");
+		expect(metadata?.roleSources?.[guildOwnerEntityId as string]).toBe(
+			"connector_admin",
+		);
 	});
 });

--- a/plugins/plugin-discord/identity.ts
+++ b/plugins/plugin-discord/identity.ts
@@ -165,21 +165,25 @@ export function buildDiscordWorldMetadata(
 	const roles: Record<string, Role> = {
 		[ownerId]: Role.OWNER,
 	};
+	const roleSources: Record<string, "owner" | "connector_admin"> = {
+		[ownerId]: "owner",
+	};
 
-	// The Discord guild owner should also be recognized as an owner in their
-	// guild.  Map the guild owner's Discord snowflake to a runtime entity ID
-	// and grant OWNER so that role resolution picks them up even when the bot-
-	// application owner extraction didn't include them.
+	// Discord guild ownership is connector provenance, not app ownership. Keep
+	// the grant auditable and let core's connector-admin whitelist decide whether
+	// it can rise above GUEST at read time.
 	if (guildOwnerId && DISCORD_SNOWFLAKE_PATTERN.test(guildOwnerId)) {
 		const guildOwnerEntityId = createUniqueUuid(runtime, guildOwnerId);
 		if (guildOwnerEntityId !== ownerId) {
-			roles[guildOwnerEntityId] = Role.OWNER;
+			roles[guildOwnerEntityId] = Role.ADMIN;
+			roleSources[guildOwnerEntityId] = "connector_admin";
 		}
 	}
 
 	return {
 		ownership: { ownerId },
 		roles,
+		roleSources,
 	};
 }
 

--- a/plugins/plugin-discord/identity.ts
+++ b/plugins/plugin-discord/identity.ts
@@ -8,7 +8,9 @@ import {
 	createUniqueUuid,
 	type IAgentRuntime,
 	type Metadata,
-	Role,
+	type RolesWorldMetadata,
+	recordOwnerGrant,
+	recordRoleGrant,
 	stringToUuid,
 } from "@elizaos/core";
 
@@ -162,29 +164,21 @@ export function buildDiscordWorldMetadata(
 	guildOwnerId: string | undefined,
 ): Metadata | undefined {
 	const ownerId = resolveElizaOwnerEntityId(runtime);
-	const roles: Record<string, Role> = {
-		[ownerId]: Role.OWNER,
-	};
-	const roleSources: Record<string, "owner" | "connector_admin"> = {
-		[ownerId]: "owner",
-	};
+	const metadata: RolesWorldMetadata = { ownership: { ownerId } };
+	recordOwnerGrant(metadata, ownerId);
 
-	// Discord guild ownership is connector provenance, not app ownership. Keep
-	// the grant auditable and let core's connector-admin whitelist decide whether
-	// it can rise above GUEST at read time.
+	// Discord guild ownership is connector provenance, not app ownership. Record
+	// it through core's canonical grant helper so the role and its source stay
+	// paired, and let the connector-admin whitelist decide at read time whether
+	// the grant can rise above GUEST.
 	if (guildOwnerId && DISCORD_SNOWFLAKE_PATTERN.test(guildOwnerId)) {
 		const guildOwnerEntityId = createUniqueUuid(runtime, guildOwnerId);
 		if (guildOwnerEntityId !== ownerId) {
-			roles[guildOwnerEntityId] = Role.ADMIN;
-			roleSources[guildOwnerEntityId] = "connector_admin";
+			recordRoleGrant(metadata, guildOwnerEntityId, "ADMIN", "connector_admin");
 		}
 	}
 
-	return {
-		ownership: { ownerId },
-		roles,
-		roleSources,
-	};
+	return metadata;
 }
 
 export function buildDiscordEntityMetadata(


### PR DESCRIPTION
## Summary

Fixes #14707.

`buildDiscordWorldMetadata()` no longer grants Discord guild owners bare app-level OWNER in world metadata. The app owner remains OWNER with `roleSources[ownerId] = "owner"`; a Discord guild owner is now recorded as ADMIN with `roleSources[guildOwnerEntityId] = "connector_admin"`.

Core already treats connector-admin sourced grants as fail-closed unless the entity matches `ELIZA_ROLES_CONNECTOR_ADMINS_JSON`, so this removes the headless-deployment OWNER escalation while keeping the connector provenance auditable.

## Evidence

- `bun run --cwd plugins/plugin-discord test __tests__/identity.test.ts` — passed, 8 tests.
- `bunx @biomejs/biome check plugins/plugin-discord/identity.ts plugins/plugin-discord/__tests__/identity.test.ts --no-errors-on-unmatched` — passed after write pass made no changes.
- `bun run --cwd plugins/plugin-discord build` — passed.
- `bun run --cwd plugins/plugin-discord typecheck` — passed after building fresh-worktree declarations for `plugins/plugin-sql`, `packages/vault`, and `plugins/plugin-commands`.
- `git diff --check origin/develop...HEAD` — passed.
- `bun run audit:error-policy-ratchet --report` — passed, no new fallback slop.

## Broader Test Note

- `bun run --cwd plugins/plugin-discord test` was attempted. It ran 36/38 files and 236/240 tests successfully, then failed in the same unrelated outbound-media fetch mock tests seen on adjacent Discord role work:
  - `__tests__/outbound-attachment.test.ts` attempted a real `http://127.0.0.1:8080/v1/media/...` fetch and got `ECONNREFUSED` instead of the test's mocked HTTP response.
  - `actions/messageConnector.outbound-media.test.ts` expected its fetch mock to be called, but the guarded media fetch path did not hit that mock.

These failures are outside the Discord identity metadata builder touched here; the focused identity test and package build/typecheck gates pass.

## Evidence N/A

- Live Discord credentialed owner/guild proof: N/A locally because no Discord bot/application credentials are configured in this environment. The deterministic world metadata builder is covered with unit tests.
- UI screenshots/video: N/A; no app UI changed.