### PR TITLE
fix(core): bound the room entity slice and merged prompt in post-turn evaluation

### DIFF
--- a/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.test.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.test.ts
@@ -7,13 +7,18 @@
 import { describe, expect, it, vi } from "vitest";
 import { logger } from "../../../logger.ts";
 import type {
+	Entity,
 	EvaluatorProcessorContext,
 	IAgentRuntime,
 	Memory,
 	UUID,
 } from "../../../types/index.ts";
 import { parseExtractorOutputTolerant } from "./factExtractor.schema.ts";
-import { factMemoryEvaluator } from "./reflection-items.ts";
+import {
+	factMemoryEvaluator,
+	REFLECTION_ENTITY_LIMIT,
+	relationshipEvaluator,
+} from "./reflection-items.ts";
 
 const agentId = "00000000-0000-0000-0000-0000000000aa" as UUID;
 const entityId = "00000000-0000-0000-0000-0000000000bb" as UUID;
@@ -361,5 +366,119 @@ describe("factExtractor tolerant parsing (#11235)", () => {
 		expect(parseExtractorOutputTolerant(null)).toBeNull();
 		// An empty ops array is a VALID (zero-op) turn, not a parse failure.
 		expect(parseExtractorOutputTolerant({ ops: [] })).toEqual({ ops: [] });
+	});
+});
+
+describe("reflection context bounds the room entity slice (#15087)", () => {
+	const authorId = "00000000-0000-0000-0000-0000000000cf" as UUID;
+
+	function subAgentEntityId(index: number): UUID {
+		return `00000000-0000-0000-0001-${String(index).padStart(12, "0")}` as UUID;
+	}
+
+	// Names are chosen so the human participants sort AFTER every sub-agent
+	// entity — getEntityDetails returns the room alphabetically, so a naive
+	// slice would drop exactly the entities the extractors need.
+	function roomEntities(subAgentCount: number): Entity[] {
+		const entities: Entity[] = [
+			{ id: agentId, agentId, names: ["zed-agent"], metadata: {} },
+			{ id: entityId, agentId, names: ["zoe-sender"], metadata: {} },
+			{ id: authorId, agentId, names: ["yuki-author"], metadata: {} },
+		];
+		for (let index = 0; index < subAgentCount; index += 1) {
+			entities.push({
+				id: subAgentEntityId(index),
+				agentId,
+				names: [
+					`sub-agent: Build and deploy web app number ${index} — ${"with detailed task requirements ".repeat(16)}`,
+				],
+				metadata: {},
+			});
+		}
+		return entities;
+	}
+
+	function contextRuntime(entities: Entity[]): IAgentRuntime {
+		return {
+			agentId,
+			getMemories: vi.fn(async () => [
+				{
+					id: "00000000-0000-0000-0000-0000000000d1" as UUID,
+					entityId,
+					agentId,
+					roomId,
+					content: { text: "can you check the weather for me?" },
+					createdAt: 1,
+				},
+				{
+					id: "00000000-0000-0000-0000-0000000000d2" as UUID,
+					entityId: authorId,
+					agentId,
+					roomId,
+					content: { text: "ping me when it's done" },
+					createdAt: 2,
+				},
+			]),
+			getRelationships: vi.fn(async () => []),
+			getRoom: vi.fn(async () => null),
+			getEntitiesForRoom: vi.fn(async () => entities),
+		} as unknown as IAgentRuntime;
+	}
+
+	async function prepareContext(runtime: IAgentRuntime) {
+		const prepared = await relationshipEvaluator.prepare?.({
+			runtime,
+			message: message(),
+			state: { values: {}, data: {}, text: "" },
+			options: {},
+		});
+		if (!prepared) throw new Error("relationship prepare returned nothing");
+		return prepared;
+	}
+
+	it("keeps conversation participants and caps the remainder in an entity-flooded room", async () => {
+		// 850 sub-agent entities observed live; 400 is just as far past the cap.
+		const runtime = contextRuntime(roomEntities(400));
+		const prepared = await prepareContext(runtime);
+
+		expect(prepared.entities).toHaveLength(REFLECTION_ENTITY_LIMIT);
+		const keptIds = new Set(prepared.entities.map((entity) => entity.id));
+		expect(keptIds.has(agentId)).toBe(true);
+		expect(keptIds.has(entityId)).toBe(true);
+		expect(keptIds.has(authorId)).toBe(true);
+		// Participants lead the slice; the sub-agent flood fills the remainder.
+		expect(
+			prepared.entities
+				.slice(0, 3)
+				.map((entity) => entity.id)
+				.sort(),
+		).toEqual([agentId, entityId, authorId].sort());
+	});
+
+	it("renders a bounded Entities-in-Room block into the relationships prompt", async () => {
+		const runtime = contextRuntime(roomEntities(400));
+		const prepared = await prepareContext(runtime);
+
+		const prompt = relationshipEvaluator.prompt({
+			runtime,
+			message: message(),
+			state: { values: {}, data: {}, text: "" },
+			options: {},
+			evaluatorName: "relationships",
+			prepared,
+		});
+		// Pre-fix, 400 entities with ~550-char task-description names rendered a
+		// ~220KB block; the slice cap + per-line name bound keep the whole section
+		// prompt-sized for the TEXT_SMALL tier.
+		expect(prompt.length).toBeLessThan(20_000);
+		expect(prompt).toContain("…[truncated]");
+		expect(prompt).toContain(entityId);
+	});
+
+	it("passes rooms under the cap through untouched", async () => {
+		const entities = roomEntities(3);
+		const runtime = contextRuntime(entities);
+		const prepared = await prepareContext(runtime);
+		expect(prepared.entities).toHaveLength(entities.length);
 	});
 });

