### PR TITLE
feat(core): passive user-preference evaluator closes the personality behavior loop

### DIFF
--- a/packages/core/src/features/advanced-capabilities/evaluators/index.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/index.ts
@@ -7,6 +7,10 @@
  */
 
 export {
+	preferenceEvaluator,
+	preferenceItems,
+} from "./preference-items.ts";
+export {
 	factMemoryEvaluator,
 	identityEvaluator,
 	reflectionItems,
@@ -28,6 +32,10 @@ import { anchorBundleSafety } from "../../../bundle-safety.ts";
 // into an empty `init_X = () => {}`. Without this the on-device
 // mobile agent explodes with `ReferenceError: <name> is not defined`
 // when a consumer dereferences a re-exported binding at runtime.
+import {
+	preferenceEvaluator as _bs_10_preferenceEvaluator,
+	preferenceItems as _bs_11_preferenceItems,
+} from "./preference-items.ts";
 import {
 	factMemoryEvaluator as _bs_1_factMemoryEvaluator,
 	identityEvaluator as _bs_2_identityEvaluator,
@@ -52,4 +60,6 @@ anchorBundleSafety("FEATURES_ADVANCED_CAPABILITIES_EVALUATORS_INDEX", [
 	_bs_7_skillItems,
 	_bs_8_skillProposalEvaluator,
 	_bs_9_skillRefinementEvaluator,
+	_bs_10_preferenceEvaluator,
+	_bs_11_preferenceItems,
 ]);

--- a/packages/core/src/features/advanced-capabilities/evaluators/preference-items.test.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/preference-items.test.ts
@@ -1,0 +1,582 @@
+/**
+ * Deterministic unit tests for the passive preference evaluator
+ * (preference-items.ts): tolerant op parsing (trait/value pairing, reply_gate
+ * unrepresentability, directive cap), the processor's write policy against a
+ * REAL PersonalityStore (never-overwrite-explicit, same-run escalation guard,
+ * confidence gating, directive dedupe, retract-only-inferred), durable
+ * preference-fact row shape and update-not-duplicate, and the gates/prompt
+ * degrade when the store is absent. Model output is stubbed at the parse
+ * boundary — no live model; the store and fact-write path are real
+ * (in-memory FakeRuntime).
+ */
+import { describe, expect, it, vi } from "vitest";
+import { logger } from "../../../logger.ts";
+import type {
+	EvaluatorProcessorContext,
+	Memory,
+	State,
+	UUID,
+} from "../../../types/index.ts";
+import type { FakeRuntime } from "../personality/__tests__/test-helpers.ts";
+import { makeFakeRuntime } from "../personality/__tests__/test-helpers.ts";
+import {
+	type PreferencePrepared,
+	preferenceEvaluator,
+} from "./preference-items.ts";
+import {
+	type PreferenceExtractorOutput,
+	parsePreferenceOutputTolerant,
+} from "./preferenceExtractor.schema.ts";
+
+const AGENT = "00000000-0000-4000-8000-0000000000aa" as UUID;
+const USER = "00000000-0000-4000-8000-0000000000ab" as UUID;
+const ROOM = "00000000-0000-4000-8000-0000000000ac" as UUID;
+
+const EMPTY_STATE: State = { values: {}, data: {}, text: "" };
+
+function makeMessage(text = "honestly that reply was way too long"): Memory {
+	return {
+		id: "00000000-0000-4000-8000-0000000000ad" as UUID,
+		entityId: USER,
+		agentId: AGENT,
+		roomId: ROOM,
+		content: { text },
+		createdAt: Date.now(),
+	};
+}
+
+function mustParse(raw: unknown): PreferenceExtractorOutput {
+	const parsed = parsePreferenceOutputTolerant(raw);
+	if (!parsed) throw new Error("expected a parseable preference envelope");
+	return parsed;
+}
+
+function preferenceFact(id: string, text: string, keywords: string[]): Memory {
+	return {
+		id: id as UUID,
+		entityId: USER,
+		agentId: AGENT,
+		roomId: ROOM,
+		content: { text },
+		metadata: {
+			kind: "durable",
+			category: "preference",
+			confidence: 0.7,
+			keywords,
+		},
+		createdAt: Date.now(),
+	};
+}
+
+function processOps(
+	fake: FakeRuntime,
+	output: PreferenceExtractorOutput,
+	prepared: Partial<PreferencePrepared> = {},
+) {
+	const processor = preferenceEvaluator.processors?.[0];
+	if (!processor) throw new Error("missing preference processor");
+	const context: EvaluatorProcessorContext<
+		PreferenceExtractorOutput,
+		PreferencePrepared
+	> = {
+		runtime: fake.runtime,
+		message: makeMessage(),
+		state: EMPTY_STATE,
+		options: {},
+		evaluatorName: "preferences",
+		prepared: {
+			recentMessages: [],
+			slot: null,
+			knownPreferenceFacts: [],
+			...prepared,
+		},
+		output,
+	};
+	return processor.process(context);
+}
+
+describe("preference extractor tolerant parsing", () => {
+	it("keeps one valid op of each kind", () => {
+		const parsed = parsePreferenceOutputTolerant({
+			ops: [
+				{
+					op: "set_trait",
+					trait: "verbosity",
+					value: "terse",
+					confidence: 0.9,
+				},
+				{ op: "add_directive", text: "no emojis", confidence: 0.85 },
+				{
+					op: "add_preference_fact",
+					claim: "prefers the dark background",
+					keywords: ["dark", "background", "theme"],
+				},
+				{ op: "retract_trait", trait: "tone" },
+			],
+		});
+		expect(parsed?.ops.map((o) => o.op)).toEqual([
+			"set_trait",
+			"add_directive",
+			"add_preference_fact",
+			"retract_trait",
+		]);
+	});
+
+	it("drops a trait/value mismatch without discarding the rest, and warns", () => {
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const parsed = parsePreferenceOutputTolerant({
+				ops: [
+					// "warm" is a tone value, not a verbosity value.
+					{
+						op: "set_trait",
+						trait: "verbosity",
+						value: "warm",
+						confidence: 0.9,
+					},
+					{ op: "set_trait", trait: "tone", value: "warm", confidence: 0.9 },
+				],
+			});
+			expect(parsed?.ops).toHaveLength(1);
+			expect(parsed?.ops[0]).toMatchObject({ trait: "tone", value: "warm" });
+			expect(warnSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					src: "preferences",
+					count: 1,
+					issues: [expect.stringContaining("verbosity")],
+				}),
+				"dropped malformed preference op(s)",
+			);
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
+	it("cannot represent a reply_gate write — the trait enum rejects it", () => {
+		const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+		try {
+			const parsed = parsePreferenceOutputTolerant({
+				ops: [
+					{
+						op: "set_trait",
+						trait: "reply_gate",
+						value: "never_until_lift",
+						confidence: 1,
+					},
+				],
+			});
+			expect(parsed?.ops).toHaveLength(0);
+			expect(warnSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
+	it("caps directive text at 200 chars in code, not on the wire", () => {
+		const parsed = mustParse({
+			ops: [{ op: "add_directive", text: "x".repeat(500), confidence: 0.9 }],
+		});
+		const op = parsed.ops[0];
+		expect(op.op).toBe("add_directive");
+		if (op.op === "add_directive") expect(op.text).toHaveLength(200);
+	});
+
+	it("returns null only when the envelope itself is not { ops: array }", () => {
+		expect(parsePreferenceOutputTolerant({ nope: true })).toBeNull();
+		expect(parsePreferenceOutputTolerant(null)).toBeNull();
+		// Zero ops is a valid no-preference turn, not a parse failure.
+		expect(parsePreferenceOutputTolerant({ ops: [] })).toEqual({ ops: [] });
+	});
+});
+
+describe("applyPreferenceOps trait policy", () => {
+	it("applies a high-confidence trait with agent_inferred provenance and an audit entry", async () => {
+		const fake = makeFakeRuntime({ agentId: AGENT });
+		const result = await processOps(
+			fake,
+			mustParse({
+				ops: [
+					{
+						op: "set_trait",
+						trait: "verbosity",
+						value: "terse",
+						confidence: 0.9,
+					},
+				],
+			}),
+		);
+		const slot = fake.store.getSlot(USER, AGENT);
+		expect(slot.verbosity).toBe("terse");
+		expect(slot.source).toBe("agent_inferred");
+		expect(fake.store.getRecentAudit()[0]?.action).toBe(
+			"set_trait:verbosity=terse",
+		);
+		expect(result?.data).toMatchObject({ traitsSet: 1 });
+	});
+
+	it("discards a trait below the 0.8 confidence gate", async () => {
+		const fake = makeFakeRuntime({ agentId: AGENT });
+		const result = await processOps(
+			fake,
+			mustParse({
+				ops: [
+					{
+						op: "set_trait",
+						trait: "verbosity",
+						value: "terse",
+						confidence: 0.79,
+					},
+				],
+			}),
+		);
+		expect(fake.store.getSlot(USER, AGENT).verbosity).toBeNull();
+		expect(result?.data).toMatchObject({ traitsSet: 0, skipped: 1 });
+	});
+
+	it("never overwrites an explicitly-set trait, even at confidence 1", async () => {
+		const fake = makeFakeRuntime({ agentId: AGENT });
+		fake.store.applyTrait({
+			scope: "user",
+			userId: USER,
+			agentId: AGENT,
+			actorId: USER,
+			trait: "tone",
+			value: "warm",
+		});
+		const result = await processOps(
+			fake,
+			mustParse({
+				ops: [{ op: "set_trait", trait: "tone", value: "cold", confidence: 1 }],
+			}),
+		);
+		const slot = fake.store.getSlot(USER, AGENT);
+		expect(slot.tone).toBe("warm");
+		expect(slot.source).toBe("user");
+		expect(result?.data).toMatchObject({ traitsSet: 0, skipped: 1 });
+	});
+
+	it("may overwrite a previously inferred trait", async () => {
+		const fake = makeFakeRuntime({ agentId: AGENT });
+		fake.store.applyTrait({
+			scope: "user",
+			userId: USER,
+			agentId: AGENT,
+			actorId: AGENT,
+			trait: "verbosity",
+			value: "normal",
+			source: "agent_inferred",
+		});
+		await processOps(
+			fake,
+			mustParse({
+				ops: [
+					{
+						op: "set_trait",
+						trait: "verbosity",
+						value: "verbose",
+						confidence: 0.9,
+					},
+				],
+			}),
+		);
+		expect(fake.store.getSlot(USER, AGENT).verbosity).toBe("verbose");
+	});
+
+	it("gates every trait op against the pre-run slot: one inferred write cannot unlock overwriting an explicit trait in the same run", async () => {
+		const fake = makeFakeRuntime({ agentId: AGENT });
+		fake.store.applyTrait({
+			scope: "user",
+			userId: USER,
+			agentId: AGENT,
+			actorId: USER,
+			trait: "tone",
+			value: "warm",
+		});
+		const result = await processOps(
+			fake,
+			mustParse({
+				ops: [
+					// This null-trait fill flips slot.source to agent_inferred...
+					{
+						op: "set_trait",
+						trait: "verbosity",
+						value: "terse",
+						confidence: 0.9,
+					},
+					// ...which must NOT let this op overwrite the explicit tone.
+					{ op: "set_trait", trait: "tone", value: "cold", confidence: 0.95 },
+				],
+			}),
+		);
+		const slot = fake.store.getSlot(USER, AGENT);
+		expect(slot.verbosity).toBe("terse");
+		expect(slot.tone).toBe("warm");
+		expect(result?.data).toMatchObject({ traitsSet: 1, skipped: 1 });
+	});
+
+	it("retracts an inferred trait but never an explicit one", async () => {
+		const inferred = makeFakeRuntime({ agentId: AGENT });
+		inferred.store.applyTrait({
+			scope: "user",
+			userId: USER,
+			agentId: AGENT,
+			actorId: AGENT,
+			trait: "verbosity",
+			value: "terse",
+			source: "agent_inferred",
+		});
+		await processOps(
+			inferred,
+			mustParse({ ops: [{ op: "retract_trait", trait: "verbosity" }] }),
+		);
+		expect(inferred.store.getSlot(USER, AGENT).verbosity).toBeNull();
+
+		const explicit = makeFakeRuntime({ agentId: AGENT });
+		explicit.store.applyTrait({
+			scope: "user",
+			userId: USER,
+			agentId: AGENT,
+			actorId: USER,
+			trait: "verbosity",
+			value: "terse",
+		});
+		const result = await processOps(
+			explicit,
+			mustParse({ ops: [{ op: "retract_trait", trait: "verbosity" }] }),
+		);
+		expect(explicit.store.getSlot(USER, AGENT).verbosity).toBe("terse");
+		expect(result?.data).toMatchObject({ traitsRetracted: 0, skipped: 1 });
+	});
+});
+
+describe("applyPreferenceOps directives", () => {
+	it("adds a directive with agent_inferred provenance", async () => {
+		const fake = makeFakeRuntime({ agentId: AGENT });
+		await processOps(
+			fake,
+			mustParse({
+				ops: [
+					{
+						op: "add_directive",
+						text: "one question at a time",
+						confidence: 0.9,
+					},
+				],
+			}),
+		);
+		const slot = fake.store.getSlot(USER, AGENT);
+		expect(slot.custom_directives).toEqual(["one question at a time"]);
+		expect(slot.source).toBe("agent_inferred");
+	});
+
+	it("dedupes a lexically similar directive instead of appending a near-copy", async () => {
+		const fake = makeFakeRuntime({ agentId: AGENT });
+		fake.store.addDirective({
+			userId: USER,
+			agentId: AGENT,
+			actorId: USER,
+			directive: "no emojis in replies",
+		});
+		const result = await processOps(
+			fake,
+			mustParse({
+				ops: [{ op: "add_directive", text: "avoid emojis", confidence: 0.9 }],
+			}),
+		);
+		expect(fake.store.getSlot(USER, AGENT).custom_directives).toEqual([
+			"no emojis in replies",
+		]);
+		expect(result?.data).toMatchObject({ directivesAdded: 0, skipped: 1 });
+	});
+});
+
+describe("applyPreferenceOps preference facts", () => {
+	it("writes a durable preference fact row with extractor provenance", async () => {
+		const fake = makeFakeRuntime({ agentId: AGENT });
+		const result = await processOps(
+			fake,
+			mustParse({
+				ops: [
+					{
+						op: "add_preference_fact",
+						claim: "prefers the dark background in the app",
+						keywords: ["dark", "background", "theme"],
+					},
+				],
+			}),
+		);
+		const rows = fake.memories.get("facts") ?? [];
+		expect(rows).toHaveLength(1);
+		expect(rows[0].content.text).toBe("prefers the dark background in the app");
+		expect(rows[0].entityId).toBe(USER);
+		expect(rows[0].metadata).toMatchObject({
+			kind: "durable",
+			category: "preference",
+			source: "preference_extractor",
+			verificationStatus: "self_reported",
+		});
+		expect((rows[0].metadata as { keywords?: string[] }).keywords).toEqual(
+			expect.arrayContaining(["dark", "background"]),
+		);
+		expect(result?.data).toMatchObject({ factsAdded: 1 });
+	});
+
+	it("strengthens an existing similar preference instead of duplicating it", async () => {
+		const fake = makeFakeRuntime({ agentId: AGENT });
+		const existing = preferenceFact(
+			"00000000-0000-4000-8000-0000000000af",
+			"the user prefers morning check-ins",
+			["morning", "check", "ins"],
+		);
+		fake.memories.set("facts", [existing]);
+		const result = await processOps(
+			fake,
+			mustParse({
+				ops: [
+					{
+						op: "add_preference_fact",
+						claim: "prefers morning check-ins",
+						keywords: ["morning", "check-ins"],
+					},
+				],
+			}),
+			{ knownPreferenceFacts: [existing] },
+		);
+		const rows = fake.memories.get("facts") ?? [];
+		expect(rows).toHaveLength(1);
+		expect(
+			(rows[0].metadata as { confidence?: number }).confidence,
+		).toBeCloseTo(0.8);
+		expect(result?.data).toMatchObject({ factsAdded: 0, factsStrengthened: 1 });
+	});
+
+	it("dedupes against a fact inserted earlier in the same run", async () => {
+		const fake = makeFakeRuntime({ agentId: AGENT });
+		const result = await processOps(
+			fake,
+			mustParse({
+				ops: [
+					{
+						op: "add_preference_fact",
+						claim: "prefers morning check-ins",
+						keywords: ["morning", "check-ins"],
+					},
+					{
+						op: "add_preference_fact",
+						claim: "the user prefers morning check-ins",
+						keywords: ["morning", "check-ins"],
+					},
+				],
+			}),
+		);
+		expect(fake.memories.get("facts") ?? []).toHaveLength(1);
+		expect(result?.data).toMatchObject({ factsAdded: 1, factsStrengthened: 1 });
+	});
+});
+
+describe("applyPreferenceOps boundaries", () => {
+	it("no preference means no write anywhere", async () => {
+		const fake = makeFakeRuntime({ agentId: AGENT });
+		const result = await processOps(fake, mustParse({ ops: [] }));
+		expect(fake.memories.get("facts") ?? []).toHaveLength(0);
+		const slot = fake.store.getSlot(USER, AGENT);
+		expect(slot.verbosity).toBeNull();
+		expect(slot.custom_directives).toEqual([]);
+		expect(fake.store.getRecentAudit()).toHaveLength(0);
+		expect(result?.data).toMatchObject({ traitsSet: 0, factsAdded: 0 });
+	});
+
+	it("without the PersonalityStore, the fact lane still lands and slot ops are dropped", async () => {
+		const fake = makeFakeRuntime({ agentId: AGENT });
+		(fake.runtime as unknown as { getService: () => null }).getService = () =>
+			null;
+		const result = await processOps(
+			fake,
+			mustParse({
+				ops: [
+					{
+						op: "set_trait",
+						trait: "verbosity",
+						value: "terse",
+						confidence: 0.9,
+					},
+					{
+						op: "add_preference_fact",
+						claim: "prefers the dark background",
+						keywords: ["dark", "background"],
+					},
+				],
+			}),
+		);
+		expect(fake.memories.get("facts") ?? []).toHaveLength(1);
+		expect(result?.data).toMatchObject({ factsAdded: 1, droppedNoStore: 1 });
+	});
+});
+
+describe("preferenceEvaluator gates and prompt", () => {
+	it("shouldRun accepts a user message and rejects the agent's own or empty messages", async () => {
+		const fake = makeFakeRuntime({ agentId: AGENT });
+		const base = { runtime: fake.runtime, options: {} };
+		await expect(
+			preferenceEvaluator.shouldRun({ ...base, message: makeMessage() }),
+		).resolves.toBe(true);
+		await expect(
+			preferenceEvaluator.shouldRun({
+				...base,
+				message: { ...makeMessage(), entityId: AGENT },
+			}),
+		).resolves.toBe(false);
+		await expect(
+			preferenceEvaluator.shouldRun({
+				...base,
+				message: { ...makeMessage(), content: { text: "   " } },
+			}),
+		).resolves.toBe(false);
+	});
+
+	it("prompt shows current slot state and stored preferences", () => {
+		const fake = makeFakeRuntime({ agentId: AGENT });
+		const prompt = preferenceEvaluator.prompt({
+			runtime: fake.runtime,
+			message: makeMessage(),
+			state: EMPTY_STATE,
+			options: {},
+			prepared: {
+				recentMessages: [makeMessage("please keep it short")],
+				slot: {
+					...fake.store.getSlot(USER, AGENT),
+					verbosity: "terse",
+					custom_directives: ["no emojis"],
+					source: "agent_inferred",
+				},
+				knownPreferenceFacts: [
+					preferenceFact(
+						"00000000-0000-4000-8000-0000000000af",
+						"prefers morning check-ins",
+						["morning"],
+					),
+				],
+			},
+		});
+		expect(prompt).toContain("set_trait");
+		expect(prompt).toContain("verbosity: terse");
+		expect(prompt).toContain("no emojis");
+		expect(prompt).toContain("last set by: agent_inferred");
+		expect(prompt).toContain("prefers morning check-ins");
+		expect(prompt).toContain("please keep it short");
+	});
+
+	it("prompt stops advertising slot ops when the store is unavailable", () => {
+		const fake = makeFakeRuntime({ agentId: AGENT });
+		const prompt = preferenceEvaluator.prompt({
+			runtime: fake.runtime,
+			message: makeMessage(),
+			state: EMPTY_STATE,
+			options: {},
+			prepared: { recentMessages: [], slot: null, knownPreferenceFacts: [] },
+		});
+		expect(prompt).not.toContain("set_trait");
+		expect(prompt).not.toContain("add_directive");
+		expect(prompt).toContain("add_preference_fact");
+	});
+});

--- a/packages/core/src/features/advanced-capabilities/evaluators/preference-items.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/preference-items.ts
@@ -1,0 +1,518 @@
+/**
+ * Passive user-preference extraction evaluator (`preferences`) — the
+ * conversational writer for the personality behavior loop (#14675). Runs
+ * post-response beside the reflection evaluators and extracts, via one
+ * strict-JSON-schema model call, preferences the user expressed in passing
+ * ("ugh, that was way too long", "no emojis please", "I prefer morning
+ * check-ins") — zero explicit input required.
+ *
+ * Writes route to the store that can already act on each kind, so no new
+ * store or provider exists here. Closed-enum reply-style traits and custom
+ * directives go to the PersonalityStore slot with source "agent_inferred";
+ * `userPersonalityProvider` re-injects them into every prompt and verbosity is
+ * hard-enforced in the reply callback. Domain / view / interaction-pattern
+ * preferences land as durable `preference` facts in the facts table, consumed
+ * by the FACTS provider and downstream systems (LifeOps scheduling, view
+ * actions) exactly like fact-extractor rows.
+ *
+ * Safety invariants: inference never overwrites an explicitly-set trait (slot
+ * source "user"/"admin" — explicit beats inferred), never touches `reply_gate`
+ * (silencing the agent off an inferred signal is a hazard; the op is not even
+ * representable in the schema), and never writes global scope. Trait gates are
+ * evaluated against the slot snapshot taken before any write this run, so one
+ * inferred write cannot unlock overwriting an explicit trait in the same run.
+ * Slot provenance is slot-level, not per-trait, so an inferred write marks the
+ * whole slot "agent_inferred"; per-trait provenance is deferred to the slot
+ * persistence work (#14674). On runtimes without the PersonalityStore service
+ * (advanced capabilities off), the fact lane still works and slot ops are
+ * dropped with a debug log — the counters in the processor result record it.
+ */
+import { v4 } from "uuid";
+import { logger } from "../../../logger.ts";
+import { EvaluatorPriority } from "../../../services/evaluator-priorities.ts";
+import type {
+	Evaluator,
+	IAgentRuntime,
+	JSONSchema,
+	Memory,
+	MemoryMetadata,
+	RegisteredEvaluator,
+	UUID,
+} from "../../../types/index.ts";
+import { asUUID } from "../../../types/index.ts";
+import type { CustomMetadata, FactMetadata } from "../../../types/memory.ts";
+import { MemoryType } from "../../../types/memory.ts";
+import { isSyntheticConversationArtifactMemory } from "../../../utils/synthetic-conversation-artifact.ts";
+import {
+	buildFactKeywordsForStorage,
+	buildFactSearchText,
+	factLexicalSimilarity,
+	readStoredFactKeywords,
+} from "../fact-keywords.ts";
+import {
+	getPersonalityStore,
+	type PersonalityStore,
+} from "../personality/services/personality-store.ts";
+import {
+	FORMALITY_VALUES,
+	type PersonalitySlot,
+	TONE_VALUES,
+	TRAIT_VALUES,
+	VERBOSITY_VALUES,
+} from "../personality/types.ts";
+import {
+	type AddDirectiveOp,
+	type AddPreferenceFactOp,
+	type PreferenceExtractorOutput,
+	parsePreferenceOutputTolerant,
+	type RetractTraitOp,
+	type SetTraitOp,
+} from "./preferenceExtractor.schema.ts";
+import {
+	canEvaluateMessage,
+	DEDUP_SIMILARITY_THRESHOLD,
+	formatRecentMessages,
+	NEW_FACT_CONFIDENCE,
+	preserveFactMetadata,
+	STRENGTHEN_DELTA,
+} from "./reflection-items.ts";
+
+const RECENT_MESSAGES_LIMIT = 10;
+const PREFERENCE_FACT_LOOKBACK = 60;
+const MAX_KNOWN_PREFERENCES = 15;
+// Slot writes shape EVERY subsequent prompt for this user (and verbosity is
+// hard-enforced post-generation), so only high-confidence signals may touch
+// the PersonalityStore. Preference facts have no gate — they go through the
+// same dedupe/strengthen discipline as fact-extractor rows and only surface
+// via ranked retrieval.
+const SLOT_CONFIDENCE_THRESHOLD = 0.8;
+
+const preferenceOpsSchema: JSONSchema = {
+	type: "object",
+	properties: {
+		ops: {
+			type: "array",
+			items: {
+				type: "object",
+				properties: {
+					op: {
+						type: "string",
+						enum: [
+							"set_trait",
+							"add_directive",
+							"add_preference_fact",
+							"retract_trait",
+						],
+					},
+					trait: { type: "string", enum: [...TRAIT_VALUES] },
+					// One flat enum across all three traits: a per-trait value union
+					// is not expressible under the strict structured-output invariants
+					// (see reflection-items.ts header). Trait/value pairing is
+					// validated in parsePreferenceOutputTolerant instead.
+					value: {
+						type: "string",
+						enum: [...VERBOSITY_VALUES, ...TONE_VALUES, ...FORMALITY_VALUES],
+					},
+					confidence: { type: "number" },
+					evidence: { type: "string" },
+					text: { type: "string" },
+					claim: { type: "string" },
+					// No maxItems: strict structured-output validators reject array
+					// length constraints — the 16-keyword cap is enforced in code.
+					keywords: {
+						type: "array",
+						items: { type: "string" },
+					},
+					reason: { type: "string" },
+				},
+				required: ["op"],
+				additionalProperties: false,
+			},
+		},
+	},
+	required: ["ops"],
+	additionalProperties: false,
+};
+
+export interface PreferencePrepared {
+	recentMessages: Memory[];
+	/** Null when the PersonalityStore service is not registered. */
+	slot: PersonalitySlot | null;
+	knownPreferenceFacts: Memory[];
+}
+
+function nowIso(): string {
+	return new Date().toISOString();
+}
+
+function clamp01(value: number): number {
+	if (!Number.isFinite(value)) return 0;
+	if (value < 0) return 0;
+	if (value > 1) return 1;
+	return value;
+}
+
+function readFactMetadata(memory: Memory): FactMetadata {
+	const meta = memory.metadata;
+	if (!meta || typeof meta !== "object" || Array.isArray(meta)) return {};
+	return meta as FactMetadata;
+}
+
+function isDurablePreferenceFact(memory: Memory): boolean {
+	const meta = readFactMetadata(memory);
+	return meta.category === "preference" && meta.kind !== "current";
+}
+
+function pickFactConfidence(memory: Memory): number {
+	const value = readFactMetadata(memory).confidence;
+	if (typeof value === "number" && Number.isFinite(value)) return value;
+	return NEW_FACT_CONFIDENCE;
+}
+
+async function preparePreferences(
+	runtime: IAgentRuntime,
+	message: Memory,
+): Promise<PreferencePrepared> {
+	const [recentMessagesRaw, entityFacts] = await Promise.all([
+		runtime.getMemories({
+			tableName: "messages",
+			roomId: message.roomId,
+			limit: RECENT_MESSAGES_LIMIT,
+			unique: false,
+		}),
+		runtime.getMemories({
+			tableName: "facts",
+			roomId: message.roomId,
+			entityId: message.entityId,
+			limit: PREFERENCE_FACT_LOOKBACK,
+			unique: false,
+		}),
+	]);
+	const recentMessages = recentMessagesRaw.filter(
+		(memory) => !isSyntheticConversationArtifactMemory(memory),
+	);
+	const knownPreferenceFacts = entityFacts.filter(isDurablePreferenceFact);
+	const store = getPersonalityStore(runtime);
+	return {
+		recentMessages,
+		slot: store ? store.getSlot(message.entityId) : null,
+		knownPreferenceFacts,
+	};
+}
+
+function formatSlotForPrompt(slot: PersonalitySlot | null): string {
+	if (!slot) return "(personality slot store unavailable)";
+	const lines: string[] = [];
+	if (slot.verbosity) lines.push(`- verbosity: ${slot.verbosity}`);
+	if (slot.tone) lines.push(`- tone: ${slot.tone}`);
+	if (slot.formality) lines.push(`- formality: ${slot.formality}`);
+	slot.custom_directives.forEach((directive, index) => {
+		lines.push(`- directive ${index + 1}: ${directive}`);
+	});
+	if (lines.length === 0) return "(none set)";
+	lines.push(`- last set by: ${slot.source}`);
+	return lines.join("\n");
+}
+
+function formatKnownPreferences(facts: Memory[]): string {
+	const lines: string[] = [];
+	for (const fact of facts.slice(0, MAX_KNOWN_PREFERENCES)) {
+		const text = fact.content.text ?? "";
+		if (text) lines.push(`- ${text}`);
+	}
+	return lines.length > 0 ? lines.join("\n") : "(none)";
+}
+
+type SlotOpOutcome =
+	| "applied"
+	| "unchanged"
+	| "skipped_low_confidence"
+	| "skipped_explicit";
+
+/**
+ * Gate reads `gateSlot` — the pre-run snapshot — never the live slot: writing
+ * an inferred trait flips the whole slot's source to "agent_inferred" (slot
+ * provenance is not per-trait), and gating on the live slot would let that
+ * first write unlock overwriting an explicitly-set trait later in the same run.
+ */
+function applySetTrait(
+	store: PersonalityStore,
+	runtime: IAgentRuntime,
+	userId: UUID,
+	gateSlot: PersonalitySlot,
+	op: SetTraitOp,
+): SlotOpOutcome {
+	if (op.confidence < SLOT_CONFIDENCE_THRESHOLD)
+		return "skipped_low_confidence";
+	const current = gateSlot[op.trait];
+	if (current === op.value) return "unchanged";
+	if (current !== null && gateSlot.source !== "agent_inferred") {
+		return "skipped_explicit";
+	}
+	store.applyTrait({
+		scope: "user",
+		userId,
+		agentId: runtime.agentId,
+		actorId: runtime.agentId,
+		trait: op.trait,
+		value: op.value,
+		source: "agent_inferred",
+	});
+	return "applied";
+}
+
+function applyRetractTrait(
+	store: PersonalityStore,
+	runtime: IAgentRuntime,
+	userId: UUID,
+	gateSlot: PersonalitySlot,
+	op: RetractTraitOp,
+): SlotOpOutcome {
+	// Retraction only undoes inference. An explicit trait (source user/admin)
+	// is cleared through the PERSONALITY action, never by the extractor.
+	if (gateSlot.source !== "agent_inferred") return "skipped_explicit";
+	if (gateSlot[op.trait] === null) return "unchanged";
+	store.applyTrait({
+		scope: "user",
+		userId,
+		agentId: runtime.agentId,
+		actorId: runtime.agentId,
+		trait: op.trait,
+		value: null,
+		source: "agent_inferred",
+	});
+	return "applied";
+}
+
+function applyAddDirective(
+	store: PersonalityStore,
+	runtime: IAgentRuntime,
+	userId: UUID,
+	op: AddDirectiveOp,
+): "added" | "deduped" | "skipped_low_confidence" {
+	if (op.confidence < SLOT_CONFIDENCE_THRESHOLD)
+		return "skipped_low_confidence";
+	// Dedupe against the LIVE slot (unlike trait gates) so two near-identical
+	// directives emitted in one run collapse to one entry.
+	const existing = store.getSlot(userId, runtime.agentId).custom_directives;
+	const isDuplicate = existing.some(
+		(directive) =>
+			factLexicalSimilarity([op.text], [directive]) >=
+			DEDUP_SIMILARITY_THRESHOLD,
+	);
+	if (isDuplicate) return "deduped";
+	store.addDirective({
+		userId,
+		agentId: runtime.agentId,
+		actorId: runtime.agentId,
+		directive: op.text,
+		source: "agent_inferred",
+	});
+	return "added";
+}
+
+interface FactCandidate {
+	memory: Memory;
+	searchText: string;
+}
+
+async function applyAddPreferenceFact(
+	runtime: IAgentRuntime,
+	message: Memory,
+	candidates: FactCandidate[],
+	op: AddPreferenceFactOp,
+): Promise<{ added: boolean; strengthened: boolean }> {
+	const keywords = buildFactKeywordsForStorage(
+		op.keywords ?? [],
+		op.claim,
+		"preference",
+	);
+	const targetValues = [op.claim, "preference", keywords];
+	let best: { memory: Memory; similarity: number } | null = null;
+	for (const candidate of candidates) {
+		const similarity = factLexicalSimilarity(targetValues, [
+			candidate.searchText,
+			readStoredFactKeywords(candidate.memory),
+		]);
+		if (similarity >= DEDUP_SIMILARITY_THRESHOLD) {
+			if (!best || similarity > best.similarity) {
+				best = { memory: candidate.memory, similarity };
+			}
+		}
+	}
+	if (best?.memory.id) {
+		// Update-not-duplicate: a re-stated preference reinforces the existing
+		// row instead of creating a near-copy the provider would rank twice.
+		const nextMeta: CustomMetadata = {
+			...preserveFactMetadata(best.memory),
+			confidence: clamp01(pickFactConfidence(best.memory) + STRENGTHEN_DELTA),
+			lastConfirmedAt: nowIso(),
+		};
+		await runtime.updateMemory({ id: best.memory.id, metadata: nextMeta });
+		return { added: false, strengthened: true };
+	}
+	const metadata: MemoryMetadata = {
+		type: MemoryType.CUSTOM,
+		source: "preference_extractor",
+		confidence: NEW_FACT_CONFIDENCE,
+		lastConfirmedAt: nowIso(),
+		kind: "durable",
+		category: "preference",
+		structuredFields: {},
+		keywords,
+		verificationStatus: "self_reported",
+	};
+	const memory: Memory = {
+		id: asUUID(v4()),
+		entityId: message.entityId,
+		agentId: runtime.agentId,
+		roomId: message.roomId,
+		content: { text: op.claim },
+		metadata,
+		createdAt: Date.now(),
+	};
+	const persistedId = await runtime.createMemory(memory, "facts", true);
+	if (persistedId) {
+		candidates.push({ memory, searchText: buildFactSearchText(memory) });
+	}
+	return { added: persistedId != null, strengthened: false };
+}
+
+export const preferenceEvaluator: Evaluator<
+	PreferenceExtractorOutput,
+	PreferencePrepared
+> = {
+	name: "preferences",
+	description:
+		"Extracts user preferences about the agent, views, and interaction style from ordinary conversation.",
+	priority: EvaluatorPriority.REFLECTION_PREFERENCES,
+	schema: preferenceOpsSchema,
+	async shouldRun({ runtime, message }) {
+		// The agent's own messages carry no user preference signal, and
+		// evaluating them would let the agent "infer" preferences from itself.
+		return canEvaluateMessage(message) && message.entityId !== runtime.agentId;
+	},
+	async prepare({ runtime, message }) {
+		return preparePreferences(runtime, message);
+	},
+	prompt({ runtime, prepared }) {
+		const agentName = runtime.character.name ?? "Agent";
+		// Without the PersonalityStore, slot ops would be dropped in the
+		// processor anyway — don't advertise them, so the model routes
+		// everything usable through the fact lane.
+		const slotOps = prepared.slot
+			? `- set_trait: reply style that clearly maps to a closed trait value. verbosity: terse|normal|verbose. tone: warm|neutral|direct|cold. formality: casual|professional|formal.
+- add_directive: standing reply-style rule with no trait mapping ("no emojis", "one question at a time", "don't stack messages"). Short imperative text, max 200 chars.
+- retract_trait: the user pushes back on an inferred trait shown below.
+`
+			: "";
+		const complaintExample = prepared.slot
+			? '"ugh, way too long" -> set_trait verbosity=terse'
+			: '"ugh, way too long" -> add_preference_fact "prefers short replies"';
+		return `Find preferences the user expressed about how ${agentName} should behave or how they want to interact. Passive signals count: complaints (${complaintExample}), asides, repeated corrections — not just direct requests.
+
+Ops:
+${slotOps}- add_preference_fact: preferences that are knowledge rather than reply style — views/UI (theme, background, widgets), content, timing ("morning check-ins", "quiet hours after 10pm"), interaction patterns ("prefers chat over views", "reads slowly, wants time to think"). claim + 3-8 lowercase retrieval keywords.
+
+Rules:
+- Only the speaker's own expressed preferences. Not the agent's suggestions, not hypotheticals, not third parties.
+- confidence 0-1, honest; slot ops below 0.8 are discarded.
+- No preference expressed -> {"ops":[]}.
+- Never emit anything about muting, ignoring, or when ${agentName} may reply.
+
+Current personality for this user:
+${formatSlotForPrompt(prepared.slot)}
+
+Known preferences already stored:
+${formatKnownPreferences(prepared.knownPreferenceFacts)}
+
+Recent messages:
+${formatRecentMessages(prepared.recentMessages)}`;
+	},
+	parse(output) {
+		// Tolerant, op-by-op — drops are logged inside
+		// parsePreferenceOutputTolerant (this parse contract has no
+		// runtime/logger). Null only when the envelope isn't { ops: [...] }.
+		return parsePreferenceOutputTolerant(output);
+	},
+	processors: [
+		{
+			name: "applyPreferenceOps",
+			async process({ runtime, message, prepared, output }) {
+				const store = getPersonalityStore(runtime);
+				const userId = message.entityId;
+				// Pre-run snapshot for trait gates — see applySetTrait.
+				const gateSlot = store ? store.getSlot(userId) : null;
+				const candidates: FactCandidate[] = prepared.knownPreferenceFacts.map(
+					(memory) => ({ memory, searchText: buildFactSearchText(memory) }),
+				);
+				let traitsSet = 0;
+				let traitsRetracted = 0;
+				let directivesAdded = 0;
+				let factsAdded = 0;
+				let factsStrengthened = 0;
+				let skipped = 0;
+				let droppedNoStore = 0;
+				for (const op of output.ops) {
+					if (op.op === "add_preference_fact") {
+						const result = await applyAddPreferenceFact(
+							runtime,
+							message,
+							candidates,
+							op,
+						);
+						if (result.added) factsAdded += 1;
+						if (result.strengthened) factsStrengthened += 1;
+						continue;
+					}
+					if (!store || !gateSlot) {
+						droppedNoStore += 1;
+						continue;
+					}
+					if (op.op === "set_trait") {
+						const outcome = applySetTrait(store, runtime, userId, gateSlot, op);
+						if (outcome === "applied") traitsSet += 1;
+						else skipped += 1;
+						continue;
+					}
+					if (op.op === "add_directive") {
+						const outcome = applyAddDirective(store, runtime, userId, op);
+						if (outcome === "added") directivesAdded += 1;
+						else skipped += 1;
+						continue;
+					}
+					const outcome = applyRetractTrait(
+						store,
+						runtime,
+						userId,
+						gateSlot,
+						op,
+					);
+					if (outcome === "applied") traitsRetracted += 1;
+					else skipped += 1;
+				}
+				if (droppedNoStore > 0) {
+					// Expected on runtimes without advanced capabilities (the store is
+					// a config choice, not a broken pipeline) — debug, not warn, and
+					// the counters below keep it visible in trajectories.
+					logger.debug(
+						{ src: "preferences", droppedNoStore },
+						"PersonalityStore unavailable; dropped slot ops",
+					);
+				}
+				const counters = {
+					traitsSet,
+					traitsRetracted,
+					directivesAdded,
+					factsAdded,
+					factsStrengthened,
+					skipped,
+					droppedNoStore,
+				};
+				return { success: true, values: counters, data: counters };
+			},
+		},
+	],
+};
+
+export const preferenceItems: RegisteredEvaluator[] = [preferenceEvaluator];

--- a/packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/preferenceExtractor.schema.ts
@@ -1,0 +1,141 @@
+/**
+ * Zod schemas and tolerant parser for the passive preference extractor
+ * (preference-items.ts). One post-turn LLM call emits ops that route a user's
+ * conversationally expressed preferences to the store that can act on them:
+ * closed-enum reply-style traits go to the PersonalityStore slot (`set_trait` /
+ * `retract_trait`), standing style rules with no trait mapping become custom
+ * directives (`add_directive`), and domain/view/interaction-pattern preferences
+ * land in the facts table as durable `preference` facts (`add_preference_fact`).
+ *
+ * `reply_gate` is deliberately unrepresentable here: silencing the agent must
+ * never be inferred from conversation (#14675) — it stays PERSONALITY-action-
+ * only. Global scope is equally absent; every op targets the speaking user.
+ */
+import z from "zod";
+import { logger } from "../../../logger.ts";
+import {
+	FORMALITY_VALUES,
+	MAX_DIRECTIVE_CHARS,
+	type PersonalityTrait,
+	TONE_VALUES,
+	VERBOSITY_VALUES,
+} from "../personality/types.ts";
+
+/** Traits inference may write. Closed set — `reply_gate` is excluded by design. */
+export const PreferenceTraitEnum = z.enum(["verbosity", "tone", "formality"]);
+
+const TRAIT_VALUE_SETS: Record<PersonalityTrait, ReadonlySet<string>> = {
+	verbosity: new Set<string>(VERBOSITY_VALUES),
+	tone: new Set<string>(TONE_VALUES),
+	formality: new Set<string>(FORMALITY_VALUES),
+};
+
+const SetTraitOpSchema = z.object({
+	op: z.literal("set_trait"),
+	trait: PreferenceTraitEnum,
+	value: z.string().min(1),
+	confidence: z.number().min(0).max(1),
+	evidence: z.string().optional(),
+});
+
+const AddDirectiveOpSchema = z.object({
+	op: z.literal("add_directive"),
+	// Cap enforced here, not on the wire: strict structured-output validators
+	// (Groq/Cerebras/OpenAI strict) reject maxLength outright — see the schema
+	// invariant note in reflection-items.ts.
+	text: z
+		.string()
+		.trim()
+		.min(1)
+		.transform((text) => text.slice(0, MAX_DIRECTIVE_CHARS)),
+	confidence: z.number().min(0).max(1),
+	evidence: z.string().optional(),
+});
+
+const AddPreferenceFactOpSchema = z.object({
+	op: z.literal("add_preference_fact"),
+	claim: z.string().min(1),
+	// Trim instead of reject, mirroring the fact extractor's KeywordsSchema:
+	// the wire schema cannot advertise maxItems, so an over-long list degrades
+	// to the first 16. Storage re-caps via MAX_KEYWORDS anyway.
+	keywords: z
+		.array(z.string().min(1))
+		.transform((keywords) => keywords.slice(0, 16))
+		.optional(),
+	confidence: z.number().min(0).max(1).optional(),
+	evidence: z.string().optional(),
+});
+
+const RetractTraitOpSchema = z.object({
+	op: z.literal("retract_trait"),
+	trait: PreferenceTraitEnum,
+	reason: z.string().optional(),
+});
+
+/** Discriminated union of every op the preference extractor may emit. */
+export const PreferenceOpSchema = z.discriminatedUnion("op", [
+	SetTraitOpSchema,
+	AddDirectiveOpSchema,
+	AddPreferenceFactOpSchema,
+	RetractTraitOpSchema,
+]);
+
+export type SetTraitOp = z.infer<typeof SetTraitOpSchema>;
+export type AddDirectiveOp = z.infer<typeof AddDirectiveOpSchema>;
+export type AddPreferenceFactOp = z.infer<typeof AddPreferenceFactOpSchema>;
+export type RetractTraitOp = z.infer<typeof RetractTraitOpSchema>;
+export type PreferenceOp = z.infer<typeof PreferenceOpSchema>;
+
+/** Top-level extractor envelope: one object with a single `ops` field. */
+export interface PreferenceExtractorOutput {
+	ops: PreferenceOp[];
+}
+
+/**
+ * Parse the extractor envelope tolerantly, op-by-op — same contract as
+ * `parseExtractorOutputTolerant` in factExtractor.schema.ts: one malformed op
+ * must not discard the rest of the turn's valid ops, and drops are logged HERE
+ * because the evaluator `parse` hook has no runtime/logger in scope.
+ *
+ * Trait/value pairing is validated here rather than in the union: the wire
+ * schema advertises one flat `value` enum across all three traits (a per-trait
+ * union is not expressible under the strict structured-output invariants), so
+ * the model can emit e.g. `trait: "verbosity", value: "warm"` — that op drops
+ * with a logged issue instead of silently writing a nonsense trait.
+ *
+ * Returns null only when the envelope itself is not `{ ops: array }`.
+ */
+export function parsePreferenceOutputTolerant(
+	output: unknown,
+): PreferenceExtractorOutput | null {
+	const envelope = z.object({ ops: z.array(z.unknown()) }).safeParse(output);
+	if (!envelope.success) return null;
+	const ops: PreferenceOp[] = [];
+	const issues: string[] = [];
+	for (const raw of envelope.data.ops) {
+		const parsed = PreferenceOpSchema.safeParse(raw);
+		if (!parsed.success) {
+			issues.push(
+				parsed.error.issues
+					.map(
+						(issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`,
+					)
+					.join("; "),
+			);
+			continue;
+		}
+		const op = parsed.data;
+		if (op.op === "set_trait" && !TRAIT_VALUE_SETS[op.trait].has(op.value)) {
+			issues.push(`set_trait: "${op.value}" is not a valid ${op.trait} value`);
+			continue;
+		}
+		ops.push(op);
+	}
+	if (issues.length > 0) {
+		logger.warn(
+			{ src: "preferences", count: issues.length, issues },
+			"dropped malformed preference op(s)",
+		);
+	}
+	return { ops };
+}

--- a/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.test.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.test.ts
@@ -203,7 +203,10 @@ describe("reflection evaluator schemas are strict-structured-output safe", () =>
 
 	it("every object node in every reflection schema has explicit properties + additionalProperties:false", async () => {
 		const { reflectionItems } = await import("./reflection-items.ts");
-		for (const evaluator of reflectionItems) {
+		// preferenceItems ships in the same merged post-turn call, so its wire
+		// schema must satisfy the identical strict-mode invariant.
+		const { preferenceItems } = await import("./preference-items.ts");
+		for (const evaluator of [...reflectionItems, ...preferenceItems]) {
 			const schema = (evaluator as { schema?: unknown }).schema;
 			if (!schema) continue;
 			assertStrictObjectNodes(schema, evaluator.name ?? "evaluator");

--- a/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts
@@ -73,11 +73,14 @@ import {
 const MAX_KNOWN_PER_KIND = 15;
 const FACT_LOOKBACK_LIMIT = 60;
 const RECENT_MESSAGES_LIMIT = 10;
-const STRENGTHEN_DELTA = 0.1;
+// Exported fact-store tuning shared with the preference evaluator
+// (preference-items.ts), which writes durable `preference` facts through the
+// same dedupe/strengthen discipline — one source of truth for the thresholds.
+export const STRENGTHEN_DELTA = 0.1;
 const DECAY_DELTA = 0.15;
 const FACT_DECAY_FLOOR = 0.2;
-const NEW_FACT_CONFIDENCE = 0.7;
-const DEDUP_SIMILARITY_THRESHOLD = 0.42;
+export const NEW_FACT_CONFIDENCE = 0.7;
+export const DEDUP_SIMILARITY_THRESHOLD = 0.42;
 const IDENTITY_CONFIDENCE_THRESHOLD = 0.5;
 
 const factOpsSchema: JSONSchema = {
@@ -353,7 +356,7 @@ function formatKnownLines(memories: Memory[], kind: FactKind): string {
 	return lines.length > 0 ? lines.join("\n") : "(none)";
 }
 
-function formatRecentMessages(memories: Memory[]): string {
+export function formatRecentMessages(memories: Memory[]): string {
 	const lines: string[] = [];
 	for (const memory of memories) {
 		if (isSyntheticConversationArtifactMemory(memory)) continue;
@@ -531,7 +534,7 @@ async function insertFact(
 	return persistedId;
 }
 
-function preserveFactMetadata(fact: Memory): CustomMetadata {
+export function preserveFactMetadata(fact: Memory): CustomMetadata {
 	const meta = readFactMetadata(fact);
 	const normalizedStructured =
 		meta.structuredFields && typeof meta.structuredFields === "object"
@@ -874,7 +877,7 @@ async function storeTaskCompletionReflection(
 	}
 }
 
-function canEvaluateMessage(message: Memory): boolean {
+export function canEvaluateMessage(message: Memory): boolean {
 	return Boolean(
 		message.content.text?.trim() &&
 			message.entityId &&

--- a/packages/core/src/features/advanced-capabilities/index.ts
+++ b/packages/core/src/features/advanced-capabilities/index.ts
@@ -59,6 +59,7 @@ import { messageAction } from "./actions/message.ts";
 import { postAction } from "./actions/post.ts";
 import { updateRoleAction } from "./actions/role.ts";
 import { roomOpAction } from "./actions/room.ts";
+import { preferenceItems } from "./evaluators/preference-items.ts";
 import { reflectionItems } from "./evaluators/reflection-items.ts";
 import { skillItems } from "./evaluators/skill-items.ts";
 import { advancedContactsProvider } from "./providers/contacts.ts";
@@ -103,6 +104,7 @@ export const advancedActions = [
 
 export const advancedEvaluators = [
 	...reflectionItems,
+	...preferenceItems,
 	...skillItems,
 	experiencePatternEvaluator,
 ] satisfies readonly RegisteredEvaluator[];

--- a/packages/core/src/features/advanced-capabilities/personality/__tests__/test-helpers.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/__tests__/test-helpers.ts
@@ -98,6 +98,14 @@ export function makeFakeRuntime(options: FakeRuntimeOptions = {}): FakeRuntime {
 				.filter((m) => !opts.roomId || m.roomId === opts.roomId)
 				.slice(0, opts.count ?? list.length);
 		},
+		async updateMemory(patch: Partial<Memory> & { id: UUID }): Promise<void> {
+			for (const [k, list] of memories.entries()) {
+				memories.set(
+					k,
+					list.map((m) => (m.id === patch.id ? { ...m, ...patch } : m)),
+				);
+			}
+		},
 		async deleteMemory(id: UUID): Promise<void> {
 			for (const [k, list] of memories.entries()) {
 				memories.set(

--- a/packages/core/src/features/advanced-capabilities/personality/providers/user-personality.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/providers/user-personality.ts
@@ -40,6 +40,14 @@ function renderSlot(
 		});
 	}
 	if (lines.length === 0) return null;
+	if (slot.source === "agent_inferred") {
+		// Provenance is slot-level (last writer), so this annotates the block,
+		// not individual traits. The model should treat inferred style as an
+		// observation it can explain and offer to undo, not a user order.
+		lines.push(
+			"- provenance: inferred from conversation, not explicitly set; offer to adjust if the user objects",
+		);
+	}
 	return [header, ...lines, footer].join("\n");
 }
 

--- a/packages/core/src/features/advanced-capabilities/personality/services/personality-store.ts
+++ b/packages/core/src/features/advanced-capabilities/personality/services/personality-store.ts
@@ -257,6 +257,7 @@ export class PersonalityStore extends Service {
 		agentId: UUID;
 		actorId: UUID;
 		directive: string;
+		source?: PersonalitySlot["source"];
 	}): { before: PersonalitySlot; after: PersonalitySlot } {
 		const before = this.getSlot(args.userId, args.agentId);
 		const next = [...before.custom_directives, args.directive];
@@ -266,7 +267,7 @@ export class PersonalityStore extends Service {
 			...before,
 			custom_directives: next,
 			updated_at: new Date().toISOString(),
-			source: "user",
+			source: args.source ?? "user",
 		};
 		this.setSlot(after);
 		this.recordAudit({

--- a/packages/core/src/plugins/native-features.ts
+++ b/packages/core/src/plugins/native-features.ts
@@ -14,6 +14,7 @@
 import { promoteSubactionsToActions } from "../actions/promote-subactions";
 import { messageAction } from "../features/advanced-capabilities/actions/message";
 import { postAction } from "../features/advanced-capabilities/actions/post";
+import { preferenceItems } from "../features/advanced-capabilities/evaluators/preference-items";
 import { reflectionItems } from "../features/advanced-capabilities/evaluators/reflection-items";
 import { skillItems } from "../features/advanced-capabilities/evaluators/skill-items";
 import { advancedContactsProvider } from "../features/advanced-capabilities/providers/contacts";
@@ -70,7 +71,7 @@ export const relationshipsPlugin: Plugin = {
 		...promoteSubactionsToActions(messageAction),
 		...promoteSubactionsToActions(postAction),
 	],
-	evaluators: [...reflectionItems, ...skillItems],
+	evaluators: [...reflectionItems, ...preferenceItems, ...skillItems],
 	providers: [
 		advancedContactsProvider,
 		factsProvider,

--- a/packages/core/src/services/evaluator-priorities.ts
+++ b/packages/core/src/services/evaluator-priorities.ts
@@ -35,6 +35,11 @@ export const EvaluatorPriority = {
 
 	// Reflection group: ordered by dependency (facts before identity, etc.).
 	REFLECTION_FACTS: 100,
+	// Preferences run right after facts: both extract from the same recent
+	// window, and the fact extractor stays the owner of generic claims — the
+	// preference extractor only routes behavior-shaping ops (personality slot
+	// traits, directives, durable preference facts).
+	REFLECTION_PREFERENCES: 105,
 	REFLECTION_RELATIONSHIPS: 110,
 	REFLECTION_IDENTITY: 120,
 	REFLECTION_SUCCESS: 130,

--- a/packages/scenario-runner/test/scenarios/deterministic-preference-extraction.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-preference-extraction.scenario.ts
@@ -1,0 +1,223 @@
+/**
+ * Deterministic (keyless) proof for the passive preference evaluator (#14675):
+ * the `preferences` evaluator must be registered on a real runtime boot, its
+ * processor must route a parsed extraction into the REAL stores (a personality
+ * slot trait with `agent_inferred` provenance, and a durable `preference` fact
+ * row in the facts table), and the re-injection path must close the loop —
+ * `userPersonalityPreferences` renders the inferred trait into the next turn's
+ * prompt context.
+ *
+ * Runs zero turns: the LLM judgment half of the evaluator (prompt → ops) is
+ * covered by unit tests and live lanes; this scenario pins the wiring —
+ * registration → write policy → storage rows → prompt injection — through the
+ * real runtime with no model call.
+ */
+import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+const FACT_CLAIM = "prefers the dark background in the app";
+
+interface ProviderResultLike {
+  text: string;
+}
+
+interface ProviderLike {
+  name: string;
+  get(
+    runtime: unknown,
+    message: Record<string, unknown>,
+    state: Record<string, unknown>,
+  ): Promise<ProviderResultLike>;
+}
+
+interface ProcessorLike {
+  process(context: Record<string, unknown>): Promise<unknown>;
+}
+
+interface EvaluatorLike {
+  name: string;
+  processors?: ProcessorLike[];
+}
+
+interface PersonalitySlotLike {
+  verbosity: string | null;
+  source: string;
+  custom_directives: string[];
+}
+
+interface PersonalityStoreLike {
+  getSlot(userId: string): PersonalitySlotLike;
+}
+
+interface MemoryRowLike {
+  content: { text?: string };
+  metadata?: { category?: string; kind?: string; source?: string };
+}
+
+interface RuntimeLike {
+  agentId: string;
+  evaluators: EvaluatorLike[];
+  providers: ProviderLike[];
+  getService(name: string): unknown;
+  getMemories(opts: {
+    tableName: string;
+    roomId: string;
+    entityId?: string;
+    limit?: number;
+    unique?: boolean;
+  }): Promise<MemoryRowLike[]>;
+}
+
+async function expectPreferenceLoopClosed(
+  ctx: ScenarioContext,
+): Promise<string | undefined> {
+  const runtime = ctx.runtime as RuntimeLike | undefined;
+  if (!runtime) return "scenario runtime unavailable";
+  if (!ctx.primaryRoomId || !ctx.primaryUserId) {
+    return "executor did not expose primaryRoomId/primaryUserId to checks";
+  }
+
+  const evaluator = runtime.evaluators.find((e) => e.name === "preferences");
+  if (!evaluator) {
+    return "preferences evaluator is not registered on the runtime";
+  }
+  const processor = evaluator.processors?.[0];
+  if (!processor) return "preferences evaluator has no processor";
+
+  const store = runtime.getService(
+    "PERSONALITY_STORE",
+  ) as PersonalityStoreLike | null;
+  if (!store) {
+    return "PERSONALITY_STORE service is not registered (advancedCapabilities runtime expected)";
+  }
+
+  // Drive the processor with an already-parsed extraction — the deterministic
+  // stand-in for the model's ops — against the real store and real facts table.
+  const message = {
+    id: crypto.randomUUID(),
+    entityId: ctx.primaryUserId,
+    agentId: runtime.agentId,
+    roomId: ctx.primaryRoomId,
+    content: {
+      text: "ugh, that was way too long. also I like the dark background",
+    },
+    createdAt: Date.now(),
+  };
+  await processor.process({
+    runtime,
+    message,
+    state: { values: {}, data: {}, text: "" },
+    options: {},
+    evaluatorName: "preferences",
+    prepared: {
+      recentMessages: [],
+      slot: store.getSlot(ctx.primaryUserId),
+      knownPreferenceFacts: [],
+    },
+    output: {
+      ops: [
+        {
+          op: "set_trait",
+          trait: "verbosity",
+          value: "terse",
+          confidence: 0.9,
+        },
+        {
+          op: "add_preference_fact",
+          claim: FACT_CLAIM,
+          keywords: ["dark", "background", "theme"],
+        },
+      ],
+    },
+  });
+
+  const slot = store.getSlot(ctx.primaryUserId);
+  if (slot.verbosity !== "terse") {
+    return `inferred trait never landed in the personality slot; verbosity=${String(slot.verbosity)}`;
+  }
+  if (slot.source !== "agent_inferred") {
+    return `inferred write must carry agent_inferred provenance; source=${slot.source}`;
+  }
+
+  const facts = await runtime.getMemories({
+    tableName: "facts",
+    roomId: ctx.primaryRoomId,
+    entityId: ctx.primaryUserId,
+    limit: 20,
+    unique: false,
+  });
+  const row = facts.find((fact) => fact.content.text === FACT_CLAIM);
+  if (!row) {
+    return `durable preference fact row never landed in the facts table; got ${facts.length} rows`;
+  }
+  if (
+    row.metadata?.category !== "preference" ||
+    row.metadata?.kind !== "durable" ||
+    row.metadata?.source !== "preference_extractor"
+  ) {
+    return `preference fact row has wrong metadata: ${JSON.stringify(row.metadata)}`;
+  }
+
+  // Behavior-loop closure: the provider must re-inject the inferred trait
+  // (with provenance) into the prompt context of the user's next message.
+  const personality = runtime.providers.find(
+    (p) => p.name === "userPersonalityPreferences",
+  );
+  if (!personality) {
+    return "userPersonalityPreferences provider is not registered";
+  }
+  const rendered = await personality.get(
+    runtime,
+    {
+      id: crypto.randomUUID(),
+      entityId: ctx.primaryUserId,
+      agentId: runtime.agentId,
+      roomId: ctx.primaryRoomId,
+      content: { text: "what should we do next?" },
+      createdAt: Date.now(),
+    },
+    { values: {}, data: {}, text: "" },
+  );
+  if (!rendered.text.includes("verbosity: terse")) {
+    return `inferred trait never reached the prompt; provider text: ${rendered.text || "(empty)"}`;
+  }
+  if (!rendered.text.includes("inferred from conversation")) {
+    return `inferred provenance annotation missing from prompt; provider text: ${rendered.text}`;
+  }
+  return undefined;
+}
+
+export default scenario({
+  lane: "pr-deterministic",
+  id: "deterministic-preference-extraction",
+  title:
+    "A passively extracted preference lands in the personality slot + facts table and re-enters the prompt",
+  domain: "scenario-runner",
+  tags: [
+    "pr",
+    "deterministic",
+    "zero-cost",
+    "preferences",
+    "personality",
+    "14675",
+  ],
+  status: "active",
+  isolation: "per-scenario",
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Preference extraction loop",
+    },
+  ],
+  seed: [],
+  turns: [],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "preference extraction closes the behavior loop through real stores",
+      predicate: expectPreferenceLoopClosed,
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Implements the design brief in #14675 (LifeOps architecture review, adversarially verified): a **passive preference extraction evaluator** — the missing conversational writer for the personality behavior machinery. A user who says *"ugh, that was way too long"*, *"stop using emojis"*, or *"I prefer morning check-ins"* in passing now gets durable behavior change with **zero explicit input**.

**What it extracts** (one strict-JSON-schema post-turn model call, LLM-decides — no keyword matching):
- **Agent behavior** — reply length/tone/formality → `set_trait` ops into the PersonalityStore slot with `source: "agent_inferred"`
- **Standing style rules** with no trait mapping ("no emojis", "one question at a time") → `add_directive` (lexical dedupe at the shared 0.42 threshold, FIFO-capped by the store)
- **Views/UI, content, timing, interaction patterns** (theme, background, "morning check-ins", "reads slowly, wants time to think") → `add_preference_fact`: durable `category: "preference"` rows in the **existing facts table** (no new store — CLAUDE.md ban respected), same rows the FACTS provider (and #14829's interaction-preference lane) reads

**How it becomes behavior** (zero new providers): `userPersonalityProvider` already injects slot traits + directives into every prompt, and verbosity is already hard-enforced in the reply callback. `renderSlot` now annotates `agent_inferred` slots with a provenance line so the model can explain/offer to undo. Preference facts surface through the FACTS provider exactly like fact-extractor rows.

**Safety invariants:**
- Inference **never overwrites an explicitly-set trait** (slot source `user`/`admin`) — explicit beats inferred, at any confidence
- Trait gates read the **pre-run slot snapshot**, so one inferred write can't flip slot provenance and unlock overwriting an explicit trait in the same run
- `reply_gate` is **unrepresentable** in the op schema (silencing the agent off an inferred signal is a hazard; stays PERSONALITY-action-only)
- Global scope is never written; slot ops gate at confidence ≥ 0.8; retraction only undoes inference
- Every slot write goes through `applyTrait`/`addDirective` → existing audit trail; PERSONALITY show_state/audit can inspect and clear

**Architecture mirrors the fact evaluator exactly**: sibling `preference-items.ts` + `preferenceExtractor.schema.ts` (tolerant op-by-op parse, strict-structured-output-safe wire schema, caps in code not on the wire), new `REFLECTION_PREFERENCES: 105` priority (facts=100 stays owner of generic claims), registered via `advancedEvaluators` + the `relationships` native feature like `reflectionItems`. On runtimes without the PersonalityStore (advanced capabilities off), the prompt stops advertising slot ops, the fact lane still works, and drops are counted in the processor result.

Closes #14675

## Verification

- `bun x vitest run` — preference-items.test.ts (**19 tests**), reflection-items.test.ts (strict-schema walker now covers the new evaluator), all personality suites, evaluator service: **94 passed / 0 failed**
- `pr-deterministic` scenario `deterministic-preference-extraction` (zero-turn, keyless, real runtime boot): **passed** — registration → write policy → real PersonalityStore slot → real facts-table row → `userPersonalityPreferences` prompt render, all asserted through the real runtime
- `bun run --cwd packages/core typecheck` — passed
- `bunx biome check` on all touched files — passed
- `bun run audit:error-policy-ratchet` — no new fallback-slop in touched files
- `git diff --check` — passed

## Live-LLM trajectory (real model, real prompt, real stores)

A live Claude model was driven through the evaluator's **real** `prompt()` and wire schema on a synthetic 4-turn conversation, output parsed by the **real** `parsePreferenceOutputTolerant`, ops applied by the **real** processor against a **real PersonalityStore** and facts table, then re-rendered by the **real** `userPersonalityProvider`:

- complaint *"ugh, that was way too long again"* → `set_trait verbosity=terse` (conf 0.95) → slot `verbosity: "terse", source: "agent_inferred"`
- *"stop using emojis, it reads weird"* → directive `"Do not use emojis in replies"`
- *"I really like the dark background"* + *"check-ins in the morning, I read slowly"* → 2 durable `preference` fact rows (`source: "preference_extractor"`, keywords intact)
- next-turn provider render includes the `[PERSONALITY for THIS user]` block **with the inferred-provenance line**

<details><summary>Full live run: prompt → model output → parsed ops → store state → next-turn prompt render</summary>

```
=== REAL EVALUATOR PROMPT ===
Find preferences the user expressed about how TestAgent should behave or how they want to interact. Passive signals count: complaints ("ugh, way too long" -> set_trait verbosity=terse), asides, repeated corrections — not just direct requests.

Ops:
- set_trait: reply style that clearly maps to a closed trait value. verbosity: terse|normal|verbose. tone: warm|neutral|direct|cold. formality: casual|professional|formal.
- add_directive: standing reply-style rule with no trait mapping ("no emojis", "one question at a time", "don't stack messages"). Short imperative text, max 200 chars.
- retract_trait: the user pushes back on an inferred trait shown below.
- add_preference_fact: preferences that are knowledge rather than reply style — views/UI (theme, background, widgets), content, timing ("morning check-ins", "quiet hours after 10pm"), interaction patterns ("prefers chat over views", "reads slowly, wants time to think"). claim + 3-8 lowercase retrieval keywords.

Rules:
- Only the speaker's own expressed preferences. Not the agent's suggestions, not hypotheticals, not third parties.
- confidence 0-1, honest; slot ops below 0.8 are discarded.
- No preference expressed -> {"ops":[]}.
- Never emit anything about muting, ignoring, or when TestAgent may reply.

Current personality for this user:
(none set)

Known preferences already stored:
(none)

Recent messages:
- Eliza: Here's a detailed breakdown of your week ahead... (long reply)
- Sam: ugh, that was way too long again. just give me the short version. also stop using emojis, it reads weird
- Eliza: Got it — short version: 3 meetings, 2 deadlines.
- Sam: better. btw I really like the dark background in the app, keep it that way. and I'd rather get check-ins in the morning, I read slowly in the evenings

=== LIVE MODEL OUTPUT ===
{"ops":[{"op":"set_trait","trait":"verbosity","value":"terse","confidence":0.95,"evidence":"ugh, that was way too long again. just give me the short version"},{"op":"add_directive","text":"Do not use emojis in replies","confidence":0.95,"evidence":"stop using emojis, it reads weird"},{"op":"add_preference_fact","claim":"prefers dark background/theme in the app","keywords":["dark","background","theme","app","display","ui"],"confidence":0.9,"evidence":"I really like the dark background in the app, keep it that way"},{"op":"add_preference_fact","claim":"prefers check-ins in the morning, reads slowly in the evenings","keywords":["morning","check-in","evening","timing","schedule","reading"],"confidence":0.85,"evidence":"I'd rather get check-ins in the morning, I read slowly in the evenings"}]}

=== PARSED OPS ===
[
  {
    "op": "set_trait",
    "trait": "verbosity",
    "value": "terse",
    "confidence": 0.95,
    "evidence": "ugh, that was way too long again. just give me the short version"
  },
  {
    "op": "add_directive",
    "text": "Do not use emojis in replies",
    "confidence": 0.95,
    "evidence": "stop using emojis, it reads weird"
  },
  {
    "op": "add_preference_fact",
    "claim": "prefers dark background/theme in the app",
    "keywords": [
      "dark",
      "background",
      "theme",
      "app",
      "display",
      "ui"
    ],
    "confidence": 0.9,
    "evidence": "I really like the dark background in the app, keep it that way"
  },
  {
    "op": "add_preference_fact",
    "claim": "prefers check-ins in the morning, reads slowly in the evenings",
    "keywords": [
      "morning",
      "check-in",
      "evening",
      "timing",
      "schedule",
      "reading"
    ],
    "confidence": 0.85,
    "evidence": "I'd rather get check-ins in the morning, I read slowly in the evenings"
  }
]

=== PROCESSOR RESULT ===
{"traitsSet":1,"traitsRetracted":0,"directivesAdded":1,"factsAdded":2,"factsStrengthened":0,"skipped":0,"droppedNoStore":0}

=== PERSONALITY SLOT AFTER ===
{
  "userId": "00000000-0000-4000-8000-0000000000ab",
  "agentId": "00000000-0000-4000-8000-0000000000aa",
  "verbosity": "terse",
  "tone": null,
  "formality": null,
  "reply_gate": null,
  "custom_directives": [
    "Do not use emojis in replies"
  ],
  "updated_at": "2026-07-06T04:32:24.145Z",
  "source": "agent_inferred"
}

=== AUDIT ===
[
  "add_directive:Do not use emojis in replies",
  "set_trait:verbosity=terse"
]

=== FACTS TABLE ROWS ===
[
  {
    "text": "prefers dark background/theme in the app",
    "metadata": {
      "type": "custom",
      "source": "preference_extractor",
      "confidence": 0.7,
      "lastConfirmedAt": "2026-07-06T04:32:24.146Z",
      "kind": "durable",
      "category": "preference",
      "structuredFields": {},
      "keywords": [
        "dark",
        "background",
        "theme",
        "app",
        "display",
        "prefers",
        "preference"
      ],
      "verificationStatus": "self_reported"
    }
  },
  {
    "text": "prefers check-ins in the morning, reads slowly in the evenings",
    "metadata": {
      "type": "custom",
      "source": "preference_extractor",
      "confidence": 0.7,
      "lastConfirmedAt": "2026-07-06T04:32:24.147Z",
      "kind": "durable",
      "category": "preference",
      "structuredFields": {},
      "keywords": [
        "morning",
        "check",
        "evening",
        "timing",
        "schedule",
        "reading",
        "prefers",
        "ins",
        "reads",
        "slowly",
        "evenings",
        "preference"
      ],
      "verificationStatus": "self_reported"
    }
  }
]

=== NEXT-TURN PROVIDER RENDER ===
[PERSONALITY for THIS user]
- verbosity: terse
- custom directives:
  1. Do not use emojis in replies
- provenance: inferred from conversation, not explicitly set; offer to adjust if the user objects
[/PERSONALITY for THIS user]
```

</details>

## Evidence notes

- **UI screenshots/video:** N/A — core post-turn evaluator + prompt-context change; no rendered app surface.
- **Backend logs:** the deterministic scenario run above executes through the real runtime boot (structured logs in the scenario report); parse-drop warnings are asserted in unit tests via the logger spy.
- **Domain artifacts:** facts-table rows, personality slot, audit entries, and provider render inspected by hand — shown inline in the live-run details block and asserted in the scenario.

## Known follow-ups (out of scope, tracked)

- **#14674 / PR #14740 (PersonalityStore persistence)** is the prerequisite the design brief names: slots are in-memory today, so inferred traits evaporate on restart until that lands. All writes here go through the store API, so persistence is picked up automatically when #14740 merges. Preference **facts** are already durable DB rows.
- **Slot-level provenance**: `PersonalitySlot.source` is per-slot, not per-trait, so an inferred write marks the whole slot `agent_inferred` (cross-turn, a later high-confidence inferred signal may then overwrite a previously explicit trait). The same-run escalation guard closes the intra-run case; per-trait provenance belongs with the #14740 slot-shape work.
- **#14829** (FACTS provider interaction-preference lane) is complementary and unmerged; this PR writes the same `category: "preference"` rows its lane surfaces — no coupling either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)