### PR TITLE
fix(cloud): forward inbound Origin through the embedded Steward proxy (unblocks SIWE/SIWS nonce)

### DIFF
--- a/packages/cloud/api/__tests__/steward-embedded-origin-forward.test.ts
+++ b/packages/cloud/api/__tests__/steward-embedded-origin-forward.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Regression: the embedded Steward proxy must forward an `Origin` upstream so
+ * Steward's origin-gated auth checks pass through the same-origin proxy.
+ *
+ * Steward's SIWE/SIWS `GET /auth/nonce` rejects a request carrying neither an
+ * allowed `Origin` nor `Referer` ("SIWE nonce requests require an allowed
+ * Origin or Referer"). The SDK calls Steward through this SAME-ORIGIN proxy,
+ * so on that GET the browser sends no `Origin`, and `Referer` is a
+ * fetch-forbidden header that never survives the Worker subrequest — Steward
+ * saw neither and 400'd every wallet sign-in (prod + staging; the old
+ * cloud-frontend e2e mocked `/auth/nonce`, so it went unnoticed).
+ *
+ * The proxy is authoritative for the host the browser connected to, so it
+ * stamps that host as `Origin` when the client didn't send one, and preserves
+ * a real client `Origin` when present.
+ */
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { AppEnv } from "@/types/cloud-worker-env";
+import { embeddedStewardHandler } from "../src/steward/embedded";
+
+const UPSTREAM = "https://steward.example.test";
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function makeApp() {
+  const app = new Hono<AppEnv>();
+  app.use(async (c, next) => {
+    c.env = {
+      STEWARD_API_URL: UPSTREAM,
+      STEWARD_TENANT_ID: "elizacloud-staging",
+    } as AppEnv["Bindings"];
+    await next();
+  });
+  app.all("/steward/*", embeddedStewardHandler);
+  return app;
+}
+
+let lastUpstreamOrigin: string | null = null;
+
+beforeEach(() => {
+  lastUpstreamOrigin = null;
+  globalThis.fetch = (async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const h = new Headers(init?.headers ?? {});
+    lastUpstreamOrigin = h.get("origin");
+    void input;
+    return new Response(JSON.stringify({ ok: true, nonce: "n" }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+describe("embedded Steward proxy — Origin forwarding (SIWE nonce fix)", () => {
+  it("stamps the inbound host as Origin on a GET nonce when the client sent none", async () => {
+    const app = makeApp();
+    // Same-origin GET nonce: a real browser sends NO Origin here.
+    const res = await app.request(
+      "https://staging.elizacloud.ai/steward/auth/nonce",
+    );
+
+    expect(res.status).toBe(200);
+    // Steward now receives a concrete, trusted origin instead of nothing.
+    expect(lastUpstreamOrigin).toBe("https://staging.elizacloud.ai");
+  });
+
+  it("preserves a real client Origin instead of overwriting it", async () => {
+    const app = makeApp();
+    const res = await app.request(
+      "https://staging.elizacloud.ai/steward/auth/nonce",
+      { headers: { origin: "https://app-staging.elizacloud.ai" } },
+    );
+
+    expect(res.status).toBe(200);
+    // The browser's genuine Origin wins — we only fill the gap.
+    expect(lastUpstreamOrigin).toBe("https://app-staging.elizacloud.ai");
+  });
+
+  it("uses the prod host on a prod-origin request", async () => {
+    const app = makeApp();
+    const res = await app.request("https://elizacloud.ai/steward/auth/nonce");
+
+    expect(res.status).toBe(200);
+    expect(lastUpstreamOrigin).toBe("https://elizacloud.ai");
+  });
+});

--- a/packages/cloud/api/__tests__/steward-embedded-origin-forward.test.ts
+++ b/packages/cloud/api/__tests__/steward-embedded-origin-forward.test.ts
@@ -15,19 +15,30 @@
  * a real client `Origin` when present.
  */
 import { Hono } from "hono";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppEnv } from "@/types/cloud-worker-env";
-import { embeddedStewardHandler } from "../src/steward/embedded";
+
+vi.mock("@/lib/utils/logger", () => ({
+  logger: {
+    debug: () => undefined,
+    error: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+  },
+}));
+
+const { embeddedStewardHandler } = await import("../src/steward/embedded");
 
 const UPSTREAM = "https://steward.example.test";
 const ORIGINAL_FETCH = globalThis.fetch;
 
-function makeApp() {
+function makeApp(env: Partial<AppEnv["Bindings"]> = {}) {
   const app = new Hono<AppEnv>();
   app.use(async (c, next) => {
     c.env = {
       STEWARD_API_URL: UPSTREAM,
       STEWARD_TENANT_ID: "elizacloud-staging",
+      ...env,
     } as AppEnv["Bindings"];
     await next();
   });
@@ -36,16 +47,35 @@ function makeApp() {
 }
 
 let lastUpstreamOrigin: string | null = null;
+let lastUpstreamSignature: string | null = null;
+let lastUpstreamTenant: string | null = null;
+let lastUpstreamIdempotencyKey: string | null = null;
+let lastUpstreamMethod: string | null = null;
+let lastUpstreamUrl: string | null = null;
 
 beforeEach(() => {
   lastUpstreamOrigin = null;
+  lastUpstreamSignature = null;
+  lastUpstreamTenant = null;
+  lastUpstreamIdempotencyKey = null;
+  lastUpstreamMethod = null;
+  lastUpstreamUrl = null;
   globalThis.fetch = (async (
     input: RequestInfo | URL,
     init?: RequestInit,
   ): Promise<Response> => {
     const h = new Headers(init?.headers ?? {});
     lastUpstreamOrigin = h.get("origin");
-    void input;
+    lastUpstreamSignature = h.get("x-steward-signature");
+    lastUpstreamTenant = h.get("x-steward-tenant");
+    lastUpstreamIdempotencyKey = h.get("idempotency-key");
+    lastUpstreamMethod = init?.method ?? null;
+    lastUpstreamUrl =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
     return new Response(JSON.stringify({ ok: true, nonce: "n" }), {
       status: 200,
       headers: { "content-type": "application/json" },
@@ -88,5 +118,27 @@ describe("embedded Steward proxy — Origin forwarding (SIWE nonce fix)", () => 
 
     expect(res.status).toBe(200);
     expect(lastUpstreamOrigin).toBe("https://elizacloud.ai");
+  });
+
+  it("stamps Origin before signing mutating requests without dropping signature headers", async () => {
+    const app = makeApp({ STEWARD_REQUEST_SIGNING_SECRET: "test-secret" });
+    const res = await app.request(
+      "https://staging.elizacloud.ai/steward/auth/email/send",
+      {
+        method: "POST",
+        body: JSON.stringify({ email: "user@example.com" }),
+        headers: { "content-type": "application/json" },
+      },
+    );
+
+    expect(res.status).toBe(200);
+    expect(lastUpstreamUrl).toBe(`${UPSTREAM}/auth/email/send`);
+    expect(lastUpstreamMethod).toBe("POST");
+    expect(lastUpstreamOrigin).toBe("https://staging.elizacloud.ai");
+    expect(lastUpstreamTenant).toBe("elizacloud-staging");
+    expect(lastUpstreamIdempotencyKey).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+    expect(lastUpstreamSignature).toMatch(/^v1=[0-9a-f]{64}$/);
   });
 });

--- a/packages/cloud/api/src/steward/embedded.ts
+++ b/packages/cloud/api/src/steward/embedded.ts
@@ -282,6 +282,23 @@ export const embeddedStewardHandler: MiddlewareHandler<AppEnv> = async (c) => {
   // upstream fetch sets its own.
   headers.delete("host");
 
+  // Forward the real inbound origin so Steward's origin-gated auth checks pass.
+  // Steward's SIWE/SIWS `GET /auth/nonce` rejects a request that carries
+  // neither an allowed `Origin` nor `Referer` ("SIWE nonce requests require an
+  // allowed Origin or Referer"). The SDK calls Steward through THIS same-origin
+  // proxy, so on that GET the browser sends no `Origin` at all, and its
+  // `Referer` is a fetch-forbidden header that never survives the Worker
+  // subrequest — Steward saw neither and 400'd EVERY wallet sign-in, on prod as
+  // well as staging (the old cloud-frontend e2e mocked `/auth/nonce`, so this
+  // went unnoticed). This proxy is authoritative for the host the browser
+  // connected to, so stamp that host as `Origin` whenever the client didn't
+  // send one. Only fills the gap — a real browser `Origin` (cross-origin/POST
+  // legs) is preserved. `Origin` is not part of the signed canonical request
+  // (see the hashed-header set above), so this is safe for signed mutating legs.
+  if (!headers.has("origin")) {
+    headers.set("origin", url.origin);
+  }
+
   // Pin the tenant per-env. Steward's email/passkey routes resolve tenant
   // from `X-Steward-Tenant || body.tenantId || STEWARD_DEFAULT_TENANT_ID`
   // (auth.ts:2171,2200,2246), so forcing the header keeps those flows scoped


### PR DESCRIPTION
## The bug (found via the wallet-signin E2E)
Wallet sign-in 400s at the **first** step, on **prod and staging**:
```
GET /steward/auth/nonce → {"ok":false,"error":"SIWE nonce requests require an allowed Origin or Referer"}
```

## Root cause
The `@stwd/sdk` calls Steward through this **same-origin proxy**, so on the nonce GET the browser sends **no `Origin`** (same-origin GETs don't), and its `Referer` is a **fetch-forbidden header** that never survives the Worker subrequest. Steward received neither → rejected every wallet sign-in. The old cloud-frontend e2e **mocked `/auth/nonce`**, so the real endpoint was never exercised and this shipped unnoticed.

## Fix
The proxy is authoritative for the host the browser connected to, so stamp that host as `Origin` on the upstream request **when the client didn't send one** (a genuine browser `Origin` on cross-origin/POST legs is preserved). `Origin` is **not** part of the signed canonical request (checked against the hashed-header set), so signed mutating legs are unaffected.

## Evidence
- Injected-wallet E2E against **live staging** (fresh keypair, real viem/ed25519 signatures) reaches this exact nonce gate and gets the 400 — confirming the client flow is correct and the block is server-side (screenshots on #14901).
- Direct curl reproduces the 400 on prod `api.elizacloud.ai` too.
- Unit test: origin absent → inbound host stamped; present → preserved; prod host on prod origin. **3/3.**

**Depends on / unblocks:** the wallet UI #14901. This is the server-side half; together they make wallet sign-in actually complete. Needs a **cloud-api Worker deploy** to verify live (I'll re-run the E2E post-deploy). If Steward's own allowlist also excludes our origins, that's a follow-up on the Steward config — but the proxy MUST forward an origin regardless.

https://claude.ai/code/session_01CpnRyFUuGvzz61SsrnC3Sd

## Verification update - 2026-07-06

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend-only Cloudflare Worker proxy change; no user-visible UI existed before this patch.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend-only Cloudflare Worker proxy change; no rendered app surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no interactive UI flow changed in this PR; the affected surface is the /steward Worker proxy request path.
<!-- evidence-row:backend-logs -->
- [x] N/A - no deployed backend runtime log artifact is available before Worker deploy; local backend verification logs were reviewed: `bun test __tests__/steward-embedded-origin-forward.test.ts` passed 3/3, `bun run typecheck` passed including `wrangler deploy --env production --dry-run --outdir .wrangler-dry-run`, and `bun run audit:error-policy-ratchet --report` passed with no new fallback slop.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser console/network surface changed; this PR only changes `packages/cloud/api/src/steward/embedded.ts`.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no model, prompt, provider, action, or trajectory-producing code path changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifact: regression test captures the upstream Steward request headers and proves nonce requests now receive `Origin: https://staging.elizacloud.ai`, explicit client origins are preserved, and prod-origin requests receive `Origin: https://elizacloud.ai`; no DB rows, migrations, billing, or durable storage artifacts are produced by this proxy-header change.