--- a/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts
+++ b/packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts
@@ -425,12 +425,60 @@ export function formatRecentMessages(memories: Memory[]): string {
 	return lines.length > 0 ? lines.join("\n") : "(none)";
 }
 
+// A room's entity table grows without bound — the sub-agent orchestration path
+// registers one permanent entity per spawned coding session, and busy rooms
+// accumulate hundreds (850 of 861 observed live, #15087). The relationships and
+// identities sections each render this list into the ONE merged post-turn
+// TEXT_SMALL call, so an unbounded list eventually exceeds the small model's
+// context and every evaluation in the room 400s (~220KB of a 310KB failing
+// prompt was the entity list, twice). Extraction only needs entities that can
+// be evidenced in the recent-message window, so conversation participants are
+// kept first and the remainder (name-only reference candidates) is capped. The
+// main-context entities provider (entities.ts) applies the same display-cap
+// discipline.
+export const REFLECTION_ENTITY_LIMIT = 50;
+// An entity name is name-scale; a sub-agent session entity carries its whole
+// task description as its name. Bound each rendered line so one entity cannot
+// dominate the prompt.
+const ENTITY_NAMES_RENDER_MAX_CHARS = 240;
+
+function boundRender(text: string, maxChars: number): string {
+	if (text.length <= maxChars) return text;
+	return `${text.slice(0, maxChars)}…[truncated]`;
+}
+
+function boundReflectionEntities(params: {
+	entities: Entity[];
+	agentId: UUID;
+	message: Memory;
+	recentMessages: Memory[];
+}): Entity[] {
+	const { entities, agentId, message, recentMessages } = params;
+	if (entities.length <= REFLECTION_ENTITY_LIMIT) return entities;
+	const participantIds = new Set<string>([agentId]);
+	if (message.entityId) participantIds.add(message.entityId);
+	for (const recent of recentMessages) {
+		if (recent.entityId) participantIds.add(recent.entityId);
+	}
+	const participants: Entity[] = [];
+	const others: Entity[] = [];
+	for (const entity of entities) {
+		if (entity.id && participantIds.has(entity.id)) {
+			participants.push(entity);
+		} else {
+			others.push(entity);
+		}
+	}
+	return [...participants, ...others].slice(0, REFLECTION_ENTITY_LIMIT);
+}
+
 function formatEntities(entities: Entity[]): string {
 	if (entities.length === 0) return "(none)";
 	return entities
 		.map((entity) => {
 			const names = Array.isArray(entity.names) ? entity.names.join(", ") : "";
-			return `- ${names || "unknown"} (ID: ${entity.id ?? "unknown"})`;
+			const bounded = boundRender(names, ENTITY_NAMES_RENDER_MAX_CHARS);
+			return `- ${bounded || "unknown"} (ID: ${entity.id ?? "unknown"})`;
 		})
 		.join("\n");
 }
