### PR TITLE
fix(coding-tools): bound shell disk cleanup probe

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop-post-tool-evaluator-failure.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-post-tool-evaluator-failure.test.ts
@@ -102,10 +102,11 @@ describe("planner-loop — post-tool evaluator failure recovery", () => {
 	});
 
 	it("does not leak log-shaped output — a tool without userFacingText is never relayed", async () => {
-		// A SHELL/fetch-style tool emits log-shaped `text` (prompts, exit codes, raw
-		// bodies) and leaves userFacingText unset. When the evaluator provider-throws
-		// after it, the relay must not dump that log into the user channel; with
-		// nothing user-facing to relay it rethrows the provider error instead.
+		// A raw SHELL/fetch-style tool result emits log-shaped `text` (prompts, exit
+		// codes, raw bodies) and leaves userFacingText unset. When the evaluator
+		// provider-throws after it, the relay must not dump that log into the user
+		// channel; with nothing user-facing to relay it rethrows the provider error
+		// instead.
 		const shellLog =
 			"$ cat secrets.txt\nexit 0\ncwd=/home/milady\nAWS_SECRET=leak-me";
 		const executeToolCall = vi.fn(async () => ({

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -2749,12 +2749,12 @@ function terminalMessageFromToolCalls(
  * format into the user channel.
  *
  * Tools that produce real user-facing answers (Q&A, content generation,
- * REPLY) must opt in by setting `userFacingText`. Tools that emit logs
- * (BASH, SHELL, fetchers, file readers) leave it unset; this function
- * then returns undefined and the caller falls through to the evaluator's
- * synthesized reply instead of dumping the log into the channel. The
- * contract is structural: tools declare what is safe to show, the
- * framework never guesses by parsing wrapper text.
+ * mutation confirmations, vetted shell projections) must opt in by setting
+ * `userFacingText`. Tools that only emit logs (raw shell transcripts, fetchers,
+ * file readers) leave it unset; this function then returns undefined and the
+ * caller falls through to the evaluator's synthesized reply instead of dumping
+ * the log into the channel. The contract is structural: tools declare what is
+ * safe to show, the framework never guesses by parsing wrapper text.
  */
 function latestToolResultText(
 	trajectory: PlannerTrajectory,
@@ -2779,10 +2779,11 @@ function latestToolResultText(
  * {@link latestToolResultText}: the diagnostic `text`/`summary` fields are
  * log-shaped (shell prompts, exit codes, cwd, raw fetch bodies) and must not be
  * guessed into the user channel. A tool declares its output safe to show by
- * setting `userFacingText` — FILE write/edit do so ("Wrote N bytes to <path>");
- * SHELL, fetchers, and file readers leave it unset, so their raw logs never leak
- * here. Returns undefined when no successful non-terminal tool exposed a
- * user-facing result, so genuine failures still surface.
+ * setting `userFacingText` — FILE write/edit do so ("Wrote N bytes to <path>"),
+ * as do narrowly vetted shell projections. Raw shell transcripts, fetchers, and
+ * file readers leave it unset, so their logs never leak here. Returns undefined
+ * when no successful non-terminal tool exposed a user-facing result, so genuine
+ * failures still surface.
  */
 function deterministicSuccessfulToolRelay(
 	trajectory: PlannerTrajectory,

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -1001,6 +1001,7 @@ describeIfPosix("shellAction", () => {
 
       expect(result.success).toBe(true);
       expect(result.text).toContain("df -h / /home");
+      expect(result.text).toContain("timeout 3s du -sh");
       expect(result.text).toContain("free -m");
       expect(result.userFacingText).toContain("Root disk:");
       expect(result.userFacingText).toContain("Biggest cleanup candidate:");

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -129,12 +129,12 @@ export function resolveCommandPlatform(): CommandPlatform {
   return process.platform === "darwin" ? "macos" : "linux";
 }
 
-// --- POSIX (Linux) — kept byte-for-byte so the existing Linux command/parser
-// contract is unchanged. ---
+// --- POSIX (Linux) — each cleanup candidate is capped independently so a busy
+// /tmp or package cache cannot consume the whole SHELL turn budget.
 const POSIX_HEALTH_COMMAND = `PORT="\${ELIZA_API_PORT:-\${ELIZA_PORT:-\${API_PORT:-\${SERVER_PORT:-2138}}}}"; curl -sS "http://127.0.0.1:\${PORT}/api/health"`;
 const LINUX_MEMORY_COMMAND = "free -m";
 const LINUX_DISK_INSPECTION_COMMAND =
-  'df -h / /home; printf \'\\n--- cleanup candidates ---\\n\'; for p in /tmp /var/tmp "$HOME/.cache" "$HOME/.bun" "$HOME/.npm" "$HOME/.local/share/Trash"; do [ -e "$p" ] && du -sh "$p" 2>/dev/null; done | sort -hr | head -n 10';
+  'df -h / /home; printf \'\\n--- cleanup candidates ---\\n\'; for p in /tmp /var/tmp "$HOME/.cache" "$HOME/.bun" "$HOME/.npm" "$HOME/.local/share/Trash"; do [ -e "$p" ] && timeout 3s du -sh "$p" 2>/dev/null || true; done | sort -hr | head -n 10';
 
 // --- macOS — `free` is Linux-only, so synthesize a `free -m`-compatible `Mem:`
 // line from `sysctl`/`vm_stat` (page size via `hw.pagesize`, which is 16384 on


### PR DESCRIPTION
## Summary
- Caps each Linux shell diagnostic cleanup-candidate `du -sh` probe with `timeout 3s` so a busy `/tmp`, package cache, or home cache cannot consume the whole SHELL turn budget.
- Keeps the post-tool relay contract comments aligned with the already-merged safe `userFacingText` behavior from #14883.
- Adds coverage asserting the generated shell diagnostic text includes the bounded `timeout 3s du -sh` probe.

## Verification
- `bun run --cwd plugins/plugin-coding-tools test -- bash` -> 2 files, 56 tests passed.
- `bun run --cwd packages/core test -- planner-loop-post-tool-evaluator-failure` -> 1 file, 5 tests passed.
- `bunx @biomejs/biome check packages/core/src/runtime/planner-loop.ts packages/core/src/runtime/__tests__/planner-loop-post-tool-evaluator-failure.test.ts plugins/plugin-coding-tools/src/actions/bash.ts plugins/plugin-coding-tools/src/actions/bash.test.ts` -> clean.
- `git diff --check` -> clean.
- `bun run audit:error-policy-ratchet --report` -> no new fallback-slop in touched production files.
- `bun run --cwd packages/core typecheck` -> clean.
- `bun run --cwd plugins/plugin-coding-tools typecheck` -> clean.

## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - runtime/tooling command generation only; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
- [x] N/A - runtime/tooling command generation only; no rendered UI changed.

<!-- evidence-row:walkthrough-video -->
- [x] N/A - no browser/mobile flow changed; focused shell-action tests exercise the generated diagnostic command contract.

<!-- evidence-row:backend-logs -->
- [x] N/A - no server process started; local command output above verifies the runtime/tooling paths.

<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend/network path changed.

<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt/model behavior changed; deterministic planner-loop regression remains covered.

<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external domain artifact is produced; focused test artifact: `plugins/plugin-coding-tools` shell-action suite now asserts the Linux diagnostic command includes `timeout 3s du -sh`, proving cleanup candidate probes are independently bounded.
