### PR TITLE
fix(#14335): emit devices status evidence artifacts

### DIFF
--- a/packages/app/scripts/devices-status.mjs
+++ b/packages/app/scripts/devices-status.mjs
@@ -6,8 +6,10 @@
  * before a runner starts.
  */
 import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import sharp from "sharp";
 import { readDevicectlDeviceList } from "./ios-device-devicectl.mjs";
 import { DEFAULT_APP_BUNDLE_ID } from "./ios-device-lib.mjs";
 import {
@@ -21,6 +23,7 @@ import {
   buildDeviceStatusRow,
   formatDeviceStatusTable,
   hasNonFreshDevice,
+  renderDeviceStatusEvidenceSvg,
 } from "./lib/devices-status.mjs";
 import {
   readDeployLedger,
@@ -37,6 +40,16 @@ const repoRoot = path.resolve(appRoot, "..", "..");
 
 function hasArg(name) {
   return process.argv.includes(name);
+}
+
+function optionValue(...names) {
+  for (const name of names) {
+    const index = process.argv.indexOf(name);
+    if (index !== -1) return process.argv[index + 1] ?? null;
+    const inline = process.argv.find((arg) => arg.startsWith(`${name}=`));
+    if (inline) return inline.slice(name.length + 1);
+  }
+  return null;
 }
 
 function runText(command, args, options = {}) {
@@ -66,11 +79,13 @@ function latestLedgerEntryForDevice(device, entries) {
     )[0];
 }
 
-function fetchDevelopHead() {
-  spawnSync("git", ["fetch", "origin", "develop", "--quiet"], {
-    cwd: repoRoot,
-    stdio: "ignore",
-  });
+function resolveDevelopHead({ fetch = true } = {}) {
+  if (fetch) {
+    spawnSync("git", ["fetch", "origin", "develop", "--quiet"], {
+      cwd: repoRoot,
+      stdio: "ignore",
+    });
+  }
   return runText("git", ["rev-parse", "origin/develop"]);
 }
 
@@ -214,8 +229,8 @@ function iosPhysicalRows(developHead) {
   });
 }
 
-export function collectDeviceStatus() {
-  const developHead = fetchDevelopHead();
+export function collectDeviceStatus({ fetch = true } = {}) {
+  const developHead = resolveDevelopHead({ fetch });
   return [
     ...androidRows(developHead),
     ...iosSimulatorRows(developHead),
@@ -223,12 +238,54 @@ export function collectDeviceStatus() {
   ];
 }
 
-function main() {
-  const rows = collectDeviceStatus();
+async function writeEvidenceArtifacts({ outputDir, rows, table, generatedAt }) {
+  const absoluteDir = path.resolve(outputDir);
+  mkdirSync(absoluteDir, { recursive: true });
+  const json = JSON.stringify(rows, null, 2);
+  const manifest = {
+    command: "devices:status",
+    generatedAt,
+    artifacts: {
+      table: "devices-status.txt",
+      json: "devices-status.json",
+      screenshot: "devices-status.jpg",
+    },
+  };
+  writeFileSync(path.join(absoluteDir, "devices-status.txt"), `${table}\n`);
+  writeFileSync(path.join(absoluteDir, "devices-status.json"), `${json}\n`);
+  writeFileSync(
+    path.join(absoluteDir, "manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  const svg = renderDeviceStatusEvidenceSvg({
+    table,
+    generatedAt,
+    title: "bun run --cwd packages/app devices:status",
+  });
+  await sharp(Buffer.from(svg))
+    .jpeg({ quality: 92 })
+    .toFile(path.join(absoluteDir, "devices-status.jpg"));
+  return absoluteDir;
+}
+
+async function main() {
+  const rows = collectDeviceStatus({ fetch: !hasArg("--no-fetch") });
+  const table = formatDeviceStatusTable(rows);
+  const json = JSON.stringify(rows, null, 2);
+  const evidenceDir = optionValue("--evidence-dir", "--evidence");
   if (hasArg("--json")) {
-    console.log(JSON.stringify(rows, null, 2));
+    console.log(json);
   } else {
-    console.log(formatDeviceStatusTable(rows));
+    console.log(table);
+  }
+  if (evidenceDir) {
+    const outputDir = await writeEvidenceArtifacts({
+      outputDir: evidenceDir,
+      rows,
+      table,
+      generatedAt: new Date().toISOString(),
+    });
+    console.error(`evidence: ${outputDir}`);
   }
   if (hasArg("--require-fresh") && hasNonFreshDevice(rows)) {
     process.exitCode = 1;
@@ -239,5 +296,8 @@ const isDirectRun =
   process.argv[1] &&
   path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 if (isDirectRun) {
-  main();
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
 }

--- a/packages/app/scripts/devices-status.test.mjs
+++ b/packages/app/scripts/devices-status.test.mjs
@@ -8,6 +8,7 @@ import {
   buildDeviceStatusRow,
   formatDeviceStatusTable,
   hasNonFreshDevice,
+  renderDeviceStatusEvidenceSvg,
   rendererStampVerdict,
   sameCommit,
 } from "./lib/devices-status.mjs";
@@ -79,5 +80,18 @@ describe("devices-status policy", () => {
     expect(formatDeviceStatusTable([row])).toContain("emulator-5554");
     expect(formatDeviceStatusTable([row])).toContain("FRESH");
     expect(formatDeviceStatusTable([row])).toContain("pid 42");
+  });
+
+  it("renders the table as escaped terminal-style SVG evidence", () => {
+    const svg = renderDeviceStatusEvidenceSvg({
+      table: "DEVICE  REASON\nphone   a < b & c",
+      generatedAt: "2026-07-06T00:00:00.000Z",
+    });
+
+    expect(svg).toContain("devices:status");
+    expect(svg).toContain('xml:space="preserve"');
+    expect(svg).toContain("2026-07-06T00:00:00.000Z");
+    expect(svg).toContain("a &lt; b &amp; c");
+    expect(svg).not.toContain("a < b & c");
   });
 });

--- a/packages/app/scripts/lib/devices-status.mjs
+++ b/packages/app/scripts/lib/devices-status.mjs
@@ -101,3 +101,43 @@ export function formatDeviceStatusTable(rows) {
     ...body.map(render),
   ].join("\n");
 }
+
+function escapeXml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+export function renderDeviceStatusEvidenceSvg({
+  table,
+  generatedAt,
+  title = "devices:status",
+}) {
+  const lines = String(table).split("\n");
+  const fontSize = 18;
+  const lineHeight = 28;
+  const padding = 32;
+  const longestLine = Math.max(...lines.map((line) => line.length), 1);
+  const width = Math.max(960, padding * 2 + longestLine * 11);
+  const height = padding * 2 + 44 + lines.length * lineHeight;
+  const escapedTitle = escapeXml(title);
+  const escapedGeneratedAt = escapeXml(generatedAt);
+  const text = lines
+    .map(
+      (line, index) =>
+        `<text x="${padding}" y="${padding + 72 + index * lineHeight}">${escapeXml(line)}</text>`,
+    )
+    .join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+  <rect width="100%" height="100%" fill="#111111"/>
+  <text x="${padding}" y="${padding + 12}" fill="#ffffff" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="22" font-weight="700">${escapedTitle}</text>
+  <text x="${padding}" y="${padding + 42}" fill="#a3a3a3" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="14">${escapedGeneratedAt}</text>
+  <g fill="#f5f5f5" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="${fontSize}" xml:space="preserve">
+${text}
+  </g>
+</svg>`;
+}


### PR DESCRIPTION
## Summary
- Add `devices:status --evidence-dir <dir>` to emit a reviewer-ready evidence bundle from the same read-only device freshness probe: `devices-status.txt`, `devices-status.json`, `devices-status.jpg`, and `manifest.json`.
- Make `--no-fetch` actually skip the `git fetch origin develop` step while still comparing against the local `origin/develop` ref.
- Add pure coverage for the terminal-style SVG screenshot renderer so table screenshots keep spacing and escape status text safely.

## Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - tooling-only CLI change; no app UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - tooling-only CLI change; generated evidence screenshot was manually reviewed locally.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact: https://gist.github.com/lalalune/1d763294119b38e2fd18012e011fb8e2 includes the generated text, JSON, manifest, command stdout/stderr, require-fresh exit code, and manual screenshot review for `devices:status --no-fetch --evidence-dir`.

## Current Hardware Evidence
Command:
```bash
bun run --cwd packages/app devices:status -- --no-fetch --evidence-dir /tmp/eliza-devices-status-evidence
```

Observed table:
```text
PLATFORM    DEVICE             KIND    BUILD         COMMIT        DEVELOP       VERDICT  LEASE  REASON
--------    ------             ----    -----         ------        -------       -------  -----  ------
android     27051JEGR10034     device  5c05ab1770dd  3403f9bc241f  7cdef14d1723  STALE    -      installed 3403f9bc241f != develop 7cdef14d1723
ios-sim     iOS simulator n/a  n/a     -             -             7cdef14d1723  UNKNOWN  -      no installed renderer stamp
ios-device  physical iOS n/a   n/a     -             -             7cdef14d1723  UNKNOWN  -      no installed renderer stamp
```

Generated files:
```text
devices-status.jpg 58443 bytes
devices-status.json 1126 bytes
devices-status.txt 602 bytes
manifest.json 210 bytes
```

`devices-status.jpg` is a valid JPEG (`1637x248`) and was manually opened; it shows the stale Android verdict and the two host-unavailable iOS rows.

## Verification
```bash
bun test packages/app/scripts/devices-status.test.mjs
bunx @biomejs/biome check packages/app/scripts/devices-status.mjs packages/app/scripts/lib/devices-status.mjs packages/app/scripts/devices-status.test.mjs
node --check packages/app/scripts/devices-status.mjs && node --check packages/app/scripts/lib/devices-status.mjs
bun run --cwd packages/app devices:status -- --json --no-fetch --require-fresh >/tmp/eliza-devices-status-require-fresh.json; status=$?; test $status -eq 1; jq -e 'length >= 1 and any(.[]; .platform == "android" and .verdict != "FRESH")' /tmp/eliza-devices-status-require-fresh.json
git diff --check
```

Observed locally:
- `devices-status.test.mjs`: 7 pass, 0 fail.
- Targeted Biome check passed.
- Node syntax checks passed.
- `--require-fresh` exited 1 for the stale attached Android device and still emitted valid JSON.
- `git diff --check` passed.

## Known gaps / failures
- This improves #14335 evidence automation and captures the current STALE Android state. Closing #14335 still requires the final hardware run after redeploy showing the same device FRESH, plus an iOS-device/simulator run on macOS.
