### PR TITLE
fix(types): repair pre-existing develop typecheck errors (ui + agent)

### DIFF
--- a/packages/app-core/tsconfig.json
+++ b/packages/app-core/tsconfig.json
@@ -114,6 +114,7 @@
       "@elizaos/plugin-sql/__tests__/test-helpers": [
         "../../plugins/plugin-sql/src/__tests__/test-helpers.ts"
       ],
+      "@elizaos/plugin-sql/*": ["../../plugins/plugin-sql/src/*"],
       "@elizaos/auth": ["../auth/src/index.ts"],
       "@elizaos/auth/*": ["../auth/src/*"],
       "@elizaos/shared": ["../shared/src/index.ts"],

--- a/plugins/plugin-capacitor-bridge/tsconfig.json
+++ b/plugins/plugin-capacitor-bridge/tsconfig.json
@@ -14,7 +14,6 @@
 		"outDir": "./dist",
 		"rootDir": "../../../",
 		"lib": ["ES2022", "DOM", "DOM.Iterable"],
-		"jsx": "react-jsx",
 		"types": ["node", "bun"],
 		"allowImportingTsExtensions": true,
 		"rewriteRelativeImportExtensions": true,

--- a/plugins/plugin-capacitor-bridge/tsconfig.json
+++ b/plugins/plugin-capacitor-bridge/tsconfig.json
@@ -14,6 +14,7 @@
 		"outDir": "./dist",
 		"rootDir": "../../../",
 		"lib": ["ES2022", "DOM", "DOM.Iterable"],
+		"jsx": "react-jsx",
 		"types": ["node", "bun"],
 		"allowImportingTsExtensions": true,
 		"rewriteRelativeImportExtensions": true,

--- a/turbo.json
+++ b/turbo.json
@@ -411,6 +411,10 @@
       "outputs": []
     },
     "@elizaos/plugin-calendar#typecheck": {
+      "dependsOn": [
+        "@elizaos/import-conversations#build",
+        "@elizaos/plugin-inbox#build"
+      ],
       "outputs": []
     },
     "@elizaos/plugin-personal-assistant#typecheck": {

--- a/turbo.json
+++ b/turbo.json
@@ -454,7 +454,14 @@
       "outputs": []
     },
     "@elizaos/plugin-capacitor-bridge#typecheck": {
-      "dependsOn": ["@elizaos/core#build", "@elizaos/shared#build", "^build"],
+      "dependsOn": [
+        "@elizaos/core#build",
+        "@elizaos/shared#build",
+        "@elizaos/plugin-streaming#build",
+        "@elizaos/plugin-elizacloud#build",
+        "@elizaos/plugin-inbox#build",
+        "^build"
+      ],
       "outputs": []
     },
     "@elizaos/example-autonomous#typecheck": {

--- a/turbo.json
+++ b/turbo.json
@@ -374,6 +374,7 @@
         "@elizaos/app-core#build",
         "@elizaos/plugin-agent-skills#build",
         "@elizaos/plugin-app-manager#build",
+        "@elizaos/plugin-inbox#build",
         "@elizaos/plugin-task-coordinator#build"
       ],
       "outputs": []
@@ -383,6 +384,7 @@
         "@elizaos/core#build",
         "@elizaos/shared#build",
         "@elizaos/agent#build",
+        "@elizaos/plugin-inbox#build",
         "^build"
       ],
       "outputs": []
