### PR TITLE
fix(ui): back Today card with owner todos

### DIFF
--- a/packages/ui/src/components/chat/widgets/todo.test.tsx
+++ b/packages/ui/src/components/chat/widgets/todo.test.tsx
@@ -1,10 +1,27 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface WorkbenchTodoFixture {
+  id: string;
+  name: string;
+  description: string;
+  type: string;
+  isCompleted: boolean;
+  isUrgent: boolean;
+  priority: number | null;
+}
 
 const {
   authMock,
   getBaseUrlMock,
+  fetchMock,
   listWorkbenchTodosMock,
   mockState,
   publishHomeAttentionSpy,
@@ -12,7 +29,10 @@ const {
   // Auth gate (#11084) - mutable so tests can flip the session state.
   authMock: { authenticated: true },
   getBaseUrlMock: vi.fn(() => "http://localhost"),
-  listWorkbenchTodosMock: vi.fn(async () => ({ todos: [] })),
+  fetchMock: vi.fn(),
+  listWorkbenchTodosMock: vi.fn(
+    async (): Promise<{ todos: WorkbenchTodoFixture[] }> => ({ todos: [] }),
+  ),
   mockState: {
     workbench: {
       todos: [
@@ -25,7 +45,7 @@ const {
           isUrgent: false,
           priority: null,
         },
-      ],
+      ] satisfies WorkbenchTodoFixture[],
     },
     t: (_key: string, vars?: { defaultValue?: string }) =>
       vars?.defaultValue ?? "",
@@ -68,11 +88,49 @@ if (!TodoWidget) {
   throw new Error("todo.items widget not registered");
 }
 
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function mockLifeOpsResponses({
+  todos = [],
+  goals = [],
+}: {
+  todos?: unknown[];
+  goals?: unknown[];
+} = {}) {
+  fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes("/api/lifeops/todos")) {
+      return jsonResponse({ todos });
+    }
+    if (url.includes("/api/lifeops/goals")) {
+      return jsonResponse({ goals });
+    }
+    if (url.includes("/api/lifeops/occurrences/")) {
+      return jsonResponse({});
+    }
+    return jsonResponse({});
+  });
+}
+
+function isoDaysFromNow(days: number): string {
+  const value = new Date();
+  value.setDate(value.getDate() + days);
+  return value.toISOString();
+}
+
 beforeEach(() => {
   getBaseUrlMock.mockReset();
   getBaseUrlMock.mockReturnValue("http://localhost");
   listWorkbenchTodosMock.mockClear();
   listWorkbenchTodosMock.mockResolvedValue({ todos: [] });
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+  mockLifeOpsResponses();
   publishHomeAttentionSpy.mockClear();
   authMock.authenticated = true;
   mockState.workbench.todos = [
@@ -196,8 +254,16 @@ describe("TodoSidebarWidget", () => {
   });
 
   it("home slot: applies the host-supplied spanClassName to its single root grid-item element (#11752)", async () => {
-    // Hold the cached todo (no poll) so the card stays rendered while asserting.
-    authMock.authenticated = false;
+    mockLifeOpsResponses({
+      todos: [
+        {
+          id: "owner-today",
+          title: "Call pharmacy",
+          status: "pending",
+          dueDate: new Date().toISOString(),
+        },
+      ],
+    });
     const { container } = render(
       <TodoWidget
         slot="home"
@@ -207,7 +273,7 @@ describe("TodoSidebarWidget", () => {
       />,
     );
 
-    expect(await screen.findByText("Cached todo")).toBeTruthy();
+    expect(await screen.findByText("Call pharmacy")).toBeTruthy();
     const root = container.firstElementChild;
     expect(root).not.toBeNull();
     expect(root?.className).toContain("col-span-2");
@@ -218,39 +284,147 @@ describe("TodoSidebarWidget", () => {
   });
 
   it("home slot: falls back to the default 2x1 span when no spanClassName is supplied (#11752)", async () => {
-    authMock.authenticated = false;
+    mockLifeOpsResponses({
+      todos: [
+        {
+          id: "owner-today",
+          title: "Call pharmacy",
+          status: "pending",
+          dueDate: new Date().toISOString(),
+        },
+      ],
+    });
     const { container } = render(
       <TodoWidget slot="home" events={[]} clearEvents={vi.fn()} />,
     );
-    expect(await screen.findByText("Cached todo")).toBeTruthy();
+    expect(await screen.findByText("Call pharmacy")).toBeTruthy();
     expect(container.firstElementChild?.className).toContain("col-span-2");
+  });
+
+  it("home slot: renders only owner todos due or overdue today", async () => {
+    mockState.workbench.todos = [
+      {
+        id: "workbench-1",
+        name: "Agent workbench todo",
+        description: "",
+        type: "task",
+        isCompleted: false,
+        isUrgent: false,
+        priority: null,
+      },
+    ];
+    mockLifeOpsResponses({
+      todos: [
+        {
+          id: "owner-overdue",
+          title: "Pay rent",
+          status: "pending",
+          dueDate: isoDaysFromNow(-1),
+        },
+        {
+          id: "owner-today",
+          title: "Call pharmacy",
+          status: "pending",
+          dueDate: new Date().toISOString(),
+        },
+        {
+          id: "owner-tomorrow",
+          title: "Pack lunch",
+          status: "pending",
+          dueDate: isoDaysFromNow(1),
+        },
+        {
+          id: "owner-undated",
+          title: "Someday",
+          status: "pending",
+          dueDate: null,
+        },
+        {
+          id: "owner-done",
+          title: "Already done",
+          status: "completed",
+          dueDate: new Date().toISOString(),
+        },
+      ],
+    });
+
+    render(<TodoWidget slot="home" events={[]} clearEvents={vi.fn()} />);
+
+    expect(await screen.findByText("Pay rent")).toBeTruthy();
+    expect(await screen.findByText("Call pharmacy")).toBeTruthy();
+    expect(screen.queryByText("Pack lunch")).toBeNull();
+    expect(screen.queryByText("Someday")).toBeNull();
+    expect(screen.queryByText("Already done")).toBeNull();
+    expect(screen.queryByText("Agent workbench todo")).toBeNull();
+    expect(listWorkbenchTodosMock).not.toHaveBeenCalled();
+  });
+
+  it("home slot: completing an owner todo posts to the occurrence endpoint and refreshes", async () => {
+    let completed = false;
+    fetchMock.mockImplementation(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.includes("/api/lifeops/todos")) {
+          const todos = completed
+            ? []
+            : [
+                {
+                  id: "owner-today",
+                  title: "Call pharmacy",
+                  status: "pending",
+                  dueDate: new Date().toISOString(),
+                },
+              ];
+          return jsonResponse({ todos });
+        }
+        if (url.includes("/api/lifeops/goals")) {
+          return jsonResponse({ goals: [] });
+        }
+        if (url.includes("/api/lifeops/occurrences/owner-today/complete")) {
+          expect(init?.method).toBe("POST");
+          expect(JSON.parse(String(init?.body))).toEqual({
+            metadata: { source: "home_today_widget" },
+          });
+          completed = true;
+          return jsonResponse({});
+        }
+        return jsonResponse({});
+      },
+    );
+
+    render(<TodoWidget slot="home" events={[]} clearEvents={vi.fn()} />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Complete "Call pharmacy"/ }),
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://localhost/api/lifeops/occurrences/owner-today/complete",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    await waitFor(() => {
+      expect(screen.queryByText("Call pharmacy")).toBeNull();
+    });
   });
 
   it("home slot: renders an at-risk goal as one flagged row inside Today (spec §E item 5)", async () => {
     mockState.workbench.todos = [];
     listWorkbenchTodosMock.mockResolvedValue({ todos: [] });
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(
-        async () =>
-          new Response(
-            JSON.stringify({
-              goals: [
-                {
-                  goal: {
-                    id: "goal-at-risk",
-                    title: "Ship the release",
-                    status: "active",
-                    reviewState: "at_risk",
-                  },
-                  links: [],
-                },
-              ],
-            }),
-            { status: 200, headers: { "Content-Type": "application/json" } },
-          ),
-      ),
-    );
+    mockLifeOpsResponses({
+      goals: [
+        {
+          goal: {
+            id: "goal-at-risk",
+            title: "Ship the release",
+            status: "active",
+            reviewState: "at_risk",
+          },
+          links: [],
+        },
+      ],
+    });
 
     render(<TodoWidget slot="home" events={[]} clearEvents={vi.fn()} />);
 
@@ -270,28 +444,19 @@ describe("TodoSidebarWidget", () => {
   it("home slot: preserves needs-attention goals in the merged Today row", async () => {
     mockState.workbench.todos = [];
     listWorkbenchTodosMock.mockResolvedValue({ todos: [] });
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(
-        async () =>
-          new Response(
-            JSON.stringify({
-              goals: [
-                {
-                  goal: {
-                    id: "goal-needs-attention",
-                    title: "Reconnect with the team",
-                    status: "active",
-                    reviewState: "needs_attention",
-                  },
-                  links: [],
-                },
-              ],
-            }),
-            { status: 200, headers: { "Content-Type": "application/json" } },
-          ),
-      ),
-    );
+    mockLifeOpsResponses({
+      goals: [
+        {
+          goal: {
+            id: "goal-needs-attention",
+            title: "Reconnect with the team",
+            status: "active",
+            reviewState: "needs_attention",
+          },
+          links: [],
+        },
+      ],
+    });
 
     render(<TodoWidget slot="home" events={[]} clearEvents={vi.fn()} />);
 

--- a/packages/ui/src/components/chat/widgets/todo.tsx
+++ b/packages/ui/src/components/chat/widgets/todo.tsx
@@ -1,8 +1,8 @@
 /**
- * Chat-sidebar (and home-grid) TODO widget: lists the agent workbench's todos,
- * seeded from the app store's `workbench.todos`, refreshed on live workbench
- * events, and backed by a visible-tab poll for missed events. Exports
- * `TODO_PLUGIN_WIDGETS`, the widget-registry entry consumed by the sidebar.
+ * Chat-sidebar TODO widget plus the home-grid Today card. The sidebar lists
+ * the agent workbench todos from app state and workbench events; the home card
+ * reads owner LifeOps todos so dated personal tasks, not agent workbench tasks,
+ * drive the user's Today surface.
  *
  * On the home surface this is the "Today" card, and per spec §B/§E item 5 it
  * absorbs the goals resident: when the goals store reports an at-risk (or
@@ -10,7 +10,7 @@
  * rather than as a second standalone home widget. The card then self-publishes
  * the goals escalation weight so the merged card floats up on goal urgency.
  */
-import { ListTodo, Target } from "lucide-react";
+import { Check, ListTodo, Target } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { client } from "../../../api";
 import { supportsFullAppShellRoutes } from "../../../api/app-shell-capabilities";
@@ -40,12 +40,39 @@ const TODO_WIDGET_KEY = "todo/todo.items";
 
 const TODO_REFRESH_INTERVAL_MS = 15_000;
 const MAX_VISIBLE_TODOS = 8;
+const HOME_MAX_VISIBLE_TODOS = 3;
+const COMPLETED_OWNER_TODO_STATUSES = new Set([
+  "complete",
+  "completed",
+  "done",
+  "skipped",
+  "cancelled",
+  "canceled",
+]);
+
+interface TodoWidgetTodo extends WorkbenchTodo {
+  dueDate?: string | null;
+  dueLabel?: "Today" | "Overdue";
+  ownerOccurrenceId?: string;
+}
+
+interface OwnerTodoWire {
+  id: string;
+  title: string;
+  status: string;
+  dueDate: string | null;
+}
 
 const fallbackTranslate: TranslateFn = (key, vars) =>
   typeof vars?.defaultValue === "string" ? vars.defaultValue : key;
 
-function sortTodosForWidget(todos: WorkbenchTodo[]): WorkbenchTodo[] {
+function sortTodosForWidget<T extends TodoWidgetTodo>(todos: T[]): T[] {
   return [...todos].sort((left, right) => {
+    const leftDue = dueTime(left.dueDate);
+    const rightDue = dueTime(right.dueDate);
+    if (leftDue !== rightDue) {
+      return leftDue - rightDue;
+    }
     if (left.isCompleted !== right.isCompleted) {
       return left.isCompleted ? 1 : -1;
     }
@@ -61,12 +88,114 @@ function sortTodosForWidget(todos: WorkbenchTodo[]): WorkbenchTodo[] {
   });
 }
 
-function dedupeTodos(todos: WorkbenchTodo[]): WorkbenchTodo[] {
-  const byId = new Map<string, WorkbenchTodo>();
+function dedupeTodos<T extends TodoWidgetTodo>(todos: T[]): T[] {
+  const byId = new Map<string, T>();
   for (const todo of todos) {
     byId.set(todo.id, todo);
   }
   return sortTodosForWidget([...byId.values()]);
+}
+
+function dueTime(value: string | null | undefined): number {
+  if (!value) return Number.MAX_SAFE_INTEGER;
+  const time = new Date(value).getTime();
+  return Number.isFinite(time) ? time : Number.MAX_SAFE_INTEGER;
+}
+
+function isDueOrOverdueToday(value: string | null | undefined): boolean {
+  const time = dueTime(value);
+  if (time === Number.MAX_SAFE_INTEGER) return false;
+  const tomorrow = new Date();
+  tomorrow.setHours(0, 0, 0, 0);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  return time < tomorrow.getTime();
+}
+
+function ownerTodoDueLabel(value: string | null): "Today" | "Overdue" {
+  const startOfToday = new Date();
+  startOfToday.setHours(0, 0, 0, 0);
+  return dueTime(value) < startOfToday.getTime() ? "Overdue" : "Today";
+}
+
+function parseOwnerTodos(payload: unknown): OwnerTodoWire[] {
+  if (typeof payload !== "object" || payload === null) {
+    throw new Error("LifeOps todos response was not an object");
+  }
+  const todos = (payload as { todos?: unknown }).todos;
+  if (!Array.isArray(todos)) {
+    throw new Error("LifeOps todos response did not include todos");
+  }
+  return todos.map((todo) => {
+    if (typeof todo !== "object" || todo === null) {
+      throw new Error("LifeOps todo record was not an object");
+    }
+    const { id, title, status, dueDate } = todo as {
+      id?: unknown;
+      title?: unknown;
+      status?: unknown;
+      dueDate?: unknown;
+    };
+    if (
+      typeof id !== "string" ||
+      typeof title !== "string" ||
+      typeof status !== "string" ||
+      (dueDate !== null && typeof dueDate !== "string")
+    ) {
+      throw new Error("LifeOps todo record was malformed");
+    }
+    return { id, title, status, dueDate: dueDate ?? null };
+  });
+}
+
+function ownerTodoToWidgetTodo(todo: OwnerTodoWire): TodoWidgetTodo | null {
+  const isCompleted = COMPLETED_OWNER_TODO_STATUSES.has(todo.status);
+  if (isCompleted || !isDueOrOverdueToday(todo.dueDate)) return null;
+  const dueLabel = ownerTodoDueLabel(todo.dueDate);
+  return {
+    id: todo.id,
+    name: todo.title,
+    description: "",
+    type: "task",
+    isCompleted,
+    isUrgent: dueLabel === "Overdue",
+    priority: null,
+    dueDate: todo.dueDate,
+    dueLabel,
+    ownerOccurrenceId: todo.id,
+  };
+}
+
+async function fetchOwnerTodosForToday(): Promise<TodoWidgetTodo[]> {
+  const response = await fetch(`${client.getBaseUrl()}/api/lifeops/todos`);
+  if (!response.ok) {
+    throw new Error(`LifeOps todos request failed (${response.status})`);
+  }
+  return dedupeTodos(
+    parseOwnerTodos(await response.json()).flatMap((todo) => {
+      const mapped = ownerTodoToWidgetTodo(todo);
+      return mapped ? [mapped] : [];
+    }),
+  );
+}
+
+async function completeOwnerTodo(occurrenceId: string): Promise<void> {
+  const response = await fetch(
+    `${client.getBaseUrl()}/api/lifeops/occurrences/${encodeURIComponent(
+      occurrenceId,
+    )}/complete`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        metadata: { source: "home_today_widget" },
+      }),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `LifeOps occurrence completion failed (${response.status})`,
+    );
+  }
 }
 
 function isWorkbenchTodoChangeEvent(
@@ -95,75 +224,98 @@ function homeBadgeClassName(tone: "default" | "home", accent?: string): string {
 function TodoRow({
   todo,
   tone = "default",
+  onComplete,
 }: {
-  todo: WorkbenchTodo;
+  todo: TodoWidgetTodo;
   tone?: "default" | "home";
+  onComplete?: (todo: TodoWidgetTodo) => void;
 }) {
   const showDescription =
     todo.description.trim().length > 0 && todo.description !== todo.name;
   const showType = todo.type.trim().length > 0 && todo.type !== "task";
   const isHome = tone === "home";
-
-  return (
-    <div
-      className={`rounded-sm border p-3 ${
-        isHome
-          ? "border-white/15 bg-white/10 text-white"
-          : "border-border/50 bg-bg/70"
-      }`}
-    >
-      <div className="flex items-start gap-2">
-        <span
-          className={`mt-1.5 inline-block h-2 w-2 shrink-0 rounded-full ${
-            isHome
-              ? "bg-white/70"
-              : todo.isUrgent
-                ? "bg-danger"
-                : todo.priority != null
-                  ? "bg-accent"
-                  : "bg-muted"
-          }`}
-        />
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-1.5">
-            <span
-              className={`min-w-0 truncate text-xs font-semibold ${
-                isHome ? "text-white" : "text-txt"
-              }`}
+  const content = (
+    <div className="flex items-start gap-2">
+      <span
+        className={`mt-1 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border ${
+          isHome
+            ? "border-white/50 bg-white/10 text-white"
+            : "border-border bg-bg text-muted"
+        }`}
+        aria-hidden="true"
+      >
+        {onComplete ? <Check className="h-3 w-3 opacity-0" /> : null}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span
+            className={`min-w-0 truncate text-xs font-semibold ${
+              isHome ? "text-white" : "text-txt"
+            }`}
+          >
+            {todo.name}
+          </span>
+          {todo.dueLabel ? (
+            <Badge
+              variant="secondary"
+              className={homeBadgeClassName(
+                tone,
+                todo.dueLabel === "Overdue" ? "text-danger" : undefined,
+              )}
             >
-              {todo.name}
-            </span>
-            {todo.isUrgent ? (
-              <Badge
-                variant="secondary"
-                className={homeBadgeClassName(tone, "text-danger")}
-              >
-                Urgent
-              </Badge>
-            ) : null}
-            {todo.priority != null ? (
-              <Badge variant="secondary" className={homeBadgeClassName(tone)}>
-                P{todo.priority}
-              </Badge>
-            ) : null}
-            {showType ? (
-              <Badge variant="secondary" className={homeBadgeClassName(tone)}>
-                {todo.type}
-              </Badge>
-            ) : null}
-          </div>
-          {showDescription ? (
-            <p
-              className={`mt-1 line-clamp-2 text-xs-tight leading-5 ${
-                isHome ? "text-white/70" : "text-muted"
-              }`}
+              {todo.dueLabel}
+            </Badge>
+          ) : null}
+          {todo.isUrgent && !todo.dueLabel ? (
+            <Badge
+              variant="secondary"
+              className={homeBadgeClassName(tone, "text-danger")}
             >
-              {todo.description}
-            </p>
+              Urgent
+            </Badge>
+          ) : null}
+          {todo.priority != null ? (
+            <Badge variant="secondary" className={homeBadgeClassName(tone)}>
+              P{todo.priority}
+            </Badge>
+          ) : null}
+          {showType ? (
+            <Badge variant="secondary" className={homeBadgeClassName(tone)}>
+              {todo.type}
+            </Badge>
           ) : null}
         </div>
+        {showDescription ? (
+          <p
+            className={`mt-1 line-clamp-2 text-xs-tight leading-5 ${
+              isHome ? "text-white/70" : "text-muted"
+            }`}
+          >
+            {todo.description}
+          </p>
+        ) : null}
       </div>
     </div>
+  );
+
+  const className = `rounded-sm border p-3 ${
+    isHome
+      ? "border-white/15 bg-white/10 text-white"
+      : "border-border/50 bg-bg/70"
+  }`;
+
+  if (!onComplete) {
+    return <div className={className}>{content}</div>;
+  }
+  return (
+    <button
+      type="button"
+      aria-label={`Complete "${todo.name}"`}
+      onClick={() => onComplete(todo)}
+      className={`${className} min-h-11 w-full text-left transition-colors hover:bg-white/15`}
+    >
+      {content}
+    </button>
   );
 }
 
@@ -228,19 +380,26 @@ function GoalAttentionRow({
 function TodoItemsContent({
   todos,
   loading,
+  error,
   goal,
   onOpenGoal,
+  onCompleteTodo,
   tone = "default",
 }: {
-  todos: WorkbenchTodo[];
+  todos: TodoWidgetTodo[];
   loading: boolean;
+  error: boolean;
   goal: AttentionGoal | null;
   onOpenGoal: () => void;
+  onCompleteTodo?: (todo: TodoWidgetTodo) => void;
   tone?: "default" | "home";
 }) {
   const openTodos = todos.filter((todo) => !todo.isCompleted);
   const hiddenCompletedCount = todos.length - openTodos.length;
-  const visibleTodos = openTodos.slice(0, MAX_VISIBLE_TODOS);
+  const visibleTodos = openTodos.slice(
+    0,
+    tone === "home" ? HOME_MAX_VISIBLE_TODOS : MAX_VISIBLE_TODOS,
+  );
   const remainingCount = openTodos.length - visibleTodos.length;
   const goalRow = goal ? (
     <GoalAttentionRow goal={goal} onOpen={onOpenGoal} tone={tone} />
@@ -252,6 +411,16 @@ function TodoItemsContent({
         className={`py-3 text-xs ${tone === "home" ? "text-white/70" : "text-muted"}`}
       >
         Refreshing todos…
+      </div>
+    );
+  }
+
+  if (error && openTodos.length === 0 && !goal) {
+    return (
+      <div
+        className={`py-3 text-xs ${tone === "home" ? "text-white/70" : "text-muted"}`}
+      >
+        Could not load today's todos.
       </div>
     );
   }
@@ -275,8 +444,20 @@ function TodoItemsContent({
     <div className="flex flex-col gap-2">
       {goalRow}
       {visibleTodos.map((todo) => (
-        <TodoRow key={todo.id} todo={todo} tone={tone} />
+        <TodoRow
+          key={todo.id}
+          todo={todo}
+          tone={tone}
+          onComplete={todo.ownerOccurrenceId ? onCompleteTodo : undefined}
+        />
       ))}
+      {error ? (
+        <p
+          className={`px-1 text-xs-tight ${tone === "home" ? "text-white/70" : "text-muted"}`}
+        >
+          Could not sync today's todos.
+        </p>
+      ) : null}
       {remainingCount > 0 ? (
         <p
           className={`px-1 text-xs-tight ${tone === "home" ? "text-white/70" : "text-muted"}`}
@@ -344,6 +525,7 @@ function TodoSidebarWidget({
   slot,
   spanClassName = "col-span-2 row-span-1",
 }: ChatSidebarWidgetProps) {
+  const onHome = slot === "home";
   const { workbench, t: appT } = useAppSelectorShallow((s) => ({
     workbench: s.workbench,
     t: s.t,
@@ -352,10 +534,11 @@ function TodoSidebarWidget({
   // Auth gate (#11084): the widget mounts before the auth probe resolves, so
   // the 15s todo poll must stay dormant until the session is authenticated.
   const authenticated = useIsAuthenticated();
-  const [todos, setTodos] = useState<WorkbenchTodo[]>(() =>
-    dedupeTodos(workbench?.todos ?? []),
+  const [todos, setTodos] = useState<TodoWidgetTodo[]>(() =>
+    onHome ? [] : dedupeTodos(workbench?.todos ?? []),
   );
   const [todosLoading, setTodosLoading] = useState(false);
+  const [todosError, setTodosError] = useState(false);
   const lastHandledTodoEventIdRef = useRef<string | null>(null);
 
   // The async todo fetch can resolve after the widget unmounts; guard the
@@ -370,15 +553,17 @@ function TodoSidebarWidget({
   }, []);
 
   useEffect(() => {
+    if (onHome) return;
     setTodos(dedupeTodos(workbench?.todos ?? []));
-  }, [workbench?.todos]);
+  }, [onHome, workbench?.todos]);
 
   const loadTodos = useCallback(
     async (silent = false) => {
       if (!authenticated || !supportsFullAppShellRoutes(client.getBaseUrl())) {
         if (mountedRef.current) {
-          setTodos(dedupeTodos(workbench?.todos ?? []));
+          setTodos(onHome ? [] : dedupeTodos(workbench?.todos ?? []));
           setTodosLoading(false);
+          setTodosError(false);
         }
         return;
       }
@@ -388,23 +573,32 @@ function TodoSidebarWidget({
       }
 
       try {
-        const result = await client.listWorkbenchTodos();
+        const result = onHome
+          ? { todos: await fetchOwnerTodosForToday() }
+          : await client.listWorkbenchTodos();
         if (mountedRef.current) {
           setTodos(dedupeTodos(result.todos));
+          setTodosError(false);
         }
       } catch {
-        // error-policy:J4 glance tile - fall back to the workbench snapshot
-        // already in view state rather than surfacing a broken card.
-        if (mountedRef.current && (workbench?.todos?.length ?? 0) > 0) {
+        // error-policy:J4 glance tile - sidebar keeps the app-store snapshot,
+        // while home keeps prior owner todos and renders an explicit load error
+        // if it has no last-good rows.
+        if (
+          mountedRef.current &&
+          !onHome &&
+          (workbench?.todos?.length ?? 0) > 0
+        ) {
           setTodos(dedupeTodos(workbench?.todos ?? []));
         }
+        if (mountedRef.current) setTodosError(true);
       } finally {
         if (mountedRef.current) {
           setTodosLoading(false);
         }
       }
     },
-    [authenticated, workbench?.todos],
+    [authenticated, onHome, workbench?.todos],
   );
 
   useEffect(() => {
@@ -412,6 +606,7 @@ function TodoSidebarWidget({
   }, [loadTodos, todos.length]);
 
   useEffect(() => {
+    if (onHome) return;
     const latestTodoEvent = events.find(isWorkbenchTodoChangeEvent);
     if (
       !latestTodoEvent ||
@@ -421,7 +616,7 @@ function TodoSidebarWidget({
     }
     lastHandledTodoEventIdRef.current = latestTodoEvent.id;
     void loadTodos(true);
-  }, [events, loadTodos]);
+  }, [events, loadTodos, onHome]);
 
   // Refresh only while the document is visible - pause the silent poll in a
   // backgrounded app/tab. Live workbench events do the normal foreground
@@ -433,7 +628,6 @@ function TodoSidebarWidget({
 
   const openTodos = todos.filter((todo) => !todo.isCompleted);
   const hasUrgent = openTodos.some((todo) => todo.isUrgent);
-  const onHome = slot === "home";
   // The merged at-risk goal row (§E item 5) is home-only; the chat sidebar
   // keeps the pure todo list.
   const nav = useWidgetNavigation();
@@ -452,11 +646,35 @@ function TodoSidebarWidget({
         : null;
   usePublishHomeAttention(TODO_WIDGET_KEY, homeAttentionWeight);
 
+  const completeTodo = useCallback(
+    async (todo: TodoWidgetTodo) => {
+      if (!todo.ownerOccurrenceId) return;
+      try {
+        await completeOwnerTodo(todo.ownerOccurrenceId);
+        if (mountedRef.current) {
+          setTodos((prev) =>
+            prev.map((item) =>
+              item.id === todo.id ? { ...item, isCompleted: true } : item,
+            ),
+          );
+        }
+        await loadTodos(true);
+      } catch {
+        // error-policy:J4 home glance action - keep the row in place and mark
+        // the Today card as errored so a failed completion is visible.
+        if (mountedRef.current) setTodosError(true);
+      }
+    },
+    [loadTodos],
+  );
+
   // On the home grid, render nothing when there are no open todos AND no at-risk
   // goal - the home surface must not show empty-state placeholders (#9143). A
   // flagged goal alone keeps the merged Today card alive. The chat sidebar keeps
   // its empty state.
-  if (onHome && openTodos.length === 0 && !attentionGoal) return null;
+  if (onHome && openTodos.length === 0 && !attentionGoal && !todosError) {
+    return null;
+  }
 
   const section = (
     <WidgetSection
@@ -468,8 +686,10 @@ function TodoSidebarWidget({
       <TodoItemsContent
         todos={todos}
         loading={todosLoading}
+        error={todosError}
         goal={attentionGoal}
         onOpenGoal={() => nav.openView("/goals", "goals")}
+        onCompleteTodo={onHome ? completeTodo : undefined}
         tone={onHome ? "home" : "default"}
       />
     </WidgetSection>

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -489,7 +489,7 @@ try {
   // autonomous/domain cards AND the demoted wallet/health cards must stay absent
   // even though the fixture still exposes their plugins/routes elsewhere.
   const WIDGET_CARDS = [
-    ["chat-widget-todos", "Buy groceries"],
+    ["chat-widget-todos", "Call pharmacy"],
     // The merged at-risk goal renders inside the Today card (§E item 5).
     ["todo-goal-attention-row", "Ship the release"],
     ["chat-widget-calendar-upcoming", "Design review"],

--- a/packages/ui/src/widgets/__fixtures__/home-widget-mock-data.ts
+++ b/packages/ui/src/widgets/__fixtures__/home-widget-mock-data.ts
@@ -3,8 +3,8 @@
  *
  * One source of truth for "the home dashboard, populated with attention-worthy
  * data" - shared between the home-screen e2e fixture and the Storybook story so
- * both render the REAL kept home widgets (calendar / Today-todos, with the
- * at-risk goal folded into the Today card per spec §E item 5) plus
+ * both render the REAL kept home widgets (calendar / Today owner-todos, with
+ * the at-risk goal folded into the Today card per spec §E item 5) plus
  * notifications/approvals, fed by injected DATA only (no stubbing of WidgetHost
  * or the widget components). The goals payload now feeds the Today card's
  * flagged row rather than a standalone goals resident; the sleep payload is
@@ -235,6 +235,22 @@ export function homeWidgetTodosResponse() {
   };
 }
 
+function homeWidgetOwnerTodosResponse() {
+  if (homeWidgetMockMode() === "quiet") {
+    return { todos: [] };
+  }
+  return {
+    todos: [
+      {
+        id: "todo-call-pharmacy",
+        title: "Call pharmacy",
+        status: "pending",
+        dueDate: new Date().toISOString(),
+      },
+    ],
+  };
+}
+
 export function homeWidgetApprovalsResponse() {
   return homeWidgetMockMode() === "attention"
     ? approvalsPayload()
@@ -274,6 +290,10 @@ function routeTable(): RouteMatch[] {
     {
       test: has("/api/lifeops/goals"),
       body: whenAttention(goalsPayload, { goals: [] }),
+    },
+    {
+      test: has("/api/lifeops/todos"),
+      body: homeWidgetOwnerTodosResponse,
     },
     {
       test: has("/api/lifeops/sleep/history"),


### PR DESCRIPTION
## Summary
- route the home Today card to `/api/lifeops/todos` instead of agent workbench todos
- filter owner todos to due/overdue today, cap the home list to three items, and add row tap completion through `/api/lifeops/occurrences/:id/complete`
- keep chat-sidebar todo behavior on the existing workbench data path and update the home-screen fixture expectation to the owner todo payload

Closes #14734

## Verification
- PASS `bun run --cwd packages/ui test src/components/chat/widgets/todo.test.tsx`
- PASS `bun run --cwd packages/ui build:dist`
- PASS `git diff --check`
- PASS `bun run audit:error-policy-ratchet`
- PARTIAL `bun run --cwd packages/app audit:app` - Playwright capture phase passed 365/365; chained packaged OCR triage failed on unrelated baseline regressions in built-in apps/views/logs/relationships/transcripts surfaces.
- BLOCKED `bun run --cwd packages/ui typecheck` - existing package-wide errors outside touched files: `settings-sections.ts`, `startup-phase-poll.test.ts`, `widget-cert-fixture.tsx`, and `voice-selftest-harness.test.ts`.
