### PR TITLE
ci(#14369): view-action ratchet covers the full shell-view component tree

### DIFF
--- a/packages/scripts/view-action-ratchet.mjs
+++ b/packages/scripts/view-action-ratchet.mjs
@@ -13,9 +13,9 @@
  *      by HTTP verb; POST/PUT/PATCH/DELETE (or a dynamic `method:`) marks the
  *      method as mutating. The typed client is the single write path for shell
  *      views, so its mutating surface IS the view-mutation vocabulary.
- *   2. Scan the builtin-view renderer trees (`components/pages`,
- *      `components/settings`, `components/character` under `packages/ui/src`)
- *      for calls to mutating client methods and for raw
+ *   2. Scan the whole first-party shell-view component tree
+ *      (`packages/ui/src/components`) for calls to mutating client methods
+ *      and for raw
  *      `fetch`/`client.fetch`/`client.rawRequest` calls with a mutating verb.
  *   3. Every discovered mutation site must resolve in the curated registry
  *      (`view-action-ratchet.registry.json`) to exactly one of:
@@ -48,11 +48,17 @@ const REGISTRY_PATH = path.join(
   "view-action-ratchet.registry.json",
 );
 const CLIENT_API_DIR = "packages/ui/src/api";
-const VIEW_ROOTS = [
-  "packages/ui/src/components/pages",
-  "packages/ui/src/components/settings",
-  "packages/ui/src/components/character",
-];
+// The entire first-party shell-view component tree, not a hand-picked subset:
+// builtin views render their entry page under `components/pages` but compose
+// mutating sections from siblings (`components/local-inference`,
+// `components/connectors`, `components/custom-actions`, `components/transcripts`
+// — the Live-meeting builtin view — etc.). Scanning only pages/settings/
+// character let those sections' mutations pass the gate uncovered, so the
+// "every builtin-view mutation has a chat twin" guarantee was silently false.
+// Pure-presentational dirs (primitives, ui, shared) carry no client mutations,
+// so scanning the whole tree adds coverage without noise. Third-party plugin
+// view bundles live outside packages/ui and stay out of scope (see header).
+const VIEW_ROOTS = ["packages/ui/src/components"];
 const CATALOG_MD = "packages/docs/action-catalog.md";
 const CANONICAL_SPEC_DIR = "packages/prompts/specs/actions";
 

--- a/packages/scripts/view-action-ratchet.registry.json
+++ b/packages/scripts/view-action-ratchet.registry.json
@@ -170,6 +170,188 @@
     },
     "updateCloudCompatAgent": {
       "exempt": "Eliza Cloud account-scoped agent management, authenticated by the user's cloud session"
+    },
+    "requestMeetingBot": { "action": "JOIN_MEETING" },
+    "stopMeeting": { "action": "LEAVE_MEETING" },
+    "createTranscript": { "action": "START_TRANSCRIPTION" },
+    "updatePlugin": {
+      "action": "PLUGIN",
+      "note": "agent-rendered plugin card in chat MessageContent; PLUGIN is the enable/configure twin"
+    },
+    "authorizeDiscordLocal": {
+      "action": "CONNECTOR",
+      "note": "Discord local-connector authorize; CONNECTOR is the setup/control facade"
+    },
+    "disconnectDiscordLocal": { "action": "CONNECTOR" },
+    "saveDiscordLocalSubscriptions": { "action": "CONNECTOR" },
+    "startTelegramAccountAuth": { "action": "CONNECTOR" },
+    "submitTelegramAccountAuth": { "action": "CONNECTOR" },
+    "disconnectTelegramAccount": { "action": "CONNECTOR" },
+    "startConnectorAccountOAuth": { "action": "CONNECTOR" },
+    "attachAppRun": {
+      "exempt": "app-runtime session IPC for a running mini-app (FullscreenView), not a builtin-view content mutation — launchApp/stopApp are the APP twins"
+    },
+    "detachAppRun": {
+      "exempt": "app-runtime session IPC for a running mini-app (FullscreenView)"
+    },
+    "controlAppRun": {
+      "exempt": "app-runtime session control for a running mini-app (FullscreenView)"
+    },
+    "heartbeatAppRun": {
+      "exempt": "app-runtime session keepalive for a running mini-app (FullscreenView)"
+    },
+    "sendAppRunMessage": {
+      "exempt": "app-runtime session message IPC for a running mini-app (FullscreenView)"
+    },
+    "sendAppSessionMessage": {
+      "exempt": "app-runtime session message IPC for a running mini-app (FullscreenView)"
+    },
+    "stopAppRun": {
+      "exempt": "app-runtime session teardown for a running mini-app (FullscreenView)"
+    },
+    "startAccountOAuth": {
+      "exempt": "provider OAuth consent — user-gesture browser handshake in AddAccountDialog"
+    },
+    "cancelAccountOAuth": {
+      "exempt": "provider OAuth consent — cancels the in-progress AddAccountDialog handshake"
+    },
+    "submitAccountOAuthCode": {
+      "exempt": "provider OAuth consent — user pastes the returned code in AddAccountDialog"
+    },
+    "createApiKeyAccount": {
+      "exempt": "provider credential consent — user-entered API-key account in AddAccountDialog"
+    },
+    "tunnelCredential": {
+      "exempt": "chat plumbing — agent-rendered credential-tunnel card in MessageContent"
+    },
+    "respondToComputerUseApproval": {
+      "exempt": "user-gesture approval — computer-use consent overlay"
+    },
+    "submitBugReport": {
+      "exempt": "developer diagnostics — bug report submission"
+    },
+    "postBootstrapExchange": {
+      "exempt": "setup/onboarding — pre-agent bootstrap token exchange in BootstrapStep"
+    },
+    "setInboxChatMute": {
+      "exempt": "chat plumbing — per-conversation mute toggle in the chat sidebar"
+    },
+    "spawnShellSession": {
+      "exempt": "chat plumbing — opens a shell/terminal conversation from the sidebar"
+    },
+    "startLocalInferenceDownload": {
+      "gap": {
+        "issue": "#15012",
+        "reason": "local-model download has no chat/voice action twin"
+      }
+    },
+    "cancelLocalInferenceDownload": {
+      "gap": {
+        "issue": "#15012",
+        "reason": "local-model download cancel has no chat/voice action twin"
+      }
+    },
+    "setLocalInferenceActive": {
+      "gap": {
+        "issue": "#15012",
+        "reason": "activating a local model has no chat/voice action twin"
+      }
+    },
+    "clearLocalInferenceActive": {
+      "gap": {
+        "issue": "#15012",
+        "reason": "clearing the active local model has no chat/voice action twin"
+      }
+    },
+    "uninstallLocalInferenceModel": {
+      "gap": {
+        "issue": "#15012",
+        "reason": "uninstalling a local model has no chat/voice action twin"
+      }
+    },
+    "verifyLocalInferenceModel": {
+      "gap": {
+        "issue": "#15012",
+        "reason": "verifying a local model has no chat/voice action twin"
+      }
+    },
+    "setLocalInferencePolicy": {
+      "gap": {
+        "issue": "#15012",
+        "reason": "local-inference routing policy has no chat/voice action twin"
+      }
+    },
+    "setLocalInferencePreferredProvider": {
+      "gap": {
+        "issue": "#15012",
+        "reason": "local-inference preferred-provider has no chat/voice action twin"
+      }
+    },
+    "setLocalInferenceAssignment": {
+      "gap": {
+        "issue": "#15012",
+        "reason": "local-inference slot assignment has no chat/voice action twin"
+      }
+    },
+    "triggerVoiceModelUpdate": {
+      "gap": {
+        "issue": "#15012",
+        "reason": "voice-model update has no chat/voice action twin"
+      }
+    },
+    "pinVoiceModel": {
+      "gap": {
+        "issue": "#15012",
+        "reason": "pinning a voice model has no chat/voice action twin"
+      }
+    },
+    "setVoiceModelPreferences": {
+      "gap": {
+        "issue": "#15012",
+        "reason": "voice-model preferences have no chat/voice action twin"
+      }
+    },
+    "generateCustomAction": {
+      "gap": {
+        "issue": "#15012",
+        "reason": "custom-action authoring has no chat/voice action twin"
+      }
+    },
+    "createCustomAction": {
+      "gap": {
+        "issue": "#15012",
+        "reason": "custom-action authoring has no chat/voice action twin"
+      }
+    },
+    "updateCustomAction": {
+      "gap": {
+        "issue": "#15012",
+        "reason": "custom-action authoring has no chat/voice action twin"
+      }
+    },
+    "deleteCustomAction": {
+      "gap": {
+        "issue": "#15012",
+        "reason": "custom-action authoring has no chat/voice action twin"
+      }
+    },
+    "testCustomAction": {
+      "gap": {
+        "issue": "#15012",
+        "reason": "custom-action testing has no chat/voice action twin"
+      }
+    },
+    "deleteTranscript": {
+      "gap": {
+        "issue": "#15012",
+        "reason": "transcript deletion has no chat/voice action twin"
+      }
+    },
+    "updateTranscript": {
+      "gap": {
+        "issue": "#15012",
+        "reason": "transcript rename/update has no chat/voice action twin"
+      }
     }
   },
   "rawSites": {
@@ -222,6 +404,14 @@
     },
     "POST ANDROID_SMS_GATEWAY_WEBHOOK_URL": {
       "exempt": "background SMS-forwarding bridge to the cloud gateway, not an on-screen control"
+    },
+    "POST /api/setup/telegram/start": {
+      "action": "CONNECTOR",
+      "note": "Telegram bot setup entry point (TelegramBotSetupPanel); CONNECTOR is the setup/control facade"
+    },
+    "POST /api/setup/telegram/cancel": {
+      "action": "CONNECTOR",
+      "note": "cancels the Telegram bot setup flow"
     }
   }
 }


