### PR TITLE
fix(evidence): repair 4 verified defects in the GPU vision job queue (#14543)

### DIFF
--- a/docker/certification/queue-lib.d.mts
+++ b/docker/certification/queue-lib.d.mts
@@ -1,0 +1,55 @@
+/**
+ * Type surface for the plain-node queue kernel in `queue-lib.mjs` (#14549).
+ * Exists so TS consumers — notably the cross-layer drift guard
+ * `packages/evidence/src/queue/parity.test.ts` — see a typed contract instead of
+ * `any`; keep it in lockstep with the module's exports.
+ */
+
+export const QUEUE_DIRS: readonly string[];
+
+export interface QueueLimits {
+  maxPending: number;
+  drainAfterMs: number;
+  pollMs: number;
+  requestTimeoutMs: number;
+}
+export const DEFAULT_LIMITS: Readonly<QueueLimits>;
+
+export interface WorkerState {
+  unreachableSince: number | null;
+  draining: boolean;
+}
+
+export class QueueJobInvalidError extends Error {
+  reason: string;
+  constructor(reason: string);
+}
+
+export function parseJob(
+  raw: string,
+  knownModels: readonly string[],
+): Record<string, unknown>;
+export function claimOrder(fileNames: readonly string[]): string[];
+export function decideEnqueue(
+  pendingCount: number,
+  maxPending: number,
+): { accept: true } | { accept: false; reason: string };
+export function createWorkerState(): WorkerState;
+export function onServiceUnreachable(
+  state: WorkerState,
+  nowMs: number,
+  drainAfterMs: number,
+): WorkerState;
+export function onServiceOk(): WorkerState;
+export function shouldSkipJob(state: WorkerState): boolean;
+export function resultRecord(
+  job: Record<string, unknown>,
+  outcome: { status: string; [key: string]: unknown },
+  completedAtIso: string,
+): Record<string, unknown>;
+export const IMAGE_PLACEHOLDER: string;
+export function resolveImagePlaceholders(
+  request: unknown,
+  dataUri: string,
+): unknown;
+export function makeJobId(nowMs: number, entropy: string): string;

--- a/packages/evidence/src/certify/orchestrate.test.ts
+++ b/packages/evidence/src/certify/orchestrate.test.ts
@@ -10,12 +10,16 @@
 
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { createBundle } from "../bundle.ts";
 import { runCli } from "../cli.ts";
 import { EvidenceError } from "../errors.ts";
+import { FileJobQueue } from "../queue/file-queue.ts";
+import { runQueueWorker } from "../queue/worker.ts";
 import { generateCertificationKeypair } from "./keys.ts";
 import {
   type MatrixRunner,
@@ -23,6 +27,7 @@ import {
   orchestrateCertify,
   parseReviewerVerdicts,
   type ReviewerVerdictsDocument,
+  resolveGpuQueueExecutor,
 } from "./orchestrate.ts";
 import type { RollupResult } from "./rollup.ts";
 import { verifyCertification } from "./sign.ts";
@@ -286,6 +291,176 @@ describe("orchestrateCertify — red paths", () => {
     });
     expect(reverify.ok).toBe(false);
     expect(reverify.failures.map((f) => f.code)).toContain("bundle-tampered");
+  });
+});
+
+const PNG_1X1 = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+/** A throwaway git repo with one screenshot in an ingestable silo. */
+function tmpGitRepoWithScreenshot(): string {
+  const dir = tmpDir("evidence-orch-gitshot-");
+  const git = (...args: string[]) =>
+    execFileSync("git", args, { cwd: dir, stdio: "pipe" });
+  git("init", "-q");
+  git("config", "user.email", "test@example.com");
+  git("config", "user.name", "Test");
+  git("config", "commit.gpgsign", "false");
+  const shotDir = path.join(dir, "e2e-recordings", "login", "desktop");
+  fs.mkdirSync(shotDir, { recursive: true });
+  fs.writeFileSync(path.join(shotDir, "shot.png"), PNG_1X1);
+  git("add", ".");
+  git("commit", "-qm", "init");
+  return dir;
+}
+
+/** Stub gpu-vision service: /health + OpenAI /v1/chat/completions. */
+function startVisionStub(content: string) {
+  const server = createServer((req, res) => {
+    if (req.url === "/health") return void res.writeHead(200).end("ok");
+    if (req.url === "/v1/chat/completions" && req.method === "POST") {
+      req.resume();
+      req.on("end", () =>
+        res
+          .writeHead(200, { "content-type": "application/json" })
+          .end(JSON.stringify({ choices: [{ message: { content } }] })),
+      );
+      return;
+    }
+    res.writeHead(404).end();
+  });
+  const started = new Promise<string>((resolve) =>
+    server.listen(0, "127.0.0.1", () =>
+      resolve(`http://127.0.0.1:${(server.address() as AddressInfo).port}`),
+    ),
+  );
+  return { server, started };
+}
+
+/** Find the analysis.json in a bundle whose document records `analyzerId`. */
+function findAnalysisRecord(
+  bundleDir: string,
+  analyzerId: string,
+): Record<string, unknown> | undefined {
+  const walk = (dir: string): string[] =>
+    fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) return walk(full);
+      return entry.isFile() && entry.name.endsWith(".analysis.json")
+        ? [full]
+        : [];
+    });
+  for (const file of walk(bundleDir)) {
+    const doc = JSON.parse(fs.readFileSync(file, "utf8"));
+    const record = doc.results?.[analyzerId];
+    if (record !== undefined) return record;
+  }
+  return undefined;
+}
+
+describe("resolveGpuQueueExecutor", () => {
+  it("returns an executor only at gpu/full tier with a queue root", () => {
+    const root = tmpDir("evidence-orch-qroot-");
+    expect(
+      resolveGpuQueueExecutor("gpu", { gpuQueueRoot: root } as never),
+    ).toBeDefined();
+    expect(
+      resolveGpuQueueExecutor("full", { gpuQueueRoot: root } as never),
+    ).toBeDefined();
+    // No root → inline (undefined); cpu tier → inline even with a root.
+    expect(resolveGpuQueueExecutor("gpu", {} as never)).toBeUndefined();
+    expect(
+      resolveGpuQueueExecutor("cpu", { gpuQueueRoot: root } as never),
+    ).toBeUndefined();
+  });
+});
+
+describe("orchestrateCertify — gpu queue wiring (#14543 acceptance)", () => {
+  // A passing lane so the rollup has a signable verdict; the screenshot is what
+  // the gpu analyzer (routed through the queue) actually analyzes.
+  const passingMatrix: MatrixRunner = async () => ({
+    command: "fake-matrix",
+    lanes: [{ lane: "matrix", passed: 1, failed: 0, skipped: 0, log: "ok\n" }],
+  });
+
+  it("routes gpu analyzers through a resident queue worker at --tier gpu", async () => {
+    const stub = startVisionStub("# Login\nSign in to Eliza");
+    const stubUrl = await stub.started;
+    const prevUrl = process.env.ELIZA_GPU_VISION_URL;
+    process.env.ELIZA_GPU_VISION_URL = stubUrl;
+    const controller = new AbortController();
+    const queueRoot = tmpDir("evidence-orch-queue-");
+    try {
+      const repoRoot = tmpGitRepoWithScreenshot();
+      const worker = runQueueWorker({
+        queue: new FileJobQueue(queueRoot),
+        tier: "gpu",
+        signal: controller.signal,
+        limits: { pollMs: 20 },
+      });
+
+      const result = await orchestrateCertify({
+        tier: "gpu",
+        repoRoot,
+        outDir: tmpDir("evidence-orch-out-"),
+        signingKey: KEYPAIR.privateKeyPem,
+        reviewer: REVIEWER,
+        runMatrix: passingMatrix,
+        gpuQueueRoot: queueRoot,
+        gpuQueueTimeoutMs: 30_000,
+        env: {},
+        now: NOW,
+      });
+      controller.abort();
+      await worker;
+
+      // The gpu analyzer's result reached analysis.json via the queue worker —
+      // a real OCR transcript, not an inline run and not a fabrication.
+      const record = findAnalysisRecord(result.bundleDir, "ocr.unlimited");
+      expect(record?.status).toBe("ran");
+      expect((record?.data as { text: string }).text).toContain(
+        "Sign in to Eliza",
+      );
+      // The run advertises the queue path in its analyze step.
+      const analyzeStep = result.steps.find((s) => s.step === "analyze");
+      expect(analyzeStep?.detail).toMatch(/via queue worker/);
+    } finally {
+      process.env.ELIZA_GPU_VISION_URL = prevUrl;
+      controller.abort();
+      stub.server.close();
+    }
+  });
+
+  it("honestly skips gpu analyzers when no worker drains the queue", async () => {
+    const prevUrl = process.env.ELIZA_GPU_VISION_URL;
+    delete process.env.ELIZA_GPU_VISION_URL;
+    try {
+      const repoRoot = tmpGitRepoWithScreenshot();
+      const result = await orchestrateCertify({
+        tier: "gpu",
+        repoRoot,
+        outDir: tmpDir("evidence-orch-out-"),
+        signingKey: KEYPAIR.privateKeyPem,
+        reviewer: REVIEWER,
+        runMatrix: passingMatrix,
+        gpuQueueRoot: tmpDir("evidence-orch-queue-"),
+        gpuQueueTimeoutMs: 300, // no worker: fail fast to an honest skip
+        env: {},
+        now: NOW,
+      });
+
+      // No worker consumed the job: an honest skip naming the missing worker,
+      // never a fabricated transcript — and the run still produces a cert.
+      const record = findAnalysisRecord(result.bundleDir, "ocr.unlimited");
+      expect(record?.status).toBe("skipped-missing-tool");
+      expect(record?.reason).toMatch(/no gpu queue worker/);
+      expect("data" in (record ?? {})).toBe(false);
+      expect(fs.existsSync(result.certPath)).toBe(true);
+    } finally {
+      if (prevUrl !== undefined) process.env.ELIZA_GPU_VISION_URL = prevUrl;
+    }
   });
 });
 

