### PR TITLE
fix(pa): record check-in acknowledgements on owner replies

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/inbound-reply-completion.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/inbound-reply-completion.integration.test.ts
@@ -19,6 +19,7 @@ import {
   createLifeOpsTestRuntime,
   type RealTestRuntimeResult,
 } from "../../../test/helpers/runtime.ts";
+import { CheckinService } from "../checkin/checkin-service.js";
 import { resolvePendingPromptsStore } from "../pending-prompts/store.js";
 import { LifeOpsRepository } from "../repository.js";
 import { completeFiredTasksOnOwnerReply } from "./inbound-reply-completion.js";
@@ -32,6 +33,7 @@ interface FiredTaskSeed {
   firedAtIso: string;
   completionCheck: ScheduledTaskCompletionCheck;
   subject?: ScheduledTask["subject"];
+  metadata?: ScheduledTask["metadata"];
 }
 
 async function seedFiredTask(
@@ -52,7 +54,7 @@ async function seedFiredTask(
     ownerVisible: true,
     completionCheck: seed.completionCheck,
     ...(seed.subject ? { subject: seed.subject } : {}),
-    metadata: { pendingPromptRoomId: seed.roomId },
+    metadata: { pendingPromptRoomId: seed.roomId, ...(seed.metadata ?? {}) },
     state: {
       status: "fired",
       firedAt: seed.firedAtIso,
@@ -135,6 +137,67 @@ describe("inbound-reply completion — production wiring", () => {
       (entry) => entry.transition === "completed",
     );
     expect(completedEntry?.reason).toBe("completion-check:user_replied_within");
+  }, 180_000);
+
+  it("an owner reply to a fired check-in records the check-in report acknowledgement so escalation does not ratchet to max", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const checkins = new CheckinService(runtime);
+    const base = Date.parse("2026-05-12T14:00:00.000Z");
+
+    await checkins.runMorningCheckin({
+      now: new Date(base - 48 * 60 * 60_000),
+    });
+    await checkins.runMorningCheckin({
+      now: new Date(base - 24 * 60 * 60_000),
+    });
+    const repliedReport = await checkins.runMorningCheckin({
+      now: new Date(base - 5 * 60_000),
+    });
+    expect(await checkins.getEscalationLevel(new Date(base))).toBe(3);
+
+    const roomId = "room-checkin-ack";
+    const task = await seedFiredTask(runtime, {
+      roomId,
+      firedAtIso: new Date(base - 4 * 60_000).toISOString(),
+      completionCheck: { kind: "user_replied_within" },
+      metadata: { checkinReportId: repliedReport.reportId },
+    });
+
+    const reply = ownerReply(runtime, roomId);
+    reply.createdAt = base;
+    await runtime.emitEvent(EventType.MESSAGE_RECEIVED, { message: reply });
+
+    expect(await persistedStatus(runtime, task.taskId)).toBe("completed");
+    expect(await checkins.getEscalationLevel(new Date(base))).toBe(2);
+  }, 180_000);
+
+  it("an owner reply after a sleep-cycle check-in acknowledges the latest unacknowledged report", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const checkins = new CheckinService(runtime);
+    const base = Date.parse("2026-05-12T14:00:00.000Z");
+
+    await checkins.runMorningCheckin({
+      now: new Date(base - 48 * 60 * 60_000),
+    });
+    await checkins.runMorningCheckin({
+      now: new Date(base - 24 * 60 * 60_000),
+    });
+    const repliedReport = await checkins.runMorningCheckin({
+      now: new Date(base - 5 * 60_000),
+    });
+    expect(await checkins.getEscalationLevel(new Date(base))).toBe(3);
+
+    const reply = ownerReply(runtime, "room-sleep-cycle-checkin");
+    reply.createdAt = base;
+    (reply as { metadata?: Record<string, unknown> }).metadata = {
+      checkinReportId: repliedReport.reportId,
+    };
+    const result = await completeFiredTasksOnOwnerReply(runtime, reply);
+
+    expect(result.evaluated).toHaveLength(0);
+    expect(await checkins.getEscalationLevel(new Date(base))).toBe(2);
   }, 180_000);
 
   it("a reply in a different room leaves the fired task untouched", async () => {

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/inbound-reply-completion.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/inbound-reply-completion.ts
@@ -31,6 +31,7 @@ import {
   getScheduledTaskRunner,
   pendingPromptRoomIdForTask,
 } from "@elizaos/plugin-scheduling";
+import { CheckinService } from "../checkin/checkin-service.js";
 import { resolvePendingPromptsStore } from "../pending-prompts/store.js";
 import { recordTaskStateEntry } from "./scheduler.js";
 
@@ -44,6 +45,62 @@ export interface InboundReplyCompletionResult {
 }
 
 const EMPTY: InboundReplyCompletionResult = { evaluated: [], completed: [] };
+
+function metadataString(
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+): string | null {
+  const value = metadata?.[key];
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+async function acknowledgeCheckinReportForCompletedTask(
+  runtime: IAgentRuntime,
+  task: { taskId: string; kind?: string; metadata?: Record<string, unknown> },
+): Promise<boolean> {
+  if (task.kind !== "checkin") return false;
+  const reportId = metadataString(task.metadata, "checkinReportId");
+  if (!reportId) return false;
+  await new CheckinService(runtime).recordCheckinAcknowledgement({ reportId });
+  logger.info(
+    {
+      src: LOG_SRC,
+      agentId: runtime.agentId,
+      taskId: task.taskId,
+      reportId,
+    },
+    `[InboundReplyCompletion] owner reply acknowledged check-in report ${reportId}`,
+  );
+  return true;
+}
+
+function checkinReportIdFromOwnerReply(message: Memory): string | null {
+  const metadata = (message as { metadata?: Record<string, unknown> }).metadata;
+  return (
+    metadataString(metadata, "checkinReportId") ??
+    metadataString(metadata, "reportId")
+  );
+}
+
+async function acknowledgeCheckinReportFromReplyMetadata(
+  runtime: IAgentRuntime,
+  message: Memory,
+): Promise<boolean> {
+  const reportId = checkinReportIdFromOwnerReply(message);
+  if (!reportId) return false;
+  await new CheckinService(runtime).recordCheckinAcknowledgement({ reportId });
+  logger.info(
+    {
+      src: LOG_SRC,
+      agentId: runtime.agentId,
+      reportId,
+    },
+    `[InboundReplyCompletion] owner reply acknowledged check-in report from reply metadata ${reportId}`,
+  );
+  return true;
+}
 
 /**
  * Evaluate completion checks for fired tasks awaiting a reply in the
@@ -59,18 +116,22 @@ export async function completeFiredTasksOnOwnerReply(
   if (message.entityId === runtime.agentId) return EMPTY;
   if (!(await hasOwnerAccess(runtime, message))) return EMPTY;
 
-  const runner = getScheduledTaskRunner(runtime, {
-    agentId: String(runtime.agentId),
-  });
-  const fired = await runner.list({ status: "fired" });
-  if (fired.length === 0) return EMPTY;
-
   const repliedAtIso =
     typeof message.createdAt === "number" && Number.isFinite(message.createdAt)
       ? new Date(message.createdAt).toISOString()
       : new Date().toISOString();
 
+  const runner = getScheduledTaskRunner(runtime, {
+    agentId: String(runtime.agentId),
+  });
+  const fired = await runner.list({ status: "fired" });
+  if (fired.length === 0) {
+    await acknowledgeCheckinReportFromReplyMetadata(runtime, message);
+    return EMPTY;
+  }
+
   const result: InboundReplyCompletionResult = { evaluated: [], completed: [] };
+  let acknowledgedCheckinReport = false;
   for (const task of fired) {
     if (!task.completionCheck) continue;
     if (pendingPromptRoomIdForTask(task) !== roomId) continue;
@@ -90,6 +151,9 @@ export async function completeFiredTasksOnOwnerReply(
           "completed",
           new Date(repliedAtIso),
         );
+        acknowledgedCheckinReport =
+          (await acknowledgeCheckinReportForCompletedTask(runtime, task)) ||
+          acknowledgedCheckinReport;
         logger.info(
           {
             src: LOG_SRC,
@@ -114,6 +178,9 @@ export async function completeFiredTasksOnOwnerReply(
         }`,
       );
     }
+  }
+  if (!acknowledgedCheckinReport) {
+    await acknowledgeCheckinReportFromReplyMetadata(runtime, message);
   }
   return result;
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
@@ -339,6 +339,10 @@ async function composeOwnerFacingScheduledTaskText(
         now: new Date(record.firedAtIso),
       });
       const summaryText = assembled.report.summaryText.trim();
+      if (record.metadata) {
+        record.metadata.checkinReportId = assembled.report.reportId;
+        record.metadata.checkinKind = assembled.report.kind;
+      }
       if (summaryText.length > 0) return summaryText;
       throw new Error("Morning check-in assembler returned empty summaryText");
     } catch (error) {


### PR DESCRIPTION
[sol-orch]

## Summary
- carry the assembled morning check-in `reportId` into fired scheduled-task metadata
- record `recordCheckinAcknowledgement()` at the deterministic owner reply completion seam when a check-in task completes
- support explicit `checkinReportId` / `reportId` reply metadata for non-scheduled check-in surfaces without LLM classification
- add regression coverage for both scheduled check-in replies and metadata-linked sleep-cycle replies keeping escalation below max

Fixes #14726

## Verification
- `bunx @biomejs/biome@2.5.2 check plugins/plugin-personal-assistant/src/lifeops/checkin/checkin-service.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/inbound-reply-completion.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/inbound-reply-completion.integration.test.ts` ✅
- `bunx vitest run plugins/plugin-personal-assistant/src/lifeops/scheduled-task/inbound-reply-completion.integration.test.ts -t "check-in"` ❌ blocked in this worktree before test collection by unresolved package entry chain after isolated install/build prep, currently `@elizaos/plugin-local-inference` after prebuilding core/auth/cloud-routing/plugin-elizacloud/plugin-wallet/plugin-app-manager/plugin-x402/plugin-agent-skills/plugin-streaming/plugin-agent-orchestrator/plugin-sql. Previous blockers were the same missing local package dist pattern, not the changed files.
- `bun run --cwd plugins/plugin-personal-assistant typecheck` ❌ blocked by existing local workspace/package resolution and generated export drift across many PA files (`@elizaos/agent`, `@elizaos/core`, contract exports), not isolated to this diff.

## Review
- `codex review --uncommitted` timed out / was SIGKILLed after >100s. I self-reviewed and addressed the actionable early finding by removing the broad “latest unacked report” fallback; acknowledgements now require either completed check-in task metadata or explicit reply metadata.
