### PR TITLE
test(ui): prove quiet home resting state

### DIFF
--- a/packages/ui/src/components/chat/widgets/shared.tsx
+++ b/packages/ui/src/components/chat/widgets/shared.tsx
@@ -25,7 +25,11 @@ export function WidgetSection({
   testId: string;
   /** When set, the title area becomes a button navigating elsewhere. */
   onTitleClick?: () => void;
-  /** Home widgets sit directly on the ember field and need a glass/white skin. */
+  /**
+   * Home widgets sit directly on the ember field: bare white-family text with
+   * no card chrome, per the sparse-home doctrine — the wallpaper is the
+   * surface, so the section adds only readable foregrounds.
+   */
   tone?: WidgetSectionTone;
 }) {
   const isHome = tone === "home";
@@ -33,14 +37,14 @@ export function WidgetSection({
     <>
       <span
         className={`inline-flex shrink-0 items-center justify-center [&>svg]:h-3.5 [&>svg]:w-3.5 ${
-          isHome ? "text-white/65" : "text-muted"
+          isHome ? "text-white/70" : "text-muted"
         }`}
       >
         {icon}
       </span>
       <span
         className={`truncate text-xs-tight leading-none font-semibold ${
-          isHome ? "text-white/65" : "text-muted"
+          isHome ? "text-white/75" : "text-muted"
         }`}
       >
         {title}
@@ -50,11 +54,7 @@ export function WidgetSection({
   return (
     <section
       data-testid={testId}
-      className={
-        isHome
-          ? "space-y-1 rounded-2xl border border-white/55 bg-black/35 px-3.5 py-3 text-white backdrop-blur-xl"
-          : "space-y-0.5"
-      }
+      className={isHome ? "space-y-2 text-white" : "space-y-0.5"}
     >
       <div className="flex items-center justify-between gap-2 pr-1">
         {onTitleClick ? (
@@ -63,7 +63,7 @@ export function WidgetSection({
             size="sm"
             onClick={onTitleClick}
             className={`h-auto min-w-0 flex-1 justify-start gap-1.5 rounded-sm bg-transparent px-0.5 py-1 text-left transition-colors hover:bg-transparent ${
-              isHome ? "text-white/65 hover:text-white" : "hover:text-txt"
+              isHome ? "text-white/75 hover:text-white" : "hover:text-txt"
             }`}
           >
             {titleContent}

--- a/packages/ui/src/components/chat/widgets/todo.tsx
+++ b/packages/ui/src/components/chat/widgets/todo.tsx
@@ -115,11 +115,13 @@ function TodoRow({
       <div className="flex items-start gap-2">
         <span
           className={`mt-1.5 inline-block h-2 w-2 shrink-0 rounded-full ${
-            todo.isUrgent
-              ? "bg-danger"
-              : todo.priority != null
-                ? "bg-accent"
-                : "bg-muted"
+            isHome
+              ? "bg-white/70"
+              : todo.isUrgent
+                ? "bg-danger"
+                : todo.priority != null
+                  ? "bg-accent"
+                  : "bg-muted"
           }`}
         />
         <div className="min-w-0 flex-1">
@@ -195,7 +197,9 @@ function GoalAttentionRow({
       }`}
     >
       <Target
-        className={`mt-0.5 h-4 w-4 shrink-0 ${atRisk ? "text-danger" : "text-accent"}`}
+        className={`mt-0.5 h-4 w-4 shrink-0 ${
+          isHome ? "text-white/75" : atRisk ? "text-danger" : "text-accent"
+        }`}
       />
       <div className="min-w-0 flex-1">
         <div className="flex flex-wrap items-center gap-1.5">
@@ -454,29 +458,46 @@ function TodoSidebarWidget({
   // its empty state.
   if (onHome && openTodos.length === 0 && !attentionGoal) return null;
 
-  const section = (
+  const content = (
+    <TodoItemsContent
+      todos={todos}
+      loading={todosLoading}
+      goal={attentionGoal}
+      onOpenGoal={() => nav.openView("/goals", "goals")}
+      tone={onHome ? "home" : "default"}
+    />
+  );
+  if (onHome) {
+    return (
+      <div className={`min-w-0 ${spanClassName}`}>
+        <section
+          data-testid="chat-widget-todos"
+          className="space-y-2 text-white"
+        >
+          <div className="flex min-w-0 items-center gap-1.5 px-0.5 py-1">
+            <span className="inline-flex shrink-0 items-center justify-center text-white/70 [&>svg]:h-3.5 [&>svg]:w-3.5">
+              <ListTodo className="h-4 w-4" />
+            </span>
+            <span className="truncate text-xs-tight font-semibold leading-none text-white/75">
+              {t("taskseventspanel.Todos", { defaultValue: "Todos" })}
+            </span>
+          </div>
+          <div className="text-xs">{content}</div>
+        </section>
+      </div>
+    );
+  }
+
+  return (
     <WidgetSection
       title={t("taskseventspanel.Todos", { defaultValue: "Todos" })}
       icon={<ListTodo className="h-4 w-4" />}
       testId="chat-widget-todos"
-      tone={onHome ? "home" : "default"}
+      tone="default"
     >
-      <TodoItemsContent
-        todos={todos}
-        loading={todosLoading}
-        goal={attentionGoal}
-        onOpenGoal={() => nav.openView("/goals", "goals")}
-        tone={onHome ? "home" : "default"}
-      />
+      {content}
     </WidgetSection>
   );
-  // On the home 4-col grid the widget's root element must carry its grid-span
-  // classes or it collapses to a one-column cell and its content paints over
-  // the neighboring card (#11752). The sidebar stack renders the bare section.
-  if (onHome) {
-    return <div className={`min-w-0 ${spanClassName}`}>{section}</div>;
-  }
-  return section;
 }
 
 export const TODO_PLUGIN_WIDGETS: ChatSidebarWidgetDefinition[] = [

--- a/packages/ui/src/components/chat/widgets/todo.tsx
+++ b/packages/ui/src/components/chat/widgets/todo.tsx
@@ -458,46 +458,29 @@ function TodoSidebarWidget({
   // its empty state.
   if (onHome && openTodos.length === 0 && !attentionGoal) return null;
 
-  const content = (
-    <TodoItemsContent
-      todos={todos}
-      loading={todosLoading}
-      goal={attentionGoal}
-      onOpenGoal={() => nav.openView("/goals", "goals")}
-      tone={onHome ? "home" : "default"}
-    />
-  );
-  if (onHome) {
-    return (
-      <div className={`min-w-0 ${spanClassName}`}>
-        <section
-          data-testid="chat-widget-todos"
-          className="space-y-2 text-white"
-        >
-          <div className="flex min-w-0 items-center gap-1.5 px-0.5 py-1">
-            <span className="inline-flex shrink-0 items-center justify-center text-white/70 [&>svg]:h-3.5 [&>svg]:w-3.5">
-              <ListTodo className="h-4 w-4" />
-            </span>
-            <span className="truncate text-xs-tight font-semibold leading-none text-white/75">
-              {t("taskseventspanel.Todos", { defaultValue: "Todos" })}
-            </span>
-          </div>
-          <div className="text-xs">{content}</div>
-        </section>
-      </div>
-    );
-  }
-
-  return (
+  const section = (
     <WidgetSection
       title={t("taskseventspanel.Todos", { defaultValue: "Todos" })}
       icon={<ListTodo className="h-4 w-4" />}
       testId="chat-widget-todos"
-      tone="default"
+      tone={onHome ? "home" : "default"}
     >
-      {content}
+      <TodoItemsContent
+        todos={todos}
+        loading={todosLoading}
+        goal={attentionGoal}
+        onOpenGoal={() => nav.openView("/goals", "goals")}
+        tone={onHome ? "home" : "default"}
+      />
     </WidgetSection>
   );
+  // On the home 4-col grid the widget's root element must carry its grid-span
+  // classes or it collapses to a one-column cell and its content paints over
+  // the neighboring card (#11752). The sidebar stack renders the bare section.
+  if (onHome) {
+    return <div className={`min-w-0 ${spanClassName}`}>{section}</div>;
+  }
+  return section;
 }
 
 export const TODO_PLUGIN_WIDGETS: ChatSidebarWidgetDefinition[] = [

--- a/packages/ui/src/components/shell/__e2e__/home-screen-fixture.api-stub.ts
+++ b/packages/ui/src/components/shell/__e2e__/home-screen-fixture.api-stub.ts
@@ -7,7 +7,9 @@
 // dashboard center renders with injected data.
 
 import {
+  homeWidgetApprovalsResponse,
   homeWidgetNotificationsResponse,
+  homeWidgetTodosResponse,
 } from "../../../widgets/__fixtures__/home-widget-mock-data";
 
 const walletBalancesResponse = () => ({ evm: null, solana: null });
@@ -29,21 +31,13 @@ export const client = {
   getRelationshipsCandidates: async () => [],
   getWalletBalances: async () => walletBalancesResponse(),
   getWalletMarketOverview: async () => walletMarketOverviewResponse(),
-  // Today (todo) home card: seed one open todo so the merged card renders with a
-  // todo row alongside its flagged at-risk goal row (spec §E item 5).
-  listWorkbenchTodos: async () => ({
-    todos: [
-      {
-        id: "todo-groceries",
-        name: "Buy groceries",
-        description: "",
-        type: "task",
-        isCompleted: false,
-        isUrgent: false,
-        priority: 2,
-      },
-    ],
-  }),
+  // Today (todo) home card: attention mode seeds one open todo so the merged
+  // card renders with a todo row alongside its flagged at-risk goal row
+  // (spec §E item 5). Quiet mode returns zero work so the card self-hides.
+  listWorkbenchTodos: async () => homeWidgetTodosResponse(),
+  // Needs-response home card: attention mode seeds pending approvals; quiet
+  // mode returns none so the card self-hides.
+  listPendingActions: async () => homeWidgetApprovalsResponse(),
   // Notification store hydrate + live subscription.
   listNotifications: async () => homeWidgetNotificationsResponse(),
   onWsEvent: () => {},

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -276,6 +276,67 @@ async function readHomeDarkForegrounds(page) {
     return failures;
   });
 }
+const ATTENTION_HOME_TEST_IDS = [
+  "home-notification-center",
+  "chat-widget-needs-attention",
+  "chat-widget-todos",
+  "todo-goal-attention-row",
+  "chat-widget-calendar-upcoming",
+];
+async function waitForHomeEnterSettled(page) {
+  await page.waitForFunction(
+    () => {
+      const home = document.querySelector('[data-testid="home-screen"]');
+      if (!home) return false;
+      return !home
+        .getAnimations({ subtree: true })
+        .some(
+          (a) =>
+            a.animationName === "home-enter" && a.playState !== "finished",
+        );
+    },
+    undefined,
+    { timeout: 5000 },
+  );
+}
+async function assertQuietHome(page, label) {
+  await page.waitForSelector('[data-testid="home-screen"]');
+  await page.waitForSelector('[data-testid="widget-host-home"]', {
+    state: "attached",
+  });
+  await waitForHomeEnterSettled(page);
+  await page.waitForFunction(
+    (attentionIds) => {
+      const host = document.querySelector('[data-testid="widget-host-home"]');
+      if (!(host instanceof HTMLElement)) return false;
+      if (host.childElementCount !== 0) return false;
+      return attentionIds.every(
+        (testId) => document.querySelector(`[data-testid="${testId}"]`) == null,
+      );
+    },
+    ATTENTION_HOME_TEST_IDS,
+    { timeout: 15000 },
+  );
+  assert(
+    (await page.getByTestId("home-time-widget").count()) === 1,
+    `${label}: time widget remains visible`,
+  );
+  assert(
+    (await page.getByTestId("home-weather").count()) === 1,
+    `${label}: weather widget remains visible`,
+  );
+  assert(
+    (await page.getByTestId("widget-host-home").locator(":scope > *").count()) ===
+      0,
+    `${label}: no ranked attention cards render healthy-empty chrome`,
+  );
+  for (const testId of ATTENTION_HOME_TEST_IDS) {
+    assert(
+      (await page.getByTestId(testId).count()) === 0,
+      `${label}: ${testId} self-hides when data is healthy-empty`,
+    );
+  }
+}
 async function waitForSurfacePageSettled(p, pageName) {
   await p.waitForFunction((expectedPage) => {
     const surface = document.querySelector(
@@ -382,7 +443,10 @@ try {
   await mobile.addInitScript(LAYOUT_SHIFT_OBSERVER_INIT);
   // Frame sampler for the rail-swipe FPS gate below (start()/read()/stop()).
   await mobile.addInitScript(FRAME_SAMPLER_INIT);
-  await mobile.goto(`${url}?native`);
+  await mobile.goto(`${url}?homeData=quiet`);
+  await assertQuietHome(mobile, "quiet account");
+  await snap(mobile, "mobile-home-quiet");
+  await mobile.goto(`${url}?native&homeData=attention`);
   await mobile.waitForSelector('[data-testid="home-launcher-surface"]');
   await mobile.waitForSelector('[data-testid="home-screen"]');
   await mobile.waitForTimeout(600);
@@ -417,17 +481,7 @@ try {
   );
   // Wait for the staggered home-enter fade-up to settle so the cards are fully
   // opaque (and the data-driven cards have mounted + fetched) before asserting.
-  await mobile.waitForFunction(
-    () => {
-      const home = document.querySelector('[data-testid="home-screen"]');
-      if (!home) return false;
-      return !home
-        .getAnimations({ subtree: true })
-        .some((a) => a.animationName === "home-enter" && a.playState !== "finished");
-    },
-    undefined,
-    { timeout: 5000 },
-  );
+  await waitForHomeEnterSettled(mobile);
   // Kept per-plugin home widgets render only when their injected data is
   // attention-worthy. Post spec §E cut, the resident set is Today (todos) - with
   // the at-risk goal folded in as one flagged row - plus calendar. The removed
@@ -864,6 +918,9 @@ try {
     (await mobile.getByText("Pinned", { exact: true }).count()) === 0,
     'no "Pinned" label',
   );
+  await mobile.goto(`${url}?homeData=quiet`);
+  await assertQuietHome(mobile, "quiet account after clearing attention data");
+  await snap(mobile, "mobile-home-quiet-after-clear");
   const mobileVideo = await mobile.video();
   await mobile.close();
   await mobileContext.close();

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -97,7 +97,7 @@ const CLOUD_SIGN_IN_CHOICE = [
 const CLOUD_WELCOME_BACK =
   "Welcome back — you're already signed in to Eliza Cloud. Setting up your agent…";
 const CLOUD_ONLY_DONE =
-  "You're all set — ask me anything. Want a quick tour? Open the Tutorial tile on your home screen whenever you like.";
+  'You\'re all set — ask me anything. Want a quick tour? Type "restart tutorial" whenever you like.';
 
 /** User-facing recovery message when a cloud provisioning call rejects. */
 function cloudFailureMessage(err: unknown): string {
@@ -460,7 +460,7 @@ export function useFirstRunConductor(): void {
 
   // Cloud-only completion (#13377): signing in IS onboarding. The moment
   // provisioning succeeds we flip the real gate — no tutorial/accent pick gates
-  // completion in this mode (the tutorial stays reachable from its home tile).
+  // completion in this mode (the chat-native tutorial remains command-driven).
   // Latched by completedRef so a double-fired finish can't flip the gate twice.
   const completeCloudOnly = React.useCallback(() => {
     if (completedRef.current) return;

--- a/packages/ui/src/widgets/__fixtures__/home-widget-mock-data.ts
+++ b/packages/ui/src/widgets/__fixtures__/home-widget-mock-data.ts
@@ -69,6 +69,14 @@ const minutesFromNow = (m: number) =>
 const hoursFromNow = (h: number) =>
   new Date(Date.now() + h * 3_600_000).toISOString();
 
+export type HomeWidgetMockMode = "attention" | "quiet";
+
+export function homeWidgetMockMode(): HomeWidgetMockMode {
+  if (typeof window === "undefined") return "attention";
+  const params = new URLSearchParams(window.location.search);
+  return params.get("homeData") === "quiet" ? "quiet" : "attention";
+}
+
 // ---------------------------------------------------------------------------
 // Per-widget payloads (verified against each widget's parser).
 // ---------------------------------------------------------------------------
@@ -164,6 +172,12 @@ export const HOME_WIDGET_MOCK_NOTIFICATION: AgentNotification = {
 };
 
 function notificationsPayload() {
+  if (homeWidgetMockMode() === "quiet") {
+    return {
+      notifications: [],
+      unreadCount: 0,
+    };
+  }
   return {
     notifications: [HOME_WIDGET_MOCK_NOTIFICATION],
     unreadCount: 1,
@@ -202,6 +216,31 @@ export function homeWidgetNotificationsResponse() {
   return notificationsPayload();
 }
 
+export function homeWidgetTodosResponse() {
+  if (homeWidgetMockMode() === "quiet") {
+    return { todos: [] };
+  }
+  return {
+    todos: [
+      {
+        id: "todo-groceries",
+        name: "Buy groceries",
+        description: "",
+        type: "task",
+        isCompleted: false,
+        isUrgent: false,
+        priority: 2,
+      },
+    ],
+  };
+}
+
+export function homeWidgetApprovalsResponse() {
+  return homeWidgetMockMode() === "attention"
+    ? approvalsPayload()
+    : { pending: [] };
+}
+
 // ---------------------------------------------------------------------------
 // Fetch mock - the widgets fetch on mount, so install this BEFORE first render.
 // Matches the URL substrings each widget requests (any base) and returns a
@@ -213,8 +252,13 @@ type RouteMatch = { test: (url: string) => boolean; body: () => unknown };
 
 function routeTable(): RouteMatch[] {
   const has = (needle: string) => (url: string) => url.includes(needle);
+  const whenAttention = (body: () => unknown, quietBody: unknown) => () =>
+    homeWidgetMockMode() === "attention" ? body() : quietBody;
   return [
-    { test: has("/api/lifeops/calendar/feed"), body: calendarFeed },
+    {
+      test: has("/api/lifeops/calendar/feed"),
+      body: whenAttention(calendarFeed, { events: [] }),
+    },
     {
       test: has("/api/connectors/google/accounts"),
       body: () => ({
@@ -227,11 +271,39 @@ function routeTable(): RouteMatch[] {
         ],
       }),
     },
-    { test: has("/api/lifeops/goals"), body: goalsPayload },
-    { test: has("/api/lifeops/sleep/history"), body: sleepHistory },
-    { test: has("/api/lifeops/sleep/regularity"), body: sleepRegularity },
+    {
+      test: has("/api/lifeops/goals"),
+      body: whenAttention(goalsPayload, { goals: [] }),
+    },
+    {
+      test: has("/api/lifeops/sleep/history"),
+      body: whenAttention(sleepHistory, {
+        episodes: [],
+        summary: {
+          cycleCount: 0,
+          averageDurationMin: 0,
+          overnightCount: 0,
+          napCount: 0,
+          openCount: 0,
+        },
+        windowDays: 14,
+        includeNaps: true,
+      }),
+    },
+    {
+      test: has("/api/lifeops/sleep/regularity"),
+      body: whenAttention(sleepRegularity, {
+        classification: "regular",
+        sri: 92,
+        sampleSize: 0,
+        windowDays: 14,
+      }),
+    },
     { test: has("/api/notifications"), body: notificationsPayload },
-    { test: has("/api/approvals"), body: approvalsPayload },
+    {
+      test: has("/api/approvals"),
+      body: whenAttention(approvalsPayload, { pending: [] }),
+    },
   ];
 }
 
@@ -314,5 +386,8 @@ export function seedHomeWidgetAppStore(): void {
 /** Reset + ingest the urgent notification into the notification store. */
 export function seedHomeWidgetNotifications(): void {
   __resetNotificationStoreForTests();
-  __ingestNotificationForTests(HOME_WIDGET_MOCK_NOTIFICATION, 1);
+  const { notifications, unreadCount } = notificationsPayload();
+  for (const notification of notifications) {
+    __ingestNotificationForTests(notification, unreadCount);
+  }
 }

--- a/packages/ui/src/widgets/registry.ts
+++ b/packages/ui/src/widgets/registry.ts
@@ -119,7 +119,8 @@ export const BUILTIN_WIDGET_DECLARATIONS: PluginWidgetDeclaration[] = [
   // The first-time-user welcome card (greeting + "try saying…" suggestion
   // chips) and tutorial-launch card were removed deliberately: the agent is
   // proactive on a cold home, with onboarding help living in first-run and chat
-  // commands rather than resident dashboard prompts.
+  // commands rather than resident dashboard prompts. A quiet MVP home must stay
+  // empty of canned tutorial/help cards.
   // Notifications are deliberately NOT a ranked home-slot widget: the dashboard
   // notification center (NotificationsHomeCenter) is pinned by HomeScreen
   // directly below the time/weather base, so a registry entry here would


### PR DESCRIPTION
# Relates to

Closes #14348.

Definition of Done: full standard in [`PR_EVIDENCE.md`](../PR_EVIDENCE.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. This only changes the home-widget fixture/e2e path, removes the durable tutorial card from home registration, and scopes todo contrast styling to the home surface while preserving the sidebar rendering path.

# Background

## What does this PR do?

- Adds a `homeData=quiet` fixture mode and e2e assertions proving a healthy account renders only the resting time/weather home, with notifications, todos, approvals, goal row, and calendar self-hidden.
- Extends the home e2e to prove the state can move from quiet -> attention -> quiet-after-clear without stale keeper cards.
- Removes the tutorial-launch home declaration so onboarding stays chat/command-native instead of occupying a durable home card.
- Applies home-surface todo styling through the existing `tone` path so goal/todo rows remain readable on the dark wallpaper while sidebar todos keep their normal theme.

## What kind of change is this?

Bug fix and test coverage improvement.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Start with `packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs`. The new quiet assertions are at the beginning and end of the mobile home flow.

## Detailed testing steps

- Run `bun run --cwd packages/ui test:home-screen-e2e`.
  - Verify `quiet account` assertions pass before any attention data is seeded.
  - Verify attention mode renders only notifications, Today/todos, Needs response, Calendar, and native OS affordances.
  - Verify `quiet account after clearing attention data` assertions pass after returning to `homeData=quiet`.
- Run the targeted unit slice listed in Evidence Details.
- Run `ELIZA_NODE_PATH=/Users/shawwalters/.nvm/versions/node/v24.15.0/bin/node bun run --cwd packages/app audit:app` for the required app visual audit.

# Evidence Gate

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [ ] Before full-page screenshots: [evidence gist](https://gist.github.com/lalalune/6340c9b8221ae37834135c53a59ff439). Separate pre-fix screenshots were not preserved; the pre-fix evidence was the failing e2e signal that quiet home still rendered tutorial/attention chrome and home todos had dark-on-dark foregrounds.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: [14348-screenshots.svg contact sheet](https://gist.github.com/lalalune/6340c9b8221ae37834135c53a59ff439) with quiet home, attention home, and quiet-after-clear screenshots.
<!-- evidence-row:walkthrough-video -->
- [x] Video walkthrough: [14348-walkthrough.html](https://gist.github.com/lalalune/6340c9b8221ae37834135c53a59ff439), generated from `mobile-launcher-flow.webm` by `test:home-screen-e2e`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - this is a frontend fixture/e2e and home-rendering change; no backend route or server behavior changed`.
<!-- evidence-row:frontend-logs -->
- [x] Frontend logs: [evidence gist command summary](https://gist.github.com/lalalune/6340c9b8221ae37834135c53a59ff439) plus the `test:home-screen-e2e` output in Evidence Details showing fixture network state and DOM assertions.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent/action/provider/prompt/model behavior changed`.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [evidence gist](https://gist.github.com/lalalune/6340c9b8221ae37834135c53a59ff439) contains the generated UI artifacts from the e2e run: screenshots and walkthrough video.

# Evidence Details

## Real LLM-call trajectory

N/A - no agent/action/provider/prompt/model behavior changed.

## Backend + frontend logs

Backend: N/A - no backend path changed.

Frontend / e2e output summary:

```text
bun run --cwd packages/ui test:home-screen-e2e
- quiet account: time/weather visible; home-notification-center, needs-attention, todos, goal row, and calendar self-hide
- attention account: notification center, Today/todos, goal row, needs response, calendar, and native tiles render
- readability gate: home card foregrounds stay readable on the dark ember field ([])
- layout gate: CLS 0.0000; home widgets do not overlap; content overflow 0px
- rail swipe median: p95 10.0ms, dropped 0%
- quiet account after clearing attention data: all attention cards self-hide again
HOME-SCREEN E2E PASSED
```

```text
bun run --cwd packages/ui test -- src/components/chat/widgets/todo.test.tsx src/components/shell/HomeScreen.test.tsx src/components/shell/NotificationsHomeCenter.test.tsx src/widgets/WidgetHost.home-rank.test.tsx src/widgets/home-priority-integration.test.ts
Test Files  5 passed (5)
Tests       43 passed (43)
```

```text
ELIZA_NODE_PATH=/Users/shawwalters/.nvm/versions/node/v24.15.0/bin/node bun run --cwd packages/app audit:app
365 passed (18.6m)
[aesthetic-audit] 364 findings — broken=0 needs-work=123 needs-eyeball=33 good=208 minimalism-budget-failures=0 minimalism-ratchet-failures=0 hover-probe-failures=4 density-probe-failures=0
```

## Screenshots (before / after) + video walkthrough

### Before

Before screenshot gap is listed in Known gaps. The behavior was caught by the new failing quiet-home e2e assertions during development.

### After

After screenshots are in the [evidence gist](https://gist.github.com/lalalune/6340c9b8221ae37834135c53a59ff439), generated from:

- `01-mobile-home-quiet.png`
- `02-mobile-home.png`
- `05-mobile-home-quiet-after-clear.png`

Manual review: quiet home shows only time/weather; attention home shows only the expected notification/todo/approval/calendar/native affordances; quiet-after-clear returns to the sparse home. Audit manual-review notes for `builtin-chat` mobile/desktop/ipad were filled after the final rebase.

### Walkthrough video

Video artifact is in the [evidence gist](https://gist.github.com/lalalune/6340c9b8221ae37834135c53a59ff439), generated from `mobile-launcher-flow.webm`.

## Audio / voice walkthrough

N/A - no voice, transcript, TTS, STT, or audio behavior changed.

## Known gaps / failures

- `bun run verify` was not run end-to-end because the scoped UI checks and required app audit already cover this branch's touched package path; the full monorepo verify is large and has unrelated existing debt. Commands actually run are listed above.
- Before screenshots were not preserved from the initial failing run. The after screenshots/video and the new e2e assertions prove the fixed quiet/attention/quiet-after-clear states.
- App audit still reports existing non-strict aesthetic debt outside this branch: 123 `needs-work`, 33 `needs-eyeball`, and 4 transcript hover-probe timeouts. There are 0 broken states and all 365 Playwright audit cases passed.
