### PR TITLE
feat(corpus): add gray-area rewrite stage

### DIFF
--- a/packages/corpus-tools/README.md
+++ b/packages/corpus-tools/README.md
@@ -43,6 +43,13 @@ The driver refuses `rewrite` and `llm` unless the local ledger contains a green
 `secrets` record for each message, so off-device stages cannot run on raw
 credentials by accident.
 
+Stage `rewrite` runs only in `deep` mode. It replaces gray-area named specifics
+such as employers, projects, cities, and events with stable fictional
+equivalents while preserving the surrounding message structure; `fast-track`
+mode records an explicit skip. The current package-local implementation is the
+deterministic contract harness for the model-backed Cerebras pass, so live
+Cerebras proof still requires `CEREBRAS_API_KEY`.
+
 ## X Mapping
 
 The canonical schema includes platform `x`. The existing LifeOps simulator

--- a/packages/corpus-tools/src/index.ts
+++ b/packages/corpus-tools/src/index.ts
@@ -4,6 +4,7 @@
  */
 export * from "./mappers.ts";
 export * from "./pipeline/driver.ts";
+export * from "./pipeline/rewrite.ts";
 export * from "./pipeline/secrets.ts";
 export * from "./schema.ts";
 export * from "./validator.ts";

--- a/packages/corpus-tools/src/pipeline/driver.ts
+++ b/packages/corpus-tools/src/pipeline/driver.ts
@@ -15,6 +15,11 @@ import {
 } from "../schema.ts";
 import { findCorpusShardFiles, readCorpusShard } from "../validator.ts";
 import { minePiiCandidates, writeMineArtifacts } from "./mine.ts";
