### PR TITLE
fix(ios): apply brand tint to scene windows

### DIFF
--- a/packages/app-core/platforms/ios/App/App/AppDelegate.swift
+++ b/packages/app-core/platforms/ios/App/App/AppDelegate.swift
@@ -20,16 +20,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         ElizaStartupTrace.bootstrap()
         ElizaHomeIndicator.install()
 
-        // Brand tint on native surfaces the WebView can't reach. elizaOS ships
-        // orange as its single accent and never blue; without an app tint iOS
-        // falls back to system blue for system-presented UIKit — the deep-link
-        // "Open in Eliza?" UIAlertController buttons (verified blue on device),
-        // share sheets, and any default-tinted control. #FF5800 mirrors shared
-        // brand `--eliza-brand-orange`. Appearance proxy covers windows created
-        // later; the direct set covers the Capacitor key window already up.
-        let elizaBrandOrange = UIColor(red: 1.0, green: 0x58 / 255.0, blue: 0.0, alpha: 1.0)
-        UIWindow.appearance().tintColor = elizaBrandOrange
-        window?.tintColor = elizaBrandOrange
+        ElizaBrandTint.install(on: window)
 
         UNUserNotificationCenter.current().delegate = self
         BackgroundRunnerPlugin.registerBackgroundTask()
@@ -199,6 +190,21 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             }
         }
         completionHandler()
+    }
+}
+
+/// Native UIKit accent policy for surfaces outside the WebView. The app uses
+/// brand orange as its single accent, so system-presented controls such as
+/// deep-link alerts and share sheets should inherit orange rather than iOS
+/// default blue. The appearance proxy covers future windows; scene delegates
+/// also pass their concrete window because scene-based apps do not reliably set
+/// `AppDelegate.window`.
+enum ElizaBrandTint {
+    private static let orange = UIColor(red: 1.0, green: 0x58 / 255.0, blue: 0.0, alpha: 1.0)
+
+    static func install(on window: UIWindow?) {
+        UIWindow.appearance().tintColor = orange
+        window?.tintColor = orange
     }
 }
 

--- a/packages/app-core/platforms/ios/App/App/SceneDelegate.swift
+++ b/packages/app-core/platforms/ios/App/App/SceneDelegate.swift
@@ -9,6 +9,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         willConnectTo session: UISceneSession,
         options connectionOptions: UIScene.ConnectionOptions
     ) {
+        ElizaBrandTint.install(on: window)
+
         for context in connectionOptions.urlContexts {
             forwardOpenUrl(context)
         }
@@ -26,6 +28,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
         forwardUserActivity(userActivity)
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        ElizaBrandTint.install(on: window)
     }
 
     private func forwardOpenUrl(_ context: UIOpenURLContext) {


### PR DESCRIPTION
Follow-up to merged #14826.

## Summary

#14826 set the brand-orange tint from `AppDelegate`, but this iOS template uses `SceneDelegate` and `UIApplicationSceneManifest`. In scene-based apps `AppDelegate.window` is not the reliable concrete key window, so the merged fix can still leave scene-created UIKit surfaces on the default iOS blue.

This follow-up keeps the global `UIWindow.appearance().tintColor` policy, moves the color into a shared `ElizaBrandTint` helper, and applies it from `SceneDelegate` during scene connection and activation.

## Required Evidence Rows

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: #14826 documented the iPhone 16 Pro simulator native deep-link alert rendering iOS default blue before the tint fix.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: N/A - blocked locally by missing full Xcode/iPhone simulator SDK; this PR is draft until rebuilt/reinstalled on simulator and the native alert is captured with orange buttons.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: N/A - blocked locally by missing full Xcode/iPhone simulator SDK; capture a short simulator recording of the rebuilt app deep-link alert before undrafting.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: N/A - native iOS UIKit tint only; no backend path changed.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - native iOS UIKit tint only; WebView/network behavior is unchanged.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - no agent/model/prompt behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - no persistent domain artifact is produced.

## Verification

- Reviewed the iOS lifecycle: `Info.plist` declares `UIApplicationSceneManifest` and `SceneDelegate`; `SceneDelegate` owns `window`.
- `git diff --check origin/develop...HEAD`: passed.
- `bun run audit:error-policy-ratchet --report`: passed; Swift-only diff, no production TS/JS fallback-slop findings.
- `xcodebuild -version`: blocked locally because active developer directory is `/Library/Developer/CommandLineTools`, not full Xcode.
- `xcrun --sdk iphonesimulator --show-sdk-path`: blocked locally because the iPhone simulator SDK is unavailable.

## Native proof still required before merge

Run on a machine with full Xcode and a booted simulator:

```bash
bun run --cwd packages/app build:ios:local:sim
bun run --cwd packages/app cap:sync:ios
```

Then reinstall the app, trigger the deep link, and attach the after screenshot/video proving the native `Open in "Eliza"?` alert uses brand orange rather than `#007AFF` blue.
