### PR TITLE
fix(ui): annotate intentional viewport-unit fallbacks for biome

### DIFF
--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -141,7 +141,10 @@ body.pwa-standalone {
      top + height driving the box, a leftover `bottom: 0` would re-anchor the
      fixed body to the collapsed layout-viewport bottom — the exact bug. */
   bottom: auto;
+  /* Progressive vh→dvh→lvh viewport fallback: older engines use vh, newer
+     override with dvh then lvh. The duplicate `height` is intentional. */
   height: 100vh;
+  /* biome-ignore lint/suspicious/noDuplicateProperties: progressive viewport fallback (vh→dvh→lvh). */
   height: 100dvh;
   height: 100lvh;
   /* BOTTOM-BAR FIX (r4): TRANSPARENT floor. The prior "defensive" warm-ember
@@ -174,6 +177,7 @@ body.pwa-standalone {
 body.native #root,
 body.pwa-standalone #root {
   min-height: 100vh;
+  /* biome-ignore lint/suspicious/noDuplicateProperties: progressive viewport fallback (vh→dvh→lvh). */
   min-height: 100dvh;
   min-height: 100lvh;
   max-height: 100vh;
@@ -193,6 +197,7 @@ body.pwa-standalone #root {
 body.native [data-app-shell-root],
 body.pwa-standalone [data-app-shell-root] {
   height: 100vh;
+  /* biome-ignore lint/suspicious/noDuplicateProperties: progressive viewport fallback (vh→dvh→lvh). */
   height: 100dvh;
   height: 100lvh;
 }
@@ -227,6 +232,7 @@ body.pwa-standalone textarea {
        body to the collapsed layout-viewport bottom — the #14319 bug. */
     bottom: auto;
     height: 100vh;
+    /* biome-ignore lint/suspicious/noDuplicateProperties: progressive viewport fallback (vh→dvh→lvh). */
     height: 100dvh;
     height: 100lvh;
     /* BOTTOM-BAR FIX (r4): TRANSPARENT floor (mirror of the class-path rule).
@@ -247,6 +253,7 @@ body.pwa-standalone textarea {
      100vh→100dvh→100lvh progressive-enhancement stack the body uses. */
   body #root {
     min-height: 100vh;
+    /* biome-ignore lint/suspicious/noDuplicateProperties: progressive viewport fallback (vh→dvh→lvh). */
     min-height: 100dvh;
     min-height: 100lvh;
     max-height: 100vh;
@@ -264,6 +271,7 @@ body.pwa-standalone textarea {
      column reaches the physical screen edge, full-bleed. */
   body [data-app-shell-root] {
     height: 100vh;
+    /* biome-ignore lint/suspicious/noDuplicateProperties: progressive viewport fallback (vh→dvh→lvh). */
     height: 100dvh;
     height: 100lvh;
   }


### PR DESCRIPTION
## Problem

`biome check packages/ui/src` fails on `develop` (exit 1) — confirmed pre-existing on clean `origin/develop`. Root cause: `packages/ui/src/styles/styles.css` declares `height` / `min-height` / `max-height` three times per rule as a progressive-enhancement viewport fallback:

```css
height: 100vh;   /* engines without dvh/lvh keep this */
height: 100dvh;  /* dynamic viewport */
height: 100lvh;  /* large viewport — final override */
```

Biome's `lint/suspicious/noDuplicateProperties` flags each group as a duplicate-property **error** (6 errors), so the whole `biome check` gate goes red for everyone.

This is a **valid** fallback, not a bug — older browsers fall back to `vh`, newer ones use `dvh`/`lvh`.

## Fix

Scoped `// biome-ignore lint/suspicious/noDuplicateProperties: progressive viewport fallback (vh→dvh→lvh).` on the first overriding declaration of each of the 6 fallback groups (option (a): scoped-ignore-with-reason — minimal and honest). One suppression covers the whole `vh→dvh→lvh` group since biome reports only the first duplicate per property.

No behavior change (comment-only). No blanket rule disable in `biome.json`.

## Verification

- `bunx @biomejs/biome check packages/ui/src` → **exit 0** (was exit 1 on develop).
- Original develop `styles.css` → `biome check` exit 1; patched → exit 0.
- Every added suppression is used (no `suppressions/unused`); the 2 speculative `max-height` suppressions I first added were removed once biome confirmed only the first duplicated property per block is reported.
- Sibling CSS (`base.css`, `brand-gold.css`) checked — no `noDuplicateProperties` there.

Remaining `noDescendingSpecificity` warnings in the file are **pre-existing, non-blocking** (warnings, not errors — `biome check` exits 0 with them) and out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)