### PR TITLE
fix(roles): close residual connector-owner and DM-pairing gaps (#14707/#14710/#14712 follow-up)

### DIFF
--- a/packages/agent/src/runtime/eliza-plugin-services.test.ts
+++ b/packages/agent/src/runtime/eliza-plugin-services.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Guards the eliza plugin's service registrations (#14710 residual): core
+ * PairingService must ship with the default agent, because the connectors'
+ * default DM policy is "pairing" and checkPairingAllowed fails CLOSED when the
+ * service is missing — an agent without it silently denies every DM and offers
+ * no pairing path.
+ *
+ * eliza-plugin.ts is read as TEXT (not imported) so vitest never eagerly
+ * resolves its transitive optional-plugin action imports — the same technique
+ * core-static-plugin-registrations.test.ts uses for eliza.ts.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+function servicesBlock(): string {
+  const source = readFileSync(path.join(here, "eliza-plugin.ts"), "utf8");
+  const match = source.match(/services:\s*\[([^\]]*)\]/);
+  if (!match) {
+    throw new Error("eliza-plugin.ts no longer declares a services array");
+  }
+  return match[1];
+}
+
+describe("createElizaPlugin service registrations", () => {
+  it("registers PairingService so the default 'pairing' DM policy is operable", () => {
+    expect(servicesBlock()).toContain("PairingService");
+  });
+
+  it("keeps OwnerBindingService registered ahead of connector pairing commands", () => {
+    expect(servicesBlock()).toContain("OwnerBindingService");
+  });
+});

--- a/packages/agent/src/runtime/eliza-plugin.ts
+++ b/packages/agent/src/runtime/eliza-plugin.ts
@@ -16,6 +16,7 @@ import {
   AgentEventService,
   logger,
   NotificationService,
+  PairingService,
   promoteSubactionsToActions,
 } from "@elizaos/core";
 import { compactConversationAction } from "../actions/compact-conversation.ts";
@@ -163,6 +164,10 @@ export function createElizaPlugin(config?: ElizaPluginConfig): Plugin {
       // commands. Registered here (before connector plugins start) so the
       // Discord/Telegram pairing services find it and register their commands.
       OwnerBindingService as ServiceClass,
+      // DM pairing-code allowlist backing the connectors' default dmPolicy
+      // "pairing". Without it registered, checkPairingAllowed fails CLOSED
+      // (#14710) and every non-whitelisted DM sender is denied.
+      PairingService as ServiceClass,
     ],
 
     init: async (_pluginConfig, runtime: IAgentRuntime) => {

--- a/packages/core/src/roles.resolution.test.ts
+++ b/packages/core/src/roles.resolution.test.ts
@@ -176,6 +176,60 @@ describe("resolveEntityRole — stored grants under a configured owner", () => {
 	});
 });
 
