### PR TITLE
fix(cloud): degrade Cerebras response_format rejection

### DIFF
--- a/packages/cloud/shared/src/lib/providers/cerebras-direct.test.ts
+++ b/packages/cloud/shared/src/lib/providers/cerebras-direct.test.ts
@@ -1,0 +1,103 @@
+// Exercises Cerebras direct request-shaping without hitting the network.
+import { afterEach, describe, expect, test } from "bun:test";
+import type { OpenAIChatRequest } from "./types";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+const { CerebrasDirectProvider } = await import("./cerebras-direct");
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+function body(init: RequestInit | undefined): Record<string, unknown> {
+  return JSON.parse(String(init?.body)) as Record<string, unknown>;
+}
+
+function unsupportedResponseFormat(): Response {
+  return new Response(
+    JSON.stringify({
+      error: {
+        message: "Unsupported parameter: response_format",
+        type: "invalid_request_error",
+        code: "unsupported_parameter",
+      },
+    }),
+    { status: 400, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+function badRequest(message = "bad request"): Response {
+  return new Response(
+    JSON.stringify({
+      error: {
+        message,
+        type: "invalid_request_error",
+        code: "invalid_request_error",
+      },
+    }),
+    { status: 400, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+function ok(model: unknown): Response {
+  return new Response(
+    JSON.stringify({
+      id: "chatcmpl-cerebras-test",
+      object: "chat.completion",
+      created: 0,
+      model,
+      choices: [
+        {
+          index: 0,
+          message: { role: "assistant", content: "ok" },
+          finish_reason: "stop",
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+const request: OpenAIChatRequest = {
+  model: "gemma-4-31b",
+  messages: [{ role: "user", content: "return json" }],
+  response_format: { type: "json_object" },
+};
+
+describe("CerebrasDirectProvider response_format fallback", () => {
+  test("retries once without response_format and marks the degraded response", async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+    globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+      const sent = body(init);
+      bodies.push(sent);
+      return bodies.length === 1 ? unsupportedResponseFormat() : ok(sent.model);
+    }) as typeof fetch;
+
+    const provider = new CerebrasDirectProvider("test-key");
+    const response = await provider.chatCompletions(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-eliza-response-format")).toBe("dropped");
+    expect(bodies).toHaveLength(2);
+    expect(bodies[0]?.response_format).toEqual({ type: "json_object" });
+    expect(bodies[1]?.response_format).toBeUndefined();
+    expect(bodies.map((sent) => sent.model)).toEqual(["gemma-4-31b", "gemma-4-31b"]);
+  });
+
+  test("does not retry unrelated 400s", async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+    globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+      bodies.push(body(init));
+      return badRequest("messages must not be empty");
+    }) as typeof fetch;
+
+    const provider = new CerebrasDirectProvider("test-key");
+    await expect(provider.chatCompletions(request)).rejects.toMatchObject({
+      status: 400,
+    });
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]?.response_format).toEqual({ type: "json_object" });
+  });
+});

--- a/packages/cloud/shared/src/lib/providers/cerebras-direct.ts
+++ b/packages/cloud/shared/src/lib/providers/cerebras-direct.ts
@@ -14,6 +14,7 @@ import type {
   AIProvider,
   OpenAIChatRequest,
   OpenAIEmbeddingsRequest,
+  ProviderHttpError,
   ProviderRequestOptions,
 } from "./types";
 
@@ -23,6 +24,29 @@ const CEREBRAS_LABEL: ProviderLabel = {
   requestFailedCode: "cerebras_request_failed",
   timeoutCode: "cerebras_timeout",
 };
+
+const RESPONSE_FORMAT_DROPPED_HEADER = "x-eliza-response-format";
+
+function isResponseFormatUnsupported(error: unknown): error is ProviderHttpError {
+  if (!error || typeof error !== "object" || !("status" in error)) {
+    return false;
+  }
+  const httpError = error as ProviderHttpError;
+  if (httpError.status !== 400) return false;
+  const message = httpError.error?.message ?? "";
+  const code = httpError.error?.code ?? "";
+  return /response_format/i.test(`${message} ${code}`);
+}
+
+function withResponseFormatDroppedHeader(response: Response): Response {
+  const headers = new Headers(response.headers);
+  headers.set(RESPONSE_FORMAT_DROPPED_HEADER, "dropped");
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
 
 export class CerebrasDirectProvider implements AIProvider {
   name = "cerebras";
@@ -65,16 +89,41 @@ export class CerebrasDirectProvider implements AIProvider {
       messageCount: request.messages.length,
     });
 
-    return await this.fetchWithTimeout(
-      `${this.baseUrl}/chat/completions`,
-      {
-        method: "POST",
-        headers: this.getHeaders(),
-        body: JSON.stringify(body),
-        signal: options?.signal,
-      },
-      options?.timeoutMs,
-    );
+    try {
+      return await this.fetchWithTimeout(
+        `${this.baseUrl}/chat/completions`,
+        {
+          method: "POST",
+          headers: this.getHeaders(),
+          body: JSON.stringify(body),
+          signal: options?.signal,
+        },
+        options?.timeoutMs,
+      );
+    } catch (error) {
+      // error-policy:J4 explicit provider degrade — Cerebras can reject
+      // OpenAI-compatible structured-output hints; retry once without that hint
+      // and mark the response so callers know upstream did not enforce it.
+      if (!request.response_format || !isResponseFormatUnsupported(error)) {
+        throw error;
+      }
+      const { response_format: _responseFormat, ...degradedBody } = body;
+      logger.warn("[Cerebras Direct] Upstream rejected response_format; retrying once without it", {
+        model: degradedBody.model,
+        responseFormatType: request.response_format.type,
+      });
+      const degradedResponse = await this.fetchWithTimeout(
+        `${this.baseUrl}/chat/completions`,
+        {
+          method: "POST",
+          headers: this.getHeaders(),
+          body: JSON.stringify(degradedBody),
+          signal: options?.signal,
+        },
+        options?.timeoutMs,
+      );
+      return withResponseFormatDroppedHeader(degradedResponse);
+    }
   }
 
   async embeddings(_request: OpenAIEmbeddingsRequest): Promise<Response> {


### PR DESCRIPTION
Fixes #14986.

## Summary
- Retries Cerebras direct chat completions once without `response_format` when upstream returns a 400 that specifically names `response_format`.
- Marks the successful degraded response with `x-eliza-response-format: dropped` so clients can detect that structured-output enforcement was not honored upstream.
- Leaves unrelated 400s fail-fast and covered by a negative test.

## Verification
- `ulimit -n 2048; bun test src/lib/providers/cerebras-direct.test.ts` from `packages/cloud/shared` in the installed checkout: 2 passed, 9 expects.
- `bunx @biomejs/biome check packages/cloud/shared/src/lib/providers/cerebras-direct.ts packages/cloud/shared/src/lib/providers/cerebras-direct.test.ts`: passed.
- `git diff --check`: passed in the clean branch worktree.
- Full monorepo `bun run verify`: not run in this dirty local checkout; focused provider coverage is attached here and CI should run the branch.

## Evidence
<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - backend provider request/response behavior only; no rendered UI changed.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - backend provider request/response behavior only; no rendered UI changed.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user-clickable browser/native flow changed.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - no long-running backend server was started; focused Bun provider test output is in Verification and shows the degrade log plus both assertions passing.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend client code changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no prompt/model-selection/action-planner behavior changed; this is an OpenAI-compatible gateway/provider retry contract. Live upstream evidence is on #14986 from the reporting lane.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - no persisted DB/memory/wallet artifact is produced; deterministic provider test captures the outbound request bodies and response header contract in memory.