### PR TITLE
fix(plugin-elizacloud): sanitize orphaned tool messages in native /chat/completions

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/unit/text-native-message-sanitize.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/text-native-message-sanitize.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Offline unit coverage for the native `/chat/completions` message sanitizer
+ * (`buildNativeMessages` → `sanitizeNativeMessages` in `src/models/text.ts`).
+ *
+ * The Cloud gateway strictly enforces OpenAI tool-call linkage: a `role:"tool"`
+ * message is rejected with a whole-request 400 (`invalid_request_error`) unless a
+ * directly-preceding assistant message declared the matching id in its
+ * `tool_calls`, and an unanswered assistant `tool_calls` 500s "Tool result is
+ * missing". Runtime-rendered history routinely carries bare tool-result messages
+ * (no `tool_call_id`, no preceding assistant `tool_calls`) — the live cause of
+ * the 400 that broke every tool-using turn. The sanitizer must downgrade unpaired
+ * tool messages to `user` and strip unanswered assistant `tool_calls`, while
+ * leaving well-formed pairs untouched. The fetch is mocked to capture the
+ * outgoing `messages` array (same technique as
+ * `text-cerebras-response-format.test.ts`).
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { generateNativeChatCompletion } from "../../src/models/text";
+
+type RuntimeFixture = Pick<IAgentRuntime, "character" | "emitEvent" | "getSetting"> &
+  Partial<IAgentRuntime>;
+
+function runtime(): IAgentRuntime {
+  const settings: Record<string, string | undefined> = {
+    ELIZAOS_CLOUD_API_KEY: "eliza_test_key",
+  };
+  const fixture: RuntimeFixture = {
+    character: { name: "Eliza", bio: [] },
+    getSetting: (key: string) => settings[key],
+    emitEvent: vi.fn(),
+  };
+  return fixture as IAgentRuntime;
+}
+
+function cannedResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      choices: [{ message: { content: "ok" }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } }
+  );
+}
+
+async function captureMessages(
+  messages: Array<Record<string, unknown>>
+): Promise<Array<Record<string, unknown>>> {
+  let captured: Array<Record<string, unknown>> = [];
+  vi.spyOn(globalThis, "fetch").mockImplementation(
+    async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (typeof init?.body === "string") {
+        const body = JSON.parse(init.body) as { messages?: Array<Record<string, unknown>> };
+        captured = body.messages ?? [];
+      }
+      return cannedResponse();
+    }
+  );
+
+  await generateNativeChatCompletion(runtime(), "TEXT_SMALL", { prompt: "hi", messages } as never, {
+    modelName: "zai-glm-4.7",
+    prompt: "hi",
+  });
+
+  return captured;
+}
+
+describe("native /chat/completions message sanitizer (offline)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("downgrades an orphaned tool message (no preceding assistant tool_calls) to a user message", async () => {
+    const out = await captureMessages([
+      { role: "system", content: "sys" },
+      { role: "user", content: "what's the weather?" },
+      { role: "assistant", content: "let me check" },
+      { role: "tool", content: "sunny, 24C" },
+    ]);
+
+    const last = out[out.length - 1];
+    expect(last.role).toBe("user");
+    expect(last.tool_call_id).toBeUndefined();
+    expect(last.content).toBe("[tool result] sunny, 24C");
+    // No stray tool-role message survives to trip the gateway.
+    expect(out.some((m) => m.role === "tool")).toBe(false);
+  });
+
+  it("downgrades a tool message whose tool_call_id has no matching assistant tool_call", async () => {
+    const out = await captureMessages([
+      { role: "user", content: "weather?" },
+      { role: "assistant", content: "checking" },
+      { role: "tool", tool_call_id: "call_x", content: "sunny" },
+    ]);
+
+    const last = out[out.length - 1];
+    expect(last.role).toBe("user");
+    expect(last.tool_call_id).toBeUndefined();
+    expect(last.content).toBe("[tool result] sunny");
+  });
+
+  it("preserves a well-formed assistant tool_calls -> tool pair untouched", async () => {
+    const assistant = {
+      role: "assistant",
+      content: null,
+      tool_calls: [{ id: "call_1", type: "function", function: { name: "getW", arguments: "{}" } }],
+    };
+    const out = await captureMessages([
+      { role: "user", content: "weather?" },
+      assistant,
+      { role: "tool", tool_call_id: "call_1", content: "sunny" },
+    ]);
+
+    const asst = out.find((m) => m.role === "assistant");
+    expect(asst?.tool_calls).toEqual(assistant.tool_calls);
+    const tool = out.find((m) => m.role === "tool");
+    expect(tool).toBeDefined();
+    expect(tool?.tool_call_id).toBe("call_1");
+  });
+
+  it("strips tool_calls from an assistant message whose calls go unanswered", async () => {
+    const out = await captureMessages([
+      { role: "user", content: "weather?" },
+      {
+        role: "assistant",
+        content: "on it",
+        tool_calls: [
+          { id: "call_1", type: "function", function: { name: "getW", arguments: "{}" } },
+        ],
+      },
+      { role: "user", content: "still there?" },
+    ]);
+
+    const asst = out.find((m) => m.content === "on it");
+    expect(asst?.role).toBe("assistant");
+    expect(asst?.tool_calls).toBeUndefined();
+  });
+
+  it("downgrades matched tool messages too when an assistant is only partially answered", async () => {
+    const out = await captureMessages([
+      { role: "user", content: "weather and stocks?" },
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          { id: "call_weather", type: "function", function: { name: "getW", arguments: "{}" } },
+          { id: "call_stock", type: "function", function: { name: "getS", arguments: "{}" } },
+        ],
+      },
+      { role: "tool", tool_call_id: "call_weather", content: "sunny" },
+      { role: "user", content: "continue" },
+    ]);
+
+    const asst = out.find((m) => m.role === "assistant");
+    expect(asst?.tool_calls).toBeUndefined();
+    const downgraded = out.find((m) => m.content === "[tool result] sunny");
+    expect(downgraded?.role).toBe("user");
+    expect(downgraded?.tool_call_id).toBeUndefined();
+    expect(out.some((m) => m.role === "tool")).toBe(false);
+  });
+});

