### PR TITLE
feat(voice): Kokoro as default TTS + native STT preference (iOS/Android)

### DIFF
--- a/packages/agent/src/api/server-lazy-routes.ts
+++ b/packages/agent/src/api/server-lazy-routes.ts
@@ -429,8 +429,8 @@ export async function handleMobileOptionalRoutes(
     typeof pathname !== "string" ||
     !(
       pathname.startsWith("/api/local-inference") ||
-      pathname === "/api/tts/local-inference" ||
-      pathname === "/api/asr/local-inference" ||
+      pathname.startsWith("/api/tts/local-inference") ||
+      pathname.startsWith("/api/asr/local-inference") ||
       pathname.startsWith("/api/mobile") ||
       pathname === "/api/runtime/mode" ||
       pathname.startsWith("/api/computer-use/") ||

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -2052,7 +2052,7 @@ async function handleRequest(
 
   if (
     (pathname.startsWith("/api/local-inference") ||
-      pathname === "/api/tts/local-inference" ||
+      pathname.startsWith("/api/tts/local-inference") ||
       pathname.startsWith("/api/asr/local-inference") ||
       pathname.startsWith("/api/voice/audio-frames") ||
       pathname === "/api/voice/playback-frames" ||

--- a/packages/ui/src/components/settings/VoiceConfigView.tsx
+++ b/packages/ui/src/components/settings/VoiceConfigView.tsx
@@ -23,6 +23,7 @@ import {
 } from "../../bridge/native-plugins";
 import { dispatchWindowEvent, VOICE_CONFIG_UPDATED_EVENT } from "../../events";
 import { useDefaultProviderPresets } from "../../hooks/useDefaultProviderPresets";
+import { useResolvedTtsDefault } from "../../hooks/useResolvedTtsDefault";
 import { useAppSelector } from "../../state";
 import {
   hasConfiguredApiKey,
@@ -1093,14 +1094,41 @@ export function VoiceConfigView() {
   const { defaults: providerDefaults } = useDefaultProviderPresets();
   const advancedEnabled = useAdvancedSettingsEnabled();
 
-  // Falls back to the device default until the user picks a provider.
-  const currentProvider = voiceConfig.provider ?? providerDefaults.tts;
-  const currentAsrProvider: AsrProvider =
-    voiceConfig.asr?.provider ?? providerDefaults.asr;
   const cloudVoiceAvailable = elizaCloudVoiceProxyAvailable;
   const hasElevenLabsApiKey = hasConfiguredApiKey(
     voiceConfig.elevenlabs?.apiKey,
   );
+  // Capability-aware default: on-device Kokoro when staged, else Eliza Cloud
+  // Kokoro when a session exists, else ElevenLabs (key), else browser TTS. This
+  // is the provider that will actually play when the user hasn't picked one, so
+  // it (not the raw platform preference) is what the picker highlights + labels.
+  const { provider: resolvedTtsDefault } = useResolvedTtsDefault({
+    cloudVoiceAvailable,
+    elevenLabsKeyConfigured: hasElevenLabsApiKey,
+  });
+
+  // Falls back to the resolved device default until the user picks a provider.
+  const currentProvider = voiceConfig.provider ?? resolvedTtsDefault;
+  const currentAsrProvider: AsrProvider =
+    voiceConfig.asr?.provider ?? providerDefaults.asr;
+
+  // Human-readable label for the resolved default. Both Kokoro transports read
+  // as "Kokoro"; the browser SpeechSynthesis fallback (`robot-voice`) reads as
+  // "browser voice" since it is not one of the listed provider cards.
+  const resolvedTtsDefaultLabel =
+    resolvedTtsDefault === "local-inference"
+      ? t("voiceconfigview.KokoroOnDevice", {
+          defaultValue: "Kokoro (on-device)",
+        })
+      : resolvedTtsDefault === "eliza-cloud"
+        ? t("voiceconfigview.KokoroCloud", {
+            defaultValue: "Kokoro (Eliza Cloud)",
+          })
+        : resolvedTtsDefault === "elevenlabs"
+          ? "ElevenLabs"
+          : t("voiceconfigview.BrowserVoice", {
+              defaultValue: "browser voice",
+            });
   const defaultVoiceMode: VoiceMode = cloudVoiceAvailable
     ? hasElevenLabsApiKey
       ? "own-key"
@@ -1263,7 +1291,9 @@ export function VoiceConfigView() {
                 ? `Eliza Cloud — ${t("voiceconfigview.ServedViaElizaCloud")}`
                 : currentProvider === "elevenlabs"
                   ? `ElevenLabs — ${currentMode === "cloud" ? t("voiceconfigview.ServedViaElizaCloud") : t("voiceconfigview.RequiresApiKey")}`
-                  : `${providerInfo ? t(providerInfo.labelKey, { defaultValue: providerInfo.label }) : ""} — ${t("voiceconfigview.NoApiKeyNeeded")}`}
+                  : providerInfo
+                    ? `${t(providerInfo.labelKey, { defaultValue: providerInfo.label })} — ${t("voiceconfigview.NoApiKeyNeeded")}`
+                    : `${t("voiceconfigview.BrowserVoice", { defaultValue: "browser voice" })} — ${t("voiceconfigview.NoApiKeyNeeded")}`}
             </span>
             <span
               className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${
@@ -1279,6 +1309,12 @@ export function VoiceConfigView() {
           </span>
         }
       >
+        <p className="mb-2 text-xs text-muted">
+          {t("voiceconfigview.TtsDeviceDefault", {
+            defaultValue: "Device default: {{provider}}",
+            provider: resolvedTtsDefaultLabel,
+          })}
+        </p>
         <div className="grid gap-2 sm:grid-cols-2">
           {VOICE_PROVIDERS.map((p) => (
             <TtsProviderButton

--- a/packages/ui/src/hooks/useResolvedTtsDefault.test.tsx
+++ b/packages/ui/src/hooks/useResolvedTtsDefault.test.tsx
@@ -1,0 +1,220 @@
+// @vitest-environment jsdom
+
+/**
+ * Drives the real `useResolvedTtsDefault` hook + `useDefaultProviderPresets` +
+ * `resolveDefaultTtsProvider` against a mocked runtime-mode snapshot and a
+ * mocked on-device readiness probe. Asserts the capability-aware default chain
+ * per platform/config: on-device Kokoro when staged, else Eliza Cloud Kokoro,
+ * else ElevenLabs (key), else browser SpeechSynthesis — and that the probe only
+ * fires when the platform/mode would use an on-device voice.
+ */
+
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../api/runtime-mode-client", () => ({
+  fetchRuntimeModeSnapshot: vi.fn(),
+}));
+
+vi.mock("../voice/local-tts-status", () => ({
+  isLocalInferenceTtsReady: vi.fn(),
+}));
+
+import {
+  fetchRuntimeModeSnapshot,
+  type RuntimeModeSnapshot,
+} from "../api/runtime-mode-client";
+import { isLocalInferenceTtsReady } from "../voice/local-tts-status";
+import { BROWSER_TTS_PROVIDER } from "../voice/voice-provider-defaults";
+import {
+  type UseResolvedTtsDefaultResult,
+  useResolvedTtsDefault,
+} from "./useResolvedTtsDefault";
+import { __resetRuntimeModeCacheForTests } from "./useRuntimeMode";
+
+const fetchMock = vi.mocked(fetchRuntimeModeSnapshot);
+const ttsReadyMock = vi.mocked(isLocalInferenceTtsReady);
+
+function HookProbe(props: {
+  onState: (result: UseResolvedTtsDefaultResult) => void;
+  options: Parameters<typeof useResolvedTtsDefault>[0];
+}): null {
+  const result = useResolvedTtsDefault(props.options);
+  props.onState(result);
+  return null;
+}
+
+async function resolveOnce(
+  options: Parameters<typeof useResolvedTtsDefault>[0],
+  runtimeMode: RuntimeModeSnapshot,
+): Promise<UseResolvedTtsDefaultResult> {
+  fetchMock.mockResolvedValueOnce(runtimeMode);
+  const seen: UseResolvedTtsDefaultResult[] = [];
+  render(<HookProbe onState={(r) => seen.push(r)} options={options} />);
+  await waitFor(() => {
+    expect(seen[seen.length - 1]?.runtimeMode).toBe(runtimeMode.mode);
+  });
+  return seen[seen.length - 1] as UseResolvedTtsDefaultResult;
+}
+
+beforeEach(() => {
+  __resetRuntimeModeCacheForTests();
+  fetchMock.mockReset();
+  ttsReadyMock.mockReset();
+  ttsReadyMock.mockResolvedValue(false);
+});
+
+afterEach(() => {
+  __resetRuntimeModeCacheForTests();
+});
+
+describe("useResolvedTtsDefault", () => {
+  it("desktop-local with staged on-device Kokoro resolves to local-inference", async () => {
+    const last = await resolveOnce(
+      {
+        platformOverride: "desktop",
+        cloudVoiceAvailable: true,
+        elevenLabsKeyConfigured: true,
+        localInferenceTtsReadyOverride: true,
+      },
+      {
+        mode: "local",
+        deploymentRuntime: "local",
+        isRemoteController: false,
+        remoteApiBaseConfigured: false,
+      },
+    );
+    expect(last.provider).toBe("local-inference");
+  });
+
+  it("desktop-local without a staged voice falls to Eliza Cloud Kokoro", async () => {
+    const last = await resolveOnce(
+      {
+        platformOverride: "desktop",
+        cloudVoiceAvailable: true,
+        elevenLabsKeyConfigured: true,
+        localInferenceTtsReadyOverride: false,
+      },
+      {
+        mode: "local",
+        deploymentRuntime: "local",
+        isRemoteController: false,
+        remoteApiBaseConfigured: false,
+      },
+    );
+    expect(last.provider).toBe("eliza-cloud");
+  });
+
+  it("cloud agent with a session resolves to Eliza Cloud Kokoro", async () => {
+    const last = await resolveOnce(
+      {
+        platformOverride: "web",
+        cloudVoiceAvailable: true,
+        elevenLabsKeyConfigured: false,
+      },
+      {
+        mode: "cloud",
+        deploymentRuntime: "cloud",
+        isRemoteController: false,
+        remoteApiBaseConfigured: false,
+      },
+    );
+    expect(last.provider).toBe("eliza-cloud");
+  });
+
+  it("cloud agent with NO session but an ElevenLabs key resolves to elevenlabs", async () => {
+    const last = await resolveOnce(
+      {
+        platformOverride: "web",
+        cloudVoiceAvailable: false,
+        elevenLabsKeyConfigured: true,
+      },
+      {
+        mode: "cloud",
+        deploymentRuntime: "cloud",
+        isRemoteController: false,
+        remoteApiBaseConfigured: false,
+      },
+    );
+    expect(last.provider).toBe("elevenlabs");
+  });
+
+  it("with no capabilities at all resolves to browser SpeechSynthesis", async () => {
+    const last = await resolveOnce(
+      {
+        platformOverride: "web",
+        cloudVoiceAvailable: false,
+        elevenLabsKeyConfigured: false,
+      },
+      {
+        mode: "cloud",
+        deploymentRuntime: "cloud",
+        isRemoteController: false,
+        remoteApiBaseConfigured: false,
+      },
+    );
+    expect(last.provider).toBe(BROWSER_TTS_PROVIDER);
+  });
+
+  it("probes on-device readiness only on desktop/mobile-local surfaces", async () => {
+    ttsReadyMock.mockResolvedValue(true);
+    await resolveOnce(
+      {
+        platformOverride: "desktop",
+        cloudVoiceAvailable: false,
+        elevenLabsKeyConfigured: false,
+      },
+      {
+        mode: "local",
+        deploymentRuntime: "local",
+        isRemoteController: false,
+        remoteApiBaseConfigured: false,
+      },
+    );
+    expect(ttsReadyMock).toHaveBeenCalled();
+  });
+
+  it("does NOT probe on-device readiness for a cloud agent", async () => {
+    await resolveOnce(
+      {
+        platformOverride: "web",
+        cloudVoiceAvailable: true,
+        elevenLabsKeyConfigured: false,
+      },
+      {
+        mode: "cloud",
+        deploymentRuntime: "cloud",
+        isRemoteController: false,
+        remoteApiBaseConfigured: false,
+      },
+    );
+    expect(ttsReadyMock).not.toHaveBeenCalled();
+  });
+
+  it("upgrades to on-device Kokoro once the real probe reports ready", async () => {
+    ttsReadyMock.mockResolvedValue(true);
+    const seen: UseResolvedTtsDefaultResult[] = [];
+    fetchMock.mockResolvedValueOnce({
+      mode: "local",
+      deploymentRuntime: "local",
+      isRemoteController: false,
+      remoteApiBaseConfigured: false,
+    });
+    render(
+      <HookProbe
+        onState={(r) => seen.push(r)}
+        options={{
+          platformOverride: "desktop",
+          cloudVoiceAvailable: false,
+          elevenLabsKeyConfigured: false,
+        }}
+      />,
+    );
+    // The probe is async; the default upgrades to local-inference once it
+    // resolves. Before then the terminal browser fallback is safe.
+    await waitFor(() => {
+      expect(seen[seen.length - 1]?.provider).toBe("local-inference");
+    });
+    expect(ttsReadyMock).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/hooks/useResolvedTtsDefault.ts
+++ b/packages/ui/src/hooks/useResolvedTtsDefault.ts
@@ -1,0 +1,113 @@
+/**
+ * useResolvedTtsDefault — the concrete default TTS provider for the current
+ * device, agent mode, and *live* runtime capabilities.
+ *
+ * `useDefaultProviderPresets` gives the platform/mode preference;
+ * `resolveDefaultTtsProvider` turns it into a provider that can actually run
+ * right now: on-device Kokoro when its engine is staged (probed via
+ * `GET /api/tts/local-inference/status`), else Kokoro through Eliza Cloud when a
+ * voice session exists, else ElevenLabs when a key is configured, else the
+ * browser SpeechSynthesis fallback. Consumed by `useVoiceConfig` (to seed the
+ * default when the user hasn't picked a provider) and by `VoiceConfigView` (to
+ * label which provider the "Device default" resolves to).
+ *
+ * The readiness probe is deferred: the on-device check only fires when the
+ * platform/mode preference is `local-inference` (desktop/mobile-local), so a
+ * web/cloud surface never pays for a probe it wouldn't act on. Until the probe
+ * settles the hook returns the non-on-device answer (cloud → ElevenLabs →
+ * browser), which is always safe — it can only *upgrade* to on-device Kokoro
+ * once the probe confirms a staged voice.
+ */
+
+import { useEffect, useState } from "react";
+import { isLocalInferenceTtsReady } from "../voice/local-tts-status";
+import {
+  type PresetPlatform,
+  type PresetRuntimeMode,
+  resolveDefaultTtsProvider,
+  type VoiceCapabilitySnapshot,
+  type VoiceProvider,
+} from "../voice/voice-provider-defaults";
+import {
+  type UseDefaultProviderPresetsOptions,
+  useDefaultProviderPresets,
+} from "./useDefaultProviderPresets";
+
+export interface UseResolvedTtsDefaultOptions
+  extends UseDefaultProviderPresetsOptions {
+  /** A linked Eliza Cloud session with a working TTS proxy exists. */
+  cloudVoiceAvailable: boolean;
+  /** The user has configured an ElevenLabs API key. */
+  elevenLabsKeyConfigured: boolean;
+  /**
+   * Test-only override for the on-device Kokoro readiness. Production leaves
+   * this undefined and lets the hook probe `/api/tts/local-inference/status`.
+   */
+  localInferenceTtsReadyOverride?: boolean;
+}
+
+export interface UseResolvedTtsDefaultResult {
+  /** The concrete default TTS provider to seed / display. */
+  provider: VoiceProvider;
+  /** Resolved platform that produced the default. */
+  platform: PresetPlatform;
+  /** Resolved runtime mode that produced the default. */
+  runtimeMode: PresetRuntimeMode;
+}
+
+export function useResolvedTtsDefault(
+  options: UseResolvedTtsDefaultOptions,
+): UseResolvedTtsDefaultResult {
+  const {
+    cloudVoiceAvailable,
+    elevenLabsKeyConfigured,
+    localInferenceTtsReadyOverride,
+    ...presetOptions
+  } = options;
+  const { platform, runtimeMode } = useDefaultProviderPresets(presetOptions);
+
+  // Only desktop/mobile-local surfaces can host an on-device voice, so the probe
+  // (and its state) only matters when the platform/mode preference would pick it.
+  const wantsLocalTts =
+    (runtimeMode === "local" || runtimeMode === "local-only") &&
+    (platform === "desktop" || platform === "mobile");
+
+  const [localTtsReady, setLocalTtsReady] = useState<boolean>(
+    localInferenceTtsReadyOverride ?? false,
+  );
+
+  useEffect(() => {
+    if (localInferenceTtsReadyOverride !== undefined) {
+      setLocalTtsReady(localInferenceTtsReadyOverride);
+      return;
+    }
+    if (!wantsLocalTts) {
+      setLocalTtsReady(false);
+      return;
+    }
+    let cancelled = false;
+    const controller = new AbortController();
+    void isLocalInferenceTtsReady({ signal: controller.signal }).then(
+      (ready) => {
+        if (!cancelled) setLocalTtsReady(ready);
+      },
+    );
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [wantsLocalTts, localInferenceTtsReadyOverride]);
+
+  const capabilities: VoiceCapabilitySnapshot = {
+    localInferenceTtsReady: localTtsReady,
+    cloudVoiceAvailable,
+    elevenLabsKeyConfigured,
+  };
+
+  const provider = resolveDefaultTtsProvider(
+    { platform, runtimeMode },
+    capabilities,
+  );
+
+  return { provider, platform, runtimeMode };
+}

--- a/packages/ui/src/voice/character-voice-config.ts
+++ b/packages/ui/src/voice/character-voice-config.ts
@@ -130,14 +130,27 @@ export function resolveCharacterVoiceConfigFromAppConfig(args: {
   };
 }
 
+/**
+ * Seed the platform/runtime provider defaults onto a loaded voice config,
+ * leaving any explicit user choice untouched.
+ *
+ * `resolvedTtsProvider` is the capability-aware default from
+ * `resolveDefaultTtsProvider` (on-device Kokoro when staged, else Eliza Cloud
+ * Kokoro, else ElevenLabs, else browser SpeechSynthesis). When omitted the
+ * platform/mode preference in `defaults.tts` is used directly — the pre-probe
+ * fallback, still a Kokoro transport on every device. The ASR default always
+ * comes from the platform matrix; the interactive-capture engine is chosen
+ * independently in `voice-capture-factory.ts`.
+ */
 export function applyVoiceProviderDefaults(
   config: VoiceConfig | null,
   defaults: DefaultVoiceProviderResult,
+  resolvedTtsProvider?: VoiceConfig["provider"],
 ): VoiceConfig {
   const base = config ?? {};
   return {
     ...base,
-    provider: base.provider ?? defaults.tts,
+    provider: base.provider ?? resolvedTtsProvider ?? defaults.tts,
     asr: base.asr ?? { provider: defaults.asr },
   };
 }

--- a/packages/ui/src/voice/local-tts-status.test.ts
+++ b/packages/ui/src/voice/local-tts-status.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+// Verifies the on-device Kokoro TTS readiness probe: it hits
+// `/api/tts/local-inference/status`, treats `{ ready: true }` as ready, and
+// fails CLOSED (unknown readiness → not ready) on non-2xx, non-JSON, or a
+// thrown fetch. `fetchWithCsrf` + `resolveApiUrl` are stubbed so assertions run
+// against the request the helper builds, not a live server.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchWithCsrf } from "../api/csrf-client";
+import { resolveApiUrl } from "../utils";
+import { isLocalInferenceTtsReady } from "./local-tts-status";
+
+vi.mock("../api/csrf-client", () => ({
+  fetchWithCsrf: vi.fn(),
+}));
+
+vi.mock("../utils", () => ({
+  resolveApiUrl: vi.fn((path: string) => `http://agent.local${path}`),
+}));
+
+const fetchWithCsrfMock = vi.mocked(fetchWithCsrf);
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+afterEach(() => {
+  fetchWithCsrfMock.mockReset();
+  vi.mocked(resolveApiUrl).mockClear();
+});
+
+describe("isLocalInferenceTtsReady", () => {
+  it("probes GET /api/tts/local-inference/status", async () => {
+    fetchWithCsrfMock.mockResolvedValue(
+      jsonResponse({ ready: true, provider: "local-inference" }),
+    );
+    await isLocalInferenceTtsReady();
+    const [url, init] = fetchWithCsrfMock.mock.calls[0] ?? [];
+    expect(url).toBe("http://agent.local/api/tts/local-inference/status");
+    expect((init as RequestInit).method).toBe("GET");
+  });
+
+  it("returns true when the server reports ready", async () => {
+    fetchWithCsrfMock.mockResolvedValue(
+      jsonResponse({ ready: true, provider: "local-inference" }),
+    );
+    await expect(isLocalInferenceTtsReady()).resolves.toBe(true);
+  });
+
+  it("returns false when the server reports not-ready", async () => {
+    fetchWithCsrfMock.mockResolvedValue(
+      jsonResponse({ ready: false, provider: null }),
+    );
+    await expect(isLocalInferenceTtsReady()).resolves.toBe(false);
+  });
+
+  it("fails closed on a non-2xx response", async () => {
+    fetchWithCsrfMock.mockResolvedValue(jsonResponse({}, false, 503));
+    await expect(isLocalInferenceTtsReady()).resolves.toBe(false);
+  });
+
+  it("fails closed on a non-JSON body", async () => {
+    fetchWithCsrfMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new Error("not json");
+      },
+    } as unknown as Response);
+    await expect(isLocalInferenceTtsReady()).resolves.toBe(false);
+  });
+
+  it("fails closed when the fetch throws (server unreachable)", async () => {
+    fetchWithCsrfMock.mockRejectedValue(new Error("network down"));
+    await expect(isLocalInferenceTtsReady()).resolves.toBe(false);
+  });
+
+  it("forwards an abort signal to fetch", async () => {
+    fetchWithCsrfMock.mockResolvedValue(jsonResponse({ ready: true }));
+    const controller = new AbortController();
+    await isLocalInferenceTtsReady({ signal: controller.signal });
+    const [, init] = fetchWithCsrfMock.mock.calls[0] ?? [];
+    expect((init as RequestInit).signal).toBe(controller.signal);
+  });
+});

--- a/packages/ui/src/voice/local-tts-status.ts
+++ b/packages/ui/src/voice/local-tts-status.ts
@@ -1,0 +1,43 @@
+/**
+ * Client probe for on-device Kokoro TTS readiness.
+ *
+ * The TTS default-resolver ({@link resolveDefaultTtsProvider}) prefers the
+ * on-device `local-inference` Kokoro voice, but only when the runtime has a
+ * TEXT_TO_SPEECH handler actually staged. This hits
+ * `GET /api/tts/local-inference/status` (`{ ready, provider }`) — the mirror of
+ * the ASR status probe — so a box with no local voice degrades to Eliza Cloud /
+ * ElevenLabs / browser SpeechSynthesis instead of selecting `local-inference`
+ * and 503-ing on the first utterance.
+ *
+ * Like the ASR probe, a failed/unreachable request deliberately resolves
+ * `false`: "unknown readiness" is treated as "not ready" so a default is never
+ * pinned to a backend we cannot confirm can synthesize.
+ */
+
+import { fetchWithCsrf } from "../api/csrf-client";
+import { resolveApiUrl } from "../utils";
+
+export async function isLocalInferenceTtsReady(options?: {
+  signal?: AbortSignal;
+}): Promise<boolean> {
+  try {
+    const res = await fetchWithCsrf(
+      resolveApiUrl("/api/tts/local-inference/status"),
+      {
+        method: "GET",
+        headers: { Accept: "application/json" },
+        signal: options?.signal,
+      },
+    );
+    if (!res.ok) return false;
+    // error-policy:J3 non-JSON body reads as "not ready"
+    const parsed = (await res.json().catch(() => null)) as {
+      ready?: unknown;
+    } | null;
+    return parsed?.ready === true;
+  } catch {
+    // error-policy:J4 readiness probe — "unknown readiness" reads as "not
+    // ready" (see header) so a default is never pinned to an unconfirmed engine
+    return false;
+  }
+}

--- a/packages/ui/src/voice/useVoiceConfig.ts
+++ b/packages/ui/src/voice/useVoiceConfig.ts
@@ -9,10 +9,13 @@ import { client } from "../api/client";
 import type { VoiceConfig } from "../api/client-types-config";
 import { VOICE_CONFIG_UPDATED_EVENT } from "../events";
 import { useDefaultProviderPresets } from "../hooks/useDefaultProviderPresets";
+import { useResolvedTtsDefault } from "../hooks/useResolvedTtsDefault";
+import { useAppSelector } from "../state";
 import {
   applyVoiceProviderDefaults,
   resolveCharacterVoiceConfigFromAppConfig,
 } from "./character-voice-config";
+import { hasConfiguredApiKey } from "./types";
 
 export interface UseVoiceConfigResult {
   /** Saved voice config with platform/runtime provider defaults applied. Never null. */
@@ -35,6 +38,21 @@ export function useVoiceConfig(uiLanguage: string): UseVoiceConfigResult {
   const [voiceConfig, setVoiceConfig] = React.useState<VoiceConfig | null>(
     null,
   );
+  const cloudVoiceAvailable = useAppSelector(
+    (s) => s.elizaCloudVoiceProxyAvailable,
+  );
+  // ElevenLabs is a default only when the user has actually configured a key —
+  // it is never selected silently (slow + key-gated).
+  const elevenLabsKeyConfigured = hasConfiguredApiKey(
+    voiceConfig?.elevenlabs?.apiKey,
+  );
+  // Capability-aware default: on-device Kokoro when staged, else Eliza Cloud
+  // Kokoro when a session exists, else ElevenLabs (key), else browser TTS. Only
+  // seeds when the user hasn't picked a provider (see applyVoiceProviderDefaults).
+  const { provider: resolvedTtsProvider } = useResolvedTtsDefault({
+    cloudVoiceAvailable,
+    elevenLabsKeyConfigured,
+  });
   const [voiceBootstrapTick, setVoiceBootstrapTick] = React.useState(0);
   const isMountedRef = React.useRef(false);
 
@@ -100,8 +118,13 @@ export function useVoiceConfig(uiLanguage: string): UseVoiceConfigResult {
   }, [loadVoiceConfig]);
 
   const voiceConfigWithDefaults = React.useMemo(
-    () => applyVoiceProviderDefaults(voiceConfig, voiceProviderDefaults),
-    [voiceConfig, voiceProviderDefaults],
+    () =>
+      applyVoiceProviderDefaults(
+        voiceConfig,
+        voiceProviderDefaults,
+        resolvedTtsProvider,
+      ),
+    [voiceConfig, voiceProviderDefaults, resolvedTtsProvider],
   );
 
   const reloadVoiceConfig = React.useCallback(() => {

--- a/packages/ui/src/voice/voice-capture-factory.test.ts
+++ b/packages/ui/src/voice/voice-capture-factory.test.ts
@@ -205,6 +205,38 @@ describe("createVoiceCapture", () => {
     });
   });
 
+  it("prefers native TalkMode over an explicit local-inference preference on native mobile", async () => {
+    // The on-device Kokoro/ASR default resolves ASR to `local-inference` on
+    // desktop, but on native mobile the local-inference ASR assets are not
+    // staged — the readiness probe can report ready and then 502 at stop() with
+    // no recoverable fallback. So on a native platform the OS recognizer
+    // (TalkMode) must win ahead of the probe even when the caller passes
+    // `asrProvider: "local-inference"`.
+    isNativePlatformMock.mockReturnValue(true);
+    isLocalInferenceAsrReadyMock.mockResolvedValue(true);
+    const talkMode = makeFakeTalkMode();
+    getTalkModePluginMock.mockReturnValue(talkMode as never);
+    const onTranscript = vi.fn();
+
+    const capture = createVoiceCapture({
+      onTranscript,
+      asrProvider: "local-inference",
+    });
+    await capture.start();
+
+    expect(talkMode.start).toHaveBeenCalledTimes(1);
+    expect(startLocalAsrRecorderMock).not.toHaveBeenCalled();
+    // The native path is chosen ahead of the local-inference readiness probe.
+    expect(isLocalInferenceAsrReadyMock).not.toHaveBeenCalled();
+
+    talkMode.emit("transcript", { transcript: "hello", isFinal: true });
+    expect(onTranscript).toHaveBeenLastCalledWith({
+      text: "hello",
+      final: true,
+      backend: "talkmode",
+    });
+  });
+
   it("finalizeOnStop commits the running interim as the final turn (push-to-talk)", async () => {
     isNativePlatformMock.mockReturnValue(true);
     const talkMode = makeFakeTalkMode();

--- a/packages/ui/src/voice/voice-provider-defaults.test.ts
+++ b/packages/ui/src/voice/voice-provider-defaults.test.ts
@@ -4,10 +4,20 @@
  */
 import { describe, expect, it } from "vitest";
 import {
+  BROWSER_TTS_PROVIDER,
   type PresetPlatform,
   type PresetRuntimeMode,
   pickDefaultVoiceProvider,
+  resolveDefaultTtsProvider,
+  type VoiceCapabilitySnapshot,
 } from "./voice-provider-defaults";
+
+/** No backend can run — the terminal (browser SpeechSynthesis) case. */
+const NO_CAPABILITIES: VoiceCapabilitySnapshot = {
+  localInferenceTtsReady: false,
+  cloudVoiceAvailable: false,
+  elevenLabsKeyConfigured: false,
+};
 
 describe("pickDefaultVoiceProvider", () => {
   it("desktop + local-only agent uses on-device OmniVoice + Gemma ASR", () => {
@@ -91,6 +101,192 @@ describe("pickDefaultVoiceProvider", () => {
         const result = pickDefaultVoiceProvider({ platform, runtimeMode });
         expect(typeof result.tts).toBe("string");
         expect(typeof result.asr).toBe("string");
+      }
+    }
+  });
+});
+
+describe("resolveDefaultTtsProvider — capability-aware default chain", () => {
+  it("desktop-local prefers on-device Kokoro when the engine is staged", () => {
+    expect(
+      resolveDefaultTtsProvider(
+        { platform: "desktop", runtimeMode: "local" },
+        {
+          localInferenceTtsReady: true,
+          cloudVoiceAvailable: true,
+          elevenLabsKeyConfigured: true,
+        },
+      ),
+    ).toBe("local-inference");
+  });
+
+  it("desktop-local falls to Eliza Cloud Kokoro when the on-device engine is NOT staged", () => {
+    expect(
+      resolveDefaultTtsProvider(
+        { platform: "desktop", runtimeMode: "local" },
+        {
+          localInferenceTtsReady: false,
+          cloudVoiceAvailable: true,
+          elevenLabsKeyConfigured: true,
+        },
+      ),
+    ).toBe("eliza-cloud");
+  });
+
+  it("mobile-local prefers on-device Kokoro when staged (native TalkMode carries it in practice)", () => {
+    expect(
+      resolveDefaultTtsProvider(
+        { platform: "mobile", runtimeMode: "local-only" },
+        {
+          localInferenceTtsReady: true,
+          cloudVoiceAvailable: false,
+          elevenLabsKeyConfigured: false,
+        },
+      ),
+    ).toBe("local-inference");
+  });
+
+  it("web/cloud uses Eliza Cloud Kokoro when a cloud session exists", () => {
+    for (const platform of ["web", "desktop", "mobile"] as PresetPlatform[]) {
+      expect(
+        resolveDefaultTtsProvider(
+          { platform, runtimeMode: "cloud" },
+          {
+            localInferenceTtsReady: false,
+            cloudVoiceAvailable: true,
+            elevenLabsKeyConfigured: true,
+          },
+        ),
+      ).toBe("eliza-cloud");
+    }
+  });
+
+  it("prefers a staged on-device Kokoro over ElevenLabs even when the platform preferred cloud but no session exists", () => {
+    // web/cloud preference is eliza-cloud, but there is no cloud session — a
+    // locally-staged voice still beats the key-gated remote one.
+    expect(
+      resolveDefaultTtsProvider(
+        { platform: "web", runtimeMode: "cloud" },
+        {
+          localInferenceTtsReady: true,
+          cloudVoiceAvailable: false,
+          elevenLabsKeyConfigured: true,
+        },
+      ),
+    ).toBe("local-inference");
+  });
+
+  it("uses ElevenLabs only when a key is configured and no Kokoro transport is available", () => {
+    expect(
+      resolveDefaultTtsProvider(
+        { platform: "web", runtimeMode: "cloud" },
+        {
+          localInferenceTtsReady: false,
+          cloudVoiceAvailable: false,
+          elevenLabsKeyConfigured: true,
+        },
+      ),
+    ).toBe("elevenlabs");
+  });
+
+  it("never selects ElevenLabs without a configured key", () => {
+    expect(
+      resolveDefaultTtsProvider(
+        { platform: "web", runtimeMode: "cloud" },
+        {
+          localInferenceTtsReady: false,
+          cloudVoiceAvailable: false,
+          elevenLabsKeyConfigured: false,
+        },
+      ),
+    ).not.toBe("elevenlabs");
+  });
+
+  it("terminates at browser SpeechSynthesis when nothing else can run", () => {
+    const platforms: PresetPlatform[] = ["desktop", "mobile", "web"];
+    const modes: PresetRuntimeMode[] = [
+      "local",
+      "local-only",
+      "cloud",
+      "remote",
+    ];
+    for (const platform of platforms) {
+      for (const runtimeMode of modes) {
+        expect(
+          resolveDefaultTtsProvider({ platform, runtimeMode }, NO_CAPABILITIES),
+        ).toBe(BROWSER_TTS_PROVIDER);
+      }
+    }
+  });
+
+  it("resolves to a runnable provider for every capability combination", () => {
+    const platforms: PresetPlatform[] = ["desktop", "mobile", "web"];
+    const modes: PresetRuntimeMode[] = [
+      "local",
+      "local-only",
+      "cloud",
+      "remote",
+    ];
+    const bools = [false, true];
+    for (const platform of platforms) {
+      for (const runtimeMode of modes) {
+        for (const localInferenceTtsReady of bools) {
+          for (const cloudVoiceAvailable of bools) {
+            for (const elevenLabsKeyConfigured of bools) {
+              const provider = resolveDefaultTtsProvider(
+                { platform, runtimeMode },
+                {
+                  localInferenceTtsReady,
+                  cloudVoiceAvailable,
+                  elevenLabsKeyConfigured,
+                },
+              );
+              // The resolved provider must correspond to a capability that is
+              // actually present — never a backend that would fail on the first
+              // utterance. Browser TTS is always runnable in a renderer.
+              if (provider === "local-inference") {
+                expect(localInferenceTtsReady).toBe(true);
+              } else if (provider === "eliza-cloud") {
+                expect(cloudVoiceAvailable).toBe(true);
+              } else if (provider === "elevenlabs") {
+                expect(elevenLabsKeyConfigured).toBe(true);
+              } else {
+                expect(provider).toBe(BROWSER_TTS_PROVIDER);
+              }
+            }
+          }
+        }
+      }
+    }
+  });
+
+  it("the chain strictly prefers Kokoro (either transport) over ElevenLabs", () => {
+    // Whenever ANY Kokoro transport is available and a key is also configured,
+    // ElevenLabs must not win — Kokoro is the default, ElevenLabs is opt-in.
+    const kokoroCapable: VoiceCapabilitySnapshot[] = [
+      {
+        localInferenceTtsReady: true,
+        cloudVoiceAvailable: false,
+        elevenLabsKeyConfigured: true,
+      },
+      {
+        localInferenceTtsReady: false,
+        cloudVoiceAvailable: true,
+        elevenLabsKeyConfigured: true,
+      },
+    ];
+    for (const caps of kokoroCapable) {
+      for (const platform of ["desktop", "mobile", "web"] as PresetPlatform[]) {
+        for (const runtimeMode of [
+          "local",
+          "local-only",
+          "cloud",
+          "remote",
+        ] as PresetRuntimeMode[]) {
+          expect(
+            resolveDefaultTtsProvider({ platform, runtimeMode }, caps),
+          ).not.toBe("elevenlabs");
+        }
       }
     }
   });

--- a/packages/ui/src/voice/voice-provider-defaults.ts
+++ b/packages/ui/src/voice/voice-provider-defaults.ts
@@ -45,9 +45,18 @@
  * so interactive `eliza-cloud` ASR is the real cloud transcriber. Browser
  * SpeechRecognition is used only when WAV capture is unsupported (no
  * `getUserMedia`/`AudioContext`).
+ *
+ * `pickDefaultVoiceProvider` gives the platform/mode *preference*.
+ * `resolveDefaultTtsProvider` (below) turns that preference into a concrete
+ * provider against the runtime's actual capabilities — Kokoro on-device when
+ * staged, else Kokoro via Eliza Cloud when a session exists, else ElevenLabs
+ * (key-gated), else browser SpeechSynthesis — so a default is never pinned to a
+ * backend that will fail on the first utterance.
  */
 
 import type { AsrProvider, VoiceProvider } from "../api/client-types-config";
+
+export type { VoiceProvider } from "../api/client-types-config";
 
 export type PresetPlatform = "desktop" | "mobile" | "web";
 
@@ -97,4 +106,87 @@ export function pickDefaultVoiceProvider(
   // Web shell hosting a local agent: no on-device audio runtime, so use the
   // measured free cloud Kokoro path for TTS and Eliza Cloud for ASR.
   return { tts: "eliza-cloud", asr: "eliza-cloud" };
+}
+
+/**
+ * Runtime capabilities observed at resolution time. `pickDefaultVoiceProvider`
+ * expresses the *preferred* Kokoro path per platform/mode; this fills in whether
+ * that path can actually run right now, so the default can fall through instead
+ * of pinning a backend that will 503/401 on the first utterance.
+ */
+export interface VoiceCapabilitySnapshot {
+  /** `GET /api/tts/local-inference/status` reported a staged on-device voice. */
+  localInferenceTtsReady: boolean;
+  /** A linked Eliza Cloud session with a working TTS proxy exists. */
+  cloudVoiceAvailable: boolean;
+  /** The user has configured an ElevenLabs API key. */
+  elevenLabsKeyConfigured: boolean;
+}
+
+/**
+ * The terminal browser-SpeechSynthesis fallback. `robot-voice` is not one of
+ * the three server-backed engines the TTS queue dispatches (eliza-cloud /
+ * local-inference / elevenlabs), so `useVoiceChat`'s processQueue routes it to
+ * `speakBrowser` — i.e. it *is* the "speak with the OS voice" provider value.
+ */
+export const BROWSER_TTS_PROVIDER: VoiceProvider = "robot-voice";
+
+/**
+ * Resolve the concrete default TTS provider given the platform/mode preference
+ * and what the runtime can actually do right now. This is the "no explicit user
+ * choice" chain the product wants for bidirectional voice:
+ *
+ *   Kokoro on-device (`local-inference`, when its engine is staged)
+ *     → Kokoro via Eliza Cloud (`eliza-cloud`, when a cloud session exists)
+ *     → ElevenLabs (`elevenlabs`, only if a key is configured)
+ *     → browser SpeechSynthesis ({@link BROWSER_TTS_PROVIDER}).
+ *
+ * The preferred entry point (from {@link pickDefaultVoiceProvider}) only orders
+ * the two Kokoro transports for this platform — on desktop/mobile-local the
+ * on-device path is tried first; on web/cloud the cloud path is. Whatever the
+ * preference, an unavailable backend is skipped, never selected-then-failed.
+ * ElevenLabs is deliberately last and key-gated: it is slow and never a silent
+ * default. There is always a terminal answer (browser TTS), so this never
+ * returns a provider that cannot run.
+ *
+ * Native mobile is not modeled here: `useVoiceChat` unconditionally routes the
+ * reply through the native TalkMode engine (on-device Kokoro) on a Capacitor
+ * platform, ahead of this web dispatch, so the on-device voice is used there
+ * regardless of the resolved provider value.
+ */
+export function resolveDefaultTtsProvider(
+  input: PickDefaultVoiceProviderInput,
+  capabilities: VoiceCapabilitySnapshot,
+): VoiceProvider {
+  const preferred = pickDefaultVoiceProvider(input).tts;
+
+  // On-device Kokoro first when the platform/mode preference chose it AND the
+  // engine is actually staged. A desktop/mobile-local box whose voice bundle
+  // isn't downloaded yet skips this and falls to the cloud path below.
+  if (preferred === "local-inference" && capabilities.localInferenceTtsReady) {
+    return "local-inference";
+  }
+
+  // Eliza Cloud Kokoro when a linked cloud session with a working TTS proxy
+  // exists. This is the default on web/cloud, and the fallback when on-device
+  // Kokoro isn't staged.
+  if (capabilities.cloudVoiceAvailable) {
+    return "eliza-cloud";
+  }
+
+  // On-device Kokoro is still preferable to ElevenLabs/browser even when the
+  // platform preferred the cloud path but no cloud session is available — a
+  // staged local voice beats a key-gated remote one.
+  if (capabilities.localInferenceTtsReady) {
+    return "local-inference";
+  }
+
+  // ElevenLabs only with a configured key. Never a silent default (slow + gated)
+  // — reached only when no Kokoro transport is available.
+  if (capabilities.elevenLabsKeyConfigured) {
+    return "elevenlabs";
+  }
+
+  // Terminal: the OS SpeechSynthesis voice always exists in a browser renderer.
+  return BROWSER_TTS_PROVIDER;
 }

--- a/plugins/plugin-local-inference/src/routes/local-inference-tts-route.test.ts
+++ b/plugins/plugin-local-inference/src/routes/local-inference-tts-route.test.ts
@@ -163,10 +163,8 @@ describe("local inference TTS route", () => {
 	});
 
 	it("status reports ready when a TEXT_TO_SPEECH handler is registered", async () => {
-		const getModel = vi.fn((type: string, provider?: string) =>
-			type === ModelType.TEXT_TO_SPEECH && provider === "eliza-local-inference"
-				? () => new Uint8Array()
-				: undefined,
+		const getModel = vi.fn((type: string) =>
+			type === ModelType.TEXT_TO_SPEECH ? () => new Uint8Array() : undefined,
 		);
 		const state: CompatRuntimeState = {
 			current: { getModel } as unknown as CompatRuntimeState["current"],

--- a/plugins/plugin-local-inference/src/routes/local-inference-tts-route.test.ts
+++ b/plugins/plugin-local-inference/src/routes/local-inference-tts-route.test.ts
@@ -6,6 +6,7 @@
 
 import * as http from "node:http";
 import { Socket } from "node:net";
+import { ModelType } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import type { CompatRuntimeState } from "./compat-helpers";
 import {
@@ -32,6 +33,18 @@ function fakeReq(body?: unknown): http.IncomingMessage {
 	if (body !== undefined) {
 		(req as { body?: unknown }).body = body;
 	}
+	return req;
+}
+
+function fakeStatusReq(): http.IncomingMessage {
+	const req = new http.IncomingMessage(new Socket());
+	req.method = "GET";
+	req.url = "/api/tts/local-inference/status";
+	req.headers = { host: "localhost:2138" };
+	Object.defineProperty(req.socket, "remoteAddress", {
+		value: "127.0.0.1",
+		configurable: true,
+	});
 	return req;
 }
 
@@ -146,6 +159,69 @@ describe("local inference TTS route", () => {
 			speed: 1.15,
 			sampleRate: 24_000,
 			format: "wav",
+		});
+	});
+
+	it("status reports ready when a TEXT_TO_SPEECH handler is registered", async () => {
+		const getModel = vi.fn((type: string, provider?: string) =>
+			type === ModelType.TEXT_TO_SPEECH && provider === "eliza-local-inference"
+				? () => new Uint8Array()
+				: undefined,
+		);
+		const state: CompatRuntimeState = {
+			current: { getModel } as unknown as CompatRuntimeState["current"],
+		};
+		const out = fakeRes();
+
+		const handled = await handleLocalInferenceTtsRoute(
+			fakeStatusReq(),
+			out.res,
+			state,
+		);
+
+		expect(handled).toBe(true);
+		expect(out.status()).toBe(200);
+		expect(JSON.parse(out.bodyBuffer().toString())).toEqual({
+			ready: true,
+			provider: "local-inference",
+		});
+	});
+
+	it("status reports not-ready when no TEXT_TO_SPEECH handler exists", async () => {
+		const getModel = vi.fn(() => undefined);
+		const state: CompatRuntimeState = {
+			current: { getModel } as unknown as CompatRuntimeState["current"],
+		};
+		const out = fakeRes();
+
+		const handled = await handleLocalInferenceTtsRoute(
+			fakeStatusReq(),
+			out.res,
+			state,
+		);
+
+		expect(handled).toBe(true);
+		expect(out.status()).toBe(200);
+		expect(JSON.parse(out.bodyBuffer().toString())).toEqual({
+			ready: false,
+			provider: null,
+		});
+	});
+
+	it("status reports not-ready when the runtime is absent", async () => {
+		const state: CompatRuntimeState = { current: null };
+		const out = fakeRes();
+
+		const handled = await handleLocalInferenceTtsRoute(
+			fakeStatusReq(),
+			out.res,
+			state,
+		);
+
+		expect(handled).toBe(true);
+		expect(JSON.parse(out.bodyBuffer().toString())).toEqual({
+			ready: false,
+			provider: null,
 		});
 	});
 

--- a/plugins/plugin-local-inference/src/routes/local-inference-tts-route.ts
+++ b/plugins/plugin-local-inference/src/routes/local-inference-tts-route.ts
@@ -141,23 +141,20 @@ function isClosed(res: http.ServerResponse): boolean {
 }
 
 /**
- * True when the runtime has a TEXT_TO_SPEECH handler registered under one of
- * the on-device provider ids the POST path drives (`useLocalInferenceTts`).
+ * True when the runtime has a TEXT_TO_SPEECH handler registered — the same
+ * signal the ASR status route uses for TRANSCRIPTION. The POST path
+ * (`useLocalInferenceTts`) then resolves the concrete on-device provider from
+ * `LOCAL_TTS_PROVIDER_IDS`; readiness only needs to know a synthesizer exists.
  * The client TTS default-resolver probes this so a box without a staged Kokoro
  * voice degrades to Eliza Cloud / ElevenLabs / browser SpeechSynthesis instead
  * of picking `local-inference` and 503-ing on the first utterance.
  */
 function hasLocalInferenceTtsHandler(state: CompatRuntimeState): boolean {
-	const runtime = state.current;
-	const getModel = runtime?.getModel;
-	if (typeof getModel !== "function") return false;
-	for (const provider of LOCAL_TTS_PROVIDER_IDS) {
-		if (getModel.call(runtime, ModelType.TEXT_TO_SPEECH, provider)) {
-			return true;
-		}
-	}
-	// A provider-less lookup covers a handler registered without an explicit id.
-	return Boolean(getModel.call(runtime, ModelType.TEXT_TO_SPEECH));
+	const getModel = state.current?.getModel;
+	return (
+		typeof getModel === "function" &&
+		Boolean(getModel.call(state.current, ModelType.TEXT_TO_SPEECH))
+	);
 }
 
 export async function handleLocalInferenceTtsRoute(

--- a/plugins/plugin-local-inference/src/routes/local-inference-tts-route.ts
+++ b/plugins/plugin-local-inference/src/routes/local-inference-tts-route.ts
@@ -140,6 +140,26 @@ function isClosed(res: http.ServerResponse): boolean {
 	return res.destroyed || res.writableEnded;
 }
 
+/**
+ * True when the runtime has a TEXT_TO_SPEECH handler registered under one of
+ * the on-device provider ids the POST path drives (`useLocalInferenceTts`).
+ * The client TTS default-resolver probes this so a box without a staged Kokoro
+ * voice degrades to Eliza Cloud / ElevenLabs / browser SpeechSynthesis instead
+ * of picking `local-inference` and 503-ing on the first utterance.
+ */
+function hasLocalInferenceTtsHandler(state: CompatRuntimeState): boolean {
+	const runtime = state.current;
+	const getModel = runtime?.getModel;
+	if (typeof getModel !== "function") return false;
+	for (const provider of LOCAL_TTS_PROVIDER_IDS) {
+		if (getModel.call(runtime, ModelType.TEXT_TO_SPEECH, provider)) {
+			return true;
+		}
+	}
+	// A provider-less lookup covers a handler registered without an explicit id.
+	return Boolean(getModel.call(runtime, ModelType.TEXT_TO_SPEECH));
+}
+
 export async function handleLocalInferenceTtsRoute(
 	req: http.IncomingMessage,
 	res: http.ServerResponse,
@@ -147,6 +167,15 @@ export async function handleLocalInferenceTtsRoute(
 ): Promise<boolean> {
 	const method = req.method?.toUpperCase() ?? "GET";
 	const url = new URL(req.url ?? "/", "http://localhost");
+	if (method === "GET" && url.pathname === "/api/tts/local-inference/status") {
+		if (!(await ensureRouteAuthorized(req, res, state))) return true;
+		const ready = hasLocalInferenceTtsHandler(state);
+		sendJson(res, 200, {
+			ready,
+			provider: ready ? "local-inference" : null,
+		});
+		return true;
+	}
 	if (method !== "POST" || url.pathname !== "/api/tts/local-inference") {
 		return false;
 	}


### PR DESCRIPTION
## Bidirectional voice: Kokoro as the default TTS + native STT preference

Makes **Kokoro the default TTS when no explicit provider is configured**, and locks the **native OS speech recognizer as the preferred STT on iOS/Android**. Explicit ElevenLabs users are untouched.

### TTS — capability-aware default chain

Previously the default TTS provider was a fixed platform/runtime-mode guess (`pickDefaultVoiceProvider`). If the picked default couldn't actually run — desktop-local with no staged Kokoro voice, or web/cloud with no cloud session — it would 503/401 and fail closed to silence. Now the default resolves against **what the runtime can actually do right now**:

```
explicit user choice (always wins)
  -> Kokoro on-device (local-inference, when its engine is staged)
  -> Kokoro via Eliza Cloud (eliza-cloud, when a voice session exists)
  -> ElevenLabs (only when a key is configured — never a silent default)
  -> browser SpeechSynthesis (terminal fallback)
```

- **`resolveDefaultTtsProvider`** (`packages/ui/src/voice/voice-provider-defaults.ts`) — pure resolver over the platform preference + a `VoiceCapabilitySnapshot`; always returns a runnable provider.
- **`useResolvedTtsDefault`** (`packages/ui/src/hooks/useResolvedTtsDefault.ts`) — React wrapper. Probes on-device readiness (`GET /api/tts/local-inference/status`) only on desktop/mobile-local; upgrades to on-device Kokoro once confirmed. Never pins a backend it can't confirm.
- **`GET /api/tts/local-inference/status`** (`plugins/plugin-local-inference/src/routes/local-inference-tts-route.ts`) — new readiness probe mirroring the ASR one. `{ ready, provider }`; `ready` iff a TEXT_TO_SPEECH handler is registered. A failing/unreachable probe reads as **not ready** (fail-closed), so the default falls through explicitly.
- **`useVoiceConfig`** seeds the resolved provider (recomputed every load, **never persisted** — an explicit choice always wins). **`VoiceConfigView`** surfaces the resolved "Device default: Kokoro (…)" and keeps the picker fully switchable.
- Agent-server + lazy-route path gates for `/api/tts/local-inference` widened to `startsWith` so the `/status` subpath reaches the handler (matches the ASR gate).

No silent fabrication: a failing backend still surfaces the existing observable `ttsError` and fail-closed behavior (#12253) — this change only affects which provider is chosen *by default*, not error handling of an explicitly-chosen one.

### STT — native OS recognizer preferred on iOS/Android

Investigated the TalkMode Capacitor plugin: the iOS `TalkModePlugin.swift` **already implements the full SFSpeechRecognizer path** (`startRecognition` -> `AVAudioEngine` tap -> `recognitionTask` with partial results -> `handleTranscript`/`finalizeTranscript` emitting the `transcript` event with `isFinal`, plus silence monitoring + permission handling), and Android has `ElizaVoiceNative`. The hook-free `voice-capture-factory` already prefers native TalkMode on **both** platforms ahead of the local-inference probe. This PR adds a test that **locks that preference** for the exact failure mode the arch notes flag (on mobile the local-inference ASR assets aren't staged; the probe can report ready then 502 at `stop()` with no fallback — so TalkMode must win even when `asrProvider: "local-inference"` is explicitly requested).

### Evidence

| Evidence | Status |
| --- | --- |
| Deterministic tests (provider-order matrix + error path) | see below |
| iOS TalkMode Swift bridge-contract tests | `swift test` passes on this host (3/3) |
| Real-LLM trajectories | N/A — no agent/action/prompt/model change; client provider-selection + a readiness route |
| Full iOS TalkModePlugin build (SFSpeechRecognizer + Capacitor) | N/A in this shell — needs `xcodebuild` in the iOS app; command below |
| Frontend video / before-after screenshots | N/A in this shell — no browser/simulator; the settings "Device default" label + picker are covered by `VoiceConfigView.test.tsx` |
| Backend logs / domain artifacts | N/A — TTS status route is unit-covered; no new agent-side side effects |

<details>
<summary>Deterministic test output</summary>

```
# packages/ui — resolver + probe + hook
src/voice/voice-provider-defaults.test.ts .... 18 passed  (pickDefaultVoiceProvider + resolveDefaultTtsProvider full matrix)
src/hooks/useResolvedTtsDefault.test.tsx .....  8 passed  (per-platform chain, probe gating, async upgrade)
src/voice/local-tts-status.test.ts ..........  7 passed  (probe GET, ready/not-ready, fail-closed non-2xx/non-JSON/throw)
Tests  33 passed (33)

# packages/ui — STT preference + regression (explicit ElevenLabs untouched)
src/voice/voice-capture-factory.test.ts ..... 13 passed  (native TalkMode over explicit local-inference)
src/hooks/useVoiceChat.fail-closed.test.tsx ..  passed   (explicit-provider fail-closed intact)
src/hooks/useVoiceChat.bidirectional.test.tsx   passed
src/components/settings/VoiceConfigView.test.tsx passed  (resolved device-default label + switchable picker)
src/components/shell/useShellVoiceOutput.test.tsx 11 passed

# plugins/plugin-local-inference — new /status endpoint
src/routes/local-inference-tts-route.test.ts .  7 passed  (status ready / not-ready / no-runtime + existing POST path)

# iOS TalkMode Swift bridge contract (SFSpeechRecognizer transcript payload)
plugins/plugin-native-talkmode/ios $ swift test
  Executed 3 tests, with 0 failures  (transcript {transcript,isFinal} payload, barge-in interrupt, state/permission payloads)

# repo-root gate
bun run audit:error-policy-ratchet -> no new fallback-slop in touched files
```
</details>

**Human must run for full iOS on-device proof:**
```bash
# Build the full TalkModePlugin (SFSpeechRecognizer + Capacitor) into the iOS app, then run on a simulator/device:
bun run --cwd packages/app build:ios && \
  xcodebuild -workspace packages/app-core/platforms/ios/App/App.xcworkspace \
    -scheme App -destination 'platform=iOS Simulator,name=iPhone 16' build
# then capture: bun run --cwd packages/app capture:ios-sim  (speak -> confirm native SFSpeechRecognizer transcript + Kokoro TTS playback)
```

Pre-existing unrelated failure (NOT this branch): `local-inference-route-contracts.fuzz.test.ts` line 555 asserts the ASR response has no `aec` field, but the ASR route on develop always returns one. Flagged as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
