### PR TITLE
fix(scenarios): test cli and judge failure paths

### DIFF
--- a/packages/scenario-runner/bin/eliza-scenarios
+++ b/packages/scenario-runner/bin/eliza-scenarios
@@ -1,2 +1,6 @@
 #!/usr/bin/env node
-import "../dist/cli.js";
+// The compiled cli.js only self-executes when it IS process.argv[1]; under this
+// shim argv[1] is the shim itself, so invoke the exported boundary explicitly.
+import { runCliAndExit } from "../dist/cli.js";
+
+runCliAndExit();

--- a/packages/scenario-runner/src/cli.test.ts
+++ b/packages/scenario-runner/src/cli.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Behavioral coverage for the scenario-runner CLI contract. The tests load
+ * real temporary scenario files through the loader, then inject the runtime
+ * boundary so exit-code, filtering, skip-policy, and artifact-plumbing
+ * semantics stay deterministic and cheap enough for the unit lane.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { ScenarioDefinition } from "@elizaos/scenario-runner/schema";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type CliDependencies,
+  CliUsageError,
+  parseArgs,
+  runCli,
+} from "./cli.ts";
+import type { AggregateReport, ScenarioReport } from "./types.ts";
+
+const ENV_KEYS = [
+  "ELIZA_TRAJECTORY_DIR",
+  "ELIZA_TRAJECTORY_LOGGING",
+  "ELIZA_LIFEOPS_RUN_DIR",
+  "ELIZA_LIFEOPS_RUN_ID",
+  "ELIZA_LIFEOPS_SCENARIO_ID",
+  "LIFEOPS_LIVE_JUDGE_MIN_SCORE",
+  "SKIP_REASON",
+] as const;
+const DETERMINISTIC_PROVIDER_NAME = "deterministic-llm-proxy" as const;
+
+function writeScenario(
+  dir: string,
+  id: string,
+  overrides: Partial<ScenarioDefinition> = {},
+): void {
+  writeFileSync(
+    path.join(dir, `${id}.scenario.ts`),
+    `export default ${JSON.stringify({
+      id,
+      title: id,
+      domain: "cli-test",
+      lane: "pr-deterministic",
+      turns: [],
+      ...overrides,
+    })};\n`,
+  );
+}
+
+function scenarioReport(
+  id: string,
+  status: ScenarioReport["status"],
+): ScenarioReport {
+  return {
+    id,
+    title: id,
+    domain: "cli-test",
+    tags: [],
+    status,
+    skipReason: status === "skipped" ? "dependency unavailable" : undefined,
+    durationMs: 1,
+    turns: [],
+    finalChecks: [],
+    actionsCalled: [],
+    failedAssertions:
+      status === "failed" ? [{ label: "unit", detail: "forced failure" }] : [],
+    providerName: "unit-test",
+  };
+}
+
+function aggregateReport(
+  reports: ScenarioReport[],
+  providerName: string | null,
+  startedAtIso: string,
+  completedAtIso: string,
+  runId: string,
+): AggregateReport {
+  const totals = reports.reduce(
+    (acc, report) => {
+      acc[report.status] += 1;
+      return acc;
+    },
+    { passed: 0, failed: 0, skipped: 0 },
+  );
+  return {
+    runId,
+    startedAtIso,
+    completedAtIso,
+    providerName,
+    scenarios: reports,
+    totals: {
+      ...totals,
+      costUsd: 0,
+      finalChecksSkipped: 0,
+    },
+    totalCount: reports.length,
+    passedCount: totals.passed,
+    failedCount: totals.failed,
+    skippedCount: totals.skipped,
+    totalCostUsd: 0,
+  };
+}
+
+function createDependencies(
+  resolveStatus: (id: string) => ScenarioReport["status"],
+  overrides: Partial<CliDependencies> = {},
+): CliDependencies {
+  return {
+    availableProviderNames: vi.fn(() => ["unit-test"]),
+    shouldUseDeterministicLlmProxy: vi.fn(() => true),
+    createScenarioRuntime: vi.fn(async () => ({
+      runtime: {} as never,
+      pgliteDir: tmpdir(),
+      providerName: DETERMINISTIC_PROVIDER_NAME,
+      providerConfig: {
+        name: DETERMINISTIC_PROVIDER_NAME,
+        env: {},
+        pluginPackage: null,
+      },
+      cleanup: vi.fn(async () => undefined),
+    })),
+    runScenario: vi.fn(async (scenario) =>
+      scenarioReport(scenario.id, resolveStatus(scenario.id)),
+    ),
+    buildAggregate: vi.fn(aggregateReport),
+    printStdoutSummary: vi.fn(),
+    writeReport: vi.fn(),
+    writeReportBundle: vi.fn(),
+    writeScenarioRunViewer: vi.fn(),
+    exportScenarioNativeJsonl: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("scenario-runner CLI", () => {
+  let tempDir: string;
+  let stdout = "";
+  let stderr = "";
+  let savedEnv: Partial<Record<(typeof ENV_KEYS)[number], string>>;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), "scenario-runner-cli-"));
+    stdout = "";
+    stderr = "";
+    savedEnv = {};
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdout += String(chunk);
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderr += String(chunk);
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("parses run filters and rejects invalid lanes without exiting the process", () => {
+    const parsed = parseArgs([
+      "run",
+      tempDir,
+      "--scenario",
+      "alpha,beta",
+      "--lane",
+      "pr-deterministic",
+      "nested/*.scenario.ts",
+    ]);
+
+    expect(parsed.command).toBe("run");
+    expect(parsed.dir).toBe(path.resolve(tempDir));
+    expect([...(parsed.filter ?? [])]).toEqual(["alpha", "beta"]);
+    expect(parsed.lane).toBe("pr-deterministic");
+    expect(parsed.fileGlobs).toEqual(["nested/*.scenario.ts"]);
+    expect(() => parseArgs(["list", tempDir, "--lane", "bad-lane"])).toThrow(
+      CliUsageError,
+    );
+  });
+
+  it("lists only scenarios in the requested lane", async () => {
+    writeScenario(tempDir, "cli-pr", { lane: "pr-deterministic" });
+    writeScenario(tempDir, "cli-live", { lane: "live-only" });
+
+    const code = await runCli(["list", tempDir, "--lane", "live-only"]);
+
+    expect(code).toBe(0);
+    expect(stdout.trim()).toBe("cli-live");
+  });
+
+  it("returns exit 0 for passing scenarios and exit 1 for failed scenarios", async () => {
+    writeScenario(tempDir, "cli-pass");
+    writeScenario(tempDir, "cli-fail");
+    const dependencies = createDependencies((id) =>
+      id === "cli-fail" ? "failed" : "passed",
+    );
+
+    await expect(
+      runCli(["run", tempDir, "--scenario", "cli-pass"], dependencies),
+    ).resolves.toBe(0);
+    await expect(
+      runCli(["run", tempDir, "--scenario", "cli-fail"], dependencies),
+    ).resolves.toBe(1);
+    expect(dependencies.runScenario).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns exit 2 when a scenario skips without SKIP_REASON", async () => {
+    writeScenario(tempDir, "cli-skip");
+    const dependencies = createDependencies(() => "skipped");
+
+    const code = await runCli(["run", tempDir], dependencies);
+
+    expect(code).toBe(2);
+    expect(stderr).toContain("skipped without SKIP_REASON");
+  });
+
+  it("allows skipped scenarios when SKIP_REASON documents the skip", async () => {
+    process.env.SKIP_REASON = "unit test intentionally skips";
+    writeScenario(tempDir, "cli-skip");
+    const dependencies = createDependencies(() => "skipped");
+
+    const code = await runCli(["run", tempDir], dependencies);
+
+    expect(code).toBe(0);
+    expect(stderr).not.toContain("skipped without SKIP_REASON");
+  });
+
+  it("fails loudly before runtime creation when no provider or proxy is available", async () => {
+    writeScenario(tempDir, "cli-provider-required");
+    const createScenarioRuntime = vi.fn();
+    const dependencies = createDependencies(() => "passed", {
+      availableProviderNames: vi.fn(() => []),
+      shouldUseDeterministicLlmProxy: vi.fn(() => false),
+      createScenarioRuntime,
+    });
+
+    const code = await runCli(["run", tempDir], dependencies);
+
+    expect(code).toBe(2);
+    expect(stderr).toContain("no LLM provider API key set");
+    expect(createScenarioRuntime).not.toHaveBeenCalled();
+  });
+
+  it("threads run-dir, run id, and native export paths through the run", async () => {
+    writeScenario(tempDir, "cli-artifacts");
+    const runDir = path.join(tempDir, "run");
+    const nativePath = path.join(tempDir, "native.jsonl");
+    const dependencies = createDependencies(() => "passed");
+
+    const code = await runCli(
+      [
+        "run",
+        tempDir,
+        "--run-dir",
+        runDir,
+        "--runId",
+        "run-fixed",
+        "--export-native",
+        nativePath,
+      ],
+      dependencies,
+    );
+
+    expect(code).toBe(0);
+    expect(process.env.ELIZA_TRAJECTORY_LOGGING).toBe("1");
+    expect(process.env.ELIZA_TRAJECTORY_DIR).toBe(
+      path.join(runDir, "trajectories"),
+    );
+    expect(process.env.ELIZA_LIFEOPS_RUN_ID).toBe("run-fixed");
+    expect(process.env.ELIZA_LIFEOPS_RUN_DIR).toBe(runDir);
+    expect(process.env.ELIZA_LIFEOPS_SCENARIO_ID).toBe("cli-artifacts");
+    expect(dependencies.exportScenarioNativeJsonl).toHaveBeenCalledWith(
+      runDir,
+      nativePath,
+      expect.any(Map),
+      expect.any(Map),
+      expect.any(Map),
+    );
+    expect(dependencies.writeScenarioRunViewer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        artifactPaths: expect.objectContaining({
+          runDir,
+          nativeJsonl: nativePath,
+        }),
+      }),
+      runDir,
+      { nativeJsonlPath: nativePath },
+    );
+  });
+});

