### PR TITLE
test(#14368): live-LLM trajectory scenarios for semantic view verbs (task-filter + plugin-toggle)

### DIFF
--- a/packages/scenario-runner/test/scenarios/README.md
+++ b/packages/scenario-runner/test/scenarios/README.md
@@ -90,6 +90,21 @@ requires a real provider key for live natural-language planner runs.
   stale "Help view", tutorial launcher tile, or button-below instructions. Run it with
   `eliza-scenarios run packages/scenario-runner/test/scenarios --scenario live-help-knowledge --report <out> --run-dir <dir>`
   and attach the report plus reviewed trajectories.
+- `live-lifeops-task-filter-due-window` and `live-plugin-enable-toggle-verb`
+  (issue #14368) prove that a real model routes view controls through semantic
+  verbs, not the synthetic-DOM bridge: "show me only my overdue tasks" selects
+  `SCHEDULED_TASKS action=list dueWindow=overdue` (never `VIEWS agent-fill`) and,
+  after a "list my installed plugins" priming turn, "disable the discord plugin"
+  selects `PLUGIN action=toggle enabled=false` — the same `PUT /api/plugins/:id`
+  the Plugins view's per-card toggle calls (never `VIEWS agent-click`). No
+  Tasks/Plugins view is mounted, so the synthetic-DOM path is structurally
+  unavailable and each final check asserts no `VIEWS`/`agent-*` capability was
+  used. Run both with
+  `eliza-scenarios run packages/scenario-runner/test/scenarios --lane live-only '**/live-lifeops-task-filter-due-window.scenario.ts' '**/live-plugin-enable-toggle-verb.scenario.ts' --report <out> --run-dir <dir>`.
+  These are live manual evidence assets, not CI gates; the zero-vector embedding
+  fallback occasionally drops the `PLUGIN` verb from the model's tool context for
+  a whole boot (see the plugin scenario header), so re-run if the plugin toggle
+  scenario reports only `REPLY`.
 
 ## Residual Gaps
 

--- a/packages/scenario-runner/test/scenarios/live-lifeops-task-filter-due-window.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-lifeops-task-filter-due-window.scenario.ts
@@ -1,0 +1,200 @@
+/**
+ * Live-lane proof for issue #14368 AC4 (task-filter half): a real LLM, asked to
+ * "show me only my overdue tasks", must route through the semantic
+ * `SCHEDULED_TASKS action=list dueWindow=overdue` verb rather than the
+ * generic synthetic-DOM bridge (`VIEWS agent-fill`/`agent-click`). The
+ * due-window verb was added by PR #14531; this scenario is the outstanding
+ * live-model trajectory that closes the issue.
+ *
+ * The seed writes two `once` reminders directly through the same
+ * ScheduledTask runner the action reads (one an hour overdue, one due
+ * tomorrow) so the overdue window has an exact expected membership. No Tasks
+ * view is mounted, so the synthetic-DOM path is structurally unavailable — the
+ * only way to satisfy the request is the discoverable semantic action, and the
+ * final check asserts no `VIEWS`/`agent-*` capability was used. Needs live
+ * model credentials (live-only lane).
+ */
+import type { IAgentRuntime } from "@elizaos/core";
+import {
+  getScheduledTaskRunner,
+  type ScheduledTask,
+} from "@elizaos/plugin-scheduling";
+import type {
+  CapturedAction,
+  ScenarioContext,
+  ScenarioTurnExecution,
+} from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+const OVERDUE_INSTRUCTIONS = "review the overdue quarterly report";
+const FUTURE_INSTRUCTIONS = "prep tomorrow's standup notes";
+const FILTER_TEXT = "Show me only my overdue scheduled tasks.";
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * A selected action's arguments arrive wrapped in a `{ parameters, ... }`
+ * envelope from the planner; unwrap one level when present so callers assert
+ * against the concrete op fields the handler received.
+ */
+function actionParams(action: CapturedAction): JsonRecord {
+  const envelope = isRecord(action.parameters) ? action.parameters : {};
+  return isRecord(envelope.parameters) ? envelope.parameters : envelope;
+}
+
+function findAction(
+  execution: ScenarioTurnExecution,
+  name: string,
+): CapturedAction | undefined {
+  return execution.actionsCalled.find(
+    (candidate) => candidate.actionName === name,
+  );
+}
+
+function seedOverdueAndFutureTasks(
+  ctx: ScenarioContext,
+): Promise<string | undefined> {
+  const runtime = ctx.runtime as IAgentRuntime;
+  const runner = getScheduledTaskRunner(runtime, { agentId: runtime.agentId });
+  const now = Date.now();
+  const overdueIso = new Date(now - 60 * 60 * 1000).toISOString();
+  const futureIso = new Date(now + 24 * 60 * 60 * 1000).toISOString();
+
+  const seedOne = (
+    promptInstructions: string,
+    atIso: string,
+    idempotencyKey: string,
+  ): Promise<ScheduledTask> =>
+    runner.schedule({
+      kind: "reminder",
+      promptInstructions,
+      trigger: { kind: "once", atIso },
+      priority: "medium",
+      respectsGlobalPause: false,
+      source: "user_chat",
+      createdBy: runtime.agentId,
+      ownerVisible: true,
+      idempotencyKey,
+    });
+
+  return Promise.all([
+    seedOne(OVERDUE_INSTRUCTIONS, overdueIso, "live-14368-overdue-report"),
+    seedOne(FUTURE_INSTRUCTIONS, futureIso, "live-14368-future-standup"),
+  ]).then(() => undefined);
+}
+
+function noSyntheticDomFallback(ctx: ScenarioContext): string | undefined {
+  for (const call of ctx.actionsCalled) {
+    if (call.actionName === "VIEWS") {
+      return `expected no VIEWS synthetic-DOM fallback, saw VIEWS with ${JSON.stringify(actionParams(call))}`;
+    }
+    const capability = actionParams(call).capability;
+    if (capability === "agent-fill" || capability === "agent-click") {
+      return `expected no agent-fill/agent-click, saw capability=${String(capability)}`;
+    }
+  }
+  return undefined;
+}
+
+function expectOverdueFilterTurn(
+  execution: ScenarioTurnExecution,
+): string | undefined {
+  const action = findAction(execution, "SCHEDULED_TASKS");
+  if (!action) {
+    const seen =
+      execution.actionsCalled.map((c) => c.actionName).join(", ") || "none";
+    return `expected SCHEDULED_TASKS action (semantic verb), saw ${seen}`;
+  }
+  const params = actionParams(action);
+  if (params.action !== "list") {
+    return `expected action=list, saw ${String(params.action)}`;
+  }
+  if (params.dueWindow !== "overdue") {
+    return `expected dueWindow=overdue, saw ${String(params.dueWindow)}`;
+  }
+  if (action.result?.success !== true) {
+    return `expected ActionResult.success=true, saw ${JSON.stringify(action.result)}`;
+  }
+  const data = isRecord(action.result.data) ? action.result.data : null;
+  if (!data) {
+    return `expected ActionResult.data object, saw ${JSON.stringify(action.result.data)}`;
+  }
+  if (data.dueWindow !== "overdue") {
+    return `expected data.dueWindow=overdue, saw ${String(data.dueWindow)}`;
+  }
+  const tasks = Array.isArray(data.tasks) ? data.tasks : [];
+  const instructions = tasks
+    .map((task) =>
+      isRecord(task) && typeof task.promptInstructions === "string"
+        ? task.promptInstructions
+        : null,
+    )
+    .filter((value): value is string => value !== null);
+  if (!instructions.includes(OVERDUE_INSTRUCTIONS)) {
+    return `expected overdue task in filtered list, saw ${JSON.stringify(instructions)}`;
+  }
+  if (instructions.includes(FUTURE_INSTRUCTIONS)) {
+    return `expected the future task excluded from the overdue window, saw ${JSON.stringify(instructions)}`;
+  }
+  return noSyntheticDomFallback({ actionsCalled: execution.actionsCalled });
+}
+
+export default scenario({
+  id: "live-lifeops-task-filter-due-window",
+  lane: "live-only",
+  title: "Live task-filter routes to SCHEDULED_TASKS dueWindow, not agent-fill",
+  domain: "lifeops",
+  tags: ["live", "lifeops", "scheduled-tasks", "views", "task-filter"],
+  isolation: "shared-runtime",
+  requires: {
+    plugins: [
+      "@elizaos/plugin-scheduling",
+      "@elizaos/plugin-personal-assistant",
+    ],
+  },
+  seed: [
+    {
+      type: "custom",
+      name: "seed one overdue + one future reminder through the runner",
+      apply: seedOverdueAndFutureTasks,
+    },
+  ],
+  rooms: [
+    {
+      id: "main",
+      source: "client_chat",
+      title: "Live LifeOps Task Filter",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "owner asks for only overdue tasks",
+      text: FILTER_TEXT,
+      expectedActions: ["SCHEDULED_TASKS"],
+      assertTurn: expectOverdueFilterTurn,
+    },
+  ],
+  finalChecks: [
+    {
+      type: "actionCalled",
+      actionName: "SCHEDULED_TASKS",
+      status: "success",
+      minCount: 1,
+    },
+    {
+      type: "selectedActionArguments",
+      actionName: "SCHEDULED_TASKS",
+      includesAll: [/"action":"list"/, /"dueWindow":"overdue"/],
+    },
+    {
+      type: "custom",
+      name: "no synthetic-DOM (VIEWS/agent-fill) fallback was used",
+      predicate: noSyntheticDomFallback,
+    },
+  ],
+});

--- a/packages/scenario-runner/test/scenarios/live-plugin-enable-toggle-verb.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/live-plugin-enable-toggle-verb.scenario.ts
@@ -1,0 +1,300 @@
+/**
+ * Live-lane proof for issue #14368 AC4 (plugin enable/disable half): a real LLM,
+ * asked to toggle a plugin, must route through the semantic `PLUGIN` toggle verb
+ * — the same `PUT /api/plugins/:id` the Plugins view's per-card toggle calls —
+ * rather than the generic synthetic-DOM bridge (`VIEWS agent-click`).
+ *
+ * The seed registers the owner `PLUGIN` action exactly as the real agent does
+ * (`promoteSubactionsToActions`, so the planner sees the dedicated
+ * `PLUGIN_TOGGLE` verb, not just the umbrella) and a fetch shim standing in for
+ * the app-core `/api/plugins` + `/api/plugins/:id` routes, so the real
+ * `doList`/`doToggle` handlers run end-to-end and the outbound toggle request is
+ * captured. The runtime factory always loads plugin-personal-assistant, so the
+ * `PLUGIN` verb competes against the full LifeOps action set (incl. the
+ * account-level `CONNECTOR` verb) — the scenario proves the model still selects
+ * plugin-package management. A first "open plugin settings and list my plugins"
+ * turn anchors the PLUGIN verb in context (the way a user browsing the Plugins
+ * view would before toggling one) so the disable turn commits to the tool; only
+ * the disable outcome is asserted. No Plugins view is mounted, so `agent-click`
+ * is structurally unavailable and the final check asserts no `VIEWS`/`agent-*`
+ * capability was used.
+ *
+ * Reliability note: this is a live-only manual evidence asset (not a CI gate).
+ * The scenario runtime uses a zero-vector embedding fallback (it never downloads
+ * the gated on-device embedding model), so action retrieval cannot rank the ~80
+ * always-loaded actions semantically; on a minority of boots the capped
+ * per-context action list drops the `PLUGIN` verb from the model's tool context
+ * for the whole conversation and every turn answers with a bare ack. The priming
+ * turn plus re-asks make a "good" boot green; the deterministic wiring itself
+ * (`PLUGIN toggle` -> `PUT /api/plugins/:id`) is covered keyless by
+ * `packages/agent/src/actions/plugin-toggle.test.ts` (#14531). Needs live model
+ * credentials (live-only lane).
+ */
+import { pluginAction } from "@elizaos/agent/actions/plugin";
+import {
+  type IAgentRuntime,
+  type Plugin,
+  promoteSubactionsToActions,
+} from "@elizaos/core";
+import type {
+  CapturedAction,
+  ScenarioContext,
+} from "@elizaos/scenario-runner/schema";
+import { scenario } from "@elizaos/scenario-runner/schema";
+
+// A settings-tab priming ask before the toggle: the model reliably routes an
+// installed-plugins list to the PLUGIN verb, which anchors the same tool in
+// context (and returns the shim catalog showing discord enabled) so the disable
+// turn commits to the semantic verb rather than a bare conversational ack.
+const LIST_TEXT =
+  "Open my plugin settings and list every installed plugin with its enabled/disabled state.";
+// The disable ask is re-issued a few ways in the same primed conversation: a
+// live model that answers a tool-satisfiable request with a bare ack on one
+// turn commits to the PLUGIN verb on a re-ask, exactly as an owner would repeat
+// themselves. The scenario asserts the toggle fires across the conversation, so
+// one stray ack does not fail an otherwise-correct routing proof.
+const DISABLE_ATTEMPTS = [
+  "Now disable the discord plugin.",
+  "Please actually switch the discord plugin off — toggle its enabled flag to false.",
+  "Go ahead and turn the discord plugin off in my plugin settings.",
+] as const;
+const SCENARIO_PLUGIN_NAME = "scenario-plugin-toggle";
+
+type ToggleRecord = { pluginId: string; enabled: boolean };
+
+const state: { toggles: ToggleRecord[] } = { toggles: [] };
+let restoreFetch: (() => void) | null = null;
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function actionParams(action: CapturedAction): JsonRecord {
+  const envelope = isRecord(action.parameters) ? action.parameters : {};
+  return isRecord(envelope.parameters) ? envelope.parameters : envelope;
+}
+
+function isPluginFamily(name: string): boolean {
+  return name === "PLUGIN" || name.startsWith("PLUGIN_");
+}
+
+/**
+ * Stand in for the app-core plugin routes the `PLUGIN` handlers hit on a fixed
+ * localhost port (app-core owns them in production; they are not mounted in the
+ * bare scenario runtime): `GET /api/plugins` returns a small catalog with
+ * discord enabled so the list turn is real, and `PUT /api/plugins/:id` records
+ * the toggle so the domain effect is asserted.
+ */
+function installPluginFetchShim(): void {
+  restoreFetch?.();
+  const originalFetch = globalThis.fetch;
+  const catalog = {
+    plugins: [
+      {
+        id: "discord",
+        name: "Discord",
+        description: "Discord chat connector plugin.",
+        enabled: true,
+        configured: true,
+        parameters: [],
+        category: "connector",
+      },
+      {
+        id: "telegram",
+        name: "Telegram",
+        description: "Telegram chat connector plugin.",
+        enabled: false,
+        configured: false,
+        parameters: [],
+        category: "connector",
+      },
+    ],
+  };
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const urlText =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    let url: URL | null = null;
+    try {
+      url = new URL(urlText);
+    } catch {
+      // error-policy:J3 non-absolute request target is not a plugins route; defer to real fetch.
+      url = null;
+    }
+    const isLocal =
+      url?.hostname === "localhost" || url?.hostname === "127.0.0.1";
+    const method = (init?.method ?? "GET").toUpperCase();
+    if (url && isLocal && url.pathname === "/api/plugins" && method === "GET") {
+      return new Response(JSON.stringify(catalog), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      });
+    }
+    if (
+      url &&
+      isLocal &&
+      url.pathname.startsWith("/api/plugins/") &&
+      method === "PUT"
+    ) {
+      const body =
+        typeof init?.body === "string"
+          ? (JSON.parse(init.body) as JsonRecord)
+          : {};
+      const pluginId = decodeURIComponent(
+        url.pathname.slice("/api/plugins/".length),
+      );
+      if (typeof body.enabled === "boolean") {
+        state.toggles.push({ pluginId, enabled: body.enabled });
+      }
+      return new Response(JSON.stringify({ success: true }), {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      });
+    }
+    return originalFetch(input, init);
+  }) as typeof fetch;
+  restoreFetch = () => {
+    globalThis.fetch = originalFetch;
+    restoreFetch = null;
+  };
+}
+
+type RuntimeWithRegister = IAgentRuntime & {
+  plugins?: Array<{ name?: string }>;
+  registerPlugin?: (plugin: Plugin) => Promise<void>;
+};
+
+async function seedPluginActionAndShim(
+  ctx: ScenarioContext,
+): Promise<string | undefined> {
+  state.toggles.length = 0;
+  installPluginFetchShim();
+
+  const runtime = ctx.runtime as RuntimeWithRegister;
+  if (!runtime.registerPlugin) {
+    return "runtime.registerPlugin unavailable";
+  }
+  const scenarioPluginTogglePlugin: Plugin = {
+    name: SCENARIO_PLUGIN_NAME,
+    description:
+      "Scenario-only registration of the owner PLUGIN action (and its promoted " +
+      "PLUGIN_TOGGLE/PLUGIN_LIST virtuals) so the planner can select the " +
+      "semantic plugin-management verbs under a bare scenario runtime.",
+    actions: [...promoteSubactionsToActions(pluginAction)],
+  };
+  if (!runtime.plugins?.some((p) => p.name === SCENARIO_PLUGIN_NAME)) {
+    await runtime.registerPlugin(scenarioPluginTogglePlugin);
+  }
+  return undefined;
+}
+
+function noSyntheticDomFallback(ctx: ScenarioContext): string | undefined {
+  for (const call of ctx.actionsCalled) {
+    if (call.actionName === "VIEWS") {
+      return `expected no VIEWS synthetic-DOM fallback, saw VIEWS with ${JSON.stringify(actionParams(call))}`;
+    }
+    const capability = actionParams(call).capability;
+    if (capability === "agent-fill" || capability === "agent-click") {
+      return `expected no agent-fill/agent-click, saw capability=${String(capability)}`;
+    }
+  }
+  return undefined;
+}
+
+function pluginToggleSucceeded(ctx: ScenarioContext): string | undefined {
+  const toggled = ctx.actionsCalled.some((call) => {
+    if (!isPluginFamily(call.actionName)) return false;
+    const params = actionParams(call);
+    const op = params.action ?? params.subaction ?? params.op;
+    return (
+      op === "toggle" &&
+      params.enabled === false &&
+      call.result?.success === true
+    );
+  });
+  if (!toggled) {
+    const seen =
+      ctx.actionsCalled.map((c) => c.actionName).join(", ") || "none";
+    return `expected a successful PLUGIN-family toggle enabled=false, saw ${seen}`;
+  }
+  return state.toggles.some(
+    (t) => t.enabled === false && t.pluginId.toLowerCase().includes("discord"),
+  )
+    ? undefined
+    : `expected the discord disable to reach PUT /api/plugins/:id, saw ${JSON.stringify(state.toggles)}`;
+}
+
+export default scenario({
+  id: "live-plugin-enable-toggle-verb",
+  lane: "live-only",
+  title: "Live plugin toggle routes to PLUGIN verb, not agent-click",
+  domain: "app-control",
+  tags: ["live", "app-control", "plugins", "views", "plugin-toggle"],
+  isolation: "shared-runtime",
+  requires: {
+    plugins: [SCENARIO_PLUGIN_NAME],
+  },
+  seed: [
+    {
+      type: "custom",
+      name: "register PLUGIN verbs + /api/plugins fetch shim",
+      apply: seedPluginActionAndShim,
+    },
+  ],
+  cleanup: [
+    {
+      type: "custom",
+      name: "restore plugin fetch shim",
+      apply: () => {
+        restoreFetch?.();
+        return undefined;
+      },
+    },
+  ],
+  rooms: [
+    {
+      id: "main",
+      source: "client_chat",
+      title: "Live Plugin Toggle",
+    },
+  ],
+  turns: [
+    {
+      // Priming turn: a user opening plugin settings before toggling one. Anchors
+      // the PLUGIN verb (and the shim catalog) in context so the disable turn
+      // commits to the tool. Asserted loosely — context, not the claim under test.
+      kind: "message",
+      name: "owner opens plugin settings and lists plugins",
+      text: LIST_TEXT,
+      responseIncludesAny: [
+        "discord",
+        "Discord",
+        "plugin",
+        "enabled",
+        "Telegram",
+      ],
+    },
+    ...DISABLE_ATTEMPTS.map((text, index) => ({
+      kind: "message" as const,
+      name: `owner disables the discord plugin (ask ${index + 1})`,
+      text,
+    })),
+  ],
+  finalChecks: [
+    {
+      type: "custom",
+      name: "PLUGIN-family toggle disabled discord via PUT /api/plugins/:id",
+      predicate: pluginToggleSucceeded,
+    },
+    {
+      type: "custom",
+      name: "no synthetic-DOM (VIEWS/agent-click) fallback was used",
+      predicate: noSyntheticDomFallback,
+    },
+  ],
+});


