### PR TITLE
feat(console): wallet (SIWE/SIWS) sign-in on the login page

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.tsx
@@ -5,14 +5,12 @@
  * (Google / Discord / GitHub), plus the post-redirect OAuth `code` / `#token`
  * consumption + cookie sync.
  *
- * Wallet (SIWE / SIWS) sign-in is currently absent — it was dropped when the
- * old cloud-frontend was folded into `@elizaos/ui` (`4056e0e868`), where the
- * wallet libs weren't yet available. There is no `showWallets` flag; the
- * branch simply wasn't ported. The original blocker is gone (rainbowkit /
- * wagmi / @solana are now deps here, added for billing crypto top-up, and the
- * Steward backend serves `siwe`/`siws` on staging + prod), so re-enabling is a
- * bounded port of the wallet UI from `cloud-frontend@4056e0e868` gated on the
- * live `auth.getProviders()` flags — not a flag flip. Tracked for nubs's call.
+ * Wallet (SIWE / SIWS) sign-in is the bounded port of the wallet UI from
+ * `cloud-frontend@4056e0e868` (nubs's call, 2026-07-06): gated on the live
+ * `auth.getProviders()` flags, rendered by `wallet-buttons.tsx` inside the
+ * billing crypto top-up's `StewardWalletProviders` contexts. Both pieces are
+ * React.lazy + mounted only on wallet intent, so wagmi/rainbowkit/@solana stay
+ * out of the login bundle until a wallet button is clicked.
  */
 
 import {
@@ -28,7 +26,7 @@ import type {
 } from "@stwd/sdk";
 import { StewardAuth } from "@stwd/sdk";
 import { AlertCircle } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 import {
   Navigate,
   useLocation,
@@ -104,7 +102,26 @@ type Provider =
   | "google"
   | "discord"
   | "github"
-  | "twitter";
+  | "twitter"
+  | "ethereum"
+  | "solana";
+
+type WalletKind = "ethereum" | "solana";
+
+// Wallet libs (wagmi / rainbowkit / @solana) are heavy; both pieces load only
+// when the user expresses wallet intent (see `walletButtonsMounted`).
+const StewardWalletProviders = lazy(() =>
+  import("../../../billing/wallet/steward-wallet-providers").then((m) => ({
+    default: m.StewardWalletProviders,
+  })),
+);
+const WalletButtons = lazy(() =>
+  import("./wallet-buttons").then((m) => ({ default: m.WalletButtons })),
+);
+
+function hasAnyWalletProvider(providers: StewardProviders): boolean {
+  return Boolean(providers.siwe || providers.siws);
+}
 
 const DEFAULT_PROVIDERS: StewardProviders = {
   passkey: true,
@@ -250,6 +267,12 @@ export default function StewardLoginSection() {
   const [step, setStep] = useState<AuthStep>("idle");
   const [loading, setLoading] = useState<Provider | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Wallet libs mount only on intent: the first wallet-button click renders
+  // the (lazy) providers + buttons and auto-starts that wallet's flow.
+  const [walletButtonsMounted, setWalletButtonsMounted] = useState(false);
+  const [autoStartWallet, setAutoStartWallet] = useState<WalletKind | null>(
+    null,
+  );
   const [callbackError, setCallbackError] = useState<string | null>(null);
   const [redirectTo, setRedirectTo] = useState<string | null>(null);
   // Detected once, synchronously, BEFORE the callback-consuming effect below
@@ -271,6 +294,7 @@ export default function StewardLoginSection() {
   const hasOAuthProviders = Boolean(
     providers.google || providers.discord || providers.github,
   );
+  const showWallets = hasAnyWalletProvider(providers);
 
   useEffect(() => {
     if (PLAYWRIGHT_TEST_AUTH_ENABLED) {
@@ -552,6 +576,14 @@ export default function StewardLoginSection() {
       oauthOrigin,
       { stewardApiUrl, stewardTenantId: STEWARD_TENANT_ID, codeChallenge },
     );
+  }
+
+  // First wallet click: mount the lazy wallet stack and remember which chain
+  // to auto-start once it's up, so the user doesn't have to click twice.
+  function handleWalletIntent(kind: WalletKind) {
+    setError(null);
+    setWalletButtonsMounted(true);
+    setAutoStartWallet(kind);
   }
 
   if (redirectTo) {
@@ -843,6 +875,83 @@ export default function StewardLoginSection() {
             </Button>
           )}
         </div>
+      )}
+
+      {showWallets && (
+        <>
+          <div className="flex items-center gap-3">
+            <div className="h-px flex-1 bg-border" />
+            <span className="text-xs text-muted">
+              {t("cloud.login.orSignInWallet", {
+                defaultValue: "or sign in with a wallet",
+              })}
+            </span>
+            <div className="h-px flex-1 bg-border" />
+          </div>
+
+          {walletButtonsMounted ? (
+            <Suspense
+              fallback={
+                <div className="flex min-h-touch items-center justify-center py-2.5">
+                  <Spinner />
+                </div>
+              }
+            >
+              <StewardWalletProviders>
+                <WalletButtons
+                  auth={auth}
+                  autoStart={autoStartWallet}
+                  disabled={isLoading}
+                  loadingProvider={
+                    loading === "ethereum" || loading === "solana"
+                      ? (loading as WalletKind)
+                      : null
+                  }
+                  onAutoStartHandled={() => setAutoStartWallet(null)}
+                  onLoadingChange={(kind) => setLoading(kind)}
+                  onSuccess={(result) =>
+                    handleSuccess(result.token, result.refreshToken)
+                  }
+                  onError={(walletError) => {
+                    setError(
+                      walletError.message ||
+                        t("cloud.login.error.walletFailed", {
+                          defaultValue: "Wallet sign-in failed",
+                        }),
+                    );
+                  }}
+                />
+              </StewardWalletProviders>
+            </Suspense>
+          ) : (
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              {providers.siwe && (
+                <Button
+                  variant="ghost"
+                  type="button"
+                  onClick={() => handleWalletIntent("ethereum")}
+                  disabled={isLoading}
+                  className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+                >
+                  {t("cloud.login.wallet.evm", { defaultValue: "EVM wallet" })}
+                </Button>
+              )}
+              {providers.siws && (
+                <Button
+                  variant="ghost"
+                  type="button"
+                  onClick={() => handleWalletIntent("solana")}
+                  disabled={isLoading}
+                  className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+                >
+                  {t("cloud.login.wallet.solana", {
+                    defaultValue: "Solana wallet",
+                  })}
+                </Button>
+              )}
+            </div>
+          )}
+        </>
       )}
 
       {error && (

--- a/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/steward-login-section.wallet.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+
+/**
+ * Wallet (SIWE / SIWS) sign-in port — gating tests.
+ *
+ * The wallet branch renders ONLY when the live `auth.getProviders()` flags
+ * serve `siwe`/`siws` (the bounded port from `cloud-frontend@4056e0e868`).
+ * These tests pin the gate in both directions:
+ *  - flags on  → the "or sign in with a wallet" divider + per-chain intent
+ *    buttons render (EVM for `siwe`, Solana for `siws`), WITHOUT loading the
+ *    wallet libs (they lazy-mount on click).
+ *  - flags off → no wallet UI at all (the pre-port behavior).
+ */
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const providerFlags = vi.hoisted(() => ({ siwe: false, siws: false }));
+
+vi.mock("../../lib/steward-session", () => ({
+  hasStewardOAuthCallbackInUrl: () => false,
+  consumeStewardCodeFromQuery: () => null,
+  consumeStewardTokensFromHash: () => null,
+  exchangeStewardCodeViaApi: () => Promise.resolve({}),
+  refreshStewardSessionViaCookie: () => Promise.resolve({ ok: true as const }),
+  syncStewardSessionCookie: () => Promise.resolve(),
+}));
+
+vi.mock("@stwd/sdk", () => ({
+  StewardAuth: class {
+    getSession() {
+      return null;
+    }
+    getProviders() {
+      return Promise.resolve({
+        passkey: true,
+        email: true,
+        siwe: providerFlags.siwe,
+        siws: providerFlags.siws,
+        google: true,
+        discord: false,
+        github: false,
+        twitter: false,
+        oauth: ["google"],
+      });
+    }
+    refreshSession() {
+      return Promise.resolve(null);
+    }
+  },
+}));
+
+vi.mock("../../../shell/steward-url", () => ({
+  resolveBrowserStewardApiUrl: () => "https://api.example.test",
+}));
+
+vi.mock("../../../shell/steward-config", () => ({
+  configuredStewardTenantId: () => "elizacloud",
+  DEFAULT_STEWARD_TENANT_ID: "elizacloud",
+}));
+
+vi.mock("../../../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (_key: string, opts?: { defaultValue?: string }) =>
+    opts?.defaultValue ?? _key,
+}));
+
+vi.mock("../../lib/steward-oauth-url", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../lib/steward-oauth-url")
+  >("../../lib/steward-oauth-url");
+  return {
+    ...actual,
+    consumeStewardPkceVerifier: () => undefined,
+    buildStewardOAuthRedirectUri: () => "https://app.example.test/login",
+  };
+});
+
+vi.mock("../../lib/login-return-to", () => ({
+  resolveLoginReturnTo: () => "/dashboard",
+  consumePendingOAuthReturnTo: () => null,
+  storePendingOAuthReturnTo: () => undefined,
+}));
+
+// The section module-caches the providers fetch (`cachedStewardProviders`),
+// so each test must import a FRESH module instance or the first test's flags
+// leak into the rest.
+async function renderSection() {
+  vi.resetModules();
+  const { default: StewardLoginSection } = await import(
+    "./steward-login-section"
+  );
+  return render(
+    <MemoryRouter initialEntries={["/login"]}>
+      <StewardLoginSection />
+    </MemoryRouter>,
+  );
+}
+
+describe("StewardLoginSection — wallet sign-in gating (SIWE/SIWS port)", () => {
+  beforeEach(() => {
+    providerFlags.siwe = false;
+    providerFlags.siws = false;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("renders the wallet divider + both chain intent buttons when siwe AND siws are served", async () => {
+    providerFlags.siwe = true;
+    providerFlags.siws = true;
+
+    await renderSection();
+
+    await waitFor(() =>
+      expect(screen.getByText("or sign in with a wallet")).toBeTruthy(),
+    );
+    expect(screen.getByRole("button", { name: /EVM wallet/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Solana wallet/i })).toBeTruthy();
+  });
+
+  it("renders only the served chain's button (siwe only → EVM, no Solana)", async () => {
+    providerFlags.siwe = true;
+
+    await renderSection();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /EVM wallet/i })).toBeTruthy(),
+    );
+    expect(screen.queryByRole("button", { name: /Solana wallet/i })).toBeNull();
+  });
+
+  it("renders NO wallet UI when neither siwe nor siws is served", async () => {
+    await renderSection();
+
+    // Wait for the providers fetch to settle (Google renders from the mock).
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Google/i })).toBeTruthy(),
+    );
+    expect(screen.queryByText("or sign in with a wallet")).toBeNull();
+    expect(screen.queryByRole("button", { name: /EVM wallet/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Solana wallet/i })).toBeNull();
+  });
+});

