### PR TITLE
test(uploads): prove image/audio/video/text/pdf/json e2e + close enrichment gaps

### DIFF
--- a/packages/agent/src/api/chat-attachment-processing-lifecycle.test.ts
+++ b/packages/agent/src/api/chat-attachment-processing-lifecycle.test.ts
@@ -130,7 +130,10 @@ function bytesForMime(mimeType: string): Buffer {
     return Buffer.from("# Lifecycle\n\n- upload\n- process", "utf8");
   }
   if (mimeType === "application/json") {
-    return Buffer.from('{"lifecycle":true,"items":["upload","process"]}', "utf8");
+    return Buffer.from(
+      '{"lifecycle":true,"items":["upload","process"]}',
+      "utf8",
+    );
   }
   return Buffer.from(`binary fixture for ${mimeType}`, "utf8");
 }
@@ -316,10 +319,7 @@ describe("chat attachment upload -> store -> processing lifecycle (#10714)", () 
       const disposition = String(head.headers["Content-Disposition"]);
       // Only image/audio/video/pdf render inline; text/* and application/json
       // are forced to download (attachment) by the serve-path security policy.
-      if (
-        mimeType.startsWith("text/") ||
-        mimeType === "application/json"
-      ) {
+      if (mimeType.startsWith("text/") || mimeType === "application/json") {
         expect(disposition, mimeType).toContain("attachment");
       } else {
         expect(disposition, mimeType).toBe("inline");

--- a/packages/agent/src/api/chat-attachment-processing-lifecycle.test.ts
+++ b/packages/agent/src/api/chat-attachment-processing-lifecycle.test.ts
@@ -64,6 +64,7 @@ const EXPECTED_EXT_BY_MIME: Record<
   "text/plain": "txt",
   "text/csv": "csv",
   "text/markdown": "md",
+  "application/json": "json",
 };
 
 function expectedContentType(mimeType: string): string {
@@ -77,6 +78,7 @@ function expectedServedMime(mimeType: string): string {
   if (mimeType === "text/plain") return "text/plain; charset=utf-8";
   if (mimeType === "text/csv") return "text/csv; charset=utf-8";
   if (mimeType === "text/markdown") return "text/markdown; charset=utf-8";
+  if (mimeType === "application/json") return "application/json; charset=utf-8";
   if (mimeType === "image/jpeg") return "image/jpeg";
   if (mimeType === "audio/mp3") return "audio/mpeg";
   if (mimeType === "audio/x-wav" || mimeType === "audio/wave")
@@ -127,22 +129,38 @@ function bytesForMime(mimeType: string): Buffer {
   if (mimeType === "text/markdown") {
     return Buffer.from("# Lifecycle\n\n- upload\n- process", "utf8");
   }
+  if (mimeType === "application/json") {
+    return Buffer.from('{"lifecycle":true,"items":["upload","process"]}', "utf8");
+  }
   return Buffer.from(`binary fixture for ${mimeType}`, "utf8");
 }
 
 function makeRes(): {
   res: ServerResponse;
   get: () => { status: number; headers: Record<string, unknown> };
+  /**
+   * Resolves once a piped read stream (the Range 206 path calls
+   * `createReadStream(...).pipe(res)`) has finished writing. Awaiting it keeps
+   * that async read from racing `afterAll`'s temp-dir cleanup, which otherwise
+   * surfaces as unhandled ENOENT for the just-served media file.
+   */
+  whenEnded: () => Promise<void>;
 } {
   let status = 0;
   let headers: Record<string, unknown> = {};
+  let resolveEnded: (() => void) | undefined;
+  const ended = new Promise<void>((resolve) => {
+    resolveEnded = resolve;
+  });
   const res = {
     writeHead(nextStatus: number, nextHeaders: Record<string, unknown>) {
       status = nextStatus;
       headers = nextHeaders;
       return this;
     },
-    end() {},
+    end() {
+      resolveEnded?.();
+    },
     write() {
       return true;
     },
@@ -156,11 +174,14 @@ function makeRes(): {
       return true;
     },
   } as unknown as ServerResponse;
-  return { res, get: () => ({ status, headers }) };
+  return { res, whenEnded: () => ended, get: () => ({ status, headers }) };
 }
 
-function serve(url: string, options: { method?: string; range?: string } = {}) {
-  const { res, get } = makeRes();
+async function serve(
+  url: string,
+  options: { method?: string; range?: string } = {},
+) {
+  const { res, get, whenEnded } = makeRes();
   const handled = serveMediaFile(
     {
       method: options.method ?? "HEAD",
@@ -170,6 +191,10 @@ function serve(url: string, options: { method?: string; range?: string } = {}) {
     url,
   );
   expect(handled).toBe(true);
+  // A GET (full or Range) pipes a read stream that resolves `end` on completion;
+  // HEAD/416 answer synchronously. Await so the stream closes before the next
+  // assertion (and before cleanup).
+  await whenEnded();
   return get();
 }
 
@@ -195,7 +220,7 @@ async function mediaStoreFetch(input: unknown): Promise<Response> {
     return new Response("not found", { status: 404, statusText: "Not Found" });
   }
   const body = fs.readFileSync(path.join(stateDir, "media", fileName));
-  const head = serve(pathName);
+  const head = await serve(pathName);
   return new Response(body, {
     status: 200,
     statusText: "OK",
@@ -282,21 +307,26 @@ describe("chat attachment upload -> store -> processing lifecycle (#10714)", () 
       expect(compact?.mimeType).toBe(mimeType);
       expect(compact?.checksum).toBe(attachment?.checksum);
 
-      const head = serve(attachment?.url ?? "");
+      const head = await serve(attachment?.url ?? "");
       expect(head.status, mimeType).toBe(200);
       expect(head.headers["Content-Type"], mimeType).toBe(
         expectedServedMime(mimeType),
       );
       expect(head.headers["X-Content-Type-Options"], mimeType).toBe("nosniff");
       const disposition = String(head.headers["Content-Disposition"]);
-      if (mimeType.startsWith("text/")) {
+      // Only image/audio/video/pdf render inline; text/* and application/json
+      // are forced to download (attachment) by the serve-path security policy.
+      if (
+        mimeType.startsWith("text/") ||
+        mimeType === "application/json"
+      ) {
         expect(disposition, mimeType).toContain("attachment");
       } else {
         expect(disposition, mimeType).toBe("inline");
       }
 
       if (mimeType.startsWith("audio/") || mimeType.startsWith("video/")) {
-        const ranged = serve(attachment?.url ?? "", {
+        const ranged = await serve(attachment?.url ?? "", {
           method: "GET",
           range: "bytes=0-2",
         });

--- a/packages/agent/src/api/chat-attachments.test.ts
+++ b/packages/agent/src/api/chat-attachments.test.ts
@@ -80,17 +80,72 @@ describe("validateChatImages", () => {
     expect(validateChatImages([])).toBeNull();
   });
 
-  it("accepts images, audio, video, and pdf", () => {
+  it("accepts images, audio, video, pdf, text, and json", () => {
     expect(validateChatImages(ok("image/png"))).toBeNull();
     expect(validateChatImages(ok("audio/mpeg"))).toBeNull();
+    expect(validateChatImages(ok("audio/wav"))).toBeNull();
+    expect(validateChatImages(ok("audio/mp4"))).toBeNull();
     expect(validateChatImages(ok("video/mp4"))).toBeNull();
+    expect(validateChatImages(ok("video/webm"))).toBeNull();
     expect(validateChatImages(ok("application/pdf"))).toBeNull();
+    expect(validateChatImages(ok("text/plain"))).toBeNull();
+    expect(validateChatImages(ok("text/csv"))).toBeNull();
+    expect(validateChatImages(ok("text/markdown"))).toBeNull();
+    expect(validateChatImages(ok("application/json"))).toBeNull();
   });
 
   it("rejects unsupported types", () => {
     expect(validateChatImages(ok("application/x-msdownload"))).toMatch(
       /Unsupported attachment type/,
     );
+    // A spoofed SVG-as-image (image/svg+xml is deliberately NOT on the upload
+    // allow-list — it can carry script) is rejected before the store ever sees
+    // it; the media store's markup sniffer is the second line of defence.
+    expect(validateChatImages(ok("image/svg+xml"))).toMatch(
+      /Unsupported attachment type/,
+    );
+  });
+
+  it("rejects corrupt base64 that decodes to zero bytes", () => {
+    // Degenerate-but-syntactically-valid base64 (`=`, `==`, a lone char) is a
+    // non-empty string that carries no bytes; persisting it would write an empty
+    // file into the store and land an unreadable attachment.
+    for (const data of ["=", "==", "A"]) {
+      expect(
+        validateChatImages([{ data, mimeType: "image/png", name: "f" }]),
+        data,
+      ).toMatch(/zero bytes/);
+    }
+    // A well-formed 1+ byte payload is still accepted.
+    expect(
+      validateChatImages([{ data: "QQ==", mimeType: "image/png", name: "f" }]),
+    ).toBeNull();
+  });
+
+  it("rejects base64 with invalid characters", () => {
+    expect(
+      validateChatImages([
+        { data: "not valid base64!!", mimeType: "image/png", name: "f" },
+      ]),
+    ).toMatch(/invalid base64/);
+  });
+
+  it("enforces the larger media cap for non-image attachments", () => {
+    // A ~12 MiB base64 audio payload is under the 15 MiB media cap but over the
+    // 5 MiB image cap — it must be accepted (media cap), proving the two caps
+    // are applied per-kind, not uniformly.
+    const mediaSized = "A".repeat(12 * 1_048_576);
+    expect(
+      validateChatImages([
+        { data: mediaSized, mimeType: "audio/mpeg", name: "clip.mp3" },
+      ]),
+    ).toBeNull();
+    // The same payload as an IMAGE exceeds the 5 MiB image cap → rejected.
+    expect(
+      validateChatImages([
+        { data: mediaSized, mimeType: "image/png", name: "big.png" },
+      ]),
+    ).toMatch(/too large/);
   });
 
   it("rejects data-URL payloads (must be raw base64)", () => {

--- a/packages/agent/src/api/chat-attachments.test.ts
+++ b/packages/agent/src/api/chat-attachments.test.ts
@@ -55,6 +55,29 @@ describe("serializeMessageAttachments", () => {
     expect(out?.map((a) => a.id)).toEqual(["s", "d", "b"]);
   });
 
+  it("round-trips the notProcessed enrichment reason", () => {
+    const out = serializeMessageAttachments({
+      attachments: [
+        {
+          id: "aud",
+          url: "/api/media/abc.mp3",
+          contentType: "audio",
+          notProcessed: "Audio transcription unavailable: no provider",
+        },
+      ],
+    });
+    expect(out?.[0].notProcessed).toBe(
+      "Audio transcription unavailable: no provider",
+    );
+  });
+
+  it("omits notProcessed when the attachment was enriched cleanly", () => {
+    const out = serializeMessageAttachments({
+      attachments: [{ id: "img", url: "/api/media/abc.png", text: "OCR" }],
+    });
+    expect(out?.[0]).not.toHaveProperty("notProcessed");
+  });
+
   it("drops non-renderable placeholder URLs (unpersisted uploads)", () => {
     expect(
       serializeMessageAttachments({

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -1208,6 +1208,8 @@ type SerializedMessageAttachment = {
   text?: string;
   mimeType?: string;
   thumbnailUrl?: string;
+  /** Reason enrichment could not extract text/description (see Media.notProcessed). */
+  notProcessed?: string;
 };
 
 /**
@@ -1242,6 +1244,7 @@ export function serializeMessageAttachments(
       ...(str(a.text) ? { text: str(a.text) } : {}),
       ...(str(a.mimeType) ? { mimeType: str(a.mimeType) } : {}),
       ...(str(a.thumbnailUrl) ? { thumbnailUrl: str(a.thumbnailUrl) } : {}),
+      ...(str(a.notProcessed) ? { notProcessed: str(a.notProcessed) } : {}),
     });
   }
   return out.length > 0 ? out : undefined;

--- a/packages/agent/src/api/media-store.test.ts
+++ b/packages/agent/src/api/media-store.test.ts
@@ -156,8 +156,28 @@ describe("media-store", () => {
     expect(persistMediaBytes(Buffer.from("c"), "application/pdf").url).toMatch(
       /\.pdf$/,
     );
+    expect(
+      persistMediaBytes(Buffer.from("{}"), "application/json").url,
+    ).toMatch(/\.json$/);
     // Unknown mime falls back to .bin
     expect(persistMediaBytes(Buffer.from("d"), "x/y").url).toMatch(/\.bin$/);
+  });
+
+  it("serves a stored json file as a downloadable text payload", () => {
+    // application/json is a text document, not an inline-safe media type, so the
+    // serve path returns it with a charset content-type and an attachment
+    // disposition (never inline-rendered on the dashboard origin).
+    const { url } = persistMediaBytes(
+      Buffer.from('{"ok":true}'),
+      "application/json",
+    );
+    const { res, get } = makeRes();
+    serveMediaFile({ method: "HEAD", headers: {} } as never, res, url);
+    const { status, headers } = get();
+    expect(status).toBe(200);
+    expect(headers["Content-Type"]).toBe("application/json; charset=utf-8");
+    expect(String(headers["Content-Disposition"])).toContain("attachment");
+    expect(headers["X-Content-Type-Options"]).toBe("nosniff");
   });
 
   it("persists a base64 data URL", () => {

--- a/packages/agent/src/api/server-helpers.ts
+++ b/packages/agent/src/api/server-helpers.ts
@@ -484,6 +484,21 @@ export function cloneWithoutBlockedObjectKeys<T>(value: T): T {
 // same numbers pre-send and the two sides cannot drift.
 const BASE64_RE = /^[A-Za-z0-9+/]*={0,2}$/;
 
+/**
+ * True when a syntactically-valid base64 string decodes to zero bytes. `BASE64_RE`
+ * accepts degenerate payloads like `"="`, `"=="`, or a single stray char `"A"`
+ * (each < 2 base64 chars of real data) that are non-empty strings yet carry no
+ * bytes. Persisting one would write an empty file into the content-addressed
+ * store and land a zero-byte attachment the agent can never read, so the upload
+ * is rejected up front as a corrupt payload (never fabricated into a valid one).
+ */
+function base64DecodesToZeroBytes(data: string): boolean {
+  // A base64 quantum is 4 chars → 3 bytes; the last group may be `xx==` (1 byte)
+  // or `xxx=` (2 bytes). Any run shorter than 2 non-padding chars yields nothing.
+  const withoutPadding = data.replace(/=+$/, "");
+  return withoutPadding.length < 2;
+}
+
 // Re-exported for chat-routes and for parity tests against the client side.
 export { CHAT_UPLOAD_MIME_TYPES };
 
@@ -527,6 +542,8 @@ export function validateChatImages(images: unknown): string | null {
       return `Attachment too large (max ${maxBytes / 1_048_576} MB)`;
     if (!BASE64_RE.test(data))
       return "Attachment data contains invalid base64 characters";
+    if (base64DecodesToZeroBytes(data))
+      return "Attachment data decodes to zero bytes";
     if (typeof name !== "string" || !name)
       return "Each attachment must have a name string";
     if (name.length > MAX_IMAGE_NAME_LENGTH)

--- a/packages/core/src/features/basic-capabilities/index.ts
+++ b/packages/core/src/features/basic-capabilities/index.ts
@@ -371,10 +371,13 @@ export async function processAttachments(
 			}
 
 			const contentType = res.headers.get("content-type") || "";
-			// Any text/* document (plain, csv, markdown — all on the chat upload
-			// allow-list) is readable as text. Previously only text/plain was
-			// handled, so csv/markdown fell through to "skipped" (#10714).
-			const isText = contentType.startsWith("text/");
+			// Any text/* document (plain, csv, markdown) and application/json — all
+			// on the chat upload allow-list — is readable as text. Previously only
+			// text/plain was handled, so csv/markdown/json fell through to
+			// "skipped" (#10714).
+			const isText =
+				contentType.startsWith("text/") ||
+				contentType.startsWith("application/json");
 			const isPdf = contentType.startsWith("application/pdf");
 
 			if (isText) {

--- a/packages/core/src/services/message.processAttachments.test.ts
+++ b/packages/core/src/services/message.processAttachments.test.ts
@@ -241,7 +241,9 @@ describe("DefaultMessageService.processAttachments", () => {
 		expect(out[0].text).toBeUndefined();
 		expect(out[0].url).toBe("/api/media/abc.mp3");
 		expect(out[0].notProcessed).toMatch(/audio transcription unavailable/i);
-		expect(out[0].notProcessed).toContain("no transcription provider configured");
+		expect(out[0].notProcessed).toContain(
+			"no transcription provider configured",
+		);
 	});
 
 	it("marks notProcessed when audio transcription returns empty text", async () => {

--- a/packages/core/src/services/message.processAttachments.test.ts
+++ b/packages/core/src/services/message.processAttachments.test.ts
@@ -1,8 +1,11 @@
 /**
  * Covers `DefaultMessageService.processAttachments`: remote fetches route through
  * the mocked SSRF-guarded fetcher (zero real network), a failing attachment is
- * isolated as ephemeral without throwing, and local text/csv/markdown/pdf docs
- * extract real text through the un-mocked extractor.
+ * isolated as ephemeral without throwing, local text/csv/markdown/json/pdf docs
+ * extract real text through the un-mocked extractor, audio/video transcribe via
+ * the TRANSCRIPTION model, and every enrichment failure (unsupported subtype,
+ * transcription backend error, empty transcript) records an explicit
+ * `notProcessed` reason instead of leaving text/description silently unset.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ContentType, type Media } from "../types/primitives";
@@ -148,6 +151,138 @@ describe("DefaultMessageService.processAttachments", () => {
 		]);
 
 		expect(out[0].text).toBe(body);
+	});
+
+	it("extracts application/json documents as UTF-8 text", async () => {
+		// application/json is on the chat upload allow-list but is not a text/*
+		// mime, so it used to fall through to "unsupported document type". It must
+		// now extract as readable text like csv/markdown.
+		const body = '{"lifecycle":true,"items":["upload","process"]}';
+		const bytes = Buffer.from(body, "utf8");
+		const localFetch = localDocFetch(bytes, "application/json; charset=utf-8");
+		const svc = new DefaultMessageService();
+		const runtime = mockRuntime(localFetch as unknown as typeof fetch);
+
+		const out = await svc.processAttachments(runtime, [
+			{
+				id: "doc",
+				url: "/api/media/abc.json",
+				contentType: ContentType.DOCUMENT,
+			},
+		]);
+
+		expect(out[0].text).toBe(body);
+		expect(out[0].notProcessed).toBeUndefined();
+	});
+
+	it("marks notProcessed on an unsupported document subtype (never silent)", async () => {
+		// An opaque binary document (zip) is stored + served but has no text
+		// extractor. It must carry an explicit notProcessed reason so a
+		// stored-but-unreadable attachment is distinguishable from an empty one.
+		const bytes = Buffer.from([0x50, 0x4b, 0x03, 0x04]); // PK.. zip header
+		const localFetch = localDocFetch(bytes, "application/zip");
+		const svc = new DefaultMessageService();
+		const runtime = mockRuntime(localFetch as unknown as typeof fetch);
+
+		const out = await svc.processAttachments(runtime, [
+			{
+				id: "doc",
+				url: "/api/media/abc.zip",
+				contentType: ContentType.DOCUMENT,
+			},
+		]);
+
+		expect(out[0].text).toBeUndefined();
+		expect(out[0].notProcessed).toMatch(/unsupported document type/i);
+		expect(out[0].notProcessed).toContain("application/zip");
+	});
+
+	it("transcribes a local audio attachment via the TRANSCRIPTION model", async () => {
+		const bytes = Buffer.from("fake-mp3-bytes");
+		const localFetch = localDocFetch(bytes, "audio/mpeg");
+		const svc = new DefaultMessageService();
+		const runtime = mockRuntime(localFetch as unknown as typeof fetch);
+		(runtime.useModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+			"  hello from the microphone  ",
+		);
+
+		const out = await svc.processAttachments(runtime, [
+			{
+				id: "aud",
+				url: "/api/media/abc.mp3",
+				contentType: ContentType.AUDIO,
+			},
+		]);
+
+		expect(out[0].text).toBe("hello from the microphone");
+		expect(out[0].description).toBe("Transcript: hello from the microphone");
+		expect(out[0].notProcessed).toBeUndefined();
+	});
+
+	it("marks notProcessed when the audio transcription backend throws", async () => {
+		const bytes = Buffer.from("fake-mp3-bytes");
+		const localFetch = localDocFetch(bytes, "audio/mpeg");
+		const svc = new DefaultMessageService();
+		const runtime = mockRuntime(localFetch as unknown as typeof fetch);
+		(runtime.useModel as ReturnType<typeof vi.fn>).mockRejectedValue(
+			new Error("no transcription provider configured"),
+		);
+
+		const out = await svc.processAttachments(runtime, [
+			{
+				id: "aud",
+				url: "/api/media/abc.mp3",
+				contentType: ContentType.AUDIO,
+			},
+		]);
+
+		// Bytes stay stored + served (URL preserved); the failure is explicit, not
+		// a fabricated empty transcript.
+		expect(out[0].text).toBeUndefined();
+		expect(out[0].url).toBe("/api/media/abc.mp3");
+		expect(out[0].notProcessed).toMatch(/audio transcription unavailable/i);
+		expect(out[0].notProcessed).toContain("no transcription provider configured");
+	});
+
+	it("marks notProcessed when audio transcription returns empty text", async () => {
+		const bytes = Buffer.from("fake-mp3-bytes");
+		const localFetch = localDocFetch(bytes, "audio/mpeg");
+		const svc = new DefaultMessageService();
+		const runtime = mockRuntime(localFetch as unknown as typeof fetch);
+		(runtime.useModel as ReturnType<typeof vi.fn>).mockResolvedValue("   ");
+
+		const out = await svc.processAttachments(runtime, [
+			{
+				id: "aud",
+				url: "/api/media/abc.mp3",
+				contentType: ContentType.AUDIO,
+			},
+		]);
+
+		expect(out[0].text).toBeUndefined();
+		expect(out[0].notProcessed).toMatch(/no text|no speech/i);
+	});
+
+	it("transcribes a local video attachment via the TRANSCRIPTION model", async () => {
+		const bytes = Buffer.from("fake-mp4-bytes");
+		const localFetch = localDocFetch(bytes, "video/mp4");
+		const svc = new DefaultMessageService();
+		const runtime = mockRuntime(localFetch as unknown as typeof fetch);
+		(runtime.useModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+			"spoken words in the clip",
+		);
+
+		const out = await svc.processAttachments(runtime, [
+			{
+				id: "vid",
+				url: "/api/media/abc.mp4",
+				contentType: ContentType.VIDEO,
+			},
+		]);
+
+		expect(out[0].text).toBe("spoken words in the clip");
+		expect(out[0].description).toBe("Transcript: spoken words in the clip");
+		expect(out[0].notProcessed).toBeUndefined();
 	});
 
 	it("extracts real text from an application/pdf document (previously skipped)", async () => {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -10159,6 +10159,8 @@ export class DefaultMessageService implements IMessageService {
 								"Generated image description",
 							);
 						} else {
+							processedAttachment.notProcessed =
+								"Image description unavailable (vision backend returned no result)";
 							runtime.logger.warn(
 								{ src: "service:message" },
 								"Image description unavailable for attachment",
@@ -10174,11 +10176,14 @@ export class DefaultMessageService implements IMessageService {
 							url,
 							isRemote,
 						);
-						// Any text/* document (plain, csv, markdown — all on the chat
-						// upload allow-list) is readable as text; PDFs are extracted via
-						// unpdf. Previously only text/plain was handled, so csv/markdown/
-						// pdf were skipped and never seen by the agent (#10714).
-						const isText = contentType.startsWith("text/");
+						// Any text/* document (plain, csv, markdown) and application/json —
+						// all on the chat upload allow-list — is readable as UTF-8 text;
+						// PDFs are extracted via unpdf. Previously only text/plain was
+						// handled, so csv/markdown/pdf were skipped and never seen by the
+						// agent (#10714).
+						const isText =
+							contentType.startsWith("text/") ||
+							contentType.startsWith("application/json");
 						const isPdf = contentType.startsWith("application/pdf");
 
 						if (isText) {
@@ -10220,6 +10225,7 @@ export class DefaultMessageService implements IMessageService {
 								"Extracted PDF text content",
 							);
 						} else {
+							processedAttachment.notProcessed = `Unsupported document type (${contentType}); stored but text not extracted`;
 							runtime.logger.warn(
 								{ src: "service:message", contentType },
 								"Skipping unsupported document type",
@@ -10266,8 +10272,12 @@ export class DefaultMessageService implements IMessageService {
 									},
 									"Transcribed audio attachment",
 								);
+							} else {
+								processedAttachment.notProcessed =
+									"Audio transcription returned no text (empty or no speech detected)";
 							}
 						} catch (err) {
+							processedAttachment.notProcessed = `Audio transcription unavailable: ${err instanceof Error ? err.message : String(err)}`;
 							runtime.logger.warn(
 								{ src: "service:message", err },
 								"Audio transcription failed, continuing without transcript",
@@ -10314,8 +10324,12 @@ export class DefaultMessageService implements IMessageService {
 									},
 									"Transcribed video attachment",
 								);
+							} else {
+								processedAttachment.notProcessed =
+									"Video transcription returned no text (empty or no speech detected)";
 							}
 						} catch (err) {
+							processedAttachment.notProcessed = `Video transcription unavailable: ${err instanceof Error ? err.message : String(err)}`;
 							runtime.logger.warn(
 								{ src: "service:message", err },
 								"Video transcription failed, continuing without transcript",

--- a/packages/core/src/types/primitives.ts
+++ b/packages/core/src/types/primitives.ts
@@ -283,6 +283,17 @@ export interface Media {
 	 * device). Surfaces a retry affordance instead of a permanently broken tile.
 	 */
 	ephemeral?: boolean;
+
+	/**
+	 * Human-readable reason the enrichment pass could not extract text /
+	 * description for this attachment — e.g. a transcription backend being
+	 * unavailable, an empty transcript, or an unsupported document subtype. Set
+	 * by `MessageService.processAttachments` so a failed enrichment surfaces
+	 * observably instead of leaving `text`/`description` silently unset (which
+	 * conflates "no backend" with "genuinely empty"). Never a fabricated value —
+	 * its presence means the bytes are stored + served but not machine-readable.
+	 */
+	notProcessed?: string;
 }
 
 export const ContentType = {

--- a/packages/shared/src/chat-upload-limits.ts
+++ b/packages/shared/src/chat-upload-limits.ts
@@ -83,6 +83,7 @@ export const CHAT_UPLOAD_MIME_TYPES = [
   "text/plain",
   "text/csv",
   "text/markdown",
+  "application/json",
 ] as const;
 
 export type ChatUploadMimeType = (typeof CHAT_UPLOAD_MIME_TYPES)[number];

--- a/packages/ui/src/api/client-types-chat.ts
+++ b/packages/ui/src/api/client-types-chat.ts
@@ -134,6 +134,13 @@ export interface MessageAttachment {
    * transcript — the chat tile opens it in the maximized, editable viewer.
    */
   transcriptId?: string;
+  /**
+   * Reason the enrichment pass could not extract text/description (e.g. a
+   * transcription backend being unavailable). Present only on a failed
+   * enrichment; the tile surfaces it so a stored-but-unreadable attachment is
+   * never silently indistinguishable from a genuinely empty one.
+   */
+  notProcessed?: string;
 }
 
 export interface ConversationMessageReaction {

--- a/packages/ui/src/components/chat/MessageAttachments.test.tsx
+++ b/packages/ui/src/components/chat/MessageAttachments.test.tsx
@@ -151,6 +151,12 @@ describe("attachmentPreviewKind", () => {
         make({ url: "https://x/notes", mimeType: "text/plain" }),
       ),
     ).toBe("code");
+    // application/json is now an uploadable document; it previews as code.
+    expect(
+      attachmentPreviewKind(
+        make({ url: "https://x/data", mimeType: "application/json" }),
+      ),
+    ).toBe("code");
     expect(
       attachmentPreviewKind(make({ url: "https://x/blob", text: "hello" })),
     ).toBe("code");
@@ -444,5 +450,74 @@ describe("MessageAttachments — optimistic paste echo (self-composed data: URLs
     expect([...hrefs, ...srcs]).not.toContain(
       "data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==",
     );
+  });
+});
+
+describe("MessageAttachments — not-processed enrichment state", () => {
+  // When the server's enrichment pass could not extract text/description (e.g. a
+  // transcription backend being unavailable) it sets `notProcessed` with a
+  // reason. The tile still renders (the bytes are stored + downloadable) AND a
+  // "Not processed: <reason>" notice appears, so a stored-but-unreadable
+  // attachment is never silently indistinguishable from an empty one.
+
+  it("renders the media tile PLUS a not-processed notice for a failed audio transcription", () => {
+    const { container } = render(
+      <MessageAttachments
+        attachments={[
+          {
+            id: "aud",
+            url: "https://x/clip.mp3",
+            contentType: "audio",
+            title: "clip.mp3",
+            notProcessed: "Audio transcription unavailable: no provider",
+          },
+        ]}
+      />,
+    );
+    // The audio player still renders — the bytes are reachable.
+    expect(container.querySelector("audio")).not.toBeNull();
+    // ...and the failure is surfaced, not silent.
+    const notice = screen.getByTestId("attachment-not-processed");
+    expect(notice.textContent).toMatch(
+      /Not processed: Audio transcription unavailable: no provider/,
+    );
+  });
+
+  it("renders a not-processed notice under a document file card", () => {
+    render(
+      <MessageAttachments
+        attachments={[
+          {
+            id: "doc",
+            url: "https://x/archive.zip",
+            contentType: "document",
+            title: "archive.zip",
+            notProcessed:
+              "Unsupported document type (application/zip); stored but text not extracted",
+          },
+        ]}
+      />,
+    );
+    const notice = screen.getByTestId("attachment-not-processed");
+    expect(notice.textContent).toMatch(/application\/zip/);
+    // The download card is still present alongside the notice.
+    expect(screen.getByRole("link", { name: /archive\.zip/i })).not.toBeNull();
+  });
+
+  it("shows no notice when the attachment was processed normally", () => {
+    render(
+      <MessageAttachments
+        attachments={[
+          {
+            id: "img",
+            url: "https://x/cat.png",
+            contentType: "image",
+            title: "cat",
+            description: "a cat",
+          },
+        ]}
+      />,
+    );
+    expect(screen.queryByTestId("attachment-not-processed")).toBeNull();
   });
 });

--- a/packages/ui/src/components/chat/MessageAttachments.tsx
+++ b/packages/ui/src/components/chat/MessageAttachments.tsx
@@ -403,6 +403,24 @@ function ImageTile({
   );
 }
 
+/**
+ * Small inline notice shown under an attachment tile when the server's
+ * enrichment pass could not extract text/description (e.g. a transcription
+ * backend being unavailable). The bytes are stored and downloadable — this only
+ * tells the user the machine-readable content is missing, so a stored-but-
+ * unreadable attachment is never silently indistinguishable from an empty one.
+ */
+function NotProcessedNotice({ reason }: { reason: string }): React.JSX.Element {
+  return (
+    <div
+      data-testid="attachment-not-processed"
+      className="max-w-[min(22rem,100%)] text-2xs text-muted"
+    >
+      Not processed: {reason}
+    </div>
+  );
+}
+
 function FileTile({
   att,
   src,
@@ -1004,16 +1022,29 @@ export function MessageAttachments({
       className={cn("mt-1.5 flex flex-col gap-2", className)}
     >
       {attachments.map((att) => {
+        // A stored-but-unreadable attachment shows its tile PLUS a "Not
+        // processed: <reason>" notice so the failed enrichment is visible on
+        // reload, never silently missing text.
+        const notProcessed = att.notProcessed?.trim();
+        const withNotice = (tile: React.ReactNode): React.ReactNode =>
+          notProcessed ? (
+            <div key={att.id} className="flex flex-col gap-1">
+              {tile}
+              <NotProcessedNotice reason={notProcessed} />
+            </div>
+          ) : (
+            tile
+          );
         const kind = resolveKind(att);
         // A transcript opens the maximized editor from the attachment record,
         // not by navigating to its URL — so it needs no URL guard.
         if (isTranscriptAttachment(att)) {
-          return (
+          return withNotice(
             <TranscriptTile
               key={att.id}
               att={att}
               onOpen={() => setTranscript(att)}
-            />
+            />,
           );
         }
         // Scheme allowlist: never hand an agent-provided URL with a dangerous
@@ -1026,7 +1057,7 @@ export function MessageAttachments({
           !isSafeAttachmentUrl(att.url) &&
           !isBenignInlineTextDataUrl(att.url)
         ) {
-          return <UnsafeAttachmentTile key={att.id} att={att} />;
+          return withNotice(<UnsafeAttachmentTile key={att.id} att={att} />);
         }
         const src = resolveAttachmentUrl(att.url);
         if (!src) return null;
@@ -1039,7 +1070,7 @@ export function MessageAttachments({
               att.thumbnailUrl && isSafeAttachmentUrl(att.thumbnailUrl)
                 ? resolveAttachmentUrl(att.thumbnailUrl)
                 : src;
-            return (
+            return withNotice(
               <ImageTile
                 key={att.id}
                 att={att}
@@ -1052,11 +1083,11 @@ export function MessageAttachments({
                     downloadAs: downloadName(att, "image"),
                   })
                 }
-              />
+              />,
             );
           }
           case "audio":
-            return (
+            return withNotice(
               <div
                 key={att.id}
                 data-testid="audio-attachment"
@@ -1076,10 +1107,10 @@ export function MessageAttachments({
                 >
                   <track kind="captions" />
                 </audio>
-              </div>
+              </div>,
             );
           case "video":
-            return (
+            return withNotice(
               <video
                 key={att.id}
                 src={src}
@@ -1090,7 +1121,7 @@ export function MessageAttachments({
                 className="aspect-video max-h-80 w-full max-w-[min(22rem,100%)] rounded-lg border border-border bg-card object-contain"
               >
                 <track kind="captions" />
-              </video>
+              </video>,
             );
           default: {
             // `document` attachments get a richer inline preview when we can
@@ -1100,16 +1131,24 @@ export function MessageAttachments({
             if (kind === "document") {
               const previewKind = attachmentPreviewKind(att);
               if (previewKind === "pdf") {
-                return <PdfTile key={att.id} att={att} src={src} t={t} />;
+                return withNotice(
+                  <PdfTile key={att.id} att={att} src={src} t={t} />,
+                );
               }
               if (previewKind === "model3d") {
-                return <Model3dTile key={att.id} att={att} src={src} t={t} />;
+                return withNotice(
+                  <Model3dTile key={att.id} att={att} src={src} t={t} />,
+                );
               }
               if (previewKind === "code") {
-                return <CodeTile key={att.id} att={att} src={src} t={t} />;
+                return withNotice(
+                  <CodeTile key={att.id} att={att} src={src} t={t} />,
+                );
               }
             }
-            return <FileTile key={att.id} att={att} src={src} kind={kind} />;
+            return withNotice(
+              <FileTile key={att.id} att={att} src={src} kind={kind} />,
+            );
           }
         }
       })}

--- a/packages/ui/src/components/chat/MessageAttachments.tsx
+++ b/packages/ui/src/components/chat/MessageAttachments.tsx
@@ -92,7 +92,12 @@ function resolveKind(att: MessageAttachment): MessageAttachmentContentType {
   if (mime.startsWith("image/")) return "image";
   if (mime.startsWith("video/")) return "video";
   if (mime.startsWith("audio/")) return "audio";
-  if (mime === "application/pdf" || mime.startsWith("text/")) return "document";
+  if (
+    mime === "application/pdf" ||
+    mime === "application/json" ||
+    mime.startsWith("text/")
+  )
+    return "document";
   const u = att.url.toLowerCase();
   if (IMAGE_EXT.test(u) || u.startsWith("data:image/")) return "image";
   if (VIDEO_EXT.test(u) || u.startsWith("data:video/")) return "video";
@@ -225,10 +230,12 @@ export function attachmentPreviewKind(
     return "model3d";
   }
 
-  // Text/code: a text-* MIME, a known code/text extension, an inline
-  // text data: URL, or an attachment that already carries extracted text.
+  // Text/code: a text-* MIME, application/json (an uploadable text document), a
+  // known code/text extension, an inline text data: URL, or an attachment that
+  // already carries extracted text.
   if (
     mime.startsWith("text/") ||
+    mime === "application/json" ||
     CODE_EXT.test(path) ||
     url.trim().toLowerCase().startsWith("data:text/") ||
     (typeof att.text === "string" && att.text.trim().length > 0)

--- a/packages/ui/src/utils/image-attachment.test.ts
+++ b/packages/ui/src/utils/image-attachment.test.ts
@@ -52,12 +52,13 @@ describe("chatUploadKind", () => {
 });
 
 describe("isSupportedChatUpload", () => {
-  it("accepts images, audio, video, pdf, and text", () => {
+  it("accepts images, audio, video, pdf, text, and json", () => {
     expect(isSupportedChatUpload(file("image/jpeg"))).toBe(true);
     expect(isSupportedChatUpload(file("audio/wav"))).toBe(true);
     expect(isSupportedChatUpload(file("video/webm"))).toBe(true);
     expect(isSupportedChatUpload(file("application/pdf"))).toBe(true);
     expect(isSupportedChatUpload(file("text/csv"))).toBe(true);
+    expect(isSupportedChatUpload(file("application/json"))).toBe(true);
   });
 
   it("rejects unsupported types", () => {
@@ -128,6 +129,8 @@ describe("CHAT_UPLOAD_ACCEPT", () => {
     expect(CHAT_UPLOAD_ACCEPT).toContain("audio/*");
     expect(CHAT_UPLOAD_ACCEPT).toContain("video/*");
     expect(CHAT_UPLOAD_ACCEPT).toContain("application/pdf");
+    expect(CHAT_UPLOAD_ACCEPT).toContain("text/csv");
+    expect(CHAT_UPLOAD_ACCEPT).toContain("application/json");
   });
 });
 

--- a/packages/ui/src/utils/image-attachment.ts
+++ b/packages/ui/src/utils/image-attachment.ts
@@ -137,7 +137,7 @@ export function partitionAttachmentFiles(
 
 /** `accept` attribute for the chat upload <input> — images, audio, video, PDFs, text docs. */
 export const CHAT_UPLOAD_ACCEPT =
-  "image/*,audio/*,video/*,application/pdf,text/plain,text/csv,text/markdown";
+  "image/*,audio/*,video/*,application/pdf,text/plain,text/csv,text/markdown,application/json";
 
 /**
  * True when a file's MIME type is an attachment kind chat upload accepts.


### PR DESCRIPTION
## What

Proves the chat-upload pipeline works end-to-end for every media type (image / audio / video / text / pdf / **json**) with real tests, and closes three real agent-understanding gaps found along the way. Upload path is `POST /api/conversations/:id/messages` with base64 attachments → `validateChatImages` + `buildChatAttachments` → content-addressed media store → `DefaultMessageService.processAttachments`. No second store; `Media` widened additively only; `ContentType` untouched (per #8876).

## Real bugs fixed

1. **Zero-byte base64 attachments were accepted.** `BASE64_RE` accepts degenerate payloads (`"="`, `"=="`, a lone `"A"`) — non-empty strings that decode to **zero bytes**. Persisting one writes an empty file into the content-addressed store and lands an unreadable attachment. `validateChatImages` now rejects them up front as corrupt input.

2. **`application/json` was rejected on send but mapped everywhere else.** JSON was in the media store's mime/ext maps and the UI `DOC_EXT`/`CODE_EXT` regexes, but NOT on `CHAT_UPLOAD_MIME_TYPES`, so a dragged `.json` was silently dropped client-side and 400'd server-side. Added it to the shared allow-list + client `CHAT_UPLOAD_ACCEPT`; the document text-extraction branch now reads `application/json` as UTF-8 text; the UI `resolveKind`/`attachmentPreviewKind` classify a mime-only JSON as a document/code preview.

3. **Failed enrichment was silent.** Audio/video transcription failure, an empty transcript, an unsupported document subtype, and vision-unavailable all left `text`/`description` unset with no marker — conflating "no backend" with "genuinely empty." Added `Media.notProcessed` (additive) set at every such site with an explicit reason; it round-trips through `serializeMessageAttachments` and renders under the tile as **"Not processed: &lt;reason&gt;"** so the failure is observable on reload.

## Tests (real paths, deterministic harness — no mock stands in for the thing under test)

- **core `message.processAttachments`** (+6): json extraction; audio + video transcription via the real `TRANSCRIPTION` model dispatch; `notProcessed` on unsupported-subtype / backend-error / empty-transcript.
- **agent `chat-attachments`** (+5): json accept; spoofed `image/svg+xml` reject; corrupt zero-byte base64 reject; invalid-base64 reject; per-kind size caps (12 MiB accepted as audio, rejected as image); `notProcessed` serialization round-trip.
- **agent `media-store`** (+2) and **`chat-attachment-processing-lifecycle`** (+json): json store/serve (download disposition) + full upload→store→serve→process lifecycle over the **real** content-addressed store. Also fixed a pre-existing async read-stream cleanup race in the lifecycle test (`serve` now awaits stream end; the run previously emitted 14 unhandled ENOENTs).
- **ui `image-attachment` + `MessageAttachments`**: json accept; not-processed render.

## Evidence

| Row | Status |
| --- | --- |
| Backend unit/integration tests | ✅ below |
| Frontend unit tests | ✅ below |
| Real-LLM trajectories | N/A — no agent/prompt/model-behavior change; transcription/vision dispatch is exercised via the real `useModel(TRANSCRIPTION/IMAGE_DESCRIPTION)` code path with a deterministic model stub (a live ASR/vision provider is not reachable from this shell) |
| Rendered UI proof (video / before-after screenshots) | N/A — renderer boot + screenshot capture not reachable from this shell; the `Not processed` notice + json preview are covered by jsdom render tests instead |
| Backend structured logs / frontend console+network | N/A — no running server in this shell |

<details>
<summary>Backend tests — core + agent (99 passing)</summary>

```
# packages/core
message.processAttachments.test.ts ............... 13 passed
process-attachments-documents.test.ts ............  5 passed
Test Files  2 passed (2)   Tests  18 passed (18)

# packages/agent
chat-attachments.test.ts ......................... 16 passed
media-store.test.ts .............................. 54 passed
chat-attachment-processing-lifecycle.test.ts .....  1 passed  (0 unhandled errors)
chat-upload-limits.parity.test.ts ................ 10 passed
Test Files  4 passed (4)   Tests  81 passed (81)
```
</details>

<details>
<summary>Frontend tests — ui (74 passing)</summary>

```
# packages/ui
MessageAttachments.test.tsx ...................... 27 passed
image-attachment.test.ts ......................... 47 passed
Test Files  2 passed (2)   Tests  74 passed (74)
```
</details>

<details>
<summary>Lint + error-policy ratchet</summary>

```
biome check <all touched files> — clean
audit:error-policy-ratchet — no new fallback-slop in touched files
  (every touched file: emptyCatch X->X, serverConsole 0->0)
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
