### PR TITLE
feat(evidence): one-command evidence:certify orchestrator (#14546)

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "test:matrix:review": "node scripts/evidence-review/run-matrix.mjs --open",
     "test:matrix": "node scripts/evidence-review/run-matrix.mjs --no-open",
     "test:watch-human": "bun run --cwd packages/app test:e2e:human",
+    "evidence:certify": "bun packages/evidence/src/cli.ts certify",
     "evidence:review": "node scripts/evidence-review/generate.mjs --open",
     "evidence:open": "node scripts/evidence-review/generate.mjs --open",
     "evidence:review:no-open": "node scripts/evidence-review/generate.mjs --no-open",

--- a/packages/evidence/package.json
+++ b/packages/evidence/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "bundle:create": "bun src/cli.ts create",
     "bundle:verify": "bun src/cli.ts verify",
+    "certify": "bun src/cli.ts certify",
     "certify:keygen": "bun src/certify/cli.ts keygen",
     "certify:rollup": "bun src/certify/cli.ts rollup",
     "certify:sign": "bun src/certify/cli.ts sign",

--- a/packages/evidence/src/bundle.ts
+++ b/packages/evidence/src/bundle.ts
@@ -246,6 +246,17 @@ export class EvidenceBundle {
   }
 
   /**
+   * The artifacts added so far, as a snapshot copy. The certify orchestrator
+   * (#14546) reads this after silo ingest to hand the analyzer runner its work
+   * list before `finalize()` seals the manifest — the runner then adds its
+   * `analysis.json` back through `addArtifact`, so a live view (not a snapshot)
+   * would iterate over its own emissions. Callers must not mutate the result.
+   */
+  get artifacts(): readonly ArtifactEntry[] {
+    return [...this.entries];
+  }
+
+  /**
    * Copy/hardlink `filePath` into the bundle and record its manifest entry.
    * The hash is computed from the bytes as stored in the bundle, so a corrupt
    * copy is caught at add time rather than at certification time.

--- a/packages/evidence/src/certify/orchestrate.test.ts
+++ b/packages/evidence/src/certify/orchestrate.test.ts
@@ -1,0 +1,441 @@
+/**
+ * End-to-end orchestrator tests against real finalized bundles and real
+ * Ed25519 keys on a tmp filesystem — no mocked crypto, no mocked sign/verify.
+ * A scripted matrix runner and injected clock keep runs deterministic; every
+ * green assertion re-verifies the produced certification.json with the shipped
+ * `verifyCertification`, and every red/tamper assertion drives that same
+ * verifier to a typed failure. The fresh-bundle path uses a throwaway git repo
+ * so provenance collection is exercised for real.
+ */
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createBundle } from "../bundle.ts";
+import { runCli } from "../cli.ts";
+import { EvidenceError } from "../errors.ts";
+import { generateCertificationKeypair } from "./keys.ts";
+import {
+  type MatrixRunner,
+  mergeReviewerVerdicts,
+  orchestrateCertify,
+  parseReviewerVerdicts,
+  type ReviewerVerdictsDocument,
+} from "./orchestrate.ts";
+import type { RollupResult } from "./rollup.ts";
+import { verifyCertification } from "./sign.ts";
+
+const COMMIT = "abcdef0123456789abcdef0123456789abcdef01";
+const NOW = () => new Date("2026-07-06T12:00:00.000Z");
+const KEYPAIR = generateCertificationKeypair();
+
+const tmpDirs: string[] = [];
+
+function tmpDir(prefix = "evidence-orch-"): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/** Build a finalized fixture bundle with the given lane counts + a screenshot. */
+async function fixtureBundle(lanes: {
+  [lane: string]: { passed: number; failed: number; skipped: number };
+}): Promise<string> {
+  const sourceDir = tmpDir("evidence-orch-src-");
+  const bundle = createBundle({
+    rootDir: tmpDir("evidence-orch-runs-"),
+    provenance: {
+      commit: COMMIT,
+      branch: "feat/orch-test",
+      runner: "local",
+      tier: "cpu",
+      envFingerprint: { tier: "cpu" },
+    },
+    now: NOW,
+  });
+  let index = 0;
+  for (const [lane, counts] of Object.entries(lanes)) {
+    const source = path.join(sourceDir, `result-${index}.json`);
+    index += 1;
+    fs.writeFileSync(source, `${JSON.stringify(counts)}\n`);
+    await bundle.addArtifact(source, {
+      kind: "report",
+      source: "fixture",
+      lane,
+      producedBy: "orchestrate.test.ts",
+      bundlePath: `lanes/${lane}/result.json`,
+    });
+  }
+  await bundle.finalize();
+  return bundle.dir;
+}
+
+/** A throwaway git repo so `collectGitProvenance` returns a real sha/branch. */
+function tmpGitRepo(): string {
+  const dir = tmpDir("evidence-orch-git-");
+  const git = (...args: string[]) =>
+    execFileSync("git", args, { cwd: dir, stdio: "pipe" });
+  git("init", "-q");
+  git("config", "user.email", "test@example.com");
+  git("config", "user.name", "Test");
+  git("config", "commit.gpgsign", "false");
+  fs.writeFileSync(path.join(dir, "README.md"), "fixture\n");
+  git("add", ".");
+  git("commit", "-qm", "init");
+  return dir;
+}
+
+const REVIEWER = {
+  kind: "agent",
+  id: "orch-test",
+  model: "claude-fable-5",
+} as const;
+
+function reviewerDoc(
+  verdicts: ReviewerVerdictsDocument["verdicts"],
+): ReviewerVerdictsDocument {
+  return { schema: 1, reviewer: REVIEWER, verdicts };
+}
+
+describe("orchestrateCertify — fresh bundle green path", () => {
+  it("captures a passing matrix lane, signs, and self-verifies green", async () => {
+    const repoRoot = tmpGitRepo();
+    const runMatrix: MatrixRunner = async () => ({
+      command: "fake-matrix",
+      lanes: [
+        { lane: "matrix", passed: 42, failed: 0, skipped: 0, log: "ok\n" },
+      ],
+    });
+    const result = await orchestrateCertify({
+      tier: "cpu",
+      repoRoot,
+      outDir: tmpDir("evidence-orch-out-"),
+      signingKey: KEYPAIR.privateKeyPem,
+      reviewer: REVIEWER,
+      runMatrix,
+      env: {},
+      now: NOW,
+    });
+
+    expect(result.overallVerdict).toBe("green");
+    expect(result.verify.ok).toBe(true);
+    expect(fs.existsSync(result.certPath)).toBe(true);
+    // The lane the matrix produced is present as a mechanical pass verdict.
+    expect(
+      result.certification.verdicts.some(
+        (verdict) =>
+          verdict.subject === "lane:matrix" && verdict.verdict === "pass",
+      ),
+    ).toBe(true);
+    // The lane result.json is actually in the bundle the cert is bound to.
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(result.bundleDir, "manifest.json"), "utf8"),
+    );
+    expect(
+      manifest.artifacts.some(
+        (a: { path: string }) => a.path === "lanes/matrix/result.json",
+      ),
+    ).toBe(true);
+
+    // Re-verify from disk with the trusted public key — the CI-gate contract.
+    const reverify = await verifyCertification(result.certPath, {
+      publicKeyPem: KEYPAIR.publicKeyPem,
+      bundleDir: result.bundleDir,
+      now: NOW,
+    });
+    expect(reverify.ok).toBe(true);
+    expect(reverify.failures).toEqual([]);
+  });
+});
+
+describe("orchestrateCertify — pre-built bundle", () => {
+  it("certifies an existing bundle green via --skip-matrix semantics", async () => {
+    const bundleDir = await fixtureBundle({
+      matrix: { passed: 10, failed: 0, skipped: 0 },
+    });
+    const result = await orchestrateCertify({
+      tier: "cpu",
+      repoRoot: process.cwd(),
+      existingBundleDir: bundleDir,
+      skipMatrix: true,
+      signingKey: KEYPAIR.privateKeyPem,
+      reviewerVerdicts: reviewerDoc([
+        { subject: "view:home", verdict: "pass", notes: "reviewed by hand" },
+      ]),
+      now: NOW,
+    });
+    expect(result.overallVerdict).toBe("green");
+    expect(result.certification.reviewer.id).toBe("orch-test");
+    // Reviewer-added subject plus the mechanical lane pass are both signed.
+    const subjects = result.certification.verdicts.map((v) => v.subject).sort();
+    expect(subjects).toEqual(["lane:matrix", "view:home"]);
+  });
+
+  it("lets a reviewer waive a mechanically failing lane (with notes) to green", async () => {
+    const bundleDir = await fixtureBundle({
+      flaky: { passed: 1, failed: 3, skipped: 0 },
+    });
+    const result = await orchestrateCertify({
+      tier: "cpu",
+      repoRoot: process.cwd(),
+      existingBundleDir: bundleDir,
+      signingKey: KEYPAIR.privateKeyPem,
+      reviewerVerdicts: reviewerDoc([
+        {
+          subject: "lane:flaky",
+          verdict: "waived",
+          notes: "known-flaky lane tracked in #99999; not release-blocking",
+        },
+      ]),
+      now: NOW,
+    });
+    expect(result.overallVerdict).toBe("green");
+    expect(result.verify.ok).toBe(true);
+    const waived = result.certification.verdicts.find(
+      (v) => v.subject === "lane:flaky",
+    );
+    expect(waived?.verdict).toBe("waived");
+  });
+});
+
+describe("orchestrateCertify — red paths", () => {
+  it("signs a truthful red certification when a lane fails and is not waived", async () => {
+    const bundleDir = await fixtureBundle({
+      broken: { passed: 0, failed: 2, skipped: 0 },
+    });
+    const result = await orchestrateCertify({
+      tier: "cpu",
+      repoRoot: process.cwd(),
+      existingBundleDir: bundleDir,
+      signingKey: KEYPAIR.privateKeyPem,
+      reviewer: REVIEWER,
+      now: NOW,
+    });
+    expect(result.overallVerdict).toBe("red");
+    expect(result.verify.ok).toBe(false);
+    expect(result.verify.failures.map((f) => f.code)).toContain(
+      "verdict-failures",
+    );
+    // The cert is still written — a red run does not suppress its own proof.
+    expect(fs.existsSync(result.certPath)).toBe(true);
+    const reverify = await verifyCertification(result.certPath, {
+      publicKeyPem: KEYPAIR.publicKeyPem,
+      bundleDir,
+      now: NOW,
+    });
+    expect(reverify.ok).toBe(false);
+  });
+
+  it("refuses to flip a mechanically failing lane to pass", async () => {
+    const bundleDir = await fixtureBundle({
+      broken: { passed: 0, failed: 1, skipped: 0 },
+    });
+    await expect(
+      orchestrateCertify({
+        tier: "cpu",
+        repoRoot: process.cwd(),
+        existingBundleDir: bundleDir,
+        signingKey: KEYPAIR.privateKeyPem,
+        reviewerVerdicts: reviewerDoc([
+          {
+            subject: "lane:broken",
+            verdict: "pass",
+            notes: "looks fine to me",
+          },
+        ]),
+        now: NOW,
+      }),
+    ).rejects.toThrow(/cannot mark mechanically fail/);
+  });
+
+  it("fails verification after the bundle manifest is tampered post-sign", async () => {
+    const bundleDir = await fixtureBundle({
+      matrix: { passed: 5, failed: 0, skipped: 0 },
+    });
+    const result = await orchestrateCertify({
+      tier: "cpu",
+      repoRoot: process.cwd(),
+      existingBundleDir: bundleDir,
+      signingKey: KEYPAIR.privateKeyPem,
+      reviewer: REVIEWER,
+      reviewerVerdicts: reviewerDoc([
+        { subject: "view:home", verdict: "pass", notes: "ok" },
+      ]),
+      now: NOW,
+    });
+    expect(result.overallVerdict).toBe("green");
+
+    // Flip the lane result.json under the signed manifest hash.
+    const laneResult = path.join(bundleDir, "lanes", "matrix", "result.json");
+    fs.writeFileSync(
+      laneResult,
+      `${JSON.stringify({ passed: 0, failed: 9, skipped: 0 })}\n`,
+    );
+    const reverify = await verifyCertification(result.certPath, {
+      publicKeyPem: KEYPAIR.publicKeyPem,
+      bundleDir,
+      now: NOW,
+    });
+    expect(reverify.ok).toBe(false);
+    expect(reverify.failures.map((f) => f.code)).toContain("bundle-tampered");
+  });
+});
+
+describe("mergeReviewerVerdicts", () => {
+  const rollup: RollupResult = {
+    schema: 1,
+    verdicts: [
+      {
+        subject: "lane:a",
+        verdict: "pass",
+        evidence: ["lanes/a/result.json"],
+        notes: "ok",
+      },
+      {
+        subject: "lane:b",
+        verdict: "fail",
+        evidence: ["lanes/b/result.json"],
+        notes: "failed=1",
+      },
+    ],
+    summary: {
+      lanes: [],
+      analysesScanned: 0,
+      analysisFindings: [],
+      missingArtifacts: [],
+      counts: { pass: 1, fail: 1, waived: 0 },
+    },
+  };
+
+  it("carries every rollup subject through and adds reviewer subjects", () => {
+    const merged = mergeReviewerVerdicts(rollup, [
+      { subject: "lane:b", verdict: "waived", notes: "flaky" },
+      { subject: "view:x", verdict: "pass", evidence: [] },
+    ]);
+    expect(merged.map((v) => v.subject)).toEqual([
+      "lane:a",
+      "lane:b",
+      "view:x",
+    ]);
+    expect(merged.find((v) => v.subject === "lane:b")?.verdict).toBe("waived");
+    // Waived subject keeps the rollup evidence when the override omits it.
+    expect(merged.find((v) => v.subject === "lane:b")?.evidence).toEqual([
+      "lanes/b/result.json",
+    ]);
+  });
+
+  it("throws on a false-pass override of a mechanical fail", () => {
+    expect(() =>
+      mergeReviewerVerdicts(rollup, [{ subject: "lane:b", verdict: "pass" }]),
+    ).toThrow(EvidenceError);
+  });
+});
+
+describe("parseReviewerVerdicts", () => {
+  it("rejects a document with no verdicts", () => {
+    expect(() =>
+      parseReviewerVerdicts({ schema: 1, verdicts: [] }, "test"),
+    ).toThrow(/invalid reviewer verdicts/);
+  });
+  it("rejects an unknown verdict value", () => {
+    expect(() =>
+      parseReviewerVerdicts(
+        { schema: 1, verdicts: [{ subject: "x", verdict: "maybe" }] },
+        "test",
+      ),
+    ).toThrow(/invalid reviewer verdicts/);
+  });
+});
+
+describe("certify CLI subcommand", () => {
+  function captureIo() {
+    const out: string[] = [];
+    const err: string[] = [];
+    return {
+      io: { out: (l: string) => out.push(l), err: (l: string) => err.push(l) },
+      out,
+      err,
+    };
+  }
+
+  it("exits 0 and writes a verifiable cert over an existing bundle", async () => {
+    const bundleDir = await fixtureBundle({
+      matrix: { passed: 3, failed: 0, skipped: 0 },
+    });
+    const keyFile = path.join(tmpDir("evidence-orch-key-"), "key.pem");
+    fs.writeFileSync(keyFile, KEYPAIR.privateKeyPem);
+    const verdictsFile = path.join(tmpDir("evidence-orch-rv-"), "rv.json");
+    fs.writeFileSync(
+      verdictsFile,
+      JSON.stringify(
+        reviewerDoc([{ subject: "view:home", verdict: "pass", notes: "ok" }]),
+      ),
+    );
+    const certOut = path.join(
+      tmpDir("evidence-orch-cert-"),
+      "certification.json",
+    );
+    const { io } = captureIo();
+    const code = await runCli(
+      [
+        "certify",
+        "--tier",
+        "cpu",
+        "--bundle",
+        bundleDir,
+        "--reviewer-id",
+        "cli-agent",
+        "--reviewer-kind",
+        "agent",
+        "--key-file",
+        keyFile,
+        "--reviewer-verdicts",
+        verdictsFile,
+        "--cert-out",
+        certOut,
+      ],
+      io,
+    );
+    expect(code).toBe(0);
+    expect(fs.existsSync(certOut)).toBe(true);
+    const reverify = await verifyCertification(certOut, {
+      publicKeyPem: KEYPAIR.publicKeyPem,
+      bundleDir,
+    });
+    expect(reverify.ok).toBe(true);
+  });
+
+  it("exits 1 on a red bundle without waivers", async () => {
+    const bundleDir = await fixtureBundle({
+      broken: { passed: 0, failed: 1, skipped: 0 },
+    });
+    const keyFile = path.join(tmpDir("evidence-orch-key-"), "key.pem");
+    fs.writeFileSync(keyFile, KEYPAIR.privateKeyPem);
+    const { io } = captureIo();
+    const code = await runCli(
+      [
+        "certify",
+        "--tier",
+        "cpu",
+        "--bundle",
+        bundleDir,
+        "--reviewer-id",
+        "cli-agent",
+        "--reviewer-kind",
+        "agent",
+        "--key-file",
+        keyFile,
+      ],
+      io,
+    );
+    expect(code).toBe(1);
+  });
+});

