### PR TITLE
fix(lifeops): deliver sleep-cycle check-ins to connected connector routes, not app-only (#14702)

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.checkin-chips.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.checkin-chips.test.ts
@@ -379,4 +379,63 @@ describe("sleep-cycle check-in connector delivery (#14702)", () => {
       delivered: false,
     });
   });
+
+  it("tries the next ranked connector route when the top route send fails", async () => {
+    const sendMessageToTarget = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("telegram offline"))
+      .mockResolvedValueOnce(undefined);
+    const { domain, emitAssistantEvent } = makeDomain({
+      sendMessageToTarget,
+      candidates: [
+        {
+          channel: "telegram",
+          score: 10,
+          evidence: [],
+          vetoReasons: [],
+          interruptionBudget: "normal",
+        },
+        {
+          channel: "discord",
+          score: 9,
+          evidence: [],
+          vetoReasons: [],
+          interruptionBudget: "normal",
+        },
+      ],
+    });
+    const stubbed = domain as unknown as {
+      resolvePrimaryChannelPolicy: unknown;
+      resolveRuntimeReminderTarget: unknown;
+    };
+    stubbed.resolvePrimaryChannelPolicy = vi.fn(async () => null);
+    stubbed.resolveRuntimeReminderTarget = vi.fn(async (channel: string) => ({
+      source: channel,
+      connectorRef: `runtime:${channel}:chat-1`,
+      target: { source: channel, channelId: `${channel}-chat-1` },
+      resolution: { sourceOfTruth: "config" },
+    }));
+
+    await runSleepCycleCheckins(domain);
+
+    expect(sendMessageToTarget).toHaveBeenCalledTimes(2);
+    expect(sendMessageToTarget.mock.calls[0][0]).toMatchObject({
+      source: "telegram",
+      channelId: "telegram-chat-1",
+    });
+    expect(sendMessageToTarget.mock.calls[1][0]).toMatchObject({
+      source: "discord",
+      channelId: "discord-chat-1",
+    });
+    const [, , data] = emitAssistantEvent.mock.calls[0] as [
+      string,
+      string,
+      Record<string, unknown>,
+    ];
+    expect(data.connectorDelivery).toMatchObject({
+      attempted: true,
+      channel: "discord",
+      delivered: true,
+    });
+  });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.checkin-chips.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.checkin-chips.test.ts
@@ -5,6 +5,12 @@
  * lifeops-choice-markers.test.ts; this suite covers the DISPATCH wiring —
  * deterministic vitest with the check-in engine and sleep-cycle predicates
  * mocked, so only summary+chips → emitAssistantEvent is under test.
