### PR TITLE
feat(lifeops): kind-aware needs-attention taps + remaining one-tap [CHOICE] sites (#14737, #14733 follow-up)

### DIFF
--- a/packages/test/vitest/integration.config.ts
+++ b/packages/test/vitest/integration.config.ts
@@ -74,6 +74,29 @@ const discordSubpathAliases: ModuleAlias[] = existsSync(discordScraperSource)
       },
     ]
   : [];
+// Same story for plugin-app-control's `/actions/settings` subpath: its build
+// (tsup with index + worker entries only) never emits dist/actions/*.js, so
+// the agent's settings-actions.ts import only resolves under the
+// `eliza-source` exports condition vite's SSR resolver ignores. Pin it to the
+// TS source so the PA plugin graph can boot in this lane.
+const appControlSettingsSource = path.join(
+  elizaWorkspaceRoot,
+  "plugins",
+  "plugin-app-control",
+  "src",
+  "actions",
+  "settings.ts",
+);
+const appControlSubpathAliases: ModuleAlias[] = existsSync(
+  appControlSettingsSource,
+)
+  ? [
+      {
+        find: /^@elizaos\/plugin-app-control\/actions\/settings$/,
+        replacement: appControlSettingsSource,
+      },
+    ]
+  : [];
 // Include/exclude globs are cwd-relative, but the eliza workspace sits at
 // `eliza/` in the nested eliza layout and at the repo root in a flat eliza
 // checkout (#11047). Derive the prefix instead of hardcoding `eliza/` so the
