### PR TITLE
ci(#14622): flip setAppPermissions view→action ratchet to SETTINGS twin

### DIFF
--- a/packages/scripts/view-action-ratchet.registry.json
+++ b/packages/scripts/view-action-ratchet.registry.json
@@ -79,10 +79,8 @@
       }
     },
     "setAppPermissions": {
-      "gap": {
-        "issue": "#14622",
-        "reason": "app-permissions namespace grants have no semantic twin; SETTINGS_WRITE_REGISTRY is unwired"
-      }
+      "action": "SETTINGS",
+      "note": "app-permissions section route write (GET+PUT /api/apps/permissions/:slug) in SETTINGS_WRITE_REGISTRY; read-modify-write grant/revoke of one fs|net namespace via section=app-permissions app=<slug> key=fs|net value=on|off"
     },
     "updateExperience": {
       "gap": {


### PR DESCRIPTION
## Root cause

`Settings → App permissions` per-namespace toggles call `client.setAppPermissions(slug, nextSet)` (`packages/ui/src/components/settings/AppPermissionsSection.tsx:139`). Their semantic twin was **already built** in #14637:

- `SETTINGS section=app-permissions app=<slug> key=fs|net value=on|off` read-modify-writes the **same** `/api/apps/permissions/:slug` route the on-screen control calls (`APP_PERMISSION_NAMESPACE_KEY` in `plugins/plugin-app-control/src/actions/settings.ts`).
- `SETTINGS_WRITE_REGISTRY["app-permissions"]` is a real `route` capability (not `unwired`).

But the #14369 view→action ratchet sweep (#14967, merged after #14637) re-baselined `setAppPermissions` as a **`gap`** in `packages/scripts/view-action-ratchet.registry.json`. That reopened #14622: the ratchet asserted the mutation had no chat/voice twin when one already existed. This is a registry/reality drift, not a missing action.

## Fix (minimal, one canonical path)

Reconcile the ratchet registry — map `setAppPermissions` to its `SETTINGS` twin, matching the existing `setShellEnabled` precedent (also a permissions-section route write). The gate now records the single canonical semantic path instead of a stale gap. No product code changes: the twin, its tests, and its scenario already ship on develop.

## Acceptance criteria

- [x] A semantic action drives the same use case as the toggle — `SETTINGS section=app-permissions app=<slug> key=fs|net value=on|off` (#14637).
- [x] `SETTINGS_WRITE_REGISTRY["app-permissions"]` is a real `route` capability (#14637).
- [x] The ratchet registry entry for `setAppPermissions` flips from `gap` to `action` — **this PR**.
- [x] Real-LLM scenario evidence — live-only `settings-app-permissions-toggle` scenario ("revoke network access for the weather app") ships in `plugins/plugin-app-control/test/scenarios/`.

## Verification

- `node packages/scripts/view-action-ratchet.mjs` → **passes**; `setAppPermissions` now a `SETTINGS` twin, no longer a gap (`ok: true`, `SETTINGS mapped: true`).
- `node packages/scripts/view-action-ratchet.mjs --self-test` → passes.
- `bun test src/actions/settings.test.ts` (plugin-app-control) → **103 pass / 0 fail**, incl. app-permissions read-modify-write route + namespace-alias tests and the `via: "SETTINGS"` completeness pin.

## Evidence Gate

- Before/after screenshots — `N/A - CI ratchet-registry reconciliation only; no rendered UI surface changed`.
- Walkthrough video — `N/A - no interactive UI flow changed`.
- Backend logs — `N/A - no backend service path started; ratchet + unit-test output listed under Verification`.
- Frontend logs — `N/A - no frontend request/response or state changed`.
- Real-LLM trajectory — `N/A locally (no live provider credentials in this environment); the live-only settings-app-permissions-toggle scenario (added #14637) carries keyed CI/manual evidence`.
- Domain artifacts — `N/A - deterministic route tests verify the namespace grant mutation`.

Closes #14622

🤖 Generated with [Claude Code](https://claude.com/claude-code)