### PR TITLE
fix(app): p3 phone-app ui/ux polish — 44px touch floor, plugin-page error state, default-on aesthetic gate

### DIFF
--- a/packages/app/test/audit/aesthetic-audit-rules.test.ts
+++ b/packages/app/test/audit/aesthetic-audit-rules.test.ts
@@ -22,6 +22,7 @@ import {
   parseMinimalismBaseline,
   parseNavigationTabPaths,
   parseRgb,
+  resolveAuditStrictFlags,
   type VerdictFinding,
 } from "../ui-smoke/aesthetic-audit-rules";
 
@@ -761,5 +762,51 @@ describe("evaluateStrictGate (#9304 / #10710 strict verdict gate)", () => {
     expect(gate.message).toContain("crash @ desktop: readableChars=0");
     expect(gate.message).toContain("'needs-work'");
     expect(gate.message).toContain("debt @ desktop");
+  });
+});
+
+describe("resolveAuditStrictFlags (#10710 default-on gate)", () => {
+  it("defaults BOTH gates on when the vars are unset", () => {
+    expect(resolveAuditStrictFlags({})).toEqual({
+      strict: true,
+      needsWorkStrict: true,
+    });
+  });
+
+  it('opts out only on an explicit "0"', () => {
+    expect(
+      resolveAuditStrictFlags({
+        ELIZA_AUDIT_APP_STRICT: "0",
+        ELIZA_AUDIT_APP_STRICT_NEEDS_WORK: "0",
+      }),
+    ).toEqual({ strict: false, needsWorkStrict: false });
+  });
+
+  it('stays on for "1" — parity with the app-aesthetic-audit CI lane', () => {
+    expect(
+      resolveAuditStrictFlags({
+        ELIZA_AUDIT_APP_STRICT: "1",
+        ELIZA_AUDIT_APP_STRICT_NEEDS_WORK: "1",
+      }),
+    ).toEqual({ strict: true, needsWorkStrict: true });
+  });
+
+  it("gates each axis independently", () => {
+    expect(
+      resolveAuditStrictFlags({ ELIZA_AUDIT_APP_STRICT_NEEDS_WORK: "0" }),
+    ).toEqual({ strict: true, needsWorkStrict: false });
+    expect(resolveAuditStrictFlags({ ELIZA_AUDIT_APP_STRICT: "0" })).toEqual({
+      strict: false,
+      needsWorkStrict: true,
+    });
+  });
+
+  it('treats any non-"0" value as on', () => {
+    expect(
+      resolveAuditStrictFlags({
+        ELIZA_AUDIT_APP_STRICT: "",
+        ELIZA_AUDIT_APP_STRICT_NEEDS_WORK: "true",
+      }),
+    ).toEqual({ strict: true, needsWorkStrict: true });
   });
 });

--- a/packages/app/test/ui-smoke/aesthetic-audit-rules.ts
+++ b/packages/app/test/ui-smoke/aesthetic-audit-rules.ts
@@ -615,3 +615,33 @@ export function evaluateStrictGate(
 
   return { undebtedBroken, undebtedNeedsWork, failed, message };
 }
+
+/** The audit's strict-gate env inputs (a `process.env` is structurally
+ * assignable to this). */
+export interface AuditStrictEnv {
+  ELIZA_AUDIT_APP_STRICT?: string;
+  ELIZA_AUDIT_APP_STRICT_NEEDS_WORK?: string;
+}
+
+/**
+ * Resolve the strict-gate flags from the environment — DEFAULT-ON (#10710
+ * follow-up).
+ *
+ * Both the `broken` gate and the `needs-work` extension now default ON: a run
+ * gates unless the corresponding var is explicitly set to `"0"`. This makes a
+ * bare `bun run --cwd packages/app audit:app` enforce the same posture the
+ * `app-aesthetic-audit.yml` CI lane already forces (both vars `"1"`), so a NEW
+ * blue / orange→black-hover / missing-overlay regression fails by default
+ * instead of only when someone remembers to opt in. Known-parked debt is
+ * allowlisted per slug-viewport in the spec's `AESTHETIC_VERDICT_DEBT`, which
+ * must shrink over time. Set the relevant var to `"0"` only to triage locally.
+ */
+export function resolveAuditStrictFlags(env: AuditStrictEnv): {
+  strict: boolean;
+  needsWorkStrict: boolean;
+} {
+  return {
+    strict: env.ELIZA_AUDIT_APP_STRICT !== "0",
+    needsWorkStrict: env.ELIZA_AUDIT_APP_STRICT_NEEDS_WORK !== "0",
+  };
+}

