### PR TITLE
fix(app): harden live visual QA evidence

### DIFF
--- a/packages/app/scripts/lib/visual-qa.mjs
+++ b/packages/app/scripts/lib/visual-qa.mjs
@@ -16,6 +16,9 @@
  * read) when it is not, so the analyzer is safe to call from any capture lane.
  */
 import { execFile } from "node:child_process";
+import { copyFile, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { promisify } from "node:util";
 import sharp from "sharp";
 
@@ -86,22 +89,69 @@ async function colorFractions(image) {
   };
 }
 
+function normalizeOcrText(stdout) {
+  const lines = stdout
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+  return lines.join("\n");
+}
+
+async function runTesseract(pngPath, { psm = "6", cwd } = {}) {
+  const { stdout } = await execFileAsync(
+    "tesseract",
+    [pngPath, "stdout", "--psm", psm],
+    { timeout: 60_000, maxBuffer: 8 * 1024 * 1024, cwd },
+  );
+  return normalizeOcrText(stdout);
+}
+
+/**
+ * Some macOS tesseract/leptonica builds fail to open screenshots from `/tmp`
+ * even when normal file APIs can read the PNG. Retrying from the caller's
+ * workspace keeps OCR useful for evidence bundles that live under `/tmp`.
+ */
+async function retryOcrFromWorkspaceCopy(pngPath) {
+  const cwd = process.cwd();
+  const workspaceRoot = cwd && !cwd.startsWith(tmpdir()) ? cwd : null;
+  if (!workspaceRoot) return null;
+  const tempDir = await mkdtemp(path.join(workspaceRoot, ".visual-qa-ocr-"));
+  try {
+    const copied = path.join(tempDir, "screenshot.png");
+    await copyFile(pngPath, copied);
+    return await runTesseract(path.relative(workspaceRoot, copied), {
+      psm: "11",
+      cwd: workspaceRoot,
+    });
+  } finally {
+    try {
+      await rm(tempDir, { recursive: true, force: true });
+    } catch {
+      // error-policy:J6 temporary OCR cleanup is best-effort; a failed delete
+      // should not turn a valid screenshot analysis into a false failure.
+    }
+  }
+}
+
 /** On-screen text via the tesseract CLI, or an explicit note when unavailable. */
 async function ocrText(pngPath) {
   try {
-    const { stdout } = await execFileAsync(
-      "tesseract",
-      [pngPath, "-", "--psm", "6"],
-      { timeout: 60_000, maxBuffer: 8 * 1024 * 1024 },
-    );
-    const lines = stdout
-      .split("\n")
-      .map((l) => l.trim())
-      .filter(Boolean);
-    return { text: lines.join("\n"), note: null };
+    return { text: await runTesseract(pngPath), note: null };
   } catch (err) {
-    // J3: OCR is an optional enrichment — report its absence explicitly rather
-    // than fabricate an empty transcript that would read as "no text on screen".
+    try {
+      const retryText = await retryOcrFromWorkspaceCopy(pngPath);
+      if (retryText !== null) {
+        return {
+          text: retryText,
+          note: "primary tesseract read failed; OCR succeeded from a workspace-local copy",
+        };
+      }
+    } catch {
+      // error-policy:J3 the explicit note below reports the primary OCR failure;
+      // retry failure does not fabricate text or hide the unavailable signal.
+    }
+    // error-policy:J3 OCR is optional enrichment; report absence explicitly
+    // rather than fabricate an empty transcript as "no text on screen".
     const note =
       err?.code === "ENOENT"
         ? "tesseract not installed"

--- a/packages/app/scripts/visual-qa-live.mjs
+++ b/packages/app/scripts/visual-qa-live.mjs
@@ -1,7 +1,4 @@
 #!/usr/bin/env node
-import { mkdirSync, writeFileSync } from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 /**
  * Live visual-QA sweep against a running dashboard dev server. Complements the
  * heavier `audit:app` (which prebuilds every plugin-view bundle and walks the
@@ -30,10 +27,16 @@ import { fileURLToPath } from "node:url";
  * Usage:
  *   node scripts/visual-qa-live.mjs --base http://127.0.0.1:2138 [--out DIR] [--strict]
  */
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
 import { analyzeScreenshot, changeMetric } from "./lib/visual-qa.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..", "..", "..");
+export const COMPOSER_PROBE_TEXT = "remind me to call the pharmacy before 5";
 
 // Mirrors the canonical Steward seed contract in
 // `test/ui-smoke/helpers/test-auth.ts` (STEWARD_SESSION_TOKEN_KEY + the
@@ -113,6 +116,7 @@ export function buildStateMatrix() {
         seed: "fresh",
         route: "/",
         focusComposer: true,
+        expectedComposerText: COMPOSER_PROBE_TEXT,
       });
     }
   }
