### PR TITLE
fix(ui): give the home "Today" card a real owner-todos read model (#14734)

### DIFF
--- a/packages/ui/src/components/chat/widgets/today-todos-data.test.ts
+++ b/packages/ui/src/components/chat/widgets/today-todos-data.test.ts
@@ -1,0 +1,249 @@
+// Read-model unit tests for the home "Today" card: boundary parsing of the
+// untrusted /api/lifeops/todos wire, the due/overdue-today selection, and the
+// occurrence-complete write. Deterministic — `now` is injected, fetch is stubbed.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { getBaseUrlMock } = vi.hoisted(() => ({
+  getBaseUrlMock: vi.fn(() => "http://localhost"),
+}));
+
+vi.mock("../../../api", () => ({
+  client: { getBaseUrl: getBaseUrlMock },
+}));
+
+import {
+  completeTodayTodo,
+  dueOrOverdueToday,
+  fetchTodayTodos,
+  isOverdue,
+  loadTodayTodosForGlance,
+  overdueCount,
+  parseTodayTodos,
+  type TodayTodo,
+  todosEqual,
+} from "./today-todos-data";
+
+// A fixed clock: 2026-07-06T12:00:00Z. All fixtures are relative to it.
+const NOW = Date.parse("2026-07-06T12:00:00.000Z");
+const YESTERDAY = "2026-07-05T09:00:00.000Z";
+const EARLIER_TODAY = "2026-07-06T08:00:00.000Z";
+const LATER_TODAY = "2026-07-06T22:00:00.000Z";
+const TOMORROW = "2026-07-07T09:00:00.000Z";
+
+function todo(over: Partial<TodayTodo> & { id: string }): TodayTodo {
+  return {
+    title: `Todo ${over.id}`,
+    dueDate: LATER_TODAY,
+    status: "pending",
+    ...over,
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  getBaseUrlMock.mockReturnValue("http://localhost");
+});
+
+describe("parseTodayTodos", () => {
+  it("keeps only well-formed, due-dated records and normalizes status", () => {
+    const parsed = parseTodayTodos({
+      todos: [
+        { id: "a", title: "Has due", status: "in_progress", dueDate: TOMORROW },
+        { id: "b", title: "No due", status: "pending", dueDate: null },
+        { id: "c", title: "Bad due", status: "pending", dueDate: "not-a-date" },
+        {
+          id: "d",
+          title: "Unknown status",
+          status: "weird",
+          dueDate: TOMORROW,
+        },
+        { id: 5, title: "Bad id", status: "pending", dueDate: TOMORROW },
+        { title: "No id", status: "pending", dueDate: TOMORROW },
+        "garbage",
+      ],
+    });
+    expect(parsed).toEqual([
+      { id: "a", title: "Has due", status: "in_progress", dueDate: TOMORROW },
+      {
+        id: "d",
+        title: "Unknown status",
+        status: "pending",
+        dueDate: TOMORROW,
+      },
+    ]);
+  });
+
+  it("returns [] for non-object / missing-array payloads", () => {
+    expect(parseTodayTodos(null)).toEqual([]);
+    expect(parseTodayTodos({})).toEqual([]);
+    expect(parseTodayTodos({ todos: "nope" })).toEqual([]);
+    expect(parseTodayTodos("nope")).toEqual([]);
+  });
+});
+
+describe("dueOrOverdueToday", () => {
+  it("keeps overdue + today, drops future and completed, sorts most-overdue first", () => {
+    const glance = dueOrOverdueToday(
+      [
+        todo({ id: "future", dueDate: TOMORROW }),
+        todo({ id: "today-late", dueDate: LATER_TODAY }),
+        todo({ id: "overdue", dueDate: YESTERDAY }),
+        todo({ id: "today-early", dueDate: EARLIER_TODAY }),
+        todo({ id: "done", dueDate: YESTERDAY, status: "completed" }),
+      ],
+      NOW,
+    );
+    expect(glance.map((t) => t.id)).toEqual([
+      "overdue",
+      "today-early",
+      "today-late",
+    ]);
+  });
+
+  it("treats a due date at the last ms of today as still due today", () => {
+    const endOfToday = "2026-07-06T23:59:59.999Z";
+    const glance = dueOrOverdueToday(
+      [todo({ id: "edge", dueDate: endOfToday })],
+      NOW,
+    );
+    // Boundary check uses local end-of-day; a UTC-late timestamp on the same
+    // calendar day resolves as due today under the test's UTC clock.
+    expect(glance.map((t) => t.id)).toContain("edge");
+  });
+});
+
+describe("isOverdue / overdueCount", () => {
+  it("classifies before-start-of-today as overdue, today as not", () => {
+    expect(isOverdue(todo({ id: "y", dueDate: YESTERDAY }), NOW)).toBe(true);
+    expect(isOverdue(todo({ id: "t", dueDate: EARLIER_TODAY }), NOW)).toBe(
+      false,
+    );
+  });
+
+  it("counts only the overdue members of the glance", () => {
+    const count = overdueCount(
+      [
+        todo({ id: "overdue", dueDate: YESTERDAY }),
+        todo({ id: "today", dueDate: LATER_TODAY }),
+        todo({ id: "future", dueDate: TOMORROW }),
+      ],
+      NOW,
+    );
+    expect(count).toBe(1);
+  });
+});
+
+describe("fetchTodayTodos", () => {
+  it("GETs the owner-todos route and parses the response", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            todos: [
+              { id: "a", title: "A", status: "pending", dueDate: TOMORROW },
+            ],
+          }),
+          { status: 200 },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const todos = await fetchTodayTodos();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost/api/lifeops/todos",
+    );
+    expect(todos).toEqual([
+      { id: "a", title: "A", status: "pending", dueDate: TOMORROW },
+    ]);
+  });
+
+  it("throws on a non-2xx response so the caller can degrade (J4)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("nope", { status: 500 })),
+    );
+    await expect(fetchTodayTodos()).rejects.toThrow(
+      "Todos request failed (500)",
+    );
+  });
+});
+
+describe("completeTodayTodo", () => {
+  it("POSTs the occurrence-complete write with the encoded id", async () => {
+    const fetchMock = vi.fn(async () => new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    await completeTodayTodo("occ 1/2");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost/api/lifeops/occurrences/occ%201%2F2/complete",
+      expect.objectContaining({ method: "POST", body: "{}" }),
+    );
+  });
+
+  it("rejects on failure so an optimistic completion can roll back", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("no", { status: 409 })),
+    );
+    await expect(completeTodayTodo("x")).rejects.toThrow(
+      "Complete todo failed (409)",
+    );
+  });
+});
+
+describe("loadTodayTodosForGlance", () => {
+  it("returns [] (gated, not pending) when unauthenticated", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await loadTodayTodosForGlance(false)).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns [] without fetching on a limited cloud-agent base", async () => {
+    getBaseUrlMock.mockReturnValue("https://agent-1.elizacloud.ai");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    expect(await loadTodayTodosForGlance(true)).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns null on a fetch failure so the caller keeps last-good (J4)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("boom", { status: 503 })),
+    );
+    expect(await loadTodayTodosForGlance(true)).toBeNull();
+  });
+
+  it("returns the parsed todos when authenticated on a full app base", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              todos: [
+                { id: "a", title: "A", status: "pending", dueDate: TOMORROW },
+              ],
+            }),
+            { status: 200 },
+          ),
+      ),
+    );
+    expect(await loadTodayTodosForGlance(true)).toEqual([
+      { id: "a", title: "A", status: "pending", dueDate: TOMORROW },
+    ]);
+  });
+});
+
+describe("todosEqual", () => {
+  it("is false against null and on any field change; true on identical content", () => {
+    const a = [todo({ id: "1", title: "One", dueDate: TOMORROW })];
+    expect(todosEqual(null, a)).toBe(false);
+    expect(
+      todosEqual(a, [todo({ id: "1", title: "One", dueDate: TOMORROW })]),
+    ).toBe(true);
+    expect(
+      todosEqual(a, [todo({ id: "1", title: "Changed", dueDate: TOMORROW })]),
+    ).toBe(false);
+    expect(todosEqual(a, [])).toBe(false);
+  });
+});

