### PR TITLE
feat(corpus): add deterministic PII candidate mining

### DIFF
--- a/packages/corpus-tools/README.md
+++ b/packages/corpus-tools/README.md
@@ -28,6 +28,12 @@ the validator. `--resume` reuses content-hash + ruleset-version markers from
 `scrub-ledger.jsonl`, so rerunning unchanged input should report zero stage
 executions and a ledger hit rate of `1`.
 
+Stage `mine` also emits `candidates.jsonl`, `candidate-frequency.json`, and
+`candidate-review.csv` under `.state/`. Candidate rows carry source references
+and salted value hashes; replacement identity is intentionally deferred to the
+context/pseudonym-consistency pass so this deterministic stage never forks the
+corpus-wide mapping.
+
 ## X Mapping
 
 The canonical schema includes platform `x`. The existing LifeOps simulator

--- a/packages/corpus-tools/package.json
+++ b/packages/corpus-tools/package.json
@@ -22,6 +22,7 @@
     "format:check": "bunx @biomejs/biome format src fixtures"
   },
   "dependencies": {
+    "@elizaos/core": "workspace:*",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/corpus-tools/src/pipeline/driver.ts
+++ b/packages/corpus-tools/src/pipeline/driver.ts
@@ -14,6 +14,7 @@ import {
   scrubStateRank,
 } from "../schema.ts";
 import { findCorpusShardFiles, readCorpusShard } from "../validator.ts";
+import { minePiiCandidates, writeMineArtifacts } from "./mine.ts";
 
 export const SCRUB_STAGE_NAMES = [
   "mine",
@@ -41,6 +42,7 @@ export interface ScrubStageContext {
 export interface ScrubStageResult {
   message?: CorpusMessage;
   tombstone?: boolean;
+  metadata?: Record<string, unknown>;
   cost?: {
     inputTokens?: number;
     outputTokens?: number;
@@ -102,6 +104,7 @@ export interface ScrubStageReport {
   inputTokens: number;
   outputTokens: number;
   estimatedUsd: number;
+  candidateCount?: number;
 }
 
 export interface ScrubRunReport {
@@ -126,6 +129,11 @@ export interface ScrubRunReport {
   };
   outputPath?: string;
   reportPath?: string;
+  mineArtifacts?: {
+    candidatesPath: string;
+    frequencyPath: string;
+    reviewCsvPath: string;
+  };
 }
 
 interface LedgerState {
@@ -307,15 +315,27 @@ function defaultStage(stage: ScrubStageName): ScrubStageDefinition {
     name: stage,
     version: "1",
     targetState,
-    run(message, context) {
+    async run(message, context) {
       assertScrubStateTransition(message.scrubState, targetState);
       const next = stableCloneMessage(message);
       next.scrubState = targetState;
+      const mined =
+        stage === "mine"
+          ? await minePiiCandidates([message], {
+              hashSalt: context.rulesetVersion,
+            })
+          : undefined;
       const isLlmExemplar =
         stage === "llm" &&
         (context.mode === "deep" || context.isClusterExemplar);
       return {
         message: next,
+        metadata:
+          mined === undefined
+            ? undefined
+            : {
+                candidateCount: mined.candidates.length,
+              },
         cost: isLlmExemplar
           ? {
               inputTokens: Math.ceil(message.text.length / 4),
@@ -388,6 +408,7 @@ export async function runScrubPipeline(
     outputTokens: 0,
     estimatedUsd: 0,
   }));
+  let mineArtifactPaths: ScrubRunReport["mineArtifacts"] | undefined;
 
   for (let stageIndex = 0; stageIndex < stages.length; stageIndex += 1) {
     const stage = stages[stageIndex];
@@ -458,6 +479,15 @@ export async function runScrubPipeline(
       report.inputTokens += cost.inputTokens;
       report.outputTokens += cost.outputTokens;
       report.estimatedUsd += cost.estimatedUsd;
+      if (
+        result.metadata &&
+        typeof result.metadata === "object" &&
+        "candidateCount" in result.metadata &&
+        typeof result.metadata.candidateCount === "number"
+      ) {
+        report.candidateCount =
+          (report.candidateCount ?? 0) + result.metadata.candidateCount;
+      }
       const output = result.tombstone ? undefined : result.message;
       if (!result.tombstone && !output) {
         throw new Error(
@@ -489,6 +519,13 @@ export async function runScrubPipeline(
       recordsWritten += 1;
     }
     messages = nextMessages;
+    if (!options.dryRun && stage.name === "mine") {
+      const artifacts = await minePiiCandidates(messages, {
+        hashSalt: options.rulesetVersion,
+      });
+      mineArtifactPaths = await writeMineArtifacts(stateDir, artifacts);
+      report.candidateCount = artifacts.candidates.length;
+    }
   }
 
   if (!options.dryRun) {
@@ -519,6 +556,7 @@ export async function runScrubPipeline(
     },
     outputPath: options.dryRun ? undefined : outputPath,
     reportPath,
+    mineArtifacts: mineArtifactPaths,
   };
   await writeReport(reportPath, runReport);
   return { messages, report: runReport };

--- a/packages/corpus-tools/src/pipeline/mine.test.ts
+++ b/packages/corpus-tools/src/pipeline/mine.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Stage-0 PII mining coverage for #14766. These tests prove the corpus miner
+ * catches every deterministic core detector kind, includes contact-gazetteer
+ * entity spans, and emits byte-stable owner-review artifacts for the same salt.
+ */
+import { PII_DETECTORS } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import type { CorpusContact, CorpusMessage } from "../schema.ts";
+import { minePiiCandidates } from "./mine.ts";
+
+const BASE_TS = Date.parse("2026-06-01T12:00:00.000Z");
+
+const CANARIES: Readonly<Record<string, string>> = {
+  email: "jane.doe+x@example.co.uk",
+  "credit-card": "4242424242424242",
+  ssn: "123-45-6789",
+  iban: "GB29 NWBK 6016 1331 9268 19",
+  jwt: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U",
+  "seed-phrase":
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+  "wif-private-key": "5HueCGU8rMjxEXxiPuD5BDku4MkFqeZyd4dZ1jvhTVqvbTLvyTJ",
+  "url-credentials": "postgres://app:s3cr3tP4ss@db.host:5432/prod",
+  "anthropic-key": "sk-ant-api03-9fK3xQ7zL2mNpR8tV4wYbC1dE6gH0jKlMnOp",
+  "stripe-webhook-secret": "whsec_aBcD1234efGH5678ijKL9012mnOPqrSt",
+  "slack-webhook-url":
+    "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+  "basic-auth-header": "Authorization: Basic dXNlcjpzM2NyZXRwYXNz",
+  "google-oauth-refresh-token":
+    "1//0gB7xLm9Qw3rT4refreshTokenBodyAbCdEf0123456789",
+  "telegram-bot-token": "123456789:AAH-abcdefghijklmnopqrstuvwxyz1234567",
+  "pgp-private-key":
+    "-----BEGIN PGP PRIVATE KEY BLOCK-----\nlQOYBF...\n-----END PGP PRIVATE KEY BLOCK-----",
+  "aws-access-key": "AKIAIOSFODNN7EXAMPLE",
+  "stripe-key": "sk_live_4eC39HqLyjWDarjtT1zdp7dc",
+  "google-api-key": "AIzaSyA-1234567890abcdefghijklmnopqrstu",
+  "github-token": "ghp_1234567890abcdefghijklmnopqrstuvwxyz",
+  "openai-key": "sk-test_1234567890abcdef",
+  "slack-token": "xoxb-12345-67890-abcdefghij",
+  "private-key":
+    "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIQ\n-----END EC PRIVATE KEY-----",
+  "hex-secret": `0x${"a".repeat(64)}`,
+  "mac-address": "01:23:45:67:89:ab",
+  ipv4: "192.168.0.42",
+  phone: "+1 (415) 555-2671",
+};
+
+function message(id: string, text: string): CorpusMessage {
+  return {
+    id,
+    platform: "gmail",
+    accountId: "work",
+    threadId: `thread-${id}`,
+    ts: BASE_TS,
+    direction: "in",
+    senderId: "sender@example.test",
+    senderDisplay: "Sender Example",
+    recipients: [
+      { id: "owner", display: "Owner", address: "owner@example.test" },
+    ],
+    subject: "PII canary",
+    text,
+    labels: [],
+    attachments: [],
+    scrubState: "raw",
+  };
+}
+
+describe("minePiiCandidates", () => {
+  it("has a canary for every core deterministic detector kind", () => {
+    expect(Object.keys(CANARIES).sort()).toEqual(
+      PII_DETECTORS.map((detector) => detector.kind).sort(),
+    );
+  });
+
+  it("catches every seeded deterministic detector kind", async () => {
+    const rows = Object.entries(CANARIES).map(([kind, value], index) =>
+      message(`canary-${index}`, `Stage 0 canary for ${kind}: ${value}`),
+    );
+
+    const artifacts = await minePiiCandidates(rows, { hashSalt: "canary-v1" });
+    const seen = new Set(
+      artifacts.candidates.map((candidate) => candidate.kind),
+    );
+
+    for (const kind of Object.keys(CANARIES)) {
+      expect(seen.has(kind), `missing ${kind}`).toBe(true);
+    }
+    expect(
+      artifacts.candidates.every((candidate) => candidate.sourceRef.memoryId),
+    ).toBe(true);
+  });
+
+  it("emits stable hashes and contact-gazetteer candidates", async () => {
+    const contacts: CorpusContact[] = [
+      {
+        id: "contact-alice",
+        display: "Alice Example",
+        handles: [{ platform: "gmail", accountId: "work", handle: "alice" }],
+        emails: ["alice@example.test"],
+        phones: ["415-555-0101"],
+        source: "collector",
+      },
+    ];
+    const rows = [
+      message(
+        "contact-row",
+        "Alice Example asked us to use alice@example.test and 415-555-0101.",
+      ),
+    ];
+
+    const first = await minePiiCandidates(rows, {
+      contacts,
+      hashSalt: "stable-v1",
+    });
+    const second = await minePiiCandidates(rows, {
+      contacts,
+      hashSalt: "stable-v1",
+    });
+
+    expect(first).toEqual(second);
+    expect(first.candidates.map((candidate) => candidate.kind)).toEqual(
+      expect.arrayContaining(["person", "email", "phone"]),
+    );
+    expect(first.reviewCsv).toContain("valueHash");
+    expect(first.reviewCsv).toContain("Alice Example");
+  });
+});

--- a/packages/corpus-tools/src/pipeline/mine.ts
+++ b/packages/corpus-tools/src/pipeline/mine.ts
@@ -1,0 +1,274 @@
+/**
+ * Deterministic PII candidate mining for corpus scrub stage 0. The miner joins
+ * core structured detectors with a contact-derived gazetteer and emits
+ * source-referenced candidates, frequency summaries, and owner-review CSV rows
+ * without assigning replacement pseudonyms.
+ */
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import {
+  CompositeEntityRecognizer,
+  detectPii,
+  type EntitySpan,
+  GazetteerEntityRecognizer,
+  getDefaultRedactPatterns,
+  type PiiMatch,
+  RegexEntityRecognizer,
+} from "@elizaos/core";
+import type { CorpusContact, CorpusMessage } from "../schema.ts";
+
+export interface PiiCandidate {
+  msgId: string;
+  sourceRef: {
+    tableName: "corpus_messages";
+    memoryId: string;
+    threadId: string;
+    platform: CorpusMessage["platform"];
+    accountId: string;
+    field: "text";
+    span: { start: number; end: number };
+  };
+  kind: string;
+  surfaceForm: string;
+  valueHash: string;
+  context: string;
+  confidence: number;
+  detector: "structured" | "entity" | "redact-pattern";
+}
+
+export interface PiiFrequencyRow {
+  kind: string;
+  valueHash: string;
+  count: number;
+  sample: string;
+  sampleContext: string;
+}
+
+export interface PiiMineArtifacts {
+  candidates: PiiCandidate[];
+  frequencies: PiiFrequencyRow[];
+  reviewCsv: string;
+}
+
+export interface MinePiiOptions {
+  contacts?: readonly CorpusContact[];
+  hashSalt: string;
+}
+
+interface RawCandidate {
+  start: number;
+  end: number;
+  kind: string;
+  value: string;
+  confidence: number;
+  detector: PiiCandidate["detector"];
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function valueHash(value: string, salt: string): string {
+  return sha256(`${salt}\0${value}`);
+}
+
+function contextAround(text: string, start: number, end: number): string {
+  return text.slice(Math.max(0, start - 40), Math.min(text.length, end + 40));
+}
+
+function csvCell(value: string | number): string {
+  const text = String(value);
+  return `"${text.replaceAll('"', '""')}"`;
+}
+
+function contactGazetteerEntries(
+  messages: readonly CorpusMessage[],
+  contacts: readonly CorpusContact[],
+): Array<{ kind: string; value: string }> {
+  const entries: Array<{ kind: string; value: string }> = [];
+  const add = (kind: string, value: string | undefined): void => {
+    const trimmed = value?.trim();
+    if (trimmed && trimmed.length >= 2) entries.push({ kind, value: trimmed });
+  };
+  for (const contact of contacts) {
+    add("person", contact.display);
+    for (const email of contact.emails) add("email", email);
+    for (const phone of contact.phones) add("phone", phone);
+    for (const handle of contact.handles) add("person", handle.handle);
+  }
+  for (const message of messages) {
+    add("person", message.senderDisplay);
+    add("email", message.senderId.includes("@") ? message.senderId : undefined);
+    for (const recipient of message.recipients) {
+      add("person", recipient.display);
+      add("email", recipient.address);
+    }
+  }
+  return entries;
+}
+
+function redactPatternMatches(text: string): RawCandidate[] {
+  const candidates: RawCandidate[] = [];
+  for (const rawPattern of getDefaultRedactPatterns()) {
+    const pattern = new RegExp(rawPattern, "gi");
+    for (const match of text.matchAll(pattern)) {
+      const value = match[match.length - 1] || match[0];
+      if (!value) continue;
+      const whole = match[0];
+      const start = (match.index ?? 0) + whole.indexOf(value);
+      candidates.push({
+        start,
+        end: start + value.length,
+        kind: "redact-pattern",
+        value,
+        confidence: 0.95,
+        detector: "redact-pattern",
+      });
+    }
+  }
+  return candidates;
+}
+
+function fromPiiMatch(match: PiiMatch): RawCandidate {
+  return {
+    start: match.start,
+    end: match.end,
+    kind: match.kind,
+    value: match.value,
+    confidence: 1,
+    detector: "structured",
+  };
+}
+
+function fromEntitySpan(span: EntitySpan): RawCandidate | undefined {
+  if (span.start === undefined || span.end === undefined) return undefined;
+  return {
+    start: span.start,
+    end: span.end,
+    kind: span.kind,
+    value: span.value,
+    confidence: span.score ?? 0.85,
+    detector: "entity",
+  };
+}
+
+function resolveCandidateOverlaps(candidates: RawCandidate[]): RawCandidate[] {
+  const sorted = [...candidates].sort(
+    (a, b) => b.end - b.start - (a.end - a.start) || a.start - b.start,
+  );
+  const kept: RawCandidate[] = [];
+  for (const candidate of sorted) {
+    if (
+      kept.some(
+        (other) => candidate.start < other.end && other.start < candidate.end,
+      )
+    ) {
+      continue;
+    }
+    kept.push(candidate);
+  }
+  return kept.sort((a, b) => a.start - b.start);
+}
+
+export async function minePiiCandidates(
+  messages: readonly CorpusMessage[],
+  options: MinePiiOptions,
+): Promise<PiiMineArtifacts> {
+  const recognizer = new CompositeEntityRecognizer([
+    new GazetteerEntityRecognizer(
+      contactGazetteerEntries(messages, options.contacts ?? []),
+      { name: "corpus-contact-gazetteer" },
+    ),
+    new RegexEntityRecognizer({ address: true, email: true, phone: true }),
+  ]);
+  const candidates: PiiCandidate[] = [];
+
+  for (const message of messages) {
+    const structured = detectPii(message.text).map(fromPiiMatch);
+    const entitySpans = (await recognizer.recognize(message.text))
+      .map(fromEntitySpan)
+      .filter((span): span is RawCandidate => span !== undefined);
+    const rawCandidates = resolveCandidateOverlaps([
+      ...structured,
+      ...entitySpans,
+      ...redactPatternMatches(message.text),
+    ]);
+    for (const candidate of rawCandidates) {
+      candidates.push({
+        msgId: message.id,
+        sourceRef: {
+          tableName: "corpus_messages",
+          memoryId: message.id,
+          threadId: message.threadId,
+          platform: message.platform,
+          accountId: message.accountId,
+          field: "text",
+          span: { start: candidate.start, end: candidate.end },
+        },
+        kind: candidate.kind,
+        surfaceForm: candidate.value,
+        valueHash: valueHash(candidate.value, options.hashSalt),
+        context: contextAround(message.text, candidate.start, candidate.end),
+        confidence: candidate.confidence,
+        detector: candidate.detector,
+      });
+    }
+  }
+
+  const byValue = new Map<string, PiiFrequencyRow>();
+  for (const candidate of candidates) {
+    const key = `${candidate.kind}\0${candidate.valueHash}`;
+    const existing = byValue.get(key);
+    if (existing) {
+      existing.count += 1;
+      continue;
+    }
+    byValue.set(key, {
+      kind: candidate.kind,
+      valueHash: candidate.valueHash,
+      count: 1,
+      sample: candidate.surfaceForm,
+      sampleContext: candidate.context,
+    });
+  }
+  const frequencies = [...byValue.values()].sort(
+    (a, b) => b.count - a.count || a.kind.localeCompare(b.kind),
+  );
+  const reviewCsv = [
+    ["kind", "valueHash", "count", "sample", "sampleContext"]
+      .map(csvCell)
+      .join(","),
+    ...frequencies.map((row) =>
+      [row.kind, row.valueHash, row.count, row.sample, row.sampleContext]
+        .map(csvCell)
+        .join(","),
+    ),
+  ].join("\n");
+
+  return { candidates, frequencies, reviewCsv: `${reviewCsv}\n` };
+}
+
+export async function writeMineArtifacts(
+  stateDir: string,
+  artifacts: PiiMineArtifacts,
+): Promise<{
+  candidatesPath: string;
+  frequencyPath: string;
+  reviewCsvPath: string;
+}> {
+  await fs.mkdir(stateDir, { recursive: true });
+  const candidatesPath = path.join(stateDir, "candidates.jsonl");
+  const frequencyPath = path.join(stateDir, "candidate-frequency.json");
+  const reviewCsvPath = path.join(stateDir, "candidate-review.csv");
+  await fs.writeFile(
+    candidatesPath,
+    `${artifacts.candidates.map((candidate) => JSON.stringify(candidate)).join("\n")}\n`,
+  );
+  await fs.writeFile(
+    frequencyPath,
+    `${JSON.stringify(artifacts.frequencies, null, 2)}\n`,
+  );
+  await fs.writeFile(reviewCsvPath, artifacts.reviewCsv);
+  return { candidatesPath, frequencyPath, reviewCsvPath };
+}


### PR DESCRIPTION
## Summary
- add deterministic Stage 0 PII candidate mining for scrub-driver inputs
- combine core PII detectors, contact-derived gazetteer matching, and redact-pattern scanning into local owner-review artifacts
- write byte-stable `.state/candidates.jsonl`, `.state/candidate-frequency.json`, and `.state/candidate-review.csv`; pseudonym assignment is intentionally deferred to the context pass

Closes #14766.

Stacked on #15069 (`fix/14764-pii-scrub-driver`), which is stacked on #15058.

## Validation
- PASS: `bun run --cwd packages/corpus-tools typecheck`
- PASS: `bun run --cwd packages/corpus-tools test` (3 files, 12 tests)
- PASS: `bun run --cwd packages/corpus-tools lint`
- PASS: `git diff --check HEAD~1..HEAD`
- PASS: `bun run check:agents-claude`
- PASS: `bun run audit:error-policy-ratchet`
- KNOWN PRE-EXISTING BLOCKER: `node packages/scripts/type-safety-ratchet.mjs` fails outside this package: `as unknown as` 75/73 and core/agent/app-core `?? []` 582/581

## Evidence
- Synthetic raw-corpus CLI run: 20 input rows, `recordsWritten=20`, `candidateCount=7`
- Candidate kinds detected in local owner-review artifacts: `credit-card`, `email`, `ipv4`, `openai-key`, `person`, `phone`, `ssn`
- Resume rerun: `recordsWritten=0`, `hitRate=1`, `candidateCount=7`
- Byte-stability verified across rerun for `candidate-review.csv`, `candidates.jsonl`, and `candidate-frequency.json`

## Safety Notes
- Artifacts are local `.state` owner-review outputs and intentionally include surface samples/context for review.
- Candidate hashes are salted by ruleset version, so deterministic review is stable for a run configuration without becoming a global unsalted identifier.
- Stage 0 does not assign pseudonyms; contextual replacement planning remains a later pass so identity consistency can use surrounding narrative and modality context.

## Required Evidence Rows
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots N/A - package CLI/pipeline change only; no UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots N/A - package CLI/pipeline change only; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video N/A - package CLI/pipeline change only; no UI surface.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs N/A - no server process; validation used package CLI output captured in the issue evidence.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs N/A - no frontend surface or browser runtime changed.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory N/A - deterministic candidate-mining stage only; no model call is part of this change.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts https://github.com/elizaOS/eliza/issues/14766#issuecomment-4894830003