### PR TITLE
fix(telegram): supervise poller launch so post-launch code runs

### DIFF
--- a/plugins/plugin-telegram/src/service.launch-supervision.test.ts
+++ b/plugins/plugin-telegram/src/service.launch-supervision.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for `TelegramService.launchPollerSupervised` — the supervised
+ * launch that replaces `await bot.launch()`. Telegraf v4's `bot.launch()`
+ * resolves only when polling stops, so awaiting it for completion strands every
+ * post-launch step (dedup registration, `setMyCommands`, shutdown handlers).
+ * These tests drive a controllable fake Telegraf bot (its `launch(config,
+ * onLaunch)` deferred is resolved/rejected by the test) to prove: the connect
+ * signal settles the returned promise so the caller proceeds; a post-connect
+ * poll failure self-heals with bounded, backed-off relaunches; and a newer
+ * runtime taking over the token cancels the loser's relaunch. Runtime, timers,
+ * and `@elizaos/core` (logger/Service) are mocked.
+ */
+import { logger } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TelegramService } from "./service";
+
+const CONFLICT = "409: Conflict: terminated by other getUpdates request";
+
+type SupervisedLaunch = (
+  bot: unknown,
+  botToken: string | null | undefined,
+  accountId: string,
+) => Promise<void>;
+
+function callLaunch(
+  service: TelegramService,
+  bot: unknown,
+  botToken: string | null,
+  accountId: string,
+): Promise<void> {
+  return (
+    service as unknown as { launchPollerSupervised: SupervisedLaunch }
+  ).launchPollerSupervised(bot, botToken, accountId);
+}
+
+interface LaunchCall {
+  config: { dropPendingUpdates?: boolean; allowedUpdates?: string[] };
+  onLaunch: () => void;
+  resolve: () => void;
+  reject: (error: unknown) => void;
+}
+
+function makeBot() {
+  const calls: LaunchCall[] = [];
+  const bot = {
+    launch: vi.fn(
+      (config: LaunchCall["config"], onLaunch: () => void): Promise<void> =>
+        new Promise<void>((resolve, reject) => {
+          calls.push({ config, onLaunch, resolve, reject });
+        }),
+    ),
+    stop: vi.fn(),
+  };
+  return { bot, calls };
+}
+
+function makeService() {
+  const runtime = { agentId: "agent-test", reportError: vi.fn() };
+  const service = Object.assign(
+    Object.create(TelegramService.prototype) as TelegramService,
+    { runtime },
+  );
+  return { service, runtime };
+}
+
+// Flush the microtask that runs the launch promise's rejection handler before
+// its backoff `setTimeout` is scheduled.
+async function flushMicrotasks(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(0);
+}
+
+describe("TelegramService.launchPollerSupervised", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves on the connect signal (unblocking the post-launch path) with drop-pending polling", async () => {
+    const { bot, calls } = makeBot();
+    const { service } = makeService();
+
+    const launched = callLaunch(service, bot, "tok-connect", "acct");
+    // The poll loop is still running (launch promise stays pending); the caller
+    // must proceed off the connect callback, not off loop completion.
+    expect(bot.launch).toHaveBeenCalledTimes(1);
+    expect(calls[0].config).toEqual({
+      dropPendingUpdates: true,
+      allowedUpdates: ["message", "message_reaction", "callback_query"],
+    });
+
+    calls[0].onLaunch();
+    await expect(launched).resolves.toBeUndefined();
+  });
+
+  it("self-heals a post-connect poll failure with a bounded, backed-off relaunch and then gives up", async () => {
+    const { bot, calls } = makeBot();
+    const { service, runtime } = makeService();
+
+    const launched = callLaunch(service, bot, "tok-heal", "acct");
+    calls[0].onLaunch();
+    await launched;
+
+    // Persistent conflict on every attempt: backoff doubles (2^n s) capped at
+    // 30s, and each attempt reuses the same bot instance (no re-registration of
+    // handlers). Five relaunches → six launches total.
+    const backoffsMs = [2000, 4000, 8000, 16000, 30000];
+    for (let i = 0; i < backoffsMs.length; i++) {
+      calls[i].reject(new Error(CONFLICT));
+      await flushMicrotasks();
+      expect(runtime.reportError).toHaveBeenCalledWith(
+        "telegram:poll",
+        expect.any(Error),
+        expect.objectContaining({ accountId: "acct" }),
+      );
+      await vi.advanceTimersByTimeAsync(backoffsMs[i]);
+      expect(bot.launch).toHaveBeenCalledTimes(i + 2);
+    }
+
+    // Sixth failure exceeds the relaunch budget: give up, do not relaunch.
+    calls[5].reject(new Error(CONFLICT));
+    await flushMicrotasks();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ maxPollRelaunches: 5 }),
+      expect.stringContaining("gave up"),
+    );
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(bot.launch).toHaveBeenCalledTimes(6);
+    expect(runtime.reportError).toHaveBeenCalledTimes(6);
+  });
+
+  it("does not relaunch after a newer runtime takes over the bot token", async () => {
+    const first = makeBot();
+    const second = makeBot();
+    const { service } = makeService();
+
+    const firstLaunched = callLaunch(
+      service,
+      first.bot,
+      "tok-takeover",
+      "acct",
+    );
+    first.calls[0].onLaunch();
+    await firstLaunched;
+
+    // A newer runtime launches on the same token and connects: its connect
+    // registers it as the active poller, superseding the first.
+    const secondLaunched = callLaunch(
+      service,
+      second.bot,
+      "tok-takeover",
+      "acct",
+    );
+    second.calls[0].onLaunch();
+    await secondLaunched;
+
+    // The first poller's loop now dies. Because it no longer owns the token,
+    // the failure is surfaced but no relaunch is scheduled.
+    first.calls[0].reject(new Error(CONFLICT));
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(first.bot.launch).toHaveBeenCalledTimes(1);
+    expect(second.bot.launch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/plugin-telegram/src/service.ts
+++ b/plugins/plugin-telegram/src/service.ts
@@ -766,17 +766,11 @@ export class TelegramService extends Service {
       );
     }
 
-    await bot.launch({
-      dropPendingUpdates: true,
-      allowedUpdates: ["message", "message_reaction", "callback_query"],
-    });
-    if (botToken) {
-      ACTIVE_TELEGRAM_POLLERS.set(botToken, {
-        bot,
-        agentId: this.runtime.agentId,
-        accountId,
-      });
-    }
+    // Telegraf v4's `bot.launch()` resolves only when polling STOPS — it awaits
+    // the long-poll loop internally — so it must not be awaited for completion.
+    // launchPollerSupervised awaits just the connect signal and then supervises
+    // the loop (with bounded self-healing relaunch) in the background.
+    await this.launchPollerSupervised(bot, botToken, accountId);
 
     // Publish the slash-command menu to Telegram so commands appear in the `/`
     // menu. setMyCommands failure is logged + swallowed (network) and must not
@@ -796,9 +790,174 @@ export class TelegramService extends Service {
       "Bot info retrieved",
     );
 
-    // Handle sigint and sigterm signals to gracefully stop the bot
-    process.once("SIGINT", () => bot.stop("SIGINT"));
-    process.once("SIGTERM", () => bot.stop("SIGTERM"));
+    // Stop the poller on process shutdown so the long-poll slot is released
+    // before a replacement process starts — otherwise the new process's poller
+    // 409s against the lingering one. bot.stop() throws if already stopped, so
+    // teardown is best-effort.
+    const stopBot = (reason: string): void => {
+      try {
+        bot.stop(reason);
+      } catch {
+        // error-policy:J6 best-effort teardown — bot already stopped.
+      }
+    };
+    process.once("SIGINT", () => stopBot("SIGINT"));
+    process.once("SIGTERM", () => stopBot("SIGTERM"));
+  }
+
+  /**
+   * Launches the Telegraf long-poll loop and keeps it running for the lifetime
+   * of the process.
+   *
+   * `bot.launch()` in Telegraf v4 only settles when polling stops (it awaits the
+   * loop internally), so the returned promise resolves on the `onLaunch`
+   * callback — fired after `getMe` succeeds, just before polling begins — and
+   * the loop is supervised in the background afterwards. A failure *after*
+   * connecting (a 409 "terminated by other getUpdates request" from a transient
+   * poller overlap during a restart, or a dropped network) is relaunched with
+   * exponential backoff so the connector self-heals instead of going
+   * permanently silent. Relaunches are bounded to `maxPollRelaunches` (reset
+   * after a stable run) so a genuinely duplicated bot instance cannot thrash
+   * forever, and stop entirely once a newer runtime has taken over the token
+   * (the dedup map points at a different bot). Message/command handlers are
+   * registered once by the caller before this runs; a relaunch reuses the same
+   * bot instance, so they are never double-registered.
+   */
+  private launchPollerSupervised(
+    bot: Telegraf<Context>,
+    botToken: string | null | undefined,
+    accountId: string,
+  ): Promise<void> {
+    const maxPollRelaunches = 5;
+    // A loop that ran healthy for at least this long before failing is treated
+    // as a fresh transient (relaunch budget reset); a faster failure counts
+    // against the budget so a persistent conflict cannot relaunch forever.
+    const stableRunMs = 60_000;
+
+    const ownsToken = (): boolean => {
+      if (!botToken) {
+        return true;
+      }
+      const active = ACTIVE_TELEGRAM_POLLERS.get(botToken);
+      return active === undefined || active.bot === bot;
+    };
+    const markActive = (): void => {
+      if (botToken) {
+        ACTIVE_TELEGRAM_POLLERS.set(botToken, {
+          bot,
+          agentId: this.runtime.agentId,
+          accountId,
+        });
+      }
+    };
+    const clearActive = (): void => {
+      if (!botToken) {
+        return;
+      }
+      const active = ACTIVE_TELEGRAM_POLLERS.get(botToken);
+      if (active?.bot === bot) {
+        ACTIVE_TELEGRAM_POLLERS.delete(botToken);
+      }
+    };
+
+    let relaunches = 0;
+
+    return new Promise<void>((resolve, reject) => {
+      let connectedOnce = false;
+
+      const scheduleRelaunch = (): void => {
+        if (!ownsToken()) {
+          clearActive();
+          return;
+        }
+        if (relaunches >= maxPollRelaunches) {
+          logger.error(
+            {
+              src: "plugin:telegram",
+              agentId: this.runtime.agentId,
+              accountId,
+              maxPollRelaunches,
+            },
+            "Telegram poller gave up after repeated conflicts — verify only one instance holds this bot token",
+          );
+          clearActive();
+          return;
+        }
+        relaunches++;
+        const delayMs = Math.min(2 ** relaunches * 1000, 30_000);
+        logger.warn(
+          {
+            src: "plugin:telegram",
+            agentId: this.runtime.agentId,
+            accountId,
+            attempt: relaunches,
+            delaySeconds: delayMs / 1000,
+          },
+          "Relaunching Telegram poller after poll-loop failure",
+        );
+        setTimeout(() => {
+          if (!ownsToken()) {
+            clearActive();
+            return;
+          }
+          runLaunch();
+        }, delayMs);
+      };
+
+      const runLaunch = (): void => {
+        let connectedAt = 0;
+        bot
+          .launch(
+            {
+              dropPendingUpdates: true,
+              allowedUpdates: ["message", "message_reaction", "callback_query"],
+            },
+            () => {
+              connectedAt = Date.now();
+              markActive();
+              if (!connectedOnce) {
+                connectedOnce = true;
+                resolve();
+              }
+            },
+          )
+          .then(
+            () => {
+              // Clean stop (shutdown, or deliberate replacement by a newer
+              // runtime): release ownership and do not relaunch.
+              clearActive();
+              if (!connectedOnce) {
+                reject(
+                  new Error("Telegram poller stopped before it connected"),
+                );
+              }
+            },
+            (error: unknown) => {
+              if (connectedAt === 0 && !connectedOnce) {
+                // Pre-connect failure on the first launch (revoked/malformed
+                // token, network): reject so start()'s retry / token-rejection
+                // branch handles it.
+                clearActive();
+                reject(error);
+                return;
+              }
+              // error-policy:J7 poll-loop failure after connecting (or on a
+              // relaunch) — start() has already returned, so surface it
+              // observably, then self-heal with bounded backoff.
+              this.runtime.reportError("telegram:poll", error, {
+                accountId,
+                agentId: this.runtime.agentId,
+              });
+              if (connectedAt > 0 && Date.now() - connectedAt >= stableRunMs) {
+                relaunches = 0;
+              }
+              scheduleRelaunch();
+            },
+          );
+      };
+
+      runLaunch();
+    });
   }
 
   /**


### PR DESCRIPTION
## Problem

`TelegramService.initializeBot()` launches the Telegraf long-poll bot with:

```ts
await bot.launch({ dropPendingUpdates: true, allowedUpdates: [...] });
```

In Telegraf 4.16.3, `bot.launch()` calls `getMe()`, fires the (optional)
`onLaunch` callback, and then `await this.startPolling(...)` — a `for await`
loop that only settles when polling **stops**
(`node_modules/telegraf/lib/telegraf.js`: `await this.startPolling(...)` after
`onMe?.()`). So `await bot.launch()` **blocks for the entire life of the poll
loop**, and every line after it in `initializeBot()` is dead code:

- `ACTIVE_TELEGRAM_POLLERS.set(botToken, …)` — the in-process de-dup guard that
  lets a new poller stop a prior one **never registers**.
- `applyTelegramSetMyCommands(...)` — the `/` command menu is never published.
- the `"Bot info retrieved"` debug log — never emitted.
- `process.once("SIGINT"/"SIGTERM", () => bot.stop(...))` — **no graceful
  shutdown**, so the long-poll slot is never released before a replacement
  process starts.

### Consequence chain (affects any deployment that restarts)

De-dup registration is dead **and** shutdown teardown is dead, so on every
restart the old process keeps polling while the new one launches a second
poller against the same bot token. Telegram permits exactly one `getUpdates`
long-poll per token, so they trade
`409: Conflict: terminated by other getUpdates request` and kill each other —
frequently leaving **no** surviving poller (the bot goes silent).

Log signature pre-fix: N× `"Starting Telegram bot"`, **0×**
`"Bot info retrieved"`, **0×** `"Telegram bot started successfully"`.

## Fix

Replace `await bot.launch(...)` with `launchPollerSupervised()`, which awaits
**only** the `onLaunch` connect callback (fired after `getMe` succeeds, just
before polling begins) and supervises the poll loop in the **background**. This
makes all the post-launch code reachable again:

1. **De-dup registration runs on connect.** `ACTIVE_TELEGRAM_POLLERS.set(...)`
   now happens in the `onLaunch` callback, so the existing "stop the previous
   poller before launching a new one" guard has a live entry to act on.
2. **Bounded, replacement-guarded self-heal.** A poll-loop failure *after*
   connecting (a transient 409 during a restart overlap, or a dropped network)
   relaunches with exponential backoff — max 5 attempts, reset after a 60s
   stable run — **unless** a newer runtime has taken over the token (the de-dup
   map points at a different bot), in which case the loser stops cleanly.
   Relaunches keep `dropPendingUpdates: true`. Handlers are registered once by
   the caller and a relaunch reuses the same bot instance, so they are never
   double-registered.
3. **Guarded teardown.** The now-reachable SIGINT/SIGTERM handlers wrap
   `bot.stop()` (`// error-policy:J6`) since it throws if already stopped.
4. **Observability.** A post-connect failure is surfaced via
   `runtime.reportError("telegram:poll", …)` (`// error-policy:J7`) before the
   self-heal, so the failure is visible to the agent/owner rather than silent.

Pre-connect failures on the first launch (revoked/malformed token, network)
still reject so `start()`'s existing retry / token-rejection branch handles
them — the happy-path start semantics are unchanged.

## Tests

`plugins/plugin-telegram/src/service.launch-supervision.test.ts` drives a
controllable fake Telegraf bot (its `launch(config, onLaunch)` deferred is
resolved/rejected by the test) and asserts:

- the connect signal settles the returned promise (so the caller proceeds to
  the previously-dead post-launch path) with `dropPendingUpdates` polling;
- a post-connect poll failure surfaces via `reportError`, relaunches with
  doubling backoff capped at 30s, and **gives up after 5 relaunches** instead of
  thrashing forever;
- a newer runtime taking over the token **cancels** the loser's relaunch
  (proving the de-dup registration is written on connect and read before
  relaunch).

Verification (`plugins/plugin-telegram`):

- `bun run typecheck` — clean.
- `bun run test` — 113 passed (110 pre-existing + 3 new). One unrelated suite
  (`connector-sources.test.ts`) fails identically on `develop` before this
  change: its `@elizaos/core` test mock is missing a `BaseMessageAdapter`
  export used by `triage-adapter.ts` — untouched by this PR.
- `biome check` — clean on both changed files.

## Live evidence

Running live on a restart-heavy deployment: after the fix the poller holds the
long-poll slot across restarts, the `"Telegram bot started successfully"` path
fires, and an **external** `getUpdates` probe on the same token now gets the
409 (i.e. the bot is correctly the sole holder) — the inverse of the pre-fix
failure where the bot itself was the one being 409'd off.