--- a/packages/ui/src/components/chat/widgets/today-todos-data.ts
+++ b/packages/ui/src/components/chat/widgets/today-todos-data.ts
@@ -1,0 +1,175 @@
+/**
+ * Read model for the home "Today" card (todo.tsx, spec §B.3).
+ *
+ * The Today resident glances the OWNER's due/overdue todos — not the agent's
+ * workbench checklist. Those live behind the single owner-todos read the PA
+ * plugin serves (`GET /api/lifeops/todos`, a projection of the shared
+ * scheduled-task spine), each carrying a `dueDate` the workbench store lacks.
+ * This module is the card's read path: it validates that untrusted wire at the
+ * network boundary into the typed {@link TodayTodo} DTO, selects the
+ * due/overdue-today slice the glance shows, and completes a row through the
+ * canonical `POST /api/lifeops/occurrences/:id/complete` write. The card is a
+ * pure renderer over these results — it never reaches into a store.
+ *
+ * Kept dependency-light (no React) so the parsing, the today-window filter, and
+ * the completion write are unit-testable in isolation. Mirrors the shape of the
+ * sibling `goals-attention-data.ts` glance read model.
+ */
+
+import { client } from "../../../api";
+import { supportsFullAppShellRoutes } from "../../../api/app-shell-capabilities";
+
+/** Home-card poll cadence — matches the TodosView 15s background refresh. */
+export const TODAY_TODOS_REFRESH_INTERVAL_MS = 15_000;
+
+/** The item-board status the PA todos route projects each occurrence onto. */
+export type TodayTodoStatus = "pending" | "in_progress" | "completed";
+
+const KNOWN_STATUSES: ReadonlySet<string> = new Set<TodayTodoStatus>([
+  "pending",
+  "in_progress",
+  "completed",
+]);
+
+/**
+ * An owner todo flattened for the Today glance. Only due-dated todos become a
+ * `TodayTodo` (a glance is about "due today / overdue"; an undated backlog item
+ * is not glanceable), so `dueDate` is required — never nullable — here.
+ */
+export interface TodayTodo {
+  id: string;
+  title: string;
+  dueDate: string;
+  status: TodayTodoStatus;
+}
+
+function toStatus(value: unknown): TodayTodoStatus {
+  return typeof value === "string" && KNOWN_STATUSES.has(value)
+    ? (value as TodayTodoStatus)
+    : "pending";
+}
+
+/**
+ * Validate + flatten the untrusted `{ todos: [{ id, title, status, dueDate }] }`
+ * payload at the network boundary, dropping any record missing an id/title or a
+ * usable due date. A record with a null/unparseable `dueDate` is not a Today
+ * candidate and is dropped here rather than carried as a nullable field.
+ */
+export function parseTodayTodos(payload: unknown): TodayTodo[] {
+  if (typeof payload !== "object" || payload === null) return [];
+  const records = (payload as { todos?: unknown }).todos;
+  if (!Array.isArray(records)) return [];
+
+  const todos: TodayTodo[] = [];
+  for (const record of records) {
+    if (typeof record !== "object" || record === null) continue;
+    const { id, title, status, dueDate } = record as {
+      id?: unknown;
+      title?: unknown;
+      status?: unknown;
+      dueDate?: unknown;
+    };
+    if (typeof id !== "string" || typeof title !== "string") continue;
+    if (typeof dueDate !== "string" || Number.isNaN(Date.parse(dueDate))) {
+      continue;
+    }
+    todos.push({ id, title, dueDate, status: toStatus(status) });
+  }
+  return todos;
+}
+
+/** True when the todo is not yet done. */
+export function isOpen(todo: TodayTodo): boolean {
+  return todo.status !== "completed";
+}
+
+/** True when the todo's due date is strictly before the start of `now`'s day. */
+export function isOverdue(todo: TodayTodo, now: number): boolean {
+  const due = Date.parse(todo.dueDate);
+  const startOfToday = new Date(now).setHours(0, 0, 0, 0);
+  return due < startOfToday;
+}
+
+/**
+ * The glance slice (spec §B.3): open todos due today or already overdue, sorted
+ * most-overdue first so the item that has slipped longest leads. A due date past
+ * the end of today is a backlog item, not a glance, and is excluded.
+ */
+export function dueOrOverdueToday(
+  todos: TodayTodo[],
+  now: number,
+): TodayTodo[] {
+  const endOfToday = new Date(now).setHours(23, 59, 59, 999);
+  return todos
+    .filter((todo) => isOpen(todo) && Date.parse(todo.dueDate) <= endOfToday)
+    .sort(
+      (left, right) => Date.parse(left.dueDate) - Date.parse(right.dueDate),
+    );
+}
+
+/** Count of the glance slice that is already overdue — drives the card's rank. */
+export function overdueCount(todos: TodayTodo[], now: number): number {
+  return dueOrOverdueToday(todos, now).filter((todo) => isOverdue(todo, now))
+    .length;
+}
+
+export async function fetchTodayTodos(): Promise<TodayTodo[]> {
+  const response = await fetch(`${client.getBaseUrl()}/api/lifeops/todos`);
+  if (!response.ok) {
+    throw new Error(`Todos request failed (${response.status})`);
+  }
+  return parseTodayTodos(await response.json());
+}
+
+/**
+ * Complete an owner todo through the canonical occurrence-complete write. The
+ * caller applies the row optimistically and reloads; a rejected promise lets the
+ * caller roll the optimistic completion back.
+ */
+export async function completeTodayTodo(id: string): Promise<void> {
+  const response = await fetch(
+    `${client.getBaseUrl()}/api/lifeops/occurrences/${encodeURIComponent(id)}/complete`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`Complete todo failed (${response.status})`);
+  }
+}
+
+/** Shallow content equality so an unchanged poll doesn't re-render the card. */
+export function todosEqual(a: TodayTodo[] | null, b: TodayTodo[]): boolean {
+  if (!a || a.length !== b.length) return false;
+  return a.every((todo, i) => {
+    const other = b[i];
+    return (
+      todo.id === other.id &&
+      todo.title === other.title &&
+      todo.dueDate === other.dueDate &&
+      todo.status === other.status
+    );
+  });
+}
+
+/**
+ * Best-effort owner-todos fetch for the glance: honors the auth gate and the
+ * limited-cloud-base guard, and swallows fetch errors (returns `null` so the
+ * caller keeps its last-good render, todo.tsx J4 pattern). Returns `[]` when
+ * gated so the caller resolves to "loaded, empty" rather than "still pending".
+ */
+export async function loadTodayTodosForGlance(
+  authenticated: boolean,
+): Promise<TodayTodo[] | null> {
+  if (!authenticated || !supportsFullAppShellRoutes(client.getBaseUrl())) {
+    return [];
+  }
+  try {
+    return await fetchTodayTodos();
+  } catch {
+    // error-policy:J4 glance surface - signal "keep last good" to the caller.
+    return null;
+  }
+}

