### PR TITLE
fix(lifeops): capture passive view and reaction presence

### DIFF
--- a/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts
@@ -8,6 +8,7 @@ import {
   type IAgentRuntime,
   type MessagePayload,
   type UUID,
+  type ViewSwitchedPayload,
 } from "@elizaos/core";
 import { SELF_ENTITY_ID } from "@elizaos/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -57,19 +58,16 @@ const ROOM_ID = "20000000-0000-0000-0000-000000000001" as UUID;
 
 function runtimeWithRelationships(relationshipsService: unknown): {
   runtime: IAgentRuntime;
-  handlers: Map<string, (payload: MessagePayload) => Promise<void>>;
+  handlers: Map<string, (payload: unknown) => Promise<void>>;
 } {
-  const handlers = new Map<
-    string,
-    (payload: MessagePayload) => Promise<void>
-  >();
+  const handlers = new Map<string, (payload: unknown) => Promise<void>>();
   const runtime = {
     agentId: AGENT_ID,
     getService: vi.fn((name: string) =>
       name === "relationships" ? relationshipsService : null,
     ),
     registerEvent: vi.fn(
-      (event: string, handler: (payload: MessagePayload) => Promise<void>) => {
+      (event: string, handler: (payload: unknown) => Promise<void>) => {
         handlers.set(event, handler);
       },
     ),
@@ -112,6 +110,19 @@ describe("PresenceSignalBridgeService relationship recency", () => {
       relationshipId: `lifeops-contact-${CONTACT_ID}`,
       type: "contact",
     });
+  });
+
+  it("registers message, reaction, view, and action presence handlers", async () => {
+    const { runtime, handlers } = runtimeWithRelationships(null);
+    await PresenceSignalBridgeService.start(runtime);
+
+    expect([...handlers.keys()]).toEqual([
+      EventType.MESSAGE_RECEIVED,
+      EventType.MESSAGE_SENT,
+      EventType.REACTION_RECEIVED,
+      EventType.VIEW_SWITCHED,
+      EventType.ACTION_STARTED,
+    ]);
   });
 
   it("records core contact and graph recency for owner-sent connector messages", async () => {
@@ -300,5 +311,122 @@ describe("PresenceSignalBridgeService relationship recency", () => {
         },
       }),
     );
+  });
+
+  it("records connector reactions as activity and relationship touchpoints", async () => {
+    const relationshipsService = {
+      findByHandle: vi.fn(async () => ({ entityId: CONTACT_ID })),
+      getContact: vi.fn(async () => ({ entityId: CONTACT_ID })),
+      recordInteraction: vi.fn(),
+    };
+    const { runtime, handlers } =
+      runtimeWithRelationships(relationshipsService);
+    await PresenceSignalBridgeService.start(runtime);
+
+    await handlers.get(EventType.REACTION_RECEIVED)?.(
+      messagePayload({
+        reactionString: "thumbs_up",
+      } as unknown as Partial<MessagePayload>),
+    );
+
+    expect(mockState.activitySignals[0]).toMatchObject({
+      source: "connector_activity",
+      platform: "telegram",
+      observedAt: "2026-06-01T12:00:00.000Z",
+      metadata: {
+        eventType: EventType.REACTION_RECEIVED,
+        direction: "inbound",
+        handle: "priya",
+      },
+    });
+    expect(relationshipsService.recordInteraction).toHaveBeenCalledWith({
+      contactId: CONTACT_ID,
+      platform: "telegram",
+      direction: "inbound",
+      summary: "Passive telegram reaction activity",
+      externalRef: "telegram-message-1",
+      occurredAt: "2026-06-01T12:00:00.000Z",
+    });
+    expect(mockState.relationshipStore.observe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        evidence: ["lifeops:contact", "reaction_ingest"],
+      }),
+    );
+  });
+
+  it("records metadata-only reactions as connector activity", async () => {
+    const { runtime, handlers } = runtimeWithRelationships(null);
+    await PresenceSignalBridgeService.start(runtime);
+
+    await handlers.get(EventType.REACTION_RECEIVED)?.({
+      runtime,
+      source: "imessage",
+      handle: "+15555550123",
+      targetGuid: "imessage-target-1",
+      reactionKind: "heart",
+      timestamp: Date.parse("2026-06-01T13:00:00.000Z"),
+    } as unknown as MessagePayload);
+
+    expect(mockState.activitySignals).toHaveLength(1);
+    expect(mockState.activitySignals[0]).toMatchObject({
+      source: "connector_activity",
+      platform: "imessage",
+      state: "active",
+      observedAt: "2026-06-01T13:00:00.000Z",
+      metadata: {
+        eventType: EventType.REACTION_RECEIVED,
+        handle: "+15555550123",
+        direction: "inbound",
+        reactionKind: "heart",
+      },
+    });
+  });
+
+  it("records user view switches as app lifecycle activity", async () => {
+    const { runtime, handlers } = runtimeWithRelationships(null);
+    await PresenceSignalBridgeService.start(runtime);
+
+    await handlers.get(EventType.VIEW_SWITCHED)?.({
+      runtime,
+      viewId: "inbox",
+      viewLabel: "Inbox",
+      viewPath: "/inbox",
+      viewType: "builtin",
+      previousViewId: "home",
+      initiatedBy: "user",
+      roomId: ROOM_ID,
+      observedAt: "2026-06-01T14:00:00.000Z",
+    } as unknown as ViewSwitchedPayload);
+
+    expect(mockState.activitySignals).toHaveLength(1);
+    expect(mockState.activitySignals[0]).toMatchObject({
+      source: "app_lifecycle",
+      platform: "app_view",
+      state: "active",
+      observedAt: "2026-06-01T14:00:00.000Z",
+      idleState: "active",
+      metadata: {
+        eventType: EventType.VIEW_SWITCHED,
+        viewId: "inbox",
+        viewLabel: "Inbox",
+        viewPath: "/inbox",
+        viewType: "builtin",
+        previousViewId: "home",
+        roomId: ROOM_ID,
+      },
+    });
+  });
+
+  it("ignores agent-initiated view switches for owner presence", async () => {
+    const { runtime, handlers } = runtimeWithRelationships(null);
+    await PresenceSignalBridgeService.start(runtime);
+
+    await handlers.get(EventType.VIEW_SWITCHED)?.({
+      runtime,
+      viewId: "wallet",
+      initiatedBy: "agent",
+    } as unknown as ViewSwitchedPayload);
+
+    expect(mockState.activitySignals).toHaveLength(0);
   });
 });