@@ -479,7 +527,16 @@ async function prepareReflectionContext(
 	const recentMessages = recentMessagesRaw.filter(
 		(memory) => !isSyntheticConversationArtifactMemory(memory),
 	);
-	return { recentMessages, existingRelationships, entities };
+	return {
+		recentMessages,
+		existingRelationships,
+		entities: boundReflectionEntities({
+			entities,
+			agentId,
+			message,
+			recentMessages,
+		}),
+	};
 }
 
 async function prepareFacts(

--- a/packages/core/src/services/evaluator.test.ts
+++ b/packages/core/src/services/evaluator.test.ts
@@ -14,7 +14,7 @@ import {
 	type Memory,
 	ModelType,
 } from "../types";
-import { EvaluatorService } from "./evaluator";
+import { EVALUATOR_PROMPT_MAX_CHARS, EvaluatorService } from "./evaluator";
 
 function makeRuntime(): AgentRuntime {
 	const runtime = new AgentRuntime({
@@ -520,5 +520,58 @@ describe("EvaluatorService", () => {
 		expect(useModel).toHaveBeenCalledTimes(5);
 		expect(useModel.mock.calls[2]?.[1]).toHaveProperty("responseSchema");
 		expect(useModel.mock.calls[3]?.[1]).toHaveProperty("responseSchema");
+	});
+
+	it("fails fast without any model call when the merged prompt exceeds the size cap (#15087)", async () => {
+		const runtime = makeRuntime();
+
+		runtime.registerEvaluator({
+			name: "small",
+			description: "well-behaved section",
+			schema: schema(),
+			shouldRun: async () => true,
+			prompt: () => "Extract small.",
+			parse: (output) => output as never,
+			processors: [
+				{ name: "storeSmall", process: async () => ({ success: true }) },
+			],
+		});
+		runtime.registerEvaluator({
+			name: "runaway",
+			description: "section with an unbounded context block",
+			schema: schema(),
+			shouldRun: async () => true,
+			prompt: () => "x".repeat(EVALUATOR_PROMPT_MAX_CHARS + 1),
+			parse: (output) => output as never,
+			processors: [
+				{ name: "storeRunaway", process: async () => ({ success: true }) },
+			],
+		});
+
+		const useModel = vi.fn();
+		runtime.useModel = useModel as AgentRuntime["useModel"];
+
+		const result = await new EvaluatorService(runtime).run(makeMessage());
+
+		// The oversized prompt is guaranteed to fail on the TEXT_SMALL tier —
+		// the guard must spend zero model round-trips (the pre-guard behavior
+		// burned three: schema, json_object, plain).
+		expect(useModel).not.toHaveBeenCalled();
+		expect(result.skipped).toBe(false);
+		expect(result.processedEvaluators).toEqual([]);
+		expect(result.results).toEqual([]);
+		expect(result.errors).toEqual([
+			{
+				evaluatorName: "post_turn",
+				error: expect.stringContaining("exceeds") as unknown as string,
+			},
+		]);
+		expect(runtime.emitEvent).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({
+				evaluatorName: "post_turn",
+				completed: false,
+			}),
+		);
 	});
 });

--- a/packages/core/src/services/evaluator.ts
+++ b/packages/core/src/services/evaluator.ts
@@ -96,13 +96,24 @@ function buildMergedSchema(active: PreparedEntry[]): JSONSchema {
 	};
 }
 
