### PR TITLE
test(lifeops): add child student deadline scenarios

### DIFF
--- a/packages/scripts/check-lifeops-persona-catalog-coverage.mjs
+++ b/packages/scripts/check-lifeops-persona-catalog-coverage.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Coverage gate for the LifeOps persona scenario-pack ledgers. The eight pack
+ * Coverage gate for the LifeOps persona scenario-pack ledgers. The pack
  * catalogs are progress ledgers, not executable scenarios; this script confirms
  * their declared scenario ids resolve to the real TypeScript scenario-runner
  * corpus or the Python LifeOpsBench corpus and prints authored/verified totals.
@@ -42,6 +42,7 @@ const EXPECTED_CATALOGS = [
   ["mediation-logistics.catalog.json", "I2", 8],
   ["co-parenting.catalog.json", "J1", 10],
   ["third-party-support.catalog.json", "K1", 10],
+  ["child-student-deadlines.catalog.json", "L1", 6],
 ];
 
 const VALID_TIERS = new Set(["T1", "T2", "T3", "T4"]);

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/child-student-deadlines.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/child-student-deadlines.catalog.json
@@ -1,0 +1,64 @@
+{
+  "catalogId": "child-student-deadlines",
+  "title": "Pack L1 - Child voice and student deadline scenario catalog",
+  "source": {
+    "parentIssue": "#14352",
+    "packId": "L1",
+    "persona": "MVP child/student owner coverage",
+    "targetCount": 6,
+    "notes": [
+      "This ledger covers the MVP gap where child-voice owners and student report/deadline owners had zero scenario coverage.",
+      "Rows start authored because live model trajectories and hand-reviewed store artifacts are required before verification. Flip to verified only after the scenario-runner report, native trajectory JSONL, and persisted reminder/todo rows have been inspected."
+    ]
+  },
+  "scenarios": [
+    {
+      "id": "child-book-report-backplan",
+      "pack": "L1",
+      "tier": "T2",
+      "surface": "scenario-runner",
+      "status": "authored",
+      "notes": "Child owner asks for help with a Friday book report, gets distracted, then confirms. Live verification must show a stored report plan with an earlier checkpoint, no parent-only or therapy framing."
+    },
+    {
+      "id": "child-book-report-cancel-reask",
+      "pack": "L1",
+      "tier": "T2",
+      "surface": "scenario-runner",
+      "status": "authored",
+      "notes": "Cancellation/re-ask flow. Live verification must show the canceled science-report reminder was not persisted and only the confirmed ask-Ms.-Rivera replacement exists."
+    },
+    {
+      "id": "child-morning-routine-plain-words",
+      "pack": "L1",
+      "tier": "T1",
+      "surface": "scenario-runner",
+      "status": "authored",
+      "notes": "Plain child morning routine. Live verification must show a daily routine/reminder covering teeth, lunch, and math folder without infantilizing or clinical wording."
+    },
+    {
+      "id": "student-term-paper-night-owl-deadline",
+      "pack": "L1",
+      "tier": "T2",
+      "surface": "scenario-runner",
+      "status": "authored",
+      "notes": "Night-owl adult student asks for a seminar-paper plan. Live verification must show the stored reminder plan avoids default 8am/9am slots and includes draft/citations/final-pass phases."
+    },
+    {
+      "id": "student-lab-report-distractor-deadline",
+      "pack": "L1",
+      "tier": "T2",
+      "surface": "scenario-runner",
+      "status": "authored",
+      "notes": "Lab-report deadline survives an unrelated pizza distractor. Live verification must show a report plan exists and no pizza task was created."
+    },
+    {
+      "id": "student-report-two-phase-commit",
+      "pack": "L1",
+      "tier": "T1",
+      "surface": "scenario-runner",
+      "status": "authored",
+      "notes": "Two-phase commit for a history report. Live verification must show the first turn asks before saving and the confirmed turn creates the outline/draft/proofread reminder plan."
+    }
+  ]
+}

