### PR TITLE
fix: land inbound message scenario seeds

### DIFF
--- a/packages/scenario-runner/src/seeds.test.ts
+++ b/packages/scenario-runner/src/seeds.test.ts
@@ -6,6 +6,7 @@
 import http from "node:http";
 import type { AddressInfo } from "node:net";
 import type { AgentRuntime, UUID } from "@elizaos/core";
+import { stringToUuid } from "@elizaos/core";
 import { createRealTestRuntime } from "@elizaos/core/testing";
 import type {
   ScenarioContext,
@@ -325,6 +326,83 @@ describe("scenario memory seeds", () => {
     }
   }, 120_000);
 
+  it("writes inbound-message memory seeds into the messages table", async () => {
+    const harness = await createRealTestRuntime({
+      withLLM: false,
+      characterName: "scenario-inbound-seed-test",
+    });
+    try {
+      const roomId = stringToUuid("scenario-inbound-seed-room");
+      const ownerId = stringToUuid("scenario-inbound-seed-owner");
+      await harness.runtime.ensureConnection({
+        entityId: ownerId,
+        roomId,
+        worldId: stringToUuid("scenario-inbound-seed-world"),
+        userName: "Scenario owner",
+        source: "scenario-runner",
+        channelId: roomId,
+        type: "DM",
+      });
+      const ctx = {
+        runtime: harness.runtime,
+        scenarioId: "identity.detect-impersonation-attempt",
+        now: "2026-07-06T14:00:00.000Z",
+        primaryRoomId: roomId,
+        primaryUserId: ownerId,
+      } as ScenarioContext;
+
+      const result = await applyScenarioSeedStep(ctx, {
+        type: "memory",
+        content: {
+          kind: "inbound-message",
+          platform: "telegram",
+          handle: "@jordan_kim_real",
+          platformUserId: "tg-99887",
+          displayName: "Jordan Kim",
+          text: "hey can you send me the deck and wallet seed quickly",
+          priority: "interrupt",
+        },
+      } satisfies ScenarioSeedStep);
+
+      expect(result).toBeUndefined();
+      const memories = await harness.runtime.getMemories({
+        roomId,
+        tableName: "messages",
+        count: 5,
+      });
+      expect(memories).toHaveLength(1);
+      expect(memories[0]?.content).toMatchObject({
+        text: "hey can you send me the deck and wallet seed quickly",
+        source: "telegram",
+        displayName: "Jordan Kim",
+        senderName: "Jordan Kim",
+        username: "@jordan_kim_real",
+        platformUserId: "tg-99887",
+        priority: "interrupt",
+      });
+      expect(memories[0]?.metadata).toMatchObject({
+        type: "message",
+        source: "scenario-seed",
+        kind: "inbound-message",
+        scenarioId: "identity.detect-impersonation-attempt",
+        entityName: "Jordan Kim",
+        sender: {
+          name: "Jordan Kim",
+          username: "@jordan_kim_real",
+          id: "tg-99887",
+        },
+        provider: "telegram",
+        telegram: {
+          userId: "tg-99887",
+          id: "tg-99887",
+        },
+      });
+    } finally {
+      await harness.cleanup();
+    }
+  }, 120_000);
+
+
   it("maps rolodex-entity memory seeds into relationship contacts", async () => {
     const { ctx, relationships, runtime } = createSeedHarness();
 
@@ -613,13 +691,14 @@ describe("scenario memory seeds", () => {
     const result = await applyScenarioSeedStep(ctx, {
       type: "memory",
       content: {
-        kind: "inbound-message",
+        kind: "voice-call-attempt",
         text: "hello",
       },
     } satisfies ScenarioSeedStep);
 
-    expect(result).toMatch(/unsupported memory seed kind "inbound-message"/);
+    expect(result).toMatch(/unsupported memory seed kind "voice-call-attempt"/);
     expect(result).toContain("calendar-event");
+    expect(result).toContain("inbound-message");
     expect(createMemory).not.toHaveBeenCalled();
     expect(relationships.addContact).not.toHaveBeenCalled();
   });

--- a/packages/scenario-runner/src/seeds.ts
+++ b/packages/scenario-runner/src/seeds.ts
@@ -7,7 +7,7 @@
  * executor between setup and the first turn.
  */
 import type { AgentRuntime, UUID } from "@elizaos/core";
-import { MemoryType, stringToUuid } from "@elizaos/core";
+import { createMessageMemory, MemoryType, stringToUuid } from "@elizaos/core";
 import type {
   ScenarioContext,
   ScenarioSeedStep,
@@ -267,6 +267,18 @@ type CalendarEventMemorySeed = MemoryContactSeed & {
   canceled?: unknown;
   cancelledAt?: unknown;
   canceledAt?: unknown;
+};
+
+type InboundMessageMemorySeed = MemoryContactSeed & {
+  from?: unknown;
+  relationship?: unknown;
+  priority?: unknown;
+  text?: unknown;
+  source?: unknown;
+  messageId?: unknown;
+  occurredAt?: unknown;
+  threadId?: unknown;
+  url?: unknown;
 };
 
 type ConnectorStatusLike = {
@@ -839,6 +851,126 @@ async function seedCalendarEventMemory(
   return undefined;
 }
 
+function inboundMessageSenderName(seed: InboundMessageMemorySeed): string {
+  return (
+    readNonEmptyString(seed.displayName) ??
+    readNonEmptyString(seed.from) ??
+    readNonEmptyString(seed.handle) ??
+    "Scenario sender"
+  );
+}
+
+function inboundMessageSenderEntityId(
+  ctx: ScenarioContext,
+  seed: InboundMessageMemorySeed,
+): UUID {
+  const platform = readNonEmptyString(seed.platform) ?? "scenario";
+  const identity =
+    readNonEmptyString(seed.platformUserId) ??
+    readNonEmptyString(seed.handle) ??
+    inboundMessageSenderName(seed);
+  return stringToUuid(
+    `scenario-inbound-message-sender:${ctx.scenarioId ?? "unknown"}:${platform}:${identity}`,
+  ) as UUID;
+}
+
+function inboundMessageTimestamp(
+  ctx: ScenarioContext,
+  seed: InboundMessageMemorySeed,
+): number {
+  const occurredAt = readNonEmptyString(seed.occurredAt);
+  if (occurredAt) {
+    const parsed = Date.parse(occurredAt);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return readScenarioNow(ctx).getTime();
+}
+
+async function seedInboundMessageMemory(
+  ctx: ScenarioContext,
+  seed: InboundMessageMemorySeed,
+): Promise<string | undefined> {
+  const text = readNonEmptyString(seed.text);
+  if (!text) {
+    return "inbound-message memory seed requires non-empty text";
+  }
+  const runtime = requireRuntime(ctx);
+  const roomId = readNonEmptyString(ctx.primaryRoomId);
+  if (!roomId) {
+    return "inbound-message memory seed requires ctx.primaryRoomId (set by the executor before seeds run)";
+  }
+
+  const senderName = inboundMessageSenderName(seed);
+  const senderEntityId = inboundMessageSenderEntityId(ctx, seed);
+  const existingEntity = await runtime.getEntityById(senderEntityId);
+  if (!existingEntity) {
+    await runtime.createEntity({
+      id: senderEntityId,
+      names: [senderName],
+      agentId: runtime.agentId,
+    });
+  }
+
+  const timestamp = inboundMessageTimestamp(ctx, seed);
+  const platform = readNonEmptyString(seed.platform) ?? "scenario";
+  const handle = readNonEmptyString(seed.handle);
+  const platformUserId = readNonEmptyString(seed.platformUserId);
+  const url = readNonEmptyString(seed.url);
+  const relationship = readNonEmptyString(seed.relationship);
+  const priority = readNonEmptyString(seed.priority);
+  const threadId = readNonEmptyString(seed.threadId);
+  const messageId =
+    readNonEmptyString(seed.messageId) ??
+    `${ctx.scenarioId ?? "scenario"}:${roomId}:${senderEntityId}:${timestamp}`;
+  const source = readNonEmptyString(seed.source) ?? platform;
+  const memory = createMessageMemory({
+    id: stringToUuid(`scenario-inbound-message:${messageId}`),
+    entityId: senderEntityId,
+    roomId: roomId as UUID,
+    content: {
+      text,
+      source,
+      ...(url ? { url } : {}),
+      ...(handle ? { username: handle } : {}),
+      displayName: senderName,
+      senderName,
+      from: readNonEmptyString(seed.from) ?? senderName,
+      ...(platform ? { platform } : {}),
+      ...(platformUserId ? { platformUserId } : {}),
+      ...(relationship ? { relationship } : {}),
+      ...(priority ? { priority } : {}),
+    },
+  });
+  memory.createdAt = timestamp;
+  memory.metadata = {
+    ...memory.metadata,
+    source: "scenario-seed",
+    sourceId: messageId,
+    timestamp,
+    scenarioId: ctx.scenarioId,
+    kind: "inbound-message",
+    entityName: senderName,
+    sender: {
+      name: senderName,
+      ...(handle ? { username: handle } : {}),
+      ...(platformUserId ? { id: platformUserId } : {}),
+    },
+    provider: platform,
+    ...(handle ? { username: handle } : {}),
+    ...(platformUserId ? { fromId: platformUserId, platformUserId } : {}),
+    ...(relationship ? { relationship } : {}),
+    ...(priority ? { priority } : {}),
+    ...(threadId ? { thread: { id: threadId } } : {}),
+    ...(platform === "telegram" && platformUserId
+      ? { telegram: { userId: platformUserId, id: platformUserId, messageId } }
+      : {}),
+  };
+  await runtime.createMemory(memory, "messages");
+  return undefined;
+}
+
 async function seedContact(
   ctx: ScenarioContext,
   seed: ContactSeed,
@@ -936,11 +1068,14 @@ async function seedMemory(
   if (memoryType === "calendar-event") {
     return seedCalendarEventMemory(ctx, content as CalendarEventMemorySeed);
   }
+  if (memoryType === "inbound-message") {
+    return seedInboundMessageMemory(ctx, content as InboundMessageMemorySeed);
+  }
   if (memoryType !== null) {
     // A seed the runner cannot land must fail the scenario, never no-op:
     // a silently dropped seed fabricates the premise the checks grade
     // against (#14631 — the "seeded VIP fact" the model never received).
-    return `unsupported memory seed kind "${memoryType}" — supported: contact/rolodex-entity/merged-entity/calendar-event, travel profile/trip/booking/upgrade-offer/calendar-focus-window, or plain { text } for a durable owner fact`;
+    return `unsupported memory seed kind "${memoryType}" — supported: contact/rolodex-entity/merged-entity/calendar-event/inbound-message, travel profile/trip/booking/upgrade-offer/calendar-focus-window, or plain { text } for a durable owner fact`;
   }
   const text = readNonEmptyString((content as { text?: unknown }).text);
   if (!text) {


### PR DESCRIPTION
## Summary

Adds real support for `kind: "inbound-message"` scenario memory seeds in the scenario runner. The runner now creates a deterministic sender entity and persists a `MemoryType.MESSAGE` record into the canonical `messages` table, with platform/sender metadata attached for recent-message, relationship, identity, and push grounding.

This covers the two currently-authored inbound-message fixtures:

- `push.urgent-bypasses-do-not-disturb` - urgent mom message can exist as prior inbound context with relationship/priority metadata.
- `identity.detect-impersonation-attempt` - suspicious Telegram inbound lands with a different platform user id from the known rolodex entity.

The seed intentionally does not call `messageService.handleMessage`; it creates pre-existing conversation state without executing the agent pipeline before the scenario turn.

## Why

Issue #14815 is about making structured scenario memory seeds land in real durable stores instead of being unsupported or silently fake. `inbound-message` seeds previously failed as unsupported, so scenarios that depended on prior inbound context were grading against state that never existed. This PR lands that state in the same messages table used by normal inbound turns.

## Verification

| Evidence type | Result |
| --- | --- |
| before-screenshots | N/A - scenario-runner seed persistence change; no UI surface changed. |
| after-screenshots | N/A - scenario-runner seed persistence change; no UI surface changed. |
| walkthrough-video | N/A - no user-facing UI flow changed in this slice. |
| backend-logs | `bun run --cwd packages/scenario-runner test -- src/seeds.test.ts` exercised real PGLite migrations plus messages-table persistence; local log: 1 file passed, 15 tests passed. |
| frontend-logs | N/A - no browser or app UI involved. |
| llm-trajectory | N/A - seed persistence only; no model/action/prompt behavior changed. Live scenario trajectories remain required before closing #14815. |
| domain-artifacts | Added a PGLite-backed test that calls `runtime.getMemories({ tableName: "messages" })` after seeding and asserts stored text, source, display name, handle, platform id, priority, sender metadata, and Telegram identity metadata. |

Checks run:

```bash
bun run --cwd packages/scenario-runner test -- src/seeds.test.ts
bunx @biomejs/biome check packages/scenario-runner/src/seeds.ts packages/scenario-runner/src/seeds.test.ts
bun packages/scenario-runner/src/cli.ts list packages/test/scenarios/lifeops.identity --lane live-only --validate-scenarios
bun packages/scenario-runner/src/cli.ts list packages/test/scenarios/lifeops.push --lane live-only --validate-scenarios
git diff --check
```

`bun run --cwd packages/scenario-runner typecheck` still fails on the current workspace baseline unrelated to this diff: unresolved optional plugin/module exports (`@elizaos/plugin-xr`, `@elizaos/plugin-blocker/services/website-blocker/index`, `@elizaos/plugin-scheduling`, UI capacitor/TUI imports, shared appearance/transcript exports). It reports no errors in the touched seed files.

## Follow-up Scope

This is one structured-memory slice for #14815. Remaining unsupported seed families include push ladder/device state, browser/task state, voice-call-attempt, and other push/follow-up fixtures; those should each land through the owning durable store with tests like this one.

Fixes part of #14815.