### PR TITLE
fix(lifeops): preserve connector activity provenance

### DIFF
--- a/plugins/plugin-health/src/sleep/awake-probability.ts
+++ b/plugins/plugin-health/src/sleep/awake-probability.ts
@@ -92,6 +92,7 @@ export function computeAwakeProbability(args: {
     const reliability = resolveActivitySignalReliability(
       latestSignal.signal.source,
       latestSignal.signal.platform,
+      latestSignal.signal.metadata,
     );
     let scale = clamp(reliability, 0, 1);
     const isSharedDeviceRisk =

--- a/plugins/plugin-health/src/sleep/source-reliability.test.ts
+++ b/plugins/plugin-health/src/sleep/source-reliability.test.ts
@@ -133,12 +133,30 @@ describe("resolveActivitySignalReliability", () => {
       resolveActivitySignalReliability("desktop_interaction", "macos"),
     ).toBe(0.8);
     expect(resolveActivitySignalReliability("connector_activity", "web")).toBe(
-      0.8,
+      0.15,
     );
     expect(resolveActivitySignalReliability("imessage_outbound", "macos")).toBe(
       0.88,
     );
     expect(resolveActivitySignalReliability("mobile_device", "ios")).toBe(0.7);
     expect(resolveActivitySignalReliability("mobile_health", "ios")).toBe(0.95);
+  });
+
+  it("derives connector message reliability from direction and channel metadata", () => {
+    expect(
+      resolveActivitySignalReliability("connector_activity", "telegram", {
+        direction: "inbound",
+      }),
+    ).toBe(0.15);
+    expect(
+      resolveActivitySignalReliability("connector_activity", "telegram", {
+        direction: "outbound_by_owner",
+      }),
+    ).toBe(0.8);
+    expect(
+      resolveActivitySignalReliability("connector_activity", "client_chat", {
+        direction: "outbound_by_owner",
+      }),
+    ).toBe(0.88);
   });
 });

--- a/plugins/plugin-health/src/sleep/source-reliability.ts
+++ b/plugins/plugin-health/src/sleep/source-reliability.ts
@@ -82,30 +82,79 @@ export function resolveSourceReliability(key: LifeOpsReliabilityKey): number {
 }
 
 /**
- * Default reliability key for each activity-signal source. The special-case
- * for `app_lifecycle` + `manual_override` platform is handled inline because
- * it's the only cross-axis override.
+ * Default reliability key for each activity-signal source. Cross-axis signal
+ * sources (`app_lifecycle`, connector messages) are handled inline because the
+ * source alone is not enough to derive confidence.
  */
 const SOURCE_RELIABILITY_KEYS: Record<
-  LifeOpsActivitySignalSource,
+  Exclude<LifeOpsActivitySignalSource, "connector_activity">,
   LifeOpsReliabilityKey
 > = {
   app_lifecycle: { kind: "device_presence", transition: true },
   page_visibility: { kind: "device_presence", transition: true },
   desktop_power: { kind: "desktop_power", transition: "system" },
   desktop_interaction: { kind: "desktop_idle", source: "iokit_hid" },
-  connector_activity: { kind: "message_outbound", channel: "gmail" },
   imessage_outbound: { kind: "message_outbound", channel: "imessage" },
   mobile_device: { kind: "mobile_device", source: "capacitor" },
   mobile_health: { kind: "mobile_health", permissionGranted: true },
 };
 
