### PR TITLE
fix: replace keyword-table NL classification with model judgment (#14716, #14717)

### DIFF
--- a/packages/core/src/features/messaging/triage/__tests__/triage-engine.test.ts
+++ b/packages/core/src/features/messaging/triage/__tests__/triage-engine.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Regression tests for the structural triage engine (#14716): the engine must
+ * make no urgency/spam/next-action judgment from message text — those calls
+ * belong to the model reading the MESSAGE action output. Deterministic — fake
+ * runtime + in-process adapter, no live model, no connector, no DB.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { IAgentRuntime, UUID } from "../../../../types/index.ts";
+import { triageMessagesAction } from "../actions/triageMessages.ts";
+import { BaseMessageAdapter } from "../adapters/base.ts";
+import { __resetDefaultMessageRefStoreForTests } from "../message-ref-store.ts";
+import {
+	rankScored,
+	resetMissingServiceWarning,
+	scoreMessage,
+	scoreMessages,
+} from "../triage-engine.ts";
+import {
+	__resetDefaultTriageServiceForTests,
+	getDefaultTriageService,
+} from "../triage-service.ts";
+import type {
+	ListOptions,
+	MessageAdapterCapabilities,
+	MessageRef,
+} from "../types.ts";
+import { createFakeRuntime, fakeContact } from "./fake-runtime.ts";
+
+function messageRef(overrides: Partial<MessageRef>): MessageRef {
+	return {
+		id: "msg",
+		source: "gmail",
+		externalId: "external-msg",
+		from: { identifier: "alice@example.com" },
+		to: [{ identifier: "owner@example.com" }],
+		snippet: "hello",
+		receivedAtMs: 1_000,
+		hasAttachments: false,
+		isRead: false,
+		...overrides,
+	};
+}
+
+class FixedListAdapter extends BaseMessageAdapter {
+	readonly source = "gmail" as const;
+	constructor(private readonly refs: MessageRef[]) {
+		super();
+	}
+	isAvailable(): boolean {
+		return true;
+	}
+	override capabilities(): MessageAdapterCapabilities {
+		return {
+			list: true,
+			search: false,
+			manage: {},
+			send: {},
+			worlds: "single",
+			channels: "none",
+		};
+	}
+	protected override async listMessagesImpl(
+		_runtime: IAgentRuntime,
+		_opts: ListOptions,
+	): Promise<MessageRef[]> {
+		return this.refs;
+	}
+}
+
+describe("triage engine structural scoring (#14716)", () => {
+	beforeEach(() => {
+		__resetDefaultMessageRefStoreForTests();
+		__resetDefaultTriageServiceForTests();
+		resetMissingServiceWarning();
+	});
+
+	it("does not let urgency keywords outrank recency", async () => {
+		const runtime = createFakeRuntime();
+		const keywordStuffed = messageRef({
+			id: "older-urgent-words",
+			externalId: "older",
+			subject: "URGENT!! emergency deadline asap",
+			snippet:
+				"urgent asap emergency deadline today need this now, please help",
+			receivedAtMs: 1_000,
+		});
+		const newerNeutral = messageRef({
+			id: "newer-neutral",
+			externalId: "newer",
+			subject: "Lunch photos",
+			snippet: "here are the photos from saturday",
+			receivedAtMs: 2_000,
+		});
+
+		const ranked = rankScored(
+			await scoreMessages(runtime, [keywordStuffed, newerNeutral]),
+		);
+		expect(ranked.map((m) => m.id)).toEqual([
+			"newer-neutral",
+			"older-urgent-words",
+		]);
+	});
+
+	it("attaches no urgency/spam/next-action judgment to any message", async () => {
+		const runtime = createFakeRuntime();
+		const newsletter = messageRef({
+			id: "newsletter",
+			from: { identifier: "deals@shop.example" },
+			subject: "Weekly newsletter — 50% off sale!",
+			snippet:
+				"Don't miss this promotion. Click here to unsubscribe from marketing.",
+		});
+
+		const score = await scoreMessage(runtime, newsletter);
+		expect(score).toEqual({
+			contactWeight: 0.5,
+			userRepliedInThread: false,
+			scoredAt: expect.any(Number),
+		});
+		// The old engine fabricated these from keyword tables; their absence is
+		// the contract — classification happens in the model, not here.
+		expect("priority" in score).toBe(false);
+		expect("suggestedAction" in score).toBe(false);
+		expect("urgencyKeywords" in score).toBe(false);
+	});
+
+	it("breaks recency ties by relationship-derived contact weight", async () => {
+		const contacts = new Map([
+			[
+				"gmail|mom@example.com",
+				fakeContact("00000000-0000-0000-0000-000000000001" as UUID, ["family"]),
+			],
+			[
+				"gmail|cold-outreach@example.com",
+				fakeContact("00000000-0000-0000-0000-000000000002" as UUID, [
+					"stranger",
+				]),
+			],
+		]);
+		const runtime = createFakeRuntime({ contactsByHandle: contacts });
+		const scored = await scoreMessages(runtime, [
+			messageRef({
+				id: "stranger",
+				from: { identifier: "cold-outreach@example.com" },
+				receivedAtMs: 5_000,
+			}),
+			messageRef({
+				id: "family",
+				from: { identifier: "mom@example.com" },
+				receivedAtMs: 5_000,
+			}),
+		]);
+
+		expect(rankScored(scored).map((m) => m.id)).toEqual(["family", "stranger"]);
+		expect(scored.find((m) => m.id === "family")?.triageScore).toMatchObject({
+			contactWeight: 1.0,
+		});
+		// Category weights only ever raise above the default — a categorized
+		// stranger floors at DEFAULT_CONTACT_WEIGHT (pre-existing semantics).
+		expect(scored.find((m) => m.id === "stranger")?.triageScore).toMatchObject({
+			contactWeight: 0.5,
+		});
+	});
+
+	it("surfaces prior thread engagement as userRepliedInThread", async () => {
+		const runtime = createFakeRuntime();
+		const score = await scoreMessage(
+			runtime,
+			messageRef({ id: "threaded", threadId: "thread-1" }),
+			{ userRepliedThreadIds: new Set(["thread-1"]) },
+		);
+		expect(score.userRepliedInThread).toBe(true);
+	});
+
+	it("MESSAGE action surfaces raw content + structural signals for the model to judge", async () => {
+		const runtime = createFakeRuntime();
+		getDefaultTriageService().register(
+			new FixedListAdapter([
+				messageRef({
+					id: "promo",
+					from: { identifier: "deals@shop.example" },
+					subject: "Flash sale",
+					snippet: "Limited offer — unsubscribe anytime",
+					receivedAtMs: 9_000,
+				}),
+			]),
+		);
+
+		const result = await triageMessagesAction.handler(
+			runtime,
+			messageRef({ id: "turn" }) as never,
+			undefined,
+			{ parameters: {} } as never,
+		);
+
+		expect(result.success).toBe(true);
+		const messages = result.data?.messages as Array<Record<string, unknown>>;
+		expect(messages).toHaveLength(1);
+		// The model gets the raw snippet plus typed structural facts — and no
+		// pre-baked priority/suggestedAction labels to anchor on.
+		expect(messages[0]).toMatchObject({
+			id: "promo",
+			snippet: "Limited offer — unsubscribe anytime",
+			receivedAtMs: 9_000,
+			isRead: false,
+			contactWeight: 0.5,
+			userRepliedInThread: false,
+		});
+		expect("priority" in messages[0]).toBe(false);
+		expect("suggestedAction" in messages[0]).toBe(false);
+	});
+});

--- a/packages/core/src/features/messaging/triage/actions/listInbox.ts
+++ b/packages/core/src/features/messaging/triage/actions/listInbox.ts
@@ -1,10 +1,11 @@
 /**
  * Read-only triage action that returns unread messages across every connected
- * platform as one priority-sorted feed. Registered under the shared `MESSAGE`
- * action name; serves cached refs from the TriageService store when present
- * (re-ranked via `rankScored`) and otherwise triggers a live `triage()` pull,
- * then filters to unread and trims to the requested limit. ADMIN-gated and
- * side-effect free — it never drafts or mutates.
+ * platform as one recency-sorted feed with structural signals attached; the
+ * model reading the result judges urgency (#14716). Registered under the
+ * shared `MESSAGE` action name; serves cached refs from the TriageService
+ * store when present (re-ranked via `rankScored`) and otherwise triggers a
+ * live `triage()` pull, then filters to unread and trims to the requested
+ * limit. ADMIN-gated and side-effect free — it never drafts or mutates.
  */
 
 import { logger } from "../../../../logger.ts";
@@ -28,7 +29,7 @@ export const listInboxAction: Action = {
 	contexts: ["messaging", "email", "connectors"],
 	roleGate: { minRole: "ADMIN" },
 	description:
-		"Read-only list of unread messages from every connected platform as one feed, sorted by priority and recency. Use when the user asks 'what's in my inbox across everything' or 'show me unread across all platforms'. Do not use as the first step for respond/reply-to-inbox or needs-answer requests; use MESSAGE so reply-worthy messages are identified before drafting.",
+		"Read-only list of unread messages from every connected platform as one feed, newest first with sender relationship weight attached. Use when the user asks 'what's in my inbox across everything' or 'show me unread across all platforms'. Do not use as the first step for respond/reply-to-inbox or needs-answer requests; use MESSAGE so reply-worthy messages are identified before drafting.",
 	similes: ["LIST_MESSAGES", "SHOW_UNREAD_ACROSS"],
 	parameters: [
 		{
@@ -134,7 +135,9 @@ export const listInboxAction: Action = {
 						from: m.from.identifier,
 						subject: m.subject ?? null,
 						snippet: m.snippet,
-						priority: m.triageScore?.priority ?? null,
+						receivedAtMs: m.receivedAtMs,
+						contactWeight: m.triageScore?.contactWeight ?? null,
+						userRepliedInThread: m.triageScore?.userRepliedInThread ?? null,
 					})),
 				},
 			};

--- a/packages/core/src/features/messaging/triage/actions/searchMessages.ts
+++ b/packages/core/src/features/messaging/triage/actions/searchMessages.ts
@@ -147,7 +147,7 @@ export const searchMessagesAction: Action = {
 					snippet: m.snippet,
 					receivedAtMs: m.receivedAtMs,
 					tags: m.tags ?? [],
-					priority: m.triageScore?.priority ?? null,
+					contactWeight: m.triageScore?.contactWeight ?? null,
 				})),
 			},
 		};

