### PR TITLE
test(cloud): audit all registered console routes

### DIFF
--- a/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts
@@ -107,6 +107,13 @@ const PUBLIC = false;
  * bottom fails when this table drifts from the live registry.
  */
 const CLOUD_AUDIT_CASES: CloudAuditCase[] = [
+  // home/
+  {
+    slug: "dashboard",
+    path: "/dashboard",
+    route: "dashboard",
+    auth: AUTH,
+  },
   // instances/
   {
     slug: "dashboard-agents",
@@ -135,6 +142,12 @@ const CLOUD_AUDIT_CASES: CloudAuditCase[] = [
   },
   // billing/
   {
+    slug: "dashboard-billing",
+    path: "/dashboard/billing",
+    route: "dashboard/billing",
+    auth: AUTH,
+  },
+  {
     slug: "dashboard-billing-success",
     path: "/dashboard/billing/success",
     route: "dashboard/billing/success",
@@ -151,6 +164,25 @@ const CLOUD_AUDIT_CASES: CloudAuditCase[] = [
     slug: "dashboard-organization",
     path: "/dashboard/organization",
     route: "dashboard/organization",
+    auth: AUTH,
+  },
+  // account-security/
+  {
+    slug: "dashboard-account",
+    path: "/dashboard/account",
+    route: "dashboard/account",
+    auth: AUTH,
+  },
+  {
+    slug: "dashboard-security",
+    path: "/dashboard/security",
+    route: "dashboard/security",
+    auth: AUTH,
+  },
+  {
+    slug: "dashboard-security-permissions",
+    path: "/dashboard/security/permissions",
+    route: "dashboard/security/permissions",
     auth: AUTH,
   },
   // join/ — signed-out /join redirects to /login (audited separately), so
@@ -263,6 +295,27 @@ const CLOUD_AUDIT_CASES: CloudAuditCase[] = [
     slug: "dashboard-api-explorer",
     path: "/dashboard/api-explorer",
     route: "dashboard/api-explorer",
+    auth: AUTH,
+  },
+  // api-keys/
+  {
+    slug: "dashboard-api-keys",
+    path: "/dashboard/api-keys",
+    route: "dashboard/api-keys",
+    auth: AUTH,
+  },
+  // monetization/
+  {
+    slug: "dashboard-monetization",
+    path: "/dashboard/monetization",
+    route: "dashboard/monetization",
+    auth: AUTH,
+  },
+  // connectors/
+  {
+    slug: "dashboard-connectors",
+    path: "/dashboard/connectors",
+    route: "dashboard/connectors",
     auth: AUTH,
   },
   // applications/


### PR DESCRIPTION
## Summary
- Adds the eight registered cloud console routes that were missing from `audit:cloud` coverage: `/dashboard`, `/dashboard/billing`, `/dashboard/api-keys`, `/dashboard/account`, `/dashboard/security`, `/dashboard/security/permissions`, `/dashboard/monetization`, and `/dashboard/connectors`.
- Keeps the existing coverage guard strict: every registered route must still have a concrete audit case.
- Uses the existing cloud audit stubs for the newly covered account/security/billing/API-key/monetization/connectors surfaces.

## Verification
- `git diff --check` -> clean.
- `bunx @biomejs/biome check packages/app/test/ui-smoke/cloud-surfaces-aesthetic-audit.spec.ts` -> clean.
- `ELIZA_UI_SMOKE_DISABLE_VIDEO=1 bun run --cwd packages/app audit:cloud` -> 85 passed, 1 skipped; 84 findings; broken=0, needs-work=0, needs-eyeball=84, good=0.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - test harness coverage table only; no product UI code changed.

<!-- evidence-row:after-screenshots -->
- [x] N/A - test harness coverage table only; no product UI code changed. Local audit generated desktop/mobile screenshots for all 42 routes and reported 84 findings with broken=0, needs-work=0.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - disabled during local rerun with `ELIZA_UI_SMOKE_DISABLE_VIDEO=1` to avoid ENOSPC while preserving screenshot/report evidence.

<!-- evidence-row:backend-logs -->
- [x] N/A - no backend service behavior changed; Playwright used the existing deterministic cloud API stubs.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime behavior changed; `audit:cloud` console/pageerror capture completed with broken=0 and needs-work=0 across 84 findings.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model/action/prompt behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external domain artifact is produced by this coverage-table-only change; local `audit:cloud` report generated 84 findings: broken=0, needs-work=0, needs-eyeball=84.
