### PR TITLE
fix(ui): consolidate home blur budget

### DIFF
--- a/packages/ui/src/components/chat/widgets/home-widget-card.test.tsx
+++ b/packages/ui/src/components/chat/widgets/home-widget-card.test.tsx
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { Circle } from "lucide-react";
+import { describe, expect, it, vi } from "vitest";
+
+import { HomeWidgetCard } from "./home-widget-card";
+
+describe("HomeWidgetCard", () => {
+  it("renders as a solid token tile with no per-card backdrop blur", () => {
+    render(
+      <HomeWidgetCard
+        icon={<Circle aria-hidden />}
+        label="Needs"
+        value="Approve deployment"
+        testId="home-widget-card"
+        ariaLabel="Needs response: approve deployment"
+        onActivate={vi.fn()}
+      />,
+    );
+
+    const card = screen.getByTestId("home-widget-card");
+    expect(card.className).toContain("bg-[var(--brand-black)]");
+    expect(card.className).toContain("border-[color:color-mix");
+    expect(card.className).not.toContain("backdrop-blur");
+    expect(card.className).not.toMatch(/bg-black\/35/);
+  });
+});

--- a/packages/ui/src/components/chat/widgets/home-widget-card.tsx
+++ b/packages/ui/src/components/chat/widgets/home-widget-card.tsx
@@ -1,17 +1,18 @@
 /**
- * HomeWidgetCard — the compact, icon-first, whole-card-clickable building block
+ * HomeWidgetCard - the compact, icon-first, whole-card-clickable building block
  * for the home dashboard (#9143).
  *
  * Home widgets are glanceable, not dashboards: an icon, a one-word label, and a
  * SINGLE high-priority datum (a value and/or a status badge). The whole card is
- * a button — tapping it navigates to the full surface (or runs the relevant
+ * a button - tapping it navigates to the full surface (or runs the relevant
  * action). Because the visible text is intentionally minimal, the full meaning
  * lives in `ariaLabel` for screen readers.
  *
- * Sits on the orange home wallpaper as a solid warm-dark card tile (the `card`
- * surface token). Orange is accent-only: resting neutral, escalating to the
- * status hue on danger/warn, never orange→black — per the hover system. All
- * color comes from tokens so the tile stays theme-aware.
+ * Sits on the orange home wallpaper as a solid brand-token tile. Home glass
+ * belongs to the notification center recipe only; resident cards do not add
+ * blur or translucent black layers. Orange is accent-only: resting neutral,
+ * escalating to the status hue on danger/warn. All color comes from tokens so
+ * the tile stays theme-aware.
  */
 
 import { type ReactNode, useMemo } from "react";
