### PR TITLE
fix(lifeops): route deadline reminders to owner reminders

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/owner-surfaces.ts
+++ b/plugins/plugin-personal-assistant/src/actions/owner-surfaces.ts
@@ -254,9 +254,9 @@ export const ownerRemindersAction: Action = {
       "RECURRING_REMINDER",
     ],
     description:
-      "Owner reminders: create/update/delete/complete/skip/snooze/review one-off/recurring.",
+      'Owner reminders: create/update/delete/complete/skip/snooze/review one-off, date-only, deadline ("by the 20th"), and recurring reminders.',
     descriptionCompressed:
-      "owner reminders: action=create|update|delete|complete|skip|snooze|review",
+      "owner reminders/deadlines: action=create|update|delete|complete|skip|snooze|review",
     defaultKind: "definition",
   }),
   name: "OWNER_REMINDERS",
@@ -272,9 +272,9 @@ export const ownerRemindersAction: Action = {
     "RECURRING_REMINDER",
   ],
   description:
-    "Owner reminders: create/update/delete/complete/skip/snooze/review one-off/recurring.",
+    'Owner reminders: create/update/delete/complete/skip/snooze/review one-off, date-only, deadline ("by the 20th"), and recurring reminders.',
   descriptionCompressed:
-    "owner reminders: action=create|update|delete|complete|skip|snooze|review",
+    "owner reminders/deadlines: action=create|update|delete|complete|skip|snooze|review",
 };
 
 export const ownerAlarmsAction: Action = {

--- a/plugins/plugin-personal-assistant/src/actions/scheduled-task.ts
+++ b/plugins/plugin-personal-assistant/src/actions/scheduled-task.ts
@@ -289,7 +289,7 @@ const TRIGGER_KINDS =
  * correct surface explicitly.
  */
 const HABIT_REDIRECT_HINT =
-  "If the owner asked to start a habit/routine or a recurring personal reminder in chat, do not retry here — call OWNER_ROUTINES (or OWNER_REMINDERS) with action=create instead; that flow builds the habit definition and reminder plan without a raw trigger.";
+  'If the owner asked to create a new personal reminder in chat — one-off, dated/deadline ("by the 20th"), recurring, habit, or routine — do not retry here. Call OWNER_REMINDERS action=create for reminders or OWNER_ROUTINES action=create for habits/routines; those flows build the definition and reminder plan without a raw trigger.';
 
 const PLAIN_TIMING_MISSING_TEXT =
   "I could not save that yet because I need a clear time or recurrence. Please tell me when it should happen.";
@@ -1170,11 +1170,11 @@ export const scheduledTaskAction: Action & {
     "surface:internal",
   ],
   description:
-    "Low-level admin surface over LifeOps ScheduledTask records. Kinds: reminder, checkin, followup, approval, recap, watcher, output, custom. Ops: list|get|create|update|snooze|skip|complete|acknowledge|dismiss|cancel|reopen|history. create schedules a raw task and requires an explicit structural trigger — it is NOT the flow for saving a habit/routine/recurring personal reminder the owner asks for in chat; OWNER_ROUTINES / OWNER_REMINDERS action=create own that (definition + reminder plan).",
+    'Low-level admin surface over LifeOps ScheduledTask records. Kinds: reminder, checkin, followup, approval, recap, watcher, output, custom. Ops: list|get|create|update|snooze|skip|complete|acknowledge|dismiss|cancel|reopen|history. create schedules a raw task and requires an explicit structural trigger — it is NOT the flow for saving a new owner reminder the user asks for in chat, including one-off date/deadline reminders like "by the 20th"; OWNER_REMINDERS action=create owns that definition + reminder plan. OWNER_ROUTINES owns habits/routines.',
   descriptionCompressed:
-    "low-level scheduled-item admin list|get|create|update|snooze|skip|complete|ack|dismiss|cancel|history; NOT new-habit/routine creation (-> OWNER_ROUTINES/OWNER_REMINDERS create)",
+    "low-level scheduled-item admin list|get|create|update|snooze|skip|complete|ack|dismiss|cancel|history; NOT new owner reminders/deadlines/habits (-> OWNER_REMINDERS/OWNER_ROUTINES create)",
   routingHint:
-    'manage EXISTING scheduled items ("snooze that reminder", "show me only overdue tasks" -> action=list dueWindow=overdue, "what\'s due today" -> action=list dueWindow=today, "complete check-in", "scheduled-item history") -> SCHEDULED_TASKS; NEW habit/routine/recurring personal reminder ("brush my teeth at 8 am and 9 pm every day", "remind me daily at 9pm") -> OWNER_ROUTINES/OWNER_REMINDERS action=create; coding/project/agent task threads -> TASKS/plugin-task-coordinator; per-occurrence complete/skip/snooze next occurrence -> OWNER_REMINDERS/OWNER_TODOS/OWNER_ROUTINES',
+    'manage EXISTING scheduled items ("snooze that reminder", "show me only overdue tasks" -> action=list dueWindow=overdue, "what\'s due today" -> action=list dueWindow=today, "complete check-in", "scheduled-item history") -> SCHEDULED_TASKS; NEW owner reminders/deadlines ("remind me to renew registration by the 20th", "call mom tomorrow") -> OWNER_REMINDERS action=create; NEW habit/routine/recurring personal reminder ("brush my teeth at 8 am and 9 pm every day", "remind me daily at 9pm") -> OWNER_ROUTINES/OWNER_REMINDERS action=create; coding/project/agent task threads -> TASKS/plugin-task-coordinator; per-occurrence complete/skip/snooze next occurrence -> OWNER_REMINDERS/OWNER_TODOS/OWNER_ROUTINES',
   contexts: [
     "tasks",
     "automation",

--- a/plugins/plugin-personal-assistant/test/action-structure-audit.test.ts
+++ b/plugins/plugin-personal-assistant/test/action-structure-audit.test.ts
@@ -250,6 +250,25 @@ describe("brush-teeth habit-save routing contract (#9950/#10722)", () => {
     );
   });
 
+  it("claims one-off deadline reminders on OWNER_REMINDERS and de-claims them on SCHEDULED_TASKS", () => {
+    const reminders = findAction("OWNER_REMINDERS");
+    expect(reminders?.description).toContain("deadline");
+    expect(reminders?.description).toContain("by the 20th");
+    expect(reminders?.descriptionCompressed).toContain("deadlines");
+
+    const scheduledTasks = findAction("SCHEDULED_TASKS");
+    expect(scheduledTasks?.description).toContain(
+      "NOT the flow for saving a new owner reminder",
+    );
+    expect(scheduledTasks?.description).toContain("by the 20th");
+    expect(scheduledTasks?.routingHint).toContain(
+      "NEW owner reminders/deadlines",
+    );
+    expect(scheduledTasks?.routingHint).toContain(
+      "OWNER_REMINDERS action=create",
+    );
+  });
+
   it("declares the productivity context on owner-life umbrellas (Stage-1 boost parity with SCHEDULED_TASKS)", () => {
     for (const name of Object.keys(PINNED_KINDS)) {
       const action = findAction(name);

--- a/plugins/plugin-personal-assistant/test/helpers/lifeops-prompt-benchmark-cases.ts
+++ b/plugins/plugin-personal-assistant/test/helpers/lifeops-prompt-benchmark-cases.ts
@@ -575,6 +575,12 @@ function buildCapabilityCoverageCases(): PromptBenchmarkCase[] {
       acceptableActions: ["LIFE"],
     },
     {
+      task: "reminder_dispatch",
+      prompt: "Remind me to renew the car registration by the 20th.",
+      expectedAction: "OWNER_REMINDERS",
+      acceptableActions: ["LIFE"],
+    },
+    {
       task: "inbox_triage",
       prompt:
         "Find the vendor renewal invoice email and tell me if it needs a reply.",

--- a/plugins/plugin-personal-assistant/test/lifeops-prompt-benchmark.test.ts
+++ b/plugins/plugin-personal-assistant/test/lifeops-prompt-benchmark.test.ts
@@ -72,6 +72,14 @@ describe("LifeOps prompt benchmark catalog", () => {
         true,
       );
     }
+    expect(
+      cases.some(
+        (testCase) =>
+          testCase.variantId === "direct" &&
+          testCase.expectedAction === "OWNER_REMINDERS" &&
+          testCase.prompt.includes("registration by the 20th"),
+      ),
+    ).toBe(true);
   });
 });
 

--- a/plugins/plugin-personal-assistant/test/scheduled-task-trigger-boundary.test.ts
+++ b/plugins/plugin-personal-assistant/test/scheduled-task-trigger-boundary.test.ts
@@ -248,9 +248,11 @@ describe("SCHEDULED_TASKS create — trigger boundary", () => {
     })) as { success: boolean; text?: string; data?: Record<string, unknown> };
     expect(result.success).toBe(false);
     expect(result.data?.error).toBe("INVALID_TRIGGER");
