### PR TITLE
fix(agent): report interaction telemetry emit failures

### DIFF
--- a/packages/agent/src/api/interactions-routes.test.ts
+++ b/packages/agent/src/api/interactions-routes.test.ts
@@ -26,6 +26,7 @@ function makeCtx(
 ): {
   ctx: InteractionsRouteContext;
   emitEvent: ReturnType<typeof vi.fn>;
+  reportError: ReturnType<typeof vi.fn>;
   json: ReturnType<typeof vi.fn>;
   error: ReturnType<typeof vi.fn>;
 } {
@@ -33,6 +34,7 @@ function makeCtx(
     body === undefined ? [] : [Buffer.from(JSON.stringify(body))],
   ) as unknown as http.IncomingMessage;
   const emitEvent = vi.fn(async () => {});
+  const reportError = vi.fn();
   const json = vi.fn();
   const error = vi.fn();
   const ctx: InteractionsRouteContext = {
@@ -44,10 +46,11 @@ function makeCtx(
     error,
     runtime: {
       emitEvent,
+      reportError,
       logger: { debug: vi.fn() },
     } as unknown as AgentRuntime,
   };
-  return { ctx, emitEvent, json, error };
+  return { ctx, emitEvent, reportError, json, error };
 }
 
 function shortcutCalls(emitEvent: ReturnType<typeof vi.fn>) {
@@ -218,6 +221,28 @@ describe("handleInteractionsRoutes — SHORTCUT_FIRED (#8792)", () => {
       expect.objectContaining({ ok: true }),
     );
   });
+
+  it("surfaces shortcut emit failures without failing the route", async () => {
+    const { ctx, emitEvent, reportError, json } = makeCtx({
+      shortcutId: "show-keyboard-shortcuts",
+    });
+    const failure = new Error("event bus down");
+    emitEvent.mockRejectedValueOnce(failure);
+
+    await expect(handleInteractionsRoutes(ctx)).resolves.toBe(true);
+
+    expect(json).toHaveBeenCalledWith(
+      ctx.res,
+      expect.objectContaining({ ok: true }),
+    );
+    await vi.waitFor(() =>
+      expect(reportError).toHaveBeenCalledWith(
+        "InteractionsRoutes.shortcutFired",
+        failure,
+        { shortcutId: "show-keyboard-shortcuts" },
+      ),
+    );
+  });
 });
 
 describe("handleInteractionsRoutes — composer lifecycle (#14679)", () => {
@@ -321,5 +346,37 @@ describe("handleInteractionsRoutes — composer lifecycle (#14679)", () => {
     await expect(handleInteractionsRoutes(ctx)).resolves.toBe(true);
     expect(composerCalls(emitEvent)).toHaveLength(0);
     expect(error).toHaveBeenCalledWith(ctx.res, expect.any(String), 400);
+  });
+
+  it("surfaces composer emit failures without failing the route", async () => {
+    const { ctx, emitEvent, reportError, json } = makeCtx(
+      {
+        activity: "typing_started",
+        surface: "continuous_chat_overlay",
+        draftLength: 5,
+        occurredAt: "2026-06-01T12:00:00.000Z",
+      },
+      "POST",
+      "/api/interactions/composer",
+    );
+    const failure = new Error("event bus down");
+    emitEvent.mockRejectedValueOnce(failure);
+
+    await expect(handleInteractionsRoutes(ctx)).resolves.toBe(true);
+
+    expect(json).toHaveBeenCalledWith(
+      ctx.res,
+      expect.objectContaining({ ok: true, activity: "typing_started" }),
+    );
+    await vi.waitFor(() =>
+      expect(reportError).toHaveBeenCalledWith(
+        "InteractionsRoutes.composerActivity",
+        failure,
+        {
+          activity: "typing_started",
+          surface: "continuous_chat_overlay",
+        },
+      ),
+    );
   });
 });

--- a/packages/agent/src/api/interactions-routes.ts
+++ b/packages/agent/src/api/interactions-routes.ts
@@ -215,11 +215,12 @@ export async function handleInteractionsRoutes(
           initiatedBy: "user",
         })
         .catch((err) => {
-          // error-policy:J7 telemetry emission must not break the interaction route.
-          runtime.logger?.debug?.(
-            { src: "InteractionsRoutes", err },
-            "[InteractionsRoutes] composer activity emit failed",
-          );
+          // error-policy:J7 telemetry emission must not break the interaction
+          // route, but a broken event bus must reach RECENT_ERRORS.
+          runtime.reportError("InteractionsRoutes.composerActivity", err, {
+            activity: request.activity,
+            surface: request.surface,
+          });
         });
     }
 
@@ -245,11 +246,11 @@ export async function handleInteractionsRoutes(
         initiatedBy: "user",
       })
       .catch((err) => {
-        // error-policy:J7 telemetry emission must not break the interaction route.
-        runtime.logger?.debug?.(
-          { src: "InteractionsRoutes", err },
-          "[InteractionsRoutes] SHORTCUT_FIRED emit failed",
-        );
+        // error-policy:J7 telemetry emission must not break the interaction
+        // route, but a broken event bus must reach RECENT_ERRORS.
+        runtime.reportError("InteractionsRoutes.shortcutFired", err, {
+          shortcutId: request.shortcutId,
+        });
       });
   }
 

--- a/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts
@@ -113,7 +113,7 @@ describe("PresenceSignalBridgeService relationship recency", () => {
     });
   });
 
-  it("registers message, reaction, view, and action presence handlers", async () => {
+  it("registers message, reaction, view, action, and composer presence handlers", async () => {
     const { runtime, handlers } = runtimeWithRelationships(null);
     await PresenceSignalBridgeService.start(runtime);
 


### PR DESCRIPTION
## Summary

Follow-up from reviewing #14987 after it merged.

- Routes `/api/interactions/shortcut` and `/api/interactions/composer` still return success for best-effort telemetry, but failed `runtime.emitEvent` promises now call `runtime.reportError` instead of debug-only logging.
- Adds failure-path tests proving shortcut/composer emit failures are surfaced while the route response remains `{ ok: true }`.
- Updates the LifeOps presence registration test title to reflect the composer handlers already present on `develop`.

## Verification

- `bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/api/interactions-routes.test.ts` - pass, 16 tests.
- `bunx vitest run --config vitest.config.ts src/activity-profile/presence-signal-bridge-service.test.ts` from `plugins/plugin-personal-assistant` - pass, 19 tests.
- `bunx biome check packages/agent/src/api/interactions-routes.ts packages/agent/src/api/interactions-routes.test.ts plugins/plugin-personal-assistant/src/activity-profile/presence-signal-bridge-service.test.ts` - pass.
- `git diff --check --cached` before commit - pass.
- `bun run audit:error-policy-ratchet --report` after commit - pass; 1 changed production source file, no new fallback slop.

## Evidence

<!-- evidence-row:before-screenshots --> N/A - backend API telemetry failure handling only; no rendered UI changed.
<!-- evidence-row:after-screenshots --> N/A - backend API telemetry failure handling only; no rendered UI changed.
<!-- evidence-row:walkthrough-video --> N/A - no interactive UI flow changed.
<!-- evidence-row:backend-logs --> N/A - focused route tests assert the backend failure path and `runtime.reportError` call directly.
<!-- evidence-row:frontend-logs --> N/A - no browser/client behavior changed.
<!-- evidence-row:llm-trajectory --> N/A - no model, prompt, planner, or action behavior changed.
<!-- evidence-row:domain-artifacts --> N/A - no persistent domain artifact is produced; the change surfaces telemetry emit failures to runtime diagnostics.