### PR TITLE
fix(lifeops): schedule approval queue prompts

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/approval-queue.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/approval-queue.ts
@@ -739,16 +739,29 @@ export class PgApprovalQueue implements ApprovalQueue {
     logger.info(
       `[ApprovalQueue] enqueued ${input.action} for ${input.subjectUserId} as ${id}`,
     );
-    await scheduleApprovalTask(this.runtime, {
-      agentId: this.agentId,
-      requestId: id,
-      subjectUserId: input.subjectUserId,
-      action: input.action,
-      channel: input.channel,
-      reason: input.reason,
-      requestedBy: input.requestedBy,
-      createdAt: now,
-    });
+    try {
+      await scheduleApprovalTask(this.runtime, {
+        agentId: this.agentId,
+        requestId: id,
+        subjectUserId: input.subjectUserId,
+        action: input.action,
+        channel: input.channel,
+        reason: input.reason,
+        requestedBy: input.requestedBy,
+        createdAt: now,
+      });
+    } catch (error) {
+      // error-policy:J2 The approval row and ScheduledTask must be atomic from
+      // the caller's perspective: rollback the row, then rethrow with context.
+      await executeRawSql(
+        this.runtime,
+        `DELETE FROM approval_requests WHERE id = ${sqlText(id)} AND agent_id = ${sqlText(this.agentId)}`,
+      );
+      throw new Error(
+        `[ApprovalQueue] failed to schedule approval task for ${id}; rolled back approval row`,
+        { cause: error },
+      );
+    }
     // An outbound action now needs the owner's go-ahead. Surface it directly
     // in chat with one-tap approval chips, and also on the notification rail so
     // the owner is interrupted even when they are not watching chat. Both

--- a/plugins/plugin-personal-assistant/src/lifeops/approval-queue.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/approval-queue.ts
@@ -8,6 +8,10 @@ import { randomUUID } from "node:crypto";
 import { getAgentEventService, resolveApprovalService } from "@elizaos/agent";
 import { type IAgentRuntime, logger, ServiceType } from "@elizaos/core";
 import {
+  getScheduledTaskRunner,
+  type ScheduledTaskInput,
+} from "@elizaos/plugin-scheduling";
+import {
   type ApprovalAction,
   type ApprovalChannel,
   type ApprovalEnqueueInput,
@@ -21,6 +25,7 @@ import {
   ApprovalStateTransitionError,
   ApprovalTransitionConflictError,
 } from "./approval-queue.types.js";
+import { getChannelRegistry } from "./channels/index.js";
 import { buildApprovalChoiceText } from "./choice-markers.js";
 import {
   executeRawSql,
@@ -599,6 +604,93 @@ function getNotifier(runtime: IAgentRuntime): NotificationEmitter | null {
   return svc && typeof svc.notify === "function" ? svc : null;
 }
 
+const APPROVAL_ESCALATION_CHANNEL_ORDER = [
+  "telegram",
+  "signal",
+  "whatsapp",
+  "discord",
+  "sms",
+  "voice",
+  "imessage",
+  "email",
+  "x_dm",
+  "push",
+  "in_app",
+] as const;
+
+function approvalEscalationSteps(
+  runtime: IAgentRuntime,
+  preferredChannel: ApprovalChannel,
+): NonNullable<ScheduledTaskInput["escalation"]>["steps"] {
+  const registry = getChannelRegistry(runtime);
+  const registered = new Set(registry?.list().map((c) => c.kind) ?? []);
+  const ordered = [preferredChannel, ...APPROVAL_ESCALATION_CHANNEL_ORDER];
+  const seen = new Set<string>();
+  return ordered
+    .filter((channelKey) => {
+      if (seen.has(channelKey) || !registered.has(channelKey)) return false;
+      seen.add(channelKey);
+      const channel = registry?.get(channelKey);
+      return (
+        channelKey === "push" ||
+        channelKey === "in_app" ||
+        Boolean(channel?.send)
+      );
+    })
+    .map((channelKey, index) => ({
+      channelKey,
+      delayMinutes: index === 0 ? 0 : 15,
+      intensity: index === 0 ? "normal" : "urgent",
+    }));
+}
+
+async function scheduleApprovalTask(
+  runtime: IAgentRuntime,
+  input: {
+    agentId: string;
+    requestId: string;
+    subjectUserId: string;
+    action: ApprovalAction;
+    channel: ApprovalChannel;
+    reason: string;
+    requestedBy: string;
+    createdAt: Date;
+  },
+): Promise<string> {
+  const runner = getScheduledTaskRunner(runtime, { agentId: input.agentId });
+  const task = await runner.schedule({
+    kind: "approval",
+    promptInstructions: `Approval needed: ${input.reason}. Reply "approve ${input.requestId}" or "reject ${input.requestId}".`,
+    trigger: { kind: "once", atIso: input.createdAt.toISOString() },
+    priority: "high",
+    completionCheck: {
+      kind: "user_acknowledged",
+      params: { requestId: input.requestId },
+    },
+    escalation: {
+      steps: approvalEscalationSteps(runtime, input.channel),
+    },
+    subject: { kind: "self", id: input.subjectUserId },
+    idempotencyKey: `approval:${input.requestId}`,
+    respectsGlobalPause: false,
+    source: "plugin",
+    createdBy: input.agentId,
+    ownerVisible: true,
+    metadata: {
+      approvalRequestId: input.requestId,
+      approvalAction: input.action,
+      approvalChannel: input.channel,
+      requestedBy: input.requestedBy,
+      pendingPromptRoomId: `approval:${input.requestId}`,
+      pendingPromptAction: input.action,
+    },
+  });
+  logger.info(
+    `[ApprovalQueue] scheduled approval task ${task.taskId} for ${input.requestId}`,
+  );
+  return task.taskId;
+}
+
 export interface ApprovalQueueOptions {
   readonly agentId: string;
 }
@@ -647,6 +739,16 @@ export class PgApprovalQueue implements ApprovalQueue {
     logger.info(
       `[ApprovalQueue] enqueued ${input.action} for ${input.subjectUserId} as ${id}`,
     );
+    await scheduleApprovalTask(this.runtime, {
+      agentId: this.agentId,
+      requestId: id,
+      subjectUserId: input.subjectUserId,
+      action: input.action,
+      channel: input.channel,
+      reason: input.reason,
+      requestedBy: input.requestedBy,
+      createdAt: now,
+    });
     // An outbound action now needs the owner's go-ahead. Surface it directly
     // in chat with one-tap approval chips, and also on the notification rail so
     // the owner is interrupted even when they are not watching chat. Both

--- a/plugins/plugin-personal-assistant/test/approval-queue-notify-error.integration.test.ts
+++ b/plugins/plugin-personal-assistant/test/approval-queue-notify-error.integration.test.ts
@@ -18,6 +18,7 @@ import {
   Service,
   ServiceType,
 } from "@elizaos/core";
+import { schedulingPlugin } from "@elizaos/plugin-scheduling";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createRealTestRuntime } from "../../../packages/test/helpers/real-runtime.ts";
 import { createApprovalQueue } from "../src/lifeops/approval-queue.js";
@@ -71,11 +72,12 @@ beforeAll(async () => {
   stateDir = mkdtempSync(join(tmpdir(), "approval-notify-err-"));
   process.env.ELIZA_STATE_DIR = stateDir;
   const result = await createRealTestRuntime({
-    plugins: [personalAssistantPlugin],
+    plugins: [schedulingPlugin, personalAssistantPlugin],
   });
   runtime = result.runtime;
   cleanup = result.cleanup;
   await runtime.registerService(FailingNotificationService);
+  await runtime.getServiceLoadPromise(ServiceType.NOTIFICATION);
   queue = createApprovalQueue(runtime, { agentId: runtime.agentId });
 }, 180_000);
 

--- a/plugins/plugin-personal-assistant/test/approval-queue.integration.test.ts
+++ b/plugins/plugin-personal-assistant/test/approval-queue.integration.test.ts
@@ -16,6 +16,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentRuntime } from "@elizaos/core";
 import { AgentEventService, parseInteractionBlocks } from "@elizaos/core";
+import { schedulingPlugin } from "@elizaos/plugin-scheduling";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { createRealTestRuntime } from "../../../packages/test/helpers/real-runtime.ts";
 import { createApprovalQueue } from "../src/lifeops/approval-queue.js";
@@ -25,6 +26,7 @@ import {
   type ApprovalQueue,
   ApprovalStateTransitionError,
 } from "../src/lifeops/approval-queue.types.js";
+import { LifeOpsRepository } from "../src/lifeops/repository.js";
 import { personalAssistantPlugin } from "../src/plugin.js";
 
 let runtime: AgentRuntime;
@@ -98,7 +100,7 @@ function messageInput(
 beforeAll(async () => {
   setIsolatedEnv();
   const result = await createRealTestRuntime({
-    plugins: [personalAssistantPlugin],
+    plugins: [schedulingPlugin, personalAssistantPlugin],
   });
   runtime = result.runtime;
   cleanup = result.cleanup;
@@ -202,6 +204,39 @@ describe("ApprovalQueue integration (real PGlite)", () => {
     } finally {
       unsubscribe();
     }
+  }, 60_000);
+
+  it("enqueue creates an owner-visible approval ScheduledTask for connector escalation (#14722)", async () => {
+    const enqueued = await queue.enqueue(
+      messageInput({ subjectUserId: "owner-scheduled-task" }),
+    );
+
+    const repo = new LifeOpsRepository(runtime);
+    const task = await repo.getScheduledTaskByIdempotencyKey(
+      runtime.agentId,
+      `approval:${enqueued.id}`,
+    );
+
+    expect(task).not.toBeNull();
+    expect(task?.kind).toBe("approval");
+    expect(task?.priority).toBe("high");
+    expect(task?.ownerVisible).toBe(true);
+    expect(task?.respectsGlobalPause).toBe(false);
+    expect(task?.subject).toEqual({
+      kind: "self",
+      id: "owner-scheduled-task",
+    });
+    expect(task?.metadata?.approvalRequestId).toBe(enqueued.id);
+    expect(task?.metadata?.approvalAction).toBe("send_message");
+    expect(task?.metadata?.pendingPromptRoomId).toBe(`approval:${enqueued.id}`);
+    expect(task?.completionCheck?.kind).toBe("user_acknowledged");
+    expect(task?.completionCheck?.params).toEqual({ requestId: enqueued.id });
+    expect(task?.escalation?.steps?.map((step) => step.channelKey)).toEqual(
+      expect.arrayContaining(["sms", "telegram", "discord", "imessage"]),
+    );
+    expect(task?.escalation?.steps?.at(-1)?.channelKey).toBe("in_app");
+    expect(task?.promptInstructions).toContain(`approve ${enqueued.id}`);
+    expect(task?.promptInstructions).toContain(`reject ${enqueued.id}`);
   }, 60_000);
 
   it("enqueue → reject records resolver", async () => {

--- a/plugins/plugin-personal-assistant/test/approval-queue.integration.test.ts
+++ b/plugins/plugin-personal-assistant/test/approval-queue.integration.test.ts
@@ -239,6 +239,67 @@ describe("ApprovalQueue integration (real PGlite)", () => {
     expect(task?.promptInstructions).toContain(`reject ${enqueued.id}`);
   }, 60_000);
 
+  it("rolls back the approval row when the ScheduledTask cannot be created", async () => {
+    const failedStateDir = mkdtempSync(
+      join(tmpdir(), "approval-queue-schedule-fail-"),
+    );
+    const failedConfigPath = join(failedStateDir, "eliza.json");
+    writeFileSync(
+      failedConfigPath,
+      JSON.stringify({ logging: { level: "error" } }),
+      "utf8",
+    );
+    const previousStateDir = process.env.ELIZA_STATE_DIR;
+    const previousConfigPath = process.env.ELIZA_CONFIG_PATH;
+    const previousPersistConfigPath = process.env.ELIZA_PERSIST_CONFIG_PATH;
+    process.env.ELIZA_STATE_DIR = failedStateDir;
+    process.env.ELIZA_CONFIG_PATH = failedConfigPath;
+    process.env.ELIZA_PERSIST_CONFIG_PATH = failedConfigPath;
+    let failedCleanup: (() => Promise<void>) | null = null;
+    try {
+      const result = await createRealTestRuntime({
+        plugins: [personalAssistantPlugin],
+      });
+      failedCleanup = result.cleanup;
+      const failedQueue = createApprovalQueue(result.runtime, {
+        agentId: result.runtime.agentId,
+      });
+
+      await expect(
+        failedQueue.enqueue(
+          messageInput({ subjectUserId: "owner-schedule-fail" }),
+        ),
+      ).rejects.toThrow("failed to schedule approval task");
+
+      await expect(
+        failedQueue.list({
+          subjectUserId: "owner-schedule-fail",
+          state: null,
+          action: null,
+          limit: 10,
+        }),
+      ).resolves.toEqual([]);
+    } finally {
+      await failedCleanup?.();
+      if (previousStateDir === undefined) {
+        delete process.env.ELIZA_STATE_DIR;
+      } else {
+        process.env.ELIZA_STATE_DIR = previousStateDir;
+      }
+      if (previousConfigPath === undefined) {
+        delete process.env.ELIZA_CONFIG_PATH;
+      } else {
+        process.env.ELIZA_CONFIG_PATH = previousConfigPath;
+      }
+      if (previousPersistConfigPath === undefined) {
+        delete process.env.ELIZA_PERSIST_CONFIG_PATH;
+      } else {
+        process.env.ELIZA_PERSIST_CONFIG_PATH = previousPersistConfigPath;
+      }
+      rmSync(failedStateDir, { recursive: true, force: true });
+    }
+  }, 180_000);
+
   it("enqueue → reject records resolver", async () => {
     const enqueued = await queue.enqueue(
       messageInput({ subjectUserId: "owner-reject" }),

--- a/plugins/plugin-personal-assistant/test/stubs/agent.ts
+++ b/plugins/plugin-personal-assistant/test/stubs/agent.ts
@@ -223,9 +223,22 @@ export function getAgentEventServiceStubEvents(): AgentEventServiceStubEvent[] {
   return [...getAgentEventServiceStubState().events];
 }
 
-export function getAgentEventService(): {
+export function getAgentEventService(runtime?: {
+  getService?: (serviceType: string) => unknown;
+}): {
   emit: (event: AgentEventServiceStubEvent) => void;
 } | null {
+  const runtimeService = runtime?.getService?.("agent_event");
+  if (
+    runtimeService &&
+    typeof runtimeService === "object" &&
+    "emit" in runtimeService &&
+    typeof runtimeService.emit === "function"
+  ) {
+    return runtimeService as {
+      emit: (event: AgentEventServiceStubEvent) => void;
+    };
+  }
   const state = getAgentEventServiceStubState();
   if (!state.enabled) return null;
   return {
@@ -233,6 +246,10 @@ export function getAgentEventService(): {
       state.events.push(event);
     },
   };
+}
+
+export function resolveApprovalService(): null {
+  return null;
 }
 
 export const PERMISSIONS_REGISTRY_SERVICE = "eliza_permissions_registry";

--- a/plugins/plugin-personal-assistant/vitest.config.ts
+++ b/plugins/plugin-personal-assistant/vitest.config.ts
@@ -58,9 +58,16 @@ const optionalCorePluginStubPackages = new Set([
   "@elizaos/plugin-app-control",
   "@elizaos/plugin-shell",
   "@elizaos/plugin-coding-tools",
+  "@elizaos/plugin-pty",
+  "@elizaos/plugin-birdclaw",
   "@elizaos/plugin-commands",
   "@elizaos/plugin-video",
+  "@elizaos/plugin-vision",
   "@elizaos/plugin-background-runner",
+  "@elizaos/plugin-native-filesystem",
+  "@elizaos/plugin-app-manager",
+  "@elizaos/plugin-elizacloud",
+  "@elizaos/plugin-inbox/plugin",
   "@elizaos/plugin-ollama",
   "@elizaos/plugin-anthropic",
   "@elizaos/plugin-openai",
@@ -102,6 +109,23 @@ const agentSourceJsToTsPlugin = {
   load(id: string) {
     if (!id.startsWith(optionalCorePluginStubPrefix)) return null;
     const packageName = id.slice(optionalCorePluginStubPrefix.length);
+    if (packageName === "@elizaos/plugin-app-control") {
+      return [
+        "export function parseSettingsRequest(input) { return input ?? {}; }",
+        "export function createSettingsAction() {",
+        "  return {",
+        '    name: "SETTINGS_SECTION_TEST_STUB",',
+        '    description: "Test stub for app-control section settings.",',
+        "    examples: [],",
+        "    validate: async () => true,",
+        "    handler: async () => ({ success: false, text: 'settings stub unavailable' }),",
+        "  };",
+        "}",
+        'const plugin = { name: "plugin-app-control-test-stub", description: "Test stub for @elizaos/plugin-app-control", actions: [], providers: [], evaluators: [], services: [] };',
+        "export { plugin };",
+        "export default plugin;",
+      ].join("\n");
+    }
     const name = `${packageName.slice("@elizaos/".length)}-test-stub`;
     return [
       `const plugin = ${JSON.stringify({

--- a/plugins/plugin-personal-assistant/vitest.src-integration.config.ts
+++ b/plugins/plugin-personal-assistant/vitest.src-integration.config.ts
@@ -18,7 +18,9 @@
 // plugin barrel (its `@elizaos/core` string alias breaks the `/node` subpath
 // import that `@elizaos/plugin-x`'s dist pulls in), and the package's
 // test:integration script only names two test/ files there — so the pause
-// test never ran anywhere before this wiring.
+// test never ran anywhere before this wiring. Approval-queue integration specs
+// are included by name for the same reason: they boot the real PGlite runtime
+// and need this package's first-party source aliases instead of dist entries.
 
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -42,6 +44,7 @@ export default defineConfig({
       `${packageRootFromRepo}/src/**/*.integration.test.{ts,tsx}`,
       `${packageRootFromRepo}/test/scheduled-task-action.integration.test.ts`,
       `${packageRootFromRepo}/test/global-pause.integration.test.ts`,
+      `${packageRootFromRepo}/test/approval-queue.integration.test.ts`,
       `${packageRootFromRepo}/test/approval-queue-notify-error.integration.test.ts`,
     ],
     exclude: [


### PR DESCRIPTION
Fixes #14722.

## Summary
- Makes `PgApprovalQueue.enqueue()` create a durable owner-visible `ScheduledTask` with `kind: "approval"` for every pending approval request.
- Seeds connector-capable escalation steps from the registered `ChannelRegistry`, preferring the request channel when it is sendable and falling back through connector channels before push/in-app.
- Keeps existing chat chips and notification rail behavior, but the durable scheduled-task write is now part of enqueue instead of a transient side-channel.
- Wires the PA integration test lane so the real PGlite approval queue specs run with the scheduling service and source aliases.

## Evidence
- [x] Real DB artifact: `approval-queue.integration.test.ts` now asserts the persisted `life_scheduled_tasks` row by `idempotencyKey = approval:<requestId>`, including `kind: "approval"`, owner visibility, self subject, request metadata, completion params, connector escalation channels, and approve/reject prompt text.
- [x] Real PGlite tests: `bunx vitest run --config plugins/plugin-personal-assistant/vitest.src-integration.config.ts plugins/plugin-personal-assistant/test/approval-queue.integration.test.ts plugins/plugin-personal-assistant/test/approval-queue-notify-error.integration.test.ts` -> 2 files passed, 8 tests passed.
- [x] Lint/format: `bunx biome check plugins/plugin-personal-assistant/src/lifeops/approval-queue.ts plugins/plugin-personal-assistant/test/approval-queue.integration.test.ts plugins/plugin-personal-assistant/test/approval-queue-notify-error.integration.test.ts plugins/plugin-personal-assistant/test/stubs/agent.ts plugins/plugin-personal-assistant/vitest.config.ts plugins/plugin-personal-assistant/vitest.src-integration.config.ts` -> passed.
- [x] Error-policy ratchet: `bun run audit:error-policy-ratchet` -> passed, no new empty catch/server console in touched production file.
- [x] Whitespace: `git diff --check origin/develop..HEAD` -> passed.
- [ ] Package typecheck: attempted `bun run --cwd plugins/plugin-personal-assistant typecheck`, but the lane is blocked in this isolated worktree by pre-existing unresolved optional workspace package declarations and unrelated errors (for example `@elizaos/plugin-calendar`, `@elizaos/plugin-health`, `@elizaos/plugin-scheduling`, and existing scheduled-task re-export errors). The focused integration tests above compile and execute the changed path through the package Vitest config.
- [ ] Screenshots/video: N/A - backend approval scheduling path; no UI pixels changed.
- [ ] Live LLM trajectories: N/A - no prompt/model/action-planner behavior changed; the verification is the real queue insert plus real scheduled-task row in PGlite.

## Notes
- The integration test run emits third-party sourcemap warnings from `entities` / `@electric-sql/client`; tests still pass.
