### PR TITLE
fix(ui): finish de-surfacing organization language from the console

### DIFF
--- a/packages/ui/src/cloud-ui/components/analytics/cost-alerts.tsx
+++ b/packages/ui/src/cloud-ui/components/analytics/cost-alerts.tsx
@@ -27,7 +27,7 @@ export function CostAlerts({ costTrending }: CostAlertsProps) {
     alerts.push({
       type: "error",
       title: "Low Balance",
-      description: `Your organization will run out of balance in ${costTrending.daysUntilBalanceZero} days at current burn rate. Consider adding funds.`,
+      description: `You will run out of balance in ${costTrending.daysUntilBalanceZero} days at current burn rate. Consider adding funds.`,
     });
   }
 

--- a/packages/ui/src/cloud/billing/BillingSection.test.tsx
+++ b/packages/ui/src/cloud/billing/BillingSection.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Billing surface fallback states. Asserts the no-account branch renders the
+ * account-first copy and never surfaces Organization language — the console
+ * presents as plain per-user accounts (#14298, follow-up to #14282).
+ */
+
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const billingUser = vi.hoisted(() => ({
+  value: {
+    user: null as unknown,
+    isLoading: false,
+    isAuthenticated: true,
+    isError: false,
+    error: null as unknown,
+  },
+}));
+
+vi.mock("@elizaos/ui/cloud-ui", () => ({
+  DashboardErrorState: ({ message }: { message: string }) => (
+    <div role="alert">{message}</div>
+  ),
+  DashboardLoadingState: ({ label }: { label: string }) => <div>{label}</div>,
+}));
+
+vi.mock("../shell/CloudI18nProvider", () => ({
+  useCloudT: () => (key: string, opts?: { defaultValue?: string }) =>
+    opts?.defaultValue ?? key,
+}));
+
+vi.mock("./data/billing-data", () => ({
+  useBillingUser: () => billingUser.value,
+}));
+
+vi.mock("./components/billing-tab", () => ({
+  BillingTab: () => <div>billing tab</div>,
+}));
+
+vi.mock("./wallet/ConditionalWalletProviders", () => ({
+  ConditionalWalletProviders: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+import { BillingSectionBody } from "./BillingSection";
+
+describe("BillingSectionBody", () => {
+  afterEach(() => {
+    cleanup();
+    billingUser.value = {
+      user: null,
+      isLoading: false,
+      isAuthenticated: true,
+      isError: false,
+      error: null,
+    };
+  });
+
+  it("renders account-first copy with no Organization language when the account is missing", () => {
+    const { container } = render(<BillingSectionBody />);
+    const text = container.textContent ?? "";
+
+    expect(text).toContain("No account found for billing");
+    expect(text).not.toMatch(/organization/i);
+  });
+
+  it("renders the billing tab once the account resolves", () => {
+    billingUser.value = {
+      user: { organization_id: "org-1" },
+      isLoading: false,
+      isAuthenticated: true,
+      isError: false,
+      error: null,
+    };
+    const { container } = render(<BillingSectionBody />);
+    expect(container.textContent ?? "").toContain("billing tab");
+  });
+});

--- a/packages/ui/src/cloud/billing/BillingSection.tsx
+++ b/packages/ui/src/cloud/billing/BillingSection.tsx
@@ -58,8 +58,8 @@ export function BillingSectionBody() {
   if (!user) {
     return (
       <DashboardErrorState
-        message={t("cloud.billing.noOrganization", {
-          defaultValue: "No organization associated with this account",
+        message={t("cloud.billing.noAccount", {
+          defaultValue: "No account found for billing",
         })}
       />
     );

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -1170,7 +1170,6 @@
   "cloud.billing.loading": "Loading billing",
   "cloud.billing.metaDescription": "Add funds and manage your billing",
   "cloud.billing.metaTitle": "Billing",
-  "cloud.billing.noOrganization": "No organization associated with this account",
   "cloud.billing.pageTitle": "Billing",
   "cloud.billing.paymentCanceled": "Payment canceled. No charges were made.",
   "cloud.billing.success.backToBilling": "Back to Billing",

--- a/packages/ui/src/i18n/locales/es.json
+++ b/packages/ui/src/i18n/locales/es.json
@@ -1159,7 +1159,6 @@
   "cloud.billing.loading": "Cargando facturación",
   "cloud.billing.metaDescription": "Añade fondos y gestiona tu facturación",
   "cloud.billing.metaTitle": "Facturación",
-  "cloud.billing.noOrganization": "No hay organización asociada a esta cuenta",
   "cloud.billing.pageTitle": "Facturación",
   "cloud.billing.paymentCanceled": "Pago cancelado. No se cobró nada.",
   "cloud.billing.success.backToBilling": "Volver a Facturación",

--- a/packages/ui/src/i18n/locales/ja.json
+++ b/packages/ui/src/i18n/locales/ja.json
@@ -1159,7 +1159,6 @@
   "cloud.billing.loading": "お支払い情報を読み込み中",
   "cloud.billing.metaDescription": "資金を追加し、お支払いを管理",
   "cloud.billing.metaTitle": "お支払い",
-  "cloud.billing.noOrganization": "このアカウントに関連付けられた組織がありません",
   "cloud.billing.pageTitle": "お支払い",
   "cloud.billing.paymentCanceled": "お支払いがキャンセルされました。請求はされていません。",
   "cloud.billing.success.backToBilling": "お支払いに戻る",

--- a/packages/ui/src/i18n/locales/ko.json
+++ b/packages/ui/src/i18n/locales/ko.json
@@ -1159,7 +1159,6 @@
   "cloud.billing.loading": "결제 정보 불러오는 중",
   "cloud.billing.metaDescription": "결제 정보를 관리하고 충전해요",
   "cloud.billing.metaTitle": "결제",
-  "cloud.billing.noOrganization": "이 계정에 연결된 조직이 없어요",
   "cloud.billing.pageTitle": "결제",
   "cloud.billing.paymentCanceled": "결제가 취소됐어요. 청구된 금액은 없어요.",
   "cloud.billing.success.backToBilling": "결제로 돌아가기",

--- a/packages/ui/src/i18n/locales/pt.json
+++ b/packages/ui/src/i18n/locales/pt.json
@@ -1159,7 +1159,6 @@
   "cloud.billing.loading": "Carregando cobrança",
   "cloud.billing.metaDescription": "Adicione fundos e gerencie sua cobrança",
   "cloud.billing.metaTitle": "Cobrança",
-  "cloud.billing.noOrganization": "Sem organização associada a esta conta",
   "cloud.billing.pageTitle": "Cobrança",
   "cloud.billing.paymentCanceled": "Pagamento cancelado. Nada foi cobrado.",
   "cloud.billing.success.backToBilling": "Voltar para Cobrança",

--- a/packages/ui/src/i18n/locales/tl.json
+++ b/packages/ui/src/i18n/locales/tl.json
@@ -1159,7 +1159,6 @@
   "cloud.billing.loading": "Naglo-load ng billing",
   "cloud.billing.metaDescription": "Mag-dagdag ng pondo at i-manage ang billing",
   "cloud.billing.metaTitle": "Pagsingil",
-  "cloud.billing.noOrganization": "Walang organization na naka-associate sa account na ito",
   "cloud.billing.pageTitle": "Pagsingil",
   "cloud.billing.paymentCanceled": "Cancelled ang payment. Walang sinisingil.",
   "cloud.billing.success.backToBilling": "Bumalik sa Billing",

--- a/packages/ui/src/i18n/locales/vi.json
+++ b/packages/ui/src/i18n/locales/vi.json
@@ -1159,7 +1159,6 @@
   "cloud.billing.loading": "Đang tải thanh toán",
   "cloud.billing.metaDescription": "Nạp tiền và quản lý thanh toán",
   "cloud.billing.metaTitle": "Thanh toán",
-  "cloud.billing.noOrganization": "Không có tổ chức nào gắn với tài khoản này",
   "cloud.billing.pageTitle": "Thanh toán",
   "cloud.billing.paymentCanceled": "Đã hủy thanh toán. Không có khoản phí nào.",
   "cloud.billing.success.backToBilling": "Quay lại Thanh toán",

--- a/packages/ui/src/i18n/locales/zh-CN.json
+++ b/packages/ui/src/i18n/locales/zh-CN.json
@@ -1159,7 +1159,6 @@
   "cloud.billing.loading": "加载账单中",
   "cloud.billing.metaDescription": "充值并管理你的账单",
   "cloud.billing.metaTitle": "账单",
-  "cloud.billing.noOrganization": "此账户没有关联的组织",
   "cloud.billing.pageTitle": "账单",
   "cloud.billing.paymentCanceled": "支付已取消。未产生任何费用。",
   "cloud.billing.success.backToBilling": "返回账单",


### PR DESCRIPTION
Follow-up to #14282 (de-surfaced the Organization nav item + overview card) and #14443 (removed the account-page Organization card + "you're part of {org}" copy). Closes the remaining reachable-surface gap tracked in #14298: the console should read as **plain user accounts, no orgs**, while the backend org/tenancy model is preserved untouched.

## Org surfaces still remaining (before this PR)

The two files #14298 named (`account-page-client.tsx`, `organization-info.tsx`) were **already resolved by #14443** — the account page is clean and test-locked (`account-page-client.test.tsx` asserts no org language even when the user has an org). A fresh grep of `packages/ui/src` for reachable, user-visible Organization copy surfaced two that remained:

- `packages/ui/src/cloud/billing/BillingSection.tsx:61` — the no-account error state rendered **"No organization associated with this account"** on the **promoted** `/dashboard/billing` console surface.
- `packages/ui/src/cloud-ui/components/analytics/cost-alerts.tsx:30` — the low-balance alert rendered **"Your organization will run out of balance…"** on the analytics surface.

## Changes

- **BillingSection**: rewrite the no-account error to account-first copy and rename the misleading i18n key `cloud.billing.noOrganization` → `cloud.billing.noAccount` (`"No account found for billing"`).
- **cost-alerts**: `"Your organization will run out of balance…"` → `"You will run out of balance…"`, matching the component's existing second-person voice (its sibling alerts already say "your daily burn rate", "you'll spend…").
- **i18n**: drop the now-dead `cloud.billing.noOrganization` key from all eight locale files (en, es, ja, ko, pt, tl, vi, zh-CN).
- **test**: add `BillingSection.test.tsx` asserting the no-account state renders the account-first copy and contains **no** Organization language, plus the resolved-account path.

## Intentionally left (org concept genuinely required)

Per #14282's established direction and #14298's own carve-out ("unless a deep-link/admin/invite flow explicitly needs it"):

- `cloud/organization/*` route + `register-cloud-settings.ts` Organization settings section — the org route **stays registered** for invite deep-links (de-surfaced from nav, not deleted).
- `invite-accept-page.tsx` ("Organization"), `steward-login-section.tsx` ("Your organization requires SSO"), members tab — invite / enterprise-SSO / admin flows that inherently reference the org container.
- Internal data-model identifiers (`organization_id`, `OrganizationDto`, code comments) — backend tenancy/money container, out of scope (UI copy only).
- Orphaned i18n keys from the card #14443 deleted (`cloud.organizationInfo.*`, `accountTab.orgIdLabel`) — no `.tsx` renders them, so not user-reachable; left as-is to keep this PR scoped.

## Verification

- **Tests**: `BillingSection.test.tsx` + `account-page-client.test.tsx` → **3/3 pass** (vitest).
- **Typecheck** (`bun run --cwd packages/ui typecheck`): touched files clean. The 11 errors reported are all in files this PR does not touch (core/shared i18n, voice self-test, settings-sections, widget-cert) — pre-existing `develop` state.
- **Biome**: `biome check` clean on all touched files.
- **Visual scope / caveat**: this is a **copy-only** change (two strings + a dead i18n key) with **no** styling, layout, color, or hover changes — the color law (orange accent only, no blue) is unaffected. Verified by code-trace + touched-component review + unit tests. Full visual E2E (`audit:app`) was **not** run here: the app stack requires Node 24 + Playwright and does not boot in this environment (Node 22). No device/pixel verification is claimed — a maintainer with the app stack can capture the billing no-account + analytics low-balance states if rendered proof is required.

refs #14298, #14282, #14443