### PR TITLE
test(#14353): first-run onboarding journey scenarios — fast-start + customize → first reminder

### DIFF
--- a/plugins/plugin-personal-assistant/test/scenarios/_helpers/first-run-onboarding.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/_helpers/first-run-onboarding.ts
@@ -1,0 +1,378 @@
+/**
+ * Shared drive-and-assert helpers for the first-run onboarding journey
+ * scenarios (fast-start + customize → first reminder).
+ *
+ * First-run is NOT model-invocable: the live chat's onboarding conductor drives
+ * `FirstRunService` directly (there is no planner action the model can select),
+ * and the affordance only reaches the model through `firstRunProvider`. So the
+ * scenarios split the proof: their live message turns exercise the model with
+ * the onboarding affordance surfaced (recorded trajectory evidence), while these
+ * helpers own pass/fail by driving the real `FirstRunService` through the same
+ * path the conductor would — using the PRODUCTION scheduled-task runner so
+ * seeded records land in the real `app_lifeops.life_scheduled_tasks` store —
+ * then asserting that store (via `LifeOpsRepository`), never reply text.
+ *
+ * Precondition: `createScenarioRuntime` force-marks first-run `complete` (so the
+ * provider stays quiet for unrelated scenarios). `resetFirstRunPrecondition`
+ * runs as a seed step to restore the fresh-boot `pending` state these scenarios
+ * require, so the provider surfaces during the turns and the service can be
+ * walked from scratch in the final check.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { LifeOpsRepository } from "@elizaos/plugin-personal-assistant";
+import {
+  DEFAULT_PACK_IDEMPOTENCY_KEYS,
+  deriveMorningWindow,
+  parseWakeTime,
+} from "@elizaos/plugin-personal-assistant/lifeops/first-run/defaults";
+import { validateChannel } from "@elizaos/plugin-personal-assistant/lifeops/first-run/questions";
+import {
+  FirstRunService,
+  type ScheduledTaskRunnerLike,
+} from "@elizaos/plugin-personal-assistant/lifeops/first-run/service";
+import { getScheduledTaskRunner } from "@elizaos/plugin-personal-assistant/lifeops/scheduled-task/service";
+import type { ScheduledTask } from "@elizaos/plugin-scheduling";
+import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
+
+function asRuntime(ctx: ScenarioContext): IAgentRuntime {
+  return ctx.runtime as IAgentRuntime;
+}
+
+function agentIdOf(runtime: IAgentRuntime): string {
+  return String(runtime.agentId ?? "");
+}
+
+/**
+ * Build a `FirstRunService` bound to the PRODUCTION runner so scheduled records
+ * are upserted into the DB-backed store (readable by `LifeOpsRepository`),
+ * exactly as the boot seeder / conductor path does. `getScheduledTaskRunner`
+ * throws when `@elizaos/plugin-scheduling` is not registered — that is a real
+ * wiring failure the scenario should surface, not mask.
+ */
+function productionFirstRunService(runtime: IAgentRuntime): FirstRunService {
+  const runner = getScheduledTaskRunner(runtime, {
+    agentId: agentIdOf(runtime),
+  }) as unknown as ScheduledTaskRunnerLike;
+  return new FirstRunService(runtime, { runner });
+}
+
+function repoOf(runtime: IAgentRuntime): LifeOpsRepository {
+  return new LifeOpsRepository(
+    runtime as unknown as ConstructorParameters<typeof LifeOpsRepository>[0],
+  );
+}
+
+async function readFirstRunTasks(
+  runtime: IAgentRuntime,
+): Promise<ScheduledTask[]> {
+  const tasks = await repoOf(runtime).listScheduledTasks(agentIdOf(runtime), {
+    source: "first_run",
+  });
+  return tasks;
+}
+
+function taskByKey(
+  tasks: ScheduledTask[],
+  idempotencyKey: string,
+): ScheduledTask | undefined {
+  return tasks.find(
+    (t) => (t as { idempotencyKey?: string }).idempotencyKey === idempotencyKey,
+  );
+}
+
+/** Cron minute+hour a `cronAtLocal(hhmm, tz)` trigger encodes, or null. */
+function cronHourMinute(
+  task: ScheduledTask | undefined,
+): { minute: number; hour: number } | null {
+  const trigger = task?.trigger;
+  if (trigger?.kind !== "cron") return null;
+  const parts = trigger.expression.trim().split(/\s+/);
+  if (parts.length < 2) return null;
+  const minute = Number.parseInt(parts[0], 10);
+  const hour = Number.parseInt(parts[1], 10);
+  if (!Number.isFinite(minute) || !Number.isFinite(hour)) return null;
+  return { minute, hour };
+}
+
+/**
+ * Assert the seeded default pack materialized in the real store and that the
+ * gm reminder's cron is DERIVED from the answered wake time (outcome, not
+ * routing). Returns an error string on the first failure, else undefined.
+ */
+function assertDefaultPackAnchoredToWake(
+  tasks: ScheduledTask[],
+  answeredWake: string,
+): string | undefined {
+  const wakeHHMM = parseWakeTime(answeredWake);
+  if (!wakeHHMM) {
+    return `test bug: wake time "${answeredWake}" did not parse`;
+  }
+  const morning = deriveMorningWindow(wakeHHMM);
+  const [wakeHour, wakeMinute] = morning.startLocal
+    .split(":")
+    .map((p) => Number.parseInt(p, 10));
+
+  const gm = taskByKey(tasks, DEFAULT_PACK_IDEMPOTENCY_KEYS.gm);
+  const gn = taskByKey(tasks, DEFAULT_PACK_IDEMPOTENCY_KEYS.gn);
+  const checkin = taskByKey(tasks, DEFAULT_PACK_IDEMPOTENCY_KEYS.checkin);
+  const morningBrief = taskByKey(
+    tasks,
+    DEFAULT_PACK_IDEMPOTENCY_KEYS.morningBrief,
+  );
+  if (!gm || !gn || !checkin || !morningBrief) {
+    return (
+      `expected the seeded first-run default pack (gm/gn/checkin/morningBrief) ` +
+      `in the scheduled-task store; saw idempotency keys ` +
+      `[${tasks
+        .map((t) => (t as { idempotencyKey?: string }).idempotencyKey ?? "?")
+        .join(", ")}]`
+    );
+  }
+
+  const gmAnchor = cronHourMinute(gm);
+  if (!gmAnchor) {
+    return `gm reminder is not a cron trigger: ${JSON.stringify(gm.trigger)}`;
+  }
+  if (gmAnchor.hour !== wakeHour || gmAnchor.minute !== wakeMinute) {
+    return (
+      `gm cron must be anchored to the answered wake time ` +
+      `${morning.startLocal} (→ "${wakeMinute} ${wakeHour} * * *"), saw ` +
+      `"${(gm.trigger as { expression?: string }).expression}"`
+    );
+  }
+
+  if (checkin.kind !== "checkin") {
+    return `check-in record has wrong kind: ${checkin.kind}`;
+  }
+  // The morning brief fires off the wake CONFIRMATION anchor, not a clock time.
+  if (morningBrief.trigger.kind !== "relative_to_anchor") {
+    return `morning brief must be wake-anchored, saw ${JSON.stringify(morningBrief.trigger)}`;
+  }
+  if (morningBrief.trigger.anchorKey !== "wake.confirmed") {
+    return `morning brief anchor must be wake.confirmed, saw ${morningBrief.trigger.anchorKey}`;
+  }
+  const gnAnchor = cronHourMinute(gn);
+  if (gnAnchor?.hour !== 22 || gnAnchor?.minute !== 0) {
+    return `gn reminder must fire at 22:00 local, saw ${JSON.stringify(gn.trigger)}`;
+  }
+  return undefined;
+}
+
+/**
+ * Seed step: restore the fresh-boot `pending` first-run state the harness
+ * overwrote to `complete`. Also clears the seeded-defaults marker so the
+ * scenario's drive schedules the pack from scratch.
+ */
+export async function resetFirstRunPrecondition(
+  ctx: ScenarioContext,
+): Promise<string | undefined> {
+  const runtime = asRuntime(ctx);
+  await new FirstRunService(runtime).resetState();
+  const record = await new FirstRunService(runtime).readState();
+  if (record.status !== "pending") {
+    return `first-run precondition reset failed: status is ${record.status}`;
+  }
+  return undefined;
+}
+
+/**
+ * Fast-start (defaults) outcome: one wake-time question, then the default pack
+ * materializes with anchors derived from the answer. `answeredWake` is the
+ * free-text wake time the owner gives (e.g. "6:30am").
+ */
+export function fastStartSeedsFirstReminder(
+  answeredWake: string,
+): (ctx: ScenarioContext) => Promise<string | undefined> {
+  return async (ctx: ScenarioContext) => {
+    const runtime = asRuntime(ctx);
+    const service = productionFirstRunService(runtime);
+
+    const ask = await service.runDefaultsPath({});
+    if (
+      ask.status !== "needs_more_input" ||
+      ask.awaitingQuestion !== "wakeTime"
+    ) {
+      return `fast-start must ask wake time first, saw ${ask.status}/${ask.awaitingQuestion}`;
+    }
+
+    const done = await service.runDefaultsPath({ wakeTime: answeredWake });
+    if (done.status !== "ok") {
+      return `fast-start did not complete, saw ${done.status} (${done.message})`;
+    }
+    if (done.scheduledTasks.length === 0) {
+      return "fast-start completed but scheduled no tasks";
+    }
+
+    const tasks = await readFirstRunTasks(runtime);
+    return assertDefaultPackAnchoredToWake(tasks, answeredWake);
+  };
+}
+
+/**
+ * Full customize walk incl. the conditional relationships question (Q5 fires
+ * only because `follow-ups` is among the categories), then assert the default
+ * pack seeded with anchors derived from the answered morning window and that
+ * the preferred name persisted.
+ */
+export async function customizeFullWalkSeedsReminders(
+  ctx: ScenarioContext,
+): Promise<string | undefined> {
+  const runtime = asRuntime(ctx);
+  const service = productionFirstRunService(runtime);
+
+  const q1 = await service.runCustomizePath({});
+  if (q1.awaitingQuestion !== "preferredName") {
+    return `expected Q1 preferredName, saw ${q1.awaitingQuestion}`;
+  }
+  const q2 = await service.runCustomizePath({ preferredName: "Sam" });
+  if (q2.awaitingQuestion !== "timezoneAndWindows") {
+    return `expected Q2 timezoneAndWindows, saw ${q2.awaitingQuestion}`;
+  }
+  const q3 = await service.runCustomizePath({
+    timezone: "America/Los_Angeles",
+    morningWindow: { startLocal: "06:30", endLocal: "11:30" },
+    eveningWindow: { startLocal: "18:00", endLocal: "22:00" },
+  });
+  if (q3.awaitingQuestion !== "categories") {
+    return `expected Q3 categories, saw ${q3.awaitingQuestion}`;
+  }
+  const q4 = await service.runCustomizePath({
+    categories: ["reminder packs", "follow-ups"],
+  });
+  if (q4.awaitingQuestion !== "channel") {
+    return `expected Q4 channel, saw ${q4.awaitingQuestion}`;
+  }
+  // follow-ups selected → the conditional relationships question MUST fire.
+  const q5 = await service.runCustomizePath({ channel: "in_app" });
+  if (q5.awaitingQuestion !== "relationships") {
+    return `follow-ups selected but Q5 relationships was skipped (saw ${q5.awaitingQuestion})`;
+  }
+  const done = await service.runCustomizePath({
+    relationships: [
+      { name: "Alice", cadenceDays: 14 },
+      { name: "Bob", cadenceDays: 30 },
+    ],
+  });
+  if (done.status !== "ok") {
+    return `customize did not complete, saw ${done.status} (${done.message})`;
+  }
+  if (done.facts.preferredName !== "Sam") {
+    return `preferred name not persisted, saw ${done.facts.preferredName}`;
+  }
+
+  const tasks = await readFirstRunTasks(runtime);
+  // Morning window start 06:30 is the wake anchor for the customize path.
+  return assertDefaultPackAnchoredToWake(tasks, "06:30");
+}
+
+/**
+ * Abandon-mid-customize → resume without data loss. Answers Q1+Q2, abandons,
+ * then a FRESH service instance (same runtime cache) resumes: it must advance
+ * to the next UNanswered question (categories) rather than re-ask Q1/Q2, and
+ * the persisted answers must survive. Exercises `FirstRunStateStore` durability.
+ */
+export async function abandonResumeNoDataLoss(
+  ctx: ScenarioContext,
+): Promise<string | undefined> {
+  const runtime = asRuntime(ctx);
+  const first = productionFirstRunService(runtime);
+
+  const a1 = await first.runCustomizePath({ preferredName: "Riley" });
+  if (a1.awaitingQuestion !== "timezoneAndWindows") {
+    return `expected timezoneAndWindows after name, saw ${a1.awaitingQuestion}`;
+  }
+  const a2 = await first.runCustomizePath({
+    timezone: "America/Chicago",
+    morningWindow: { startLocal: "07:00", endLocal: "12:00" },
+    eveningWindow: { startLocal: "19:00", endLocal: "23:00" },
+  });
+  if (a2.awaitingQuestion !== "categories") {
+    return `expected categories after timezone, saw ${a2.awaitingQuestion}`;
+  }
+
+  // Abandon: the owner walks away mid-flow. State persists (in_progress).
+  const state = await first.readState();
+  if (state.status !== "in_progress") {
+    return `expected in_progress after partial answers, saw ${state.status}`;
+  }
+  if (state.partialAnswers.preferredName !== "Riley") {
+    return `Q1 answer lost from partialAnswers before resume`;
+  }
+
+  // Resume on a fresh instance with NO new input: it must NOT re-ask an
+  // already-answered question — it advances to the first unanswered one.
+  const resumed = productionFirstRunService(runtime);
+  const r = await resumed.runCustomizePath({});
+  if (r.awaitingQuestion !== "categories") {
+    return (
+      `resume re-asked an already-answered question — expected to resume at ` +
+      `categories, saw ${r.awaitingQuestion}`
+    );
+  }
+
+  // Finish the flow to prove resume reaches a real seeded first reminder.
+  const c = await resumed.runCustomizePath({ categories: ["reminder packs"] });
+  if (c.awaitingQuestion !== "channel") {
+    return `expected channel after categories, saw ${c.awaitingQuestion}`;
+  }
+  const done = await resumed.runCustomizePath({ channel: "in_app" });
+  if (done.status !== "ok") {
+    return `resumed customize did not complete, saw ${done.status}`;
+  }
+  if (done.facts.preferredName !== "Riley") {
+    return `preferred name lost across resume, saw ${done.facts.preferredName}`;
+  }
+
+  const tasks = await readFirstRunTasks(runtime);
+  // Morning window start 07:00 was answered before the abandon.
+  return assertDefaultPackAnchoredToWake(tasks, "07:00");
+}
+
+/**
+ * Channel answer for a channel with no connected dispatcher → recorded with
+ * `fallbackToInApp: true` and the warning surfaced. Asserts both the raw
+ * validator contract and that the surfaced first-run result carries the
+ * fallback warning + "(fallback)" completion message.
+ */
+export async function channelFallbackRecorded(
+  ctx: ScenarioContext,
+): Promise<string | undefined> {
+  const runtime = asRuntime(ctx);
+
+  const validation = await validateChannel("telegram", runtime);
+  if (validation.fallbackToInApp !== true) {
+    return `unconnected telegram must fall back to in-app, saw ${JSON.stringify(validation)}`;
+  }
+  if (!validation.warning || !/fall.?back|in-?app/i.test(validation.warning)) {
+    return `expected a fallback warning, saw ${JSON.stringify(validation.warning)}`;
+  }
+
+  const service = productionFirstRunService(runtime);
+  await service.runCustomizePath({ preferredName: "Jordan" });
+  await service.runCustomizePath({
+    timezone: "UTC",
+    morningWindow: { startLocal: "06:00", endLocal: "11:00" },
+    eveningWindow: { startLocal: "18:00", endLocal: "22:00" },
+  });
+  await service.runCustomizePath({ categories: ["reminder packs"] });
+  const done = await service.runCustomizePath({ channel: "telegram" });
+  if (done.status !== "ok") {
+    return `customize with fallback channel did not complete, saw ${done.status}`;
+  }
+  if (
+    done.warnings.length === 0 ||
+    !done.warnings.some((w) => /fall.?back|in-?app/i.test(w))
+  ) {
+    return `fallback warning not surfaced on the first-run result, saw ${JSON.stringify(done.warnings)}`;
+  }
+  if (!/\(fallback\)/.test(done.message)) {
+    return `completion message must mark the channel fallback, saw ${done.message}`;
+  }
+
+  const tasks = await readFirstRunTasks(runtime);
+  if (tasks.length === 0) {
+    return "fallback-channel customize seeded no scheduled tasks";
+  }
+  return undefined;
+}

--- a/plugins/plugin-personal-assistant/test/scenarios/first-run-abandon-resume-no-data-loss.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/first-run-abandon-resume-no-data-loss.scenario.ts
@@ -1,0 +1,67 @@
+/**
+ * Onboarding journey — abandon mid-customize, then resume without data loss.
+ * The owner answers the first two customize questions, walks away, and comes
+ * back later. The LIVE message turns show the interruption + return (recorded
+ * trajectory evidence); pass/fail is the DOMAIN durability contract, since
+ * first-run is conductor-driven, not model-invocable. The final check proves it:
+ * a fresh `FirstRunService` instance reads the persisted `partialAnswers` and
+ * resumes at the first UNanswered question (categories) instead of re-asking the
+ * name or windows, and the flow still reaches a real seeded first reminder
+ * anchored to the earlier answer.
+ *
+ * Fail-without-fix anchor: `FirstRunStateStore.recordAnswer` / `.abandon`
+ * persistence (`src/lifeops/first-run/state.ts`) and the resume merge in
+ * `FirstRunService.runCustomizePath` (`persistCustomizePartials` +
+ * `nextCustomizeQuestion`).
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  abandonResumeNoDataLoss,
+  resetFirstRunPrecondition,
+} from "./_helpers/first-run-onboarding.ts";
+
+export default scenario({
+  lane: "live-only",
+  id: "first-run-abandon-resume-no-data-loss",
+  title: "First-run resume: abandon mid-customize → resume with no re-asking",
+  domain: "lifeops.first-run",
+  tags: ["lifeops", "first-run", "onboarding", "resume", "mvp", "14353"],
+  status: "active",
+  tier: "T3",
+  isolation: "per-scenario",
+  requires: { plugins: ["@elizaos/plugin-personal-assistant"] },
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "First open (interrupted)",
+    },
+  ],
+  seed: [
+    {
+      type: "custom",
+      name: "reset first-run to fresh pending",
+      apply: resetFirstRunPrecondition,
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "owner starts customize then gets pulled away",
+      text: "let's customize. call me Riley, i'm in America/Chicago, mornings 7 to noon. actually hold on, someone's at the door — brb.",
+    },
+    {
+      kind: "message",
+      name: "owner returns to finish",
+      text: "ok i'm back — where were we? let's keep going with the setup.",
+    },
+  ],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "resume-preserves-answers-no-reask",
+      predicate: abandonResumeNoDataLoss,
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/first-run-channel-fallback-to-in-app.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/first-run-channel-fallback-to-in-app.scenario.ts
@@ -1,0 +1,62 @@
+/**
+ * Onboarding journey — channel answer for a channel with no connected
+ * dispatcher. The owner picks a notification channel (telegram) that is not
+ * connected in this runtime; onboarding must record the choice with
+ * `fallbackToInApp: true` and surface a warning rather than silently promising
+ * delivery it cannot make. The LIVE message turn records the model's handling
+ * (trajectory evidence); pass/fail is the DOMAIN contract, since first-run is
+ * conductor-driven, not model-invocable. The final check asserts both the raw
+ * `validateChannel` contract and that the surfaced first-run result carries the
+ * fallback warning + a "(fallback)" completion message, then confirms the
+ * default pack still seeded.
+ *
+ * Fail-without-fix anchor: `validateChannel` + the `ChannelInspector`
+ * connectivity check (`src/lifeops/first-run/questions.ts`, header contract)
+ * and `installFirstRunChannelInspector` (`.../first-run/channel-inspector.ts`).
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  channelFallbackRecorded,
+  resetFirstRunPrecondition,
+} from "./_helpers/first-run-onboarding.ts";
+
+export default scenario({
+  lane: "live-only",
+  id: "first-run-channel-fallback-to-in-app",
+  title: "First-run channel fallback: unconnected channel → in-app + warning",
+  domain: "lifeops.first-run",
+  tags: ["lifeops", "first-run", "onboarding", "channel", "mvp", "14353"],
+  status: "active",
+  tier: "T4",
+  isolation: "per-scenario",
+  requires: { plugins: ["@elizaos/plugin-personal-assistant"] },
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "First open (channel choice)",
+    },
+  ],
+  seed: [
+    {
+      type: "custom",
+      name: "reset first-run to fresh pending",
+      apply: resetFirstRunPrecondition,
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "owner asks to be nudged on an unconnected channel",
+      text: "set me up, but send my nudges over Telegram — that's where i live.",
+    },
+  ],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "unconnected-channel-falls-back-with-warning",
+      predicate: channelFallbackRecorded,
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/first-run-customize-walk-seeds-first-reminder.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/first-run-customize-walk-seeds-first-reminder.scenario.ts
@@ -1,0 +1,68 @@
+/**
+ * Onboarding journey — customize (5-question) path. A fresh owner opts to
+ * customize; the LIVE message turns exercise the model with the onboarding
+ * affordance surfaced (recorded trajectory = the "walk the user through"
+ * evidence), while the final check drives the real `FirstRunService` through all
+ * five questions, including the CONDITIONAL relationships question that fires
+ * only because `follow-ups` is among the selected categories.
+ *
+ * Pass/fail is the DOMAIN outcome, not chat text (first-run is conductor-driven,
+ * not model-invocable): the final check asserts the seeded default pack in the
+ * real scheduled-task store, anchored to the answered morning window, via
+ * `LifeOpsRepository`.
+ *
+ * Fail-without-fix anchor: `FirstRunService.runCustomizePath` +
+ * `nextCustomizeQuestion` conditional gating (`src/lifeops/first-run/service.ts`)
+ * and the `relationships.shouldAsk` predicate (`.../first-run/questions.ts`).
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  customizeFullWalkSeedsReminders,
+  resetFirstRunPrecondition,
+} from "./_helpers/first-run-onboarding.ts";
+
+export default scenario({
+  lane: "live-only",
+  id: "first-run-customize-walk-seeds-first-reminder",
+  title: "First-run customize: full 5-question walk → first reminder seeded",
+  domain: "lifeops.first-run",
+  tags: ["lifeops", "first-run", "onboarding", "customize", "mvp", "14353"],
+  status: "active",
+  tier: "T2",
+  isolation: "per-scenario",
+  requires: { plugins: ["@elizaos/plugin-personal-assistant"] },
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "First open (customize)",
+    },
+  ],
+  seed: [
+    {
+      type: "custom",
+      name: "reset first-run to fresh pending",
+      apply: resetFirstRunPrecondition,
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "owner chooses to customize",
+      text: "i'd rather customize my setup than take the defaults — walk me through the options.",
+    },
+    {
+      kind: "message",
+      name: "owner supplies preferences incl. follow-ups",
+      text: "call me Sam. i'm in America/Los_Angeles, morning is roughly 6:30 to 11:30, evening 6 to 10pm. turn on reminder packs and follow-ups. nudge me in-app. for follow-ups: Alice every 2 weeks, Bob monthly.",
+    },
+  ],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "customize-walk-conditional-q5-and-seeded-pack",
+      predicate: customizeFullWalkSeedsReminders,
+    },
+  ],
+});

--- a/plugins/plugin-personal-assistant/test/scenarios/first-run-fast-start-seeds-first-reminder.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/first-run-fast-start-seeds-first-reminder.scenario.ts
@@ -1,0 +1,69 @@
+/**
+ * Onboarding journey — fast-start (defaults) path. A fresh owner asks to be set
+ * up quickly. The message turns run against the LIVE model with the
+ * `firstRunProvider` affordance surfaced (the seed restores fresh `pending`
+ * state), so the recorded trajectory shows the live model engaging with
+ * onboarding — the "walk the user through" evidence.
+ *
+ * Pass/fail is the DOMAIN outcome, not chat text: first-run is conductor-driven,
+ * not model-invocable (no planner action seeds it), so the model's improvised
+ * reply is not the asserted contract. The final check drives the real
+ * `FirstRunService` through the production runner (the seam the in-chat
+ * conductor uses) and asserts `app_lifeops.life_scheduled_tasks` via
+ * `LifeOpsRepository`: the default pack (gm/gn/checkin/morning-brief)
+ * materializes and the gm reminder's cron is anchored to the answered wake time.
+ *
+ * Fail-without-fix anchor: `FirstRunService.runDefaultsPath` + `buildDefaultsPack`
+ * (`src/lifeops/first-run/defaults.ts`).
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+import {
+  fastStartSeedsFirstReminder,
+  resetFirstRunPrecondition,
+} from "./_helpers/first-run-onboarding.ts";
+
+export default scenario({
+  lane: "live-only",
+  id: "first-run-fast-start-seeds-first-reminder",
+  title: "First-run fast-start: defaults + wake time → first reminder seeded",
+  domain: "lifeops.first-run",
+  tags: ["lifeops", "first-run", "onboarding", "mvp", "14353"],
+  status: "active",
+  tier: "T2",
+  isolation: "per-scenario",
+  requires: { plugins: ["@elizaos/plugin-personal-assistant"] },
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      channelType: "DM",
+      title: "First open",
+    },
+  ],
+  seed: [
+    {
+      type: "custom",
+      name: "reset first-run to fresh pending",
+      apply: resetFirstRunPrecondition,
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "owner asks to be set up fast",
+      text: "hey — just installed you. can you get me set up? i don't want to fiddle with a bunch of settings, just the sensible defaults.",
+    },
+    {
+      kind: "message",
+      name: "owner answers wake time",
+      text: "i usually wake up around 6:30am",
+    },
+  ],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "defaults-pack-seeded-anchored-to-wake",
+      predicate: fastStartSeedsFirstReminder("6:30am"),
+    },
+  ],
+});


### PR DESCRIPTION
## What

Authors a `lane: "live-only"` scenario pack for the **first-run onboarding journey** — the funnel's first mile — covering both entry paths, each ending in the owner's **first reminder actually materializing**:

| Scenario | Path | Domain outcome asserted |
| --- | --- | --- |
| `first-run-fast-start-seeds-first-reminder` | fast-start (defaults) | one wake-time answer → default pack seeded; **gm cron anchored to the answered wake time**, gn at 22:00, morning brief on the `wake.confirmed` anchor, check-in `kind` |
| `first-run-customize-walk-seeds-first-reminder` | customize (5 questions) | full walk incl. the **conditional relationships question** (fires only because `follow-ups` is selected) → default pack seeded, anchored to the answered morning window, preferred name persisted |
| `first-run-abandon-resume-no-data-loss` | resume | answer Q1+Q2, abandon, resume on a fresh service instance → **advances to the first unanswered question, no re-asking** → first reminder seeded, anchored to the pre-abandon answer |
| `first-run-channel-fallback-to-in-app` | channel fallback | an unconnected channel → recorded with `fallbackToInApp: true`, warning surfaced, `(fallback)` completion message, pack still seeded |

New files: 4 `.scenario.ts` + one shared helper (`_helpers/first-run-onboarding.ts`). No first-run behavior or question wording changed.

## Why / how it works

First-run is **conductor-driven, not model-invocable** — there is no planner action the model can select to seed it; the affordance only reaches the model through `firstRunProvider`. So each scenario **splits the proof**:

- **Live message turns** exercise the model with the onboarding affordance surfaced (recorded trajectory = the "walk the user through" evidence). The seed step restores fresh `pending` state, since `createScenarioRuntime` force-marks first-run `complete`.
- A **custom final check owns pass/fail** by driving the real `FirstRunService` through the **production scheduled-task runner** — the same seam the in-chat conductor uses — then asserting `app_lifeops.life_scheduled_tasks` via `LifeOpsRepository`. This is the DOMAIN artifact ("outcome, not routing"), never chat text.

The conversational layer is deliberately **not** judged: because first-run isn't model-driven, the improvised replies vary widely run-to-run (see trajectories below), so gating on them would be flaky and would not prove the contract. The deterministic domain check is the contract.

Closes #14353

## Acceptance criteria

- [x] 4+ scenarios covering fast-start, full customize, resume-after-abandon, and channel-fallback — **authored + verified live**.
- [x] Final checks assert seeded `ScheduledTask` records (ids from `DEFAULT_PACK_IDEMPOTENCY_KEYS`) with anchors **derived from the answered wake time** — outcome, not routing.
- [x] Resume scenario proves no re-asking of already-answered questions (fresh `FirstRunService` resumes at `categories`).
- [x] No changes to question wording or first-run behavior.

> Note on record-ids: `FirstRunService.runDefaultsPath`/`runCustomizePath` seed the **first-run defaults pack** (`buildDefaultsPack` → `DEFAULT_PACK_IDEMPOTENCY_KEYS`, cron-anchored to the wake time), which is the code path onboarding actually exercises — asserted here. The separately-seeded `daily-rhythm` pack (boot seeder / spine registry) is disabled in the scenario runtime and is out of scope for these onboarding paths.

## Evidence — real live-model run (Cerebras `gpt-oss-120b` via the openai provider), on the `develop` base

All four pass; each `custom` domain check returned `undefined` (= pass) against the real scheduled-task store.

```
PASSED | first-run-fast-start-seeds-first-reminder     | 44100ms | domain-check: PASS
PASSED | first-run-customize-walk-seeds-first-reminder | 13404ms | domain-check: PASS
PASSED | first-run-abandon-resume-no-data-loss         |  8202ms | domain-check: PASS
PASSED | first-run-channel-fallback-to-in-app          | 14197ms | domain-check: PASS
```

Run command (per-scenario isolation, no LLM proxy):
```
bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/cli.ts \
  run ../../plugins/plugin-personal-assistant/test/scenarios \
  --scenario <id> --report <out>.json --run-dir <out>
```

<details><summary>Live model trajectories (verbatim — why the conversational layer isn't judged)</summary>

```
### fast-start
user[asks to be set up fast] -> "Welcome! I'll take care of the basics so you can start using me right away. I'll enable the sensible-default settings, set up any required initial configuration..."
user[answers wake time]      -> "Got it--your typical wake-up time is around 6:30 am. Would you like me to set an alarm for that time or create a morning routine for you?"

### customize
user[chooses to customize]   -> "Sure! Here's a quick guide to customizing your setup instead of using the default options: 1. Identify What You Want to Change..."
user[supplies preferences]   -> "I couldn't schedule the task because the trigger type is missing..."   <- model has no first-run action; improvises

### abandon/resume
user[starts then pulled away]-> "I ran ENTITY and got a result, but I couldn't format the details cleanly here. On it."
user[returns to finish]      -> "Welcome back, Riley! We're all set with your name, time zone (America/Chicago), and morning hours (7 am-noon). What's next?"

### channel fallback
user[unconnected channel]    -> "I can't schedule that task yet; I need promptInstructions describing what the task should actually do..."
```

These are genuine live outputs — variable and sometimes off, precisely because onboarding is not model-driven. Pass/fail therefore rests on the domain checks, not these replies.
</details>

<details><summary>Domain-artifact assertions (what the custom checks verify against the real store)</summary>

The helper drives `FirstRunService` with `getScheduledTaskRunner(...)` (production runner) and reads back via `LifeOpsRepository.listScheduledTasks(agentId, { source: "first_run" })`:

- **fast-start** (`"6:30am"` -> `06:30`): gm trigger is `cron` `"30 6 * * *"` (derived from the answered wake time); gn `"0 22 * * *"`; morning brief `relative_to_anchor` `anchorKey: "wake.confirmed"`; check-in `kind === "checkin"`.
- **customize**: awaiting-question order `preferredName -> timezoneAndWindows -> categories -> channel -> relationships` (Q5 fires only with `follow-ups`); preferred name persisted; pack anchored to morning-window start `06:30`.
- **abandon/resume**: after Q1+Q2 the record is `in_progress` with `partialAnswers.preferredName === "Riley"`; a fresh `FirstRunService` with no input resumes at `categories` (not `preferredName`); name survives to completion; pack anchored to `07:00`.
- **channel fallback**: `validateChannel("telegram", runtime).fallbackToInApp === true` with a fallback warning; the customize result carries a fallback warning + `(fallback)` completion message; pack still seeded.
</details>

## PR_EVIDENCE

| Evidence | Status |
| --- | --- |
| Real-LLM trajectories | done — live Cerebras run, 4/4 pass — excerpts inline above |
| Backend structured logs | done — `[PLUGIN:SQL]` migrations, `[eliza-scenarios] passed`, `[Migration]` in run output |
| Domain artifacts | done — seeded `ScheduledTask` rows asserted in `app_lifeops.life_scheduled_tasks` (the custom checks) |
| Before/after screenshots + video | N/A — scenario-runner test-authoring change; no UI surface added or modified |
| Per-platform (native/mobile/desktop) capture | N/A — no native/UI change |
| Audio walkthrough | N/A — no voice/TTS/STT change |

Scoped verify: `bunx biome check` clean on all 5 changed files. (Repo-wide `scenario-runner typecheck` surfaces only pre-existing `@elizaos/shared/*` subpath resolution errors in `plugin-local-inference`, unrelated to these files.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
