### PR TITLE
fix(app-control): wire update settings action

### DIFF
--- a/plugins/plugin-app-control/src/actions/settings.test.ts
+++ b/plugins/plugin-app-control/src/actions/settings.test.ts
@@ -231,8 +231,7 @@ describe("registry completeness", () => {
 			trackingIssue: 14911,
 		});
 		expect(SETTINGS_WRITE_REGISTRY.updates).toMatchObject({
-			kind: "unwired",
-			trackingIssue: 14912,
+			kind: "route",
 		});
 	});
 
@@ -274,7 +273,7 @@ describe("SETTINGS action: list", () => {
 			via: "SETTINGS",
 		});
 		const updates = sections.find((s) => s.id === "updates");
-		expect(updates).toMatchObject({ writable: false, via: "not-yet-wired" });
+		expect(updates).toMatchObject({ writable: true, via: "SETTINGS" });
 	});
 });
 
@@ -873,6 +872,123 @@ describe("SETTINGS action: set on an owned route section", () => {
 	});
 });
 
+it("checks update status through the same backend route as Release Center", async () => {
+	const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({
+		ok: true,
+		data: {
+			currentVersion: "1.0.0",
+			latestVersion: "1.0.1",
+			updateAvailable: true,
+		},
+	}));
+	const { result, texts } = await invoke(
+		{ action: "set", section: "updates", key: "check" },
+		routeFetch,
+	);
+	expect(routeFetch).toHaveBeenCalledWith({
+		method: "GET",
+		path: "/api/update/status?force=true",
+	});
+	expect(result?.success).toBe(true);
+	expect(result?.data).toMatchObject({ section: "updates", key: "check" });
+	expect(texts.join(" ")).toContain("1.0.1");
+});
+
+it("switches update channel through the backend channel route", async () => {
+	const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({
+		ok: true,
+		data: { channel: "beta" },
+	}));
+	const { result, texts } = await invoke(
+		{ action: "set", section: "updates", key: "channel", value: "beta" },
+		routeFetch,
+	);
+	expect(routeFetch).toHaveBeenCalledWith({
+		method: "PUT",
+		path: "/api/update/channel",
+		body: { channel: "beta" },
+	});
+	expect(result?.success).toBe(true);
+	expect(texts.join(" ")).toContain("beta");
+});
+
+it("surfaces update-check backend errors instead of saying already current", async () => {
+	const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({
+		ok: true,
+		data: {
+			currentVersion: "1.0.0",
+			latestVersion: null,
+			updateAvailable: false,
+			error: "Unable to reach the npm registry.",
+		},
+	}));
+	const { result, texts } = await invoke(
+		{ action: "set", section: "updates", key: "check" },
+		routeFetch,
+	);
+	expect(result?.success).toBe(true);
+	expect(texts.join(" ")).toContain("Unable to reach the npm registry");
+	expect(texts.join(" ")).not.toContain("Already current");
+});
+
+it("returns the update apply plan instead of fabricating an apply job", async () => {
+	const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({
+		ok: true,
+		data: {
+			canExecuteUpdate: false,
+			updateCommand: "npm i -g @elizaos/cli@latest",
+			updateInstructions: "Run the update command from a trusted shell.",
+		},
+	}));
+	const { result, texts } = await invoke(
+		{ action: "set", section: "updates", key: "apply" },
+		routeFetch,
+	);
+	expect(routeFetch).toHaveBeenCalledWith({
+		method: "GET",
+		path: "/api/update/status?force=true",
+	});
+	expect(result?.success).toBe(true);
+	expect(texts.join(" ")).toContain("npm i -g @elizaos/cli@latest");
+});
+
+it("does not offer apply when the forced check found no available update", async () => {
+	const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({
+		ok: true,
+		data: {
+			canExecuteUpdate: true,
+			updateAvailable: false,
+			updateCommand: "elizaos update --apply",
+		},
+	}));
+	const { result, texts } = await invoke(
+		{ action: "set", section: "updates", key: "apply" },
+		routeFetch,
+	);
+	expect(result?.success).toBe(true);
+	expect(texts.join(" ")).toContain("No update is available");
+	expect(texts.join(" ")).not.toContain("elizaos update --apply");
+});
+
+it("includes the executable update command when the backend says apply is local-safe", async () => {
+	const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({
+		ok: true,
+		data: {
+			canExecuteUpdate: true,
+			updateAvailable: true,
+			updateCommand: "elizaos update --apply",
+			updateInstructions:
+				"Updates are delegated to the detected package manager.",
+		},
+	}));
+	const { result, texts } = await invoke(
+		{ action: "set", section: "updates", key: "apply" },
+		routeFetch,
+	);
+	expect(result?.success).toBe(true);
+	expect(texts.join(" ")).toContain("elizaos update --apply");
+});
+
 describe("SETTINGS action: set on delegated/readonly/unwired sections", () => {
 	it("points a delegated section at its dedicated action without writing", async () => {
 		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({ ok: true }));
@@ -898,7 +1014,7 @@ describe("SETTINGS action: set on delegated/readonly/unwired sections", () => {
 	it("refuses an unwired gap section with its stated reason", async () => {
 		const { result, texts } = await invoke({
 			action: "set",
-			section: "updates",
+			section: "voice",
 			value: "on",
 		});
 		expect(result?.success).toBe(false);

--- a/plugins/plugin-app-control/src/actions/settings.ts
+++ b/plugins/plugin-app-control/src/actions/settings.ts
@@ -592,6 +592,129 @@ function resolvePermissionNamespace(token: string | null): string | null {
 	return PERMISSION_NAMESPACE_ALIASES.get(token.trim().toLowerCase()) ?? null;
 }
 
+function readRecord(value: unknown): Record<string, unknown> {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: {};
+}
+
+function readStringField(data: unknown, field: string): string | null {
+	const value = readRecord(data)[field];
+	return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function readBooleanField(data: unknown, field: string): boolean | null {
+	const value = readRecord(data)[field];
+	return typeof value === "boolean" ? value : null;
+}
+
+function summarizeUpdateStatus(data: unknown): string {
+	const error = readStringField(data, "error");
+	if (error) return `Update check failed: ${error}`;
+
+	const currentVersion = readStringField(data, "currentVersion") ?? "unknown";
+	const latestVersion =
+		readStringField(data, "latestVersion") ?? currentVersion;
+	const channel = readStringField(data, "channel");
+	const updateAvailable = readBooleanField(data, "updateAvailable");
+	const availability =
+		updateAvailable === true
+			? `Update available: ${latestVersion}`
+			: updateAvailable === false
+				? "Already current"
+				: `Latest version: ${latestVersion}`;
+	return `${availability}. Current version: ${currentVersion}${channel ? ` on ${channel}` : ""}.`;
+}
+
+function normalizeUpdateChannel(value: string | null): string | null {
+	const normalized = value?.trim().toLowerCase();
+	return normalized === "stable" ||
+		normalized === "beta" ||
+		normalized === "nightly"
+		? normalized
+		: null;
+}
+
+const UPDATE_STATUS_KEY: SettingsWritableKey = {
+	description:
+		"Read the current release/update status without forcing a check.",
+	valueType: "command",
+	apply: async ({ routeFetch }) =>
+		routeFetch({ method: "GET", path: "/api/update/status" }),
+	successText: (_value, _request, outcome) =>
+		`Update status: ${summarizeUpdateStatus(outcome.data)}`,
+};
+
+const UPDATE_CHECK_KEY: SettingsWritableKey = {
+	description: "Force a release/update check and report the resulting status.",
+	valueType: "command",
+	apply: async ({ routeFetch }) =>
+		routeFetch({ method: "GET", path: "/api/update/status?force=true" }),
+	successText: (_value, _request, outcome) =>
+		`Update check complete. ${summarizeUpdateStatus(outcome.data)}`,
+};
+
+const UPDATE_CHANNEL_KEY: SettingsWritableKey = {
+	description: "Switch the release channel to stable, beta, or nightly.",
+	valueType: "command",
+	apply: async ({ request, routeFetch }) => {
+		const channel = normalizeUpdateChannel(request.value);
+		if (!channel) {
+			return {
+				ok: false,
+				detail: "provide value=stable, value=beta, or value=nightly",
+			};
+		}
+		return routeFetch({
+			method: "PUT",
+			path: "/api/update/channel",
+			body: { channel },
+		});
+	},
+	successText: (_value, request, outcome) => {
+		const channel =
+			readStringField(outcome.data, "channel") ??
+			normalizeUpdateChannel(request.value) ??
+			"selected";
+		return `Update channel is now ${channel}.`;
+	},
+};
+
+const UPDATE_APPLY_KEY: SettingsWritableKey = {
+	description:
+		"Return the trusted update apply plan from the release backend. It never fabricates a job when this host cannot execute updates directly.",
+	valueType: "command",
+	apply: async ({ routeFetch }) =>
+		routeFetch({ method: "GET", path: "/api/update/status?force=true" }),
+	successText: (_value, _request, outcome) => {
+		const error = readStringField(outcome.data, "error");
+		if (error)
+			return `I can't apply an update because the update check failed: ${error}`;
+
+		const updateAvailable = readBooleanField(outcome.data, "updateAvailable");
+		if (updateAvailable === false) {
+			return "No update is available to apply.";
+		}
+
+		const canExecute = readBooleanField(outcome.data, "canExecuteUpdate");
+		const command = readStringField(outcome.data, "updateCommand");
+		const instructions = readStringField(outcome.data, "updateInstructions");
+		if (canExecute === true) {
+			const prefix = command
+				? `Update is ready to apply. Run: ${command}`
+				: "Update is ready to apply from the Release Center.";
+			return instructions ? `${prefix} ${instructions}` : prefix;
+		}
+		return command
+			? `I can't apply this update directly from chat on this host. Run: ${command}`
+			: `I can't apply this update directly from chat on this host.${
+					instructions
+						? ` ${instructions}`
+						: " Open Release Center for the apply instructions."
+				}`;
+	},
+};
+
 const APP_PERMISSION_NAMESPACE_KEY: SettingsWritableKey = {
 	description:
 		"Grant or revoke one recognised permission namespace for a registered app. Requires app=<slug>; key/namespace is fs or net.",
@@ -768,10 +891,18 @@ export const SETTINGS_WRITE_REGISTRY: Readonly<
 		trackingIssue: 14911,
 	},
 	updates: {
-		kind: "unwired",
-		reason:
-			"Update check/apply is an asynchronous job surface, not a settings value.",
-		trackingIssue: 14912,
+		kind: "route",
+		summary:
+			"Release/update status, forced update checks, release-channel changes, and trusted apply instructions.",
+		keys: {
+			status: UPDATE_STATUS_KEY,
+			check: UPDATE_CHECK_KEY,
+			"check-for-updates": UPDATE_CHECK_KEY,
+			channel: UPDATE_CHANNEL_KEY,
+			"set-channel": UPDATE_CHANNEL_KEY,
+			apply: UPDATE_APPLY_KEY,
+			"apply-update": UPDATE_APPLY_KEY,
+		},
 	},
 	advanced: {
 		kind: "route",


### PR DESCRIPTION
## Summary
- wire the SETTINGS `updates` section to existing `/api/update/status` and `/api/update/channel` backend routes
- support `status`, forced `check`, `channel`, and `apply` instructions without fabricating a remote apply job
- surface update-check errors and avoid offering apply when no update is available

## Tests
```
bun run --cwd packages/core prebuild
```

```
bunx @biomejs/biome check plugins/plugin-app-control/src/actions/settings.ts plugins/plugin-app-control/src/actions/settings.test.ts

Checked 2 files in 42ms. No fixes applied.
```

```
bun run --cwd plugins/plugin-app-control test src/actions/settings.test.ts

✓ src/actions/settings.test.ts (68 tests) 50ms

Test Files  1 passed (1)
Tests  68 passed (68)
```

Codex review: no blocking correctness issues found after follow-up fixes.

Closes #14912

signed — [sol-orch]