### PR TITLE
feat(ui): auto-seed demo notifications on dev boot (inline inbox active by default)

### DIFF
--- a/packages/ui/src/components/shell/notifications-boot.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.tsx
@@ -13,6 +13,7 @@ import { useAppSelector } from "../../state";
 import {
   initNotifications,
   registerNotificationToastSink,
+  seedDevNotificationsIfEmpty,
 } from "../../state/notifications/notification-store";
 import { initPushRegistration } from "../../state/notifications/push-registration";
 import { goHome } from "../../state/shell-surface-store";
@@ -27,6 +28,14 @@ export function NotificationsShellBoot(): null {
     // Native-only, gated on granted permission, guarded against double-register.
     // The token POST is what makes the server's APNs/FCM stack a live pipeline.
     void initPushRegistration();
+    // Dev builds only: paint the demo spread when the inbox is empty so the
+    // inline home notification surface is visible by default while developing.
+    // Prod bundles compile `import.meta.env.DEV` to false, so this is stripped.
+    try {
+      if (import.meta.env?.DEV) void seedDevNotificationsIfEmpty();
+    } catch {
+      // `import.meta.env` unavailable (non-Vite host) — treat as non-dev.
+    }
   }, []);
 
   // The single shared toast sink: interrupt-worthy notifications surface as

--- a/packages/ui/src/state/notifications/notification-store.test.ts
+++ b/packages/ui/src/state/notifications/notification-store.test.ts
@@ -12,6 +12,7 @@ const markNotificationReadApi = vi.fn();
 const markAllNotificationsReadApi = vi.fn();
 const removeNotificationApi = vi.fn();
 const clearNotificationsApi = vi.fn();
