### PR TITLE
fix(core): model-failover error stringifies to [object Object] — give it a real diagnostic message

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -35,7 +35,7 @@ import { ensureConnection as ensureConnectionStandalone } from "./connection";
 import { registerConnectorSourceDefinitions } from "./connectors";
 import { deriveKnownSecrets } from "./constants/secrets";
 import { InMemoryDatabaseAdapter } from "./database/inMemoryAdapter";
-import { type ReportedError, toElizaError } from "./errors";
+import { ElizaError, type ReportedError, toElizaError } from "./errors";
 import {
 	type CapabilityConfig,
 	type CapabilitySettingFlags,
@@ -114,7 +114,10 @@ import {
 	SecretSwapSession,
 } from "./security/secret-swap";
 import { DefaultMessageService } from "./services/message";
-import { isModelProviderFallbackError } from "./services/message/fallback-reply";
+import {
+	describeModelCallError,
+	isModelProviderFallbackError,
+} from "./services/message/fallback-reply";
 import type { TaskService } from "./services/task";
 import type { ToolPolicyService } from "./services/tool-policy";
 import { decryptSecret, getSalt } from "./settings";
@@ -4942,11 +4945,32 @@ export class AgentRuntime implements IAgentRuntime {
 		throw new Error(`No handler found for delegate type: ${requestedModelKey}`);
 	}
 
-	private rethrowModelFailoverError(error: unknown): never {
-		if (error instanceof Error) {
+	/**
+	 * Surface the failure that ends a `useModel` failover chain. A real `Error`
+	 * with a message rethrows unchanged so provider SDK stack traces and typed
+	 * subclasses (e.g. `NoModelProviderConfiguredError`, which the chat UI
+	 * narrows on) survive the boundary. Everything else — the bare
+	 * `{ status, error }` objects some providers/AI-SDK paths throw, or a
+	 * message-less `Error` — becomes an `ElizaError` whose message names the
+	 * provider, HTTP status, and underlying cause. Without this, a bare object
+	 * stringified to the diagnostically useless "[object Object]" in logs,
+	 * trajectories, and any user-surfaced failure text.
+	 */
+	private rethrowModelFailoverError(
+		error: unknown,
+		failed?: { modelKey: string; provider: string },
+	): never {
+		if (error instanceof Error && error.message.trim().length > 0) {
 			throw error;
 		}
-		throw new Error(String(error));
+		const detail = describeModelCallError(error);
+		const provider = failed?.provider ?? "unknown";
+		throw new ElizaError(`Model provider "${provider}" failed: ${detail}`, {
+			code: "MODEL_PROVIDER_FAILED",
+			cause: error,
+			context: { provider: failed?.provider, modelKey: failed?.modelKey },
+			severity: "ephemeral",
+		});
 	}
 
 	getModel(
@@ -6072,7 +6096,10 @@ export class AgentRuntime implements IAgentRuntime {
 					providerAttemptStartedOutput ||
 					!this.shouldFailOverModelProvider(error, requestedModelKey)
 				) {
-					this.rethrowModelFailoverError(error);
+					this.rethrowModelFailoverError(error, {
+						modelKey: resolvedModelKey,
+						provider: resolvedModel.provider,
+					});
 				}
 				this.logModelProviderFailover({
 					requestedModelKey,

--- a/packages/core/src/runtime/__tests__/model-provider-failover.test.ts
+++ b/packages/core/src/runtime/__tests__/model-provider-failover.test.ts
@@ -219,4 +219,79 @@ describe("AgentRuntime.useModel provider failover", () => {
 		expect(exhaustedHandler).toHaveBeenCalledTimes(1);
 		expect(backupHandler).not.toHaveBeenCalled();
 	});
+
+	// Regression: a provider that throws a bare structured object (not an Error)
+	// used to be rethrown as `new Error(String(error))` === "Error: [object
+	// Object]", stranding provider/status/cause out of logs, trajectories, and
+	// any user-surfaced failure text. The rethrow must assemble a real message.
+	it("stringifies a non-Error provider failure diagnostically, not as [object Object]", async () => {
+		const runtime = makeRuntime();
+		const structuredFailure = {
+			status: 500,
+			error: { message: "upstream exploded" },
+		};
+		const failingHandler = vi.fn(async () => {
+			throw structuredFailure;
+		});
+		runtime.registerModel(
+			ModelType.TEXT_LARGE,
+			failingHandler,
+			"claude-sdk",
+			100,
+		);
+
+		const thrown = await runtime
+			.useModel(ModelType.TEXT_LARGE, { prompt: "hello" })
+			.then(
+				() => {
+					throw new Error("expected useModel to reject");
+				},
+				(error: unknown) => error,
+			);
+
+		expect(thrown).toBeInstanceOf(Error);
+		const err = thrown as Error & { code?: string; cause?: unknown };
+		expect(err.message).not.toContain("[object Object]");
+		expect(String(err)).not.toContain("[object Object]");
+		// Provider name + underlying cause + HTTP status all present.
+		expect(err.message).toContain("claude-sdk");
+		expect(err.message).toContain("upstream exploded");
+		expect(err.message).toContain("500");
+		expect(err.code).toBe("MODEL_PROVIDER_FAILED");
+		expect(err.cause).toBe(structuredFailure);
+		expect(failingHandler).toHaveBeenCalledTimes(1);
+	});
+
+	// A structured object with no status or message must still not degrade to
+	// "[object Object]" — the payload is serialized so it stays inspectable.
+	it("serializes an opaque non-Error failure payload instead of [object Object]", async () => {
+		const runtime = makeRuntime();
+		const opaqueFailure = {
+			reason: "provider melted",
+			providerHint: "claude-sdk",
+		};
+		const failingHandler = vi.fn(async () => {
+			throw opaqueFailure;
+		});
+		runtime.registerModel(
+			ModelType.TEXT_LARGE,
+			failingHandler,
+			"claude-sdk",
+			100,
+		);
+
+		const thrown = await runtime
+			.useModel(ModelType.TEXT_LARGE, { prompt: "hello" })
+			.then(
+				() => {
+					throw new Error("expected useModel to reject");
+				},
+				(error: unknown) => error,
+			);
+
+		const err = thrown as Error & { cause?: unknown };
+		expect(err.message).not.toContain("[object Object]");
+		expect(err.message).toContain("provider melted");
+		expect(err.cause).toBe(opaqueFailure);
+	});
 });

--- a/packages/core/src/services/message/fallback-reply.ts
+++ b/packages/core/src/services/message/fallback-reply.ts
@@ -40,6 +40,75 @@ function hasHttpStatus(error: unknown, statuses: readonly number[]): boolean {
 	return statuses.includes(Number(candidate.statusCode ?? candidate.status));
 }
 
+function readHttpStatus(error: unknown): number | undefined {
+	const candidate = asErrorObject(error);
+	if (!candidate) return undefined;
+	const status = Number(candidate.statusCode ?? candidate.status);
+	return Number.isFinite(status) && status > 0 ? status : undefined;
+}
+
+/**
+ * Pull the most specific human-readable message off a thrown value: a real
+ * `Error.message`, a raw string, or the nested provider body a bare object
+ * carries (`{ error: { message } }`, `{ error: "..." }`, `{ message }`).
+ * Returns undefined when nothing message-shaped is present so the caller can
+ * fall back to status or a serialized payload rather than "[object Object]".
+ */
+function extractErrorMessage(error: unknown): string | undefined {
+	if (error instanceof Error) {
+		const message = error.message.trim();
+		return message.length > 0 ? message : undefined;
+	}
+	if (typeof error === "string") {
+		const message = error.trim();
+		return message.length > 0 ? message : undefined;
+	}
+	const candidate = asErrorObject(error);
+	if (!candidate) return undefined;
+	const body = candidate.error;
+	if (typeof body === "string" && body.trim().length > 0) {
+		return body.trim();
+	}
+	if (body !== null && typeof body === "object") {
+		const nested = (body as { message?: unknown }).message;
+		if (typeof nested === "string" && nested.trim().length > 0) {
+			return nested.trim();
+		}
+	}
+	const topLevel = (candidate as { message?: unknown }).message;
+	if (typeof topLevel === "string" && topLevel.trim().length > 0) {
+		return topLevel.trim();
+	}
+	return undefined;
+}
+
+/**
+ * Render any thrown model-call failure as one diagnostic line — the HTTP
+ * status (unwrapped from the AI SDK retry envelope) plus the most specific
+ * message found on the error or its structured body. Providers throw a mix of
+ * `Error` instances and bare `{ status, error }` objects; a bare object
+ * stringifies to the useless "[object Object]", so the model-failover rethrow
+ * routes non-trivial values through here to keep logs, trajectories, and any
+ * user-surfaced failure text diagnostic. Never returns "[object Object]": when
+ * no status or message is recoverable it serializes the payload instead.
+ */
+export function describeModelCallError(error: unknown): string {
+	const unwrapped = unwrapRetryError(error);
+	const status = readHttpStatus(unwrapped) ?? readHttpStatus(error);
+	const message = extractErrorMessage(unwrapped) ?? extractErrorMessage(error);
+	if (message && status) return `HTTP ${status}: ${message}`;
+	if (message) return message;
+	if (status) return `HTTP ${status}`;
+	try {
+		const serialized = JSON.stringify(error);
+		if (serialized && serialized !== "{}") return serialized;
+	} catch {
+		// error-policy:J3 a non-serializable payload (circular ref, BigInt) still
+		// must not surface as "[object Object]" — fall through to String().
+	}
+	return String(error);
+}
+
 /**
  * Detect provider rate-limit / 429 failures so the user-facing failure reply
  * can say "I'm being rate-limited, try again shortly" instead of the opaque


### PR DESCRIPTION
## Problem (found live)

A gmail draft/search turn surfaced **`Error: [object Object]`** from `rethrowModelFailoverError` in `packages/core/src/runtime.ts`. When a model provider throws a **bare structured object** (not an `Error`) — the `{ status, error: { message } }` shape AI-SDK / provider paths use — and the `useModel` failover chain is exhausted, the old code rethrew it as:

```ts
if (error instanceof Error) throw error;
throw new Error(String(error));   // String({...}) === "[object Object]"
```

`String()` on a plain object is `"[object Object]"`, so the provider, HTTP status, and underlying cause were **stranded out of logs, trajectories, and any user-surfaced failure text**. Diagnostically useless — and if it reaches a user it is the opposite of human (ties to the humanness doctrine #14873).

## Fix (structural)

`rethrowModelFailoverError` now:

- **Well-formed `Error` with a message → rethrown unchanged.** Provider SDK stack traces and typed subclasses (e.g. `NoModelProviderConfiguredError`, which the chat UI narrows on) survive the failover boundary untouched.
- **Everything else** (bare object, or a message-less `Error`) → wrapped in an **`ElizaError`** (`packages/core/src/errors.ts`) with `code: "MODEL_PROVIDER_FAILED"`, the original preserved on `.cause`, `context: { provider, modelKey }`, and `severity: "ephemeral"` — so it composes with `runtime.reportError` and stringifies diagnostically.

The message is assembled by a new exported helper `describeModelCallError` in `services/message/fallback-reply.ts` (where the sibling error-shape classifiers already live). It unwraps the AI-SDK retry envelope, reads the HTTP status, and extracts the most specific message from the error or its nested provider body (`{ error: { message } }`, `{ error: "..." }`, `{ message }`). When neither status nor message is recoverable it **serializes the payload** rather than ever returning `"[object Object]"`.

Result message, e.g.: `Model provider "claude-sdk" failed: HTTP 500: upstream exploded`.

The in-catch call site passes `{ modelKey, provider }` from the failed `resolvedModel`, so the provider name is always in the message.

## Test — failing-then-passing

Two regression tests added to `runtime/__tests__/model-provider-failover.test.ts`, driving a **real** `AgentRuntime` over the in-memory adapter with a stub handler that throws a bare object (no network model call):

1. `{ status: 500, error: { message: "upstream exploded" } }` → asserts the thrown error's `.message`/`String(err)` contain the provider (`claude-sdk`), cause (`upstream exploded`), and status (`500`), **not** `[object Object]`; and `.code === "MODEL_PROVIDER_FAILED"`, `.cause === the original object`.
2. An opaque `{ reason, providerHint }` payload with no status/message → asserts it serializes (`provider melted`), never `[object Object]`.

**On pre-fix behavior (temporarily reverted rethrow):**

```
× stringifies a non-Error provider failure diagnostically, not as [object Object]
× serializes an opaque non-Error failure payload instead of [object Object]
AssertionError: expected '[object Object]' not to contain '[object Object]'
  Tests  2 failed | 7 passed (9)
```

**With the fix:**

```
Test Files  2 passed (2)
     Tests  13 passed (13)   # failover suite + provider-error-hygiene
```

`bun run --cwd packages/core typecheck` clean.

## Scope

`packages/core` only. No behavior change for well-formed provider errors (rethrown as-is); the fix only rescues the previously-`[object Object]` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)