### PR TITLE
feat(core): attribute trajectory provider context

### DIFF
--- a/packages/core/src/features/trajectories/TrajectoriesService.test.ts
+++ b/packages/core/src/features/trajectories/TrajectoriesService.test.ts
@@ -145,6 +145,18 @@ describe("TrajectoriesService", () => {
 			purpose: "action",
 			actionType: "runtime.useModel",
 			latencyMs: 1,
+			providerOrder: ["CHARACTER"],
+			providerAttributions: [
+				{
+					providerName: "CHARACTER",
+					sha256:
+						"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					tokenCount: 8,
+					position: 0,
+					spanStart: 5,
+					spanEnd: 19,
+				},
+			],
 		});
 		await service.flushWriteQueue(trajectoryId);
 
@@ -157,6 +169,14 @@ describe("TrajectoriesService", () => {
 		expect(call.tools.circular.self).toBe("[Circular]");
 		expect(call.tools.circular.fn).toBe("[Function toolHandler]");
 		expect(call.providerMetadata.self).toBe("[Circular]");
+		expect(call.providerOrder).toEqual(["CHARACTER"]);
+		expect(call.providerAttributions[0]).toMatchObject({
+			providerName: "CHARACTER",
+			tokenCount: 8,
+			position: 0,
+			spanStart: 5,
+			spanEnd: 19,
+		});
 	});
 
 	it("keeps empty step objects parseable across queued step writes", async () => {

--- a/packages/core/src/features/trajectories/TrajectoriesService.ts
+++ b/packages/core/src/features/trajectories/TrajectoriesService.ts
@@ -535,6 +535,12 @@ function normalizeLlmCall(value: unknown): LLMCall | null {
 	}
 	const tags = stringArrayValue(value.tags);
 	if (tags) call.tags = tags;
+	const providerOrder = stringArrayValue(value.providerOrder);
+	if (providerOrder) call.providerOrder = providerOrder;
+	if (Array.isArray(value.providerAttributions)) {
+		call.providerAttributions =
+			value.providerAttributions as LLMCall["providerAttributions"];
+	}
 	if (Array.isArray(value.messages)) call.messages = value.messages;
 	if (Array.isArray(value.toolCalls)) call.toolCalls = value.toolCalls;
 	if ("tools" in value) call.tools = value.tools;
@@ -564,6 +570,19 @@ function normalizeProviderAccess(value: unknown): ProviderAccess | null {
 		purpose,
 	};
 	if (isJsonObject(value.query)) access.query = value.query;
+	const sha256 = stringValue(value.sha256);
+	if (sha256 !== null) access.sha256 = sha256;
+	for (const key of [
+		"tokenCount",
+		"position",
+		"spanStart",
+		"spanEnd",
+	] as const) {
+		const numericValue = numberValue(value[key]);
+		if (numericValue !== null) {
+			access[key] = numericValue;
+		}
+	}
 	for (const key of [
 		"runId",
 		"roomId",
@@ -1695,6 +1714,8 @@ export class TrajectoriesService extends Service {
 				roomId: params.roomId,
 				messageId: params.messageId,
 				executionTraceId: params.executionTraceId,
+				providerOrder: params.providerOrder,
+				providerAttributions: params.providerAttributions,
 			};
 			step.llmCalls.push(llmCall);
 
@@ -1764,6 +1785,11 @@ export class TrajectoriesService extends Service {
 		stepId: string;
 		providerName: string;
 		data: Record<string, unknown>;
+		sha256?: string;
+		tokenCount?: number;
+		position?: number;
+		spanStart?: number;
+		spanEnd?: number;
 		purpose: string;
 		query?: Record<string, unknown>;
 		runId?: string;
@@ -1776,6 +1802,11 @@ export class TrajectoriesService extends Service {
 		params: {
 			providerName: string;
 			data: Record<string, unknown>;
+			sha256?: string;
+			tokenCount?: number;
+			position?: number;
+			spanStart?: number;
+			spanEnd?: number;
 			purpose: string;
 			query?: Record<string, unknown>;
 			runId?: string;
@@ -1791,6 +1822,11 @@ export class TrajectoriesService extends Service {
 					stepId: string;
 					providerName: string;
 					data: Record<string, unknown>;
+					sha256?: string;
+					tokenCount?: number;
+					position?: number;
+					spanStart?: number;
+					spanEnd?: number;
 					purpose: string;
 					query?: Record<string, unknown>;
 					runId?: string;
@@ -1801,6 +1837,11 @@ export class TrajectoriesService extends Service {
 		arg2?: {
 			providerName: string;
 			data: Record<string, unknown>;
+			sha256?: string;
+			tokenCount?: number;
+			position?: number;
+			spanStart?: number;
+			spanEnd?: number;
 			purpose: string;
 			query?: Record<string, unknown>;
 		},
@@ -1812,6 +1853,11 @@ export class TrajectoriesService extends Service {
 						stepId: arg1,
 						providerName: arg2?.providerName ?? "unknown",
 						data: arg2?.data ?? {},
+						sha256: arg2?.sha256,
+						tokenCount: arg2?.tokenCount,
+						position: arg2?.position,
+						spanStart: arg2?.spanStart,
+						spanEnd: arg2?.spanEnd,
 						purpose: arg2?.purpose ?? "other",
 						query: arg2?.query,
 					}
@@ -1854,6 +1900,11 @@ export class TrajectoriesService extends Service {
 			stepId: string;
 			providerName: string;
 			data: Record<string, unknown>;
+			sha256?: string;
+			tokenCount?: number;
+			position?: number;
+			spanStart?: number;
+			spanEnd?: number;
 			purpose: string;
 			query?: Record<string, unknown>;
 			runId?: string;
@@ -1872,6 +1923,11 @@ export class TrajectoriesService extends Service {
 				providerName: params.providerName,
 				timestamp: Date.now(),
 				data: params.data as Record<string, JsonValue>,
+				sha256: params.sha256,
+				tokenCount: params.tokenCount,
+				position: params.position,
+				spanStart: params.spanStart,
+				spanEnd: params.spanEnd,
 				query: params.query as Record<string, JsonValue> | undefined,
 				purpose: params.purpose,
 				runId: params.runId,
@@ -1906,6 +1962,11 @@ export class TrajectoriesService extends Service {
 		access: {
 			providerName: string;
 			data: Record<string, unknown>;
+			sha256?: string;
+			tokenCount?: number;
+			position?: number;
+			spanStart?: number;
+			spanEnd?: number;
 			purpose: string;
 			query?: Record<string, unknown>;
 		},

--- a/packages/core/src/features/trajectories/integration.ts
+++ b/packages/core/src/features/trajectories/integration.ts
@@ -132,6 +132,11 @@ export function logProviderAccess(
 	access: {
 		providerName: string;
 		data: ProviderAccessData;
+		sha256?: string;
+		tokenCount?: number;
+		position?: number;
+		spanStart?: number;
+		spanEnd?: number;
 		purpose: string;
 		query?: ProviderAccessData;
 	},

--- a/packages/core/src/features/trajectories/types.ts
+++ b/packages/core/src/features/trajectories/types.ts
@@ -17,6 +17,8 @@
  * exporters, read routes, rewards); widen additively so on-disk rows and the
  * viewer wire shapes stay backward-compatible.
  */
+
+import type { TrajectoryProviderAttribution } from "../../runtime/trajectory-provider-attribution";
 import type { JsonObject, JsonPrimitive, JsonValue, UUID } from "../../types";
 import type { ContextEvent } from "../../types/context-object";
 
@@ -110,6 +112,8 @@ export interface LLMCall {
 	roomId?: string;
 	messageId?: string;
 	executionTraceId?: string;
+	providerOrder?: string[];
+	providerAttributions?: TrajectoryProviderAttribution[];
 }
 
 export interface ProviderAccess {
@@ -122,6 +126,11 @@ export interface ProviderAccess {
 
 	// What was returned
 	data: Record<string, JsonValue>;
+	sha256?: string;
+	tokenCount?: number;
+	position?: number;
+	spanStart?: number;
+	spanEnd?: number;
 
 	// Context
 	purpose: string;

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -91,6 +91,7 @@ import {
 	resolveEffectiveSystemPrompt,
 	textFromChatMessageContent,
 } from "./runtime/system-prompt";
+import { buildProviderAttributionsFromState } from "./runtime/trajectory-provider-attribution";
 import { TurnControllerRegistry } from "./runtime/turn-controller";
 import { BM25 } from "./search";
 import {
@@ -4263,30 +4264,6 @@ export class AgentRuntime implements IAgentRuntime {
 			reused: providersToGet.length - providersToRun.length,
 		});
 
-		if (trajectoryStepId && trajLogger) {
-			const userText =
-				typeof message.content.text === "string" ? message.content.text : "";
-			const trajCtx = getTrajectoryContext();
-			const providerTraceId = this.getActiveTrace(this.getCurrentRunId())?.id;
-			for (const r of providerData) {
-				try {
-					const textLen = typeof r.text === "string" ? r.text.length : 0;
-					trajLogger.logProviderAccess({
-						stepId: trajectoryStepId,
-						providerName: r.providerName,
-						data: { textLength: textLen },
-						purpose: "compose_state",
-						query: { message: userText.slice(0, 2000) },
-						runId: trajCtx?.runId,
-						roomId: trajCtx?.roomId,
-						messageId: trajCtx?.messageId,
-						executionTraceId: providerTraceId,
-					});
-				} catch {
-					// Trajectory logging must never break core message flow.
-				}
-			}
-		}
 		const currentProviderResults: Record<
 			string,
 			{
@@ -4338,6 +4315,62 @@ export class AgentRuntime implements IAgentRuntime {
 		// Redact any secrets from provider context before use
 		const rawProvidersText = orderedTexts.join("\n");
 		const providersText = this.redactSecrets(rawProvidersText);
+		const providerOrderNames = providersToGet.map((provider) => provider.name);
+		const attributionState = {
+			values: {},
+			data: {
+				providerOrder: providerOrderNames,
+				providers: currentProviderResults,
+			},
+			text: providersText,
+		} as State;
+		const providerAttribution = buildProviderAttributionsFromState({
+			state: attributionState,
+			prompt: providersText,
+		});
+		const providerAttributionByName = new Map(
+			providerAttribution.providerAttributions.map((entry) => [
+				entry.providerName,
+				entry,
+			]),
+		);
+		const activeTrajectoryContext = getTrajectoryContext();
+		if (activeTrajectoryContext) {
+			activeTrajectoryContext.providerOrder = providerAttribution.providerOrder;
+			activeTrajectoryContext.providerAttributions =
+				providerAttribution.providerAttributions;
+		}
+		if (trajectoryStepId && trajLogger) {
+			const userText =
+				typeof message.content.text === "string" ? message.content.text : "";
+			const trajCtx = activeTrajectoryContext;
+			const providerTraceId = this.getActiveTrace(this.getCurrentRunId())?.id;
+			for (const r of providerData) {
+				try {
+					const redactedText =
+						currentProviderResults[r.providerName]?.text ?? "";
+					const attribution = providerAttributionByName.get(r.providerName);
+					trajLogger.logProviderAccess({
+						stepId: trajectoryStepId,
+						providerName: r.providerName,
+						data: { textLength: redactedText.length },
+						sha256: attribution?.sha256,
+						tokenCount: attribution?.tokenCount,
+						position: attribution?.position,
+						spanStart: attribution?.spanStart,
+						spanEnd: attribution?.spanEnd,
+						purpose: "compose_state",
+						query: { message: userText.slice(0, 2000) },
+						runId: trajCtx?.runId,
+						roomId: trajCtx?.roomId,
+						messageId: trajCtx?.messageId,
+						executionTraceId: providerTraceId,
+					});
+				} catch {
+					// Trajectory logging must never break core message flow.
+				}
+			}
+		}
 		const conversationSeed = buildDeterministicSeed(
 			this.agentId,
 			message.roomId,
@@ -4378,7 +4411,7 @@ export class AgentRuntime implements IAgentRuntime {
 			data: {
 				...cachedState.data,
 				__conversationSeed: conversationSeed,
-				providerOrder: providersToGet.map((provider) => provider.name),
+				providerOrder: providerOrderNames,
 				providers: currentProviderResults,
 			},
 			text: providersText,
@@ -6216,6 +6249,8 @@ export class AgentRuntime implements IAgentRuntime {
 				roomId: trajCtx.roomId,
 				messageId: trajCtx.messageId,
 				executionTraceId: activeTrace?.id,
+				providerOrder: trajCtx.providerOrder,
+				providerAttributions: trajCtx.providerAttributions,
 			});
 		} catch {
 			// Trajectory logging must never break core model flow.

--- a/packages/core/src/runtime/__tests__/trajectory-provider-attribution.test.ts
+++ b/packages/core/src/runtime/__tests__/trajectory-provider-attribution.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit coverage for trajectory provider attribution: hash-first provider
+ * records, ordered prompt spans, and exact prompt-slice round trips.
+ */
+import { describe, expect, it } from "bun:test";
+import type { State } from "../../types/state";
+import {
+	buildProviderAttributionsFromState,
+	flattenTrajectoryMessages,
+	sha256Text,
+} from "../trajectory-provider-attribution";
+
+describe("trajectory provider attribution", () => {
+	it("records provider order and spans that round-trip against the prompt", () => {
+		const state = {
+			data: {
+				providerOrder: ["CHARACTER", "RECENT_MESSAGES"],
+				providers: {
+					CHARACTER: {
+						providerName: "CHARACTER",
+						text: "Character voice: precise and brief.",
+					},
+					RECENT_MESSAGES: {
+						providerName: "RECENT_MESSAGES",
+						text: "User: remind me tomorrow.",
+					},
+				},
+			},
+		} as State;
+		const prompt = flattenTrajectoryMessages([
+			{
+				role: "system",
+				content: "provider:CHARACTER:\nCharacter voice: precise and brief.",
+			},
+			{
+				role: "user",
+				content: "provider:RECENT_MESSAGES:\nUser: remind me tomorrow.",
+			},
+		]);
+
+		const result = buildProviderAttributionsFromState({ state, prompt });
+
+		expect(result.providerOrder).toEqual(["CHARACTER", "RECENT_MESSAGES"]);
+		expect(result.providerAttributions).toHaveLength(2);
+		for (const entry of result.providerAttributions) {
+			expect(entry.sha256).toHaveLength(64);
+			expect(entry.tokenCount).toBeGreaterThan(0);
+			expect(entry.spanStart).toBeGreaterThanOrEqual(0);
+			expect(entry.spanEnd).toBeGreaterThan(entry.spanStart ?? 0);
+		}
+		const [character, recent] = result.providerAttributions;
+		expect(prompt.slice(character.spanStart, character.spanEnd)).toBe(
+			"Character voice: precise and brief.",
+		);
+		expect(prompt.slice(recent.spanStart, recent.spanEnd)).toBe(
+			"User: remind me tomorrow.",
+		);
+		expect(character.sha256).toBe(
+			sha256Text("Character voice: precise and brief."),
+		);
+	});
+
+	it("omits spans when a provider was selected but not rendered into the prompt", () => {
+		const state = {
+			data: {
+				providerOrder: ["ACTIONS"],
+				providers: {
+					ACTIONS: { providerName: "ACTIONS", text: "tool catalog" },
+				},
+			},
+		} as State;
+
+		const result = buildProviderAttributionsFromState({
+			state,
+			prompt: "planner_stage:\nNo provider block here.",
+		});
+
+		expect(result.providerAttributions).toEqual([
+			{
+				providerName: "ACTIONS",
+				sha256: sha256Text("tool catalog"),
+				tokenCount: 4,
+				position: 0,
+			},
+		]);
+	});
+});

--- a/packages/core/src/runtime/__tests__/trajectory-provider-attribution.test.ts
+++ b/packages/core/src/runtime/__tests__/trajectory-provider-attribution.test.ts
@@ -27,7 +27,10 @@ describe("trajectory provider attribution", () => {
 				},
 			},
 		} as State;
-		const prompt = flattenTrajectoryMessages([
+		// The recorded stage persists `messages`, never a second flattened prompt.
+		// Spans index into the read-time reconstruction of that same array, so the
+		// round trip below mirrors exactly what a consumer reconstructs on read.
+		const messages = [
 			{
 				role: "system",
 				content: "provider:CHARACTER:\nCharacter voice: precise and brief.",
@@ -36,7 +39,8 @@ describe("trajectory provider attribution", () => {
 				role: "user",
 				content: "provider:RECENT_MESSAGES:\nUser: remind me tomorrow.",
 			},
-		]);
+		];
+		const prompt = flattenTrajectoryMessages(messages);
 
 		const result = buildProviderAttributionsFromState({ state, prompt });
 
@@ -49,10 +53,12 @@ describe("trajectory provider attribution", () => {
 			expect(entry.spanEnd).toBeGreaterThan(entry.spanStart ?? 0);
 		}
 		const [character, recent] = result.providerAttributions;
-		expect(prompt.slice(character.spanStart, character.spanEnd)).toBe(
+		// Reconstruct from `messages` (as a reader does) — no stored prompt needed.
+		const reconstructed = flattenTrajectoryMessages(messages);
+		expect(reconstructed.slice(character.spanStart, character.spanEnd)).toBe(
 			"Character voice: precise and brief.",
 		);
-		expect(prompt.slice(recent.spanStart, recent.spanEnd)).toBe(
+		expect(reconstructed.slice(recent.spanStart, recent.spanEnd)).toBe(
 			"User: remind me tomorrow.",
 		);
 		expect(character.sha256).toBe(

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -87,6 +87,10 @@ import {
 	buildSpanSamplerPlan,
 	withGuidedDecodeProviderOptions,
 } from "./response-grammar";
+import {
+	buildProviderAttributionsFromState,
+	flattenTrajectoryMessages,
+} from "./trajectory-provider-attribution";
 import type {
 	RecordedStage,
 	RecordedToolCall,
@@ -316,6 +320,7 @@ export async function runPlannerLoop(
 				recorder: params.recorder,
 				trajectoryId: params.trajectoryId,
 				parentStageId: params.parentStageId,
+				providerAttributionState: params.providerAttributionState,
 				iteration,
 				onUsage: observePlannerUsage,
 			});
@@ -1301,6 +1306,7 @@ async function callPlanner(params: {
 	recorder?: TrajectoryRecorder;
 	trajectoryId?: string;
 	parentStageId?: string;
+	providerAttributionState?: PlannerLoopParams["providerAttributionState"];
 	iteration?: number;
 	/**
 	 * Side-channel observer called once per model call with the gross
@@ -1532,6 +1538,7 @@ async function callPlanner(params: {
 		segmentHashes: prefixHashes.map((entry) => entry.segmentHash),
 		prefixHash,
 		logger: params.runtime.logger,
+		providerAttributionState: params.providerAttributionState,
 	});
 
 	return parsed;
@@ -1830,6 +1837,7 @@ async function recordPlannerStage(args: {
 	endedAt: number;
 	segmentHashes: string[];
 	prefixHash: string;
+	providerAttributionState?: PlannerLoopParams["providerAttributionState"];
 	logger?: PlannerRuntime["logger"];
 }): Promise<void> {
 	if (!args.recorder || !args.trajectoryId) return;
@@ -1840,6 +1848,11 @@ async function recordPlannerStage(args: {
 		const usage = extractUsage(args.raw);
 		const finishReason = extractFinishReason(args.raw);
 		const modelName = extractModelName(args.raw);
+		const prompt = flattenTrajectoryMessages(args.modelParams.messages);
+		const providerAttribution = buildProviderAttributionsFromState({
+			state: args.providerAttributionState,
+			prompt,
+		});
 		const stage: RecordedStage = {
 			stageId: `stage-planner-iter-${args.iteration}-${args.startedAt}`,
 			kind: "planner",
@@ -1852,6 +1865,7 @@ async function recordPlannerStage(args: {
 				modelType: String(args.modelType),
 				modelName,
 				provider: args.provider ?? "default",
+				prompt,
 				messages: args.modelParams.messages,
 				tools: args.modelParams.tools,
 				toolChoice: args.modelParams.toolChoice,
@@ -1865,6 +1879,8 @@ async function recordPlannerStage(args: {
 				usage,
 				finishReason,
 				costUsd: usage ? computeCallCostUsd(modelName, usage) : undefined,
+				providerOrder: providerAttribution.providerOrder,
+				providerAttributions: providerAttribution.providerAttributions,
 			},
 			cache: {
 				segmentHashes: args.segmentHashes,
@@ -2777,6 +2793,7 @@ async function finishWithForcedSynthesis(params: {
 		recorder: loop.recorder,
 		trajectoryId: loop.trajectoryId,
 		parentStageId: loop.parentStageId,
+		providerAttributionState: loop.providerAttributionState,
 		iteration,
 		onUsage: params.onUsage,
 	});

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -1848,10 +1848,12 @@ async function recordPlannerStage(args: {
 		const usage = extractUsage(args.raw);
 		const finishReason = extractFinishReason(args.raw);
 		const modelName = extractModelName(args.raw);
-		const prompt = flattenTrajectoryMessages(args.modelParams.messages);
+		// Flatten `messages` only to locate provider spans; the flattened form is
+		// not persisted — `messages` is the canonical record and spans index into
+		// `flattenTrajectoryMessages(messages)` reconstructed at read time.
 		const providerAttribution = buildProviderAttributionsFromState({
 			state: args.providerAttributionState,
-			prompt,
+			prompt: flattenTrajectoryMessages(args.modelParams.messages),
 		});
 		const stage: RecordedStage = {
 			stageId: `stage-planner-iter-${args.iteration}-${args.startedAt}`,
@@ -1865,7 +1867,6 @@ async function recordPlannerStage(args: {
 				modelType: String(args.modelType),
 				modelName,
 				provider: args.provider ?? "default",
-				prompt,
 				messages: args.modelParams.messages,
 				tools: args.modelParams.tools,
 				toolChoice: args.modelParams.toolChoice,

--- a/packages/core/src/runtime/planner-types.ts
+++ b/packages/core/src/runtime/planner-types.ts
@@ -14,6 +14,7 @@ import type {
 	ToolChoice,
 	ToolDefinition,
 } from "../types/model";
+import type { State } from "../types/state";
 import type { ChainingLoopConfig } from "./limits";
 import type { TrajectoryRecorder } from "./trajectory-recorder";
 
@@ -205,6 +206,7 @@ export interface PlannerLoopParams {
 	recorder?: TrajectoryRecorder;
 	trajectoryId?: string;
 	parentStageId?: string;
+	providerAttributionState?: State;
 }
 
 export interface RunEvaluatorParams {

--- a/packages/core/src/runtime/trajectory-provider-attribution.ts
+++ b/packages/core/src/runtime/trajectory-provider-attribution.ts
@@ -5,9 +5,8 @@
  * provider selection without storing another copy of provider text.
  */
 import { createHash } from "node:crypto";
-import type { ChatMessage, PromptSegment } from "../types/model";
+import type { ChatMessage } from "../types/model";
 import type { State } from "../types/state";
-import { segmentBlock } from "./context-renderer";
 
 export interface TrajectoryProviderAttribution {
 	providerName: string;
@@ -52,15 +51,6 @@ export function flattenTrajectoryMessages(
 			return `${role}:\n${content}`;
 		})
 		.join("\n\n");
-}
-
-export function flattenTrajectoryPromptSegments(
-	segments: readonly PromptSegment[] | undefined,
-): string {
-	if (!Array.isArray(segments) || segments.length === 0) {
-		return "";
-	}
-	return segments.map(segmentBlock).filter(Boolean).join("\n\n");
 }
 
 function providerSnapshotsFromState(state: State | undefined): {

--- a/packages/core/src/runtime/trajectory-provider-attribution.ts
+++ b/packages/core/src/runtime/trajectory-provider-attribution.ts
@@ -1,0 +1,154 @@
+/**
+ * Provider attribution helpers for trajectory records. Runtime prompt
+ * composition already knows the ordered provider blocks that fed a model call;
+ * these helpers persist hash-first spans so optimizers can reason about
+ * provider selection without storing another copy of provider text.
+ */
+import { createHash } from "node:crypto";
+import type { ChatMessage, PromptSegment } from "../types/model";
+import type { State } from "../types/state";
+import { segmentBlock } from "./context-renderer";
+
+export interface TrajectoryProviderAttribution {
+	providerName: string;
+	sha256: string;
+	tokenCount: number;
+	position: number;
+	spanStart?: number;
+	spanEnd?: number;
+}
+
+interface ProviderTextSnapshot {
+	providerName: string;
+	text: string;
+	position: number;
+}
+
+export function sha256Text(text: string): string {
+	return createHash("sha256").update(text).digest("hex");
+}
+
+export function estimateTrajectoryTextTokens(text: string): number {
+	return Math.ceil(text.length / 3.5);
+}
+
+export function flattenTrajectoryMessages(
+	messages: readonly ChatMessage[] | readonly unknown[] | undefined,
+): string {
+	if (!Array.isArray(messages) || messages.length === 0) {
+		return "";
+	}
+	return messages
+		.map((message) => {
+			if (!message || typeof message !== "object") {
+				return String(message);
+			}
+			const record = message as { role?: unknown; content?: unknown };
+			const role = typeof record.role === "string" ? record.role : "message";
+			const content =
+				typeof record.content === "string"
+					? record.content
+					: JSON.stringify(record.content ?? "");
+			return `${role}:\n${content}`;
+		})
+		.join("\n\n");
+}
+
+export function flattenTrajectoryPromptSegments(
+	segments: readonly PromptSegment[] | undefined,
+): string {
+	if (!Array.isArray(segments) || segments.length === 0) {
+		return "";
+	}
+	return segments.map(segmentBlock).filter(Boolean).join("\n\n");
+}
+
+function providerSnapshotsFromState(state: State | undefined): {
+	providerOrder: string[];
+	snapshots: ProviderTextSnapshot[];
+} {
+	const providers = state?.data?.providers;
+	if (!providers || typeof providers !== "object") {
+		return { providerOrder: [], snapshots: [] };
+	}
+	const providerMap = providers as Record<string, unknown>;
+	const providerOrder = Array.isArray(state.data.providerOrder)
+		? state.data.providerOrder.map((name) => String(name))
+		: Object.keys(providerMap).sort((left, right) => left.localeCompare(right));
+	const seen = new Set<string>();
+	const snapshots: ProviderTextSnapshot[] = [];
+	for (const providerName of providerOrder) {
+		if (seen.has(providerName)) {
+			continue;
+		}
+		seen.add(providerName);
+		const provider = providerMap[providerName];
+		if (!provider || typeof provider !== "object") {
+			continue;
+		}
+		const text = (provider as { text?: unknown }).text;
+		if (typeof text !== "string" || text.trim() === "") {
+			continue;
+		}
+		snapshots.push({
+			providerName,
+			text: text.trim(),
+			position: snapshots.length,
+		});
+	}
+	return { providerOrder, snapshots };
+}
+
+function locateProviderSpan(
+	prompt: string,
+	snapshot: ProviderTextSnapshot,
+	cursor: number,
+): { start?: number; end?: number; nextCursor: number } {
+	if (!prompt) {
+		return { nextCursor: cursor };
+	}
+	const direct = prompt.indexOf(snapshot.text, cursor);
+	if (direct >= 0) {
+		return {
+			start: direct,
+			end: direct + snapshot.text.length,
+			nextCursor: direct + snapshot.text.length,
+		};
+	}
+	const labeled = `provider:${snapshot.providerName}:\n${snapshot.text}`;
+	const labeledStart = prompt.indexOf(labeled, cursor);
+	if (labeledStart >= 0) {
+		const textStart = labeledStart + labeled.length - snapshot.text.length;
+		return {
+			start: textStart,
+			end: textStart + snapshot.text.length,
+			nextCursor: textStart + snapshot.text.length,
+		};
+	}
+	return { nextCursor: cursor };
+}
+
+export function buildProviderAttributionsFromState(args: {
+	state?: State;
+	prompt?: string;
+}): {
+	providerOrder: string[];
+	providerAttributions: TrajectoryProviderAttribution[];
+} {
+	const { providerOrder, snapshots } = providerSnapshotsFromState(args.state);
+	let cursor = 0;
+	const providerAttributions = snapshots.map((snapshot) => {
+		const span = locateProviderSpan(args.prompt ?? "", snapshot, cursor);
+		cursor = span.nextCursor;
+		return {
+			providerName: snapshot.providerName,
+			sha256: sha256Text(snapshot.text),
+			tokenCount: estimateTrajectoryTextTokens(snapshot.text),
+			position: snapshot.position,
+			...(span.start !== undefined && span.end !== undefined
+				? { spanStart: span.start, spanEnd: span.end }
+				: {}),
+		};
+	});
+	return { providerOrder, providerAttributions };
+}

--- a/packages/core/src/runtime/trajectory-recorder.ts
+++ b/packages/core/src/runtime/trajectory-recorder.ts
@@ -37,6 +37,7 @@ import {
 	type TraceCorrelation,
 } from "./trace-correlation";
 import { resolveTrajectoryGate } from "./trajectory-gate";
+import type { TrajectoryProviderAttribution } from "./trajectory-provider-attribution";
 
 // ---------------------------------------------------------------------------
 // Schema (mirrors PLAN.md §18.1)
@@ -93,6 +94,14 @@ export interface RecordedModelCall {
 	 * pricing table at `features/trajectories/pricing.ts` changes.
 	 */
 	priceTableId?: string;
+	/** Provider order selected for the composeState call that fed this model input. */
+	providerOrder?: string[];
+	/**
+	 * Hash-first provider contributions with spans into `prompt`. Text is not
+	 * duplicated here; consumers can slice the recorded prompt to verify exact
+	 * provenance when spans are present.
+	 */
+	providerAttributions?: TrajectoryProviderAttribution[];
 }
 
 /**

--- a/packages/core/src/runtime/trajectory-recorder.ts
+++ b/packages/core/src/runtime/trajectory-recorder.ts
@@ -97,9 +97,11 @@ export interface RecordedModelCall {
 	/** Provider order selected for the composeState call that fed this model input. */
 	providerOrder?: string[];
 	/**
-	 * Hash-first provider contributions with spans into `prompt`. Text is not
-	 * duplicated here; consumers can slice the recorded prompt to verify exact
-	 * provenance when spans are present.
+	 * Hash-first provider contributions. No provider text is duplicated: when
+	 * `spanStart`/`spanEnd` are present they index into the flattened form of the
+	 * persisted `messages` (`flattenTrajectoryMessages(messages)`), derived once
+	 * at read time — consumers slice that to verify exact provenance rather than a
+	 * second stored copy of the prompt.
 	 */
 	providerAttributions?: TrajectoryProviderAttribution[];
 }

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -6972,10 +6972,12 @@ async function recordMessageHandlerStage(args: {
 				? undefined
 				: extractMessageHandlerUsage(args.raw);
 		const modelName = extractMessageHandlerModelName(args.raw);
-		const prompt = flattenTrajectoryMessages(args.messages);
+		// Flatten `messages` only to locate provider spans; the flattened form is
+		// not persisted — `messages` is the canonical record and spans index into
+		// `flattenTrajectoryMessages(messages)` reconstructed at read time.
 		const providerAttribution = buildProviderAttributionsFromState({
 			state: args.state,
-			prompt,
+			prompt: flattenTrajectoryMessages(args.messages),
 		});
 		await args.recorder.recordStage(args.trajectoryId, {
 			stageId: `stage-msghandler-${args.startedAt}`,
@@ -6987,7 +6989,6 @@ async function recordMessageHandlerStage(args: {
 				modelType: String(ModelType.RESPONSE_HANDLER),
 				modelName,
 				provider: resolveRecordedStageProvider(args.raw, args.provider),
-				prompt,
 				messages: args.messages,
 				tools: args.tools,
 				toolChoice: args.toolChoice,

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -151,6 +151,10 @@ import { actionHasSubActions, runSubPlanner } from "../runtime/sub-planner";
 import { buildCanonicalSystemPrompt } from "../runtime/system-prompt";
 import { resolveTraceCorrelationFromEnv } from "../runtime/trace-correlation";
 import {
+	buildProviderAttributionsFromState,
+	flattenTrajectoryMessages,
+} from "../runtime/trajectory-provider-attribution";
+import {
 	createJsonFileTrajectoryRecorder,
 	finalizeTrajectoryRecording,
 	isTrajectoryRecordingEnabled,
@@ -6222,6 +6226,7 @@ export async function runV5MessageRuntimeStage1(args: {
 				segmentHashes: stage1PrefixHashes.map((entry) => entry.segmentHash),
 				prefixHash: stage1PrefixHash,
 				provider: messageHandlerProvider,
+				state: args.state,
 				logger: args.runtime.logger,
 			});
 		}
@@ -6760,6 +6765,7 @@ export async function runV5MessageRuntimeStage1(args: {
 				evaluatorEffects,
 				recorder,
 				trajectoryId,
+				providerAttributionState: plannerState,
 				executeToolCall: (toolCall, ctx) =>
 					executeV5PlannedToolCall({
 						runtime: args.runtime,
@@ -6956,6 +6962,7 @@ async function recordMessageHandlerStage(args: {
 	 * the real provider instead of the fabricated `"default"` literal (#13623).
 	 */
 	provider?: string;
+	state?: State;
 	logger?: IAgentRuntime["logger"];
 }): Promise<void> {
 	try {
@@ -6965,6 +6972,11 @@ async function recordMessageHandlerStage(args: {
 				? undefined
 				: extractMessageHandlerUsage(args.raw);
 		const modelName = extractMessageHandlerModelName(args.raw);
+		const prompt = flattenTrajectoryMessages(args.messages);
+		const providerAttribution = buildProviderAttributionsFromState({
+			state: args.state,
+			prompt,
+		});
 		await args.recorder.recordStage(args.trajectoryId, {
 			stageId: `stage-msghandler-${args.startedAt}`,
 			kind: "messageHandler",
@@ -6975,6 +6987,7 @@ async function recordMessageHandlerStage(args: {
 				modelType: String(ModelType.RESPONSE_HANDLER),
 				modelName,
 				provider: resolveRecordedStageProvider(args.raw, args.provider),
+				prompt,
 				messages: args.messages,
 				tools: args.tools,
 				toolChoice: args.toolChoice,
@@ -6983,6 +6996,8 @@ async function recordMessageHandlerStage(args: {
 				toolCalls: extractMessageHandlerToolCalls(args.raw),
 				usage,
 				finishReason: getStage1FinishReason(args.raw) || undefined,
+				providerOrder: providerAttribution.providerOrder,
+				providerAttributions: providerAttribution.providerAttributions,
 			},
 			cache: args.prefixHash
 				? {

--- a/packages/core/src/services/trajectory-types.ts
+++ b/packages/core/src/services/trajectory-types.ts
@@ -4,6 +4,8 @@
  * usage-totals, and cache-stats shapes; and the eliza-native export row and
  * format tag that the export helpers and training pipelines consume.
  */
+
+import type { TrajectoryProviderAttribution } from "../runtime/trajectory-provider-attribution";
 import type { JsonValue } from "../types/primitives.ts";
 
 // Re-export the canonical retrieval-funnel shapes from `trajectory-recorder`
@@ -125,6 +127,8 @@ export interface TrajectoryLlmCallRecord {
 	executionTraceId?: string;
 	createdAt?: string;
 	tokenUsageEstimated?: boolean;
+	providerOrder?: string[];
+	providerAttributions?: TrajectoryProviderAttribution[];
 }
 
 export interface TrajectoryProviderAccessRecord {
@@ -134,6 +138,11 @@ export interface TrajectoryProviderAccessRecord {
 	providerName?: string;
 	purpose?: string;
 	data?: Record<string, unknown>;
+	sha256?: string;
+	tokenCount?: number;
+	position?: number;
+	spanStart?: number;
+	spanEnd?: number;
 	query?: Record<string, unknown>;
 	timestamp?: number;
 	runId?: string;

--- a/packages/core/src/trajectory-context.ts
+++ b/packages/core/src/trajectory-context.ts
@@ -7,6 +7,7 @@
  */
 
 import { getAmbientSingleton, setAmbientSingleton } from "./ambient-context";
+import type { TrajectoryProviderAttribution } from "./runtime/trajectory-provider-attribution";
 import type { PseudonymSession } from "./security/pii-pseudonymizer";
 import type { SecretSwapSession } from "./security/secret-swap";
 import type { RoleGateRole } from "./types/contexts";
@@ -32,6 +33,13 @@ export interface TrajectoryContext {
 	userRole?: RoleGateRole;
 	/** Pipeline stage purpose for trajectory logging (e.g. "should_respond", "response", "action", "evaluation"). */
 	purpose?: string;
+	/**
+	 * Latest composed provider contribution snapshot for the active step. The
+	 * runtime stamps it onto the next model call so DB trajectories can
+	 * reconstruct provider order and prompt spans without storing provider text.
+	 */
+	providerOrder?: string[];
+	providerAttributions?: TrajectoryProviderAttribution[];
 	/**
 	 * Turn-scoped secret-swap session (#10469). Minted on the first `useModel`
 	 * call of a turn when secret-swap is enabled, then reused by every subsequent

--- a/packages/core/src/trajectory-utils.ts
+++ b/packages/core/src/trajectory-utils.ts
@@ -27,6 +27,7 @@ import {
 	type JsonValue,
 	type Trajectory,
 } from "./features/trajectories/types";
+import type { TrajectoryProviderAttribution } from "./runtime/trajectory-provider-attribution";
 import type { TrajectorySkillInvocationRecord } from "./services/trajectory-types";
 import {
 	getTrajectoryContext,
@@ -92,12 +93,19 @@ export type TrajectoryLlmCallDetails = {
 	completionTokens?: number;
 	cacheReadInputTokens?: number;
 	cacheCreationInputTokens?: number;
+	providerOrder?: string[];
+	providerAttributions?: TrajectoryProviderAttribution[];
 };
 
 export type TrajectoryProviderAccessParams = {
 	stepId: string;
 	providerName: string;
 	data: Record<string, string | number | boolean | null>;
+	sha256?: string;
+	tokenCount?: number;
+	position?: number;
+	spanStart?: number;
+	spanEnd?: number;
 	purpose: string;
 	query?: Record<string, string | number | boolean | null>;
 	runId?: string;
@@ -117,6 +125,8 @@ export type TrajectoryRuntimeLlmCallParams = {
 	roomId?: string;
 	messageId?: string;
 	executionTraceId?: string;
+	providerOrder?: string[];
+	providerAttributions?: TrajectoryProviderAttribution[];
 } & TrajectoryLlmCallDetails;
 
 export type TrajectoryRuntimeLlmCallLogger = {

--- a/packages/scripts/trajectory.ts
+++ b/packages/scripts/trajectory.ts
@@ -23,6 +23,7 @@
  *   validate   - Structural validation for complete, reviewable trajectories.
  *   compare    - Cache/batching/cost deltas between two trajectories.
  *   aggregate  - Cross-trajectory rollup.
+ *   providers  - Per-provider token/cost attribution for model calls.
  */
 
 import type { Dirent } from "node:fs";
@@ -79,6 +80,17 @@ interface ModelCallRecord {
   usage?: UsageBreakdown;
   finishReason?: string;
   costUsd?: number;
+  providerOrder?: string[];
+  providerAttributions?: ProviderAttributionRecord[];
+}
+
+interface ProviderAttributionRecord {
+  providerName: string;
+  sha256: string;
+  tokenCount: number;
+  position: number;
+  spanStart?: number;
+  spanEnd?: number;
 }
 
 interface ToolStageRecord {
@@ -1087,6 +1099,91 @@ async function cmdAggregate(opts: AggregateOptions): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// Subcommand: providers
+// ---------------------------------------------------------------------------
+
+interface ProviderRollupRow {
+  providerName: string;
+  calls: number;
+  tokens: number;
+  costUsd: number;
+  spans: number;
+  sha256: string;
+}
+
+function providerRows(trajectory: RecordedTrajectory): ProviderRollupRow[] {
+  const rows = new Map<string, ProviderRollupRow>();
+  for (const stage of trajectory.stages) {
+    const model = stage.model;
+    const attributions = model?.providerAttributions ?? [];
+    if (!model || attributions.length === 0) continue;
+    const totalProviderTokens = attributions.reduce(
+      (total, entry) => total + Math.max(0, entry.tokenCount || 0),
+      0,
+    );
+    for (const entry of attributions) {
+      const current = rows.get(entry.providerName) ?? {
+        providerName: entry.providerName,
+        calls: 0,
+        tokens: 0,
+        costUsd: 0,
+        spans: 0,
+        sha256: entry.sha256,
+      };
+      current.calls += 1;
+      current.tokens += Math.max(0, entry.tokenCount || 0);
+      if (
+        typeof model.costUsd === "number" &&
+        Number.isFinite(model.costUsd) &&
+        totalProviderTokens > 0
+      ) {
+        current.costUsd +=
+          model.costUsd *
+          (Math.max(0, entry.tokenCount || 0) / totalProviderTokens);
+      }
+      if (
+        typeof entry.spanStart === "number" &&
+        typeof entry.spanEnd === "number"
+      ) {
+        current.spans += 1;
+      }
+      rows.set(entry.providerName, current);
+    }
+  }
+  return [...rows.values()].sort(
+    (left, right) =>
+      right.tokens - left.tokens ||
+      left.providerName.localeCompare(right.providerName),
+  );
+}
+
+async function cmdProviders(id: string): Promise<void> {
+  const loaded = await loadTrajectory(id);
+  if (!loaded) throw new Error(`Trajectory not found: ${id}`);
+  const rows = providerRows(loaded.trajectory);
+  if (rows.length === 0) {
+    console.log(c.dim("No provider attribution records found."));
+    return;
+  }
+  const widths = {
+    provider: Math.max(8, ...rows.map((row) => row.providerName.length)),
+    calls: 5,
+    tokens: Math.max(6, ...rows.map((row) => String(row.tokens).length)),
+    cost: 10,
+    spans: 5,
+    sha: 12,
+  };
+  const header = `${"provider".padEnd(widths.provider)}  ${"calls".padEnd(widths.calls)}  ${"tokens".padEnd(widths.tokens)}  ${"cost".padEnd(widths.cost)}  ${"spans".padEnd(widths.spans)}  sha256`;
+  console.log(c.bold(header));
+  console.log(c.dim("-".repeat(header.length)));
+  for (const row of rows) {
+    console.log(
+      `${row.providerName.padEnd(widths.provider)}  ${String(row.calls).padEnd(widths.calls)}  ${String(row.tokens).padEnd(widths.tokens)}  ${formatUsd(row.costUsd).padEnd(widths.cost)}  ${String(row.spans).padEnd(widths.spans)}  ${row.sha256.slice(0, widths.sha)}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Argv parsing (lightweight; no dependency)
 // ---------------------------------------------------------------------------
 
@@ -1178,6 +1275,7 @@ Commands:
   export <id> --format markdown|html|json [--out <path>]
   validate <id-or-path> [--expected-stages a,b] [--expected-contexts x,y] [--strict-messages] [--json]
   compare <idA> <idB> [--json]
+  providers <id>
   aggregate [--since <iso>] [--agent <id>]
 
 Trajectories are read from \${ELIZA_TRAJECTORY_DIR} (default ./trajectories/).`);
@@ -1281,6 +1379,12 @@ async function main(): Promise<void> {
         idB,
         flags.has("json") && flags.get("json") !== "false",
       );
+      return;
+    }
+    case "providers": {
+      const id = positional[0];
+      if (!id) throw new Error("`providers` requires a trajectory id");
+      await cmdProviders(id);
       return;
     }
     case "aggregate": {


### PR DESCRIPTION
## Summary

Refs #14877.

- Adds hash-first provider attribution for trajectory model calls: `providerOrder` plus per-provider `{ providerName, sha256, tokenCount, position, spanStart, spanEnd }`.
- Stamps attribution into JSON-file Stage 1/planner records and DB trajectory LLM-call rows; provider-access records now carry hash/token/order fields too.
- Adds `trajectory providers <id>` to print per-provider token/cost attribution from saved trajectory JSON.

## Validation

- `bun run --cwd packages/core prebuild && bun run --cwd packages/cloud/routing build`
- `bun x biome check ...` on touched files: pass with warning-only existing `packages/scripts/trajectory.ts` env-var cache warnings for `ELIZA_TRAJECTORY_DIR` and `NO_COLOR`.
- `bun run --cwd packages/core typecheck`
- `bun test packages/core/src/runtime/__tests__/trajectory-provider-attribution.test.ts packages/core/src/features/trajectories/TrajectoriesService.test.ts packages/core/src/runtime/__tests__/trajectory-recorder.test.ts` (57 pass)
- `ELIZA_TRAJECTORY_DIR=<fixture> bun packages/scripts/trajectory.ts providers tj-provider` printed the expected proportional provider token/cost table.
- `git diff --check`
- `bun run audit:error-policy-ratchet`

## Evidence

<!-- evidence-row:before-screenshots -->
N/A - runtime/CLI trajectory record-shape change; no UI surface changed.

<!-- evidence-row:after-screenshots -->
N/A - runtime/CLI trajectory record-shape change; no UI surface changed.

<!-- evidence-row:walkthrough-video -->
N/A - runtime/CLI trajectory record-shape change; no UI walkthrough surface exists.

<!-- evidence-row:backend-logs -->
N/A - no server process was run; validation used focused runtime/service tests and the offline trajectory CLI.

<!-- evidence-row:frontend-logs -->
N/A - no frontend code or browser surface changed.

<!-- evidence-row:llm-trajectory -->
N/A - live model trajectory pending credentials; this shell has `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GROQ_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, `OPENROUTER_API_KEY`, and `CEREBRAS_API_KEY` unset.

<!-- evidence-row:domain-artifacts -->
N/A - no persistent external domain artifact was produced; the local trajectory fixture was created under `mktemp` only to verify `trajectory providers` output.