### PR TITLE
fix(background): pass user catalog references to renderer (#14725)

### DIFF
--- a/plugins/plugin-app-control/src/actions/background.test.ts
+++ b/plugins/plugin-app-control/src/actions/background.test.ts
@@ -191,6 +191,29 @@ describe("inferBackgroundPlan", () => {
 			}),
 		).toMatchObject({ op: "set", mode: "shader", color: "#7c3aed" });
 	});
+
+	it("falls through an unknown explicit catalog reference for renderer-side user catalog resolution", () => {
+		expect(
+			inferBackgroundPlan("change my background", undefined, {
+				catalog: "sunset beach",
+			}),
+		).toEqual({
+			op: "set",
+			mode: "catalog",
+			catalogId: "sunset beach",
+			catalogLabel: "sunset beach",
+		});
+	});
+
+	it("passes a quoted catalog reference through without curated matching", () => {
+		expect(
+			inferBackgroundPlan('use "sunset beach" as my background', undefined),
+		).toMatchObject({
+			op: "set",
+			mode: "catalog",
+			catalogId: "sunset beach",
+		});
+	});
 });
 
 describe("programmable GLSL shader plan (#10694)", () => {
@@ -502,6 +525,20 @@ describe("BACKGROUND action — catalog name-select + upload handoff (#13538)", 
 			vi.fn(async () => []),
 		);
 		expect(emitted).toEqual([{ op: "set", catalogId: "ocean-deep" }]);
+	});
+
+	it("passes a user-saved catalog reference through for renderer-side lookup", async () => {
+		const { action, emitted, replies, callback } = setup();
+		const result = await action.handler(
+			runtime,
+			message("use my sunset wallpaper"),
+			undefined,
+			undefined,
+			callback,
+		);
+		expect(emitted).toEqual([{ op: "set", catalogId: "sunset" }]);
+		expect(result.success).toBe(true);
+		expect(replies[0]).toContain("sunset");
 	});
 
 	it("an explicit generate wins over a same-named catalog entry", async () => {

--- a/plugins/plugin-app-control/src/actions/background.test.ts
+++ b/plugins/plugin-app-control/src/actions/background.test.ts
@@ -214,6 +214,36 @@ describe("inferBackgroundPlan", () => {
 			catalogId: "sunset beach",
 		});
 	});
+
+	it("does not let an unknown catalog option override explicit image or generate inputs", () => {
+		expect(
+			inferBackgroundPlan("change my background", undefined, {
+				catalog: "sunset beach",
+				imageUrl: "/api/media/generated.png",
+			}),
+		).toEqual({
+			op: "set",
+			mode: "image",
+			imageUrl: "/api/media/generated.png",
+		});
+		expect(
+			inferBackgroundPlan("change my background", undefined, {
+				catalog: "sunset beach",
+				prompt: "a quiet redwood grove",
+			}),
+		).toEqual({
+			op: "set",
+			generatePrompt: "a quiet redwood grove",
+		});
+		expect(
+			inferBackgroundPlan("generate a sunset beach background", undefined, {
+				catalog: "sunset beach",
+			}),
+		).toMatchObject({
+			op: "set",
+			generatePrompt: "sunset beach",
+		});
+	});
 });
 
 describe("programmable GLSL shader plan (#10694)", () => {

--- a/plugins/plugin-app-control/src/actions/background.test.ts
+++ b/plugins/plugin-app-control/src/actions/background.test.ts
@@ -244,6 +244,14 @@ describe("inferBackgroundPlan", () => {
 			generatePrompt: "sunset beach",
 		});
 	});
