### PR TITLE
fix(lifeops): keep scheduled task replies plain

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/scheduled-task.ts
+++ b/plugins/plugin-personal-assistant/src/actions/scheduled-task.ts
@@ -291,6 +291,43 @@ const TRIGGER_KINDS =
 const HABIT_REDIRECT_HINT =
   "If the owner asked to start a habit/routine or a recurring personal reminder in chat, do not retry here — call OWNER_ROUTINES (or OWNER_REMINDERS) with action=create instead; that flow builds the habit definition and reminder plan without a raw trigger.";
 
+const PLAIN_TIMING_MISSING_TEXT =
+  "I could not save that yet because I need a clear time or recurrence. Please tell me when it should happen.";
+const PLAIN_DESTINATION_MISSING_TEXT =
+  "I could not save that yet because the delivery destination is not available.";
+
+function scheduledItemNoun(kind: ScheduledTaskKindParam | undefined): string {
+  switch (kind) {
+    case "reminder":
+      return "reminder";
+    case "checkin":
+      return "check-in";
+    case "followup":
+      return "follow-up";
+    case "approval":
+      return "approval";
+    case "recap":
+      return "recap";
+    default:
+      return "scheduled item";
+  }
+}
+
+function verbPastTense(label: string): string {
+  switch (label) {
+    case "skip":
+      return "skipped";
+    case "complete":
+      return "completed";
+    case "dismiss":
+      return "dismissed";
+    case "reopen":
+      return "reopened";
+    default:
+      return label;
+  }
+}
+
 type TriggerNormalization =
   | { ok: true; trigger: ScheduledTaskTrigger }
   | { ok: false; message: string };
