### PR TITLE
chore(lifeops): repair choice-chip and check-in residuals from #14861/#14852

### DIFF
--- a/plugins/plugin-inbox/test/inbox-choice-markers.test.ts
+++ b/plugins/plugin-inbox/test/inbox-choice-markers.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Deterministic coverage for the INBOX draft/triage [CHOICE] emitters: chips
+ * parse through the real core interaction parser, labels are sanitized, and
+ * every chip value survives the connector reply-callback size cap.
+ */
 import { describe, expect, it } from "vitest";
 import { encodeReplyCallback } from "../../../packages/core/src/messaging/interactions/callback";
 import { parseInteractionBlocks } from "../../../packages/core/src/messaging/interactions/parse";
@@ -53,7 +58,9 @@ function entry(overrides: Partial<TriageEntry>): TriageEntry {
 }
 
 describe("INBOX choice markers", () => {
-  it("appends send/edit/discard chips to draft confirmations", () => {
+  // Chip values must map to real INBOX ops (triage|reply|snooze|archive|approve):
+  // Send=approve, Discard=archive. There is no edit op, so no Edit chip.
+  it("appends send/discard chips to draft confirmations", () => {
     const text = appendInboxDraftChoiceMarker(
       "Drafted reply for JJ. Confirm before sending.",
       "draft-entry-1",
@@ -67,8 +74,7 @@ describe("INBOX choice markers", () => {
       id: "draft-entry-1",
       options: [
         { value: "inbox approve draft-entry-1", label: "Send" },
-        { value: "inbox edit draft-entry-1", label: "Edit" },
-        { value: "inbox discard draft-entry-1", label: "Discard" },
+        { value: "inbox archive draft-entry-1", label: "Discard" },
       ],
     });
   });

--- a/plugins/plugin-personal-assistant/src/lifeops/checkin/morning-checkin-ownership.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/checkin/morning-checkin-ownership.ts
@@ -1,13 +1,16 @@
 /**
- * Explicit cross-engine ownership for the owner-visible morning check-in.
+ * Log-side ownership record for the owner-visible morning check-in.
  *
- * The scheduled-task spine gets first claim because it is the one scheduler that
- * can consolidate wake.confirmed work and call the morning-brief assembler.
- * The sleep-cycle RemindersDomain remains a fallback only when no morning
- * check-in report exists for the local day; when the spine already assembled
- * one, this module makes that suppressed duplicate visible in ordinary logs.
+ * Two engines can assemble the morning check-in: the scheduled-task spine
+ * (wake.confirmed watcher delegating to the morning-brief assembler) and the
+ * sleep-cycle RemindersDomain. Both persist through
+ * `CheckinService.runMorningCheckin`, so the `life_checkin_reports` row is the
+ * dedupe arbiter — whichever engine fires second sees `hasCheckinForLocalDay`
+ * and skips. This module names the engines and makes the sleep-cycle skip
+ * observable in ordinary logs; the skip itself lives with the report check in
+ * `RemindersDomain` (and its spine-side twin in `runtime-wiring.ts`).
  */
-import { type IAgentRuntime, logger } from "@elizaos/core";
+import { logger } from "@elizaos/core";
 
 export const MORNING_CHECKIN_OWNER_ENGINE = "scheduled-task-spine" as const;
 export const MORNING_CHECKIN_SUPPRESSED_ENGINE =
@@ -20,32 +23,16 @@ export interface SleepCycleMorningCheckinSuppressionContext {
   wakeAt?: string | null;
 }
 
-/**
- * Cross-engine ownership rule for the owner-visible morning check-in.
- *
- * The scheduled-task spine owns morning delivery because it is the single
- * scheduler that already consolidates wake.confirmed records and invokes the
- * morning-brief assembler. The sleep-cycle RemindersDomain may still own night
- * check-ins, but it must not race the spine for the morning surface.
- */
-export function shouldSuppressSleepCycleMorningCheckin(): boolean {
-  return true;
-}
-
 export function reportSuppressedSleepCycleMorningCheckin(
-  _runtime: IAgentRuntime,
   context: SleepCycleMorningCheckinSuppressionContext,
 ): void {
-  const metadata = {
-    ...context,
-    ownerEngine: MORNING_CHECKIN_OWNER_ENGINE,
-    suppressedEngine: MORNING_CHECKIN_SUPPRESSED_ENGINE,
-    deliveryBasis: "sleep_cycle",
-  };
   logger.info(
     {
       src: "lifeops:morning-checkin-ownership",
-      ...metadata,
+      ...context,
+      ownerEngine: MORNING_CHECKIN_OWNER_ENGINE,
+      suppressedEngine: MORNING_CHECKIN_SUPPRESSED_ENGINE,
+      deliveryBasis: "sleep_cycle",
     },
     "Suppressed duplicate sleep-cycle morning check-in; scheduled-task spine owns morning delivery.",
   );

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
@@ -100,10 +100,7 @@ import {
   CheckinService,
   type CheckinSourceService,
 } from "../checkin/checkin-service.js";
-import {
-  reportSuppressedSleepCycleMorningCheckin,
-  shouldSuppressSleepCycleMorningCheckin,
-} from "../checkin/morning-checkin-ownership.js";
+import { reportSuppressedSleepCycleMorningCheckin } from "../checkin/morning-checkin-ownership.js";
 import { resolveCheckinSchedule } from "../checkin/schedule-resolver.js";
 import { appendCheckinAckChoiceMarker } from "../choice-markers.js";
 import {
@@ -5596,14 +5593,14 @@ export class RemindersDomain {
         timezone,
       });
       if (alreadySent) {
-        if (kind === "morning" && shouldSuppressSleepCycleMorningCheckin()) {
+        if (kind === "morning") {
           const localDay = getLocalDateKey(
             getZonedDateParts(args.now, timezone),
           );
           const suppressionKey = `${this.ctx.agentId()}:${timezone}:${localDay}`;
           if (!this.loggedMorningCheckinSuppressionKeys.has(suppressionKey)) {
             this.loggedMorningCheckinSuppressionKeys.add(suppressionKey);
-            reportSuppressedSleepCycleMorningCheckin(this.ctx.runtime, {
+            reportSuppressedSleepCycleMorningCheckin({
               agentId: this.ctx.agentId(),
               nowIso: args.now.toISOString(),
               timezone,

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.owner-facing-copy.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.owner-facing-copy.test.ts
@@ -25,10 +25,21 @@ vi.mock("../repository.js", () => ({
   LifeOpsRepository: class LifeOpsRepository {},
 }));
 
-vi.mock("@elizaos/agent", () => ({
-  createLocalAgentBackup: vi.fn(),
-  getAgentEventService: vi.fn(() => agentMocks.eventService),
-}));
+// Spread the shared PA agent stub so the owner-contact channel-target
+// resolution the dispatcher performs before a connector send stays real; the
+// telegram contact gives the connected-channel test a resolvable target, and
+// the event service is this file's spy.
+vi.mock("@elizaos/agent", async () => {
+  const stub = await import("../../../test/stubs/agent.ts");
+  return {
+    ...stub,
+    createLocalAgentBackup: vi.fn(),
+    getAgentEventService: vi.fn(() => agentMocks.eventService),
+    loadOwnerContactsConfig: vi.fn(() => ({
+      telegram: { channelId: "owner-telegram-channel" },
+    })),
+  };
+});
 
 const morningBriefMocks = vi.hoisted(() => ({
   assembleMorningBrief: vi.fn(),
@@ -171,7 +182,7 @@ describe("production scheduled-task dispatcher owner-facing copy", () => {
     const loggerInfo = vi.spyOn(logger, "info").mockImplementation(() => {});
     const { runtime } = makeRuntime({ reportError });
 
-    reportSuppressedSleepCycleMorningCheckin(runtime, {
+    reportSuppressedSleepCycleMorningCheckin({
       agentId: "agent-test",
       nowIso: "2026-07-06T14:00:00.000Z",
       timezone: "America/Denver",

--- a/plugins/plugin-personal-assistant/test/lifeops-choice-markers.test.ts
+++ b/plugins/plugin-personal-assistant/test/lifeops-choice-markers.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Deterministic coverage for the LifeOps approval/check-in [CHOICE] emitters:
+ * chips parse through the real core interaction parser and every chip value
+ * survives the connector reply-callback size cap. No model, no DB.
+ */
 import { describe, expect, it } from "vitest";
 import { encodeReplyCallback } from "../../../packages/core/src/messaging/interactions/callback";
 import { parseInteractionBlocks } from "../../../packages/core/src/messaging/interactions/parse";


### PR DESCRIPTION
## Summary

Post-merge repair for the lifeops-approvals cluster (#14861, #14852, follows lalalune's review notes on both):

- **Green two tests left red on `develop`:**
  - `plugins/plugin-inbox/test/inbox-choice-markers.test.ts` still asserted the removed **Edit** chip and the old `inbox discard` value. The merged source is correct — chip values must map to real INBOX ops (`triage|reply|snooze|archive|approve`): Send=approve, Discard=archive. Test now locks that mapping.
  - `runtime-wiring.owner-facing-copy.test.ts` ('sends the model-rendered message through connected channel payloads') failed with **No "loadOwnerContactsConfig" export** on the hand-rolled `@elizaos/agent` mock after the dispatcher gained owner-contact channel-target resolution (#14817/#14879). Now mocks via the shared PA agent stub (`test/stubs/agent.ts`) plus a telegram owner contact, keeping the resolution path real.
- **Trim #14852 ceremony:** delete the constant-`true` `shouldSuppressSleepCycleMorningCheckin()` gate and the unused `runtime` parameter on `reportSuppressedSleepCycleMorningCheckin`; the module header now states the real dedupe arbiter — the `life_checkin_reports` row both engines persist through `CheckinService.runMorningCheckin`.
- **Headers:** required prose headers on the two new choice-marker test files.

## Verification

- `bunx vitest run src/lifeops/scheduled-task/runtime-wiring.owner-facing-copy.test.ts test/lifeops-choice-markers.test.ts` → 2 files, 8 tests passed (was 1 failed on clean develop tip).
- `bunx vitest run test/inbox-choice-markers.test.ts` (plugin-inbox) → 2 tests passed (was 1 failed on clean develop tip).
- `bunx biome check` on all 5 touched files → clean.
- `git diff --check` → clean.

## Evidence / N/A

- Screenshots/video: N/A — test/comment/dead-code-only change; no runtime surface altered (the only production-code edit removes a constant-true gate and an unused parameter; behavior identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)