### PR TITLE
fix(evidence): require OCR in review wrappers (#15045)

### DIFF
--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -25,6 +25,12 @@ export const SURFACE_ARTIFACT_ROW_IDS = [
   "after-screenshots",
   "walkthrough-video",
 ];
+export const SURFACE_OCR_EVIDENCE_ROW = {
+  id: "ocr-review",
+  label: "OCR visual text review",
+};
+const OCR_EVIDENCE_RE =
+  /\bOCR\b|ocr-triage|mvp:visual-verify|audit:app:verify|tesseract|text readout/i;
 
 const MARKER_RE = /<!--\s*evidence-row:([a-z0-9-]+)\s*-->/gi;
 const RETIRED_REPO_EVIDENCE_PATH = [
@@ -51,6 +57,15 @@ export function parseLabels(value) {
 export function requiresSurfaceArtifacts(labels) {
   const labelSet = new Set(parseLabels(labels));
   return SURFACE_EVIDENCE_LABELS.some((label) => labelSet.has(label));
+}
+
+export function hasOcrEvidenceReference(rows) {
+  for (const rowText of rows.values()) {
+    if (OCR_EVIDENCE_RE.test(rowText) && hasArtifactReference(rowText)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function hasNaWithReason(text) {
@@ -182,6 +197,10 @@ export function evaluatePrEvidence(
         : "blank",
     };
   });
+  if (surfaceArtifactsRequired && !hasOcrEvidenceReference(rows)) {
+    findings.push({ ...SURFACE_OCR_EVIDENCE_ROW, status: "ocr-required" });
+  }
+
   return {
     ok: findings.every((finding) => finding.status === "ok"),
     findings,
@@ -224,7 +243,7 @@ function usage() {
 Options:
   --body-file <path>  Read the PR body from a file (default: stdin).
   --labels <labels>   Comma-separated PR labels; ui/frontend/native require
-                      concrete screenshot/video artifacts.
+                      concrete screenshot/video artifacts and linked OCR proof.
   --changed-files-file <path>
                       Reject committed files under retired repo evidence paths.
   --json              Print machine-readable findings JSON.
@@ -247,7 +266,7 @@ function buildFixtureBody(overrides = {}) {
     "llm-trajectory":
       "- [ ] Real-LLM trajectory: [report](https://example.com/report.json)",
     "domain-artifacts":
-      "- [ ] Domain artifacts `N/A - no domain artifacts produced`.",
+      "- [ ] Domain artifacts: OCR report https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000007",
   };
   const merged = { ...defaults, ...overrides };
   return REQUIRED_EVIDENCE_ROWS.map(
@@ -315,6 +334,10 @@ function runSelfTest() {
       failures.push(
         "ui-labeled screenshot/video rows should require artifacts",
       );
+    }
+    const ocr = findings.find((finding) => finding.id === "ocr-review");
+    if (ocr?.status !== "ocr-required") {
+      failures.push("ui-labeled evidence should require OCR proof");
     }
   }
 
@@ -418,6 +441,7 @@ function main() {
       `\nEvidence gate FAILED: ${bad.length} row(s) blank or missing, ${retiredEvidenceFiles.length} retired repo evidence file(s) changed. ` +
         "Attach the artifact inline (GitHub attachment URL) or write `N/A - <reason>` on each row. " +
         "For ui/frontend/native PRs, before/after screenshots and walkthrough video require concrete inline artifact links. " +
+        "Surface PRs also require linked OCR evidence from the visual review/audit. " +
         "Retired repo-local evidence paths do not count as evidence and must not be committed.",
     );
     process.exit(1);

--- a/scripts/check-pr-evidence.test.mjs
+++ b/scripts/check-pr-evidence.test.mjs
@@ -16,6 +16,7 @@ import {
   findRetiredRepoEvidenceFiles,
   hasArtifactReference,
   hasNaWithReason,
+  hasOcrEvidenceReference,
   isChecked,
   isRowSatisfied,
   isRowSatisfiedForContext,
@@ -46,7 +47,7 @@ function buildBody(overrides = {}) {
     "llm-trajectory":
       "- [ ] Real-LLM trajectory: [report](https://example.com/report.json)",
     "domain-artifacts":
-      "- [ ] Domain artifacts `N/A - no domain artifacts produced`.",
+      "- [ ] Domain artifacts: OCR report https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000007",
   };
   const merged = { ...defaults, ...overrides };
   return REQUIRED_EVIDENCE_ROWS.map(
@@ -127,9 +128,13 @@ describe("check-pr-evidence parser", () => {
         "artifact-required",
       );
     }
+    assert.equal(
+      findings.find((finding) => finding.id === "ocr-review").status,
+      "ocr-required",
+    );
   });
 
-  it("passes UI-labeled PRs when screenshot/video rows have concrete artifacts", () => {
+  it("passes UI-labeled PRs when screenshot/video rows and OCR proof have concrete artifacts", () => {
     const { ok, findings } = evaluatePrEvidence(
       buildBody({
         "before-screenshots":
@@ -138,12 +143,36 @@ describe("check-pr-evidence parser", () => {
           "- [ ] After screenshots: https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000003",
         "walkthrough-video":
           "- [ ] Walkthrough video: https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000004",
+        "domain-artifacts":
+          "- [ ] OCR text readout: https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000008",
       }),
       REQUIRED_EVIDENCE_ROWS,
       { labels: "frontend" },
     );
     assert.equal(ok, true);
     assert.ok(findings.every((finding) => finding.status === "ok"));
+  });
+
+  it("fails UI-labeled PRs when screenshot/video artifacts omit OCR proof", () => {
+    const { ok, findings } = evaluatePrEvidence(
+      buildBody({
+        "before-screenshots":
+          "- [ ] Before screenshots: https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000002",
+        "after-screenshots":
+          "- [ ] After screenshots: https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000003",
+        "walkthrough-video":
+          "- [ ] Walkthrough video: https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000004",
+        "domain-artifacts":
+          "- [ ] Domain artifacts `N/A - no domain artifacts produced`.",
+      }),
+      REQUIRED_EVIDENCE_ROWS,
+      { labels: "ui" },
+    );
+    assert.equal(ok, false);
+    assert.equal(
+      findings.find((finding) => finding.id === "ocr-review").status,
+      "ocr-required",
+    );
   });
 
   it("fails on a bare `N/A` with no reason", () => {
@@ -207,6 +236,22 @@ describe("check-pr-evidence row primitives", () => {
       true,
     );
     assert.equal(hasArtifactReference("just words, no artifact"), false);
+  });
+
+  it("detects linked OCR evidence without accepting keyword-only prose", () => {
+    const rows = new Map([
+      [
+        "domain-artifacts",
+        "- [ ] OCR report: https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000009",
+      ],
+    ]);
+    assert.equal(hasOcrEvidenceReference(rows), true);
+    assert.equal(
+      hasOcrEvidenceReference(
+        new Map([["domain-artifacts", "- [ ] OCR report was reviewed"]]),
+      ),
+      false,
+    );
   });
 
   it("rejects retired repo-local evidence paths", () => {

--- a/scripts/e2e-recordings/run-all-require-evidence.test.mjs
+++ b/scripts/e2e-recordings/run-all-require-evidence.test.mjs
@@ -3,7 +3,7 @@
 // --require-evidence (auto-on under CI) so a headless runner that captured zero
 // artifacts fails the run, while preserving the soft-skip behavior otherwise.
 import { describe, expect, it } from "vitest";
-import { classifyRunResults } from "./run-all.mjs";
+import { classifyRunResults, parseRunAllArgs } from "./run-all.mjs";
 
 const passedSuite = { name: "app", passed: true, skipped: false, exitCode: 0 };
 const failedSuite = {
@@ -21,6 +21,19 @@ const skippedSuite = {
 };
 
 describe("classifyRunResults require-evidence contract (#13624)", () => {
+  it("requires OCR for generated evidence review dashboards", () => {
+    expect(parseRunAllArgs(["--review"]).reviewOcr).toBe("on");
+    expect(parseRunAllArgs(["--review", "--review-ocr=on"]).reviewOcr).toBe(
+      "on",
+    );
+    expect(() => parseRunAllArgs(["--review", "--review-ocr=off"])).toThrow(
+      /--review-ocr must be on/,
+    );
+    expect(() => parseRunAllArgs(["--review", "--review-ocr=auto"])).toThrow(
+      /--review-ocr must be on/,
+    );
+  });
+
   it("without require-evidence: a skip stays a soft skip and does not fail the run", () => {
     const c = classifyRunResults([passedSuite, skippedSuite], false);
     expect(c.passed.map((r) => r.name)).toEqual(["app"]);

--- a/scripts/e2e-recordings/run-all.mjs
+++ b/scripts/e2e-recordings/run-all.mjs
@@ -16,7 +16,7 @@
  *   --skip-viewer             Skip generating the viewer index
  *   --review                  Generate evidence/index.html for manual review
  *   --open-review             Open the generated evidence review dashboard
- *   --review-ocr=auto|on|off  OCR mode for --review. Default: off
+ *   --review-ocr=on           OCR mode for --review. Packaged OCR is required.
  */
 
 import { spawnSync } from "node:child_process";
@@ -34,35 +34,61 @@ const SCRIPTS_DIR = __dirname;
 const PACKAGES = UI_E2E_SUITES;
 
 // ─── CLI argument parsing ────────────────────────────────────────────────────
-const args = process.argv.slice(2);
-const flagMap = new Map();
-for (const arg of args) {
-  const [key, val] = arg.replace(/^--/, "").split("=");
-  flagMap.set(key, val ?? true);
+export function parseRunAllArgs(argv) {
+  const flagMap = new Map();
+  for (const arg of argv) {
+    const [key, val] = arg.replace(/^--/, "").split("=");
+    flagMap.set(key, val ?? true);
+  }
+
+  const reviewOcr = flagMap.has("review-ocr")
+    ? String(flagMap.get("review-ocr"))
+    : "on";
+  if (reviewOcr !== "on") {
+    throw new Error(
+      "--review-ocr must be on; OCR is required for evidence review and uses the packaged tesseract.js dependency",
+    );
+  }
+
+  return {
+    onlyPackages: flagMap.has("packages")
+      ? String(flagMap.get("packages"))
+          .split(",")
+          .map((s) => s.trim())
+      : null,
+    skipTests:
+      flagMap.get("skip-tests") === true ||
+      flagMap.get("skip-tests") === "true",
+    skipSheets:
+      flagMap.get("skip-sheets") === true ||
+      flagMap.get("skip-sheets") === "true",
+    skipViewer:
+      flagMap.get("skip-viewer") === true ||
+      flagMap.get("skip-viewer") === "true",
+    review:
+      flagMap.get("review") === true ||
+      flagMap.get("review") === "true" ||
+      flagMap.get("open-review") === true ||
+      flagMap.get("open-review") === "true",
+    openReview:
+      flagMap.get("open-review") === true ||
+      flagMap.get("open-review") === "true",
+    reviewOcr,
+    requireEvidence: resolveRequireEvidence(argv),
+  };
 }
 
-const onlyPackages = flagMap.has("packages")
-  ? String(flagMap.get("packages"))
-      .split(",")
-      .map((s) => s.trim())
-  : null;
-
-const skipTests =
-  flagMap.get("skip-tests") === true || flagMap.get("skip-tests") === "true";
-const skipSheets =
-  flagMap.get("skip-sheets") === true || flagMap.get("skip-sheets") === "true";
-const skipViewer =
-  flagMap.get("skip-viewer") === true || flagMap.get("skip-viewer") === "true";
-const review =
-  flagMap.get("review") === true ||
-  flagMap.get("review") === "true" ||
-  flagMap.get("open-review") === true ||
-  flagMap.get("open-review") === "true";
-const openReview =
-  flagMap.get("open-review") === true || flagMap.get("open-review") === "true";
-const reviewOcr = flagMap.has("review-ocr")
-  ? String(flagMap.get("review-ocr"))
-  : "off";
+const args = process.argv.slice(2);
+const {
+  onlyPackages,
+  skipTests,
+  skipSheets,
+  skipViewer,
+  review,
+  openReview,
+  reviewOcr,
+  requireEvidence,
+} = parseRunAllArgs(args);
 
 // When evidence is required (explicit --require-evidence, or auto-on under CI),
 // a suite that soft-skips (SKIP_EXIT_CODE=77, missing dir/script/package.json,
@@ -71,8 +97,6 @@ const reviewOcr = flagMap.has("review-ocr")
 // a headless runner with nothing captured (#13624 "green-with-nothing"). We
 // hand argv explicitly (stripping the `=value` join key parsing above only
 // affects flagMap; resolveRequireEvidence re-scans raw argv).
-const requireEvidence = resolveRequireEvidence(args);
-
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function banner(text) {

--- a/scripts/evidence-review/run-matrix.mjs
+++ b/scripts/evidence-review/run-matrix.mjs
@@ -113,7 +113,7 @@ Options:
   --out=<dir>              Output directory for matrix-run.json and reviewer.
   --review / --no-review   Generate the evidence reviewer after the matrix.
   --open / --no-open       Open the reviewer after generation. Default: no-open.
-  --review-ocr=on|auto|off OCR mode passed to evidence:review. Default: on.
+  --review-ocr=on          OCR mode passed to evidence:review. Packaged OCR is required.
   --stop-on-failure        Stop after the first failed step.
   --dry-run                Write a planned manifest without executing commands.
   --help, -h               Show this help.`);
@@ -156,8 +156,10 @@ export function parseMatrixArgs(argv) {
     }
   }
 
-  if (!["auto", "on", "off"].includes(options.reviewOcr)) {
-    throw new Error("--review-ocr must be auto, on, or off");
+  if (options.reviewOcr !== "on") {
+    throw new Error(
+      "--review-ocr must be on; OCR is required for evidence review and uses the packaged tesseract.js dependency",
+    );
   }
   return options;
 }

--- a/scripts/evidence-review/run-matrix.test.mjs
+++ b/scripts/evidence-review/run-matrix.test.mjs
@@ -72,13 +72,13 @@ test("can skip device lanes while keeping test and visual evidence lanes", () =>
   );
 });
 
-test("validates explicit step ids and OCR mode", () => {
+test("validates explicit step ids and requires OCR", () => {
   const options = parseMatrixArgs([
     "--only=e2e-recordings,app-audit",
-    "--review-ocr=auto",
+    "--review-ocr=on",
     "--open",
   ]);
-  assert.equal(options.reviewOcr, "auto");
+  assert.equal(options.reviewOcr, "on");
   assert.equal(options.open, true);
   assert.deepEqual(
     selectMatrixSteps(MATRIX_STEPS, options).map((step) => step.id),
@@ -89,8 +89,12 @@ test("validates explicit step ids and OCR mode", () => {
     /unknown matrix step/,
   );
   assert.throws(
-    () => parseMatrixArgs(["--review-ocr=yes"]),
-    /--review-ocr must be auto, on, or off/,
+    () => parseMatrixArgs(["--review-ocr=off"]),
+    /--review-ocr must be on/,
+  );
+  assert.throws(
+    () => parseMatrixArgs(["--review-ocr=auto"]),
+    /--review-ocr must be on/,
   );
 });
 


### PR DESCRIPTION
Fixes #15045.

## Summary

Tightens the end-of-work evidence path so OCR cannot be silently skipped when generating or reviewing MVP UI evidence:

- `scripts/e2e-recordings/run-all.mjs` now defaults `--review-ocr` to `on` and rejects `off`/`auto`.
- `scripts/evidence-review/run-matrix.mjs` now rejects `off`/`auto` as well; the matrix always calls the packaged OCR-backed reviewer with required OCR.
- `scripts/check-pr-evidence.mjs` now requires `ui`/`frontend`/`native` PR bodies to include linked OCR/audit proof in addition to concrete screenshot/video artifacts.
- Added parser coverage proving the required OCR default, explicit failure cases, and UI evidence rejection when screenshot/video links omit OCR proof.

The lower-level evidence reviewer still owns the packaged `tesseract.js` engine path. These wrappers and PR gates now enforce that the MVP evidence workflow uses it instead of producing or accepting an OCR-less review.

## Validation

```text
bun test scripts/check-pr-evidence.test.mjs scripts/evidence-review/evidence-review.test.mjs scripts/e2e-recordings/run-all-require-evidence.test.mjs scripts/evidence-review/run-matrix.test.mjs
# 49 pass, 0 fail

node scripts/check-pr-evidence.mjs --self-test
# check-pr-evidence self-test passed (9 cases).

bunx @biomejs/biome check --write scripts/check-pr-evidence.mjs scripts/check-pr-evidence.test.mjs scripts/e2e-recordings/run-all.mjs scripts/e2e-recordings/run-all-require-evidence.test.mjs scripts/evidence-review/run-matrix.mjs scripts/evidence-review/run-matrix.test.mjs
# Checked 6 files. No fixes applied.

git diff --check
# clean

bun run audit:error-policy-ratchet --report
# 0 changed production source file(s); no new fallback-slop in touched files
```

CLI probes:

```text
node scripts/evidence-review/run-matrix.mjs --dry-run --skip-devices --only=e2e-recordings --no-review
node -e 'const fs=require("fs"); const m=JSON.parse(fs.readFileSync("evidence/matrix-run.json","utf8")); console.log(JSON.stringify({reviewOcr:m.options.reviewOcr,status:m.status,steps:m.steps.map(s=>[s.id,s.status])}))'
# {"reviewOcr":"on","status":"planned","steps":[["e2e-recordings","planned"]]}

node scripts/e2e-recordings/run-all.mjs --review-ocr=off --skip-tests --skip-sheets --skip-viewer --no-review
# exits 1: --review-ocr must be on; OCR is required for evidence review and uses the packaged tesseract.js dependency

node scripts/e2e-recordings/run-all.mjs --skip-tests --skip-sheets --skip-viewer --no-review
# exits 0; default parser path still works
```

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: `N/A - evidence tooling change; no app UI surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: `N/A - evidence tooling change; no app UI surface changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: `N/A - evidence tooling change; no interactive user-facing flow changed`.

<!-- evidence-row:backend-logs -->
- [x] Backend/test logs: https://github.com/elizaOS/eliza/issues/15045#issuecomment-4891176744

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: `N/A - no frontend runtime code changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory evidence: `N/A - no agent/action/prompt/model behavior changed`.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: https://github.com/elizaOS/eliza/issues/15045#issuecomment-4891176744