### PR TITLE
feat(lifeops): register passive signal sources through one extension point (#14690)

### DIFF
--- a/packages/shared/src/contracts/personal-assistant.ts
+++ b/packages/shared/src/contracts/personal-assistant.ts
@@ -1084,8 +1084,42 @@ export const LIFEOPS_ACTIVITY_SIGNAL_SOURCES = [
   "mobile_device",
   "mobile_health",
 ] as const;
+/**
+ * The closed built-in passive-signal vocabulary: the eight sources whose
+ * telemetry payload schema and reliability weight ship in-tree. It is the
+ * discriminant for the typed built-in mappers, the reliability keys, and the
+ * awake-probability model.
+ */
 export type LifeOpsActivitySignalSource =
   (typeof LIFEOPS_ACTIVITY_SIGNAL_SOURCES)[number];
+
+/**
+ * Open passive-signal source identifier — the built-in vocabulary plus any
+ * namespaced source a plugin contributes at runtime through the
+ * `SignalSourceRegistry`. Mirrors how `LifeOpsBusFamily` opens the closed
+ * `LifeOpsTelemetryFamily` union: persisted signals and ingestion requests
+ * carry this open type, while the built-in mapping/reliability tables keep the
+ * closed `LifeOpsActivitySignalSource` discriminant. `(string & {})` preserves
+ * literal autocomplete for the built-ins while admitting contributed sources.
+ */
+export type LifeOpsActivitySignalSourceName =
+  | LifeOpsActivitySignalSource
+  | (string & {});
+
+/**
+ * `true` when `source` is one of the built-in `LIFEOPS_ACTIVITY_SIGNAL_SOURCES`
+ * (carries a typed payload schema + reliability weight). Callers narrow an open
+ * `LifeOpsActivitySignalSourceName` to the closed union before reaching the
+ * built-in mapper/reliability tables; a contributed source is dispatched
+ * through its `SignalSourceRegistry` entry instead.
+ */
+export function isBuiltinActivitySignalSource(
+  source: LifeOpsActivitySignalSourceName,
+): source is LifeOpsActivitySignalSource {
+  return (LIFEOPS_ACTIVITY_SIGNAL_SOURCES as readonly string[]).includes(
+    source,
+  );
+}
 
 export const LIFEOPS_ACTIVITY_SIGNAL_STATES = [
   "active",
@@ -1345,7 +1379,7 @@ export interface SyncLifeOpsHealthConnectorRequest {
 export interface LifeOpsActivitySignal {
   id: string;
   agentId: string;
-  source: LifeOpsActivitySignalSource;
+  source: LifeOpsActivitySignalSourceName;
   platform: string;
   state: LifeOpsActivitySignalState;
   observedAt: string;
@@ -3404,7 +3438,7 @@ export interface CaptureLifeOpsPhoneConsentRequest {
 }
 
 export interface CaptureLifeOpsActivitySignalRequest {
-  source: LifeOpsActivitySignalSource;
+  source: LifeOpsActivitySignalSourceName;
   platform?: string;
   state: LifeOpsActivitySignalState;
   observedAt?: string;

--- a/plugins/plugin-health/src/contracts/health.ts
+++ b/plugins/plugin-health/src/contracts/health.ts
@@ -11,6 +11,7 @@ export type {
   GetLifeOpsHealthSummaryRequest,
   LifeOpsActivitySignal,
   LifeOpsActivitySignalSource,
+  LifeOpsActivitySignalSourceName,
   LifeOpsAwakeProbability,
   LifeOpsAwakeProbabilityContributor,
   LifeOpsAwakeProbabilitySource,
@@ -89,6 +90,8 @@ export type {
 } from "./lifeops.js";
 
 export {
+  isBuiltinActivitySignalSource,
+  LIFEOPS_ACTIVITY_SIGNAL_SOURCES,
   LIFEOPS_CIRCADIAN_STATES,
   LIFEOPS_HEALTH_CONNECTOR_CAPABILITIES,
   LIFEOPS_HEALTH_CONNECTOR_PROVIDERS,

--- a/plugins/plugin-health/src/contracts/lifeops.ts
+++ b/plugins/plugin-health/src/contracts/lifeops.ts
@@ -6,6 +6,16 @@
  * the connector-degradation types. Consumed across the screen-time, scheduling,
  * and connector layers.
  */
+// The passive-signal source vocabulary is owned by `@elizaos/shared`; health
+// imports and re-exports the canonical const/type/guard so its reliability
+// tables and the PA telemetry mapper agree on one definition instead of
+// drifting copies.
+import {
+  isBuiltinActivitySignalSource,
+  LIFEOPS_ACTIVITY_SIGNAL_SOURCES,
+  type LifeOpsActivitySignalSource,
+  type LifeOpsActivitySignalSourceName,
+} from "@elizaos/shared";
 import type { LifeOpsConnectorDegradation } from "./lifeops-connector-degradation.js";
 
 export type {
@@ -13,6 +23,12 @@ export type {
   LifeOpsConnectorDegradationAxis,
 } from "./lifeops-connector-degradation.js";
 export { LIFEOPS_CONNECTOR_DEGRADATION_AXES } from "./lifeops-connector-degradation.js";
+export {
+  isBuiltinActivitySignalSource,
+  LIFEOPS_ACTIVITY_SIGNAL_SOURCES,
+  type LifeOpsActivitySignalSource,
+  type LifeOpsActivitySignalSourceName,
+};
 
 export const LIFEOPS_TIME_WINDOW_NAMES = [
   "morning",
@@ -1068,19 +1084,6 @@ export interface LifeOpsChannelPolicy {
   updatedAt: string;
 }
 
-export const LIFEOPS_ACTIVITY_SIGNAL_SOURCES = [
-  "app_lifecycle",
-  "page_visibility",
-  "desktop_power",
-  "desktop_interaction",
-  "connector_activity",
-  "imessage_outbound",
-  "mobile_device",
-  "mobile_health",
-] as const;
-export type LifeOpsActivitySignalSource =
-  (typeof LIFEOPS_ACTIVITY_SIGNAL_SOURCES)[number];
-
 export const LIFEOPS_ACTIVITY_SIGNAL_STATES = [
   "active",
   "idle",
@@ -1339,7 +1342,7 @@ export interface SyncLifeOpsHealthConnectorRequest {
 export interface LifeOpsActivitySignal {
   id: string;
   agentId: string;
-  source: LifeOpsActivitySignalSource;
+  source: LifeOpsActivitySignalSourceName;
   platform: string;
   state: LifeOpsActivitySignalState;
   observedAt: string;
@@ -3520,7 +3523,7 @@ export interface CaptureLifeOpsPhoneConsentRequest {
 }
 
 export interface CaptureLifeOpsActivitySignalRequest {
-  source: LifeOpsActivitySignalSource;
+  source: LifeOpsActivitySignalSourceName;
   platform?: string;
   state: LifeOpsActivitySignalState;
   observedAt?: string;

--- a/plugins/plugin-health/src/sleep/awake-probability.ts
+++ b/plugins/plugin-health/src/sleep/awake-probability.ts
@@ -3,11 +3,12 @@
  * from activity signals, schedule regularity, and sleep-cycle state. Gates
  * check-in timing across the sleep domain.
  */
-import type {
-  LifeOpsActivitySignal,
-  LifeOpsAwakeProbability,
-  LifeOpsScheduleRegularity,
-  LifeOpsSleepCycle,
+import {
+  isBuiltinActivitySignalSource,
+  type LifeOpsActivitySignal,
+  type LifeOpsAwakeProbability,
+  type LifeOpsScheduleRegularity,
+  type LifeOpsSleepCycle,
 } from "../contracts/health.js";
 import { getZonedDateParts } from "../util/time.js";
 import { parseIsoMs } from "../util/time-util.js";
@@ -86,7 +87,14 @@ export function computeAwakeProbability(args: {
     return false;
   });
 
-  if (latestSignal) {
+  // The built-in logistic model only scores the closed built-in sources; a
+  // plugin-contributed source (browser activity, view usage, …) is skipped
+  // here rather than fed a fabricated weight — it would need to also teach this
+  // model to participate.
+  if (
+    latestSignal &&
+    isBuiltinActivitySignalSource(latestSignal.signal.source)
+  ) {
     const ageMs = args.nowMs - latestSignal.observedAtMs;
     const state = latestSignal.signal.state;
     const reliability = resolveActivitySignalReliability(

--- a/plugins/plugin-health/src/sleep/source-reliability.test.ts
+++ b/plugins/plugin-health/src/sleep/source-reliability.test.ts
@@ -159,4 +159,12 @@ describe("resolveActivitySignalReliability", () => {
       }),
     ).toBe(0.88);
   });
+
+  it("throws (never fabricates) for a contributed source with no built-in weight", () => {
+    // A registry-contributed source resolves its weight through its own entry;
+    // the built-in table must fail fast rather than invent a confidence number.
+    expect(() =>
+      resolveActivitySignalReliability("browser_activity", "browser_web"),
+    ).toThrow(/no built-in reliability weight/);
+  });
 });

--- a/plugins/plugin-health/src/sleep/source-reliability.ts
+++ b/plugins/plugin-health/src/sleep/source-reliability.ts
@@ -3,7 +3,12 @@
  * and `resolveActivitySignalReliability` rank manual overrides, mobile-health,
  * desktop-power, and message-channel evidence when inferring sleep/wake.
  */
-import type { LifeOpsActivitySignalSource } from "../contracts/health.js";
+import { ElizaError } from "@elizaos/core";
+import {
+  isBuiltinActivitySignalSource,
+  type LifeOpsActivitySignalSource,
+  type LifeOpsActivitySignalSourceName,
+} from "../contracts/health.js";
 
 export type LifeOpsReliabilityKey =
   | { kind: "manual_override" }
@@ -143,11 +148,28 @@ function connectorActivityReliabilityKey(
   };
 }
 
+/**
+ * Built-in reliability weight for one of the closed
+ * `LIFEOPS_ACTIVITY_SIGNAL_SOURCES`. Contributed (non-built-in) sources supply
+ * their own weight through their `SignalSourceRegistry` entry and never reach
+ * here — so an unknown source is a dispatch bug, not a data value: it throws
+ * rather than fabricating a confidence number.
+ */
 export function resolveActivitySignalReliability(
-  source: LifeOpsActivitySignalSource,
+  source: LifeOpsActivitySignalSourceName,
   platform: string,
   metadata?: Record<string, unknown>,
 ): number {
+  if (!isBuiltinActivitySignalSource(source)) {
+    throw new ElizaError(
+      `resolveActivitySignalReliability: no built-in reliability weight for contributed source "${source}"; resolve it through the SignalSourceRegistry entry`,
+      {
+        code: "LIFEOPS_UNKNOWN_SIGNAL_SOURCE_RELIABILITY",
+        context: { source, platform },
+        severity: "fatal",
+      },
+    );
+  }
   if (source === "app_lifecycle" && platform === "manual_override") {
     return resolveSourceReliability({ kind: "manual_override" });
   }

--- a/plugins/plugin-personal-assistant/src/activity-profile/types.ts
+++ b/plugins/plugin-personal-assistant/src/activity-profile/types.ts
@@ -3,6 +3,7 @@
  * their hour ranges, per-platform activity records, activity signals, the
  * assembled ActivityProfile, and the proactive-action shape.
  */
+import type { LifeOpsActivitySignalSourceName } from "@elizaos/shared";
 import type { LifeOpsHealthSignal } from "../contracts/index.js";
 
 export type TimeBucket =
@@ -58,15 +59,7 @@ export interface PlatformActivity {
 }
 
 export interface ActivitySignalRecord {
-  source:
-    | "app_lifecycle"
-    | "page_visibility"
-    | "desktop_power"
-    | "desktop_interaction"
-    | "connector_activity"
-    | "imessage_outbound"
-    | "mobile_device"
-    | "mobile_health";
+  source: LifeOpsActivitySignalSourceName;
   platform: string;
   state: "active" | "idle" | "background" | "locked" | "sleeping";
   observedAt: number;

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.ts
@@ -122,6 +122,7 @@ import {
   resolveOwnerFactStore,
   resolveOwnerTimeZone,
 } from "../owner/fact-store.js";
+import { getSignalSourceRegistry } from "../registries/signal-source-registry.js";
 import { refreshLifeOpsRelativeTime } from "../relative-time.js";
 import {
   createLifeOpsActivitySignal,
@@ -1061,8 +1062,9 @@ function buildActiveCalendarEventReminders(
 function normalizeActivitySignalSource(
   value: unknown,
   field: string,
+  validSources?: readonly string[],
 ): LifeOpsActivitySignal["source"] {
-  return normalizeReminderActivitySignalSource(value, field);
+  return normalizeReminderActivitySignalSource(value, field, validSources);
 }
 
 function normalizeActivitySignalState(
@@ -4603,9 +4605,16 @@ export class RemindersDomain {
     request: CaptureLifeOpsActivitySignalRequest,
   ): Promise<LifeOpsActivitySignal> {
     const health = normalizeHealthSignal(request.health, "health");
+    const registeredSources = getSignalSourceRegistry(
+      this.ctx.runtime,
+    )?.sources();
     const signal = createLifeOpsActivitySignal({
       agentId: this.ctx.agentId(),
-      source: normalizeActivitySignalSource(request.source, "source"),
+      source: normalizeActivitySignalSource(
+        request.source,
+        "source",
+        registeredSources,
+      ),
       platform: normalizeOptionalString(request.platform) ?? "client_chat",
       state: normalizeActivitySignalState(request.state, "state"),
       observedAt:

--- a/plugins/plugin-personal-assistant/src/lifeops/registries/index.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/registries/index.ts
@@ -68,6 +68,14 @@ export {
   UnknownFeatureFlagError,
 } from "./feature-flag-registry.js";
 export {
+  __resetSignalSourceRegistryForTests,
+  createSignalSourceRegistry,
+  getSignalSourceRegistry,
+  registerSignalSourceRegistry,
+  type SignalSourceContribution,
+  type SignalSourceRegistry,
+} from "./signal-source-registry.js";
+export {
   type WebsiteBlockerStartResult,
   websiteBlockerContribution,
 } from "./website-blocker-contribution.js";

--- a/plugins/plugin-personal-assistant/src/lifeops/registries/signal-source-registry.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/registries/signal-source-registry.ts
@@ -1,0 +1,125 @@
+/**
+ * SignalSourceRegistry.
+ *
+ * The single extension point for passive activity-signal sources. Each source
+ * contributes one entry carrying both halves of "how to interpret this source":
+ * a `telemetryMapper` (persisted signal → canonical `LifeOpsTelemetryPayload`)
+ * and a `reliability` weight resolver. Before this registry those two halves
+ * lived in three coordinated places — the closed source union in
+ * `@elizaos/shared`, the closed mapper switch in PA's `telemetry-mapping.ts`,
+ * and the closed reliability table in `@elizaos/plugin-health` — so adding one
+ * source (browser activity, view usage, reaction activity, …) meant edits
+ * across three packages. A registration collapses that to one call.
+ *
+ * The source vocabulary is opened exactly as `LifeOpsBusFamily` opened
+ * `LifeOpsTelemetryFamily`: the built-in eight keep their closed
+ * `LifeOpsActivitySignalSource` discriminant (and typed payload schemas), while
+ * `LifeOpsActivitySignalSourceName` admits any contributed source. Ingestion
+ * (`normalizeActivitySignalSource`) validates against `registry.sources()`, and
+ * the telemetry-mirror path dispatches through `registry.get(source)` instead
+ * of a switch whose `default` silently dropped the row.
+ *
+ * Per-runtime, `WeakMap`-keyed like `FamilyRegistry` so lifetime tracks the
+ * runtime and nothing leaks across tests.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import type {
+  LifeOpsActivitySignal,
+  LifeOpsActivitySignalSourceName,
+  LifeOpsTelemetryPayload,
+} from "@elizaos/shared";
+
+export interface SignalSourceContribution {
+  /** Open-string source identifier (built-in or contributed). */
+  source: LifeOpsActivitySignalSourceName;
+  /** Human-readable description for diagnostics + the planner. */
+  description: string;
+  /** Producer of this source: `"app-lifeops"`, `"plugin-browser"`, etc. */
+  contributor: string;
+  /**
+   * Map a persisted signal into its canonical telemetry payload. Returns
+   * `null` when *this signal instance* legitimately produces no telemetry row
+   * (e.g. a `mobile_health` signal with no health payload) — that is not an
+   * error. An *unregistered* source, by contrast, never reaches a mapper: the
+   * mirror path reports it via `runtime.reportError`.
+   */
+  telemetryMapper: (
+    signal: LifeOpsActivitySignal,
+  ) => LifeOpsTelemetryPayload | null;
+  /** Confidence weight in [0, 1] for a signal instance from this source. */
+  reliability: (signal: LifeOpsActivitySignal) => number;
+}
+
+export interface SignalSourceRegistry {
+  register(contribution: SignalSourceContribution): void;
+  get(source: LifeOpsActivitySignalSourceName): SignalSourceContribution | null;
+  has(source: LifeOpsActivitySignalSourceName): boolean;
+  list(filter?: { contributor?: string }): SignalSourceContribution[];
+  /** Every registered source name — the ingestion allow-list. */
+  sources(): LifeOpsActivitySignalSourceName[];
+}
+
+class InMemorySignalSourceRegistry implements SignalSourceRegistry {
+  private readonly bySource = new Map<
+    LifeOpsActivitySignalSourceName,
+    SignalSourceContribution
+  >();
+
+  register(contribution: SignalSourceContribution): void {
+    if (!contribution.source) {
+      throw new Error("SignalSourceRegistry.register: source is required");
+    }
+    if (this.bySource.has(contribution.source)) {
+      throw new Error(
+        `SignalSourceRegistry.register: source "${contribution.source}" already registered`,
+      );
+    }
+    this.bySource.set(contribution.source, contribution);
+  }
+
+  get(
+    source: LifeOpsActivitySignalSourceName,
+  ): SignalSourceContribution | null {
+    return this.bySource.get(source) ?? null;
+  }
+
+  has(source: LifeOpsActivitySignalSourceName): boolean {
+    return this.bySource.has(source);
+  }
+
+  list(filter?: { contributor?: string }): SignalSourceContribution[] {
+    const all = Array.from(this.bySource.values());
+    if (!filter?.contributor) return all;
+    return all.filter((c) => c.contributor === filter.contributor);
+  }
+
+  sources(): LifeOpsActivitySignalSourceName[] {
+    return Array.from(this.bySource.keys());
+  }
+}
+
+export function createSignalSourceRegistry(): SignalSourceRegistry {
+  return new InMemorySignalSourceRegistry();
+}
+
+const registries = new WeakMap<IAgentRuntime, SignalSourceRegistry>();
+
+export function registerSignalSourceRegistry(
+  runtime: IAgentRuntime,
+  registry: SignalSourceRegistry,
+): void {
+  registries.set(runtime, registry);
+}
+
+export function getSignalSourceRegistry(
+  runtime: IAgentRuntime,
+): SignalSourceRegistry | null {
+  return registries.get(runtime) ?? null;
+}
+
+export function __resetSignalSourceRegistryForTests(
+  runtime: IAgentRuntime,
+): void {
+  registries.delete(runtime);
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/repository.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/repository.ts
@@ -16,7 +16,7 @@ import {
   resolveKnowledgeGraphService,
 } from "@elizaos/agent";
 import type { IAgentRuntime } from "@elizaos/core";
-import { logger } from "@elizaos/core";
+import { ElizaError, logger } from "@elizaos/core";
 import type {
   BrowserBridgeCompanionStatus,
   BrowserBridgePageContext,
@@ -112,6 +112,7 @@ import {
   normalizeLifeOpsAccountPrivacyScope,
   normalizeLifeOpsEgressDataClasses,
 } from "./privacy-egress.js";
+import { getSignalSourceRegistry } from "./registries/signal-source-registry.js";
 import { refreshLifeOpsRelativeTime } from "./relative-time.js";
 import { lifeOpsSchema } from "./schema.js";
 import {
@@ -3447,9 +3448,29 @@ export class LifeOpsRepository {
       )`,
     );
 
+    // Both the bus publish and the telemetry mirror dispatch through the
+    // per-source registry. A missing registry is a boot-wiring failure, not a
+    // data condition: surface it observably and skip the mirror rather than
+    // fabricating a telemetry row for an unknown source.
+    const signalSourceRegistry = getSignalSourceRegistry(this.runtime);
+    if (signalSourceRegistry === null) {
+      this.runtime.reportError(
+        "lifeops.repository",
+        new ElizaError(
+          "SignalSourceRegistry is not registered on the runtime; activity-signal telemetry mirror skipped",
+          {
+            code: "LIFEOPS_SIGNAL_SOURCE_REGISTRY_MISSING",
+            context: { agentId: signal.agentId, source: signal.source },
+            severity: "fatal",
+          },
+        ),
+      );
+      return;
+    }
+
     const activityBus = getActivitySignalBus(this.runtime);
     if (activityBus) {
-      publishActivitySignalToBus(activityBus, signal);
+      publishActivitySignalToBus(activityBus, signal, signalSourceRegistry);
     }
 
     // Mirror into the canonical telemetry store. Dedupes on
@@ -3461,6 +3482,8 @@ export class LifeOpsRepository {
       const telemetry = buildTelemetryEventFromSignal(
         signal,
         new Date().toISOString(),
+        signalSourceRegistry,
+        this.runtime,
       );
       if (telemetry) {
         await this.insertTelemetryEvent(telemetry);

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/activity-gates.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/activity-gates.test.ts
@@ -23,9 +23,11 @@ import {
   createFamilyRegistry,
   registerBuiltinTelemetryFamilies,
 } from "../registries/family-registry.js";
+import { createSignalSourceRegistry } from "../registries/signal-source-registry.js";
 import { publishActivitySignalToBus } from "../signals/activity-signal-publisher.js";
 import type { ActivitySignalBus } from "../signals/bus.js";
 import { createActivitySignalBus } from "../signals/bus.js";
+import { registerBuiltinSignalSources } from "../telemetry-mapping.js";
 import {
   behaviouralBaselineFromProfile,
   registerActivityProfileGates,
@@ -273,7 +275,13 @@ describe("no_recent_user_message_in reader", () => {
 
   it("defers when MESSAGE_RECEIVED activity is mirrored onto the real bus", async () => {
     const bus = makeMessageActivityBus();
-    const result = publishActivitySignalToBus(bus, messageReceivedSignal());
+    const signalSourceRegistry = createSignalSourceRegistry();
+    registerBuiltinSignalSources(signalSourceRegistry);
+    const result = publishActivitySignalToBus(
+      bus,
+      messageReceivedSignal(),
+      signalSourceRegistry,
+    );
     expect(result).toEqual({ published: 1, unmapped: 0 });
     expect(
       bus.hasSignalSince({

--- a/plugins/plugin-personal-assistant/src/lifeops/service-helpers-reminder.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/service-helpers-reminder.ts
@@ -127,17 +127,22 @@ export function isReminderReviewClosed(
   );
 }
 
+/**
+ * Validate an ingested activity-signal source against the registered source
+ * vocabulary. `validSources` is the `SignalSourceRegistry.sources()` allow-list
+ * so a plugin-contributed source is accepted at runtime; it defaults to the
+ * built-in eight for callers that validate without a runtime in scope. The
+ * `mobileDevice`/`mobile-health` aliases stay for the mobile clients that send
+ * camelCase/kebab-case.
+ */
 export function normalizeActivitySignalSource(
   value: unknown,
   field: string,
+  validSources: readonly string[] = LIFEOPS_ACTIVITY_SIGNAL_SOURCES,
 ): LifeOpsActivitySignal["source"] {
   const source = requireNonEmptyString(value, field);
-  if (
-    LIFEOPS_ACTIVITY_SIGNAL_SOURCES.includes(
-      source as LifeOpsActivitySignal["source"],
-    )
-  ) {
-    return source as LifeOpsActivitySignal["source"];
+  if (validSources.includes(source)) {
+    return source;
   }
   if (
     source === "mobileDevice" ||
@@ -149,10 +154,7 @@ export function normalizeActivitySignalSource(
       ? "mobile_health"
       : "mobile_device";
   }
-  fail(
-    400,
-    `${field} must be one of: ${LIFEOPS_ACTIVITY_SIGNAL_SOURCES.join(", ")}`,
-  );
+  fail(400, `${field} must be one of: ${validSources.join(", ")}`);
 }
 
 export function normalizeActivitySignalState(

--- a/plugins/plugin-personal-assistant/src/lifeops/signal-source-registry.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/signal-source-registry.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Drives the real passive-signal-source extension path: the in-memory
+ * `SignalSourceRegistry`, the built-in registration, the registry-dispatched
+ * `buildTelemetryEventFromSignal`, and the ingestion allow-list. The load-bearing
+ * assertion is that a *contributed* source (not one of the built-in eight)
+ * flows all the way to a persisted telemetry row and past ingestion with a
+ * single `registry.register` call — which the pre-registry closed switch +
+ * closed union could not do. Deterministic (no live model / DB); the mapper and
+ * reliability are plain functions.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import {
+  LIFEOPS_ACTIVITY_SIGNAL_SOURCES,
+  type LifeOpsActivitySignal,
+} from "@elizaos/shared";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createSignalSourceRegistry,
+  type SignalSourceContribution,
+} from "./registries/signal-source-registry.js";
+import { normalizeActivitySignalSource } from "./service-helpers-reminder.js";
+import {
+  buildTelemetryEventFromSignal,
+  registerBuiltinSignalSources,
+} from "./telemetry-mapping.js";
+
+function signal(
+  overrides: Partial<LifeOpsActivitySignal> = {},
+): LifeOpsActivitySignal {
+  return {
+    id: "signal-1",
+    agentId: "agent-1",
+    source: "desktop_interaction",
+    platform: "macos_desktop",
+    state: "active",
+    observedAt: "2026-07-06T04:00:00.000Z",
+    idleState: null,
+    idleTimeSeconds: 3,
+    onBattery: null,
+    health: null,
+    metadata: {},
+    createdAt: "2026-07-06T04:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function fakeRuntime(): {
+  runtime: IAgentRuntime;
+  reportError: ReturnType<typeof vi.fn>;
+} {
+  const reportError = vi.fn();
+  return { runtime: { reportError } as unknown as IAgentRuntime, reportError };
+}
+
+/** A plugin-contributed passive source: a browser-activity focus window. */
+const browserActivityContribution: SignalSourceContribution = {
+  source: "browser_activity",
+  description: "Browser tab focus/blur window (contributed by plugin-browser).",
+  contributor: "plugin-browser",
+  telemetryMapper: (s) =>
+    s.state === "active"
+      ? {
+          family: "browser_focus_window",
+          platform: "browser_web",
+          startAt: s.observedAt,
+          endAt: s.observedAt,
+          domain: typeof s.metadata.host === "string" ? s.metadata.host : "",
+          tabId: s.id,
+          focusedSeconds: 0,
+        }
+      : null,
+  reliability: () => 0.65,
+};
+
+describe("SignalSourceRegistry", () => {
+  it("registers, looks up, and guards duplicates / empty sources", () => {
+    const registry = createSignalSourceRegistry();
+    registry.register(browserActivityContribution);
+
+    expect(registry.has("browser_activity")).toBe(true);
+    expect(registry.get("browser_activity")?.contributor).toBe(
+      "plugin-browser",
+    );
+    expect(registry.get("view_usage")).toBeNull();
+    expect(registry.sources()).toEqual(["browser_activity"]);
+
+    expect(() => registry.register(browserActivityContribution)).toThrow(
+      /already registered/,
+    );
+    expect(() =>
+      registry.register({
+        ...browserActivityContribution,
+        source: "",
+      }),
+    ).toThrow(/source is required/);
+  });
+
+  it("registers all eight built-ins with mapper + reliability", () => {
+    const registry = createSignalSourceRegistry();
+    registerBuiltinSignalSources(registry);
+
+    expect(registry.sources().sort()).toEqual(
+      [...LIFEOPS_ACTIVITY_SIGNAL_SOURCES].sort(),
+    );
+    for (const source of LIFEOPS_ACTIVITY_SIGNAL_SOURCES) {
+      const contribution = registry.get(source);
+      expect(contribution).not.toBeNull();
+      expect(contribution?.contributor).toBe("app-lifeops");
+    }
+  });
+});
+
+describe("buildTelemetryEventFromSignal (registry-dispatched)", () => {
+  it("maps a built-in source through its registered mapper + reliability", () => {
+    const registry = createSignalSourceRegistry();
+    registerBuiltinSignalSources(registry);
+    const { runtime, reportError } = fakeRuntime();
+
+    const event = buildTelemetryEventFromSignal(
+      signal({ source: "desktop_interaction", idleTimeSeconds: 3 }),
+      "2026-07-06T04:00:01.000Z",
+      registry,
+      runtime,
+    );
+
+    expect(event).not.toBeNull();
+    expect(event?.family).toBe("desktop_idle_sample");
+    // desktop_idle via iokit_hid weight (source-reliability table).
+    expect(event?.sourceReliability).toBe(0.8);
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it("maps a CONTRIBUTED source to a telemetry row — the extension the closed switch could not", () => {
+    const registry = createSignalSourceRegistry();
+    registerBuiltinSignalSources(registry);
+    registry.register(browserActivityContribution);
+    const { runtime, reportError } = fakeRuntime();
+
+    const event = buildTelemetryEventFromSignal(
+      signal({
+        source: "browser_activity",
+        state: "active",
+        metadata: { host: "example.com" },
+      }),
+      "2026-07-06T04:00:01.000Z",
+      registry,
+      runtime,
+    );
+
+    expect(event).not.toBeNull();
+    expect(event?.family).toBe("browser_focus_window");
+    expect(event?.sourceReliability).toBe(0.65);
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it("reports (not silently drops) an unregistered source", () => {
+    const registry = createSignalSourceRegistry();
+    registerBuiltinSignalSources(registry);
+    const { runtime, reportError } = fakeRuntime();
+
+    const event = buildTelemetryEventFromSignal(
+      signal({ source: "totally_unknown_source" }),
+      "2026-07-06T04:00:01.000Z",
+      registry,
+      runtime,
+    );
+
+    expect(event).toBeNull();
+    expect(reportError).toHaveBeenCalledTimes(1);
+    const [scope, error] = reportError.mock.calls[0];
+    expect(scope).toBe("lifeops.telemetry-mapping");
+    expect((error as { code?: string }).code).toBe(
+      "LIFEOPS_UNREGISTERED_SIGNAL_SOURCE",
+    );
+  });
+
+  it("returns null quietly when a registered mapper yields no row for this instance", () => {
+    const registry = createSignalSourceRegistry();
+    registerBuiltinSignalSources(registry);
+    const { runtime, reportError } = fakeRuntime();
+
+    // mobile_health with no health payload legitimately maps to null.
+    const event = buildTelemetryEventFromSignal(
+      signal({ source: "mobile_health", health: null }),
+      "2026-07-06T04:00:01.000Z",
+      registry,
+      runtime,
+    );
+
+    expect(event).toBeNull();
+    expect(reportError).not.toHaveBeenCalled();
+  });
+});
+
+describe("normalizeActivitySignalSource (registry allow-list)", () => {
+  it("accepts a contributed source that is in the registered allow-list", () => {
+    const registry = createSignalSourceRegistry();
+    registerBuiltinSignalSources(registry);
+    registry.register(browserActivityContribution);
+
+    expect(
+      normalizeActivitySignalSource(
+        "browser_activity",
+        "source",
+        registry.sources(),
+      ),
+    ).toBe("browser_activity");
+  });
+
+  it("rejects a source outside the registered allow-list", () => {
+    const registry = createSignalSourceRegistry();
+    registerBuiltinSignalSources(registry);
+
+    expect(() =>
+      normalizeActivitySignalSource(
+        "browser_activity",
+        "source",
+        registry.sources(),
+      ),
+    ).toThrow();
+  });
+
+  it("still validates built-ins and aliases without a registry", () => {
+    expect(normalizeActivitySignalSource("app_lifecycle", "source")).toBe(
+      "app_lifecycle",
+    );
+    expect(normalizeActivitySignalSource("mobile-health", "source")).toBe(
+      "mobile_health",
+    );
+    expect(() => normalizeActivitySignalSource("ouija", "source")).toThrow();
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/signals/activity-signal-publisher.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/signals/activity-signal-publisher.ts
@@ -7,7 +7,7 @@
  */
 
 import type { LifeOpsActivitySignal } from "@elizaos/shared";
-import { mapSignalToTelemetryPayload } from "../telemetry-mapping.js";
+import type { SignalSourceRegistry } from "../registries/signal-source-registry.js";
 import type { ActivitySignalBus } from "./bus.js";
 
 export interface PublishActivitySignalResult {
@@ -18,8 +18,9 @@ export interface PublishActivitySignalResult {
 export function publishActivitySignalToBus(
   bus: ActivitySignalBus,
   signal: LifeOpsActivitySignal,
+  registry: SignalSourceRegistry,
 ): PublishActivitySignalResult {
-  const payload = mapSignalToTelemetryPayload(signal);
+  const payload = registry.get(signal.source)?.telemetryMapper(signal) ?? null;
   if (payload?.family !== "message_activity_event") {
     return { published: 0, unmapped: 1 };
   }

--- a/plugins/plugin-personal-assistant/src/lifeops/telemetry-mapping.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/telemetry-mapping.ts
@@ -1,26 +1,33 @@
 /**
- * Shared mapper from persisted `LifeOpsActivitySignal` records into
- * `LifeOpsTelemetryPayload` rows. `LifeOpsRepository.createActivitySignal`
- * calls this on writes so passive signals are mirrored into
- * `life_telemetry_events` with a dedupe-stable payload.
- *
- * This file is the canonical mapping table for current signal families; keep
- * it aligned with the shared `LifeOpsTelemetryPayload` union.
+ * Built-in mapper from persisted `LifeOpsActivitySignal` records into
+ * `LifeOpsTelemetryPayload` rows, plus the registration that publishes those
+ * mappers (and their reliability weights) into the `SignalSourceRegistry`.
+ * `LifeOpsRepository.createActivitySignal` mirrors passive signals into
+ * `life_telemetry_events` by dispatching through the registry, so the switch
+ * below is the *built-in* half only — contributed sources bring their own
+ * mapper. Keep the switch aligned with the shared `LifeOpsTelemetryPayload`
+ * discriminated union.
  */
 
 import crypto from "node:crypto";
+import { ElizaError, type IAgentRuntime } from "@elizaos/core";
 // Import the leaf module, not the `@elizaos/plugin-health` barrel: this file is
 // in the data-layer graph that `lifeops/repository.ts` pulls into the keyless
 // node test lane (goals.real-db), where the barrel (→ React views → @elizaos/ui)
 // must never enter and has no dist entry to resolve.
 import { resolveActivitySignalReliability } from "@elizaos/plugin-health/sleep/source-reliability";
-import type {
-  LifeOpsActivitySignal,
-  LifeOpsDevicePlatform,
-  LifeOpsTelemetryEvent,
-  LifeOpsTelemetryMessageChannel,
-  LifeOpsTelemetryPayload,
+import {
+  LIFEOPS_ACTIVITY_SIGNAL_SOURCES,
+  type LifeOpsActivitySignal,
+  type LifeOpsDevicePlatform,
+  type LifeOpsTelemetryEvent,
+  type LifeOpsTelemetryMessageChannel,
+  type LifeOpsTelemetryPayload,
 } from "@elizaos/shared";
+import type {
+  SignalSourceContribution,
+  SignalSourceRegistry,
+} from "./registries/signal-source-registry.js";
 
 export function deriveTelemetryDedupeKey(
   family: string,
@@ -206,17 +213,76 @@ export function mapSignalToTelemetryPayload(
   }
 }
 
-export function buildTelemetryEventFromSignal(
-  signal: LifeOpsActivitySignal,
-  nowIso: string,
-): LifeOpsTelemetryEvent | null {
-  const payload = mapSignalToTelemetryPayload(signal);
-  if (payload === null) return null;
-  const reliability = resolveActivitySignalReliability(
+/**
+ * Reliability weight for a built-in source, read straight from the health
+ * reliability table. Contributed sources register their own resolver.
+ */
+function builtinSignalReliability(signal: LifeOpsActivitySignal): number {
+  return resolveActivitySignalReliability(
     signal.source,
     signal.platform,
     signal.metadata,
   );
+}
+
+/**
+ * Register the eight built-in passive-signal sources. All share the typed
+ * built-in mapper (which dispatches on `signal.source`/`signal.platform`) and
+ * the health reliability table; a plugin contributes a new source by calling
+ * `registry.register` with its own `telemetryMapper` + `reliability`.
+ */
+export function registerBuiltinSignalSources(
+  registry: SignalSourceRegistry,
+): void {
+  for (const source of LIFEOPS_ACTIVITY_SIGNAL_SOURCES) {
+    const contribution: SignalSourceContribution = {
+      source,
+      description: `LifeOps built-in passive signal source: ${source}`,
+      contributor: "app-lifeops",
+      telemetryMapper: mapSignalToTelemetryPayload,
+      reliability: builtinSignalReliability,
+    };
+    registry.register(contribution);
+  }
+}
+
+/**
+ * Build the canonical telemetry event for a persisted signal by dispatching
+ * through the `SignalSourceRegistry`. An *unregistered* source is a broken
+ * pipeline — it is surfaced via `runtime.reportError` (RECENT_ERRORS provider +
+ * owner escalation) rather than silently dropped, which is what the old
+ * `default: return null` switch branch did. A registered source whose mapper
+ * returns `null` for this instance (e.g. `mobile_health` with no payload)
+ * legitimately produces no row and returns quietly.
+ */
+export function buildTelemetryEventFromSignal(
+  signal: LifeOpsActivitySignal,
+  nowIso: string,
+  registry: SignalSourceRegistry,
+  runtime: IAgentRuntime,
+): LifeOpsTelemetryEvent | null {
+  const contribution = registry.get(signal.source);
+  if (contribution === null) {
+    runtime.reportError(
+      "lifeops.telemetry-mapping",
+      new ElizaError(
+        `No SignalSourceRegistry entry for source "${signal.source}"; telemetry row dropped`,
+        {
+          code: "LIFEOPS_UNREGISTERED_SIGNAL_SOURCE",
+          context: {
+            source: signal.source,
+            platform: signal.platform,
+            agentId: signal.agentId,
+          },
+          severity: "ephemeral",
+        },
+      ),
+    );
+    return null;
+  }
+  const payload = contribution.telemetryMapper(signal);
+  if (payload === null) return null;
+  const reliability = contribution.reliability(signal);
   return {
     id: crypto.randomUUID(),
     agentId: signal.agentId,

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -136,6 +136,7 @@ import {
   createAnchorRegistry,
   createEventKindRegistry,
   createFamilyRegistry,
+  createSignalSourceRegistry,
   createWorkflowStepRegistry,
   registerAnchorRegistry,
   registerAppLifeOpsAnchors,
@@ -147,6 +148,7 @@ import {
   registerDefaultWorkflowStepPack,
   registerEventKindRegistry,
   registerFamilyRegistry,
+  registerSignalSourceRegistry,
   registerWorkflowStepRegistry,
 } from "./lifeops/registries/index.js";
 import { LifeOpsRepository } from "./lifeops/repository.js";
@@ -177,6 +179,7 @@ import {
   createActivitySignalBus,
   registerActivitySignalBus,
 } from "./lifeops/signals/bus.js";
+import { registerBuiltinSignalSources } from "./lifeops/telemetry-mapping.js";
 import { threadOpsFieldEvaluator } from "./lifeops/work-threads/field-evaluator-thread-ops.js";
 import { isDarwin } from "./platform/host.js";
 import { browserBridgeProvider } from "./provider.js";
@@ -876,6 +879,13 @@ const rawPersonalAssistantPlugin: Plugin = {
     (
       runtime as IAgentRuntime & { busFamilyRegistry?: typeof familyRegistry }
     ).busFamilyRegistry = familyRegistry;
+
+    // Passive activity-signal source registry — the single extension point a
+    // plugin registers a new source through (ingestion allow-list + telemetry
+    // mapper + reliability), instead of the old three-package coordinated edit.
+    const signalSourceRegistry = createSignalSourceRegistry();
+    registerBuiltinSignalSources(signalSourceRegistry);
+    registerSignalSourceRegistry(runtime, signalSourceRegistry);
 
     const workflowStepRegistry = createWorkflowStepRegistry();
     registerDefaultWorkflowStepPack(workflowStepRegistry);


### PR DESCRIPTION
Closes #14690.

## Root cause

Adding one passive activity-signal source required coordinated edits across three packages:

- `LIFEOPS_ACTIVITY_SIGNAL_SOURCES` was a closed const in `@elizaos/shared`.
- `mapSignalToTelemetryPayload` was a closed switch in `plugin-personal-assistant`; its default branch silently dropped unmapped sources from the canonical telemetry store.
- `resolveActivitySignalReliability` was a closed reliability table in `plugin-health` keyed on that union.
- `plugin-health/src/contracts/lifeops.ts` carried a duplicated copy of the union.

Ingestion (`normalizeActivitySignalSource`) rejected any source outside the closed union, so a plugin could not contribute a runtime passive source such as `browser_activity`, `view_usage`, or `reaction_activity`. The bus side was already open (`LifeOpsBusFamily` + `FamilyRegistry`); the persisted-signal side was not.

## Fix

This opens the source vocabulary the same way `LifeOpsBusFamily` opened `LifeOpsTelemetryFamily`: closed core union plus open namespaced string, routed through a per-runtime `SignalSourceRegistry`.

Each source contributes one entry carrying both halves of interpretation: `{ telemetryMapper, reliability }`. Adding a source is now a single `registry.register(...)` call, without editing the shared contract, PA telemetry switch, or plugin-health reliability table.

- `registries/signal-source-registry.ts` adds `register` / `get` / `has` / `list` / `sources`, per-runtime `WeakMap` wiring, and built-in registration.
- `buildTelemetryEventFromSignal` dispatches through the registry. An unregistered source reports `LIFEOPS_UNREGISTERED_SIGNAL_SOURCE` through `runtime.reportError` instead of silently returning healthy-empty.
- Registered mappers that return `null` for a specific instance remain legitimate quiet no-row cases.
- Ingestion validates against `registry.sources()`, preserving built-in aliases while accepting registered contributed sources.
- Health reliability throws with `ElizaError` for contributed sources without built-in weights; awake-probability skips contributed sources rather than fabricating a weight.
- `plugin-health` imports/re-exports the canonical shared signal-source const/type/guard instead of duplicating the union.

## Verification

Replayed onto current `origin/develop` (`da4f3bf5ae`) and force-pushed rebased head `6e55f6010f`.

```text
bun test --conditions eliza-source \
  plugins/plugin-personal-assistant/src/lifeops/signal-source-registry.test.ts \
  plugins/plugin-personal-assistant/src/lifeops/telemetry-mapping.test.ts \
  plugins/plugin-personal-assistant/src/lifeops/scheduled-task/activity-gates.test.ts \
  plugins/plugin-health/src/sleep/source-reliability.test.ts \
  plugins/plugin-health/src/sleep/awake-probability.test.ts

35 pass, 0 fail, 102 expect() calls
```

Additional checks:

```text
bun run --cwd packages/shared typecheck
bunx @biomejs/biome check <17 touched files>
git diff --check origin/develop...HEAD
bun run audit:error-policy-ratchet --report
```

All passed. Full verification notes are in https://github.com/elizaOS/eliza/pull/15040#issuecomment-4890953334.

## Canonical evidence rows

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: `N/A - backend/runtime data-pipeline change; no UI surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: `N/A - backend/runtime data-pipeline change; no UI surface changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: `N/A - backend/runtime data-pipeline change; no user-facing flow changed`.

<!-- evidence-row:backend-logs -->
- [x] Backend/runtime verification: [verification comment](https://github.com/elizaOS/eliza/pull/15040#issuecomment-4890953334) shows the registry-dispatched ingestion/mapping path, observable unregistered-source error reporting, and fail-fast health reliability behavior.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: `N/A - no frontend code or network UI path changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: `N/A - no prompt, model, planner, action-selection, or agent-response behavior changed`.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [verification comment](https://github.com/elizaOS/eliza/pull/15040#issuecomment-4890953334) documents the persisted telemetry-row artifact exercised by `signal-source-registry.test.ts` for a contributed `browser_activity` source and the explicit error artifact for an unregistered source.
