### PR TITLE
feat(lifeops): route VIEW_SWITCHED + REACTION_RECEIVED into presence signals (#14689)

### DIFF
--- a/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts
@@ -8,6 +8,7 @@ import {
   type IAgentRuntime,
   type MessagePayload,
   type UUID,
+  type ViewSwitchedPayload,
 } from "@elizaos/core";
 import { SELF_ENTITY_ID } from "@elizaos/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -299,6 +300,124 @@ describe("PresenceSignalBridgeService relationship recency", () => {
           lastInteractionDirection: "outbound",
         },
       }),
+    );
+  });
+});
+
+describe("PresenceSignalBridgeService view-switch + reaction signals (#14689)", () => {
+  beforeEach(() => {
+    mockState.activitySignals.length = 0;
+    vi.clearAllMocks();
+  });
+
+  function viewSwitchPayload(
+    overrides: Partial<ViewSwitchedPayload> = {},
+  ): ViewSwitchedPayload {
+    return {
+      runtime: {} as IAgentRuntime,
+      source: "client_chat",
+      viewId: "wallet",
+      viewLabel: "Wallet",
+      initiatedBy: "user",
+      ...overrides,
+    } as unknown as ViewSwitchedPayload;
+  }
+
+  it("writes an app_lifecycle signal for a user-initiated view switch", async () => {
+    const { runtime, handlers } = runtimeWithRelationships({});
+    await PresenceSignalBridgeService.start(runtime);
+
+    await handlers.get(EventType.VIEW_SWITCHED)?.(
+      viewSwitchPayload() as unknown as MessagePayload,
+    );
+
+    expect(mockState.activitySignals).toHaveLength(1);
+    expect(mockState.activitySignals[0]).toMatchObject({
+      source: "app_lifecycle",
+      platform: "agent_view",
+      state: "active",
+      metadata: expect.objectContaining({
+        eventType: "VIEW_SWITCHED",
+        viewId: "wallet",
+        initiatedBy: "user",
+      }),
+    });
+  });
+
+  it("ignores agent-initiated view switches (not owner presence)", async () => {
+    const { runtime, handlers } = runtimeWithRelationships({});
+    await PresenceSignalBridgeService.start(runtime);
+
+    await handlers.get(EventType.VIEW_SWITCHED)?.(
+      viewSwitchPayload({ initiatedBy: "agent" }) as unknown as MessagePayload,
+    );
+
+    expect(mockState.activitySignals).toHaveLength(0);
+  });
+
+  it("dedupes a rapid re-switch to the same view within the window", async () => {
+    const { runtime, handlers } = runtimeWithRelationships({});
+    await PresenceSignalBridgeService.start(runtime);
+
+    await handlers.get(EventType.VIEW_SWITCHED)?.(
+      viewSwitchPayload() as unknown as MessagePayload,
+    );
+    await handlers.get(EventType.VIEW_SWITCHED)?.(
+      viewSwitchPayload() as unknown as MessagePayload,
+    );
+
+    expect(mockState.activitySignals).toHaveLength(1);
+  });
+
+  it("writes a connector_activity signal for a contact reaction", async () => {
+    const { runtime, handlers } = runtimeWithRelationships({});
+    await PresenceSignalBridgeService.start(runtime);
+
+    await handlers.get(EventType.REACTION_RECEIVED)?.(messagePayload());
+
+    expect(mockState.activitySignals).toHaveLength(1);
+    expect(mockState.activitySignals[0]).toMatchObject({
+      source: "connector_activity",
+      platform: "telegram",
+      observedAt: "2026-06-01T12:00:00.000Z",
+      metadata: expect.objectContaining({
+        eventType: "REACTION_RECEIVED",
+        entityId: CONTACT_ID,
+      }),
+    });
+  });
+
+  it("ignores the agent's own reactions", async () => {
+    const { runtime, handlers } = runtimeWithRelationships({});
+    await PresenceSignalBridgeService.start(runtime);
+
+    await handlers.get(EventType.REACTION_RECEIVED)?.(
+      messagePayload({
+        message: {
+          ...messagePayload().message,
+          entityId: AGENT_ID,
+        },
+      }),
+    );
+
+    expect(mockState.activitySignals).toHaveLength(0);
+  });
+
+  it("registers and unregisters the view-switch and reaction handlers", async () => {
+    const { runtime, handlers } = runtimeWithRelationships({});
+    const service = await PresenceSignalBridgeService.start(runtime);
+
+    expect(handlers.has(EventType.VIEW_SWITCHED)).toBe(true);
+    expect(handlers.has(EventType.REACTION_RECEIVED)).toBe(true);
+
+    await service.stop();
+    expect(runtime.unregisterEvent).toHaveBeenCalledWith(
+      EventType.VIEW_SWITCHED,
+      expect.any(Function),
+    );
+    expect(runtime.unregisterEvent).toHaveBeenCalledWith(
+      EventType.REACTION_RECEIVED,
+      expect.any(Function),
     );
   });
 });