+// Every input to the merged prompt is count- and render-bounded upstream
+// (recent-message window, fact lookback, reflection entity slice, relationship
+// render), so a healthy merged prompt stays far under this cap. A prompt beyond
+// it means some section regressed to unbounded growth, and the TEXT_SMALL tier
+// this call targets cannot hold it anyway — the call is guaranteed to fail
+// (observed live: a 310KB merged prompt 400-ing 3× per turn, every turn, in a
+// room whose entity table had grown to 861 rows, #15087). The guard turns that
+// failure mode into one diagnosable log line with per-section sizes instead of
+// three doomed model round-trips per turn.
+export const EVALUATOR_PROMPT_MAX_CHARS = 120_000;
+
 function buildPrompt(params: {
 	runtime: IAgentRuntime;
 	message: Memory;
 	state: State;
 	active: PreparedEntry[];
 	options: EvaluatorRunOptions;
-}): string {
+}): { prompt: string; sectionChars: Record<string, number> } {
 	const { runtime, message, state, active, options } = params;
 	const agentName = runtime.character.name ?? "Agent";
 	const latestMessage = message.content.text ?? "";
@@ -117,27 +128,31 @@ function buildPrompt(params: {
 		: undefined;
 	const providerContext = state.text.trim() || "(none)";
 
-	const evaluatorSections = active
-		.map(({ evaluator, prepared }) => {
-			const section = evaluator.prompt({
-				runtime,
-				message,
-				state,
-				options,
-				prepared,
-			});
-			return [
+	const sections = active.map(({ evaluator, prepared }) => {
+		const section = evaluator.prompt({
+			runtime,
+			message,
+			state,
+			options,
+			prepared,
+		});
+		return {
+			name: evaluator.name,
+			text: [
 				`### ${evaluator.name}`,
 				evaluator.description,
 				"",
 				section,
 				"",
 				`Put result under "${evaluator.name}".`,
-			].join("\n");
-		})
+			].join("\n"),
+		};
+	});
+	const evaluatorSections = sections
+		.map((section) => section.text)
 		.join("\n\n");
 
-	return `# Task: Post-turn evaluation
+	const prompt = `# Task: Post-turn evaluation
 
 Evaluate just-finished turn for ${agentName}.
 
@@ -169,6 +184,16 @@ ${providerContext}
 
 ${evaluatorSections}
 `;
+	// The shared entry covers everything outside the evaluator sections (latest
+	// message, agent responses, action results, provider context) so a blowup
+	// there is attributable too.
+	const sectionChars: Record<string, number> = {
+		shared: prompt.length - evaluatorSections.length,
+	};
+	for (const section of sections) {
+		sectionChars[section.name] = section.text.length;
+	}
+	return { prompt, sectionChars };
 }
 
 // Schema-SPECIFIC rejection tokens: a HIGH-CONFIDENCE signal that the provider
@@ -718,13 +743,29 @@ export class EvaluatorService extends BaseService {
 				}),
 			);
 
-		const prompt = buildPrompt({
+		const { prompt, sectionChars } = buildPrompt({
 			runtime: this.runtime,
 			message,
 			state: composedState,
 			active: preparedEntries,
 			options,
 		});
+		if (prompt.length > EVALUATOR_PROMPT_MAX_CHARS) {
+			const failure = `Merged evaluator prompt is ${prompt.length} chars and exceeds the ${EVALUATOR_PROMPT_MAX_CHARS}-char cap; skipped the doomed TEXT_SMALL call`;
+			this.runtime.logger.error(
+				{
+					src: "service:evaluator",
+					agentId: this.runtime.agentId,
+					roomId: message.roomId,
+					promptChars: prompt.length,
+					maxChars: EVALUATOR_PROMPT_MAX_CHARS,
+					sectionChars,
+				},
+				"Merged evaluator prompt exceeds the size cap — a section has grown unbounded; post-turn evaluation skipped for this turn",
+			);
+			await this.emitEvaluatorCompleted(evaluatorId, false, new Error(failure));
+			return this.failedResult({ preparedEntries, errors, error: failure });
+		}
 		const schema = buildMergedSchema(preparedEntries);
 		const { output, error } = await this.readEvaluatorOutput({
 			evaluatorId,


### PR DESCRIPTION
Fixes #15087

## Root cause

A room's entity table grows without bound — the sub-agent orchestration path registers one **permanent entity per spawned coding session** (`plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts`, needed for the `memories.entity_id` FK on relay memories), and nothing ever removes them. A live room had **861 entities, 850 of them `sub-agent: <task…>`**.

`prepareReflectionContext` (`packages/core/src/features/advanced-capabilities/evaluators/reflection-items.ts`) fetches **all** of them via `getEntityDetails`, and the `relationships` + `identities` evaluator sections each render the full list into the ONE merged post-turn `TEXT_SMALL` call (`packages/core/src/services/evaluator.ts`). Measured live: **~220KB of a 310KB failing prompt was the entity list, twice**. The call 400s on any small-context `TEXT_SMALL` (Eliza Cloud `gemma-4-31b` observed), and the schema → `json_object` → plain fallback ladder re-sends the *same* oversized prompt twice more:

```
[RF400-DEBUG] route=chat/completions status=400 model=gemma-4-31b toolCount=0 messages=[{"role":"system","contentLen":7019},{"role":"user","contentLen":312492}] params={"model":"gemma-4-31b","max_tokens":8192,"temperature":0}
[RF400-DEBUG] route=chat/completions responseBody={"error":{"message":"Bad Request","type":"invalid_request_error"}}
```

Three doomed ~310KB round-trips per turn, every turn; every trajectory in the room ends `status: "errored"`; fact/relationship/identity/success extraction silently dead for the room.

## Fix (structural, at the caller — no wire-layer trim)

1. **`prepareReflectionContext` bounds the entity slice** (`REFLECTION_ENTITY_LIMIT = 50`): conversation participants (message sender, agent, recent-message authors) are kept first — `getEntityDetails` returns the room alphabetically, so a naive slice would drop exactly the entities the extractors need — and the remainder (name-only reference candidates) fills up to the cap. Rooms under the cap pass through untouched. This matches the evaluators' own semantics (extract only what the recent conversation evidences) and the display-cap discipline the main-context entities provider (`entities.ts`, `MAX_ENTITY_DISPLAY_COUNT`) already applies.
2. **`formatEntities` bounds each rendered line** — a sub-agent entity's name is an entire task description.
3. **`EvaluatorService` fails fast when the merged prompt exceeds `EVALUATOR_PROMPT_MAX_CHARS` (120K)**: one `logger.error` with per-section char sizes + a failed run result, zero model calls — instead of three guaranteed-400 round-trips per turn. Every legitimate input is already count- and render-bounded far below the cap, so tripping it means a section regressed to unbounded growth, and the log line names which one.

## Tests

`packages/core`: 4 new tests (23 pass total in the two touched files, full suite green):

- entity-flooded room (400 sub-agent entities): slice capped at 50, sender/agent/recent-author survive and lead the slice;
- the rendered `relationships` prompt stays <20KB (pre-fix: ~200KB+) with per-line truncation;
- rooms under the cap pass through untouched;
- `EvaluatorService.run` with an oversized merged prompt: `useModel` never called, `post_turn` error surfaced, `EVALUATOR_COMPLETED(completed:false)` emitted.

`bun run --cwd packages/core typecheck` clean, biome clean on touched files.

## Follow-up (kept out of scope)

Sub-agent entity lifecycle: one permanent room entity per spawned session also pollutes other entities-in-room consumers (e.g. `findEntityByName` resolution prompts). Tracked in #15087 discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - backend-only core runtime change (post-turn evaluator model call); no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - backend-only core runtime change; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user-visible flow; the change is in the post-turn TEXT_SMALL evaluation call. Live before/after behavior is captured in the evidence comment: https://github.com/elizaOS/eliza/pull/15091#issuecomment-4896090779
<!-- evidence-row:backend-logs -->
- [x] Backend logs: pre-fix 400x3 wire capture + post-fix clean-call logs and measured 92,481-byte bounded prompt (was 310-338KB) — https://github.com/elizaOS/eliza/pull/15091#issuecomment-4896090779
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend surface touched.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: pre-fix errored trajectory (tj-5eaefcd6add3a4, status=errored on a trivial turn) vs post-fix finished trajectory (tj-954b6d42e5847f, status=finished, reply "4") from the live agent in the same 861-entity room — https://github.com/elizaOS/eliza/pull/15091#issuecomment-4896090779
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: measured room entity table (861 entities, 850 sub-agent) and the dumped merged evaluator prompt before (310,627-338,454 bytes, 861-line entity blocks x2) and after (92,481 bytes, 50-line blocks) — https://github.com/elizaOS/eliza/pull/15091#issuecomment-4896090779