+import {
+  buildRewritePlan,
+  type RewritePlan,
+  rewriteSameThemes,
+} from "./rewrite.ts";
 import { swapPermanentSecrets } from "./secrets.ts";
 
 export const SCRUB_STAGE_NAMES = [
@@ -39,6 +44,7 @@ export interface ScrubStageContext {
   clusterKey: string;
   isClusterExemplar: boolean;
   knownSecrets?: Record<string, string | undefined>;
+  rewritePlan?: RewritePlan;
 }
 
 export interface ScrubStageResult {
@@ -109,6 +115,8 @@ export interface ScrubStageReport {
   estimatedUsd: number;
   candidateCount?: number;
   secretReplacementCount?: number;
+  rewriteReplacementCount?: number;
+  rewriteSkipped?: number;
 }
 
 export interface ScrubRunReport {
@@ -371,6 +379,36 @@ function defaultStage(stage: ScrubStageName): ScrubStageDefinition {
           cost: ZERO_COST,
         };
       }
+      if (stage === "rewrite") {
+        const next = stableCloneMessage(message);
+        if (context.mode === "fast-track") {
+          next.scrubState = targetState;
+          return {
+            message: next,
+            metadata: {
+              rewriteSkipped: 1,
+            },
+            cost: ZERO_COST,
+          };
+        }
+        const rewritten = rewriteSameThemes(
+          message,
+          context.rewritePlan ?? { surrogates: [] },
+        );
+        return {
+          message: rewritten.message,
+          metadata: {
+            rewriteReplacementCount: rewritten.replacements.length,
+          },
+          cost: {
+            inputTokens: Math.ceil(message.text.length / 4),
+            outputTokens: Math.ceil(rewritten.message.text.length / 4),
+            estimatedUsd:
+              0.0000006 * (message.text.length + rewritten.message.text.length),
+            llmCalls: 1,
+          },
+        };
+      }
       const next = stableCloneMessage(message);
       next.scrubState = targetState;
       const mined =
@@ -511,6 +549,10 @@ export async function runScrubPipeline(
     const stage = stages[stageIndex];
     const report = stageReports[stageIndex];
     const nextMessages: CorpusMessage[] = [];
+    const rewritePlan =
+      stage.name === "rewrite"
+        ? buildRewritePlan(messages, { hashSalt: options.rulesetVersion })
+        : undefined;
     clusterExemplars.clear();
 
     for (const message of messages) {
@@ -570,6 +612,7 @@ export async function runScrubPipeline(
         clusterKey,
         isClusterExemplar,
         knownSecrets,
+        rewritePlan,
       });
       stageExecutions += 1;
       report.executed += 1;
@@ -596,6 +639,25 @@ export async function runScrubPipeline(
         report.secretReplacementCount =
           (report.secretReplacementCount ?? 0) +
           result.metadata.secretReplacementCount;
+      }
+      if (
+        result.metadata &&
+        typeof result.metadata === "object" &&
+        "rewriteReplacementCount" in result.metadata &&
+        typeof result.metadata.rewriteReplacementCount === "number"
+      ) {
+        report.rewriteReplacementCount =
+          (report.rewriteReplacementCount ?? 0) +
+          result.metadata.rewriteReplacementCount;
+      }
+      if (
+        result.metadata &&
+        typeof result.metadata === "object" &&
+        "rewriteSkipped" in result.metadata &&
+        typeof result.metadata.rewriteSkipped === "number"
+      ) {
+        report.rewriteSkipped =
+          (report.rewriteSkipped ?? 0) + result.metadata.rewriteSkipped;
       }
       const output = result.tombstone ? undefined : result.message;
       if (!result.tombstone && !output) {

--- a/packages/corpus-tools/src/pipeline/rewrite.test.ts
+++ b/packages/corpus-tools/src/pipeline/rewrite.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Stage-3 gray-area rewrite coverage for #14770. The deterministic harness
+ * proves the contract the model-backed path must preserve: consistent fictional
+ * replacements across a thread, no source-value reintroduction, and explicit
+ * fast-track skip accounting.
+ */
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { CorpusMessage } from "../schema.ts";
+import { runScrubPipeline } from "./driver.ts";
+import { buildRewritePlan, rewriteSameThemes } from "./rewrite.ts";
+
+const BASE_TS = Date.parse("2026-06-01T12:00:00.000Z");
+
+function message(
+  id: string,
+  text: string,
+  labels: string[] = [],
+): CorpusMessage {
+  return {
+    id,
+    platform: "gmail",
+    accountId: "work",
+    threadId: "thread-gray-rewrite",
+    ts: BASE_TS,
+    direction: "in",
+    senderId: "sender@example.test",
+    senderDisplay: "Sender Example",
+    recipients: [
+      { id: "owner", display: "Owner", address: "owner@example.test" },
+    ],
+    subject: "Gray rewrite",
+    text,
+    labels,
+    attachments: [],
+    scrubState: "raw",
+  };
+}
+
+async function writeShard(dir: string, messages: readonly CorpusMessage[]) {
+  const shard = path.join(dir, "gmail", "work", "2026-06.jsonl");
+  await fs.mkdir(path.dirname(shard), { recursive: true });
+  await fs.writeFile(
+    shard,
+    `${messages.map((row) => JSON.stringify(row)).join("\n")}\n`,
+  );
+}
+
+function threadRows(): CorpusMessage[] {
+  return Array.from({ length: 10 }, (_, index) =>
+    message(
+      `gray-${index}`,
+      `Acme Corp update ${index}: Project Atlas prep in Portland is still tied to the Launch Gala plan.`,
+    ),
+  );
+}
+
+describe("rewriteSameThemes", () => {
+  it("keeps fictional replacements consistent across a synthetic thread", () => {
+    const rows = threadRows();
+    const plan = buildRewritePlan(rows, { hashSalt: "rewrite-v1" });
+
+    const rewritten = rows.map((row) => rewriteSameThemes(row, plan).message);
+
+    const acmeReplacement = plan.surrogates.find(
+      (surrogate) => surrogate.source === "Acme Corp",
+    )?.replacement;
+    const projectReplacement = plan.surrogates.find(
+      (surrogate) => surrogate.source === "Project Atlas",
+    )?.replacement;
+    expect(acmeReplacement).toBeTruthy();
+    expect(projectReplacement).toBeTruthy();
+    expect(rewritten.every((row) => !row.text.includes("Acme Corp"))).toBe(
+      true,
+    );
+    expect(rewritten.every((row) => !row.text.includes("Project Atlas"))).toBe(
+      true,
+    );
+    expect(
+      rewritten.every((row) => row.text.includes(acmeReplacement ?? "")),
+    ).toBe(true);
+    expect(
+      rewritten.every((row) => row.text.includes(projectReplacement ?? "")),
+    ).toBe(true);
+  });
+});
+
+describe("scrub pipeline rewrite stage", () => {
+  it("deep mode rewrites gray-area specifics without reintroducing source values", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "corpus-rewrite-"));
+    await writeShard(dir, threadRows());
+
+    const result = await runScrubPipeline({
+      targetPath: dir,
+      stage: "all",
+      mode: "deep",
+      resume: true,
+      dryRun: false,
+      rulesetVersion: "rewrite-pipeline-v1",
+    });
+
+    const rewriteReport = result.report.stageReports.find(
+      (stage) => stage.stage === "rewrite",
+    );
+    expect(rewriteReport?.rewriteReplacementCount).toBe(40);
+    for (const row of result.messages) {
+      expect(row.text).not.toContain("Acme Corp");
+      expect(row.text).not.toContain("Project Atlas");
+      expect(row.text).not.toContain("Portland");
+      expect(row.text).not.toContain("Launch Gala");
+    }
+  });
+
+  it("fast-track mode skips gray rewrite and reports the skip explicitly", async () => {
+    const dir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "corpus-rewrite-fast-"),
+    );
+    await writeShard(dir, [
+      message(
+        "newsletter-1",
+        "Acme Corp newsletter: Project Atlas in Portland.",
+        ["newsletter"],
+      ),
+    ]);
+
+    const result = await runScrubPipeline({
+      targetPath: dir,
+      stage: "all",
+      mode: "fast-track",
+      resume: true,
+      dryRun: false,
+      rulesetVersion: "rewrite-fast-v1",
+    });
+
+    const rewriteReport = result.report.stageReports.find(
+      (stage) => stage.stage === "rewrite",
+    );
+    expect(rewriteReport?.rewriteSkipped).toBe(1);
+    expect(result.messages[0].text).toContain("Acme Corp");
+  });
+});

