### PR TITLE
fix(lifeops): surface composer activity signals

### DIFF
--- a/packages/agent/src/api/interactions-routes.test.ts
+++ b/packages/agent/src/api/interactions-routes.test.ts
@@ -1,11 +1,12 @@
 /**
- * POST /api/interactions/shortcut → EventType.SHORTCUT_FIRED contract (#8792).
+ * POST /api/interactions/* → runtime interaction event contract.
  *
  * The client-keyboard half of the interaction-reporting seam (the view-switch
  * half is views-routes.proactive-emit.test.ts). A user-fired shortcut must reach
  * the agent as a SHORTCUT_FIRED event (initiatedBy "user") the proactive decider
- * can react to — and a malformed/oversized report must be rejected, never emit,
- * and never throw.
+ * can react to. Composer lifecycle reports must reach the runtime as draft
+ * metadata only (#14679). Malformed/oversized reports must be rejected, never
+ * emit, and never throw.
  */
 import type http from "node:http";
 import { Readable } from "node:stream";
@@ -14,6 +15,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   handleInteractionsRoutes,
   type InteractionsRouteContext,
+  parseComposerBody,
   parseShortcutBody,
 } from "./interactions-routes.ts";
 
@@ -54,6 +56,15 @@ function shortcutCalls(emitEvent: ReturnType<typeof vi.fn>) {
   );
 }
 
