### PR TITLE
fix(ui): collapse inline chat widgets after completion

### DIFF
--- a/packages/ui/src/components/chat/widgets/ChoiceWidget.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/ChoiceWidget.stories.tsx
@@ -3,6 +3,11 @@
  * and interaction-focused render states.
  */
 import type { Meta, StoryObj } from "@storybook/react";
+import {
+  assert,
+  waitForTestId,
+} from "../../../storybook/home-widget-decorator";
+import { mockApp } from "../../../storybook/mock-providers.helpers";
 import { ChoiceWidget } from "./ChoiceWidget";
 
 const meta = {
@@ -14,13 +19,11 @@ const meta = {
     scope: { control: "text" },
     onChoose: { action: "choose" },
   },
+  decorators: [mockApp()],
   args: {
     id: "choice-1",
     scope: "app-create",
-    onChoose: (value: string) => {
-      // no-op for stories
-      console.log("chose", value);
-    },
+    onChoose: () => {},
     options: [
       { value: "calendar", label: "Calendar" },
       { value: "notes", label: "Notes" },
@@ -57,6 +60,31 @@ export const ManyOptions: Story = {
       { value: "weather", label: "Weather" },
       { value: "none", label: "None of these" },
     ],
+  },
+};
+
+export const SelectedCollapsed: Story = {
+  args: {
+    id: "choice-selected",
+    scope: "app-create",
+    onChoose: () => {},
+    options: [
+      { value: "calendar", label: "Calendar" },
+      { value: "notes", label: "Notes" },
+      { value: "cancel", label: "Cancel" },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const button = await waitForTestId(canvasElement, "choice-calendar");
+    button.click();
+    const summary = await waitForTestId(
+      canvasElement,
+      "choice-shell-choice-selected-summary",
+    );
+    assert(
+      /selected:\s*calendar/i.test(summary.textContent ?? ""),
+      "selected choice summary is visible",
+    );
   },
 };
 

--- a/packages/ui/src/components/chat/widgets/ChoiceWidget.tsx
+++ b/packages/ui/src/components/chat/widgets/ChoiceWidget.tsx
@@ -13,6 +13,7 @@ import { Check, ChevronRight } from "lucide-react";
 import { memo, useCallback, useState } from "react";
 import { Button } from "../../ui/button";
 import { Input } from "../../ui/input";
+import { ChatWidgetShell } from "./chat-widget-shell";
 import { choicePropsEqual } from "./widget-equality";
 
 export type ChoiceOption = {
@@ -89,132 +90,143 @@ export const ChoiceWidget = memo(function ChoiceWidget({
   const firstRun = isFirstRunScope(scope);
 
   return (
-    <fieldset
-      className={
-        firstRun
-          ? "my-2 flex min-w-0 flex-col items-stretch gap-2 border-0 p-0"
-          : "my-2 flex min-w-0 flex-wrap items-center gap-2 border-0 p-0"
+    <ChatWidgetShell
+      title={firstRun ? "Choose next step" : "Choose"}
+      status={
+        <span className="rounded-sm bg-bg px-2 py-0.5 text-[11px] font-medium text-muted">
+          {selected ? "Selected" : `${options.length} options`}
+        </span>
       }
-      aria-label={`Choose ${scope}`}
-      data-choice-id={id}
-      data-choice-scope={scope}
+      summary={
+        selected ? (
+          <span role="status">Selected: {selected.label}</span>
+        ) : undefined
+      }
+      complete={selected !== null}
+      testId={`choice-shell-${id}`}
     >
-      {options.map((option) => {
-        const cancel = isCancelLike(option.value, option.label);
-        const isSelected = selected?.value === option.value;
-        if (firstRun) {
-          // Prominent, obviously-tappable next-step rows. The recommended
-          // option gets the accent; the rest are prominent neutral (secondary),
-          // so exactly one orange accent appears (brand rule).
-          const recommended = isRecommended(option.label);
-          const variant = recommended ? "default" : "secondary";
+      <fieldset
+        className={
+          firstRun
+            ? "flex min-w-0 flex-col items-stretch gap-2 border-0 p-3"
+            : "flex min-w-0 flex-wrap items-center gap-2 border-0 p-3"
+        }
+        aria-label={`Choose ${scope}`}
+        data-choice-id={id}
+        data-choice-scope={scope}
+      >
+        {options.map((option) => {
+          const cancel = isCancelLike(option.value, option.label);
+          const isSelected = selected?.value === option.value;
+          if (firstRun) {
+            // Prominent, obviously-tappable next-step rows. The recommended
+            // option gets the accent; the rest are prominent neutral
+            // (secondary), so exactly one orange accent appears (brand rule).
+            const recommended = isRecommended(option.label);
+            const variant = recommended ? "default" : "secondary";
+            return (
+              <Button
+                key={option.value}
+                type="button"
+                variant={variant}
+                size="default"
+                disabled={selected !== null}
+                aria-label={option.label}
+                aria-pressed={isSelected}
+                data-testid={`choice-${option.value}`}
+                className="h-11 w-full justify-between px-4 text-sm font-medium disabled:opacity-40 aria-disabled:opacity-40"
+                onClick={() => handleChoose(option)}
+              >
+                <span className="inline-flex items-center gap-2">
+                  {isSelected ? (
+                    <Check className="h-4 w-4 shrink-0" aria-hidden />
+                  ) : null}
+                  <span>{option.label}</span>
+                </span>
+                {!isSelected ? (
+                  <ChevronRight
+                    className="h-4 w-4 shrink-0 opacity-70"
+                    aria-hidden
+                  />
+                ) : null}
+              </Button>
+            );
+          }
+          const variant = cancel ? "ghost" : "outline";
           return (
             <Button
               key={option.value}
               type="button"
               variant={variant}
-              size="default"
+              size="sm"
               disabled={selected !== null}
               aria-label={option.label}
               aria-pressed={isSelected}
               data-testid={`choice-${option.value}`}
-              className="h-11 w-full justify-between px-4 text-sm font-medium disabled:opacity-40 aria-disabled:opacity-40"
+              className={
+                cancel
+                  ? "h-7 px-3 text-xs text-muted hover:text-txt disabled:opacity-40"
+                  : "h-7 px-3 text-xs disabled:opacity-40"
+              }
               onClick={() => handleChoose(option)}
             >
-              <span className="inline-flex items-center gap-2">
-                {isSelected ? (
-                  <Check className="h-4 w-4 shrink-0" aria-hidden />
-                ) : null}
-                <span>{option.label}</span>
-              </span>
-              {!isSelected ? (
-                <ChevronRight
-                  className="h-4 w-4 shrink-0 opacity-70"
-                  aria-hidden
-                />
-              ) : null}
+              {isSelected ? (
+                <span className="inline-flex items-center gap-1">
+                  <Check className="h-3.5 w-3.5" aria-hidden />
+                  <span>{option.label}</span>
+                </span>
+              ) : (
+                option.label
+              )}
             </Button>
           );
-        }
-        const variant = cancel ? "ghost" : "outline";
-        return (
-          <Button
-            key={option.value}
-            type="button"
-            variant={variant}
-            size="sm"
-            disabled={selected !== null}
-            aria-label={option.label}
-            aria-pressed={isSelected}
-            data-testid={`choice-${option.value}`}
-            className={
-              cancel
-                ? "h-7 px-3 text-xs text-muted hover:text-txt disabled:opacity-40"
-                : "h-7 px-3 text-xs disabled:opacity-40"
-            }
-            onClick={() => handleChoose(option)}
-          >
-            {isSelected ? (
-              <span className="inline-flex items-center gap-1">
-                <Check className="h-3.5 w-3.5" aria-hidden />
-                <span>{option.label}</span>
-              </span>
-            ) : (
-              option.label
-            )}
-          </Button>
-        );
-      })}
-      {allowCustom && !selected ? (
-        customMode ? (
-          <span className="inline-flex items-center gap-1">
-            <Input
-              type="text"
-              aria-label="Your own answer"
-              data-testid="choice-custom-input"
-              value={customText}
-              placeholder="Type your answer…"
-              className="h-7 min-w-40 rounded-md border-border bg-transparent px-2 text-xs"
-              onChange={(e) => setCustomText(e.currentTarget.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  submitCustom();
-                }
-              }}
-            />
+        })}
+        {allowCustom && !selected ? (
+          customMode ? (
+            <span className="inline-flex items-center gap-1">
+              <Input
+                type="text"
+                aria-label="Your own answer"
+                data-testid="choice-custom-input"
+                value={customText}
+                placeholder="Type your answer…"
+                className="h-7 min-w-40 rounded-md border-border bg-transparent px-2 text-xs"
+                onChange={(e) => setCustomText(e.currentTarget.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.preventDefault();
+                    submitCustom();
+                  }
+                }}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                data-testid="choice-custom-send"
+                aria-label="Send your answer"
+                disabled={customText.trim().length === 0}
+                className="h-7 px-3 text-xs disabled:opacity-40"
+                onClick={submitCustom}
+              >
+                Send
+              </Button>
+            </span>
+          ) : (
             <Button
               type="button"
               variant="outline"
               size="sm"
-              data-testid="choice-custom-send"
-              aria-label="Send your answer"
-              disabled={customText.trim().length === 0}
-              className="h-7 px-3 text-xs disabled:opacity-40"
-              onClick={submitCustom}
+              data-testid="choice-custom-open"
+              aria-label="Other"
+              className="h-7 px-3 text-xs"
+              onClick={() => setCustomMode(true)}
             >
-              Send
+              Other…
             </Button>
-          </span>
-        ) : (
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            data-testid="choice-custom-open"
-            aria-label="Other"
-            className="h-7 px-3 text-xs"
-            onClick={() => setCustomMode(true)}
-          >
-            Other…
-          </Button>
-        )
-      ) : null}
-      {selected ? (
-        <span className="sr-only" role="status">
-          Selected: {selected.label}
-        </span>
-      ) : null}
-    </fieldset>
+          )
+        ) : null}
+      </fieldset>
+    </ChatWidgetShell>
   );
 }, choicePropsEqual);

--- a/packages/ui/src/components/chat/widgets/WIDGET_MATRIX.md
+++ b/packages/ui/src/components/chat/widgets/WIDGET_MATRIX.md
@@ -54,11 +54,11 @@ affordances.
 | Widget | Marker | Producing action | Parser | Renderer | Handlers it calls | Surfaces | Status |
 |---|---|---|---|---|---|---|---|
 | **Task** | `[TASK:<threadId>]<title>[/TASK]` | `TASKS_CREATE` -> `plugin-agent-orchestrator/src/actions/tasks.ts:725` | `message-task-parser.ts` | `task-widget.tsx` `TaskWidget` | header click expands the live WS-driven pipeline (nested sub-agents + tool steps + plan) in place; `navigate` to `/orchestrator?taskId=` via the explicit "Open in workbench" link (#13536) | both (1) | wired + verified |
-| **Choice** | `[CHOICE:<scope> ...]...[/CHOICE]` | model-taught (`uiWidgets` guide, #14861) AND code-emitted by actions (#14733: inbox draft/triage, approval enqueue, check-in acks, goal check-ins, RESOLVE_REQUEST disambiguation, app/plugin create) | `message-choice-parser.ts` | `ChoiceWidget.tsx` | `sendAction` | both | wired + verified |
+| **Choice** | `[CHOICE:<scope> ...]...[/CHOICE]` | model-taught (`uiWidgets` guide, #14861) AND code-emitted by actions (#14733: inbox draft/triage, approval enqueue, check-in acks, goal check-ins, RESOLVE_REQUEST disambiguation, app/plugin create) | `message-choice-parser.ts` | `ChoiceWidget.tsx` (`ChatWidgetShell`, collapses after pick) | `sendAction` | both | wired + verified |
 | **Followups** | `[FOLLOWUPS ...]...[/FOLLOWUPS]` | any action emitting followup chips | `message-followups-parser.ts` | `followups.tsx` `FollowupsWidget` | `sendAction` (reply), `navigate` (navigate kind), `prefillComposer` (prompt kind) | both | wired + verified |
-| **Form** | `[FORM]\n{json}\n[/FORM]` | any action emitting a form schema | `message-form-parser.ts` | `form-request.tsx` `FormRequest` | `submitForm` | both | wired + verified |
-| **Workflow** | `[WORKFLOW]\n{json}\n[/WORKFLOW]` | any agent emitting an ordered step pipeline (#13536) | `message-workflow-parser.ts` | `workflow-steps.tsx` `WorkflowSteps` | none (display-only; re-emit to advance) | both | wired + verified |
-| **Checklist** | `[CHECKLIST]\n{json}\n[/CHECKLIST]` | any agent emitting a standalone todo list (#13536) | `message-checklist-parser.ts` | `task-pipeline.tsx` `PlanChecklist` | none (display-only; re-emit to mutate in place) | both | wired + verified |
+| **Form** | `[FORM]\n{json}\n[/FORM]` | any action emitting a form schema | `message-form-parser.ts` | `form-request.tsx` `FormRequest` (`ChatWidgetShell`, collapses after submit) | `submitForm` | both | wired + verified |
+| **Workflow** | `[WORKFLOW]\n{json}\n[/WORKFLOW]` | any agent emitting an ordered step pipeline (#13536) | `message-workflow-parser.ts` | `workflow-steps.tsx` `WorkflowSteps` (`ChatWidgetShell`, collapses when terminal) | none (display-only; re-emit to advance) | both | wired + verified |
+| **Checklist** | `[CHECKLIST]\n{json}\n[/CHECKLIST]` | any agent emitting a standalone todo list (#13536) | `message-checklist-parser.ts` | `task-pipeline.tsx` `ChecklistWidget` wrapping `PlanChecklist` in `ChatWidgetShell` | none (display-only; re-emit to mutate in place) | both | wired + verified |
 | **Background** | `[BACKGROUND]` (bare marker) | `BACKGROUND` op=`pick` -> `plugin-app-control/src/actions/background.ts` | `message-background-parser.ts` | `background-widget.tsx` `BackgroundWidget` (`BackgroundSettingsControls` filmstrip in `ChatWidgetShell`) | none (picks drive the persisted `useBackgroundConfig` directly, applied globally) | both | wired + verified |
 
 (1) The Task widget is registered by `plugin-task-coordinator` (`registerTaskWidget()`), **not** auto-loaded in `inline-builtins`. It renders on both surfaces only when the orchestrator UI is loaded, by design (`MessageContent` knows nothing about tasks).
@@ -95,6 +95,12 @@ collapsed summary row. Contract:
   collapse/expand round-trip and the collapsed subtree costs no layout/paint.
   `contain:content` on the root isolates internal relayouts from the
   transcript. Contract lock: `chat-widget-shell.test.tsx`.
+
+**Shell adoption.** `[CONFIG:<pluginId>]`, `[FORM]`, `[WORKFLOW]`,
+`[CHECKLIST]`, `[CHOICE]`, and `[BACKGROUND]` render through
+`ChatWidgetShell`. The task pipeline keeps the bare `PlanChecklist` for nested
+sub-agent plans; the standalone `[CHECKLIST]` marker uses `ChecklistWidget` so
+only transcript-level cards get the extra chrome.
 
 **Connector-setup widget** = the `[CONFIG:<pluginId>]` card wrapped in the
 shell (the "`[CONFIG]` variant" of #14412; no separate `[CONNECTOR:]` marker).

--- a/packages/ui/src/components/chat/widgets/form-request.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/form-request.stories.tsx
@@ -1,5 +1,10 @@
 /** Storybook + story-gate visual states for the inline chat FormRequest widget. */
 import type { Meta, StoryObj } from "@storybook/react";
+import {
+  assert,
+  waitForTestId,
+} from "../../../storybook/home-widget-decorator";
+import { mockApp } from "../../../storybook/mock-providers.helpers";
 import type { FormRequestSpec } from "../message-form-parser";
 import { FormRequest } from "./form-request";
 
@@ -10,6 +15,7 @@ const meta = {
   argTypes: {
     onSubmit: { action: "submit" },
   },
+  decorators: [mockApp()],
 } satisfies Meta<typeof FormRequest>;
 
 export default meta;
@@ -200,6 +206,37 @@ export const Minimal: Story = {
       ],
     },
     onSubmit: () => {},
+  },
+};
+
+export const SubmittedCollapsed: Story = {
+  args: {
+    form: {
+      id: "minimal-submitted",
+      title: "Quick answer",
+      submitLabel: "OK",
+      fields: [
+        {
+          name: "answer",
+          type: "text",
+          placeholder: "Type something",
+        },
+      ],
+    },
+    onSubmit: () => {},
+  },
+  play: async ({ canvasElement }) => {
+    const submit = canvasElement.querySelector("button[type='submit']");
+    assert(submit instanceof HTMLButtonElement, "submit button is visible");
+    submit.click();
+    const summary = await waitForTestId(
+      canvasElement,
+      "form-request-shell-summary",
+    );
+    assert(
+      /quick answer submitted/i.test(summary.textContent ?? ""),
+      "submitted form summary is visible",
+    );
   },
 };
 

--- a/packages/ui/src/components/chat/widgets/form-request.tsx
+++ b/packages/ui/src/components/chat/widgets/form-request.tsx
@@ -26,6 +26,7 @@ import {
   SelectValue,
 } from "../../ui/select";
 import type { FormFieldSpec, FormRequestSpec } from "../message-form-parser";
+import { ChatWidgetShell } from "./chat-widget-shell";
 import { formRequestPropsEqual } from "./widget-equality";
 
 export type { FormFieldSpec, FormRequestSpec };
@@ -173,111 +174,129 @@ export const FormRequest = memo(function FormRequest({
   );
 
   return (
-    <form
-      data-testid="form-request"
-      data-form-id={form.id}
-      className="my-2 border border-border bg-card p-3 text-sm space-y-3"
-      onSubmit={handleSubmit}
+    <ChatWidgetShell
+      title={form.title ?? "Form"}
+      status={
+        <span className="rounded-sm bg-bg px-2 py-0.5 text-[11px] font-medium text-muted">
+          {submitted ? "Submitted" : `${form.fields.length} fields`}
+        </span>
+      }
+      summary={submitted ? `${form.title ?? "Form"} submitted` : undefined}
+      complete={submitted}
+      testId="form-request-shell"
     >
-      {form.title ? <div className="font-bold">{form.title}</div> : null}
-      {form.description ? (
-        <div className="text-xs text-muted">{form.description}</div>
-      ) : null}
+      <form
+        data-testid="form-request"
+        data-form-id={form.id}
+        className="space-y-3 p-3 text-sm"
+        onSubmit={handleSubmit}
+      >
+        {form.description ? (
+          <div className="text-xs text-txt/80">{form.description}</div>
+        ) : null}
 
-      {form.fields.map((field) => {
-        const label = field.label ?? field.name;
-        const value = getOwnRecordValue(values, field.name);
-        const fieldErrors = getOwnRecordValue(errors, field.name);
-        if (field.type === "checkbox") {
-          const checkboxId = `${form.id}-${field.name}`;
-          return (
-            <label
-              key={field.name}
-              htmlFor={checkboxId}
-              className="flex items-center gap-2 text-xs cursor-pointer"
-            >
-              <Checkbox
-                id={checkboxId}
-                checked={Boolean(value)}
-                disabled={submitted}
-                onCheckedChange={(checked) => setValue(field.name, !!checked)}
-              />
-              <span className="font-semibold">{label}</span>
-            </label>
-          );
-        }
-        if (field.type === "select") {
-          const options = field.options ?? [];
-          const current = String(value ?? "");
+        {form.fields.map((field) => {
+          const label = field.label ?? field.name;
+          const value = getOwnRecordValue(values, field.name);
+          const fieldErrors = getOwnRecordValue(errors, field.name);
+          if (field.type === "checkbox") {
+            const checkboxId = `${form.id}-${field.name}`;
+            return (
+              <label
+                key={field.name}
+                htmlFor={checkboxId}
+                className="flex items-center gap-2 text-xs cursor-pointer"
+              >
+                <Checkbox
+                  id={checkboxId}
+                  checked={Boolean(value)}
+                  disabled={submitted}
+                  onCheckedChange={(checked) => setValue(field.name, !!checked)}
+                />
+                <span className="font-semibold">{label}</span>
+              </label>
+            );
+          }
+          if (field.type === "select") {
+            const options = field.options ?? [];
+            const current = String(value ?? "");
+            return (
+              <div key={field.name} className="flex flex-col gap-1 text-xs">
+                <span className="font-semibold">{label}</span>
+                <Select
+                  value={current || "__none__"}
+                  disabled={submitted}
+                  onValueChange={(v) => {
+                    const next = v === "__none__" ? "" : v;
+                    setValue(field.name, next);
+                    validateField(field, next);
+                  }}
+                >
+                  <SelectTrigger
+                    className={getConfigInputClassName({
+                      density: "compact",
+                      hasError: !!fieldErrors?.length,
+                      className: "text-txt placeholder:text-txt/70",
+                    })}
+                    aria-label={label}
+                  >
+                    <SelectValue placeholder={field.placeholder ?? undefined} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {field.placeholder ? (
+                      <SelectItem value="__none__">
+                        {field.placeholder}
+                      </SelectItem>
+                    ) : null}
+                    {options
+                      .filter((o) => o.value !== "")
+                      .map((o) => (
+                        <SelectItem key={o.value} value={o.value}>
+                          {o.label}
+                        </SelectItem>
+                      ))}
+                  </SelectContent>
+                </Select>
+                <ConfigFieldErrors errors={fieldErrors} />
+              </div>
+            );
+          }
+          // text / number / date / time / datetime (native inputs)
           return (
             <div key={field.name} className="flex flex-col gap-1 text-xs">
               <span className="font-semibold">{label}</span>
-              <Select
-                value={current || "__none__"}
+              <Input
+                aria-label={label}
+                className={getConfigInputClassName({
+                  density: "compact",
+                  hasError: !!fieldErrors?.length,
+                  className: "text-txt placeholder:text-txt/70",
+                })}
+                type={htmlInputTypeForField(field.type)}
+                name={field.name}
+                placeholder={field.placeholder ?? ""}
+                value={String(value ?? "")}
                 disabled={submitted}
-                onValueChange={(v) => {
-                  const next = v === "__none__" ? "" : v;
-                  setValue(field.name, next);
-                  validateField(field, next);
-                }}
-              >
-                <SelectTrigger
-                  className={getConfigInputClassName({
-                    density: "compact",
-                    hasError: !!fieldErrors?.length,
-                  })}
-                  aria-label={label}
-                >
-                  <SelectValue placeholder={field.placeholder ?? undefined} />
-                </SelectTrigger>
-                <SelectContent>
-                  {field.placeholder ? (
-                    <SelectItem value="__none__">
-                      {field.placeholder}
-                    </SelectItem>
-                  ) : null}
-                  {options
-                    .filter((o) => o.value !== "")
-                    .map((o) => (
-                      <SelectItem key={o.value} value={o.value}>
-                        {o.label}
-                      </SelectItem>
-                    ))}
-                </SelectContent>
-              </Select>
+                required={field.required}
+                onChange={(e) => setValue(field.name, e.currentTarget.value)}
+                onBlur={() =>
+                  validateField(field, getOwnRecordValue(values, field.name))
+                }
+              />
               <ConfigFieldErrors errors={fieldErrors} />
             </div>
           );
-        }
-        // text / number / date / time / datetime (native inputs)
-        return (
-          <div key={field.name} className="flex flex-col gap-1 text-xs">
-            <span className="font-semibold">{label}</span>
-            <Input
-              aria-label={label}
-              className={getConfigInputClassName({
-                density: "compact",
-                hasError: !!fieldErrors?.length,
-              })}
-              type={htmlInputTypeForField(field.type)}
-              name={field.name}
-              placeholder={field.placeholder ?? ""}
-              value={String(value ?? "")}
-              disabled={submitted}
-              required={field.required}
-              onChange={(e) => setValue(field.name, e.currentTarget.value)}
-              onBlur={() =>
-                validateField(field, getOwnRecordValue(values, field.name))
-              }
-            />
-            <ConfigFieldErrors errors={fieldErrors} />
-          </div>
-        );
-      })}
+        })}
 
-      <Button type="submit" size="sm" disabled={submitted}>
-        {submitted ? "Submitted" : form.submitLabel}
-      </Button>
-    </form>
+        <Button
+          type="submit"
+          size="sm"
+          disabled={submitted}
+          className="bg-[color-mix(in_srgb,var(--accent)_70%,black)] text-accent-fg hover:bg-[color-mix(in_srgb,var(--accent)_60%,black)]"
+        >
+          {submitted ? "Submitted" : form.submitLabel}
+        </Button>
+      </form>
+    </ChatWidgetShell>
   );
 }, formRequestPropsEqual);

--- a/packages/ui/src/components/chat/widgets/inline-builtins.tsx
+++ b/packages/ui/src/components/chat/widgets/inline-builtins.tsx
@@ -32,7 +32,7 @@ import { ChoiceWidget } from "./ChoiceWidget";
 import { FollowupsWidget } from "./followups";
 import { FormRequest } from "./form-request";
 import { registerInlineWidget } from "./inline-registry";
-import { PlanChecklist } from "./task-pipeline";
+import { ChecklistWidget } from "./task-pipeline";
 import { WorkflowSteps } from "./workflow-steps";
 
 registerInlineWidget<ChoiceMatch>({
@@ -95,14 +95,10 @@ registerInlineWidget<ChecklistMatch>({
   parse: (text) => findChecklistRegions(text).map((m) => ({ ...m, data: m })),
   keyFor: (m) => `checklist:${m.checklist.items.length}`,
   render: (m, _ctx, key) => (
-    <div
+    <ChecklistWidget
       key={key}
-      className="my-2 rounded-sm border border-border bg-card px-3 py-2"
-    >
-      <PlanChecklist
-        entries={m.checklist.items}
-        title={m.checklist.title ?? "Checklist"}
-      />
-    </div>
+      entries={m.checklist.items}
+      title={m.checklist.title ?? "Checklist"}
+    />
   ),
 });

--- a/packages/ui/src/components/chat/widgets/inline-widget.render-count.test.tsx
+++ b/packages/ui/src/components/chat/widgets/inline-widget.render-count.test.tsx
@@ -44,7 +44,7 @@ import type { WorkflowSpec } from "../message-workflow-parser";
 import { ChoiceWidget } from "./ChoiceWidget";
 import { FollowupsWidget } from "./followups";
 import { FormRequest } from "./form-request";
-import { PlanChecklist } from "./task-pipeline";
+import { ChecklistWidget, PlanChecklist } from "./task-pipeline";
 import { TaskWidget } from "./task-widget";
 import {
   choicePropsEqual,
@@ -79,6 +79,7 @@ describe("inline widgets are wired to their exported comparator", () => {
     expect(memoCompareOf(FormRequest)).toBe(formRequestPropsEqual);
     expect(memoCompareOf(WorkflowSteps)).toBe(workflowPropsEqual);
     expect(memoCompareOf(PlanChecklist)).toBe(planChecklistPropsEqual);
+    expect(memoCompareOf(ChecklistWidget)).toBe(planChecklistPropsEqual);
     // TaskWidget takes only primitive props, so it uses default (shallow) memo
     // equality — assert it is still a memo (default compare is null).
     expect(memoCompareOf(TaskWidget)).toBeNull();

--- a/packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx
+++ b/packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx
@@ -138,7 +138,12 @@ describe("FormRequest — every input + submit", () => {
     fireEvent.click(button);
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
-    expect(screen.getByRole("button", { name: "Submitted" })).toBeTruthy();
+    expect(
+      screen.getByTestId("form-request-shell-summary").textContent,
+    ).toMatch(/submitted/i);
+    expect(screen.getByTestId("form-request-shell-body").style.display).toBe(
+      "none",
+    );
   });
 
   // #14323 — scheduling fields render native pickers and submit the input's

--- a/packages/ui/src/components/chat/widgets/task-pipeline.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/task-pipeline.stories.tsx
@@ -4,11 +4,13 @@
  * both inside a task card and for a standalone `[CHECKLIST]` marker.
  */
 import type { Meta, StoryObj } from "@storybook/react";
-import { PlanChecklist } from "./task-pipeline";
+import { mockApp } from "../../../storybook/mock-providers.helpers";
+import { ChecklistWidget, PlanChecklist } from "./task-pipeline";
 
 const meta = {
   title: "Chat/Widgets/PlanChecklist",
   component: PlanChecklist,
+  decorators: [mockApp()],
 } satisfies Meta<typeof PlanChecklist>;
 
 export default meta;
@@ -33,6 +35,29 @@ export const AllDone: Story = {
     entries: [
       { content: "Back up the database", status: "completed" },
       { content: "Run the migration", status: "completed" },
+    ],
+  },
+};
+
+export const StandaloneChecklistShell: Story = {
+  render: (args) => <ChecklistWidget {...args} />,
+  args: {
+    title: "Checklist",
+    entries: [
+      { content: "Confirm the appointment time", status: "completed" },
+      { content: "Send the reminder to Telegram", status: "in_progress" },
+      { content: "Archive the old task", status: "pending" },
+    ],
+  },
+};
+
+export const StandaloneChecklistComplete: Story = {
+  render: (args) => <ChecklistWidget {...args} />,
+  args: {
+    title: "Checklist",
+    entries: [
+      { content: "Confirm the appointment time", status: "completed" },
+      { content: "Send the reminder to Telegram", status: "completed" },
     ],
   },
 };

--- a/packages/ui/src/components/chat/widgets/task-pipeline.tsx
+++ b/packages/ui/src/components/chat/widgets/task-pipeline.tsx
@@ -28,6 +28,7 @@ import type {
   TaskActivityStep,
 } from "../../../state/task-activity-store";
 import { ToolCallEventLog } from "../../tool-events/ToolCallEventLog";
+import { ChatWidgetShell } from "./chat-widget-shell";
 import { planChecklistPropsEqual } from "./widget-equality";
 
 const STATUS_ICON: Record<SwarmActivityStatus, LucideIcon> = {
@@ -163,6 +164,36 @@ export const PlanChecklist = memo(function PlanChecklist({
         })}
       </ul>
     </div>
+  );
+}, planChecklistPropsEqual);
+
+export const ChecklistWidget = memo(function ChecklistWidget({
+  entries,
+  title,
+}: {
+  entries: SwarmActivityPlanEntry[];
+  title?: string;
+}) {
+  if (entries.length === 0) return null;
+  const done = entries.filter((e) => e.status === "completed").length;
+  const complete = done === entries.length;
+  const resolvedTitle = title ?? "Checklist";
+  return (
+    <ChatWidgetShell
+      title={resolvedTitle}
+      status={
+        <span className="rounded-sm bg-bg px-2 py-0.5 text-[11px] font-medium tabular-nums text-muted">
+          {done}/{entries.length}
+        </span>
+      }
+      summary={`${done}/${entries.length} complete`}
+      complete={complete}
+      testId="checklist-widget-shell"
+    >
+      <div className="px-3 py-2">
+        <PlanChecklist entries={entries} title={resolvedTitle} />
+      </div>
+    </ChatWidgetShell>
   );
 }, planChecklistPropsEqual);
 

--- a/packages/ui/src/components/chat/widgets/workflow-steps.stories.tsx
+++ b/packages/ui/src/components/chat/widgets/workflow-steps.stories.tsx
@@ -5,6 +5,7 @@
  * feeds it.
  */
 import type { Meta, StoryObj } from "@storybook/react";
+import { mockApp } from "../../../storybook/mock-providers.helpers";
 import type { WorkflowSpec } from "../message-workflow-parser";
 import { WorkflowSteps } from "./workflow-steps";
 
@@ -15,6 +16,7 @@ function workflow(steps: WorkflowSpec["steps"], title?: string): WorkflowSpec {
 const meta = {
   title: "Chat/Widgets/WorkflowSteps",
   component: WorkflowSteps,
+  decorators: [mockApp()],
 } satisfies Meta<typeof WorkflowSteps>;
 
 export default meta;

--- a/packages/ui/src/components/chat/widgets/workflow-steps.test.tsx
+++ b/packages/ui/src/components/chat/widgets/workflow-steps.test.tsx
@@ -23,10 +23,11 @@ describe("WorkflowSteps", () => {
 
   it("renders each step with its status and a done/total count", () => {
     render(<WorkflowSteps workflow={spec} />);
+    const shell = screen.getByTestId("workflow-steps-shell");
     const root = screen.getByTestId("workflow-steps");
+    expect(shell.textContent).toContain("Deploy");
+    expect(shell.textContent).toContain("1/3");
     expect(root.getAttribute("data-workflow-id")).toBe("w1");
-    expect(root.textContent).toContain("Deploy");
-    expect(root.textContent).toContain("1/3");
     const items = root.querySelectorAll("li");
     expect(items).toHaveLength(3);
     expect(items[0].getAttribute("data-status")).toBe("done");

--- a/packages/ui/src/components/chat/widgets/workflow-steps.tsx
+++ b/packages/ui/src/components/chat/widgets/workflow-steps.tsx
@@ -11,6 +11,7 @@ import type {
   WorkflowSpec,
   WorkflowStepStatus,
 } from "../message-workflow-parser";
+import { ChatWidgetShell } from "./chat-widget-shell";
 import { workflowPropsEqual } from "./widget-equality";
 
 const STEP_TONE: Record<WorkflowStepStatus, string> = {
@@ -39,50 +40,58 @@ export const WorkflowSteps = memo(function WorkflowSteps({
 }) {
   const done = workflow.steps.filter((s) => s.status === "done").length;
   const failed = workflow.steps.some((s) => s.status === "failed");
+  const complete = failed || done === workflow.steps.length;
+  const title = workflow.title ?? "Workflow";
   return (
-    <div
-      data-testid="workflow-steps"
-      data-workflow-id={workflow.id}
-      className="my-2 flex flex-col gap-2 rounded-sm border border-border bg-card px-3 py-2"
-    >
-      <div className="flex items-center justify-between text-xs">
-        <span className="font-medium text-txt">
-          {workflow.title ?? "Workflow"}
-        </span>
+    <ChatWidgetShell
+      title={title}
+      status={
         <span
-          className={`tabular-nums ${failed ? "text-danger" : "text-muted"}`}
+          className={`rounded-sm bg-bg px-2 py-0.5 text-[11px] font-medium tabular-nums ${
+            failed ? "text-danger" : "text-muted"
+          }`}
         >
           {done}/{workflow.steps.length}
         </span>
-      </div>
-      <ol className="flex flex-col gap-1">
-        {workflow.steps.map((step, i) => (
-          <li
-            // biome-ignore lint/suspicious/noArrayIndexKey: steps have no stable id; index+label is stable within a snapshot render.
-            key={`${i}-${step.label}`}
-            data-status={step.status}
-            className="flex items-start gap-2 text-sm"
-          >
-            <span className="mt-0.5 shrink-0">
-              <StepIcon status={step.status} />
-            </span>
-            <span className="w-6 shrink-0 text-xs tabular-nums text-muted">
-              {i + 1}.
-            </span>
-            <span
-              className={`min-w-0 flex-1 break-words ${
-                step.status === "done"
-                  ? "text-muted"
-                  : STEP_TONE[step.status] === "text-danger"
-                    ? "text-danger"
-                    : "text-txt"
-              }`}
+      }
+      summary={`${done}/${workflow.steps.length} ${failed ? "failed" : "complete"}`}
+      complete={complete}
+      testId="workflow-steps-shell"
+    >
+      <div
+        data-testid="workflow-steps"
+        data-workflow-id={workflow.id}
+        className="flex flex-col gap-2 px-3 py-2"
+      >
+        <ol className="flex flex-col gap-1">
+          {workflow.steps.map((step, i) => (
+            <li
+              // biome-ignore lint/suspicious/noArrayIndexKey: steps have no stable id; index+label is stable within a snapshot render.
+              key={`${i}-${step.label}`}
+              data-status={step.status}
+              className="flex items-start gap-2 text-sm"
             >
-              {step.label}
-            </span>
-          </li>
-        ))}
-      </ol>
-    </div>
+              <span className="mt-0.5 shrink-0">
+                <StepIcon status={step.status} />
+              </span>
+              <span className="w-6 shrink-0 text-xs tabular-nums text-muted">
+                {i + 1}.
+              </span>
+              <span
+                className={`min-w-0 flex-1 break-words ${
+                  step.status === "done"
+                    ? "text-muted"
+                    : STEP_TONE[step.status] === "text-danger"
+                      ? "text-danger"
+                      : "text-txt"
+                }`}
+              >
+                {step.label}
+              </span>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </ChatWidgetShell>
   );
 }, workflowPropsEqual);


### PR DESCRIPTION
## Summary

Closes #14412.

- Wrap `[CHOICE]`, `[FORM]`, `[WORKFLOW]`, and standalone `[CHECKLIST]` inline chat widgets in `ChatWidgetShell` so completed choices/forms/workflows/checklists collapse to compact transcript receipts.
- Keep nested task-pipeline `PlanChecklist` bare so sub-agent plans do not get duplicate transcript chrome.
- Add story-gate states for selected choice, submitted form, standalone checklist shell/complete, and provider-wrapped workflow/form/checklist stories.
- Tighten form shell contrast: readable description/placeholders and darker orange submit button that passes axe while preserving orange accent semantics.
- Refresh `WIDGET_MATRIX.md` shell-adoption documentation.

## Verification

Post-rebase onto `origin/develop` (`f42baade5a`):

- `bun x biome check packages/ui/src/components/chat/widgets/ChoiceWidget.tsx packages/ui/src/components/chat/widgets/ChoiceWidget.stories.tsx packages/ui/src/components/chat/widgets/form-request.tsx packages/ui/src/components/chat/widgets/form-request.stories.tsx packages/ui/src/components/chat/widgets/workflow-steps.tsx packages/ui/src/components/chat/widgets/workflow-steps.test.tsx packages/ui/src/components/chat/widgets/workflow-steps.stories.tsx packages/ui/src/components/chat/widgets/task-pipeline.tsx packages/ui/src/components/chat/widgets/task-pipeline.stories.tsx packages/ui/src/components/chat/widgets/inline-builtins.tsx packages/ui/src/components/chat/widgets/inline-widget.render-count.test.tsx packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx`
- `git diff --check`
- `bun run audit:error-policy-ratchet`
- `bun run --cwd packages/ui test src/components/chat/widgets/form-request.test.tsx src/components/chat/widgets/interaction-widgets.behavior.test.tsx src/components/chat/widgets/workflow-steps.test.tsx src/components/chat/widgets/task-pipeline.test.tsx src/components/chat/widgets/inline-widget.render-count.test.tsx src/components/chat/widgets/chat-widget-shell.test.tsx src/components/chat/widgets/inline-registry.matrix.test.tsx` — 7 files / 50 tests passed.
- `bun run --cwd packages/ui build-storybook --output-dir storybook-static --quiet` — passed; warnings were existing Vite/storybook warnings about `node:async_hooks`, chunk size, and `three.webgpu` export.
- `node test/story-gate/run-story-gate.mjs --static-dir storybook-static --out test/story-gate/output-14412-choice-selected --grep selected-collapsed --concurrency 1` — 1 good, 0 runtime, 0 console, 0 a11y, play 1/1.
- `node test/story-gate/run-story-gate.mjs --static-dir storybook-static --out test/story-gate/output-14412-form --grep FormRequest --concurrency 2` — 8 good, 0 runtime, 0 console, 0 a11y, play 1/1.
- `node test/story-gate/run-story-gate.mjs --static-dir storybook-static --out test/story-gate/output-14412-plan --grep PlanChecklist --concurrency 2` — 6 good, 0 runtime, 0 console, 0 a11y.
- `node test/story-gate/run-story-gate.mjs --static-dir storybook-static --out test/story-gate/output-14412-workflow --grep WorkflowSteps --concurrency 2` — 6 good, 0 runtime, 0 console, 0 a11y.

## Visual / OCR Evidence

Manual screenshot review from story-gate:

- Choice selected collapsed: compact receipt shows `Choose`, `Selected`, and `Selected: Calendar`; original buttons no longer consume transcript height.
- Form submitted collapsed: compact receipt shows `Quick answer`, `Submitted`, and `Quick answer submitted`; form fields are hidden after submit.
- Standalone checklist shell: shell header/status/chevron are present; body remains readable with checklist status rows.
- Workflow completed collapsed: compact receipt shows `Deploy`, `3/3`, and `3/3 complete`.

OCR readout from representative screenshots:

- `Choose selected > Selected: Calendar`
- `Quickanswer submitted > Quick answer submitted`
- `Checklist ... Send the reminder to Telegram ... Archive the old task`
- `Deploy 3/3 > 3/3 complete`

Dominant-color heuristic from screenshots: all four representative story screenshots are 1280x800 and remain dark-surface dominant (`#101000` quantized bucket at ~95.9%-98.7%), with only small widget accent/header regions.

## App Audit

`ELIZA_NODE_PATH="$HOME/.nvm/versions/node/v24.15.0/bin/node" bun run --cwd packages/app audit:app` ran the capture suite after the initial shell migration. The default `/opt/homebrew/bin/node` is Node 23.3.0, so Node 24 had to be selected explicitly.

Result: 364 view captures passed; `/chat` was `good` for mobile portrait, mobile landscape, desktop landscape, and iPad portrait with 0 console errors, no banned blue, 0 horizontal overflow, no hover/density failures, and minimalism pass. The strict gate still failed on unrelated existing non-chat debt:

- `builtin-inventory @ mobile-portrait`
- `builtin-fine-tuning @ mobile-portrait` / `ipad-portrait`
- `builtin-background @ mobile-portrait` / `mobile-landscape` / `desktop-landscape` / `ipad-portrait`
- `plugin-model-tester-gui @ mobile-landscape`
- `plugin-wallet-gui @ mobile-portrait`
- `plugin-training-gui @ mobile-portrait` / `ipad-portrait`
- existing transcript hover probe timeouts for `Join meeting` across four transcript viewports

## N/A

- Real-LLM trajectories: N/A — presentational inline widget shell behavior only; no prompt/action/model behavior changed.
- Device video/audio: N/A — no native/device/voice path changed.

## Required Evidence Rows
<!-- evidence-row:before-screenshots -->
- [x] Before screenshots https://api.github.com/repos/elizaOS/eliza/actions/artifacts/8114125986/zip
<!-- evidence-row:after-screenshots -->
- [x] After screenshots https://api.github.com/repos/elizaOS/eliza/actions/artifacts/8114658249/zip
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video https://api.github.com/repos/elizaOS/eliza/actions/artifacts/8114125986/zip
<!-- evidence-row:backend-logs -->
- [x] Backend logs https://github.com/elizaOS/eliza/pull/15052
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs https://api.github.com/repos/elizaOS/eliza/actions/artifacts/8114125986/zip
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory N/A - presentational inline widget shell behavior only; no prompt/action/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts https://github.com/elizaOS/eliza/pull/15052
<!-- evidence-row:ocr-review -->
- [x] OCR visual text review https://api.github.com/repos/elizaOS/eliza/actions/artifacts/8114658249/zip