--- a/packages/corpus-tools/src/pipeline/rewrite.ts
+++ b/packages/corpus-tools/src/pipeline/rewrite.ts
@@ -1,0 +1,153 @@
+/**
+ * Deterministic same-theme rewrite support for scrub stage 3. The production
+ * pipeline can swap this pure planner for a model-backed rewriter, but the
+ * contract remains the same: keep thread texture while replacing real-world
+ * named specifics with stable fictional equivalents and fail if any source
+ * value survives the rewrite.
+ */
+import { createHash } from "node:crypto";
+import type { CorpusMessage } from "../schema.ts";
+
+export interface RewriteSurrogate {
+  kind: "org" | "project" | "place" | "event";
+  source: string;
+  replacement: string;
+  sourceHash: string;
+}
+
+export interface RewritePlan {
+  surrogates: RewriteSurrogate[];
+}
+
+export interface RewriteResult {
+  message: CorpusMessage;
+  replacements: RewriteSurrogate[];
+}
+
+const ORG_REPLACEMENTS = [
+  "Northstar Labs",
+  "Harbor Works",
+  "Juniper Systems",
+  "Beacon Studio",
+];
+const PROJECT_REPLACEMENTS = [
+  "Project Lantern",
+  "Project Meridian",
+  "Project Orchard",
+  "Project Harbor",
+];
+const PLACE_REPLACEMENTS = ["Riverton", "Lakehaven", "Ashford", "Marin Bay"];
+const EVENT_REPLACEMENTS = [
+  "Founders Dinner",
+  "Spring Showcase",
+  "Partner Summit",
+  "Launch Social",
+];
+
+const ENTITY_PATTERNS: readonly {
+  kind: RewriteSurrogate["kind"];
+  pattern: RegExp;
+  replacements: readonly string[];
+}[] = [
+  {
+    kind: "project",
+    pattern: /\bProject [A-Z][a-zA-Z0-9-]{2,}\b/g,
+    replacements: PROJECT_REPLACEMENTS,
+  },
+  {
+    kind: "org",
+    pattern:
+      /\b[A-Z][a-zA-Z0-9-]+ (?:Corp|Corporation|Inc|LLC|Labs|Systems|Studio|Works)\b/g,
+    replacements: ORG_REPLACEMENTS,
+  },
+  {
+    kind: "event",
+    pattern: /\b[A-Z][a-z]+ (?:Gala|Summit|Retreat|Dinner|Launch|Showcase)\b/g,
+    replacements: EVENT_REPLACEMENTS,
+  },
+  {
+    kind: "place",
+    pattern: /\b(?:Portland|Austin|Seattle|Chicago|Boston|Denver|Brooklyn)\b/g,
+    replacements: PLACE_REPLACEMENTS,
+  },
+];
+
+function stableHash(value: string, salt: string): string {
+  return createHash("sha256").update(`${salt}\0${value}`).digest("hex");
+}
+
+function replacementFor(
+  source: string,
+  salt: string,
+  replacements: readonly string[],
+): string {
+  const hash = stableHash(source, salt);
+  const index = Number.parseInt(hash.slice(0, 8), 16) % replacements.length;
+  return replacements[index];
+}
+
+export function buildRewritePlan(
+  messages: readonly CorpusMessage[],
+  options: { hashSalt: string },
+): RewritePlan {
+  const bySource = new Map<string, RewriteSurrogate>();
+  for (const message of messages) {
+    for (const definition of ENTITY_PATTERNS) {
+      definition.pattern.lastIndex = 0;
+      for (const match of message.text.matchAll(definition.pattern)) {
+        const source = match[0].trim();
+        if (source.startsWith("[[SECRET:")) continue;
+        if (!bySource.has(source)) {
+          bySource.set(source, {
+            kind: definition.kind,
+            source,
+            replacement: replacementFor(
+              source,
+              options.hashSalt,
+              definition.replacements,
+            ),
+            sourceHash: stableHash(source, options.hashSalt),
+          });
+        }
+      }
+    }
+  }
+  return {
+    surrogates: [...bySource.values()].sort((a, b) =>
+      a.source.localeCompare(b.source),
+    ),
+  };
+}
+
+export function rewriteSameThemes(
+  message: CorpusMessage,
+  plan: RewritePlan,
+): RewriteResult {
+  const replacements = plan.surrogates.filter((surrogate) =>
+    message.text.includes(surrogate.source),
+  );
+  let text = message.text;
+  for (const surrogate of [...replacements].sort(
+    (a, b) => b.source.length - a.source.length,
+  )) {
+    text = text.split(surrogate.source).join(surrogate.replacement);
+  }
+  const leaked = replacements.filter((surrogate) =>
+    text.includes(surrogate.source),
+  );
+  if (leaked.length > 0) {
+    throw new Error(
+      `rewrite reintroduced source values: ${leaked
+        .map((surrogate) => surrogate.sourceHash)
+        .join(", ")}`,
+    );
+  }
+  return {
+    message: {
+      ...message,
+      text,
+      scrubState: "rewritten",
+    },
+    replacements,
+  };
+}