@@ -49,39 +50,37 @@ export function useWidgetNavigation(): {
 
 export type HomeWidgetTone = "default" | "danger" | "warn";
 
-// Home sits over the ember wallpaper, which can be substantially darker than
-// the theme token surface underneath it. Keep readable text white on every card;
-// urgency is carried by the rail, chip, and badge instead of recoloring the datum.
+export const HOME_WIDGET_SOLID_TILE_CLASS =
+  "group relative flex h-auto w-full overflow-hidden rounded-2xl border border-[color:color-mix(in_srgb,var(--brand-white)_20%,var(--brand-black))] bg-[var(--brand-black)] text-left text-[var(--brand-white)]";
+
 const TONE_VALUE_CLASS: Record<HomeWidgetTone, string> = {
-  default: "text-white",
-  danger: "text-white",
-  warn: "text-white",
+  default: "text-[var(--brand-white)]",
+  danger: "text-[var(--brand-white)]",
+  warn: "text-[var(--brand-white)]",
 };
 
-// The icon chip stays white-tinted because `.theme-app` maps semantic status
-// tokens to black, which is correct on orange panels but illegible on dark
-// glass. Urgency is carried by the visible badge/label, not tiny color fills.
 const TONE_CHIP_CLASS: Record<HomeWidgetTone, string> = {
-  default: "bg-white/10 text-white",
-  danger: "bg-white/14 text-white",
-  warn: "bg-white/14 text-white",
+  default:
+    "border-[color:color-mix(in_srgb,var(--brand-white)_18%,transparent)] bg-[color:color-mix(in_srgb,var(--brand-white)_10%,transparent)] text-[var(--brand-white)]",
+  danger: "border-danger/55 bg-danger/15 text-[var(--brand-white)]",
+  warn: "border-warn/55 bg-warn/15 text-[var(--brand-white)]",
 };
 
 export interface HomeWidgetCardProps {
-  /** Lucide icon (the primary identifier — text is secondary). */
+  /** Lucide icon (the primary identifier - text is secondary). */
   icon: ReactNode;
   /** One short label, e.g. "Bills", "Goals", "Sleep". */
   label: string;
   /** The single high-priority datum, e.g. "−$125.50" or "Design review". */
   value?: ReactNode;
-  /** Secondary metric kept tight, e.g. "in 45m" — omit when not high-signal. */
+  /** Secondary metric kept tight, e.g. "in 45m" - omit when not high-signal. */
   meta?: ReactNode;
   /** Count/status pill, e.g. "1", "At risk", "Irregular". */
   badge?: ReactNode;
   tone?: HomeWidgetTone;
   /** data-testid on the card button. */
   testId: string;
-  /** Full accessible description — visible text is minimal, so this carries it. */
+  /** Full accessible description - visible text is minimal, so this carries it. */
   ariaLabel: string;
   /** Tap / Enter → navigate to the full surface or run the action. */
   onActivate: () => void;
@@ -106,15 +105,14 @@ export function HomeWidgetCard({
       title={label}
       onClick={onActivate}
       className={cn(
-        // A SOLID warm-dark tile (the card surface token) with a warm hairline
-        // edge, so it sits in the ember field instead of letting it bleed
-        // through (the old bg-black/55 was translucent). A left accent rail keys
-        // the tone. Tactile: a hair lift + warmer edge on hover, scale-press on
-        // tap. Surface/border/hover all resolve through tokens so the tile is
-        // theme-aware, never a baked-in white/black opacity ladder.
-        "group relative flex h-auto w-full items-center gap-3 overflow-hidden whitespace-normal rounded-2xl border border-white/55 bg-black/35 px-3.5 py-3 text-left text-white backdrop-blur-xl",
+        // A solid token tile. The old translucent black-opacity + per-card blur
+        // stacked a new backdrop-filter for every resident. The card surface is
+        // now genuinely opaque at the recipe level; tone is keyed by the rail,
+        // chip, and badge instead of another glass layer.
+        HOME_WIDGET_SOLID_TILE_CLASS,
+        "items-center gap-3 whitespace-normal px-3.5 py-3 text-[var(--brand-white)]",
         "transition-[transform,border-color,background-color] duration-150",
-        "hover:border-white/75 hover:bg-black/45",
+        "hover:border-[color:color-mix(in_srgb,var(--brand-white)_34%,var(--brand-black))] hover:bg-[var(--brand-black)]",
         "active:scale-[0.985] motion-reduce:active:scale-100",
       )}
     >
@@ -125,15 +123,15 @@ export function HomeWidgetCard({
         className={cn(
           "absolute inset-y-2.5 left-0 w-[3px] rounded-full transition-colors duration-150",
           tone === "danger"
-            ? "bg-white/80"
+            ? "bg-danger"
             : tone === "warn"
-              ? "bg-white/70"
-              : "bg-white/35 group-hover:bg-white/70",
+              ? "bg-warn"
+              : "bg-border-strong group-hover:bg-accent",
         )}
       />
       <span
         className={cn(
-          "relative inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl [&>svg]:h-[18px] [&>svg]:w-[18px]",
+          "relative inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border [&>svg]:h-[18px] [&>svg]:w-[18px]",
           TONE_CHIP_CLASS[tone],
         )}
       >
@@ -144,7 +142,7 @@ export function HomeWidgetCard({
           read as a real dashboard), with the single high-priority datum below
           it. When a widget supplies no datum, the label carries the row alone. */}
       <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span className="truncate text-xs-tight font-medium uppercase tracking-[0.08em] text-white/65">
+        <span className="truncate text-xs-tight font-medium uppercase tracking-[0.08em] text-[color:color-mix(in_srgb,var(--brand-white)_68%,transparent)]">
           {label}
         </span>
         {value != null ? (
@@ -164,7 +162,7 @@ export function HomeWidgetCard({
       </span>
 
       {meta != null ? (
-        <span className="shrink-0 text-xs-tight tabular-nums text-white/80">
+        <span className="shrink-0 text-xs-tight tabular-nums text-[color:color-mix(in_srgb,var(--brand-white)_82%,transparent)]">
           {meta}
         </span>
       ) : null}
@@ -173,10 +171,10 @@ export function HomeWidgetCard({
           className={cn(
             "shrink-0 rounded-full px-2 py-0.5 text-xs-tight font-semibold tabular-nums",
             tone === "danger"
-              ? "bg-white/16 text-white"
+              ? "border border-danger/55 bg-danger/15 text-[var(--brand-white)]"
               : tone === "warn"
-                ? "bg-white/16 text-white"
-                : "bg-white/12 text-white",
+                ? "border border-warn/55 bg-warn/15 text-[var(--brand-white)]"
+                : "border border-[color:color-mix(in_srgb,var(--brand-white)_18%,transparent)] bg-[color:color-mix(in_srgb,var(--brand-white)_10%,transparent)] text-[var(--brand-white)]",
           )}
         >
           {badge}

--- a/packages/ui/src/components/chat/widgets/wallet-balance.test.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.test.tsx
@@ -20,7 +20,7 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Auth gate (#11084) — mutable so tests can flip the session state. Default
+// Auth gate (#11084) - mutable so tests can flip the session state. Default
 // authenticated so the pre-gate behavior tests exercise the live poll path.
 const { authMock } = vi.hoisted(() => ({
   authMock: { authenticated: true },
@@ -38,6 +38,8 @@ vi.mock("../../../api", () => ({
 
 const navOpenView = vi.fn();
 vi.mock("./home-widget-card", () => ({
+  HOME_WIDGET_SOLID_TILE_CLASS:
+    "group relative flex h-auto w-full overflow-hidden rounded-2xl border border-[color:color-mix(in_srgb,var(--brand-white)_20%,var(--brand-black))] bg-[var(--brand-black)] text-left text-[var(--brand-white)]",
   useWidgetNavigation: () => ({ openView: navOpenView, openTab: vi.fn() }),
 }));
 
@@ -146,7 +148,7 @@ describe("WalletBalanceWidget (price-only, #10706)", () => {
     ).toBeTruthy();
   });
 
-  it("renders price-only rows for held assets — no amount or holding value", async () => {
+  it("renders price-only rows for held assets - no amount or holding value", async () => {
     getWalletBalances.mockResolvedValue(
       balances([
         { symbol: "USDC", valueUsd: "500" },

--- a/packages/ui/src/components/chat/widgets/wallet-balance.tsx
+++ b/packages/ui/src/components/chat/widgets/wallet-balance.tsx
@@ -1,13 +1,13 @@
 /**
  * WALLET home widget. A glanceable, chromeless tile on the ember home field
- * showing crypto **unit prices only** — never the amount held or the holding
+ * showing crypto **unit prices only** - never the amount held or the holding
  * value (#10706). Tapping opens the wallet view.
  *
  * Two states, always visible once prices load (#14344): when the user holds ≥1
  * priced token worth ≥ $1, the top-3 held by holding value; otherwise the
  * tracked BTC/SOL/ETH default rows (back-filled from trending movers if the
  * overview is partial). Prices refresh on a 60s document-visibility-gated
- * interval — no polling while the app is backgrounded. It self-hides only when
+ * interval - no polling while the app is backgrounded. It self-hides only when
  * prices are unavailable (both endpoints down / never loaded): the home surface
  * shows no error chrome; the wallet view owns error state (J4).
  */
@@ -20,7 +20,10 @@ import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
 import { useIntervalWhenDocumentVisible } from "../../../hooks/useDocumentVisibility";
 import type { WidgetProps } from "../../../widgets/types";
 import { Button } from "../../ui/button";
-import { useWidgetNavigation } from "./home-widget-card";
+import {
+  HOME_WIDGET_SOLID_TILE_CLASS,
+  useWidgetNavigation,
+} from "./home-widget-card";
 import {
   type PricedHolding,
   selectDefaultPriceRows,
@@ -43,7 +46,7 @@ function formatPrice(priceUsd: number): string {
       maximumFractionDigits: digits,
     }).format(priceUsd);
   } catch {
-    // error-policy:J3 Intl rejected the locale/currency — plain formatting
+    // error-policy:J3 Intl rejected the locale/currency - plain formatting
     return `$${priceUsd.toFixed(digits)}`;
   }
 }
@@ -147,9 +150,9 @@ export function WalletBalanceWidget(
         .join(", ")}. Open wallet.`}
       onClick={() => nav.openView("/wallet", "wallet")}
       variant="ghost"
-      className={`${spanClassName} group flex h-auto w-full flex-col items-stretch gap-1 rounded-2xl border border-white/55 bg-black/35 px-3 py-2.5 text-left font-normal text-white backdrop-blur-xl transition-[background-color,border-color,opacity] hover:border-white/75 hover:bg-black/45 hover:opacity-90`}
+      className={`${spanClassName} ${HOME_WIDGET_SOLID_TILE_CLASS} flex-col items-stretch gap-1 px-3 py-2.5 font-normal transition-[background-color,border-color,opacity] hover:border-[color:color-mix(in_srgb,var(--brand-white)_34%,var(--brand-black))] hover:bg-[var(--brand-black)] hover:opacity-90`}
     >
-      <span className="flex items-center gap-2 text-xs text-white/65 [&>svg]:h-3.5 [&>svg]:w-3.5">
+      <span className="flex items-center gap-2 text-xs text-[color:color-mix(in_srgb,var(--brand-white)_68%,transparent)] [&>svg]:h-3.5 [&>svg]:w-3.5">
         <Wallet />
         Wallet
       </span>
@@ -161,13 +164,15 @@ export function WalletBalanceWidget(
             data-testid={`wallet-price-row-${h.symbol}`}
             className="flex items-baseline justify-between gap-2 text-sm"
           >
-            <span className="truncate font-medium text-white">{h.symbol}</span>
+            <span className="truncate font-medium text-[var(--brand-white)]">
+              {h.symbol}
+            </span>
             <span className="flex shrink-0 items-baseline gap-1.5">
-              <span className="tabular-nums text-white">
+              <span className="tabular-nums text-[var(--brand-white)]">
                 {formatPrice(h.priceUsd)}
               </span>
               {change ? (
-                <span className="tabular-nums text-xs text-white/75">
+                <span className="tabular-nums text-xs text-[color:color-mix(in_srgb,var(--brand-white)_82%,transparent)]">
                   {change}
                 </span>
               ) : null}

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -6,7 +6,7 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Mutations are optimistic writes through the API client — mock the transport,
+// Mutations are optimistic writes through the API client - mock the transport,
 // not the store, so mark-read/dismiss/clear exercise the real store paths.
 vi.mock("../../api/client", () => ({
   client: {
@@ -34,6 +34,7 @@ import {
   __ingestNotificationForTests,
   __resetNotificationStoreForTests,
 } from "../../state/notifications/notification-store";
+import { HOME_GLASS_CLASS } from "./home-glass";
 import {
   NotificationsHomeCenter,
   orderDashboardNotifications,
@@ -73,7 +74,7 @@ describe("orderDashboardNotifications", () => {
     const urgentOld = makeNotification({
       priority: "urgent",
       createdAt: 1_600_000_000_000,
-      readAt: 1_600_000_500_000, // read — must NOT sink below unread lows
+      readAt: 1_600_000_500_000, // read - must NOT sink below unread lows
     });
     const normalNew = makeNotification({ priority: "normal" });
     const ordered = orderDashboardNotifications([low, urgentOld, normalNew]);
@@ -178,7 +179,7 @@ describe("NotificationsHomeCenter", () => {
     expect(__getStateForTests().notifications).toHaveLength(0);
   });
 
-  it("keeps a tapped (now read) row in place — order ignores read state", () => {
+  it("keeps a tapped (now read) row in place - order ignores read state", () => {
     const urgent = makeNotification({ priority: "urgent", title: "First" });
     __ingestNotificationForTests(makeNotification({ title: "Second" }));
     __ingestNotificationForTests(urgent);
@@ -206,7 +207,7 @@ describe("NotificationsHomeCenter", () => {
       makeNotification({ priority: "normal", title: "Quiet one" }),
     );
     render(<NotificationsHomeCenter />);
-    // A normal notification is just its line + time — no leading accent rail,
+    // A normal notification is just its line + time - no leading accent rail,
     // no per-row icon chip (the box-in-a-box slop is gone).
     expect(screen.queryByTestId("notification-row-accent")).toBeNull();
     expect(screen.queryByTestId("notification-row-icon")).toBeNull();
@@ -227,12 +228,11 @@ describe("NotificationsHomeCenter", () => {
     expect(screen.getAllByTestId("notification-row-accent")).toHaveLength(2);
   });
 
-  it("is a quiet glass surface, not a heavy filled card", () => {
+  it("uses the shared home glass recipe as the single blur budget owner", () => {
     __ingestNotificationForTests(makeNotification());
     render(<NotificationsHomeCenter />);
     const card = screen.getByTestId("home-notification-center");
-    // Hairline border + translucent surface (lock-screen glass), not the old
-    // opaque `bg-card` box with a solid `border-border`.
+    expect(card.className).toBe(HOME_GLASS_CLASS);
     expect(card.className).toContain("backdrop-blur");
     expect(card.className).not.toContain("border-border");
   });

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -33,6 +33,7 @@ import {
 } from "../../state/notifications/notification-store";
 import { NOTIFICATION_PRIORITY_RANK } from "../../widgets/home-priority";
 import { Button } from "../ui/button";
+import { HOME_GLASS_CLASS } from "./home-glass";
 import { RelativeTime } from "./RelativeTime";
 
 /**
@@ -359,18 +360,10 @@ export function NotificationsHomeCenter(): React.JSX.Element | null {
       // The card owns its gap from the editorial header above (mt-4) so a
       // hidden widget (null render) leaves no dead spacer in the column.
       //
-      // Lock-screen glass, not a chrome box: a single hairline border + a
-      // faintly translucent surface over the wallpaper (backdrop-blur where
-      // supported), no heavy filled card. This reads as an iOS lock-screen
-      // notification stack sitting on the home field rather than an app card.
-      //
-      // Blur audit (spec §C.4 item 4): stepped `backdrop-blur-xl` →
-      // `backdrop-blur-md`. A full-strength blur over the animated wallpaper is
-      // a per-frame compositing cost on iOS Safari that the always-mounted home
-      // pays forever; `md` still reads as glass. The `supports-[backdrop-filter]`
-      // translucency stays the primary low-end path (an opaque-enough surface
-      // where blur is unsupported), so legibility never depends on the blur.
-      className="mt-4 flex flex-col overflow-hidden rounded-2xl border border-white/55 bg-black/35 text-white backdrop-blur-md supports-[backdrop-filter]:bg-black/30"
+      // Lock-screen glass, not a chrome box: a single shared recipe owns the
+      // entire home backdrop-filter budget. Ranked widgets stay solid token
+      // tiles, so adding residents never adds more blur surfaces.
+      className={HOME_GLASS_CLASS}
     >
       <style>{NOTIF_SCROLL_CSS}</style>
       {/* Pinned header: a quiet eyebrow + unread count, actions to the right.

--- a/packages/ui/src/components/shell/home-glass.ts
+++ b/packages/ui/src/components/shell/home-glass.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared home glass recipe.
+ *
+ * Home owns one backdrop-filter budget: the pinned notification center. Ranked
+ * widget cards must stay solid token tiles so every additional resident does
+ * not add another compositing surface over the wallpaper.
+ */
+export const HOME_GLASS_CLASS =
+  "mt-4 flex flex-col overflow-hidden rounded-2xl border border-white/55 bg-black/35 text-white backdrop-blur-md supports-[backdrop-filter]:bg-black/30";


### PR DESCRIPTION
## Summary
- Consolidates the home notification glass class into `HOME_GLASS_CLASS`, the only home surface that carries `backdrop-blur`.
- Converts resident widget cards, including the shared `HomeWidgetCard` and wallet balance widget, to solid brand-token tiles with no per-card blur or translucent black layer.
- Adds class-contract coverage for the solid card recipe and updates notification center coverage to assert the shared glass recipe.

## Expected visual delta
The home notification center keeps its quiet lock-screen glass treatment. Ranked resident cards now read as solid black brand-token tiles over the orange home field, with tokenized white text and status rails/chips for hierarchy. Adding more residents no longer adds additional backdrop-filter surfaces.

## Validation
- `NODE_OPTIONS="${NODE_OPTIONS:-} --no-experimental-webstorage --disable-warning=ExperimentalWarning" bunx vitest run --config ./vitest.config.ts src/components/chat/widgets/home-widget-card.test.tsx src/components/chat/widgets/wallet-balance.test.tsx src/components/chat/widgets/agent-provisioning.test.tsx src/components/shell/NotificationsHomeCenter.test.tsx src/components/shell/NotificationsHomeCenter.render-count.test.tsx src/components/shell/HomeScreen.test.tsx src/widgets/registry.home.test.ts src/widgets/WidgetHost.home-rank.test.tsx src/widgets/WidgetHost.home-launch.test.tsx src/widgets/WidgetHost.render-storm.test.tsx` - 10 files, 66 tests passed. Existing act warnings from WeatherTile/TodoSidebarWidget.
- `bunx @biomejs/biome@2.5.2 check packages/ui/src/components/chat/widgets/home-widget-card.tsx packages/ui/src/components/chat/widgets/home-widget-card.test.tsx packages/ui/src/components/chat/widgets/wallet-balance.tsx packages/ui/src/components/chat/widgets/wallet-balance.test.tsx packages/ui/src/components/shell/NotificationsHomeCenter.tsx packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx packages/ui/src/components/shell/home-glass.ts` - passed.
- Grep on touched files: raw hex colors none, em dash none, `backdrop-blur` only in `HOME_GLASS_CLASS` plus tests asserting the budget.
- Codex review was started with `codex review --uncommitted`; it exceeded the 100s lane budget and was killed, then I self-reviewed the diff and reran the focused checks above.

Closes #14908

Signed-off-by: Sol <sol@shad0w.xyz>
