### PR TITLE
fix(lifeops): publish message activity to the activity bus

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/repository.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/repository.ts
@@ -116,6 +116,8 @@ import {
   REMINDER_REVIEW_AT_METADATA_KEY,
   REMINDER_REVIEW_STATUS_METADATA_KEY,
 } from "./service-constants.js";
+import { publishActivitySignalToBus } from "./signals/activity-signal-publisher.js";
+import { getActivitySignalBus } from "./signals/bus.js";
 import {
   executeRawSql,
   executeRawSqlTx,
@@ -3416,6 +3418,11 @@ export class LifeOpsRepository {
         ${sqlQuote(signal.createdAt)}
       )`,
     );
+
+    const activityBus = getActivitySignalBus(this.runtime);
+    if (activityBus) {
+      publishActivitySignalToBus(activityBus, signal);
+    }
 
     // Mirror into the canonical telemetry store. Dedupes on
     // (agent_id, dedupe_key) so re-persists and migrator replays are safe.

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/activity-gates.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/activity-gates.test.ts
@@ -16,8 +16,16 @@ import {
   createTaskGateRegistry,
   registerBuiltInGates,
 } from "@elizaos/plugin-scheduling";
+import type { LifeOpsActivitySignal } from "@elizaos/shared";
 import { describe, expect, it } from "vitest";
 import type { ActivityProfile } from "../../activity-profile/types.js";
+import {
+  createFamilyRegistry,
+  registerBuiltinTelemetryFamilies,
+} from "../registries/family-registry.js";
+import { publishActivitySignalToBus } from "../signals/activity-signal-publisher.js";
+import type { ActivitySignalBus } from "../signals/bus.js";
+import { createActivitySignalBus } from "../signals/bus.js";
 import {
   behaviouralBaselineFromProfile,
   registerActivityProfileGates,
@@ -96,14 +104,54 @@ function makeRuntime(profile: ActivityProfile | null): IAgentRuntime {
 
 function makeContext(
   task: ScheduledTask,
-  opts: { nowIso?: string; busActive?: boolean } = {},
+  opts: {
+    nowIso?: string;
+    busActive?: boolean;
+    activity?: GateEvaluationContext["activity"];
+  } = {},
 ): GateEvaluationContext {
   return {
     task,
     nowIso: opts.nowIso ?? "2026-05-10T12:00:00.000Z",
     ownerFacts: { timezone: "UTC" },
-    activity: { hasSignalSince: () => opts.busActive === true },
+    activity: opts.activity ?? {
+      hasSignalSince: () => opts.busActive === true,
+    },
     subjectStore: { wasUpdatedSince: () => false },
+  };
+}
+
+function makeMessageActivityBus(): ActivitySignalBus {
+  const familyRegistry = createFamilyRegistry();
+  registerBuiltinTelemetryFamilies(familyRegistry);
+  return createActivitySignalBus({
+    familyRegistry,
+    retentionMs: Number.MAX_SAFE_INTEGER,
+  });
+}
+
+function messageReceivedSignal(
+  overrides: Partial<LifeOpsActivitySignal> = {},
+): LifeOpsActivitySignal {
+  return {
+    id: "signal-message-received",
+    agentId: "11111111-1111-1111-1111-111111111111",
+    source: "connector_activity",
+    platform: "telegram",
+    state: "active",
+    observedAt: "2026-05-10T11:55:00.000Z",
+    idleState: null,
+    idleTimeSeconds: 0,
+    onBattery: null,
+    health: null,
+    metadata: {
+      eventType: "MESSAGE_RECEIVED",
+      entityId: "owner",
+      externalMessageId: "telegram-message-1",
+      conversationHash: "telegram-chat-1",
+    },
+    createdAt: "2026-05-10T11:55:00.000Z",
+    ...overrides,
   };
 }
 
@@ -220,6 +268,32 @@ describe("no_recent_user_message_in reader", () => {
       task,
       makeContext(task, { nowIso: NOW, busActive: true }),
     );
+    expect(decision?.kind).toBe("defer");
+  });
+
+  it("defers when MESSAGE_RECEIVED activity is mirrored onto the real bus", async () => {
+    const bus = makeMessageActivityBus();
+    const result = publishActivitySignalToBus(bus, messageReceivedSignal());
+    expect(result).toEqual({ published: 1, unmapped: 0 });
+    expect(
+      bus.hasSignalSince({
+        signalKind: "message_activity_event",
+        sinceIso: "2026-05-10T11:30:00.000Z",
+      }),
+    ).toBe(true);
+
+    const reg = createTaskGateRegistry();
+    registerActivityProfileGates(
+      makeRuntime(baseProfile({ lastSeenAt: 0 })),
+      reg,
+    );
+    const gate = reg.get("no_recent_user_message_in");
+    const task = taskWithGate("no_recent_user_message_in", { minutes: 30 });
+    const decision = await gate?.evaluate(
+      task,
+      makeContext(task, { nowIso: "2026-05-10T12:00:00.000Z", activity: bus }),
+    );
+
     expect(decision?.kind).toBe("defer");
   });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/signals/activity-signal-publisher.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/signals/activity-signal-publisher.ts
@@ -1,0 +1,39 @@
+/**
+ * Bridges persisted LifeOps activity signals onto the in-memory activity bus.
+ * The SQL activity-signal table is the durable source of truth, while gates
+ * and completion checks read the bus for low-latency suppression decisions.
+ * Only message-activity signals are mirrored here; health-derived families have
+ * their own publisher because they are produced from circadian transitions.
+ */
+
+import type { LifeOpsActivitySignal } from "@elizaos/shared";
+import { mapSignalToTelemetryPayload } from "../telemetry-mapping.js";
+import type { ActivitySignalBus } from "./bus.js";
+
+export interface PublishActivitySignalResult {
+  published: number;
+  unmapped: number;
+}
+
+export function publishActivitySignalToBus(
+  bus: ActivitySignalBus,
+  signal: LifeOpsActivitySignal,
+): PublishActivitySignalResult {
+  const payload = mapSignalToTelemetryPayload(signal);
+  if (payload?.family !== "message_activity_event") {
+    return { published: 0, unmapped: 1 };
+  }
+
+  bus.publish({
+    family: payload.family,
+    occurredAt: signal.observedAt,
+    payload,
+    metadata: {
+      source: "lifeops-activity-signal",
+      signalId: signal.id,
+      signalSource: signal.source,
+      signalPlatform: signal.platform,
+    },
+  });
+  return { published: 1, unmapped: 0 };
+}


### PR DESCRIPTION
## Summary

Fixes #14685.

- Adds a narrow activity-signal bus publisher that mirrors persisted `message_activity_event` activity signals onto the in-memory `ActivitySignalBus`.
- Wires `LifeOpsRepository.createActivitySignal` to publish after the durable activity-signal insert, so `no_recent_user_message_in` gates can observe recent owner messages immediately instead of waiting for the activity-profile refresh loop.
- Adds a regression that publishes a MESSAGE_RECEIVED-shaped connector activity signal into a real FamilyRegistry-backed bus and proves the real PA `no_recent_user_message_in` reader defers.

## Verification

- `bunx @biomejs/biome check --write plugins/plugin-personal-assistant/src/lifeops/signals/activity-signal-publisher.ts plugins/plugin-personal-assistant/src/lifeops/repository.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/activity-gates.test.ts`
- `bun run --cwd plugins/plugin-personal-assistant test -- src/lifeops/scheduled-task/activity-gates.test.ts test/health-signal-bus.test.ts` - passed before rebase: 2 files / 19 tests.
- `TMPDIR=$PWD/.tmp/vitest bun run --cwd plugins/plugin-personal-assistant test -- src/lifeops/scheduled-task/activity-gates.test.ts` - passed after rebase: 1 file / 12 tests.
- `bun run --cwd plugins/plugin-scheduling test -- src/scheduled-task/gate-registry.test.ts` - passed after rebase: 1 file / 15 tests.
- `git diff --check` - passed.
- `bun run audit:error-policy-ratchet --report` - passed, 0 new fallback-slop in touched production files.
- `bun run --cwd plugins/plugin-personal-assistant typecheck` - blocked by existing package-wide missing dependency/export and implicit-any errors unrelated to touched files, starting with `Cannot find module '@elizaos/plugin-blocker/services/app-blocker/index'` and `Cannot find module '@elizaos/plugin-elizacloud/cloud/x402-payment-handler'`.
- `bun run verify` - blocked before Turbo by existing root type-safety ratchet baseline: `as unknown as: 76 / 73`.

Note: the post-rebase two-file PA suite rerun hit `ENOSPC` in the system temp transform cache while importing `health-signal-bus.test.ts`; the changed file itself was rerun successfully with a repo-local `TMPDIR`.

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - scheduler/activity-bus backend contract change only; no UI surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - scheduler/activity-bus backend contract change only; no UI surface changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - scheduler/activity-bus backend contract change only; no user-facing screen flow changed`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no deployed backend service was run; deterministic unit tests exercised the bus publisher and gate reader directly`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend code or browser surface changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no prompt, model, planner, or agent-response behavior changed; deterministic bus/gate contract changed`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts N/A - tests assert the domain artifacts directly: a message_activity_event envelope appears on ActivitySignalBus and no_recent_user_message_in returns defer.
