### PR TITLE
fix(plugin-elizacloud): omit response_format on native chat completions (cloud gateway 400s on it)

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/unit/text-cerebras-response-format.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/text-cerebras-response-format.test.ts
@@ -1,9 +1,10 @@
 /**
  * Offline unit coverage for the native `/chat/completions` `response_format`
- * gate. Cerebras-served native chat models 400 on
- * `response_format: { type: "json_schema" }`, so for those models the wire body
- * must carry `{ type: "json_object" }` instead. Every other model keeps the
- * full `json_schema` payload so structured output stays schema-constrained.
+ * gate. The Cloud gateway 400s on `response_format` for its served models —
+ * both `json_schema` and `json_object` (verified live against zai-glm-4.7 and
+ * gemma-4-31b) — so the wire body must omit `response_format` entirely and
+ * rely on the schema embedded in the prompt. Only an explicit caller-supplied
+ * `responseFormat` override still reaches the wire.
  *
  * The fetch is mocked: we capture the request body and return a canned
  * chat-completions response, asserting only the outgoing `response_format`.
@@ -85,17 +86,22 @@ describe("native /chat/completions response_format gate", () => {
     `cerebras:${DEFAULT_CEREBRAS_TEXT_MODEL}`,
     "gpt-oss-120b",
     "zai-glm-4.7",
-  ])("emits json_object for cerebras-served %s", async (modelName) => {
+    "gemma-4-31b",
+    "gpt-4o-mini",
+  ])("omits response_format for %s", async (modelName) => {
     const body = await captureBody(modelName);
-    expect(body?.response_format).toEqual({ type: "json_object" });
+    expect(body).not.toBeNull();
+    expect(body?.response_format).toBeUndefined();
   });
 
-  it("keeps json_schema for non-cerebras models", async () => {
-    const body = await captureBody("gpt-4o-mini");
-    expect(body?.response_format).toMatchObject({
-      type: "json_schema",
-      json_schema: { name: "reply_envelope" },
+  it("still honors an explicit caller responseFormat override", async () => {
+    const body = await captureBody("zai-glm-4.7", {
+      responseSchema: {
+        ...RESPONSE_SCHEMA,
+        responseFormat: { type: "json_object" },
+      },
     });
+    expect(body?.response_format).toEqual({ type: "json_object" });
   });
 });
 

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -350,12 +350,9 @@ function isReasoningModel(modelName: string): boolean {
 }
 
 /**
- * True when the Cloud gateway routes this model to Cerebras. Cerebras's
- * OpenAI-compatible endpoint rejects
- * `response_format: { type: "json_schema", ... }` with a 400, so structured
- * output for these models must fall back to `{ type: "json_object" }`.
- * Mirrors plugin-openai's `isCerebrasMode` json_object scrub, detected by
- * model name here because one Cloud key serves many providers.
+ * Strips provider prefixes and variant suffixes so Cerebras-served models can
+ * be recognized by bare id (one Cloud key serves many providers, and callers
+ * pass `cerebras:...` / `openai/...` / `:suffix` forms interchangeably).
  */
 function normalizeCerebrasModelId(modelName: string): string {
   return modelName
@@ -364,15 +361,6 @@ function normalizeCerebrasModelId(modelName: string): string {
     .replace(/^cerebras[:/]/, "")
     .replace(/^openai\//, "")
     .replace(/:(?!free$).+$/, "");
-}
-
-function isCerebrasServedModel(modelName: string): boolean {
-  const id = normalizeCerebrasModelId(modelName);
-  return (
-    id === DEFAULT_CEREBRAS_TEXT_MODEL ||
-    id === "gpt-oss-120b" ||
-    id === "zai-glm-4.7"
-  );
 }
 
 function resolveCerebrasThinkingOffReasoningEffort(
@@ -585,39 +573,26 @@ export function normalizeNativeToolChoice(toolChoice: unknown): unknown {
   return toolName ? { type: "function", function: { name: toolName } } : toolChoice;
 }
 
-function buildNativeResponseFormat(responseSchema: unknown, modelName: string): unknown {
+function buildNativeResponseFormat(responseSchema: unknown, _modelName: string): unknown {
   if (!responseSchema) {
     return undefined;
   }
 
-  // Cerebras-served models 400 on `response_format: json_schema`, so emit
-  // `json_object` and rely on the schema embedded in the prompt body.
-  if (isCerebrasServedModel(modelName)) {
-    return { type: "json_object" };
-  }
-
+  // An explicit caller-supplied response format still wins.
   const schemaRecord = asRecord(responseSchema);
   if (schemaRecord.responseFormat) {
     return schemaRecord.responseFormat;
   }
 
-  const schemaOptions =
-    "schema" in schemaRecord
-      ? {
-          schema: schemaRecord.schema,
-          name: firstString(schemaRecord.name) ?? "structured_response",
-          description: firstString(schemaRecord.description),
-        }
-      : { schema: responseSchema, name: "structured_response", description: undefined };
-
-  return {
-    type: "json_schema",
-    json_schema: {
-      name: schemaOptions.name,
-      ...(schemaOptions.description ? { description: schemaOptions.description } : {}),
-      schema: schemaOptions.schema,
-    },
-  };
+  // The Cloud's native `/chat/completions` gateway 400s on `response_format`
+  // for its served models — BOTH `json_schema` AND `json_object`, verified
+  // live against zai-glm-4.7 AND gemma-4-31b (each: with either format → 400,
+  // without → 200). The structured schema is already embedded in the prompt
+  // body and the caller repairs/validates the returned JSON, so omit
+  // `response_format` entirely; otherwise every structured-output call (the
+  // trajectory evaluator, the planner) fails with `Bad Request` and breaks
+  // every tool-using turn (web search, price lookups, sub-agent spawns).
+  return undefined;
 }
 
 function resolvePromptCacheKey(providerOptions: Record<string, unknown>): string | undefined {


### PR DESCRIPTION
## The bug

The Eliza Cloud native `/chat/completions` gateway returns **HTTP 400** whenever the request carries `response_format` — for **both** `json_schema` and `json_object` — on its served models. Verified live with direct probes against the gateway:

| model | `response_format: json_schema` | `response_format: json_object` | no `response_format` |
|---|---|---|---|
| `zai-glm-4.7` | 400 | 400 | 200 |
| `gemma-4-31b` | 400 | 400 | 200 |

`buildNativeResponseFormat` (`plugins/plugin-elizacloud/src/models/text.ts`) special-cased `isCerebrasServedModel()` (`zai-glm-4.7` / `gpt-oss-120b`) by downgrading `json_schema` to `json_object` — but (a) `json_object` **also** 400s, and (b) `gemma-4-31b` (the default `TEXT_SMALL`/`TEXT_LARGE` model) isn't in that list, so it was sent full `json_schema`. Result: **every structured-output call through the native path 400s**.

## Impact

The trajectory evaluator (and any other `responseSchema` caller) fails with `Bad Request` on every invocation, which breaks **every tool-using turn** — web search, price lookups, sub-agent spawns — on Cloud-served models.

## The fix

Omit `response_format` on the native `/chat/completions` path entirely. This is safe because the structured schema is already embedded in the prompt body and the caller repairs/validates the returned JSON. An explicit caller-supplied `responseFormat` override still passes through untouched.

Cleanup: removing the special case left `isCerebrasServedModel` with zero references, so it is deleted (its helper `normalizeCerebrasModelId` and `DEFAULT_CEREBRAS_TEXT_MODEL` stay — both are still used by the `reasoning_effort` thinking-off mapping).

Updated `__tests__/unit/text-cerebras-response-format.test.ts`: the wire body must omit `response_format` for cerebras-served and non-cerebras models alike, and must still honor an explicit `responseFormat` override. The `reasoning_effort` gate coverage in the same file is untouched and still passes.

## Long-term

The *proper* fix is cloud-gateway-side: the gateway should accept (or strip) `response_format` for its served models instead of 400ing. Once it does, schema-constrained decoding can be re-enabled from this plugin. This PR unbreaks clients now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
