### PR TITLE
fix(lifeops): normalize scheduled task planner aliases

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/scheduled-task.test.ts
+++ b/plugins/plugin-personal-assistant/src/actions/scheduled-task.test.ts
@@ -39,6 +39,7 @@ const DUE_BY_PROMPT: Record<string, boolean> = {
 };
 
 let storedTasks: ScheduledTask[];
+let scheduledInputs: Record<string, unknown>[];
 let resolveNextFireAtCalls: string[];
 let resolveDueDecisionCalls: string[];
 let ownerTimezone: string;
@@ -81,6 +82,14 @@ vi.mock("../lifeops/scheduled-task/service.js", () => ({
     },
     async resolveOwnerFacts() {
       return { timezone: ownerTimezone };
+    },
+    async schedule(input: Record<string, unknown>) {
+      scheduledInputs.push(input);
+      return {
+        ...fakeTask("created-task"),
+        ...input,
+        taskId: "created-task",
+      } as ScheduledTask;
     },
   })),
 }));
@@ -138,6 +147,7 @@ describe("SCHEDULED_TASKS list — dueWindow filter", () => {
       fakeTask("missed-recurring-task"),
       fakeTask("manual-task"),
     ];
+    scheduledInputs = [];
     resolveNextFireAtCalls = [];
     resolveDueDecisionCalls = [];
     ownerTimezone = "UTC";
@@ -218,6 +228,65 @@ describe("SCHEDULED_TASKS list — dueWindow filter", () => {
       (p) => p.name,
     );
     expect(paramNames).toContain("dueWindow");
+  });
+
+  it("normalizes planner create aliases and empty structural objects before scheduling", async () => {
+    const result = await scheduledTaskAction.handler(
+      makeRuntime(),
+      makeMessage(),
+      undefined,
+      {
+        parameters: {
+          action: "create",
+          kind: "reminder",
+          promptInstructions: "Remind the user to send the Q3 budget report.",
+          trigger: { fire_at: "2026-07-14T09:30:00Z" },
+          contextRequest: {},
+          shouldFire: {},
+          completionCheck: { type: "user_acknowledged" },
+          output: {},
+          pipeline: {},
+          escalation: {},
+        },
+      },
+      undefined,
+    );
+
+    expect(result.success).toBe(true);
+    expect(scheduledInputs).toHaveLength(1);
+    const input = scheduledInputs[0];
+    expect(input).toMatchObject({
+      trigger: { kind: "once", atIso: "2026-07-14T09:30:00Z" },
+      completionCheck: { kind: "user_acknowledged" },
+      output: { destination: "channel", target: "in_app:room-1" },
+    });
+    expect(input).not.toHaveProperty("contextRequest");
+    expect(input).not.toHaveProperty("shouldFire");
+    expect(input).not.toHaveProperty("pipeline");
+    expect(input).not.toHaveProperty("escalation");
+  });
+
+  it("maps common planner output aliases back to the channel destination", async () => {
+    const result = await scheduledTaskAction.handler(
+      makeRuntime(),
+      makeMessage(),
+      undefined,
+      {
+        parameters: {
+          action: "create",
+          kind: "reminder",
+          promptInstructions: "Remind the user to send the Q3 budget report.",
+          trigger: { kind: "once", atIso: "2026-07-14T09:30:00Z" },
+          output: { destination: "push" },
+        },
+      },
+      undefined,
+    );
+
+    expect(result.success).toBe(true);
+    expect(scheduledInputs.at(-1)).toMatchObject({
+      output: { destination: "channel", target: "in_app:room-1" },
+    });
   });
 
   afterEach(() => {

--- a/plugins/plugin-personal-assistant/src/actions/scheduled-task.ts
+++ b/plugins/plugin-personal-assistant/src/actions/scheduled-task.ts
@@ -346,7 +346,17 @@ function normalizeTriggerInput(value: unknown): TriggerNormalization {
     };
   }
   const record = value as Record<string, unknown>;
-  const kindRaw = pickString(record, ["kind", "type"]);
+  const onceAtIso = pickString(record, [
+    "atIso",
+    "fireAtIso",
+    "fireAt",
+    "fire_at",
+    "at",
+    "when",
+    "datetime",
+  ]);
+  const kindRaw =
+    pickString(record, ["kind", "type"]) ?? (onceAtIso ? "once" : null);
   if (!kindRaw) {
     return {
       ok: false,
@@ -375,7 +385,7 @@ function normalizeTriggerInput(value: unknown): TriggerNormalization {
       };
     }
     case "once": {
-      const atIso = pickString(record, ["atIso", "at", "when", "datetime"]);
+      const atIso = onceAtIso;
       if (!atIso || !Number.isFinite(Date.parse(atIso))) {
         return {
           ok: false,
@@ -499,6 +509,93 @@ function stableTriggerKey(trigger: ScheduledTaskTrigger): string {
     .sort()
     .map((key) => `${key}=${JSON.stringify(record[key])}`)
     .join("|");
+}
+
+function nonEmptyRecord<T>(value: T | undefined): T | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return Object.keys(value).length > 0 ? value : undefined;
+}
+
+function defaultChatOutput(
+  scope: RunnerScope,
+): ScheduledTask["output"] | undefined {
+  return scope.roomId
+    ? { destination: "channel", target: `in_app:${scope.roomId}` }
+    : undefined;
+}
+
+function normalizeOutputDestination(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+}
+
+function normalizeOutputInput(
+  scope: RunnerScope,
+  output: ScheduledTaskParams["output"],
+): ScheduledTask["output"] | undefined {
+  if (!output || typeof output !== "object" || Array.isArray(output)) {
+    return defaultChatOutput(scope);
+  }
+  if (Object.keys(output).length === 0) {
+    return defaultChatOutput(scope);
+  }
+  const rawDestination =
+    typeof output.destination === "string" ? output.destination.trim() : "";
+  const destination = normalizeOutputDestination(rawDestination);
+  const rawTarget =
+    typeof output.target === "string" && output.target.trim().length > 0
+      ? output.target.trim()
+      : undefined;
+  const inAppTarget =
+    rawTarget ?? (scope.roomId ? `in_app:${scope.roomId}` : "in_app");
+
+  if (
+    destination === "in_app" ||
+    destination === "push" ||
+    destination === "notification" ||
+    destination.startsWith("in_app:")
+  ) {
+    return {
+      ...output,
+      destination: "channel",
+      target: destination.startsWith("in_app:") ? rawDestination : inAppTarget,
+    };
+  }
+
+  if (destination === "channel") {
+    return {
+      ...output,
+      destination: "channel",
+      target: rawTarget ?? inAppTarget,
+    };
+  }
+
+  return output;
+}
+
+function normalizeCompletionCheckInput(
+  value: ScheduledTaskParams["completionCheck"],
+): ScheduledTask["completionCheck"] | undefined {
+  const check = nonEmptyRecord(value);
+  if (!check) return undefined;
+  if (typeof check.kind === "string" && check.kind.trim().length > 0) {
+    return check;
+  }
+  if (typeof (check as { type?: unknown }).type === "string") {
+    const kind = (check as { type: string }).type.trim();
+    if (kind.length > 0) {
+      const { type: _type, ...rest } =
+        check as ScheduledTask["completionCheck"] & {
+          type?: string;
+        };
+      return { ...rest, kind };
+    }
+  }
+  return check;
 }
 
 const DUE_WINDOWS = ["overdue", "today"] as const;
@@ -695,6 +792,8 @@ async function handleCreate(
       data: { subaction: "create", task: duplicate, deduplicated: true },
     };
   }
+  const output = normalizeOutputInput(scope, params.output);
+  const completionCheck = normalizeCompletionCheckInput(params.completionCheck);
   const metadata = {
     ...(params.metadata ?? {}),
     ...(requestedTaskId ? { plannerTaskId: requestedTaskId } : {}),
@@ -709,25 +808,18 @@ async function handleCreate(
       promptInstructions,
       trigger,
       priority,
-      ...(params.contextRequest
+      ...(nonEmptyRecord(params.contextRequest)
         ? { contextRequest: params.contextRequest }
         : {}),
-      ...(params.shouldFire ? { shouldFire: params.shouldFire } : {}),
-      ...(params.completionCheck
-        ? { completionCheck: params.completionCheck }
+      ...(nonEmptyRecord(params.shouldFire)
+        ? { shouldFire: params.shouldFire }
         : {}),
-      ...(params.escalation ? { escalation: params.escalation } : {}),
-      ...(params.output
-        ? { output: params.output }
-        : scope.roomId
-          ? {
-              output: {
-                destination: "channel",
-                target: `in_app:${scope.roomId}`,
-              },
-            }
-          : {}),
-      ...(params.pipeline ? { pipeline: params.pipeline } : {}),
+      ...(completionCheck ? { completionCheck } : {}),
+      ...(nonEmptyRecord(params.escalation)
+        ? { escalation: params.escalation }
+        : {}),
+      ...(output ? { output } : {}),
+      ...(nonEmptyRecord(params.pipeline) ? { pipeline: params.pipeline } : {}),
       ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
       ...(params.idempotencyKey
         ? { idempotencyKey: params.idempotencyKey }


### PR DESCRIPTION
Follow-up to #14822. After #14822 merged, a live rerun on current `develop` exposed additional planner spelling drift in the low-level `SCHEDULED_TASKS_CREATE` adapter: the model can emit `trigger.fire_at` without `trigger.kind`, or `completionCheck.type` instead of `completionCheck.kind`. The runner schema should stay strict, but the chat action adapter can safely normalize those common planner aliases before scheduling.

Changes:

- infer a one-shot trigger when a planner supplies an ISO-ish once timestamp alias (`fire_at`, `fireAtIso`, `fireAt`, etc.) without `kind`
- translate `completionCheck.type` to canonical `completionCheck.kind`
- keep the earlier empty-object/default-output normalization so `{}` planner shells do not override chat defaults
- add unit coverage using the exact live failure shape

Verification:

- `bunx @biomejs/biome check plugins/plugin-personal-assistant/src/actions/scheduled-task.ts plugins/plugin-personal-assistant/src/actions/scheduled-task.test.ts`
- `bun run --cwd plugins/plugin-personal-assistant test src/actions/scheduled-task.test.ts` (8 tests)
- `bun run --cwd plugins/plugin-personal-assistant build:types`
- `git diff --check origin/develop...HEAD`
- `bun run audit:error-policy-ratchet --report`

Live evidence (current `origin/develop` + this branch):

- command: `bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/cli.ts run test/scenarios --lane live-only --scenario live-chat-widgets-form-roundtrip --report-dir /tmp/eliza-14822-followup-live --run-dir /tmp/eliza-14822-followup-live test/scenarios/live-chat-widgets-form-roundtrip.scenario.ts`
- result: passed, provider=`openai`, runId `63296e07-9d5e-46e5-8962-f8d4b41deb80`, 1 passed / 0 failed
- report: `/tmp/eliza-14822-followup-live/001-live-chat-widgets-form-roundtrip.json`
- viewer: `/tmp/eliza-14822-followup-live/viewer/index.html`

Manual report/trajectory review:

- turn 1 emitted a grammar-valid `[FORM]` for report name, date, and time
- turn 2 consumed the raw form submit and called `OWNER_REMINDERS_CREATE` with the submitted Q3 budget report/Dana details and `due_date=2026-07-14`, `due_time=09:30`
- the action succeeded and the reply confirmed the saved reminder; both final checks passed and `judgeScore` was `1`