### PR TITLE
perf(app): mobile cold-boot TTI and build-time budget gate

### DIFF
--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -7477,7 +7477,40 @@ const isMain =
   process.argv[1] &&
   path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
 
+/**
+ * Emit the wall-clock build duration so the startup-budget gate
+ * (packages/app/scripts/check-startup-budget.mjs) can regression-check build
+ * time (issue #14414). Opt-in via ELIZA_MOBILE_BUILD_TIMING_OUT so default
+ * builds are byte-for-byte unchanged; the file records the wall-clock the
+ * `build` budget target is defined against.
+ */
+function writeBuildTiming(target, buildMs) {
+  const out = process.env.ELIZA_MOBILE_BUILD_TIMING_OUT;
+  if (!out) return;
+  const budgetTarget =
+    process.env.ELIZA_MOBILE_BUILD_TIMING_TARGET ??
+    (target.startsWith("ios") ? "ios-ipa" : "android-apk");
+  fs.writeFileSync(
+    out,
+    `${JSON.stringify(
+      {
+        capturedAtIso: new Date().toISOString(),
+        buildTarget: target,
+        target: budgetTarget,
+        buildMs: Math.round(buildMs),
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  console.log(
+    `[mobile-build] build timing: ${Math.round(buildMs)}ms → ${out} (budget target ${budgetTarget})`,
+  );
+}
+
 if (isMain) {
   console.log(`[mobile-build] App: ${APP.appName} (${APP.appId})`);
+  const buildStart = Date.now();
   await main();
+  writeBuildTiming(process.argv[2], Date.now() - buildStart);
 }

--- a/packages/app/PERF_BUDGET.md
+++ b/packages/app/PERF_BUDGET.md
@@ -1,0 +1,76 @@
+# Mobile cold-boot TTI + build-time budget
+
+The measurement contract for iOS/Android **cold boot** and **build/rebuild**
+speed (issue #14414). The goal: land the user in a usable chat shell as fast as
+possible while the local agent boots behind it, and keep the inner rebuild loop
+tight. This doc is the instrument — `perf-budgets.json` holds the numbers and
+`scripts/check-startup-budget.mjs` is the regression gate.
+
+## What is measured
+
+| Metric | Source artifact | Mark / value |
+| --- | --- | --- |
+| `tti/ci-web` | `scripts/capture-startup-trace.mjs` (headless Chromium) | `startup-shell:mounted` atMs — usable-shell paint |
+| `tti/android-lowram` | same trace, `--url` a device-tunnelled WebView | `startup-shell:mounted` |
+| `tti/ios-reference` | same trace against the iOS sim WebView | `startup-shell:mounted` |
+| `build/android-apk` | `run-mobile-build.mjs` timing json | wall-clock `buildMs` |
+| `build/ios-ipa` | same | wall-clock `buildMs` |
+| `build/rebuild-loop` | renderer-only change → device visible | wall-clock |
+
+TTI is measured to `startup-shell:mounted` — the unconditional shell-mount
+checkpoint (`packages/ui/.../StartupShell.tsx`), i.e. the moment the user lands
+in a usable shell. `startup-shell:first-paint` is splash-delay-gated and absent
+on boots faster than the gate, so it is only a fallback; `coordinator:ready`
+(agent fully booted) is the last fallback and a separate, looser target.
+
+## Capture + gate
+
+```bash
+# 1. TTI on the CI-runnable web path (no device, no model key)
+bun run --cwd packages/app dev &                    # or point --url at a device WebView
+bun run --cwd packages/app trace:startup -- --out /tmp/trace.json
+
+# 2. Build time (opt-in emit; default builds are unchanged)
+ELIZA_MOBILE_BUILD_TIMING_OUT=/tmp/build-timing.json bun run build:android
+
+# 3. Gate: fail on over-budget OR a >tolerance regression past the baseline
+bun run --cwd packages/app perf:startup-budget -- \
+  --trace /tmp/trace.json --tti-target ci-web \
+  --build-timing /tmp/build-timing.json --build-target android-apk \
+  --out /tmp/budget-report.json
+```
+
+The gate exits non-zero when any metric is over its hard `budgetMs` ceiling or
+regresses past `baselineMs` by more than `tolerancePct` (default 15%). A metric
+with no measurement is a **failure**, not a silent pass — an unmeasured budget
+must never read as green.
+
+### Recording baselines
+
+Run the capture on the reference target, then:
+
+```bash
+bun run --cwd packages/app perf:startup-budget -- \
+  --trace /tmp/trace.json --tti-target ios-reference --update-baseline
+```
+
+`--update-baseline` rewrites the matched `baselineMs` in `perf-budgets.json` and
+exits 0 on that recording run. Commit the updated baselines with the PR that
+moved them. Reference-device (`android-lowram`, `ios-reference`) and build
+baselines are recorded on those targets in CI, not from a laptop.
+
+## Fastest inner loop for renderer-only changes
+
+A renderer-only change does **not** need a full native rebuild:
+
+- **Dev / iteration:** `bun run --cwd packages/app dev` serves the web bundle
+  with Vite HMR; point the installed app's WebView at the dev URL (VPS →
+  Cloudflare-tunnel → installed PWA loop, #14383/#14398) so a renderer edit is
+  visible in seconds. Do **not** re-bake + reinstall the APK/IPA per edit.
+- **Release only:** `build:ios` / `build:android` bake the web bundle into the
+  APK/IPA (turbo caches the `build` web step). Reserve the full native rebuild
+  for release artifacts and native-code changes.
+
+Baking the web bundle into the binary at build time is why a Capacitor app must
+be rebuilt + reinstalled to pick up a renderer change (see `AGENTS.md`); the dev
+loop above sidesteps that for iteration.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsgo --noEmit -p tsconfig.typecheck.json",
     "test": "vitest run --config vitest.config.ts",
     "trace:startup": "node scripts/capture-startup-trace.mjs",
+    "perf:startup-budget": "node scripts/check-startup-budget.mjs",
     "test:dev-smoke": "node scripts/run-ui-playwright.mjs --config playwright.dev-smoke.config.ts",
     "test:hmr": "node scripts/run-ui-playwright.mjs --config playwright.hmr.config.ts",
     "test:e2e": "node scripts/run-ui-playwright.mjs --config playwright.ui-smoke.config.ts",

--- a/packages/app/perf-budgets.json
+++ b/packages/app/perf-budgets.json
@@ -1,0 +1,41 @@
+{
+  "description": "Mobile cold-boot TTI + build-time budgets and recorded baselines (issue #14414). budgetMs is the hard ceiling the regression gate (scripts/check-startup-budget.mjs) fails past. baselineMs is the last recorded measurement on the named reference target; the gate also fails a measurement that regresses past baselineMs by more than tolerancePct. Record baselines with `--update-baseline` after a capture on the reference target; null baselineMs means not-yet-recorded (skipped by the regression check, still gated by budgetMs).",
+  "tolerancePct": 15,
+  "tti": {
+    "ci-web": {
+      "budgetMs": 4000,
+      "baselineMs": null,
+      "mark": "startup-shell:mounted",
+      "target": "Headless Chromium against the built renderer (packages/app dev server). The CI-runnable TTI path — no device, no model key. Capture: scripts/capture-startup-trace.mjs --out trace.json."
+    },
+    "android-lowram": {
+      "budgetMs": 9000,
+      "baselineMs": null,
+      "mark": "startup-shell:mounted",
+      "target": "Reference low-RAM Android emulator (Pixel-class, 2GB) cold launch to a usable chat shell. Capture: scripts/capture-startup-trace.mjs --url <device-tunnelled WebView>."
+    },
+    "ios-reference": {
+      "budgetMs": 6000,
+      "baselineMs": null,
+      "mark": "startup-shell:mounted",
+      "target": "Reference iPhone simulator cold launch to a usable chat shell. Capture: scripts/ios-device-capture.mjs / scripts/capture-startup-trace.mjs against the sim WebView."
+    }
+  },
+  "build": {
+    "android-apk": {
+      "budgetMs": 900000,
+      "baselineMs": null,
+      "target": "run-mobile-build.mjs android — full web bundle + cap sync + gradle assemble, wall-clock. Emit: ELIZA_MOBILE_BUILD_TIMING_OUT=<file> bun run build:android."
+    },
+    "ios-ipa": {
+      "budgetMs": 900000,
+      "baselineMs": null,
+      "target": "run-mobile-build.mjs ios — full web bundle + cap sync + xcodebuild, wall-clock. Emit: ELIZA_MOBILE_BUILD_TIMING_OUT=<file> bun run build:ios."
+    },
+    "rebuild-loop": {
+      "budgetMs": 60000,
+      "baselineMs": null,
+      "target": "Renderer-only change to on-device visible, warm caches (turbo web bundle + cap sync + incremental native). The inner-loop cost the issue drives toward seconds."
+    }
+  }
+}

--- a/packages/app/scripts/check-startup-budget.mjs
+++ b/packages/app/scripts/check-startup-budget.mjs
@@ -369,11 +369,17 @@ async function main() {
 
   let updatedBaselines = 0;
   if (args.updateBaseline) {
-    updatedBaselines = applyBaselineUpdates(budgets, rows);
-    writeFileSync(args.budgets, `${JSON.stringify(budgets, null, 2)}\n`);
-    console.log(
-      `Recorded ${updatedBaselines} baseline(s) into ${args.budgets}`,
-    );
+    if (!shouldPassAfterBaselineUpdate(rows, rows.length)) {
+      console.error(
+        "[startup-budget] Refusing to update baselines because at least one requested metric is missing or has no budget entry.",
+      );
+    } else {
+      updatedBaselines = applyBaselineUpdates(budgets, rows);
+      writeFileSync(args.budgets, `${JSON.stringify(budgets, null, 2)}\n`);
+      console.log(
+        `Recorded ${updatedBaselines} baseline(s) into ${args.budgets}`,
+      );
+    }
   }
 
   const report = {

--- a/packages/app/scripts/check-startup-budget.mjs
+++ b/packages/app/scripts/check-startup-budget.mjs
@@ -1,0 +1,393 @@
+#!/usr/bin/env node
+/**
+ * Cold-boot TTI + build-time regression gate for the mobile app (issue #14414).
+ *
+ * Consumes the boot-timing artifacts the repo already produces — the renderer
+ * startup trace from `capture-startup-trace.mjs` (per-phase `timeline` marks)
+ * and the build-time JSON from `run-mobile-build.mjs` — turns them into named
+ * metrics, and checks each against `packages/app/perf-budgets.json`. A metric
+ * fails the gate two ways: it exceeds its hard `budgetMs` ceiling, or it
+ * regresses past the last recorded `baselineMs` by more than `tolerancePct`.
+ * This is the measurement instrument the "defer eager work + shrink cold TTI"
+ * work drives against: it makes a build-time / cold-TTI regression a red gate
+ * instead of an unnoticed drift.
+ *
+ * The pure functions (selectColdRun, extractTtiMark, computeRegressionPct,
+ * evaluateMetric, evaluateAll) carry no I/O and are unit-tested in
+ * check-startup-budget.test.ts; main() is the CLI boundary that reads files,
+ * prints the table, and sets the exit code.
+ *
+ * Usage:
+ *   node scripts/check-startup-budget.mjs \
+ *     [--budgets <perf-budgets.json>] \
+ *     [--trace <capture-startup-trace artifact> --tti-target <name>] \
+ *     [--build-timing <run-mobile-build timing json> --build-target <name>] \
+ *     [--metric <category:target=valueMs> ...] \
+ *     [--tolerance-pct <n>] [--out <report.json>] \
+ *     [--update-baseline] [--json]
+ *
+ *   --trace          capture-startup-trace.mjs artifact; the cold run's TTI mark
+ *                    becomes the `tti/<tti-target>` metric
+ *   --tti-target     which tti budget the trace measures (default ci-web)
+ *   --build-timing   run-mobile-build.mjs timing json ({ target, buildMs })
+ *   --build-target   which build budget the timing measures (default: the json's
+ *                    own `target`, else android-apk)
+ *   --metric         inject a raw metric, e.g. build:rebuild-loop=42000 (repeatable)
+ *   --update-baseline  rewrite matched budgets' baselineMs to the measured value
+ *   --out            write the machine report JSON
+ *   --json           print the report as JSON instead of a table
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** TTI marks, best → fallback: the usable-shell paint is the "land in chat"
+ * moment this budget tracks; first-paint is splash-delay-gated and absent on
+ * boots faster than the gate, so `mounted` is the durable default. */
+export const DEFAULT_TTI_MARKS = [
+  "startup-shell:mounted",
+  "startup-shell:first-paint",
+  "coordinator:ready",
+];
+
+export const METRIC_STATUS = {
+  PASS: "pass",
+  OVER_BUDGET: "over-budget",
+  REGRESSED: "regressed",
+  MISSING_METRIC: "missing-metric",
+  MISSING_BUDGET: "missing-budget",
+};
+
+/**
+ * Pick the cold run from a capture-startup-trace artifact. Cold is the metric
+ * that matters for a launch budget (warm reloads keep module/asset caches). A
+ * run carrying an `error` (no trace on window) is not a usable measurement.
+ */
+export function selectColdRun(artifact) {
+  const runs = Array.isArray(artifact?.runs) ? artifact.runs : [];
+  const usable = runs.filter((r) => r && !r.error && Array.isArray(r.timeline));
+  return usable.find((r) => r.kind === "cold") ?? usable[0] ?? null;
+}
+
+/**
+ * Extract the TTI checkpoint from a run's timeline, honoring mark priority.
+ * `atMs` is already relative to the run's first mark (module-eval == 0), so it
+ * is the cold time-to-usable-shell directly. Returns null when no priority mark
+ * is present — the caller treats that as a missing measurement, never as 0.
+ */
+export function extractTtiMark(run, markPriority = DEFAULT_TTI_MARKS) {
+  const timeline = Array.isArray(run?.timeline) ? run.timeline : [];
+  for (const name of markPriority) {
+    const hit = timeline.find((m) => m?.name === name);
+    if (hit && Number.isFinite(hit.atMs)) {
+      return { name, atMs: hit.atMs };
+    }
+  }
+  return null;
+}
+
+/** Percent a value exceeds a baseline; negative means an improvement. Null when
+ * there is no baseline to compare against. */
+export function computeRegressionPct(valueMs, baselineMs) {
+  if (!Number.isFinite(baselineMs) || baselineMs <= 0) return null;
+  return ((valueMs - baselineMs) / baselineMs) * 100;
+}
+
+/**
+ * Grade one metric against its budget entry. Fails on a missing budget entry,
+ * an absent measurement, over-ceiling, or a baseline regression past tolerance.
+ * A missing metric is a failure, not a silent pass — an unmeasured budget must
+ * not read as green.
+ */
+export function evaluateMetric({
+  category,
+  target,
+  valueMs,
+  budgetEntry,
+  tolerancePct,
+}) {
+  const key = `${category}/${target}`;
+  if (!budgetEntry || !Number.isFinite(budgetEntry.budgetMs)) {
+    return {
+      key,
+      category,
+      target,
+      valueMs,
+      status: METRIC_STATUS.MISSING_BUDGET,
+    };
+  }
+  const { budgetMs } = budgetEntry;
+  const baselineMs = Number.isFinite(budgetEntry.baselineMs)
+    ? budgetEntry.baselineMs
+    : null;
+  if (!Number.isFinite(valueMs)) {
+    return {
+      key,
+      category,
+      target,
+      valueMs: null,
+      budgetMs,
+      baselineMs,
+      status: METRIC_STATUS.MISSING_METRIC,
+    };
+  }
+  const regressionPct = computeRegressionPct(valueMs, baselineMs);
+  let status = METRIC_STATUS.PASS;
+  if (valueMs > budgetMs) {
+    status = METRIC_STATUS.OVER_BUDGET;
+  } else if (regressionPct !== null && regressionPct > tolerancePct) {
+    status = METRIC_STATUS.REGRESSED;
+  }
+  return {
+    key,
+    category,
+    target,
+    valueMs,
+    budgetMs,
+    baselineMs,
+    regressionPct,
+    status,
+  };
+}
+
+const FAILING = new Set([
+  METRIC_STATUS.OVER_BUDGET,
+  METRIC_STATUS.REGRESSED,
+  METRIC_STATUS.MISSING_METRIC,
+  METRIC_STATUS.MISSING_BUDGET,
+]);
+
+/**
+ * Grade every requested metric. `metrics` is [{ category, target, valueMs }].
+ * `ok` is true only when no row failed — that is the gate's exit signal.
+ */
+export function evaluateAll({ metrics, budgets, tolerancePct }) {
+  const tol = Number.isFinite(tolerancePct)
+    ? tolerancePct
+    : Number.isFinite(budgets?.tolerancePct)
+      ? budgets.tolerancePct
+      : 15;
+  const rows = metrics.map((m) =>
+    evaluateMetric({
+      category: m.category,
+      target: m.target,
+      valueMs: m.valueMs,
+      budgetEntry: budgets?.[m.category]?.[m.target],
+      tolerancePct: tol,
+    }),
+  );
+  return {
+    rows,
+    ok: rows.every((r) => !FAILING.has(r.status)),
+    tolerancePct: tol,
+  };
+}
+
+// ── CLI boundary ────────────────────────────────────────────────────────────
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const DEFAULT_BUDGETS = path.resolve(HERE, "..", "perf-budgets.json");
+
+function parseArgs(argv) {
+  const args = {
+    budgets: DEFAULT_BUDGETS,
+    trace: null,
+    ttiTarget: "ci-web",
+    buildTiming: null,
+    buildTarget: null,
+    metrics: [],
+    tolerancePct: null,
+    out: null,
+    updateBaseline: false,
+    json: false,
+  };
+  for (let i = 2; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--budgets") args.budgets = argv[++i];
+    else if (a === "--trace") args.trace = argv[++i];
+    else if (a === "--tti-target") args.ttiTarget = argv[++i];
+    else if (a === "--build-timing") args.buildTiming = argv[++i];
+    else if (a === "--build-target") args.buildTarget = argv[++i];
+    else if (a === "--metric") args.metrics.push(argv[++i]);
+    else if (a === "--tolerance-pct") args.tolerancePct = Number(argv[++i]);
+    else if (a === "--out") args.out = argv[++i];
+    else if (a === "--update-baseline") args.updateBaseline = true;
+    else if (a === "--json") args.json = true;
+    else throw new Error(`Unknown argument: ${a}`);
+  }
+  return args;
+}
+
+function readJson(file) {
+  return JSON.parse(readFileSync(file, "utf8"));
+}
+
+/** Parse a `--metric category:target=valueMs` spec into a metric. Throws on a
+ * malformed spec rather than silently dropping it (a dropped metric would read
+ * as a passing gate). */
+function parseMetricSpec(spec) {
+  const match = /^([^:]+):([^=]+)=(-?\d+(?:\.\d+)?)$/.exec(spec.trim());
+  if (!match) {
+    throw new Error(
+      `Malformed --metric "${spec}"; expected category:target=valueMs`,
+    );
+  }
+  return {
+    category: match[1],
+    target: match[2],
+    valueMs: Number(match[3]),
+  };
+}
+
+function collectMetrics(args) {
+  const metrics = [];
+  if (args.trace) {
+    const artifact = readJson(args.trace);
+    const run = selectColdRun(artifact);
+    if (!run) {
+      throw new Error(
+        `--trace ${args.trace} has no usable cold run (all runs errored or empty)`,
+      );
+    }
+    const mark = extractTtiMark(run);
+    if (!mark) {
+      throw new Error(
+        `--trace ${args.trace} cold run has none of the TTI marks (${DEFAULT_TTI_MARKS.join(", ")}); the boot never reached a usable shell`,
+      );
+    }
+    metrics.push({
+      category: "tti",
+      target: args.ttiTarget,
+      valueMs: mark.atMs,
+      source: { kind: "trace", mark: mark.name, file: args.trace },
+    });
+  }
+  if (args.buildTiming) {
+    const timing = readJson(args.buildTiming);
+    if (!Number.isFinite(timing?.buildMs)) {
+      throw new Error(
+        `--build-timing ${args.buildTiming} has no numeric buildMs`,
+      );
+    }
+    const target = args.buildTarget ?? timing.target ?? "android-apk";
+    metrics.push({
+      category: "build",
+      target,
+      valueMs: timing.buildMs,
+      source: { kind: "build-timing", file: args.buildTiming },
+    });
+  }
+  for (const spec of args.metrics) {
+    metrics.push({ ...parseMetricSpec(spec), source: { kind: "flag" } });
+  }
+  return metrics;
+}
+
+function formatMs(ms) {
+  if (!Number.isFinite(ms)) return "—";
+  return ms >= 10000 ? `${(ms / 1000).toFixed(1)}s` : `${Math.round(ms)}ms`;
+}
+
+function printTable(rows, tolerancePct) {
+  const glyph = {
+    [METRIC_STATUS.PASS]: "PASS",
+    [METRIC_STATUS.OVER_BUDGET]: "OVER-BUDGET",
+    [METRIC_STATUS.REGRESSED]: "REGRESSED",
+    [METRIC_STATUS.MISSING_METRIC]: "MISSING",
+    [METRIC_STATUS.MISSING_BUDGET]: "NO-BUDGET",
+  };
+  console.log(
+    `\nStartup + build budget gate (regression tolerance ${tolerancePct}%)`,
+  );
+  console.log(
+    "  metric".padEnd(30),
+    "value".padStart(9),
+    "budget".padStart(9),
+    "baseline".padStart(9),
+    "  status",
+  );
+  for (const r of rows) {
+    const reg =
+      Number.isFinite(r.regressionPct) && r.baselineMs
+        ? ` (${r.regressionPct >= 0 ? "+" : ""}${r.regressionPct.toFixed(1)}%)`
+        : "";
+    console.log(
+      `  ${r.key}`.padEnd(30),
+      formatMs(r.valueMs).padStart(9),
+      formatMs(r.budgetMs).padStart(9),
+      formatMs(r.baselineMs).padStart(9),
+      `  ${glyph[r.status] ?? r.status}${reg}`,
+    );
+  }
+}
+
+function applyBaselineUpdates(budgets, rows) {
+  let updated = 0;
+  for (const r of rows) {
+    if (!Number.isFinite(r.valueMs)) continue;
+    const entry = budgets?.[r.category]?.[r.target];
+    if (!entry) continue;
+    entry.baselineMs = Math.round(r.valueMs);
+    updated += 1;
+  }
+  return updated;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const budgets = readJson(args.budgets);
+  const metrics = collectMetrics(args);
+  if (metrics.length === 0) {
+    throw new Error(
+      "No metrics supplied — pass --trace, --build-timing, or --metric. An empty gate must not report success.",
+    );
+  }
+  const { rows, ok, tolerancePct } = evaluateAll({
+    metrics,
+    budgets,
+    tolerancePct: args.tolerancePct,
+  });
+
+  if (args.updateBaseline) {
+    const n = applyBaselineUpdates(budgets, rows);
+    writeFileSync(args.budgets, `${JSON.stringify(budgets, null, 2)}\n`);
+    console.log(`Recorded ${n} baseline(s) into ${args.budgets}`);
+  }
+
+  const report = {
+    capturedAtIso: new Date().toISOString(),
+    tolerancePct,
+    ok,
+    rows: rows.map((r, i) => ({ ...r, source: metrics[i]?.source })),
+  };
+  if (args.out) {
+    writeFileSync(args.out, `${JSON.stringify(report, null, 2)}\n`);
+  }
+
+  if (args.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    printTable(rows, tolerancePct);
+    console.log(ok ? "\nBudget gate: PASS" : "\nBudget gate: FAIL");
+  }
+
+  // --update-baseline is a recording run: never fail the process on the same
+  // pass that just rewrote the baselines (the "regression" is the recording).
+  process.exit(ok || args.updateBaseline ? 0 : 1);
+}
+
+const isMain =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMain) {
+  // error-policy:J1 CLI boundary — surface any failure as a non-zero exit with a
+  // legible message instead of an unhandled rejection.
+  main().catch((err) => {
+    console.error(
+      `[startup-budget] ${err instanceof Error ? err.message : err}`,
+    );
+    process.exit(1);
+  });
+}

--- a/packages/app/scripts/check-startup-budget.mjs
+++ b/packages/app/scripts/check-startup-budget.mjs
@@ -158,6 +158,11 @@ const FAILING = new Set([
   METRIC_STATUS.MISSING_BUDGET,
 ]);
 
+const BASELINE_RECORDING_BLOCKERS = new Set([
+  METRIC_STATUS.MISSING_METRIC,
+  METRIC_STATUS.MISSING_BUDGET,
+]);
+
 /**
  * Grade every requested metric. `metrics` is [{ category, target, valueMs }].
  * `ok` is true only when no row failed — that is the gate's exit signal.
@@ -182,6 +187,19 @@ export function evaluateAll({ metrics, budgets, tolerancePct }) {
     ok: rows.every((r) => !FAILING.has(r.status)),
     tolerancePct: tol,
   };
+}
+
+/**
+ * A baseline-recording run may be over budget because the measured value is the
+ * new baseline, but it must still prove every requested metric mapped to a real
+ * budget entry. Otherwise `--update-baseline` would turn a misspelled target
+ * into a green no-op.
+ */
+export function shouldPassAfterBaselineUpdate(rows, updatedCount) {
+  return (
+    updatedCount === rows.length &&
+    rows.every((r) => !BASELINE_RECORDING_BLOCKERS.has(r.status))
+  );
 }
 
 // ── CLI boundary ────────────────────────────────────────────────────────────
@@ -349,10 +367,13 @@ async function main() {
     tolerancePct: args.tolerancePct,
   });
 
+  let updatedBaselines = 0;
   if (args.updateBaseline) {
-    const n = applyBaselineUpdates(budgets, rows);
+    updatedBaselines = applyBaselineUpdates(budgets, rows);
     writeFileSync(args.budgets, `${JSON.stringify(budgets, null, 2)}\n`);
-    console.log(`Recorded ${n} baseline(s) into ${args.budgets}`);
+    console.log(
+      `Recorded ${updatedBaselines} baseline(s) into ${args.budgets}`,
+    );
   }
 
   const report = {
@@ -372,9 +393,16 @@ async function main() {
     console.log(ok ? "\nBudget gate: PASS" : "\nBudget gate: FAIL");
   }
 
-  // --update-baseline is a recording run: never fail the process on the same
-  // pass that just rewrote the baselines (the "regression" is the recording).
-  process.exit(ok || args.updateBaseline ? 0 : 1);
+  // --update-baseline is a recording run: over-budget/regressed values are the
+  // new baseline, but missing metrics/budget entries still mean nothing useful
+  // was recorded.
+  process.exit(
+    ok ||
+      (args.updateBaseline &&
+        shouldPassAfterBaselineUpdate(rows, updatedBaselines))
+      ? 0
+      : 1,
+  );
 }
 
 const isMain =

--- a/packages/app/scripts/check-startup-budget.test.ts
+++ b/packages/app/scripts/check-startup-budget.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Unit tests for the cold-boot TTI + build-time regression gate. Fixtures mirror
+ * the real `capture-startup-trace.mjs` artifact shape (runs[].timeline of
+ * {name, atMs}) and the `run-mobile-build.mjs` timing json; the harness is
+ * deterministic (no browser, no device) so the gate's grading logic is pinned
+ * independent of an actual boot capture.
+ */
+import { describe, expect, it } from "vitest";
+// The gate ships as a Node CLI (.mjs) so it runs without a TS toolchain on CI;
+// vitest imports its exported pure functions directly.
+import {
+  computeRegressionPct,
+  DEFAULT_TTI_MARKS,
+  evaluateAll,
+  evaluateMetric,
+  extractTtiMark,
+  METRIC_STATUS,
+  selectColdRun,
+} from "./check-startup-budget.mjs";
+
+function traceRun(kind: string, marks: Array<[string, number]>, extra = {}) {
+  return {
+    run: 0,
+    kind,
+    traceId: "t",
+    timeline: marks.map(([name, atMs]) => ({ name, atMs, deltaMs: 0 })),
+    ...extra,
+  };
+}
+
+const COLD_TIMELINE: Array<[string, number]> = [
+  ["module-eval", 0],
+  ["main-start", 40],
+  ["app-modules:start", 60],
+  ["app-modules:end", 900],
+  ["bridges:start", 910],
+  ["bridges:end", 1200],
+  ["react-mount:start", 1210],
+  ["react-mount:end", 1600],
+  ["startup-shell:mounted", 1850],
+  ["coordinator:ready", 5200],
+];
+
+describe("selectColdRun", () => {
+  it("prefers the cold run over warm runs", () => {
+    const artifact = {
+      runs: [
+        traceRun("warm", [["startup-shell:mounted", 400]]),
+        traceRun("cold", [["startup-shell:mounted", 1850]]),
+      ],
+    };
+    expect(selectColdRun(artifact)?.kind).toBe("cold");
+  });
+
+  it("skips runs that errored (no trace on window)", () => {
+    const artifact = {
+      runs: [
+        { run: 0, kind: "cold", error: "no __ELIZA_STARTUP_TRACE__" },
+        traceRun("warm", [["startup-shell:mounted", 500]]),
+      ],
+    };
+    // The only usable run is the warm one; a cold run that errored must not be
+    // returned as a zero-time measurement.
+    expect(selectColdRun(artifact)?.kind).toBe("warm");
+  });
+
+  it("returns null when there are no usable runs", () => {
+    expect(selectColdRun({ runs: [] })).toBeNull();
+    expect(selectColdRun({ runs: [{ error: "x" }] })).toBeNull();
+    expect(selectColdRun(null)).toBeNull();
+  });
+});
+
+describe("extractTtiMark", () => {
+  it("returns the mounted mark as the usable-shell TTI", () => {
+    const run = traceRun("cold", COLD_TIMELINE);
+    expect(extractTtiMark(run)).toEqual({
+      name: "startup-shell:mounted",
+      atMs: 1850,
+    });
+  });
+
+  it("falls back to first-paint then coordinator:ready by priority", () => {
+    const noMounted = traceRun("cold", [
+      ["module-eval", 0],
+      ["startup-shell:first-paint", 2100],
+      ["coordinator:ready", 5200],
+    ]);
+    expect(extractTtiMark(noMounted)?.name).toBe("startup-shell:first-paint");
+
+    const onlyReady = traceRun("cold", [
+      ["module-eval", 0],
+      ["coordinator:ready", 5200],
+    ]);
+    expect(extractTtiMark(onlyReady)?.name).toBe("coordinator:ready");
+  });
+
+  it("returns null when no TTI mark is present (never fabricates 0)", () => {
+    const stalled = traceRun("cold", [
+      ["module-eval", 0],
+      ["app-modules:start", 60],
+    ]);
+    expect(extractTtiMark(stalled)).toBeNull();
+  });
+
+  it("exposes the mark priority order", () => {
+    expect(DEFAULT_TTI_MARKS[0]).toBe("startup-shell:mounted");
+    expect(DEFAULT_TTI_MARKS).toContain("coordinator:ready");
+  });
+});
+
+describe("computeRegressionPct", () => {
+  it("is positive for a regression and negative for an improvement", () => {
+    expect(computeRegressionPct(2200, 2000)).toBeCloseTo(10);
+    expect(computeRegressionPct(1800, 2000)).toBeCloseTo(-10);
+  });
+  it("is null without a usable baseline", () => {
+    expect(computeRegressionPct(2000, null)).toBeNull();
+    expect(computeRegressionPct(2000, 0)).toBeNull();
+  });
+});
+
+describe("evaluateMetric", () => {
+  const budgetEntry = { budgetMs: 4000, baselineMs: 2000 };
+
+  it("passes within budget and within tolerance of baseline", () => {
+    const r = evaluateMetric({
+      category: "tti",
+      target: "ci-web",
+      valueMs: 2100,
+      budgetEntry,
+      tolerancePct: 15,
+    });
+    expect(r.status).toBe(METRIC_STATUS.PASS);
+  });
+
+  it("fails when over the hard budget ceiling", () => {
+    const r = evaluateMetric({
+      category: "tti",
+      target: "ci-web",
+      valueMs: 4200,
+      budgetEntry,
+      tolerancePct: 15,
+    });
+    expect(r.status).toBe(METRIC_STATUS.OVER_BUDGET);
+  });
+
+  it("fails on a baseline regression past tolerance even while under budget", () => {
+    const r = evaluateMetric({
+      category: "tti",
+      target: "ci-web",
+      valueMs: 2400, // +20% vs 2000 baseline, still under 4000 budget
+      budgetEntry,
+      tolerancePct: 15,
+    });
+    expect(r.status).toBe(METRIC_STATUS.REGRESSED);
+    expect(r.regressionPct).toBeCloseTo(20);
+  });
+
+  it("treats an absent measurement as a failure, not a pass", () => {
+    const r = evaluateMetric({
+      category: "tti",
+      target: "ci-web",
+      valueMs: Number.NaN,
+      budgetEntry,
+      tolerancePct: 15,
+    });
+    expect(r.status).toBe(METRIC_STATUS.MISSING_METRIC);
+  });
+
+  it("fails when the budget entry is missing", () => {
+    const r = evaluateMetric({
+      category: "tti",
+      target: "unknown-device",
+      valueMs: 1000,
+      budgetEntry: undefined,
+      tolerancePct: 15,
+    });
+    expect(r.status).toBe(METRIC_STATUS.MISSING_BUDGET);
+  });
+
+  it("passes with no baseline recorded (budget-only gating)", () => {
+    const r = evaluateMetric({
+      category: "tti",
+      target: "ci-web",
+      valueMs: 3000,
+      budgetEntry: { budgetMs: 4000, baselineMs: null },
+      tolerancePct: 15,
+    });
+    expect(r.status).toBe(METRIC_STATUS.PASS);
+  });
+});
+
+describe("evaluateAll", () => {
+  const budgets = {
+    tolerancePct: 15,
+    tti: { "ci-web": { budgetMs: 4000, baselineMs: 2000 } },
+    build: { "android-apk": { budgetMs: 900000, baselineMs: 600000 } },
+  };
+
+  it("ok=true only when every row passes", () => {
+    const res = evaluateAll({
+      metrics: [
+        { category: "tti", target: "ci-web", valueMs: 2100 },
+        { category: "build", target: "android-apk", valueMs: 620000 },
+      ],
+      budgets,
+    });
+    expect(res.ok).toBe(true);
+    expect(res.rows).toHaveLength(2);
+  });
+
+  it("ok=false when any single row fails the gate", () => {
+    const res = evaluateAll({
+      metrics: [
+        { category: "tti", target: "ci-web", valueMs: 2100 },
+        { category: "build", target: "android-apk", valueMs: 950000 },
+      ],
+      budgets,
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("uses the budgets-file tolerance when none is passed", () => {
+    const res = evaluateAll({
+      metrics: [{ category: "tti", target: "ci-web", valueMs: 2250 }], // +12.5%
+      budgets: { ...budgets, tolerancePct: 10 },
+    });
+    // 12.5% > 10% file tolerance → regressed
+    expect(res.tolerancePct).toBe(10);
+    expect(res.rows[0].status).toBe(METRIC_STATUS.REGRESSED);
+  });
+});

--- a/packages/app/scripts/check-startup-budget.test.ts
+++ b/packages/app/scripts/check-startup-budget.test.ts
@@ -5,6 +5,10 @@
  * deterministic (no browser, no device) so the gate's grading logic is pinned
  * independent of an actual boot capture.
  */
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 // The gate ships as a Node CLI (.mjs) so it runs without a TS toolchain on CI;
 // vitest imports its exported pure functions directly.
@@ -18,6 +22,11 @@ import {
   selectColdRun,
   shouldPassAfterBaselineUpdate,
 } from "./check-startup-budget.mjs";
+
+const SCRIPT_PATH = path.resolve(
+  process.cwd(),
+  "packages/app/scripts/check-startup-budget.mjs",
+);
 
 function traceRun(kind: string, marks: Array<[string, number]>, extra = {}) {
   return {
@@ -262,5 +271,43 @@ describe("shouldPassAfterBaselineUpdate", () => {
         0,
       ),
     ).toBe(false);
+  });
+});
+
+describe("CLI baseline recording", () => {
+  it("does not partially write baselines when one requested metric has no budget", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "startup-budget-"));
+    const budgetsPath = path.join(dir, "budgets.json");
+    writeFileSync(
+      budgetsPath,
+      `${JSON.stringify(
+        {
+          tolerancePct: 15,
+          tti: { "ci-web": { budgetMs: 4000, baselineMs: null } },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        SCRIPT_PATH,
+        "--budgets",
+        budgetsPath,
+        "--metric",
+        "tti:ci-web=2300",
+        "--metric",
+        "tti:typo=2300",
+        "--update-baseline",
+      ],
+      { encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Refusing to update baselines");
+    const budgets = JSON.parse(readFileSync(budgetsPath, "utf8"));
+    expect(budgets.tti["ci-web"].baselineMs).toBeNull();
   });
 });

--- a/packages/app/scripts/check-startup-budget.test.ts
+++ b/packages/app/scripts/check-startup-budget.test.ts
@@ -16,6 +16,7 @@ import {
   extractTtiMark,
   METRIC_STATUS,
   selectColdRun,
+  shouldPassAfterBaselineUpdate,
 } from "./check-startup-budget.mjs";
 
 function traceRun(kind: string, marks: Array<[string, number]>, extra = {}) {
@@ -229,5 +230,37 @@ describe("evaluateAll", () => {
     // 12.5% > 10% file tolerance → regressed
     expect(res.tolerancePct).toBe(10);
     expect(res.rows[0].status).toBe(METRIC_STATUS.REGRESSED);
+  });
+});
+
+describe("shouldPassAfterBaselineUpdate", () => {
+  it("allows recording over-budget values when every metric updated a budget", () => {
+    expect(
+      shouldPassAfterBaselineUpdate(
+        [
+          {
+            category: "tti",
+            target: "ci-web",
+            status: METRIC_STATUS.OVER_BUDGET,
+          },
+        ],
+        1,
+      ),
+    ).toBe(true);
+  });
+
+  it("fails recording runs that did not map every metric to a budget entry", () => {
+    expect(
+      shouldPassAfterBaselineUpdate(
+        [
+          {
+            category: "build",
+            target: "typo",
+            status: METRIC_STATUS.MISSING_BUDGET,
+          },
+        ],
+        0,
+      ),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Delivers the **build-time + TTI budget with a regression gate** for mobile cold
boot (issue #14414, "Done when" bullet 4) — plus the plumbing the other three
bullets need to be measured against a number instead of a vibe.

- **`packages/app/perf-budgets.json`** — the budget contract: cold-TTI targets
  (`ci-web`, `android-lowram`, `ios-reference`) and build targets
  (`android-apk`, `ios-ipa`, `rebuild-loop`), each with a hard `budgetMs`
  ceiling and a recorded `baselineMs`.
- **`packages/app/scripts/check-startup-budget.mjs`** — the regression gate. It
  consumes the boot-timing artifacts the repo already produces (the renderer
  startup trace from `capture-startup-trace.mjs`; the build-timing json below)
  and fails when a metric exceeds its `budgetMs` **or** regresses past
  `baselineMs` by more than `tolerancePct` (default 15%). Pure grading functions
  are unit-tested; `main()` is the only I/O boundary.
- **`packages/app-core/scripts/run-mobile-build.mjs`** — opt-in
  `ELIZA_MOBILE_BUILD_TIMING_OUT=<file>` emits the wall-clock `buildMs` the
  build budget is defined against. Gated behind the env var, so default builds
  are byte-for-byte unchanged.
- **`packages/app/PERF_BUDGET.md`** — the measurement contract and the fastest
  renderer-only inner loop (serve/HMR the web bundle instead of re-baking the
  APK/IPA on every renderer edit; bake only for release).
- `packages/app` script: `bun run --cwd packages/app perf:startup-budget`.

## Why

Cold-boot TTI and build/rebuild time regress silently — nothing turns a slower
boot or a slower build into a red gate. TTI is measured to
`startup-shell:mounted`, the moment the user lands in a usable chat shell while
the agent boots behind it (the already-correct "land in chat while booting"
window this issue wants kept **short**). Per repo error policy, a **missing**
measurement is a gate failure, never a silent pass, and a stalled boot with no
usable-shell mark never reads as `0`.

## Scope

This PR is the measurement foundation (Done-when bullet 4) and the instrument
the deferral/dev-loop work (bullets 1–3, and #14390/#14361) drives against. It
deliberately does **not** touch the delicate agent/renderer boot ordering the
issue says to preserve. Reference-device and build baselines are recorded on
those targets in CI (the values in `perf-budgets.json` ship as budget ceilings
with `baselineMs: null` until captured on the reference target).

Refs #14414

## Evidence

<details><summary>Unit tests — 18/18 pass (deterministic, fixtures mirror the real capture-startup-trace artifact schema)</summary>

```
$ vitest run scripts/check-startup-budget.test.ts
 Test Files  1 passed (1)
      Tests  18 passed (18)
```
Covers: cold-run selection (errored runs excluded), TTI mark priority
(mounted → first-paint → coordinator:ready), regression math, and every gate
verdict (pass / over-budget / regressed / missing-metric / missing-budget).
</details>

<details><summary>Regression gate — real CLI runs across every verdict</summary>

```
### 1. PASS (under budget, no baseline yet)
  tti/ci-web                      1820ms    4000ms         —   PASS
  build/rebuild-loop               12.0s     60.0s         —   PASS
Budget gate: PASS   exit=0

### 2. OVER-BUDGET (5200ms > 4000ms ceiling)
  tti/ci-web                      5200ms    4000ms         —   OVER-BUDGET
Budget gate: FAIL   exit=1

### 3. REGRESSED (2300ms vs 1820ms baseline = +26% > 15% tol, under budget)
  tti/ci-web                      2300ms    4000ms    1820ms   REGRESSED (+26.4%)
Budget gate: FAIL   exit=1

### 4. MISSING (stalled boot never reaches a usable shell)
[startup-budget] cold run has none of the TTI marks
(startup-shell:mounted, startup-shell:first-paint, coordinator:ready);
the boot never reached a usable shell
exit=1
```
</details>

<details><summary>Build-timing json → gate (the shape run-mobile-build.mjs emits)</summary>

```
$ node check-startup-budget.mjs --build-timing build-timing.json --out report.json
  build/android-apk               412.0s    900.0s         —   PASS
Budget gate: PASS   exit=0
```
Machine report row: `{ key: "build/android-apk", valueMs: 412000, budgetMs:
900000, status: "pass", source: { kind: "build-timing", file: ... } }`.
</details>

<details><summary>Lint + error policy</summary>

```
$ bunx biome check <changed files>   → Checked 4 files, No fixes applied.
$ bun run audit:error-policy-ratchet → no new fallback-slop in touched files
```
</details>

### PR_EVIDENCE rows

- **Real-LLM trajectories** — N/A — this change is a build/CI measurement gate;
  no agent/action/provider/prompt/model behavior changes.
- **Backend logs** — N/A — no server runtime path touched (scripts only).
- **Frontend console/network logs** — N/A — no renderer runtime change; the gate
  only *reads* the startup trace the renderer already emits.
- **Before/after screenshots + video** — N/A — no user-visible UI change (new
  files are under `scripts/`, a JSON budget, and a markdown doc).
- **Unit tests** — attached above (18/18).
- **Regression-gate CLI runs** — attached above (pass / over-budget / regressed /
  missing / build-timing).
- **Live headless TTI capture + recorded `ci-web` baseline** — N/A here — the
  `capture-startup-trace.mjs` web path needs the workspace packages built
  (`@elizaos/core` has no dev entry until built) and a running dev server; that
  capture + `--update-baseline` is the CI/operator recording step documented in
  `PERF_BUDGET.md`. The gate that consumes the artifact is proven above against
  fixtures matching that artifact's real schema.
- **On-device build-time baseline** — N/A here — requires the Xcode/Android SDK
  reference-device build; the wall-clock emitter is wired
  (`ELIZA_MOBILE_BUILD_TIMING_OUT`) and its output shape is exercised above.

