### PR TITLE
fix(lifeops): deliver check-ins before persisting

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/checkin/checkin-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/checkin/checkin-service.ts
@@ -1347,8 +1347,17 @@ export class CheckinService {
       ...reportWithoutSummary,
       summaryText: await this.renderSummary(reportWithoutSummary),
     };
-    await this.persistReport(report, now);
+    if (request.persist !== false) {
+      await this.persistReport(report, now);
+    }
     return report;
+  }
+
+  public async persistCheckinReport(
+    report: CheckinReport,
+    now = new Date(report.generatedAt),
+  ): Promise<void> {
+    await this.persistReport(report, now);
   }
 
   private fallbackSummary(report: Omit<CheckinReport, "summaryText">): string {

--- a/plugins/plugin-personal-assistant/src/lifeops/checkin/types.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/checkin/types.ts
@@ -132,6 +132,12 @@ export interface RunCheckinRequest {
   readonly now?: Date;
   readonly timezone?: string;
   /**
+   * Sleep-cycle dispatchers set this false while they are still proving an
+   * actual delivery surface accepted the report. A persisted report is the
+   * local-day idempotency marker, so failed delivery must not write it.
+   */
+  readonly persist?: boolean;
+  /**
    * Night-only sleep recap to thread into the night-summary prompt. Built by
    * `processSleepCycleCheckins` from the merged schedule-state record. Ignored
    * for morning check-ins.

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.checkin-chips.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.checkin-chips.test.ts
@@ -1,13 +1,16 @@
 /**
- * Sleep-cycle check-in delivery carries one-tap ack chips (#14733): the
- * morning/night summary emitted onto the assistant stream must end with a
- * `[CHOICE:checkin-<reportId>]` block. The marker builder itself is pinned by
- * lifeops-choice-markers.test.ts; this suite covers the DISPATCH wiring —
- * deterministic vitest with the check-in engine and sleep-cycle predicates
- * mocked, so only summary+chips → emitAssistantEvent is under test.
+ * Sleep-cycle check-in delivery carries one-tap ack chips and honest delivery
+ * accounting. The marker builder itself is pinned by
+ * lifeops-choice-markers.test.ts; this suite covers the dispatch wiring with a
+ * mocked check-in engine so generated reports only become day-done markers
+ * after an app stream or connector accepts the message.
  */
 import { parseInteractionBlocks } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createChannelRegistry,
+  registerChannelRegistry,
+} from "../channels/index.js";
 import type { LifeOpsContext } from "../lifeops-context.js";
 import { type RemindersDeps, RemindersDomain } from "./reminders-service.js";
 
@@ -23,6 +26,7 @@ const checkinMocks = vi.hoisted(() => ({
     summaryText: "Night recap.",
     escalationLevel: 0,
   })),
+  persistCheckinReport: vi.fn(async () => undefined),
 }));
 
 vi.mock("../checkin/checkin-service.js", () => ({
@@ -30,6 +34,7 @@ vi.mock("../checkin/checkin-service.js", () => ({
     hasCheckinForLocalDay = checkinMocks.hasCheckinForLocalDay;
     runMorningCheckin = checkinMocks.runMorningCheckin;
     runNightCheckin = checkinMocks.runNightCheckin;
+    persistCheckinReport = checkinMocks.persistCheckinReport;
   },
 }));
 
@@ -52,10 +57,23 @@ vi.mock("@elizaos/plugin-health", async (importOriginal) => {
 
 const NOW = new Date("2026-07-05T08:00:00.000Z");
 
-function makeDomain() {
-  const emitAssistantEvent = vi.fn();
+const routeCandidates = [
+  {
+    channel: "in_app",
+    score: 450,
+    evidence: ["default in-app anchor"],
+    vetoReasons: [],
+    interruptionBudget: "normal",
+  },
+];
+
+function makeDomain(
+  contactRouteCandidates: Array<Record<string, unknown>> = routeCandidates,
+) {
+  const emitAssistantEvent = vi.fn(() => true);
+  const runtime = { emitEvent: vi.fn(async () => undefined) };
   const ctx = {
-    runtime: { emitEvent: vi.fn(async () => undefined) },
+    runtime,
     repository: {},
     agentId: () => "00000000-0000-0000-0000-0000000000dd",
     emitAssistantEvent,
@@ -78,8 +96,11 @@ function makeDomain() {
     domain as unknown as {
       buildOwnerContactRouteEventMetadata: unknown;
     }
-  ).buildOwnerContactRouteEventMetadata = vi.fn(async () => ({}));
-  return { domain, emitAssistantEvent };
+  ).buildOwnerContactRouteEventMetadata = vi.fn(async () => ({
+    contactRoutePurpose: "checkin",
+    contactRouteCandidates,
+  }));
+  return { domain, emitAssistantEvent, runtime };
 }
 
 const currentSchedule = {
@@ -107,15 +128,20 @@ beforeEach(() => {
   checkinMocks.hasCheckinForLocalDay.mockClear();
   checkinMocks.hasCheckinForLocalDay.mockResolvedValue(false);
   checkinMocks.runMorningCheckin.mockClear();
+  checkinMocks.runNightCheckin.mockClear();
+  checkinMocks.persistCheckinReport.mockClear();
 });
 
-describe("sleep-cycle check-in dispatch (#14733)", () => {
-  it("emits the morning summary with ack chips onto the assistant stream", async () => {
+describe("sleep-cycle check-in dispatch (#14702, #14733)", () => {
+  it("emits the morning summary with ack chips and persists only after the assistant stream accepts it", async () => {
     const { domain, emitAssistantEvent } = makeDomain();
 
     await runSleepCycleCheckins(domain);
 
     expect(checkinMocks.runMorningCheckin).toHaveBeenCalledTimes(1);
+    expect(checkinMocks.runMorningCheckin).toHaveBeenCalledWith(
+      expect.objectContaining({ now: NOW, timezone: "UTC", persist: false }),
+    );
     expect(emitAssistantEvent).toHaveBeenCalledTimes(1);
     const [text, source, data] = emitAssistantEvent.mock.calls[0] as [
       string,
@@ -140,9 +166,13 @@ describe("sleep-cycle check-in dispatch (#14733)", () => {
       "details rep-morning-1",
       "snooze rep-morning-1",
     ]);
+    expect(checkinMocks.persistCheckinReport).toHaveBeenCalledWith(
+      expect.objectContaining({ reportId: "rep-morning-1" }),
+      NOW,
+    );
   });
 
-  it("skips the emit entirely when the day's check-in already went out", async () => {
+  it("skips the emit and persist entirely when the day's check-in already went out", async () => {
     checkinMocks.hasCheckinForLocalDay.mockResolvedValue(true);
     const { domain, emitAssistantEvent } = makeDomain();
 
@@ -150,5 +180,80 @@ describe("sleep-cycle check-in dispatch (#14733)", () => {
 
     expect(checkinMocks.runMorningCheckin).not.toHaveBeenCalled();
     expect(emitAssistantEvent).not.toHaveBeenCalled();
+    expect(checkinMocks.persistCheckinReport).not.toHaveBeenCalled();
+  });
+
+  it("does not persist a generated report when no delivery surface accepts it", async () => {
+    const { domain, emitAssistantEvent } = makeDomain();
+    emitAssistantEvent.mockReturnValue(false);
+
+    await runSleepCycleCheckins(domain);
+
+    expect(checkinMocks.runMorningCheckin).toHaveBeenCalledTimes(1);
+    expect(emitAssistantEvent).toHaveBeenCalledTimes(1);
+    expect(checkinMocks.persistCheckinReport).not.toHaveBeenCalled();
+  });
+
+  it("falls through from unavailable in-app delivery to the next connector route before persisting", async () => {
+    const smsSend = vi.fn(async () => ({ ok: true, messageId: "sms-1" }));
+    const { domain, emitAssistantEvent, runtime } = makeDomain([
+      ...routeCandidates,
+      {
+        channel: "sms",
+        score: 320,
+        evidence: ["primary direct policy"],
+        vetoReasons: [],
+        interruptionBudget: "normal",
+      },
+    ]);
+    emitAssistantEvent.mockReturnValue(false);
+    const registry = createChannelRegistry();
+    registry.register({
+      kind: "sms",
+      describe: { label: "SMS" },
+      capabilities: {
+        send: true,
+        read: false,
+        reminders: true,
+        voice: false,
+        attachments: false,
+        quietHoursAware: true,
+      },
+      send: smsSend,
+    });
+    registerChannelRegistry(runtime as never, registry);
+    (
+      domain as unknown as {
+        resolvePrimaryChannelPolicy: RemindersDomain["resolvePrimaryChannelPolicy"];
+      }
+    ).resolvePrimaryChannelPolicy = vi.fn(async () => ({
+      id: "policy-sms",
+      agentId: "00000000-0000-0000-0000-0000000000dd",
+      channelType: "sms",
+      channelRef: "+15551230000",
+      enabled: true,
+      priority: 1,
+      createdAt: NOW.toISOString(),
+      updatedAt: NOW.toISOString(),
+      metadata: {},
+    }));
+
+    await runSleepCycleCheckins(domain);
+
+    expect(emitAssistantEvent).toHaveBeenCalledTimes(1);
+    expect(smsSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: "+15551230000",
+        message: expect.stringContaining("Morning! 2 meetings today"),
+        metadata: expect.objectContaining({
+          checkinKind: "morning",
+          reportId: "rep-morning-1",
+        }),
+      }),
+    );
+    expect(checkinMocks.persistCheckinReport).toHaveBeenCalledWith(
+      expect.objectContaining({ reportId: "rep-morning-1" }),
+      NOW,
+    );
   });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
@@ -96,6 +96,7 @@ import {
   readNativeAppleReminderMetadata,
   updateNativeAppleReminderLikeItem,
 } from "../apple-reminders.js";
+import { getChannelRegistry } from "../channels/index.js";
 import {
   CheckinService,
   type CheckinSourceService,
@@ -103,6 +104,7 @@ import {
 import { reportSuppressedSleepCycleMorningCheckin } from "../checkin/morning-checkin-ownership.js";
 import { resolveCheckinSchedule } from "../checkin/schedule-resolver.js";
 import { appendCheckinAckChoiceMarker } from "../choice-markers.js";
+import type { DispatchResult } from "../connectors/contract.js";
 import {
   type ContactRoutePurpose,
   resolveContactRouteCandidates,
@@ -884,6 +886,25 @@ function serializeContactRouteCandidates(
     vetoReasons: candidate.vetoReasons,
     interruptionBudget: candidate.interruptionBudget,
   }));
+}
+
+type SerializedContactRouteCandidate = ReturnType<
+  typeof serializeContactRouteCandidates
+>[number];
+
+function readSerializedContactRouteCandidates(
+  value: unknown,
+): SerializedContactRouteCandidate[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(
+    (candidate): candidate is SerializedContactRouteCandidate =>
+      typeof candidate === "object" &&
+      candidate !== null &&
+      isReminderChannel((candidate as { channel?: unknown }).channel) &&
+      Array.isArray((candidate as { vetoReasons?: unknown }).vetoReasons),
+  );
 }
 
 function formatNearbyReminderTitlesForPrompt(titles: string[]): string {
@@ -2857,6 +2878,129 @@ export class RemindersDomain {
         contactRouteError: lifeOpsErrorMessage(error),
       };
     }
+  }
+
+  private async resolveCheckinRouteTarget(
+    channel: LifeOpsReminderChannel,
+  ): Promise<string | null> {
+    const policy = await this.resolvePrimaryChannelPolicy(channel);
+    if (channel === "sms" || channel === "voice") {
+      return normalizeOptionalString(policy?.channelRef) ?? null;
+    }
+    const runtimeTarget = await this.resolveRuntimeReminderTarget(
+      channel as Exclude<
+        LifeOpsReminderStep["channel"],
+        "in_app" | "sms" | "voice"
+      >,
+      policy,
+    );
+    if (!runtimeTarget) {
+      return null;
+    }
+    return (
+      normalizeOptionalString(runtimeTarget.target.channelId) ??
+      normalizeOptionalString(runtimeTarget.target.roomId) ??
+      normalizeOptionalString(runtimeTarget.target.entityId) ??
+      null
+    );
+  }
+
+  private async dispatchCheckinReport(args: {
+    reportId: string;
+    kind: "morning" | "night";
+    message: string;
+    metadata: Record<string, unknown>;
+  }): Promise<DispatchResult> {
+    const candidates = readSerializedContactRouteCandidates(
+      args.metadata.contactRouteCandidates,
+    );
+    const rankedCandidates =
+      candidates.length > 0
+        ? candidates
+        : [
+            {
+              channel: "in_app",
+              score: 0,
+              evidence: ["fallback in-app surface"],
+              vetoReasons: [],
+              interruptionBudget: "normal",
+            } satisfies SerializedContactRouteCandidate,
+          ];
+    const registry = getChannelRegistry(this.ctx.runtime);
+    let lastFailure: DispatchResult = {
+      ok: false,
+      reason: "disconnected",
+      userActionable: true,
+      message: "No eligible check-in delivery route was available.",
+    };
+
+    for (const candidate of rankedCandidates) {
+      if (candidate.vetoReasons.length > 0) {
+        continue;
+      }
+      if (candidate.channel === "in_app") {
+        const accepted = this.ctx.emitAssistantEvent(
+          args.message,
+          "lifeops-checkin",
+          args.metadata,
+        );
+        if (accepted) {
+          return {
+            ok: true,
+            messageId: `assistant-stream:${args.reportId}`,
+            channelKey: "in_app",
+          };
+        }
+        lastFailure = {
+          ok: false,
+          reason: "disconnected",
+          userActionable: false,
+          message: "Assistant event stream is not registered.",
+        };
+        continue;
+      }
+
+      const channel = registry?.get(candidate.channel) ?? null;
+      if (!channel?.send) {
+        lastFailure = {
+          ok: false,
+          reason: "disconnected",
+          userActionable: true,
+          message: `Channel "${candidate.channel}" is not registered for check-in delivery.`,
+        };
+        continue;
+      }
+      const target = await this.resolveCheckinRouteTarget(candidate.channel);
+      if (!target) {
+        lastFailure = {
+          ok: false,
+          reason: "unknown_recipient",
+          userActionable: true,
+          message: `Channel "${candidate.channel}" has no resolved owner target.`,
+        };
+        continue;
+      }
+      const result = await channel.send({
+        target,
+        message: args.message,
+        metadata: {
+          ...args.metadata,
+          checkinKind: args.kind,
+          reportId: args.reportId,
+          routeCandidate: candidate,
+        },
+      });
+      if (result.ok) {
+        return {
+          ...result,
+          target: result.target ?? target,
+          channelKey: result.channelKey ?? candidate.channel,
+        };
+      }
+      lastFailure = result;
+    }
+
+    return lastFailure;
   }
 
   public async resolveReminderEscalationChannels(args: {
@@ -5613,35 +5757,57 @@ export class RemindersDomain {
       }
       const report =
         kind === "morning"
-          ? await service.runMorningCheckin({ now: args.now, timezone })
+          ? await service.runMorningCheckin({
+              now: args.now,
+              timezone,
+              persist: false,
+            })
           : await service.runNightCheckin({
               now: args.now,
               timezone,
               sleepRecap,
+              persist: false,
             });
       const routeMetadata = await this.buildOwnerContactRouteEventMetadata({
         purpose: "checkin",
         urgency: report.escalationLevel >= 2 ? "high" : "medium",
         now: args.now,
       });
-      this.ctx.emitAssistantEvent(
-        appendCheckinAckChoiceMarker(report.summaryText, {
-          reportId: report.reportId,
-          kind,
-        }),
-        "lifeops-checkin",
-        {
-          checkinKind: kind,
-          reportId: report.reportId,
-          deliveryBasis: "sleep_cycle",
-          circadianState: currentSchedule.circadianState,
-          wakeAt: currentSchedule.wakeAt,
-          bedtimeTargetAt: currentSchedule.relativeTime.bedtimeTargetAt,
-          minutesUntilBedtimeTarget:
-            currentSchedule.relativeTime.minutesUntilBedtimeTarget,
-          ...routeMetadata,
-        },
-      );
+      const message = appendCheckinAckChoiceMarker(report.summaryText, {
+        reportId: report.reportId,
+        kind,
+      });
+      const metadata = {
+        checkinKind: kind,
+        reportId: report.reportId,
+        deliveryBasis: "sleep_cycle",
+        circadianState: currentSchedule.circadianState,
+        wakeAt: currentSchedule.wakeAt,
+        bedtimeTargetAt: currentSchedule.relativeTime.bedtimeTargetAt,
+        minutesUntilBedtimeTarget:
+          currentSchedule.relativeTime.minutesUntilBedtimeTarget,
+        ...routeMetadata,
+      };
+      const delivery = await this.dispatchCheckinReport({
+        reportId: report.reportId,
+        kind,
+        message,
+        metadata,
+      });
+      if (!delivery.ok) {
+        this.ctx.logLifeOpsWarn(
+          "sleep_cycle_checkin_delivery",
+          "[lifeops] Sleep-cycle check-in delivery failed; report not persisted.",
+          {
+            kind,
+            reportId: report.reportId,
+            reason: delivery.reason,
+            message: delivery.message,
+          },
+        );
+        return;
+      }
+      await service.persistCheckinReport(report, args.now);
     };
 
     if (

--- a/plugins/plugin-personal-assistant/src/lifeops/service-mixin-core.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/service-mixin-core.ts
@@ -693,7 +693,7 @@ export class LifeOpsServiceBase {
     text: string,
     source: string,
     data: Record<string, unknown> = {},
-  ): void {
+  ): boolean {
     const eventService = getAgentEventService(this.runtime) as {
       emit?: (event: {
         runId: string;
@@ -703,7 +703,7 @@ export class LifeOpsServiceBase {
       }) => void;
     } | null;
     if (!eventService?.emit) {
-      return;
+      return false;
     }
     eventService.emit({
       runId: crypto.randomUUID(),
@@ -715,6 +715,7 @@ export class LifeOpsServiceBase {
         ...data,
       },
     });
+    return true;
   }
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Route sleep-cycle morning/night check-ins through ranked owner contact route candidates instead of only emitting in-app metadata.
- Add deferred check-in persistence so the local-day idempotency marker is written only after an app stream or connector returns an accepted delivery result.
- Expand the deterministic check-in dispatch suite to prove accepted in-app delivery, already-sent suppression, no-surface/no-persist failure, and connector fallback before persistence.

## Evidence
<!-- evidence-row:before-screenshots -->
N/A - backend LifeOps scheduling/connector delivery change; no app UI pixels changed.

<!-- evidence-row:after-screenshots -->
N/A - backend LifeOps scheduling/connector delivery change; no app UI pixels changed.

<!-- evidence-row:walkthrough-video -->
N/A - no user-facing UI flow changed; behavior is covered by deterministic dispatch tests below.

<!-- evidence-row:backend-logs -->
N/A - no live backend server was started for this deterministic service-layer change. Command evidence: `bun run --cwd plugins/plugin-personal-assistant test -- src/lifeops/domains/reminders-service.checkin-chips.test.ts` passed after rebase: 1 file, 4 tests. The suite proves generated reports are persisted only after accepted delivery and that failed in-app delivery falls through to SMS connector send before persistence.

<!-- evidence-row:frontend-logs -->
N/A - frontend bundle and browser network/console behavior are untouched.

<!-- evidence-row:llm-trajectory -->
N/A - no prompt, model, or agent-planner behavior changed; the check-in summary text is mocked in the deterministic dispatch test.

<!-- evidence-row:domain-artifacts -->
N/A - no durable runtime domain artifact is produced until the scheduler fires in a configured owner runtime. Command evidence: `bunx @biomejs/biome check plugins/plugin-personal-assistant/src/lifeops/checkin/types.ts plugins/plugin-personal-assistant/src/lifeops/checkin/checkin-service.ts plugins/plugin-personal-assistant/src/lifeops/service-mixin-core.ts plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.checkin-chips.test.ts` passed. `git diff --check origin/develop..HEAD` passed. `bun run audit:error-policy-ratchet --report` passed with 4 changed production files and no new fallback-slop.

## Notes
- `bun run --cwd plugins/plugin-personal-assistant typecheck` still fails on the existing package baseline: missing sibling plugin declarations/exports and pre-existing `LifeOpsScheduleMergedStateRecord` type drift. A filtered run against touched files showed only those baseline diagnostics, not the new dispatch helper or persistence API.

Closes #14702