### PR DESCRIPTION
## Summary
- add the Stage 3 `rewrite` contract for gray-area same-theme corpus rewriting
- build a deterministic surrogate plan for employers, projects, places, and events so thread references stay consistent
- run rewrite only in `deep` mode; `fast-track` records an explicit skip
- preserve the Stage 1 off-device gate so rewrite cannot run without green `secrets` ledger entries

Closes #14770.

Stacked on #15072 (`fix/14768-pii-secrets-stage`), which is stacked on #15070/#15069/#15058.

## Validation
- PASS: `bun run --cwd packages/corpus-tools typecheck`
- PASS: `bun run --cwd packages/corpus-tools test` (5 files, 19 tests)
- PASS: `bun run --cwd packages/corpus-tools lint`
- PASS: `git diff --check HEAD~1..HEAD`
- PASS: `bun run check:agents-claude`
- PASS: `bun run audit:error-policy-ratchet`
- KNOWN PRE-EXISTING BLOCKER: `node packages/scripts/type-safety-ratchet.mjs` fails outside this package: `as unknown as` 75/73 and core/agent/app-core `?? []` 582/581
- LIVE CEREBRAS BLOCKED: `CEREBRAS_API_KEY` is unset in this environment, so this PR includes deterministic contract/evidence but no live Cerebras run

## Evidence
- Synthetic 10-message thread: `rewriteExecuted=10`, `rewriteReplacementCount=40`, `lhsLeakCount=0`
- Five manually reviewed before/after examples show consistent replacements: `Acme Corp -> Northstar Labs`, `Project Atlas -> Project Orchard`, `Portland -> Lakehaven`, `Launch Gala -> Partner Summit`
- Cost report from run: `rewriteEstimatedUsd=0.0012180000000000001`; extrapolated `estimatedUsdPer10k=1.2180000000000002`
- Resume rerun: `recordsWritten=0`, `hitRate=1`, output hash stable (`c9b83cfbbc0d9a9c97c49420ecb90471061167f554ec391f18b6fa8f4715ddd7`)

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - package CLI/pipeline change only; no UI surface.`
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - package CLI/pipeline change only; no UI surface.`
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - package CLI/pipeline change only; no UI surface.`
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no server process; validation used package CLI output captured in the issue evidence.`
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend surface or browser runtime changed.`
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - CEREBRAS_API_KEY is unset in this environment; deterministic contract evidence is included and live Cerebras remains required once a key is available.`
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts https://github.com/elizaOS/eliza/issues/14770#issuecomment-4894996946

## Safety Notes
- This stage rewrites only after the `secrets` ledger gate, so raw credentials cannot be sent into rewrite.
- Source-value reintroduction is checked against the rewrite plan LHS; the stage throws if a planned source value survives replacement.
- The current implementation is the deterministic package-local harness for the model-backed Cerebras pass; live model evidence remains required once a key is available.
