### PR TITLE
fix(lifeops): update relationship recency from messages

### DIFF
--- a/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Presence bridge tests for passive relationship recency. The service listens
+ * to runtime message events, so the test drives the registered handler and
+ * verifies both the activity signal and relationship/contact recency writes.
+ */
+import {
+  EventType,
+  type IAgentRuntime,
+  type MessagePayload,
+  type UUID,
+} from "@elizaos/core";
+import { SELF_ENTITY_ID } from "@elizaos/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockState = vi.hoisted(() => {
+  const entityStore = {
+    observeIdentity: vi.fn(),
+    recordInteraction: vi.fn(),
+  };
+  const relationshipStore = {
+    get: vi.fn(),
+    observe: vi.fn(),
+  };
+  return {
+    activitySignals: [] as Array<Record<string, unknown>>,
+    entityStore,
+    relationshipStore,
+  };
+});
+
+vi.mock("../lifeops/repository.js", () => ({
+  createLifeOpsActivitySignal: (params: Record<string, unknown>) => ({
+    ...params,
+    id: "signal-1",
+    createdAt: "2026-06-01T12:00:01.000Z",
+  }),
+  LifeOpsRepository: class LifeOpsRepository {
+    async createActivitySignal(signal: Record<string, unknown>): Promise<void> {
+      mockState.activitySignals.push(signal);
+    }
+
+    async entityStore(): Promise<typeof mockState.entityStore> {
+      return mockState.entityStore;
+    }
+
+    async relationshipStore(): Promise<typeof mockState.relationshipStore> {
+      return mockState.relationshipStore;
+    }
+  },
+}));
+
+import { PresenceSignalBridgeService } from "./presence-signal-bridge-service.js";
+
+const AGENT_ID = "00000000-0000-0000-0000-000000000001" as UUID;
+const CONTACT_ID = "10000000-0000-0000-0000-000000000001" as UUID;
+const ROOM_ID = "20000000-0000-0000-0000-000000000001" as UUID;
+
+function runtimeWithRelationships(relationshipsService: unknown): {
+  runtime: IAgentRuntime;
+  handlers: Map<string, (payload: MessagePayload) => Promise<void>>;
+} {
+  const handlers = new Map<
+    string,
+    (payload: MessagePayload) => Promise<void>
+  >();
+  const runtime = {
+    agentId: AGENT_ID,
+    getService: vi.fn((name: string) =>
+      name === "relationships" ? relationshipsService : null,
+    ),
+    registerEvent: vi.fn(
+      (event: string, handler: (payload: MessagePayload) => Promise<void>) => {
+        handlers.set(event, handler);
+      },
+    ),
+    unregisterEvent: vi.fn(),
+  } as unknown as IAgentRuntime;
+  return { runtime, handlers };
+}
+
+function messagePayload(
+  overrides: Partial<MessagePayload> = {},
+): MessagePayload {
+  return {
+    runtime: {} as IAgentRuntime,
+    source: "telegram",
+    message: {
+      id: "30000000-0000-0000-0000-000000000001",
+      entityId: CONTACT_ID,
+      roomId: ROOM_ID,
+      agentId: AGENT_ID,
+      content: {
+        text: "Sent the check-in",
+        source: "telegram",
+        channelType: "telegram",
+      },
+      createdAt: Date.parse("2026-06-01T12:00:00.000Z"),
+      metadata: {
+        originalId: "telegram-message-1",
+        sender: { username: "priya" },
+      },
+    },
+    ...overrides,
+  } as unknown as MessagePayload;
+}
+
+describe("PresenceSignalBridgeService relationship recency", () => {
+  beforeEach(() => {
+    mockState.activitySignals.length = 0;
+    vi.clearAllMocks();
+    mockState.relationshipStore.get.mockResolvedValue({
+      relationshipId: `lifeops-contact-${CONTACT_ID}`,
+      type: "contact",
+    });
+  });
+
+  it("records core contact and graph recency for owner-sent connector messages", async () => {
+    const relationshipsService = {
+      findByHandle: vi.fn(async () => ({ entityId: CONTACT_ID })),
+      getContact: vi.fn(async () => ({ entityId: CONTACT_ID })),
+      recordInteraction: vi.fn(),
+    };
+    const { runtime, handlers } =
+      runtimeWithRelationships(relationshipsService);
+    await PresenceSignalBridgeService.start(runtime);
+
+    await handlers.get(EventType.MESSAGE_SENT)?.(messagePayload());
+
+    expect(mockState.activitySignals[0]).toMatchObject({
+      source: "connector_activity",
+      platform: "telegram",
+      observedAt: "2026-06-01T12:00:00.000Z",
+    });
+    expect(relationshipsService.recordInteraction).toHaveBeenCalledWith({
+      contactId: CONTACT_ID,
+      platform: "telegram",
+      direction: "outbound",
+      summary: "Passive telegram message activity",
+      externalRef: "telegram-message-1",
+      occurredAt: "2026-06-01T12:00:00.000Z",
+    });
+    expect(mockState.entityStore.recordInteraction).toHaveBeenCalledWith(
+      CONTACT_ID,
+      {
+        platform: "telegram",
+        direction: "outbound",
+        summary: "Passive telegram message activity",
+        occurredAt: "2026-06-01T12:00:00.000Z",
+      },
+    );
+    expect(mockState.relationshipStore.observe).toHaveBeenCalledWith({
+      fromEntityId: SELF_ENTITY_ID,
+      toEntityId: CONTACT_ID,
+      type: "contact",
+      metadataPatch: {
+        lastInteractionPlatform: "telegram",
+        lastInteractionDirection: "outbound",
+      },
+      evidence: ["lifeops:contact", "message_ingest"],
+      confidence: 0.8,
+      occurredAt: "2026-06-01T12:00:00.000Z",
+      source: "extraction",
+    });
+    expect(mockState.entityStore.observeIdentity).not.toHaveBeenCalled();
+  });
+
+  it("uses identity observation when only a connector handle is known", async () => {
+    const relationshipsService = {
+      getContact: vi.fn(async () => null),
+    };
+    mockState.entityStore.observeIdentity.mockResolvedValue({
+      entity: { entityId: CONTACT_ID },
+    });
+    mockState.relationshipStore.get.mockResolvedValue(null);
+    const { runtime, handlers } =
+      runtimeWithRelationships(relationshipsService);
+    await PresenceSignalBridgeService.start(runtime);
+
+    await handlers.get(EventType.MESSAGE_RECEIVED)?.(
+      messagePayload({
+        message: {
+          ...messagePayload().message,
+          entityId: "10000000-0000-0000-0000-000000000099" as UUID,
+        },
+      }),
+    );
+
+    expect(mockState.entityStore.observeIdentity).toHaveBeenCalledWith({
+      platform: "telegram",
+      handle: "priya",
+      evidence: ["lifeops:contact", "message_ingest"],
+      confidence: 0.8,
+      suggestedType: "person",
+    });
+    expect(mockState.entityStore.recordInteraction).toHaveBeenCalledWith(
+      CONTACT_ID,
+      expect.objectContaining({ direction: "inbound" }),
+    );
+  });
+
+  it("records iMessage outbound events that carry the owner entity and recipient handle", async () => {
+    const relationshipsService = {
+      findByHandle: vi.fn(async () => ({ entityId: CONTACT_ID })),
+      getContact: vi.fn(async () => null),
+      recordInteraction: vi.fn(),
+    };
+    const { runtime, handlers } =
+      runtimeWithRelationships(relationshipsService);
+    await PresenceSignalBridgeService.start(runtime);
+
+    await handlers.get(EventType.MESSAGE_SENT)?.(
+      messagePayload({
+        source: "imessage",
+        message: {
+          ...messagePayload().message,
+          entityId: AGENT_ID,
+          content: { text: "On it", source: "imessage" },
+          metadata: {
+            originalId: "imessage-message-1",
+            imessage: { chatId: "+15555550123" },
+          },
+        },
+      }),
+    );
+
+    expect(relationshipsService.findByHandle).toHaveBeenCalledWith(
+      "imessage",
+      "+15555550123",
+    );
+    expect(relationshipsService.recordInteraction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contactId: CONTACT_ID,
+        platform: "imessage",
+        direction: "outbound",
+        externalRef: "imessage-message-1",
+      }),
+    );
+    expect(mockState.relationshipStore.observe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toEntityId: CONTACT_ID,
+        metadataPatch: {
+          lastInteractionPlatform: "imessage",
+          lastInteractionDirection: "outbound",
+        },
+      }),
+    );
+  });
+});

