### PR TITLE
fix: land calendar event scenario seeds

### DIFF
--- a/packages/scenario-runner/src/seeds.test.ts
+++ b/packages/scenario-runner/src/seeds.test.ts
@@ -6,6 +6,7 @@
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import type { AgentRuntime, UUID } from "@elizaos/core";
+import { createRealTestRuntime } from "@elizaos/core/testing";
 import type {
   ScenarioContext,
   ScenarioSeedStep,
@@ -213,6 +214,117 @@ function baseConnector(
 }
 
 describe("scenario memory seeds", () => {
+  it("writes calendar-event memory seeds into the LifeOps calendar event store", async () => {
+    const harness = await createRealTestRuntime({
+      withLLM: false,
+      characterName: "scenario-calendar-seed-test",
+    });
+    try {
+      const ctx = {
+        runtime: harness.runtime,
+        scenarioId: "push.meeting-reminder-T-0",
+        now: "2026-07-06T14:00:00.000Z",
+      } as ScenarioContext;
+
+      const result = await applyScenarioSeedStep(ctx, {
+        type: "memory",
+        content: {
+          kind: "calendar-event",
+          id: "evt-eng-standup",
+          title: "Eng standup",
+          startAt: "2026-07-06T15:00:00.000Z",
+          joinLink: "https://meet.example.com/eng-standup",
+          attendees: [
+            { email: "owner@example.com", responseStatus: "accepted" },
+          ],
+        },
+      } satisfies ScenarioSeedStep);
+
+      expect(result).toBeUndefined();
+      const { LifeOpsRepository } = await import(
+        "../../../plugins/plugin-personal-assistant/src/lifeops/repository.ts"
+      );
+      const repository = new LifeOpsRepository(harness.runtime);
+      const events = await repository.listCalendarEvents(
+        String(harness.runtime.agentId),
+        "google",
+        "2026-07-06T14:30:00.000Z",
+        "2026-07-06T16:00:00.000Z",
+      );
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        id: "evt-eng-standup",
+        externalId: "evt-eng-standup",
+        calendarId: "primary",
+        title: "Eng standup",
+        status: "confirmed",
+        startAt: "2026-07-06T15:00:00.000Z",
+        endAt: "2026-07-06T15:30:00.000Z",
+        conferenceLink: "https://meet.example.com/eng-standup",
+        metadata: expect.objectContaining({
+          source: "scenario-seed",
+          kind: "calendar-event",
+          scenarioId: "push.meeting-reminder-T-0",
+          joinLink: "https://meet.example.com/eng-standup",
+        }),
+      });
+      expect(events[0]?.attendees).toEqual([
+        { email: "owner@example.com", responseStatus: "accepted" },
+      ]);
+    } finally {
+      await harness.cleanup();
+    }
+  }, 120_000);
+
+  it("maps cancelled calendar-event shorthand into cancelled calendar rows", async () => {
+    const harness = await createRealTestRuntime({
+      withLLM: false,
+      characterName: "scenario-cancelled-calendar-seed-test",
+    });
+    try {
+      const ctx = {
+        runtime: harness.runtime,
+        scenarioId: "push.scheduled-notification-cancel-when-event-cancelled",
+        now: "2026-07-06T14:00:00.000Z",
+      } as ScenarioContext;
+
+      const result = await applyScenarioSeedStep(ctx, {
+        type: "memory",
+        content: {
+          kind: "calendar-event",
+          id: "evt-investor-sync",
+          title: "Investor sync",
+          startAt: "2026-07-06T16:00:00.000Z",
+          cancelled: true,
+          cancelledAt: "2026-07-06T13:50:00.000Z",
+        },
+      } satisfies ScenarioSeedStep);
+
+      expect(result).toBeUndefined();
+      const { LifeOpsRepository } = await import(
+        "../../../plugins/plugin-personal-assistant/src/lifeops/repository.ts"
+      );
+      const repository = new LifeOpsRepository(harness.runtime);
+      const events = await repository.listCalendarEvents(
+        String(harness.runtime.agentId),
+        "google",
+        "2026-07-06T15:30:00.000Z",
+        "2026-07-06T17:00:00.000Z",
+      );
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        id: "evt-investor-sync",
+        title: "Investor sync",
+        status: "cancelled",
+        metadata: expect.objectContaining({
+          cancelledAt: "2026-07-06T13:50:00.000Z",
+        }),
+      });
+    } finally {
+      await harness.cleanup();
+    }
+  }, 120_000);
+
   it("maps rolodex-entity memory seeds into relationship contacts", async () => {
     const { ctx, relationships, runtime } = createSeedHarness();
 
@@ -507,6 +619,7 @@ describe("scenario memory seeds", () => {
     } satisfies ScenarioSeedStep);
 
     expect(result).toMatch(/unsupported memory seed kind "inbound-message"/);
+    expect(result).toContain("calendar-event");
     expect(createMemory).not.toHaveBeenCalled();
     expect(relationships.addContact).not.toHaveBeenCalled();
   });

