### PR TITLE
feat(telegram): bundle default app credentials for personal-account login

### DIFF
--- a/plugins/plugin-telegram/src/account-setup-routes.test.ts
+++ b/plugins/plugin-telegram/src/account-setup-routes.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit coverage for `resolveTelegramAppCredentials` — the three-tier MTProto
+ * app-credential precedence (per-account config → deployment settings → bundled
+ * default) that keeps personal-account login off the broken my.telegram.org
+ * scrape. Deterministic: a plain fake runtime whose `getSetting` reads a map, no
+ * network and no real model. The resolver is pure, so it runs under the
+ * package's global `@elizaos/core` stub (`__tests__/core-test-mock.ts`).
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+
+import { resolveTelegramAppCredentials } from "./account-setup-routes.ts";
+
+const BUNDLED = { apiId: 2040, apiHash: "b18441a1ff607e10a989891a5462e627" };
+
+function makeRuntime(settings: Record<string, string> = {}): IAgentRuntime {
+  return {
+    getSetting: (key: string) => settings[key] ?? null,
+  } as unknown as IAgentRuntime;
+}
+
+describe("resolveTelegramAppCredentials", () => {
+  it("prefers per-account configured creds (string appId)", () => {
+    const creds = resolveTelegramAppCredentials(makeRuntime(), {
+      appId: "12345",
+      appHash: "cfgHashcfgHashcfgHashcfgHashcfg1",
+    });
+    expect(creds).toEqual({
+      apiId: 12345,
+      apiHash: "cfgHashcfgHashcfgHashcfgHashcfg1",
+    });
+  });
+
+  it("accepts a numeric configured appId and trims the hash", () => {
+    const creds = resolveTelegramAppCredentials(makeRuntime(), {
+      appId: 67890,
+      appHash: "  spacedHashspacedHashspacedHas  ",
+    });
+    expect(creds).toEqual({
+      apiId: 67890,
+      apiHash: "spacedHashspacedHashspacedHas",
+    });
+  });
+
+  it("falls through to TELEGRAM_APP_ID / TELEGRAM_APP_HASH settings when no config", () => {
+    const creds = resolveTelegramAppCredentials(
+      makeRuntime({
+        TELEGRAM_APP_ID: "555",
+        TELEGRAM_APP_HASH: "envHashenvHashenvHashenvHashenv1",
+      }),
+      {},
+    );
+    expect(creds).toEqual({
+      apiId: 555,
+      apiHash: "envHashenvHashenvHashenvHashenv1",
+    });
+  });
+
+  it("returns the bundled default when neither config nor settings resolve", () => {
+    expect(resolveTelegramAppCredentials(makeRuntime(), {})).toEqual(BUNDLED);
+  });
+
+  it("ignores a config with a blank appHash and uses the next tier", () => {
+    const creds = resolveTelegramAppCredentials(
+      makeRuntime({
+        TELEGRAM_APP_ID: "777",
+        TELEGRAM_APP_HASH: "envHashenvHashenvHashenvHashenv2",
+      }),
+      { appId: "12345", appHash: "   " },
+    );
+    expect(creds).toEqual({
+      apiId: 777,
+      apiHash: "envHashenvHashenvHashenvHashenv2",
+    });
+  });
+
+  it("ignores a non-numeric TELEGRAM_APP_ID and falls back to the bundled default", () => {
+    const creds = resolveTelegramAppCredentials(
+      makeRuntime({
+        TELEGRAM_APP_ID: "not-a-number",
+        TELEGRAM_APP_HASH: "envHashenvHashenvHashenvHashenv3",
+      }),
+      {},
+    );
+    expect(creds).toEqual(BUNDLED);
+  });
+
+  it("prefers configured creds over deployment settings when both are present", () => {
+    const creds = resolveTelegramAppCredentials(
+      makeRuntime({
+        TELEGRAM_APP_ID: "999",
+        TELEGRAM_APP_HASH: "envHashenvHashenvHashenvHashenv4",
+      }),
+      { appId: "12345", appHash: "cfgHashcfgHashcfgHashcfgHashcfg2" },
+    );
+    expect(creds).toEqual({
+      apiId: 12345,
+      apiHash: "cfgHashcfgHashcfgHashcfgHashcfg2",
+    });
+  });
+});

--- a/plugins/plugin-telegram/src/account-setup-routes.ts
+++ b/plugins/plugin-telegram/src/account-setup-routes.ts
@@ -176,6 +176,63 @@ function resolveConfiguredPhone(
     : null;
 }
 
