### PR TITLE
feat(corpus): add permanent secret scrub stage

### DIFF
--- a/packages/corpus-tools/README.md
+++ b/packages/corpus-tools/README.md
@@ -34,6 +34,15 @@ and salted value hashes; replacement identity is intentionally deferred to the
 context/pseudonym-consistency pass so this deterministic stage never forks the
 corpus-wide mapping.
 
+Stage `secrets` permanently replaces high-confidence credentials and
+secret-shaped tokens with typed placeholders such as
+`[[SECRET:openai-key:1a2b3c4d5e6f]]`. Placeholder ids are salted by the
+ruleset version and stable across reruns. Local `.env*` files beside the target
+are used only as known-secret seeds; their raw values are not written to reports.
+The driver refuses `rewrite` and `llm` unless the local ledger contains a green
+`secrets` record for each message, so off-device stages cannot run on raw
+credentials by accident.
+
 ## X Mapping
 
 The canonical schema includes platform `x`. The existing LifeOps simulator

--- a/packages/corpus-tools/src/index.ts
+++ b/packages/corpus-tools/src/index.ts
@@ -4,5 +4,6 @@
  */
 export * from "./mappers.ts";
 export * from "./pipeline/driver.ts";
+export * from "./pipeline/secrets.ts";
 export * from "./schema.ts";
 export * from "./validator.ts";

--- a/packages/corpus-tools/src/pipeline/driver.ts
+++ b/packages/corpus-tools/src/pipeline/driver.ts
@@ -15,6 +15,7 @@ import {
 } from "../schema.ts";
 import { findCorpusShardFiles, readCorpusShard } from "../validator.ts";
 import { minePiiCandidates, writeMineArtifacts } from "./mine.ts";
