### PR TITLE
test(app): enforce packaged OCR fallback for visual QA

### DIFF
--- a/packages/app/scripts/lib/visual-qa.mjs
+++ b/packages/app/scripts/lib/visual-qa.mjs
@@ -170,8 +170,9 @@ async function ocrText(pngPath) {
         note: "tesseract CLI unavailable; OCR succeeded with tesseract.js",
       };
     } catch (fallbackError) {
-      // error-policy:J3 OCR is optional enrichment; report absence explicitly
-      // rather than fabricate an empty transcript as "no text on screen".
+      // error-policy:J3 OCR is required evidence; when both packaged engines
+      // fail, report the failure explicitly instead of presenting "no text" as
+      // a successful read.
       const primary =
         err?.code === "ENOENT"
           ? "tesseract CLI not installed"

--- a/packages/app/scripts/lib/visual-qa.test.ts
+++ b/packages/app/scripts/lib/visual-qa.test.ts
@@ -1,11 +1,12 @@
 // Unit tests for the visual-QA analyzer: colour fractions, dominant palette,
 // change-metric, and the pure expectation evaluator, all on synthetic
 // sharp-generated fixtures so they run deterministically in CI without a real
-// screenshot or tesseract. OCR itself is exercised via its documented
-// degradation contract (missing tesseract → explicit note, never a fake read).
-import { mkdtempSync } from "node:fs";
+// screenshot. OCR must remain packaged: the analyzer may prefer a system
+// tesseract binary, but the repo dependency fallback is part of the contract.
+import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import sharp from "sharp";
 import { afterAll, describe, expect, it } from "vitest";
 import {
@@ -17,6 +18,17 @@ import {
 } from "./visual-qa.mjs";
 
 const dir = mkdtempSync(join(tmpdir(), "visual-qa-"));
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const appPackageJson = JSON.parse(
+  readFileSync(resolve(__dirname, "../../package.json"), "utf8"),
+);
+const rootPackageJson = JSON.parse(
+  readFileSync(resolve(__dirname, "../../../../package.json"), "utf8"),
+);
+const rootLockfile = readFileSync(
+  resolve(__dirname, "../../../../bun.lock"),
+  "utf8",
+);
 const solid = async (name: string, r: number, g: number, b: number) => {
   const p = join(dir, name);
   await sharp({
@@ -116,6 +128,18 @@ describe("evaluateExpectation (pure gate logic)", () => {
 });
 
 describe("analyzeScreenshot end to end", () => {
+  it("keeps the packaged tesseract.js fallback available for required OCR", async () => {
+    expect(
+      appPackageJson.dependencies?.["tesseract.js"] ??
+        appPackageJson.devDependencies?.["tesseract.js"],
+    ).toBeTruthy();
+    expect(
+      rootPackageJson.dependencies?.["tesseract.js"] ??
+        rootPackageJson.devDependencies?.["tesseract.js"],
+    ).toBeTruthy();
+    expect(rootLockfile).toContain('"tesseract.js": ["tesseract.js@');
+  });
+
   it("flags a blue screen as a brand:no_blue failure with a real palette", async () => {
     const report = await analyzeScreenshot(
       await solid("bluescreen.png", 20, 40, 210),
@@ -126,9 +150,8 @@ describe("analyzeScreenshot end to end", () => {
     expect(report.verdict).toBe("fail");
     expect(report.color_fractions.blue_fraction).toBeGreaterThan(0.9);
     expect(report.dominant_palette[0].fraction).toBeGreaterThan(0.9);
-    // OCR is optional enrichment: text is always a string, and ocr_note is
-    // either null (tesseract ran) or a non-empty reason string (it could not),
-    // never a fabricated empty read presented as success.
+    // OCR must either produce text or name the engine failure; it must never
+    // fabricate an empty read as a successful "no text on screen" result.
     expect(typeof report.ocr_text).toBe("string");
     expect(
       report.ocr_note === null || typeof report.ocr_note === "string",


### PR DESCRIPTION
## Summary
- follow up #14937 by changing the remaining OCR wording from optional enrichment to required evidence
- add a regression test that verifies the app package, root package, and lockfile all keep tesseract.js available for the required OCR fallback

This makes the OCR path fail mechanically if the packaged fallback is removed, instead of silently relying on a system tesseract install.

## Evidence Gate
<!-- evidence-row:before-screenshots -->
- [x] N/A - audit tooling/test wording only; no product UI surface changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - audit tooling/test wording only; no product UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing interaction changed; focused tests verify OCR packaging enforcement.
<!-- evidence-row:backend-logs -->
- [x] N/A - no backend code changed.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend runtime flow changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persistent domain artifacts are produced; the durable artifact is the dependency/lockfile guard.

## Verification
- node --check packages/app/scripts/lib/visual-qa.mjs && node --check packages/app/scripts/visual-qa-live.mjs: passed.
- bunx vitest run packages/app/scripts/visual-qa-live.test.mjs packages/app/scripts/lib/visual-qa.test.ts: 2 files, 29 tests passed.
- bunx @biomejs/biome check packages/app/scripts/visual-qa-live.mjs packages/app/scripts/visual-qa-live.test.mjs packages/app/scripts/lib/visual-qa.mjs packages/app/scripts/lib/visual-qa.test.ts: passed.
- git diff --check origin/develop...HEAD: passed.
- bun run audit:error-policy-ratchet --report: passed, no changed production source files.