+// Public Telegram Desktop app credentials (api_id 2040). api_id/api_hash
+// identify the CLIENT APP, not the user, and grant no account access on their
+// own — the minted StringSession is the real secret. Bundling a working default
+// makes personal-account onboarding zero-friction: the user never has to visit
+// my.telegram.org to register an app.
+//
+// Future option: instead of one shared bundled app, auto-fetch each user's OWN
+// api_id/api_hash by repairing the my.telegram.org scraper
+// (account-auth-service.ts getOrCreateProvisionedApp), whose HTML parser Telegram
+// broke. That path is only reached when NO credentials resolve here — which,
+// with this bundled default, is never — so it is documented, not wired.
+const BUNDLED_TELEGRAM_APP_ID = 2040;
+const BUNDLED_TELEGRAM_APP_HASH = "b18441a1ff607e10a989891a5462e627";
+
+/**
+ * Resolve the MTProto app credentials for the personal-account login, in
+ * priority order: (1) per-account configured creds (power users / own app
+ * identity), (2) deployment settings `TELEGRAM_APP_ID` / `TELEGRAM_APP_HASH`,
+ * (3) the bundled default. Never returns null, so the fragile my.telegram.org
+ * provisioning scrape is bypassed entirely. Exported for direct unit coverage
+ * of the three-tier precedence.
+ */
+export function resolveTelegramAppCredentials(
+  runtime: IAgentRuntime,
+  connConfig: Record<string, unknown>,
+): { apiId: number; apiHash: string } {
+  if (
+    (typeof connConfig.appId === "string" ||
+      typeof connConfig.appId === "number") &&
+    typeof connConfig.appHash === "string" &&
+    connConfig.appHash.trim().length > 0
+  ) {
+    return {
+      apiId: Number(connConfig.appId),
+      apiHash: connConfig.appHash.trim(),
+    };
+  }
+  const envId = runtime.getSetting("TELEGRAM_APP_ID");
+  const envHash = runtime.getSetting("TELEGRAM_APP_HASH");
+  const parsedEnvId =
+    typeof envId === "string" || typeof envId === "number"
+      ? Number(envId)
+      : Number.NaN;
+  if (
+    Number.isInteger(parsedEnvId) &&
+    parsedEnvId > 0 &&
+    typeof envHash === "string" &&
+    envHash.trim().length > 0
+  ) {
+    return { apiId: parsedEnvId, apiHash: envHash.trim() };
+  }
+  return {
+    apiId: BUNDLED_TELEGRAM_APP_ID,
+    apiHash: BUNDLED_TELEGRAM_APP_HASH,
+  };
+}
+
 function resolveService(
   runtime: IAgentRuntime,
 ): TelegramAccountRuntimeServiceLike | null {
@@ -377,16 +434,7 @@ async function handleStart(
     createSessionOptions(config),
   );
 
-  const credentials =
-    hasConfiguredTelegramAccount(connectorConfig) &&
-    (typeof connectorConfig.appId === "string" ||
-      typeof connectorConfig.appId === "number") &&
-    typeof connectorConfig.appHash === "string"
-      ? {
-          apiId: Number(connectorConfig.appId),
-          apiHash: connectorConfig.appHash,
-        }
-      : null;
+  const credentials = resolveTelegramAppCredentials(runtime, connectorConfig);
 
   try {
     await telegramAccountAuthSession.start({ phone, credentials });


### PR DESCRIPTION
## What

Adds bundled default MTProto app credentials to the Telegram **personal-account** (GramJS/MTProto) login so a user can connect a personal Telegram account **without first visiting my.telegram.org** to register an app.

The personal-account login route (`plugins/plugin-telegram/src/account-setup-routes.ts` `handleStart`) previously resolved app credentials **only** from the per-account `connectorConfig.appId`/`appHash`, falling back to `null`. A `null` credentials value pushes the login onto a my.telegram.org HTML-scrape provisioning path (`account-auth-service.ts` `getOrCreateProvisionedApp`) whose parser Telegram has broken — so onboarding a fresh account fails.

## How

New `resolveTelegramAppCredentials(runtime, connConfig)` resolver that **always** returns `{ apiId, apiHash }`, in priority order:

1. **Per-account configured creds** — `connConfig.appId` / `appHash` (power users bringing their own app identity).
2. **Deployment settings** — `TELEGRAM_APP_ID` / `TELEGRAM_APP_HASH` via `runtime.getSetting`.
3. **Bundled default** — Telegram Desktop's public `api_id` `2040` (`BUNDLED_TELEGRAM_APP_ID` / `BUNDLED_TELEGRAM_APP_HASH`).

`handleStart` now calls this resolver instead of the old `null`-fallback, so the fragile my.telegram.org scrape is never reached.

### Why a bundled `api_id`/`api_hash` is safe

`api_id`/`api_hash` identify the **client app**, not the user, and grant **no account access on their own** — the per-session MTProto `StringSession` minted during login is the real secret. Telegram Desktop's `api_id 2040` is public and is the standard value third-party clients bundle. Sharing one default app across installs does not share or expose any account.

### Future alternative (documented, not wired)

Instead of one shared bundled app, each user's **own** `api_id`/`api_hash` could be auto-fetched by repairing the my.telegram.org scraper (`account-auth-service.ts` `getOrCreateProvisionedApp`). That path is only reached when **no** credentials resolve — which, with the bundled default, is never — so it is documented in a code comment rather than wired.

`hasConfiguredTelegramAccount` is retained (still used by `statusFromState`).

## Testing

New unit suite `plugins/plugin-telegram/src/account-setup-routes.test.ts` asserts the three-tier precedence and edge cases: configured creds win (string + numeric `appId`, hash trimming), env settings are next, the bundled default is used when neither resolves, a blank configured `appHash` falls through, and a non-numeric `TELEGRAM_APP_ID` falls back to the bundled default.

```
# plugins/plugin-telegram
bun run typecheck                                  # clean (exit 0)
bunx biome check src/account-setup-routes.ts src/account-setup-routes.test.ts   # clean (exit 0)
bunx vitest run src/account-setup-routes.test.ts   # 7 passed (7)
bunx vitest run src/routes-e2e.test.ts             # 11 passed (11)  (real-dispatch, exercises handleStart)
bun run test                                       # 117 passed
```

N/A - no UI, model-trajectory, or on-device surface changes in this diff (pure server-side credential resolution). The one unrelated suite failure in a fully-offline worktree (`connector-sources.test.ts`, missing `BaseMessageAdapter` on the core test stub) is unchanged from `develop` and independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