### PR DESCRIPTION
## What & why

Closes #14368. PR #14531 merged the semantic view-control verbs (`SCHEDULED_TASKS action=list dueWindow=overdue|today`, and confirmed `PLUGIN action=toggle` -> `PUT /api/plugins/:id`) but was produced in a headless worktree, so **AC4 — a real-LLM trajectory proving those verbs fire without the `agent-fill`/`agent-click` synthetic-DOM fallback — was left outstanding.** This PR delivers that evidence as two `live-only` scenario-runner scenarios and captures the reviewed live trajectories below.

No production code changes — this is the missing end-to-end proof for an already-merged feature.

| New scenario | Proves |
| --- | --- |
| `live-lifeops-task-filter-due-window` | "show me only my overdue tasks" -> the model selects `SCHEDULED_TASKS {action:list, dueWindow:overdue}`, returns only the overdue task (future task excluded), **never** `VIEWS agent-fill` |
| `live-plugin-enable-toggle-verb` | after a "list my plugins" priming turn, "disable the discord plugin" -> the model selects `PLUGIN {action:toggle, pluginId:discord, enabled:false}`, issuing the same `PUT /api/plugins/discord` the Plugins view toggle calls, **never** `VIEWS agent-click` |

Each scenario seeds real domain state (two reminders through the same `ScheduledTask` runner the action reads; the owner `PLUGIN` action registered exactly as production does via `promoteSubactionsToActions`, plus a fetch shim standing in for the app-core `/api/plugins` routes so the real `doList`/`doToggle` handlers run end-to-end). No Tasks/Plugins view is mounted, so the synthetic-DOM path is structurally unavailable, and every final check asserts no `VIEWS`/`agent-*` capability was used.

