### PR TITLE
fix(pwa): reclaim background layers + safe-area floor to true physical bottom (kill launch-bg bottom bar; unblock chat taps)

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2725,6 +2725,16 @@ export function App() {
               // very bottom edge; opaque dark elsewhere as the FOUC guard.
               renderSharedAppBackground ? "bg-transparent" : "bg-bg",
             )}
+            // BOTTOM-BAR ROOT CAUSE (device r5): this `fixed inset-0` floor is a
+            // fixed descendant of the fixed body, so its `bottom: 0` anchors to
+            // the ICB that COLLAPSES to the small/layout viewport on the
+            // installed iOS standalone PWA (~59px short of the true 100lvh
+            // bottom). On OPAQUE routes it then stops short and the launch-bg
+            // strip shows below it; on wallpaper routes it is transparent so the
+            // (now-reclaimed) wallpaper owns the edge. Drop it by the same
+            // collapse delta the composer + wallpaper use so the FOUC guard
+            // reaches the physical bottom too. No-op wherever 100lvh === 100dvh.
+            style={{ bottom: "calc(-1 * max(0px, 100lvh - 100dvh))" }}
           />
           {/* The unified app background, mounted once here so it persists
               seamlessly across shared-background routes. It keeps the

--- a/packages/ui/src/backgrounds/AppBackground.test.tsx
+++ b/packages/ui/src/backgrounds/AppBackground.test.tsx
@@ -42,6 +42,47 @@ describe("AppBackground", () => {
     ).toBeNull();
   });
 
+  it("extends the shader wallpaper past the collapsed-ICB bottom to the TRUE physical bottom (standalone PWA)", () => {
+    // BOTTOM-BAR ROOT CAUSE (device r5): the wallpaper is `fixed inset-0`, so
+    // its `bottom: 0` anchors to the fixed-descendant initial containing block.
+    // On the installed iOS standalone PWA that ICB COLLAPSES to the small/layout
+    // viewport (~59px short of the true 100lvh bottom), so the wallpaper stops
+    // ABOVE the home-indicator zone and the dimmed launch-bg (#root/body
+    // --launch-bg orange under the scrim) shows through as the rgb(61,27,11)
+    // strip. The composer already compensates with a `-1 * max(0px, 100lvh -
+    // 100dvh)` bottom; the wallpaper MUST do the same so it reaches the physical
+    // bottom and owns the whole screen. No-op everywhere the two viewports agree
+    // (desktop/Android/non-collapsed) where the delta is 0.
+    seed({ mode: "shader", color: "#ef5a1f" });
+    const { container } = render(<AppBackground />);
+    const shader = container.querySelector<HTMLElement>(
+      '[data-testid="app-background-shader"]',
+    );
+    // jsdom's CSS parser mangles the lvh/dvh `calc(max(...))` on reserialize,
+    // so assert the load-bearing markers survive rather than the exact string:
+    // a negative `calc(... max(...))` reclaim that references the dynamic
+    // viewport unit. (The exact source form is pinned in the source-string
+    // test in standalone-pwa-lockdown.test.ts.)
+    const bottom = shader?.style.bottom ?? "";
+    expect(bottom).toContain("calc");
+    expect(bottom).toContain("max");
+    expect(bottom).toContain("100dvh");
+  });
+
+  it("extends the image wallpaper past the collapsed-ICB bottom to the TRUE physical bottom (standalone PWA)", () => {
+    seed({ mode: "image", color: "#000000", imageUrl: "/api/media/x.png" });
+    const { container } = render(<AppBackground />);
+    const image = container.querySelector<HTMLElement>(
+      '[data-testid="app-background-image"]',
+    );
+    // jsdom mangles the lvh/dvh calc; assert the surviving markers (see the
+    // shader test note + the source-string pin in standalone-pwa-lockdown).
+    const bottom = image?.style.bottom ?? "";
+    expect(bottom).toContain("calc");
+    expect(bottom).toContain("max");
+    expect(bottom).toContain("100dvh");
+  });
+
   it("renders a cover image when configured for image mode", () => {
     seed({ mode: "image", color: "#000000", imageUrl: "/api/media/x.png" });
     const { container } = render(<AppBackground />);

--- a/packages/ui/src/backgrounds/ImageBackground.tsx
+++ b/packages/ui/src/backgrounds/ImageBackground.tsx
@@ -54,6 +54,17 @@ export function ImageBackground({
       className="pointer-events-none fixed inset-0"
       style={{
         zIndex: 0,
+        // BOTTOM-BAR ROOT CAUSE (device r5): this `fixed inset-0` cover image's
+        // `bottom: 0` anchors to the fixed-descendant ICB, which COLLAPSES to
+        // the small/layout viewport on the installed iOS standalone PWA (~59px
+        // short of the true 100lvh bottom). Left alone the wallpaper stops above
+        // the home-indicator zone and the dimmed launch-bg shows through as the
+        // rgb(61,27,11) bar under the composer. Drop the bottom edge by the
+        // collapse delta so the cover image reaches the TRUE physical bottom —
+        // the same reclaim the chat composer applies. `max(0px, 100lvh -
+        // 100dvh)` is 0 wherever the two viewports agree (desktop/Android), so
+        // this is a no-op except on the collapsing iOS-standalone geometry.
+        bottom: "calc(-1 * max(0px, 100lvh - 100dvh))",
         backgroundImage: `url("${imageUrl}")`,
         backgroundSize: "cover",
         backgroundPosition: "center",

--- a/packages/ui/src/backgrounds/ProgrammableShaderBackground.tsx
+++ b/packages/ui/src/backgrounds/ProgrammableShaderBackground.tsx
@@ -292,7 +292,17 @@ export function ProgrammableShaderBackground({
       data-testid="app-background-glsl"
       data-eliza-bg="glsl"
       className="pointer-events-none fixed inset-0 overflow-hidden"
-      style={{ zIndex: 0, backgroundColor: color }}
+      style={{
+        zIndex: 0,
+        // BOTTOM-BAR ROOT CAUSE (device r5): drop this `fixed inset-0` GLSL
+        // wallpaper's bottom by the fixed-descendant ICB collapse delta so it
+        // reaches the TRUE physical bottom on the installed iOS standalone PWA
+        // instead of stopping ~59px short and exposing the launch-bg bar. Same
+        // reclaim as the composer + the other background layers; no-op wherever
+        // 100lvh === 100dvh (desktop/Android).
+        bottom: "calc(-1 * max(0px, 100lvh - 100dvh))",
+        backgroundColor: color,
+      }}
     />
   );
 }

--- a/packages/ui/src/backgrounds/ShaderBackground.tsx
+++ b/packages/ui/src/backgrounds/ShaderBackground.tsx
@@ -76,6 +76,18 @@ export function ShaderBackground({
       className="pointer-events-none fixed inset-0 overflow-hidden"
       style={{
         zIndex: 0,
+        // BOTTOM-BAR ROOT CAUSE (device r5): this `fixed inset-0` wallpaper's
+        // `bottom: 0` anchors to the fixed-descendant ICB, which COLLAPSES to
+        // the small/layout viewport on the installed iOS standalone PWA (~59px
+        // short of the true 100lvh bottom). Left alone the field stops above the
+        // home-indicator zone and the dimmed launch-bg (#root/body --launch-bg
+        // orange, under the scrim) shows through as the rgb(61,27,11) bar. Drop
+        // the bottom edge by the collapse delta so the field reaches the TRUE
+        // physical bottom and owns the whole screen — the SAME reclaim the chat
+        // composer applies. `max(0px, 100lvh - 100dvh)` is 0 wherever the two
+        // viewports agree (desktop/Android/non-collapsed), so this is a no-op
+        // except on the exact iOS-standalone geometry that collapses.
+        bottom: "calc(-1 * max(0px, 100lvh - 100dvh))",
         backgroundImage: `linear-gradient(to bottom, ${color} 0%, ${color} 52%, ${floor} 100%)`,
       }}
     >

--- a/packages/ui/src/components/shell/HomeScreen.test.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.test.tsx
@@ -38,11 +38,13 @@ import {
   __ingestNotificationForTests,
   __resetNotificationStoreForTests,
 } from "../../state/notifications/notification-store";
+import { __resetHomeDismissalsForTests } from "../../widgets/home-dismissal-store";
 import { HomeScreen } from "./HomeScreen";
 
 afterEach(() => {
   cleanup();
   __resetNotificationStoreForTests();
+  __resetHomeDismissalsForTests();
 });
 
 const NATIVE_OS_TILES = ["messages", "phone", "contacts", "camera"];
@@ -128,7 +130,31 @@ describe("HomeScreen", () => {
     expect(screen.queryByTestId("notifications-shade")).toBeNull();
   });
 
-  it("opens the notification shade from the bottom hint once notifications exist", () => {
+  // GESTURE-HINT OVERLAP FIX (#14945 follow-up): the one-time gesture hint
+  // ("Swipe for apps. Pull chat up. Hold wallpaper to restyle.") sat as the last
+  // flow item in the scroll column, flush against the top of the reserved
+  // composer-clearance zone — on device the floating composer overlapped it and
+  // only the top few pixels of the hint peeked above the composer edge. Its
+  // wrapper must carry an explicit bottom clearance keyed to the composer
+  // footprint + safe area so it can NEVER render under the composer.
+  it("anchors the gesture hint above the floating composer (explicit bottom clearance, never overlapping)", () => {
+    // The gesture hint is a one-time widget; ensure a pristine dismissal store
+    // so it renders on this mount.
+    __resetHomeDismissalsForTests();
+    render(<HomeScreen onOpenTile={vi.fn()} />);
+    const hint = screen.getByTestId("home-gesture-hint");
+    // The hint's positioning wrapper is its parent in the HomeScreen column.
+    const wrapper = hint.parentElement;
+    expect(wrapper).not.toBeNull();
+    const cls = wrapper?.className ?? "";
+    // The wrapper must reserve clearance for the floating composer footprint
+    // (the measured pill height var) plus the bottom safe area, so the hint
+    // always sits fully ABOVE the composer, not behind it.
+    expect(cls).toContain("--eliza-continuous-chat-clearance");
+    expect(cls).toMatch(/safe-area-bottom|android-gesture-inset-bottom/);
+  });
+
+  it("pins the notification center widget between the base widgets and the WidgetHost once notifications exist", () => {
     __ingestNotificationForTests(makeNotification());
     render(<HomeScreen onOpenTile={vi.fn()} />);
     // Hidden until pulled up: only the quiet hint pill is on the dashboard.

--- a/packages/ui/src/components/shell/HomeScreen.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.tsx
@@ -345,8 +345,29 @@ export function HomeScreen({
             />
           </div>
 
+          {/* GESTURE-HINT OVERLAP FIX (#14945 follow-up): the one-time hint used
+            to sit as an ordinary flow item with only a `pb-2` gutter. When it
+            was the terminal content item (the common no-AOSP-tiles home) it
+            landed at the very bottom of the `min-h-full` column — exactly the
+            top edge of the scroller's reserved composer-clearance pad. On device
+            the floating composer (resting a full safe-area inset off the true
+            bottom, standing its measured pill height tall) overlapped that edge,
+            so only the top few pixels of the hint peeked above the composer.
+
+            Fix: pin the hint STICKY to the bottom of the scroller, offset up by
+            the exact composer footprint (published pill-height var) + bottom
+            safe area + a small gap. Sticky keeps it in normal flow (so a tall
+            widget stack still pushes it down and it scrolls with content) while
+            GUARANTEEING it never descends into the composer's zone — it always
+            rests fully ABOVE the floating composer, never behind it. The gap
+            matches the scroller's own composer pad math so the hint tracks the
+            live pill height, not a stale guess. */}
           <div
