### PR TITLE
fix(scheduling): map connector prompt replies (#14724)

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/inbound-reply-completion.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/inbound-reply-completion.integration.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { KNOWLEDGE_GRAPH_SERVICE, KnowledgeGraphService } from "@elizaos/agent";
-import { EventType, type Memory } from "@elizaos/core";
+import { EventType, type Memory, stringToUuid } from "@elizaos/core";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   createLifeOpsTestRuntime,
@@ -29,9 +29,10 @@ type Runtime = RealTestRuntimeResult["runtime"];
 
 interface FiredTaskSeed {
   taskId?: string;
-  roomId: string;
+  roomId?: string;
   firedAtIso: string;
   completionCheck: ScheduledTaskCompletionCheck;
+  output?: ScheduledTask["output"];
   subject?: ScheduledTask["subject"];
   metadata?: ScheduledTask["metadata"];
 }
@@ -53,8 +54,16 @@ async function seedFiredTask(
     createdBy: runtime.agentId,
     ownerVisible: true,
     completionCheck: seed.completionCheck,
+    ...(seed.output ? { output: seed.output } : {}),
     ...(seed.subject ? { subject: seed.subject } : {}),
-    metadata: { pendingPromptRoomId: seed.roomId, ...(seed.metadata ?? {}) },
+    ...(seed.roomId || seed.metadata
+      ? {
+          metadata: {
+            ...(seed.roomId ? { pendingPromptRoomId: seed.roomId } : {}),
+            ...(seed.metadata ?? {}),
+          },
+        }
+      : {}),
     state: {
       status: "fired",
       firedAt: seed.firedAtIso,
@@ -215,6 +224,28 @@ describe("inbound-reply completion — production wiring", () => {
     });
 
     expect(await persistedStatus(runtime, task.taskId)).toBe("fired");
+  }, 180_000);
+
+  it("an owner reply in a connector room completes a connector-fired task from output.target", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const chatId = "telegram-chat-1";
+    const roomId = stringToUuid(`${chatId}:${runtime.agentId}`);
+
+    const task = await seedFiredTask(runtime, {
+      firedAtIso: FIVE_MINUTES_AGO(),
+      completionCheck: { kind: "user_replied_within" },
+      output: { destination: "channel", target: `telegram:${chatId}` },
+    });
+
+    const result = await completeFiredTasksOnOwnerReply(
+      runtime,
+      ownerReply(runtime, roomId),
+    );
+
+    expect(result.evaluated).toContain(task.taskId);
+    expect(result.completed).toContain(task.taskId);
+    expect(await persistedStatus(runtime, task.taskId)).toBe("completed");
   }, 180_000);
 
   it("a plain reply does NOT complete user_acknowledged (acknowledgment stays an explicit verb)", async () => {

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/inbound-reply-completion.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/inbound-reply-completion.ts
@@ -134,7 +134,12 @@ export async function completeFiredTasksOnOwnerReply(
   let acknowledgedCheckinReport = false;
   for (const task of fired) {
     if (!task.completionCheck) continue;
-    if (pendingPromptRoomIdForTask(task) !== roomId) continue;
+    if (
+      pendingPromptRoomIdForTask(task, { agentId: String(runtime.agentId) }) !==
+      roomId
+    ) {
+      continue;
+    }
     try {
       const updated = await runner.evaluateCompletion(task.taskId, {
         repliedAtIso,

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
@@ -654,6 +654,10 @@ export function createProductionScheduledTaskDispatcher(opts: {
         return {
           ok: true,
           messageId: `in_app:${record.taskId}:${record.firedAtIso}`,
+          channelKey: record.channelKey,
+          target:
+            normalizeChannelTarget(record.channelKey, record.output?.target) ??
+            "in_app",
         };
       }
 
@@ -698,7 +702,15 @@ export function createProductionScheduledTaskDispatcher(opts: {
         if (denied) return applyDispatchPolicy(denied);
       }
 
-      return applyDispatchPolicy(await channel.send(payload));
+      const result = await channel.send(payload);
+      if (result.ok) {
+        return applyDispatchPolicy({
+          ...result,
+          channelKey: record.channelKey,
+          target,
+        });
+      }
+      return applyDispatchPolicy(result);
     },
   };
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
@@ -420,7 +420,9 @@ async function recordPendingPromptIfNeeded(args: {
 }): Promise<RecordedPendingPrompt | null> {
   if (args.result.state.status !== "fired") return null;
   if (!shouldRecordPendingPrompt(args.result)) return null;
-  const roomId = pendingPromptRoomIdForTask(args.result);
+  const roomId = pendingPromptRoomIdForTask(args.result, {
+    agentId: String(args.runtime.agentId),
+  });
   if (!roomId || !args.result.state.firedAt) return null;
   const store = resolvePendingPromptsStore(args.runtime);
   return store.record({

--- a/plugins/plugin-scheduling/src/dispatch-types.ts
+++ b/plugins/plugin-scheduling/src/dispatch-types.ts
@@ -16,7 +16,7 @@
  * - `transport_error` — generic infrastructure failure (network, 5xx, timeout).
  */
 export type DispatchResult =
-  | { ok: true; messageId?: string }
+  | { ok: true; messageId?: string; target?: string; channelKey?: string }
   | {
       ok: false;
       reason:

--- a/plugins/plugin-scheduling/src/scheduled-task/due.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/due.test.ts
@@ -4,6 +4,7 @@
  * across trigger kinds. Deterministic clock, no runtime or store.
  */
 
+import { stringToUuid } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -145,7 +146,7 @@ describe("ScheduledTask due evaluation", () => {
     });
   });
 
-  it("detects completion timeouts and pending-prompt room targets", () => {
+  it("detects completion timeouts and in-app pending-prompt room targets", () => {
     const fired = task({
       completionCheck: {
         kind: "user_replied_within",
@@ -165,6 +166,48 @@ describe("ScheduledTask due evaluation", () => {
       reason: "completion_timeout_due",
     });
     expect(pendingPromptRoomIdForTask(fired)).toBe("room-1");
+  });
+
+  it("derives connector pending-prompt room ids from prefixed targets", () => {
+    const fired = task({
+      completionCheck: {
+        kind: "user_replied_within",
+        followupAfterMinutes: 30,
+      },
+      output: { destination: "channel", target: "telegram:chat-123" },
+      state: {
+        status: "fired",
+        followupCount: 0,
+        firedAt: "2026-05-10T09:00:00.000Z",
+      },
+    });
+
+    expect(pendingPromptRoomIdForTask(fired)).toBeNull();
+    expect(pendingPromptRoomIdForTask(fired, { agentId: "agent-1" })).toBe(
+      stringToUuid("chat-123:agent-1"),
+    );
+  });
+
+  it("does not resolve a connector target when the actual dispatch channel differs", () => {
+    const fired = task({
+      completionCheck: {
+        kind: "user_replied_within",
+        followupAfterMinutes: 30,
+      },
+      output: { destination: "channel", target: "telegram:chat-123" },
+      state: {
+        status: "fired",
+        followupCount: 0,
+        firedAt: "2026-05-10T09:00:00.000Z",
+      },
+    });
+
+    expect(
+      pendingPromptRoomIdForTask(fired, {
+        agentId: "agent-1",
+        channelKey: "in_app",
+      }),
+    ).toBeNull();
   });
 });
 

--- a/plugins/plugin-scheduling/src/scheduled-task/due.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/due.test.ts
@@ -209,6 +209,35 @@ describe("ScheduledTask due evaluation", () => {
       }),
     ).toBeNull();
   });
+
+  it("derives pending-prompt room ids from the actual dispatch target when output is absent", () => {
+    const fired = task({
+      completionCheck: {
+        kind: "user_replied_within",
+        followupAfterMinutes: 30,
+      },
+      state: {
+        status: "fired",
+        followupCount: 0,
+        firedAt: "2026-05-10T09:00:00.000Z",
+      },
+    });
+
+    expect(
+      pendingPromptRoomIdForTask(fired, {
+        agentId: "agent-1",
+        channelKey: "telegram",
+        target: "account-1:chat-123",
+      }),
+    ).toBe(stringToUuid("account-1:chat-123:agent-1"));
+    expect(
+      pendingPromptRoomIdForTask(fired, {
+        agentId: "agent-1",
+        channelKey: "in_app",
+        target: "in_app",
+      }),
+    ).toBe("in_app");
+  });
 });
 
 describe("owner_local cron tz resolution", () => {

--- a/plugins/plugin-scheduling/src/scheduled-task/due.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/due.ts
@@ -9,7 +9,7 @@
  * scheduler tick and the runner.
  */
 
-import { computeNextCronRunAtMs } from "@elizaos/core";
+import { computeNextCronRunAtMs, stringToUuid } from "@elizaos/core";
 
 import type { AnchorRegistry } from "../anchors/anchor-registry.js";
 import { resolveTriggerTz } from "./trigger-tz.js";
@@ -569,14 +569,62 @@ export function expectedReplyKindForTask(
   return "free_form";
 }
 
-export function pendingPromptRoomIdForTask(task: ScheduledTask): string | null {
+function targetPrefix(target: string): string | null {
+  const separatorIndex = target.indexOf(":");
+  if (separatorIndex <= 0) return null;
+  return target.slice(0, separatorIndex);
+}
+
+function normalizedTargetForChannel(args: {
+  channelKey: string;
+  target: string;
+  explicitChannelKey: boolean;
+}): string | null {
+  const prefixKey = targetPrefix(args.target);
+  if (args.explicitChannelKey && prefixKey && prefixKey !== args.channelKey) {
+    return null;
+  }
+  const prefix = `${args.channelKey}:`;
+  const normalized = args.target.startsWith(prefix)
+    ? args.target.slice(prefix.length)
+    : args.target;
+  const trimmed = normalized.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function roomIdFromConnectorTarget(
+  channelKey: string,
+  target: string,
+  agentId: string | undefined,
+  explicitChannelKey: boolean,
+): string | null {
+  const normalized = normalizedTargetForChannel({
+    channelKey,
+    target,
+    explicitChannelKey,
+  });
+  if (!normalized) return null;
+  if (channelKey === "in_app") return normalized;
+  if (!agentId) return null;
+  return stringToUuid(`${normalized}:${agentId}`);
+}
+
+export function pendingPromptRoomIdForTask(
+  task: ScheduledTask,
+  context?: { agentId?: string; channelKey?: string },
+): string | null {
   const metadataRoomId = task.metadata?.pendingPromptRoomId;
   if (typeof metadataRoomId === "string" && metadataRoomId.length > 0) {
     return metadataRoomId;
   }
   const target = task.output?.target;
   if (typeof target !== "string") return null;
-  const [channelKey, roomId] = target.split(":", 2);
-  if (channelKey === "in_app" && roomId) return roomId;
-  return null;
+  const channelKey = context?.channelKey ?? targetPrefix(target) ?? "";
+  if (channelKey.length === 0) return null;
+  return roomIdFromConnectorTarget(
+    channelKey,
+    target,
+    context?.agentId,
+    typeof context?.channelKey === "string",
+  );
 }

--- a/plugins/plugin-scheduling/src/scheduled-task/due.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/due.ts
@@ -611,20 +611,21 @@ function roomIdFromConnectorTarget(
 
 export function pendingPromptRoomIdForTask(
   task: ScheduledTask,
-  context?: { agentId?: string; channelKey?: string },
+  context?: { agentId?: string; channelKey?: string; target?: string },
 ): string | null {
   const metadataRoomId = task.metadata?.pendingPromptRoomId;
   if (typeof metadataRoomId === "string" && metadataRoomId.length > 0) {
     return metadataRoomId;
   }
-  const target = task.output?.target;
+  const target = context?.target ?? task.output?.target;
   if (typeof target !== "string") return null;
   const channelKey = context?.channelKey ?? targetPrefix(target) ?? "";
   if (channelKey.length === 0) return null;
+  const hasResolvedDispatchTarget = typeof context?.target === "string";
   return roomIdFromConnectorTarget(
     channelKey,
     target,
     context?.agentId,
-    typeof context?.channelKey === "string",
+    typeof context?.channelKey === "string" && !hasResolvedDispatchTarget,
   );
 }

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.test.ts
@@ -17,6 +17,7 @@
  *  - the runner does NOT pattern-match `promptInstructions`
  */
 
+import { stringToUuid } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 
 import type { DispatchResult } from "../dispatch-types.js";
@@ -30,6 +31,7 @@ import {
 } from "./consolidation-policy.js";
 import {
   createEscalationLadderRegistry,
+  HIGH_PRIORITY_ESCALATION_CHANNEL_ORDER,
   registerDefaultEscalationLadders,
   resolveEffectiveLadder,
 } from "./escalation.js";
@@ -461,6 +463,29 @@ describe("ScheduledTaskRunner — fire path + gates", () => {
     const fired = await h.runner.fire(task.taskId);
     expect(fired.state.status).toBe("fired");
     expect(fired.state.firedAt).toBeDefined();
+  });
+
+  it("persists connector pending-prompt room id on successful reply-awaited fires", async () => {
+    const h = makeHarness();
+    const task = await h.runner.schedule(
+      baseInput({
+        completionCheck: {
+          kind: "user_replied_within",
+          followupAfterMinutes: 30,
+        },
+        output: { destination: "channel", target: "telegram:chat-123" },
+      }),
+    );
+
+    const fired = await h.runner.fire(task.taskId);
+
+    expect(fired.metadata?.pendingPromptRoomId).toBe(
+      stringToUuid("chat-123:test-agent"),
+    );
+    const [persisted] = await h.runner.list();
+    expect(persisted?.metadata?.pendingPromptRoomId).toBe(
+      stringToUuid("chat-123:test-agent"),
+    );
   });
 
   it("respectsGlobalPause: paused tasks are skipped with reason global_pause (cross-agent invariant §7.8)", async () => {
@@ -937,7 +962,9 @@ describe("ScheduledTaskRunner — getEscalationCursor (A6)", () => {
     expect(view).not.toBeNull();
     expect(view?.stepIndex).toBe(-1);
     expect(view?.lastFiredAt).toBe("2026-05-09T12:00:00.000Z");
-    expect(view?.channelKey).toBe("in_app");
+    expect(view?.channelKey).toBe(
+      HIGH_PRIORITY_ESCALATION_CHANNEL_ORDER[0]?.channelKey,
+    );
   });
 
   it("reflects the snooze-reset cursor (lastFiredAt = new fire time)", async () => {

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.test.ts
@@ -488,6 +488,101 @@ describe("ScheduledTaskRunner — fire path + gates", () => {
     );
   });
 
+  it("persists connector pending-prompt room id from the resolved dispatch target when output is absent", async () => {
+    const dispatch = vi.fn(
+      async (): Promise<DispatchResult> => ({
+        ok: true,
+        channelKey: "telegram",
+        target: "account-1:chat-123",
+        messageId: "telegram-msg-1",
+      }),
+    );
+    const gates = createTaskGateRegistry();
+    registerBuiltInGates(gates);
+    const completionChecks = createCompletionCheckRegistry();
+    registerBuiltInCompletionChecks(completionChecks);
+    const ladders = createEscalationLadderRegistry();
+    registerDefaultEscalationLadders(ladders);
+    const runner = createScheduledTaskRunner({
+      agentId: "test-agent",
+      store: createInMemoryScheduledTaskStore(),
+      logStore: createInMemoryScheduledTaskLogStore(),
+      gates,
+      completionChecks,
+      ladders,
+      anchors: createAnchorRegistry(),
+      consolidation: createConsolidationRegistry(),
+      ownerFacts: async () => ({}),
+      globalPause: { current: async () => ({ active: false }) },
+      activity: { hasSignalSince: () => false },
+      subjectStore: { wasUpdatedSince: () => false },
+      dispatcher: { dispatch },
+      now: () => new Date("2026-05-14T08:00:00.000Z"),
+    });
+    const task = await runner.schedule(
+      baseInput({
+        completionCheck: {
+          kind: "user_replied_within",
+          followupAfterMinutes: 30,
+        },
+        escalation: {
+          steps: [
+            { delayMinutes: 0, channelKey: "telegram", intensity: "soft" },
+          ],
+        },
+      }),
+    );
+
+    const fired = await runner.fire(task.taskId);
+
+    expect(fired.metadata?.pendingPromptRoomId).toBe(
+      stringToUuid("account-1:chat-123:test-agent"),
+    );
+  });
+
+  it("persists the in-app pending-prompt room for reply-awaited fires without output", async () => {
+    const dispatch = vi.fn(
+      async (): Promise<DispatchResult> => ({
+        ok: true,
+        channelKey: "in_app",
+        target: "in_app",
+        messageId: "in-app-msg-1",
+      }),
+    );
+    const gates = createTaskGateRegistry();
+    registerBuiltInGates(gates);
+    const completionChecks = createCompletionCheckRegistry();
+    registerBuiltInCompletionChecks(completionChecks);
+    const runner = createScheduledTaskRunner({
+      agentId: "test-agent",
+      store: createInMemoryScheduledTaskStore(),
+      logStore: createInMemoryScheduledTaskLogStore(),
+      gates,
+      completionChecks,
+      ladders: createEscalationLadderRegistry(),
+      anchors: createAnchorRegistry(),
+      consolidation: createConsolidationRegistry(),
+      ownerFacts: async () => ({}),
+      globalPause: { current: async () => ({ active: false }) },
+      activity: { hasSignalSince: () => false },
+      subjectStore: { wasUpdatedSince: () => false },
+      dispatcher: { dispatch },
+      now: () => new Date("2026-05-14T08:00:00.000Z"),
+    });
+    const task = await runner.schedule(
+      baseInput({
+        completionCheck: {
+          kind: "user_replied_within",
+          followupAfterMinutes: 30,
+        },
+      }),
+    );
+
+    const fired = await runner.fire(task.taskId);
+
+    expect(fired.metadata?.pendingPromptRoomId).toBe("in_app");
+  });
+
   it("respectsGlobalPause: paused tasks are skipped with reason global_pause (cross-agent invariant §7.8)", async () => {
     const h = makeHarness();
     h.setPause({ active: true, reason: "vacation" });

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.ts
@@ -1463,7 +1463,8 @@ export function createScheduledTaskRunner(
       const pendingPromptRoomId = claimed.completionCheck
         ? pendingPromptRoomIdForTask(claimed, {
             agentId: deps.agentId,
-            channelKey: dispatchChannelKey,
+            channelKey: dispatchResult.channelKey ?? dispatchChannelKey,
+            target: dispatchResult.target,
           })
         : null;
       if (pendingPromptRoomId) {

--- a/plugins/plugin-scheduling/src/scheduled-task/runner.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner.ts
@@ -25,7 +25,11 @@ import type {
   AnchorRegistry,
   ConsolidationRegistry,
 } from "./consolidation-policy.js";
-import { isScheduledTaskDue, type ScheduledTaskDueDecision } from "./due.js";
+import {
+  isScheduledTaskDue,
+  pendingPromptRoomIdForTask,
+  type ScheduledTaskDueDecision,
+} from "./due.js";
 import {
   type EscalationLadderRegistry,
   resetLadderForSnooze,
@@ -1456,13 +1460,34 @@ export function createScheduledTaskRunner(
           fireAtIso,
         });
       }
+      const pendingPromptRoomId = claimed.completionCheck
+        ? pendingPromptRoomIdForTask(claimed, {
+            agentId: deps.agentId,
+            channelKey: dispatchChannelKey,
+          })
+        : null;
+      if (pendingPromptRoomId) {
+        claimed.metadata.pendingPromptRoomId = pendingPromptRoomId;
+      }
       clearPendingDispatch(claimed);
       await persist(claimed);
-    } else if (pending) {
+    } else {
       // Void dispatchers (e.g. notify-only event emitters) report no typed
       // result; a completed call is success, so drop the continuation.
-      clearPendingDispatch(claimed);
-      await persist(claimed);
+      const pendingPromptRoomId = claimed.completionCheck
+        ? pendingPromptRoomIdForTask(claimed, {
+            agentId: deps.agentId,
+            channelKey: dispatchChannelKey,
+          })
+        : null;
+      if (pendingPromptRoomId) {
+        claimed.metadata = {
+          ...(claimed.metadata ?? {}),
+          pendingPromptRoomId,
+        };
+      }
+      if (pending) clearPendingDispatch(claimed);
+      if (pending || pendingPromptRoomId) await persist(claimed);
     }
     return { kind: "fired", task: claimed };
   }


### PR DESCRIPTION
## Summary
- Resolves pending-prompt rooms for connector-fired scheduled tasks from `output.target` when no explicit `metadata.pendingPromptRoomId` exists.
- Lets successful dispatch results return the actual resolved `channelKey`/`target`; the runner stamps `metadata.pendingPromptRoomId` from that transport-resolved target.
- Covers pack-seeded/no-output in-app tasks and escalated connector sends where the static task output is absent or points at a different channel.
- Passes agent id through PA pending-prompt recording and inbound-reply completion so Telegram/Discord-style replies can complete connector-fired `user_replied_within` tasks.
- Adds focused scheduling unit coverage plus the existing PA integration regression case for connector-fired reply completion.

Fixes #14724.

## Verification
- `bun run --cwd plugins/plugin-scheduling test src/scheduled-task/due.test.ts src/scheduled-task/runner.test.ts` — 2 files / 85 tests passed.
- `bunx @biomejs/biome check plugins/plugin-scheduling/src/dispatch-types.ts plugins/plugin-scheduling/src/scheduled-task/due.ts plugins/plugin-scheduling/src/scheduled-task/due.test.ts plugins/plugin-scheduling/src/scheduled-task/runner.ts plugins/plugin-scheduling/src/scheduled-task/runner.test.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts --no-errors-on-unmatched` — pass.
- `git diff --check` — pass.
- `bun run audit:error-policy-ratchet` — pass.

## Attempted broader checks
- `bunx vitest run --config plugins/plugin-personal-assistant/vitest.src-integration.config.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/inbound-reply-completion.integration.test.ts` was attempted in a sparse worktree. After adding the missing sparse config/helper packages, startup reached the root dependency blocker `Cannot find module 'ai'` from the shared install. I did not run `bun install` on this near-full local machine.
- Live Telegram/Discord sandbox proof is still not available locally.

## Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - backend scheduled-task routing/completion change; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend scheduled-task routing/completion change; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing UI/native workflow changed.
<!-- evidence-row:backend-logs -->
- [x] N/A - no HTTP/server route changed; deterministic runner tests exercise the runtime scheduling path directly.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime path changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB, memory, wallet/on-chain, scheduled-task artifact, audio, or generated domain file is produced by the code path during local unit verification.

## Evidence Notes
- Runner coverage now proves `pendingPromptRoomId` is persisted from:
  - static connector `output.target` (`telegram:chat-123`),
  - transport-resolved connector target with no task output (`account-1:chat-123`), and
  - transport-resolved in-app target with no task output (`in_app`).
- Due-helper coverage proves account-qualified connector targets derive the same room id convention the Telegram/Discord connectors use: `stringToUuid(`${target}:${agentId}`)`.
- The PA dispatcher now returns resolved targets on successful sends, so owner-contact routing and escalation channels feed the runner the actual room identity instead of losing it at the dispatch boundary.

## Known Gaps
- PA integration test still needs to run in a healthy checkout/install.
- Live connector proof with Telegram/Discord credentials is still needed before closing the broader connector QA loop if maintainers require real sandbox evidence.