@@ -403,7 +405,7 @@
       "outputs": []
     },
     "@elizaos/plugin-discord#typecheck": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["@elizaos/plugin-inbox#build", "^build"],
       "outputs": []
     },
     "@elizaos/plugin-tailscale#typecheck": {
@@ -438,6 +440,7 @@
     "@elizaos/plugin-contacts#typecheck": {
       "dependsOn": [
         "@elizaos/capacitor-contacts#build",
+        "@elizaos/plugin-inbox#build",
         "@elizaos/ui#build",
         "^build"
       ],
@@ -545,7 +548,7 @@
       "outputs": []
     },
     "@elizaos/plugin-training#typecheck": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["@elizaos/plugin-inbox#build", "^build"],
       "outputs": []
     },
     "@elizaos/plugin-sub-agent-claude-code#typecheck": {
@@ -553,7 +556,7 @@
       "outputs": []
     },
     "@elizaos/plugin-local-inference#typecheck": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["@elizaos/plugin-inbox#build", "^build"],
       "outputs": []
     },
     "@elizaos/example-farcaster#build": {


### PR DESCRIPTION
## What

Clears the **Type Check** CI gate on `develop`. These errors were confirmed failing on clean `origin/develop`, blocking a green typecheck for everyone. Each is fixed at the root — corrected type, no `as any` / suppression-without-reason. Rebased onto current `develop` and extended to cover the errors that recent merges (project-switcher #14135, corpus-tools stack) introduced into the `turbo run typecheck --affected` set.

## Errors fixed (0 remaining across the affected packages)

| Site | Error | Root-cause fix |
| --- | --- | --- |
| `agent/src/api/message-corpus.ts:514` | TS2820 `"messages"` not a `MemoryType` | Genuine bug — memory metadata discriminator should be `MemoryType.MESSAGE` (singular). The `"messages"` **table-name** arg one line down is correct and unchanged. |
| `agent/.../conversation-seed-messages-route.test.ts` · `message-corpus-search.test.ts` | TS2352 `"dm"` not a `ChannelType` | Room `type` used lowercase `"dm"`; the enum member is `ChannelType.DM` (`"DM"`). The cast was masking it. Use the enum constant. |
| `ui/.../settings/settings-sections.ts:261` | TS2345 `string` → id union | `nonCatalogMeta` widened its param to `string`, breaking the typed `Map.get`. Type it to the id union derived from `SETTINGS_NON_CATALOG_SECTION_META`. |
| `ui/src/testing/__e2e__/widget-cert-fixture.tsx:17` | TS2459 `WidgetCertReport` not exported | Re-export the type (owned by `scroll-cert`) from `widget-cert.ts`, the report-producing layer the fixture imports from. |
| `ui/.../startup-phase-poll.test.ts:2027` | TS2322 `null` → `PersistedActiveServer` | Production `RestoringSessionCtx` always carries a non-null `restoredActiveServer`; "no session" is a `null` ctx. The partial-ctx-with-null-fields was an impossible state — pass `null` for the whole ctx (behaviorally identical, every read is `ctx?.`-guarded). |
| `ui/.../voice-selftest-harness.test.ts:186,192` | TS2352 partial Web Audio double | Cast partial `AudioContext`/`AudioBuffer` test doubles through `unknown`, matching precedent in `useVoiceChat.local-asr.test.tsx:117`. The test drives the early-bail suspended-context path. |
| `plugin-task-coordinator/src/index.ts:336` (via `plugin-capacitor-bridge#typecheck`) | TS6142 `ProjectSwitcher.tsx` — `--jsx` not set | #14135 re-exported the new `ProjectSwitcher.tsx` from `plugin-task-coordinator/src/index.ts`; capacitor-bridge maps that source barrel via tsconfig paths, so its program now compiles a `.tsx` but its tsconfig had no `jsx`. Add `"jsx": "react-jsx"` (react + `@types/react` already resolve; matches `packages/ui`). |
| `agent/src/api/*` (via `plugin-capacitor-bridge#typecheck`) | TS7016 / TS2307 `plugin-streaming` · `plugin-elizacloud/host-routes` · `plugin-inbox/plugin` dist missing | agent source (mapped to `@elizaos/agent/*`) imports those optional plugins, which are not capacitor-bridge deps, so `^build` never built their dist `.d.ts`. Add the three `#build`s to the turbo `typecheck` override, mirroring the sibling calendar / personal-assistant overrides. |
| `@elizaos/plugin-calendar#typecheck` | TS2307 `import-conversations` · `plugin-inbox` dist missing | The calendar override replaced the global `dependsOn` with an empty one so it built no dependencies, yet its tsconfig maps `@elizaos/ui/*` and `@elizaos/agent/*` to source. Give the override the two builds it needs. |

The `validation-keyword-data.ts` "cannot find module" errors on a fresh clone are **not** code failures — that file is gitignored and regenerated by `core` `prebuild` (`generate-keywords.mjs`); CI generates it before typecheck.

## Verification

Rebased onto current `origin/develop`. Every affected package typechecks clean:

```
$ bun run --cwd packages/ui typecheck
$ tsgo --noEmit -p tsconfig.json        # exit 0, 0 errors

$ bun run --cwd packages/agent typecheck
$ tsgo --noEmit -p tsconfig.json        # exit 0, 0 errors

$ bun run --cwd packages/corpus-tools typecheck
$ tsgo --noEmit -p tsconfig.json        # exit 0, 0 errors

$ bun run --cwd plugins/plugin-capacitor-bridge typecheck
$ tsgo --noEmit                         # exit 0, 0 errors
```

Full `turbo run typecheck --affected` is green on the rebased tree. The only local delta is a `hono@4.12.18`↔`4.12.27` / Stripe-apiVersion **node_modules version skew** in `packages/cloud/api` that this branch does not touch — it resolves to a single version on a clean CI install, where `@elizaos/cloud-api:typecheck` passes (verified in the prior CI run log).

## Evidence

Type-only + build-graph change — no runtime, UI, or agent-behavior surface. Every diff is a corrected type annotation, a type re-export, a tsconfig `jsx` flag, or a turbo build-dependency edge; no rendered output changes. Each row below is `N/A` with a reason.

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: `N/A - type-only + turbo/tsconfig build-graph change; no rendered UI surface changes.`

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: `N/A - type-only + turbo/tsconfig build-graph change; no rendered UI surface changes.`

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: `N/A - no user-exercisable behavior changes; the verifiable artifact is the typecheck output above.`

<!-- evidence-row:backend-logs -->
- [ ] Backend logs: `N/A - no runtime code path added or changed; the change is purely compile-time typing and build ordering.`

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: `N/A - no client runtime behavior changes; only compile-time types in packages/ui.`

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: `N/A - no agent/action/provider/prompt/model behavior changes; the message-corpus fix only corrects the seeded memory row discriminator to MemoryType.MESSAGE (table name unchanged).`

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: `N/A - produces no domain artifacts; the deliverable is a clean typecheck (0 errors) across the affected packages, shown above.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
