### PR TITLE
feat(app-control): hot-apply voice settings to the running shell (#14910)

### DIFF
--- a/packages/shared/src/events/index.ts
+++ b/packages/shared/src/events/index.ts
@@ -165,6 +165,30 @@ export interface AppearanceApplyPayload extends Record<string, unknown> {
   homeTimeWidgetHidden?: boolean;
 }
 
+export const VOICE_SETTINGS_APPLY_EVENT = "voice-settings:apply" as const;
+
+/**
+ * Payload broadcast on {@link VOICE_SETTINGS_APPLY_EVENT}.
+ *
+ * The SETTINGS voice twin persists these under `messages.voice` via `/api/config`,
+ * but the running capture path (useShellController.startCapture) and ChatView
+ * read the localStorage mirrors VoiceSectionMount seeds — never the config blob.
+ * This payload re-seeds those mirrors live so a chat-driven change reaches the
+ * running shell without a Settings → Voice remount. Fields are optional so a
+ * single-field write does not have to restate the whole voice config.
+ */
+export interface VoiceSettingsApplyPayload extends Record<string, unknown> {
+  /** Continuous-chat mode: off (push-to-talk), vad-gated, or always-on. */
+  continuous?: "off" | "vad-gated" | "always-on";
+  /** VAD end-of-turn thresholds the capture hot path reads. */
+  vadAutoStop?: {
+    /** Trailing silence (ms) that ends a turn in local-ASR capture. */
+    silenceMs: number;
+    /** RMS amplitude (0–1) above which audio is treated as speech. */
+    speechRmsThreshold: number;
+  };
+}
+
 // ── Avatar / VRM ─────────────────────────────────────────────────────────
 export const VRM_TELEPORT_COMPLETE_EVENT =
   "eliza:vrm-teleport-complete" as const;

--- a/packages/ui/src/backgrounds/AppBackground.tsx
+++ b/packages/ui/src/backgrounds/AppBackground.tsx
@@ -8,6 +8,7 @@ import { lazy, Suspense, useState } from "react";
 import type { ShaderConfig } from "../state/ui-preferences";
 import { DEFAULT_BACKGROUND_COLOR } from "../state/ui-preferences";
 import { useBackgroundConfig } from "../state/useBackgroundConfig";
+import { useVoiceSettingsApplyChannel } from "../voice/useVoiceSettingsApplyChannel";
 import { ImageBackground } from "./ImageBackground";
 import { ShaderBackground } from "./ShaderBackground";
 import { useAppearanceApplyChannel } from "./useAppearanceApplyChannel";
@@ -74,6 +75,7 @@ export function AppBackground({
   const { backgroundConfig } = useBackgroundConfig();
   useBackgroundApplyChannel();
   useAppearanceApplyChannel();
+  useVoiceSettingsApplyChannel();
   if (!visible) return null;
   // Defensive: the app store can return a non-object slice before the provider
   // seeds it (e.g. the test fallback proxy). Fall back to the default shader.

--- a/packages/ui/src/components/pages/ChatView.tsx
+++ b/packages/ui/src/components/pages/ChatView.tsx
@@ -35,6 +35,7 @@ import { useChatAvatarVoiceBridge } from "../../hooks/useChatAvatarVoiceBridge";
 import { useConnectorSendAsAccount } from "../../hooks/useConnectorSendAsAccount";
 import { useIntervalWhenDocumentVisible } from "../../hooks/useDocumentVisibility";
 import { useLoadOlderOnScroll } from "../../hooks/useLoadOlderOnScroll";
+import { useViewEvent } from "../../hooks/useViewEvent";
 import { claimAssistantLaunchPayloadFromHash } from "../../platform/assistant-launch-payload";
 import {
   CodingAgentControlChip,
@@ -58,7 +59,14 @@ import {
   intakeAttachmentFiles,
   MAX_CHAT_IMAGES,
 } from "../../utils/image-attachment";
-import type { VoiceContinuousMode } from "../../voice/voice-chat-types";
+import {
+  VOICE_SETTINGS_APPLY_EVENT,
+  type VoiceSettingsApplyPayload,
+} from "../../voice/useVoiceSettingsApplyChannel";
+import {
+  VOICE_CONTINUOUS_MODES,
+  type VoiceContinuousMode,
+} from "../../voice/voice-chat-types";
 import { AccountRequiredCard } from "../chat/AccountRequiredCard";
 import { AgentActivityBox } from "../chat/AgentActivityBox";
 import { ConnectorAccountPicker } from "../chat/ConnectorAccountPicker";
@@ -95,6 +103,13 @@ const CHAT_INPUT_MAX_HEIGHT_PX = 200;
 const TYPING_INDICATOR_STALL_MS = 30_000;
 const fallbackTranslate: TranslateFn = (key, options) =>
   typeof options?.defaultValue === "string" ? options.defaultValue : key;
+
+function readAppliedContinuousMode(value: unknown): VoiceContinuousMode | null {
+  return typeof value === "string" &&
+    VOICE_CONTINUOUS_MODES.includes(value as VoiceContinuousMode)
+    ? (value as VoiceContinuousMode)
+    : null;
+}
 
 type ChatViewVariant = "default" | "game-modal";
 type InboxChatSelection = {
@@ -287,6 +302,11 @@ export function ChatView({
   const [typingStalled, setTypingStalled] = useState(false);
   const [continuousChatMode, setContinuousChatMode] =
     useState<VoiceContinuousMode>(loadContinuousChatMode);
+  useViewEvent(VOICE_SETTINGS_APPLY_EVENT, (event) => {
+    const payload = event.payload as VoiceSettingsApplyPayload;
+    const continuous = readAppliedContinuousMode(payload.continuous);
+    if (continuous) setContinuousChatMode(continuous);
+  });
   const handleContinuousChatModeChange = useCallback(
     (next: VoiceContinuousMode) => {
       setContinuousChatMode(next);

--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -7,6 +7,7 @@
 // store, and voice-output hook are mocked; localStorage is backed by an
 // in-memory Storage so hands-free persistence is real.
 
+import { VOICE_SETTINGS_APPLY_EVENT } from "@elizaos/shared/events";
 import { act, cleanup, renderHook } from "@testing-library/react";
 import {
   afterEach,
@@ -17,7 +18,7 @@ import {
   type Mock,
   vi,
 } from "vitest";
-
+import { emitViewEvent } from "../../../views/view-event-bus";
 import {
   createVoiceCapture,
   type VoiceCaptureFactoryOptions,
@@ -771,6 +772,45 @@ describe("useShellController — voice capture routing", () => {
     expect(appMock.value.sendChatText.mock.calls[0]?.[1]).toMatchObject({
       channelType: "VOICE_DM",
     });
+  });
+
+  it("voice-settings apply always-on engages the mounted hands-free shell", async () => {
+    const { result } = renderHook(() => useShellController());
+    expect(result.current.handsFree).toBe(false);
+
+    await act(async () => {
+      emitViewEvent(
+        VOICE_SETTINGS_APPLY_EVENT,
+        { continuous: "always-on" },
+        "agent",
+      );
+      await Promise.resolve();
+    });
+
+    expect(result.current.handsFree).toBe(true);
+    expect(result.current.isOpen).toBe(true);
+    expect(createVoiceCaptureMock).toHaveBeenCalledTimes(1);
+    expect(captureHandles[0]?.start).toHaveBeenCalledTimes(1);
+  });
+
+  it("voice-settings apply off stops the mounted hands-free shell", async () => {
+    const { result } = renderHook(() => useShellController());
+    await act(async () => {
+      result.current.toggleHandsFree();
+    });
+    expect(result.current.handsFree).toBe(true);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      emitViewEvent(VOICE_SETTINGS_APPLY_EVENT, { continuous: "off" }, "agent");
+      await Promise.resolve();
+    });
+
+    expect(result.current.handsFree).toBe(false);
+    expect(captureHandles[0]?.stop).toHaveBeenCalledTimes(1);
+    expect(voiceOutputMock.stopSpeaking).toHaveBeenCalled();
   });
 
   it("a spoken 'start transcription' in converse flips into transcription mode and is not sent", async () => {

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -13,6 +13,10 @@
  * state of their own. ShellControllerContext provides one instance so the pill
  * and the overlay stay in lock-step without double-mounting this hook.
  */
+import {
+  VOICE_SETTINGS_APPLY_EVENT,
+  type VoiceSettingsApplyPayload,
+} from "@elizaos/shared/events";
 import type { TranscriptSegment } from "@elizaos/shared/transcripts";
 import * as React from "react";
 import type {
@@ -23,6 +27,7 @@ import {
   VOICE_CONTROL_EVENT,
   type VoiceControlEventDetail,
 } from "../../events";
+import { useViewEvent } from "../../hooks/useViewEvent";
 import type { HomeModelStatus } from "../../services/local-inference/home-model-status";
 import {
   useChatComposer,
@@ -54,6 +59,10 @@ import {
   type VoiceCaptureHandle,
   type VoiceCaptureState,
 } from "../../voice/voice-capture-factory";
+import {
+  VOICE_CONTINUOUS_MODES,
+  type VoiceContinuousMode,
+} from "../../voice/voice-chat-types";
 import { buildVoiceTurnSignal } from "../../voice/voice-turn-signal";
 import { matchWakeName } from "../../voice/wake-name-match";
 import { useHomeModelStatus } from "../local-inference/useHomeModelStatus";
@@ -280,6 +289,13 @@ function sameStringList(a?: string[], b?: string[]): boolean {
     if (a[i] !== b[i]) return false;
   }
   return true;
+}
+
+function readAppliedContinuousMode(value: unknown): VoiceContinuousMode | null {
+  return typeof value === "string" &&
+    VOICE_CONTINUOUS_MODES.includes(value as VoiceContinuousMode)
+    ? (value as VoiceContinuousMode)
+    : null;
 }
 
 // Granular shallow selection instead of useApp() so the shell controller only
@@ -1187,6 +1203,36 @@ export function useShellController(): ShellController {
       if (!responding) startCapture("converse");
     }
   }, [responding, startCapture, stopCapture, voiceOutput]);
+
+  useViewEvent(
+    VOICE_SETTINGS_APPLY_EVENT,
+    React.useCallback(
+      (event) => {
+        const payload = event.payload as VoiceSettingsApplyPayload;
+        const continuous = readAppliedContinuousMode(payload.continuous);
+        if (!continuous) return;
+        saveContinuousChatMode(continuous);
+
+        if (continuous === "always-on") {
+          if (handsFreeRef.current) return;
+          priorContinuousModeRef.current = "off";
+          setHandsFree(true);
+          handsFreeRef.current = true;
+          setIsOpen(true);
+          if (!responding) startCapture("converse");
+          return;
+        }
+
+        priorContinuousModeRef.current = continuous;
+        if (!handsFreeRef.current) return;
+        setHandsFree(false);
+        handsFreeRef.current = false;
+        if (captureRef.current) stopCapture();
+        voiceOutput.stopSpeaking();
+      },
+      [responding, startCapture, stopCapture, voiceOutput],
+    ),
+  );
 
   // "Hey eliza" wake word: a native detection arms a bounded listening window
   // that opens the mic and closes once the agent has responded (or after an idle

--- a/packages/ui/src/voice/useVoiceSettingsApplyChannel.test.tsx
+++ b/packages/ui/src/voice/useVoiceSettingsApplyChannel.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+/**
+ * jsdom coverage for the chat-to-voice view event bridge. The hook runs against
+ * real localStorage and the real persistence mirrors so the test proves the
+ * broadcast contract reaches the same `loadContinuousChatMode` / `loadVadAutoStop`
+ * values the running shell/capture path reads — no stubbed setters.
+ */
+
+import { VOICE_SETTINGS_APPLY_EVENT as SHARED_VOICE_SETTINGS_APPLY_EVENT } from "@elizaos/shared/events";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  loadContinuousChatMode,
+  loadVadAutoStop,
+  saveContinuousChatMode,
+  saveVadAutoStop,
+} from "../state/persistence";
+import { emitViewEvent } from "../views/view-event-bus";
+import {
+  useVoiceSettingsApplyChannel,
+  VOICE_SETTINGS_APPLY_EVENT,
+} from "./useVoiceSettingsApplyChannel";
+
+function Channel(): null {
+  useVoiceSettingsApplyChannel();
+  return null;
+}
+
+function apply(payload: Record<string, unknown>): void {
+  act(() => {
+    emitViewEvent(VOICE_SETTINGS_APPLY_EVENT, payload, "agent");
+  });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+describe("useVoiceSettingsApplyChannel", () => {
+  it("uses the shared voice-settings apply event contract", () => {
+    expect(VOICE_SETTINGS_APPLY_EVENT).toBe(SHARED_VOICE_SETTINGS_APPLY_EVENT);
+  });
+
+  it("re-seeds the continuous-chat and VAD mirrors the shell reads", () => {
+    render(<Channel />);
+    apply({
+      continuous: "always-on",
+      vadAutoStop: { silenceMs: 1200, speechRmsThreshold: 0.004 },
+    });
+
+    expect(loadContinuousChatMode()).toBe("always-on");
+    expect(loadVadAutoStop()).toEqual({
+      silenceMs: 1200,
+      speechRmsThreshold: 0.004,
+    });
+  });
+
+  it("ignores an unknown continuous mode and a non-numeric VAD pair", () => {
+    saveContinuousChatMode("vad-gated");
+    saveVadAutoStop({ silenceMs: 800, speechRmsThreshold: 0.005 });
+    render(<Channel />);
+
+    apply({
+      continuous: "turbo",
+      vadAutoStop: { silenceMs: "loud", speechRmsThreshold: 0.01 },
+    });
+
+    // Prior mirror values survive an invalid broadcast — the capture path is
+    // never handed a malformed value.
+    expect(loadContinuousChatMode()).toBe("vad-gated");
+    expect(loadVadAutoStop()).toEqual({
+      silenceMs: 800,
+      speechRmsThreshold: 0.005,
+    });
+  });
+
+  it("applies a single provided field without disturbing the other mirror", () => {
+    saveVadAutoStop({ silenceMs: 950, speechRmsThreshold: 0.006 });
+    render(<Channel />);
+
+    apply({ continuous: "off" });
+
+    expect(loadContinuousChatMode()).toBe("off");
+    expect(loadVadAutoStop()).toEqual({
+      silenceMs: 950,
+      speechRmsThreshold: 0.006,
+    });
+  });
+});

--- a/packages/ui/src/voice/useVoiceSettingsApplyChannel.ts
+++ b/packages/ui/src/voice/useVoiceSettingsApplyChannel.ts
@@ -1,0 +1,67 @@
+/**
+ * Always-mounted bridge for chat-driven voice preferences.
+ *
+ * The SETTINGS voice twin persists `messages.voice` through `/api/config`, but
+ * the capture hot path (useShellController.startCapture) and ChatView read the
+ * localStorage mirrors (loadVadAutoStop / loadContinuousChatMode) that
+ * VoiceSectionMount seeds — never the config blob, and only on its own mount.
+ * This hook subscribes to the `voice-settings:apply` broadcast the action emits
+ * after a successful config write and re-seeds those same mirrors, so a
+ * chat-driven change reaches the running shell without a Settings → Voice
+ * remount or an app reload. It is the voice twin of useAppearanceApplyChannel.
+ *
+ * Payload fields are validated before they touch the mirrors: a crafted or
+ * partial broadcast can only ever write a known continuous mode or a fully
+ * numeric VAD pair, never a malformed value into the capture path.
+ */
+
+import {
+  VOICE_SETTINGS_APPLY_EVENT,
+  type VoiceSettingsApplyPayload,
+} from "@elizaos/shared/events";
+import { useViewEvent } from "../hooks/useViewEvent";
+import {
+  saveContinuousChatMode,
+  saveVadAutoStop,
+  type VadAutoStopValue,
+} from "../state/persistence";
+import {
+  VOICE_CONTINUOUS_MODES,
+  type VoiceContinuousMode,
+} from "./voice-chat-types";
+
+export type { VoiceSettingsApplyPayload } from "@elizaos/shared/events";
+export { VOICE_SETTINGS_APPLY_EVENT };
+
+function readContinuousMode(value: unknown): VoiceContinuousMode | null {
+  return typeof value === "string" &&
+    VOICE_CONTINUOUS_MODES.includes(value as VoiceContinuousMode)
+    ? (value as VoiceContinuousMode)
+    : null;
+}
+
+function readVadAutoStop(value: unknown): VadAutoStopValue | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const { silenceMs, speechRmsThreshold } = value as Record<string, unknown>;
+  if (
+    typeof silenceMs !== "number" ||
+    !Number.isFinite(silenceMs) ||
+    typeof speechRmsThreshold !== "number" ||
+    !Number.isFinite(speechRmsThreshold)
+  ) {
+    return null;
+  }
+  return { silenceMs, speechRmsThreshold };
+}
+
+export function useVoiceSettingsApplyChannel(): void {
+  useViewEvent(VOICE_SETTINGS_APPLY_EVENT, (event) => {
+    const payload = event.payload as VoiceSettingsApplyPayload;
+
+    const continuous = readContinuousMode(payload.continuous);
+    if (continuous) saveContinuousChatMode(continuous);
+
+    const vadAutoStop = readVadAutoStop(payload.vadAutoStop);
+    if (vadAutoStop) saveVadAutoStop(vadAutoStop);
+  });
+}

--- a/plugins/plugin-app-control/src/actions/settings.test.ts
+++ b/plugins/plugin-app-control/src/actions/settings.test.ts
@@ -7,7 +7,10 @@
  */
 
 import type { HandlerCallback, IAgentRuntime, Memory } from "@elizaos/core";
-import { APPEARANCE_APPLY_EVENT } from "@elizaos/shared";
+import {
+	APPEARANCE_APPLY_EVENT,
+	VOICE_SETTINGS_APPLY_EVENT,
+} from "@elizaos/shared";
 import {
 	SETTINGS_NON_CATALOG_SECTION_META,
 	SETTINGS_SECTION_META,
@@ -662,6 +665,100 @@ describe("SETTINGS action: set on an owned route section", () => {
 		});
 		expect(result?.success).toBe(true);
 		expect(texts.join(" ")).toContain("speech threshold is 0.01");
+	});
+
+	it("broadcasts voice-settings:apply so the running shell mirrors update", async () => {
+		// #14910: persisting messages.voice alone leaves the live capture path stale;
+		// the action must also broadcast the applied prefs to re-seed the shell's
+		// localStorage mirrors (useVoiceSettingsApplyChannel). Explicit stored VAD
+		// values keep this independent of the default-value fix (#14994).
+		const routeFetch = vi.fn<SettingsRouteFetch>(async (request) => {
+			if (request.method === "GET") {
+				return {
+					ok: true,
+					data: {
+						messages: {
+							voice: {
+								continuous: "off",
+								vadAutoStop: { silenceMs: 1100, speechRmsThreshold: 0.005 },
+							},
+						},
+					},
+				};
+			}
+			return { ok: true };
+		});
+		const { result } = await invoke(
+			{
+				action: "set",
+				section: "voice",
+				key: "continuous",
+				value: "always-on",
+			},
+			routeFetch,
+		);
+		expect(routeFetch).toHaveBeenCalledTimes(3);
+		expect(routeFetch).toHaveBeenNthCalledWith(3, {
+			method: "POST",
+			path: "/api/views/events/broadcast",
+			body: {
+				type: VOICE_SETTINGS_APPLY_EVENT,
+				payload: {
+					continuous: "always-on",
+					vadAutoStop: { silenceMs: 1100, speechRmsThreshold: 0.005 },
+				},
+			},
+		});
+		expect(result?.success).toBe(true);
+		expect(VOICE_SETTINGS_APPLY_EVENT).toBe("voice-settings:apply");
+	});
+
+	it("surfaces a voice broadcast failure instead of fabricating live-apply", async () => {
+		// The config write can succeed while the broadcast fails; the shell would
+		// then stay on old values, so the action reports failure rather than a
+		// fabricated success (#14910).
+		const routeFetch = vi.fn<SettingsRouteFetch>(async (request) => {
+			if (request.method === "GET") {
+				return {
+					ok: true,
+					data: { messages: { voice: { continuous: "off" } } },
+				};
+			}
+			if (request.method === "PUT") return { ok: true };
+			return { ok: false, detail: "view broadcast failed" };
+		});
+		const { result, texts } = await invoke(
+			{ action: "set", section: "voice", key: "continuous", value: "vad" },
+			routeFetch,
+		);
+		expect(routeFetch).toHaveBeenCalledTimes(3);
+		expect(result?.success).toBe(false);
+		expect(texts.join(" ")).toContain("view broadcast failed");
+	});
+
+	it("does not broadcast when the voice config write fails", async () => {
+		// Fail-fast: a failed PUT returns before the broadcast, so the shell is
+		// never told about a change that did not persist.
+		const routeFetch = vi.fn<SettingsRouteFetch>(async (request) => {
+			if (request.method === "GET") {
+				return { ok: true, data: { messages: {} } };
+			}
+			return { ok: false, detail: "config save failed" };
+		});
+		const { result } = await invoke(
+			{
+				action: "set",
+				section: "voice",
+				key: "continuous",
+				value: "always-on",
+			},
+			routeFetch,
+		);
+		expect(routeFetch).toHaveBeenCalledTimes(2);
+		expect(routeFetch).not.toHaveBeenCalledWith(
+			expect.objectContaining({ path: "/api/views/events/broadcast" }),
+		);
+		expect(result?.success).toBe(false);
 	});
 
 	it("dispatches permissions shell off through the backend route", async () => {

--- a/plugins/plugin-app-control/src/actions/settings.ts
+++ b/plugins/plugin-app-control/src/actions/settings.ts
@@ -39,6 +39,8 @@ import {
 	normalizeWalletRpcProviderId,
 	type PermissionId,
 	resolveInitialWalletRpcSelections,
+	VOICE_SETTINGS_APPLY_EVENT,
+	type VoiceSettingsApplyPayload,
 	WALLET_RPC_PROVIDER_OPTIONS,
 	type WalletConfigStatus,
 	type WalletRpcChain,
@@ -903,6 +905,26 @@ function buildVoiceSettingsPrefs(
 	return "provide key=continuous|silence-ms|rms";
 }
 
+// Mirror the applied prefs onto the running shell. Persisting messages.voice
+// alone leaves capture stale: ChatView / useShellController read the localStorage
+// mirrors (loadContinuousChatMode / loadVadAutoStop) that VoiceSectionMount seeds
+// from config, and never re-read config until that section remounts. Broadcasting
+// voice-settings:apply drives useVoiceSettingsApplyChannel to re-seed those
+// mirrors live — the same loopback appearance:apply uses (#14910).
+function voiceSettingsBroadcastRequest(
+	prefs: VoiceSettingsPrefs,
+): SettingsRouteRequest {
+	const payload: VoiceSettingsApplyPayload = {
+		continuous: prefs.continuous,
+		vadAutoStop: prefs.vadAutoStop,
+	};
+	return {
+		method: "POST",
+		path: "/api/views/events/broadcast",
+		body: { type: VOICE_SETTINGS_APPLY_EVENT, payload },
+	};
+}
+
 const VOICE_PREFS_KEY: SettingsWritableKey = {
 	description:
 		"Voice continuous-chat mode and VAD end-of-turn thresholds persisted under messages.voice through /api/config.",
@@ -924,7 +946,13 @@ const VOICE_PREFS_KEY: SettingsWritableKey = {
 			path: "/api/config",
 			body: { messages: { ...messages, voice: next } },
 		});
-		return outcome.ok ? { ...outcome, data: next } : outcome;
+		if (!outcome.ok) return outcome;
+
+		// The action's contract is to change voice behavior in the running app, so
+		// a broadcast failure is a real failure (the shell would stay stale) — not
+		// swallowed, even though config already persisted.
+		const applied = await routeFetch(voiceSettingsBroadcastRequest(next));
+		return applied.ok ? { ...applied, data: next } : applied;
 	},
 	successText: (_value, _request, outcome) => {
 		const next = readVoiceSettingsPrefs({ messages: { voice: outcome.data } });


### PR DESCRIPTION
## What

Hot-applies chat-driven voice settings to the already-running shell. This is the client-side runtime-application half of reopened #14910: `SETTINGS section=voice` persisted `messages.voice` via `/api/config`, but the mounted capture path kept reading stale localStorage mirrors until Settings -> Voice remounted or the app reloaded.

## How

- `@elizaos/shared/events` adds `VOICE_SETTINGS_APPLY_EVENT` and `VoiceSettingsApplyPayload`.
- `plugin-app-control` broadcasts the applied voice prefs to `/api/views/events/broadcast` only after the `/api/config` write succeeds; broadcast failure is surfaced instead of pretending the live shell applied it.
- `packages/ui` mounts `useVoiceSettingsApplyChannel` next to the appearance apply channel so broadcasts re-seed the same `saveContinuousChatMode` / `saveVadAutoStop` mirrors used by capture.
- `useShellController` now handles the mounted-shell part directly: always-on broadcasts engage hands-free capture, and off/vad-gated broadcasts stop hands-free state without waiting for a remount. The handler persists the applied mode and keeps `handsFreeRef` in sync with React state.

## Fields Covered

`continuous` (`off` / `vad-gated` / `always-on`) and `vadAutoStop` (`silenceMs`, `speechRmsThreshold`) cover the full `messages.voice` surface the SETTINGS voice twin writes. Wake-word and voice-profile enrollment stay out because those are device-local audio flows with no safe loopback write.

## Evidence Rows

<!-- evidence-row:before-screenshots --> N/A - headless voice settings apply channel; no rendered layout, copy, or color changed, so packaged OCR has no screenshot input for this PR.
<!-- evidence-row:after-screenshots --> N/A - headless voice settings apply channel; no rendered layout, copy, or color changed, so packaged OCR has no screenshot input for this PR.
<!-- evidence-row:walkthrough-video --> N/A - no interactive visual UI flow changed; focused jsdom tests exercise the action broadcast, storage mirrors, and mounted shell state.
<!-- evidence-row:backend-logs --> N/A - no new backend service/log path; action tests assert the real loopback `/api/views/events/broadcast` request shape and failure handling.
<!-- evidence-row:frontend-logs --> N/A - no browser session recorded; focused UI tests emit the real view event and assert localStorage plus mounted shell behavior.
<!-- evidence-row:llm-trajectory --> N/A - deterministic action/broadcast handling; no prompt, model, or planner behavior changed.
<!-- evidence-row:domain-artifacts --> N/A - no persistent domain artifact beyond config/localStorage mirrors; tests assert persisted config write, broadcast payload, and the mounted shell capture state.

## Verification

```
$ bunx vitest run --config vitest.config.ts src/components/shell/__tests__/useShellController.test.tsx src/voice/useVoiceSettingsApplyChannel.test.tsx  # packages/ui
Test Files  2 passed (2)
Tests       60 passed (60)

$ bun run --cwd plugins/plugin-app-control test src/actions/settings.test.ts
Test Files  1 passed (1)
Tests       106 passed (106)

$ bunx @biomejs/biome check packages/shared/src/events/index.ts packages/ui/src/backgrounds/AppBackground.tsx packages/ui/src/components/pages/ChatView.tsx packages/ui/src/components/shell/useShellController.ts packages/ui/src/components/shell/__tests__/useShellController.test.tsx packages/ui/src/voice/useVoiceSettingsApplyChannel.ts packages/ui/src/voice/useVoiceSettingsApplyChannel.test.tsx plugins/plugin-app-control/src/actions/settings.ts plugins/plugin-app-control/src/actions/settings.test.ts
Checked 9 files. No fixes applied.

$ bun run --cwd plugins/plugin-app-control typecheck
$ bun run --cwd packages/shared typecheck
$ git diff --check origin/develop...HEAD
$ bun run audit:error-policy-ratchet --report
[error-policy-ratchet] no new fallback-slop in touched files
```

`packages/ui typecheck` still has unrelated baseline failures outside this PR's files; the new channel and mounted-shell coverage are covered by the focused Vitest run above.

Closes #14910
