### PR TITLE
fix(cloud): stop wallet auto-pop on sign-in + shared-session recovery + console loading repair

### DIFF
--- a/packages/ui/src/cloud/lib/auth-query.ts
+++ b/packages/ui/src/cloud/lib/auth-query.ts
@@ -21,7 +21,11 @@ export function useAuthenticatedQueryGate(
 ): AuthenticatedQueryGate {
   const session = useSessionAuth();
   return {
-    enabled: enabled && session.ready && session.authenticated,
+    // Gate on `authenticated` (a valid, expiry-checked stored token exists and
+    // api-client injects it as the Bearer) rather than also on `ready` — the
+    // latter waits for the @stwd SDK's slow session resolution, which left the
+    // agents list spinning for seconds after the token was already usable.
+    enabled: enabled && session.authenticated,
     userId: session.user?.id ?? null,
   };
 }

--- a/packages/ui/src/cloud/shell/StewardProvider.tsx
+++ b/packages/ui/src/cloud/shell/StewardProvider.tsx
@@ -90,9 +90,12 @@ function StewardRuntimeLoading() {
       aria-live="polite"
       role="status"
       style={{
+        // Pre-theme fallback (renders before the theme tree mounts, so it uses
+        // literals not vars): black to match the console, not the old beige that
+        // flashed light-on-black and read as a broken load.
         alignItems: "center",
-        background: "#f8f4ef",
-        color: "#2f261f",
+        background: "#000",
+        color: "rgba(255,255,255,0.55)",
         display: "flex",
         justifyContent: "center",
         minHeight: "100vh",

--- a/packages/ui/src/state/cloud-siwe-login.test.ts
+++ b/packages/ui/src/state/cloud-siwe-login.test.ts
@@ -198,6 +198,23 @@ describe("e2e wallet + SIWE login", () => {
     expect((window as { ethereum?: unknown }).ethereum).toBe(sentinel);
   });
 
+  it("ignores Phantom's window.ethereum injection (never SIWE with Phantom)", () => {
+    // Phantom multichain-injects window.ethereum with isPhantom:true; treating
+    // it as an EVM SIWE provider pops Phantom on a non-wallet sign-in (the
+    // "picked Google, got Phantom" bug). It must read as no injected provider.
+    (window as { ethereum?: unknown }).ethereum = {
+      isPhantom: true,
+      request: async () => [],
+    };
+    expect(getInjectedEthereumProvider()).toBeNull();
+  });
+
+  it("returns a genuine (non-Phantom) injected EVM provider", () => {
+    const metamask = { isMetaMask: true, request: async () => [] };
+    (window as { ethereum?: unknown }).ethereum = metamask;
+    expect(getInjectedEthereumProvider()).toBe(metamask);
+  });
+
   it("completes the full SIWE handshake with a REAL recoverable signature and stores the session", async () => {
     window.localStorage.setItem(E2E_WALLET_KEY_STORAGE_KEY, PRIVATE_KEY);
     await installE2eWalletIfRequested();

--- a/packages/ui/src/state/cloud-siwe-login.ts
+++ b/packages/ui/src/state/cloud-siwe-login.ts
@@ -31,6 +31,8 @@ export interface InjectedEthereumProvider {
   }): Promise<unknown>;
   /** Set by the e2e test wallet so harness-only behavior can identify it. */
   isElizaE2eWallet?: boolean;
+  /** Phantom multichain-injects itself as window.ethereum; never SIWE with it. */
+  isPhantom?: boolean;
 }
 
 export function getInjectedEthereumProvider(): InjectedEthereumProvider | null {
@@ -41,6 +43,10 @@ export function getInjectedEthereumProvider(): InjectedEthereumProvider | null {
     typeof provider === "object" &&
     typeof (provider as InjectedEthereumProvider).request === "function"
   ) {
+    // Phantom injects window.ethereum (isPhantom:true) but is a Solana wallet;
+    // treating it as an EVM SIWE provider pops Phantom on a non-wallet sign-in.
+    // Mirrors the /login wallet-buttons guard (wallet-buttons.tsx).
+    if ((provider as InjectedEthereumProvider).isPhantom === true) return null;
     return provider as InjectedEthereumProvider;
   }
   return null;

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -8,6 +8,7 @@
 import { logger } from "@elizaos/logger";
 import {
   clearStoredStewardToken,
+  hasStewardAuthedCookie,
   readStoredStewardToken,
   writeStoredStewardToken,
 } from "@elizaos/shared/steward-session-client";
@@ -339,7 +340,40 @@ function resolveRestoreStewardRefreshEndpoint(): string | undefined {
  */
 async function resolveRestoredStewardToken(): Promise<string | null> {
   const stored = readStoredStewardToken()?.trim();
-  if (!stored) return null;
+  if (!stored) {
+    // No app-origin token, but the shared, HttpOnly .elizacloud.ai session
+    // cookie is present — the user signed in on the console (or another
+    // *.elizacloud.ai tab). Recover the access token from it (bounded, same as
+    // the /login page) instead of forcing a redundant re-sign-in; on success
+    // the top-level LoginView gate and the first-run conductor both skip.
+    if (typeof window !== "undefined" && hasStewardAuthedCookie()) {
+      let cookieTimeout: ReturnType<typeof setTimeout> | undefined;
+      const recovered = await Promise.race([
+        // error-policy:J4 a failed cookie refresh falls through to
+        // unauthenticated restore (sign-in wall), never fabricates a session.
+        refreshCloudStewardSession({
+          endpoint: resolveRestoreStewardRefreshEndpoint(),
+        }).catch(() => null),
+        new Promise<null>((resolve) => {
+          cookieTimeout = setTimeout(
+            () => resolve(null),
+            STEWARD_RESTORE_REFRESH_TIMEOUT_MS,
+          );
+        }),
+      ]);
+      if (cookieTimeout) clearTimeout(cookieTimeout);
+      if (recovered?.token) {
+        writeStoredStewardToken(recovered.token);
+        try {
+          window.dispatchEvent(new CustomEvent("steward-token-sync"));
+        } catch {
+          // error-policy:J6 best-effort nudge — listeners re-read next tick.
+        }
+        return recovered.token;
+      }
+    }
+    return null;
+  }
   const secs = cloudTokenSecsRemaining(stored);
   // Opaque/device-code token (no decodable `exp`) → nothing to refresh.
   if (secs === null) return stored;

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -494,14 +494,19 @@ export function useCloudState({
       };
       elizaCloudLoginCompletionRef.current = loginCompletion;
 
-      // Wallet SIWE (#13377): an injected EIP-1193 provider (a real browser
-      // wallet, or the e2e harness wallet on devices) signs in with a genuine
-      // EIP-4361 handshake against the cloud API — no browser round trip, no
-      // human beyond the wallet's own approval. Taken only when a provider is
-      // actually injected AND no still-usable session exists; a rejection or
-      // handshake failure falls through to the other sign-in paths on the
-      // same click.
-      if (!hasUsableStoredStewardToken() && getInjectedEthereumProvider()) {
+      // Zero-interaction wallet SIWE (#13377) is the E2E HARNESS path ONLY.
+      // A real browser wallet (Phantom, MetaMask, …) injects window.ethereum
+      // too, so taking this branch for any injected provider auto-pops the
+      // user's wallet the instant they click "Sign in with Eliza Cloud" —
+      // even when they meant to pick Google — and leaves the pre-opened
+      // popup blank (the "white page"). Real wallet sign-in is an EXPLICIT
+      // choice behind the /login page's EVM/Solana buttons; only the harness
+      // wallet (isElizaE2eWallet, packages/ui/src/platform/e2e-wallet.ts, which
+      // by its own gates never installs on deployed web) may sign in headlessly.
+      if (
+        !hasUsableStoredStewardToken() &&
+        getInjectedEthereumProvider()?.isElizaE2eWallet === true
+      ) {
         const siweBase =
           getBootConfig().cloudApiBase ?? "https://elizacloud.ai";
         try {

--- a/packages/ui/src/styles/base.css
+++ b/packages/ui/src/styles/base.css
@@ -524,7 +524,10 @@ body.pwa-standalone * {
 
 .theme-cloud {
   --bg: var(--brand-black);
-  --bg-accent: rgba(255, 255, 255, 0.04);
+  /* Skeleton blocks (`animate-pulse bg-bg-accent`) were near-invisible on the
+     black console at 0.04 — the pulse read as "broken/frozen". 0.08 makes the
+     loading state legibly animate. */
+  --bg-accent: rgba(255, 255, 255, 0.08);
   --bg-elevated: rgba(255, 255, 255, 0.04);
   --bg-hover: rgba(255, 255, 255, 0.08);
   --bg-muted: rgba(255, 255, 255, 0.06);


### PR DESCRIPTION
## Three demo-blocking cloud/app bugs nubs hit (root-caused + fixed)

### 1. Phantom pops on ANY sign-in (even Google) + blank popup 🔴
`handleCloudLogin`'s auto-SIWE branch (`useCloudState.ts:504`) treated *any* injected `window.ethereum` as wallet intent. Phantom multichain-injects `window.ethereum` (`isPhantom:true`), so it popped on a Google-intent click, and the pre-opened popup sat blank (the white page). **Fix:** gate the zero-interaction SIWE to the e2e harness wallet only (`isElizaE2eWallet`); real wallet sign-in stays behind the explicit /login EVM/Solana buttons. Defense-in-depth: `getInjectedEthereumProvider()` now ignores `isPhantom`. Regression test added.

### 2. "Sign in again" across elizacloud.ai → app.elizacloud.ai 🟡
The cookie SSO already works (`.elizacloud.ai`-scoped), but the boot gate `resolveRestoredStewardToken()` only checked the stored token, never the cookie. **Fix:** recover the token via a bounded cookie refresh (same pattern as the /login page) before forcing a re-sign-in.

### 3. Agents list slow + broken-looking loader 🟡
- Gate authenticated queries on a valid stored token instead of the slow `@stwd` session resolution (`auth-query.ts`).
- Make the console skeleton visible (`--bg-accent` 0.04 → 0.08).
- Replace the beige loading flash with a black theme-consistent state (`StewardProvider.tsx`).

## Verification
- packages/ui typecheck clean (touched files)
- `cloud-siwe-login.test.ts` 13/13 pass incl. new Phantom-guard cases
- Rendered staging E2E to follow on this PR

cc @lalalune — demo-day cloud fixes.