### PR TITLE
fix(ui): make launcher favorite pin touch-first

### DIFF
--- a/packages/ui/src/components/pages/Launcher.test.tsx
+++ b/packages/ui/src/components/pages/Launcher.test.tsx
@@ -268,6 +268,7 @@ describe("Launcher zones", () => {
   });
 
   it("toggles a favorite only from the All Apps zone", () => {
+    const onLaunch = vi.fn();
     const onToggleFavorite = vi.fn();
     render(
       <Launcher
@@ -277,17 +278,38 @@ describe("Launcher zones", () => {
         ]}
         favoriteIds={new Set(["wallet"])}
         onToggleFavorite={onToggleFavorite}
-        onLaunch={() => {}}
+        onLaunch={onLaunch}
       />,
     );
     // The pin lives in the exhaustive grid (one per id), not on the read-only
-    // Favorites projection.
+    // Favorites projection. It is a touch-first 44px target and clicking it does
+    // not also launch the app tile.
     expect(screen.getAllByTestId("launcher-favorite-wallet")).toHaveLength(1);
     const pin = screen.getByTestId("launcher-favorite-wallet");
     expect(pin.getAttribute("aria-pressed")).toBe("true");
+    expect(pin.className).toContain("h-11");
+    expect(pin.className).toContain("w-11");
     fireEvent.click(pin);
     expect(onToggleFavorite).toHaveBeenCalledTimes(1);
     expect(onToggleFavorite.mock.calls[0][0].id).toBe("wallet");
+    expect(onLaunch).not.toHaveBeenCalled();
+  });
+
+  it("keeps unpinned favorite targets visible on coarse pointers", () => {
+    render(
+      <Launcher
+        zones={zones([wallet])}
+        favoriteIds={new Set()}
+        onToggleFavorite={() => {}}
+        onLaunch={() => {}}
+      />,
+    );
+
+    const pin = screen.getByTestId("launcher-favorite-wallet");
+    expect(pin.className).toContain("h-11");
+    expect(pin.className).toContain("w-11");
+    expect(pin.className).toContain("opacity-0");
+    expect(pin.className).toContain("pointer-coarse:opacity-100");
   });
 
   it("omits the favorite pin affordance when no toggle handler is supplied", () => {

--- a/packages/ui/src/components/pages/Launcher.tsx
+++ b/packages/ui/src/components/pages/Launcher.tsx
@@ -121,12 +121,11 @@ const IconTile = memo(function IconTile({
         ) : null}
         {onToggleFavorite ? (
           // The pin lives on the tile itself (the only place a launcher-scoped
-          // favorite has meaning). Neutral, hidden until hover/focus so the grid
-          // stays calm; the filled/gold state persists once pinned so a Favorites
-          // member reads as pinned even at rest.
+          // favorite has meaning). Fine pointers keep the quiet hover/focus
+          // reveal, while coarse pointers get a visible 44px target at rest so
+          // Favorites can be managed on the phone-primary surface.
           <Button
-            variant="ghost"
-            size="icon-sm"
+            unstyled
             data-testid={`launcher-favorite-${entry.id}`}
             aria-pressed={isFavorite}
             aria-label={
@@ -139,14 +138,14 @@ const IconTile = memo(function IconTile({
               onToggleFavorite(entry);
             }}
             className={cn(
-              "absolute -right-2 -top-2 h-6 w-6 rounded-full bg-black/55 p-0 text-white transition-opacity hover:bg-black/70",
+              "absolute -right-3.5 -top-3.5 inline-flex h-11 w-11 items-center justify-center rounded-full border border-border/50 bg-card/85 p-0 text-card-foreground shadow-sm transition-[background-color,opacity,transform] active:scale-[0.98] hover:bg-card",
               isFavorite
                 ? "text-warn opacity-100"
-                : "text-white/80 opacity-0 focus-visible:opacity-100 group-hover:opacity-100",
+                : "opacity-0 focus-visible:opacity-100 group-hover:opacity-100 pointer-coarse:opacity-100",
             )}
           >
             <Star
-              className="h-3.5 w-3.5"
+              className="h-4 w-4"
               fill={isFavorite ? "currentColor" : "none"}
               aria-hidden
             />


### PR DESCRIPTION
## Summary
- makes the launcher Favorites pin a 44px touch target instead of a 24px hover-only control
- keeps fine-pointer behavior calm with hover/focus reveal, while coarse pointers show the unpinned target at rest
- preserves existing favorite toggle semantics and prevents pin clicks from also launching the tile

## Mobile behavior
On phone and tablet coarse pointers, every All Apps favorite pin has a visible 44px circular target at rest. Tapping it pins or unpins the app without opening the app. Fine-pointer desktop still reveals unpinned pins on hover or focus.

## Validation
- `cd packages/ui && bunx vitest run src/components/pages/Launcher.test.tsx --config vitest.config.ts`
- `bunx biome check packages/ui/src/components/pages/Launcher.tsx packages/ui/src/components/pages/Launcher.test.tsx`
- `rg -n '(fill|stroke|color|background|bg|text|border|shadow|className)[^\n]*#[0-9A-Fa-f]{3,8}' packages/ui/src/components/pages/Launcher.tsx packages/ui/src/components/pages/Launcher.test.tsx` produced no CSS raw hex matches
- `rg -n 'h-11|w-11|pointer-coarse:opacity-100' packages/ui/src/components/pages/Launcher.tsx packages/ui/src/components/pages/Launcher.test.tsx` confirms the 44px target and coarse-pointer visibility classes
- `codex review --uncommitted` reported no discrete correctness issues

Closes #14927

Signed-off-by: Sol <sol@shad0w.xyz>
[sol-orch]