+
+	it("keeps ordinary color requests ahead of user-catalog fallback", () => {
+		expect(inferBackgroundPlan("make my background teal")).toMatchObject({
+			op: "set",
+			mode: "shader",
+			colorLabel: "teal",
+		});
+	});
 });
 
 describe("programmable GLSL shader plan (#10694)", () => {

--- a/plugins/plugin-app-control/src/actions/background.ts
+++ b/plugins/plugin-app-control/src/actions/background.ts
@@ -299,6 +299,32 @@ function extractGeneratePrompt(text: string): string {
 		.trim();
 }
 
+const USER_CATALOG_REFERENCE_RE =
+	/\b(my|mine|saved|generated|created|uploaded|custom|yours?)\b/i;
+
+function cleanUserCatalogReference(value: string): string | null {
+	const cleaned = value
+		.replace(BACKGROUND_NOUN_RE, " ")
+		.replace(
+			/\b(set|make|change|use|turn|switch|give me|apply|put|choose|pick|select|to|as|a|an|the|my|mine|own|saved|generated|created|uploaded|custom|wallpaper|please|one|that|this|i|me|you|your|yours)\b/gi,
+			" ",
+		)
+		.replace(/\s+/g, " ")
+		.trim();
+	return cleaned.length >= 2 ? cleaned : null;
+}
+
+function extractUserCatalogReference(
+	text: string,
+	explicitCatalog: string | null,
+): string | null {
+	if (explicitCatalog?.trim()) return explicitCatalog.trim();
+	const quoted = text.match(/["“']([^"”']{2,})["”']/);
+	if (quoted?.[1]?.trim()) return quoted[1].trim();
+	if (!USER_CATALOG_REFERENCE_RE.test(text)) return null;
+	return cleanUserCatalogReference(text);
+}
+
 /**
  * Resolve the user's request into a single plan. Returns null when the message
  * isn't an actionable background request (so the action stays un-triggered).
@@ -368,6 +394,24 @@ export function inferBackgroundPlan(
 			catalogId,
 			catalogLabel: meta?.label ?? catalogId,
 		};
+	}
+	if (
+		(explicitCatalog || !wantsFreshGenerate) &&
+		!hasImageAttachment &&
+		(explicitCatalog || !isUploadIntent(trimmed))
+	) {
+		const userCatalogReference = extractUserCatalogReference(
+			trimmed,
+			explicitCatalog,
+		);
+		if (userCatalogReference) {
+			return {
+				op: "set",
+				mode: "catalog",
+				catalogId: userCatalogReference,
+				catalogLabel: userCatalogReference,
+			};
+		}
 	}
 
 	// "I want to upload a background" with no usable attachment → send the user to

--- a/plugins/plugin-app-control/src/actions/background.ts
+++ b/plugins/plugin-app-control/src/actions/background.ts
@@ -395,27 +395,6 @@ export function inferBackgroundPlan(
 			catalogLabel: meta?.label ?? catalogId,
 		};
 	}
-	if (
-		!wantsFreshGenerate &&
-		!explicitImage &&
-		!explicitPrompt &&
-		!hasImageAttachment &&
-		(explicitCatalog || !isUploadIntent(trimmed))
-	) {
-		const userCatalogReference = extractUserCatalogReference(
-			trimmed,
-			explicitCatalog,
-		);
-		if (userCatalogReference) {
-			return {
-				op: "set",
-				mode: "catalog",
-				catalogId: userCatalogReference,
-				catalogLabel: userCatalogReference,
-			};
-		}
-	}
-
 	// "I want to upload a background" with no usable attachment → send the user to
 	// the /background view (upload lives there), not a dead end. Only when the
 	// message is about uploading and carries no image attachment/URL to apply.
@@ -520,6 +499,27 @@ export function inferBackgroundPlan(
 		SET_RE.test(trimmed)
 	) {
 		return null;
+	}
+
+	if (
+		!wantsFreshGenerate &&
+		!explicitImage &&
+		!explicitPrompt &&
+		!hasImageAttachment &&
+		(explicitCatalog || !isUploadIntent(trimmed))
+	) {
+		const userCatalogReference = extractUserCatalogReference(
+			trimmed,
+			explicitCatalog,
+		);
+		if (userCatalogReference) {
+			return {
+				op: "set",
+				mode: "catalog",
+				catalogId: userCatalogReference,
+				catalogLabel: userCatalogReference,
+			};
+		}
 	}
 
 	// A described background to generate.

--- a/plugins/plugin-app-control/src/actions/background.ts
+++ b/plugins/plugin-app-control/src/actions/background.ts
@@ -396,7 +396,9 @@ export function inferBackgroundPlan(
 		};
 	}
 	if (
-		(explicitCatalog || !wantsFreshGenerate) &&
+		!wantsFreshGenerate &&
+		!explicitImage &&
+		!explicitPrompt &&
 		!hasImageAttachment &&
 		(explicitCatalog || !isUploadIntent(trimmed))
 	) {


### PR DESCRIPTION
## Summary
- Let BACKGROUND fall through unknown catalog references to the renderer by sending the raw catalog reference as `catalogId`.
- Support explicit `catalog` options, quoted catalog names, and owner/user-library phrasing such as “use my sunset wallpaper”.
- Preserve curated catalog matching, upload handoff, color parsing, attachment application, and explicit generate precedence.

Fixes #14725.

## Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - BACKGROUND action payload fallback only; no rendered UI code changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - BACKGROUND action payload fallback only; no rendered UI code changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no browser/mobile flow changed; focused action tests verify emitted background payloads for user catalog references.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend service was started; local test output in Verification shows the action-side payload path under test.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend/network flow changed; existing renderer hook resolves catalogId against user catalog ids/labels.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt/model behavior changed; this preserves raw user catalog references in the BACKGROUND action payload.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external domain artifact is produced; focused BACKGROUND action tests prove explicit catalog options, quoted names, and owner/user-library phrasing fall through as catalogId while curated catalog matching, upload handoff, color parsing, attachment application, and explicit generate precedence remain intact, and ordinary color requests such as “make my background teal” still resolve as color shader changes instead of user-catalog lookups.

## Verification
Rebased branch `fix/14725-user-background-catalog` onto current `origin/develop` (`63e5a4ca41`) and force-pushed commit `a91e8fd47d4`.

Fresh isolated worktree setup/repair used:

```bash
bun install --ignore-scripts
bun packages/scripts/ensure-workspace-symlinks.mjs
node packages/shared/scripts/generate-keywords.mjs --target ts
bun run --cwd packages/contracts build
bun run --cwd packages/cloud/routing build
bun run --cwd packages/core build
```

Focused verification on the rebased branch:

```bash
bun run --cwd plugins/plugin-app-control test src/actions/background.test.ts
bunx biome check plugins/plugin-app-control/src/actions/background.ts plugins/plugin-app-control/src/actions/background.test.ts
git diff --check origin/develop...HEAD
bun run audit:error-policy-ratchet
```

Observed locally:
- `background.test.ts`: 1 file, 54 tests passed.
- Targeted Biome check passed for the touched files.
- `git diff --check origin/develop...HEAD` passed.
- `audit:error-policy-ratchet` passed: 1 changed production source file, no new fallback slop.

## Known gaps / failures
- Full repo `bun run verify` was not run in this pass; the branch is scoped to BACKGROUND action payload inference and broadcast payloads.
- Rendered UI/video evidence: N/A for this action-side fallback; the existing renderer hook already resolves `catalogId` against user catalog ids/labels, and the focused action tests verify the emitted payloads.