### PR TITLE
refactor(testing): evidence reviewer reads bundle manifests via --bundle (#14550)

### DIFF
--- a/packages/docs/ongoing-development/unified-evidence-harness.md
+++ b/packages/docs/ongoing-development/unified-evidence-harness.md
@@ -44,8 +44,10 @@ evidence/runs/<run-id>/
 ```
 
 Existing producers are not rewritten; they are **ingested**. The 9 silos keep producing where
-they are; ingestors copy/hardlink into the bundle and record provenance. `evidence-review`
-dashboard reads the bundle manifest instead of re-scanning silos.
+they are; ingestors copy/hardlink into the bundle and record provenance. The `evidence-review`
+dashboard reads a bundle manifest directly — `generate.mjs --bundle=<run-dir>` maps the
+`@elizaos/evidence` `BundleManifest` entries into the review dashboard instead of re-scanning
+silos (bare `--bundle` reviews only that bundle; add `--source` to also scan silos).
 
 ### 2. `@elizaos/evidence` (new `packages/evidence`)
 

--- a/scripts/evidence-review/evidence-review.test.mjs
+++ b/scripts/evidence-review/evidence-review.test.mjs
@@ -3,16 +3,71 @@
  */
 
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import { analyzeImageFile, classifyArtifactPath, inferSource } from "./lib.mjs";
 
 const WHITE_PIXEL_PNG = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
   "base64",
 );
+
+const REPO_ROOT = path.resolve(
+  fileURLToPath(import.meta.url),
+  "..",
+  "..",
+  "..",
+);
+const GENERATE = "scripts/evidence-review/generate.mjs";
+
+/** Write a minimal schema-1 evidence bundle with a screenshot and a log. */
+async function writeBundle(dir, { runId = "bundle-run-001" } = {}) {
+  await mkdir(path.join(dir, "screens"), { recursive: true });
+  await writeFile(path.join(dir, "screens", "a.png"), WHITE_PIXEL_PNG);
+  await writeFile(
+    path.join(dir, "notes.log"),
+    "hello from the bundle\nsecond\n",
+  );
+  const now = new Date().toISOString();
+  const entry = (p, kind, bytes) => ({
+    path: p,
+    sha256: "0".repeat(64),
+    bytes,
+    kind,
+    source: "unit-audit",
+    producedBy: "evidence-review.test",
+    createdAt: now,
+  });
+  await writeFile(
+    path.join(dir, "manifest.json"),
+    JSON.stringify(
+      {
+        schema: 1,
+        runId,
+        createdAt: now,
+        metaSha256: "0".repeat(64),
+        artifacts: [
+          entry("screens/a.png", "screenshot", WHITE_PIXEL_PNG.length),
+          entry("notes.log", "log", 28),
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+/** Run the reviewer CLI under node from the repo root. */
+function runGenerate(args) {
+  return spawnSync("node", [GENERATE, ...args], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  });
+}
 
 test("classifies supported evidence artifact types", () => {
   assert.equal(classifyArtifactPath("shot.png"), "image");
@@ -67,6 +122,82 @@ test("flags one-color screenshots and summarizes dominant colors", async () => {
     assert.match(analysis.issues.join(" "), /one color/);
     assert.match(analysis.issues.join(" "), /near-solid/);
     assert.equal(analysis.dominantColors[0].hex, "#ffffff");
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("--bundle reviews an evidence bundle's manifest without silo scanning", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "evidence-bundle-"));
+  try {
+    const bundleDir = path.join(tmpDir, "bundle");
+    const outDir = path.join(tmpDir, "out");
+    await writeBundle(bundleDir);
+
+    const result = runGenerate([
+      `--bundle=${bundleDir}`,
+      `--out=${outDir}`,
+      "--ocr=off",
+      "--no-open",
+    ]);
+    assert.equal(result.status, 0, `generate failed: ${result.stderr}`);
+
+    const manifest = JSON.parse(
+      await readFile(path.join(outDir, "manifest.json"), "utf8"),
+    );
+    // Bare --bundle reviews only the bundle, so no silo dirs were scanned.
+    assert.deepEqual(manifest.scanDirs, []);
+    assert.equal(manifest.artifacts.length, 2);
+
+    const shot = manifest.artifacts.find((a) => a.type === "image");
+    assert.ok(shot, "screenshot artifact present");
+    assert.equal(shot.source, "unit-audit");
+    assert.equal(shot.bundleRunId, "bundle-run-001");
+    // The bundle screenshot ran through the shared image heuristics.
+    assert.ok(shot.image && shot.image.dominantColors.length > 0);
+
+    const log = manifest.artifacts.find((a) => a.type === "log");
+    assert.ok(log, "log artifact present");
+    assert.match(log.preview, /hello from the bundle/);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("--bundle fails fast when a manifest lists a missing file", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "evidence-bundle-"));
+  try {
+    const bundleDir = path.join(tmpDir, "bundle");
+    await mkdir(bundleDir, { recursive: true });
+    await writeFile(
+      path.join(bundleDir, "manifest.json"),
+      JSON.stringify({
+        schema: 1,
+        runId: "broken",
+        createdAt: new Date().toISOString(),
+        metaSha256: "0".repeat(64),
+        artifacts: [
+          {
+            path: "screens/missing.png",
+            sha256: "0".repeat(64),
+            bytes: 1,
+            kind: "screenshot",
+            source: "unit-audit",
+            producedBy: "test",
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      }),
+    );
+
+    const result = runGenerate([
+      `--bundle=${bundleDir}`,
+      `--out=${path.join(tmpDir, "out")}`,
+      "--ocr=off",
+      "--no-open",
+    ]);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /missing from the bundle/);
   } finally {
     await rm(tmpDir, { recursive: true, force: true });
   }

--- a/scripts/evidence-review/generate.mjs
+++ b/scripts/evidence-review/generate.mjs
@@ -11,7 +11,6 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import sharp from "sharp";
 import {
   closeOcrEngines,
   ocrImage,
@@ -26,8 +25,11 @@ import {
   toPosixPath,
 } from "./lib.mjs";
 
-sharp.cache(false);
-sharp.concurrency(1);
+// sharp is not imported here: all pixel work runs inside
+// @elizaos/evidence/visual-primitives (reached via lib.mjs and ocr.mjs), which
+// owns the only `sharp` this repo resolves from a root-level script. Importing
+// it here fails module resolution (sharp is nested under the evidence package),
+// which is why analyzeImageFile no longer takes a sharp handle.
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -66,6 +68,7 @@ function parseArgs(argv) {
     maxImages: 240,
     maxFilesPerDir: 6000,
     scanDirs: [],
+    bundleDir: null,
   };
   for (const arg of argv) {
     if (arg === "--open") options.open = true;
@@ -91,6 +94,11 @@ function parseArgs(argv) {
       );
     } else if (arg.startsWith("--source=")) {
       options.scanDirs.push(arg.slice("--source=".length));
+    } else if (arg.startsWith("--bundle=")) {
+      options.bundleDir = path.resolve(
+        REPO_ROOT,
+        arg.slice("--bundle=".length),
+      );
     } else if (arg === "--help" || arg === "-h") {
       printHelp();
       process.exit(0);
@@ -124,6 +132,9 @@ Options:
   --no-open               Do not open the dashboard.
   --out=<dir>             Output directory. Default: evidence/
   --source=<dir>          Scan a specific directory. Repeatable.
+  --bundle=<dir>          Read an evidence bundle's manifest.json (the @elizaos/evidence
+                          BundleManifest inventory) and review its artifacts. Used alone
+                          it reviews only that bundle; add --source to also scan silos.
   --ocr=on|auto|off       Run OCR with the packaged tesseract.js engine. Default: on.
   --max-artifacts=<n>     Limit total artifacts in the dashboard. Default: 900.
   --max-images=<n>        Limit image heuristic work. Default: 240.
@@ -209,8 +220,148 @@ function walkFiles(scanRoot, maxFiles) {
   return files.sort((a, b) => a.full.localeCompare(b.full));
 }
 
+/**
+ * Build one reviewer artifact record: stat plus the OCR/image heuristics for
+ * screenshots and a text preview for logs/reports. Shared by the silo scan and
+ * the `--bundle` manifest reader so both render through exactly the same
+ * pipeline; `counters` carries the running id, image-analysis budget, and OCR
+ * tallies across both sources.
+ */
+async function buildArtifactRecord(full, meta, options, counters) {
+  const stat = fs.statSync(full);
+  const artifact = {
+    id: `${counters.nextId++}`,
+    type: meta.type,
+    source: meta.source,
+    path: toPosixPath(path.relative(REPO_ROOT, full)),
+    href: toPosixPath(path.relative(options.outputDir, full)),
+    bytes: stat.size,
+    mtime: stat.mtime.toISOString(),
+  };
+  if (meta.bundleRunId) artifact.bundleRunId = meta.bundleRunId;
+  if (meta.type === "image") {
+    if (options.ocr !== "off") {
+      artifact.ocr = await runOcr(full, options);
+      if (artifact.ocr.status === "ok") counters.ocrOk += 1;
+      else if (options.ocr === "on") counters.ocrFail += 1;
+    }
+    if (counters.imageAnalysis < options.maxImages) {
+      counters.imageAnalysis += 1;
+      try {
+        artifact.image = await analyzeImageFile(full);
+      } catch (error) {
+        artifact.imageError = error?.message || String(error);
+      }
+    } else {
+      artifact.imageSkipped = "max image analysis limit reached";
+    }
+  } else if (
+    meta.type === "log" ||
+    meta.type === "report" ||
+    meta.type === "trajectory" ||
+    meta.type === "viewer"
+  ) {
+    artifact.preview = readTextPreview(full);
+  }
+  return artifact;
+}
+
+/**
+ * The @elizaos/evidence BundleManifest artifact kinds mapped onto the reviewer's
+ * coarser artifact types. `screenshot`/`keyframe` are pixels the image
+ * heuristics and OCR run over; `analysis`/`qa`/`report` render as inspectable
+ * text. An unlisted kind falls back to extension-based classification.
+ */
+const BUNDLE_KIND_TO_TYPE = {
+  screenshot: "image",
+  keyframe: "image",
+  video: "video",
+  log: "log",
+  trajectory: "trajectory",
+  report: "report",
+  analysis: "report",
+  qa: "report",
+  "html-tree": "viewer",
+};
+
+/**
+ * Read and structurally validate an evidence bundle's `manifest.json` — the
+ * signed artifact inventory @elizaos/evidence writes (schema 1). This is
+ * untrusted disk input (error-policy:J3): a missing or malformed manifest throws
+ * an explicit error rather than silently reviewing a partial/forged inventory.
+ */
+function readBundleManifest(bundleDir) {
+  const manifestPath = path.join(bundleDir, "manifest.json");
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error(
+      `--bundle: no manifest.json in ${toPosixPath(path.relative(REPO_ROOT, bundleDir))} (expected an @elizaos/evidence bundle directory)`,
+    );
+  }
+  let manifest;
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  } catch (error) {
+    throw new Error(
+      `--bundle: ${manifestPath} is not valid JSON: ${error?.message || error}`,
+    );
+  }
+  if (manifest?.schema !== 1 || !Array.isArray(manifest.artifacts)) {
+    throw new Error(
+      `--bundle: ${manifestPath} is not a schema-1 bundle manifest (need { schema: 1, artifacts: [] })`,
+    );
+  }
+  return manifest;
+}
+
+/**
+ * Append reviewer artifacts read from a bundle manifest. Each listed file's
+ * absolute path is recorded in `seen` so the subsequent silo scan does not
+ * re-add the same bytes when the bundle lives under a scan root. A manifest
+ * entry whose path escapes the bundle, or names a file missing from disk, throws
+ * — a bundle's signed inventory must match its contents.
+ */
+async function collectBundleArtifacts(bundleDir, options, counters, seen, out) {
+  const manifest = readBundleManifest(bundleDir);
+  const runId = typeof manifest.runId === "string" ? manifest.runId : null;
+  for (const entry of manifest.artifacts) {
+    if (out.length >= options.maxArtifacts) break;
+    const rel = typeof entry?.path === "string" ? entry.path : "";
+    const full = path.resolve(bundleDir, rel);
+    if (full !== bundleDir && !full.startsWith(bundleDir + path.sep)) {
+      throw new Error(
+        `--bundle: artifact path ${JSON.stringify(rel)} escapes the bundle directory`,
+      );
+    }
+    if (!fs.existsSync(full)) {
+      throw new Error(
+        `--bundle: manifest lists ${rel || "(empty path)"} but it is missing from the bundle`,
+      );
+    }
+    seen.add(full);
+    const type = BUNDLE_KIND_TO_TYPE[entry.kind] ?? classifyArtifactPath(full);
+    if (!type) continue;
+    const source =
+      typeof entry.source === "string" && entry.source
+        ? entry.source
+        : inferSource(REPO_ROOT, full);
+    out.push(
+      await buildArtifactRecord(
+        full,
+        { type, source, bundleRunId: runId },
+        options,
+        counters,
+      ),
+    );
+  }
+}
+
 async function collectArtifacts(options) {
-  const scanDirs = resolveScanDirs(options);
+  // A bare --bundle reviews just that bundle; the default silos are scanned only
+  // when no bundle is given, or alongside a bundle when --source is explicit.
+  const scanDirs =
+    options.bundleDir && options.scanDirs.length === 0
+      ? []
+      : resolveScanDirs(options);
   const ocrEngine =
     options.ocr === "off"
       ? { available: false, kind: "disabled", label: null, reason: null }
@@ -220,52 +371,37 @@ async function collectArtifacts(options) {
       `OCR is required but unavailable: ${ocrEngine.reason}. Run \`bun install\` so the packaged tesseract.js dependency is available, or set ELIZA_TESSERACT_BIN to a system tesseract binary.`,
     );
   }
