### PR TITLE
fix(lifeops): remove duplicate presence signal handlers

### DIFF
--- a/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts
@@ -465,12 +465,12 @@ describe("PresenceSignalBridgeService view-switch + reaction signals (#14689)", 
     expect(mockState.activitySignals).toHaveLength(1);
     expect(mockState.activitySignals[0]).toMatchObject({
       source: "app_lifecycle",
-      platform: "agent_view",
+      platform: "app_view",
       state: "active",
       metadata: expect.objectContaining({
-        eventType: "VIEW_SWITCHED",
+        eventType: EventType.VIEW_SWITCHED,
         viewId: "wallet",
-        initiatedBy: "user",
+        viewLabel: "Wallet",
       }),
     });
   });

--- a/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.ts
@@ -358,18 +358,6 @@ export class PresenceSignalBridgeService extends Service {
     await this.captureActivityFromAction(payload);
   };
 
-  private readonly viewSwitchedHandler = async (
-    payload: ViewSwitchedPayload,
-  ): Promise<void> => {
-    await this.captureActivityFromViewSwitch(payload);
-  };
-
-  private readonly reactionReceivedHandler = async (
-    payload: MessagePayload,
-  ): Promise<void> => {
-    await this.captureActivityFromReaction(payload);
-  };
-
   static override async start(
     runtime: IAgentRuntime,
   ): Promise<PresenceSignalBridgeService> {
@@ -472,100 +460,6 @@ export class PresenceSignalBridgeService extends Service {
     );
   }
 
-  private async captureActivityFromViewSwitch(
-    payload: ViewSwitchedPayload,
-  ): Promise<void> {
-    // Only the owner navigating counts as presence. Agent-initiated switches
-    // (action/evaluator navigation) are the agent moving itself, not the owner
-    // being active, so they must not read as owner activity (#14689).
-    if (payload.initiatedBy === "agent") {
-      return;
-    }
-    const viewId =
-      typeof payload.viewId === "string" && payload.viewId.length > 0
-        ? payload.viewId
-        : "unknown";
-    const observedAt = new Date().toISOString();
-    const fingerprint = `view:${viewId}`;
-    const observedMs = Date.parse(observedAt);
-    const existing = this.recentFingerprints.get(fingerprint);
-    if (
-      existing !== undefined &&
-      Number.isFinite(observedMs) &&
-      observedMs - existing < DEDUPE_WINDOW_MS
-    ) {
-      return;
-    }
-    if (Number.isFinite(observedMs)) {
-      this.recentFingerprints.set(fingerprint, observedMs);
-    }
-    const repository = new LifeOpsRepository(this.runtime);
-    await repository.createActivitySignal(
-      createLifeOpsActivitySignal({
-        agentId: String(this.runtime.agentId),
-        source: "app_lifecycle",
-        platform: "agent_view",
-        state: "active",
-        observedAt,
-        idleState: "active",
-        idleTimeSeconds: 0,
-        onBattery: null,
-        health: null,
-        metadata: {
-          eventType: "VIEW_SWITCHED",
-          viewId,
-          initiatedBy: payload.initiatedBy,
-          deviceId: getDeviceId(),
-        },
-      }),
-    );
-  }
-
-  private async captureActivityFromReaction(
-    payload: MessagePayload,
-  ): Promise<void> {
-    // A tapback/reaction from someone other than the agent is an owner (or
-    // contact) touchpoint. Reuse the message identity readers; skip the agent's
-    // own reactions so the agent reacting does not read as owner presence.
-    const entityId = readMessageEntityId(payload);
-    if (!entityId || entityId === String(this.runtime.agentId)) {
-      return;
-    }
-    const observedAt = readMessageTimestamp(payload);
-    const fingerprint = `${EventType.REACTION_RECEIVED}:${entityId}:${observedAt}`;
-    const observedMs = Date.parse(observedAt);
-    const existing = this.recentFingerprints.get(fingerprint);
-    if (
-      existing !== undefined &&
-      Number.isFinite(observedMs) &&
-      observedMs - existing < DEDUPE_WINDOW_MS
-    ) {
-      return;
-    }
-    if (Number.isFinite(observedMs)) {
-      this.recentFingerprints.set(fingerprint, observedMs);
-    }
-    const repository = new LifeOpsRepository(this.runtime);
-    await repository.createActivitySignal(
-      createLifeOpsActivitySignal({
-        agentId: String(this.runtime.agentId),
-        source: "connector_activity",
-        platform: readPlatform(payload),
-        state: "active",
-        observedAt,
-        idleState: null,
-        idleTimeSeconds: 0,
-        onBattery: null,
-        health: null,
-        metadata: {
-          eventType: "REACTION_RECEIVED",
-          entityId,
-          deviceId: getDeviceId(),
-        },
-      }),
-    );
-  }
-
   private async captureActivityFromMessage(
     eventType:
       | EventType.MESSAGE_RECEIVED
@@ -580,6 +474,9 @@ export class PresenceSignalBridgeService extends Service {
       return;
     }
     if (isAgentEntity && !handle) {
+      return;
+    }
+    if (isAgentEntity && eventType === EventType.REACTION_RECEIVED) {
       return;
     }
     const observedAt = readMessageTimestamp(payload);


### PR DESCRIPTION
## Summary
- Removes the duplicate `VIEW_SWITCHED` and `REACTION_RECEIVED` handlers that landed in #14973.
- Keeps the richer app-view and reaction metadata capture path as the single implementation.
- Updates the presence bridge regression test to assert the shipped `app_view` payload shape.

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: N/A - service/test-only regression fix; no rendered UI state changed, so there is no screen text or OCR corpus to compare for this PR.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: N/A - service/test-only regression fix; no rendered UI state changed, so OCR is not applicable to this PR's evidence surface.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: N/A - no user-facing rendered workflow changed; the broken behavior was duplicate service handlers and stale test expectations.

<!-- evidence-row:backend-logs -->
- [x] Backend logs / command output: verification summary posted at https://github.com/elizaOS/eliza/pull/14984#issuecomment-4890193084

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - no frontend/runtime browser surface changed.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - no prompt, model, action planning, provider, or LLM path changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: presence signal payload assertions in https://github.com/elizaOS/eliza/pull/14984/files and verification summary at https://github.com/elizaOS/eliza/pull/14984#issuecomment-4890193084

## Verification
- `bun run --cwd plugins/plugin-personal-assistant test src/activity-profile/presence-signal-bridge-service.test.ts`
- `bun run --cwd plugins/plugin-personal-assistant build:js`
- `bun run --cwd plugins/plugin-personal-assistant build:types`
- `bunx @biomejs/biome check plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.ts plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts`
- `git diff --check`
- `bun run audit:error-policy-ratchet --report`

Follow-up to #14973 / #14689.