### PR TITLE
fix(core): diagnostic failure reason for SCHEDULED_TASKS trajectory aborts (no more ':failed')

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -1607,6 +1607,94 @@ describe("v5 planner loop skeleton", () => {
 		).rejects.toBeInstanceOf(TrajectoryLimitExceeded);
 	});
 
+	it("surfaces the tool's diagnostic reason (not a bare 'failed') when a success:false result carries no typed error (#14873)", async () => {
+		// SCHEDULED_TASKS and most actions report failure as
+		// `{ success:false, text:"<why>", data:{ error:"<CODE>" } }`, reserving the
+		// typed `error` field for thrown Errors. Before the fix the failure
+		// signature flattened every such failure to the literal "failed", so a
+		// repeated-failure abort read `Repeated tool failure limit exceeded for
+		// SCHEDULED_TASKS:failed` — diagnostically useless (observed live on the
+		// news-heartbeat turn). The human reason must survive into the limit error.
+		const runtime = {
+			useModel: vi.fn(async () => ({
+				text: "",
+				toolCalls: [
+					{ id: "call-1", name: "SCHEDULED_TASKS", arguments: { action: "create" } },
+				],
+			})),
+		};
+		const executeToolCall = vi.fn(async () => ({
+			success: false,
+			text: "I need a trigger (once | cron | interval | ...) to schedule a task.",
+			data: { subaction: "create", error: "MISSING_TRIGGER" },
+		}));
+		const evaluate = vi.fn(async () => ({
+			success: false,
+			decision: "CONTINUE" as const,
+			thought: "Retry.",
+		}));
+
+		let thrown: unknown;
+		try {
+			await runPlannerLoop({
+				runtime,
+				context: { id: "ctx" },
+				config: { maxRepeatedFailures: 1 },
+				executeToolCall,
+				evaluate,
+			});
+		} catch (error) {
+			thrown = error;
+		}
+
+		expect(thrown).toBeInstanceOf(TrajectoryLimitExceeded);
+		const message = (thrown as TrajectoryLimitExceeded).message;
+		expect(message).toContain("SCHEDULED_TASKS");
+		expect(message).toContain("I need a trigger");
+		expect(message).not.toContain("SCHEDULED_TASKS:failed");
+	});
+
+	it("falls back to the data.error code when a success:false result has no text (#14873)", async () => {
+		// The `text` projection is the preferred human reason, but a failure that
+		// carries only a machine code in `data.error` must still name that code
+		// rather than degrade to "failed".
+		const runtime = {
+			useModel: vi.fn(async () => ({
+				text: "",
+				toolCalls: [
+					{ id: "call-1", name: "SCHEDULED_TASKS", arguments: { action: "create" } },
+				],
+			})),
+		};
+		const executeToolCall = vi.fn(async () => ({
+			success: false,
+			data: { subaction: "create", error: "MISSING_TRIGGER" },
+		}));
+		const evaluate = vi.fn(async () => ({
+			success: false,
+			decision: "CONTINUE" as const,
+			thought: "Retry.",
+		}));
+
+		let thrown: unknown;
+		try {
+			await runPlannerLoop({
+				runtime,
+				context: { id: "ctx" },
+				config: { maxRepeatedFailures: 1 },
+				executeToolCall,
+				evaluate,
+			});
+		} catch (error) {
+			thrown = error;
+		}
+
+		expect(thrown).toBeInstanceOf(TrajectoryLimitExceeded);
+		expect((thrown as TrajectoryLimitExceeded).message).toContain(
+			"MISSING_TRIGGER",
+		);
+	});
+
 	it("does not count different failed tool parameters as the same repeated failure", async () => {
 		const runtime = {
 			useModel: vi

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -2127,7 +2127,7 @@ async function executeQueuedToolCall(params: {
 		success: result.success,
 		error: isParameterValidationFailure
 			? "parameter_validation_failed"
-			: result.error,
+			: (result.error ?? diagnosticFailureReason(result)),
 		repeatKey: isParameterValidationFailure
 			? "parameter_validation"
 			: toolFailureRepeatKey(params.toolCall),
@@ -3010,6 +3010,41 @@ function splitUnavailableToolCalls(
 
 function toolFailureRepeatKey(toolCall: PlannerToolCall): string {
 	return `${toolCall.name}:${stringifyForModel(toolCall.params ?? {})}`;
+}
+
+/**
+ * Recover a diagnostic failure reason from a tool result that reported
+ * `success:false` but carried no typed `error`. The dominant action
+ * convention in this codebase puts the human-readable reason in `text` and a
+ * machine code in `data.error` — e.g. SCHEDULED_TASKS returning
+ * `{ success:false, text:"I need a trigger (once | cron | ...)", data:{ error:"MISSING_TRIGGER" } }`.
+ * The typed `error` field is reserved for thrown `Error`s, so those
+ * validation failures reach the failure tracker with `error` unset.
+ *
+ * Without this recovery, `getFailureSignature` flattens every such failure to
+ * the bare literal `"failed"`, so a repeated-failure abort surfaces the
+ * useless `SCHEDULED_TASKS:failed` instead of naming what the model got wrong
+ * (observed live: the news-heartbeat turn tripped `Repeated tool failure
+ * limit exceeded for SCHEDULED_TASKS:failed`). That violates the
+ * diagnostic-error doctrine (#14873) — a limit abort must read like a real
+ * diagnosis. Prefer the human `text`; fall back to the `data.error` code;
+ * return `undefined` only when the result carries no reason at all, which
+ * preserves the existing `"failed"` fallback for a truly empty failure.
+ *
+ * This only makes the signature MORE specific: the repeated-failure guard
+ * still discriminates by `repeatKey` (the params JSON), so identical failing
+ * calls collapse exactly as before while distinct ones stay distinct.
+ */
+function diagnosticFailureReason(
+	result: PlannerToolResult,
+): string | undefined {
+	const text = typeof result.text === "string" ? result.text.trim() : "";
+	if (text) return text;
+	const dataError = (result.data as { error?: unknown } | undefined)?.error;
+	if (typeof dataError === "string" && dataError.trim()) {
+		return dataError.trim();
+	}
+	return undefined;
 }
 
 /**


### PR DESCRIPTION
**Diagnostic defect (the [object Object] cousin the humanness doctrine #14873 bans).** Every SCHEDULED_TASKS failure returns `{success:false, text:'<why>', data:{error:'<CODE>'}}` with the typed `error` field unset (reserved for thrown Errors), so the failure-signature builder flattened it to the literal `SCHEDULED_TASKS:failed` — producing `Repeated tool failure limit exceeded for SCHEDULED_TASKS:failed`, which names nothing.

**Fix:** `diagnosticFailureReason(result)` recovers `result.text` (preferred) or `data.error` code when the typed error is unset, so the trajectory abort + telemetry name *what the model got wrong*. Behavior-preserving for the loop guard (still discriminates by repeatKey=params JSON; the signature only gets more specific — the limits in limits.ts are deliberately unchanged, they are correctly calibrated).

Found live: assistant-user-journeys.live.e2e.test.ts:826 (recurring 9am news heartbeat) — the model loops on SCHEDULED_TASKS and the abort was undiagnosable.

Tests: planner-loop.test.ts (+2) + limits.test.ts = 77 passing. tsgo clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)