### PR TITLE
fix(app-control): harden wallet RPC settings regressions

### DIFF
--- a/plugins/plugin-app-control/src/actions/settings.test.ts
+++ b/plugins/plugin-app-control/src/actions/settings.test.ts
@@ -857,6 +857,53 @@ describe("SETTINGS action: set on an owned route section", () => {
 		expect(texts.join(" ")).toContain("Secrets/Vault");
 	});
 
+	it("scopes chain/provider wallet RPC requests to the requested chain", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async (request) => {
+			if (request.method === "GET") {
+				return {
+					ok: true,
+					data: {
+						selectedRpcProviders: {
+							evm: "eliza-cloud",
+							bsc: "ankr",
+							solana: "helius-birdeye",
+						},
+						walletNetwork: "mainnet",
+						legacyCustomChains: [],
+					},
+				};
+			}
+			return { ok: true };
+		});
+		const { result } = await invoke(
+			{
+				action: "set",
+				section: "wallet-rpc",
+				chain: "evm",
+				provider: "alchemy",
+			},
+			routeFetch,
+		);
+		expect(routeFetch).toHaveBeenNthCalledWith(2, {
+			method: "PUT",
+			path: "/api/wallet/config",
+			body: {
+				selections: {
+					evm: "alchemy",
+					bsc: "ankr",
+					solana: "helius-birdeye",
+				},
+				walletNetwork: "mainnet",
+				credentials: {},
+			},
+		});
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({
+			section: "wallet-rpc",
+			key: "evm",
+		});
+	});
+
 	it("switches all wallet RPC providers to Eliza Cloud without exposing secrets", async () => {
 		const routeFetch = vi.fn<SettingsRouteFetch>(async (request) => {
 			if (request.method === "GET") {
@@ -1416,11 +1463,11 @@ describe("SETTINGS action: set on delegated/readonly/unwired sections", () => {
 	it("refuses an unwired gap section with its stated reason", async () => {
 		const { result, texts } = await invoke({
 			action: "set",
-			section: "voice",
+			section: "apps",
 			value: "on",
 		});
 		expect(result?.success).toBe(false);
-		expect(texts.join(" ")).toContain("yet");
+		expect(texts.join(" ")).toContain("VIEWS/APP");
 	});
 });
 

--- a/plugins/plugin-app-control/src/actions/settings.ts
+++ b/plugins/plugin-app-control/src/actions/settings.ts
@@ -883,7 +883,10 @@ function readWalletRpcProviderToken(
 				? request.bsc
 				: request.solana;
 	if (chainSpecific) return chainSpecific;
-	if (request.provider) return request.provider;
+	const providerTargetChain = resolveWalletRpcChain(request.chain ?? keyName);
+	if (request.provider && providerTargetChain === chain) {
+		return request.provider;
+	}
 	return resolveWalletRpcChain(keyName) === chain ? request.value : null;
 }
 


### PR DESCRIPTION
## Summary
- Fixes the app-control wallet RPC settings command so `chain=<chain> provider=<provider>` only applies the provider to the requested chain.
- Adds a regression test proving `chain=evm provider=alchemy` preserves the existing BSC and Solana selections when writing `/api/wallet/config`.
- Repairs the stale unwired-section regression after #14952 made `section=voice` writable; the test now uses the remaining unwired `apps` section and no longer accidentally fetches localhost.

## Required Evidence Rows
<!-- evidence-row:before-screenshots -->
N/A - command-only app-control settings action/test repair; no rendered app surface changed.

<!-- evidence-row:after-screenshots -->
N/A - command-only app-control settings action/test repair; no rendered app surface changed.

<!-- evidence-row:walkthrough-video -->
N/A - command-only app-control settings action/test repair; no rendered app surface or interactive browser flow changed.

<!-- evidence-row:backend-logs -->
N/A - no backend/server process is changed or started; the regression verifies the generated `/api/wallet/config` route payload directly.

<!-- evidence-row:frontend-logs -->
N/A - no frontend runtime surface is changed; this is a deterministic app-control action parser/route-write fix.

<!-- evidence-row:llm-trajectory -->
N/A - no prompt/model behavior changed; the command parsing path is covered by deterministic Vitest.

<!-- evidence-row:domain-artifacts -->
N/A - no persistent domain artifact is created; the regression asserts the wallet RPC configuration payload preserves untouched chain selections and that the unwired-section test remains local.

## Verification
| Check | Result |
| --- | --- |
| `bun run --cwd plugins/plugin-app-control test src/actions/settings.test.ts` | PASS - 1 file, 80 tests passed |
| `bun run --cwd plugins/plugin-app-control typecheck` | PASS |
| `bunx biome check plugins/plugin-app-control/src/actions/settings.ts plugins/plugin-app-control/src/actions/settings.test.ts` | PASS |
| `git diff --check origin/develop...HEAD` | PASS |
| `bun run audit:error-policy-ratchet --report` | PASS - no new fallback-slop in touched files |

## Manual Review
- Reviewed the merged #14949 command implementation and found that the advertised compact command form (`chain=evm provider=alchemy`) leaked `provider` into every chain while iterating wallet RPC selections.
- Confirmed the regression test exercises the exact compact command shape and asserts the persisted payload keeps untouched chains unchanged.
- Confirmed the post-#14952 test repair keeps the unwired-section assertion on an actually unwired section (`apps`) instead of the now-wired voice route.

Fixes follow-up from #14949 / #14911.