+describe("resolveEntityRole — stored OWNER grants and provenance (#14707 residual)", () => {
+	it("folds a sourceless legacy stored OWNER grant to GUEST even with no canonical owner configured", async () => {
+		// Worlds persisted before guild-owner grants carried provenance still
+		// hold OWNER grants the old Discord code wrote for every guild owner.
+		// Without a configured canonical owner these used to resolve to app
+		// OWNER — any guild owner hosting the bot inherited the deployment.
+		const runtime = makeRuntime();
+		const metadata: RolesWorldMetadata = {
+			roles: { [SENDER_ID]: "OWNER" },
+		};
+		expect(await resolveEntityRole(runtime, null, metadata, SENDER_ID)).toBe(
+			"GUEST",
+		);
+	});
+
+	it("folds a connector_admin-sourced stored OWNER grant to GUEST with no canonical owner configured", async () => {
+		const runtime = makeRuntime();
+		const metadata: RolesWorldMetadata = {
+			roles: { [SENDER_ID]: "OWNER" },
+			roleSources: { [SENDER_ID]: "connector_admin" },
+		};
+		expect(await resolveEntityRole(runtime, null, metadata, SENDER_ID)).toBe(
+			"GUEST",
+		);
+	});
+
+	it("honors a deliberate manual OWNER grant with no canonical owner configured", async () => {
+		const runtime = makeRuntime();
+		const metadata: RolesWorldMetadata = {
+			roles: { [SENDER_ID]: "OWNER" },
+			roleSources: { [SENDER_ID]: "manual" },
+		};
+		expect(await resolveEntityRole(runtime, null, metadata, SENDER_ID)).toBe(
+			"OWNER",
+		);
+	});
+
+	it("honors a manual OWNER grant made by the canonical owner (deliberate co-owner)", async () => {
+		// canModifyRole only lets an existing OWNER write an OWNER grant, so a
+		// manual OWNER grant is a deliberate co-owner appointment — resolution
+		// must not silently ignore what the role-management surface permits.
+		const runtime = makeRuntime({
+			settings: { ELIZA_ADMIN_ENTITY_ID: OWNER_ID },
+		});
+		const metadata: RolesWorldMetadata = {
+			roles: { [SENDER_ID]: "OWNER" },
+			roleSources: { [SENDER_ID]: "manual" },
+		};
+		expect(await resolveEntityRole(runtime, null, metadata, SENDER_ID)).toBe(
+			"OWNER",
+		);
+	});
+});
+
 describe("resolveEntityRole — connector-admin whitelist ceiling", () => {
 	const whitelistSettings = {
 		ELIZA_ADMIN_ENTITY_ID: OWNER_ID,

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -785,7 +785,14 @@ export async function resolveEntityRole(
 
 	if (explicitRole !== "GUEST") {
 		if (explicitRole === "OWNER") {
-			return hasConfiguredCanonicalOwner(runtime) ? "GUEST" : "OWNER";
+			// A stored OWNER grant is honored only when it was made deliberately
+			// through the role-management gate (source "manual", writable solely by
+			// an existing OWNER via canModifyRole). Connector-written and sourceless
+			// legacy grants fold to GUEST: worlds persisted before #14845 still
+			// carry OWNER grants the old Discord code wrote for every guild owner,
+			// and honoring them whenever no canonical owner is configured made any
+			// guild owner hosting the bot the app-level OWNER (#14707).
+			return explicitSource === "manual" ? "OWNER" : "GUEST";
 		}
 
 		if (explicitSource === "connector_admin") {

--- a/packages/core/src/services/pairing-integration.test.ts
+++ b/packages/core/src/services/pairing-integration.test.ts
@@ -9,10 +9,12 @@ import { ServiceType } from "../types/service";
 import { checkPairingAllowed } from "./pairing-integration";
 
 describe("checkPairingAllowed", () => {
-	it("denies when PairingService is unavailable", async () => {
+	it("denies when PairingService is unavailable and reports the misconfiguration", async () => {
+		const reportError = vi.fn();
 		const runtime = {
 			getService: vi.fn(() => null),
 			logger: { warn: vi.fn() },
+			reportError,
 		} as unknown as IAgentRuntime;
 
 		const result = await checkPairingAllowed(runtime, {
@@ -26,5 +28,8 @@ describe("checkPairingAllowed", () => {
 			idLabel: "userId",
 			replyMessage: "Access pairing is temporarily unavailable.",
 		});
+		// Systemic misconfiguration must reach the agent/owner, not just a log.
+		expect(reportError).toHaveBeenCalledTimes(1);
+		expect(reportError.mock.calls[0][0]).toBe("pairing-integration");
 	});
 });

--- a/packages/core/src/services/pairing-integration.ts
+++ b/packages/core/src/services/pairing-integration.ts
@@ -88,9 +88,18 @@ export async function checkPairingAllowed(
 
 	const pairingService = await getPairingService(runtime);
 	if (!pairingService) {
-		runtime.logger.warn(
-			{ src: "pairing-integration", channel },
-			"PairingService not available; denying pairing-gated sender",
+		// Fail CLOSED, and treat this as a systemic misconfiguration rather than
+		// a per-message event: callers only reach here because the channel's DM
+		// policy is "pairing", and the eliza plugin registers PairingService, so
+		// a missing service means a mis-wired host. reportError surfaces it to
+		// the agent (RECENT_ERRORS) and escalates to the owner on repetition —
+		// a logger.warn per denied DM never reaches anyone (#14710).
+		runtime.reportError(
+			"pairing-integration",
+			new Error(
+				"PairingService is not registered but the DM policy is 'pairing'; denying sender",
+			),
+			{ channel, senderId },
 		);
 		return {
 			allowed: false,

--- a/packages/core/src/types/memory.ts
+++ b/packages/core/src/types/memory.ts
@@ -257,6 +257,12 @@ export interface MessageMetadata {
 
 	telegram?: {
 		userId?: string | number;
+		/**
+		 * Stable platform id of the sender, mirroring `userId` — role
+		 * resolution's connector identity matching compares the `userId`/`id`
+		 * pair (#14711).
+		 */
+		id?: string | number;
 		chatId?: string | number;
 		messageId?: string;
 		threadId?: string | number;

--- a/plugins/plugin-discord/AGENTS.md
+++ b/plugins/plugin-discord/AGENTS.md
@@ -131,7 +131,7 @@ bun run --cwd plugins/plugin-discord clean       # rm dist + .turbo + generated 
 | `DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS` | No | `"false"` to reply without an @-mention (default: `true`) |
 | `DISCORD_DM_POLICY` | No | DM access policy: `open` / `allowlist` / `pairing` / `disabled` (default: `pairing`) |
 | `DISCORD_ALLOW_FROM` | No | Comma-separated Discord user IDs allowed under the `allowlist` DM policy |
-| `ELIZA_DISCORD_OWNER_USER_IDS_JSON` | No | JSON array of Discord user IDs that should alias to the canonical Eliza owner entity. Use only for the actual owner or deliberate owner aliases; Discord application team members are kept as separate entities and may be connector admins via `ELIZA_ROLES_CONNECTOR_ADMINS_JSON`. |
+| `ELIZA_DISCORD_OWNER_USER_IDS_JSON` | No | JSON array of Discord user IDs that should alias to the canonical Eliza owner entity. Use only for the actual owner or deliberate owner aliases; Discord application team members are kept as separate entities; accepted, non-read-only members are seeded as connector admins (pending invitees and `read_only` members get no standing), and more can be added via `ELIZA_ROLES_CONNECTOR_ADMINS_JSON`. |
 | `DISCORD_AUTO_REPLY` | No | `"true"` to auto-generate replies; default `false` (messages are ingested but not answered) |
 | `DISCORD_SYNC_PROFILE` | No | `"false"` to skip bot profile sync on startup (default: `true`) |
 | `DISCORD_IPC_DIR` | No | Override the IPC socket directory searched by `DiscordLocalService` when connecting to the Discord desktop app |

--- a/plugins/plugin-discord/CLAUDE.md
+++ b/plugins/plugin-discord/CLAUDE.md
@@ -131,7 +131,7 @@ bun run --cwd plugins/plugin-discord clean       # rm dist + .turbo + generated 
 | `DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS` | No | `"false"` to reply without an @-mention (default: `true`) |
 | `DISCORD_DM_POLICY` | No | DM access policy: `open` / `allowlist` / `pairing` / `disabled` (default: `pairing`) |
 | `DISCORD_ALLOW_FROM` | No | Comma-separated Discord user IDs allowed under the `allowlist` DM policy |
-| `ELIZA_DISCORD_OWNER_USER_IDS_JSON` | No | JSON array of Discord user IDs that should alias to the canonical Eliza owner entity. Use only for the actual owner or deliberate owner aliases; Discord application team members are kept as separate entities and may be connector admins via `ELIZA_ROLES_CONNECTOR_ADMINS_JSON`. |
+| `ELIZA_DISCORD_OWNER_USER_IDS_JSON` | No | JSON array of Discord user IDs that should alias to the canonical Eliza owner entity. Use only for the actual owner or deliberate owner aliases; Discord application team members are kept as separate entities; accepted, non-read-only members are seeded as connector admins (pending invitees and `read_only` members get no standing), and more can be added via `ELIZA_ROLES_CONNECTOR_ADMINS_JSON`. |
 | `DISCORD_AUTO_REPLY` | No | `"true"` to auto-generate replies; default `false` (messages are ingested but not answered) |
 | `DISCORD_SYNC_PROFILE` | No | `"false"` to skip bot profile sync on startup (default: `true`) |
 | `DISCORD_IPC_DIR` | No | Override the IPC socket directory searched by `DiscordLocalService` when connecting to the Discord desktop app |

--- a/plugins/plugin-discord/__tests__/dm-policy.test.ts
+++ b/plugins/plugin-discord/__tests__/dm-policy.test.ts
@@ -1,0 +1,84 @@
+/**
+ * DM pairing-gate tests for MessageManager.checkDmAccess (#14710 residual):
+ * the resolved bot owner / connector-admin whitelist members are the pairing
+ * APPROVERS and must never be locked behind their own gate, while strangers
+ * stay fail-closed when the PairingService is missing. Drives the real
+ * checkDmAccess + checkPairingAllowed path over a deterministic fake runtime
+ * (no vi.mock of core).
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { MessageManager } from "../messages";
+import type { IDiscordService } from "../types";
+
+const OWNER_SNOWFLAKE = "600000000000000002";
+const STRANGER_SNOWFLAKE = "600000000000000009";
+
+function makeManager(settings: Record<string, string> = {}): {
+	manager: MessageManager;
+	reportError: ReturnType<typeof vi.fn>;
+} {
+	const reportError = vi.fn();
+	const runtime = {
+		agentId: "11111111-1111-1111-1111-111111111111",
+		character: { name: "TestAgent" },
+		getSetting: (key: string) => settings[key],
+		getService: () => null,
+		reportError,
+		logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+	} as unknown as IAgentRuntime;
+	const service = {
+		client: { user: { id: "888000000000000000" } },
+		accountId: "default",
+		getChannelType: async () => "DM",
+		discordSettings: {
+			autoReply: true,
+			dmPolicy: "pairing",
+			shouldIgnoreBotMessages: true,
+			shouldIgnoreDirectMessages: false,
+			replyToMode: "first",
+		},
+	} as unknown as IDiscordService;
+	return { manager: new MessageManager(service, runtime), reportError };
+}
+
+type DmAccessProbe = {
+	checkDmAccess(message: {
+		author: Record<string, unknown>;
+	}): Promise<{ allowed: boolean }>;
+};
+
+function dmFrom(userId: string): { author: Record<string, unknown> } {
+	return {
+		author: {
+			id: userId,
+			username: "someone",
+			displayName: "Someone",
+			discriminator: "0",
+		},
+	};
+}
+
+describe("MessageManager.checkDmAccess — pairing policy (#14710)", () => {
+	it("denies a stranger when the PairingService is missing (fail closed) and reports it", async () => {
+		const { manager, reportError } = makeManager();
+		const result = await (manager as unknown as DmAccessProbe).checkDmAccess(
+			dmFrom(STRANGER_SNOWFLAKE),
+		);
+		expect(result.allowed).toBe(false);
+		expect(reportError).toHaveBeenCalledTimes(1);
+	});
+
+	it("never locks the resolved owner / connector admins behind their own pairing gate", async () => {
+		const { manager, reportError } = makeManager({
+			ELIZA_ROLES_CONNECTOR_ADMINS_JSON: JSON.stringify({
+				discord: [OWNER_SNOWFLAKE],
+			}),
+		});
+		const result = await (manager as unknown as DmAccessProbe).checkDmAccess(
+			dmFrom(OWNER_SNOWFLAKE),
+		);
+		expect(result.allowed).toBe(true);
+		expect(reportError).not.toHaveBeenCalled();
+	});
+});

--- a/plugins/plugin-discord/__tests__/identity.test.ts
+++ b/plugins/plugin-discord/__tests__/identity.test.ts
@@ -22,6 +22,7 @@ import {
 
 const SNOWFLAKE_A = "123456789012345678";
 const SNOWFLAKE_B = "234567890123456789";
+const SNOWFLAKE_C = "345678901234567890";
 
 describe("extractDiscordOwnerUserIds", () => {
 	it("reads the direct application owner", () => {
@@ -83,6 +84,52 @@ describe("extractDiscordTeamAdminUserIds", () => {
 	it("returns [] for non-objects", () => {
 		expect(extractDiscordTeamAdminUserIds(null)).toEqual([]);
 		expect(extractDiscordTeamAdminUserIds("nope")).toEqual([]);
+	});
+
+	it("skips pending invitees (membership_state 1) — they have not accepted", () => {
+		expect(
+			extractDiscordTeamAdminUserIds({
+				team: {
+					members: [
+						{ user: { id: SNOWFLAKE_B }, membershipState: 1 },
+						{ user: { id: SNOWFLAKE_C }, membership_state: 1 },
+					],
+				},
+			}),
+		).toEqual([]);
+	});
+
+	it("skips read_only members — they deliberately hold no write access", () => {
+		expect(
+			extractDiscordTeamAdminUserIds({
+				team: {
+					members: [
+						{
+							user: { id: SNOWFLAKE_B },
+							membershipState: 2,
+							role: "read_only",
+						},
+					],
+				},
+			}),
+		).toEqual([]);
+	});
+
+	it("keeps accepted developers and members with absent state/role fields", () => {
+		expect(
+			extractDiscordTeamAdminUserIds({
+				team: {
+					members: [
+						{
+							user: { id: SNOWFLAKE_B },
+							membershipState: 2,
+							role: "developer",
+						},
+						{ user: { id: SNOWFLAKE_C } },
+					],
+				},
+			}),
+		).toEqual([SNOWFLAKE_B, SNOWFLAKE_C]);
 	});
 });
 

--- a/plugins/plugin-discord/identity.ts
+++ b/plugins/plugin-discord/identity.ts
@@ -105,6 +105,9 @@ export function extractDiscordOwnerUserIds(application: unknown): string[] {
 	return [...ownerCandidates];
 }
 
+// Discord team membership_state: 1 = invited (pending), 2 = accepted.
+const TEAM_MEMBERSHIP_ACCEPTED = 2;
+
 export function extractDiscordTeamAdminUserIds(application: unknown): string[] {
 	const applicationRecord = asRecord(application);
 	if (!applicationRecord) {
@@ -127,11 +130,34 @@ export function extractDiscordTeamAdminUserIds(application: unknown): string[] {
 	if (memberIterable) {
 		for (const entry of memberIterable) {
 			// Collection/Map yields [key, value] tuples; Array yields values directly.
-			const member = Array.isArray(entry) ? entry[1] : entry;
-			const memberId = readUserIdFromOwnerLike(member);
-			if (memberId) {
-				adminCandidates.add(memberId);
+			const member = asRecord(Array.isArray(entry) ? entry[1] : entry);
+			if (!member) {
+				continue;
 			}
+			const memberId = readUserIdFromOwnerLike(member);
+			if (!memberId) {
+				continue;
+			}
+			// Connector-admin standing is only for members who actually hold it on
+			// Discord's side: pending invitees (membership_state 1) have not
+			// accepted, and read_only members deliberately hold no write access —
+			// neither may be seeded as an admin (#14712). Members whose state/role
+			// fields are absent (older discord.js payload shapes) are treated as
+			// accepted developers.
+			const membershipStateRaw =
+				member.membershipState ?? member.membership_state;
+			const membershipState =
+				typeof membershipStateRaw === "number" ? membershipStateRaw : null;
+			if (
+				membershipState !== null &&
+				membershipState !== TEAM_MEMBERSHIP_ACCEPTED
+			) {
+				continue;
+			}
+			if (typeof member.role === "string" && member.role === "read_only") {
+				continue;
+			}
+			adminCandidates.add(memberId);
 		}
 	}
 

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -15,6 +15,7 @@ import {
 	EventType,
 	type FetchedDocumentUrl as FetchedKnowledgeUrl,
 	fetchDocumentFromUrl,
+	getConnectorAdminWhitelist,
 	type HandlerCallback,
 	type IAgentRuntime,
 	isInAllowlist,
@@ -448,6 +449,16 @@ export class MessageManager {
 		if (policy === "pairing") {
 			// Check static allowlist first (if configured, allow bypass of pairing)
 			if (this.discordSettings.allowFrom?.includes(userId)) {
+				return { allowed: true };
+			}
+
+			// The resolved bot owner and explicitly whitelisted connector admins
+			// (seeded by refreshOwnerDiscordUserIds from the application owner /
+			// team / ELIZA_DISCORD_OWNER_USER_IDS_JSON) are the pairing APPROVERS —
+			// they must never be locked behind their own pairing gate (#14710).
+			const discordAdminIds =
+				getConnectorAdminWhitelist(this.runtime).discord ?? [];
+			if (discordAdminIds.includes(userId)) {
 				return { allowed: true };
 			}
 

--- a/plugins/plugin-telegram/src/connector-sources.test.ts
+++ b/plugins/plugin-telegram/src/connector-sources.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Guards the telegram connector-source registration contract (#14711): the
+ * plugin must declare the flat-field identity projection (fromId/entityName)
+ * and world-id key (telegramChatId) so core role resolution can derive sender
+ * identity and world from telegram memories without connector literals.
+ */
+import { describe, expect, it } from "vitest";
+import telegramPlugin from "./index";
+
+describe("telegram connectorSources registration", () => {
+  it("declares the identity mapping and world-id keys role resolution depends on", () => {
+    const source = telegramPlugin.connectorSources?.find(
+      (entry) => entry.source === "telegram",
+    );
+    expect(source).toBeDefined();
+    expect(source?.identityMetadataMapping).toEqual({
+      userIdField: "fromId",
+      nameField: "entityName",
+    });
+    expect(source?.worldIdMetadataKeys).toEqual(["telegramChatId"]);
+  });
+});


### PR DESCRIPTION
## Summary

Residual hardening on top of the landed roles-security cluster (#14845 → #14707, #14841 → #14710, #14837 → #14711, #14863 → #14712). All four issues are closed; auditing the landed fixes against the original reports surfaced four remaining gaps, each closed here with regression tests.

Refs #14707, #14710, #14711, #14712.

### 1. Legacy stored OWNER grants still escalated (#14707 residual)
`resolveEntityRole` honored a stored world OWNER grant whenever no canonical owner was configured. #14845 only changed **new** grant writes (guild owner → ADMIN/`connector_admin`); worlds persisted before it still carry OWNER grants the old Discord code wrote for every guild owner, so any guild owner hosting the bot still resolved to app-level OWNER in unconfigured deployments. Stored OWNER is now honored only with `manual` provenance — writable solely by an existing OWNER through the `canModifyRole` gate.

**Product-intent call:** a `manual` OWNER grant is now honored even when a canonical owner IS configured (develop folded all stored OWNER to GUEST). `canModifyRole` only lets an existing OWNER write an OWNER grant, so this is a deliberate co-owner appointment; resolution silently ignoring what the role-management surface permits seemed wrong. Flagging for review.

### 2. Default DM policy was inoperable: PairingService never registered (#14710 residual)
#14841 made `checkPairingAllowed` fail closed when `ServiceType.PAIRING` is missing — correct — but **nothing in the repo registers core `PairingService`**. With the connectors' default `dmPolicy: "pairing"`, every Discord/WhatsApp DM from a non-`allowFrom` sender was denied with "Access pairing is temporarily unavailable." and no pairing path existed at all. The eliza plugin now registers `PairingService` (next to `OwnerBindingService`, before connector plugins start). The missing-service deny now also escalates via `runtime.reportError` (systemic misconfiguration, reaches RECENT_ERRORS/owner) instead of a per-message `logger.warn`.

### 3. Approvers locked behind their own pairing gate (#14710 residual)
Discord `checkDmAccess` under `pairing` admitted only static `allowFrom` before consulting the pairing service — the resolved bot owner / team (seeded into the connector-admin whitelist by `refreshOwnerDiscordUserIds`) had to pair with themselves. Whitelisted connector admins now bypass the gate they administer.

### 4. Pending/read-only team members seeded as connector admins (#14712 residual)
`extractDiscordTeamAdminUserIds` seeded **every** team member. Pending invitees (`membership_state` 1) have not accepted and `read_only` members deliberately hold no write access on Discord's side; both are now skipped (absent state/role fields keep the older-payload behavior of counting as accepted developers).

Plus: `metadata.telegram.id` declared on `MessageMetadata` (stamped since #14837, compared by role resolution — #14711), and a drift-guard test for the telegram connector-source identity mapping registration.

## Test plan

- `packages/core/src/roles.resolution.test.ts` — 4 new cases: sourceless / `connector_admin`-sourced stored OWNER folds to GUEST with **no** canonical owner configured; `manual` OWNER honored with and without a canonical owner (30 total in file, green).
- `packages/core/src/services/pairing-integration.test.ts` — missing-service deny asserts `reportError` escalation.
- `packages/agent/src/runtime/eliza-plugin-services.test.ts` (new) — PairingService + OwnerBindingService registration guard (text-read technique from core-static-plugin-registrations.test.ts).
- `plugins/plugin-discord/__tests__/dm-policy.test.ts` (new) — real `checkDmAccess` + `checkPairingAllowed` path: stranger fails closed + reported; whitelisted admin bypasses.
- `plugins/plugin-discord/__tests__/identity.test.ts` — 3 new membership-state/role filtering cases.
- `plugins/plugin-telegram/src/connector-sources.test.ts` (new) — identity-mapping registration guard.
- Suites run green: core roles/pairing/account-manager + agent owner-binding (#14765 suites) 83 tests; discord identity/dm-policy/allowlist/slash-commands/owner-refresh 29 tests; telegram messageManager + connector-sources 21 tests.
- `bun run audit:error-policy-ratchet` clean; biome clean; core/agent/discord/telegram typecheck clean (pre-existing unrelated missing-optional-dep module errors in the isolated worktree aside).

## Evidence

- Real trajectories: N/A - no model/prompt/planner behavior change; pure role-resolution/gating logic covered by deterministic tests over real code paths (no vi.mock of the units under test).
- UI screenshots/video: N/A - no UI surface touched.
- Backend logs: the new tests assert the actual structured escalation (`runtime.reportError("pairing-integration", …)`) fires on the misconfiguration path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Evidence Gate

<!-- evidence-row:before-screenshots -->
- [x] N/A - role resolution, pairing integration, and connector identity logic only; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - no UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no browser/mobile user flow changed; deterministic role/DM-policy tests exercise the affected backend paths.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend service was started; tests assert the structured `runtime.reportError("pairing-integration", ...)` escalation fires on the missing PairingService path.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend or network runtime changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, planner, or action-selection behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external domain artifact is produced; focused tests cover stored role provenance, PairingService registration, Discord DM policy, Discord team-member filtering, and Telegram connector-source identity mapping.
