### PR TITLE
fix(scenario-runner): materialize remaining MVP memory seeds

### DIFF
--- a/packages/scenario-runner/src/seeds.test.ts
+++ b/packages/scenario-runner/src/seeds.test.ts
@@ -819,10 +819,19 @@ describe("scenario memory seeds", () => {
         primaryUserId: ownerId,
       } as ScenarioContext;
 
+      const missingEventResult = await applyScenarioSeedStep(ctx, {
+        type: "memory",
+        content: {
+          kind: "scheduled-push-ladder",
+          eventId: "missing-event",
+          rungs: [{ offsetMin: -10, channel: "mobile", status: "pending" }],
+        },
+      } satisfies ScenarioSeedStep);
       const appointmentResult = await applyScenarioSeedStep(ctx, {
         type: "memory",
         content: {
           kind: "appointment",
+          id: "evt-investor-sync",
           provider: "Westside Imaging",
           startAt: "2026-07-06T20:00:00.000Z",
           requiresSignature: true,
@@ -841,6 +850,9 @@ describe("scenario memory seeds", () => {
         },
       } satisfies ScenarioSeedStep);
 
+      expect(missingEventResult).toMatch(
+        /requires a previously seeded calendar event/,
+      );
       expect(appointmentResult).toBeUndefined();
       expect(ladderResult).toBeUndefined();
       const { LifeOpsRepository } = await import(
@@ -891,6 +903,20 @@ describe("scenario memory seeds", () => {
               index: 0,
             },
           }),
+          trigger: {
+            kind: "once",
+            atIso: "2026-07-06T19:00:00.000Z",
+          },
+        }),
+      );
+      expect(scheduledTasks).toContainEqual(
+        expect.objectContaining({
+          taskId:
+            "scenario-scheduled-push-ladder:push.scheduled-notification-cancel-when-event-cancelled:evt-investor-sync:1:mobile",
+          trigger: {
+            kind: "once",
+            atIso: "2026-07-06T19:50:00.000Z",
+          },
         }),
       );
     } finally {

--- a/packages/scenario-runner/src/seeds.test.ts
+++ b/packages/scenario-runner/src/seeds.test.ts
@@ -52,6 +52,14 @@ type LifeOpsReminderAttemptForTest = {
   reviewStatus?: string | null;
 };
 
+type LifeOpsBrowserSessionForTest = {
+  id: string;
+  title: string;
+  status: string;
+  result: Record<string, unknown>;
+  metadata: Record<string, unknown>;
+};
+
 let activeServer: http.Server | null = null;
 const originalGoogleBase = process.env.ELIZA_MOCK_GOOGLE_BASE;
 
@@ -786,6 +794,301 @@ describe("scenario memory seeds", () => {
     }
   }, 120_000);
 