+function composerCalls(emitEvent: ReturnType<typeof vi.fn>) {
+  return emitEvent.mock.calls.filter(
+    (call) =>
+      call[0] === EventType.USER_TYPING_STARTED ||
+      call[0] === EventType.USER_TYPING_PAUSED ||
+      call[0] === EventType.USER_DRAFT_ABANDONED,
+  );
+}
+
 afterEach(() => vi.restoreAllMocks());
 
 describe("parseShortcutBody", () => {
@@ -81,6 +92,73 @@ describe("parseShortcutBody", () => {
     expect(parseShortcutBody('{"shortcutId":"UPPER"}')).toBeNull();
     expect(parseShortcutBody(`{"shortcutId":"${"a".repeat(60)}"}`)).toBeNull();
     expect(parseShortcutBody("{}")).toBeNull();
+  });
+});
+
+describe("parseComposerBody", () => {
+  it("accepts composer metadata without draft text", () => {
+    expect(
+      parseComposerBody(
+        JSON.stringify({
+          activity: "typing_paused",
+          surface: "continuous_chat_overlay",
+          conversationId: "conversation-1",
+          draftLength: 14,
+          idleForMs: 2000,
+          occurredAt: "2026-06-01T12:00:00.000Z",
+        }),
+      ),
+    ).toEqual({
+      activity: "typing_paused",
+      surface: "continuous_chat_overlay",
+      conversationId: "conversation-1",
+      draftLength: 14,
+      idleForMs: 2000,
+      occurredAt: "2026-06-01T12:00:00.000Z",
+    });
+  });
+
+  it("rejects malformed composer lifecycle reports", () => {
+    expect(parseComposerBody("")).toBeNull();
+    expect(parseComposerBody("not json")).toBeNull();
+    expect(parseComposerBody("[]")).toBeNull();
+    expect(
+      parseComposerBody(
+        JSON.stringify({
+          activity: "typing_paused",
+          surface: "continuous_chat_overlay",
+          draftLength: 4,
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      parseComposerBody(
+        JSON.stringify({
+          activity: "typing_started",
+          surface: "Continuous Chat",
+          draftLength: 4,
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      parseComposerBody(
+        JSON.stringify({
+          activity: "typing_started",
+          surface: "continuous_chat_overlay",
+          draftLength: -1,
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      parseComposerBody(
+        JSON.stringify({
+          activity: "typing_started",
+          surface: "continuous_chat_overlay",
+          draftLength: 4,
+          occurredAt: "not-a-date",
+        }),
+      ),
+    ).toBeNull();
   });
 });
 
@@ -139,5 +217,109 @@ describe("handleInteractionsRoutes — SHORTCUT_FIRED (#8792)", () => {
       ctx.res,
       expect.objectContaining({ ok: true }),
     );
+  });
+});
+
+describe("handleInteractionsRoutes — composer lifecycle (#14679)", () => {
+  it("emits USER_TYPING_STARTED for a valid composer report", async () => {
+    const { ctx, emitEvent, json } = makeCtx(
+      {
+        activity: "typing_started",
+        surface: "continuous_chat_overlay",
+        conversationId: "conversation-1",
+        draftLength: 5,
+        occurredAt: "2026-06-01T12:00:00.000Z",
+      },
+      "POST",
+      "/api/interactions/composer",
+    );
+
+    await expect(handleInteractionsRoutes(ctx)).resolves.toBe(true);
+
+    const calls = composerCalls(emitEvent);
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0]).toBe(EventType.USER_TYPING_STARTED);
+    expect(calls[0][1]).toEqual(
+      expect.objectContaining({
+        activity: "typing_started",
+        surface: "continuous_chat_overlay",
+        conversationId: "conversation-1",
+        draftLength: 5,
+        occurredAt: "2026-06-01T12:00:00.000Z",
+        initiatedBy: "user",
+        source: "composer-interaction",
+      }),
+    );
+    expect(calls[0][1]).not.toHaveProperty("text");
+    expect(json).toHaveBeenCalledWith(
+      ctx.res,
+      expect.objectContaining({ ok: true, activity: "typing_started" }),
+    );
+  });
+
+  it("emits USER_TYPING_PAUSED with idle age", async () => {
+    const { ctx, emitEvent } = makeCtx(
+      {
+        activity: "typing_paused",
+        surface: "continuous_chat_overlay",
+        draftLength: 5,
+        idleForMs: 2000,
+        occurredAt: "2026-06-01T12:00:02.000Z",
+      },
+      "POST",
+      "/api/interactions/composer",
+    );
+
+    await expect(handleInteractionsRoutes(ctx)).resolves.toBe(true);
+
+    const calls = composerCalls(emitEvent);
+    expect(calls[0][0]).toBe(EventType.USER_TYPING_PAUSED);
+    expect(calls[0][1]).toEqual(
+      expect.objectContaining({
+        activity: "typing_paused",
+        idleForMs: 2000,
+      }),
+    );
+  });
+
+  it("emits USER_DRAFT_ABANDONED for a cleared draft", async () => {
+    const { ctx, emitEvent } = makeCtx(
+      {
+        activity: "draft_abandoned",
+        surface: "continuous_chat_overlay",
+        draftLength: 0,
+        reason: "cleared",
+        occurredAt: "2026-06-01T12:00:03.000Z",
+      },
+      "POST",
+      "/api/interactions/composer",
+    );
+
+    await expect(handleInteractionsRoutes(ctx)).resolves.toBe(true);
+
+    const calls = composerCalls(emitEvent);
+    expect(calls[0][0]).toBe(EventType.USER_DRAFT_ABANDONED);
+    expect(calls[0][1]).toEqual(
+      expect.objectContaining({
+        activity: "draft_abandoned",
+        reason: "cleared",
+      }),
+    );
+  });
+
+  it("rejects malformed composer bodies without emitting", async () => {
+    const { ctx, emitEvent, error } = makeCtx(
+      {
+        activity: "typing_paused",
+        surface: "continuous_chat_overlay",
+        draftLength: 5,
+      },
+      "POST",
+      "/api/interactions/composer",
+    );
+
+    await expect(handleInteractionsRoutes(ctx)).resolves.toBe(true);
+    expect(composerCalls(emitEvent)).toHaveLength(0);
+    expect(error).toHaveBeenCalledWith(ctx.res, expect.any(String), 400);
   });
 });

--- a/packages/agent/src/api/interactions-routes.ts
+++ b/packages/agent/src/api/interactions-routes.ts
@@ -1,12 +1,16 @@
 /**
- * POST /api/interactions/shortcut — report a user-fired UI/keyboard shortcut so
- * the agent observes it as a first-class interaction (#8792).
+ * POST /api/interactions/shortcut and /api/interactions/composer — report
+ * user UI activity so the agent observes it as first-class interaction context
+ * (#8792, #14679).
  *
  * The view-switch half of this contract lives in `views-routes.ts`
  * (`POST /api/views/:id/navigate` → `VIEW_SWITCHED`). This is the keyboard /
  * command-palette half: the client reports a stable `shortcutId` and the route
  * emits `EventType.SHORTCUT_FIRED`, which the proactive-interaction decider
  * consumes (governed by debounce / cooldown / daily-cap / model-judge-silent).
+ * The composer half carries only lifecycle metadata (started / paused /
+ * abandoned), never draft text, so providers can reason about "user is
+ * thinking" without leaking what they have not sent.
  *
  * Emission is fire-and-forget: a dropped event must never break the shortcut the
  * user actually pressed. This route is auth+proxy thin — it records nothing and
@@ -23,7 +27,18 @@ const MAX_BODY_BYTES = 4 * 1024;
 
 /** Stable shortcut id: kebab-case, bounded length (e.g. "open-command-palette"). */
 const SHORTCUT_ID_PATTERN = /^[a-z][a-z0-9-]{1,48}$/;
+const SURFACE_ID_PATTERN = /^[a-z][a-z0-9_-]{1,64}$/;
 const MAX_CONTEXT_CHARS = 120;
+const MAX_CONVERSATION_ID_CHARS = 128;
+const MAX_DRAFT_LENGTH = 100_000;
+
+const COMPOSER_ACTIVITY_TO_EVENT = {
+  typing_started: EventType.USER_TYPING_STARTED,
+  typing_paused: EventType.USER_TYPING_PAUSED,
+  draft_abandoned: EventType.USER_DRAFT_ABANDONED,
+} as const;
+
+type ComposerActivity = keyof typeof COMPOSER_ACTIVITY_TO_EVENT;
 
 export interface InteractionsRouteContext {
   req: http.IncomingMessage;
@@ -38,6 +53,16 @@ export interface InteractionsRouteContext {
 export interface ShortcutInteractionRequest {
   shortcutId: string;
   context?: string;
+}
+
+export interface ComposerInteractionRequest {
+  activity: ComposerActivity;
+  surface: string;
+  conversationId?: string;
+  draftLength: number;
+  idleForMs?: number;
+  reason?: "cleared" | "blurred" | "conversation_switched" | "unknown";
+  occurredAt: string;
 }
 
 /** Parse + validate the shortcut report body; null on anything malformed. */
@@ -65,11 +90,93 @@ export function parseShortcutBody(
   return { shortcutId, ...(context ? { context } : {}) };
 }
 
+function readBoundedString(
+  value: unknown,
+  maxChars: number,
+): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed.slice(0, maxChars) : undefined;
+}
+
+function readNonNegativeInteger(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  const integer = Math.trunc(value);
+  return integer >= 0 ? integer : null;
+}
+
+function readOccurredAt(value: unknown): string | null {
+  if (typeof value !== "string") return new Date().toISOString();
+  const parsedMs = Date.parse(value);
+  return Number.isFinite(parsedMs) ? new Date(parsedMs).toISOString() : null;
+}
+
+/** Parse + validate a composer lifecycle report; null on anything malformed. */
+export function parseComposerBody(
+  raw: string,
+): ComposerInteractionRequest | null {
+  if (!raw.trim()) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  const body = parsed as Record<string, unknown>;
+  const activity =
+    typeof body.activity === "string" &&
+    body.activity in COMPOSER_ACTIVITY_TO_EVENT
+      ? (body.activity as ComposerActivity)
+      : null;
+  if (!activity) return null;
+
+  const surface = readBoundedString(body.surface, 64);
+  if (!surface || !SURFACE_ID_PATTERN.test(surface)) return null;
+
+  const draftLength = readNonNegativeInteger(body.draftLength);
+  if (draftLength === null || draftLength > MAX_DRAFT_LENGTH) return null;
+
+  const idleForMs = readNonNegativeInteger(body.idleForMs);
+  if (activity === "typing_paused" && idleForMs === null) return null;
+
+  const reason =
+    body.reason === "cleared" ||
+    body.reason === "blurred" ||
+    body.reason === "conversation_switched" ||
+    body.reason === "unknown"
+      ? body.reason
+      : undefined;
+  const occurredAt = readOccurredAt(body.occurredAt);
+  if (!occurredAt) return null;
+
+  const conversationId = readBoundedString(
+    body.conversationId,
+    MAX_CONVERSATION_ID_CHARS,
+  );
+  return {
+    activity,
+    surface,
+    draftLength,
+    ...(conversationId ? { conversationId } : {}),
+    ...(idleForMs !== null ? { idleForMs } : {}),
+    ...(reason ? { reason } : {}),
+    occurredAt,
+  };
+}
+
 export async function handleInteractionsRoutes(
   ctx: InteractionsRouteContext,
 ): Promise<boolean> {
   const { req, res, method, pathname, json, error, runtime } = ctx;
-  if (pathname !== "/api/interactions/shortcut") return false;
+  if (
+    pathname !== "/api/interactions/shortcut" &&
+    pathname !== "/api/interactions/composer"
+  ) {
+    return false;
+  }
   if (method !== "POST") {
     error(res, "Method not allowed", 405);
     return true;
@@ -79,6 +186,44 @@ export async function handleInteractionsRoutes(
     maxBytes: MAX_BODY_BYTES,
     returnNullOnTooLarge: true,
   });
+  if (pathname === "/api/interactions/composer") {
+    const request = parseComposerBody(buffer?.toString("utf8") ?? "");
+    if (!request) {
+      error(res, "Invalid composer interaction body", 400);
+      return true;
+    }
+
+    if (runtime) {
+      const eventType = COMPOSER_ACTIVITY_TO_EVENT[request.activity];
+      void runtime
+        .emitEvent(eventType, {
+          runtime,
+          source: "composer-interaction",
+          activity: request.activity,
+          surface: request.surface,
+          ...(request.conversationId
+            ? { conversationId: request.conversationId }
+            : {}),
+          draftLength: request.draftLength,
+          ...(request.idleForMs !== undefined
+            ? { idleForMs: request.idleForMs }
+            : {}),
+          ...(request.reason ? { reason: request.reason } : {}),
+          occurredAt: request.occurredAt,
+          initiatedBy: "user",
+        })
+        .catch((err) => {
+          runtime.logger?.debug?.(
+            { src: "InteractionsRoutes", err },
+            "[InteractionsRoutes] composer activity emit failed",
+          );
+        });
+    }
+
+    json(res, { ok: true, activity: request.activity });
+    return true;
+  }
+
   const request = parseShortcutBody(buffer?.toString("utf8") ?? "");
   if (!request) {
     error(res, "Invalid shortcut interaction body", 400);

--- a/packages/agent/src/api/interactions-routes.ts
+++ b/packages/agent/src/api/interactions-routes.ts
@@ -74,6 +74,7 @@ export function parseShortcutBody(
   try {
     parsed = JSON.parse(raw);
   } catch {
+    // error-policy:J3 untrusted request JSON parses to an explicit invalid body.
     return null;
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
@@ -120,6 +121,7 @@ export function parseComposerBody(
   try {
     parsed = JSON.parse(raw);
   } catch {
+    // error-policy:J3 untrusted request JSON parses to an explicit invalid body.
     return null;
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
@@ -213,6 +215,7 @@ export async function handleInteractionsRoutes(
           initiatedBy: "user",
         })
         .catch((err) => {
+          // error-policy:J7 telemetry emission must not break the interaction route.
           runtime.logger?.debug?.(
             { src: "InteractionsRoutes", err },
             "[InteractionsRoutes] composer activity emit failed",
@@ -242,6 +245,7 @@ export async function handleInteractionsRoutes(
         initiatedBy: "user",
       })
       .catch((err) => {
+        // error-policy:J7 telemetry emission must not break the interaction route.
         runtime.logger?.debug?.(
           { src: "InteractionsRoutes", err },
           "[InteractionsRoutes] SHORTCUT_FIRED emit failed",

--- a/packages/agent/src/api/server-lazy-routes.ts
+++ b/packages/agent/src/api/server-lazy-routes.ts
@@ -249,7 +249,12 @@ export async function handleInteractionsRoutes(
   ...args: Parameters<InteractionsRoutesModule["handleInteractionsRoutes"]>
 ): ReturnType<InteractionsRoutesModule["handleInteractionsRoutes"]> {
   const ctx = routeContext(args);
-  if (ctx?.pathname !== "/api/interactions/shortcut") return false;
+  if (
+    ctx?.pathname !== "/api/interactions/shortcut" &&
+    ctx?.pathname !== "/api/interactions/composer"
+  ) {
+    return false;
+  }
   return (await import("./interactions-routes.ts")).handleInteractionsRoutes(
     ...args,
   );

--- a/packages/core/src/types/events.ts
+++ b/packages/core/src/types/events.ts
@@ -99,6 +99,9 @@ export enum EventType {
 	VIEW_SWITCHED = "VIEW_SWITCHED",
 	SLASH_COMMAND_INVOKED = "SLASH_COMMAND_INVOKED",
 	SHORTCUT_FIRED = "SHORTCUT_FIRED",
+	USER_TYPING_STARTED = "USER_TYPING_STARTED",
+	USER_TYPING_PAUSED = "USER_TYPING_PAUSED",
+	USER_DRAFT_ABANDONED = "USER_DRAFT_ABANDONED",
 
 	// Hook system events - command lifecycle
 	HOOK_COMMAND_NEW = "HOOK_COMMAND_NEW",
@@ -420,6 +423,33 @@ export interface ShortcutFiredPayload extends EventPayload {
 	roomId?: UUID;
 }
 
+/** Composer activity states reported by chat surfaces without draft contents. */
+export type ComposerActivityKind =
+	| "typing_started"
+	| "typing_paused"
+	| "draft_abandoned";
+
+/**
+ * Payload for composer activity events — the user's draft lifecycle in a chat
+ * composer. Carries only metadata; the draft text never leaves the client.
+ */
+export interface ComposerActivityPayload extends EventPayload {
+	activity: ComposerActivityKind;
+	initiatedBy: "user";
+	/** Stable client surface id (e.g. "continuous_chat_overlay"). */
+	surface: string;
+	/** Conversation or room id the composer is editing, when known. */
+	conversationId?: string;
+	/** Draft character count after trimming; never the draft text. */
+	draftLength: number;
+	/** Pause debounce age for typing_paused events. */
+	idleForMs?: number;
+	/** Why a draft cleared without submission, when known. */
+	reason?: "cleared" | "blurred" | "conversation_switched" | "unknown";
+	occurredAt: string;
+	roomId?: UUID;
+}
+
 // ============================================================================
 // Hook System Event Payloads
 // ============================================================================
@@ -630,6 +660,9 @@ export interface EventPayloadMap {
 	[EventType.VIEW_SWITCHED]: ViewSwitchedPayload;
 	[EventType.SLASH_COMMAND_INVOKED]: SlashCommandInvokedPayload;
 	[EventType.SHORTCUT_FIRED]: ShortcutFiredPayload;
+	[EventType.USER_TYPING_STARTED]: ComposerActivityPayload;
+	[EventType.USER_TYPING_PAUSED]: ComposerActivityPayload;
+	[EventType.USER_DRAFT_ABANDONED]: ComposerActivityPayload;
 	// Hook system event payloads
 	[EventType.HOOK_COMMAND_NEW]: HookCommandPayload;
 	[EventType.HOOK_COMMAND_RESET]: HookCommandPayload;

--- a/packages/ui/src/chat/report-composer-activity.test.ts
+++ b/packages/ui/src/chat/report-composer-activity.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+/**
+ * Covers composer activity reporting (#14679): draft lifecycle metadata POSTs
+ * to `/api/interactions/composer` without sending unsent draft text.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../utils/eliza-globals", () => ({
+  getElizaApiBase: () => "http://localhost:31337",
+  getElizaApiToken: () => "test-token",
+}));
+
+import { reportComposerActivity } from "./report-composer-activity";
+
+const fetchMock = vi.fn(() => Promise.resolve(new Response("{}")));
+
+beforeEach(() => {
+  fetchMock.mockClear();
+  vi.stubGlobal("fetch", fetchMock);
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe("reportComposerActivity (#14679)", () => {
+  it("POSTs composer metadata with auth and no draft text", () => {
+    reportComposerActivity({
+      activity: "typing_paused",
+      surface: "continuous_chat_overlay",
+      conversationId: "conversation-1",
+      draftLength: 17,
+      idleForMs: 2000,
+      occurredAt: "2026-06-01T12:00:02.000Z",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toBe("http://localhost:31337/api/interactions/composer");
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer test-token",
+    );
+    const body = JSON.parse(init.body as string);
+    expect(body).toEqual({
+      activity: "typing_paused",
+      surface: "continuous_chat_overlay",
+      conversationId: "conversation-1",
+      draftLength: 17,
+      idleForMs: 2000,
+      occurredAt: "2026-06-01T12:00:02.000Z",
+    });
+    expect(body).not.toHaveProperty("text");
+    expect(body).not.toHaveProperty("draft");
+  });
+
+  it("reports a cleared draft reason", () => {
+    reportComposerActivity({
+      activity: "draft_abandoned",
+      surface: "continuous_chat_overlay",
+      draftLength: 0,
+      reason: "cleared",
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(JSON.parse(init.body as string)).toEqual(
+      expect.objectContaining({
+        activity: "draft_abandoned",
+        reason: "cleared",
+        draftLength: 0,
+      }),
+    );
+  });
+
+  it("is fire-and-forget when fetch rejects", () => {
+    fetchMock.mockReturnValueOnce(Promise.reject(new Error("offline")));
+    expect(() =>
+      reportComposerActivity({
+        activity: "typing_started",
+        surface: "continuous_chat_overlay",
+        draftLength: 3,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/ui/src/chat/report-composer-activity.ts
+++ b/packages/ui/src/chat/report-composer-activity.ts
@@ -53,8 +53,11 @@ export function reportComposerActivity(report: ComposerActivityReport): void {
         `[reportComposerActivity] composer report failed: ${err instanceof Error ? err.message : String(err)}`,
       );
     });
-  } catch {
+  } catch (err) {
     // error-policy:J7 same guard for synchronous setup failures — telemetry
     // must never break composer input.
+    logger.warn(
+      `[reportComposerActivity] composer report setup failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 }

--- a/packages/ui/src/chat/report-composer-activity.ts
+++ b/packages/ui/src/chat/report-composer-activity.ts
@@ -1,0 +1,60 @@
+/**
+ * Fire-and-forget composer activity reporter for chat surfaces. It reports
+ * draft lifecycle metadata to the agent while keeping unsent text entirely
+ * client-side.
+ */
+import { logger } from "@elizaos/core";
+import { getElizaApiBase, getElizaApiToken } from "../utils/eliza-globals";
+
+export type ComposerActivityKind =
+  | "typing_started"
+  | "typing_paused"
+  | "draft_abandoned";
+
+export interface ComposerActivityReport {
+  activity: ComposerActivityKind;
+  surface: string;
+  conversationId?: string | null;
+  draftLength: number;
+  idleForMs?: number;
+  reason?: "cleared" | "blurred" | "conversation_switched" | "unknown";
+  occurredAt?: string;
+}
+
+/** Report composer lifecycle metadata to the agent without blocking input. */
+export function reportComposerActivity(report: ComposerActivityReport): void {
+  try {
+    const base = getElizaApiBase();
+    if (!base || typeof fetch === "undefined") return;
+    const token = getElizaApiToken();
+    void fetch(`${base}/api/interactions/composer`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({
+        activity: report.activity,
+        surface: report.surface,
+        ...(report.conversationId
+          ? { conversationId: report.conversationId }
+          : {}),
+        draftLength: report.draftLength,
+        ...(report.idleForMs !== undefined
+          ? { idleForMs: report.idleForMs }
+          : {}),
+        ...(report.reason ? { reason: report.reason } : {}),
+        occurredAt: report.occurredAt ?? new Date().toISOString(),
+      }),
+    }).catch((err) => {
+      // error-policy:J7 telemetry write must not break typing; warn keeps a dead
+      // reporting endpoint observable in the browser console.
+      logger.warn(
+        `[reportComposerActivity] composer report failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+  } catch {
+    // error-policy:J7 same guard for synchronous setup failures — telemetry
+    // must never break composer input.
+  }
+}

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -54,6 +54,10 @@ vi.mock("../../utils/clipboard", () => ({
   copyTextToClipboard: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("../../chat/report-composer-activity", () => ({
+  reportComposerActivity: vi.fn(),
+}));
+
 import * as React from "react";
 import { client } from "../../api/client";
 import type {
@@ -62,6 +66,7 @@ import type {
   ConversationMessageSearchResult,
   ImageAttachment,
 } from "../../api/client-types-chat";
+import { reportComposerActivity } from "../../chat/report-composer-activity";
 import { CHAT_PREFILL_EVENT, ELIZA_BACK_INTENT_EVENT } from "../../events";
 import {
   LAYOUT_SHIFT_INTENT_ATTR,
@@ -96,6 +101,7 @@ afterEach(() => {
   cleanup();
   resetShellSurfaceForTests();
   setViewChatBinding(null);
+  vi.mocked(reportComposerActivity).mockClear();
   vi.mocked(client.searchConversationMessages).mockReset();
   vi.mocked(Element.prototype.scrollIntoView).mockClear();
   document.getElementById("chat-message-m-hit")?.remove();
@@ -226,6 +232,75 @@ describe("ContinuousChatOverlay", () => {
     });
     expect(screen.getByLabelText("send")).toBeTruthy();
     expect(screen.queryByLabelText("talk")).toBeNull();
+  });
+
+  it("reports typing start and pause from the real composer draft", () => {
+    vi.useFakeTimers();
+    try {
+      render(<ContinuousChatOverlay controller={makeController()} />);
+      fireEvent.change(screen.getByLabelText("message"), {
+        target: { value: "hello" },
+      });
+
+      expect(reportComposerActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activity: "typing_started",
+          surface: "continuous_chat_overlay",
+          draftLength: 5,
+        }),
+      );
+      expect(reportComposerActivity).not.toHaveBeenCalledWith(
+        expect.objectContaining({ activity: "typing_paused" }),
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(1_999);
+      });
+      expect(reportComposerActivity).not.toHaveBeenCalledWith(
+        expect.objectContaining({ activity: "typing_paused" }),
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(reportComposerActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activity: "typing_paused",
+          surface: "continuous_chat_overlay",
+          draftLength: 5,
+          idleForMs: 2_000,
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reports draft_abandoned only when the user clears typed text", () => {
+    const controller = makeController();
+    render(<ContinuousChatOverlay controller={controller} />);
+    const input = screen.getByLabelText("message");
+
+    fireEvent.change(input, { target: { value: "discard me" } });
+    fireEvent.change(input, { target: { value: "" } });
+
+    expect(reportComposerActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activity: "draft_abandoned",
+        surface: "continuous_chat_overlay",
+        draftLength: 0,
+        reason: "cleared",
+      }),
+    );
+
+    vi.mocked(reportComposerActivity).mockClear();
+    fireEvent.change(input, { target: { value: "send me" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(controller.send).toHaveBeenCalledWith("send me");
+    expect(reportComposerActivity).not.toHaveBeenCalledWith(
+      expect.objectContaining({ activity: "draft_abandoned" }),
+    );
   });
 
   it("shows a disabled, no-op send control when the agent can't accept input (canSend false)", () => {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -33,6 +33,7 @@ import type {
   ImageAttachment,
 } from "../../api/client-types-chat";
 import { useComposerKeydown, useComposerPaste } from "../../chat/composer-core";
+import { reportComposerActivity } from "../../chat/report-composer-activity";
 import {
   parseSlashDraft,
   resolveClientShortcutExecution,
@@ -262,6 +263,8 @@ const MAXIMIZE_RESTORE_ZONE_VH = 0.2;
 // of resting free — so near-detent releases are deterministic + clean, and only
 // the clear gaps between detents keep the free-drag rest height.
 const SHEET_DETENT_MAGNET = 64;
+const COMPOSER_TYPING_PAUSE_MS = 2_000;
+const COMPOSER_ACTIVITY_SURFACE = "continuous_chat_overlay";
 
 // A light iOS-style impact on each detent cross. Self-contained + guarded so it
 // is a no-op off-native (and in jsdom tests) without coupling the overlay to the
@@ -1106,6 +1109,8 @@ export function ContinuousChatOverlay({
   // so submitText keeps its stable identity.
   const activeConversationIdRef = React.useRef(activeConversationId);
   activeConversationIdRef.current = activeConversationId;
+  const composerHadDraftRef = React.useRef(draft.trim().length > 0);
+  const composerPauseTimerRef = React.useRef<number | null>(null);
   // The active view can take over the composer: override the placeholder and
   // receive the live draft (e.g. Help uses the chat as its search box).
   const viewChatBinding = useViewChatBinding();
@@ -1795,6 +1800,42 @@ export function ContinuousChatOverlay({
   const listening = phase === "listening";
   const hasDraft = draft.trim().length > 0;
   const hasImages = pendingImages.length > 0;
+  React.useEffect(() => {
+    const draftLength = draft.trim().length;
+    if (composerPauseTimerRef.current !== null) {
+      window.clearTimeout(composerPauseTimerRef.current);
+      composerPauseTimerRef.current = null;
+    }
+    if (draftLength === 0) {
+      composerHadDraftRef.current = false;
+      return;
+    }
+    if (!composerHadDraftRef.current) {
+      reportComposerActivity({
+        activity: "typing_started",
+        surface: COMPOSER_ACTIVITY_SURFACE,
+        conversationId: activeConversationId,
+        draftLength,
+      });
+      composerHadDraftRef.current = true;
+    }
+    composerPauseTimerRef.current = window.setTimeout(() => {
+      reportComposerActivity({
+        activity: "typing_paused",
+        surface: COMPOSER_ACTIVITY_SURFACE,
+        conversationId: activeConversationIdRef.current,
+        draftLength: draftRef.current.trim().length,
+        idleForMs: COMPOSER_TYPING_PAUSE_MS,
+      });
+      composerPauseTimerRef.current = null;
+    }, COMPOSER_TYPING_PAUSE_MS);
+    return () => {
+      if (composerPauseTimerRef.current !== null) {
+        window.clearTimeout(composerPauseTimerRef.current);
+        composerPauseTimerRef.current = null;
+      }
+    };
+  }, [activeConversationId, draft]);
 
   // Send `text` (and optional images) through the normal chat pipeline, clearing
   // the composer. Shared by the send button and the slash menu (agent commands).
@@ -4609,10 +4650,23 @@ export function ContinuousChatOverlay({
                 rows={1}
                 value={draft}
                 onChange={(e) => {
-                  setDraft(e.target.value);
+                  const nextDraft = e.target.value;
+                  if (
+                    draft.trim().length > 0 &&
+                    nextDraft.trim().length === 0
+                  ) {
+                    reportComposerActivity({
+                      activity: "draft_abandoned",
+                      surface: COMPOSER_ACTIVITY_SURFACE,
+                      conversationId: activeConversationIdRef.current,
+                      draftLength: 0,
+                      reason: "cleared",
+                    });
+                  }
+                  setDraft(nextDraft);
                   // Mirror the live draft to the active view (Help search etc.).
-                  viewChatBinding?.onQuery?.(e.target.value);
-                  if (e.target.value.trim().length > 0) expand();
+                  viewChatBinding?.onQuery?.(nextDraft);
+                  if (nextDraft.trim().length > 0) expand();
                 }}
                 onFocus={() => {
                   // Widen out of the short-landscape compact affordance (#14173)

--- a/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts
@@ -4,6 +4,7 @@
  * verifies both the activity signal and relationship/contact recency writes.
  */
 import {
+  type ComposerActivityPayload,
   EventType,
   type IAgentRuntime,
   type MessagePayload,
@@ -552,6 +553,131 @@ describe("PresenceSignalBridgeService view-switch + reaction signals (#14689)", 
     );
     expect(runtime.unregisterEvent).toHaveBeenCalledWith(
       EventType.REACTION_RECEIVED,
+      expect.any(Function),
+    );
+  });
+});
+
+describe("PresenceSignalBridgeService composer activity signals (#14679)", () => {
+  beforeEach(() => {
+    mockState.activitySignals.length = 0;
+    vi.clearAllMocks();
+  });
+
+  function composerPayload(
+    overrides: Partial<ComposerActivityPayload> = {},
+  ): ComposerActivityPayload {
+    return {
+      runtime: {} as IAgentRuntime,
+      source: "composer-interaction",
+      activity: "typing_started",
+      surface: "continuous_chat_overlay",
+      conversationId: "conversation-1",
+      draftLength: 12,
+      occurredAt: "2026-06-01T12:00:00.000Z",
+      initiatedBy: "user",
+      ...overrides,
+    } as unknown as ComposerActivityPayload;
+  }
+
+  it("writes an active app_lifecycle signal for typing start", async () => {
+    const { runtime, handlers } = runtimeWithRelationships({});
+    await PresenceSignalBridgeService.start(runtime);
+
+    await handlers.get(EventType.USER_TYPING_STARTED)?.(
+      composerPayload() as unknown as MessagePayload,
+    );
+
+    expect(mockState.activitySignals).toHaveLength(1);
+    expect(mockState.activitySignals[0]).toMatchObject({
+      source: "app_lifecycle",
+      platform: "composer",
+      state: "active",
+      idleState: "active",
+      observedAt: "2026-06-01T12:00:00.000Z",
+      metadata: expect.objectContaining({
+        eventType: "USER_TYPING_STARTED",
+        activity: "typing_started",
+        surface: "continuous_chat_overlay",
+        conversationId: "conversation-1",
+        draftLength: 12,
+      }),
+    });
+  });
+
+  it("writes an idle signal for typing pause without draft contents", async () => {
+    const { runtime, handlers } = runtimeWithRelationships({});
+    await PresenceSignalBridgeService.start(runtime);
+
+    await handlers.get(EventType.USER_TYPING_PAUSED)?.(
+      composerPayload({
+        activity: "typing_paused",
+        idleForMs: 2000,
+        occurredAt: "2026-06-01T12:00:02.000Z",
+      }) as unknown as MessagePayload,
+    );
+
+    expect(mockState.activitySignals[0]).toMatchObject({
+      source: "app_lifecycle",
+      platform: "composer",
+      state: "idle",
+      idleState: "idle",
+      idleTimeSeconds: 2,
+      metadata: expect.objectContaining({
+        eventType: "USER_TYPING_PAUSED",
+        activity: "typing_paused",
+        idleForMs: 2000,
+      }),
+    });
+    expect(mockState.activitySignals[0]).not.toHaveProperty("text");
+    expect(mockState.activitySignals[0]).not.toHaveProperty("draft");
+  });
+
+  it("writes an idle signal for a user-cleared draft", async () => {
+    const { runtime, handlers } = runtimeWithRelationships({});
+    await PresenceSignalBridgeService.start(runtime);
+
+    await handlers.get(EventType.USER_DRAFT_ABANDONED)?.(
+      composerPayload({
+        activity: "draft_abandoned",
+        draftLength: 0,
+        reason: "cleared",
+        occurredAt: "2026-06-01T12:00:03.000Z",
+      }) as unknown as MessagePayload,
+    );
+
+    expect(mockState.activitySignals[0]).toMatchObject({
+      source: "app_lifecycle",
+      platform: "composer",
+      state: "idle",
+      metadata: expect.objectContaining({
+        eventType: "USER_DRAFT_ABANDONED",
+        activity: "draft_abandoned",
+        reason: "cleared",
+        draftLength: 0,
+      }),
+    });
+  });
+
+  it("registers and unregisters composer activity handlers", async () => {
+    const { runtime, handlers } = runtimeWithRelationships({});
+    const service = await PresenceSignalBridgeService.start(runtime);
+
+    expect(handlers.has(EventType.USER_TYPING_STARTED)).toBe(true);
+    expect(handlers.has(EventType.USER_TYPING_PAUSED)).toBe(true);
+    expect(handlers.has(EventType.USER_DRAFT_ABANDONED)).toBe(true);
+
+    await service.stop();
+    expect(runtime.unregisterEvent).toHaveBeenCalledWith(
+      EventType.USER_TYPING_STARTED,
+      expect.any(Function),
+    );
+    expect(runtime.unregisterEvent).toHaveBeenCalledWith(
+      EventType.USER_TYPING_PAUSED,
+      expect.any(Function),
+    );
+    expect(runtime.unregisterEvent).toHaveBeenCalledWith(
+      EventType.USER_DRAFT_ABANDONED,
       expect.any(Function),
     );
   });

--- a/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts
@@ -123,6 +123,9 @@ describe("PresenceSignalBridgeService relationship recency", () => {
       EventType.REACTION_RECEIVED,
       EventType.VIEW_SWITCHED,
       EventType.ACTION_STARTED,
+      EventType.USER_TYPING_STARTED,
+      EventType.USER_TYPING_PAUSED,
+      EventType.USER_DRAFT_ABANDONED,
     ]);
   });
 

--- a/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.ts
@@ -7,6 +7,7 @@
 import crypto from "node:crypto";
 import {
   type ActionEventPayload,
+  type ComposerActivityPayload,
   EventType,
   type IAgentRuntime,
   type MessagePayload,
@@ -358,6 +359,12 @@ export class PresenceSignalBridgeService extends Service {
     await this.captureActivityFromAction(payload);
   };
 
+  private readonly composerActivityHandler = async (
+    payload: ComposerActivityPayload,
+  ): Promise<void> => {
+    await this.captureActivityFromComposer(payload);
+  };
+
   static override async start(
     runtime: IAgentRuntime,
   ): Promise<PresenceSignalBridgeService> {
@@ -375,6 +382,18 @@ export class PresenceSignalBridgeService extends Service {
     runtime.registerEvent(
       EventType.ACTION_STARTED,
       service.actionStartedHandler,
+    );
+    runtime.registerEvent(
+      EventType.USER_TYPING_STARTED,
+      service.composerActivityHandler,
+    );
+    runtime.registerEvent(
+      EventType.USER_TYPING_PAUSED,
+      service.composerActivityHandler,
+    );
+    runtime.registerEvent(
+      EventType.USER_DRAFT_ABANDONED,
+      service.composerActivityHandler,
     );
     return service;
   }
@@ -399,6 +418,18 @@ export class PresenceSignalBridgeService extends Service {
     this.runtime.unregisterEvent(
       EventType.ACTION_STARTED,
       this.actionStartedHandler,
+    );
+    this.runtime.unregisterEvent(
+      EventType.USER_TYPING_STARTED,
+      this.composerActivityHandler,
+    );
+    this.runtime.unregisterEvent(
+      EventType.USER_TYPING_PAUSED,
+      this.composerActivityHandler,
+    );
+    this.runtime.unregisterEvent(
+      EventType.USER_DRAFT_ABANDONED,
+      this.composerActivityHandler,
     );
   }
 
@@ -441,6 +472,60 @@ export class PresenceSignalBridgeService extends Service {
           eventType: "ACTION_STARTED",
           actionName,
           messageId,
+          deviceId: getDeviceId(),
+        },
+      }),
+    );
+  }
+
+  private async captureActivityFromComposer(
+    payload: ComposerActivityPayload,
+  ): Promise<void> {
+    const observedAt = payload.occurredAt;
+    const observedMs = Date.parse(observedAt);
+    if (!Number.isFinite(observedMs)) {
+      return;
+    }
+    const conversationId = payload.conversationId ?? "unknown-conversation";
+    const fingerprint = `composer:${payload.activity}:${payload.surface}:${conversationId}:${observedAt}`;
+    const existing = this.recentFingerprints.get(fingerprint);
+    if (existing !== undefined && observedMs - existing < DEDUPE_WINDOW_MS) {
+      return;
+    }
+    this.recentFingerprints.set(fingerprint, observedMs);
+
+    const state =
+      payload.activity === "typing_started" ? ("active" as const) : "idle";
+    const repository = new LifeOpsRepository(this.runtime);
+    await repository.createActivitySignal(
+      createLifeOpsActivitySignal({
+        agentId: String(this.runtime.agentId),
+        source: "app_lifecycle",
+        platform: "composer",
+        state,
+        observedAt,
+        idleState: state,
+        idleTimeSeconds:
+          typeof payload.idleForMs === "number"
+            ? Math.max(0, Math.round(payload.idleForMs / 1000))
+            : 0,
+        onBattery: null,
+        health: null,
+        metadata: {
+          eventType:
+            payload.activity === "typing_started"
+              ? "USER_TYPING_STARTED"
+              : payload.activity === "typing_paused"
+                ? "USER_TYPING_PAUSED"
+                : "USER_DRAFT_ABANDONED",
+          activity: payload.activity,
+          surface: payload.surface,
+          conversationId,
+          draftLength: payload.draftLength,
+          ...(payload.idleForMs !== undefined
+            ? { idleForMs: payload.idleForMs }
+            : {}),
+          ...(payload.reason ? { reason: payload.reason } : {}),
           deviceId: getDeviceId(),
         },
       }),

--- a/plugins/plugin-personal-assistant/src/providers/activity-profile.ts
+++ b/plugins/plugin-personal-assistant/src/providers/activity-profile.ts
@@ -27,7 +27,9 @@ import {
 import { resolveCurrentBucket } from "../activity-profile/analyzer.js";
 import { PROACTIVE_TASK_TAGS } from "../activity-profile/proactive-worker.js";
 import { readProfileFromMetadata } from "../activity-profile/service.js";
+import type { LifeOpsActivitySignal } from "../contracts/index.js";
 import { resolveDefaultTimeZone } from "../lifeops/defaults.js";
+import { LifeOpsRepository } from "../lifeops/repository.js";
 import {
   buildUtcDateFromLocalParts,
   getLocalDateKey,
@@ -68,6 +70,87 @@ function formatTopApps(apps: ActivityAppBreakdown[]): string {
     .slice(0, ACTIVITY_USAGE_TOP_APPS)
     .map((app) => `${app.appName} ${formatDuration(app.totalMs)}`)
     .join(", ");
+}
+
+interface LatestComposerActivity {
+  activity: string;
+  surface: string;
+  conversationId: string | null;
+  draftLength: number | null;
+  observedAtMs: number;
+  reason: string | null;
+}
+
+function readMetadataString(
+  metadata: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = metadata[key];
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function readMetadataNumber(
+  metadata: Record<string, unknown>,
+  key: string,
+): number | null {
+  const value = metadata[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function mapComposerSignal(
+  signal: LifeOpsActivitySignal,
+): LatestComposerActivity | null {
+  if (signal.platform !== "composer" || !isRecord(signal.metadata)) {
+    return null;
+  }
+  const activity = readMetadataString(signal.metadata, "activity");
+  const observedAtMs = Date.parse(signal.observedAt);
+  if (!activity || !Number.isFinite(observedAtMs)) {
+    return null;
+  }
+  return {
+    activity,
+    surface: readMetadataString(signal.metadata, "surface") ?? "composer",
+    conversationId: readMetadataString(signal.metadata, "conversationId"),
+    draftLength: readMetadataNumber(signal.metadata, "draftLength"),
+    observedAtMs,
+    reason: readMetadataString(signal.metadata, "reason"),
+  };
+}
+
+function formatComposerActivityContext(
+  activity: LatestComposerActivity,
+  now: Date,
+): string {
+  const ago = formatAgo(now.getTime() - activity.observedAtMs);
+  const draftPart =
+    activity.draftLength !== null ? `, ${activity.draftLength} chars` : "";
+  if (activity.activity === "typing_started") {
+    return `composer active ${ago}${draftPart}`;
+  }
+  if (activity.activity === "typing_paused") {
+    return `composer paused ${ago}${draftPart}`;
+  }
+  return `composer draft cleared ${ago}`;
+}
+
+async function readLatestComposerActivity(args: {
+  runtime: IAgentRuntime;
+  now: Date;
+}): Promise<LatestComposerActivity | null> {
+  const repository = new LifeOpsRepository(args.runtime);
+  const sinceAt = new Date(args.now.getTime() - 30 * 60_000).toISOString();
+  const signals = await repository.listActivitySignals(
+    String(args.runtime.agentId),
+    { sinceAt, limit: 25 },
+  );
+  for (const signal of signals) {
+    const activity = mapComposerSignal(signal);
+    if (activity) return activity;
+  }
+  return null;
 }
 
 export function formatActivityUsageContext(args: {
@@ -183,6 +266,12 @@ export const activityProfileProvider: Provider = {
         sessionCount: number;
       }>,
       userTodayAppUsageTotalMs: 0,
+      userComposerActivity: null,
+      userComposerSurface: null,
+      userComposerConversationId: null,
+      userComposerDraftLength: null,
+      userComposerObservedAt: null,
+      userComposerReason: null,
     };
     let values: ActivityProviderValues = { ...baseValues };
     let data: ActivityProviderData = {};
@@ -279,6 +368,40 @@ export const activityProfileProvider: Provider = {
           err: error instanceof Error ? error : undefined,
         },
         "[activity-profile] Failed to read proactive task metadata; falling back to time-bucket-only context.",
+      );
+    }
+
+    try {
+      const composerActivity = await readLatestComposerActivity({
+        runtime,
+        now,
+      });
+      if (composerActivity) {
+        parts.push(formatComposerActivityContext(composerActivity, now));
+        values = {
+          ...values,
+          userComposerActivity: composerActivity.activity,
+          userComposerSurface: composerActivity.surface,
+          userComposerConversationId: composerActivity.conversationId,
+          userComposerDraftLength: composerActivity.draftLength,
+          userComposerObservedAt: composerActivity.observedAtMs,
+          userComposerReason: composerActivity.reason,
+        };
+        data = {
+          ...data,
+          composerActivity,
+        };
+      }
+    } catch (error) {
+      // error-policy:J4 explicit provider degrade — composer context is helpful
+      // but absence must not suppress the rest of the activity profile.
+      logger.warn(
+        {
+          boundary: "activity_profile",
+          operation: "provider_composer_activity_read",
+          err: error instanceof Error ? error : undefined,
+        },
+        "[activity-profile] Failed to read composer activity context; continuing without composer context.",
       );
     }
 

--- a/plugins/plugin-personal-assistant/test/activity-profile-provider.test.ts
+++ b/plugins/plugin-personal-assistant/test/activity-profile-provider.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   hasOwnerAccess: vi.fn(),
   getActivityReportBetween: vi.fn(),
   getLatestForegroundActivity: vi.fn(),
+  listActivitySignals: vi.fn(),
   logger: {
     debug: vi.fn(),
     warn: vi.fn(),
@@ -40,6 +41,14 @@ vi.mock("../src/activity-profile/service.js", () => ({
 vi.mock("../src/activity-profile/activity-tracker-reporting.js", () => ({
   getActivityReportBetween: mocks.getActivityReportBetween,
   getLatestForegroundActivity: mocks.getLatestForegroundActivity,
+}));
+
+vi.mock("../src/lifeops/repository.js", () => ({
+  LifeOpsRepository: class LifeOpsRepository {
+    async listActivitySignals(...args: unknown[]): Promise<unknown> {
+      return mocks.listActivitySignals(...args);
+    }
+  },
 }));
 
 import {
@@ -97,6 +106,7 @@ describe("activityProfileProvider app-usage context", () => {
       observedAtMs: Date.parse("2026-01-15T18:00:00.000Z"),
       activeMs: 1_800_000,
     });
+    mocks.listActivitySignals.mockReset().mockResolvedValue([]);
     mocks.logger.debug.mockReset();
     mocks.logger.warn.mockReset();
   });
@@ -190,6 +200,56 @@ describe("activityProfileProvider app-usage context", () => {
     expect(result).toEqual({ text: "", values: {}, data: {} });
     expect(mocks.getActivityReportBetween).not.toHaveBeenCalled();
     expect(mocks.getLatestForegroundActivity).not.toHaveBeenCalled();
+    expect(mocks.listActivitySignals).not.toHaveBeenCalled();
+  });
+
+  it("injects latest composer activity without draft text", async () => {
+    mocks.listActivitySignals.mockResolvedValueOnce([
+      {
+        id: "composer-signal-1",
+        agentId: "agent-activity",
+        source: "app_lifecycle",
+        platform: "composer",
+        state: "idle",
+        observedAt: "2026-01-15T18:29:00.000Z",
+        idleState: "idle",
+        idleTimeSeconds: 2,
+        onBattery: null,
+        health: null,
+        metadata: {
+          eventType: "USER_TYPING_PAUSED",
+          activity: "typing_paused",
+          surface: "continuous_chat_overlay",
+          conversationId: "conversation-1",
+          draftLength: 19,
+          idleForMs: 2000,
+        },
+        createdAt: "2026-01-15T18:29:00.100Z",
+      },
+    ]);
+
+    const result = await activityProfileProvider.get(
+      makeRuntime() as never,
+      makeMessage() as never,
+      {} as never,
+    );
+
+    expect(result.text).toContain("composer paused 1m ago, 19 chars");
+    expect(result.values).toMatchObject({
+      userComposerActivity: "typing_paused",
+      userComposerSurface: "continuous_chat_overlay",
+      userComposerConversationId: "conversation-1",
+      userComposerDraftLength: 19,
+      userComposerObservedAt: Date.parse("2026-01-15T18:29:00.000Z"),
+      userComposerReason: null,
+    });
+    expect(result.data?.composerActivity).toEqual(
+      expect.objectContaining({
+        activity: "typing_paused",
+        draftLength: 19,
+      }),
+    );
+    expect(JSON.stringify(result)).not.toContain("what the user typed");
   });
 
   it("keeps base context when app usage read fails", async () => {


### PR DESCRIPTION
## Summary

Fixes #14679.

- Adds first-class core runtime events for composer lifecycle: `USER_TYPING_STARTED`, `USER_TYPING_PAUSED`, and `USER_DRAFT_ABANDONED`.
- Extends `/api/interactions/*` with `POST /api/interactions/composer`, validating metadata-only payloads and emitting runtime events without ever accepting draft text.
- Wires the continuous chat overlay to report draft start, two-second typing pause, and user-cleared drafts while avoiding false `draft_abandoned` on successful sends.
- Persists composer activity through the existing LifeOps `app_lifecycle` activity-signal path and exposes the latest composer state through the `activity-profile` provider (`userComposer*` values).
- Preserves the current passive presence bridge semantics from `develop`: reaction events still use hashed sender/conversation metadata, agent self-reactions are ignored, and view switches stay on the `app_view` activity path.

## Verification

- `bun install --frozen-lockfile --ignore-scripts`
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/cloud/routing build`
- `bun run --cwd packages/contracts build`
- `bun run --cwd packages/logger build`
- `bunx biome check packages/core/src/types/events.ts packages/agent/src/api/interactions-routes.ts packages/agent/src/api/interactions-routes.test.ts packages/agent/src/api/server-lazy-routes.ts packages/ui/src/chat/report-composer-activity.ts packages/ui/src/chat/report-composer-activity.test.ts packages/ui/src/components/shell/ContinuousChatOverlay.tsx packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.ts plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts plugins/plugin-personal-assistant/src/providers/activity-profile.ts plugins/plugin-personal-assistant/test/activity-profile-provider.test.ts`
- `git diff --check`
- `bun run audit:error-policy-ratchet --report`
- `bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/api/interactions-routes.test.ts` - 14 passed
- `bunx vitest run --config vitest.config.ts src/chat/report-composer-activity.test.ts src/components/shell/ContinuousChatOverlay.test.tsx` from `packages/ui` - 160 passed
- `bun run --cwd plugins/plugin-personal-assistant test src/activity-profile/presence-signal-bridge-service.test.ts` - 19 passed
- `bunx vitest run --config vitest.config.ts src/activity-profile/presence-signal-bridge-service.test.ts test/activity-profile-provider.test.ts` from `plugins/plugin-personal-assistant` - 24 passed
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core build:node`
- `bun run --cwd plugins/plugin-personal-assistant build:js` - passed; duplicate-member warning grep found no `Duplicate member`/`WARN` lines
- `bun run --cwd plugins/plugin-personal-assistant build:types`

## Typecheck Caveats

- `bun run --cwd packages/agent typecheck` still fails on existing unrelated baseline issues: optional plugin module declarations such as `@elizaos/plugin-app-control` / `@elizaos/plugin-streaming`, existing room type casts, and `packages/ui/src/components/settings/settings-sections.ts`.
- `bun run --cwd packages/ui typecheck` still fails on existing unrelated baseline issues in todo widget tests, settings sections, startup phase poll tests, widget cert exports, and voice selftest casts.
- `bun run --cwd plugins/plugin-personal-assistant typecheck` still fails on existing optional-package/export baseline issues. Focused tests and build lanes above cover the changed composer/presence/provider paths.

## Evidence

<!-- evidence-row:before-screenshots --> N/A - telemetry-only composer reporting; no rendered layout, copy, color, or interaction affordance changed.
<!-- evidence-row:after-screenshots --> N/A - telemetry-only composer reporting; no rendered layout, copy, color, or interaction affordance changed.
<!-- evidence-row:walkthrough-video --> N/A - no visible UI flow changed; targeted jsdom overlay tests drive typing, pause, clear, and send behavior.
<!-- evidence-row:backend-logs --> N/A - no server process was run; focused route tests verify `/api/interactions/composer` validation and runtime event emission.
<!-- evidence-row:frontend-logs --> N/A - no browser session was recorded; focused UI tests verify fetch payloads and telemetry failure handling without draft text.
<!-- evidence-row:llm-trajectory --> N/A - deterministic telemetry/provider context change; no model, prompt, planner, or action behavior changed.
<!-- evidence-row:domain-artifacts --> N/A - no persistent artifact was captured outside tests; focused LifeOps tests assert persisted `app_lifecycle` composer activity signals and provider values (`userComposer*`), including no draft text persistence.