### PR DESCRIPTION
## What / why

Completes the #14369 view→action ratchet. The merged gate (#14967) hardcoded `VIEW_ROOTS` to only `components/pages`, `components/settings`, and `components/character`, so its headline guarantee — **every builtin-view on-screen mutation maps to a registered agent action** — was **silently false**. Builtin-view mutations rendered from sibling component dirs passed the gate completely uncovered, most glaringly `components/transcripts/` — the renderer of the `transcripts` (Live meeting) **builtin view** itself.

Proven gap on `develop` (the ratchet's own scanner, run over the whole `components` tree): **73 mutation sites** outside the three scanned roots, e.g.

```
components/transcripts/LiveMeetingPage.tsx  requestMeetingBot, stopMeeting     <- builtin view!
components/local-inference/LocalInferencePanel.tsx  startLocalInferenceDownload, uninstallLocalInferenceModel, ...
components/custom-actions/CustomActionEditor.tsx    create/update/delete/generate/testCustomAction
components/connectors/*  Discord/Telegram connector auth
components/apps/FullscreenView.tsx  app-runtime session IPC
```

## Fix

- **`VIEW_ROOTS` → `["packages/ui/src/components"]`** — the whole first-party shell-view component tree, not a hand-picked subset. Pure-presentational dirs (`primitives`, `ui`, `shared`) carry no client mutations, so scanning them adds coverage without noise; third-party plugin view bundles live outside `packages/ui` and stay out of scope by design.
- **Every newly-surfaced site is dispositioned** in `view-action-ratchet.registry.json`:
  - **Mapped to a real twin:** `requestMeetingBot`→`JOIN_MEETING`, `stopMeeting`→`LEAVE_MEETING`, `createTranscript`→`START_TRANSCRIPTION`, `updatePlugin`→`PLUGIN`, Discord/Telegram connector flows + `POST /api/setup/telegram/*`→`CONNECTOR`.
  - **Designed exemptions (with reasons):** app-runtime session IPC (`FullscreenView`), provider OAuth / API-key consent (`AddAccountDialog`), computer-use approval, bug-report diagnostics, pre-agent bootstrap, and chat plumbing (sidebar mute, shell-session spawn, credential-tunnel card).
  - **Baselined gaps (tracked by #15012):** local-inference model management, custom-action authoring, transcript delete/rename — genuine missing chat/voice twins.

## Evidence

<details><summary>Ratchet green on the broadened scope + self-test</summary>

```
[view-action-ratchet] self-test passed
[view-action-ratchet] 210 mutation site(s) across 71 builtin-view file(s); 24 action twin(s); 33 baselined gap(s); registered actions: 198
[view-action-ratchet] every builtin-view mutation maps to a registered action (or a documented exemption/gap)
EXIT=0
```
Coverage rose from **137 → 210** sites (the 73 previously-uncovered sites are now gated).
</details>

<details><summary>Red path — an injected local-only mutation still fails</summary>

```
# injected raw fetch("/api/files/purge-all", { method: "POST" }) into FilesView.tsx
[view-action-ratchet] FAIL — 1 violation(s):
  - packages/ui/src/components/pages/FilesView.tsx:73 — unmapped builtin-view mutation raw request "POST /api/files/purge-all".
EXIT=1
# restored
restore EXIT=0
```
</details>

Mapped twins verified present in `packages/docs/action-catalog.md` (`JOIN_MEETING`, `LEAVE_MEETING`, `START_TRANSCRIPTION`) and in the registered-action inventory. The `#14824` per-view handler test is unaffected (it reads BUILTIN_VIEWS + the live inventory, both untouched).

- Before/after screenshots: `N/A - CI-gate scope + curated registry; no rendered UI changed`
- Walkthrough video: `N/A - the green/red gate output above is the execution evidence`
- Backend logs: `N/A - no server runtime path changed`
- Frontend console/network logs: `N/A - no browser surface changed`
- Real-LLM trajectory: `N/A - no model/prompt behavior changed; action-docs.ts untouched`
- Domain artifacts: the curated `view-action-ratchet.registry.json` dispositions are in the diff; gap tracking issue #15012 filed

Follows up #14369 / #14967.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
