### PR TITLE
fix(evidence): run ffmpeg-static installer with node

### DIFF
--- a/packages/evidence/src/ffmpeg-binaries.test.ts
+++ b/packages/evidence/src/ffmpeg-binaries.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { resolveNodeInstallRunner } from "./ffmpeg-binaries.ts";
+
+describe("resolveNodeInstallRunner", () => {
+  it("keeps the current executable when already running under Node", () => {
+    expect(
+      resolveNodeInstallRunner({
+        env: {},
+        execPath: "/opt/node/bin/node",
+      }),
+    ).toBe("/opt/node/bin/node");
+    expect(
+      resolveNodeInstallRunner({
+        env: {},
+        execPath: "C:\\Program Files\\nodejs\\node.exe",
+      }),
+    ).toBe("C:\\Program Files\\nodejs\\node.exe");
+  });
+
+  it("uses node from PATH when invoked under Bun", () => {
+    expect(
+      resolveNodeInstallRunner({
+        env: {},
+        execPath: "/opt/homebrew/bin/bun",
+      }),
+    ).toBe("node");
+  });
+
+  it("honors an explicit Node binary override", () => {
+    expect(
+      resolveNodeInstallRunner({
+        env: { ELIZA_NODE_BIN: "/custom/node" },
+        execPath: "/opt/homebrew/bin/bun",
+      }),
+    ).toBe("/custom/node");
+    expect(
+      resolveNodeInstallRunner({
+        env: { NODE_BINARY: "/toolchain/node" },
+        execPath: "/opt/homebrew/bin/bun",
+      }),
+    ).toBe("/toolchain/node");
+  });
+});

--- a/packages/evidence/src/ffmpeg-binaries.ts
+++ b/packages/evidence/src/ffmpeg-binaries.ts
@@ -31,6 +31,27 @@ let ffmpegStaticInstallPromise: Promise<
   { installed: true } | { installed: false; reason: string }
 > | null = null;
 
+function isNodeExecutable(candidate: string): boolean {
+  return /^(node|nodejs)(\.exe)?$/i.test(candidate);
+}
+
+export function resolveNodeInstallRunner({
+  env = process.env,
+  execPath = process.execPath,
+}: {
+  env?: NodeJS.ProcessEnv;
+  execPath?: string;
+} = {}): string {
+  const configured = env.ELIZA_NODE_BIN?.trim() || env.NODE_BINARY?.trim();
+  if (configured) return configured;
+
+  const posixName = path.basename(execPath);
+  const winName = path.win32.basename(execPath);
+  return isNodeExecutable(posixName) || isNodeExecutable(winName)
+    ? execPath
+    : "node";
+}
+
 /** Whether a binary answers `-version`, with a reason when it does not. */
 async function binaryAvailable(
   bin: string,
@@ -101,7 +122,8 @@ function installFfmpegStaticOnce(): Promise<
     }
 
     try {
-      await execFileAsync(process.execPath, [installer], {
+      const nodeRunner = resolveNodeInstallRunner();
+      await execFileAsync(nodeRunner, [installer], {
         cwd: root,
         timeout: 120_000,
       });


### PR DESCRIPTION
## Summary
- Fix the evidence-package `ffmpeg-static` repair path added in #14851 so `install.js` runs under Node instead of raw `process.execPath`.
- Keep the current Node executable when already running under Node, fall back to `node` when invoked under Bun, and allow `ELIZA_NODE_BIN` / `NODE_BINARY` overrides for pinned toolchains.
- Add focused coverage for Node, Bun, Windows `node.exe`, and explicit override cases.

## Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - evidence/capture resolver only; no UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - evidence/capture resolver only; no UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - this changes the video evidence dependency repair path, not a user flow.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend runtime behavior changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime behavior changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external domain artifact is produced; focused resolver tests prove the install runner selection does not use Bun for `ffmpeg-static/install.js`.

## Verification
Run on rebased head `528fb2d861` against `origin/develop` `1b4a458341`:

```bash
bun run --cwd packages/evidence test src/ffmpeg-binaries.test.ts src/video/normalize.test.ts
bun test packages/evidence/src/ffmpeg-binaries.test.ts
bunx @biomejs/biome check packages/evidence/src/ffmpeg-binaries.ts packages/evidence/src/ffmpeg-binaries.test.ts
git diff --check origin/develop...HEAD
bun run audit:error-policy-ratchet --report
```

Observed:
- Evidence Vitest wrapper passed: 2 files, 10 tests.
- Direct Bun test passed: 3 tests.
- Targeted Biome passed.
- `git diff --check` passed.
- Error-policy ratchet passed; `packages/evidence/src/ffmpeg-binaries.ts` stayed `emptyCatch 0->0`, `serverConsole 0->0`.

Known local limitation: `bun run --cwd packages/evidence typecheck` could not run to completion in this fresh worktree because the shared install is missing `sharp` and `pixelmatch`; it stops on those package-level dependency resolution errors before this resolver change.
