### PR TITLE
test(cloud): pin my-agents malformed create validation

### DIFF
--- a/packages/cloud/api/test/e2e/group-c-agents.test.ts
+++ b/packages/cloud/api/test/e2e/group-c-agents.test.ts
@@ -632,17 +632,23 @@ describeE2E("/api/my-agents/characters", () => {
     expect(body.data?.pagination?.page).toBe(1);
   });
 
-  test("POST with malformed body returns 500 (create fails at the DB layer)", async () => {
-    // Missing the required `name` field — the handler casts to ElizaCharacter
-    // without route-layer validation, so the insert fails in the repository.
-    // Current contract: 500. A route-layer validator would make this a 400;
-    // update this pin when one lands.
+  test("POST with malformed body returns 400 validation error", async () => {
+    // Missing the required `name` field. The character service rejects it as a
+    // caller validation error before any DB insert is attempted.
     const res = await api.post(
       "/api/my-agents/characters",
       { nope: "no name here" },
       { headers: bearerHeaders() },
     );
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      success?: boolean;
+      error?: string;
+      code?: string;
+    };
+    expect(body.success).toBe(false);
+    expect(body.code).toBe("validation_error");
+    expect(body.error).toMatch(/invalid name/i);
   });
 });
 


### PR DESCRIPTION
## Summary

Updates the Cloud API group-c e2e contract for `POST /api/my-agents/characters` with a malformed body. The route now returns the service-level validation response (`400` / `validation_error`) for a missing required `name`, but the deploy e2e still expected the old DB-layer `500`.

This is the failure that blocked the API Worker deploy in Cloud CF Deploy run `28770610742`: `Expected: 500`, `Received: 400` at `packages/cloud/api/test/e2e/group-c-agents.test.ts:645`.

## Validation

- `bunx @biomejs/biome check packages/cloud/api/test/e2e/group-c-agents.test.ts`
- `git diff --check`
- `TEST_PGLITE_PERSIST=1 E2E_ONLY=group-c bun run --cwd packages/cloud/api test:e2e --filter 'POST with malformed body returns 400 validation error'`
  - Result: `84 pass`, `0 fail`, `111 expect() calls`

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - test-only Cloud API e2e contract update; no UI surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - test-only Cloud API e2e contract update; no UI surface changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no user-facing flow changed; this only updates a deploy-suite assertion`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no runtime backend implementation changed; local filtered e2e output is summarized in Validation`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend code path changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent, action, provider, prompt, or model behavior changed`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no DB rows, generated assets, wallet/on-chain outputs, memories, or scheduled tasks produced`.

## Notes

Local e2e setup required the same generated/build artifacts CI normally has before this suite: generated i18n keyword data plus built `@elizaos/cloud-routing`/`@elizaos/core`. No generated or build artifacts are included in this PR.
