### PR TITLE
feat(corpus): add resumable PII scrub driver

### DIFF
--- a/packages/corpus-tools/README.md
+++ b/packages/corpus-tools/README.md
@@ -13,11 +13,20 @@ which is ignored by the repo-wide `**/data/` rule. Only synthetic fixtures under
 
 ```bash
 bun run --cwd packages/corpus-tools validate -- fixtures/synthetic
+bun run --cwd packages/corpus-tools corpus:scrub -- --target data --stage all --mode deep --resume
+bun run --cwd packages/corpus-tools corpus:scrub -- --target data --stage llm --mode fast-track --dry-run
 ```
 
 The validator accepts either a shard file or a directory of `*.jsonl` shards and
 prints a JSON summary. It fails non-zero on schema, cutoff, duplicate-id,
 reply-reference, thread-reference, or manifest-integrity errors.
+
+The scrub driver writes its local-only ledger, output, and report under
+`<target>/.state/` by default. Keep generated outputs there or outside the input
+tree; a top-level `*.jsonl` beside platform shards is treated as corpus input by
+the validator. `--resume` reuses content-hash + ruleset-version markers from
+`scrub-ledger.jsonl`, so rerunning unchanged input should report zero stage
+executions and a ledger hit rate of `1`.
 
 ## X Mapping
 

--- a/packages/corpus-tools/package.json
+++ b/packages/corpus-tools/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "validate": "bun src/cli.ts validate",
+    "corpus:scrub": "bun src/cli.ts scrub",
     "test": "node ../scripts/run-vitest.mjs run --config ./vitest.config.ts",
     "typecheck": "tsgo --noEmit -p tsconfig.json",
     "lint": "bunx @biomejs/biome check src fixtures",

--- a/packages/corpus-tools/src/cli.ts
+++ b/packages/corpus-tools/src/cli.ts
@@ -4,18 +4,82 @@
  * diagnostics; this file is the only place that prints and converts validation
  * failure into a process exit code.
  */
+import {
+  runScrubPipeline,
+  type ScrubMode,
+  type ScrubStageSelector,
+} from "./pipeline/driver.ts";
 import { validateCorpusTarget } from "./validator.ts";
 