--- a/packages/ui/src/cloud/public-pages/pages/login/wallet-buttons.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/wallet-buttons.tsx
@@ -1,0 +1,466 @@
+/**
+ * Native Ethereum + Solana sign-in buttons for the Steward login section.
+ *
+ * Bounded port of `cloud-frontend@4056e0e868`'s wallet-buttons (#the wallet
+ * branch dropped in the cloud-frontend → @elizaos/ui fold). Changes from the
+ * original: i18n comes from CloudI18nProvider, and the @web3icons brand marks
+ * are dropped for text-only buttons (the console is black-and-white; color is
+ * reserved for meaning).
+ *
+ * Click flow:
+ *   1. If not connected, open the wallet connect modal (native EIP-1193 /
+ *      injected connector preferred over the RainbowKit QR modal).
+ *   2. Once connected, auto-trigger the SIWE/SIWS signature.
+ *   3. Call onSuccess(result) or onError(err).
+ *
+ * Must render inside `StewardWalletProviders` (wagmi + RainbowKit + Solana
+ * adapter contexts — shared with the billing crypto top-up).
+ */
+
+import { useConnectModal } from "@rainbow-me/rainbowkit";
+import { useWallet } from "@solana/wallet-adapter-react";
+import { useWalletModal } from "@solana/wallet-adapter-react-ui";
+import type {
+  StewardAuth,
+  StewardAuthResult,
+  StewardMfaRequiredResult,
+} from "@stwd/sdk";
+import { useCallback, useEffect, useRef } from "react";
+import { type Connector, useAccount, useConnect, useSignMessage } from "wagmi";
+import { useCloudT } from "../../../shell/CloudI18nProvider";
+
+type HexAddress = `0x${string}`;
+
+interface Eip1193Provider {
+  isPhantom?: boolean;
+  request(args: {
+    method: "eth_accounts" | "eth_requestAccounts";
+  }): Promise<readonly string[] | null>;
+  request(args: {
+    method: "personal_sign";
+    params: readonly [`0x${string}`, HexAddress];
+  }): Promise<string>;
+}
+
+function getWindowEthereumProvider(): Eip1193Provider | null {
+  if (typeof window === "undefined") return null;
+  const ethereum = (window as Window & { ethereum?: Eip1193Provider }).ethereum;
+  if (!ethereum || typeof ethereum.request !== "function") return null;
+  if (ethereum.isPhantom === true) return null;
+  return ethereum;
+}
+
+function isHexAddress(value: string | undefined): value is HexAddress {
+  return /^0x[a-fA-F0-9]{40}$/.test(value ?? "");
+}
+
+// Wallet sign-in returns `StewardAuthResult | StewardMfaRequiredResult`.
+// There is no MFA-continuation UI in this login surface, so narrow on the
+// `mfaRequired` discriminant and surface a clear error instead of forwarding
+// an MFA challenge to onSuccess as if it carried tokens.
+function requireCompletedAuth(
+  result: StewardAuthResult | StewardMfaRequiredResult,
+): StewardAuthResult {
+  if ("mfaRequired" in result) {
+    throw new Error("MFA required — not yet supported in this client.");
+  }
+  return result;
+}
+
+async function requestEip1193Account(
+  provider: Eip1193Provider,
+): Promise<HexAddress | null> {
+  const existingAccounts = await provider.request({ method: "eth_accounts" });
+  const [existingAccount] = existingAccounts ?? [];
+  if (isHexAddress(existingAccount)) return existingAccount;
+
+  const requestedAccounts = await provider.request({
+    method: "eth_requestAccounts",
+  });
+  const [requestedAccount] = requestedAccounts ?? [];
+  return isHexAddress(requestedAccount) ? requestedAccount : null;
+}
+
+function stringToHex(value: string): `0x${string}` {
+  let hex = "";
+  for (const byte of new TextEncoder().encode(value)) {
+    hex += byte.toString(16).padStart(2, "0");
+  }
+  return `0x${hex}`;
+}
+
+async function personalSign(
+  provider: Eip1193Provider,
+  address: HexAddress,
+  message: string,
+): Promise<string> {
+  const signature = await provider.request({
+    method: "personal_sign",
+    params: [stringToHex(message), address],
+  });
+  if (!signature.startsWith("0x")) {
+    throw new Error("Wallet returned an invalid Ethereum signature.");
+  }
+  return signature;
+}
+
+// Phantom injects itself as an Ethereum provider but must never be used for
+// SIWE — it is Solana-first and the user's intent for SIWE is a real EVM wallet.
+// We mirror the previous EIP-1193 isPhantom check, but against the connector's
+// underlying provider so the wagmi store stays the source of truth.
+async function isPhantomConnector(connector: Connector): Promise<boolean> {
+  const id = connector.id.toLowerCase();
+  const name = (connector.name ?? "").toLowerCase();
+  if (id.includes("phantom") || name.includes("phantom")) return true;
+  try {
+    const provider = (await connector.getProvider()) as unknown;
+    if (provider !== null && typeof provider === "object") {
+      if (Reflect.get(provider, "isPhantom") === true) return true;
+    }
+  } catch {
+    // If a connector can't surface its provider yet, treat it as non-Phantom
+    // and let downstream connect() surface any real failure.
+  }
+  return false;
+}
+
+// Pick the best EVM connector that is NOT Phantom. Prefer an "injected"-style
+// connector (MetaMask, generic injected, Coinbase, etc.) over WalletConnect so
+// users with a wallet extension get the native popup instead of a QR modal.
+async function pickInjectedConnector(
+  connectors: readonly Connector[],
+): Promise<Connector | null> {
+  const eligible: Connector[] = [];
+  for (const connector of connectors) {
+    if (await isPhantomConnector(connector)) continue;
+    eligible.push(connector);
+  }
+  if (eligible.length === 0) return null;
+
+  // Prefer injected-type connectors over walletConnect; ordering within
+  // `connectors` already reflects RainbowKit's wallet detection priority.
+  const injected = eligible.find((c) => {
+    const type = c.type.toLowerCase();
+    const id = c.id.toLowerCase();
+    return (
+      type === "injected" ||
+      id === "metamask" ||
+      id === "metaMaskSDK".toLowerCase() ||
+      id === "coinbasewallet" ||
+      id === "coinbasewalletsdk"
+    );
+  });
+  return injected ?? eligible[0];
+}
+
+export function WalletButtons({
+  autoStart,
+  auth,
+  disabled,
+  onAutoStartHandled,
+  onSuccess,
+  onError,
+  onLoadingChange,
+  loadingProvider,
+}: {
+  autoStart?: "ethereum" | "solana" | null;
+  auth: StewardAuth;
+  disabled: boolean;
+  onAutoStartHandled?: () => void;
+  onSuccess: (result: StewardAuthResult) => void | Promise<void>;
+  onError: (error: Error, kind: "ethereum" | "solana") => void;
+  onLoadingChange: (kind: "ethereum" | "solana" | null) => void;
+  loadingProvider: "ethereum" | "solana" | null;
+}) {
+  return (
+    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+      <EthereumButton
+        autoStart={autoStart === "ethereum"}
+        auth={auth}
+        disabled={disabled}
+        onAutoStartHandled={onAutoStartHandled}
+        loading={loadingProvider === "ethereum"}
+        onSuccess={onSuccess}
+        onError={(err) => onError(err, "ethereum")}
+        onLoadingChange={(l) => onLoadingChange(l ? "ethereum" : null)}
+      />
+      <SolanaButton
+        autoStart={autoStart === "solana"}
+        auth={auth}
+        disabled={disabled}
+        onAutoStartHandled={onAutoStartHandled}
+        loading={loadingProvider === "solana"}
+        onSuccess={onSuccess}
+        onError={(err) => onError(err, "solana")}
+        onLoadingChange={(l) => onLoadingChange(l ? "solana" : null)}
+      />
+    </div>
+  );
+}
+
+// ── Ethereum ────────────────────────────────────────────────────────────────
+
+function EthereumButton({
+  autoStart,
+  auth,
+  disabled,
+  loading,
+  onAutoStartHandled,
+  onSuccess,
+  onError,
+  onLoadingChange,
+}: {
+  autoStart: boolean;
+  auth: StewardAuth;
+  disabled: boolean;
+  loading: boolean;
+  onAutoStartHandled?: () => void;
+  onSuccess: (result: StewardAuthResult) => void | Promise<void>;
+  onError: (err: Error) => void;
+  onLoadingChange: (loading: boolean) => void;
+}) {
+  const t = useCloudT();
+  const { address, isConnected } = useAccount();
+  const { signMessageAsync } = useSignMessage();
+  const { connectAsync, connectors } = useConnect();
+  const { openConnectModal } = useConnectModal();
+  // We start a sign flow either from the click (if already connected) or after
+  // the user connects via the modal. This ref tracks the "we're waiting for
+  // connection to trigger SIWE" intent.
+  const pendingSignRef = useRef(false);
+
+  const signWith = useCallback(
+    async (
+      addr: HexAddress,
+      signMessage: (message: string) => Promise<string>,
+    ) => {
+      onLoadingChange(true);
+      try {
+        const result = requireCompletedAuth(
+          await auth.signInWithSIWE(addr, signMessage),
+        );
+        await onSuccess(result);
+      } catch (e) {
+        const err = e instanceof Error ? e : new Error(String(e));
+        onError(err);
+      } finally {
+        onLoadingChange(false);
+      }
+    },
+    [auth, onSuccess, onError, onLoadingChange],
+  );
+
+  const sign = useCallback(
+    async (addr: HexAddress) => {
+      await signWith(addr, async (message: string) => {
+        return await signMessageAsync({ message });
+      });
+    },
+    [signMessageAsync, signWith],
+  );
+
+  const signWithEip1193 = useCallback(
+    async (provider: Eip1193Provider, addr: HexAddress) => {
+      await signWith(addr, async (message: string) => {
+        return await personalSign(provider, addr, message);
+      });
+    },
+    [signWith],
+  );
+
+  // If click triggered a connect modal, once connection lands, auto-sign.
+  useEffect(() => {
+    if (pendingSignRef.current && isConnected && address) {
+      pendingSignRef.current = false;
+      void sign(address);
+    }
+  }, [isConnected, address, sign]);
+
+  const connectAndSign = useCallback(async () => {
+    onLoadingChange(true);
+    try {
+      const provider = getWindowEthereumProvider();
+      if (provider) {
+        const account = await requestEip1193Account(provider);
+        if (account) {
+          await signWithEip1193(provider, account);
+          return;
+        }
+      }
+
+      const connector = await pickInjectedConnector(connectors);
+      if (!connector) {
+        // No injected connector available — fall through to the RainbowKit
+        // modal (WalletConnect QR etc.).
+        pendingSignRef.current = true;
+        openConnectModal?.();
+        return;
+      }
+      const { accounts } = await connectAsync({ connector });
+      const [account] = accounts;
+      if (!account) {
+        throw new Error(
+          t("cloud.login.wallet.error.noAccount", {
+            defaultValue: "No Ethereum account returned by wallet.",
+          }),
+        );
+      }
+      await sign(account);
+    } catch (e) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      onError(err);
+    } finally {
+      onLoadingChange(false);
+    }
+  }, [
+    connectAsync,
+    connectors,
+    openConnectModal,
+    onError,
+    onLoadingChange,
+    sign,
+    signWithEip1193,
+    t,
+  ]);
+
+  const handleClick = useCallback(() => {
+    if (disabled || loading) return;
+    if (isConnected && address) {
+      void sign(address);
+      return;
+    }
+    void connectAndSign();
+  }, [disabled, loading, isConnected, address, sign, connectAndSign]);
+
+  const autoStartedRef = useRef(false);
+  useEffect(() => {
+    if (!autoStart || autoStartedRef.current || disabled || loading) return;
+    autoStartedRef.current = true;
+    onAutoStartHandled?.();
+    handleClick();
+  }, [autoStart, disabled, handleClick, loading, onAutoStartHandled]);
+
+  // If the user closes the modal without connecting, we don't have a clean
+  // signal from RainbowKit; the next effect-tick just leaves pendingSignRef
+  // set until the next connect. That's fine — worst case is a stale flag
+  // that fires on a later successful connect.
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={disabled}
+      className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+    >
+      {loading && <Spinner />}
+      {t("cloud.login.wallet.evm", { defaultValue: "EVM wallet" })}
+    </button>
+  );
+}
+
+// ── Solana ──────────────────────────────────────────────────────────────────
+
+function SolanaButton({
+  autoStart,
+  auth,
+  disabled,
+  loading,
+  onAutoStartHandled,
+  onSuccess,
+  onError,
+  onLoadingChange,
+}: {
+  autoStart: boolean;
+  auth: StewardAuth;
+  disabled: boolean;
+  loading: boolean;
+  onAutoStartHandled?: () => void;
+  onSuccess: (result: StewardAuthResult) => void | Promise<void>;
+  onError: (err: Error) => void;
+  onLoadingChange: (loading: boolean) => void;
+}) {
+  const t = useCloudT();
+  const wallet = useWallet();
+  const { setVisible } = useWalletModal();
+  const pendingSignRef = useRef(false);
+
+  const sign = useCallback(async () => {
+    if (!wallet.publicKey || !wallet.signMessage) {
+      onError(
+        new Error(
+          t("cloud.login.wallet.error.notSupported", {
+            defaultValue:
+              "Connected Solana wallet does not support message signing.",
+          }),
+        ),
+      );
+      return;
+    }
+    onLoadingChange(true);
+    try {
+      const publicKey = wallet.publicKey.toBase58();
+      const signMessage = wallet.signMessage;
+      const result = requireCompletedAuth(
+        await auth.signInWithSolana(publicKey, async (msg: Uint8Array) => {
+          const out = await signMessage(msg);
+          if (!out)
+            throw new Error(
+              t("cloud.login.wallet.error.emptySignature", {
+                defaultValue: "Wallet returned an empty signature.",
+              }),
+            );
+          return out;
+        }),
+      );
+      await onSuccess(result);
+    } catch (e) {
+      const err = e instanceof Error ? e : new Error(String(e));
+      onError(err);
+    } finally {
+      onLoadingChange(false);
+    }
+  }, [auth, wallet, onSuccess, onError, onLoadingChange, t]);
+
+  useEffect(() => {
+    if (pendingSignRef.current && wallet.connected && wallet.publicKey) {
+      pendingSignRef.current = false;
+      void sign();
+    }
+  }, [wallet.connected, wallet.publicKey, sign]);
+
+  const handleClick = useCallback(() => {
+    if (disabled || loading) return;
+    if (wallet.connected && wallet.publicKey) {
+      void sign();
+      return;
+    }
+    pendingSignRef.current = true;
+    setVisible(true);
+  }, [disabled, loading, wallet.connected, wallet.publicKey, sign, setVisible]);
+
+  const autoStartedRef = useRef(false);
+  useEffect(() => {
+    if (!autoStart || autoStartedRef.current || disabled || loading) return;
+    autoStartedRef.current = true;
+    onAutoStartHandled?.();
+    handleClick();
+  }, [autoStart, disabled, handleClick, loading, onAutoStartHandled]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={disabled}
+      className="flex min-h-touch items-center justify-center gap-2 rounded-md border border-border-strong bg-bg-elevated px-4 py-2.5 text-sm font-semibold text-txt transition-[background-color,border-color,transform] hover:border-border-hover hover:bg-bg-hover active:scale-[0.99] disabled:pointer-events-none disabled:opacity-50"
+    >
+      {loading && <Spinner />}
+      {t("cloud.login.wallet.solana", { defaultValue: "Solana wallet" })}
+    </button>
+  );
+}
+
+function Spinner() {
+  return (
+    <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent opacity-70 motion-reduce:animate-none" />
+  );
+}

