### PR TITLE
test(cloud): pin eliza-app gateway auth gate

### DIFF
--- a/packages/cloud/api/test/e2e/group-f-connectors.test.ts
+++ b/packages/cloud/api/test/e2e/group-f-connectors.test.ts
@@ -4,7 +4,7 @@
  * Routes covered:
  *   /api/eliza-app/connections
  *   /api/eliza-app/connections/:platform/initiate
- *   /api/eliza-app/gateway/:agentId
+ *   /api/eliza-app/gateway/:agentId (removed; auth-gated before dispatch)
  *   /api/eliza-app/user/me
  *   /api/eliza-app/webhook/blooio        (forwards to webhook gateway)
  *   /api/eliza-app/webhook/discord       (forwards to Discord webhook handler)
@@ -22,7 +22,7 @@
  * Auth notes (from auth.ts publicPathPrefixes):
  *   - /api/eliza-app/webhook/* — public (no global auth gate)
  *   - /api/eliza-app/user/*   — public (handler does its own session check)
- *   - /api/eliza-app/gateway/* — public
+ *   - /api/eliza-app/gateway/* — removed from public allowlist (#12043)
  *   - /api/eliza/* — public
  *   - /api/webhooks/* — public
  *   - /api/eliza-app/connections requires an eliza-app session token
@@ -215,33 +215,25 @@ describeE2E("POST /api/eliza-app/connections/:platform/initiate", () => {
 // ---------------------------------------------------------------------------
 
 describeE2E("POST /api/eliza-app/gateway/:agentId", () => {
-  // Public path — no auth gate.
+  // Removed path — no public auth bypass (#12043).
 
-  test("missing message body → 400", async () => {
+  test("missing message body → 401 before removed gateway handling", async () => {
     const res = await api.post("/api/eliza-app/gateway/test-agent-001", {});
-    expect(res.status).toBe(400);
-    const body = (await res.json()) as { success?: boolean; error?: string };
-    expect(body.success).toBe(false);
-    expect(body.error).toMatch(/empty message/i);
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).toBe("authentication_required");
   });
 
-  test("valid message → 200 with reply", async () => {
+  test("valid message → 401 before removed gateway handling", async () => {
     const res = await api.post("/api/eliza-app/gateway/test-agent-001", {
       message: "hello",
     });
-    expect(res.status).toBe(200);
-    const body = (await res.json()) as {
-      success?: boolean;
-      reply?: string;
-      historyLength?: number;
-    };
-    expect(body.success).toBe(true);
-    expect(typeof body.reply).toBe("string");
-    expect(body.reply?.length).toBeGreaterThan(0);
-    expect(typeof body.historyLength).toBe("number");
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).toBe("authentication_required");
   });
 
-  test("non-JSON body → 400 or 500", async () => {
+  test("non-JSON body → 401 before body parsing", async () => {
     const res = await fetch(
       `${getBaseUrl()}/api/eliza-app/gateway/test-agent-001`,
       {
@@ -250,9 +242,9 @@ describeE2E("POST /api/eliza-app/gateway/:agentId", () => {
         body: "not-json{{",
       },
     );
-    // The handler parses the body itself; malformed JSON surfaces as its own
-    // 500 envelope (not a middleware 400).
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).toBe("authentication_required");
   });
 });
 


### PR DESCRIPTION
## Summary

Updates the Cloud API group-f e2e contract for the removed `POST /api/eliza-app/gateway/:agentId` route. The route is no longer mounted and is explicitly no longer public per the existing #12043 auth allowlist test, so unauthenticated requests are rejected by the global auth middleware before body parsing or the old canned gateway behavior.

This is the current API Worker deploy blocker from Cloud CF Deploy run `28772621903`: `packages/cloud/api/test/e2e/group-f-connectors.test.ts` still expected the old public gateway behavior (`400` / `200` / `500`) while the live Worker returned `401`.

## Validation

- `bunx @biomejs/biome check packages/cloud/api/test/e2e/group-f-connectors.test.ts`
- `git diff --check`
- `TEST_PGLITE_PERSIST=1 E2E_ONLY=group-f bun run --cwd packages/cloud/api test:e2e --filter 'POST /api/eliza-app/gateway/:agentId'`
  - Result: `36 pass`, `0 fail`, `56 expect() calls`

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - test-only Cloud API e2e contract update; no UI surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - test-only Cloud API e2e contract update; no UI surface changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no user-facing flow changed; this only updates a deploy-suite assertion`.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no runtime backend implementation changed; local filtered e2e output is summarized in Validation`.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend code path changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent, action, provider, prompt, or model behavior changed`.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - no DB rows, generated assets, wallet/on-chain outputs, memories, or scheduled tasks produced`.

## Notes

Local e2e setup required installing dependencies and generating/building the same local artifacts CI already has before the Worker suite (`shared` i18n keyword data, `@elizaos/core`, and `@elizaos/cloud-routing`). No generated, dependency, or build artifacts are included in this PR.