+ *
+ * A second suite pins the connector-delivery slice (#14702): the dispatch
+ * consults the owner's ranked contact routes and sends the same summary+chips
+ * to the top non-vetoed connected route via `runtime.sendMessageToTarget`
+ * BEFORE the guaranteed in-app emit, so connector-primary / headless owners
+ * stop losing the night (and sleep-cycle morning) check-in off-app.
  */
 import { parseInteractionBlocks } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -52,11 +58,20 @@ vi.mock("@elizaos/plugin-health", async (importOriginal) => {
 
 const NOW = new Date("2026-07-05T08:00:00.000Z");
 
-function makeDomain() {
+function makeDomain(
+  overrides: { candidates?: unknown[]; sendMessageToTarget?: unknown } = {},
+) {
   const emitAssistantEvent = vi.fn();
   const ctx = {
-    runtime: { emitEvent: vi.fn(async () => undefined) },
-    repository: {},
+    runtime: {
+      emitEvent: vi.fn(async () => undefined),
+      ...(overrides.sendMessageToTarget
+        ? { sendMessageToTarget: overrides.sendMessageToTarget }
+        : {}),
+    },
+    repository: {
+      listChannelPolicies: vi.fn(async () => []),
+    },
     agentId: () => "00000000-0000-0000-0000-0000000000dd",
     emitAssistantEvent,
     logLifeOpsWarn: vi.fn(),
@@ -72,13 +87,18 @@ function makeDomain() {
     ctx as unknown as LifeOpsContext,
     deps as unknown as RemindersDeps,
   );
-  // TS `private` is compile-time only — stub the contact-route lookup so the
-  // dispatch path needs no owner-contacts fixture.
-  (
-    domain as unknown as {
-      buildOwnerContactRouteEventMetadata: unknown;
-    }
-  ).buildOwnerContactRouteEventMetadata = vi.fn(async () => ({}));
+  // TS `private` is compile-time only — stub the contact-route ranking and the
+  // activity-profile read so the dispatch path needs no owner-contacts / DB
+  // fixture. `resolveOwnerContactRouteCandidates` is the seam the check-in
+  // dispatch consults for connected-route delivery (#14702).
+  const stubbed = domain as unknown as {
+    resolveOwnerContactRouteCandidates: unknown;
+    readReminderActivityProfileSnapshot: unknown;
+  };
+  stubbed.readReminderActivityProfileSnapshot = vi.fn(async () => null);
+  stubbed.resolveOwnerContactRouteCandidates = vi.fn(
+    async () => overrides.candidates ?? [],
+  );
   return { domain, emitAssistantEvent };
 }
 
@@ -150,5 +170,213 @@ describe("sleep-cycle check-in dispatch (#14733)", () => {
 
     expect(checkinMocks.runMorningCheckin).not.toHaveBeenCalled();
     expect(emitAssistantEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe("sleep-cycle check-in connector delivery (#14702)", () => {
+  beforeEach(() => {
+    checkinMocks.hasCheckinForLocalDay.mockClear();
+    checkinMocks.hasCheckinForLocalDay.mockResolvedValue(false);
+    checkinMocks.runMorningCheckin.mockClear();
+  });
+
+  it("delivers the summary+chips to the top connected connector route, then still emits in-app", async () => {
+    const sendMessageToTarget = vi.fn(async () => undefined);
+    const { domain, emitAssistantEvent } = makeDomain({
+      sendMessageToTarget,
+      candidates: [
+        {
+          channel: "telegram",
+          score: 10,
+          evidence: ["purpose:checkin"],
+          vetoReasons: [],
+          interruptionBudget: "normal",
+        },
+      ],
+    });
+    // The connector-target resolver + policy lookup are exercised elsewhere;
+    // stub them so this suite pins the dispatch decision (top non-vetoed route
+    // → sendMessageToTarget with the same ack-marker text) without a DB.
+    const stubbed = domain as unknown as {
+      resolvePrimaryChannelPolicy: unknown;
+      resolveRuntimeReminderTarget: unknown;
+    };
+    stubbed.resolvePrimaryChannelPolicy = vi.fn(async () => null);
+    stubbed.resolveRuntimeReminderTarget = vi.fn(async () => ({
+      source: "telegram",
+      connectorRef: "runtime:telegram:chat-1",
+      target: { source: "telegram", channelId: "chat-1" },
+      resolution: { sourceOfTruth: "config" },
+    }));
+
+    await runSleepCycleCheckins(domain);
+
+    expect(sendMessageToTarget).toHaveBeenCalledTimes(1);
+    const [target, payload] = sendMessageToTarget.mock.calls[0] as [
+      Record<string, unknown>,
+      { text: string; source: string; metadata: Record<string, unknown> },
+    ];
+    expect(target).toMatchObject({ source: "telegram", channelId: "chat-1" });
+    // The connector send carries the same owner-facing text (ack chips
+    // included) so #14884/#14885 ack round-trips off-app.
+    expect(payload.text).toContain(
+      "Morning! 2 meetings today, 1 overdue todo.",
+    );
+    expect(payload.text).toContain("[CHOICE:checkin-rep-morning-1");
+    expect(payload.metadata).toMatchObject({
+      channelType: "telegram",
+      lifeopsCheckin: true,
+      checkinReportId: "rep-morning-1",
+    });
+    // In-app remains the guaranteed final rung.
+    expect(emitAssistantEvent).toHaveBeenCalledTimes(1);
+    const [, , data] = emitAssistantEvent.mock.calls[0] as [
+      string,
+      string,
+      Record<string, unknown>,
+    ];
+    expect(data.connectorDelivery).toMatchObject({
+      attempted: true,
+      channel: "telegram",
+      delivered: true,
+    });
+  });
+
+  it("skips vetoed and in_app/sms/voice routes and does not send off-app when none qualify", async () => {
+    const sendMessageToTarget = vi.fn(async () => undefined);
+    const { domain, emitAssistantEvent } = makeDomain({
+      sendMessageToTarget,
+      candidates: [
+        {
+          channel: "discord",
+          score: 8,
+          evidence: [],
+          vetoReasons: ["quiet_hours"],
+          interruptionBudget: "normal",
+        },
+        {
+          channel: "in_app",
+          score: 5,
+          evidence: [],
+          vetoReasons: [],
+          interruptionBudget: "normal",
+        },
+        {
+          channel: "sms",
+          score: 4,
+          evidence: [],
+          vetoReasons: [],
+          interruptionBudget: "normal",
+        },
+      ],
+    });
+
+    await runSleepCycleCheckins(domain);
+
+    expect(sendMessageToTarget).not.toHaveBeenCalled();
+    // The check-in is never dropped: in-app still fires.
+    expect(emitAssistantEvent).toHaveBeenCalledTimes(1);
+    const [, , data] = emitAssistantEvent.mock.calls[0] as [
+      string,
+      string,
+      Record<string, unknown>,
+    ];
+    expect(data.connectorDelivery).toMatchObject({
+      attempted: false,
+      channel: null,
+      delivered: false,
+    });
+  });
+
+  it("degrades to in-app only when contact-route resolution throws", async () => {
+    const sendMessageToTarget = vi.fn(async () => undefined);
+    const emitAssistantEvent = vi.fn();
+    const ctx = {
+      runtime: {
+        emitEvent: vi.fn(async () => undefined),
+        sendMessageToTarget,
+      },
+      repository: {
+        // The check-in dispatch reads channel policies to rank routes; a
+        // throw here must not drop the check-in.
+        listChannelPolicies: vi.fn(async () => {
+          throw new Error("db unavailable");
+        }),
+      },
+      agentId: () => "00000000-0000-0000-0000-0000000000dd",
+      emitAssistantEvent,
+      logLifeOpsWarn: vi.fn(),
+      logLifeOpsError: vi.fn(),
+    };
+    const domain = new RemindersDomain(
+      ctx as unknown as LifeOpsContext,
+      {
+        runDueWorkflows: vi.fn(async () => []),
+        runDueEventWorkflows: vi.fn(async () => []),
+        snoozeOccurrence: vi.fn(),
+        checkinSource: {},
+      } as unknown as RemindersDeps,
+    );
+    (
+      domain as unknown as { readReminderActivityProfileSnapshot: unknown }
+    ).readReminderActivityProfileSnapshot = vi.fn(async () => null);
+
+    await runSleepCycleCheckins(domain);
+
+    expect(sendMessageToTarget).not.toHaveBeenCalled();
+    expect(emitAssistantEvent).toHaveBeenCalledTimes(1);
+    const [, , data] = emitAssistantEvent.mock.calls[0] as [
+      string,
+      string,
+      Record<string, unknown>,
+    ];
+    expect(data.connectorDelivery).toMatchObject({
+      attempted: false,
+      delivered: false,
+    });
+  });
+
+  it("falls back to in-app when the connector send throws", async () => {
+    const sendMessageToTarget = vi.fn(async () => {
+      throw new Error("connector offline");
+    });
+    const { domain, emitAssistantEvent } = makeDomain({
+      sendMessageToTarget,
+      candidates: [
+        {
+          channel: "telegram",
+          score: 10,
+          evidence: [],
+          vetoReasons: [],
+          interruptionBudget: "normal",
+        },
+      ],
+    });
+    const stubbed = domain as unknown as {
+      resolvePrimaryChannelPolicy: unknown;
+      resolveRuntimeReminderTarget: unknown;
+    };
+    stubbed.resolvePrimaryChannelPolicy = vi.fn(async () => null);
+    stubbed.resolveRuntimeReminderTarget = vi.fn(async () => ({
+      source: "telegram",
+      connectorRef: "runtime:telegram:chat-1",
+      target: { source: "telegram", channelId: "chat-1" },
+      resolution: { sourceOfTruth: "config" },
+    }));
+
+    await runSleepCycleCheckins(domain);
+
+    expect(sendMessageToTarget).toHaveBeenCalledTimes(1);
+    expect(emitAssistantEvent).toHaveBeenCalledTimes(1);
+    const [, , data] = emitAssistantEvent.mock.calls[0] as [
+      string,
+      string,
+      Record<string, unknown>,
+    ];
+    expect(data.connectorDelivery).toMatchObject({
+      attempted: true,
+      channel: "telegram",
+      delivered: false,
+    });
   });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.checkin-chips.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.checkin-chips.test.ts
@@ -438,4 +438,61 @@ describe("sleep-cycle check-in connector delivery (#14702)", () => {
       delivered: true,
     });
   });
+
+  it("tries the next ranked connector route when target resolution fails", async () => {
+    const sendMessageToTarget = vi.fn(async () => undefined);
+    const { domain, emitAssistantEvent } = makeDomain({
+      sendMessageToTarget,
+      candidates: [
+        {
+          channel: "telegram",
+          score: 10,
+          evidence: [],
+          vetoReasons: [],
+          interruptionBudget: "normal",
+        },
+        {
+          channel: "discord",
+          score: 9,
+          evidence: [],
+          vetoReasons: [],
+          interruptionBudget: "normal",
+        },
+      ],
+    });
+    const stubbed = domain as unknown as {
+      resolvePrimaryChannelPolicy: unknown;
+      resolveRuntimeReminderTarget: unknown;
+    };
+    stubbed.resolvePrimaryChannelPolicy = vi.fn(async () => null);
+    stubbed.resolveRuntimeReminderTarget = vi.fn(async (channel: string) => {
+      if (channel === "telegram") {
+        throw new Error("telegram route unavailable");
+      }
+      return {
+        source: channel,
+        connectorRef: `runtime:${channel}:chat-1`,
+        target: { source: channel, channelId: `${channel}-chat-1` },
+        resolution: { sourceOfTruth: "config" },
+      };
+    });
+
+    await runSleepCycleCheckins(domain);
+
+    expect(sendMessageToTarget).toHaveBeenCalledTimes(1);
+    expect(sendMessageToTarget.mock.calls[0][0]).toMatchObject({
+      source: "discord",
+      channelId: "discord-chat-1",
+    });
+    const [, , data] = emitAssistantEvent.mock.calls[0] as [
+      string,
+      string,
+      Record<string, unknown>,
+    ];
+    expect(data.connectorDelivery).toMatchObject({
+      attempted: true,
+      channel: "discord",
+      delivered: true,
+    });
+  });
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
@@ -5623,11 +5623,28 @@ export class RemindersDomain {
       if (!isReminderChannel(channel)) {
         continue;
       }
-      const policy = await this.resolvePrimaryChannelPolicy(channel);
-      const runtimeTarget = await this.resolveRuntimeReminderTarget(
-        channel,
-        policy,
-      );
+      let runtimeTarget: Awaited<
+        ReturnType<RemindersDomain["resolveRuntimeReminderTarget"]>
+      >;
+      try {
+        const policy = await this.resolvePrimaryChannelPolicy(channel);
+        runtimeTarget = await this.resolveRuntimeReminderTarget(
+          channel,
+          policy,
+        );
+      } catch (error) {
+        const reason = lifeOpsErrorMessage(error);
+        // error-policy:J4 Check-in connector routes are optional delivery
+        // enrichment; resolver failure tries the next ranked connector and then
+        // degrades to the guaranteed in-app emit below.
+        this.ctx.logLifeOpsWarn(
+          "checkin_connector_route",
+          `[lifeops] Check-in connector route resolution failed for ${channel}; trying the next ranked route before falling back to in-app.`,
+          { error: reason },
+        );
+        firstFailure ??= { channel, reason };
+        continue;
+      }
       if (!runtimeTarget) {
         continue;
       }
@@ -5657,6 +5674,9 @@ export class RemindersDomain {
         };
       } catch (error) {
         const reason = lifeOpsErrorMessage(error);
+        // error-policy:J4 Check-in connector dispatch is optional delivery
+        // enrichment; failed sends try the next ranked connector and then
+        // degrade to the guaranteed in-app emit below.
         this.ctx.logLifeOpsWarn(
           "checkin_connector_dispatch",
           `[lifeops] Check-in connector delivery failed for ${channel}; trying the next ranked route before falling back to in-app.`,

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
@@ -5569,6 +5569,105 @@ export class RemindersDomain {
     }
   }
 
+  /**
+   * Deliver a sleep-cycle check-in to the owner's top-ranked connected
+   * contact route (telegram/discord/whatsapp/signal/…) when one exists.
+   *
+   * Historically `processSleepCycleCheckins` computed ranked route candidates
+   * then discarded them — the check-in was emitted app-only via
+   * `emitAssistantEvent`, so connector-primary / headless owners never saw the
+   * night (or sleep-cycle morning) summary off-app (#14702). This walks the
+   * already-veto-filtered candidate list, skips channels with no runtime
+   * target (`in_app` / `sms` / `voice` — the reminder path handles those
+   * separately), resolves the first connector-backed route, and sends the same
+   * owner-facing text (ack-choice-marker included, so #14884/#14885 ack
+   * round-trips regardless of which surface the reply lands on) through the
+   * proven `runtime.sendMessageToTarget` path the reminder escalation uses.
+   *
+   * In-app remains the guaranteed final rung: the caller always emits onto the
+   * assistant stream afterwards, so a connector miss never drops the check-in.
+   * Returns a small delivery receipt for the emitted event's diagnostics.
+   */
+  private async deliverCheckinToTopConnectorRoute(args: {
+    candidates: readonly ReminderRouteCandidate[];
+    text: string;
+    reportId: string;
+    kind: "morning" | "night";
+    urgency: LifeOpsReminderUrgency;
+    now: Date;
+  }): Promise<{
+    attempted: boolean;
+    channel: LifeOpsReminderChannel | null;
+    delivered: boolean;
+    reason?: string;
+  }> {
+    if (typeof this.ctx.runtime.sendMessageToTarget !== "function") {
+      return { attempted: false, channel: null, delivered: false };
+    }
+    for (const candidate of args.candidates) {
+      if (candidate.vetoReasons.length > 0) {
+        continue;
+      }
+      const channel = candidate.channel;
+      // `in_app` is the guaranteed final rung the caller emits; `sms` / `voice`
+      // have no `sendMessageToTarget` route (they escalate via the dedicated
+      // reminder connector path). Skip them here so we only try connectors
+      // that can carry the summary text with its ack chips.
+      if (channel === "in_app" || channel === "sms" || channel === "voice") {
+        continue;
+      }
+      if (!isReminderChannel(channel)) {
+        continue;
+      }
+      const policy = await this.resolvePrimaryChannelPolicy(channel);
+      const runtimeTarget = await this.resolveRuntimeReminderTarget(
+        channel,
+        policy,
+      );
+      if (!runtimeTarget) {
+        continue;
+      }
+      const sendPayload = {
+        text: args.text,
+        source: runtimeTarget.source,
+        metadata: {
+          channelType: channel,
+          lifeopsCheckin: true,
+          checkinKind: args.kind,
+          checkinReportId: args.reportId,
+          reportId: args.reportId,
+          urgency: args.urgency,
+          routeSource: runtimeTarget.source,
+          routeResolution: runtimeTarget.resolution,
+        },
+      };
+      try {
+        await this.ctx.runtime.sendMessageToTarget(
+          runtimeTarget.target,
+          sendPayload,
+        );
+        return {
+          attempted: true,
+          channel,
+          delivered: true,
+        };
+      } catch (error) {
+        this.ctx.logLifeOpsWarn(
+          "checkin_connector_dispatch",
+          `[lifeops] Check-in connector delivery failed for ${channel}; falling back to in-app.`,
+          { error: lifeOpsErrorMessage(error) },
+        );
+        return {
+          attempted: true,
+          channel,
+          delivered: false,
+          reason: lifeOpsErrorMessage(error),
+        };
+      }
+    }
+    return { attempted: false, channel: null, delivered: false };
+  }
+
   private async processSleepCycleCheckins(args: {
     now: Date;
     currentSchedule: LifeOpsScheduleMergedStateRecord | null;
@@ -5619,29 +5718,63 @@ export class RemindersDomain {
               timezone,
               sleepRecap,
             });
-      const routeMetadata = await this.buildOwnerContactRouteEventMetadata({
-        purpose: "checkin",
-        urgency: report.escalationLevel >= 2 ? "high" : "medium",
+      const urgency: LifeOpsReminderUrgency =
+        report.escalationLevel >= 2 ? "high" : "medium";
+      // Rank the owner's connected contact routes once (telegram/discord/…),
+      // reusing the same veto/quiet-hours machinery the reminder escalation
+      // path uses. Historically these candidates became inert event metadata
+      // and the check-in was delivered app-only (#14702). Now we attempt a
+      // real connector send to the top non-vetoed route BEFORE the in-app
+      // emit, which remains the guaranteed final rung.
+      const ownerFacingText = appendCheckinAckChoiceMarker(report.summaryText, {
+        reportId: report.reportId,
+        kind,
+      });
+      // Resolve ranked routes defensively: a policy/profile read failure must
+      // NOT drop the check-in — the in-app emit below is the guaranteed rung,
+      // so we degrade to zero candidates (in-app only) instead of throwing.
+      let candidates: ReminderRouteCandidate[] = [];
+      try {
+        const [activityProfile, policies] = await Promise.all([
+          this.readReminderActivityProfileSnapshot({ now: args.now }),
+          this.ctx.repository.listChannelPolicies(this.ctx.agentId()),
+        ]);
+        candidates = await this.resolveOwnerContactRouteCandidates({
+          purpose: "checkin",
+          activityProfile,
+          policies,
+          urgency,
+          attempts: [],
+          now: args.now,
+        });
+      } catch (error) {
+        this.ctx.logLifeOpsWarn(
+          "checkin_contact_route",
+          "[lifeops] Failed to resolve check-in contact routes; delivering in-app only.",
+          { error: lifeOpsErrorMessage(error) },
+        );
+      }
+      const connectorDelivery = await this.deliverCheckinToTopConnectorRoute({
+        candidates,
+        text: ownerFacingText,
+        reportId: report.reportId,
+        kind,
+        urgency,
         now: args.now,
       });
-      this.ctx.emitAssistantEvent(
-        appendCheckinAckChoiceMarker(report.summaryText, {
-          reportId: report.reportId,
-          kind,
-        }),
-        "lifeops-checkin",
-        {
-          checkinKind: kind,
-          reportId: report.reportId,
-          deliveryBasis: "sleep_cycle",
-          circadianState: currentSchedule.circadianState,
-          wakeAt: currentSchedule.wakeAt,
-          bedtimeTargetAt: currentSchedule.relativeTime.bedtimeTargetAt,
-          minutesUntilBedtimeTarget:
-            currentSchedule.relativeTime.minutesUntilBedtimeTarget,
-          ...routeMetadata,
-        },
-      );
+      this.ctx.emitAssistantEvent(ownerFacingText, "lifeops-checkin", {
+        checkinKind: kind,
+        reportId: report.reportId,
+        deliveryBasis: "sleep_cycle",
+        circadianState: currentSchedule.circadianState,
+        wakeAt: currentSchedule.wakeAt,
+        bedtimeTargetAt: currentSchedule.relativeTime.bedtimeTargetAt,
+        minutesUntilBedtimeTarget:
+          currentSchedule.relativeTime.minutesUntilBedtimeTarget,
+        contactRoutePurpose: "checkin",
+        contactRouteCandidates: serializeContactRouteCandidates(candidates),
+        connectorDelivery,
+      });
     };
 
     if (

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
@@ -5579,8 +5579,8 @@ export class RemindersDomain {
    * night (or sleep-cycle morning) summary off-app (#14702). This walks the
    * already-veto-filtered candidate list, skips channels with no runtime
    * target (`in_app` / `sms` / `voice` — the reminder path handles those
-   * separately), resolves the first connector-backed route, and sends the same
-   * owner-facing text (ack-choice-marker included, so #14884/#14885 ack
+   * separately), resolves connector-backed routes in rank order, and sends the
+   * same owner-facing text (ack-choice-marker included, so #14884/#14885 ack
    * round-trips regardless of which surface the reply lands on) through the
    * proven `runtime.sendMessageToTarget` path the reminder escalation uses.
    *
@@ -5604,6 +5604,10 @@ export class RemindersDomain {
     if (typeof this.ctx.runtime.sendMessageToTarget !== "function") {
       return { attempted: false, channel: null, delivered: false };
     }
+    let firstFailure: {
+      channel: LifeOpsReminderChannel;
+      reason: string;
+    } | null = null;
     for (const candidate of args.candidates) {
       if (candidate.vetoReasons.length > 0) {
         continue;
@@ -5652,18 +5656,22 @@ export class RemindersDomain {
           delivered: true,
         };
       } catch (error) {
+        const reason = lifeOpsErrorMessage(error);
         this.ctx.logLifeOpsWarn(
           "checkin_connector_dispatch",
-          `[lifeops] Check-in connector delivery failed for ${channel}; falling back to in-app.`,
-          { error: lifeOpsErrorMessage(error) },
+          `[lifeops] Check-in connector delivery failed for ${channel}; trying the next ranked route before falling back to in-app.`,
+          { error: reason },
         );
-        return {
-          attempted: true,
-          channel,
-          delivered: false,
-          reason: lifeOpsErrorMessage(error),
-        };
+        firstFailure ??= { channel, reason };
       }
+    }
+    if (firstFailure) {
+      return {
+        attempted: true,
+        channel: firstFailure.channel,
+        delivered: false,
+        reason: firstFailure.reason,
+      };
     }
     return { attempted: false, channel: null, delivered: false };
   }
@@ -5748,6 +5756,8 @@ export class RemindersDomain {
           now: args.now,
         });
       } catch (error) {
+        // error-policy:J4 Check-in route ranking is optional delivery enrichment;
+        // the in-app check-in below is the designed unavailable state.
         this.ctx.logLifeOpsWarn(
           "checkin_contact_route",
           "[lifeops] Failed to resolve check-in contact routes; delivering in-app only.",


### PR DESCRIPTION
Closes #14702.

## Problem

`processSleepCycleCheckins` computed ranked owner contact-route candidates for `purpose: "checkin"` and then delivered only through `emitAssistantEvent`. Connector-primary and headless owners could miss the night check-in and sleep-cycle morning fallback off-app, even though route ranking had already identified connected surfaces.

## Fix

- Attempts real connector delivery to ranked, non-vetoed connector routes via `runtime.sendMessageToTarget` before the guaranteed in-app emit.
- Skips `in_app`, `sms`, and `voice` in this path because in-app is the final rung and SMS/voice use dedicated reminder connector escalation.
- Sends the same owner-facing check-in text, including `[CHOICE:checkin-<reportId>]`, with `checkinReportId` metadata so ack replies can round-trip from the connector surface.
- Keeps in-app delivery as the guaranteed fallback and includes a `connectorDelivery` receipt on the emitted event.
- Tries the next ranked connector route when the top connector send fails before falling back to in-app-only diagnostics.

## Verification

- `bun install --frozen-lockfile --ignore-scripts`
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/cloud/routing build`
- `bun run --cwd packages/contracts build`
- `bun run --cwd plugins/plugin-personal-assistant test src/lifeops/domains/reminders-service.checkin-chips.test.ts` (8 passed)
- `bun run --cwd plugins/plugin-personal-assistant build:js` (passed; emitted duplicate-member warnings in merged `presence-signal-bridge-service.ts`, outside this PR diff)
- `bun run --cwd plugins/plugin-personal-assistant build:types`
- `bunx @biomejs/biome check plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.checkin-chips.test.ts`
- `git diff --check origin/develop...HEAD -- plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.checkin-chips.test.ts`
- `bun run audit:error-policy-ratchet --report`

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: N/A - backend reminder/check-in dispatch path only; no rendered UI or native screen changed.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: N/A - backend reminder/check-in dispatch path only; proof is the focused connector-delivery test suite.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: N/A - no user-clickable UI flow changed; the changed path is scheduler/check-in delivery logic exercised through unit tests.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs: N/A - no long-running backend server was started; local backend proof is the package Vitest run showing the connector send, fallback route, connector-target resolution failure, contact-route resolution failure, connector-send failure, and guaranteed in-app emit cases.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - no browser UI or network client code changed.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - deterministic scheduler/check-in delivery behavior; no prompt, model, provider, or action-planner behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - the focused unit harness does not persist rows; it asserts the domain artifacts directly in memory: `sendMessageToTarget` payload text/metadata, ack marker, `checkinReportId`, `connectorDelivery`, route skip behavior, fallback route retry, connector-target resolution retry, and guaranteed in-app emit.

## Blocked / not run

- `bun run --cwd plugins/plugin-personal-assistant typecheck` still fails on existing package-wide unresolved workspace declaration exports and unrelated strict errors outside this change. Verified examples include unresolved `@elizaos/core`, `@elizaos/plugin-calendar`, `@elizaos/plugin-finances`, `@elizaos/plugin-scheduling`, and moved scheduled-task/contract exports. The touched files build and their focused tests pass.
- `bunx vitest run plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.checkin-chips.test.ts` without the package config fails in this isolated worktree because `@elizaos/plugin-health` package exports are not built; the package test script uses the correct workspace aliases and passed.
