### PR TITLE
feat(lifeops): FTU goal-discovery provider + anticipation-feedback evaluators

### DIFF
--- a/plugins/plugin-personal-assistant/AGENTS.md
+++ b/plugins/plugin-personal-assistant/AGENTS.md
@@ -54,6 +54,7 @@ The plugin is opt-in; add `@elizaos/plugin-personal-assistant` to the agent's pl
 | `websiteBlocker` | `src/providers/website-blocker.ts` | Current website-blocker status |
 | `appBlocker` | `src/providers/app-blocker.ts` | Current app-blocker status |
 | `firstRun` | `src/providers/first-run.ts` | First-run completion state and affordances |
+| `ftuGoal` | `src/providers/ftu-goal.ts` | Post-first-run goal-discovery affordance; silent once the owner's primary goal is known |
 | `roomPolicy` | `src/providers/room-policy.ts` | Per-room handoff/policy state |
 | `lifeops` | `src/providers/lifeops.ts` | Aggregated owner context for assistant planning |
 | `pendingPrompts` | `src/providers/pending-prompts.ts` | Pending questions waiting for owner input |
@@ -81,6 +82,8 @@ The `lifeops_scheduled_task_runner` service (`ScheduledTaskRunnerService`) is no
 |---|---|---|
 | `owner.profile_extraction` (response handler) | `src/lifeops/owner/profile-extraction-evaluator.ts` | Extracts owner facts from agent responses |
 | `threadOps` (response handler field) | `src/lifeops/work-threads/field-evaluator-thread-ops.ts` | Propagates work-thread field ops from responses |
+| `ftu_goal_discovery` (post-turn, merged call) | `src/lifeops/ftu-goal/evaluator.ts` | Extracts the owner's primary goal after first-run; persists the `primaryGoal` owner fact and closes discovery once confident |
+| `anticipation_feedback` (post-turn, merged call) | `src/lifeops/anticipation/evaluator.ts` | Classifies the owner's reaction to proactive dispatches (accepted / rejected / ignored) into durable rolling stats |
 
 ### Views
 

--- a/plugins/plugin-personal-assistant/CLAUDE.md
+++ b/plugins/plugin-personal-assistant/CLAUDE.md
@@ -54,6 +54,7 @@ The plugin is opt-in; add `@elizaos/plugin-personal-assistant` to the agent's pl
 | `websiteBlocker` | `src/providers/website-blocker.ts` | Current website-blocker status |
 | `appBlocker` | `src/providers/app-blocker.ts` | Current app-blocker status |
 | `firstRun` | `src/providers/first-run.ts` | First-run completion state and affordances |
+| `ftuGoal` | `src/providers/ftu-goal.ts` | Post-first-run goal-discovery affordance; silent once the owner's primary goal is known |
 | `roomPolicy` | `src/providers/room-policy.ts` | Per-room handoff/policy state |
 | `lifeops` | `src/providers/lifeops.ts` | Aggregated owner context for assistant planning |
 | `pendingPrompts` | `src/providers/pending-prompts.ts` | Pending questions waiting for owner input |
@@ -81,6 +82,8 @@ The `lifeops_scheduled_task_runner` service (`ScheduledTaskRunnerService`) is no
 |---|---|---|
 | `owner.profile_extraction` (response handler) | `src/lifeops/owner/profile-extraction-evaluator.ts` | Extracts owner facts from agent responses |
 | `threadOps` (response handler field) | `src/lifeops/work-threads/field-evaluator-thread-ops.ts` | Propagates work-thread field ops from responses |
+| `ftu_goal_discovery` (post-turn, merged call) | `src/lifeops/ftu-goal/evaluator.ts` | Extracts the owner's primary goal after first-run; persists the `primaryGoal` owner fact and closes discovery once confident |
+| `anticipation_feedback` (post-turn, merged call) | `src/lifeops/anticipation/evaluator.ts` | Classifies the owner's reaction to proactive dispatches (accepted / rejected / ignored) into durable rolling stats |
 
 ### Views
 