--- a/packages/evidence/src/certify/orchestrate.ts
+++ b/packages/evidence/src/certify/orchestrate.ts
@@ -36,6 +36,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { z } from "zod";
+import type { AnalyzerExecutor } from "../analyzers/index.ts";
 import { analyzeArtifacts } from "../analyzers/runner.ts";
 import { createBundle, type EvidenceBundle, verifyBundle } from "../bundle.ts";
 import { EvidenceError, EvidenceValidationError } from "../errors.ts";
@@ -45,6 +46,8 @@ import {
   collectGitProvenance,
   resolveRunnerKind,
 } from "../provenance.ts";
+import { QueueExecutor } from "../queue/executor.ts";
+import { FileJobQueue } from "../queue/file-queue.ts";
 import { parseMeta, type Tier } from "../schema.ts";
 import {
   askBatch,
@@ -192,6 +195,16 @@ export interface CertifyOptions {
   expiresHours?: number;
   /** Where to write the certification; default `<bundle>/certification.json`. */
   certOut?: string;
+  /**
+   * Route gpu-tier analyzers through a resident GPU worker draining this queue
+   * root (`evidence:gpu-queue worker --root <dir>`) instead of running them
+   * inline, so one model load is shared across every screenshot. Only takes
+   * effect at tier `gpu`/`full`; when no worker produces a result the executor
+   * degrades to an honest `skipped-missing-tool` record, never a fabrication.
+   */
+  gpuQueueRoot?: string;
+  /** How long the queue executor waits for a worker result before an honest skip. */
+  gpuQueueTimeoutMs?: number;
   /** Test matrix runner; default spawns `packages/scripts/run-all-tests.mjs`. */
   runMatrix?: MatrixRunner;
   /** Env for vision-QA backend resolution + provenance; default `process.env`. */
@@ -455,6 +468,27 @@ export function mergeReviewerVerdicts(
   );
 }
 
+/**
+ * Build the {@link QueueExecutor} that offloads gpu-tier analyzers to a resident
+ * worker, or `undefined` to keep the inline path. Returns an executor only when
+ * a queue root is configured AND the run tier actually has gpu-tier work — a
+ * queue at cpu tier would just be dead weight, and inline (the default) already
+ * emits the correct `skipped-tier`/`skipped-missing-tool` records there.
+ */
+export function resolveGpuQueueExecutor(
+  tier: Tier,
+  options: CertifyOptions,
+): AnalyzerExecutor | undefined {
+  if (options.gpuQueueRoot === undefined) return undefined;
+  if (tier !== "gpu" && tier !== "full") return undefined;
+  const queue = new FileJobQueue(path.resolve(options.gpuQueueRoot));
+  return new QueueExecutor(queue, {
+    ...(options.gpuQueueTimeoutMs !== undefined
+      ? { resultTimeoutMs: options.gpuQueueTimeoutMs }
+      : {}),
+  });
+}
+
 function resolveReviewer(options: CertifyOptions): CertificationReviewer {
   const reviewer = options.reviewer ?? options.reviewerVerdicts?.reviewer;
   if (reviewer === undefined) {
@@ -570,16 +604,24 @@ export async function orchestrateCertify(
     );
 
     const analyzeInputs = bundle.artifacts;
+    const executor = resolveGpuQueueExecutor(tier, options);
     const analysis = await analyzeArtifacts(bundle.dir, analyzeInputs, {
       tier,
       bundle,
+      ...(executor !== undefined ? { executor } : {}),
     });
+    const analyzeVia =
+      executor !== undefined
+        ? ` (gpu tier via queue worker at ${options.gpuQueueRoot})`
+        : "";
     steps.push({
       step: "analyze",
       status: "ran",
-      detail: `${analysis.subjects.length} subject(s) analyzed at tier ${tier}`,
+      detail: `${analysis.subjects.length} subject(s) analyzed at tier ${tier}${analyzeVia}`,
     });
-    io.out(`  analyze: ${analysis.subjects.length} subject(s) at tier ${tier}`);
+    io.out(
+      `  analyze: ${analysis.subjects.length} subject(s) at tier ${tier}${analyzeVia}`,
+    );
 
     steps.push(await runVisionQaPass(bundle, env, io));
 

--- a/packages/evidence/src/cli.ts
+++ b/packages/evidence/src/cli.ts
@@ -36,12 +36,17 @@ const USAGE = `Usage:
                    [--bundle <existing-dir>] [--requirements <file>] [--base-ref <ref>]
                    [--expires-hours <n>] [--key-file <pem>] [--cert-out <path>]
                    [--out <dir>] [--repo-root <dir>]
+                   [--gpu-queue <queue-dir>] [--gpu-queue-timeout-ms <n>]
 
 create   Open a new evidence bundle, ingest every known silo, finalize.
 verify   Re-hash every artifact in an existing bundle and report integrity.
 certify  One command: matrix → ingest → analyze → vision-qa → rollup →
          reviewer merge → sign → self-verify. Writes a signed certification.json
-         and exits 0 only when it self-verifies (green), 1 when red.`;
+         and exits 0 only when it self-verifies (green), 1 when red.
+         At --tier gpu/full, --gpu-queue <dir> offloads gpu analyzers to a
+         resident worker draining that queue (evidence:gpu-queue worker --root
+         <dir>) instead of loading a model per screenshot; without a worker the
+         gpu analyzers honestly skip.`;
 
 /** Output sinks; injectable so tests capture instead of spawning. */
 export interface CliIo {
@@ -208,6 +213,8 @@ interface CertifyArgs {
   certOut?: string;
   outDir?: string;
   repoRoot?: string;
+  gpuQueueRoot?: string;
+  gpuQueueTimeoutMs?: number;
 }
 
 function parseCertifyArgs(argv: string[]): CertifyArgs {
@@ -227,6 +234,8 @@ function parseCertifyArgs(argv: string[]): CertifyArgs {
     "--cert-out",
     "--out",
     "--repo-root",
+    "--gpu-queue",
+    "--gpu-queue-timeout-ms",
   ]);
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -295,6 +304,17 @@ function parseCertifyArgs(argv: string[]): CertifyArgs {
       );
     }
   }
+  const gpuQueueTimeoutRaw = value.get("--gpu-queue-timeout-ms");
+  let gpuQueueTimeoutMs: number | undefined;
+  if (gpuQueueTimeoutRaw !== undefined) {
+    gpuQueueTimeoutMs = Number(gpuQueueTimeoutRaw);
+    if (!Number.isFinite(gpuQueueTimeoutMs) || gpuQueueTimeoutMs <= 0) {
+      throw new EvidenceError(
+        `--gpu-queue-timeout-ms must be a positive number, got: ${gpuQueueTimeoutRaw}`,
+        { code: "CLI_USAGE" },
+      );
+    }
+  }
   return {
     tier: tierRaw as Tier,
     ...(reviewerId !== undefined ? { reviewerId } : {}),
@@ -312,6 +332,8 @@ function parseCertifyArgs(argv: string[]): CertifyArgs {
     certOut: value.get("--cert-out"),
     outDir: value.get("--out"),
     repoRoot: value.get("--repo-root"),
+    gpuQueueRoot: value.get("--gpu-queue"),
+    gpuQueueTimeoutMs,
   };
 }
 
@@ -364,6 +386,12 @@ async function runCertify(argv: string[], io: CliIo): Promise<number> {
       : {}),
     ...(args.certOut !== undefined ? { certOut: args.certOut } : {}),
     ...(args.outDir !== undefined ? { outDir: args.outDir } : {}),
+    ...(args.gpuQueueRoot !== undefined
+      ? { gpuQueueRoot: args.gpuQueueRoot }
+      : {}),
+    ...(args.gpuQueueTimeoutMs !== undefined
+      ? { gpuQueueTimeoutMs: args.gpuQueueTimeoutMs }
+      : {}),
     io,
   });
 

--- a/packages/evidence/src/queue/analysis-merge.test.ts
+++ b/packages/evidence/src/queue/analysis-merge.test.ts
@@ -1,0 +1,145 @@
+// The per-subject merge into analysis.json, driven on a REAL filesystem. The
+// load path is unit-tested (create-when-absent, refuse-corrupt), and the
+// concurrency guarantee is proven the only way it can be — with genuinely
+// separate OS processes: N `bun` children merge N distinct analyzers into one
+// analysis.json at once, and every result must survive. Without the O_EXCL lock
+// this is a lost-update race (temp+rename is atomic per write but not per
+// read-modify-write across processes), so the child-race test is the regression
+// guard for that bug.
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, expect, it } from "vitest";
+import { mergeAnalyzerResult } from "./analysis-merge.ts";
+
+const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "evidence-merge-"));
+afterAll(() => fs.rmSync(scratch, { recursive: true, force: true }));
+
+let n = 0;
+function newDir(): string {
+  const dir = path.join(scratch, `s${n++}`);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+const MERGE_SOURCE = fileURLToPath(
+  new URL("./analysis-merge.ts", import.meta.url),
+);
+
+// A standalone worker that performs one merge, spawned as a separate OS process
+// so the cross-process lock is genuinely exercised (a single JS process cannot
+// interleave synchronous merges).
+const WORKER_PATH = path.join(scratch, "merge-worker.mjs");
+fs.writeFileSync(
+  WORKER_PATH,
+  `import { mergeAnalyzerResult } from ${JSON.stringify(MERGE_SOURCE)};
+const [analysisPath, analyzerId] = process.argv.slice(2);
+mergeAnalyzerResult({
+  analysisPath,
+  artifact: "visual/x/shot.png",
+  analyzerId,
+  result: { status: "ran", durationMs: 1, data: { text: analyzerId } },
+});
+`,
+);
+
+describe("mergeAnalyzerResult (single process)", () => {
+  it("creates a fresh schema-1 document when the target is absent", () => {
+    const analysisPath = path.join(newDir(), "shot.png.analysis.json");
+    const doc = mergeAnalyzerResult({
+      analysisPath,
+      artifact: "visual/x/shot.png",
+      analyzerId: "ocr.unlimited",
+      result: { status: "ran", durationMs: 3, data: { text: "hi" } },
+    });
+    expect(doc.schema).toBe(1);
+    expect(doc.artifact).toBe("visual/x/shot.png");
+    expect(doc.results["ocr.unlimited"].status).toBe("ran");
+    // Persisted to disk, not just returned.
+    const onDisk = JSON.parse(fs.readFileSync(analysisPath, "utf8"));
+    expect(onDisk.results["ocr.unlimited"].status).toBe("ran");
+    // The lockfile is released, never left behind.
+    expect(fs.existsSync(`${analysisPath}.lock`)).toBe(false);
+  });
+
+  it("adds a second analyzer without dropping the first", () => {
+    const analysisPath = path.join(newDir(), "shot.png.analysis.json");
+    mergeAnalyzerResult({
+      analysisPath,
+      artifact: "visual/x/shot.png",
+      analyzerId: "brand.rules",
+      result: { status: "ran", durationMs: 1, data: {} },
+    });
+    mergeAnalyzerResult({
+      analysisPath,
+      artifact: "visual/x/shot.png",
+      analyzerId: "ocr.unlimited",
+      result: { status: "ran", durationMs: 2, data: { text: "hi" } },
+    });
+    const doc = JSON.parse(fs.readFileSync(analysisPath, "utf8"));
+    expect(Object.keys(doc.results).sort()).toEqual([
+      "brand.rules",
+      "ocr.unlimited",
+    ]);
+  });
+
+  it("refuses to merge onto a corrupt existing document", () => {
+    const analysisPath = path.join(newDir(), "shot.png.analysis.json");
+    fs.writeFileSync(analysisPath, "{ not json");
+    expect(() =>
+      mergeAnalyzerResult({
+        analysisPath,
+        artifact: "visual/x/shot.png",
+        analyzerId: "ocr.unlimited",
+        result: { status: "ran", durationMs: 1, data: {} },
+      }),
+    ).toThrow(/not valid JSON/);
+  });
+});
+
+/** Run one merge in a separate OS process via bun so the race is real. */
+function spawnMerge(analysisPath: string, analyzerId: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("bun", [WORKER_PATH, analysisPath, analyzerId], {
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let err = "";
+    child.stderr.on("data", (c) => {
+      err += String(c);
+    });
+    child.on("error", reject);
+    child.on("close", (code) =>
+      code === 0
+        ? resolve(0)
+        : reject(
+            new Error(`merge child (${analyzerId}) exited ${code}: ${err}`),
+          ),
+    );
+  });
+}
+
+describe("mergeAnalyzerResult (concurrent cross-process writers)", () => {
+  it("preserves every analyzer when N processes merge one subject at once", async () => {
+    const analysisPath = path.join(newDir(), "shot.png.analysis.json");
+    // Ten simultaneous processes, each a distinct gpu/cpu analyzer landing on
+    // the same subject — the two-workers-one-screenshot case the queue permits.
+    const analyzers = Array.from({ length: 10 }, (_, i) => `analyzer.${i}`);
+
+    const codes = await Promise.all(
+      analyzers.map((id) => spawnMerge(analysisPath, id)),
+    );
+    expect(codes.every((c) => c === 0)).toBe(true);
+
+    const doc = JSON.parse(fs.readFileSync(analysisPath, "utf8"));
+    // Every writer survives — no lost update. (Unlocked, several would vanish.)
+    expect(Object.keys(doc.results).sort()).toEqual([...analyzers].sort());
+    for (const id of analyzers) {
+      expect(doc.results[id].status).toBe("ran");
+      expect(doc.results[id].data.text).toBe(id);
+    }
+    expect(fs.existsSync(`${analysisPath}.lock`)).toBe(false);
+  });
+});

--- a/packages/evidence/src/queue/analysis-merge.ts
+++ b/packages/evidence/src/queue/analysis-merge.ts
@@ -3,9 +3,12 @@
  * writes a whole document at once, but the GPU queue worker contributes ONE
  * `gpu`-tier analyzer's result per job, out of band, after the cpu-tier document
  * already exists — so it reads-modify-writes the `results` map keyed by analyzer
- * name. The write is atomic (temp file + rename) because a certification run may
- * read `analysis.json` while the worker is streaming results into it, and a
- * torn read of half-written JSON must never happen.
+ * name. Each write is atomic (temp file + rename) so a certification run reading
+ * `analysis.json` mid-stream never sees torn JSON, AND the whole read-modify-
+ * write is serialized by a per-subject O_EXCL lockfile: two workers merging two
+ * different gpu analyzers for the same subject would otherwise both read the old
+ * document and the later rename would silently drop the earlier analyzer's
+ * result (temp+rename guards readers, not lost updates across processes).
  *
  * A missing target document is created as a fresh schema-1 doc rather than
  * failing: the worker can legitimately land a gpu result before the cpu pass
@@ -66,9 +69,10 @@ function loadOrInit(analysisPath: string, artifact: string): AnalysisDocument {
 /**
  * Merge `result` under `analyzerId` into the analysis document at
  * `analysisPath`, creating the document (and its directory) when absent. Returns
- * the written document. The write is temp-file + atomic-rename within the same
- * directory so concurrent readers see either the old or the new document, never
- * a partial one.
+ * the written document. The read-modify-write runs under a per-subject lock and
+ * the write itself is temp-file + atomic-rename within the same directory, so
+ * concurrent readers see either the old or the new document (never a partial
+ * one) and concurrent writers never drop each other's analyzer result.
  */
 export function mergeAnalyzerResult(params: {
   analysisPath: string;
@@ -80,14 +84,126 @@ export function mergeAnalyzerResult(params: {
   const dir = path.dirname(analysisPath);
   fs.mkdirSync(dir, { recursive: true });
 
-  const document = loadOrInit(analysisPath, artifact);
-  document.results[analyzerId] = result;
+  return withAnalysisLock(analysisPath, () => {
+    const document = loadOrInit(analysisPath, artifact);
+    document.results[analyzerId] = result;
 
-  const tmp = path.join(
-    dir,
-    `.${path.basename(analysisPath)}.${process.pid}.${Date.now()}.tmp`,
-  );
-  fs.writeFileSync(tmp, `${JSON.stringify(document, null, 2)}\n`);
-  fs.renameSync(tmp, analysisPath);
-  return document;
+    const tmp = path.join(
+      dir,
+      `.${path.basename(analysisPath)}.${process.pid}.${Date.now()}.tmp`,
+    );
+    fs.writeFileSync(tmp, `${JSON.stringify(document, null, 2)}\n`);
+    fs.renameSync(tmp, analysisPath);
+    return document;
+  });
+}
+
+// A merge holds the lock only for one small synchronous read-write, so the
+// contention window is tiny; the retry budget is generous enough to serialize a
+// burst of workers on one subject, and the staleness break-in keeps a holder
+// that crashed mid-merge from wedging the subject forever. STALE < ACQUIRE so a
+// dead holder is reclaimed before a live waiter exhausts its budget.
+const LOCK_RETRY_MS = 20;
+const LOCK_ACQUIRE_TIMEOUT_MS = 30_000;
+const LOCK_STALE_MS = 10_000;
+
+/**
+ * Run `fn` while holding an exclusive lock on `<analysisPath>.lock`. Release
+ * happens on both the success and error paths (not in a `finally`, so a release
+ * fault can never mask fn()'s own error).
+ */
+function withAnalysisLock<T>(analysisPath: string, fn: () => T): T {
+  const lockPath = `${analysisPath}.lock`;
+  const fd = acquireLock(lockPath);
+  let result: T;
+  try {
+    result = fn();
+  } catch (error) {
+    releaseLock(fd, lockPath);
+    throw error;
+  }
+  releaseLock(fd, lockPath);
+  return result;
+}
+
+/**
+ * Close and remove the lockfile. A failed unlink is best-effort teardown: a
+ * leaked lockfile is self-healing — the next writer's staleness break-in
+ * reclaims it — so it never throws (which would mask a merge error) and never
+ * escalates.
+ */
+function releaseLock(fd: number, lockPath: string): void {
+  fs.closeSync(fd);
+  try {
+    fs.unlinkSync(lockPath);
+  } catch (error) {
+    // error-policy:J6 best-effort teardown — ENOENT means a staleness break-in
+    // already reclaimed it; any other fault leaves a lockfile the next writer's
+    // break-in clears, so swallowing here cannot wedge the subject.
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+  }
+}
+
+/** Spin on an O_EXCL create until the lock is ours; the create IS the mutex. */
+function acquireLock(lockPath: string): number {
+  const deadline = Date.now() + LOCK_ACQUIRE_TIMEOUT_MS;
+  for (;;) {
+    let fd: number;
+    try {
+      // 'wx' = O_CREAT | O_EXCL | O_WRONLY: exactly one racing process creates
+      // the file; every other open fails with EEXIST and retries.
+      fd = fs.openSync(lockPath, "wx");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+        // error-policy:J2 context-adding rethrow — a non-contention fault
+        // (perms, ENOSPC) is a real failure the worker must surface.
+        throw new EvidenceError(`cannot acquire analysis lock ${lockPath}`, {
+          code: "ANALYSIS_LOCK_FAILED",
+          cause: error,
+          context: { lockPath },
+        });
+      }
+      if (breakStaleLock(lockPath)) continue; // crashed holder reclaimed
+      if (Date.now() >= deadline) {
+        throw new EvidenceError(
+          `timed out after ${LOCK_ACQUIRE_TIMEOUT_MS}ms waiting for analysis lock ${lockPath}`,
+          { code: "ANALYSIS_LOCK_TIMEOUT", context: { lockPath } },
+        );
+      }
+      sleepSync(LOCK_RETRY_MS);
+      continue;
+    }
+    fs.writeSync(fd, `${process.pid} ${new Date().toISOString()}\n`);
+    return fd;
+  }
+}
+
+/**
+ * Remove a lockfile whose holder is gone (mtime older than the stale window).
+ * Returns true when the caller should retry the create immediately — either a
+ * stale lock was broken or the lock vanished on its own between open and stat.
+ */
+function breakStaleLock(lockPath: string): boolean {
+  let mtimeMs: number;
+  try {
+    mtimeMs = fs.statSync(lockPath).mtimeMs;
+  } catch (error) {
+    // Released between the failed open and the stat: a normal retry wins now.
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return true;
+    throw error;
+  }
+  if (Date.now() - mtimeMs <= LOCK_STALE_MS) return false;
+  try {
+    fs.unlinkSync(lockPath);
+  } catch (error) {
+    // error-policy:J6 best-effort break-in — another waiter unlinked it first;
+    // ENOENT is success, anything else is a real fault to surface.
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  return true;
+}
+
+/** Block this thread for `ms` in a synchronous context without a busy spin. */
+function sleepSync(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }

--- a/packages/evidence/src/queue/parity.test.ts
+++ b/packages/evidence/src/queue/parity.test.ts
@@ -1,0 +1,101 @@
+// Drift guard for the two filesystem GPU job queues that intentionally coexist
+// (see state.ts's header for the layering rationale): this package's TS analyzer
+// queue and the compose-level plain-node OpenAI-request queue at
+// docker/certification/queue-lib.mjs (#14549). Their job SHAPES differ by design
+// (analyzerId+analysisPath vs model+request), but the pure filesystem-queue
+// kernel they share — the four dir names, the backpressure cap + drain window,
+// FIFO claim order, id generation, and the unreachable→drain→reset state machine
+// — MUST stay byte-identical, or the two queues silently diverge (the review's
+// permanent-drain-latch bug was exactly such a divergence). This test imports
+// BOTH real modules and asserts the shared kernel agrees; a physically shared
+// runtime module is deliberately avoided (a workspace-TS import is fragile in
+// the ro-mounted plain-node container, and a docker-owned import is wrong for a
+// published package), so this contract test is the mechanical anti-drift check.
+
+import { describe, expect, it } from "vitest";
+// The container queue lives outside this package; a test-only relative import is
+// safe (tests run in the full checkout) where a runtime import would not be.
+import * as docker from "../../../../docker/certification/queue-lib.mjs";
+import {
+  claimOrder,
+  createWorkerState,
+  DEFAULT_LIMITS,
+  decideEnqueue,
+  makeJobId,
+  onServiceOk,
+  onServiceUnreachable,
+  QUEUE_DIRS,
+  shouldDrain,
+} from "./state.ts";
+
+describe("queue kernel parity with docker/certification/queue-lib.mjs", () => {
+  it("agrees on the four queue directory names and their order", () => {
+    expect([...QUEUE_DIRS]).toEqual([...docker.QUEUE_DIRS]);
+  });
+
+  it("agrees on the shared backpressure + drain limits", () => {
+    // Only the shared kernel keys are contracted; the per-job wall-clock ceiling
+    // is intentionally per-queue (jobTimeoutMs=180s analyzer vs
+    // requestTimeoutMs=300s http proxy) and is NOT part of the shared contract.
+    expect(DEFAULT_LIMITS.maxPending).toBe(docker.DEFAULT_LIMITS.maxPending);
+    expect(DEFAULT_LIMITS.drainAfterMs).toBe(
+      docker.DEFAULT_LIMITS.drainAfterMs,
+    );
+    expect(DEFAULT_LIMITS.pollMs).toBe(docker.DEFAULT_LIMITS.pollMs);
+  });
+
+  it("agrees on FIFO claim order over timestamp-prefixed ids", () => {
+    const names = [
+      `${makeJobId(3_000, "c")}.json`,
+      `${makeJobId(1_000, "a")}.json`,
+      `${makeJobId(2_000, "b")}.json`,
+      "README",
+    ];
+    expect(claimOrder(names)).toEqual(docker.claimOrder(names));
+  });
+
+  it("agrees on enqueue backpressure decisions", () => {
+    for (const [pending, max] of [
+      [0, 256],
+      [255, 256],
+      [256, 256],
+      [300, 256],
+    ] as const) {
+      expect(decideEnqueue(pending, max)).toEqual(
+        docker.decideEnqueue(pending, max),
+      );
+    }
+  });
+
+  it("agrees on id generation for the same clock + entropy", () => {
+    expect(makeJobId(1_700_000_000_000, "abc123")).toBe(
+      docker.makeJobId(1_700_000_000_000, "abc123"),
+    );
+  });
+
+  it("agrees on the connectivity state machine, transition for transition", () => {
+    expect(createWorkerState()).toEqual(docker.createWorkerState());
+
+    // Drive both machines through the same outage timeline and compare every
+    // intermediate state, plus the drain predicate (named differently per side).
+    const timeline = [1_000, 5_000, 121_000, 200_000];
+    let ours = createWorkerState();
+    let theirs = docker.createWorkerState();
+    for (const nowMs of timeline) {
+      ours = onServiceUnreachable(ours, nowMs, DEFAULT_LIMITS.drainAfterMs);
+      theirs = docker.onServiceUnreachable(
+        theirs,
+        nowMs,
+        docker.DEFAULT_LIMITS.drainAfterMs,
+      );
+      expect(ours).toEqual(theirs);
+      expect(shouldDrain(ours)).toBe(docker.shouldSkipJob(theirs));
+    }
+
+    // A successful contact fully resets both back to the healthy state.
+    expect(onServiceOk()).toEqual(docker.onServiceOk());
+    expect(shouldDrain(onServiceOk())).toBe(
+      docker.shouldSkipJob(docker.onServiceOk()),
+    );
+  });
+});

--- a/packages/evidence/src/queue/state.ts
+++ b/packages/evidence/src/queue/state.ts
@@ -17,6 +17,19 @@
  *                         `skipped` record is an honest drain marker carrying the
  *                         reason the GPU never analyzed the image, NEVER fabricated
  *                         analyzer data (repo doctrine: "not loaded" ≠ "empty").
+ *
+ * Layering: a second filesystem GPU queue exists at
+ * `docker/certification/queue-lib.mjs` (#14549). It runs in the compose GPU
+ * profile as PLAIN NODE against a read-only repo mount and carries a different
+ * job shape (an OpenAI `model`+`request` proxied to the resident llama-server,
+ * not an `analyzerId` merged into `analysis.json`), so the two are NOT merged
+ * into one runtime module: a workspace-TS import is fragile in that container
+ * (it may run before the package installs/builds), and a docker-owned import
+ * would be wrong for this published package. What they DO share — the four dir
+ * names, the backpressure cap + drain window, FIFO claim order, id generation,
+ * and the unreachable→drain→reset state machine below — is held identical by a
+ * mechanical drift guard (`parity.test.ts`), so the copies can never silently
+ * diverge the way the recovery latch once did (#15006 review).
  */
 
 import type { AnalyzerResult } from "../analyzers/types.ts";

--- a/packages/evidence/src/queue/worker.test.ts
+++ b/packages/evidence/src/queue/worker.test.ts
@@ -16,7 +16,8 @@ import { UnlimitedOcrEngine } from "../analyzers/ocr/engines.ts";
 import { makeOcrAnalyzer } from "../analyzers/ocr/ocr.ts";
 import type { Analyzer } from "../analyzers/types.ts";
 import { FileJobQueue } from "./file-queue.ts";
-import { runQueueWorker } from "./worker.ts";
+import { DEFAULT_LIMITS, type WorkerState } from "./state.ts";
+import { processJob, runQueueWorker } from "./worker.ts";
 
 const scratch = fs.mkdtempSync(path.join(os.tmpdir(), "evidence-worker-"));
 afterAll(() => fs.rmSync(scratch, { recursive: true, force: true }));
@@ -193,6 +194,106 @@ describe("queue worker with the service down (honest degradation)", () => {
     // The job is back in pending, unconsumed — no analysis.json fabricated.
     expect(queue.pendingCount()).toBe(1);
     expect(fs.existsSync(analysisPath)).toBe(false);
+  });
+});
+
+describe("queue worker recovers from a latched drain (liveness)", () => {
+  it("processJob analyzes the job and clears the drain latch once the service is reachable again", async () => {
+    const stub = startStub(() => "# Login\nSign in to Eliza");
+    const baseUrl = await stub.started;
+    try {
+      const root = newRoot();
+      const queue = new FileJobQueue(root);
+      const img = writePng(path.join(root, "shot.png"));
+      const analysisPath = path.join(root, "shot.png.analysis.json");
+      enqueueOne(queue, img, analysisPath);
+      const claimed = queue.claim();
+      if (!claimed) throw new Error("expected to claim the enqueued job");
+
+      // The worker is already latched into drain mode from a prior sustained
+      // outage. With the service back up, processJob must re-probe (via the
+      // analyzer's availability check), analyze for real, and reset the latch —
+      // NOT skip blindly the way a permanent latch would.
+      const draining: WorkerState = { unreachableSince: 1_000, draining: true };
+      const outcome = await processJob(
+        claimed,
+        {
+          queue,
+          analyzers: [unlimitedAt(baseUrl)],
+          tier: "gpu",
+          limits: DEFAULT_LIMITS,
+          now: () => 2_000,
+        },
+        draining,
+      );
+
+      expect(outcome.action).toBe("completed");
+      expect(outcome.state.draining).toBe(false);
+      expect(outcome.state.unreachableSince).toBeNull();
+      const doc = JSON.parse(fs.readFileSync(analysisPath, "utf8"));
+      expect(doc.results["ocr.unlimited"].status).toBe("ran");
+    } finally {
+      stub.server.close();
+    }
+  });
+
+  it("after an outage latches drain, the next job is PROCESSED once the service recovers", async () => {
+    // /health is down on the FIRST probe (latches drain at drainAfterMs=0) then
+    // recovers — the redeploy-outage a resident worker must survive. Before the
+    // fix the latch was permanent and every subsequent job skipped forever.
+    let healthProbes = 0;
+    const server = createServer((req, res) => {
+      if (req.url === "/health") {
+        healthProbes += 1;
+        if (healthProbes === 1) {
+          res.writeHead(503).end("service redeploying");
+          return;
+        }
+        res.writeHead(200).end("ok");
+        return;
+      }
+      if (req.url === "/v1/chat/completions" && req.method === "POST") {
+        req.resume();
+        req.on("end", () =>
+          res
+            .writeHead(200, { "content-type": "application/json" })
+            .end(
+              JSON.stringify({ choices: [{ message: { content: "# Home" } }] }),
+            ),
+        );
+        return;
+      }
+      res.writeHead(404).end();
+    });
+    const baseUrl = await new Promise<string>((resolve) =>
+      server.listen(0, "127.0.0.1", () =>
+        resolve(`http://127.0.0.1:${(server.address() as AddressInfo).port}`),
+      ),
+    );
+    try {
+      const root = newRoot();
+      const queue = new FileJobQueue(root);
+      const a = writePng(path.join(root, "a.png"));
+      const b = writePng(path.join(root, "b.png"));
+      enqueueOne(queue, a, path.join(root, "a.png.analysis.json"));
+      enqueueOne(queue, b, path.join(root, "b.png.analysis.json"));
+
+      const counts = await runQueueWorker({
+        queue,
+        analyzers: [unlimitedAt(baseUrl)],
+        tier: "gpu",
+        stopWhenIdle: true,
+        limits: { drainAfterMs: 0 },
+      });
+
+      // One job drained while the service was down; the other was analyzed for
+      // real after recovery. The permanent-latch bug would have skipped both.
+      expect(counts.skipped).toBe(1);
+      expect(counts.completed).toBe(1);
+      expect(healthProbes).toBeGreaterThanOrEqual(2);
+    } finally {
+      server.close();
+    }
   });
 });
 

