### PR TITLE
fix(#14910): align SETTINGS voice VAD default with capture default

### DIFF
--- a/plugins/plugin-app-control/src/actions/settings.test.ts
+++ b/plugins/plugin-app-control/src/actions/settings.test.ts
@@ -12,9 +12,11 @@ import {
 	SETTINGS_NON_CATALOG_SECTION_META,
 	SETTINGS_SECTION_META,
 } from "@elizaos/ui/components/settings/settings-section-meta";
+import { DEFAULT_LOCAL_ASR_AUTO_STOP } from "@elizaos/ui/voice/local-asr-capture";
 import { describe, expect, it, vi } from "vitest";
 import {
 	createSettingsAction,
+	DEFAULT_VOICE_SETTINGS_PREFS,
 	parseBooleanValue,
 	parseSettingsRequest,
 	resolveSectionId,
@@ -579,6 +581,87 @@ describe("SETTINGS action: set on an owned route section", () => {
 		expect(routeFetch).toHaveBeenCalledTimes(2);
 		expect(result?.success).toBe(false);
 		expect(texts.join(" ")).toContain("config save failed");
+	});
+
+	// #14910: the SETTINGS voice write is the semantic twin of the Voice UI. Its
+	// defaults are what a partial/empty `messages.voice` config gets filled in
+	// with, so they must equal the values the running capture path uses with no
+	// stored override — otherwise a chat write persists a different VAD
+	// sensitivity than the Voice UI applies. Pin against the canonical constant so
+	// any future drift fails here instead of silently diverging.
+	it("keeps voice VAD defaults in sync with the canonical capture defaults", () => {
+		expect(DEFAULT_VOICE_SETTINGS_PREFS.vadAutoStop).toEqual({
+			silenceMs: DEFAULT_LOCAL_ASR_AUTO_STOP.silenceMs,
+			speechRmsThreshold: DEFAULT_LOCAL_ASR_AUTO_STOP.speechRmsThreshold,
+		});
+	});
+
+	it("fills a partial voice config's missing RMS with the capture default when setting silence", async () => {
+		// Stored config has a continuous mode but no vadAutoStop — the write must
+		// seed the missing speechRmsThreshold with the canonical capture default
+		// (0.003), not a value that diverges from the Voice UI.
+		const routeFetch = vi.fn<SettingsRouteFetch>(async (request) => {
+			if (request.method === "GET") {
+				return {
+					ok: true,
+					data: { messages: { voice: { continuous: "vad-gated" } } },
+				};
+			}
+			return { ok: true };
+		});
+		const { result } = await invoke(
+			{ action: "set", section: "voice", key: "silence-ms", value: "1200" },
+			routeFetch,
+		);
+		expect(routeFetch).toHaveBeenNthCalledWith(2, {
+			method: "PUT",
+			path: "/api/config",
+			body: {
+				messages: {
+					voice: {
+						continuous: "vad-gated",
+						vadAutoStop: {
+							silenceMs: 1200,
+							speechRmsThreshold:
+								DEFAULT_LOCAL_ASR_AUTO_STOP.speechRmsThreshold,
+						},
+					},
+				},
+			},
+		});
+		expect(result?.success).toBe(true);
+	});
+
+	it("fills an empty voice config's missing silence with the capture default when setting RMS", async () => {
+		// Empty `messages` — setting only the RMS must seed the missing silenceMs
+		// with the canonical capture default (900ms) so the twin stays aligned.
+		const routeFetch = vi.fn<SettingsRouteFetch>(async (request) => {
+			if (request.method === "GET") {
+				return { ok: true, data: { messages: {} } };
+			}
+			return { ok: true };
+		});
+		const { result, texts } = await invoke(
+			{ action: "set", section: "voice", key: "rms", value: "0.01" },
+			routeFetch,
+		);
+		expect(routeFetch).toHaveBeenNthCalledWith(2, {
+			method: "PUT",
+			path: "/api/config",
+			body: {
+				messages: {
+					voice: {
+						continuous: "off",
+						vadAutoStop: {
+							silenceMs: DEFAULT_LOCAL_ASR_AUTO_STOP.silenceMs,
+							speechRmsThreshold: 0.01,
+						},
+					},
+				},
+			},
+		});
+		expect(result?.success).toBe(true);
+		expect(texts.join(" ")).toContain("speech threshold is 0.01");
 	});
 
 	it("dispatches permissions shell off through the backend route", async () => {

--- a/plugins/plugin-app-control/src/actions/settings.ts
+++ b/plugins/plugin-app-control/src/actions/settings.ts
@@ -673,11 +673,22 @@ const VOICE_CONTINUOUS_ALIASES: ReadonlyMap<string, VoiceContinuousMode> =
 		["on", "always-on"],
 	]);
 
-const DEFAULT_VOICE_SETTINGS_PREFS: VoiceSettingsPrefs = {
+// These defaults fill in a partial/empty `messages.voice` config before it is
+// written back through /api/config, so they MUST equal the values the running
+// capture path uses when it has no stored override — `DEFAULT_LOCAL_ASR_AUTO_STOP`
+// in @elizaos/ui (silenceMs 900, speechRmsThreshold 0.003), which is also what
+// the Voice settings UI (`DEFAULT_VAD_AUTO_STOP`/`DEFAULT_VAD_AUTO_STOP_PREFS`)
+// seeds from. Any other value here would let a chat-issued voice SETTINGS write
+// (e.g. "set voice silence to 1200") silently persist a *different* VAD
+// sensitivity than the Voice UI applies, so the two twins diverge (#14910). The
+// literals are duplicated rather than imported because this server action must
+// not pull the browser capture graph into its bundle; the drift is caught
+// mechanically by a test that imports the canonical constant.
+export const DEFAULT_VOICE_SETTINGS_PREFS: VoiceSettingsPrefs = {
 	continuous: "off",
 	vadAutoStop: {
 		silenceMs: 900,
-		speechRmsThreshold: 0.006,
+		speechRmsThreshold: 0.003,
 	},
 };
 

--- a/plugins/plugin-app-control/vitest.config.ts
+++ b/plugins/plugin-app-control/vitest.config.ts
@@ -104,6 +104,14 @@ export default defineConfig({
 					"components/settings/settings-section-meta.ts",
 				),
 			},
+			// Canonical VAD capture defaults, resolved to source so the settings
+			// drift-guard test can assert the SETTINGS voice defaults never diverge
+			// from what the running capture path uses. Load-safe: the module only
+			// imports a pure helper and touches browser globals inside functions.
+			{
+				find: "@elizaos/ui/voice/local-asr-capture",
+				replacement: path.join(uiSrc, "voice/local-asr-capture.ts"),
+			},
 			{
 				find: "@elizaos/tui",
 				replacement: path.join(tuiSrc, "index.ts"),


### PR DESCRIPTION
## What

`SETTINGS section=voice` (the chat-write semantic twin of the Voice settings UI, #14369) defaulted its VAD end-of-turn sensitivity to `speechRmsThreshold: 0.006`, while the running capture path and the Voice UI both default to `DEFAULT_LOCAL_ASR_AUTO_STOP.speechRmsThreshold === 0.003` (which `DEFAULT_VAD_AUTO_STOP` / `DEFAULT_VAD_AUTO_STOP_PREFS` also seed from).

- Aligns `DEFAULT_VOICE_SETTINGS_PREFS.vadAutoStop.speechRmsThreshold` to `0.003` (`silenceMs 900` already matched).
- Documents why the literals are duplicated rather than imported: the server-side action must not pull the browser capture graph (`local-asr-capture`) into its bundle.
- Exports `DEFAULT_VOICE_SETTINGS_PREFS` and adds a **drift-guard test** that imports the canonical `DEFAULT_LOCAL_ASR_AUTO_STOP` and asserts equality, so any future divergence fails CI instead of silently persisting a different VAD sensitivity than the Voice UI.
- Adds two behavioral tests for the partial/empty `messages.voice` path (set only silence → RMS filled with `0.003`; set only RMS on empty config → silence filled with `900`).

## Why

This is the concrete residual defect that reopened #14910 after #14952 merged. When a user issues a chat voice write against a partial/empty `messages.voice` config (e.g. "set voice silence to 1200"), the read-modify-write fills the missing `speechRmsThreshold` with this default and persists it — so the chat twin wrote `0.006` where the Voice UI uses `0.003`, diverging the two twins the #14369 audit requires to stay aligned.

Closes #14910

## Scope / follow-up

The reopen comment also noted that the SETTINGS write persists `messages.voice` via `/api/config` but does not hot-apply to the already-running shell's local mirrors (`loadVadAutoStop()` / `loadContinuousChatMode()`), which `VoiceSectionMount` seeds on mount. That is a distinct **client-side** runtime-application concern (a server action cannot write the client's localStorage mirror; it needs a broadcast listener on the capture hot path) and is out of scope for this default/partial-config fix. Flagging for the reviewer in case it should be tracked as its own issue.

## Evidence

<details>
<summary>Scoped tests — <code>plugin-app-control</code> settings action (84 passed)</summary>

```
$ bun run --cwd plugins/plugin-app-control test src/actions/settings.test.ts
 Test Files  1 passed (1)
      Tests  84 passed (84)
```
</details>

<details>
<summary>Drift guard is real (negative check) — reverting default to 0.006 fails the guard + partial-config test</summary>

```
# temporarily set DEFAULT_VOICE_SETTINGS_PREFS.vadAutoStop.speechRmsThreshold = 0.006
 ❯ src/actions/settings.test.ts (84 tests | 2 failed)
     × keeps voice VAD defaults in sync with the canonical capture defaults
     × fills a partial voice config's missing RMS with the capture default when setting silence
 Tests  2 failed | 82 passed (84)
# restored to 0.003 → 84 passed
```
</details>

<details>
<summary>Typecheck + Biome (changed files)</summary>

```
$ bun run --cwd plugins/plugin-app-control typecheck   # tsgo --noEmit — clean
$ bunx @biomejs/biome check settings.ts settings.test.ts vitest.config.ts
Checked 3 files in 81ms. No fixes applied.
```
</details>

- **Real-LLM trajectory:** N/A — deterministic read-modify-write of a config default; no model/prompt/planner behavior changed. The route payload construction and partial/empty-config fill are covered by focused action tests.
- **App visual audit / screenshots / video:** N/A — no rendered UI pixels change; this is a server-side default value and its test coverage. The Voice UI (`VoiceSection`) already renders `0.003` from the canonical constant this now matches.
- **Backend/frontend logs:** N/A — no new runtime log path; the change is a constant + tests.