--- a/plugins/plugin-elizacloud/__tests__/unit/text-native-message-sanitize.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/text-native-message-sanitize.test.ts
@@ -163,4 +163,29 @@ describe("native /chat/completions message sanitizer (offline)", () => {
     expect(downgraded?.tool_call_id).toBeUndefined();
     expect(out.some((m) => m.role === "tool")).toBe(false);
   });
+
+  it("downgrades the whole tool block when an orphan interrupts pending assistant calls", async () => {
+    const out = await captureMessages([
+      { role: "user", content: "weather and stocks?" },
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          { id: "call_weather", type: "function", function: { name: "getW", arguments: "{}" } },
+          { id: "call_stock", type: "function", function: { name: "getS", arguments: "{}" } },
+        ],
+      },
+      { role: "tool", tool_call_id: "call_other", content: "orphan" },
+      { role: "tool", tool_call_id: "call_weather", content: "sunny" },
+      { role: "tool", tool_call_id: "call_stock", content: "42" },
+    ]);
+
+    const asst = out.find((m) => m.role === "assistant");
+    expect(asst?.tool_calls).toBeUndefined();
+    expect(asst?.content).toBe("");
+    expect(out.some((m) => m.role === "tool")).toBe(false);
+    expect(out.map((m) => m.content)).toContain("[tool result] orphan");
+    expect(out.map((m) => m.content)).toContain("[tool result] sunny");
+    expect(out.map((m) => m.content)).toContain("[tool result] 42");
+  });
 });

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -447,6 +447,84 @@ function shouldReturnNativeResult(params: GenerateTextParamsWithNativeOptions): 
   return Boolean(params.messages || params.tools || params.toolChoice || params.responseSchema);
 }
 