--- a/packages/core/src/features/messaging/triage/actions/triageMessages.ts
+++ b/packages/core/src/features/messaging/triage/actions/triageMessages.ts
@@ -1,10 +1,10 @@
 /**
  * The inbox-triage action for the messaging-triage capability, registered under
  * the shared `MESSAGE` action name. It fetches unread/recent messages across
- * connected platforms via the TriageService, scores each with deterministic
- * contact + urgency heuristics, and returns a priority-ranked summary plus a
- * per-message list (priority + suggested action). Read-only scan; it never
- * drafts or sends.
+ * connected platforms via the TriageService and returns them newest-first with
+ * structural signals attached (sender relationship weight, unread state, prior
+ * thread engagement); the model reading the result decides urgency and next
+ * action (#14716). Read-only scan; it never drafts or sends.
  */
 import { logger } from "../../../../logger.ts";
 import type {
@@ -31,7 +31,7 @@ export const triageMessagesAction: Action = {
 	contexts: ["messaging", "email", "documents"],
 	roleGate: { minRole: "ADMIN" },
 	description:
-		"Fetch unread/recent messages across connected platforms (gmail, discord, telegram, twitter, imessage, signal, whatsapp), score each one with deterministic contact+urgency heuristics, and return a priority-ranked list.",
+		"Fetch unread/recent messages across connected platforms (gmail, discord, telegram, twitter, imessage, signal, whatsapp) and return them newest-first with structural signals per message (sender relationship weight, unread state, whether the user previously replied in the thread). Judge urgency and the right next action from each message's content and signals.",
 	similes: ["PRIORITIZE_MESSAGES", "RANK_INBOX", "SCAN_MESSAGES"],
 	parameters: [messageSourceParameter, limitParameter, sinceMsParameter],
 	examples: [
@@ -75,7 +75,7 @@ export const triageMessagesAction: Action = {
 		const summary =
 			ranked.length === 0
 				? "No new messages across connected platforms."
-				: `Triaged ${ranked.length} message(s). Top priority: ${ranked[0].triageScore?.priority ?? "unknown"}.`;
+				: `Fetched ${ranked.length} message(s) across ${new Set(ranked.map((m) => m.source)).size} platform(s), newest first.`;
 
 		logger.info(`[TriageMessages] ${summary}`);
 
@@ -97,8 +97,10 @@ export const triageMessagesAction: Action = {
 					from: m.from.identifier,
 					subject: m.subject ?? null,
 					snippet: m.snippet,
-					priority: m.triageScore?.priority ?? null,
-					suggestedAction: m.triageScore?.suggestedAction ?? null,
+					receivedAtMs: m.receivedAtMs,
+					isRead: m.isRead,
+					contactWeight: m.triageScore?.contactWeight ?? null,
+					userRepliedInThread: m.triageScore?.userRepliedInThread ?? null,
 				})),
 			},
 		};

--- a/packages/core/src/features/messaging/triage/triage-engine.ts
+++ b/packages/core/src/features/messaging/triage/triage-engine.ts
@@ -1,12 +1,15 @@
 /**
- * Deterministic cross-platform triage scoring.
+ * Structural triage signals for cross-platform messages.
  *
- * Scoring inputs:
- *   - contact weight (resolved via RelationshipsService.findByHandle)
- *   - urgency keywords in subject/snippet/body
- *   - recency floor (<1h => high floor, <24h => medium floor)
- *   - thread context (bump one level if user previously replied in thread)
- *   - spam heuristics (bulk-mailer / promotional keywords)
+ * The engine deliberately makes no urgency, spam, or next-action judgment —
+ * those are language-understanding calls that belong to the model reading the
+ * MESSAGE action output (#14716; keyword tables were English-only and
+ * word-presence-based, so "no deadline on this" read as urgent). It attaches
+ * only typed structural facts the model cannot cheaply derive from the
+ * message text itself:
+ *   - contact weight (relationship category resolved via RelationshipsService)
+ *   - whether the user previously replied in the message's thread
+ * and orders the feed by recency, with contact weight as the tie-break.
  */
 
 import { logger } from "../../../logger.ts";
@@ -15,12 +18,7 @@ import type {
 	RelationshipsService,
 } from "../../../services/relationships.ts";
 import type { IAgentRuntime } from "../../../types/index.ts";