+const seedDevNotificationsApi = vi.fn();
 const onWsEvent = vi.fn();
 
 vi.mock("../../api/client", () => ({
@@ -23,6 +24,8 @@ vi.mock("../../api/client", () => ({
       markAllNotificationsReadApi(...args),
     removeNotification: (...args: unknown[]) => removeNotificationApi(...args),
     clearNotifications: (...args: unknown[]) => clearNotificationsApi(...args),
+    seedDevNotifications: (...args: unknown[]) =>
+      seedDevNotificationsApi(...args),
     onWsEvent: (...args: unknown[]) => onWsEvent(...args),
   },
 }));
@@ -49,6 +52,7 @@ import {
   markNotificationRead,
   registerNotificationToastSink,
   removeNotification,
+  seedDevNotificationsIfEmpty,
 } from "./notification-store";
 
 function makeNotification(
@@ -79,6 +83,10 @@ describe("notification-store", () => {
     markAllNotificationsReadApi.mockReset().mockResolvedValue({ changed: 0 });
     removeNotificationApi.mockReset().mockResolvedValue({ ok: true });
     clearNotificationsApi.mockReset().mockResolvedValue({ ok: true });
+    seedDevNotificationsApi.mockReset().mockResolvedValue({
+      count: 0,
+      notifications: [],
+    });
     onWsEvent.mockReset();
     invokeDesktopBridgeRequest.mockReset().mockResolvedValue(null);
     showNativeNotification.mockReset().mockResolvedValue("none");
@@ -444,5 +452,46 @@ describe("notification-store", () => {
     expect(__getStateForTests().notifications.every((n) => !n.readAt)).toBe(
       true,
     );
+  });
+
+  describe("seedDevNotificationsIfEmpty (dev default-active)", () => {
+    it("seeds the demo spread when the inbox hydrates empty", async () => {
+      const seeded = [
+        makeNotification({ id: "s1", priority: "urgent" }),
+        makeNotification({ id: "s2", priority: "normal", readAt: Date.now() }),
+      ];
+      seedDevNotificationsApi.mockResolvedValueOnce({
+        count: 2,
+        notifications: seeded,
+      });
+      await seedDevNotificationsIfEmpty();
+      expect(seedDevNotificationsApi).toHaveBeenCalledTimes(1);
+      expect(__getStateForTests().notifications).toHaveLength(2);
+      // Unread count is derived from the seeded rows (one is pre-read).
+      expect(__getStateForTests().unreadCount).toBe(1);
+    });
+
+    it("never seeds over a real inbox", async () => {
+      listNotifications.mockResolvedValueOnce({
+        notifications: [makeNotification({ id: "real" })],
+        unreadCount: 1,
+      });
+      await seedDevNotificationsIfEmpty();
+      expect(seedDevNotificationsApi).not.toHaveBeenCalled();
+      expect(__getStateForTests().notifications).toHaveLength(1);
+      expect(__getStateForTests().notifications[0]?.id).toBe("real");
+    });
+
+    it("runs at most once per session", async () => {
+      await seedDevNotificationsIfEmpty();
+      await seedDevNotificationsIfEmpty();
+      expect(seedDevNotificationsApi).toHaveBeenCalledTimes(1);
+    });
+
+    it("stays data-driven when the seed route 404s (no throw)", async () => {
+      seedDevNotificationsApi.mockRejectedValueOnce(new Error("404"));
+      await expect(seedDevNotificationsIfEmpty()).resolves.toBeUndefined();
+      expect(__getStateForTests().notifications).toHaveLength(0);
+    });
   });
 });

--- a/packages/ui/src/state/notifications/notification-store.ts
+++ b/packages/ui/src/state/notifications/notification-store.ts
@@ -317,6 +317,35 @@ export function initNotifications(): void {
   client.onWsEvent("agent_event", handleWsAgentEvent);
 }
 
+let devSeedAttempted = false;
+
+/**
+ * Dev-only: populate the demo spread when the inbox is empty so the home
+ * notification surface is visible by default while developing. The boot wiring
+ * calls this only in dev builds (`import.meta.env.DEV`); the server's
+ * `/dev/seed` route is itself non-production (404s in prod), so this stays a
+ * no-op outside dev. Runs at most once per session and never seeds over a real
+ * inbox — production is strictly data-driven.
+ */
+export async function seedDevNotificationsIfEmpty(): Promise<void> {
+  if (devSeedAttempted) return;
+  devSeedAttempted = true;
+  // Hydrate first so we only seed a genuinely-empty inbox, never over real rows.
+  if (!state.hydrated) await hydrate();
+  if (state.notifications.length > 0) return;
+  try {
+    const res = await client.seedDevNotifications();
+    setState({
+      notifications: res.notifications,
+      unreadCount: countUnread(res.notifications),
+      hydrated: true,
+    });
+  } catch {
+    // Prod 404s the seed route (or it is otherwise unavailable) — stay
+    // data-driven; a dev seed failure must never break boot.
+  }
+}
+
 /** Register the in-app toast sink (the app shell wires `setActionNotice`). */
 export function registerNotificationToastSink(sink: ToastSink | null): void {
   toastSink = sink;
@@ -411,6 +440,7 @@ export function useNotifications(): NotificationState {
 export function __resetNotificationStoreForTests(): void {
   state = { notifications: [], unreadCount: 0, hydrated: false };
   initialized = false;
+  devSeedAttempted = false;
   toastSink = null;
   listeners.clear();
 }


### PR DESCRIPTION
## Auto-seed demo notifications on dev boot (inline inbox active by default)

The home notification inbox is data-driven and self-hides when empty, so a fresh dev/desktop build shows nothing until a notification is produced — making the inline surface easy to miss while developing. This makes it **active by default in dev**.

### What changed
- **`notification-store`** — new `seedDevNotificationsIfEmpty()`: hydrates first, and only if the inbox is genuinely empty POSTs the server's non-production `/api/notifications/dev/seed` spread (urgent→low across approval/reminder/message/task/health/system/workflow) and paints it. Runs **at most once per session**, **never seeds over a real inbox**, and swallows failures (prod 404s the route).
- **`notifications-boot`** — calls it on boot **only in dev builds** (`import.meta.env.DEV`, wrapped in try/catch for non-Vite hosts). Prod bundles compile `DEV` to `false`, so it's stripped entirely.

Net effect: `bun run dev` / a dev desktop build now shows the notification inbox inline (under the clock, fading in) by default; **production stays strictly data-driven** — no demo data, no extra request.

### Tests
`notification-store.test.ts` — 4 new cases: seeds when empty, **never over a real inbox**, once-per-session, and stays data-driven when the seed route 404s (no throw). Full store suite **29 passed**; typecheck + biome clean.

### Manual verification
Restart the dev stack, then `curl -X POST http://127.0.0.1:<API_PORT>/api/notifications/dev/seed` also paints the same spread on demand.
