### PR TITLE
fix(inbox): make the one-tap Snooze chip actually snooze (#14735)

### DIFF
--- a/plugins/plugin-inbox/src/actions/inbox.ts
+++ b/plugins/plugin-inbox/src/actions/inbox.ts
@@ -514,10 +514,13 @@ const DEFAULT_SNOOZE_MS = 24 * 60 * 60 * 1000;
  */
 function resolveSnoozeUntil(params: InboxActionParameters): string | null {
   const raw = params.snoozedUntil ?? params.until;
-  if (typeof raw !== "string" || !raw.trim()) {
+  if (raw === undefined) {
     return new Date(Date.now() + DEFAULT_SNOOZE_MS).toISOString();
   }
-  const parsed = Date.parse(raw);
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const parsed = Date.parse(trimmed);
   if (!Number.isFinite(parsed)) return null;
   return new Date(parsed).toISOString();
 }

--- a/plugins/plugin-inbox/src/actions/inbox.ts
+++ b/plugins/plugin-inbox/src/actions/inbox.ts
@@ -498,9 +498,25 @@ function parseConfirmation(value: unknown): boolean {
   return false;
 }
 
-function parseSnoozeUntil(params: InboxActionParameters): string | null {
+/** Default snooze window when a tap sends no explicit timestamp: ~1 day out. */
+const DEFAULT_SNOOZE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Resolve the snooze-until timestamp for a snooze op.
+ *
+ * Three outcomes, kept distinct on purpose:
+ *   - a valid explicit timestamp  -> that ISO instant
+ *   - NO timestamp at all          -> the default window (one-tap Snooze chip:
+ *                                     its value is a bare `inbox snooze <id>`,
+ *                                     so a tap carries no time to parse #14735)
+ *   - an INVALID timestamp         -> `null`, so the caller rejects bad input
+ *                                     instead of silently snoozing to default
+ */
+function resolveSnoozeUntil(params: InboxActionParameters): string | null {
   const raw = params.snoozedUntil ?? params.until;
-  if (typeof raw !== "string" || !raw.trim()) return null;
+  if (typeof raw !== "string" || !raw.trim()) {
+    return new Date(Date.now() + DEFAULT_SNOOZE_MS).toISOString();
+  }
   const parsed = Date.parse(raw);
   if (!Number.isFinite(parsed)) return null;
   return new Date(parsed).toISOString();
@@ -749,7 +765,7 @@ export async function executeInboxQueueOperation(args: {
     }
     case "snooze": {
       const id = requireEntryId(args.params);
-      const until = parseSnoozeUntil(args.params);
+      const until = resolveSnoozeUntil(args.params);
       if (!until) {
         throw new Error("valid snooze timestamp is required");
       }

--- a/plugins/plugin-inbox/test/inbox-action.test.ts
+++ b/plugins/plugin-inbox/test/inbox-action.test.ts
@@ -737,6 +737,25 @@ describe("INBOX umbrella action — cross-channel inbox", () => {
       );
       expect(update?.sql).toContain("resolved = FALSE");
     });
+
+    it("rejects an explicit malformed snooze timestamp instead of applying the default window", async () => {
+      const { runtime, calls } = makeDbRuntime((sql) => {
+        if (sql.startsWith("SELECT")) return [makeTriageRow({ id: "entry-1" })];
+        return [];
+      });
+
+      const result = await callInbox(runtime, makeMessage(), {
+        subaction: "snooze",
+        entryId: "entry-1",
+        snoozedUntil: 24 * 60 * 60 * 1000,
+      } as unknown as InboxActionParameters);
+
+      expect(result.success).toBe(false);
+      expect(result.data).toMatchObject({ error: "INBOX_OPERATION_FAILED" });
+      expect(
+        calls.filter((call) => call.sql.startsWith("UPDATE")),
+      ).toHaveLength(0);
+    });
   });
 
   // The marker builders themselves are pinned by inbox-choice-markers.test.ts;

--- a/plugins/plugin-inbox/test/inbox-action.test.ts
+++ b/plugins/plugin-inbox/test/inbox-action.test.ts
@@ -949,5 +949,42 @@ describe("INBOX umbrella action — cross-channel inbox", () => {
         entryId: "e2",
       });
     });
+
+    it("a snooze chip value round-trips into a successful default snooze of that entry (#14735)", async () => {
+      // The Snooze chip emitted by the triage grammar carries only
+      // `inbox snooze <id>` (no timestamp — a tap has no free text to add and
+      // the value must stay under the 64-byte connector cap). Before this fix
+      // the snooze op threw "valid snooze timestamp is required", so the one
+      // shipped Snooze affordance was a guaranteed error. A bare snooze tap
+      // must now succeed with a sane default window instead of failing.
+      const before = Date.now();
+      const { runtime, calls } = makeDbRuntime((sql) =>
+        sql.startsWith("SELECT") ? [makeTriageRow({ id: "e3" })] : [],
+      );
+
+      // The tapped value is exactly `inbox snooze e3`; the planner maps the
+      // tokens to subaction + entryId with NO `until`/`snoozedUntil` param.
+      const value = "inbox snooze e3";
+      const [, subaction, entryId] = value.split(" ");
+      const result = await callInbox(runtime, makeMessage(value), {
+        subaction,
+        entryId,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toMatchObject({ subaction: "snooze", entryId: "e3" });
+
+      const snoozedUntil = (result.data as { snoozedUntil?: string })
+        .snoozedUntil;
+      expect(typeof snoozedUntil).toBe("string");
+      const untilMs = Date.parse(snoozedUntil ?? "");
+      // Default window is ~24h out: safely in the future, and under two days.
+      expect(untilMs).toBeGreaterThan(before + 20 * 60 * 60 * 1000);
+      expect(untilMs).toBeLessThan(before + 48 * 60 * 60 * 1000);
+
+      const update = calls.find((call) => call.sql.startsWith("UPDATE"));
+      expect(update?.sql).toContain("snoozed_until = ");
+      expect(update?.sql).toContain("resolved = FALSE");
+    });
   });
 });