+interface ScrubCliOptions {
+  targetPath: string;
+  stage: ScrubStageSelector;
+  mode: ScrubMode;
+  resume: boolean;
+  dryRun: boolean;
+  rulesetVersion: string;
+  stateDir?: string;
+  ledgerPath?: string;
+  outputPath?: string;
+  reportPath?: string;
+}
+
+function readFlagValue(args: string[], flag: string): string | undefined {
+  const index = args.indexOf(flag);
+  if (index === -1) return undefined;
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`missing value for ${flag}`);
+  }
+  return value;
+}
+
+function parseScrubCliOptions(args: string[]): ScrubCliOptions {
+  const stage = readFlagValue(args, "--stage") ?? "all";
+  const mode = readFlagValue(args, "--mode") ?? "deep";
+  if (
+    !["all", "mine", "secrets", "delete", "rewrite", "llm", "verify"].includes(
+      stage,
+    )
+  ) {
+    throw new Error(`invalid --stage ${stage}`);
+  }
+  if (mode !== "fast-track" && mode !== "deep") {
+    throw new Error(`invalid --mode ${mode}`);
+  }
+  return {
+    targetPath: readFlagValue(args, "--target") ?? "data",
+    stage: stage as ScrubStageSelector,
+    mode,
+    resume: args.includes("--resume"),
+    dryRun: args.includes("--dry-run"),
+    rulesetVersion: readFlagValue(args, "--ruleset-version") ?? "1",
+    stateDir: readFlagValue(args, "--state-dir"),
+    ledgerPath: readFlagValue(args, "--ledger"),
+    outputPath: readFlagValue(args, "--output"),
+    reportPath: readFlagValue(args, "--report"),
+  };
+}
+
 async function main(argv: string[]): Promise<number> {
-  const [command, target = "data"] = argv;
-  if (command !== "validate") {
-    process.stderr.write("usage: corpus validate <file-or-dir>\n");
-    return 2;
+  const [command, maybeTarget = "data", ...rest] = argv;
+  if (command === "validate") {
+    const result = await validateCorpusTarget(maybeTarget);
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return result.ok ? 0 : 1;
   }
 
-  const result = await validateCorpusTarget(target);
-  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
-  return result.ok ? 0 : 1;
+  if (command === "scrub") {
+    const options = parseScrubCliOptions([maybeTarget, ...rest]);
+    const result = await runScrubPipeline(options);
+    process.stdout.write(`${JSON.stringify(result.report, null, 2)}\n`);
+    return 0;
+  }
+
+  process.stderr.write(
+    "usage: corpus validate <file-or-dir>\n       corpus scrub --target <file-or-dir> --stage <stage|all> --mode <deep|fast-track> [--resume] [--dry-run]\n",
+  );
+  return 2;
 }
 
 main(process.argv.slice(2))

--- a/packages/corpus-tools/src/index.ts
+++ b/packages/corpus-tools/src/index.ts
@@ -3,5 +3,6 @@
  * loader adapters.
  */
 export * from "./mappers.ts";
+export * from "./pipeline/driver.ts";
 export * from "./schema.ts";
 export * from "./validator.ts";

--- a/packages/corpus-tools/src/pipeline/driver.test.ts
+++ b/packages/corpus-tools/src/pipeline/driver.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Scrub-driver tests for #14764. The stages are deterministic stand-ins for
+ * downstream PII detectors and rewriters so the tests can prove orchestration:
+ * marker idempotency, crash resume, fast-track clustering, and cost reporting.
+ */
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { CorpusMessage, ScrubState } from "../schema.ts";
+import {
+  runScrubPipeline,
+  type ScrubStageDefinition,
+  type ScrubStageName,
+} from "./driver.ts";
+
+const BASE_TS = Date.parse("2026-06-01T12:00:00.000Z");
+
+function hashMessages(messages: readonly CorpusMessage[]): string {
+  return createHash("sha256").update(JSON.stringify(messages)).digest("hex");
+}
+
+function message(
+  id: string,
+  text: string,
+  labels: string[] = [],
+): CorpusMessage {
+  return {
+    id,
+    platform: "gmail",
+    accountId: "work",
+    threadId: `thread-${id}`,
+    ts: BASE_TS,
+    direction: "in",
+    senderId: "newsletter@example.test",
+    senderDisplay: "Newsletter Example",
+    recipients: [
+      { id: "owner", display: "Owner", address: "owner@example.test" },
+    ],
+    subject: "Weekly digest",
+    text,
+    labels,
+    attachments: [],
+    scrubState: "raw",
+  };
+}
+
+async function writeShard(dir: string, messages: readonly CorpusMessage[]) {
+  const shard = path.join(dir, "gmail", "work", "2026-06.jsonl");
+  await fs.mkdir(path.dirname(shard), { recursive: true });
+  await fs.writeFile(
+    shard,
+    `${messages.map((row) => JSON.stringify(row)).join("\n")}\n`,
+  );
+  return shard;
+}
+
+function targetState(stage: ScrubStageName): ScrubState {
+  switch (stage) {
+    case "mine":
+      return "mined";
+    case "secrets":
+    case "delete":
+      return "swapped";
+    case "rewrite":
+    case "llm":
+      return "rewritten";
+    case "verify":
+      return "verified";
+  }
+}
+
+function deterministicStages(): ScrubStageDefinition[] {
+  const stageNames: ScrubStageName[] = [
+    "mine",
+    "secrets",
+    "delete",
+    "rewrite",
+    "llm",
+    "verify",
+  ];
+  return stageNames.map((stageName) => ({
+    name: stageName,
+    version: "test-v1",
+    targetState: targetState(stageName),
+    run(message, context) {
+      const next: CorpusMessage = {
+        ...message,
+        text:
+          stageName === "rewrite"
+            ? message.text.replaceAll("Alice", "Person A")
+            : message.text,
+        scrubState: targetState(stageName),
+      };
+      return {
+        message: next,
+        cost:
+          stageName === "llm" &&
+          (context.mode === "deep" || context.isClusterExemplar)
+            ? {
+                inputTokens: 100,
+                outputTokens: 20,
+                estimatedUsd: 0.01,
+                llmCalls: 1,
+              }
+            : {
+                inputTokens: 0,
+                outputTokens: 0,
+                estimatedUsd: 0,
+                llmCalls: 0,
+              },
+      };
+    },
+  }));
+}
+
+describe("scrub pipeline driver", () => {
+  it("resumes after interruption to the same final output hash", async () => {
+    const uninterruptedDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "corpus-scrub-uninterrupted-"),
+    );
+    const resumedDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "corpus-scrub-resumed-"),
+    );
+    const rows = [
+      message("msg-1", "Alice can review the packet."),
+      message("msg-2", "Alice will send notes tomorrow."),
+      message("msg-3", "No personal name here."),
+    ];
+    await writeShard(uninterruptedDir, rows);
+    await writeShard(resumedDir, rows);
+
+    const uninterrupted = await runScrubPipeline({
+      targetPath: uninterruptedDir,
+      mode: "deep",
+      resume: true,
+      dryRun: false,
+      rulesetVersion: "resume-test",
+      stages: deterministicStages(),
+    });
+
+    await expect(
+      runScrubPipeline({
+        targetPath: resumedDir,
+        mode: "deep",
+        resume: true,
+        dryRun: false,
+        rulesetVersion: "resume-test",
+        stages: deterministicStages(),
+        maxStageExecutions: 5,
+      }),
+    ).rejects.toThrow("simulated interruption");
+
+    const resumed = await runScrubPipeline({
+      targetPath: resumedDir,
+      mode: "deep",
+      resume: true,
+      dryRun: false,
+      rulesetVersion: "resume-test",
+      stages: deterministicStages(),
+    });
+
+    expect(hashMessages(resumed.messages)).toBe(
+      hashMessages(uninterrupted.messages),
+    );
+    expect(resumed.report.ledger.hitRate).toBeGreaterThan(0);
+    expect(resumed.messages.every((row) => row.scrubState === "verified")).toBe(
+      true,
+    );
+  });
+
+  it("reruns unchanged input as 100% ledger hits", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "corpus-scrub-rerun-"));
+    await writeShard(dir, [
+      message("msg-1", "Alice can review the packet."),
+      message("msg-2", "Alice can review the packet again."),
+    ]);
+
+    await runScrubPipeline({
+      targetPath: dir,
+      mode: "deep",
+      resume: true,
+      dryRun: false,
+      rulesetVersion: "rerun-test",
+      stages: deterministicStages(),
+    });
+    const rerun = await runScrubPipeline({
+      targetPath: dir,
+      mode: "deep",
+      resume: true,
+      dryRun: false,
+      rulesetVersion: "rerun-test",
+      stages: deterministicStages(),
+    });
+
+    expect(rerun.report.ledger.recordsWritten).toBe(0);
+    expect(rerun.report.ledger.hitRate).toBe(1);
+    expect(
+      rerun.report.stageReports.every((stage) => stage.executed === 0),
+    ).toBe(true);
+  });
+
+  it("fast-track reduces newsletter LLM calls by at least 10x", async () => {
+    const deepDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "corpus-scrub-deep-"),
+    );
+    const fastDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "corpus-scrub-fast-"),
+    );
+    const rows = Array.from({ length: 1_000 }, (_, index) =>
+      message(
+        `newsletter-${index}`,
+        `Weekly digest issue ${index}: Alice can review item ${index}. Visit https://example.test/${index}.`,
+        ["newsletter"],
+      ),
+    );
+    await writeShard(deepDir, rows);
+    await writeShard(fastDir, rows);
+
+    const deep = await runScrubPipeline({
+      targetPath: deepDir,
+      mode: "deep",
+      resume: true,
+      dryRun: false,
+      rulesetVersion: "fast-track-test",
+      stages: deterministicStages(),
+    });
+    const fast = await runScrubPipeline({
+      targetPath: fastDir,
+      mode: "fast-track",
+      resume: true,
+      dryRun: false,
+      rulesetVersion: "fast-track-test",
+      stages: deterministicStages(),
+    });
+
+    const deepLlmCalls = deep.report.stageReports.find(
+      (stage) => stage.stage === "llm",
+    )?.llmCalls;
+    const fastLlmCalls = fast.report.stageReports.find(
+      (stage) => stage.stage === "llm",
+    )?.llmCalls;
+    expect(deepLlmCalls).toBe(1_000);
+    expect(fastLlmCalls).toBeLessThanOrEqual(100);
+    expect(fast.report.clusterStats.largestCluster).toBe(1_000);
+    expect(fast.report.stageReports).toContainEqual(
+      expect.objectContaining({
+        stage: "llm",
+        inputTokens: fastLlmCalls === undefined ? 0 : fastLlmCalls * 100,
+      }),
+    );
+  });
+});