--- a/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts
@@ -198,6 +198,62 @@ describe("PresenceSignalBridgeService relationship recency", () => {
     );
   });
 
+  it("does not dedupe same-timestamp handle-only messages for different contacts", async () => {
+    const morganId = "10000000-0000-0000-0000-000000000002" as UUID;
+    const relationshipsService = {
+      getContact: vi.fn(async () => null),
+    };
+    mockState.entityStore.observeIdentity.mockImplementation(
+      async ({ handle }: { handle: string }) => ({
+        entity: { entityId: handle === "morgan" ? morganId : CONTACT_ID },
+      }),
+    );
+    mockState.relationshipStore.get.mockResolvedValue(null);
+    const { runtime, handlers } =
+      runtimeWithRelationships(relationshipsService);
+    await PresenceSignalBridgeService.start(runtime);
+
+    await handlers.get(EventType.MESSAGE_RECEIVED)?.(
+      messagePayload({
+        message: {
+          ...messagePayload().message,
+          entityId: undefined,
+        },
+      }),
+    );
+    await handlers.get(EventType.MESSAGE_RECEIVED)?.(
+      messagePayload({
+        message: {
+          ...messagePayload().message,
+          entityId: undefined,
+          id: "30000000-0000-0000-0000-000000000002",
+          metadata: {
+            originalId: "telegram-message-2",
+            sender: { username: "morgan" },
+          },
+        },
+      }),
+    );
+
+    expect(mockState.activitySignals).toHaveLength(2);
+    expect(mockState.entityStore.observeIdentity).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ handle: "priya" }),
+    );
+    expect(mockState.entityStore.observeIdentity).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ handle: "morgan" }),
+    );
+    expect(mockState.entityStore.recordInteraction).toHaveBeenCalledWith(
+      CONTACT_ID,
+      expect.objectContaining({ direction: "inbound" }),
+    );
+    expect(mockState.entityStore.recordInteraction).toHaveBeenCalledWith(
+      morganId,
+      expect.objectContaining({ direction: "inbound" }),
+    );
+  });
+
   it("records iMessage outbound events that carry the owner entity and recipient handle", async () => {
     const relationshipsService = {
       findByHandle: vi.fn(async () => ({ entityId: CONTACT_ID })),

--- a/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.ts
@@ -11,8 +11,14 @@ import {
   type IAgentRuntime,
   type MessagePayload,
   Service,
+  type UUID,
 } from "@elizaos/core";
+import { SELF_ENTITY_ID } from "@elizaos/shared";
 import { getDeviceId } from "../lifeops/device-identity.js";
+import {
+  contactEdgeId,
+  LIFEOPS_CONTACT_TAG,
+} from "../lifeops/relationships/mapping.js";
 import {
   createLifeOpsActivitySignal,
   LifeOpsRepository,
@@ -92,6 +98,126 @@ function readPlatform(payload: MessagePayload): string {
 
 function hashTelemetryIdentity(scope: string, value: string): string {
   return `${scope}:${crypto.createHash("sha256").update(value).digest("hex").slice(0, 32)}`;
+}
+
+function readMetadataRecord(payload: MessagePayload): Record<string, unknown> {
+  const record = isRecord(payload.message) ? payload.message : null;
+  return isRecord(record?.metadata) ? record.metadata : {};
+}
+
+function readNestedString(value: unknown, key: string): string | null {
+  if (!isRecord(value)) return null;
+  const candidate = value[key];
+  return typeof candidate === "string" && candidate.trim().length > 0
+    ? candidate.trim()
+    : null;
+}
+
+function readMessageHandle(payload: MessagePayload): string | null {
+  const record = isRecord(payload.message) ? payload.message : null;
+  const content = isRecord(record?.content) ? record.content : {};
+  const metadata = readMetadataRecord(payload);
+  const sender = metadata.sender ?? metadata.author ?? metadata.user;
+  const imessage = metadata.imessage;
+  const candidates = [
+    content.handle,
+    content.username,
+    content.senderUsername,
+    content.senderName,
+    content.to,
+    metadata.to,
+    metadata.recipient,
+    readNestedString(imessage, "chatId"),
+    readNestedString(sender, "username"),
+    readNestedString(sender, "handle"),
+    readNestedString(sender, "id"),
+    metadata.senderHandle,
+    metadata.username,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      return candidate.trim();
+    }
+  }
+  return null;
+}
+
+function readExternalMessageId(payload: MessagePayload): string | undefined {
+  const record = isRecord(payload.message) ? payload.message : null;
+  const metadata = readMetadataRecord(payload);
+  const candidates = [metadata.originalId, metadata.externalId, record?.id];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      return candidate.trim();
+    }
+  }
+  return undefined;
+}
+
+interface RelationshipActivityContact {
+  entityId: UUID;
+}
+
+interface RelationshipActivityService {
+  getContact(entityId: UUID): Promise<RelationshipActivityContact | null>;
+  findByHandle?(
+    platform: string,
+    identifier: string,
+  ): Promise<RelationshipActivityContact | null>;
+  recordInteraction?(input: {
+    contactId: UUID;
+    platform: string;
+    direction: "inbound" | "outbound";
+    summary?: string;
+    externalRef?: string;
+    occurredAt?: string;
+  }): Promise<unknown>;
+}
+
+function isRelationshipActivityContact(
+  value: unknown,
+): value is RelationshipActivityContact {
+  return (
+    isRecord(value) &&
+    typeof value.entityId === "string" &&
+    value.entityId.length > 0
+  );
+}
+
+function getRelationshipActivityService(
+  runtime: IAgentRuntime,
+): RelationshipActivityService | null {
+  const service: unknown = runtime.getService("relationships");
+  if (!isRecord(service)) return null;
+  const getContact = service.getContact;
+  if (typeof getContact !== "function") return null;
+  const findByHandle = service.findByHandle;
+  const recordInteraction = service.recordInteraction;
+  return {
+    getContact: async (entityId) => {
+      const result = await getContact.call(service, entityId);
+      return isRelationshipActivityContact(result) ? result : null;
+    },
+    ...(typeof findByHandle === "function"
+      ? {
+          findByHandle: async (platform, identifier) => {
+            const result = await findByHandle.call(
+              service,
+              platform,
+              identifier,
+            );
+            return isRelationshipActivityContact(result) ? result : null;
+          },
+        }
+      : {}),
+    ...(typeof recordInteraction === "function"
+      ? {
+          recordInteraction: async (input) => {
+            await recordInteraction.call(service, input);
+          },
+        }
+      : {}),
+  };
 }
 
 export class PresenceSignalBridgeService extends Service {
@@ -201,11 +327,17 @@ export class PresenceSignalBridgeService extends Service {
     payload: MessagePayload,
   ): Promise<void> {
     const entityId = readMessageEntityId(payload);
-    if (!entityId || entityId === String(this.runtime.agentId)) {
+    const handle = readMessageHandle(payload);
+    const isAgentEntity = entityId === String(this.runtime.agentId);
+    if (!entityId && !handle) {
+      return;
+    }
+    if (isAgentEntity && !handle) {
       return;
     }
     const observedAt = readMessageTimestamp(payload);
-    const fingerprint = `${eventType}:${entityId}:${observedAt}`;
+    const fingerprintEntity = handle ?? entityId;
+    const fingerprint = `${eventType}:${fingerprintEntity}:${observedAt}`;
     const observedMs = Date.parse(observedAt);
     const existing = this.recentFingerprints.get(fingerprint);
     if (
@@ -222,6 +354,7 @@ export class PresenceSignalBridgeService extends Service {
     const platform = readPlatform(payload);
     const direction =
       eventType === EventType.MESSAGE_SENT ? "outbound_by_owner" : "inbound";
+    const senderIdentity = entityId ?? handle ?? "unknown-sender";
     await repository.createActivitySignal(
       createLifeOpsActivitySignal({
         agentId: String(this.runtime.agentId),
@@ -235,13 +368,14 @@ export class PresenceSignalBridgeService extends Service {
         health: null,
         metadata: {
           eventType,
-          entityId,
+          entityId: entityId ?? null,
+          ...(handle ? { handle } : {}),
           direction,
           externalMessageId: readMessageId(payload),
           senderHash:
             direction === "outbound_by_owner"
               ? "owner"
-              : hashTelemetryIdentity("sender", entityId),
+              : hashTelemetryIdentity("sender", senderIdentity),
           conversationHash: hashTelemetryIdentity(
             "conversation",
             readConversationId(payload),
@@ -250,5 +384,93 @@ export class PresenceSignalBridgeService extends Service {
         },
       }),
     );
+    await this.recordRelationshipRecency({
+      eventType,
+      entityId: isAgentEntity ? null : (entityId ?? null),
+      observedAt,
+      platform,
+      payload,
+      repository,
+    });
+  }
+
+  private async recordRelationshipRecency(args: {
+    eventType: EventType.MESSAGE_RECEIVED | EventType.MESSAGE_SENT;
+    entityId: string | null;
+    observedAt: string;
+    platform: string;
+    payload: MessagePayload;
+    repository: LifeOpsRepository;
+  }): Promise<void> {
+    const direction =
+      args.eventType === EventType.MESSAGE_SENT ? "outbound" : "inbound";
+    const handle = readMessageHandle(args.payload);
+    const externalRef = readExternalMessageId(args.payload);
+    const summary = `Passive ${args.platform} message activity`;
+    const service = getRelationshipActivityService(this.runtime);
+
+    let contactId: UUID | null = null;
+    if (service?.findByHandle && handle) {
+      const matched = await service.findByHandle(args.platform, handle);
+      contactId = matched?.entityId ?? null;
+    }
+    if (!contactId && service && args.entityId) {
+      const direct = await service.getContact(args.entityId as UUID);
+      contactId = direct?.entityId ?? null;
+    }
+    if (contactId && service?.recordInteraction) {
+      await service.recordInteraction({
+        contactId,
+        platform: args.platform,
+        direction,
+        summary,
+        ...(externalRef ? { externalRef } : {}),
+        occurredAt: args.observedAt,
+      });
+    }
+
+    const agentId = String(this.runtime.agentId);
+    const entityStore = await args.repository.entityStore(agentId);
+    let graphEntityId = contactId ?? args.entityId;
+    if (handle && !contactId) {
+      const observed = await entityStore.observeIdentity({
+        platform: args.platform,
+        handle,
+        evidence: [LIFEOPS_CONTACT_TAG, "message_ingest"],
+        confidence: 0.8,
+        suggestedType: "person",
+      });
+      graphEntityId = observed.entity.entityId;
+    }
+    if (!graphEntityId) {
+      return;
+    }
+    await entityStore.recordInteraction(graphEntityId, {
+      platform: args.platform,
+      direction,
+      summary,
+      occurredAt: args.observedAt,
+    });
+
+    const relationshipStore = await args.repository.relationshipStore(agentId);
+    const existingEdge = await relationshipStore.get(
+      contactEdgeId(graphEntityId),
+    );
+    if (!existingEdge) {
+      return;
+    }
+    await relationshipStore.observe({
+      fromEntityId: SELF_ENTITY_ID,
+      toEntityId: graphEntityId,
+      type: existingEdge.type,
+      metadataPatch: {
+        lastInteractionPlatform: args.platform,
+        lastInteractionDirection: direction,
+      },
+      evidence: [LIFEOPS_CONTACT_TAG, "message_ingest"],
+      confidence: 0.8,
+      occurredAt: args.observedAt,
+      source: "extraction",
+    });
   }
 }

--- a/plugins/plugin-personal-assistant/src/followup/followup-tracker.test.ts
+++ b/plugins/plugin-personal-assistant/src/followup/followup-tracker.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Follow-up tracker tests for passive contact recency. The production tracker
+ * reads the RelationshipsService contact projection, so these cases pin the
+ * fields updated by real message ingestion rather than only manual actions.
+ */
+import type { IAgentRuntime, JsonValue, UUID } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type ContactInfo,
+  computeOverdueFollowups,
+} from "./followup-tracker.js";
+
+const NOW = Date.parse("2026-06-01T12:00:00.000Z");
+
+function contact(
+  overrides: Partial<ContactInfo> & { entityId: UUID },
+): ContactInfo {
+  return {
+    categories: [],
+    tags: [],
+    customFields: {},
+    ...overrides,
+  };
+}
+
+function runtimeWithContacts(contacts: ContactInfo[]): IAgentRuntime {
+  const service = {
+    searchContacts: vi.fn(async () => contacts),
+    getContact: vi.fn(
+      async (entityId: UUID) =>
+        contacts.find((entry) => entry.entityId === entityId) ?? null,
+    ),
+    updateContact: vi.fn(),
+  };
+  return {
+    agentId: "00000000-0000-0000-0000-000000000001" as UUID,
+    getService: vi.fn((name: string) =>
+      name === "relationships" ? service : null,
+    ),
+    getEntityById: vi.fn(async (entityId: UUID) => ({
+      names: [
+        String(
+          contacts.find((entry) => entry.entityId === entityId)?.customFields
+            .displayName ?? entityId,
+        ),
+      ],
+    })),
+  } as unknown as IAgentRuntime;
+}
+
+describe("computeOverdueFollowups passive recency", () => {
+  it("uses RelationshipsService lastInteractionAt written by real message ingestion", async () => {
+    const runtime = runtimeWithContacts([
+      contact({
+        entityId: "10000000-0000-0000-0000-000000000001" as UUID,
+        customFields: {
+          displayName: "Priya",
+          lastContactedAt: "2026-04-01T12:00:00.000Z" as JsonValue,
+        },
+        lastInteractionAt: "2026-05-31T12:00:00.000Z",
+      }),
+    ]);
+
+    const digest = await computeOverdueFollowups(runtime, NOW, 30);
+
+    expect(digest.overdue).toEqual([]);
+  });
+
+  it("learns cadence from observed interaction intervals when no override exists", async () => {
+    const runtime = runtimeWithContacts([
+      contact({
+        entityId: "10000000-0000-0000-0000-000000000002" as UUID,
+        customFields: { displayName: "Morgan" },
+        lastInteractionAt: "2026-05-21T12:00:00.000Z",
+        interactions: [
+          { occurredAt: "2026-05-07T12:00:00.000Z" },
+          { occurredAt: "2026-05-14T12:00:00.000Z" },
+          { occurredAt: "2026-05-21T12:00:00.000Z" },
+        ],
+      }),
+    ]);
+
+    const digest = await computeOverdueFollowups(runtime, NOW, 30);
+
+    expect(digest.overdue).toHaveLength(1);
+    expect(digest.overdue[0]).toMatchObject({
+      displayName: "Morgan",
+      thresholdDays: 7,
+      daysOverdue: 4,
+    });
+  });
+});

--- a/plugins/plugin-personal-assistant/src/followup/followup-tracker.ts
+++ b/plugins/plugin-personal-assistant/src/followup/followup-tracker.ts
@@ -42,6 +42,9 @@ export interface ContactInfo {
   categories: string[];
   tags: string[];
   customFields: Record<string, JsonValue>;
+  interactions?: Array<{ occurredAt: string }>;
+  lastInteractionAt?: string;
+  followupThresholdDays?: number;
 }
 
 export interface RelationshipsServiceLike {
@@ -77,6 +80,8 @@ export const FOLLOWUP_DEFAULT_THRESHOLD_DAYS = 30;
 export const FOLLOWUP_MEMORY_TABLE = "reminders" as const;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+const MIN_LEARNED_THRESHOLD_DAYS = 3;
+const MAX_LEARNED_THRESHOLD_DAYS = 90;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -153,21 +158,61 @@ function getStringField(contact: ContactInfo, key: string): string | null {
 }
 
 function resolveLastContactedAtMs(contact: ContactInfo): number | null {
-  const raw =
-    getStringField(contact, "lastContactedAt") ??
-    getStringField(contact, "lastInteractionAt");
-  if (!raw) return null;
-  const ms = new Date(raw).getTime();
-  return Number.isFinite(ms) ? ms : null;
+  const candidates = [
+    getStringField(contact, "lastContactedAt"),
+    getStringField(contact, "lastInteractionAt"),
+    contact.lastInteractionAt,
+  ];
+  const parsed = candidates
+    .map((raw) => (raw ? new Date(raw).getTime() : Number.NaN))
+    .filter(Number.isFinite);
+  return parsed.length > 0 ? Math.max(...parsed) : null;
+}
+
+function clampThresholdDays(days: number): number {
+  return Math.min(
+    MAX_LEARNED_THRESHOLD_DAYS,
+    Math.max(MIN_LEARNED_THRESHOLD_DAYS, Math.ceil(days)),
+  );
+}
+
+function resolveLearnedCadenceDays(contact: ContactInfo): number | null {
+  const interactionTimes = (contact.interactions ?? [])
+    .map((interaction) => new Date(interaction.occurredAt).getTime())
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b);
+  if (interactionTimes.length < 2) return null;
+
+  const gaps: number[] = [];
+  for (let index = 1; index < interactionTimes.length; index += 1) {
+    const gapDays =
+      (interactionTimes[index] - interactionTimes[index - 1]) / DAY_MS;
+    if (Number.isFinite(gapDays) && gapDays > 0) {
+      gaps.push(gapDays);
+    }
+  }
+  if (gaps.length === 0) return null;
+
+  const middle = Math.floor(gaps.length / 2);
+  const median =
+    gaps.length % 2 === 1
+      ? gaps[middle]
+      : (gaps[middle - 1] + gaps[middle]) / 2;
+  return clampThresholdDays(median);
 }
 
 function resolveThresholdDays(
   contact: ContactInfo,
   defaultDays: number,
 ): number {
-  const days = getNumberField(contact, "followupThresholdDays");
+  const days =
+    getNumberField(contact, "followupThresholdDays") ??
+    (typeof contact.followupThresholdDays === "number" &&
+    Number.isFinite(contact.followupThresholdDays)
+      ? contact.followupThresholdDays
+      : null);
   if (days !== null && days > 0) return days;
-  return defaultDays;
+  return resolveLearnedCadenceDays(contact) ?? defaultDays;
 }
 
 async function resolveDisplayName(


### PR DESCRIPTION
## Summary

Fixes #14687.

- Records passive message recency from runtime `MESSAGE_SENT` / `MESSAGE_RECEIVED` events into the existing contact and relationship graph surfaces.
- Resolves connector handles through the relationship/contact service and `EntityStore.observeIdentity`, then updates `EntityStore.recordInteraction` and the active SELF -> contact edge via `RelationshipStore.observe`.
- Handles iMessage outbound events whose payload carries the owner/agent entity id but recipient handle metadata (`metadata.imessage.chatId`), so those sends are no longer discarded as self activity.
- Repoints the follow-up tracker to read `ContactInfo.lastInteractionAt`, the field written by real `RelationshipsService.recordInteraction`, and learns per-contact cadence from observed interaction intervals when no explicit threshold exists.

## Verification

- PASS: `PATH=/Users/shawwalters/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH TMPDIR=/Users/shawwalters/.codex/worktrees/a7c3/eliza/.tmp/vitest bun run --cwd plugins/plugin-personal-assistant test -- src/activity-profile/presence-signal-bridge-service.test.ts src/followup/followup-tracker.test.ts` — 2 files / 6 tests. Covers connector outbound, handle-only inbound, same-timestamp handle-only dedupe across contacts, iMessage owner-entity outbound, tracker suppression from real `lastInteractionAt`, and learned cadence from interaction intervals.
- PASS: `git diff --check && PATH=/Users/shawwalters/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH bun run audit:error-policy-ratchet --report` against `origin/develop` `4ebf883e3f` — no whitespace errors and no new fallback-slop in the two touched production files.
- BLOCKED BASELINE: `PATH=/Users/shawwalters/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH TMPDIR=/Users/shawwalters/.codex/worktrees/a7c3/eliza/.tmp/vitest bun run --cwd plugins/plugin-personal-assistant test -- test/relationships-edge-state.test.ts` fails before running tests because Vite cannot resolve `@elizaos/plugin-app-manager` from `packages/agent/src/runtime/eliza.ts`.
- BLOCKED BASELINE: `PATH=/Users/shawwalters/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH bun run --cwd plugins/plugin-personal-assistant typecheck` still fails on existing unresolved workspace plugin imports (`@elizaos/plugin-blocker`, `@elizaos/plugin-calendar`, `@elizaos/plugin-health`, `@elizaos/plugin-scheduling`, etc.). Branch-local `presence-signal-bridge-service.ts` type errors found during verification were fixed before pushing; the filtered probe shows no remaining `presence-signal-bridge-service` or `followup-tracker` errors.
- BLOCKED BASELINE: `PATH=/Users/shawwalters/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH bun run verify` stops at `audit:type-safety-ratchet` with `as unknown as: 76 / 73`, matching the known repo baseline blocker and before workspace typecheck/lint execution.

## Evidence Rows

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: N/A - backend/event-ingest and tracker calculation change only; no rendered app UI changed.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: N/A - backend/event-ingest and tracker calculation change only; no rendered app UI changed.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: N/A - no user-facing UI flow changed; behavior is exercised by deterministic event-ingest/tracker tests.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no backend server was started; the relevant backend path is the runtime event handler and follow-up calculation, verified by focused Vitest outputs above.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - no frontend surface or network flow changed.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - no agent prompt/action/model behavior changed; the fix is deterministic event ingestion and relationship/follow-up state calculation.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no persisted production artifacts were generated; domain state transitions are verified by assertions on `recordInteraction`, `RelationshipStore.observe`, and `computeOverdueFollowups` in the focused tests listed above.


## Additional review fix
- Commit `7232c4ad85` fixes a dedupe edge where handle-only connector events with no `entityId` shared the same `null` fingerprint at the same timestamp. The fingerprint now uses `handle ?? entityId`, and the focused presence bridge test proves two same-timestamp handle-only messages for different contacts both produce activity signals and relationship recency writes.
