### PR TITLE
fix(app-control): wire appearance settings chat writes

### DIFF
--- a/packages/shared/src/events/index.ts
+++ b/packages/shared/src/events/index.ts
@@ -6,6 +6,8 @@
  * EmotePicker, ChatView, etc.).
  */
 
+import type { UiLanguage } from "../i18n/language.js";
+
 // ── App lifecycle ────────────────────────────────────────────────────────
 export const COMMAND_PALETTE_EVENT = "eliza:command-palette" as const;
 export const EMOTE_PICKER_EVENT = "eliza:emote-picker" as const;
@@ -147,6 +149,20 @@ export interface BackgroundApplyPayload extends Record<string, unknown> {
    * crafted payload can't wedge or escape the background (#11088 / #13523).
    */
   catalogId?: string;
+}
+
+export const APPEARANCE_APPLY_EVENT = "appearance:apply" as const;
+
+/** Payload broadcast on {@link APPEARANCE_APPLY_EVENT}. */
+export interface AppearanceApplyPayload extends Record<string, unknown> {
+  /** Theme mode persisted by the Appearance settings section. */
+  themeMode?: "light" | "dark" | "system";
+  /** Accent preset id, e.g. default, amber, rose, green. */
+  accentId?: string;
+  /** Supported UI language code. */
+  language?: UiLanguage;
+  /** Whether the home time/date widget is hidden. */
+  homeTimeWidgetHidden?: boolean;
 }
 
 // ── Avatar / VRM ─────────────────────────────────────────────────────────

--- a/packages/ui/src/backgrounds/AppBackground.tsx
+++ b/packages/ui/src/backgrounds/AppBackground.tsx
@@ -10,6 +10,7 @@ import { DEFAULT_BACKGROUND_COLOR } from "../state/ui-preferences";
 import { useBackgroundConfig } from "../state/useBackgroundConfig";
 import { ImageBackground } from "./ImageBackground";
 import { ShaderBackground } from "./ShaderBackground";
+import { useAppearanceApplyChannel } from "./useAppearanceApplyChannel";
 import { useBackgroundApplyChannel } from "./useBackgroundApplyChannel";
 
 // three.js (~1.5 MB raw / ~320 KB brotli) is only needed for the opt-in GLSL
