### PR TITLE
fix(app): recover shared console session on first-run too (SSO part 2)

### DIFF
--- a/packages/ui/src/cloud/lib/auth-query.ts
+++ b/packages/ui/src/cloud/lib/auth-query.ts
@@ -21,7 +21,11 @@ export function useAuthenticatedQueryGate(
 ): AuthenticatedQueryGate {
   const session = useSessionAuth();
   return {
-    enabled: enabled && session.ready && session.authenticated,
+    // Gate on `authenticated` (a valid, expiry-checked stored token exists and
+    // api-client injects it as the Bearer) rather than also on `ready` — the
+    // latter waits for the @stwd SDK's slow session resolution, which left the
+    // agents list spinning for seconds after the token was already usable.
+    enabled: enabled && session.authenticated,
     userId: session.user?.id ?? null,
   };
 }

--- a/packages/ui/src/cloud/shell/StewardProvider.tsx
+++ b/packages/ui/src/cloud/shell/StewardProvider.tsx
@@ -90,9 +90,12 @@ function StewardRuntimeLoading() {
       aria-live="polite"
       role="status"
       style={{
+        // Pre-theme fallback (renders before the theme tree mounts, so it uses
+        // literals not vars): black to match the console, not the old beige that
+        // flashed light-on-black and read as a broken load.
         alignItems: "center",
-        background: "#f8f4ef",
-        color: "#2f261f",
+        background: "#000",
+        color: "rgba(255,255,255,0.55)",
         display: "flex",
         justifyContent: "center",
         minHeight: "100vh",

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -43,6 +43,10 @@
  */
 
 import { logger } from "@elizaos/logger";
+import {
+  hasStewardAuthedCookie,
+  writeStoredStewardToken,
+} from "@elizaos/shared/steward-session-client";
 import * as React from "react";
 import type {
   ConversationMessage,
@@ -50,7 +54,10 @@ import type {
   LocalAgentBackupMetadata,
 } from "../api";
 import { client } from "../api";
-import { getCloudAuthToken } from "../api/client-cloud";
+import {
+  getCloudAuthToken,
+  refreshCloudStewardSession,
+} from "../api/client-cloud";
 import { getBootConfig } from "../config/boot-config";
 import { ACCENT_PRESETS, useAppSelectorShallow } from "../state";
 import { useConversationMessages } from "../state/ConversationMessagesContext.hooks";
@@ -1149,6 +1156,29 @@ export function useFirstRunConductor(): void {
             `${CLOUD_SIGN_IN_GREETING}\n\n${CLOUD_SIGN_IN_CHOICE}`,
           ),
         );
+        // Cross-subdomain SSO: a user already signed in on the console carries
+        // the shared, HttpOnly .elizacloud.ai refresh cookie, but localStorage
+        // does not cross subdomains — so this app origin has no stored token
+        // and would ask them to sign in AGAIN. Recover the access token from
+        // the cookie (same-origin refresh route, same pattern as the /login
+        // page); the token poll below then upgrades to welcome-back within
+        // 500ms. Fire-and-forget: a failed refresh simply leaves the normal
+        // sign-in greeting in place.
+        if (typeof window !== "undefined" && hasStewardAuthedCookie()) {
+          // error-policy:J4 failed cookie refresh degrades to the sign-in
+          // greeting already on screen; it never fabricates a session.
+          refreshCloudStewardSession()
+            .then((refreshed) => {
+              if (!refreshed?.token) return;
+              writeStoredStewardToken(refreshed.token);
+              try {
+                window.dispatchEvent(new CustomEvent("steward-token-sync"));
+              } catch {
+                // error-policy:J6 best-effort nudge — the poll re-reads anyway.
+              }
+            })
+            .catch(() => undefined);
+        }
         // A usable session can also LAND after this mount without any
         // elizaCloudConnected flip: the native storage bridge hydrates the
         // durable token from Capacitor Preferences asynchronously, and a web

--- a/packages/ui/src/state/cloud-siwe-login.test.ts
+++ b/packages/ui/src/state/cloud-siwe-login.test.ts
@@ -198,6 +198,23 @@ describe("e2e wallet + SIWE login", () => {
     expect((window as { ethereum?: unknown }).ethereum).toBe(sentinel);
   });
 
+  it("ignores Phantom's window.ethereum injection (never SIWE with Phantom)", () => {
+    // Phantom multichain-injects window.ethereum with isPhantom:true; treating
+    // it as an EVM SIWE provider pops Phantom on a non-wallet sign-in (the
+    // "picked Google, got Phantom" bug). It must read as no injected provider.
+    (window as { ethereum?: unknown }).ethereum = {
+      isPhantom: true,
+      request: async () => [],
+    };
+    expect(getInjectedEthereumProvider()).toBeNull();
+  });
+
+  it("returns a genuine (non-Phantom) injected EVM provider", () => {
+    const metamask = { isMetaMask: true, request: async () => [] };
+    (window as { ethereum?: unknown }).ethereum = metamask;
+    expect(getInjectedEthereumProvider()).toBe(metamask);
+  });
+
   it("completes the full SIWE handshake with a REAL recoverable signature and stores the session", async () => {
     window.localStorage.setItem(E2E_WALLET_KEY_STORAGE_KEY, PRIVATE_KEY);
     await installE2eWalletIfRequested();

--- a/packages/ui/src/state/cloud-siwe-login.ts
+++ b/packages/ui/src/state/cloud-siwe-login.ts
@@ -31,6 +31,8 @@ export interface InjectedEthereumProvider {
   }): Promise<unknown>;
   /** Set by the e2e test wallet so harness-only behavior can identify it. */
   isElizaE2eWallet?: boolean;
+  /** Phantom multichain-injects itself as window.ethereum; never SIWE with it. */
+  isPhantom?: boolean;
 }
 
 export function getInjectedEthereumProvider(): InjectedEthereumProvider | null {
@@ -41,6 +43,10 @@ export function getInjectedEthereumProvider(): InjectedEthereumProvider | null {
     typeof provider === "object" &&
     typeof (provider as InjectedEthereumProvider).request === "function"
   ) {
+    // Phantom injects window.ethereum (isPhantom:true) but is a Solana wallet;
+    // treating it as an EVM SIWE provider pops Phantom on a non-wallet sign-in.
+    // Mirrors the /login wallet-buttons guard (wallet-buttons.tsx).
+    if ((provider as InjectedEthereumProvider).isPhantom === true) return null;
     return provider as InjectedEthereumProvider;
   }
   return null;

--- a/packages/ui/src/state/startup-phase-restore.ts
+++ b/packages/ui/src/state/startup-phase-restore.ts
@@ -8,6 +8,7 @@
 import { logger } from "@elizaos/logger";
 import {
   clearStoredStewardToken,
+  hasStewardAuthedCookie,
   readStoredStewardToken,
   writeStoredStewardToken,
 } from "@elizaos/shared/steward-session-client";
@@ -339,7 +340,40 @@ function resolveRestoreStewardRefreshEndpoint(): string | undefined {
  */
 async function resolveRestoredStewardToken(): Promise<string | null> {
   const stored = readStoredStewardToken()?.trim();
-  if (!stored) return null;
+  if (!stored) {
+    // No app-origin token, but the shared, HttpOnly .elizacloud.ai session
+    // cookie is present — the user signed in on the console (or another
+    // *.elizacloud.ai tab). Recover the access token from it (bounded, same as
+    // the /login page) instead of forcing a redundant re-sign-in; on success
+    // the top-level LoginView gate and the first-run conductor both skip.
+    if (typeof window !== "undefined" && hasStewardAuthedCookie()) {
+      let cookieTimeout: ReturnType<typeof setTimeout> | undefined;
+      const recovered = await Promise.race([
+        // error-policy:J4 a failed cookie refresh falls through to
+        // unauthenticated restore (sign-in wall), never fabricates a session.
+        refreshCloudStewardSession({
+          endpoint: resolveRestoreStewardRefreshEndpoint(),
+        }).catch(() => null),
+        new Promise<null>((resolve) => {
+          cookieTimeout = setTimeout(
+            () => resolve(null),
+            STEWARD_RESTORE_REFRESH_TIMEOUT_MS,
+          );
+        }),
+      ]);
+      if (cookieTimeout) clearTimeout(cookieTimeout);
+      if (recovered?.token) {
+        writeStoredStewardToken(recovered.token);
+        try {
+          window.dispatchEvent(new CustomEvent("steward-token-sync"));
+        } catch {
+          // error-policy:J6 best-effort nudge — listeners re-read next tick.
+        }
+        return recovered.token;
+      }
+    }
+    return null;
+  }
   const secs = cloudTokenSecsRemaining(stored);
   // Opaque/device-code token (no decodable `exp`) → nothing to refresh.
   if (secs === null) return stored;

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -494,14 +494,19 @@ export function useCloudState({
       };
       elizaCloudLoginCompletionRef.current = loginCompletion;
 
-      // Wallet SIWE (#13377): an injected EIP-1193 provider (a real browser
-      // wallet, or the e2e harness wallet on devices) signs in with a genuine
-      // EIP-4361 handshake against the cloud API — no browser round trip, no
-      // human beyond the wallet's own approval. Taken only when a provider is
-      // actually injected AND no still-usable session exists; a rejection or
-      // handshake failure falls through to the other sign-in paths on the
-      // same click.
-      if (!hasUsableStoredStewardToken() && getInjectedEthereumProvider()) {
+      // Zero-interaction wallet SIWE (#13377) is the E2E HARNESS path ONLY.
+      // A real browser wallet (Phantom, MetaMask, …) injects window.ethereum
+      // too, so taking this branch for any injected provider auto-pops the
+      // user's wallet the instant they click "Sign in with Eliza Cloud" —
+      // even when they meant to pick Google — and leaves the pre-opened
+      // popup blank (the "white page"). Real wallet sign-in is an EXPLICIT
+      // choice behind the /login page's EVM/Solana buttons; only the harness
+      // wallet (isElizaE2eWallet, packages/ui/src/platform/e2e-wallet.ts, which
+      // by its own gates never installs on deployed web) may sign in headlessly.
+      if (
+        !hasUsableStoredStewardToken() &&
+        getInjectedEthereumProvider()?.isElizaE2eWallet === true
+      ) {
         const siweBase =
           getBootConfig().cloudApiBase ?? "https://elizacloud.ai";
         try {

--- a/packages/ui/src/styles/base.css
+++ b/packages/ui/src/styles/base.css
@@ -524,7 +524,10 @@ body.pwa-standalone * {
 
 .theme-cloud {
   --bg: var(--brand-black);
-  --bg-accent: rgba(255, 255, 255, 0.04);
+  /* Skeleton blocks (`animate-pulse bg-bg-accent`) were near-invisible on the
+     black console at 0.04 — the pulse read as "broken/frozen". 0.08 makes the
+     loading state legibly animate. */
+  --bg-accent: rgba(255, 255, 255, 0.08);
   --bg-elevated: rgba(255, 255, 255, 0.04);
   --bg-hover: rgba(255, 255, 255, 0.08);
   --bg-muted: rgba(255, 255, 255, 0.06);


### PR DESCRIPTION
Follow-up to #15081: the cookie-recovery covered the restore path only; a fresh browser goes through the first-run conductor and still saw the sign-in greeting despite a valid shared `.elizacloud.ai` session cookie.

Kick the bounded cookie refresh in the conductor's no-token branch; the existing 500ms token poll then upgrades to welcome-back and auto-resumes into the user's agent (reuse newest running / provision when none) — exactly the expected already-signed-in behavior.

Route reachability verified from the app origin: `POST /api/auth/steward-refresh` with a browser Origin → 401 `missing_token` (origin gate passed) on app-staging / app / staging hosts. Typecheck clean. Rendered staging SSO E2E to follow once deployed.