### PR TITLE
fix(app): require automated OCR for live visual QA evidence

### DIFF
--- a/packages/app/scripts/lib/visual-qa.mjs
+++ b/packages/app/scripts/lib/visual-qa.mjs
@@ -11,12 +11,13 @@
  * gate asserts on, right beside the screenshot — so "looks fine" becomes
  * "OCR shows the expected copy, palette is neutral, 0.0 blue, verdict pass".
  *
- * Pixels come from `sharp` (already a repo dep); OCR shells to the `tesseract`
- * CLI when present and degrades to an explicit note (never a fabricated empty
- * read) when it is not, so the analyzer is safe to call from any capture lane.
+ * Pixels come from `sharp` (already a repo dep); OCR uses the system
+ * `tesseract` CLI when present and falls back to the repo's `tesseract.js`
+ * dependency before reporting an explicit unavailable note. A missing OCR
+ * binary must never masquerade as "no text on screen".
  */
 import { execFile } from "node:child_process";
-import { copyFile, mkdtemp, rm } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -133,7 +134,20 @@ async function retryOcrFromWorkspaceCopy(pngPath) {
   }
 }
 
-/** On-screen text via the tesseract CLI, or an explicit note when unavailable. */
+async function runTesseractJs(pngPath) {
+  const { createWorker } = await import("tesseract.js");
+  const cachePath = path.join(tmpdir(), "eliza-visual-qa-tesseract-cache");
+  await mkdir(cachePath, { recursive: true });
+  const worker = await createWorker("eng", undefined, { cachePath });
+  try {
+    const result = await worker.recognize(pngPath);
+    return normalizeOcrText(result?.data?.text ?? "");
+  } finally {
+    await worker.terminate();
+  }
+}
+
+/** On-screen text via tesseract OCR, or an explicit note when unavailable. */
 async function ocrText(pngPath) {
   try {
     return { text: await runTesseract(pngPath), note: null };
@@ -150,13 +164,25 @@ async function ocrText(pngPath) {
       // error-policy:J3 the explicit note below reports the primary OCR failure;
       // retry failure does not fabricate text or hide the unavailable signal.
     }
-    // error-policy:J3 OCR is optional enrichment; report absence explicitly
-    // rather than fabricate an empty transcript as "no text on screen".
-    const note =
-      err?.code === "ENOENT"
-        ? "tesseract not installed"
-        : `tesseract failed: ${String(err?.message ?? err).slice(0, 120)}`;
-    return { text: "", note };
+    try {
+      return {
+        text: await runTesseractJs(pngPath),
+        note: "tesseract CLI unavailable; OCR succeeded with tesseract.js",
+      };
+    } catch (fallbackError) {
+      // error-policy:J3 OCR is optional enrichment; report absence explicitly
+      // rather than fabricate an empty transcript as "no text on screen".
+      const primary =
+        err?.code === "ENOENT"
+          ? "tesseract CLI not installed"
+          : `tesseract CLI failed: ${String(err?.message ?? err).slice(0, 120)}`;
+      return {
+        text: "",
+        note: `${primary}; tesseract.js failed: ${String(
+          fallbackError?.message ?? fallbackError,
+        ).slice(0, 120)}`,
+      };
+    }
   }
 }
 

--- a/packages/app/scripts/visual-qa-live.mjs
+++ b/packages/app/scripts/visual-qa-live.mjs
@@ -221,16 +221,27 @@ async function focusAndType(page) {
   await page.waitForTimeout(600);
 }
 