@@ -72,6 +73,7 @@ export function AppBackground({
 }: AppBackgroundProps = {}): React.JSX.Element | null {
   const { backgroundConfig } = useBackgroundConfig();
   useBackgroundApplyChannel();
+  useAppearanceApplyChannel();
   if (!visible) return null;
   // Defensive: the app store can return a non-object slice before the provider
   // seeds it (e.g. the test fallback proxy). Fall back to the default shader.

--- a/packages/ui/src/backgrounds/useAppearanceApplyChannel.test.tsx
+++ b/packages/ui/src/backgrounds/useAppearanceApplyChannel.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+/**
+ * jsdom coverage for the chat-to-appearance view event bridge. The hook is
+ * tested with the app store seeded directly so the test proves the event
+ * contract reaches the same setters used by the Appearance settings section.
+ */
+
+import { APPEARANCE_APPLY_EVENT as SHARED_APPEARANCE_APPLY_EVENT } from "@elizaos/shared/events";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { __setAppValueForTests } from "../state/app-store";
+import { emitViewEvent } from "../views/view-event-bus";
+import {
+  APPEARANCE_APPLY_EVENT,
+  useAppearanceApplyChannel,
+} from "./useAppearanceApplyChannel";
+
+function Channel(): null {
+  useAppearanceApplyChannel();
+  return null;
+}
+
+function mountChannel() {
+  const setters = {
+    setUiThemeMode: vi.fn(),
+    setUiAccent: vi.fn(),
+    setUiLanguage: vi.fn(),
+    setHomeTimeWidgetHidden: vi.fn(),
+  };
+  __setAppValueForTests(setters as never);
+  render(<Channel />);
+  return setters;
+}
+
+function apply(payload: Record<string, unknown>): void {
+  act(() => {
+    emitViewEvent(APPEARANCE_APPLY_EVENT, payload, "agent");
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  __setAppValueForTests(null);
+});
+
+describe("useAppearanceApplyChannel", () => {
+  it("uses the shared appearance apply event contract", () => {
+    expect(APPEARANCE_APPLY_EVENT).toBe(SHARED_APPEARANCE_APPLY_EVENT);
+  });
+
+  it("applies valid appearance fields to the persisted preference setters", () => {
+    const setters = mountChannel();
+    apply({
+      themeMode: "dark",
+      accentId: "green",
+      language: "es",
+      homeTimeWidgetHidden: true,
+    });
+
+    expect(setters.setUiThemeMode).toHaveBeenCalledWith("dark");
+    expect(setters.setUiAccent).toHaveBeenCalledWith("green");
+    expect(setters.setUiLanguage).toHaveBeenCalledWith("es");
+    expect(setters.setHomeTimeWidgetHidden).toHaveBeenCalledWith(true);
+  });
+
+  it("ignores unrecognised theme, accent, and language tokens", () => {
+    const setters = mountChannel();
+    apply({
+      themeMode: "sepia",
+      accentId: "cyan",
+      language: "fr",
+      homeTimeWidgetHidden: "false",
+    });
+
+    expect(setters.setUiThemeMode).not.toHaveBeenCalled();
+    expect(setters.setUiAccent).not.toHaveBeenCalled();
+    expect(setters.setUiLanguage).not.toHaveBeenCalled();
+    expect(setters.setHomeTimeWidgetHidden).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/backgrounds/useAppearanceApplyChannel.ts
+++ b/packages/ui/src/backgrounds/useAppearanceApplyChannel.ts
@@ -1,0 +1,64 @@
+/**
+ * Always-mounted bridge for chat-driven appearance preferences.
+ *
+ * SETTINGS broadcasts `appearance:apply` over the shared view-event bus; this
+ * hook is the renderer subscriber that applies those semantic values to the
+ * same persisted preference setters used by the Appearance settings section.
+ */
+
+import {
+  APPEARANCE_APPLY_EVENT,
+  type AppearanceApplyPayload,
+} from "@elizaos/shared/events";
+import { useViewEvent } from "../hooks/useViewEvent";
+import { UI_LANGUAGES, type UiLanguage } from "../i18n";
+import { useAppSelector } from "../state/app-store";
+import { ACCENT_PRESETS, type UiThemeMode } from "../state/ui-preferences";
+
+export type { AppearanceApplyPayload } from "@elizaos/shared/events";
+export { APPEARANCE_APPLY_EVENT };
+
+const THEME_MODES = new Set<UiThemeMode>(["light", "dark", "system"]);
+const ACCENT_IDS = new Set(ACCENT_PRESETS.map((preset) => preset.id));
+const LANGUAGE_IDS = new Set<string>(UI_LANGUAGES);
+
+function readThemeMode(value: unknown): UiThemeMode | null {
+  return typeof value === "string" && THEME_MODES.has(value as UiThemeMode)
+    ? (value as UiThemeMode)
+    : null;
+}
+
+function readAccentId(value: unknown): string | null {
+  return typeof value === "string" && ACCENT_IDS.has(value) ? value : null;
+}
+
+function readLanguage(value: unknown): UiLanguage | null {
+  return typeof value === "string" && LANGUAGE_IDS.has(value)
+    ? (value as UiLanguage)
+    : null;
+}
+
+export function useAppearanceApplyChannel(): void {
+  const setUiThemeMode = useAppSelector((state) => state.setUiThemeMode);
+  const setUiAccent = useAppSelector((state) => state.setUiAccent);
+  const setUiLanguage = useAppSelector((state) => state.setUiLanguage);
+  const setHomeTimeWidgetHidden = useAppSelector(
+    (state) => state.setHomeTimeWidgetHidden,
+  );
+
+  useViewEvent(APPEARANCE_APPLY_EVENT, (event) => {
+    const payload = event.payload as AppearanceApplyPayload;
+    const themeMode = readThemeMode(payload.themeMode);
+    if (themeMode) setUiThemeMode(themeMode);
+
+    const accentId = readAccentId(payload.accentId);
+    if (accentId) setUiAccent(accentId);
+
+    const language = readLanguage(payload.language);
+    if (language) setUiLanguage(language);
+
+    if (typeof payload.homeTimeWidgetHidden === "boolean") {
+      setHomeTimeWidgetHidden(payload.homeTimeWidgetHidden);
+    }
+  });
+}

--- a/plugins/plugin-app-control/src/actions/settings.test.ts
+++ b/plugins/plugin-app-control/src/actions/settings.test.ts
@@ -7,6 +7,7 @@
  */
 
 import type { HandlerCallback, IAgentRuntime, Memory } from "@elizaos/core";
+import { APPEARANCE_APPLY_EVENT } from "@elizaos/shared";
 import {
 	SETTINGS_NON_CATALOG_SECTION_META,
 	SETTINGS_SECTION_META,
@@ -261,6 +262,8 @@ describe("SETTINGS action: list", () => {
 		expect(model).toMatchObject({ writable: true, via: "MODEL_SWITCH" });
 		const permissions = sections.find((s) => s.id === "permissions");
 		expect(permissions).toMatchObject({ writable: true, via: "SETTINGS" });
+		const appearance = sections.find((s) => s.id === "appearance");
+		expect(appearance).toMatchObject({ writable: true, via: "SETTINGS" });
 		const capabilities = sections.find((s) => s.id === "capabilities");
 		expect(capabilities).toMatchObject({ writable: true, via: "SETTINGS" });
 		const advanced = sections.find((s) => s.id === "advanced");
@@ -276,6 +279,100 @@ describe("SETTINGS action: list", () => {
 });
 
 describe("SETTINGS action: set on an owned route section", () => {
+	it("dispatches appearance theme mode through the view event broadcast route", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({ ok: true }));
+		const { result, texts } = await invoke(
+			{ action: "set", section: "appearance", key: "theme", value: "dark" },
+			routeFetch,
+		);
+		expect(routeFetch).toHaveBeenCalledWith({
+			method: "POST",
+			path: "/api/views/events/broadcast",
+			body: {
+				type: APPEARANCE_APPLY_EVENT,
+				payload: { themeMode: "dark" },
+			},
+		});
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({
+			section: "appearance",
+			key: "theme",
+		});
+		expect(texts.join(" ")).toContain("Theme mode is dark");
+	});
+
+	it("dispatches appearance accent aliases through the view event broadcast route", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({ ok: true }));
+		const { result } = await invoke(
+			{ action: "set", section: "appearance", key: "accent", value: "orange" },
+			routeFetch,
+		);
+		expect(routeFetch).toHaveBeenCalledWith({
+			method: "POST",
+			path: "/api/views/events/broadcast",
+			body: {
+				type: APPEARANCE_APPLY_EVENT,
+				payload: { accentId: "default" },
+			},
+		});
+		expect(result?.success).toBe(true);
+	});
+
+	it("dispatches appearance UI language through the view event broadcast route", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({ ok: true }));
+		const { result } = await invoke(
+			{
+				action: "set",
+				section: "theme",
+				key: "language",
+				value: "spanish",
+			},
+			routeFetch,
+		);
+		expect(routeFetch).toHaveBeenCalledWith({
+			method: "POST",
+			path: "/api/views/events/broadcast",
+			body: {
+				type: APPEARANCE_APPLY_EVENT,
+				payload: { language: "es" },
+			},
+		});
+		expect(result?.success).toBe(true);
+	});
+
+	it("dispatches the home time/date widget visibility as the persisted hidden flag", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({ ok: true }));
+		const { result } = await invoke(
+			{
+				action: "set",
+				section: "appearance",
+				key: "home-time-widget",
+				value: "off",
+			},
+			routeFetch,
+		);
+		expect(routeFetch).toHaveBeenCalledWith({
+			method: "POST",
+			path: "/api/views/events/broadcast",
+			body: {
+				type: APPEARANCE_APPLY_EVENT,
+				payload: { homeTimeWidgetHidden: true },
+			},
+		});
+		expect(result?.success).toBe(true);
+	});
+
+	it("rejects unsupported appearance values without broadcasting", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({ ok: true }));
+		const { result, texts } = await invoke(
+			{ action: "set", section: "appearance", key: "theme", value: "sepia" },
+			routeFetch,
+		);
+		expect(routeFetch).not.toHaveBeenCalled();
+		expect(result?.success).toBe(false);
+		expect(texts.join(" ")).toContain("supported appearance value");
+	});
+
 	it("dispatches permissions shell off through the backend route", async () => {
 		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({ ok: true }));
 		const { result, texts } = await invoke(

--- a/plugins/plugin-app-control/src/actions/settings.ts
+++ b/plugins/plugin-app-control/src/actions/settings.ts
@@ -31,6 +31,8 @@ import type {
 } from "@elizaos/core";
 import { logger, resolveServerOnlyPort } from "@elizaos/core";
 import {
+	APPEARANCE_APPLY_EVENT,
+	type AppearanceApplyPayload,
 	AppPermissionsViewSchema,
 	isPermissionId,
 	type PermissionId,
@@ -390,6 +392,135 @@ const COMPUTER_USE_CAPABILITY_KEY = makeCapabilityConfigKey(
 	"computer-use",
 );
 
+const APPEARANCE_THEME_ALIASES: ReadonlyMap<
+	string,
+	AppearanceApplyPayload["themeMode"]
+> = new Map([
+	["light", "light"],
+	["day", "light"],
+	["dark", "dark"],
+	["night", "dark"],
+	["system", "system"],
+	["auto", "system"],
+	["automatic", "system"],
+]);
+
+const APPEARANCE_ACCENT_ALIASES: ReadonlyMap<string, string> = new Map([
+	["default", "default"],
+	["orange", "default"],
+	["eliza", "default"],
+	["amber", "amber"],
+	["yellow", "amber"],
+	["rose", "rose"],
+	["pink", "rose"],
+	["red", "red"],
+	["green", "green"],
+	["olive", "olive"],
+]);
+
+const APPEARANCE_LANGUAGE_ALIASES: ReadonlyMap<
+	string,
+	AppearanceApplyPayload["language"]
+> = new Map([
+	["en", "en"],
+	["english", "en"],
+	["zh-cn", "zh-CN"],
+	["zh", "zh-CN"],
+	["chinese", "zh-CN"],
+	["mandarin", "zh-CN"],
+	["ko", "ko"],
+	["korean", "ko"],
+	["es", "es"],
+	["spanish", "es"],
+	["pt", "pt"],
+	["portuguese", "pt"],
+	["vi", "vi"],
+	["vietnamese", "vi"],
+	["tl", "tl"],
+	["tagalog", "tl"],
+	["filipino", "tl"],
+	["ja", "ja"],
+	["japanese", "ja"],
+]);
+
+function normalizeAppearanceToken(value: string | null): string | null {
+	if (!value) return null;
+	const normalized = value.trim().toLowerCase();
+	return normalized.length > 0 ? normalized : null;
+}
+
+function appearanceBroadcastRequest(
+	payload: AppearanceApplyPayload,
+): SettingsRouteRequest {
+	return {
+		method: "POST",
+		path: "/api/views/events/broadcast",
+		body: { type: APPEARANCE_APPLY_EVENT, payload },
+	};
+}
+
+function makeAppearanceCommandKey(
+	field: "themeMode" | "accentId" | "language",
+	description: string,
+): SettingsWritableKey {
+	return {
+		description,
+		valueType: "command",
+		apply: ({ request, routeFetch }) => {
+			const token = normalizeAppearanceToken(request.value);
+			const value =
+				field === "themeMode"
+					? APPEARANCE_THEME_ALIASES.get(token ?? "")
+					: field === "accentId"
+						? APPEARANCE_ACCENT_ALIASES.get(token ?? "")
+						: APPEARANCE_LANGUAGE_ALIASES.get(token ?? "");
+			if (!value) {
+				return Promise.resolve({
+					ok: false,
+					detail: `provide a supported appearance value for ${field}`,
+				});
+			}
+			return routeFetch(appearanceBroadcastRequest({ [field]: value }));
+		},
+		successText: (_value, request) => {
+			const token = normalizeAppearanceToken(request.value);
+			const value =
+				field === "themeMode"
+					? APPEARANCE_THEME_ALIASES.get(token ?? "")
+					: field === "accentId"
+						? APPEARANCE_ACCENT_ALIASES.get(token ?? "")
+						: APPEARANCE_LANGUAGE_ALIASES.get(token ?? "");
+			if (field === "themeMode") return `Theme mode is ${value}.`;
+			if (field === "accentId") return `Accent is ${value}.`;
+			return `UI language is ${value}.`;
+		},
+	};
+}
+
+const APPEARANCE_THEME_KEY = makeAppearanceCommandKey(
+	"themeMode",
+	"Theme mode: light, dark, or system.",
+);
+const APPEARANCE_ACCENT_KEY = makeAppearanceCommandKey(
+	"accentId",
+	"Accent preset: default/orange, amber, rose, red, green, or olive.",
+);
+const APPEARANCE_LANGUAGE_KEY = makeAppearanceCommandKey(
+	"language",
+	"UI language: en, zh-CN, ko, es, pt, vi, tl, or ja.",
+);
+
+const APPEARANCE_HOME_TIME_WIDGET_KEY: SettingsWritableKey = {
+	description: "Whether the home time/date widget is visible.",
+	valueType: "boolean",
+	buildRequest: (visible) =>
+		appearanceBroadcastRequest({ homeTimeWidgetHidden: !visible }),
+	successText: (visible) =>
+		visible
+			? "Home time/date widget is shown."
+			: "Home time/date widget is hidden.",
+};
+
 function readBackupFileName(data: unknown): string | null {
 	if (!data || typeof data !== "object") return null;
 	const backup = (data as { backup?: unknown }).backup;
@@ -550,9 +681,22 @@ export const SETTINGS_WRITE_REGISTRY: Readonly<
 		summary: "Switch inference between the on-device model and Eliza Cloud.",
 	},
 	appearance: {
-		kind: "delegate",
-		action: "BACKGROUND",
-		summary: "Change theme and appearance via the background control.",
+		kind: "route",
+		summary:
+			"Theme mode, accent preset, UI language, and the home time/date widget.",
+		keys: {
+			theme: APPEARANCE_THEME_KEY,
+			"theme-mode": APPEARANCE_THEME_KEY,
+			mode: APPEARANCE_THEME_KEY,
+			accent: APPEARANCE_ACCENT_KEY,
+			"accent-color": APPEARANCE_ACCENT_KEY,
+			language: APPEARANCE_LANGUAGE_KEY,
+			lang: APPEARANCE_LANGUAGE_KEY,
+			"ui-language": APPEARANCE_LANGUAGE_KEY,
+			"home-time-widget": APPEARANCE_HOME_TIME_WIDGET_KEY,
+			"time-widget": APPEARANCE_HOME_TIME_WIDGET_KEY,
+			clock: APPEARANCE_HOME_TIME_WIDGET_KEY,
+		},
 	},
 	background: {
 		kind: "delegate",
@@ -1036,13 +1180,20 @@ export function createSettingsAction(deps: SettingsActionDeps = {}): Action {
 			"REQUEST_OS_PERMISSION",
 			"ASK_FOR_MICROPHONE",
 			"ASK_FOR_CAMERA",
+			"CHANGE_THEME_MODE",
+			"SET_THEME_MODE",
+			"CHANGE_ACCENT",
+			"SET_ACCENT",
+			"CHANGE_UI_LANGUAGE",
+			"SET_UI_LANGUAGE",
+			"HOME_TIME_WIDGET",
 		],
 		description:
-			"Change a built-in settings VALUE or run a built-in settings operation from chat — most importantly turning OS/runtime permissions like shell access on/off via section=permissions key=shell, requesting OS permissions via section=permissions key=request permission=microphone|camera|location|notifications|screen-recording, turning automatic training on/off via section=capabilities key=auto-training, toggling the wallet/browser/computer-use capabilities via section=capabilities key=wallet|browser|computer-use value=on|off, granting/revoking an app permission namespace via section=app-permissions app=<slug> key=fs|net value=on|off, and creating/restoring local agent backups via section=advanced key=create-backup|restore-backup. Restore requires fileName and confirm=true. Also reads (`action=get`) or lists (`action=list`) which settings are changeable. `action=set` writes an owned section or points to the dedicated action that owns a delegated section (models→MODEL_SWITCH, background→BACKGROUND, identity→CHARACTER, connectors→CONNECTOR, secrets→CREDENTIALS). This CHANGES a setting's value or runs an explicit settings operation; opening a settings page without changing anything is VIEWS. Never fill a settings field with agent-fill.",
+			"Change a built-in settings VALUE or run a built-in settings operation from chat — most importantly turning OS/runtime permissions like shell access on/off via section=permissions key=shell, requesting OS permissions via section=permissions key=request permission=microphone|camera|location|notifications|screen-recording, changing appearance values via section=appearance key=theme|accent|language|home-time-widget, turning automatic training on/off via section=capabilities key=auto-training, toggling the wallet/browser/computer-use capabilities via section=capabilities key=wallet|browser|computer-use value=on|off, granting/revoking an app permission namespace via section=app-permissions app=<slug> key=fs|net value=on|off, and creating/restoring local agent backups via section=advanced key=create-backup|restore-backup. Restore requires fileName and confirm=true. Also reads (`action=get`) or lists (`action=list`) which settings are changeable. `action=set` writes an owned section or points to the dedicated action that owns a delegated section (models→MODEL_SWITCH, background→BACKGROUND, identity→CHARACTER, connectors→CONNECTOR, secrets→CREDENTIALS). This CHANGES a setting's value or runs an explicit settings operation; opening a settings page without changing anything is VIEWS. Never fill a settings field with agent-fill.",
 		descriptionCompressed:
-			"settings get|set|list section/key/value — CHANGE a setting VALUE or run a settings operation, incl. shell access, OS permission requests, auto-training, app permissions, and local backups",
+			"settings get|set|list section/key/value — CHANGE a setting VALUE or run a settings operation, incl. shell access, OS permission requests, appearance, auto-training, app permissions, and local backups",
 		routingHint:
-			"Semantic settings reads/writes that do NOT already have a dedicated action -> SETTINGS. Changing a PERMISSION or setting VALUE is SETTINGS action=set, NOT navigation: 'turn off shell permissions', 'disable shell access', 'turn off shell access', 'revoke shell access', 'stop the agent running shell commands', 'turn shell back on', 'change my permissions' -> SETTINGS section=permissions key=shell value=off|on. 'ask for microphone permission', 'request camera access', 'enable location permission', 'turn on notifications', 'request screen recording' -> SETTINGS section=permissions key=request permission=microphone|camera|location|notifications|screen-recording. 'turn on auto-training', 'enable automatic training', 'disable auto training' -> SETTINGS section=capabilities key=auto-training value=on|off. 'turn off the wallet capability', 'enable the browser capability', 'disable computer use' -> SETTINGS section=capabilities key=wallet|browser|computer-use value=on|off. 'revoke network access for my-app', 'grant filesystem access to sample-app' -> SETTINGS section=app-permissions app=<slug> key=net|fs value=off|on. 'back up my agent', 'create a local backup' -> SETTINGS section=advanced key=create-backup. 'restore backup <file>' -> SETTINGS section=advanced key=restore-backup fileName=<file> confirm=true; if confirm is absent, ask for confirmation. Also 'what settings can you change' / 'list settings' -> SETTINGS action=list. Do NOT use SETTINGS for changes a dedicated action owns: switching the model is MODEL_SWITCH, the background/theme is BACKGROUND, the agent identity is CHARACTER, connectors are CONNECTOR, secret/API keys are CREDENTIALS. The distinction from VIEWS is value-vs-navigation: changing/toggling a permission or setting VALUE, requesting an OS permission, or running a backup operation, is SETTINGS even though it lives on a settings page; merely OPENING or navigating to a settings page with no value change is VIEWS. SETTINGS never fills a form field with agent-fill.",
+			"Semantic settings reads/writes that do NOT already have a dedicated action -> SETTINGS. Changing a PERMISSION or setting VALUE is SETTINGS action=set, NOT navigation: 'turn off shell permissions', 'disable shell access', 'turn off shell access', 'revoke shell access', 'stop the agent running shell commands', 'turn shell back on', 'change my permissions' -> SETTINGS section=permissions key=shell value=off|on. 'ask for microphone permission', 'request camera access', 'enable location permission', 'turn on notifications', 'request screen recording' -> SETTINGS section=permissions key=request permission=microphone|camera|location|notifications|screen-recording. 'switch to dark mode', 'use system theme', 'set the accent to green', 'change UI language to Spanish', 'hide/show the home time widget' -> SETTINGS section=appearance key=theme|accent|language|home-time-widget value=<value>. 'turn on auto-training', 'enable automatic training', 'disable auto training' -> SETTINGS section=capabilities key=auto-training value=on|off. 'turn off the wallet capability', 'enable the browser capability', 'disable computer use' -> SETTINGS section=capabilities key=wallet|browser|computer-use value=on|off. 'revoke network access for my-app', 'grant filesystem access to sample-app' -> SETTINGS section=app-permissions app=<slug> key=net|fs value=off|on. 'back up my agent', 'create a local backup' -> SETTINGS section=advanced key=create-backup. 'restore backup <file>' -> SETTINGS section=advanced key=restore-backup fileName=<file> confirm=true; if confirm is absent, ask for confirmation. Also 'what settings can you change' / 'list settings' -> SETTINGS action=list. Do NOT use SETTINGS for changes a dedicated action owns: switching the model is MODEL_SWITCH, the background/wallpaper is BACKGROUND, the agent identity is CHARACTER, connectors are CONNECTOR, secret/API keys are CREDENTIALS. The distinction from VIEWS is value-vs-navigation: changing/toggling a permission or setting VALUE, requesting an OS permission, or running a backup operation, is SETTINGS even though it lives on a settings page; merely OPENING or navigating to a settings page with no value change is VIEWS. SETTINGS never fills a form field with agent-fill.",
 		suppressPostActionContinuation: true,
 
 		parameters: [
@@ -1055,14 +1206,14 @@ export function createSettingsAction(deps: SettingsActionDeps = {}): Action {
 			{
 				name: "section",
 				description:
-					"Canonical settings section id or alias (e.g. permissions, capabilities, app-permissions, ai-model, background, secrets). Required for get/set.",
+					"Canonical settings section id or alias (e.g. appearance, permissions, capabilities, app-permissions, ai-model, background, secrets). Required for get/set.",
 				required: false,
 				schema: { type: "string" },
 			},
 			{
 				name: "key",
 				description:
-					"The specific toggle or operation within the section (e.g. shell, auto-training, fs/net, create-backup, restore-backup). Optional; defaults to the section's primary key.",
+					"The specific toggle or operation within the section (e.g. theme, accent, language, home-time-widget, shell, auto-training, fs/net, create-backup, restore-backup). Optional; defaults to the section's primary key.",
 				required: false,
 				schema: { type: "string" },
 			},
@@ -1104,7 +1255,7 @@ export function createSettingsAction(deps: SettingsActionDeps = {}): Action {
 			{
 				name: "value",
 				description:
-					"The new value for a set. Boolean toggles accept on/off, enable/disable, true/false.",
+					"The new value for a set. Boolean toggles accept on/off, enable/disable, true/false; appearance accepts theme/accent/language tokens.",
 				required: false,
 				schema: { type: "string" },
 			},


### PR DESCRIPTION
## Summary
- Adds a shared `appearance:apply` view event payload for theme mode, accent, UI language, and home time/date widget changes.
- Mounts an always-on UI subscriber beside `AppBackground` so chat-driven appearance writes hit the same persisted preference setters as the Appearance settings section.
- Changes SETTINGS `appearance` from a BACKGROUND delegate to owned route keys that broadcast through `/api/views/events/broadcast`.

Closes #14723.

## Evidence
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd plugins/plugin-app-control test src/actions/settings.test.ts` -> 62 passed
- `bun run --cwd packages/ui test src/backgrounds/useAppearanceApplyChannel.test.tsx` -> 3 passed
- `bunx biome check packages/shared/src/events/index.ts packages/ui/src/backgrounds/AppBackground.tsx packages/ui/src/backgrounds/useAppearanceApplyChannel.ts packages/ui/src/backgrounds/useAppearanceApplyChannel.test.tsx plugins/plugin-app-control/src/actions/settings.ts plugins/plugin-app-control/src/actions/settings.test.ts`
- `git diff --check origin/develop...HEAD`
- `bun run audit:error-policy-ratchet`

## Blocked checks
- `bun run --cwd plugins/plugin-app-control typecheck` is blocked by existing workspace dependency declaration/module resolution failures: `fs-extra`, `markdown-it`, `fast-redact`, `marked`, `get-east-asian-width`, and `puppeteer-core`.
- `bun run --cwd packages/ui typecheck` is blocked by existing broad workspace missing dependencies including `pg`, `stripe`, `marked`, Capacitor packages, `three`, cloud UI deps, and other app-wide type errors.
- `bun run --cwd packages/app audit:app` is blocked before screenshot capture by unrelated view-build failures resolving `@elizaos/capacitor-messages`, `@elizaos/capacitor-phone`, and `marked` in `plugin-task-coordinator`.

## Visual Evidence
N/A - the required app visual audit did not reach browser capture because dependency resolution failed during view bundle builds before screenshots.