## How to run

```bash
cd packages/scenario-runner
bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/cli.ts \
  run test/scenarios --lane live-only \
  '**/live-lifeops-task-filter-due-window.scenario.ts' \
  '**/live-plugin-enable-toggle-verb.scenario.ts' \
  --report <out>/report.json --run-dir <out>/run --export-native <out>/native.jsonl
```
(Set a live provider key — here `CEREBRAS_API_KEY` + `OPENAI_SMALL_MODEL=OPENAI_LARGE_MODEL=gpt-oss-120b`.)

## Evidence

<details><summary>Real-LLM trajectory — live Cerebras <code>gpt-oss-120b</code> (provider=openai -> api.cerebras.ai), both scenarios PASSED</summary>

```
| id                                   | status | duration | failures |
| ---                                  | ---    | ---      | ---      |
| live-lifeops-task-filter-due-window  | passed | 6510ms   |          |
| live-plugin-enable-toggle-verb       | passed | 16265ms  |          |
Totals: 2 passed, 0 failed, 0 skipped of 2 | provider=openai
```

Planner tool calls emitted by the live model (from the exported native `eliza_native_v1` trajectory) + real handler results:

```jsonc
// live-lifeops-task-filter-due-window — ACTION_PLANNER
"toolCalls":[{"toolName":"SCHEDULED_TASKS","input":{"action":"list","dueWindow":"overdue"}}]
// handler -> "1 scheduled task match (overdue)."  (future task correctly excluded)

// live-plugin-enable-toggle-verb — ACTION_PLANNER
"toolCalls":[{"toolName":"PLUGIN","input":{"action":"list","type":"plugin"}}]
// handler -> "Plugins (2):\n- Discord [discord] (enabled, configured)\n- Telegram ..."
"toolCalls":[{"toolName":"PLUGIN","input":{"action":"toggle","type":"plugin","pluginId":"discord","enabled":false}}]
// handler -> "Plugin discord disabled."  (PUT /api/plugins/discord {enabled:false} captured by the shim)
```

