### PR TITLE
fix(scenarios): render scheduled dispatches in strict mode

### DIFF
--- a/packages/scenario-runner/src/runtime-factory.test.ts
+++ b/packages/scenario-runner/src/runtime-factory.test.ts
@@ -3,7 +3,10 @@ import { ModelType } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
   clearLlmWireMockEnvForLiveProvider,
+  deterministicScheduledDispatchRenderText,
+  isScheduledDispatchRenderPrompt,
   loadScenarioTestMocksForTests,
+  resolveScenarioDeterministicLlmCall,
   resolveScenarioProviderConfig,
   shouldUseDeterministicLlmProxy,
   shouldUseStrictDeterministicLlmProxy,
@@ -64,6 +67,75 @@ describe("scenario runtime deterministic LLM proxy mode", () => {
     await expect(
       plugin.models?.[ModelType.TEXT_EMBEDDING]?.({} as never, "hello"),
     ).resolves.toEqual([0, 0, 0]);
+  });
+
+  it("recognizes scheduled-dispatch render prompts and returns deterministic owner-facing text", () => {
+    const prompt = [
+      "You are the owner's personal assistant. A scheduled task just fired and you must now write the message to send to the owner.",
+      "The instruction below tells you what to communicate. It is an instruction to you, not the message itself — never repeat or quote it verbatim.",
+      "Write only the message body, speaking directly to the owner in a natural assistant voice.",
+      "Do not mention scheduled tasks, instructions, or that this message was automated. No preamble, no markdown fences, no meta commentary.",
+      "",
+      "Instruction:",
+      "Remind the owner to stretch for five minutes.",
+      "",
+      "Fired at: 2026-07-05T09:00:00.000Z",
+      "",
+      "Message:",
+    ].join("\n");
+
+    expect(isScheduledDispatchRenderPrompt(prompt)).toBe(true);
+    expect(deterministicScheduledDispatchRenderText(prompt)).toBe(
+      "Quick nudge: stretch for five minutes.",
+    );
+    expect(deterministicScheduledDispatchRenderText(prompt)).not.toContain(
+      "Remind the owner",
+    );
+    expect(isScheduledDispatchRenderPrompt("ordinary TEXT_LARGE prompt")).toBe(
+      false,
+    );
+  });
+
+  it("resolves the scheduled-dispatch render model call outside the fixture registry", () => {
+    const prompt = [
+      "You are the owner's personal assistant. A scheduled task just fired and you must now write the message to send to the owner.",
+      "The instruction below tells you what to communicate. It is an instruction to you, not the message itself — never repeat or quote it verbatim.",
+      "Write only the message body, speaking directly to the owner in a natural assistant voice.",
+      "Do not mention scheduled tasks, instructions, or that this message was automated. No preamble, no markdown fences, no meta commentary.",
+      "",
+      "Instruction:",
+      "Ask the owner to take a short walk.",
+      "",
+      "Fired at: 2026-07-05T09:00:00.000Z",
+      "",
+      "Message:",
+    ].join("\n");
+
+    expect(
+      resolveScenarioDeterministicLlmCall({
+        modelType: ModelType.TEXT_LARGE,
+        params: { prompt },
+        latestUserText: "",
+      }),
+    ).toBe("Quick nudge: take a short walk.");
+    expect(
+      resolveScenarioDeterministicLlmCall({
+        modelType: ModelType.TEXT_LARGE,
+        params: {
+          messages: [
+            { role: "user", content: [{ type: "text", text: prompt }] },
+          ],
+        },
+        latestUserText: "",
+      }),
+    ).toBe("Quick nudge: take a short walk.");
+    expect(
+      resolveScenarioDeterministicLlmCall({
+        modelType: ModelType.TEXT_SMALL,
+        params: { prompt },
+        latestUserText: "",
+      }),
+    ).toBeNull();
   });
 });
 

