### PR TITLE
feat(lifeops): add commitment ledger primitive

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/commitments/index.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/commitments/index.ts
@@ -1,0 +1,2 @@
+/** Commitment-ledger domain exports for durable obligations and regret audits. */
+export * from "./ledger.js";

--- a/plugins/plugin-personal-assistant/src/lifeops/commitments/ledger.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/commitments/ledger.ts
@@ -1,0 +1,257 @@
+/**
+ * Durable commitment and obligation ledger primitives for LifeOps. Connector
+ * and document ingestion code can write normalized rows here, while brief and
+ * prioritization paths can audit the same records for orphaned promises,
+ * renewal/filing deadlines, and "what will I regret" queries.
+ */
+import crypto from "node:crypto";
+
+export type LifeOpsCommitmentSource =
+  | "sent_mail"
+  | "transcript"
+  | "chat"
+  | "document";
+
+export type LifeOpsCommitmentKind =
+  | "commitment"
+  | "renewal"
+  | "filing"
+  | "warranty";
+
+export type LifeOpsCommitmentStatus =
+  | "open"
+  | "tracked"
+  | "completed"
+  | "dismissed"
+  | "superseded";
+
+export interface LifeOpsCommitmentLedgerRecord {
+  id: string;
+  agentId: string;
+  source: LifeOpsCommitmentSource;
+  sourceKey: string;
+  kind: LifeOpsCommitmentKind;
+  summary: string;
+  counterparty: string | null;
+  dueAt: string | null;
+  confidence: number;
+  status: LifeOpsCommitmentStatus;
+  scheduledTaskId: string | null;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CommitmentExtractionInput {
+  agentId: string;
+  source: LifeOpsCommitmentSource;
+  sourceKey: string;
+  text: string;
+  observedAt: string;
+  counterparty?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CommitmentRegretAuditItem {
+  record: LifeOpsCommitmentLedgerRecord;
+  score: number;
+  reasons: string[];
+}
+
+export interface CommitmentRegretAudit {
+  generatedAt: string;
+  horizonEndAt: string;
+  items: CommitmentRegretAuditItem[];
+}
+
+const COMMITMENT_RE =
+  /\b(i(?:'ll| will| can| need to| owe| promised to)|we(?:'ll| will| need to)|let me|i am going to)\b/i;
+const SPECULATIVE_RE =
+  /\b(maybe|sometime|eventually|if we get around to it|might|could)\b/i;
+const WEEKDAYS = [
+  "sunday",
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+] as const;
+
+function sha16(input: string): string {
+  return crypto.createHash("sha256").update(input).digest("hex").slice(0, 16);
+}
+
+function normalizeText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function clampConfidence(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+
+function addUtcDays(date: Date, days: number): Date {
+  const next = new Date(date.getTime());
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}
+
+function endOfUtcDay(date: Date): string {
+  const next = new Date(date.getTime());
+  next.setUTCHours(17, 0, 0, 0);
+  return next.toISOString();
+}
+
+function nextWeekdayIso(observedAt: string, weekdayName: string): string {
+  const base = new Date(observedAt);
+  const target = WEEKDAYS.indexOf(
+    weekdayName.toLowerCase() as (typeof WEEKDAYS)[number],
+  );
+  if (target < 0 || Number.isNaN(base.getTime())) return observedAt;
+  const today = base.getUTCDay();
+  let delta = (target - today + 7) % 7;
+  if (delta === 0) delta = 7;
+  return endOfUtcDay(addUtcDays(base, delta));
+}
+
+function resolveDueAt(text: string, observedAt: string): string | null {
+  const isoDate = text.match(/\b(20\d{2}-\d{2}-\d{2})\b/);
+  if (isoDate?.[1]) {
+    return endOfUtcDay(new Date(`${isoDate[1]}T00:00:00.000Z`));
+  }
+  if (/\btomorrow\b/i.test(text)) {
+    return endOfUtcDay(addUtcDays(new Date(observedAt), 1));
+  }
+  const weekdayPattern = new RegExp(
+    `\\b(?:by|before|on|next)?\\s*(${WEEKDAYS.join("|")})\\b`,
+    "i",
+  );
+  const weekday = text.match(weekdayPattern)?.[1];
+  return weekday ? nextWeekdayIso(observedAt, weekday) : null;
+}
+
+function classifyKind(text: string): LifeOpsCommitmentKind {
+  if (/\b(renew|renewal|cancellation deadline|trial ends)\b/i.test(text)) {
+    return "renewal";
+  }
+  if (/\b(file|filing|submit|tax|court|deadline)\b/i.test(text)) {
+    return "filing";
+  }
+  if (/\b(warranty|guarantee|return window)\b/i.test(text)) {
+    return "warranty";
+  }
+  return "commitment";
+}
+
+function firstCommitmentSentence(text: string): string | null {
+  for (const part of text.split(/(?<=[.!?])\s+/)) {
+    const sentence = normalizeText(part);
+    if (!sentence) continue;
+    if (!COMMITMENT_RE.test(sentence)) continue;
+    if (SPECULATIVE_RE.test(sentence)) continue;
+    return sentence.replace(/[.!?]+$/, "");
+  }
+  return null;
+}
+
+export function createLifeOpsCommitmentLedgerRecord(
+  params: Omit<
+    LifeOpsCommitmentLedgerRecord,
+    "id" | "createdAt" | "updatedAt" | "status" | "scheduledTaskId"
+  > & {
+    id?: string;
+    status?: LifeOpsCommitmentStatus;
+    scheduledTaskId?: string | null;
+    createdAt?: string;
+    updatedAt?: string;
+  },
+): LifeOpsCommitmentLedgerRecord {
+  const timestamp = params.createdAt ?? new Date().toISOString();
+  const summary = normalizeText(params.summary);
+  return {
+    ...params,
+    id:
+      params.id ??
+      `commit_${sha16(`${params.agentId}:${params.source}:${params.sourceKey}:${params.kind}:${summary}`)}`,
+    summary,
+    confidence: clampConfidence(params.confidence),
+    status: params.status ?? "open",
+    scheduledTaskId: params.scheduledTaskId ?? null,
+    createdAt: timestamp,
+    updatedAt: params.updatedAt ?? timestamp,
+  };
+}
+
+export function extractCommitmentLedgerRecords(
+  input: CommitmentExtractionInput,
+): LifeOpsCommitmentLedgerRecord[] {
+  const sentence = firstCommitmentSentence(input.text);
+  if (!sentence) return [];
+  const kind = classifyKind(sentence);
+  return [
+    createLifeOpsCommitmentLedgerRecord({
+      agentId: input.agentId,
+      source: input.source,
+      sourceKey: input.sourceKey,
+      kind,
+      summary: sentence,
+      counterparty: input.counterparty?.trim() || null,
+      dueAt: resolveDueAt(sentence, input.observedAt),
+      confidence: kind === "commitment" ? 0.74 : 0.82,
+      metadata: {
+        ...(input.metadata ?? {}),
+        observedAt: input.observedAt,
+        textSha256: crypto
+          .createHash("sha256")
+          .update(input.text)
+          .digest("hex"),
+      },
+    }),
+  ];
+}
+
+export function buildCommitmentRegretAudit(
+  records: LifeOpsCommitmentLedgerRecord[],
+  args: { nowIso: string; horizonDays?: number } = {
+    nowIso: new Date().toISOString(),
+  },
+): CommitmentRegretAudit {
+  const now = new Date(args.nowIso);
+  const horizonEnd = addUtcDays(now, args.horizonDays ?? 7);
+  const horizonEndAt = horizonEnd.toISOString();
+  const items = records
+    .filter((record) => record.status === "open" || record.status === "tracked")
+    .map((record): CommitmentRegretAuditItem => {
+      const reasons: string[] = [];
+      let score = record.confidence;
+      if (!record.scheduledTaskId) {
+        score += 0.35;
+        reasons.push("no scheduled tracker");
+      }
+      if (record.dueAt) {
+        const due = new Date(record.dueAt);
+        if (due <= horizonEnd) {
+          score += 0.3;
+          reasons.push("due inside audit horizon");
+        }
+        if (due < now) {
+          score += 0.25;
+          reasons.push("overdue");
+        }
+      } else {
+        score += 0.12;
+        reasons.push("no explicit due date");
+      }
+      if (record.kind !== "commitment") {
+        score += 0.15;
+        reasons.push(`${record.kind} obligation`);
+      }
+      return { record, score: Number(score.toFixed(3)), reasons };
+    })
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        a.record.createdAt.localeCompare(b.record.createdAt),
+    );
+  return { generatedAt: args.nowIso, horizonEndAt, items };
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/index.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/index.ts
@@ -2,6 +2,7 @@
 export * from "./app-state.js";
 export * from "./apple-reminders.js";
 export * from "./bulk-review.js";
+export * from "./commitments/index.js";
 export * from "./defaults.js";
 export * from "./document-review.js";
 export * from "./email-curation.js";

--- a/plugins/plugin-personal-assistant/src/lifeops/repository.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/repository.ts
@@ -103,6 +103,12 @@ import {
   type LifeOpsWorkflowDefinition,
   type LifeOpsWorkflowRun,
 } from "../contracts/index.js";
+import type {
+  LifeOpsCommitmentKind,
+  LifeOpsCommitmentLedgerRecord,
+  LifeOpsCommitmentSource,
+  LifeOpsCommitmentStatus,
+} from "./commitments/index.js";
 import {
   createConnectorAccountPrivacyPolicy,
   deriveConnectorAccountId,
@@ -559,6 +565,29 @@ function parseAuditEvent(row: Record<string, unknown>): LifeOpsAuditEvent {
     decision: parseJsonRecord(row.decision_json),
     actor: toText(row.actor) as LifeOpsAuditEvent["actor"],
     createdAt: toText(row.created_at),
+  };
+}
+
+function parseCommitmentLedgerRecord(
+  row: Record<string, unknown>,
+): LifeOpsCommitmentLedgerRecord {
+  return {
+    id: toText(row.id),
+    agentId: toText(row.agent_id),
+    source: toText(row.source) as LifeOpsCommitmentSource,
+    sourceKey: toText(row.source_key),
+    kind: toText(row.kind) as LifeOpsCommitmentKind,
+    summary: toText(row.summary),
+    counterparty: row.counterparty ? toText(row.counterparty) : null,
+    dueAt: row.due_at ? toText(row.due_at) : null,
+    confidence: toNumber(row.confidence),
+    status: toText(row.status, "open") as LifeOpsCommitmentStatus,
+    scheduledTaskId: row.scheduled_task_id
+      ? toText(row.scheduled_task_id)
+      : null,
+    metadata: parseJsonRecord(row.metadata_json),
+    createdAt: toText(row.created_at),
+    updatedAt: toText(row.updated_at),
   };
 }
 
@@ -3267,6 +3296,91 @@ export class LifeOpsRepository {
         ORDER BY created_at DESC`,
     );
     return rows.map(parseAuditEvent);
+  }
+
+  async upsertCommitmentLedgerRecord(
+    record: LifeOpsCommitmentLedgerRecord,
+  ): Promise<void> {
+    await executeRawSql(
+      this.runtime,
+      `INSERT INTO app_lifeops.life_commitment_ledger (
+        id, agent_id, source, source_key, kind, summary, counterparty, due_at,
+        confidence, status, scheduled_task_id, metadata_json, created_at,
+        updated_at
+      ) VALUES (
+        ${sqlQuote(record.id)},
+        ${sqlQuote(record.agentId)},
+        ${sqlQuote(record.source)},
+        ${sqlQuote(record.sourceKey)},
+        ${sqlQuote(record.kind)},
+        ${sqlQuote(record.summary)},
+        ${sqlText(record.counterparty)},
+        ${sqlText(record.dueAt)},
+        ${sqlNumber(record.confidence)},
+        ${sqlQuote(record.status)},
+        ${sqlText(record.scheduledTaskId)},
+        ${sqlJson(record.metadata)},
+        ${sqlQuote(record.createdAt)},
+        ${sqlQuote(record.updatedAt)}
+      )
+      ON CONFLICT(agent_id, source, source_key, kind, summary)
+      DO UPDATE SET
+        counterparty = EXCLUDED.counterparty,
+        due_at = EXCLUDED.due_at,
+        confidence = EXCLUDED.confidence,
+        status = EXCLUDED.status,
+        scheduled_task_id = EXCLUDED.scheduled_task_id,
+        metadata_json = EXCLUDED.metadata_json,
+        updated_at = EXCLUDED.updated_at`,
+    );
+  }
+
+  async getCommitmentLedgerRecord(
+    agentId: string,
+    id: string,
+  ): Promise<LifeOpsCommitmentLedgerRecord | null> {
+    const rows = await executeRawSql(
+      this.runtime,
+      `SELECT *
+         FROM app_lifeops.life_commitment_ledger
+        WHERE agent_id = ${sqlQuote(agentId)}
+          AND id = ${sqlQuote(id)}
+        LIMIT 1`,
+    );
+    const row = rows[0];
+    return row ? parseCommitmentLedgerRecord(row) : null;
+  }
+
+  async listCommitmentLedgerRecords(
+    agentId: string,
+    filter: {
+      statuses?: LifeOpsCommitmentStatus[];
+      dueBeforeIso?: string;
+      source?: LifeOpsCommitmentSource;
+    } = {},
+  ): Promise<LifeOpsCommitmentLedgerRecord[]> {
+    const clauses = [`agent_id = ${sqlQuote(agentId)}`];
+    if (filter.statuses?.length) {
+      clauses.push(
+        `status IN (${filter.statuses.map((status) => sqlQuote(status)).join(", ")})`,
+      );
+    }
+    if (filter.dueBeforeIso) {
+      clauses.push(
+        `(due_at IS NULL OR due_at <= ${sqlQuote(filter.dueBeforeIso)})`,
+      );
+    }
+    if (filter.source) {
+      clauses.push(`source = ${sqlQuote(filter.source)}`);
+    }
+    const rows = await executeRawSql(
+      this.runtime,
+      `SELECT *
+         FROM app_lifeops.life_commitment_ledger
+        WHERE ${clauses.join(" AND ")}
+        ORDER BY due_at ASC NULLS LAST, created_at ASC`,
+    );
+    return rows.map(parseCommitmentLedgerRecord);
   }
 
   // ---------------------------------------------------------------------

--- a/plugins/plugin-personal-assistant/src/lifeops/schema.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/schema.ts
@@ -316,6 +316,41 @@ export const lifeAuditEvents = appLifeopsPgSchema.table(
   ],
 );
 
+export const lifeCommitmentLedger = appLifeopsPgSchema.table(
+  "life_commitment_ledger",
+  {
+    id: text("id").primaryKey(),
+    agentId: text("agent_id").notNull(),
+    source: text("source").notNull(),
+    sourceKey: text("source_key").notNull(),
+    kind: text("kind").notNull(),
+    summary: text("summary").notNull(),
+    counterparty: text("counterparty"),
+    dueAt: text("due_at"),
+    confidence: real("confidence").notNull(),
+    status: text("status").notNull().default("open"),
+    scheduledTaskId: text("scheduled_task_id"),
+    metadataJson: text("metadata_json").notNull().default("{}"),
+    createdAt: text("created_at").notNull(),
+    updatedAt: text("updated_at").notNull(),
+  },
+  (t) => [
+    unique("uniq_life_commitment_source").on(
+      t.agentId,
+      t.source,
+      t.sourceKey,
+      t.kind,
+      t.summary,
+    ),
+    index("idx_life_commitment_agent_status_due").on(
+      t.agentId,
+      t.status,
+      t.dueAt,
+    ),
+    index("idx_life_commitment_source").on(t.agentId, t.source, t.sourceKey),
+  ],
+);
+
 // Finance tables (life_payment_*, life_subscription_*) moved to
 // @elizaos/plugin-finances under pgSchema("app_finances"). PA no longer creates
 // them in app_lifeops; the finances plugin owns + migrates them. PA's raw
@@ -1564,6 +1599,7 @@ export const lifeOpsSchema = {
   lifeReminderPlans,
   lifeReminderAttempts,
   lifeAuditEvents,
+  lifeCommitmentLedger,
   lifeEmailUnsubscribes,
   lifeActivitySignals,
   lifeHealthMetricSamples,

--- a/plugins/plugin-personal-assistant/test/commitment-ledger.test.ts
+++ b/plugins/plugin-personal-assistant/test/commitment-ledger.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Regression coverage for the durable commitments/obligations ledger. The
+ * extractor is deliberately conservative and deterministic here; live model
+ * extraction trajectories belong to the scenario lane once credentials are
+ * available.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildCommitmentRegretAudit,
+  createLifeOpsCommitmentLedgerRecord,
+  extractCommitmentLedgerRecords,
+  LifeOpsRepository,
+} from "../src/lifeops/index.js";
+import {
+  createLifeOpsTestRuntime,
+  type RealTestRuntimeResult,
+} from "./helpers/runtime.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-000000001864";
+const OBSERVED_AT = "2026-07-06T15:00:00.000Z";
+
+describe("commitment ledger extraction and audit", () => {
+  it("extracts a concrete sent-mail promise with a due date", () => {
+    const rows = extractCommitmentLedgerRecords({
+      agentId: AGENT_ID,
+      source: "sent_mail",
+      sourceKey: "gmail:msg-1",
+      observedAt: OBSERVED_AT,
+      counterparty: "Mira",
+      text: "I'll send the deck Friday and include the pricing appendix.",
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      source: "sent_mail",
+      sourceKey: "gmail:msg-1",
+      kind: "commitment",
+      counterparty: "Mira",
+      dueAt: "2026-07-10T17:00:00.000Z",
+      status: "open",
+      scheduledTaskId: null,
+    });
+    expect(rows[0]?.summary).toContain("send the deck Friday");
+  });
+
+  it("does not create rows for speculative chit-chat", () => {
+    const rows = extractCommitmentLedgerRecords({
+      agentId: AGENT_ID,
+      source: "chat",
+      sourceKey: "thread:loose",
+      observedAt: OBSERVED_AT,
+      text: "Yeah maybe sometime we could send something over.",
+    });
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it("ranks orphaned near-term obligations ahead of tracked or completed rows", () => {
+    const orphan = createLifeOpsCommitmentLedgerRecord({
+      agentId: AGENT_ID,
+      source: "sent_mail",
+      sourceKey: "gmail:deck",
+      kind: "commitment",
+      summary: "I'll send the deck Friday",
+      counterparty: "Mira",
+      dueAt: "2026-07-10T17:00:00.000Z",
+      confidence: 0.74,
+      metadata: {},
+      createdAt: "2026-07-06T15:00:00.000Z",
+    });
+    const tracked = createLifeOpsCommitmentLedgerRecord({
+      agentId: AGENT_ID,
+      source: "document",
+      sourceKey: "contract:acme",
+      kind: "renewal",
+      summary: "Renewal notice for Acme contract",
+      counterparty: "Acme",
+      dueAt: "2026-07-12T17:00:00.000Z",
+      confidence: 0.9,
+      status: "tracked",
+      scheduledTaskId: "st_acme_renewal",
+      metadata: {},
+      createdAt: "2026-07-06T16:00:00.000Z",
+    });
+    const completed = createLifeOpsCommitmentLedgerRecord({
+      agentId: AGENT_ID,
+      source: "chat",
+      sourceKey: "thread:done",
+      kind: "commitment",
+      summary: "I will send the notes",
+      counterparty: null,
+      dueAt: "2026-07-07T17:00:00.000Z",
+      confidence: 0.8,
+      status: "completed",
+      metadata: {},
+      createdAt: "2026-07-06T17:00:00.000Z",
+    });
+
+    const audit = buildCommitmentRegretAudit([tracked, completed, orphan], {
+      nowIso: "2026-07-09T12:00:00.000Z",
+      horizonDays: 7,
+    });
+
+    expect(audit.items.map((item) => item.record.id)).toEqual([
+      orphan.id,
+      tracked.id,
+    ]);
+    expect(audit.items[0]?.reasons).toContain("no scheduled tracker");
+    expect(audit.items[0]?.reasons).toContain("due inside audit horizon");
+  });
+});
+
+describe("commitment ledger repository", () => {
+  let runtimeResult: RealTestRuntimeResult | null = null;
+
+  afterEach(async () => {
+    await runtimeResult?.cleanup();
+    runtimeResult = null;
+  });
+
+  it("persists extracted obligations through the LifeOps schema", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    const { runtime } = runtimeResult;
+    await LifeOpsRepository.bootstrapSchema(runtime);
+    const repo = new LifeOpsRepository(runtime);
+    const record = extractCommitmentLedgerRecords({
+      agentId: runtime.agentId,
+      source: "sent_mail",
+      sourceKey: "gmail:msg-commitment",
+      observedAt: OBSERVED_AT,
+      counterparty: "Mira",
+      text: "I'll send the deck Friday and include the pricing appendix.",
+    })[0];
+    if (!record) {
+      throw new Error("Expected commitment extraction to produce one record.");
+    }
+
+    await repo.upsertCommitmentLedgerRecord(record);
+
+    const reloaded = new LifeOpsRepository(runtime);
+    const rows = await reloaded.listCommitmentLedgerRecords(runtime.agentId, {
+      statuses: ["open"],
+      dueBeforeIso: "2026-07-11T00:00:00.000Z",
+    });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: record.id,
+      source: "sent_mail",
+      sourceKey: "gmail:msg-commitment",
+      counterparty: "Mira",
+      dueAt: "2026-07-10T17:00:00.000Z",
+      scheduledTaskId: null,
+    });
+
+    await reloaded.upsertCommitmentLedgerRecord({
+      ...record,
+      status: "tracked",
+      scheduledTaskId: "st_deck_followup",
+      updatedAt: "2026-07-06T18:00:00.000Z",
+    });
+
+    const tracked = await reloaded.getCommitmentLedgerRecord(
+      runtime.agentId,
+      record.id,
+    );
+    expect(tracked).toMatchObject({
+      status: "tracked",
+      scheduledTaskId: "st_deck_followup",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Refs #14864.

- Adds `app_lifeops.life_commitment_ledger`, a durable PA-owned table for commitment/renewal/filing/warranty obligations with source identity, due date, confidence, status, scheduled-task linkage, and metadata.
- Adds `LifeOpsRepository` helpers to upsert, fetch, and list ledger rows for future connector/document hooks and BRIEF/PRIORITIZE audit consumers.
- Adds conservative deterministic extraction and regret-audit primitives: concrete promises become ledger rows; speculative chit-chat is rejected; orphaned near-term obligations rank above tracked/completed rows.
- Adds focused tests covering sent-mail extraction, false-positive guard, regret ranking, and DB-backed persistence through the real LifeOps schema/repository path.

## Validation

- `ELIZA_SKIP_ARTIFACT_SYNC=1 bun install`
- `bun run --cwd packages/core prebuild`
- `bun run --cwd packages/core build`
- `bun run --cwd packages/shared build`
- `bun run --cwd packages/cloud/routing build`
- `bun x biome check plugins/plugin-personal-assistant/src/lifeops/schema.ts plugins/plugin-personal-assistant/src/lifeops/repository.ts plugins/plugin-personal-assistant/src/lifeops/index.ts plugins/plugin-personal-assistant/src/lifeops/commitments/index.ts plugins/plugin-personal-assistant/src/lifeops/commitments/ledger.ts plugins/plugin-personal-assistant/test/commitment-ledger.test.ts`
- `bun run --cwd plugins/plugin-personal-assistant test -- test/commitment-ledger.test.ts` (4 pass; warning-only localstorage/sourcemap noise)
- `git diff --check`
- `bun run audit:error-policy-ratchet`

Known verification limit: `bun run --cwd plugins/plugin-personal-assistant typecheck` remains blocked by package-wide unresolved optional workspace exports and existing strictness errors (for example `@elizaos/plugin-blocker`, `@elizaos/plugin-finances`, `@elizaos/plugin-health`, `@elizaos/agent`, scheduling barrel exports, and existing implicit-any/unknown errors). Grepping that output for the new ledger files found no `commitment`/`commitment-ledger` diagnostics.

## Evidence

<!-- evidence-row:before-screenshots -->
N/A - no UI surface changed; this is a LifeOps runtime persistence/domain primitive.

<!-- evidence-row:after-screenshots -->
N/A - no UI surface changed; this is a LifeOps runtime persistence/domain primitive.

<!-- evidence-row:walkthrough-video -->
N/A - no browser/desktop/mobile walkthrough surface changed.

<!-- evidence-row:backend-logs -->
N/A - no server process was run; validation used focused LifeOps runtime tests against the real repository/schema path.

<!-- evidence-row:frontend-logs -->
N/A - no frontend code or browser surface changed.

<!-- evidence-row:llm-trajectory -->
N/A - live model extraction trajectory pending credentials; this shell has `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GROQ_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, `OPENROUTER_API_KEY`, and `CEREBRAS_API_KEY` unset. This PR adds the durable primitive and deterministic conservative extractor, not the final live extraction evaluator.

<!-- evidence-row:domain-artifacts -->
N/A - no durable external artifact was produced; the focused test persisted and reloaded the ledger row inside an ephemeral test database that was cleaned up by the runtime helper.