### PR TITLE
fix(scenario-runner): fail generic runtime failure replies (#14696)

### DIFF
--- a/packages/scenario-runner/src/executor.test.ts
+++ b/packages/scenario-runner/src/executor.test.ts
@@ -1102,6 +1102,50 @@ describe("scenario executor action turns", () => {
     ]);
   });
 
+  it("fails turns that only receive the generic runtime failure reply", async () => {
+    const runtime = {
+      ...createRuntime([]),
+      messageService: {
+        handleMessage: vi.fn(async (_runtime, _message, callback) => {
+          await callback({
+            text: "Something went wrong on my end. Please try again.",
+          });
+          return {};
+        }),
+      },
+    } as unknown as AgentRuntime;
+
+    const report = await runScenario(
+      {
+        id: "generic-failure-reply",
+        title: "Generic failure reply",
+        domain: "executor",
+        turns: [
+          {
+            kind: "message",
+            name: "model fails",
+            text: "answer the user",
+          },
+        ],
+      },
+      runtime,
+      {
+        minJudgeScore: 0.8,
+        providerName: "unit-test",
+        turnTimeoutMs: 1_000,
+      },
+    );
+
+    expect(report.status).toBe("failed");
+    expect(report.turns[0]?.actionsCalled[0]).toMatchObject({
+      actionName: "REPLY",
+      result: { data: { source: "synthesized-reply" } },
+    });
+    expect(report.turns[0]?.failedAssertions).toEqual([
+      "runtimeFailureReply: model/runtime failure produced the generic apology; this cannot satisfy scenario evidence",
+    ]);
+  });
+
   it("matches expectedActions against the action selected during the turn", async () => {
     const runtime = createRuntime(
       [

--- a/packages/scenario-runner/src/executor.test.ts
+++ b/packages/scenario-runner/src/executor.test.ts
@@ -1102,6 +1102,9 @@ describe("scenario executor action turns", () => {
     ]);
   });
 
+  const RUNTIME_FAILURE_ASSERTION =
+    "runtimeFailureReply: the runtime returned a synthetic model/runtime failure reply (rate-limit, auth, credits, or generic apology); this cannot satisfy scenario evidence";
+
   it("fails turns that only receive the generic runtime failure reply", async () => {
     const runtime = {
       ...createRuntime([]),
@@ -1109,6 +1112,7 @@ describe("scenario executor action turns", () => {
         handleMessage: vi.fn(async (_runtime, _message, callback) => {
           await callback({
             text: "Something went wrong on my end. Please try again.",
+            elizaSyntheticFailure: true,
           });
           return {};
         }),
@@ -1142,7 +1146,52 @@ describe("scenario executor action turns", () => {
       result: { data: { source: "synthesized-reply" } },
     });
     expect(report.turns[0]?.failedAssertions).toEqual([
-      "runtimeFailureReply: model/runtime failure produced the generic apology; this cannot satisfy scenario evidence",
+      RUNTIME_FAILURE_ASSERTION,
+    ]);
+  });
+
+  // The synthetic failure reply varies by failure kind (rate-limit, auth,
+  // credits) and can be character-template-overridden, so keying on the
+  // structural `elizaSyntheticFailure` flag — not one apology string — is what
+  // stops a rate-limited live run (the most common failure) from false-passing.
+  it("fails turns on a non-generic synthetic failure reply via the structural flag", async () => {
+    const runtime = {
+      ...createRuntime([]),
+      messageService: {
+        handleMessage: vi.fn(async (_runtime, _message, callback) => {
+          await callback({
+            text: "My model provider is rate-limiting me right now — give it a few seconds and try again.",
+            elizaSyntheticFailure: true,
+          });
+          return {};
+        }),
+      },
+    } as unknown as AgentRuntime;
+
+    const report = await runScenario(
+      {
+        id: "rate-limit-failure-reply",
+        title: "Rate-limit failure reply",
+        domain: "executor",
+        turns: [
+          {
+            kind: "message",
+            name: "model is rate-limited",
+            text: "answer the user",
+          },
+        ],
+      },
+      runtime,
+      {
+        minJudgeScore: 0.8,
+        providerName: "unit-test",
+        turnTimeoutMs: 1_000,
+      },
+    );
+
+    expect(report.status).toBe("failed");
+    expect(report.turns[0]?.failedAssertions).toEqual([
+      RUNTIME_FAILURE_ASSERTION,
     ]);
   });
 

--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -117,6 +117,13 @@ function isSynthesizedReplyAction(
   return action.actionName === "REPLY" && data?.source === "synthesized-reply";
 }
 
+function isGenericRuntimeFailureReply(responseText: unknown): boolean {
+  return (
+    typeof responseText === "string" &&
+    responseText.trim() === "Something went wrong on my end. Please try again."
+  );
+}
+
 function stringifyForAssertion(value: unknown): string {
   if (typeof value === "string") {
     return value;
@@ -1815,6 +1822,12 @@ async function runTurnAssertions(
   const failures: string[] = [];
   let judgeScore: number | undefined;
   const kind = typeof turn.kind === "string" ? turn.kind : "message";
+
+  if (isGenericRuntimeFailureReply(execution.responseText)) {
+    failures.push(
+      "runtimeFailureReply: model/runtime failure produced the generic apology; this cannot satisfy scenario evidence",
+    );
+  }
 
   if (typeof turn.assertResponse === "function") {
     const result = turnUsesStatusResponse(kind)

--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -117,12 +117,13 @@ function isSynthesizedReplyAction(
   return action.actionName === "REPLY" && data?.source === "synthesized-reply";
 }
 
-function isGenericRuntimeFailureReply(responseText: unknown): boolean {
-  return (
-    typeof responseText === "string" &&
-    responseText.trim() === "Something went wrong on my end. Please try again."
-  );
-}
+// The runtime message callback receives full `Content`; the executor only
+// needs the reply text plus the structural failure marker set by
+// `buildStructuredFailureReply` (packages/core/src/services/message.ts).
+type SyntheticFailureAwareContent = {
+  text?: string;
+  elizaSyntheticFailure?: boolean;
+};
 
 function stringifyForAssertion(value: unknown): string {
   if (typeof value === "string") {
@@ -209,6 +210,7 @@ type ExecutedTurn = ScenarioTurnExecution & {
   apiBody?: unknown;
   durationMs?: number;
   reportResponseText?: string;
+  syntheticFailure?: boolean;
 };
 
 type ScenarioVariableState = {
@@ -1420,7 +1422,11 @@ async function executeMessageTurn(
   turnTimeoutMs: number,
   scenarioId: string,
   runId?: string,
-): Promise<{ responseText: string; durationMs: number }> {
+): Promise<{
+  responseText: string;
+  durationMs: number;
+  syntheticFailure: boolean;
+}> {
   const text =
     typeof turn.text === "string"
       ? String(resolveScenarioTemplates(turn.text, currentNow))
@@ -1461,10 +1467,10 @@ async function executeMessageTurn(
         handleMessage: (
           rt: AgentRuntime,
           memory: Memory,
-          cb: (content: { text?: string }) => Promise<unknown>,
+          cb: (content: SyntheticFailureAwareContent) => Promise<unknown>,
           options?: Record<string, unknown>,
         ) => Promise<{
-          responseContent?: { text?: string };
+          responseContent?: SyntheticFailureAwareContent;
           responseMessages?: Memory[];
         }>;
       };
@@ -1478,8 +1484,17 @@ async function executeMessageTurn(
 
   const startedAt = Date.now();
   let responseText = "";
-  const callback = async (content: { text?: string }): Promise<unknown[]> => {
+  // The runtime synthesizes a failure reply (rate-limit / auth / credits /
+  // generic apology) when a model call fails; it carries the structural
+  // `elizaSyntheticFailure` flag the chat DTO and recent-messages filter
+  // already key on. Capture it so the turn fails on the flag, not on matching
+  // one of several apology strings that drift and can be template-overridden.
+  let syntheticFailure = false;
+  const callback = async (
+    content: SyntheticFailureAwareContent,
+  ): Promise<unknown[]> => {
     if (content.text) responseText += content.text;
+    if (content.elizaSyntheticFailure === true) syntheticFailure = true;
     return [];
   };
   const timeoutMs =
@@ -1494,11 +1509,14 @@ async function executeMessageTurn(
   if (!responseText && result?.responseContent?.text) {
     responseText = result.responseContent.text;
   }
+  if (result?.responseContent?.elizaSyntheticFailure === true) {
+    syntheticFailure = true;
+  }
 
   // Let completed events settle.
   await new Promise((r) => setTimeout(r, 500));
 
-  return { responseText, durationMs: Date.now() - startedAt };
+  return { responseText, durationMs: Date.now() - startedAt, syntheticFailure };
 }
 
 async function executeActionTurn(
@@ -1823,9 +1841,9 @@ async function runTurnAssertions(
   let judgeScore: number | undefined;
   const kind = typeof turn.kind === "string" ? turn.kind : "message";
 
-  if (isGenericRuntimeFailureReply(execution.responseText)) {
+  if (execution.syntheticFailure === true) {
     failures.push(
-      "runtimeFailureReply: model/runtime failure produced the generic apology; this cannot satisfy scenario evidence",
+      "runtimeFailureReply: the runtime returned a synthetic model/runtime failure reply (rate-limit, auth, credits, or generic apology); this cannot satisfy scenario evidence",
     );
   }
 


### PR DESCRIPTION
Fixes #14696.

## Summary

The scenario runner now fails a message turn when the runtime returns the canonical generic failure apology:

```text
Something went wrong on my end. Please try again.
```

This closes a concrete MVP evidence gap found while reviewing #15041: `f1-cross-persona-privacy-minimization` reported `passed` even though the Codex CLI model call failed, the trajectory status was `errored`, native export wrote zero rows, and the judge scored the fallback apology as privacy-safe.

## Root cause

`runScenario()` accepted any non-empty message callback text as the turn response. If no action was captured, it synthesized a marker `REPLY` so conversational scenarios could still assert text-only replies. That is valid for real text-only completions, but the generic runtime failure reply is not product behavior and must not satisfy scenario assertions, final judges, or PR evidence.

## Fix

`runTurnAssertions()` now adds a failure when the response text exactly matches the runtime failure apology. Legitimate synthesized text replies still work; only the explicit failure apology is rejected.

A regression test reproduces the false-pass shape: a message turn with no assertions and only the generic apology now fails with `runtimeFailureReply`.

## Validation

```text
bun test --conditions eliza-source packages/scenario-runner/src/executor.test.ts
# 30 pass, 0 fail, 92 expect() calls

bunx @biomejs/biome check packages/scenario-runner/src/executor.ts packages/scenario-runner/src/executor.test.ts
# Checked 2 files. No fixes applied.

git diff --check origin/develop...HEAD
# clean

bun run audit:error-policy-ratchet --report
# no new fallback-slop in touched files
```

`bun run --cwd packages/scenario-runner typecheck` was attempted and is still blocked by the existing workspace-link/type baseline (missing optional plugin subpaths plus unrelated UI/shared dist drift); no diagnostic points at these two touched files.

## Evidence

The concrete false-pass source is documented on #14696: https://github.com/elizaOS/eliza/issues/14696#issuecomment-4891018016

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: `N/A - scenario-runner backend/test harness change; no UI surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: `N/A - scenario-runner backend/test harness change; no UI surface changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: `N/A - scenario-runner backend/test harness change; no user-facing UI flow changed`.

<!-- evidence-row:backend-logs -->
- [x] Backend/test logs: [#14696 false-pass evidence](https://github.com/elizaOS/eliza/issues/14696#issuecomment-4891018016) plus the validation commands above show the runner failure condition and regression test.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: `N/A - no frontend code changed`.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory evidence: [#14696 false-pass evidence](https://github.com/elizaOS/eliza/issues/14696#issuecomment-4891018016) documents the rejected live trajectory shape: model runtime error, `trajectory.status="errored"`, zero native rows, and zero token/cost metrics.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [#14696 false-pass evidence](https://github.com/elizaOS/eliza/issues/14696#issuecomment-4891018016) documents the generated `report.json`, `native.manifest.json`, empty `native.jsonl`, and errored trajectory that motivated this guard.
