### PR TITLE
refactor(ui): extract wallpaper idiom tokens

### DIFF
--- a/packages/ui/src/components/composites/chat/chat-bubble.tsx
+++ b/packages/ui/src/components/composites/chat/chat-bubble.tsx
@@ -11,13 +11,16 @@ import type * as React from "react";
 
 import { cn } from "../../../lib/utils";
 import {
+  WALLPAPER_FLOAT_SHADOW,
+  WALLPAPER_GLASS,
+} from "../../shell/wallpaper-idiom";
+import {
   getChatSourceMeta,
   normalizeChatSourceKey,
 } from "./chat-source.helpers";
 
-/** Soft text shadow for floating (un-scrimmed) glass text so it reads over
- * bright views. Shared with the overlay's other floating chrome. */
-export const GLASS_FLOAT_SHADOW = "[text-shadow:0_1px_4px_rgba(0,0,0,0.7)]";
+/** @deprecated Use WALLPAPER_FLOAT_SHADOW from shell/wallpaper-idiom instead. */
+export const GLASS_FLOAT_SHADOW = WALLPAPER_FLOAT_SHADOW;
 
 /** The overlay's shared easing for cheap (opacity/translate-only) motion. */
 export const GLASS_EASE: [number, number, number, number] = [0.22, 1, 0.36, 1];
@@ -59,8 +62,8 @@ export function ChatBubble({
           "select-text [-webkit-touch-callout:default]",
           // No per-message fill — text floats on the overlay's one shared panel
           // glass; the hairline edge defines the item boundary (#10698).
-          "border border-white/15 text-white",
-          GLASS_FLOAT_SHADOW,
+          WALLPAPER_GLASS.messageBubble,
+          WALLPAPER_FLOAT_SHADOW,
           className,
         )}
         data-chat-source={normalizedSource ?? undefined}

--- a/packages/ui/src/components/pages/Launcher.tsx
+++ b/packages/ui/src/components/pages/Launcher.tsx
@@ -25,6 +25,11 @@ import { memo, useCallback } from "react";
 import type { ViewEntry } from "../../hooks/view-catalog";
 import { cn } from "../../lib/utils";
 import { emitViewInteraction } from "../../view-telemetry";
+import {
+  WALLPAPER_FLOAT_SHADOW,
+  WALLPAPER_GLASS,
+  WALLPAPER_TEXT,
+} from "../shell/wallpaper-idiom";
 import { Button } from "../ui/button";
 import { ViewTileImage } from "../views/ViewTileImage";
 import type { LauncherZone } from "./launcher-curation";
