### PR TITLE
fix(settings): prime OS permission handoff payload

### DIFF
--- a/packages/agent/src/api/views-routes.navigate-broadcast.test.ts
+++ b/packages/agent/src/api/views-routes.navigate-broadcast.test.ts
@@ -164,6 +164,36 @@ describe("POST /api/views/:id/navigate broadcast contract", () => {
     });
   });
 
+  it("carries opaque deep-link payloads to the shell frame and response", async () => {
+    const payload = { permissionRequest: { permission: "microphone" } };
+    const { ctx, json, broadcastWs } = makeNavigateCtx("settings", {
+      path: "/settings",
+      subview: "permissions",
+      payload,
+    });
+
+    await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+
+    expect(broadcastWs).toHaveBeenCalledWith({
+      type: SHELL_NAVIGATE_VIEW_WS_EVENT,
+      viewId: "settings",
+      viewPath: "/settings",
+      viewLabel: "Settings",
+      viewType: "gui",
+      subview: "permissions",
+      payload,
+    });
+    expect(json).toHaveBeenCalledWith(
+      ctx.res,
+      expect.objectContaining({
+        ok: true,
+        viewId: "settings",
+        subview: "permissions",
+        payload,
+      }),
+    );
+  });
+
   it("broadcasts close actions without requiring a navigation path consumer", async () => {
     const { ctx, broadcastWs } = makeNavigateCtx("settings", {
       action: "close",

--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -905,6 +905,7 @@ export async function handleViewsRoutes(
   //   placement: string    — optional split placement hint: left/right/top/bottom
   //   path: string         — override the navigation path
   //   alwaysOnTop: boolean — for open-window, ask the shell to keep it above normal windows
+  //   payload: unknown     — opaque deep-link state consumed by the target view
   if (method === "POST" && subResource === "navigate") {
     const body = await readJsonBody<Record<string, unknown>>(req, res).catch(
       () => null,
@@ -948,11 +949,14 @@ export async function handleViewsRoutes(
       typeof body?.placement === "string" && body.placement.trim().length > 0
         ? body.placement.trim()
         : undefined;
+    const payload =
+      body && Object.hasOwn(body, "payload") ? body.payload : undefined;
     const layoutPayload = {
       ...(layoutViews && layoutViews.length > 0 ? { views: layoutViews } : {}),
       ...(layout ? { layout } : {}),
       ...(placement ? { placement } : {}),
     };
+    const deepLinkPayload = payload !== undefined ? { payload } : {};
 
     logger.info(
       { src: "ViewsRoutes", viewId: id, viewPath, action, subview },
@@ -1044,6 +1048,7 @@ export async function handleViewsRoutes(
         ...(subview ? { subview } : {}),
         ...(alwaysOnTop ? { alwaysOnTop } : {}),
         ...layoutPayload,
+        ...deepLinkPayload,
       };
       ctx.broadcastWs?.(createShellNavigateViewWsFrame(navigatePayload));
     }
@@ -1057,6 +1062,7 @@ export async function handleViewsRoutes(
       ...(subview ? { subview } : {}),
       ...(alwaysOnTop ? { alwaysOnTop } : {}),
       ...layoutPayload,
+      ...deepLinkPayload,
     });
     return true;
   }

--- a/packages/shared/src/events/index.ts
+++ b/packages/shared/src/events/index.ts
@@ -175,6 +175,8 @@ export interface ShellNavigateViewPayload {
   layout?: string;
   placement?: string;
   alwaysOnTop?: boolean;
+  /** Opaque target-view deep-link state, validated by the receiving view. */
+  payload?: unknown;
 }
 
 export type ShellNavigateViewWsFrame = ShellNavigateViewPayload & {
@@ -212,6 +214,7 @@ export function normalizeShellNavigateViewPayload(
     layout: readNonEmptyString(data.layout),
     placement: readNonEmptyString(data.placement),
     alwaysOnTop: data.alwaysOnTop === true,
+    ...(Object.hasOwn(data, "payload") ? { payload: data.payload } : {}),
   };
 }
 

--- a/packages/shared/src/events/shell-navigate-view.test.ts
+++ b/packages/shared/src/events/shell-navigate-view.test.ts
@@ -44,6 +44,7 @@ describe("shell navigate view websocket event", () => {
         layout: "split",
         placement: "right",
         alwaysOnTop: true,
+        payload: { permissionRequest: { permission: "microphone" } },
       }),
     ).toEqual({
       viewId: "wallet",
@@ -56,6 +57,7 @@ describe("shell navigate view websocket event", () => {
       layout: "split",
       placement: "right",
       alwaysOnTop: true,
+      payload: { permissionRequest: { permission: "microphone" } },
     });
   });
 

--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -77,6 +77,16 @@ const dynamicViewLoaderMock = vi.hoisted(() => ({
   ),
 }));
 
+const settingsViewMock = vi.hoisted(() => ({
+  render: vi.fn(
+    (_props: {
+      initialSection?: string;
+      navigatePayload?: unknown;
+      navigateSequence?: number;
+    }) => <div data-testid="settings-view" />,
+  ),
+}));
+
 const remoteLedgerView = {
   id: "remote-ledger",
   label: "Remote Ledger",
@@ -376,6 +386,14 @@ vi.mock("./components/pages/ChatView", () => ({
   __resetCompanionSpeechMemoryForTests: vi.fn(),
 }));
 
+vi.mock("./components/pages/SettingsView", () => ({
+  SettingsView: (props: {
+    initialSection?: string;
+    navigatePayload?: unknown;
+    navigateSequence?: number;
+  }) => settingsViewMock.render(props),
+}));
+
 vi.mock("./components/character/CharacterEditor", () => ({
   CharacterEditor: ({ initialPage }: { initialPage?: string }) => (
     <div
@@ -437,6 +455,7 @@ describe("App navigate-view event wiring", () => {
     desktopBridgeMock.invokeDesktopBridgeRequest.mockClear();
     desktopBridgeMock.subscribeDesktopBridgeEvent.mockClear();
     dynamicViewLoaderMock.render.mockClear();
+    settingsViewMock.render.mockClear();
   });
 
   afterEach(() => {
@@ -473,6 +492,33 @@ describe("App navigate-view event wiring", () => {
       expect(appState.setTab).toHaveBeenCalledWith("settings");
     });
     expect(desktopTabsMock.openTab).not.toHaveBeenCalled();
+  });
+
+  it("passes settings navigate payloads into SettingsView for targeted permission priming", async () => {
+    appState.tab = "settings";
+    window.history.replaceState(null, "", "/?shellMode=full");
+    const payload = { permissionRequest: { permission: "microphone" } };
+    render(<App />);
+
+    fireEvent(
+      window,
+      createNavigateViewEvent({
+        viewId: "settings",
+        viewPath: "/settings",
+        subview: "permissions",
+        payload,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(settingsViewMock.render).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initialSection: "permissions",
+          navigatePayload: payload,
+          navigateSequence: 1,
+        }),
+      );
+    });
   });
 
   it("pins remote views and opens remote view windows through App wiring", async () => {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1284,6 +1284,8 @@ interface StaticTabRenderContext {
   nativeOsSurfaceEnabled: boolean;
   navigationPath: string;
   settingsInitialSection?: string | null;
+  settingsNavigatePayload?: unknown;
+  settingsNavigateSequence?: number;
   walletNav?: ReactNode;
   characterNav?: ReactNode;
 }
@@ -1350,11 +1352,17 @@ function buildStaticTabRenderers(): Record<
     database: wrap(<DatabasePageView />),
     logs: wrap(<LogsView />),
     desktop: wrap(<DesktopWorkspaceSection />),
-    settings: ({ settingsInitialSection }) => (
+    settings: ({
+      settingsInitialSection,
+      settingsNavigatePayload,
+      settingsNavigateSequence,
+    }) => (
       <TabContentView surface="transparent">
         <SettingsView
           key="settings-root"
           initialSection={settingsInitialSection ?? undefined}
+          navigatePayload={settingsNavigatePayload}
+          navigateSequence={settingsNavigateSequence}
         />
       </TabContentView>
     ),
@@ -1397,6 +1405,8 @@ function renderStaticViewRouterTab({
   nativeOsSurfaceEnabled,
   navigationPath,
   settingsInitialSection,
+  settingsNavigatePayload,
+  settingsNavigateSequence,
   walletNav,
   characterNav,
 }: {
@@ -1404,6 +1414,8 @@ function renderStaticViewRouterTab({
   nativeOsSurfaceEnabled: boolean;
   navigationPath: string;
   settingsInitialSection?: string | null;
+  settingsNavigatePayload?: unknown;
+  settingsNavigateSequence?: number;
   walletNav?: ReactNode;
   characterNav?: ReactNode;
 }): ReactNode {
@@ -1417,6 +1429,8 @@ function renderStaticViewRouterTab({
       nativeOsSurfaceEnabled,
       navigationPath,
       settingsInitialSection,
+      settingsNavigatePayload,
+      settingsNavigateSequence,
       walletNav,
       characterNav,
     });
@@ -1434,6 +1448,8 @@ function renderViewRouterContent({
   appSlug,
   nativeOsSurfaceEnabled,
   settingsInitialSection,
+  settingsNavigatePayload,
+  settingsNavigateSequence,
 }: {
   tab: string;
   dynamicPage: ResolvedDynamicPage | null;
@@ -1444,6 +1460,8 @@ function renderViewRouterContent({
   appSlug: string | null;
   nativeOsSurfaceEnabled: boolean;
   settingsInitialSection?: string | null;
+  settingsNavigatePayload?: unknown;
+  settingsNavigateSequence?: number;
 }): ReactNode {
   if (visibleDynamicPage(dynamicPage, enabledKinds)) {
     return (
@@ -1497,6 +1515,8 @@ function renderViewRouterContent({
     nativeOsSurfaceEnabled,
     navigationPath,
     settingsInitialSection,
+    settingsNavigatePayload,
+    settingsNavigateSequence,
     walletNav,
     characterNav,
   });
@@ -1510,9 +1530,13 @@ type ViewRouterRouteOverride = {
 function ViewRouter({
   routeOverride,
   settingsInitialSection,
+  settingsNavigatePayload,
+  settingsNavigateSequence,
 }: {
   routeOverride?: ViewRouterRouteOverride;
   settingsInitialSection?: string | null;
+  settingsNavigatePayload?: unknown;
+  settingsNavigateSequence?: number;
 }) {
   const activeTab = useAppSelector((s) => s.tab);
   const tab = routeOverride?.tab ?? activeTab;
@@ -1561,6 +1585,8 @@ function ViewRouter({
     appSlug,
     nativeOsSurfaceEnabled,
     settingsInitialSection,
+    settingsNavigatePayload,
+    settingsNavigateSequence,
   });
 
   // A distinct lifecycle identity per routed surface: builtin tab id, or
@@ -1624,6 +1650,8 @@ type ShellContentProps = {
   setCustomActionsPanelOpen: (open: boolean) => void;
   setEditingAction: (action: import("./api").CustomActionDef | null) => void;
   settingsInitialSection: string | null;
+  settingsNavigatePayload: unknown;
+  settingsNavigateSequence: number;
   tab: string;
   uiShellMode: string;
   viewLayout: ActiveViewLayout | null;
@@ -1703,7 +1731,11 @@ function RoutedShellContent(props: ShellContentProps): ReactNode {
             onClear={props.onClearViewLayout}
           />
         ) : (
-          <ViewRouter settingsInitialSection={props.settingsInitialSection} />
+          <ViewRouter
+            settingsInitialSection={props.settingsInitialSection}
+            settingsNavigatePayload={props.settingsNavigatePayload}
+            settingsNavigateSequence={props.settingsNavigateSequence}
+          />
         )}
       </main>
     </div>
@@ -2154,6 +2186,9 @@ export function App() {
   const [settingsInitialSection, setSettingsInitialSection] = useState<
     string | null
   >(null);
+  const [settingsNavigatePayload, setSettingsNavigatePayload] =
+    useState<unknown>(undefined);
+  const [settingsNavigateSequence, setSettingsNavigateSequence] = useState(0);
 
   // Desktop tab bar — persisted pinned tabs for the Electrobun shell.
   const {
@@ -2291,6 +2326,8 @@ export function App() {
           `[SettingsNavigate] routing subview "${detail.subview}" to SettingsView initialSection`,
         );
         setSettingsInitialSection(detail.subview);
+        setSettingsNavigatePayload(detail.payload);
+        setSettingsNavigateSequence((sequence) => sequence + 1);
         setTab("settings");
         return;
       }
@@ -2442,6 +2479,8 @@ export function App() {
         setCustomActionsPanelOpen={setCustomActionsPanelOpen}
         setEditingAction={setEditingAction}
         settingsInitialSection={settingsInitialSection}
+        settingsNavigatePayload={settingsNavigatePayload}
+        settingsNavigateSequence={settingsNavigateSequence}
         tab={tab}
         uiShellMode={uiShellMode}
         viewLayout={viewLayout}
@@ -2457,6 +2496,8 @@ export function App() {
       screenBackgroundPolicy,
       customActionsPanelOpen,
       settingsInitialSection,
+      settingsNavigatePayload,
+      settingsNavigateSequence,
       desktopTabBar,
       availableViewsForDesktopTabs,
       viewLayout,

--- a/packages/ui/src/components/pages/SettingsView.test.tsx
+++ b/packages/ui/src/components/pages/SettingsView.test.tsx
@@ -27,6 +27,9 @@ import { SettingsView } from "./SettingsView";
 // their own tests). The useApp + section-registry mocks are the seams this
 // refactor must keep stable.
 const appMock = vi.hoisted(() => ({ value: {} as Record<string, unknown> }));
+const permissionPrimingMock = vi.hoisted(() => ({
+  calls: [] as Array<{ ids: string[]; open: boolean }>,
+}));
 // Controls whether the deliberately-throwing "crash" section throws on render,
 // so a single test can flip it off and assert the per-section retry recovers.
 const crashControl = vi.hoisted(() => ({ shouldThrow: true }));
@@ -69,6 +72,26 @@ vi.mock("../../state", () => ({
     sel(appMock.value),
   useAppSelectorShallow: (sel: (value: Record<string, unknown>) => unknown) =>
     sel(appMock.value),
+}));
+
+vi.mock("../permissions/PermissionPrimingModal", () => ({
+  PermissionPrimingModal: (props: {
+    ids: string[];
+    open: boolean;
+    onComplete: () => void;
+  }) => {
+    permissionPrimingMock.calls.push({
+      ids: props.ids,
+      open: props.open,
+    });
+    return (
+      <div
+        data-testid="permission-priming-modal"
+        data-ids={props.ids.join(",")}
+        data-open={String(props.open)}
+      />
+    );
+  },
 }));
 
 vi.mock("../settings/settings-sections", () => {
@@ -168,6 +191,7 @@ function sectionTab(label: string): HTMLButtonElement {
 
 beforeEach(() => {
   appMock.value = makeContext();
+  permissionPrimingMock.calls = [];
   crashControl.shouldThrow = true;
 });
 
@@ -227,6 +251,41 @@ describe("SettingsView", () => {
     expect(screen.getByTestId("stub-runtime")).toBeTruthy();
     expect(screen.queryByTestId("stub-identity")).toBeNull();
     expect(screen.getByTestId("view-header").textContent).toContain("Runtime");
+  });
+
+  it("opens a targeted permission priming modal from a settings navigate payload", async () => {
+    render(
+      <SettingsView
+        initialSection="runtime"
+        navigatePayload={{
+          permissionRequest: { permission: "microphone" },
+        }}
+        navigateSequence={1}
+      />,
+    );
+
+    expect(
+      (await screen.findByTestId("permission-priming-modal")).getAttribute(
+        "data-ids",
+      ),
+    ).toBe("microphone");
+    expect(permissionPrimingMock.calls.at(-1)).toEqual({
+      ids: ["microphone"],
+      open: true,
+    });
+  });
+
+  it("ignores malformed permission request navigation payloads", () => {
+    render(
+      <SettingsView
+        initialSection="runtime"
+        navigatePayload={{ permissionRequest: { permission: "shell" } }}
+        navigateSequence={1}
+      />,
+    );
+
+    expect(screen.queryByTestId("permission-priming-modal")).toBeNull();
+    expect(permissionPrimingMock.calls).toHaveLength(0);
   });
 
   it("the header back affordance returns from a section to the hub", () => {

--- a/packages/ui/src/components/pages/SettingsView.tsx
+++ b/packages/ui/src/components/pages/SettingsView.tsx
@@ -14,12 +14,14 @@
  * deep-links a specific section. Also reusable in modal form (`inModal`).
  */
 import { isViewVisible } from "@elizaos/core";
+import { isPermissionId, type PermissionId } from "@elizaos/shared";
 import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
 import { ContentLayout } from "../../layouts/content-layout";
 import { isAndroidCloudBuild } from "../../platform/android-runtime";
 import { useAppSelectorShallow } from "../../state";
 import { useEnabledViewKinds } from "../../state/useViewKinds";
+import { PermissionPrimingModal } from "../permissions/PermissionPrimingModal";
 import { SettingsSectionNav } from "../settings/SettingsSectionNav";
 import {
   type GroupedSettingsSections,
@@ -37,6 +39,19 @@ import { ErrorBoundary } from "../ui/error-boundary";
 import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
 
 type Translate = (key: string, vars?: Record<string, unknown>) => string;
+
+function readSettingsPermissionRequest(payload: unknown): PermissionId | null {
+  if (!payload || typeof payload !== "object") return null;
+  const permissionRequest = (payload as { permissionRequest?: unknown })
+    .permissionRequest;
+  if (!permissionRequest || typeof permissionRequest !== "object") {
+    return null;
+  }
+  const permission = (permissionRequest as { permission?: unknown }).permission;
+  return isPermissionId(permission) && permission !== "shell"
+    ? permission
+    : null;
+}
 
 /**
  * Loading placeholder for a lazily-loaded section body (#11351). Deliberately
@@ -181,10 +196,14 @@ function SettingsSectionSurfaceAnchor({
 export function SettingsView({
   inModal,
   initialSection,
+  navigatePayload,
+  navigateSequence = 0,
 }: {
   inModal?: boolean;
   onClose?: () => void;
   initialSection?: string;
+  navigatePayload?: unknown;
+  navigateSequence?: number;
 } = {}) {
   const { t, loadPlugins, walletEnabled } = useAppSelectorShallow((s) => ({
     t: s.t,
@@ -194,6 +213,9 @@ export function SettingsView({
   const enabledKinds = useEnabledViewKinds();
   const [activeSection, setActiveSection] = useState<string | null>(
     () => initialSection ?? readSettingsHashSection(),
+  );
+  const [primePermission, setPrimePermission] = useState<PermissionId | null>(
+    null,
   );
 
   const visibleSections = useMemo(() => {
@@ -233,6 +255,15 @@ export function SettingsView({
     if (!initialSection) return;
     openSection(initialSection);
   }, [initialSection, openSection]);
+
+  useEffect(() => {
+    const permission = readSettingsPermissionRequest(navigatePayload);
+    if (!permission) {
+      if (navigateSequence > 0) setPrimePermission(null);
+      return;
+    }
+    setPrimePermission(permission);
+  }, [navigatePayload, navigateSequence]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -304,6 +335,13 @@ export function SettingsView({
               <SettingsHubEmptyState t={t} />
             )}
           </div>
+          {primePermission ? (
+            <PermissionPrimingModal
+              ids={[primePermission]}
+              open
+              onComplete={() => setPrimePermission(null)}
+            />
+          ) : null}
         </div>
       </ContentLayout>
     </ShellViewAgentSurface>

--- a/packages/ui/src/components/permissions/PermissionPrimingModal.tsx
+++ b/packages/ui/src/components/permissions/PermissionPrimingModal.tsx
@@ -228,10 +228,20 @@ function PrimingCard({
   const t = useAppSelector((s) => s.t);
   const copy = PRIMING_COPY[id];
   const Icon = copy ? (ICONS[copy.icon] ?? ShieldCheck) : ShieldCheck;
-  const title = copy ? t(copy.titleKey, { defaultValue: copy.title }) : id;
+  const fallbackName = id.replaceAll("-", " ");
+  const title = copy
+    ? t(copy.titleKey, { defaultValue: copy.title })
+    : t("permissionpriming.generic.title", {
+        defaultValue: "Allow {{permission}}",
+        permission: fallbackName,
+      });
   const rationale = copy
     ? t(copy.rationaleKey, { defaultValue: copy.rationale })
-    : "";
+    : t("permissionpriming.generic.rationale", {
+        defaultValue:
+          "Enable this permission so I can complete the request you just made.",
+        permission: fallbackName,
+      });
 
   const denied = status === "denied";
 

--- a/packages/ui/src/state/startup-phase-hydrate.navigate-frame.test.ts
+++ b/packages/ui/src/state/startup-phase-hydrate.navigate-frame.test.ts
@@ -162,6 +162,31 @@ describe("agent view-switch raw WS frame to DOM navigate event", () => {
     teardown();
   });
 
+  it("forwards opaque deep-link payloads from raw frames into the DOM event", () => {
+    const payload = { permissionRequest: { permission: "microphone" } };
+    clientMock.deliverFrame(
+      JSON.stringify({
+        type: SHELL_NAVIGATE_VIEW_WS_EVENT,
+        viewId: "settings",
+        viewPath: "/settings",
+        viewLabel: "Settings",
+        viewType: "gui",
+        subview: "permissions",
+        payload,
+      }),
+    );
+
+    expect(navHandler).toHaveBeenCalledTimes(1);
+    const detail = (navHandler.mock.calls[0][0] as CustomEvent).detail;
+    expect(detail).toMatchObject({
+      viewId: "settings",
+      viewPath: "/settings",
+      subview: "permissions",
+      payload,
+    });
+    teardown();
+  });
+
   it("fills defaults when the backend omits action and alwaysOnTop", () => {
     // The backend spreads `action`/`alwaysOnTop` only when truthy
     // (views-routes.ts:794-795), so a plain `show` navigation omits both keys.

--- a/plugins/plugin-app-control/src/actions/settings.test.ts
+++ b/plugins/plugin-app-control/src/actions/settings.test.ts
@@ -330,7 +330,7 @@ describe("SETTINGS action: set on an owned route section", () => {
 				path: "/settings",
 				subview: "permissions",
 				source: "settings-action",
-				permission: "microphone",
+				payload: { permissionRequest: { permission: "microphone" } },
 			},
 		});
 		expect(result?.success).toBe(true);
@@ -397,6 +397,16 @@ describe("SETTINGS action: set on an owned route section", () => {
 		expect(routeFetch).toHaveBeenCalledWith({
 			method: "POST",
 			path: "/api/permissions/notifications/request",
+		});
+		expect(routeFetch).toHaveBeenCalledWith({
+			method: "POST",
+			path: "/api/views/settings/navigate",
+			body: {
+				path: "/settings",
+				subview: "permissions",
+				source: "settings-action",
+				payload: { permissionRequest: { permission: "notifications" } },
+			},
 		});
 		expect(result?.values).toMatchObject({
 			key: "request",

--- a/plugins/plugin-app-control/src/actions/settings.ts
+++ b/plugins/plugin-app-control/src/actions/settings.ts
@@ -231,7 +231,7 @@ function resolveSystemPermissionId(token: string | null): PermissionId | null {
 function isPermissionStateNeedingHandoff(data: unknown): boolean {
 	if (!data || typeof data !== "object") return true;
 	const status = (data as { status?: unknown }).status;
-	return status !== "granted" && status !== "not-applicable";
+	return status !== "granted";
 }
 
 function readPermissionFromOutcome(data: unknown): PermissionId | null {
@@ -292,7 +292,7 @@ const PERMISSIONS_REQUEST_KEY: SettingsWritableKey = {
 					path: "/settings",
 					subview: "permissions",
 					source: "settings-action",
-					permission,
+					payload: { permissionRequest: { permission } },
 				},
 			});
 			handoff = handoffOutcome.ok;


### PR DESCRIPTION
## Summary
- follow-up to #14906 / #14729: preserve navigate-view `payload` through the backend WS frame and frontend normalizer
- make SETTINGS permission handoff send `payload.permissionRequest.permission` instead of a dropped top-level field
- have Settings validate that payload and open the existing permission-priming modal for the exact OS permission, including `not-applicable` server responses where native/mobile clients may still need to own the dialog

## Verification
- `bun run --cwd plugins/plugin-app-control test src/actions/settings.test.ts` (57 passed)
- `bun run --cwd packages/agent test src/api/views-routes.navigate-broadcast.test.ts` (18 passed)
- `bun run --cwd packages/shared test src/events/shell-navigate-view.test.ts` (3 passed)
- `bun run --cwd packages/ui test src/state/startup-phase-hydrate.navigate-frame.test.ts src/components/pages/SettingsView.test.tsx src/App.navigate-view-wiring.test.tsx src/app-navigate-view.test.ts src/components/permissions/PermissionPrimingModal.test.tsx src/components/permissions/use-permission-priming.test.ts src/components/permissions/permission-priming.test.ts` (77 passed)
- `bun run --cwd packages/ui test:permission-priming-e2e` (desktop + mobile screenshots/video, no page errors)
- `bunx @biomejs/biome check <12 touched files> --no-errors-on-unmatched`
- `git diff --check origin/develop...HEAD`
- `bun run audit:error-policy-ratchet`
- `bun run --cwd packages/shared typecheck && bun run --cwd plugins/plugin-app-control typecheck`

## Typecheck Notes
- `bun run --cwd packages/ui typecheck` is still blocked by existing unrelated errors in `todo.test.tsx`, `settings-sections.ts`, `startup-phase-poll.test.ts`, `widget-cert-fixture.tsx`, and `voice-selftest-harness.test.ts`.
- `bun run --cwd packages/agent typecheck` is still blocked by existing optional package resolution/import-conversations errors plus the same `settings-sections.ts` issue.

## Evidence Matrix
<!-- evidence-row:before-screenshots -->
- Before screenshots: [before-state handoff-loss SVG](https://gist.githubusercontent.com/lalalune/86dc99e92f5820befe5bf2bc59ac59f5/raw/7760308dcbf2fccf043efdd5dd339416aa87e466/permission-handoff-before.svg) showing the merged #14906 payload drop: the top-level permission field never reached Settings, so no targeted modal could open.
<!-- evidence-row:after-screenshots -->
- After screenshots: [permission handoff contact sheet](https://gist.githubusercontent.com/lalalune/86dc99e92f5820befe5bf2bc59ac59f5/raw/74c63d1fac690e12042a1dcc304760f99ed9c146/permission-handoff-contact-sheet.svg) from the real-browser permission-priming e2e.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: [embedded WebM walkthrough HTML](https://gist.githubusercontent.com/lalalune/86dc99e92f5820befe5bf2bc59ac59f5/raw/7d47b99a24fef342c1841cc5c11a2dc7a27feadb/permission-handoff-walkthrough.html).
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - focused route test proves `POST /api/views/settings/navigate` echoes/broadcasts `payload.permissionRequest.permission`; no live server was required for this route-contract change.
<!-- evidence-row:frontend-logs -->
- Frontend logs: N/A - `test:permission-priming-e2e` completed with `no page errors (0)`; manual visual review confirmed desktop soft ask and mobile denied recovery state fit without overlap.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no model prompt/planner path changed; this repairs deterministic SETTINGS action payload plumbing and UI consumption.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: [visual evidence summary](https://gist.githubusercontent.com/lalalune/86dc99e92f5820befe5bf2bc59ac59f5/raw/6727b6a62efb8ffbe4f60dbbffcfd9575dab5783/permission-handoff-summary.md); unit tests cover route payload, WS normalization, App handoff, Settings validation, and app-control not-applicable fallback.
