### PR TITLE
feat(search): message search time-range (since/until) + backdated 1yr corpus seeder

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "publish:eliza1:dry-run": "cd packages/training && node ../scripts/run-python.mjs -m scripts.publish.publish_eliza1_all --dry-run",
     "dev:agent": "bun run --cwd packages/agent dev",
     "dev:core": "bun run --cwd packages/core dev",
+    "seed:messages": "node packages/scripts/seed-message-corpus.mjs",
     "start:debug": "NODE_NO_WARNINGS=1 LOG_LEVEL=debug bun run --cwd packages/agent start",
     "build": "node packages/scripts/run-turbo.mjs run build --concurrency=8 --filter='!./packages/examples/**' --filter='!./packages/benchmarks/**' --cache=local:rw,remote:r --output-logs=errors-only && bun run check:view-bundles",
     "build:client": "node packages/scripts/run-turbo.mjs run build --filter=@elizaos/app",

--- a/packages/agent/src/api/__tests__/conversation-message-search.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-message-search.test.ts
@@ -69,13 +69,27 @@ function docOf(row: SeedRow): string {
 /** Faithful model of IDatabaseAdapter.searchMessages: corpus-wide ranked hits. */
 function modelSearch(
   rows: SeedRow[],
-  params: { roomIds: UUID[]; query: string; limit?: number; offset?: number },
+  params: {
+    roomIds: UUID[];
+    query: string;
+    limit?: number;
+    offset?: number;
+    since?: number;
+    until?: number;
+  },
 ): MessageSearchHit[] {
   const roomSet = new Set(params.roomIds);
   const q = fold(params.query).trim();
   const terms = q.split(/\s+/).filter(Boolean);
   const hits = rows
     .filter((r) => roomSet.has(r.roomId))
+    // Inclusive [since, until] window, applied before ranking + LIMIT/OFFSET,
+    // exactly as the real adapters do.
+    .filter(
+      (r) =>
+        (params.since === undefined || r.createdAt >= params.since) &&
+        (params.until === undefined || r.createdAt <= params.until),
+    )
     .map((r) => {
       const doc = docOf(r);
       const allTerms = terms.every((t) => doc.includes(t));
@@ -178,6 +192,8 @@ const runtime = {
     query: string;
     limit?: number;
     offset?: number;
+    since?: number;
+    until?: number;
   }): Promise<MessageSearchHit[]> =>
     Promise.resolve(modelSearch(liveRows(), params)),
 } as unknown as AgentRuntime;
@@ -363,5 +379,70 @@ describe("GET /api/conversations/messages/search (route boundary)", () => {
     expect(r.body.count).toBe(0);
     expect(searchSpy).not.toHaveBeenCalled();
     searchSpy.mockRestore();
+  });
+
+  it("garbage since/until is rejected with 400, never a silently-ignored filter", async () => {
+    // Non-numeric, non-ISO, and empty strings are all invalid — the route must
+    // 400 rather than search an unbounded window the caller did not ask for.
+    expect((await runSearch("q=filler&since=notadate")).status).toBe(400);
+    expect((await runSearch("q=filler&until=abc")).status).toBe(400);
+    expect(
+      (await runSearch(`q=filler&since=${encodeURIComponent("  ")}`)).status,
+    ).toBe(400);
+    expect(
+      (await runSearch("q=filler&until=2026-13-45T99:99:99Z")).status,
+    ).toBe(400);
+  });
+
+  it("since later than until is rejected with 400", async () => {
+    const r = await runSearch("q=filler&since=5000&until=2000");
+    expect(r.status).toBe(400);
+  });
+
+  it("valid epoch-ms and ISO 8601 bounds are accepted", async () => {
+    expect((await runSearch("q=filler&since=1000&until=9999")).status).toBe(
+      200,
+    );
+    // ISO 8601 parses without error even if it excludes the (year-1970) corpus.
+    const iso = await runSearch(
+      `q=filler&since=${encodeURIComponent("2026-01-01T00:00:00Z")}`,
+    );
+    expect(iso.status).toBe(200);
+  });
+
+  it("a since/until window narrows the corpus and never leaks a row outside it", async () => {
+    // The 120 filler rows carry contiguous createdAt values (seeded 1000+seq).
+    // A window strictly inside that span must return only the in-window rows,
+    // never one outside — proving the store applies the bound the route forwards.
+    const fillerTimes = liveRows()
+      .filter((r) => r.text.includes("filler"))
+      .map((r) => r.createdAt)
+      .sort((a, b) => a - b);
+    expect(fillerTimes.length).toBe(120);
+    // Pick a 20-wide interior window well away from both ends.
+    const since = fillerTimes[40];
+    const until = fillerTimes[59];
+    const expectedInWindow = fillerTimes.filter(
+      (t) => t >= since && t <= until,
+    ).length;
+    expect(expectedInWindow).toBe(20);
+
+    const windowed = await runSearch(
+      `q=filler&limit=500&since=${since}&until=${until}`,
+    );
+    expect(windowed.status).toBe(200);
+    // Only the in-window filler rows come back (limit 500 > 20, so no clamp).
+    expect(windowed.body.count).toBe(20);
+    expect(
+      windowed.body.results.every(
+        (x) => x.createdAt >= since && x.createdAt <= until,
+      ),
+    ).toBe(true);
+    // A row just outside either bound is provably excluded.
+    expect(
+      windowed.body.results.some(
+        (x) => x.createdAt < since || x.createdAt > until,
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/agent/src/api/__tests__/conversation-seed-messages-route.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-seed-messages-route.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Endpoint test for `POST /api/conversations/dev/seed-messages` — the dev-only
+ * backdated-corpus seed route. Drives the real `handleConversationRoutes`
+ * against a real `InMemoryDatabaseAdapter` (through a thin runtime shim) and
+ * asserts the HTTP-boundary behaviour the route owns: production 404, bounded +
+ * validated request body (garbage → 400), and a successful seed that lands real
+ * backdated rows and registers the conversations in live state.
+ *
+ * The seeder + adapter under it are real; only the request/response plumbing is
+ * synthesized. The generated search corpus itself is proven end-to-end against
+ * the real ranker + window filter in `message-corpus-search.test.ts`.
+ */
+
+import type { Memory, UUID } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../../../core/src/database/inMemoryAdapter.ts";
+import {
+  type ConversationRouteContext,
+  type ConversationRouteState,
+  handleConversationRoutes,
+} from "../conversation-routes.ts";
+import type { ConversationMeta } from "../server-types.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000c1" as UUID;
+
+function makeRuntime(adapter: InMemoryDatabaseAdapter): unknown {
+  return {
+    agentId: AGENT_ID,
+    character: { name: "Eliza" },
+    async ensureConnection(params: {
+      roomId: UUID;
+      roomName?: string;
+      worldId?: UUID;
+      source?: string;
+      channelId?: string;
+    }) {
+      await adapter.createRooms([
+        {
+          id: params.roomId,
+          agentId: AGENT_ID,
+          name: params.roomName,
+          source: params.source ?? "test",
+          type: "dm",
+          worldId: params.worldId,
+          channelId: params.channelId,
+        } as Parameters<InMemoryDatabaseAdapter["createRooms"]>[0][number],
+      ]);
+    },
+    async createMemory(memory: Memory, tableName: string, unique?: boolean) {
+      const [id] = await adapter.createMemories([
+        { memory, tableName, ...(unique !== undefined ? { unique } : {}) },
+      ]);
+      return id;
+    },
+  };
+}
+
+function makeState(adapter: InMemoryDatabaseAdapter): ConversationRouteState {
+  return {
+    runtime: makeRuntime(adapter),
+    conversations: new Map<string, ConversationMeta>(),
+    deletedConversationIds: new Set<string>(),
+    conversationRestorePromise: null,
+  } as unknown as ConversationRouteState;
+}
+
+interface Captured {
+  status: number;
+  body: Record<string, unknown> & { error?: string };
+}
+
+function seedRequest(
+  state: ConversationRouteState,
+  body: unknown,
+): Promise<Captured> {
+  return new Promise((resolve) => {
+    const captured: Partial<Captured> = {};
+    const ctx = {
+      req: {
+        url: "/api/conversations/dev/seed-messages",
+        headers: { host: "localhost" },
+      },
+      res: {},
+      method: "POST",
+      pathname: "/api/conversations/dev/seed-messages",
+      readJsonBody: () => Promise.resolve(body),
+      json: (_res: unknown, data: unknown, status = 200) => {
+        captured.status = status;
+        captured.body = data as Captured["body"];
+        resolve(captured as Captured);
+      },
+      error: (_res: unknown, message: string, status = 500) => {
+        captured.status = status;
+        captured.body = { error: message };
+        resolve(captured as Captured);
+      },
+      state,
+    } as unknown as ConversationRouteContext;
+    void handleConversationRoutes(ctx);
+  });
+}
+
+describe("POST /api/conversations/dev/seed-messages (route boundary)", () => {
+  const prevNodeEnv = process.env.NODE_ENV;
+  let adapter: InMemoryDatabaseAdapter;
+
+  beforeEach(async () => {
+    adapter = new InMemoryDatabaseAdapter();
+    await adapter.initialize();
+  });
+  afterEach(() => {
+    process.env.NODE_ENV = prevNodeEnv;
+  });
+
+  it("returns 404 in production (route existence is not advertised)", async () => {
+    process.env.NODE_ENV = "production";
+    const r = await seedRequest(makeState(adapter), {});
+    expect(r.status).toBe(404);
+  });
+
+  it("rejects an out-of-bounds request body with 400", async () => {
+    process.env.NODE_ENV = "test";
+    // conversations max is 200; 500 is over the fat-finger guard.
+    const r = await seedRequest(makeState(adapter), { conversations: 500 });
+    expect(r.status).toBe(400);
+  });
+
+  it("rejects an unknown field (strict schema) with 400", async () => {
+    process.env.NODE_ENV = "test";
+    const r = await seedRequest(makeState(adapter), { bogus: 1 });
+    expect(r.status).toBe(400);
+  });
+
+  it("rejects a non-integer count with 400", async () => {
+    process.env.NODE_ENV = "test";
+    const r = await seedRequest(makeState(adapter), {
+      messagesPerConversation: 3.5,
+    });
+    expect(r.status).toBe(400);
+  });
+
+  it("seeds a real backdated corpus and registers the conversations in state", async () => {
+    process.env.NODE_ENV = "test";
+    const state = makeState(adapter);
+    const r = await seedRequest(state, {
+      conversations: 3,
+      messagesPerConversation: 6,
+      spanMonths: 13,
+      seed: 7,
+    });
+    expect(r.status).toBe(200);
+    expect(r.body.conversations).toBe(3);
+    expect(r.body.messagesCreated).toBe(18);
+    expect(Array.isArray(r.body.sampleQueries)).toBe(true);
+    // Oldest message predates the anchor by more than a year.
+    const oldest = r.body.oldestMessageAt as number;
+    expect(Date.now() - oldest).toBeGreaterThan(365 * 24 * 60 * 60 * 1000);
+    // The seeded conversations are now live + immediately listable.
+    expect(state.conversations.size).toBe(3);
+
+    // And the rows are really in the store: a topic keyword search hits them.
+    const roomIds = Array.from(state.conversations.values()).map(
+      (c) => c.roomId,
+    );
+    const query = (r.body.sampleQueries as string[])[0];
+    const hits = await adapter.searchMessages({
+      roomIds,
+      query,
+      tableName: "messages",
+      limit: 100,
+    });
+    expect(hits.length).toBeGreaterThan(0);
+  });
+
+  it("returns 503 when the runtime is not available", async () => {
+    process.env.NODE_ENV = "test";
+    const state = {
+      runtime: null,
+      conversations: new Map(),
+      deletedConversationIds: new Set<string>(),
+      conversationRestorePromise: null,
+    } as unknown as ConversationRouteState;
+    const r = await seedRequest(state, {});
+    expect(r.status).toBe(503);
+  });
+});

--- a/packages/agent/src/api/__tests__/message-corpus-search.test.ts
+++ b/packages/agent/src/api/__tests__/message-corpus-search.test.ts
@@ -1,0 +1,245 @@
+/**
+ * End-to-end proof that the backdated message-corpus seeder feeds real, scalable
+ * time-window message search. Runs the REAL `generateMessageCorpus` +
+ * `seedMessageCorpus` and drives the REAL `InMemoryDatabaseAdapter.searchMessages`
+ * (real `rankMessageSearch` + real `withinCreatedAtWindow`) — no model of the
+ * store stands in for the thing under test.
+ *
+ * The adapter is imported from the in-tree core source (relative path) rather
+ * than the `@elizaos/core` dist so the window filter under test is the current
+ * source, not a stale build in a shared worktree tree. The seeder writes through
+ * a thin runtime shim whose `createMemory`/`ensureConnection` delegate straight
+ * to that real adapter, so the seed → store → search path is fully real.
+ *
+ * It locks the properties the lane exists to guarantee:
+ *   1. Corpus-wide recall — a keyword from ~a year ago is found even when a
+ *      recency window would otherwise truncate it.
+ *   2. `since`/`until` narrow correctly and never leak a row outside the window.
+ *   3. Pagination is stable — disjoint offset pages tile the full result set.
+ */
+
+import type { Memory, MessageSearchHit, UUID } from "@elizaos/core";
+import { beforeAll, describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../../../core/src/database/inMemoryAdapter.ts";
+import {
+  generateMessageCorpus,
+  type MessageCorpusRuntime,
+  seedMessageCorpus,
+} from "../message-corpus.ts";
+
+const MONTH_MS = 30 * 24 * 60 * 60 * 1000;
+const YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+// Frozen anchor so backdated timestamps + spread are byte-stable across runs.
+const NOW = Date.UTC(2026, 5, 15, 12, 0, 0);
+const SEED = 4242;
+const AGENT_ID = "00000000-0000-0000-0000-0000000000a9" as UUID;
+
+/**
+ * Real runtime surface for the seeder: `createMemory` lands rows in the real
+ * adapter under the given table; `ensureConnection` records the room. Both are
+ * genuine adapter writes — the search path they feed is unmocked.
+ */
+function makeRuntimeShim(
+  adapter: InMemoryDatabaseAdapter,
+): MessageCorpusRuntime {
+  return {
+    agentId: AGENT_ID,
+    character: { name: "Eliza" },
+    async ensureConnection(params) {
+      await adapter.createRooms([
+        {
+          id: params.roomId,
+          agentId: AGENT_ID,
+          name: params.roomName,
+          source: params.source ?? "test",
+          type: "dm",
+          worldId: params.worldId,
+          channelId: params.channelId,
+        } as Parameters<InMemoryDatabaseAdapter["createRooms"]>[0][number],
+      ]);
+    },
+    async createMemory(memory: Memory, tableName: string, unique?: boolean) {
+      const [id] = await adapter.createMemories([
+        { memory, tableName, ...(unique !== undefined ? { unique } : {}) },
+      ]);
+      return id;
+    },
+  };
+}
+
+async function search(
+  adapter: InMemoryDatabaseAdapter,
+  roomIds: readonly UUID[],
+  query: string,
+  opts: {
+    limit?: number;
+    offset?: number;
+    since?: number;
+    until?: number;
+  } = {},
+): Promise<MessageSearchHit[]> {
+  return adapter.searchMessages({
+    roomIds: [...roomIds],
+    query,
+    tableName: "messages",
+    limit: opts.limit ?? 20,
+    offset: opts.offset ?? 0,
+    ...(opts.since !== undefined ? { since: opts.since } : {}),
+    ...(opts.until !== undefined ? { until: opts.until } : {}),
+  });
+}
+
+const at = (h: MessageSearchHit): number =>
+  typeof h.memory.createdAt === "number" ? h.memory.createdAt : Number.NaN;
+
+describe("message-corpus seeder → real time-window search", () => {
+  let adapter: InMemoryDatabaseAdapter;
+  let roomIds: UUID[];
+  let sampleQueries: string[];
+  let oldestMessageAt: number;
+  let newestMessageAt: number;
+
+  beforeAll(async () => {
+    adapter = new InMemoryDatabaseAdapter();
+    await adapter.initialize();
+    // ~1 year+ of history: 10 conversations × 30 messages over 13 months, so
+    // there is material on both sides of every "N months ago" boundary.
+    const corpus = generateMessageCorpus({
+      conversationCount: 10,
+      messagesPerConversation: 30,
+      spanMonths: 13,
+      factsPerConversation: 1,
+      seed: SEED,
+      now: NOW,
+    });
+    const summary = await seedMessageCorpus(makeRuntimeShim(adapter), corpus);
+    roomIds = summary.conversations.map((c) => c.roomId);
+    sampleQueries = summary.sampleQueries;
+    oldestMessageAt = summary.oldestMessageAt;
+    newestMessageAt = summary.newestMessageAt;
+  });
+
+  it("seeds a real backdated corpus spanning more than a year", () => {
+    expect(roomIds.length).toBe(10);
+    expect(NOW - oldestMessageAt).toBeGreaterThan(YEAR_MS);
+    expect(newestMessageAt).toBeLessThanOrEqual(NOW);
+    expect(sampleQueries.length).toBeGreaterThan(0);
+  });
+
+  it("corpus-wide recall: search reaches back past a year for a real keyword", async () => {
+    // Every sample query names a distinct topic pack; the oldest packs sit ~13
+    // months back. Prove the search itself reaches a hit older than a one-year
+    // boundary — a recency-truncated slice would drop it.
+    const oldestAcrossQueries = Math.min(
+      ...(await Promise.all(
+        sampleQueries.map(async (q) => {
+          const hits = await search(adapter, roomIds, q, { limit: 500 });
+          expect(hits.length).toBeGreaterThan(0);
+          return Math.min(...hits.map(at));
+        }),
+      )),
+    );
+    expect(NOW - oldestAcrossQueries).toBeGreaterThan(YEAR_MS);
+  });
+
+  it("until= narrows to older messages; every hit is within the window", async () => {
+    const query = sampleQueries[0];
+    const unbounded = await search(adapter, roomIds, query, { limit: 500 });
+    const until = NOW - 9 * MONTH_MS;
+    const windowed = await search(adapter, roomIds, query, {
+      limit: 500,
+      until,
+    });
+    // A window can only shrink or hold the result set, never grow it.
+    expect(windowed.length).toBeLessThanOrEqual(unbounded.length);
+    // No hit newer than `until` leaks through.
+    expect(windowed.every((h) => at(h) <= until)).toBe(true);
+    // The window is meaningful: there ARE newer hits it excluded.
+    expect(unbounded.some((h) => at(h) > until)).toBe(true);
+  });
+
+  it("since= narrows to newer messages; every hit is within the window", async () => {
+    const query = sampleQueries[0];
+    const since = NOW - 4 * MONTH_MS;
+    const windowed = await search(adapter, roomIds, query, {
+      limit: 500,
+      since,
+    });
+    expect(windowed.every((h) => at(h) >= since)).toBe(true);
+    const unbounded = await search(adapter, roomIds, query, { limit: 500 });
+    // Something older than `since` exists in the unbounded set that this dropped.
+    expect(unbounded.some((h) => at(h) < since)).toBe(true);
+  });
+
+  it("since+until brackets an inner window derived from the real hit spread", async () => {
+    // Pick a query whose hits span more than a day, then bracket strictly
+    // inside the oldest and newest hit. The window must drop both extremes and
+    // keep the interior — proving since AND until narrow at once, on real
+    // backdated timestamps rather than an assumed month layout.
+    let query = sampleQueries[0];
+    let times = (await search(adapter, roomIds, query, { limit: 500 }))
+      .map(at)
+      .sort((a, b) => a - b);
+    for (const q of sampleQueries) {
+      const t = (await search(adapter, roomIds, q, { limit: 500 }))
+        .map(at)
+        .sort((a, b) => a - b);
+      if (
+        t.length >= 3 &&
+        t[t.length - 1] - t[0] > times[times.length - 1] - times[0]
+      ) {
+        query = q;
+        times = t;
+      }
+    }
+    const oldest = times[0];
+    const newest = times[times.length - 1];
+    expect(newest - oldest).toBeGreaterThan(24 * 60 * 60 * 1000);
+    const since = oldest + 1;
+    const until = newest - 1;
+    const windowed = await search(adapter, roomIds, query, {
+      limit: 500,
+      since,
+      until,
+    });
+    expect(windowed.every((h) => at(h) >= since && at(h) <= until)).toBe(true);
+    // Both extremes were excluded — narrowing happened on both bounds.
+    expect(windowed.some((h) => at(h) === oldest)).toBe(false);
+    expect(windowed.some((h) => at(h) === newest)).toBe(false);
+    // And the interior survived: unless every hit sat on an extreme, some remain.
+    const interior = times.filter((t) => t > oldest && t < newest);
+    expect(windowed.length).toBe(interior.length);
+  });
+
+  it("pagination is stable: disjoint offset pages tile the full result set", async () => {
+    const query = sampleQueries[0];
+    const full = await search(adapter, roomIds, query, { limit: 500 });
+    expect(full.length).toBeGreaterThan(6);
+
+    const pageSize = 3;
+    const pages: MessageSearchHit[][] = [];
+    for (let offset = 0; offset < full.length; offset += pageSize) {
+      pages.push(
+        await search(adapter, roomIds, query, { limit: pageSize, offset }),
+      );
+    }
+    const paged = pages.flat();
+
+    // Same length, same order, same rows — offset paging reproduces the full
+    // ranking with no gaps and no duplicates.
+    expect(paged.map((h) => h.memory.id)).toEqual(full.map((h) => h.memory.id));
+    expect(new Set(paged.map((h) => h.memory.id)).size).toBe(paged.length);
+  });
+
+  it("a window entirely after the corpus returns nothing (never a fabricated hit)", async () => {
+    const query = sampleQueries[0];
+    const since = NOW + 24 * 60 * 60 * 1000;
+    const until = NOW + 2 * 24 * 60 * 60 * 1000;
+    const windowed = await search(adapter, roomIds, query, {
+      limit: 500,
+      since,
+      until,
+    });
+    expect(windowed.length).toBe(0);
+  });
+});

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -4,6 +4,8 @@
  * Handles:
  *   POST   /api/conversations            – create
  *   GET    /api/conversations             – list
+ *   GET    /api/conversations/messages/search – corpus-wide message search
+ *   POST   /api/conversations/dev/seed-messages – dev-only backdated corpus seed
  *   GET    /api/conversations/:id/messages – get messages
  *   POST   /api/conversations/:id/messages/truncate – truncate
  *   DELETE /api/conversations/:id/messages/:messageId – delete one message
@@ -41,8 +43,10 @@ import {
   PostConversationCleanupEmptyRequestSchema,
   PostConversationRequestSchema,
   PostConversationTruncateRequestSchema,
+  PostSeedMessagesRequestSchema,
   parsePositiveInteger,
 } from "@elizaos/shared";
+import { generateMessageCorpus, seedMessageCorpus } from "./message-corpus.ts";
 import type { ElizaConfig } from "../config/config.ts";
 import { resolveStateDir } from "../config/paths.ts";
 import type {
@@ -1680,6 +1684,88 @@ export async function handleConversationRoutes(
       error(res, "Failed to search conversation messages", 500);
       return true;
     }
+  }
+
+  // ── POST /api/conversations/dev/seed-messages ───────────────────────
+  // Dev-only: generate a large, realistic, BACKDATED conversation history
+  // (default 12 conversations × 40 messages over 13 months, plus derived
+  // facts) so message search — including since/until windows like "a year
+  // ago" — has a real corpus. Invoked by
+  // `packages/scripts/seed-message-corpus.mjs` for manual demo prep.
+  if (
+    method === "POST" &&
+    pathname === "/api/conversations/dev/seed-messages"
+  ) {
+    // 404 (not 403) in production so the route's existence isn't advertised.
+    if (process.env.NODE_ENV === "production") {
+      error(res, "Not found", 404);
+      return true;
+    }
+    if (!state.runtime) {
+      error(res, "Agent runtime not available", 503);
+      return true;
+    }
+    const rawSeed = await readJsonBody<Record<string, unknown>>(req, res);
+    if (rawSeed === null) return true;
+    const parsedSeed = PostSeedMessagesRequestSchema.safeParse(rawSeed);
+    if (!parsedSeed.success) {
+      error(
+        res,
+        parsedSeed.error.issues[0]?.message ?? "Invalid request body",
+        400,
+      );
+      return true;
+    }
+    await waitForConversationRestore(state);
+    const corpus = generateMessageCorpus({
+      ...(parsedSeed.data.conversations !== undefined
+        ? { conversationCount: parsedSeed.data.conversations }
+        : {}),
+      ...(parsedSeed.data.messagesPerConversation !== undefined
+        ? { messagesPerConversation: parsedSeed.data.messagesPerConversation }
+        : {}),
+      ...(parsedSeed.data.spanMonths !== undefined
+        ? { spanMonths: parsedSeed.data.spanMonths }
+        : {}),
+      ...(parsedSeed.data.factsPerConversation !== undefined
+        ? { factsPerConversation: parsedSeed.data.factsPerConversation }
+        : {}),
+      ...(parsedSeed.data.seed !== undefined
+        ? { seed: parsedSeed.data.seed }
+        : {}),
+    });
+    const summary = await seedMessageCorpus(state.runtime, corpus);
+    // Register the seeded conversations in the live in-memory list so they are
+    // visible + searchable immediately, without waiting for a restart-restore.
+    for (const conv of summary.conversations) {
+      state.conversations.set(conv.id, {
+        id: conv.id,
+        title: conv.title,
+        roomId: conv.roomId,
+        createdAt: new Date(conv.createdAt).toISOString(),
+        updatedAt: new Date(conv.lastMessageAt).toISOString(),
+      });
+    }
+    evictOldestConversation(state.conversations, 500);
+    logger.info(
+      {
+        conversations: summary.conversations.length,
+        messages: summary.messagesCreated,
+        facts: summary.factsCreated,
+        oldestMessageAt: summary.oldestMessageAt,
+        newestMessageAt: summary.newestMessageAt,
+      },
+      "[ConversationSearch] seeded backdated message corpus",
+    );
+    json(res, {
+      conversations: summary.conversations.length,
+      messagesCreated: summary.messagesCreated,
+      factsCreated: summary.factsCreated,
+      oldestMessageAt: summary.oldestMessageAt,
+      newestMessageAt: summary.newestMessageAt,
+      sampleQueries: summary.sampleQueries,
+    });
+    return true;
   }
 
   // ── POST /api/conversations ─────────────────────────────────────────

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -46,7 +46,6 @@ import {
   PostSeedMessagesRequestSchema,
   parsePositiveInteger,
 } from "@elizaos/shared";
-import { generateMessageCorpus, seedMessageCorpus } from "./message-corpus.ts";
 import type { ElizaConfig } from "../config/config.ts";
 import { resolveStateDir } from "../config/paths.ts";
 import type {
@@ -79,6 +78,7 @@ import {
   sanitizeConversationMetadata,
 } from "./conversation-metadata.ts";
 import { evictOldestConversation } from "./memory-bounds.ts";
+import { generateMessageCorpus, seedMessageCorpus } from "./message-corpus.ts";
 import {
   buildUserMessages,
   getErrorMessage,
@@ -1492,7 +1492,9 @@ function normalizeMessageSearchQuery(value: string | null): string {
  * Absent → `null`; present-but-unparseable → `"invalid"` so the route can 400
  * instead of silently searching an unbounded window the caller didn't ask for.
  */
-function parseMessageSearchTime(value: string | null): number | null | "invalid" {
+function parseMessageSearchTime(
+  value: string | null,
+): number | null | "invalid" {
   if (value === null) return null;
   const trimmed = value.trim();
   if (!trimmed) return "invalid";
@@ -1651,10 +1653,9 @@ export async function handleConversationRoutes(
             messageId: memory.id,
             conversationId: conversation.id,
             roomId,
-            role:
-              memory.entityId === runtime.agentId
-                ? "assistant"
-                : ("user" as const),
+            role: (memory.entityId === runtime.agentId
+              ? "assistant"
+              : "user") as "assistant" | "user",
             text: rawText,
             snippet: buildMessageSearchSnippet(rawText, query),
             createdAt: memory.createdAt,

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -1482,6 +1482,24 @@ function normalizeMessageSearchQuery(value: string | null): string {
   return (value === null ? "" : value).trim().replace(/\s+/g, " ");
 }
 
+/**
+ * Parse an optional `since`/`until` search param into epoch ms. Accepts a
+ * non-negative epoch-ms integer or any `Date.parse`-able string (ISO 8601).
+ * Absent → `null`; present-but-unparseable → `"invalid"` so the route can 400
+ * instead of silently searching an unbounded window the caller didn't ask for.
+ */
+function parseMessageSearchTime(value: string | null): number | null | "invalid" {
+  if (value === null) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return "invalid";
+  if (/^\d+$/.test(trimmed)) {
+    const epochMs = Number(trimmed);
+    return Number.isSafeInteger(epochMs) ? epochMs : "invalid";
+  }
+  const parsed = Date.parse(trimmed);
+  return Number.isNaN(parsed) ? "invalid" : parsed;
+}
+
 /** A `…keyword…` excerpt around the first match, or a head-truncated fallback. */
 function buildMessageSearchSnippet(text: string, query: string): string {
   const normalizedText = text.replace(/\s+/g, " ").trim();
@@ -1555,6 +1573,23 @@ export async function handleConversationRoutes(
       requestUrl.searchParams.get("offset"),
       0,
     );
+    // Optional inclusive time window (epoch ms or ISO 8601): "messages from a
+    // year ago" is `until=<9 months ago>` etc. Garbage input is a 400, never a
+    // silently ignored filter.
+    const since = parseMessageSearchTime(requestUrl.searchParams.get("since"));
+    const until = parseMessageSearchTime(requestUrl.searchParams.get("until"));
+    if (since === "invalid" || until === "invalid") {
+      error(
+        res,
+        "since/until must be an epoch-ms timestamp or an ISO 8601 date",
+        400,
+      );
+      return true;
+    }
+    if (since !== null && until !== null && since > until) {
+      error(res, "since must not be later than until", 400);
+      return true;
+    }
     const runtime = state.runtime;
     const waifuAccess = resolveWaifuChatAccess(req);
     const conversationsByRoomId = new Map<UUID, ConversationMeta>();
@@ -1587,6 +1622,8 @@ export async function handleConversationRoutes(
         tableName: "messages",
         limit,
         offset,
+        ...(since !== null ? { since } : {}),
+        ...(until !== null ? { until } : {}),
       });
       const results = hits.flatMap(({ memory, ftsRank, trigramSimilarity }) => {
         const roomId = memory.roomId;
@@ -1626,6 +1663,8 @@ export async function handleConversationRoutes(
           queryLength: query.length,
           limit,
           offset,
+          ...(since !== null ? { since } : {}),
+          ...(until !== null ? { until } : {}),
           rawHits: hits.length,
           results: results.length,
         },

--- a/packages/agent/src/api/message-corpus.ts
+++ b/packages/agent/src/api/message-corpus.ts
@@ -1,0 +1,543 @@
+/**
+ * Deterministic backdated chat-history generator + seeder for message search.
+ * Produces N web-chat conversations × M messages spread across a configurable
+ * span (default 13 months) with realistic topical text and per-conversation
+ * derived owner facts, then lands them through the runtime as real rooms in
+ * the agent's web-chat world (`web-conv-*` channel ids) with real backdated
+ * `createdAt` values — so `restoreConversationsFromDb` rebuilds them as
+ * ordinary conversations and time-window searches ("messages from a year
+ * ago") have a corpus to hit.
+ *
+ * Consumed by the dev-only seed route in `conversation-routes.ts`, by the
+ * scenario-runner `messages` seed step, and by
+ * `packages/scripts/seed-message-corpus.mjs` for manual demo prep. Generation
+ * is a pure function of (seed, now, shape options); ids are random so
+ * re-seeding adds more history instead of colliding.
+ */
+import { randomUUID } from "node:crypto";
+import {
+  ChannelType,
+  MemoryType,
+  MESSAGE_SOURCE_CLIENT_CHAT,
+  type Memory,
+  stringToUuid,
+  type UUID,
+} from "@elizaos/core";
+
+export interface MessageCorpusOptions {
+  /** Number of conversations to generate. */
+  conversationCount?: number;
+  /** Messages per conversation (user/assistant alternating). */
+  messagesPerConversation?: number;
+  /** Months of history to spread conversation start times across. */
+  spanMonths?: number;
+  /** Derived owner facts written per conversation. */
+  factsPerConversation?: number;
+  /** RNG seed — same seed + now yields byte-identical text and timestamps. */
+  seed?: number;
+  /** Anchor timestamp (epoch ms) the span counts back from. */
+  now?: number;
+}
+
+export interface GeneratedCorpusMessage {
+  role: "user" | "assistant";
+  text: string;
+  createdAt: number;
+}
+
+export interface GeneratedCorpusConversation {
+  title: string;
+  topic: string;
+  createdAt: number;
+  messages: GeneratedCorpusMessage[];
+  facts: Array<{ text: string; createdAt: number }>;
+}
+
+export interface GeneratedMessageCorpus {
+  conversations: GeneratedCorpusConversation[];
+  /** Distinctive per-topic keywords usable as demo search queries. */
+  sampleQueries: string[];
+  oldestMessageAt: number;
+  newestMessageAt: number;
+}
+
+const DEFAULT_CONVERSATIONS = 12;
+const DEFAULT_MESSAGES_PER_CONVERSATION = 40;
+const DEFAULT_SPAN_MONTHS = 13;
+const DEFAULT_FACTS_PER_CONVERSATION = 1;
+const DEFAULT_SEED = 1337;
+const MONTH_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** mulberry32 — tiny deterministic PRNG; quality is irrelevant, replay is not. */
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a += 0x6d2b79f5;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+interface TopicPack {
+  topic: string;
+  titles: string[];
+  userLines: string[];
+  assistantLines: string[];
+  facts: string[];
+  /** A distinctive query that should hit this topic's messages. */
+  sampleQuery: string;
+}
+
+// Each pack carries distinctive low-collision keywords (marathon, sourdough,
+// kubernetes, …) so demo searches land on the intended topic, and enough line
+// variety that FTS ranking has real signal instead of near-identical rows.
+const TOPIC_PACKS: TopicPack[] = [
+  {
+    topic: "fitness",
+    titles: ["Marathon training plan", "Long run recap", "Race week prep"],
+    userLines: [
+      "My long run this weekend was {n} kilometers and my knees are feeling it",
+      "Signed up for the Berlin marathon — is a {n} week training block enough?",
+      "What should my tempo pace be if my 10k time is {n} minutes?",
+      "I skipped two runs this week, how do I get the training plan back on track?",
+      "The new running shoes felt great for the first {n} kilometers",
+      "Should I do the interval session before or after strength training?",
+    ],
+    assistantLines: [
+      "For marathon training, keep the long run under {n} percent of weekly volume",
+      "A negative split strategy works well — go out {n} seconds slower per kilometer",
+      "Your taper should start about {n} weeks before race day",
+      "Recovery runs should feel easy — conversational pace, roughly {n} minutes per kilometer",
+      "Carb loading matters most in the final {n} hours before the marathon",
+    ],
+    facts: [
+      "Owner is training for the Berlin marathon and runs long on weekends",
+      "Owner's easy run pace is about six minutes per kilometer",
+    ],
+    sampleQuery: "marathon training",
+  },
+  {
+    topic: "baking",
+    titles: ["Sourdough starter log", "Weekend bake plans", "Crumb troubleshooting"],
+    userLines: [
+      "The sourdough starter doubled in {n} hours today, smells like ripe fruit",
+      "My crumb came out dense again — should I extend bulk fermentation?",
+      "Tried a {n} percent hydration dough and it was a sticky mess",
+      "The oven spring on today's loaf was the best I've ever had",
+      "Do I need to feed the starter twice a day in summer?",
+      "Scoring pattern collapsed again, the blade keeps dragging",
+    ],
+    assistantLines: [
+      "For an open crumb, push bulk fermentation until the dough grows about {n} percent",
+      "A colder proof — {n} hours in the fridge — deepens the sourdough flavor",
+      "Sticky dough usually means underdeveloped gluten; add {n} more coil folds",
+      "Steam for the first {n} minutes is what gives you that glossy crust",
+      "Feed the starter 1:{n}:{n} flour to water when the kitchen runs warm",
+    ],
+    facts: [
+      "Owner keeps a sourdough starter and bakes on weekends",
+      "Owner prefers high-hydration open-crumb loaves",
+    ],
+    sampleQuery: "sourdough starter",
+  },
+  {
+    topic: "infra",
+    titles: ["Kubernetes cluster upgrade", "Deploy pipeline debugging", "Incident postmortem"],
+    userLines: [
+      "The kubernetes cluster upgrade to {n}.x left two nodes NotReady",
+      "Deploy rolled back automatically — the readiness probe timed out after {n} seconds",
+      "Should we move the ingress controller before or after the node pool swap?",
+      "CI is red again, the integration stage flaked {n} times this week",
+      "Postgres connection pool exhausted at {n} connections during the spike",
+      "The canary deploy looked healthy for {n} minutes then error rates doubled",
+    ],
+    assistantLines: [
+      "Drain and cordon the NotReady nodes first, then check kubelet logs for certificate errors",
+      "Raise the readiness probe initial delay to {n} seconds and watch the rollout",
+      "Pin the ingress controller to the stable node pool until the upgrade settles",
+      "PgBouncer in transaction mode would cap the pool at {n} without starving workers",
+      "A {n} percent canary for thirty minutes is a safer promotion gate",
+    ],
+    facts: [
+      "Owner operates a kubernetes cluster and prefers canary deploys",
+      "Owner's production database is Postgres behind a connection pooler",
+    ],
+    sampleQuery: "kubernetes cluster",
+  },
+  {
+    topic: "finance",
+    titles: ["Quarterly budget review", "Invoice follow-ups", "Subscription audit"],
+    userLines: [
+      "The quarterly budget shows {n} percent overspend on cloud infrastructure",
+      "Invoice number {n} from the design contractor is still unpaid",
+      "Can we cut the software subscriptions bill? It grew {n} percent this year",
+      "Payroll runs on the {n}th — make sure the transfer clears before then",
+      "The accountant needs receipts for the March travel by Friday",
+      "Revenue landed {n} percent above forecast this quarter",
+    ],
+    assistantLines: [
+      "Cloud spend is driven by the staging environment — shutting it down nights saves about {n} percent",
+      "I drafted a reminder for invoice {n}; it is {n} days past due",
+      "Three subscriptions overlap in functionality — consolidating saves {n} per month",
+      "Flagging the payroll cutoff — initiate the transfer {n} business days early",
+      "Categorized the March receipts; two are missing merchant names",
+    ],
+    facts: [
+      "Owner reviews the budget quarterly and tracks cloud spend closely",
+      "Owner's payroll runs monthly on a fixed date",
+    ],
+    sampleQuery: "quarterly budget",
+  },
+  {
+    topic: "travel",
+    titles: ["Kyoto itinerary", "Autumn trip planning", "Flight and ryokan bookings"],
+    userLines: [
+      "Thinking {n} days in Kyoto then the train to Osaka — too rushed?",
+      "The ryokan near Arashiyama has an opening the week of the {n}th",
+      "Should we book the Shinkansen passes before we land?",
+      "Foliage forecast says peak color in Kyoto around late November",
+      "Found flights with one stop for {n} less — worth the longer layover?",
+      "Add the Fushimi Inari sunrise walk to the itinerary please",
+    ],
+    assistantLines: [
+      "Four nights in Kyoto covers the main temples without rushing — day {n} for Nara",
+      "Booked-out ryokan often release rooms {n} days ahead; I can watch for that",
+      "Buy the rail pass online first — activation at the airport takes minutes",
+      "Sunrise at Fushimi Inari means starting the climb around {n} in the morning",
+      "The layover saves money but risks the last airport train; buffer {n} hours",
+    ],
+    facts: [
+      "Owner is planning an autumn trip to Kyoto with a ryokan stay",
+      "Owner prefers early-morning sightseeing before crowds",
+    ],
+    sampleQuery: "kyoto itinerary",
+  },
+  {
+    topic: "reading",
+    titles: ["Book club notes", "Reading list triage", "Sci-fi recommendations"],
+    userLines: [
+      "Finished reading Dune last night — the ecology subplot deserved more pages",
+      "Book club picked a {n} page biography for next month, wish me luck",
+      "Any sci-fi recommendations that feel like Le Guin but newer?",
+      "I keep abandoning books at the {n} percent mark, is that a bad habit?",
+      "The translation of the novel felt stiff — is the original better regarded?",
+      "Reading pace this month: {n} books, mostly on the train",
+    ],
+    assistantLines: [
+      "If you liked Dune's ecology, the Mars trilogy goes even deeper into terraforming",
+      "For Le Guin's texture try Ancillary Justice or A Memory Called Empire",
+      "Abandoning a book at {n} percent is a verdict, not a failure",
+      "Biographies read faster after chapter {n} once the childhood section ends",
+      "Your reading log says fiction outnumbers nonfiction {n} to one this year",
+    ],
+    facts: [
+      "Owner is in a monthly book club and favors literary sci-fi",
+      "Owner reads mostly during train commutes",
+    ],
+    sampleQuery: "book club",
+  },
+  {
+    topic: "garden",
+    titles: ["Tomato seedling log", "Garden bed planning", "Pest patrol"],
+    userLines: [
+      "The tomato seedlings are {n} centimeters tall and leaning toward the window",
+      "Aphids are back on the pepper plants — neem oil again or something stronger?",
+      "When should I transplant the seedlings to the raised bed?",
+      "The compost thermometer read {n} degrees this morning, is that too hot?",
+      "Squirrels dug up two of the bean rows overnight",
+      "First ripe tomato of the season — the Sungold beat the Brandywine by weeks",
+    ],
+    assistantLines: [
+      "Leaning seedlings want more light — {n} hours under the grow lamp evens them out",
+      "Transplant after the last frost date once nights stay above {n} degrees",
+      "Ladybugs clear an aphid flare-up in about {n} days without spraying",
+      "Compost above {n} degrees cooks the microbes — turn the pile and add browns",
+      "Netting the bean rows tonight; squirrels give up after a week of failure",
+    ],
+    facts: [
+      "Owner grows tomatoes from seed in a raised-bed garden",
+      "Owner composts and battles aphids without pesticides",
+    ],
+    sampleQuery: "tomato seedlings",
+  },
+  {
+    topic: "health",
+    titles: ["Sleep schedule reset", "Migraine tracking", "Checkup follow-up"],
+    userLines: [
+      "Slept {n} hours again — the new schedule isn't sticking",
+      "Migraine hit at noon, third one this month, always after skipped lunch",
+      "The doctor wants a follow-up blood panel in {n} weeks",
+      "Screen time after midnight is clearly wrecking my mornings",
+      "Tried the earlier caffeine cutoff and woke up before the alarm",
+      "Headache diary says the trigger cluster is stress plus dehydration",
+    ],
+    assistantLines: [
+      "Anchor the wake time first — the sleep time follows within {n} days",
+      "Your migraine log shows skipped meals precede {n} of the last episodes",
+      "I scheduled the blood panel reminder {n} days out with a fasting note",
+      "A hard screens-off at eleven has the strongest evidence in your own data",
+      "Hydration plus a mid-morning snack has cut your headache frequency before",
+    ],
+    facts: [
+      "Owner tracks migraines and skipped meals are a known trigger",
+      "Owner is resetting their sleep schedule around a fixed wake time",
+    ],
+    sampleQuery: "migraine tracking",
+  },
+];
+
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+function fillTemplate(template: string, rng: () => number): string {
+  return template.replace(/\{n\}/g, () => String(2 + Math.floor(rng() * 40)));
+}
+
+/**
+ * Generate a deterministic backdated corpus. Conversation start times are
+ * spread oldest-first across the span ending at `now`, so a span of 13+
+ * months guarantees material on both sides of a "one year ago" boundary.
+ */
+export function generateMessageCorpus(
+  options: MessageCorpusOptions = {},
+): GeneratedMessageCorpus {
+  const conversationCount = options.conversationCount ?? DEFAULT_CONVERSATIONS;
+  const messagesPerConversation =
+    options.messagesPerConversation ?? DEFAULT_MESSAGES_PER_CONVERSATION;
+  const spanMonths = options.spanMonths ?? DEFAULT_SPAN_MONTHS;
+  const factsPerConversation =
+    options.factsPerConversation ?? DEFAULT_FACTS_PER_CONVERSATION;
+  const now = options.now ?? Date.now();
+  const rng = mulberry32(options.seed ?? DEFAULT_SEED);
+
+  const spanMs = spanMonths * MONTH_MS;
+  const earliest = now - spanMs;
+  // Leave headroom after the last conversation start so its messages fit
+  // before `now` even at one message per few minutes.
+  const startWindow = spanMs - messagesPerConversation * 5 * 60_000 - 60_000;
+
+  const conversations: GeneratedCorpusConversation[] = [];
+  let oldestMessageAt = Number.POSITIVE_INFINITY;
+  let newestMessageAt = 0;
+
+  for (let i = 0; i < conversationCount; i++) {
+    const pack = TOPIC_PACKS[i % TOPIC_PACKS.length];
+    // Even spread plus jitter, oldest first.
+    const slot = conversationCount === 1 ? 0 : i / (conversationCount - 1);
+    const jitter = (rng() - 0.5) * (startWindow / conversationCount);
+    const startAt = Math.round(
+      Math.min(
+        now - messagesPerConversation * 5 * 60_000 - 60_000,
+        Math.max(earliest, earliest + slot * startWindow + jitter),
+      ),
+    );
+    const startDate = new Date(startAt);
+    const monthName = MONTH_NAMES[startDate.getUTCMonth()];
+    const title = `${pack.titles[Math.floor(rng() * pack.titles.length)]} (${monthName} ${startDate.getUTCFullYear()})`;
+
+    const messages: GeneratedCorpusMessage[] = [];
+    let at = startAt;
+    for (let j = 0; j < messagesPerConversation; j++) {
+      const role = j % 2 === 0 ? "user" : "assistant";
+      const lines = role === "user" ? pack.userLines : pack.assistantLines;
+      const text = fillTemplate(lines[Math.floor(rng() * lines.length)], rng);
+      messages.push({ role, text, createdAt: at });
+      oldestMessageAt = Math.min(oldestMessageAt, at);
+      newestMessageAt = Math.max(newestMessageAt, at);
+      // 30s–5min between turns.
+      at += 30_000 + Math.floor(rng() * 270_000);
+    }
+
+    const facts: Array<{ text: string; createdAt: number }> = [];
+    for (let f = 0; f < factsPerConversation; f++) {
+      const factText = pack.facts[f % pack.facts.length];
+      facts.push({
+        text: `${factText} (noted ${monthName} ${startDate.getUTCFullYear()})`,
+        createdAt: messages.at(-1)?.createdAt ?? startAt,
+      });
+    }
+
+    conversations.push({
+      title,
+      topic: pack.topic,
+      createdAt: startAt,
+      messages,
+      facts,
+    });
+  }
+
+  return {
+    conversations,
+    sampleQueries: TOPIC_PACKS.slice(
+      0,
+      Math.min(conversationCount, TOPIC_PACKS.length),
+    ).map((p) => p.sampleQuery),
+    oldestMessageAt: Number.isFinite(oldestMessageAt) ? oldestMessageAt : now,
+    newestMessageAt,
+  };
+}
+
+/**
+ * The narrow runtime surface the seeder writes through. `AgentRuntime`
+ * satisfies it structurally; tests can drive it with a real runtime over an
+ * in-memory adapter.
+ */
+export interface MessageCorpusRuntime {
+  agentId: UUID;
+  character: { name?: string };
+  ensureConnection(params: {
+    entityId: UUID;
+    roomId: UUID;
+    roomName?: string;
+    worldId?: UUID;
+    userName?: string;
+    source?: string;
+    type?: ChannelType | string;
+    channelId?: string;
+    messageServerId?: UUID;
+    metadata?: Record<string, unknown>;
+  }): Promise<unknown>;
+  createMemory(
+    memory: Memory,
+    tableName: string,
+    unique?: boolean,
+  ): Promise<UUID>;
+}
+
+export interface SeededConversationRef {
+  /** Conversation id (the `web-conv-<id>` channel suffix). */
+  id: string;
+  roomId: UUID;
+  title: string;
+  topic: string;
+  createdAt: number;
+  lastMessageAt: number;
+}
+
+export interface MessageCorpusSeedSummary {
+  conversations: SeededConversationRef[];
+  messagesCreated: number;
+  factsCreated: number;
+  oldestMessageAt: number;
+  newestMessageAt: number;
+  sampleQueries: string[];
+}
+
+/**
+ * Land a generated corpus through the runtime as real web-chat conversations:
+ * one `web-conv-*` room per conversation in the agent's web-chat world (the
+ * exact shape `restoreConversationsFromDb` scans for), user messages authored
+ * by a deterministic simulated-owner entity, assistant messages by the agent,
+ * and per-conversation derived facts in the `facts` table — all with the
+ * corpus's backdated `createdAt` values.
+ */
+export async function seedMessageCorpus(
+  runtime: MessageCorpusRuntime,
+  corpus: GeneratedMessageCorpus,
+): Promise<MessageCorpusSeedSummary> {
+  const agentName = runtime.character.name ?? "Eliza";
+  const worldId = stringToUuid(`${agentName}-web-chat-world`);
+  const messageServerId = stringToUuid(`${agentName}-web-server`) as UUID;
+  const ownerEntityId = stringToUuid(
+    `message-corpus-owner-${runtime.agentId}`,
+  ) as UUID;
+
+  const seeded: SeededConversationRef[] = [];
+  let messagesCreated = 0;
+  let factsCreated = 0;
+
+  for (const conversation of corpus.conversations) {
+    const conversationId = randomUUID();
+    const roomId = stringToUuid(`web-conv-${conversationId}`) as UUID;
+    await runtime.ensureConnection({
+      entityId: ownerEntityId,
+      roomId,
+      roomName: conversation.title,
+      worldId,
+      userName: "Demo Owner",
+      source: MESSAGE_SOURCE_CLIENT_CHAT,
+      channelId: `web-conv-${conversationId}`,
+      type: ChannelType.DM,
+      messageServerId,
+      metadata: { ownership: { ownerId: ownerEntityId } },
+    });
+
+    let lastMessageAt = conversation.createdAt;
+    for (const message of conversation.messages) {
+      await runtime.createMemory(
+        {
+          id: randomUUID() as UUID,
+          entityId: message.role === "assistant" ? runtime.agentId : ownerEntityId,
+          agentId: runtime.agentId,
+          roomId,
+          worldId,
+          content: { text: message.text, source: MESSAGE_SOURCE_CLIENT_CHAT },
+          metadata: { type: "messages" },
+          createdAt: message.createdAt,
+        },
+        "messages",
+      );
+      messagesCreated += 1;
+      lastMessageAt = message.createdAt;
+    }
+
+    for (const fact of conversation.facts) {
+      // Same durable-fact shape the scenario-runner memory seed writes, so the
+      // core FACTS provider retrieves these like extractor-persisted facts.
+      await runtime.createMemory(
+        {
+          id: randomUUID() as UUID,
+          entityId: ownerEntityId,
+          agentId: runtime.agentId,
+          roomId,
+          worldId,
+          content: { text: fact.text },
+          metadata: {
+            type: MemoryType.CUSTOM,
+            source: "message-corpus-seed",
+            confidence: 0.95,
+            kind: "durable",
+            category: "seeded",
+            keywords: [],
+          },
+          createdAt: fact.createdAt,
+        },
+        "facts",
+        true,
+      );
+      factsCreated += 1;
+    }
+
+    seeded.push({
+      id: conversationId,
+      roomId,
+      title: conversation.title,
+      topic: conversation.topic,
+      createdAt: conversation.createdAt,
+      lastMessageAt,
+    });
+  }
+
+  return {
+    conversations: seeded,
+    messagesCreated,
+    factsCreated,
+    oldestMessageAt: corpus.oldestMessageAt,
+    newestMessageAt: corpus.newestMessageAt,
+    sampleQueries: corpus.sampleQueries,
+  };
+}

--- a/packages/agent/src/api/message-corpus.ts
+++ b/packages/agent/src/api/message-corpus.ts
@@ -17,9 +17,9 @@
 import { randomUUID } from "node:crypto";
 import {
   ChannelType,
-  MemoryType,
   MESSAGE_SOURCE_CLIENT_CHAT,
   type Memory,
+  MemoryType,
   stringToUuid,
   type UUID,
 } from "@elizaos/core";
@@ -86,12 +86,16 @@ interface TopicPack {
   userLines: string[];
   assistantLines: string[];
   facts: string[];
-  /** A distinctive query that should hit this topic's messages. */
+  /**
+   * A single distinctive token guaranteed to recur across this pack's lines, so
+   * it reliably lands hits. A multi-word phrase would require every term in one
+   * message — brittle against generated line variety — so keep it one word.
+   */
   sampleQuery: string;
 }
 
 // Each pack carries distinctive low-collision keywords (marathon, sourdough,
-// kubernetes, …) so demo searches land on the intended topic, and enough line
+// canary, …) so demo searches land on the intended topic, and enough line
 // variety that FTS ranking has real signal instead of near-identical rows.
 const TOPIC_PACKS: TopicPack[] = [
   {
@@ -116,11 +120,15 @@ const TOPIC_PACKS: TopicPack[] = [
       "Owner is training for the Berlin marathon and runs long on weekends",
       "Owner's easy run pace is about six minutes per kilometer",
     ],
-    sampleQuery: "marathon training",
+    sampleQuery: "marathon",
   },
   {
     topic: "baking",
-    titles: ["Sourdough starter log", "Weekend bake plans", "Crumb troubleshooting"],
+    titles: [
+      "Sourdough starter log",
+      "Weekend bake plans",
+      "Crumb troubleshooting",
+    ],
     userLines: [
       "The sourdough starter doubled in {n} hours today, smells like ripe fruit",
       "My crumb came out dense again — should I extend bulk fermentation?",
@@ -140,11 +148,15 @@ const TOPIC_PACKS: TopicPack[] = [
       "Owner keeps a sourdough starter and bakes on weekends",
       "Owner prefers high-hydration open-crumb loaves",
     ],
-    sampleQuery: "sourdough starter",
+    sampleQuery: "sourdough",
   },
   {
     topic: "infra",
-    titles: ["Kubernetes cluster upgrade", "Deploy pipeline debugging", "Incident postmortem"],
+    titles: [
+      "Kubernetes cluster upgrade",
+      "Deploy pipeline debugging",
+      "Incident postmortem",
+    ],
     userLines: [
       "The kubernetes cluster upgrade to {n}.x left two nodes NotReady",
       "Deploy rolled back automatically — the readiness probe timed out after {n} seconds",
@@ -164,11 +176,15 @@ const TOPIC_PACKS: TopicPack[] = [
       "Owner operates a kubernetes cluster and prefers canary deploys",
       "Owner's production database is Postgres behind a connection pooler",
     ],
-    sampleQuery: "kubernetes cluster",
+    sampleQuery: "canary",
   },
   {
     topic: "finance",
-    titles: ["Quarterly budget review", "Invoice follow-ups", "Subscription audit"],
+    titles: [
+      "Quarterly budget review",
+      "Invoice follow-ups",
+      "Subscription audit",
+    ],
     userLines: [
       "The quarterly budget shows {n} percent overspend on cloud infrastructure",
       "Invoice number {n} from the design contractor is still unpaid",
@@ -188,11 +204,15 @@ const TOPIC_PACKS: TopicPack[] = [
       "Owner reviews the budget quarterly and tracks cloud spend closely",
       "Owner's payroll runs monthly on a fixed date",
     ],
-    sampleQuery: "quarterly budget",
+    sampleQuery: "invoice",
   },
   {
     topic: "travel",
-    titles: ["Kyoto itinerary", "Autumn trip planning", "Flight and ryokan bookings"],
+    titles: [
+      "Kyoto itinerary",
+      "Autumn trip planning",
+      "Flight and ryokan bookings",
+    ],
     userLines: [
       "Thinking {n} days in Kyoto then the train to Osaka — too rushed?",
       "The ryokan near Arashiyama has an opening the week of the {n}th",
@@ -212,11 +232,15 @@ const TOPIC_PACKS: TopicPack[] = [
       "Owner is planning an autumn trip to Kyoto with a ryokan stay",
       "Owner prefers early-morning sightseeing before crowds",
     ],
-    sampleQuery: "kyoto itinerary",
+    sampleQuery: "kyoto",
   },
   {
     topic: "reading",
-    titles: ["Book club notes", "Reading list triage", "Sci-fi recommendations"],
+    titles: [
+      "Book club notes",
+      "Reading list triage",
+      "Sci-fi recommendations",
+    ],
     userLines: [
       "Finished reading Dune last night — the ecology subplot deserved more pages",
       "Book club picked a {n} page biography for next month, wish me luck",
@@ -236,7 +260,7 @@ const TOPIC_PACKS: TopicPack[] = [
       "Owner is in a monthly book club and favors literary sci-fi",
       "Owner reads mostly during train commutes",
     ],
-    sampleQuery: "book club",
+    sampleQuery: "abandoning",
   },
   {
     topic: "garden",
@@ -260,7 +284,7 @@ const TOPIC_PACKS: TopicPack[] = [
       "Owner grows tomatoes from seed in a raised-bed garden",
       "Owner composts and battles aphids without pesticides",
     ],
-    sampleQuery: "tomato seedlings",
+    sampleQuery: "seedlings",
   },
   {
     topic: "health",
@@ -284,7 +308,7 @@ const TOPIC_PACKS: TopicPack[] = [
       "Owner tracks migraines and skipped meals are a known trigger",
       "Owner is resetting their sleep schedule around a fixed wake time",
     ],
-    sampleQuery: "migraine tracking",
+    sampleQuery: "migraine",
   },
 ];
 
@@ -481,7 +505,8 @@ export async function seedMessageCorpus(
       await runtime.createMemory(
         {
           id: randomUUID() as UUID,
-          entityId: message.role === "assistant" ? runtime.agentId : ownerEntityId,
+          entityId:
+            message.role === "assistant" ? runtime.agentId : ownerEntityId,
           agentId: runtime.agentId,
           roomId,
           worldId,

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -276,6 +276,8 @@ export abstract class DatabaseAdapter<DB extends object = object>
 		tableName?: string;
 		limit?: number;
 		offset?: number;
+		since?: number;
+		until?: number;
 		accessContext?: AccessContext;
 	}): Promise<MessageSearchHit[]>;
 

--- a/packages/core/src/database/inMemoryAdapter.ts
+++ b/packages/core/src/database/inMemoryAdapter.ts
@@ -14,7 +14,7 @@
  * lost on restart.
  */
 import { DatabaseAdapter } from "../database";
-import { rankMessageSearch } from "../search";
+import { rankMessageSearch, withinCreatedAtWindow } from "../search";
 import type {
 	AccessContext,
 	Agent,
@@ -954,6 +954,8 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 		tableName?: string;
 		limit?: number;
 		offset?: number;
+		since?: number;
+		until?: number;
 		accessContext?: AccessContext;
 	}): Promise<MessageSearchHit[]> {
 		if (params.roomIds.length === 0) return [];
@@ -963,7 +965,16 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<
 			const list = this.memoriesByRoom.get(roomTableKey(tableName, rid)) ?? [];
 			candidates.push(...list);
 		}
-		const ranked = rankMessageSearch(candidates, params.query);
+		// The window is applied before ranking + LIMIT/OFFSET, mirroring the SQL
+		// adapters' created_at range conditions.
+		const windowed = candidates.filter((memory) =>
+			withinCreatedAtWindow(
+				typeof memory.createdAt === "number" ? memory.createdAt : undefined,
+				params.since,
+				params.until,
+			),
+		);
+		const ranked = rankMessageSearch(windowed, params.query);
 		const offset = typeof params.offset === "number" ? params.offset : 0;
 		const limit = params.limit ?? 20;
 		return ranked

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -9038,6 +9038,8 @@ ${section_end}`;
 		tableName?: string;
 		limit?: number;
 		offset?: number;
+		since?: number;
+		until?: number;
 		accessContext?: AccessContext;
 	}): Promise<MessageSearchHit[]> {
 		return this.adapter.searchMessages(params);

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -1922,6 +1922,25 @@ function termTrigramSimilarity(queryTerms: string[], document: string): number {
 	return total / queryTerms.length;
 }
 
+/**
+ * Whether a message's `createdAt` falls inside an inclusive `[since, until]`
+ * epoch-ms window. The in-memory twin of the SQL adapters' `created_at`
+ * range conditions in `searchMessages`, so both store paths agree on window
+ * semantics. When a bound is set, a row without a numeric `createdAt` is
+ * excluded — an unknown timestamp cannot be proven to be inside the window.
+ */
+export function withinCreatedAtWindow(
+	createdAt: number | undefined,
+	since?: number,
+	until?: number,
+): boolean {
+	if (since === undefined && until === undefined) return true;
+	if (typeof createdAt !== "number") return false;
+	if (since !== undefined && createdAt < since) return false;
+	if (until !== undefined && createdAt > until) return false;
+	return true;
+}
+
 /** A message-shaped record the in-memory search ranker can score and order. */
 export interface SearchableMessage {
 	content: { text?: unknown; attachments?: unknown };

--- a/packages/core/src/types/database.ts
+++ b/packages/core/src/types/database.ts
@@ -978,6 +978,14 @@ export interface IDatabaseAdapter<DB extends object = object> {
 		tableName?: string;
 		limit?: number;
 		offset?: number;
+		/**
+		 * Inclusive lower bound on `Memory.createdAt` (epoch ms). Applied in the
+		 * store together with the match predicate, before ranking and LIMIT/OFFSET,
+		 * so a time window never truncates recall ("messages from a year ago").
+		 */
+		since?: number;
+		/** Inclusive upper bound on `Memory.createdAt` (epoch ms). */
+		until?: number;
 		accessContext?: AccessContext;
 	}): Promise<MessageSearchHit[]>;
 

--- a/packages/scripts/seed-message-corpus.mjs
+++ b/packages/scripts/seed-message-corpus.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+/**
+ * Seed a running agent with ~1 year of backdated conversations, messages, and
+ * derived owner facts, then prove the corpus is searchable across a "one year
+ * ago" time window. Manual demo-prep for message search: run `bun run dev` (or
+ * any local agent), then run this against its API.
+ *
+ * It POSTs the dev-only `POST /api/conversations/dev/seed-messages` endpoint
+ * (404 in production) — the same route the seeder module powers — so the corpus
+ * is landed through the real runtime as real web-chat rooms with real backdated
+ * `createdAt` values, not injected around it. After seeding it issues a couple
+ * of `GET /api/conversations/messages/search` calls against the returned sample
+ * queries: one unbounded, one bounded to `until = 9 months ago`, so the
+ * operator can see that a relevant hit older than any recency window is still
+ * found and that the `since`/`until` window narrows the result set.
+ *
+ * Usage:
+ *   node packages/scripts/seed-message-corpus.mjs
+ *   node packages/scripts/seed-message-corpus.mjs --conversations=24 --messages=60 --span-months=18
+ *   node packages/scripts/seed-message-corpus.mjs --api-port=31337 --seed=99
+ */
+import process from "node:process";
+
+const DEFAULT_API_PORT = 31337;
+const MONTH_MS = 30 * 24 * 60 * 60 * 1000;
+
+function parseArgs(argv) {
+  const options = {
+    apiPort: Number(process.env.ELIZA_API_PORT) || DEFAULT_API_PORT,
+    host: process.env.ELIZA_API_HOST || "127.0.0.1",
+    body: {},
+  };
+  for (const arg of argv) {
+    if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    }
+    const [key, value] = arg.split("=", 2);
+    if (value === undefined) {
+      throw new Error(`Expected --key=value, got ${arg}`);
+    }
+    switch (key) {
+      case "--api-port":
+        options.apiPort = parsePositiveInt(value, key);
+        break;
+      case "--host":
+        options.host = value;
+        break;
+      case "--conversations":
+        options.body.conversations = parsePositiveInt(value, key);
+        break;
+      case "--messages":
+        options.body.messagesPerConversation = parsePositiveInt(value, key);
+        break;
+      case "--span-months":
+        options.body.spanMonths = parsePositiveInt(value, key);
+        break;
+      case "--facts":
+        options.body.factsPerConversation = parseNonNegativeInt(value, key);
+        break;
+      case "--seed":
+        options.body.seed = parseIntStrict(value, key);
+        break;
+      default:
+        throw new Error(`Unknown flag ${key}`);
+    }
+  }
+  return options;
+}
+
+function parseIntStrict(value, flag) {
+  const n = Number(value);
+  if (!Number.isSafeInteger(n)) throw new Error(`${flag} must be an integer`);
+  return n;
+}
+
+function parsePositiveInt(value, flag) {
+  const n = parseIntStrict(value, flag);
+  if (n < 1) throw new Error(`${flag} must be >= 1`);
+  return n;
+}
+
+function parseNonNegativeInt(value, flag) {
+  const n = parseIntStrict(value, flag);
+  if (n < 0) throw new Error(`${flag} must be >= 0`);
+  return n;
+}
+
+function printHelp() {
+  process.stdout.write(
+    `Seed a running agent with ~1 year of backdated messages for search demos.
+
+Usage:
+  node packages/scripts/seed-message-corpus.mjs [flags]
+
+Flags:
+  --api-port=N        Agent API port (default ${DEFAULT_API_PORT}; env ELIZA_API_PORT)
+  --host=HOST         Agent API host (default 127.0.0.1; env ELIZA_API_HOST)
+  --conversations=N   Conversations to generate (1-200, default 12)
+  --messages=N        Messages per conversation (1-500, default 40)
+  --span-months=N     Months of history to spread across (1-60, default 13)
+  --facts=N           Derived owner facts per conversation (0-10, default 1)
+  --seed=N            RNG seed for reproducible text/timestamps (default 1337)
+`,
+  );
+}
+
+async function postJson(url, body) {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  let parsed;
+  try {
+    parsed = text ? JSON.parse(text) : {};
+  } catch {
+    throw new Error(
+      `Non-JSON response from ${url} (HTTP ${res.status}): ${text.slice(0, 200)}`,
+    );
+  }
+  if (!res.ok) {
+    const message =
+      (parsed && typeof parsed.error === "string" && parsed.error) ||
+      `HTTP ${res.status}`;
+    throw new Error(`POST ${url} failed: ${message}`);
+  }
+  return parsed;
+}
+
+async function getJson(url) {
+  const res = await fetch(url);
+  const text = await res.text();
+  let parsed;
+  try {
+    parsed = text ? JSON.parse(text) : {};
+  } catch {
+    throw new Error(
+      `Non-JSON response from ${url} (HTTP ${res.status}): ${text.slice(0, 200)}`,
+    );
+  }
+  if (!res.ok) {
+    const message =
+      (parsed && typeof parsed.error === "string" && parsed.error) ||
+      `HTTP ${res.status}`;
+    throw new Error(`GET ${url} failed: ${message}`);
+  }
+  return parsed;
+}
+
+function iso(ms) {
+  return new Date(ms).toISOString();
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const base = `http://${options.host}:${options.apiPort}`;
+
+  process.stdout.write(`Seeding backdated message corpus via ${base} ...\n`);
+  const summary = await postJson(
+    `${base}/api/conversations/dev/seed-messages`,
+    options.body,
+  );
+
+  process.stdout.write(
+    `Seeded ${summary.conversations} conversations, ${summary.messagesCreated} messages, ` +
+      `${summary.factsCreated} facts.\n` +
+      `Oldest message: ${iso(summary.oldestMessageAt)}\n` +
+      `Newest message: ${iso(summary.newestMessageAt)}\n` +
+      `Sample queries: ${(summary.sampleQueries ?? []).join(", ")}\n\n`,
+  );
+
+  const sampleQuery = (summary.sampleQueries ?? [])[0];
+  if (!sampleQuery) {
+    process.stdout.write("No sample query returned; skipping search proof.\n");
+    return;
+  }
+
+  // Prove the corpus is hittable across a year: an unbounded search finds the
+  // topic, and an `until = 9 months ago` window still returns older hits while
+  // dropping anything newer — the "messages from a year ago" case.
+  const untilMs = Date.now() - 9 * MONTH_MS;
+  const q = encodeURIComponent(sampleQuery);
+  const unbounded = await getJson(
+    `${base}/api/conversations/messages/search?q=${q}&limit=100`,
+  );
+  const windowed = await getJson(
+    `${base}/api/conversations/messages/search?q=${q}&limit=100&until=${untilMs}`,
+  );
+
+  const oldestUnbounded = unbounded.results.reduce(
+    (min, r) => Math.min(min, r.createdAt),
+    Number.POSITIVE_INFINITY,
+  );
+
+  process.stdout.write(
+    `Search proof for "${sampleQuery}":\n` +
+      `  unbounded            → ${unbounded.count} hits (oldest ${
+        Number.isFinite(oldestUnbounded) ? iso(oldestUnbounded) : "n/a"
+      })\n` +
+      `  until=9 months ago   → ${windowed.count} hits (all createdAt <= ${iso(untilMs)})\n`,
+  );
+
+  const windowRespected = windowed.results.every((r) => r.createdAt <= untilMs);
+  if (!windowRespected) {
+    throw new Error(
+      "Time-window search returned a hit newer than `until` — the store is ignoring the window",
+    );
+  }
+  process.stdout.write("Time window honored by the store. Done.\n");
+}
+
+main().catch((err) => {
+  process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+  process.exitCode = 1;
+});

--- a/packages/shared/src/contracts/conversation-routes.ts
+++ b/packages/shared/src/contracts/conversation-routes.ts
@@ -114,6 +114,21 @@ export const PostConversationCleanupEmptyRequestSchema = z
     return trimmed ? { keepId: trimmed } : {};
   });
 
+/**
+ * POST /api/conversations/dev/seed-messages (dev-only, 404 in production).
+ * Shape of the backdated message-corpus seed request; bounds keep a fat-finger
+ * from generating an unbounded corpus in one call.
+ */
+export const PostSeedMessagesRequestSchema = z
+  .object({
+    conversations: z.number().int().min(1).max(200).optional(),
+    messagesPerConversation: z.number().int().min(1).max(500).optional(),
+    spanMonths: z.number().int().min(1).max(60).optional(),
+    factsPerConversation: z.number().int().min(0).max(10).optional(),
+    seed: z.number().int().optional(),
+  })
+  .strict();
+
 export type ConversationMetadataInput = z.infer<
   typeof ConversationMetadataSchema
 >;
@@ -138,4 +153,7 @@ export type PatchConversationRequest = z.infer<
 >;
 export type PostConversationCleanupEmptyRequest = z.infer<
   typeof PostConversationCleanupEmptyRequestSchema
+>;
+export type PostSeedMessagesRequest = z.infer<
+  typeof PostSeedMessagesRequestSchema
 >;

--- a/packages/ui/src/api/client-chat.ts
+++ b/packages/ui/src/api/client-chat.ts
@@ -363,10 +363,19 @@ declare module "./client-base" {
     /**
      * Keyword search across every conversation the user can see, ranked by
      * relevance then recency. Backs the chat message-search affordance.
+     * `since`/`until` (epoch ms, inclusive) scope the search to a time window
+     * — e.g. "messages from about a year ago" — applied in the store before
+     * ranking, so old hits are found rather than recency-truncated.
      */
     searchConversationMessages(
       query: string,
-      options?: { limit?: number; offset?: number; signal?: AbortSignal },
+      options?: {
+        limit?: number;
+        offset?: number;
+        since?: number;
+        until?: number;
+        signal?: AbortSignal;
+      },
     ): Promise<ConversationMessageSearchResponse>;
     /**
      * Fetch the cross-channel inbox. Returns the most recent
@@ -1084,6 +1093,8 @@ ElizaClient.prototype.searchConversationMessages = async function (
   if (options?.limit !== undefined) params.set("limit", String(options.limit));
   if (options?.offset !== undefined)
     params.set("offset", String(options.offset));
+  if (options?.since !== undefined) params.set("since", String(options.since));
+  if (options?.until !== undefined) params.set("until", String(options.until));
   return this.fetch<ConversationMessageSearchResponse>(
     `/api/conversations/messages/search?${params}`,
     options?.signal ? { signal: options.signal } : undefined,

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -46,8 +46,8 @@ import {
   rankMessageSearch,
   type Task,
   type UUID,
-  withinCreatedAtWindow,
   type World,
+  withinCreatedAtWindow,
 } from "@elizaos/core";
 import { EphemeralHNSW } from "./hnsw";
 import { COLLECTIONS, type IStorage } from "./types";

--- a/plugins/plugin-inmemorydb/adapter.ts
+++ b/plugins/plugin-inmemorydb/adapter.ts
@@ -46,6 +46,7 @@ import {
   rankMessageSearch,
   type Task,
   type UUID,
+  withinCreatedAtWindow,
   type World,
 } from "@elizaos/core";
 import { EphemeralHNSW } from "./hnsw";
@@ -647,6 +648,8 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
     tableName?: string;
     limit?: number;
     offset?: number;
+    since?: number;
+    until?: number;
     accessContext?: AccessContext;
   }): Promise<MessageSearchHit[]> {
     if (params.roomIds.length === 0) return [];
@@ -656,7 +659,17 @@ export class InMemoryDatabaseAdapter extends DatabaseAdapter<IStorage> {
       COLLECTIONS.MEMORIES,
       (m) => roomSet.has(m.roomId as UUID) && m.metadata?.type === tableName
     );
-    const candidates = stored.map(toMemory);
+    // The window is applied before ranking + LIMIT/OFFSET, mirroring the SQL
+    // adapters' created_at range conditions.
+    const candidates = stored
+      .map(toMemory)
+      .filter((memory) =>
+        withinCreatedAtWindow(
+          typeof memory.createdAt === "number" ? memory.createdAt : undefined,
+          params.since,
+          params.until
+        )
+      );
     const ranked = rankMessageSearch(candidates, params.query);
     const offset = typeof params.offset === "number" ? params.offset : 0;
     const limit = params.limit ?? 20;

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -1722,6 +1722,8 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
     tableName?: string;
     limit?: number;
     offset?: number;
+    since?: number;
+    until?: number;
     accessContext?: AccessContext;
   }): Promise<MessageSearchHit[]> {
     return this.withDatabase(async () => {
@@ -1729,6 +1731,16 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       const tableName = params.tableName ?? "messages";
       const limit = params.limit ?? 20;
       const offset = params.offset ?? 0;
+      // Inclusive created_at window, applied with the match predicate BEFORE
+      // ranking and LIMIT/OFFSET so a "one year ago" window never loses hits to
+      // a recency-truncated slice. Both branches below share these conditions.
+      const timeConditions: SQL[] = [];
+      if (typeof params.since === "number") {
+        timeConditions.push(gte(memoryTable.createdAt, new Date(params.since)));
+      }
+      if (typeof params.until === "number") {
+        timeConditions.push(lte(memoryTable.createdAt, new Date(params.until)));
+      }
       const trigramAvailable = await this.isTrigramAvailable();
 
       // Fold the query in SQL with the same function the document is folded with.
@@ -1761,6 +1773,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
         eq(memoryTable.type, tableName),
         eq(memoryTable.agentId, this.agentId),
         inArray(memoryTable.roomId, params.roomIds),
+        ...timeConditions,
         sql`(${tsvector} @@ ${tsquery} OR ${document} LIKE eliza_search_like_pattern(${params.query}) OR ${trigramMatch})`,
       ];
 
@@ -1836,6 +1849,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
               eq(memoryTable.type, tableName),
               eq(memoryTable.agentId, this.agentId),
               inArray(memoryTable.roomId, params.roomIds),
+              ...timeConditions,
               or(
                 sql`(${memoryTable.content}->>'text') ILIKE ${`%${escapeIlikeLiteral(params.query)}%`} ESCAPE '\\'`,
                 sql`${memoryTable.content}::text ILIKE ${`%${escapeIlikeLiteral(params.query)}%`} ESCAPE '\\'`


### PR DESCRIPTION
## What

Makes message/memory search work at scale with a time range, and gives it a real corpus to test against:

1. **`since`/`until` time-range on `searchMessages`** (contract → all three DB adapters → route → client). Applied in the store *with* the match predicate, **before** ranking + LIMIT/OFFSET, so a "one year ago" window never truncates recall.
2. **Backdated message-corpus seeder** (`packages/agent/src/api/message-corpus.ts`) — generates ~1 year of realistic conversations/messages/derived-facts with real backdated `createdAt`, landed through the runtime as real `web-conv-*` web-chat rooms (the exact shape `restoreConversationsFromDb` scans for).
3. **Dev-only seed endpoint** `POST /api/conversations/dev/seed-messages` (404 in production) with a bounded, strict, validated request schema.
4. **CLI** `bun run seed:messages` (`packages/scripts/seed-message-corpus.mjs`) for manual demo prep — POSTs the dev endpoint, then proves a "9 months ago" window is honored by the store.

## No partial pipeline

All three implementations of the `IDatabaseAdapter.searchMessages` contract honor the window:

- `packages/core/src/database/inMemoryAdapter.ts`
- `plugins/plugin-inmemorydb/adapter.ts` (also backs `plugin-localdb`, which wraps it)
- `plugins/plugin-sql/src/base.ts` (both the FTS/trigram branch and the ILIKE fallback branch share the `created_at` range conditions)

The in-memory path and the SQL path share one window-predicate semantics via `withinCreatedAtWindow` (`packages/core/src/search.ts`): when a bound is set, a row without a numeric `createdAt` is excluded.

## Validation

`since`/`until` are validated at the route: garbage / empty / malformed-ISO -> **400**; `since > until` -> **400**; epoch-ms integer or ISO 8601 accepted. A garbage bound is never a silently-ignored filter.

## Evidence

- **Real-LLM trajectories** - N/A. No agent/action/prompt/model behavior changes; this is store + route + a dev seeder.
- **Frontend screenshots/video** - N/A. No UI change beyond the existing search client gaining optional params.
- **Backend logs** - the seed route emits `[ConversationSearch] seeded backdated message corpus`; search emits `[ConversationSearch] FTS message search completed` with `since`/`until` context.
- **Domain artifacts** - the seeder writes real backdated `messages` + `facts` rows; the tests read them back through the real store and assert on their `createdAt`.

### Tests (real adapter, real ranker, real window filter - no mock of the thing under test)

`message-corpus-search.test.ts` drives the **real `InMemoryDatabaseAdapter`** (imported from in-tree core source so the current window filter is under test, not a stale dist build) fed by the **real `generateMessageCorpus` + `seedMessageCorpus`**:

<details>
<summary>bunx vitest run (3 files, 27 tests)</summary>

```
✓ message-corpus-search.test.ts > seeds a real backdated corpus spanning more than a year
✓ message-corpus-search.test.ts > corpus-wide recall: search reaches back past a year for a real keyword
✓ message-corpus-search.test.ts > until= narrows to older messages; every hit is within the window
✓ message-corpus-search.test.ts > since= narrows to newer messages; every hit is within the window
✓ message-corpus-search.test.ts > since+until brackets an inner window derived from the real hit spread
✓ message-corpus-search.test.ts > pagination is stable: disjoint offset pages tile the full result set
✓ message-corpus-search.test.ts > a window entirely after the corpus returns nothing (never a fabricated hit)

✓ conversation-message-search.test.ts (14 tests: adds since/until 400-validation, since>until 400,
    valid epoch-ms + ISO 8601 accepted, deterministic window-narrowing)

✓ conversation-seed-messages-route.test.ts > returns 404 in production
✓ conversation-seed-messages-route.test.ts > rejects an out-of-bounds request body with 400
✓ conversation-seed-messages-route.test.ts > rejects an unknown field (strict schema) with 400
✓ conversation-seed-messages-route.test.ts > rejects a non-integer count with 400
✓ conversation-seed-messages-route.test.ts > seeds a real backdated corpus and registers the conversations in state
✓ conversation-seed-messages-route.test.ts > returns 503 when the runtime is not available

 Test Files  3 passed (3)
      Tests  27 passed (27)
```
</details>

### Verify

- `bunx biome check <touched files>` -> clean.
- `bun run --cwd packages/agent typecheck` -> no errors in touched files (4 pre-existing `TS2688` "cannot find type def" for `bun`/`node`/`react`/`react-dom` are worktree node_modules-resolution noise, not from this change).
- `bun run audit:error-policy-ratchet` -> `no new fallback-slop in touched files`.

## Notes / residual

- The end-to-end test imports the core adapter via a relative in-tree path because `@elizaos/core` resolves to a **stale dist** in shared worktrees; importing source guarantees the window filter under test is the current code. The real runtime path is identical (`runtime.searchMessages` is a straight passthrough to `adapter.searchMessages`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Evidence Matrix
<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - backend/store/API/client-param change plus dev seeder; no rendered UI component changed.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - backend/store/API/client-param change plus dev seeder; no rendered UI component changed.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no user-facing UI flow changed in this PR; the relevant walkthrough is the seeded corpus/search CLI and API logs.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no live server was run in this local pass; tests exercise the route and adapter behavior, and the PR body documents the expected `[ConversationSearch]` seed/search log lines for a live run.
<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A - no rendered frontend flow changed; the existing client only gains optional `since`/`until` params.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no agent/action/provider/prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - no production DB artifact was generated in this local pass; deterministic tests seed and read real backdated in-memory `messages`/`facts` rows and assert `createdAt` window behavior.

## Stronger Follow-Up Proof
For final MVP demo evidence, run `bun run seed:messages` against a dev server, attach the backend seed/search logs plus the generated summary JSON/output, and prove an old-window query returns only messages inside the requested `since`/`until` bounds.