-    expect(result.text).toContain("OWNER_REMINDERS action=create");
-    expect(result.text).toContain("by the 20th");
-    expect(result.text).toContain("do not retry here");
+    expectPlainScheduledTaskText(result.text);
+    const repair = result.data?.repair as string | undefined;
+    expect(repair).toContain("OWNER_REMINDERS action=create");
+    expect(repair).toContain("by the 20th");
+    expect(repair).toContain("do not retry here");
   });
 
   it("an invalid trigger also carries the habit-definition redirect", async () => {

--- a/plugins/plugin-personal-assistant/test/scheduled-task-trigger-boundary.test.ts
+++ b/plugins/plugin-personal-assistant/test/scheduled-task-trigger-boundary.test.ts
@@ -238,6 +238,21 @@ describe("SCHEDULED_TASKS create — trigger boundary", () => {
     expect(result.data?.repair).toContain("action=create");
   });
 
+  it("a missing trigger on a one-off deadline reminder redirects to OWNER_REMINDERS instead of another raw retry", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const result = (await create(runtime, {
+      kind: "reminder",
+      promptInstructions: "Renew the car registration by the 20th.",
+      trigger: {},
+    })) as { success: boolean; text?: string; data?: Record<string, unknown> };
+    expect(result.success).toBe(false);
+    expect(result.data?.error).toBe("INVALID_TRIGGER");
+    expect(result.text).toContain("OWNER_REMINDERS action=create");
+    expect(result.text).toContain("by the 20th");
+    expect(result.text).toContain("do not retry here");
+  });
+
   it("an invalid trigger also carries the habit-definition redirect", async () => {
     runtimeResult = await createLifeOpsTestRuntime();
     const { runtime } = runtimeResult;


### PR DESCRIPTION
## Summary
- Claims one-off date/deadline reminder phrasing on `OWNER_REMINDERS` and explicitly de-claims it from raw `SCHEDULED_TASKS` create.
- Expands the `SCHEDULED_TASKS` invalid-trigger recovery hint so a wrong first attempt tells the planner to use `OWNER_REMINDERS action=create` instead of retrying the raw scheduled-task action.
- Adds the exact regression prompt, `Remind me to renew the car registration by the 20th.`, to the LifeOps prompt benchmark catalog as an `OWNER_REMINDERS` case.

Fixes #15017

## Verification
- `bunx @biomejs/biome check plugins/plugin-personal-assistant/src/actions/scheduled-task.ts plugins/plugin-personal-assistant/src/actions/owner-surfaces.ts plugins/plugin-personal-assistant/test/scheduled-task-trigger-boundary.test.ts plugins/plugin-personal-assistant/test/action-structure-audit.test.ts plugins/plugin-personal-assistant/test/helpers/lifeops-prompt-benchmark-cases.ts plugins/plugin-personal-assistant/test/lifeops-prompt-benchmark.test.ts`
- `bunx vitest run --config plugins/plugin-personal-assistant/vitest.config.ts plugins/plugin-personal-assistant/test/scheduled-task-trigger-boundary.test.ts plugins/plugin-personal-assistant/test/action-structure-audit.test.ts plugins/plugin-personal-assistant/test/lifeops-prompt-benchmark.test.ts` — 24 passed, 1 live-gated benchmark skipped
- `bun run audit:error-policy-ratchet`
- `git diff --check origin/develop..HEAD`

## Typecheck
- `bun run --cwd plugins/plugin-personal-assistant typecheck` still fails on the existing package baseline. Filtered touched-file diagnostics are pre-existing areas outside this change: `owner-surfaces.ts` handler implicit-any lines 505/517/541 and `scheduled-task.ts` scheduled-task export/import debt plus old unknown-error lines 837/841/848/852. This PR only changes action routing metadata and tests.

## Evidence notes
- The deterministic trigger-boundary test now verifies the failed `SCHEDULED_TASKS` create path returns `INVALID_TRIGGER` with `OWNER_REMINDERS action=create`, the exact `by the 20th` phrase, and `do not retry here`.
- The action-structure audit verifies `OWNER_REMINDERS` owns deadline wording while `SCHEDULED_TASKS` explicitly rejects new owner reminders/deadlines.
- The prompt benchmark catalog now includes the exact #15017 deadline reminder phrase as an `OWNER_REMINDERS` selected-action expectation.