--- a/packages/ui/src/components/chat/widgets/todo.test.tsx
+++ b/packages/ui/src/components/chat/widgets/todo.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
@@ -8,11 +9,24 @@ const {
   listWorkbenchTodosMock,
   mockState,
   publishHomeAttentionSpy,
+  openViewSpy,
 } = vi.hoisted(() => ({
   // Auth gate (#11084) - mutable so tests can flip the session state.
   authMock: { authenticated: true },
   getBaseUrlMock: vi.fn(() => "http://localhost"),
-  listWorkbenchTodosMock: vi.fn(async () => ({ todos: [] })),
+  listWorkbenchTodosMock: vi.fn(
+    async (): Promise<{
+      todos: Array<{
+        id: string;
+        name: string;
+        description: string;
+        type: string;
+        isCompleted: boolean;
+        isUrgent: boolean;
+        priority: number | null;
+      }>;
+    }> => ({ todos: [] }),
+  ),
   mockState: {
     workbench: {
       todos: [
@@ -31,7 +45,46 @@ const {
       vars?.defaultValue ?? "",
   },
   publishHomeAttentionSpy: vi.fn(),
+  openViewSpy: vi.fn(),
 }));
+
+// The home card fetches owner todos (/api/lifeops/todos) and the urgent goal
+// (/api/lifeops/goals) through the read models, and completes a row through
+// /api/lifeops/occurrences/:id/complete. This router drives the REAL read path.
+const completeState = { status: 200, calls: [] as string[] };
+function stubLifeopsFetch(todos: unknown[], goals: unknown[] = []) {
+  completeState.status = 200;
+  completeState.calls = [];
+  const fetchMock = vi.fn(async (url: unknown) => {
+    const u = String(url);
+    if (u.includes("/api/lifeops/occurrences/") && u.endsWith("/complete")) {
+      completeState.calls.push(u);
+      return new Response("{}", { status: completeState.status });
+    }
+    if (u.includes("/api/lifeops/todos")) {
+      return new Response(JSON.stringify({ todos }), { status: 200 });
+    }
+    if (u.includes("/api/lifeops/goals")) {
+      return new Response(JSON.stringify({ goals }), { status: 200 });
+    }
+    return new Response("{}", { status: 404 });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const overdueDue = () => new Date(Date.now() - DAY_MS).toISOString();
+const dueTodayDue = () => new Date().toISOString();
+const futureDue = () => new Date(Date.now() + 2 * DAY_MS).toISOString();
+function ownerTodo(over: {
+  id: string;
+  title?: string;
+  status?: string;
+  dueDate: string;
+}) {
+  return { title: `Todo ${over.id}`, status: "pending", ...over };
+}
 
 vi.mock("../../../api", () => ({
   client: {
@@ -57,6 +110,10 @@ vi.mock("../../../widgets/home-attention-store", () => ({
   usePublishHomeAttention: publishHomeAttentionSpy,
 }));
 
+vi.mock("./home-widget-card", () => ({
+  useWidgetNavigation: () => ({ openView: openViewSpy }),
+}));
+
 import { HOME_SIGNAL_WEIGHTS } from "../../../widgets/home-priority";
 import { TODO_PLUGIN_WIDGETS } from "./todo";
 
@@ -74,6 +131,7 @@ beforeEach(() => {
   listWorkbenchTodosMock.mockClear();
   listWorkbenchTodosMock.mockResolvedValue({ todos: [] });
   publishHomeAttentionSpy.mockClear();
+  openViewSpy.mockClear();
   authMock.authenticated = true;
   mockState.workbench.todos = [
     {
@@ -195,9 +253,113 @@ describe("TodoSidebarWidget", () => {
     expect(listWorkbenchTodosMock).toHaveBeenCalledTimes(2);
   });
 
+  it("home slot: renders the OWNER's due/overdue todos, not the agent workbench (#14734)", async () => {
+    stubLifeopsFetch([
+      ownerTodo({ id: "od", title: "Pay rent", dueDate: overdueDue() }),
+      ownerTodo({
+        id: "td",
+        title: "Call the dentist",
+        dueDate: dueTodayDue(),
+      }),
+      ownerTodo({ id: "fut", title: "Book flights", dueDate: futureDue() }),
+    ]);
+
+    render(<TodoWidget slot="home" events={[]} clearEvents={vi.fn()} />);
+
+    // Owner todos with due dates render...
+    expect(await screen.findByText("Pay rent")).toBeTruthy();
+    expect(screen.getByText("Call the dentist")).toBeTruthy();
+    // ...the future todo is not a glance...
+    expect(screen.queryByText("Book flights")).toBeNull();
+    // ...and the agent's workbench checklist never appears on the Today card.
+    expect(screen.queryByText("Cached todo")).toBeNull();
+    // Overdue carries the accent badge; due-today is neutral.
+    expect(screen.getByText("Overdue")).toBeTruthy();
+    expect(screen.getByText("Due today")).toBeTruthy();
+  });
+
+  it("home slot: self-hides when nothing is due/overdue and there is no urgent goal", async () => {
+    stubLifeopsFetch([
+      ownerTodo({ id: "fut", title: "Book flights", dueDate: futureDue() }),
+    ]);
+    const { container } = render(
+      <TodoWidget slot="home" events={[]} clearEvents={vi.fn()} />,
+    );
+    await waitFor(() => {
+      expect(container.firstElementChild).toBeNull();
+    });
+  });
+
+  it("home slot: tapping a row completes it through the occurrence-complete write and it disappears (#14734)", async () => {
+    stubLifeopsFetch([
+      ownerTodo({ id: "occ-1", title: "Pay rent", dueDate: overdueDue() }),
+    ]);
+    const user = userEvent.setup();
+
+    render(<TodoWidget slot="home" events={[]} clearEvents={vi.fn()} />);
+    const row = await screen.findByTestId("today-todo-row");
+    // First reload after complete returns an empty list (the occurrence is done).
+    await user.click(row);
+
+    await waitFor(() => {
+      expect(completeState.calls).toContain(
+        "http://localhost/api/lifeops/occurrences/occ-1/complete",
+      );
+    });
+    await waitFor(() => {
+      expect(screen.queryByText("Pay rent")).toBeNull();
+    });
+  });
+
+  it("home slot: restores the row when the completion write fails (J4 rollback)", async () => {
+    stubLifeopsFetch([
+      ownerTodo({ id: "occ-2", title: "Pay rent", dueDate: overdueDue() }),
+    ]);
+    completeState.status = 500;
+    const user = userEvent.setup();
+
+    render(<TodoWidget slot="home" events={[]} clearEvents={vi.fn()} />);
+    const row = await screen.findByTestId("today-todo-row");
+    await user.click(row);
+
+    await waitFor(() => {
+      expect(completeState.calls.length).toBe(1);
+    });
+    // The write failed, so the row must come back rather than silently drop.
+    await waitFor(() => {
+      expect(screen.getByText("Pay rent")).toBeTruthy();
+    });
+  });
+
+  it("home slot: an overdue todo publishes the reminder attention weight", async () => {
+    stubLifeopsFetch([
+      ownerTodo({ id: "od", title: "Pay rent", dueDate: overdueDue() }),
+    ]);
+    render(<TodoWidget slot="home" events={[]} clearEvents={vi.fn()} />);
+    await screen.findByText("Pay rent");
+    await waitFor(() => {
+      expect(publishHomeAttentionSpy).toHaveBeenLastCalledWith(
+        "todo/todo.items",
+        HOME_SIGNAL_WEIGHTS.reminder,
+      );
+    });
+  });
+
+  it("home slot: tapping the header opens the routed todos view", async () => {
+    stubLifeopsFetch([
+      ownerTodo({ id: "od", title: "Pay rent", dueDate: overdueDue() }),
+    ]);
+    const user = userEvent.setup();
+    render(<TodoWidget slot="home" events={[]} clearEvents={vi.fn()} />);
+    await screen.findByText("Pay rent");
+    await user.click(screen.getByRole("button", { name: /Today/ }));
+    expect(openViewSpy).toHaveBeenCalledWith("/todos", "todos");
+  });
+
   it("home slot: applies the host-supplied spanClassName to its single root grid-item element (#11752)", async () => {
-    // Hold the cached todo (no poll) so the card stays rendered while asserting.
-    authMock.authenticated = false;
+    stubLifeopsFetch([
+      ownerTodo({ id: "od", title: "Pay rent", dueDate: overdueDue() }),
+    ]);
     const { container } = render(
       <TodoWidget
         slot="home"
@@ -207,7 +369,7 @@ describe("TodoSidebarWidget", () => {
       />,
     );
 
-    expect(await screen.findByText("Cached todo")).toBeTruthy();
+    expect(await screen.findByText("Pay rent")).toBeTruthy();
     const root = container.firstElementChild;
     expect(root).not.toBeNull();
     expect(root?.className).toContain("col-span-2");
@@ -218,38 +380,30 @@ describe("TodoSidebarWidget", () => {
   });
 
   it("home slot: falls back to the default 2x1 span when no spanClassName is supplied (#11752)", async () => {
-    authMock.authenticated = false;
+    stubLifeopsFetch([
+      ownerTodo({ id: "od", title: "Pay rent", dueDate: overdueDue() }),
+    ]);
     const { container } = render(
       <TodoWidget slot="home" events={[]} clearEvents={vi.fn()} />,
     );
-    expect(await screen.findByText("Cached todo")).toBeTruthy();
+    expect(await screen.findByText("Pay rent")).toBeTruthy();
     expect(container.firstElementChild?.className).toContain("col-span-2");
   });
 
   it("home slot: renders an at-risk goal as one flagged row inside Today (spec §E item 5)", async () => {
-    mockState.workbench.todos = [];
-    listWorkbenchTodosMock.mockResolvedValue({ todos: [] });
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(
-        async () =>
-          new Response(
-            JSON.stringify({
-              goals: [
-                {
-                  goal: {
-                    id: "goal-at-risk",
-                    title: "Ship the release",
-                    status: "active",
-                    reviewState: "at_risk",
-                  },
-                  links: [],
-                },
-              ],
-            }),
-            { status: 200, headers: { "Content-Type": "application/json" } },
-          ),
-      ),
+    stubLifeopsFetch(
+      [],
+      [
+        {
+          goal: {
+            id: "goal-at-risk",
+            title: "Ship the release",
+            status: "active",
+            reviewState: "at_risk",
+          },
+          links: [],
+        },
+      ],
     );
 
     render(<TodoWidget slot="home" events={[]} clearEvents={vi.fn()} />);
@@ -268,29 +422,19 @@ describe("TodoSidebarWidget", () => {
   });
 
   it("home slot: preserves needs-attention goals in the merged Today row", async () => {
-    mockState.workbench.todos = [];
-    listWorkbenchTodosMock.mockResolvedValue({ todos: [] });
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(
-        async () =>
-          new Response(
-            JSON.stringify({
-              goals: [
-                {
-                  goal: {
-                    id: "goal-needs-attention",
-                    title: "Reconnect with the team",
-                    status: "active",
-                    reviewState: "needs_attention",
-                  },
-                  links: [],
-                },
-              ],
-            }),
-            { status: 200, headers: { "Content-Type": "application/json" } },
-          ),
-      ),
+    stubLifeopsFetch(
+      [],
+      [
+        {
+          goal: {
+            id: "goal-needs-attention",
+            title: "Reconnect with the team",
+            status: "active",
+            reviewState: "needs_attention",
+          },
+          links: [],
+        },
+      ],
     );
 
     render(<TodoWidget slot="home" events={[]} clearEvents={vi.fn()} />);

--- a/packages/ui/src/components/chat/widgets/todo.tsx
+++ b/packages/ui/src/components/chat/widgets/todo.tsx
@@ -1,17 +1,24 @@
 /**
- * Chat-sidebar (and home-grid) TODO widget: lists the agent workbench's todos,
- * seeded from the app store's `workbench.todos`, refreshed on live workbench
- * events, and backed by a visible-tab poll for missed events. Exports
- * `TODO_PLUGIN_WIDGETS`, the widget-registry entry consumed by the sidebar.
+ * The `todo.items` widget, which serves two different surfaces from one
+ * registration because the widget host renders it in both:
  *
- * On the home surface this is the "Today" card, and per spec §B/§E item 5 it
- * absorbs the goals resident: when the goals store reports an at-risk (or
- * needs-attention) goal, that goal renders as one flagged row inside this card
- * rather than as a second standalone home widget. The card then self-publishes
- * the goals escalation weight so the merged card floats up on goal urgency.
+ *  - Chat sidebar (`TodoSidebarWidget`): the agent's own workbench checklist,
+ *    seeded from the app store's `workbench.todos`, refreshed on live workbench
+ *    events and a visible-tab repair poll. This is "what the agent is working
+ *    on" and is the store's to own.
+ *  - Home grid (`TodayHomeCard`): the OWNER's "Today" resident (spec §B.3) —
+ *    their due/overdue todos, which carry a `dueDate` the workbench checklist
+ *    does not. These are a different domain read entirely, so the home card does
+ *    NOT read a store: it renders the typed DTO from the `today-todos-data` read
+ *    model (`GET /api/lifeops/todos`) and completes a row through that model's
+ *    occurrence-complete write. Per §E item 5 it also absorbs the single most
+ *    urgent goal as one flagged row and self-publishes the escalation weight so
+ *    the merged card floats up on goal urgency.
+ *
+ * Exports `TODO_PLUGIN_WIDGETS`, the widget-registry entry the host consumes.
  */
-import { ListTodo, Target } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { Circle, ListTodo, Target } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { client } from "../../../api";
 import { supportsFullAppShellRoutes } from "../../../api/app-shell-capabilities";
 import type { WorkbenchTodo } from "../../../api/client-types-config";
@@ -31,6 +38,15 @@ import {
 } from "./goals-attention-data";
 import { useWidgetNavigation } from "./home-widget-card";
 import { EmptyWidgetState, WidgetSection } from "./shared";
+import {
+  completeTodayTodo,
+  dueOrOverdueToday,
+  isOverdue,
+  loadTodayTodosForGlance,
+  TODAY_TODOS_REFRESH_INTERVAL_MS,
+  type TodayTodo,
+  todosEqual,
+} from "./today-todos-data";
 import type {
   ChatSidebarWidgetDefinition,
   ChatSidebarWidgetProps,
@@ -40,6 +56,8 @@ const TODO_WIDGET_KEY = "todo/todo.items";
 
 const TODO_REFRESH_INTERVAL_MS = 15_000;
 const MAX_VISIBLE_TODOS = 8;
+/** The Today glance shows at most three rows (spec §B.3). */
+const MAX_TODAY_ROWS = 3;
 
 const fallbackTranslate: TranslateFn = (key, vars) =>
   typeof vars?.defaultValue === "string" ? vars.defaultValue : key;
@@ -168,6 +186,56 @@ function TodoRow({
 }
 
 /**
+ * A single owner-todo row in the Today card. The whole row is the completion
+ * affordance (a 44px tap target holds the home hit-area rule): tapping toggles
+ * the todo done. Overdue todos carry the accent (spec §B.3 "overdue in the
+ * accent color"); an on-time due-today todo is neutral white-family.
+ */
+function TodayTodoRow({
+  todo,
+  now,
+  onComplete,
+}: {
+  todo: TodayTodo;
+  now: number;
+  onComplete: () => void;
+}) {
+  const overdue = isOverdue(todo, now);
+  return (
+    <button
+      type="button"
+      data-testid="today-todo-row"
+      aria-label={`Complete todo "${todo.title}"`}
+      onClick={onComplete}
+      className="flex min-h-11 w-full items-start gap-2 rounded-sm border border-white/15 bg-white/10 p-3 text-left text-white"
+    >
+      <Circle
+        className={`mt-0.5 h-4 w-4 shrink-0 ${overdue ? "text-accent" : "text-white/70"}`}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="min-w-0 truncate text-xs font-semibold text-white">
+            {todo.title}
+          </span>
+          {overdue ? (
+            <Badge
+              variant="secondary"
+              className={homeBadgeClassName("home", "text-accent")}
+            >
+              Overdue
+            </Badge>
+          ) : (
+            <Badge variant="secondary" className={homeBadgeClassName("home")}>
+              Due today
+            </Badge>
+          )}
+        </div>
+      </div>
+    </button>
+  );
+}
+
+/**
  * The merged goal-attention row (§E item 5): renders the single urgent goal
  * inline in the Today card. Whole-row button so the home 44px target rule holds;
  * tapping opens the Goals view.
@@ -225,44 +293,26 @@ function GoalAttentionRow({
   );
 }
 
-function TodoItemsContent({
+/**
+ * The chat-sidebar content: the agent's workbench checklist, grouped open-first.
+ */
+function WorkbenchTodoItems({
   todos,
   loading,
-  goal,
-  onOpenGoal,
-  tone = "default",
 }: {
   todos: WorkbenchTodo[];
   loading: boolean;
-  goal: AttentionGoal | null;
-  onOpenGoal: () => void;
-  tone?: "default" | "home";
 }) {
   const openTodos = todos.filter((todo) => !todo.isCompleted);
   const hiddenCompletedCount = todos.length - openTodos.length;
   const visibleTodos = openTodos.slice(0, MAX_VISIBLE_TODOS);
   const remainingCount = openTodos.length - visibleTodos.length;
-  const goalRow = goal ? (
-    <GoalAttentionRow goal={goal} onOpen={onOpenGoal} tone={tone} />
-  ) : null;
 
-  if (loading && todos.length === 0 && !goal) {
-    return (
-      <div
-        className={`py-3 text-xs ${tone === "home" ? "text-white/70" : "text-muted"}`}
-      >
-        Refreshing todos…
-      </div>
-    );
+  if (loading && todos.length === 0) {
+    return <div className="py-3 text-xs text-muted">Refreshing todos…</div>;
   }
 
   if (openTodos.length === 0) {
-    // A flagged goal alone still gives the card a reason to render; only a fully
-    // empty Today (no open todos AND no at-risk goal) shows the empty state
-    // (which the sidebar surface uses; the home surface hides entirely).
-    if (goalRow) {
-      return <div className="flex flex-col gap-2">{goalRow}</div>;
-    }
     return (
       <EmptyWidgetState
         icon={<ListTodo className="h-8 w-8" />}
@@ -273,21 +323,16 @@ function TodoItemsContent({
 
   return (
     <div className="flex flex-col gap-2">
-      {goalRow}
       {visibleTodos.map((todo) => (
-        <TodoRow key={todo.id} todo={todo} tone={tone} />
+        <TodoRow key={todo.id} todo={todo} />
       ))}
       {remainingCount > 0 ? (
-        <p
-          className={`px-1 text-xs-tight ${tone === "home" ? "text-white/70" : "text-muted"}`}
-        >
+        <p className="px-1 text-xs-tight text-muted">
           +{remainingCount} more open todo{remainingCount === 1 ? "" : "s"}
         </p>
       ) : null}
       {hiddenCompletedCount > 0 ? (
-        <p
-          className={`px-1 text-xs-tight ${tone === "home" ? "text-white/70" : "text-muted"}`}
-        >
+        <p className="px-1 text-xs-tight text-muted">
           {hiddenCompletedCount} completed todo
           {hiddenCompletedCount === 1 ? "" : "s"} hidden
         </p>
@@ -297,13 +342,12 @@ function TodoItemsContent({
 }
 
 /**
- * Fetch the single urgent goal for the merged Today card (§E item 5). Only
- * active on the home surface; the chat-sidebar Todos widget never surfaces
- * goals. Polls at the goals cadence, visibility-gated, and keeps its last-good
- * value on a transient failure (J4). Returns `null` when there is no at-risk or
- * needs-attention goal (or off-home), so it contributes nothing to the card.
+ * Fetch the single urgent goal for the merged Today card (§E item 5). Polls at
+ * the goals cadence, visibility-gated, and keeps its last-good value on a
+ * transient failure (J4). Returns `null` when there is no at-risk or
+ * needs-attention goal, so it contributes nothing to the card.
  */
-function useAtRiskGoal(active: boolean): AttentionGoal | null {
+function useAtRiskGoal(): AttentionGoal | null {
   const authenticated = useIsAuthenticated();
   const [goals, setGoals] = useState<AttentionGoal[] | null>(null);
   const mountedRef = useRef(true);
@@ -315,40 +359,186 @@ function useAtRiskGoal(active: boolean): AttentionGoal | null {
   }, []);
 
   const load = useCallback(async () => {
-    if (!active) return;
     const next = await loadGoalsForGlance(authenticated);
     // A null return means the fetch failed (J4) - keep the last good value.
     if (next == null || !mountedRef.current) return;
     setGoals((prev) => (goalsEqual(prev, next) ? prev : next));
-  }, [active, authenticated]);
+  }, [authenticated]);
 
   useEffect(() => {
-    if (!active) {
-      setGoals(null);
-      return;
-    }
     void load();
-  }, [active, load]);
-  useIntervalWhenDocumentVisible(
-    () => void load(),
-    GOALS_REFRESH_INTERVAL_MS,
-    active,
-  );
+  }, [load]);
+  useIntervalWhenDocumentVisible(() => void load(), GOALS_REFRESH_INTERVAL_MS);
 
-  if (!active || goals == null) return null;
+  if (goals == null) return null;
   return mostUrgentGoal(goals);
 }
 
-function TodoSidebarWidget({
-  events,
-  slot,
+/**
+ * The owner's Today todos read model, driving the home card. Loads through
+ * `today-todos-data` (never a store), polls visibility-gated, keeps last-good on
+ * a transient failure (J4), and completes a row optimistically: the tapped todo
+ * disappears immediately, a successful write is confirmed by the reload, and a
+ * failed write restores the row.
+ *
+ * `now` is state sampled inside the load/poll callbacks — never `Date.now()` in
+ * render — so the due/overdue slice recomputes on each 15s tick (surfacing a
+ * todo that crosses into overdue) while keeping renders deterministic.
+ */
+function useTodayTodos(): {
+  glance: TodayTodo[] | null;
+  now: number;
+  hasOverdue: boolean;
+  complete: (id: string) => void;
+} {
+  const authenticated = useIsAuthenticated();
+  const [todos, setTodos] = useState<TodayTodo[] | null>(null);
+  const [now, setNow] = useState(0);
+  const [completingIds, setCompletingIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const load = useCallback(async () => {
+    const next = await loadTodayTodosForGlance(authenticated);
+    if (!mountedRef.current) return;
+    setNow(Date.now());
+    // A null return means the fetch failed (J4) - keep the last good value.
+    if (next == null) return;
+    setTodos((prev) => (todosEqual(prev, next) ? prev : next));
+  }, [authenticated]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+  useIntervalWhenDocumentVisible(
+    () => void load(),
+    TODAY_TODOS_REFRESH_INTERVAL_MS,
+  );
+
+  const complete = useCallback(
+    (id: string) => {
+      setCompletingIds((prev) => new Set(prev).add(id));
+      completeTodayTodo(id)
+        .then(() => load())
+        .catch(() => {
+          // error-policy:J4 optimistic write failed - restore the row so the
+          // user sees it is still open rather than a silent drop.
+          if (!mountedRef.current) return;
+          setCompletingIds((prev) => {
+            const next = new Set(prev);
+            next.delete(id);
+            return next;
+          });
+        });
+    },
+    [load],
+  );
+
+  const glance = useMemo(() => {
+    if (todos == null) return null;
+    return dueOrOverdueToday(todos, now).filter(
+      (todo) => !completingIds.has(todo.id),
+    );
+  }, [todos, now, completingIds]);
+  const hasOverdue = useMemo(
+    () => (glance ?? []).some((todo) => isOverdue(todo, now)),
+    [glance, now],
+  );
+
+  return { glance, now, hasOverdue, complete };
+}
+
+/**
+ * The home "Today" resident: the owner's due/overdue todos as a pure render over
+ * the read model, plus the merged urgent-goal row. Publishes its home-attention
+ * weight from the STRONGER of its two signals (an at-risk goal outranks an
+ * overdue todo), and self-hides when it has nothing to show — the home surface
+ * must not paint empty-state placeholders (#9143).
+ */
+function TodayHomeCard({
   spanClassName = "col-span-2 row-span-1",
-}: ChatSidebarWidgetProps) {
-  const { workbench, t: appT } = useAppSelectorShallow((s) => ({
+}: {
+  spanClassName?: string;
+}) {
+  const t = useAppSelectorShallow((s) => s.t) ?? fallbackTranslate;
+  const nav = useWidgetNavigation();
+  const { glance, now, hasOverdue, complete } = useTodayTodos();
+  const attentionGoal = useAtRiskGoal();
+
+  const rows = glance ?? [];
+  const visibleTodos = rows.slice(0, MAX_TODAY_ROWS);
+  const remainingCount = rows.length - visibleTodos.length;
+
+  // Float the merged Today card up on the STRONGER of its two signals: an
+  // at-risk goal contributes the goals escalation weight (higher than the todo
+  // reminder weight), so goal urgency dominates - matching the standalone goals
+  // card this absorbed (§E item 5). Both publish under the todo key because the
+  // ranker attributes a self-published weight to the declaration whose key
+  // matches, and the merged resident IS `todo/todo.items`.
+  const homeAttentionWeight = attentionGoal
+    ? HOME_SIGNAL_WEIGHTS.escalation
+    : hasOverdue
+      ? HOME_SIGNAL_WEIGHTS.reminder
+      : null;
+  usePublishHomeAttention(TODO_WIDGET_KEY, homeAttentionWeight);
+
+  // Nothing due/overdue AND no at-risk goal: the card has no reason to render.
+  if (rows.length === 0 && !attentionGoal) return null;
+
+  const goalRow = attentionGoal ? (
+    <GoalAttentionRow
+      goal={attentionGoal}
+      onOpen={() => nav.openView("/goals", "goals")}
+      tone="home"
+    />
+  ) : null;
+
+  return (
+    <div className={`min-w-0 ${spanClassName}`}>
+      <WidgetSection
+        title={t("taskseventspanel.Today", { defaultValue: "Today" })}
+        icon={<ListTodo className="h-4 w-4" />}
+        testId="chat-widget-todos"
+        tone="home"
+        onTitleClick={() => nav.openView("/todos", "todos")}
+      >
+        <div className="flex flex-col gap-2">
+          {goalRow}
+          {visibleTodos.map((todo) => (
+            <TodayTodoRow
+              key={todo.id}
+              todo={todo}
+              now={now}
+              onComplete={() => complete(todo.id)}
+            />
+          ))}
+          {remainingCount > 0 ? (
+            <p className="px-1 text-xs-tight text-white/70">
+              +{remainingCount} more due today
+            </p>
+          ) : null}
+        </div>
+      </WidgetSection>
+    </div>
+  );
+}
+
+/**
+ * The chat-sidebar Todos widget: the agent's workbench checklist. Seeds from the
+ * app store, refreshes on live workbench events, and repairs missed events with
+ * a visible-tab poll.
+ */
+function WorkbenchTodoSidebar({ events }: ChatSidebarWidgetProps) {
+  const { workbench } = useAppSelectorShallow((s) => ({
     workbench: s.workbench,
-    t: s.t,
   }));
-  const t = appT ?? fallbackTranslate;
   // Auth gate (#11084): the widget mounts before the auth probe resolves, so
   // the 15s todo poll must stay dormant until the session is authenticated.
   const authenticated = useIsAuthenticated();
@@ -431,56 +621,30 @@ function TodoSidebarWidget({
     TODO_REFRESH_INTERVAL_MS,
   );
 
-  const openTodos = todos.filter((todo) => !todo.isCompleted);
-  const hasUrgent = openTodos.some((todo) => todo.isUrgent);
-  const onHome = slot === "home";
-  // The merged at-risk goal row (§E item 5) is home-only; the chat sidebar
-  // keeps the pure todo list.
-  const nav = useWidgetNavigation();
-  const attentionGoal = useAtRiskGoal(onHome);
-  // Float the merged Today card up on the STRONGER of its two signals: an
-  // at-risk goal contributes the goals escalation weight (higher than the todo
-  // reminder weight), so goal urgency dominates - matching the standalone goals
-  // card this absorbed (§E item 5). Both publish under the todo key because the
-  // ranker attributes a self-published weight to the declaration whose key
-  // matches, and the merged resident IS `todo/todo.items` now.
-  const homeAttentionWeight =
-    onHome && attentionGoal
-      ? HOME_SIGNAL_WEIGHTS.escalation
-      : onHome && hasUrgent
-        ? HOME_SIGNAL_WEIGHTS.reminder
-        : null;
-  usePublishHomeAttention(TODO_WIDGET_KEY, homeAttentionWeight);
+  const { t: appT } = useAppSelectorShallow((s) => ({ t: s.t }));
+  const t = appT ?? fallbackTranslate;
 
-  // On the home grid, render nothing when there are no open todos AND no at-risk
-  // goal - the home surface must not show empty-state placeholders (#9143). A
-  // flagged goal alone keeps the merged Today card alive. The chat sidebar keeps
-  // its empty state.
-  if (onHome && openTodos.length === 0 && !attentionGoal) return null;
-
-  const section = (
+  return (
     <WidgetSection
       title={t("taskseventspanel.Todos", { defaultValue: "Todos" })}
       icon={<ListTodo className="h-4 w-4" />}
       testId="chat-widget-todos"
-      tone={onHome ? "home" : "default"}
     >
-      <TodoItemsContent
-        todos={todos}
-        loading={todosLoading}
-        goal={attentionGoal}
-        onOpenGoal={() => nav.openView("/goals", "goals")}
-        tone={onHome ? "home" : "default"}
-      />
+      <WorkbenchTodoItems todos={todos} loading={todosLoading} />
     </WidgetSection>
   );
-  // On the home 4-col grid the widget's root element must carry its grid-span
-  // classes or it collapses to a one-column cell and its content paints over
-  // the neighboring card (#11752). The sidebar stack renders the bare section.
-  if (onHome) {
-    return <div className={`min-w-0 ${spanClassName}`}>{section}</div>;
+}
+
+/**
+ * Widget-host entry: dispatches to the home "Today" card (owner todos read
+ * model) or the chat-sidebar workbench checklist by slot. They are separate
+ * surfaces backed by separate reads; the host renders whichever the slot needs.
+ */
+function TodoSidebarWidget(props: ChatSidebarWidgetProps) {
+  if (props.slot === "home") {
+    return <TodayHomeCard spanClassName={props.spanClassName} />;
   }
-  return section;
+  return <WorkbenchTodoSidebar {...props} />;
 }
 
 export const TODO_PLUGIN_WIDGETS: ChatSidebarWidgetDefinition[] = [


### PR DESCRIPTION
## Root cause

The flagship ADHD **"Today"** home card (`packages/ui/src/components/chat/widgets/todo.tsx`) read the app store's `workbench.todos` **directly** — the AGENT's work checklist. `WorkbenchTodo` has no `dueDate`, so the spec's Today resident (NOTIFICATIONS-WIDGETS-SYSTEM.md §B.3: *"up to 3 items due/overdue today, checkbox affordance, tap toggles done"*) could not be built on it. The card was a **store-reader for the wrong store**, and showed the agent's chores instead of the owner's due/overdue todos.

The owner's todos (with `dueDate`) already live behind `GET /api/lifeops/todos` — a projection of the shared scheduled-task spine — but only the routed `TodosView` consumed them. The home card had no read path to them.

## Fix — one canonical read path, card becomes a pure renderer

New read model **`today-todos-data.ts`** (dependency-light, mirrors the sibling `goals-attention-data.ts`):

- validates the untrusted `GET /api/lifeops/todos` wire at the boundary into the typed **`TodayTodo`** DTO (drops null/undated/malformed records — a glance is only about *due*),
- selects the **due/overdue-today** slice (`dueOrOverdueToday`), sorted most-overdue-first,
- completes a row through the canonical **`POST /api/lifeops/occurrences/:id/complete`** write.

`todo.tsx` now **dispatches by slot**:
- **home** → `TodayHomeCard`, a pure render over the DTO (checkbox affordance, overdue in the accent color, **optimistic completion with rollback**, header opens the routed todos view). It never touches a store.
- **chat sidebar** → the agent's workbench checklist (a legitimately different domain read) is preserved unchanged.

The merged at-risk-goal row (§E item 5) and the home-attention weighting are preserved; the overdue count now drives the `reminder` weight (an at-risk goal still outranks it with `escalation`). `now` is sampled inside the load/poll callbacks — never `Date.now()` in render — so renders stay deterministic (passes `audit:ui-determinism`).

## Architecture alignment

- **Client displays, never computes / read model returns a typed DTO** — the card reads DTO fields; all selection/derivation lives in the read model.
- **DTO fields required by default** — `TodayTodo.dueDate` is non-nullable; undated records are dropped at the boundary, not carried as `null`.
- **Error policy J4** — a failed glance fetch returns `null` so the card keeps last-good (never fabricates empty); a failed completion write rolls the optimistic row back rather than silently dropping it.
- **Sparse-home doctrine** — the card self-hides when nothing is due/overdue and no goal is urgent.
- `view-action-ratchet` and `audit:ui-determinism` both pass for the touched files.

## Evidence

**Real-path tests (30 passing)** — drive the actual fetch → parse → filter → render → complete path; each fails without the fix.

<details><summary>Test run</summary>

```
today-todos-data.test.ts (15) — parseTodayTodos, dueOrOverdueToday (today-window + overdue sort + end-of-day boundary),
  isOverdue/overdueCount, fetchTodayTodos (GET + throw on 5xx), completeTodayTodo (encoded POST + reject on failure),
  loadTodayTodosForGlance (auth gate / limited-base gate / J4 null / happy path), todosEqual

todo.test.tsx (15) — sidebar workbench behavior preserved; home slot:
  ✓ renders the OWNER's due/overdue todos, not the agent workbench (#14734)
  ✓ self-hides when nothing is due/overdue and there is no urgent goal
  ✓ tapping a row completes it through the occurrence-complete write and it disappears
  ✓ restores the row when the completion write fails (J4 rollback)
  ✓ an overdue todo publishes the reminder attention weight
  ✓ tapping the header opens the routed todos view
  ✓ spanClassName / at-risk goal / needs-attention goal (§E item 5) preserved

Test Files  2 passed (2)   Tests  30 passed (30)
```
</details>

- **Before/after screenshots (live app):** N/A — booting the full app + SIWE login + seeding `life_task_definitions`/occurrences with due dates is out of scope for this lane. The exact card DOM (owner titles rendered, workbench hidden, `Overdue`/`Due today` badges, tap-to-complete removing the row) is asserted by the rendering tests above against a live fetch router.
- **Backend trajectory / real-LLM:** N/A — no agent/model/prompt behavior changed; this is a UI read-path fix over an existing REST endpoint.

Closes #14734

🤖 Generated with [Claude Code](https://claude.com/claude-code)