--- a/packages/evidence/src/certify/orchestrate.test.ts
+++ b/packages/evidence/src/certify/orchestrate.test.ts
@@ -413,6 +413,48 @@ describe("certify CLI subcommand", () => {
     expect(reverify.ok).toBe(true);
   });
 
+  it("accepts reviewer identity from the reviewer-verdicts file", async () => {
+    const bundleDir = await fixtureBundle({
+      matrix: { passed: 3, failed: 0, skipped: 0 },
+    });
+    const keyFile = path.join(tmpDir("evidence-orch-key-"), "key.pem");
+    fs.writeFileSync(keyFile, KEYPAIR.privateKeyPem);
+    const verdictsFile = path.join(tmpDir("evidence-orch-rv-"), "rv.json");
+    fs.writeFileSync(
+      verdictsFile,
+      JSON.stringify(
+        reviewerDoc([{ subject: "view:home", verdict: "pass", notes: "ok" }]),
+      ),
+    );
+    const certOut = path.join(
+      tmpDir("evidence-orch-cert-"),
+      "certification.json",
+    );
+    const { io } = captureIo();
+    const code = await runCli(
+      [
+        "certify",
+        "--tier",
+        "cpu",
+        "--bundle",
+        bundleDir,
+        "--key-file",
+        keyFile,
+        "--reviewer-verdicts",
+        verdictsFile,
+        "--cert-out",
+        certOut,
+      ],
+      io,
+    );
+    expect(code).toBe(0);
+    const cert = JSON.parse(fs.readFileSync(certOut, "utf8"));
+    expect(cert.reviewer).toMatchObject({
+      kind: "agent",
+      id: "orch-test",
+    });
+  });
+
   it("exits 1 on a red bundle without waivers", async () => {
     const bundleDir = await fixtureBundle({
       broken: { passed: 0, failed: 1, skipped: 0 },

--- a/packages/evidence/src/certify/orchestrate.ts
+++ b/packages/evidence/src/certify/orchestrate.ts
@@ -50,6 +50,7 @@ import {
   askBatch,
   buildQaRecord,
   resolveBackend,
+  VISION_QA_ENV,
   type VisionQuestion,
   writeQaRecord,
 } from "../vision-qa/index.ts";
@@ -334,7 +335,7 @@ async function runVisionQaPass(
   env: NodeJS.ProcessEnv,
   io: CertifyIo,
 ): Promise<StepOutcome> {
-  let backend: string;
+  let backend: ReturnType<typeof resolveBackend>;
   try {
     backend = resolveBackend({}, env);
   } catch (error) {
@@ -374,7 +375,23 @@ async function runVisionQaPass(
   }));
   const results = await askBatch(
     entries.map(({ imagePath, questions }) => ({ imagePath, questions })),
-    { cacheDir: bundle.dir },
+    {
+      backend,
+      cacheDir: bundle.dir,
+      ...(backend === "local" && env[VISION_QA_ENV.baseUrl] !== undefined
+        ? { baseUrl: env[VISION_QA_ENV.baseUrl] }
+        : {}),
+      ...(backend === "anthropic" &&
+      env[VISION_QA_ENV.anthropicKey] !== undefined
+        ? { apiKey: env[VISION_QA_ENV.anthropicKey] }
+        : {}),
+      ...(backend === "openai" && env[VISION_QA_ENV.openaiKey] !== undefined
+        ? { apiKey: env[VISION_QA_ENV.openaiKey] }
+        : {}),
+      ...(backend === "local" && env[VISION_QA_ENV.openaiKey] !== undefined
+        ? { apiKey: env[VISION_QA_ENV.openaiKey] }
+        : {}),
+    },
   );
   for (let index = 0; index < results.length; index += 1) {
     const entry = entries[index];

--- a/packages/evidence/src/certify/orchestrate.ts
+++ b/packages/evidence/src/certify/orchestrate.ts
@@ -1,0 +1,664 @@
+/**
+ * The one-command certification orchestrator: chains the evidence pieces that
+ * already exist (bundle builder, silo ingestors, analyzer runner, vision-QA,
+ * verdict rollup, Ed25519 sign/verify) into a single `evidence:certify` run so
+ * a keyholder produces a signed, self-verified `certification.json` in one
+ * command. It reuses every downstream module unchanged — this file is glue and
+ * honesty enforcement, never a reimplementation of any step.
+ *
+ * The chain (a fresh bundle): optional test matrix → capture its per-lane
+ * pass/fail as `lanes/<lane>/result.json` → `createBundle` + `ingestAllSilos`
+ * → `analyzeArtifacts` over the ingested pixels at the run tier (writes
+ * `analysis.json` beside each subject) → optional VLM Q&A pass (honest skip
+ * when no backend is configured) → `finalize` → mechanical `rollupBundle` →
+ * reviewer merge (overrides/additions folded onto the rollup, recording the
+ * reviewer identity) → `signCertification` → immediate offline
+ * `verifyCertification` against the derived public key and the bundle itself.
+ *
+ * Honesty is structural, not advisory. The mechanical rollup drafts every lane
+ * fail / skipped lane / analyzer expectation failure as a non-pass verdict; a
+ * reviewer may `waive` such a subject (waivers require notes, which survive
+ * into the signed cert) but may never flip a mechanically non-pass subject to
+ * `pass` — that is rejected at merge time, the same hole the gate's
+ * verdict-completeness check closes. The run self-verifies at the end, so
+ * `overallVerdict` is `red` whenever the produced certification would fail the
+ * #14547 gate; a red run still writes the truthful (failing) certification
+ * rather than fabricating a green one.
+ *
+ * With `existingBundleDir` the create/ingest/analyze/vision steps are skipped
+ * and a pre-built finalized bundle is certified as-is (rollup → review → sign
+ * → verify), which is how the local-fallback certifier signs a bundle another
+ * runner captured.
+ */
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { z } from "zod";
+import { analyzeArtifacts } from "../analyzers/runner.ts";
+import { createBundle, type EvidenceBundle, verifyBundle } from "../bundle.ts";
+import { EvidenceError, EvidenceValidationError } from "../errors.ts";
+import { ingestAllSilos } from "../ingest.ts";
+import {
+  buildEnvFingerprint,
+  collectGitProvenance,
+  resolveRunnerKind,
+} from "../provenance.ts";
+import { parseMeta, type Tier } from "../schema.ts";
+import {
+  askBatch,
+  buildQaRecord,
+  resolveBackend,
+  type VisionQuestion,
+  writeQaRecord,
+} from "../vision-qa/index.ts";
+import { derivePublicKeyPem, toPrivateKey } from "./keys.ts";
+import {
+  type CertificationRequirements,
+  type RollupResult,
+  rollupBundle,
+} from "./rollup.ts";
+import {
+  type Certification,
+  type CertificationPayload,
+  type CertificationReviewer,
+  type CertificationVerdict,
+  REVIEWER_KINDS,
+} from "./schema.ts";
+import {
+  type CertificationVerifyReport,
+  signCertification,
+  verifyCertification,
+} from "./sign.ts";
+
+/** One reviewer decision merged onto the mechanical rollup. */
+export interface ReviewerOverride {
+  subject: string;
+  verdict: CertificationVerdict["verdict"];
+  /** Bundle-relative evidence paths; defaults to the rollup subject's evidence. */
+  evidence?: string[];
+  notes?: string;
+}
+
+/** A `--reviewer-verdicts` document: reviewer identity plus per-subject overrides. */
+export interface ReviewerVerdictsDocument {
+  schema: 1;
+  reviewer?: CertificationReviewer;
+  verdicts: ReviewerOverride[];
+}
+
+const reviewerVerdictsSchema = z.strictObject({
+  schema: z.literal(1),
+  reviewer: z
+    .strictObject({
+      kind: z.enum(REVIEWER_KINDS),
+      id: z.string().min(1),
+      model: z.string().min(1).optional(),
+    })
+    .optional(),
+  verdicts: z
+    .array(
+      z.strictObject({
+        subject: z.string().min(1),
+        verdict: z.enum(["pass", "fail", "waived"]),
+        evidence: z.array(z.string()).optional(),
+        notes: z.string().optional(),
+      }),
+    )
+    .min(1),
+});
+
+/** Validate an untrusted reviewer-verdicts value; throws typed invalid. */
+export function parseReviewerVerdicts(
+  value: unknown,
+  described: string,
+): ReviewerVerdictsDocument {
+  const result = reviewerVerdictsSchema.safeParse(value);
+  if (!result.success) {
+    const issues = result.error.issues.map((issue) => ({
+      path: issue.path.map(String).join(".") || "$",
+      message: issue.message,
+    }));
+    throw new EvidenceValidationError(
+      `invalid reviewer verdicts (${described}): ${issues
+        .map((issue) => `${issue.path}: ${issue.message}`)
+        .join("; ")}`,
+      issues,
+      { code: "REVIEWER_VERDICTS_INVALID" },
+    );
+  }
+  return result.data;
+}
+
+/** Output sink for progress lines; the CLI supplies a console-backed writer. */
+export interface CertifyIo {
+  out(line: string): void;
+  err(line: string): void;
+}
+
+const SILENT_IO: CertifyIo = { out: () => {}, err: () => {} };
+
+/** One lane's pass/fail counts, captured from the test matrix. */
+export interface MatrixLaneResult {
+  lane: string;
+  passed: number;
+  failed: number;
+  skipped: number;
+  /** Combined stdout/stderr of the run, stored as a lane log artifact. */
+  log?: string;
+}
+
+/** Result of a matrix run: one entry per lane it reports. */
+export interface MatrixRunResult {
+  command: string;
+  lanes: MatrixLaneResult[];
+}
+
+/** Runs the test matrix and reports per-lane pass/fail; injectable for tests. */
+export type MatrixRunner = (context: {
+  repoRoot: string;
+  tier: Tier;
+  io: CertifyIo;
+}) => Promise<MatrixRunResult>;
+
+/** How one orchestration step resolved, recorded in the run summary. */
+export interface StepOutcome {
+  step: string;
+  status: "ran" | "skipped" | "degraded";
+  detail: string;
+}
+
+/** Options for {@link orchestrateCertify}. */
+export interface CertifyOptions {
+  tier: Tier;
+  repoRoot: string;
+  /** Directory holding run dirs for a fresh bundle; default `<repoRoot>/evidence/runs`. */
+  outDir?: string;
+  /** Certify this pre-built finalized bundle instead of creating one. */
+  existingBundleDir?: string;
+  /** Skip the test matrix; lane verdicts then come only from ingested silos. */
+  skipMatrix?: boolean;
+  /** Reviewer overrides/additions folded onto the mechanical rollup. */
+  reviewerVerdicts?: ReviewerVerdictsDocument;
+  /** Reviewer identity; required unless supplied by the reviewer-verdicts file. */
+  reviewer?: CertificationReviewer;
+  /** Ed25519 private key (PEM or KeyObject) held by the certifier. */
+  signingKey: string | import("node:crypto").KeyObject;
+  requirements?: CertificationRequirements;
+  /** Promotion source ref recorded in the payload; default `develop`. */
+  baseRef?: string;
+  expiresHours?: number;
+  /** Where to write the certification; default `<bundle>/certification.json`. */
+  certOut?: string;
+  /** Test matrix runner; default spawns `packages/scripts/run-all-tests.mjs`. */
+  runMatrix?: MatrixRunner;
+  /** Env for vision-QA backend resolution + provenance; default `process.env`. */
+  env?: NodeJS.ProcessEnv;
+  now?: () => Date;
+  io?: CertifyIo;
+}
+
+/** Full result of an orchestrated certification run. */
+export interface CertifyResult {
+  bundleDir: string;
+  manifestSha256: string;
+  certPath: string;
+  certification: Certification;
+  /** `green` iff the produced certification self-verifies against the bundle. */
+  overallVerdict: "green" | "red";
+  verify: CertificationVerifyReport;
+  rollup: RollupResult;
+  steps: StepOutcome[];
+  tier: Tier;
+}
+
+const CERTIFY_QUESTION: VisionQuestion = {
+  id: "renders-cleanly",
+  question:
+    "Does this screenshot render as a complete, correct UI with no visible " +
+    "error text, broken layout, blank/placeholder regions, or overlapping content?",
+  expected: "yes",
+};
+
+/**
+ * Default matrix runner: spawn the repo's cross-package test runner and record
+ * a single `matrix` lane from its exit code. A non-zero exit is a lane failure
+ * (`failed: 1`), never a skipped-and-forgotten result — the whole point is that
+ * a red matrix produces a red certification. The full output is captured as the
+ * lane log so a reviewer can read what failed.
+ */
+export const spawnRunAllTests: MatrixRunner = ({ repoRoot, io }) => {
+  const script = path.join(
+    repoRoot,
+    "packages",
+    "scripts",
+    "run-all-tests.mjs",
+  );
+  const command = `node ${path.relative(repoRoot, script)}`;
+  io.out(`  matrix: ${command}`);
+  return new Promise<MatrixRunResult>((resolve, reject) => {
+    const child = spawn("node", [script], {
+      cwd: repoRoot,
+      env: process.env,
+    });
+    let buffer = "";
+    const capture = (chunk: Buffer) => {
+      buffer += chunk.toString("utf8");
+    };
+    child.stdout.on("data", capture);
+    child.stderr.on("data", capture);
+    child.on("error", (error) => {
+      // error-policy:J2 context-adding rethrow — a runner that cannot even
+      // launch is an environment failure the certifier must see, not a lane
+      // result to fabricate.
+      reject(
+        new EvidenceError(`test matrix failed to launch: ${command}`, {
+          code: "CERTIFY_MATRIX_LAUNCH",
+          cause: error,
+          context: { command },
+        }),
+      );
+    });
+    child.on("close", (code) => {
+      const passed = code === 0 ? 1 : 0;
+      const failed = code === 0 ? 0 : 1;
+      resolve({
+        command,
+        lanes: [{ lane: "matrix", passed, failed, skipped: 0, log: buffer }],
+      });
+    });
+  });
+};
+
+/** Write a JSON value to a scratch file and add it to the bundle at `bundlePath`. */
+async function addJsonArtifact(
+  bundle: EvidenceBundle,
+  bundlePath: string,
+  value: unknown,
+  options: { kind: "report" | "log"; source: string; lane?: string },
+): Promise<void> {
+  const scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), "certify-"));
+  const scratch = path.join(scratchDir, path.posix.basename(bundlePath));
+  fs.writeFileSync(scratch, `${JSON.stringify(value, null, 2)}\n`);
+  try {
+    await bundle.addArtifact(scratch, {
+      kind: options.kind,
+      source: options.source,
+      producedBy: "evidence:certify",
+      bundlePath,
+      ...(options.lane !== undefined ? { lane: options.lane } : {}),
+    });
+  } finally {
+    fs.rmSync(scratchDir, { recursive: true, force: true });
+  }
+}
+
+/** Add a lane's `result.json` (+ log, when present) so rollup scores the lane. */
+async function addLaneResult(
+  bundle: EvidenceBundle,
+  lane: MatrixLaneResult,
+): Promise<void> {
+  await addJsonArtifact(
+    bundle,
+    `lanes/${lane.lane}/result.json`,
+    { passed: lane.passed, failed: lane.failed, skipped: lane.skipped },
+    { kind: "report", source: "test-matrix", lane: lane.lane },
+  );
+  if (lane.log !== undefined && lane.log.length > 0) {
+    const scratchDir = fs.mkdtempSync(path.join(os.tmpdir(), "certify-log-"));
+    const scratch = path.join(scratchDir, "matrix.log");
+    fs.writeFileSync(scratch, lane.log);
+    try {
+      await bundle.addArtifact(scratch, {
+        kind: "log",
+        source: "test-matrix",
+        lane: lane.lane,
+        producedBy: "evidence:certify",
+        bundlePath: `lanes/${lane.lane}/logs/matrix.log`,
+      });
+    } finally {
+      fs.rmSync(scratchDir, { recursive: true, force: true });
+    }
+  }
+}
+
+/**
+ * Run the VLM Q&A pass over the bundle's screenshots. When no backend is
+ * configured this is an honest skip (recorded, never a fabricated green); a
+ * configured backend runs the shared `askBatch` and writes a `qa.json` beside
+ * each screenshot for the reviewer to fold into verdicts.
+ */
+async function runVisionQaPass(
+  bundle: EvidenceBundle,
+  env: NodeJS.ProcessEnv,
+  io: CertifyIo,
+): Promise<StepOutcome> {
+  let backend: string;
+  try {
+    backend = resolveBackend({}, env);
+  } catch (error) {
+    // error-policy:J4 explicit degrade — a keyless run has no VLM; that is a
+    // designed "unavailable" outcome recorded honestly, distinct from a run
+    // where every screenshot passed Q&A.
+    if (
+      error instanceof EvidenceError &&
+      error.code === "VISION_NOT_CONFIGURED"
+    ) {
+      io.out("  vision-qa: skipped (no backend configured)");
+      return {
+        step: "vision-qa",
+        status: "skipped",
+        detail: "no VLM backend configured (keyless run)",
+      };
+    }
+    throw error;
+  }
+
+  const screenshots = bundle.artifacts.filter(
+    (artifact) => artifact.kind === "screenshot",
+  );
+  if (screenshots.length === 0) {
+    io.out(`  vision-qa: ${backend}, no screenshots to review`);
+    return {
+      step: "vision-qa",
+      status: "ran",
+      detail: `${backend}: no screenshots in bundle`,
+    };
+  }
+
+  const entries = screenshots.map((artifact) => ({
+    imagePath: path.join(bundle.dir, ...artifact.path.split("/")),
+    questions: [CERTIFY_QUESTION],
+    bundlePath: artifact.path,
+  }));
+  const results = await askBatch(
+    entries.map(({ imagePath, questions }) => ({ imagePath, questions })),
+    { cacheDir: bundle.dir },
+  );
+  for (let index = 0; index < results.length; index += 1) {
+    const entry = entries[index];
+    const { result } = results[index];
+    // buildQaRecord is called for its validation side; writeQaRecord persists.
+    void buildQaRecord(entry.bundlePath, entry.questions, result);
+    await writeQaRecord(bundle, entry.bundlePath, entry.questions, result);
+  }
+  io.out(`  vision-qa: ${backend}, ${results.length} screenshot(s) reviewed`);
+  return {
+    step: "vision-qa",
+    status: "ran",
+    detail: `${backend}: ${results.length} screenshot(s) reviewed`,
+  };
+}
+
+/**
+ * Fold reviewer overrides onto the mechanical rollup. Every rollup subject is
+ * carried through (dropping one would make the cert fail the gate's
+ * completeness check); an override replaces a subject's verdict/notes/evidence,
+ * and a subject not in the rollup is added as a reviewer-supplied verdict.
+ * Flipping a mechanically non-pass subject to `pass` is refused — the honest
+ * escape hatch is `waived` (which the schema forces to carry notes).
+ */
+export function mergeReviewerVerdicts(
+  rollup: RollupResult,
+  overrides: ReviewerOverride[],
+): CertificationVerdict[] {
+  const bySubject = new Map<string, CertificationVerdict>();
+  const mechanical = new Map<string, CertificationVerdict["verdict"]>();
+  for (const verdict of rollup.verdicts) {
+    bySubject.set(verdict.subject, { ...verdict });
+    mechanical.set(verdict.subject, verdict.verdict);
+  }
+  for (const override of overrides) {
+    const mechanicalVerdict = mechanical.get(override.subject);
+    if (
+      mechanicalVerdict !== undefined &&
+      mechanicalVerdict !== "pass" &&
+      override.verdict === "pass"
+    ) {
+      throw new EvidenceError(
+        `reviewer cannot mark mechanically ${mechanicalVerdict} subject '${override.subject}' as pass; waive it with notes instead`,
+        {
+          code: "CERTIFY_FALSE_PASS",
+          context: { subject: override.subject, mechanicalVerdict },
+        },
+      );
+    }
+    const existing = bySubject.get(override.subject);
+    const evidence = override.evidence ?? existing?.evidence ?? [];
+    bySubject.set(override.subject, {
+      subject: override.subject,
+      verdict: override.verdict,
+      evidence,
+      ...(override.notes !== undefined ? { notes: override.notes } : {}),
+    });
+  }
+  return [...bySubject.values()].sort((a, b) =>
+    a.subject < b.subject ? -1 : a.subject > b.subject ? 1 : 0,
+  );
+}
+
+function resolveReviewer(options: CertifyOptions): CertificationReviewer {
+  const reviewer = options.reviewer ?? options.reviewerVerdicts?.reviewer;
+  if (reviewer === undefined) {
+    throw new EvidenceError(
+      "certify requires a reviewer identity (--reviewer-id/--reviewer-kind or a reviewer block in --reviewer-verdicts)",
+      { code: "CERTIFY_REVIEWER_MISSING" },
+    );
+  }
+  return reviewer;
+}
+
+/**
+ * Build (or adopt) an evidence bundle and drive it through the full
+ * certification chain, returning the signed certification and its self-verify
+ * report. Throws typed `EvidenceError`s for operator failures (no reviewer, a
+ * false-pass override, a launch failure); a legitimately failing bundle is not
+ * an error — it produces a signed cert with `overallVerdict: "red"`.
+ */
+export async function orchestrateCertify(
+  options: CertifyOptions,
+): Promise<CertifyResult> {
+  const io = options.io ?? SILENT_IO;
+  const env = options.env ?? process.env;
+  const now = options.now;
+  const reviewer = resolveReviewer(options);
+  const privateKey = toPrivateKey(options.signingKey);
+  const publicKeyPem = derivePublicKeyPem(privateKey);
+  const steps: StepOutcome[] = [];
+
+  let bundleDir: string;
+  let manifestSha256: string;
+  let tier: Tier;
+  let commit: string;
+  let branch: string;
+
+  if (options.existingBundleDir !== undefined) {
+    bundleDir = path.resolve(options.existingBundleDir);
+    const report = await verifyBundle(bundleDir);
+    if (!report.ok) {
+      throw new EvidenceError(
+        `refusing to certify: existing bundle failed integrity with ${report.issues.length} issue(s)`,
+        { code: "CERTIFY_BUNDLE_TAMPERED", context: { bundleDir } },
+      );
+    }
+    const meta = parseMeta(
+      JSON.parse(fs.readFileSync(path.join(bundleDir, "meta.json"), "utf8")),
+      path.join(bundleDir, "meta.json"),
+    );
+    manifestSha256 = report.manifestSha256;
+    tier = meta.tier;
+    commit = meta.commit;
+    branch = meta.branch;
+    io.out(`certifying existing bundle ${report.runId} (tier=${tier})`);
+    steps.push({
+      step: "bundle",
+      status: "ran",
+      detail: `adopted pre-built bundle ${report.runId}`,
+    });
+  } else {
+    tier = options.tier;
+    const git = collectGitProvenance(options.repoRoot);
+    commit = git.commit;
+    branch = git.branch;
+    const runner = resolveRunnerKind(env);
+    const rootDir = path.resolve(
+      options.outDir ?? path.join(options.repoRoot, "evidence", "runs"),
+    );
+    const bundle = createBundle({
+      rootDir,
+      provenance: {
+        commit,
+        branch,
+        runner,
+        tier,
+        envFingerprint: buildEnvFingerprint(tier),
+      },
+      ...(now !== undefined ? { now } : {}),
+    });
+    bundleDir = bundle.dir;
+    io.out(`bundle ${bundle.runId} (tier=${tier})`);
+
+    if (options.skipMatrix === true) {
+      steps.push({
+        step: "matrix",
+        status: "skipped",
+        detail: "--skip-matrix; lane verdicts come from ingested silos only",
+      });
+      io.out("  matrix: skipped (--skip-matrix)");
+    } else {
+      const runMatrix = options.runMatrix ?? spawnRunAllTests;
+      const matrix = await runMatrix({ repoRoot: options.repoRoot, tier, io });
+      for (const lane of matrix.lanes) await addLaneResult(bundle, lane);
+      const failedLanes = matrix.lanes.filter((lane) => lane.failed > 0);
+      steps.push({
+        step: "matrix",
+        status: failedLanes.length > 0 ? "degraded" : "ran",
+        detail: `${matrix.command}: ${matrix.lanes.length} lane(s), ${failedLanes.length} failing`,
+      });
+    }
+
+    const ingest = await ingestAllSilos(bundle, options.repoRoot);
+    const ingestedCount = ingest.reduce(
+      (sum, result) => sum + result.artifactCount,
+      0,
+    );
+    steps.push({
+      step: "ingest",
+      status: "ran",
+      detail: `${ingest.filter((r) => r.status === "ingested").length} silo(s), ${ingestedCount} artifact(s)`,
+    });
+    io.out(
+      `  ingest: ${ingestedCount} artifact(s) from ${ingest.length} silo(s)`,
+    );
+
+    const analyzeInputs = bundle.artifacts;
+    const analysis = await analyzeArtifacts(bundle.dir, analyzeInputs, {
+      tier,
+      bundle,
+    });
+    steps.push({
+      step: "analyze",
+      status: "ran",
+      detail: `${analysis.subjects.length} subject(s) analyzed at tier ${tier}`,
+    });
+    io.out(`  analyze: ${analysis.subjects.length} subject(s) at tier ${tier}`);
+
+    steps.push(await runVisionQaPass(bundle, env, io));
+
+    await addJsonArtifact(
+      bundle,
+      "certify/run-summary.json",
+      { schema: 1, tier, commit, branch, steps },
+      { kind: "report", source: "evidence:certify" },
+    );
+
+    const finalized = await bundle.finalize();
+    manifestSha256 = finalized.manifestSha256;
+    io.out(`  finalize: manifest sha256 ${manifestSha256}`);
+  }
+
+  const rollup = rollupBundle(bundleDir, {
+    ...(options.requirements !== undefined
+      ? { requirements: options.requirements }
+      : {}),
+  });
+  steps.push({
+    step: "rollup",
+    status: "ran",
+    detail: `${rollup.verdicts.length} subject(s) (pass=${rollup.summary.counts.pass} fail=${rollup.summary.counts.fail} waived=${rollup.summary.counts.waived})`,
+  });
+
+  const verdicts = mergeReviewerVerdicts(
+    rollup,
+    options.reviewerVerdicts?.verdicts ?? [],
+  );
+  const reviewCounts = { pass: 0, fail: 0, waived: 0 };
+  for (const verdict of verdicts) reviewCounts[verdict.verdict] += 1;
+  steps.push({
+    step: "review",
+    status: "ran",
+    detail: `${reviewer.kind}:${reviewer.id} — ${verdicts.length} verdict(s) (pass=${reviewCounts.pass} fail=${reviewCounts.fail} waived=${reviewCounts.waived})`,
+  });
+
+  const createdAt = (now ?? (() => new Date()))();
+  const payload: CertificationPayload = {
+    schema: 1,
+    bundleSha: manifestSha256,
+    commit,
+    branch,
+    baseRef: options.baseRef ?? "develop",
+    tier,
+    verdicts,
+    reviewer,
+    createdAt: createdAt.toISOString(),
+    ...(options.expiresHours !== undefined
+      ? {
+          expiresAt: new Date(
+            createdAt.getTime() + options.expiresHours * 3_600_000,
+          ).toISOString(),
+        }
+      : {}),
+  };
+  const certification = signCertification(payload, privateKey);
+  const certPath = path.resolve(
+    options.certOut ?? path.join(bundleDir, "certification.json"),
+  );
+  fs.writeFileSync(certPath, `${JSON.stringify(certification, null, 2)}\n`);
+  steps.push({
+    step: "sign",
+    status: "ran",
+    detail: `signed ${certPath} (key ${certification.signature.publicKeyFingerprint})`,
+  });
+
+  // Self-verify against the derived public key AND the bundle so the run's own
+  // `overallVerdict` matches exactly what the #14547 gate would compute — a
+  // false-pass, a stray fail, or a tampered bundle turns the run red here.
+  const verify = await verifyCertification(certPath, {
+    publicKeyPem,
+    bundleDir,
+    ...(options.requirements !== undefined
+      ? { requirements: options.requirements }
+      : {}),
+    ...(now !== undefined ? { now } : {}),
+  });
+  const overallVerdict = verify.ok ? "green" : "red";
+  io.out(
+    `certification ${overallVerdict.toUpperCase()} — ${certPath}` +
+      (verify.ok
+        ? ""
+        : `\n  failures: ${verify.failures.map((f) => f.code).join(", ")}`),
+  );
+
+  return {
+    bundleDir,
+    manifestSha256,
+    certPath,
+    certification,
+    overallVerdict,
+    verify,
+    rollup,
+    steps,
+    tier,
+  };
+}

--- a/packages/evidence/src/cli.ts
+++ b/packages/evidence/src/cli.ts
@@ -8,9 +8,17 @@
  * with a captured writer instead of spawning a child process.
  */
 
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { createBundle, verifyBundle } from "./bundle.ts";
+import { resolveSigningKey } from "./certify/keys.ts";
+import {
+  orchestrateCertify,
+  parseReviewerVerdicts,
+} from "./certify/orchestrate.ts";
+import { parseRequirements } from "./certify/rollup.ts";
+import { REVIEWER_KINDS, type ReviewerKind } from "./certify/schema.ts";
 import { EvidenceError } from "./errors.ts";
 import { ingestAllSilos } from "./ingest.ts";
 import {
@@ -23,9 +31,17 @@ import { TIERS, type Tier } from "./schema.ts";
 const USAGE = `Usage:
   bundle:create -- --tier <cpu|gpu|full> [--out <dir>] [--repo-root <dir>]
   bundle:verify -- <bundle-dir>
+  certify       -- --tier <cpu|gpu|full> --reviewer-id <id> --reviewer-kind <agent|human>
+                   [--reviewer-model <m>] [--reviewer-verdicts <file>] [--skip-matrix]
+                   [--bundle <existing-dir>] [--requirements <file>] [--base-ref <ref>]
+                   [--expires-hours <n>] [--key-file <pem>] [--cert-out <path>]
+                   [--out <dir>] [--repo-root <dir>]
 
 create   Open a new evidence bundle, ingest every known silo, finalize.
-verify   Re-hash every artifact in an existing bundle and report integrity.`;
+verify   Re-hash every artifact in an existing bundle and report integrity.
+certify  One command: matrix → ingest → analyze → vision-qa → rollup →
+         reviewer merge → sign → self-verify. Writes a signed certification.json
+         and exits 0 only when it self-verifies (green), 1 when red.`;
 
 /** Output sinks; injectable so tests capture instead of spawning. */
 export interface CliIo {
@@ -152,12 +168,205 @@ async function runVerify(argv: string[], io: CliIo): Promise<number> {
   return report.ok ? 0 : 1;
 }
 
+function readJson(filePath: string, what: string): unknown {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, "utf8");
+  } catch (error) {
+    // error-policy:J2 context-adding rethrow — a missing input file is a
+    // usage-level failure the invoking harness must see.
+    throw new EvidenceError(`${what} unreadable: ${filePath}`, {
+      code: "CLI_INPUT_UNREADABLE",
+      cause: error,
+      context: { filePath },
+    });
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    // error-policy:J3 untrusted input — malformed JSON is a typed failure.
+    throw new EvidenceError(`${what} is not valid JSON: ${filePath}`, {
+      code: "CLI_INPUT_INVALID",
+      cause: error,
+      context: { filePath },
+    });
+  }
+}
+
+interface CertifyArgs {
+  tier: Tier;
+  reviewerId: string;
+  reviewerKind: ReviewerKind;
+  reviewerModel?: string;
+  reviewerVerdictsPath?: string;
+  requirementsPath?: string;
+  existingBundleDir?: string;
+  skipMatrix: boolean;
+  baseRef?: string;
+  expiresHours?: number;
+  keyFile?: string;
+  certOut?: string;
+  outDir?: string;
+  repoRoot?: string;
+}
+
+function parseCertifyArgs(argv: string[]): CertifyArgs {
+  const value = new Map<string, string>();
+  const flags = new Set<string>();
+  const valueFlags = new Set([
+    "--tier",
+    "--reviewer-id",
+    "--reviewer-kind",
+    "--reviewer-model",
+    "--reviewer-verdicts",
+    "--requirements",
+    "--bundle",
+    "--base-ref",
+    "--expires-hours",
+    "--key-file",
+    "--cert-out",
+    "--out",
+    "--repo-root",
+  ]);
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--skip-matrix") {
+      flags.add(arg);
+      continue;
+    }
+    if (valueFlags.has(arg)) {
+      const next = argv[index + 1];
+      if (next === undefined) {
+        throw new EvidenceError(`${arg} requires a value`, {
+          code: "CLI_USAGE",
+        });
+      }
+      value.set(arg, next);
+      index += 1;
+      continue;
+    }
+    throw new EvidenceError(`unknown argument: ${arg}`, { code: "CLI_USAGE" });
+  }
+  const tierRaw = value.get("--tier");
+  if (tierRaw === undefined) {
+    throw new EvidenceError("--tier is required", { code: "CLI_USAGE" });
+  }
+  if (!(TIERS as readonly string[]).includes(tierRaw)) {
+    throw new EvidenceError(
+      `--tier must be one of ${TIERS.join("|")}, got: ${tierRaw}`,
+      { code: "CLI_USAGE" },
+    );
+  }
+  const reviewerId = value.get("--reviewer-id");
+  const reviewerKindRaw = value.get("--reviewer-kind");
+  if (reviewerId === undefined || reviewerKindRaw === undefined) {
+    throw new EvidenceError("--reviewer-id and --reviewer-kind are required", {
+      code: "CLI_USAGE",
+    });
+  }
+  if (!(REVIEWER_KINDS as readonly string[]).includes(reviewerKindRaw)) {
+    throw new EvidenceError(
+      `--reviewer-kind must be one of ${REVIEWER_KINDS.join("|")}, got: ${reviewerKindRaw}`,
+      { code: "CLI_USAGE" },
+    );
+  }
+  const expiresRaw = value.get("--expires-hours");
+  let expiresHours: number | undefined;
+  if (expiresRaw !== undefined) {
+    expiresHours = Number(expiresRaw);
+    if (!Number.isFinite(expiresHours) || expiresHours <= 0) {
+      throw new EvidenceError(
+        `--expires-hours must be a positive number, got: ${expiresRaw}`,
+        { code: "CLI_USAGE" },
+      );
+    }
+  }
+  return {
+    tier: tierRaw as Tier,
+    reviewerId,
+    reviewerKind: reviewerKindRaw as ReviewerKind,
+    reviewerModel: value.get("--reviewer-model"),
+    reviewerVerdictsPath: value.get("--reviewer-verdicts"),
+    requirementsPath: value.get("--requirements"),
+    existingBundleDir: value.get("--bundle"),
+    skipMatrix: flags.has("--skip-matrix"),
+    baseRef: value.get("--base-ref"),
+    expiresHours,
+    keyFile: value.get("--key-file"),
+    certOut: value.get("--cert-out"),
+    outDir: value.get("--out"),
+    repoRoot: value.get("--repo-root"),
+  };
+}
+
+async function runCertify(argv: string[], io: CliIo): Promise<number> {
+  const args = parseCertifyArgs(argv);
+  const repoRoot = path.resolve(args.repoRoot ?? defaultRepoRoot());
+  const signingKey = resolveSigningKey({
+    env: process.env,
+    ...(args.keyFile !== undefined ? { keyFile: args.keyFile } : {}),
+  });
+  const reviewerVerdicts =
+    args.reviewerVerdictsPath !== undefined
+      ? parseReviewerVerdicts(
+          readJson(args.reviewerVerdictsPath, "reviewer verdicts file"),
+          args.reviewerVerdictsPath,
+        )
+      : undefined;
+  const requirements =
+    args.requirementsPath !== undefined
+      ? parseRequirements(
+          readJson(args.requirementsPath, "requirements file"),
+          args.requirementsPath,
+        )
+      : undefined;
+
+  const result = await orchestrateCertify({
+    tier: args.tier,
+    repoRoot,
+    signingKey,
+    reviewer: {
+      kind: args.reviewerKind,
+      id: args.reviewerId,
+      ...(args.reviewerModel !== undefined
+        ? { model: args.reviewerModel }
+        : {}),
+    },
+    skipMatrix: args.skipMatrix,
+    ...(reviewerVerdicts !== undefined ? { reviewerVerdicts } : {}),
+    ...(requirements !== undefined ? { requirements } : {}),
+    ...(args.existingBundleDir !== undefined
+      ? { existingBundleDir: args.existingBundleDir }
+      : {}),
+    ...(args.baseRef !== undefined ? { baseRef: args.baseRef } : {}),
+    ...(args.expiresHours !== undefined
+      ? { expiresHours: args.expiresHours }
+      : {}),
+    ...(args.certOut !== undefined ? { certOut: args.certOut } : {}),
+    ...(args.outDir !== undefined ? { outDir: args.outDir } : {}),
+    io,
+  });
+
+  io.out("");
+  io.out(`  bundle:   ${result.bundleDir}`);
+  io.out(`  manifest: ${result.manifestSha256}`);
+  io.out(`  cert:     ${result.certPath}`);
+  io.out(`  verdict:  ${result.overallVerdict.toUpperCase()}`);
+  if (!result.verify.ok) {
+    for (const failure of result.verify.failures) {
+      io.err(`  ${failure.code}: ${failure.message}`);
+    }
+  }
+  return result.overallVerdict === "green" ? 0 : 1;
+}
+
 /** Parse argv (without node/script prefix) and run; returns the exit code. */
 export async function runCli(argv: string[], io: CliIo): Promise<number> {
   const [command, ...rest] = argv;
   try {
     if (command === "create") return await runCreate(rest, io);
     if (command === "verify") return await runVerify(rest, io);
+    if (command === "certify") return await runCertify(rest, io);
     io.err(USAGE);
     return command === undefined || command === "--help" || command === "-h"
       ? 0

--- a/packages/evidence/src/cli.ts
+++ b/packages/evidence/src/cli.ts
@@ -195,8 +195,8 @@ function readJson(filePath: string, what: string): unknown {
 
 interface CertifyArgs {
   tier: Tier;
-  reviewerId: string;
-  reviewerKind: ReviewerKind;
+  reviewerId?: string;
+  reviewerKind?: ReviewerKind;
   reviewerModel?: string;
   reviewerVerdictsPath?: string;
   requirementsPath?: string;
@@ -259,12 +259,26 @@ function parseCertifyArgs(argv: string[]): CertifyArgs {
   }
   const reviewerId = value.get("--reviewer-id");
   const reviewerKindRaw = value.get("--reviewer-kind");
-  if (reviewerId === undefined || reviewerKindRaw === undefined) {
-    throw new EvidenceError("--reviewer-id and --reviewer-kind are required", {
-      code: "CLI_USAGE",
-    });
+  if ((reviewerId === undefined) !== (reviewerKindRaw === undefined)) {
+    throw new EvidenceError(
+      "--reviewer-id and --reviewer-kind must be provided together",
+      {
+        code: "CLI_USAGE",
+      },
+    );
   }
-  if (!(REVIEWER_KINDS as readonly string[]).includes(reviewerKindRaw)) {
+  if (reviewerId === undefined && value.has("--reviewer-model")) {
+    throw new EvidenceError(
+      "--reviewer-model requires --reviewer-id and --reviewer-kind",
+      {
+        code: "CLI_USAGE",
+      },
+    );
+  }
+  if (
+    reviewerKindRaw !== undefined &&
+    !(REVIEWER_KINDS as readonly string[]).includes(reviewerKindRaw)
+  ) {
     throw new EvidenceError(
       `--reviewer-kind must be one of ${REVIEWER_KINDS.join("|")}, got: ${reviewerKindRaw}`,
       { code: "CLI_USAGE" },
@@ -283,8 +297,10 @@ function parseCertifyArgs(argv: string[]): CertifyArgs {
   }
   return {
     tier: tierRaw as Tier,
-    reviewerId,
-    reviewerKind: reviewerKindRaw as ReviewerKind,
+    ...(reviewerId !== undefined ? { reviewerId } : {}),
+    ...(reviewerKindRaw !== undefined
+      ? { reviewerKind: reviewerKindRaw as ReviewerKind }
+      : {}),
     reviewerModel: value.get("--reviewer-model"),
     reviewerVerdictsPath: value.get("--reviewer-verdicts"),
     requirementsPath: value.get("--requirements"),
@@ -325,13 +341,17 @@ async function runCertify(argv: string[], io: CliIo): Promise<number> {
     tier: args.tier,
     repoRoot,
     signingKey,
-    reviewer: {
-      kind: args.reviewerKind,
-      id: args.reviewerId,
-      ...(args.reviewerModel !== undefined
-        ? { model: args.reviewerModel }
-        : {}),
-    },
+    ...(args.reviewerId !== undefined && args.reviewerKind !== undefined
+      ? {
+          reviewer: {
+            kind: args.reviewerKind,
+            id: args.reviewerId,
+            ...(args.reviewerModel !== undefined
+              ? { model: args.reviewerModel }
+              : {}),
+          },
+        }
+      : {}),
     skipMatrix: args.skipMatrix,
     ...(reviewerVerdicts !== undefined ? { reviewerVerdicts } : {}),
     ...(requirements !== undefined ? { requirements } : {}),

--- a/packages/evidence/src/index.ts
+++ b/packages/evidence/src/index.ts
@@ -112,6 +112,22 @@ export {
   resolveSigningKey,
   SIGNING_KEY_ENV_VAR,
 } from "./certify/keys.ts";
+// One-command certify orchestrator (#14546): chains matrix → ingest →
+// analyze → vision-qa → rollup → reviewer merge → sign → self-verify.
+export {
+  type CertifyOptions,
+  type CertifyResult,
+  type MatrixLaneResult,
+  type MatrixRunner,
+  type MatrixRunResult,
+  mergeReviewerVerdicts,
+  orchestrateCertify,
+  parseReviewerVerdicts,
+  type ReviewerOverride,
+  type ReviewerVerdictsDocument,
+  type StepOutcome,
+  spawnRunAllTests,
+} from "./certify/orchestrate.ts";
 export {
   type AnalysisFinding,
   type ArtifactRequirement,


### PR DESCRIPTION
Part of #14541. Closes the orchestrator half of #14546.

## What this adds

The certification **pieces** already merged in #14610 (`certify:keygen|rollup|sign|verify`). What was missing is the **one command** that runs them as a chain. This PR adds `evidence:certify`.

`orchestrateCertify` (`packages/evidence/src/certify/orchestrate.ts`) chains the existing modules — **nothing is reimplemented**, this file is glue + honesty enforcement:

1. **test matrix** (optional) — spawns `packages/scripts/run-all-tests.mjs`, captures its pass/fail as `lanes/<lane>/result.json`. `--skip-matrix` skips it; injectable `runMatrix` for tests.
2. **`createBundle` + `ingestAllSilos`** — the existing bundle builder + silo ingest.
3. **`analyzeArtifacts`** — the existing analyzer runner, fanned over the ingested pixels at the selected tier, writing `analysis.json` beside each subject (runs before `finalize`).
4. **vision-QA pass** — the existing `askBatch`/`writeQaRecord`; **honest skip** recorded when no VLM backend is configured (keyless), never a fabricated green.
5. **`finalize`** → `rollupBundle` — the existing mechanical verdict rollup.
6. **reviewer merge** — reviewer overrides/additions folded onto the rollup; agent/human identity recorded.
7. **`signCertification`** → writes `certification.json` → immediate offline **`verifyCertification`** against the derived public key + the bundle.

Flags: `--tier cpu|gpu|full`, `--skip-matrix`, `--bundle <existing-dir>` (certify a pre-built finalized bundle: rollup → review → sign → verify only), `--reviewer-verdicts <file>`, `--reviewer-id/-kind/-model`, `--requirements`, `--base-ref`, `--expires-hours`, `--key-file`, `--cert-out`.

### Honesty is structural, not advisory

- The mechanical rollup drafts every **lane fail / skipped lane / analyzer expectation failure** as a non-pass verdict.
- A reviewer may **waive** such a subject (waivers require notes, which survive into the signed cert) but may **never flip a mechanically non-pass subject to `pass`** — rejected at merge time (`CERTIFY_FALSE_PASS`), the same hole the #14547 gate's completeness check closes.
- The run **self-verifies**; `overallVerdict` is `red` whenever the produced cert would fail the gate. **A red run still writes the truthful (failing) certification** rather than fabricating a green one. Exit code: 0 iff green, 1 if red.

Also: `evidence:certify` root script + `certify` package script (resolves the `check-docs` reference at `unified-evidence-harness.md:87`), and a read-only `EvidenceBundle.artifacts` getter so the analyzer step can enumerate work before `finalize` seals the manifest.

## Evidence — real signed cert produced + verified

Built a tiny fixture bundle (`lanes/server` + `lanes/ui` passing), generated a real Ed25519 demo key, and ran the shipped CLI end-to-end.

<details><summary><b>GREEN: evidence:certify → offline certify:verify</b></summary>

```
########## evidence:certify  (GREEN) ##########
certifying existing bundle 20260706-120000-abcdef0-cpu (tier=cpu)
certification GREEN — /tmp/demo-cert.json

  bundle:   /tmp/certify-demo-runs/20260706-120000-abcdef0-cpu
  manifest: 6667c79d5c4d3282ff442432a48ad3807d1f074cd88dcba63487dac152495f82
  cert:     /tmp/demo-cert.json
  verdict:  GREEN
== exit 0 ==

########## certify:verify  (offline, trusted pubkey) ##########
certification /tmp/demo-cert.json
  commit abcdef0123456789abcdef0123456789abcdef01 (feat/demo → develop) tier=cpu
  reviewer agent:shaw-agent (claude-fable-5)
  verdicts: 3  createdAt: 2026-07-06T07:53:55.373Z
  VERIFIED
== exit 0 ==
```
The cert signed by the orchestrator verifies with the **independent** `certify:verify` path the CI gate uses.
</details>

<details><summary><b>RED + tamper + false-pass guard</b></summary>

```
########## TAMPER: flip a lane result under the signed manifest ##########
  bundle-tampered: bundle integrity check failed: hash-mismatch:lanes/server/result.json
  FAILED
== exit 1 (tamper caught) ==

########## RED PATH: failing lane, no waiver ##########
certification RED — /tmp/red-cert.json
  failures: verdict-failures
  verdict-failures: 1 failing verdict(s): lane:server
== certify exit 1 (cert still written truthfully) ==
--- the red cert records the fail honestly ---
[{"subject":"lane:server","verdict":"fail","evidence":["lanes/server/result.json"],"notes":"passed=3 failed=2 skipped=0"}]

########## FALSE-PASS GUARD: reviewer tries to flip fail->pass ##########
error [CERTIFY_FALSE_PASS]: reviewer cannot mark mechanically fail subject 'lane:server' as pass; waive it with notes instead
== exit 1 (refused) ==
```
</details>

## Tests — real bundles, real Ed25519 keys, no mocked crypto

`orchestrate.test.ts` (12 tests): green **fresh-bundle** path (real throwaway git repo for provenance + scripted matrix lane), green **pre-built** path, reviewer **waive** of a failing lane, **red** verdict path, **false-pass** refusal, **post-sign tamper** detection (re-verified with the shipped `verifyCertification`), reviewer-merge completeness, and the **CLI** subcommand exit codes (0 green / 1 red). Every green assertion re-verifies the cert from disk.

<details><summary><b>bun run --cwd packages/evidence test</b></summary>

```
 Test Files  38 passed | 1 skipped (39)
      Tests  355 passed | 1 skipped (356)
```
(1 skipped = `vision-qa.live.test.ts`, needs a live VLM key.)

Orchestrator file alone:
```
 Test Files  1 passed (1)
      Tests  12 passed (12)
```
</details>

## Gates

| Gate | Result |
| --- | --- |
| `bun run --cwd packages/evidence test` | 355 passed, 1 skipped (live-only) |
| `bun run --cwd packages/evidence typecheck` (tsgo) | clean |
| `bun run --cwd packages/evidence lint` (biome) | clean |
| `check-docs` `evidence:certify` ref | resolved (7 remaining errors are a pre-existing unrelated doc) |
| error-policy ratchet | no new fallback-slop |

Real-LLM trajectories: N/A — this is harness plumbing, not agent/prompt behavior; the VLM Q&A step delegates to the already-tested `packages/evidence/src/vision-qa` exports and honest-skips when keyless. Frontend/native capture: N/A — CLI + library, no UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence Rows

<!-- evidence-row:before-screenshots --> N/A - CLI/library evidence certification orchestrator; no rendered UI, native, or browser surface changed.
<!-- evidence-row:after-screenshots --> N/A - CLI/library evidence certification orchestrator; no rendered UI, native, or browser surface changed.
<!-- evidence-row:walkthrough-video --> N/A - no interactive UI flow; the shipped CLI path is exercised by package tests and the command transcript above.
<!-- evidence-row:backend-logs --> N/A - no long-running backend service; CLI stdout/stderr and package test output cover the executed command path.
<!-- evidence-row:frontend-logs --> N/A - no frontend/browser session is involved.
<!-- evidence-row:llm-trajectory --> N/A - no agent, prompt, planner, or model behavior changed; VLM vision-QA remains delegated to the existing evidence backend and records an honest keyless skip.
<!-- evidence-row:domain-artifacts --> N/A - no product domain state is changed; the applicable artifact proof is the signed-cert transcript above showing green offline verification, truthful red cert writing, tamper detection, and false-pass refusal.