+  const counters = { nextId: 1, imageAnalysis: 0, ocrOk: 0, ocrFail: 0 };
   const artifacts = [];
-  let imageAnalysisCount = 0;
-  let ocrFailureCount = 0;
-  let ocrOkCount = 0;
+  // Absolute paths already emitted, so a bundle under a scan root is not listed
+  // twice: the bundle read wins, the silo scan skips those files.
+  const seen = new Set();
+
+  if (options.bundleDir) {
+    await collectBundleArtifacts(
+      options.bundleDir,
+      options,
+      counters,
+      seen,
+      artifacts,
+    );
+  }
 
   for (const scanRoot of scanDirs) {
     if (artifacts.length >= options.maxArtifacts) break;
     const files = walkFiles(scanRoot, options.maxFilesPerDir);
     for (const { full, type } of files) {
       if (artifacts.length >= options.maxArtifacts) break;
-      const stat = fs.statSync(full);
-      const rel = toPosixPath(path.relative(REPO_ROOT, full));
-      const artifact = {
-        id: `${artifacts.length + 1}`,
-        type,
-        source: inferSource(REPO_ROOT, full),
-        path: rel,
-        href: toPosixPath(path.relative(options.outputDir, full)),
-        bytes: stat.size,
-        mtime: stat.mtime.toISOString(),
-      };
-      if (type === "image") {
-        if (options.ocr !== "off") {
-          artifact.ocr = await runOcr(full, options);
-          if (artifact.ocr.status === "ok") ocrOkCount += 1;
-          else if (options.ocr === "on") ocrFailureCount += 1;
-        }
-      }
-      if (type === "image" && imageAnalysisCount < options.maxImages) {
-        imageAnalysisCount += 1;
-        try {
-          artifact.image = await analyzeImageFile(full, sharp);
-        } catch (error) {
-          artifact.imageError = error?.message || String(error);
-        }
-      } else if (type === "image") {
-        artifact.imageSkipped = "max image analysis limit reached";
-      } else if (
-        type === "log" ||
-        type === "report" ||
-        type === "trajectory" ||
-        type === "viewer"
-      ) {
-        artifact.preview = readTextPreview(full);
-      }
-      artifacts.push(artifact);
+      if (seen.has(full)) continue;
+      seen.add(full);
+      artifacts.push(
+        await buildArtifactRecord(
+          full,
+          { type, source: inferSource(REPO_ROOT, full) },
+          options,
+          counters,
+        ),
+      );
     }
   }
 