+  it("maps appointment and scheduled-push-ladder seeds into calendar and scheduled-task state", async () => {
+    const harness = await createRealTestRuntime({
+      withLLM: false,
+      characterName: "scenario-appointment-ladder-seed-test",
+    });
+    try {
+      const roomId = stringToUuid("scenario-appointment-ladder-room");
+      const ownerId = stringToUuid("scenario-appointment-ladder-owner");
+      await harness.runtime.ensureConnection({
+        entityId: ownerId,
+        roomId,
+        worldId: stringToUuid("scenario-appointment-ladder-world"),
+        userName: "Scenario owner",
+        source: "scenario-runner",
+        channelId: roomId,
+        type: "DM",
+      });
+      const ctx = {
+        runtime: harness.runtime,
+        scenarioId: "push.scheduled-notification-cancel-when-event-cancelled",
+        now: "2026-07-06T14:00:00.000Z",
+        primaryRoomId: roomId,
+        primaryUserId: ownerId,
+      } as ScenarioContext;
+
+      const appointmentResult = await applyScenarioSeedStep(ctx, {
+        type: "memory",
+        content: {
+          kind: "appointment",
+          provider: "Westside Imaging",
+          startAt: "2026-07-06T20:00:00.000Z",
+          requiresSignature: true,
+          signatureCompleted: false,
+        },
+      } satisfies ScenarioSeedStep);
+      const ladderResult = await applyScenarioSeedStep(ctx, {
+        type: "memory",
+        content: {
+          kind: "scheduled-push-ladder",
+          eventId: "evt-investor-sync",
+          rungs: [
+            { offsetMin: -60, channel: "desktop", status: "pending" },
+            { offsetMin: -10, channel: "mobile", status: "pending" },
+          ],
+        },
+      } satisfies ScenarioSeedStep);
+
+      expect(appointmentResult).toBeUndefined();
+      expect(ladderResult).toBeUndefined();
+      const { LifeOpsRepository } = await import(
+        "../../../plugins/plugin-personal-assistant/src/lifeops/repository.ts"
+      );
+      const repository = new LifeOpsRepository(harness.runtime);
+      const events = await repository.listCalendarEvents(
+        String(harness.runtime.agentId),
+        "google",
+        "2026-07-06T19:30:00.000Z",
+        "2026-07-06T21:00:00.000Z",
+      );
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          title: "Westside Imaging appointment",
+          startAt: "2026-07-06T20:00:00.000Z",
+          metadata: expect.objectContaining({
+            source: "scenario-seed",
+            appointment: expect.objectContaining({
+              provider: "Westside Imaging",
+              requiresSignature: true,
+              signatureCompleted: false,
+            }),
+          }),
+        }),
+      );
+
+      const scheduledTasks = await repository.listScheduledTasks(
+        String(harness.runtime.agentId),
+        { kind: "reminder", status: "scheduled" },
+      );
+      expect(
+        scheduledTasks.filter(
+          (task: LifeOpsScheduledTaskForTest) =>
+            task.metadata?.seedKind === "scheduled-push-ladder",
+        ),
+      ).toHaveLength(2);
+      expect(scheduledTasks).toContainEqual(
+        expect.objectContaining({
+          taskId:
+            "scenario-scheduled-push-ladder:push.scheduled-notification-cancel-when-event-cancelled:evt-investor-sync:0:desktop",
+          metadata: expect.objectContaining({
+            eventId: "evt-investor-sync",
+            rung: {
+              offsetMin: -60,
+              channel: "desktop",
+              status: "pending",
+              index: 0,
+            },
+          }),
+        }),
+      );
+    } finally {
+      await harness.cleanup();
+    }
+  }, 120_000);
+
+  it("maps browser-task-state seeds into browser workflow sessions", async () => {
+    const harness = await createRealTestRuntime({
+      withLLM: false,
+      characterName: "scenario-browser-task-seed-test",
+    });
+    try {
+      const roomId = stringToUuid("scenario-browser-task-room");
+      const ownerId = stringToUuid("scenario-browser-task-owner");
+      await harness.runtime.ensureConnection({
+        entityId: ownerId,
+        roomId,
+        worldId: stringToUuid("scenario-browser-task-world"),
+        userName: "Scenario owner",
+        source: "scenario-runner",
+        channelId: roomId,
+        type: "DM",
+      });
+      const ctx = {
+        runtime: harness.runtime,
+        scenarioId: "push.stuck-agent-calls-user-CAPTCHA",
+        now: "2026-07-06T14:00:00.000Z",
+        primaryRoomId: roomId,
+        primaryUserId: ownerId,
+      } as ScenarioContext;
+
+      const result = await applyScenarioSeedStep(ctx, {
+        type: "memory",
+        content: {
+          kind: "browser-task-state",
+          task: "United online check-in",
+          blockedBy: "CAPTCHA",
+          attempts: 2,
+        },
+      } satisfies ScenarioSeedStep);
+
+      expect(result).toBeUndefined();
+      const { LifeOpsRepository } = await import(
+        "../../../plugins/plugin-personal-assistant/src/lifeops/repository.ts"
+      );
+      const repository = new LifeOpsRepository(harness.runtime);
+      const sessions = (await repository.listBrowserSessions(
+        String(harness.runtime.agentId),
+      )) as LifeOpsBrowserSessionForTest[];
+      expect(sessions).toContainEqual(
+        expect.objectContaining({
+          title: "United online check-in",
+          status: "failed",
+          result: {
+            browserTask: {
+              task: "United online check-in",
+              blockedBy: "CAPTCHA",
+              attempts: 2,
+              state: "blocked",
+            },
+          },
+          metadata: expect.objectContaining({
+            source: "scenario-seed",
+            seedKind: "browser-task-state",
+          }),
+        }),
+      );
+    } finally {
+      await harness.cleanup();
+    }
+  }, 120_000);
+
+  it("maps follow-up, digest, and voice-attempt seeds into LifeOps scheduled state", async () => {
+    const harness = await createRealTestRuntime({
+      withLLM: false,
+      characterName: "scenario-followup-state-seed-test",
+    });
+    try {
+      const roomId = stringToUuid("scenario-followup-state-room");
+      const ownerId = stringToUuid("scenario-followup-state-owner");
+      await harness.runtime.ensureConnection({
+        entityId: ownerId,
+        roomId,
+        worldId: stringToUuid("scenario-followup-state-world"),
+        userName: "Scenario owner",
+        source: "scenario-runner",
+        channelId: roomId,
+        type: "DM",
+      });
+      const ctx = {
+        runtime: harness.runtime,
+        scenarioId: "followup.list-overdue-by-priority",
+        now: "2026-07-06T14:00:00.000Z",
+        primaryRoomId: roomId,
+        primaryUserId: ownerId,
+      } as ScenarioContext;
+
+      await applyScenarioSeedStep(ctx, {
+        type: "memory",
+        content: {
+          kind: "overdue-followup",
+          name: "Reply to Acme VIP customer",
+          priority: "vip",
+          overdueAt: "2026-07-01T14:00:00.000Z",
+        },
+      } satisfies ScenarioSeedStep);
+      await applyScenarioSeedStep(ctx, {
+        type: "memory",
+        content: {
+          kind: "pending-low-urgency-pushes",
+          items: [
+            { title: "Send newsletter draft", category: "writing" },
+            { title: "Archive old email labels", category: "inbox" },
+          ],
+        },
+      } satisfies ScenarioSeedStep);
+      await applyScenarioSeedStep(ctx, {
+        type: "memory",
+        content: {
+          kind: "voice-call-attempt",
+          outcome: "voicemail",
+          attemptedAt: "2026-07-06T13:55:00.000Z",
+          reason: "CAPTCHA on United check-in",
+        },
+      } satisfies ScenarioSeedStep);
+
+      const { LifeOpsRepository } = (await import(
+        "../../../plugins/plugin-personal-assistant/src/lifeops/repository.ts"
+      )) as {
+        LifeOpsRepository: new (
+          runtime: AgentRuntime,
+        ) => {
+          listScheduledTasks: (
+            agentId: string,
+            filter?: Record<string, unknown>,
+          ) => Promise<LifeOpsScheduledTaskForTest[]>;
+          listReminderAttempts: (
+            agentId: string,
+            filter?: Record<string, unknown>,
+          ) => Promise<LifeOpsReminderAttemptForTest[]>;
+        };
+      };
+      const repository = new LifeOpsRepository(harness.runtime);
+      const scheduledTasks = await repository.listScheduledTasks(
+        String(harness.runtime.agentId),
+        { status: "scheduled" },
+      );
+      expect(scheduledTasks).toContainEqual(
+        expect.objectContaining({
+          taskId:
+            "scenario-overdue-followup:followup.list-overdue-by-priority:Reply to Acme VIP customer",
+          priority: "high",
+          metadata: expect.objectContaining({
+            seedKind: "overdue-followup",
+            followup: expect.objectContaining({
+              topic: null,
+              overdueAt: "2026-07-01T14:00:00.000Z",
+            }),
+          }),
+        }),
+      );
+      expect(scheduledTasks).toContainEqual(
+        expect.objectContaining({
+          taskId:
+            "scenario-pending-low-urgency-pushes:followup.list-overdue-by-priority:Low-urgency digest",
+          priority: "low",
+          metadata: expect.objectContaining({
+            seedKind: "pending-low-urgency-pushes",
+            digest: expect.objectContaining({
+              titles: ["Send newsletter draft", "Archive old email labels"],
+            }),
+          }),
+        }),
+      );
+
+      const attempts = await repository.listReminderAttempts(
+        String(harness.runtime.agentId),
+        {
+          planId:
+            "scenario-reminder-plan:followup.list-overdue-by-priority:CAPTCHA on United check-in",
+        },
+      );
+      expect(attempts).toContainEqual(
+        expect.objectContaining({
+          channel: "voice",
+          outcome: "blocked_connector",
+          deliveryMetadata: expect.objectContaining({
+            result: "failed",
+            title: "CAPTCHA on United check-in",
+          }),
+        }),
+      );
+    } finally {
+      await harness.cleanup();
+    }
+  }, 120_000);
+
   it("maps rolodex-entity memory seeds into relationship contacts", async () => {
     const { ctx, relationships, runtime } = createSeedHarness();
 
@@ -1000,12 +1303,14 @@ describe("scenario memory seeds", () => {
     const result = await applyScenarioSeedStep(ctx, {
       type: "memory",
       content: {
-        kind: "voice-call-attempt",
+        kind: "future-unsupported-kind",
         text: "hello",
       },
     } satisfies ScenarioSeedStep);
 
-    expect(result).toMatch(/unsupported memory seed kind "voice-call-attempt"/);
+    expect(result).toMatch(
+      /unsupported memory seed kind "future-unsupported-kind"/,
+    );
     expect(result).toContain("user-state");
     expect(createMemory).not.toHaveBeenCalled();
     expect(relationships.addContact).not.toHaveBeenCalled();

--- a/packages/scenario-runner/src/seeds.ts
+++ b/packages/scenario-runner/src/seeds.ts
@@ -50,6 +50,32 @@ type LifeOpsScheduledTask = Record<string, unknown> & {
   metadata?: Record<string, unknown>;
 };
 
+type LifeOpsBrowserSessionSeedInput = {
+  id: string;
+  agentId: string;
+  domain: string;
+  subjectType: string;
+  subjectId: string;
+  visibilityScope: string;
+  contextPolicy: string;
+  workflowId: string | null;
+  browser: string | null;
+  companionId: string | null;
+  profileId: string | null;
+  windowId: string | null;
+  tabId: string | null;
+  title: string;
+  status: string;
+  actions: Record<string, unknown>[];
+  currentActionIndex: number;
+  awaitingConfirmationForActionId: string | null;
+  result: Record<string, unknown>;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+  finishedAt: string | null;
+};
+
 type LifeOpsReminderAttempt = Record<string, unknown> & {
   id: string;
   agentId: string;
@@ -112,6 +138,12 @@ type LifeOpsRepositoryInstance = {
     agentId: string,
     options?: Record<string, unknown>,
   ) => Promise<LifeOpsReminderAttempt[]>;
+  createBrowserSession: (
+    session: LifeOpsBrowserSessionSeedInput,
+  ) => Promise<unknown>;
+  listBrowserSessions: (
+    agentId: string,
+  ) => Promise<LifeOpsBrowserSessionSeedInput[]>;
   upsertCalendarEvent: (
     event: LifeOpsCalendarEventSeedInput,
     side?: LifeOpsCalendarEventSeedInput["side"],
@@ -310,6 +342,58 @@ type ReminderAttemptMemorySeed = {
   result?: unknown;
   statusCode?: unknown;
   topic?: unknown;
+};
+
+type ScheduledPushLadderSeed = {
+  kind?: unknown;
+  type?: unknown;
+  eventId?: unknown;
+  rungs?: unknown;
+};
+
+type ScheduledPushLadderRungSeed = {
+  offsetMin?: unknown;
+  channel?: unknown;
+  status?: unknown;
+};
+
+type AppointmentMemorySeed = CalendarEventMemorySeed & {
+  provider?: unknown;
+  requiresSignature?: unknown;
+  signatureCompleted?: unknown;
+  cancellationPolicy?: unknown;
+};
+
+type BrowserTaskStateMemorySeed = {
+  kind?: unknown;
+  type?: unknown;
+  task?: unknown;
+  blockedBy?: unknown;
+  attempts?: unknown;
+};
+
+type FollowupMemorySeed = {
+  kind?: unknown;
+  type?: unknown;
+  title?: unknown;
+  name?: unknown;
+  topic?: unknown;
+  counterparty?: unknown;
+  platformOfOrigin?: unknown;
+  sentProposal?: unknown;
+  sentAt?: unknown;
+  response?: unknown;
+  firstAskedAt?: unknown;
+  blockedPeople?: unknown;
+  options?: unknown;
+  bumpedTimes?: unknown;
+  overdueAt?: unknown;
+  priority?: unknown;
+  scheduledAt?: unknown;
+  attendee?: unknown;
+  reason?: unknown;
+  channelsTried?: unknown;
+  urgency?: unknown;
 };
 
 type LadderStateMemorySeed = {
@@ -855,7 +939,14 @@ function normalizeScheduledTaskPriority(
   if (text === "low" || text === "medium" || text === "high") {
     return text;
   }
-  if (text === "urgent") return "high";
+  if (
+    text === "urgent" ||
+    text === "critical" ||
+    text === "vip" ||
+    text === "board"
+  ) {
+    return "high";
+  }
   return "medium";
 }
 
@@ -1172,6 +1263,63 @@ async function seedQueuedPushMemory(
   return undefined;
 }
 
+function scenarioTaskId(
+  ctx: ScenarioContext,
+  seedKind: string,
+  discriminator: string,
+): string {
+  return `scenario-${seedKind}:${ctx.scenarioId ?? "unknown"}:${discriminator}`;
+}
+
+async function upsertScenarioScheduledTask(
+  ctx: ScenarioContext,
+  args: {
+    seedKind: string;
+    title: string;
+    taskKind?: string;
+    dueAt?: Date;
+    priority?: unknown;
+    status?: string;
+    subjectKind?: string;
+    subjectId?: string;
+    metadata?: Record<string, unknown>;
+  },
+): Promise<string | undefined> {
+  const runtime = requireRuntime(ctx);
+  const dueAt = args.dueAt ?? readScenarioNow(ctx);
+  const { LifeOpsRepository } = await loadLifeOps();
+  await LifeOpsRepository.bootstrapSchema(runtime);
+  const repository = new LifeOpsRepository(runtime);
+  const taskId = scenarioTaskId(ctx, args.seedKind, args.title);
+  await repository.upsertScheduledTask(
+    String(runtime.agentId),
+    {
+      taskId,
+      kind: args.taskKind ?? "reminder",
+      promptInstructions: args.title,
+      trigger: { kind: "once", atIso: dueAt.toISOString() },
+      priority: normalizeScheduledTaskPriority(args.priority),
+      respectsGlobalPause: true,
+      state: { status: args.status ?? "scheduled", followupCount: 0 },
+      source: "scenario_seed",
+      createdBy: String(runtime.agentId),
+      ownerVisible: true,
+      subject:
+        args.subjectKind && args.subjectId
+          ? { kind: args.subjectKind, id: args.subjectId }
+          : undefined,
+      metadata: {
+        source: "scenario-seed",
+        scenarioId: ctx.scenarioId ?? null,
+        seedKind: args.seedKind,
+        ...(args.metadata ?? {}),
+      },
+    },
+    { nextFireAtIso: dueAt.toISOString() },
+  );
+  return undefined;
+}
+
 function normalizeDeviceIntentTargets(value: unknown): string[] {
   const targets = readStringArray(value);
   return targets.length > 0 ? targets : ["all"];
@@ -1400,6 +1548,49 @@ async function seedLadderStateMemory(
   return undefined;
 }
 
+async function seedScheduledPushLadderMemory(
+  ctx: ScenarioContext,
+  seed: ScheduledPushLadderSeed,
+): Promise<string | undefined> {
+  const eventId = readNonEmptyString(seed.eventId);
+  if (!eventId) {
+    return "scheduled-push-ladder seed requires an eventId";
+  }
+  if (!Array.isArray(seed.rungs) || seed.rungs.length === 0) {
+    return "scheduled-push-ladder seed requires a non-empty rungs array";
+  }
+  const now = readScenarioNow(ctx);
+  for (const [index, entry] of seed.rungs.entries()) {
+    const rung =
+      entry && typeof entry === "object" && !Array.isArray(entry)
+        ? (entry as ScheduledPushLadderRungSeed)
+        : null;
+    if (!rung) {
+      return "scheduled-push-ladder rungs must be objects";
+    }
+    const offsetMin = readOptionalNumber(rung.offsetMin) ?? 0;
+    const channel = normalizeReminderAttemptChannel(rung.channel);
+    const status = readNonEmptyString(rung.status) ?? "pending";
+    const dueAt = new Date(now.getTime() + offsetMin * 60_000);
+    const result = await upsertScenarioScheduledTask(ctx, {
+      seedKind: "scheduled-push-ladder",
+      title: `${eventId}:${index}:${channel}`,
+      taskKind: "reminder",
+      dueAt,
+      priority: "medium",
+      status: status === "cancelled" ? "cancelled" : "scheduled",
+      subjectKind: "calendar_event",
+      subjectId: eventId,
+      metadata: {
+        eventId,
+        rung: { offsetMin, channel, status, index },
+      },
+    });
+    if (result) return result;
+  }
+  return undefined;
+}
+
 function normalizeCalendarProvider(
   value: unknown,
 ): LifeOpsCalendarEventSeedInput["provider"] | null {
@@ -1548,6 +1739,248 @@ async function seedCalendarEventMemory(
   const repository = new LifeOpsRepository(runtime);
   await repository.upsertCalendarEvent(event, event.side);
   return undefined;
+}
+
+async function seedAppointmentMemory(
+  ctx: ScenarioContext,
+  seed: AppointmentMemorySeed,
+): Promise<string | undefined> {
+  const provider = readNonEmptyString(seed.provider);
+  const startAt = readNonEmptyString(seed.startAt);
+  if (!provider || !startAt) {
+    return "appointment memory seed requires provider and startAt";
+  }
+  const result = await seedCalendarEventMemory(ctx, {
+    ...seed,
+    kind: "calendar-event",
+    provider: "google",
+    title:
+      readNonEmptyString(seed.title) ??
+      `${provider}${provider.toLowerCase().includes("appointment") ? "" : " appointment"}`,
+    description:
+      readNonEmptyString(seed.description) ??
+      [
+        readNonEmptyString(seed.cancellationPolicy)
+          ? `Cancellation policy: ${readNonEmptyString(seed.cancellationPolicy)}`
+          : null,
+        readOptionalBoolean(seed.requiresSignature) !== undefined
+          ? `Requires signature: ${readOptionalBoolean(seed.requiresSignature)}`
+          : null,
+        readOptionalBoolean(seed.signatureCompleted) !== undefined
+          ? `Signature completed: ${readOptionalBoolean(seed.signatureCompleted)}`
+          : null,
+      ]
+        .filter((entry): entry is string => entry !== null)
+        .join("\n"),
+    metadata: {
+      ...(readOptionalRecord(seed.metadata) ?? {}),
+      appointment: {
+        provider,
+        cancellationPolicy: readNonEmptyString(seed.cancellationPolicy),
+        requiresSignature: readOptionalBoolean(seed.requiresSignature),
+        signatureCompleted: readOptionalBoolean(seed.signatureCompleted),
+      },
+    },
+  });
+  if (result) return result;
+  return writeDurableFact(
+    ctx,
+    formatStructuredMemoryFact("appointment", seed),
+    {
+      seedKind: "appointment",
+    },
+  );
+}
+
+async function seedBrowserTaskStateMemory(
+  ctx: ScenarioContext,
+  seed: BrowserTaskStateMemorySeed,
+): Promise<string | undefined> {
+  const task = readNonEmptyString(seed.task);
+  if (!task) {
+    return "browser-task-state seed requires a task";
+  }
+  const runtime = requireRuntime(ctx);
+  const blockedBy = readNonEmptyString(seed.blockedBy);
+  const attempts = readOptionalNumber(seed.attempts);
+  const now = readScenarioNow(ctx).toISOString();
+  const { LifeOpsRepository } = await loadLifeOps();
+  await LifeOpsRepository.bootstrapSchema(runtime);
+  const repository = new LifeOpsRepository(runtime);
+  await repository.createBrowserSession({
+    id: scenarioTaskId(ctx, "browser-task-state", task),
+    agentId: String(runtime.agentId),
+    domain: "user_lifeops",
+    subjectType: "owner",
+    subjectId: String(runtime.agentId),
+    visibilityScope: "owner_only",
+    contextPolicy: "allowed_in_private_chat",
+    workflowId: scenarioTaskId(ctx, "browser-workflow", task),
+    browser: null,
+    companionId: null,
+    profileId: null,
+    windowId: null,
+    tabId: null,
+    title: task,
+    status: blockedBy ? "failed" : "running",
+    actions: [],
+    currentActionIndex: 0,
+    awaitingConfirmationForActionId: null,
+    result: {
+      browserTask: {
+        task,
+        blockedBy,
+        attempts,
+        state: blockedBy ? "blocked" : "running",
+      },
+    },
+    metadata: {
+      source: "scenario-seed",
+      scenarioId: ctx.scenarioId ?? null,
+      seedKind: "browser-task-state",
+      task,
+      blockedBy,
+      attempts,
+    },
+    createdAt: now,
+    updatedAt: now,
+    finishedAt: blockedBy ? now : null,
+  });
+  return writeDurableFact(
+    ctx,
+    formatStructuredMemoryFact("browser-task-state", seed),
+    { seedKind: "browser-task-state" },
+  );
+}
+
+function followupTitle(seed: FollowupMemorySeed, fallback: string): string {
+  return (
+    readNonEmptyString(seed.title) ??
+    readNonEmptyString(seed.name) ??
+    readNonEmptyString(seed.topic) ??
+    fallback
+  );
+}
+
+function followupDueAt(ctx: ScenarioContext, seed: FollowupMemorySeed): Date {
+  return (
+    readIsoDate(seed.overdueAt) ??
+    readIsoDate(seed.firstAskedAt) ??
+    readIsoDate(seed.sentAt) ??
+    readIsoDate(seed.scheduledAt) ??
+    readScenarioNow(ctx)
+  );
+}
+
+async function seedFollowupMemory(
+  ctx: ScenarioContext,
+  seed: FollowupMemorySeed,
+  seedKind: string,
+): Promise<string | undefined> {
+  const title = followupTitle(seed, seedKind);
+  const status = seedKind === "missed-event" ? "fired" : "scheduled";
+  const result = await upsertScenarioScheduledTask(ctx, {
+    seedKind,
+    title,
+    taskKind:
+      seedKind === "open-decision"
+        ? "approval"
+        : seedKind === "missed-event"
+          ? "checkin"
+          : "reminder",
+    dueAt: followupDueAt(ctx, seed),
+    priority:
+      readNonEmptyString(seed.priority) ?? readNonEmptyString(seed.urgency),
+    status,
+    subjectKind: seedKind.includes("thread") ? "thread" : "owner",
+    subjectId:
+      readNonEmptyString(seed.counterparty) ??
+      readNonEmptyString(seed.attendee) ??
+      readNonEmptyString(seed.topic) ??
+      String(requireRuntime(ctx).agentId),
+    metadata: {
+      followup: {
+        kind: seedKind,
+        topic: readNonEmptyString(seed.topic),
+        counterparty:
+          readNonEmptyString(seed.counterparty) ??
+          readNonEmptyString(seed.attendee),
+        platformOfOrigin: readNonEmptyString(seed.platformOfOrigin),
+        sentProposal: readNonEmptyString(seed.sentProposal),
+        sentAt: readNonEmptyString(seed.sentAt),
+        firstAskedAt: readNonEmptyString(seed.firstAskedAt),
+        blockedPeople: readStringArray(seed.blockedPeople),
+        options: Array.isArray(seed.options) ? seed.options : [],
+        bumpedTimes: readOptionalNumber(seed.bumpedTimes),
+        overdueAt: readNonEmptyString(seed.overdueAt),
+        reason: readNonEmptyString(seed.reason),
+        channelsTried: readStringArray(seed.channelsTried),
+        urgency: readNonEmptyString(seed.urgency),
+      },
+    },
+  });
+  if (result) return result;
+  return writeDurableFact(ctx, formatStructuredMemoryFact(seedKind, seed), {
+    seedKind,
+  });
+}
+
+async function seedPendingLowUrgencyPushesMemory(
+  ctx: ScenarioContext,
+  seed: Record<string, unknown>,
+): Promise<string | undefined> {
+  const items = Array.isArray(seed.items) ? seed.items : [];
+  if (items.length === 0) {
+    return "pending-low-urgency-pushes seed requires a non-empty items array";
+  }
+  const titles: string[] = [];
+  for (const item of items) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    const title = readNonEmptyString((item as { title?: unknown }).title);
+    if (title) titles.push(title);
+  }
+  if (titles.length === 0) {
+    return "pending-low-urgency-pushes seed items require titles";
+  }
+  const result = await upsertScenarioScheduledTask(ctx, {
+    seedKind: "pending-low-urgency-pushes",
+    title: "Low-urgency digest",
+    taskKind: "reminder",
+    dueAt: readScenarioNow(ctx),
+    priority: "low",
+    metadata: {
+      digest: {
+        items,
+        titles,
+      },
+    },
+  });
+  if (result) return result;
+  return writeDurableFact(
+    ctx,
+    formatStructuredMemoryFact("pending-low-urgency-pushes", seed),
+    { seedKind: "pending-low-urgency-pushes" },
+  );
+}
+
+async function seedVoiceCallAttemptMemory(
+  ctx: ScenarioContext,
+  seed: ReminderAttemptMemorySeed & Record<string, unknown>,
+): Promise<string | undefined> {
+  const outcome = readNonEmptyString(seed.outcome);
+  return seedReminderAttemptMemory(ctx, {
+    ...seed,
+    kind: "voice-call-attempt",
+    channel: "voice",
+    result:
+      outcome === "voicemail" || outcome === "failed" || outcome === "missed"
+        ? "failed"
+        : outcome,
+    title:
+      readNonEmptyString(seed.reason) ??
+      readNonEmptyString(seed.title) ??
+      "Voice call attempt",
+  });
 }
 
 function inboundMessageSenderName(seed: InboundMessageMemorySeed): string {
@@ -1786,6 +2219,43 @@ async function seedMemory(
   if (memoryType === "ladder-state") {
     return seedLadderStateMemory(ctx, content as LadderStateMemorySeed);
   }
+  if (memoryType === "scheduled-push-ladder") {
+    return seedScheduledPushLadderMemory(
+      ctx,
+      content as ScheduledPushLadderSeed,
+    );
+  }
+  if (memoryType === "appointment") {
+    return seedAppointmentMemory(ctx, content as AppointmentMemorySeed);
+  }
+  if (memoryType === "browser-task-state") {
+    return seedBrowserTaskStateMemory(
+      ctx,
+      content as BrowserTaskStateMemorySeed,
+    );
+  }
+  if (
+    memoryType === "missed-event" ||
+    memoryType === "open-decision" ||
+    memoryType === "open-followup" ||
+    memoryType === "open-thread" ||
+    memoryType === "overdue-followup" ||
+    memoryType === "stalled-thread"
+  ) {
+    return seedFollowupMemory(ctx, content as FollowupMemorySeed, memoryType);
+  }
+  if (memoryType === "pending-low-urgency-pushes") {
+    return seedPendingLowUrgencyPushesMemory(
+      ctx,
+      content as Record<string, unknown>,
+    );
+  }
+  if (memoryType === "voice-call-attempt") {
+    return seedVoiceCallAttemptMemory(
+      ctx,
+      content as ReminderAttemptMemorySeed & Record<string, unknown>,
+    );
+  }
   if (memoryType && TRAVEL_FACT_MEMORY_KINDS.has(memoryType)) {
     const text = formatStructuredMemoryFact(memoryType, content);
     return writeDurableFact(ctx, text, { seedKind: memoryType });
@@ -1800,7 +2270,7 @@ async function seedMemory(
     // A seed the runner cannot land must fail the scenario, never no-op:
     // a silently dropped seed fabricates the premise the checks grade
     // against (#14631 — the "seeded VIP fact" the model never received).
-    return `unsupported memory seed kind "${memoryType}" — supported: contact/rolodex-entity/merged-entity/calendar-event/inbound-message/user-state/focus-window-active/queued-push/device-intent/push-delivery-attempt/outbound-push-attempt/ladder-state, travel profile/trip/booking/upgrade-offer/calendar-focus-window, or plain { text } for a durable owner fact`;
+    return `unsupported memory seed kind "${memoryType}" — supported: contact/rolodex-entity/merged-entity/calendar-event/appointment/inbound-message/user-state/focus-window-active/queued-push/device-intent/push-delivery-attempt/outbound-push-attempt/voice-call-attempt/ladder-state/scheduled-push-ladder/browser-task-state/follow-up state kinds, travel profile/trip/booking/upgrade-offer/calendar-focus-window, or plain { text } for a durable owner fact`;
   }
   const text = readNonEmptyString((content as { text?: unknown }).text);
   if (!text) {

--- a/packages/scenario-runner/src/seeds.ts
+++ b/packages/scenario-runner/src/seeds.ts
@@ -121,6 +121,12 @@ type LifeOpsCalendarEventSeedInput = {
   accountEmail?: string;
 };
 
+type LifeOpsCalendarEvent = {
+  id: string;
+  externalId: string;
+  startAt: string;
+};
+
 type LifeOpsRepositoryInstance = {
   createDefinition: (definition: LifeOpsTaskDefinition) => Promise<unknown>;
   upsertOccurrence: (occurrence: LifeOpsOccurrence) => Promise<unknown>;
@@ -148,6 +154,13 @@ type LifeOpsRepositoryInstance = {
     event: LifeOpsCalendarEventSeedInput,
     side?: LifeOpsCalendarEventSeedInput["side"],
   ) => Promise<unknown>;
+  listCalendarEvents: (
+    agentId: string,
+    provider: LifeOpsCalendarEventSeedInput["provider"],
+    timeMin?: string,
+    timeMax?: string,
+    side?: LifeOpsCalendarEventSeedInput["side"],
+  ) => Promise<LifeOpsCalendarEvent[]>;
 };
 
 type LifeOpsRepositoryConstructor = {
@@ -1559,7 +1572,10 @@ async function seedScheduledPushLadderMemory(
   if (!Array.isArray(seed.rungs) || seed.rungs.length === 0) {
     return "scheduled-push-ladder seed requires a non-empty rungs array";
   }
-  const now = readScenarioNow(ctx);
+  const eventStartAt = await resolveScenarioCalendarEventStart(ctx, eventId);
+  if (!eventStartAt) {
+    return `scheduled-push-ladder seed requires a previously seeded calendar event matching eventId "${eventId}"`;
+  }
   for (const [index, entry] of seed.rungs.entries()) {
     const rung =
       entry && typeof entry === "object" && !Array.isArray(entry)
@@ -1571,7 +1587,7 @@ async function seedScheduledPushLadderMemory(
     const offsetMin = readOptionalNumber(rung.offsetMin) ?? 0;
     const channel = normalizeReminderAttemptChannel(rung.channel);
     const status = readNonEmptyString(rung.status) ?? "pending";
-    const dueAt = new Date(now.getTime() + offsetMin * 60_000);
+    const dueAt = new Date(eventStartAt.getTime() + offsetMin * 60_000);
     const result = await upsertScenarioScheduledTask(ctx, {
       seedKind: "scheduled-push-ladder",
       title: `${eventId}:${index}:${channel}`,
@@ -1589,6 +1605,27 @@ async function seedScheduledPushLadderMemory(
     if (result) return result;
   }
   return undefined;
+}
+
+async function resolveScenarioCalendarEventStart(
+  ctx: ScenarioContext,
+  eventId: string,
+): Promise<Date | null> {
+  const runtime = requireRuntime(ctx);
+  const { LifeOpsRepository } = await loadLifeOps();
+  await LifeOpsRepository.bootstrapSchema(runtime);
+  const repository = new LifeOpsRepository(runtime);
+  const events = await repository.listCalendarEvents(
+    String(runtime.agentId),
+    "google",
+    undefined,
+    undefined,
+    "owner",
+  );
+  const event = events.find(
+    (candidate) => candidate.id === eventId || candidate.externalId === eventId,
+  );
+  return event ? readIsoDate(event.startAt) : null;
 }
 
 function normalizeCalendarProvider(


### PR DESCRIPTION
## Summary
- Materializes the remaining MVP structured memory seed kinds into product-owned state instead of failing/no-oping.
- Adds support for appointment, scheduled-push-ladder, browser-task-state, follow-up state, pending-low-urgency-pushes, and voice-call-attempt seeds.
- Adds PGLite-backed tests that inspect LifeOps calendar rows, scheduled-task rows, browser workflow sessions, and reminder attempts.

Closes #14815.

## Verification
- `bun x biome check packages/scenario-runner/src/seeds.ts packages/scenario-runner/src/seeds.test.ts`
- `bun test --conditions eliza-source packages/scenario-runner/src/seeds.test.ts` -> 24 pass, 0 fail, 83 expect calls
- `bun run --cwd packages/scenario-runner build`
- `git diff --check`
- `bun run audit:error-policy-ratchet`
- Memory seed inventory script over scenario modules -> unsupported 0 for loaded memory seed kinds

## Known Baseline
- `bun run --cwd packages/scenario-runner typecheck` still fails before/around this change on existing workspace/package resolution and unrelated type errors, including optional plugin module declarations (`@elizaos/plugin-discord/service`, `@elizaos/plugin-scheduling`, `@elizaos/plugin-personal-assistant/lifeops/service`, etc.) and UI/shared background catalog type mismatches. No touched-file type errors were isolated from that baseline.

## Required Evidence Rows
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots N/A - scenario-runner seed materialization has no UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots N/A - scenario-runner seed materialization has no UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video N/A - package seed materialization change; behavior is exercised by PGLite-backed tests rather than a user-visible flow.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs N/A - no long-running backend service or external server log artifact; PGLite-backed seed behavior is covered by `bun test --conditions eliza-source packages/scenario-runner/src/seeds.test.ts`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs N/A - no frontend code or browser surface changed.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory N/A - seed materialization only; the added tests run `withLLM: false` and no prompt/action/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts N/A - no durable external artifact file is produced; local PGLite-backed tests inspect LifeOps calendar events, scheduled tasks, browser workflow sessions, and reminder attempts.