@@ -94,7 +99,8 @@ const IconTile = memo(function IconTile({
             // owns hover/focus chrome; the inner visual owns color/glyph. Flat —
             // no border; a subtle glass wash is the icon plate (neutral resting →
             // neutral-with-opacity hover).
-            "h-16 w-16 overflow-hidden rounded-2xl bg-white/10 text-white transition-colors hover:bg-white/20",
+            "h-16 w-16 overflow-hidden rounded-2xl transition-colors",
+            WALLPAPER_GLASS.iconPlate,
             // Neutralize Button's default-size padding (px-4 py-2 letterboxed
             // the artwork into a 32×48 inset) and its [&_svg]:size-4 descendant
             // rule (which would shrink the 28px glyph fallback): the artwork
@@ -157,7 +163,13 @@ const IconTile = memo(function IconTile({
           ("Relationships", ~79px at 11px) cannot wrap at a word boundary — a
           tighter cap clipped it mid-glyph (#14427). line-clamp-2 still wraps
           multi-word labels. */}
-      <span className="line-clamp-2 max-w-[5.25rem] text-center text-[11px] font-medium leading-tight text-white [text-shadow:0_1px_3px_rgba(0,0,0,0.55)]">
+      <span
+        className={cn(
+          "line-clamp-2 max-w-[5.25rem] text-center text-[11px] font-medium leading-tight",
+          WALLPAPER_TEXT.base,
+          WALLPAPER_FLOAT_SHADOW,
+        )}
+      >
         {entry.label}
       </span>
     </div>
@@ -199,7 +211,13 @@ function ZoneHeader({ label }: { label: string }) {
   // card chrome (the launcher paints straight onto the wallpaper).
   return (
     <div className="flex items-center gap-3 px-1">
-      <h2 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-white/85 [text-shadow:0_1px_3px_rgba(0,0,0,0.55)]">
+      <h2
+        className={cn(
+          "text-[11px] font-semibold uppercase tracking-[0.14em]",
+          WALLPAPER_TEXT.primary,
+          WALLPAPER_FLOAT_SHADOW,
+        )}
+      >
         {label}
       </h2>
       <div className="h-px flex-1 bg-white/20" />

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -131,6 +131,7 @@ import {
 } from "./topic-grouping";
 import { type PullGestureBinding, usePullGesture } from "./use-pull-gesture";
 import type { ConversationNav, ShellController } from "./useShellController";
+import { WALLPAPER_FLOAT_SHADOW, WALLPAPER_TEXT } from "./wallpaper-idiom";
 
 /** No-op slash controller so the overlay renders without a provider (stories). */
 const EMPTY_SLASH_CONTROLLER: SlashCommandController = {
@@ -179,9 +180,6 @@ const EMPTY_SLASH_CONTROLLER: SlashCommandController = {
  * in isolation (stories / harness) with a mock. The app wraps it in a small
  * context-reading mount (see App.tsx) that supplies the shared controller.
  */
-
-// Floating (un-scrimmed) text gets a soft shadow so it reads over bright views.
-const FLOAT_SHADOW = "[text-shadow:0_1px_4px_rgba(0,0,0,0.7)]";
 
 // Shared easing for the overlay's cheap motion path. Open/close must stay
 // opacity/translate only: animating blur/filter or scaling a scrollable
@@ -652,11 +650,11 @@ function TurnStatusIndicator({
       <div
         className={cn(
           "rounded-2xl rounded-bl-md border px-3.5 py-2",
-          FLOAT_SHADOW,
+          WALLPAPER_FLOAT_SHADOW,
           // Orange (the accent) ONLY for spoken replies; every other phase is
           // neutral white glass. No blue anywhere.
           // #10698: no own scrim — the shared panel glass carries the contrast;
-          // keep only the tone border (orange when speaking) + FLOAT_SHADOW.
+          // keep only the tone border (orange when speaking) + WALLPAPER_FLOAT_SHADOW.
           speaking ? "border-accent/45" : "border-border",
         )}
       >
@@ -715,7 +713,7 @@ function renderOverlayMessageBody(
       <div
         className={cn(
           "max-w-[85%] rounded-2xl rounded-bl-md border border-accent/30 bg-scrim px-3.5 py-3 text-txt",
-          FLOAT_SHADOW,
+          WALLPAPER_FLOAT_SHADOW,
         )}
       >
         <div className="mb-1 text-[14px] font-medium">
@@ -3847,7 +3845,7 @@ export function ContinuousChatOverlay({
             className={cn(
               "pointer-events-auto h-auto gap-1.5 rounded-full border px-3 py-1.5 text-sm font-medium transition-colors",
               "border-warn/40 bg-warn/15 text-warn hover:bg-warn/25",
-              FLOAT_SHADOW,
+              WALLPAPER_FLOAT_SHADOW,
             )}
           >
             <Glyph d={SPEAKER_MUTED_GLYPH} />
@@ -4515,7 +4513,11 @@ export function ContinuousChatOverlay({
                 {imageError ? (
                   <p
                     role="alert"
-                    className={cn("text-xs text-red-200/90", FLOAT_SHADOW)}
+                    className={cn(
+                      "text-xs",
+                      WALLPAPER_TEXT.danger,
+                      WALLPAPER_FLOAT_SHADOW,
+                    )}
                   >
                     {imageError}
                   </p>

--- a/packages/ui/src/components/shell/DefaultHomeWidgets.tsx
+++ b/packages/ui/src/components/shell/DefaultHomeWidgets.tsx
@@ -20,6 +20,7 @@ import {
 } from "../../hooks/useWeather";
 import { cn } from "../../lib/utils";
 import { useAppSelector } from "../../state";
+import { WALLPAPER_FLOAT_SHADOW, WALLPAPER_TEXT } from "./wallpaper-idiom";
 
 /**
  * The home dashboard's always-on base widgets: a deterministic 4-column grid
@@ -32,11 +33,6 @@ import { useAppSelector } from "../../state";
  * Always rendered as the base of the home surface - the data-driven WidgetHost
  * cards flow in below it, so the dashboard is never bare.
  */
-
-// White text legibility over the bright orange field, no card behind it. The
-// wallpaper is a known field (not a theme surface), so `text-white` + this
-// shadow is the intended idiom here rather than themed text tokens.
-const FLOAT_SHADOW = "[text-shadow:0_1px_3px_rgba(0,0,0,0.38)]";
 
 /** Locale hour cycle, resolved once at module load (never per render). */
 const CLOCK_24H = prefers24HourClock();
@@ -96,11 +92,11 @@ function WeatherTile(): React.JSX.Element {
       data-status={weather.status}
       className={cn(
         "col-span-2 row-span-2 flex min-w-0 flex-col items-end justify-end text-right text-white",
-        FLOAT_SHADOW,
+        WALLPAPER_FLOAT_SHADOW,
       )}
     >
       {weather.status === "loading" ? (
-        <div className="text-sm text-white/70">Loading…</div>
+        <div className={cn("text-sm", WALLPAPER_TEXT.secondary)}>Loading…</div>
       ) : weather.status === "unavailable" ? (
         // Actionable, not a dead-end: an explicit tap is the ONE place allowed
         // to trigger the OS location prompt (home load never does). (#14345)
@@ -111,11 +107,19 @@ function WeatherTile(): React.JSX.Element {
           aria-label="Enable location to show weather"
           className="flex flex-col items-end text-right transition-opacity hover:opacity-80"
         >
-          <Cloud className="h-7 w-7 text-white/70" aria-hidden />
+          <Cloud
+            className={cn("h-7 w-7", WALLPAPER_TEXT.secondary)}
+            aria-hidden
+          />
           <div className="mt-1.5 text-sm font-medium text-white/80">
             Weather
           </div>
-          <div className="mt-0.5 max-w-[11rem] text-xs-tight leading-tight text-white/60">
+          <div
+            className={cn(
+              "mt-0.5 max-w-[11rem] text-xs-tight leading-tight",
+              WALLPAPER_TEXT.muted,
+            )}
+          >
             Tap to enable location
           </div>
         </button>
@@ -125,12 +129,19 @@ function WeatherTile(): React.JSX.Element {
             <Icon className="h-7 w-7 text-accent" aria-hidden />
             <div className="text-4xl font-semibold leading-none tabular-nums tracking-tighter">
               {weather.temp}
-              <span className="align-top text-base font-medium text-white/60">
+              <span
+                className={cn(
+                  "align-top text-base font-medium",
+                  WALLPAPER_TEXT.muted,
+                )}
+              >
                 {weather.unit}
               </span>
             </div>
           </div>
-          <div className="mt-1.5 text-sm font-medium text-white/85">
+          <div
+            className={cn("mt-1.5 text-sm font-medium", WALLPAPER_TEXT.primary)}
+          >
             {weather.condition}
           </div>
         </>
@@ -174,12 +185,17 @@ const HomeClock = memo(function HomeClock(): React.JSX.Element {
           {time}
         </span>
         {ampm ? (
-          <span className="text-base font-semibold uppercase tracking-wide text-white/60">
+          <span
+            className={cn(
+              "text-base font-semibold uppercase tracking-wide",
+              WALLPAPER_TEXT.muted,
+            )}
+          >
             {ampm}
           </span>
         ) : null}
       </div>
-      <div className="mt-3 text-base font-medium text-white/85">
+      <div className={cn("mt-3 text-base font-medium", WALLPAPER_TEXT.primary)}>
         {dateLabel}
       </div>
       <div className="mt-1 text-sm font-medium text-accent/90">
@@ -221,7 +237,7 @@ export function DefaultHomeWidgets(): React.JSX.Element | null {
           data-testid="home-time-widget"
           className={cn(
             "col-span-2 row-span-2 flex min-w-0 flex-col justify-end text-left text-white",
-            FLOAT_SHADOW,
+            WALLPAPER_FLOAT_SHADOW,
           )}
         >
           <HomeClock />

--- a/packages/ui/src/components/shell/HomeScreen.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.tsx
@@ -24,6 +24,7 @@ import { DefaultHomeWidgets } from "./DefaultHomeWidgets";
 import { HomeBackgroundQuickPicker } from "./HomeBackgroundQuickPicker";
 import { HomeGestureHint } from "./HomeGestureHint";
 import { NotificationsHomeCenter } from "./NotificationsHomeCenter";
+import { WALLPAPER_FLOAT_SHADOW, WALLPAPER_TEXT } from "./wallpaper-idiom";
 
 /**
  * A press that lands on a tile, widget, or any interactive control owns its own
@@ -354,7 +355,9 @@ export function HomeScreen({
                       className={cn(
                         // Naked tile: icon + label sit directly on the ambient
                         // orange field - no fill, no border.
-                        "flex h-auto flex-col items-center gap-1.5 whitespace-normal rounded-2xl px-1 py-3.5 text-white [text-shadow:0_1px_3px_rgba(0,0,0,0.38)]",
+                        "flex h-auto flex-col items-center gap-1.5 whitespace-normal rounded-2xl px-1 py-3.5",
+                        WALLPAPER_TEXT.base,
+                        WALLPAPER_FLOAT_SHADOW,
                         // Tactile press: a quick scale-down on tap (stilled for
                         // reduce-motion users), plus a faint white wash on hover.
                         "transition-[transform,background-color] duration-150 active:scale-[0.96] motion-reduce:active:scale-100",

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -35,6 +35,7 @@ import { NOTIFICATION_PRIORITY_RANK } from "../../widgets/home-priority";
 import { Button } from "../ui/button";
 import { HOME_GLASS_CLASS } from "./home-glass";
 import { RelativeTime } from "./RelativeTime";
+import { WALLPAPER_TEXT } from "./wallpaper-idiom";
 
 /**
  * Height cap for the scrolling list (the header stays pinned above it). Sized
@@ -369,7 +370,12 @@ export function NotificationsHomeCenter(): React.JSX.Element | null {
       {/* Pinned header: a quiet eyebrow + unread count, actions to the right.
           No boxed bell chip - the label alone names the surface. */}
       <div className="flex shrink-0 items-center gap-1.5 px-3.5 pb-1 pt-2.5">
-        <span className="text-2xs font-medium uppercase tracking-[0.1em] text-white/70">
+        <span
+          className={cn(
+            "text-2xs font-medium uppercase tracking-[0.1em]",
+            WALLPAPER_TEXT.secondary,
+          )}
+        >
           Notifications
         </span>
         {unreadCount > 0 ? (
@@ -388,7 +394,10 @@ export function NotificationsHomeCenter(): React.JSX.Element | null {
               aria-label="Mark all read"
               title="Mark all read"
               data-testid="notifications-mark-all-read"
-              className="text-white/70 hover:bg-white/10 hover:text-white"
+              className={cn(
+                WALLPAPER_TEXT.secondary,
+                "hover:bg-white/10 hover:text-white",
+              )}
               onClick={() => void markAllNotificationsRead()}
             >
               <CheckCheck className="h-4 w-4" />
@@ -400,7 +409,10 @@ export function NotificationsHomeCenter(): React.JSX.Element | null {
             aria-label="Clear all notifications"
             title="Clear all"
             data-testid="notifications-clear-all"
-            className="text-white/70 hover:bg-white/10 hover:text-white"
+            className={cn(
+              WALLPAPER_TEXT.secondary,
+              "hover:bg-white/10 hover:text-white",
+            )}
             onClick={() => void clearNotifications()}
           >
             <Trash2 className="h-4 w-4" />

--- a/packages/ui/src/components/shell/SlashCommandMenu.tsx
+++ b/packages/ui/src/components/shell/SlashCommandMenu.tsx
@@ -18,8 +18,11 @@ import {
 import type { SlashCommandController } from "../../chat/useSlashCommandController";
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
-
-const FLOAT_SHADOW = "[text-shadow:0_1px_4px_rgba(0,0,0,0.7)]";
+import {
+  WALLPAPER_FLOAT_SHADOW,
+  WALLPAPER_GLASS,
+  WALLPAPER_TEXT,
+} from "./wallpaper-idiom";
 
 export interface SlashMenuItem {
   id: string;
@@ -236,8 +239,10 @@ export function SlashCommandMenu({
       return (
         <div
           className={cn(
-            "absolute bottom-full left-0 right-0 z-10 mb-2 rounded-2xl border border-white/12 bg-black/85 px-4 py-3 text-xs text-white/55",
-            FLOAT_SHADOW,
+            "absolute bottom-full left-0 right-0 z-10 mb-2 rounded-2xl px-4 py-3 text-xs",
+            WALLPAPER_GLASS.menuStatus,
+            WALLPAPER_TEXT.soft,
+            WALLPAPER_FLOAT_SHADOW,
           )}
           role="status"
           data-testid="slash-menu-loading"
@@ -252,8 +257,10 @@ export function SlashCommandMenu({
       return (
         <div
           className={cn(
-            "absolute bottom-full left-0 right-0 z-10 mb-2 rounded-2xl border border-amber-400/25 bg-black/85 px-4 py-3 text-xs text-amber-200/80",
-            FLOAT_SHADOW,
+            "absolute bottom-full left-0 right-0 z-10 mb-2 rounded-2xl px-4 py-3 text-xs",
+            WALLPAPER_GLASS.menuWarning,
+            WALLPAPER_TEXT.warning,
+            WALLPAPER_FLOAT_SHADOW,
           )}
           role="status"
           data-testid="slash-menu-error"
@@ -275,14 +282,16 @@ export function SlashCommandMenu({
       data-testid="slash-command-menu"
       className={cn(
         "absolute bottom-full left-0 right-0 z-10 mb-2 max-h-[min(46vh,22rem)] overflow-y-auto",
-        "rounded-2xl border border-white/14 bg-black/85 py-1.5",
+        "rounded-2xl py-1.5",
+        WALLPAPER_GLASS.menuPanel,
         "[scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
       )}
     >
       <div
         className={cn(
-          "px-3.5 pb-1 pt-0.5 text-[10px] font-medium uppercase tracking-wider text-white/40",
-          FLOAT_SHADOW,
+          "px-3.5 pb-1 pt-0.5 text-[10px] font-medium uppercase tracking-wider",
+          WALLPAPER_TEXT.faint,
+          WALLPAPER_FLOAT_SHADOW,
         )}
       >
         {state.headerLabel}
@@ -295,7 +304,7 @@ export function SlashCommandMenu({
         <div
           className={cn(
             "mx-2 mb-1 rounded-lg border border-amber-400/25 bg-amber-400/5 px-2.5 py-1 text-[10px] text-amber-200/80",
-            FLOAT_SHADOW,
+            WALLPAPER_FLOAT_SHADOW,
           )}
           role="status"
           data-testid="slash-menu-partial-error"
@@ -333,8 +342,9 @@ export function SlashCommandMenu({
         >
           <span
             className={cn(
-              "min-w-0 shrink-0 font-mono text-[13px] text-white/95",
-              FLOAT_SHADOW,
+              "min-w-0 shrink-0 font-mono text-[13px]",
+              WALLPAPER_TEXT.strong,
+              WALLPAPER_FLOAT_SHADOW,
             )}
           >
             {item.primary}
@@ -342,8 +352,9 @@ export function SlashCommandMenu({
           {item.secondary ? (
             <span
               className={cn(
-                "min-w-0 flex-1 truncate text-[12px] text-white/55",
-                FLOAT_SHADOW,
+                "min-w-0 flex-1 truncate text-[12px]",
+                WALLPAPER_TEXT.soft,
+                WALLPAPER_FLOAT_SHADOW,
               )}
             >
               {item.secondary}

--- a/packages/ui/src/components/shell/wallpaper-idiom.test.ts
+++ b/packages/ui/src/components/shell/wallpaper-idiom.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Unit coverage for the shared wallpaper idiom token module.
+ * The harness is pure Vitest: no DOM or mocked browser state, just locked class
+ * recipes so duplicated shell wallpaper values do not drift again.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  WALLPAPER_FLOAT_SHADOW,
+  WALLPAPER_GLASS,
+  WALLPAPER_TEXT,
+} from "./wallpaper-idiom";
+
+describe("wallpaper idiom tokens", () => {
+  it("keeps floating wallpaper text on one shared shadow", () => {
+    expect(WALLPAPER_FLOAT_SHADOW).toBe(
+      "[text-shadow:0_1px_4px_rgba(0,0,0,0.7)]",
+    );
+  });
+
+  it("keeps wallpaper text and glass recipes tokenized", () => {
+    expect(WALLPAPER_TEXT.primary).toBe("text-white/85");
+    expect(WALLPAPER_GLASS.notificationCenter).toContain("backdrop-blur-md");
+    expect(WALLPAPER_GLASS.notificationCenter).not.toContain(
+      "backdrop-blur-xl",
+    );
+    expect(Object.values(WALLPAPER_GLASS).join(" ")).not.toMatch(
+      /#[0-9a-f]{3,8}/i,
+    );
+  });
+});

--- a/packages/ui/src/components/shell/wallpaper-idiom.ts
+++ b/packages/ui/src/components/shell/wallpaper-idiom.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared wallpaper-surface visual tokens.
+ *
+ * These classes are intentionally theme-independent: wallpaper surfaces sit on
+ * the live ambient field instead of app chrome, so they use fixed white text,
+ * dark glass washes, and a single float shadow for legibility over bright or
+ * busy backgrounds.
+ */
+
+/** Floating text shadow for naked white-on-wallpaper text and glass rows. */
+export const WALLPAPER_FLOAT_SHADOW = "[text-shadow:0_1px_4px_rgba(0,0,0,0.7)]";
+
+/** Fixed light-text ladder for copy rendered directly over wallpaper. */
+export const WALLPAPER_TEXT = {
+  base: "text-white",
+  strong: "text-white/95",
+  primary: "text-white/85",
+  secondary: "text-white/70",
+  muted: "text-white/60",
+  soft: "text-white/55",
+  faint: "text-white/40",
+  whisper: "text-white/35",
+  danger: "text-red-200/90",
+  warning: "text-amber-200/80",
+} as const;
+
+/** Dark-glass recipes used by wallpaper-mounted shell chrome. */
+export const WALLPAPER_GLASS = {
+  notificationCenter:
+    "border border-white/55 bg-black/35 text-white backdrop-blur-md supports-[backdrop-filter]:bg-black/30",
+  menuPanel: "border border-white/14 bg-black/85",
+  menuStatus: "border border-white/12 bg-black/85",
+  menuWarning: "border border-amber-400/25 bg-black/85",
+  messageBubble: "border border-white/15 text-white",
+  iconPlate: "bg-white/10 text-white hover:bg-white/20",
+  floatingControl: "bg-black/55 text-white hover:bg-black/70",
+} as const;


### PR DESCRIPTION
[sol-orch] signed

## Summary
- Extracted shared wallpaper idiom tokens for float shadow, fixed white text ladder, and dark-glass recipes.
- Replaced duplicated wallpaper constants/classes across home, launcher, continuous chat overlay, slash menu, notification center, and glass chat bubble.
- Kept existing glass blur tiers intact, no new backdrop blur, no raw hex in the new token module.

Closes #14909

## Verification
- `bunx @biomejs/biome check packages/ui/src/components/shell/wallpaper-idiom.ts packages/ui/src/components/shell/wallpaper-idiom.test.ts packages/ui/src/components/shell/DefaultHomeWidgets.tsx packages/ui/src/components/shell/HomeScreen.tsx packages/ui/src/components/shell/ContinuousChatOverlay.tsx packages/ui/src/components/shell/SlashCommandMenu.tsx packages/ui/src/components/composites/chat/chat-bubble.tsx packages/ui/src/components/pages/Launcher.tsx packages/ui/src/components/shell/NotificationsHomeCenter.tsx`
- `NODE_OPTIONS="${NODE_OPTIONS:-} --no-experimental-webstorage --disable-warning=ExperimentalWarning" ../../node_modules/.bin/vitest run --config ./vitest.config.ts src/components/shell/wallpaper-idiom.test.ts src/components/shell/DefaultHomeWidgets.test.tsx src/components/shell/DefaultHomeWidgets.render-count.test.tsx src/components/shell/NotificationsHomeCenter.test.tsx src/components/shell/NotificationsHomeCenter.render-count.test.tsx src/components/shell/SlashCommandMenu.error-state.test.tsx src/components/pages/Launcher.test.tsx` (53 tests passed)
- `rg -n "const FLOAT_SHADOW|\[text-shadow:0_1px_[34]px_rgba\(0,0,0" packages/ui/src --glob '!**/__e2e__/output*'` (only `wallpaper-idiom.ts` and its test)
- `rg -n "#[0-9a-fA-F]{3,8}" packages/ui/src/components/shell/wallpaper-idiom.ts` (no matches)
- `codex review --uncommitted` (P2 compatibility alias fixed, P3 test header fixed)

## Notes
- `GLASS_FLOAT_SHADOW` remains as a deprecated compatibility alias to avoid breaking public UI barrel consumers.
