### PR TITLE
fix(core): relay noop clarification on planner continuation exhaustion

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop-terminal-continuation-noop-relay.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-terminal-continuation-noop-relay.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Covers terminal-continuation recovery for no-op clarification actions. When a
+ * successful tool structurally marks its result as `noop: true`, its clarification
+ * question is the real user-facing outcome, so a stuck evaluator/planner loop must
+ * relay that question instead of replacing it with a generic trajectory-limit
+ * failure. Deterministic - vitest-mocked `useModel` + injected evaluator; no live
+ * model.
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { TrajectoryLimitExceeded } from "../limits";
+import { runPlannerLoop } from "../planner-loop";
+
+function plannerEmitsNoopThenTerminalText(terminalText: string) {
+	return {
+		useModel: vi
+			.fn()
+			.mockResolvedValueOnce({
+				text: "",
+				toolCalls: [
+					{
+						id: "call-1",
+						name: "OWNER_GOALS",
+						arguments: { action: "create_goal" },
+					},
+				],
+				usage: { promptTokens: 100, completionTokens: 10, totalTokens: 110 },
+			})
+			.mockResolvedValueOnce({
+				text: terminalText,
+				usage: { promptTokens: 100, completionTokens: 10, totalTokens: 110 },
+			}),
+	};
+}
+
+function evaluatorRequestsAnotherIteration() {
+	return vi.fn(async () => ({
+		success: true,
+		decision: "CONTINUE" as const,
+		thought: "The previous result needs a final response.",
+	}));
+}
+
+describe("planner-loop - terminal continuation noop clarification relay", () => {
+	it("relays a successful noop action's clarification when terminal-only continuation exhaustion would otherwise discard it", async () => {
+		const clarification =
+			"What would success look like for you: completing the 5K in a target time, distance, or consistency goal?";
+		const runtime = plannerEmitsNoopThenTerminalText(
+			"I need one more detail before I can set that goal.",
+		);
+		const executeToolCall = vi.fn(async () => ({
+			success: true,
+			text: clarification,
+			data: {
+				noop: true,
+				error: "NOOP_GOAL_UNGROUNDED",
+				suggestedOperation: "create_goal",
+			},
+		}));
+		const evaluate = evaluatorRequestsAnotherIteration();
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			config: { maxTerminalOnlyContinuations: 0 },
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(clarification);
+		expect(executeToolCall).toHaveBeenCalledTimes(1);
+		expect(evaluate).toHaveBeenCalledTimes(2);
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not leak diagnostic text when the successful tool lacks the noop marker", async () => {
+		const shellLog =
+			"$ cat secrets.txt\nexit 0\ncwd=/home/milady\nAWS_SECRET=leak-me";
+		const runtime = plannerEmitsNoopThenTerminalText(
+			"I need to call SHELL again before answering.",
+		);
+		const executeToolCall = vi.fn(async () => ({
+			success: true,
+			text: shellLog,
+		}));
+		const evaluate = evaluatorRequestsAnotherIteration();
+
+		await expect(
+			runPlannerLoop({
+				runtime,
+				context: { id: "ctx" },
+				config: { maxTerminalOnlyContinuations: 0 },
+				executeToolCall,
+				evaluate,
+			}),
+		).rejects.toMatchObject({
+			kind: "terminal_only_continuations",
+		} satisfies Partial<TrajectoryLimitExceeded>);
+	});
+
+	it("accepts the noop marker when ActionResult values were nested under data.values", async () => {
+		const clarification =
+			"Which deadline should I use before I create that reminder?";
+		const runtime = plannerEmitsNoopThenTerminalText(
+			"I need to keep working on the reminder.",
+		);
+		const executeToolCall = vi.fn(async () => ({
+			success: true,
+			text: clarification,
+			data: {
+				values: {
+					noop: true,
+				},
+			},
+		}));
+		const evaluate = evaluatorRequestsAnotherIteration();
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			config: { maxTerminalOnlyContinuations: 0 },
+			executeToolCall,
+			evaluate,
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(clarification);
+	});
+});

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -456,6 +456,27 @@ export async function runPlannerLoop(
 					}
 
 					terminalOnlyContinuations++;
