### PR TITLE
fix(app): compact plugin summaries for portrait chat clearance

### DIFF
--- a/packages/ui/src/spatial/__tests__/integration.test.tsx
+++ b/packages/ui/src/spatial/__tests__/integration.test.tsx
@@ -9,13 +9,15 @@
 
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   Card,
   evaluateToSpatialTree,
   HStack,
   SpatialSurface,
   Text,
+  useContinuousChatClearanceActive,
+  useContinuousChatCompactClearanceActive,
   useContinuousChatSideClearanceActive,
   useSpatialState,
   VStack,
@@ -34,6 +36,9 @@ afterEach(() => {
   window.__elizaXRContext = undefined;
   document.documentElement.style.removeProperty(
     "--eliza-continuous-chat-side-clearance",
+  );
+  document.documentElement.style.removeProperty(
+    "--eliza-continuous-chat-clearance",
   );
 });
 
@@ -83,6 +88,20 @@ function ChatClearanceProbe() {
   return <span data-testid="chat-clearance-probe">{String(active)}</span>;
 }
 
+function ChatBottomClearanceProbe() {
+  const active = useContinuousChatClearanceActive();
+  return (
+    <span data-testid="chat-bottom-clearance-probe">{String(active)}</span>
+  );
+}
+
+function ChatCompactClearanceProbe() {
+  const active = useContinuousChatCompactClearanceActive();
+  return (
+    <span data-testid="chat-compact-clearance-probe">{String(active)}</span>
+  );
+}
+
 describe("continuous chat side-clearance hook", () => {
   it("tracks the shell-published inline-end clearance var", async () => {
     render(<ChatClearanceProbe />);
@@ -112,6 +131,104 @@ describe("continuous chat side-clearance hook", () => {
         "false",
       ),
     );
+  });
+
+  it("tracks the shell-published bottom clearance var", async () => {
+    render(<ChatBottomClearanceProbe />);
+    expect(screen.getByTestId("chat-bottom-clearance-probe").textContent).toBe(
+      "false",
+    );
+
+    act(() => {
+      document.documentElement.style.setProperty(
+        "--eliza-continuous-chat-clearance",
+        "96px",
+      );
+    });
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("chat-bottom-clearance-probe").textContent,
+      ).toBe("true"),
+    );
+  });
+
+  it("uses compact mode for side clearance or mobile-width bottom clearance", async () => {
+    const originalInnerWidth = Object.getOwnPropertyDescriptor(
+      window,
+      "innerWidth",
+    );
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn((query: string) => ({
+        matches: query.includes("max-width: 767px")
+          ? window.innerWidth <= 767
+          : false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 390,
+    });
+
+    try {
+      render(<ChatCompactClearanceProbe />);
+      expect(
+        screen.getByTestId("chat-compact-clearance-probe").textContent,
+      ).toBe("false");
+
+      act(() => {
+        document.documentElement.style.setProperty(
+          "--eliza-continuous-chat-clearance",
+          "96px",
+        );
+      });
+      await waitFor(() =>
+        expect(
+          screen.getByTestId("chat-compact-clearance-probe").textContent,
+        ).toBe("true"),
+      );
+
+      act(() => {
+        Object.defineProperty(window, "innerWidth", {
+          configurable: true,
+          value: 1024,
+        });
+        window.dispatchEvent(new Event("resize"));
+      });
+      await waitFor(() =>
+        expect(
+          screen.getByTestId("chat-compact-clearance-probe").textContent,
+        ).toBe("false"),
+      );
+
+      act(() => {
+        document.documentElement.style.setProperty(
+          "--eliza-continuous-chat-side-clearance",
+          "232px",
+        );
+      });
+      await waitFor(() =>
+        expect(
+          screen.getByTestId("chat-compact-clearance-probe").textContent,
+        ).toBe("true"),
+      );
+    } finally {
+      if (originalInnerWidth) {
+        Object.defineProperty(window, "innerWidth", originalInnerWidth);
+      }
+      Object.defineProperty(window, "matchMedia", {
+        configurable: true,
+        value: originalMatchMedia,
+      });
+    }
   });
 });
 

