### PR TITLE
test(mocks): add corpus gmail fidelity contracts

### DIFF
--- a/packages/test/mocks/__tests__/google-mock-fidelity.test.ts
+++ b/packages/test/mocks/__tests__/google-mock-fidelity.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Verifies that corpus-loaded Gmail mock data keeps Google-shaped wire
+ * responses. The expected fields come from the canonical corpus mapper, then
+ * the test exercises the HTTP mock so scenario seeds and connector code see
+ * the same shape a real Gmail integration would parse.
+ */
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { readCorpusShard, toGmailFixtureMessage } from "@elizaos/corpus-tools";
+import { afterEach, describe, expect, it } from "vitest";
+import { type StartedMocks, startMocks } from "../scripts/start-mocks.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const sampleCorpusDir = path.resolve(
+  __dirname,
+  "../../../corpus-tools/fixtures/synthetic",
+);
+const sampleShard = path.join(sampleCorpusDir, "gmail/work/2026-06.jsonl");
+
+let activeMocks: StartedMocks | null = null;
+
+afterEach(async () => {
+  if (!activeMocks) return;
+  await activeMocks.stop();
+  activeMocks = null;
+});
+
+async function jsonRequest(
+  url: string,
+  init?: RequestInit,
+): Promise<{ response: Response; body: Record<string, unknown> }> {
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+  });
+  return { response, body: (await response.json()) as Record<string, unknown> };
+}
+
+function responseHeaders(body: Record<string, unknown>) {
+  const payload = body.payload;
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("expected Gmail payload object");
+  }
+  const headers = (payload as { headers?: unknown }).headers;
+  if (!Array.isArray(headers)) {
+    throw new Error("expected Gmail payload headers");
+  }
+  return headers as Array<{ name: string; value: string }>;
+}
+
+function payloadBodyText(body: Record<string, unknown>): string {
+  const payload = body.payload as { body?: { data?: string } } | undefined;
+  const data = payload?.body?.data;
+  if (!data) throw new Error("expected Gmail payload body data");
+  return Buffer.from(data, "base64url").toString("utf8");
+}
+
+describe("Google Gmail mock fidelity", () => {
+  it("round-trips corpus rows through Google-shaped list/get/modify responses", async () => {
+    const shard = await readCorpusShard(sampleShard, {
+      rootDir: sampleCorpusDir,
+    });
+    expect(shard.issues).toEqual([]);
+    const expected = toGmailFixtureMessage(shard.messages[0]);
+
+    const startedAt = Date.now();
+    activeMocks = await startMocks({
+      envs: ["google"],
+      corpus: { dir: sampleCorpusDir },
+    });
+    const readyAt = Date.now();
+    const baseUrl = activeMocks.baseUrls.google;
+
+    const firstPage = await jsonRequest(
+      `${baseUrl}/gmail/v1/users/me/messages?maxResults=1`,
+    );
+    expect(firstPage.response.status).toBe(200);
+    expect(firstPage.body).toEqual(
+      expect.objectContaining({
+        resultSizeEstimate: expect.any(Number),
+        nextPageToken: "1",
+      }),
+    );
+    expect(firstPage.body.messages).toEqual([expect.any(Object)]);
+
+    const corpusSearch = await jsonRequest(
+      `${baseUrl}/gmail/v1/users/me/messages?q=Atlas%20launch%20checklist`,
+    );
+    expect(corpusSearch.response.status).toBe(200);
+    expect(corpusSearch.body.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: expected.id,
+          threadId: expected.threadId,
+        }),
+      ]),
+    );
+
+    const fetched = await jsonRequest(
+      `${baseUrl}/gmail/v1/users/me/messages/${expected.id}`,
+    );
+    expect(fetched.response.status).toBe(200);
+    expect(fetched.body).toEqual(
+      expect.objectContaining({
+        id: expected.id,
+        threadId: expected.threadId,
+        labelIds: expected.labelIds,
+        snippet: expected.snippet,
+        historyId: expect.any(String),
+        internalDate: expect.any(String),
+      }),
+    );
+    const internalDate = Number(fetched.body.internalDate);
+    expect(internalDate).toBeGreaterThanOrEqual(
+      startedAt + expected.internalDateOffsetMs,
+    );
+    expect(internalDate).toBeLessThanOrEqual(
+      readyAt + expected.internalDateOffsetMs,
+    );
+    expect(responseHeaders(fetched.body)).toEqual(
+      expect.arrayContaining([
+        { name: "From", value: "Alice Example <alice@example.test>" },
+        { name: "To", value: "Owner <owner@example.test>" },
+        { name: "Subject", value: "Atlas launch checklist" },
+        { name: "Message-Id", value: "<syn-gmail-001@corpus-tools.local>" },
+      ]),
+    );
+    expect(payloadBodyText(fetched.body)).toBe(expected.bodyText);
+
+    const modified = await jsonRequest(
+      `${baseUrl}/gmail/v1/users/me/messages/batchModify`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          ids: [expected.id],
+          removeLabelIds: ["UNREAD"],
+          addLabelIds: ["STARRED"],
+        }),
+      },
+    );
+    expect(modified.response.status).toBe(200);
+
+    const refetched = await jsonRequest(
+      `${baseUrl}/gmail/v1/users/me/messages/${expected.id}`,
+    );
+    expect(refetched.body.labelIds).toEqual(
+      expect.arrayContaining(["INBOX", "STARRED"]),
+    );
+    expect(refetched.body.labelIds).not.toContain("UNREAD");
+  });
+});

