### PR TITLE
chore(cloud): Steward-tenant backfill for pre-#14869 orgs — frees the 665 looping accounts (#14645)

### DIFF
--- a/packages/scripts/cloud/admin/backfill-steward-tenants.ts
+++ b/packages/scripts/cloud/admin/backfill-steward-tenants.ts
@@ -1,0 +1,153 @@
+#!/usr/bin/env bun
+/**
+ * Backfill per-org Steward tenants for organizations created before eager
+ * provisioning landed (#14869 / #14645).
+ *
+ * Orgs born before that fix have `organizations.steward_tenant_id = NULL`
+ * (tenants were only created lazily at first agent-provision), which leaves
+ * their users unable to complete the console golden path. This walks every
+ * NULL-tenant org through the exact production path — `ensureStewardTenant`
+ * (idempotent, 409-tolerant, fail-closed on keyless provisions) — so the
+ * backfill can be safely re-run and never half-provisions an org.
+ *
+ * ⚠️ Each provision creates a REAL tenant on the shared Steward service, so
+ * the default is a dry-run listing; pass --execute to mutate. Use --org to
+ * target specific orgs first (e.g. launch-QA accounts), --limit to bound a
+ * run, and --delay-ms to pace the Steward API.
+ *
+ * Usage:
+ *   bun run packages/scripts/cloud/admin/backfill-steward-tenants.ts            # dry-run
+ *   bun run ... --org <uuid> [--org <uuid> ...] --execute                       # targeted
+ *   bun run ... --limit 100 --execute                                           # bounded batch
+ */
+
+import { isNull } from "drizzle-orm";
+import { loadEnvFiles } from "./local-dev-helpers";
+
+loadEnvFiles();
+
+interface Flags {
+  execute: boolean;
+  orgIds: string[];
+  limit: number | undefined;
+  delayMs: number;
+}
+
+function parseFlags(args: string[]): Flags {
+  const flags: Flags = {
+    execute: args.includes("--execute"),
+    orgIds: [],
+    limit: undefined,
+    delayMs: 150,
+  };
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--org") {
+      const value = args[i + 1];
+      if (!value) throw new Error("Missing value for --org");
+      flags.orgIds.push(value);
+      i++;
+    } else if (args[i] === "--limit" || args[i] === "--delay-ms") {
+      const value = Number.parseInt(args[i + 1] ?? "", 10);
+      if (!Number.isFinite(value) || value <= 0) {
+        throw new Error(`Invalid value for ${args[i]}: ${args[i + 1]}`);
+      }
+      if (args[i] === "--limit") flags.limit = value;
+      else flags.delayMs = value;
+      i++;
+    }
+  }
+  return flags;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log(`
+Backfill per-org Steward tenants (#14645)
+=========================================
+
+Options:
+  --execute        Actually provision (default: dry-run listing only)
+  --org <uuid>     Target specific org id(s); repeatable. Skips the NULL scan.
+  --limit <n>      Process at most n orgs
+  --delay-ms <n>   Pause between provisions (default: 150)
+  --help           Show this message
+`);
+    process.exit(0);
+  }
+
+  const flags = parseFlags(args);
+
+  const { db } = await import("@elizaos/cloud-shared/db/client");
+  const { organizations } = await import("@elizaos/cloud-shared/db/schemas/organizations");
+  const { ensureStewardTenant } = await import(
+    "@elizaos/cloud-shared/lib/services/steward-tenant-config"
+  );
+  const { isStewardPlatformConfigured } = await import(
+    "@elizaos/cloud-shared/lib/services/steward-platform-users"
+  );
+
+  if (flags.execute && !isStewardPlatformConfigured()) {
+    // Without a platform key ensureStewardTenant silently falls back to the
+    // shared default tenant instead of provisioning — that "success" would
+    // mark nothing and fix nothing. Refuse to pretend.
+    console.error(
+      "STEWARD_PLATFORM_KEYS is not configured; --execute would no-op into the default-tenant fallback. Aborting.",
+    );
+    process.exit(1);
+  }
+
+  let candidates: Array<{ id: string; slug: string }>;
+  if (flags.orgIds.length > 0) {
+    candidates = flags.orgIds.map((id) => ({ id, slug: "(targeted)" }));
+  } else {
+    const rows = await db
+      .select({ id: organizations.id, slug: organizations.slug })
+      .from(organizations)
+      .where(isNull(organizations.steward_tenant_id));
+    candidates = flags.limit ? rows.slice(0, flags.limit) : rows;
+    console.log(
+      `Found ${rows.length} org(s) with NULL steward_tenant_id${flags.limit ? `; processing ${candidates.length}` : ""}`,
+    );
+  }
+
+  if (!flags.execute) {
+    for (const org of candidates) console.log(`DRY-RUN would provision: ${org.id} (${org.slug})`);
+    console.log(`\nDry-run complete: ${candidates.length} org(s). Re-run with --execute to provision.`);
+    process.exit(0);
+  }
+
+  let provisioned = 0;
+  let alreadyHad = 0;
+  let failed = 0;
+  for (const [index, org] of candidates.entries()) {
+    try {
+      const result = await ensureStewardTenant(org.id);
+      if (result.isNew) {
+        provisioned++;
+        console.log(`[${index + 1}/${candidates.length}] provisioned ${result.tenantId} for ${org.id}`);
+      } else {
+        alreadyHad++;
+        console.log(`[${index + 1}/${candidates.length}] already linked ${result.tenantId} for ${org.id}`);
+      }
+    } catch (error) {
+      failed++;
+      console.error(
+        `[${index + 1}/${candidates.length}] FAILED ${org.id}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    if (flags.delayMs > 0 && index < candidates.length - 1) {
+      await new Promise((resolve) => setTimeout(resolve, flags.delayMs));
+    }
+  }
+
+  console.log(
+    `\nBackfill complete: ${provisioned} provisioned, ${alreadyHad} already linked, ${failed} failed of ${candidates.length}.`,
+  );
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch((error) => {
+  console.error("Backfill failed:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

The reviewable backfill for #14645's remaining half: **665 orgs created before #14869 have `steward_tenant_id = NULL`** and their users cannot complete the console golden path (incl. the Seeker phone-lane org `7c7412f9`/nubsvault). #14869 (merged) fixes future signups only; this script fixes the existing population.

## How

Walks every NULL-tenant org through **`ensureStewardTenant(orgId)`** — the exact production path #14869 runs at signup (idempotent: early-returns linked orgs; 409-links deterministic `elizacloud-<slug>` tenants; fail-closed before writing the org row on keyless/unparseable provisions — per its J1 blocks). No raw SQL, no new mutation surface.

Safety shape (each provision creates a REAL tenant on the shared Steward service):
- **Dry-run by default** — lists candidates, mutates nothing; `--execute` required to provision.
- **`--org <uuid>`** (repeatable) targeted mode — run the launch-QA orgs first (`7c7412f9` etc.).
- **`--limit` / `--delay-ms`** (default 150ms) to bound + pace the Steward API.
- **Refuses `--execute` without `STEWARD_PLATFORM_KEYS`** — `ensureStewardTenant` would otherwise silently fall back to the shared default tenant, "succeeding" while fixing nothing.
- Per-org failures are counted + reported, never abort the batch; non-zero exit on any failure.

## Evidence

- `--help` + flag parsing verified locally; dry-run resolves imports and reaches the real `SELECT ... WHERE steward_tenant_id IS NULL` (fails locally only for lack of schema in a fresh PGlite — the sibling `backfill-steward-users.ts` cannot run locally at all; these are box-run admin tools, executed via `tsx --tsconfig packages/cloud-shared/tsconfig.json` on the CP with the real `DATABASE_URL`, same as tonight's #14424 ops).
- Package-subpath imports (`@elizaos/cloud-shared/...`) chosen over `@/` aliases so the script resolves both in-repo and on the CP box layout (`packages/cloud-shared`).
- **Run plan (after this gets eyes): staging dry-run → staging `--execute` → sol/qa re-verify a previously-looping staging account → prod targeted `--org 7c7412f9` (frees the phone lane) → prod full batch.** I will not run `--execute` anywhere before this PR is reviewed (money/auth-adjacent mass mutation on the shared Steward service).
- N/A - screenshots/trajectories (headless admin CLI; domain artifacts = the org rows + Steward tenants, which the run plan captures per environment).

Part of #14645 (with #14869). cc @0xSolace (issue owner) @qa-agent (post-backfill verify).

https://claude.ai/code/session_01Y9PKm5MocuCmetfstCenBH


## Evidence Matrix
<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - headless cloud admin CLI/backfill script; no rendered UI changed.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - headless cloud admin CLI/backfill script; no rendered UI changed.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no browser/mobile workflow changed; the required walkthrough artifact is the staged dry-run/execute terminal log and post-backfill account verification.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no shared Steward mutation was executed before review; attach staging/prod dry-run and execute logs when the run plan is performed.
<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A - no frontend runtime path changed.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no model/action/provider/prompt behavior changed.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - no tenant/org rows were mutated in this local pass; the required domain artifacts are staging/prod before/after org rows, created Steward tenant IDs, failure counts, and a previously-looping account completing sign-in after backfill.

## Execution Evidence Required
Do not treat #14645 as closed until the reviewed script has a captured dry-run, targeted staging execute, targeted prod execute for the phone-lane org, and full batch report with per-org successes/failures plus post-backfill account verification.