-import type {
-	MessageRef,
-	SuggestedAction,
-	TriagePriority,
-	TriageScore,
-} from "./types.ts";
+import type { MessageRef, TriageScore } from "./types.ts";
 
 const CATEGORY_WEIGHTS: Record<string, number> = {
 	family: 1.0,
@@ -34,38 +32,6 @@ const CATEGORY_WEIGHTS: Record<string, number> = {
 };
 
 export const DEFAULT_CONTACT_WEIGHT = 0.5;
-
-const URGENCY_KEYWORDS = [
-	"urgent",
-	"asap",
-	"emergency",
-	"deadline",
-	"today",
-	"need now",
-	"help",
-] as const;
-
-const URGENCY_BUMP_PER_HIT = 0.2;
-const URGENCY_MAX_BUMP = 0.5;
-
-const SPAM_KEYWORDS = [
-	"unsubscribe",
-	"click here to unsubscribe",
-	"limited time offer",
-	"act now",
-	"free trial",
-	"promotional",
-	"newsletter",
-	"marketing",
-	"you've been selected",
-	"viagra",
-	"crypto airdrop",
-	"congratulations you won",
-] as const;
-
-const MINUTE_MS = 60 * 1000;
-const HOUR_MS = 60 * MINUTE_MS;
-const DAY_MS = 24 * HOUR_MS;
 
 /**
  * Resolve the contact weight for a sender. Returns DEFAULT_CONTACT_WEIGHT
@@ -107,72 +73,10 @@ export async function resolveContactWeight(
 	return { weight: best, contact };
 }
 
-function findUrgencyKeywords(text: string): string[] {
-	const lower = text.toLowerCase();
-	const hits: string[] = [];
-	for (const keyword of URGENCY_KEYWORDS) {
-		if (lower.includes(keyword)) hits.push(keyword);
-	}
-	return hits;
-}
-
-function looksLikeSpam(msg: MessageRef): boolean {
-	const haystack =
-		`${msg.subject ?? ""} ${msg.snippet} ${msg.body ?? ""}`.toLowerCase();
-	let hits = 0;
-	for (const kw of SPAM_KEYWORDS) {
-		if (haystack.includes(kw)) hits++;
-	}
-	// two promotional markers is a strong spam signal
-	return hits >= 2;
-}
-
-function scoreToPriority(score: number): TriagePriority {
-	if (score >= 1.1) return "critical";
-	if (score >= 0.8) return "high";
-	if (score >= 0.5) return "medium";
-	return "low";
-}
-
-function priorityToAction(priority: TriagePriority): SuggestedAction {
-	switch (priority) {
-		case "critical":
-			return "respond-now";
-		case "high":
-			return "respond-today";
-		case "medium":
-			return "respond-this-week";
-		case "low":
-			return "archive";
-		case "spam":
-			return "skip";
-	}
-}
-
-const PRIORITY_ORDER: TriagePriority[] = ["low", "medium", "high", "critical"];
-
-function bumpPriority(priority: TriagePriority): TriagePriority {
-	if (priority === "spam") return priority;
-	const idx = PRIORITY_ORDER.indexOf(priority);
-	if (idx < 0 || idx === PRIORITY_ORDER.length - 1) return priority;
-	return PRIORITY_ORDER[idx + 1];
-}
-
-function floorPriority(
-	priority: TriagePriority,
-	floor: TriagePriority,
-): TriagePriority {
-	if (priority === "spam" || floor === "spam") return priority;
-	const a = PRIORITY_ORDER.indexOf(priority);
-	const b = PRIORITY_ORDER.indexOf(floor);
-	if (a < 0 || b < 0) return priority;
-	return PRIORITY_ORDER[Math.max(a, b)];
-}
-
 export interface ScoreContext {
 	/**
 	 * Optional: set of threadIds in which the user has previously replied.
-	 * Used for the thread-context bump.
+	 * Surfaced as the userRepliedInThread signal.
 	 */
 	userRepliedThreadIds?: Set<string>;
 	nowMs?: number;
@@ -189,57 +93,11 @@ export async function scoreMessage(
 		message.source,
 		message.from.identifier,
 	);
-
-	const searchText = `${message.subject ?? ""} ${message.snippet} ${message.body ?? ""}`;
-	const urgencyHits = findUrgencyKeywords(searchText);
-	const urgencyBump = Math.min(
-		URGENCY_MAX_BUMP,
-		urgencyHits.length * URGENCY_BUMP_PER_HIT,
-	);
-
-	if (looksLikeSpam(message) && contactWeight <= DEFAULT_CONTACT_WEIGHT) {
-		return {
-			priority: "spam",
-			reason: "Matches promotional / bulk-mailer heuristics",
-			suggestedAction: "skip",
-			contactWeight,
-			urgencyKeywords: urgencyHits,
-			scoredAt: nowMs,
-		};
-	}
-
-	const rawScore = contactWeight + urgencyBump;
-	let priority = scoreToPriority(rawScore);
-
-	// Recency floors
-	const ageMs = Math.max(0, nowMs - message.receivedAtMs);
-	if (ageMs < HOUR_MS) {
-		priority = floorPriority(priority, "high");
-	} else if (ageMs < DAY_MS) {
-		priority = floorPriority(priority, "medium");
-	}
-
-	// Thread context bump
-	if (message.threadId && ctx.userRepliedThreadIds?.has(message.threadId)) {
-		priority = bumpPriority(priority);
-	}
-
-	const reasonParts: string[] = [`contact weight ${contactWeight.toFixed(2)}`];
-	if (urgencyHits.length > 0) {
-		reasonParts.push(`urgency [${urgencyHits.join(", ")}]`);
-	}
-	if (ageMs < HOUR_MS) reasonParts.push("received <1h ago");
-	else if (ageMs < DAY_MS) reasonParts.push("received <24h ago");
-	if (message.threadId && ctx.userRepliedThreadIds?.has(message.threadId)) {
-		reasonParts.push("user previously replied in thread");
-	}
-
 	return {
-		priority,
-		reason: reasonParts.join("; "),
-		suggestedAction: priorityToAction(priority),
 		contactWeight,
-		urgencyKeywords: urgencyHits,
+		userRepliedInThread: Boolean(
+			message.threadId && ctx.userRepliedThreadIds?.has(message.threadId),
+		),
 		scoredAt: nowMs,
 	};
 }
@@ -257,19 +115,19 @@ export async function scoreMessages(
 	return out;
 }
 
-const PRIORITY_RANK: Record<TriagePriority, number> = {
-	critical: 4,
-	high: 3,
-	medium: 2,
-	low: 1,
-	spam: 0,
-};
-
+/**
+ * Presentation order for the feed: newest first, contact weight breaking
+ * ties. Unscored refs sort at the default weight — the comparator needs a
+ * total order, and a missing score carries no relationship information.
+ */
 export function rankScored(messages: MessageRef[]): MessageRef[] {
 	return [...messages].sort((a, b) => {
-		const pa = a.triageScore ? PRIORITY_RANK[a.triageScore.priority] : -1;
-		const pb = b.triageScore ? PRIORITY_RANK[b.triageScore.priority] : -1;
-		if (pa !== pb) return pb - pa;
-		return b.receivedAtMs - a.receivedAtMs;
+		if (a.receivedAtMs !== b.receivedAtMs) {
+			return b.receivedAtMs - a.receivedAtMs;
+		}
+		return (
+			(b.triageScore?.contactWeight ?? DEFAULT_CONTACT_WEIGHT) -
+			(a.triageScore?.contactWeight ?? DEFAULT_CONTACT_WEIGHT)
+		);
 	});
 }

--- a/packages/core/src/features/messaging/triage/types.ts
+++ b/packages/core/src/features/messaging/triage/types.ts
@@ -32,21 +32,16 @@ export const ALL_MESSAGE_SOURCES: readonly MessageSource[] = [
 	"browser_bridge",
 ] as const;
 
