### PR TITLE
perf(agent): precheck proactive gate before the judge to skip discarded model calls (#14678)

### DIFF
--- a/packages/agent/src/services/proactive-interaction-decider.test.ts
+++ b/packages/agent/src/services/proactive-interaction-decider.test.ts
@@ -123,6 +123,39 @@ describe("decideProactiveComment (#8792)", () => {
     expect(res.reason).toContain("cooldown");
   });
 
+  it("does not spend a judge call when the gate denies pre-judge (#14678)", async () => {
+    const gate = new ProactiveInteractionGate(configForChattiness("subtle"));
+    const judge = vi.fn(async () => "offer");
+    // First user switch is admitted (one judge call, consumed).
+    await decideProactiveComment({ payload: payload(), gate, judge, now: 0 });
+    expect(judge).toHaveBeenCalledTimes(1);
+    // A settled second switch to a DIFFERENT surface inside the global cooldown
+    // window is text-independently deniable — the judge must not be called.
+    const res = await decideProactiveComment({
+      payload: payload({ viewId: "calendar", viewLabel: "Calendar" }),
+      gate,
+      judge,
+      now: 30_000,
+    });
+    expect(res.text).toBeNull();
+    expect(res.reason).toContain("cooldown");
+    // Still only the first call — the cooldown short-circuited before the judge.
+    expect(judge).toHaveBeenCalledTimes(1);
+  });
+
+  it("still invokes the judge when the gate would admit pre-judge (#14678)", async () => {
+    const gate = new ProactiveInteractionGate(configForChattiness("subtle"));
+    const judge = vi.fn(async () => "pull balances?");
+    const res = await decideProactiveComment({
+      payload: payload(),
+      gate,
+      judge,
+      now: 0,
+    });
+    expect(judge).toHaveBeenCalledTimes(1);
+    expect(res.text).toBe("pull balances?");
+  });
+
   it("debounces a burst: an immediate re-switch is not yet settled", async () => {
     const gate = new ProactiveInteractionGate(configForChattiness("subtle"));
     const judge = async () => "offer";

--- a/packages/agent/src/services/proactive-interaction-decider.ts
+++ b/packages/agent/src/services/proactive-interaction-decider.ts
@@ -179,6 +179,17 @@ export async function decideProactiveComment(
     };
   }
 
+  // Text-independent gate precheck BEFORE the (paid) judge. Daily cap, global
+  // cooldown, and per-surface cooldown are all knowable without the candidate
+  // text, and tryAdmit would discard the judge output unconditionally if any of
+  // them fails. Short-circuit here so a settled view-switch during a cooldown /
+  // cap window costs zero model calls (#14678). Only textual dedup still needs
+  // the candidate, so the final tryAdmit below remains the source of truth.
+  const precheck = gate.wouldAdmit(surface, now);
+  if (!precheck.admitted) {
+    return { text: null, delivery: null, reason: precheck.reason };
+  }
+
   const candidate = normalizeProactiveOffer(await judge(payload));
   if (!candidate) {
     return {

--- a/packages/agent/src/services/proactive-interaction-gate.test.ts
+++ b/packages/agent/src/services/proactive-interaction-gate.test.ts
@@ -117,6 +117,42 @@ describe("ProactiveInteractionGate — UX governance (#8792)", () => {
     expect(r.admitted).toBe(false);
     expect(r.reason).toBe("disabled");
   });
+
+  it("wouldAdmit is a non-mutating text-independent precheck (#14678)", () => {
+    const g = gate(SUBTLE);
+    // Pure precheck: no emission recorded, so calling it many times never
+    // consumes the daily cap or arms a cooldown.
+    for (let i = 0; i < 5; i++) {
+      const w = g.wouldAdmit("wallet", 0);
+      expect(w.admitted).toBe(true);
+      expect(w.reason).toBe("ok");
+    }
+    // A real admission still goes through, proving wouldAdmit did not mutate.
+    expect(
+      g.tryAdmit({ surface: "wallet", text: "pull balances?", now: 0 })
+        .admitted,
+    ).toBe(true);
+  });
+
+  it("wouldAdmit mirrors tryAdmit's text-independent denials (#14678)", () => {
+    const g = gate(SUBTLE);
+    g.tryAdmit({ surface: "wallet", text: "a", now: 0 });
+    // Global cooldown across surfaces is text-independent — precheck sees it.
+    const w = g.wouldAdmit("calendar", 30_000);
+    expect(w.admitted).toBe(false);
+    expect(w.reason).toBe("global cooldown");
+    // And it matches what tryAdmit would report for the same surface/time.
+    expect(
+      g.tryAdmit({ surface: "calendar", text: "b", now: 30_000 }).reason,
+    ).toBe("global cooldown");
+  });
+
+  it("wouldAdmit reports 'disabled' when chattiness is off (#14678)", () => {
+    const g = gate(configForChattiness("off"));
+    const w = g.wouldAdmit("wallet", 0);
+    expect(w.admitted).toBe(false);
+    expect(w.reason).toBe("disabled");
+  });
 });
 
 describe("resolveProactiveChattiness — kill-switch + setting", () => {

--- a/packages/agent/src/services/proactive-interaction-gate.ts
+++ b/packages/agent/src/services/proactive-interaction-gate.ts
@@ -175,13 +175,28 @@ export class ProactiveInteractionGate {
   }
 
   /**
-   * Check every gate and, when all pass, record the emission. Returns the first
-   * failing reason so callers can log why a comment was suppressed.
+   * Evaluate every text-INDEPENDENT gate (disabled, settle, daily cap, global
+   * cooldown, per-surface cooldown) without touching the candidate text and
+   * without recording anything. Returns the first failing reason, or `"ok"`
+   * when the surface would currently be admitted pending only textual dedup.
+   *
+   * Callers use this as a cheap precheck BEFORE soliciting the (paid) model
+   * judge: if the gate would deny on a text-independent rule, there is no point
+   * spending a judge call whose output {@link tryAdmit} would discard
+   * unconditionally (#14678). It never mutates gate state, so a real admission
+   * still goes through {@link tryAdmit}.
    */
-  tryAdmit(input: AdmitInput): AdmitResult {
-    const { surface, text, now } = input;
+  wouldAdmit(surface: string, now: number): AdmitResult {
     this.pruneOlderThan(now);
+    return this.checkTextIndependentGates(surface, now);
+  }
 
+  /**
+   * The text-independent portion of the admission gate. Shared by
+   * {@link wouldAdmit} (precheck) and {@link tryAdmit} (commit) so the two can
+   * never drift. Assumes {@link pruneOlderThan} has already run.
+   */
+  private checkTextIndependentGates(surface: string, now: number): AdmitResult {
     if (this.config.chattiness === "off" || this.config.dailyCap <= 0) {
       return { admitted: false, reason: "disabled" };
     }
@@ -207,6 +222,21 @@ export class ProactiveInteractionGate {
       now - lastForSurface.at < this.config.perSurfaceCooldownMs
     ) {
       return { admitted: false, reason: "per-surface cooldown" };
+    }
+    return { admitted: true, reason: "ok" };
+  }
+
+  /**
+   * Check every gate and, when all pass, record the emission. Returns the first
+   * failing reason so callers can log why a comment was suppressed.
+   */
+  tryAdmit(input: AdmitInput): AdmitResult {
+    const { surface, text, now } = input;
+    this.pruneOlderThan(now);
+
+    const textIndependent = this.checkTextIndependentGates(surface, now);
+    if (!textIndependent.admitted) {
+      return textIndependent;
     }
     // Textual dedup (same surface + same text within the window).
     const normalized = text.trim().toLowerCase();


### PR DESCRIPTION
## Problem

`decideProactiveComment` (`packages/agent/src/services/proactive-interaction-decider.ts`) runs the TEXT_SMALL judge **before** `gate.tryAdmit`, but three of the four admission rules — daily cap, global cooldown, per-surface cooldown (`proactive-interaction-gate.ts`) — are text-independent and knowable pre-judge. Only textual dedup needs the candidate.

Under the default `subtle` policy (dailyCap 12, 2-min global / 10-min per-surface cooldown), every settled view switch inside a cooldown window spends a model call whose output `tryAdmit` discards unconditionally — a per-navigation token leak on a default-on feature. The `NON_PROACTIVE_SHORTCUT_IDS` header already treats pre-gate judge calls as a cost to avoid; this closes the same gap for the cooldown/cap rules.

## Fix

- Add `ProactiveInteractionGate.wouldAdmit(surface, now)`: a **non-mutating**, text-independent precheck (disabled + settle + daily cap + global cooldown + per-surface cooldown). No dedup, no recording.
- Call it in `decideProactiveComment` **before** the judge. On deny, short-circuit with the gate's reason and skip the judge entirely.
- Extract the shared checks into a private `checkTextIndependentGates()` used by both `wouldAdmit` (precheck) and `tryAdmit` (commit) so the two can't drift. `tryAdmit` still runs the same checks + textual dedup + records the emission, so **admitted-offer behavior is unchanged**.

## Tests

Decider (`proactive-interaction-decider.test.ts`):
- the judge is **not** called when the gate would deny pre-judge (global cooldown) — asserted via a `vi.fn` call count; **red before the fix, green after** (verified by reverting the precheck).
- the judge **is** called when the gate would admit.

Gate (`proactive-interaction-gate.test.ts`):
- `wouldAdmit` is non-mutating (repeated calls never consume the cap / arm a cooldown, and a real `tryAdmit` still admits afterward).
- `wouldAdmit` mirrors `tryAdmit`'s text-independent denial reason (`global cooldown`).
- `wouldAdmit` reports `disabled` when chattiness is off.

```
$ npx vitest run \
    src/services/proactive-interaction-gate.test.ts \
    src/services/proactive-interaction-decider.test.ts \
    src/services/proactive-interaction-decider.wiring.test.ts \
    src/api/proactive-interaction-pipeline.test.ts
 Test Files  4 passed (4)
      Tests  60 passed (60)
```

Biome clean on all touched files (`@biomejs/biome@2.5.1`).

_Codex review timed out headless (>100s, no output); self-reviewed instead: `tryAdmit`'s check ordering + `pruneOlderThan`-first are preserved exactly, `wouldAdmit` performs no `emissions.push`, and the double prune across `wouldAdmit`+`tryAdmit` on the admit path is idempotent._

Closes #14678

— [sol-orch]