### PR TITLE
[codex] fix waifu stripe duplicate mock typecheck

### DIFF
--- a/packages/cloud/api/__tests__/stripe-event-waifu.test.ts
+++ b/packages/cloud/api/__tests__/stripe-event-waifu.test.ts
@@ -4,7 +4,9 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 const agentId = "123e4567-e89b-12d3-a456-426614174000";
 const paymentIntentId = "pi_agent_topup";
 const webhookFetch = mock(async () => Response.json({ ok: true }));
-const getTransactionByStripePaymentIntent = mock(async () => null);
+const getTransactionByStripePaymentIntent = mock(
+  async (): Promise<{ id: string } | null> => null,
+);
 const addCredits = mock(async () => ({ newBalance: 8.25 }));
 const getByStripeInvoiceId = mock(async () => null);
 const createInvoice = mock(async () => undefined);


### PR DESCRIPTION
## Summary

Fixes the Cloud CF Deploy API Worker typecheck blocker in `packages/cloud/api/__tests__/stripe-event-waifu.test.ts`.

The duplicate agent top-up test intentionally makes `getTransactionByStripePaymentIntent` return an existing transaction object, but the mock was inferred from `async () => null`, so CI typed `mockImplementationOnce(async () => ({ id }))` as invalid:

```text
__tests__/stripe-event-waifu.test.ts(270,76): error TS2322: Type 'Promise<{ id: string; }>' is not assignable to type 'Promise<null>'.
```

This widens the mock return type to `Promise<{ id: string } | null>`, matching the sibling checkout verify test pattern.

## Validation

- `bunx @biomejs/biome check packages/cloud/api/__tests__/stripe-event-waifu.test.ts --no-errors-on-unmatched`
- `git diff --check`

Local sparse-worktree limits:
- `bun run --cwd packages/cloud/api typecheck` could not run locally because `tsgo` is not installed in this sparse checkout.
- `bun test packages/cloud/api/__tests__/stripe-event-waifu.test.ts` could not collect locally because workspace deps such as `drizzle-orm` are not installed in this sparse checkout.

## Deploy Context

Observed on Cloud CF Deploy run `28769669792`, API Worker job `85300900038`, while trying to get staging onto a commit containing #14887 for #14645 live verification.
