### PR TITLE
fix(core): restore FORM-marker planner template assertions clobbered by #14883

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -218,8 +218,13 @@ describe("v5 planner loop skeleton", () => {
 		);
 	});
 
-	it("bans JSON/tool attempts in the base planner template", () => {
-		expect(plannerTemplate).toContain("function syntax, JSON/tool attempts");
+	it("allows structured chat markers while still banning arbitrary JSON/tool attempts", () => {
+		expect(plannerTemplate).toContain("arbitrary JSON/tool attempts");
+		expect(plannerTemplate).toContain(
+			"Structured chat markers are allowed in messageToUser",
+		);
+		expect(plannerTemplate).toContain("[FORM]\\n{json}\\n[/FORM]");
+		expect(plannerTemplate).toContain("The JSON inside [FORM] is form data");
 	});
 
 	it("forbids phantom in-flight investigative claims in messageToUser/REPLY (planner side)", () => {


### PR DESCRIPTION
## Summary

PR #14883 merged with a rebase that clobbered 90e8bc03f65 ("fix(core): allow FORM markers in evaluator replies"), landing a red test on develop: `planner-loop.test.ts` asserts `plannerTemplate` contains `"function syntax, JSON/tool attempts"`, but the template has read `"function syntax, arbitrary JSON/tool attempts"` since 90e8bc03f65. Repro on develop: `cd packages/core && bunx vitest run src/runtime/__tests__/planner-loop.test.ts -t "bans JSON/tool attempts"` → 1 failed.

This restores the 90e8bc03f65 assertions verbatim (arbitrary JSON/tool attempts banned; `[FORM]`/structured chat markers allowed in messageToUser). Test-only change; no production code touched.

## Evidence

- Before (develop @ 95a5fb41c5a): `1 failed | 60 skipped` on the targeted test.
- After: `bunx vitest run src/runtime/__tests__/planner-loop.test.ts` → **61 passed (61)**.
- Defect documented on #14883 (post-merge review comment).

Other rows N/A - test-only restore of previously-reviewed assertions; no runtime surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)