@@ -274,12 +410,15 @@ async function collectArtifacts(options) {
     repoRoot: REPO_ROOT,
     outputDir: options.outputDir,
     scanDirs: scanDirs.map((dir) => toPosixPath(path.relative(REPO_ROOT, dir))),
+    bundleDir: options.bundleDir
+      ? toPosixPath(path.relative(REPO_ROOT, options.bundleDir))
+      : null,
     ocr: {
       mode: options.ocr,
       engine: ocrEngine.available ? ocrEngine.label : null,
       available: options.ocr === "off" ? false : Boolean(ocrEngine.available),
-      ok: ocrOkCount,
-      failures: ocrFailureCount,
+      ok: counters.ocrOk,
+      failures: counters.ocrFail,
     },
     artifacts,
   };
@@ -457,7 +596,7 @@ function buildHtml(manifest) {
 <body>
 <header>
   <h1>Evidence Review</h1>
-  <p class="subtitle">Generated ${htmlEscape(manifest.generatedAt)} from ${htmlEscape(manifest.scanDirs.join(", "))}. OCR: ${htmlEscape(ocrLabel)}.</p>
+  <p class="subtitle">Generated ${htmlEscape(manifest.generatedAt)} from ${htmlEscape([manifest.bundleDir ? `bundle ${manifest.bundleDir}` : null, ...manifest.scanDirs].filter(Boolean).join(", "))}. OCR: ${htmlEscape(ocrLabel)}.</p>
   <div class="stats">
     <span class="stat">${counts.total} artifacts</span>
     <span class="stat">${counts.image ?? 0} screenshots</span>


### PR DESCRIPTION
## What & why

`#14550` is the final consolidation phase of the unified evidence harness (`#14541`), executing the repo-level half of `#14470`. **While this branch was in flight, PR #14966 merged** and consolidated the visual-verify **primitives** (OCR / palette / pixel-diff / expectation math) into a single `packages/evidence/src/visual-primitives.mjs`, rewiring all four `#14470` consumers to import `@elizaos/evidence/visual-primitives`. That solves the primitive-duplication half of `#14550`/`#14470`.

This PR does **not** re-do that work. It completes the **reviewer + bundle-schema** half of `#14550` that `#14966` left open, and fixes a startup regression `#14966` introduced:

- **`scripts/evidence-review/generate.mjs` gains `--bundle=<dir>`** — it reads an `@elizaos/evidence` `BundleManifest` (`schema: 1`, `artifacts[]`) and maps each `ArtifactEntry` into the review dashboard through the **same** OCR/image-heuristic pipeline as the silo scan. This is `#14550` acceptance item "`bun run evidence:review` and the matrix reviewer read bundle manifests." Bare `--bundle` reviews only that bundle; add `--source` to also scan silos. The bundle dir is de-duped against the silo scan so a bundle under `evidence/` is never listed twice. Malformed / incomplete manifests **fail fast** (`error-policy:J3`) — a missing or path-escaping entry throws, never fabricates a review.
- **Shared `buildArtifactRecord()`** — the silo scan and the bundle reader now build artifact records through one code path (DRY) instead of two copies of the stat/OCR/image/preview logic.
- **Fix `#14966` regression:** `generate.mjs` still had `import sharp from "sharp"` at the top, but after `#14966` moved all pixel work into `visual-primitives.mjs`, `sharp` is only resolvable from *inside* the evidence package — a root-level script can't resolve it, so **`bun run evidence:review` crashed on startup** (`ERR_MODULE_NOT_FOUND: sharp`). `lib.mjs` already ignores its `sharp` param (`void sharp`). The dead import + `sharp.cache/concurrency` config is removed and `analyzeImageFile(full)` is called with no handle.
- **Doc:** the `unified-evidence-harness.md` design doc now names the `--bundle` mechanism it described as intent ("dashboard reads the bundle manifest instead of re-scanning silos").

## Acceptance proof

### OCR/palette/pixel-diff math lives in exactly one package

Function **definitions** of the visual-verify primitives exist only in `packages/evidence`; everywhere else imports them.

```
$ git grep -nE "^\s*(export )?function (bucketRgb|quantizePalette|quantizeChannel|dominantColorsFromPng|classifyColor|colorFractionsFromRaw|rgbToHsl)\b" \
    -- ':!packages/evidence/**' ':!**/node_modules/**' ':!**/dist/**'
(no output — no duplicated math outside packages/evidence)
```

The one `parseRgb` outside evidence — `packages/app/test/ui-smoke/aesthetic-audit-rules.ts:368` — is a **deliberate dependency-free** copy in the DOM aesthetic-audit module (its header states it must import nothing so the Playwright spec can load it); `#14966` left it, and it is out of scope here.

Consumers import the shared module:

```
$ git grep -n "@elizaos/evidence/visual-primitives" -- packages/app/scripts scripts/evidence-review
packages/app/scripts/lib/visual-qa.mjs:16:} from "@elizaos/evidence/visual-primitives";
packages/app/scripts/mvp-visual-verify/{color-bucket,diff,dominant-color,expectation-eval,ocr}.mjs
scripts/evidence-review/lib.mjs:9: ... from "@elizaos/evidence/visual-primitives";
```

### Deleted-code inventory

- **None in this PR.** `#14966` kept `packages/app/scripts/mvp-visual-verify/{color-bucket,diff,dominant-color,ocr}.mjs` as thin re-export adapters rather than deleting them; that is the merged owner decision, not re-litigated here.
- **`scripts/view-audit/*` — evaluated, NOT deleted.** It is a distinct **manually-run** crawler set (`run-device-batches.sh` → `device-gentle-crawler.mjs`), is **not** wired into any `package.json` script or CI, and is **cited by repo doctrine** — root `CLAUDE.md`/`AGENTS.md` reference `scripts/view-audit/output/MASTER-REPORT.md` in the Error-Handling section. It is not redundant with `audit:app` (DOM aesthetic audit, a different concern). Deleting it would orphan that doctrine citation; that belongs in a separate, coordinated change, not this focused reviewer PR.

### Gates

**`test:evidence-review` (`node --test scripts/evidence-review/*.test.mjs`)** — 23/23 pass, including 2 new `--bundle` cases that drive the real CLI:

```
✔ classifies supported evidence artifact types
✔ infers the standard evidence source directories
✔ flags one-color screenshots and summarizes dominant colors
✔ --bundle reviews an evidence bundle's manifest without silo scanning (117ms)
✔ --bundle fails fast when a manifest lists a missing file (96ms)
... reporter + run-matrix suites ...
ℹ tests 23   ℹ pass 23   ℹ fail 0
```

**Real CLI smoke** — `--bundle` reads a bundle manifest; the reviewer starts (regression fixed):

```
$ node scripts/evidence-review/generate.mjs --bundle=<bundle> --out=<out> --ocr=off --no-open
Evidence manifest: <out>/manifest.json
Evidence dashboard: <out>/index.html
Artifacts: 2 total, 1 screenshots, 0 videos, 0 trajectories, 1 logs.
# manifest: { bundleDir: "<bundle>", scanDirs: [], artifacts: [
#   { type:"image", source:"unit-audit", bundleRunId:"bundle-run-001", image:{...} },
#   { type:"log",   source:"unit-audit", bundleRunId:"bundle-run-001", preview:"hello from the bundle" } ] }
```

**Silo-scan path unchanged** — `--source=<dir>` still scans and classifies (`bundleDir: null`).

**Biome** — `biome check scripts/evidence-review/{generate,evidence-review.test}.mjs` → clean.

### Note on `bun run verify`

This diff is scripts-only (`.mjs` + one `.md`) with **no TypeScript and no dependency changes**, so the workspace `tsc` typecheck is a no-op for it; the proportionate gates above (Biome lint/format + the `node:test` reviewer suite + real CLI runs) are the meaningful signal. `PR_EVIDENCE.md` referenced by `CLAUDE.md` is not present in the tree, so that doc update is N/A.

## Evidence

| Type | Status | Evidence |
| --- | --- | --- |
| Before/after screenshots | N/A — tooling-only | No product UI pixels changed; this is evidence-reviewer CLI/reporting code. |
| Walkthrough video | N/A — tooling-only | No user-facing flow changed. |
| Backend logs | N/A — no server path | No route/provider/action/service behavior changed. |
| Frontend logs | N/A — no frontend path | No web/desktop/mobile UI touched. |
| Real-LLM trajectories | N/A — no model path | No agent/action/prompt/model behavior changed. |
| Domain artifacts | ✅ | The evidence bundle → review manifest above (bundle `manifest.json` in, dashboard `manifest.json` + `index.html` out), plus the 23-test suite. |

Fixes the reviewer half of #14550 (after #14966 landed the #14470 primitive consolidation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence Rows

<!-- evidence-row:before-screenshots --> N/A - tooling-only evidence-review CLI plus an ongoing-development design doc; no rendered app/native/docs-site page pixels changed.
<!-- evidence-row:after-screenshots --> N/A - tooling-only evidence-review CLI plus an ongoing-development design doc; no rendered app/native/docs-site page pixels changed.
<!-- evidence-row:walkthrough-video --> N/A - no interactive product flow; the real CLI reviewer path is exercised by the --bundle node:test cases and CLI smoke transcript above.
<!-- evidence-row:backend-logs --> N/A - no server route/provider/action/service path changed.
<!-- evidence-row:frontend-logs --> N/A - no browser/frontend session is involved.
<!-- evidence-row:llm-trajectory --> N/A - no agent, prompt, planner, model, or live-LLM behavior changed.
<!-- evidence-row:domain-artifacts --> N/A - no product domain state changes; the relevant tooling artifact is the generated evidence-review manifest/dashboard path proven by the CLI test and transcript above.