--- a/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
+++ b/packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts
@@ -18,6 +18,7 @@ import {
   OVERLAY_NATIVE_OR_CANVAS_SLUGS,
   parseMinimalismBaseline,
   parseNavigationTabPaths,
+  resolveAuditStrictFlags,
 } from "./aesthetic-audit-rules";
 import {
   installDefaultAppRoutes,
@@ -36,24 +37,29 @@ import {
 import { VIEW_CASES } from "./plugin-view-cases";
 import { VIEW_ROUTES } from "./view-routes";
 
-// Strict-gate config (#9304). The audit was a pure reporter — `broken` /
+// Strict-gate config (#9304, #10710). The audit was a pure reporter — `broken` /
 // `needs-work` verdicts only landed in report.json and never failed a run, so a
-// regressed view shipped green. With `ELIZA_AUDIT_APP_STRICT=1` the audit becomes
-// a GATE that fails on any `broken` verdict (a real crash / blank render /
-// console error / empty view) outside the shrinking debt allowlist below.
-// `needs-work` (design debt: blue / orange-hover / off-token radius) is logged
-// with a count but not hard-gated by default — opt in with
-// `ELIZA_AUDIT_APP_STRICT_NEEDS_WORK=1` (#10710) once the current set is captured
-// into AESTHETIC_VERDICT_DEBT from a clean CI run.
-const AUDIT_STRICT = process.env.ELIZA_AUDIT_APP_STRICT === "1";
+// regressed view shipped green. It is now a GATE, DEFAULT-ON on BOTH axes: it
+// fails on any `broken` verdict (a real crash / blank render / console error /
+// empty view) AND on any `needs-work` verdict (design debt: blue /
+// orange→black-hover / off-token radius) outside the shrinking debt allowlist
+// below. `resolveAuditStrictFlags` reads the env: each axis stays on unless its
+// var is explicitly `"0"`, so a bare `audit:app` enforces the same posture the
+// `app-aesthetic-audit.yml` CI lane already forces (both vars `"1"`) — a NEW
+// regression fails by default instead of only when someone opts in. Opt OUT with
+// `ELIZA_AUDIT_APP_STRICT=0` / `ELIZA_AUDIT_APP_STRICT_NEEDS_WORK=0` to triage.
+const { strict: AUDIT_STRICT, needsWorkStrict: AUDIT_STRICT_NEEDS_WORK } =
+  resolveAuditStrictFlags(process.env);
 // Sub-pixel slack for the document-level horizontal-overflow invariant: fractional
 // scrollWidth/innerWidth rounding can differ by ~1px on a healthy layout. A real
 // un-contained overflow (WS5) blows past this comfortably.
 const HORIZONTAL_OVERFLOW_TOLERANCE_PX = 2;
-const AUDIT_STRICT_NEEDS_WORK =
-  process.env.ELIZA_AUDIT_APP_STRICT_NEEDS_WORK === "1";
 // Key: `${slug}-${viewport}`. Value: the worst verdict currently tolerated for
-// that view. Empty = zero debt (the INTERACTION_DEBT={}/MAX=0 convention).
+// that view. Empty = zero debt (the INTERACTION_DEBT={}/MAX=0 convention). The
+// CI lane runs the gate default-on against an empty allowlist and passes, so the
+// current baseline carries no parked `broken`/`needs-work` view; keep it empty
+// and add a slug-viewport key ONLY for genuinely-accepted debt, shrinking it
+// over time.
 const AESTHETIC_VERDICT_DEBT: AestheticVerdictDebt = {};
 
 // "Her"-minimal ratchet baseline (#9950) — the committed per-view record of the

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -63,6 +63,7 @@ import { BuildBadge } from "./components/shell/BuildBadge";
 import { ChatSurface } from "./components/shell/ChatSurface";
 import { ConnectionLostOverlay } from "./components/shell/ConnectionLostOverlay";
 import { ContinuousChatOverlay } from "./components/shell/ContinuousChatOverlay";
+import { DynamicPluginFallback } from "./components/shell/DynamicPluginFallback";
 import { HomeLauncherSurface } from "./components/shell/HomeLauncherSurface";
 import { HomePill } from "./components/shell/HomePill";
 import { HomeScreen, type HomeTileTarget } from "./components/shell/HomeScreen";
@@ -750,14 +751,12 @@ function DynamicPluginPage({ resolved }: { resolved: ResolvedDynamicPage }) {
   if (resolved.registration) {
     return <RegisteredAppShellPage registration={resolved.registration} />;
   }
-  // No bundled registration — display a lightweight loading fallback
-  // so the shell stays responsive. Plugins that ship bundled components
-  // should call `registerAppShellPage` at boot to avoid this path.
-  return (
-    <div className="flex flex-1 min-h-0 min-w-0 items-center justify-center text-sm text-muted">
-      Loading {resolved.id}…
-    </div>
-  );
+  // No bundled registration yet: the tab declared a `componentExport` but no
+  // plugin has called `registerAppShellPage`. Registration may still arrive on
+  // the boot idle path (a `registryVersion` bump re-resolves this page and the
+  // branch above takes over); if it never does, the fallback degrades from
+  // loading to a designed error state instead of an unbounded spinner.
+  return <DynamicPluginFallback id={resolved.id} />;
 }
 
 function WalletInventoryPage() {

--- a/packages/ui/src/components/shell/DynamicPluginFallback.test.tsx
+++ b/packages/ui/src/components/shell/DynamicPluginFallback.test.tsx
@@ -48,4 +48,21 @@ describe("DynamicPluginFallback", () => {
     expect(screen.getByTestId("dynamic-plugin-page-loading")).toBeTruthy();
     expect(screen.queryByTestId("dynamic-plugin-page-error")).toBeNull();
   });
+
+  it("restarts the timeout when the unresolved plugin id changes", () => {
+    const { rerender } = render(
+      <DynamicPluginFallback id="stale-plugin" timeoutMs={5_000} />,
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(5_001);
+    });
+    expect(screen.getByTestId("dynamic-plugin-page-error")).toBeTruthy();
+
+    rerender(<DynamicPluginFallback id="fresh-plugin" timeoutMs={5_000} />);
+
+    expect(screen.getByTestId("dynamic-plugin-page-loading")).toBeTruthy();
+    expect(screen.queryByTestId("dynamic-plugin-page-error")).toBeNull();
+    expect(screen.getByText(/Loading fresh-plugin/)).toBeTruthy();
+  });
 });