--- a/packages/scenario-runner/src/seeds.ts
+++ b/packages/scenario-runner/src/seeds.ts
@@ -36,9 +36,40 @@ type LifeOpsOccurrence = Record<string, unknown> & {
   state: LifeOpsOccurrenceState;
 };
 
+type LifeOpsCalendarEventSeedInput = {
+  id: string;
+  externalId: string;
+  agentId: string;
+  provider: "google" | "apple_calendar";
+  side: "owner" | "agent";
+  calendarId: string;
+  title: string;
+  description: string;
+  location: string;
+  status: string;
+  startAt: string;
+  endAt: string;
+  isAllDay: boolean;
+  timezone: string | null;
+  htmlLink: string | null;
+  conferenceLink: string | null;
+  organizer: Record<string, unknown> | null;
+  attendees: Record<string, unknown>[];
+  metadata: Record<string, unknown>;
+  syncedAt: string;
+  updatedAt: string;
+  connectorAccountId?: string;
+  grantId?: string;
+  accountEmail?: string;
+};
+
 type LifeOpsRepositoryInstance = {
   createDefinition: (definition: LifeOpsTaskDefinition) => Promise<unknown>;
   upsertOccurrence: (occurrence: LifeOpsOccurrence) => Promise<unknown>;
+  upsertCalendarEvent: (
+    event: LifeOpsCalendarEventSeedInput,
+    side?: LifeOpsCalendarEventSeedInput["side"],
+  ) => Promise<unknown>;
 };
 
 type LifeOpsRepositoryConstructor = {
@@ -70,12 +101,18 @@ type LifeOpsRepositoryModule = {
 // Loaded lazily so this module can be built without pulling app-lifeops into the
 // scenario-runner rootDir (app-lifeops is only available at runtime).
 async function loadLifeOps() {
-  const defaultsSpecifier: string =
-    "../../../plugins/plugin-personal-assistant/src/lifeops/defaults.ts";
-  const engineSpecifier: string =
-    "../../../plugins/plugin-personal-assistant/src/lifeops/engine.ts";
-  const repositorySpecifier: string =
-    "../../../plugins/plugin-personal-assistant/src/lifeops/repository.ts";
+  const defaultsSpecifier = new URL(
+    "../../../plugins/plugin-personal-assistant/src/lifeops/defaults.ts",
+    import.meta.url,
+  ).href;
+  const engineSpecifier = new URL(
+    "../../../plugins/plugin-personal-assistant/src/lifeops/engine.ts",
+    import.meta.url,
+  ).href;
+  const repositorySpecifier = new URL(
+    "../../../plugins/plugin-personal-assistant/src/lifeops/repository.ts",
+    import.meta.url,
+  ).href;
   const [
     { resolveDefaultWindowPolicy },
     { materializeDefinitionOccurrences },
@@ -200,6 +237,37 @@ const TRAVEL_FACT_MEMORY_KINDS = new Set([
   "upgrade-offer",
   "calendar-focus-window",
 ]);
+
+type CalendarEventMemorySeed = MemoryContactSeed & {
+  externalId?: unknown;
+  calendarId?: unknown;
+  provider?: unknown;
+  side?: unknown;
+  title?: unknown;
+  description?: unknown;
+  location?: unknown;
+  status?: unknown;
+  startAt?: unknown;
+  endAt?: unknown;
+  durationMinutes?: unknown;
+  isAllDay?: unknown;
+  timezone?: unknown;
+  timeZone?: unknown;
+  htmlLink?: unknown;
+  url?: unknown;
+  conferenceLink?: unknown;
+  joinLink?: unknown;
+  organizer?: unknown;
+  attendees?: unknown;
+  metadata?: unknown;
+  connectorAccountId?: unknown;
+  grantId?: unknown;
+  accountEmail?: unknown;
+  cancelled?: unknown;
+  canceled?: unknown;
+  cancelledAt?: unknown;
+  canceledAt?: unknown;
+};
 
 type ConnectorStatusLike = {
   state: "ok" | "degraded" | "disconnected";
@@ -332,6 +400,12 @@ function readOptionalNumber(value: unknown): number | undefined {
 
 function readOptionalBoolean(value: unknown): boolean | undefined {
   return typeof value === "boolean" ? value : undefined;
+}
+
+function readOptionalRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
 }
 
 function readPositiveInteger(value: unknown): number | undefined {
@@ -615,6 +689,156 @@ function buildContactEntityId(runtime: AgentRuntime, name: string): UUID {
   return stringToUuid(`scenario-contact-${name}-${runtime.agentId}`) as UUID;
 }
 
+function normalizeCalendarProvider(
+  value: unknown,
+): LifeOpsCalendarEventSeedInput["provider"] | null {
+  const provider = readNonEmptyString(value);
+  if (provider === "google" || provider === "apple_calendar") {
+    return provider;
+  }
+  return provider ? null : "google";
+}
+
+function normalizeCalendarSide(
+  value: unknown,
+): LifeOpsCalendarEventSeedInput["side"] | null {
+  const side = readNonEmptyString(value);
+  if (side === "owner" || side === "agent") {
+    return side;
+  }
+  return side ? null : "owner";
+}
+
+function normalizeIsoDate(value: unknown): string | null {
+  const raw = readNonEmptyString(value);
+  if (!raw) return null;
+  const timestamp = Date.parse(raw);
+  return Number.isFinite(timestamp) ? new Date(timestamp).toISOString() : null;
+}
+
+function normalizeCalendarAttendees(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      return [];
+    }
+    return [entry as Record<string, unknown>];
+  });
+}
+
+function calendarEventMetadata(
+  ctx: ScenarioContext,
+  seed: CalendarEventMemorySeed,
+): Record<string, unknown> {
+  const authored = readOptionalRecord(seed.metadata);
+  const joinLink =
+    readNonEmptyString(seed.joinLink) ??
+    readNonEmptyString(seed.conferenceLink);
+  const cancelledAt =
+    normalizeIsoDate(seed.cancelledAt) ?? normalizeIsoDate(seed.canceledAt);
+  return {
+    ...(authored ?? {}),
+    source: "scenario-seed",
+    kind: "calendar-event",
+    ...(ctx.scenarioId ? { scenarioId: ctx.scenarioId } : {}),
+    ...(joinLink ? { joinLink } : {}),
+    ...(cancelledAt ? { cancelledAt } : {}),
+  };
+}
+
+function normalizeCalendarEventSeed(
+  ctx: ScenarioContext,
+  runtime: AgentRuntime,
+  seed: CalendarEventMemorySeed,
+): LifeOpsCalendarEventSeedInput | string {
+  const provider = normalizeCalendarProvider(seed.provider);
+  if (!provider) {
+    return "calendar-event memory seed provider must be google or apple_calendar";
+  }
+  const side = normalizeCalendarSide(seed.side);
+  if (!side) {
+    return "calendar-event memory seed side must be owner or agent";
+  }
+  const title = readNonEmptyString(seed.title);
+  if (!title) {
+    return "calendar-event memory seed requires a title";
+  }
+  const startAt = normalizeIsoDate(seed.startAt);
+  if (!startAt) {
+    return "calendar-event memory seed requires a valid startAt timestamp";
+  }
+  const durationMinutes = readPositiveInteger(seed.durationMinutes) ?? 30;
+  const endAt =
+    normalizeIsoDate(seed.endAt) ??
+    new Date(Date.parse(startAt) + durationMinutes * 60_000).toISOString();
+  if (Date.parse(endAt) <= Date.parse(startAt)) {
+    return "calendar-event memory seed endAt must be after startAt";
+  }
+
+  const id =
+    readNonEmptyString(seed.id) ??
+    stringToUuid(
+      `scenario-calendar-event:${ctx.scenarioId ?? "unknown"}:${title}:${startAt}`,
+    );
+  const externalId = readNonEmptyString(seed.externalId) ?? id;
+  const cancelled =
+    readOptionalBoolean(seed.cancelled) ?? readOptionalBoolean(seed.canceled);
+  const status =
+    readNonEmptyString(seed.status) ?? (cancelled ? "cancelled" : "confirmed");
+  const conferenceLink =
+    readNonEmptyString(seed.conferenceLink) ??
+    readNonEmptyString(seed.joinLink);
+  const connectorAccountId = readNonEmptyString(seed.connectorAccountId);
+  const grantId = readNonEmptyString(seed.grantId);
+  const accountEmail = readNonEmptyString(seed.accountEmail);
+  const nowIso = readScenarioNow(ctx).toISOString();
+  return {
+    id,
+    externalId,
+    agentId: String(runtime.agentId),
+    provider,
+    side,
+    calendarId: readNonEmptyString(seed.calendarId) ?? "primary",
+    title,
+    description: readNonEmptyString(seed.description) ?? "",
+    location: readNonEmptyString(seed.location) ?? "",
+    status,
+    startAt,
+    endAt,
+    isAllDay: readOptionalBoolean(seed.isAllDay) ?? false,
+    timezone:
+      readNonEmptyString(seed.timezone) ??
+      readNonEmptyString(seed.timeZone) ??
+      null,
+    htmlLink: readNonEmptyString(seed.htmlLink) ?? readNonEmptyString(seed.url),
+    conferenceLink,
+    organizer: readOptionalRecord(seed.organizer),
+    attendees: normalizeCalendarAttendees(seed.attendees),
+    metadata: calendarEventMetadata(ctx, seed),
+    syncedAt: nowIso,
+    updatedAt: nowIso,
+    ...(connectorAccountId ? { connectorAccountId } : {}),
+    ...(grantId ? { grantId } : {}),
+    ...(accountEmail ? { accountEmail } : {}),
+  };
+}
+
+async function seedCalendarEventMemory(
+  ctx: ScenarioContext,
+  seed: CalendarEventMemorySeed,
+): Promise<string | undefined> {
+  const runtime = requireRuntime(ctx);
+  const { LifeOpsRepository } = await loadLifeOps();
+  await LifeOpsRepository.bootstrapSchema(runtime);
+  const event = normalizeCalendarEventSeed(ctx, runtime, seed);
+  if (typeof event === "string") {
+    return event;
+  }
+  const repository = new LifeOpsRepository(runtime);
+  await repository.upsertCalendarEvent(event, event.side);
+  return undefined;
+}
+
 async function seedContact(
   ctx: ScenarioContext,
   seed: ContactSeed,
@@ -709,11 +933,14 @@ async function seedMemory(
     const text = formatStructuredMemoryFact(memoryType, content);
     return writeDurableFact(ctx, text, { seedKind: memoryType });
   }
+  if (memoryType === "calendar-event") {
+    return seedCalendarEventMemory(ctx, content as CalendarEventMemorySeed);
+  }
   if (memoryType !== null) {
     // A seed the runner cannot land must fail the scenario, never no-op:
     // a silently dropped seed fabricates the premise the checks grade
     // against (#14631 — the "seeded VIP fact" the model never received).
-    return `unsupported memory seed kind "${memoryType}" — supported: contact/rolodex-entity/merged-entity, travel profile/trip/booking/upgrade-offer/calendar-focus-window, or plain { text } for a durable owner fact`;
+    return `unsupported memory seed kind "${memoryType}" — supported: contact/rolodex-entity/merged-entity/calendar-event, travel profile/trip/booking/upgrade-offer/calendar-focus-window, or plain { text } for a durable owner fact`;
   }
   const text = readNonEmptyString((content as { text?: unknown }).text);
   if (!text) {


### PR DESCRIPTION
## Summary

Adds real support for `kind: "calendar-event"` scenario memory seeds in the scenario runner. The runner now normalizes authored calendar shorthand into the existing LifeOps calendar event repository and persists rows through `LifeOpsRepository.upsertCalendarEvent` after bootstrapping the LifeOps/app-calendar schema.

This covers the two currently-authored push scenarios that need calendar state:

- `push.meeting-reminder-T-0` - seeded meeting with join link lands as a queryable calendar row.
- `push.scheduled-notification-cancel-when-event-cancelled` - seeded cancelled event lands with `status: "cancelled"` and cancellation metadata.

Also fixes the lazy LifeOps dynamic imports in `seeds.ts` to resolve via `import.meta.url`, matching the existing connector registry loader and avoiding root-relative `/plugins/...` failures under Vitest.

## Why

Issue #14815 is about making structured scenario memory seeds land in real durable stores instead of being unsupported or silently fake. Calendar-event seeds previously failed as an unsupported memory kind, which meant these push scenarios could not start from the calendar state their assertions grade against. This PR removes that gap for the calendar slice without adding a parallel store.

## Verification

| Evidence type | Result |
| --- | --- |
| before-screenshots | N/A - scenario-runner seed persistence change; no UI surface changed. |
| after-screenshots | N/A - scenario-runner seed persistence change; no UI surface changed. |
| walkthrough-video | N/A - no user-facing UI flow changed in this slice. |
| backend-logs | `bun run --cwd packages/scenario-runner test -- src/seeds.test.ts` exercised real PGLite migrations and repository writes; local log: 1 file passed, 16 tests passed. |
| frontend-logs | N/A - no browser or app UI involved. |
| llm-trajectory | N/A - seed persistence only; no model/action/prompt behavior changed. Live scenario trajectories remain required before closing #14815. |
| domain-artifacts | Added PGLite-backed tests that query `LifeOpsRepository.listCalendarEvents` after seeding and assert the stored event title, status, start/end timestamps, conference link, attendees, and metadata. |

Checks run:

```bash
bun run --cwd packages/scenario-runner test -- src/seeds.test.ts
bunx @biomejs/biome check packages/scenario-runner/src/seeds.ts packages/scenario-runner/src/seeds.test.ts
bun packages/scenario-runner/src/cli.ts list packages/test/scenarios/lifeops.push --lane live-only --validate-scenarios
git diff --check
```

`bun run --cwd packages/scenario-runner typecheck` still fails on current workspace baseline unrelated to this diff: unresolved optional plugin/module exports (`@elizaos/plugin-discord/service`, `@elizaos/plugin-scheduling`, `@elizaos/plugin-calendar/service/schema`, UI capacitor/TUI imports, shared appearance/transcript exports) plus existing LifeOps schedule record type drift. After fixing the local `src/seeds.ts` strictness issue, typecheck reports no errors in the touched files.

## Follow-up Scope

This is one structured-memory slice for #14815. Remaining unsupported seed families include `inbound-message`, push ladder/device state, browser/task state, and other push/follow-up fixtures; those should each land through the owning durable store with tests like this one.

Fixes part of #14815.