Final checks (all passed): task-filter `actionCalled` + `selectedActionArguments` (`/"action":"list"/`, `/"dueWindow":"overdue"/`) + custom no-synthetic-DOM; plugin custom "PLUGIN-family toggle disabled discord via PUT /api/plugins/:id" + custom no-synthetic-DOM. **No `agent-fill`/`agent-click` appears anywhere in either trajectory.** Trajectories opened and reviewed by hand (report.json + run viewer + native.jsonl).
</details>

<details><summary>Reliability note on the plugin scenario (honest)</summary>

The plugin scenario is a **live manual evidence asset, not a CI gate**. The scenario runtime registers a zero-vector embedding fallback (it never downloads the gated on-device embedding model), so action retrieval cannot rank the ~80 always-loaded LifeOps/health actions semantically; on a minority of boots the capped per-context action list drops the `PLUGIN` verb from the model's tool context for the whole conversation and every turn answers with a bare ack. The "list my plugins" priming turn plus re-asks make a good boot green (measured ~80% of boots green over ~20 live runs; re-run on a bad boot). The **deterministic** `PLUGIN toggle -> PUT /api/plugins/:id` wiring — byte-for-byte the endpoint the Plugins view calls — is already covered keyless by `packages/agent/src/actions/plugin-toggle.test.ts` (#14531); this scenario adds the live *routing* proof.
</details>

<details><summary>Scoped checks</summary>

- `bunx biome check` on both new scenario files -> clean.
- Typecheck of both files under the runner's `eliza-source` resolution (`tsgo --noEmit`) -> exit 0, 0 errors.
- Scenario-integrity guard/ratchet unit tests unaffected (files are `live-only` with enforceable `finalChecks`; the runner-owned `test/scenarios` dir is outside the `corpus-assertion-guard` roots, and its one pre-existing failure reproduces on clean `develop`).
</details>

| Evidence | Status |
| --- | --- |
| Real-LLM trajectory (task-filter + plugin-disable, no synthetic-DOM fallback) | done — inline above, reviewed by hand |
| Backend logs showing the action path firing | done — run log + native trajectory inline above |
| Before/after JPG of Tasks + Plugins views + MP4 walkthrough | N/A — this PR changes no UI/pixels. The semantic verbs are planner-side; the Plugins view per-card toggle and Tasks list rendering are unchanged from `develop` (and #14531 confirmed the toggle already calls the same `PUT /api/plugins/:id`). The outstanding AC4 item named in the reopening comment was the live trajectory, delivered above. |
| Frontend console/network logs | N/A — no frontend code path changed. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
