### PR TITLE
fix(ui): anchor notifications hint to the home top edge, blur-free

### DIFF
--- a/packages/ui/src/components/shell/HomeScreen.test.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.test.tsx
@@ -137,6 +137,47 @@ describe("HomeScreen", () => {
     expect(screen.queryByTestId("notifications-shade")).toBeNull();
   });
 
+  // DEVICE FEEDBACK (adjusting #15039's placement): the hint used to render as
+  // the FIRST flow item inside the scroll column, ABOVE the clock — on device
+  // it floated in the upper-middle mid-air like a misplaced iOS lock-screen
+  // element. It now hugs the TOP EDGE of the home surface (the iOS
+  // notification-center idiom: you pull from the edge, the affordance lives at
+  // the edge), anchored under the status-bar safe area and OUT of the flow
+  // column so it never pushes the clock down.
+  it("anchors the notifications hint at the top edge, not in the flow column above the clock", () => {
+    __ingestNotificationForTests(makeNotification());
+    render(<HomeScreen onOpenTile={vi.fn()} />);
+    const hint = screen.getByTestId("home-notifications-hint");
+    // The pill's positioning wrapper (its grandparent: pill -> pointer-events
+    // re-enable div -> absolute top-edge wrapper) must be an absolute, top-edge
+    // anchored element keyed to the safe-area top inset.
+    const inner = hint.parentElement;
+    const wrapper = inner?.parentElement;
+    const cls = wrapper?.className ?? "";
+    expect(cls).toContain("absolute");
+    expect(cls).toContain("--safe-area-top");
+
+    // It must NOT sit inside the flow column that starts with the clock/widgets.
+    // The clock base (home-time / DefaultHomeWidgets) lives in the max-w-2xl
+    // flex column; the hint wrapper is a sibling of that column, not an
+    // ancestor-descendant of it.
+    const column = wrapper?.parentElement?.querySelector(".max-w-2xl");
+    expect(column).not.toBeNull();
+    expect(column?.contains(hint)).toBe(false);
+  });
+
+  // Blur budget (#9141 / #14943): the home spends its ONE backdrop-filter on the
+  // pinned notification center / shade. The top-edge hint is a quiet whisper and
+  // must stay blur-free (a soft float shadow carries legibility instead), so it
+  // adds no new compositing surface over the wallpaper.
+  it("renders the notifications hint blur-free (no backdrop-filter on the pill)", () => {
+    __ingestNotificationForTests(makeNotification());
+    render(<HomeScreen onOpenTile={vi.fn()} />);
+    const hint = screen.getByTestId("home-notifications-hint");
+    expect(hint.className).not.toMatch(/backdrop-blur|backdrop-filter/);
+    expect(hint.className).not.toContain("supports-[backdrop-filter]");
+  });
+
   // GESTURE-HINT OVERLAP FIX (#14945 follow-up): the one-time gesture hint
   // ("Swipe for apps. Pull chat up. Hold wallpaper to restyle.") sat as the last
   // flow item in the scroll column, flush against the top of the reserved

