### PR TITLE
fix(#14912): harden updates SETTINGS status contract and failure semantics

### DIFF
--- a/plugins/plugin-app-control/src/actions/settings.test.ts
+++ b/plugins/plugin-app-control/src/actions/settings.test.ts
@@ -1445,6 +1445,145 @@ describe("SETTINGS action: set on an owned route section", () => {
 		expect(texts.join(" ")).toContain("chat cannot apply it directly");
 		expect(texts.join(" ")).toContain("no remote execution endpoint");
 	});
+
+	it("fails the status read when the update check returned an error", async () => {
+		// The route answers HTTP 200 with `error` populated when the check itself
+		// failed; that must not read as a successful SETTINGS action.
+		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({
+			ok: true,
+			data: {
+				currentVersion: "1.0.0",
+				channel: "stable",
+				updateAvailable: false,
+				latestVersion: null,
+				error: "registry unreachable: ETIMEDOUT",
+			},
+		}));
+		const { result, texts } = await invoke(
+			{ action: "set", section: "updates", key: "status" },
+			routeFetch,
+		);
+		expect(result?.success).toBe(false);
+		const joined = texts.join(" ");
+		expect(joined).toContain("registry unreachable");
+		expect(joined).not.toContain("unknown");
+	});
+
+	it("fails rather than narrating a healthy status from a malformed payload", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({
+			ok: true,
+			// Missing currentVersion and updateAvailable: previously rendered as
+			// the healthy-looking "Current: unknown on unknown".
+			data: { channel: "stable" },
+		}));
+		const { result, texts } = await invoke(
+			{ action: "set", section: "updates", key: "status" },
+			routeFetch,
+		);
+		expect(result?.success).toBe(false);
+		const joined = texts.join(" ");
+		expect(joined).toContain("unrecognized payload");
+		expect(joined).not.toContain("unknown on unknown");
+	});
+
+	it("fails the update check when the route body is not a status object", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({
+			ok: true,
+			data: "not a status object",
+		}));
+		const { result, texts } = await invoke(
+			{ action: "set", section: "updates", key: "check" },
+			routeFetch,
+		);
+		expect(result?.success).toBe(false);
+		expect(texts.join(" ")).not.toContain("unknown");
+	});
+
+	it("fails the apply plan when the update check errored", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({
+			ok: true,
+			data: {
+				currentVersion: "1.0.0",
+				channel: "stable",
+				updateAvailable: false,
+				latestVersion: null,
+				error: "registry unreachable",
+			},
+		}));
+		const { result, texts } = await invoke(
+			{ action: "set", section: "updates", key: "apply" },
+			routeFetch,
+		);
+		expect(result?.success).toBe(false);
+		const joined = texts.join(" ");
+		expect(joined).toContain("the update check failed");
+		expect(joined).not.toContain("unknown");
+	});
+
+	it("surfaces a failed forced refresh after a channel change without fabricating a status", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async (request) => {
+			if (request.method === "PUT")
+				return { ok: true, data: { channel: "beta" } };
+			return {
+				ok: true,
+				data: {
+					currentVersion: "1.0.0",
+					channel: "beta",
+					updateAvailable: false,
+					latestVersion: null,
+					error: "registry unreachable while refreshing",
+				},
+			};
+		});
+		const { result, texts } = await invoke(
+			{ action: "set", section: "updates", key: "channel", value: "beta" },
+			routeFetch,
+		);
+		// The channel write landed, so the operation succeeded — but the failed
+		// refresh is surfaced, never masked by the channel-write echo.
+		expect(result?.success).toBe(true);
+		const joined = texts.join(" ");
+		expect(joined).toContain("Update channel is beta");
+		expect(joined).toContain("couldn't refresh the release status");
+		expect(joined).toContain("registry unreachable while refreshing");
+		expect(joined).not.toContain("unknown");
+	});
+
+	it("surfaces a transport failure on the forced refresh after a channel change", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async (request) => {
+			if (request.method === "PUT")
+				return { ok: true, data: { channel: "nightly" } };
+			return {
+				ok: false,
+				detail: "route /api/update/status?force=true returned 503",
+			};
+		});
+		const { result, texts } = await invoke(
+			{ action: "set", section: "updates", key: "channel", value: "nightly" },
+			routeFetch,
+		);
+		expect(result?.success).toBe(true);
+		const joined = texts.join(" ");
+		expect(joined).toContain("Update channel is nightly");
+		expect(joined).toContain("couldn't refresh the release status");
+		expect(joined).toContain("503");
+		expect(joined).not.toContain("unknown");
+	});
+
+	it("does not refresh status when the channel write itself fails", async () => {
+		const routeFetch = vi.fn<SettingsRouteFetch>(async (request) => {
+			if (request.method === "PUT")
+				return { ok: false, detail: "channel write rejected" };
+			return { ok: true, data: {} };
+		});
+		const { result, texts } = await invoke(
+			{ action: "set", section: "updates", key: "channel", value: "beta" },
+			routeFetch,
+		);
+		expect(result?.success).toBe(false);
+		expect(texts.join(" ")).toContain("channel write rejected");
+		expect(routeFetch).toHaveBeenCalledTimes(1);
+	});
 });
 
 describe("SETTINGS action: set on delegated/readonly/unwired sections", () => {

--- a/plugins/plugin-app-control/src/actions/settings.test.ts
+++ b/plugins/plugin-app-control/src/actions/settings.test.ts
@@ -1472,8 +1472,8 @@ describe("SETTINGS action: set on an owned route section", () => {
 	it("fails rather than narrating a healthy status from a malformed payload", async () => {
 		const routeFetch = vi.fn<SettingsRouteFetch>(async () => ({
 			ok: true,
-			// Missing currentVersion and updateAvailable: previously rendered as
-			// the healthy-looking "Current: unknown on unknown".
+			// Missing required status fields must never be narrated as a healthy
+			// version/channel pair.
 			data: { channel: "stable" },
 		}));
 		const { result, texts } = await invoke(

--- a/plugins/plugin-app-control/src/actions/settings.ts
+++ b/plugins/plugin-app-control/src/actions/settings.ts
@@ -352,17 +352,23 @@ const PERMISSIONS_REQUEST_KEYS: Readonly<Record<string, SettingsWritableKey>> =
 
 type UpdateChannel = "stable" | "beta" | "nightly";
 
+/**
+ * The slice of the /api/update/status contract the chat narration consumes.
+ * Deliberately a subset of the shared AgentUpdateStatus contract: this action
+ * never reads dist-tags, channel version maps, or install internals, so
+ * validating those would reject a payload that is perfectly adequate to narrate.
+ * The essentials (currentVersion, channel, updateAvailable) are required so a
+ * malformed status can never render as a healthy "unknown on unknown".
+ */
 interface UpdateStatusPayload {
-	currentVersion?: string;
-	channel?: string;
-	installMethod?: string;
-	updateAvailable?: boolean;
-	latestVersion?: string | null;
-	lastCheckAt?: string | null;
-	error?: string | null;
-	updateCommand?: string | null;
-	updateInstructions?: string | null;
-	canExecuteUpdate?: boolean;
+	currentVersion: string;
+	channel: string;
+	updateAvailable: boolean;
+	latestVersion: string | null;
+	error: string | null;
+	updateCommand: string | null;
+	updateInstructions: string | null;
+	canExecuteUpdate: boolean;
 }
 
 const UPDATE_CHANNELS = new Set<UpdateChannel>(["stable", "beta", "nightly"]);
@@ -371,23 +377,43 @@ function isUpdateChannel(value: string | null): value is UpdateChannel {
 	return value !== null && UPDATE_CHANNELS.has(value as UpdateChannel);
 }
 
-function readUpdateStatusPayload(data: unknown): UpdateStatusPayload {
-	if (!data || typeof data !== "object") return {};
-	return data as UpdateStatusPayload;
+function readNullableString(value: unknown): string | null {
+	return typeof value === "string" ? value : null;
 }
 
-function describeUpdateStatus(data: unknown): string {
-	const status = readUpdateStatusPayload(data);
-	if (status.error) {
-		return `Update check failed: ${status.error}`;
+/**
+ * Validate the status body, requiring the fields the narration reads. Returns
+ * null for a missing or malformed payload so a broken status route surfaces as
+ * an error instead of a fabricated version pair — the previous `data as`
+ * cast let a shapeless body render as a healthy "unknown on unknown".
+ */
+function parseUpdateStatusPayload(data: unknown): UpdateStatusPayload | null {
+	if (!data || typeof data !== "object") return null;
+	const record = data as Record<string, unknown>;
+	const { currentVersion, channel, updateAvailable } = record;
+	if (typeof currentVersion !== "string" || currentVersion.length === 0) {
+		return null;
 	}
-	const current = status.currentVersion ?? "unknown";
-	const channel = status.channel ?? "unknown";
+	if (typeof channel !== "string" || channel.length === 0) return null;
+	if (typeof updateAvailable !== "boolean") return null;
+	return {
+		currentVersion,
+		channel,
+		updateAvailable,
+		latestVersion: readNullableString(record.latestVersion),
+		error: readNullableString(record.error),
+		updateCommand: readNullableString(record.updateCommand),
+		updateInstructions: readNullableString(record.updateInstructions),
+		canExecuteUpdate: record.canExecuteUpdate === true,
+	};
+}
+
+function describeUpdateStatus(status: UpdateStatusPayload): string {
 	if (status.updateAvailable) {
 		const latest = status.latestVersion ?? "the latest release";
-		return `Update available: ${current} → ${latest} on ${channel}.`;
+		return `Update available: ${status.currentVersion} → ${latest} on ${status.channel}.`;
 	}
-	return `Current: ${current} on ${channel}.`;
+	return `Current: ${status.currentVersion} on ${status.channel}.`;
 }
 
 function fetchUpdateStatus(
@@ -400,22 +426,57 @@ function fetchUpdateStatus(
 	});
 }
 
+/**
+ * Fetch the update status and collapse it to a usable payload or an honest
+ * failure. The route answers HTTP 200 even when the underlying check failed
+ * (registry unreachable, etc.), so a successful transport is not proof of a
+ * usable status: a populated `error`, an unrecognized body, or a transport
+ * failure all yield ok:false so the SETTINGS action reports the failure instead
+ * of narrating a fabricated or partially-failed status.
+ */
+async function resolveUpdateStatus(
+	routeFetch: SettingsRouteFetch,
+	force: boolean,
+): Promise<SettingsRouteOutcome> {
+	const outcome = await fetchUpdateStatus(routeFetch, force);
+	if (!outcome.ok) return outcome;
+	const status = parseUpdateStatusPayload(outcome.data);
+	if (!status) {
+		return {
+			ok: false,
+			detail: "the update status route returned an unrecognized payload",
+		};
+	}
+	if (status.error) {
+		return { ok: false, detail: `the update check failed: ${status.error}` };
+	}
+	return { ok: true, data: status };
+}
+
 const UPDATES_STATUS_KEY: SettingsWritableKey = {
 	description:
 		"Read the connected agent update status from the same backend route the Release Center uses.",
 	valueType: "command",
-	apply: async ({ routeFetch }) => fetchUpdateStatus(routeFetch, false),
-	successText: (_value, _request, outcome) =>
-		`Release status: ${describeUpdateStatus(outcome.data)}`,
+	apply: ({ routeFetch }) => resolveUpdateStatus(routeFetch, false),
+	successText: (_value, _request, outcome) => {
+		const status = parseUpdateStatusPayload(outcome.data);
+		return status
+			? `Release status: ${describeUpdateStatus(status)}`
+			: "Release status is unavailable.";
+	},
 };
 
 const UPDATES_CHECK_KEY: SettingsWritableKey = {
 	description:
 		"Force an update check through the connected agent update-status route.",
 	valueType: "command",
-	apply: async ({ routeFetch }) => fetchUpdateStatus(routeFetch, true),
-	successText: (_value, _request, outcome) =>
-		`Update check complete. ${describeUpdateStatus(outcome.data)}`,
+	apply: ({ routeFetch }) => resolveUpdateStatus(routeFetch, true),
+	successText: (_value, _request, outcome) => {
+		const status = parseUpdateStatusPayload(outcome.data);
+		return status
+			? `Update check complete. ${describeUpdateStatus(status)}`
+			: "Update check complete, but the status was unavailable.";
+	},
 };
 
 const UPDATES_CHANNEL_KEY: SettingsWritableKey = {
@@ -435,25 +496,48 @@ const UPDATES_CHANNEL_KEY: SettingsWritableKey = {
 			body: { channel: request.value },
 		});
 		if (!channelResult.ok) return channelResult;
-		const status = await fetchUpdateStatus(routeFetch, true);
-		return status.ok ? status : channelResult;
+		// The channel switch is the primary effect and is already persisted. A
+		// forced refresh that fails must be reported as such, never masked by
+		// echoing the channel-write body as if it were a healthy status.
+		const refreshed = await resolveUpdateStatus(routeFetch, true);
+		return {
+			ok: true,
+			data: {
+				channel: request.value,
+				status: refreshed.ok ? refreshed.data : null,
+				refreshError: refreshed.ok
+					? null
+					: (refreshed.detail ?? "the update status could not be refreshed"),
+			},
+		};
 	},
-	successText: (_value, request, outcome) =>
-		`Update channel is ${request.value}. ${describeUpdateStatus(outcome.data)}`,
+	successText: (_value, request, outcome) => {
+		const data = readPlainObject(outcome.data) ?? {};
+		const channel =
+			typeof data.channel === "string" ? data.channel : (request.value ?? "");
+		const refreshError = readNullableString(data.refreshError);
+		if (refreshError) {
+			return `Update channel is ${channel}, but I couldn't refresh the release status: ${refreshError}.`;
+		}
+		const status = parseUpdateStatusPayload(data.status);
+		return status
+			? `Update channel is ${channel}. ${describeUpdateStatus(status)}`
+			: `Update channel is ${channel}.`;
+	},
 };
 
 const UPDATES_APPLY_KEY: SettingsWritableKey = {
 	description:
 		"Report the real apply plan for an available connected-agent update. Chat does not invent a remote installer.",
 	valueType: "command",
-	apply: async ({ routeFetch }) => fetchUpdateStatus(routeFetch, true),
+	apply: ({ routeFetch }) => resolveUpdateStatus(routeFetch, true),
 	successText: (_value, _request, outcome) => {
-		const status = readUpdateStatusPayload(outcome.data);
-		if (status.error) {
-			return `I checked the update plan, but the update check failed: ${status.error}`;
+		const status = parseUpdateStatusPayload(outcome.data);
+		if (!status) {
+			return "I checked for an update, but the status was unavailable.";
 		}
 		if (!status.updateAvailable) {
-			return `No update to apply. ${describeUpdateStatus(outcome.data)}`;
+			return `No update to apply. ${describeUpdateStatus(status)}`;
 		}
 		const instruction =
 			status.updateCommand ??

--- a/plugins/plugin-app-control/src/actions/settings.ts
+++ b/plugins/plugin-app-control/src/actions/settings.ts
@@ -384,8 +384,7 @@ function readNullableString(value: unknown): string | null {
 /**
  * Validate the status body, requiring the fields the narration reads. Returns
  * null for a missing or malformed payload so a broken status route surfaces as
- * an error instead of a fabricated version pair — the previous `data as`
- * cast let a shapeless body render as a healthy "unknown on unknown".
+ * an error instead of a fabricated version pair.
  */
 function parseUpdateStatusPayload(data: unknown): UpdateStatusPayload | null {
 	if (!data || typeof data !== "object") return null;


### PR DESCRIPTION
## What

Hardens the `updates` section of the SETTINGS semantic chat-write twin
(`plugins/plugin-app-control/src/actions/settings.ts`). #14956 wired the route
but left three honesty defects the reopen flagged; this fixes all three and
covers them.

**Defects fixed**

1. **HTTP-200-with-`error` treated as success.** `GET /api/update/status`
   answers HTTP 200 even when the update check itself failed (registry
   unreachable, etc.) — the failure lives in the body's `error` field, not the
   status code (`packages/agent/src/api/update-routes.ts:89`). The action keyed
   success off the transport, so `status`/`check`/`apply` reported a successful
   SETTINGS action while narrating "Update check failed: …". Now
   `resolveUpdateStatus` inspects the parsed body and returns `ok:false` when
   `error` is populated, so the action reports the failure.
2. **Malformed body accepted via `data as UpdateStatusPayload`.** The unchecked
   cast let a shapeless/missing body render as the healthy-looking
   `Current: unknown on unknown`. Replaced with `parseUpdateStatusPayload`,
   which requires `currentVersion`, `channel`, and `updateAvailable` and returns
   `null` (→ `ok:false`, "unrecognized payload") otherwise. `describeUpdateStatus`
   now takes a validated payload and can no longer emit "unknown".
3. **Masked forced refresh after a channel change.** After `PUT
   /api/update/channel` the forced status refresh could fail, and the old code
   returned the channel-write body — fabricating a healthy status. The channel
   write is the primary effect and still succeeds; a failed refresh is now
   surfaced honestly ("Update channel is beta, but I couldn't refresh the
   release status: …") instead of masked.

## Why

Binding repo error policy: "not loaded" must never read as "zero/empty", data
paths fail-fast and never fabricate, and DTO/route fields are validated at the
boundary rather than cast. The `updates` twin was the last place in this action
still doing all three.

Closes #14912

## Scope

Deliberately validates only the subset of the shared `AgentUpdateStatus`
contract the chat narration reads (version/channel/updateAvailable + optional
apply-plan fields); it never reads dist-tags or channel version maps, so
coupling narration validity to those would wrongly reject an adequate payload.

## Evidence

<details><summary>Unit tests — 88 passed (7 new failure-path tests), scoped run</summary>

```
$ bun run --cwd plugins/plugin-app-control test src/actions/settings.test.ts
 Test Files  1 passed (1)
      Tests  88 passed (88)

# new coverage (verbose):
 ✓ … > fails the status read when the update check returned an error
 ✓ … > fails rather than narrating a healthy status from a malformed payload
 ✓ … > fails the update check when the route body is not a status object
 ✓ … > fails the apply plan when the update check errored
 ✓ … > surfaces a failed forced refresh after a channel change without fabricating a status
 ✓ … > surfaces a transport failure on the forced refresh after a channel change
 ✓ … > does not refresh status when the channel write itself fails
```
</details>

<details><summary>Typecheck + Biome + error-policy ratchet — clean</summary>

```
$ bun run --cwd plugins/plugin-app-control typecheck   # tsgo --noEmit, no errors
$ bunx @biomejs/biome check .../settings.ts .../settings.test.ts
Checked 2 files in 80ms. No fixes applied.
$ bun run audit:error-policy-ratchet
[error-policy-ratchet] no new fallback-slop in touched files
```
</details>

<details><summary>Backend logs — action code path firing (structured logger)</summary>

```
[SettingsAction] set section=updates key=status value=null
[SettingsAction] set section=updates key=check value=null
[SettingsAction] set section=updates key=channel value=null
[SettingsAction] set section=updates key=apply value=null
```
</details>

- **Real-LLM trajectory:** N/A — no planner/prompt/model behavior changed
  (`similes`, `routingHint`, `description`, `parameters` untouched). This hardens
  the action's deterministic handling of backend-route responses; the real code
  path is driven end-to-end by the unit tests through the injected
  `SettingsRouteFetch` seam, including the error/malformed/transport-failure
  paths a live check cannot deterministically reproduce.
- **Frontend logs / before-after screenshots / video:** N/A — server-side chat
  action only; no UI pixels changed.
- **Domain artifacts:** the outcome/reply text is the artifact; asserted by the
  new tests (channel write persists; refresh failure and check errors surface
  without fabricating a version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