+function readMetadataString(
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+): string | null {
+  const value = metadata?.[key];
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function normalizeMessageReliabilityChannel(
+  value: string,
+): LifeOpsMessageReliabilityChannel {
+  const normalized = value.toLowerCase();
+  if (normalized.includes("telegram")) return "telegram";
+  if (normalized.includes("discord")) return "discord";
+  if (normalized.includes("imessage")) return "imessage";
+  if (normalized.includes("whatsapp")) return "whatsapp";
+  if (normalized.includes("signal")) return "signal";
+  if (normalized.includes("sms") || normalized.includes("twilio")) {
+    return "sms";
+  }
+  if (normalized.includes("x_dm") || normalized === "x") return "x_dm";
+  if (normalized.includes("gmail") || normalized.includes("email")) {
+    return "gmail";
+  }
+  return "eliza_chat";
+}
+
+function connectorActivityReliabilityKey(
+  platform: string,
+  metadata?: Record<string, unknown>,
+): LifeOpsReliabilityKey {
+  if (metadata?.direction !== "outbound_by_owner") {
+    return { kind: "message_inbound" };
+  }
+  return {
+    kind: "message_outbound",
+    channel: normalizeMessageReliabilityChannel(
+      readMetadataString(metadata, "channel") ?? platform,
+    ),
+  };
+}
+
 export function resolveActivitySignalReliability(
   source: LifeOpsActivitySignalSource,
   platform: string,
+  metadata?: Record<string, unknown>,
 ): number {
   if (source === "app_lifecycle" && platform === "manual_override") {
     return resolveSourceReliability({ kind: "manual_override" });
+  }
+  if (source === "connector_activity") {
+    return resolveSourceReliability(
+      connectorActivityReliabilityKey(platform, metadata),
+    );
   }
   return resolveSourceReliability(SOURCE_RELIABILITY_KEYS[source]);
 }

--- a/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.ts
@@ -4,6 +4,7 @@
  * LifeOps activity signals keyed by device id, so presence observed on one
  * device contributes to the owner's activity/presence profile.
  */
+import crypto from "node:crypto";
 import {
   type ActionEventPayload,
   EventType,
@@ -38,6 +39,38 @@ function readMessageTimestamp(payload: MessagePayload): string {
   return new Date().toISOString();
 }
 
+function readMessageId(payload: MessagePayload): string {
+  const record = isRecord(payload.message) ? payload.message : null;
+  const metadata = isRecord(record?.metadata) ? record.metadata : null;
+  const candidates = [metadata?.originalId, record?.id];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.length > 0) {
+      return candidate;
+    }
+  }
+  return crypto.randomUUID();
+}
+
+function readConversationId(payload: MessagePayload): string {
+  const payloadRecord = isRecord(payload) ? payload : null;
+  const record = isRecord(payload.message) ? payload.message : null;
+  const content = isRecord(record?.content) ? record.content : null;
+  const candidates = [
+    content?.channelId,
+    content?.conversationId,
+    content?.threadId,
+    record?.roomId,
+    payloadRecord?.roomId,
+    payload.source,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.length > 0) {
+      return candidate;
+    }
+  }
+  return "unknown-conversation";
+}
+
 function readPlatform(payload: MessagePayload): string {
   const messageRecord = isRecord(payload.message) ? payload.message : null;
   const content = isRecord(messageRecord?.content)
@@ -55,6 +88,10 @@ function readPlatform(payload: MessagePayload): string {
     }
   }
   return "runtime_event";
