### PR TITLE
fix(lifeops): route urgent escalation to owner connector

### DIFF
--- a/plugins/plugin-personal-assistant/src/default-packs/escalation-ladders.ts
+++ b/plugins/plugin-personal-assistant/src/default-packs/escalation-ladders.ts
@@ -9,7 +9,7 @@
  * priority_high_default:   { steps: [
  *   { delayMinutes: 0,  channelKey: "in_app",   intensity: "soft" },
  *   { delayMinutes: 15, channelKey: "push",     intensity: "normal" },
- *   { delayMinutes: 45, channelKey: "imessage", intensity: "urgent" },
+ *   { delayMinutes: 45, channelKey: "owner_preferred", intensity: "urgent" },
  * ]}
  * ```
  */
@@ -30,7 +30,7 @@ export const DEFAULT_ESCALATION_LADDERS: Readonly<
     steps: [
       { delayMinutes: 0, channelKey: "in_app", intensity: "soft" },
       { delayMinutes: 15, channelKey: "push", intensity: "normal" },
-      { delayMinutes: 45, channelKey: "imessage", intensity: "urgent" },
+      { delayMinutes: 45, channelKey: "owner_preferred", intensity: "urgent" },
     ],
   },
 };

--- a/plugins/plugin-personal-assistant/src/lifeops/channels/default-pack.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/channels/default-pack.ts
@@ -11,7 +11,10 @@
  */
 
 import type { IAgentRuntime } from "@elizaos/core";
-import type { DispatchResult } from "../connectors/contract.js";
+import type {
+  ConnectorContribution,
+  DispatchResult,
+} from "../connectors/contract.js";
 import { getConnectorRegistry } from "../connectors/registry.js";
 import type {
   ChannelCapabilities,
@@ -27,6 +30,8 @@ const NULL_CAPABILITIES: ChannelCapabilities = {
   attachments: false,
   quietHoursAware: false,
 };
+
+const OWNER_PREFERRED_CHANNEL_KEY = "owner_preferred";
 
 interface ChannelDescriptor {
   kind: string;
@@ -214,6 +219,156 @@ const CHANNEL_DESCRIPTORS: readonly ChannelDescriptor[] = [
   },
 ];
 
+const OWNER_CONNECTOR_PRIORITY = [
+  "telegram",
+  "discord",
+  "signal",
+  "whatsapp",
+  "imessage",
+  "twilio",
+  "google",
+  "x",
+] as const;
+
+const CHANNEL_TO_CONNECTOR_KIND: Readonly<Record<string, string>> = {
+  email: "google",
+  imessage: "imessage",
+  telegram: "telegram",
+  discord: "discord",
+  signal: "signal",
+  whatsapp: "whatsapp",
+  x: "x",
+  x_dm: "x",
+  sms: "twilio",
+  voice: "twilio",
+  twilio_voice: "twilio",
+};
+
+function readSendPayloadTarget(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const target = (payload as { target?: unknown }).target;
+  return typeof target === "string" && target.trim().length > 0
+    ? target.trim()
+    : null;
+}
+
+function withPayloadTarget(payload: unknown, target: string): unknown {
+  return payload && typeof payload === "object"
+    ? { ...(payload as Record<string, unknown>), target }
+    : payload;
+}
+
+function parseExplicitConnectorTarget(
+  target: string | null,
+): { connectorKind: string; target: string } | null {
+  if (!target) return null;
+  const separatorIndex = target.indexOf(":");
+  if (separatorIndex <= 0) return null;
+  const prefix = target.slice(0, separatorIndex);
+  const connectorKind = CHANNEL_TO_CONNECTOR_KIND[prefix] ?? prefix;
+  const connectorTarget = target.slice(separatorIndex + 1).trim();
+  return connectorTarget ? { connectorKind, target: connectorTarget } : null;
+}
+
+async function connectedConnector(
+  connectors: ConnectorContribution[],
+): Promise<ConnectorContribution | null> {
+  const byKind = new Map(
+    connectors.map((connector) => [connector.kind, connector]),
+  );
+  const priorityKinds = new Set<string>(OWNER_CONNECTOR_PRIORITY);
+  for (const kind of OWNER_CONNECTOR_PRIORITY) {
+    const connector = byKind.get(kind);
+    if (!connector?.send) continue;
+    const status = await connector.status();
+    if (status.state === "ok") return connector;
+  }
+  for (const connector of connectors) {
+    if (!connector.send || priorityKinds.has(connector.kind)) continue;
+    const status = await connector.status();
+    if (status.state === "ok") return connector;
+  }
+  return null;
+}
+
+function createOwnerPreferredChannel(
+  runtime: IAgentRuntime,
+): ChannelContribution {
+  return {
+    kind: OWNER_PREFERRED_CHANNEL_KEY,
+    describe: { label: "Owner preferred connected channel" },
+    capabilities: {
+      ...NULL_CAPABILITIES,
+      send: true,
+      reminders: true,
+      attachments: true,
+      quietHoursAware: true,
+    },
+    async send(payload: unknown): Promise<DispatchResult> {
+      const registry = getConnectorRegistry(runtime);
+      if (!registry) {
+        return {
+          ok: false,
+          reason: "transport_error",
+          userActionable: false,
+          message:
+            "ConnectorRegistry is not registered on the runtime; owner-preferred channel cannot resolve a dispatcher.",
+        };
+      }
+      const target = readSendPayloadTarget(payload);
+      const explicit = parseExplicitConnectorTarget(target);
+      const sendCapable = registry.list().filter((connector) => connector.send);
+      if (explicit) {
+        const connector = registry.get(explicit.connectorKind);
+        if (!connector?.send) {
+          return {
+            ok: false,
+            reason: "disconnected",
+            userActionable: true,
+            message: `Owner-preferred target "${target}" routes through connector "${explicit.connectorKind}", which is not registered or has no send.`,
+          };
+        }
+        const status = await connector.status();
+        if (status.state !== "ok") {
+          return {
+            ok: false,
+            reason:
+              status.state === "disconnected"
+                ? "disconnected"
+                : "transport_error",
+            userActionable: true,
+            message:
+              status.message ??
+              `Connector "${explicit.connectorKind}" is ${status.state}.`,
+          };
+        }
+        return connector.send(withPayloadTarget(payload, explicit.target));
+      }
+
+      const connector = await connectedConnector(sendCapable);
+      if (!connector?.send) {
+        return {
+          ok: false,
+          reason: "disconnected",
+          userActionable: true,
+          message:
+            "No connected owner messaging connector is available for owner-preferred escalation.",
+        };
+      }
+      if (!target || target === OWNER_PREFERRED_CHANNEL_KEY) {
+        return {
+          ok: false,
+          reason: "unknown_recipient",
+          userActionable: true,
+          message:
+            "Owner-preferred escalation needs a connector-qualified target such as telegram:<chat-id> or discord:<channel-id>.",
+        };
+      }
+      return connector.send(payload);
+    },
+  };
+}
+
 function buildChannelContribution(
   descriptor: ChannelDescriptor,
   runtime: IAgentRuntime,
@@ -282,7 +437,7 @@ export const DEFAULT_CHANNEL_PACK: readonly ChannelContribution[] = [];
  */
 export const DEFAULT_CHANNEL_KINDS: readonly string[] = CHANNEL_DESCRIPTORS.map(
   (descriptor) => descriptor.kind,
-);
+).concat(OWNER_PREFERRED_CHANNEL_KEY);
 
 export function registerDefaultChannelPack(
   registry: ChannelRegistry,
@@ -295,4 +450,5 @@ export function registerDefaultChannelPack(
   for (const descriptor of CHANNEL_DESCRIPTORS) {
     registry.register(buildChannelContribution(descriptor, runtime));
   }
+  registry.register(createOwnerPreferredChannel(runtime));
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/escalation-ladders.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/escalation-ladders.ts
@@ -4,9 +4,9 @@
  * `priority`:
  * - `priority_low_default`    — single attempt, no ladder.
  * - `priority_medium_default` — 1 retry after 30 min.
- * - `priority_high_default`   — 3 steps across channels (in_app → push → imessage).
+ * - `priority_high_default`   — 3 steps across channels (in_app → push → owner_preferred).
  *
- * Channel keys (`in_app`, `push`, `imessage`) reference
+ * Channel keys (`in_app`, `push`, `owner_preferred`) reference
  * {@link import("./channels/contract.js").ChannelContribution.kind}; the
  * channel registry is responsible for resolving them at dispatch time.
  */
@@ -36,7 +36,7 @@ export const DEFAULT_ESCALATION_LADDERS: Readonly<{
     steps: [
       { delayMinutes: 0, channelKey: "in_app", intensity: "soft" },
       { delayMinutes: 15, channelKey: "push", intensity: "normal" },
-      { delayMinutes: 45, channelKey: "imessage", intensity: "urgent" },
+      { delayMinutes: 45, channelKey: "owner_preferred", intensity: "urgent" },
     ],
   },
 } as const;

--- a/plugins/plugin-personal-assistant/test/contracts.test.ts
+++ b/plugins/plugin-personal-assistant/test/contracts.test.ts
@@ -7,11 +7,13 @@
  * §3.17, plus the priority-posture map and the default escalation ladders.
  */
 
-import { describe, expect, it } from "vitest";
+import { createMockRuntime } from "@elizaos/core/testing";
+import { describe, expect, it, vi } from "vitest";
 import {
   type ChannelContribution,
   createChannelRegistry,
   PRIORITY_TO_POSTURE,
+  registerDefaultChannelPack,
   type ScheduledTaskPriority,
 } from "../src/lifeops/channels/index.js";
 import {
@@ -19,6 +21,7 @@ import {
   createConnectorRegistry,
   type DispatchResult,
   decideDispatchPolicy,
+  registerConnectorRegistry,
 } from "../src/lifeops/connectors/index.js";
 import { DEFAULT_ESCALATION_LADDERS } from "../src/lifeops/escalation-ladders.js";
 import {
@@ -188,6 +191,62 @@ describe("ChannelRegistry", () => {
     expect(() => registry.register(makeChannel({ kind: "in_app" }))).toThrow(
       /already registered/,
     );
+  });
+
+  it("routes owner_preferred connector-qualified targets through the connected connector", async () => {
+    const runtime = createMockRuntime({
+      agentId: "agent-owner-preferred",
+    });
+    const connectorRegistry = createConnectorRegistry();
+    const telegramSend = vi.fn(
+      async (): Promise<DispatchResult> => ({
+        ok: true,
+        messageId: "telegram-dispatch-1",
+      }),
+    );
+    const imessageSend = vi.fn(
+      async (): Promise<DispatchResult> => ({
+        ok: true,
+        messageId: "imessage-dispatch-1",
+      }),
+    );
+
+    connectorRegistry.register(
+      makeConnector({
+        kind: "telegram",
+        capabilities: ["telegram.send"],
+        send: telegramSend,
+      }),
+    );
+    connectorRegistry.register(
+      makeConnector({
+        kind: "imessage",
+        capabilities: ["imessage.send"],
+        send: imessageSend,
+        status: async () => ({
+          state: "disconnected" as const,
+          observedAt: new Date(0).toISOString(),
+        }),
+      }),
+    );
+    registerConnectorRegistry(runtime, connectorRegistry);
+
+    const channelRegistry = createChannelRegistry();
+    registerDefaultChannelPack(channelRegistry, runtime);
+    const ownerPreferred = channelRegistry.get("owner_preferred");
+
+    expect(ownerPreferred).not.toBeNull();
+    await expect(
+      ownerPreferred?.send?.({
+        target: "telegram:owner-chat",
+        message: "urgent reminder",
+      }),
+    ).resolves.toEqual({ ok: true, messageId: "telegram-dispatch-1" });
+    expect(telegramSend).toHaveBeenCalledWith({
+      target: "owner-chat",
+      message: "urgent reminder",
+    });
+    expect(imessageSend).not.toHaveBeenCalled();
   });
 });
 
@@ -388,18 +447,19 @@ describe("decideDispatchPolicy (W1-F dispatch policy)", () => {
     });
   });
 
-  it("user-actionable failure on the last step → fail (terminal beats degraded)", () => {
+  it("user-actionable failure on the last step → surface_degraded before terminal handling", () => {
     const result: DispatchResult = {
       ok: false,
       reason: "auth_expired",
       userActionable: true,
+      message: "Reconnect Telegram.",
     };
     expect(
       decideDispatchPolicy(result, { currentStepIndex: 0, totalSteps: 1 }),
     ).toEqual({
-      kind: "fail",
+      kind: "surface_degraded",
       reason: "auth_expired",
-      message: undefined,
+      message: "Reconnect Telegram.",
     });
   });
 
@@ -485,7 +545,11 @@ describe("DEFAULT_ESCALATION_LADDERS", () => {
       steps: [
         { delayMinutes: 0, channelKey: "in_app", intensity: "soft" },
         { delayMinutes: 15, channelKey: "push", intensity: "normal" },
-        { delayMinutes: 45, channelKey: "imessage", intensity: "urgent" },
+        {
+          delayMinutes: 45,
+          channelKey: "owner_preferred",
+          intensity: "urgent",
+        },
       ],
     });
   });

--- a/plugins/plugin-personal-assistant/test/default-packs.schema.test.ts
+++ b/plugins/plugin-personal-assistant/test/default-packs.schema.test.ts
@@ -360,7 +360,7 @@ describe("W1-D default escalation ladders", () => {
     expect(DEFAULT_ESCALATION_LADDERS.priority_high_default.steps).toEqual([
       { delayMinutes: 0, channelKey: "in_app", intensity: "soft" },
       { delayMinutes: 15, channelKey: "push", intensity: "normal" },
-      { delayMinutes: 45, channelKey: "imessage", intensity: "urgent" },
+      { delayMinutes: 45, channelKey: "owner_preferred", intensity: "urgent" },
     ]);
   });
 });

--- a/plugins/plugin-scheduling/src/dispatch-policy.ts
+++ b/plugins/plugin-scheduling/src/dispatch-policy.ts
@@ -8,7 +8,9 @@
  *
  * Decision matrix:
  * - `ok: true`                           → `complete`
- * - `userActionable: true` failure       → `surface_degraded` (advance ladder)
+ * - `userActionable: true` failure       → `surface_degraded` (advance ladder
+ *                                          when possible; still surface on the
+ *                                          final step before terminal failure)
  *                                          and surface via the
  *                                          connector-degradation provider.
  * - `retryAfterMinutes` set              → `retry` (do NOT advance ladder).
@@ -128,15 +130,15 @@ export function decideDispatchPolicy(
     };
   }
 
-  // Permanent failure on the last available step → terminal.
-  if (isLastStep) {
-    return { kind: "fail", reason, message };
-  }
-
   // User-actionable failure (e.g. auth_expired) — advance, but flag for the
   // connector-degradation provider so the user is told what to fix.
   if (failure.userActionable) {
     return { kind: "surface_degraded", reason, message };
+  }
+
+  // Permanent non-actionable failure on the last available step → terminal.
+  if (isLastStep) {
+    return { kind: "fail", reason, message };
   }
 
   // Generic permanent failure on a non-final step → advance to next step.

--- a/plugins/plugin-scheduling/src/scheduled-task/dispatch-policy-enforcement.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/dispatch-policy-enforcement.test.ts
@@ -114,7 +114,7 @@ function makeHarness(initialIso = "2026-05-11T12:00:00.000Z"): Harness {
         return result;
       },
     },
-    channelKeys: () => new Set(["in_app", "push", "imessage"]),
+    channelKeys: () => new Set(["in_app", "push", "owner_preferred"]),
     now: () => new Date(nowIso),
   });
 
@@ -195,6 +195,28 @@ describe("dispatch-policy enforcement (typed DispatchResult failures)", () => {
       (t) => t.state.pipelineParentId === task.taskId,
     );
     expect(children).toHaveLength(1);
+  });
+
+  it("terminal user-actionable failure still records connector degradation", async () => {
+    const h = makeHarness();
+    const task = await h.runner.schedule(reminderInput());
+    h.queueDispatchResults({
+      ok: false,
+      reason: "disconnected",
+      userActionable: true,
+      message: "No owner messaging connector is connected.",
+    });
+
+    const result = await h.runner.fireWithResult(task.taskId);
+    expect(result.kind).toBe("dispatch_failed");
+
+    const persisted = await h.store.get(task.taskId);
+    expect(persisted?.state.status).toBe("failed");
+    expect(persisted?.metadata?.connectorDegradation).toMatchObject({
+      reason: "disconnected",
+      message: "No owner messaging connector is connected.",
+    });
+    expect(await transitions(h, task.taskId)).toContain("failed");
   });
 
   it("rate_limited retries the same step with backoff and stays out of 'fired'", async () => {
@@ -298,7 +320,7 @@ describe("dispatch-policy enforcement (typed DispatchResult failures)", () => {
     const h = makeHarness();
     const task = await h.runner.schedule(
       reminderInput({
-        priority: "high", // 3-step default ladder: in_app → push → imessage
+        priority: "high", // 3-step default ladder: in_app → push → owner_preferred
       }),
     );
     const transportError: DispatchResult = {
@@ -310,7 +332,7 @@ describe("dispatch-policy enforcement (typed DispatchResult failures)", () => {
       transportError, // initial attempt (default channel)
       transportError, // ladder step 0: in_app (+0m)
       transportError, // ladder step 1: push (+15m)
-      transportError, // ladder step 2: imessage (+45m)
+      transportError, // ladder step 2: owner_preferred (+45m)
     );
 
     let result = await h.runner.fireWithResult(task.taskId);
@@ -324,7 +346,7 @@ describe("dispatch-policy enforcement (typed DispatchResult failures)", () => {
       );
     }
 
-    expect(attempts).toEqual(["in_app", "in_app", "push", "imessage"]);
+    expect(attempts).toEqual(["in_app", "in_app", "push", "owner_preferred"]);
     expect(result.kind).toBe("dispatch_failed");
     const persisted = await h.store.get(task.taskId);
     expect(persisted?.state.status).toBe("failed");

--- a/plugins/plugin-scheduling/src/scheduled-task/escalation.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/escalation.ts
@@ -76,7 +76,7 @@ export const DEFAULT_ESCALATION_LADDERS: Readonly<
     steps: [
       { delayMinutes: 0, channelKey: "in_app", intensity: "soft" },
       { delayMinutes: 15, channelKey: "push", intensity: "normal" },
-      { delayMinutes: 45, channelKey: "imessage", intensity: "urgent" },
+      { delayMinutes: 45, channelKey: "owner_preferred", intensity: "urgent" },
     ],
   },
 });

--- a/plugins/plugin-scheduling/src/scheduled-task/runner-fuzz.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner-fuzz.test.ts
@@ -309,7 +309,7 @@ function makeHarness(startIso: string): FuzzHarness {
         return script;
       },
     },
-    channelKeys: () => new Set(["in_app", "push", "imessage"]),
+    channelKeys: () => new Set(["in_app", "push", "owner_preferred"]),
     now: () => {
       nowMs += 1;
       return new Date(nowMs);

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.ts
@@ -1544,6 +1544,16 @@ export function createScheduledTaskRunner(
         const nextLadderIndex = ladderIndex + 1;
         const nextStep = ladder.steps[nextLadderIndex];
         if (!nextStep) {
+          if (decision.kind === "surface_degraded") {
+            task.metadata = {
+              ...(task.metadata ?? {}),
+              connectorDegradation: {
+                reason: decision.reason,
+                message: decision.message,
+                atIso: fireAtIso,
+              },
+            };
+          }
           return failTerminal(task, decision.reason, decision.message);
         }
         const nextAttemptAtIso = new Date(


### PR DESCRIPTION
## Summary

Fixes #14714.

- Changes the default high-priority escalation ladder from `in_app -> push -> imessage` to `in_app -> push -> owner_preferred` in scheduling and personal-assistant contracts.
- Adds an `owner_preferred` default channel that resolves connector-qualified targets such as `telegram:<chat-id>` through the registered, connected connector instead of assuming iMessage.
- Surfaces user-actionable terminal dispatch failures as connector degradation before terminal failure so the owner can see what connector needs repair.
- Updates contract/schema/fuzz coverage for the new ladder and final-step degradation behavior.

## Verification

- `bunx @biomejs/biome check --write plugins/plugin-scheduling/src/dispatch-policy.ts plugins/plugin-scheduling/src/scheduled-task/runner.ts plugins/plugin-scheduling/src/scheduled-task/escalation.ts plugins/plugin-scheduling/src/scheduled-task/dispatch-policy-enforcement.test.ts plugins/plugin-scheduling/src/scheduled-task/runner-fuzz.test.ts plugins/plugin-personal-assistant/src/default-packs/escalation-ladders.ts plugins/plugin-personal-assistant/src/lifeops/escalation-ladders.ts plugins/plugin-personal-assistant/src/lifeops/channels/default-pack.ts plugins/plugin-personal-assistant/test/contracts.test.ts plugins/plugin-personal-assistant/test/default-packs.schema.test.ts`
- `bun run --cwd plugins/plugin-personal-assistant test -- test/contracts.test.ts test/default-packs.schema.test.ts` — 2 files / 64 tests passed
- `bun run --cwd plugins/plugin-scheduling test -- src/scheduled-task/dispatch-policy-enforcement.test.ts src/scheduled-task/escalation.test.ts src/scheduled-task/runner-fuzz.test.ts` — 3 files / 20 tests passed
- `bun run --cwd plugins/plugin-scheduling typecheck` — passed
- `git diff --check` — passed
- `bun run audit:error-policy-ratchet --report` — passed, 0 new fallback-slop in touched files
- `bun run --cwd plugins/plugin-personal-assistant typecheck` — blocked by existing package-wide missing dependency/export and implicit-any errors unrelated to touched files, starting with `Cannot find module '@elizaos/plugin-blocker/services/app-blocker/index'` and `Cannot find module '@elizaos/plugin-elizacloud/cloud/x402-payment-handler'`.
- `bun run verify` — blocked before Turbo by existing root type-safety ratchet baseline: `as unknown as: 76 / 73`.

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - scheduler/channel contract change only; no UI surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - scheduler/channel contract change only; no UI surface changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - scheduler/channel contract change only; no user-facing screen flow changed`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no deployed backend service was run; deterministic scheduler/channel tests exercised the dispatch policy and connector-routing code paths directly`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend code or browser surface changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no prompt, model, planner, or agent-response behavior changed; deterministic dispatch contracts changed`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts N/A - tests assert the domain artifacts directly: metadata.connectorDegradation, owner_preferred ladder steps, and Telegram connector dispatch payloads.