@@ -680,7 +717,7 @@ async function handleList(
   const windowNote = dueWindow ? ` (${dueWindow})` : "";
   return {
     success: true,
-    text: `${filtered.length} scheduled task${filtered.length === 1 ? "" : "s"} match${windowNote}.`,
+    text: `${filtered.length} scheduled item${filtered.length === 1 ? "" : "s"} match${windowNote}.`,
     data: {
       subaction: "list",
       tasks: filtered,
@@ -697,7 +734,7 @@ async function handleGet(
   if (!taskId) {
     return {
       success: false,
-      text: "I need a taskId to fetch a scheduled task.",
+      text: "I need to know which scheduled item you mean.",
       data: { subaction: "get", error: "MISSING_TASK_ID" },
     };
   }
@@ -706,13 +743,13 @@ async function handleGet(
   if (!task) {
     return {
       success: false,
-      text: `No scheduled task found with id ${taskId}.`,
+      text: "I could not find that scheduled item.",
       data: { subaction: "get", error: "NOT_FOUND" },
     };
   }
   return {
     success: true,
-    text: `Found scheduled task ${task.taskId} (${task.kind}, ${task.state.status}).`,
+    text: "Found that scheduled item.",
     data: { subaction: "get", task },
   };
 }
@@ -728,31 +765,38 @@ async function handleCreate(
   if (promptInstructions.length === 0) {
     return {
       success: false,
-      text: "I need promptInstructions describing what the scheduled task should do.",
+      text: "I need the reminder text before I can save it.",
       data: { subaction: "create", error: "MISSING_PROMPT_INSTRUCTIONS" },
     };
   }
   if (params.trigger === undefined || params.trigger === null) {
     return {
       success: false,
-      text: `I need a trigger (${TRIGGER_KINDS}) to schedule a task. ${HABIT_REDIRECT_HINT}`,
-      data: { subaction: "create", error: "MISSING_TRIGGER" },
+      text: PLAIN_TIMING_MISSING_TEXT,
+      data: {
+        subaction: "create",
+        error: "MISSING_TRIGGER",
+        message: `Missing trigger (${TRIGGER_KINDS}).`,
+        repair: HABIT_REDIRECT_HINT,
+      },
     };
   }
   const normalized = normalizeTriggerInput(params.trigger);
   if (!normalized.ok) {
     return {
       success: false,
-      text: `${normalized.message} ${HABIT_REDIRECT_HINT}`,
+      text: PLAIN_TIMING_MISSING_TEXT,
       data: {
         subaction: "create",
         error: "INVALID_TRIGGER",
         message: normalized.message,
+        repair: HABIT_REDIRECT_HINT,
       },
     };
   }
   const trigger = normalized.trigger;
   const kind = normalizeKind(params.kind) ?? "custom";
+  const noun = scheduledItemNoun(kind);
   const priority: ScheduledTaskPriorityParam = params.priority ?? "medium";
   const subject = buildSubject(
     normalizeSubjectKind(params.subjectKind),
@@ -788,7 +832,7 @@ async function handleCreate(
   if (duplicate) {
     return {
       success: true,
-      text: `An identical ${kind} task already exists (${duplicate.taskId}) — not creating a duplicate.`,
+      text: `That ${noun} is already scheduled.`,
       data: { subaction: "create", task: duplicate, deduplicated: true },
     };
   }
@@ -834,7 +878,7 @@ async function handleCreate(
     if (error instanceof ScheduledTaskValidationError) {
       return {
         success: false,
-        text: `Scheduled task validation failed: ${error.issues.join("; ")}`,
+        text: PLAIN_TIMING_MISSING_TEXT,
         data: {
           subaction: "create",
           error: "INVALID_SCHEDULED_TASK",
@@ -845,7 +889,7 @@ async function handleCreate(
     if (error instanceof ChannelKeyError) {
       return {
         success: false,
-        text: `Scheduled task validation failed: ${error.message}`,
+        text: PLAIN_DESTINATION_MISSING_TEXT,
         data: {
           subaction: "create",
           error: "INVALID_SCHEDULED_TASK",
@@ -857,7 +901,7 @@ async function handleCreate(
   }
   return {
     success: true,
-    text: `Scheduled ${kind} task ${created.taskId}.`,
+    text: `Scheduled the ${noun}.`,
     data: { subaction: "create", task: created },
   };
 }
@@ -870,21 +914,21 @@ async function handleUpdate(
   if (!taskId) {
     return {
       success: false,
-      text: "I need a taskId to update a scheduled task.",
+      text: "I need to know which scheduled item you mean.",
       data: { subaction: "update", error: "MISSING_TASK_ID" },
     };
   }
   if (!params.patch || typeof params.patch !== "object") {
     return {
       success: false,
-      text: "I need a `patch` object describing the fields to update.",
+      text: "I need to know what to change on that scheduled item.",
       data: { subaction: "update", error: "MISSING_PATCH" },
     };
   }
   const updated = await scope.runner.apply(taskId, "edit", params.patch);
   return {
     success: true,
-    text: `Updated scheduled task ${taskId}.`,
+    text: "Updated that scheduled item.",
     data: { subaction: "update", task: updated },
   };
 }
@@ -897,7 +941,7 @@ async function handleSnooze(
   if (!taskId) {
     return {
       success: false,
-      text: "I need a taskId to snooze a scheduled task.",
+      text: "I need to know which scheduled item you mean.",
       data: { subaction: "snooze", error: "MISSING_TASK_ID" },
     };
   }
@@ -912,7 +956,7 @@ async function handleSnooze(
   if (minutes === undefined && untilIso === undefined) {
     return {
       success: false,
-      text: "I need either `minutes` or `untilIso` to snooze.",
+      text: "Tell me when to remind you again.",
       data: { subaction: "snooze", error: "MISSING_SNOOZE_TARGET" },
     };
   }
@@ -923,7 +967,7 @@ async function handleSnooze(
   await resolvePendingPromptsStore(scope.runtime).forgetTask(taskId);
   return {
     success: true,
-    text: `Snoozed scheduled task ${taskId}.`,
+    text: "Snoozed that scheduled item.",
     data: { subaction: "snooze", task: snoozed },
   };
 }
@@ -936,7 +980,7 @@ async function handleAcknowledge(
   if (!taskId) {
     return {
       success: false,
-      text: "I need a taskId to acknowledge a scheduled task.",
+      text: "I need to know which scheduled item you mean.",
       data: { subaction: "acknowledge", error: "MISSING_TASK_ID" },
     };
   }
@@ -947,7 +991,7 @@ async function handleAcknowledge(
   await resolvePendingPromptsStore(scope.runtime).forgetTask(taskId);
   return {
     success: true,
-    text: `Acknowledged scheduled task ${taskId}.`,
+    text: "Acknowledged that scheduled item.",
     data: { subaction: "acknowledge", task: updated },
   };
 }
@@ -962,7 +1006,7 @@ async function handleVerbWithReason(
   if (!taskId) {
     return {
       success: false,
-      text: `I need a taskId to ${label} a scheduled task.`,
+      text: "I need to know which scheduled item you mean.",
       data: { subaction: verb, error: "MISSING_TASK_ID" },
     };
   }
@@ -976,7 +1020,7 @@ async function handleVerbWithReason(
   }
   return {
     success: true,
-    text: `${label.charAt(0).toUpperCase()}${label.slice(1)}d scheduled task ${taskId}.`,
+    text: `Marked that scheduled item as ${verbPastTense(label)}.`,
     data: { subaction: verb, task: updated },
   };
 }
@@ -989,7 +1033,7 @@ async function handleHistory(
   if (!taskId) {
     return {
       success: false,
-      text: "I need a taskId to read history (the state log is partitioned per task).",
+      text: "I need to know which scheduled item you mean before I can read its history.",
       data: { subaction: "history", error: "MISSING_TASK_ID" },
     };
   }
@@ -1010,7 +1054,7 @@ async function handleHistory(
   });
   return {
     success: true,
-    text: `${entries.length} scheduled-task log row${entries.length === 1 ? "" : "s"}.`,
+    text: `${entries.length} history entr${entries.length === 1 ? "y" : "ies"}.`,
     data: { subaction: "history", entries },
   };
 }

--- a/plugins/plugin-personal-assistant/test/scheduled-task-trigger-boundary.test.ts
+++ b/plugins/plugin-personal-assistant/test/scheduled-task-trigger-boundary.test.ts
@@ -10,8 +10,8 @@
  * an unlabeled `success:false` (`expression.trim` throw). It then created a
  * SECOND identical reminder on the next turn under a different
  * idempotencyKey. These tests pin the boundary: aliases normalize, incomplete
- * triggers fail with a teaching message, and an identical active task is
- * returned instead of duplicated.
+ * triggers keep teaching details in structured data instead of user copy, and
+ * an identical active task is returned instead of duplicated.
  */
 
 import type { Memory, UUID } from "@elizaos/core";
@@ -35,18 +35,36 @@ function ownerMessage(agentId: UUID, text: string): Memory {
 
 type CreateParams = Record<string, unknown>;
 
+async function runScheduledTaskAction(
+  runtime: RealTestRuntimeResult["runtime"],
+  parameters: Record<string, unknown>,
+) {
+  return scheduledTaskAction.handler?.(
+    runtime,
+    ownerMessage(runtime.agentId, "scheduled-task operation"),
+    undefined,
+    { parameters },
+    undefined,
+    [],
+  );
+}
+
 async function create(
   runtime: RealTestRuntimeResult["runtime"],
   parameters: CreateParams,
 ) {
-  return scheduledTaskAction.handler?.(
-    runtime,
-    ownerMessage(runtime.agentId, "schedule it"),
-    undefined,
-    { parameters: { subaction: "create", ...parameters } },
-    undefined,
-    [],
+  return runScheduledTaskAction(runtime, {
+    subaction: "create",
+    ...parameters,
+  });
+}
+
+function expectPlainScheduledTaskText(text: string | undefined): void {
+  expect(text).toBeDefined();
+  expect(text).not.toMatch(
+    /ISO-8601|promptInstructions|trigger type|taskId|OWNER_[A-Z_]+|expression|during_window/u,
   );
+  expect(text).not.toMatch(/\b(?:st|task)_[a-z0-9_]+\b/u);
 }
 
 describe("SCHEDULED_TASKS create — trigger boundary", () => {
@@ -98,8 +116,9 @@ describe("SCHEDULED_TASKS create — trigger boundary", () => {
       kind: "reminder",
       promptInstructions: "Call mom.",
       trigger: { type: "once", at: "2026-07-03T17:00:00.000Z" },
-    })) as { success: boolean; data?: Record<string, unknown> };
+    })) as { success: boolean; text?: string; data?: Record<string, unknown> };
     expect(result.success).toBe(true);
+    expectPlainScheduledTaskText(result.text);
     const task = result.data?.task as {
       trigger: { kind: string; atIso: string };
     };
@@ -109,7 +128,34 @@ describe("SCHEDULED_TASKS create — trigger boundary", () => {
     });
   });
 
-  it("an incomplete cron trigger fails with a teaching message, never a bare success:false", async () => {
+  it("task-control confirmations keep raw ids out of user-facing text", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    const created = (await create(runtime, {
+      kind: "reminder",
+      promptInstructions: "Pay the electric bill.",
+      trigger: { type: "once", at: "2026-07-03T17:00:00.000Z" },
+    })) as { success: boolean; text?: string; data?: Record<string, unknown> };
+    expect(created.success).toBe(true);
+    expectPlainScheduledTaskText(created.text);
+    const task = created.data?.task as { taskId: string };
+
+    for (const parameters of [
+      { subaction: "get", taskId: task.taskId },
+      { subaction: "update", taskId: task.taskId, patch: { priority: "low" } },
+      { subaction: "history", taskId: task.taskId },
+      { subaction: "complete", taskId: task.taskId },
+    ]) {
+      const result = (await runScheduledTaskAction(runtime, parameters)) as {
+        success: boolean;
+        text?: string;
+      };
+      expect(result.success).toBe(true);
+      expectPlainScheduledTaskText(result.text);
+    }
+  });
+
+  it("an incomplete cron trigger fails with structured detail, never a bare success:false", async () => {
     runtimeResult = await createLifeOpsTestRuntime();
     const { runtime } = runtimeResult;
     const result = (await create(runtime, {
@@ -119,10 +165,11 @@ describe("SCHEDULED_TASKS create — trigger boundary", () => {
     })) as { success: boolean; text?: string; data?: Record<string, unknown> };
     expect(result.success).toBe(false);
     expect(result.data?.error).toBe("INVALID_TRIGGER");
-    expect(result.text).toContain('expression: "<5-field cron>"');
+    expectPlainScheduledTaskText(result.text);
+    expect(result.data?.message).toContain('expression: "<5-field cron>"');
   });
 
-  it("an unparseable once datetime fails with the expected shape in the message", async () => {
+  it("an unparseable once datetime keeps schema detail out of the user-facing message", async () => {
     runtimeResult = await createLifeOpsTestRuntime();
     const { runtime } = runtimeResult;
     const result = (await create(runtime, {
@@ -132,10 +179,11 @@ describe("SCHEDULED_TASKS create — trigger boundary", () => {
     })) as { success: boolean; text?: string; data?: Record<string, unknown> };
     expect(result.success).toBe(false);
     expect(result.data?.error).toBe("INVALID_TRIGGER");
-    expect(result.text).toContain("ISO-8601");
+    expectPlainScheduledTaskText(result.text);
+    expect(result.data?.message).toContain("ISO-8601");
   });
 
-  it("an unknown trigger kind names the valid kinds", async () => {
+  it("an unknown trigger kind keeps valid-kind detail in data only", async () => {
     runtimeResult = await createLifeOpsTestRuntime();
     const { runtime } = runtimeResult;
     const result = (await create(runtime, {
@@ -145,7 +193,8 @@ describe("SCHEDULED_TASKS create — trigger boundary", () => {
     })) as { success: boolean; text?: string; data?: Record<string, unknown> };
     expect(result.success).toBe(false);
     expect(result.data?.error).toBe("INVALID_TRIGGER");
-    expect(result.text).toContain("during_window");
+    expectPlainScheduledTaskText(result.text);
+    expect(result.data?.message).toContain("during_window");
   });
 
   it("an identical active task is returned instead of a duplicate (cross-turn re-ask)", async () => {
@@ -170,6 +219,7 @@ describe("SCHEDULED_TASKS create — trigger boundary", () => {
     })) as { success: boolean; data?: Record<string, unknown> };
     expect(second.success).toBe(true);
     expect(second.data?.deduplicated).toBe(true);
+    expectPlainScheduledTaskText(second.text);
     const secondTask = second.data?.task as { taskId: string };
     expect(secondTask.taskId).toBe(firstTask.taskId);
   });
@@ -183,8 +233,9 @@ describe("SCHEDULED_TASKS create — trigger boundary", () => {
     })) as { success: boolean; text?: string; data?: Record<string, unknown> };
     expect(result.success).toBe(false);
     expect(result.data?.error).toBe("MISSING_TRIGGER");
-    expect(result.text).toContain("OWNER_ROUTINES");
-    expect(result.text).toContain("action=create");
+    expectPlainScheduledTaskText(result.text);
+    expect(result.data?.repair).toContain("OWNER_ROUTINES");
+    expect(result.data?.repair).toContain("action=create");
   });
 
   it("an invalid trigger also carries the habit-definition redirect", async () => {
@@ -197,7 +248,8 @@ describe("SCHEDULED_TASKS create — trigger boundary", () => {
     })) as { success: boolean; text?: string; data?: Record<string, unknown> };
     expect(result.success).toBe(false);
     expect(result.data?.error).toBe("INVALID_TRIGGER");
-    expect(result.text).toContain("OWNER_ROUTINES");
+    expectPlainScheduledTaskText(result.text);
+    expect(result.data?.repair).toContain("OWNER_ROUTINES");
   });
 
   it("a retried create that reuses the same planner-supplied taskId is idempotent, even with a fresh idempotencyKey and rewritten body", async () => {


### PR DESCRIPTION
## Summary
- Replaces `SCHEDULED_TASKS` user-facing handler text that leaked `taskId`, `promptInstructions`, trigger-kind/schema names, ISO examples, and validation jargon.
- Keeps exact diagnostics and planner repair guidance in `ActionResult.data` (`message`, `issues`, `repair`) instead of putting them in visible copy.
- Extends the scheduled-task trigger-boundary test with a reusable plain-text invariant and success/control-path assertions so raw ids do not reappear in confirmations.

Fixes #15025

## Verification
- `bunx @biomejs/biome check plugins/plugin-personal-assistant/src/actions/scheduled-task.ts plugins/plugin-personal-assistant/test/scheduled-task-trigger-boundary.test.ts` — passed
- `bun run generate:action-search-keywords` — required in the fresh worktree before the package test because generated keyword data was absent locally; generated file was restored after verification
- `bunx vitest run --config plugins/plugin-personal-assistant/vitest.config.ts plugins/plugin-personal-assistant/test/scheduled-task-trigger-boundary.test.ts` — 1 file / 13 tests passed
- `git diff --check origin/develop...HEAD` — passed
- `bun run audit:error-policy-ratchet --report` — passed, no new fallback-slop in touched files

## Typecheck
- `bun run --cwd plugins/plugin-personal-assistant typecheck` still fails on the existing package baseline. Filtered touched-file diagnostics remain old `scheduled-task.ts` import/export debt plus pre-existing implicit-any/unknown-error lines; the test file has no diagnostics in the filtered output.

## Evidence
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - no rendered UI changed; this is action-handler visible copy.`

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - no rendered UI changed; this is action-handler visible copy.`

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no interactive UI flow changed.`

<!-- evidence-row:backend-logs -->
- [ ] Backend/test logs: https://github.com/elizaOS/eliza/issues/15025#issuecomment-4891261208

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend runtime path changed.`

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - this PR changes deterministic action result copy and tests, not agent planning/model behavior.`

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: https://github.com/elizaOS/eliza/issues/15025#issuecomment-4891261208

## OCR review
- `N/A - no screenshot artifact exists for this non-UI PR. OCR remains mandatory for rendered UI evidence and must not be skipped.`

## Evidence notes
- The regression test now asserts visible `text` does not contain `ISO-8601`, `promptInstructions`, `trigger type`, `taskId`, `OWNER_*`, schema words like `expression` / `during_window`, or raw `st_` / `task_` ids.
- Internal details are still available in `data.message`, `data.issues`, and `data.repair` for debugging/planner recovery without being shown to the owner.