### PR TITLE
test(#14326): prove sensitive-request DM link-out on the real connector adapters

### DIFF
--- a/plugins/plugin-discord/__tests__/sensitive-request-adapter.test.ts
+++ b/plugins/plugin-discord/__tests__/sensitive-request-adapter.test.ts
@@ -3,8 +3,15 @@
  * approval requests, against a mocked runtime and Discord client.
  */
 import type { IAgentRuntime, SensitiveRequest } from "@elizaos/core";
+import {
+	createSensitiveRequestDispatchRegistry,
+	type SensitiveRequestDeliveryAdapter,
+} from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createDiscordDmSensitiveRequestAdapter } from "../sensitive-request-adapter";
+import {
+	createDiscordDmSensitiveRequestAdapter,
+	discordDmSensitiveRequestAdapter,
+} from "../sensitive-request-adapter";
 
 interface MockDmChannel {
 	id: string;
@@ -242,5 +249,71 @@ describe("discordDmSensitiveRequestAdapter", () => {
 			content: string;
 		};
 		expect(sent.content).toContain("https://cloud.eliza.example/secret/req-1");
+	});
+});
+
+// The connector leg of #14326: the REAL exported adapter, wired through the REAL
+// core dispatch registry the way production loads it, proving (a) two connectors
+// sharing the "dm" target resolve per channel and (b) the secret value never
+// appears in the outbound DM the connector puts on the wire — only the link does.
+describe("discordDmSensitiveRequestAdapter — real dispatch-registry integration (#14326)", () => {
+	const HOSTED_LINK = "https://cloud.eliza.example/sensitive-requests/req-1";
+	const SECRET_SENTINEL = "sk-live-DO-NOT-LEAK-discord-1234567890";
+
+	function makeCloudRuntimeWithDiscord(client: unknown): IAgentRuntime {
+		return {
+			getSetting: vi.fn((key: string) =>
+				key === "ELIZA_CLOUD_API_KEY" ? "cloud-key-abc" : undefined,
+			),
+			getService: vi.fn((name: string) =>
+				name === "discord" ? { client } : null,
+			),
+		} as unknown as IAgentRuntime;
+	}
+
+	it("resolve('dm') picks Discord over a Telegram-like sibling when the Discord service is live", () => {
+		const registry = createSensitiveRequestDispatchRegistry();
+		// A sibling that claims the channel only when a "telegram" service exists —
+		// here it does not, so the registry must fall through to Discord.
+		const telegramLike: SensitiveRequestDeliveryAdapter = {
+			target: "dm",
+			supportsChannel: (_ch, runtime) =>
+				Boolean(
+					(runtime as { getService?: (n: string) => unknown })?.getService?.(
+						"telegram",
+					),
+				),
+			deliver: async () => ({ delivered: true, target: "dm" }),
+		};
+		registry.register(telegramLike);
+		registry.register(discordDmSensitiveRequestAdapter);
+
+		const runtime = makeCloudRuntimeWithDiscord(makeMockDiscord().client);
+		expect(registry.resolve?.("dm", "user-snowflake-1234", runtime)).toBe(
+			discordDmSensitiveRequestAdapter,
+		);
+	});
+
+	it("delivers the hosted link in the DM but never the secret value", async () => {
+		const mock = makeMockDiscord();
+		const runtime = makeCloudRuntimeWithDiscord(mock.client);
+		const registry = createSensitiveRequestDispatchRegistry();
+		registry.register(discordDmSensitiveRequestAdapter);
+
+		const request = makeRequest({
+			kind: "secret",
+			callback: { url: HOSTED_LINK },
+			// Secret-adjacent material the adapter must never serialize into the DM.
+			secretValue: SECRET_SENTINEL,
+		} as Partial<SensitiveRequest>);
+
+		const result = await registry
+			.resolve?.("dm", "user-snowflake-1234", runtime)
+			?.deliver({ request, channelId: "user-snowflake-1234", runtime });
+
+		expect(result?.delivered).toBe(true);
+		const sent = mock.dmChannel.send.mock.calls[0]?.[0] as { content: string };
+		expect(sent.content).toContain(HOSTED_LINK);
+		expect(sent.content).not.toContain(SECRET_SENTINEL);
 	});
 });

