### PR TITLE
feat(core): [pii] PII_SCRUB model-type seam — tier-0 escalation + throw-never-fabricate (Closes #14809)

### DIFF
--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -73,6 +73,15 @@ export {
 	parsePiiSwapList,
 } from "./pii-pseudonymizer.js";
 export {
+	assertValidScrubResult,
+	PiiScrubFabricationError,
+	type ScrubEscalationRequest,
+	type ScrubEscalationResult,
+	type ScrubResultAssertionOptions,
+	scrubWithEscalation,
+	type Tier0Span,
+} from "./pii-scrub-seam.js";
+export {
 	createSecretsRedactor,
 	// Pattern-based redaction
 	getDefaultRedactPatterns,

--- a/packages/core/src/security/pii-scrub-seam.test.ts
+++ b/packages/core/src/security/pii-scrub-seam.test.ts
@@ -112,8 +112,42 @@ describe("scrubWithEscalation — tier-0 escalation", () => {
 		});
 
 		expect(useModel).toHaveBeenCalledTimes(1);
+		expect(
+			(useModel.mock.calls[0][1] as PiiScrubParams).candidateSpans,
+		).toEqual(["Dana Whitfield"]);
 		expect(result.escalated).toBe(true);
 		expect(result.escalation?.verdicts[0].replacement).toBe("Priya Okafor");
+	});
+
+	it("escalates a wider candidate that only partially overlaps tier-0", async () => {
+		const text = "email a@b.com and Dana about the deal";
+		const handler = {
+			fn: vi.fn(
+				async (params: PiiScrubParams): Promise<PiiScrubResult> => ({
+					verdicts: [
+						{
+							span: params.candidateSpans[0] ?? "",
+							kind: "pii",
+							replacement: "[redacted]",
+						},
+					],
+					modelId: "local-gguf",
+					rulesetVersion: params.rulesetVersion,
+				}),
+			),
+		};
+		const { runtime, useModel } = makeRuntime(handler);
+
+		await scrubWithEscalation(runtime, {
+			text,
+			candidateSpans: ["a@b.com and Dana"],
+			rulesetVersion: RULESET,
+		});
+
+		expect(useModel).toHaveBeenCalledTimes(1);
+		expect(
+			(useModel.mock.calls[0][1] as PiiScrubParams).candidateSpans,
+		).toEqual(["a@b.com and Dana"]);
 	});
 });
 
