### PR TITLE
test(#14371): bidirectional voice e2e — real audio round-trip on web + local paths incl. failure modes

### DIFF
--- a/packages/app/test/ui-smoke/voice-realaudio.spec.ts
+++ b/packages/app/test/ui-smoke/voice-realaudio.spec.ts
@@ -9,6 +9,16 @@
  * The ASR/agent/TTS BACKENDS are mocked (not provisioned in CI); the AUDIO IN
  * and every client step are real. No human, no microphone.
  *
+ * The trailing `test.describe` block (#14371) adds the failure-path coverage a
+ * real user hits — mic-permission denied, silence/empty capture, and a TTS
+ * fetch dropped mid-stream — asserting a distinguishable error/degrade render
+ * (three-state rule, never healthy-empty) in the same keyless fake-mic lane, plus
+ * an opt-in LIVE web round-trip (gated on ELIZA_VOICE_LIVE_RAILWAY=1) that drops
+ * every mock and drives the real cloud STT proxy (`/api/asr/cloud` → Railway
+ * Whisper) → live agent → cloud Kokoro TTS (`/api/tts/cloud`), asserting a
+ * transcript match and decoded NON-silent audio out. The live variant SKIPS
+ * (never green) when ungated; the failure paths always run.
+ *
  *   bun run --cwd packages/app test:e2e test/ui-smoke/voice-realaudio.spec.ts
  */
 import { expect, type Page, test } from "@playwright/test";
@@ -573,4 +583,395 @@ test("REAL audio: transcription start during spoken local TTS barges in and sile
     })
     .toBeGreaterThanOrEqual(2);
   expect(Math.min(...asrPosts)).toBeGreaterThan(1000);
+});
+
+// Failure paths the mocked front-door tests above never exercise (#14371). Each
+// runs in the SAME keyless fake-mic Chromium lane and asserts a distinguishable
+// error/degrade render — the three-state rule forbids a failure that reads as a
+// healthy empty result (a silent no-op mic, a phantom send, a hung player).
+const CLOUD_CONVERSATION_ID = "voice-live-convo";
+
+function appConfigWithCloudVoice(): Record<string, unknown> {
+  const base = appConfigWithLocalVoice() as {
+    messages: { tts: { provider: string; asr: { provider: string } } };
+  };
+  // Web/cloud default: Eliza Cloud Kokoro TTS (`/api/tts/cloud`) + Eliza Cloud
+  // ASR, whose interactive web capture records a WAV and POSTs it to the cloud
+  // STT proxy (`/api/asr/cloud` → Railway Whisper). See voice-provider-defaults.
+  base.messages.tts.provider = "eliza-cloud";
+  base.messages.tts.asr.provider = "eliza-cloud";
+  return base;
+}
+
+async function installCloudVoiceConfig(page: Page): Promise<void> {
+  await page.unroute("**/api/status").catch(() => {});
+  await page.route("**/api/status**", async (route) => {
+    if (route.request().method() !== "GET") return route.fallback();
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        state: "running",
+        agentName: "Playwright Smoke",
+        model: "ui-smoke",
+        canRespond: true,
+        startedAt: Date.now() - 60_000,
+        uptime: 60_000,
+      }),
+    });
+  });
+  await page.unroute("**/api/config").catch(() => {});
+  await page.route("**/api/config", async (route) => {
+    if (!["GET", "PATCH", "PUT"].includes(route.request().method())) {
+      return route.fallback();
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(appConfigWithCloudVoice()),
+    });
+  });
+}
+
+/** Count POSTs to a client route (ignoring the `/status` probe siblings). */
+function countPosts(page: Page, needle: string): { get: () => number } {
+  let n = 0;
+  page.on("request", (req) => {
+    if (
+      req.method() === "POST" &&
+      req.url().includes(needle) &&
+      !req.url().includes("/status")
+    ) {
+      n += 1;
+    }
+  });
+  return { get: () => n };
+}
+
+/** Parse a WAV buffer and report duration + whether any sample is non-silent. */
+function inspectWav(bytes: Buffer): {
+  isWav: boolean;
+  durationMs: number;
+  peak: number;
+} {
+  if (bytes.length < 44 || bytes.toString("ascii", 0, 4) !== "RIFF") {
+    return { isWav: false, durationMs: 0, peak: 0 };
+  }
+  const sampleRate = bytes.readUInt32LE(24);
+  const channels = bytes.readUInt16LE(22) || 1;
+  const bitsPerSample = bytes.readUInt16LE(34) || 16;
+  const bytesPerSample = bitsPerSample / 8;
+  let dataOffset = 12;
+  let dataLen = 0;
+  while (dataOffset + 8 <= bytes.length) {
+    const id = bytes.toString("ascii", dataOffset, dataOffset + 4);
+    const size = bytes.readUInt32LE(dataOffset + 4);
+    if (id === "data") {
+      dataOffset += 8;
+      dataLen = Math.min(size, bytes.length - dataOffset);
+      break;
+    }
+    dataOffset += 8 + size;
+  }
+  let peak = 0;
+  if (bitsPerSample === 16) {
+    for (let i = dataOffset; i + 1 < dataOffset + dataLen; i += 2) {
+      peak = Math.max(peak, Math.abs(bytes.readInt16LE(i)));
+    }
+  }
+  const frames = dataLen / (bytesPerSample * channels);
+  return {
+    isWav: true,
+    durationMs: sampleRate ? Math.round((frames / sampleRate) * 1000) : 0,
+    peak,
+  };
+}
+
+test.describe("voice failure paths (keyless)", () => {
+  test("mic permission denied surfaces a distinguishable error and starts NO phantom capture", async ({
+    page,
+  }) => {
+    await installLocalVoiceConfig(page);
+    // Deny the device before any app script runs: the real capture path calls
+    // navigator.mediaDevices.getUserMedia, so a rejected promise here drives the
+    // genuine NotAllowedError client path (the fake-audio device would otherwise
+    // grant the mic in this lane).
+    await page.addInitScript(() => {
+      const md = navigator.mediaDevices;
+      if (md) {
+        md.getUserMedia = () =>
+          Promise.reject(
+            new DOMException("Permission denied", "NotAllowedError"),
+          );
+      }
+    });
+    const asrPosts = countPosts(page, "/api/asr/local-inference");
+
+    await openAppPath(page, "/chat");
+    await expect(page.getByTestId("continuous-chat-overlay")).toBeVisible({
+      timeout: 30_000,
+    });
+    const mic = page.getByTestId("chat-composer-mic");
+    await expect(mic).toHaveAttribute("aria-label", "talk", {
+      timeout: 15_000,
+    });
+
+    await mic.click();
+
+    // The denial must render a visible, error-toned notice — not a silent mic.
+    const notice = page.getByTestId("shell-action-notice");
+    await expect(notice).toBeVisible({ timeout: 15_000 });
+    await expect(notice).toHaveAttribute("data-tone", "error");
+    await expect(notice).toContainText("Microphone access was denied");
+
+    // No phantom capture: the mic must roll back to its resting "talk" label
+    // (not stay lit as an "end conversation" the device never opened) and no
+    // WAV may reach ASR because recording never started.
+    await expect(mic).toHaveAttribute("aria-label", "talk", {
+      timeout: 15_000,
+    });
+    await page.waitForTimeout(1500);
+    expect(asrPosts.get(), "a denied mic must POST no captured audio").toBe(0);
+  });
+
+  test("silent/empty capture sends NO message and returns to rest (no phantom send)", async ({
+    page,
+  }) => {
+    await installLocalVoiceConfig(page);
+    // Silence transcribes to an empty string; the local-inference transcribe
+    // helper treats that as a typed-invalid result and throws, so the turn must
+    // be dropped — never sent as an empty user message. Override the phrase-echo
+    // mock to return the empty transcript a silent clip produces.
+    await page.unroute("**/api/asr/local-inference").catch(() => {});
+    await page.route("**/api/asr/local-inference", async (route) => {
+      if (route.request().method() !== "POST") return route.fallback();
+      const bytes = route.request().postDataBuffer()?.byteLength ?? 0;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ text: "", capturedBytes: bytes }),
+      });
+    });
+    const streamPosts = countPosts(
+      page,
+      `/api/conversations/${CHAT_CONVERSATION_ID}/messages/stream`,
+    );
+
+    await openAppPath(page, "/chat");
+    await expect(page.getByTestId("continuous-chat-overlay")).toBeVisible({
+      timeout: 30_000,
+    });
+    const mic = page.getByTestId("chat-composer-mic");
+    await expect(mic).toHaveAttribute("aria-label", "talk", {
+      timeout: 15_000,
+    });
+
+    // Drive a real fake-device converse turn that transcribes to nothing.
+    await mic.click();
+    await expect(mic).toHaveAttribute("aria-label", "end conversation", {
+      timeout: 15_000,
+    });
+    await page.waitForTimeout(2000);
+    await mic.click();
+    await expect(mic).toHaveAttribute("aria-label", "talk", {
+      timeout: 15_000,
+    });
+
+    // An empty transcription may never become a sent turn, and no user bubble
+    // may appear for the silence.
+    await page.waitForTimeout(1500);
+    expect(
+      streamPosts.get(),
+      "a silent/empty turn must not POST a message",
+    ).toBe(0);
+    await expect(
+      page.locator('[data-testid^="chat-message-user"]'),
+    ).toHaveCount(0);
+  });
+
+  test("TTS dropped mid-stream fails closed (no hung playback) and the next turn still speaks", async ({
+    page,
+  }) => {
+    await installLocalVoiceConfig(page);
+    await installAudioSourceProbe(page);
+
+    // Turn 1 drops the TTS connection; turn 2 restores it. A dropped fetch is a
+    // real network error (not a user-cancel AbortError), so it must fail closed
+    // — the queue drains, speaking clears, and nothing keeps playing.
+    let dropTts = true;
+    let ttsAttempts = 0;
+    for (const r of ["**/api/tts/cloud", "**/api/tts/local-inference"]) {
+      await page.unroute(r).catch(() => {});
+      await page.route(r, async (route) => {
+        if (route.request().method() !== "POST") return route.fallback();
+        ttsAttempts += 1;
+        if (dropTts) return route.abort("connectionaborted");
+        await route.fulfill({
+          status: 200,
+          headers: { "content-type": "audio/wav" },
+          body: tinyWav(8),
+        });
+      });
+    }
+
+    await openAppPath(page, "/chat");
+    await expect(page.getByTestId("continuous-chat-overlay")).toBeVisible({
+      timeout: 30_000,
+    });
+    const mic = page.getByTestId("chat-composer-mic");
+    await expect(mic).toHaveAttribute("aria-label", "talk", {
+      timeout: 15_000,
+    });
+
+    // Turn 1: a voice-originated reply is spoken, but its TTS fetch is dropped.
+    await mic.click();
+    await expect(mic).toHaveAttribute("aria-label", "end conversation", {
+      timeout: 15_000,
+    });
+    await page.waitForTimeout(1500);
+    await mic.click();
+    await expect(mic).toHaveAttribute("aria-label", "talk", {
+      timeout: 15_000,
+    });
+
+    await expect
+      .poll(() => ttsAttempts, {
+        timeout: 25_000,
+        message: "the spoken reply must attempt a TTS fetch",
+      })
+      .toBeGreaterThanOrEqual(1);
+    // The dropped fetch must not have produced hung playback: no Web Audio
+    // source ever started for the failed turn.
+    await page.waitForTimeout(1500);
+    const afterDrop = await readAudioProbe(page);
+    expect(
+      afterDrop.starts,
+      "a dropped TTS fetch must not start audio playback",
+    ).toBe(0);
+
+    // Turn 2: TTS restored — the pipeline must recover and actually speak.
+    dropTts = false;
+    await mic.click();
+    await expect(mic).toHaveAttribute("aria-label", "end conversation", {
+      timeout: 15_000,
+    });
+    await page.waitForTimeout(1500);
+    await mic.click();
+
+    await expect
+      .poll(async () => (await readAudioProbe(page)).starts, {
+        timeout: 25_000,
+        message: "after a TTS failure the next turn must resume playback",
+      })
+      .toBeGreaterThan(0);
+  });
+});
+
+// Opt-in LIVE web round-trip against the REAL cloud voice pipeline (#14371).
+// Gated on ELIZA_VOICE_LIVE_RAILWAY=1 with reachable Railway STT/TTS + a live
+// LLM key; it drops every backend mock so the injected known-phrase WAV flows
+// mic → cloud STT proxy (`/api/asr/cloud` → Whisper) → live agent → cloud Kokoro
+// TTS (`/api/tts/cloud`) → decoded, non-silent audio out. SKIPPED (never green)
+// when ungated so an unprovisioned lane can never masquerade as passing.
+const LIVE_RAILWAY = process.env.ELIZA_VOICE_LIVE_RAILWAY === "1";
+
+test.describe("live cloud voice round-trip (Railway path)", () => {
+  test.skip(
+    !LIVE_RAILWAY,
+    "set ELIZA_VOICE_LIVE_RAILWAY=1 with reachable Railway STT/TTS + a live LLM key",
+  );
+
+  test("injected known-phrase WAV round-trips through real cloud STT → agent → cloud TTS", async ({
+    page,
+  }) => {
+    await installCloudVoiceConfig(page);
+    await installAudioSourceProbe(page);
+
+    // Drop the mocks the shared beforeEach installed so these reach the live
+    // stack (which proxies to the real cloud STT/TTS + runs a live agent turn).
+    for (const r of [
+      "**/api/asr/cloud",
+      "**/api/tts/cloud",
+      "**/api/conversations",
+      `**/api/conversations/${CLOUD_CONVERSATION_ID}/messages/stream`,
+      `**/api/conversations/${CHAT_CONVERSATION_ID}/messages/stream`,
+    ]) {
+      await page.unroute(r).catch(() => {});
+    }
+
+    let asrTranscript = "";
+    let ttsBytes = 0;
+    let ttsContentType = "";
+    let ttsAudio: Buffer | null = null;
+    page.on("response", async (res) => {
+      const url = res.url();
+      if (url.includes("/api/asr/cloud") && res.ok()) {
+        // error-policy:J6 diagnostic capture — a failed body read must not mask
+        // the assertion below, which fails loudly on an empty transcript.
+        const json = (await res.json().catch(() => null)) as {
+          text?: unknown;
+        } | null;
+        if (typeof json?.text === "string") asrTranscript = json.text;
+      }
+      if (url.includes("/api/tts/cloud") && res.ok()) {
+        ttsContentType = res.headers()["content-type"] ?? "";
+        const body = await res.body().catch(() => Buffer.alloc(0));
+        ttsBytes = body.byteLength;
+        ttsAudio = body;
+      }
+    });
+
+    await openAppPath(page, "/chat");
+    await expect(page.getByTestId("continuous-chat-overlay")).toBeVisible({
+      timeout: 30_000,
+    });
+    const mic = page.getByTestId("chat-composer-mic");
+    await expect(mic).toHaveAttribute("aria-label", "talk", {
+      timeout: 15_000,
+    });
+
+    await mic.click();
+    await expect(mic).toHaveAttribute("aria-label", "end conversation", {
+      timeout: 15_000,
+    });
+    await page.waitForTimeout(2500);
+    await mic.click();
+
+    // Real cloud STT returned the injected phrase (the fixture speaks it).
+    await expect
+      .poll(() => asrTranscript.toLowerCase(), {
+        timeout: 60_000,
+        message: "cloud STT must transcribe the injected known phrase",
+      })
+      .toContain("time");
+
+    // Real cloud TTS returned decoded, non-silent audio that actually played.
+    await expect
+      .poll(() => ttsBytes, {
+        timeout: 60_000,
+        message: "cloud TTS must return a non-trivial audio body",
+      })
+      .toBeGreaterThan(2000);
+    expect(ttsContentType).toContain("audio");
+    await expect
+      .poll(async () => (await readAudioProbe(page)).starts, {
+        timeout: 30_000,
+        message: "the decoded cloud TTS audio must start real playback",
+      })
+      .toBeGreaterThan(0);
+
+    // Report the real audio characteristics for the PR evidence log.
+    if (ttsAudio) {
+      const wav = inspectWav(ttsAudio);
+      console.log(
+        `[voice-live] STT="${asrTranscript}" TTS bytes=${ttsBytes} ` +
+          `type=${ttsContentType} wav=${wav.isWav} durationMs=${wav.durationMs} peak=${wav.peak}`,
+      );
+      if (wav.isWav) {
+        expect(wav.peak, "cloud TTS audio must be non-silent").toBeGreaterThan(
+          32,
+        );
+      }
+    }
+  });
 });

