### PR TITLE
fix(discord): keep team members out of owner aliases (#14712)

### DIFF
--- a/plugins/plugin-discord/AGENTS.md
+++ b/plugins/plugin-discord/AGENTS.md
@@ -131,6 +131,7 @@ bun run --cwd plugins/plugin-discord clean       # rm dist + .turbo + generated 
 | `DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS` | No | `"false"` to reply without an @-mention (default: `true`) |
 | `DISCORD_DM_POLICY` | No | DM access policy: `open` / `allowlist` / `pairing` / `disabled` (default: `pairing`) |
 | `DISCORD_ALLOW_FROM` | No | Comma-separated Discord user IDs allowed under the `allowlist` DM policy |
+| `ELIZA_DISCORD_OWNER_USER_IDS_JSON` | No | JSON array of Discord user IDs that should alias to the canonical Eliza owner entity. Use only for the actual owner or deliberate owner aliases; Discord application team members are kept as separate entities and may be connector admins via `ELIZA_ROLES_CONNECTOR_ADMINS_JSON`. |
 | `DISCORD_AUTO_REPLY` | No | `"true"` to auto-generate replies; default `false` (messages are ingested but not answered) |
 | `DISCORD_SYNC_PROFILE` | No | `"false"` to skip bot profile sync on startup (default: `true`) |
 | `DISCORD_IPC_DIR` | No | Override the IPC socket directory searched by `DiscordLocalService` when connecting to the Discord desktop app |

--- a/plugins/plugin-discord/CLAUDE.md
+++ b/plugins/plugin-discord/CLAUDE.md
@@ -131,6 +131,7 @@ bun run --cwd plugins/plugin-discord clean       # rm dist + .turbo + generated 
 | `DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS` | No | `"false"` to reply without an @-mention (default: `true`) |
 | `DISCORD_DM_POLICY` | No | DM access policy: `open` / `allowlist` / `pairing` / `disabled` (default: `pairing`) |
 | `DISCORD_ALLOW_FROM` | No | Comma-separated Discord user IDs allowed under the `allowlist` DM policy |
+| `ELIZA_DISCORD_OWNER_USER_IDS_JSON` | No | JSON array of Discord user IDs that should alias to the canonical Eliza owner entity. Use only for the actual owner or deliberate owner aliases; Discord application team members are kept as separate entities and may be connector admins via `ELIZA_ROLES_CONNECTOR_ADMINS_JSON`. |
 | `DISCORD_AUTO_REPLY` | No | `"true"` to auto-generate replies; default `false` (messages are ingested but not answered) |
 | `DISCORD_SYNC_PROFILE` | No | `"false"` to skip bot profile sync on startup (default: `true`) |
 | `DISCORD_IPC_DIR` | No | Override the IPC socket directory searched by `DiscordLocalService` when connecting to the Discord desktop app |

--- a/plugins/plugin-discord/README.md
+++ b/plugins/plugin-discord/README.md
@@ -60,6 +60,12 @@ DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS=true
 
 # Testing (Optional)
 DISCORD_TEST_CHANNEL_ID=123456789012345678
+
+# Owner Alias Override (Optional)
+# JSON array of Discord user IDs that intentionally alias to the canonical
+# Eliza owner entity. Do not put ordinary Discord application team members here;
+# they stay auditable as separate connector-admin identities.
+ELIZA_DISCORD_OWNER_USER_IDS_JSON='["123456789012345678"]'
 ```
 
 Settings can also be configured in your character file under `settings.discord`:

--- a/plugins/plugin-discord/__tests__/identity.test.ts
+++ b/plugins/plugin-discord/__tests__/identity.test.ts
@@ -1,21 +1,22 @@
 /**
- * Unit tests for owner-user-id extraction and parsing from settings
- * (`extractDiscordOwnerUserIds`, `parseDiscordOwnerUserIds`). Pure-function
- * assertions.
+ * Unit tests for Discord owner alias extraction, team-admin extraction, and
+ * owner-id setting parsing. These pure helpers decide whether an inbound
+ * Discord user is collapsed to the canonical owner entity or kept auditable as
+ * their own connector identity.
  */
 import { describe, expect, it } from "vitest";
 import {
 	extractDiscordOwnerUserIds,
+	extractDiscordTeamAdminUserIds,
 	parseDiscordOwnerUserIds,
 } from "../identity.ts";
 
 /**
  * Owner-id resolution decides who the Discord bot treats as its owner — a
  * security-sensitive grant. Snowflakes must match Discord's 15-20 digit shape
- * (anything else is rejected, never coerced), extraction must dedupe across the
- * direct owner / team owner / team members shapes (Array OR discord.js
- * Collection), and parse must tolerate JSON-string or array config without
- * letting a malformed id through.
+ * (anything else is rejected, never coerced). Team members are connector-admin
+ * candidates, but they must never be owner aliases because owner aliasing also
+ * rewrites message attribution to the canonical owner entity.
  */
 
 const SNOWFLAKE_A = "123456789012345678";
@@ -28,7 +29,7 @@ describe("extractDiscordOwnerUserIds", () => {
 		]);
 	});
 
-	it("collects + dedupes team owner and members", () => {
+	it("collects + dedupes direct owner and team owner only", () => {
 		const application = {
 			owner: { id: SNOWFLAKE_A },
 			team: {
@@ -37,19 +38,50 @@ describe("extractDiscordOwnerUserIds", () => {
 			},
 		};
 		const ids = extractDiscordOwnerUserIds(application);
-		expect(ids.sort()).toEqual([SNOWFLAKE_A, SNOWFLAKE_B].sort());
+		expect(ids).toEqual([SNOWFLAKE_A]);
 	});
 
-	it("handles a discord.js Collection (Map of [key, member])", () => {
+	it("reads a team-owned application's team owner as the owner alias", () => {
+		expect(
+			extractDiscordOwnerUserIds({
+				team: {
+					ownerId: SNOWFLAKE_A,
+					members: [{ user: { id: SNOWFLAKE_B } }],
+				},
+			}),
+		).toEqual([SNOWFLAKE_A]);
+	});
+
+	it("does not treat a discord.js team member Collection as owner aliases", () => {
 		const members = new Map([["k", { user: { id: SNOWFLAKE_B } }]]);
-		expect(extractDiscordOwnerUserIds({ team: { members } })).toEqual([
-			SNOWFLAKE_B,
-		]);
+		expect(extractDiscordOwnerUserIds({ team: { members } })).toEqual([]);
 	});
 
 	it("returns [] for non-objects", () => {
 		expect(extractDiscordOwnerUserIds(null)).toEqual([]);
 		expect(extractDiscordOwnerUserIds("nope")).toEqual([]);
+	});
+});
+
+describe("extractDiscordTeamAdminUserIds", () => {
+	it("collects team members from array-shaped application metadata", () => {
+		expect(
+			extractDiscordTeamAdminUserIds({
+				team: { members: [{ user: { id: SNOWFLAKE_B } }] },
+			}),
+		).toEqual([SNOWFLAKE_B]);
+	});
+
+	it("handles a discord.js Collection (Map of [key, member])", () => {
+		const members = new Map([["k", { user: { id: SNOWFLAKE_B } }]]);
+		expect(extractDiscordTeamAdminUserIds({ team: { members } })).toEqual([
+			SNOWFLAKE_B,
+		]);
+	});
+
+	it("returns [] for non-objects", () => {
+		expect(extractDiscordTeamAdminUserIds(null)).toEqual([]);
+		expect(extractDiscordTeamAdminUserIds("nope")).toEqual([]);
 	});
 });
 

--- a/plugins/plugin-discord/__tests__/owner-refresh.test.ts
+++ b/plugins/plugin-discord/__tests__/owner-refresh.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Service-level Discord owner refresh tests. The harness calls the real
+ * `DiscordService.prototype.refreshOwnerDiscordUserIds` with a fake ready
+ * client so owner aliasing and connector-admin whitelist writes stay coupled.
+ */
+import { getConnectorAdminWhitelist, type IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { DiscordService } from "../service.ts";
+
+const OWNER_ID = "123456789012345678";
+const TEAM_MEMBER_ID = "234567890123456789";
+
+function makeRuntime(): IAgentRuntime {
+	const settings = new Map<string, string | null>();
+	return {
+		agentId: "agent-1",
+		character: { name: "Eliza" },
+		getSetting: (key: string) => settings.get(key),
+		setSetting: (key: string, value: string | null) => {
+			settings.set(key, value);
+		},
+		logger: {
+			error: vi.fn(),
+			warn: vi.fn(),
+			info: vi.fn(),
+			debug: vi.fn(),
+		},
+	} as unknown as IAgentRuntime;
+}
+
+describe("DiscordService.refreshOwnerDiscordUserIds", () => {
+	it("keeps team members out of the owner alias set while whitelisting them as connector admins", async () => {
+		const runtime = makeRuntime();
+		const service = Object.assign(Object.create(DiscordService.prototype), {
+			runtime,
+		}) as DiscordService;
+		const client = {
+			application: {
+				fetch: vi.fn().mockResolvedValue({
+					team: {
+						ownerId: OWNER_ID,
+						members: [
+							{ user: { id: OWNER_ID } },
+							{ user: { id: TEAM_MEMBER_ID } },
+						],
+					},
+				}),
+			},
+		};
+
+		await service.refreshOwnerDiscordUserIds(client as never);
+
+		const ownerAliases = (
+			service as unknown as { ownerDiscordUserIds: Set<string> }
+		).ownerDiscordUserIds;
+		expect([...ownerAliases]).toEqual([OWNER_ID]);
+		expect(getConnectorAdminWhitelist(runtime).discord).toEqual([
+			OWNER_ID,
+			TEAM_MEMBER_ID,
+		]);
+	});
+});

--- a/plugins/plugin-discord/identity.ts
+++ b/plugins/plugin-discord/identity.ts
@@ -1,7 +1,8 @@
 /**
  * Owner/entity id resolution and world/entity metadata for Discord. Maps
- * Discord user ids to runtime entity ids and builds the world/entity metadata
- * stored on inbound messages.
+ * Discord user ids to runtime entity ids, keeping bot-application owner
+ * aliases separate from Discord team admin grants so message attribution stays
+ * auditable.
  */
 import {
 	createUniqueUuid,
@@ -99,6 +100,16 @@ export function extractDiscordOwnerUserIds(application: unknown): string[] {
 		ownerCandidates.add(teamOwnerId);
 	}
 
+	return [...ownerCandidates];
+}
+
+export function extractDiscordTeamAdminUserIds(application: unknown): string[] {
+	const applicationRecord = asRecord(application);
+	if (!applicationRecord) {
+		return [];
+	}
+
+	const team = asRecord(applicationRecord.team);
 	const teamMembers = team?.members;
 	// Discord.js returns team.members as a Collection (Map-like), not an Array.
 	// Handle both Array and iterable (Collection/Map) shapes.
@@ -110,18 +121,19 @@ export function extractDiscordOwnerUserIds(application: unknown): string[] {
 					"function"
 			? (teamMembers as Iterable<unknown>)
 			: null;
+	const adminCandidates = new Set<string>();
 	if (memberIterable) {
 		for (const entry of memberIterable) {
 			// Collection/Map yields [key, value] tuples; Array yields values directly.
 			const member = Array.isArray(entry) ? entry[1] : entry;
 			const memberId = readUserIdFromOwnerLike(member);
 			if (memberId) {
-				ownerCandidates.add(memberId);
+				adminCandidates.add(memberId);
 			}
 		}
 	}
 
-	return [...ownerCandidates];
+	return [...adminCandidates];
 }
 
 export function parseDiscordOwnerUserIds(value: unknown): string[] {

--- a/plugins/plugin-discord/service.ts
+++ b/plugins/plugin-discord/service.ts
@@ -137,6 +137,7 @@ import {
 import { getDiscordSettings } from "./environment";
 import {
 	extractDiscordOwnerUserIds,
+	extractDiscordTeamAdminUserIds,
 	parseDiscordOwnerUserIds,
 	resolveDiscordRuntimeEntityId,
 	resolveElizaOwnerEntityId,
@@ -537,9 +538,9 @@ export class DiscordService extends Service implements IDiscordService {
 	public allowAllSlashCommands: Set<string> = new Set();
 
 	/**
-	 * Resolves owner Discord user IDs from either the explicit
-	 * ELIZA_DISCORD_OWNER_USER_IDS_JSON setting or the Discord application's
-	 * team/owner metadata, and registers them as Discord connector admins.
+	 * Resolves Discord IDs that should alias to the canonical owner entity.
+	 * Discord team members stay separate entities and are registered only as
+	 * connector admins so their messages remain attributable.
 	 * Called from the extracted onReady handler once the client is ready.
 	 */
 	public async refreshOwnerDiscordUserIds(
@@ -554,6 +555,7 @@ export class DiscordService extends Service implements IDiscordService {
 			!(typeof explicitSetting === "string" && explicitSetting.trim() === "");
 
 		let ownerIds: string[];
+		let teamAdminIds: string[] = [];
 		if (hasExplicitSetting) {
 			ownerIds = parseDiscordOwnerUserIds(
 				Array.isArray(explicitSetting)
@@ -582,6 +584,13 @@ export class DiscordService extends Service implements IDiscordService {
 				application = client.application;
 			}
 			ownerIds = [...new Set(extractDiscordOwnerUserIds(application))];
+			teamAdminIds = [
+				...new Set(
+					extractDiscordTeamAdminUserIds(application).filter(
+						(userId) => !ownerIds.includes(userId),
+					),
+				),
+			];
 		}
 
 		this.ownerDiscordUserIds = new Set(ownerIds);
@@ -594,11 +603,17 @@ export class DiscordService extends Service implements IDiscordService {
 				"No Discord owner user IDs resolved — owner will not be recognized from Discord messages. " +
 					"Set ELIZA_DISCORD_OWNER_USER_IDS_JSON to fix this.",
 			);
+		}
+		if (ownerIds.length === 0 && teamAdminIds.length === 0) {
 			return;
 		}
 		const existingWhitelist = getConnectorAdminWhitelist(this.runtime);
 		const nextDiscordAdmins = [
-			...new Set([...(existingWhitelist.discord ?? []), ...ownerIds]),
+			...new Set([
+				...(existingWhitelist.discord ?? []),
+				...ownerIds,
+				...teamAdminIds,
+			]),
 		];
 		setConnectorAdminWhitelist(this.runtime, {
 			...existingWhitelist,
@@ -609,8 +624,9 @@ export class DiscordService extends Service implements IDiscordService {
 				src: "plugin:discord",
 				agentId: this.runtime.agentId,
 				ownerDiscordUserIds: ownerIds,
+				teamAdminDiscordUserIds: teamAdminIds,
 			},
-			"Resolved Discord owner identities for canonical Eliza owner mapping",
+			"Resolved Discord privileged identities for owner mapping and connector admin access",
 		);
 	}
 


### PR DESCRIPTION
## Summary
- Split Discord application owner aliases from Discord team-member connector-admin grants.
- Keep only the direct application owner, team owner, and explicit `ELIZA_DISCORD_OWNER_USER_IDS_JSON` IDs in `ownerDiscordUserIds`, so ordinary team members are no longer attributed to the canonical Eliza owner entity.
- Keep Discord team members eligible for connector-admin access through the connector-admin whitelist path, and add service-level plus pure extraction regression coverage.
- Document `ELIZA_DISCORD_OWNER_USER_IDS_JSON` in the Discord docs.

Fixes #14712.

## Verification
- `bun run --cwd plugins/plugin-discord test __tests__/identity.test.ts __tests__/owner-refresh.test.ts` — 2 files / 11 tests passed
- `bunx @biomejs/biome check plugins/plugin-discord/identity.ts plugins/plugin-discord/service.ts plugins/plugin-discord/__tests__/identity.test.ts plugins/plugin-discord/__tests__/owner-refresh.test.ts plugins/plugin-discord/README.md plugins/plugin-discord/CLAUDE.md plugins/plugin-discord/AGENTS.md --no-errors-on-unmatched` — pass; Biome checked 4 source/test files, docs are ignored by this config
- `git diff --check origin/develop...HEAD` — pass
- `bun run --cwd packages/vault build` — pass; restored missing `@elizaos/vault` dist types needed by transitive Discord typecheck imports
- `bun run --cwd plugins/plugin-sql build` — pass; restored missing `@elizaos/plugin-sql` dist types needed by transitive Discord typecheck imports
- `bun run --cwd plugins/plugin-discord typecheck` — pass
- `bun run --cwd plugins/plugin-discord build` — pass
- `bun run audit:error-policy-ratchet --report` — pass; no new fallback slop reported on base `origin/develop` at `7cdef14d17`
- `bun run --cwd plugins/plugin-discord test` — attempted full suite; 37/39 files and 238/243 tests passed. The 5 failures are existing outbound-media fetch mock failures in `__tests__/outbound-attachment.test.ts` and `actions/messageConnector.outbound-media.test.ts`, where guarded media fetch hits `127.0.0.1:8080` auth or bypasses the expected mock. These files are unrelated to Discord owner/team identity mapping.

## Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] `N/A - backend Discord connector identity/role mapping change only; no UI surface, screenshots, or pixels changed.`
<!-- evidence-row:after-screenshots -->
- [x] `N/A - backend Discord connector identity/role mapping change only; no UI surface, screenshots, or pixels changed.`
<!-- evidence-row:walkthrough-video -->
- [x] `N/A - no user-facing UI flow changed. The changed path is Discord application metadata extraction plus service-level connector-admin whitelist registration.`
<!-- evidence-row:backend-logs -->
- [x] `N/A - no live Discord backend log artifact is available without sandbox credentials. The service-level regression test exercised the real refresh method and verified owner/admin runtime state; details below.`
<!-- evidence-row:frontend-logs -->
- [x] `N/A - no frontend/client code path changed.`
<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent action, provider, prompt, model, or LLM turn behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - no persistent DB, memory, wallet, scheduled-task, or generated file artifact is produced. The transient runtime connector-admin whitelist state was inspected in the service-level test; details below.`

## Evidence Details
- Live Discord round-trip: not captured locally because no Discord sandbox credentials/token are available in this environment.
- Screenshots/video/frontend logs: not applicable because this is connector backend identity mapping, not a UI change.
- The strongest local proof is the service-level regression test: it invokes the real refresh method, exercises application metadata extraction, writes the real connector-admin whitelist setting, and asserts the team member is excluded from canonical owner aliasing.

## Known Gaps / Failures
- Full Discord test suite still has unrelated outbound-media fetch mock failures: 2 failed files, 5 failed tests, 37 passed files, 238 passed tests. The failures are limited to generated-media attachment fetch behavior and do not exercise the owner/team identity mapping changed here.
