### PR TITLE
fix(lifeops): remove duplicate presence bridge handlers

### DIFF
--- a/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts
@@ -530,6 +530,7 @@ describe("PresenceSignalBridgeService view-switch + reaction signals (#14689)", 
         message: {
           ...messagePayload().message,
           entityId: AGENT_ID,
+          metadata: {},
         },
       }),
     );

--- a/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.ts
@@ -376,11 +376,6 @@ export class PresenceSignalBridgeService extends Service {
       EventType.ACTION_STARTED,
       service.actionStartedHandler,
     );
-    runtime.registerEvent(EventType.VIEW_SWITCHED, service.viewSwitchedHandler);
-    runtime.registerEvent(
-      EventType.REACTION_RECEIVED,
-      service.reactionReceivedHandler,
-    );
     return service;
   }
 
@@ -404,14 +399,6 @@ export class PresenceSignalBridgeService extends Service {
     this.runtime.unregisterEvent(
       EventType.ACTION_STARTED,
       this.actionStartedHandler,
-    );
-    this.runtime.unregisterEvent(
-      EventType.VIEW_SWITCHED,
-      this.viewSwitchedHandler,
-    );
-    this.runtime.unregisterEvent(
-      EventType.REACTION_RECEIVED,
-      this.reactionReceivedHandler,
     );
   }
 


### PR DESCRIPTION
## Summary

Removes the duplicate presence bridge handler members that landed on `develop` after the passive presence work merged. The class now has one registration path for `VIEW_SWITCHED` and `REACTION_RECEIVED`, keeping the richer implementation that records app-view metadata and handles both message-shaped and metadata-shaped reactions.

## Verification

- `bun install --frozen-lockfile --ignore-scripts`
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/cloud/routing build`
- `bun run --cwd packages/contracts build`
- `bun run --cwd plugins/plugin-personal-assistant test src/activity-profile/presence-signal-bridge-service.test.ts` - 15 passed
- `bun run --cwd plugins/plugin-personal-assistant build:js` - passed; `rg "Duplicate member|WARN" /tmp/presence-build-js.log` found no duplicate-member warnings
- `bun run --cwd plugins/plugin-personal-assistant build:types`
- `bunx @biomejs/biome check plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.ts plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts`
- `git diff --check origin/develop...HEAD -- plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.ts plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts`
- `bun run audit:error-policy-ratchet --report`

Known package-wide gate:

- `bun run --cwd plugins/plugin-personal-assistant typecheck` still fails on existing unresolved workspace/module declarations and unrelated strict errors outside this diff, before reaching this change.

## Evidence

<!-- evidence-row:before-screenshots --> N/A - backend/service cleanup; no rendered UI changed.
<!-- evidence-row:after-screenshots --> N/A - backend/service cleanup; no rendered UI changed.
<!-- evidence-row:walkthrough-video --> N/A - backend/service cleanup; no interactive UI flow changed.
<!-- evidence-row:backend-logs --> N/A - no server process was run; local package test and build output above prove the handler path and absence of duplicate-member build warnings.
<!-- evidence-row:frontend-logs --> N/A - no browser UI or network path changed.
<!-- evidence-row:llm-trajectory --> N/A - deterministic event bridge cleanup; no model, prompt, or planner behavior changed.
<!-- evidence-row:domain-artifacts --> N/A - no persistent domain artifact is produced by this cleanup; focused test asserts view-switch and reaction activity signal artifacts, including app-view metadata and self-reaction filtering.
