### PR TITLE
fix(scheduling): render scheduled notification titles

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts
@@ -51,6 +51,7 @@ import {
   registerScheduledTaskRunnerDeps,
   renderFailureDispatchResult,
   renderScheduledDispatchMessage,
+  renderScheduledDispatchTitle,
   type ScheduledTaskRunnerDepsBundle,
   type ScheduledTaskRunnerHandle,
   type ScheduledTaskStore,
@@ -617,12 +618,17 @@ export function createProductionScheduledTaskDispatcher(opts: {
           });
           surfacesAccepted += 1;
         }
-        const isUrgent = record.intensity === "urgent";
         const notifier = getNotifier(opts.runtime);
         if (notifier) {
           try {
+            const title = await renderScheduledDispatchTitle(
+              opts.runtime,
+              record,
+              message,
+            );
+            const isUrgent = record.intensity === "urgent";
             await notifier.notify({
-              title: isUrgent ? "Approval needed" : "Reminder",
+              title,
               body: message,
               category: isUrgent ? "approval" : "reminder",
               priority: isUrgent ? "urgent" : "normal",
@@ -637,6 +643,13 @@ export function createProductionScheduledTaskDispatcher(opts: {
             });
             surfacesAccepted += 1;
           } catch (error) {
+            // error-policy:J4 explicit user-facing degrade — the assistant
+            // stream may still have accepted the same owner-facing message.
+            opts.runtime.reportError(
+              "lifeops:scheduled-task:notification-render",
+              error,
+              { taskId: record.taskId, channelKey: record.channelKey },
+            );
             logger.warn(
               { src: "lifeops:scheduled-task", error },
               "Notification emit failed",

--- a/plugins/plugin-personal-assistant/test/scheduled-task-dispatch-render.test.ts
+++ b/plugins/plugin-personal-assistant/test/scheduled-task-dispatch-render.test.ts
@@ -7,7 +7,10 @@
  * Deterministic: the model is stubbed at the runtime boundary (`useModel`).
  */
 import type { IAgentRuntime } from "@elizaos/core";
-import { buildScheduledDispatchRenderPrompt } from "@elizaos/plugin-scheduling";
+import {
+  buildScheduledDispatchRenderPrompt,
+  buildScheduledDispatchTitlePrompt,
+} from "@elizaos/plugin-scheduling";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { ChannelContribution } from "../src/lifeops/channels/contract.js";
 import {
@@ -26,6 +29,7 @@ import {
 const INSTRUCTION =
   "Remind the owner to take their medication and ask how they slept.";
 const RENDERED = "Time for your medication — and how did you sleep last night?";
+const RENDERED_TITLE = "Medication and sleep check";
 
 interface ReportedErrorCapture {
   scope: string;
@@ -101,11 +105,12 @@ beforeEach(() => {
 });
 
 describe("scheduled dispatch renders promptInstructions through the model", () => {
-  it("delivers the model output — never the raw instruction — to the assistant stream and notification body", async () => {
+  it("delivers model output — never raw or generic copy — to the assistant stream and notification", async () => {
     enableAgentEventServiceStub();
     const notified: Record<string, unknown>[] = [];
     const { runtime, modelPrompts } = makeRuntime({
-      model: () => RENDERED,
+      model: ({ prompt }) =>
+        prompt.includes("notification title") ? RENDERED_TITLE : RENDERED,
       notifier: {
         notify: async (input) => {
           notified.push(input);
@@ -119,8 +124,10 @@ describe("scheduled dispatch renders promptInstructions through the model", () =
 
     expect(result).toMatchObject({ ok: true });
     // The instruction fed the model as prompt payload...
-    expect(modelPrompts).toHaveLength(1);
+    expect(modelPrompts).toHaveLength(2);
     expect(modelPrompts[0]).toContain(INSTRUCTION);
+    expect(modelPrompts[1]).toContain(RENDERED);
+    expect(modelPrompts[1]).not.toContain(INSTRUCTION);
     // ...and only the model's rendering reached the user-visible surfaces.
     const events = getAgentEventServiceStubEvents();
     expect(events).toHaveLength(1);
@@ -129,6 +136,9 @@ describe("scheduled dispatch renders promptInstructions through the model", () =
       "Remind the owner to take",
     );
     expect(notified).toHaveLength(1);
+    expect(notified[0]?.title).toBe(RENDERED_TITLE);
+    expect(notified[0]?.title).not.toBe("Reminder");
+    expect(notified[0]?.title).not.toBe("Approval needed");
     expect(notified[0]?.body).toBe(RENDERED);
     expect(String(notified[0]?.body)).not.toContain("Remind the owner to take");
   });
@@ -153,7 +163,7 @@ describe("scheduled dispatch renders promptInstructions through the model", () =
       }),
     );
 
-    expect(result).toEqual({ ok: true, messageId: "m1" });
+    expect(result).toMatchObject({ ok: true, messageId: "m1" });
     expect(modelPrompts).toHaveLength(1);
     expect(sent).toHaveLength(1);
     expect(sent[0]?.message).toBe(RENDERED);
@@ -315,5 +325,20 @@ describe("buildScheduledDispatchRenderPrompt", () => {
       firedAtIso: "2026-07-05T09:00:00.000Z",
     });
     expect(soft).toContain("gentle");
+  });
+});
+
+describe("buildScheduledDispatchTitlePrompt", () => {
+  it("uses the rendered body, not the instruction payload, as notification title context", () => {
+    const prompt = buildScheduledDispatchTitlePrompt(
+      {
+        intensity: "normal",
+        firedAtIso: "2026-07-05T09:00:00.000Z",
+      },
+      RENDERED,
+    );
+    expect(prompt).toContain(RENDERED);
+    expect(prompt).toContain("under 8 words");
+    expect(prompt).not.toContain(INSTRUCTION);
   });
 });

--- a/plugins/plugin-scheduling/src/scheduled-task/dispatch-render.test.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/dispatch-render.test.ts
@@ -9,14 +9,17 @@ import type { IAgentRuntime } from "@elizaos/core";
 import { describe, expect, it } from "vitest";
 import {
   buildScheduledDispatchRenderPrompt,
+  buildScheduledDispatchTitlePrompt,
   RENDER_FAILURE_RETRY_MINUTES,
   renderScheduledDispatchMessage,
+  renderScheduledDispatchTitle,
 } from "./dispatch-render.js";
 import { ScheduledTaskRunnerService } from "./runner-service.js";
 
 const INSTRUCTION =
   "Remind the owner to take their medication and ask how they slept.";
 const RENDERED = "Time for your medication — and how did you sleep last night?";
+const RENDERED_TITLE = "Medication and sleep check";
 
 interface NotifyCapture {
   title?: string;
@@ -114,11 +117,52 @@ describe("renderScheduledDispatchMessage", () => {
   });
 });
 
+describe("renderScheduledDispatchTitle", () => {
+  it("returns a model-rendered title from the owner-facing body", async () => {
+    const { runtime, modelPrompts } = makeRuntime({
+      model: () => RENDERED_TITLE,
+    });
+    const title = await renderScheduledDispatchTitle(
+      runtime,
+      {
+        taskId: "st_title",
+        firedAtIso: "2026-07-05T09:00:00.000Z",
+        channelKey: "in_app",
+        promptInstructions: INSTRUCTION,
+        contextRequest: undefined,
+      },
+      RENDERED,
+    );
+
+    expect(title).toBe(RENDERED_TITLE);
+    expect(modelPrompts).toHaveLength(1);
+    expect(modelPrompts[0]).toContain(RENDERED);
+    expect(modelPrompts[0]).not.toContain(INSTRUCTION);
+  });
+
+  it("throws on blank title output", async () => {
+    await expect(
+      renderScheduledDispatchTitle(
+        makeRuntime({ model: () => "  \n" }).runtime,
+        {
+          taskId: "st_title_blank",
+          firedAtIso: "2026-07-05T09:00:00.000Z",
+          channelKey: "in_app",
+          promptInstructions: INSTRUCTION,
+          contextRequest: undefined,
+        },
+        RENDERED,
+      ),
+    ).rejects.toMatchObject({ code: "SCHEDULED_DISPATCH_TITLE_RENDER_EMPTY" });
+  });
+});
+
 describe("default scheduled-task dispatcher (no injected deps)", () => {
-  it("notifies with the model-rendered body, never the raw instruction", async () => {
+  it("notifies with model-rendered body and title, never raw or generic copy", async () => {
     const notified: NotifyCapture[] = [];
     const { runtime, modelPrompts } = makeRuntime({
-      model: () => RENDERED,
+      model: ({ prompt }) =>
+        prompt.includes("notification title") ? RENDERED_TITLE : RENDERED,
       notified,
     });
     const service = await ScheduledTaskRunnerService.start(runtime);
@@ -128,9 +172,13 @@ describe("default scheduled-task dispatcher (no injected deps)", () => {
     const fired = await runner.fire(task.taskId);
 
     expect(fired.state.status).toBe("fired");
-    expect(modelPrompts).toHaveLength(1);
+    expect(modelPrompts).toHaveLength(2);
     expect(modelPrompts[0]).toContain(INSTRUCTION);
+    expect(modelPrompts[1]).toContain(RENDERED);
     expect(notified).toHaveLength(1);
+    expect(notified[0]?.title).toBe(RENDERED_TITLE);
+    expect(notified[0]?.title).not.toBe("Reminder");
+    expect(notified[0]?.title).not.toBe("Approval needed");
     expect(notified[0]?.body).toBe(RENDERED);
     expect(notified[0]?.body).not.toContain("Remind the owner to take");
   });
@@ -183,5 +231,26 @@ describe("buildScheduledDispatchRenderPrompt", () => {
     expect(
       buildScheduledDispatchRenderPrompt({ ...base, intensity: "soft" }),
     ).toContain("gentle");
+  });
+});
+
+describe("buildScheduledDispatchTitlePrompt", () => {
+  it("uses the rendered body as title context and structural urgency framing", () => {
+    const normal = buildScheduledDispatchTitlePrompt(
+      {
+        intensity: "normal",
+        firedAtIso: "2026-07-05T09:00:00.000Z",
+      },
+      RENDERED,
+    );
+    expect(normal).toContain(RENDERED);
+    expect(normal).toContain("under 8 words");
+    expect(normal).not.toContain(INSTRUCTION);
+    expect(
+      buildScheduledDispatchTitlePrompt(
+        { intensity: "urgent", firedAtIso: "2026-07-05T09:00:00.000Z" },
+        RENDERED,
+      ),
+    ).toContain("urgent");
   });
 });

--- a/plugins/plugin-scheduling/src/scheduled-task/dispatch-render.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/dispatch-render.ts
@@ -4,11 +4,11 @@
  * take their medication and ask how they slept"), never user-facing copy —
  * hosts author it explicitly as a model prompt (see PA's
  * `default-packs/persona-packs.ts`). Every dispatcher that emits to a
- * user-visible surface (assistant stream, notification body, connector channel
- * send) must call {@link renderScheduledDispatchMessage} first so the owner
- * receives the model's composed message, not the instruction itself. Consumers:
- * the spine's default notification dispatcher (`runner-service.ts`) and PA's
- * production dispatcher (`plugin-personal-assistant` runtime-wiring).
+ * user-visible surface (assistant stream, notification body/title, connector
+ * channel send) must render through the model first so the owner receives the
+ * model's composed copy, not instruction text or a generic system label.
+ * Consumers: the spine's default notification dispatcher (`runner-service.ts`)
+ * and PA's production dispatcher (`plugin-personal-assistant` runtime-wiring).
  *
  * Same model seam as PA's `CheckinService.renderSummary`:
  * `runWithTrajectoryPurpose` + `runtime.useModel(TEXT_LARGE)`. Fail-fast by
@@ -76,6 +76,38 @@ export function buildScheduledDispatchRenderPrompt(
 }
 
 /**
+ * Build the notification-title prompt from the already-rendered body. The title
+ * is a visible owner-facing surface too, so it must preserve the same assistant
+ * voice instead of collapsing scheduled output to generic chrome such as
+ * "Reminder" or "Approval needed".
+ */
+export function buildScheduledDispatchTitlePrompt(
+  record: Pick<ScheduledTaskDispatchRecord, "intensity" | "firedAtIso">,
+  body: string,
+): string {
+  const lines: string[] = [
+    "You are the owner's personal assistant. Write a concise notification title for the scheduled message below.",
+    "Write only the title. Do not mention scheduled tasks, automation, instructions, or reminders as system concepts.",
+    "Use natural assistant voice and keep it under 8 words.",
+  ];
+  if (record.intensity === "urgent") {
+    lines.push("This is urgent: make the title direct and action-oriented.");
+  } else if (record.intensity === "soft") {
+    lines.push("Keep the title gentle.");
+  }
+  lines.push(
+    "",
+    "Message body:",
+    body,
+    "",
+    `Fired at: ${record.firedAtIso}`,
+    "",
+    "Title:",
+  );
+  return lines.join("\n");
+}
+
+/**
  * Render the user-facing message for a dispatch through the runtime's model.
  * Throws `ElizaError` (ephemeral) when the model surface is missing, the model
  * call fails, or the model returns blank output — callers must translate the
@@ -116,6 +148,56 @@ export async function renderScheduledDispatchMessage(
       "Model returned empty output for the scheduled dispatch message.",
       {
         code: "SCHEDULED_DISPATCH_RENDER_EMPTY",
+        context: { taskId: record.taskId, channelKey: record.channelKey },
+        severity: "ephemeral",
+      },
+    );
+  }
+  return text;
+}
+
+/**
+ * Render the user-facing notification title for a dispatch through the model.
+ * The body is rendered first by the caller so the title follows the final
+ * owner-facing wording, not the task instruction payload.
+ */
+export async function renderScheduledDispatchTitle(
+  runtime: IAgentRuntime,
+  record: ScheduledTaskDispatchRecord,
+  body: string,
+): Promise<string> {
+  if (typeof runtime.useModel !== "function") {
+    throw new ElizaError(
+      "Runtime has no model surface; cannot render the scheduled dispatch title.",
+      {
+        code: "SCHEDULED_DISPATCH_TITLE_MODEL_UNAVAILABLE",
+        context: { taskId: record.taskId, channelKey: record.channelKey },
+        severity: "ephemeral",
+      },
+    );
+  }
+  const prompt = buildScheduledDispatchTitlePrompt(record, body);
+  let response: unknown;
+  try {
+    response = await runWithTrajectoryPurpose(
+      "scheduled-dispatch-title-render",
+      () => runtime.useModel(ModelType.TEXT_LARGE, { prompt }),
+    );
+  } catch (error) {
+    // error-policy:J2 context-adding rethrow
+    throw new ElizaError("Scheduled dispatch title rendering failed.", {
+      code: "SCHEDULED_DISPATCH_TITLE_RENDER_FAILED",
+      cause: error,
+      context: { taskId: record.taskId, channelKey: record.channelKey },
+      severity: "ephemeral",
+    });
+  }
+  const text = typeof response === "string" ? response.trim() : "";
+  if (text.length === 0) {
+    throw new ElizaError(
+      "Model returned empty output for the scheduled dispatch title.",
+      {
+        code: "SCHEDULED_DISPATCH_TITLE_RENDER_EMPTY",
         context: { taskId: record.taskId, channelKey: record.channelKey },
         severity: "ephemeral",
       },

--- a/plugins/plugin-scheduling/src/scheduled-task/index.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/index.ts
@@ -26,9 +26,11 @@ export {
 } from "./default-pack.js";
 export {
   buildScheduledDispatchRenderPrompt,
+  buildScheduledDispatchTitlePrompt,
   RENDER_FAILURE_RETRY_MINUTES,
   renderFailureDispatchResult,
   renderScheduledDispatchMessage,
+  renderScheduledDispatchTitle,
 } from "./dispatch-render.js";
 export {
   expectedReplyKindForTask,

--- a/plugins/plugin-scheduling/src/scheduled-task/runner-service.ts
+++ b/plugins/plugin-scheduling/src/scheduled-task/runner-service.ts
@@ -45,6 +45,7 @@ import {
 import {
   renderFailureDispatchResult,
   renderScheduledDispatchMessage,
+  renderScheduledDispatchTitle,
 } from "./dispatch-render.js";
 import {
   createEscalationLadderRegistry,
@@ -207,8 +208,10 @@ function createDefaultScheduledTaskDispatcher(
       // failure is a typed, retryable dispatch failure — never fall back to
       // delivering the raw instruction text.
       let body: string;
+      let title: string;
       try {
         body = await renderScheduledDispatchMessage(runtime, record);
+        title = await renderScheduledDispatchTitle(runtime, record, body);
       } catch (error) {
         // error-policy:J1 boundary translation — dispatch outcomes are the
         // runner's typed contract; the failure also reaches RECENT_ERRORS and
@@ -226,7 +229,7 @@ function createDefaultScheduledTaskDispatcher(
       const isUrgent = record.intensity === "urgent";
       void getNotifier(runtime)
         ?.notify({
-          title: isUrgent ? "Approval needed" : "Reminder",
+          title,
           body,
           category: isUrgent ? "approval" : "reminder",
           priority: isUrgent ? "urgent" : "normal",


### PR DESCRIPTION
## Summary

Refs #14874.

- Adds a shared model-rendered scheduled dispatch notification title prompt/render helper.
- Uses the rendered title in the scheduling spine default notification dispatcher instead of fixed "Reminder" / "Approval needed" copy.
- Uses the rendered title in the LifeOps in-app notification path while keeping connector sends/body rendering on the existing owner-facing message path.
- Extends scheduling and LifeOps regression tests so notification titles are rendered from the model body and never raw instruction or generic system copy.

## Validation

- `ELIZA_SKIP_ARTIFACT_SYNC=1 bun install`
- `bun run --cwd packages/core prebuild`
- `bun run --cwd packages/cloud/routing build`
- `bun run --cwd packages/core build`
- `bun run --cwd packages/shared build`
- `bun x biome check plugins/plugin-scheduling/src/scheduled-task/dispatch-render.ts plugins/plugin-scheduling/src/scheduled-task/runner-service.ts plugins/plugin-scheduling/src/scheduled-task/index.ts plugins/plugin-scheduling/src/scheduled-task/dispatch-render.test.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/runtime-wiring.ts plugins/plugin-personal-assistant/test/scheduled-task-dispatch-render.test.ts`
- `bun run --cwd plugins/plugin-scheduling test -- src/scheduled-task/dispatch-render.test.ts` (8 pass)
- `bun run --cwd plugins/plugin-personal-assistant test -- test/scheduled-task-dispatch-render.test.ts` (11 pass; warning-only missing sourcemap/localstorage noise)
- `bun run --cwd plugins/plugin-scheduling typecheck`
- `bun run --cwd plugins/plugin-scheduling build`
- `git diff --check`
- `bun run audit:error-policy-ratchet`

Known verification limit: `bun run --cwd plugins/plugin-personal-assistant typecheck` still fails on current branch with package-wide unresolved optional workspace exports and existing strictness errors (for example `@elizaos/plugin-blocker`, `@elizaos/plugin-finances`, `@elizaos/plugin-health`, `@elizaos/agent`, plus existing implicit-any/unknown errors). The focused LifeOps regression test passes.

## Evidence

<!-- evidence-row:before-screenshots -->
N/A - no UI surface changed; this is scheduled runtime dispatch copy.

<!-- evidence-row:after-screenshots -->
N/A - no UI surface changed; this is scheduled runtime dispatch copy.

<!-- evidence-row:walkthrough-video -->
N/A - no browser/desktop/mobile walkthrough surface changed.

<!-- evidence-row:backend-logs -->
N/A - no server process was run; validation used focused scheduling/LifeOps runtime tests that exercise the dispatcher paths directly.

<!-- evidence-row:frontend-logs -->
N/A - no frontend code or browser surface changed.

<!-- evidence-row:llm-trajectory -->
N/A - live model trajectory pending credentials; this shell has `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GROQ_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, `OPENROUTER_API_KEY`, and `CEREBRAS_API_KEY` unset.

<!-- evidence-row:domain-artifacts -->
N/A - no persistent external domain artifact was produced; deterministic tests captured the scheduled dispatch notification payloads in memory.