--- a/packages/ui/src/components/shell/DynamicPluginFallback.test.tsx
+++ b/packages/ui/src/components/shell/DynamicPluginFallback.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+/**
+ * Behaviour test for the unregistered-plugin fallback (#App.tsx DynamicPluginPage
+ * dead-end): it must move from a loading state to a designed error state after
+ * the timeout — the loading/empty/error three-state rule — never spin forever.
+ * Deterministic fake timers; no live model or network.
+ */
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DynamicPluginFallback,
+  UNREGISTERED_PLUGIN_TIMEOUT_MS,
+} from "./DynamicPluginFallback";
+
+describe("DynamicPluginFallback", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("shows loading first, then degrades to a designed error state after the timeout", () => {
+    render(<DynamicPluginFallback id="my-plugin" />);
+
+    expect(screen.getByTestId("dynamic-plugin-page-loading")).toBeTruthy();
+    expect(screen.queryByTestId("dynamic-plugin-page-error")).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(UNREGISTERED_PLUGIN_TIMEOUT_MS + 1);
+    });
+
+    const error = screen.getByTestId("dynamic-plugin-page-error");
+    expect(error.getAttribute("role")).toBe("alert");
+    expect(screen.getByText("This view failed to load")).toBeTruthy();
+    expect(screen.queryByTestId("dynamic-plugin-page-loading")).toBeNull();
+  });
+
+  it("keeps the loading state until the timeout deadline (registration may still arrive)", () => {
+    render(<DynamicPluginFallback id="pending" timeoutMs={5_000} />);
+
+    act(() => {
+      vi.advanceTimersByTime(4_999);
+    });
+
+    expect(screen.getByTestId("dynamic-plugin-page-loading")).toBeTruthy();
+    expect(screen.queryByTestId("dynamic-plugin-page-error")).toBeNull();
+  });
+});