--- a/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts
@@ -11,7 +11,7 @@ import {
   type ViewSwitchedPayload,
 } from "@elizaos/core";
 import { SELF_ENTITY_ID } from "@elizaos/shared";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockState = vi.hoisted(() => {
   const entityStore = {
@@ -310,6 +310,10 @@ describe("PresenceSignalBridgeService view-switch + reaction signals (#14689)", 
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   function viewSwitchPayload(
     overrides: Partial<ViewSwitchedPayload> = {},
   ): ViewSwitchedPayload {
@@ -356,12 +360,15 @@ describe("PresenceSignalBridgeService view-switch + reaction signals (#14689)", 
   });
 
   it("dedupes a rapid re-switch to the same view within the window", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-01T12:00:00.000Z"));
     const { runtime, handlers } = runtimeWithRelationships({});
     await PresenceSignalBridgeService.start(runtime);
 
     await handlers.get(EventType.VIEW_SWITCHED)?.(
       viewSwitchPayload() as unknown as MessagePayload,
     );
+    vi.setSystemTime(new Date("2026-06-01T12:00:00.250Z"));
     await handlers.get(EventType.VIEW_SWITCHED)?.(
       viewSwitchPayload() as unknown as MessagePayload,
     );

--- a/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.ts
@@ -12,6 +12,7 @@ import {
   type MessagePayload,
   Service,
   type UUID,
+  type ViewSwitchedPayload,
 } from "@elizaos/core";
 import { SELF_ENTITY_ID } from "@elizaos/shared";
 import { getDeviceId } from "../lifeops/device-identity.js";
@@ -246,6 +247,18 @@ export class PresenceSignalBridgeService extends Service {
     await this.captureActivityFromAction(payload);
   };
 
+  private readonly viewSwitchedHandler = async (
+    payload: ViewSwitchedPayload,
+  ): Promise<void> => {
+    await this.captureActivityFromViewSwitch(payload);
+  };
+
+  private readonly reactionReceivedHandler = async (
+    payload: MessagePayload,
+  ): Promise<void> => {
+    await this.captureActivityFromReaction(payload);
+  };
+
   static override async start(
     runtime: IAgentRuntime,
   ): Promise<PresenceSignalBridgeService> {
@@ -258,6 +271,11 @@ export class PresenceSignalBridgeService extends Service {
     runtime.registerEvent(
       EventType.ACTION_STARTED,
       service.actionStartedHandler,
+    );
+    runtime.registerEvent(EventType.VIEW_SWITCHED, service.viewSwitchedHandler);
+    runtime.registerEvent(
+      EventType.REACTION_RECEIVED,
+      service.reactionReceivedHandler,
     );
     return service;
   }
@@ -274,6 +292,14 @@ export class PresenceSignalBridgeService extends Service {
     this.runtime.unregisterEvent(
       EventType.ACTION_STARTED,
       this.actionStartedHandler,
+    );
+    this.runtime.unregisterEvent(
+      EventType.VIEW_SWITCHED,
+      this.viewSwitchedHandler,
+    );
+    this.runtime.unregisterEvent(
+      EventType.REACTION_RECEIVED,
+      this.reactionReceivedHandler,
     );
   }
 
@@ -316,6 +342,100 @@ export class PresenceSignalBridgeService extends Service {
           eventType: "ACTION_STARTED",
           actionName,
           messageId,
+          deviceId: getDeviceId(),
+        },
+      }),
+    );
+  }
+
+  private async captureActivityFromViewSwitch(
+    payload: ViewSwitchedPayload,
+  ): Promise<void> {
+    // Only the owner navigating counts as presence. Agent-initiated switches
+    // (action/evaluator navigation) are the agent moving itself, not the owner
+    // being active, so they must not read as owner activity (#14689).
+    if (payload.initiatedBy === "agent") {
+      return;
+    }
+    const viewId =
+      typeof payload.viewId === "string" && payload.viewId.length > 0
+        ? payload.viewId
+        : "unknown";
+    const observedAt = new Date().toISOString();
+    const fingerprint = `view:${viewId}:${observedAt}`;
+    const observedMs = Date.parse(observedAt);
+    const existing = this.recentFingerprints.get(fingerprint);
+    if (
+      existing !== undefined &&
+      Number.isFinite(observedMs) &&
+      observedMs - existing < DEDUPE_WINDOW_MS
+    ) {
+      return;
+    }
+    if (Number.isFinite(observedMs)) {
+      this.recentFingerprints.set(fingerprint, observedMs);
+    }
+    const repository = new LifeOpsRepository(this.runtime);
+    await repository.createActivitySignal(
+      createLifeOpsActivitySignal({
+        agentId: String(this.runtime.agentId),
+        source: "app_lifecycle",
+        platform: "agent_view",
+        state: "active",
+        observedAt,
+        idleState: "active",
+        idleTimeSeconds: 0,
+        onBattery: null,
+        health: null,
+        metadata: {
+          eventType: "VIEW_SWITCHED",
+          viewId,
+          initiatedBy: payload.initiatedBy,
+          deviceId: getDeviceId(),
+        },
+      }),
+    );
+  }
+
+  private async captureActivityFromReaction(
+    payload: MessagePayload,
+  ): Promise<void> {
+    // A tapback/reaction from someone other than the agent is an owner (or
+    // contact) touchpoint. Reuse the message identity readers; skip the agent's
+    // own reactions so the agent reacting does not read as owner presence.
+    const entityId = readMessageEntityId(payload);
+    if (!entityId || entityId === String(this.runtime.agentId)) {
+      return;
+    }
+    const observedAt = readMessageTimestamp(payload);
+    const fingerprint = `${EventType.REACTION_RECEIVED}:${entityId}:${observedAt}`;
+    const observedMs = Date.parse(observedAt);
+    const existing = this.recentFingerprints.get(fingerprint);
+    if (
+      existing !== undefined &&
+      Number.isFinite(observedMs) &&
+      observedMs - existing < DEDUPE_WINDOW_MS
+    ) {
+      return;
+    }
+    if (Number.isFinite(observedMs)) {
+      this.recentFingerprints.set(fingerprint, observedMs);
+    }
+    const repository = new LifeOpsRepository(this.runtime);
+    await repository.createActivitySignal(
+      createLifeOpsActivitySignal({
+        agentId: String(this.runtime.agentId),
+        source: "connector_activity",
+        platform: readPlatform(payload),
+        state: "active",
+        observedAt,
+        idleState: null,
+        idleTimeSeconds: 0,
+        onBattery: null,
+        health: null,
+        metadata: {
+          eventType: "REACTION_RECEIVED",
+          entityId,
           deviceId: getDeviceId(),
         },
       }),

--- a/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.ts
@@ -362,7 +362,7 @@ export class PresenceSignalBridgeService extends Service {
         ? payload.viewId
         : "unknown";
     const observedAt = new Date().toISOString();
-    const fingerprint = `view:${viewId}:${observedAt}`;
+    const fingerprint = `view:${viewId}`;
     const observedMs = Date.parse(observedAt);
     const existing = this.recentFingerprints.get(fingerprint);
     if (


### PR DESCRIPTION
## Problem

`PresenceSignalBridgeService` registered only `MESSAGE_RECEIVED`, `MESSAGE_SENT`, and `ACTION_STARTED`. Two owner-activity events were dropped on the floor:

- `VIEW_SWITCHED` — emitted on every navigation, but consumed only by the proactive-comment decider.
- `REACTION_RECEIVED` — emitted by the telegram/discord/imessage/signal connectors, but consumed only by basic-capabilities' reaction handler.

Neither became a LifeOps activity signal, so an owner actively browsing views or tapping tapbacks read as **absent** to wake detection, GM/GN planning, `wasActiveToday`, and the `no_recent_user_message_in` gate — exactly the passive habit data the doctrine says to gather.

## Fix

Two new handlers, wired into `start()` / `stop()` alongside the existing three, using the established capture pattern (5s dedupe window, `createLifeOpsActivitySignal` shape):

- **`VIEW_SWITCHED` → `app_lifecycle` / `agent_view` active signal.** User-initiated only — agent-initiated switches are the agent moving itself, not owner presence, so they are skipped (mirrors the decider's `initiatedBy === "agent"` handling).
- **`REACTION_RECEIVED` → `connector_activity` signal** keyed on the reacting entity, skipping the agent's own reactions, so a tapback counts as an owner/contact touchpoint.

Both reuse the existing message identity/timestamp/platform readers and the same dedupe map. Reaction capture intentionally writes only the activity signal (the primary miss); it does not fold reaction semantics into the message-specific relationship-recency writer.

## Tests (`presence-signal-bridge-service.test.ts`, new `#14689` block)

- user-initiated view switch → one `app_lifecycle`/`agent_view` signal
- agent-initiated view switch → no signal
- rapid re-switch to same view within window → deduped to one signal
- contact reaction → one `connector_activity` signal
- agent's own reaction → no signal
- view-switch + reaction handlers register on `start()` and unregister on `stop()`

```
$ npx vitest run src/activity-profile/presence-signal-bridge-service.test.ts
 Test Files  1 passed (1)
      Tests  10 passed (10)   # 4 pre-existing + 6 new, stable across repeated runs
```

Biome clean on both touched files (`@biomejs/biome@2.5.1`).

_Codex review timed out headless (>100s, no output); self-reviewed instead: handler registration/teardown is symmetric with the existing three, signal shapes match the `app_lifecycle`/`connector_activity` precedents (all required fields present), `platform` is a free string field (`agent_action` already used), and reaction capture reuses the battle-tested message readers with agent-self and missing-entity guards._

Closes #14689

— [sol-orch]