--- a/packages/evidence/src/queue/worker.ts
+++ b/packages/evidence/src/queue/worker.ts
@@ -12,8 +12,11 @@
  * connectivity failure requeues the job (transient blips retry); once the outage
  * outlasts `drainAfterMs` the worker latches into drain mode and writes
  * `skipped` records — an image the GPU never analyzed is marked as such, and is
- * NEVER given a fabricated empty transcript. This module is library code: it
- * never touches `console`; observability is a caller-supplied `onEvent` hook.
+ * NEVER given a fabricated empty transcript. Drain mode is not terminal: every
+ * job still runs the analyzer, whose cheap availability probe re-contacts the
+ * service, so a GPU host that recovers after the latch set is detected and the
+ * latch clears. This module is library code: it never touches `console`;
+ * observability is a caller-supplied `onEvent` hook.
  */
 
 import {
@@ -33,7 +36,6 @@ import type { ClaimedJob, FileJobQueue } from "./file-queue.ts";
 import {
   createWorkerState,
   DEFAULT_LIMITS,
-  drainSkipResult,
   isConnectivityFailure,
   type JobResult,
   onServiceOk,
@@ -91,6 +93,15 @@ export interface ProcessOutcome {
  * result into `analysis.json` and finalizes the job for every terminal action;
  * on a transient connectivity failure (before the drain threshold) it requeues
  * the job instead, so a brief service blip retries rather than losing the image.
+ *
+ * A drained job is NOT short-circuited to a blind skip. Running the analyzer
+ * costs only its cheap availability probe (a `/health` GET that fails fast when
+ * the host is down) when the service is still unreachable, and that probe is
+ * exactly the recovery check: if the GPU service came back after an outage
+ * latched drain mode, this contact succeeds, the latch clears, and the job is
+ * analyzed for real. Without it a single sustained outage would wedge the
+ * resident worker into skipping every future job forever — a broken pipeline
+ * masked as honest state (#15006 review; matches `queue-worker.mjs`'s re-probe).
  */
 export async function processJob(
   claimed: ClaimedJob,
@@ -99,14 +110,6 @@ export async function processJob(
 ): Promise<ProcessOutcome> {
   const { queue, analyzers, tier, limits, now } = deps;
   const { job } = claimed;
-
-  // Already draining: skip without touching the (known-dead) service.
-  if (shouldDrain(state)) {
-    const result = drainSkipResult(
-      `gpu vision service unreachable; queue draining (job ${job.id} skipped)`,
-    );
-    return finalize(claimed, deps, state, "skipped", result);
-  }
 
   const analyzer = resolveAnalyzer(job.analyzerId, analyzers);
   if (!analyzer) {
@@ -149,7 +152,9 @@ export async function processJob(
   if (isConnectivityFailure(result)) {
     const nextState = onServiceUnreachable(state, now(), limits.drainAfterMs);
     if (shouldDrain(nextState)) {
-      // Outage outlasted the window: consume the job as an honest skip.
+      // Outage outlasted the window (or the latch is already set): consume the
+      // job as an honest skip carrying the probe's real reason. A later job
+      // re-probes here, so recovery still resets the latch above.
       return finalize(claimed, deps, nextState, "skipped", result);
     }
     // Transient: put the job back for a later retry once the service returns.
@@ -161,6 +166,9 @@ export async function processJob(
     };
   }
 
+  // A real contact (ran/failed): the service is reachable, so clear any drain
+  // latch — this is how a recovered service exits drain mode — and record the
+  // real analyzer result.
   const action: WorkerAction =
     result.status === "failed" ? "failed" : "completed";
   return finalize(claimed, deps, onServiceOk(), action, result);


### PR DESCRIPTION
Post-merge follow-up to **#15006** (squash-merged as `372a87d1`). Fixes the four defects from the adversarial review — https://github.com/elizaOS/eliza/pull/15006#issuecomment-4890489268 — that landed with the merge.

## Defects fixed

### 1. BLOCKER — permanent drain latch (liveness)
`processJob` short-circuited a drained job to a blind skip and only ever called `onServiceOk()` *after* running an analyzer, so one sustained outage latched `draining=true` forever and every future job skipped even after the GPU service recovered — a broken pipeline masked as honest state.

Fix: drain mode no longer short-circuits. The worker runs the analyzer whose cheap availability probe (a fast-failing `/health` GET) re-contacts the service; a service that recovered after the latch set is detected, the latch clears, and the job is analyzed for real. This mirrors the recovery re-probe in the already-merged `docker/certification/queue-worker.mjs` (#14549).

Tests (`worker.test.ts`): a `processJob` unit test (draining state + reachable service → `completed`, latch cleared) and an end-to-end `runQueueWorker` test where `/health` is down on the first probe (latches drain) then recovers → the next job is **processed**, not skipped forever.

### 2. BLOCKER/dedup — parallel queue drift
`state.ts` and `docker/certification/queue-lib.mjs` (#14549) share a filesystem-queue kernel but had already drifted (defect 1 was the first drift).

**Architecture decision: keep both, guard with a parity/contract test — do NOT force a shared runtime module.** The two queues are genuinely different: different job *shapes* (this queue's `analyzerId`+`analysisPath` merged into `analysis.json` vs the container queue's OpenAI `model`+`request` proxied to the resident llama-server) and different runtime *layers* (this TS package vs plain Node running in the compose GPU profile against a **read-only** repo mount, before the workspace is guaranteed installed/built). A physically-shared runtime module is fragile in both directions — a workspace-TS import can't resolve in that container, and a docker-owned import is wrong for a published package.

Instead, `parity.test.ts` imports **both** real modules and asserts the shared kernel agrees — the four dir names, the backpressure cap + drain window, FIFO claim order, id generation, and the `unreachable→drain→reset` state machine, transition for transition — so they can never silently diverge again. `state.ts`'s header documents the layering. A new `docker/certification/queue-lib.d.mts` types the cross-layer import (no `any`).

### 3. BLOCKER/acceptance — `QueueExecutor` unwired
Nothing set `AnalyzeOptions.executor`, so `evidence:certify --tier gpu` still ran gpu analyzers inline — the #14543 acceptance ("via a resident worker") was unmet.

Fix: `evidence:certify --tier gpu|full --gpu-queue <dir>` now routes gpu-tier analyzers through a `QueueExecutor` (enqueue → resident worker → poll result), sharing one model load; cpu analyzers still run inline, and with no worker the gpu analyzers **honestly skip** (`skipped-missing-tool` naming the missing worker), never a fabrication. Built on the merged orchestrator (#15004).

Tests (`orchestrate.test.ts`): a real fresh-bundle certify at `--tier gpu` with a screenshot ingested and a concurrent stub worker → the OCR result lands via the queue; the no-worker path → honest skip, and the run still produces a signed cert. Plus a `resolveGpuQueueExecutor` unit test (executor only at gpu/full with a root).

### 4. SHOULD-FIX — lost-update race in `analysis-merge.ts`
Cross-process read-modify-write of `analysis.json`: temp+rename is atomic per write but not per update, so two workers merging two analyzers for one subject dropped a result.

Fix: the whole read-modify-write runs under a per-subject `O_EXCL` lockfile (bounded retry + staleness break-in so a crashed holder self-heals). Test (`analysis-merge.test.ts`): **10 real OS processes** merge 10 distinct analyzers into one `analysis.json` at once — all 10 survive. (Confirmed the unlocked version loses ~half.)

## Evidence

Full `packages/evidence` suite green on the `develop` base:

```
Test Files  45 passed | 1 skipped (46)
     Tests  420 passed | 1 skipped (421)
```

- `bun run --cwd packages/evidence typecheck` — clean
- `bun run --cwd packages/evidence lint` — clean
- `bun run audit:error-policy-ratchet` — `no new fallback-slop in touched files`
- `docker/certification` queue test (`bun test`) — 12 pass (unaffected by the new `.d.mts`)

All new throw sites use `EvidenceError`; every kept catch carries a `// error-policy:J<N>` annotation; no `console` in library code; drain/no-worker paths degrade to honest skips, never fabricated results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Evidence Rows

<!-- evidence-row:before-screenshots --> N/A - evidence queue/orchestrator infrastructure only; no rendered UI surface or screenshot input changed.
<!-- evidence-row:after-screenshots --> N/A - evidence queue/orchestrator infrastructure only; no rendered UI surface or screenshot input changed.
<!-- evidence-row:walkthrough-video --> N/A - no interactive UI flow changed; queue recovery, worker routing, parity, and merge locking are covered by deterministic process tests.
<!-- evidence-row:backend-logs --> N/A - no deployed backend/service log path changed; verification is deterministic package command output in the Evidence section (evidence suite, docker queue tests, lint/typecheck, ratchet).
<!-- evidence-row:frontend-logs --> N/A - no browser/frontend runtime path changed.
<!-- evidence-row:llm-trajectory --> N/A - no prompt/model/planner behavior changed; this wires deterministic evidence analyzers/queue execution and filesystem merge semantics.
<!-- evidence-row:domain-artifacts --> N/A - no persistent product/domain artifact is produced by this infrastructure change; tests assert the queue result files, cert bundle outputs, and analysis.json merge artifacts directly.