@@ -344,6 +378,23 @@ describe("assertValidScrubResult — structural fail-closed", () => {
 			assertValidScrubResult(
 				{
 					verdicts: [{ span: "Acme", kind: "safe" }],
+					modelId: "m",
+					rulesetVersion: RULESET,
+				},
+				{
+					rulesetVersion: RULESET,
+					text,
+					requiredSpans: ["Dana Whitfield"],
+				},
+			),
+		).toThrow(/no verdict/);
+	});
+
+	it("rejects when only a narrower span received a verdict for a wider required span", () => {
+		expect(() =>
+			assertValidScrubResult(
+				{
+					verdicts: [{ span: "Dana", kind: "pii", replacement: "Priya" }],
 					modelId: "m",
 					rulesetVersion: RULESET,
 				},

--- a/packages/core/src/security/pii-scrub-seam.test.ts
+++ b/packages/core/src/security/pii-scrub-seam.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Contract tests for the `PII_SCRUB` model-type seam (#14809).
+ *
+ * The failure contract IS the test: this seam is worth having only if it is
+ * fail-closed. We prove:
+ *
+ *  - **Tier-0 short-circuit:** content whose sensitive spans are fully covered by
+ *    the deterministic detectors makes ZERO model calls (call-count assertion).
+ *  - **Fail-closed missing handler:** residue to escalate + no `PII_SCRUB`
+ *    handler registered → throws (never passes un-inspected content as clean).
+ *  - **Throw-never-fabricate:** a handler that throws propagates (item
+ *    failed-for-retry); it is NEVER caught-and-defaulted to a clean verdict.
+ *  - **Structural fabrication rejection:** a malformed / mismatched "all clear"
+ *    result is rejected by `assertValidScrubResult`.
+ *  - **Background priority:** the escalation call is issued at
+ *    `priority: "background"` (never preempts interactive).
+ *  - **Lane swap by registration only:** the same call-site runs green against
+ *    two different handler registrations (local vs cloud) with no call-site
+ *    change.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+	ModelType,
+	type PiiScrubParams,
+	type PiiScrubResult,
+} from "../types/model";
+import type { IAgentRuntime } from "../types/runtime";
+import {
+	assertValidScrubResult,
+	PiiScrubFabricationError,
+	scrubWithEscalation,
+} from "./pii-scrub-seam";
+
+/**
+ * Minimal fake runtime exposing only `getModel` / `useModel`. The handler, when
+ * present, is a spy so we can assert call count and the params it received.
+ */
+function makeRuntime(handler?: {
+	fn: (params: PiiScrubParams) => Promise<PiiScrubResult>;
+}): { runtime: IAgentRuntime; useModel: ReturnType<typeof vi.fn> } {
+	const useModel = vi.fn(
+		async (_type: string, params: PiiScrubParams): Promise<PiiScrubResult> => {
+			if (!handler) throw new Error("no handler");
+			return handler.fn(params);
+		},
+	);
+	const runtime = {
+		getModel: (type: string) =>
+			type === ModelType.PII_SCRUB && handler ? handler.fn : undefined,
+		useModel,
+	} as unknown as IAgentRuntime;
+	return { runtime, useModel };
+}
+
+const RULESET = "v1";
+
+describe("scrubWithEscalation — tier-0 escalation", () => {
+	it("makes ZERO model calls when tier-0 covers every candidate", async () => {
+		// A real credit card + SSN are structured PII the deterministic detectors
+		// catch. Passing them as candidates must NOT escalate.
+		const text = "card 4111111111111111 and ssn 219-09-9999 in this text";
+		const { runtime, useModel } = makeRuntime();
+
+		const result = await scrubWithEscalation(runtime, {
+			text,
+			candidateSpans: ["4111111111111111", "219-09-9999"],
+			rulesetVersion: RULESET,
+		});
+
+		expect(useModel).not.toHaveBeenCalled();
+		expect(result.escalated).toBe(false);
+		expect(result.escalation).toBeNull();
+		expect(result.tier0.map((s) => s.kind)).toContain("credit-card");
+	});
+
+	it("makes ZERO model calls when there are no candidates at all", async () => {
+		const { runtime, useModel } = makeRuntime();
+		const result = await scrubWithEscalation(runtime, {
+			text: "nothing to see here",
+			candidateSpans: [],
+			rulesetVersion: RULESET,
+		});
+		expect(useModel).not.toHaveBeenCalled();
+		expect(result.escalated).toBe(false);
+	});
+
+	it("escalates ONLY the residue candidates tier-0 could not decide", async () => {
+		const text = "email me at a@b.com about Dana Whitfield at Acme";
+		const handler = {
+			fn: vi.fn(
+				async (params: PiiScrubParams): Promise<PiiScrubResult> => ({
+					verdicts: [
+						{
+							span: "Dana Whitfield",
+							kind: "pii",
+							replacement: "Priya Okafor",
+						},
+					],
+					modelId: "local-gguf",
+					rulesetVersion: params.rulesetVersion,
+				}),
+			),
+		};
+		const { runtime, useModel } = makeRuntime(handler);
+
+		const result = await scrubWithEscalation(runtime, {
+			text,
+			// a@b.com is a tier-0 email; Dana Whitfield is the residue
+			candidateSpans: ["a@b.com", "Dana Whitfield"],
+			rulesetVersion: RULESET,
+		});
+
+		expect(useModel).toHaveBeenCalledTimes(1);
+		expect(result.escalated).toBe(true);
+		expect(result.escalation?.verdicts[0].replacement).toBe("Priya Okafor");
+	});
+});
+
+describe("scrubWithEscalation — fail-closed doctrine", () => {
+	it("throws when residue exists but NO PII_SCRUB handler is registered", async () => {
+		const { runtime, useModel } = makeRuntime(); // no handler
+		await expect(
+			scrubWithEscalation(runtime, {
+				text: "contact Dana Whitfield about the deal",
+				candidateSpans: ["Dana Whitfield"],
+				rulesetVersion: RULESET,
+			}),
+		).rejects.toBeInstanceOf(PiiScrubFabricationError);
+		// And it must NOT have tried to fabricate a clean pass.
+		expect(useModel).not.toHaveBeenCalled();
+	});
+
+	it("propagates a handler throw (never defaults to a clean verdict)", async () => {
+		const boom = new Error("model unavailable");
+		const handler = {
+			fn: vi.fn(async (): Promise<PiiScrubResult> => {
+				throw boom;
+			}),
+		};
+		const { runtime } = makeRuntime(handler);
+		await expect(
+			scrubWithEscalation(runtime, {
+				text: "contact Dana Whitfield about the deal",
+				candidateSpans: ["Dana Whitfield"],
+				rulesetVersion: RULESET,
+			}),
+		).rejects.toThrow("model unavailable");
+	});
+
+	it("rejects a fabricated all-clear that drops an escalated candidate", async () => {
+		// Handler returns a well-formed but EMPTY verdict set — i.e. it silently
+		// declared the residue clean by omission. Fail-closed must reject it.
+		const handler = {
+			fn: vi.fn(
+				async (params: PiiScrubParams): Promise<PiiScrubResult> => ({
+					verdicts: [],
+					modelId: "local-gguf",
+					rulesetVersion: params.rulesetVersion,
+				}),
+			),
+		};
+		const { runtime } = makeRuntime(handler);
+		await expect(
+			scrubWithEscalation(runtime, {
+				text: "contact Dana Whitfield about the deal",
+				candidateSpans: ["Dana Whitfield"],
+				rulesetVersion: RULESET,
+			}),
+		).rejects.toBeInstanceOf(PiiScrubFabricationError);
+	});
+
+	it("rejects a result carrying a stale ruleset version", async () => {
+		const handler = {
+			fn: vi.fn(
+				async (): Promise<PiiScrubResult> => ({
+					verdicts: [{ span: "Dana Whitfield", kind: "pii", replacement: "X" }],
+					modelId: "local-gguf",
+					rulesetVersion: "v0-stale",
+				}),
+			),
+		};
+		const { runtime } = makeRuntime(handler);
+		await expect(
+			scrubWithEscalation(runtime, {
+				text: "contact Dana Whitfield about the deal",
+				candidateSpans: ["Dana Whitfield"],
+				rulesetVersion: RULESET,
+			}),
+		).rejects.toBeInstanceOf(PiiScrubFabricationError);
+	});
+});
+
+describe("scrubWithEscalation — background priority", () => {
+	it("issues the escalation call at background priority by default", async () => {
+		const handler = {
+			fn: vi.fn(
+				async (params: PiiScrubParams): Promise<PiiScrubResult> => ({
+					verdicts: [
+						{ span: "Dana Whitfield", kind: "pii", replacement: "Priya" },
+					],
+					modelId: "local-gguf",
+					rulesetVersion: params.rulesetVersion,
+				}),
+			),
+		};
+		const { runtime, useModel } = makeRuntime(handler);
+		await scrubWithEscalation(runtime, {
+			text: "contact Dana Whitfield",
+			candidateSpans: ["Dana Whitfield"],
+			rulesetVersion: RULESET,
+		});
+		const params = useModel.mock.calls[0][1] as PiiScrubParams;
+		expect(params.priority).toBe("background");
+	});
+});
+
+describe("lane swap by registration only", () => {
+	// The SAME request runs green against two different handlers (local GGUF vs
+	// cloud) — the call-site is identical; only the registered handler differs.
+	const request = {
+		text: "contact Dana Whitfield about the deal",
+		candidateSpans: ["Dana Whitfield"],
+		rulesetVersion: RULESET,
+	};
+
+	it("runs against a local-GGUF handler", async () => {
+		const { runtime } = makeRuntime({
+			fn: async (params) => ({
+				verdicts: [
+					{ span: "Dana Whitfield", kind: "pii", replacement: "Priya Okafor" },
+				],
+				modelId: "eliza-privacy-gguf",
+				rulesetVersion: params.rulesetVersion,
+			}),
+		});
+		const result = await scrubWithEscalation(runtime, request);
+		expect(result.escalation?.modelId).toBe("eliza-privacy-gguf");
+	});
+
+	it("runs against a cloud handler with ZERO call-site changes", async () => {
+		const { runtime } = makeRuntime({
+			fn: async (params) => ({
+				verdicts: [
+					{ span: "Dana Whitfield", kind: "pii", replacement: "Priya Okafor" },
+				],
+				modelId: "cerebras-cloud",
+				rulesetVersion: params.rulesetVersion,
+			}),
+		});
+		const result = await scrubWithEscalation(runtime, request);
+		expect(result.escalation?.modelId).toBe("cerebras-cloud");
+	});
+});
+
+describe("assertValidScrubResult — structural fail-closed", () => {
+	const text = "contact Dana Whitfield at Acme";
+
+	it("accepts a well-formed pii + safe result", () => {
+		const good: PiiScrubResult = {
+			verdicts: [
+				{ span: "Dana Whitfield", kind: "pii", replacement: "Priya Okafor" },
+				{ span: "Acme", kind: "safe" },
+			],
+			modelId: "m",
+			rulesetVersion: RULESET,
+		};
+		expect(() =>
+			assertValidScrubResult(good, { rulesetVersion: RULESET, text }),
+		).not.toThrow();
+	});
+
+	it("rejects a non-object", () => {
+		expect(() =>
+			assertValidScrubResult(null, { rulesetVersion: RULESET, text }),
+		).toThrow(PiiScrubFabricationError);
+	});
+
+	it("rejects a missing modelId", () => {
+		expect(() =>
+			assertValidScrubResult(
+				{ verdicts: [], modelId: "", rulesetVersion: RULESET },
+				{ rulesetVersion: RULESET, text },
+			),
+		).toThrow(/modelId/);
+	});
+
+	it("rejects a pii verdict with no replacement (fail-open)", () => {
+		expect(() =>
+			assertValidScrubResult(
+				{
+					verdicts: [{ span: "Dana Whitfield", kind: "pii" }],
+					modelId: "m",
+					rulesetVersion: RULESET,
+				},
+				{ rulesetVersion: RULESET, text },
+			),
+		).toThrow(/replacement/);
+	});
+
+	it("rejects a safe verdict that carries a replacement", () => {
+		expect(() =>
+			assertValidScrubResult(
+				{
+					verdicts: [{ span: "Acme", kind: "safe", replacement: "Northwind" }],
+					modelId: "m",
+					rulesetVersion: RULESET,
+				},
+				{ rulesetVersion: RULESET, text },
+			),
+		).toThrow(PiiScrubFabricationError);
+	});
+
+	it("rejects a verdict for a span not present in the text (hallucinated span)", () => {
+		expect(() =>
+			assertValidScrubResult(
+				{
+					verdicts: [
+						{ span: "Bob Nonexistent", kind: "pii", replacement: "X" },
+					],
+					modelId: "m",
+					rulesetVersion: RULESET,
+				},
+				{ rulesetVersion: RULESET, text },
+			),
+		).toThrow(/not present in the source text/);
+	});
+
+	it("rejects an unknown verdict kind", () => {
+		expect(() =>
+			assertValidScrubResult(
+				{
+					verdicts: [{ span: "Dana Whitfield", kind: "maybe" }],
+					modelId: "m",
+					rulesetVersion: RULESET,
+				},
+				{ rulesetVersion: RULESET, text },
+			),
+		).toThrow(/unknown kind/);
+	});
+
+	it("rejects when a required span received no verdict", () => {
+		expect(() =>
+			assertValidScrubResult(
+				{
+					verdicts: [{ span: "Acme", kind: "safe" }],
+					modelId: "m",
+					rulesetVersion: RULESET,
+				},
+				{
+					rulesetVersion: RULESET,
+					text,
+					requiredSpans: ["Dana Whitfield"],
+				},
+			),
+		).toThrow(/no verdict/);
+	});
+});

--- a/packages/core/src/security/pii-scrub-seam.ts
+++ b/packages/core/src/security/pii-scrub-seam.ts
@@ -146,7 +146,7 @@ function coveredByTier0(
 	if (needle.length === 0) return true;
 	for (const span of tier0) {
 		if (span.span === needle) return true;
-		if (span.span.includes(needle) || needle.includes(span.span)) return true;
+		if (span.span.includes(needle)) return true;
 	}
 	return false;
 }
@@ -193,6 +193,7 @@ export async function scrubWithEscalation(
 
 	const params: PiiScrubParams = {
 		text: request.text,
+		candidateSpans: residue,
 		contextPack: request.contextPack,
 		pseudonymAssignments: request.pseudonymAssignments,
 		rulesetVersion: request.rulesetVersion,
@@ -321,7 +322,7 @@ export function assertValidScrubResult(
 			// A required span is covered if some verdict span equals it or contains
 			// it (the model may return a wider span that subsumes the candidate).
 			const covered = [...seenSpans].some(
-				(s) => s === needle || s.includes(needle) || needle.includes(s),
+				(s) => s === needle || s.includes(needle),
 			);
 			if (!covered) {
 				throw new PiiScrubFabricationError(

--- a/packages/core/src/security/pii-scrub-seam.ts
+++ b/packages/core/src/security/pii-scrub-seam.ts
@@ -1,0 +1,335 @@
+/**
+ * The `PII_SCRUB` model-type seam (`[pii] PII_SCRUB model-type seam`, #14809).
+ *
+ * The corpus scrub pipeline needs LLM judgment (context-aware classification +
+ * rewrite) from two interchangeable providers — an on-device privacy-filter
+ * GGUF (default, data never leaves the device) and Eliza Cloud (bulk/Cerebras).
+ * Call-sites (LLM-pass, audio span labeling, verify) must not know which lane
+ * serves them. That indirection is `ModelType.PII_SCRUB` + `runtime.useModel`;
+ * the winning lane is chosen by registration priority exactly like
+ * `TEXT_EMBEDDING` (`local-inference@0 < BYO@1 < Eliza Cloud@50`).
+ *
+ * This module owns the two things that make the seam *safe* rather than just
+ * *typed*:
+ *
+ *   1. **Deterministic tier-0 escalation** ({@link scrubWithEscalation}).
+ *      The free, dependency-free {@link detectPii} detectors always run first.
+ *      Content whose sensitive spans are *fully* covered by tier-0 makes ZERO
+ *      model calls — the model is the escalation tier for the residue tier-0
+ *      cannot decide, never a replacement for the deterministic floor.
+ *
+ *   2. **Throw-never-fabricate / fail-closed** ({@link assertValidScrubResult}).
+ *      A model handler that cannot decide MUST throw (#9324; the embeddings
+ *      doctrine). A model error must NEVER surface as a "clean" verdict.
+ *      {@link assertValidScrubResult} rejects a structurally-invalid result
+ *      (missing replacement on a `pii` verdict, wrong ruleset version, a verdict
+ *      for a span not present in the input) by throwing
+ *      {@link PiiScrubFabricationError} — so a handler cannot fabricate a
+ *      pass by returning a malformed "all clear". The escalation orchestrator
+ *      lets that throw propagate: the caller marks the item failed-for-retry and
+ *      the content stays quarantined from every share/export surface.
+ *
+ * What this module does NOT do: it is not a job runner (that is the async rails,
+ * #14808), it does not own scrub prompts/semantics (the LLM-pass issue), and it
+ * does not select or train the privacy GGUF. It is purely the escalation gate +
+ * failure contract that sits between the deterministic detectors and the model.
+ */
+
+import type {
+	LocalInferencePriority,
+	PiiPseudonymAssignment,
+	PiiScrubParams,
+	PiiScrubResult,
+	PiiScrubVerdict,
+} from "../types/model.js";
+import { ModelType } from "../types/model.js";
+import type { IAgentRuntime } from "../types/runtime.js";
+import { detectPii, type PiiMatch } from "./pii-detectors.js";
+
+/**
+ * Thrown when a {@link PiiScrubResult} is structurally invalid — the seam's
+ * fail-closed tripwire. A model handler returning a malformed "clean" result
+ * (or a result that does not correspond to the requested text) is a fabrication
+ * attempt from the pipeline's point of view; we throw rather than trust it, so
+ * unscrubbed content can never fail-open onto an export surface.
+ */
+export class PiiScrubFabricationError extends Error {
+	constructor(message: string) {
+		super(`PII scrub result rejected (fail-closed): ${message}`);
+		this.name = "PiiScrubFabricationError";
+	}
+}
+
+/**
+ * A single tier-0 decision: the deterministic detectors matched this span, so
+ * it is PII and is redacted with a deterministic placeholder — no model call.
+ */
+export interface Tier0Span {
+	/** The matched sensitive substring. */
+	readonly span: string;
+	/** Detector class (`credit-card`, `email`, `ssn`, …). */
+	readonly kind: string;
+	/** Start offset in the source text. */
+	readonly start: number;
+	/** End offset in the source text. */
+	readonly end: number;
+}
+
+/** Outcome of {@link scrubWithEscalation}. */
+export interface ScrubEscalationResult {
+	/** Deterministic tier-0 spans (redacted without any model call). */
+	readonly tier0: readonly Tier0Span[];
+	/**
+	 * The model verdicts for the escalated residue, or `null` when the model was
+	 * never called (tier-0 fully covered the content OR there was no residue to
+	 * escalate). `null` is the *positive* "no escalation needed" signal — it is
+	 * never used to mean "assume clean" for un-inspected text.
+	 */
+	readonly escalation: PiiScrubResult | null;
+	/** True when the model seam was invoked (residue existed and was escalated). */
+	readonly escalated: boolean;
+}
+
+/**
+ * Candidate residue extractor. The deterministic detectors handle *structured*
+ * PII (cards, SSNs, keys, addresses). Everything the pipeline still wants a
+ * model to judge (names/orgs in ambiguous context, gray-area rewrites) is
+ * surfaced by the caller as `candidateSpans`. Only candidates NOT already
+ * covered by a tier-0 span are escalated — so a value the deterministic layer
+ * already caught never costs a model call.
+ */
+export interface ScrubEscalationRequest {
+	/** The text being scrubbed. */
+	readonly text: string;
+	/**
+	 * Model-judgment candidates the caller mined (e.g. from the entity
+	 * recognizer). Spans already covered by a tier-0 detection are dropped before
+	 * any model call. When empty, the model is never invoked.
+	 */
+	readonly candidateSpans: readonly string[];
+	/** Active ruleset version (threaded into the model call + result check). */
+	readonly rulesetVersion: string;
+	/** Optional retrieval context for the model. Never the secret vault. */
+	readonly contextPack?: string;
+	/** Per-chunk cluster→surrogate slice (never the whole map). */
+	readonly pseudonymAssignments?: readonly PiiPseudonymAssignment[];
+	/**
+	 * Local-lane scheduling priority. Defaults to `"background"` — the scrub is
+	 * deferred autonomous work and must never preempt an interactive turn.
+	 */
+	readonly priority?: LocalInferencePriority;
+	/** Per-request cancellation. */
+	readonly signal?: AbortSignal;
+	/** Detector kinds to skip in tier-0 (forwarded to {@link detectPii}). */
+	readonly disabledKinds?: ReadonlySet<string>;
+}
+
+function toTier0(matches: readonly PiiMatch[]): Tier0Span[] {
+	return matches.map((m) => ({
+		span: m.value,
+		kind: m.kind,
+		start: m.start,
+		end: m.end,
+	}));
+}
+
+/**
+ * True when `candidate` is already covered by a deterministic tier-0 span —
+ * either the same value or a substring contained inside a matched span. Such a
+ * candidate is a redundant escalation and is dropped.
+ */
+function coveredByTier0(
+	candidate: string,
+	tier0: readonly Tier0Span[],
+): boolean {
+	const needle = candidate.trim();
+	if (needle.length === 0) return true;
+	for (const span of tier0) {
+		if (span.span === needle) return true;
+		if (span.span.includes(needle) || needle.includes(span.span)) return true;
+	}
+	return false;
+}
+
+/**
+ * Run the deterministic tier-0 detectors, then escalate ONLY the residue
+ * candidates to the `PII_SCRUB` model. Fail-closed throughout:
+ *
+ * - No `PII_SCRUB` handler registered but there IS residue to judge → throws.
+ *   (We must never silently pass un-inspected candidates as clean.)
+ * - The model handler throws → the error propagates (item failed-for-retry).
+ * - The model returns a structurally-invalid result → {@link assertValidScrubResult}
+ *   throws {@link PiiScrubFabricationError}.
+ *
+ * The only path that returns without a model verdict is when there is genuinely
+ * nothing to escalate (`escalation: null, escalated: false`) — an explicit,
+ * auditable "tier-0 covered everything", not an assumption.
+ */
+export async function scrubWithEscalation(
+	runtime: IAgentRuntime,
+	request: ScrubEscalationRequest,
+): Promise<ScrubEscalationResult> {
+	const tier0 = toTier0(
+		detectPii(request.text, { disabledKinds: request.disabledKinds }),
+	);
+
+	const residue = request.candidateSpans.filter(
+		(c) => !coveredByTier0(c, tier0),
+	);
+
+	// Tier-0 short-circuit: nothing the model needs to judge → zero model calls.
+	if (residue.length === 0) {
+		return { tier0, escalation: null, escalated: false };
+	}
+
+	// There IS residue. A missing handler is fail-closed: we cannot judge it, so
+	// we cannot declare it clean — throw so the caller quarantines the item.
+	const handler = runtime.getModel(ModelType.PII_SCRUB);
+	if (!handler) {
+		throw new PiiScrubFabricationError(
+			`no PII_SCRUB model registered but ${residue.length} candidate span(s) require escalation; refusing to pass un-inspected content`,
+		);
+	}
+
+	const params: PiiScrubParams = {
+		text: request.text,
+		contextPack: request.contextPack,
+		pseudonymAssignments: request.pseudonymAssignments,
+		rulesetVersion: request.rulesetVersion,
+		priority: request.priority ?? "background",
+		signal: request.signal,
+	};
+
+	// A handler failure MUST propagate — never caught-and-defaulted to clean.
+	const result = await runtime.useModel(ModelType.PII_SCRUB, params);
+
+	// Structural fail-closed check: reject a fabricated/mismatched "all clear".
+	assertValidScrubResult(result, {
+		rulesetVersion: request.rulesetVersion,
+		text: request.text,
+		requiredSpans: residue,
+	});
+
+	return { tier0, escalation: result, escalated: true };
+}
+
+/** Options controlling {@link assertValidScrubResult}'s structural checks. */
+export interface ScrubResultAssertionOptions {
+	/** The ruleset version the result MUST have been produced under. */
+	readonly rulesetVersion: string;
+	/** The source text; every verdict span must be a substring of it. */
+	readonly text: string;
+	/**
+	 * The candidate spans that were escalated. Every one MUST receive a verdict —
+	 * a result that silently omits a requested span is a fail-open and is
+	 * rejected. Omit to skip the coverage check (e.g. handler-level unit tests).
+	 */
+	readonly requiredSpans?: readonly string[];
+}
+
+/**
+ * Structural fail-closed validator for a {@link PiiScrubResult}. Throws
+ * {@link PiiScrubFabricationError} unless the result is a well-formed, auditable
+ * verdict set for the requested text:
+ *
+ * - `modelId` is a non-empty string (audit trail).
+ * - `rulesetVersion` matches the version the call was made under (a stale-ruleset
+ *   verdict must not be trusted as current).
+ * - `verdicts` is an array; each verdict's `span` is a non-empty substring of
+ *   the source `text` (a verdict for a span not in the text is a fabrication).
+ * - every `pii` verdict carries a non-empty `replacement` (a `pii` verdict with
+ *   no replacement would leave the real value in place — fail-open).
+ * - `safe` verdicts carry NO `replacement` (a `safe` verdict is a positive
+ *   "clean" judgment, not a redaction).
+ * - when `requiredSpans` is given, every required span receives a verdict (the
+ *   handler cannot silently drop a candidate and have it treated as clean).
+ *
+ * This is the tripwire that turns "the model returned something" into "the model
+ * returned something we can *prove* is a real inspection result".
+ */
+export function assertValidScrubResult(
+	result: unknown,
+	options: ScrubResultAssertionOptions,
+): asserts result is PiiScrubResult {
+	if (result === null || typeof result !== "object") {
+		throw new PiiScrubFabricationError("result is not an object");
+	}
+	const r = result as Partial<PiiScrubResult>;
+
+	if (typeof r.modelId !== "string" || r.modelId.length === 0) {
+		throw new PiiScrubFabricationError("missing or empty modelId");
+	}
+	if (r.rulesetVersion !== options.rulesetVersion) {
+		throw new PiiScrubFabricationError(
+			`ruleset version mismatch: expected ${JSON.stringify(
+				options.rulesetVersion,
+			)}, got ${JSON.stringify(r.rulesetVersion)}`,
+		);
+	}
+	if (!Array.isArray(r.verdicts)) {
+		throw new PiiScrubFabricationError("verdicts is not an array");
+	}
+
+	const seenSpans = new Set<string>();
+	for (const verdict of r.verdicts as readonly PiiScrubVerdict[]) {
+		if (verdict === null || typeof verdict !== "object") {
+			throw new PiiScrubFabricationError("verdict is not an object");
+		}
+		if (typeof verdict.span !== "string" || verdict.span.length === 0) {
+			throw new PiiScrubFabricationError("verdict has missing or empty span");
+		}
+		if (!options.text.includes(verdict.span)) {
+			throw new PiiScrubFabricationError(
+				`verdict span ${JSON.stringify(
+					verdict.span,
+				)} is not present in the source text`,
+			);
+		}
+		if (verdict.kind === "pii") {
+			if (
+				typeof verdict.replacement !== "string" ||
+				verdict.replacement.length === 0
+			) {
+				throw new PiiScrubFabricationError(
+					`pii verdict for ${JSON.stringify(
+						verdict.span,
+					)} is missing a replacement`,
+				);
+			}
+		} else if (verdict.kind === "safe") {
+			if (verdict.replacement !== undefined) {
+				throw new PiiScrubFabricationError(
+					`safe verdict for ${JSON.stringify(
+						verdict.span,
+					)} must not carry a replacement`,
+				);
+			}
+		} else {
+			throw new PiiScrubFabricationError(
+				`verdict has unknown kind ${JSON.stringify(
+					(verdict as { kind?: unknown }).kind,
+				)}`,
+			);
+		}
+		seenSpans.add(verdict.span);
+	}
+
+	if (options.requiredSpans) {
+		for (const required of options.requiredSpans) {
+			const needle = required.trim();
+			if (needle.length === 0) continue;
+			// A required span is covered if some verdict span equals it or contains
+			// it (the model may return a wider span that subsumes the candidate).
+			const covered = [...seenSpans].some(
+				(s) => s === needle || s.includes(needle) || needle.includes(s),
+			);
+			if (!covered) {
+				throw new PiiScrubFabricationError(
+					`escalated candidate ${JSON.stringify(
+						required,
+					)} received no verdict (fail-open dropped candidate)`,
+				);
+			}
+		}
+	}
+}

--- a/packages/core/src/types/model.ts
+++ b/packages/core/src/types/model.ts
@@ -944,6 +944,12 @@ export interface PiiScrubParams {
 	/** The chunk of text to classify / rewrite. */
 	text: string;
 	/**
+	 * Exact candidate spans the deterministic tier-0 detectors did not fully
+	 * cover. The handler must return a verdict for each span or throw; absence is
+	 * never interpreted as clean.
+	 */
+	candidateSpans: readonly string[];
+	/**
 	 * Optional retrieval context that helps the model disambiguate borderline
 	 * candidates (surrounding messages, thread summary). Never the secret
 	 * mapping table.

--- a/packages/core/src/types/model.ts
+++ b/packages/core/src/types/model.ts
@@ -78,6 +78,18 @@ export const ModelType = {
 	 * {@link ModelType.TEXT_EMBEDDING} when a provider does not register it.
 	 */
 	TEXT_EMBEDDING_BATCH: "TEXT_EMBEDDING_BATCH",
+	/**
+	 * Context-aware PII classification + rewrite for the corpus scrub pipeline
+	 * (`[pii] PII_SCRUB model-type seam`). One call-site, two interchangeable
+	 * lanes: an on-device privacy-filter GGUF (default — data never leaves the
+	 * device) and Eliza Cloud (bulk/Cerebras), selected by registration priority
+	 * exactly like {@link ModelType.TEXT_EMBEDDING}. This is the ESCALATION tier
+	 * above the free deterministic detectors ({@link ModelParamsMap} entry
+	 * documents the contract) — never a replacement for them. The typed result
+	 * ({@link PiiScrubResult}) structurally bans fake-clean fabrication: a handler
+	 * that cannot decide MUST throw, never emit a "clean" verdict.
+	 */
+	PII_SCRUB: "PII_SCRUB",
 	TEXT_TOKENIZER_ENCODE: "TEXT_TOKENIZER_ENCODE",
 	TEXT_TOKENIZER_DECODE: "TEXT_TOKENIZER_DECODE",
 	TEXT_REASONING_SMALL: "REASONING_SMALL",
@@ -903,6 +915,107 @@ export interface BatchTextEmbeddingParams {
 }
 
 /**
+ * A single pseudonym assignment slice handed to a {@link ModelType.PII_SCRUB}
+ * call: one real-entity cluster mapped to its stable session surrogate. The
+ * scrub call-site passes ONLY the assignments relevant to the current chunk
+ * (`the cluster→pseudonym slice relevant to this chunk`), never the whole secret
+ * map — a model must never receive the full mapping table (it is a secret
+ * artifact). The `value` is the real value; it is present because the LLM-pass
+ * needs it to reason coherently over the chunk, but it is scoped to what this
+ * chunk already contains.
+ */
+export interface PiiPseudonymAssignment {
+	/** Stable id of the entity cluster this assignment covers. */
+	readonly entityClusterId: string;
+	/** The realistic surrogate the model should use in its rewrite. */
+	readonly surrogate: string;
+	/** Entity class (`person`, `org`, `location`, …). */
+	readonly kind: string;
+}
+
+/**
+ * Parameters for the {@link ModelType.PII_SCRUB} escalation call — context-aware
+ * PII classification + rewrite for candidates the deterministic tier-0 detectors
+ * could not decide. This is the ESCALATION tier, not a replacement for tier-0:
+ * the pipeline always runs the free deterministic detectors first and only calls
+ * this seam for the residue.
+ */
+export interface PiiScrubParams {
+	/** The chunk of text to classify / rewrite. */
+	text: string;
+	/**
+	 * Optional retrieval context that helps the model disambiguate borderline
+	 * candidates (surrounding messages, thread summary). Never the secret
+	 * mapping table.
+	 */
+	contextPack?: string;
+	/**
+	 * The cluster→surrogate slice relevant to THIS chunk only — never the whole
+	 * corpus secret map. Lets the model rewrite consistently with the corpus-wide
+	 * pseudonym assignment without ever seeing the full vault.
+	 */
+	pseudonymAssignments?: readonly PiiPseudonymAssignment[];
+	/**
+	 * The active ruleset version. Threaded through so the result is
+	 * content-addressable (`pii:<sha256(content)>:v<rulesetVersion>`) and a
+	 * ruleset bump re-scrubs deterministically.
+	 */
+	rulesetVersion: string;
+	/**
+	 * Scheduling priority on single-lane local backends. The scrub is deferred
+	 * autonomous work, so this is `"background"` — it must never queue ahead of
+	 * an interactive turn. Cloud adapters ignore it.
+	 */
+	priority?: LocalInferencePriority;
+	/** Per-request cancellation, forwarded to the underlying transport. */
+	signal?: AbortSignal;
+}
+
+/**
+ * The kind of decision a {@link PiiScrubVerdict} carries for one span.
+ * - `pii`: the span is sensitive and must be replaced with `replacement`.
+ * - `safe`: the model positively judged the span non-sensitive (an explicit,
+ *   auditable "I looked and it is clean" — NOT the absence of a verdict).
+ */
+export type PiiScrubVerdictKind = "pii" | "safe";
+
+/**
+ * One model verdict over a single candidate span. A `pii` verdict MUST carry a
+ * `replacement`; a `safe` verdict is an explicit positive judgment. There is no
+ * "unknown" verdict kind on purpose: a model that cannot decide throws (see the
+ * error doctrine on {@link ModelResultMap}), it never fabricates a `safe`.
+ */
+export interface PiiScrubVerdict {
+	/** The exact candidate substring this verdict is about. */
+	readonly span: string;
+	/** Whether the span is PII (replace) or positively judged safe (keep). */
+	readonly kind: PiiScrubVerdictKind;
+	/** Optional link back to the pseudonym cluster this span belongs to. */
+	readonly entityClusterId?: string;
+	/**
+	 * The surrogate to substitute when `kind === "pii"`. Required for `pii`
+	 * verdicts, absent for `safe`. Enforced structurally by
+	 * {@link assertValidScrubResult}.
+	 */
+	readonly replacement?: string;
+}
+
+/**
+ * Typed result of a {@link ModelType.PII_SCRUB} call. The shape structurally
+ * bans fake-clean fabrication: a handler NEVER returns an empty/absent result
+ * to mean "clean" — it either returns explicit per-span verdicts or throws.
+ * `modelId` + `rulesetVersion` make the verdict auditable and content-addressable.
+ */
+export interface PiiScrubResult {
+	/** One verdict per candidate span the model was asked to judge. */
+	readonly verdicts: readonly PiiScrubVerdict[];
+	/** Provider model id that produced these verdicts (audit trail). */
+	readonly modelId: string;
+	/** The ruleset version this scrub was performed under. */
+	readonly rulesetVersion: string;
+}
+
+/**
  * Parameters for image generation models
  */
 export interface ImageGenerationParams {
@@ -1298,6 +1411,7 @@ export interface ModelParamsMap {
 	[ModelType.TEXT_REASONING_LARGE]: GenerateTextParams;
 	[ModelType.TEXT_EMBEDDING]: TextEmbeddingParams | string | null;
 	[ModelType.TEXT_EMBEDDING_BATCH]: BatchTextEmbeddingParams;
+	[ModelType.PII_SCRUB]: PiiScrubParams;
 	[ModelType.TEXT_TOKENIZER_ENCODE]: TokenizeTextParams;
 	[ModelType.TEXT_TOKENIZER_DECODE]: DetokenizeTextParams;
 	[ModelType.IMAGE]: ImageGenerationParams;
@@ -1333,6 +1447,7 @@ export interface ModelResultMap {
 	[ModelType.TEXT_REASONING_LARGE]: string;
 	[ModelType.TEXT_EMBEDDING]: number[];
 	[ModelType.TEXT_EMBEDDING_BATCH]: number[][];
+	[ModelType.PII_SCRUB]: PiiScrubResult;
 	[ModelType.TEXT_TOKENIZER_ENCODE]: number[];
 	[ModelType.TEXT_TOKENIZER_DECODE]: string;
 	[ModelType.IMAGE]: ImageGenerationResult[];


### PR DESCRIPTION
Closes #14809.

The `PII_SCRUB` model-type seam: one call-site, two interchangeable lanes (on-device privacy-GGUF default, Eliza Cloud bulk) selected by registration priority exactly like `TEXT_EMBEDDING` (`local-inference@0 < BYO@1 < Eliza Cloud@50`). This is the LLM-judgment **escalation tier above** the free deterministic detectors, never a replacement for them.

## What this adds

- **`ModelType.PII_SCRUB`** + typed `PiiScrubParams` / `PiiScrubResult` (`packages/core/src/types/model.ts`). Verdicts carry an explicit `pii` | `safe` kind — there is deliberately **no `unknown` verdict**: a model that cannot decide throws, it never fabricates a `safe`.
- **`scrubWithEscalation()`** (`packages/core/src/security/pii-scrub-seam.ts`): runs `detectPii` tier-0 first, then escalates **only the residue** candidates tier-0 could not decide. Content fully covered by tier-0 makes **ZERO** model calls.
- **Fail-closed doctrine** (#9324, the embeddings error policy): missing `PII_SCRUB` handler plus residue throws, handler throws propagate, and `assertValidScrubResult()` rejects fabricated/mismatched all-clear results.
- Default `priority: "background"` so scrub work does not preempt an interactive turn.

## Verification

- `bun install --frozen-lockfile --ignore-scripts`
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/cloud/routing build`
- `bun run --cwd packages/contracts build`
- `bun run --cwd packages/logger build`
- `bun test packages/core/src/security/pii-scrub-seam.test.ts packages/core/src/security/pii-detectors.test.ts packages/core/src/security/pii-pseudonymizer.test.ts` (55 passed; seam suite 20 passed)
- `bunx biome check packages/core/src/security/pii-scrub-seam.ts packages/core/src/security/pii-scrub-seam.test.ts packages/core/src/security/index.ts packages/core/src/types/model.ts`
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core build:node`
- `bun run --cwd packages/core build`
- `git diff --check origin/develop...HEAD -- packages/core/src/security/index.ts packages/core/src/security/pii-scrub-seam.test.ts packages/core/src/security/pii-scrub-seam.ts packages/core/src/types/model.ts`
- `bun run audit:error-policy-ratchet --report`

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: N/A - core security/model seam only; no rendered UI or native surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: N/A - core security/model seam only; verification is the fail-closed contract test suite and core bundle builds.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: N/A - no user-clickable flow changed; the seam is exercised by deterministic runtime model-handler tests.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs: N/A - no server process was started; the touched core module has no route/service runtime side effect and is verified by focused tests plus Node/browser/edge builds.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - no browser UI or network flow changed; browser compatibility is covered by `bun run --cwd packages/core build`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - this PR introduces the typed seam and fail-closed validator before any live provider/prompt implementation exists; tests prove handler registration swap, missing-handler throw, handler-throw propagation, and fabricated-result rejection without invoking a model.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - no persisted memory/DB/domain rows are produced by this core contract; the inspected artifact is the deterministic test output showing 55 security tests passed, including 20 seam tests.

## Scope

Seam + escalation gate + failure contract **only**. Explicitly NOT:
- the async job rails (#14808) — this seam is what those rails' LLM stages call through;
- scrub prompts / semantics (LLM-pass issue);
- selecting/training the privacy GGUF.

The two execution lanes in #14808 exercise this same seam, so lane policy (local default, cloud opt-in) stays one registration decision.

— [sol-orch]