--- a/packages/ui/src/components/shell/DynamicPluginFallback.tsx
+++ b/packages/ui/src/components/shell/DynamicPluginFallback.tsx
@@ -1,0 +1,59 @@
+/**
+ * Fallback for a plugin nav tab that resolved to a `componentExport` but has no
+ * matching `registerAppShellPage` registration yet. Registration rides the boot
+ * idle path, so this holds a brief loading state; a `registryVersion` bump in
+ * `App.tsx` re-resolves the page and hands off to the real component once it
+ * arrives. A tab that ships a `componentExport` and never registers would
+ * otherwise strand the user on an unbounded "Loading…" — so after a bounded
+ * wait this degrades to a designed error state, honoring the loading/empty/error
+ * three-state rule instead of spinning forever.
+ */
+import { useEffect, useState } from "react";
+
+/**
+ * How long to wait for a late `registerAppShellPage` before declaring the view
+ * failed. Registration is a boot-idle side effect, so a few seconds is ample;
+ * past it the tab is treated as shipping no usable view.
+ */
+export const UNREGISTERED_PLUGIN_TIMEOUT_MS = 10_000;
+
+export function DynamicPluginFallback({
+  id,
+  timeoutMs = UNREGISTERED_PLUGIN_TIMEOUT_MS,
+}: {
+  id: string;
+  timeoutMs?: number;
+}) {
+  const [timedOut, setTimedOut] = useState(false);
+  useEffect(() => {
+    setTimedOut(false);
+    const timer = setTimeout(() => setTimedOut(true), timeoutMs);
+    return () => clearTimeout(timer);
+  }, [timeoutMs]);
+
+  if (timedOut) {
+    return (
+      <div
+        role="alert"
+        data-testid="dynamic-plugin-page-error"
+        className="flex flex-1 min-h-0 min-w-0 flex-col items-center justify-center gap-1 px-4 text-center"
+      >
+        <p className="text-sm font-medium text-destructive">
+          This view failed to load
+        </p>
+        <p className="max-w-prose text-xs-tight text-muted">
+          No view is registered for "{id}" in this build.
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div
+      aria-busy="true"
+      data-testid="dynamic-plugin-page-loading"
+      className="flex flex-1 min-h-0 min-w-0 items-center justify-center text-sm text-muted"
+    >
+      Loading {id}…
+    </div>
+  );
+}

--- a/packages/ui/src/components/shell/DynamicPluginFallback.tsx
+++ b/packages/ui/src/components/shell/DynamicPluginFallback.tsx
@@ -24,14 +24,14 @@ export function DynamicPluginFallback({
   id: string;
   timeoutMs?: number;
 }) {
-  const [timedOut, setTimedOut] = useState(false);
+  const [timedOutForId, setTimedOutForId] = useState<string | null>(null);
   useEffect(() => {
-    setTimedOut(false);
-    const timer = setTimeout(() => setTimedOut(true), timeoutMs);
+    setTimedOutForId(null);
+    const timer = setTimeout(() => setTimedOutForId(id), timeoutMs);
     return () => clearTimeout(timer);
-  }, [timeoutMs]);
+  }, [id, timeoutMs]);
 
