### PR TITLE
fix(ui): skip cloud-hosted local-inference probes

### DIFF
--- a/packages/scripts/error-policy-ratchet.mjs
+++ b/packages/scripts/error-policy-ratchet.mjs
@@ -37,7 +37,16 @@ import { createRequire } from "node:module";
 import path from "node:path";
 
 const require = createRequire(import.meta.url);
-const ts = require("typescript");
+const args = new Set(process.argv.slice(2));
+const FORCE_LEXICAL = args.has("--force-lexical");
+let ts = null;
+if (!FORCE_LEXICAL) {
+  try {
+    ts = require("typescript");
+  } catch (err) {
+    if (err?.code !== "MODULE_NOT_FOUND") throw err;
+  }
+}
 
 const ROOT = path.resolve(import.meta.dirname, "../..");
 
@@ -72,7 +81,6 @@ const EXCLUDED_SEGMENTS = new Set([
   "tests",
 ]);
 
-const args = new Set(process.argv.slice(2));
 const JSON_FLAG = args.has("--json");
 const SELF_TEST = args.has("--self-test");
 const REPORT = args.has("--report");
@@ -118,12 +126,121 @@ function sourceFileKind(relPath) {
   return relPath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
 }
 
+function stripCommentsAndStrings(sourceText) {
+  let out = "";
+  let state = "code";
+  let quote = "";
+  for (let i = 0; i < sourceText.length; i += 1) {
+    const ch = sourceText[i];
+    const next = sourceText[i + 1];
+
+    if (state === "lineComment") {
+      if (ch === "\n") {
+        state = "code";
+        out += ch;
+      } else {
+        out += " ";
+      }
+      continue;
+    }
+
+    if (state === "blockComment") {
+      if (ch === "*" && next === "/") {
+        out += "  ";
+        i += 1;
+        state = "code";
+      } else {
+        out += ch === "\n" ? "\n" : " ";
+      }
+      continue;
+    }
+
+    if (state === "string") {
+      if (ch === "\\") {
+        out += " ";
+        if (next) {
+          out += next === "\n" ? "\n" : " ";
+          i += 1;
+        }
+      } else if (ch === quote) {
+        out += " ";
+        state = "code";
+      } else {
+        out += ch === "\n" ? "\n" : " ";
+      }
+      continue;
+    }
+
+    if (ch === "/" && next === "/") {
+      out += "  ";
+      i += 1;
+      state = "lineComment";
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      out += "  ";
+      i += 1;
+      state = "blockComment";
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === "`") {
+      out += " ";
+      quote = ch;
+      state = "string";
+      continue;
+    }
+    out += ch;
+  }
+  return out;
+}
+
+function lineForIndex(sourceText, index) {
+  let line = 1;
+  for (let i = 0; i < index; i += 1) {
+    if (sourceText[i] === "\n") line += 1;
+  }
+  return line;
+}
+
+function collectFindingsLexical(sourceText, relPath) {
+  const source = stripCommentsAndStrings(sourceText);
+  const findings = [];
+  const trackConsole = inServerConsoleScope(relPath);
+
+  for (const match of source.matchAll(/\bcatch\s*(?:\([^)]*\)\s*)?\{\s*\}/g)) {
+    findings.push({
+      kind: "emptyCatch",
+      file: relPath,
+      line: lineForIndex(source, match.index),
+    });
+  }
+
+  if (trackConsole) {
+    for (const match of source.matchAll(
+      /\bconsole\s*\.\s*[A-Za-z_$][\w$]*\s*\(/g,
+    )) {
+      let i = match.index - 1;
+      while (i >= 0 && /\s/.test(source[i])) i -= 1;
+      if (source[i] === ".") continue;
+      findings.push({
+        kind: "serverConsole",
+        file: relPath,
+        line: lineForIndex(source, match.index),
+      });
+    }
+  }
+
+  return findings;
+}
+
 /**
  * Classify one source file's text. Empty catch blocks are counted everywhere;
  * console.* calls only when the file is in SERVER_CONSOLE_SCOPE. Exported for
  * the self-test.
  */
 export function collectFindings(sourceText, relPath) {
+  if (!ts) return collectFindingsLexical(sourceText, relPath);
+
   const sourceFile = ts.createSourceFile(
     relPath,
     sourceText,
@@ -201,9 +318,11 @@ function resolveBaseRef() {
     "develop",
   ].filter(Boolean);
   for (const ref of candidates) {
-    if (git(["rev-parse", "--verify", "--quiet", `${ref}^{commit}`], {
-      allowFailure: true,
-    })) {
+    if (
+      git(["rev-parse", "--verify", "--quiet", `${ref}^{commit}`], {
+        allowFailure: true,
+      })
+    ) {
       return ref;
     }
   }
@@ -291,7 +410,12 @@ function repoWideTotals() {
   );
   const findings = [];
   for (const relPath of files) {
-    findings.push(...collectFindings(readFileSync(path.join(ROOT, relPath), "utf8"), relPath));
+    findings.push(
+      ...collectFindings(
+        readFileSync(path.join(ROOT, relPath), "utf8"),
+        relPath,
+      ),
+    );
   }
   return { filesScanned: files.length, counts: summarize(findings) };
 }
@@ -302,7 +426,9 @@ function printHumanSummary({ baseRef, base, files, perFile, regressions }) {
   );
   for (const row of perFile) {
     const deltas = Object.keys(KIND_LABELS)
-      .map((kind) => `${kind} ${row.base[kind] ?? 0}->${row.current[kind] ?? 0}`)
+      .map(
+        (kind) => `${kind} ${row.base[kind] ?? 0}->${row.current[kind] ?? 0}`,
+      )
       .join(", ");
     console.log(`[error-policy-ratchet]   ${row.file}: ${deltas}`);
   }
@@ -310,7 +436,9 @@ function printHumanSummary({ baseRef, base, files, perFile, regressions }) {
     console.log("[error-policy-ratchet] no new fallback-slop in touched files");
     return;
   }
-  console.error("[error-policy-ratchet] new fallback-slop added in touched files:");
+  console.error(
+    "[error-policy-ratchet] new fallback-slop added in touched files:",
+  );
   for (const r of regressions) {
     console.error(
       `  - ${r.file}: ${KIND_LABELS[r.kind]} ${r.base} -> ${r.current}`,
@@ -373,23 +501,33 @@ function runSelfTest() {
     { ...ZERO_COUNTS },
   );
   if (unchanged.length !== 0) {
-    console.error("[error-policy-ratchet] self-test failed: unchanged file regressed");
+    console.error(
+      "[error-policy-ratchet] self-test failed: unchanged file regressed",
+    );
     process.exit(1);
   }
   if (added.length !== 1 || added[0].kind !== "emptyCatch") {
-    console.error("[error-policy-ratchet] self-test failed: added slop not caught");
+    console.error(
+      "[error-policy-ratchet] self-test failed: added slop not caught",
+    );
     process.exit(1);
   }
   if (removed.length !== 0) {
-    console.error("[error-policy-ratchet] self-test failed: removal counted as regression");
+    console.error(
+      "[error-policy-ratchet] self-test failed: removal counted as regression",
+    );
     process.exit(1);
   }
   if (newFileClean.length !== 0) {
-    console.error("[error-policy-ratchet] self-test failed: clean new file regressed");
+    console.error(
+      "[error-policy-ratchet] self-test failed: clean new file regressed",
+    );
     process.exit(1);
   }
   if (newFileSlop.length !== 1 || newFileSlop[0].kind !== "emptyCatch") {
-    console.error("[error-policy-ratchet] self-test failed: new-file slop not caught");
+    console.error(
+      "[error-policy-ratchet] self-test failed: new-file slop not caught",
+    );
     process.exit(1);
   }
   console.log("[error-policy-ratchet] self-test passed");

--- a/packages/ui/src/chat/report-composer-activity.test.ts
+++ b/packages/ui/src/chat/report-composer-activity.test.ts
@@ -7,9 +7,15 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const { elizaGlobalsMock } = vi.hoisted(() => ({
+  elizaGlobalsMock: {
+    base: "http://localhost:31337",
+    token: "test-token",
+  },
+}));
 vi.mock("../utils/eliza-globals", () => ({
-  getElizaApiBase: () => "http://localhost:31337",
-  getElizaApiToken: () => "test-token",
+  getElizaApiBase: () => elizaGlobalsMock.base,
+  getElizaApiToken: () => elizaGlobalsMock.token,
 }));
 
 import { reportComposerActivity } from "./report-composer-activity";
@@ -17,6 +23,8 @@ import { reportComposerActivity } from "./report-composer-activity";
 const fetchMock = vi.fn(() => Promise.resolve(new Response("{}")));
 
 beforeEach(() => {
+  elizaGlobalsMock.base = "http://localhost:31337";
+  elizaGlobalsMock.token = "test-token";
   fetchMock.mockClear();
   vi.stubGlobal("fetch", fetchMock);
 });
@@ -86,5 +94,18 @@ describe("reportComposerActivity (#14679)", () => {
         draftLength: 3,
       }),
     ).not.toThrow();
+  });
+
+  it("skips direct cloud-agent bases that do not expose composer telemetry", () => {
+    elizaGlobalsMock.base =
+      "https://23766030-c096-4a14-932a-a4e43c562432.elizacloud.ai";
+
+    reportComposerActivity({
+      activity: "typing_started",
+      surface: "continuous_chat_overlay",
+      draftLength: 3,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/chat/report-composer-activity.ts
+++ b/packages/ui/src/chat/report-composer-activity.ts
@@ -4,6 +4,7 @@
  * client-side.
  */
 import { logger } from "@elizaos/core";
+import { supportsFullAppShellRoutes } from "../api/app-shell-capabilities";
 import { getElizaApiBase, getElizaApiToken } from "../utils/eliza-globals";
 
 export type ComposerActivityKind =
@@ -26,6 +27,7 @@ export function reportComposerActivity(report: ComposerActivityReport): void {
   try {
     const base = getElizaApiBase();
     if (!base || typeof fetch === "undefined") return;
+    if (!supportsFullAppShellRoutes(base)) return;
     const token = getElizaApiToken();
     void fetch(`${base}/api/interactions/composer`, {
       method: "POST",

--- a/packages/ui/src/components/chat/widgets/model-download.test.tsx
+++ b/packages/ui/src/components/chat/widgets/model-download.test.tsx
@@ -17,6 +17,20 @@ vi.mock("../../../hooks/useAuthStatus", () => ({
   useIsAuthenticated: () => authMock.authenticated,
 }));
 
+const { runtimeModeMock } = vi.hoisted(() => ({
+  runtimeModeMock: {
+    state: { phase: "ready" as const, snapshot: { mode: "local" as const } },
+    mode: "local" as const,
+    isLocalOnly: true,
+    isCloudMode: false,
+    isRemoteMode: false,
+    refetch: vi.fn(),
+  },
+}));
+vi.mock("../../../hooks/useRuntimeMode", () => ({
+  useRuntimeMode: () => runtimeModeMock,
+}));
+
 import type {
   LocalInferenceSlotReadiness,
   ModelHubSnapshot,
@@ -25,12 +39,14 @@ import type {
 // The widget reads via the typed client (getLocalInferenceHub /
 // startLocalInferenceDownload) — mock both. getLocalInferenceHub is overridden
 // per-test; startLocalInferenceDownload is a spy we assert the retry against.
-const { getHubMock, startDownloadMock } = vi.hoisted(() => ({
+const { getBaseUrlMock, getHubMock, startDownloadMock } = vi.hoisted(() => ({
+  getBaseUrlMock: vi.fn(() => "http://localhost:31337"),
   getHubMock: vi.fn(),
   startDownloadMock: vi.fn(),
 }));
 vi.mock("../../../api", () => ({
   client: {
+    getBaseUrl: getBaseUrlMock,
     getLocalInferenceHub: getHubMock,
     startLocalInferenceDownload: startDownloadMock,
   },
@@ -114,6 +130,16 @@ function hub(
 describe("ModelDownloadWidget", () => {
   beforeEach(() => {
     authMock.authenticated = true;
+    Object.assign(runtimeModeMock, {
+      state: { phase: "ready", snapshot: { mode: "local" } },
+      mode: "local",
+      isLocalOnly: true,
+      isCloudMode: false,
+      isRemoteMode: false,
+    });
+    runtimeModeMock.refetch.mockClear();
+    getBaseUrlMock.mockReset();
+    getBaseUrlMock.mockReturnValue("http://localhost:31337");
     getHubMock.mockReset();
     startDownloadMock.mockReset();
     startDownloadMock.mockResolvedValue({ job: {} });
@@ -275,6 +301,27 @@ describe("ModelDownloadWidget", () => {
     await Promise.resolve();
     expect(getHubMock).not.toHaveBeenCalled();
     // Dormant → the first-fetch loading hold renders nothing.
+    expect(
+      container.querySelector('[data-testid="chat-widget-model-download"]'),
+    ).toBeNull();
+  });
+
+  it("does not fetch local-inference endpoints in cloud runtime mode", async () => {
+    Object.assign(runtimeModeMock, {
+      state: { phase: "ready", snapshot: { mode: "cloud" } },
+      mode: "cloud",
+      isLocalOnly: false,
+      isCloudMode: true,
+      isRemoteMode: false,
+    });
+    getHubMock.mockResolvedValue(
+      hub({ TEXT_LARGE: slot({ state: "downloading" }) }),
+    );
+
+    const { container } = render(<ModelDownloadWidget />);
+
+    await Promise.resolve();
+    expect(getHubMock).not.toHaveBeenCalled();
     expect(
       container.querySelector('[data-testid="chat-widget-model-download"]'),
     ).toBeNull();

--- a/packages/ui/src/components/chat/widgets/model-download.tsx
+++ b/packages/ui/src/components/chat/widgets/model-download.tsx
@@ -8,7 +8,10 @@
 import { Download, Loader2, TriangleAlert } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { client } from "../../../api";
+import { supportsFullAppShellRoutes } from "../../../api/app-shell-capabilities";
+import { isDesktopExternalApiBaseUrl } from "../../../api/desktop-external-api-base";
 import { useIsAuthenticated } from "../../../hooks/useAuthStatus";
+import { useRuntimeMode } from "../../../hooks/useRuntimeMode";
 import { cn } from "../../../lib/utils";
 import {
   deriveHomeModelStatus,
@@ -75,10 +78,23 @@ const INITIAL: LocalModelDownloads = {
   loading: true,
 };
 
+const SETTLED_NOT_REQUIRED: LocalModelDownloads = {
+  status: NOT_REQUIRED_STATUS,
+  rows: [],
+  loading: false,
+};
+
 function appendTokenParam(url: string): string {
   const token = getElizaApiToken()?.trim();
   if (!token) return url;
   return `${url}${url.includes("?") ? "&" : "?"}token=${encodeURIComponent(token)}`;
+}
+
+function supportsLocalInferenceStatus(): boolean {
+  const baseUrl = client.getBaseUrl();
+  return (
+    supportsFullAppShellRoutes(baseUrl) && !isDesktopExternalApiBaseUrl(baseUrl)
+  );
 }
 
 function rowsFromReadiness(
@@ -116,10 +132,19 @@ export function useLocalModelDownloads(): LocalModelDownloads {
   // probe resolves, so the hub fetch + download SSE stream must stay dormant
   // until the session is authenticated (mirrors useHomeModelStatus).
   const authenticated = useIsAuthenticated();
+  const runtimeMode = useRuntimeMode();
 
   useEffect(() => {
-    if (!authenticated) {
+    if (!authenticated || runtimeMode.state.phase === "loading") {
       setState(INITIAL);
+      return;
+    }
+    if (
+      runtimeMode.isCloudMode ||
+      runtimeMode.isRemoteMode ||
+      !supportsLocalInferenceStatus()
+    ) {
+      setState(SETTLED_NOT_REQUIRED);
       return;
     }
 
@@ -168,7 +193,12 @@ export function useLocalModelDownloads(): LocalModelDownloads {
       if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
       es?.close();
     };
-  }, [authenticated]);
+  }, [
+    authenticated,
+    runtimeMode.isCloudMode,
+    runtimeMode.isRemoteMode,
+    runtimeMode.state.phase,
+  ]);
 
   return state;
 }


### PR DESCRIPTION
## Summary
- Do not render/fetch the local model download widget in cloud or remote runtime modes, or when the configured API base is a hosted cloud-agent/direct base that does not expose full app-shell routes.
- Skip optional composer telemetry for direct cloud-agent bases that do not expose `/api/interactions/composer`.
- Add regression coverage for both hosted-cloud no-op paths.
- Harden `error-policy-ratchet.mjs` so the no-install lane-coverage CI job uses a dependency-free lexical fallback when `typescript` is unavailable, while keeping the TypeScript AST path when dependencies exist.

Fixes #15077.

## Verification
- `bun install --frozen-lockfile` ✅
- `bunx @biomejs/biome check packages/ui/src/components/chat/widgets/model-download.tsx packages/ui/src/components/chat/widgets/model-download.test.tsx packages/ui/src/chat/report-composer-activity.ts packages/ui/src/chat/report-composer-activity.test.ts` ✅
- `bunx @biomejs/biome check --write packages/scripts/error-policy-ratchet.mjs packages/ui/src/components/chat/widgets/model-download.tsx packages/ui/src/components/chat/widgets/model-download.test.tsx packages/ui/src/chat/report-composer-activity.ts packages/ui/src/chat/report-composer-activity.test.ts` ✅ (only existing `ERROR_POLICY_BASE_REF` warning)
- `bun run --cwd packages/ui test src/components/chat/widgets/model-download.test.tsx src/chat/report-composer-activity.test.ts` ✅ 2 files / 15 tests
- `node packages/scripts/error-policy-ratchet.mjs --self-test` ✅
- `node packages/scripts/error-policy-ratchet.mjs --self-test --force-lexical` ✅
- `node packages/scripts/error-policy-ratchet.mjs --force-lexical` ✅ no new fallback-slop in touched files
- `git diff --check` ✅

## Typecheck note
- `bun run --cwd packages/ui typecheck` currently fails on existing/baseline repo issues outside this patch, including missing `@elizaos/cloud-routing`, `settings-sections.ts`, `startup-phase-poll.test.ts`, `widget-cert-fixture.tsx`, and `voice-selftest-harness.test.ts`. The reported errors do not point at the files changed in this PR.

## Risk
- Low-risk hosted-cloud guard: local/full app-shell behavior keeps the existing widget fetch path; cloud/remote/direct hosted-agent bases settle to `not-required` and render nothing instead of probing local-inference endpoints.
- The ratchet fallback only runs when `typescript` is unavailable or `--force-lexical` is passed; installed/dev paths keep the existing TypeScript AST scanner.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshot evidence: production mobile app baseline from the #15077 reproduction is in the evidence packet: https://gist.github.com/NubsCarson/086785ecb7add5ea3aac93284f6315c6#file-mobile-app-auth-png-base64-txt
<!-- evidence-row:after-screenshots -->
- [ ] After screenshot evidence: N/A - this PR has no visible UI delta before deploy; expected visual state remains the verified mobile chat baseline, linked here for comparison: https://gist.github.com/NubsCarson/086785ecb7add5ea3aac93284f6315c6#file-mobile-app-chat-answer-visible-png-base64-txt
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: N/A - behavior change is request suppression, not a visible flow; production mobile walkthrough evidence and artifact index are linked here: https://gist.github.com/NubsCarson/086785ecb7add5ea3aac93284f6315c6#file-readme-md
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: N/A - frontend/client guard only; server behavior is unchanged.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: #15077 reproduction and PR verification notes are attached here: https://github.com/elizaOS/eliza/issues/15077#issuecomment-4895644737
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model behavior changed; related production smoke JSON is linked for context: https://gist.github.com/NubsCarson/086785ecb7add5ea3aac93284f6315c6#file-mobile-app-chat-answer-visible-json
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts / OCR text readout: OCR/text body snippet from the verified mobile chat smoke is linked here: https://gist.github.com/NubsCarson/086785ecb7add5ea3aac93284f6315c6#file-mobile-app-chat-answer-visible-json
