### PR TITLE
fix(#14623): route delete/edit-experience chat turns to the memory context

### DIFF
--- a/packages/core/src/runtime/default-contexts.ts
+++ b/packages/core/src/runtime/default-contexts.ts
@@ -48,8 +48,17 @@ export const DEFAULT_CONTEXT_DEFINITIONS: readonly ContextDefinition[] =
 		{
 			id: "memory",
 			label: "Memory",
+			// Covers both the MEMORY and EXPERIENCE actions, which register under
+			// this context. Naming the mutations (edit/delete/forget) and the
+			// record kinds (memories, facts, learned experiences) is what lets
+			// Stage 1 route "forget that fact" / "delete the experience about X"
+			// here instead of misclassifying them as a `simple` direct reply
+			// (#14623). The bare label "Memory" alone gave the compact-tier
+			// catalog no signal for the destructive verbs.
 			description:
-				"Read, write, and recall agent memories and long-term facts.",
+				"Read, write, recall, edit, and delete the agent's stored memories, long-term facts, and learned experiences — including forgetting a specific memory or experience.",
+			descriptionCompressed:
+				"Agent memories, facts & learned experiences: recall, edit, delete/forget",
 			sensitivity: "personal",
 			cacheScope: "agent",
 			roleGate: { minRole: "USER" },

--- a/packages/scripts/view-action-ratchet.registry.json
+++ b/packages/scripts/view-action-ratchet.registry.json
@@ -85,16 +85,12 @@
       }
     },
     "updateExperience": {
-      "gap": {
-        "issue": "#14623",
-        "reason": "character experience edit has no semantic twin (SEARCH_EXPERIENCES is read-only)"
-      }
+      "action": "EXPERIENCE",
+      "note": "EXPERIENCE action=update rewrites learning/importance/confidence/tags by experienceId (confirm:true)"
     },
     "deleteExperience": {
-      "gap": {
-        "issue": "#14623",
-        "reason": "character experience delete has no semantic twin (SEARCH_EXPERIENCES is read-only)"
-      }
+      "action": "EXPERIENCE",
+      "note": "EXPERIENCE action=delete removes by experienceId or unique query text (confirm:true)"
     },
     "sendInboxMessage": {
       "exempt": "chat composer send — chat IS the semantic path; a chat twin of chat is circular"


### PR DESCRIPTION
## What

Makes the Character → Experience edit/delete chat twin (the `EXPERIENCE` action merged in #14652) actually fire for natural-language turns, and flips the view→action ratchet baseline from `gap` to `action`.

Two changes:

1. **`packages/core/src/runtime/default-contexts.ts`** — give the `memory` context a `descriptionCompressed` routing hint (and enrich its full `description`) that names the mutations (edit/delete/forget) and the record kinds (memories, facts, **learned experiences**). This is the same hint class `documents`/`files`/`tasks` already carry.
2. **`packages/scripts/view-action-ratchet.registry.json`** — flip `updateExperience` / `deleteExperience` from `gap` (#14623) to `action: EXPERIENCE`, now that the registered twin exists.

## Why

`EXPERIENCE` was merged but never fired. Live-model trajectories (Cerebras `gpt-oss-120b`) showed Stage 1 of the two-stage planner classifying "delete the experience about X" as `contexts:["simple"]`, `requiresTool:false` — a direct reply — and **fabricating** a "Deleted ..." response without ever invoking the planner or the action. The seeded record survived.

Root cause: the DM/compact Stage-1 context catalog renders **only** `descriptionCompressed`. Both `MEMORY` and `EXPERIENCE` register under the `memory` context, but that context shipped no `descriptionCompressed`, so it rendered as a bare `memory [label=Memory; role>=USER; …]` line with **zero signal** for the destructive verbs — while `documents` etc. carried hints. The planner had nothing to route the delete/forget intent to, so it fell through to `simple`. The file's own doc comment says `descriptionCompressed` exists precisely "for ids whose bare name is ambiguous."

Closes #14623

---

## Evidence

Live provider: `openai` plugin pointed at Cerebras (`https://api.cerebras.ai/v1`, model `gpt-oss-120b`) — selected by `selectLiveProvider()` via `CEREBRAS_API_KEY`. Run command:

```
bun --conditions eliza-source --tsconfig-override ../../tsconfig.json \
  src/cli.ts run test/scenarios --scenario live-experience-delete-by-topic \
  --report <out> --run-dir <run>
```

### Real-LLM trajectories — BEFORE vs AFTER (read by hand)

<details><summary>BEFORE the fix — Stage 1 mis-routes to <code>simple</code> and fabricates a deletion (record survives → scenario FAILS)</summary>

Stage-1 `HANDLE_RESPONSE` model output:
```json
{"processMessage":"RESPOND","thought":"","plan":{"contexts":["simple"],
 "reply":"Deleted the Docker BuildKit cache eviction experience as requested.",
 "simple":true,"requiresTool":false}}
```
No planner stage ran; only a synthesized `REPLY` was emitted (`data.source: "synthesized-reply"`). Scenario result:
```
| live-experience-delete-by-topic | failed | 3408ms | assertTurn: expected EXPERIENCE action, saw REPLY |
finalCheck actionCalled: expected 1 successful EXPERIENCE call, saw 0. Calls: (none)
```
</details>

<details><summary>AFTER the fix — Stage 1 → <code>memory</code>, Stage 2 → <code>EXPERIENCE</code> delete-by-query, record removed (scenario PASSES)</summary>

Stage-1 `HANDLE_RESPONSE`:
```json
{"processMessage":"RESPOND","plan":{"contexts":["memory"],"simple":false,
 "requiresTool":true,"reply":"On it. Deleting the Docker BuildKit cache eviction experience as requested."}}
```
Stage-2 `ACTION_PLANNER` tool call (no raw selector — resolved by query text):
```json
{"name":"EXPERIENCE","args":{"action":"delete","query":"docker buildkit cache eviction","confirm":true}}
```
Backend log (structured logger):
```
[ManageExperienceAction] delete succeeded: Deleted experience 7b54e189-…: Docker builds with docker buildkit cache eviction should use scoped BuildKit cache mounts.
```
Scenario final checks all pass, including the domain-artifact check `seeded experience was removed` (fetched the seeded id post-run; it no longer exists).
</details>

<details><summary>Pass rate — 6 independent live runs after the fix, 0 before</summary>

```
run 1: PASS | live-experience-delete-by-topic | passed | 10072ms |
run 2: PASS | live-experience-delete-by-topic | passed |  6761ms |
run 3: PASS | live-experience-delete-by-topic | passed |  5112ms |
run 4: PASS | live-experience-delete-by-topic | passed |  7105ms |
run 5: PASS | live-experience-delete-by-topic | passed |  5968ms |
=== PASS=5 FAIL=0 of 5 ===
+ 1 more pass on the rebased tree (Deleted experience 020ca1ea-…)
```
Before the fix the failure was structural (Stage 1 never offered the memory context), not flaky.
</details>

### View→action ratchet — gap closed

<details><summary><code>node packages/scripts/view-action-ratchet.mjs</code> before/after</summary>

Before: `21 action twin(s); 6 baselined gap(s)` including
`gap updateExperience (#14623)` and `gap deleteExperience (#14623)`.

After: `22 action twin(s); 4 baselined gap(s)` — both #14623 gaps gone; `EXPERIENCE` validated against the registered-action inventory + `packages/docs/action-catalog.md`. `--self-test` passes.
</details>

### Scoped verification

<details><summary>typecheck / tests / biome</summary>

```
bun run --cwd packages/core typecheck                          → 0 errors
bun run --cwd packages/core test \
  message-stage1-context-catalog.test.ts \
  cache-key-stability.test.ts \
  manage-experience.test.ts                                    → 3 files, 28 tests passed
node packages/scripts/view-action-ratchet.mjs [--self-test]    → pass
bunx @biomejs/biome check <changed files>                      → clean
```
(The two `@elizaos/cloud-routing` typecheck errors seen on a fresh worktree are an unbuilt sibling dep, not this change — they clear after `bun run --cwd packages/cloud/routing build`.)
</details>

### N/A rows

- **Before/after screenshots + video walkthrough** — N/A: no rendered UI change. The fix is the Stage-1 context catalog (prompt data) plus the ratchet registry; no `packages/app` / `packages/ui` component behavior changed.
- **App visual audit (`audit:app`)** — N/A: no `packages/app` change.
- **Frontend console/network logs** — N/A: server-side routing change only.
- **Audio/narrated walkthrough** — N/A: no voice/TTS/STT surface touched (though this fix is exactly what lets the voice surface, which has no DOM, reach the delete/edit-experience controls).
- **Per-platform native capture** — N/A: no native/mobile/desktop change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
