### PR TITLE
fix(mobile-build): android-cloud comment strip no longer swallows @xml/shortcuts (#14408)

### DIFF
--- a/packages/app-core/scripts/mobile/android-manifest.mjs
+++ b/packages/app-core/scripts/mobile/android-manifest.mjs
@@ -47,9 +47,16 @@ export function removeXmlCommentsContaining(xml, markers) {
   let patched = xml;
   for (const marker of markers) {
     const escapedMarker = escapeRegExp(marker);
+    // Match a SINGLE comment whose body contains the marker. The body pattern
+    // `(?:(?!-->)[\s\S])*?` refuses to cross a closing `-->`, so the match can
+    // no longer span from one comment, through real markup we must keep (e.g.
+    // the MainActivity @xml/shortcuts meta-data), into a later comment that
+    // merely mentions the marker. Without the boundary guard the unbounded
+    // `[\s\S]*?` deleted the intervening markup and tripped the android-cloud
+    // "does not register @xml/shortcuts" audit (elizaOS/eliza#14408).
     patched = patched.replace(
       new RegExp(
-        `\\n?\\s*<!--[\\s\\S]*?${escapedMarker}[\\s\\S]*?-->\\s*`,
+        `\\n?\\s*<!--(?:(?!-->)[\\s\\S])*?${escapedMarker}(?:(?!-->)[\\s\\S])*?-->\\s*`,
         "g",
       ),
       "\n",

--- a/packages/app-core/scripts/run-mobile-build-android-manifest.test.mjs
+++ b/packages/app-core/scripts/run-mobile-build-android-manifest.test.mjs
@@ -113,4 +113,33 @@ describe("Android manifest XML helpers", () => {
     ).not.toContain("ElizaAgentService");
     expect(stripXmlComments(xml)).toBe("\n<manifest></manifest>");
   });
+
+  it("does not swallow real markup between two separate comments (regression #14408)", () => {
+    // Reproduces the android-cloud pre-gradle audit failure: an earlier
+    // comment, then real markup we must keep (the MainActivity @xml/shortcuts
+    // meta-data), then a later descriptive comment that MENTIONS the stripped
+    // marker. The unbounded `[\s\S]*?` regex matched from the first `<!--`
+    // across the closing `-->` into the second comment, deleting the shortcuts
+    // registration in between and tripping the "does not register @xml/shortcuts"
+    // audit failure.
+    const xml = `<!-- leading note, no marker here -->
+<application>
+    <meta-data
+        android:name="android.app.shortcuts"
+        android:resource="@xml/shortcuts" />
+    <!-- descriptive note that references ElizaAssistActivity fallback flow -->
+    <activity android:name=".MainActivity" />
+</application>`;
+
+    const stripped = removeXmlCommentsContaining(xml, ["ElizaAssistActivity"]);
+
+    // The real shortcuts meta-data between the two comments must survive.
+    expect(stripped).toContain('android:name="android.app.shortcuts"');
+    expect(stripped).toContain("@xml/shortcuts");
+    expect(stripped).toContain(".MainActivity");
+    // The leading comment (no marker) must survive untouched.
+    expect(stripped).toContain("leading note, no marker here");
+    // Only the comment that actually contains the marker is removed.
+    expect(stripped).not.toContain("ElizaAssistActivity");
+  });
 });


### PR DESCRIPTION
## Problem

`node packages/app-core/scripts/run-mobile-build.mjs android-cloud[-debug]` cannot build from a clean committed tree. The pre-gradle audit fails with:

```
[mobile-build] android-cloud pre-gradle audit failed:
  - AndroidManifest.xml does not register @xml/shortcuts
```

## Root cause (headless-reproduced)

The cloud manifest strip itself is correct — it removes `ElizaAgentService`, the assist/voice components, and the forbidden `ASSIST`/`VOICE_COMMAND`/`BIND_VOICE_INTERACTION` intents. The regression is in `removeXmlCommentsContaining()` (`packages/app-core/scripts/mobile/android-manifest.mjs`).

It used an unbounded regex:

```
<!--[\s\S]*?MARKER[\s\S]*?-->
```

`[\s\S]*?` does not respect comment boundaries, so a single match can span from one `<!--`, **across a closing `-->` and real markup in between**, into a later comment that merely mentions the marker.

On the committed android template, the `ElizaAssistActivity` marker made the match run from the leading comment, **through the `.MainActivity` `@xml/shortcuts` meta-data**, into the big descriptive comment documenting the assist fallback flow. That deleted the shortcuts registration, so `auditAndroidCloudSource`'s "does not register @xml/shortcuts" check failed — the committed template could never pass the cloud audit.

## Fix

Guard the comment body with `(?:(?!-->)[\s\S])*?` so a single match cannot cross a `-->`. Only the comment that actually contains the marker is removed; intervening markup survives.

## Verification (headless)

- New regression test in `run-mobile-build-android-manifest.test.mjs` reproduces the exact failure (red before, green after): an earlier comment + real `@xml/shortcuts` markup + a later comment mentioning the stripped marker — the shortcuts registration must survive.
- Ran the full cloud component strip against the **real committed `AndroidManifest.xml`** and confirmed the audit now passes end to end: `ElizaAgentService`, all forbidden intents, and all stripped components are gone, and `@xml/shortcuts` is retained.

```
$ npx vitest run scripts/run-mobile-build-android-manifest.test.mjs \
    scripts/run-mobile-build-android-targets.test.mjs \
    scripts/run-mobile-build-plugin-manifest.test.mjs
 Test Files  3 passed (3)
      Tests  16 passed (16)
```

Biome clean on both touched files (`@biomejs/biome@2.5.1`). Codex review: no correctness issue introduced.

Closes #14408

— [sol-orch]