### PR TITLE
feat(lifeops): model-decided proactivity — moment judge gate + unanswered-question follow-up (#14677, #14676)

### DIFF
--- a/plugins/plugin-personal-assistant/src/default-packs/habit-starters.ts
+++ b/plugins/plugin-personal-assistant/src/default-packs/habit-starters.ts
@@ -13,6 +13,11 @@
  *   8. shave — weekly
  *
  * `defaultEnabled: false` — first-run customize asks; defaults path skips.
+ *
+ * Every owner-facing poke here (except high-priority `workout`, which the
+ * judge's safety rail bypasses anyway) carries a trailing `model_moment_check`
+ * gate: the structural gates decide WHETHER today/this window qualifies, the
+ * model judge decides whether NOW is a good moment to interrupt (#14677).
  */
 
 import type { DefaultPack } from "./registry-types.js";
@@ -44,7 +49,7 @@ const brushTeethDefinition: ReminderTaskDefinition = {
   contextRequest: { includeOwnerFacts: ["preferredName"] },
   trigger: { kind: "during_window", windowKey: "morning_or_night" },
   priority: "medium",
-  shouldFire: { gates: [] },
+  shouldFire: { gates: [{ kind: "model_moment_check" }] },
   respectsGlobalPause: true,
   source: "default_pack",
   createdBy: HABIT_STARTERS_PACK_KEY,
@@ -67,7 +72,10 @@ const showerDefinition: ReminderTaskDefinition = {
   trigger: { kind: "during_window", windowKey: "morning" },
   priority: "low",
   shouldFire: {
-    gates: [{ kind: "weekday_only", params: { weekdays: [1, 3, 5] } }],
+    gates: [
+      { kind: "weekday_only", params: { weekdays: [1, 3, 5] } },
+      { kind: "model_moment_check" },
+    ],
   },
   respectsGlobalPause: true,
   source: "default_pack",
@@ -91,7 +99,10 @@ const invisalignDefinition: ReminderTaskDefinition = {
   trigger: { kind: "during_window", windowKey: "afternoon" },
   priority: "medium",
   shouldFire: {
-    gates: [{ kind: "weekday_only", params: { weekdays: [1, 2, 3, 4, 5] } }],
+    gates: [
+      { kind: "weekday_only", params: { weekdays: [1, 2, 3, 4, 5] } },
+      { kind: "model_moment_check" },
+    ],
   },
   respectsGlobalPause: true,
   source: "default_pack",
@@ -120,6 +131,7 @@ const drinkWaterDefinition: ReminderTaskDefinition = {
         kind: "during_window",
         params: { windows: ["morning", "afternoon", "evening"] },
       },
+      { kind: "model_moment_check" },
     ],
   },
   respectsGlobalPause: true,
@@ -138,10 +150,14 @@ const drinkWaterDefinition: ReminderTaskDefinition = {
 
 /**
  * Stretch — interval + multi-gate composition (per IMPL §3.4):
- *   `first_deny`: [weekend_skip, late_evening_skip, stretch.walk_out_reset]
+ *   `first_deny`: [weekend_skip, stretch.walk_out_reset, model_moment_check]
  *
- * `first_deny` short-circuits on the first denying gate. The `stretch.walk_out_reset`
- * gate is registered by the scheduled-task runner's gate-registry.
+ * `first_deny` short-circuits on the first denying gate, so the model call is
+ * only paid when the structural gates already allowed. The
+ * `stretch.walk_out_reset` gate is registered by the scheduled-task runner's
+ * gate-registry. The former `late_evening_skip` gate encoded a timing
+ * JUDGMENT ("too late in the evening"); that call belongs to the moment
+ * judge, which sees the local time plus the owner's presence and rhythm.
  */
 const stretchDefinition: ReminderTaskDefinition = {
   definitionKind: "reminder",
@@ -154,8 +170,8 @@ const stretchDefinition: ReminderTaskDefinition = {
     compose: "first_deny",
     gates: [
       { kind: "weekend_skip" },
-      { kind: "late_evening_skip" },
       { kind: "stretch.walk_out_reset" },
+      { kind: "model_moment_check" },
     ],
   },
   respectsGlobalPause: true,
@@ -181,7 +197,7 @@ const vitaminsDefinition: ReminderTaskDefinition = {
   contextRequest: { includeOwnerFacts: ["preferredName"] },
   trigger: { kind: "during_window", windowKey: "morning_or_evening" },
   priority: "medium",
-  shouldFire: { gates: [] },
+  shouldFire: { gates: [{ kind: "model_moment_check" }] },
   respectsGlobalPause: true,
   source: "default_pack",
   createdBy: HABIT_STARTERS_PACK_KEY,
@@ -238,7 +254,10 @@ const shaveDefinition: ReminderTaskDefinition = {
   trigger: { kind: "during_window", windowKey: "morning" },
   priority: "low",
   shouldFire: {
-    gates: [{ kind: "weekday_only", params: { weekdays: [2, 5] } }],
+    gates: [
+      { kind: "weekday_only", params: { weekdays: [2, 5] } },
+      { kind: "model_moment_check" },
+    ],
   },
   respectsGlobalPause: true,
   source: "default_pack",

--- a/plugins/plugin-personal-assistant/src/lifeops/first-run/defaults.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/first-run/defaults.ts
@@ -134,6 +134,17 @@ function cronAtLocal(hhmm: string, tz: string): ScheduledTaskInput["trigger"] {
   };
 }
 
+/**
+ * Fire-time admission for the owner-facing daily pokes: the cron decides WHEN
+ * the ritual is scheduled; the `model_moment_check` judge (#14677) decides
+ * whether NOW is actually a good moment — send / defer / drop with the
+ * owner's presence, rhythm, and quiet-streak context. System records
+ * (local backup) and owner-invoked ones (weekly review) carry no judge.
+ */
+const MOMENT_JUDGED: NonNullable<ScheduledTaskInput["shouldFire"]> = {
+  gates: [{ kind: "model_moment_check" }],
+};
+
 export function buildDefaultsPack(
   context: DefaultsPackContext,
 ): ScheduledTaskInput[] {
@@ -146,6 +157,7 @@ export function buildDefaultsPack(
         "Wish the owner a warm good morning and surface anything pressing for the day.",
       trigger: cronAtLocal(morningWindow.startLocal, timezone),
       priority: "low",
+      shouldFire: MOMENT_JUDGED,
       respectsGlobalPause: true,
       source: "first_run",
       createdBy: agentId,
@@ -165,6 +177,7 @@ export function buildDefaultsPack(
       promptInstructions: "Wish the owner good night before they wind down.",
       trigger: cronAtLocal("22:00", timezone),
       priority: "low",
+      shouldFire: MOMENT_JUDGED,
       respectsGlobalPause: true,
       source: "first_run",
       createdBy: agentId,
@@ -185,6 +198,7 @@ export function buildDefaultsPack(
         "Run the daily check-in: ask the owner how they're feeling and what's on their plate today.",
       trigger: cronAtLocal("09:00", timezone),
       priority: "medium",
+      shouldFire: MOMENT_JUDGED,
       respectsGlobalPause: true,
       source: "first_run",
       createdBy: agentId,
@@ -215,6 +229,7 @@ export function buildDefaultsPack(
         offsetMinutes: 0,
       },
       priority: "medium",
+      shouldFire: MOMENT_JUDGED,
       respectsGlobalPause: true,
       source: "first_run",
       createdBy: agentId,

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/inbound-reply-completion.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/inbound-reply-completion.integration.test.ts
@@ -74,10 +74,24 @@ async function seedFiredTask(
   return task;
 }
 
+const OWNER_ENTITY_ID = "owner-entity-1";
+
+/**
+ * `hasRoleAccess` fails CLOSED for senders whose role cannot be resolved, so
+ * the completion pass's owner gate needs the canonical-owner setting the
+ * production first-run flow records (same pattern as
+ * scheduler.integration.test.ts).
+ */
+async function createOwnerScopedRuntime(): Promise<RealTestRuntimeResult> {
+  const result = await createLifeOpsTestRuntime();
+  result.runtime.setSetting("ELIZA_ADMIN_ENTITY_ID", OWNER_ENTITY_ID, false);
+  return result;
+}
+
 function ownerReply(runtime: Runtime, roomId: string): Memory {
   return {
     id: `msg-${Math.random().toString(36).slice(2, 10)}`,
-    entityId: "owner-entity-1",
+    entityId: OWNER_ENTITY_ID,
     roomId,
     agentId: runtime.agentId,
     content: { text: "done!" },
@@ -107,7 +121,7 @@ describe("inbound-reply completion — production wiring", () => {
   });
 
   it("an owner reply in the pending-prompt room completes a fired user_replied_within task via MESSAGE_RECEIVED", async () => {
-    runtimeResult = await createLifeOpsTestRuntime();
+    runtimeResult = await createOwnerScopedRuntime();
     const { runtime } = runtimeResult;
     const roomId = "room-checkin-1";
 
@@ -149,7 +163,7 @@ describe("inbound-reply completion — production wiring", () => {
   }, 180_000);
 
   it("an owner reply to a fired check-in records the check-in report acknowledgement so escalation does not ratchet to max", async () => {
-    runtimeResult = await createLifeOpsTestRuntime();
+    runtimeResult = await createOwnerScopedRuntime();
     const { runtime } = runtimeResult;
     const checkins = new CheckinService(runtime);
     const base = Date.parse("2026-05-12T14:00:00.000Z");
@@ -182,7 +196,7 @@ describe("inbound-reply completion — production wiring", () => {
   }, 180_000);
 
   it("an owner reply after a sleep-cycle check-in acknowledges the latest unacknowledged report", async () => {
-    runtimeResult = await createLifeOpsTestRuntime();
+    runtimeResult = await createOwnerScopedRuntime();
     const { runtime } = runtimeResult;
     const checkins = new CheckinService(runtime);
     const base = Date.parse("2026-05-12T14:00:00.000Z");
@@ -210,7 +224,7 @@ describe("inbound-reply completion — production wiring", () => {
   }, 180_000);
 
   it("a reply in a different room leaves the fired task untouched", async () => {
-    runtimeResult = await createLifeOpsTestRuntime();
+    runtimeResult = await createOwnerScopedRuntime();
     const { runtime } = runtimeResult;
 
     const task = await seedFiredTask(runtime, {
@@ -249,7 +263,7 @@ describe("inbound-reply completion — production wiring", () => {
   }, 180_000);
 
   it("a plain reply does NOT complete user_acknowledged (acknowledgment stays an explicit verb)", async () => {
-    runtimeResult = await createLifeOpsTestRuntime();
+    runtimeResult = await createOwnerScopedRuntime();
     const { runtime } = runtimeResult;
     const roomId = "room-ack-1";
 
@@ -271,7 +285,7 @@ describe("inbound-reply completion — production wiring", () => {
   }, 180_000);
 
   it("the agent's own outbound message never evaluates completion", async () => {
-    runtimeResult = await createLifeOpsTestRuntime();
+    runtimeResult = await createOwnerScopedRuntime();
     const { runtime } = runtimeResult;
     const roomId = "room-self-1";
 
@@ -297,7 +311,7 @@ describe("inbound-reply completion — production wiring", () => {
   }, 180_000);
 
   it("subject_updated completes only after the real entity row changes", async () => {
-    runtimeResult = await createLifeOpsTestRuntime();
+    runtimeResult = await createOwnerScopedRuntime();
     const { runtime } = runtimeResult;
     const roomId = "room-subject-1";
 

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/moment-judge.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/moment-judge.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Moment-judge gate (#14677) — deterministic unit coverage with the model
+ * stubbed at the runtime boundary (`useModel`): verdict parsing/clamping,
+ * prompt composition from owner context, gate mapping (send/defer/drop), the
+ * high-priority safety rail, and the judge-unavailable degrade.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import type {
+  GateEvaluationContext,
+  ScheduledTask,
+} from "@elizaos/plugin-scheduling";
+import { describe, expect, it } from "vitest";
+import {
+  buildMomentJudgePrompt,
+  composeMomentJudgeContext,
+  MAX_DEFER_MINUTES,
+  MIN_DEFER_MINUTES,
+  type MomentJudgeContext,
+  makeModelMomentCheckGate,
+  parseMomentJudgeVerdict,
+} from "./moment-judge.js";
+
+interface FakeRuntimeOptions {
+  modelOutput?: unknown;
+  modelError?: Error;
+  tasks?: unknown[];
+}
+
+interface FakeRuntime {
+  runtime: IAgentRuntime;
+  prompts: string[];
+  reportedErrors: Array<{ scope: string; error: unknown }>;
+}
+
+function makeFakeRuntime(options: FakeRuntimeOptions = {}): FakeRuntime {
+  const prompts: string[] = [];
+  const reportedErrors: Array<{ scope: string; error: unknown }> = [];
+  const cache = new Map<string, unknown>();
+  const runtime = {
+    agentId: "agent-1",
+    async getTasks() {
+      return options.tasks ?? [];
+    },
+    async getCache(key: string) {
+      return cache.get(key);
+    },
+    async setCache(key: string, value: unknown) {
+      cache.set(key, value);
+      return true;
+    },
+    async deleteCache(key: string) {
+      cache.delete(key);
+      return true;
+    },
+    async useModel(_type: string, params: { prompt: string }) {
+      prompts.push(params.prompt);
+      if (options.modelError) throw options.modelError;
+      return options.modelOutput ?? null;
+    },
+    reportError(scope: string, error: unknown) {
+      reportedErrors.push({ scope, error });
+    },
+  } as unknown as IAgentRuntime;
+  return { runtime, prompts, reportedErrors };
+}
+
+function makeTask(overrides: Partial<ScheduledTask> = {}): ScheduledTask {
+  return {
+    taskId: "t-moment-1",
+    kind: "reminder",
+    promptInstructions: "Send a soft stretch nudge.",
+    trigger: { kind: "interval", everyMinutes: 360 },
+    priority: "low",
+    respectsGlobalPause: true,
+    state: { status: "scheduled", followupCount: 0 },
+    source: "default_pack",
+    createdBy: "habit-starters",
+    ownerVisible: true,
+    ...overrides,
+  };
+}
+
+function makeGateContext(
+  task: ScheduledTask,
+  overrides: Partial<GateEvaluationContext> = {},
+): GateEvaluationContext {
+  return {
+    task,
+    nowIso: "2026-07-05T15:00:00.000Z",
+    ownerFacts: { timezone: "America/New_York" },
+    activity: { hasSignalSince: () => false },
+    subjectStore: { wasUpdatedSince: () => false },
+    ...overrides,
+  };
+}
+
+function makeJudgeContext(
+  overrides: Partial<MomentJudgeContext> = {},
+): MomentJudgeContext {
+  return {
+    task: {
+      kind: "reminder",
+      priority: "low",
+      source: "default_pack",
+      promptInstructions: "Send a soft stretch nudge.",
+    },
+    nowIso: "2026-07-05T15:00:00.000Z",
+    timezone: "America/New_York",
+    minutesSinceOwnerSeen: 12,
+    ownerObservedAsleep: false,
+    quietStreakDays: undefined,
+    quietHours: null,
+    morningWindow: null,
+    eveningWindow: null,
+    chronotype: null,
+    scheduleStyle: null,
+    ...overrides,
+  };
+}
+
+describe("parseMomentJudgeVerdict", () => {
+  it("parses a send verdict", () => {
+    expect(
+      parseMomentJudgeVerdict('{"decision":"send","reason":"owner active"}'),
+    ).toMatchObject({ decision: "send", reason: "owner active" });
+  });
+
+  it("parses a defer verdict and keeps in-range minutes", () => {
+    const verdict = parseMomentJudgeVerdict(
+      '{"decision":"defer","deferMinutes":25,"reason":"mid-meeting"}',
+    );
+    expect(verdict).toMatchObject({ decision: "defer", deferMinutes: 25 });
+  });
+
+  it("clamps defer minutes to the [min, max] window", () => {
+    expect(
+      parseMomentJudgeVerdict('{"decision":"defer","deferMinutes":1}')
+        ?.deferMinutes,
+    ).toBe(MIN_DEFER_MINUTES);
+    expect(
+      parseMomentJudgeVerdict('{"decision":"defer","deferMinutes":100000}')
+        ?.deferMinutes,
+    ).toBe(MAX_DEFER_MINUTES);
+  });
+
+  it("defaults defer minutes when the model omits them", () => {
+    const verdict = parseMomentJudgeVerdict('{"decision":"defer"}');
+    expect(verdict?.deferMinutes).toBeGreaterThanOrEqual(MIN_DEFER_MINUTES);
+    expect(verdict?.deferMinutes).toBeLessThanOrEqual(MAX_DEFER_MINUTES);
+  });
+
+  it("parses a drop verdict from a fenced JSON block", () => {
+    expect(
+      parseMomentJudgeVerdict(
+        '```json\n{"decision":"drop","reason":"stale"}\n```',
+      ),
+    ).toMatchObject({ decision: "drop", reason: "stale" });
+  });
+
+  it("accepts a pre-parsed object", () => {
+    expect(
+      parseMomentJudgeVerdict({ decision: "SEND", reason: "fine" }),
+    ).toMatchObject({ decision: "send" });
+  });
+
+  it("returns null for garbage, unknown decisions, and non-objects", () => {
+    expect(parseMomentJudgeVerdict("not json at all")).toBeNull();
+    expect(parseMomentJudgeVerdict('{"decision":"maybe"}')).toBeNull();
+    expect(parseMomentJudgeVerdict('"send"')).toBeNull();
+    expect(parseMomentJudgeVerdict(null)).toBeNull();
+    expect(parseMomentJudgeVerdict(42)).toBeNull();
+  });
+});
+
+describe("buildMomentJudgePrompt", () => {
+  it("grounds the prompt in the task and the owner context", () => {
+    const prompt = buildMomentJudgePrompt(
+      makeJudgeContext({
+        quietStreakDays: 4,
+        quietHours: { start: "22:00", end: "07:00" },
+        morningWindow: { start: "07:00", end: "12:00" },
+        chronotype: "late",
+        scheduleStyle: "regular",
+      }),
+    );
+    expect(prompt).toContain("task kind: reminder; priority: low");
+    expect(prompt).toContain("Send a soft stretch nudge.");
+    expect(prompt).toContain("12 minute(s) ago");
+    expect(prompt).toContain("observed circadian state: awake");
+    expect(prompt).toContain("4 consecutive ignored check-ins/follow-ups");
+    expect(prompt).toContain("22:00-07:00");
+    expect(prompt).toContain("07:00-12:00");
+    expect(prompt).toContain("chronotype: late; schedule style: regular");
+    expect(prompt).toContain('"send" | "defer" | "drop"');
+  });
+
+  it("labels unknown context honestly instead of fabricating values", () => {
+    const prompt = buildMomentJudgePrompt(
+      makeJudgeContext({
+        minutesSinceOwnerSeen: null,
+        ownerObservedAsleep: null,
+        quietStreakDays: undefined,
+      }),
+    );
+    expect(prompt).toContain("last seen active: unknown");
+    expect(prompt).toContain("observed circadian state: unknown");
+    expect(prompt).toContain("none (owner has been responsive)");
+  });
+});
+
+describe("composeMomentJudgeContext", () => {
+  it("reads presence and circadian state from the persisted activity profile", async () => {
+    const nowIso = "2026-07-05T15:00:00.000Z";
+    const lastSeenAt = Date.parse(nowIso) - 30 * 60_000;
+    const { runtime } = makeFakeRuntime({
+      tasks: [
+        {
+          name: "PROACTIVE_AGENT",
+          metadata: {
+            activityProfile: {
+              ownerEntityId: "owner-1",
+              analyzedAt: Date.parse(nowIso),
+              totalMessages: 12,
+              isCurrentlySleeping: true,
+              lastSeenAt,
+              platforms: [],
+              analysisWindowDays: 14,
+            },
+          },
+        },
+      ],
+    });
+    const task = makeTask();
+    const context = await composeMomentJudgeContext(
+      runtime,
+      task,
+      makeGateContext(task, {
+        nowIso,
+        ownerFacts: { timezone: "UTC" },
+        activity: { hasSignalSince: () => false },
+        subjectStore: { wasUpdatedSince: () => false },
+        task,
+      }),
+    );
+    expect(context.minutesSinceOwnerSeen).toBe(30);
+    expect(context.ownerObservedAsleep).toBe(true);
+    expect(context.timezone).toBe("UTC");
+  });
+
+  it("reports unknown presence when no profile exists yet", async () => {
+    const { runtime } = makeFakeRuntime();
+    const task = makeTask();
+    const context = await composeMomentJudgeContext(
+      runtime,
+      task,
+      makeGateContext(task),
+    );
+    expect(context.minutesSinceOwnerSeen).toBeNull();
+    expect(context.ownerObservedAsleep).toBeNull();
+    expect(context.quietStreakDays).toBeUndefined();
+  });
+});
+
+describe("makeModelMomentCheckGate", () => {
+  it("honors a send verdict with allow", async () => {
+    const fake = makeFakeRuntime({
+      modelOutput: '{"decision":"send","reason":"owner just active"}',
+    });
+    const gate = makeModelMomentCheckGate(fake.runtime);
+    const task = makeTask();
+    const decision = await gate.evaluate(task, makeGateContext(task));
+    expect(decision).toEqual({ kind: "allow" });
+    expect(fake.prompts).toHaveLength(1);
+    expect(fake.prompts[0]).toContain("Send a soft stretch nudge.");
+    expect(fake.prompts[0]).toContain("last seen active");
+  });
+
+  it("honors a defer verdict with a gate defer", async () => {
+    const fake = makeFakeRuntime({
+      modelOutput:
+        '{"decision":"defer","deferMinutes":30,"reason":"likely asleep"}',
+    });
+    const gate = makeModelMomentCheckGate(fake.runtime);
+    const task = makeTask();
+    const decision = await gate.evaluate(task, makeGateContext(task));
+    expect(decision).toEqual({
+      kind: "defer",
+      until: { offsetMinutes: 30 },
+      reason: "model_moment_check: likely asleep",
+    });
+  });
+
+  it("honors a drop verdict with a deny", async () => {
+    const fake = makeFakeRuntime({
+      modelOutput: '{"decision":"drop","reason":"redundant poke"}',
+    });
+    const gate = makeModelMomentCheckGate(fake.runtime);
+    const task = makeTask();
+    const decision = await gate.evaluate(task, makeGateContext(task));
+    expect(decision).toEqual({
+      kind: "deny",
+      reason: "model_moment_check: redundant poke",
+    });
+  });
+
+  it("never model-vetoes a high-priority task (safety rail, no model call)", async () => {
+    const fake = makeFakeRuntime({
+      modelOutput: '{"decision":"drop","reason":"should never be consulted"}',
+    });
+    const gate = makeModelMomentCheckGate(fake.runtime);
+    const task = makeTask({ priority: "high" });
+    const decision = await gate.evaluate(task, makeGateContext(task));
+    expect(decision).toEqual({ kind: "allow" });
+    expect(fake.prompts).toHaveLength(0);
+  });
+
+  it("degrades to allow and reports the error when the judge call fails", async () => {
+    const fake = makeFakeRuntime({ modelError: new Error("model down") });
+    const gate = makeModelMomentCheckGate(fake.runtime);
+    const task = makeTask();
+    const decision = await gate.evaluate(task, makeGateContext(task));
+    expect(decision).toEqual({ kind: "allow" });
+    expect(fake.reportedErrors).toHaveLength(1);
+    expect(fake.reportedErrors[0]?.scope).toBe(
+      "lifeops:scheduled-task:moment-judge",
+    );
+  });
+
+  it("degrades to allow on unparseable judge output", async () => {
+    const fake = makeFakeRuntime({ modelOutput: "shrug, hard to say" });
+    const gate = makeModelMomentCheckGate(fake.runtime);
+    const task = makeTask();
+    const decision = await gate.evaluate(task, makeGateContext(task));
+    expect(decision).toEqual({ kind: "allow" });
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/moment-judge.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/moment-judge.ts
@@ -1,0 +1,360 @@
+/**
+ * Model-judged admission for scheduled/proactive dispatch (#14677): the
+ * production reader for the spine's `model_moment_check` gate kind.
+ *
+ * Every other gate in the fire path is deterministic (clock, flag, threshold).
+ * This one gives the MODEL the "should I speak to the owner right now?"
+ * decision, fed with the owner context the runtime already tracks: what is
+ * about to be sent (the task's structural fields plus its instruction, passed
+ * as opaque payload — nothing here branches on the text), how recently the
+ * owner was seen, whether the observed rhythm says they are asleep, how long
+ * they have been ignoring pokes (quiet streak), the local time, and the
+ * owner's extracted schedule preferences. The verdict maps onto the gate
+ * vocabulary: send → allow, defer → defer(offsetMinutes), drop → deny.
+ *
+ * Placement doctrine: deterministic gates that encode HARD constraints
+ * (owner-set quiet hours, weekday config) stay as the outer backstop and are
+ * composed BEFORE this gate under `first_deny`, so the model call is only paid
+ * when everything structural already allowed. Gates that encoded JUDGMENT
+ * ("is the owner busy?", "is it too late in the evening?") become inputs to
+ * this prompt instead of hardcoded policy. High-priority tasks bypass the
+ * judge entirely — a model must never veto an urgent send (same safety rail
+ * as `quiet_hours.highPriorityBypass`).
+ */
+
+import {
+  type IAgentRuntime,
+  logger,
+  ModelType,
+  runWithTrajectoryPurpose,
+} from "@elizaos/core";
+import type {
+  GateDecision,
+  GateEvaluationContext,
+  ScheduledTask,
+  TaskGateContribution,
+} from "@elizaos/plugin-scheduling";
+import {
+  quietStreakDaysFromObservations,
+  runQuietUserWatcher,
+} from "../../default-packs/quiet-user-watcher.js";
+import { createRecentTaskStatesProvider } from "../../providers/recent-task-states.js";
+import { readActivityProfile } from "./activity-gates.js";
+
+export const MOMENT_JUDGE_TRAJECTORY_PURPOSE = "scheduled-moment-judge";
+
+/** Defer clamp: a model "defer" reschedules between 5 minutes and 8 hours. */
+export const MIN_DEFER_MINUTES = 5;
+export const MAX_DEFER_MINUTES = 8 * 60;
+const DEFAULT_DEFER_MINUTES = 60;
+
+export type MomentJudgeDecision = "send" | "defer" | "drop";
+
+export interface MomentJudgeVerdict {
+  decision: MomentJudgeDecision;
+  /** Only meaningful for `defer`; clamped to [MIN, MAX]_DEFER_MINUTES. */
+  deferMinutes: number;
+  reason: string;
+}
+
+/** Owner-context brief the judge prompt is grounded in. */
+export interface MomentJudgeContext {
+  task: Pick<
+    ScheduledTask,
+    "kind" | "priority" | "source" | "promptInstructions"
+  >;
+  nowIso: string;
+  /** IANA timezone used for the local-time line. */
+  timezone: string;
+  /** Minutes since the owner was last observed active, when known. */
+  minutesSinceOwnerSeen: number | null;
+  /** Observed circadian state from the activity profile, when known. */
+  ownerObservedAsleep: boolean | null;
+  /** Consecutive ignored check-ins/follow-ups; undefined = not quiet. */
+  quietStreakDays: number | undefined;
+  quietHours: { start: string; end: string } | null;
+  morningWindow: { start?: string; end?: string } | null;
+  eveningWindow: { start?: string; end?: string } | null;
+  chronotype: string | null;
+  scheduleStyle: string | null;
+}
+
+function localTimeLine(nowIso: string, timezone: string): string {
+  const date = new Date(nowIso);
+  if (Number.isNaN(date.getTime())) return "unknown";
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      weekday: "long",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    }).format(date);
+  } catch {
+    // error-policy:J3 untrusted-input sanitizing — an invalid owner timezone
+    // string degrades to the UTC reading, explicitly labeled as such.
+    return `${new Date(nowIso).toISOString()} (UTC; owner timezone invalid)`;
+  }
+}
+
+/**
+ * Build the moment-judge prompt. Pure and exported for direct prompt-content
+ * tests. `promptInstructions` is embedded as opaque payload so the judge sees
+ * WHAT is about to be sent; no code here branches on it.
+ */
+export function buildMomentJudgePrompt(context: MomentJudgeContext): string {
+  const lines: string[] = [
+    "You are the timing judge for a personal assistant. A scheduled message for the owner is about to be sent. Decide whether NOW is a good moment.",
+    "Verdicts:",
+    '- "send": now is fine (or the message is time-sensitive enough to matter more than the interruption).',
+    '- "defer": worth sending, but later — pick deferMinutes for a better moment (owner likely asleep, clearly mid-conversation elsewhere, an odd hour for this kind of message).',
+    '- "drop": not worth sending at all (stale, redundant, or the owner has been ignoring these and this one is low-value).',
+    "Guidance:",
+    "- Messages the owner explicitly asked for (source user_chat) should almost never be dropped; prefer send or a short defer.",
+    "- A long quiet streak means back off: prefer defer or drop for low-value pokes instead of chasing.",
+    "- If the owner was active moments ago they are present — a relevant message can send; an interruption to deep activity can wait a few minutes.",
+    "",
+    "About to be sent:",
+    `- task kind: ${context.task.kind}; priority: ${context.task.priority}; origin: ${context.task.source}`,
+    `- instruction the assistant will compose the message from: ${context.task.promptInstructions}`,
+    "",
+    "Owner context:",
+    `- local time: ${localTimeLine(context.nowIso, context.timezone)}`,
+    `- last seen active: ${
+      context.minutesSinceOwnerSeen === null
+        ? "unknown"
+        : `${context.minutesSinceOwnerSeen} minute(s) ago`
+    }`,
+    `- observed circadian state: ${
+      context.ownerObservedAsleep === null
+        ? "unknown"
+        : context.ownerObservedAsleep
+          ? "asleep"
+          : "awake"
+    }`,
+    `- quiet streak: ${
+      context.quietStreakDays === undefined
+        ? "none (owner has been responsive)"
+        : `${context.quietStreakDays} consecutive ignored check-ins/follow-ups`
+    }`,
+    `- owner-set quiet hours: ${
+      context.quietHours
+        ? `${context.quietHours.start}-${context.quietHours.end} (already enforced upstream; treat as context)`
+        : "none"
+    }`,
+    `- morning window: ${
+      context.morningWindow?.start
+        ? `${context.morningWindow.start}-${context.morningWindow.end ?? "?"}`
+        : "unknown"
+    }; evening window: ${
+      context.eveningWindow?.start
+        ? `${context.eveningWindow.start}-${context.eveningWindow.end ?? "?"}`
+        : "unknown"
+    }`,
+    `- chronotype: ${context.chronotype ?? "unknown"}; schedule style: ${context.scheduleStyle ?? "unknown"}`,
+    "",
+    'Respond as JSON only: {"decision": "send" | "defer" | "drop", "deferMinutes": <integer, only for defer>, "reason": "<one short sentence>"}',
+  ];
+  return lines.join("\n");
+}
+
+function clampDeferMinutes(raw: unknown): number {
+  const parsed =
+    typeof raw === "number" && Number.isFinite(raw)
+      ? Math.round(raw)
+      : typeof raw === "string" && Number.isFinite(Number(raw))
+        ? Math.round(Number(raw))
+        : DEFAULT_DEFER_MINUTES;
+  return Math.min(MAX_DEFER_MINUTES, Math.max(MIN_DEFER_MINUTES, parsed));
+}
+
+/**
+ * Parse the judge model output into a typed verdict, or `null` when the output
+ * carries no usable decision (the caller then treats the judgment as
+ * unavailable — it never fabricates a verdict from garbage).
+ */
+export function parseMomentJudgeVerdict(
+  raw: unknown,
+): MomentJudgeVerdict | null {
+  let obj: unknown = raw;
+  if (typeof raw === "string") {
+    const trimmed = raw
+      .trim()
+      .replace(/^```(?:json)?\s*/i, "")
+      .replace(/\s*```$/i, "");
+    try {
+      obj = JSON.parse(trimmed);
+    } catch {
+      // error-policy:J3 untrusted-input sanitizing — non-JSON model output is
+      // an explicit "no verdict", never coerced into a decision.
+      return null;
+    }
+  }
+  if (!obj || typeof obj !== "object") return null;
+  const record = obj as Record<string, unknown>;
+  const decisionRaw =
+    typeof record.decision === "string"
+      ? record.decision.trim().toLowerCase()
+      : "";
+  if (
+    decisionRaw !== "send" &&
+    decisionRaw !== "defer" &&
+    decisionRaw !== "drop"
+  ) {
+    return null;
+  }
+  return {
+    decision: decisionRaw,
+    deferMinutes: clampDeferMinutes(record.deferMinutes),
+    reason:
+      typeof record.reason === "string" && record.reason.trim().length > 0
+        ? record.reason.trim()
+        : "no reason given",
+  };
+}
+
+/** Assemble the judge's owner-context brief from the runtime + gate context. */
+export async function composeMomentJudgeContext(
+  runtime: IAgentRuntime,
+  task: ScheduledTask,
+  context: GateEvaluationContext,
+): Promise<MomentJudgeContext> {
+  const nowMs = Date.parse(context.nowIso);
+  const profile = await readActivityProfile(runtime);
+  const lastSeenAt =
+    profile && Number.isFinite(profile.lastSeenAt) && profile.lastSeenAt > 0
+      ? profile.lastSeenAt
+      : null;
+  const observations = await runQuietUserWatcher(
+    createRecentTaskStatesProvider(runtime),
+    { asOf: new Date(Number.isFinite(nowMs) ? nowMs : Date.now()) },
+  );
+  return {
+    task: {
+      kind: task.kind,
+      priority: task.priority,
+      source: task.source,
+      promptInstructions: task.promptInstructions,
+    },
+    nowIso: context.nowIso,
+    timezone: context.ownerFacts.timezone ?? "UTC",
+    minutesSinceOwnerSeen:
+      lastSeenAt !== null && Number.isFinite(nowMs)
+        ? Math.max(0, Math.round((nowMs - lastSeenAt) / 60_000))
+        : null,
+    ownerObservedAsleep: profile ? profile.isCurrentlySleeping === true : null,
+    quietStreakDays: quietStreakDaysFromObservations(observations),
+    quietHours: context.ownerFacts.quietHours
+      ? {
+          start: context.ownerFacts.quietHours.start,
+          end: context.ownerFacts.quietHours.end,
+        }
+      : null,
+    morningWindow: context.ownerFacts.morningWindow ?? null,
+    eveningWindow: context.ownerFacts.eveningWindow ?? null,
+    chronotype: context.ownerFacts.chronotype ?? null,
+    scheduleStyle: context.ownerFacts.scheduleStyle ?? null,
+  };
+}
+
+function verdictToGateDecision(verdict: MomentJudgeVerdict): GateDecision {
+  switch (verdict.decision) {
+    case "send":
+      return { kind: "allow" };
+    case "defer":
+      return {
+        kind: "defer",
+        until: { offsetMinutes: verdict.deferMinutes },
+        reason: `model_moment_check: ${verdict.reason}`,
+      };
+    case "drop":
+      return {
+        kind: "deny",
+        reason: `model_moment_check: ${verdict.reason}`,
+      };
+  }
+}
+
+/**
+ * The production `model_moment_check` gate. First-wins registration in PA's
+ * runner wiring makes this take precedence over the spine's always-allow
+ * fallback.
+ */
+export function makeModelMomentCheckGate(
+  runtime: IAgentRuntime,
+): TaskGateContribution {
+  return {
+    kind: "model_moment_check",
+    async evaluate(
+      task: ScheduledTask,
+      context: GateEvaluationContext,
+    ): Promise<GateDecision> {
+      // Safety rail, not judgment: urgent sends are never model-vetoed.
+      if (task.priority === "high") {
+        return { kind: "allow" };
+      }
+      const judgeContext = await composeMomentJudgeContext(
+        runtime,
+        task,
+        context,
+      );
+      let verdict: MomentJudgeVerdict | null;
+      try {
+        const raw = await runWithTrajectoryPurpose(
+          MOMENT_JUDGE_TRAJECTORY_PURPOSE,
+          () =>
+            runtime.useModel(ModelType.TEXT_SMALL, {
+              prompt: buildMomentJudgePrompt(judgeContext),
+            }),
+        );
+        verdict = parseMomentJudgeVerdict(raw);
+      } catch (error) {
+        // error-policy:J4 explicit degrade — the moment judgment REFINES the
+        // deterministic gates that already allowed this fire; when the judge
+        // is unavailable the honest behavior is today's deterministic-only
+        // dispatch, not a starved task. The failure is surfaced to the agent
+        // and owner escalation via reportError.
+        runtime.reportError("lifeops:scheduled-task:moment-judge", error, {
+          taskId: task.taskId,
+          kind: task.kind,
+        });
+        return { kind: "allow" };
+      }
+      if (!verdict) {
+        logger.warn(
+          {
+            src: "lifeops:scheduled-task:moment-judge",
+            agentId: runtime.agentId,
+            taskId: task.taskId,
+          },
+          "[MomentJudge] unparseable judge output; proceeding without a moment judgment",
+        );
+        return { kind: "allow" };
+      }
+      logger.info(
+        {
+          src: "lifeops:scheduled-task:moment-judge",
+          agentId: runtime.agentId,
+          taskId: task.taskId,
+          decision: verdict.decision,
+          deferMinutes: verdict.deferMinutes,
+          reason: verdict.reason,
+        },
+        `[MomentJudge] ${verdict.decision}: ${verdict.reason}`,
+      );
+      return verdictToGateDecision(verdict);
+    },
+  };
+}
+
+/**
+ * Register the production moment judge into a gate registry. Must run BEFORE
+ * `registerBuiltInGates` (first-wins) so this reader shadows the spine's
+ * always-allow fallback.
+ */
+export function registerModelMomentCheckGate(
+  runtime: IAgentRuntime,
+  registry: { register(c: TaskGateContribution): void },
+): void {
+  registry.register(makeModelMomentCheckGate(runtime));
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
@@ -76,6 +76,7 @@ import {
   readActivityProfile,
   registerActivityProfileGates,
 } from "./activity-gates.js";
+import { registerModelMomentCheckGate } from "./moment-judge.js";
 import { createLifeOpsSubjectStoreView } from "./subject-store.js";
 
 interface RepositoryBackedStores {
@@ -760,12 +761,14 @@ function buildLifeOpsRunnerDeps(
   const stores = makeRepositoryBackedStores(opts.runtime, opts.agentId);
 
   const gates = createTaskGateRegistry();
-  // Register the real ActivityProfile-backed readers for circadian_state_in and
-  // no_recent_user_message_in BEFORE the built-ins. registerBuiltInGates is
+  // Register the real ActivityProfile-backed readers for circadian_state_in /
+  // no_recent_user_message_in and the model moment judge for
+  // model_moment_check BEFORE the built-ins. registerBuiltInGates is
   // first-wins, so these production readers take precedence over the generic
   // fallbacks (which stay resolvable when PA is absent, e.g. plugin-health
   // standalone tests).
   registerActivityProfileGates(opts.runtime, gates);
+  registerModelMomentCheckGate(opts.runtime, gates);
   registerBuiltInGates(gates);
 
   const completionChecks = createCompletionCheckRegistry();

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/unanswered-question-followup.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/unanswered-question-followup.integration.test.ts
@@ -1,0 +1,422 @@
+/**
+ * Unanswered-question follow-up (#14676) against the real spine: a real
+ * runtime (PA + scheduling plugins, DB-backed runner), models stubbed at the
+ * runtime boundary. Covers registration from an agent reply, supersede,
+ * owner-reply cancellation through the registered MESSAGE_RECEIVED handler,
+ * and the fire path where the model_moment_check judge (#14677) decides —
+ * including the quiet-hours hard constraint composing BEFORE the judge.
+ */
+
+import {
+  ChannelType,
+  EventType,
+  type Memory,
+  ModelType,
+  stringToUuid,
+  type UUID,
+} from "@elizaos/core";
+import type { ScheduledTask } from "@elizaos/plugin-scheduling";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createLifeOpsTestRuntime,
+  type RealTestRuntimeResult,
+} from "../../../test/helpers/runtime.ts";
+import { createOwnerFactStore } from "../owner/fact-store.js";
+import { getScheduledTaskRunner } from "./service.js";
+import {
+  cancelQuestionFollowupsOnOwnerReply,
+  extractTrailingQuestion,
+  isUnansweredQuestionFollowupTask,
+  registerQuestionFollowupForAgentMessage,
+  UNANSWERED_QUESTION_FOLLOWUP_DELAY_MINUTES,
+} from "./unanswered-question-followup.js";
+
+type Runtime = RealTestRuntimeResult["runtime"];
+
+interface SeededRoom {
+  roomId: UUID;
+  ownerEntityId: UUID;
+}
+
+let seedCounter = 0;
+
+async function seedOwnerRoom(runtime: Runtime): Promise<SeededRoom> {
+  seedCounter += 1;
+  const roomId = stringToUuid(`uqf-room-${seedCounter}`);
+  const ownerEntityId = stringToUuid(`uqf-owner-${seedCounter}`);
+  // hasRoleAccess fails CLOSED for senders whose role cannot be resolved, so
+  // the owner gate needs the canonical-owner setting the production first-run
+  // flow records (same pattern as scheduler.integration.test.ts).
+  runtime.setSetting("ELIZA_ADMIN_ENTITY_ID", ownerEntityId, false);
+  await runtime.ensureConnection({
+    entityId: ownerEntityId,
+    roomId,
+    worldId: stringToUuid(`uqf-world-${seedCounter}`),
+    worldName: "UQF",
+    userName: "Owner",
+    name: "Owner",
+    source: "test",
+    type: ChannelType.DM,
+    channelId: `uqf-${seedCounter}`,
+  });
+  return { roomId, ownerEntityId };
+}
+
+async function persistOwnerMessage(
+  runtime: Runtime,
+  room: SeededRoom,
+  text: string,
+): Promise<UUID> {
+  seedCounter += 1;
+  const id = stringToUuid(`uqf-inbound-${seedCounter}`);
+  await runtime.createMemory(
+    {
+      id,
+      agentId: runtime.agentId as UUID,
+      roomId: room.roomId,
+      entityId: room.ownerEntityId,
+      content: { text, source: "test" },
+      createdAt: Date.now() - 1_000,
+    } as Memory,
+    "messages",
+  );
+  return id;
+}
+
+function agentReply(
+  runtime: Runtime,
+  room: SeededRoom,
+  text: string,
+  inReplyTo?: UUID,
+): Memory {
+  seedCounter += 1;
+  return {
+    id: stringToUuid(`uqf-reply-${seedCounter}`),
+    agentId: runtime.agentId as UUID,
+    roomId: room.roomId,
+    entityId: runtime.agentId as UUID,
+    content: {
+      text,
+      source: "test",
+      ...(inReplyTo ? { inReplyTo } : {}),
+    },
+    createdAt: Date.now(),
+  } as Memory;
+}
+
+async function listQuestionFollowups(
+  runtime: Runtime,
+  roomId: string,
+  status: ScheduledTask["state"]["status"] = "scheduled",
+): Promise<ScheduledTask[]> {
+  const runner = getScheduledTaskRunner(runtime, {
+    agentId: String(runtime.agentId),
+  });
+  const tasks = await runner.list({ kind: "followup", status });
+  return tasks.filter((task) => isUnansweredQuestionFollowupTask(task, roomId));
+}
+
+/** Register a TEXT_SMALL judge stub; returns the prompts it received. */
+function stubMomentJudge(runtime: Runtime, output: string | Error): string[] {
+  const prompts: string[] = [];
+  runtime.registerModel(
+    ModelType.TEXT_SMALL,
+    async (_rt: unknown, params: { prompt: string }) => {
+      prompts.push(params.prompt);
+      if (output instanceof Error) throw output;
+      return output;
+    },
+    "uqf-judge-stub",
+  );
+  return prompts;
+}
+
+describe("extractTrailingQuestion", () => {
+  it("extracts the final question sentence", () => {
+    expect(
+      extractTrailingQuestion(
+        "Booked the table for 7. Do you want me to invite Sam too?",
+      ),
+    ).toBe("Do you want me to invite Sam too?");
+  });
+
+  it("returns null when the reply does not end with a question", () => {
+    expect(extractTrailingQuestion("Done! The table is booked.")).toBeNull();
+    expect(
+      extractTrailingQuestion("Is it raining? Yes — take an umbrella."),
+    ).toBeNull();
+    expect(extractTrailingQuestion("")).toBeNull();
+  });
+
+  it("allows closing quotes after the question mark", () => {
+    expect(extractTrailingQuestion('She asked "are you coming?"')).toBe(
+      'She asked "are you coming?"',
+    );
+  });
+});
+
+describe("unanswered-question follow-up — real spine", () => {
+  let runtimeResult: RealTestRuntimeResult | null = null;
+
+  afterEach(async () => {
+    if (runtimeResult) {
+      await runtimeResult.cleanup();
+      runtimeResult = null;
+    }
+  });
+
+  it("registers a once follow-up with judge-gated admission for an agent question", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const room = await seedOwnerRoom(runtime);
+    const inboundId = await persistOwnerMessage(runtime, room, "any ideas?");
+
+    const before = Date.now();
+    const registration = await registerQuestionFollowupForAgentMessage(
+      runtime,
+      agentReply(runtime, room, "A few! What time works for you?", inboundId),
+    );
+    expect(registration).not.toBeNull();
+    const fireAtMs = Date.parse(registration?.fireAtIso ?? "");
+    expect(fireAtMs).toBeGreaterThanOrEqual(
+      before + (UNANSWERED_QUESTION_FOLLOWUP_DELAY_MINUTES - 1) * 60_000,
+    );
+    expect(fireAtMs).toBeLessThanOrEqual(
+      Date.now() + (UNANSWERED_QUESTION_FOLLOWUP_DELAY_MINUTES + 1) * 60_000,
+    );
+
+    const scheduled = await listQuestionFollowups(runtime, room.roomId);
+    expect(scheduled).toHaveLength(1);
+    const task = scheduled[0] as ScheduledTask;
+    expect(task.kind).toBe("followup");
+    expect(task.trigger.kind).toBe("once");
+    expect(task.shouldFire?.compose).toBe("first_deny");
+    expect(task.shouldFire?.gates.map((gate) => gate.kind)).toEqual([
+      "quiet_hours",
+      "model_moment_check",
+    ]);
+    expect(task.completionCheck?.kind).toBe("user_replied_within");
+    expect(task.metadata?.pendingPromptRoomId).toBe(room.roomId);
+    expect(task.metadata?.questionSnippet).toBe("What time works for you?");
+    expect(task.ownerVisible).toBe(true);
+    expect(task.promptInstructions).toContain("What time works for you?");
+  });
+
+  it("registers nothing without a trailing question or without an owner inbound", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const room = await seedOwnerRoom(runtime);
+    const inboundId = await persistOwnerMessage(runtime, room, "thanks!");
+
+    // No trailing question.
+    expect(
+      await registerQuestionFollowupForAgentMessage(
+        runtime,
+        agentReply(runtime, room, "You're welcome. All done.", inboundId),
+      ),
+    ).toBeNull();
+    // Question, but not a reply to any inbound message.
+    expect(
+      await registerQuestionFollowupForAgentMessage(
+        runtime,
+        agentReply(runtime, room, "Want me to keep going?"),
+      ),
+    ).toBeNull();
+    // Question, but the referenced inbound does not exist.
+    expect(
+      await registerQuestionFollowupForAgentMessage(
+        runtime,
+        agentReply(
+          runtime,
+          room,
+          "Want me to keep going?",
+          stringToUuid("uqf-missing-inbound"),
+        ),
+      ),
+    ).toBeNull();
+    // A non-agent message never registers.
+    expect(
+      await registerQuestionFollowupForAgentMessage(runtime, {
+        id: stringToUuid("uqf-user-msg"),
+        agentId: runtime.agentId as UUID,
+        roomId: room.roomId,
+        entityId: room.ownerEntityId,
+        content: { text: "can you hear me?", inReplyTo: inboundId },
+        createdAt: Date.now(),
+      } as Memory),
+    ).toBeNull();
+    expect(await listQuestionFollowups(runtime, room.roomId)).toHaveLength(0);
+  });
+
+  it("a newer agent question supersedes the scheduled follow-up (one per room)", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const room = await seedOwnerRoom(runtime);
+    const inboundId = await persistOwnerMessage(runtime, room, "hm");
+
+    const first = await registerQuestionFollowupForAgentMessage(
+      runtime,
+      agentReply(runtime, room, "Should I book the flight?", inboundId),
+    );
+    const second = await registerQuestionFollowupForAgentMessage(
+      runtime,
+      agentReply(
+        runtime,
+        room,
+        "Or would you rather take the train?",
+        inboundId,
+      ),
+    );
+    expect(first).not.toBeNull();
+    expect(second?.supersededTaskIds).toEqual([first?.taskId]);
+
+    const scheduled = await listQuestionFollowups(runtime, room.roomId);
+    expect(scheduled.map((task) => task.taskId)).toEqual([second?.taskId]);
+    const dismissed = await listQuestionFollowups(
+      runtime,
+      room.roomId,
+      "dismissed",
+    );
+    expect(dismissed.map((task) => task.taskId)).toEqual([first?.taskId]);
+  });
+
+  it("an owner reply through MESSAGE_RECEIVED dismisses the scheduled follow-up", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const room = await seedOwnerRoom(runtime);
+    const inboundId = await persistOwnerMessage(runtime, room, "let me think");
+
+    const registration = await registerQuestionFollowupForAgentMessage(
+      runtime,
+      agentReply(runtime, room, "Take your time — red or blue?", inboundId),
+    );
+    expect(registration).not.toBeNull();
+
+    // The REAL seam: the plugin's registered events[MESSAGE_RECEIVED] handler.
+    await runtime.emitEvent(EventType.MESSAGE_RECEIVED, {
+      runtime,
+      message: {
+        id: stringToUuid("uqf-owner-answer"),
+        agentId: runtime.agentId as UUID,
+        roomId: room.roomId,
+        entityId: room.ownerEntityId,
+        content: { text: "blue", source: "test" },
+        createdAt: Date.now(),
+      } as Memory,
+      source: "test",
+    });
+
+    expect(await listQuestionFollowups(runtime, room.roomId)).toHaveLength(0);
+    const dismissed = await listQuestionFollowups(
+      runtime,
+      room.roomId,
+      "dismissed",
+    );
+    expect(dismissed.map((task) => task.taskId)).toEqual([
+      registration?.taskId,
+    ]);
+  });
+
+  it("the agent's own outbound never cancels the follow-up", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const room = await seedOwnerRoom(runtime);
+    const inboundId = await persistOwnerMessage(runtime, room, "hm");
+    await registerQuestionFollowupForAgentMessage(
+      runtime,
+      agentReply(runtime, room, "Should I proceed?", inboundId),
+    );
+    const dismissed = await cancelQuestionFollowupsOnOwnerReply(
+      runtime,
+      agentReply(runtime, room, "Still there?"),
+    );
+    expect(dismissed).toEqual([]);
+    expect(await listQuestionFollowups(runtime, room.roomId)).toHaveLength(1);
+  });
+
+  it("fire path honors a judge drop verdict (task skipped, nothing dispatched)", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const prompts = stubMomentJudge(
+      runtime,
+      '{"decision":"drop","reason":"owner moved on"}',
+    );
+    const room = await seedOwnerRoom(runtime);
+    const inboundId = await persistOwnerMessage(runtime, room, "hm");
+    const registration = await registerQuestionFollowupForAgentMessage(
+      runtime,
+      agentReply(runtime, room, "Want the summary emailed?", inboundId),
+    );
+
+    const runner = getScheduledTaskRunner(runtime, {
+      agentId: String(runtime.agentId),
+    });
+    const result = await runner.fireWithResult(String(registration?.taskId));
+    expect(result.kind).toBe("skipped");
+    if (result.kind === "skipped") {
+      expect(result.reason).toContain("model_moment_check");
+      expect(result.reason).toContain("owner moved on");
+    }
+    // The judge saw the open question and the owner context.
+    expect(prompts).toHaveLength(1);
+    expect(prompts[0]).toContain("Want the summary emailed?");
+    expect(prompts[0]).toContain("last seen active");
+  });
+
+  it("fire path honors a judge send verdict (task fires and dispatches)", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    stubMomentJudge(runtime, '{"decision":"send","reason":"good moment"}');
+    const room = await seedOwnerRoom(runtime);
+    const inboundId = await persistOwnerMessage(runtime, room, "hm");
+    const registration = await registerQuestionFollowupForAgentMessage(
+      runtime,
+      agentReply(runtime, room, "Want the summary emailed?", inboundId),
+    );
+
+    const runner = getScheduledTaskRunner(runtime, {
+      agentId: String(runtime.agentId),
+    });
+    const result = await runner.fireWithResult(String(registration?.taskId));
+    expect(result.kind).toBe("fired");
+    if (result.kind === "fired") {
+      expect(result.task.state.status).toBe("fired");
+    }
+  });
+
+  it("owner-set quiet hours defer BEFORE the judge is ever consulted (hard constraint)", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const prompts = stubMomentJudge(
+      runtime,
+      new Error("judge must not be consulted inside quiet hours"),
+    );
+    // All-day quiet hours make the defer deterministic regardless of wall time.
+    await createOwnerFactStore(runtime).update(
+      {
+        quietHours: {
+          startLocal: "00:00",
+          endLocal: "23:59",
+          timezone: "UTC",
+        },
+      },
+      { source: "profile_save", recordedAt: new Date().toISOString() },
+    );
+    const room = await seedOwnerRoom(runtime);
+    const inboundId = await persistOwnerMessage(runtime, room, "hm");
+    const registration = await registerQuestionFollowupForAgentMessage(
+      runtime,
+      agentReply(runtime, room, "Want the summary emailed?", inboundId),
+    );
+
+    const runner = getScheduledTaskRunner(runtime, {
+      agentId: String(runtime.agentId),
+    });
+    const result = await runner.fireWithResult(String(registration?.taskId));
+    expect(result.kind).toBe("skipped");
+    if (result.kind === "skipped") {
+      expect(result.reason).toContain("quiet_hours");
+    }
+    expect(prompts).toHaveLength(0);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/unanswered-question-followup.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/unanswered-question-followup.ts
@@ -1,0 +1,325 @@
+/**
+ * Unanswered-question follow-up (#14676): the path from an agent question in
+ * ordinary chat to an unprompted nudge when the owner never answers.
+ *
+ * The pending-prompt / no-reply machinery only ever covered ScheduledTask
+ * fires; a question the agent asked in a normal REPLY turn evaporated the
+ * moment the turn ended. This module closes the loop with the ONE scheduler:
+ *
+ *  - On `MESSAGE_SENT` (agent outbound replying to an owner message), a cheap
+ *    structural candidate check — does the reply END with a question? — seeds
+ *    a `kind: "followup"` ScheduledTask with a `once` trigger. Detection is
+ *    only candidacy: whether the nudge is actually worth sending is decided
+ *    at fire time by the `model_moment_check` gate (the #14677 moment judge),
+ *    which sees the open question, the owner's presence/quiet-streak context,
+ *    and can send / defer / drop. `quiet_hours` composes before it as the
+ *    hard-constraint backstop.
+ *  - On `MESSAGE_RECEIVED` (owner speaks in the room), every still-scheduled
+ *    question follow-up for that room is dismissed: the owner re-engaged, so
+ *    a delayed nudge about the old turn is stale — if the agent still wants
+ *    the answer, the live conversation is where it re-asks (and its next
+ *    reply re-registers a fresh follow-up if it ends with a question).
+ *  - Once FIRED, the existing spine machinery owns the rest: the scheduler
+ *    records a pending prompt, `inbound-reply-completion` completes the task
+ *    when the owner answers, and the completion timeout lets it go quietly
+ *    (kind `followup` has no no-reply ladder — one nudge, never a chase).
+ *
+ * At most one scheduled question follow-up exists per room: registering a new
+ * one dismisses its predecessor (the newest agent question supersedes).
+ */
+
+import { hasOwnerAccess } from "@elizaos/agent";
+import {
+  type IAgentRuntime,
+  logger,
+  type Memory,
+  type MessagePayload,
+  type UUID,
+} from "@elizaos/core";
+import type {
+  ScheduledTask,
+  ScheduledTaskInput,
+} from "@elizaos/plugin-scheduling";
+import { getScheduledTaskRunner } from "./service.js";
+
+const LOG_SRC = "lifeops:scheduled-task:unanswered-question-followup";
+
+/** Structural metadata marker for question follow-up tasks. */
+export const UNANSWERED_QUESTION_METADATA_KEY = "unansweredQuestionFollowup";
+
+export const UNANSWERED_QUESTION_CREATED_BY =
+  "lifeops:unanswered-question-followup";
+
+/**
+ * Delay between the unanswered question and the follow-up's scheduled fire.
+ * Deliberately generous for chat: long enough that "still typing / reading"
+ * silences never trigger it, short enough that the thread is still warm. The
+ * fire-time moment judge can defer further; it cannot fire earlier.
+ */
+export const UNANSWERED_QUESTION_FOLLOWUP_DELAY_MINUTES = 45;
+
+/**
+ * After the nudge fires, how long an owner reply still completes the task
+ * before the completion timeout lets it go (no retry ladder for `followup`).
+ */
+const FOLLOWUP_COMPLETION_TIMEOUT_MINUTES = 4 * 60;
+
+const QUESTION_SNIPPET_MAX_LENGTH = 200;
+
+function messageText(message: Memory): string {
+  const text = message.content?.text;
+  return typeof text === "string" ? text : "";
+}
+
+/**
+ * Structural candidate detection: the message ENDS with a question sentence.
+ * A trailing question is the strongest "awaiting an answer" signal; mid-text
+ * questions are usually rhetorical or already resolved by the surrounding
+ * prose. Returns the final question sentence (clamped) or null. Whether the
+ * question deserves a nudge is NOT decided here — that is the fire-time
+ * moment judge's call.
+ */
+export function extractTrailingQuestion(text: string): string | null {
+  const trimmed = text.trim();
+  if (trimmed.length < 4) return null;
+  // Allow closing quotes/brackets after the question mark.
+  if (!/\?["'’”)\]]*$/.test(trimmed)) return null;
+  const lastQuestionMark = trimmed.lastIndexOf("?");
+  const preceding = trimmed.slice(0, lastQuestionMark);
+  const sentenceStart =
+    Math.max(
+      preceding.lastIndexOf("."),
+      preceding.lastIndexOf("!"),
+      preceding.lastIndexOf("?"),
+      preceding.lastIndexOf("\n"),
+    ) + 1;
+  // Keep everything through the end: the anchor regex guarantees only the
+  // question mark and its closing quotes/brackets follow `sentenceStart`.
+  const question = trimmed.slice(sentenceStart).trim();
+  if (question.length < 4) return null;
+  if (question.length <= QUESTION_SNIPPET_MAX_LENGTH) return question;
+  return `…${question.slice(question.length - QUESTION_SNIPPET_MAX_LENGTH + 1)}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+/** Structural check: is this task an unanswered-question follow-up (for `roomId`)? */
+export function isUnansweredQuestionFollowupTask(
+  task: ScheduledTask,
+  roomId?: string,
+): boolean {
+  if (task.kind !== "followup") return false;
+  const metadata = isRecord(task.metadata) ? task.metadata : null;
+  if (metadata?.[UNANSWERED_QUESTION_METADATA_KEY] !== true) return false;
+  if (roomId === undefined) return true;
+  return metadata.pendingPromptRoomId === roomId;
+}
+
+type RunnerHandle = ReturnType<typeof getScheduledTaskRunner>;
+
+async function dismissScheduledQuestionFollowups(
+  runner: RunnerHandle,
+  roomId: string,
+  reason: string,
+): Promise<string[]> {
+  const scheduled = await runner.list({
+    kind: "followup",
+    status: "scheduled",
+  });
+  const dismissed: string[] = [];
+  for (const task of scheduled) {
+    if (!isUnansweredQuestionFollowupTask(task, roomId)) continue;
+    await runner.apply(task.taskId, "dismiss", { reason });
+    dismissed.push(task.taskId);
+  }
+  return dismissed;
+}
+
+function buildQuestionFollowupTask(args: {
+  agentId: string;
+  roomId: string;
+  messageId: string;
+  question: string;
+  nowMs: number;
+}): ScheduledTaskInput {
+  const fireAtIso = new Date(
+    args.nowMs + UNANSWERED_QUESTION_FOLLOWUP_DELAY_MINUTES * 60_000,
+  ).toISOString();
+  return {
+    kind: "followup",
+    promptInstructions:
+      `Earlier you asked the owner: "${args.question}" and they have not answered. ` +
+      "Write one gentle, low-pressure follow-up that re-surfaces the question without guilt-tripping. " +
+      "One short line; make it easy to answer or wave off.",
+    trigger: { kind: "once", atIso: fireAtIso },
+    priority: "low",
+    shouldFire: {
+      compose: "first_deny",
+      // Hard constraint first (owner-set quiet hours), then the model moment
+      // judge decides send / defer / drop with full owner context (#14677).
+      gates: [{ kind: "quiet_hours" }, { kind: "model_moment_check" }],
+    },
+    completionCheck: {
+      kind: "user_replied_within",
+      followupAfterMinutes: FOLLOWUP_COMPLETION_TIMEOUT_MINUTES,
+    },
+    output: { destination: "channel", target: `in_app:${args.roomId}` },
+    respectsGlobalPause: true,
+    source: "plugin",
+    createdBy: UNANSWERED_QUESTION_CREATED_BY,
+    ownerVisible: true,
+    idempotencyKey: `lifeops:unanswered-question:${args.roomId}:${args.messageId}`,
+    metadata: {
+      [UNANSWERED_QUESTION_METADATA_KEY]: true,
+      pendingPromptRoomId: args.roomId,
+      questionMessageId: args.messageId,
+      questionSnippet: args.question,
+    },
+  };
+}
+
+export interface QuestionFollowupRegistration {
+  taskId: string;
+  fireAtIso: string;
+  supersededTaskIds: string[];
+}
+
+/**
+ * Register a follow-up for an agent reply that ends with a question. Returns
+ * the registration, or `null` when the message is not a qualifying agent
+ * question (not the agent's, no room, no trailing question, or not a reply to
+ * an owner message).
+ */
+export async function registerQuestionFollowupForAgentMessage(
+  runtime: IAgentRuntime,
+  message: Memory,
+  options: { now?: Date } = {},
+): Promise<QuestionFollowupRegistration | null> {
+  if (message.entityId !== runtime.agentId) return null;
+  const roomId = typeof message.roomId === "string" ? message.roomId : null;
+  if (!roomId || !message.id) return null;
+  const question = extractTrailingQuestion(messageText(message));
+  if (!question) return null;
+
+  // Owner scope: only replies to an owner message register a follow-up. The
+  // outbound memory itself carries the agent's entity, so ownership is read
+  // from the inbound message this reply answers.
+  const inReplyTo = message.content?.inReplyTo;
+  if (typeof inReplyTo !== "string" || inReplyTo.length === 0) return null;
+  const inbound = await runtime.getMemoryById(inReplyTo as UUID);
+  if (!inbound || !(await hasOwnerAccess(runtime, inbound))) return null;
+
+  const now = options.now ?? new Date();
+  const runner = getScheduledTaskRunner(runtime, {
+    agentId: String(runtime.agentId),
+  });
+  // The newest question supersedes any still-scheduled predecessor: one open
+  // question follow-up per room.
+  const supersededTaskIds = await dismissScheduledQuestionFollowups(
+    runner,
+    roomId,
+    "superseded_by_newer_agent_question",
+  );
+  const input = buildQuestionFollowupTask({
+    agentId: String(runtime.agentId),
+    roomId,
+    messageId: String(message.id),
+    question,
+    nowMs: now.getTime(),
+  });
+  const task = await runner.schedule(input);
+  logger.info(
+    {
+      src: LOG_SRC,
+      agentId: runtime.agentId,
+      taskId: task.taskId,
+      roomId,
+      supersededTaskIds,
+    },
+    `[UnansweredQuestionFollowup] registered follow-up for open question in room ${roomId}`,
+  );
+  return {
+    taskId: task.taskId,
+    fireAtIso:
+      input.trigger.kind === "once" ? input.trigger.atIso : now.toISOString(),
+    supersededTaskIds,
+  };
+}
+
+/**
+ * Dismiss still-scheduled question follow-ups for a room the owner just spoke
+ * in. FIRED follow-ups are deliberately untouched — the reply completes those
+ * through `inbound-reply-completion` / `user_replied_within`.
+ */
+export async function cancelQuestionFollowupsOnOwnerReply(
+  runtime: IAgentRuntime,
+  message: Memory,
+): Promise<string[]> {
+  if (message.entityId === runtime.agentId) return [];
+  const roomId = typeof message.roomId === "string" ? message.roomId : null;
+  if (!roomId) return [];
+  if (!(await hasOwnerAccess(runtime, message))) return [];
+  const runner = getScheduledTaskRunner(runtime, {
+    agentId: String(runtime.agentId),
+  });
+  const dismissed = await dismissScheduledQuestionFollowups(
+    runner,
+    roomId,
+    "owner_re_engaged",
+  );
+  if (dismissed.length > 0) {
+    logger.info(
+      { src: LOG_SRC, agentId: runtime.agentId, roomId, dismissed },
+      "[UnansweredQuestionFollowup] owner re-engaged; dismissed scheduled follow-up(s)",
+    );
+  }
+  return dismissed;
+}
+
+/**
+ * `MESSAGE_SENT` event handler. Boundary catch: an outbound chat reply must
+ * never fail because the scheduled-task store or runner host is broken.
+ */
+export async function handleAgentMessageSentForQuestionFollowup(
+  payload: MessagePayload,
+): Promise<void> {
+  try {
+    const runtime = payload.runtime;
+    if (!runtime || !payload.message) return;
+    await registerQuestionFollowupForAgentMessage(runtime, payload.message);
+  } catch (error) {
+    // error-policy:J1 boundary translation — event-bus handler edge; the
+    // failure is logged and the send pipeline continues.
+    logger.warn(
+      { src: LOG_SRC, error },
+      `[UnansweredQuestionFollowup] follow-up registration failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
+/**
+ * `MESSAGE_RECEIVED` event handler. Boundary catch: an inbound chat message
+ * must never fail because a follow-up row is broken.
+ */
+export async function handleOwnerMessageForQuestionFollowup(
+  payload: MessagePayload,
+): Promise<void> {
+  try {
+    const runtime = payload.runtime;
+    if (!runtime || !payload.message) return;
+    await cancelQuestionFollowupsOnOwnerReply(runtime, payload.message);
+  } catch (error) {
+    // error-policy:J1 boundary translation — event-bus handler edge; the
+    // failure is logged and the message pipeline continues.
+    logger.warn(
+      { src: LOG_SRC, error },
+      `[UnansweredQuestionFollowup] follow-up cancellation failed: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -161,6 +161,10 @@ import {
 } from "./lifeops/scheduled-task/runtime-wiring.js";
 import { handleScheduledTaskInboundMessage } from "./lifeops/scheduled-task/scheduler.js";
 import { getScheduledTaskRunner as getProductionScheduledTaskRunner } from "./lifeops/scheduled-task/service.js";
+import {
+  handleAgentMessageSentForQuestionFollowup,
+  handleOwnerMessageForQuestionFollowup,
+} from "./lifeops/scheduled-task/unanswered-question-followup.js";
 import { lifeOpsSchema } from "./lifeops/schema.js";
 import {
   createSendPolicyRegistry,
@@ -725,7 +729,14 @@ const rawPersonalAssistantPlugin: Plugin = {
           );
         }
       },
+      // Owner re-engaged: any still-scheduled unanswered-question follow-up
+      // for the room is stale — dismiss it (#14676).
+      handleOwnerMessageForQuestionFollowup,
     ],
+    // Agent reply ends with a question the owner never answers → seed a
+    // once-fired follow-up whose fire-time admission is the model moment
+    // judge (#14676, riding the #14677 model_moment_check seam).
+    [EventType.MESSAGE_SENT]: [handleAgentMessageSentForQuestionFollowup],
     // Fold recognized voice turns into the entity/relationship graph via
     // the merge engine, then round-trip the binding to the voice-profile
     // owner. See lifeops/entities/voice-observer-bridge.ts.

--- a/plugins/plugin-personal-assistant/test/default-packs.schema.test.ts
+++ b/plugins/plugin-personal-assistant/test/default-packs.schema.test.ts
@@ -420,8 +420,10 @@ describe("W1-D habit-starters pack", () => {
       (r) => r.metadata?.recordKey === HABIT_STARTER_KEYS.stretch,
     );
     expect(stretch?.shouldFire?.compose).toBe("first_deny");
+    // late_evening_skip encoded a timing JUDGMENT; that call now belongs to
+    // the model moment judge, composed after the structural gates (#14677).
     expect(stretch?.shouldFire?.gates.map((g) => g.kind).sort()).toEqual([
-      "late_evening_skip",
+      "model_moment_check",
       "stretch.walk_out_reset",
       "weekend_skip",
     ]);

--- a/plugins/plugin-personal-assistant/vitest.config.ts
+++ b/plugins/plugin-personal-assistant/vitest.config.ts
@@ -322,6 +322,21 @@ export default defineConfig({
       // the broad `@elizaos/ui/(.+)` stub alias so they win the match.
       { find: /^@elizaos\/ui\/spatial\/tui$/, replacement: uiSpatialTuiSrc },
       { find: /^@elizaos\/ui\/spatial$/, replacement: uiSpatialSrc },
+      // Pure-data settings-section metadata consumed by app-control's settings
+      // action (#14804) — React-free by design, so anchor the real module
+      // ahead of the broad ui stub alias.
+      {
+        find: /^@elizaos\/ui\/components\/settings\/settings-section-meta$/,
+        replacement: path.join(
+          elizaRoot,
+          "packages",
+          "ui",
+          "src",
+          "components",
+          "settings",
+          "settings-section-meta.ts",
+        ),
+      },
       {
         find: /^@elizaos\/ui\/(.+)$/,
         replacement: path.join(lifeopsTestStubsRoot, "ui.ts"),
@@ -378,6 +393,22 @@ export default defineConfig({
           elizaRoot,
           "plugins",
           "plugin-calendar",
+          "src",
+          "$1.ts",
+        ),
+      },
+      // The agent's settings action pulls the shared parser from the
+      // `@elizaos/plugin-app-control/actions/settings` subpath (#14804), but
+      // app-control's build bundles only the barrel — there is no per-file
+      // dist and vitest has no eliza-source condition, so the subpath must be
+      // anchored to source (the bare specifier stays stubbed via
+      // optionalCorePluginStubPackages above).
+      {
+        find: /^@elizaos\/plugin-app-control\/(.+)$/,
+        replacement: path.join(
+          elizaRoot,
+          "plugins",
+          "plugin-app-control",
           "src",
           "$1.ts",
         ),

--- a/plugins/plugin-scheduling/src/scheduled-task/gate-registry.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/gate-registry.test.ts
@@ -326,3 +326,37 @@ describe("weekday_only honors params.weekdays", () => {
     });
   });
 });
+
+describe("registerBuiltInGates: model_moment_check fallback (#14677)", () => {
+  it("registers a resolvable model_moment_check gate", () => {
+    const reg = createTaskGateRegistry();
+    registerBuiltInGates(reg);
+    expect(reg.get("model_moment_check")).not.toBeNull();
+    expect(lookupGateDecision(reg, "model_moment_check")).toEqual({
+      kind: "allow",
+    });
+  });
+
+  it("allows by default — no judge available means no judgment, never a starved task", async () => {
+    const reg = createTaskGateRegistry();
+    registerBuiltInGates(reg);
+    const gate = reg.get("model_moment_check");
+    const task = sleepRecapTask();
+    const decision = await gate?.evaluate(task, makeContext(task));
+    expect(decision).toEqual({ kind: "allow" });
+  });
+
+  it("a pre-registered production judge wins over the fallback (first-wins)", async () => {
+    const reg = createTaskGateRegistry();
+    reg.register({
+      kind: "model_moment_check",
+      evaluate: () => ({ kind: "deny", reason: "judge says drop" }),
+    });
+    registerBuiltInGates(reg);
+    const task = sleepRecapTask();
+    const decision = await reg
+      .get("model_moment_check")
+      ?.evaluate(task, makeContext(task));
+    expect(decision).toEqual({ kind: "deny", reason: "judge says drop" });
+  });
+});

--- a/plugins/plugin-scheduling/src/scheduled-task/gate-registry.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/gate-registry.ts
@@ -2,7 +2,7 @@
  * TaskGateRegistry. Built-in kinds: `weekend_skip`, `weekend_only`,
  * `weekday_only`, `late_evening_skip`, `quiet_hours`, `during_travel`,
  * `circadian_state_in`, `no_recent_user_message_in`,
- * `personal_baseline_sufficient`.
+ * `personal_baseline_sufficient`, `model_moment_check`.
  *
  * The runner uses these gates in `shouldFire.gates`; composition is
  * the responsibility of the runner (`compose: "all" | "any" | "first_deny"`).
@@ -340,6 +340,25 @@ const noRecentUserMessageInGate: TaskGateContribution = {
   },
 };
 
+/**
+ * `model_moment_check` — generic built-in fallback (#14677). The real reader is
+ * a model judgment ("is this a good moment to interrupt the owner?") that needs
+ * a live model surface, which the spine deliberately does not have — it is
+ * registered by `plugin-personal-assistant`'s runner wiring and, because
+ * `registerBuiltInGates` is first-wins, takes precedence over this fallback.
+ *
+ * Standalone (no judge registered) there is no judgment to consult, so the
+ * honest default is `allow`: the task's deterministic gates already ran, and
+ * this kind exists to REFINE their verdict, never to silently starve a task on
+ * hosts without a model.
+ */
+const modelMomentCheckGate: TaskGateContribution = {
+  kind: "model_moment_check",
+  evaluate(): GateDecision {
+    return { kind: "allow" };
+  },
+};
+
 interface PersonalBaselineSufficientParams {
   minSamples?: number;
 }
@@ -424,6 +443,7 @@ export function registerBuiltInGates(reg: TaskGateRegistry): void {
     circadianStateInGate,
     noRecentUserMessageInGate,
     personalBaselineSufficientGate,
+    modelMomentCheckGate,
   ];
   for (const gate of builtins) {
     if (!reg.get(gate.kind)) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -51,6 +51,14 @@ export default defineConfig({
         replacement: path.join(root, "packages/agent/src/$1"),
       },
       {
+        // The agent's settings action imports the shared parser from this
+        // subpath (#14804); app-control's build bundles only the barrel, so
+        // without the eliza-source condition the subpath has no dist file to
+        // resolve to and must be pinned to source here.
+        find: /^@elizaos\/plugin-app-control\/(.+)$/,
+        replacement: path.join(root, "plugins/plugin-app-control/src/$1"),
+      },
+      {
         find: /^@elizaos\/logger$/,
         replacement: path.join(root, "packages/logger/src/index.ts"),
       },


### PR DESCRIPTION
Closes #14677. Closes #14676.

## What became model-decided vs what stays structural

**Model-decided (new):**
- Whether NOW is a good moment for any owner-facing proactive send: the new `model_moment_check` gate asks a TEXT_SMALL judge for `send` / `defer(minutes)` / `drop`, grounded in owner context the runtime already tracks (minutes since last seen active, observed circadian state, quiet streak of ignored pokes, owner-local time, morning/evening windows, chronotype, schedule style). A `defer` reschedules (clamped 5m–8h); a `drop` skips the fire.
- Whether an unanswered question deserves a nudge at all: the follow-up task's fire-time admission is `first_deny: [quiet_hours, model_moment_check]`, so the judge sees the open question text and the owner's presence before anything is sent.
- The former `late_evening_skip` on the stretch habit — a hardcoded timing judgment ("too late in the evening") — is now the judge's call.

**Structural (unchanged doctrine, deliberately NOT model-decided):**
- Hard constraints stay deterministic and compose BEFORE the judge under `first_deny`: owner-set `quiet_hours`, `weekday_only`/`weekend_skip` config, `during_window` triggers — the model call is only paid when everything structural already allowed, and the judge can never override owner-set quiet hours (verified by test).
- `priority: high` bypasses the judge entirely — a model must never veto an urgent send (same rail as `quiet_hours.highPriorityBypass`).
- Judge unavailable / unparseable output degrades to today's deterministic-only dispatch (reported via `runtime.reportError`), never a starved task, never a fabricated verdict.
- Candidate detection for the unanswered-question follow-up is structural (reply ENDS with a question, replying to an owner message) — detection is only candidacy; worth is the judge's fire-time call.

## The seam

- `plugin-scheduling` gains `model_moment_check` as a built-in gate kind with an honest always-allow fallback; `registerBuiltInGates` is first-wins, so PA's runner wiring registers the real model-backed reader ahead of it (same pattern as the ActivityProfile gates). Hosts without PA (plugin-health standalone) keep resolving the kind.
- PA `moment-judge.ts`: prompt builder + verdict parser are pure and unit-tested; the gate reads the runtime model under a trajectory purpose (`scheduled-moment-judge`).
- PA `unanswered-question-followup.ts` (#14676): `MESSAGE_SENT` seeds a `kind:"followup"` once-task (45m) when an agent reply to an owner message ends with a question; `MESSAGE_RECEIVED` dismisses still-scheduled follow-ups for the room (owner re-engaged); a newer question supersedes its predecessor (one per room); a FIRED nudge completes through the existing `user_replied_within` inbound-reply seam. No new scheduler: everything is `ScheduledTask` records through the one runner.
- Default packs: morning greeting, nightly wind-down, daily check-in, weekly planning, and the owner-facing habit starters now carry the judge after their structural gates.

## Repairs found along the way

- `inbound-reply-completion.integration.test.ts` was silently broken: core `hasRoleAccess` now fails CLOSED for senders whose role cannot be resolved, so the harness's synthetic owner never passed `hasOwnerAccess` and 3 of its tests failed under the source lane. The harness now records the canonical owner (`ELIZA_ADMIN_ENTITY_ID`), the same pattern `scheduler.integration.test.ts` uses; the two check-in tests added on develop got the same treatment.
- #14804 added an `@elizaos/plugin-app-control/actions/settings` import to `packages/agent`, but app-control's build bundles only the barrel and vitest lanes have no `eliza-source` condition — every source-resolving lane that loads agent src died with "Cannot find package". Pinned the subpath (and the React-free `settings-section-meta` ui subpath it pulls) to source in the root and PA vitest configs, following the in-repo plugin-discord/user-account-scraper precedent.

## Tests (all green locally)

| Suite | Lane | Result |
| --- | --- | --- |
| `unanswered-question-followup.integration.test.ts` (new, 11 tests: registration, supersede, MESSAGE_RECEIVED dismissal, self-outbound immunity, judge drop/send verdicts on the real fire path, quiet-hours-before-judge hard constraint) | PA `vitest.src-integration.config.ts` (real DB runtime) AND root config (real `hasOwnerAccess`) | 11/11 |
| `inbound-reply-completion.integration.test.ts` (repaired, 7 tests) | both lanes as above | 7/7 |
| `moment-judge.test.ts` (new, 17 tests: prompt content, verdict parsing incl. fenced/garbage output, defer clamping, high-priority bypass, judge-failure degrade) | PA unit lane | 17/17 |
| `gate-registry.test.ts` (+2: fallback allow, first-wins shadowing) | plugin-scheduling lane | 18/18 |
| `default-packs.schema.test.ts` (stretch gate assertion updated) | PA unit lane | 40/41* |

\* the one failure (`priority_high_default has connected-channel candidates ending in in_app`) is pre-existing develop fallout from #14881, present with this branch's changes stashed; untouched by this PR.

`bun x biome check` clean on all touched files; `bun run audit:error-policy-ratchet` — no new fallback-slop; turbo `typecheck` green for `@elizaos/plugin-personal-assistant` + `@elizaos/plugin-scheduling` (79 tasks).

## Evidence

- Backend structured logs: integration runs log `[MomentJudge] drop: owner moved on` / `[UnansweredQuestionFollowup] registered follow-up …` through the real runner (see test output; logs in details below).
- Real-LLM trajectories: N/A — the judge is exercised at the runtime `useModel` boundary with deterministic verdict stubs in the integration tests (the fire path, gate composition, and degrade behavior are what changed); the prompt content itself is pinned by unit tests. No UI surface changed.
- Screenshots / video / frontend logs: N/A — no user-facing UI change.

<details><summary>Integration lane output</summary>

```
Test Files  2 passed (2)
     Tests  18 passed (18)   # PA vitest.src-integration.config.ts
```

```
Tests  11 passed (11)  # unanswered-question-followup, root config (real hasOwnerAccess)
Tests   7 passed (7)   # inbound-reply-completion, root config
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)