### PR TITLE
test: lock reminder chat choice replies

### DIFF
--- a/plugins/plugin-personal-assistant/test/reminder-helpers.test.ts
+++ b/plugins/plugin-personal-assistant/test/reminder-helpers.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import {
   _isReminderIntensity,
+  classifyReminderOwnerResponseText,
   coerceReminderIntensity,
   isReminderChannel,
   isReminderReviewClosed,
@@ -82,5 +83,35 @@ describe("review attempt reads", () => {
     expect(isReminderReviewClosed({ reviewStatus: "escalated" })).toBe(true);
     expect(isReminderReviewClosed({ reviewStatus: "pending" })).toBe(false);
     expect(isReminderReviewClosed({ reviewStatus: null })).toBe(false);
+  });
+});
+
+describe("owner reply classifier", () => {
+  it("resolves reminder chat choice payloads without semantic fallback", () => {
+    const context = {
+      title: "Take your meds.",
+      attemptedAt: "2026-07-06T12:00:00.000Z",
+      respondedAt: "2026-07-06T12:01:00.000Z",
+      channel: "in_app" as const,
+      allowStandaloneResolution: true,
+    };
+
+    expect(classifyReminderOwnerResponseText("done", context)).toMatchObject({
+      decision: "explicit_resolution",
+      resolution: "completed",
+      snoozeRequest: null,
+    });
+    expect(
+      classifyReminderOwnerResponseText("10 minutes", context),
+    ).toMatchObject({
+      decision: "explicit_resolution",
+      resolution: "snoozed",
+      snoozeRequest: { minutes: 10 },
+    });
+    expect(classifyReminderOwnerResponseText("skip", context)).toMatchObject({
+      decision: "explicit_resolution",
+      resolution: "skipped",
+      snoozeRequest: null,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Adds regression coverage proving the exact reminder chat choice payloads from #14842 (`done`, `10 minutes`, `skip`) resolve through the deterministic reminder owner-reply classifier.
- Ties the chat-visible reminder chips to the LifeOps resolution path for #14732 without relying on semantic/model fallback.

## Evidence
- `bunx vitest run packages/agent/src/api/server-helpers-swarm.test.ts` -> 1 file passed, 15 tests passed.
- `bunx vitest run --config vitest.config.ts src/lifeops/domains/reminders-service.in-app-nudge.test.ts test/reminder-helpers.test.ts` -> 2 files passed, 7 tests passed.
- `bunx @biomejs/biome check packages/agent/src/api/server-helpers-swarm.ts packages/agent/src/api/server-helpers-swarm.test.ts plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.in-app-nudge.test.ts plugins/plugin-personal-assistant/test/reminder-helpers.test.ts` -> clean.
- `git diff --check` -> clean.

## Visual / Live Evidence
- N/A - test-only follow-up. #14842 carries the user-facing chat persistence change; this PR only adds deterministic classifier coverage for the emitted choice payloads.