### PR TITLE
fix(lifeops): wire first-run channel inspector (#14730)

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/first-run/channel-inspector.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/first-run/channel-inspector.ts
@@ -7,13 +7,13 @@
 import type { IAgentRuntime } from "@elizaos/core";
 import type { ChannelRegistry } from "../channels/index.js";
 import { getConnectorRegistry } from "../connectors/registry.js";
-import { setChannelInspector } from "./questions.js";
+import { setRuntimeChannelInspector } from "./questions.js";
 
 export function installFirstRunChannelInspector(
   runtime: IAgentRuntime,
   channelRegistry: ChannelRegistry,
 ): void {
-  setChannelInspector({
+  setRuntimeChannelInspector(runtime, {
     isRegistered(channel) {
       return channelRegistry.get(channel) !== null;
     },

--- a/plugins/plugin-personal-assistant/src/lifeops/first-run/channel-inspector.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/first-run/channel-inspector.ts
@@ -1,0 +1,37 @@
+/**
+ * Registry-backed channel inspector for first-run notification validation.
+ * The first-run question parser owns the fallback behavior, while this module
+ * adapts the runtime's channel and connector registries into the inspector
+ * contract installed by the plugin composition root.
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import type { ChannelRegistry } from "../channels/index.js";
+import { getConnectorRegistry } from "../connectors/registry.js";
+import { setChannelInspector } from "./questions.js";
+
+export function installFirstRunChannelInspector(
+  runtime: IAgentRuntime,
+  channelRegistry: ChannelRegistry,
+): void {
+  setChannelInspector({
+    isRegistered(channel) {
+      return channelRegistry.get(channel) !== null;
+    },
+    async isConnected(channel) {
+      if (channel === "in_app") {
+        return true;
+      }
+      const contribution = channelRegistry.get(channel);
+      const connectorKind = contribution?.connectorKind ?? channel;
+      if (!connectorKind) {
+        return false;
+      }
+      const connector = getConnectorRegistry(runtime)?.get(connectorKind);
+      if (!connector) {
+        return false;
+      }
+      const status = await connector.status();
+      return status.state === "ok";
+    },
+  });
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/first-run/questions.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/first-run/questions.ts
@@ -221,8 +221,8 @@ export interface ChannelValidationResult {
  * default implementation without touching this module.
  */
 export interface ChannelInspector {
-  isRegistered(channel: string): boolean;
-  isConnected(channel: string): boolean;
+  isRegistered(channel: string): boolean | Promise<boolean>;
+  isConnected(channel: string): boolean | Promise<boolean>;
 }
 
 class FallbackChannelInspector implements ChannelInspector {
@@ -248,10 +248,10 @@ export function setChannelInspector(inspector: ChannelInspector | null): void {
   activeInspector = inspector ?? new FallbackChannelInspector();
 }
 
-export function validateChannel(
+export async function validateChannel(
   rawChannel: unknown,
   _runtime: IAgentRuntime,
-): ChannelValidationResult {
+): Promise<ChannelValidationResult> {
   const normalized =
     typeof rawChannel === "string" ? rawChannel.trim().toLowerCase() : "";
   if (!normalized) {
@@ -263,7 +263,7 @@ export function validateChannel(
       warning: "No channel was selected — defaulting to in-app notifications.",
     };
   }
-  const registered = activeInspector.isRegistered(normalized);
+  const registered = await activeInspector.isRegistered(normalized);
   if (!registered) {
     return {
       channel: "in_app",
@@ -273,7 +273,7 @@ export function validateChannel(
       warning: `Channel "${normalized}" is not registered — falling back to in-app notifications.`,
     };
   }
-  const connected = activeInspector.isConnected(normalized);
+  const connected = await activeInspector.isConnected(normalized);
   if (!connected) {
     return {
       channel: normalized,

--- a/plugins/plugin-personal-assistant/src/lifeops/first-run/questions.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/first-run/questions.ts
@@ -242,15 +242,28 @@ class FallbackChannelInspector implements ChannelInspector {
   }
 }
 
-let activeInspector: ChannelInspector = new FallbackChannelInspector();
+const fallbackInspector = new FallbackChannelInspector();
+const runtimeInspectors = new WeakMap<IAgentRuntime, ChannelInspector>();
+let activeInspector: ChannelInspector | null = null;
 
 export function setChannelInspector(inspector: ChannelInspector | null): void {
-  activeInspector = inspector ?? new FallbackChannelInspector();
+  activeInspector = inspector;
+}
+
+export function setRuntimeChannelInspector(
+  runtime: IAgentRuntime,
+  inspector: ChannelInspector | null,
+): void {
+  if (inspector) {
+    runtimeInspectors.set(runtime, inspector);
+    return;
+  }
+  runtimeInspectors.delete(runtime);
 }
 
 export async function validateChannel(
   rawChannel: unknown,
-  _runtime: IAgentRuntime,
+  runtime: IAgentRuntime,
 ): Promise<ChannelValidationResult> {
   const normalized =
     typeof rawChannel === "string" ? rawChannel.trim().toLowerCase() : "";
@@ -263,7 +276,9 @@ export async function validateChannel(
       warning: "No channel was selected — defaulting to in-app notifications.",
     };
   }
-  const registered = await activeInspector.isRegistered(normalized);
+  const inspector =
+    runtimeInspectors.get(runtime) ?? activeInspector ?? fallbackInspector;
+  const registered = await inspector.isRegistered(normalized);
   if (!registered) {
     return {
       channel: "in_app",
@@ -273,7 +288,7 @@ export async function validateChannel(
       warning: `Channel "${normalized}" is not registered — falling back to in-app notifications.`,
     };
   }
-  const connected = await activeInspector.isConnected(normalized);
+  const connected = await inspector.isConnected(normalized);
   if (!connected) {
     return {
       channel: normalized,

--- a/plugins/plugin-personal-assistant/src/lifeops/first-run/service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/first-run/service.ts
@@ -402,7 +402,7 @@ export class FirstRunService {
 
     const morningWindow = deriveMorningWindow(parsed);
     const timezone = parseTimezone(input.timezone) ?? this.resolveTimezone();
-    const channelValidation = validateChannel(
+    const channelValidation = await validateChannel(
       input.channel ?? "in_app",
       this.runtime,
     );
@@ -484,7 +484,7 @@ export class FirstRunService {
       };
     }
 
-    const finalized = finalizeCustomizeAnswers(merged, this.runtime);
+    const finalized = await finalizeCustomizeAnswers(merged, this.runtime);
 
     const factsPatch: OwnerFactsPatch = {
       preferredName: finalized.preferredName,
@@ -568,7 +568,7 @@ export class FirstRunService {
       };
     }
 
-    const finalized = finalizeCustomizeAnswers(merged, this.runtime);
+    const finalized = await finalizeCustomizeAnswers(merged, this.runtime);
     const factsPatch: OwnerFactsPatch = {
       preferredName: finalized.preferredName,
       timezone: finalized.timezone,
@@ -738,10 +738,10 @@ interface FinalizedCustomizeAnswers extends CustomizeAnswers {
   channelFallbackToInApp: boolean;
 }
 
-function finalizeCustomizeAnswers(
+async function finalizeCustomizeAnswers(
   answers: Record<string, unknown>,
   runtime: IAgentRuntime,
-): FinalizedCustomizeAnswers {
+): Promise<FinalizedCustomizeAnswers> {
   const preferredName = parsePreferredName(answers.preferredName) ?? "";
   const timezone = parseTimezone(answers.timezone) ?? "UTC";
   const morningWindow =
@@ -749,7 +749,7 @@ function finalizeCustomizeAnswers(
   const eveningWindow =
     parseTimeWindow(answers.eveningWindow) ?? DEFAULT_EVENING_WINDOW;
   const categories = parseCategories(answers.categories) ?? [];
-  const validation = validateChannel(answers.channel, runtime);
+  const validation = await validateChannel(answers.channel, runtime);
   const relationships = parseRelationships(answers.relationships) ?? undefined;
   const finalized: FinalizedCustomizeAnswers = {
     preferredName,

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -110,6 +110,8 @@ import {
 } from "./lifeops/connectors/index.js";
 import { applyMockoonEnvOverrides } from "./lifeops/connectors/mockoon-redirect.js";
 import { handleVoiceTurnObserved } from "./lifeops/entities/voice-observer-bridge.js";
+import { installFirstRunChannelInspector } from "./lifeops/first-run/channel-inspector.js";
+import { setChannelInspector } from "./lifeops/first-run/questions.js";
 import { FirstRunService } from "./lifeops/first-run/service.js";
 import { createOwnerLocaleExamplesProvider } from "./lifeops/i18n/localized-examples-provider.js";
 import {
@@ -773,6 +775,7 @@ const rawPersonalAssistantPlugin: Plugin = {
       send: (payload) => handleMeetingJoinDispatch(runtime, payload),
     });
     registerChannelRegistry(runtime, channelRegistry);
+    installFirstRunChannelInspector(runtime, channelRegistry);
     (
       runtime as IAgentRuntime & { channelRegistry?: typeof channelRegistry }
     ).channelRegistry = channelRegistry;
@@ -1000,6 +1003,8 @@ const rawPersonalAssistantPlugin: Plugin = {
    * to touch those here.
    */
   dispose: async (runtime: IAgentRuntime) => {
+    setChannelInspector(null);
+
     const taskNames: readonly string[] = [
       PROACTIVE_TASK_NAME,
       LIFEOPS_TASK_NAME,

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -111,7 +111,7 @@ import {
 import { applyMockoonEnvOverrides } from "./lifeops/connectors/mockoon-redirect.js";
 import { handleVoiceTurnObserved } from "./lifeops/entities/voice-observer-bridge.js";
 import { installFirstRunChannelInspector } from "./lifeops/first-run/channel-inspector.js";
-import { setChannelInspector } from "./lifeops/first-run/questions.js";
+import { setRuntimeChannelInspector } from "./lifeops/first-run/questions.js";
 import { FirstRunService } from "./lifeops/first-run/service.js";
 import { createOwnerLocaleExamplesProvider } from "./lifeops/i18n/localized-examples-provider.js";
 import {
@@ -1003,7 +1003,7 @@ const rawPersonalAssistantPlugin: Plugin = {
    * to touch those here.
    */
   dispose: async (runtime: IAgentRuntime) => {
-    setChannelInspector(null);
+    setRuntimeChannelInspector(runtime, null);
 
     const taskNames: readonly string[] = [
       PROACTIVE_TASK_NAME,

--- a/plugins/plugin-personal-assistant/test/first-run-config-validation.test.ts
+++ b/plugins/plugin-personal-assistant/test/first-run-config-validation.test.ts
@@ -245,6 +245,45 @@ describe("first-run config validation", () => {
     });
   });
 
+  it("keeps production channel inspectors isolated per runtime", async () => {
+    const connectedRuntime = createMinimalRuntimeStub();
+    const connectorRegistry = createConnectorRegistry();
+    connectorRegistry.register(makeConnectedTelegramConnector());
+    registerConnectorRegistry(connectedRuntime, connectorRegistry);
+
+    const connectedChannelRegistry = createChannelRegistry();
+    registerDefaultChannelPack(connectedChannelRegistry, connectedRuntime);
+    installFirstRunChannelInspector(connectedRuntime, connectedChannelRegistry);
+
+    const disconnectedRuntime = createMinimalRuntimeStub();
+    const disconnectedChannelRegistry = createChannelRegistry();
+    registerDefaultChannelPack(
+      disconnectedChannelRegistry,
+      disconnectedRuntime,
+    );
+    installFirstRunChannelInspector(
+      disconnectedRuntime,
+      disconnectedChannelRegistry,
+    );
+
+    await expect(
+      validateChannel("telegram", connectedRuntime),
+    ).resolves.toEqual({
+      channel: "telegram",
+      registered: true,
+      connected: true,
+      fallbackToInApp: false,
+    });
+    await expect(
+      validateChannel("telegram", disconnectedRuntime),
+    ).resolves.toMatchObject({
+      channel: "telegram",
+      registered: true,
+      connected: false,
+      fallbackToInApp: true,
+    });
+  });
+
   it("rejects an unregistered channel with the right warning", async () => {
     const runtime = createMinimalRuntimeStub();
     const result = await validateChannel("morse_code", runtime);

--- a/plugins/plugin-personal-assistant/test/first-run-config-validation.test.ts
+++ b/plugins/plugin-personal-assistant/test/first-run-config-validation.test.ts
@@ -7,7 +7,17 @@
  * fallback path produces an in_app channel + warning.
  */
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createChannelRegistry,
+  registerDefaultChannelPack,
+} from "../src/lifeops/channels/index.ts";
+import type { ConnectorContribution } from "../src/lifeops/connectors/contract.ts";
+import {
+  createConnectorRegistry,
+  registerConnectorRegistry,
+} from "../src/lifeops/connectors/registry.ts";
+import { installFirstRunChannelInspector } from "../src/lifeops/first-run/channel-inspector.ts";
 import { buildDefaultsPack } from "../src/lifeops/first-run/defaults.ts";
 import {
   parseCategories,
@@ -27,6 +37,8 @@ import type {
   ScheduledTaskInput,
 } from "../src/lifeops/wave1-types.ts";
 import { createMinimalRuntimeStub } from "./first-run-helpers.ts";
+
+afterEach(() => setChannelInspector(null));
 
 const VALID_TRIGGER_KINDS = new Set([
   "once",
@@ -90,6 +102,26 @@ function asScheduledTask(input: ScheduledTaskInput): ScheduledTaskInput {
   expect(input.promptInstructions.length).toBeGreaterThan(0);
   expect(input.source).toBe("first_run");
   return input;
+}
+
+function makeConnectedTelegramConnector(): ConnectorContribution {
+  return {
+    kind: "telegram",
+    capabilities: ["telegram.send"],
+    modes: ["local"],
+    describe: { label: "Telegram" },
+    async start() {},
+    async disconnect() {},
+    async verify() {
+      return true;
+    },
+    async status() {
+      return {
+        state: "ok",
+        observedAt: "2026-07-06T00:00:00.000Z",
+      };
+    },
+  };
 }
 
 describe("first-run config validation", () => {
@@ -176,28 +208,46 @@ describe("first-run config validation", () => {
     expect(result?.length).toBe(5);
   });
 
-  it("validateChannel falls back to in_app + warning for unconnected channels", () => {
+  it("validateChannel falls back to in_app + warning for unconnected channels", async () => {
     const runtime = createMinimalRuntimeStub();
-    const result = validateChannel("telegram", runtime);
+    const result = await validateChannel("telegram", runtime);
     expect(result.fallbackToInApp).toBe(true);
     expect(result.warning).toMatch(/fall back/i);
   });
 
-  it("validateChannel passes a connected channel through cleanly", () => {
+  it("validateChannel passes a connected channel through cleanly", async () => {
     setChannelInspector({
       isRegistered: () => true,
       isConnected: () => true,
     });
     const runtime = createMinimalRuntimeStub();
-    const result = validateChannel("telegram", runtime);
+    const result = await validateChannel("telegram", runtime);
     expect(result.fallbackToInApp).toBe(false);
     expect(result.warning).toBeUndefined();
     setChannelInspector(null);
   });
 
-  it("rejects an unregistered channel with the right warning", () => {
+  it("validates a connected Telegram channel through the production registry inspector", async () => {
     const runtime = createMinimalRuntimeStub();
-    const result = validateChannel("morse_code", runtime);
+    const connectorRegistry = createConnectorRegistry();
+    connectorRegistry.register(makeConnectedTelegramConnector());
+    registerConnectorRegistry(runtime, connectorRegistry);
+
+    const channelRegistry = createChannelRegistry();
+    registerDefaultChannelPack(channelRegistry, runtime);
+    installFirstRunChannelInspector(runtime, channelRegistry);
+
+    await expect(validateChannel("telegram", runtime)).resolves.toEqual({
+      channel: "telegram",
+      registered: true,
+      connected: true,
+      fallbackToInApp: false,
+    });
+  });
+
+  it("rejects an unregistered channel with the right warning", async () => {
+    const runtime = createMinimalRuntimeStub();
+    const result = await validateChannel("morse_code", runtime);
     expect(result.channel).toBe("in_app");
     expect(result.fallbackToInApp).toBe(true);
     expect(result.warning).toMatch(/not registered/i);

--- a/plugins/plugin-personal-assistant/test/first-run-questions.test.ts
+++ b/plugins/plugin-personal-assistant/test/first-run-questions.test.ts
@@ -99,15 +99,15 @@ describe("nextUnansweredQuestion", () => {
 });
 
 describe("validateChannel", () => {
-  it("defaults to in_app for empty input", () => {
-    expect(validateChannel("", runtime)).toMatchObject({
+  it("defaults to in_app for empty input", async () => {
+    await expect(validateChannel("", runtime)).resolves.toMatchObject({
       channel: "in_app",
       fallbackToInApp: true,
     });
   });
 
-  it("falls back when a channel is unregistered", () => {
-    const res = validateChannel("slack", runtime);
+  it("falls back when a channel is unregistered", async () => {
+    const res = await validateChannel("slack", runtime);
     expect(res).toMatchObject({
       channel: "in_app",
       registered: false,
@@ -115,8 +115,8 @@ describe("validateChannel", () => {
     });
   });
 
-  it("keeps a registered-but-disconnected channel with a fallback warning", () => {
-    const res = validateChannel("push", runtime);
+  it("keeps a registered-but-disconnected channel with a fallback warning", async () => {
+    const res = await validateChannel("push", runtime);
     expect(res).toMatchObject({
       channel: "push",
       registered: true,
@@ -126,12 +126,12 @@ describe("validateChannel", () => {
     expect(res.warning).toMatch(/disconnected/);
   });
 
-  it("passes a connected channel through cleanly (injected inspector)", () => {
+  it("passes a connected channel through cleanly (injected inspector)", async () => {
     setChannelInspector({
       isRegistered: (c) => c === "discord",
       isConnected: (c) => c === "discord",
     });
-    expect(validateChannel("discord", runtime)).toEqual({
+    await expect(validateChannel("discord", runtime)).resolves.toEqual({
       channel: "discord",
       registered: true,
       connected: true,


### PR DESCRIPTION
## Summary
- Install a first-run channel inspector during personal-assistant plugin init after the channel/connector registries are registered.
- Make `validateChannel` async so Q4 can consult connector-backed channel status instead of the fallback-only inspector.
- Add registry-backed coverage proving a connected Telegram connector validates as connected during first-run channel selection, and that production inspectors are isolated per runtime.

Fixes #14730.

## Verification
- `bun run --cwd plugins/plugin-personal-assistant test test/first-run-questions.test.ts test/first-run-config-validation.test.ts` (2 files, 24 tests)
- `bunx biome check plugins/plugin-personal-assistant/src/plugin.ts plugins/plugin-personal-assistant/src/lifeops/first-run/channel-inspector.ts plugins/plugin-personal-assistant/src/lifeops/first-run/questions.ts plugins/plugin-personal-assistant/src/lifeops/first-run/service.ts plugins/plugin-personal-assistant/test/first-run-questions.test.ts plugins/plugin-personal-assistant/test/first-run-config-validation.test.ts`
- `git diff --check origin/develop...HEAD`
- `bun run audit:error-policy-ratchet`

## Notes
- `bun run --cwd plugins/plugin-personal-assistant typecheck` is currently blocked by existing package-wide resolution/type failures unrelated to this change, including missing workspace modules such as `@elizaos/agent`, `@elizaos/plugin-calendar`, and `@elizaos/plugin-health`.
- `bun run --cwd plugins/plugin-personal-assistant build` now passes in this checkout (JS build + noCheck types build).
- Live Telegram/Discord credentials and UI capture: N/A for this scoped registry wiring; the regression test uses the real channel/connector registries with a deterministic connected Telegram contribution.

## Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - LifeOps first-run registry wiring only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - LifeOps first-run registry wiring only; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no browser/mobile user flow changed; deterministic first-run tests exercise the channel-selection behavior.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend service was started; local test output in Verification shows the registry-backed first-run path executing.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or network flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt/model/action planner behavior changed; this wires channel registry status into first-run validation.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external domain artifact is produced; focused tests prove validateChannel falls back for disconnected/unregistered channels, passes a connected Telegram connector through the production registry inspector, and keeps production inspectors isolated per runtime.