@@ -165,6 +169,34 @@ export function seedDriftOffenders(deltas, { minChangedFraction = 0.02 } = {}) {
     .map((d) => ({ viewport: d.viewport, changedFraction: d.changedFraction }));
 }
 
+export function evaluateCaptureReadiness({
+  state,
+  domText = "",
+  composerText = "",
+  minDomTextLength = 12,
+}) {
+  const checks = [];
+  let pass = true;
+  const check = (name, ok, detail) => {
+    checks.push({ name, ok: Boolean(ok), detail });
+    if (!ok) pass = false;
+  };
+  const normalizedDomText = domText.replace(/\s+/g, " ").trim();
+  check(
+    "dom:not_blank",
+    normalizedDomText.length >= minDomTextLength,
+    `visible DOM text length ${normalizedDomText.length} (min ${minDomTextLength})`,
+  );
+  if (state.expectedComposerText) {
+    check(
+      "composer:typed_text_present",
+      composerText.includes(state.expectedComposerText),
+      `composer text ${composerText.includes(state.expectedComposerText) ? "contains" : "does not contain"} the probe`,
+    );
+  }
+  return { pass, checks };
+}
+
 async function focusAndType(page) {
   // Prefer the canonical chat composer; the generic fallback keeps the capture
   // meaningful on gates that render a plain input. No match fails the sweep —
@@ -176,8 +208,55 @@ async function focusAndType(page) {
         .locator('textarea, [contenteditable="true"], input[type="text"]')
         .first();
   await box.click({ timeout: 4000 });
-  await box.type("remind me to call the pharmacy before 5", { delay: 8 });
+  await box.type(COMPOSER_PROBE_TEXT, { delay: 8 });
   await page.waitForTimeout(600);
+}
+
+async function readVisibleText(page, stateId) {
+  try {
+    return (await page.locator("body").innerText({ timeout: 4000 }))
+      .replace(/\s+/g, " ")
+      .trim();
+  } catch (error) {
+    throw new Error(
+      `Failed to read visible DOM text for ${stateId}: ${error?.message ?? error}`,
+    );
+  }
+}
+
+async function readComposerText(page) {
+  const box = page
+    .locator('textarea, [contenteditable="true"], input[type="text"]')
+    .first();
+  return box.evaluate((el) =>
+    "value" in el ? String(el.value) : String(el.textContent ?? ""),
+  );
+}
+
+function gitValue(args) {
+  try {
+    return execFileSync("git", args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    // error-policy:J7 provenance enrichment must never kill a local visual pass;
+    // the report records null so reviewers can see metadata was unavailable.
+    return null;
+  }
+}
+
+function buildRunMeta({ base, outDir, strict, stateCount }) {
+  return {
+    createdAt: new Date().toISOString(),
+    base,
+    outDir,
+    strict,
+    stateCount,
+    commit: gitValue(["rev-parse", "HEAD"]),
+    branch: gitValue(["branch", "--show-current"]),
+  };
 }
 
 async function main() {
@@ -203,6 +282,12 @@ async function main() {
 
   const onboardedSeed = buildOnboardedSeed();
   const matrix = buildStateMatrix();
+  const meta = buildRunMeta({
+    base,
+    outDir,
+    strict,
+    stateCount: matrix.length,
+  });
   const browser = await chromium.launch();
   const reports = [];
 
@@ -240,14 +325,34 @@ async function main() {
             `Failed to load ${state.id} at ${targetUrl}: HTTP ${response?.status() ?? "unknown"}`,
           );
         }
-        await page
-          .waitForLoadState("networkidle", { timeout: 5000 })
-          // error-policy:J6 best-effort settle — SPAs holding long-poll/WS
-          // connections never reach networkidle; the fixed wait below is the
-          // real settle gate and the screenshot still fails loudly on its own.
-          .catch(() => {});
+        let networkIdle = "reached";
+        try {
+          await page.waitForLoadState("networkidle", { timeout: 5000 });
+        } catch (error) {
+          // error-policy:J4 a dev server without an API often keeps failed proxy
+          // requests noisy; screenshot validity is checked by DOM and image
+          // analysis below, so a timeout is recorded instead of hidden.
+          networkIdle = `timeout: ${String(error?.message ?? error).slice(0, 120)}`;
+        }
         await page.waitForTimeout(1500);
         if (state.focusComposer) await focusAndType(page);
+        const domText = await readVisibleText(page, state.id);
+        const composerText = state.focusComposer
+          ? await readComposerText(page)
+          : "";
+        const readiness = evaluateCaptureReadiness({
+          state,
+          domText,
+          composerText,
+        });
+        if (!readiness.pass) {
+          throw new Error(
+            `Invalid capture for ${state.id}: ${readiness.checks
+              .filter((c) => !c.ok)
+              .map((c) => `${c.name} (${c.detail})`)
+              .join(", ")}`,
+          );
+        }
 
         const file = path.join(outDir, `${state.id}.png`);
         await page.screenshot({ path: file });
@@ -260,10 +365,16 @@ async function main() {
           size: report.size,
           dominant_palette: report.dominant_palette,
           color_fractions: report.color_fractions,
+          visual_verdict: report.verdict,
+          visual_checks: report.checks,
+          network_idle: networkIdle,
+          dom_checks: readiness.checks,
+          dom_text: domText.slice(0, 240),
           ocr_text: (report.ocr_text || "")
             .replace(/\s+/g, " ")
             .trim()
             .slice(0, 240),
+          ocr_note: report.ocr_note,
         };
         reports.push(entry);
         const measured = entry.color_fractions?.blue_fraction;
@@ -304,7 +415,7 @@ async function main() {
   const verdict = aggregateVerdict(reports);
   writeFileSync(
     path.join(outDir, "report.json"),
-    JSON.stringify({ base, verdict, seedDeltas, reports }, null, 2),
+    JSON.stringify({ meta, verdict, seedDeltas, reports }, null, 2),
   );
   console.log(
     `\n${verdict.pass ? "PASS" : "FAIL"} — no-blue invariant (ceiling ${verdict.blueCeiling}); ${reports.length} states → ${outDir}/report.json`,

--- a/packages/app/scripts/visual-qa-live.test.mjs
+++ b/packages/app/scripts/visual-qa-live.test.mjs
@@ -11,6 +11,8 @@ import {
   buildCaptureUrl,
   buildOnboardedSeed,
   buildStateMatrix,
+  COMPOSER_PROBE_TEXT,
+  evaluateCaptureReadiness,
   FIRST_RUN_COMPLETE_KEY,
   STEWARD_SESSION_TOKEN_KEY,
   seedDriftOffenders,
@@ -119,5 +121,45 @@ describe("seedDriftOffenders", () => {
     expect(seedDriftOffenders([{ viewport: "desktop" }])).toEqual([
       { viewport: "desktop", changedFraction: undefined },
     ]);
+  });
+});
+
+describe("evaluateCaptureReadiness", () => {
+  it("passes for a nonblank state with visible DOM text", () => {
+    const v = evaluateCaptureReadiness({
+      state: { id: "desktop-shell" },
+      domText: "Backend Unreachable Try again",
+    });
+    expect(v.pass).toBe(true);
+  });
+
+  it("fails blank captures before color heuristics can hide them", () => {
+    const v = evaluateCaptureReadiness({
+      state: { id: "desktop-shell" },
+      domText: "   ",
+    });
+    expect(v.pass).toBe(false);
+    expect(v.checks.map((c) => c.name)).toContain("dom:not_blank");
+  });
+
+  it("requires the mobile composer probe to survive focus and typing", () => {
+    const state = {
+      id: "mobile-composer-focused",
+      expectedComposerText: COMPOSER_PROBE_TEXT,
+    };
+    expect(
+      evaluateCaptureReadiness({
+        state,
+        domText: "Sign in to Eliza Cloud",
+        composerText: COMPOSER_PROBE_TEXT,
+      }).pass,
+    ).toBe(true);
+    expect(
+      evaluateCaptureReadiness({
+        state,
+        domText: "Sign in to Eliza Cloud",
+        composerText: "",
+      }).pass,
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
Relates to #14818.

## Summary

This tightens the newly merged `packages/app audit:live` visual-QA sweep so it is useful as MVP evidence rather than just a screenshot collector:

- Adds commit/branch/run provenance to `report.json`.
- Fails captures that render blank DOM or lose the mobile composer probe text, with DOM text polling to avoid transient blank reads during app startup.
- Preserves analyzer verdict/checks and OCR notes per state.
- Makes OCR required-but-automated: use the system `tesseract` CLI when available, retry CLI OCR from a short-lived workspace-local copy for `/tmp` evidence bundles, then fall back to the repo's `tesseract.js` dependency with its language cache outside the worktree.
- Keeps the merged seed-drift and unmeasured-blue fail-closed gates.

## Testing

```text
node --check packages/app/scripts/lib/visual-qa.mjs && node --check packages/app/scripts/visual-qa-live.mjs

bunx @biomejs/biome check packages/app/scripts/visual-qa-live.mjs packages/app/scripts/visual-qa-live.test.mjs packages/app/scripts/lib/visual-qa.mjs packages/app/scripts/lib/visual-qa.test.ts
Checked 4 files in 77ms. No fixes applied.

bunx vitest run packages/app/scripts/visual-qa-live.test.mjs packages/app/scripts/lib/visual-qa.test.ts
Test Files  2 passed (2)
Tests       25 passed (25)

git diff --check origin/develop...HEAD

bun run audit:error-policy-ratchet --report
[error-policy-ratchet] base origin/develop (cccb464215); 0 changed production source file(s)
[error-policy-ratchet] no new fallback-slop in touched files
```

## Live Evidence

```text
bun run --cwd packages/app audit:live -- --base http://127.0.0.1:2151 --out /tmp/eliza-visual-qa-hardening-7d0472e --strict
PASS — no-blue invariant (ceiling 0.02); 7 states → /tmp/eliza-visual-qa-hardening-7d0472e/report.json
```

Report summary:

```json
{
  "commit": "7d0472ef6a0317a6a4d59232031cb0c03198504c",
  "verdict": { "pass": true, "offenders": [], "blueCeiling": 0.02 },
  "seedDeltas": [
    { "viewport": "desktop", "changedFraction": 0.0542 },
    { "viewport": "mobile", "changedFraction": 0.088 }
  ],
  "states": [
    { "id": "desktop-onboarding", "blue": 0, "orange": 0, "neutral": 1, "ocr_note": "tesseract CLI unavailable; OCR succeeded with tesseract.js", "ocr": "Sign in to Eliza Cloud > Ask me anything — or pick an option" },
    { "id": "desktop-shell", "blue": 0, "orange": 0.0259, "neutral": 0.9613, "ocr_note": "tesseract CLI unavailable; OCR succeeded with tesseract.js", "ocr": "Startup failed: Backend Unreachable Previously configured backend is unreachable. Check your connection or reset" },
    { "id": "desktop-chat", "blue": 0, "orange": 0.0259, "neutral": 0.9613, "ocr_note": "tesseract CLI unavailable; OCR succeeded with tesseract.js", "ocr": "Startup failed: Backend Unreachable Previously configured backend is unreachable. Check your connection or reset" },
    { "id": "mobile-onboarding", "blue": 0, "orange": 0, "neutral": 1, "ocr_note": "tesseract CLI unavailable; OCR succeeded with tesseract.js", "ocr": "Sign in to Eliza Cloud > Ask me anything — or pick an option" },
    { "id": "mobile-shell", "blue": 0, "orange": 0.0422, "neutral": 0.9347, "ocr_note": "tesseract CLI unavailable; OCR succeeded with tesseract.js", "ocr": "Startup failed: Backend Unreachable Previously configured backend is unreachable. Check your connection or reset" },
    { "id": "mobile-chat", "blue": 0, "orange": 0.0422, "neutral": 0.9347, "ocr_note": "tesseract CLI unavailable; OCR succeeded with tesseract.js", "ocr": "Startup failed: Backend Unreachable Previously configured backend is unreachable. Check your connection or reset" },
    { "id": "mobile-composer-focused", "blue": 0, "orange": 0, "neutral": 1, "ocr_note": "tesseract CLI unavailable; OCR succeeded with tesseract.js", "ocr": "Sign in to Eliza Cloud > remind me to call the pharmacy > before 5" }
  ]
}
```

Manual screenshot review: current artifacts under `/tmp/eliza-visual-qa-hardening-7d0472e/` were opened and reviewed. Desktop/mobile onboarding showed the Eliza Cloud sign-in gate; desktop/mobile shell and chat showed the designed Backend Unreachable state; mobile composer-focused showed the typed pharmacy reminder visible above the send affordance with no clipping.

Repo cleanliness check after the fallback run: no `eng.traineddata*` or `.visual-qa-ocr-*` files were left in the worktree.

## Evidence Matrix

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - this changes audit tooling only; no product UI surface changed.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - no product UI surface changed; generated locally by `audit:live` under `/tmp/eliza-visual-qa-hardening-7d0472e/` and manually reviewed; report summary above includes OCR + palette/readiness signals for every state.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - CLI audit/analyzer hardening; no user-facing interaction flow changed.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no backend code changed; the live run intentionally had no backend so the designed Backend Unreachable state was captured.
<!-- evidence-row:frontend-logs -->
- Frontend logs: N/A - no frontend runtime code changed; expected no-backend dev-server warnings only (`API server unavailable` for slash-command/custom-action catalog); the audit passed strict visual gates.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no agent/action/provider/prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - no persistent domain artifacts are produced by this tooling change.

## Known Gaps

Full `bun run verify` was not run for this narrow app-script change. Focused parser, formatter, unit, ratchet, and strict live visual evidence are included above.