### PR TITLE
fix(app): preserve live visual QA failure evidence

### DIFF
--- a/packages/app/scripts/visual-qa-live.mjs
+++ b/packages/app/scripts/visual-qa-live.mjs
@@ -4,21 +4,21 @@
  * heavier `audit:app` (which prebuilds every plugin-view bundle and walks the
  * full route matrix): this tool points a headless Chromium at an *already
  * running* server, captures a small matrix of the states that actually matter
- * for the MVP — the pre-auth onboarding gate, the keyboard-adjacent mobile
- * composer, and (by seeding a session) the post-onboarding shell + its designed
- * error render — and runs each capture through the repo's own `visual-qa.mjs`
- * analyzer (OCR + dominant palette + brand-colour fractions). One report.json +
- * a terminal summary come out; `--strict` turns the brand-colour invariant
- * ("no blue", elizaOS orange is accent-only) into a non-zero exit so a lane can
- * gate on it.
+ * for the MVP — the first-run home/onboarding prompt, the keyboard-adjacent
+ * mobile composer, and (by seeding a session) the post-onboarding shell + its
+ * designed degraded renders — and runs each capture through the repo's own
+ * `visual-qa.mjs` analyzer (OCR + dominant palette + brand-colour fractions).
+ * One report.json + a terminal summary come out; `--strict` turns the
+ * brand-colour invariant ("no blue", elizaOS orange is accent-only) into a
+ * non-zero exit so a lane can gate on it.
  *