+					if (terminalOnlyContinuations > config.maxTerminalOnlyContinuations) {
+						const relay =
+							deterministicTerminalContinuationLimitRelay(trajectory);
+						if (relay) {
+							params.runtime.logger?.warn?.(
+								{
+									iteration,
+									terminalOnlyContinuations,
+									maxTerminalOnlyContinuations:
+										config.maxTerminalOnlyContinuations,
+								},
+								"[planner-loop] terminal-only continuation limit reached; relaying the completed tool result instead of discarding the turn",
+							);
+							return {
+								status: "finished",
+								trajectory,
+								evaluator,
+								finalMessage: userSafeFinalMessage(relay, trajectory),
+							};
+						}
+					}
 					assertTrajectoryLimit({
 						kind: "terminal_only_continuations",
 						max: config.maxTerminalOnlyContinuations,
@@ -2795,6 +2816,44 @@ function deterministicSuccessfulToolRelay(
 		if (candidate) return candidate;
 	}
 	return undefined;
+}
+
+function deterministicTerminalContinuationLimitRelay(
+	trajectory: PlannerTrajectory,
+): string | undefined {
+	return (
+		deterministicSuccessfulToolRelay(trajectory) ??
+		deterministicNoopClarificationRelay(trajectory)
+	);
+}
+
+function deterministicNoopClarificationRelay(
+	trajectory: PlannerTrajectory,
+): string | undefined {
+	for (const step of [...trajectory.steps].reverse()) {
+		if (!step.toolCall || step.result?.success !== true) continue;
+		if (isTerminalToolCall(step.toolCall)) continue;
+		if (!hasNoopMarker(step.result)) continue;
+
+		const candidate = sanitizePlannerMessage(
+			step.result.userFacingText ?? step.result.text,
+		);
+		if (candidate && !isUnsafeUserVisibleText(candidate)) return candidate;
+	}
+	return undefined;
+}
+
+function hasNoopMarker(result: PlannerToolResult): boolean {
+	const data = result.data;
+	if (!data) return false;
+	if (data.noop === true) return true;
+	const values = data.values;
+	return (
+		values !== null &&
+		typeof values === "object" &&
+		!Array.isArray(values) &&
+		(values as Record<string, unknown>).noop === true
+	);
 }
 
 /**

--- a/packages/scenario-runner/src/seeds.test.ts
+++ b/packages/scenario-runner/src/seeds.test.ts
@@ -786,7 +786,6 @@ describe("scenario memory seeds", () => {
     }
   }, 120_000);
 
-
   it("maps rolodex-entity memory seeds into relationship contacts", async () => {
     const { ctx, relationships, runtime } = createSeedHarness();
 


### PR DESCRIPTION
Fixes #15030.

## Summary
- Relay a successful non-terminal tool result when terminal-only continuation exhaustion is about to throw, preserving existing opt-in `userFacingText` behavior.
- Add a narrow structural fallback for successful `data.noop === true` clarification actions so the action's clarification text can end the turn.
- Keep diagnostic `text` protected for ordinary tools; the negative regression test verifies shell/log-shaped output still throws instead of leaking.

## Validation
- `bun x biome check packages/core/src/runtime/planner-loop.ts packages/core/src/runtime/__tests__/planner-loop-terminal-continuation-noop-relay.test.ts`
- `bun test packages/core/src/runtime/__tests__/planner-loop-terminal-continuation-noop-relay.test.ts` (3 pass)
- `bun test packages/core/src/runtime/__tests__/planner-loop-post-tool-evaluator-failure.test.ts packages/core/src/runtime/__tests__/planner-loop-terminal-finish-without-message.test.ts packages/core/src/runtime/__tests__/planner-loop-terminal-continuation-noop-relay.test.ts` (9 pass)
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/core build:node`
- `git diff --check`
- `bun run audit:error-policy-ratchet`

## Evidence notes
- This is core planner-loop behavior, not a UI path; screenshots/video are N/A.
- I searched for an existing #15030 scenario and did not find one. The new deterministic unit test reproduces the issue shape directly: successful `OWNER_GOALS` noop clarification, evaluator CONTINUE, terminal-only continuation cap reached, and final message equals the clarification.
