### PR TITLE
fix(lifeops): bridge core fact memories

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/owner/core-fact-memory-bridge.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/core-fact-memory-bridge.test.ts
@@ -11,6 +11,8 @@ import {
 } from "./core-fact-memory-bridge.js";
 import {
   createOwnerFactStore,
+  type OwnerFactStore,
+  type OwnerFactsPatch,
   registerOwnerFactStore,
   resolveOwnerFactStore,
 } from "./fact-store.js";
@@ -179,6 +181,24 @@ class FakeRelationshipStore {
   }
 }
 
+/**
+ * Fake OwnerFactStore that records the patches the bridge writes, so the
+ * value-extraction leg can be asserted directly without dragging in the
+ * cache-backed store's scheduler-profile mirror (owner-profile.ts).
+ */
+function captureFactStore(): {
+  store: OwnerFactStore;
+  patches: OwnerFactsPatch[];
+} {
+  const patches: OwnerFactsPatch[] = [];
+  const store = {
+    async update(patch: OwnerFactsPatch) {
+      patches.push(patch);
+    },
+  } as unknown as OwnerFactStore;
+  return { store, patches };
+}
+
 function installFakeGraph(
   entityStore = new FakeEntityStore(),
   relationshipStore = new FakeRelationshipStore(),
@@ -219,6 +239,58 @@ describe("bridgeCoreFactMemory", () => {
       source: "agent_inferred",
       note: "core fact-memory bridge from fact:44444444-4444-4444-4444-444444444444",
     });
+  });
+
+  it("projects a preferred name from a language-agnostic structured field", async () => {
+    // The core extractor's `structured_fields` carry the value regardless of
+    // the claim's language ("je m'appelle" here), so a non-English identity
+    // fact still projects a preferredName the English claim regex never sees.
+    const { store, patches } = captureFactStore();
+    const result = await bridgeCoreFactMemory(
+      makeRuntime(),
+      factMemory({
+        id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" as UUID,
+        text: "je m'appelle Alex",
+        category: "identity",
+        structuredFields: { name: "Alex" },
+      }),
+      { factStore: store },
+    );
+
+    expect(result.ownerFactKeys).toEqual(["preferredName"]);
+    expect(patches).toEqual([{ preferredName: "Alex" }]);
+  });
+
+  it("recovers a preferred name from the English claim when structured fields are absent", async () => {
+    const { store, patches } = captureFactStore();
+    const result = await bridgeCoreFactMemory(
+      makeRuntime(),
+      factMemory({
+        id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" as UUID,
+        text: "my name is Robin",
+        category: "identity",
+      }),
+      { factStore: store },
+    );
+
+    expect(result.ownerFactKeys).toContain("preferredName");
+    expect(patches).toEqual([{ preferredName: "Robin" }]);
+  });
+
+  it("lets the structured field win over the English claim regex", async () => {
+    const { store, patches } = captureFactStore();
+    await bridgeCoreFactMemory(
+      makeRuntime(),
+      factMemory({
+        id: "cccccccc-cccc-cccc-cccc-cccccccccccc" as UUID,
+        text: "call me Bob",
+        category: "identity",
+        structuredFields: { preferredName: "Robert" },
+      }),
+      { factStore: store },
+    );
+
+    expect(patches).toEqual([{ preferredName: "Robert" }]);
   });
 
   it("projects relationship facts and handle claims into the entity graph", async () => {

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/core-fact-memory-bridge.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/core-fact-memory-bridge.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Unit coverage for the core fact-memory bridge: synthetic facts-table rows
+ * from the core `factMemory` evaluator are projected into the real
+ * OwnerFactStore cache and fake graph stores without another LLM call.
+ */
+import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  bridgeCoreFactMemory,
+  registerCoreFactMemoryBridge,
+} from "./core-fact-memory-bridge.js";
+import {
+  createOwnerFactStore,
+  registerOwnerFactStore,
+  resolveOwnerFactStore,
+} from "./fact-store.js";
+
+const agentMocks = vi.hoisted(() => ({
+  hasOwnerAccess: vi.fn(),
+  resolveKnowledgeGraphService: vi.fn(),
+}));
+
+vi.mock("@elizaos/agent", () => ({
+  hasOwnerAccess: agentMocks.hasOwnerAccess,
+  resolveKnowledgeGraphService: agentMocks.resolveKnowledgeGraphService,
+}));
+
+const agentId = "11111111-1111-1111-1111-111111111111" as UUID;
+const ownerEntityId = "22222222-2222-2222-2222-222222222222" as UUID;
+const roomId = "33333333-3333-3333-3333-333333333333" as UUID;
+
+function makeRuntime(): IAgentRuntime & {
+  hooks: Array<{
+    id: string;
+    handler: (runtime: IAgentRuntime, ctx: unknown) => Promise<void>;
+  }>;
+  cache: Map<string, unknown>;
+} {
+  const cache = new Map<string, unknown>();
+  const hooks: Array<{
+    id: string;
+    handler: (runtime: IAgentRuntime, ctx: unknown) => Promise<void>;
+  }> = [];
+  const runtime = {
+    agentId,
+    character: { name: "Eliza" },
+    logger: {
+      warn: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    },
+    reportError: vi.fn(),
+    async getCache<T>(key: string): Promise<T | null> {
+      const value = cache.get(key);
+      return value === undefined ? null : (value as T);
+    },
+    async setCache<T>(key: string, value: T): Promise<boolean> {
+      cache.set(key, value);
+      return true;
+    },
+    async deleteCache(key: string): Promise<boolean> {
+      return cache.delete(key);
+    },
+    registerPipelineHook: vi.fn(
+      (spec: { id: string; handler: (typeof hooks)[number]["handler"] }) => {
+        hooks.push(spec);
+      },
+    ),
+    hooks,
+    cache,
+  };
+  registerOwnerFactStore(
+    runtime as unknown as IAgentRuntime,
+    createOwnerFactStore(runtime as unknown as IAgentRuntime),
+  );
+  return runtime as unknown as ReturnType<typeof makeRuntime>;
+}
+
+function factMemory(args: {
+  id: UUID;
+  text: string;
+  category: string;
+  structuredFields?: Record<string, unknown>;
+  confidence?: number;
+}): Memory {
+  return {
+    id: args.id,
+    entityId: ownerEntityId,
+    agentId,
+    roomId,
+    content: { text: args.text },
+    metadata: {
+      type: "custom",
+      source: "fact_extractor",
+      kind: "durable",
+      category: args.category,
+      structuredFields: args.structuredFields ?? {},
+      confidence: args.confidence ?? 0.7,
+      lastConfirmedAt: "2026-07-06T12:00:00.000Z",
+    },
+    createdAt: Date.parse("2026-07-06T12:00:00.000Z"),
+  };
+}
+
+class FakeEntityStore {
+  public identities: unknown[] = [];
+  public upserts: unknown[] = [];
+
+  async ensureSelf() {
+    return {
+      entityId: "self",
+      type: "person",
+      preferredName: "Owner",
+      identities: [],
+      tags: [],
+      visibility: "owner_agent_admin",
+      state: {},
+    };
+  }
+
+  async get() {
+    return null;
+  }
+
+  async resolve() {
+    return [];
+  }
+
+  async upsert(entity: { preferredName: string; type: string }) {
+    this.upserts.push(entity);
+    return {
+      entityId: `entity:${entity.preferredName.toLowerCase()}`,
+      type: entity.type,
+      preferredName: entity.preferredName,
+      identities: [],
+      tags: [],
+      visibility: "owner_agent_admin",
+      state: {},
+    };
+  }
+
+  async observeIdentity(identity: unknown) {
+    this.identities.push(identity);
+    const displayName =
+      typeof identity === "object" && identity && "displayName" in identity
+        ? String((identity as { displayName?: unknown }).displayName)
+        : "Unknown";
+    return {
+      entity: {
+        entityId: `entity:${displayName.toLowerCase()}`,
+        type: "person",
+        preferredName: displayName,
+        identities: [],
+        tags: [],
+        visibility: "owner_agent_admin",
+        state: {},
+      },
+    };
+  }
+}
+
+class FakeRelationshipStore {
+  public observations: unknown[] = [];
+
+  async observe(observation: unknown) {
+    this.observations.push(observation);
+    return {
+      relationshipId: `relationship:${this.observations.length}`,
+      fromEntityId: "self",
+      toEntityId: "entity:pat",
+      type: "managed_by",
+      metadata: {},
+      confidence: 0.7,
+      evidence: [],
+      source: "extraction",
+      updatedAt: "2026-07-06T12:00:00.000Z",
+    };
+  }
+}
+
+function installFakeGraph(
+  entityStore = new FakeEntityStore(),
+  relationshipStore = new FakeRelationshipStore(),
+) {
+  agentMocks.resolveKnowledgeGraphService.mockReturnValue({
+    getEntityStore: vi.fn(() => entityStore),
+    getRelationshipStore: vi.fn(() => relationshipStore),
+  });
+  return { entityStore, relationshipStore };
+}
+
+beforeEach(() => {
+  agentMocks.hasOwnerAccess.mockReset();
+  agentMocks.resolveKnowledgeGraphService.mockReset();
+  agentMocks.hasOwnerAccess.mockResolvedValue(true);
+});
+
+describe("bridgeCoreFactMemory", () => {
+  it("projects core identity facts into the OwnerFactStore with agent provenance", async () => {
+    const runtime = makeRuntime();
+    const result = await bridgeCoreFactMemory(
+      runtime,
+      factMemory({
+        id: "44444444-4444-4444-4444-444444444444" as UUID,
+        text: "timezone is Europe/Berlin",
+        category: "identity",
+        structuredFields: { timezone: "Europe/Berlin" },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      skipped: false,
+      ownerFactKeys: ["timezone"],
+    });
+    const facts = await resolveOwnerFactStore(runtime).read();
+    expect(facts.timezone?.value).toBe("Europe/Berlin");
+    expect(facts.timezone?.provenance).toMatchObject({
+      source: "agent_inferred",
+      note: "core fact-memory bridge from fact:44444444-4444-4444-4444-444444444444",
+    });
+  });
+
+  it("projects relationship facts and handle claims into the entity graph", async () => {
+    const runtime = makeRuntime();
+    const { entityStore, relationshipStore } = installFakeGraph();
+
+    const result = await bridgeCoreFactMemory(
+      runtime,
+      factMemory({
+        id: "55555555-5555-5555-5555-555555555555" as UUID,
+        text: "Pat is my manager. Pat's Telegram handle is @pat.",
+        category: "relationship",
+        structuredFields: { name: "Pat", relationshipType: "manager" },
+      }),
+    );
+
+    expect(result).toMatchObject({
+      skipped: false,
+      identityCount: 1,
+      relationshipCount: 1,
+    });
+    expect(entityStore.identities).toEqual([
+      expect.objectContaining({
+        platform: "telegram",
+        handle: "@pat",
+        displayName: "Pat",
+        evidence: ["fact:55555555-5555-5555-5555-555555555555"],
+      }),
+    ]);
+    expect(relationshipStore.observations).toEqual([
+      expect.objectContaining({
+        fromEntityId: "self",
+        toEntityId: "entity:pat",
+        type: "managed_by",
+        evidence: ["fact:55555555-5555-5555-5555-555555555555"],
+      }),
+    ]);
+    const facts = await resolveOwnerFactStore(runtime).read();
+    expect(facts.preferredName).toBeUndefined();
+  });
+
+  it("does not replay a bridged fact into graph stores", async () => {
+    const runtime = makeRuntime();
+    const { relationshipStore } = installFakeGraph();
+    const memory = factMemory({
+      id: "66666666-6666-6666-6666-666666666666" as UUID,
+      text: "Pat is my manager.",
+      category: "relationship",
+    });
+
+    const first = await bridgeCoreFactMemory(runtime, memory);
+    const second = await bridgeCoreFactMemory(runtime, memory);
+
+    expect(first.skipped).toBe(false);
+    expect(second).toMatchObject({
+      skipped: true,
+      reason: "already_bridged",
+    });
+    expect(relationshipStore.observations).toHaveLength(1);
+  });
+
+  it("registers an after-memory hook for facts-table rows", async () => {
+    const runtime = makeRuntime();
+    registerCoreFactMemoryBridge(runtime);
+
+    expect(runtime.registerPipelineHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "lifeops:core-fact-memory-bridge",
+        phase: "after_memory_persisted",
+        mutatesPrimary: false,
+      }),
+    );
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/core-fact-memory-bridge.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/core-fact-memory-bridge.ts
@@ -175,6 +175,24 @@ function normalizeTravelPreference(claim: string): string | null {
   return `Prefer ${cleaned}`;
 }
 
+/**
+ * Sets a claim-derived value only when the structured fields did not already
+ * supply one. The core extractor's `structured_fields` are the language-
+ * agnostic primary — they carry the same value whether the owner wrote "my
+ * name is Alex" or "je m'appelle Alex" — so they must win over the English
+ * claim regexes, which are a fast path for the common phrasings the model
+ * happened to echo verbatim in the claim text.
+ */
+function setFactFromClaim(
+  patch: OwnerFactsPatch,
+  key: OwnerStringFactKey,
+  value: string | null,
+): void {
+  if (!patch[key]) {
+    setFact(patch, key, value);
+  }
+}
+
 function extractOwnerFacts(
   claim: string,
   metadata: FactMetadata,
@@ -184,32 +202,117 @@ function extractOwnerFacts(
   const category = metadata.category;
 
   if (category === "identity") {
-    setFact(patch, "preferredName", firstString(fields, ["preferredName"]));
-    setFact(patch, "orientation", firstString(fields, ["orientation"]));
-    setFact(patch, "gender", firstString(fields, ["gender"]));
+    // Alias lists cover the natural key names the extractor emits — it is not
+    // constrained to a canonical schema, so a name may arrive as `name`,
+    // `preferredName`, `nickname`, etc. Missing all of them is fine; the claim
+    // fallbacks below recover the English case.
+    setFact(
+      patch,
+      "preferredName",
+      firstString(fields, [
+        "preferredName",
+        "preferred_name",
+        "name",
+        "fullName",
+        "full_name",
+        "nickname",
+        "goesBy",
+        "goes_by",
+        "displayName",
+      ]),
+    );
+    setFact(
+      patch,
+      "orientation",
+      firstString(fields, [
+        "orientation",
+        "sexualOrientation",
+        "sexual_orientation",
+      ]),
+    );
+    setFact(
+      patch,
+      "gender",
+      firstString(fields, [
+        "gender",
+        "genderIdentity",
+        "gender_identity",
+        "pronouns",
+      ]),
+    );
     setFact(patch, "age", firstString(fields, ["age"]));
     setFact(
       patch,
       "location",
-      firstString(fields, ["location", "city", "homeCity", "home_location"]),
+      firstString(fields, [
+        "location",
+        "city",
+        "homeCity",
+        "home_city",
+        "home_location",
+        "hometown",
+        "country",
+        "residence",
+      ]),
     );
     setFact(
       patch,
       "timezone",
-      firstString(fields, ["timezone", "timeZone", "ianaTimezone"]),
+      firstString(fields, [
+        "timezone",
+        "timeZone",
+        "time_zone",
+        "ianaTimezone",
+        "iana_timezone",
+      ]),
+    );
+
+    setFactFromClaim(
+      patch,
+      "preferredName",
+      cleanName(
+        /\b(?:my name is|i'?m called|people call me|you can call me|call me)\s+(?!at\b|on\b)([^,.!?]{2,60})/iu.exec(
+          claim,
+        )?.[1],
+      ),
     );
 
     const location =
       /\b(?:live|lives|living|based|located)\s+in\s+([^,.!?]{2,80})/iu.exec(
         claim,
       )?.[1] ?? /\bmoved\s+to\s+([^,.!?]{2,80})/iu.exec(claim)?.[1];
-    setFact(patch, "location", cleanName(location));
+    setFactFromClaim(patch, "location", cleanName(location));
 
     const timezone =
       /\b(?:timezone|time zone)\s+(?:is\s+)?([A-Za-z0-9_/+.-]{2,60})/iu.exec(
         claim,
       )?.[1];
-    setFact(patch, "timezone", timezone ?? null);
+    setFactFromClaim(patch, "timezone", timezone ?? null);
+  }
+
+  if (category === "relationship") {
+    setFact(
+      patch,
+      "relationshipStatus",
+      firstString(fields, [
+        "relationshipStatus",
+        "relationship_status",
+        "status",
+        "maritalStatus",
+        "marital_status",
+      ]),
+    );
+    setFact(
+      patch,
+      "partnerName",
+      firstString(fields, [
+        "partnerName",
+        "partner_name",
+        "partner",
+        "spouse",
+        "spouseName",
+      ]),
+    );
   }
 
   const partner =
@@ -219,20 +322,7 @@ function extractOwnerFacts(
     /\b([^,.!?]{2,60})\s+is\s+(?:my\s+)?(?:partner|spouse|husband|wife)\b/iu.exec(
       claim,
     )?.[1];
-  setFact(patch, "partnerName", cleanName(partner));
-
-  if (category === "relationship") {
-    setFact(
-      patch,
-      "relationshipStatus",
-      firstString(fields, ["relationshipStatus", "status"]),
-    );
-    setFact(
-      patch,
-      "partnerName",
-      firstString(fields, ["partnerName", "partner", "spouse"]),
-    );
-  }
+  setFactFromClaim(patch, "partnerName", cleanName(partner));
 
   if (category === "preference") {
     setFact(patch, "locale", firstString(fields, ["locale", "languageLocale"]));

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/core-fact-memory-bridge.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/core-fact-memory-bridge.ts
@@ -1,0 +1,576 @@
+/**
+ * Bridges core fact-memory rows into LifeOps's typed owner facts and entity
+ * graph. Core owns the LLM extraction and facts table; this module is the
+ * Personal Assistant-side projection that turns those durable rows into the
+ * structural state LifeOps schedulers, policies, and relationship tools read.
+ */
+import { hasOwnerAccess, resolveKnowledgeGraphService } from "@elizaos/agent";
+import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
+import { SELF_ENTITY_ID } from "../entities/types.js";
+import {
+  applyExtractedEdges,
+  type ExtractedEdge,
+} from "../relationships/extraction.js";
+import { asCacheRuntime } from "../runtime-cache.js";
+import {
+  type OwnerFactStore,
+  type OwnerFactsPatch,
+  resolveOwnerFactStore,
+} from "./fact-store.js";
+
+const BRIDGED_FACT_IDS_CACHE_KEY = "eliza:lifeops:core-fact-memory-bridge:v1";
+const MAX_BRIDGED_FACT_IDS = 1_000;
+
+const HANDLE_PLATFORMS =
+  "telegram|slack|discord|twitter|x|email|github|nostr|signal|imessage";
+
+const RELATIONSHIP_TYPES: Record<string, string> = {
+  boss: "managed_by",
+  manager: "managed_by",
+  supervisor: "managed_by",
+  lead: "managed_by",
+  partner: "partner_of",
+  spouse: "partner_of",
+  husband: "partner_of",
+  wife: "partner_of",
+  colleague: "colleague_of",
+  coworker: "colleague_of",
+  teammate: "colleague_of",
+  friend: "knows",
+  doctor: "care_provider",
+  therapist: "care_provider",
+  coach: "care_provider",
+};
+
+type FactMetadata = {
+  source?: string;
+  kind?: string;
+  category?: string;
+  structuredFields?: Record<string, unknown>;
+  confidence?: number;
+  lastConfirmedAt?: string;
+};
+
+type IdentityHint = {
+  name: string;
+  platform: string;
+  handle: string;
+};
+
+type OwnerStringFactKey =
+  | "preferredName"
+  | "relationshipStatus"
+  | "partnerName"
+  | "orientation"
+  | "gender"
+  | "age"
+  | "location"
+  | "travelBookingPreferences"
+  | "preferredNotificationChannel"
+  | "locale"
+  | "timezone";
+
+export interface CoreFactMemoryBridgeResult {
+  skipped: boolean;
+  reason?: string;
+  ownerFactKeys: string[];
+  identityCount: number;
+  relationshipCount: number;
+}
+
+interface BridgeDeps {
+  ownerAccess?: typeof hasOwnerAccess;
+  factStore?: OwnerFactStore;
+  now?: () => Date;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function cleanName(raw: string | undefined): string | null {
+  const value = raw?.replace(/["'`]/g, "").replace(/\s+/g, " ").trim();
+  if (!value || value.length < 2 || value.length > 80) return null;
+  if (/^(?:me|my|mine|you|them|someone|somebody|at|on)$/iu.test(value)) {
+    return null;
+  }
+  return value;
+}
+
+function cleanHandle(raw: string | undefined): string | null {
+  const value = raw?.trim().replace(/[),.;!?]+$/u, "");
+  if (!value || value.length < 2 || value.length > 120) return null;
+  return value;
+}
+
+function normalizePlatform(raw: string): string {
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "twitter") return "x";
+  return normalized;
+}
+
+function factMetadata(memory: Memory): FactMetadata | null {
+  const metadata = memory.metadata;
+  if (!isRecord(metadata)) return null;
+  const structured = isRecord(metadata.structuredFields)
+    ? metadata.structuredFields
+    : {};
+  return {
+    source: readString(metadata.source) ?? undefined,
+    kind: readString(metadata.kind) ?? undefined,
+    category: readString(metadata.category) ?? undefined,
+    structuredFields: structured,
+    confidence:
+      typeof metadata.confidence === "number" ? metadata.confidence : undefined,
+    lastConfirmedAt: readString(metadata.lastConfirmedAt) ?? undefined,
+  };
+}
+
+function firstString(
+  fields: Record<string, unknown>,
+  keys: readonly string[],
+): string | null {
+  for (const key of keys) {
+    const value = readString(fields[key]);
+    if (value) return value;
+  }
+  return null;
+}
+
+function setFact(
+  patch: OwnerFactsPatch,
+  key: OwnerStringFactKey,
+  value: string | null,
+): void {
+  if (value) {
+    patch[key] = value;
+  }
+}
+
+function sentenceCase(value: string): string {
+  return value.replace(/^(.)/u, (first) => first.toUpperCase());
+}
+
+function normalizeTravelPreference(claim: string): string | null {
+  if (
+    !/\b(?:travel|booking|bookings|trip|trips|flight|flights|hotel|hotels|seat|seats|luggage|bag|bags|carry-?on)\b/iu.test(
+      claim,
+    )
+  ) {
+    return null;
+  }
+  const cleaned = claim
+    .replace(/\s+/g, " ")
+    .replace(/[.!?]+$/u, "")
+    .trim();
+  if (cleaned.length < 8) return null;
+  if (/^prefer\b/iu.test(cleaned)) return sentenceCase(cleaned);
+  if (/^prefers\b/iu.test(cleaned)) return sentenceCase(cleaned);
+  return `Prefer ${cleaned}`;
+}
+
+function extractOwnerFacts(
+  claim: string,
+  metadata: FactMetadata,
+): OwnerFactsPatch {
+  const fields = metadata.structuredFields ?? {};
+  const patch: OwnerFactsPatch = {};
+  const category = metadata.category;
+
+  if (category === "identity") {
+    setFact(patch, "preferredName", firstString(fields, ["preferredName"]));
+    setFact(patch, "orientation", firstString(fields, ["orientation"]));
+    setFact(patch, "gender", firstString(fields, ["gender"]));
+    setFact(patch, "age", firstString(fields, ["age"]));
+    setFact(
+      patch,
+      "location",
+      firstString(fields, ["location", "city", "homeCity", "home_location"]),
+    );
+    setFact(
+      patch,
+      "timezone",
+      firstString(fields, ["timezone", "timeZone", "ianaTimezone"]),
+    );
+
+    const location =
+      /\b(?:live|lives|living|based|located)\s+in\s+([^,.!?]{2,80})/iu.exec(
+        claim,
+      )?.[1] ?? /\bmoved\s+to\s+([^,.!?]{2,80})/iu.exec(claim)?.[1];
+    setFact(patch, "location", cleanName(location));
+
+    const timezone =
+      /\b(?:timezone|time zone)\s+(?:is\s+)?([A-Za-z0-9_/+.-]{2,60})/iu.exec(
+        claim,
+      )?.[1];
+    setFact(patch, "timezone", timezone ?? null);
+  }
+
+  const partner =
+    /\b(?:partner|spouse|husband|wife)\s+(?:is|named)\s+([^,.!?]{2,60})/iu.exec(
+      claim,
+    )?.[1] ??
+    /\b([^,.!?]{2,60})\s+is\s+(?:my\s+)?(?:partner|spouse|husband|wife)\b/iu.exec(
+      claim,
+    )?.[1];
+  setFact(patch, "partnerName", cleanName(partner));
+
+  if (category === "relationship") {
+    setFact(
+      patch,
+      "relationshipStatus",
+      firstString(fields, ["relationshipStatus", "status"]),
+    );
+    setFact(
+      patch,
+      "partnerName",
+      firstString(fields, ["partnerName", "partner", "spouse"]),
+    );
+  }
+
+  if (category === "preference") {
+    setFact(patch, "locale", firstString(fields, ["locale", "languageLocale"]));
+    setFact(
+      patch,
+      "preferredNotificationChannel",
+      firstString(fields, ["preferredNotificationChannel", "channel"]),
+    );
+    setFact(
+      patch,
+      "travelBookingPreferences",
+      firstString(fields, [
+        "travelBookingPreferences",
+        "travelPreference",
+        "bookingPreference",
+      ]),
+    );
+  }
+
+  if (category === "preference" && !patch.travelBookingPreferences) {
+    setFact(
+      patch,
+      "travelBookingPreferences",
+      normalizeTravelPreference(claim),
+    );
+  }
+
+  return patch;
+}
+
+function relationTypeForRole(role: string | null): string | null {
+  if (!role) return null;
+  return RELATIONSHIP_TYPES[role.toLowerCase()] ?? role.toLowerCase();
+}
+
+function edgeForSelfToPerson(
+  name: string | null,
+  type: string | null,
+  confidence: number,
+  metadata?: Record<string, unknown>,
+): ExtractedEdge | null {
+  if (!name || !type) return null;
+  return {
+    fromRef: { id: SELF_ENTITY_ID },
+    toRef: { name, type: "person" },
+    type,
+    ...(metadata ? { metadata } : {}),
+    confidence,
+  };
+}
+
+function extractRelationshipEdges(
+  claim: string,
+  metadata: FactMetadata,
+): ExtractedEdge[] {
+  const confidence = metadata.confidence ?? 0.7;
+  const fields = metadata.structuredFields ?? {};
+  const edges: ExtractedEdge[] = [];
+
+  const structuredName = firstString(fields, [
+    "person",
+    "name",
+    "target",
+    "relatedPerson",
+    "partner",
+    "manager",
+    "boss",
+  ]);
+  const structuredRole = firstString(fields, [
+    "relationshipType",
+    "relationship",
+    "role",
+    "type",
+  ]);
+  const structuredType = relationTypeForRole(structuredRole);
+  const structuredEdge = edgeForSelfToPerson(
+    structuredName,
+    structuredType,
+    confidence,
+    structuredRole ? { extractedRole: structuredRole } : undefined,
+  );
+  if (structuredEdge) edges.push(structuredEdge);
+
+  const relationPatterns = [
+    /\b([A-Z][A-Za-z0-9 .'-]{1,60})\s+is\s+(?:my\s+)?(boss|manager|supervisor|lead|partner|spouse|husband|wife|colleague|coworker|teammate|friend|doctor|therapist|coach)\b/gu,
+    /\b(?:my\s+)(boss|manager|supervisor|lead|partner|spouse|husband|wife|colleague|coworker|teammate|friend|doctor|therapist|coach)\s+is\s+([A-Z][A-Za-z0-9 .'-]{1,60})\b/gu,
+  ];
+  for (const pattern of relationPatterns) {
+    for (const match of claim.matchAll(pattern)) {
+      const first = match[1] ?? "";
+      const second = match[2] ?? "";
+      const roleFirst = Boolean(RELATIONSHIP_TYPES[first.toLowerCase()]);
+      const name = cleanName(roleFirst ? second : first);
+      const type = relationTypeForRole(roleFirst ? first : second);
+      const edge = edgeForSelfToPerson(name, type, confidence, {
+        extractedRole: roleFirst ? first : second,
+      });
+      if (edge) edges.push(edge);
+    }
+  }
+
+  const reportsTo =
+    /\b(?:i\s+)?(?:report|reports)\s+to\s+([A-Z][A-Za-z0-9 .'-]{1,60})\b/iu.exec(
+      claim,
+    )?.[1];
+  const reportsToEdge = edgeForSelfToPerson(
+    cleanName(reportsTo),
+    "managed_by",
+    confidence,
+    { extractedRole: "manager" },
+  );
+  if (reportsToEdge) edges.push(reportsToEdge);
+
+  const organization =
+    firstString(fields, ["company", "organization", "employer"]) ??
+    /\b(?:work|works)\s+(?:at|for)\s+([A-Z][A-Za-z0-9 .&'-]{1,80})\b/iu.exec(
+      claim,
+    )?.[1] ??
+    /\b(?:employer|company)\s+is\s+([A-Z][A-Za-z0-9 .&'-]{1,80})\b/iu.exec(
+      claim,
+    )?.[1];
+  const orgName = cleanName(organization);
+  if (orgName) {
+    edges.push({
+      fromRef: { id: SELF_ENTITY_ID },
+      toRef: { name: orgName, type: "organization" },
+      type: "works_at",
+      confidence,
+    });
+  }
+
+  return dedupeEdges(edges);
+}
+
+function extractIdentityHints(claim: string): IdentityHint[] {
+  const hints: IdentityHint[] = [];
+  const namePlatformHandle = new RegExp(
+    `\\b([A-Z][A-Za-z0-9 '-]{1,60})'s\\s+(${HANDLE_PLATFORMS})\\s+(?:handle|username|account|profile)\\s+is\\s+(@?[A-Za-z0-9_.+\\-@]+)\\b`,
+    "giu",
+  );
+  for (const match of claim.matchAll(namePlatformHandle)) {
+    const name = cleanName(match[1]);
+    const platform = readString(match[2]);
+    const handle = cleanHandle(match[3]);
+    if (name && platform && handle) {
+      hints.push({ name, platform: normalizePlatform(platform), handle });
+    }
+  }
+
+  const platformNameHandle = new RegExp(
+    `\\b(?:the\\s+)?(${HANDLE_PLATFORMS})\\s+(?:handle|username|account|profile)\\s+for\\s+([A-Z][A-Za-z0-9 '-]{1,60})\\s+is\\s+(@?[A-Za-z0-9_.+\\-@]+)\\b`,
+    "giu",
+  );
+  for (const match of claim.matchAll(platformNameHandle)) {
+    const platform = readString(match[1]);
+    const name = cleanName(match[2]);
+    const handle = cleanHandle(match[3]);
+    if (name && platform && handle) {
+      hints.push({ name, platform: normalizePlatform(platform), handle });
+    }
+  }
+
+  const nameHandlePlatform = new RegExp(
+    `\\b([A-Z][A-Za-z0-9 '-]{1,60})\\s+(?:goes by|is)\\s+(@[A-Za-z0-9_.+-]+)\\s+on\\s+(${HANDLE_PLATFORMS})\\b`,
+    "giu",
+  );
+  for (const match of claim.matchAll(nameHandlePlatform)) {
+    const name = cleanName(match[1]);
+    const handle = cleanHandle(match[2]);
+    const platform = readString(match[3]);
+    if (name && platform && handle) {
+      hints.push({ name, platform: normalizePlatform(platform), handle });
+    }
+  }
+  return hints;
+}
+
+function edgeKey(edge: ExtractedEdge): string {
+  return [
+    edge.fromRef.id ?? edge.fromRef.name ?? "",
+    edge.toRef.id ?? edge.toRef.name ?? "",
+    edge.type,
+  ]
+    .map((value) => value.toLowerCase())
+    .join("|");
+}
+
+function dedupeEdges(edges: ExtractedEdge[]): ExtractedEdge[] {
+  const seen = new Set<string>();
+  const result: ExtractedEdge[] = [];
+  for (const edge of edges) {
+    const key = edgeKey(edge);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(edge);
+  }
+  return result;
+}
+
+async function readBridgedFactIds(
+  runtime: IAgentRuntime,
+): Promise<Set<string>> {
+  const cache = asCacheRuntime(runtime);
+  const stored = await cache.getCache<unknown>(BRIDGED_FACT_IDS_CACHE_KEY);
+  if (!Array.isArray(stored)) return new Set();
+  return new Set(
+    stored
+      .map((value) => (typeof value === "string" ? value : null))
+      .filter((value): value is string => Boolean(value)),
+  );
+}
+
+async function markFactBridged(
+  runtime: IAgentRuntime,
+  factId: string,
+): Promise<void> {
+  const bridged = await readBridgedFactIds(runtime);
+  bridged.delete(factId);
+  const next = [factId, ...Array.from(bridged)].slice(0, MAX_BRIDGED_FACT_IDS);
+  await asCacheRuntime(runtime).setCache(BRIDGED_FACT_IDS_CACHE_KEY, next);
+}
+
+function skipped(reason: string): CoreFactMemoryBridgeResult {
+  return {
+    skipped: true,
+    reason,
+    ownerFactKeys: [],
+    identityCount: 0,
+    relationshipCount: 0,
+  };
+}
+
+function factIdFor(memory: Memory, memoryId?: UUID): string | null {
+  return readString(memoryId) ?? readString(memory.id);
+}
+
+export async function bridgeCoreFactMemory(
+  runtime: IAgentRuntime,
+  memory: Memory,
+  deps: BridgeDeps & { memoryId?: UUID } = {},
+): Promise<CoreFactMemoryBridgeResult> {
+  const metadata = factMetadata(memory);
+  if (metadata?.source !== "fact_extractor") return skipped("not_core_fact");
+  if (metadata.kind !== "durable") return skipped("not_durable");
+  const factId = factIdFor(memory, deps.memoryId);
+  if (!factId) return skipped("missing_fact_id");
+  if ((await readBridgedFactIds(runtime)).has(factId)) {
+    return skipped("already_bridged");
+  }
+
+  const ownerAccess = deps.ownerAccess ?? hasOwnerAccess;
+  if (!(await ownerAccess(runtime, memory))) {
+    await markFactBridged(runtime, factId);
+    return skipped("not_owner_fact");
+  }
+
+  const claim = readString(memory.content.text) ?? "";
+  const patch = extractOwnerFacts(claim, metadata);
+  const ownerFactKeys = Object.keys(patch);
+  if (ownerFactKeys.length > 0) {
+    await (deps.factStore ?? resolveOwnerFactStore(runtime)).update(patch, {
+      source: "agent_inferred",
+      recordedAt:
+        metadata.lastConfirmedAt ??
+        (deps.now ? deps.now() : new Date()).toISOString(),
+      note: `core fact-memory bridge from fact:${factId}`,
+    });
+  }
+
+  let identityCount = 0;
+  let relationshipCount = 0;
+  const identityHints = extractIdentityHints(claim);
+  const edges = extractRelationshipEdges(claim, metadata);
+  if (identityHints.length > 0 || edges.length > 0) {
+    const knowledgeGraph = resolveKnowledgeGraphService(runtime);
+    if (!knowledgeGraph) {
+      throw new Error(
+        "[core-fact-memory-bridge] KnowledgeGraphService is not registered on the runtime",
+      );
+    }
+    const entityStore = knowledgeGraph.getEntityStore(runtime.agentId);
+    const relationshipStore = knowledgeGraph.getRelationshipStore(
+      runtime.agentId,
+    );
+    for (const identity of identityHints) {
+      await entityStore.observeIdentity({
+        platform: identity.platform,
+        handle: identity.handle,
+        displayName: identity.name,
+        evidence: [`fact:${factId}`],
+        confidence: metadata.confidence ?? 0.7,
+        suggestedType: "person",
+      });
+      identityCount += 1;
+    }
+    if (edges.length > 0) {
+      const result = await applyExtractedEdges({
+        entityStore,
+        relationshipStore,
+        evidenceId: `fact:${factId}`,
+        edges,
+        source: "extraction",
+      });
+      relationshipCount = result.relationships.length;
+    }
+  }
+
+  await markFactBridged(runtime, factId);
+  return {
+    skipped: false,
+    ownerFactKeys,
+    identityCount,
+    relationshipCount,
+  };
+}
+
+export function registerCoreFactMemoryBridge(runtime: IAgentRuntime): void {
+  runtime.registerPipelineHook({
+    id: "lifeops:core-fact-memory-bridge",
+    phase: "after_memory_persisted",
+    schedule: "serial",
+    mutatesPrimary: false,
+    async handler(hookRuntime, ctx) {
+      if (ctx.phase !== "after_memory_persisted" || ctx.tableName !== "facts") {
+        return;
+      }
+      try {
+        await bridgeCoreFactMemory(hookRuntime, ctx.memory, {
+          memoryId: ctx.memoryId,
+        });
+      } catch (error) {
+        // error-policy:J7 diagnostics-must-not-kill-the-loop — fact projection
+        // failures must surface without aborting the original memory write.
+        hookRuntime.reportError("CoreFactMemoryBridge", error, {
+          memoryId: ctx.memoryId,
+          tableName: ctx.tableName,
+        });
+      }
+    },
+  });
+}

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -126,6 +126,7 @@ import {
   createOwnerSendPolicy,
   registerOwnerSendApprovalWorker,
 } from "./lifeops/messaging/owner-send-policy.js";
+import { registerCoreFactMemoryBridge } from "./lifeops/owner/core-fact-memory-bridge.js";
 import {
   createOwnerFactStore,
   registerOwnerFactStore,
@@ -907,6 +908,7 @@ const rawPersonalAssistantPlugin: Plugin = {
 
     const ownerFactStore = createOwnerFactStore(runtime);
     registerOwnerFactStore(runtime, ownerFactStore);
+    registerCoreFactMemoryBridge(runtime);
 
     const promptRegistry = createMultilingualPromptRegistry();
     registerDefaultPromptPack(promptRegistry);


### PR DESCRIPTION
## Summary

Fixes #14688 by adding a Personal Assistant-side projection from core `factMemory` rows (`metadata.source = "fact_extractor"`) into the canonical LifeOps structures:

- registers an `after_memory_persisted` pipeline hook after the OwnerFactStore is installed;
- bridges durable owner identity/preference facts into `OwnerFactStore` with `agent_inferred` provenance;
- bridges relationship and handle claims into `EntityStore` / `RelationshipStore` via the existing `applyExtractedEdges` path;
- records processed fact ids in runtime cache so the same fact evidence is not replayed into graph strengthening.

## Verification

<!-- evidence-row:before-screenshots -->
N/A - backend/runtime projection only; no UI surface or visual state changed.

<!-- evidence-row:after-screenshots -->
N/A - backend/runtime projection only; no UI surface or visual state changed.

<!-- evidence-row:walkthrough-video -->
N/A - backend/runtime projection only; no user-facing walkthrough surface changed.

<!-- evidence-row:backend-logs -->
N/A - no server process was run for this backend projection patch; verification is deterministic unit output: `bun run --cwd plugins/plugin-personal-assistant test -- src/lifeops/owner/core-fact-memory-bridge.test.ts` passed: 1 file / 4 tests. The test exercises OwnerFactStore projection, entity graph projection, handle projection, and replay dedupe.

<!-- evidence-row:frontend-logs -->
N/A - no frontend code path, browser surface, console output, or network behavior changed.

<!-- evidence-row:llm-trajectory -->
N/A - no prompt/model behavior changed; tests feed synthetic persisted `fact_extractor` memories into the deterministic bridge that consumes already-created core LLM facts.

<!-- evidence-row:domain-artifacts -->
N/A - no persisted domain artifact file is produced by this projection code. Static/domain verification: `bunx @biomejs/biome check plugins/plugin-personal-assistant/src/plugin.ts plugins/plugin-personal-assistant/src/lifeops/owner/core-fact-memory-bridge.ts plugins/plugin-personal-assistant/src/lifeops/owner/core-fact-memory-bridge.test.ts` passed. `git diff --check origin/develop..HEAD` passed. `bun run audit:error-policy-ratchet --report` passed with no new fallback-slop in 2 changed production files. `bun run --cwd plugins/plugin-personal-assistant typecheck` still fails on the known package baseline (missing sibling plugin declarations and scheduled-task export mismatches); filtered output shows no diagnostics for `core-fact-memory-bridge.ts` or the bridge import/registration lines.

---

## Completion (value-extraction leg)

Follow-up commit `fix(lifeops): project real owner-fact values from core fact structured fields` finishes the value-extraction leg flagged in review. The seam (`after_memory_persisted` hook → OwnerFactStore/EntityStore/RelationshipStore, idempotent bridged-fact cache, no second store) was already correct; the projection was not: each owner-fact read looked up a single literal `structured_fields` key (e.g. `preferredName` only from `structuredFields.preferredName`) with no claim fallback, so a realistic identity fact from the core extractor — `category=identity`, `structured_fields={ name: "Alex" }` — projected **nothing**.

Fix, entirely PA-side (respects the core→agent direction #14688 mandates):
- Broaden every owner-fact read to the natural key names the free-form extractor actually emits (`name`/`preferredName`/`nickname`/`displayName`, `home_city`/`hometown`/`country`, `iana_timezone`, `marital_status`, `spouse`, …).
- Add English claim fallbacks for the keys that lacked one (notably `preferredName`), **guarded so the language-agnostic structured field wins** over the claim regex — a non-English fact ("je m'appelle Alex") projects via structured fields; an English one recovers from the claim.

### Verification
- `bun run --cwd plugins/plugin-personal-assistant test -- src/lifeops/owner/core-fact-memory-bridge.test.ts` → **7 passed** (added: structured-field projection of a non-English identity fact; English-claim recovery; structured-wins-over-claim precedence).
- `bun run audit:error-policy-ratchet` → no new fallback-slop in touched files.
- Typecheck of the two changed files surfaces no new diagnostics.
- `bunx @biomejs/biome check` clean.

<!-- evidence-row:llm-trajectory -->
N/A - deterministic projection of already-extracted core `fact_extractor` structured fields; no new prompt/model behavior. The tests feed the exact structured-field + claim shapes the core LLM extractor produces.