### PR TITLE
fix(evidence): require ffmpeg for capture video

### DIFF
--- a/packages/app/scripts/capture-linux-desktop.mjs
+++ b/packages/app/scripts/capture-linux-desktop.mjs
@@ -2,8 +2,8 @@
 // Linux desktop capture (issue #9944): screenshot + screen recording + an info
 // log of the headed X11 desktop (incl. the Electrobun window), written to the
 // generated capture-output directory.
-// Skips with a reason (exit 0) when ffmpeg or an X display is missing — so a
-// headless CI run is a clean no-op.
+// Skips with a reason (exit 0) when no X display exists; ffmpeg is a required
+// capture dependency and is resolved or installed before recording.
 //
 // Usage (from packages/app):
 //   bun run capture:linux-desktop -- --issue <n> --slug <s> [--duration <sec>]
@@ -20,13 +20,10 @@ import {
   parseFlags,
   skip,
 } from "./lib/capture-output.mjs";
+import { resolveRequiredFfmpeg } from "./lib/ffmpeg.mjs";
 
 const PLATFORM = "linux-desktop";
 const log = logFor(PLATFORM);
-
-function hasFfmpeg() {
-  return spawnSync("ffmpeg", ["-version"], { stdio: "ignore" }).status === 0;
-}
 
 /** Screen geometry from xdpyinfo, else a safe 1920x1080 default. */
 function screenSize(display) {
@@ -38,9 +35,9 @@ function screenSize(display) {
   return m ? `${m[1]}x${m[2]}` : "1920x1080";
 }
 
-function captureScreenshot(display, size, outPath) {
+function captureScreenshot(ffmpeg, display, size, outPath) {
   const res = spawnSync(
-    "ffmpeg",
+    ffmpeg,
     [
       "-y",
       "-f",
@@ -58,10 +55,10 @@ function captureScreenshot(display, size, outPath) {
   return res.status === 0 && existsSync(outPath);
 }
 
-function recordVideo(display, size, outPath, durationSec) {
+function recordVideo(ffmpeg, display, size, outPath, durationSec) {
   return new Promise((resolve) => {
     const proc = spawn(
-      "ffmpeg",
+      ffmpeg,
       [
         "-y",
         "-f",
@@ -96,9 +93,7 @@ async function main() {
   if (!display) {
     skip(PLATFORM, "no $DISPLAY (headless host — no X11 desktop to capture)");
   }
-  if (!hasFfmpeg()) {
-    skip(PLATFORM, "ffmpeg not found (install ffmpeg for x11grab capture)");
-  }
+  const ffmpeg = resolveRequiredFfmpeg({ log });
 
   const flags = parseFlags();
   const base = evidenceBaseName({
@@ -111,7 +106,7 @@ async function main() {
   log(`capturing X11 desktop ${display} @ ${size}`);
 
   const pngPath = evidencePath(base, "png");
-  if (captureScreenshot(display, size, pngPath)) {
+  if (captureScreenshot(ffmpeg, display, size, pngPath)) {
     log(`screenshot → ${pngPath} (${statSync(pngPath).size} bytes)`);
   } else {
     log("screenshot failed (no file written)");
@@ -119,7 +114,13 @@ async function main() {
 
   const mp4Path = evidencePath(base, "mp4");
   log(`recording ${durationSec}s → ${mp4Path}`);
-  const recorded = await recordVideo(display, size, mp4Path, durationSec);
+  const recorded = await recordVideo(
+    ffmpeg,
+    display,
+    size,
+    mp4Path,
+    durationSec,
+  );
   log(
     recorded
       ? `recording → ${mp4Path} (${statSync(mp4Path).size} bytes)`
@@ -130,7 +131,7 @@ async function main() {
   writeFileSync(
     infoPath,
     `[capture:${PLATFORM}] host=${process.platform} display=${display} size=${size}\n` +
-      `ffmpeg=${spawnSync("ffmpeg", ["-version"], { encoding: "utf8" }).stdout?.split("\n")[0] ?? "?"}\n`,
+      `ffmpeg=${spawnSync(ffmpeg, ["-version"], { encoding: "utf8" }).stdout?.split("\n")[0] ?? "?"}\n`,
     "utf8",
   );
   log(`info log → ${infoPath}`);

--- a/packages/app/scripts/capture-macos-desktop.mjs
+++ b/packages/app/scripts/capture-macos-desktop.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // macOS desktop evidence capture: screenshot + best-effort screen recording +
-// backend log for headed Electrobun/manual voice runs. Skips cleanly on non-macOS
-// hosts; records video only when ffmpeg can access the avfoundation screen input.
+// backend log for headed Electrobun/manual voice runs. Skips cleanly on
+// non-macOS hosts; ffmpeg is resolved or installed before recording.
 import { spawn, spawnSync } from "node:child_process";
 import { existsSync, statSync, writeFileSync } from "node:fs";
 import {
@@ -13,6 +13,7 @@ import {
   parseFlags,
   skip,
 } from "./lib/capture-output.mjs";
+import { resolveRequiredFfmpeg } from "./lib/ffmpeg.mjs";
 
 const PLATFORM = "macos-desktop";
 const log = logFor(PLATFORM);
@@ -26,11 +27,10 @@ function captureScreenshot(outPath) {
   return res.status === 0 && existsSync(outPath);
 }
 
-function recordVideo(outPath, durationSec) {
-  if (!hasCommand("ffmpeg")) return Promise.resolve(false);
+function recordVideo(ffmpeg, outPath, durationSec) {
   return new Promise((resolve) => {
     const proc = spawn(
-      "ffmpeg",
+      ffmpeg,
       [
         "-y",
         "-f",
@@ -64,6 +64,7 @@ async function main() {
   if (!hasCommand("screencapture")) {
     skip(PLATFORM, "screencapture not found");
   }
+  const ffmpeg = resolveRequiredFfmpeg({ log });
 
   const flags = parseFlags();
   const base = evidenceBaseName({
@@ -82,7 +83,7 @@ async function main() {
 
   const mp4Path = evidencePath(base, "mp4");
   log(`recording ${durationSec}s -> ${mp4Path}`);
-  const recorded = await recordVideo(mp4Path, durationSec);
+  const recorded = await recordVideo(ffmpeg, mp4Path, durationSec);
   log(
     recorded
       ? `recording -> ${mp4Path} (${statSync(mp4Path).size} bytes)`
@@ -94,7 +95,7 @@ async function main() {
     infoPath,
     `[capture:${PLATFORM}] host=${process.platform}\n` +
       `screencapture=${hasCommand("screencapture") ? "present" : "missing"}\n` +
-      `ffmpeg=${spawnSync("ffmpeg", ["-version"], { encoding: "utf8" }).stdout?.split("\n")[0] ?? "missing"}\n`,
+      `ffmpeg=${spawnSync(ffmpeg, ["-version"], { encoding: "utf8" }).stdout?.split("\n")[0] ?? "missing"}\n`,
     "utf8",
   );
   log(`info log -> ${infoPath}`);

--- a/packages/app/scripts/capture-windows-desktop.mjs
+++ b/packages/app/scripts/capture-windows-desktop.mjs
@@ -2,8 +2,8 @@
 // Windows desktop capture (issue #9944): screenshot + screen recording + an
 // info log of the headed desktop (incl. the Electrobun window) via ffmpeg
 // `gdigrab`, written to the generated capture-output directory.
-// Skips with a reason (exit 0) when not on Windows or ffmpeg is missing — so a
-// non-Windows CI run is a clean no-op.
+// Skips with a reason (exit 0) when not on Windows; ffmpeg is a required
+// capture dependency and is resolved or installed before recording.
 //
 // Usage (from packages/app):
 //   bun run capture:windows-desktop -- --issue <n> --slug <s> [--duration <sec>]
@@ -20,27 +20,24 @@ import {
   parseFlags,
   skip,
 } from "./lib/capture-output.mjs";
+import { resolveRequiredFfmpeg } from "./lib/ffmpeg.mjs";
 
 const PLATFORM = "windows-desktop";
 const log = logFor(PLATFORM);
 
-function hasFfmpeg() {
-  return spawnSync("ffmpeg", ["-version"], { stdio: "ignore" }).status === 0;
-}
-
-function captureScreenshot(outPath) {
+function captureScreenshot(ffmpeg, outPath) {
   const res = spawnSync(
-    "ffmpeg",
+    ffmpeg,
     ["-y", "-f", "gdigrab", "-i", "desktop", "-frames:v", "1", outPath],
     { stdio: "ignore" },
   );
   return res.status === 0 && existsSync(outPath);
 }
 
-function recordVideo(outPath, durationSec) {
+function recordVideo(ffmpeg, outPath, durationSec) {
   return new Promise((resolve) => {
     const proc = spawn(
-      "ffmpeg",
+      ffmpeg,
       [
         "-y",
         "-f",
@@ -69,9 +66,7 @@ async function main() {
       `windows-desktop capture requires a windows host (host is ${process.platform})`,
     );
   }
-  if (!hasFfmpeg()) {
-    skip(PLATFORM, "ffmpeg not found (install ffmpeg for gdigrab capture)");
-  }
+  const ffmpeg = resolveRequiredFfmpeg({ log });
 
   const flags = parseFlags();
   const base = evidenceBaseName({
@@ -83,7 +78,7 @@ async function main() {
   log("capturing windows desktop via gdigrab");
 
   const pngPath = evidencePath(base, "png");
-  if (captureScreenshot(pngPath)) {
+  if (captureScreenshot(ffmpeg, pngPath)) {
     log(`screenshot → ${pngPath} (${statSync(pngPath).size} bytes)`);
   } else {
     log("screenshot failed (no file written)");
@@ -91,7 +86,7 @@ async function main() {
 
   const mp4Path = evidencePath(base, "mp4");
   log(`recording ${durationSec}s → ${mp4Path}`);
-  const recorded = await recordVideo(mp4Path, durationSec);
+  const recorded = await recordVideo(ffmpeg, mp4Path, durationSec);
   log(
     recorded
       ? `recording → ${mp4Path} (${statSync(mp4Path).size} bytes)`
@@ -102,7 +97,7 @@ async function main() {
   writeFileSync(
     infoPath,
     `[capture:${PLATFORM}] host=${process.platform}\n` +
-      `ffmpeg=${spawnSync("ffmpeg", ["-version"], { encoding: "utf8" }).stdout?.split("\n")[0] ?? "?"}\n`,
+      `ffmpeg=${spawnSync(ffmpeg, ["-version"], { encoding: "utf8" }).stdout?.split("\n")[0] ?? "?"}\n`,
     "utf8",
   );
   log(`info log → ${infoPath}`);

--- a/packages/app/scripts/lib/ffmpeg.mjs
+++ b/packages/app/scripts/lib/ffmpeg.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// Required ffmpeg resolution for evidence capture scripts. Capture lanes must
+// not go green without video simply because the host lacks ffmpeg, so this
+// helper resolves an explicit binary, a PATH binary, an installed static npm
+// binary, or installs the platform package before failing loudly.
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+
+const defaultRequire = createRequire(import.meta.url);
+
+export function createFfmpegResolver({
+  env = process.env,
+  execFileSync: execFileSyncDep = execFileSync,
+  existsSync: existsSyncDep = existsSync,
+  getuid = process.getuid?.bind(process),
+  platform = process.platform,
+  require: requireDep = defaultRequire,
+  spawnSync: spawnSyncDep = spawnSync,
+} = {}) {
+  function commandWorks(bin) {
+    return spawnSyncDep(bin, ["-version"], { stdio: "ignore" }).status === 0;
+  }
+
+  function bundledFfmpeg() {
+    try {
+      const mod = requireDep("ffmpeg-static");
+      return typeof mod === "string" && mod.length > 0 && existsSyncDep(mod)
+        ? mod
+        : null;
+    } catch {
+      // error-policy:J3 optional static package fallback; caller installs/fails.
+      return null;
+    }
+  }
+
+  function sudoPrefix() {
+    if (typeof getuid === "function" && getuid() === 0) return [];
+    const sudo = spawnSyncDep("sudo", ["-n", "true"], { stdio: "ignore" });
+    return sudo.status === 0 ? ["sudo"] : null;
+  }
+
+  function installLinux(log) {
+    if (
+      spawnSyncDep("apt-get", ["--version"], { stdio: "ignore" }).status !== 0
+    ) {
+      throw new Error(
+        "ffmpeg is required for evidence capture, apt-get is unavailable, and no bundled ffmpeg-static binary was found.",
+      );
+    }
+    const sudo = sudoPrefix();
+    if (sudo === null) {
+      throw new Error(
+        "ffmpeg is required for evidence capture, but apt-get needs sudo privileges. Install ffmpeg or rerun where sudo -n apt-get is allowed.",
+      );
+    }
+    log("ffmpeg missing; installing via apt-get.");
+    const command = sudo.length > 0 ? sudo[0] : "apt-get";
+    const prefix = sudo.length > 0 ? ["apt-get"] : [];
+    execFileSyncDep(command, [...prefix, "update"], { stdio: "inherit" });
+    execFileSyncDep(command, [...prefix, "install", "-y", "ffmpeg"], {
+      stdio: "inherit",
+    });
+  }
+
+  function installDarwin(log) {
+    if (spawnSyncDep("brew", ["--version"], { stdio: "ignore" }).status !== 0) {
+      throw new Error(
+        "ffmpeg is required for evidence capture, Homebrew is unavailable, and no bundled ffmpeg-static binary was found.",
+      );
+    }
+    log("ffmpeg missing; installing via Homebrew.");
+    execFileSyncDep("brew", ["install", "ffmpeg"], { stdio: "inherit" });
+  }
+
+  function installWindows(log) {
+    if (
+      spawnSyncDep("winget", ["--version"], { stdio: "ignore" }).status !== 0
+    ) {
+      throw new Error(
+        "ffmpeg is required for evidence capture, winget is unavailable, and no bundled ffmpeg-static binary was found.",
+      );
+    }
+    log("ffmpeg missing; installing via winget.");
+    execFileSyncDep(
+      "winget",
+      [
+        "install",
+        "-e",
+        "--id",
+        "Gyan.FFmpeg",
+        "--accept-source-agreements",
+        "--accept-package-agreements",
+      ],
+      { stdio: "inherit" },
+    );
+  }
+
+  function installForPlatform(log) {
+    if (platform === "linux") return installLinux(log);
+    if (platform === "darwin") return installDarwin(log);
+    if (platform === "win32") return installWindows(log);
+    throw new Error(
+      `ffmpeg is required for evidence capture, but automatic installation is unsupported on ${platform}.`,
+    );
+  }
+
+  return {
+    resolveRequiredFfmpeg({ log = () => {} } = {}) {
+      const explicit =
+        env.ELIZA_FFMPEG_BIN?.trim() ||
+        env.ELIZA_FFMPEG_PATH?.trim() ||
+        env.FFMPEG_PATH?.trim();
+      if (explicit) {
+        if (commandWorks(explicit)) return explicit;
+        throw new Error(`Configured ffmpeg is not invocable: ${explicit}`);
+      }
+
+      if (commandWorks("ffmpeg")) return "ffmpeg";
+
+      const bundled = bundledFfmpeg();
+      if (bundled && commandWorks(bundled)) return bundled;
+
+      installForPlatform(log);
+      if (commandWorks("ffmpeg")) return "ffmpeg";
+
+      const installedBundled = bundledFfmpeg();
+      if (installedBundled && commandWorks(installedBundled)) {
+        return installedBundled;
+      }
+
+      throw new Error(
+        "ffmpeg installation completed but ffmpeg is still not invocable.",
+      );
+    },
+  };
+}
+
+const defaultResolver = createFfmpegResolver();
+
+export function resolveRequiredFfmpeg(options) {
+  return defaultResolver.resolveRequiredFfmpeg(options);
+}

--- a/packages/app/scripts/lib/ffmpeg.test.mjs
+++ b/packages/app/scripts/lib/ffmpeg.test.mjs
@@ -1,0 +1,125 @@
+/**
+ * Exercises the evidence-capture ffmpeg resolver without touching the host
+ * package manager. The tests inject process and command dependencies so install
+ * decisions can be asserted deterministically.
+ */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createFfmpegResolver } from "./ffmpeg.mjs";
+
+function makeResolver({
+  env = {},
+  platform = "linux",
+  getuid = () => 0,
+  aptGet = true,
+  sudo = false,
+  bundled = null,
+  bundledExists = true,
+  bundledWorks = true,
+  ffmpegInitiallyWorks = false,
+} = {}) {
+  const execCalls = [];
+  const logMessages = [];
+  let ffmpegWorks = ffmpegInitiallyWorks;
+
+  const resolver = createFfmpegResolver({
+    env,
+    execFileSync(command, args) {
+      execCalls.push([command, args]);
+      if (args.includes("install") && args.includes("ffmpeg")) {
+        ffmpegWorks = true;
+      }
+    },
+    existsSync(candidate) {
+      return bundledExists && candidate === bundled;
+    },
+    getuid,
+    platform,
+    require(name) {
+      if (name !== "ffmpeg-static" || bundled === null) {
+        throw new Error(`missing ${name}`);
+      }
+      return bundled;
+    },
+    spawnSync(command, args) {
+      if (args[0] === "-version") {
+        if (command === "ffmpeg") return { status: ffmpegWorks ? 0 : 1 };
+        if (command === bundled) return { status: bundledWorks ? 0 : 1 };
+        if (command === env.ELIZA_FFMPEG_BIN) return { status: 0 };
+        return { status: 1 };
+      }
+      if (command === "apt-get" && args[0] === "--version") {
+        return { status: aptGet ? 0 : 1 };
+      }
+      if (command === "sudo" && args.join(" ") === "-n true") {
+        return { status: sudo ? 0 : 1 };
+      }
+      return { status: 1 };
+    },
+  });
+
+  return {
+    execCalls,
+    logMessages,
+    resolve() {
+      return resolver.resolveRequiredFfmpeg({
+        log(message) {
+          logMessages.push(message);
+        },
+      });
+    },
+  };
+}
+
+test("returns a configured invocable ffmpeg path", () => {
+  const { resolve } = makeResolver({
+    env: { ELIZA_FFMPEG_BIN: "/opt/ffmpeg" },
+  });
+
+  assert.equal(resolve(), "/opt/ffmpeg");
+});
+
+test("uses a bundled static binary before installing a system package", () => {
+  const { execCalls, resolve } = makeResolver({
+    bundled: "/cache/ffmpeg-static/ffmpeg",
+  });
+
+  assert.equal(resolve(), "/cache/ffmpeg-static/ffmpeg");
+  assert.deepEqual(execCalls, []);
+});
+
+test("installs ffmpeg with apt-get as root when no binary is available", () => {
+  const { execCalls, logMessages, resolve } = makeResolver();
+
+  assert.equal(resolve(), "ffmpeg");
+  assert.deepEqual(execCalls, [
+    ["apt-get", ["update"]],
+    ["apt-get", ["install", "-y", "ffmpeg"]],
+  ]);
+  assert.deepEqual(logMessages, ["ffmpeg missing; installing via apt-get."]);
+});
+
+test("installs ffmpeg with sudo apt-get when non-root sudo is available", () => {
+  const { execCalls, resolve } = makeResolver({
+    getuid: () => 1000,
+    sudo: true,
+  });
+
+  assert.equal(resolve(), "ffmpeg");
+  assert.deepEqual(execCalls, [
+    ["sudo", ["apt-get", "update"]],
+    ["sudo", ["apt-get", "install", "-y", "ffmpeg"]],
+  ]);
+});
+
+test("fails loudly when Linux install needs unavailable sudo", () => {
+  const { resolve } = makeResolver({ getuid: () => 1000 });
+
+  assert.throws(resolve, /apt-get needs sudo privileges/);
+});
+
+test("fails loudly on unsupported platforms", () => {
+  const { resolve } = makeResolver({ platform: "freebsd" });
+
+  assert.throws(resolve, /automatic installation is unsupported on freebsd/);
+});

--- a/packages/app/scripts/walkthrough-e2e.mjs
+++ b/packages/app/scripts/walkthrough-e2e.mjs
@@ -36,6 +36,7 @@ import {
 import { createServer } from "node:net";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveRequiredFfmpeg } from "./lib/ffmpeg.mjs";
 
 /** Pick a free localhost TCP port. The repo runs many concurrent ui-smoke
  * stacks (agent worktrees); the default 2138/31337 collide and silently break a
@@ -106,11 +107,6 @@ function loadEnvFile(file) {
     out[key] = val;
   }
   return out;
-}
-
-function which(bin) {
-  const r = spawnSync("which", [bin], { encoding: "utf8" });
-  return r.status === 0 ? r.stdout.trim() : null;
 }
 
 function run(cmd, args, opts = {}) {
@@ -583,46 +579,42 @@ async function main() {
   // 3) Stitch human-speed recordings.
   const stitched = [];
   if (!args.skipStitch) {
-    const ffmpeg = which("ffmpeg");
-    if (!ffmpeg) {
+    const ffmpeg = resolveRequiredFfmpeg({
+      log: (message) => console.log(`[walkthrough] ${message}`),
+    });
+    const outDir = join(
+      REPO_ROOT,
+      "e2e-recordings",
+      "app",
+      "walkthrough",
+      runId,
+    );
+    mkdirSync(outDir, { recursive: true });
+    const font = detectFont(ffmpeg);
+    if (!font)
       console.warn(
-        "[walkthrough] ffmpeg not found — skipping recording stitch (install ffmpeg to enable).",
+        "[walkthrough] ffmpeg lacks the drawtext filter — stitching paced frames without step captions.",
       );
-    } else {
-      const outDir = join(
-        REPO_ROOT,
-        "e2e-recordings",
-        "app",
-        "walkthrough",
+    for (const vp of args.viewports.split(",").map((v) => v.trim())) {
+      const s = await stitchViewport({
+        ffmpeg,
+        runDir,
+        viewport: vp,
+        outDir,
+        font,
+      });
+      if (s) stitched.push(s);
+    }
+    if (stitched.length) {
+      writeViewerHtml({
+        outDir,
+        runDir,
         runId,
-      );
-      mkdirSync(outDir, { recursive: true });
-      const font = detectFont(ffmpeg);
-      if (!font)
-        console.warn(
-          "[walkthrough] ffmpeg lacks the drawtext filter — stitching paced frames without step captions.",
-        );
-      for (const vp of args.viewports.split(",").map((v) => v.trim())) {
-        const s = await stitchViewport({
-          ffmpeg,
-          runDir,
-          viewport: vp,
-          outDir,
-          font,
-        });
-        if (s) stitched.push(s);
-      }
-      if (stitched.length) {
-        writeViewerHtml({
-          outDir,
-          runDir,
-          runId,
-          lane,
-          stitched,
-          verdictMdPath: verdictMd,
-        });
-        console.log(`[walkthrough] recordings → ${outDir}`);
-      }
+        lane,
+        stitched,
+        verdictMdPath: verdictMd,
+      });
+      console.log(`[walkthrough] recordings → ${outDir}`);
     }
   }
 

--- a/packages/evidence/src/ffmpeg-binaries.ts
+++ b/packages/evidence/src/ffmpeg-binaries.ts
@@ -9,6 +9,7 @@
 import { execFile } from "node:child_process";
 import fs from "node:fs";
 import { createRequire } from "node:module";
+import path from "node:path";
 import { promisify } from "node:util";
 
 const require = createRequire(import.meta.url);
@@ -20,6 +21,15 @@ interface ToolResolution {
   bin: string;
   source: "env" | "system" | "bundled";
 }
+
+interface BundledPathResult {
+  bin: string | null;
+  reason?: string;
+}
+
+let ffmpegStaticInstallPromise: Promise<
+  { installed: true } | { installed: false; reason: string }
+> | null = null;
 
 /** Whether a binary answers `-version`, with a reason when it does not. */
 async function binaryAvailable(
@@ -60,13 +70,73 @@ function requireFfmpegStaticPath(): string | null {
   return null;
 }
 
-function bundledFfmpegPath(): string | null {
-  const candidate = requireFfmpegStaticPath();
-  if (candidate === null) return null;
-  return fs.existsSync(candidate) ? candidate : null;
+function packageRoot(packageName: string): string | null {
+  try {
+    return path.dirname(require.resolve(packageName));
+  } catch (error) {
+    // error-policy:J3 optional packaged binary — absence is reported by caller.
+    void error;
+  }
+  return null;
 }
 
-function bundledFfprobePath(): string | null {
+function installFfmpegStaticOnce(): Promise<
+  { installed: true } | { installed: false; reason: string }
+> {
+  ffmpegStaticInstallPromise ??= (async () => {
+    const root = packageRoot("ffmpeg-static");
+    if (root === null) {
+      return {
+        installed: false,
+        reason: "ffmpeg-static package is not installed",
+      };
+    }
+
+    const installer = path.join(root, "install.js");
+    if (!fs.existsSync(installer)) {
+      return {
+        installed: false,
+        reason: "ffmpeg-static install script is missing",
+      };
+    }
+
+    try {
+      await execFileAsync(process.execPath, [installer], {
+        cwd: root,
+        timeout: 120_000,
+      });
+      return { installed: true };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        installed: false,
+        reason: `ffmpeg-static install failed: ${message.slice(0, 160)}`,
+      };
+    }
+  })();
+
+  return ffmpegStaticInstallPromise;
+}
+
+async function bundledFfmpegPath(): Promise<BundledPathResult> {
+  const candidate = requireFfmpegStaticPath();
+  if (candidate === null) return { bin: null };
+  if (fs.existsSync(candidate)) return { bin: candidate };
+
+  const installed = await installFfmpegStaticOnce();
+  if (!installed.installed) {
+    return { bin: null, reason: installed.reason };
+  }
+
+  return fs.existsSync(candidate)
+    ? { bin: candidate }
+    : {
+        bin: null,
+        reason: `ffmpeg-static install completed but ${candidate} is still missing`,
+      };
+}
+
+function bundledFfprobePath(): BundledPathResult {
   try {
     const mod = require("ffprobe-static") as { path?: string } | string;
     const candidate = typeof mod === "string" ? mod : mod.path;
@@ -75,13 +145,13 @@ function bundledFfprobePath(): string | null {
       candidate.length > 0 &&
       fs.existsSync(candidate)
     ) {
-      return candidate;
+      return { bin: candidate };
     }
   } catch (error) {
     // error-policy:J3 optional packaged binary — absence is reported by caller.
     void error;
   }
-  return null;
+  return { bin: null };
 }
 
 function configuredEnvPath(tool: ToolName): string | undefined {
@@ -90,7 +160,7 @@ function configuredEnvPath(tool: ToolName): string | undefined {
     : envPath(["ELIZA_FFPROBE_BIN", "ELIZA_FFPROBE_PATH", "FFPROBE_PATH"]);
 }
 
-function bundledPath(tool: ToolName): string | null {
+async function bundledPath(tool: ToolName): Promise<BundledPathResult> {
   return tool === "ffmpeg" ? bundledFfmpegPath() : bundledFfprobePath();
 }
 
@@ -123,13 +193,13 @@ async function resolveTool(
     };
   }
 
-  const bundled = bundledPath(tool);
-  if (bundled !== null) {
-    const available = await binaryAvailable(bundled);
+  const bundled = await bundledPath(tool);
+  if (bundled.bin !== null) {
+    const available = await binaryAvailable(bundled.bin);
     if (available.available) {
       return {
         available: true,
-        resolution: { bin: bundled, source: "bundled" },
+        resolution: { bin: bundled.bin, source: "bundled" },
       };
     }
     return {
@@ -140,7 +210,9 @@ async function resolveTool(
 
   return {
     available: false,
-    reason: `${tool} not found on PATH and bundled ${tool}-static package is unavailable`,
+    reason: bundled.reason
+      ? `${tool} not found on PATH and bundled ${tool}-static package is unavailable: ${bundled.reason}`
+      : `${tool} not found on PATH and bundled ${tool}-static package is unavailable`,
   };
 }
 

--- a/packages/evidence/src/video/normalize.test.ts
+++ b/packages/evidence/src/video/normalize.test.ts
@@ -121,7 +121,7 @@ describe("normalizeVideo degradation", () => {
         expect(ffprobe.source).toBe("bundled");
       } else {
         expect(ffprobe.reason).toMatch(
-          /ffprobe not found on PATH and bundled ffprobe-static package is unavailable/,
+          /ffprobe (not found on PATH and bundled ffprobe-static package is unavailable|system binary missing and bundled binary failed)/,
         );
       }
 
@@ -138,7 +138,7 @@ describe("normalizeVideo degradation", () => {
       restoreEnv("ELIZA_FFMPEG_BIN", prevFfmpeg);
       restoreEnv("ELIZA_FFPROBE_BIN", prevFfprobe);
     }
-  });
+  }, 150_000);
 
   it("skips honestly when ffprobe/ffmpeg are absent", async () => {
     const prevFfmpeg = process.env.ELIZA_FFMPEG_BIN;


### PR DESCRIPTION
## Summary
- Repair the evidence video ffmpeg resolver when the bundled `ffmpeg-static` package is installed but its platform binary is missing.
- Add required app-side ffmpeg resolution for walkthrough and desktop capture scripts: env/PATH, bundled static package when available, then platform package-manager install before failing loudly.
- Stop treating missing ffmpeg as a green capture skip on target desktop platforms; video evidence is now required once the capture lane is applicable.

## Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - evidence/capture tooling only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - evidence/capture tooling only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this PR changes video evidence generation infrastructure; no user-facing flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact: evidence/capture scripts now resolve or install ffmpeg instead of silently skipping video output when the lane is applicable.

## Verification
Rebased branch `fix/evidence-ffmpeg-auto-install` onto current `origin/develop` (`c447a203b33`) and force-pushed commit `2814eb5cde7`.

```bash
bun test packages/evidence/src/video/normalize.test.ts
bun test packages/app/scripts/lib/ffmpeg.test.mjs
node --test packages/app/scripts/lib/ffmpeg.test.mjs
node -e "import('./packages/app/scripts/lib/ffmpeg.mjs').then(({resolveRequiredFfmpeg}) => console.log(resolveRequiredFfmpeg()))"
bunx @biomejs/biome check packages/evidence/src/ffmpeg-binaries.ts packages/evidence/src/video/normalize.test.ts packages/app/scripts/lib/ffmpeg.mjs packages/app/scripts/lib/ffmpeg.test.mjs packages/app/scripts/walkthrough-e2e.mjs packages/app/scripts/capture-linux-desktop.mjs packages/app/scripts/capture-windows-desktop.mjs packages/app/scripts/capture-macos-desktop.mjs
bun run --cwd packages/evidence typecheck
node --check packages/app/scripts/lib/ffmpeg.mjs
node --check packages/app/scripts/walkthrough-e2e.mjs
node --check packages/app/scripts/capture-linux-desktop.mjs
node --check packages/app/scripts/capture-windows-desktop.mjs
node --check packages/app/scripts/capture-macos-desktop.mjs
git diff --check
```

Observed locally:
- `normalize.test.ts`: 7 pass, 0 fail.
- `ffmpeg.test.mjs`: 6 pass, 0 fail under both `bun test` and `node --test`.
- Runtime resolver smoke printed `ffmpeg` on this host.
- Targeted Biome check passed.
- `packages/evidence typecheck` passed.
- Node syntax checks passed.
- `git diff --check` passed.

## Known gaps / failures
- Full repo `bun run verify` was not run in this pass; this branch is scoped to evidence/capture ffmpeg resolution and the focused tests/checks above cover the changed behavior.