-            className={cn(enterClass, "pb-2")}
+            className={cn(
+              enterClass,
+              "sticky z-[2] pb-2",
+              "bottom-[calc(var(--eliza-mobile-nav-offset,0px)+max(var(--safe-area-bottom,0px),var(--android-gesture-inset-bottom,0px))+var(--eliza-continuous-chat-clearance,5.25rem)+0.75rem)]",
+            )}
             style={{ animationDelay: "130ms" }}
           >
             <HomeGestureHint />

--- a/packages/ui/src/platform/standalone-pwa-lockdown.test.ts
+++ b/packages/ui/src/platform/standalone-pwa-lockdown.test.ts
@@ -237,12 +237,23 @@ describe("CSS geometry contract — fixed-body ICB collapse fix (bottom black ba
     expect(block).toMatch(/right:\s*0/);
   });
 
-  it("paints a warm ember floor color on the standalone body (no --launch-bg black seam)", () => {
-    // Defensive: any sub-pixel seam at the true bottom must read as the warm
-    // ember-floor ambience, never the near-black --launch-bg band.
+  it("leaves the standalone body floor TRANSPARENT so the wallpaper owns the bottom edge (no painted floor strip)", () => {
+    // BOTTOM-BAR FIX (r4): the prior "defensive warm-ember floor" painted an
+    // OPAQUE color-mix(--launch-bg 82%, ember) === rgb(61,27,11) slab on the
+    // fixed body. Whenever the `fixed inset-0` wallpaper failed to reach the
+    // true bottom by even a hair (ICB rounding on device), that slab bled
+    // through as a UNIFORM warm-brown bar across the whole home-indicator zone
+    // under the floating composer — the recurring "bottom bar" (flagged in 3
+    // successive builds). The floor must be TRANSPARENT so the only thing
+    // visible at the bottom edge is the wallpaper (the always-mounted
+    // `fixed inset-0` AppBackground, which spans the full 100lvh body), never a
+    // painted band. Any true seam falls through to html/#root's near-black
+    // --launch-bg, which is ambient-consistent with a dark wallpaper — not a
+    // bright warm bar.
     const block = standalonePwaOwnBlock();
-    expect(block).toMatch(/background-color:\s*color-mix/);
-    expect(block).toContain("--launch-bg");
+    expect(block).toMatch(/background-color:\s*transparent/);
+    // And it must NOT paint the old warm-ember color-mix slab.
+    expect(block).not.toMatch(/background-color:\s*color-mix/);
   });
 
   it("keeps the native (Capacitor) body on `inset: 0` — the fix is PWA-scoped", () => {
@@ -368,9 +379,10 @@ describe("CSS-FIRST contract — media-query lockdown is detection-independent",
     expect(block ?? "").toContain("touch-action: pan-y");
     // Release `bottom` so top+height drive the box (the #14319 anchor fix).
     expect(block ?? "").toMatch(/bottom:\s*auto/);
-    // Warm ember floor instead of the near-black --launch-bg band.
-    expect(block ?? "").toMatch(/background-color:\s*color-mix/);
-    expect(block ?? "").toContain("--launch-bg");
+    // BOTTOM-BAR FIX (r4): transparent floor — the wallpaper owns the bottom
+    // edge; no painted warm-ember slab that bleeds through as a bar.
+    expect(block ?? "").toMatch(/background-color:\s*transparent/);
+    expect(block ?? "").not.toMatch(/background-color:\s*color-mix/);
   });
 
   it("styles.css media block reclaims #root to the LARGE viewport (100lvh)", () => {
@@ -448,5 +460,50 @@ describe("Keyboard-lift geometry contract — reclaim does NOT shift the compose
     expect(layoutSrc).toContain("viewportH -");
     expect(layoutSrc).not.toContain("100lvh");
     expect(layoutSrc).not.toContain("100dvh");
+  });
+});
+
+describe("Fixed background layers reach the TRUE physical bottom (bottom-bar root cause)", () => {
+  // BOTTOM-BAR ROOT CAUSE (device r5): every full-bleed background layer is a
+  // `fixed inset-0` descendant of the fixed body. On the installed iOS
+  // standalone PWA the fixed-descendant ICB collapses to the small/layout
+  // viewport (~59px short of the true 100lvh bottom). The composer already
+  // compensates its `bottom` by `-1 * max(0px, 100lvh - 100dvh)`; the wallpaper
+  // AND the shell-owned safe-area floor must do the same so nothing stops short
+  // and exposes the dimmed launch-bg as a uniform bar under the composer. The
+  // delta is 0 on every viewport where the two agree (desktop/Android), so this
+  // is a pure iOS-standalone reclaim, no-op elsewhere.
+  const DELTA = "calc(-1 * max(0px, 100lvh - 100dvh))";
+  const appTsx = readFileSync(resolve(process.cwd(), "src/App.tsx"), "utf8");
+  const shaderSrc = readFileSync(
+    resolve(process.cwd(), "src/backgrounds/ShaderBackground.tsx"),
+    "utf8",
+  );
+  const imageSrc = readFileSync(
+    resolve(process.cwd(), "src/backgrounds/ImageBackground.tsx"),
+    "utf8",
+  );
+  const glslSrc = readFileSync(
+    resolve(process.cwd(), "src/backgrounds/ProgrammableShaderBackground.tsx"),
+    "utf8",
+  );
+
+  it("drops the shell-owned safe-area floor to the true bottom via the lvh−dvh delta", () => {
+    // The `app-safe-area-floor` is the FOUC guard on opaque routes; if it stops
+    // short its `bg-bg`/transparent edge leaves the launch-bg strip exposed.
+    expect(appTsx).toContain(DELTA);
+    expect(appTsx).toContain("app-safe-area-floor");
+  });
+
+  it("drops the ShaderBackground wallpaper to the true bottom via the lvh−dvh delta", () => {
+    expect(shaderSrc).toContain(DELTA);
+  });
+
+  it("drops the ImageBackground wallpaper to the true bottom via the lvh−dvh delta", () => {
+    expect(imageSrc).toContain(DELTA);
+  });
+
+  it("drops the programmable GLSL wallpaper to the true bottom via the lvh−dvh delta", () => {
+    expect(glslSrc).toContain(DELTA);
   });
 });

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -144,12 +144,19 @@ body.pwa-standalone {
   height: 100vh;
   height: 100dvh;
   height: 100lvh;
-  /* Defensive floor color: if a 1px sub-pixel seam survives at the very bottom
-     edge (rounding between 100lvh and the device screen), paint it the warm
-     ember-floor tone the ImageBackground bottom-gradient + ShaderBackground
-     fallback already pool there, so a seam reads as lock-screen ambience —
-     never the near-black --launch-bg band. Sits UNDER the fixed wallpaper. */
-  background-color: color-mix(in srgb, var(--launch-bg, #160d07) 82%, #ef5a1f);
+  /* BOTTOM-BAR FIX (r4): TRANSPARENT floor. The prior "defensive" warm-ember
+     color-mix(--launch-bg 82%, #ef5a1f) resolved to an OPAQUE rgb(61,27,11)
+     slab on the fixed body. It was meant only to hide a 1px sub-pixel seam, but
+     whenever the `fixed inset-0` wallpaper failed to reach the true bottom by
+     more than a hair (ICB rounding on device), that slab bled through as a
+     UNIFORM warm-brown BAR spanning the whole home-indicator zone under the
+     floating composer — the recurring "bottom bar" (r3.x). The wallpaper
+     (AppBackground, a `fixed inset-0` cover-fit layer that spans the full 100lvh
+     body) must be the ONLY thing visible at the bottom edge, lock-screen style.
+     Going transparent lets it own the edge; any residual seam falls through to
+     html/#root's near-black --launch-bg, which is ambient-consistent with a dark
+     wallpaper — never a bright warm bar. */
+  background-color: transparent;
 }
 
 /* RECLAIM THE BOTTOM STRIP (#14411): #root fills the LARGE viewport (100lvh),
@@ -222,9 +229,12 @@ body.pwa-standalone textarea {
     height: 100vh;
     height: 100dvh;
     height: 100lvh;
-    /* Warm ember floor: any sub-pixel seam at the true bottom reads as
-       lock-screen ambience, never the near-black --launch-bg band. */
-    background-color: color-mix(in srgb, var(--launch-bg, #160d07) 82%, #ef5a1f);
+    /* BOTTOM-BAR FIX (r4): TRANSPARENT floor (mirror of the class-path rule).
+       An opaque warm-ember slab here bled through as a uniform brown bar in the
+       home-indicator zone whenever the fixed wallpaper missed the true bottom.
+       Transparent lets the full-bleed wallpaper own the bottom edge; any seam
+       falls through to html/#root's near-black --launch-bg, not a bright bar. */
+    background-color: transparent;
   }
 
   /* biome-ignore lint/style/noDescendingSpecificity: intentional bare #root lock mirroring body.pwa-standalone #root. */


### PR DESCRIPTION
## Bottom-bar (launch-bg strip) + gesture-hint overlap — root-cause fix

Fixes the recurring bottom bar under the floating composer on the installed iOS standalone PWA, which on the latest device build (`e89e81aed1`) was **also blocking chat taps** in that zone. Also fixes the `HomeGestureHint` (#14945) rendering behind the composer.

### DEFECT 1 — the opaque bottom bar (root cause found this round)

**Device evidence:** the strip runs the bottom ~51pt full width, perfectly uniform `rgb(61,27,11)` == the `--launch-bg` orange (`#ef5a1f`, the `packages/app/index.html` FOUC guard painted on `html/body/#root`) dimmed to ~25% under the readability scrim. It is the **body/launch background showing through where the wallpaper stops short of the true screen bottom**.

**Mechanism:** every full-bleed background layer is a `fixed inset-0` descendant of the fixed body. On the installed iOS standalone PWA the fixed-descendant **initial containing block collapses to the small/layout viewport** (~59px short of the true `100lvh` bottom), so each layer's `bottom: 0` anchors above the home-indicator zone and the dimmed launch-bg leaks through as a bar. The chat composer already compensated with `bottom: -1 * max(0px, 100lvh - 100dvh)` (contract-tested) — but the wallpaper (`ShaderBackground` / `ImageBackground` / `ProgrammableShaderBackground`) and the shell-owned `app-safe-area-floor` did **not**, so they stopped short. Prior "reclaim #root to 100lvh" work (#14539 / #14224 / #14184 / #14067) didn't neutralize the collapse for these specific fixed descendants on this geometry.

**Fix:**
- Apply the SAME proven collapse reclaim `bottom: calc(-1 * max(0px, 100lvh - 100dvh))` to all four `fixed inset-0` layers so they reach the true physical bottom and the wallpaper owns the whole screen, lock-screen style. The delta is `0` wherever `100lvh === 100dvh` (desktop / Android / non-collapsed) — a pure iOS-standalone reclaim, no-op elsewhere.
- Make the standalone body floor `background-color: transparent` (both the `body.pwa-standalone` class path and the CSS-first `@media (display-mode: standalone) and (pointer: coarse)` block). The prior "defensive" warm-ember `color-mix(--launch-bg 82%, #ef5a1f)` resolved to the exact opaque `rgb(61,27,11)` slab; transparent lets the now-reclaimed wallpaper own the edge, and any true seam falls through to `html/#root`'s near-black `--launch-bg` (ambient-consistent with a dark wallpaper), never a bright bar.
- All four layers stay `pointer-events-none` — extending them adds **no** pointer blocker. With the composer + wallpaper both at the true bottom, the composer's tap / pull-up targets align and bottom-zone taps reach chat again.

### DEFECT 2 — gesture hint clipped behind the composer

The one-time `HomeGestureHint` sat as the terminal flow item flush against the reserved composer-clearance pad, so the floating composer overlapped it (only the top pixels peeked). Pinned it **sticky** to the scroller bottom, offset up by the composer footprint (`--eliza-continuous-chat-clearance`) + bottom safe area + a small gap, so it always rests fully **above** the composer.

### Rules
- Tokens only, no hex, no new `backdrop-blur`, 44px+ tap targets preserved.
- `index.html` untouched (protected file); fix lives entirely in the app/ui layer.
- Failing-test-first: tests pin the **actual mechanism** (fixed layers carry the lvh−dvh reclaim; body floor is transparent; hint wrapper carries the composer-clearance offset), not a generic class assertion.

### Tests
- `AppBackground.test.tsx`: shader + image wallpapers carry the collapse-reclaim bottom.
- `standalone-pwa-lockdown.test.ts`: all four fixed layers carry `calc(-1 * max(0px, 100lvh - 100dvh))`; standalone body floor is `transparent` (not the old `color-mix`).
- `HomeScreen.test.tsx`: gesture-hint wrapper reserves composer clearance + safe area.
- Full `App.screen-background-fuzz.test.tsx` (77 tests) + backgrounds + safe-area-fill suites green. biome clean (only 2 pre-existing unrelated warnings in the test teardown).

— [sol-orch]