--- a/plugins/plugin-telegram/src/sensitive-request-adapter.test.ts
+++ b/plugins/plugin-telegram/src/sensitive-request-adapter.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Real-connector proof for the Telegram sensitive-request DM link-out (#14326).
+ *
+ * The security-sensitive path this covers: an agent needs a secret / OAuth
+ * consent from a group chat where an inline widget cannot render, so it DMs the
+ * user a single tap-through link to a hosted authenticated page; the value is
+ * collected there and never typed into the chat transport. This exercises the
+ * REAL production adapter (`telegramDmSensitiveRequestAdapter`) end-to-end over
+ * a REAL Telegraf client doing a REAL HTTP round-trip to a local stand-in Bot
+ * API server — so the exact bytes Telegram would receive are captured and the
+ * "no secret material transits chat" invariant is asserted against the actual
+ * serialized wire payload, not a hand-rolled stub of it. The merged headless
+ * e2e (`packages/cloud/shared/.../sensitive-request-hosted-page-e2e.test.ts`)
+ * proves the service/token/callback leg; this file proves the connector leg the
+ * issue's remaining acceptance criterion calls out. The only thing not real
+ * here is the Bot API host (local server, not api.telegram.org) and the human
+ * who taps the link — that final live round-trip is owner-run and gated in the
+ * hosted-page e2e.
+ */
+
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+import type { AddressInfo } from "node:net";
+import { Telegraf } from "telegraf";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  createSensitiveRequestDispatchRegistry,
+  type DispatchSensitiveRequest,
+  type SensitiveRequestDeliveryAdapter,
+} from "../../../packages/core/src/sensitive-requests/dispatch-registry";
+import { telegramDmSensitiveRequestAdapter } from "./sensitive-request-adapter";
+
+// A benign token — the local server accepts anything; only the URL path shape
+// (`/bot<token>/sendMessage`) and JSON body matter.
+const BOT_TOKEN = "999999999:AA_test_dummy_telegram_bot_token";
+const CHAT_ID = "123456789";
+const HOSTED_LINK = "https://cloud.example.ai/sensitive-requests/req-tg-1";
+// Placed in request fields the adapter must NOT serialize. If the raw wire body
+// ever contains this, the connector leaked secret-adjacent material.
+const SECRET_SENTINEL = "sk-live-DO-NOT-LEAK-telegram-0987654321";
+
+interface CapturedCall {
+  path: string;
+  method: string;
+  contentType: string | undefined;
+  body: string;
+  parsed: Record<string, unknown>;
+}
+
+/**
+ * A minimal, faithful stand-in for the Telegram Bot API. Real Telegraf serializes
+ * and POSTs to it over HTTP; we capture the exact request and reply with the
+ * `{ ok: true, result: <Message> }` envelope Telegraf's client (telegraf 4.16.3,
+ * `core/network/client.ts`) requires. `mode` lets a test force the blocked-by-user
+ * error path (HTTP 200 + `ok:false`, which Telegraf turns into a thrown error).
+ */
+class MockBotApi {
+  readonly calls: CapturedCall[] = [];
+  mode: "ok" | "blocked" = "ok";
+  private server: Server | undefined;
+
+  async start(): Promise<string> {
+    this.server = createServer((req, res) => this.handle(req, res));
+    await new Promise<void>((resolve) =>
+      this.server?.listen(0, "127.0.0.1", resolve),
+    );
+    const { port } = this.server?.address() as AddressInfo;
+    return `http://127.0.0.1:${port}`;
+  }
+
+  async stop(): Promise<void> {
+    if (!this.server) return;
+    await new Promise<void>((resolve, reject) =>
+      this.server?.close((err) => (err ? reject(err) : resolve())),
+    );
+  }
+
+  reset(): void {
+    this.calls.length = 0;
+    this.mode = "ok";
+  }
+
+  private handle(req: IncomingMessage, res: ServerResponse): void {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      const body = Buffer.concat(chunks).toString("utf8");
+      let parsed: Record<string, unknown> = {};
+      try {
+        parsed = body ? (JSON.parse(body) as Record<string, unknown>) : {};
+      } catch {
+        // error-policy:J3 untrusted body — record raw, leave parsed empty so the
+        // test can still assert on the wire bytes.
+        parsed = {};
+      }
+      this.calls.push({
+        path: req.url ?? "",
+        method: req.method ?? "",
+        contentType: req.headers["content-type"],
+        body,
+        parsed,
+      });
+      res.setHeader("content-type", "application/json");
+      if (this.mode === "blocked") {
+        // Real Telegram response when the user has blocked the bot. HTTP 200 with
+        // ok:false is exactly what Telegraf surfaces as a TelegramError.
+        res.statusCode = 200;
+        res.end(
+          JSON.stringify({
+            ok: false,
+            error_code: 403,
+            description: "Forbidden: bot was blocked by the user",
+          }),
+        );
+        return;
+      }
+      const chatId = Number((parsed as { chat_id?: unknown }).chat_id);
+      res.statusCode = 200;
+      res.end(
+        JSON.stringify({
+          ok: true,
+          result: {
+            message_id: 42,
+            date: Math.floor(Date.now() / 1000),
+            chat: { id: chatId, type: "private" },
+            text: (parsed as { text?: string }).text ?? "",
+          },
+        }),
+      );
+    });
+  }
+}
+
+let mockApi: MockBotApi;
+let apiRoot: string;
+
+function makeTelegramRuntime(): { getService: (name: string) => unknown } {
+  // A real Telegraf client, pointed at the local Bot API. Wrapped in the exact
+  // `{ bot }` shape the adapter's `getTelegramBot` looks up under the "telegram"
+  // service — so the adapter drives the genuine telegraf send path.
+  const bot = new Telegraf(BOT_TOKEN, { telegram: { apiRoot } });
+  return {
+    getService: (name: string) => (name === "telegram" ? { bot } : null),
+  };
+}
+
+function makeRequest(
+  overrides: Partial<DispatchSensitiveRequest> = {},
+): DispatchSensitiveRequest {
+  return {
+    id: "req-tg-1",
+    kind: "secret",
+    expiresAt: "2099-01-01T00:00:00.000Z",
+    // The hosted link the connector DMs. Production populates this via the
+    // secrets/oauth feature (cloud-authenticated link when Cloud is linked).
+    callback: { url: HOSTED_LINK },
+    delivery: { reason: "The agent needs your OpenAI API key to continue." },
+    // Secret-adjacent material the adapter must never put on the wire.
+    secretValue: SECRET_SENTINEL,
+    ...overrides,
+  } as DispatchSensitiveRequest;
+}
+
+beforeAll(async () => {
+  mockApi = new MockBotApi();
+  apiRoot = await mockApi.start();
+});
+
+afterAll(async () => {
+  await mockApi.stop();
+});
+
+afterEach(() => {
+  mockApi.reset();
+});
+
+describe("#14326 telegramDmSensitiveRequestAdapter — real connector transport", () => {
+  it("declares the 'dm' target and only supports the channel when the Telegram bot is live", () => {
+    expect(telegramDmSensitiveRequestAdapter.target).toBe("dm");
+    // Present service → claims the DM channel.
+    expect(
+      telegramDmSensitiveRequestAdapter.supportsChannel?.(
+        CHAT_ID,
+        makeTelegramRuntime(),
+      ),
+    ).toBe(true);
+    // No Telegram service → does not claim it, so the registry falls through to
+    // another connector's "dm" adapter.
+    expect(
+      telegramDmSensitiveRequestAdapter.supportsChannel?.(CHAT_ID, {
+        getService: () => null,
+      }),
+    ).toBe(false);
+  });
+
+  it("the real dispatch registry resolves 'dm' to Telegram over a sibling connector for a Telegram chat", async () => {
+    const registry = createSensitiveRequestDispatchRegistry();
+    // A Discord-like sibling that claims only its own transport. Registering both
+    // under "dm" is the collision the registry resolves per channel.
+    const discordLike: SensitiveRequestDeliveryAdapter = {
+      target: "dm",
+      supportsChannel: (_ch, runtime) =>
+        Boolean(
+          (runtime as { getService?: (n: string) => unknown })?.getService?.(
+            "discord",
+          ),
+        ),
+      deliver: async () => ({ delivered: true, target: "dm" }),
+    };
+    registry.register(discordLike);
+    registry.register(telegramDmSensitiveRequestAdapter);
+
+    const runtime = makeTelegramRuntime();
+    const resolved = registry.resolve?.("dm", CHAT_ID, runtime);
+    expect(resolved).toBe(telegramDmSensitiveRequestAdapter);
+  });
+
+  it("delivers a secret link-out DM over a real Telegraf HTTP round-trip; the link is on the wire, the secret is not", async () => {
+    const runtime = makeTelegramRuntime();
+
+    const result = await telegramDmSensitiveRequestAdapter.deliver({
+      request: makeRequest(),
+      channelId: CHAT_ID,
+      runtime,
+    });
+
+    // The adapter reports a real delivery with the link it handed off.
+    expect(result.delivered).toBe(true);
+    expect(result.target).toBe("dm");
+    expect(result.channelId).toBe(CHAT_ID);
+    expect(result.url).toBe(HOSTED_LINK);
+
+    // A real HTTP POST reached the Bot API at the sendMessage endpoint.
+    expect(mockApi.calls).toHaveLength(1);
+    const call = mockApi.calls[0];
+    expect(call.method).toBe("POST");
+    expect(call.path).toBe(`/bot${BOT_TOKEN}/sendMessage`);
+    expect(call.contentType).toContain("application/json");
+
+    // The message targets the right chat and carries the tap-through link button.
+    expect(call.parsed.chat_id).toBe(Number(CHAT_ID));
+    const replyMarkup = call.parsed.reply_markup as {
+      inline_keyboard: Array<Array<{ text: string; url: string }>>;
+    };
+    expect(replyMarkup.inline_keyboard[0][0].url).toBe(HOSTED_LINK);
+    expect(replyMarkup.inline_keyboard[0][0].text).toBe("Provide securely");
+    expect(String(call.parsed.text)).toContain(
+      "A sensitive value is needed to continue.",
+    );
+
+    // The invariant: the exact bytes on the wire carry the link but never the
+    // secret-adjacent material attached to the request.
+    expect(call.body).toContain(HOSTED_LINK);
+    expect(call.body).not.toContain(SECRET_SENTINEL);
+  });
+
+  it("labels the button 'Connect <provider>' for an OAuth consent link-out", async () => {
+    const runtime = makeTelegramRuntime();
+
+    await telegramDmSensitiveRequestAdapter.deliver({
+      request: makeRequest({
+        kind: "oauth",
+        provider: "google",
+        callback: { url: HOSTED_LINK },
+        delivery: { reason: "Connect Google to read your calendar." },
+      }),
+      channelId: CHAT_ID,
+      runtime,
+    });
+
+    const replyMarkup = mockApi.calls[0].parsed.reply_markup as {
+      inline_keyboard: Array<Array<{ text: string; url: string }>>;
+    };
+    expect(replyMarkup.inline_keyboard[0][0].text).toBe("Connect google");
+    expect(replyMarkup.inline_keyboard[0][0].url).toBe(HOSTED_LINK);
+  });
+
+  it("sends a plain-text fallback with no button when no link is available", async () => {
+    const runtime = makeTelegramRuntime();
+
+    const result = await telegramDmSensitiveRequestAdapter.deliver({
+      request: makeRequest({
+        callback: {},
+        delivery: {
+          reason: "A value is required.",
+          instruction: "Open the Eliza app.",
+        },
+      }),
+      channelId: CHAT_ID,
+      runtime,
+    });
+
+    expect(result.delivered).toBe(true);
+    expect(result.url).toBeUndefined();
+    const call = mockApi.calls[0];
+    expect(call.parsed.reply_markup).toBeUndefined();
+    expect(String(call.parsed.text)).toContain("Open the Eliza app.");
+  });
+
+  it("fails closed with no HTTP call when no Telegram bot is available", async () => {
+    const result = await telegramDmSensitiveRequestAdapter.deliver({
+      request: makeRequest(),
+      channelId: CHAT_ID,
+      runtime: { getService: () => null },
+    });
+
+    expect(result.delivered).toBe(false);
+    expect(result.error).toBe("Telegram service unavailable");
+    expect(mockApi.calls).toHaveLength(0);
+  });
+
+  it("rejects a non-numeric Telegram user id before any send", async () => {
+    const runtime = makeTelegramRuntime();
+
+    const result = await telegramDmSensitiveRequestAdapter.deliver({
+      request: makeRequest(),
+      channelId: "not-a-telegram-id",
+      runtime,
+    });
+
+    expect(result.delivered).toBe(false);
+    expect(result.error).toMatch(/No Telegram user id available/);
+    expect(mockApi.calls).toHaveLength(0);
+  });
+
+  it("surfaces a delivery failure when the recipient has blocked the bot", async () => {
+    const runtime = makeTelegramRuntime();
+    mockApi.mode = "blocked";
+
+    const result = await telegramDmSensitiveRequestAdapter.deliver({
+      request: makeRequest(),
+      channelId: CHAT_ID,
+      runtime,
+    });
+
+    // The real HTTP call happened and returned Telegram's 403; the adapter turns
+    // it into a structured failure rather than throwing.
+    expect(mockApi.calls).toHaveLength(1);
+    expect(result.delivered).toBe(false);
+    expect(result.target).toBe("dm");
+    expect(result.error).toMatch(/blocked by the user/i);
+  });
+});