+function toolCallIds(toolCalls: unknown): string[] {
+  if (!Array.isArray(toolCalls)) {
+    return [];
+  }
+  const ids: string[] = [];
+  for (const call of toolCalls) {
+    const id = firstString(asRecord(call).id);
+    if (id) {
+      ids.push(id);
+    }
+  }
+  return ids;
+}
+
+// The native `/chat/completions` gateway strictly enforces OpenAI tool-call
+// linkage: a `role:"tool"` message is only valid when a directly-preceding
+// assistant message declared a matching id in its `tool_calls`, and an
+// assistant `tool_calls` entry is only valid when a later tool message answers
+// it. Runtime-rendered history routinely violates both — a prior turn's tool
+// result surfaces as a bare `role:"tool"` message with no `tool_call_id` and no
+// assistant `tool_calls` before it — and the gateway 400s the WHOLE request on
+// that (`invalid_request_error`), breaking every tool-using turn. Reconstructing
+// the original `tool_calls` isn't possible from rendered history, so make the
+// array spec-valid instead: downgrade every unpaired tool message to a plain
+// `role:"user"` message (verified 200 against the gateway) with a `[tool result]`
+// marker so its content survives, and strip `tool_calls` from any assistant
+// message whose calls go unanswered (which would otherwise 500 "Tool result is
+// missing"). Well-formed assistant→tool pairs pass through untouched.
+function sanitizeNativeMessages(
+  messages: Array<Record<string, unknown>>
+): Array<Record<string, unknown>> {
+  const result = messages.map((message) => ({ ...message }));
+  let openAssistant: Record<string, unknown> | null = null;
+  let matchedToolMessages: Array<Record<string, unknown>> = [];
+  let pending = new Set<string>();
+  const downgradeToolMessage = (message: Record<string, unknown>): void => {
+    delete message.tool_call_id;
+    message.role = "user";
+    message.content = `[tool result] ${stringifyMessageContent(message.content)}`;
+  };
+  const finalizeOpenAssistant = (): void => {
+    if (openAssistant && pending.size > 0) {
+      delete openAssistant.tool_calls;
+      if (openAssistant.content == null) {
+        openAssistant.content = "";
+      }
+      for (const toolMessage of matchedToolMessages) {
+        downgradeToolMessage(toolMessage);
+      }
+    }
+    openAssistant = null;
+    matchedToolMessages = [];
+    pending = new Set();
+  };
+  for (const message of result) {
+    if (message.role === "tool") {
+      const id = firstString(message.tool_call_id);
+      if (id && pending.has(id)) {
+        pending.delete(id);
+        matchedToolMessages.push(message);
+      } else {
+        downgradeToolMessage(message);
+      }
+      continue;
+    }
+    finalizeOpenAssistant();
+    if (message.role === "assistant") {
+      const ids = toolCallIds(message.tool_calls);
+      if (ids.length > 0) {
+        openAssistant = message;
+        pending = new Set(ids);
+      }
+    }
+  }
+  finalizeOpenAssistant();
+  return result;
+}
+
 function buildNativeMessages(
   params: GenerateTextParamsWithNativeOptions,
   promptText: string,
@@ -459,10 +537,11 @@ function buildNativeMessages(
         : { role: "user", content: stringifyMessageContent(message) }
     );
     const first = asRecord(messages[0]);
-    if (systemPrompt && first.role !== "system") {
-      return [{ role: "system", content: systemPrompt }, ...messages];
-    }
-    return messages;
+    const withSystem =
+      systemPrompt && first.role !== "system"
+        ? [{ role: "system", content: systemPrompt }, ...messages]
+        : messages;
+    return sanitizeNativeMessages(withSystem);
   }
 
   const messages: Array<Record<string, unknown>> = [];

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -508,6 +508,9 @@ function sanitizeNativeMessages(
         pending.delete(id);
         matchedToolMessages.push(message);
       } else {
+        if (openAssistant && pending.size > 0) {
+          finalizeOpenAssistant();
+        }
         downgradeToolMessage(message);
       }
       continue;


### PR DESCRIPTION
## Problem

The Cloud native `/chat/completions` gateway strictly enforces OpenAI tool-call linkage:

- an `assistant.tool_calls[id]` paired with a later `tool.tool_call_id` of the same id → **200**
- an orphaned `role:"tool"` message (no matching preceding `assistant.tool_calls`) → **400 `invalid_request_error`** on the *whole* request
- an unanswered `assistant.tool_calls` → **500 "Tool result is missing"**

`buildNativeMessages()` in `src/models/text.ts` builds the wire `messages` array directly from the runtime-rendered history. That history routinely carries **bare tool-result messages** — `role:"tool"` with no `tool_call_id`, preceded by an assistant with no `tool_calls`. So the gateway 400'd, and the user got "Something went wrong" on **every tool-using turn** (web search, live-info price/weather lookups, sub-agent spawns).

### 400 evidence

Gateway probes + request instrumentation on the live bot confirmed the linkage rule: a well-formed `assistant.tool_calls` + `tool.tool_call_id` pair returns 200, while an orphaned `role:"tool"` message returns `400 invalid_request_error`. The orphaned shape is exactly what rendered history produces, so tool turns 400'd deterministically.

## Fix

A `sanitizeNativeMessages()` helper, wired into `buildNativeMessages()`, makes the array spec-valid without inventing `tool_calls` that can't be reconstructed from rendered history:

- **downgrade every unpaired `role:"tool"` message** to `role:"user"` with a `[tool result] ` prefix (content preserved, verified 200 against the gateway)
- **strip `tool_calls` from any assistant** whose calls go unanswered (would otherwise 500)
- **leave well-formed `assistant.tool_calls → tool` pairs untouched**

## Verification

- `bun run --cwd plugins/plugin-elizacloud typecheck` — clean
- `bun run --cwd plugins/plugin-elizacloud test` — **328 passed / 3 skipped / 0 failed** (incl. the new 4-case suite)
- `biome lint` on the touched files — clean (the sole warning is a pre-existing `noAssignInExpressions` in untouched streaming code)
- New offline unit suite `__tests__/unit/text-native-message-sanitize.test.ts` (fetch mocked, outgoing `messages` captured): orphaned tool → user; mismatched `tool_call_id` → user; well-formed pair untouched; unanswered assistant `tool_calls` stripped; content preserved.

### Live-verified on a running agent

- `who is the ceo of openai?` → **"Sam Altman is the CEO of OpenAI."** (trajectory status `finished`, 0 Bad Requests)
- `hi` → normal greeting (no regression on non-tool turns)

## Companion

This is the second half of the Cloud-400 fix for tool turns. The first half — omitting `response_format` for the gateway's served models (`buildNativeResponseFormat → undefined`) — landed via **#14999** and is already on `develop`; this PR does not touch it.
