### PR TITLE
fix(evidence): video-lane failure-path integrity — preserve failure evidence, unpoison bundles, deterministic recording pick (#14545 follow-up)

### DIFF
--- a/packages/evidence/src/analyzers/runner.test.ts
+++ b/packages/evidence/src/analyzers/runner.test.ts
@@ -19,6 +19,7 @@ import { promisify } from "node:util";
 import { afterAll, describe, expect, it } from "vitest";
 import { createBundle } from "../bundle.ts";
 import { EvidenceError } from "../errors.ts";
+import { resolveFfmpegBinary } from "../ffmpeg-binaries.ts";
 import { ffmpegAvailable } from "./keyframes.ts";
 import { analyzeArtifacts } from "./runner.ts";
 import { makeTmpDir, solidPng } from "./test-fixtures.ts";
@@ -27,10 +28,15 @@ import type { Analyzer } from "./types.ts";
 const execFileAsync = promisify(execFile);
 const scratch = makeTmpDir();
 const hasFfmpeg = await ffmpegAvailable();
+// Generate the clip with the SAME binary the gate above resolves (env, PATH,
+// or bundled): a hardcoded "ffmpeg" fails instead of skipping on machines
+// that only carry the bundled static binary.
+const ffmpeg = await resolveFfmpegBinary();
+const ffmpegBin = ffmpeg.available ? ffmpeg.bin : "ffmpeg";
 afterAll(() => rmSync(scratch, { recursive: true, force: true }));
 
 async function makeVideo(out: string): Promise<void> {
-  await execFileAsync("ffmpeg", [
+  await execFileAsync(ffmpegBin, [
     "-hide_banner",
     "-loglevel",
     "error",
@@ -148,7 +154,9 @@ describe("analyzeArtifacts (runner integration)", () => {
     }
 
     await bundle.finalize();
-  });
+    // Keyframe extraction + the analyzer fan-out overrun vitest's 5s default
+    // under parallel suite load; the explicit budget matches the driver suite's.
+  }, 120_000);
 
   it("returns documents without a bundle and skips emit-requiring analyzers", async () => {
     // Analyze a bare screenshot with no bundle: documents are returned but not

--- a/packages/evidence/src/video/cli.test.ts
+++ b/packages/evidence/src/video/cli.test.ts
@@ -1,11 +1,46 @@
-// Video CLI argv contract, tool-free (always runs). Drives runVideoCli with a
+// Video CLI argv contract and failure-path integrity. Drives runVideoCli with a
 // captured IO instead of spawning a process: asserts usage on no command,
 // unknown-arg / missing-required / bad-enum rejections surface as a structured
-// error line + non-zero exit, and the ingest command rejects a bad granularity.
-// The happy paths (which launch chromium/ffmpeg) are covered by the driver and
-// walkthroughs suites, not here.
-import { describe, expect, it } from "vitest";
+// error line + non-zero exit, and the ingest command rejects a bad granularity
+// (all tool-free). Failure-path tests then prove a failed run cannot poison a
+// --bundle dir (removed when unfinalized; never created for a bad --def) and —
+// gated on real chromium — that a failed walkthrough preserves its scratch
+// recording as failure evidence while a retry into the same --bundle succeeds.
+// The happy paths' analysis details are covered by the driver and walkthroughs
+// suites, not here.
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
 import { type CliIo, runVideoCli } from "./cli.ts";
+import { serveFixture } from "./fixture-server.ts";
+
+const dir = mkdtempSync(join(os.tmpdir(), "evidence-video-cli-"));
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+/** Can we launch a real headless chromium? Gate the browser lane honestly. */
+async function chromiumLaunchable(): Promise<boolean> {
+  try {
+    const { chromium } = (await import("@playwright/test")) as {
+      chromium: { launch(o?: unknown): Promise<{ close(): Promise<void> }> };
+    };
+    const browser = await chromium.launch({ headless: true });
+    await browser.close();
+    return true;
+  } catch {
+    // error-policy:J4 test-capability gate — an absent browser download is a
+    // skipped lane with a reason, not a failed test.
+    return false;
+  }
+}
+
+const hasChromium = await chromiumLaunchable();
 
 function capture(): { io: CliIo; out: string[]; err: string[] } {
   const out: string[] = [];
@@ -57,3 +92,166 @@ describe("runVideoCli argv contract", () => {
     expect(err.join("\n")).toMatch(/--granularity must be one of/);
   });
 });
+
+describe("bundle poisoning on failed runs", () => {
+  it("removes the unfinalized --bundle dir when ingest fails, so a retry is not blocked", async () => {
+    const bundleDir = join(dir, "ingest-fail-bundle");
+    const argv = [
+      "ingest",
+      "--file",
+      join(dir, "does-not-exist.webm"),
+      "--granularity",
+      "feature",
+      "--slug",
+      "ok",
+      "--bundle",
+      bundleDir,
+    ];
+
+    const first = capture();
+    expect(await runVideoCli(argv, first.io)).toBe(1);
+    expect(first.err.join("\n")).toMatch(/VIDEO_SOURCE_MISSING/);
+    expect(first.err.join("\n")).toMatch(/removed unfinalized bundle dir/);
+    // The poisoned dir is gone, so the retry reports the REAL problem again
+    // instead of BUNDLE_DIR_EXISTS.
+    expect(existsSync(bundleDir)).toBe(false);
+
+    const second = capture();
+    expect(await runVideoCli(argv, second.io)).toBe(1);
+    expect(second.err.join("\n")).toMatch(/VIDEO_SOURCE_MISSING/);
+    expect(second.err.join("\n")).not.toMatch(/BUNDLE_DIR_EXISTS/);
+  });
+
+  it("does not create the --bundle dir when the walkthrough definition is invalid", async () => {
+    const badDef = join(dir, "bad-def.json");
+    writeFileSync(badDef, "{ this is not json");
+    const bundleDir = join(dir, "bad-def-bundle");
+    const { io, err } = capture();
+    const code = await runVideoCli(
+      ["walkthrough", "--def", badDef, "--bundle", bundleDir],
+      io,
+    );
+    expect(code).toBe(1);
+    expect(err.join("\n")).toMatch(/WALKTHROUGH_DEF_INVALID/);
+    expect(existsSync(bundleDir)).toBe(false);
+  });
+
+  it("reports a typed BUNDLE_DIR_EXISTS for a pre-existing --bundle dir (sealed, no reuse)", async () => {
+    const bundleDir = mkdtempSync(join(dir, "preexisting-bundle-"));
+    const { io, err } = capture();
+    const code = await runVideoCli(
+      [
+        "ingest",
+        "--file",
+        join(dir, "irrelevant.webm"),
+        "--granularity",
+        "feature",
+        "--slug",
+        "ok",
+        "--bundle",
+        bundleDir,
+      ],
+      io,
+    );
+    expect(code).toBe(1);
+    expect(err.join("\n")).toMatch(/BUNDLE_DIR_EXISTS/);
+    // Not ours: a pre-existing dir must never be deleted by the cleanup.
+    expect(existsSync(bundleDir)).toBe(true);
+  });
+});
+
+const FIXTURE_HTML = `<!doctype html><html><head><meta charset="utf-8"><title>cli-fixture</title></head>
+<body><p data-testid="msg">hello-fixture</p></body></html>`;
+
+function defJson(slug: string, expectText: string): string {
+  return JSON.stringify({
+    slug,
+    granularity: "feature",
+    steps: [
+      { action: "goto", value: "/", label: "open" },
+      {
+        action: "assertText",
+        selector: '[data-testid="msg"]',
+        value: expectText,
+        label: "check",
+      },
+    ],
+  });
+}
+
+describe.skipIf(!hasChromium)(
+  "walkthrough failure path (real chromium)",
+  () => {
+    it("preserves the scratch as failure evidence, unpoisons the bundle, and retries clean", async () => {
+      const root = mkdtempSync(join(dir, "fixture-"));
+      writeFileSync(join(root, "index.html"), FIXTURE_HTML);
+      const failDef = join(dir, "fail-def.json");
+      writeFileSync(failDef, defJson("cli-fail", "text-that-never-appears"));
+      const passDef = join(dir, "pass-def.json");
+      writeFileSync(passDef, defJson("cli-pass", "hello-fixture"));
+      const bundleDir = join(dir, "walkthrough-bundle");
+
+      const server = await serveFixture(root);
+      let scratch: string | undefined;
+      try {
+        const first = capture();
+        const code = await runVideoCli(
+          [
+            "walkthrough",
+            "--def",
+            failDef,
+            "--bundle",
+            bundleDir,
+            "--base-url",
+            server.baseUrl,
+          ],
+          first.io,
+        );
+        expect(code).toBe(1);
+        const stderr = first.err.join("\n");
+        expect(stderr).toMatch(/WALKTHROUGH_ASSERTION_FAILED/);
+        expect(stderr).toMatch(/removed unfinalized bundle dir/);
+
+        // The failed run printed its preserved scratch path, and the scratch
+        // really holds the diagnosable recording of the failed walkthrough.
+        const preserved = first.err.find((line) =>
+          line.startsWith("walkthrough scratch preserved for diagnosis: "),
+        );
+        expect(preserved).toBeDefined();
+        scratch = (preserved as string).slice(
+          "walkthrough scratch preserved for diagnosis: ".length,
+        );
+        expect(existsSync(scratch)).toBe(true);
+        const recordings = readdirSync(join(scratch, "cli-fail", ".video"));
+        expect(recordings.some((name) => /\.(webm|mp4|mov)$/i.test(name))).toBe(
+          true,
+        );
+
+        // The unfinalized bundle dir is gone, so the retry into the SAME
+        // --bundle path succeeds instead of dying with BUNDLE_DIR_EXISTS.
+        expect(existsSync(bundleDir)).toBe(false);
+        const second = capture();
+        const retryCode = await runVideoCli(
+          [
+            "walkthrough",
+            "--def",
+            passDef,
+            "--bundle",
+            bundleDir,
+            "--base-url",
+            server.baseUrl,
+          ],
+          second.io,
+        );
+        expect(retryCode).toBe(0);
+        expect(second.out.join("\n")).toMatch(/walkthroughs ran: 1/);
+        expect(existsSync(join(bundleDir, "manifest.json"))).toBe(true);
+      } finally {
+        await server.stop();
+        if (scratch !== undefined) {
+          rmSync(scratch, { recursive: true, force: true });
+        }
+      }
+    }, 180_000);
+  },
+);

--- a/packages/evidence/src/video/cli.ts
+++ b/packages/evidence/src/video/cli.ts
@@ -3,9 +3,17 @@
  * over one or all shipped definitions and ingests each produced video (normalized
  * + keyframe-analyzed) into a bundle; `ingest` normalizes and ingests an already
  * recorded video (a producer's webm/mov) into a bundle. Like the bundle CLI this
- * is a thin process boundary: it parses argv, opens or reuses a bundle with real
+ * is a thin process boundary: it parses argv, opens a fresh bundle with real
  * git provenance, drives the library, and prints an honest summary. The library
  * never logs; stdout/stderr here are the product.
+ *
+ * Bundles are sealed single-writer artifacts: a pre-existing `--bundle` dir is
+ * a typed BUNDLE_DIR_EXISTS error, never an append. To keep that contract
+ * retry-safe, arguments and definitions are validated BEFORE the bundle dir is
+ * created, and a run that fails mid-way removes its unfinalized bundle dir (no
+ * manifest — worthless as evidence, poisonous to the next attempt) while
+ * preserving the walkthrough scratch dir, whose raw video/screenshots ARE the
+ * failure evidence; its path is printed for diagnosis.
  */
 
 import fs from "node:fs";
@@ -145,15 +153,10 @@ async function runWalkthroughCommand(
   }
   const repoRoot = path.resolve(values.get("repo-root") ?? defaultRepoRoot());
   const tier = parseTier(values.get("tier"));
-  const bundle = openBundle(values.get("bundle"), repoRoot, tier);
-  // Scratch must live OUTSIDE the bundle dir: verifyBundle sweeps for unlisted
-  // files, and the driver's raw webm/screenshots are not manifest artifacts.
-  const outRoot = values.get("out")
-    ? path.resolve(values.get("out") as string)
-    : fs.mkdtempSync(path.join(os.tmpdir(), "evidence-walkthrough-"));
-  const cleanupScratch = values.get("out") === undefined;
   const baseUrl = values.get("base-url");
 
+  // Definitions load and validate BEFORE the bundle dir is created: a bad
+  // --def must not leave an empty bundle dir behind to poison the retry.
   const defs =
     defArg === "all"
       ? loadAllWalkthroughDefs()
@@ -164,8 +167,17 @@ async function runWalkthroughCommand(
           },
         ];
 
+  const bundle = openBundle(values.get("bundle"), repoRoot, tier);
+  // Scratch must live OUTSIDE the bundle dir: verifyBundle sweeps for unlisted
+  // files, and the driver's raw webm/screenshots are not manifest artifacts.
+  const outRoot = values.get("out")
+    ? path.resolve(values.get("out") as string)
+    : fs.mkdtempSync(path.join(os.tmpdir(), "evidence-walkthrough-"));
+  const cleanupScratch = values.get("out") === undefined;
+
   io.out(`bundle ${bundle.runId}`);
   let ran = 0;
+  let finalized: Awaited<ReturnType<EvidenceBundle["finalize"]>>;
   try {
     for (const { def } of defs) {
       if (def.requiresApp && baseUrl === undefined) {
@@ -186,10 +198,19 @@ async function runWalkthroughCommand(
       );
       ran += 1;
     }
-  } finally {
-    if (cleanupScratch) fs.rmSync(outRoot, { recursive: true, force: true });
+    finalized = await bundle.finalize();
+  } catch (error) {
+    // error-policy:J6 best-effort teardown — the unfinalized bundle dir (no
+    // manifest) would fail the next run with BUNDLE_DIR_EXISTS, so it is
+    // removed; the scratch dir is the failure evidence (raw recording,
+    // screenshots) and is preserved with its path printed. The original error
+    // rethrows untouched to the J1 boundary below.
+    fs.rmSync(bundle.dir, { recursive: true, force: true });
+    io.err(`run failed; removed unfinalized bundle dir: ${bundle.dir}`);
+    io.err(`walkthrough scratch preserved for diagnosis: ${outRoot}`);
+    throw error;
   }
-  const finalized = await bundle.finalize();
+  if (cleanupScratch) fs.rmSync(outRoot, { recursive: true, force: true });
   io.out("");
   io.out(`  walkthroughs ran: ${ran}`);
   io.out(`  manifest:  ${finalized.manifestPath}`);
@@ -226,14 +247,26 @@ async function runIngestCommand(argv: string[], io: CliIo): Promise<number> {
   const repoRoot = path.resolve(values.get("repo-root") ?? defaultRepoRoot());
   const tier = parseTier(values.get("tier"));
   const bundle = openBundle(values.get("bundle"), repoRoot, tier);
-  const result = await ingestVideo(bundle, path.resolve(file), {
-    granularity: granularityRaw as VideoGranularity,
-    slug,
-    source: "video-ingest",
-    producedBy: "video:ingest",
-    tier,
-  });
-  const finalized = await bundle.finalize();
+  let result: Awaited<ReturnType<typeof ingestVideo>>;
+  let finalized: Awaited<ReturnType<EvidenceBundle["finalize"]>>;
+  try {
+    result = await ingestVideo(bundle, path.resolve(file), {
+      granularity: granularityRaw as VideoGranularity,
+      slug,
+      source: "video-ingest",
+      producedBy: "video:ingest",
+      tier,
+    });
+    finalized = await bundle.finalize();
+  } catch (error) {
+    // error-policy:J6 best-effort teardown — a failed ingest leaves no
+    // manifest; the dir would poison the retry with BUNDLE_DIR_EXISTS. The
+    // source video is the caller's file and is untouched; the original error
+    // rethrows untouched to the J1 boundary below.
+    fs.rmSync(bundle.dir, { recursive: true, force: true });
+    io.err(`run failed; removed unfinalized bundle dir: ${bundle.dir}`);
+    throw error;
+  }
   io.out(`bundle ${bundle.runId}`);
   io.out(`  video:     ${result.video.path}`);
   io.out(`  normalize: ${result.normalize.status}`);

--- a/packages/evidence/src/video/driver.test.ts
+++ b/packages/evidence/src/video/driver.test.ts
@@ -4,13 +4,27 @@
 // unavailable (after attempting nothing destructive; the runner reports the
 // skip). Asserts the driver records a video, per-step screenshots, and an ARIA
 // snapshot, executes every step in order, and fails fast on a false assertion.
-import { mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+// The teardown/recording-selection contract (browser closed on every failure
+// path, step error winning over close noise, this-run's recording picked over a
+// stale one, non-http(s) goto rejection) is asserted tool-free against an
+// injected structural browser, where each failure can be provoked exactly.
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import { runWalkthrough } from "./driver.ts";
+import { type RunWalkthroughOptions, runWalkthrough } from "./driver.ts";
 import { serveFixture } from "./fixture-server.ts";
-import { parseWalkthroughDef } from "./walkthrough-schema.ts";
+import {
+  parseWalkthroughDef,
+  type WalkthroughDef,
+} from "./walkthrough-schema.ts";
 
 const dir = mkdtempSync(join(os.tmpdir(), "evidence-driver-"));
 afterAll(() => rmSync(dir, { recursive: true, force: true }));
@@ -153,5 +167,179 @@ describe("runWalkthrough guards", () => {
     await expect(
       runWalkthrough(def, { out: join(dir, "never") }),
     ).rejects.toMatchObject({ code: "WALKTHROUGH_REQUIRES_APP" });
+  });
+});
+
+type FakeChromium = NonNullable<RunWalkthroughOptions["browser"]>;
+
+/**
+ * Structural browser matching the driver's Pw* contract, with injectable
+ * failures at each lifecycle stage and a recording written on context.close
+ * (mirroring how real Playwright flushes the video file).
+ */
+function fakeChromium(behavior: {
+  newContextError?: Error;
+  gotoError?: Error;
+  contextCloseError?: Error;
+  /** File written into recordVideo.dir when the context closes. */
+  videoName?: string;
+}): {
+  chromium: FakeChromium;
+  calls: { browserClosed: boolean; contextClosed: boolean };
+} {
+  const calls = { browserClosed: false, contextClosed: false };
+  let videoDir: string | undefined;
+  const locator = {
+    scrollIntoViewIfNeeded: async () => {},
+    hover: async () => {},
+    click: async () => {},
+    fill: async () => {},
+    waitFor: async () => {},
+    first: () => locator,
+    textContent: async () => "fake",
+  };
+  const page = {
+    goto: async () => {
+      if (behavior.gotoError !== undefined) throw behavior.gotoError;
+      return undefined;
+    },
+    locator: () => locator,
+    waitForTimeout: async () => {},
+    evaluate: async () => undefined,
+    screenshot: async (options: { path: string }) => {
+      writeFileSync(options.path, "png");
+      return Buffer.from("png");
+    },
+    ariaSnapshot: async () => "- fake",
+    content: async () => "",
+    close: async () => {},
+  };
+  const context = {
+    newPage: async () => page,
+    close: async () => {
+      calls.contextClosed = true;
+      if (videoDir !== undefined && behavior.videoName !== undefined) {
+        writeFileSync(join(videoDir, behavior.videoName), "webm-bytes");
+      }
+      if (behavior.contextCloseError !== undefined) {
+        throw behavior.contextCloseError;
+      }
+    },
+  };
+  const browser = {
+    newContext: async (options: { recordVideo: { dir: string } }) => {
+      videoDir = options.recordVideo.dir;
+      if (behavior.newContextError !== undefined) {
+        throw behavior.newContextError;
+      }
+      return context;
+    },
+    close: async () => {
+      calls.browserClosed = true;
+    },
+  };
+  return { chromium: { launch: async () => browser }, calls };
+}
+
+const FAKE_DEF: WalkthroughDef = {
+  slug: "fake-run",
+  granularity: "feature",
+  steps: [{ action: "goto", value: "/" }],
+};
+
+describe("runWalkthrough teardown and recording selection (fake browser)", () => {
+  it("picks this run's recording, never a stale one left in .video", async () => {
+    const out = mkdtempSync(join(dir, "stale-"));
+    // A previous run's recording; alphabetically FIRST so a naive files[0]
+    // pick would ingest it instead of the fresh one.
+    mkdirSync(join(out, ".video"), { recursive: true });
+    writeFileSync(join(out, ".video", "aaa-stale.webm"), "stale-bytes");
+    const { chromium } = fakeChromium({ videoName: "zzz-fresh.webm" });
+    const result = await runWalkthrough(FAKE_DEF, {
+      out,
+      baseUrl: "http://127.0.0.1:1/",
+      browser: chromium,
+      stepPauseMs: 0,
+    });
+    expect(basename(result.video)).toBe("zzz-fresh.webm");
+    expect(existsSync(join(out, ".video", "aaa-stale.webm"))).toBe(false);
+  });
+
+  it("closes the browser when context creation fails", async () => {
+    const { chromium, calls } = fakeChromium({
+      newContextError: new Error("disk full during recordVideo setup"),
+    });
+    await expect(
+      runWalkthrough(FAKE_DEF, {
+        out: mkdtempSync(join(dir, "leak-")),
+        baseUrl: "http://127.0.0.1:1/",
+        browser: chromium,
+        stepPauseMs: 0,
+      }),
+    ).rejects.toThrow("disk full during recordVideo setup");
+    expect(calls.browserClosed).toBe(true);
+  });
+
+  it("surfaces the step error, not a context.close rejection, and still closes the browser", async () => {
+    const { chromium, calls } = fakeChromium({
+      gotoError: new Error("step-boom"),
+      contextCloseError: new Error("close-boom"),
+      videoName: "run.webm",
+    });
+    await expect(
+      runWalkthrough(FAKE_DEF, {
+        out: mkdtempSync(join(dir, "mask-")),
+        baseUrl: "http://127.0.0.1:1/",
+        browser: chromium,
+        stepPauseMs: 0,
+      }),
+    ).rejects.toThrow("step-boom");
+    expect(calls.contextClosed).toBe(true);
+    expect(calls.browserClosed).toBe(true);
+  });
+
+  it("surfaces a context.close rejection when the steps themselves succeeded", async () => {
+    const { chromium, calls } = fakeChromium({
+      contextCloseError: new Error("close-boom"),
+      videoName: "run.webm",
+    });
+    await expect(
+      runWalkthrough(FAKE_DEF, {
+        out: mkdtempSync(join(dir, "close-")),
+        baseUrl: "http://127.0.0.1:1/",
+        browser: chromium,
+        stepPauseMs: 0,
+      }),
+    ).rejects.toThrow("close-boom");
+    expect(calls.browserClosed).toBe(true);
+  });
+
+  it("rejects a goto that resolves to a non-http(s) URL before it reaches the page", async () => {
+    const fileDef: WalkthroughDef = {
+      slug: "file-goto",
+      granularity: "feature",
+      steps: [{ action: "goto", value: "file:///etc/passwd" }],
+    };
+    const { chromium } = fakeChromium({ videoName: "run.webm" });
+    await expect(
+      runWalkthrough(fileDef, {
+        out: mkdtempSync(join(dir, "scheme-")),
+        baseUrl: "http://127.0.0.1:1/",
+        browser: chromium,
+        stepPauseMs: 0,
+      }),
+    ).rejects.toMatchObject({ code: "WALKTHROUGH_URL_SCHEME" });
+  });
+
+  it("rejects a relative goto against a non-http(s) baseUrl", async () => {
+    const { chromium } = fakeChromium({ videoName: "run.webm" });
+    await expect(
+      runWalkthrough(FAKE_DEF, {
+        out: mkdtempSync(join(dir, "scheme-base-")),
+        baseUrl: "file:///srv/app/",
+        browser: chromium,
+        stepPauseMs: 0,
+      }),
+    ).rejects.toMatchObject({ code: "WALKTHROUGH_URL_SCHEME" });
   });
 });

--- a/packages/evidence/src/video/driver.ts
+++ b/packages/evidence/src/video/driver.ts
@@ -133,14 +133,46 @@ async function loadChromium(): Promise<PwChromium> {
 }
 
 function resolveUrl(value: string, baseUrl: string | undefined): string {
-  if (/^https?:\/\//.test(value)) return value;
-  if (baseUrl === undefined) {
+  let resolved: URL;
+  if (/^https?:\/\//i.test(value)) {
+    resolved = parseUrl(value, undefined);
+  } else {
+    if (baseUrl === undefined) {
+      throw new EvidenceError(
+        `walkthrough goto '${value}' is relative but no baseUrl was provided`,
+        { code: "WALKTHROUGH_NO_BASE_URL", context: { value } },
+      );
+    }
+    resolved = parseUrl(value, baseUrl);
+  }
+  // Scheme allowlist enforced again at execution time (the schema also rejects
+  // non-http(s) gotos): a def constructed in code, or a file:/javascript: base
+  // URL, must never reach page.goto — that would screenshot local files or run
+  // script into the evidence bundle.
+  if (resolved.protocol !== "http:" && resolved.protocol !== "https:") {
     throw new EvidenceError(
-      `walkthrough goto '${value}' is relative but no baseUrl was provided`,
-      { code: "WALKTHROUGH_NO_BASE_URL", context: { value } },
+      `walkthrough goto '${value}' resolved to a non-http(s) URL: ${resolved.href}`,
+      {
+        code: "WALKTHROUGH_URL_SCHEME",
+        context: { value, resolved: resolved.href },
+      },
     );
   }
-  return new URL(value, baseUrl).toString();
+  return resolved.toString();
+}
+
+function parseUrl(value: string, base: string | undefined): URL {
+  try {
+    return new URL(value, base);
+  } catch (error) {
+    // error-policy:J3 untrusted definition input — an unparseable goto target
+    // is a typed invalid, never a raw TypeError from the URL constructor.
+    throw new EvidenceError(`walkthrough goto is not a valid URL: ${value}`, {
+      code: "WALKTHROUGH_URL_INVALID",
+      cause: error,
+      context: { value, base },
+    });
+  }
 }
 
 /** Execute one step against the page; throws on any failure (fail-fast). */
@@ -223,60 +255,92 @@ export async function runWalkthrough(
   const stepPauseMs = options.stepPauseMs ?? DEFAULT_STEP_PAUSE_MS;
   fs.mkdirSync(options.out, { recursive: true });
   const videoDir = path.join(options.out, ".video");
+  // A reused `out` dir may still hold a previous run's recording; clearing the
+  // video dir up front guarantees whatever file appears here afterwards belongs
+  // to THIS run — a stale recording ingested as fresh evidence is worse than
+  // no evidence.
+  fs.rmSync(videoDir, { recursive: true, force: true });
   fs.mkdirSync(videoDir, { recursive: true });
 
   const chromium = options.browser ?? (await loadChromium());
   const browser = await chromium.launch({ headless: true });
-  const context = await browser.newContext({
-    viewport,
-    recordVideo: { dir: videoDir, size: viewport },
-    ...(baseUrl !== undefined ? { baseURL: baseUrl } : {}),
-  });
-  const page = await context.newPage();
 
   const steps: StepLog[] = [];
   const screenshots: string[] = [];
   const ariaSnapshots: string[] = [];
-  let index = 0;
+  // Once the browser process exists, every failure path below must still close
+  // it — and the failure that aborted the run must be the one the caller sees,
+  // never a secondary close() rejection. `failure` carries the first error
+  // through both teardown stages instead of letting a throwing finally mask it.
+  let failure: { error: unknown } | undefined;
   try {
-    for (const step of def.steps) {
-      const started = performance.now();
-      await runStep(page, step, baseUrl, timeout);
-      if (stepPauseMs > 0) await page.waitForTimeout(stepPauseMs);
-      const record: StepLog = {
-        index,
-        action: step.action,
-        durationMs: Math.round(performance.now() - started),
-        ...(step.label !== undefined ? { label: step.label } : {}),
-        ...("selector" in step && step.selector !== undefined
-          ? { selector: step.selector }
-          : {}),
-        ...("value" in step && step.value !== undefined
-          ? { value: step.value }
-          : {}),
-      };
-      const tag = `${String(index).padStart(2, "0")}-${slugStep(step)}`;
-      if (step.screenshotAfter) {
-        const shot = path.join(options.out, `${tag}.png`);
-        await page.screenshot({ path: shot });
-        screenshots.push(shot);
-        record.screenshot = path.basename(shot);
+    const context = await browser.newContext({
+      viewport,
+      recordVideo: { dir: videoDir, size: viewport },
+      ...(baseUrl !== undefined ? { baseURL: baseUrl } : {}),
+    });
+    try {
+      const page = await context.newPage();
+      let index = 0;
+      for (const step of def.steps) {
+        const started = performance.now();
+        await runStep(page, step, baseUrl, timeout);
+        if (stepPauseMs > 0) await page.waitForTimeout(stepPauseMs);
+        const record: StepLog = {
+          index,
+          action: step.action,
+          durationMs: Math.round(performance.now() - started),
+          ...(step.label !== undefined ? { label: step.label } : {}),
+          ...("selector" in step && step.selector !== undefined
+            ? { selector: step.selector }
+            : {}),
+          ...("value" in step && step.value !== undefined
+            ? { value: step.value }
+            : {}),
+        };
+        const tag = `${String(index).padStart(2, "0")}-${slugStep(step)}`;
+        if (step.screenshotAfter) {
+          const shot = path.join(options.out, `${tag}.png`);
+          await page.screenshot({ path: shot });
+          screenshots.push(shot);
+          record.screenshot = path.basename(shot);
+        }
+        if (step.ariaAfter) {
+          const snapshot = await captureAriaSnapshot(page, timeout);
+          const snapPath = path.join(options.out, `${tag}.aria.yaml`);
+          fs.writeFileSync(snapPath, snapshot);
+          ariaSnapshots.push(snapPath);
+          record.ariaSnapshot = path.basename(snapPath);
+        }
+        steps.push(record);
+        index += 1;
       }
-      if (step.ariaAfter) {
-        const snapshot = await captureAriaSnapshot(page, timeout);
-        const snapPath = path.join(options.out, `${tag}.aria.yaml`);
-        fs.writeFileSync(snapPath, snapshot);
-        ariaSnapshots.push(snapPath);
-        record.ariaSnapshot = path.basename(snapPath);
-      }
-      steps.push(record);
-      index += 1;
+    } catch (error) {
+      failure = { error };
     }
+    // Closing the context flushes and finalizes the recorded video file — after
+    // a failed step too, so a failed run leaves a diagnosable recording.
+    try {
+      await context.close();
+    } catch (error) {
+      // error-policy:J6 best-effort teardown — the step failure is the primary
+      // diagnosis; a context-close rejection surfaces only when the run itself
+      // succeeded (browser.close below still runs either way).
+      failure ??= { error };
+    }
+  } catch (error) {
+    // newContext (or an unexpected non-step failure) before the guarded region.
+    failure ??= { error };
   } finally {
-    // Closing the context flushes and finalizes the recorded video file.
-    await context.close();
-    await browser.close();
+    try {
+      await browser.close();
+    } catch (error) {
+      // error-policy:J6 best-effort teardown — same rule as context.close: the
+      // original run failure wins; a close rejection surfaces only on its own.
+      failure ??= { error };
+    }
   }
+  if (failure !== undefined) throw failure.error;
 
   const rawVideo = findVideoFile(videoDir);
   const stepsLogPath = path.join(options.out, "steps.json");
@@ -327,7 +391,12 @@ function slugStep(step: WalkthroughStep): string {
   );
 }
 
-/** Playwright writes the video as a random-named file in `videoDir`. */
+/**
+ * Playwright writes the video as a random-named file in `videoDir`. The dir is
+ * cleared before the run, so normally exactly one file exists; if several do
+ * (e.g. a page recreated mid-run), the newest by mtime is this run's final
+ * recording — never an arbitrary directory-order pick.
+ */
 function findVideoFile(videoDir: string): string {
   const files = fs
     .readdirSync(videoDir)
@@ -338,5 +407,13 @@ function findVideoFile(videoDir: string): string {
       { code: "WALKTHROUGH_NO_VIDEO", context: { videoDir } },
     );
   }
-  return path.join(videoDir, files[0]);
+  const newest = files
+    .map((name) => {
+      const filePath = path.join(videoDir, name);
+      return { filePath, mtimeMs: fs.statSync(filePath).mtimeMs };
+    })
+    .sort(
+      (a, b) => b.mtimeMs - a.mtimeMs || (a.filePath < b.filePath ? -1 : 1),
+    );
+  return newest[0].filePath;
 }

--- a/packages/evidence/src/video/fixture-server.test.ts
+++ b/packages/evidence/src/video/fixture-server.test.ts
@@ -46,4 +46,21 @@ describe("serveFixture", () => {
       await server.stop();
     }
   });
+
+  it("answers malformed percent-encoding with 400 and keeps serving", async () => {
+    const root = mkdtempSync(join(dir, "root3-"));
+    writeFileSync(join(root, "index.html"), "<h1>hi</h1>");
+    const server = await serveFixture(root);
+    try {
+      // decodeURIComponent("%") throws URIError; before the guard this crashed
+      // the whole process mid-walkthrough instead of answering the request.
+      const bad = await fetch(`${server.baseUrl}%`);
+      expect(bad.status).toBe(400);
+      // The server survived and still serves the index.
+      const index = await fetch(server.baseUrl);
+      expect(index.status).toBe(200);
+    } finally {
+      await server.stop();
+    }
+  });
 });

--- a/packages/evidence/src/video/fixture-server.ts
+++ b/packages/evidence/src/video/fixture-server.ts
@@ -40,7 +40,16 @@ export async function serveFixture(
       res.writeHead(405).end("method not allowed");
       return;
     }
-    const urlPath = decodeURIComponent((req.url ?? "/").split("?")[0]);
+    let urlPath: string;
+    try {
+      urlPath = decodeURIComponent((req.url ?? "/").split("?")[0]);
+    } catch {
+      // error-policy:J3 untrusted request input — malformed percent-encoding
+      // (e.g. GET /%) is a 400 response, never an uncaught URIError that kills
+      // the server mid-walkthrough.
+      res.writeHead(400).end("bad request");
+      return;
+    }
     const rel = urlPath === "/" ? indexFile : urlPath.replace(/^\/+/, "");
     const filePath = path.resolve(root, rel);
     // Traversal guard: a resolved path must stay inside the served root.

--- a/packages/evidence/src/video/ingest.test.ts
+++ b/packages/evidence/src/video/ingest.test.ts
@@ -12,6 +12,7 @@ import { promisify } from "node:util";
 import { afterAll, describe, expect, it } from "vitest";
 import { createBundle, verifyBundle } from "../bundle.ts";
 import { EvidenceError } from "../errors.ts";
+import { resolveFfmpegBinary } from "../ffmpeg-binaries.ts";
 import { ingestVideo } from "./ingest.ts";
 import { videoToolsAvailable } from "./normalize.ts";
 
@@ -20,10 +21,15 @@ const dir = mkdtempSync(join(os.tmpdir(), "evidence-video-ingest-"));
 afterAll(() => rmSync(dir, { recursive: true, force: true }));
 
 const tools = await videoToolsAvailable();
+// Generate clips with the SAME binary the code under test resolves: the gate
+// above accepts env/PATH/bundled ffmpeg, so a hardcoded "ffmpeg" would fail
+// (instead of honestly skipping) on machines with only the bundled binary.
+const ffmpeg = await resolveFfmpegBinary();
+const ffmpegBin = ffmpeg.available ? ffmpeg.bin : "ffmpeg";
 
 /** Two-scene webm: 1s red then 1s blue, so scene detection sees one hard cut. */
 async function makeTwoSceneWebm(out: string): Promise<void> {
-  await execFileAsync("ffmpeg", [
+  await execFileAsync(ffmpegBin, [
     "-hide_banner",
     "-loglevel",
     "error",
@@ -109,7 +115,9 @@ describe.skipIf(!tools.available)("ingestVideo (ffmpeg present)", () => {
     expect(finalized.manifest.artifacts.length).toBeGreaterThan(4);
     const report = await verifyBundle(bundle.dir);
     expect(report.ok).toBe(true);
-  });
+    // ffmpeg transcode + keyframe fan-out overrun vitest's 5s default under
+    // parallel suite load; the explicit budget matches the driver suite's.
+  }, 120_000);
 });
 
 describe("ingestVideo validation", () => {

--- a/packages/evidence/src/video/normalize.test.ts
+++ b/packages/evidence/src/video/normalize.test.ts
@@ -25,6 +25,13 @@ const dir = mkdtempSync(join(os.tmpdir(), "evidence-normalize-"));
 afterAll(() => rmSync(dir, { recursive: true, force: true }));
 
 const tools = await videoToolsAvailable();
+// Generate clips with the SAME binaries the code under test resolves: the gate
+// above accepts env/PATH/bundled tools, so hardcoded "ffmpeg"/"ffprobe" would
+// fail (instead of honestly skipping) on machines with only the bundled ones.
+const ffmpeg = await resolveFfmpegBinary();
+const ffmpegBin = ffmpeg.available ? ffmpeg.bin : "ffmpeg";
+const ffprobe = await resolveFfprobeBinary();
+const ffprobeBin = ffprobe.available ? ffprobe.bin : "ffprobe";
 
 /** Solid-colour clip in the requested container/codec/faststart layout. */
 async function makeClip(
@@ -51,7 +58,63 @@ async function makeClip(
   ];
   if (out.endsWith(".mp4") && faststart) args.push("-movflags", "+faststart");
   args.push(out);
-  await execFileAsync("ffmpeg", args);
+  await execFileAsync(ffmpegBin, args);
+}
+
+/** h264 mp4 with one video + two aac audio streams, without faststart. */
+async function makeTwoAudioMp4(out: string): Promise<void> {
+  await execFileAsync(ffmpegBin, [
+    "-hide_banner",
+    "-loglevel",
+    "error",
+    "-y",
+    "-f",
+    "lavfi",
+    "-i",
+    "color=c=red:s=64x64:d=1",
+    "-f",
+    "lavfi",
+    "-i",
+    "sine=frequency=440:duration=1",
+    "-f",
+    "lavfi",
+    "-i",
+    "sine=frequency=880:duration=1",
+    "-map",
+    "0:v",
+    "-map",
+    "1:a",
+    "-map",
+    "2:a",
+    "-pix_fmt",
+    "yuv420p",
+    "-c:v",
+    "libx264",
+    "-c:a",
+    "aac",
+    out,
+  ]);
+}
+
+/** Count of streams per codec_type as ffprobe reports them. */
+async function countStreams(file: string): Promise<Record<string, number>> {
+  const { stdout } = await execFileAsync(ffprobeBin, [
+    "-v",
+    "error",
+    "-print_format",
+    "json",
+    "-show_streams",
+    file,
+  ]);
+  const parsed = JSON.parse(stdout) as {
+    streams?: { codec_type?: string }[];
+  };
+  const counts: Record<string, number> = {};
+  for (const stream of parsed.streams ?? []) {
+    const type = stream.codec_type ?? "unknown";
+    counts[type] = (counts[type] ?? 0) + 1;
+  }
+  return counts;
 }
 
 describe.skipIf(!tools.available)("normalizeVideo (ffmpeg present)", () => {
@@ -93,6 +156,20 @@ describe.skipIf(!tools.available)("normalizeVideo (ffmpeg present)", () => {
     const probe = await probeVideo(out);
     expect(probe.videoCodec).toBe("h264");
     expect(probe.faststart).toBe(true);
+  });
+
+  it("remux keeps every non-subtitle stream (both audio tracks survive)", async () => {
+    const clip = join(dir, "two-audio.mp4");
+    await makeTwoAudioMp4(clip);
+    expect((await countStreams(clip)).audio).toBe(2);
+    const out = join(dir, "two-audio-out.mp4");
+    const result = await normalizeVideo(clip, out);
+    expect(result.status).toBe("remuxed");
+    // Without `-map 0` ffmpeg keeps one stream per type and the second audio
+    // track would be silently dropped from the evidence.
+    const counts = await countStreams(out);
+    expect(counts.video).toBe(1);
+    expect(counts.audio).toBe(2);
   });
 
   it("transcodes a webm to canonical h264+faststart mp4", async () => {

--- a/packages/evidence/src/video/normalize.ts
+++ b/packages/evidence/src/video/normalize.ts
@@ -173,6 +173,9 @@ export async function normalizeVideo(
   }
   if (isH264Mp4) {
     // Already h264: remux only (stream copy) to move moov to the front.
+    // `-map 0` keeps every input stream (ffmpeg's default keeps only one per
+    // type, silently dropping e.g. a second audio track); subtitles are dropped
+    // to match the transcode path — GitHub inline playback ignores them.
     await execFileAsync(
       tools.ffmpeg.bin,
       [
@@ -182,6 +185,10 @@ export async function normalizeVideo(
         "-y",
         "-i",
         inputPath,
+        "-map",
+        "0",
+        "-map",
+        "-0:s?",
         "-c",
         "copy",
         "-movflags",

--- a/packages/evidence/src/video/walkthrough-schema.test.ts
+++ b/packages/evidence/src/video/walkthrough-schema.test.ts
@@ -145,6 +145,73 @@ describe("parseWalkthroughDef", () => {
       ),
     ).toThrow(EvidenceValidationError);
   });
+
+  it("rejects goto targets with non-http(s) schemes", () => {
+    for (const value of [
+      "file:///etc/passwd",
+      "javascript:alert(1)",
+      "data:text/html,<script>1</script>",
+      "chrome://settings",
+    ]) {
+      expect(() =>
+        parseWalkthroughDef(
+          {
+            slug: "x",
+            granularity: "feature",
+            steps: [{ action: "goto", value }],
+          },
+          "test",
+        ),
+      ).toThrow(EvidenceValidationError);
+    }
+  });
+
+  it("accepts http(s) and relative goto targets", () => {
+    for (const value of [
+      "https://example.com/page",
+      "http://127.0.0.1:8080/",
+      "/settings",
+      "settings?tab=1",
+    ]) {
+      const def = parseWalkthroughDef(
+        {
+          slug: "ok",
+          granularity: "feature",
+          steps: [{ action: "goto", value }],
+        },
+        "test",
+      );
+      expect(def.steps).toHaveLength(1);
+    }
+  });
+
+  it("rejects a non-http(s) baseUrl", () => {
+    expect(() =>
+      parseWalkthroughDef(
+        {
+          slug: "x",
+          granularity: "feature",
+          baseUrl: "file:///srv/app/",
+          steps: [{ action: "goto", value: "/" }],
+        },
+        "test",
+      ),
+    ).toThrow(EvidenceValidationError);
+  });
+
+  it("rejects waitFor and scroll steps carrying both selector and value", () => {
+    for (const step of [
+      { action: "waitFor", selector: "#a", value: "500" },
+      { action: "scroll", selector: "#a", value: "300" },
+    ]) {
+      expect(() =>
+        parseWalkthroughDef(
+          { slug: "x", granularity: "feature", steps: [step] },
+          "test",
+        ),
+      ).toThrow(EvidenceValidationError);
+    }
+  });
 });
 
 describe("shipped walkthrough definitions", () => {

--- a/packages/evidence/src/video/walkthrough-schema.ts
+++ b/packages/evidence/src/video/walkthrough-schema.ts
@@ -38,13 +38,32 @@ const stepBase = {
   ariaAfter: z.boolean().optional(),
 };
 
+// A goto target is either a relative path (no scheme; resolved against the
+// run's baseUrl — the fixture server's or the booted app's http origin) or an
+// absolute http(s) URL. Any other explicit scheme (file:, javascript:, data:,
+// …) is rejected at validation time: page.goto on such a URL would screenshot
+// local files or execute script straight into an evidence bundle.
+const SCHEME_PREFIX = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+function isHttpOrRelative(value: string): boolean {
+  const scheme = SCHEME_PREFIX.exec(value);
+  if (scheme === null) return true;
+  return /^https?:$/i.test(scheme[0]);
+}
+const NON_HTTP_MESSAGE =
+  "must be an http(s) URL or a relative path (non-http(s) schemes are not allowed)";
+
 // Each action carries exactly the fields it needs; a discriminated union means
 // `click` without a `selector` fails validation instead of no-op'ing at runtime.
 const stepSchema = z.discriminatedUnion("action", [
   z.strictObject({
     action: z.literal("goto"),
-    /** Absolute URL, or a path resolved against the run's baseUrl. */
-    value: z.string().min(1),
+    /** http(s) URL, or a path resolved against the run's baseUrl. */
+    value: z
+      .string()
+      .min(1)
+      .refine(isHttpOrRelative, {
+        message: `goto value ${NON_HTTP_MESSAGE}`,
+      }),
     ...stepBase,
   }),
   z.strictObject({
@@ -100,7 +119,13 @@ const walkthroughSchema = z
     /** Human title for the walkthrough. */
     title: z.string().min(1).optional(),
     /** Default base URL for relative `goto` steps; overridable at run time. */
-    baseUrl: z.string().url().optional(),
+    baseUrl: z
+      .string()
+      .url()
+      .refine((value) => /^https?:\/\//i.test(value), {
+        message: "baseUrl must be an http(s) URL",
+      })
+      .optional(),
     /**
      * Marks a walkthrough that can only run against the booted real app (no
      * self-contained fixture). The driver refuses to run it without an explicit
@@ -120,6 +145,20 @@ const walkthroughSchema = z
           code: "custom",
           path: ["steps", index],
           message: "waitFor requires a selector or a value (ms)",
+        });
+      }
+      // The driver executes selector-or-value, never both; accepting both
+      // would silently ignore one field of the definition.
+      if (
+        step.action === "waitFor" &&
+        step.selector !== undefined &&
+        step.value !== undefined
+      ) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["steps", index],
+          message:
+            "waitFor takes a selector or a value (ms), not both (the value would be ignored)",
         });
       }
       if (
@@ -142,6 +181,18 @@ const walkthroughSchema = z
           code: "custom",
           path: ["steps", index],
           message: "scroll requires a selector or a value (px)",
+        });
+      }
+      if (
+        step.action === "scroll" &&
+        step.selector !== undefined &&
+        step.value !== undefined
+      ) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["steps", index],
+          message:
+            "scroll takes a selector or a value (px), not both (the value would be ignored)",
         });
       }
       if (

--- a/packages/evidence/src/video/walkthroughs.ts
+++ b/packages/evidence/src/video/walkthroughs.ts
@@ -145,31 +145,24 @@ export async function runAndIngestWalkthrough(
         : {}),
     });
     // Screenshots, snapshots, and the steps-log ride into the bundle alongside
-    // the video so the walkthrough is fully self-describing evidence.
-    let shotIndex = 0;
+    // the video so the walkthrough is fully self-describing evidence. The
+    // driver's basenames already carry the zero-padded step index, so they are
+    // used as-is — re-prefixing would double-index ("00-03-click.png").
     for (const shot of run.screenshots) {
       await bundle.addArtifact(shot, {
         kind: "screenshot",
         source,
         producedBy: "walkthrough-driver",
-        bundlePath: `video/${def.granularity}s/${def.slug}/steps/${String(
-          shotIndex,
-        ).padStart(2, "0")}-${path.basename(shot)}`,
+        bundlePath: `video/${def.granularity}s/${def.slug}/steps/${path.basename(shot)}`,
       });
-      shotIndex += 1;
     }
-    let snapIndex = 0;
     for (const snap of run.ariaSnapshots) {
       await bundle.addArtifact(snap, {
         kind: "html-tree",
         source,
         producedBy: "walkthrough-driver",
-        bundlePath: `html-trees/${def.slug}/${String(snapIndex).padStart(
-          2,
-          "0",
-        )}-${path.basename(snap)}`,
+        bundlePath: `html-trees/${def.slug}/${path.basename(snap)}`,
       });
-      snapIndex += 1;
     }
     await bundle.addArtifact(run.stepsLog, {
       kind: "report",


### PR DESCRIPTION
Follow-up to the merged **#14629** (video-evidence lane, #14545). The PR merged before its planned adversarial review ran (reviewer session died); that review was posted post-merge and flagged 8 failure-path defects plus 3 minor robustness gaps. This PR fixes all of them, each with a test that provokes the exact failure mode.

Review comment being addressed: https://github.com/elizaOS/eliza/pull/14629#issuecomment-4889632718

All paths below are `packages/evidence/` relative. Fixes concentrate on the failure/retry paths the merged lane never exercised: evidence destroyed on failure, `--bundle` dir poisoned on retry, stale-video pick, a browser-leak window, and a fixture-server crash.

---

### Finding 1 — A failed walkthrough destroyed its own failure evidence
`src/video/cli.ts`. The driver finalizes the recording in a `finally` so "a failed run leaves a diagnosable recording", but the CLI's scratch-cleanup `finally` ran on the error path too and `rm -rf`'d the scratch (recording + screenshots + steps log).

- **Before:** scratch cleaned unconditionally in `finally`.
- **After:** scratch is removed **only on success**; on failure the raw recording is preserved and its path is printed (`walkthrough scratch preserved for diagnosis: …`), then the original error rethrows to the J1 boundary.

### Finding 2 — Failed runs poisoned `--bundle` (BUNDLE_DIR_EXISTS on retry)
`src/video/cli.ts`. `openBundle` created the dir before validation/run, so any failure left an empty, manifest-less dir and every retry died with `BUNDLE_DIR_EXISTS`.

- **Before:** dir created first; failures left it behind.
- **After:** argv + definitions validated **before** the dir is created; on mid-run failure the unfinalized (manifest-less) dir is removed at a J6 teardown, so a retry hits the real error again, not `BUNDLE_DIR_EXISTS`. A genuinely pre-existing dir is still a typed `BUNDLE_DIR_EXISTS` and is never deleted (sealed single-writer contract). Header corrected: bundles are fresh, not "reused".

### Finding 3 — `findVideoFile` picked `files[0]` → could ingest a stale recording
`src/video/driver.ts`. A reused `--out/.video` dir accumulates one webm per run; readdir-order pick could ship the previous run's video as this run's evidence.

- **Before:** `return path.join(videoDir, files[0])`.
- **After:** `.video` is cleared before the run; `findVideoFile` picks **newest by mtime** (name tie-break) so the result is unambiguously this run's recording.

### Finding 4 — Browser leak / original error masked in driver teardown
`src/video/driver.ts`. `newContext`/`newPage` ran outside the guarded region (leaked chromium on e.g. full-disk `recordVideo` setup), and a throwing `context.close()` in `finally` skipped `browser.close()` and masked the step error.

- **Before:** setup outside `try`; `context.close()` then `browser.close()` in one `finally`.
- **After:** all setup inside the guard; context and browser closed **independently**; the first/step error is carried in a `failure` cell and always wins — a secondary close rejection only surfaces when the run itself succeeded.

### Finding 5 — Uncaught `URIError` crashed the fixture server (`GET /%`)
`src/video/fixture-server.ts`. `decodeURIComponent` on a malformed path threw out of the request handler and killed the process mid-walkthrough.

- **Before:** `const urlPath = decodeURIComponent(...)` unguarded.
- **After:** J3 try/catch → `400 bad request`; the server keeps serving.

### Finding 6 — Suite flaked under default parallelism (vitest 5000ms)
`src/analyzers/runner.test.ts`, `src/video/ingest.test.ts`. ffmpeg transcode + keyframe fan-out overran vitest's 5s default under parallel load (two clean full runs failed the same 2 files).

- **After:** explicit `120_000` budget on the ffmpeg-heavy integration tests, matching the driver suite.

### Finding 7 — Tests hardcoded PATH `ffmpeg` while gating on `videoToolsAvailable()`
`src/video/normalize.test.ts`, `src/video/ingest.test.ts`, `src/analyzers/runner.test.ts`. The availability gate accepts env/bundled binaries, but clip generation exec'd bare `"ffmpeg"` → on a bundled-only machine the suites ran and failed at generation instead of skipping.

- **After:** clips are generated with the **same** binary the gate resolves (`resolveFfmpegBinary()` / `resolveFfprobeBinary()`), so a bundled-only host skips honestly.

### Finding 8 — `goto` scheme hole (file:/javascript:/data:)
`src/video/driver.ts` + `src/video/walkthrough-schema.ts`. Only `^https?://` was treated as absolute; `file:///…`/`javascript:…` passed schema and reached `page.goto` unchanged (would screenshot local files / run script into a bundle).

- **After:** non-http(s) schemes are rejected at **both** schema validation (`WALKTHROUGH_URL_SCHEME` message) and driver execution (typed `WALKTHROUGH_URL_SCHEME` after resolution); an unparseable target is a typed `WALKTHROUGH_URL_INVALID` (J3), never a raw `TypeError`.

### Minor items (also fixed)
- **Remux dropped extra streams:** `src/video/normalize.ts` remux now uses `-map 0 -map -0:s?` so a second audio track survives (subtitles dropped to match the transcode path).
- **Double-indexed screenshot names:** `src/video/walkthroughs.ts` used driver basenames as-is (no more `00-03-hover-send.png`).
- **`waitFor`/`scroll` with both selector and value:** schema now rejects it instead of the driver silently ignoring the value.

---

### Verification

Full `packages/evidence` suite green after rebasing onto current `develop`, real system ffmpeg 7.1, real headless chromium:

```text
$ bun run --cwd packages/evidence test
 Test Files  37 passed | 1 skipped (38)
      Tests  359 passed | 1 skipped (360)
```

Per-finding test tails (failure modes provoked):

```text
# Findings 1 & 2 — cli.test.ts (real chromium)
✓ bundle poisoning on failed runs > removes the unfinalized --bundle dir when ingest fails, so a retry is not blocked
✓ bundle poisoning on failed runs > does not create the --bundle dir when the walkthrough definition is invalid
✓ bundle poisoning on failed runs > reports a typed BUNDLE_DIR_EXISTS for a pre-existing --bundle dir (sealed, no reuse)
✓ walkthrough failure path (real chromium) > preserves the scratch as failure evidence, unpoisons the bundle, and retries clean  4583ms

# Findings 3, 4, 8 — driver.test.ts (injected structural browser)
✓ teardown and recording selection > picks this run's recording, never a stale one left in .video
✓ teardown and recording selection > closes the browser when context creation fails
✓ teardown and recording selection > surfaces the step error, not a context.close rejection, and still closes the browser
✓ teardown and recording selection > surfaces a context.close rejection when the steps themselves succeeded
✓ teardown and recording selection > rejects a goto that resolves to a non-http(s) URL before it reaches the page
✓ teardown and recording selection > rejects a relative goto against a non-http(s) baseUrl

# Finding 5 — fixture-server.test.ts
✓ serveFixture > answers malformed percent-encoding with 400 and keeps serving

# Finding 8 (schema side) — walkthrough-schema.test.ts
✓ rejects goto targets with non-http(s) schemes
✓ accepts http(s) and relative goto targets
✓ rejects a non-http(s) baseUrl
✓ rejects waitFor and scroll steps carrying both selector and value

# Minor (remux stream preservation) — normalize.test.ts
✓ normalizeVideo (ffmpeg present) > remux keeps every non-subtitle stream (both audio tracks survive)  659ms
```

Gates: `bun run --cwd packages/evidence test` (full suite green), `typecheck` (tsgo, clean), `lint` (biome, clean).

Doctrine: fail-fast preserved; new catches carry `// error-policy:J3/J4/J6` annotations; no `console` in library code (CLI stdout/stderr is the product); prose headers updated to describe the sealed-bundle + preserved-scratch contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence Rows

<!-- evidence-row:before-screenshots --> N/A - headless evidence video tooling; no product UI/native/browser surface changed.
<!-- evidence-row:after-screenshots --> N/A - headless evidence video tooling; no product UI/native/browser surface changed.
<!-- evidence-row:walkthrough-video --> N/A - this changes the walkthrough recorder itself rather than a product flow; real Chromium failure-path tests and transcripts above prove preserved recordings and clean retry behavior.
<!-- evidence-row:backend-logs --> N/A - no app backend route/provider/action/service path changed; CLI stderr/stdout transcripts above cover the process boundary.
<!-- evidence-row:frontend-logs --> N/A - no frontend/browser app session changed; Playwright fixture coverage is represented by the package tests above.
<!-- evidence-row:llm-trajectory --> N/A - no agent, prompt, planner, model, or live-LLM behavior changed.
<!-- evidence-row:domain-artifacts --> N/A - no product domain state changes; the relevant evidence artifacts are the preserved scratch recording, generated manifest, normalized video/keyframes, and analysis paths proven by the tests/transcripts above.