--- a/packages/scripts/voice-matrix.mjs
+++ b/packages/scripts/voice-matrix.mjs
@@ -48,7 +48,7 @@ const CELLS = [
   {
     id: "web.fake-mic.roundtrip",
     title:
-      "Web fake-device mic capture -> ASR -> agent -> local TTS + barge-in",
+      "Web fake-device mic capture -> ASR -> agent -> local TTS + barge-in + failure paths (mic-denied / silent / TTS-drop)",
     platform: "web",
     dimensions: {
       transcriptionState: "off",
@@ -69,6 +69,35 @@ const CELLS = [
     env: UI_SMOKE_MATRIX_ENV,
     evidence: ["packages/app/test-results", "e2e-recordings/app/test-results"],
     probe: "web",
+  },
+  {
+    // Opt-in LIVE web round-trip against the real Railway STT/TTS + a live agent
+    // (#14371). Same spec file, but the live `test.describe` only runs (never
+    // skips-as-pass) when ELIZA_VOICE_LIVE_RAILWAY=1; the `webLiveRailway` probe
+    // gates the cell to `skip` until the lane is provisioned.
+    id: "web.live.railway-roundtrip",
+    title:
+      "Web LIVE cloud voice round-trip: injected WAV -> Railway Whisper STT -> live agent -> Railway Kokoro TTS -> non-silent audio",
+    platform: "web",
+    dimensions: {
+      transcriptionState: "off",
+      chimeIn: "should-respond",
+      wakewordContext: "idle-wake",
+      noiseRejection: "quiet",
+      voices: "owner",
+    },
+    class: "live-cloud-voice-roundtrip",
+    command: [
+      "bun",
+      "run",
+      "--cwd",
+      "packages/app",
+      "test:e2e",
+      "test/ui-smoke/voice-realaudio.spec.ts",
+    ],
+    env: UI_SMOKE_MATRIX_ENV,
+    evidence: ["packages/app/test-results", "e2e-recordings/app/test-results"],
+    probe: "webLiveRailway",
   },
   {
     id: "web.fake-mic.transcript-roundtrip",
@@ -659,6 +688,19 @@ function probeCell(cell) {
       return {
         available: true,
         reason: "Chromium fake-device mic lane is host-runnable",
+      };
+    case "webLiveRailway":
+      if (process.env.ELIZA_VOICE_LIVE_RAILWAY !== "1") {
+        return {
+          available: false,
+          reason:
+            "set ELIZA_VOICE_LIVE_RAILWAY=1 with reachable Railway STT/TTS + a live LLM key",
+        };
+      }
+      return {
+        available: true,
+        reason:
+          "ELIZA_VOICE_LIVE_RAILWAY=1: live cloud voice round-trip enabled",
       };
     case "linuxFused":
       if (process.platform !== "linux")

--- a/packages/ui/src/components/shell/ShellOverlays.tsx
+++ b/packages/ui/src/components/shell/ShellOverlays.tsx
@@ -130,6 +130,8 @@ export function ShellOverlays({
           role="status"
           aria-live="polite"
           aria-busy={actionNotice.busy ? true : undefined}
+          data-testid="shell-action-notice"
+          data-tone={actionNotice.tone}
         >
           {actionNotice.busy ? (
             <Spinner size={16} className="shrink-0 opacity-95" aria-hidden />

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -966,6 +966,17 @@ export function useShellController(): ShellController {
           captureRef.current = null;
           setAnalyser(null);
           setRecording(false);
+          // A hands-free tap optimistically lit the mic ("end conversation")
+          // before the device opened; a denial must roll that back so the button
+          // returns to its resting "talk" state instead of showing a lit,
+          // phantom-capturing conversation the mic never actually started. Mirror
+          // the deliberate tap-off (restore the prior non-always-on mode) so a
+          // reload doesn't re-engage a mic the user can't grant.
+          if (handsFreeRef.current) {
+            saveContinuousChatMode(priorContinuousModeRef.current);
+            setHandsFree(false);
+            handsFreeRef.current = false;
+          }
           // Mic permission denial / capture failure was previously swallowed —
           // the user tapped the mic and nothing happened with no feedback.
           // Surface a clear, actionable notice through the shell's toast channel


### PR DESCRIPTION
## What / why

`voice-realaudio.spec.ts` drove the real client capture path but mocked all three backends and never covered the failure paths a real user hits. This adds them, in the same keyless fake-mic Chromium lane (`chromium-voice-mic`, `--use-file-for-fake-audio-capture`), plus an opt-in LIVE cloud round-trip.

**Failure paths (keyless, always run):**
- **Mic permission denied** — `getUserMedia` rejects `NotAllowedError`: a distinguishable, error-toned notice renders and **no phantom capture** starts (zero WAVs reach ASR); the mic rolls back to its resting **"talk"** label instead of a lit "end conversation" the device never opened.
- **Silent / empty capture** — the empty transcript is a typed-invalid result (`transcribeLocalInferenceWav` throws), so the turn is **dropped, never sent**: no `messages/stream` POST, no user bubble, clean return to rest.
- **TTS dropped mid-stream** — a real connection drop (not a user-cancel `AbortError`) **fails closed**: no silent engine swap, no hung player (audio probe shows 0 playback for the failed turn); the **next turn recovers and speaks** (probe `starts > 0`).

**Live web round-trip** (gated on `ELIZA_VOICE_LIVE_RAILWAY=1`) drops every mock and drives the real cloud STT proxy (`/api/asr/cloud` → Railway Whisper) → live agent → cloud Kokoro TTS (`/api/tts/cloud`), asserting transcript containment **and decoded, non-silent audio out** (inspects real WAV bytes / duration / peak). It **SKIPS (never green) when ungated**.

**voice:matrix** — new gated cell `web.live.railway-roundtrip` (probe `webLiveRailway` → `skip` until provisioned); the existing `web.fake-mic.roundtrip` cell now also exercises the failure paths.

**Two small source fixes** make the mic-denied error state honest and assertable (three-state rule — no healthy-empty):
- `ShellOverlays.tsx` — the action-notice toast gets a stable `data-testid="shell-action-notice"` + `data-tone` (it had no test hook).
- `useShellController.ts` — a capture failure now rolls hands-free back, so a **denied mic returns to rest** rather than appearing to still capture (the "no phantom capture" acceptance criterion).

Desktop/local path stays covered by the existing `test:desktop:voice` (matrix cell `macos.electrobun.live-roundtrip`) and the nightly `voice-live-e2e.yml` lane — no new harness. Native builds are not rebuilt in this worktree.

Closes #14371

## Evidence

**Real e2e run** — `bun run --cwd packages/app test:e2e test/ui-smoke/voice-realaudio.spec.ts` (E2E_RECORD=1), real live app stack (cold build → live stack → real Chromium fake-audio device, no human, no microphone):

```
Running 6 tests using 1 worker
  ✓ 1 pressing the mic button ... completes the voice round-trip (6.7s)
  ✓ 2 REAL audio: transcription start during spoken local TTS barges in ... (5.8s)
  ✓ 3 voice failure paths (keyless) › mic permission denied ... NO phantom capture (3.3s)
  ✓ 4 voice failure paths (keyless) › silent/empty capture sends NO message ... (5.3s)
  ✓ 5 voice failure paths (keyless) › TTS dropped mid-stream fails closed ... next turn still speaks (6.6s)
  -  6 live cloud voice round-trip (Railway path) › ... [SKIPPED — ungated]
  5 passed (1.9m), 1 skipped
```

The two pre-existing tests still pass; the live variant correctly reports `skipped`, not passed, when ungated.

**voice:matrix** — `ELIZA_VOICE_LIVE_RAILWAY=1 node packages/scripts/voice-matrix.mjs --platform web.live.railway-roundtrip` → `pending` (provisioned, awaiting `--run`); ungated → `skip=1` (never masquerades as pass). `bun test packages/scripts/__tests__/voice-matrix.test.ts` → 2 pass.

**Scoped verify** — biome clean on all 4 changed files; ui/app typecheck show only pre-existing errors (unbuilt workspace deps / unrelated test files), none in the changed files.

| Evidence | Status |
|---|---|
| E2E test run (real app stack, 5 passed / 1 skipped) | ✅ above |
| Per-failure-state screenshots + video (mic-denied, silent, TTS-drop) | ✅ captured at `e2e-recordings/app/test-results/voice-realaudio-voice-fail-*/` (`video.webm` + `test-finished-1.png` per test) — not committed per repo policy |
| Backend `[Voice STT/TTS API]` logs | N/A — keyless lane mocks the cloud STT/TTS routes; real backend logs only exist on the gated `ELIZA_VOICE_LIVE_RAILWAY` lane |
| Live-LLM trajectory for the in-loop agent turn | N/A — the live agent turn only runs on the gated Railway lane, which is unreachable from this environment (no reachable Railway STT/TTS + live LLM); the spec + matrix cell are wired so a provisioned runner exercises and records it |
| WER / latency numbers | N/A — WER/latency are scored only against a REAL recognizer (the gated live lane, `plugin-local-inference *.real.test.ts`, and hardware matrix cells); the keyless lane uses an echo/mock ASR where a WER assertion is structurally 0 (see the file's #10726 note) |
| MP4 with audio of the full live round-trip | N/A — requires the gated Railway lane + audio-capture runner; not reachable here |

## Infra-blocked (documented, not skipped)

The live Railway round-trip (real STT/TTS + live agent + audible MP4) cannot run from this environment: no reachable Railway Whisper/Kokoro endpoints and no live-LLM voice stack. It is fully wired and env-gated so a provisioned CI runner (or the nightly lane) executes and records it; ungated it skips rather than false-passing.