--- a/packages/test/mocks/__tests__/provider-coverage-contract.test.ts
+++ b/packages/test/mocks/__tests__/provider-coverage-contract.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Guards the LifeOps provider mock coverage ledger. Existing historical
+ * validation-path drift is listed explicitly so new drift fails mechanically
+ * while the backlog can burn down the acknowledged missing files one by one.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  LIFEOPS_PROVIDER_MOCK_COVERAGE,
+  REQUIRED_LIFEOPS_PROVIDER_IDS,
+} from "../helpers/provider-coverage.ts";
+import { MOCK_ENVIRONMENTS } from "../scripts/start-mocks.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "../../../..");
+
+const LEGACY_MISSING_VALIDATION_PATHS = new Set([
+  "test/mocks/__tests__/google-calendar-mock.test.ts",
+  "plugins/plugin-personal-assistant/test/lifeops-simulator.test.ts",
+  "test/mocks/__tests__/non-google-provider-mocks.test.ts",
+  "plugins/plugin-personal-assistant/src/actions/search-across-channels.test.ts",
+  "test/mocks/__tests__/mock-runtime-seeding.test.ts",
+  "plugins/plugin-personal-assistant/test/whatsapp.test.ts",
+  "plugins/plugin-telegram/src/local-client.test.ts",
+  "plugins/plugin-personal-assistant/src/lifeops/service-mixin-telegram.test.ts",
+  "plugins/plugin-personal-assistant/test/cross-channel-send.test.ts",
+  "plugins/plugin-personal-assistant/src/lifeops/service-mixin-signal.test.ts",
+  "plugins/plugin-personal-assistant/test/discord-browser-scraper.test.ts",
+  "plugins/plugin-personal-assistant/test/lifeops-discord-browser-companion.test.ts",
+  "plugins/plugin-personal-assistant/test/imessage.test.ts",
+  "plugins/plugin-personal-assistant/src/lifeops/imessage-bridge.test.ts",
+  "test/mocks/__tests__/mock-runtime.smoke.test.ts",
+  "plugins/plugin-personal-assistant/test/twilio-sms.test.ts",
+  "plugins/plugin-personal-assistant/test/twilio-call.test.ts",
+  "plugins/plugin-personal-assistant/test/calendly.test.ts",
+]);
+
+function resolveValidationPath(entry: string): string | null {
+  const candidates = [
+    path.resolve(repoRoot, entry),
+    entry.startsWith("test/")
+      ? path.resolve(repoRoot, "packages", entry)
+      : null,
+    entry.startsWith("../") ? path.resolve(repoRoot, entry.slice(3)) : null,
+    path.resolve(repoRoot, "packages/test", entry),
+  ].filter((candidate): candidate is string => Boolean(candidate));
+  return candidates.find((candidate) => fs.existsSync(candidate)) ?? null;
+}
+
+describe("provider coverage contract", () => {
+  it("lists exactly the required LifeOps provider ids once", () => {
+    const actual = LIFEOPS_PROVIDER_MOCK_COVERAGE.map((entry) => entry.id);
+    expect(new Set(actual).size).toBe(actual.length);
+    expect([...actual].sort()).toEqual(
+      [...REQUIRED_LIFEOPS_PROVIDER_IDS].sort(),
+    );
+  });
+
+  it("keeps environments, surfaces, gaps, and validation paths auditable", () => {
+    const environments = new Set(MOCK_ENVIRONMENTS);
+    const unexpectedMissing: string[] = [];
+    const staleAllowlist: string[] = [];
+
+    for (const entry of LIFEOPS_PROVIDER_MOCK_COVERAGE) {
+      if (entry.environment !== null) {
+        expect(environments.has(entry.environment)).toBe(true);
+      }
+      expect(entry.surfaces.length, `${entry.id} surfaces`).toBeGreaterThan(0);
+      expect(entry.knownGaps.length, `${entry.id} knownGaps`).toBeGreaterThan(
+        0,
+      );
+
+      for (const validationPath of entry.validation) {
+        const resolved = resolveValidationPath(validationPath);
+        if (!resolved && !LEGACY_MISSING_VALIDATION_PATHS.has(validationPath)) {
+          unexpectedMissing.push(validationPath);
+        }
+        if (resolved && LEGACY_MISSING_VALIDATION_PATHS.has(validationPath)) {
+          staleAllowlist.push(validationPath);
+        }
+      }
+    }
+
+    expect(unexpectedMissing).toEqual([]);
+    expect(staleAllowlist).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `provider-coverage-contract.test.ts` to mechanically guard the LifeOps provider mock coverage ledger: required provider ids, duplicate ids, known environments, non-empty surfaces/gaps, and validation-path drift.
- Adds `google-mock-fidelity.test.ts` for the corpus-loaded Gmail mock path: Google-shaped list/get responses, payload headers, `internalDate` ms string, body decode, search/list pagination, and batchModify label semantics.
- Keeps historical missing validation files explicit in a legacy allowlist so new drift fails while the backlog can burn down the known missing paths.

Depends on #15059 and #15058. Closes #14775.

## Validation
- `bunx vitest run packages/test/mocks/__tests__/provider-coverage-contract.test.ts packages/test/mocks/__tests__/google-mock-fidelity.test.ts packages/test/mocks/__tests__/google-gmail-corpus-loader.test.ts packages/test/mocks/__tests__/google-gmail-fault.test.ts` -> 4 files passed, 10 tests passed.
- `bunx @biomejs/biome check packages/test/mocks/__tests__/provider-coverage-contract.test.ts packages/test/mocks/__tests__/google-mock-fidelity.test.ts packages/test/mocks/__tests__/google-gmail-corpus-loader.test.ts packages/test/mocks/helpers/corpus-loader.ts packages/test/mocks/scripts/google-gmail-state.ts packages/test/mocks/scripts/start-mocks.ts packages/test/mocks/helpers/mock-runtime.ts packages/scenario-runner/src/seeds.ts packages/test/package.json` -> passed.
- `bun run --cwd packages/corpus-tools test` -> 1 file passed, 6 tests passed.
- `bun run --cwd packages/corpus-tools typecheck` -> passed.
- `bunx @biomejs/biome check packages/corpus-tools` -> passed.
- `git diff --cached --check && git diff --check` -> passed before commit.
- `bun run audit:error-policy-ratchet` -> passed.
- `bun run check:agents-claude` -> passed.

## Evidence
- Fidelity test starts the real local Google mock with the synthetic corpus, derives expected Gmail fixture fields from `toGmailFixtureMessage()`, fetches the HTTP Gmail message, decodes its payload body, verifies headers/labels/thread/history/internalDate shape, and mutates labels through `batchModify`.
- Provider coverage contract now exposes the historical missing validation paths as an explicit list rather than silent README drift.

N/A: live LLM trajectories, screenshots, and videos. This is mock/test contract infrastructure and does not change model behavior or rendered UI.

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - mock/test infrastructure, no rendered UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - mock/test infrastructure, no rendered UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no user-exercisable flow; behavior is covered by deterministic tests`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no server runtime code path changed; validated by inline vitest assertions`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent, action, prompt, or model behavior change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts `N/A - contract/test infrastructure only; mock wire-shape assertions are inline in the Validation section`.
