### PR TITLE
fix(cloud): backfill Steward tenants for pre-#14869 orgs (#14645)

### DIFF
--- a/packages/cloud/shared/src/lib/services/steward-tenant-migration.test.ts
+++ b/packages/cloud/shared/src/lib/services/steward-tenant-migration.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for the one-off Steward tenant backfill (#14645).
+ *
+ * PR #14869 provisions Steward tenants eagerly at signup, but orgs created
+ * before that fix still have steward_tenant_id = NULL and 403-loop on
+ * /steward/user/me/tenants. `backfillStewardTenants` provisions a tenant for
+ * each such org. Asserted here:
+ *   (a) every NULL-tenant candidate is provisioned exactly once,
+ *   (b) FAIL-OPEN accounting: one org failing does NOT abort the run — the
+ *       others still provision and the failure is counted, not thrown,
+ *   (c) --dry-run provisions nothing but reports the candidate count,
+ *   (d) --max-orgs caps how many candidates are processed.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Candidate rows the mocked readQuery returns (NULL-tenant orgs).
+let candidateRows: Array<{ id: string }> = [];
+const ensureStewardTenantCalls: string[] = [];
+let failForOrgId: string | null = null;
+
+mock.module("../../db/helpers", () => ({
+  // The service passes an async (db) => query builder; we bypass the real DB
+  // and hand back the staged candidate rows.
+  readQuery: async () => candidateRows,
+}));
+
+mock.module("./steward-tenant-config", () => ({
+  ensureStewardTenant: async (organizationId: string) => {
+    ensureStewardTenantCalls.push(organizationId);
+    if (failForOrgId && organizationId === failForOrgId) {
+      throw new Error(`Steward unreachable for ${organizationId}`);
+    }
+    return { tenantId: `elizacloud-${organizationId}`, isNew: true };
+  },
+}));
+
+mock.module("../utils/logger", () => ({
+  logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+}));
+
+describe("backfillStewardTenants (#14645)", () => {
+  beforeEach(() => {
+    candidateRows = [];
+    ensureStewardTenantCalls.length = 0;
+    failForOrgId = null;
+  });
+
+  test("provisions a tenant for every NULL-tenant org exactly once", async () => {
+    candidateRows = [{ id: "org-a" }, { id: "org-b" }, { id: "org-c" }];
+    const { backfillStewardTenants } = await import("./steward-tenant-migration");
+
+    const summary = await backfillStewardTenants();
+
+    expect(ensureStewardTenantCalls.sort()).toEqual(["org-a", "org-b", "org-c"]);
+    expect(summary).toEqual({ scanned: 3, provisioned: 3, failed: 0, dryRun: false });
+  });
+
+  test("FAIL-OPEN: one org failing does not abort the run; it is counted", async () => {
+    candidateRows = [{ id: "org-a" }, { id: "org-bad" }, { id: "org-c" }];
+    failForOrgId = "org-bad";
+    const { backfillStewardTenants } = await import("./steward-tenant-migration");
+
+    const summary = await backfillStewardTenants({ batchSize: 10 });
+
+    // All three were attempted; the good two succeeded, the bad one is counted.
+    expect(ensureStewardTenantCalls.sort()).toEqual(["org-a", "org-bad", "org-c"]);
+    expect(summary.scanned).toBe(3);
+    expect(summary.provisioned).toBe(2);
+    expect(summary.failed).toBe(1);
+  });
+
+  test("--dry-run provisions nothing but reports the candidate count", async () => {
+    candidateRows = [{ id: "org-a" }, { id: "org-b" }];
+    const { backfillStewardTenants } = await import("./steward-tenant-migration");
+
+    const summary = await backfillStewardTenants({ dryRun: true });
+
+    expect(ensureStewardTenantCalls).toHaveLength(0);
+    expect(summary).toEqual({ scanned: 2, provisioned: 0, failed: 0, dryRun: true });
+  });
+
+  test("--max-orgs caps how many candidates are processed", async () => {
+    candidateRows = [{ id: "org-a" }, { id: "org-b" }, { id: "org-c" }, { id: "org-d" }];
+    const { backfillStewardTenants } = await import("./steward-tenant-migration");
+
+    const summary = await backfillStewardTenants({ maxOrgs: 2 });
+
+    expect(ensureStewardTenantCalls).toHaveLength(2);
+    expect(summary.scanned).toBe(2);
+    expect(summary.provisioned).toBe(2);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/steward-tenant-migration.ts
+++ b/packages/cloud/shared/src/lib/services/steward-tenant-migration.ts
@@ -1,0 +1,99 @@
+// Coordinates the one-off backfill of per-org Steward tenants (#14645).
+//
+// Steward tenants were historically provisioned LAZILY — only at first
+// agent-provision (docker-sandbox-provider -> ensureStewardTenant). PR #14869
+// makes them eager at signup, but every org that signed up BEFORE that fix
+// still has `steward_tenant_id = NULL` and therefore hits the
+// `GET /steward/user/me/tenants` 403 -> infinite /login bounce. This backfill
+// provisions a tenant for each such org so those existing users stop looping.
+//
+// Safe by construction: `ensureStewardTenant` is idempotent + 409-tolerant and
+// short-circuits for orgs that already hold a tenant, so re-running is a no-op
+// for the populated majority. Mirrors the (now-retired) steward-user backfill —
+// users went through the same lazy -> eager-mandatory-at-signup + backfill path.
+
+import { isNull } from "drizzle-orm";
+import { readQuery } from "../../db/helpers";
+import { organizations } from "../../db/schemas/organizations";
+import { logger } from "../utils/logger";
+import { ensureStewardTenant } from "./steward-tenant-config";
+
+export interface StewardTenantBackfillOptions {
+  /** Orgs to provision per concurrent batch (default: 25). */
+  batchSize?: number;
+  /** Stop after processing at most this many candidate orgs. */
+  maxOrgs?: number;
+  /** List candidates without provisioning. */
+  dryRun?: boolean;
+}
+
+export interface StewardTenantBackfillSummary {
+  scanned: number;
+  provisioned: number;
+  failed: number;
+  dryRun: boolean;
+}
+
+export async function backfillStewardTenants(
+  options: StewardTenantBackfillOptions = {},
+): Promise<StewardTenantBackfillSummary> {
+  const dryRun = options.dryRun ?? false;
+  const batchSize = options.batchSize && options.batchSize > 0 ? options.batchSize : 25;
+
+  const candidates = await readQuery(
+    async (db) =>
+      db
+        .select({ id: organizations.id })
+        .from(organizations)
+        .where(isNull(organizations.steward_tenant_id)),
+    "backfillStewardTenants.listNullTenantOrgs",
+  );
+
+  const limited =
+    options.maxOrgs && options.maxOrgs > 0 ? candidates.slice(0, options.maxOrgs) : candidates;
+
+  const summary: StewardTenantBackfillSummary = {
+    scanned: limited.length,
+    provisioned: 0,
+    failed: 0,
+    dryRun,
+  };
+
+  logger.info(
+    `[StewardTenantMigration] Backfill starting: ${limited.length} org(s) with NULL steward_tenant_id${dryRun ? " (dry-run)" : ""}`,
+  );
+
+  if (dryRun) {
+    for (const org of limited) {
+      logger.info(`[StewardTenantMigration] (dry-run) would provision tenant for org ${org.id}`);
+    }
+    return summary;
+  }
+
+  for (let i = 0; i < limited.length; i += batchSize) {
+    const batch = limited.slice(i, i + batchSize);
+    const results = await Promise.allSettled(batch.map((org) => ensureStewardTenant(org.id)));
+    results.forEach((result, index) => {
+      const orgId = batch[index].id;
+      if (result.status === "fulfilled") {
+        summary.provisioned += 1;
+        logger.info(
+          `[StewardTenantMigration] Provisioned tenant ${result.value.tenantId} for org ${orgId} (isNew=${result.value.isNew})`,
+        );
+      } else {
+        summary.failed += 1;
+        const cause =
+          result.reason instanceof Error ? result.reason.message : String(result.reason);
+        logger.error(
+          `[StewardTenantMigration] Failed to provision tenant for org ${orgId}: ${cause}`,
+        );
+      }
+    });
+  }
+
+  logger.info(
+    `[StewardTenantMigration] Backfill complete: scanned=${summary.scanned} provisioned=${summary.provisioned} failed=${summary.failed}`,
+  );
+
+  return summary;
+}

--- a/packages/scripts/cloud/admin/backfill-steward-tenants.ts
+++ b/packages/scripts/cloud/admin/backfill-steward-tenants.ts
@@ -1,0 +1,94 @@
+#!/usr/bin/env bun
+// Drives the cloud admin one-off backfill of per-org Steward tenants (#14645).
+//
+// Provisions a Steward tenant for every org that still has a NULL
+// steward_tenant_id (orgs that signed up before PR #14869 made tenants eager
+// at signup). Without this, `GET /steward/user/me/tenants` 403s those existing
+// users into an infinite /login loop. `ensureStewardTenant` is idempotent +
+// 409-tolerant, so this is safe to (re)run and no-ops for orgs already linked.
+
+import type { StewardTenantBackfillOptions } from "@/lib/services/steward-tenant-migration";
+import { loadEnvFiles } from "./local-dev-helpers";
+
+loadEnvFiles();
+
+function parseNumberFlag(args: string[], flag: string): number | undefined {
+  const index = args.indexOf(flag);
+  if (index === -1) {
+    return undefined;
+  }
+
+  const rawValue = args[index + 1];
+  if (!rawValue) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+
+  const value = Number.parseInt(rawValue, 10);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`Invalid value for ${flag}: ${rawValue}`);
+  }
+
+  return value;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log(`
+Backfill Steward Tenants (#14645)
+=================================
+
+Provisions a Steward tenant for every org with a NULL steward_tenant_id
+(pre-#14869 signups) so GET /steward/user/me/tenants stops returning 403 and
+bouncing those users to /login forever. Idempotent + 409-tolerant: safe to
+re-run; no-ops for orgs that already have a tenant.
+
+Usage:
+  bun run packages/scripts/cloud/admin/backfill-steward-tenants.ts [options]
+
+Options:
+  --batch-size <n>  Orgs to provision per concurrent batch (default: 25)
+  --max-orgs <n>    Stop after processing at most n candidate orgs
+  --dry-run         List candidate orgs without provisioning
+  --help            Show this message
+`);
+    process.exit(0);
+  }
+
+  const { backfillStewardTenants } = await import(
+    "@/lib/services/steward-tenant-migration"
+  );
+
+  const options: StewardTenantBackfillOptions = {
+    batchSize: parseNumberFlag(args, "--batch-size"),
+    maxOrgs: parseNumberFlag(args, "--max-orgs"),
+    dryRun: args.includes("--dry-run"),
+  };
+
+  console.log("Starting Steward tenant backfill...");
+  if (options.dryRun) {
+    console.log("Running in dry-run mode.");
+  }
+
+  const summary = await backfillStewardTenants(options);
+
+  console.log("\nBackfill summary");
+  console.log("================");
+  console.log(`Scanned:     ${summary.scanned}`);
+  console.log(`Provisioned: ${summary.provisioned}`);
+  console.log(`Failed:      ${summary.failed}`);
+  console.log(`Dry run:     ${summary.dryRun ? "yes" : "no"}`);
+
+  if (summary.failed > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error(
+    "Backfill failed:",
+    error instanceof Error ? error.message : String(error),
+  );
+  process.exit(1);
+});


### PR DESCRIPTION
## What
A one-off admin backfill that provisions a Steward tenant for **every org with a NULL `steward_tenant_id`** — the companion #14869 needs to fully close #14645.

## Why
#14869 (merged) provisions Steward tenants **eagerly at signup**, which fixes *new* users. But it does nothing for orgs created **before** it, which still have `steward_tenant_id = NULL` → `GET /steward/user/me/tenants` **403** → the app reads that as unauthenticated → infinite `/login` bounce. Those users can never reach agent-provision to self-heal.

Ground-truth (qa-agent, staging DB): **665 orgs** are NULL-tenant — including the **funded Seeker demo org `7c7412f9` (nubsvault)** and `9d063b2e` (elizamakesmagic). Until they're backfilled, the **phone/demo golden path stays red** even with #14869 merged.

This mirrors the exact path the Steward **users** system already took: lazy → eager-mandatory-at-signup + one-time backfill (`backfillStewardUserMappings`, now retired once caught up).

## How
- **`lib/services/steward-tenant-migration.ts`** — `backfillStewardTenants({batchSize?, maxOrgs?, dryRun?})`: selects orgs `WHERE steward_tenant_id IS NULL`, calls `ensureStewardTenant(org.id)` per org in concurrent batches, returns `{scanned, provisioned, failed, dryRun}`.
- **Safe by construction:** `ensureStewardTenant` is **idempotent + 409-tolerant** and short-circuits (`isNew:false`) for orgs that already hold a tenant — so re-running is a no-op for the 2,911 populated orgs, and a partial/failed run can be re-run.
- **Fail-open accounting:** one org failing (`Promise.allSettled`) does **not** abort the run — the rest still provision; failures are counted + logged, not thrown.
- **`scripts/cloud/admin/backfill-steward-tenants.ts`** — thin CLI (mirrors `backfill-steward-users.ts`): `--dry-run`, `--batch-size <n>`, `--max-orgs <n>`, `--help`.
- **Not a schema migration** — no DDL, no migration file; it's an admin data script (append-only migration rules N/A).

## Verify
```
$ bun run --cwd packages/cloud/shared test steward-tenant-migration
 4 pass  0 fail  11 expect() calls
  ✓ provisions a tenant for every NULL-tenant org exactly once
  ✓ FAIL-OPEN: one org failing does not abort the run; it is counted
  ✓ --dry-run provisions nothing but reports the candidate count
  ✓ --max-orgs caps how many candidates are processed

$ bun run --cwd packages/cloud/shared typecheck   # clean (no errors in steward-tenant-migration.*)
$ bunx biome check <3 files>                       # No fixes applied
```
E2E against real DB rows: **N/A locally — deliberately deferred to the operator run** (this writes tenants to the real cloud DB, which is the cloud lane's lever). Recommended sequence below; the `--dry-run` first pass IS the read-only preflight.

## ⚠️ Running it is the cloud lane's lever — do NOT auto-merge
This writes to the production/staging cloud DB. I ([maintainer]) built + tested the tool but am **not** running it or self-merging. Recommended operator sequence (@0xSolace / @standujar / nubs):
1. `bun run packages/scripts/cloud/admin/backfill-steward-tenants.ts --dry-run` → confirm the candidate count (~665 on staging).
2. Real run (batched). Idempotent, so safe.
3. Spot-check the launch-test orgs got tenants: **`7c7412f9`**, `9d063b2e` (+ any org nubs will test).
4. @qa-agent (owns the post-merge #14645 verify) runs the REAL sign-in golden path on `nubsvault` + `nubsontopgang` → close #14645.

Closes the existing-user half of #14645 (the new-user half is #14869). — [maintainer]
