### PR TITLE
test(app-control): pin SETTINGS chat-write audit gaps

### DIFF
--- a/plugins/plugin-app-control/src/actions/settings.test.ts
+++ b/plugins/plugin-app-control/src/actions/settings.test.ts
@@ -14,6 +14,7 @@ import {
 	parseBooleanValue,
 	parseSettingsRequest,
 	resolveSectionId,
+	SETTINGS_NON_CATALOG_SECTION_AUDIT,
 	SETTINGS_WRITE_REGISTRY,
 	type SettingsRouteFetch,
 } from "./settings.ts";
@@ -168,6 +169,49 @@ describe("registry completeness", () => {
 		const metaIds = SETTINGS_SECTION_META.map((m) => m.id).sort();
 		const registryIds = Object.keys(SETTINGS_WRITE_REGISTRY).sort();
 		expect(registryIds).toEqual(metaIds);
+	});
+
+	it("pins audit records for non-catalog settings sections", () => {
+		expect(Object.keys(SETTINGS_NON_CATALOG_SECTION_AUDIT).sort()).toEqual([
+			"cloud-agents",
+			"cloud-overview",
+			"my-runtimes",
+		]);
+		for (const [id, entry] of Object.entries(
+			SETTINGS_NON_CATALOG_SECTION_AUDIT,
+		)) {
+			expect(
+				entry.reason.trim().length,
+				`non-catalog section "${id}" needs a durable audit reason`,
+			).toBeGreaterThan(20);
+			expect(
+				entry.coveredBy || entry.trackingIssue,
+				`non-catalog section "${id}" needs coverage or an issue`,
+			).toBeTruthy();
+			expect(SETTINGS_WRITE_REGISTRY[id]).toBeUndefined();
+		}
+	});
+
+	it("requires every unwired catalog section to be tracked or explicitly exempt", () => {
+		for (const [id, cap] of Object.entries(SETTINGS_WRITE_REGISTRY)) {
+			if (cap.kind !== "unwired") continue;
+			expect(
+				cap.trackingIssue || cap.exemptionReason,
+				`unwired section "${id}" needs a tracking issue or exemption`,
+			).toBeTruthy();
+		}
+		expect(SETTINGS_WRITE_REGISTRY.voice).toMatchObject({
+			kind: "unwired",
+			trackingIssue: 14910,
+		});
+		expect(SETTINGS_WRITE_REGISTRY["wallet-rpc"]).toMatchObject({
+			kind: "unwired",
+			trackingIssue: 14911,
+		});
+		expect(SETTINGS_WRITE_REGISTRY.updates).toMatchObject({
+			kind: "unwired",
+			trackingIssue: 14912,
+		});
 	});
 
 	it("names only real dedicated actions for delegated sections", () => {

--- a/plugins/plugin-app-control/src/actions/settings.ts
+++ b/plugins/plugin-app-control/src/actions/settings.ts
@@ -16,9 +16,9 @@
  * endpoint the on-screen control calls, so view button and action are twins),
  * `readonly` for pure diagnostics, or `unwired` for a gap section whose semantic
  * write is deliberately deferred (with a stated reason). Every built-in section
- * id has a registry entry — a completeness invariant the unit test pins so the
- * catalog can never silently drift, and which the view-mutation ratchet (#14369)
- * consumes as the action-side mapping.
+ * id has a registry entry, and every non-catalog settings section has an
+ * explicit audit disposition — completeness invariants the unit tests pin so
+ * the catalog and chat-write audit can never silently drift.
  */
 
 import type {
@@ -120,7 +120,39 @@ export type SettingsSectionCapability =
 			kind: "unwired";
 			/** Why the semantic write is deferred, not merely missing. */
 			reason: string;
+			/** Open issue that owns the missing action/view twin. */
+			trackingIssue?: number;
+			/** Durable reason this section is intentionally not chat-writable. */
+			exemptionReason?: string;
 	  };
+
+export interface SettingsNonCatalogAuditEntry {
+	reason: string;
+	coveredBy?: string;
+	trackingIssue?: number;
+}
+
+export const SETTINGS_NON_CATALOG_SECTION_AUDIT: Readonly<
+	Record<string, SettingsNonCatalogAuditEntry>
+> = {
+	"cloud-overview": {
+		reason:
+			"Cloud upsell/account overview is a late-registered non-catalog page, not a local setting value.",
+		coveredBy: "VIEWS navigation and cloud onboarding surfaces",
+	},
+	"cloud-agents": {
+		reason:
+			"Cloud agent create/switch/delete is a cloud agent-management workflow, not part of the local SETTINGS value registry.",
+		coveredBy:
+			"AGENT_SWITCH for switching; cloud agent management needs its own product action if chat-write is required.",
+	},
+	"my-runtimes": {
+		reason:
+			"Runtime registry management spans local/cloud/VPS runtimes and is outside the pinned settings catalog.",
+		coveredBy:
+			"MODEL_SWITCH for inference target changes; runtime CRUD needs a separate runtime-management action if chat-write is required.",
+	},
+};
 
 const PERMISSIONS_SHELL_KEY: SettingsWritableKey = {
 	description:
@@ -376,12 +408,14 @@ export const SETTINGS_WRITE_REGISTRY: Readonly<
 	},
 	security: {
 		kind: "readonly",
-		summary: "Security posture and status; no chat-writable value.",
+		summary:
+			"Security posture and host password status; password changes are deliberately not chat-writable because secrets must not flow through the model.",
 	},
 	voice: {
 		kind: "unwired",
 		reason:
 			"Voice enable/config is not yet exposed as a semantic action; it currently lives behind the voice section controls.",
+		trackingIssue: 14910,
 	},
 	capabilities: {
 		kind: "route",
@@ -399,21 +433,27 @@ export const SETTINGS_WRITE_REGISTRY: Readonly<
 		kind: "unwired",
 		reason:
 			"Installed-view management is handled by the VIEWS/APP surface, not a settings value.",
+		exemptionReason:
+			"APP and VIEWS own app installation, launch, creation, and view management; SETTINGS must not duplicate that workflow.",
 	},
 	"remote-plugins": {
 		kind: "unwired",
 		reason:
 			"Remote plugin host registration is developer-only and has no single-value chat write.",
+		exemptionReason:
+			"Remote plugin registration is a developer workflow without a stable single-value setting contract.",
 	},
 	"wallet-rpc": {
 		kind: "unwired",
 		reason:
 			"RPC endpoint configuration is a structured object; wallet keys are read-only from chat.",
+		trackingIssue: 14911,
 	},
 	updates: {
 		kind: "unwired",
 		reason:
 			"Update check/apply is an asynchronous job surface, not a settings value.",
+		trackingIssue: 14912,
 	},
 	advanced: {
 		kind: "route",


### PR DESCRIPTION
## Summary
- filed missing #14369 tracking issues for SETTINGS `voice`, `wallet-rpc`, and `updates` gaps: #14910, #14911, #14912
- added explicit non-catalog settings audit records for `cloud-overview`, `cloud-agents`, and `my-runtimes`
- required every `unwired` catalog registry entry to carry either a tracking issue or an exemption reason
- clarified why Security password changes are intentionally not chat-writable

Fixes #14727.

## Verification
- `bun run --cwd plugins/plugin-app-control test src/actions/settings.test.ts` — 51 passed
- `bunx biome check plugins/plugin-app-control/src/actions/settings.ts plugins/plugin-app-control/src/actions/settings.test.ts`
- `git diff --check origin/develop...HEAD`
- `bun run audit:error-policy-ratchet`

## Notes
- `bun run --cwd plugins/plugin-app-control typecheck` is blocked by existing workspace dependency-resolution issues for `fs-extra`, `markdown-it`, `fast-redact`, `marked`, `get-east-asian-width`, and `puppeteer-core` in the shared node_modules install.

## Evidence Matrix
<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - test/audit registry coverage change only; no rendered settings UI changed.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - test/audit registry coverage change only; the proof is the focused SETTINGS audit test requiring each unwired entry to have a tracking issue or exemption reason.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no user-facing workflow changed; this PR tracks missing semantic twins rather than adding the voice/wallet-rpc/updates implementations.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no backend route changed; focused action tests exercise the registry/audit behavior directly.
<!-- evidence-row:frontend-logs -->
- Frontend logs: N/A - no frontend runtime path changed.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no model/action execution behavior changed; the PR pins coverage metadata and issue links.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - no DB/memory/wallet/on-chain/generated artifact is produced; durable artifacts are the linked tracking issues #14910, #14911, and #14912 plus the audit assertion.

## Remaining Scope
This PR should close #14727 only as the meta-audit/tracking gap. The actual semantic chat-write implementations remain in #14910, #14911, and #14912.
