### PR TITLE
fix(app-control): wire voice settings action

### DIFF
--- a/plugins/plugin-app-control/src/actions/settings.test.ts
+++ b/plugins/plugin-app-control/src/actions/settings.test.ts
@@ -247,8 +247,7 @@ describe("registry completeness", () => {
 			).toBeTruthy();
 		}
 		expect(SETTINGS_WRITE_REGISTRY.voice).toMatchObject({
-			kind: "unwired",
-			trackingIssue: 14910,
+			kind: "route",
 		});
 		expect(SETTINGS_WRITE_REGISTRY["wallet-rpc"]).toMatchObject({
 			kind: "route",
@@ -291,6 +290,8 @@ describe("SETTINGS action: list", () => {
 		expect(permissions).toMatchObject({ writable: true, via: "SETTINGS" });
 		const appearance = sections.find((s) => s.id === "appearance");
 		expect(appearance).toMatchObject({ writable: true, via: "SETTINGS" });
+		const voice = sections.find((s) => s.id === "voice");
+		expect(voice).toMatchObject({ writable: true, via: "SETTINGS" });
 		const capabilities = sections.find((s) => s.id === "capabilities");
 		expect(capabilities).toMatchObject({ writable: true, via: "SETTINGS" });
 		const walletRpc = sections.find((s) => s.id === "wallet-rpc");
@@ -400,6 +401,151 @@ describe("SETTINGS action: set on an owned route section", () => {
 		expect(routeFetch).not.toHaveBeenCalled();
 		expect(result?.success).toBe(false);
 		expect(texts.join(" ")).toContain("supported appearance value");
+	});
+
+	it("updates voice continuous-chat mode through the config route", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async (request) => {
+			if (request.method === "GET") {
+				return {
+					ok: true,
+					data: {
+						messages: {
+							existing: { keep: true },
+							voice: {
+								continuous: "off",
+								vadAutoStop: {
+									silenceMs: 900,
+									speechRmsThreshold: 0.006,
+								},
+							},
+						},
+					},
+				};
+			}
+			return { ok: true };
+		});
+		const { result, texts } = await invoke(
+			{
+				action: "set",
+				section: "voice",
+				key: "continuous",
+				value: "always-on",
+			},
+			routeFetch,
+		);
+		expect(routeFetch).toHaveBeenNthCalledWith(1, {
+			method: "GET",
+			path: "/api/config",
+		});
+		expect(routeFetch).toHaveBeenNthCalledWith(2, {
+			method: "PUT",
+			path: "/api/config",
+			body: {
+				messages: {
+					existing: { keep: true },
+					voice: {
+						continuous: "always-on",
+						vadAutoStop: {
+							silenceMs: 900,
+							speechRmsThreshold: 0.006,
+						},
+					},
+				},
+			},
+		});
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({
+			section: "voice",
+			key: "continuous",
+		});
+		expect(texts.join(" ")).toContain("continuous chat is always-on");
+	});
+
+	it("updates voice VAD silence while preserving existing voice prefs", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async (request) => {
+			if (request.method === "GET") {
+				return {
+					ok: true,
+					data: {
+						messages: {
+							voice: {
+								continuous: "vad-gated",
+								vadAutoStop: {
+									silenceMs: 900,
+									speechRmsThreshold: 0.006,
+								},
+							},
+						},
+					},
+				};
+			}
+			return { ok: true };
+		});
+		const { result } = await invoke(
+			{
+				action: "set",
+				section: "voice",
+				key: "silence-ms",
+				value: "1200",
+			},
+			routeFetch,
+		);
+		expect(routeFetch).toHaveBeenNthCalledWith(2, {
+			method: "PUT",
+			path: "/api/config",
+			body: {
+				messages: {
+					voice: {
+						continuous: "vad-gated",
+						vadAutoStop: {
+							silenceMs: 1200,
+							speechRmsThreshold: 0.006,
+						},
+					},
+				},
+			},
+		});
+		expect(result?.success).toBe(true);
+	});
+
+	it("rejects out-of-range voice VAD values before writing", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({
+			ok: true,
+			data: { messages: { voice: { continuous: "off" } } },
+		}));
+		const { result, texts } = await invoke(
+			{
+				action: "set",
+				section: "voice",
+				key: "rms",
+				value: "0.2",
+			},
+			routeFetch,
+		);
+		expect(routeFetch).toHaveBeenCalledTimes(1);
+		expect(result?.success).toBe(false);
+		expect(texts.join(" ")).toContain("between 0.001 and 0.02");
+	});
+
+	it("surfaces voice config backend failures instead of fabricating success", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async (request) => {
+			if (request.method === "GET") {
+				return { ok: true, data: { messages: {} } };
+			}
+			return { ok: false, detail: "config save failed" };
+		});
+		const { result, texts } = await invoke(
+			{
+				action: "set",
+				section: "voice",
+				key: "continuous-chat",
+				value: "vad",
+			},
+			routeFetch,
+		);
+		expect(routeFetch).toHaveBeenCalledTimes(2);
+		expect(result?.success).toBe(false);
+		expect(texts.join(" ")).toContain("config save failed");
 	});
 
 	it("dispatches permissions shell off through the backend route", async () => {

--- a/plugins/plugin-app-control/src/actions/settings.ts
+++ b/plugins/plugin-app-control/src/actions/settings.ts
@@ -644,6 +644,199 @@ const APPEARANCE_HOME_TIME_WIDGET_KEY: SettingsWritableKey = {
 			: "Home time/date widget is hidden.",
 };
 
+type VoiceContinuousMode = "off" | "vad-gated" | "always-on";
+
+interface VoiceVadAutoStopPrefs {
+	silenceMs: number;
+	speechRmsThreshold: number;
+}
+
+interface VoiceSettingsPrefs {
+	continuous: VoiceContinuousMode;
+	vadAutoStop: VoiceVadAutoStopPrefs;
+}
+
+const VOICE_CONTINUOUS_ALIASES: ReadonlyMap<string, VoiceContinuousMode> =
+	new Map([
+		["off", "off"],
+		["push-to-talk", "off"],
+		["ptt", "off"],
+		["manual", "off"],
+		["vad", "vad-gated"],
+		["vad-gated", "vad-gated"],
+		["gated", "vad-gated"],
+		["hands-free", "vad-gated"],
+		["handsfree", "vad-gated"],
+		["always-on", "always-on"],
+		["always", "always-on"],
+		["continuous", "always-on"],
+		["on", "always-on"],
+	]);
+
+const DEFAULT_VOICE_SETTINGS_PREFS: VoiceSettingsPrefs = {
+	continuous: "off",
+	vadAutoStop: {
+		silenceMs: 900,
+		speechRmsThreshold: 0.006,
+	},
+};
+
+const VOICE_VAD_SILENCE_MIN_MS = 300;
+const VOICE_VAD_SILENCE_MAX_MS = 3000;
+const VOICE_VAD_RMS_MIN = 0.001;
+const VOICE_VAD_RMS_MAX = 0.02;
+
+function readPlainObject(value: unknown): Record<string, unknown> | null {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null;
+}
+
+function readVoiceVadAutoStop(value: unknown): VoiceVadAutoStopPrefs {
+	const stored = readPlainObject(value);
+	const silenceMs = stored?.silenceMs;
+	const speechRmsThreshold = stored?.speechRmsThreshold;
+	return {
+		silenceMs:
+			typeof silenceMs === "number" && Number.isFinite(silenceMs)
+				? silenceMs
+				: DEFAULT_VOICE_SETTINGS_PREFS.vadAutoStop.silenceMs,
+		speechRmsThreshold:
+			typeof speechRmsThreshold === "number" &&
+			Number.isFinite(speechRmsThreshold)
+				? speechRmsThreshold
+				: DEFAULT_VOICE_SETTINGS_PREFS.vadAutoStop.speechRmsThreshold,
+	};
+}
+
+function readVoiceSettingsPrefs(config: unknown): VoiceSettingsPrefs {
+	const root = readPlainObject(config) ?? {};
+	const messages = readPlainObject(root.messages) ?? {};
+	const voice = readPlainObject(messages.voice) ?? {};
+	const continuous =
+		typeof voice.continuous === "string"
+			? VOICE_CONTINUOUS_ALIASES.get(voice.continuous)
+			: undefined;
+	return {
+		continuous: continuous ?? DEFAULT_VOICE_SETTINGS_PREFS.continuous,
+		vadAutoStop: readVoiceVadAutoStop(voice.vadAutoStop),
+	};
+}
+
+function readConfigMessages(config: unknown): Record<string, unknown> {
+	return readPlainObject(readPlainObject(config)?.messages) ?? {};
+}
+
+function normalizeVoiceContinuousMode(
+	value: string | null,
+): VoiceContinuousMode | null {
+	if (!value) return null;
+	return VOICE_CONTINUOUS_ALIASES.get(value.trim().toLowerCase()) ?? null;
+}
+
+function parseBoundedNumber(args: {
+	value: string | null;
+	min: number;
+	max: number;
+	label: string;
+}): number | string {
+	if (!args.value) return `provide ${args.label}=<number>`;
+	const parsed = Number(args.value);
+	if (!Number.isFinite(parsed)) return `${args.label} must be a number`;
+	if (parsed < args.min || parsed > args.max) {
+		return `${args.label} must be between ${args.min} and ${args.max}`;
+	}
+	return parsed;
+}
+
+function buildVoiceSettingsPrefs(
+	current: VoiceSettingsPrefs,
+	keyName: string,
+	value: string | null,
+): VoiceSettingsPrefs | string {
+	const normalizedKey = keyName.trim().toLowerCase();
+	if (
+		normalizedKey === "continuous" ||
+		normalizedKey === "continuous-chat" ||
+		normalizedKey === "mode"
+	) {
+		const continuous = normalizeVoiceContinuousMode(value);
+		if (!continuous) {
+			return "provide value=off|vad-gated|always-on for voice continuous chat";
+		}
+		return { ...current, continuous };
+	}
+
+	if (
+		normalizedKey === "silence" ||
+		normalizedKey === "silence-ms" ||
+		normalizedKey === "vad-silence" ||
+		normalizedKey === "end-of-turn"
+	) {
+		const silenceMs = parseBoundedNumber({
+			value,
+			min: VOICE_VAD_SILENCE_MIN_MS,
+			max: VOICE_VAD_SILENCE_MAX_MS,
+			label: "silenceMs",
+		});
+		if (typeof silenceMs === "string") return silenceMs;
+		return {
+			...current,
+			vadAutoStop: { ...current.vadAutoStop, silenceMs },
+		};
+	}
+
+	if (
+		normalizedKey === "rms" ||
+		normalizedKey === "sensitivity" ||
+		normalizedKey === "speech-threshold" ||
+		normalizedKey === "vad-rms"
+	) {
+		const speechRmsThreshold = parseBoundedNumber({
+			value,
+			min: VOICE_VAD_RMS_MIN,
+			max: VOICE_VAD_RMS_MAX,
+			label: "speechRmsThreshold",
+		});
+		if (typeof speechRmsThreshold === "string") return speechRmsThreshold;
+		return {
+			...current,
+			vadAutoStop: { ...current.vadAutoStop, speechRmsThreshold },
+		};
+	}
+
+	return "provide key=continuous|silence-ms|rms";
+}
+
+const VOICE_PREFS_KEY: SettingsWritableKey = {
+	description:
+		"Voice continuous-chat mode and VAD end-of-turn thresholds persisted under messages.voice through /api/config.",
+	valueType: "command",
+	apply: async ({ keyName, request, routeFetch }) => {
+		const current = await routeFetch({ method: "GET", path: "/api/config" });
+		if (!current.ok) return current;
+		if (!readPlainObject(current.data)) {
+			return { ok: false, detail: "config route returned an invalid object" };
+		}
+
+		const previous = readVoiceSettingsPrefs(current.data);
+		const next = buildVoiceSettingsPrefs(previous, keyName, request.value);
+		if (typeof next === "string") return { ok: false, detail: next };
+
+		const messages = readConfigMessages(current.data);
+		const outcome = await routeFetch({
+			method: "PUT",
+			path: "/api/config",
+			body: { messages: { ...messages, voice: next } },
+		});
+		return outcome.ok ? { ...outcome, data: next } : outcome;
+	},
+	successText: (_value, _request, outcome) => {
+		const next = readVoiceSettingsPrefs({ messages: { voice: outcome.data } });
+		return `Voice settings updated: continuous chat is ${next.continuous}, silence is ${next.vadAutoStop.silenceMs}ms, speech threshold is ${next.vadAutoStop.speechRmsThreshold}.`;
+	},
+};
+
 const WALLET_RPC_CHAIN_ALIASES: ReadonlyMap<string, WalletRpcChain> = new Map([
 	["evm", "evm"],
 	["eth", "evm"],
@@ -1068,10 +1261,22 @@ export const SETTINGS_WRITE_REGISTRY: Readonly<
 			"Security posture and host password status; password changes are deliberately not chat-writable because secrets must not flow through the model.",
 	},
 	voice: {
-		kind: "unwired",
-		reason:
-			"Voice enable/config is not yet exposed as a semantic action; it currently lives behind the voice section controls.",
-		trackingIssue: 14910,
+		kind: "route",
+		summary:
+			"Voice continuous-chat mode and VAD end-of-turn thresholds. Wake word remains a device-local toggle in Settings because it is not backed by a loopback route.",
+		keys: {
+			continuous: VOICE_PREFS_KEY,
+			"continuous-chat": VOICE_PREFS_KEY,
+			mode: VOICE_PREFS_KEY,
+			silence: VOICE_PREFS_KEY,
+			"silence-ms": VOICE_PREFS_KEY,
+			"vad-silence": VOICE_PREFS_KEY,
+			"end-of-turn": VOICE_PREFS_KEY,
+			rms: VOICE_PREFS_KEY,
+			sensitivity: VOICE_PREFS_KEY,
+			"speech-threshold": VOICE_PREFS_KEY,
+			"vad-rms": VOICE_PREFS_KEY,
+		},
 	},
 	capabilities: {
 		kind: "route",
@@ -1580,13 +1785,17 @@ export function createSettingsAction(deps: SettingsActionDeps = {}): Action {
 			"UPDATE_STATUS",
 			"APPLY_UPDATE",
 			"CHANGE_UPDATE_CHANNEL",
+			"VOICE_SETTINGS",
+			"VOICE_CONTINUOUS_CHAT",
+			"VOICE_END_OF_TURN",
+			"VOICE_VAD_SETTINGS",
 		],
 		description:
-			"Change a built-in settings VALUE or run a built-in settings operation from chat — most importantly turning OS/runtime permissions like shell access on/off via section=permissions key=shell, requesting OS permissions via section=permissions key=request permission=microphone|camera|location|notifications|screen-recording, changing appearance values via section=appearance key=theme|accent|language|home-time-widget, turning automatic training on/off via section=capabilities key=auto-training, toggling the wallet/browser/computer-use capabilities via section=capabilities key=wallet|browser|computer-use value=on|off, selecting wallet RPC providers via section=wallet-rpc key=evm|bsc|solana value=<provider> or key=cloud, granting/revoking an app permission namespace via section=app-permissions app=<slug> key=fs|net value=on|off, creating/restoring local agent backups via section=advanced key=create-backup|restore-backup, and checking/reporting connected-agent updates via section=updates key=status|check|channel|apply. Restore requires fileName and confirm=true. Update channel requires value=stable|beta|nightly. Also reads (`action=get`) or lists (`action=list`) which settings are changeable. `action=set` writes an owned section or points to the dedicated action that owns a delegated section (models→MODEL_SWITCH, background→BACKGROUND, identity→CHARACTER, connectors→PLUGIN, secrets→SECRETS). This CHANGES a setting's value or runs an explicit settings operation; opening a settings page without changing anything is VIEWS. Never fill a settings field with agent-fill.",
+			"Change a built-in settings VALUE or run a built-in settings operation from chat — most importantly turning OS/runtime permissions like shell access on/off via section=permissions key=shell, requesting OS permissions via section=permissions key=request permission=microphone|camera|location|notifications|screen-recording, changing appearance values via section=appearance key=theme|accent|language|home-time-widget, changing voice continuous-chat/end-of-turn prefs via section=voice key=continuous|silence-ms|rms, turning automatic training on/off via section=capabilities key=auto-training, toggling the wallet/browser/computer-use capabilities via section=capabilities key=wallet|browser|computer-use value=on|off, selecting wallet RPC providers via section=wallet-rpc key=evm|bsc|solana value=<provider> or key=cloud, granting/revoking an app permission namespace via section=app-permissions app=<slug> key=fs|net value=on|off, creating/restoring local agent backups via section=advanced key=create-backup|restore-backup, and checking/reporting connected-agent updates via section=updates key=status|check|channel|apply. Restore requires fileName and confirm=true. Update channel requires value=stable|beta|nightly. Also reads (`action=get`) or lists (`action=list`) which settings are changeable. `action=set` writes an owned section or points to the dedicated action that owns a delegated section (models→MODEL_SWITCH, background→BACKGROUND, identity→CHARACTER, connectors→PLUGIN, secrets→SECRETS). This CHANGES a setting's value or runs an explicit settings operation; opening a settings page without changing anything is VIEWS. Never fill a settings field with agent-fill.",
 		descriptionCompressed:
-			"settings get|set|list section/key/value — CHANGE a setting VALUE or run a settings operation, incl. shell access, OS permission requests, appearance, auto-training, wallet RPC providers, app permissions, local backups, and updates",
+			"settings get|set|list section/key/value — CHANGE a setting VALUE or run a settings operation, incl. shell access, OS permission requests, appearance, voice, auto-training, wallet RPC providers, app permissions, local backups, and updates",
 		routingHint:
-			"Semantic settings reads/writes that do NOT already have a dedicated action -> SETTINGS. Changing a PERMISSION or setting VALUE is SETTINGS action=set, NOT navigation: 'turn off shell permissions', 'disable shell access', 'turn off shell access', 'revoke shell access', 'stop the agent running shell commands', 'turn shell back on', 'change my permissions' -> SETTINGS section=permissions key=shell value=off|on. 'ask for microphone permission', 'request camera access', 'enable location permission', 'turn on notifications', 'request screen recording' -> SETTINGS section=permissions key=request permission=microphone|camera|location|notifications|screen-recording. 'switch to dark mode', 'use system theme', 'set the accent to green', 'change UI language to Spanish', 'hide/show the home time widget' -> SETTINGS section=appearance key=theme|accent|language|home-time-widget value=<value>. 'turn on auto-training', 'enable automatic training', 'disable auto training' -> SETTINGS section=capabilities key=auto-training value=on|off. 'turn off the wallet capability', 'enable the browser capability', 'disable computer use' -> SETTINGS section=capabilities key=wallet|browser|computer-use value=on|off. 'use Alchemy for EVM RPC', 'set BSC RPC to NodeReal', 'use Helius for Solana RPC' -> SETTINGS section=wallet-rpc key=evm|bsc|solana value=alchemy|infura|ankr|nodereal|quicknode|helius-birdeye|eliza-cloud. 'use Eliza Cloud RPC' -> SETTINGS section=wallet-rpc key=cloud. 'switch wallet network to testnet' -> SETTINGS section=wallet-rpc key=network value=testnet. Never put wallet API keys or RPC URLs in SETTINGS; use SECRETS for API keys and vault material. 'check for updates', 'refresh update status' -> SETTINGS section=updates key=check. 'what update version am I on' -> SETTINGS section=updates key=status. 'switch updates to beta/nightly/stable' -> SETTINGS section=updates key=channel value=beta|nightly|stable. 'apply the available update' -> SETTINGS section=updates key=apply. 'revoke network access for my-app', 'grant filesystem access to sample-app' -> SETTINGS section=app-permissions app=<slug> key=net|fs value=off|on. 'back up my agent', 'create a local backup' -> SETTINGS section=advanced key=create-backup. 'restore backup <file>' -> SETTINGS section=advanced key=restore-backup fileName=<file> confirm=true; if confirm is absent, ask for confirmation. Also 'what settings can you change' / 'list settings' -> SETTINGS action=list. Do NOT use SETTINGS for changes a dedicated action owns: switching the model is MODEL_SWITCH, the background/wallpaper is BACKGROUND, the agent identity is CHARACTER, connector plugin lifecycle/config is PLUGIN, secret/API keys are SECRETS. The distinction from VIEWS is value-vs-navigation: changing/toggling a permission or setting VALUE, requesting an OS permission, changing an appearance value, changing wallet RPC provider selection, checking update status, changing update channel, or running a backup operation, is SETTINGS even though it lives on a settings page; merely OPENING or navigating to a settings page with no value change is VIEWS. SETTINGS never fills a form field with agent-fill.",
+			"Semantic settings reads/writes that do NOT already have a dedicated action -> SETTINGS. Changing a PERMISSION or setting VALUE is SETTINGS action=set, NOT navigation: 'turn off shell permissions', 'disable shell access', 'turn off shell access', 'revoke shell access', 'stop the agent running shell commands', 'turn shell back on', 'change my permissions' -> SETTINGS section=permissions key=shell value=off|on. 'ask for microphone permission', 'request camera access', 'enable location permission', 'turn on notifications', 'request screen recording' -> SETTINGS section=permissions key=request permission=microphone|camera|location|notifications|screen-recording. 'switch to dark mode', 'use system theme', 'set the accent to green', 'change UI language to Spanish', 'hide/show the home time widget' -> SETTINGS section=appearance key=theme|accent|language|home-time-widget value=<value>. 'turn on continuous voice chat', 'switch voice to VAD', 'turn off hands-free voice' -> SETTINGS section=voice key=continuous value=always-on|vad-gated|off. 'set voice silence to 1200ms', 'make voice end-of-turn threshold 0.008' -> SETTINGS section=voice key=silence-ms|rms value=<number>. Wake word and voice profiles are device-local controls; open Settings > Voice for those. 'turn on auto-training', 'enable automatic training', 'disable auto training' -> SETTINGS section=capabilities key=auto-training value=on|off. 'turn off the wallet capability', 'enable the browser capability', 'disable computer use' -> SETTINGS section=capabilities key=wallet|browser|computer-use value=on|off. 'use Alchemy for EVM RPC', 'set BSC RPC to NodeReal', 'use Helius for Solana RPC' -> SETTINGS section=wallet-rpc key=evm|bsc|solana value=alchemy|infura|ankr|nodereal|quicknode|helius-birdeye|eliza-cloud. 'use Eliza Cloud RPC' -> SETTINGS section=wallet-rpc key=cloud. 'switch wallet network to testnet' -> SETTINGS section=wallet-rpc key=network value=testnet. Never put wallet API keys or RPC URLs in SETTINGS; use SECRETS for API keys and vault material. 'check for updates', 'refresh update status' -> SETTINGS section=updates key=check. 'what update version am I on' -> SETTINGS section=updates key=status. 'switch updates to beta/nightly/stable' -> SETTINGS section=updates key=channel value=beta|nightly|stable. 'apply the available update' -> SETTINGS section=updates key=apply. 'revoke network access for my-app', 'grant filesystem access to sample-app' -> SETTINGS section=app-permissions app=<slug> key=net|fs value=off|on. 'back up my agent', 'create a local backup' -> SETTINGS section=advanced key=create-backup. 'restore backup <file>' -> SETTINGS section=advanced key=restore-backup fileName=<file> confirm=true; if confirm is absent, ask for confirmation. Also 'what settings can you change' / 'list settings' -> SETTINGS action=list. Do NOT use SETTINGS for changes a dedicated action owns: switching the model is MODEL_SWITCH, the background/wallpaper is BACKGROUND, the agent identity is CHARACTER, connector plugin lifecycle/config is PLUGIN, secret/API keys are SECRETS. The distinction from VIEWS is value-vs-navigation: changing/toggling a permission or setting VALUE, requesting an OS permission, changing an appearance value, changing voice preferences, changing wallet RPC provider selection, checking update status, changing update channel, or running a backup operation, is SETTINGS even though it lives on a settings page; merely OPENING or navigating to a settings page with no value change is VIEWS. SETTINGS never fills a form field with agent-fill.",
 		suppressPostActionContinuation: true,
 
 		parameters: [
@@ -1606,7 +1815,7 @@ export function createSettingsAction(deps: SettingsActionDeps = {}): Action {
 			{
 				name: "key",
 				description:
-					"The specific toggle or operation within the section (e.g. theme, accent, language, home-time-widget, shell, auto-training, wallet-rpc evm/bsc/solana/cloud/network, fs/net, create-backup, restore-backup, status/check/channel/apply for updates). Optional; defaults to the section's primary key.",
+					"The specific toggle or operation within the section (e.g. theme, accent, language, home-time-widget, shell, voice continuous/silence-ms/rms, auto-training, wallet-rpc evm/bsc/solana/cloud/network, fs/net, create-backup, restore-backup, status/check/channel/apply for updates). Optional; defaults to the section's primary key.",
 				required: false,
 				schema: { type: "string" },
 			},
@@ -1669,7 +1878,7 @@ export function createSettingsAction(deps: SettingsActionDeps = {}): Action {
 			{
 				name: "value",
 				description:
-					"The new value for a set. Boolean toggles accept on/off, enable/disable, true/false; appearance accepts theme/accent/language tokens.",
+					"The new value for a set. Boolean toggles accept on/off, enable/disable, true/false; appearance accepts theme/accent/language tokens; voice accepts off|vad-gated|always-on or numeric VAD values.",
 				required: false,
 				schema: { type: "string" },
 			},


### PR DESCRIPTION
## Summary
- Wires `SETTINGS section=voice` through the existing `/api/config` read-modify-write path used by the voice settings UI.
- Supports server-backed voice preferences: continuous-chat mode plus VAD silence/RMS end-of-turn thresholds under `messages.voice`.
- Keeps wake-word listening and voice-profile enrollment out of SETTINGS because they are device-local/audio flows without a safe loopback write route for the active shell.

Fixes #14910.

## Verification update - 2026-07-06

- Rebased onto current `origin/develop`, preserved the merged wallet RPC and updates SETTINGS routes, and resolved the settings action conflict.
- Verified `node packages/shared/scripts/generate-keywords.mjs --target ts`, `bun run --cwd packages/cloud/routing build`, `bun run --cwd packages/contracts build`, `bun run --cwd plugins/plugin-app-control test src/actions/settings.test.ts` (79 passed), `bunx biome check plugins/plugin-app-control/src/actions/settings.ts plugins/plugin-app-control/src/actions/settings.test.ts`, `bun run --cwd plugins/plugin-app-control typecheck`, `git diff --check origin/develop...HEAD -- plugins/plugin-app-control/src/actions/settings.ts plugins/plugin-app-control/src/actions/settings.test.ts`, and `bun run audit:error-policy-ratchet --report`.

<!-- evidence-row:before-screenshots -->
- [x] N/A - action-only settings route change; no rendered UI surface changed before this patch.
<!-- evidence-row:after-screenshots -->
- [x] N/A - action-only settings route change; no app screen or visual state changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no frontend interaction surface changed; voice preference writes are exercised through the SETTINGS action tests.
<!-- evidence-row:backend-logs -->
- [x] N/A - no deployed backend runtime log artifact is produced by this plugin action unit path; local verification logs were reviewed for keyword generation, cloud-routing/contracts builds, focused Vitest, package typecheck, Biome, diff check, and error-policy ratchet.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code or browser console/network surface changed.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no live model prompt/provider behavior changed; this PR wires deterministic SETTINGS action parameters to the existing `/api/config` route and explicitly leaves wake-word/enrollment device flows out of model-routed writes.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no persisted DB/file artifact is produced by this action unit path; domain behavior is proven by `settings.test.ts`, which verifies GET `/api/config` then PUT `/api/config` with `messages.voice` continuous and `vadAutoStop` values, preserves existing voice prefs, rejects invalid/out-of-range values before writes, and surfaces backend failures instead of fabricating success.


