### PR TITLE
fix(lifeops): conform check-in dispatch result to DispatchResult (#14702 follow-up)

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
@@ -2948,7 +2948,6 @@ export class RemindersDomain {
           return {
             ok: true,
             messageId: `assistant-stream:${args.reportId}`,
-            channelKey: "in_app",
           };
         }
         lastFailure = {
@@ -2991,11 +2990,7 @@ export class RemindersDomain {
         },
       });
       if (result.ok) {
-        return {
-          ...result,
-          target: result.target ?? target,
-          channelKey: result.channelKey ?? candidate.channel,
-        };
+        return result;
       }
       lastFailure = result;
     }


### PR DESCRIPTION
## Problem

`#14968` (merged) added `dispatchCheckinReport` to `reminders-service.ts`, but its success returns don't conform to the `DispatchResult` contract:

- in-app branch returns `{ ok: true, messageId, channelKey: "in_app" }`
- connector branch returns `{ ...result, target: result.target ?? target, channelKey: result.channelKey ?? candidate.channel }`

`DispatchResult`'s success variant is `{ ok: true; messageId?: string }` (see `plugins/plugin-scheduling/src/dispatch-types.ts` and the built `dist/dispatch-types.d.ts`). `channelKey`/`target` are not on it, so this produced four errors in the package typecheck:

```
reminders-service.ts(2951): TS2353 'channelKey' does not exist in type '{ ok: true; messageId?: string }'
reminders-service.ts(2996): TS2353 'target' does not exist ...
reminders-service.ts(2996): TS2339 Property 'target' does not exist ...
reminders-service.ts(2997): TS2339 Property 'channelKey' does not exist ...
```

The sole caller (`processSleepCycleCheckins`) only reads `.ok`, `.reason`, and `.message`, so `channelKey`/`target` were dead fields.

## Fix

Return the plain conformant `DispatchResult`:
- in-app: `{ ok: true, messageId }`
- connector: `return result;` (already `DispatchResult` narrowed to `ok: true`)

No behavior change — the caller reads none of the removed fields.

## Verification

- `tsc --noEmit -p tsconfig.build.json` — the four `reminders-service.ts` errors are gone (pre-existing baseline errors in `runtime-wiring.ts`/`scheduler.ts`/`telemetry-mapping.ts` are untouched and out of scope).
- `vitest run reminders-service.checkin-chips.test.ts` — 4/4 pass (deliver-before-persist behavior unchanged).
- `biome check` on the touched file — clean.

Evidence rows N/A: backend service-layer typing fix; no UI/model/prompt/native surface. Behavior is pinned by the deterministic dispatch suite above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)