--- a/plugins/plugin-personal-assistant/src/lifeops/anticipation/evaluator.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/anticipation/evaluator.ts
@@ -1,0 +1,143 @@
+/**
+ * `anticipation_feedback` — post-turn evaluator that classifies how the owner
+ * received the agent's most recent proactive (anticipatory) message:
+ * `accepted`, `rejected`, or `ignored`.
+ *
+ * Detection keys off the proactive-dispatch markers the scheduler writes when
+ * a proactive task fires (see `./store.ts` for why the pending-prompts store
+ * cannot serve that role). Runs inside the runtime's single merged
+ * SMALL-model evaluation call, so it costs no extra round-trip. Idempotence
+ * is structural: the processor removes every marker it classifies, and
+ * `shouldRun` is false when no unprocessed marker exists — the same owner
+ * turn is never classified twice. When several markers are pending, the
+ * newest one is model-classified against the owner's reply and the older,
+ * never-engaged ones are deterministically counted as `ignored`.
+ */
+
+import { hasOwnerAccess } from "@elizaos/agent";
+import type { Evaluator, JSONSchema } from "@elizaos/core";
+import {
+  type AnticipationOutcome,
+  listUnprocessedDispatches,
+  type ProactiveDispatchMarker,
+  recordAnticipationFeedback,
+} from "./store.js";
+
+export interface AnticipationFeedbackOutput {
+  outcome: AnticipationOutcome;
+}
+
+export interface AnticipationFeedbackPrepared {
+  markers: ProactiveDispatchMarker[];
+}
+
+const anticipationSchema: JSONSchema = {
+  type: "object",
+  properties: {
+    outcome: {
+      type: "string",
+      enum: ["accepted", "rejected", "ignored"],
+    },
+  },
+  required: ["outcome"],
+  additionalProperties: false,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function parseAnticipationFeedbackOutput(
+  output: unknown,
+): AnticipationFeedbackOutput | null {
+  if (!isRecord(output)) return null;
+  const outcome = output.outcome;
+  if (
+    outcome !== "accepted" &&
+    outcome !== "rejected" &&
+    outcome !== "ignored"
+  ) {
+    return null;
+  }
+  return { outcome };
+}
+
+export const anticipationFeedbackEvaluator: Evaluator<
+  AnticipationFeedbackOutput,
+  AnticipationFeedbackPrepared
+> = {
+  name: "anticipation_feedback",
+  description:
+    "Classifies whether the owner accepted, rejected, or ignored the agent's most recent proactive message.",
+  priority: 150,
+  schema: anticipationSchema,
+
+  async shouldRun({ runtime, message }) {
+    if (!message.content.text || message.entityId === runtime.agentId) {
+      return false;
+    }
+    if (!(await hasOwnerAccess(runtime, message))) {
+      return false;
+    }
+    const markers = await listUnprocessedDispatches(runtime, message.roomId);
+    return markers.length > 0;
+  },
+
+  async prepare({ runtime, message }) {
+    return {
+      markers: await listUnprocessedDispatches(runtime, message.roomId),
+    };
+  },
+
+  prompt({ prepared }) {
+    const latest = prepared.markers[prepared.markers.length - 1];
+    return `The agent proactively messaged the owner (without being asked). Classify the owner's reply in the shared turn context as a reaction to that proactive message.
+
+Proactive message the agent sent:
+${latest?.snippet || "(content unavailable)"}
+
+Rules:
+- accepted: the owner engages positively — answers the question, acts on the nudge, thanks the agent, or asks to continue.
+- rejected: the owner pushes back — asks the agent to stop, calls it unwanted/annoying, or explicitly declines the suggestion.
+- ignored: the owner's reply does not engage with the proactive message at all (talks about something unrelated).`;
+  },
+
+  parse: parseAnticipationFeedbackOutput,
+
+  processors: [
+    {
+      name: "recordAnticipationOutcome",
+      async process({ runtime, message, prepared, output }) {
+        if (prepared.markers.length === 0) {
+          return undefined;
+        }
+        const latest = prepared.markers[prepared.markers.length - 1];
+        if (!latest) return undefined;
+        // The owner's reply is read as feedback on the NEWEST proactive
+        // message; older unaddressed dispatches were demonstrably ignored —
+        // count them deterministically without burning model output on them.
+        const entries: Array<{
+          marker: ProactiveDispatchMarker;
+          outcome: AnticipationOutcome;
+        }> = prepared.markers
+          .slice(0, -1)
+          .map((marker) => ({ marker, outcome: "ignored" as const }));
+        entries.push({ marker: latest, outcome: output.outcome });
+        const stats = await recordAnticipationFeedback(
+          runtime,
+          message.roomId,
+          entries,
+        );
+        return {
+          success: true,
+          values: {
+            anticipationOutcome: output.outcome,
+            anticipationAccepted: stats.accepted,
+            anticipationRejected: stats.rejected,
+            anticipationIgnored: stats.ignored,
+          },
+        };
+      },
+    },
+  ],
+};

--- a/plugins/plugin-personal-assistant/src/lifeops/anticipation/store.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/anticipation/store.ts
@@ -1,0 +1,292 @@
+/**
+ * Proactive-dispatch markers + rolling anticipation-feedback stats.
+ *
+ * Two small cache-backed records that let the `anticipation_feedback`
+ * evaluator judge how the owner receives proactive (agent-initiated) messages:
+ *
+ * 1. **Dispatch markers** — written at the proactive dispatch site (the
+ *    scheduler records one alongside each pending prompt it opens). The
+ *    pending-prompts store itself cannot serve as the evaluator's signal:
+ *    inbound-reply completion resolves those entries on `MESSAGE_RECEIVED`,
+ *    *before* post-turn evaluation runs, so by evaluator time the prompt is
+ *    gone. Markers live per room, are bounded, age out after
+ *    {@link MARKER_RETENTION_HOURS}, and are removed exactly once when
+ *    feedback for them is recorded — that removal is what makes the evaluator
+ *    idempotent (no marker => `shouldRun` false => no double-processing).
+ *
+ * 2. **Rolling stats** — accepted / rejected / ignored counters plus a
+ *    bounded recent-outcome ring, durable across restarts, so proactivity
+ *    (frequency, intensity) can be tuned from observed owner reception.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { asCacheRuntime } from "../runtime-cache.js";
+
+export const MARKER_RETENTION_HOURS = 24;
+const MAX_MARKERS_PER_ROOM = 8;
+const MAX_RECENT_OUTCOMES = 20;
+const SNIPPET_MAX_LENGTH = 160;
+
+const STATS_CACHE_KEY = "eliza:lifeops:anticipation:stats:v1";
+
+function markersCacheKey(roomId: string): string {
+  return `eliza:lifeops:anticipation:dispatches:${roomId}:v1`;
+}
+
+export interface ProactiveDispatchMarker {
+  taskId: string;
+  /** ISO-8601 instant the proactive message fired into the room. */
+  firedAt: string;
+  /** Clamped copy of the dispatched prompt, for the classifier's context. */
+  snippet: string;
+}
+
+export type AnticipationOutcome = "accepted" | "rejected" | "ignored";
+
+export interface AnticipationOutcomeEntry {
+  taskId: string;
+  firedAt: string;
+  outcome: AnticipationOutcome;
+  recordedAt: string;
+}
+
+export interface AnticipationStats {
+  accepted: number;
+  rejected: number;
+  ignored: number;
+  updatedAt: string;
+  /** Newest-last bounded ring of individual outcomes. */
+  recent: AnticipationOutcomeEntry[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isValidIso(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    Number.isFinite(Date.parse(value))
+  );
+}
+
+function isOutcome(value: unknown): value is AnticipationOutcome {
+  return value === "accepted" || value === "rejected" || value === "ignored";
+}
+
+function clampSnippet(value: string): string {
+  const trimmed = value.trim();
+  return trimmed.length <= SNIPPET_MAX_LENGTH
+    ? trimmed
+    : `${trimmed.slice(0, SNIPPET_MAX_LENGTH - 1).trimEnd()}…`;
+}
+
+function normalizeMarkers(value: unknown): ProactiveDispatchMarker[] {
+  if (!Array.isArray(value)) return [];
+  const markers: ProactiveDispatchMarker[] = [];
+  for (const entry of value) {
+    if (!isRecord(entry)) continue;
+    if (typeof entry.taskId !== "string" || entry.taskId.length === 0) {
+      continue;
+    }
+    if (!isValidIso(entry.firedAt)) continue;
+    markers.push({
+      taskId: entry.taskId,
+      firedAt: entry.firedAt,
+      snippet: typeof entry.snippet === "string" ? entry.snippet : "",
+    });
+  }
+  return markers;
+}
+
+function nonNegativeCount(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? Math.floor(value)
+    : 0;
+}
+
+function normalizeStats(value: unknown, now: Date): AnticipationStats {
+  const base: AnticipationStats = {
+    accepted: 0,
+    rejected: 0,
+    ignored: 0,
+    updatedAt: now.toISOString(),
+    recent: [],
+  };
+  if (!isRecord(value)) return base;
+  base.accepted = nonNegativeCount(value.accepted);
+  base.rejected = nonNegativeCount(value.rejected);
+  base.ignored = nonNegativeCount(value.ignored);
+  if (isValidIso(value.updatedAt)) base.updatedAt = value.updatedAt;
+  if (Array.isArray(value.recent)) {
+    for (const entry of value.recent) {
+      if (!isRecord(entry)) continue;
+      if (typeof entry.taskId !== "string" || entry.taskId.length === 0) {
+        continue;
+      }
+      if (!isValidIso(entry.firedAt) || !isValidIso(entry.recordedAt)) {
+        continue;
+      }
+      if (!isOutcome(entry.outcome)) continue;
+      base.recent.push({
+        taskId: entry.taskId,
+        firedAt: entry.firedAt,
+        outcome: entry.outcome,
+        recordedAt: entry.recordedAt,
+      });
+    }
+    if (base.recent.length > MAX_RECENT_OUTCOMES) {
+      base.recent = base.recent.slice(-MAX_RECENT_OUTCOMES);
+    }
+  }
+  return base;
+}
+
+function liveMarkers(
+  markers: ProactiveDispatchMarker[],
+  now: Date,
+): ProactiveDispatchMarker[] {
+  const cutoffMs = now.getTime() - MARKER_RETENTION_HOURS * 3_600_000;
+  return markers
+    .filter((marker) => Date.parse(marker.firedAt) >= cutoffMs)
+    .sort((a, b) => Date.parse(a.firedAt) - Date.parse(b.firedAt));
+}
+
+/**
+ * Record that a proactive message fired into `roomId`. Called at the
+ * scheduler's dispatch site right after the pending prompt is recorded.
+ * Re-firing the same task replaces its marker (newest fire wins).
+ */
+export async function recordProactiveDispatch(
+  runtime: IAgentRuntime,
+  input: {
+    roomId: string;
+    taskId: string;
+    firedAt: string;
+    snippet: string;
+  },
+): Promise<void> {
+  if (!input.roomId) {
+    throw new Error("[anticipation-store] roomId is required");
+  }
+  if (!input.taskId) {
+    throw new Error("[anticipation-store] taskId is required");
+  }
+  if (!isValidIso(input.firedAt)) {
+    throw new Error("[anticipation-store] firedAt must be ISO-8601");
+  }
+  const cache = asCacheRuntime(runtime);
+  const stored = normalizeMarkers(
+    await cache.getCache<ProactiveDispatchMarker[]>(
+      markersCacheKey(input.roomId),
+    ),
+  );
+  const next = stored.filter((marker) => marker.taskId !== input.taskId);
+  next.push({
+    taskId: input.taskId,
+    firedAt: input.firedAt,
+    snippet: clampSnippet(input.snippet),
+  });
+  const bounded =
+    next.length > MAX_MARKERS_PER_ROOM
+      ? next
+          .sort((a, b) => Date.parse(a.firedAt) - Date.parse(b.firedAt))
+          .slice(-MAX_MARKERS_PER_ROOM)
+      : next;
+  await cache.setCache<ProactiveDispatchMarker[]>(
+    markersCacheKey(input.roomId),
+    bounded,
+  );
+}
+
+/**
+ * Markers in `roomId` that have not yet received feedback, oldest first.
+ * Aged-out markers (past {@link MARKER_RETENTION_HOURS}) are dropped from
+ * the result and pruned from the cache.
+ */
+export async function listUnprocessedDispatches(
+  runtime: IAgentRuntime,
+  roomId: string,
+  opts: { now?: Date } = {},
+): Promise<ProactiveDispatchMarker[]> {
+  const now = opts.now ?? new Date();
+  const cache = asCacheRuntime(runtime);
+  const stored = normalizeMarkers(
+    await cache.getCache<ProactiveDispatchMarker[]>(markersCacheKey(roomId)),
+  );
+  const live = liveMarkers(stored, now);
+  if (live.length !== stored.length) {
+    await cache.setCache<ProactiveDispatchMarker[]>(
+      markersCacheKey(roomId),
+      live,
+    );
+  }
+  return live;
+}
+
+/**
+ * Record outcomes for `roomId` markers and remove them so they are never
+ * classified twice. Updates the rolling stats in the same pass.
+ */
+export async function recordAnticipationFeedback(
+  runtime: IAgentRuntime,
+  roomId: string,
+  entries: Array<{
+    marker: ProactiveDispatchMarker;
+    outcome: AnticipationOutcome;
+  }>,
+  opts: { now?: Date } = {},
+): Promise<AnticipationStats> {
+  const now = opts.now ?? new Date();
+  const cache = asCacheRuntime(runtime);
+
+  if (entries.length > 0) {
+    const stored = normalizeMarkers(
+      await cache.getCache<ProactiveDispatchMarker[]>(markersCacheKey(roomId)),
+    );
+    const processedKeys = new Set(
+      entries.map(({ marker }) => `${marker.taskId}:${marker.firedAt}`),
+    );
+    const remaining = stored.filter(
+      (marker) => !processedKeys.has(`${marker.taskId}:${marker.firedAt}`),
+    );
+    await cache.setCache<ProactiveDispatchMarker[]>(
+      markersCacheKey(roomId),
+      remaining,
+    );
+  }
+
+  const stats = normalizeStats(
+    await cache.getCache<AnticipationStats>(STATS_CACHE_KEY),
+    now,
+  );
+  const recordedAt = now.toISOString();
+  for (const { marker, outcome } of entries) {
+    stats[outcome] += 1;
+    stats.recent.push({
+      taskId: marker.taskId,
+      firedAt: marker.firedAt,
+      outcome,
+      recordedAt,
+    });
+  }
+  if (stats.recent.length > MAX_RECENT_OUTCOMES) {
+    stats.recent = stats.recent.slice(-MAX_RECENT_OUTCOMES);
+  }
+  stats.updatedAt = recordedAt;
+  await cache.setCache<AnticipationStats>(STATS_CACHE_KEY, stats);
+  return stats;
+}
+
+/** Read the rolling anticipation-feedback stats (proactivity tuning input). */
+export async function readAnticipationStats(
+  runtime: IAgentRuntime,
+  opts: { now?: Date } = {},
+): Promise<AnticipationStats> {
+  const cache = asCacheRuntime(runtime);
+  return normalizeStats(
+    await cache.getCache<AnticipationStats>(STATS_CACHE_KEY),
+    opts.now ?? new Date(),
+  );
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/ftu-goal/evaluator.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/ftu-goal/evaluator.ts
@@ -1,0 +1,153 @@
+/**
+ * `ftu_goal_discovery` — post-turn evaluator that extracts the owner's
+ * primary goal (what they value / want the assistant's help with) from the
+ * conversation once first-run setup is complete.
+ *
+ * Runs inside the runtime's single merged, schema-constrained SMALL-model
+ * evaluation call (`EvaluatorService`), so it adds no extra model round-trip
+ * to the turn. `shouldRun` is the no-reprocessing gate: it is `false` the
+ * moment the `FtuGoalStateStore` records a goal, so completed discovery never
+ * re-evaluates the same conversation. The processor persists the goal as the
+ * typed `primaryGoal` owner fact (with `agent_inferred` provenance) and flips
+ * the lifecycle to `complete` only when extraction confidence clears
+ * {@link FTU_GOAL_CONFIDENCE_THRESHOLD}.
+ */
+
+import { hasOwnerAccess } from "@elizaos/agent";
+import type { Evaluator, JSONSchema } from "@elizaos/core";
+import { createFirstRunStateStore } from "../first-run/state.js";
+import { createOwnerFactStore } from "../owner/fact-store.js";
+import { createFtuGoalStateStore } from "./state.js";
+
+/**
+ * Minimum extraction confidence required to persist the goal and close
+ * discovery. Below this the turn contributes nothing and discovery stays
+ * open — a half-guessed goal written as fact is worse than another turn of
+ * conversation.
+ */
+export const FTU_GOAL_CONFIDENCE_THRESHOLD = 0.7;
+
+const MAX_GOAL_LENGTH = 240;
+
+export interface FtuGoalDiscoveryOutput {
+  goalFound: boolean;
+  goal: string;
+  confidence: number;
+}
+
+const ftuGoalSchema: JSONSchema = {
+  type: "object",
+  properties: {
+    goalFound: { type: "boolean" },
+    goal: { type: "string" },
+    confidence: { type: "number" },
+  },
+  required: ["goalFound", "goal", "confidence"],
+  additionalProperties: false,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function parseFtuGoalOutput(
+  output: unknown,
+): FtuGoalDiscoveryOutput | null {
+  if (!isRecord(output)) return null;
+  if (typeof output.goalFound !== "boolean") return null;
+  const goal = typeof output.goal === "string" ? output.goal.trim() : "";
+  const confidence =
+    typeof output.confidence === "number" && Number.isFinite(output.confidence)
+      ? Math.min(1, Math.max(0, output.confidence))
+      : 0;
+  return {
+    goalFound: output.goalFound && goal.length > 0,
+    goal: goal.slice(0, MAX_GOAL_LENGTH),
+    confidence,
+  };
+}
+
+export const ftuGoalDiscoveryEvaluator: Evaluator<FtuGoalDiscoveryOutput> = {
+  name: "ftu_goal_discovery",
+  description:
+    "Extracts the owner's primary goal — what they value or want the assistant's help with — from the conversation after first-run setup completes.",
+  priority: 140,
+  schema: ftuGoalSchema,
+
+  async shouldRun({ runtime, message }) {
+    if (!message.content.text || message.entityId === runtime.agentId) {
+      return false;
+    }
+    if (!(await hasOwnerAccess(runtime, message))) {
+      return false;
+    }
+    const firstRun = await createFirstRunStateStore(runtime).read();
+    if (firstRun.status !== "complete") {
+      return false;
+    }
+    const ftuGoal = await createFtuGoalStateStore(runtime).read();
+    return ftuGoal.status === "pending";
+  },
+
+  prompt() {
+    return `Decide whether this turn reveals the owner's PRIMARY goal: the thing they mainly value or want the assistant's ongoing help with (e.g. "ship my startup's iOS app", "stay on top of email and family follow-ups", "train for a marathon").
+Judge from the owner's latest message in the shared turn context, in light of the agent's response.
+Rules:
+- goalFound=true only when the owner expresses a durable want, priority, or area they need help with — in their own words, not the agent's suggestion.
+- goal: one compact sentence (max ~30 words) restating that want. Empty string when goalFound=false.
+- confidence: 0-1. Use >=${FTU_GOAL_CONFIDENCE_THRESHOLD} only when the owner stated it plainly; use lower values for hints or topic-of-the-moment chatter.
+- One-off tasks ("remind me at 3pm"), pleasantries, and questions about the assistant itself are NOT goals => goalFound=false, goal="", confidence=0.`;
+  },
+
+  parse: parseFtuGoalOutput,
+
+  processors: [
+    {
+      name: "persistDiscoveredGoal",
+      async process({ runtime, message, output }) {
+        if (
+          !output.goalFound ||
+          output.goal.length === 0 ||
+          output.confidence < FTU_GOAL_CONFIDENCE_THRESHOLD
+        ) {
+          return undefined;
+        }
+        const stateStore = createFtuGoalStateStore(runtime);
+        // Idempotence backstop: shouldRun already gates on `pending`, but a
+        // concurrent turn may have completed discovery between the gate and
+        // this processor. Never overwrite an already-discovered goal.
+        const current = await stateStore.read();
+        if (current.status === "complete") {
+          return undefined;
+        }
+
+        const discoveredAt = new Date().toISOString();
+        const sourceMessageId =
+          typeof message.id === "string" && message.id.length > 0
+            ? message.id
+            : undefined;
+        await createOwnerFactStore(runtime).update(
+          { primaryGoal: output.goal },
+          {
+            source: "agent_inferred",
+            recordedAt: discoveredAt,
+            note: `ftu goal discovery from message:${sourceMessageId ?? "(unknown)"}`,
+          },
+        );
+        await stateStore.complete({
+          goal: output.goal,
+          confidence: output.confidence,
+          discoveredAt,
+          ...(sourceMessageId ? { sourceMessageId } : {}),
+        });
+        return {
+          success: true,
+          values: {
+            ftuGoalDiscovered: true,
+            ftuGoalConfidence: output.confidence,
+          },
+        };
+      },
+    },
+  ],
+};

--- a/plugins/plugin-personal-assistant/src/lifeops/ftu-goal/state.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/ftu-goal/state.ts
@@ -1,0 +1,125 @@
+/**
+ * Post-first-run goal-discovery lifecycle state.
+ *
+ * After first-run setup completes, the assistant's next discovery job is to
+ * learn what the owner actually wants help with. This store owns the
+ * `pending` → `complete` lifecycle for that discovery: the `ftuGoal` provider
+ * surfaces its affordance while `pending`, and the `ftu_goal_discovery`
+ * evaluator flips it to `complete` exactly once when a high-confidence goal
+ * is extracted. The goal VALUE itself is canonical in the `OwnerFactStore`
+ * (`primaryGoal`); this record keeps only the lifecycle plus a discovery
+ * snapshot for audit.
+ *
+ * Persistence: cache-backed (same durability pattern as
+ * `FirstRunStateStore`), never in-memory only.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { asCacheRuntime } from "../runtime-cache.js";
+
+export type FtuGoalStatus = "pending" | "complete";
+
+export interface DiscoveredFtuGoal {
+  /** One compact sentence, in the owner's own terms. */
+  goal: string;
+  /** Extraction confidence in [0, 1] at the time the state flipped. */
+  confidence: number;
+  /** ISO-8601 instant the goal was recorded. */
+  discoveredAt: string;
+  /** Message id the extraction keyed off, when known. */
+  sourceMessageId?: string;
+}
+
+export interface FtuGoalRecord {
+  status: FtuGoalStatus;
+  goal?: DiscoveredFtuGoal;
+}
+
+export interface FtuGoalStateStore {
+  read(): Promise<FtuGoalRecord>;
+  /** Flip to `complete` with the discovered goal snapshot. Idempotent: a second call overwrites the snapshot but the status stays `complete`. */
+  complete(goal: DiscoveredFtuGoal): Promise<FtuGoalRecord>;
+  /** Clear the lifecycle back to `pending` (tests / owner-requested re-discovery). */
+  reset(): Promise<void>;
+}
+
+const FTU_GOAL_CACHE_KEY = "eliza:lifeops:ftu-goal:v1";
+
+const EMPTY_RECORD: FtuGoalRecord = { status: "pending" };
+
+function normalizeGoal(value: unknown): DiscoveredFtuGoal | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const v = value as Record<string, unknown>;
+  const goal = typeof v.goal === "string" ? v.goal.trim() : "";
+  const confidence =
+    typeof v.confidence === "number" &&
+    Number.isFinite(v.confidence) &&
+    v.confidence >= 0 &&
+    v.confidence <= 1
+      ? v.confidence
+      : null;
+  const discoveredAt =
+    typeof v.discoveredAt === "string" &&
+    Number.isFinite(Date.parse(v.discoveredAt))
+      ? v.discoveredAt
+      : null;
+  if (!goal || confidence === null || discoveredAt === null) {
+    return undefined;
+  }
+  const normalized: DiscoveredFtuGoal = { goal, confidence, discoveredAt };
+  if (typeof v.sourceMessageId === "string" && v.sourceMessageId.length > 0) {
+    normalized.sourceMessageId = v.sourceMessageId;
+  }
+  return normalized;
+}
+
+function normalizeRecord(value: unknown): FtuGoalRecord {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return { ...EMPTY_RECORD };
+  }
+  const v = value as Record<string, unknown>;
+  const goal = normalizeGoal(v.goal);
+  // A `complete` status without a valid goal snapshot is a corrupt record;
+  // treat it as pending so discovery re-runs instead of silently stalling.
+  if (v.status === "complete" && goal) {
+    return { status: "complete", goal };
+  }
+  return { ...EMPTY_RECORD };
+}
+
+export function createFtuGoalStateStore(
+  runtime: IAgentRuntime,
+): FtuGoalStateStore {
+  const cache = asCacheRuntime(runtime);
+
+  const read = async (): Promise<FtuGoalRecord> => {
+    const stored = await cache.getCache<FtuGoalRecord>(FTU_GOAL_CACHE_KEY);
+    return normalizeRecord(stored);
+  };
+
+  return {
+    read,
+    async complete(goal: DiscoveredFtuGoal): Promise<FtuGoalRecord> {
+      const normalized = normalizeGoal(goal);
+      if (!normalized) {
+        throw new Error(
+          "[ftu-goal-state] complete() requires a goal with goal text, confidence in [0,1], and an ISO discoveredAt",
+        );
+      }
+      const next: FtuGoalRecord = { status: "complete", goal: normalized };
+      await cache.setCache<FtuGoalRecord>(FTU_GOAL_CACHE_KEY, next);
+      return { status: next.status, goal: { ...normalized } };
+    },
+    async reset(): Promise<void> {
+      if (typeof cache.deleteCache === "function") {
+        await cache.deleteCache(FTU_GOAL_CACHE_KEY);
+      } else {
+        await cache.setCache<FtuGoalRecord>(FTU_GOAL_CACHE_KEY, {
+          ...EMPTY_RECORD,
+        });
+      }
+    },
+  };
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/fact-store.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/fact-store.ts
@@ -140,6 +140,13 @@ export interface OwnerFacts {
   age?: OwnerFactEntry<string>;
   location?: OwnerFactEntry<string>;
 
+  /**
+   * What the owner primarily wants the assistant's help with — one compact
+   * sentence in the owner's own terms. Discovered conversationally after
+   * first-run by the `ftu_goal_discovery` evaluator.
+   */
+  primaryGoal?: OwnerFactEntry<string>;
+
   // Preferences
   travelBookingPreferences?: OwnerFactEntry<string>;
   activeTravel?: OwnerFactEntry<OwnerActiveTravel>;
@@ -167,6 +174,7 @@ export interface OwnerFactsPatch {
   gender?: string;
   age?: string;
   location?: string;
+  primaryGoal?: string;
   travelBookingPreferences?: string;
   morningWindow?: OwnerFactWindow;
   eveningWindow?: OwnerFactWindow;
@@ -459,6 +467,7 @@ function normalizeRecord(value: unknown): PersistedRecord {
     "gender",
     "age",
     "location",
+    "primaryGoal",
     "travelBookingPreferences",
     "preferredNotificationChannel",
     "locale",
@@ -517,6 +526,7 @@ interface NormalizedPatch {
       | "gender"
       | "age"
       | "location"
+      | "primaryGoal"
       | "travelBookingPreferences"
       | "preferredNotificationChannel"
       | "locale"
@@ -542,6 +552,7 @@ function normalizePatch(patch: OwnerFactsPatch): NormalizedPatch {
     "gender",
     "age",
     "location",
+    "primaryGoal",
     "travelBookingPreferences",
     "preferredNotificationChannel",
     "locale",
@@ -653,6 +664,7 @@ class CacheBackedOwnerFactStore implements OwnerFactStore {
       "gender",
       "age",
       "location",
+      "primaryGoal",
       "travelBookingPreferences",
       "preferredNotificationChannel",
       "locale",
@@ -817,6 +829,9 @@ function cloneFacts(facts: OwnerFacts): OwnerFacts {
   if (facts.gender) next.gender = cloneStringEntry(facts.gender);
   if (facts.age) next.age = cloneStringEntry(facts.age);
   if (facts.location) next.location = cloneStringEntry(facts.location);
+  if (facts.primaryGoal) {
+    next.primaryGoal = cloneStringEntry(facts.primaryGoal);
+  }
   if (facts.travelBookingPreferences) {
     next.travelBookingPreferences = cloneStringEntry(
       facts.travelBookingPreferences,

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
@@ -41,6 +41,7 @@ import {
   createRecentTaskStatesProvider,
   type RecentTaskStateEntry,
 } from "../../providers/recent-task-states.js";
+import { recordProactiveDispatch } from "../anticipation/store.js";
 import {
   ownerFactsToView,
   type ReminderIntensity,
@@ -423,7 +424,7 @@ async function recordPendingPromptIfNeeded(args: {
   const roomId = pendingPromptRoomIdForTask(args.result);
   if (!roomId || !args.result.state.firedAt) return null;
   const store = resolvePendingPromptsStore(args.runtime);
-  return store.record({
+  const recorded = await store.record({
     roomId,
     taskId: args.result.taskId,
     promptSnippet: args.result.promptInstructions,
@@ -437,6 +438,30 @@ async function recordPendingPromptIfNeeded(args: {
           ).toISOString()
         : undefined,
   });
+  // The anticipation-feedback marker mirrors the pending prompt but is
+  // resolved by the post-turn evaluator, not by inbound-reply completion —
+  // pending prompts are gone before evaluators run (see
+  // ../anticipation/store.ts).
+  try {
+    await recordProactiveDispatch(args.runtime, {
+      roomId,
+      taskId: args.result.taskId,
+      firedAt: args.result.state.firedAt,
+      snippet: args.result.promptInstructions,
+    });
+  } catch (error) {
+    // error-policy:J7 diagnostics-must-not-kill-the-loop — a failed learning
+    // marker must not undo the pending prompt that already committed;
+    // reportError keeps repeated failures observable.
+    logger.warn(
+      `[lifeops-scheduled-task] anticipation marker write failed for ${args.result.taskId}: ${errorMessage(error)}`,
+    );
+    args.runtime.reportError("lifeops:scheduled-task:anticipation", error, {
+      taskId: args.result.taskId,
+      roomId,
+    });
+  }
+  return recorded;
 }
 
 export async function processDueScheduledTasks(

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -97,6 +97,7 @@ import {
   FOLLOWUP_TRACKER_TASK_NAME,
   registerFollowupTrackerWorker,
 } from "./followup/index.js";
+import { anticipationFeedbackEvaluator } from "./lifeops/anticipation/evaluator.js";
 import { registerLifeOpsCalendarGate } from "./lifeops/calendar-gate.js";
 import {
   createChannelRegistry,
@@ -111,6 +112,7 @@ import {
 import { applyMockoonEnvOverrides } from "./lifeops/connectors/mockoon-redirect.js";
 import { handleVoiceTurnObserved } from "./lifeops/entities/voice-observer-bridge.js";
 import { FirstRunService } from "./lifeops/first-run/service.js";
+import { ftuGoalDiscoveryEvaluator } from "./lifeops/ftu-goal/evaluator.js";
 import { createOwnerLocaleExamplesProvider } from "./lifeops/i18n/localized-examples-provider.js";
 import {
   createMultilingualPromptRegistry,
@@ -175,6 +177,7 @@ import { activityProfileProvider } from "./providers/activity-profile.js";
 import { crossChannelContextProvider } from "./providers/cross-channel-context.js";
 // LifeOps core providers
 import { firstRunProvider } from "./providers/first-run.js";
+import { ftuGoalProvider } from "./providers/ftu-goal.js";
 import { healthProvider } from "./providers/health.js";
 import { lifeOpsProvider } from "./providers/lifeops.js";
 import { pendingApprovalsProvider } from "./providers/pending-approvals.js";
@@ -631,6 +634,7 @@ const rawPersonalAssistantPlugin: Plugin = {
   providers: [
     browserBridgeProvider,
     firstRunProvider,
+    ftuGoalProvider,
     roomPolicyProvider,
     lifeOpsProvider,
     pendingApprovalsProvider,
@@ -656,6 +660,9 @@ const rawPersonalAssistantPlugin: Plugin = {
   ],
   responseHandlerEvaluators: [ownerProfileExtractionEvaluator],
   responseHandlerFieldEvaluators: [threadOpsFieldEvaluator],
+  // Post-turn evaluators join the runtime's single merged SMALL-model
+  // evaluation call (EvaluatorService) — no extra model round-trip per turn.
+  evaluators: [ftuGoalDiscoveryEvaluator, anticipationFeedbackEvaluator],
   // No views — the LifeOps overview surface was removed (owner: "no need for an
   // overview"). Domain views live in the per-domain plugins; the personal
   // assistant is the chat itself (PERSONAL_ASSISTANT action).
@@ -1081,6 +1088,20 @@ export {
   setFollowupThresholdAction,
   writeOverdueDigestMemory,
 } from "./followup/index.js";
+export {
+  anticipationFeedbackEvaluator,
+  type AnticipationFeedbackOutput,
+  parseAnticipationFeedbackOutput,
+} from "./lifeops/anticipation/evaluator.js";
+export {
+  type AnticipationOutcome,
+  type AnticipationStats,
+  listUnprocessedDispatches,
+  type ProactiveDispatchMarker,
+  readAnticipationStats,
+  recordAnticipationFeedback,
+  recordProactiveDispatch,
+} from "./lifeops/anticipation/store.js";
 export { CheckinService } from "./lifeops/checkin/checkin-service.js";
 export type { CheckinSchedule } from "./lifeops/checkin/schedule-resolver.js";
 export { resolveCheckinSchedule } from "./lifeops/checkin/schedule-resolver.js";
@@ -1111,6 +1132,19 @@ export {
   type SeededDefaultsMarker,
   type SeededDefaultsStore,
 } from "./lifeops/first-run/state.js";
+export {
+  FTU_GOAL_CONFIDENCE_THRESHOLD,
+  ftuGoalDiscoveryEvaluator,
+  type FtuGoalDiscoveryOutput,
+  parseFtuGoalOutput,
+} from "./lifeops/ftu-goal/evaluator.js";
+export {
+  createFtuGoalStateStore,
+  type DiscoveredFtuGoal,
+  type FtuGoalRecord,
+  type FtuGoalStateStore,
+  type FtuGoalStatus,
+} from "./lifeops/ftu-goal/state.js";
 export {
   createGlobalPauseStore,
   type GlobalPauseStatus,
@@ -1262,6 +1296,8 @@ export {
 } from "./lifeops/work-threads/index.js";
 export type { FirstRunAffordance } from "./providers/first-run.js";
 export { firstRunProvider } from "./providers/first-run.js";
+export type { FtuGoalAffordance } from "./providers/ftu-goal.js";
+export { ftuGoalProvider } from "./providers/ftu-goal.js";
 export { healthProvider } from "./providers/health.js";
 export { inboxTriageProvider } from "./providers/inbox-triage.js";
 export { lifeOpsProvider } from "./providers/lifeops.js";

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -1089,8 +1089,8 @@ export {
   writeOverdueDigestMemory,
 } from "./followup/index.js";
 export {
-  anticipationFeedbackEvaluator,
   type AnticipationFeedbackOutput,
+  anticipationFeedbackEvaluator,
   parseAnticipationFeedbackOutput,
 } from "./lifeops/anticipation/evaluator.js";
 export {
@@ -1134,8 +1134,8 @@ export {
 } from "./lifeops/first-run/state.js";
 export {
   FTU_GOAL_CONFIDENCE_THRESHOLD,
-  ftuGoalDiscoveryEvaluator,
   type FtuGoalDiscoveryOutput,
+  ftuGoalDiscoveryEvaluator,
   parseFtuGoalOutput,
 } from "./lifeops/ftu-goal/evaluator.js";
 export {

--- a/plugins/plugin-personal-assistant/src/providers/ftu-goal.ts
+++ b/plugins/plugin-personal-assistant/src/providers/ftu-goal.ts
@@ -1,0 +1,106 @@
+/**
+ * `ftuGoalProvider` — surfaces the post-first-run goal-discovery affordance
+ * to the planner: once setup is complete but the assistant has not yet
+ * learned what the owner primarily wants help with, it injects a compact
+ * instruction to discover that conversationally (one natural question woven
+ * into the reply — never a survey). Goes silent the moment the
+ * `ftu_goal_discovery` evaluator records a goal.
+ *
+ * Position `-5`: after `firstRun` (`-10`) so the setup affordance always wins
+ * the turn while first-run is still pending, but ahead of ordinary context.
+ * Private surfaces only (DM / voice DM / self / API) — goal discovery is an
+ * owner conversation, not something to raise in a group room.
+ */
+
+import { hasOwnerAccess } from "@elizaos/agent";
+import type {
+  IAgentRuntime,
+  Memory,
+  Provider,
+  ProviderResult,
+  State,
+} from "@elizaos/core";
+import { ChannelType, logger } from "@elizaos/core";
+import { createFirstRunStateStore } from "../lifeops/first-run/state.js";
+import { createFtuGoalStateStore } from "../lifeops/ftu-goal/state.js";
+
+export interface FtuGoalAffordance {
+  kind: "ftu_goal_discovery_pending";
+  oneLine: string;
+}
+
+const QUIET_RESULT: ProviderResult = {
+  text: "",
+  values: { ftuGoalPending: false },
+  data: {},
+};
+
+const ONE_LINE =
+  "You haven't learned what the owner mainly wants your help with. Weave ONE natural, curious question into your reply to discover what they value or want to get done — conversational, never a survey.";
+
+function isPrivateSurface(message: Memory): boolean {
+  const channelType = message.content.channelType;
+  return (
+    channelType === ChannelType.DM ||
+    channelType === ChannelType.VOICE_DM ||
+    channelType === ChannelType.SELF ||
+    channelType === ChannelType.API
+  );
+}
+
+export const ftuGoalProvider: Provider = {
+  name: "ftuGoal",
+  description:
+    "Surfaces a goal-discovery affordance after first-run completes and before a primary owner goal is known. Silent once the goal is discovered.",
+  descriptionCompressed:
+    "Post-first-run goal-discovery affordance; quiet once a goal is known.",
+  dynamic: true,
+  position: -5,
+  cacheScope: "turn",
+
+  async get(
+    runtime: IAgentRuntime,
+    message: Memory,
+    _state: State,
+  ): Promise<ProviderResult> {
+    if (!isPrivateSurface(message)) {
+      return QUIET_RESULT;
+    }
+    if (!(await hasOwnerAccess(runtime, message))) {
+      return QUIET_RESULT;
+    }
+
+    let firstRunComplete: boolean;
+    let goalPending: boolean;
+    try {
+      const [firstRun, ftuGoal] = await Promise.all([
+        createFirstRunStateStore(runtime).read(),
+        createFtuGoalStateStore(runtime).read(),
+      ]);
+      firstRunComplete = firstRun.status === "complete";
+      goalPending = ftuGoal.status === "pending";
+    } catch (error) {
+      // error-policy:J4 — a broken cache backend must not break the turn; the
+      // affordance degrades to silent and the failure stays observable.
+      logger.debug("[ftu-goal-provider] state read failed:", String(error));
+      return QUIET_RESULT;
+    }
+
+    // Discovery only starts once setup is done: while first-run is pending the
+    // firstRun provider owns the onboarding turn, and stacking a second ask on
+    // top of setup questions would turn onboarding into a survey.
+    if (!firstRunComplete || !goalPending) {
+      return QUIET_RESULT;
+    }
+
+    const affordance: FtuGoalAffordance = {
+      kind: "ftu_goal_discovery_pending",
+      oneLine: ONE_LINE,
+    };
+    return {
+      text: ONE_LINE,
+      values: { ftuGoalPending: true },
+      data: { affordance },
+    };
+  },
+};

--- a/plugins/plugin-personal-assistant/test/anticipation-feedback.test.ts
+++ b/plugins/plugin-personal-assistant/test/anticipation-feedback.test.ts
@@ -18,7 +18,7 @@ import {
   recordAnticipationFeedback,
   recordProactiveDispatch,
 } from "../src/lifeops/anticipation/store.ts";
-import { createMinimalRuntimeStub } from "./first-run-helpers.ts";
+import { createOwnerRuntimeStub } from "./first-run-helpers.ts";
 
 const ROOM_ID = "room-anticipation-1";
 const EMPTY_STATE = { values: {}, data: {}, text: "" } as never;
@@ -50,7 +50,7 @@ async function recordMarker(
 
 describe("proactive-dispatch marker store", () => {
   it("validates inputs", async () => {
-    const runtime = createMinimalRuntimeStub();
+    const runtime = createOwnerRuntimeStub();
     await expect(
       recordProactiveDispatch(runtime, {
         roomId: "",
@@ -70,7 +70,7 @@ describe("proactive-dispatch marker store", () => {
   });
 
   it("lists markers oldest-first and re-recording a task replaces its marker", async () => {
-    const runtime = createMinimalRuntimeStub();
+    const runtime = createOwnerRuntimeStub();
     const base = Date.now();
     await recordMarker(runtime, "t2", new Date(base - 60_000).toISOString());
     await recordMarker(runtime, "t1", new Date(base - 120_000).toISOString());
@@ -85,7 +85,7 @@ describe("proactive-dispatch marker store", () => {
   });
 
   it("ages markers out after the retention window", async () => {
-    const runtime = createMinimalRuntimeStub();
+    const runtime = createOwnerRuntimeStub();
     const now = new Date();
     await recordMarker(
       runtime,
@@ -102,7 +102,7 @@ describe("proactive-dispatch marker store", () => {
   });
 
   it("bounds the per-room marker ring to the newest entries", async () => {
-    const runtime = createMinimalRuntimeStub();
+    const runtime = createOwnerRuntimeStub();
     const base = Date.now();
     for (let i = 0; i < 10; i += 1) {
       await recordMarker(
@@ -137,7 +137,7 @@ describe("anticipation_feedback output parsing", () => {
 
 describe("anticipation_feedback evaluator", () => {
   it("shouldRun is false without unprocessed markers and for the agent's own turns", async () => {
-    const runtime = createMinimalRuntimeStub();
+    const runtime = createOwnerRuntimeStub();
     expect(
       await anticipationFeedbackEvaluator.shouldRun({
         runtime,
@@ -168,7 +168,7 @@ describe("anticipation_feedback evaluator", () => {
   });
 
   it("prompt embeds the newest proactive snippet", async () => {
-    const runtime = createMinimalRuntimeStub();
+    const runtime = createOwnerRuntimeStub();
     await recordMarker(
       runtime,
       "t1",
@@ -193,7 +193,7 @@ describe("anticipation_feedback evaluator", () => {
   });
 
   it("processor records the classified outcome, marks older markers ignored, and never double-processes", async () => {
-    const runtime = createMinimalRuntimeStub();
+    const runtime = createOwnerRuntimeStub();
     const base = Date.now();
     await recordMarker(runtime, "old", new Date(base - 120_000).toISOString());
     await recordMarker(runtime, "new", new Date(base - 30_000).toISOString());
@@ -249,7 +249,7 @@ describe("anticipation_feedback evaluator", () => {
 
 describe("rolling anticipation stats", () => {
   it("accumulates durably and bounds the recent ring", async () => {
-    const runtime = createMinimalRuntimeStub();
+    const runtime = createOwnerRuntimeStub();
     const now = new Date();
     for (let i = 0; i < 25; i += 1) {
       await recordAnticipationFeedback(

--- a/plugins/plugin-personal-assistant/test/anticipation-feedback.test.ts
+++ b/plugins/plugin-personal-assistant/test/anticipation-feedback.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Covers the anticipation-feedback loop: proactive-dispatch markers (record /
+ * age-out / bounds), the anticipation_feedback evaluator's shouldRun gate,
+ * parse, and processor (newest marker model-classified, older ones counted
+ * ignored, markers removed so the turn is never classified twice), and the
+ * durable rolling stats. Deterministic — real stores against the real runtime
+ * cache contract, no model call.
+ */
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  anticipationFeedbackEvaluator,
+  parseAnticipationFeedbackOutput,
+} from "../src/lifeops/anticipation/evaluator.ts";
+import {
+  listUnprocessedDispatches,
+  readAnticipationStats,
+  recordAnticipationFeedback,
+  recordProactiveDispatch,
+} from "../src/lifeops/anticipation/store.ts";
+import { createMinimalRuntimeStub } from "./first-run-helpers.ts";
+
+const ROOM_ID = "room-anticipation-1";
+const EMPTY_STATE = { values: {}, data: {}, text: "" } as never;
+
+function ownerReply(runtime: IAgentRuntime, text: string): Memory {
+  return {
+    id: "msg-reply-1",
+    entityId: "owner-entity-1",
+    roomId: ROOM_ID,
+    agentId: runtime.agentId,
+    content: { text },
+    createdAt: Date.now(),
+  } as never;
+}
+
+async function recordMarker(
+  runtime: IAgentRuntime,
+  taskId: string,
+  firedAt: string,
+  snippet = "Morning! Want a quick plan for today?",
+): Promise<void> {
+  await recordProactiveDispatch(runtime, {
+    roomId: ROOM_ID,
+    taskId,
+    firedAt,
+    snippet,
+  });
+}
+
+describe("proactive-dispatch marker store", () => {
+  it("validates inputs", async () => {
+    const runtime = createMinimalRuntimeStub();
+    await expect(
+      recordProactiveDispatch(runtime, {
+        roomId: "",
+        taskId: "t1",
+        firedAt: new Date().toISOString(),
+        snippet: "x",
+      }),
+    ).rejects.toThrow(/roomId/);
+    await expect(
+      recordProactiveDispatch(runtime, {
+        roomId: ROOM_ID,
+        taskId: "t1",
+        firedAt: "not-a-date",
+        snippet: "x",
+      }),
+    ).rejects.toThrow(/ISO-8601/);
+  });
+
+  it("lists markers oldest-first and re-recording a task replaces its marker", async () => {
+    const runtime = createMinimalRuntimeStub();
+    const base = Date.now();
+    await recordMarker(runtime, "t2", new Date(base - 60_000).toISOString());
+    await recordMarker(runtime, "t1", new Date(base - 120_000).toISOString());
+    let markers = await listUnprocessedDispatches(runtime, ROOM_ID);
+    expect(markers.map((m) => m.taskId)).toEqual(["t1", "t2"]);
+
+    const refire = new Date(base - 1_000).toISOString();
+    await recordMarker(runtime, "t1", refire, "updated nudge");
+    markers = await listUnprocessedDispatches(runtime, ROOM_ID);
+    expect(markers.map((m) => m.taskId)).toEqual(["t2", "t1"]);
+    expect(markers[1]?.snippet).toBe("updated nudge");
+  });
+
+  it("ages markers out after the retention window", async () => {
+    const runtime = createMinimalRuntimeStub();
+    const now = new Date();
+    await recordMarker(
+      runtime,
+      "stale",
+      new Date(now.getTime() - 25 * 3_600_000).toISOString(),
+    );
+    await recordMarker(
+      runtime,
+      "fresh",
+      new Date(now.getTime() - 3_600_000).toISOString(),
+    );
+    const markers = await listUnprocessedDispatches(runtime, ROOM_ID, { now });
+    expect(markers.map((m) => m.taskId)).toEqual(["fresh"]);
+  });
+
+  it("bounds the per-room marker ring to the newest entries", async () => {
+    const runtime = createMinimalRuntimeStub();
+    const base = Date.now();
+    for (let i = 0; i < 10; i += 1) {
+      await recordMarker(
+        runtime,
+        `t${i}`,
+        new Date(base - (10 - i) * 60_000).toISOString(),
+      );
+    }
+    const markers = await listUnprocessedDispatches(runtime, ROOM_ID);
+    expect(markers).toHaveLength(8);
+    expect(markers[0]?.taskId).toBe("t2");
+    expect(markers[7]?.taskId).toBe("t9");
+  });
+});
+
+describe("anticipation_feedback output parsing", () => {
+  it("accepts only the three outcomes", () => {
+    expect(parseAnticipationFeedbackOutput({ outcome: "accepted" })).toEqual({
+      outcome: "accepted",
+    });
+    expect(parseAnticipationFeedbackOutput({ outcome: "rejected" })).toEqual({
+      outcome: "rejected",
+    });
+    expect(parseAnticipationFeedbackOutput({ outcome: "ignored" })).toEqual({
+      outcome: "ignored",
+    });
+    expect(parseAnticipationFeedbackOutput({ outcome: "maybe" })).toBeNull();
+    expect(parseAnticipationFeedbackOutput("accepted")).toBeNull();
+    expect(parseAnticipationFeedbackOutput(null)).toBeNull();
+  });
+});
+
+describe("anticipation_feedback evaluator", () => {
+  it("shouldRun is false without unprocessed markers and for the agent's own turns", async () => {
+    const runtime = createMinimalRuntimeStub();
+    expect(
+      await anticipationFeedbackEvaluator.shouldRun({
+        runtime,
+        message: ownerReply(runtime, "hello"),
+        options: {},
+      }),
+    ).toBe(false);
+
+    await recordMarker(runtime, "t1", new Date().toISOString());
+    const agentTurn = {
+      ...ownerReply(runtime, "here is your plan"),
+      entityId: runtime.agentId,
+    } as Memory;
+    expect(
+      await anticipationFeedbackEvaluator.shouldRun({
+        runtime,
+        message: agentTurn,
+        options: {},
+      }),
+    ).toBe(false);
+    expect(
+      await anticipationFeedbackEvaluator.shouldRun({
+        runtime,
+        message: ownerReply(runtime, "yes please!"),
+        options: {},
+      }),
+    ).toBe(true);
+  });
+
+  it("prompt embeds the newest proactive snippet", async () => {
+    const runtime = createMinimalRuntimeStub();
+    await recordMarker(
+      runtime,
+      "t1",
+      new Date().toISOString(),
+      "Want me to prep your morning brief?",
+    );
+    const message = ownerReply(runtime, "sure");
+    const prepared = await anticipationFeedbackEvaluator.prepare?.({
+      runtime,
+      message,
+      state: EMPTY_STATE,
+      options: {},
+    });
+    const prompt = anticipationFeedbackEvaluator.prompt({
+      runtime,
+      message,
+      state: EMPTY_STATE,
+      options: {},
+      prepared: prepared as never,
+    });
+    expect(prompt).toContain("Want me to prep your morning brief?");
+  });
+
+  it("processor records the classified outcome, marks older markers ignored, and never double-processes", async () => {
+    const runtime = createMinimalRuntimeStub();
+    const base = Date.now();
+    await recordMarker(runtime, "old", new Date(base - 120_000).toISOString());
+    await recordMarker(runtime, "new", new Date(base - 30_000).toISOString());
+
+    const message = ownerReply(runtime, "yes, that helps — thanks!");
+    const prepared = await anticipationFeedbackEvaluator.prepare?.({
+      runtime,
+      message,
+      state: EMPTY_STATE,
+      options: {},
+    });
+    const processor = anticipationFeedbackEvaluator.processors?.[0];
+    if (!processor) {
+      throw new Error("anticipation_feedback must register its processor");
+    }
+    const result = await processor.process({
+      runtime,
+      message,
+      state: EMPTY_STATE,
+      options: {},
+      prepared: prepared as never,
+      output: { outcome: "accepted" },
+      evaluatorName: anticipationFeedbackEvaluator.name,
+    });
+    expect(result).toMatchObject({
+      success: true,
+      values: {
+        anticipationOutcome: "accepted",
+        anticipationAccepted: 1,
+        anticipationIgnored: 1,
+        anticipationRejected: 0,
+      },
+    });
+
+    // Markers are consumed: the same owner turn cannot be classified twice.
+    expect(await listUnprocessedDispatches(runtime, ROOM_ID)).toHaveLength(0);
+    expect(
+      await anticipationFeedbackEvaluator.shouldRun({
+        runtime,
+        message,
+        options: {},
+      }),
+    ).toBe(false);
+
+    const stats = await readAnticipationStats(runtime);
+    expect(stats).toMatchObject({ accepted: 1, rejected: 0, ignored: 1 });
+    expect(stats.recent.map((entry) => entry.outcome)).toEqual([
+      "ignored",
+      "accepted",
+    ]);
+  });
+});
+
+describe("rolling anticipation stats", () => {
+  it("accumulates durably and bounds the recent ring", async () => {
+    const runtime = createMinimalRuntimeStub();
+    const now = new Date();
+    for (let i = 0; i < 25; i += 1) {
+      await recordAnticipationFeedback(
+        runtime,
+        ROOM_ID,
+        [
+          {
+            marker: {
+              taskId: `t${i}`,
+              firedAt: now.toISOString(),
+              snippet: "nudge",
+            },
+            outcome: i % 2 === 0 ? "accepted" : "rejected",
+          },
+        ],
+        { now },
+      );
+    }
+    const stats = await readAnticipationStats(runtime, { now });
+    expect(stats.accepted).toBe(13);
+    expect(stats.rejected).toBe(12);
+    expect(stats.recent).toHaveLength(20);
+    expect(stats.recent[stats.recent.length - 1]?.taskId).toBe("t24");
+  });
+});

--- a/plugins/plugin-personal-assistant/test/first-run-helpers.ts
+++ b/plugins/plugin-personal-assistant/test/first-run-helpers.ts
@@ -124,3 +124,29 @@ export function createMinimalRuntimeStub(
 }
 
 export const SCHEDULER_TASK_ID_FOR_TESTS = SCHEDULER_TASK_ID;
+
+/**
+ * The entity id owner-gated tests send messages from. A deployed app records
+ * its owner in the `ELIZA_ADMIN_ENTITY_ID` setting (the canonical-owner key
+ * `getConfiguredOwnerEntityIds` reads); {@link createOwnerRuntimeStub} wires
+ * that setting to this id so `hasOwnerAccess` resolves the sender as OWNER
+ * without standing up a full world/role graph.
+ */
+export const OWNER_ENTITY_ID_FOR_TESTS = "owner-entity-1";
+
+/**
+ * A minimal runtime stub whose sender ({@link OWNER_ENTITY_ID_FOR_TESTS}) is
+ * the configured canonical owner, so owner-gated providers/evaluators run. The
+ * caller's overrides win (none of the owner-gated tests set `getSetting`).
+ */
+export function createOwnerRuntimeStub(
+  overrides: Partial<MinimalRuntimeStub> = {},
+): IAgentRuntime {
+  return createMinimalRuntimeStub({
+    getSetting: ((key: string) =>
+      key === "ELIZA_ADMIN_ENTITY_ID"
+        ? OWNER_ENTITY_ID_FOR_TESTS
+        : undefined) as never,
+    ...overrides,
+  });
+}

--- a/plugins/plugin-personal-assistant/test/ftu-evaluators-merged-call.test.ts
+++ b/plugins/plugin-personal-assistant/test/ftu-evaluators-merged-call.test.ts
@@ -19,7 +19,7 @@ import { createFirstRunStateStore } from "../src/lifeops/first-run/state.ts";
 import { ftuGoalDiscoveryEvaluator } from "../src/lifeops/ftu-goal/evaluator.ts";
 import { createFtuGoalStateStore } from "../src/lifeops/ftu-goal/state.ts";
 import { createOwnerFactStore } from "../src/lifeops/owner/fact-store.ts";
-import { createMinimalRuntimeStub } from "./first-run-helpers.ts";
+import { createOwnerRuntimeStub } from "./first-run-helpers.ts";
 
 const ROOM_ID = "room-merged-call-1";
 
@@ -33,7 +33,7 @@ function createEvaluatorRuntime(modelOutput: Record<string, unknown>): {
   calls: CapturedModelCall[];
 } {
   const calls: CapturedModelCall[] = [];
-  const runtime = createMinimalRuntimeStub({
+  const runtime = createOwnerRuntimeStub({
     evaluators: [ftuGoalDiscoveryEvaluator, anticipationFeedbackEvaluator],
     useModel: (async (
       _modelType: string,

--- a/plugins/plugin-personal-assistant/test/ftu-evaluators-merged-call.test.ts
+++ b/plugins/plugin-personal-assistant/test/ftu-evaluators-merged-call.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Drives the REAL core EvaluatorService end to end with both new
+ * personal-assistant evaluators registered: one merged schema-constrained
+ * SMALL-model call, sections parsed per evaluator, processors persisting to
+ * the real stores, and shouldRun closing both gates afterwards (no second
+ * model call, no reprocessing). The model response is a deterministic stub —
+ * everything else (service, evaluators, stores, cache) is the production code.
+ */
+import type { IAgentRuntime, JSONSchema, Memory } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { EvaluatorService } from "../../../packages/core/src/services/evaluator.ts";
+import { anticipationFeedbackEvaluator } from "../src/lifeops/anticipation/evaluator.ts";
+import {
+  listUnprocessedDispatches,
+  readAnticipationStats,
+  recordProactiveDispatch,
+} from "../src/lifeops/anticipation/store.ts";
+import { createFirstRunStateStore } from "../src/lifeops/first-run/state.ts";
+import { ftuGoalDiscoveryEvaluator } from "../src/lifeops/ftu-goal/evaluator.ts";
+import { createFtuGoalStateStore } from "../src/lifeops/ftu-goal/state.ts";
+import { createOwnerFactStore } from "../src/lifeops/owner/fact-store.ts";
+import { createMinimalRuntimeStub } from "./first-run-helpers.ts";
+
+const ROOM_ID = "room-merged-call-1";
+
+interface CapturedModelCall {
+  prompt: string;
+  schema: JSONSchema | undefined;
+}
+
+function createEvaluatorRuntime(modelOutput: Record<string, unknown>): {
+  runtime: IAgentRuntime;
+  calls: CapturedModelCall[];
+} {
+  const calls: CapturedModelCall[] = [];
+  const runtime = createMinimalRuntimeStub({
+    evaluators: [ftuGoalDiscoveryEvaluator, anticipationFeedbackEvaluator],
+    useModel: (async (
+      _modelType: string,
+      params: {
+        messages?: Array<{ content: string }>;
+        responseSchema?: JSONSchema;
+      },
+    ) => {
+      calls.push({
+        prompt: params.messages?.[0]?.content ?? "",
+        schema: params.responseSchema,
+      });
+      return modelOutput;
+    }) as never,
+    emitEvent: (async () => {}) as never,
+    reportError: (() => {}) as never,
+    logger: {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    } as never,
+  } as never);
+  return { runtime, calls };
+}
+
+function ownerMessage(runtime: IAgentRuntime, text: string): Memory {
+  return {
+    id: "msg-merged-1",
+    entityId: "owner-entity-1",
+    roomId: ROOM_ID,
+    agentId: runtime.agentId,
+    content: { text },
+    createdAt: Date.now(),
+  } as never;
+}
+
+describe("FTU + anticipation evaluators through the real merged EvaluatorService call", () => {
+  it("runs both evaluators in one model call, persists via processors, then never reprocesses", async () => {
+    const { runtime, calls } = createEvaluatorRuntime({
+      ftu_goal_discovery: {
+        goalFound: true,
+        goal: "Stay on top of email and family follow-ups",
+        confidence: 0.85,
+      },
+      anticipation_feedback: { outcome: "accepted" },
+    });
+
+    const firstRun = createFirstRunStateStore(runtime);
+    await firstRun.begin("defaults");
+    await firstRun.complete();
+    await recordProactiveDispatch(runtime, {
+      roomId: ROOM_ID,
+      taskId: "gm-task",
+      firedAt: new Date(Date.now() - 60_000).toISOString(),
+      snippet: "Morning! Want a quick plan for today?",
+    });
+
+    const service = (await EvaluatorService.start(runtime)) as EvaluatorService;
+    const message = ownerMessage(
+      runtime,
+      "Yes please — mostly I need help staying on top of email and family follow-ups.",
+    );
+    const result = await service.run(message, undefined, { didRespond: true });
+
+    expect(result.skipped).toBe(false);
+    expect(result.errors).toEqual([]);
+    expect(result.activeEvaluators.sort()).toEqual([
+      "anticipation_feedback",
+      "ftu_goal_discovery",
+    ]);
+    expect(result.processedEvaluators.sort()).toEqual([
+      "anticipation_feedback",
+      "ftu_goal_discovery",
+    ]);
+
+    // Exactly ONE merged model call, whose prompt and schema carry both
+    // evaluator sections.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.prompt).toContain("### ftu_goal_discovery");
+    expect(calls[0]?.prompt).toContain("### anticipation_feedback");
+    expect(Object.keys(calls[0]?.schema?.properties ?? {}).sort()).toEqual([
+      "anticipation_feedback",
+      "ftu_goal_discovery",
+    ]);
+
+    // Processor side effects hit the real stores.
+    const facts = await createOwnerFactStore(runtime).read();
+    expect(facts.primaryGoal?.value).toBe(
+      "Stay on top of email and family follow-ups",
+    );
+    expect((await createFtuGoalStateStore(runtime).read()).status).toBe(
+      "complete",
+    );
+    expect(await listUnprocessedDispatches(runtime, ROOM_ID)).toHaveLength(0);
+    expect(await readAnticipationStats(runtime)).toMatchObject({
+      accepted: 1,
+      rejected: 0,
+      ignored: 0,
+    });
+
+    // Second turn: both gates are closed — the service skips without another
+    // model call and without touching the persisted state.
+    const second = await service.run(
+      ownerMessage(runtime, "thanks! also what's the weather"),
+      undefined,
+      { didRespond: true },
+    );
+    expect(second.skipped).toBe(true);
+    expect(second.activeEvaluators).toEqual([]);
+    expect(calls).toHaveLength(1);
+    expect(
+      (await createOwnerFactStore(runtime).read()).primaryGoal?.value,
+    ).toBe("Stay on top of email and family follow-ups");
+  });
+
+  it("keeps discovery open when the merged output is low-confidence", async () => {
+    const { runtime, calls } = createEvaluatorRuntime({
+      ftu_goal_discovery: {
+        goalFound: true,
+        goal: "Maybe something with fitness?",
+        confidence: 0.4,
+      },
+      anticipation_feedback: { outcome: "ignored" },
+    });
+    const firstRun = createFirstRunStateStore(runtime);
+    await firstRun.begin("defaults");
+    await firstRun.complete();
+
+    const service = (await EvaluatorService.start(runtime)) as EvaluatorService;
+    const result = await service.run(
+      ownerMessage(runtime, "eh, I sometimes think about the gym"),
+      undefined,
+      { didRespond: true },
+    );
+
+    // Only the goal evaluator was active (no proactive marker), it ran, and
+    // low confidence left the pipeline open for the next turn.
+    expect(result.activeEvaluators).toEqual(["ftu_goal_discovery"]);
+    expect(calls).toHaveLength(1);
+    expect((await createFtuGoalStateStore(runtime).read()).status).toBe(
+      "pending",
+    );
+    expect(
+      (await createOwnerFactStore(runtime).read()).primaryGoal,
+    ).toBeUndefined();
+  });
+});

--- a/plugins/plugin-personal-assistant/test/ftu-goal-discovery.test.ts
+++ b/plugins/plugin-personal-assistant/test/ftu-goal-discovery.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Covers the post-first-run goal-discovery surface: ftuGoal provider gating
+ * (private-only, first-run-complete-only, silent once discovered), the
+ * ftu_goal_discovery evaluator's shouldRun gate / parse / processor state
+ * transitions, and the no-double-processing guarantee. Deterministic — real
+ * stores against the real runtime cache contract, no model call.
+ */
+import { ChannelType, type IAgentRuntime, type Memory } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { createFirstRunStateStore } from "../src/lifeops/first-run/state.ts";
+import {
+  FTU_GOAL_CONFIDENCE_THRESHOLD,
+  ftuGoalDiscoveryEvaluator,
+  parseFtuGoalOutput,
+} from "../src/lifeops/ftu-goal/evaluator.ts";
+import { createFtuGoalStateStore } from "../src/lifeops/ftu-goal/state.ts";
+import { createOwnerFactStore } from "../src/lifeops/owner/fact-store.ts";
+import { ftuGoalProvider } from "../src/providers/ftu-goal.ts";
+import { createMinimalRuntimeStub } from "./first-run-helpers.ts";
+
+const EMPTY_STATE = { values: {}, data: {}, text: "" } as never;
+
+function ownerMessage(
+  runtime: IAgentRuntime,
+  text: string,
+  channelType: ChannelType = ChannelType.DM,
+): Memory {
+  return {
+    id: "msg-owner-1",
+    entityId: "owner-entity-1",
+    roomId: "room-1",
+    agentId: runtime.agentId,
+    content: { text, channelType },
+    createdAt: Date.now(),
+  } as never;
+}
+
+async function completeFirstRun(runtime: IAgentRuntime): Promise<void> {
+  const store = createFirstRunStateStore(runtime);
+  await store.begin("defaults");
+  await store.complete();
+}
+
+describe("ftuGoal provider gating", () => {
+  it("stays quiet while first-run is still pending", async () => {
+    const runtime = createMinimalRuntimeStub();
+    const result = await ftuGoalProvider.get(
+      runtime,
+      ownerMessage(runtime, "hello"),
+      EMPTY_STATE,
+    );
+    expect(result.values?.ftuGoalPending).toBe(false);
+    expect(result.text).toBe("");
+  });
+
+  it("surfaces the discovery affordance once first-run is complete and no goal is known", async () => {
+    const runtime = createMinimalRuntimeStub();
+    await completeFirstRun(runtime);
+    const result = await ftuGoalProvider.get(
+      runtime,
+      ownerMessage(runtime, "hey"),
+      EMPTY_STATE,
+    );
+    expect(result.values?.ftuGoalPending).toBe(true);
+    expect(result.text).toMatch(/discover what they value/i);
+    expect(result.data?.affordance).toMatchObject({
+      kind: "ftu_goal_discovery_pending",
+    });
+  });
+
+  it("stays quiet on non-private surfaces", async () => {
+    const runtime = createMinimalRuntimeStub();
+    await completeFirstRun(runtime);
+    const result = await ftuGoalProvider.get(
+      runtime,
+      ownerMessage(runtime, "hey", ChannelType.GROUP),
+      EMPTY_STATE,
+    );
+    expect(result.values?.ftuGoalPending).toBe(false);
+  });
+
+  it("goes silent once a goal has been discovered", async () => {
+    const runtime = createMinimalRuntimeStub();
+    await completeFirstRun(runtime);
+    await createFtuGoalStateStore(runtime).complete({
+      goal: "Ship the iOS app",
+      confidence: 0.9,
+      discoveredAt: new Date().toISOString(),
+    });
+    const result = await ftuGoalProvider.get(
+      runtime,
+      ownerMessage(runtime, "hey"),
+      EMPTY_STATE,
+    );
+    expect(result.values?.ftuGoalPending).toBe(false);
+    expect(result.text).toBe("");
+  });
+});
+
+describe("ftu_goal_discovery evaluator shouldRun gate", () => {
+  it("is false before first-run completes", async () => {
+    const runtime = createMinimalRuntimeStub();
+    const active = await ftuGoalDiscoveryEvaluator.shouldRun({
+      runtime,
+      message: ownerMessage(runtime, "I want help staying on top of email"),
+      options: {},
+    });
+    expect(active).toBe(false);
+  });
+
+  it("is true once first-run is complete and the goal is undiscovered", async () => {
+    const runtime = createMinimalRuntimeStub();
+    await completeFirstRun(runtime);
+    const active = await ftuGoalDiscoveryEvaluator.shouldRun({
+      runtime,
+      message: ownerMessage(runtime, "I want help staying on top of email"),
+      options: {},
+    });
+    expect(active).toBe(true);
+  });
+
+  it("is false for the agent's own messages", async () => {
+    const runtime = createMinimalRuntimeStub();
+    await completeFirstRun(runtime);
+    const message = {
+      ...ownerMessage(runtime, "noted!"),
+      entityId: runtime.agentId,
+    } as Memory;
+    const active = await ftuGoalDiscoveryEvaluator.shouldRun({
+      runtime,
+      message,
+      options: {},
+    });
+    expect(active).toBe(false);
+  });
+
+  it("is false once the goal is discovered — completed discovery never reprocesses", async () => {
+    const runtime = createMinimalRuntimeStub();
+    await completeFirstRun(runtime);
+    await createFtuGoalStateStore(runtime).complete({
+      goal: "Ship the iOS app",
+      confidence: 0.9,
+      discoveredAt: new Date().toISOString(),
+    });
+    const active = await ftuGoalDiscoveryEvaluator.shouldRun({
+      runtime,
+      message: ownerMessage(runtime, "also remind me to buy milk"),
+      options: {},
+    });
+    expect(active).toBe(false);
+  });
+});
+
+describe("ftu_goal_discovery output parsing", () => {
+  it("rejects non-object and malformed output", () => {
+    expect(parseFtuGoalOutput(null)).toBeNull();
+    expect(parseFtuGoalOutput("goal")).toBeNull();
+    expect(parseFtuGoalOutput([])).toBeNull();
+    expect(parseFtuGoalOutput({ goal: "x", confidence: 1 })).toBeNull();
+    expect(
+      parseFtuGoalOutput({ goalFound: "yes", goal: "x", confidence: 1 }),
+    ).toBeNull();
+  });
+
+  it("normalizes valid output: trims goal, clamps confidence, empties goalFound without text", () => {
+    expect(
+      parseFtuGoalOutput({
+        goalFound: true,
+        goal: "  Train for a marathon  ",
+        confidence: 1.7,
+      }),
+    ).toEqual({ goalFound: true, goal: "Train for a marathon", confidence: 1 });
+    expect(
+      parseFtuGoalOutput({ goalFound: true, goal: "   ", confidence: 0.9 }),
+    ).toEqual({ goalFound: false, goal: "", confidence: 0.9 });
+    expect(
+      parseFtuGoalOutput({
+        goalFound: false,
+        goal: "",
+        confidence: Number.NaN,
+      }),
+    ).toEqual({ goalFound: false, goal: "", confidence: 0 });
+  });
+});
+
+describe("ftu_goal_discovery processor", () => {
+  function processorContext(
+    runtime: IAgentRuntime,
+    output: { goalFound: boolean; goal: string; confidence: number },
+  ) {
+    return {
+      runtime,
+      message: ownerMessage(runtime, "I want help shipping my iOS app"),
+      state: EMPTY_STATE,
+      options: {},
+      prepared: undefined,
+      output,
+      evaluatorName: ftuGoalDiscoveryEvaluator.name,
+    };
+  }
+
+  const persistProcessor = ftuGoalDiscoveryEvaluator.processors?.[0];
+  if (!persistProcessor) {
+    throw new Error("ftu_goal_discovery must register its persist processor");
+  }
+
+  it("does not persist below the confidence threshold", async () => {
+    const runtime = createMinimalRuntimeStub();
+    await completeFirstRun(runtime);
+    const result = await persistProcessor.process(
+      processorContext(runtime, {
+        goalFound: true,
+        goal: "Ship the iOS app",
+        confidence: FTU_GOAL_CONFIDENCE_THRESHOLD - 0.1,
+      }),
+    );
+    expect(result).toBeUndefined();
+    expect((await createFtuGoalStateStore(runtime).read()).status).toBe(
+      "pending",
+    );
+    expect(
+      (await createOwnerFactStore(runtime).read()).primaryGoal,
+    ).toBeUndefined();
+  });
+
+  it("persists the primaryGoal fact with provenance and completes the durable state", async () => {
+    const runtime = createMinimalRuntimeStub();
+    await completeFirstRun(runtime);
+    const result = await persistProcessor.process(
+      processorContext(runtime, {
+        goalFound: true,
+        goal: "Ship the iOS app",
+        confidence: 0.9,
+      }),
+    );
+    expect(result).toMatchObject({
+      success: true,
+      values: { ftuGoalDiscovered: true, ftuGoalConfidence: 0.9 },
+    });
+
+    const facts = await createOwnerFactStore(runtime).read();
+    expect(facts.primaryGoal?.value).toBe("Ship the iOS app");
+    expect(facts.primaryGoal?.provenance.source).toBe("agent_inferred");
+    expect(facts.primaryGoal?.provenance.note).toContain("msg-owner-1");
+
+    // Durable, not instance-local: a fresh store on the same runtime cache
+    // reads the completed record (the PersonalityStore bug class, #14740).
+    const record = await createFtuGoalStateStore(runtime).read();
+    expect(record.status).toBe("complete");
+    expect(record.goal).toMatchObject({
+      goal: "Ship the iOS app",
+      confidence: 0.9,
+      sourceMessageId: "msg-owner-1",
+    });
+  });
+
+  it("never overwrites an already-discovered goal (idempotence backstop)", async () => {
+    const runtime = createMinimalRuntimeStub();
+    await completeFirstRun(runtime);
+    await persistProcessor.process(
+      processorContext(runtime, {
+        goalFound: true,
+        goal: "Ship the iOS app",
+        confidence: 0.9,
+      }),
+    );
+    const second = await persistProcessor.process(
+      processorContext(runtime, {
+        goalFound: true,
+        goal: "A totally different goal",
+        confidence: 0.99,
+      }),
+    );
+    expect(second).toBeUndefined();
+    const record = await createFtuGoalStateStore(runtime).read();
+    expect(record.goal?.goal).toBe("Ship the iOS app");
+    // shouldRun is the primary no-reprocessing gate and is now closed too.
+    const active = await ftuGoalDiscoveryEvaluator.shouldRun({
+      runtime,
+      message: ownerMessage(runtime, "more chatter"),
+      options: {},
+    });
+    expect(active).toBe(false);
+  });
+});

--- a/plugins/plugin-personal-assistant/test/ftu-goal-discovery.test.ts
+++ b/plugins/plugin-personal-assistant/test/ftu-goal-discovery.test.ts
@@ -16,7 +16,7 @@ import {
 import { createFtuGoalStateStore } from "../src/lifeops/ftu-goal/state.ts";
 import { createOwnerFactStore } from "../src/lifeops/owner/fact-store.ts";
 import { ftuGoalProvider } from "../src/providers/ftu-goal.ts";
-import { createMinimalRuntimeStub } from "./first-run-helpers.ts";
+import { createOwnerRuntimeStub } from "./first-run-helpers.ts";
 
 const EMPTY_STATE = { values: {}, data: {}, text: "" } as never;
 
@@ -43,7 +43,7 @@ async function completeFirstRun(runtime: IAgentRuntime): Promise<void> {
 
 describe("ftuGoal provider gating", () => {
   it("stays quiet while first-run is still pending", async () => {
-    const runtime = createMinimalRuntimeStub();
+    const runtime = createOwnerRuntimeStub();
     const result = await ftuGoalProvider.get(
       runtime,
       ownerMessage(runtime, "hello"),
@@ -54,7 +54,7 @@ describe("ftuGoal provider gating", () => {
   });
 
   it("surfaces the discovery affordance once first-run is complete and no goal is known", async () => {
-    const runtime = createMinimalRuntimeStub();
+    const runtime = createOwnerRuntimeStub();
     await completeFirstRun(runtime);
     const result = await ftuGoalProvider.get(
       runtime,
@@ -69,7 +69,7 @@ describe("ftuGoal provider gating", () => {
   });
 
   it("stays quiet on non-private surfaces", async () => {
-    const runtime = createMinimalRuntimeStub();
+    const runtime = createOwnerRuntimeStub();
     await completeFirstRun(runtime);
     const result = await ftuGoalProvider.get(
       runtime,
@@ -80,7 +80,7 @@ describe("ftuGoal provider gating", () => {
   });
 
   it("goes silent once a goal has been discovered", async () => {
-    const runtime = createMinimalRuntimeStub();
+    const runtime = createOwnerRuntimeStub();
     await completeFirstRun(runtime);
     await createFtuGoalStateStore(runtime).complete({
       goal: "Ship the iOS app",
@@ -99,7 +99,7 @@ describe("ftuGoal provider gating", () => {
 
 describe("ftu_goal_discovery evaluator shouldRun gate", () => {
   it("is false before first-run completes", async () => {
-    const runtime = createMinimalRuntimeStub();
+    const runtime = createOwnerRuntimeStub();
     const active = await ftuGoalDiscoveryEvaluator.shouldRun({
       runtime,
       message: ownerMessage(runtime, "I want help staying on top of email"),
@@ -109,7 +109,7 @@ describe("ftu_goal_discovery evaluator shouldRun gate", () => {
   });
 
   it("is true once first-run is complete and the goal is undiscovered", async () => {
-    const runtime = createMinimalRuntimeStub();
+    const runtime = createOwnerRuntimeStub();
     await completeFirstRun(runtime);
     const active = await ftuGoalDiscoveryEvaluator.shouldRun({
       runtime,
@@ -120,7 +120,7 @@ describe("ftu_goal_discovery evaluator shouldRun gate", () => {
   });
 
   it("is false for the agent's own messages", async () => {
-    const runtime = createMinimalRuntimeStub();
+    const runtime = createOwnerRuntimeStub();
     await completeFirstRun(runtime);
     const message = {
       ...ownerMessage(runtime, "noted!"),
@@ -135,7 +135,7 @@ describe("ftu_goal_discovery evaluator shouldRun gate", () => {
   });
 
   it("is false once the goal is discovered — completed discovery never reprocesses", async () => {
-    const runtime = createMinimalRuntimeStub();
+    const runtime = createOwnerRuntimeStub();
     await completeFirstRun(runtime);
     await createFtuGoalStateStore(runtime).complete({
       goal: "Ship the iOS app",
@@ -205,7 +205,7 @@ describe("ftu_goal_discovery processor", () => {
   }
 
   it("does not persist below the confidence threshold", async () => {
-    const runtime = createMinimalRuntimeStub();
+    const runtime = createOwnerRuntimeStub();
     await completeFirstRun(runtime);
     const result = await persistProcessor.process(
       processorContext(runtime, {
@@ -224,7 +224,7 @@ describe("ftu_goal_discovery processor", () => {
   });
 
   it("persists the primaryGoal fact with provenance and completes the durable state", async () => {
-    const runtime = createMinimalRuntimeStub();
+    const runtime = createOwnerRuntimeStub();
     await completeFirstRun(runtime);
     const result = await persistProcessor.process(
       processorContext(runtime, {
@@ -255,7 +255,7 @@ describe("ftu_goal_discovery processor", () => {
   });
 
   it("never overwrites an already-discovered goal (idempotence backstop)", async () => {
-    const runtime = createMinimalRuntimeStub();
+    const runtime = createOwnerRuntimeStub();
     await completeFirstRun(runtime);
     await persistProcessor.process(
       processorContext(runtime, {


### PR DESCRIPTION
## What

First-time-user (FTU) **goal-discovery** experience + **anticipation-feedback** loop, built entirely on the existing provider/evaluator patterns — no new scheduling or double-processing machinery.

- **`ftuGoal` provider** (`plugins/plugin-personal-assistant/src/providers/ftu-goal.ts`, position `-5`, private surfaces + owner only): once first-run is complete but no primary owner goal is known, injects a compact instruction to discover what the owner values by weaving ONE natural question into the reply. Goes silent the moment a goal is recorded.
- **`ftu_goal_discovery` evaluator** (`src/lifeops/ftu-goal/evaluator.ts`) + **state store** (`src/lifeops/ftu-goal/state.ts`): runs in the **single merged post-turn `EvaluatorService` call**, parses the goal + confidence, and its processor persists the goal to `OwnerFactStore` and flips FTU-goal state to `complete` at/above the confidence threshold. `shouldRun` is `false` once complete → **no reprocessing**.
- **`anticipation_feedback` evaluator** (`src/lifeops/anticipation/evaluator.ts`) + **marker store** (`src/lifeops/anticipation/store.ts`): when the agent's prior turn was a proactive dispatch, classifies the owner's response (accepted / ignored) against recorded dispatch markers, counts older markers as ignored, removes markers so a turn is never classified twice, and keeps durable rolling stats to tune proactivity.
- Both evaluators registered in the plugin (`src/plugin.ts`); scheduler wiring records proactive-dispatch markers (`src/lifeops/scheduled-task/scheduler.ts`).

Minimizes work: reuses the merged single-model post-turn evaluator call (no extra model calls), the runtime cache stores, `OwnerFactStore`, and the existing provider position/gating conventions.

## Evidence

| Type | Status |
| --- | --- |
| Deterministic tests (provider gating, evaluator parse/processor/shouldRun, no-double-processing, real merged `EvaluatorService` call) | ✅ 24/24 pass — see below |
| Real-LLM trajectory | N/A — evaluators use a deterministic model stub in-test; no live provider key in this shell. A credentialed runner should capture a live merged-call trajectory. |
| Frontend/UI | N/A — this is a runtime provider/evaluator change with no UI surface of its own (the affordance renders through the agent's normal reply). |

<details><summary>Test run (24 passed)</summary>

```
bunx vitest run \
  plugins/plugin-personal-assistant/test/ftu-goal-discovery.test.ts \
  plugins/plugin-personal-assistant/test/anticipation-feedback.test.ts \
  plugins/plugin-personal-assistant/test/ftu-evaluators-merged-call.test.ts
 Test Files  3 passed (3)
      Tests  24 passed (24)
```
The merged-call test drives the **real** `packages/core` `EvaluatorService` with both evaluators registered: one merged schema-constrained call, sections parsed per evaluator, processors persisting to the real stores, and `shouldRun` closing both gates afterward (no second call, no reprocessing).
</details>

## Notes
Owner-gating is real: the provider + both evaluators require `hasOwnerAccess`. Tests configure the sender as the canonical owner via `ELIZA_ADMIN_ENTITY_ID` (`createOwnerRuntimeStub`) exactly as a deployed app does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Evidence Matrix
<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - runtime provider/evaluator change only; no rendered UI component changed.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - runtime provider/evaluator change only; the first visible effect appears as normal agent reply text and must be proven through live trajectory evidence.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no dedicated UI/native workflow changed; a chat transcript/trajectory is the relevant walkthrough artifact for this PR.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no HTTP/server route changed in this PR; deterministic tests exercise the provider/evaluator/store paths directly.
<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A - no frontend surface or network runtime changed.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - not captured in this local shell because no live provider key is available; this remains required before treating the PR as MVP-ready because the provider/evaluator behavior is model-adjacent.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - no persisted production artifact was generated in this local pass; focused tests assert the intended domain writes: primary owner goal persisted to `OwnerFactStore`, FTU goal state flips complete, anticipation markers are consumed exactly once, and rolling proactivity stats are updated.

## Merge Blocker
Before merging as MVP-ready, capture and manually review a credentialed live scenario trajectory that shows the provider asking one natural goal-discovery question, the evaluator parsing the owner's answer, `OwnerFactStore` receiving the goal fact, and `shouldRun` going silent on the next turn.