-export type TriagePriority = "critical" | "high" | "medium" | "low" | "spam";
-
-export type SuggestedAction =
-	| "respond-now"
-	| "respond-today"
-	| "respond-this-week"
-	| "archive"
-	| "skip";
-
+/**
+ * Structural signals attached per message. Urgency, spam, and next-action are
+ * deliberately absent — the model reading the MESSAGE action output makes
+ * those judgments from the message content plus these facts (#14716).
+ */
 export interface TriageScore {
-	priority: TriagePriority;
-	reason: string;
-	suggestedAction: SuggestedAction;
+	/** Relationship-derived sender weight; DEFAULT_CONTACT_WEIGHT when unknown. */
 	contactWeight: number;
-	urgencyKeywords: string[];
+	/** True when the user has previously replied in this message's thread. */
+	userRepliedInThread: boolean;
 	scoredAt: number;
 }
 

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -61,9 +61,7 @@ export type {
 	ScoreContext,
 	SearchMessagesFilters,
 	SendPolicy,
-	SuggestedAction,
 	TriageOptions,
-	TriagePriority,
 	TriageScore,
 } from "./features/messaging/triage";
 export {

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -102,9 +102,7 @@ export type {
 	ScoreContext,
 	SearchMessagesFilters,
 	SendPolicy,
-	SuggestedAction,
 	TriageOptions,
-	TriagePriority,
 	TriageScore,
 } from "./features/messaging/triage";
 // Cross-platform messaging triage (MESSAGE, MESSAGE, MESSAGE,

--- a/plugins/plugin-personal-assistant/src/actions/brief.ts
+++ b/plugins/plugin-personal-assistant/src/actions/brief.ts
@@ -167,32 +167,18 @@ function readString(
     : null;
 }
 
-function messageUrgency(ref: MessageRef): LifeOpsBriefingInboxItem["urgency"] {
-  switch (ref.triageScore?.priority) {
-    case "critical":
-    case "high":
-      return "high";
-    case "medium":
-      return "medium";
-    case "low":
-    case "spam":
-      return "low";
-    default:
-      return "unknown";
-  }
-}
-
 function mapMessageRefToBriefingItem(
   ref: MessageRef,
 ): LifeOpsBriefingInboxItem {
+  // Triage attaches only structural signals (#14716); urgency is judged by
+  // the compose model reading the snippet, so items arrive unclassified.
   return {
     id: ref.id,
     channel: ref.source,
     senderName: ref.from.displayName ?? ref.from.identifier,
     snippet: ref.snippet,
-    urgency: messageUrgency(ref),
-    classification:
-      ref.triageScore?.suggestedAction ?? (ref.isRead ? "read" : "unread"),
+    urgency: "unknown",
+    classification: ref.isRead ? "read" : "unread",
   };
 }
 

--- a/plugins/plugin-personal-assistant/src/lifeops/service-helpers-reminder.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/service-helpers-reminder.ts
@@ -902,8 +902,7 @@ export type ReminderOwnerResponseClassifierSource =
   | "none"
   | "deterministic"
   | "semantic"
-  | "semantic_abstain"
-  | "semantic_error";
+  | "semantic_abstain";
 
 export type ReminderOwnerResponseContext = {
   title?: string | null;
@@ -1170,81 +1169,6 @@ export function decideReminderReviewTransition(args: {
     : { kind: "escalate", observation };
 }
 
-const SNOOZE_RESPONSE_PATTERNS = [
-  /^\s*\d{1,3}\s*(m|min|mins|minute|minutes|h|hr|hrs|hour|hours)\s*$/i,
-  /\b(snooze|remind me later|later|not now|in a bit)\b/i,
-  /\b(remind me|ping me|nudge me)\s+(in|at|after|tomorrow|tonight)\b/i,
-];
-
-const SKIP_RESPONSE_PATTERNS = [
-  /\b(skip|dismiss|ignore|cancel this|stop this reminder)\b/i,
-];
-
-const COMPLETE_RESPONSE_PATTERNS = [
-  /\b(done|finished|completed|complete|did it|handled|all set)\b/i,
-  /\b(i|we)\s+(did|finished|completed|handled)\b/i,
-];
-
-const ACKNOWLEDGE_RESPONSE_PATTERNS = [
-  /\b(ack|acknowledged|got it|roger|copy|seen|ok|okay|yep|yes)\b/i,
-];
-
-function matchesAnyPattern(
-  value: string,
-  patterns: readonly RegExp[],
-): boolean {
-  return patterns.some((pattern) => pattern.test(value));
-}
-
-const TITLE_STOP_WORDS = new Set([
-  "a",
-  "an",
-  "and",
-  "for",
-  "me",
-  "my",
-  "of",
-  "the",
-  "this",
-  "to",
-]);
-
-function tokenizeReminderText(value: string): string[] {
-  return value
-    .toLowerCase()
-    .split(/[^a-z0-9]+/u)
-    .map((token) => token.trim())
-    .filter((token) => token.length > 2 && !TITLE_STOP_WORDS.has(token));
-}
-
-function responseReferencesReminder(
-  text: string,
-  context?: ReminderOwnerResponseContext,
-): boolean {
-  const lower = text.toLowerCase();
-  if (/\b(this|that|the)\s+reminder\b/u.test(lower)) {
-    return true;
-  }
-  if (/\b(reminder|nudge|ping)\b/u.test(lower)) {
-    return true;
-  }
-  const titleTokens = tokenizeReminderText(context?.title ?? "");
-  if (titleTokens.length === 0) {
-    return false;
-  }
-  const responseTokens = new Set(tokenizeReminderText(text));
-  const matchingTokenCount = titleTokens.filter((token) =>
-    responseTokens.has(token),
-  ).length;
-  if (titleTokens.length === 1) {
-    return matchingTokenCount === 1 && titleTokens[0].length >= 4;
-  }
-  if (titleTokens.length === 2) {
-    return matchingTokenCount === 2;
-  }
-  return matchingTokenCount >= 2;
-}
-
 function resolveResponseTimestampMs(
   value: ReminderOwnerResponseContext["respondedAt"],
 ): number | null {
@@ -1287,67 +1211,6 @@ function normalizeStandaloneResponse(value: string): string {
     .replace(/\s+/gu, " ");
 }
 
-function isStandaloneResolutionResponse(value: string): boolean {
-  const normalized = normalizeStandaloneResponse(value);
-  if (
-    /^\d{1,3}\s*(m|min|mins|minute|minutes|h|hr|hrs|hour|hours)$/iu.test(
-      normalized,
-    )
-  ) {
-    return true;
-  }
-  if (
-    /^(remind me|ping me|nudge me)\s+(at|after|tomorrow)\b/iu.test(normalized)
-  ) {
-    return true;
-  }
-  return (
-    normalized === "done" ||
-    normalized === "finished" ||
-    normalized === "completed" ||
-    normalized === "complete" ||
-    normalized === "did it" ||
-    normalized === "handled" ||
-    normalized === "all set" ||
-    normalized === "skip" ||
-    normalized === "dismiss" ||
-    normalized === "cancel this" ||
-    normalized === "ack" ||
-    normalized === "acknowledged" ||
-    normalized === "got it" ||
-    normalized === "roger" ||
-    normalized === "copy" ||
-    normalized === "seen" ||
-    normalized === "ok" ||
-    normalized === "okay" ||
-    normalized === "yep" ||
-    normalized === "yes" ||
-    normalized === "snooze" ||
-    normalized === "later" ||
-    normalized === "not now" ||
-    normalized === "in a bit" ||
-    normalized === "remind me later"
-  );
-}
-
-function isResponseBoundToReminder(
-  text: string,
-  context?: ReminderOwnerResponseContext,
-): boolean {
-  if (!context) {
-    return true;
-  }
-  if (responseReferencesReminder(text, context)) {
-    return true;
-  }
-  if (context.allowStandaloneResolution === false) {
-    return false;
-  }
-  return (
-    isPromptAdjacentResponse(context) && isStandaloneResolutionResponse(text)
-  );
-}
-
 function toSnoozeMinutes(value: string, unit: string): number | null {
   const amount = Number.parseInt(value, 10);
   if (!Number.isFinite(amount) || amount <= 0) {
@@ -1366,185 +1229,119 @@ function toSnoozeMinutes(value: string, unit: string): number | null {
   return amount;
 }
 
-export function parseReminderSnoozeRequestFromText(text: string): {
-  request: SnoozeLifeOpsOccurrenceRequest | null;
-  needsClarification: boolean;
-  reason: string;
-} {
-  const cleaned = text.trim().toLowerCase();
-  if (/\btomorrow\s+morning\b/u.test(cleaned)) {
-    return {
-      request: { preset: "tomorrow_morning" },
-      needsClarification: false,
-      reason: "snooze_tomorrow_morning",
-    };
+/**
+ * Exact-match structural fast-path (#14717). A reply classifies here only
+ * when, after trivial normalization, the ENTIRE message is a bare resolution
+ * word ("done", "skip", "ok", ...) or a bare snooze duration ("30m",
+ * "2 hours") AND the reply is prompt-adjacent with standalone resolution
+ * allowed. Anything longer — negations, hedges, sentences that merely contain
+ * a keyword ("no, don't skip it") — is a language-understanding judgment and
+ * goes to the semantic (LLM) classifier in classifyReminderOwnerResponse.
+ */
+const EXACT_REPLY_RESOLUTIONS: ReadonlyMap<
+  string,
+  ReminderOwnerResponseResolution
+> = new Map([
+  ["done", "completed"],
+  ["finished", "completed"],
+  ["completed", "completed"],
+  ["complete", "completed"],
+  ["did it", "completed"],
+  ["handled", "completed"],
+  ["all set", "completed"],
+  ["skip", "skipped"],
+  ["dismiss", "skipped"],
+  ["cancel this", "skipped"],
+  ["ack", "acknowledged"],
+  ["acknowledged", "acknowledged"],
+  ["got it", "acknowledged"],
+  ["roger", "acknowledged"],
+  ["copy", "acknowledged"],
+  ["seen", "acknowledged"],
+  ["ok", "acknowledged"],
+  ["okay", "acknowledged"],
+  ["yep", "acknowledged"],
+  ["yes", "acknowledged"],
+]);
+
+// Snooze intent without a duration — certain about the intent, but the
+// occurrence still needs a duration, so it clarifies instead of resolving.
+const EXACT_SNOOZE_REPLIES: ReadonlySet<string> = new Set([
+  "snooze",
+  "later",
+  "not now",
+  "in a bit",
+  "remind me later",
+]);
+
+const BARE_DURATION_PATTERN =
+  /^(\d{1,3})\s*(m|min|mins|minute|minutes|h|hr|hrs|hour|hours)$/iu;
+
+function bareDurationToSnoozeRequest(
+  normalized: string,
+): SnoozeLifeOpsOccurrenceRequest | null {
+  const match = normalized.match(BARE_DURATION_PATTERN);
+  if (!match) {
+    return null;
   }
-  if (/\btonight\b/u.test(cleaned)) {
-    return {
-      request: { preset: "tonight" },
-      needsClarification: false,
-      reason: "snooze_tonight",
-    };
+  const minutes = toSnoozeMinutes(match[1] ?? "", match[2] ?? "");
+  if (minutes === null) {
+    return null;
   }
-  const durationMatch = cleaned.match(
-    /\b(?:in|after|for)?\s*(\d{1,3})\s*(m|min|mins|minute|minutes|h|hr|hrs|hour|hours)\b/u,
-  );
-  if (durationMatch) {
-    const minutes = toSnoozeMinutes(
-      durationMatch[1] ?? "",
-      durationMatch[2] ?? "",
-    );
-    if (minutes !== null) {
-      if (minutes === 15) {
-        return {
-          request: { preset: "15m" },
-          needsClarification: false,
-          reason: "snooze_15m",
-        };
-      }
-      if (minutes === 30) {
-        return {
-          request: { preset: "30m" },
-          needsClarification: false,
-          reason: "snooze_30m",
-        };
-      }
-      if (minutes === 60) {
-        return {
-          request: { preset: "1h" },
-          needsClarification: false,
-          reason: "snooze_1h",
-        };
-      }
-      return {
-        request: { minutes },
-        needsClarification: false,
-        reason: "snooze_duration",
-      };
-    }
-  }
-  const vagueSnooze =
-    /\b(snooze|later|not now|in a bit|some other time)\b/u.test(cleaned) ||
-    /\b(remind me|ping me|nudge me)\s+(at|after|tomorrow)\b/u.test(cleaned);
-  return {
-    request: null,
-    needsClarification: vagueSnooze,
-    reason: vagueSnooze ? "snooze_needs_duration" : "no_snooze_request",
-  };
+  if (minutes === 15) return { preset: "15m" };
+  if (minutes === 30) return { preset: "30m" };
+  if (minutes === 60) return { preset: "1h" };
+  return { minutes };
 }
 
-export function classifyReminderOwnerResponseText(
+function isExactReplyBindable(context?: ReminderOwnerResponseContext): boolean {
+  if (!context) {
+    return true;
+  }
+  return (
+    context.allowStandaloneResolution !== false &&
+    isPromptAdjacentResponse(context)
+  );
+}
+
+export function classifyExactReminderReply(
   text: string,
   context?: ReminderOwnerResponseContext,
-): ReminderOwnerResponseClassification {
-  const cleaned = text.trim();
-  if (cleaned.length === 0) {
+): ReminderOwnerResponseClassification | null {
+  const normalized = normalizeStandaloneResponse(text);
+  if (!isExactReplyBindable(context)) {
+    return null;
+  }
+  const resolution = EXACT_REPLY_RESOLUTIONS.get(normalized);
+  if (resolution) {
     return {
-      decision: "unrelated",
-      resolution: null,
+      decision: "explicit_resolution",
+      resolution,
       snoozeRequest: null,
-      confidence: 0,
-      reason: "empty_response",
+      confidence: 1,
+      reason: `exact_${resolution}_reply`,
     };
   }
-  if (matchesAnyPattern(cleaned, SNOOZE_RESPONSE_PATTERNS)) {
-    if (!isResponseBoundToReminder(cleaned, context)) {
-      return {
-        decision: "unrelated",
-        resolution: null,
-        snoozeRequest: null,
-        confidence: 0.35,
-        reason: "snooze_language_not_bound_to_reminder",
-      };
-    }
-    const snooze = parseReminderSnoozeRequestFromText(cleaned);
-    if (snooze.request) {
-      return {
-        decision: "explicit_resolution",
-        resolution: "snoozed",
-        snoozeRequest: snooze.request,
-        confidence: 0.86,
-        reason: snooze.reason,
-      };
-    }
-    if (snooze.needsClarification) {
-      return {
-        decision: "needs_clarification",
-        resolution: null,
-        snoozeRequest: null,
-        confidence: 0.68,
-        reason: snooze.reason,
-      };
-    }
+  const snoozeRequest = bareDurationToSnoozeRequest(normalized);
+  if (snoozeRequest) {
+    return {
+      decision: "explicit_resolution",
+      resolution: "snoozed",
+      snoozeRequest,
+      confidence: 1,
+      reason: "exact_snooze_duration_reply",
+    };
+  }
+  if (EXACT_SNOOZE_REPLIES.has(normalized)) {
     return {
       decision: "needs_clarification",
       resolution: null,
       snoozeRequest: null,
-      confidence: 0.62,
+      confidence: 1,
       reason: "snooze_needs_duration",
     };
   }
-  if (matchesAnyPattern(cleaned, SKIP_RESPONSE_PATTERNS)) {
-    if (!isResponseBoundToReminder(cleaned, context)) {
-      return {
-        decision: "unrelated",
-        resolution: null,
-        snoozeRequest: null,
-        confidence: 0.35,
-        reason: "skip_language_not_bound_to_reminder",
-      };
-    }
-    return {
-      decision: "explicit_resolution",
-      resolution: "skipped",
-      snoozeRequest: null,
-      confidence: 0.82,
-      reason: "skip_language",
-    };
-  }
-  if (matchesAnyPattern(cleaned, COMPLETE_RESPONSE_PATTERNS)) {
-    if (!isResponseBoundToReminder(cleaned, context)) {
-      return {
-        decision: "unrelated",
-        resolution: null,
-        snoozeRequest: null,
-        confidence: 0.35,
-        reason: "completion_language_not_bound_to_reminder",
-      };
-    }
-    return {
-      decision: "explicit_resolution",
-      resolution: "completed",
-      snoozeRequest: null,
-      confidence: 0.86,
-      reason: "completion_language",
-    };
-  }
-  if (matchesAnyPattern(cleaned, ACKNOWLEDGE_RESPONSE_PATTERNS)) {
-    if (!isResponseBoundToReminder(cleaned, context)) {
-      return {
-        decision: "unrelated",
-        resolution: null,
-        snoozeRequest: null,
-        confidence: 0.3,
-        reason: "acknowledgement_language_not_bound_to_reminder",
-      };
-    }
-    return {
-      decision: "explicit_resolution",
-      resolution: "acknowledged",
-      snoozeRequest: null,
-      confidence: 0.74,
-      reason: "acknowledgement_language",
-    };
-  }
-  return {
-    decision: "unrelated",
-    resolution: null,
-    snoozeRequest: null,
-    confidence: 0.4,
-    reason: "no_explicit_reminder_resolution",
-  };
+  return null;
 }
 
 export type ReminderOwnerResponseClassificationInput = {
@@ -1667,47 +1464,67 @@ export function parseReminderOwnerResponseSemanticClassification(
   };
 }
 
+/**
+ * Classify an owner reply against a reminder. The semantic (LLM) classifier
+ * is the primary judge (#14717); the only deterministic path left is the
+ * exact-match fast-path for replies that ARE a bare resolution word or bare
+ * duration. Without a usable model verdict the reply stays "unrelated" —
+ * degraded detection is honest; a keyword guess that flips reminder state is
+ * not. A throwing semanticClassifier propagates: the injected classifier
+ * already returns null for model/parse failures, so a throw is a bug upstream.
+ */
 export async function classifyReminderOwnerResponse(args: {
   text: string;
   context?: ReminderOwnerResponseContext;
   semanticClassifier?: ReminderOwnerResponseSemanticClassifier | null;
 }): Promise<ReminderOwnerResponseClassification> {
-  const deterministic = classifyReminderOwnerResponseText(
-    args.text,
-    args.context,
-  );
-  if (deterministic.decision !== "unrelated" || !args.semanticClassifier) {
-    return { ...deterministic, classifierSource: "deterministic" };
+  const cleaned = args.text.trim();
+  if (cleaned.length === 0) {
+    return {
+      decision: "unrelated",
+      resolution: null,
+      snoozeRequest: null,
+      confidence: 0,
+      reason: "empty_response",
+      classifierSource: "deterministic",
+    };
+  }
+  const exact = classifyExactReminderReply(cleaned, args.context);
+  if (exact) {
+    return { ...exact, classifierSource: "deterministic" };
   }
   if (args.semanticClassifier) {
-    try {
-      const semantic = await args.semanticClassifier({
-        text: args.text,
-        context: args.context,
-      });
-      if (semantic && semantic.decision !== "abstain") {
-        return {
-          ...semantic,
-          classifierSource: "semantic",
-          semanticReason: semantic.reason,
-        };
-      }
-      if (semantic?.decision === "abstain") {
-        return {
-          ...deterministic,
-          classifierSource: "semantic_abstain",
-          semanticReason: semantic.reason,
-        };
-      }
-    } catch {
+    const semantic = await args.semanticClassifier({
+      text: args.text,
+      context: args.context,
+    });
+    if (semantic && semantic.decision !== "abstain") {
       return {
-        ...deterministic,
-        classifierSource: "semantic_error",
-        semanticReason: "semantic_classifier_error",
+        ...semantic,
+        classifierSource: "semantic",
+        semanticReason: semantic.reason,
+      };
+    }
+    if (semantic?.decision === "abstain") {
+      return {
+        decision: "unrelated",
+        resolution: null,
+        snoozeRequest: null,
+        confidence: semantic.confidence,
+        reason: "semantic_abstain",
+        classifierSource: "semantic_abstain",
+        semanticReason: semantic.reason,
       };
     }
   }
-  return { ...deterministic, classifierSource: "deterministic" };
+  return {
+    decision: "unrelated",
+    resolution: null,
+    snoozeRequest: null,
+    confidence: 0,
+    reason: "no_semantic_verdict",
+    classifierSource: "none",
+  };
 }
 
 export function normalizeReminderUrgencyValue(

--- a/plugins/plugin-personal-assistant/test/reminder-helpers.test.ts
+++ b/plugins/plugin-personal-assistant/test/reminder-helpers.test.ts
@@ -2,7 +2,7 @@
 import { describe, expect, it } from "vitest";
 import {
   _isReminderIntensity,
-  classifyReminderOwnerResponseText,
+  classifyExactReminderReply,
   coerceReminderIntensity,
   isReminderChannel,
   isReminderReviewClosed,
@@ -96,19 +96,17 @@ describe("owner reply classifier", () => {
       allowStandaloneResolution: true,
     };
 
-    expect(classifyReminderOwnerResponseText("done", context)).toMatchObject({
+    expect(classifyExactReminderReply("done", context)).toMatchObject({
       decision: "explicit_resolution",
       resolution: "completed",
       snoozeRequest: null,
     });
-    expect(
-      classifyReminderOwnerResponseText("10 minutes", context),
-    ).toMatchObject({
+    expect(classifyExactReminderReply("10 minutes", context)).toMatchObject({
       decision: "explicit_resolution",
       resolution: "snoozed",
       snoozeRequest: { minutes: 10 },
     });
-    expect(classifyReminderOwnerResponseText("skip", context)).toMatchObject({
+    expect(classifyExactReminderReply("skip", context)).toMatchObject({
       decision: "explicit_resolution",
       resolution: "skipped",
       snoozeRequest: null,

--- a/plugins/plugin-personal-assistant/test/reminder-owner-response-classifier.test.ts
+++ b/plugins/plugin-personal-assistant/test/reminder-owner-response-classifier.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Regression tests for reminder owner-response classification (#14717): the
+ * semantic (LLM) classifier is the primary judge; the only deterministic path
+ * is the exact-match fast-path for replies that ARE a bare resolution word or
+ * duration. Deterministic harness — the semantic seam is stubbed at its
+ * injection boundary, and the model boundary test stubs runtime.useModel to
+ * capture the real prompt.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  type RemindersDeps,
+  RemindersDomain,
+} from "../src/lifeops/domains/reminders-service.js";
+import type { LifeOpsContext } from "../src/lifeops/lifeops-context.js";
+import {
+  classifyExactReminderReply,
+  classifyReminderOwnerResponse,
+  type ReminderOwnerResponseClassificationInput,
+  type ReminderOwnerResponseContext,
+  type ReminderOwnerResponseSemanticClassification,
+} from "../src/lifeops/service-helpers-reminder.js";
+
+const ATTEMPTED_AT = "2026-07-05T10:00:00.000Z";
+
+function adjacentContext(
+  overrides: Partial<ReminderOwnerResponseContext> = {},
+): ReminderOwnerResponseContext {
+  return {
+    title: "dentist appointment",
+    attemptedAt: ATTEMPTED_AT,
+    respondedAt: "2026-07-05T10:02:00.000Z",
+    channel: "in_app",
+    allowStandaloneResolution: true,
+    ...overrides,
+  };
+}
+
+function stubSemantic(
+  result: ReminderOwnerResponseSemanticClassification | null,
+): {
+  classifier: (
+    input: ReminderOwnerResponseClassificationInput,
+  ) => Promise<ReminderOwnerResponseSemanticClassification | null>;
+  calls: ReminderOwnerResponseClassificationInput[];
+} {
+  const calls: ReminderOwnerResponseClassificationInput[] = [];
+  return {
+    calls,
+    classifier: async (input) => {
+      calls.push(input);
+      return result;
+    },
+  };
+}
+
+describe("classifyReminderOwnerResponse (#14717)", () => {
+  it("routes negated keyword sentences to the semantic classifier instead of regex-resolving them", async () => {
+    // Pre-#14717 the \bskip\b table classified this as an explicit skip.
+    const semantic = stubSemantic({
+      decision: "unrelated",
+      resolution: null,
+      snoozeRequest: null,
+      confidence: 0.9,
+      reason: "owner_declines_skip",
+    });
+    const result = await classifyReminderOwnerResponse({
+      text: "no, don't skip it",
+      context: adjacentContext(),
+      semanticClassifier: semantic.classifier,
+    });
+
+    expect(semantic.calls).toHaveLength(1);
+    expect(semantic.calls[0].text).toBe("no, don't skip it");
+    expect(semantic.calls[0].context?.title).toBe("dentist appointment");
+    expect(result.decision).toBe("unrelated");
+    expect(result.resolution).toBeNull();
+    expect(result.classifierSource).toBe("semantic");
+  });
+
+  it("routes keyword-bearing sentences to the semantic classifier and its verdict wins", async () => {
+    // Pre-#14717 \bdone\b + title-token overlap resolved this as completed.
+    const semantic = stubSemantic({
+      decision: "needs_clarification",
+      resolution: null,
+      snoozeRequest: null,
+      confidence: 0.7,
+      reason: "owner_says_not_done_yet",
+    });
+    const result = await classifyReminderOwnerResponse({
+      text: "the dentist appointment isn't done yet, ping me tomorrow",
+      context: adjacentContext(),
+      semanticClassifier: semantic.classifier,
+    });
+
+    expect(semantic.calls).toHaveLength(1);
+    expect(result.decision).toBe("needs_clarification");
+    expect(result.classifierSource).toBe("semantic");
+    expect(result.semanticReason).toBe("owner_says_not_done_yet");
+  });
+
+  it("resolves bare exact replies deterministically without a model (keyless lanes)", async () => {
+    const done = await classifyReminderOwnerResponse({
+      text: "Done!",
+      context: adjacentContext(),
+    });
+    expect(done).toMatchObject({
+      decision: "explicit_resolution",
+      resolution: "completed",
+      classifierSource: "deterministic",
+      confidence: 1,
+    });
+
+    const duration = await classifyReminderOwnerResponse({
+      text: "30m",
+      context: adjacentContext(),
+    });
+    expect(duration).toMatchObject({
+      decision: "explicit_resolution",
+      resolution: "snoozed",
+      snoozeRequest: { preset: "30m" },
+    });
+
+    const oddDuration = await classifyReminderOwnerResponse({
+      text: "2 hours",
+      context: adjacentContext(),
+    });
+    expect(oddDuration.snoozeRequest).toEqual({ minutes: 120 });
+
+    const vagueSnooze = await classifyReminderOwnerResponse({
+      text: "not now",
+      context: adjacentContext(),
+    });
+    expect(vagueSnooze).toMatchObject({
+      decision: "needs_clarification",
+      reason: "snooze_needs_duration",
+    });
+  });
+
+  it("does not fast-path exact replies when standalone resolution is disallowed", async () => {
+    const semantic = stubSemantic({
+      decision: "abstain",
+      resolution: null,
+      snoozeRequest: null,
+      confidence: 0.4,
+      reason: "competing_prompts",
+    });
+    const result = await classifyReminderOwnerResponse({
+      text: "done",
+      context: adjacentContext({ allowStandaloneResolution: false }),
+      semanticClassifier: semantic.classifier,
+    });
+    expect(semantic.calls).toHaveLength(1);
+    expect(result.decision).toBe("unrelated");
+    expect(result.classifierSource).toBe("semantic_abstain");
+  });
+
+  it("does not fast-path exact replies outside the prompt-adjacency window", () => {
+    const result = classifyExactReminderReply(
+      "done",
+      adjacentContext({ respondedAt: "2026-07-05T10:30:00.000Z" }),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("reports an honest non-verdict when no semantic classifier is available", async () => {
+    const result = await classifyReminderOwnerResponse({
+      text: "I finished the dentist thing yesterday",
+      context: adjacentContext(),
+    });
+    expect(result).toMatchObject({
+      decision: "unrelated",
+      resolution: null,
+      confidence: 0,
+      reason: "no_semantic_verdict",
+      classifierSource: "none",
+    });
+  });
+
+  it("propagates a throwing semantic classifier instead of swallowing it", async () => {
+    await expect(
+      classifyReminderOwnerResponse({
+        text: "handled it while you were away",
+        context: adjacentContext(),
+        semanticClassifier: async () => {
+          throw new Error("classifier exploded");
+        },
+      }),
+    ).rejects.toThrow("classifier exploded");
+  });
+});
+
+describe("classifyReminderOwnerResponseSemantically model boundary (#14717)", () => {
+  function domainWithModel(response: string): {
+    domain: RemindersDomain;
+    prompts: string[];
+  } {
+    const prompts: string[] = [];
+    const useModel = async (
+      _modelType: string,
+      params: { prompt: string },
+    ): Promise<string> => {
+      prompts.push(params.prompt);
+      return response;
+    };
+    const ctx = {
+      runtime: { useModel } as unknown as IAgentRuntime,
+    } as LifeOpsContext;
+    return {
+      domain: new RemindersDomain(ctx, {} as RemindersDeps),
+      prompts,
+    };
+  }
+
+  it("sends the owner reply and reminder context to the model and parses its structured verdict", async () => {
+    const { domain, prompts } = domainWithModel(
+      JSON.stringify({
+        decision: "explicit_resolution",
+        resolution: "snoozed",
+        snoozeMinutes: 45,
+        snoozePreset: null,
+        confidence: 0.9,
+        reason: "wants_45_minutes",
+      }),
+    );
+
+    const result = await domain.classifyReminderOwnerResponseSemantically({
+      text: "no, don't skip it — give me 45 minutes",
+      context: {
+        title: "dentist appointment",
+        attemptedAt: ATTEMPTED_AT,
+        respondedAt: "2026-07-05T10:02:00.000Z",
+        channel: "in_app",
+        allowStandaloneResolution: false,
+      },
+    });
+
+    expect(prompts).toHaveLength(1);
+    const prompt = prompts[0];
+    expect(prompt).toContain("no, don't skip it — give me 45 minutes");
+    expect(prompt).toContain("dentist appointment");
+    expect(prompt).toContain("allowStandaloneResolution: false");
+    expect(result).toMatchObject({
+      decision: "explicit_resolution",
+      resolution: "snoozed",
+      snoozeRequest: { minutes: 45 },
+      confidence: 0.9,
+    });
+  });
+
+  it("returns null (not a fabricated verdict) when the model output is unparseable", async () => {
+    const { domain } = domainWithModel("sure thing, marking it complete!");
+    const result = await domain.classifyReminderOwnerResponseSemantically({
+      text: "no, don't skip it",
+      context: { title: "dentist appointment" },
+    });
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #14716, fixes #14717.

Two hardcoded natural-language classifiers were making judgment calls that belong to the model. Both are replaced by structural signals + the LLM seam; net **−181 production lines** in the reminder classifier and **−131** in the triage engine (+474 lines of regression tests).

## #14716 — core triage engine scored urgency/spam by keyword tables

**Root cause.** `packages/core/src/features/messaging/triage/triage-engine.ts` derived `TriageScore.priority` / `suggestedAction` from `URGENCY_KEYWORDS` / `SPAM_KEYWORDS` word-presence: English-only, negation-blind ("no deadline on this" read as urgent; "help" boosted anything), and any mail containing "newsletter"/"unsubscribe" from a non-close contact was auto-labeled spam→skip. The fabricated labels were then surfaced to the model as pre-baked verdicts.

**Fix.** The engine now attaches only typed structural facts the model cannot cheaply derive from text — relationship-derived `contactWeight` (via RelationshipsService), `userRepliedInThread`, `scoredAt` — and `rankScored` orders by recency with contact weight as tie-break. The `MESSAGE` actions (`triageMessages`, `listInbox`, `searchMessages`) surface raw snippets plus these signals (`receivedAtMs`, `isRead`, `contactWeight`, `userRepliedInThread`) and no `priority`/`suggestedAction` fields, so the model reading the ActionResult decides urgency and next action. `TriagePriority`/`SuggestedAction` types are deleted from `@elizaos/core`. `brief.ts` (personal assistant) no longer maps keyword-derived priority into briefing urgency — the compose model judges from the snippet.

**Deleted:** `URGENCY_KEYWORDS`, `SPAM_KEYWORDS`, `findUrgencyKeywords`, `looksLikeSpam`, `scoreToPriority`, `priorityToAction`, priority bump/floor ladder, recency floors, `PRIORITY_RANK` sort, `messageUrgency` (brief.ts).
**Kept:** contact-weight resolution (structural), store/adapter plumbing, action registration.

## #14717 — reminder owner replies classified by regex tables

**Root cause.** `plugins/plugin-personal-assistant/src/lifeops/service-helpers-reminder.ts` resolved reminder state from four substring-matching regex tables + title-token-overlap binding, and consulted the existing LLM classifier (`classifyReminderOwnerResponseSemantically`, which already builds a full prompt with title/adjacency/binding context) **only when the regexes matched nothing**. So `\bskip\b` matched "no, don't skip it" → skipped; `\bdone\b` + title overlap matched "the dentist appointment isn't done yet, ping me tomorrow" → completed — silent wrong state transitions, English-only.

**Fix.** Composition inverted: the semantic (LLM) classifier is primary. The only deterministic path left is an exact-match fast-path (`classifyExactReminderReply`) that fires when the **entire** normalized reply is a bare resolution word or bare duration — exactly the strings the in-app reminder chat choices submit (`done` / `10 minutes` / `skip`, see `appendReminderChatChoices`) — gated on prompt adjacency + `allowStandaloneResolution`. Keyless lanes keep working through it. Without a usable model verdict the reply stays `unrelated` (reason `no_semantic_verdict`) — degraded detection is honest; a keyword guess that flips reminder state is not. A throwing injected classifier now propagates instead of being silently swallowed (the production classifier already returns `null` on model/parse failure).

**Deleted:** `SNOOZE/SKIP/COMPLETE/ACKNOWLEDGE_RESPONSE_PATTERNS`, `matchesAnyPattern`, `tokenizeReminderText` + `TITLE_STOP_WORDS` + `responseReferencesReminder` (title-token binding heuristic), `isStandaloneResolutionResponse`, `isResponseBoundToReminder`, `parseReminderSnoozeRequestFromText` (text sniffer), the fabricated confidence constants (0.86/0.82/0.74/0.35…), the swallowing `catch` in the composer, and the now-producerless `semantic_error` classifier source.
**Kept:** prompt-adjacency window, duration→preset normalization (feeds the fast-path), the semantic prompt/parse layer (unchanged), `decideReminderReviewTransition` and all downstream acknowledgement wiring (untouched per the parallel checkin lane).

## Tests (fail without the fix — verified both ways)

- `packages/core/src/features/messaging/triage/__tests__/triage-engine.test.ts` — 5 tests: keyword-stuffed older message no longer outranks newer neutral; a "newsletter…unsubscribe" promo gets **no** priority/suggestedAction/urgencyKeywords fields; recency ties break by contact weight (family 1.0 vs default); `userRepliedInThread` surfaces; MESSAGE action DTO carries raw snippet + structural signals and no fabricated labels. **Ran against the pre-fix engine: 4/5 fail** (tie-break test passes on both, as intended).
- `plugins/plugin-personal-assistant/test/reminder-owner-response-classifier.test.ts` — 9 tests: negated/keyword-bearing sentences reach the stubbed semantic seam and its verdict wins; bare `done`/`30m`/`2 hours`/`not now` resolve deterministically without a model; fast-path refuses non-adjacent and standalone-disallowed replies; honest `no_semantic_verdict` when no model; throwing classifier propagates; **model-boundary test stubs `runtime.useModel` and asserts the real prompt carries the reply text, reminder title, and `allowStandaloneResolution`**, and that the structured verdict (incl. `snoozeMinutes` → `{minutes:45}`) parses; unparseable model output returns `null`, never a fabricated verdict. **Ran against the pre-fix classifier: 5/9 fail.**
- `test/reminder-helpers.test.ts` updated: the chat-choice payload test now targets `classifyExactReminderReply` (same exact payloads the CHOICE block emits).

```
packages/core triage suite:            5 files, 18 tests — green
core advanced-capabilities:            21 files, 158 tests — green
core action-retrieval:                 15 tests — green
PA reminder suites (helpers+new):      2 files, 15 tests — green
PA brief suites (4 files):             31 passed, 5 skipped — green
PA decomposition-integration:          6 tests — green
plugin-inbox inbox-action:             23 tests — green (LLM triage seam untouched)
plugin-google/signal/inbox typecheck:  green (triage-adapter consumers compile)
bun run audit:error-policy-ratchet:    no new fallback-slop in touched files
biome:                                 clean on all touched files
```

**Full PA unit lane (1264 tests):** 1240 passed, 17 failed in 11 files — every failure verified **pre-existing** by re-running the same files at the pristine merge-base in an identical environment: 16 fail there byte-identically (e.g. `travel_reconcile: cache.getCache is not a function`, scheduled-task `no_reply_retry_1` vs `completion_timeout_due`, BlockerSettingsCards React errors); the 17th (`signature-deadline-scheduler`) is masked at base by the #14804 module-load break and fails with the identical assertion diff once only the loading fix from this PR is applied to pristine base sources. None touch triage or reminder-reply classification.

## Pre-existing develop breakage found while validating (not introduced here)

1. **PA `test:background-real` lane could not even load** since #14804: agent source now imports `@elizaos/plugin-app-control/actions/settings` by subpath, which only resolves under the `eliza-source` exports condition; the PA vitest stub only intercepted the bare specifier. **Fixed in this PR** (`vitest.config.ts`: subpath→source aliases for `plugin-app-control/*` and the React-free `settings-section-meta` data module, placed ahead of the broad ui stub alias).
2. With module loading repaired, `reminder-review-job.real.e2e.test.ts` fails on `42P01: app_reminders.life_reminder_plans` missing — **reproduced identically with pristine `origin/develop` sources** in the same environment, so it predates this change (schema bootstrap regression in the real-runtime harness, likely separate upstream churn).
3. `plugins/plugin-personal-assistant` `tsc` typecheck has one pre-existing error in `src/actions/scheduled-task.ts:589` from #14879 (upstream, file untouched here); no typecheck errors in any file this PR touches.

## Evidence

- Backend logs / frontend logs / screenshots / video: **N/A** — no UI surface; core scoring types + a background classifier. The observable contract is the ActionResult DTO and classification records, asserted byte-level in the tests above.
- Real-LLM trajectories: **N/A** — this change authors no new prompt: the triage engine now makes **zero** model calls (the consumer is the agent loop reading the action result), and the reminder semantic prompt is the pre-existing `lifeops-reminders-classify-reply` prompt, unchanged; the tests assert at the `useModel` boundary that the exact prompt + reply reach it.
- Domain artifacts: classification records and action DTOs asserted in tests; reviewed by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)