-  if (timedOut) {
+  if (timedOutForId === id) {
     return (
       <div
         role="alert"

--- a/packages/ui/src/components/ui/button.test.ts
+++ b/packages/ui/src/components/ui/button.test.ts
@@ -1,0 +1,21 @@
+/**
+ * Button primitive coverage for the shared touch-target floor. The assertions
+ * stay at the variant-class boundary because real geometry is enforced by the
+ * app and widget certification sweeps.
+ */
+import { describe, expect, it } from "vitest";
+import { buttonVariants } from "./button";
+
+describe("buttonVariants", () => {
+  it.each([
+    "default",
+    "sm",
+    "icon",
+    "icon-sm",
+  ] as const)("adds the coarse-pointer 44px floor for compact %s buttons", (size) => {
+    const className = buttonVariants({ size });
+
+    expect(className).toContain("pointer-coarse:min-h-touch");
+    expect(className).toContain("pointer-coarse:min-w-touch");
+  });
+});

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -39,8 +39,9 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-4 py-2 pointer-coarse:min-h-touch",
-        sm: "h-9 rounded-sm px-3 py-1.5 pointer-coarse:min-h-touch",
+        default:
+          "h-10 px-4 py-2 pointer-coarse:min-h-touch pointer-coarse:min-w-touch",
+        sm: "h-9 rounded-sm px-3 py-1.5 pointer-coarse:min-h-touch pointer-coarse:min-w-touch",
         lg: "h-11 rounded-sm px-8 py-2.5",
         icon: "h-10 w-10 pointer-coarse:min-h-touch pointer-coarse:min-w-touch",
         "icon-sm":

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -5,6 +5,14 @@
  * `buttonVariants` rather than restyling their own buttons. `asChild` renders
  * the styling onto a Radix Slot child so links can adopt button appearance.
  * Accent-orange resting → darker-orange hover per the brand hover system.
+ *
+ * On coarse-pointer (touch) surfaces the compact sizes compose a 44px hit floor
+ * (`pointer-coarse:min-h/min-w-touch` = `--min-touch-target`) so the rendered
+ * tap target meets the Apple-HIG minimum the tap-target-geometry gate enforces,
+ * without enlarging the fine-pointer (mouse) resting look — the glyph keeps its
+ * declared size; only the clickable box grows. `min-*` composes with a caller's
+ * `h-*`/`w-*` override, so a shrunk icon button (e.g. the chat header's
+ * `h-9 w-9`) still reaches the floor on touch.
  */
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
@@ -31,11 +39,12 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-sm px-3 py-1.5",
+        default: "h-10 px-4 py-2 pointer-coarse:min-h-touch",
+        sm: "h-9 rounded-sm px-3 py-1.5 pointer-coarse:min-h-touch",
         lg: "h-11 rounded-sm px-8 py-2.5",
-        icon: "h-10 w-10",
-        "icon-sm": "h-8 w-8",
+        icon: "h-10 w-10 pointer-coarse:min-h-touch pointer-coarse:min-w-touch",
+        "icon-sm":
+          "h-8 w-8 pointer-coarse:min-h-touch pointer-coarse:min-w-touch",
         "icon-lg": "h-11 w-11",
       },
     },


### PR DESCRIPTION
## What

Three P3 UI/UX polish fixes for the Eliza mobile app, from the phone-app audit. Each defect was re-verified against `origin/develop` before changing (the audit was captured against an older tree).

### Found-vs-claimed

| Audit defect | Status on develop | Action |
|---|---|---|
| **Cloud-settings dark-only island** (`SettingsView.tsx` hardcoded `theme-cloud bg-black text-white`) | **NOT PRESENT** — already fixed upstream by the #13452 / #13590 Settings refactor. `SettingsView.tsx:74` now explicitly documents "no per-section `theme-cloud bg-black` islands". | None (no-op; would have re-fixed a solved bug) |
| **Sub-44px touch targets** (`button.tsx` sizes; chat header `h-9 w-9`=36px; connector Add `h-8`=32px) | **CONFIRMED** — `button.tsx` `default`=40, `sm`=36, `icon`=40, `icon-sm`=32; only the base.css coarse floor at `[data-spatial-surface]` covers spatial buttons, not these. | Fixed |
| **DynamicPluginPage dead-end** (`App.tsx` permanent `Loading {id}…`) | **CONFIRMED** — `App.tsx:749-760` renders an unbounded loading fallback with no error/timeout when a tab declares `componentExport` but never registers. | Fixed |
| **Aesthetic audit opt-in gate** (`all-views-aesthetic-audit.spec.ts` `AUDIT_STRICT*` default off) | **CONFIRMED in code** (`=== "1"`) — but the `app-aesthetic-audit.yml` CI lane already forces both flags to `1` against an empty debt list and passes, so the current baseline is clean. | Fixed (code default now matches CI) |

## Changes

**1. 44px touch floor at the button primitive (`packages/ui/src/components/ui/button.tsx`)**
- Compact sizes compose `pointer-coarse:min-h-touch` (and `min-w-touch` for icon sizes) = the repo's `--min-touch-target` (44px). This is the same idiom the chat composer (`chat-composer.tsx`) already uses.
- Touch-only (`@media (pointer: coarse)`) — the fine-pointer (desktop mouse) resting look is unchanged; the glyph keeps its declared size, only the clickable box grows.
- `min-*` composes with a caller's `h-*`/`w-*` override, so this **also** lifts the chat header controls (`size="icon-sm"` + `h-9 w-9` inside `ContinuousChatOverlay`) and the connector **Add account** button (`size="sm"` + `h-8`) to the floor **without touching those files**.

**2. DynamicPluginPage error/timeout state (`packages/ui/src/App.tsx` + new `components/shell/DynamicPluginFallback.tsx`)**
- The permanent `Loading {id}…` dead-end is replaced with a bounded fallback: it holds the loading state, and a `registryVersion` re-resolve hands off to the real component if registration arrives on the boot idle path; if it never does, after a timeout it degrades to a designed **error** state (`role="alert"`, "This view failed to load"), honoring the loading/empty/error three-state rule.
- Extracted into its own small file so it is unit-testable without importing the whole shell.

**3. Aesthetic audit default-gating (`packages/app/test/ui-smoke/all-views-aesthetic-audit.spec.ts` + `aesthetic-audit-rules.ts`)**
- New pure `resolveAuditStrictFlags(env)`: both the `broken` gate and the `needs-work` extension now **default ON** (each opts out only on an explicit `=0`), so a bare `bun run --cwd packages/app audit:app` enforces the same posture the CI lane already forces. A **new** blue / orange→black-hover / missing-overlay regression now fails by default instead of only when someone opts in.
- `AESTHETIC_VERDICT_DEBT` stays empty — CI already runs the gate default-on against an empty allowlist and passes, so there is no currently-parked `broken`/`needs-work` view to allowlist. (The audit's own parked items are handled by other gates: sub-44px by the tap-target-geometry specs, the onboarding chevron clip lives in first-run which is not a registered audit view, and the dark island is already fixed.)

**Tests added**
- `DynamicPluginFallback.test.tsx` — loading → error-state timeout (fake timers).
- `resolveAuditStrictFlags` cases in `aesthetic-audit-rules.test.ts` — default-on, `=0` opt-out, `=1` parity, independent axes.

## Verification

- **Unit tests:** `packages/app` audit rules **56/56 pass** (incl. 5 new resolver tests); `packages/ui` fallback **2/2 pass**.
- **Biome:** clean (read-only check) on all 7 touched files.
- **Typecheck:** none of the 7 touched files produce type errors. The repo-wide `packages/ui` typecheck reports 11 pre-existing errors, all **outside this diff** (i18n keyword codegen: `core/src/i18n/*`, `shared/src/i18n/keyword-matching.ts`; plus pre-existing test/fixture issues in `todo.test.tsx`, `startup-phase-poll.test.ts`, `widget-cert-fixture.tsx`, `voice-selftest-harness.test.ts`, `settings-sections.ts`) — the known i18n-codegen gotcha on this base, not introduced here.
- **Color law:** no blue introduced; no arbitrary accent; the error state reuses the existing semantic `text-destructive`/`text-muted` tokens (same as the sibling `RegisteredAppShellPage` error fallback); the touch change is layout-only (no color/hover).

### ⚠️ Device / visual-E2E gap (honest limitation)
- `bun run --cwd packages/app audit:app` was **not** run: it needs a cold live dev-stack build (~12 min) + Playwright Chromium in a lane this environment can't practically boot. The touch/error changes are verified at the code + unit-test + color-law-review level, **not** on a real device/simulator. A device pass + an `audit:app` baseline capture is a recommended follow-up.

## Recommendation flagged (out of scope, intentionally not touched)
`packages/ui/src/components/shell/ContinuousChatOverlay.tsx` is a **~4375-line monolith** owning the phone's primary screen (pill / glass panel / transcript / gestures / onboarding backdrop / TTS / connection states). It is the highest-regression-risk surface; a blind refactor without device testing is reckless. **Recommend a separate, carefully device-tested decomposition effort** — deliberately left untouched here (the touch-floor fix reaches its header controls via the button primitive instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