--- a/packages/scenario-runner/src/runtime-factory.ts
+++ b/packages/scenario-runner/src/runtime-factory.ts
@@ -75,6 +75,10 @@ export async function loadScenarioTestMocksForTests() {
 
 const DETERMINISTIC_LLM_PROXY_PROVIDER_NAME =
   "deterministic-llm-proxy" as const;
+const SCHEDULED_DISPATCH_RENDER_PROMPT_PREFIX =
+  "You are the owner's personal assistant. A scheduled task just fired and you must now write the message to send to the owner.";
+const SCHEDULED_DISPATCH_RENDER_INSTRUCTION_MARKER = "\nInstruction:\n";
+const SCHEDULED_DISPATCH_RENDER_FIRED_AT_MARKER = "\n\nFired at:";
 
 async function createScenarioKnowledgeGraphPlugin(): Promise<Plugin> {
   const agentPackageName: string = "@elizaos/agent";
@@ -246,6 +250,104 @@ function deterministicLlmProxyProviderConfig(): RuntimeFactoryResult["providerCo
     env: {},
     pluginPackage: null,
   };
+}
+
+export function isScheduledDispatchRenderPrompt(prompt: string): boolean {
+  return (
+    prompt.startsWith(SCHEDULED_DISPATCH_RENDER_PROMPT_PREFIX) &&
+    prompt.includes(SCHEDULED_DISPATCH_RENDER_INSTRUCTION_MARKER) &&
+    prompt.includes(SCHEDULED_DISPATCH_RENDER_FIRED_AT_MARKER) &&
+    prompt.trimEnd().endsWith("Message:")
+  );
+}
+
+export function deterministicScheduledDispatchRenderText(
+  prompt: string,
+): string {
+  const instructionStart = prompt.indexOf(
+    SCHEDULED_DISPATCH_RENDER_INSTRUCTION_MARKER,
+  );
+  const firedAtStart = prompt.indexOf(
+    SCHEDULED_DISPATCH_RENDER_FIRED_AT_MARKER,
+  );
+  const instruction =
+    instructionStart >= 0 && firedAtStart > instructionStart
+      ? prompt
+          .slice(
+            instructionStart +
+              SCHEDULED_DISPATCH_RENDER_INSTRUCTION_MARKER.length,
+            firedAtStart,
+          )
+          .trim()
+      : "";
+  const ownerMessage = instruction
+    .replace(/^remind the owner to\s+/i, "")
+    .replace(/^ask the owner to\s+/i, "")
+    .replace(/^tell the owner to\s+/i, "")
+    .replace(/^gentle check-in:\s*/i, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return ownerMessage
+    ? `Quick nudge: ${ownerMessage}`
+    : "Quick nudge: checking in.";
+}
+
+type ScenarioDeterministicLlmCall = {
+  modelType?: unknown;
+  latestUserText?: unknown;
+  params?: {
+    prompt?: unknown;
+    messages?: unknown;
+  };
+};
+
+function isRecordLike(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+function chatContentText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      if (typeof part === "string") return part;
+      if (isRecordLike(part) && typeof part.text === "string") return part.text;
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function deterministicCallTextCandidates(
+  call: ScenarioDeterministicLlmCall,
+): string[] {
+  const candidates: string[] = [];
+  if (typeof call.params?.prompt === "string") {
+    candidates.push(call.params.prompt);
+  }
+  if (typeof call.latestUserText === "string") {
+    candidates.push(call.latestUserText);
+  }
+  if (Array.isArray(call.params?.messages)) {
+    for (const message of call.params.messages) {
+      if (!isRecordLike(message)) continue;
+      const text = chatContentText(message.content);
+      if (text) candidates.push(text);
+    }
+  }
+  return candidates;
+}
+
+export function resolveScenarioDeterministicLlmCall(
+  call: ScenarioDeterministicLlmCall,
+): string | null {
+  if (call.modelType !== ModelType.TEXT_LARGE) {
+    return null;
+  }
+  const prompt = deterministicCallTextCandidates(call).find(
+    isScheduledDispatchRenderPrompt,
+  );
+  return prompt ? deterministicScheduledDispatchRenderText(prompt) : null;
 }
 
 export function resolveScenarioProviderConfig(
@@ -462,6 +564,7 @@ export async function createScenarioRuntime(
   if (providerConfig.name === DETERMINISTIC_LLM_PROXY_PROVIDER_NAME) {
     const deterministicLlmProxyPlugin = createDeterministicLlmProxyPlugin({
       strict: shouldUseStrictDeterministicLlmProxy(),
+      resolve: resolveScenarioDeterministicLlmCall,
     });
     await runtime.registerPlugin(deterministicLlmProxyPlugin);
     const runtimeWithScenarioFixtures = runtime as AgentRuntime & {

--- a/plugins/plugin-health/vitest.config.ts
+++ b/plugins/plugin-health/vitest.config.ts
@@ -12,6 +12,9 @@ import {
 // Cross-plugin gate coverage must exercise sibling source, not stale dist.
 const aliases = {
   ...providerSdkAliases,
+  "@elizaos/shared": fileURLToPath(
+    new URL("../../packages/shared/src/index.ts", import.meta.url),
+  ),
   "@elizaos/tui": fileURLToPath(
     new URL("../../packages/tui/src/index.ts", import.meta.url),
   ),


### PR DESCRIPTION
Fixes #15024.

## Summary

Teaches the scenario-runner deterministic LLM proxy how to answer the scheduled-dispatch render prompt in strict mode. The resolver is registered outside the per-scenario fixture registry, so executor fixture resets do not remove it, and strict deterministic scenario runs no longer turn scheduled-task dispatch rendering into retryable `transport_error` failures.

The production dispatch path still calls `runtime.useModel(ModelType.TEXT_LARGE)` and still fails fast when the model surface is unavailable. This only affects the scenario-runner deterministic proxy lane.

## Validation

Before fix:
- `lowact-quiet-streak-softens-next-nudge` failed in strict deterministic mode.
- Scheduled-task fire ticks returned `status:"scheduled", reason:"retry:transport_error"`.
- Final failure: `assertResponse: expected exactly one timeout for the reminder, saw []`.

After fix, independently rerun by Codex:

```text
TZ=UTC EVAL_MODEL_PROVIDER=deterministic CEREBRAS_API_KEY= EVAL_CEREBRAS_API_KEY= ELIZA_E2E_CEREBRAS_API_KEY= SCENARIO_USE_LLM_PROXY=1 SCENARIO_LLM_PROXY_STRICT=1 bun --conditions eliza-source --tsconfig-override ../../tsconfig.json src/cli.ts run ../../plugins/plugin-personal-assistant/test/scenarios --scenario lowact-quiet-streak-softens-next-nudge --lane pr-deterministic --report /tmp/eliza-15047/lowact-after.json --run-dir /tmp/eliza-15047/run-after
# Scenario run e9e0a98f-67cd-4a37-a168-707f6d5ac4b5
# lowact-quiet-streak-softens-next-nudge passed
# Totals: 1 passed, 0 failed, 0 skipped of 1

bun test --conditions eliza-source packages/scenario-runner/src/runtime-factory.test.ts
# 15 pass, 0 fail, 39 expect() calls
```

Manual report review parsed the embedded scheduled-task payloads: four `scheduledTaskFires` entries with `status:"fired", reason:"once_due"`; four completion timeout entries, including the final reminder `status:"skipped", reason:"no_reply_reminder_expired"`; final task states match the expected expired check-ins and skipped reminder.

Known validation caveat:
- `bun run --cwd packages/scenario-runner typecheck` currently fails before this diff on existing workspace resolution/type issues, including missing optional package declarations such as `@elizaos/plugin-discord/service`, `@elizaos/plugin-elizacloud/host-routes`, `@elizaos/plugin-scheduling`, and unrelated UI/shared background/voice event type errors. The package build and targeted `eliza-source` test both pass.

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: `N/A - scenario-runner deterministic harness change; no app UI surface changed`.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: `N/A - scenario-runner deterministic harness change; no app UI surface changed`.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: `N/A - scenario-runner deterministic harness change; no interactive UI flow changed`.

<!-- evidence-row:backend-logs -->
- [x] Backend/test logs: https://github.com/elizaOS/eliza/issues/15024#issuecomment-4891213278

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: `N/A - no frontend runtime code changed`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory evidence: `N/A - deterministic scenario-runner proxy harness only; no live model behavior changed`.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: https://github.com/elizaOS/eliza/issues/15024#issuecomment-4891213278