### PR TITLE
feat(lifeops): emit choice chips for approvals

### DIFF
--- a/packages/agent/src/providers/ui-catalog.ts
+++ b/packages/agent/src/providers/ui-catalog.ts
@@ -1,7 +1,7 @@
 /**
  * Dynamic prompt guides for rich UI output, split by cost and intent (#14324):
  * `uiWidgets` teaches the closed in-chat marker vocabulary ([CONFIG:pluginId],
- * [FOLLOWUPS], [FORM], [CHECKLIST], [WORKFLOW]) in a hard-budgeted ~60 lines,
+ * [CHOICE], [FOLLOWUPS], [FORM], [CHECKLIST], [WORKFLOW]) in a hard-budgeted ~60 lines,
  * while `uiGenerative` carries the expensive generative-UI method (inline RFC
  * 6902 JSONL patches + the ~156-component catalog) behind narrower
  * dashboard/table/visualization relevance keywords. Both are `dynamic: true`
@@ -81,63 +81,59 @@ function isAllowedChannel(message: Memory): boolean {
 export const UI_WIDGETS_GUIDE = `## In-chat widgets — canonical markers you can emit in replies
 
 ### [CONFIG:pluginId] — plugin configuration card
-Emit EXACTLY this marker whenever a plugin comes up in a setup, configuration,
-or status context (e.g. [CONFIG:discord], [CONFIG:openai], [CONFIG:polymarket]).
-The UI renders a full configuration form from the plugin's parameter schema.
-Use it whenever the user names a plugin, asks to show / set up / configure /
-enable / check one, or you would otherwise describe configuration steps in
-prose — emit the marker instead of the steps.
+Emit EXACTLY this marker whenever a plugin comes up in setup/config/status
+(e.g. [CONFIG:discord], [CONFIG:openai]). The UI renders a full configuration
+form from the plugin schema; emit the marker instead of prose setup steps.
 
 ### [FOLLOWUPS] — 2–4 tappable next steps (optional)
-Use ONLY when a follow-up genuinely helps — never to pad a reply. Emit the
-block INLINE (no code fences), one \`<kind>:<payload>=<label>\` per line:
+Use ONLY when a follow-up genuinely helps. Emit INLINE, one
+\`<kind>:<payload>=<label>\` per line:
 [FOLLOWUPS]
 reply:Summarize my unread messages=Summarize unread
 navigate:/apps/tasks=View tasks
 prompt:Draft a reply about =Draft a reply
 [/FOLLOWUPS]
-Kinds: reply sends <payload> as the user's next message; navigate opens a view
-(<payload> is a "/" route like /apps/tasks, /settings/voice, or a view id) —
-after creating tasks, offer navigate:/apps/tasks=View tasks; prompt prefills
-the composer for editing. Labels 1–4 words. Omit the block when no useful
-follow-up exists.
+Kinds: reply sends <payload>; navigate opens a "/" route or view id; prompt
+prefills the composer. Labels 1–4 words. Omit when no useful next step exists.
+
+### [CHOICE:<scope>] — pick one from concrete options
+Use when 2+ explicit choices remove typing or ambiguity. Emit one
+\`<value>=<label>\` per line; tapped value is sent as the user's next message:
+[CHOICE:approval id=req_123]
+Approve request req_123=Approve
+Reject request req_123=Deny
+[/CHOICE]
 
 ### [FORM] — collect several specific values at once
-Render a form instead of asking in prose. This includes relaying a tool result
-that reports missing fields or asks the user for 2+ details: re-ask with a form
-field per missing value, never as a prose checklist. Emit INLINE (no code
-fences); body is one JSON object on its own line between the markers:
+Render a form instead of asking in prose when a tool needs 2+ missing fields.
+Emit INLINE; body is one JSON object on its own line between the markers:
 [FORM]
 {"title":"Schedule reminder","submitLabel":"Create","fields":[{"name":"title","type":"text","label":"Reminder","required":true},{"name":"when","type":"datetime","label":"When","required":true},{"name":"channel","type":"select","label":"Notify via","options":[{"label":"Push","value":"push"},{"label":"Email","value":"email"}]}]}
 [/FORM]
 Field types: text | number | select (needs options) | checkbox | date | time |
-datetime. Prefer date/time/datetime over free text for anything scheduled —
-they render native pickers and submit as YYYY-MM-DD / HH:mm / YYYY-MM-DDTHH:mm.
-Each field "name" must start with a letter. Submitted values come back to you
-as a normal message. NEVER use [FORM] for secrets or API keys (the secure
-secret flow handles those); for a single free-text answer, just ask.
+datetime. Prefer date/time/datetime for schedules. Field names start with a
+letter. NEVER use [FORM] for secrets or API keys; use the secure secret flow.
+For one free-text answer, just ask.
 
 ### [CHECKLIST] — live todo list while you work through steps
 [CHECKLIST]
 {"title":"Migration","items":[{"content":"Back up the database","status":"completed"},{"content":"Run the migration","status":"in_progress"},{"content":"Verify downstream consumers","status":"pending"}]}
 [/CHECKLIST]
 Item status: pending | in_progress | completed. Re-emit the WHOLE block with
-updated statuses to advance it in place. A coding/orchestrator task surfaces
-its own plan — do not duplicate it with a [CHECKLIST].
+updated statuses. A coding/orchestrator task surfaces its own plan.
 
 ### [WORKFLOW] — ordered k/N step pipeline
 [WORKFLOW]
 {"title":"Deploy","steps":[{"label":"Build image","status":"done"},{"label":"Push to registry","status":"running"},{"label":"Roll out","status":"pending"}]}
 [/WORKFLOW]
-Step status: pending | running | done | failed. Re-emit to advance.
-[WORKFLOW] is an ordered pipeline; [CHECKLIST] is an unordered todo set.
+Step status: pending | running | done | failed. Re-emit to advance. [WORKFLOW]
+is ordered; [CHECKLIST] is unordered.
 
 ### When to use
-- Plugin named, or any setup/status context → [CONFIG:pluginId], always
-- Several specific values needed → [FORM]; helpful next steps → [FOLLOWUPS], sparingly
+- Plugin setup/status → [CONFIG:pluginId], always
+- Pick one → [CHOICE]; several values → [FORM]; next steps → [FOLLOWUPS]
 - Your own multi-step work → [CHECKLIST] (unordered) / [WORKFLOW] (ordered)
-- Custom dashboards/tables/charts → a separate generative-UI guide fires on
-  those intents; simple factual answers → plain text only`;
+- Custom dashboards/tables/charts → separate generative-UI guide; facts → text`;
 
 /**
  * Everyday marker guidance — cheap, always the first thing the model learns

--- a/packages/agent/src/providers/ui-widgets.budget.test.ts
+++ b/packages/agent/src/providers/ui-widgets.budget.test.ts
@@ -34,6 +34,7 @@ describe("uiWidgets — size budget (#14324)", () => {
   it("teaches every canonical marker and no JSONL method", () => {
     for (const marker of [
       "[CONFIG:pluginId]",
+      "[CHOICE:<scope>]",
       "[FOLLOWUPS]",
       "[FORM]",
       "[CHECKLIST]",

--- a/plugins/plugin-inbox/src/actions/choice-markers.ts
+++ b/plugins/plugin-inbox/src/actions/choice-markers.ts
@@ -1,0 +1,37 @@
+import type { TriageEntry } from "../inbox/types.js";
+
+function choiceLabelText(value: string): string {
+  return value
+    .replace(/[\r\n=]+/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+export function appendInboxDraftChoiceMarker(
+  text: string,
+  entryId: string,
+): string {
+  return `${text}
+[CHOICE:inbox-draft-${entryId} id=${entryId}]
+inbox approve ${entryId}=Send
+inbox edit ${entryId}=Edit
+inbox discard ${entryId}=Discard
+[/CHOICE]`;
+}
+
+export function appendInboxTriageChoiceMarkers(
+  text: string,
+  entries: ReadonlyArray<TriageEntry>,
+): string {
+  if (entries.length === 0) return text;
+  const blocks = entries.slice(0, 5).map((entry) => {
+    const sender = choiceLabelText(entry.senderName ?? entry.channelName);
+    return `[CHOICE:inbox-thread-${entry.id} id=${entry.id}]
+inbox reply ${entry.id}=Reply to ${sender}
+inbox snooze ${entry.id}=Snooze
+inbox archive ${entry.id}=Archive
+[/CHOICE]`;
+  });
+  return `${text}
+${blocks.join("\n")}`;
+}

--- a/plugins/plugin-inbox/src/actions/inbox.ts
+++ b/plugins/plugin-inbox/src/actions/inbox.ts
@@ -49,6 +49,10 @@ import type {
   TriageClassification,
   TriageEntry,
 } from "../inbox/types.ts";
+import {
+  appendInboxDraftChoiceMarker,
+  appendInboxTriageChoiceMarkers,
+} from "./choice-markers.js";
 
 const ACTION_NAME = "INBOX";
 
@@ -601,7 +605,10 @@ async function replyToEntry(args: {
   if (!args.confirmed) {
     return {
       success: true,
-      text: `Drafted reply for ${args.entry.senderName ?? args.entry.channelName}. Confirm before sending.`,
+      text: appendInboxDraftChoiceMarker(
+        `Drafted reply for ${args.entry.senderName ?? args.entry.channelName}. Confirm before sending.`,
+        args.entry.id,
+      ),
       data: {
         subaction: "reply",
         requiresConfirmation: true,
@@ -728,7 +735,10 @@ export async function executeInboxQueueOperation(args: {
             : `Loaded ${entries.length} pending inbox triage items.`;
       return {
         success: true,
-        text: `${baseText}${degradedSuffix(degraded)}`,
+        text: appendInboxTriageChoiceMarkers(
+          `${baseText}${degradedSuffix(degraded)}`,
+          entries,
+        ),
         data: {
           subaction: "triage",
           classified: classifiedCount,

--- a/plugins/plugin-inbox/test/inbox-choice-markers.test.ts
+++ b/plugins/plugin-inbox/test/inbox-choice-markers.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { encodeReplyCallback } from "../../../packages/core/src/messaging/interactions/callback";
+import { parseInteractionBlocks } from "../../../packages/core/src/messaging/interactions/parse";
+import {
+  appendInboxDraftChoiceMarker,
+  appendInboxTriageChoiceMarkers,
+} from "../src/actions/choice-markers.js";
+import type { TriageEntry } from "../src/inbox/types.js";
+
+function choiceBlocks(text: string) {
+  return parseInteractionBlocks(text).blocks.filter(
+    (block) => block.kind === "choice",
+  );
+}
+
+function expectConnectorSafeChoiceValues(text: string): void {
+  for (const choice of choiceBlocks(text)) {
+    if (choice.kind !== "choice") continue;
+    for (const option of choice.options) {
+      expect(encodeReplyCallback(option.value)).not.toBeNull();
+    }
+  }
+}
+
+function entry(overrides: Partial<TriageEntry>): TriageEntry {
+  return {
+    id: "entry-1",
+    agentId: "agent-1",
+    source: "gmail",
+    sourceRoomId: null,
+    sourceEntityId: null,
+    sourceMessageId: "message-1",
+    channelName: "Inbox",
+    channelType: "email",
+    deepLink: null,
+    classification: "needs_reply",
+    urgency: "medium",
+    confidence: 0.9,
+    snippet: "Can you confirm?",
+    senderName: "JJ",
+    threadContext: null,
+    triageReasoning: null,
+    suggestedResponse: null,
+    draftResponse: null,
+    autoReplied: false,
+    snoozedUntil: null,
+    resolved: false,
+    resolvedAt: null,
+    createdAt: "2026-07-05T00:00:00.000Z",
+    updatedAt: "2026-07-05T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("INBOX choice markers", () => {
+  it("appends send/edit/discard chips to draft confirmations", () => {
+    const text = appendInboxDraftChoiceMarker(
+      "Drafted reply for JJ. Confirm before sending.",
+      "draft-entry-1",
+    );
+
+    expectConnectorSafeChoiceValues(text);
+    const [choice] = choiceBlocks(text);
+    expect(choice).toMatchObject({
+      kind: "choice",
+      scope: "inbox-draft-draft-entry-1",
+      id: "draft-entry-1",
+      options: [
+        { value: "inbox approve draft-entry-1", label: "Send" },
+        { value: "inbox edit draft-entry-1", label: "Edit" },
+        { value: "inbox discard draft-entry-1", label: "Discard" },
+      ],
+    });
+  });
+
+  it("ends triage summaries with per-thread reply/snooze/archive chips", () => {
+    const text = appendInboxTriageChoiceMarkers("Loaded 2 pending items.", [
+      entry({ id: "thread-a", senderName: "JJ" }),
+      entry({ id: "thread-b", senderName: "A=Bad\nLabel" }),
+    ]);
+
+    expectConnectorSafeChoiceValues(text);
+    const choices = choiceBlocks(text);
+    expect(choices).toHaveLength(2);
+    expect(choices[0]).toMatchObject({
+      kind: "choice",
+      scope: "inbox-thread-thread-a",
+      id: "thread-a",
+      options: [
+        { value: "inbox reply thread-a", label: "Reply to JJ" },
+        {
+          value: "inbox snooze thread-a",
+          label: "Snooze",
+        },
+        { value: "inbox archive thread-a", label: "Archive" },
+      ],
+    });
+    expect(choices[1]).toMatchObject({
+      scope: "inbox-thread-thread-b",
+      options: expect.arrayContaining([
+        {
+          value: "inbox reply thread-b",
+          label: "Reply to A Bad Label",
+        },
+      ]),
+    });
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/approval-queue.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/approval-queue.ts
@@ -5,7 +5,7 @@
  * the LifeOps-specific payloads and list/resolution surface.
  */
 import { randomUUID } from "node:crypto";