- * Why seeding: onboarding gates every route behind "Sign in to Eliza Cloud",
- * so a fresh browser only ever sees the gate. Injecting the canonical
- * `steward_session_token` + `eliza:first-run-complete=1` into an *isolated*
- * Playwright context (its own localStorage — it never touches the running
- * server's state or other users) lets the sweep reach the post-onboarding shell
- * and, when no backend is reachable, the designed failure state — which is the
- * three-state-rule render worth verifying (see #14415).
+ * Why seeding: first-run local state changes which product surface renders.
+ * Injecting the canonical `steward_session_token` +
+ * `eliza:first-run-complete=1` into an *isolated* Playwright context (its own
+ * localStorage — it never touches the running server's state or other users)
+ * lets the sweep reach the post-onboarding shell and, when no backend is
+ * reachable, the designed failure state — which is the three-state-rule render
+ * worth verifying (see #14415).
  *
  * Consumed by: an operator or coding agent doing a fast pre-PR visual pass
  * without the multi-minute `audit:app` prebuild. Not a CI gate unless a lane
@@ -28,7 +28,7 @@
  *   node scripts/visual-qa-live.mjs --base http://127.0.0.1:2138 [--out DIR] [--strict]
  */
 import { execFileSync } from "node:child_process";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
@@ -37,6 +37,12 @@ import { analyzeScreenshot, changeMetric } from "./lib/visual-qa.mjs";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..", "..", "..");
 export const COMPOSER_PROBE_TEXT = "remind me to call the pharmacy before 5";
+const FIRST_RUN_EXPECTED_ANY_TEXT = [
+  "Swipe for apps",
+  "Sign in to Eliza Cloud",
+];
+const SHELL_EXPECTED_ANY_TEXT = ["Settings", "Backend Unreachable"];
+const CHAT_EXPECTED_ANY_TEXT = ["Pull chat up", "Backend Unreachable"];
 
 // Mirrors the canonical Steward seed contract in
 // `test/ui-smoke/helpers/test-auth.ts` (STEWARD_SESSION_TOKEN_KEY + the
@@ -80,8 +86,9 @@ export function buildOnboardedSeed({ subject = "visual-qa-user" } = {}) {
 
 /**
  * The state matrix. Each entry is one capture: a viewport, a seed profile
- * (fresh = onboarding gate, onboarded = seeded shell), a route, and an optional
- * `focusComposer` step to exercise the keyboard-adjacent mobile layout.
+ * (fresh = first-run home prompt, onboarded = seeded shell), a route, and an
+ * optional `focusComposer` step to exercise the keyboard-adjacent mobile
+ * layout.
  */
 export const VIEWPORTS = {
   desktop: { width: 1280, height: 800, isMobile: false, hasTouch: false },
@@ -96,26 +103,39 @@ export function buildStateMatrix() {
       viewport: vpName,
       seed: "fresh",
       route: "/",
+      expectedAnyTextIncludes: FIRST_RUN_EXPECTED_ANY_TEXT,
     });
     states.push({
       id: `${vpName}-shell`,
       viewport: vpName,
       seed: "onboarded",
       route: "/views",
+      expectedAnyTextIncludes: SHELL_EXPECTED_ANY_TEXT,
     });
     states.push({
       id: `${vpName}-chat`,
       viewport: vpName,
       seed: "onboarded",
       route: "/chat",
+      expectedAnyTextIncludes: CHAT_EXPECTED_ANY_TEXT,
     });
     if (vp.isMobile) {
+      states.push({
+        id: `${vpName}-onboarding-composer-focused`,
+        viewport: vpName,
+        seed: "fresh",
+        route: "/",
+        focusComposer: true,
+        expectedAnyTextIncludes: FIRST_RUN_EXPECTED_ANY_TEXT,
+        expectedComposerText: COMPOSER_PROBE_TEXT,
+      });
       states.push({
         id: `${vpName}-composer-focused`,
         viewport: vpName,
         seed: "onboarded",
         route: "/chat",
         focusComposer: true,
+        expectedAnyTextIncludes: CHAT_EXPECTED_ANY_TEXT,
         expectedComposerText: COMPOSER_PROBE_TEXT,
       });
     }
@@ -158,15 +178,23 @@ export function aggregateVerdict(reports, { blueCeiling = 0.02 } = {}) {
 
 /**
  * Seed-vacuity gate: if the onboarded-seed contract drifts (renamed key, new
- * gate), every "seeded" capture silently re-renders the onboarding gate and
- * the sweep passes on the wrong pixels. Requiring the gate and the seeded
- * shell to differ materially per viewport turns that silent drift into a hard
- * failure. `deltas` is `[{ viewport, changedFraction }]` from `changeMetric`.
+ * startup boundary), every "seeded" capture silently re-renders the first-run
+ * surface and the sweep passes on the wrong pixels. Requiring the first-run
+ * surface and the seeded shell to differ materially per viewport turns that
+ * silent drift into a hard failure. `deltas` is
+ * `[{ viewport, changedFraction }]` from `changeMetric`.
  */
 export function seedDriftOffenders(deltas, { minChangedFraction = 0.02 } = {}) {
   return deltas
     .filter((d) => !(d.changedFraction > minChangedFraction))
-    .map((d) => ({ viewport: d.viewport, changedFraction: d.changedFraction }));
+    .map((d) => {
+      const offender = {
+        viewport: d.viewport,
+        changedFraction: d.changedFraction,
+      };
+      if (d.reason) offender.reason = d.reason;
+      return offender;
+    });
 }
 
 export function buildOverallVerdict({
@@ -185,6 +213,24 @@ export function buildOverallVerdict({
   };
 }
 
+function normalizeVisibleText(text) {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function includesText(haystack, needle) {
+  return haystack.toLocaleLowerCase().includes(needle.toLocaleLowerCase());
+}
+
+function matchesExpectedDomText(state, normalizedDomText) {
+  const required = state.expectedTextIncludes ?? [];
+  const any = state.expectedAnyTextIncludes ?? [];
+  return (
+    required.every((text) => includesText(normalizedDomText, text)) &&
+    (any.length === 0 ||
+      any.some((text) => includesText(normalizedDomText, text)))
+  );
+}
+
 export function evaluateCaptureReadiness({
   state,
   domText = "",
@@ -197,12 +243,34 @@ export function evaluateCaptureReadiness({
     checks.push({ name, ok: Boolean(ok), detail });
     if (!ok) pass = false;
   };
-  const normalizedDomText = domText.replace(/\s+/g, " ").trim();
+  const normalizedDomText = normalizeVisibleText(domText);
   check(
     "dom:not_blank",
     normalizedDomText.length >= minDomTextLength,
     `visible DOM text length ${normalizedDomText.length} (min ${minDomTextLength})`,
   );
+  for (const expected of state.expectedTextIncludes ?? []) {
+    check(
+      "dom:expected_text",
+      includesText(normalizedDomText, expected),
+      `visible DOM text ${includesText(normalizedDomText, expected) ? "contains" : "does not contain"} "${expected}"`,
+    );
+  }
+  const expectedAny = state.expectedAnyTextIncludes ?? [];
+  if (expectedAny.length) {
+    const matched = expectedAny.filter((expected) =>
+      includesText(normalizedDomText, expected),
+    );
+    check(
+      "dom:expected_any_text",
+      matched.length > 0,
+      matched.length
+        ? `visible DOM text contains "${matched[0]}"`
+        : `visible DOM text does not contain any of ${expectedAny
+            .map((text) => `"${text}"`)
+            .join(", ")}`,
+    );
+  }
   if (state.expectedComposerText) {
     check(
       "composer:typed_text_present",
@@ -213,24 +281,59 @@ export function evaluateCaptureReadiness({
   return { pass, checks };
 }
 
+async function clickOpenAppIfVisible(page, { timeout = 500 } = {}) {
+  const candidates = [
+    page.getByRole("button", { name: /^Open App$/ }).first(),
+    page.getByText(/^Open App$/).first(),
+  ];
+  for (const openApp of candidates) {
+    if (
+      !(await openApp.isVisible({ timeout }).catch(() => {
+        // error-policy:J4 absence of the startup recovery affordance simply
+        // means the screen is either already past that boundary or still
+        // settling; the composer check remains the authoritative proof.
+        return false;
+      }))
+    ) {
+      continue;
+    }
+    await openApp.click({ timeout: 2000 });
+    await page.waitForTimeout(1000);
+    return true;
+  }
+  return false;
+}
+
 async function focusAndType(page) {
+  await clickOpenAppIfVisible(page);
   const box = page.locator('[data-testid="chat-composer-textarea"]').first();
-  await box.waitFor({ state: "visible", timeout: 4000 });
+  try {
+    await box.waitFor({ state: "visible", timeout: 5000 });
+  } catch (error) {
+    const recovered = await clickOpenAppIfVisible(page, { timeout: 5000 });
+    if (!recovered) throw error;
+    await box.waitFor({ state: "visible", timeout: 10000 });
+  }
   await box.click({ timeout: 4000 });
   await box.type(COMPOSER_PROBE_TEXT, { delay: 8 });
   await page.waitForTimeout(600);
 }
 
-async function readVisibleText(page, stateId, { minLength = 12 } = {}) {
+async function readVisibleText(page, state, { minLength = 12 } = {}) {
   const deadline = Date.now() + 12_000;
   let lastText = "";
   let lastError = null;
   while (Date.now() < deadline) {
     try {
-      lastText = (await page.locator("body").innerText({ timeout: 1000 }))
-        .replace(/\s+/g, " ")
-        .trim();
-      if (lastText.length >= minLength) return lastText;
+      lastText = normalizeVisibleText(
+        await page.locator("body").innerText({ timeout: 1000 }),
+      );
+      if (
+        lastText.length >= minLength &&
+        matchesExpectedDomText(state, lastText)
+      ) {
+        return lastText;
+      }
     } catch (error) {
       lastError = error;
     }
@@ -238,7 +341,7 @@ async function readVisibleText(page, stateId, { minLength = 12 } = {}) {
   }
   if (lastError) {
     throw new Error(
-      `Failed to read visible DOM text for ${stateId}: ${lastError?.message ?? lastError}`,
+      `Failed to read visible DOM text for ${state.id}: ${lastError?.message ?? lastError}`,
     );
   }
   return lastText;
@@ -250,6 +353,38 @@ async function readComposerText(page) {
   return box.evaluate((el) =>
     "value" in el ? String(el.value) : String(el.textContent ?? ""),
   );
+}
+
+function compactError(error) {
+  return String(error?.message ?? error)
+    .replace(/\s+/g, " ")
+    .slice(0, 500);
+}
+
+function buildCaptureFailureEntry({ state, targetUrl, error, failureImage }) {
+  const detail = compactError(error);
+  return {
+    id: state.id,
+    route: state.route,
+    seed: state.seed,
+    target_url: targetUrl,
+    image: failureImage,
+    capture_error: detail,
+    visual_verdict: "fail",
+    visual_checks: [
+      { name: "capture:completed", ok: false, detail },
+      {
+        name: "brand:no_blue",
+        ok: false,
+        detail: "blue_fraction not measured because capture failed",
+      },
+    ],
+    network_idle: "not reached",
+    dom_checks: [{ name: "capture:completed", ok: false, detail }],
+    dom_text: "",
+    ocr_text: "",
+    ocr_note: "capture failed before OCR",
+  };
 }
 
 function gitValue(args) {
@@ -320,6 +455,8 @@ async function main() {
         hasTouch: vp.hasTouch,
         deviceScaleFactor: 2,
       });
+      let page = null;
+      const targetUrl = buildCaptureUrl(base, state.route);
       try {
         if (state.seed === "onboarded") {
           await ctx.addInitScript((seed) => {
@@ -327,8 +464,7 @@ async function main() {
               window.localStorage.setItem(k, v);
           }, onboardedSeed);
         }
-        const page = await ctx.newPage();
-        const targetUrl = buildCaptureUrl(base, state.route);
+        page = await ctx.newPage();
         let response;
         try {
           response = await page.goto(targetUrl, {
@@ -363,7 +499,7 @@ async function main() {
             focusError = String(error?.message ?? error).slice(0, 180);
           }
         }
-        const domText = await readVisibleText(page, state.id, {
+        const domText = await readVisibleText(page, state, {
           minLength: 12,
         });
         let composerText = "";
@@ -425,6 +561,35 @@ async function main() {
         console.log(
           `■ ${state.id.padEnd(26)} blue=${blue}${invalid}  ${entry.ocr_text.slice(0, 70)}`,
         );
+      } catch (error) {
+        const failedCheck = {
+          name: "capture:completed",
+          ok: false,
+          detail: compactError(error),
+        };
+        const failureFile = path.join(outDir, `${state.id}-failure.png`);
+        let failureImage = null;
+        if (page && !page.isClosed()) {
+          try {
+            await page.screenshot({ path: failureFile, fullPage: true });
+            failureImage = existsSync(failureFile) ? failureFile : null;
+          } catch {
+            // error-policy:J7 failure evidence is best-effort; the structured
+            // capture_error below is still the observed diagnostic signal.
+          }
+        }
+        reports.push(
+          buildCaptureFailureEntry({
+            state,
+            targetUrl,
+            error,
+            failureImage,
+          }),
+        );
+        captureFailures.push({ id: state.id, failedChecks: [failedCheck] });
+        console.log(
+          `x ${state.id.padEnd(26)} capture failed: ${failedCheck.detail}`,
+        );
       } finally {
         await ctx.close();
       }
@@ -437,12 +602,27 @@ async function main() {
   for (const vpName of Object.keys(VIEWPORTS)) {
     const gate = reports.find((r) => r.id === `${vpName}-onboarding`);
     const shell = reports.find((r) => r.id === `${vpName}-shell`);
-    if (!gate || !shell) continue;
-    const delta = await changeMetric(shell.image, gate.image);
-    seedDeltas.push({
-      viewport: vpName,
-      changedFraction: delta.changed_fraction,
-    });
+    if (!gate?.image || !shell?.image) {
+      seedDeltas.push({
+        viewport: vpName,
+        changedFraction: undefined,
+        reason: "missing onboarding or shell capture",
+      });
+      continue;
+    }
+    try {
+      const delta = await changeMetric(shell.image, gate.image);
+      seedDeltas.push({
+        viewport: vpName,
+        changedFraction: delta.changed_fraction,
+      });
+    } catch (error) {
+      seedDeltas.push({
+        viewport: vpName,
+        changedFraction: undefined,
+        reason: `change metric failed: ${compactError(error)}`,
+      });
+    }
   }
   const driftOffenders = seedDriftOffenders(seedDeltas);
   const verdict = aggregateVerdict(reports);

--- a/packages/app/scripts/visual-qa-live.test.mjs
+++ b/packages/app/scripts/visual-qa-live.test.mjs
@@ -46,7 +46,7 @@ describe("buildOnboardedSeed", () => {
 
 describe("buildStateMatrix", () => {
   const matrix = buildStateMatrix();
-  it("covers both viewports with fresh (gate) and onboarded (shell) profiles", () => {
+  it("covers both viewports with fresh first-run and onboarded shell profiles", () => {
     expect(
       matrix.some((s) => s.id === "desktop-onboarding" && s.seed === "fresh"),
     ).toBe(true);
@@ -54,12 +54,30 @@ describe("buildStateMatrix", () => {
       matrix.some((s) => s.id === "mobile-shell" && s.seed === "onboarded"),
     ).toBe(true);
   });
+  it("attaches DOM expectations so nonblank-but-wrong screens fail", () => {
+    expect(
+      matrix.find((s) => s.id === "desktop-onboarding")
+        ?.expectedAnyTextIncludes,
+    ).toEqual(
+      expect.arrayContaining(["Swipe for apps", "Sign in to Eliza Cloud"]),
+    );
+    expect(
+      matrix.find((s) => s.id === "desktop-shell")?.expectedAnyTextIncludes,
+    ).toEqual(expect.arrayContaining(["Settings", "Backend Unreachable"]));
+    expect(
+      matrix.find((s) => s.id === "mobile-chat")?.expectedAnyTextIncludes,
+    ).toEqual(expect.arrayContaining(["Pull chat up", "Backend Unreachable"]));
+  });
   it("only exercises the keyboard-adjacent composer on mobile", () => {
     const focused = matrix.filter((s) => s.focusComposer);
-    expect(focused).toHaveLength(1);
-    expect(focused[0].viewport).toBe("mobile");
-    expect(focused[0].seed).toBe("onboarded");
-    expect(focused[0].route).toBe("/chat");
+    expect(focused).toHaveLength(2);
+    expect(focused.every((s) => s.viewport === "mobile")).toBe(true);
+    expect(focused.map((s) => s.id)).toEqual([
+      "mobile-onboarding-composer-focused",
+      "mobile-composer-focused",
+    ]);
+    expect(focused.map((s) => s.seed)).toEqual(["fresh", "onboarded"]);
+    expect(focused.map((s) => s.route)).toEqual(["/", "/chat"]);
   });
   it("gives every state a unique id", () => {
     const ids = matrix.map((s) => s.id);
@@ -105,7 +123,7 @@ describe("aggregateVerdict", () => {
 });
 
 describe("seedDriftOffenders", () => {
-  it("passes when the seeded shell differs materially from the gate", () => {
+  it("passes when the seeded shell differs materially from the first-run surface", () => {
     expect(
       seedDriftOffenders([
         { viewport: "desktop", changedFraction: 0.41 },
@@ -113,7 +131,7 @@ describe("seedDriftOffenders", () => {
       ]),
     ).toEqual([]);
   });
-  it("flags a viewport whose seeded shell re-rendered the gate", () => {
+  it("flags a viewport whose seeded shell re-rendered the first-run surface", () => {
     const offenders = seedDriftOffenders([
       { viewport: "desktop", changedFraction: 0.41 },
       { viewport: "mobile", changedFraction: 0.001 },
@@ -123,6 +141,23 @@ describe("seedDriftOffenders", () => {
   it("treats an unmeasured delta as drift, never as a pass", () => {
     expect(seedDriftOffenders([{ viewport: "desktop" }])).toEqual([
       { viewport: "desktop", changedFraction: undefined },
+    ]);
+  });
+  it("preserves the reason when a seed-drift measurement could not run", () => {
+    expect(
+      seedDriftOffenders([
+        {
+          viewport: "desktop",
+          changedFraction: undefined,
+          reason: "missing onboarding or shell capture",
+        },
+      ]),
+    ).toEqual([
+      {
+        viewport: "desktop",
+        changedFraction: undefined,
+        reason: "missing onboarding or shell capture",
+      },
     ]);
   });
 });
@@ -156,7 +191,7 @@ describe("buildOverallVerdict", () => {
     ]);
   });
 
-  it("fails when the onboarded seed drifts back to the gate", () => {
+  it("fails when the onboarded seed drifts back to the first-run surface", () => {
     const verdict = buildOverallVerdict({
       colorVerdict: { pass: true },
       captureFailures: [],
@@ -174,6 +209,60 @@ describe("evaluateCaptureReadiness", () => {
       domText: "Backend Unreachable Try again",
     });
     expect(v.pass).toBe(true);
+  });
+
+  it("requires each expected text fragment for state-specific captures", () => {
+    const state = {
+      id: "desktop-onboarding",
+      expectedTextIncludes: ["Swipe for apps", "Pull chat up"],
+    };
+    expect(
+      evaluateCaptureReadiness({
+        state,
+        domText: "Good night. Swipe for apps. Pull chat up.",
+      }).pass,
+    ).toBe(true);
+    const v = evaluateCaptureReadiness({
+      state,
+      domText: "Good night. Ask Dev Smoke.",
+    });
+    expect(v.pass).toBe(false);
+    expect(v.checks.filter((c) => c.name === "dom:expected_text")).toEqual([
+      {
+        name: "dom:expected_text",
+        ok: false,
+        detail: 'visible DOM text does not contain "Swipe for apps"',
+      },
+      {
+        name: "dom:expected_text",
+        ok: false,
+        detail: 'visible DOM text does not contain "Pull chat up"',
+      },
+    ]);
+  });
+
+  it("accepts any one of the configured degraded chat surfaces", () => {
+    const state = {
+      id: "mobile-chat",
+      expectedAnyTextIncludes: ["Pull chat up", "Backend Unreachable"],
+    };
+    expect(
+      evaluateCaptureReadiness({
+        state,
+        domText: "Startup failed: Backend Unreachable. Open App.",
+      }).pass,
+    ).toBe(true);
+    const v = evaluateCaptureReadiness({
+      state,
+      domText: "Settings Wallet Tasks",
+    });
+    expect(v.pass).toBe(false);
+    expect(v.checks).toContainEqual({
+      name: "dom:expected_any_text",
+      ok: false,
+      detail:
+        'visible DOM text does not contain any of "Pull chat up", "Backend Unreachable"',
+    });
   });
 
   it("fails blank captures before color heuristics can hide them", () => {


### PR DESCRIPTION
## Summary
- Hardens the live visual-QA sweep so each state records semantic DOM expectations, not just "not blank" and color metrics.
- Preserves structured report rows and best-effort failure screenshots when a state fails before screenshot/OCR/color analysis.
- Makes the mobile composer proof recover through the visible `Open App` startup boundary, including a text fallback when role lookup is unavailable.
- Updates unit coverage for state expectations, failure aggregation, and focused composer readiness.

## Evidence
Fast checks on `d465b4beebd52286eb2bb0e30237ef4043e7adf8`:
- `node --check packages/app/scripts/visual-qa-live.mjs` — pass
- `node --check packages/app/scripts/visual-qa-live.test.mjs` — pass
- `bunx @biomejs/biome check packages/app/scripts/lib/visual-qa.mjs packages/app/scripts/visual-qa-live.mjs packages/app/scripts/visual-qa-live.test.mjs packages/app/package.json` — pass
- `bunx vitest run packages/app/scripts/visual-qa-live.test.mjs packages/app/scripts/lib/visual-qa.test.ts` — 2 files, 33 tests passed
- `git diff --check` — pass

Live visual QA:
- Command: `node packages/app/scripts/visual-qa-live.mjs --base http://127.0.0.1:42138 --out /tmp/eliza-visual-qa-live-pr-d465 --strict`
- Result: PASS; 8 states; `captureFailures=[]`; `driftOffenders=[]`; no blue offenders with ceiling `0.02`.
- Seed deltas: desktop `0.9581`, mobile `0.9397`.
- Report: `/tmp/eliza-visual-qa-live-pr-d465/report.json`.
- Manually reviewed `/tmp/eliza-visual-qa-live-pr-d465/mobile-composer-focused.png`; the typed reminder is visible in the composer and the send affordance is present. Noted residual UX debt: a small loading spinner/ghosted hint can remain behind the sheet in the no-backend dev-server path.

Failure preservation proof:
- Command: `node packages/app/scripts/visual-qa-live.mjs --base http://127.0.0.1:9 --out /tmp/eliza-visual-qa-failure-pr-d465 --strict`
- Result: expected exit `1`; `report.json` exists; 8 report rows; 8 capture failures; first row records `capture:completed` and `brand:no_blue` as failed because capture/color analysis never completed.
- Report: `/tmp/eliza-visual-qa-failure-pr-d465/report.json`.

N/A:
- Real LLM trajectories: N/A, tooling-only visual-QA harness change; no model, prompt, action, provider, or planner behavior changed.
- Full app audit: N/A for this PR because product UI code is not changed; this patch improves the fast live sweep used before/dependent on app audits.