+import { swapPermanentSecrets } from "./secrets.ts";
 
 export const SCRUB_STAGE_NAMES = [
   "mine",
@@ -37,6 +38,7 @@ export interface ScrubStageContext {
   markerKey: string;
   clusterKey: string;
   isClusterExemplar: boolean;
+  knownSecrets?: Record<string, string | undefined>;
 }
 
 export interface ScrubStageResult {
@@ -91,6 +93,7 @@ export interface ScrubRunOptions {
   rulesetVersion: string;
   stages?: readonly ScrubStageDefinition[];
   maxStageExecutions?: number;
+  knownSecrets?: Record<string, string | undefined>;
 }
 
 export interface ScrubStageReport {
@@ -105,6 +108,7 @@ export interface ScrubStageReport {
   outputTokens: number;
   estimatedUsd: number;
   candidateCount?: number;
+  secretReplacementCount?: number;
 }
 
 export interface ScrubRunReport {
@@ -185,6 +189,10 @@ function defaultStateDir(targetPath: string): string {
   return path.join(base, ".state");
 }
 
+function targetRootDir(targetPath: string): string {
+  return path.extname(targetPath) ? path.dirname(targetPath) : targetPath;
+}
+
 function stageTargetState(stage: ScrubStageName): ScrubState {
   switch (stage) {
     case "mine":
@@ -198,6 +206,10 @@ function stageTargetState(stage: ScrubStageName): ScrubState {
     case "verify":
       return "verified";
   }
+}
+
+function isOffDeviceStage(stage: ScrubStageName): boolean {
+  return stage === "rewrite" || stage === "llm";
 }
 
 function normalizeNewsletterTemplate(text: string): string {
@@ -297,6 +309,35 @@ async function readMessages(targetPath: string): Promise<CorpusMessage[]> {
   return messages;
 }
 
+function parseEnvLine(line: string): [string, string] | undefined {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith("#")) return undefined;
+  const match = trimmed.match(/^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+  if (!match) return undefined;
+  const rawValue = match[2].trim();
+  const quoted = rawValue.match(/^(['"])(.*)\1$/);
+  return [match[1], quoted ? quoted[2] : rawValue];
+}
+
+async function readKnownSecretsFromEnvFiles(
+  targetPath: string,
+): Promise<Record<string, string | undefined>> {
+  const rootDir = targetRootDir(targetPath);
+  const entries = await fs.readdir(rootDir, { withFileTypes: true });
+  const secrets: Record<string, string | undefined> = {};
+  for (const entry of entries) {
+    if (!entry.isFile() || !/^\.env(?:\.|$)/.test(entry.name)) continue;
+    const raw = await fs.readFile(path.join(rootDir, entry.name), "utf8");
+    for (const line of raw.split(/\r?\n/)) {
+      const parsed = parseEnvLine(line);
+      if (parsed) {
+        secrets[parsed[0]] = parsed[1];
+      }
+    }
+  }
+  return secrets;
+}
+
 function selectedStages(
   selector: ScrubStageSelector,
   stages: readonly ScrubStageDefinition[],
@@ -317,6 +358,19 @@ function defaultStage(stage: ScrubStageName): ScrubStageDefinition {
     targetState,
     async run(message, context) {
       assertScrubStateTransition(message.scrubState, targetState);
+      if (stage === "secrets") {
+        const swapped = swapPermanentSecrets(message, {
+          hashSalt: context.rulesetVersion,
+          knownSecrets: context.knownSecrets,
+        });
+        return {
+          message: swapped.message,
+          metadata: {
+            secretReplacementCount: swapped.replacements.length,
+          },
+          cost: ZERO_COST,
+        };
+      }
       const next = stableCloneMessage(message);
       next.scrubState = targetState;
       const mined =
@@ -351,6 +405,45 @@ function defaultStage(stage: ScrubStageName): ScrubStageDefinition {
 
 export function defaultScrubStages(): ScrubStageDefinition[] {
   return SCRUB_STAGE_NAMES.map(defaultStage);
+}
+
+function hasGreenSecretsRecord(
+  ledger: LedgerState,
+  messageId: string,
+  rulesetVersion: string,
+): boolean {
+  for (const record of ledger.byKey.values()) {
+    if (
+      record.messageId === messageId &&
+      record.stage === "secrets" &&
+      record.rulesetVersion === rulesetVersion &&
+      !record.tombstone &&
+      record.output &&
+      scrubStateRank[record.output.scrubState] >= scrubStateRank.swapped
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function assertSecretsGate(
+  stage: ScrubStageName,
+  message: CorpusMessage,
+  ledger: LedgerState,
+  rulesetVersion: string,
+): void {
+  if (!isOffDeviceStage(stage)) return;
+  if (scrubStateRank[message.scrubState] < scrubStateRank.swapped) {
+    throw new Error(
+      `refusing ${stage} before secrets stage for message ${message.id}`,
+    );
+  }
+  if (!hasGreenSecretsRecord(ledger, message.id, rulesetVersion)) {
+    throw new Error(
+      `refusing ${stage}: message ${message.id} lacks a green secrets ledger entry`,
+    );
+  }
 }
 
 async function writeJsonl(
@@ -392,6 +485,10 @@ export async function runScrubPipeline(
     : { recordsRead: 0, byKey: new Map<string, ScrubLedgerRecord>() };
   let recordsWritten = 0;
   let stageExecutions = 0;
+  const knownSecrets = {
+    ...(await readKnownSecretsFromEnvFiles(options.targetPath)),
+    ...(options.knownSecrets ?? {}),
+  };
   let messages = await readMessages(options.targetPath);
   const inputMessages = messages.length;
   const stats = clusterStats(messages, options.mode);
@@ -463,6 +560,7 @@ export async function runScrubPipeline(
         );
       }
 
+      assertSecretsGate(stage.name, message, ledger, options.rulesetVersion);
       const result = await stage.run(message, {
         stage: stage.name,
         mode: options.mode,
@@ -471,6 +569,7 @@ export async function runScrubPipeline(
         markerKey: key,
         clusterKey,
         isClusterExemplar,
+        knownSecrets,
       });
       stageExecutions += 1;
       report.executed += 1;
@@ -487,6 +586,16 @@ export async function runScrubPipeline(
       ) {
         report.candidateCount =
           (report.candidateCount ?? 0) + result.metadata.candidateCount;
+      }
+      if (
+        result.metadata &&
+        typeof result.metadata === "object" &&
+        "secretReplacementCount" in result.metadata &&
+        typeof result.metadata.secretReplacementCount === "number"
+      ) {
+        report.secretReplacementCount =
+          (report.secretReplacementCount ?? 0) +
+          result.metadata.secretReplacementCount;
       }
       const output = result.tombstone ? undefined : result.message;
       if (!result.tombstone && !output) {

--- a/packages/corpus-tools/src/pipeline/secrets.test.ts
+++ b/packages/corpus-tools/src/pipeline/secrets.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Stage-1 secret replacement coverage for #14768. The tests exercise the local
+ * permanent-swap contract: high-confidence credentials become stable typed
+ * placeholders, known `.env` values are seeded, and off-device stages cannot run
+ * without a green secrets ledger record.
+ */
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { CorpusMessage } from "../schema.ts";
+import { runScrubPipeline } from "./driver.ts";
+import { swapPermanentSecrets } from "./secrets.ts";
+
+const BASE_TS = Date.parse("2026-06-01T12:00:00.000Z");
+
+const SECRET_CANARIES: Readonly<Record<string, string>> = {
+  "anthropic-key": "sk-ant-api03-9fK3xQ7zL2mNpR8tV4wYbC1dE6gH0jKlMnOp",
+  "aws-access-key": "AKIAIOSFODNN7EXAMPLE",
+  "basic-auth-header": "Authorization: Basic dXNlcjpzM2NyZXRwYXNz",
+  "github-token": "ghp_1234567890abcdefghijklmnopqrstuvwxyz",
+  "google-api-key": "AIzaSyA-1234567890abcdefghijklmnopqrstu",
+  "google-oauth-refresh-token":
+    "1//0gB7xLm9Qw3rT4refreshTokenBodyAbCdEf0123456789",
+  "hex-secret": `0x${"a".repeat(64)}`,
+  jwt: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U",
+  "openai-key": "sk-test_1234567890abcdef",
+  "pgp-private-key":
+    "-----BEGIN PGP PRIVATE KEY BLOCK-----\nlQOYBF...\n-----END PGP PRIVATE KEY BLOCK-----",
+  "private-key":
+    "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIQ\n-----END EC PRIVATE KEY-----",
+  "seed-phrase":
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+  "slack-token": "xoxb-12345-67890-abcdefghij",
+  "slack-webhook-url":
+    "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+  "stripe-key": "sk_live_4eC39HqLyjWDarjtT1zdp7dc",
+  "stripe-webhook-secret": "whsec_aBcD1234efGH5678ijKL9012mnOPqrSt",
+  "telegram-bot-token": "123456789:AAH-abcdefghijklmnopqrstuvwxyz1234567",
+  "url-credentials": "postgres://app:s3cr3tP4ss@db.host:5432/prod",
+  "wif-private-key": "5HueCGU8rMjxEXxiPuD5BDku4MkFqeZyd4dZ1jvhTVqvbTLvyTJ",
+};
+
+function message(
+  id: string,
+  text: string,
+  scrubState: CorpusMessage["scrubState"] = "raw",
+): CorpusMessage {
+  return {
+    id,
+    platform: "gmail",
+    accountId: "work",
+    threadId: `thread-${id}`,
+    ts: BASE_TS,
+    direction: "in",
+    senderId: "sender@example.test",
+    senderDisplay: "Sender Example",
+    recipients: [
+      { id: "owner", display: "Owner", address: "owner@example.test" },
+    ],
+    subject: "Secret canary",
+    text,
+    labels: [],
+    attachments: [],
+    scrubState,
+  };
+}
+
+async function writeShard(dir: string, messages: readonly CorpusMessage[]) {
+  const shard = path.join(dir, "gmail", "work", "2026-06.jsonl");
+  await fs.mkdir(path.dirname(shard), { recursive: true });
+  await fs.writeFile(
+    shard,
+    `${messages.map((row) => JSON.stringify(row)).join("\n")}\n`,
+  );
+}
+
+describe("swapPermanentSecrets", () => {
+  it("replaces every seeded secret-kind canary with typed placeholders", () => {
+    const row = message(
+      "canaries",
+      Object.entries(SECRET_CANARIES)
+        .map(([kind, value]) => `${kind}: ${value}`)
+        .join("\n"),
+    );
+
+    const swapped = swapPermanentSecrets(row, { hashSalt: "secret-v1" });
+
+    for (const value of Object.values(SECRET_CANARIES)) {
+      expect(swapped.message.text).not.toContain(value);
+    }
+    for (const kind of Object.keys(SECRET_CANARIES)) {
+      expect(swapped.replacements.some((entry) => entry.kind === kind)).toBe(
+        true,
+      );
+    }
+    expect(swapped.message.text).toMatch(
+      /\[\[SECRET:openai-key:[a-f0-9]{12}\]\]/,
+    );
+  });
+
+  it("keeps placeholders stable across reruns and swaps known non-regex secrets", () => {
+    const row = message(
+      "known",
+      "Internal password value was hunter2-super-secret in the old notes.",
+    );
+    const first = swapPermanentSecrets(row, {
+      hashSalt: "secret-v1",
+      knownSecrets: { INTERNAL_PASSWORD: "hunter2-super-secret" },
+    });
+    const second = swapPermanentSecrets(row, {
+      hashSalt: "secret-v1",
+      knownSecrets: { INTERNAL_PASSWORD: "hunter2-super-secret" },
+    });
+
+    expect(first.message.text).toBe(second.message.text);
+    expect(first.message.text).not.toContain("hunter2-super-secret");
+    expect(first.message.text).toContain("[[SECRET:internal-password:");
+  });
+});
+
+describe("scrub pipeline secrets stage", () => {
+  it("seeds known secrets from local .env files", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "corpus-secrets-env-"));
+    await fs.writeFile(
+      path.join(dir, ".env.local"),
+      "INTERNAL_PASSWORD=hunter2-super-secret\n",
+    );
+    await writeShard(dir, [
+      message("msg-1", "The old password was hunter2-super-secret."),
+    ]);
+
+    const result = await runScrubPipeline({
+      targetPath: dir,
+      stage: "secrets",
+      mode: "deep",
+      resume: true,
+      dryRun: false,
+      rulesetVersion: "secret-env-v1",
+    });
+
+    expect(result.messages[0].text).not.toContain("hunter2-super-secret");
+    expect(result.messages[0].text).toContain("[[SECRET:internal-password:");
+    expect(result.report.stageReports[0].secretReplacementCount).toBe(1);
+  });
+
+  it("refuses off-device rewrite before a green secrets ledger entry", async () => {
+    const dir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "corpus-secrets-gate-"),
+    );
+    await writeShard(dir, [
+      message("msg-1", "Use sk-test_1234567890abcdef for the old job."),
+    ]);
+
+    await expect(
+      runScrubPipeline({
+        targetPath: dir,
+        stage: "rewrite",
+        mode: "deep",
+        resume: true,
+        dryRun: false,
+        rulesetVersion: "secret-gate-v1",
+      }),
+    ).rejects.toThrow("before secrets stage");
+  });
+});

--- a/packages/corpus-tools/src/pipeline/secrets.ts
+++ b/packages/corpus-tools/src/pipeline/secrets.ts
@@ -1,0 +1,130 @@
+/**
+ * Permanent secret replacement for corpus scrub stage 1. This pass only handles
+ * high-confidence credentials and secret-shaped tokens; broader human PII stays
+ * for the later delete/rewrite passes so API keys never leave the local machine
+ * while narrative identity context remains available to the owner-reviewed
+ * pipeline.
+ */
+import { createHash } from "node:crypto";
+import { detectPii, SecretSwapSession } from "@elizaos/core";
+import type { CorpusMessage } from "../schema.ts";
+
+export interface SecretReplacement {
+  kind: string;
+  valueHash: string;
+  placeholder: string;
+}
+
+export interface SecretSwapResult {
+  message: CorpusMessage;
+  replacements: SecretReplacement[];
+}
+
+export interface SwapSecretsOptions {
+  hashSalt: string;
+  knownSecrets?: Record<string, string | undefined>;
+}
+
+const SECRET_DETECTOR_KINDS = new Set([
+  "anthropic-key",
+  "aws-access-key",
+  "basic-auth-header",
+  "github-token",
+  "google-api-key",
+  "google-oauth-refresh-token",
+  "hex-secret",
+  "jwt",
+  "openai-key",
+  "pgp-private-key",
+  "private-key",
+  "seed-phrase",
+  "slack-token",
+  "slack-webhook-url",
+  "stripe-key",
+  "stripe-webhook-secret",
+  "telegram-bot-token",
+  "url-credentials",
+  "wif-private-key",
+]);
+
+const SECRET_PLACEHOLDER_PATTERN = /\[\[SECRET:[a-z0-9-]+:[a-f0-9]{12}\]\]/g;
+
+function stableValueHash(value: string, salt: string): string {
+  return createHash("sha256").update(`${salt}\0${value}`).digest("hex");
+}
+
+function placeholderFor(kind: string, valueHash: string): string {
+  const normalizedKind = kind
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return `[[SECRET:${normalizedKind || "secret"}:${valueHash.slice(0, 12)}]]`;
+}
+
+function shouldCollect(value: string): boolean {
+  SECRET_PLACEHOLDER_PATTERN.lastIndex = 0;
+  return value.trim().length >= 8 && !SECRET_PLACEHOLDER_PATTERN.test(value);
+}
+
+function collectSecretValues(
+  text: string,
+  knownSecrets: Record<string, string | undefined>,
+): Map<string, string> {
+  const byValue = new Map<string, string>();
+  const session = new SecretSwapSession({ knownSecrets });
+  session.substituteText(text);
+  for (const entry of session.entries) {
+    const trimmed = entry.value.trim();
+    if (
+      shouldCollect(trimmed) &&
+      (SECRET_DETECTOR_KINDS.has(entry.kind) ||
+        entry.kind === "secret" ||
+        entry.kind in knownSecrets)
+    ) {
+      byValue.set(trimmed, entry.kind);
+    }
+  }
+  for (const match of detectPii(text)) {
+    const trimmed = match.value.trim();
+    if (SECRET_DETECTOR_KINDS.has(match.kind) && byValue.has(trimmed)) {
+      byValue.set(trimmed, match.kind);
+    }
+  }
+  return byValue;
+}
+
+export function swapPermanentSecrets(
+  message: CorpusMessage,
+  options: SwapSecretsOptions,
+): SecretSwapResult {
+  const byValue = collectSecretValues(message.text, options.knownSecrets ?? {});
+  const replacements = [...byValue.entries()]
+    .map(([value, kind]) => {
+      const valueHash = stableValueHash(value, options.hashSalt);
+      return {
+        kind,
+        value,
+        valueHash,
+        placeholder: placeholderFor(kind, valueHash),
+      };
+    })
+    .sort(
+      (a, b) => b.value.length - a.value.length || a.kind.localeCompare(b.kind),
+    );
+  let text = message.text;
+  for (const replacement of replacements) {
+    text = text.split(replacement.value).join(replacement.placeholder);
+  }
+  return {
+    message: {
+      ...message,
+      text,
+      scrubState: "swapped",
+    },
+    replacements: replacements.map(({ kind, valueHash, placeholder }) => ({
+      kind,
+      valueHash,
+      placeholder,
+    })),
+  };
+}


### PR DESCRIPTION
## Summary
- add the Stage 1 `secrets` scrub stage for permanent, non-restorable corpus credential replacement
- use core `SecretSwapSession` discovery plus specific `detectPii` labels, then emit stable typed placeholders like `[[SECRET:openai-key:<hash>]]`
- seed known local secrets from `.env*` files beside the target and keep raw values out of reports
- gate `rewrite` and `llm` until each message has a green `secrets` ledger record

Closes #14768.

Stacked on #15070 (`fix/14766-pii-stage0-mining`), which is stacked on #15069/#15058.

## Validation
- PASS: `bun run --cwd packages/corpus-tools typecheck`
- PASS: `bun run --cwd packages/corpus-tools test` (4 files, 16 tests)
- PASS: `bun run --cwd packages/corpus-tools lint`
- PASS: `git diff --check HEAD~1..HEAD`
- PASS: `bun run check:agents-claude`
- PASS: `bun run audit:error-policy-ratchet`
- KNOWN PRE-EXISTING BLOCKER: `node packages/scripts/type-safety-ratchet.mjs` fails outside this package: `as unknown as` 75/73 and core/agent/app-core `?? []` 582/581

## Evidence
- Synthetic CLI secrets run: `recordsWritten=1`, `secretReplacementCount=4`, `placeholderCount=4`
- Raw output checks: output contains no raw OpenAI key, GitHub token, AWS secret assignment value, or `.env`-seeded password
- Gitleaks scan with repo config: raw shard `gitleaksBeforeCount=1` (`generic-api-key`), scrub output `gitleaksAfterCount=0`
- Resume rerun: `recordsWritten=0`, `hitRate=1`, output hash stable (`38c500f9dbdb207ac7ca157433e4faf4cf5d320d9c3acb6c020e7dce070eeb4e`)
- Gate evidence: `--stage rewrite` on a raw shard exits `1` with `refusing rewrite before secrets stage for message secret-gate-cli-1`

## Safety Notes
- Placeholders are deterministic for a ruleset version but salted, so local review remains stable without creating global unsalted identifiers.
- `.env*` values are read only as known-secret seeds and are not included in reports or ledger metadata.
- Raw shard files are left untouched; `.state/scrub-output.jsonl` is the scrubbed artifact for downstream stages.

## Required Evidence Rows
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots N/A - package CLI/pipeline change only; no UI surface.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots N/A - package CLI/pipeline change only; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video N/A - package CLI/pipeline change only; no UI surface.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs N/A - no server process; validation used package CLI output captured in the issue evidence.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs N/A - no frontend surface or browser runtime changed.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory N/A - secret swap stage is deterministic and must run before any off-device model stage.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts https://github.com/elizaOS/eliza/issues/14768#issuecomment-4894938851