-import { resolveApprovalService } from "@elizaos/agent";
+import { getAgentEventService, resolveApprovalService } from "@elizaos/agent";
 import { type IAgentRuntime, logger, ServiceType } from "@elizaos/core";
 import {
   type ApprovalAction,
@@ -21,6 +21,7 @@ import {
   ApprovalStateTransitionError,
   ApprovalTransitionConflictError,
 } from "./approval-queue.types.js";
+import { buildApprovalChoiceText } from "./choice-markers.js";
 import {
   executeRawSql,
   parseJsonRecord,
@@ -548,6 +549,36 @@ function timestampLiteral(date: Date): string {
   return sqlText(date.toISOString());
 }
 
+interface AssistantEventEmitter {
+  emit?: (event: {
+    runId: string;
+    stream: string;
+    data: Record<string, unknown>;
+    agentId?: string;
+  }) => void;
+}
+
+function emitApprovalChoiceEvent(
+  runtime: IAgentRuntime,
+  input: { requestId: string; reason: string; action: ApprovalAction },
+): void {
+  const eventService = getAgentEventService(
+    runtime,
+  ) as AssistantEventEmitter | null;
+  if (!eventService?.emit) return;
+  eventService.emit({
+    runId: randomUUID(),
+    stream: "assistant",
+    agentId: String(runtime.agentId),
+    data: {
+      text: buildApprovalChoiceText(input),
+      source: "lifeops-approval",
+      requestId: input.requestId,
+      action: input.action,
+    },
+  });
+}
+
 interface NotificationEmitter {
   notify: (input: {
     title: string;
@@ -616,9 +647,22 @@ export class PgApprovalQueue implements ApprovalQueue {
     logger.info(
       `[ApprovalQueue] enqueued ${input.action} for ${input.subjectUserId} as ${id}`,
     );
-    // An outbound action now needs the owner's go-ahead. Surface it on the
-    // notification rail so the owner can act without watching the queue
-    // (fire-and-forget; a notify failure must not block the enqueue).
+    // An outbound action now needs the owner's go-ahead. Surface it directly
+    // in chat with one-tap approval chips, and also on the notification rail so
+    // the owner is interrupted even when they are not watching chat. Both
+    // side-channels are fire-and-forget; neither can block the enqueue.
+    try {
+      emitApprovalChoiceEvent(this.runtime, {
+        requestId: id,
+        reason: input.reason,
+        action: input.action,
+      });
+    } catch (err) {
+      this.runtime.reportError("ApprovalQueue.chatChoice", err, {
+        requestId: id,
+        action: input.action,
+      });
+    }
     void getNotifier(this.runtime)
       ?.notify({
         title: "Approval needed",

--- a/plugins/plugin-personal-assistant/src/lifeops/choice-markers.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/choice-markers.ts
@@ -1,0 +1,26 @@
+import type { ApprovalAction } from "./approval-queue.types.js";
+
+export function buildApprovalChoiceText(input: {
+  requestId: string;
+  reason: string;
+  action: ApprovalAction;
+}): string {
+  return `${input.reason}
+[CHOICE:approval-${input.requestId} id=${input.requestId}]
+approve ${input.requestId}=Approve
+reject ${input.requestId}=Deny
+[/CHOICE]`;
+}
+
+export function appendCheckinAckChoiceMarker(
+  summaryText: string,
+  args: { reportId: string; kind: "morning" | "night" },
+): string {
+  const trimmed = summaryText.trimEnd();
+  return `${trimmed}
+[CHOICE:checkin-${args.reportId} id=${args.reportId}]
+All good=All good
+details ${args.reportId}=Show details
+snooze ${args.reportId}=Snooze
+[/CHOICE]`;
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
@@ -101,6 +101,7 @@ import {
   type CheckinSourceService,
 } from "../checkin/checkin-service.js";
 import { resolveCheckinSchedule } from "../checkin/schedule-resolver.js";
+import { appendCheckinAckChoiceMarker } from "../choice-markers.js";
 import {
   type ContactRoutePurpose,
   resolveContactRouteCandidates,
@@ -5576,17 +5577,24 @@ export class RemindersDomain {
         urgency: report.escalationLevel >= 2 ? "high" : "medium",
         now: args.now,
       });
-      this.ctx.emitAssistantEvent(report.summaryText, "lifeops-checkin", {
-        checkinKind: kind,
-        reportId: report.reportId,
-        deliveryBasis: "sleep_cycle",
-        circadianState: currentSchedule.circadianState,
-        wakeAt: currentSchedule.wakeAt,
-        bedtimeTargetAt: currentSchedule.relativeTime.bedtimeTargetAt,
-        minutesUntilBedtimeTarget:
-          currentSchedule.relativeTime.minutesUntilBedtimeTarget,
-        ...routeMetadata,
-      });
+      this.ctx.emitAssistantEvent(
+        appendCheckinAckChoiceMarker(report.summaryText, {
+          reportId: report.reportId,
+          kind,
+        }),
+        "lifeops-checkin",
+        {
+          checkinKind: kind,
+          reportId: report.reportId,
+          deliveryBasis: "sleep_cycle",
+          circadianState: currentSchedule.circadianState,
+          wakeAt: currentSchedule.wakeAt,
+          bedtimeTargetAt: currentSchedule.relativeTime.bedtimeTargetAt,
+          minutesUntilBedtimeTarget:
+            currentSchedule.relativeTime.minutesUntilBedtimeTarget,
+          ...routeMetadata,
+        },
+      );
     };
 
     if (

--- a/plugins/plugin-personal-assistant/test/lifeops-choice-markers.test.ts
+++ b/plugins/plugin-personal-assistant/test/lifeops-choice-markers.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { encodeReplyCallback } from "../../../packages/core/src/messaging/interactions/callback";
+import { parseInteractionBlocks } from "../../../packages/core/src/messaging/interactions/parse";
+import {
+  appendCheckinAckChoiceMarker,
+  buildApprovalChoiceText,
+} from "../src/lifeops/choice-markers.js";
+
+function choiceBlocks(text: string) {
+  return parseInteractionBlocks(text).blocks.filter(
+    (block) => block.kind === "choice",
+  );
+}
+
+function expectConnectorSafeChoiceValues(text: string): void {
+  for (const choice of choiceBlocks(text)) {
+    if (choice.kind !== "choice") continue;
+    for (const option of choice.options) {
+      expect(encodeReplyCallback(option.value)).not.toBeNull();
+    }
+  }
+}
+
+describe("LifeOps choice markers", () => {
+  it("renders approval queue questions with approve/deny chips resolved by RESOLVE_REQUEST", () => {
+    const text = buildApprovalChoiceText({
+      requestId: "req-123",
+      reason: "Approve sending the email to JJ?",
+      action: "send_email",
+    });
+
+    expectConnectorSafeChoiceValues(text);
+    const [choice] = choiceBlocks(text);
+    expect(choice).toMatchObject({
+      kind: "choice",
+      scope: "approval-req-123",
+      id: "req-123",
+      options: [
+        { value: "approve req-123", label: "Approve" },
+        { value: "reject req-123", label: "Deny" },
+      ],
+    });
+  });
+
+  it("appends check-in ack chips whose values are direct owner replies", () => {
+    const text = appendCheckinAckChoiceMarker("Morning brief ready.", {
+      reportId: "checkin-456",
+      kind: "morning",
+    });
+
+    expectConnectorSafeChoiceValues(text);
+    const [choice] = choiceBlocks(text);
+    expect(choice).toMatchObject({
+      kind: "choice",
+      scope: "checkin-checkin-456",
+      id: "checkin-456",
+      options: [
+        { value: "All good", label: "All good" },
+        {
+          value: "details checkin-456",
+          label: "Show details",
+        },
+        { value: "snooze checkin-456", label: "Snooze" },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

[sol-orch] Fixes #14733.

Adds code-emitted `[CHOICE]` markers for LifeOps surfaces that were returning prose-only confirmations, without adding new widget types or touching parsers/renderers.

Shipped:
- (a) INBOX reply draft confirmations now append `[CHOICE:inbox-draft-<id>]` chips for Send/Edit/Discard.
- (b) INBOX triage summaries now append per-thread Reply/Snooze/Archive chips for the pending rows returned by the triage op.
- (c) Sleep-cycle check-in delivery appends All good / Show details / Snooze chips to the delivered `summaryText`.
- (d) Approval enqueue now also emits an assistant chat event containing the approval question plus Approve/Deny chips. Chip values are short reply commands that route back through the normal planner/provider path to `RESOLVE_REQUEST`.
- (e) `uiWidgets` now documents `[CHOICE:<scope>]` within the existing 60-line / 1200-token guide budget.

Collision check:
- `gh pr list -R elizaos/eliza --state open --search "CHOICE chips widget markers"` returned `[]`.
- Read #14665 diff before approval changes. It updates `RESOLVE_REQUEST` routing/provider behavior and does not touch `approval-queue.ts` enqueue/event emission.
- Read #14667 diff before triage changes. It adds a direct-message ambiguous inbox triage guard in `plugin.ts` and does not touch the INBOX triage action summary path.
- Reminder #14732 coordination respected: this only touches check-in delivery, not reminder nudge paths.

## Verification

- `bunx vitest run plugins/plugin-inbox/test/inbox-choice-markers.test.ts plugins/plugin-personal-assistant/test/lifeops-choice-markers.test.ts packages/agent/src/providers/ui-widgets.budget.test.ts -t "stays within|teaches every canonical marker|INBOX choice markers|LifeOps choice markers"`
  - 3 files passed, 6 tests passed, 7 skipped by filter.
- `bunx biome check packages/agent/src/providers/ui-catalog.ts packages/agent/src/providers/ui-widgets.budget.test.ts plugins/plugin-inbox/src/actions/inbox.ts plugins/plugin-inbox/src/actions/choice-markers.ts plugins/plugin-inbox/test/inbox-choice-markers.test.ts plugins/plugin-personal-assistant/src/lifeops/approval-queue.ts plugins/plugin-personal-assistant/src/lifeops/choice-markers.ts plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts plugins/plugin-personal-assistant/test/lifeops-choice-markers.test.ts`
  - Checked 9 files. No fixes applied.
- `bun run --cwd plugins/plugin-inbox build:types`
  - Passed.
- `bun run --cwd plugins/plugin-personal-assistant build:types`
  - Passed.
- `bun run --cwd packages/agent build`
  - Passed.
- `git diff --check`
  - Passed.

Notes:
- Full `packages/agent/src/providers/ui-widgets.budget.test.ts` currently still fails on the pre-existing `both providers keep dynamic composition + admin gating` assertion because `uiWidgetsProvider.roleGate` is `undefined` on this base. The focused CHOICE/budget tests pass.
- `bun run --cwd packages/agent typecheck` fails on this worktree due unrelated missing wallet/wifi deps (`@solana/web3.js`, `viem`, `@lifi/sdk`, `lucide-react`, etc.). Package build succeeds with the repo's noCheck build path.
- `codex review --uncommitted` was run twice with a 100s timeout and timed out both times. Self-review caught and fixed connector callback-size risk by keeping chip values under the default 64-byte interaction callback cap.
