### PR TITLE
fix(settings): derive non-catalog audit from metadata

### DIFF
--- a/packages/ui/src/components/settings/settings-section-meta.ts
+++ b/packages/ui/src/components/settings/settings-section-meta.ts
@@ -29,6 +29,16 @@ export interface SettingsSectionMeta {
   aliases?: readonly string[];
 }
 
+export interface SettingsNonCatalogSectionMeta {
+  /** Stable id — also the URL hash and agent-surface address. */
+  id: string;
+  /** English display label (the i18n default value). */
+  defaultLabel: string;
+  /** Group may include host-registered groups outside the pinned catalog. */
+  group: SettingsSectionGroup | (string & {});
+  aliases?: readonly string[];
+}
+
 export const SETTINGS_GROUP_ORDER: SettingsSectionGroup[] = [
   "agent",
   "system",
@@ -129,3 +139,26 @@ export const SETTINGS_SECTION_META: SettingsSectionMeta[] = [
   { id: "app-permissions", defaultLabel: "App Permissions", group: "security" },
   { id: "security", defaultLabel: "Security", group: "security" },
 ];
+
+/**
+ * Built-in settings sections that intentionally stay out of the app-core route
+ * catalog but still register in Settings. Action-side audits consume this list
+ * so chat-write coverage for late-registered sections cannot drift silently.
+ */
+export const SETTINGS_NON_CATALOG_SECTION_META = [
+  {
+    id: "cloud-overview",
+    defaultLabel: "Overview",
+    group: "cloud",
+  },
+  {
+    id: "cloud-agents",
+    defaultLabel: "Agents",
+    group: "cloud",
+  },
+  {
+    id: "my-runtimes",
+    defaultLabel: "My Runtimes",
+    group: "system",
+  },
+] as const satisfies readonly SettingsNonCatalogSectionMeta[];

--- a/packages/ui/src/components/settings/settings-sections.ts
+++ b/packages/ui/src/components/settings/settings-sections.ts
@@ -40,6 +40,7 @@ import {
 import {
   SETTINGS_GROUP_LABEL,
   SETTINGS_GROUP_ORDER,
+  SETTINGS_NON_CATALOG_SECTION_META,
   SETTINGS_SECTION_META,
   type SettingsSectionGroup,
 } from "./settings-section-meta";
@@ -250,6 +251,18 @@ interface BuiltinSectionDefinition {
    */
   catalog?: boolean;
   Component: ComponentType | LazyExoticComponent<ComponentType>;
+}
+
+const NON_CATALOG_META_BY_ID = new Map(
+  SETTINGS_NON_CATALOG_SECTION_META.map((meta) => [meta.id, meta]),
+);
+
+function nonCatalogMeta(id: string) {
+  const meta = NON_CATALOG_META_BY_ID.get(id);
+  if (!meta) {
+    throw new Error(`Unknown non-catalog settings section "${id}"`);
+  }
+  return meta;
 }
 
 /**
@@ -467,9 +480,7 @@ const BUILTIN_SECTION_DEFINITIONS: readonly BuiltinSectionDefinition[] = [
   // built-in QA route catalog.
   // ---------------------------------------------------------------------------
   {
-    id: "cloud-overview",
-    defaultLabel: "Overview",
-    group: CLOUD_SETTINGS_GROUP_ID,
+    ...nonCatalogMeta("cloud-overview"),
     catalog: false,
     icon: Cloud,
     tone: "accent",
@@ -485,9 +496,7 @@ const BUILTIN_SECTION_DEFINITIONS: readonly BuiltinSectionDefinition[] = [
   // overview, while full Cloud-only account/billing/API surfaces remain opt-in
   // through registerCloudSettingsSections().
   {
-    id: "cloud-agents",
-    defaultLabel: "Agents",
-    group: CLOUD_SETTINGS_GROUP_ID,
+    ...nonCatalogMeta("cloud-agents"),
     catalog: false,
     icon: Bot,
     tone: "accent",
@@ -501,9 +510,7 @@ const BUILTIN_SECTION_DEFINITIONS: readonly BuiltinSectionDefinition[] = [
   // "My Runtimes" — manage + switch between local / cloud-dedicated /
   // VPS-remote runtimes (the cockpit's runtime registry).
   {
-    id: "my-runtimes",
-    defaultLabel: "My Runtimes",
-    group: "system",
+    ...nonCatalogMeta("my-runtimes"),
     catalog: false,
     icon: Server,
     tone: "neutral",

--- a/plugins/plugin-app-control/src/actions/settings.test.ts
+++ b/plugins/plugin-app-control/src/actions/settings.test.ts
@@ -7,7 +7,10 @@
  */
 
 import type { HandlerCallback, IAgentRuntime, Memory } from "@elizaos/core";
-import { SETTINGS_SECTION_META } from "@elizaos/ui/components/settings/settings-section-meta";
+import {
+	SETTINGS_NON_CATALOG_SECTION_META,
+	SETTINGS_SECTION_META,
+} from "@elizaos/ui/components/settings/settings-section-meta";
 import { describe, expect, it, vi } from "vitest";
 import {
 	createSettingsAction,
@@ -189,11 +192,12 @@ describe("registry completeness", () => {
 	});
 
 	it("pins audit records for non-catalog settings sections", () => {
-		expect(Object.keys(SETTINGS_NON_CATALOG_SECTION_AUDIT).sort()).toEqual([
-			"cloud-agents",
-			"cloud-overview",
-			"my-runtimes",
-		]);
+		const nonCatalogIds = SETTINGS_NON_CATALOG_SECTION_META.map(
+			(meta) => meta.id,
+		).sort();
+		expect(Object.keys(SETTINGS_NON_CATALOG_SECTION_AUDIT).sort()).toEqual(
+			nonCatalogIds,
+		);
 		for (const [id, entry] of Object.entries(
 			SETTINGS_NON_CATALOG_SECTION_AUDIT,
 		)) {

--- a/plugins/plugin-app-control/src/actions/settings.ts
+++ b/plugins/plugin-app-control/src/actions/settings.ts
@@ -35,7 +35,10 @@ import {
 	isPermissionId,
 	type PermissionId,
 } from "@elizaos/shared";
-import { SETTINGS_SECTION_META } from "@elizaos/ui/components/settings/settings-section-meta";
+import {
+	type SETTINGS_NON_CATALOG_SECTION_META,
+	SETTINGS_SECTION_META,
+} from "@elizaos/ui/components/settings/settings-section-meta";
 import { normalizeActionOptions, readStringOption } from "../params.js";
 
 /** The three verbs SETTINGS understands. */
@@ -136,9 +139,7 @@ export interface SettingsNonCatalogAuditEntry {
 	trackingIssue?: number;
 }
 
-export const SETTINGS_NON_CATALOG_SECTION_AUDIT: Readonly<
-	Record<string, SettingsNonCatalogAuditEntry>
-> = {
+export const SETTINGS_NON_CATALOG_SECTION_AUDIT = {
 	"cloud-overview": {
 		reason:
 			"Cloud upsell/account overview is a late-registered non-catalog page, not a local setting value.",
@@ -156,7 +157,12 @@ export const SETTINGS_NON_CATALOG_SECTION_AUDIT: Readonly<
 		coveredBy:
 			"MODEL_SWITCH for inference target changes; runtime CRUD needs a separate runtime-management action if chat-write is required.",
 	},
-};
+} satisfies Readonly<
+	Record<
+		(typeof SETTINGS_NON_CATALOG_SECTION_META)[number]["id"],
+		SettingsNonCatalogAuditEntry
+	>
+>;
 
 const PERMISSIONS_SHELL_KEY: SettingsWritableKey = {
 	description:


### PR DESCRIPTION
## Summary
- move the built-in non-catalog Settings sections into pure settings-section-meta data so non-renderer audits can derive the canonical ids without importing the React registry
- have the Settings React registry consume that same metadata for cloud-overview, cloud-agents, and my-runtimes
- type and test SETTINGS_NON_CATALOG_SECTION_AUDIT against the canonical non-catalog metadata so future catalog:false sections fail until they carry an audit disposition

Follow-up to #14913.

## Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - metadata/audit invariant only; no rendered UI appearance changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - metadata/audit invariant only; no rendered UI appearance changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing workflow changed; focused tests verify registration and audit derivation.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend service was started; local test output below exercises the action-side audit.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no browser/runtime flow changed; UI registry verification ran as a component-level registration test.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt/model/action routing behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no external domain artifact is produced; the durable artifact is the source-of-truth metadata and audit invariant.

## Verification
- bun run --cwd plugins/plugin-app-control test src/actions/settings.test.ts: 57 passed after building the upstream @elizaos/cloud-routing package entry with bun run --cwd packages/cloud/routing build.
- bun run --cwd packages/ui test -- src/components/settings/settings-sections.registration.test.ts: 12 passed. Initial run exposed missing installed react-router-dom; repaired the workspace install with bun install --ignore-scripts and reran successfully.
- bunx biome check packages/ui/src/components/settings/settings-section-meta.ts packages/ui/src/components/settings/settings-sections.ts plugins/plugin-app-control/src/actions/settings.ts plugins/plugin-app-control/src/actions/settings.test.ts: passed.
- git diff --check origin/develop...HEAD: passed.
- bun run audit:error-policy-ratchet: passed, no new fallback slop in touched production files.