+}
+
+function hashTelemetryIdentity(scope: string, value: string): string {
+  return `${scope}:${crypto.createHash("sha256").update(value).digest("hex").slice(0, 32)}`;
 }
 
 export class PresenceSignalBridgeService extends Service {
@@ -182,11 +219,14 @@ export class PresenceSignalBridgeService extends Service {
       this.recentFingerprints.set(fingerprint, observedMs);
     }
     const repository = new LifeOpsRepository(this.runtime);
+    const platform = readPlatform(payload);
+    const direction =
+      eventType === EventType.MESSAGE_SENT ? "outbound_by_owner" : "inbound";
     await repository.createActivitySignal(
       createLifeOpsActivitySignal({
         agentId: String(this.runtime.agentId),
         source: "connector_activity",
-        platform: readPlatform(payload),
+        platform,
         state: "active",
         observedAt,
         idleState: null,
@@ -196,6 +236,16 @@ export class PresenceSignalBridgeService extends Service {
         metadata: {
           eventType,
           entityId,
+          direction,
+          externalMessageId: readMessageId(payload),
+          senderHash:
+            direction === "outbound_by_owner"
+              ? "owner"
+              : hashTelemetryIdentity("sender", entityId),
+          conversationHash: hashTelemetryIdentity(
+            "conversation",
+            readConversationId(payload),
+          ),
           deviceId: getDeviceId(),
         },
       }),

--- a/plugins/plugin-personal-assistant/src/lifeops/telemetry-mapping.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/telemetry-mapping.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests the durable activity-signal to telemetry-event mapper. These cases pin
+ * provenance fields because downstream passive-learning and sleep/wake scoring
+ * treat channel, platform, direction, and sender identity as evidence quality.
+ */
+
+import type { LifeOpsActivitySignal } from "@elizaos/shared";
+import { describe, expect, it } from "vitest";
+import { mapSignalToTelemetryPayload } from "./telemetry-mapping.js";
+
+function signal(
+  overrides: Partial<LifeOpsActivitySignal> = {},
+): LifeOpsActivitySignal {
+  return {
+    id: "signal-1",
+    agentId: "agent-1",
+    source: "connector_activity",
+    platform: "telegram",
+    state: "active",
+    observedAt: "2026-07-06T04:00:00.000Z",
+    idleState: null,
+    idleTimeSeconds: 0,
+    onBattery: null,
+    health: null,
+    metadata: {},
+    createdAt: "2026-07-06T04:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("mapSignalToTelemetryPayload", () => {
+  it("preserves connector activity provenance instead of fabricating gmail/macos/owner", () => {
+    const payload = mapSignalToTelemetryPayload(
+      signal({
+        platform: "telegram",
+        metadata: {
+          direction: "inbound",
+          externalMessageId: "telegram-message-1",
+          senderHash: "sender:abc123",
+          conversationHash: "conversation:def456",
+        },
+      }),
+    );
+
+    expect(payload).toEqual({
+      family: "message_activity_event",
+      platform: "browser_web",
+      channel: "telegram",
+      direction: "inbound",
+      externalMessageId: "telegram-message-1",
+      senderHash: "sender:abc123",
+      conversationHash: "conversation:def456",
+    });
+  });
+
+  it("derives device platform from the observed signal platform", () => {
+    expect(
+      mapSignalToTelemetryPayload(
+        signal({ source: "app_lifecycle", platform: "ios" }),
+      ),
+    ).toMatchObject({ platform: "ios_capacitor" });
+    expect(
+      mapSignalToTelemetryPayload(
+        signal({ source: "app_lifecycle", platform: "macos_electrobun" }),
+      ),
+    ).toMatchObject({ platform: "macos_electrobun" });
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/telemetry-mapping.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/telemetry-mapping.ts
@@ -16,7 +16,9 @@ import crypto from "node:crypto";
 import { resolveActivitySignalReliability } from "@elizaos/plugin-health/sleep/source-reliability";
 import type {
   LifeOpsActivitySignal,
+  LifeOpsDevicePlatform,
   LifeOpsTelemetryEvent,
+  LifeOpsTelemetryMessageChannel,
   LifeOpsTelemetryPayload,
 } from "@elizaos/shared";
 
@@ -32,6 +34,64 @@ export function deriveTelemetryDedupeKey(
     .update(serialized)
     .digest("hex")
     .slice(0, 48);
+}
+
+function readMetadataString(
+  metadata: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = metadata[key];
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function hashTelemetryValue(scope: string, value: string): string {
+  return `${scope}:${crypto.createHash("sha256").update(value).digest("hex").slice(0, 32)}`;
+}
+
+function normalizeDevicePlatform(value: string): LifeOpsDevicePlatform {
+  const normalized = value.toLowerCase();
+  if (normalized.includes("ios") && !normalized.includes("ipad")) {
+    return "ios_capacitor";
+  }
+  if (normalized.includes("ipad")) {
+    return "ipados_capacitor";
+  }
+  if (normalized.includes("electrobun")) {
+    return "macos_electrobun";
+  }
+  if (normalized.includes("macos") || normalized.includes("desktop")) {
+    return "macos_desktop";
+  }
+  return "browser_web";
+}
+
+function normalizeMessageChannel(
+  value: string,
+): LifeOpsTelemetryMessageChannel {
+  const normalized = value.toLowerCase();
+  if (normalized.includes("telegram")) return "telegram";
+  if (normalized.includes("discord")) return "discord";
+  if (normalized.includes("imessage")) return "imessage";
+  if (normalized.includes("whatsapp")) return "whatsapp";
+  if (normalized.includes("signal")) return "signal";
+  if (normalized.includes("sms") || normalized.includes("twilio")) {
+    return "sms";
+  }
+  if (normalized.includes("x_dm") || normalized === "x") return "x_dm";
+  if (normalized.includes("gmail") || normalized.includes("email")) {
+    return "gmail";
+  }
+  return "eliza_chat";
+}
+
+function readMessageDirection(
+  metadata: Record<string, unknown>,
+): "inbound" | "outbound_by_owner" {
+  return metadata.direction === "outbound_by_owner"
+    ? "outbound_by_owner"
+    : "inbound";
 }
 
 export function mapSignalToTelemetryPayload(
@@ -59,7 +119,7 @@ export function mapSignalToTelemetryPayload(
     case "page_visibility":
       return {
         family: "device_presence_event",
-        platform: "macos_desktop",
+        platform: normalizeDevicePlatform(signal.platform),
         state: signal.state,
         deviceId: signal.platform,
         isTransition: true,
@@ -103,21 +163,19 @@ export function mapSignalToTelemetryPayload(
     case "connector_activity":
       return {
         family: "message_activity_event",
-        platform: "macos_desktop",
-        channel: "gmail",
-        direction:
-          signal.metadata.direction === "outbound_by_owner"
-            ? "outbound_by_owner"
-            : "inbound",
+        platform: normalizeDevicePlatform(signal.platform),
+        channel: normalizeMessageChannel(
+          readMetadataString(signal.metadata, "channel") ?? signal.platform,
+        ),
+        direction: readMessageDirection(signal.metadata),
         externalMessageId:
-          typeof signal.metadata.externalMessageId === "string"
-            ? signal.metadata.externalMessageId
-            : signal.id,
-        senderHash: "owner",
+          readMetadataString(signal.metadata, "externalMessageId") ?? signal.id,
+        senderHash:
+          readMetadataString(signal.metadata, "senderHash") ??
+          hashTelemetryValue("sender", signal.id),
         conversationHash:
-          typeof signal.metadata.conversationHash === "string"
-            ? signal.metadata.conversationHash
-            : "connector",
+          readMetadataString(signal.metadata, "conversationHash") ??
+          hashTelemetryValue("conversation", signal.platform),
       };
     case "mobile_device":
       return {
@@ -157,6 +215,7 @@ export function buildTelemetryEventFromSignal(
   const reliability = resolveActivitySignalReliability(
     signal.source,
     signal.platform,
+    signal.metadata,
   );
   return {
     id: crypto.randomUUID(),


### PR DESCRIPTION
## Summary

Fixes #14686.

- Preserves connector provenance when runtime message activity is mirrored into LifeOps activity signals: platform/channel, direction, external message id, sender hash, and conversation hash now travel with the signal instead of being collapsed later.
- Maps connector telemetry rows from the recorded provenance instead of hardcoding `gmail`, `macos_desktop`, and `owner`.
- Uses connector direction/channel metadata in sleep reliability so inbound messages remain weak wake evidence while owner outbound messages keep channel-specific confidence.
- Keeps app lifecycle/page visibility device telemetry on the observed platform family instead of forcing macOS.

## Verification

- PASS: `PATH=/Users/shawwalters/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH TMPDIR=/Users/shawwalters/.codex/worktrees/a7c3/eliza/.tmp/vitest bun run --cwd plugins/plugin-personal-assistant test -- src/lifeops/telemetry-mapping.test.ts` — 1 file / 2 tests. Confirms Telegram connector activity maps to `channel: "telegram"`, `direction: "inbound"`, preserved external ids/hashes, and iOS/macOS app lifecycle platforms map to the proper device payload platforms.
- PASS: `PATH=/Users/shawwalters/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH TMPDIR=/Users/shawwalters/.codex/worktrees/a7c3/eliza/.tmp/vitest bun run --cwd plugins/plugin-health test -- src/sleep/source-reliability.test.ts src/sleep/awake-probability.compute.test.ts` — 2 files / 16 tests. Confirms inbound connector activity is low-confidence message evidence and outbound connector activity keeps channel-specific owner reliability.
- PASS: `git diff --check && PATH=/Users/shawwalters/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH bun run audit:error-policy-ratchet --report` — no whitespace errors and no new fallback-slop in the four touched production files.
- BLOCKED BASELINE: `PATH=/Users/shawwalters/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH bun run --cwd plugins/plugin-health typecheck` still fails before this change's surface at `src/default-packs/gate-coverage.test.ts(17,8): Cannot find module '@elizaos/plugin-scheduling'`.
- BLOCKED BASELINE: `PATH=/Users/shawwalters/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH bun run --cwd plugins/plugin-personal-assistant typecheck` still fails on the existing unresolved plugin workspace imports (`@elizaos/plugin-blocker`, `@elizaos/plugin-calendar`, `@elizaos/plugin-health`, `@elizaos/plugin-scheduling`, etc.). A branch-local `presence-signal-bridge-service.ts` type error found during verification was fixed before pushing.
- BLOCKED BASELINE: `PATH=/Users/shawwalters/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH bun run verify` stops at `audit:type-safety-ratchet` with `as unknown as: 76 / 73`, matching the known repo baseline blocker and before workspace typecheck/lint execution.

## Evidence Rows

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: N/A - backend-only telemetry/reliability mapping fix; no rendered app UI changed.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: N/A - backend-only telemetry/reliability mapping fix; no rendered app UI changed.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: N/A - no user-facing UI flow changed; behavior is exercised by deterministic mapper/reliability tests.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no backend server was started; the relevant backend path is pure signal mapping and reliability scoring, verified by the focused Vitest command outputs above.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - no frontend surface or network flow changed.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - no agent prompt/action/model behavior changed; the fix is deterministic signal mapping and reliability scoring.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no persisted production artifacts were generated; domain payload shape is validated by `telemetry-mapping.test.ts` and `source-reliability.test.ts` assertions listed above.