--- a/packages/scenario-runner/src/cli.ts
+++ b/packages/scenario-runner/src/cli.ts
@@ -520,11 +520,16 @@ export async function runCli(
   return aggregate.totals.failed > 0 ? 1 : 0;
 }
 
-if (
-  process.argv[1] &&
-  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
-) {
-  runCli()
+/**
+ * Process boundary shared by direct `src/cli.ts` execution and the published
+ * `bin/eliza-scenarios` shim: runs the CLI and translates the result (or any
+ * thrown failure) into an exit code. Kept separate from `runCli` so tests can
+ * drive the CLI in-process without process.exit.
+ */
+export function runCliAndExit(
+  argv: readonly string[] = process.argv.slice(2),
+): void {
+  runCli(argv)
     .then((code) => {
       process.exit(code);
     })
@@ -539,4 +544,11 @@ if (
       );
       process.exit(1);
     });
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  runCliAndExit();
 }

--- a/packages/scenario-runner/src/cli.ts
+++ b/packages/scenario-runner/src/cli.ts
@@ -13,6 +13,7 @@
 import crypto from "node:crypto";
 import path from "node:path";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 import { logger } from "@elizaos/core";
 import {
   DEFAULT_SCENARIO_LANE,
@@ -47,7 +48,7 @@ type ScenarioRuntimeFactoryModule = Pick<
   "createScenarioRuntime" | "shouldUseDeterministicLlmProxy"
 >;
 
-interface ParsedArgs {
+export interface ParsedArgs {
   command: "run" | "list";
   dir: string;
   reportPath?: string;
@@ -63,6 +64,29 @@ interface ParsedArgs {
   validateScenarios?: boolean;
 }
 
+export class CliUsageError extends Error {
+  readonly exitCode: number;
+
+  constructor(message: string, exitCode: number) {
+    super(message);
+    this.name = "CliUsageError";
+    this.exitCode = exitCode;
+  }
+}
+
+export interface CliDependencies {
+  availableProviderNames: LiveProviderModule["availableProviderNames"];
+  runScenario: ExecutorModule["runScenario"];
+  buildAggregate: ReporterModule["buildAggregate"];
+  printStdoutSummary: ReporterModule["printStdoutSummary"];
+  writeReport: ReporterModule["writeReport"];
+  writeReportBundle: ReporterModule["writeReportBundle"];
+  writeScenarioRunViewer: ReporterModule["writeScenarioRunViewer"];
+  createScenarioRuntime: ScenarioRuntimeFactoryModule["createScenarioRuntime"];
+  shouldUseDeterministicLlmProxy: ScenarioRuntimeFactoryModule["shouldUseDeterministicLlmProxy"];
+  exportScenarioNativeJsonl: NativeExportModule["exportScenarioNativeJsonl"];
+}
+
 function scenarioNativeManifestPath(
   nativeJsonlPath?: string,
 ): string | undefined {
@@ -73,14 +97,17 @@ function scenarioNativeManifestPath(
 }
 
 function usageAndExit(message: string, code: number): never {
-  process.stderr.write(`[eliza-scenarios] ${message}\n`);
-  process.stderr.write(
-    "Usage:\n  eliza-scenarios run  <dir> [--expand-scenarios] [--count-scenarios] [--validate-scenarios] [--run-dir <dir>] [--export-native <jsonlPath>] [--report <jsonPath>] [--report-dir <dir>] [--runId <id>] [--scenario id1,id2] [--lane pr-deterministic|live-only] [fileGlob ...]\n  eliza-scenarios list <dir> [--expand-scenarios] [--count-scenarios] [--validate-scenarios] [--lane pr-deterministic|live-only] [fileGlob ...]\n",
-  );
-  process.exit(code);
+  throw new CliUsageError(message, code);
 }
 
-function parseArgs(argv: readonly string[]): ParsedArgs {
+function formatUsageError(error: CliUsageError): string {
+  return (
+    `[eliza-scenarios] ${error.message}\n` +
+    "Usage:\n  eliza-scenarios run  <dir> [--expand-scenarios] [--count-scenarios] [--validate-scenarios] [--run-dir <dir>] [--export-native <jsonlPath>] [--report <jsonPath>] [--report-dir <dir>] [--runId <id>] [--scenario id1,id2] [--lane pr-deterministic|live-only] [fileGlob ...]\n  eliza-scenarios list <dir> [--expand-scenarios] [--count-scenarios] [--validate-scenarios] [--lane pr-deterministic|live-only] [fileGlob ...]\n"
+  );
+}
+
+export function parseArgs(argv: readonly string[]): ParsedArgs {
   if (argv.length < 2) {
     usageAndExit("missing command or directory", 2);
   }
@@ -184,8 +211,53 @@ function parseArgs(argv: readonly string[]): ParsedArgs {
   };
 }
 
-async function main(): Promise<number> {
-  const argv = process.argv.slice(2);
+async function loadCliDependencies(): Promise<CliDependencies> {
+  const liveProviderSpecifier = "@elizaos/core/testing" as string;
+  const [
+    { availableProviderNames },
+    { runScenario },
+    {
+      buildAggregate,
+      printStdoutSummary,
+      writeReport,
+      writeReportBundle,
+      writeScenarioRunViewer,
+    },
+    { createScenarioRuntime, shouldUseDeterministicLlmProxy },
+    { exportScenarioNativeJsonl },
+    // Keep out-of-root imports behind widened specifiers so TypeScript does not
+    // pull those modules into this package's rootDir validation graph.
+  ]: [
+    LiveProviderModule,
+    ExecutorModule,
+    ReporterModule,
+    ScenarioRuntimeFactoryModule,
+    NativeExportModule,
+  ] = await Promise.all([
+    import(liveProviderSpecifier),
+    import("./executor.ts"),
+    import("./reporter.ts"),
+    import("./runtime-factory.ts"),
+    import("./native-export.ts"),
+  ]);
+  return {
+    availableProviderNames,
+    runScenario,
+    buildAggregate,
+    printStdoutSummary,
+    writeReport,
+    writeReportBundle,
+    writeScenarioRunViewer,
+    createScenarioRuntime,
+    shouldUseDeterministicLlmProxy,
+    exportScenarioNativeJsonl,
+  };
+}
+
+export async function runCli(
+  argv: readonly string[] = process.argv.slice(2),
+  dependencies?: CliDependencies,
+): Promise<number> {
   const parsed = parseArgs(argv);
 
   if (parsed.countScenarios) {
@@ -229,34 +301,18 @@ async function main(): Promise<number> {
     return 0;
   }
 
-  const liveProviderSpecifier = "@elizaos/core/testing" as string;
-  const [
-    { availableProviderNames },
-    { runScenario },
-    {
-      buildAggregate,
-      printStdoutSummary,
-      writeReport,
-      writeReportBundle,
-      writeScenarioRunViewer,
-    },
-    { createScenarioRuntime, shouldUseDeterministicLlmProxy },
-    { exportScenarioNativeJsonl },
-    // Keep out-of-root imports behind widened specifiers so TypeScript does not
-    // pull those modules into this package's rootDir validation graph.
-  ]: [
-    LiveProviderModule,
-    ExecutorModule,
-    ReporterModule,
-    ScenarioRuntimeFactoryModule,
-    NativeExportModule,
-  ] = await Promise.all([
-    import(liveProviderSpecifier),
-    import("./executor.ts"),
-    import("./reporter.ts"),
-    import("./runtime-factory.ts"),
-    import("./native-export.ts"),
-  ]);
+  const {
+    availableProviderNames,
+    runScenario,
+    buildAggregate,
+    printStdoutSummary,
+    writeReport,
+    writeReportBundle,
+    writeScenarioRunViewer,
+    createScenarioRuntime,
+    shouldUseDeterministicLlmProxy,
+    exportScenarioNativeJsonl,
+  } = dependencies ?? (await loadCliDependencies());
 
   if (
     availableProviderNames().length === 0 &&
@@ -464,13 +520,23 @@ async function main(): Promise<number> {
   return aggregate.totals.failed > 0 ? 1 : 0;
 }
 
-main()
-  .then((code) => {
-    process.exit(code);
-  })
-  .catch((err: unknown) => {
-    process.stderr.write(
-      `[eliza-scenarios] fatal: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
-    );
-    process.exit(1);
-  });
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  runCli()
+    .then((code) => {
+      process.exit(code);
+    })
+    // error-policy:J1 CLI boundary translates thrown failures to exit codes.
+    .catch((err: unknown) => {
+      if (err instanceof CliUsageError) {
+        process.stderr.write(formatUsageError(err));
+        process.exit(err.exitCode);
+      }
+      process.stderr.write(
+        `[eliza-scenarios] fatal: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
+      );
+      process.exit(1);
+    });
+}

--- a/packages/scenario-runner/src/judge.test.ts
+++ b/packages/scenario-runner/src/judge.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Fallback judge parsing tests. These cover the runtime TEXT_LARGE path used
+ * when the independent Cerebras judge is not configured, including the retry
+ * loop that must throw a typed error instead of fabricating a score.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { JudgeParseError, judgeTextWithLlm } from "./judge.ts";
+
+describe("judgeTextWithLlm fallback parsing", () => {
+  beforeEach(() => {
+    vi.stubEnv("EVAL_MODEL_PROVIDER", "runtime");
+    vi.stubEnv("CEREBRAS_API_KEY", "");
+    vi.stubEnv("EVAL_CEREBRAS_API_KEY", "");
+    vi.stubEnv("ELIZA_E2E_CEREBRAS_API_KEY", "");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("retries malformed TEXT_LARGE output and returns the first parseable verdict", async () => {
+    const useModel = vi
+      .fn()
+      .mockResolvedValueOnce("not json")
+      .mockResolvedValueOnce("still not json")
+      .mockResolvedValueOnce('{"score":"0.84","reason":"rubric satisfied"}');
+    const runtime = { useModel } as unknown as IAgentRuntime;
+
+    const result = await judgeTextWithLlm(
+      runtime,
+      "candidate text",
+      "rubric text",
+    );
+
+    expect(result).toEqual({
+      score: 0.84,
+      reason: "rubric satisfied",
+      verdict: "PASS",
+    });
+    expect(useModel).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws JudgeParseError after every fallback parse attempt fails", async () => {
+    const useModel = vi
+      .fn()
+      .mockResolvedValueOnce("first malformed output")
+      .mockResolvedValueOnce("second malformed output")
+      .mockResolvedValueOnce("third malformed output");
+    const runtime = { useModel } as unknown as IAgentRuntime;
+
+    let thrown: unknown;
+    try {
+      await judgeTextWithLlm(runtime, "candidate text", "rubric text");
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(JudgeParseError);
+    expect(thrown).toMatchObject({
+      name: "JudgeParseError",
+      raw: "third malformed output",
+    });
+    expect(useModel).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/scenario-runner/src/judge.ts
+++ b/packages/scenario-runner/src/judge.ts
@@ -94,7 +94,7 @@ function parseJudgeJson(raw: string): JudgeResult | null {
   };
 }
 
-class JudgeParseError extends Error {
+export class JudgeParseError extends Error {
   readonly raw: string;
   constructor(attempts: number, raw: string) {
     const preview =


### PR DESCRIPTION
## Summary
- Make `packages/scenario-runner/src/cli.ts` import-safe by exporting `parseArgs()` / `runCli()` and leaving `process.exit()` only in the direct CLI shim.
- Add CLI behavior tests for lane filtering, exit 0/1/2 semantics, SKIP_REASON enforcement, provider-gate fail-loud behavior, and run-dir/native-export env plumbing.
- Export `JudgeParseError` and add fallback TEXT_LARGE judge tests for malformed-output retry success and retry exhaustion.

## Verification
- `bun run --cwd packages/scenario-runner test -- src/cli.test.ts src/judge.test.ts` -> 2 files passed, 9 tests passed
- `bun run --cwd packages/scenario-runner test -- src/cli.test.ts src/judge.test.ts src/judge-independence.test.ts src/executor-judge-score.test.ts` -> 4 files passed, 16 tests passed
- `bunx biome check packages/scenario-runner/src/cli.ts packages/scenario-runner/src/cli.test.ts packages/scenario-runner/src/judge.ts packages/scenario-runner/src/judge.test.ts`
- `bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/cli.ts list test/scenarios --lane pr-deterministic` -> listed deterministic scenario IDs; Bun emitted its known directory-mismatch warning but exited 0
- `bun run audit:error-policy-ratchet` -> no new fallback-slop in touched files
- `git diff --check`

## Typecheck note
- `bun run --cwd packages/scenario-runner typecheck` still fails on pre-existing optional workspace module resolution errors outside this patch (for example `@elizaos/plugin-discord/service`, `@elizaos/plugin-elizacloud/host-routes`, `@elizaos/plugin-xr`, `@elizaos/plugin-blocker/services/website-blocker/index`, `@elizaos/capacitor-*`, and plugin-app-manager registry types). After fixing the new test double, there are no remaining `cli.test.ts` / `judge.test.ts` errors in the typecheck output.

## Evidence / N/A
- Screenshots/video: N/A - scenario-runner CLI/judge harness tests only; no app UI changed.
- Live LLM trajectories: N/A - this PR improves the harness failure-path tests and does not change agent behavior. Fallback judge tests explicitly avoid fabricating scores by asserting `JudgeParseError`.

Fixes #14699.
