### PR TITLE
fix(scenarios): realize travel memory seeds

### DIFF
--- a/packages/scenario-runner/src/seeds.test.ts
+++ b/packages/scenario-runner/src/seeds.test.ts
@@ -421,6 +421,80 @@ describe("scenario memory seeds", () => {
     });
   });
 
+  it.each([
+    [
+      "profile",
+      {
+        homeTimezone: "America/Los_Angeles",
+        loyalty: { marriott: "MR12345678" },
+      },
+    ],
+    [
+      "trip",
+      {
+        destination: "JFK",
+        flight: { carrier: "United", flightNumber: "UA245" },
+      },
+    ],
+    [
+      "booking",
+      {
+        carrier: "United",
+        flightNumber: "UA245",
+        origin: "SFO",
+        destination: "JFK",
+      },
+    ],
+    [
+      "upgrade-offer",
+      {
+        carrier: "United",
+        flightNumber: "UA245",
+        priceUSD: 480,
+      },
+    ],
+    [
+      "calendar-focus-window",
+      {
+        title: "Deep work — no travel",
+        rule: "no-travel",
+      },
+    ],
+  ])("writes %s structured travel memory seeds as durable owner facts", async (kind, fields) => {
+    const { ctx, createMemory } = createSeedHarness();
+
+    const result = await applyScenarioSeedStep(ctx, {
+      type: "memory",
+      content: {
+        kind,
+        ...fields,
+      },
+    } satisfies ScenarioSeedStep);
+
+    expect(result).toBeUndefined();
+    expect(createMemory).toHaveBeenCalledTimes(1);
+    const [memory, tableName, unique] = createMemory.mock.calls[0];
+    expect(tableName).toBe("facts");
+    expect(unique).toBe(true);
+    expect(memory.roomId).toBe(ctx.primaryRoomId);
+    expect(memory.entityId).toBe(ctx.primaryUserId);
+    const memoryContent = memory.content as { text: string };
+    expect(memoryContent.text).toContain(
+      `Scenario-seeded travel ${kind} context:`,
+    );
+    for (const [key, value] of Object.entries(fields)) {
+      expect(memoryContent.text).toContain(`"${key}"`);
+      if (typeof value === "string" || typeof value === "number") {
+        expect(memoryContent.text).toContain(String(value));
+      }
+    }
+    expect(memory.metadata).toMatchObject({
+      kind: "durable",
+      source: "scenario-seed",
+      seedKind: kind,
+    });
+  });
+
   it("fails the seed (never silently no-ops) on unsupported memory kinds", async () => {
     const { ctx, relationships, createMemory } = createSeedHarness();
 

--- a/packages/scenario-runner/src/seeds.ts
+++ b/packages/scenario-runner/src/seeds.ts
@@ -193,6 +193,14 @@ type MemoryContactSeed = {
   relationshipStatus?: unknown;
 };
 
+const TRAVEL_FACT_MEMORY_KINDS = new Set([
+  "profile",
+  "trip",
+  "booking",
+  "upgrade-offer",
+  "calendar-focus-window",
+]);
+
 type ConnectorStatusLike = {
   state: "ok" | "degraded" | "disconnected";
   message?: string;
@@ -697,16 +705,38 @@ async function seedMemory(
   ) {
     return seedContact(ctx, memoryEntityToContactSeed(content, memoryType));
   }
+  if (memoryType && TRAVEL_FACT_MEMORY_KINDS.has(memoryType)) {
+    const text = formatStructuredMemoryFact(memoryType, content);
+    return writeDurableFact(ctx, text, { seedKind: memoryType });
+  }
   if (memoryType !== null) {
     // A seed the runner cannot land must fail the scenario, never no-op:
     // a silently dropped seed fabricates the premise the checks grade
     // against (#14631 — the "seeded VIP fact" the model never received).
-    return `unsupported memory seed kind "${memoryType}" — supported: contact/rolodex-entity/merged-entity, or plain { text } for a durable owner fact`;
+    return `unsupported memory seed kind "${memoryType}" — supported: contact/rolodex-entity/merged-entity, travel profile/trip/booking/upgrade-offer/calendar-focus-window, or plain { text } for a durable owner fact`;
   }
   const text = readNonEmptyString((content as { text?: unknown }).text);
   if (!text) {
     return "memory seed content must carry non-empty text or a contact-like kind";
   }
+  return writeDurableFact(ctx, text);
+}
+
+function formatStructuredMemoryFact(
+  memoryType: string,
+  content: Record<string, unknown>,
+): string {
+  return [
+    `Scenario-seeded travel ${memoryType} context:`,
+    JSON.stringify(content, null, 2),
+  ].join("\n");
+}
+
+async function writeDurableFact(
+  ctx: ScenarioContext,
+  text: string,
+  metadata: Record<string, unknown> = {},
+): Promise<string | undefined> {
   // Plain-text memory seeds are owner facts: write a real durable row in the
   // `facts` table, attributed to the primary room + simulated owner entity,
   // in the exact shape the fact extractor persists — so the core FACTS
@@ -733,6 +763,7 @@ async function seedMemory(
         kind: "durable",
         category: "seeded",
         keywords: [],
+        ...metadata,
       },
       createdAt: Date.now(),
     },


### PR DESCRIPTION
## Summary

Partial #14815 fix: realizes the travel-context `type: "memory"` seed family instead of failing at seed time.

- maps `profile`, `trip`, `booking`, `upgrade-offer`, and `calendar-focus-window` memory seeds into real durable rows in the core `facts` table
- preserves fail-fast behavior for unsupported structured kinds such as `inbound-message`
- records `seedKind` metadata so seeded facts remain inspectable and attributable
- adds unit coverage for every supported travel seed kind

This does not close #14815; other structured seed families still need real-store realizations.

## Required Evidence

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - scenario-runner seed pipeline change only; no UI surface changed.`

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - scenario-runner seed pipeline change only; no UI surface changed.`

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no app view, mobile state, or visual surface changed.`

<!-- evidence-row:backend-logs -->
- [x] Backend/log evidence `N/A - no persisted log artifact for this seed-pipeline patch; focused command transcript is inline below.`

```text
bun run --cwd packages/scenario-runner test -- src/seeds.test.ts
Test Files  1 passed (1)
Tests  19 passed (19)

bun packages/scenario-runner/src/cli.ts list packages/test/scenarios/lifeops.travel --lane live-only --validate-scenarios
{ "valid": true, "total": 165, "uniqueIds": 165, "duplicateIds": [], "missingIds": [], "expansionMatches": true }

bunx biome check packages/scenario-runner/src/seeds.ts packages/scenario-runner/src/seeds.test.ts
Checked 2 files. No fixes applied.

git diff --check
```

Known baseline:

```text
bun run --cwd packages/scenario-runner typecheck
fails on existing unresolved workspace modules such as @elizaos/plugin-xr, @elizaos/plugin-blocker/services/website-blocker/index, @elizaos/plugin-personal-assistant/lifeops/service, @elizaos/plugin-scheduling, @elizaos/capacitor-camera, @elizaos/tui, and shared event/transcript export drift. No package typecheck errors remain in src/seeds.ts or src/seeds.test.ts after the local fix.
```

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend code path or browser surface changed.`

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - this patch changes seed realization and is covered by deterministic seed unit tests; live travel scenario reruns remain part of #14815 follow-through once all structured seed kinds are realized.`

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts `N/A - artifacts are committed seed-pipeline code and tests rather than generated runtime rows; focused assertions are inline.` Unit tests assert that all five travel seed kinds write the real `facts` table with durable `scenario-seed` metadata and `seedKind`, while unsupported `inbound-message` still fails without writing facts or contacts.