--- a/packages/ui/src/cloud/public-pages/pages/login/wallet-buttons.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/wallet-buttons.tsx
@@ -118,8 +118,10 @@ async function isPhantomConnector(connector: Connector): Promise<boolean> {
       if (Reflect.get(provider, "isPhantom") === true) return true;
     }
   } catch {
-    // If a connector can't surface its provider yet, treat it as non-Phantom
-    // and let downstream connect() surface any real failure.
+    // error-policy:J6 best-effort provider probe. A connector that can't
+    // surface its provider yet is treated as non-Phantom; the real failure (if
+    // any) surfaces at the downstream connect() the caller runs regardless.
+    return false;
   }
   return false;
 }


### PR DESCRIPTION
nubs GO'd re-enabling wallet sign-in. This is the **bounded port of `cloud-frontend@4056e0e868`'s wallet UI** the login section's header comment prescribed — gated on the live `auth.getProviders()` flags (Steward serves `siwe`/`siws` on staging + prod), not a flag flip.

- **wallet-buttons.tsx**: EVM (SIWE — injected/EIP-1193 preferred, RainbowKit modal fallback, Phantom excluded from the EVM path) + Solana (SIWS via wallet-adapter). `auth.signInWithSIWE`/`signInWithSolana`; the MFA-required discriminant surfaces as an error (no MFA UI on this surface). Text-only buttons matching the section's themed style (no `@web3icons` dep — console is b&w).
- **Section wiring**: divider + per-chain intent buttons; the wallet stack (`StewardWalletProviders` shared with billing crypto top-up + `WalletButtons`) is **React.lazy AND mounted only on first wallet click** → wagmi/rainbowkit/@solana stay out of the login bundle until intent (verified on the built bundle: `signInWithSIWE` = 0 hits in the entry chunk; wallet code in its own lazy chunks). Clicked chain auto-starts after mount. Success reuses `handleSuccess` (persist + cookie sync + navigate).
- **Tests**: wallet gating pinned both ways (both flags / one flag / neither) with fresh module import per test (the section module-caches the providers fetch). **6/6 login tests green**, typecheck clean, full `build:web` + chunk-safety gate green.

**Post-merge verify**: staging deploy → real wallet sign-in by nubs (agents can't sign with his wallet — that's the honest E2E boundary).

https://claude.ai/code/session_01CpnRyFUuGvzz61SsrnC3Sd