### PR TITLE
fix(app): first-class 402 credit-gate state + iOS shared-cloud trust for the phone cloud-agent path

### DIFF
--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -195,6 +195,7 @@ import {
   removeUrlParameter,
 } from "./runtime-chooser-override";
 import { registerViewServiceWorker } from "./sw-registration";
+import { isElizaCloudSharedHost } from "./url-trust-policy";
 
 declare const __ELIZA_BUILD_VARIANT__: string | undefined;
 // Set by vite.config.ts `define`. `true` for the web/desktop bundle, `false`
@@ -2890,6 +2891,7 @@ function isTrustedApiBaseUrl(parsed: URL): boolean {
     return (
       isCurrentOriginHost(host) ||
       isConfiguredCloudApiHost(host) ||
+      isElizaCloudSharedHost(host) ||
       isElizaCloudAgentSubdomain(host)
     );
   }
@@ -2915,6 +2917,7 @@ function isTrustedDeepLinkApiBaseUrl(parsed: URL): boolean {
     return (
       isCurrentOriginHost(host) ||
       (parsed.protocol === "https:" && isConfiguredCloudApiHost(host)) ||
+      (parsed.protocol === "https:" && isElizaCloudSharedHost(host)) ||
       (parsed.protocol === "https:" && isElizaCloudAgentSubdomain(host))
     );
   }

--- a/packages/app/src/url-trust-policy.ts
+++ b/packages/app/src/url-trust-policy.ts
@@ -65,6 +65,27 @@ export function isLoopbackApiHost(host: string): boolean {
   );
 }
 
+/**
+ * Canonical Eliza Cloud shared-tier control-plane hosts. The free shared agent
+ * is served in-Worker off the apex `elizacloud.ai` / its `www.` and `api.`
+ * siblings (the shared REST adapter lives at
+ * `<host>/api/v1/eliza/agents/<id>`), NOT a per-agent `*.elizacloud.ai`
+ * subdomain — so the dedicated-subdomain trust does not cover it. A store iOS
+ * build must trust these HTTPS hosts regardless of whether `cloudApiBase` was
+ * pinned to the exact host, or shared-tier bootstrap (the instant, always-on,
+ * $0 path — the mobile default) is rejected under the strict network policy.
+ * Prod hosts only; staging/dev are reached via a configured `cloudApiBase`.
+ */
+const ELIZA_CLOUD_SHARED_HOSTS: ReadonlySet<string> = new Set([
+  "elizacloud.ai",
+  "www.elizacloud.ai",
+  "api.elizacloud.ai",
+]);
+
+export function isElizaCloudSharedHost(host: string): boolean {
+  return ELIZA_CLOUD_SHARED_HOSTS.has(host.toLowerCase());
+}
+
 function isIosLocalAgentIpcUrl(parsed: URL): boolean {
   return isMobileLocalAgentIpcUrl(parsed);
 }