--- a/plugins/plugin-personal-assistant/test/scenarios/child-book-report-backplan.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/child-book-report-backplan.scenario.ts
@@ -1,0 +1,65 @@
+/**
+ * Child-voice school deadline scenario: a twelve-year-old owner gives a messy
+ * report deadline, gets distracted, then confirms. The outcome bar is a real
+ * stored reminder plan for the report, not a friendly echo of the ask.
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "child-book-report-backplan",
+  title: "Child voice: book-report deadline becomes a back-planned reminder",
+  domain: "lifeops.reminders",
+  tags: ["lifeops", "mvp", "child-voice", "student-deadline", "14352"],
+  tier: "T2",
+  status: "active",
+  isolation: "per-scenario",
+  requires: { plugins: ["@elizaos/plugin-personal-assistant"] },
+  rooms: [
+    {
+      id: "main",
+      source: "imessage",
+      channelType: "DM",
+      title: "Child book report",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "messy child deadline ask",
+      text: "um hi i'm 12 and i have a book report friday and i have not started and i keep forgetting. can you help me not mess it up? i need to read 3 chapters and make the poster thing.",
+      responseJudge: {
+        name: "preview-before-saving-child-deadline",
+        minimumScore: 0.6,
+        rubric:
+          "Grade PASS only if the assistant treats the speaker as the owner, uses plain practical language, proposes a concrete report plan/reminder setup, and asks for confirmation before claiming it is saved. Fail if it uses therapy/crisis language, talks to a parent instead of the child, or says the reminder is already saved before confirmation.",
+      },
+    },
+    {
+      kind: "message",
+      name: "distractor before consent",
+      text: "wait also what if i make the poster blue? actually don't answer that, save the reminder plan please.",
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "book report",
+      titleAliases: [
+        "book report",
+        "report friday",
+        "finish book report",
+        "book report poster",
+      ],
+      delta: 1,
+      requireReminderPlan: true,
+    },
+    {
+      type: "judgeRubric",
+      name: "child-book-report-derived-plan",
+      minimumScore: 0.7,
+      rubric:
+        "The child said the report is due Friday and gave component work (read 3 chapters, make poster). Grade PASS only if the final assistant behavior created a practical reminder/deadline plan for the report with at least one derived preparation step or earlier checkpoint, not merely a single echo of 'book report Friday'. Fail for therapy language, parent-only framing, or no stored reminder outcome.",
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/child-book-report-cancel-reask.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/child-book-report-cancel-reask.scenario.ts
@@ -1,0 +1,69 @@
+/**
+ * Child-voice cancellation repair scenario. A child cancels the first proposed
+ * report reminder, then re-asks with a narrower version; the assistant should
+ * respect the cancellation and store only the confirmed replacement.
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "child-book-report-cancel-reask",
+  title: "Child voice: cancelled book-report reminder is not duplicated",
+  domain: "lifeops.reminders",
+  tags: ["lifeops", "mvp", "child-voice", "student-deadline", "14352"],
+  tier: "T2",
+  status: "active",
+  isolation: "per-scenario",
+  requires: { plugins: ["@elizaos/plugin-personal-assistant"] },
+  rooms: [
+    {
+      id: "main",
+      source: "telegram",
+      channelType: "DM",
+      title: "Child cancel and re-ask",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "first report reminder ask",
+      text: "can you remind me about my science report? it's due next monday and i think i should start this weekend.",
+    },
+    {
+      kind: "message",
+      name: "cancel the first attempt",
+      text: "actually no wait don't save that one. my teacher changed it and i need to ask her tomorrow first.",
+      responseJudge: {
+        name: "cancel-respected-before-reask",
+        minimumScore: 0.6,
+        rubric:
+          "Grade PASS only if the assistant acknowledges the cancellation and does not claim the science-report reminder is saved. It may offer to help later. Fail if it keeps or confirms the canceled reminder.",
+      },
+    },
+    {
+      kind: "message",
+      name: "replacement confirmed ask",
+      text: "ok now save just this: tomorrow after school remind me to ask Ms. Rivera what the science report topic is.",
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "ask Ms. Rivera",
+      titleAliases: [
+        "ask Ms. Rivera",
+        "ask teacher",
+        "science report topic",
+        "ask what the science report topic is",
+      ],
+      delta: 1,
+      requireReminderPlan: true,
+    },
+    {
+      type: "definitionCountDelta",
+      title: "science report due next monday",
+      titleAliases: ["science report due", "start science report"],
+      delta: 0,
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/child-morning-routine-plain-words.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/child-morning-routine-plain-words.scenario.ts
@@ -1,0 +1,56 @@
+/**
+ * Child-voice routine scenario. The child asks in ordinary words, so the
+ * assistant should materialize a simple morning routine without adding parent
+ * rails, shame, or clinical framing.
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "child-morning-routine-plain-words",
+  title: "Child voice: plain morning routine becomes a daily reminder",
+  domain: "lifeops.reminders",
+  tags: ["lifeops", "mvp", "child-voice", "routine", "14352"],
+  tier: "T1",
+  status: "active",
+  isolation: "per-scenario",
+  requires: { plugins: ["@elizaos/plugin-personal-assistant"] },
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Child morning routine",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "plain routine ask",
+      text: "before school i always forget stuff. can you remind me every morning to brush teeth, pack my lunch, and put my math folder in my bag? just say it normal, not like a baby.",
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "school morning",
+      titleAliases: [
+        "school morning",
+        "brush teeth",
+        "pack lunch",
+        "math folder",
+        "morning routine",
+      ],
+      delta: 1,
+      cadenceKind: "daily",
+      requireReminderPlan: true,
+    },
+    {
+      type: "judgeRubric",
+      name: "plain-child-routine-no-therapy",
+      minimumScore: 0.7,
+      rubric:
+        "Grade PASS only if the assistant creates a straightforward daily school-morning reminder/routine covering teeth, lunch, and math folder in plain age-respectful wording. Fail for therapy language, parent-only handoff, infantilizing tone, or missing stored routine/reminder outcome.",
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/student-lab-report-distractor-deadline.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/student-lab-report-distractor-deadline.scenario.ts
@@ -1,0 +1,70 @@
+/**
+ * Student deadline with a distractor turn. The assistant must keep the lab
+ * report commitment alive through unrelated chat and store the confirmed
+ * deadline reminder instead of losing it.
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "student-lab-report-distractor-deadline",
+  title: "Student: lab-report deadline survives a distractor turn",
+  domain: "lifeops.reminders",
+  tags: ["lifeops", "mvp", "student", "distractor", "14352"],
+  tier: "T2",
+  status: "active",
+  isolation: "per-scenario",
+  requires: { plugins: ["@elizaos/plugin-personal-assistant"] },
+  rooms: [
+    {
+      id: "main",
+      source: "telegram",
+      channelType: "DM",
+      title: "Student lab report",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "lab report deadline ask",
+      text: "chem lab report is due tuesday night and i'm behind. can you set up reminders so i collect the data table, write the analysis, and submit it before midnight?",
+    },
+    {
+      kind: "message",
+      name: "unrelated distractor",
+      text: "also never mind the pizza order from earlier, that was for my roommate.",
+    },
+    {
+      kind: "message",
+      name: "confirm lab report plan",
+      text: "yes save the lab report plan, not the pizza thing.",
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "chem lab report",
+      titleAliases: [
+        "chem lab report",
+        "lab report",
+        "data table",
+        "write analysis",
+      ],
+      delta: 1,
+      requireReminderPlan: true,
+    },
+    {
+      type: "definitionCountDelta",
+      title: "pizza",
+      titleAliases: ["pizza order", "order pizza"],
+      delta: 0,
+    },
+    {
+      type: "judgeRubric",
+      name: "student-distractor-keeps-deadline",
+      minimumScore: 0.7,
+      rubric:
+        "Grade PASS only if the assistant keeps the chem lab report deadline through the unrelated pizza distractor and stores the report/reminder plan, while not creating a pizza task. The saved plan should reflect derived components: data table, analysis, and submission before midnight.",
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/student-report-two-phase-commit.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/student-report-two-phase-commit.scenario.ts
@@ -1,0 +1,65 @@
+/**
+ * Student deadline two-phase commit scenario. The first turn must produce a
+ * preview/confirmation request; only the second turn gives permission to write
+ * the stored report reminder.
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "student-report-two-phase-commit",
+  title: "Student: report deadline writes only after confirmation",
+  domain: "lifeops.reminders",
+  tags: ["lifeops", "mvp", "student", "two-phase-commit", "14352"],
+  tier: "T1",
+  status: "active",
+  isolation: "per-scenario",
+  requires: { plugins: ["@elizaos/plugin-personal-assistant"] },
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "Student two phase",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "deadline ask before consent",
+      text: "my history report is due next monday at 9am. can you set reminders for outline, rough draft, and final proofread?",
+      responseJudge: {
+        name: "asks-before-writing-report-plan",
+        minimumScore: 0.6,
+        rubric:
+          "Grade PASS only if the assistant previews a concrete outline/draft/proofread reminder plan and asks for confirmation before saying it has been saved. Fail if it claims the reminders are already saved on this first turn.",
+      },
+    },
+    {
+      kind: "message",
+      name: "confirm write",
+      text: "yes save it exactly like that.",
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "history report",
+      titleAliases: [
+        "history report",
+        "outline",
+        "rough draft",
+        "final proofread",
+      ],
+      delta: 1,
+      requireReminderPlan: true,
+    },
+    {
+      type: "judgeRubric",
+      name: "student-report-two-phase-outcome",
+      minimumScore: 0.7,
+      rubric:
+        "Grade PASS only if the scenario ends with a stored history-report reminder plan after owner confirmation, covering outline, rough draft, and final proofread before the Monday 9am deadline. Fail if the assistant wrote before consent, skipped the stored outcome, or merely echoed the user's words without derived planning.",
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/student-term-paper-night-owl-deadline.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/student-term-paper-night-owl-deadline.scenario.ts
@@ -1,0 +1,63 @@
+/**
+ * Student night-owl deadline scenario. The owner is an adult student with late
+ * active windows; the assistant must avoid default-morning scheduling and store
+ * a term-paper plan that fits the stated rhythm.
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+export default scenario({
+  lane: "live-only",
+  id: "student-term-paper-night-owl-deadline",
+  title: "Student night owl: term-paper deadline avoids default morning",
+  domain: "lifeops.reminders",
+  tags: ["lifeops", "mvp", "student", "night-owl", "14352"],
+  tier: "T2",
+  status: "active",
+  isolation: "per-scenario",
+  requires: { plugins: ["@elizaos/plugin-personal-assistant"] },
+  rooms: [
+    {
+      id: "main",
+      source: "discord",
+      channelType: "DM",
+      title: "Student term paper",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "late-active student deadline",
+      text: "i'm a night person and my seminar paper is due thursday at 5pm. please help me break it up, but do not set me some 8am/9am reminder. i'm normally useful after 1pm and again late evening.",
+    },
+    {
+      kind: "message",
+      name: "confirm student plan",
+      text: "yes, save that plan. draft first, citations after dinner, final pass before the deadline.",
+    },
+  ],
+  finalChecks: [
+    {
+      type: "definitionCountDelta",
+      title: "seminar paper",
+      titleAliases: [
+        "seminar paper",
+        "term paper",
+        "paper due thursday",
+        "citations",
+      ],
+      delta: 1,
+      forbiddenDueLocalTimes: [
+        { hour: 8, minute: 0 },
+        { hour: 9, minute: 0 },
+      ],
+      requireReminderPlan: true,
+    },
+    {
+      type: "judgeRubric",
+      name: "night-owl-student-deadline-plan",
+      minimumScore: 0.7,
+      rubric:
+        "Grade PASS only if the assistant creates/saves a student deadline plan for the Thursday 5pm seminar paper that respects the stated late active windows and avoids default 8am/9am reminders. It should include derived work phases such as draft, citations, and final pass. Fail if it assumes a normal morning schedule or creates no stored reminder/deadline plan.",
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

- Adds six live-only child/student deadline scenarios covering child book-report backplanning, cancel/re-ask handling, morning-routine wording, student term-paper night-owl timing, lab-report distractor handling, and two-phase commit behavior.
- Registers a new `child-student-deadlines` catalog pack with target count 6 and authored rows so the coverage ratchet sees the new pack.
- Updates the LifeOps persona catalog coverage checker's expected catalog list.

Part of #14352. This does not close #14352 yet because live-model verification and persisted-row evidence are intentionally not marked complete without credentials.

## Evidence

<!-- evidence-row:before-screenshots -->
| Type | Status | Evidence |
| --- | --- | --- |
| Before screenshots | N/A - scenario authoring only | No product UI pixels changed. |

<!-- evidence-row:after-screenshots -->
| Type | Status | Evidence |
| --- | --- | --- |
| After screenshots | N/A - scenario authoring only | No product UI pixels changed. |

<!-- evidence-row:walkthrough-video -->
| Type | Status | Evidence |
| --- | --- | --- |
| Walkthrough video | N/A - no UI flow changed | Scenario files/catalog metadata only. |

<!-- evidence-row:backend-logs -->
| Type | Status | Evidence |
| --- | --- | --- |
| Backend logs | N/A - no backend server run | This PR does not start the app/backend; it adds scenario definitions and catalog metadata. |

<!-- evidence-row:frontend-logs -->
| Type | Status | Evidence |
| --- | --- | --- |
| Frontend console/network logs | N/A - no frontend runtime path | No browser UI/runtime code changed. |

<!-- evidence-row:llm-trajectory -->
| Type | Status | Evidence |
| --- | --- | --- |
| Real-LLM trajectory | N/A - live provider credentials absent | No live provider keys were available in this worktree (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, `GROQ_API_KEY`, `OPENROUTER_API_KEY` absent), so rows remain authored, not verified. |

<!-- evidence-row:domain-artifacts -->
| Type | Status | Evidence |
| --- | --- | --- |
| Domain artifacts | N/A - requires live scenario run | Persisted-row/domain artifact evidence must be captured when the scenarios run against a live model and real stores; not fabricated here. |

<!-- evidence-row:scenario-list -->
| Type | Status | Evidence |
| --- | --- | --- |
| Scenario registry list | PASS | `bun run --cwd plugins/plugin-personal-assistant test:scenarios:list -- --scenario child-book-report-backplan,child-book-report-cancel-reask,child-morning-routine-plain-words,student-term-paper-night-owl-deadline,student-lab-report-distractor-deadline,student-report-two-phase-commit` listed all six scenario ids. |

<!-- evidence-row:catalog-ratchet -->
| Type | Status | Evidence |
| --- | --- | --- |
| Persona catalog coverage ratchet | PASS | `node packages/scripts/check-lifeops-persona-catalog-coverage.mjs --json` passed; L1 child-student-deadlines shows authored 6 / verified 0, as intended pending live verification. |

<!-- evidence-row:hygiene -->
| Type | Status | Evidence |
| --- | --- | --- |
| Formatting and diff hygiene | PASS | Targeted Biome check on the six new scenario files, catalog, and coverage script passed; `git diff --check origin/develop..HEAD` passed. |