### PR DESCRIPTION
## Summary

[sol-orch] Closes #14735.

The one-tap triage slice this issue asked for — per-thread `[CHOICE]` chips on the `triage` subaction output, routed back through `executeInboxQueueOperation` — largely **landed already via #14861** (scope `inbox-thread-<id>`, Reply/Snooze/Archive chips per pending row). This PR closes the one remaining gap in that shipped grammar: the **Snooze chip was a functional dead-end.**

### The gap

The merged Snooze chip emits the value `inbox snooze <id>` — a tap carries no free text, and the value must stay under the 64-byte connector callback cap, so there is no timestamp on it. But the snooze op did:

```ts
const until = parseSnoozeUntil(args.params); // null when no timestamp
if (!until) throw new Error("valid snooze timestamp is required");
```

So tapping the one shipped Snooze affordance **always errored**. `choice-markers.ts`'s own header promises "every emitted command must map to an operation the INBOX action already supports" — the Snooze chip quietly violated it. (The existing `inbox-action.test.ts` even has an *archive*-chip round-trip test proving that path works, and no snooze equivalent — because a snooze round-trip couldn't pass.)

### The fix

`resolveSnoozeUntil` (renamed from `parseSnoozeUntil`) now distinguishes three cases deliberately:

| Input | Outcome |
|---|---|
| valid explicit timestamp | that ISO instant (unchanged) |
| **no timestamp at all** | default window, `now + 24h` — the one-tap chip path |
| explicit-but-invalid timestamp | `null` → op still throws (bad input is still rejected, not silently snoozed) |

The chip value is untouched (still under the 64-byte cap); only its *outcome* is fixed. A one-tap Snooze now snoozes ~a day, and a user who tries to snooze to a malformed time still gets an error rather than a surprise default.

## Design decisions (documented per fable-lane brief)

- **Scope naming: kept `inbox-thread-<id>`.** The issue text proposed `[CHOICE:inbox-triage id=<entryId>]`, but #14861 shipped, parsed, and tested the `inbox-thread` scope. Extending the merged dialect coherently beats reverting to a pre-merge label and forking the grammar. No new scope introduced.
- **Routeback shape: unchanged.** Chip values stay bare `inbox <op> <id>` commands that the planner maps to `subaction` + `entryId` and dispatch through the existing `executeInboxQueueOperation`. No new op, no new param surface.
- **Default is a fixed 24h, not "9am tomorrow local."** A wall-clock default would need owner-timezone plumbing the action doesn't have here (scope creep). 24h is the dependency-free, defensible floor.

## Collision check

- `gh pr list -R elizaos/eliza --search "inbox triage" / "choice chips"` — no open PR on this surface. #14861, #14939 (both merged) shipped the chip grammar; this finishes the one op they left non-functional.
- Read #14667 (open→closed ambiguous-triage guard): it touches `plugin.ts` disambiguation only, **not** `actions/inbox.ts` snooze. No diff overlap.

## Verification

- `bunx vitest run plugins/plugin-inbox/test/inbox-action.test.ts plugins/plugin-inbox/test/inbox-choice-markers.test.ts plugins/plugin-inbox/test/inbox-routes.test.ts` — **34 passed** (incl. new "a snooze chip value round-trips into a successful default snooze" + existing explicit-timestamp snooze + archive-chip round-trip).
- `bunx biome check plugins/plugin-inbox/src/actions/inbox.ts plugins/plugin-inbox/test/inbox-action.test.ts` — Checked 2 files, no fixes applied.
- `bun run --cwd plugins/plugin-inbox build:types` — passed.
- Codex review hung >100s on the VPS; killed per protocol and self-reviewed (default only fires on absent timestamp; invalid input still rejected; chip value + cap unchanged; no regression to explicit-timestamp path or route tests).

— [sol-orch]

Co-authored-by: wakesync <shadow@shad0w.xyz>