@@ -125,7 +146,11 @@ export function createUrlTrustPolicy(ctx: UrlTrustPolicyContext) {
       if (parsed.protocol !== "https:" || isPrivateOrLoopbackApiHost(host)) {
         return false;
       }
-      return isCurrentOriginHost(host) || isConfiguredCloudApiHost(host);
+      return (
+        isCurrentOriginHost(host) ||
+        isConfiguredCloudApiHost(host) ||
+        isElizaCloudSharedHost(host)
+      );
     }
     if (ctx.isPopoutWindow && parsed.protocol === "https:") return true;
     return (
@@ -148,7 +173,8 @@ export function createUrlTrustPolicy(ctx: UrlTrustPolicyContext) {
       }
       return (
         isCurrentOriginHost(host) ||
-        (parsed.protocol === "https:" && isConfiguredCloudApiHost(host))
+        (parsed.protocol === "https:" && isConfiguredCloudApiHost(host)) ||
+        (parsed.protocol === "https:" && isElizaCloudSharedHost(host))
       );
     }
     return (

--- a/packages/app/test/url-trust-policy.test.ts
+++ b/packages/app/test/url-trust-policy.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+/**
+ * Host-trust policy coverage focused on the strict iOS (store / cloud-runtime)
+ * network policy — specifically that the canonical Eliza Cloud shared-tier hosts
+ * are trusted even when `cloudApiBase` is NOT pinned to them, so the free
+ * shared-agent bootstrap (`<host>/api/v1/eliza/agents/<id>`) is not rejected on a
+ * store build. Under jsdom `window.location.hostname` is "localhost", so any
+ * elizacloud.ai trust here comes purely from the shared-host predicate, not the
+ * current-origin allowance.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  createUrlTrustPolicy,
+  isElizaCloudSharedHost,
+} from "../src/url-trust-policy";
+
+function strictStorePolicy(cloudApiBase?: string) {
+  return createUrlTrustPolicy({
+    isNative: true,
+    isIOS: true,
+    isStoreBuild: true,
+    cloudApiBase,
+    isPopoutWindow: false,
+    getIosRuntimeMode: () => "cloud",
+  });
+}
+
+describe("isElizaCloudSharedHost", () => {
+  it("matches the canonical shared-tier control-plane hosts (case-insensitive)", () => {
+    expect(isElizaCloudSharedHost("elizacloud.ai")).toBe(true);
+    expect(isElizaCloudSharedHost("www.elizacloud.ai")).toBe(true);
+    expect(isElizaCloudSharedHost("API.elizacloud.ai")).toBe(true);
+  });
+
+  it("does not match per-agent subdomains, staging, or arbitrary hosts", () => {
+    expect(isElizaCloudSharedHost("agent-123.elizacloud.ai")).toBe(false);
+    expect(isElizaCloudSharedHost("staging.elizacloud.ai")).toBe(false);
+    expect(isElizaCloudSharedHost("evil.com")).toBe(false);
+    expect(isElizaCloudSharedHost("elizacloud.ai.evil.com")).toBe(false);
+  });
+});
+
+describe("strict iOS policy — shared-tier bootstrap", () => {
+  it("trusts the shared apex + api hosts even when cloudApiBase is not pinned", () => {
+    const policy = strictStorePolicy(undefined);
+    expect(
+      policy.isTrustedApiBaseUrl(
+        new URL("https://elizacloud.ai/api/v1/eliza/agents/agent-1"),
+      ),
+    ).toBe(true);
+    expect(
+      policy.isTrustedApiBaseUrl(
+        new URL("https://api.elizacloud.ai/api/v1/eliza/agents/agent-1"),
+      ),
+    ).toBe(true);
+  });
+
+  it("still rejects http:// and private/loopback hosts under the strict policy", () => {
+    const policy = strictStorePolicy(undefined);
+    expect(
+      policy.isTrustedApiBaseUrl(new URL("http://elizacloud.ai/api")),
+    ).toBe(false);
+    expect(policy.isTrustedApiBaseUrl(new URL("https://127.0.0.1/api"))).toBe(
+      false,
+    );
+    expect(policy.isTrustedApiBaseUrl(new URL("https://192.168.1.5/api"))).toBe(
+      false,
+    );
+  });
+
+  it("still rejects an arbitrary public https host (no blanket cloud trust)", () => {
+    const policy = strictStorePolicy(undefined);
+    expect(policy.isTrustedApiBaseUrl(new URL("https://evil.com/api"))).toBe(
+      false,
+    );
+  });
+
+  it("also trusts the shared hosts on the deep-link gateway path", () => {
+    const policy = strictStorePolicy(undefined);
+    expect(
+      policy.isTrustedDeepLinkApiBaseUrl(new URL("https://elizacloud.ai/api")),
+    ).toBe(true);
+    expect(
+      policy.isTrustedDeepLinkApiBaseUrl(new URL("https://evil.com/api")),
+    ).toBe(false);
+  });
+});

--- a/packages/ui/src/cloud/billing-console.test.ts
+++ b/packages/ui/src/cloud/billing-console.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+/**
+ * The add-credits URL builder + opener. `openExternalUrl` is stubbed (no
+ * platform browser under jsdom); the boot config is driven through the real
+ * store so the default-vs-configured cloud base resolution is exercised for real.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { openExternalUrlMock } = vi.hoisted(() => ({
+  openExternalUrlMock: vi.fn(async () => {}),
+}));
+
+vi.mock("../utils/openExternalUrl", () => ({
+  openExternalUrl: openExternalUrlMock,
+}));
+
+import { setBootConfig } from "../config/boot-config";
+import {
+  cloudBillingConsoleUrl,
+  openCloudBillingConsole,
+} from "./billing-console";
+
+afterEach(() => {
+  openExternalUrlMock.mockClear();
+});
+
+describe("cloudBillingConsoleUrl", () => {
+  it("builds the console URL from an explicit cloud base", () => {
+    expect(cloudBillingConsoleUrl("https://elizacloud.ai")).toBe(
+      "https://elizacloud.ai/dashboard/billing",
+    );
+  });
+
+  it("trims a trailing slash so the path never doubles up", () => {
+    expect(cloudBillingConsoleUrl("https://api.elizacloud.ai/")).toBe(
+      "https://api.elizacloud.ai/dashboard/billing",
+    );
+  });
+
+  it("falls back to the configured cloud base from boot config", () => {
+    setBootConfig({
+      branding: {},
+      cloudApiBase: "https://staging.elizacloud.ai",
+    });
+    expect(cloudBillingConsoleUrl()).toBe(
+      "https://staging.elizacloud.ai/dashboard/billing",
+    );
+  });
+
+  it("defaults to elizacloud.ai when no base is configured", () => {
+    setBootConfig({ branding: {}, cloudApiBase: undefined });
+    expect(cloudBillingConsoleUrl()).toBe(
+      "https://elizacloud.ai/dashboard/billing",
+    );
+  });
+});
+
+describe("openCloudBillingConsole", () => {
+  it("opens the resolved console URL via the platform opener", async () => {
+    await openCloudBillingConsole("https://elizacloud.ai");
+    expect(openExternalUrlMock).toHaveBeenCalledWith(
+      "https://elizacloud.ai/dashboard/billing",
+    );
+  });
+});

--- a/packages/ui/src/cloud/billing-console.ts
+++ b/packages/ui/src/cloud/billing-console.ts
@@ -1,0 +1,30 @@
+/**
+ * Resolves and opens the Eliza Cloud billing console — the add-funds / credits
+ * page the app links to when a dedicated-agent upgrade is refused for lack of
+ * credits (HTTP 402). On mobile the cloud dashboard is not mounted in the thin
+ * client, so this opens the hosted `<cloudApiBase>/dashboard/billing` page in the
+ * platform browser (Capacitor in-app browser / desktop bridge / new tab) via the
+ * shared `openExternalUrl`. Kept tiny and side-effect-light so both the in-chat
+ * boot-recovery conductor and the home provisioning widget reuse one add-credits
+ * path instead of hand-building the URL twice.
+ */
+
+import { getBootConfig } from "../config/boot-config";
+import { openExternalUrl } from "../utils/openExternalUrl";
+
+const DEFAULT_CLOUD_API_BASE = "https://elizacloud.ai";
+
+/** The canonical hosted add-funds / credits console URL. */
+export function cloudBillingConsoleUrl(cloudApiBase?: string): string {
+  const base = (
+    cloudApiBase ??
+    getBootConfig().cloudApiBase ??
+    DEFAULT_CLOUD_API_BASE
+  ).replace(/\/+$/, "");
+  return `${base}/dashboard/billing`;
+}
+
+/** Open the billing console on the current platform. */
+export function openCloudBillingConsole(cloudApiBase?: string): Promise<void> {
+  return openExternalUrl(cloudBillingConsoleUrl(cloudApiBase));
+}

--- a/packages/ui/src/cloud/handoff/run-cloud-agent-handoff.test.ts
+++ b/packages/ui/src/cloud/handoff/run-cloud-agent-handoff.test.ts
@@ -15,7 +15,10 @@ import {
   dispatchCloudHandoffRetry,
 } from "../../events";
 import type { ConversationHandoffResult } from "./conversation-handoff";
-import { runCloudAgentHandoff } from "./run-cloud-agent-handoff";
+import {
+  isInsufficientCreditsError,
+  runCloudAgentHandoff,
+} from "./run-cloud-agent-handoff";
 
 function collectPhases(): {
   phases: CloudHandoffPhaseDetail[];
@@ -53,6 +56,69 @@ describe("runCloudAgentHandoff", () => {
     expect(start).toHaveBeenCalledTimes(1);
     expect(phases.map((p) => p.phase)).toEqual(["migrating", "switched"]);
     expect(phases[1]).toMatchObject({ agentId: "a1", imported: 3 });
+  });
+
+  it("maps a thrown 402 to the distinct insufficient-credits phase (not a generic failed)", async () => {
+    const { phases, stop } = collectPhases();
+    // The dedicated-agent create is refused by the credit gate; the direct-cloud
+    // client tags the rejection with status 402 (see api/client-cloud.ts).
+    const start = vi.fn(async (): Promise<ConversationHandoffResult> => {
+      throw Object.assign(new Error("insufficient credits"), { status: 402 });
+    });
+
+    runCloudAgentHandoff("a402", start);
+    await flush();
+    stop();
+
+    expect(phases.map((p) => p.phase)).toEqual([
+      "migrating",
+      "insufficient-credits",
+    ]);
+    expect(phases[1]?.error).toBe("insufficient credits");
+  });
+
+  it("still arms a retry on insufficient-credits so add-credits → retry upgrades", async () => {
+    const { phases, stop } = collectPhases();
+    const start = vi
+      .fn<() => Promise<ConversationHandoffResult>>()
+      .mockRejectedValueOnce(
+        Object.assign(new Error("insufficient credits"), { status: 402 }),
+      )
+      .mockResolvedValueOnce({ status: "switched", imported: 2 });
+
+    runCloudAgentHandoff("a402b", start);
+    await flush();
+    expect(start).toHaveBeenCalledTimes(1);
+
+    // The user adds credits, then retries: the second create succeeds and the
+    // handoff completes onto the dedicated agent.
+    dispatchCloudHandoffRetry({ agentId: "a402b" });
+    await flush();
+    stop();
+
+    expect(start).toHaveBeenCalledTimes(2);
+    expect(phases.map((p) => p.phase)).toEqual([
+      "migrating",
+      "insufficient-credits",
+      "migrating",
+      "switched",
+    ]);
+  });
+
+  it("isInsufficientCreditsError detects only a 402-tagged error", () => {
+    expect(
+      isInsufficientCreditsError(
+        Object.assign(new Error("nope"), { status: 402 }),
+      ),
+    ).toBe(true);
+    expect(
+      isInsufficientCreditsError(
+        Object.assign(new Error("server"), { status: 500 }),
+      ),
+    ).toBe(false);
+    expect(isInsufficientCreditsError(new Error("plain"))).toBe(false);
+    expect(isInsufficientCreditsError(null)).toBe(false);
+    expect(isInsufficientCreditsError("402")).toBe(false);
   });
 
   it("maps a thrown supervisor to a failed phase carrying the message", async () => {

--- a/packages/ui/src/cloud/handoff/run-cloud-agent-handoff.ts
+++ b/packages/ui/src/cloud/handoff/run-cloud-agent-handoff.ts
@@ -21,6 +21,13 @@ import type { ConversationHandoffResult } from "./conversation-handoff";
  * visible with a retry instead of being swallowed (the old
  * `startCloudAgentHandoff(...).catch(() => {})`).
  *
+ * A thrown 402 from the dedicated-agent create is the credit gate, not a boot
+ * failure: it maps to the distinct `insufficient-credits` phase so the surfaces
+ * show a first-class "add credits for a dedicated agent" state instead of a
+ * generic "setup failed / retry" one. The retry is still armed (so add-credits
+ * → retry upgrades cleanly), but retrying without credits just re-gates — the
+ * user keeps the working shared agent throughout.
+ *
  * `start` is a thunk so the caller owns the supervisor args (agent id, bases,
  * token, `onSwitch` rebind) and this module stays decoupled + unit-testable.
  *
@@ -63,11 +70,29 @@ export function runCloudAgentHandoff(
     .catch((err: unknown) => {
       dispatchCloudHandoffPhase({
         agentId,
-        phase: "failed",
+        phase: isInsufficientCreditsError(err)
+          ? "insufficient-credits"
+          : "failed",
         error: err instanceof Error ? err.message : String(err),
       });
       armRetry(agentId, start, onSwitchSucceeded);
     });
+}
+
+/**
+ * True when a thrown handoff error is the cloud credit gate (HTTP 402), so the
+ * runner can surface the distinct `insufficient-credits` phase instead of a
+ * generic `failed`. The direct-cloud client tags rejected requests with the
+ * numeric `status` (see `directCloudRequest` in `api/client-cloud.ts`); a 402 on
+ * the dedicated-agent create is the only place the create is refused for
+ * billing rather than infrastructure reasons.
+ */
+export function isInsufficientCreditsError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { status?: unknown }).status === 402
+  );
 }
 
 /**

--- a/packages/ui/src/components/chat/widgets/agent-provisioning.test.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-provisioning.test.tsx
@@ -15,6 +15,7 @@ const {
   loadPersistedActiveServerMock,
   useCloudHandoffPhaseMock,
   navOpenTab,
+  openCloudBillingConsoleMock,
 } = vi.hoisted(() => ({
   getCloudCompatAgentMock: vi.fn(),
   isDirectCloudSharedAgentBaseMock: vi.fn(() => true),
@@ -23,6 +24,7 @@ const {
     () => null,
   ),
   navOpenTab: vi.fn(),
+  openCloudBillingConsoleMock: vi.fn(async () => {}),
 }));
 
 vi.mock("../../../api", () => ({
@@ -36,6 +38,9 @@ vi.mock("../../../state/persistence", () => ({
 }));
 vi.mock("../../../hooks/useCloudHandoffPhase", () => ({
   useCloudHandoffPhase: useCloudHandoffPhaseMock,
+}));
+vi.mock("../../../cloud/billing-console", () => ({
+  openCloudBillingConsole: openCloudBillingConsoleMock,
 }));
 // useWidgetNavigation → reportUserViewSwitch; stub it so the click test isolates
 // the navigation call.
@@ -96,6 +101,8 @@ describe("AgentProvisioningWidget", () => {
     loadPersistedActiveServerMock.mockReturnValue(SHARED_SERVER);
     useCloudHandoffPhaseMock.mockReturnValue(null);
     navOpenTab.mockReset();
+    openCloudBillingConsoleMock.mockReset();
+    openCloudBillingConsoleMock.mockResolvedValue(undefined);
   });
   afterEach(cleanup);
 
@@ -127,6 +134,17 @@ describe("AgentProvisioningWidget", () => {
     const detail = (onRetry.mock.calls[0][0] as CustomEvent).detail;
     expect(detail).toEqual({ agentId: "agent-123" });
     window.removeEventListener(CLOUD_HANDOFF_RETRY_EVENT, onRetry);
+  });
+
+  it("renders an Add credits tile on the 402 credit gate and opens billing on tap", () => {
+    useCloudHandoffPhaseMock.mockReturnValue(phase("insufficient-credits"));
+    render(<AgentProvisioningWidget />);
+    expect(screen.getByTestId("value").textContent).toBe(
+      "On free shared agent",
+    );
+    expect(screen.getByTestId("badge").textContent).toBe("Add credits");
+    fireEvent.click(screen.getByTestId("chat-widget-agent-provisioning"));
+    expect(openCloudBillingConsoleMock).toHaveBeenCalledTimes(1);
   });
 
   it("self-hides once the dedicated agent is attached (switched phase)", () => {

--- a/packages/ui/src/components/chat/widgets/agent-provisioning.tsx
+++ b/packages/ui/src/components/chat/widgets/agent-provisioning.tsx
@@ -18,6 +18,7 @@ import { CloudCog } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { client } from "../../../api";
 import { isDirectCloudSharedAgentBase } from "../../../api/client-cloud";
+import { openCloudBillingConsole } from "../../../cloud/billing-console";
 import {
   type CloudHandoffPhaseDetail,
   dispatchCloudHandoffRetry,
@@ -133,6 +134,28 @@ export function AgentProvisioningWidget(
   // No live handoff phase AND the active server is no longer on the shared base
   // means the dedicated agent already attached before this widget mounted.
   if (detail == null && mountedTarget == null) return null;
+
+  // Credit gate (402): keep the user on the free shared agent but surface a
+  // first-class "add credits for a dedicated agent" tile — not a silent
+  // permanent shared fallback (nubs's 0-credit guidance).
+  if (phase === "insufficient-credits") {
+    return (
+      <div className={spanClassName}>
+        <HomeWidgetCard
+          icon={<CloudCog />}
+          label="Cloud agent"
+          value="On free shared agent"
+          tone="warn"
+          badge="Add credits"
+          testId="chat-widget-agent-provisioning"
+          ariaLabel="You're on the free shared agent. Add credits to get your own dedicated agent."
+          onActivate={() => {
+            void openCloudBillingConsole();
+          }}
+        />
+      </div>
+    );
+  }
 
   const isFailure = phase === "timed-out" || phase === "failed";
 

--- a/packages/ui/src/events/index.ts
+++ b/packages/ui/src/events/index.ts
@@ -102,15 +102,20 @@ export const CLOUD_HANDOFF_PHASE_EVENT = "eliza:cloud-handoff-phase" as const;
  * adapter. `switched` — conversation copied and the live client moved to the
  * dedicated container (`switched-empty` when there was nothing to copy yet).
  * `timed-out` / `failed` — the container never became ready (or an I/O step
- * threw); the user safely stays on the working shared adapter. Mirrors
- * `ConversationHandoffStatus` plus the `migrating` in-flight phase.
+ * threw); the user safely stays on the working shared adapter.
+ * `insufficient-credits` — the dedicated upgrade was refused by the credit gate
+ * (HTTP 402): the user keeps the free shared agent, but this is a FIRST-CLASS
+ * state (a distinct "add credits for your own dedicated agent" surface), never a
+ * silent permanent shared fallback. Mirrors `ConversationHandoffStatus` plus the
+ * `migrating` in-flight phase and the `insufficient-credits` monetization gate.
  */
 export type CloudHandoffPhase =
   | "migrating"
   | "switched"
   | "switched-empty"
   | "timed-out"
-  | "failed";
+  | "failed"
+  | "insufficient-credits";
 
 export interface CloudHandoffPhaseDetail {
   agentId: string;

--- a/packages/ui/src/first-run/first-run-finish.ts
+++ b/packages/ui/src/first-run/first-run-finish.ts
@@ -504,30 +504,34 @@ export async function bindCloudAgent(
         ...(bio.length ? { agentConfig: { bio } } : {}),
         forceCreate: true,
       });
-      if (dedicated.success && dedicated.data.agentId) {
-        return dedicated.data.agentId;
+      if (!dedicated.success || !dedicated.data.agentId) {
+        throw new Error(
+          dedicated.success
+            ? "Dedicated agent creation returned no agent id."
+            : (dedicated.data.message ?? "Dedicated agent creation failed."),
+        );
       }
-      throw new Error(
-        dedicated.success
-          ? "Dedicated agent creation returned no agent id."
-          : (dedicated.data.message ?? "Dedicated agent creation failed."),
-      );
+      const dedicatedAgentId = dedicated.data.agentId;
+      // Reload insurance, persisted the INSTANT the dedicated target id is known
+      // — before the 30-120s container boot in startCloudAgentHandoff, with no
+      // await between learning the id and persisting it. The supervisor is
+      // in-memory, so a kill mid-boot resumes THIS exact handoff at startup
+      // (resumePendingCloudHandoff) instead of stranding the user on the shared
+      // adapter off the auto-upgrade path; silentlyRepointToDedicated clears the
+      // marker once the swap lands.
+      savePendingCloudHandoff({
+        sharedAgentId,
+        dedicatedAgentId,
+        sharedApiBase: cloudAgentApiBase,
+        cloudApiBase,
+        startedAt: Date.now(),
+      });
+      return dedicatedAgentId;
     };
     runCloudAgentHandoff(
       sharedAgentId,
       async () => {
         const dedicatedAgentId = await createDedicatedHandoffTarget();
-        // Reload insurance: the supervisor is in-memory, so persist the exact
-        // migration target. A reload mid-boot resumes THIS handoff at startup
-        // (resumePendingCloudHandoff) instead of stranding the user on the
-        // shared adapter; silentlyRepointToDedicated clears the marker.
-        savePendingCloudHandoff({
-          sharedAgentId,
-          dedicatedAgentId,
-          sharedApiBase: cloudAgentApiBase,
-          cloudApiBase,
-          startedAt: Date.now(),
-        });
         return await client.startCloudAgentHandoff({
           agentId: sharedAgentId,
           sharedApiBase: cloudAgentApiBase,

--- a/packages/ui/src/first-run/use-boot-recovery-conductor.test.ts
+++ b/packages/ui/src/first-run/use-boot-recovery-conductor.test.ts
@@ -33,6 +33,7 @@ const mocks = vi.hoisted(() => ({
   },
   hasUsableStoredStewardToken: vi.fn(() => true),
   dispatchCloudHandoffRetry: vi.fn(),
+  openCloudBillingConsole: vi.fn(async () => {}),
 }));
 
 vi.mock("../state", async (importOriginal) => {
@@ -61,6 +62,10 @@ vi.mock("../events", async (importOriginal) => {
       mocks.dispatchCloudHandoffRetry(detail),
   };
 });
+
+vi.mock("../cloud/billing-console", () => ({
+  openCloudBillingConsole: () => mocks.openCloudBillingConsole(),
+}));
 
 import type { ConversationMessage } from "../api";
 import type { CloudHandoffPhaseDetail } from "../events";
@@ -228,6 +233,57 @@ describe("useBootRecoveryConductor", () => {
       handoff: { phase: "failed", agentId: "agent-2" },
     });
     expect(card()?.text).toContain("dedicated agent");
+    unmount();
+  });
+
+  it("surfaces the 402 credit gate as a first-class add-credits card, not a generic failure", () => {
+    const { card, unmount } = renderConductor({
+      booting: false,
+      noProviderConfigured: false,
+      handoff: { phase: "insufficient-credits", agentId: "agent-402" },
+    });
+    const text = card()?.text ?? "";
+    // Nubs's 0-credit guidance: explicit "on free shared agent + add credits",
+    // not a silent connect failure and not the generic setup-failed copy.
+    expect(text).toContain("free shared agent");
+    expect(text).toContain("Add credits");
+    expect(text).toContain("__boot_recovery__:add-credits=");
+    expect(text).toContain("__boot_recovery__:retry-handoff=");
+    expect(text).not.toContain("couldn't finish setting up");
+    unmount();
+  });
+
+  it("add-credits opens the billing console without healing the trouble (user stays on shared)", () => {
+    const { card, unmount } = renderConductor({
+      booting: false,
+      noProviderConfigured: false,
+      handoff: { phase: "insufficient-credits", agentId: "agent-402" },
+    });
+    act(() => {
+      expect(tryHandleBootRecoveryAction("__boot_recovery__:add-credits")).toBe(
+        true,
+      );
+    });
+    expect(mocks.openCloudBillingConsole).toHaveBeenCalledTimes(1);
+    // The card stays put (with its controls) so the user can retry after funding.
+    expect(card()?.text).toContain("__boot_recovery__:add-credits=");
+    unmount();
+  });
+
+  it("retry-handoff also re-dispatches the upgrade for the insufficient-credits trouble", () => {
+    const { unmount } = renderConductor({
+      booting: false,
+      noProviderConfigured: false,
+      handoff: { phase: "insufficient-credits", agentId: "agent-402b" },
+    });
+    act(() => {
+      expect(
+        tryHandleBootRecoveryAction("__boot_recovery__:retry-handoff"),
+      ).toBe(true);
+    });
+    expect(mocks.dispatchCloudHandoffRetry).toHaveBeenCalledWith({
+      agentId: "agent-402b",
+    });
     unmount();
   });
 

--- a/packages/ui/src/first-run/use-boot-recovery-conductor.ts
+++ b/packages/ui/src/first-run/use-boot-recovery-conductor.ts
@@ -22,6 +22,7 @@
 
 import * as React from "react";
 import type { ConversationMessage } from "../api";
+import { openCloudBillingConsole } from "../cloud/billing-console";
 import { useShellControllerContext } from "../components/shell/ShellControllerContext.hooks";
 import {
   type CloudHandoffPhaseDetail,
@@ -50,6 +51,7 @@ const RELOGIN_CHOICE = `${BOOT_RECOVERY_ACTION_PREFIX}relogin=Re-log in`;
 const RETRY_CHOICE = `${BOOT_RECOVERY_ACTION_PREFIX}retry=Try again`;
 const RETRY_HANDOFF_CHOICE = `${BOOT_RECOVERY_ACTION_PREFIX}retry-handoff=Retry setup`;
 const RECONNECT_CHOICE = `${BOOT_RECOVERY_ACTION_PREFIX}reconnect=Reconnect`;
+const ADD_CREDITS_CHOICE = `${BOOT_RECOVERY_ACTION_PREFIX}add-credits=Add credits`;
 
 interface RecoveryCard {
   text: string;
@@ -76,6 +78,7 @@ function cardToTurn(card: RecoveryCard): ConversationMessage {
 /** The trouble the conductor is currently voicing, in precedence order. */
 type Trouble =
   | { kind: "connection" }
+  | { kind: "insufficient-credits"; agentId: string }
   | { kind: "handoff"; agentId: string }
   | { kind: "signed-out" }
   | { kind: "unresponsive" }
@@ -87,6 +90,14 @@ function liveCard(trouble: NonNullable<Trouble>): RecoveryCard {
       return {
         text: "I've lost my connection to the backend — I can't hear you until it's back.",
         choices: [RECONNECT_CHOICE],
+      };
+    case "insufficient-credits":
+      // Nubs's 0-credit guidance: the user keeps chatting on the free shared
+      // agent (never a silent connect failure), and gets an explicit prompt to
+      // add credits for their own dedicated agent — with a retry once they do.
+      return {
+        text: "You're on the free shared agent for now. Add credits to spin up your own dedicated agent — I'll switch you over automatically once it's ready.",
+        choices: [ADD_CREDITS_CHOICE, RETRY_HANDOFF_CHOICE],
       };
     case "handoff":
       return {
@@ -167,6 +178,11 @@ export function useBootRecoveryConductor(
   const handoffFailed =
     handoff != null &&
     (handoff.phase === "timed-out" || handoff.phase === "failed");
+  // The dedicated upgrade was refused for lack of credits (402). Distinct from a
+  // boot failure: the fix is add-credits, not retry-as-is, so it gets its own
+  // trouble kind + card copy.
+  const handoffInsufficientCredits =
+    handoff != null && handoff.phase === "insufficient-credits";
   // A dead backend connection outranks everything (nothing else can work),
   // and skips the card when another surface owns the disconnected state.
   const connectionFailed =
@@ -181,13 +197,15 @@ export function useBootRecoveryConductor(
     ? null
     : connectionFailed
       ? { kind: "connection" }
-      : handoffFailed
-        ? { kind: "handoff", agentId: handoff.agentId }
-        : stalled && !noProviderConfigured
-          ? hasUsableStoredStewardToken()
-            ? { kind: "unresponsive" }
-            : { kind: "signed-out" }
-          : null;
+      : handoffInsufficientCredits
+        ? { kind: "insufficient-credits", agentId: handoff.agentId }
+        : handoffFailed
+          ? { kind: "handoff", agentId: handoff.agentId }
+          : stalled && !noProviderConfigured
+            ? hasUsableStoredStewardToken()
+              ? { kind: "unresponsive" }
+              : { kind: "signed-out" }
+            : null;
 
   // An action pins its in-flight copy over the live card; when the action
   // settles without healing the boot, `cardVersion` bumps so the live card
@@ -318,9 +336,21 @@ export function useBootRecoveryConductor(
         return true;
       }
 
+      if (id === "add-credits") {
+        // Open the hosted billing console (add funds). Deliberately does NOT pin
+        // an in-flight card or heal the trouble: the user stays on the working
+        // shared agent with the add-credits prompt in view, and hits "Retry
+        // setup" once funded — the dedicated upgrade then proceeds.
+        void openCloudBillingConsole();
+        return true;
+      }
+
       if (id === "retry-handoff") {
         const current = troubleRef.current;
-        if (current?.kind === "handoff") {
+        if (
+          current?.kind === "handoff" ||
+          current?.kind === "insufficient-credits"
+        ) {
           pinOverride({
             text: "Retrying your dedicated agent setup…",
             choices: [],

--- a/packages/ui/src/hooks/useCloudHandoffPhase.test.tsx
+++ b/packages/ui/src/hooks/useCloudHandoffPhase.test.tsx
@@ -62,6 +62,17 @@ describe("useCloudHandoffPhase", () => {
     act(() => vi.advanceTimersByTime(60_000));
     expect(result.current?.phase).toBe("timed-out");
   });
+
+  it("keeps the insufficient-credits prompt visible until the user acts (never a silent shared fallback)", () => {
+    const { result } = renderHook(() => useCloudHandoffPhase());
+    emit({ agentId: "a1", phase: "insufficient-credits" });
+    expect(result.current?.phase).toBe("insufficient-credits");
+
+    // The credit-gate prompt must NOT self-dismiss — it stays so the user sees
+    // the add-credits path instead of being silently kept on shared.
+    act(() => vi.advanceTimersByTime(60_000));
+    expect(result.current?.phase).toBe("insufficient-credits");
+  });
 });
 
 // The floating CloudHandoffBanner was removed: failure/timeout phases now

--- a/packages/ui/src/hooks/useCloudHandoffPhase.ts
+++ b/packages/ui/src/hooks/useCloudHandoffPhase.ts
@@ -11,9 +11,9 @@ import {
 
 // How long a successful terminal phase lingers before the banner self-clears.
 // `migrating` has no timer — it persists until the swap resolves (the container
-// boot can take 60-90s). `timed-out`/`failed` also have NO timer: they stay
-// until the user retries (or a retry resolves), so the failure isn't a silent
-// auto-dismissed fallback.
+// boot can take 60-90s). `timed-out`/`failed`/`insufficient-credits` also have
+// NO timer: they stay until the user retries (or adds credits + retries), so a
+// failure or the credit-gate prompt is never a silent auto-dismissed fallback.
 const SUCCESS_LINGER_MS = 4000;
 
 /**
@@ -39,13 +39,14 @@ export function useCloudHandoffPhase(): CloudHandoffPhaseDetail | null {
 
   useEffect(() => {
     if (!detail) return;
-    // `migrating` persists until the swap resolves; `timed-out`/`failed` persist
-    // until the user retries (the banner offers a retry). Only the success
-    // phases self-dismiss.
+    // `migrating` persists until the swap resolves; `timed-out`/`failed`/
+    // `insufficient-credits` persist until the user retries or adds credits (the
+    // surface offers that path). Only the success phases self-dismiss.
     if (
       detail.phase === "migrating" ||
       detail.phase === "timed-out" ||
-      detail.phase === "failed"
+      detail.phase === "failed" ||
+      detail.phase === "insufficient-credits"
     ) {
       return;
     }


### PR DESCRIPTION
## What & why

P1 fixes for the **drive-a-cloud-agent-from-the-phone** path (the mobile app's #1 priority). The phone→Eliza-Cloud path is already wired end-to-end (provision → connect → chat → silent shared→dedicated upgrade); this PR closes the three operational gaps that made it fail for the most common new user (zero credits) and on a store iOS build, plus a handoff-ordering hardening.

## Verified current state vs. the audit

Before changing anything I traced the live code. One audited "gap" was **already fixed** in `develop`:

- **`preferSharedCloudTier` defaults ON** — `DEFAULT_BOOT_CONFIG.preferSharedCloudTier: true` (`packages/ui/src/config/boot-config-store.ts`) with a passing invariant test. The mobile first cloud chat already starts on the instant, container-free **shared** agent (no cold-boot wait, works at $0), and `silentlyRepointToDedicated` upgrades in the background. **No change needed** — the audit over-stated this one.

I also confirmed the exact 402 behavior: shared-tier creates never hit the credit gate (only eager *dedicated* provisioning does, server-side `checkAgentCreditGate`). So the 402 fires in the **background dedicated upgrade**, where it was being swallowed into a generic "setup failed / retry" loop — not surfaced as an add-credits prompt. That is the real gap this PR fixes.

## The fixes

### 1. 402 credit gate → first-class in-chat "add credits" state (nubs's 0-credit guidance)
A zero-credit user keeps the working **free shared agent** (never a silent connect failure, never a silent permanent fallback). When the background dedicated upgrade is refused (HTTP 402), a **distinct** `insufficient-credits` handoff phase now drives:
- an **in-chat card** (boot-recovery conductor): *"You're on the free shared agent for now. Add credits to spin up your own dedicated agent — I'll switch you over automatically once it's ready."* with **Add credits** + **Retry setup** controls.
- a home-grid **provisioning tile**: *On free shared agent* / **Add credits** badge.
- **Add credits** opens the hosted billing console (`<cloudApiBase>/dashboard/billing`) cross-platform; **Retry setup** re-runs the upgrade once funded.

Files: `events/index.ts` (new phase), `cloud/handoff/run-cloud-agent-handoff.ts` (`isInsufficientCreditsError` → distinct phase, retry still armed), `hooks/useCloudHandoffPhase.ts` (persists, never auto-dismisses), `first-run/use-boot-recovery-conductor.ts`, `components/chat/widgets/agent-provisioning.tsx`, new `cloud/billing-console.ts`.

### 2. iOS store trust for the shared cloud host
Under the strict iOS network policy (store build / cloud runtime mode) only the current origin, the *exact pinned* `cloudApiBase`, and per-agent `*.elizacloud.ai` subdomains were trusted — so the **shared** adapter host (`elizacloud.ai` / `api.elizacloud.ai`, not a subdomain) was rejected unless `cloudApiBase` happened to be pinned to it. Added `isElizaCloudSharedHost` (trusts the canonical prod shared hosts over HTTPS) and wired it into both `url-trust-policy.ts` (`createUrlTrustPolicy`, used by the deep-link handler) and `main.tsx`'s api-base + deep-link guards. Robust regardless of whether the store lane pins the host. Still rejects http/private/arbitrary hosts.

Files: `packages/app/src/url-trust-policy.ts`, `packages/app/src/main.tsx`.

### 3. Shared→dedicated handoff resume-marker ordering
The pending-handoff resume marker is now persisted **the instant the dedicated agent id is known** (inside the create helper), with no `await` between learning the id and persisting it and before the 30–120s container boot in `startCloudAgentHandoff`. A kill mid-provision can't strand the user off the auto-upgrade path.

File: `packages/ui/src/first-run/first-run-finish.ts`.

## Tests
Real unit tests for each decision:
- `run-cloud-agent-handoff.test.ts` — 402 → `insufficient-credits` (not `failed`); retry still arms so add-credits→retry upgrades; `isInsufficientCreditsError` matrix.
- `useCloudHandoffPhase.test.tsx` — the credits prompt persists (no silent auto-dismiss).
- `use-boot-recovery-conductor.test.ts` — first-class add-credits card copy + controls; **Add credits** opens billing without healing the trouble; **Retry setup** re-dispatches for the credits trouble.
- `agent-provisioning.test.tsx` — Add-credits tile + billing open on tap.
- `billing-console.test.ts` — URL builder (explicit/configured/default, trailing-slash).
- `url-trust-policy.test.ts` (new) — strict policy trusts the shared apex/api hosts even unpinned; rejects http/private/arbitrary; deep-link path too.

## Verification (honest scope)
- **Unit tests:** UI touched suites 49/49 pass; app trust suite 6/6 pass; conductor 17/17.
- **Typecheck:** touched files clean (the fresh-worktree cross-package errors are unbuilt-workspace-dep noise, not from this change).
- **Biome:** clean (0 errors, 0 warnings) on all touched files.
- **Out of scope / needs device:** I cannot boot a phone/simulator, so device E2E (real provision→402→add-credits→upgrade loop, store-build network policy on-device, the shared→dedicated swap timing) is **not** verified here — only via typecheck + unit tests + code-trace. A follow-up device run should confirm the on-device UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
