### PR TITLE
fix(lifeops): make fact bridge structured-field driven

### DIFF
--- a/packages/core/src/features/advanced-capabilities/evaluators/factExtractor.schema.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/factExtractor.schema.ts
@@ -79,13 +79,13 @@ const AddDurableOpSchema = z.object({
 	op: z.literal("add_durable"),
 	claim: z.string().min(1),
 	category: DurableCategoryEnum,
-	// `.default({})`, NOT required: the advertised wire schema (reflection-items
-	// factOpsSchema) marks structured_fields optional (only `op` is required)
-	// and the extractor prompt never even names the field, so the model omits it
-	// on most turns. A required schema here rejected those ops — and because the
-	// whole `ops` array was parsed atomically, one omission silently discarded
-	// EVERY fact op for the turn. The default keeps the inferred type a
-	// non-optional record so downstream applyAddDurable stays type-safe.
+	// `.default({})`, NOT required: the advertised wire schema
+	// (reflection-items factOpsSchema) keeps structured_fields optional so
+	// claim-only fact ops still parse. A required schema here rejected those ops
+	// — and because the whole `ops` array was parsed atomically, one omission
+	// silently discarded EVERY fact op for the turn. The default keeps the
+	// inferred type a non-optional record so downstream applyAddDurable stays
+	// type-safe.
 	structured_fields: StructuredFieldsSchema.default({}),
 	keywords: KeywordsSchema,
 	verification_status: VerificationStatusEnum.optional(),
@@ -96,7 +96,7 @@ const AddCurrentOpSchema = z.object({
 	op: z.literal("add_current"),
 	claim: z.string().min(1),
 	category: CurrentCategoryEnum,
-	// See AddDurableOpSchema: wire-optional + prompt-unnamed → default, not required.
+	// See AddDurableOpSchema: wire-optional → default, not required.
 	structured_fields: StructuredFieldsSchema.default({}),
 	keywords: KeywordsSchema,
 	/**

--- a/packages/core/src/features/advanced-capabilities/evaluators/factExtractor.schema.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/factExtractor.schema.ts
@@ -159,6 +159,35 @@ export const ExtractorOutputSchema = z.object({
 
 export type ExtractorOutput = z.infer<typeof ExtractorOutputSchema>;
 
+function unwrapJsonFence(text: string): string {
+	const trimmed = text.trim();
+	if (!trimmed.startsWith("```")) return trimmed;
+	const firstLineEnd = trimmed.indexOf("\n");
+	if (firstLineEnd < 0) return "";
+	const closingFence = trimmed.lastIndexOf("```");
+	if (closingFence <= firstLineEnd) return "";
+	return trimmed.slice(firstLineEnd + 1, closingFence).trim();
+}
+
+function coerceExtractorOutput(output: unknown): unknown {
+	if (typeof output !== "string") return output;
+	const candidate = unwrapJsonFence(output);
+	if (!candidate) return output;
+	try {
+		return JSON.parse(candidate);
+	} catch {
+		// error-policy:J3 Model output may be plain text; invalid JSON falls through to the typed invalid parse result.
+		return output;
+	}
+}
+
+function normalizeExtractorOp(raw: unknown): unknown {
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) return raw;
+	const record = raw as Record<string, unknown>;
+	if (record.op !== undefined || typeof record.type !== "string") return raw;
+	return { ...record, op: record.type };
+}
+
 /**
  * Parse the extractor envelope tolerantly, op-by-op.
  *
@@ -180,12 +209,14 @@ export type ExtractorOutput = z.infer<typeof ExtractorOutputSchema>;
 export function parseExtractorOutputTolerant(
 	output: unknown,
 ): ExtractorOutput | null {
-	const envelope = z.object({ ops: z.array(z.unknown()) }).safeParse(output);
+	const envelope = z
+		.object({ ops: z.array(z.unknown()) })
+		.safeParse(coerceExtractorOutput(output));
 	if (!envelope.success) return null;
 	const ops: ExtractorOp[] = [];
 	const issues: string[] = [];
 	for (const raw of envelope.data.ops) {
-		const parsed = OpSchema.safeParse(raw);
+		const parsed = OpSchema.safeParse(normalizeExtractorOp(raw));
 		if (parsed.success) {
 			ops.push(parsed.data);
 		} else {

--- a/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.test.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.test.ts
@@ -282,6 +282,36 @@ describe("factExtractor tolerant parsing (#11235)", () => {
 		});
 	});
 
+	it("accepts fenced JSON text that uses type as the op discriminator", () => {
+		const parsed = parseExtractorOutputTolerant(`\`\`\`json
+{
+  "ops": [
+    {
+      "type": "add_durable",
+      "claim": "User's preferred name is Camille and timezone is Europe/Paris.",
+      "category": "identity",
+      "keywords": ["name", "camille", "timezone", "europe/paris"],
+      "structured_fields": {
+        "preferredName": "Camille",
+        "timezone": "Europe/Paris"
+      }
+    }
+  ]
+}
+\`\`\``);
+
+		expect(parsed?.ops).toEqual([
+			expect.objectContaining({
+				op: "add_durable",
+				category: "identity",
+				structured_fields: {
+					preferredName: "Camille",
+					timezone: "Europe/Paris",
+				},
+			}),
+		]);
+	});
+
 	it("keeps valid ops when one op is malformed, and warns about the drop", () => {
 		// The evaluator parse contract (`parse?(output): TOutput | null`) has no
 		// runtime/logger, so the drop MUST be logged where it is computed —

--- a/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.test.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.test.ts
@@ -212,10 +212,62 @@ describe("reflection evaluator schemas are strict-structured-output safe", () =>
 			assertStrictObjectNodes(schema, evaluator.name ?? "evaluator");
 		}
 	});
+
+	it("fact extraction advertises structured fields consumed by LifeOps projections", () => {
+		const schema = factMemoryEvaluator.schema as {
+			properties?: {
+				ops?: {
+					items?: {
+						properties?: {
+							structured_fields?: {
+								properties?: Record<string, unknown>;
+								additionalProperties?: boolean;
+							};
+						};
+					};
+				};
+			};
+		};
+		const structured =
+			schema.properties?.ops?.items?.properties?.structured_fields;
+		expect(structured?.additionalProperties).toBe(false);
+		expect(structured?.properties).toMatchObject({
+			preferredName: { type: "string" },
+			person: { type: "string" },
+			relationshipType: { type: "string" },
+			platform: { type: "string" },
+			handle: { type: "string" },
+			travelBookingPreferences: { type: "string" },
+			timezone: { type: "string" },
+		});
+	});
+
+	it("fact extraction prompt names structured fields on the production evaluator path", () => {
+		const prompt = factMemoryEvaluator.prompt?.({
+			runtime: makeRuntime(),
+			message: message(
+				"Je m'appelle Camille et mon fuseau horaire est Europe/Paris",
+			),
+			state: { values: {}, data: {}, text: "" },
+			options: {},
+			evaluatorName: "factMemory",
+			prepared: {
+				recentMessages: [message("Je m'appelle Camille")],
+				existingRelationships: [],
+				entities: [],
+				knownFacts: [],
+			},
+		});
+		expect(prompt).toContain("structured_fields");
+		expect(prompt).toContain("Use English key names");
+		expect(prompt).toContain("preferredName");
+		expect(prompt).toContain("relationshipType");
+		expect(prompt).toContain("travelBookingPreferences");
+	});
 });
 
 describe("factExtractor tolerant parsing (#11235)", () => {
-	it("accepts an add op that omits structured_fields (wire-optional, prompt-unnamed)", () => {
+	it("accepts an add op that omits structured_fields (wire-optional)", () => {
 		const parsed = parseExtractorOutputTolerant({
 			ops: [
 				{ op: "add_durable", claim: "lives in Berlin", category: "identity" },

--- a/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts
@@ -83,6 +83,66 @@ export const NEW_FACT_CONFIDENCE = 0.7;
 export const DEDUP_SIMILARITY_THRESHOLD = 0.42;
 const IDENTITY_CONFIDENCE_THRESHOLD = 0.5;
 
+const structuredFieldProperties: Record<string, JSONSchema> = {
+	preferredName: { type: "string" },
+	orientation: { type: "string" },
+	gender: { type: "string" },
+	age: { type: "string" },
+	location: { type: "string" },
+	city: { type: "string" },
+	homeCity: { type: "string" },
+	home_location: { type: "string" },
+	timezone: { type: "string" },
+	timeZone: { type: "string" },
+	ianaTimezone: { type: "string" },
+	relationshipStatus: { type: "string" },
+	status: { type: "string" },
+	partnerName: { type: "string" },
+	partner: { type: "string" },
+	spouse: { type: "string" },
+	person: { type: "string" },
+	name: { type: "string" },
+	target: { type: "string" },
+	relatedPerson: { type: "string" },
+	relationshipType: { type: "string" },
+	relationship: { type: "string" },
+	role: { type: "string" },
+	type: { type: "string" },
+	manager: { type: "string" },
+	boss: { type: "string" },
+	platform: { type: "string" },
+	service: { type: "string" },
+	network: { type: "string" },
+	handle: { type: "string" },
+	username: { type: "string" },
+	account: { type: "string" },
+	profile: { type: "string" },
+	company: { type: "string" },
+	organization: { type: "string" },
+	employer: { type: "string" },
+	locale: { type: "string" },
+	languageLocale: { type: "string" },
+	preferredNotificationChannel: { type: "string" },
+	channel: { type: "string" },
+	travelBookingPreferences: { type: "string" },
+	travelPreference: { type: "string" },
+	bookingPreference: { type: "string" },
+	condition: { type: "string" },
+	source: { type: "string" },
+	emotion: { type: "string" },
+	window: { type: "string" },
+	event: { type: "string" },
+	to: { type: "string" },
+	goal: { type: "string" },
+	domain: { type: "string" },
+};
+
+const structuredFieldsSchema: JSONSchema = {
+	type: "object",
+	properties: structuredFieldProperties,
+	additionalProperties: false,
+};
+
 const factOpsSchema: JSONSchema = {
 	type: "object",
 	properties: {
@@ -103,19 +163,11 @@ const factOpsSchema: JSONSchema = {
 					},
 					claim: { type: "string" },
 					category: { type: "string" },
-					// Strict-mode JSON schema validators (Groq, Cerebras, OpenAI strict
-					// tools) require every nested object to carry
-					// `additionalProperties: false` AND an explicit `properties` map —
-					// an object node without `properties` is rejected outright
-					// ("Bad Request"), which kills the whole extraction call. We accept
-					// this means no extra keys land in `structured_fields` — the field
-					// stays for API contract, the model can always omit it (not in
-					// `required`).
-					structured_fields: {
-						type: "object",
-						properties: {},
-						additionalProperties: false,
-					},
+					// Strict-mode JSON schema validators require every object node to
+					// be closed. The prompt maps category-specific values into this
+					// finite key set so downstream projections can consume structured
+					// facts without reparsing language-specific claim text.
+					structured_fields: structuredFieldsSchema,
 					// No maxItems: strict structured-output validators (Cerebras, OpenAI
 					// strict) reject array length constraints outright — the whole
 					// extraction request 400s. The 16-keyword cap is enforced in code
@@ -912,6 +964,14 @@ Rules:
 - Contradiction -> contradict with factId + reason.
 - Use only fact IDs shown below for strengthen, decay, and contradict.
 - add_durable/add_current keywords: 3-8 lowercase retrieval terms from claim/category/nouns/places/dates/projects/symptoms/preferences. Omit stopwords/generic.
+- add_durable/add_current structured_fields: flat string values from the claim. Use English key names even when the message is in another language.
+  identity: preferredName, location/city, timezone, locale, orientation, gender, age.
+  relationship: person or partnerName, relationshipType, relationshipStatus, platform, handle.
+  business_role: company/organization/employer, person, relationshipType, role.
+  preference: preferredNotificationChannel, travelBookingPreferences, locale.
+  health/current state: condition, source, emotion, window.
+  life_event/goal: event, to, goal, domain.
+  Omit unknown fields; do not invent values.
 
 Recent messages:
 ${formatRecentMessages(prepared.recentMessages)}

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -357,6 +357,18 @@ For add_durable/add_current, include keywords: 3-8 lowercase retrieval terms.
 Use stable nouns, proper names, symptoms, places, projects, dates, and
 preferences. Omit stopwords and generic words.
 
+For add_durable/add_current, fill structured_fields with flat string values
+whenever the claim contains them. Use these English key names even when the
+message is in another language:
+- identity: preferredName, location/city, timezone, locale, orientation, gender, age.
+- relationship: person or partnerName, relationshipType, relationshipStatus,
+  platform, handle.
+- business_role: company/organization/employer, person, relationshipType, role.
+- preference: preferredNotificationChannel, travelBookingPreferences, locale.
+- health/current state: condition, source, emotion, window.
+- life_event/goal: event, to, goal, domain.
+Omit unknown fields; do not invent values. Examples: "mi jefe es Pat" -> {"person":"Pat","relationshipType":"manager"}; "Je m'appelle Camille" -> {"preferredName":"Camille"}.
+
 Examples:
 
 Message: "I have a flat cortisol curve confirmed via lab"

--- a/packages/prompts/test/prompts.test.js
+++ b/packages/prompts/test/prompts.test.js
@@ -129,6 +129,30 @@ describe("prompt templates (src/index.ts)", () => {
     }
   });
 
+  it("factExtractionTemplate names structured fields for multilingual LifeOps projection", () => {
+    const body = prompts.factExtractionTemplate;
+    assert.match(
+      body,
+      /Use these English key names even when the\s+message is in another language/,
+      "fact extractor should preserve English structured-field keys across locales",
+    );
+    assert.match(
+      body,
+      /"mi jefe es Pat" -> \{"person":"Pat","relationshipType":"manager"\}/,
+      "relationship facts should include person + relationshipType without English regex parsing",
+    );
+    assert.match(
+      body,
+      /"Je m'appelle Camille" -> \{"preferredName":"Camille"\}/,
+      "identity facts should include preferredName for non-English self-introductions",
+    );
+    assert.match(
+      body,
+      /relationship: person or partnerName, relationshipType, relationshipStatus,\s+platform, handle/,
+      "relationship structured fields should include graph and identity-handle keys",
+    );
+  });
+
   it("templates have balanced Handlebars delimiters", () => {
     const src = readSrc();
     const opens = (src.match(/\{\{/g) || []).length;

--- a/packages/scenario-runner/test/scenarios/live-fact-memory-structured-fields.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-fact-memory-structured-fields.scenario.ts
@@ -1,0 +1,132 @@
+/**
+ * Live-only guard for the factMemory evaluator's structured field contract.
+ * It calls the production evaluator prompt/schema through the scenario
+ * runtime's real TEXT_SMALL provider, then asserts the parsed output contains
+ * the multilingual profile fields consumed by LifeOps projections.
+ */
+
+import {
+  type IAgentRuntime,
+  type Memory,
+  ModelType,
+  type UUID,
+} from "@elizaos/core";
+import { scenario } from "@elizaos/scenario-runner/schema";
+import { factMemoryEvaluator } from "../../../core/src/features/advanced-capabilities/evaluators/reflection-items.ts";
+
+const agentId = "00000000-0000-0000-0000-0000000000aa" as UUID;
+const entityId = "00000000-0000-0000-0000-0000000000bb" as UUID;
+const roomId = "00000000-0000-0000-0000-0000000000cc" as UUID;
+
+function message(text: string): Memory {
+  return {
+    id: "00000000-0000-0000-0000-0000000000dd" as UUID,
+    entityId,
+    agentId,
+    roomId,
+    content: { text },
+    createdAt: Date.now(),
+  };
+}
+
+function asRuntime(value: unknown): IAgentRuntime {
+  if (!value || typeof value !== "object" || !("useModel" in value)) {
+    throw new Error("scenario runtime did not expose useModel");
+  }
+  return value as IAgentRuntime;
+}
+
+function readRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+async function requestFactOps(runtime: IAgentRuntime, prompt: string) {
+  const messages = [{ role: "user" as const, content: prompt }];
+  try {
+    return await runtime.useModel(ModelType.TEXT_SMALL, {
+      messages,
+      responseSchema: factMemoryEvaluator.schema,
+      responseFormat: { type: "json_object" },
+      temperature: 0,
+    });
+  } catch (error) {
+    runtime.logger.warn(
+      { error },
+      "[live-fact-memory-structured-fields] schema request failed; retrying json_object fallback",
+    );
+    return runtime.useModel(ModelType.TEXT_SMALL, {
+      messages,
+      responseFormat: { type: "json_object" },
+      temperature: 0,
+    });
+  }
+}
+
+function includesExpectedProfileFields(output: unknown): string | undefined {
+  const parsed = factMemoryEvaluator.parse?.(output);
+  if (!parsed || !Array.isArray(parsed.ops)) {
+    return `expected parsed ops array, saw ${JSON.stringify(output)}`;
+  }
+
+  const fields = parsed.ops
+    .filter((op) => op.op === "add_durable")
+    .map((op) => readRecord(op.structured_fields));
+  const hasPreferredName = fields.some(
+    (field) => field.preferredName === "Camille",
+  );
+  const hasTimezone = fields.some((field) => field.timezone === "Europe/Paris");
+  const hasManager = fields.some(
+    (field) => field.person === "Pat" && field.relationshipType === "manager",
+  );
+  const hasSlackHandle = fields.some(
+    (field) => field.platform === "slack" && field.handle === "@pat-ops",
+  );
+
+  if (hasPreferredName && hasTimezone && hasManager && hasSlackHandle) {
+    return undefined;
+  }
+  return `expected preferredName=Camille, timezone=Europe/Paris, person=Pat, relationshipType=manager, platform=slack, handle=@pat-ops in structured_fields; saw ${JSON.stringify(parsed.ops)}`;
+}
+
+export default scenario({
+  id: "live-fact-memory-structured-fields",
+  lane: "live-only",
+  title: "Fact memory live extraction emits structured LifeOps fields",
+  domain: "lifeops",
+  tags: ["lifeops", "fact-memory", "live-llm"],
+  description:
+    "Calls the production factMemory evaluator prompt/schema with multilingual owner facts and verifies the live model returns structured_fields consumed by LifeOps.",
+  isolation: "per-scenario",
+
+  seed: [
+    {
+      type: "custom",
+      name: "run-live-fact-memory-extraction",
+      apply: async (ctx) => {
+        const runtime = asRuntime(ctx.runtime);
+        const ownerMessage = message(
+          "Je m'appelle Camille, mi jefe es Pat y su Slack es @pat-ops. Mi zona horaria es Europe/Paris.",
+        );
+        const prompt = factMemoryEvaluator.prompt?.({
+          runtime,
+          message: ownerMessage,
+          state: { values: {}, data: {}, text: "" },
+          options: {},
+          evaluatorName: "factMemory",
+          prepared: {
+            recentMessages: [ownerMessage],
+            existingRelationships: [],
+            entities: [],
+            knownFacts: [],
+          },
+        });
+        if (!prompt) return "factMemory evaluator did not produce a prompt";
+        const output = await requestFactOps(runtime, prompt);
+        return includesExpectedProfileFields(output);
+      },
+    },
+  ],
+  turns: [],
+});

--- a/packages/scenario-runner/test/scenarios/live-fact-memory-structured-fields.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-fact-memory-structured-fields.scenario.ts
@@ -78,16 +78,23 @@ function includesExpectedProfileFields(output: unknown): string | undefined {
   );
   const hasTimezone = fields.some((field) => field.timezone === "Europe/Paris");
   const hasManager = fields.some(
-    (field) => field.person === "Pat" && field.relationshipType === "manager",
+    (field) =>
+      field.person === "Pat" &&
+      (field.relationshipType === "manager" ||
+        field.role === "manager" ||
+        field.role === "boss"),
   );
   const hasSlackHandle = fields.some(
-    (field) => field.platform === "slack" && field.handle === "@pat-ops",
+    (field) =>
+      typeof field.platform === "string" &&
+      field.platform.toLowerCase() === "slack" &&
+      field.handle === "@pat-ops",
   );
 
   if (hasPreferredName && hasTimezone && hasManager && hasSlackHandle) {
     return undefined;
   }
-  return `expected preferredName=Camille, timezone=Europe/Paris, person=Pat, relationshipType=manager, platform=slack, handle=@pat-ops in structured_fields; saw ${JSON.stringify(parsed.ops)}`;
+  return `expected preferredName=Camille, timezone=Europe/Paris, person=Pat, manager/boss role, platform=slack, handle=@pat-ops in structured_fields; saw ${JSON.stringify(parsed.ops)}`;
 }
 
 export default scenario({

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/core-fact-memory-bridge.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/core-fact-memory-bridge.test.ts
@@ -39,6 +39,16 @@ function makeRuntime(): IAgentRuntime & {
   cache: Map<string, unknown>;
 } {
   const cache = new Map<string, unknown>();
+  const agents = new Map<string, unknown>();
+  const tasks: Array<{
+    id: UUID;
+    name?: string;
+    description?: string;
+    roomId?: UUID;
+    tags?: string[];
+    metadata?: Record<string, unknown>;
+    dueAt?: number;
+  }> = [];
   const hooks: Array<{
     id: string;
     handler: (runtime: IAgentRuntime, ctx: unknown) => Promise<void>;
@@ -67,6 +77,48 @@ function makeRuntime(): IAgentRuntime & {
     registerPipelineHook: vi.fn(
       (spec: { id: string; handler: (typeof hooks)[number]["handler"] }) => {
         hooks.push(spec);
+      },
+    ),
+    getService: vi.fn(() => null),
+    getAgent: vi.fn(async (id: UUID) => agents.get(id) ?? null),
+    createAgent: vi.fn(async (agent: { id?: UUID }) => {
+      if (agent.id) agents.set(agent.id, agent);
+      return true;
+    }),
+    getTasks: vi.fn(async (query?: { agentIds?: UUID[]; tags?: string[] }) => {
+      if (!query?.tags || query.tags.length === 0) return [...tasks];
+      return tasks.filter((task) =>
+        query.tags?.every((tag) => task.tags?.includes(tag)),
+      );
+    }),
+    createTask: vi.fn(
+      async (task: {
+        name?: string;
+        description?: string;
+        roomId?: UUID;
+        tags?: string[];
+        metadata?: Record<string, unknown>;
+        dueAt?: number;
+      }) => {
+        const id =
+          `99999999-9999-4999-8999-${String(tasks.length + 1).padStart(12, "0")}` as UUID;
+        tasks.push({ ...task, id });
+        return id;
+      },
+    ),
+    updateTask: vi.fn(
+      async (
+        id: UUID,
+        patch: {
+          description?: string;
+          metadata?: Record<string, unknown>;
+        },
+      ) => {
+        const task = tasks.find((candidate) => candidate.id === id);
+        if (task) {
+          Object.assign(task, patch);
+        }
+        return true;
       },
     ),
     hooks,
@@ -217,24 +269,28 @@ beforeEach(() => {
 });
 
 describe("bridgeCoreFactMemory", () => {
-  it("projects core identity facts into the OwnerFactStore with agent provenance", async () => {
+  it("projects structured non-English identity facts into the OwnerFactStore with agent provenance", async () => {
     const runtime = makeRuntime();
     const result = await bridgeCoreFactMemory(
       runtime,
       factMemory({
         id: "44444444-4444-4444-4444-444444444444" as UUID,
-        text: "timezone is Europe/Berlin",
+        text: "Je m'appelle Camille et mon fuseau horaire est Europe/Paris",
         category: "identity",
-        structuredFields: { timezone: "Europe/Berlin" },
+        structuredFields: {
+          preferredName: "Camille",
+          timezone: "Europe/Paris",
+        },
       }),
     );
 
     expect(result).toMatchObject({
       skipped: false,
-      ownerFactKeys: ["timezone"],
+      ownerFactKeys: ["preferredName", "timezone"],
     });
     const facts = await resolveOwnerFactStore(runtime).read();
-    expect(facts.timezone?.value).toBe("Europe/Berlin");
+    expect(facts.preferredName?.value).toBe("Camille");
+    expect(facts.timezone?.value).toBe("Europe/Paris");
     expect(facts.timezone?.provenance).toMatchObject({
       source: "agent_inferred",
       note: "core fact-memory bridge from fact:44444444-4444-4444-4444-444444444444",
@@ -242,9 +298,6 @@ describe("bridgeCoreFactMemory", () => {
   });
 
   it("projects a preferred name from a language-agnostic structured field", async () => {
-    // The core extractor's `structured_fields` carry the value regardless of
-    // the claim's language ("je m'appelle" here), so a non-English identity
-    // fact still projects a preferredName the English claim regex never sees.
     const { store, patches } = captureFactStore();
     const result = await bridgeCoreFactMemory(
       makeRuntime(),
@@ -261,39 +314,23 @@ describe("bridgeCoreFactMemory", () => {
     expect(patches).toEqual([{ preferredName: "Alex" }]);
   });
 
-  it("recovers a preferred name from the English claim when structured fields are absent", async () => {
+  it("does not recover a preferred name from an English claim without structured fields", async () => {
     const { store, patches } = captureFactStore();
     const result = await bridgeCoreFactMemory(
       makeRuntime(),
       factMemory({
-        id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" as UUID,
+        id: "cccccccc-cccc-cccc-cccc-cccccccccccc" as UUID,
         text: "my name is Robin",
         category: "identity",
       }),
       { factStore: store },
     );
 
-    expect(result.ownerFactKeys).toContain("preferredName");
-    expect(patches).toEqual([{ preferredName: "Robin" }]);
+    expect(result.ownerFactKeys).toEqual([]);
+    expect(patches).toEqual([]);
   });
 
-  it("lets the structured field win over the English claim regex", async () => {
-    const { store, patches } = captureFactStore();
-    await bridgeCoreFactMemory(
-      makeRuntime(),
-      factMemory({
-        id: "cccccccc-cccc-cccc-cccc-cccccccccccc" as UUID,
-        text: "call me Bob",
-        category: "identity",
-        structuredFields: { preferredName: "Robert" },
-      }),
-      { factStore: store },
-    );
-
-    expect(patches).toEqual([{ preferredName: "Robert" }]);
-  });
-
-  it("projects relationship facts and handle claims into the entity graph", async () => {
+  it("projects structured relationship facts and handle claims into the entity graph", async () => {
     const runtime = makeRuntime();
     const { entityStore, relationshipStore } = installFakeGraph();
 
@@ -301,9 +338,14 @@ describe("bridgeCoreFactMemory", () => {
       runtime,
       factMemory({
         id: "55555555-5555-5555-5555-555555555555" as UUID,
-        text: "Pat is my manager. Pat's Telegram handle is @pat.",
+        text: "mi jefe es Pat y su Telegram es @pat",
         category: "relationship",
-        structuredFields: { name: "Pat", relationshipType: "manager" },
+        structuredFields: {
+          person: "Pat",
+          relationshipType: "manager",
+          platform: "Telegram",
+          handle: "@pat",
+        },
       }),
     );
 
@@ -332,13 +374,37 @@ describe("bridgeCoreFactMemory", () => {
     expect(facts.preferredName).toBeUndefined();
   });
 
+  it("does not reparse free-text claims when core omits structured fields", async () => {
+    const runtime = makeRuntime();
+    const { entityStore, relationshipStore } = installFakeGraph();
+
+    const result = await bridgeCoreFactMemory(
+      runtime,
+      factMemory({
+        id: "77777777-7777-7777-7777-777777777777" as UUID,
+        text: "Pat is my manager. Pat's Telegram handle is @pat.",
+        category: "relationship",
+      }),
+    );
+
+    expect(result).toMatchObject({
+      skipped: false,
+      identityCount: 0,
+      relationshipCount: 0,
+      ownerFactKeys: [],
+    });
+    expect(entityStore.identities).toEqual([]);
+    expect(relationshipStore.observations).toEqual([]);
+  });
+
   it("does not replay a bridged fact into graph stores", async () => {
     const runtime = makeRuntime();
     const { relationshipStore } = installFakeGraph();
     const memory = factMemory({
       id: "66666666-6666-6666-6666-666666666666" as UUID,
-      text: "Pat is my manager.",
+      text: "mi jefe es Pat",
       category: "relationship",
+      structuredFields: { person: "Pat", relationshipType: "manager" },
     });
 
     const first = await bridgeCoreFactMemory(runtime, memory);

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/core-fact-memory-bridge.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/core-fact-memory-bridge.ts
@@ -17,30 +17,15 @@ import {
   type OwnerFactsPatch,
   resolveOwnerFactStore,
 } from "./fact-store.js";
+import {
+  cleanHandle,
+  cleanName,
+  normalizePlatform,
+  relationTypeForRole,
+} from "./profile-hints.js";
 
 const BRIDGED_FACT_IDS_CACHE_KEY = "eliza:lifeops:core-fact-memory-bridge:v1";
 const MAX_BRIDGED_FACT_IDS = 1_000;
-
-const HANDLE_PLATFORMS =
-  "telegram|slack|discord|twitter|x|email|github|nostr|signal|imessage";
-
-const RELATIONSHIP_TYPES: Record<string, string> = {
-  boss: "managed_by",
-  manager: "managed_by",
-  supervisor: "managed_by",
-  lead: "managed_by",
-  partner: "partner_of",
-  spouse: "partner_of",
-  husband: "partner_of",
-  wife: "partner_of",
-  colleague: "colleague_of",
-  coworker: "colleague_of",
-  teammate: "colleague_of",
-  friend: "knows",
-  doctor: "care_provider",
-  therapist: "care_provider",
-  coach: "care_provider",
-};
 
 type FactMetadata = {
   source?: string;
@@ -94,27 +79,6 @@ function readString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
-function cleanName(raw: string | undefined): string | null {
-  const value = raw?.replace(/["'`]/g, "").replace(/\s+/g, " ").trim();
-  if (!value || value.length < 2 || value.length > 80) return null;
-  if (/^(?:me|my|mine|you|them|someone|somebody|at|on)$/iu.test(value)) {
-    return null;
-  }
-  return value;
-}
-
-function cleanHandle(raw: string | undefined): string | null {
-  const value = raw?.trim().replace(/[),.;!?]+$/u, "");
-  if (!value || value.length < 2 || value.length > 120) return null;
-  return value;
-}
-
-function normalizePlatform(raw: string): string {
-  const normalized = raw.trim().toLowerCase();
-  if (normalized === "twitter") return "x";
-  return normalized;
-}
-
 function factMetadata(memory: Memory): FactMetadata | null {
   const metadata = memory.metadata;
   if (!isRecord(metadata)) return null;
@@ -153,59 +117,15 @@ function setFact(
   }
 }
 
-function sentenceCase(value: string): string {
-  return value.replace(/^(.)/u, (first) => first.toUpperCase());
-}
-
-function normalizeTravelPreference(claim: string): string | null {
-  if (
-    !/\b(?:travel|booking|bookings|trip|trips|flight|flights|hotel|hotels|seat|seats|luggage|bag|bags|carry-?on)\b/iu.test(
-      claim,
-    )
-  ) {
-    return null;
-  }
-  const cleaned = claim
-    .replace(/\s+/g, " ")
-    .replace(/[.!?]+$/u, "")
-    .trim();
-  if (cleaned.length < 8) return null;
-  if (/^prefer\b/iu.test(cleaned)) return sentenceCase(cleaned);
-  if (/^prefers\b/iu.test(cleaned)) return sentenceCase(cleaned);
-  return `Prefer ${cleaned}`;
-}
-
-/**
- * Sets a claim-derived value only when the structured fields did not already
- * supply one. The core extractor's `structured_fields` are the language-
- * agnostic primary — they carry the same value whether the owner wrote "my
- * name is Alex" or "je m'appelle Alex" — so they must win over the English
- * claim regexes, which are a fast path for the common phrasings the model
- * happened to echo verbatim in the claim text.
- */
-function setFactFromClaim(
-  patch: OwnerFactsPatch,
-  key: OwnerStringFactKey,
-  value: string | null,
-): void {
-  if (!patch[key]) {
-    setFact(patch, key, value);
-  }
-}
-
-function extractOwnerFacts(
-  claim: string,
-  metadata: FactMetadata,
-): OwnerFactsPatch {
+function extractOwnerFacts(metadata: FactMetadata): OwnerFactsPatch {
   const fields = metadata.structuredFields ?? {};
   const patch: OwnerFactsPatch = {};
   const category = metadata.category;
 
   if (category === "identity") {
-    // Alias lists cover the natural key names the extractor emits — it is not
-    // constrained to a canonical schema, so a name may arrive as `name`,
-    // `preferredName`, `nickname`, etc. Missing all of them is fine; the claim
-    // fallbacks below recover the English case.
+    // Alias lists cover older structured-field names while the prompt/schema
+    // converge on the canonical camelCase keys. Do not recover from claim text
+    // here; the core extractor owns language-specific value extraction.
     setFact(
       patch,
       "preferredName",
@@ -266,28 +186,6 @@ function extractOwnerFacts(
         "iana_timezone",
       ]),
     );
-
-    setFactFromClaim(
-      patch,
-      "preferredName",
-      cleanName(
-        /\b(?:my name is|i'?m called|people call me|you can call me|call me)\s+(?!at\b|on\b)([^,.!?]{2,60})/iu.exec(
-          claim,
-        )?.[1],
-      ),
-    );
-
-    const location =
-      /\b(?:live|lives|living|based|located)\s+in\s+([^,.!?]{2,80})/iu.exec(
-        claim,
-      )?.[1] ?? /\bmoved\s+to\s+([^,.!?]{2,80})/iu.exec(claim)?.[1];
-    setFactFromClaim(patch, "location", cleanName(location));
-
-    const timezone =
-      /\b(?:timezone|time zone)\s+(?:is\s+)?([A-Za-z0-9_/+.-]{2,60})/iu.exec(
-        claim,
-      )?.[1];
-    setFactFromClaim(patch, "timezone", timezone ?? null);
   }
 
   if (category === "relationship") {
@@ -315,47 +213,38 @@ function extractOwnerFacts(
     );
   }
 
-  const partner =
-    /\b(?:partner|spouse|husband|wife)\s+(?:is|named)\s+([^,.!?]{2,60})/iu.exec(
-      claim,
-    )?.[1] ??
-    /\b([^,.!?]{2,60})\s+is\s+(?:my\s+)?(?:partner|spouse|husband|wife)\b/iu.exec(
-      claim,
-    )?.[1];
-  setFactFromClaim(patch, "partnerName", cleanName(partner));
-
   if (category === "preference") {
-    setFact(patch, "locale", firstString(fields, ["locale", "languageLocale"]));
+    setFact(
+      patch,
+      "locale",
+      firstString(fields, ["locale", "languageLocale", "language_locale"]),
+    );
     setFact(
       patch,
       "preferredNotificationChannel",
-      firstString(fields, ["preferredNotificationChannel", "channel"]),
+      firstString(fields, [
+        "preferredNotificationChannel",
+        "preferred_notification_channel",
+        "notificationChannel",
+        "notification_channel",
+        "channel",
+      ]),
     );
     setFact(
       patch,
       "travelBookingPreferences",
       firstString(fields, [
         "travelBookingPreferences",
+        "travel_booking_preferences",
         "travelPreference",
+        "travel_preference",
         "bookingPreference",
+        "booking_preference",
       ]),
     );
   }
 
-  if (category === "preference" && !patch.travelBookingPreferences) {
-    setFact(
-      patch,
-      "travelBookingPreferences",
-      normalizeTravelPreference(claim),
-    );
-  }
-
   return patch;
-}
-
-function relationTypeForRole(role: string | null): string | null {
-  if (!role) return null;
-  return RELATIONSHIP_TYPES[role.toLowerCase()] ?? role.toLowerCase();
 }
 
 function edgeForSelfToPerson(
@@ -374,10 +263,7 @@ function edgeForSelfToPerson(
   };
 }
 
-function extractRelationshipEdges(
-  claim: string,
-  metadata: FactMetadata,
-): ExtractedEdge[] {
+function extractRelationshipEdges(metadata: FactMetadata): ExtractedEdge[] {
   const confidence = metadata.confidence ?? 0.7;
   const fields = metadata.structuredFields ?? {};
   const edges: ExtractedEdge[] = [];
@@ -406,44 +292,8 @@ function extractRelationshipEdges(
   );
   if (structuredEdge) edges.push(structuredEdge);
 
-  const relationPatterns = [
-    /\b([A-Z][A-Za-z0-9 .'-]{1,60})\s+is\s+(?:my\s+)?(boss|manager|supervisor|lead|partner|spouse|husband|wife|colleague|coworker|teammate|friend|doctor|therapist|coach)\b/gu,
-    /\b(?:my\s+)(boss|manager|supervisor|lead|partner|spouse|husband|wife|colleague|coworker|teammate|friend|doctor|therapist|coach)\s+is\s+([A-Z][A-Za-z0-9 .'-]{1,60})\b/gu,
-  ];
-  for (const pattern of relationPatterns) {
-    for (const match of claim.matchAll(pattern)) {
-      const first = match[1] ?? "";
-      const second = match[2] ?? "";
-      const roleFirst = Boolean(RELATIONSHIP_TYPES[first.toLowerCase()]);
-      const name = cleanName(roleFirst ? second : first);
-      const type = relationTypeForRole(roleFirst ? first : second);
-      const edge = edgeForSelfToPerson(name, type, confidence, {
-        extractedRole: roleFirst ? first : second,
-      });
-      if (edge) edges.push(edge);
-    }
-  }
-
-  const reportsTo =
-    /\b(?:i\s+)?(?:report|reports)\s+to\s+([A-Z][A-Za-z0-9 .'-]{1,60})\b/iu.exec(
-      claim,
-    )?.[1];
-  const reportsToEdge = edgeForSelfToPerson(
-    cleanName(reportsTo),
-    "managed_by",
-    confidence,
-    { extractedRole: "manager" },
-  );
-  if (reportsToEdge) edges.push(reportsToEdge);
-
   const organization =
-    firstString(fields, ["company", "organization", "employer"]) ??
-    /\b(?:work|works)\s+(?:at|for)\s+([A-Z][A-Za-z0-9 .&'-]{1,80})\b/iu.exec(
-      claim,
-    )?.[1] ??
-    /\b(?:employer|company)\s+is\s+([A-Z][A-Za-z0-9 .&'-]{1,80})\b/iu.exec(
-      claim,
-    )?.[1];
+    firstString(fields, ["company", "organization", "employer"]) ?? undefined;
   const orgName = cleanName(organization);
   if (orgName) {
     edges.push({
@@ -457,45 +307,20 @@ function extractRelationshipEdges(
   return dedupeEdges(edges);
 }
 
-function extractIdentityHints(claim: string): IdentityHint[] {
+function extractIdentityHints(metadata: FactMetadata): IdentityHint[] {
   const hints: IdentityHint[] = [];
-  const namePlatformHandle = new RegExp(
-    `\\b([A-Z][A-Za-z0-9 '-]{1,60})'s\\s+(${HANDLE_PLATFORMS})\\s+(?:handle|username|account|profile)\\s+is\\s+(@?[A-Za-z0-9_.+\\-@]+)\\b`,
-    "giu",
+  const fields = metadata.structuredFields ?? {};
+  const name = cleanName(
+    firstString(fields, ["person", "name", "target", "relatedPerson"]) ??
+      undefined,
   );
-  for (const match of claim.matchAll(namePlatformHandle)) {
-    const name = cleanName(match[1]);
-    const platform = readString(match[2]);
-    const handle = cleanHandle(match[3]);
-    if (name && platform && handle) {
-      hints.push({ name, platform: normalizePlatform(platform), handle });
-    }
-  }
-
-  const platformNameHandle = new RegExp(
-    `\\b(?:the\\s+)?(${HANDLE_PLATFORMS})\\s+(?:handle|username|account|profile)\\s+for\\s+([A-Z][A-Za-z0-9 '-]{1,60})\\s+is\\s+(@?[A-Za-z0-9_.+\\-@]+)\\b`,
-    "giu",
+  const platform = firstString(fields, ["platform", "service", "network"]);
+  const handle = cleanHandle(
+    firstString(fields, ["handle", "username", "account", "profile"]) ??
+      undefined,
   );
-  for (const match of claim.matchAll(platformNameHandle)) {
-    const platform = readString(match[1]);
-    const name = cleanName(match[2]);
-    const handle = cleanHandle(match[3]);
-    if (name && platform && handle) {
-      hints.push({ name, platform: normalizePlatform(platform), handle });
-    }
-  }
-
-  const nameHandlePlatform = new RegExp(
-    `\\b([A-Z][A-Za-z0-9 '-]{1,60})\\s+(?:goes by|is)\\s+(@[A-Za-z0-9_.+-]+)\\s+on\\s+(${HANDLE_PLATFORMS})\\b`,
-    "giu",
-  );
-  for (const match of claim.matchAll(nameHandlePlatform)) {
-    const name = cleanName(match[1]);
-    const handle = cleanHandle(match[2]);
-    const platform = readString(match[3]);
-    if (name && platform && handle) {
-      hints.push({ name, platform: normalizePlatform(platform), handle });
-    }
+  if (name && platform && handle) {
+    hints.push({ name, platform: normalizePlatform(platform), handle });
   }
   return hints;
 }
@@ -579,8 +404,7 @@ export async function bridgeCoreFactMemory(
     return skipped("not_owner_fact");
   }
 
-  const claim = readString(memory.content.text) ?? "";
-  const patch = extractOwnerFacts(claim, metadata);
+  const patch = extractOwnerFacts(metadata);
   const ownerFactKeys = Object.keys(patch);
   if (ownerFactKeys.length > 0) {
     await (deps.factStore ?? resolveOwnerFactStore(runtime)).update(patch, {
@@ -594,8 +418,8 @@ export async function bridgeCoreFactMemory(
 
   let identityCount = 0;
   let relationshipCount = 0;
-  const identityHints = extractIdentityHints(claim);
-  const edges = extractRelationshipEdges(claim, metadata);
+  const identityHints = extractIdentityHints(metadata);
+  const edges = extractRelationshipEdges(metadata);
   if (identityHints.length > 0 || edges.length > 0) {
     const knowledgeGraph = resolveKnowledgeGraphService(runtime);
     if (!knowledgeGraph) {

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/profile-extraction-evaluator.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/profile-extraction-evaluator.ts
@@ -15,6 +15,12 @@ import {
   type OwnerFactsPatch,
 } from "../owner/fact-store.js";
 import {
+  cleanHandle,
+  cleanName,
+  normalizePlatform,
+  relationTypeForRole,
+} from "../owner/profile-hints.js";
+import {
   applyExtractedEdges,
   type ExtractedEdge,
 } from "../relationships/extraction.js";
@@ -84,44 +90,12 @@ const TRAVEL_PREFERENCE_CONTEXT =
 const TRAVEL_PREFERENCE_DETAILS =
   /\b(?:aisle|window|seat|seats|checked\s+bag|checked\s+bags|carry-?on|luggage|hotel|hotels|budget|\$\d|venue|venues|mile|miles|night|nights)\b/iu;
 
-const RELATIONSHIP_TYPES: Record<string, string> = {
-  boss: "managed_by",
-  manager: "managed_by",
-  partner: "partner_of",
-  spouse: "partner_of",
-  colleague: "colleague_of",
-  coworker: "colleague_of",
-  teammate: "colleague_of",
-  friend: "knows",
-};
-
 function messageText(value: unknown): string {
   if (!value || typeof value !== "object") return "";
   const content = (value as { content?: unknown }).content;
   if (!content || typeof content !== "object") return "";
   const text = (content as { text?: unknown }).text;
   return typeof text === "string" ? text : "";
-}
-
-function cleanName(raw: string | undefined): string | null {
-  const value = raw?.replace(/["'`]/g, "").replace(/\s+/g, " ").trim();
-  if (!value || value.length < 2 || value.length > 80) return null;
-  if (/^(?:me|my|mine|you|them|someone|somebody|at|on)$/iu.test(value)) {
-    return null;
-  }
-  return value;
-}
-
-function cleanHandle(raw: string | undefined): string | null {
-  const value = raw?.trim().replace(/[),.;!?]+$/u, "");
-  if (!value || value.length < 2 || value.length > 120) return null;
-  return value;
-}
-
-function normalizePlatform(raw: string): string {
-  const normalized = raw.trim().toLowerCase();
-  if (normalized === "twitter") return "x";
-  return normalized;
 }
 
 function collectFactHints(text: string, facts: OwnerFactsPatch): void {
@@ -218,7 +192,7 @@ function collectRelationshipHints(text: string): RelationshipHint[] {
   for (const match of text.matchAll(pattern)) {
     const name = cleanName(match[1]);
     const role = (match[2] ?? "").toLowerCase();
-    const type = RELATIONSHIP_TYPES[role];
+    const type = relationTypeForRole(role);
     if (name && type) {
       hints.push({ name, type });
     }

--- a/plugins/plugin-personal-assistant/src/lifeops/owner/profile-hints.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/owner/profile-hints.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared normalization for owner-profile facts that arrive through either the
+ * zero-cost chat regex extractor or the core fact-memory projection. Keeping
+ * role mapping and identity cleanup here prevents the passive-learning paths
+ * from drifting while they feed the same OwnerFactStore and graph stores.
+ */
+
+export const RELATIONSHIP_TYPE_BY_ROLE: Record<string, string> = {
+  boss: "managed_by",
+  manager: "managed_by",
+  supervisor: "managed_by",
+  lead: "managed_by",
+  partner: "partner_of",
+  spouse: "partner_of",
+  husband: "partner_of",
+  wife: "partner_of",
+  colleague: "colleague_of",
+  coworker: "colleague_of",
+  teammate: "colleague_of",
+  friend: "knows",
+  doctor: "care_provider",
+  therapist: "care_provider",
+  coach: "care_provider",
+};
+
+export function cleanName(raw: string | undefined): string | null {
+  const value = raw?.replace(/["'`]/g, "").replace(/\s+/g, " ").trim();
+  if (!value || value.length < 2 || value.length > 80) return null;
+  if (/^(?:me|my|mine|you|them|someone|somebody|at|on)$/iu.test(value)) {
+    return null;
+  }
+  return value;
+}
+
+export function cleanHandle(raw: string | undefined): string | null {
+  const value = raw?.trim().replace(/[),.;!?]+$/u, "");
+  if (!value || value.length < 2 || value.length > 120) return null;
+  return value;
+}
+
+export function normalizePlatform(raw: string): string {
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "twitter") return "x";
+  return normalized;
+}
+
+export function relationTypeForRole(role: string | null): string | null {
+  if (!role) return null;
+  return RELATIONSHIP_TYPE_BY_ROLE[role.toLowerCase()] ?? role.toLowerCase();
+}


### PR DESCRIPTION
## Summary

Follow-up to #14940 / #14688. The merged fact-memory bridge created the right LifeOps projection seam, but it still depended on English claim regex fallbacks while core's strict JSON schema advertised `structured_fields` as an empty closed object. This PR makes the core extractor capable of emitting strict-safe structured values and makes the LifeOps bridge consume only those fields.

- Adds an explicit strict-provider-safe `structured_fields` key set to core `factMemory` schema.
- Teaches both `FACT_EXTRACTION_TEMPLATE` and the production core `factMemoryEvaluator.prompt()` path to emit English structured-field keys even for non-English messages.
- Removes duplicate claim parsing from `core-fact-memory-bridge.ts`; no travel/name/timezone/relationship/handle regex recovery remains in the bridge.
- Shares profile hint normalization between the existing zero-cost regex evaluator and the bridge so relationship role mapping does not drift.
- Adds regression coverage that Spanish/French facts project through structured fields, and that English free text alone does not project through the bridge.

## Verification

<!-- evidence-row:before-screenshots --> N/A - backend/runtime prompt + projection change only; no UI surface, layout, or rendered app state changed.

<!-- evidence-row:after-screenshots --> N/A - backend/runtime prompt + projection change only; no UI surface, layout, or rendered app state changed.

<!-- evidence-row:walkthrough-video --> N/A - no user-facing visual flow changed. The behavior is validated through deterministic runtime tests that feed fact-memory rows into the bridge.

<!-- evidence-row:backend-logs --> `core-fact-memory-bridge.test.ts` -> 7 tests passed; `reflection-items.test.ts` -> 9 tests passed; `prompts.test.js` -> 26 tests passed; Biome, core typecheck/build, diff-check, and error-policy ratchet passed.

<!-- evidence-row:frontend-logs --> N/A - no frontend code path, browser console, or network behavior changed.

<!-- evidence-row:llm-trajectory --> BLOCKED - prompt/schema behavior now has `live-fact-memory-structured-fields.scenario.ts`, but local `ELIZA_CHAT_VIA_CLI=codex` failed before trajectory rows (`codex exited 1: Reading additional input from stdin...`) and `ELIZA_CHAT_VIA_CLI=claude` was unavailable. Do not merge until this scenario passes with a real provider and report/viewer/jsonl artifacts are attached.

<!-- evidence-row:domain-artifacts --> Core schema/prompt exposes `structured_fields`; LifeOps bridge tests prove multilingual structured fields project into owner facts/graph and English claim text with empty structuredFields projects nothing; scenario loader lists `live-fact-memory-structured-fields`.


