### PR TITLE
fix(discord): route button-tap replies through the canonical widget renderer (#14527)

### DIFF
--- a/plugins/plugin-discord/__tests__/interaction-replay-render.test.ts
+++ b/plugins/plugin-discord/__tests__/interaction-replay-render.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Regression guard for #14527: the Discord button-tap replay path must render a
+ * follow-up reply's link-out blocks (task cards, navigate chips) as native
+ * components, exactly like the message-manager reply path. Before the fix the
+ * replay callback rendered without the app-origin resolver, so a `[TASK:…]`
+ * reply produced after a choice tap silently lost its "Open task" button.
+ *
+ * Drives the REAL `handleInteractionCreate` codec-button branch with a fake
+ * discord.js interaction + a fake message service whose handler replies with a
+ * task card; asserts the captured `channel.send` carries the link button. Only
+ * the discord.js SDK objects are stubbed — no bot token, no network.
+ */
+import { encodeReplyCallback } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import { handleInteractionCreate } from "../discord-interactions";
+
+const TASK_ID = "abc12345def67890abcdef1234567890";
+const noop = () => {};
+
+interface CapturedSend {
+	content?: string;
+	components?: Array<{ toJSON(): { type: number; components: unknown[] } }>;
+}
+
+function makeService(appUrl: string | undefined) {
+	const sends: CapturedSend[] = [];
+	const channel = {
+		id: "chan-1",
+		send: vi.fn(async (opts: CapturedSend) => {
+			sends.push(opts);
+			return { id: `sent-${sends.length}` };
+		}),
+	};
+	// The fake message service replays the tapped choice value back into the
+	// agent loop and, like a real turn, answers with a task-card reply.
+	const messageService = {
+		handleMessage: vi.fn(
+			async (
+				_runtime: unknown,
+				_memory: unknown,
+				callback: (content: {
+					text: string;
+					source: string;
+				}) => Promise<unknown[]>,
+			) => {
+				await callback({
+					text: `Opening your task.\n[TASK:${TASK_ID}]Ship the release[/TASK]`,
+					source: "discord",
+				});
+			},
+		),
+	};
+	const service = {
+		accountId: "test",
+		client: { user: { id: "bot-1" }, users: { fetch: vi.fn() } },
+		character: {},
+		slashCommands: [],
+		timeouts: [],
+		userSelections: new Map(),
+		resolveDiscordEntityId: vi.fn(() => "00000000-0000-0000-0000-000000000001"),
+		getChannelType: vi.fn(),
+		runtime: {
+			agentId: "00000000-0000-0000-0000-0000000000aa",
+			messageService,
+			getSetting: (key: string): string | undefined =>
+				key === "ELIZA_APP_URL" ? appUrl : undefined,
+			ensureConnection: vi.fn(async () => {}),
+			logger: { info: noop, warn: noop, debug: noop, error: noop },
+		},
+	};
+	return { service, channel, sends, messageService };
+}
+
+function makeCodecButtonInteraction(channel: unknown) {
+	const codecId = encodeReplyCallback("yes", { maxBytes: 100 });
+	if (!codecId) throw new Error("codec id should encode");
+	return {
+		id: "interaction-1",
+		type: 3,
+		componentType: 2,
+		user: {
+			id: "user-1",
+			username: "alice",
+			displayName: "Alice",
+			bot: false,
+		},
+		guild: null,
+		channel,
+		message: { id: "msg-1" },
+		customId: codecId,
+		isCommand: () => false,
+		isModalSubmit: () => false,
+		isMessageComponent: () => true,
+		isStringSelectMenu: () => false,
+		isButton: () => true,
+		replied: false,
+		deferred: false,
+		deferUpdate: vi.fn(async () => {}),
+	};
+}
+
+describe("#14527 button-tap replay renders link-out blocks natively", () => {
+	it("attaches an Open task link button to a post-tap task reply", async () => {
+		const { service, channel, sends } = makeService("https://app.test");
+		const interaction = makeCodecButtonInteraction(channel);
+
+		await handleInteractionCreate(service as never, interaction as never);
+
+		expect(channel.send).toHaveBeenCalledTimes(1);
+		const built = sends[0]?.components;
+		expect(built).toBeDefined();
+		expect(built).toHaveLength(1);
+		const row = built?.[0].toJSON();
+		expect(row?.type).toBe(1);
+		const button = (
+			row?.components as Array<{ style: number; url?: string }>
+		)[0];
+		// Style 5 = Link; the URL is the resolved orchestrator task view.
+		expect(button.style).toBe(5);
+		expect(button.url).toBe(`https://app.test/orchestrator?taskId=${TASK_ID}`);
+		// Prose keeps the title; the raw marker is stripped.
+		expect(sends[0]?.content).toContain("Opening your task.");
+		expect(sends[0]?.content).not.toContain("[TASK:");
+	});
+
+	it("degrades the same reply to prose when no app origin is configured", async () => {
+		const { service, channel, sends } = makeService(undefined);
+		const interaction = makeCodecButtonInteraction(channel);
+
+		await handleInteractionCreate(service as never, interaction as never);
+
+		expect(channel.send).toHaveBeenCalledTimes(1);
+		// No resolver URL: no fabricated dead button, and the title survives as prose.
+		expect(sends[0]?.components ?? []).toHaveLength(0);
+		expect(sends[0]?.content).toContain("Ship the release");
+	});
+});

--- a/plugins/plugin-discord/__tests__/interactions.test.ts
+++ b/plugins/plugin-discord/__tests__/interactions.test.ts
@@ -10,7 +10,10 @@ import {
 	FORM_FREE_TEXT_INVITE,
 } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
-import { renderDiscordInteractions } from "../interactions";
+import {
+	buildDiscordReplyPayload,
+	renderDiscordInteractions,
+} from "../interactions";
 
 describe("renderDiscordInteractions", () => {
 	it("passes plain replies through with no components", () => {
@@ -152,5 +155,59 @@ describe("renderDiscordInteractions", () => {
 		expect(out.text).toContain("Set your reminder");
 		expect(out.text).toContain(FORM_FREE_TEXT_INVITE);
 		expect(out.text).not.toContain("/forms/");
+	});
+});
+
+// #14527 — every Discord send path must resolve link-out blocks (task cards,
+// navigate chips) identically. `buildDiscordReplyPayload` is the one place that
+// derives the app-origin resolver from settings, so both the message-manager
+// reply path and the button-tap replay path get the same "Open task" button.
+// A bare `renderDiscordInteractions(content)` without the resolver drops it.
+describe("buildDiscordReplyPayload — canonical resolver derivation (#14527)", () => {
+	const TASK_ID = "abc12345def67890abcdef1234567890";
+
+	function makeRuntime(settings: Record<string, string>) {
+		return {
+			getSetting: (key: string): string | undefined => settings[key],
+		};
+	}
+
+	it("resolves a task card to an Open task link button from ELIZA_APP_URL", () => {
+		const out = buildDiscordReplyPayload(
+			makeRuntime({ ELIZA_APP_URL: "https://app.test" }),
+			{ text: `[TASK:${TASK_ID}]Ship it[/TASK]` } as Content,
+		);
+		const button = out.components[0]?.components[0];
+		expect(button?.style).toBe(5); // Link
+		expect(button?.url).toBe(`https://app.test/orchestrator?taskId=${TASK_ID}`);
+		expect(out.needsFreeTextReply).toBe(false);
+	});
+
+	it("falls back to ELIZA_CLOUD_URL when ELIZA_APP_URL is unset", () => {
+		const out = buildDiscordReplyPayload(
+			makeRuntime({ ELIZA_CLOUD_URL: "https://cloud.test" }),
+			{ text: `[TASK:${TASK_ID}]Ship it[/TASK]` } as Content,
+		);
+		const button = out.components[0]?.components[0];
+		expect(button?.url).toBe(
+			`https://cloud.test/orchestrator?taskId=${TASK_ID}`,
+		);
+	});
+
+	it("degrades to prose (no dropped-silent button) when no app origin is set", () => {
+		const out = buildDiscordReplyPayload(makeRuntime({}), {
+			text: `[TASK:${TASK_ID}]Ship it[/TASK]`,
+		} as Content);
+		expect(out.components).toHaveLength(0);
+		expect(out.needsFreeTextReply).toBe(true);
+		expect(out.text).toContain("Ship it");
+	});
+
+	it("still renders choice buttons regardless of app-origin config", () => {
+		const out = buildDiscordReplyPayload(makeRuntime({}), {
+			text: "Approve?\n[CHOICE:approve id=c1]\nyes=Yes\nno=No\n[/CHOICE]",
+		} as Content);
+		expect(out.components).toHaveLength(1);
+		expect(out.components[0].components).toHaveLength(2);
 	});
 });

--- a/plugins/plugin-discord/discord-interactions.ts
+++ b/plugins/plugin-discord/discord-interactions.ts
@@ -36,7 +36,7 @@ import {
 	buildDiscordEntityMetadata,
 	buildDiscordWorldMetadata,
 } from "./identity";
-import { renderDiscordInteractions } from "./interactions";
+import { buildDiscordReplyPayload } from "./interactions";
 import { generateInviteUrl } from "./permissions";
 import { syncDiscordClientProfile } from "./profileSync";
 import type { DiscordService } from "./service";
@@ -260,7 +260,7 @@ export async function handleInteractionCreate(
 				if (!content.text || !channel || typeof channel.send !== "function") {
 					return [];
 				}
-				const render = renderDiscordInteractions(content);
+				const render = buildDiscordReplyPayload(service.runtime, content);
 				await sendMessageInChunks(
 					channel,
 					render.text,

--- a/plugins/plugin-discord/interactions.ts
+++ b/plugins/plugin-discord/interactions.ts
@@ -12,7 +12,9 @@
  */
 
 import {
+	buildInteractionUrlResolver,
 	type Content,
+	type IAgentRuntime,
 	type InteractionBlock,
 	type NeutralButton,
 	parseInteractionBlocks,
@@ -135,4 +137,28 @@ export function renderDiscordInteractions(
 		.filter((s) => s.trim().length > 0)
 		.join("\n\n");
 	return { text, components: visibleRows, needsFreeTextReply };
+}
+
+/**
+ * Canonical entry point for turning an outbound `Content` into Discord text +
+ * components. Every Discord send path — the streaming/DM/channel reply in
+ * `messages.ts` and the button-tap replay in `discord-interactions.ts` — routes
+ * through here so link-out blocks (task cards, `navigate` chips) resolve their
+ * URL identically. Rendering without the resolver silently drops those buttons
+ * (a `[TASK:…]` reply degrades to bare prose), so the resolver must not be a
+ * per-call-site detail: it is derived once, here, from the deployment's app
+ * origin (`ELIZA_APP_URL`, then `ELIZA_CLOUD_URL`).
+ */
+export function buildDiscordReplyPayload(
+	runtime: Pick<IAgentRuntime, "getSetting">,
+	content: Content,
+): DiscordInteractionRender {
+	const rawAppUrl =
+		runtime.getSetting("ELIZA_APP_URL") ??
+		runtime.getSetting("ELIZA_CLOUD_URL");
+	const appBaseUrl = typeof rawAppUrl === "string" ? rawAppUrl : undefined;
+	return renderDiscordInteractions(
+		content,
+		buildInteractionUrlResolver(appBaseUrl),
+	);
 }

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -5,7 +5,6 @@
  */
 import { createHash } from "node:crypto";
 import {
-	buildInteractionUrlResolver,
 	ChannelType,
 	type Content,
 	ContentType,
@@ -48,7 +47,7 @@ import { createDraftStreamController } from "./draft-stream";
 import { getDiscordSettings } from "./environment";
 import { buildDiscordWorldMetadata } from "./identity";
 import { formatInboundEnvelope } from "./inbound-envelope";
-import { renderDiscordInteractions } from "./interactions";
+import { buildDiscordReplyPayload } from "./interactions";
 import {
 	appendCoalescedDiscordMetadata,
 	type DiscordMessageWithCoalescedMetadata,
@@ -1044,15 +1043,7 @@ export class MessageManager {
 
 					// Project embedded interaction blocks (choices, task cards, …) onto
 					// native Discord components, and strip their markers from the prose.
-					const rawAppUrl =
-						this.runtime.getSetting("ELIZA_APP_URL") ||
-						this.runtime.getSetting("ELIZA_CLOUD_URL");
-					const appBaseUrl =
-						typeof rawAppUrl === "string" ? rawAppUrl : undefined;
-					const rendered = renderDiscordInteractions(
-						content,
-						buildInteractionUrlResolver(appBaseUrl),
-					);
+					const rendered = buildDiscordReplyPayload(this.runtime, content);
 					const hasComponents = rendered.components.length > 0;
 					let textContent = normalizeDiscordMessageText(rendered.text);
 					if (textContent.trim().length === 0 && hasComponents) {


### PR DESCRIPTION
## Root cause

The Discord connector had **two** outbound render+send paths that rendered interaction widgets **differently**:

| Path | Render call | Task / navigate blocks |
|---|---|---|
| Message-manager reply (`messages.ts:1052`) | `renderDiscordInteractions(content, buildInteractionUrlResolver(appBaseUrl))` | resolve to native **"Open task"** / link-out buttons ✅ |
| Button-tap replay (`discord-interactions.ts:306`) | `renderDiscordInteractions(content)` — **no resolver** | silently degrade to bare prose ❌ |

So when a user taps a choice/followup button and the agent's follow-up reply itself contains a `[TASK:…]` card or a `navigate` chip, the link button was **silently dropped** on the replay path — the exact "Discord drops widget components on render" class this issue tracks, on a path none of the merged fixes (#14577 / #14603 / #14633 / #14616) or the open #15010 touch.

The underlying defect is architectural: the URL resolver was a **per-call-site detail**, so a second send path simply forgot it. Patching each site individually (as the earlier PRs did for the DM and draft-finalize paths) leaves the next send site free to drop widgets again.

## Fix (one canonical path)

Introduce a single canonical **`buildDiscordReplyPayload(runtime, content)`** in `interactions.ts` that derives the app-origin resolver **once** (from `ELIZA_APP_URL`, then `ELIZA_CLOUD_URL`) and renders. Both outbound paths now route through it:

- `messages.ts` — the streaming / DM / channel reply path (dedups the inline resolver derivation it previously carried).
- `discord-interactions.ts` — the button-tap replay callback (previously resolver-less).

A new connector send site can no longer drop link-outs by omission — there is one place that turns a `Content` into Discord text + components.

## Evidence

**Real-path regression test** (`__tests__/interaction-replay-render.test.ts`) drives the *actual* `handleInteractionCreate` codec-button branch end to end with a fake message service that replies with a task card, and asserts the captured `channel.send` carries the resolved link button:

- With `ELIZA_APP_URL` set → button `style: 5` (Link), `url: https://app.test/orchestrator?taskId=<id>`, marker stripped from prose.
- With no app origin → degrades to prose (no fabricated dead button), title preserved.

**Proven to fail without the fix** — reverting the one-line replay-path change makes the test fail with `expected undefined to be defined` (the "Open task" button is absent):
```
× attaches an Open task link button to a post-tap task reply
AssertionError: expected undefined to be defined
```

Unit tests (`interactions.test.ts`) cover the resolver derivation from each setting and the no-config degrade.

<details><summary>Test run</summary>

```
__tests__/interactions.test.ts            13 passed
__tests__/interaction-replay-render.test.ts 2 passed
+ dm-widget-components / draft-stream-components / messages-component-delivery: 21 passed total
```
Pre-existing failures in `outbound-attachment` / `messageConnector.outbound-media` / `dm-policy` are the known media-fetch-mock fragility, reproduced identically on clean `origin/develop` (see #15010's note) — unrelated to this change; none import the touched files.
</details>

Real-LLM trajectory / screenshots: N/A — this is a deterministic connector rendering path (no model behavior change, no UI surface in this repo); the round-trip is asserted structurally by driving the real handler.

Refs #14527 (the formal acceptance criteria landed in #14577 / #14603 / #14633 / #14616 / #14682; this closes a residual silent-drop on the button-replay path). Not using `Closes` — native `[FORM]` modals / embeds / ephemeral remain per the issue's deferred list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)