### PR TITLE
fix(#14630): route explicit approval rejection shortcuts

### DIFF
--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -20,6 +20,7 @@ import {
   registerCandidateActionBackstopRule,
   registerLocalizedExamplesProvider,
   registerSendPolicy,
+  type ShortcutDefinition,
 } from "@elizaos/core";
 import {
   getSelfControlPermissionState,
@@ -192,6 +193,32 @@ import {
 const GOOGLE_CONNECTOR_PLUGIN_PACKAGE = "@elizaos/plugin-google";
 const GOOGLE_CONNECTOR_PLUGIN_NAME = "google";
 const PERMISSIONS_REGISTRY_SERVICE = "eliza_permissions_registry";
+
+export const APPROVAL_REJECT_SHORTCUT_ID = "lifeops:approval:reject";
+
+const APPROVAL_REJECT_REGEX =
+  /^(?=.*\b(?:reject|decline|deny)\b)(?=.*\b(?:send|sent|message|email|draft|approval|request|pending)\b).+$/iu;
+const APPROVAL_DONT_SEND_REGEX =
+  /^(?=.*\b(?:don['’]?\s*t|dont|do\s+not)\s+send\b)(?=.*\b(?:that|it|approval|request|pending|message|email|draft)\b).+$/iu;
+
+const lifeOpsShortcuts: ShortcutDefinition[] = [
+  {
+    id: APPROVAL_REJECT_SHORTCUT_ID,
+    kind: "natural",
+    patterns: [
+      { regex: APPROVAL_REJECT_REGEX },
+      { regex: APPROVAL_DONT_SEND_REGEX },
+    ],
+    target: {
+      kind: "action",
+      name: "RESOLVE_REQUEST_REJECT",
+    },
+    requiresAction: "RESOLVE_REQUEST_REJECT",
+    requiresElevated: true,
+    confidence: 0.97,
+    priority: 35,
+  },
+];
 
 function isPermissionsRegistry(value: unknown): value is IPermissionsRegistry {
   return (
@@ -580,6 +607,7 @@ const rawPersonalAssistantPlugin: Plugin = {
   // runner host is registered before PA's init injects deps + seeds.
   dependencies: [GOOGLE_CONNECTOR_PLUGIN_PACKAGE, "@elizaos/plugin-scheduling"],
   schema: lifeOpsSchema,
+  shortcuts: lifeOpsShortcuts,
   actions: [
     // Canonical owner-operation umbrellas. Each umbrella registers itself + its
     // per-action virtuals via

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -196,8 +196,17 @@ const PERMISSIONS_REGISTRY_SERVICE = "eliza_permissions_registry";
 
 export const APPROVAL_REJECT_SHORTCUT_ID = "lifeops:approval:reject";
 
+// The deterministic tier fires only on phrasings that are near-unambiguously a
+// verdict on a queued approval: a "don't send" hold, a reject/decline/deny verb
+// directly governing "approval(s)" / "(that|the|this) request", or the
+// "<verb> that/it/this for now" hold idiom. Looser rejection language
+// ("decline the meeting request", "reject the draft and rewrite it") stays
+// with the planner, which sees queue rows via the pendingApprovals provider
+// (#14665) and can weigh conversation context before picking RESOLVE_REQUEST.
+// A shortcut misfire is terminal for the targeted approval (reject cancels the
+// dispatch), so precision beats recall here.
 const APPROVAL_REJECT_REGEX =
-  /^(?=.*\b(?:reject|decline|deny)\b)(?=.*\b(?:send|sent|message|email|draft|approval|request|pending)\b).+$/iu;
+  /\b(?:reject|decline|deny)\b(?:\s+[\p{L}\p{N}]+){0,3}?\s+approvals?\b|\b(?:reject|decline|deny)\s+(?:(?:that|the|this)\s+)?request\b|\b(?:reject|decline|deny)\s+(?:that|it|this)\s+for\s+now\b/iu;
 const APPROVAL_DONT_SEND_REGEX =
   /^(?=.*\b(?:don['’]?\s*t|dont|do\s+not)\s+send\b)(?=.*\b(?:that|it|approval|request|pending|message|email|draft)\b).+$/iu;
 

--- a/plugins/plugin-personal-assistant/test/action-structure-audit.test.ts
+++ b/plugins/plugin-personal-assistant/test/action-structure-audit.test.ts
@@ -140,20 +140,33 @@ describe("LifeOps canonical action structure", () => {
       kind: "action",
       name: "RESOLVE_REQUEST_REJECT",
     });
-    expect(
-      registry.match("Don’t send it.", {
+    const matchOwner = (text: string) =>
+      registry.match(text, {
         actions: actionNames,
         allowNatural: true,
         isElevated: true,
-      })?.shortcut.id,
-    ).toBe(APPROVAL_REJECT_SHORTCUT_ID);
-    expect(
-      registry.match("hold that for now", {
-        actions: actionNames,
-        allowNatural: true,
-        isElevated: true,
-      }),
-    ).toBeNull();
+      });
+    for (const positive of [
+      "Don’t send it.",
+      "reject that for now",
+      "Decline the request.",
+      "deny the pending approval",
+    ]) {
+      expect(matchOwner(positive)?.shortcut.id, positive).toBe(
+        APPROVAL_REJECT_SHORTCUT_ID,
+      );
+    }
+    // Rejection verbs aimed at other objects stay with the planner, which can
+    // weigh conversation context; a shortcut misfire terminally rejects a
+    // queued approval with zero inference.
+    for (const negative of [
+      "hold that for now",
+      "Decline the meeting request from Bob",
+      "Reject the draft and write a new one",
+      "deny his request for access",
+    ]) {
+      expect(matchOwner(negative), negative).toBeNull();
+    }
     expect(
       registry.match("Don't send it, reject that request.", {
         actions: actionNames,

--- a/plugins/plugin-personal-assistant/test/action-structure-audit.test.ts
+++ b/plugins/plugin-personal-assistant/test/action-structure-audit.test.ts
@@ -3,9 +3,13 @@
  * unregistered, the owner-operation parent umbrellas register, and each exposes `action` as
  * its public discriminator. Pure plugin-shape asserts, no model.
  */
+import { ShortcutRegistry } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import { isDarwin } from "../src/platform/host.js";
-import { personalAssistantPlugin } from "../src/plugin.js";
+import {
+  APPROVAL_REJECT_SHORTCUT_ID,
+  personalAssistantPlugin,
+} from "../src/plugin.js";
 
 // OWNER_SCREENTIME is only registered on darwin because the native activity
 // tracker is macOS-only. See `platformGatedActionUmbrellas` in src/plugin.ts
@@ -113,6 +117,50 @@ describe("LifeOps canonical action structure", () => {
         (evaluator) => evaluator.name,
       ),
     ).not.toContain("lifeops.work_thread_router");
+  });
+
+  it("routes explicit pending-approval rejection phrasing to RESOLVE_REQUEST_REJECT", () => {
+    const registry = new ShortcutRegistry();
+    registry.registerMany(personalAssistantPlugin.shortcuts ?? []);
+    const actionNames = (personalAssistantPlugin.actions ?? []).map(
+      (action) => action.name,
+    );
+
+    const match = registry.match(
+      "Wait - which Chris? There are two. Don't send it, reject that for now until I confirm the right person.",
+      {
+        actions: actionNames,
+        allowNatural: true,
+        isElevated: true,
+      },
+    );
+
+    expect(match?.shortcut.id).toBe(APPROVAL_REJECT_SHORTCUT_ID);
+    expect(match?.shortcut.target).toEqual({
+      kind: "action",
+      name: "RESOLVE_REQUEST_REJECT",
+    });
+    expect(
+      registry.match("Don’t send it.", {
+        actions: actionNames,
+        allowNatural: true,
+        isElevated: true,
+      })?.shortcut.id,
+    ).toBe(APPROVAL_REJECT_SHORTCUT_ID);
+    expect(
+      registry.match("hold that for now", {
+        actions: actionNames,
+        allowNatural: true,
+        isElevated: true,
+      }),
+    ).toBeNull();
+    expect(
+      registry.match("Don't send it, reject that request.", {
+        actions: actionNames,
+        allowNatural: true,
+        isElevated: false,
+      }),
+    ).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- Add a LifeOps natural-language shortcut for explicit pending-approval rejection phrasing, routing it directly to `RESOLVE_REQUEST_REJECT`.
- Cover the exact #14630 phrasing: "Don't send it, reject that for now..." plus a straight/curly apostrophe `Don’t send it` variant.
- Preserve the existing elevated-action guard: the shortcut only matches when elevated actions are allowed and `RESOLVE_REQUEST_REJECT` is available.

## Context
PR #14665 already merged the deterministic single-pending approval resolution path. This follow-up fixes the remaining routing gap on current `develop`: the owner rejection utterance must select the reject action family instead of falling back to `PERSONAL_ASSISTANT` + `REPLY`.

## Verification
- `bun run --cwd plugins/plugin-personal-assistant test -- test/action-structure-audit.test.ts test/native-parameters.test.ts test/resolve-request-executor.test.ts` -> default-pack lint clean; 3 files passed, 24 tests passed
- `bunx biome check plugins/plugin-personal-assistant/src/plugin.ts plugins/plugin-personal-assistant/test/action-structure-audit.test.ts plugins/plugin-personal-assistant/test/native-parameters.test.ts plugins/plugin-personal-assistant/src/actions/resolve-request.ts`
- `bun --conditions eliza-source --tsconfig-override tsconfig.json packages/scenario-runner/src/cli.ts list plugins/plugin-personal-assistant/test/scenarios --scenario f1-cross-persona-wrong-recipient-highstakes` -> listed the live scenario ID; Bun emitted its known directory-mismatch warning but exited 0
- `bun run audit:error-policy-ratchet` -> no new fallback-slop in touched files
- `git diff --check`

## Evidence / N/A
- Screenshots/video: N/A - action-routing/server behavior only; no app UI changed.
- Live LLM trajectories: N/A locally - this PR fixes the deterministic shortcut route into the already-live `RESOLVE_REQUEST_REJECT` action path. The live scenario `f1-cross-persona-wrong-recipient-highstakes` is discoverable and remains the end-to-end evidence target for the secret-backed live lane.

Fixes #14630.