-async function readVisibleText(page, stateId) {
-  try {
-    return (await page.locator("body").innerText({ timeout: 4000 }))
-      .replace(/\s+/g, " ")
-      .trim();
-  } catch (error) {
+async function readVisibleText(page, stateId, { minLength = 12 } = {}) {
+  const deadline = Date.now() + 12_000;
+  let lastText = "";
+  let lastError = null;
+  while (Date.now() < deadline) {
+    try {
+      lastText = (await page.locator("body").innerText({ timeout: 1000 }))
+        .replace(/\s+/g, " ")
+        .trim();
+      if (lastText.length >= minLength) return lastText;
+    } catch (error) {
+      lastError = error;
+    }
+    await page.waitForTimeout(250);
+  }
+  if (lastError) {
     throw new Error(
-      `Failed to read visible DOM text for ${stateId}: ${error?.message ?? error}`,
+      `Failed to read visible DOM text for ${stateId}: ${lastError?.message ?? lastError}`,
     );
   }
+  return lastText;
 }
 
 async function readComposerText(page) {
@@ -352,7 +363,9 @@ async function main() {
             focusError = String(error?.message ?? error).slice(0, 180);
           }
         }
-        const domText = await readVisibleText(page, state.id);
+        const domText = await readVisibleText(page, state.id, {
+          minLength: 12,
+        });
         let composerText = "";
         if (state.focusComposer && !focusError) {
           try {


### PR DESCRIPTION
Closes #14936.
Relates to #14818. Follow-up to merged #14903.

## Summary

`packages/app audit:live` now treats OCR as required-but-automated evidence instead of optional local tooling:

- Uses the system `tesseract` CLI first.
- Retries CLI OCR from a short-lived workspace-local copy for `/tmp` evidence bundle path issues.
- Falls back to the repo's `tesseract.js` dependency when the CLI is unavailable.
- Keeps the `tesseract.js` language cache under `/tmp`, so evidence runs do not leave `eng.traineddata*` in the worktree.
- Polls visible DOM text during live capture startup so transient blank reads fail only after the app has had a fair chance to render.

## Testing

```text
node --check packages/app/scripts/lib/visual-qa.mjs && node --check packages/app/scripts/visual-qa-live.mjs

bunx @biomejs/biome check packages/app/scripts/visual-qa-live.mjs packages/app/scripts/visual-qa-live.test.mjs packages/app/scripts/lib/visual-qa.mjs packages/app/scripts/lib/visual-qa.test.ts
Checked 4 files in 74ms. No fixes applied.

bunx vitest run packages/app/scripts/visual-qa-live.test.mjs packages/app/scripts/lib/visual-qa.test.ts
Test Files  2 passed (2)
Tests       25 passed (25)

git diff --check origin/develop...HEAD

bun run audit:error-policy-ratchet --report
[error-policy-ratchet] base origin/develop (27e1db4b28); 0 changed production source file(s)
[error-policy-ratchet] no new fallback-slop in touched files
```

## Live Evidence

```text
bun run --cwd packages/app audit:live -- --base http://127.0.0.1:2151 --out /tmp/eliza-visual-qa-ocr-required-e89d0cb --strict
PASS — no-blue invariant (ceiling 0.02); 7 states → /tmp/eliza-visual-qa-ocr-required-e89d0cb/report.json
```

Report summary:

```json
{
  "commit": "e89d0cb2aa43dad2dcca269a46a351349032cc3b",
  "verdict": { "pass": true, "offenders": [], "blueCeiling": 0.02 },
  "seedDeltas": [
    { "viewport": "desktop", "changedFraction": 0.0541 },
    { "viewport": "mobile", "changedFraction": 0.0875 }
  ],
  "states": [
    { "id": "desktop-onboarding", "blue": 0, "orange": 0, "neutral": 1, "ocr_note": "tesseract CLI unavailable; OCR succeeded with tesseract.js", "ocr": "Sign in to Eliza Cloud > Ask me anything — or pick an option" },
    { "id": "desktop-shell", "blue": 0, "orange": 0.0259, "neutral": 0.9613, "ocr_note": "tesseract CLI unavailable; OCR succeeded with tesseract.js", "ocr": "Startup failed: Backend Unreachable Previously configured backend is unreachable. Check your connection or reset" },
    { "id": "desktop-chat", "blue": 0, "orange": 0.0259, "neutral": 0.9613, "ocr_note": "tesseract CLI unavailable; OCR succeeded with tesseract.js", "ocr": "Startup failed: Backend Unreachable Previously configured backend is unreachable. Check your connection or reset" },
    { "id": "mobile-onboarding", "blue": 0, "orange": 0, "neutral": 1, "ocr_note": "tesseract CLI unavailable; OCR succeeded with tesseract.js", "ocr": "Sign in to Eliza Cloud > Ask me anything — or pick an option" },
    { "id": "mobile-shell", "blue": 0, "orange": 0.0422, "neutral": 0.9347, "ocr_note": "tesseract CLI unavailable; OCR succeeded with tesseract.js", "ocr": "Startup failed: Backend Unreachable Previously configured backend is unreachable. Check your connection or reset" },
    { "id": "mobile-chat", "blue": 0, "orange": 0.0422, "neutral": 0.9347, "ocr_note": "tesseract CLI unavailable; OCR succeeded with tesseract.js", "ocr": "Startup failed: Backend Unreachable Previously configured backend is unreachable. Check your connection or reset" },
    { "id": "mobile-composer-focused", "blue": 0, "orange": 0, "neutral": 1, "ocr_note": "tesseract CLI unavailable; OCR succeeded with tesseract.js", "ocr": "Sign in to Eliza Cloud > remind me to call the pharmacy > before 5" }
  ]
}
```

Manual screenshot review: current artifacts under `/tmp/eliza-visual-qa-ocr-required-e89d0cb/` were opened and reviewed. Desktop/mobile onboarding showed the Eliza Cloud sign-in gate; desktop/mobile shell and chat showed the designed Backend Unreachable state; mobile composer-focused showed the typed pharmacy reminder visible above the send affordance with no clipping.

Repo cleanliness check after the fallback run: no `eng.traineddata*` or `.visual-qa-ocr-*` files were left in the worktree.

## Evidence Matrix

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - this changes audit tooling only; no product UI surface changed.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - no product UI surface changed; generated locally by `audit:live` under `/tmp/eliza-visual-qa-ocr-required-e89d0cb/` and manually reviewed; report summary above includes OCR + palette/readiness signals for every state.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - CLI audit/analyzer hardening; no user-facing interaction flow changed.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no backend code changed; the live run intentionally had no backend so the designed Backend Unreachable state was captured.
<!-- evidence-row:frontend-logs -->
- Frontend logs: N/A - no frontend runtime code changed; expected no-backend dev-server warnings only (`API server unavailable` for slash-command/custom-action catalog); the audit passed strict visual gates.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no agent/action/provider/prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - no persistent domain artifacts are produced by this tooling change.

## Known Gaps

Full `bun run verify` was not run for this narrow app-script change. Focused parser, formatter, unit, ratchet, and strict live visual evidence are included above.