--- a/packages/ui/src/components/shell/HomeScreen.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.tsx
@@ -53,12 +53,22 @@ const HOME_ENTER_CSS = `
 const NOTIF_PULL_THRESHOLD_PX = 24;
 
 /**
- * The top hint the notification shade drops from: a quiet pill ("N
- * notifications") that self-hides when the inbox is empty. Tap or a downward
- * pull ≥ {@link NOTIF_PULL_THRESHOLD_PX} opens the shade — the pull is tracked
- * with pointer capture on the pill itself so the home scroller never fights it.
- * The chevron points DOWN: notifications come from above, the inverse of the
- * chat sheet that rises from the bottom.
+ * The top-edge affordance the notification shade drops from: a quiet pill
+ * that hugs the very top of the home surface (directly under the status-bar
+ * safe-area inset), NOT a chip floating mid-content above the clock. This is
+ * the iOS notification-center idiom (you pull from the top edge), so the hint
+ * lives at the edge and the clock stays the visual hero. It self-hides when the
+ * inbox is empty. Tap or a downward pull ≥ {@link NOTIF_PULL_THRESHOLD_PX}
+ * opens the shade; the pull is tracked with pointer capture on the pill itself
+ * (desktop/mouse), while a region-wide top-strip touch pull (bound on the
+ * scroller) covers real-touch so the pill can stay small. The chevron points
+ * DOWN: notifications come from above, the inverse of the chat sheet that rises
+ * from the bottom.
+ *
+ * Styling is deliberately blur-free: the home compositing-blur budget is spent
+ * on the pinned notification center / shade, and a top-edge whisper doesn't
+ * earn its own compositing surface. A soft float shadow keeps the label legible
+ * over bright or busy wallpapers without a hard glass chip.
  */
 function NotificationsPullDownHint({
   onOpen,
@@ -71,65 +81,68 @@ function NotificationsPullDownHint({
   if (notifications.length === 0) return null;
   const count = notifications.length;
   return (
-    <div className="flex justify-center pb-1">
-      <button
-        type="button"
-        data-testid="home-notifications-hint"
-        aria-label={
-          unreadCount > 0
-            ? `Open notifications, ${unreadCount} unread`
-            : "Open notifications"
+    <button
+      type="button"
+      data-testid="home-notifications-hint"
+      aria-label={
+        unreadCount > 0
+          ? `Open notifications, ${unreadCount} unread`
+          : "Open notifications"
+      }
+      onClick={() => {
+        // A completed pull already opened the shade; don't double-fire on
+        // the click the same gesture synthesizes.
+        if (pulled.current) {
+          pulled.current = false;
+          return;
         }
-        onClick={() => {
-          // A completed pull already opened the shade; don't double-fire on
-          // the click the same gesture synthesizes.
-          if (pulled.current) {
-            pulled.current = false;
-            return;
-          }
+        onOpen();
+      }}
+      onPointerDown={(e) => {
+        startY.current = e.clientY;
+        pulled.current = false;
+        e.currentTarget.setPointerCapture?.(e.pointerId);
+      }}
+      onPointerMove={(e) => {
+        if (startY.current === null || pulled.current) return;
+        if (e.clientY - startY.current >= NOTIF_PULL_THRESHOLD_PX) {
+          pulled.current = true;
+          void haptics.light();
           onOpen();
-        }}
-        onPointerDown={(e) => {
-          startY.current = e.clientY;
-          pulled.current = false;
-          e.currentTarget.setPointerCapture?.(e.pointerId);
-        }}
-        onPointerMove={(e) => {
-          if (startY.current === null || pulled.current) return;
-          if (e.clientY - startY.current >= NOTIF_PULL_THRESHOLD_PX) {
-            pulled.current = true;
-            void haptics.light();
-            onOpen();
-          }
-        }}
-        onPointerUp={() => {
-          startY.current = null;
-        }}
-        onPointerCancel={() => {
-          startY.current = null;
-          pulled.current = false;
-        }}
-        className={cn(
-          "flex min-h-touch touch-none items-center gap-1.5 rounded-full px-3.5 py-1.5",
-          "bg-black/28 text-white/85 backdrop-blur-md supports-[backdrop-filter]:bg-black/22",
-          "border border-white/30 transition-colors hover:bg-black/40 active:scale-[0.97] motion-reduce:active:scale-100",
-        )}
-      >
-        <ChevronDown className="h-3.5 w-3.5 text-white/70" aria-hidden />
-        <Bell className="h-3.5 w-3.5" aria-hidden />
-        <span className="text-xs font-medium tabular-nums">
-          {count === 1 ? "1 notification" : `${count} notifications`}
+        }
+      }}
+      onPointerUp={() => {
+        startY.current = null;
+      }}
+      onPointerCancel={() => {
+        startY.current = null;
+        pulled.current = false;
+      }}
+      className={cn(
+        // A minimum 44px (min-h-touch) hit area kept small and quiet. touch-none
+        // so the pill's own pointer-capture pull never fights the scroller's
+        // touch-pan-y. Blur-free: a faint dark wash + a soft float shadow reads
+        // over any wallpaper without another compositing surface.
+        "flex min-h-touch touch-none items-center gap-1.5 rounded-full px-3 py-1",
+        "bg-black/20 text-white/80 transition-colors hover:bg-black/30",
+        "active:scale-[0.97] motion-reduce:active:scale-100",
+        WALLPAPER_FLOAT_SHADOW,
+      )}
+    >
+      <ChevronDown className="h-3 w-3 text-white/60" aria-hidden />
+      <Bell className="h-3 w-3" aria-hidden />
+      <span className="text-2xs font-medium tabular-nums">
+        {count === 1 ? "1 notification" : `${count} notifications`}
+      </span>
+      {unreadCount > 0 ? (
+        <span
+          data-testid="home-notifications-hint-unread"
+          className="rounded-full bg-white/20 px-1.5 text-2xs font-semibold tabular-nums leading-[1.05rem] text-white"
+        >
+          {unreadCount > 99 ? "99+" : unreadCount}
         </span>
-        {unreadCount > 0 ? (
-          <span
-            data-testid="home-notifications-hint-unread"
-            className="rounded-full bg-white/20 px-1.5 text-2xs font-semibold tabular-nums leading-[1.1rem] text-white"
-          >
-            {unreadCount > 99 ? "99+" : unreadCount}
-          </span>
-        ) : null}
-      </button>
-    </div>
+      ) : null}
+    </button>
   );
 }
 
@@ -384,15 +397,36 @@ export function HomeScreen({
           empty widget set reads as calm airiness rather than a broken gap; the
           AOSP tiles settle at the BOTTOM; the notifications hint anchors the
           TOP (the shade drops from above). */}
-        <div className="mx-auto flex min-h-full w-full max-w-2xl flex-col">
-          {/* Notifications drop from the top: the hint pill anchors the top of
-            the column, self-hides when the inbox is empty, and opens the shade
-            on tap or a downward pull. The shade is a portal overlay, so opening
-            it never reflows this dashboard. */}
-          <div className={enterClass} style={{ animationDelay: "60ms" }}>
+        {/* Notifications drop from the TOP EDGE: the hint pill is anchored to
+          the very top of the home surface (centered, under the status-bar
+          safe-area inset), NOT a chip floating mid-content above the clock.
+          This is the iOS notification-center idiom: the pull affordance hugs
+          the edge you pull from, so the clock stays the visual hero and the
+          pill never reads as a lock-screen element floating in mid-air. It's
+          absolutely positioned (outside the flow column) so it can't push the
+          clock down; the column's own top padding already clears it. The pill
+          self-hides when the inbox is empty; the shade is a portal overlay, so
+          opening it never reflows this dashboard. */}
+        <div
+          className={cn(
+            enterClass,
+            "pointer-events-none absolute inset-x-0 z-[3] flex justify-center",
+            // Sit directly under the status-bar safe area, hugging the true top
+            // edge. Mirrors the scroller's own top-padding math (the root shaves
+            // a capped band off the safe area) so the pill lands just inside the
+            // cleared notch, not over it.
+            "top-[calc(min(max(var(--safe-area-top,0px)-1.25rem,0px),1.25rem)+6px)]",
+          )}
+          style={{ animationDelay: "60ms" }}
+        >
+          {/* Re-enable pointer events on the pill only; the wrapper stays
+            transparent to taps so it never blocks the clock/widgets beneath. */}
+          <div className="pointer-events-auto">
             <NotificationsPullDownHint onOpen={openShade} />
           </div>
+        </div>
 
+        <div className="mx-auto flex min-h-full w-full max-w-2xl flex-col">
           {/* The always-on base: a naked sized grid with the time + weather as
             2×2 neighbours - no card, white text on the ambient field. Anchored
             at the top of the column as the editorial header. */}


### PR DESCRIPTION
## What

Device-review adjustment to the notifications pull-down hint from #15039 (lalalune's shade rework, merged). **This is product feedback on placement + styling, not a revert** — the pull-down shade mechanic itself is untouched and works well.

## Why

On device (build f42baade5a) the `NotificationsPullDownHint` pill ("N notifications" + chevron + bell) rendered as the **first flow item inside the home scroll column, above the clock**. Because the column vertically distributes its content, the pill floated in the **upper-middle** of the screen and read like a misplaced iOS lock-screen element hovering over the wallpaper mid-air. Verbatim feedback: "why tf is notifications up there, it shows up in the middle like iphone lock screen."

## The fix — anchor it to the top edge (iOS notification-center idiom)

You pull the notification center **from the top edge**, so the affordance should **hug that edge**, not float mid-content. Chosen approach (option a of the placement options considered):

- **Moved the hint out of the flow column** and anchored it **absolutely to the very top edge** of the home surface, centered, directly under the status-bar safe-area inset (`top` mirrors the scroller's own notch-clearance math). The clock stays the visual hero.
- **It cannot push the clock down** — it's absolutely positioned outside the `max-w-2xl` column; the wrapper is `pointer-events-none` (only the pill re-enables pointer events) so it never blocks the clock or widgets beneath.
- **Blur-free styling.** Dropped the pill's `backdrop-blur-md` + `supports-[backdrop-filter]` wash. The home compositing-blur budget (#9141 / #14943) is reserved for the pinned notification center / shade; a top-edge whisper doesn't earn its own compositing surface. A soft float shadow (`WALLPAPER_FLOAT_SHADOW`) carries legibility over bright/busy wallpapers instead. **No new backdrop-filter is added**, and `HomeScreen.tsx` drops off the `no-backdrop-blur-gate` offender list (verified: offender count for that file goes to zero; remaining gate offenders are pre-existing on `develop` and out of scope here).
- Quieter chrome (smaller icons/label, lighter dark wash). **44px touch target preserved** (`min-h-touch`), unread badge kept, empty-inbox self-hide kept.
- The **region-wide top-strip touch pull** already bound on the scroller still opens the shade, so the pill can stay small without shrinking the pull zone; the pill keeps its own `touch-none` pointer-capture pull for desktop/mouse.

## Visual proof

Before (in-flow, floats above the clock) vs after (quiet top-edge whisper, clock undisturbed):

![notif hint placement before/after](https://i.imgur.com/spSlrqZ.png)

## Tests

`HomeScreen` suite updated:
- new: hint is an **absolute top-edge element keyed to `--safe-area-top`**, and is **NOT inside the `max-w-2xl` clock column**
- new: pill renders **blur-free** (no `backdrop-blur` / `supports-[backdrop-filter]`)
- unchanged + green: empty-inbox self-hide, tap opens shade, downward-pull opens shade, chat-collapse on open, unread badge, deep-link close

```
Test Files  1 passed (1)
     Tests  13 passed (13)
```

Also ran the `HomeScreen.flicker` suite (green) and `no-backdrop-blur-gate` (confirmed `HomeScreen.tsx` no longer an offender).

## Notes

- Tokens + lucide only, no new backdrop-blur, 44px targets, no new deps.
- Did not touch backgrounds/canvas or the build-info chip (owned by another lane), only the safe-area-top-anchored hint.

— [sol-orch]