### PR DESCRIPTION
## What

Adds repeatable, CI-checkable automated coverage that drives the **real production connector adapters** for the sensitive-request DM link-out flow (#14326) — the security-critical path where an agent needs a secret/OAuth consent from a group chat, DMs a hosted-page link, and the value is collected off-transport.

- **`plugins/plugin-telegram/src/sensitive-request-adapter.test.ts`** (new — this adapter previously had **zero** tests): drives the real `telegramDmSensitiveRequestAdapter` end to end over a **real Telegraf 4.16.3 client doing a real HTTP round-trip** to a local Bot API stand-in (via the `apiRoot` option). The exact bytes Telegram would receive are captured and asserted — the tap-through link button is on the wire, secret-adjacent material is not. Also covers: real dispatch-registry resolution across a sibling `dm` connector, the OAuth `Connect <provider>` button label, the no-link plain-text fallback, and fail-closed paths (no bot service, non-numeric chat id, recipient-blocked-bot 403).
- **`plugins/plugin-discord/__tests__/sensitive-request-adapter.test.ts`**: adds real-dispatch-registry integration for the exported `discordDmSensitiveRequestAdapter` — per-channel resolution over a sibling connector, and hosted link present in the DM while the secret value is not.

## Why

The merged headless e2e (#14617, `packages/cloud/shared/src/lib/services/sensitive-request-hosted-page-e2e.test.ts`) proves the `SensitiveRequestsService` / token / callback leg, but it delivers over hand-rolled `makeDmAdapter` **stubs**, not the real connector code. The issue's remaining acceptance criterion — *prove the flow on a REAL connector* — was left entirely to an owner-run live pass. This PR closes the **automated-coverage half** of that criterion by exercising the actual production adapters and, for Telegram, the actual wire serialization over real HTTP. It makes the connector leg mechanically checkable so it can never silently regress.

The final `api.telegram.org` / `discord.com` + human-tap round-trip against real cloud remains **owner-gated** in the hosted-page e2e's live block (`ELIZA_SENSITIVE_LIVE=1` + `ELIZAOS_CLOUD_API_KEY` + connector bot tokens) — that leg is unchanged and still self-skips with a reason when creds are absent; it produces the MP4 / live-LLM trajectory the issue lists. This runner has only a Cerebras eval key, so that leg could not be run here (see N/A rows).

Closes #14326

## Evidence

<details><summary>Automated coverage — new Telegram real-transport suite (8/8 pass)</summary>

```
✓ src/sensitive-request-adapter.test.ts > #14326 telegramDmSensitiveRequestAdapter — real connector transport > declares the 'dm' target and only supports the channel when the Telegram bot is live
✓ > the real dispatch registry resolves 'dm' to Telegram over a sibling connector for a Telegram chat
✓ > delivers a secret link-out DM over a real Telegraf HTTP round-trip; the link is on the wire, the secret is not
✓ > labels the button 'Connect <provider>' for an OAuth consent link-out
✓ > sends a plain-text fallback with no button when no link is available
✓ > fails closed with no HTTP call when no Telegram bot is available
✓ > rejects a non-numeric Telegram user id before any send
✓ > surfaces a delivery failure when the recipient has blocked the bot

 Test Files  1 passed (1)
      Tests  8 passed (8)
```
</details>

<details><summary>Automated coverage — Discord adapter suite (10/10 pass, incl. 2 new real-registry tests)</summary>

```
✓ discordDmSensitiveRequestAdapter > ...(8 existing)...
✓ discordDmSensitiveRequestAdapter — real dispatch-registry integration (#14326) > resolve('dm') picks Discord over a Telegram-like sibling when the Discord service is live
✓ discordDmSensitiveRequestAdapter — real dispatch-registry integration (#14326) > delivers the hosted link in the DM but never the secret value

 Test Files  1 passed (1)
      Tests  10 passed (10)
```
</details>

<details><summary>Full plugin-telegram suite — no regression (17/18 files, 128 tests pass)</summary>

```
Test Files  1 failed | 17 passed (18)
     Tests  128 passed (128)
```
The single failing file (`src/connector-sources.test.ts`) is a **pre-existing** shared-mock-drift failure on `develop` (`No "BaseMessageAdapter" export is defined on the "@elizaos/core" mock`) — this PR touches neither that file nor `__tests__/core-test-mock.ts`.
</details>

<details><summary>AC #4 — raw connector payload dump: hosted link on the wire, secret never in transport</summary>

Captured from the real Telegraf → local Bot API HTTP round-trip:

```
=== DeliveryResult (what the agent's dispatch sees) ===
{
  "delivered": true,
  "target": "dm",
  "channelId": "123456789",
  "url": "https://cloud.example.ai/sensitive-requests/req-tg-1",
  "expiresAt": "2099-01-01T00:00:00.000Z"
}

=== RAW HTTP request the Telegram Bot API received ===
POST /bot999999999:AA_test_dummy_telegram_bot_token/sendMessage
{
  "chat_id": 123456789,
  "reply_markup": {
    "inline_keyboard": [[{ "text": "Provide securely",
                           "url": "https://cloud.example.ai/sensitive-requests/req-tg-1",
                           "hide": false }]]
  },
  "text": "A sensitive value is needed to continue.\nThe agent needs your OpenAI API key to continue.\nThis request expires at 2099-01-01T00:00:00.000Z."
}

=== no-secret-in-transport invariant ===
wire contains hosted link:     true
wire contains SECRET_SENTINEL: false
```
</details>

<details><summary>Backend logs — adapter fail-closed path fires (structured logger)</summary>

```
Warn  [DISCORD:SENSITIVE-REQUEST-ADAPTER] Failed to deliver sensitive request DM (err=send failed)
Warn  [DISCORD:SENSITIVE-REQUEST-ADAPTER] Failed to deliver sensitive request DM (err=fetch failed)
```
The Telegram blocked-bot 403 path is asserted to return `{ delivered:false, target:"dm", error:/blocked by the user/ }` after a real HTTP call.
</details>

**Scoped checks:** `plugin-telegram typecheck` → 0 errors; `biome check` on both changed files → clean. (Discord typecheck surfaces only pre-existing unbuilt-dep noise in unrelated files: `@elizaos/plugin-sql`, `@elizaos/vault`.)

### PR_EVIDENCE rows

- **Real-LLM trajectory:** N/A — the code path under test is connector transport (adapter → dispatch registry → HTTP), with no model call. The agent-reaction-to-fulfillment trajectory is produced by the owner-gated live block in the hosted-page e2e, which requires cloud + connector credentials not present on this runner (Cerebras-only).
- **MP4 walkthrough / before-after screenshots:** N/A — no UI surface changed; this is headless connector coverage. The human tap-through MP4 (group ask → DM link → hosted page → agent ack) is owner-gated in the live e2e block, unchanged by this PR.
- **Backend logs:** attached above (structured `[DISCORD:SENSITIVE-REQUEST-ADAPTER]` warns + asserted Telegram 403 failure result).
- **Raw connector payload dump:** attached above (real Telegraf HTTP body; link present, secret absent).
- **Domain artifacts:** N/A — no DB rows/secrets created by these tests; the secret-storage + callback leg is covered by the merged #14617 headless e2e.