--- a/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.ts
@@ -12,6 +12,7 @@ import {
   type MessagePayload,
   Service,
   type UUID,
+  type ViewSwitchedPayload,
 } from "@elizaos/core";
 import { SELF_ENTITY_ID } from "@elizaos/shared";
 import { getDeviceId } from "../lifeops/device-identity.js";
@@ -41,6 +42,29 @@ function readMessageTimestamp(payload: MessagePayload): string {
   const createdAt = record?.createdAt;
   if (typeof createdAt === "number" && Number.isFinite(createdAt)) {
     return new Date(createdAt).toISOString();
+  }
+  return new Date().toISOString();
+}
+
+function readEventTimestamp(payload: unknown): string {
+  const record = isRecord(payload) ? payload : null;
+  const metadata = isRecord(record?.metadata) ? record.metadata : null;
+  const candidates = [
+    record?.observedAt,
+    record?.createdAt,
+    record?.timestamp,
+    metadata?.observedAt,
+    metadata?.createdAt,
+    metadata?.timestamp,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === "number" && Number.isFinite(candidate)) {
+      return new Date(candidate).toISOString();
+    }
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      const parsed = Date.parse(candidate);
+      if (Number.isFinite(parsed)) return new Date(parsed).toISOString();
+    }
   }
   return new Date().toISOString();
 }
