### PR TITLE
fix(lifeops): track brief engagement judgment

### DIFF
--- a/plugins/plugin-personal-assistant/src/actions/brief.ts
+++ b/plugins/plugin-personal-assistant/src/actions/brief.ts
@@ -33,6 +33,7 @@ import {
 } from "@elizaos/core";
 import { FinancesService } from "@elizaos/plugin-finances/finances-service";
 import { hasLifeOpsAccess } from "../lifeops/access.js";
+import { buildBriefEditorialContract } from "../lifeops/briefing/editorial-judgment.js";
 import {
   BRIEF_NARRATIVE_INSTRUCTIONS,
   MEETING_PREP_INSTRUCTIONS,
@@ -40,6 +41,7 @@ import {
 import type {
   LifeOpsBriefing,
   LifeOpsBriefingCalendarItem,
+  LifeOpsBriefingEditorialContract,
   LifeOpsBriefingInboxItem,
   LifeOpsBriefingKind,
   LifeOpsBriefingLifeItem,
@@ -470,6 +472,7 @@ export function buildNarrativePrompt(args: {
   kind: LifeOpsBriefingKind;
   period: LifeOpsBriefingPeriod;
   sections: LifeOpsBriefingSections;
+  editorial?: LifeOpsBriefingEditorialContract;
   runtime?: IAgentRuntime;
   optimizationTask?: BriefOptimizationTask;
 }): string {
@@ -478,6 +481,7 @@ export function buildNarrativePrompt(args: {
       kind: args.kind,
       period: args.period,
       sections: args.sections,
+      editorial: args.editorial,
     },
     null,
     2,
@@ -512,6 +516,7 @@ async function composeNarrative(args: {
   kind: LifeOpsBriefingKind;
   period: LifeOpsBriefingPeriod;
   sections: LifeOpsBriefingSections;
+  editorial: LifeOpsBriefingEditorialContract;
   optimizationTask: BriefOptimizationTask;
 }): Promise<string | undefined> {
   if (typeof args.runtime.useModel !== "function") {
@@ -521,6 +526,7 @@ async function composeNarrative(args: {
     kind: args.kind,
     period: args.period,
     sections: args.sections,
+    editorial: args.editorial,
     runtime: args.runtime,
     optimizationTask: args.optimizationTask,
   });
@@ -580,6 +586,7 @@ async function assembleBriefing(args: {
   };
 
   const kind = SUBACTION_TO_KIND[args.subaction];
+  const editorial = buildBriefEditorialContract({ sections });
   let narrative: string | undefined;
   if (args.format === "narrative") {
     narrative = await composeNarrative({
@@ -587,6 +594,7 @@ async function assembleBriefing(args: {
       kind,
       period: args.period,
       sections,
+      editorial,
       optimizationTask: args.optimizationTask,
     });
   }
@@ -597,6 +605,7 @@ async function assembleBriefing(args: {
     period: args.period,
     generatedAt: new Date().toISOString(),
     sections,
+    editorial,
     ...(narrative ? { narrative } : {}),
   };
   return briefing;

--- a/plugins/plugin-personal-assistant/src/lifeops/briefing/editorial-judgment.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/briefing/editorial-judgment.ts
@@ -1,0 +1,334 @@
+/**
+ * Editorial judgment helpers for LifeOps briefings.
+ *
+ * The brief composer gives every surfaced item a stable structural identity,
+ * then this module turns owner engagement history into a small editorial
+ * contract: what leads, what is demoted, and what pushback the model should
+ * justify. The contract is deterministic so tests and optimization rewards can
+ * inspect the same artifact the model sees.
+ */
+
+import type {
+  LifeOpsBriefingCalendarItem,
+  LifeOpsBriefingInboxItem,
+  LifeOpsBriefingLifeItem,
+  LifeOpsBriefingMoneyItem,
+  LifeOpsBriefingSections,
+} from "../../types/briefing.js";
+
+export type LifeOpsBriefItemSource = "calendar" | "inbox" | "life" | "money";
+
+export type LifeOpsBriefItemKind =
+  | "meeting"
+  | "message"
+  | "todo"
+  | "reminder"
+  | "habit"
+  | "goal"
+  | "recurring_charge";
+
+export type LifeOpsBriefEngagementEventType =
+  | "rendered"
+  | "opened"
+  | "replied"
+  | "completed"
+  | "rescheduled"
+  | "kept"
+  | "dismissed"
+  | "ignored"
+  | "demoted";
+
+export interface LifeOpsBriefStructuredItem {
+  readonly itemId: string;
+  readonly source: LifeOpsBriefItemSource;
+  readonly kind: LifeOpsBriefItemKind;
+  readonly sourceId: string;
+  readonly itemClass: string;
+  readonly title: string;
+  readonly summary: string;
+  readonly consequenceScore: number;
+}
+
+export interface LifeOpsBriefItemEngagementSummary {
+  readonly itemClass: string;
+  readonly renderedCount: number;
+  readonly ignoredCount: number;
+  readonly actedOnCount: number;
+  readonly lastEventAt: string | null;
+}
+
+export interface LifeOpsBriefEditorialDecision {
+  readonly itemId: string;
+  readonly action: "lead" | "include" | "demote" | "omit";
+  readonly reason: string;
+}
+
+export interface LifeOpsBriefEditorialContract {
+  readonly maxItems: number;
+  readonly items: readonly LifeOpsBriefStructuredItem[];
+  readonly decisions: readonly LifeOpsBriefEditorialDecision[];
+  readonly demotedItemClasses: readonly string[];
+  readonly pushback: string | null;
+}
+
+const ACTED_ON_EVENTS = new Set<LifeOpsBriefEngagementEventType>([
+  "opened",
+  "replied",
+  "completed",
+  "rescheduled",
+  "kept",
+]);
+
+function clean(value: string): string {
+  return value.trim().replace(/\s+/gu, " ");
+}
+
+function clampScore(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function sourceItemId(
+  source: LifeOpsBriefItemSource,
+  sourceId: string,
+): string {
+  return `${source}:${sourceId}`;
+}
+
+function calendarConsequence(item: LifeOpsBriefingCalendarItem): number {
+  const title = item.title.toLowerCase();
+  if (
+    /\b(board|investor|legal|deadline|interview|client|customer)\b/u.test(title)
+  ) {
+    return 95;
+  }
+  if (/\b(sync|standup|check[- ]?in|1:1)\b/u.test(title)) {
+    return 55;
+  }
+  return 70;
+}
+
+function inboxConsequence(item: LifeOpsBriefingInboxItem): number {
+  switch (item.urgency) {
+    case "high":
+      return 90;
+    case "medium":
+      return 65;
+    case "low":
+      return 30;
+    default:
+      return /\b(approve|deadline|sign|urgent|pay|renew|decision)\b/iu.test(
+        item.snippet,
+      )
+        ? 75
+        : 45;
+  }
+}
+
+function lifeConsequence(item: LifeOpsBriefingLifeItem): number {
+  if (item.kind === "goal") return 75;
+  if (item.kind === "todo") return item.dueAt ? 80 : 55;
+  if (item.kind === "reminder") return item.dueAt ? 65 : 45;
+  return 30;
+}
+
+function moneyConsequence(item: LifeOpsBriefingMoneyItem): number {
+  if (item.amountUsd >= 500) return 85;
+  if (item.amountUsd >= 100) return 60;
+  return 35;
+}
+
+function calendarItemClass(item: LifeOpsBriefingCalendarItem): string {
+  const title = item.title.toLowerCase();
+  if (/\bnewsletter|digest|fyis?\b/u.test(title)) return "calendar:low-signal";
+  if (/\b(board|investor|legal|deadline|client|customer)\b/u.test(title)) {
+    return "calendar:high-consequence";
+  }
+  return "calendar:meeting";
+}
+
+function inboxItemClass(item: LifeOpsBriefingInboxItem): string {
+  const snippet = item.snippet.toLowerCase();
+  if (/\bnewsletter|digest|roundup|promo|promotion\b/u.test(snippet)) {
+    return "inbox:newsletter-digest";
+  }
+  if (/\b(approve|deadline|sign|urgent|pay|renew|decision)\b/u.test(snippet)) {
+    return "inbox:decision-required";
+  }
+  return `inbox:${item.channel}`;
+}
+
+export function structureBriefingItems(
+  sections: LifeOpsBriefingSections,
+): readonly LifeOpsBriefStructuredItem[] {
+  const items: LifeOpsBriefStructuredItem[] = [];
+  for (const item of sections.calendar ?? []) {
+    items.push({
+      itemId: sourceItemId("calendar", item.id),
+      source: "calendar",
+      kind: "meeting",
+      sourceId: item.id,
+      itemClass: calendarItemClass(item),
+      title: clean(item.title),
+      summary: clean(`${item.startAt} ${item.location ?? ""}`),
+      consequenceScore: calendarConsequence(item),
+    });
+  }
+  for (const item of sections.inbox ?? []) {
+    items.push({
+      itemId: sourceItemId("inbox", item.id),
+      source: "inbox",
+      kind: "message",
+      sourceId: item.id,
+      itemClass: inboxItemClass(item),
+      title: clean(`${item.senderName} via ${item.channel}`),
+      summary: clean(item.snippet),
+      consequenceScore: inboxConsequence(item),
+    });
+  }
+  for (const item of sections.life ?? []) {
+    items.push({
+      itemId: sourceItemId("life", item.id),
+      source: "life",
+      kind: item.kind,
+      sourceId: item.id,
+      itemClass: `life:${item.kind}`,
+      title: clean(item.title),
+      summary: clean(item.dueAt ? `due ${item.dueAt}` : "no due date"),
+      consequenceScore: lifeConsequence(item),
+    });
+  }
+  for (const item of sections.money ?? []) {
+    items.push({
+      itemId: sourceItemId("money", item.id),
+      source: "money",
+      kind: "recurring_charge",
+      sourceId: item.id,
+      itemClass:
+        item.amountUsd >= 100
+          ? "money:material-recurring"
+          : "money:small-recurring",
+      title: clean(item.merchant),
+      summary: clean(`$${item.amountUsd.toFixed(2)} ${item.cadence}`),
+      consequenceScore: moneyConsequence(item),
+    });
+  }
+  return items;
+}
+
+export function summarizeBriefEngagementRows(
+  rows: readonly {
+    readonly itemClass: string;
+    readonly eventType: LifeOpsBriefEngagementEventType;
+    readonly eventAt: string;
+  }[],
+): readonly LifeOpsBriefItemEngagementSummary[] {
+  const summaries = new Map<string, LifeOpsBriefItemEngagementSummary>();
+  for (const row of rows) {
+    const current =
+      summaries.get(row.itemClass) ??
+      ({
+        itemClass: row.itemClass,
+        renderedCount: 0,
+        ignoredCount: 0,
+        actedOnCount: 0,
+        lastEventAt: null,
+      } satisfies LifeOpsBriefItemEngagementSummary);
+    summaries.set(row.itemClass, {
+      itemClass: row.itemClass,
+      renderedCount:
+        current.renderedCount + (row.eventType === "rendered" ? 1 : 0),
+      ignoredCount:
+        current.ignoredCount + (row.eventType === "ignored" ? 1 : 0),
+      actedOnCount:
+        current.actedOnCount + (ACTED_ON_EVENTS.has(row.eventType) ? 1 : 0),
+      lastEventAt:
+        current.lastEventAt && current.lastEventAt > row.eventAt
+          ? current.lastEventAt
+          : row.eventAt,
+    });
+  }
+  return [...summaries.values()].sort((a, b) =>
+    a.itemClass.localeCompare(b.itemClass),
+  );
+}
+
+export function recalibrateBriefItemClasses(
+  summaries: readonly LifeOpsBriefItemEngagementSummary[],
+  options: { ignoredThreshold?: number } = {},
+): readonly string[] {
+  const ignoredThreshold = options.ignoredThreshold ?? 5;
+  return summaries
+    .filter(
+      (summary) =>
+        summary.ignoredCount >= ignoredThreshold &&
+        summary.actedOnCount === 0 &&
+        summary.ignoredCount >= summary.renderedCount - summary.actedOnCount,
+    )
+    .map((summary) => summary.itemClass)
+    .sort();
+}
+
+export function buildBriefEditorialContract(args: {
+  sections: LifeOpsBriefingSections;
+  engagementSummaries?: readonly LifeOpsBriefItemEngagementSummary[];
+  maxItems?: number;
+  overloadedCalendarThreshold?: number;
+}): LifeOpsBriefEditorialContract {
+  const maxItems = args.maxItems ?? 7;
+  const items = structureBriefingItems(args.sections);
+  const demotedItemClasses = recalibrateBriefItemClasses(
+    args.engagementSummaries ?? [],
+  );
+  const demoted = new Set(demotedItemClasses);
+  const ranked = [...items].sort((a, b) => {
+    const demotionDelta =
+      Number(demoted.has(a.itemClass)) - Number(demoted.has(b.itemClass));
+    if (demotionDelta !== 0) return demotionDelta;
+    return (
+      b.consequenceScore - a.consequenceScore ||
+      a.itemId.localeCompare(b.itemId)
+    );
+  });
+  const decisions: LifeOpsBriefEditorialDecision[] = ranked.map(
+    (item, index) => {
+      if (index === 0 && !demoted.has(item.itemClass)) {
+        return {
+          itemId: item.itemId,
+          action: "lead",
+          reason: "highest consequence item in the current briefing set",
+        };
+      }
+      if (demoted.has(item.itemClass)) {
+        return {
+          itemId: item.itemId,
+          action: index < maxItems ? "demote" : "omit",
+          reason: `${item.itemClass} has repeated ignore history with no acted-on signal`,
+        };
+      }
+      return {
+        itemId: item.itemId,
+        action: index < maxItems ? "include" : "omit",
+        reason:
+          index < maxItems
+            ? "within the consequence-ranked brief cap"
+            : "below the consequence-ranked brief cap",
+      };
+    },
+  );
+  const calendarCount = args.sections.calendar?.length ?? 0;
+  const pushback =
+    calendarCount >= (args.overloadedCalendarThreshold ?? 6)
+      ? "Calendar is overloaded; justify one meeting to cancel, decline, or shorten."
+      : null;
+  return {
+    maxItems,
+    items: ranked.map((item) => ({
+      ...item,
+      consequenceScore: clampScore(item.consequenceScore),
+    })),
+    decisions,
+    demotedItemClasses,
+    pushback,
+  };
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/index.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/index.ts
@@ -1,6 +1,7 @@
 /** Barrel for the LifeOps core: owner state, policies, scheduling, connectors, and the assistant engine. */
 export * from "./app-state.js";
 export * from "./apple-reminders.js";
+export * from "./briefing/editorial-judgment.js";
 export * from "./bulk-review.js";
 export * from "./commitments/index.js";
 export * from "./defaults.js";

--- a/plugins/plugin-personal-assistant/src/lifeops/repository.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/repository.ts
@@ -110,6 +110,13 @@ import type {
   LifeOpsCommitmentStatus,
 } from "./commitments/index.js";
 import {
+  type LifeOpsBriefEngagementEventType,
+  type LifeOpsBriefItemEngagementSummary,
+  type LifeOpsBriefItemKind,
+  type LifeOpsBriefItemSource,
+  summarizeBriefEngagementRows,
+} from "./briefing/editorial-judgment.js";
+import {
   createConnectorAccountPrivacyPolicy,
   deriveConnectorAccountId,
   deriveConnectorAccountIdFromGrant,
@@ -242,6 +249,30 @@ export interface LifeOpsCachedInboxMessage extends LifeOpsInboxMessage {
 
 type LifeOpsInboxCacheWriteMessage = LifeOpsInboxMessage & {
   priorityFlags?: readonly string[];
+};
+
+export interface LifeOpsBriefItemEngagementRecord {
+  id: string;
+  agentId: string;
+  briefingId: string;
+  itemId: string;
+  source: LifeOpsBriefItemSource;
+  kind: LifeOpsBriefItemKind;
+  sourceId: string;
+  itemClass: string;
+  eventType: LifeOpsBriefEngagementEventType;
+  eventAt: string;
+  weight: number;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+}
+
+export type LifeOpsBriefItemEngagementWrite = Omit<
+  LifeOpsBriefItemEngagementRecord,
+  "id" | "createdAt"
+> & {
+  id?: string;
+  createdAt?: string;
 };
 
 // Finance tables were carved out of plugin-personal-assistant into
@@ -492,6 +523,26 @@ function parseWebsiteAccessGrant(
     metadata: parseJsonRecord(row.metadata_json),
     createdAt: toText(row.created_at),
     updatedAt: toText(row.updated_at),
+  };
+}
+
+function parseBriefItemEngagement(
+  row: Record<string, unknown>,
+): LifeOpsBriefItemEngagementRecord {
+  return {
+    id: toText(row.id),
+    agentId: toText(row.agent_id),
+    briefingId: toText(row.briefing_id),
+    itemId: toText(row.item_id),
+    source: toText(row.source) as LifeOpsBriefItemSource,
+    kind: toText(row.kind) as LifeOpsBriefItemKind,
+    sourceId: toText(row.source_id),
+    itemClass: toText(row.item_class),
+    eventType: toText(row.event_type) as LifeOpsBriefEngagementEventType,
+    eventAt: toText(row.event_at),
+    weight: toNumber(row.weight),
+    metadata: parseJsonRecord(row.metadata_json),
+    createdAt: toText(row.created_at),
   };
 }
 
@@ -2647,6 +2698,145 @@ export class LifeOpsRepository {
     for (const statement of inboxCacheColumnRepairs) {
       await executeRawSql(runtime, statement);
     }
+  }
+
+  async recordBriefItemEngagement(
+    input: LifeOpsBriefItemEngagementWrite,
+  ): Promise<LifeOpsBriefItemEngagementRecord> {
+    const createdAt = input.createdAt ?? isoNow();
+    const id =
+      input.id ??
+      `brief_eng_${crypto
+        .createHash("sha256")
+        .update(
+          [
+            input.agentId,
+            input.briefingId,
+            input.itemId,
+            input.eventType,
+            input.eventAt,
+          ].join("\0"),
+        )
+        .digest("hex")
+        .slice(0, 20)}`;
+    await executeRawSql(
+      this.runtime,
+      `INSERT INTO app_lifeops.life_brief_item_engagements (
+        id, agent_id, briefing_id, item_id, source, kind, source_id,
+        item_class, event_type, event_at, weight, metadata_json, created_at
+      ) VALUES (
+        ${sqlQuote(id)},
+        ${sqlQuote(input.agentId)},
+        ${sqlQuote(input.briefingId)},
+        ${sqlQuote(input.itemId)},
+        ${sqlQuote(input.source)},
+        ${sqlQuote(input.kind)},
+        ${sqlQuote(input.sourceId)},
+        ${sqlQuote(input.itemClass)},
+        ${sqlQuote(input.eventType)},
+        ${sqlQuote(input.eventAt)},
+        ${sqlNumber(input.weight)},
+        ${sqlJson(input.metadata)},
+        ${sqlQuote(createdAt)}
+      )
+      ON CONFLICT (agent_id, briefing_id, item_id, event_type, event_at)
+      DO UPDATE SET
+        source = EXCLUDED.source,
+        kind = EXCLUDED.kind,
+        source_id = EXCLUDED.source_id,
+        item_class = EXCLUDED.item_class,
+        weight = EXCLUDED.weight,
+        metadata_json = EXCLUDED.metadata_json`,
+    );
+    const rows = await executeRawSql(
+      this.runtime,
+      `SELECT *
+         FROM app_lifeops.life_brief_item_engagements
+        WHERE agent_id = ${sqlQuote(input.agentId)}
+          AND briefing_id = ${sqlQuote(input.briefingId)}
+          AND item_id = ${sqlQuote(input.itemId)}
+          AND event_type = ${sqlQuote(input.eventType)}
+          AND event_at = ${sqlQuote(input.eventAt)}
+        LIMIT 1`,
+    );
+    const row = rows[0] ? parseBriefItemEngagement(rows[0]) : null;
+    if (!row) {
+      throw new ElizaError(
+        "[LifeOpsRepository] Failed to reload brief engagement",
+        {
+          code: "LIFEOPS_BRIEF_ENGAGEMENT_RELOAD_FAILED",
+          context: {
+            agentId: input.agentId,
+            briefingId: input.briefingId,
+            itemId: input.itemId,
+            eventType: input.eventType,
+            eventAt: input.eventAt,
+          },
+          severity: "error",
+        },
+      );
+    }
+    return row;
+  }
+
+  async getBriefItemEngagement(
+    agentId: string,
+    id: string,
+  ): Promise<LifeOpsBriefItemEngagementRecord | null> {
+    const rows = await executeRawSql(
+      this.runtime,
+      `SELECT *
+         FROM app_lifeops.life_brief_item_engagements
+        WHERE agent_id = ${sqlQuote(agentId)}
+          AND id = ${sqlQuote(id)}
+        LIMIT 1`,
+    );
+    const row = rows[0];
+    return row ? parseBriefItemEngagement(row) : null;
+  }
+
+  async listBriefItemEngagements(
+    agentId: string,
+    options: {
+      briefingId?: string;
+      itemClass?: string;
+      sinceIso?: string;
+      untilIso?: string;
+    } = {},
+  ): Promise<LifeOpsBriefItemEngagementRecord[]> {
+    const where = [`agent_id = ${sqlQuote(agentId)}`];
+    if (options.briefingId) {
+      where.push(`briefing_id = ${sqlQuote(options.briefingId)}`);
+    }
+    if (options.itemClass) {
+      where.push(`item_class = ${sqlQuote(options.itemClass)}`);
+    }
+    if (options.sinceIso) {
+      where.push(`event_at >= ${sqlQuote(options.sinceIso)}`);
+    }
+    if (options.untilIso) {
+      where.push(`event_at <= ${sqlQuote(options.untilIso)}`);
+    }
+    const rows = await executeRawSql(
+      this.runtime,
+      `SELECT *
+         FROM app_lifeops.life_brief_item_engagements
+        WHERE ${where.join(" AND ")}
+        ORDER BY event_at ASC, created_at ASC`,
+    );
+    return rows.map(parseBriefItemEngagement);
+  }
+
+  async summarizeBriefItemEngagements(
+    agentId: string,
+    options: {
+      sinceIso?: string;
+      untilIso?: string;
+    } = {},
+  ): Promise<readonly LifeOpsBriefItemEngagementSummary[]> {
+    return summarizeBriefEngagementRows(
+      await this.listBriefItemEngagements(agentId, options),
+    );
   }
 
   async createDefinition(definition: LifeOpsTaskDefinition): Promise<void> {

--- a/plugins/plugin-personal-assistant/src/lifeops/schema.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/schema.ts
@@ -1585,6 +1585,39 @@ export const lifeWorkThreadEvents = appLifeopsPgSchema.table(
   ],
 );
 
+export const lifeBriefItemEngagements = appLifeopsPgSchema.table(
+  "life_brief_item_engagements",
+  {
+    id: text("id").primaryKey(),
+    agentId: text("agent_id").notNull(),
+    briefingId: text("briefing_id").notNull(),
+    itemId: text("item_id").notNull(),
+    source: text("source").notNull(),
+    kind: text("kind").notNull(),
+    sourceId: text("source_id").notNull(),
+    itemClass: text("item_class").notNull(),
+    eventType: text("event_type").notNull(),
+    eventAt: text("event_at").notNull(),
+    weight: real("weight").notNull().default(0),
+    metadataJson: text("metadata_json").notNull().default("{}"),
+    createdAt: text("created_at").notNull(),
+  },
+  (t) => [
+    unique().on(t.agentId, t.briefingId, t.itemId, t.eventType, t.eventAt),
+    index("idx_life_brief_item_engagements_item").on(
+      t.agentId,
+      t.itemId,
+      t.eventAt,
+    ),
+    index("idx_life_brief_item_engagements_class").on(
+      t.agentId,
+      t.itemClass,
+      t.eventAt,
+    ),
+    index("idx_life_brief_item_engagements_brief").on(t.agentId, t.briefingId),
+  ],
+);
+
 // ---------------------------------------------------------------------------
 // Aggregate export for plugin schema property
 // ---------------------------------------------------------------------------
@@ -1647,6 +1680,7 @@ export const lifeOpsSchema = {
   lifeScheduledTaskLog,
   lifeWorkThreads,
   lifeWorkThreadEvents,
+  lifeBriefItemEngagements,
   lifeopsFeaturesTable,
 } as const;
 

--- a/plugins/plugin-personal-assistant/src/types/briefing.ts
+++ b/plugins/plugin-personal-assistant/src/types/briefing.ts
@@ -55,12 +55,45 @@ export interface LifeOpsBriefingSections {
   readonly money?: readonly LifeOpsBriefingMoneyItem[];
 }
 
+export interface LifeOpsBriefingEditorialItem {
+  readonly itemId: string;
+  readonly source: "calendar" | "inbox" | "life" | "money";
+  readonly kind:
+    | "meeting"
+    | "message"
+    | "todo"
+    | "reminder"
+    | "habit"
+    | "goal"
+    | "recurring_charge";
+  readonly sourceId: string;
+  readonly itemClass: string;
+  readonly title: string;
+  readonly summary: string;
+  readonly consequenceScore: number;
+}
+
+export interface LifeOpsBriefingEditorialDecision {
+  readonly itemId: string;
+  readonly action: "lead" | "include" | "demote" | "omit";
+  readonly reason: string;
+}
+
+export interface LifeOpsBriefingEditorialContract {
+  readonly maxItems: number;
+  readonly items: readonly LifeOpsBriefingEditorialItem[];
+  readonly decisions: readonly LifeOpsBriefingEditorialDecision[];
+  readonly demotedItemClasses: readonly string[];
+  readonly pushback: string | null;
+}
+
 export interface LifeOpsBriefing {
   readonly id: string;
   readonly kind: LifeOpsBriefingKind;
   readonly period: LifeOpsBriefingPeriod;
   readonly generatedAt: string;
   readonly sections: LifeOpsBriefingSections;
+  readonly editorial: LifeOpsBriefingEditorialContract;
   /** Free-form narrative composed by the LLM compose pass. */
   readonly narrative?: string;
 }

--- a/plugins/plugin-personal-assistant/test/brief-action.test.ts
+++ b/plugins/plugin-personal-assistant/test/brief-action.test.ts
@@ -209,6 +209,9 @@ describe("BRIEF umbrella action — Daily Operations", () => {
       expect(args.prompt).toContain("Approve the SOW"); // inbox
       expect(args.prompt).toContain("Send NDA"); // life
       expect(args.prompt).toContain("Netflix"); // money
+      expect(args.prompt).toContain('"editorial"');
+      expect(args.prompt).toContain('"itemId": "inbox:msg-1"');
+      expect(args.prompt).toContain('"action": "lead"');
     });
 
     it("honors include flags by suppressing whole sections", async () => {
@@ -279,7 +282,9 @@ describe("BRIEF umbrella action — Daily Operations", () => {
       });
       expect(result.success).toBe(true);
       expect(useModel).toHaveBeenCalledTimes(1);
-      const [modelType, args] = useModel.mock.calls[0]!;
+      const modelCall = useModel.mock.calls[0];
+      expect(modelCall).toBeDefined();
+      const [modelType, args] = modelCall as [string, { prompt: string }];
       expect(modelType).toBe(ModelType.TEXT_LARGE);
       expect(args.prompt).toContain("Standup");
     });

--- a/plugins/plugin-personal-assistant/test/brief-editorial-judgment.test.ts
+++ b/plugins/plugin-personal-assistant/test/brief-editorial-judgment.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Brief editorial-judgment tests cover the structured artifact that links
+ * rendered brief items, engagement history, and deterministic recalibration.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildBriefEditorialContract,
+  structureBriefingItems,
+} from "../src/lifeops/briefing/editorial-judgment.js";
+import { LifeOpsRepository } from "../src/lifeops/repository.js";
+import type { LifeOpsBriefingSections } from "../src/types/briefing.js";
+import { createLifeOpsTestRuntime } from "./helpers/runtime.ts";
+
+const sections: LifeOpsBriefingSections = {
+  calendar: [
+    {
+      id: "board-prep",
+      title: "Board prep with investor questions",
+      startAt: "2026-07-06T16:00:00.000Z",
+      endAt: "2026-07-06T17:00:00.000Z",
+    },
+    {
+      id: "newsletter-review",
+      title: "Newsletter digest review",
+      startAt: "2026-07-06T18:00:00.000Z",
+      endAt: "2026-07-06T18:30:00.000Z",
+    },
+  ],
+  inbox: [
+    {
+      id: "msg-approval",
+      channel: "gmail",
+      senderName: "Mara",
+      snippet: "Please approve the vendor SOW by 3pm.",
+      urgency: "high",
+      classification: "needs_reply",
+    },
+    {
+      id: "msg-newsletter",
+      channel: "gmail",
+      senderName: "Industry Roundup",
+      snippet: "Weekly newsletter digest and promo updates.",
+      urgency: "low",
+      classification: "newsletter",
+    },
+  ],
+};
+
+describe("brief editorial judgment", () => {
+  let runtimeResult:
+    | Awaited<ReturnType<typeof createLifeOpsTestRuntime>>
+    | undefined;
+
+  afterEach(async () => {
+    await runtimeResult?.cleanup();
+    runtimeResult = undefined;
+  });
+
+  it("assigns structural item identities and leads with the highest consequence item", () => {
+    const contract = buildBriefEditorialContract({ sections, maxItems: 3 });
+
+    expect(contract.items.map((item) => item.itemId)).toContain(
+      "calendar:board-prep",
+    );
+    expect(contract.items.map((item) => item.itemId)).toContain(
+      "inbox:msg-newsletter",
+    );
+    expect(contract.decisions[0]).toMatchObject({
+      itemId: "calendar:board-prep",
+      action: "lead",
+    });
+    expect(contract.decisions).toContainEqual(
+      expect.objectContaining({
+        itemId: "inbox:msg-newsletter",
+        action: "omit",
+      }),
+    );
+  });
+
+  it("demotes repeatedly ignored item classes without hiding the reason", () => {
+    const contract = buildBriefEditorialContract({
+      sections,
+      maxItems: 4,
+      engagementSummaries: [
+        {
+          itemClass: "inbox:newsletter-digest",
+          renderedCount: 5,
+          ignoredCount: 5,
+          actedOnCount: 0,
+          lastEventAt: "2026-07-05T12:00:00.000Z",
+        },
+      ],
+    });
+
+    expect(contract.demotedItemClasses).toEqual(["inbox:newsletter-digest"]);
+    expect(contract.decisions).toContainEqual(
+      expect.objectContaining({
+        itemId: "inbox:msg-newsletter",
+        action: "demote",
+        reason:
+          "inbox:newsletter-digest has repeated ignore history with no acted-on signal",
+      }),
+    );
+  });
+
+  it("persists engagement rows and summarizes recalibration signals", async () => {
+    runtimeResult = await createLifeOpsTestRuntime();
+    await LifeOpsRepository.bootstrapSchema(runtimeResult.runtime);
+    const repository = new LifeOpsRepository(runtimeResult.runtime);
+    const newsletterSource = sections.inbox?.[1] ?? sections.inbox?.[0];
+    expect(newsletterSource).toBeDefined();
+    const [newsletter] = structureBriefingItems({
+      inbox: newsletterSource ? [newsletterSource] : [],
+    });
+    if (!newsletter) {
+      throw new Error("newsletter fixture did not produce a structured item");
+    }
+
+    for (let day = 1; day <= 5; day += 1) {
+      const eventAt = `2026-07-0${day}T12:00:00.000Z`;
+      await repository.recordBriefItemEngagement({
+        agentId: runtimeResult.runtime.agentId,
+        briefingId: `brief-${day}`,
+        itemId: newsletter.itemId,
+        source: newsletter.source,
+        kind: newsletter.kind,
+        sourceId: newsletter.sourceId,
+        itemClass: newsletter.itemClass,
+        eventType: "ignored",
+        eventAt,
+        weight: -1,
+        metadata: { scenario: "ignore-pattern" },
+      });
+    }
+
+    const rows = await repository.listBriefItemEngagements(
+      runtimeResult.runtime.agentId,
+      { itemClass: "inbox:newsletter-digest" },
+    );
+    expect(rows).toHaveLength(5);
+    expect(rows[0]).toMatchObject({
+      itemId: "inbox:msg-newsletter",
+      eventType: "ignored",
+      metadata: { scenario: "ignore-pattern" },
+    });
+
+    const summaries = await repository.summarizeBriefItemEngagements(
+      runtimeResult.runtime.agentId,
+    );
+    expect(summaries).toEqual([
+      {
+        itemClass: "inbox:newsletter-digest",
+        renderedCount: 0,
+        ignoredCount: 5,
+        actedOnCount: 0,
+        lastEventAt: "2026-07-05T12:00:00.000Z",
+      },
+    ]);
+    expect(
+      buildBriefEditorialContract({
+        sections,
+        engagementSummaries: summaries,
+      }).demotedItemClasses,
+    ).toEqual(["inbox:newsletter-digest"]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add LifeOps brief editorial judgment helpers that flatten brief sections into stable item IDs/classes, rank by consequence, cap included items, and produce visible demotion/pushback decisions.
- Add `app_lifeops.life_brief_item_engagements` plus repository APIs to persist/list/summarize per-item engagement signals.
- Feed the editorial contract into the BRIEF narrative prompt and returned `LifeOpsBriefing` artifact so optimization/scenario evidence can inspect what the model saw.

## Issue

Closes part of #14872.

## Evidence

- Focused tests: `bun run --cwd plugins/plugin-personal-assistant test -- test/brief-action.test.ts test/brief-editorial-judgment.test.ts` -> 2 files, 16 tests passed. Covers prompt item structure, deterministic demotion after ignore history, and PGLite-backed engagement row persistence.
- Formatting/lint: `bun x biome check plugins/plugin-personal-assistant/src/actions/brief.ts plugins/plugin-personal-assistant/src/types/briefing.ts plugins/plugin-personal-assistant/src/lifeops/schema.ts plugins/plugin-personal-assistant/src/lifeops/repository.ts plugins/plugin-personal-assistant/src/lifeops/index.ts plugins/plugin-personal-assistant/src/lifeops/briefing/editorial-judgment.ts plugins/plugin-personal-assistant/test/brief-action.test.ts plugins/plugin-personal-assistant/test/brief-editorial-judgment.test.ts` -> no fixes applied.
- Build: `bun run --cwd plugins/plugin-personal-assistant build` completed successfully.
- Error-policy ratchet: `bun run audit:error-policy-ratchet` -> no new fallback-slop in touched files.
- Whitespace: `git diff --check` passed.
- Typecheck: after `bun run --cwd packages/core build`, `bun run --cwd packages/shared build`, and `bun run --cwd packages/cloud/routing build`, `bun run --cwd plugins/plugin-personal-assistant typecheck` still fails on existing optional workspace package resolution/type-export issues. Touched-file hits are pre-existing unresolved imports in `src/actions/brief.ts`, `src/lifeops/repository.ts`, and `src/lifeops/schema.ts`; no diagnostics mention the new `src/lifeops/briefing/editorial-judgment.ts` module or new test.

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - no UI change; this PR changes LifeOps domain data, BRIEF prompt payload, and repository/test code only.`

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - no UI change; this PR changes LifeOps domain data, BRIEF prompt payload, and repository/test code only.`

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no UI change; this PR changes LifeOps domain data, BRIEF prompt payload, and repository/test code only.`

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no server runtime launched; focused validation is unit/integration test output for the repository and action path.`

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs `N/A - no frontend or browser surface changed.`

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no model credentials are present in this environment, so the live recalibration scenario and trajectory review remain pending. The issue stays In progress.`

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [brief-editorial-judgment.test.ts](plugins/plugin-personal-assistant/test/brief-editorial-judgment.test.ts) boots a real LifeOps test runtime, migrates schema, writes five ignored `life_brief_item_engagements` rows, reads them back, and verifies the summarized recalibration signal demotes `inbox:newsletter-digest`.

## Remaining Work

- Capture the #14872 live scenarios with model trajectories: seeded ignore pattern -> "recalibrate" -> next brief demotes/omits the ignored class, with judge scoring for lead/omit/cut quality.
- Wire real owner action events from delivery surfaces into `recordBriefItemEngagement` once the relevant interaction sources are available.