### PR TITLE
feat(orchestrator): projectId + 3-project x 5–15-task end-to-end scenarios

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -911,9 +911,11 @@ async function runCreate(
   ) as OrchestratorTaskService | null | undefined;
   try {
     if (taskService && typeof taskService.createTask === "function") {
-      // Bind the durable task to a registered Project via the resolved spawn
-      // workdir (all sessions of this create share it). The service
-      // realpath-matches it against the project registry; unmatched = unbound.
+      // Bind the durable task to a registered Project: an explicit caller
+      // `projectId` (validated against the registry by the service) wins;
+      // otherwise the resolved spawn workdir (all sessions of this create share
+      // it) is realpath-matched against the registry. Unmatched = unbound.
+      const explicitProjectId = pickString(params, content, "projectId");
       const boundWorkdir = sessions[0]?.workdir;
       const detail = await taskService.createTask({
         title: taskTitle,
@@ -921,6 +923,7 @@ async function runCreate(
         kind: "coding",
         priority: taskPriority,
         originalRequest: messageText(message),
+        ...(explicitProjectId ? { projectId: explicitProjectId } : {}),
         ...(boundWorkdir ? { workdir: boundWorkdir } : {}),
         ...((originRoomId ?? taskRoomId)
           ? { roomId: originRoomId ?? taskRoomId }
@@ -2038,6 +2041,9 @@ async function runHistory(
   const window = historyWindowValue(params.window ?? content.window);
   const statuses = historyStatusesValue(params.statuses ?? content.statuses);
   const search = textValue(params.search) ?? textValue(content.search);
+  // Registered-project filter: restrict the thread listing to tasks bound to
+  // one project (the store filters on the indexed/structural `projectId`).
+  const projectId = textValue(params.projectId) ?? textValue(content.projectId);
   const includeArchived =
     pickBoolean(params, content, "includeArchived") ?? false;
   const windowFilters = buildWindowFilters(window);
@@ -2050,6 +2056,7 @@ async function runHistory(
         await taskService.listTasks({
           includeArchived,
           ...(search ? { search } : {}),
+          ...(projectId ? { projectId } : {}),
         })
       ).filter((task) =>
         taskMatchesHistoryFilters(task, statuses, windowFilters, search),
@@ -2060,6 +2067,7 @@ async function runHistory(
         windowFilters.label ? `window ${windowFilters.label}` : undefined,
         statuses.length > 0 ? `statuses ${statuses.join(", ")}` : undefined,
         search ? `search "${search}"` : undefined,
+        projectId ? `project ${projectId}` : undefined,
         includeArchived ? "including archived" : undefined,
       ].filter((part): part is string => Boolean(part));
       const filterSuffix =
@@ -2102,6 +2110,7 @@ async function runHistory(
             ...(window ? { window } : {}),
             ...(statuses.length > 0 ? { statuses } : {}),
             ...(search ? { search } : {}),
+            ...(projectId ? { projectId } : {}),
             includeArchived,
             limit,
           },
@@ -3528,6 +3537,13 @@ export const tasksAction: Action & {
       description: "Include archived threads in action=history.",
       required: false,
       schema: { type: "boolean" as const },
+    },
+    {
+      name: "projectId",
+      description:
+        "Registered project id: binds the new task to that project for action=create; restricts the thread listing to that project's tasks for action=history.",
+      required: false,
+      schema: { type: "string" as const },
     },
     // control
     {

--- a/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/multi-project-scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/multi-project-scenario.ts
@@ -17,8 +17,8 @@ import { mkdirSync, mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { upsertProject } from "@elizaos/core";
-import type { OrchestratorTaskDocument } from "../../../src/services/orchestrator-task-types.js";
 import type { OrchestratorTaskStore } from "../../../src/services/orchestrator-task-store.js";
+import type { OrchestratorTaskDocument } from "../../../src/services/orchestrator-task-types.js";
 import {
   SessionCapError,
   type SessionInfo,

--- a/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/multi-project-scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/_helpers/multi-project-scenario.ts
@@ -1,0 +1,362 @@
+/**
+ * Shared infrastructure for the multi-project orchestration scenarios: a
+ * cap-enforcing deterministic ACP, an evidence-grounded deterministic judge
+ * runtime, and a real project-registry fixture in a temp state dir.
+ *
+ * The two multi-project scenario files (portfolio + failure-isolation) drive
+ * the REAL `OrchestratorTaskService` (event bridge, transition table, admission
+ * queue, auto goal-verify) over this fake transport, the same self-contained
+ * style `orchestrator-concurrency-admission.scenario.ts` established — keyless,
+ * no subprocess, pr-deterministic. The judge here is NOT rigged to pass: it
+ * reads the verifier prompt's own evidence section and only passes completions
+ * that carry concrete test-output proof, so a broken evidence pipeline fails
+ * the scenario.
+ */
+
+import { mkdirSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { upsertProject } from "@elizaos/core";
+import type { OrchestratorTaskDocument } from "../../../src/services/orchestrator-task-types.js";
+import type { OrchestratorTaskStore } from "../../../src/services/orchestrator-task-store.js";
+import {
+  SessionCapError,
+  type SessionInfo,
+  type SpawnOptions,
+  type SpawnResult,
+} from "../../../src/services/types.js";
+
+const TERMINAL_ACP_STATUSES = new Set([
+  "stopped",
+  "completed",
+  "error",
+  "errored",
+  "cancelled",
+]);
+
+/**
+ * Deterministic ACP transport with real worker-slot accounting: throws
+ * `SessionCapError` past the cap (so the real admission queue parks spawns),
+ * records every forwarded prompt for routing assertions, and lets scenarios
+ * drive session lifecycles by emitting the same events the real transport does.
+ */
+export class MultiProjectAcp {
+  readonly sent: Array<{ sessionId: string; text: string }> = [];
+  /** Highest concurrent non-terminal worker count ever observed — the
+   * concurrency-respected proof. */
+  workerHighWaterMark = 0;
+  private readonly sessions = new Map<string, SessionInfo>();
+  private readonly handlers = new Set<
+    (sessionId: string, event: string, data: unknown) => void
+  >();
+  private readonly initialTasks = new Map<string, string>();
+  private counter = 0;
+
+  constructor(private readonly maxSessions = Number.POSITIVE_INFINITY) {}
+
+  private activeWorkers(): number {
+    let n = 0;
+    for (const s of this.sessions.values()) {
+      if (!TERMINAL_ACP_STATUSES.has(s.status)) n++;
+    }
+    return n;
+  }
+
+  async getCapacity() {
+    const workers = this.activeWorkers();
+    const max = Number.isFinite(this.maxSessions) ? this.maxSessions : 1024;
+    return {
+      maxSessions: max,
+      systemHeadroom: 2,
+      activeWorkers: workers,
+      activeSystem: 0,
+      freeWorkerSlots: Math.max(0, max - workers),
+      freeSystemSlots: 2,
+    };
+  }
+
+  async spawnSession(opts: SpawnOptions): Promise<SpawnResult> {
+    const slotClass = opts.slotClass ?? "worker";
+    if (slotClass === "worker" && this.activeWorkers() >= this.maxSessions) {
+      throw new SessionCapError(
+        "worker",
+        Number(this.maxSessions),
+        this.activeWorkers(),
+      );
+    }
+    const id = `multi-project-sess-${++this.counter}`;
+    const now = new Date();
+    const session: SessionInfo = {
+      id,
+      name: opts.name ?? id,
+      agentType: opts.agentType ?? "opencode",
+      workdir: opts.workdir ?? "/tmp/multi-project",
+      status: "ready",
+      approvalPreset: opts.approvalPreset ?? "standard",
+      createdAt: now,
+      lastActivityAt: now,
+      metadata: { ...(opts.metadata ?? {}), slotClass },
+    };
+    this.sessions.set(id, session);
+    this.initialTasks.set(id, opts.initialTask ?? "");
+    this.workerHighWaterMark = Math.max(
+      this.workerHighWaterMark,
+      this.activeWorkers(),
+    );
+    return {
+      sessionId: id,
+      id,
+      name: session.name ?? id,
+      agentType: session.agentType,
+      workdir: session.workdir,
+      status: session.status,
+      metadata: session.metadata,
+    };
+  }
+
+  /** The goal prompt handed to a spawned session at spawn time. */
+  initialTaskFor(sessionId: string): string | undefined {
+    return this.initialTasks.get(sessionId);
+  }
+
+  listSessions(): SessionInfo[] {
+    return [...this.sessions.values()];
+  }
+
+  readySessions(): SessionInfo[] {
+    return this.listSessions().filter((s) => s.status === "ready");
+  }
+
+  async getSession(id: string): Promise<SessionInfo | null> {
+    return this.sessions.get(id) ?? null;
+  }
+
+  getChangedPaths(): string[] {
+    return [];
+  }
+
+  async stopSession(id: string): Promise<void> {
+    const s = this.sessions.get(id);
+    if (s) s.status = "stopped";
+    this.emit(id, "stopped", { sessionId: id });
+  }
+
+  async sendToSession(id: string, text: string) {
+    this.sent.push({ sessionId: id, text });
+    // A corrective re-dispatch reactivates the worker: mirror the real
+    // transport, where a kept-alive session goes back to work on a follow-up.
+    const s = this.sessions.get(id);
+    if (s && s.status === "completed") s.status = "ready";
+    return {
+      sessionId: id,
+      finalText: "ack",
+      response: "ack",
+      stopReason: "end_turn",
+      durationMs: 1,
+    };
+  }
+
+  onSessionEvent(
+    cb: (sessionId: string, event: string, data: unknown) => void,
+  ): () => void {
+    this.handlers.add(cb);
+    return () => {
+      this.handlers.delete(cb);
+    };
+  }
+
+  emit(sessionId: string, event: string, data: unknown = {}): void {
+    for (const h of [...this.handlers]) h(sessionId, event, data);
+  }
+
+  /** Complete a live session: free its slot and emit task_complete so the real
+   * service advances the task through validating → auto-verify. */
+  complete(id: string, response: string): void {
+    const s = this.sessions.get(id);
+    if (s) s.status = "completed";
+    this.emit(id, "task_complete", { response });
+  }
+
+  /** Crash a live session: free its slot and emit the error the real event
+   * bridge classifies (a plain crash is un-respawnable → terminal `failed`). */
+  crash(id: string, message: string): void {
+    const s = this.sessions.get(id);
+    if (s) s.status = "errored";
+    this.emit(id, "error", { message });
+  }
+}
+
+/**
+ * Evidence-grounded deterministic verdict for the auto goal-verifier's judge
+ * prompt: pass ONLY when the prompt's completion-evidence section carries a
+ * concrete passing-test line; otherwise fail with the prompt's own acceptance
+ * criteria as `missing` (which drives the real corrective re-prompt path).
+ */
+export function judgeVerdictFromPrompt(prompt: string): {
+  passed: boolean;
+  summary: string;
+  missing: string[];
+} {
+  const evidenceStart = prompt.indexOf("---");
+  const evidenceEnd = prompt.lastIndexOf("---");
+  const evidence =
+    evidenceStart >= 0 && evidenceEnd > evidenceStart
+      ? prompt.slice(evidenceStart + 3, evidenceEnd)
+      : "";
+  if (/Tests \d+ passed/.test(evidence)) {
+    return {
+      passed: true,
+      summary: "Every acceptance criterion is backed by pasted test output.",
+      missing: [],
+    };
+  }
+  const criteriaSection = prompt.split(
+    "Acceptance criteria (each must hold for the task to pass):",
+  )[1];
+  const missing = (criteriaSection ?? "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => /^\d+\.\s/.test(line))
+    .map((line) => line.replace(/^\d+\.\s*/, ""));
+  return {
+    passed: false,
+    summary: "No concrete test output was pasted; the claim is unproven.",
+    missing: missing.length > 0 ? missing : ["concrete proof of completion"],
+  };
+}
+
+/** Minimal runtime stub the real OrchestratorTaskService runs against: the only
+ * model surface it exercises here is the goal-verifier judge, answered by
+ * {@link judgeVerdictFromPrompt}. */
+export function makeMultiProjectRuntime(
+  acp: MultiProjectAcp,
+  opts: { agentId: string; onJudge?: (prompt: string) => void },
+): unknown {
+  return {
+    agentId: opts.agentId,
+    character: { name: "MultiProjectOrchestrator" },
+    databaseAdapter: undefined,
+    logger: { debug() {}, info() {}, warn() {}, error() {} },
+    getSetting: () => undefined,
+    reportError() {},
+    useModel: async (_type: unknown, params: { prompt?: string } = {}) => {
+      const prompt = params.prompt ?? "";
+      if (prompt.includes("demanding engineering manager")) {
+        opts.onJudge?.(prompt);
+        return JSON.stringify(judgeVerdictFromPrompt(prompt));
+      }
+      return "{}";
+    },
+    getService: (type: string) =>
+      type === "ACP_SUBPROCESS_SERVICE" ? acp : undefined,
+  };
+}
+
+/** Set env overrides for a scenario run; returns a restore fn for `finally`.
+ * `undefined` deletes the key for the run. */
+export function applyScenarioEnv(
+  overrides: Record<string, string | undefined>,
+): () => void {
+  const prior = new Map<string, string | undefined>();
+  for (const [key, value] of Object.entries(overrides)) {
+    prior.set(key, process.env[key]);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  return () => {
+    for (const [key, value] of prior) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  };
+}
+
+export interface ScenarioProject {
+  /** Registered project-registry id (the durable binding key). */
+  id: string;
+  name: string;
+  /** The project's real localPath under the temp state dir — every session of
+   * a task bound to this project must spawn exactly here. */
+  localPath: string;
+  /** Distinct origin room per project. */
+  roomId: string;
+}
+
+/**
+ * Mint a temp state dir, point `ELIZA_STATE_DIR` at it, and register one REAL
+ * project-registry record per name (each with its own on-disk localPath). The
+ * returned restore fn puts the env back; the temp dir is left for the OS tmp
+ * reaper, matching the other orchestrator scenario fixtures.
+ */
+export function registerScenarioProjects(
+  prefix: string,
+  names: string[],
+): { projects: ScenarioProject[]; restoreEnv: () => void } {
+  const stateDir = mkdtempSync(join(tmpdir(), `${prefix}-state-`));
+  const restoreEnv = applyScenarioEnv({ ELIZA_STATE_DIR: stateDir });
+  const projects = names.map((name, index) => {
+    const localPath = join(stateDir, "checkouts", name);
+    mkdirSync(localPath, { recursive: true });
+    const record = upsertProject({ name, localPath });
+    return {
+      id: record.id,
+      name,
+      localPath: record.localPath,
+      roomId: `00000000-0000-4000-8000-00000000000${index + 1}`,
+    };
+  });
+  return { projects, restoreEnv };
+}
+
+export async function waitUntil(
+  predicate: () => boolean | Promise<boolean>,
+  label: string,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  throw new Error(`multi-project scenario timed out waiting for ${label}`);
+}
+
+export async function waitForTask(
+  store: OrchestratorTaskStore,
+  taskId: string,
+  predicate: (doc: OrchestratorTaskDocument) => boolean,
+  label: string,
+  timeoutMs = 5_000,
+): Promise<OrchestratorTaskDocument> {
+  const deadline = Date.now() + timeoutMs;
+  let last: OrchestratorTaskDocument | null = null;
+  while (Date.now() < deadline) {
+    last = await store.getTask(taskId);
+    if (last && predicate(last)) return last;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  throw new Error(
+    `multi-project scenario timed out waiting for ${label}; last status=${
+      last?.task.status ?? "(missing)"
+    }, events=${last ? last.events.map((e) => e.eventType).join(",") : "(none)"}`,
+  );
+}
+
+/** Every event on the doc must reference either no session or one of the
+ * task's OWN sessions — the cross-task/cross-project routing invariant.
+ * Returns the ids of foreign sessions found (empty = clean). */
+export function foreignEventSessions(doc: OrchestratorTaskDocument): string[] {
+  const own = new Set(doc.sessions.map((s) => s.sessionId));
+  const foreign = new Set<string>();
+  for (const event of doc.events) {
+    if (event.sessionId && !own.has(event.sessionId)) {
+      foreign.add(event.sessionId);
+    }
+  }
+  for (const message of doc.messages) {
+    if (message.sessionId && !own.has(message.sessionId)) {
+      foreign.add(message.sessionId);
+    }
+  }
+  return [...foreign];
+}

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-multi-project-failure-isolation.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-multi-project-failure-isolation.scenario.ts
@@ -1,0 +1,638 @@
+/**
+ * Multi-project orchestration failure isolation (pr-deterministic, keyless): the
+ * companion to `orchestrator-multi-project-portfolio.scenario.ts`. Where the
+ * portfolio proves the all-green path, this proves the ERROR paths are contained
+ * — one task failing, being grilled, or being cancelled never corrupts a sibling
+ * in the same project or a task in another project.
+ *
+ * Three registered projects run simultaneously (5 + 5 + 5 = 15 tasks) against the
+ * REAL `OrchestratorTaskService` over a cap-enforcing deterministic ACP, and each
+ * task is assigned a PLANNED outcome the scenario drives structurally:
+ *
+ *  - **clean** — completes with pasted test output; the evidence-grounded judge
+ *    passes it → `done`.
+ *  - **crash** — the sub-agent dies (`error` with a plain crash message, no
+ *    respawnable failureKind); the real event bridge classifies it un-respawnable
+ *    → terminal `failed`, with a `task_failed` event on THAT task only.
+ *  - **grill** — completes WITHOUT proof; the judge fails it → `auto_verify_failed`
+ *    → the task returns to `active` and the kept-alive worker is re-prompted; the
+ *    scenario then delivers proof, and the retry lands `done`. Proves a failed
+ *    verification neither promotes the task nor bleeds onto its siblings.
+ *  - **cancel** — archived while still parked in the admission queue; the real
+ *    `archiveTask` dequeues it, stops any session, and drives it terminal
+ *    (`archived`) without ever spawning, freeing queue pressure for the rest.
+ *
+ * Structural proofs: every task's FINAL status equals its planned outcome (total
+ * isolation), each error event lands on its own task document, event routing is
+ * clean (zero foreign sessions), the worker high-water mark never exceeds the cap
+ * and the queue drains to zero, and per-project list-by-status filters return
+ * exactly the expected partition.
+ */
+
+import type { Action, Plugin, UUID } from "@elizaos/core";
+import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
+import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
+import {
+  applyScenarioEnv,
+  foreignEventSessions,
+  MultiProjectAcp,
+  makeMultiProjectRuntime,
+  registerScenarioProjects,
+  type ScenarioProject,
+  waitForTask,
+  waitUntil,
+} from "./_helpers/multi-project-scenario";
+import { registerCalibratedJudgeFixture } from "./_helpers/orchestrator-scenario-harness";
+
+const ISOLATION_PLUGIN_NAME =
+  "orchestrator-multi-project-failure-isolation-scenario";
+const ORCHESTRATOR_MULTI_PROJECT_FAILURE_ISOLATION =
+  "ORCHESTRATOR_MULTI_PROJECT_FAILURE_ISOLATION";
+
+const AGENT_ID = "aa020000-0000-4000-8000-000000000001" as UUID;
+const CAP = 6;
+
+/** Planned outcome for each task; the scenario drives the real service to land
+ * exactly this terminal (or, for a recovered grill, `done`) status. */
+type Outcome = "clean" | "crash" | "grill" | "cancel";
+
+/** Map of a planned outcome to the terminal task status it must reach. `grill`
+ * ends `done` because the scenario delivers proof on the retry. */
+const OUTCOME_FINAL_STATUS: Record<Outcome, string> = {
+  clean: "done",
+  crash: "failed",
+  grill: "done",
+  cancel: "archived",
+};
+
+/**
+ * Per-project task plans: 3 projects, 5 tasks each (15 total). Each project mixes
+ * a distinct set of error paths with clean tasks so isolation is proven both
+ * within a project (a crash next to clean siblings) and across projects.
+ */
+const PROJECT_PLAN: Array<{ name: string; outcomes: Outcome[] }> = [
+  {
+    name: "checkout-service",
+    outcomes: ["clean", "crash", "grill", "clean", "clean"],
+  },
+  {
+    name: "web-dashboard",
+    outcomes: ["clean", "cancel", "clean", "grill", "clean"],
+  },
+  {
+    name: "mobile-app",
+    outcomes: ["clean", "clean", "crash", "clean", "cancel"],
+  },
+];
+const TOTAL = PROJECT_PLAN.reduce((sum, p) => sum + p.outcomes.length, 0);
+const CLEAN_TOTAL = countOutcome("clean");
+const CRASH_TOTAL = countOutcome("crash");
+const GRILL_TOTAL = countOutcome("grill");
+const CANCEL_TOTAL = countOutcome("cancel");
+/** Judge verdicts fire once per proofless grill (fail) + once per clean/grill
+ * completion (pass). Cancelled + crashed tasks never reach the judge. */
+const JUDGE_VERDICTS = CLEAN_TOTAL + GRILL_TOTAL * 2;
+
+function countOutcome(outcome: Outcome): number {
+  return PROJECT_PLAN.reduce(
+    (sum, p) => sum + p.outcomes.filter((o) => o === outcome).length,
+    0,
+  );
+}
+
+type PerProjectResult = {
+  projectId: string;
+  name: string;
+  statuses: Record<string, string>;
+  byStatus: Record<string, number>;
+};
+
+type IsolationResult = {
+  summary: string;
+  cap: number;
+  totalTasks: number;
+  workerHighWaterMark: number;
+  judgeVerdicts: number;
+  /** taskId -> planned outcome, for the isolation assertion. */
+  plannedOutcomes: Record<string, Outcome>;
+  /** taskId -> observed terminal status. */
+  finalStatuses: Record<string, string>;
+  /** Tasks whose observed status did not match the planned outcome. */
+  outcomeViolations: string[];
+  /** A crashed task missing its `task_failed` event, or one on the wrong task. */
+  crashEventViolations: string[];
+  /** A grilled task missing its `auto_verify_failed` event. */
+  grillEventViolations: string[];
+  /** Session ids found on a task doc that belong to another task — must be []. */
+  foreignRoutes: string[];
+  workdirViolations: string[];
+  listFilterViolations: string[];
+  perProject: PerProjectResult[];
+};
+
+function isolationData(ctx: ScenarioContext): IsolationResult | null {
+  const action = ctx.actionsCalled.find(
+    (c) => c.actionName === ORCHESTRATOR_MULTI_PROJECT_FAILURE_ISOLATION,
+  );
+  const data = action?.result?.data;
+  return data && typeof data === "object" && !Array.isArray(data)
+    ? (data as IsolationResult)
+    : null;
+}
+
+/** A completion carrying concrete proof the evidence-grounded judge accepts. */
+function proofFor(title: string, projectName: string): string {
+  return `Done: ${title}. Proof: Tests 4 passed (4) in ${projectName}.`;
+}
+
+/** A proofless completion the judge must reject, driving the grill retry. */
+function prooflessFor(title: string): string {
+  return `I finished ${title}. Everything works, trust me.`;
+}
+
+async function runFailureIsolation(): Promise<IsolationResult> {
+  const restoreGates = applyScenarioEnv({
+    ELIZA_ACP_ADMISSION_QUEUE: "1",
+    ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY: "1",
+    ELIZA_ORCHESTRATOR_WATCHDOG: "0",
+    ELIZA_ORCHESTRATOR_INDEPENDENT_VERIFY: "0",
+  });
+  const { projects, restoreEnv } = registerScenarioProjects(
+    "eliza-orch-isolation",
+    PROJECT_PLAN.map((p) => p.name),
+  );
+  const acp = new MultiProjectAcp(CAP);
+  const judgePrompts: string[] = [];
+  const runtime = makeMultiProjectRuntime(acp, {
+    agentId: AGENT_ID,
+    onJudge: (prompt) => judgePrompts.push(prompt),
+  });
+  const store = new OrchestratorTaskStore({ backend: "memory" });
+  const service = new OrchestratorTaskService(runtime as never, { store });
+  await service.start();
+
+  try {
+    // ── Create 15 tasks, round-robin interleaved across the three projects so
+    // the store never sees one project as a contiguous block. Each task carries
+    // its planned outcome for the driver + isolation assertion. ───────────────
+    const taskProject = new Map<string, ScenarioProject>();
+    const taskTitle = new Map<string, string>();
+    const plannedOutcomes: Record<string, Outcome> = {};
+    const perProjectIds = new Map<string, string[]>(
+      projects.map((p) => [p.id, []]),
+    );
+    const maxPerProject = Math.max(
+      ...PROJECT_PLAN.map((p) => p.outcomes.length),
+    );
+    for (let round = 0; round < maxPerProject; round++) {
+      for (const [index, plan] of PROJECT_PLAN.entries()) {
+        if (round >= plan.outcomes.length) continue;
+        const project = projects[index];
+        const outcome = plan.outcomes[round];
+        const title = `${plan.name} task ${round + 1} (${outcome})`;
+        const detail = await service.createTask({
+          title,
+          goal: `Ship improvement ${round + 1} for ${plan.name}.`,
+          originalRequest: `Please ship improvement ${round + 1} for ${plan.name}.`,
+          kind: "coding",
+          priority: "normal",
+          roomId: project.roomId,
+          projectId: project.id,
+          metadata: { source: "scenario-runner" },
+          acceptanceCriteria: [
+            `improvement ${round + 1} tests pass in ${plan.name}`,
+          ],
+        });
+        taskProject.set(detail.id, project);
+        taskTitle.set(detail.id, title);
+        plannedOutcomes[detail.id] = outcome;
+        perProjectIds.get(project.id)?.push(detail.id);
+      }
+    }
+
+    // ── Cancel the `cancel`-outcome tasks FIRST, while every task is still open
+    // and (after spawn) some will be parked. Archiving here proves cancel works
+    // on a not-yet-dispatched task and never spawns a worker for it. ───────────
+    for (const [taskId, outcome] of Object.entries(plannedOutcomes)) {
+      if (outcome !== "cancel") continue;
+      const archived = await service.archiveTask(taskId);
+      if (archived?.status !== "archived") {
+        throw new Error(
+          `cancel: expected archived, saw ${archived?.status ?? "(null)"} for ${taskId}`,
+        );
+      }
+    }
+
+    // ── Spawn every non-cancelled task against the 6-worker cap. Over-cap spawns
+    // park in the real admission queue; cancelled tasks are skipped entirely so
+    // no worker is ever minted for them. ──────────────────────────────────────
+    const spawnable = [...taskProject.keys()].filter(
+      (id) => plannedOutcomes[id] !== "cancel",
+    );
+    for (const taskId of spawnable) {
+      await service.spawnAgentForTask(taskId, {});
+    }
+
+    // ── Drive each ready session to its planned outcome, wave by wave, so a
+    // terminal event frees a slot and the admission queue drains the next parked
+    // task. Grilled tasks are completed proofless first (judge fails → retry),
+    // then re-completed with proof on the reactivated worker. ──────────────────
+    const workdirViolations: string[] = [];
+    const grilledOnce = new Set<string>();
+    const handled = new Set<string>();
+    for (let guard = 0; guard < TOTAL * 8; guard++) {
+      const ready = acp.readySessions().filter((s) => {
+        const taskId = String(s.metadata?.taskId ?? "");
+        const outcome = plannedOutcomes[taskId];
+        // A grilled session is "ready" again after re-engage; only skip it once
+        // its retry proof has been delivered (handled).
+        if (handled.has(s.id) && outcome !== "grill") return false;
+        if (outcome === "grill" && handled.has(s.id)) return false;
+        return true;
+      });
+      if (ready.length === 0) {
+        const depth = (await service.getAdmissionSnapshot()).queueDepth;
+        if (depth === 0) break;
+        await waitUntil(
+          () => acp.readySessions().some((s) => !handled.has(s.id)),
+          "admission drain to dispatch a parked task",
+        );
+        continue;
+      }
+      for (const session of ready) {
+        const taskId = String(session.metadata?.taskId ?? "");
+        const project = taskProject.get(taskId);
+        const outcome = plannedOutcomes[taskId];
+        if (!project) throw new Error(`session ${session.id} has no task`);
+        if (session.workdir !== project.localPath) {
+          workdirViolations.push(
+            `${session.id}: workdir ${session.workdir} != ${project.localPath}`,
+          );
+        }
+        // A fresh spawn advances the task to `active`; wait for it so the
+        // terminal event we drive next is a legal transition.
+        await waitForTask(
+          store,
+          taskId,
+          (doc) => doc.task.status === "active",
+          `task ${taskId} active after spawn`,
+        );
+        acp.emit(session.id, "message", {
+          text: `progress ${project.name}: ${taskTitle.get(taskId)}`,
+        });
+
+        if (outcome === "crash") {
+          acp.crash(session.id, "worker process died unexpectedly (SIGKILL)");
+          await waitForTask(
+            store,
+            taskId,
+            (doc) =>
+              doc.task.status === "failed" &&
+              doc.events.some((e) => e.eventType === "task_failed"),
+            `crash task ${taskId} failed`,
+          );
+          handled.add(session.id);
+          continue;
+        }
+
+        if (outcome === "grill" && !grilledOnce.has(session.id)) {
+          // First completion carries NO proof — the judge must reject it and the
+          // task must return to `active` for a corrective retry.
+          acp.complete(session.id, prooflessFor(taskTitle.get(taskId) ?? ""));
+          await waitForTask(
+            store,
+            taskId,
+            (doc) =>
+              doc.task.status === "active" &&
+              doc.events.some((e) => e.eventType === "auto_verify_failed"),
+            `grill task ${taskId} bounced back to active`,
+          );
+          grilledOnce.add(session.id);
+          // The re-engage reactivated the kept-alive session; complete it again
+          // WITH proof so the retry lands `done`.
+          await waitUntil(
+            () => acp.readySessions().some((s) => s.id === session.id),
+            `grill task ${taskId} worker reactivated`,
+          );
+          acp.complete(
+            session.id,
+            proofFor(taskTitle.get(taskId) ?? "", project.name),
+          );
+          await waitForTask(
+            store,
+            taskId,
+            (doc) =>
+              doc.task.status === "done" &&
+              doc.events.some((e) => e.eventType === "validation_passed"),
+            `grill task ${taskId} recovered to done`,
+          );
+          handled.add(session.id);
+          continue;
+        }
+
+        // clean
+        acp.complete(
+          session.id,
+          proofFor(taskTitle.get(taskId) ?? "", project.name),
+        );
+        await waitForTask(
+          store,
+          taskId,
+          (doc) =>
+            doc.task.status === "done" &&
+            doc.events.some((e) => e.eventType === "validation_passed"),
+          `clean task ${taskId} validated done`,
+        );
+        handled.add(session.id);
+      }
+    }
+    await waitUntil(
+      async () => (await service.getAdmissionSnapshot()).queueDepth === 0,
+      "admission queue drained to zero",
+    );
+
+    // ── Final structural proof across all 15 tasks. ──────────────────────────
+    const finalStatuses: Record<string, string> = {};
+    const outcomeViolations: string[] = [];
+    const crashEventViolations: string[] = [];
+    const grillEventViolations: string[] = [];
+    const foreignRoutes: string[] = [];
+    const listFilterViolations: string[] = [];
+    const perProject: PerProjectResult[] = [];
+
+    for (const project of projects) {
+      const ids = perProjectIds.get(project.id) ?? [];
+      const statuses: Record<string, string> = {};
+      const byStatus: Record<string, number> = {};
+      for (const taskId of ids) {
+        const doc = await store.getTask(taskId);
+        if (!doc) throw new Error(`task ${taskId} missing at final read`);
+        const status = doc.task.status;
+        statuses[taskId] = status;
+        finalStatuses[taskId] = status;
+        byStatus[status] = (byStatus[status] ?? 0) + 1;
+
+        const planned = plannedOutcomes[taskId];
+        const expected = OUTCOME_FINAL_STATUS[planned];
+        if (status !== expected) {
+          outcomeViolations.push(
+            `${taskId} (${planned}): status ${status}, expected ${expected}`,
+          );
+        }
+        // The error event must land on THIS task's own document.
+        if (planned === "crash") {
+          if (!doc.events.some((e) => e.eventType === "task_failed")) {
+            crashEventViolations.push(`${taskId}: no task_failed event`);
+          }
+        }
+        if (planned === "grill") {
+          if (!doc.events.some((e) => e.eventType === "auto_verify_failed")) {
+            grillEventViolations.push(`${taskId}: no auto_verify_failed event`);
+          }
+        }
+        foreignRoutes.push(...foreignEventSessions(doc));
+      }
+      perProject.push({
+        projectId: project.id,
+        name: project.name,
+        statuses,
+        byStatus,
+      });
+
+      // ── List/filter by status: each project's done/failed/archived partition
+      // returns exactly the tasks with that planned outcome, and never a sibling
+      // project's tasks. ──────────────────────────────────────────────────────
+      const idSet = new Set(ids);
+      const outcomes =
+        PROJECT_PLAN.find((p) => p.name === project.name)?.outcomes ?? [];
+      for (const [status, plannedForStatus] of [
+        ["done", ["clean", "grill"] as Outcome[]],
+        ["failed", ["crash"] as Outcome[]],
+        ["archived", ["cancel"] as Outcome[]],
+      ] as const) {
+        const expectedCount = outcomes.filter((o) =>
+          plannedForStatus.includes(o),
+        ).length;
+        const listed = await service.listTasks({
+          projectId: project.id,
+          status,
+          includeArchived: status === "archived",
+        });
+        const scoped = listed.filter((t) => idSet.has(t.id));
+        if (scoped.length !== expectedCount) {
+          listFilterViolations.push(
+            `${project.name} status=${status}: listed ${scoped.length}, expected ${expectedCount}`,
+          );
+        }
+        if (listed.some((t) => !idSet.has(t.id))) {
+          listFilterViolations.push(
+            `${project.name} status=${status}: leaked a foreign-project task`,
+          );
+        }
+      }
+    }
+
+    const doneCount = Object.values(finalStatuses).filter(
+      (s) => s === "done",
+    ).length;
+    const failedCount = Object.values(finalStatuses).filter(
+      (s) => s === "failed",
+    ).length;
+    const archivedCount = Object.values(finalStatuses).filter(
+      (s) => s === "archived",
+    ).length;
+
+    return {
+      summary:
+        `orchestrated 3 projects with mixed error paths (${TOTAL} tasks: ` +
+        `${doneCount} done, ${failedCount} failed, ${archivedCount} cancelled): ` +
+        `${CRASH_TOTAL} agent-dies crashes went terminal-failed, ${GRILL_TOTAL} proofless ` +
+        `completions were grilled and recovered on retry, ${CANCEL_TOTAL} tasks cancelled ` +
+        `before dispatch, and every clean sibling still reached done — one task failing ` +
+        `never corrupted another, with zero foreign event routes and the ${CAP}-worker cap ` +
+        `respected (high-water mark ${acp.workerHighWaterMark})`,
+      cap: CAP,
+      totalTasks: TOTAL,
+      workerHighWaterMark: acp.workerHighWaterMark,
+      judgeVerdicts: judgePrompts.length,
+      plannedOutcomes,
+      finalStatuses,
+      outcomeViolations,
+      crashEventViolations,
+      grillEventViolations,
+      foreignRoutes,
+      workdirViolations,
+      listFilterViolations,
+      perProject,
+    };
+  } finally {
+    await service.stop();
+    restoreEnv();
+    restoreGates();
+  }
+}
+
+function isolationPlugin(): Plugin {
+  const action: Action = {
+    name: ORCHESTRATOR_MULTI_PROJECT_FAILURE_ISOLATION,
+    description:
+      "Drive three registered projects with mixed error paths (crash, verify-fail grill, cancel) interleaved with clean tasks, and prove one task failing never corrupts a sibling in the same or another project.",
+    validate: async () => true,
+    handler: async () => {
+      const result = await runFailureIsolation();
+      return {
+        success: true,
+        text: result.summary,
+        userFacingText: result.summary,
+        verifiedUserFacing: true,
+        data: result,
+      };
+    },
+  };
+  return {
+    name: ISOLATION_PLUGIN_NAME,
+    description:
+      "Deterministic multi-project orchestration failure-isolation scenario.",
+    actions: [action],
+  };
+}
+
+export default scenario({
+  id: "orchestrator-multi-project-failure-isolation",
+  lane: "pr-deterministic",
+  title:
+    "Orchestrator isolates failures across 3 projects: crash, grill, and cancel paths never corrupt sibling tasks",
+  domain: "agent-orchestrator",
+  tags: [
+    "orchestrator",
+    "multi-project",
+    "multi-task",
+    "failure-isolation",
+    "error-path",
+    "concurrency",
+    "pr",
+    "deterministic",
+  ],
+  isolation: "shared-runtime",
+  requires: {
+    plugins: [ISOLATION_PLUGIN_NAME],
+  },
+  seed: [
+    {
+      type: "custom",
+      name: "register multi-project failure-isolation scenario action",
+      apply: async (ctx) => {
+        const runtime = ctx.runtime as {
+          registerPlugin?: (plugin: Plugin) => Promise<void>;
+          plugins?: Array<{ name?: string }>;
+        };
+        const already = runtime.plugins?.some(
+          (plugin) => plugin.name === ISOLATION_PLUGIN_NAME,
+        );
+        if (!already) {
+          await runtime.registerPlugin?.(isolationPlugin());
+        }
+        registerCalibratedJudgeFixture(
+          ctx.runtime as Parameters<typeof registerCalibratedJudgeFixture>[0],
+          ORCHESTRATOR_MULTI_PROJECT_FAILURE_ISOLATION,
+          [
+            "orchestrated 3 projects with mixed error paths",
+            `${CRASH_TOTAL} agent-dies crashes went terminal-failed`,
+            "grilled and recovered on retry",
+            "never corrupted another",
+          ],
+        );
+        return undefined;
+      },
+    },
+  ],
+  turns: [
+    {
+      kind: "action",
+      name: "drive three projects with interleaved crash, grill, and cancel paths",
+      text: "Run three projects at once and prove that a crashing, grilled, or cancelled task never corrupts its siblings.",
+      actionName: ORCHESTRATOR_MULTI_PROJECT_FAILURE_ISOLATION,
+      responseIncludesAny: [
+        "orchestrated 3 projects with mixed error paths",
+        "never corrupted another",
+      ],
+      assertTurn: (turn) => {
+        const data = turn.actionsCalled[0]?.result?.data as
+          | IsolationResult
+          | undefined;
+        if (!data) return "failure-isolation scenario produced no data";
+        if (data.outcomeViolations.length > 0) {
+          return `outcome violations: ${data.outcomeViolations.join(" | ").slice(0, 400)}`;
+        }
+        if (data.workerHighWaterMark > CAP) {
+          return `worker high-water mark ${data.workerHighWaterMark} exceeded cap ${CAP}`;
+        }
+        return undefined;
+      },
+    },
+  ],
+  finalChecks: [
+    {
+      type: "actionCalled",
+      actionName: ORCHESTRATOR_MULTI_PROJECT_FAILURE_ISOLATION,
+      status: "success",
+    },
+    {
+      type: "custom",
+      name: "3 projects x 15 tasks: every planned outcome held, error events landed on their own task, routing stayed clean, and cap respected",
+      predicate: (ctx) => {
+        const data = isolationData(ctx);
+        if (!data) return "failure-isolation scenario produced no data";
+        if (data.perProject.length !== 3) {
+          return `expected 3 projects, saw ${data.perProject.length}`;
+        }
+        if (Object.keys(data.finalStatuses).length !== TOTAL) {
+          return `expected ${TOTAL} task statuses, saw ${Object.keys(data.finalStatuses).length}`;
+        }
+        for (const [label, violations] of [
+          ["outcome", data.outcomeViolations],
+          ["crashEvent", data.crashEventViolations],
+          ["grillEvent", data.grillEventViolations],
+          ["foreignRoutes", data.foreignRoutes],
+          ["workdir", data.workdirViolations],
+          ["listFilter", data.listFilterViolations],
+        ] as const) {
+          if (violations.length > 0) {
+            return `${label} violations: ${violations.join(" | ").slice(0, 400)}`;
+          }
+        }
+        // Each error class actually happened (the scenario is not vacuously green
+        // because it never drove an error).
+        const finals = Object.values(data.finalStatuses);
+        const done = finals.filter((s) => s === "done").length;
+        const failed = finals.filter((s) => s === "failed").length;
+        const archived = finals.filter((s) => s === "archived").length;
+        if (failed !== CRASH_TOTAL) {
+          return `expected ${CRASH_TOTAL} failed (crashed) tasks, saw ${failed}`;
+        }
+        if (archived !== CANCEL_TOTAL) {
+          return `expected ${CANCEL_TOTAL} archived (cancelled) tasks, saw ${archived}`;
+        }
+        if (done !== CLEAN_TOTAL + GRILL_TOTAL) {
+          return `expected ${CLEAN_TOTAL + GRILL_TOTAL} done (clean + recovered grill) tasks, saw ${done}`;
+        }
+        if (data.judgeVerdicts !== JUDGE_VERDICTS) {
+          return `expected ${JUDGE_VERDICTS} verifier verdicts, saw ${data.judgeVerdicts}`;
+        }
+        if (data.workerHighWaterMark > CAP) {
+          return `worker high-water mark ${data.workerHighWaterMark} exceeded cap ${CAP}`;
+        }
+        return undefined;
+      },
+    },
+    {
+      type: "judgeRubric",
+      name: "judge verifies failure isolation across projects",
+      minimumScore: 0.95,
+      rubric:
+        "Pass only if the trace shows three projects orchestrated simultaneously with mixed error paths — a crashed sub-agent going terminal-failed, a proofless completion grilled and recovered on retry, and a cancelled task archived before dispatch — while every clean sibling still reached done and no failure corrupted another task, with the worker cap respected and zero cross-project event routing.",
+    },
+  ],
+});

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-multi-project-portfolio.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-multi-project-portfolio.scenario.ts
@@ -1,0 +1,496 @@
+/**
+ * Multi-project orchestration portfolio (pr-deterministic, keyless): the task
+ * orchestrator manages THREE registered projects simultaneously — 6 + 5 + 7 =
+ * 18 tasks — through the full create → spawn → progress → verify → complete
+ * lifecycle against the REAL `OrchestratorTaskService` (event bridge, legal
+ * transition table, admission queue, auto goal-verify) over a cap-enforcing
+ * deterministic ACP. Proves, structurally:
+ *
+ *  - project binding: every task carries its registered `projectId` and the
+ *    project-derived memory `worldId`, and every spawned session lands LOCKED
+ *    in its project's `localPath` (the #13776 per-session repo-drift fix);
+ *  - list/filter by project: `listTasks({ projectId })` returns exactly that
+ *    project's tasks, before and after the run;
+ *  - concurrency respected: 18 spawns against an 8-worker cap park 10 in the
+ *    admission queue, the worker high-water mark never exceeds the cap, and the
+ *    queue drains to zero with exactly one session per task (no drops/doubles);
+ *  - event routing: progress/completion events interleaved across all three
+ *    projects land only on their own task documents — zero foreign sessions;
+ *  - verification: every completion passes through validating → the
+ *    evidence-grounded judge (which only passes pasted test output) → done.
+ *
+ * Error paths (crash, verify-fail grill, cancel) live in the companion
+ * `orchestrator-multi-project-failure-isolation.scenario.ts`.
+ */
+
+import { projectWorldId, type UUID } from "@elizaos/core";
+import type { Action, Plugin } from "@elizaos/core";
+import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
+import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-store.js";
+import {
+  applyScenarioEnv,
+  foreignEventSessions,
+  makeMultiProjectRuntime,
+  MultiProjectAcp,
+  registerScenarioProjects,
+  type ScenarioProject,
+  waitForTask,
+  waitUntil,
+} from "./_helpers/multi-project-scenario";
+import { registerCalibratedJudgeFixture } from "./_helpers/orchestrator-scenario-harness";
+
+const PORTFOLIO_PLUGIN_NAME = "orchestrator-multi-project-portfolio-scenario";
+const ORCHESTRATOR_MULTI_PROJECT_PORTFOLIO =
+  "ORCHESTRATOR_MULTI_PROJECT_PORTFOLIO";
+
+const AGENT_ID = "aa010000-0000-4000-8000-000000000001" as UUID;
+const CAP = 8;
+/** Per-project task counts: 3 projects, 5–15 tasks each, 18 total. */
+const PROJECT_PLAN: Array<{ name: string; tasks: number }> = [
+  { name: "checkout-service", tasks: 6 },
+  { name: "web-dashboard", tasks: 5 },
+  { name: "mobile-app", tasks: 7 },
+];
+const TOTAL = PROJECT_PLAN.reduce((sum, p) => sum + p.tasks, 0);
+
+type PerProjectResult = {
+  projectId: string;
+  name: string;
+  taskIds: string[];
+  statuses: Record<string, string>;
+  doneCount: number;
+};
+
+type PortfolioResult = {
+  summary: string;
+  cap: number;
+  totalTasks: number;
+  activeAtCap: number;
+  queuedAtCap: number;
+  workerHighWaterMark: number;
+  judgeVerdicts: number;
+  sessionsPerTask: Record<string, number>;
+  /** Session ids found on a task doc that belong to another task — must be []. */
+  foreignRoutes: string[];
+  /** Sub-agent progress messages that carry another project's marker — []. */
+  crossProjectMessages: string[];
+  /** Sessions whose spawn workdir did not match the bound project localPath. */
+  workdirViolations: string[];
+  worldBindingViolations: string[];
+  listFilterViolations: string[];
+  perProject: PerProjectResult[];
+};
+
+function portfolioData(ctx: ScenarioContext): PortfolioResult | null {
+  const action = ctx.actionsCalled.find(
+    (c) => c.actionName === ORCHESTRATOR_MULTI_PROJECT_PORTFOLIO,
+  );
+  const data = action?.result?.data;
+  return data && typeof data === "object" && !Array.isArray(data)
+    ? (data as PortfolioResult)
+    : null;
+}
+
+async function runPortfolio(): Promise<PortfolioResult> {
+  const restoreGates = applyScenarioEnv({
+    ELIZA_ACP_ADMISSION_QUEUE: "1",
+    ELIZA_ORCHESTRATOR_AUTO_GOAL_VERIFY: "1",
+    ELIZA_ORCHESTRATOR_WATCHDOG: "0",
+    ELIZA_ORCHESTRATOR_INDEPENDENT_VERIFY: "0",
+  });
+  const { projects, restoreEnv } = registerScenarioProjects(
+    "eliza-orch-portfolio",
+    PROJECT_PLAN.map((p) => p.name),
+  );
+  const acp = new MultiProjectAcp(CAP);
+  const judgePrompts: string[] = [];
+  const runtime = makeMultiProjectRuntime(acp, {
+    agentId: AGENT_ID,
+    onJudge: (prompt) => judgePrompts.push(prompt),
+  });
+  const store = new OrchestratorTaskStore({ backend: "memory" });
+  const service = new OrchestratorTaskService(runtime as never, { store });
+  await service.start();
+
+  try {
+    // ── Create 18 tasks, round-robin interleaved across the three projects, so
+    // the store never sees one project's tasks as a contiguous block. ─────────
+    const taskProject = new Map<string, ScenarioProject>();
+    const taskTitle = new Map<string, string>();
+    const perProjectIds = new Map<string, string[]>(
+      projects.map((p) => [p.id, []]),
+    );
+    const maxPerProject = Math.max(...PROJECT_PLAN.map((p) => p.tasks));
+    for (let round = 0; round < maxPerProject; round++) {
+      for (const [index, plan] of PROJECT_PLAN.entries()) {
+        if (round >= plan.tasks) continue;
+        const project = projects[index];
+        const title = `${plan.name} task ${round + 1}`;
+        const detail = await service.createTask({
+          title,
+          goal: `Ship improvement ${round + 1} for ${plan.name}.`,
+          originalRequest: `Please ship improvement ${round + 1} for ${plan.name}.`,
+          kind: "coding",
+          priority: "normal",
+          roomId: project.roomId,
+          projectId: project.id,
+          metadata: { source: "scenario-runner" },
+          acceptanceCriteria: [
+            `improvement ${round + 1} tests pass in ${plan.name}`,
+          ],
+        });
+        taskProject.set(detail.id, project);
+        taskTitle.set(detail.id, title);
+        perProjectIds.get(project.id)?.push(detail.id);
+      }
+    }
+
+    // ── Binding proof: projectId + project-derived memory world per record. ──
+    const worldBindingViolations: string[] = [];
+    for (const [taskId, project] of taskProject) {
+      const doc = await store.getTask(taskId);
+      const expectedWorld = projectWorldId(AGENT_ID, project.id);
+      if (doc?.task.projectId !== project.id) {
+        worldBindingViolations.push(
+          `${taskId}: projectId=${doc?.task.projectId ?? "(none)"} expected ${project.id}`,
+        );
+      } else if (doc.task.worldId !== expectedWorld) {
+        worldBindingViolations.push(
+          `${taskId}: worldId=${doc.task.worldId ?? "(none)"} expected ${expectedWorld}`,
+        );
+      }
+    }
+
+    // ── List/filter proof BEFORE the run: exact per-project sets. ────────────
+    const listFilterViolations: string[] = [];
+    for (const project of projects) {
+      const listed = await service.listTasks({ projectId: project.id });
+      const expected = new Set(perProjectIds.get(project.id));
+      if (
+        listed.length !== expected.size ||
+        listed.some((t) => !expected.has(t.id))
+      ) {
+        listFilterViolations.push(
+          `pre-run ${project.name}: listed ${listed.length} (${listed
+            .map((t) => t.id)
+            .join(",")}), expected ${expected.size}`,
+        );
+      }
+    }
+    const allListed = await service.listTasks({});
+    if (allListed.length !== TOTAL) {
+      listFilterViolations.push(
+        `pre-run unfiltered: listed ${allListed.length}, expected ${TOTAL}`,
+      );
+    }
+
+    // ── Spawn all 18 against the 8-worker cap (interleaved order). Over-cap
+    // spawns park in the real admission queue. ────────────────────────────────
+    const interleavedIds = [...taskProject.keys()];
+    for (const taskId of interleavedIds) {
+      await service.spawnAgentForTask(taskId, {});
+    }
+    const snapshot = await service.getAdmissionSnapshot();
+    const activeAtCap = acp.readySessions().length;
+    const queuedAtCap = snapshot.queueDepth;
+    if (activeAtCap !== CAP || queuedAtCap !== TOTAL - CAP) {
+      throw new Error(
+        `expected ${CAP} active + ${TOTAL - CAP} queued at cap, saw ${activeAtCap}/${queuedAtCap}`,
+      );
+    }
+
+    // ── Waves: interleave progress events across every live project's session,
+    // then complete them with pasted test output; each completion frees a slot
+    // and the admission queue drains the next parked task. ───────────────────
+    const workdirViolations: string[] = [];
+    const validatedSessions = new Set<string>();
+    for (let guard = 0; guard < TOTAL * 4; guard++) {
+      const ready = acp
+        .readySessions()
+        .filter((s) => !validatedSessions.has(s.id));
+      if (ready.length === 0) {
+        const depth = (await service.getAdmissionSnapshot()).queueDepth;
+        if (depth === 0) break;
+        await waitUntil(
+          () => acp.readySessions().some((s) => !validatedSessions.has(s.id)),
+          "admission drain to dispatch a parked task",
+        );
+        continue;
+      }
+      // Interleaved progress first — every ready session (spanning all three
+      // projects) reports activity before any of them completes.
+      for (const session of ready) {
+        const taskId = String(session.metadata?.taskId ?? "");
+        const project = taskProject.get(taskId);
+        if (!project) throw new Error(`session ${session.id} has no task`);
+        if (session.workdir !== project.localPath) {
+          workdirViolations.push(
+            `${session.id}: workdir ${session.workdir} != ${project.localPath}`,
+          );
+        }
+        validatedSessions.add(session.id);
+        await waitForTask(
+          store,
+          taskId,
+          (doc) => doc.task.status === "active",
+          `task ${taskId} active after spawn`,
+        );
+        acp.emit(session.id, "tool_running", {
+          toolCall: { title: `bun test ${project.name}` },
+        });
+        acp.emit(session.id, "message", {
+          text: `progress ${project.name}: ${taskTitle.get(taskId)}`,
+        });
+      }
+      // Then complete the wave with concrete proof the judge demands.
+      for (const session of ready) {
+        const taskId = String(session.metadata?.taskId ?? "");
+        const project = taskProject.get(taskId);
+        acp.complete(
+          session.id,
+          `Done: ${taskTitle.get(taskId)}. Proof: Tests 3 passed (3) in ${project?.name}.`,
+        );
+        await waitForTask(
+          store,
+          taskId,
+          (doc) =>
+            doc.task.status === "done" &&
+            doc.events.some((e) => e.eventType === "validation_passed"),
+          `task ${taskId} validated done`,
+        );
+      }
+    }
+    await waitUntil(
+      async () => (await service.getAdmissionSnapshot()).queueDepth === 0,
+      "admission queue drained to zero",
+    );
+
+    // ── Final structural proof across all 18 tasks. ──────────────────────────
+    const sessionsPerTask: Record<string, number> = {};
+    const foreignRoutes: string[] = [];
+    const crossProjectMessages: string[] = [];
+    const perProject: PerProjectResult[] = [];
+    for (const project of projects) {
+      const ids = perProjectIds.get(project.id) ?? [];
+      const statuses: Record<string, string> = {};
+      for (const taskId of ids) {
+        const doc = await store.getTask(taskId);
+        if (!doc) throw new Error(`task ${taskId} missing at final read`);
+        statuses[taskId] = doc.task.status;
+        sessionsPerTask[taskId] = doc.sessions.length;
+        foreignRoutes.push(...foreignEventSessions(doc));
+        for (const message of doc.messages) {
+          if (
+            message.senderKind === "sub_agent" &&
+            message.content.startsWith("progress ") &&
+            !message.content.startsWith(`progress ${project.name}`)
+          ) {
+            crossProjectMessages.push(`${taskId}: ${message.content}`);
+          }
+        }
+      }
+      const listed = await service.listTasks({ projectId: project.id });
+      const doneCount = listed.filter((t) => t.status === "done").length;
+      if (listed.length !== ids.length || doneCount !== ids.length) {
+        listFilterViolations.push(
+          `post-run ${project.name}: ${doneCount}/${listed.length} done, expected ${ids.length}/${ids.length}`,
+        );
+      }
+      perProject.push({
+        projectId: project.id,
+        name: project.name,
+        taskIds: ids,
+        statuses,
+        doneCount,
+      });
+    }
+    const doneTotal = perProject.reduce((sum, p) => sum + p.doneCount, 0);
+    const drops = Object.entries(sessionsPerTask).filter(([, n]) => n !== 1);
+    if (drops.length > 0) {
+      throw new Error(
+        `expected exactly one session per task, saw ${JSON.stringify(sessionsPerTask)}`,
+      );
+    }
+
+    return {
+      summary:
+        `orchestrated 3 projects simultaneously (checkout-service 6, web-dashboard 5, mobile-app 7): ` +
+        `${doneTotal}/${TOTAL} tasks done end-to-end (create → spawn → progress → verify → complete), ` +
+        `${activeAtCap} active + ${queuedAtCap} queued at the ${CAP}-worker cap with high-water mark ${acp.workerHighWaterMark}, ` +
+        `${judgePrompts.length} evidence-grounded verifier verdicts, per-project list filters exact, ` +
+        `zero foreign event routes and zero cross-project message bleed`,
+      cap: CAP,
+      totalTasks: TOTAL,
+      activeAtCap,
+      queuedAtCap,
+      workerHighWaterMark: acp.workerHighWaterMark,
+      judgeVerdicts: judgePrompts.length,
+      sessionsPerTask,
+      foreignRoutes,
+      crossProjectMessages,
+      workdirViolations,
+      worldBindingViolations,
+      listFilterViolations,
+      perProject,
+    };
+  } finally {
+    await service.stop();
+    restoreEnv();
+    restoreGates();
+  }
+}
+
+function portfolioPlugin(): Plugin {
+  const action: Action = {
+    name: ORCHESTRATOR_MULTI_PROJECT_PORTFOLIO,
+    description:
+      "Drive three registered projects (18 tasks) through the full orchestrator lifecycle simultaneously: project binding, per-project list filters, cap-respecting concurrency, interleaved event routing, and evidence-verified completion.",
+    validate: async () => true,
+    handler: async () => {
+      const result = await runPortfolio();
+      return {
+        success: true,
+        text: result.summary,
+        userFacingText: result.summary,
+        verifiedUserFacing: true,
+        data: result,
+      };
+    },
+  };
+  return {
+    name: PORTFOLIO_PLUGIN_NAME,
+    description:
+      "Deterministic multi-project orchestration portfolio scenario.",
+    actions: [action],
+  };
+}
+
+export default scenario({
+  id: "orchestrator-multi-project-portfolio",
+  lane: "pr-deterministic",
+  title:
+    "Orchestrator manages 3 projects simultaneously: 18 tasks end-to-end with project binding, filters, cap-respecting concurrency, and verified completion",
+  domain: "agent-orchestrator",
+  tags: [
+    "orchestrator",
+    "multi-project",
+    "multi-task",
+    "concurrency",
+    "pr",
+    "deterministic",
+  ],
+  isolation: "shared-runtime",
+  requires: {
+    plugins: [PORTFOLIO_PLUGIN_NAME],
+  },
+  seed: [
+    {
+      type: "custom",
+      name: "register multi-project portfolio scenario action",
+      apply: async (ctx) => {
+        const runtime = ctx.runtime as {
+          registerPlugin?: (plugin: Plugin) => Promise<void>;
+          plugins?: Array<{ name?: string }>;
+        };
+        const already = runtime.plugins?.some(
+          (plugin) => plugin.name === PORTFOLIO_PLUGIN_NAME,
+        );
+        if (!already) {
+          await runtime.registerPlugin?.(portfolioPlugin());
+        }
+        registerCalibratedJudgeFixture(
+          ctx.runtime as Parameters<typeof registerCalibratedJudgeFixture>[0],
+          ORCHESTRATOR_MULTI_PROJECT_PORTFOLIO,
+          [
+            "orchestrated 3 projects simultaneously",
+            "checkout-service 6",
+            "web-dashboard 5",
+            "mobile-app 7",
+            `${TOTAL}/${TOTAL} tasks done`,
+          ],
+        );
+        return undefined;
+      },
+    },
+  ],
+  turns: [
+    {
+      kind: "action",
+      name: "manage three projects with 18 tasks simultaneously",
+      text: "Run three projects at once — checkout-service, web-dashboard, and mobile-app — and drive every task to a verified completion.",
+      actionName: ORCHESTRATOR_MULTI_PROJECT_PORTFOLIO,
+      responseIncludesAny: [
+        "orchestrated 3 projects simultaneously",
+        "tasks done end-to-end",
+      ],
+      assertTurn: (turn) => {
+        const data = turn.actionsCalled[0]?.result?.data as
+          | PortfolioResult
+          | undefined;
+        if (!data) return "portfolio scenario produced no data";
+        if (data.activeAtCap !== CAP || data.queuedAtCap !== TOTAL - CAP) {
+          return `expected ${CAP} active + ${TOTAL - CAP} queued at cap, saw ${data.activeAtCap}/${data.queuedAtCap}`;
+        }
+        if (data.workerHighWaterMark !== CAP) {
+          return `expected worker high-water mark ${CAP}, saw ${data.workerHighWaterMark}`;
+        }
+        return undefined;
+      },
+    },
+  ],
+  finalChecks: [
+    {
+      type: "actionCalled",
+      actionName: ORCHESTRATOR_MULTI_PROJECT_PORTFOLIO,
+      status: "success",
+    },
+    {
+      type: "custom",
+      name: "3 projects x 18 tasks: bindings, filters, routing, concurrency, and verified completion all hold",
+      predicate: (ctx) => {
+        const data = portfolioData(ctx);
+        if (!data) return "portfolio scenario produced no data";
+        if (data.perProject.length !== 3) {
+          return `expected 3 projects, saw ${data.perProject.length}`;
+        }
+        const doneTotal = data.perProject.reduce(
+          (sum, p) => sum + p.doneCount,
+          0,
+        );
+        if (doneTotal !== TOTAL) {
+          return `expected ${TOTAL} tasks done, saw ${doneTotal}`;
+        }
+        for (const [label, violations] of [
+          ["worldBinding", data.worldBindingViolations],
+          ["listFilter", data.listFilterViolations],
+          ["workdir", data.workdirViolations],
+          ["foreignRoutes", data.foreignRoutes],
+          ["crossProjectMessages", data.crossProjectMessages],
+        ] as const) {
+          if (violations.length > 0) {
+            return `${label} violations: ${violations.join(" | ").slice(0, 400)}`;
+          }
+        }
+        if (data.judgeVerdicts !== TOTAL) {
+          return `expected ${TOTAL} verifier verdicts (one per task), saw ${data.judgeVerdicts}`;
+        }
+        const badCounts = Object.entries(data.sessionsPerTask).filter(
+          ([, n]) => n !== 1,
+        );
+        if (badCounts.length > 0) {
+          return `expected one session per task, saw ${JSON.stringify(badCounts)}`;
+        }
+        return undefined;
+      },
+    },
+    {
+      type: "judgeRubric",
+      name: "judge verifies simultaneous multi-project orchestration",
+      minimumScore: 0.95,
+      rubric:
+        "Pass only if the trace shows three projects orchestrated simultaneously with 18 tasks driven end-to-end (create, spawn, progress, verify, complete), an 8-worker cap respected via admission queueing, exact per-project list filters, and zero cross-project event routing.",
+    },
+  ],
+});

--- a/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-multi-project-portfolio.scenario.ts
+++ b/plugins/plugin-agent-orchestrator/test/scenarios/orchestrator-multi-project-portfolio.scenario.ts
@@ -23,8 +23,8 @@
  * `orchestrator-multi-project-failure-isolation.scenario.ts`.
  */
 
-import { projectWorldId, type UUID } from "@elizaos/core";
 import type { Action, Plugin } from "@elizaos/core";
+import { projectWorldId, type UUID } from "@elizaos/core";
 import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
 import { scenario } from "@elizaos/scenario-runner/schema";
 import { OrchestratorTaskService } from "../../src/services/orchestrator-task-service.js";
@@ -32,8 +32,8 @@ import { OrchestratorTaskStore } from "../../src/services/orchestrator-task-stor
 import {
   applyScenarioEnv,
   foreignEventSessions,
-  makeMultiProjectRuntime,
   MultiProjectAcp,
+  makeMultiProjectRuntime,
   registerScenarioProjects,
   type ScenarioProject,
   waitForTask,


### PR DESCRIPTION
Exposes `projectId` on TASKS create/history for project grouping, and adds multi-project orchestration scenarios: a **3-project × 18-task** portfolio driven create→spawn→progress→verify→complete, plus a **failure-isolation** scenario proving one task's crash/cancel never corrupts sibling projects/tasks.

## Evidence
| Type | Status |
| --- | --- |
| Tests | Deterministic tests added in this branch (see commits); run per-package vitest. CI runs the suite. |
| Real-LLM trajectory | N/A — no live provider key in this shell; a credentialed runner should capture. |
| UI screenshots/video | N/A in this shell (no browser/display); capture via `bun run --cwd packages/app audit:app` on a runner where applicable. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence Matrix
<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - orchestrator action/scenario coverage change only; no rendered UI component changed.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - orchestrator action/scenario coverage change only; no rendered UI component changed.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no browser/mobile UI flow changed; the relevant walkthrough artifact is the scenario run report.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no live service run is attached in this local body; scenario execution logs should be attached when the portfolio/failure-isolation runs execute in CI or a credentialed runner.
<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A - no frontend runtime path changed.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - not captured in this local shell; if TASKS action planning semantics changed, attach a live scenario trajectory before treating the PR as MVP-ready.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - no production task records were generated in this local pass; the expected artifacts are scenario reports showing 3-project task creation/progress/verification/completion and failure isolation.

## Stronger Follow-Up Proof
Attach the scenario runner JSON/report artifacts for both new scenarios, including the project/task IDs produced, failure/cancel isolation evidence, and final task states for every project.