--- a/packages/ui/src/spatial/dom.tsx
+++ b/packages/ui/src/spatial/dom.tsx
@@ -66,33 +66,29 @@ export function detectDomModality(): SpatialModality {
 
 const CONTINUOUS_CHAT_SIDE_CLEARANCE_VAR =
   "--eliza-continuous-chat-side-clearance";
+const CONTINUOUS_CHAT_CLEARANCE_VAR = "--eliza-continuous-chat-clearance";
+const COMPACT_CHAT_MOBILE_QUERY = "(max-width: 767px)";
 
-function readContinuousChatSideClearanceActive(): boolean {
+function readRootPxVarActive(name: string): boolean {
   if (typeof window === "undefined" || typeof document === "undefined") {
     return false;
   }
   const root = document.documentElement;
   const raw =
-    getComputedStyle(root).getPropertyValue(
-      CONTINUOUS_CHAT_SIDE_CLEARANCE_VAR,
-    ) || root.style.getPropertyValue(CONTINUOUS_CHAT_SIDE_CLEARANCE_VAR);
+    getComputedStyle(root).getPropertyValue(name) ||
+    root.style.getPropertyValue(name);
   const px = Number.parseFloat(raw);
   return Number.isFinite(px) && px > 0.5;
 }
 
-/**
- * True while the app shell's continuous chat composer publishes an inline-end
- * clearance. GUI wrappers can use this to switch dense spatial views into a
- * short-landscape layout; terminal/SSR callers get `false`.
- */
-export function useContinuousChatSideClearanceActive(): boolean {
-  const [active, setActive] = useState(readContinuousChatSideClearanceActive);
+function useRootPxVarActive(name: string): boolean {
+  const [active, setActive] = useState(() => readRootPxVarActive(name));
 
   useEffect(() => {
     if (typeof window === "undefined" || typeof document === "undefined") {
       return;
     }
-    const publish = () => setActive(readContinuousChatSideClearanceActive());
+    const publish = () => setActive(readRootPxVarActive(name));
     publish();
     const observer = new MutationObserver(publish);
     observer.observe(document.documentElement, {
@@ -104,9 +100,59 @@ export function useContinuousChatSideClearanceActive(): boolean {
       observer.disconnect();
       window.removeEventListener("resize", publish);
     };
-  }, []);
+  }, [name]);
 
   return active;
+}
+
+/**
+ * True while the app shell's continuous chat composer publishes an inline-end
+ * clearance. GUI wrappers can use this to switch dense spatial views into a
+ * short-landscape layout; terminal/SSR callers get `false`.
+ */
+export function useContinuousChatSideClearanceActive(): boolean {
+  return useRootPxVarActive(CONTINUOUS_CHAT_SIDE_CLEARANCE_VAR);
+}
+
+/**
+ * True while the app shell's continuous chat composer publishes any resting
+ * bottom clearance. This tracks the floating composer footprint without
+ * assuming the view should collapse its content.
+ */
+export function useContinuousChatClearanceActive(): boolean {
+  return useRootPxVarActive(CONTINUOUS_CHAT_CLEARANCE_VAR);
+}
+
+function readCompactChatViewport(): boolean {
+  if (typeof window === "undefined") return false;
+  if (typeof window.matchMedia === "function") {
+    return window.matchMedia(COMPACT_CHAT_MOBILE_QUERY).matches;
+  }
+  return window.innerWidth <= 767;
+}
+
+/**
+ * True when shell-hosted GUI content should use its compact chat-aware layout:
+ * side clearance in short landscape, or bottom composer clearance on mobile
+ * width. Desktop keeps the fuller spatial layout even though it reserves bottom
+ * padding for the ambient composer.
+ */
+export function useContinuousChatCompactClearanceActive(): boolean {
+  const sideClearance = useContinuousChatSideClearanceActive();
+  const bottomClearance = useContinuousChatClearanceActive();
+  const [compactViewport, setCompactViewport] = useState(
+    readCompactChatViewport,
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const publish = () => setCompactViewport(readCompactChatViewport());
+    publish();
+    window.addEventListener("resize", publish);
+    return () => window.removeEventListener("resize", publish);
+  }, []);
+
+  return sideClearance || (bottomClearance && compactViewport);
 }
 
 export interface SpatialSurfaceProps {

--- a/packages/ui/src/spatial/index.ts
+++ b/packages/ui/src/spatial/index.ts
@@ -27,6 +27,8 @@ export {
   detectDomModality,
   SpatialSurface,
   type SpatialSurfaceProps,
+  useContinuousChatClearanceActive,
+  useContinuousChatCompactClearanceActive,
   useContinuousChatSideClearanceActive,
 } from "./dom.tsx";
 // React → IR evaluation + cross-modal state hooks.

--- a/plugins/plugin-hyperliquid/src/HyperliquidView.test.tsx
+++ b/plugins/plugin-hyperliquid/src/HyperliquidView.test.tsx
@@ -180,7 +180,51 @@ afterEach(() => {
 	cleanup();
 	vi.clearAllMocks();
 	vi.unstubAllGlobals();
+	document.documentElement.style.removeProperty(
+		"--eliza-continuous-chat-clearance",
+	);
 });
+
+function mockMobileBottomComposerClearance(): () => void {
+	const originalInnerWidth = Object.getOwnPropertyDescriptor(
+		window,
+		"innerWidth",
+	);
+	const originalMatchMedia = window.matchMedia;
+	Object.defineProperty(window, "innerWidth", {
+		configurable: true,
+		value: 390,
+	});
+	Object.defineProperty(window, "matchMedia", {
+		configurable: true,
+		value: vi.fn((query: string) => ({
+			matches: query.includes("max-width: 767px"),
+			media: query,
+			onchange: null,
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		})),
+	});
+	document.documentElement.style.setProperty(
+		"--eliza-continuous-chat-clearance",
+		"96px",
+	);
+	return () => {
+		if (originalInnerWidth) {
+			Object.defineProperty(window, "innerWidth", originalInnerWidth);
+		}
+		Object.defineProperty(window, "matchMedia", {
+			configurable: true,
+			value: originalMatchMedia,
+		});
+		document.documentElement.style.removeProperty(
+			"--eliza-continuous-chat-clearance",
+		);
+	};
+}
 
 describe("HyperliquidView — populated snapshot", () => {
 	it("loads status + markets + positions + orders on mount and renders the markets", async () => {
@@ -296,6 +340,22 @@ describe("HyperliquidView — controls", () => {
 		expect(
 			screen.queryByRole("toolbar", { name: "Hyperliquid controls" }),
 		).toBeNull();
+	});
+
+	it("uses the concise layout when mobile-width bottom composer clearance is active", async () => {
+		const restore = mockMobileBottomComposerClearance();
+		try {
+			render(React.createElement(HyperliquidView));
+			await screen.findByText(/Positions BTC long/);
+
+			const text = document.body.textContent ?? "";
+			expect(text).toContain("Markets BTC 50x sz5");
+			expect(text).not.toContain("orders");
+			expect(screen.queryByText("Refresh")).toBeNull();
+			expect(document.querySelector('[data-agent-id="back"]')).toBeNull();
+		} finally {
+			restore();
+		}
 	});
 
 	it("the Refresh control re-fetches status + reads", async () => {

--- a/plugins/plugin-hyperliquid/src/HyperliquidView.tsx
+++ b/plugins/plugin-hyperliquid/src/HyperliquidView.tsx
@@ -13,7 +13,7 @@
 
 import { useAgentElement } from "@elizaos/ui/agent-surface";
 import { dispatchNavigateViewEvent } from "@elizaos/ui/events";
-import { useContinuousChatSideClearanceActive } from "@elizaos/ui/spatial";
+import { useContinuousChatCompactClearanceActive } from "@elizaos/ui/spatial";
 import { type CSSProperties, useCallback } from "react";
 import {
 	type HyperliquidSnapshot,
@@ -110,7 +110,7 @@ export function HyperliquidView() {
 		loading,
 		error,
 	};
-	const compactChatClearance = useContinuousChatSideClearanceActive();
+	const compactChatClearance = useContinuousChatCompactClearanceActive();
 
 	return (
 		<>

--- a/plugins/plugin-polymarket/src/PolymarketView.test.tsx
+++ b/plugins/plugin-polymarket/src/PolymarketView.test.tsx
@@ -205,7 +205,51 @@ afterEach(() => {
   cleanup();
   vi.clearAllMocks();
   vi.unstubAllGlobals();
+  document.documentElement.style.removeProperty(
+    "--eliza-continuous-chat-clearance",
+  );
 });
+
+function mockMobileBottomComposerClearance(): () => void {
+  const originalInnerWidth = Object.getOwnPropertyDescriptor(
+    window,
+    "innerWidth",
+  );
+  const originalMatchMedia = window.matchMedia;
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    value: 390,
+  });
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: vi.fn((query: string) => ({
+      matches: query.includes("max-width: 767px"),
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+  document.documentElement.style.setProperty(
+    "--eliza-continuous-chat-clearance",
+    "96px",
+  );
+  return () => {
+    if (originalInnerWidth) {
+      Object.defineProperty(window, "innerWidth", originalInnerWidth);
+    }
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: originalMatchMedia,
+    });
+    document.documentElement.style.removeProperty(
+      "--eliza-continuous-chat-clearance",
+    );
+  };
+}
 
 describe("PolymarketView — populated markets", () => {
   it("loads status + markets on mount and opens the auto-selected market detail", async () => {
@@ -306,6 +350,24 @@ describe("PolymarketView — refresh + error path", () => {
       screen.queryByRole("toolbar", { name: "Polymarket controls" }),
     ).toBeNull();
     expect(screen.queryByText("All markets")).toBeNull();
+  });
+
+  it("uses the concise detail layout when mobile-width bottom composer clearance is active", async () => {
+    const restore = mockMobileBottomComposerClearance();
+    try {
+      render(React.createElement(PolymarketView));
+      await screen.findByText("Will BTC be above 100k?");
+
+      const text = document.body.textContent ?? "";
+      expect(text).toContain("Yes 61% · No 39%");
+      expect(text).not.toContain("orderbook tokens");
+      expect(screen.queryByText("Refresh")).toBeNull();
+      expect(
+        document.querySelector('[data-agent-id="detail-back"]'),
+      ).toBeNull();
+    } finally {
+      restore();
+    }
   });
 
   it("the Refresh control re-loads status + markets", async () => {

--- a/plugins/plugin-polymarket/src/PolymarketView.tsx
+++ b/plugins/plugin-polymarket/src/PolymarketView.tsx
@@ -11,7 +11,7 @@
  */
 
 import { useAgentElement } from "@elizaos/ui/agent-surface";
-import { useContinuousChatSideClearanceActive } from "@elizaos/ui/spatial";
+import { useContinuousChatCompactClearanceActive } from "@elizaos/ui/spatial";
 import { type CSSProperties, useCallback, useEffect } from "react";
 import {
   type PolymarketSnapshot,
@@ -105,7 +105,7 @@ export function PolymarketView() {
     loading,
     error,
   };
-  const compactChatClearance = useContinuousChatSideClearanceActive();
+  const compactChatClearance = useContinuousChatCompactClearanceActive();
 
   return (
     <>


### PR DESCRIPTION
# Relates to

Follow-up to merged #14832 and #14437. PR #14832 merged the broader compact chat clearance work; this PR carries the remaining portrait compact-state fix and regression coverage that was developed after that merge.

Definition of Done: full standard in [`PR_EVIDENCE.md`](../PR_EVIDENCE.md).

- [x] This PR targets `develop` and was squash-merged as `3d403984`; post-merge evidence was refreshed against `origin/develop` `95a5fb41` with an equivalent rebased head `0e4fb5b56`.
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased onto latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Medium-low. The remaining diff is limited to the shell-aware compact-clearance hook plus Hyperliquid/Polymarket wrappers and regression tests. The main risk is switching too much desktop content into compact mode; the hook gates bottom composer clearance behind mobile width while preserving the existing side-clearance path for short landscape.

# Background

## What does this PR do?

- Adds `useContinuousChatClearanceActive` and `useContinuousChatCompactClearanceActive` to the spatial DOM host.
- Keeps existing side-clearance behavior for short mobile landscape.
- Treats bottom composer clearance as compact only on mobile-width viewports, so portrait hosted plugin views use concise chat-native summaries without adding visible refresh/back/orderbook controls near the composer.
- Wires Hyperliquid and Polymarket GUI wrappers to the compact-clearance signal.
- Adds wrapper-level regression tests for the exact portrait compact state, plus spatial hook coverage for bottom and compact clearance.

## What kind of change is this?

Bug fix and UI verification improvement.

# Documentation changes needed?

No product docs change is required. The behavioral contract is covered by focused tests and screenshot evidence.

# Testing

## Where should a reviewer start?

Start with the contact sheet below, then inspect `packages/ui/src/spatial/dom.tsx`, `plugins/plugin-hyperliquid/src/HyperliquidView.tsx`, and `plugins/plugin-polymarket/src/PolymarketView.tsx`.

## Detailed testing steps

```bash
git diff --check
bun test packages/app/test/audit/mvp-visual-verify.test.ts
bun run --cwd packages/ui test src/spatial/__tests__/integration.test.tsx src/surface-realm-broker.test.tsx -t "continuous chat layout vars|SpatialSurface|floating-chat clearance|continuous chat side-clearance hook"
bun run --cwd plugins/plugin-hyperliquid test src/HyperliquidView.test.tsx
bun run --cwd plugins/plugin-polymarket test src/PolymarketView.test.tsx
bun run --cwd packages/app audit:app -- -g "(builtin-browser mobile-landscape|plugin-(hyperliquid|polymarket)-gui (mobile-portrait|mobile-landscape))$"
bun run --cwd packages/app mvp:visual-verify -- --strict
```

Post-rebase / post-merge evidence-refresh results:

- `git diff --check`: pass
- MVP verifier unit tests: 24 pass, 0 fail
- Spatial/surface focused tests: 6 pass, 19 skipped
- HyperliquidView tests: 22 pass
- PolymarketView tests: 16 pass
- Focused app visual audit: 5 passed; `broken=0 needs-work=0 needs-eyeball=0 good=5`
- Strict MVP visual verify at head: 5 states; system Tesseract OCR; `expectation failures=0`, `expectation skips=0`, `overflow states=0`, `new baselines=0`

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: https://gist.githubusercontent.com/lalalune/1c685c9b3d8eba73ec7518ff87289278/raw/e26660b45bbb3e558da220d2d24f1e0c1ee905a4/14890-before-after-contact-sheet.svg labeled before/after sheet, with original before PNGs in the gist (https://gist.githubusercontent.com/lalalune/1c685c9b3d8eba73ec7518ff87289278/raw/e26660b45bbb3e558da220d2d24f1e0c1ee905a4/14890-before-mobile-portrait-plugin-hyperliquid-gui.png, https://gist.githubusercontent.com/lalalune/1c685c9b3d8eba73ec7518ff87289278/raw/e26660b45bbb3e558da220d2d24f1e0c1ee905a4/14890-before-mobile-portrait-plugin-polymarket-gui.png, https://gist.githubusercontent.com/lalalune/1c685c9b3d8eba73ec7518ff87289278/raw/e26660b45bbb3e558da220d2d24f1e0c1ee905a4/14890-before-mobile-landscape-plugin-hyperliquid-gui.png, https://gist.githubusercontent.com/lalalune/1c685c9b3d8eba73ec7518ff87289278/raw/e26660b45bbb3e558da220d2d24f1e0c1ee905a4/14890-before-mobile-landscape-plugin-polymarket-gui.png, https://gist.githubusercontent.com/lalalune/1c685c9b3d8eba73ec7518ff87289278/raw/e26660b45bbb3e558da220d2d24f1e0c1ee905a4/14890-before-mobile-landscape-builtin-browser.png).<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: https://gist.githubusercontent.com/lalalune/1c685c9b3d8eba73ec7518ff87289278/raw/e26660b45bbb3e558da220d2d24f1e0c1ee905a4/14890-before-after-contact-sheet.svg labeled before/after sheet, with original after PNGs in the gist (https://gist.githubusercontent.com/lalalune/1c685c9b3d8eba73ec7518ff87289278/raw/e26660b45bbb3e558da220d2d24f1e0c1ee905a4/14890-after-mobile-portrait-plugin-hyperliquid-gui.png, https://gist.githubusercontent.com/lalalune/1c685c9b3d8eba73ec7518ff87289278/raw/e26660b45bbb3e558da220d2d24f1e0c1ee905a4/14890-after-mobile-portrait-plugin-polymarket-gui.png, https://gist.githubusercontent.com/lalalune/1c685c9b3d8eba73ec7518ff87289278/raw/e26660b45bbb3e558da220d2d24f1e0c1ee905a4/14890-after-mobile-landscape-plugin-hyperliquid-gui.png, https://gist.githubusercontent.com/lalalune/1c685c9b3d8eba73ec7518ff87289278/raw/e26660b45bbb3e558da220d2d24f1e0c1ee905a4/14890-after-mobile-landscape-plugin-polymarket-gui.png, https://gist.githubusercontent.com/lalalune/1c685c9b3d8eba73ec7518ff87289278/raw/e26660b45bbb3e558da220d2d24f1e0c1ee905a4/14890-after-mobile-landscape-builtin-browser.png). Earlier contact sheet remains at https://gist.githubusercontent.com/lalalune/1c685c9b3d8eba73ec7518ff87289278/raw/e26660b45bbb3e558da220d2d24f1e0c1ee905a4/mvp-visual-compact-chat-contact-sheet.svg.<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: https://gist.githubusercontent.com/lalalune/1c685c9b3d8eba73ec7518ff87289278/raw/e26660b45bbb3e558da220d2d24f1e0c1ee905a4/14890-before-after-walkthrough.mp4 (five-frame before/after sweep across the focused MVP states).<!-- evidence-row:backend-logs -->
- [x] `N/A - frontend shell/layout only; no backend path changed.`
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: focused audit and strict verifier artifacts are in https://gist.github.com/lalalune/1c685c9b3d8eba73ec7518ff87289278; before report https://gist.githubusercontent.com/lalalune/1c685c9b3d8eba73ec7518ff87289278/raw/e26660b45bbb3e558da220d2d24f1e0c1ee905a4/14890-before-mvp-visual-report.json and after report https://gist.githubusercontent.com/lalalune/1c685c9b3d8eba73ec7518ff87289278/raw/e26660b45bbb3e558da220d2d24f1e0c1ee905a4/14890-after-mvp-visual-report.json. Both runs passed 5 states with zero expectation failures, zero skips, and zero overflow states.<!-- evidence-row:llm-trajectory -->
- [x] `N/A - no agent/action/provider/prompt/model behavior changed.`
<!-- evidence-row:domain-artifacts -->
- [x] `N/A - no DB, memory, wallet/on-chain, scheduled-task, audio, or generated domain artifact changed.`

# Evidence Details

## Backend + frontend logs

Frontend audit summary:

```text
[aesthetic-audit] 5 findings — broken=0 needs-work=0 needs-eyeball=0 good=5 minimalism-budget-failures=0 minimalism-ratchet-failures=0 hover-probe-failures=0 density-probe-failures=0 (strict=false, needs-work-strict=false, undebted-broken=0, undebted-needs-work=0)
```

MVP verifier summary:

```text
[mvp-visual-verify] OCR engine: system tesseract (/opt/homebrew/bin/tesseract)
[mvp-visual-verify] viewports: mobile-landscape(3), mobile-portrait(2)
[mvp-visual-verify] expectation failures: 0 | expectation skips: 0 | overflow states: 0 | new baselines: 0
```

Verifier metrics:

```text
builtin-browser mobile-landscape: pass=true chars=133 words=35 overflowX=0 changed=6.647 white=0.9265 orange=0.022 neutral=0.0515
plugin-hyperliquid-gui mobile-landscape: pass=true chars=204 words=42 overflowX=0 changed=5.531 white=0.9304 orange=0.0085 neutral=0.0611
plugin-hyperliquid-gui mobile-portrait: pass=true chars=214 words=46 overflowX=0 changed=11.205 white=0.9322 orange=0.0087 neutral=0.0591
plugin-polymarket-gui mobile-landscape: pass=true chars=126 words=32 overflowX=0 changed=4.82 white=0.9424 orange=0.0055 neutral=0.0522
plugin-polymarket-gui mobile-portrait: pass=true chars=136 words=36 overflowX=0 changed=5.502 white=0.9437 orange=0.0058 neutral=0.0505
```

## Screenshots (before / after) + video walkthrough

### Before

Before screenshot N/A as noted above. The pre-fix portrait path kept redundant visible controls near the resting composer; the focused post-fix states below show the compact summaries without those controls.

### After

Post-rebase contact sheet for the focused audit states:

![MVP compact chat visual audit evidence](https://gist.githubusercontent.com/lalalune/1c685c9b3d8eba73ec7518ff87289278/raw/535aad142892bea7760eb91c5065fdfefdfde475/mvp-visual-compact-chat-contact-sheet.svg)

Raw evidence sheet: https://gist.github.com/lalalune/1c685c9b3d8eba73ec7518ff87289278

Manual review notes: Hyperliquid and Polymarket portrait states now show concise summaries above the resting composer, with no visible refresh/back/orderbook controls crowding the bottom state. Landscape states still keep right-edge content clear of the compact composer. OCR found the expected wallet/browser text, the palette remains neutral/orange, and horizontal overflow is 0px for every focused state.

### Walkthrough video

N/A - static layout/clearance regression; no click-through flow beyond rendering the audited states.

## Known gaps / failures

- `bun run verify` was not run post-rebase because this checkout is using temporary dependency symlinks from another worktree rather than a fresh `bun install`. I ran the focused unit/integration/plugin suites and the app visual audit/verifier that cover the changed behavior.
- Full 369-state `audit:app:verify` was not rerun post-rebase. The final focused audit recaptured the affected MVP states at `b924190f64`; subsequent rebases to `b178b4c151` were onto unrelated develop changes and the strict verifier was rerun at head against the retained focused screenshot output.




# Post-Merge Evidence Refresh

After the PR was squash-merged at `3d403984`, I rebuilt the same seven-file diff on top of `origin/develop` `95a5fb41` as local head `0e4fb5b56` and recaptured the focused states. Concrete UI-standard artifacts were added to the evidence gist at `e26660b45bbb3e558da220d2d24f1e0c1ee905a4`: before/after full-page PNGs, a labeled SVG/PNG contact sheet, strict verifier JSON reports, and a 1280x720 MP4 walkthrough.