@@ -100,6 +123,7 @@ const uiSourceRoot = existsSync(path.join(workspaceUiSourceRoot, "index.ts"))
 const integrationResolveAlias: ModuleAlias[] = [
   ...getOptionalPluginSdkAliases(repoRoot),
   ...discordSubpathAliases,
+  ...appControlSubpathAliases,
   ...(elizaCoreEntry
     ? [
         // Subpath aliases must precede the bare specifier. A bare-string
@@ -182,7 +206,10 @@ export default defineConfig({
     testTimeout: 120_000,
     hookTimeout: 120_000,
     globalSetup: [
-      path.join(elizaWorkspaceRoot, "packages/app-core/test/e2e-global-setup.ts"),
+      path.join(
+        elizaWorkspaceRoot,
+        "packages/app-core/test/e2e-global-setup.ts",
+      ),
     ],
     // Integration files frequently replace globals and module-level mocks.
     // Shared module state causes cross-file bleed, which is more expensive to
@@ -207,7 +234,9 @@ export default defineConfig({
       // vitest.config.ts (which excludes the integration suffix from the
       // unit lane) nor this integration config picked them up. Include
       // them now so the existing coverage runs.
-      elizaGlob("plugins/plugin-personal-assistant/test/**/*.integration.test.ts"),
+      elizaGlob(
+        "plugins/plugin-personal-assistant/test/**/*.integration.test.ts",
+      ),
       elizaGlob("plugins/*/test/**/*.integration.test.ts"),
       // Src-level plugin integration tests were dead the same way: the
       // scheduler suite at plugin-personal-assistant/src/lifeops/
@@ -216,10 +245,14 @@ export default defineConfig({
       // plugin's unit lane (integration suffix excluded) nor the test/**
       // globs above — vitest reported "No test files found" even when the
       // file was passed explicitly. Include src/** so the suite runs.
-      elizaGlob("plugins/plugin-personal-assistant/src/**/*.integration.test.ts"),
+      elizaGlob(
+        "plugins/plugin-personal-assistant/src/**/*.integration.test.ts",
+      ),
       elizaGlob("plugins/*/src/**/*.integration.test.ts"),
     ],
-    setupFiles: [path.join(elizaWorkspaceRoot, "packages/app-core/test/setup.ts")],
+    setupFiles: [
+      path.join(elizaWorkspaceRoot, "packages/app-core/test/setup.ts"),
+    ],
     exclude: [
       "dist/**",
       "**/node_modules/**",

--- a/packages/ui/src/components/chat/widgets/WIDGET_MATRIX.md
+++ b/packages/ui/src/components/chat/widgets/WIDGET_MATRIX.md
@@ -54,7 +54,7 @@ affordances.
 | Widget | Marker | Producing action | Parser | Renderer | Handlers it calls | Surfaces | Status |
 |---|---|---|---|---|---|---|---|
 | **Task** | `[TASK:<threadId>]<title>[/TASK]` | `TASKS_CREATE` -> `plugin-agent-orchestrator/src/actions/tasks.ts:725` | `message-task-parser.ts` | `task-widget.tsx` `TaskWidget` | header click expands the live WS-driven pipeline (nested sub-agents + tool steps + plan) in place; `navigate` to `/orchestrator?taskId=` via the explicit "Open in workbench" link (#13536) | both (1) | wired + verified |
-| **Choice** | `[CHOICE:<scope> ...]...[/CHOICE]` | any action emitting a choice block | `message-choice-parser.ts` | `ChoiceWidget.tsx` | `sendAction` | both | wired + verified |
+| **Choice** | `[CHOICE:<scope> ...]...[/CHOICE]` | model-taught (`uiWidgets` guide, #14861) AND code-emitted by actions (#14733: inbox draft/triage, approval enqueue, check-in acks, goal check-ins, RESOLVE_REQUEST disambiguation, app/plugin create) | `message-choice-parser.ts` | `ChoiceWidget.tsx` | `sendAction` | both | wired + verified |
 | **Followups** | `[FOLLOWUPS ...]...[/FOLLOWUPS]` | any action emitting followup chips | `message-followups-parser.ts` | `followups.tsx` `FollowupsWidget` | `sendAction` (reply), `navigate` (navigate kind), `prefillComposer` (prompt kind) | both | wired + verified |
 | **Form** | `[FORM]\n{json}\n[/FORM]` | any action emitting a form schema | `message-form-parser.ts` | `form-request.tsx` `FormRequest` | `submitForm` | both | wired + verified |
 | **Workflow** | `[WORKFLOW]\n{json}\n[/WORKFLOW]` | any agent emitting an ordered step pipeline (#13536) | `message-workflow-parser.ts` | `workflow-steps.tsx` `WorkflowSteps` | none (display-only; re-emit to advance) | both | wired + verified |

--- a/packages/ui/src/components/chat/widgets/needs-attention.test.tsx
+++ b/packages/ui/src/components/chat/widgets/needs-attention.test.tsx
@@ -23,11 +23,13 @@ const {
   listPendingActionsMock,
   publishHomeAttentionSpy,
   dispatchChatPrefillSpy,
+  dispatchChatOpenSpy,
 } = vi.hoisted(() => ({
   getBaseUrlMock: vi.fn(() => "http://localhost"),
   listPendingActionsMock: vi.fn(),
   publishHomeAttentionSpy: vi.fn(),
   dispatchChatPrefillSpy: vi.fn(),
+  dispatchChatOpenSpy: vi.fn(),
 }));
 
 // The widget reads the canonical surface through the typed client; mock only
@@ -46,12 +48,13 @@ vi.mock("../../../widgets/home-attention-store", () => ({
     publishHomeAttentionSpy(widgetKey, weight),
 }));
 
-// The round-trip hands the user back to the agent's RESOLVE_REQUEST action via a
-// prefilled chat composer; spy on that one rail while preserving the module's
+// The round-trip hands the user back to the canonical handler via a prefilled
+// (or opened) chat composer; spy on those rails while preserving the module's
 // other exports (client-base imports NETWORK_STATUS_CHANGE_EVENT et al.).
 vi.mock("../../../events", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../../events")>()),
   dispatchChatPrefill: dispatchChatPrefillSpy,
+  dispatchChatOpen: dispatchChatOpenSpy,
 }));
 
 import { HOME_SIGNAL_WEIGHTS } from "../../../widgets/home-priority";
@@ -93,6 +96,7 @@ beforeEach(() => {
   getBaseUrlMock.mockReturnValue("http://localhost");
   publishHomeAttentionSpy.mockReset();
   dispatchChatPrefillSpy.mockReset();
+  dispatchChatOpenSpy.mockReset();
   listPendingActionsMock.mockReset();
 });
 
@@ -283,5 +287,130 @@ describe("NeedsAttentionWidget (#9449)", () => {
       expect(screen.getByTestId("chat-widget-needs-attention")).toBeTruthy();
     });
     expect(container.firstElementChild?.className).toContain("col-span-2");
+  });
+});
+
+// #14737 — tap behavior derives from the pending item's kind + options; the
+// blanket "Approve: <title>" prefill only survives for approval-shaped items.
+describe("NeedsAttentionWidget kind-aware activation (#14737)", () => {
+  async function renderTop(item: PendingUserAction): Promise<HTMLElement> {
+    mockPending([item]);
+    render(<NeedsAttentionWidget {...fetchProps} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-widget-needs-attention")).toBeTruthy();
+    });
+    return screen.getByTestId("chat-widget-needs-attention");
+  }
+
+  it("an approval with options expands chips on tap instead of prefilling; Approve chip prefills the approval", async () => {
+    const card = await renderTop(
+      pending({
+        id: "a-1",
+        title: "Send the contract",
+        options: [
+          { id: "approve", label: "Approve" },
+          { id: "reject", label: "Reject", isCancel: true },
+        ],
+      }),
+    );
+
+    expect(screen.queryByTestId("needs-attention-options")).toBeNull();
+    fireEvent.click(card);
+    // First tap surfaces the choice chips — nothing is prefilled blind.
+    expect(dispatchChatPrefillSpy).not.toHaveBeenCalled();
+    expect(screen.getByTestId("needs-attention-options")).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("needs-attention-option-approve"));
+    expect(dispatchChatPrefillSpy).toHaveBeenCalledWith({
+      text: "Approve: Send the contract",
+      select: true,
+    });
+    // Choosing collapses the chip row.
+    expect(screen.queryByTestId("needs-attention-options")).toBeNull();
+  });
+
+  it("the Reject chip prefills a rejection, not an approval", async () => {
+    const card = await renderTop(
+      pending({
+        id: "a-1",
+        title: "Send the contract",
+        options: [
+          { id: "approve", label: "Approve" },
+          { id: "reject", label: "Reject", isCancel: true },
+        ],
+      }),
+    );
+
+    fireEvent.click(card);
+    fireEvent.click(screen.getByTestId("needs-attention-option-reject"));
+    expect(dispatchChatPrefillSpy).toHaveBeenCalledWith({
+      text: "Reject: Send the contract",
+      select: true,
+    });
+  });
+
+  it("a choice-kind item surfaces its real options and a tap prefills the option's label as the answer", async () => {
+    const card = await renderTop(
+      pending({
+        id: "c-1",
+        kind: "choice",
+        title: "Which time works?",
+        options: [
+          { id: "tue-3", label: "Tuesday 3pm" },
+          { id: "wed-10", label: "Wednesday 10am" },
+        ],
+      }),
+    );
+
+    fireEvent.click(card);
+    fireEvent.click(screen.getByTestId("needs-attention-option-wed-10"));
+    expect(dispatchChatPrefillSpy).toHaveBeenCalledWith({
+      text: "Wednesday 10am",
+      select: true,
+    });
+  });
+
+  it("a pending planner question (no options, free reply) opens the composer WITHOUT the wrong Approve prefill", async () => {
+    const card = await renderTop(
+      pending({
+        id: "p-1",
+        kind: "pending_prompt",
+        source: "pending-prompts",
+        title: "Which time works for the dentist?",
+        expectedReplyKind: "text",
+      }),
+    );
+
+    fireEvent.click(card);
+    expect(dispatchChatOpenSpy).toHaveBeenCalledTimes(1);
+    expect(dispatchChatPrefillSpy).not.toHaveBeenCalled();
+  });
+
+  it("an approval without options keeps the classic natural-language prefill", async () => {
+    const card = await renderTop(
+      pending({ id: "a-2", title: "Book the flight" }),
+    );
+
+    fireEvent.click(card);
+    expect(dispatchChatPrefillSpy).toHaveBeenCalledWith({
+      text: "Approve: Book the flight",
+      select: true,
+    });
+    expect(dispatchChatOpenSpy).not.toHaveBeenCalled();
+  });
+
+  it("second tap on the card collapses the chip row again", async () => {
+    const card = await renderTop(
+      pending({
+        id: "a-1",
+        title: "Send the contract",
+        options: [{ id: "approve", label: "Approve" }],
+      }),
+    );
+
+    fireEvent.click(card);
+    expect(screen.getByTestId("needs-attention-options")).toBeTruthy();
+    fireEvent.click(card);
+    expect(screen.queryByTestId("needs-attention-options")).toBeNull();
   });
 });

--- a/packages/ui/src/components/chat/widgets/needs-attention.tsx
+++ b/packages/ui/src/components/chat/widgets/needs-attention.tsx
@@ -1,22 +1,25 @@
 /**
- * Icon-first home widget surfacing the oldest pending approval the user still
- * owes the agent (waiting longest = most overdue), tapping prefills the chat to
- * resolve it. One of the home-attention widget family; `useApprovals` reads the
+ * Icon-first home widget surfacing the oldest pending action the user still
+ * owes the agent (waiting longest = most overdue). Tap behavior derives from
+ * the item's kind + options (#14737): option-carrying items expand one-tap
+ * chips, approvals prefill the chat composer, free-reply prompts open the
+ * composer. One of the home-attention widget family; `useApprovals` reads the
  * shared pending-actions source and the widget publishes into the home-attention
  * store to rank itself on the home surface.
  */
-import type { PendingUserAction } from "@elizaos/core";
+import type { PendingUserAction, PendingUserActionOption } from "@elizaos/core";
 import { CircleHelp } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { client } from "../../../api";
 import { supportsFullAppShellRoutes } from "../../../api/app-shell-capabilities";
-import { dispatchChatPrefill } from "../../../events";
+import { dispatchChatOpen, dispatchChatPrefill } from "../../../events";
 import { useIntervalWhenDocumentVisible } from "../../../hooks";
 import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
 import { useNow } from "../../../hooks/useNow";
 import { usePublishHomeAttention } from "../../../widgets/home-attention-store";
 import { HOME_SIGNAL_WEIGHTS } from "../../../widgets/home-priority";
 import type { WidgetProps } from "../../../widgets/types";
+import { Button } from "../../ui/button";
 import { HomeWidgetCard } from "./home-widget-card";
 
 // The canonical "actions requiring your response" home card (#9449 PILLAR C):
@@ -118,6 +121,48 @@ function oldestPending(
   );
 }
 
+/**
+ * What tapping the card should do, derived purely from the pending item's
+ * structural fields (#14737). GET /api/approvals merges three producers, so
+ * the old unconditional "Approve: <title>" prefill was semantically wrong for
+ * anything but an approval:
+ *  - `choices` — the item carries typed options; tapping surfaces them as
+ *    chips and the user picks one (never a blind "Approve:" prefill).
+ *  - `prefill` — an approval-shaped item without options keeps the classic
+ *    natural-language approval prefill routed to RESOLVE_REQUEST.
+ *  - `open-chat` — a free-reply prompt/question; the title IS the question,
+ *    so the tap opens the composer without prefilling a wrong verb.
+ */
+export type PendingActivation =
+  | { mode: "choices"; options: readonly PendingUserActionOption[] }
+  | { mode: "prefill"; text: string }
+  | { mode: "open-chat" };
+
+export function deriveActivation(item: PendingUserAction): PendingActivation {
+  if (item.options && item.options.length > 0) {
+    return { mode: "choices", options: item.options };
+  }
+  if (item.kind === "approval" || item.kind === "task_approval") {
+    return { mode: "prefill", text: `Approve: ${item.title}` };
+  }
+  return { mode: "open-chat" };
+}
+
+/**
+ * The composer text a tapped option prefills. The fixed approve/reject option
+ * ids from the approval producers keep the natural-language form the
+ * RESOLVE_REQUEST extraction already understands; any other option is a
+ * direct answer, so its label IS the reply.
+ */
+export function deriveOptionReply(
+  item: PendingUserAction,
+  option: PendingUserActionOption,
+): string {
+  if (option.id === "approve") return `Approve: ${item.title}`;
+  if (option.id === "reject") return `Reject: ${item.title}`;
+  return option.label;
+}
+
 export function NeedsAttentionWidget({
   spanClassName = "col-span-2 row-span-1",
 }: Partial<WidgetProps>) {
@@ -143,20 +188,59 @@ export function NeedsAttentionWidget({
   }, [top, now]);
   usePublishHomeAttention(NEEDS_ATTENTION_WIDGET_KEY, weight);
 
-  // Route back to the handler: prefill the chat composer with a natural-language
-  // approval so the agent's RESOLVE_REQUEST action resolves it in the same room
-  // the request lives in. The widget never resolves the decision itself — it
-  // hands the user to the canonical action.
+  // Choice-shaped items expand a chip row on tap. The expansion is keyed to
+  // the item id, so the row collapses by itself whenever the top item changes
+  // (resolved elsewhere, or a new oldest arrives) — no reset effect needed.
+  const [expandedForId, setExpandedForId] = useState<string | null>(null);
+  const expanded = top != null && expandedForId === top.id;
+
+  const activation = useMemo(
+    () => (top == null ? null : deriveActivation(top)),
+    [top],
+  );
+
+  // Route back to the handler without resolving anything here: prefill (or
+  // open) the chat composer so the canonical action (RESOLVE_REQUEST, the
+  // pending-prompt reply path, …) receives the user's answer. The widget
+  // renders and derives display text only — no business logic (#14737).
   const onActivate = useCallback(() => {
-    if (top == null) return;
-    dispatchChatPrefill({ text: `Approve: ${top.title}`, select: true });
-  }, [top]);
+    if (top == null || activation == null) return;
+    switch (activation.mode) {
+      case "choices":
+        setExpandedForId((current) => (current === top.id ? null : top.id));
+        return;
+      case "prefill":
+        dispatchChatPrefill({ text: activation.text, select: true });
+        return;
+      case "open-chat":
+        dispatchChatOpen();
+        return;
+    }
+  }, [top, activation]);
+
+  const onChooseOption = useCallback(
+    (option: PendingUserActionOption) => {
+      if (top == null) return;
+      setExpandedForId(null);
+      dispatchChatPrefill({
+        text: deriveOptionReply(top, option),
+        select: true,
+      });
+    },
+    [top],
+  );
 
   // Render nothing until the first load resolves with pending items (#9143).
-  if (!loaded || top == null) return null;
+  if (!loaded || top == null || activation == null) return null;
 
   const count = pending.length;
   const stale = now - top.createdAt >= STALE_PENDING_AGE_MS;
+  const hint =
+    activation.mode === "choices"
+      ? "Tap to pick a response."
+      : activation.mode === "open-chat"
+        ? "Answer in chat."
+        : "Respond in chat.";
   return (
     <div className={`min-w-0 ${spanClassName}`}>
       <HomeWidgetCard
@@ -166,9 +250,34 @@ export function NeedsAttentionWidget({
         badge={count}
         tone={stale ? "warn" : "default"}
         testId="chat-widget-needs-attention"
-        ariaLabel={`${count} action${count === 1 ? "" : "s"} need your response, oldest: ${top.title}. Respond in chat.`}
+        ariaLabel={`${count} action${count === 1 ? "" : "s"} need your response, oldest: ${top.title}. ${hint}`}
         onActivate={onActivate}
       />
+      {activation.mode === "choices" && expanded ? (
+        // Sibling of the card (the card is itself a <button>, so the chips
+        // must not nest inside it). Tapping a chip prefills the composer with
+        // that option's reply — the user still reviews and sends.
+        <fieldset
+          className="mt-1.5 flex min-w-0 flex-wrap items-center gap-1.5 border-0 p-0"
+          aria-label={`Respond to: ${top.title}`}
+          data-testid="needs-attention-options"
+        >
+          {activation.options.map((option) => (
+            <Button
+              key={option.id}
+              type="button"
+              variant={option.isCancel ? "ghost" : "outline"}
+              size="sm"
+              aria-label={option.label}
+              data-testid={`needs-attention-option-${option.id}`}
+              className="h-7 px-3 text-xs"
+              onClick={() => onChooseOption(option)}
+            >
+              {option.label}
+            </Button>
+          ))}
+        </fieldset>
+      ) : null}
     </div>
   );
 }

--- a/plugins/plugin-goals/src/actions/goals.harness.test.ts
+++ b/plugins/plugin-goals/src/actions/goals.harness.test.ts
@@ -17,11 +17,17 @@
  *   2. A low-confidence extraction → the same structured clarification, proving
  *      the action degrades safely on an uncertain model decision.
  */
-import { type HandlerCallback, type Memory, ModelType } from "@elizaos/core";
+import {
+  type HandlerCallback,
+  type Memory,
+  ModelType,
+  parseInteractionBlocks,
+} from "@elizaos/core";
 import { type MockLlmRuntime, withMockLlmRuntime } from "@elizaos/test-harness";
 import { afterEach, describe, expect, it } from "vitest";
 import { executeRawSql } from "../db/sql.ts";
 import { goalsPlugin } from "../plugin.ts";
+import { GOAL_CHECKIN_PROGRESS_STATES } from "../services/checkin.ts";
 import { ownerGoalsAction } from "./goals.ts";
 
 /**
@@ -184,6 +190,137 @@ describe("OWNER_GOALS action (keyless harness)", () => {
 
     expect(result.success).toBe(false);
     expect(reply.trim().length).toBeGreaterThan(0);
+    expect(() => harness.assertFixturesConsumed()).not.toThrow();
+  });
+
+  it("re-asks an invalid check-in progress with one-tap [CHOICE] chips whose values the checkin turn accepts (#14733)", async () => {
+    const harness = track(
+      await withMockLlmRuntime({
+        plugins: [goalsPlugin],
+        fixtures: [
+          {
+            // Extraction picked `checkin` but pulled a free-text progress the
+            // handler cannot classify.
+            name: "goal-extraction-checkin-bad-progress",
+            match: { modelType: ModelType.TEXT_LARGE },
+            response: JSON.stringify({
+              action: "checkin",
+              params: { id: "goal-123", progress: "kinda okay" },
+              missing: [],
+              confidence: 0.95,
+            }),
+            times: 1,
+          },
+        ],
+      }),
+    );
+
+    const { result, reply } = await runOwnerGoals(
+      harness,
+      "Check in on my marathon goal — it's kinda okay.",
+    );
+
+    expect(result.success).toBe(false);
+    expect((result.data as { error?: string } | undefined)?.error).toBe(
+      "invalid_progress",
+    );
+    const { blocks } = parseInteractionBlocks(reply);
+    expect(blocks).toHaveLength(1);
+    const block = blocks[0];
+    expect(block).toMatchObject({
+      kind: "choice",
+      scope: "goal-checkin",
+      id: "goal-checkin-goal-123",
+    });
+    if (block?.kind !== "choice") throw new Error("expected choice block");
+    // Round-trip contract: every chip value IS a valid `progress` token.
+    expect(block.options.map((o) => o.value)).toEqual([
+      ...GOAL_CHECKIN_PROGRESS_STATES,
+    ]);
+    expect(() => harness.assertFixturesConsumed()).not.toThrow();
+  });
+
+  it("appends the progress chips to a note-only check-in, and a chip value round-trips into recorded progress", async () => {
+    const harness = track(
+      await withMockLlmRuntime({
+        plugins: [goalsPlugin],
+        fixtures: [
+          {
+            name: "goal-extraction-create-for-checkin",
+            match: { modelType: ModelType.TEXT_LARGE },
+            response: JSON.stringify({
+              action: "create",
+              params: { title: "Ship the widget cluster" },
+              missing: [],
+              confidence: 0.95,
+            }),
+            times: 1,
+          },
+        ],
+      }),
+    );
+    await provisionAuditTable(harness);
+
+    const created = await runOwnerGoals(
+      harness,
+      "Add a goal to ship the widget cluster.",
+    );
+    expect(created.result.success, created.reply).toBe(true);
+    const record = (
+      created.result.data as { record?: { goal?: { id?: string } } } | undefined
+    )?.record;
+    const goalId = record?.goal?.id;
+    expect(typeof goalId).toBe("string");
+
+    // Turn 2: a note-only check-in — the reply must end with progress chips.
+    harness.fixtures.register({
+      name: "goal-extraction-checkin-note-only",
+      match: { modelType: ModelType.TEXT_LARGE },
+      response: JSON.stringify({
+        action: "checkin",
+        params: { id: goalId, note: "made progress this week" },
+        missing: [],
+        confidence: 0.95,
+      }),
+      times: 1,
+    });
+    const noteTurn = await runOwnerGoals(
+      harness,
+      "Check in on the widget goal: made progress this week.",
+    );
+    expect(noteTurn.result.success, noteTurn.reply).toBe(true);
+    expect(noteTurn.reply).toContain("How is it tracking?");
+    const { blocks } = parseInteractionBlocks(noteTurn.reply);
+    expect(blocks).toHaveLength(1);
+    const block = blocks[0];
+    if (block?.kind !== "choice") throw new Error("expected choice block");
+    expect(block.id).toBe(`goal-checkin-${goalId}`);
+    const tappedValue = block.options[1]?.value;
+    expect(tappedValue).toBe("at_risk");
+
+    // Turn 3: the tap — the chip value arrives as the user's message and the
+    // extraction passes it through as `progress`; the goal's reviewState
+    // must flip to the tapped token.
+    harness.fixtures.register({
+      name: "goal-extraction-checkin-tap",
+      match: { modelType: ModelType.TEXT_LARGE },
+      response: JSON.stringify({
+        action: "checkin",
+        params: { id: goalId, progress: tappedValue },
+        missing: [],
+        confidence: 0.95,
+      }),
+      times: 1,
+    });
+    const tapTurn = await runOwnerGoals(harness, tappedValue ?? "");
+    expect(tapTurn.result.success, tapTurn.reply).toBe(true);
+    expect(tapTurn.reply).toContain("at risk");
+    const updatedGoal = (
+      tapTurn.result.data as { goal?: { reviewState?: string } } | undefined
+    )?.goal;
+    expect(updatedGoal?.reviewState).toBe("at_risk");
+    // A progress-carrying check-in reply needs no chips.
+    expect(parseInteractionBlocks(tapTurn.reply).blocks).toHaveLength(0);
     expect(() => harness.assertFixturesConsumed()).not.toThrow();
   });
 });

--- a/plugins/plugin-goals/src/actions/goals.ts
+++ b/plugins/plugin-goals/src/actions/goals.ts
@@ -15,6 +15,8 @@
 import {
   type Action,
   type ActionResult,
+  appendInteractionBlock,
+  type ChoiceInteraction,
   type HandlerCallback,
   type HandlerOptions,
   type IAgentRuntime,
@@ -48,6 +50,28 @@ function parseCheckinProgress(
 ): GoalCheckinProgress | undefined {
   if (value === undefined) return undefined;
   return GOAL_CHECKIN_PROGRESS_STATES.find((state) => state === value);
+}
+
+/**
+ * One-tap progress picker for a goal check-in (#14733). A tapped option
+ * round-trips as the user's next message carrying the bare progress token
+ * (`on_track` | `at_risk` | `needs_attention`) — exactly the values the
+ * `checkin` subaction's `progress` parameter accepts, so the follow-up turn
+ * records structured progress with no free-text classification.
+ */
+export function buildGoalCheckinProgressChoice(
+  goalId: string,
+): ChoiceInteraction {
+  return {
+    kind: "choice",
+    id: `goal-checkin-${goalId}`,
+    scope: "goal-checkin",
+    options: [
+      { value: "on_track", label: "On track" },
+      { value: "at_risk", label: "At risk" },
+      { value: "needs_attention", label: "Needs attention" },
+    ],
+  };
 }
 
 const SUBACTIONS: SubactionsMap<GoalSubaction> = {
@@ -224,7 +248,12 @@ export const ownerGoalsAction: Action = {
           }
           const progress = parseCheckinProgress(params.progress);
           if (params.progress !== undefined && progress === undefined) {
-            const text = `${GOALS_LOG_PREFIX} progress must be one of: ${GOAL_CHECKIN_PROGRESS_STATES.join(", ")}.`;
+            // Ask again with one-tap chips instead of a typed-token demand;
+            // the tapped value is a valid `progress` on the next turn.
+            const text = appendInteractionBlock(
+              "How is this goal tracking?",
+              buildGoalCheckinProgressChoice(params.id ?? ""),
+            );
             await callback?.({ text });
             return {
               success: false,
@@ -238,7 +267,16 @@ export const ownerGoalsAction: Action = {
               ...(params.note !== undefined ? { note: params.note } : {}),
               ...(progress !== undefined ? { progress } : {}),
             });
-          const text = `Logged check-in for "${goal.title}"${progress ? ` — ${progress.replace(/_/g, " ")}` : ""}.`;
+          let text = `Logged check-in for "${goal.title}"${progress ? ` — ${progress.replace(/_/g, " ")}` : ""}.`;
+          if (progress === undefined) {
+            // Note-only check-in: harvest structured progress with one tap
+            // (a second `checkin` turn with progress-only is valid — the
+            // engine updates reviewState without needing a live fired task).
+            text = appendInteractionBlock(
+              `${text} How is it tracking?`,
+              buildGoalCheckinProgressChoice(goal.id),
+            );
+          }
           await callback?.({ text });
           return {
             success: true,

--- a/plugins/plugin-inbox/test/inbox-action.test.ts
+++ b/plugins/plugin-inbox/test/inbox-action.test.ts
@@ -8,12 +8,14 @@
  */
 
 import type {
+  Content,
   HandlerOptions,
   IAgentRuntime,
   Memory,
+  MessageAdapter,
   UUID,
 } from "@elizaos/core";
-import { getDefaultTriageService } from "@elizaos/core";
+import { getDefaultTriageService, parseInteractionBlocks } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -734,6 +736,218 @@ describe("INBOX umbrella action — cross-channel inbox", () => {
         "snoozed_until = '2026-07-02T04:00:00.000Z'",
       );
       expect(update?.sql).toContain("resolved = FALSE");
+    });
+  });
+
+  // The marker builders themselves are pinned by inbox-choice-markers.test.ts;
+  // these tests drive the REAL action handler end-to-end (repository + triage
+  // adapter + callback) and assert the chips reach the chat reply with values
+  // the next turn's handler accepts.
+  describe("one-tap [CHOICE] chips through the handler (#14733)", () => {
+    /**
+     * Minimal real adapter registered on the default triage service so the
+     * draft/send rail runs for real (create + send recorded); only the
+     * connector transport is faked.
+     */
+    function registerFakeGmailAdapter(): {
+      drafts: Array<{ body: string }>;
+      sent: string[];
+      archived: string[];
+    } {
+      const drafts: Array<{ body: string }> = [];
+      const sent: string[] = [];
+      const archived: string[] = [];
+      let seq = 0;
+      const adapter: MessageAdapter = {
+        source: "gmail",
+        isAvailable: () => true,
+        capabilities: () => ({
+          list: true,
+          search: false,
+          manage: { archive: true },
+          send: { reply: true },
+          worlds: "single",
+          channels: "none",
+        }),
+        listMessages: async () => [],
+        getMessage: async () => null,
+        manageMessage: async (_runtime, messageId) => {
+          archived.push(messageId);
+          return { ok: true };
+        },
+        createDraft: async (_runtime, draft) => {
+          drafts.push({ body: draft.body });
+          seq += 1;
+          return { draftId: `draft-${seq}`, preview: draft.body.slice(0, 40) };
+        },
+        sendDraft: async (_runtime, draftId) => {
+          sent.push(draftId);
+          return { externalId: `ext-${draftId}` };
+        },
+      };
+      getDefaultTriageService().register(adapter);
+      return { drafts, sent, archived };
+    }
+
+    function collectCallback(): {
+      texts: string[];
+      callback: (content: Content) => Promise<[]>;
+    } {
+      const texts: string[] = [];
+      return {
+        texts,
+        callback: async (content: Content) => {
+          if (typeof content.text === "string") texts.push(content.text);
+          return [];
+        },
+      };
+    }
+
+    it("appends send/discard chips to a drafted-reply confirmation and keeps the values the approve turn accepts", async () => {
+      registerFakeGmailAdapter();
+      const { runtime } = makeDbRuntime((sql) =>
+        sql.includes("WHERE id =") ? [makeTriageRow({ id: "entry-42" })] : [],
+      );
+      const { texts, callback } = collectCallback();
+
+      const result = await inboxAction.handler(
+        runtime,
+        makeMessage("reply to alice that friday works"),
+        undefined,
+        {
+          parameters: {
+            subaction: "reply",
+            entryId: "entry-42",
+            body: "Yes, Friday works.",
+          },
+        } as unknown as HandlerOptions,
+        callback as unknown as Parameters<typeof inboxAction.handler>[4],
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toMatchObject({
+        subaction: "reply",
+        requiresConfirmation: true,
+        entryId: "entry-42",
+      });
+      // The chat reply (callback) and the planner-facing result text agree,
+      // and both carry the structured block appended after the prose.
+      expect(texts).toHaveLength(1);
+      expect(result.text).toBe(texts[0]);
+      expect(texts[0]).toContain("Confirm before sending");
+      const { blocks } = parseInteractionBlocks(texts[0] ?? "");
+      expect(blocks).toHaveLength(1);
+      const block = blocks[0];
+      expect(block).toMatchObject({
+        kind: "choice",
+        scope: "inbox-draft-entry-42",
+        id: "entry-42",
+      });
+      if (block?.kind !== "choice") throw new Error("expected choice block");
+      // Values carry the subaction token + entry id the next turn's handler
+      // resolves ("inbox approve entry-42" → approve, entryId=entry-42);
+      // every chip maps to an op the INBOX action actually supports.
+      expect(block.options.map((o) => o.value)).toEqual([
+        "inbox approve entry-42",
+        "inbox archive entry-42",
+      ]);
+      expect(block.options.map((o) => o.label)).toEqual(["Send", "Discard"]);
+    });
+
+    it("a confirmed approve dispatches the stored draft and emits NO chips", async () => {
+      const { sent } = registerFakeGmailAdapter();
+      const { runtime } = makeDbRuntime((sql) =>
+        sql.includes("WHERE id =")
+          ? [makeTriageRow({ id: "entry-42", draft_response: "Yes, Friday." })]
+          : [],
+      );
+      const { texts, callback } = collectCallback();
+
+      const result = await inboxAction.handler(
+        runtime,
+        makeMessage("send"),
+        undefined,
+        {
+          parameters: { subaction: "approve", entryId: "entry-42" },
+        } as unknown as HandlerOptions,
+        callback as unknown as Parameters<typeof inboxAction.handler>[4],
+      );
+
+      expect(result.success).toBe(true);
+      expect(sent).toHaveLength(1);
+      expect(texts[0]).toContain("Sent reply");
+      expect(parseInteractionBlocks(texts[0] ?? "").blocks).toHaveLength(0);
+    });
+
+    it("appends per-thread reply/snooze/archive chips to the triage queue, capped at five threads, with entry ids in the values", async () => {
+      const rows = ["e1", "e2", "e3", "e4", "e5", "e6"].map((id, index) =>
+        makeTriageRow({
+          id,
+          sender_name: `Sender ${index + 1}`,
+          snippet: `message ${index + 1}`,
+        }),
+      );
+      const { runtime } = makeDbRuntime((sql) =>
+        sql.includes("life_inbox_triage_entries") ? rows : [],
+      );
+      const { texts, callback } = collectCallback();
+
+      const result = await inboxAction.handler(
+        runtime,
+        makeMessage("triage my inbox"),
+        undefined,
+        {
+          parameters: { subaction: "triage", limit: 10 },
+        } as unknown as HandlerOptions,
+        callback as unknown as Parameters<typeof inboxAction.handler>[4],
+      );
+
+      expect(result.success).toBe(true);
+      const text = texts[0] ?? "";
+      const { blocks } = parseInteractionBlocks(text);
+      expect(blocks).toHaveLength(5);
+      blocks.forEach((block, index) => {
+        const id = `e${index + 1}`;
+        expect(block).toMatchObject({
+          kind: "choice",
+          scope: `inbox-thread-${id}`,
+          id,
+        });
+        if (block.kind !== "choice") throw new Error("expected choice block");
+        // Values embed the entry id: a tap round-trips only the value, and
+        // with several blocks in one reply a bare "reply" is unattributable.
+        expect(block.options.map((o) => o.value)).toEqual([
+          `inbox reply ${id}`,
+          `inbox snooze ${id}`,
+          `inbox archive ${id}`,
+        ]);
+        // The reply chip names the sender so each block reads attributably.
+        expect(block.options[0]?.label).toBe(`Reply to Sender ${index + 1}`);
+      });
+      expect(text).not.toContain("e6");
+    });
+
+    it("an archive chip value round-trips into a successful archive of that entry", async () => {
+      const { archived } = registerFakeGmailAdapter();
+      const { runtime } = makeDbRuntime((sql) =>
+        sql.includes("WHERE id =") ? [makeTriageRow({ id: "e2" })] : [],
+      );
+
+      // The tapped value is `inbox archive e2`; the planner maps the tokens
+      // to subaction + entryId. Drive the handler with exactly that mapping.
+      const value = "inbox archive e2";
+      const [, subaction, entryId] = value.split(" ");
+      const result = await callInbox(runtime, makeMessage(value), {
+        subaction,
+        entryId,
+      });
+
+      expect(result.success).toBe(true);
+      expect(archived).toEqual(["gmail-msg-1"]);
+      expect(result.data).toMatchObject({
+        subaction: "archive",
+        entryId: "e2",
+      });
     });
   });
 });

--- a/plugins/plugin-personal-assistant/src/actions/resolve-request.ts
+++ b/plugins/plugin-personal-assistant/src/actions/resolve-request.ts
@@ -18,6 +18,8 @@ import type {
   Memory,
 } from "@elizaos/core";
 import {
+  appendInteractionBlock,
+  type ChoiceInteraction,
   logger,
   ModelType,
   resolveActionArgs,
@@ -88,6 +90,33 @@ function formatPending(requests: ReadonlyArray<ApprovalRequest>): string {
       return `${i + 1}. id=${r.id} action=${r.action} channel=${r.channel} reason=${r.reason}\n  payload:\n${payloadSummary}`;
     })
     .join("\n");
+}
+
+/** Chip labels stay glanceable; the full reason lives in the queue row. */
+function truncateReason(reason: string, max = 48): string {
+  const trimmed = reason.trim();
+  return trimmed.length <= max ? trimmed : `${trimmed.slice(0, max - 1)}…`;
+}
+
+/**
+ * One-tap request picker for an ambiguous approve/reject (#14733). Each option
+ * value is `<intent> <requestId>` — the tap round-trips it as the owner's next
+ * message, which this action's extraction resolves verbatim (the id is in the
+ * text and the `pendingApprovals` provider lists the same ids).
+ */
+export function buildResolveRequestChoice(
+  intent: ResolveSubaction,
+  pending: ReadonlyArray<ApprovalRequest>,
+): ChoiceInteraction {
+  return {
+    kind: "choice",
+    id: `approval-resolve-${Date.now().toString(36)}`,
+    scope: "approval-resolve",
+    options: pending.slice(0, 5).map((request) => ({
+      value: `${intent} ${request.id}`,
+      label: truncateReason(request.reason),
+    })),
+  };
 }
 
 function parseResolutionJson(raw: unknown): ExtractedResolution {
@@ -517,10 +546,15 @@ async function resolveApprovalRequest(
     ? { requestId: explicitRequestId, reason: explicitReason }
     : await extractResolution(runtime, userText, intent, pending);
   if (!extracted.requestId) {
+    // Ambiguous target with pending rows: ask with one-tap chips instead of
+    // demanding a typed id (#14733).
     const text =
       pending.length === 0
         ? "There are no pending approval requests."
-        : "Which request? Please reference it by id or describe it.";
+        : appendInteractionBlock(
+            "Which request?",
+            buildResolveRequestChoice(intent, pending),
+          );
     if (callback) await callback({ text });
     return {
       text,

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.checkin-chips.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.checkin-chips.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Sleep-cycle check-in delivery carries one-tap ack chips (#14733): the
+ * morning/night summary emitted onto the assistant stream must end with a
+ * `[CHOICE:checkin-<reportId>]` block. The marker builder itself is pinned by
+ * lifeops-choice-markers.test.ts; this suite covers the DISPATCH wiring —
+ * deterministic vitest with the check-in engine and sleep-cycle predicates
+ * mocked, so only summary+chips → emitAssistantEvent is under test.
+ */
+import { parseInteractionBlocks } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LifeOpsContext } from "../lifeops-context.js";
+import { type RemindersDeps, RemindersDomain } from "./reminders-service.js";
+
+const checkinMocks = vi.hoisted(() => ({
+  hasCheckinForLocalDay: vi.fn(async () => false),
+  runMorningCheckin: vi.fn(async () => ({
+    reportId: "rep-morning-1",
+    summaryText: "Morning! 2 meetings today, 1 overdue todo.",
+    escalationLevel: 0,
+  })),
+  runNightCheckin: vi.fn(async () => ({
+    reportId: "rep-night-1",
+    summaryText: "Night recap.",
+    escalationLevel: 0,
+  })),
+}));
+
+vi.mock("../checkin/checkin-service.js", () => ({
+  CheckinService: class {
+    hasCheckinForLocalDay = checkinMocks.hasCheckinForLocalDay;
+    runMorningCheckin = checkinMocks.runMorningCheckin;
+    runNightCheckin = checkinMocks.runNightCheckin;
+  },
+}));
+
+vi.mock("../checkin/schedule-resolver.js", () => ({
+  resolveCheckinSchedule: vi.fn(async () => ({
+    nightCheckinTime: "23:00",
+  })),
+}));
+
+vi.mock("@elizaos/plugin-health", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@elizaos/plugin-health")>();
+  return {
+    ...actual,
+    buildSleepRecapFromSchedule: vi.fn(() => undefined),
+    shouldRunMorningCheckinFromSleepCycle: vi.fn(() => true),
+    shouldRunNightCheckinFromSleepCycle: vi.fn(() => false),
+  };
+});
+
+const NOW = new Date("2026-07-05T08:00:00.000Z");
+
+function makeDomain() {
+  const emitAssistantEvent = vi.fn();
+  const ctx = {
+    runtime: { emitEvent: vi.fn(async () => undefined) },
+    repository: {},
+    agentId: () => "00000000-0000-0000-0000-0000000000dd",
+    emitAssistantEvent,
+    logLifeOpsWarn: vi.fn(),
+    logLifeOpsError: vi.fn(),
+  };
+  const deps = {
+    runDueWorkflows: vi.fn(async () => []),
+    runDueEventWorkflows: vi.fn(async () => []),
+    snoozeOccurrence: vi.fn(),
+    checkinSource: {},
+  };
+  const domain = new RemindersDomain(
+    ctx as unknown as LifeOpsContext,
+    deps as unknown as RemindersDeps,
+  );
+  // TS `private` is compile-time only — stub the contact-route lookup so the
+  // dispatch path needs no owner-contacts fixture.
+  (
+    domain as unknown as {
+      buildOwnerContactRouteEventMetadata: unknown;
+    }
+  ).buildOwnerContactRouteEventMetadata = vi.fn(async () => ({}));
+  return { domain, emitAssistantEvent };
+}
+
+const currentSchedule = {
+  timezone: "UTC",
+  circadianState: "awake",
+  wakeAt: "2026-07-05T07:00:00.000Z",
+  relativeTime: {
+    bedtimeTargetAt: "2026-07-05T23:00:00.000Z",
+    minutesUntilBedtimeTarget: 900,
+  },
+} as never;
+
+function runSleepCycleCheckins(domain: RemindersDomain): Promise<void> {
+  return (
+    domain as unknown as {
+      processSleepCycleCheckins(args: {
+        now: Date;
+        currentSchedule: unknown;
+      }): Promise<void>;
+    }
+  ).processSleepCycleCheckins({ now: NOW, currentSchedule });
+}
+
+beforeEach(() => {
+  checkinMocks.hasCheckinForLocalDay.mockClear();
+  checkinMocks.hasCheckinForLocalDay.mockResolvedValue(false);
+  checkinMocks.runMorningCheckin.mockClear();
+});
+
+describe("sleep-cycle check-in dispatch (#14733)", () => {
+  it("emits the morning summary with ack chips onto the assistant stream", async () => {
+    const { domain, emitAssistantEvent } = makeDomain();
+
+    await runSleepCycleCheckins(domain);
+
+    expect(checkinMocks.runMorningCheckin).toHaveBeenCalledTimes(1);
+    expect(emitAssistantEvent).toHaveBeenCalledTimes(1);
+    const [text, source, data] = emitAssistantEvent.mock.calls[0] as [
+      string,
+      string,
+      Record<string, unknown>,
+    ];
+    expect(source).toBe("lifeops-checkin");
+    expect(data.reportId).toBe("rep-morning-1");
+    expect(text).toContain("Morning! 2 meetings today, 1 overdue todo.");
+    const { blocks } = parseInteractionBlocks(text);
+    expect(blocks).toHaveLength(1);
+    const block = blocks[0];
+    expect(block).toMatchObject({
+      kind: "choice",
+      scope: "checkin-rep-morning-1",
+      id: "rep-morning-1",
+    });
+    if (block?.kind !== "choice") throw new Error("expected choice block");
+    // "All good" is a direct owner reply; details/snooze carry the report id.
+    expect(block.options.map((o) => o.value)).toEqual([
+      "All good",
+      "details rep-morning-1",
+      "snooze rep-morning-1",
+    ]);
+  });
+
+  it("skips the emit entirely when the day's check-in already went out", async () => {
+    checkinMocks.hasCheckinForLocalDay.mockResolvedValue(true);
+    const { domain, emitAssistantEvent } = makeDomain();
+
+    await runSleepCycleCheckins(domain);
+
+    expect(checkinMocks.runMorningCheckin).not.toHaveBeenCalled();
+    expect(emitAssistantEvent).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/plugin-personal-assistant/test/approval-queue.integration.test.ts
+++ b/plugins/plugin-personal-assistant/test/approval-queue.integration.test.ts
@@ -15,6 +15,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentRuntime } from "@elizaos/core";
+import { AgentEventService, parseInteractionBlocks } from "@elizaos/core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createRealTestRuntime } from "../../../packages/test/helpers/real-runtime.ts";
 import { createApprovalQueue } from "../src/lifeops/approval-queue.js";
@@ -101,6 +102,14 @@ beforeAll(async () => {
   });
   runtime = result.runtime;
   cleanup = result.cleanup;
+  // The enqueue chat-post (#14733) resolves the agent-event service off the
+  // runtime; register the real one when the test runtime lacks it. Service
+  // registration is lazy, so force the start (the agent server does the same
+  // at boot when the WS bridge subscribes).
+  if (!runtime.getService(AgentEventService.serviceType)) {
+    await runtime.registerService(AgentEventService);
+    await runtime.getServiceLoadPromise(AgentEventService.serviceType);
+  }
   queue = createApprovalQueue(runtime, { agentId: runtime.agentId });
 }, 180_000);
 
@@ -142,6 +151,57 @@ describe("ApprovalQueue integration (real PGlite)", () => {
       limit: 10,
     });
     expect(pendingList.every((r) => r.id !== enqueued.id)).toBe(true);
+  }, 60_000);
+
+  it("enqueue posts the question into chat as an assistant event with approve/reject chips (#14733)", async () => {
+    const events: Array<{ stream: string; data: Record<string, unknown> }> = [];
+    const eventService = runtime.getService(
+      AgentEventService.serviceType,
+    ) as AgentEventService;
+    const unsubscribe = eventService.subscribe((event) => {
+      events.push({ stream: event.stream, data: event.data });
+    });
+    try {
+      const enqueued = await queue.enqueue(
+        messageInput({ subjectUserId: "owner-chips" }),
+      );
+
+      const assistant = events.filter(
+        (event) =>
+          event.stream === "assistant" &&
+          event.data.source === "lifeops-approval",
+      );
+      expect(assistant).toHaveLength(1);
+      const data = assistant[0]?.data ?? {};
+      expect(data.requestId).toBe(enqueued.id);
+      expect(data.action).toBe("send_message");
+      const text = String(data.text ?? "");
+      expect(text).toContain("agent wants to confirm before sending");
+      const { blocks } = parseInteractionBlocks(text);
+      expect(blocks).toHaveLength(1);
+      const block = blocks[0];
+      if (block?.kind !== "choice") throw new Error("expected choice block");
+      expect(block.scope).toBe(`approval-${enqueued.id}`);
+      expect(block.id).toBe(enqueued.id);
+      // The tapped value is the owner's next message; it must carry the id
+      // RESOLVE_REQUEST resolves verbatim.
+      expect(block.options.map((o) => o.value)).toEqual([
+        `approve ${enqueued.id}`,
+        `reject ${enqueued.id}`,
+      ]);
+
+      // Round-trip: drive the queue with the tapped approve value's id.
+      const tapped = block.options[0]?.value ?? "";
+      const requestId = tapped.replace(/^approve /, "");
+      const approved = await queue.approve(requestId, {
+        resolvedBy: "owner-chips",
+        resolutionReason: "tapped Approve",
+      });
+      expect(approved.id).toBe(enqueued.id);
+      expect(approved.state).toBe("approved");
+    } finally {
+      unsubscribe();
+    }
   }, 60_000);
 
   it("enqueue → reject records resolver", async () => {

--- a/plugins/plugin-personal-assistant/test/resolve-request-executor.test.ts
+++ b/plugins/plugin-personal-assistant/test/resolve-request-executor.test.ts
@@ -22,6 +22,7 @@ import type {
   Memory,
   UUID,
 } from "@elizaos/core";
+import { parseInteractionBlocks } from "@elizaos/core";
 import type { LifeOpsCalendarEvent } from "@elizaos/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -112,6 +113,7 @@ import {
   ownerDocumentsAction,
 } from "../src/actions/document.js";
 import {
+  buildResolveRequestChoice,
   executeApprovedRequest,
   resolveRequestAction,
 } from "../src/actions/resolve-request.js";
@@ -699,6 +701,119 @@ describe("RESOLVE_REQUEST reject path", () => {
     expect(docMocks.markExecuting).not.toHaveBeenCalled();
     expect(docMocks.markDone).not.toHaveBeenCalled();
     expect(result).toMatchObject({ success: true });
+    expect(texts.join(" ")).toContain("Rejected");
+  });
+});
+
+describe("RESOLVE_REQUEST ambiguous-target chips (#14733)", () => {
+  function pendingPair(): [ApprovalRequest, ApprovalRequest] {
+    const base = {
+      state: "pending" as const,
+      resolvedAt: null,
+      resolvedBy: null,
+      resolutionReason: null,
+    };
+    return [
+      approvedRequest({
+        ...base,
+        action: "send_email",
+        reason: "Send the quarterly report to Dana",
+        payload: {
+          action: "send_email",
+          to: ["dana@example.com"],
+          cc: [],
+          bcc: [],
+          subject: "Q2 report",
+          body: "Attached.",
+          replyToMessageId: null,
+        },
+      }),
+      approvedRequest({
+        ...base,
+        action: "send_message",
+        reason: "Text JJ that the demo moved to 3pm",
+        payload: {
+          action: "send_message",
+          recipient: "+15550100",
+          body: "Demo moved to 3pm",
+          replyToMessageId: null,
+        },
+      }),
+    ];
+  }
+
+  it("asks 'Which request?' with one chip per pending row, values carrying `<intent> <requestId>`", async () => {
+    const runtime = makeRuntime();
+    const [first, second] = pendingPair();
+    docMocks.list.mockResolvedValue([first, second]);
+    const { texts, callback } = collectTexts();
+
+    // No requestId and no useModel on the runtime: extraction cannot pick a
+    // row, which is exactly the ambiguous branch under test.
+    const result = await resolveRequestAction.handler(
+      runtime,
+      {
+        id: randomUUID() as UUID,
+        entityId: "owner-1" as UUID,
+        roomId: randomUUID() as UUID,
+        content: { text: "approve it" },
+      } as Memory,
+      undefined,
+      {
+        parameters: { action: "approve" },
+      } as unknown as HandlerOptions,
+      callback,
+    );
+
+    expect(result).toMatchObject({ success: false });
+    expect(texts).toHaveLength(1);
+    const reply = texts[0] ?? "";
+    expect(reply).toContain("Which request?");
+    const { blocks } = parseInteractionBlocks(reply);
+    expect(blocks).toHaveLength(1);
+    const block = blocks[0];
+    if (block?.kind !== "choice") throw new Error("expected choice block");
+    expect(block.scope).toBe("approval-resolve");
+    expect(block.options.map((o) => o.value)).toEqual([
+      `approve ${first.id}`,
+      `approve ${second.id}`,
+    ]);
+    // Labels are the human-authored reasons, so the chips read as decisions.
+    expect(block.options[0]?.label).toContain("quarterly report");
+    expect(block.options[1]?.label).toContain("demo moved to 3pm");
+  });
+
+  it("a tapped chip value round-trips: `reject <id>` resolves exactly that row", async () => {
+    const runtime = makeRuntime();
+    const [first, second] = pendingPair();
+    docMocks.list.mockResolvedValue([first, second]);
+    docMocks.reject.mockResolvedValue({ ...second, state: "rejected" });
+
+    // Build the chips for a reject intent and simulate the tap: the value is
+    // the user's next message and the extraction reads the id verbatim.
+    const chips = buildResolveRequestChoice("reject", [first, second]);
+    const tapped = chips.options[1]?.value ?? "";
+    expect(tapped).toBe(`reject ${second.id}`);
+    const { texts, callback } = collectTexts();
+
+    const result = await resolveRequestAction.handler(
+      runtime,
+      {
+        id: randomUUID() as UUID,
+        entityId: "owner-1" as UUID,
+        roomId: randomUUID() as UUID,
+        content: { text: tapped },
+      } as Memory,
+      undefined,
+      {
+        parameters: { action: "reject", requestId: second.id },
+      } as unknown as HandlerOptions,
+      callback,
+    );
+
+    expect(result).toMatchObject({ success: true });
+    expect(docMocks.reject).toHaveBeenCalledTimes(1);
+    expect(docMocks.reject.mock.calls[0]?.[0]).toBe(second.id);
     expect(texts.join(" ")).toContain("Rejected");
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,6 +35,18 @@ export default defineConfig({
   resolve: {
     alias: [
       {
+        // plugin-app-control's build (tsup, index + worker entries only)
+        // never emits dist/actions/*.js; the agent's settings-actions.ts
+        // subpath import resolves only under the `eliza-source` exports
+        // condition, which vite's resolver ignores. Pin it to source so any
+        // test whose graph loads @elizaos/agent (aliased to src below) boots.
+        find: /^@elizaos\/plugin-app-control\/actions\/settings$/,
+        replacement: path.join(
+          root,
+          "plugins/plugin-app-control/src/actions/settings.ts",
+        ),
+      },
+      {
         find: /^@elizaos\/app-core$/,
         replacement: path.join(root, "packages/app-core/src/index.ts"),
       },


### PR DESCRIPTION
Fixes #14737. Completes the remaining code-emit `[CHOICE]` sites from #14733 (closed by #14861, which landed the inbox draft/triage, approval-enqueue, and check-in ack markers — this PR finishes the sites it left out and adds the handler-level and real-runtime coverage it shipped without).

## What changed

### #14737 — kind-aware needs-attention activation (`packages/ui/src/components/chat/widgets/needs-attention.tsx`)

`GET /api/approvals` merges three producers (legacy approvals, task approvals, pending planner prompts), but the widget unconditionally prefilled `Approve: <title>` — semantically wrong for a pending question ("Approve: Which time works for the dentist?"). Tap behavior now derives purely from the item's structural fields (no business logic in the component):

| Pending item shape | Tap behavior |
|---|---|
| has `options` (approval / task_approval / choice) | expands a chip row (sibling of the card — the card is itself a `<button>`); tapping a chip prefills the composer with that option's reply (`Approve: <title>` / `Reject: <title>` for the fixed approval option ids, the option label for everything else); expansion is keyed to the item id so it self-collapses when the top item changes |
| approval-shaped, no options | classic `Approve: <title>` prefill (unchanged round-trip via RESOLVE_REQUEST) |
| free-reply prompt (`pending_prompt`, `clarifying_question`, …) | opens/focuses the composer with **no** prefill — the title is the question |

`deriveActivation` / `deriveOptionReply` are exported pure functions pinned by the test matrix.

### Remaining #14733 sites (code-emitted via `appendInteractionBlock` from `@elizaos/core`)

- **Goal check-ins** (`plugins/plugin-goals/src/actions/goals.ts`): an invalid `progress` token now re-asks with one-tap chips instead of demanding a typed token, and a note-only check-in appends the same chips ("How is it tracking?"). Chip values are exactly `on_track | at_risk | needs_attention` — the `checkin` subaction's own `progress` vocabulary, so a tap records structured progress with zero free-text classification.
- **RESOLVE_REQUEST disambiguation** (`plugins/plugin-personal-assistant/src/actions/resolve-request.ts`): "Which request? Please reference it by id or describe it." becomes "Which request?" plus one chip per pending row (≤5), value `<intent> <requestId>` — the id round-trips verbatim into the extraction this action already runs, label = the human-authored reason.

### Guide decision (#14733 second half)

Overtaken by #14861, which **added [CHOICE] to the `uiWidgets` guide** (compressing other sections to stay inside the 60-line/1200-token ratchet) *and* code-emits the markers. This PR keeps that landed decision and only corrects `WIDGET_MATRIX.md`'s Choice row to record it (model-taught **and** code-emitted, with the producing actions enumerated).

### Test-infra repair (pre-existing develop breakage)

`packages/agent/src/actions/settings-actions.ts` (new on develop) imports `@elizaos/plugin-app-control/actions/settings`, but plugin-app-control's build (tsup, index + worker entries only) never emits `dist/actions/*.js` — the subpath resolves only under the `eliza-source` exports condition, which vite's resolver ignores. Every root-config plugin test and the whole PA integration lane failed to load (`integration-lane.smoke.integration.test.ts` included, on clean develop). Fixed with pinned source aliases in `vitest.config.ts` and `packages/test/vitest/integration.config.ts`, mirroring the existing plugin-discord `user-account-scraper` precedent in the same file.

### Tests added (all deterministic, no live keys)

- `plugins/plugin-inbox/test/inbox-action.test.ts` (+4): drives the REAL `INBOX` handler (repository + a real registered triage adapter + callback) — draft-confirm chips reach the chat reply with values the approve turn accepts; a confirmed approve dispatches the stored draft through the adapter and emits no chips; triage appends per-thread chips capped at five with entry ids in the values; an `inbox archive <id>` chip value round-trips into a successful archive of that entry. (#14861's own tests pin only the marker builders.)
- `plugins/plugin-goals/src/actions/goals.harness.test.ts` (+2, real PGlite + mock-LLM harness): invalid progress → chips whose values equal `GOAL_CHECKIN_PROGRESS_STATES`; full three-turn round-trip — create goal → note-only check-in (chips appended) → tap `at_risk` → goal `reviewState` flips to `at_risk` and the progress-carrying reply has no chips.
- `plugins/plugin-personal-assistant/test/resolve-request-executor.test.ts` (+2): ambiguous approve renders one chip per pending row with `<intent> <id>` values and reason labels; a tapped `reject <id>` value resolves exactly that row.
- `plugins/plugin-personal-assistant/test/approval-queue.integration.test.ts` (+1, real PGlite runtime + real `AgentEventService`): enqueue emits one `lifeops-approval` assistant event whose text parses to the approve/reject block, and the tapped value's id drives a successful `approve` of that row.
- `plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.checkin-chips.test.ts` (new, +2): the sleep-cycle dispatch wiring — morning summary reaches `emitAssistantEvent` with the ack-chip block appended; an already-sent day emits nothing.
- `packages/ui/src/components/chat/widgets/needs-attention.test.tsx` (+6): the kind matrix above — chips expand instead of blind prefill, Approve/Reject chips prefill the right verb, choice options prefill their label, free-reply prompts open chat with no prefill, option-less approvals keep the legacy prefill, second tap collapses.

## Test evidence

All run locally on this branch (rebased on `origin/develop` @ 63e5a4ca41):

| Suite | Result |
|---|---|
| `plugins/plugin-inbox/test/inbox-action.test.ts` | 27 passed |
| `plugins/plugin-inbox/test/inbox-choice-markers.test.ts` (landed, untouched) | passed |
| `plugins/plugin-goals/src/actions/goals.harness.test.ts` | 5 passed |
| `plugins/plugin-personal-assistant/test/resolve-request-executor.test.ts` | 13 passed |
| `plugins/plugin-personal-assistant/test/lifeops-choice-markers.test.ts` (landed, untouched) | 2 passed |
| `plugins/plugin-personal-assistant/test/approval-queue.integration.test.ts` | 6 passed |
| `reminders-service.checkin-chips.test.ts` (PA vitest config) | 2 passed |
| `packages/ui` needs-attention + render-parity.contract + inline-registry(.matrix) + interaction-widgets.behavior | 54 passed |
| `packages/agent/src/providers/ui-widgets.budget.test.ts` | passed (60 lines / ~956 tokens, inside the ratchet) |
| PA integration lane smoke (`integration-lane.smoke.integration.test.ts`) | 2 passed — **fails to load on develop without this PR's alias fix** |

Biome clean on every touched file; `bun run audit:error-policy-ratchet` green (no new catches or console calls).

- Video walkthrough: N/A — home-widget interaction change proven by the jsdom event-level matrix above (chip expansion, prefill payloads, chat-open dispatch are all asserted on the real component); no staged UI environment available in this lane.
- Before/after screenshots: N/A — same reason; the widget renders identically at rest (icon card), only tap routing changed.
- Real-LLM trajectories: N/A — no prompt/model-behavior change; markers are code-emitted (the tapped value re-enters the existing planner path unchanged, pinned by the deterministic mock-LLM round-trip in the goals harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)