### PR TITLE
fix(agent): resolve app-control settings import via package root (#14804)

### DIFF
--- a/packages/agent/src/actions/settings-actions.ts
+++ b/packages/agent/src/actions/settings-actions.ts
@@ -32,7 +32,7 @@ import {
 import {
   createSettingsAction as createSectionSettingsAction,
   parseSettingsRequest,
-} from "@elizaos/plugin-app-control/actions/settings";
+} from "@elizaos/plugin-app-control";
 import {
   getFirstRunProviderOption,
   normalizeFirstRunProviderId,


### PR DESCRIPTION
## What + why

`packages/agent/src/actions/settings-actions.ts` imported **runtime values** (`createSettingsAction`, `parseSettingsRequest`) from the subpath `@elizaos/plugin-app-control/actions/settings`.

`plugins/plugin-app-control` builds a **bundled** `dist/index.js` plus per-file `.d.ts` only — there is **no** `dist/actions/settings.js` — and its `package.json` exports are `['.', './*.css', './*']`. The `./*` entry maps `./actions/settings` → `./dist/actions/settings.{js,d.ts}`: the `.d.ts` exists (so TypeScript was happy) but the `.js` does **not**, so the import resolved **types but not runtime JS**. It works in source/dev mode (resolved through the `eliza-source` condition aliases) and breaks in dist/packaged mode — which is why #14804 slipped through.

**Fix:** both symbols are already re-exported from the plugin **root** `index.ts` (which resolves via the `.` export to the bundled `dist/index.js`). Repoint the import to the package root `@elizaos/plugin-app-control`. No name collision (`createSettingsAction` is aliased to `createSectionSettingsAction`; `parseSettingsRequest` is unique in the file), and `@elizaos/plugin-app-control` is already a declared dependency of `@elizaos/agent`.

This unblocks #14655's background-real lane.

## Verification (real output, dist mode)

**Before** — subpath resolves to a nonexistent JS file (from `packages/agent`):
```
$ node -e "require.resolve('@elizaos/plugin-app-control/actions/settings')"
Error: Cannot find module '.../node_modules/@elizaos/plugin-app-control/dist/actions/settings.js'
```

**After** — root barrel resolves to the bundled dist and both symbols are functions:
```
$ node -e "console.log(require.resolve('@elizaos/plugin-app-control'))"
/Users/.../plugins/plugin-app-control/dist/index.js

$ node --input-type=module -e "import('@elizaos/plugin-app-control').then(m => { console.log('createSettingsAction:', typeof m.createSettingsAction); console.log('parseSettingsRequest:', typeof m.parseSettingsRequest); })"
createSettingsAction: function
parseSettingsRequest: function
```

## Tests / checks

```
# agent settings tests
$ bunx vitest run packages/agent/src/actions/settings-backends.test.ts \
    settings-training-op.test.ts settings-chat-config-ops.test.ts \
    packages/agent/src/runtime/settings-action-composition.test.ts
 Test Files  4 passed (4)
      Tests  39 passed (39)

# plugin-app-control settings tests
$ bunx vitest run plugins/plugin-app-control/src/actions/settings.test.ts settings-routing.test.ts
 Test Files  2 passed (2)
      Tests  57 passed (57)

# scoped typecheck
$ bunx tsgo --noEmit -p tsconfig.json     # packages/agent  -> exit 0, 0 errors
$ bunx tsgo --noEmit                       # plugins/plugin-app-control -> exit 0, 0 errors

# biome
$ bunx @biomejs/biome check src/actions/settings-actions.ts
Checked 1 file in 64ms. No fixes applied.
```

Repo-wide grep confirms this was the only importer of the broken subpath (remaining hit is a `@module` comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence checklist

- [x] Before screenshots (before-screenshots): N/A - server-side import-resolution fix in `packages/agent/src/actions/settings-actions.ts`; no rendered UI changed.
- [x] After screenshots (after-screenshots): N/A - server-side import-resolution fix; no rendered UI changed.
- [x] Walkthrough video (walkthrough-video): N/A - no user-facing flow or visual state changed; verification is package/runtime import resolution plus focused tests.
- [x] Backend logs (backend-logs): N/A - no server process was started; focused runtime/package checks below prove the broken packaged import path now resolves to the bundled plugin root.
- [x] Frontend console/network logs (frontend-logs): N/A - no frontend or network behavior changed.
- [x] Real-LLM trajectory (llm-trajectory): N/A - no prompt, provider, planner, model, evaluator, or agent-response behavior changed; this only changes a runtime module specifier from a missing subpath export to the package root.
- [x] Domain artifacts (domain-artifacts): Packaged dist import proof from `/tmp/eliza-pr-14917/packages/agent`: `require.resolve('@elizaos/plugin-app-control')` returned `/tmp/eliza-pr-14917/plugins/plugin-app-control/dist/index.js`; dynamic import printed `createSettingsAction: function` and `parseSettingsRequest: function`.

## Verification update — 2026-07-06

Self-contained verification worktree: `/tmp/eliza-pr-14917` at `55b76bafdd9960db8591312df23c29338f620476`.

- `bun install --frozen-lockfile --ignore-scripts` to create worktree-local workspace links for runtime resolution.
- `node packages/shared/scripts/generate-keywords.mjs --target ts` to materialize required i18n generated data.
- Built package deps needed for packaged import proof: `bun run --cwd packages/cloud/routing build`, `bun run --cwd packages/ui build`, `bun run --cwd packages/logger build`, `bun run --cwd packages/contracts build`, `bun run --cwd packages/auth build`, `bun run --cwd packages/core build:node`, `bun run --cwd packages/shared build`, `bun run --cwd plugins/plugin-app-control build`.
- `bunx vitest run plugins/plugin-app-control/src/actions/settings.test.ts plugins/plugin-app-control/src/actions/settings-routing.test.ts` -> 2 files, 57 tests passed.
- `bunx vitest run packages/agent/src/actions/settings-backends.test.ts packages/agent/src/actions/settings-training-op.test.ts packages/agent/src/actions/settings-chat-config-ops.test.ts packages/agent/src/runtime/settings-action-composition.test.ts` -> 4 files, 39 tests passed.
- `bunx @biomejs/biome check packages/agent/src/actions/settings-actions.ts` -> passed.
- `git diff --check origin/develop...HEAD && bun run audit:error-policy-ratchet --report` -> passed; 1 touched production file, no new fallback-slop.
- Packaged import proof: `node -e "console.log(require.resolve('@elizaos/plugin-app-control'))" && node --input-type=module -e "import('@elizaos/plugin-app-control').then(m => { console.log('createSettingsAction:', typeof m.createSettingsAction); console.log('parseSettingsRequest:', typeof m.parseSettingsRequest); })"` -> root barrel resolves to `plugins/plugin-app-control/dist/index.js`; both exports are functions.