@@ -114,6 +138,7 @@ function readNestedString(value: unknown, key: string): string | null {
 }
 
 function readMessageHandle(payload: MessagePayload): string | null {
+  const payloadRecord = isRecord(payload) ? payload : null;
   const record = isRecord(payload.message) ? payload.message : null;
   const content = isRecord(record?.content) ? record.content : {};
   const metadata = readMetadataRecord(payload);
@@ -133,6 +158,8 @@ function readMessageHandle(payload: MessagePayload): string | null {
     readNestedString(sender, "id"),
     metadata.senderHandle,
     metadata.username,
+    payloadRecord?.handle,
+    payloadRecord?.username,
   ];
   for (const candidate of candidates) {
     if (typeof candidate === "string" && candidate.trim().length > 0) {
@@ -152,6 +179,72 @@ function readExternalMessageId(payload: MessagePayload): string | undefined {
     }
   }
   return undefined;
+}
+
+function readReactionTargetId(payload: unknown): string {
+  const record = isRecord(payload) ? payload : {};
+  const metadata = isRecord(record.metadata) ? record.metadata : {};
+  const candidates = [
+    record.targetGuid,
+    record.targetMessageId,
+    record.messageId,
+    record.roomId,
+    metadata.targetGuid,
+    metadata.targetTweetId,
+    metadata.messageId,
+    metadata.originalId,
+    record.source,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      return candidate.trim();
+    }
+  }
+  return "unknown-reaction-target";
+}
+
+function readReactionHandle(payload: unknown): string | null {
+  const record = isRecord(payload) ? payload : {};
+  const metadata = isRecord(record.metadata) ? record.metadata : {};
+  const user = isRecord(record.user) ? record.user : {};
+  const candidates = [
+    record.handle,
+    record.username,
+    metadata.username,
+    metadata.handle,
+    metadata.userId,
+    user.username,
+    user.id,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      return candidate.trim();
+    }
+  }
+  return null;
+}
+
+function readReactionKind(payload: unknown): string | null {
+  const record = isRecord(payload) ? payload : {};
+  const metadata = isRecord(record.metadata) ? record.metadata : {};
+  const candidates = [
+    record.reactionString,
+    record.reactionKind,
+    record.emoji,
+    metadata.type,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      return candidate.trim();
+    }
+  }
+  return null;
+}
+
+function readTopLevelEntityId(payload: unknown): string | null {
+  const record = isRecord(payload) ? payload : {};
+  const entityId = record.entityId;
+  return typeof entityId === "string" && entityId.length > 0 ? entityId : null;
 }
 
 interface RelationshipActivityContact {
@@ -240,6 +333,25 @@ export class PresenceSignalBridgeService extends Service {
     await this.captureActivityFromMessage(EventType.MESSAGE_SENT, payload);
   };
 
+  private readonly reactionReceivedHandler = async (
+    payload: MessagePayload,
+  ): Promise<void> => {
+    if (isRecord(payload.message)) {
+      await this.captureActivityFromMessage(
+        EventType.REACTION_RECEIVED,
+        payload,
+      );
+      return;
+    }
+    await this.captureActivityFromReactionMetadata(payload);
+  };
+
+  private readonly viewSwitchedHandler = async (
+    payload: ViewSwitchedPayload,
+  ): Promise<void> => {
+    await this.captureActivityFromViewSwitch(payload);
+  };
+
   private readonly actionStartedHandler = async (
     payload: ActionEventPayload,
   ): Promise<void> => {
@@ -256,6 +368,11 @@ export class PresenceSignalBridgeService extends Service {
     );
     runtime.registerEvent(EventType.MESSAGE_SENT, service.messageSentHandler);
     runtime.registerEvent(
+      EventType.REACTION_RECEIVED,
+      service.reactionReceivedHandler,
+    );
+    runtime.registerEvent(EventType.VIEW_SWITCHED, service.viewSwitchedHandler);
+    runtime.registerEvent(
       EventType.ACTION_STARTED,
       service.actionStartedHandler,
     );
@@ -270,6 +387,14 @@ export class PresenceSignalBridgeService extends Service {
     this.runtime.unregisterEvent(
       EventType.MESSAGE_SENT,
       this.messageSentHandler,
+    );
+    this.runtime.unregisterEvent(
+      EventType.REACTION_RECEIVED,
+      this.reactionReceivedHandler,
+    );
+    this.runtime.unregisterEvent(
+      EventType.VIEW_SWITCHED,
+      this.viewSwitchedHandler,
     );
     this.runtime.unregisterEvent(
       EventType.ACTION_STARTED,
@@ -323,7 +448,10 @@ export class PresenceSignalBridgeService extends Service {
   }
 
   private async captureActivityFromMessage(
-    eventType: EventType.MESSAGE_RECEIVED | EventType.MESSAGE_SENT,
+    eventType:
+      | EventType.MESSAGE_RECEIVED
+      | EventType.MESSAGE_SENT
+      | EventType.REACTION_RECEIVED,
     payload: MessagePayload,
   ): Promise<void> {
     const entityId = readMessageEntityId(payload);
@@ -394,8 +522,117 @@ export class PresenceSignalBridgeService extends Service {
     });
   }
 
+  private async captureActivityFromReactionMetadata(
+    payload: MessagePayload,
+  ): Promise<void> {
+    const observedAt = readEventTimestamp(payload);
+    const observedMs = Date.parse(observedAt);
+    const platform = readPlatform(payload);
+    const handle = readReactionHandle(payload);
+    const entityId = readTopLevelEntityId(payload);
+    const targetId = readReactionTargetId(payload);
+    const fingerprint = `reaction:${platform}:${handle ?? entityId ?? targetId}`;
+    const existing = this.recentFingerprints.get(fingerprint);
+    if (
+      existing !== undefined &&
+      Number.isFinite(observedMs) &&
+      observedMs - existing < DEDUPE_WINDOW_MS
+    ) {
+      return;
+    }
+    if (Number.isFinite(observedMs)) {
+      this.recentFingerprints.set(fingerprint, observedMs);
+    }
+
+    const repository = new LifeOpsRepository(this.runtime);
+    await repository.createActivitySignal(
+      createLifeOpsActivitySignal({
+        agentId: String(this.runtime.agentId),
+        source: "connector_activity",
+        platform,
+        state: "active",
+        observedAt,
+        idleState: null,
+        idleTimeSeconds: 0,
+        onBattery: null,
+        health: null,
+        metadata: {
+          eventType: EventType.REACTION_RECEIVED,
+          entityId,
+          ...(handle ? { handle } : {}),
+          direction: "inbound",
+          targetHash: hashTelemetryIdentity("reaction-target", targetId),
+          ...(readReactionKind(payload)
+            ? { reactionKind: readReactionKind(payload) }
+            : {}),
+          deviceId: getDeviceId(),
+        },
+      }),
+    );
+    await this.recordRelationshipRecency({
+      eventType: EventType.REACTION_RECEIVED,
+      entityId,
+      observedAt,
+      platform,
+      payload,
+      repository,
+    });
+  }
+
+  private async captureActivityFromViewSwitch(
+    payload: ViewSwitchedPayload,
+  ): Promise<void> {
+    if (payload.initiatedBy !== "user") {
+      return;
+    }
+    const observedAt = readEventTimestamp(payload);
+    const observedMs = Date.parse(observedAt);
+    const fingerprint = `view:${payload.viewId}:${payload.roomId ?? ""}`;
+    const existing = this.recentFingerprints.get(fingerprint);
+    if (
+      existing !== undefined &&
+      Number.isFinite(observedMs) &&
+      observedMs - existing < DEDUPE_WINDOW_MS
+    ) {
+      return;
+    }
+    if (Number.isFinite(observedMs)) {
+      this.recentFingerprints.set(fingerprint, observedMs);
+    }
+
+    const repository = new LifeOpsRepository(this.runtime);
+    await repository.createActivitySignal(
+      createLifeOpsActivitySignal({
+        agentId: String(this.runtime.agentId),
+        source: "app_lifecycle",
+        platform: "app_view",
+        state: "active",
+        observedAt,
+        idleState: "active",
+        idleTimeSeconds: 0,
+        onBattery: null,
+        health: null,
+        metadata: {
+          eventType: EventType.VIEW_SWITCHED,
+          viewId: payload.viewId,
+          ...(payload.viewLabel ? { viewLabel: payload.viewLabel } : {}),
+          ...(payload.viewPath ? { viewPath: payload.viewPath } : {}),
+          ...(payload.viewType ? { viewType: payload.viewType } : {}),
+          ...(payload.previousViewId
+            ? { previousViewId: payload.previousViewId }
+            : {}),
+          ...(payload.roomId ? { roomId: payload.roomId } : {}),
+          deviceId: getDeviceId(),
+        },
+      }),
+    );
+  }
+
   private async recordRelationshipRecency(args: {
-    eventType: EventType.MESSAGE_RECEIVED | EventType.MESSAGE_SENT;
+    eventType:
+      | EventType.MESSAGE_RECEIVED
+      | EventType.MESSAGE_SENT
+      | EventType.REACTION_RECEIVED;
     entityId: string | null;
     observedAt: string;
     platform: string;
@@ -406,7 +643,9 @@ export class PresenceSignalBridgeService extends Service {
       args.eventType === EventType.MESSAGE_SENT ? "outbound" : "inbound";
     const handle = readMessageHandle(args.payload);
     const externalRef = readExternalMessageId(args.payload);
-    const summary = `Passive ${args.platform} message activity`;
+    const isReaction = args.eventType === EventType.REACTION_RECEIVED;
+    const summary = `Passive ${args.platform} ${isReaction ? "reaction" : "message"} activity`;
+    const evidenceKind = isReaction ? "reaction_ingest" : "message_ingest";
     const service = getRelationshipActivityService(this.runtime);
 
     let contactId: UUID | null = null;
@@ -436,7 +675,7 @@ export class PresenceSignalBridgeService extends Service {
       const observed = await entityStore.observeIdentity({
         platform: args.platform,
         handle,
-        evidence: [LIFEOPS_CONTACT_TAG, "message_ingest"],
+        evidence: [LIFEOPS_CONTACT_TAG, evidenceKind],
         confidence: 0.8,
         suggestedType: "person",
       });
@@ -467,7 +706,7 @@ export class PresenceSignalBridgeService extends Service {
         lastInteractionPlatform: args.platform,
         lastInteractionDirection: direction,
       },
-      evidence: [LIFEOPS_CONTACT_TAG, "message_ingest"],
+      evidence: [LIFEOPS_CONTACT_TAG, evidenceKind],
       confidence: 0.8,
       occurredAt: args.observedAt,
       source: "extraction",

--- a/plugins/plugin-personal-assistant/src/ui.ts
+++ b/plugins/plugin-personal-assistant/src/ui.ts
@@ -8,6 +8,7 @@ import "./api/client-lifeops.js";
 import React from "react";
 import { AppBlockerSettingsCard as AppBlockerSettingsCardImpl } from "./components/AppBlockerSettingsCard.js";
 import { WebsiteBlockerSettingsCard as WebsiteBlockerSettingsCardImpl } from "./components/WebsiteBlockerSettingsCard.js";
+import { useLifeOpsActivitySignals } from "./hooks/useLifeOpsActivitySignals.js";
 
 import { dispatchQueuedLifeOpsGithubCallbackFromUrl } from "./platform/lifeops-github.js";
 import type {
@@ -19,11 +20,10 @@ import type {
   WebsiteBlockerSettingsMode,
 } from "./types/website-blocker-settings-card.js";
 
-function EmptyComponent() {
+export function LifeOpsActivitySignalsEffect() {
+  useLifeOpsActivitySignals();
   return null;
 }
-
-export const LifeOpsActivitySignalsEffect = EmptyComponent;
 
 export function AppBlockerSettingsCard(props: AppBlockerSettingsCardProps) {
   return React.createElement(AppBlockerSettingsCardImpl, props);


### PR DESCRIPTION
## Summary
- Registers `VIEW_SWITCHED` and `REACTION_RECEIVED` in `PresenceSignalBridgeService` so passive UI navigation and tapbacks become LifeOps activity signals.
- Writes user-initiated view switches as `app_lifecycle` / `app_view` signals and skips agent-initiated navigation so agent-driven UI movement does not fabricate owner presence.
- Writes message-backed and metadata-only reactions as `connector_activity` signals, with reaction-specific relationship recency evidence where a contact can be resolved.
- Mounts the existing `useLifeOpsActivitySignals` heartbeat from the renderer facade instead of exporting an empty component.

Fixes #14689.

## Verification
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/cloud/routing build`
- `bun run --cwd packages/contracts build`
- `bun run --cwd plugins/plugin-personal-assistant test src/activity-profile/presence-signal-bridge-service.test.ts` (9 passed)
- `bun run --cwd plugins/plugin-personal-assistant build:js`
- `bun run --cwd plugins/plugin-personal-assistant build:types`
- `bunx @biomejs/biome check plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.ts plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts plugins/plugin-personal-assistant/src/ui.ts`
- `git diff --check origin/develop...HEAD -- plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.ts plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts plugins/plugin-personal-assistant/src/ui.ts`
- `bun run audit:error-policy-ratchet --report`

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: N/A - no rendered UI appearance changes; this PR wires passive runtime events and mounts an existing side-effect heartbeat hook.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: N/A - no rendered UI appearance changes; the user-visible proof is the deterministic event bridge behavior covered by the focused test.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: N/A - no clickable visual flow changed; event handling is exercised through runtime event handlers in the test harness.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs: N/A - no deployed backend session was started; local proof is the focused runtime-event test plus package JS/types builds and the error-policy ratchet listed above.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - no browser network flow or rendered component changed; `src/ui.ts` only restores the existing heartbeat hook mount and compiled through `build:js` / `build:types`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - deterministic event bridge and renderer facade change; no prompt, provider, action planning, or model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - no persistent artifact is produced by the unit harness; the test asserts the expected `app_lifecycle`, `app_view`, `connector_activity`, relationship recency, and dedupe writes directly.

## Blocked / not run
- `bun run --cwd plugins/plugin-personal-assistant typecheck` still fails on existing package-wide unresolved cross-workspace declaration exports and strict errors outside this change. Verified examples include unresolved `@elizaos/core`, `@elizaos/plugin-calendar`, `@elizaos/plugin-finances`, `@elizaos/plugin-scheduling`, and moved scheduled-task/contract exports. The touched files build and their focused tests pass.
- App visual audit is N/A: this remounts a side-effect heartbeat and changes server-side signal handling, with no rendered UI component appearance change.