--- a/packages/corpus-tools/src/pipeline/driver.ts
+++ b/packages/corpus-tools/src/pipeline/driver.ts
@@ -1,0 +1,525 @@
+/**
+ * Idempotent scrub-pipeline driver for personal-corpus rows. The driver owns
+ * the stage graph, per-stage marker ledger, fast-track clustering, cost report,
+ * and CLI-facing file orchestration; individual PII detectors and rewrite
+ * engines plug in as pure stage functions.
+ */
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import {
+  assertScrubStateTransition,
+  type CorpusMessage,
+  type ScrubState,
+  scrubStateRank,
+} from "../schema.ts";
+import { findCorpusShardFiles, readCorpusShard } from "../validator.ts";
+
+export const SCRUB_STAGE_NAMES = [
+  "mine",
+  "secrets",
+  "delete",
+  "rewrite",
+  "llm",
+  "verify",
+] as const;
+
+export type ScrubStageName = (typeof SCRUB_STAGE_NAMES)[number];
+export type ScrubMode = "fast-track" | "deep";
+export type ScrubStageSelector = ScrubStageName | "all";
+
+export interface ScrubStageContext {
+  stage: ScrubStageName;
+  mode: ScrubMode;
+  rulesetVersion: string;
+  inputHash: string;
+  markerKey: string;
+  clusterKey: string;
+  isClusterExemplar: boolean;
+}
+
+export interface ScrubStageResult {
+  message?: CorpusMessage;
+  tombstone?: boolean;
+  cost?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    estimatedUsd?: number;
+    llmCalls?: number;
+  };
+}
+
+export type ScrubStageFunction = (
+  message: CorpusMessage,
+  context: ScrubStageContext,
+) => ScrubStageResult | Promise<ScrubStageResult>;
+
+export interface ScrubStageDefinition {
+  name: ScrubStageName;
+  version: string;
+  targetState: ScrubState;
+  run: ScrubStageFunction;
+}
+
+export interface ScrubLedgerRecord {
+  markerKey: string;
+  messageId: string;
+  stage: ScrubStageName;
+  stageVersion: string;
+  rulesetVersion: string;
+  inputHash: string;
+  outputHash: string;
+  tombstone: boolean;
+  clusterKey: string;
+  isClusterExemplar: boolean;
+  cost: Required<NonNullable<ScrubStageResult["cost"]>>;
+  output?: CorpusMessage;
+}
+
+export interface ScrubRunOptions {
+  targetPath: string;
+  stateDir?: string;
+  ledgerPath?: string;
+  outputPath?: string;
+  reportPath?: string;
+  stage?: ScrubStageSelector;
+  mode: ScrubMode;
+  resume: boolean;
+  dryRun: boolean;
+  rulesetVersion: string;
+  stages?: readonly ScrubStageDefinition[];
+  maxStageExecutions?: number;
+}
+
+export interface ScrubStageReport {
+  stage: ScrubStageName;
+  stageVersion: string;
+  executed: number;
+  ledgerHits: number;
+  alreadyComplete: number;
+  tombstoned: number;
+  llmCalls: number;
+  inputTokens: number;
+  outputTokens: number;
+  estimatedUsd: number;
+}
+
+export interface ScrubRunReport {
+  mode: ScrubMode;
+  stage: ScrubStageSelector;
+  rulesetVersion: string;
+  dryRun: boolean;
+  inputMessages: number;
+  outputMessages: number;
+  stageReports: ScrubStageReport[];
+  clusterStats: {
+    clusters: number;
+    largestCluster: number;
+    fastTrackEligibleMessages: number;
+    exemplarMessages: number;
+  };
+  ledger: {
+    path: string;
+    recordsRead: number;
+    recordsWritten: number;
+    hitRate: number;
+  };
+  outputPath?: string;
+  reportPath?: string;
+}
+
+interface LedgerState {
+  recordsRead: number;
+  byKey: Map<string, ScrubLedgerRecord>;
+}
+
+const ZERO_COST: Required<NonNullable<ScrubStageResult["cost"]>> = {
+  inputTokens: 0,
+  outputTokens: 0,
+  estimatedUsd: 0,
+  llmCalls: 0,
+};
+
+function sha256Json(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function stableCloneMessage(message: CorpusMessage): CorpusMessage {
+  return JSON.parse(JSON.stringify(message)) as CorpusMessage;
+}
+
+function costOf(
+  cost: ScrubStageResult["cost"],
+): Required<NonNullable<ScrubStageResult["cost"]>> {
+  return {
+    inputTokens: cost?.inputTokens ?? 0,
+    outputTokens: cost?.outputTokens ?? 0,
+    estimatedUsd: cost?.estimatedUsd ?? 0,
+    llmCalls: cost?.llmCalls ?? 0,
+  };
+}
+
+function stageKey(params: {
+  inputHash: string;
+  stage: ScrubStageName;
+  stageVersion: string;
+  rulesetVersion: string;
+}): string {
+  return [
+    `pii:${params.inputHash}:v${params.rulesetVersion}`,
+    params.stage,
+    params.stageVersion,
+  ].join(":");
+}
+
+function defaultStateDir(targetPath: string): string {
+  const base = path.extname(targetPath) ? path.dirname(targetPath) : targetPath;
+  return path.join(base, ".state");
+}
+
+function stageTargetState(stage: ScrubStageName): ScrubState {
+  switch (stage) {
+    case "mine":
+      return "mined";
+    case "secrets":
+    case "delete":
+      return "swapped";
+    case "rewrite":
+    case "llm":
+      return "rewritten";
+    case "verify":
+      return "verified";
+  }
+}
+
+function normalizeNewsletterTemplate(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/g, "<email>")
+    .replace(/https?:\/\/\S+/g, "<url>")
+    .replace(/\b\d+\b/g, "<number>")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function clusterKeyFor(message: CorpusMessage, mode: ScrubMode): string {
+  if (mode === "deep") return message.id;
+  const labels = new Set(message.labels.map((label) => label.toLowerCase()));
+  const fastTrackLabel =
+    labels.has("newsletter") ||
+    labels.has("notification") ||
+    labels.has("promotions") ||
+    labels.has("updates");
+  if (!fastTrackLabel) return message.id;
+  return sha256Json({
+    platform: message.platform,
+    accountId: message.accountId,
+    subject: message.subject ?? "",
+    template: normalizeNewsletterTemplate(message.text),
+  });
+}
+
+function clusterStats(messages: readonly CorpusMessage[], mode: ScrubMode) {
+  const counts = new Map<string, number>();
+  for (const message of messages) {
+    const key = clusterKeyFor(message, mode);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  let largestCluster = 0;
+  let fastTrackEligibleMessages = 0;
+  for (const count of counts.values()) {
+    if (count > largestCluster) largestCluster = count;
+    if (count > 1) fastTrackEligibleMessages += count;
+  }
+  return {
+    clusters: counts.size,
+    largestCluster,
+    fastTrackEligibleMessages,
+    exemplarMessages: counts.size,
+  };
+}
+
+async function loadLedger(ledgerPath: string): Promise<LedgerState> {
+  try {
+    const raw = await fs.readFile(ledgerPath, "utf8");
+    const byKey = new Map<string, ScrubLedgerRecord>();
+    let recordsRead = 0;
+    for (const line of raw.split(/\r?\n/)) {
+      if (line.trim().length === 0) continue;
+      const record = JSON.parse(line) as ScrubLedgerRecord;
+      byKey.set(record.markerKey, record);
+      recordsRead += 1;
+    }
+    return { recordsRead, byKey };
+  } catch (error) {
+    // error-policy:J4 first run has no local-only ledger yet; other read failures surface.
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return { recordsRead: 0, byKey: new Map() };
+    }
+    throw error;
+  }
+}
+
+async function appendLedgerRecord(
+  ledgerPath: string,
+  record: ScrubLedgerRecord,
+): Promise<void> {
+  await fs.mkdir(path.dirname(ledgerPath), { recursive: true });
+  await fs.appendFile(ledgerPath, `${JSON.stringify(record)}\n`);
+}
+
+async function readMessages(targetPath: string): Promise<CorpusMessage[]> {
+  const files = (await findCorpusShardFiles(targetPath)).filter(
+    (file) => !file.split(path.sep).includes(".state"),
+  );
+  const messages: CorpusMessage[] = [];
+  for (const file of files) {
+    const shard = await readCorpusShard(file, {
+      rootDir: path.extname(targetPath) ? path.dirname(targetPath) : targetPath,
+    });
+    if (shard.issues.length > 0) {
+      throw new Error(
+        `invalid corpus shard ${file}: ${shard.issues
+          .map((issue) => issue.message)
+          .join("; ")}`,
+      );
+    }
+    messages.push(...shard.messages);
+  }
+  return messages;
+}
+
+function selectedStages(
+  selector: ScrubStageSelector,
+  stages: readonly ScrubStageDefinition[],
+): ScrubStageDefinition[] {
+  if (selector === "all") return [...stages];
+  const found = stages.find((stage) => stage.name === selector);
+  if (!found) {
+    throw new Error(`unknown scrub stage ${selector}`);
+  }
+  return [found];
+}
+
+function defaultStage(stage: ScrubStageName): ScrubStageDefinition {
+  const targetState = stageTargetState(stage);
+  return {
+    name: stage,
+    version: "1",
+    targetState,
+    run(message, context) {
+      assertScrubStateTransition(message.scrubState, targetState);
+      const next = stableCloneMessage(message);
+      next.scrubState = targetState;
+      const isLlmExemplar =
+        stage === "llm" &&
+        (context.mode === "deep" || context.isClusterExemplar);
+      return {
+        message: next,
+        cost: isLlmExemplar
+          ? {
+              inputTokens: Math.ceil(message.text.length / 4),
+              outputTokens: Math.ceil(message.text.length / 8),
+              estimatedUsd: 0.000001 * message.text.length,
+              llmCalls: 1,
+            }
+          : ZERO_COST,
+      };
+    },
+  };
+}
+
+export function defaultScrubStages(): ScrubStageDefinition[] {
+  return SCRUB_STAGE_NAMES.map(defaultStage);
+}
+
+async function writeJsonl(
+  outputPath: string,
+  messages: readonly CorpusMessage[],
+): Promise<void> {
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(
+    outputPath,
+    `${messages.map((message) => JSON.stringify(message)).join("\n")}\n`,
+  );
+}
+
+async function writeReport(
+  reportPath: string,
+  report: ScrubRunReport,
+): Promise<void> {
+  await fs.mkdir(path.dirname(reportPath), { recursive: true });
+  await fs.writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`);
+}
+
+export async function runScrubPipeline(
+  options: ScrubRunOptions,
+): Promise<{ messages: CorpusMessage[]; report: ScrubRunReport }> {
+  const selector = options.stage ?? "all";
+  const stages = selectedStages(
+    selector,
+    options.stages ?? defaultScrubStages(),
+  );
+  const stateDir = options.stateDir ?? defaultStateDir(options.targetPath);
+  const ledgerPath =
+    options.ledgerPath ?? path.join(stateDir, "scrub-ledger.jsonl");
+  const outputPath =
+    options.outputPath ?? path.join(stateDir, "scrub-output.jsonl");
+  const reportPath =
+    options.reportPath ?? path.join(stateDir, "scrub-report.json");
+  const ledger = options.resume
+    ? await loadLedger(ledgerPath)
+    : { recordsRead: 0, byKey: new Map<string, ScrubLedgerRecord>() };
+  let recordsWritten = 0;
+  let stageExecutions = 0;
+  let messages = await readMessages(options.targetPath);
+  const inputMessages = messages.length;
+  const stats = clusterStats(messages, options.mode);
+  const clusterExemplars = new Set<string>();
+  const stageReports: ScrubStageReport[] = stages.map((stage) => ({
+    stage: stage.name,
+    stageVersion: stage.version,
+    executed: 0,
+    ledgerHits: 0,
+    alreadyComplete: 0,
+    tombstoned: 0,
+    llmCalls: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    estimatedUsd: 0,
+  }));
+
+  for (let stageIndex = 0; stageIndex < stages.length; stageIndex += 1) {
+    const stage = stages[stageIndex];
+    const report = stageReports[stageIndex];
+    const nextMessages: CorpusMessage[] = [];
+    clusterExemplars.clear();
+
+    for (const message of messages) {
+      if (
+        scrubStateRank[message.scrubState] > scrubStateRank[stage.targetState]
+      ) {
+        report.alreadyComplete += 1;
+        nextMessages.push(stableCloneMessage(message));
+        continue;
+      }
+      const inputHash = sha256Json(message);
+      const clusterKey = clusterKeyFor(message, options.mode);
+      const isClusterExemplar = !clusterExemplars.has(clusterKey);
+      clusterExemplars.add(clusterKey);
+      const key = stageKey({
+        inputHash,
+        stage: stage.name,
+        stageVersion: stage.version,
+        rulesetVersion: options.rulesetVersion,
+      });
+      const existing = ledger.byKey.get(key);
+      if (existing) {
+        report.ledgerHits += 1;
+        if (existing.tombstone) {
+          report.tombstoned += 1;
+          continue;
+        }
+        if (!existing.output) {
+          throw new Error(`ledger record ${key} is missing output snapshot`);
+        }
+        nextMessages.push(stableCloneMessage(existing.output));
+        continue;
+      }
+
+      if (options.dryRun) {
+        report.executed += 1;
+        nextMessages.push(stableCloneMessage(message));
+        continue;
+      }
+
+      if (
+        options.maxStageExecutions !== undefined &&
+        stageExecutions >= options.maxStageExecutions
+      ) {
+        throw new Error(
+          `simulated interruption after ${stageExecutions} stage executions`,
+        );
+      }
+
+      const result = await stage.run(message, {
+        stage: stage.name,
+        mode: options.mode,
+        rulesetVersion: options.rulesetVersion,
+        inputHash,
+        markerKey: key,
+        clusterKey,
+        isClusterExemplar,
+      });
+      stageExecutions += 1;
+      report.executed += 1;
+      const cost = costOf(result.cost);
+      report.llmCalls += cost.llmCalls;
+      report.inputTokens += cost.inputTokens;
+      report.outputTokens += cost.outputTokens;
+      report.estimatedUsd += cost.estimatedUsd;
+      const output = result.tombstone ? undefined : result.message;
+      if (!result.tombstone && !output) {
+        throw new Error(
+          `stage ${stage.name} returned neither message nor tombstone`,
+        );
+      }
+      if (output) {
+        assertScrubStateTransition(message.scrubState, output.scrubState);
+        nextMessages.push(stableCloneMessage(output));
+      } else {
+        report.tombstoned += 1;
+      }
+      const record: ScrubLedgerRecord = {
+        markerKey: key,
+        messageId: message.id,
+        stage: stage.name,
+        stageVersion: stage.version,
+        rulesetVersion: options.rulesetVersion,
+        inputHash,
+        outputHash: sha256Json(output ?? { tombstone: true }),
+        tombstone: result.tombstone === true,
+        clusterKey,
+        isClusterExemplar,
+        cost,
+        output: output ? stableCloneMessage(output) : undefined,
+      };
+      ledger.byKey.set(key, record);
+      await appendLedgerRecord(ledgerPath, record);
+      recordsWritten += 1;
+    }
+    messages = nextMessages;
+  }
+
+  if (!options.dryRun) {
+    await writeJsonl(outputPath, messages);
+  }
+  const totalHits = stageReports.reduce(
+    (sum, report) => sum + report.ledgerHits,
+    0,
+  );
+  const totalAttempts = stageReports.reduce(
+    (sum, report) => sum + report.ledgerHits + report.executed,
+    0,
+  );
+  const runReport: ScrubRunReport = {
+    mode: options.mode,
+    stage: selector,
+    rulesetVersion: options.rulesetVersion,
+    dryRun: options.dryRun,
+    inputMessages,
+    outputMessages: messages.length,
+    stageReports,
+    clusterStats: stats,
+    ledger: {
+      path: ledgerPath,
+      recordsRead: ledger.recordsRead,
+      recordsWritten,
+      hitRate: totalAttempts === 0 ? 0 : totalHits / totalAttempts,
+    },
+    outputPath: options.dryRun ? undefined : outputPath,
+    reportPath,
+  };
+  await writeReport(reportPath, runReport);
+  return { messages, report: runReport };
+}


### PR DESCRIPTION
## Summary
- Adds the #14764 resumable PII scrub driver under `packages/corpus-tools/src/pipeline/` with the stage graph `mine -> secrets -> delete -> rewrite -> llm -> verify`.
- Adds content-hash + ruleset-version ledger markers (`scrub-ledger.jsonl`) that persist local output snapshots for true crash resume and unchanged-input idempotency.
- Adds deep vs fast-track modes, deterministic newsletter clustering, per-stage cost/LLM-call reporting, CLI wiring, and README operator notes.
- Adds tests proving interrupted resume reaches the same final output hash, unchanged reruns execute zero stages with hit rate `1`, and fast-track reduces synthetic newsletter LLM calls by at least 10x.

## Validation
- `bun run --cwd packages/corpus-tools typecheck`
- `bun run --cwd packages/corpus-tools test` -> 2 files / 9 tests passing
- `bun run --cwd packages/corpus-tools lint`
- Raw synthetic CLI evidence: `corpus:scrub --target <tmp raw synthetic> --stage all --mode deep --resume --ruleset-version raw-evidence-v1`
  - first run: 20 input / 20 output, 120 ledger records written, all six stages executed 20 times, LLM calls 20
  - rerun: 0 records written, ledger hit rate 1, all six stages executed 0 times
- Verified synthetic CLI evidence: existing verified fixture skips earlier stages as already complete; rerun writes 0 records and reports ledger hit rate 1
- `git diff --check HEAD~1..HEAD`
- `bun run check:agents-claude`
- `bun run audit:error-policy-ratchet`

## Known blocker
- `node packages/scripts/type-safety-ratchet.mjs` still fails on pre-existing repo-wide baseline drift outside this package: `as unknown as` 75/73 and core/agent/app-core `?? []` 582/581. The new corpus-tools driver/type tests pass and the error-policy ratchet is clean.

## Notes
- This PR is stacked on #15058 (`fix/14748-corpus-tools`) because `packages/corpus-tools` is not on `develop` yet.
- Stage implementations are intentionally out of scope per #14764; this PR provides the orchestration rails and deterministic stage interface those issues plug into.

Closes #14764

## Required Evidence Rows
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots N/A - package CLI/pipeline change only; no UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots N/A - package CLI/pipeline change only; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video N/A - package CLI/pipeline change only; no UI surface.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs N/A - no server process; validation used package CLI output captured in the issue evidence.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs N/A - no frontend surface or browser runtime changed.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory N/A - corpus-tools scrub-driver orchestration only; no agent/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts https://github.com/elizaOS/eliza/issues/14764#issuecomment-4894736490