### PR TITLE
fix(ui): restore readable first-run onboarding copy

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.firstrun.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.firstrun.test.tsx
@@ -331,6 +331,28 @@ describe("ContinuousChatOverlay first-run gating", () => {
     expect(cloud.getAttribute("tabindex")).not.toBe("-1");
   });
 
+  it("renders onboarding transcript turns with panel chrome over the opaque light backdrop", () => {
+    const controller = makeController({
+      messages: [
+        {
+          id: "first-run:greeting",
+          role: "assistant",
+          content: RUNTIME_CHOICE_MESSAGE,
+          createdAt: 1,
+        },
+      ],
+    } as unknown as Partial<ShellController>);
+    render(<ContinuousChatOverlay controller={controller} firstRunOpen />);
+
+    const message = screen.getByTestId("chat-message");
+    expect(message.getAttribute("data-role")).toBe("assistant");
+    expect(screen.queryByTestId("thread-line")).toBeNull();
+    expect(
+      screen.getByText("Hi — I'm Eliza. First, where should your agent run?"),
+    ).toBeTruthy();
+    expect(screen.queryByText("Agent")).toBeNull();
+  });
+
   it("exposes the sr-only onboarding-state probe with the current step + choice ids while onboarding is open", () => {
     seedAppStoreWithActionSpy();
     const controller = makeController({

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -1714,7 +1714,8 @@ export function ContinuousChatOverlay({
       return (
         <ChatMessage
           key={m.id}
-          appearance="glass"
+          appearance={firstRunOpen ? "panel" : "glass"}
+          agentName={agentName}
           message={shellToChatMessageData(m)}
           reduceMotion={reduce}
           onCopy={handleCopyMessage}
@@ -1733,6 +1734,8 @@ export function ContinuousChatOverlay({
     },
     [
       visibleMessages.length,
+      firstRunOpen,
+      agentName,
       reduce,
       handleCopyMessage,
       handleLongPressCopy,


### PR DESCRIPTION
## Summary
- Fixes a first-run onboarding visual regression found during the live screenshot review after #14903: the intro copy used dark-glass chat row styling over the opaque light onboarding backdrop, making it visually washed out even though the DOM was present.
- Renders first-run transcript turns with the normal panel chat row while onboarding is active, and passes the real `agentName` so the row says `Eliza` instead of the generic `Agent`.
- Adds a regression test that pins first-run onboarding to panel chrome and rejects the generic `Agent` label.

## Evidence
- `bunx @biomejs/biome check packages/ui/src/components/shell/ContinuousChatOverlay.tsx packages/ui/src/components/shell/ContinuousChatOverlay.firstrun.test.tsx` — pass.
- `bunx vitest run packages/ui/src/components/shell/ContinuousChatOverlay.firstrun.test.tsx` — pass, 15 tests.
- `bun run audit:error-policy-ratchet --report` — pass; `ContinuousChatOverlay.tsx` emptyCatch 1->1, serverConsole 0->0.
- `bun run --cwd packages/app audit:live -- --base http://127.0.0.1:2151 --out /tmp/eliza-onboarding-contrast-650ebb48d0d --strict` — pass, 7 states, no-blue offenders `[]`, blue ceiling `0.02`, commit `650ebb48d0d4280bb82441babf4e4a23c0f381e2`.
- Live OCR/palette: desktop/mobile onboarding and mobile composer-focused all report `blue_fraction=0`; OCR now reads `Eliza Hi — I'm Eliza. Sign in to Eliza Cloud and I'll get you set up`; composer-focused also passes `composer:typed_text_present` for `remind me to call the pharmacy before 5`.
- Manual screenshot review: `/tmp/eliza-onboarding-contrast-650ebb48d0d/mobile-composer-focused.png` shows readable onboarding copy, real `Eliza` label, visible sign-in CTA, focused composer text, and no overlap.
- Required broad app audit: `bun run --cwd packages/app audit:app` — Playwright passed `365 passed` in 11.1m. Relevant `builtin-chat` states were `good` on mobile portrait, mobile landscape, desktop landscape, and iPad portrait. The audit summary still reports existing unrelated `needs-work` debts in wallet/inventory, fine-tuning/training, background, and model-tester overlay-clearance states; none are touched by this PR.

## Follow-up Context
- #14903 merged the visual-QA evidence hardening that made this issue obvious. This PR is the UI correction discovered by that manual screenshot pass.