### PR TITLE
fix(pwa): transparent #root+body so the iOS standalone bottom strip shows the wallpaper, not #160d07

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2687,13 +2687,16 @@ export function App() {
           className="relative flex h-[100dvh] w-full max-w-full flex-col overflow-hidden"
           // Reserve a TIGHT status-bar inset: enough to clear the notch/Dynamic
           // Island but no oversized empty band above the content (the repeated
-          // "too much space at the top" report). Shave the inset down from the
-          // full safe area, with a 1.25rem floor so notch-less phones still
+          // "too much space at the top" report; device r8 screenshot still showed
+          // dead space above the in-app clock). The iOS status bar clock already
+          // draws INSIDE the safe-area-top zone, so any app paddingTop below the
+          // full inset is ADDITIVE dead space. Shave harder, subtract 2rem from
+          // the safe area (was 1.25rem) so the big in-app clock seats snug under
+          // the status bar, with a 0.75rem floor so notch-less phones still
           // clear their status bar. Top banners bleed their bg back up via
           // `.mobile-top-banner:first-child` (styles.css). No-op on web.
           style={{
-            paddingTop:
-              "max(calc(var(--safe-area-top, 0px) - 1.25rem), 1.25rem)",
+            paddingTop: "max(calc(var(--safe-area-top, 0px) - 2rem), 0.75rem)",
           }}
         >
           {/* BOTTOM-BAR / SAFE-AREA FLOOR (do not remove): a viewport-filling

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -480,14 +480,16 @@ describe("ContinuousChatOverlay", () => {
 
   it("seats the resting composer above the home indicator: full gesture inset plus a small gap", () => {
     // Lock-screen anchoring: with the overlay reclaimed to the true physical
-    // bottom, the resting composer should clear the whole home-indicator/
-    // Android gesture inset plus a small visual gap (~34px + 10px on iOS), not
-    // the old 40% inset compensation that was tuned around the collapsed-ICB
-    // float and left a dead band under the composer.
+    // bottom (device r8, screen.height reclaim), the resting composer clears the
+    // whole home-indicator/Android gesture inset plus a SMALL visual gap
+    // (~34px + 8px on iOS). The gap was trimmed 0.625rem → 0.5rem (device r8:
+    // "bottom has excess padding") so the composer sits one finger above the
+    // indicator, not floating in a dead band, no longer the old 40% inset
+    // compensation that was tuned around the collapsed-ICB float.
     render(<ContinuousChatOverlay controller={makeController()} />);
     const overlay = screen.getByTestId("continuous-chat-overlay");
     expect(overlay.style.paddingBottom).toBe(
-      "calc(var(--eliza-mobile-nav-offset, 0px) + max(var(--safe-area-bottom, 0px), var(--android-gesture-inset-bottom, 0px)) + 0.625rem)",
+      "calc(var(--eliza-mobile-nav-offset, 0px) + max(var(--safe-area-bottom, 0px), var(--android-gesture-inset-bottom, 0px)) + 0.5rem)",
     );
   });
 
@@ -1327,6 +1329,55 @@ describe("ContinuousChatOverlay", () => {
       expect(sheet.getAttribute("data-variant")).toBe("open");
     } finally {
       overlay.remove();
+    }
+  });
+
+  it("cedes taps to the INLINE home notification center (below the glass) instead of collapsing (device r8)", () => {
+    // #15080 moved the notification inbox inline on the home column, BELOW the
+    // chat glass (not the old Z_NOTIFICATION_OVERLAY shade). Its rows are live
+    // interactive surfaces: without an exemption the outside-tap collapse-
+    // swallower ate the row's tap (preventDefault + suppressNextOutsideClick),
+    // so tapping a notification did NOTHING ("interacting is cooked"). The
+    // swallower now exempts [data-testid="home-notification-center"] and
+    // [data-notif-row]; a tap on a row must leave the chat OPEN and not be
+    // swallowed.
+    render(<ContinuousChatOverlay controller={makeController()} />);
+    const sheet = screen.getByTestId("chat-sheet");
+    fireEvent.focus(screen.getByLabelText("message"));
+    expect(sheet.getAttribute("data-variant")).toBe("open");
+
+    // Mirror the notification center's real markers: a [data-notif-row] li with
+    // its open button, under the [data-testid="home-notification-center"] host.
+    const center = document.createElement("section");
+    center.setAttribute("data-testid", "home-notification-center");
+    const row = document.createElement("li");
+    row.setAttribute("data-notif-row", "");
+    const rowButton = document.createElement("button");
+    let opened = false;
+    rowButton.addEventListener("click", () => {
+      opened = true;
+    });
+    row.appendChild(rowButton);
+    center.appendChild(row);
+    document.body.appendChild(center);
+    try {
+      fireEvent.pointerDown(rowButton, {
+        clientX: 40,
+        clientY: 40,
+        pointerId: 7,
+      });
+      fireEvent.pointerUp(rowButton, {
+        clientX: 40,
+        clientY: 40,
+        pointerId: 7,
+      });
+      // The chat stays open (tap NOT swallowed into a collapse)...
+      expect(sheet.getAttribute("data-variant")).toBe("open");
+      // ...and the row's own click is NOT suppressed by the swallower.
+      fireEvent.click(rowButton, { clientX: 40, clientY: 40 });
+      expect(opened).toBe(true);
+    } finally {
+      center.remove();
     }
   });
 

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -3250,9 +3250,22 @@ export function ContinuousChatOverlay({
     // Z_NOTIFICATION_OVERLAY, any open Radix dialog) must win the tap — the
     // swallower otherwise eats their first tap AND collapses the chat under
     // them. "Tap outside collapses" is only for the background view.
+    //
+    // The inline home notification center (#15080) is a live INTERACTIVE
+    // surface even though it sits BELOW the chat glass (inline on the home
+    // column, not the old Z_NOTIFICATION_OVERLAY shade). Its rows own tap (open
+    // / deep-link), swipe-dismiss, and a long-press menu; without this
+    // exemption the capture-phase pointerup below preventDefault +
+    // stopImmediatePropagation'd the row's tap and set suppressNextOutsideClick,
+    // so the click-swallower ate the row's onClick, tapping a notification did
+    // NOTHING ("interacting is cooked", device r8). Exempt the notification
+    // center (rows, its menu, the header actions) so its own handlers win; a
+    // real tap on the bare field AROUND the rows still collapses the chat.
     const isAboveShellOverlay = (target: EventTarget | null): boolean =>
       target instanceof Element &&
-      !!target.closest('[data-above-shell-overlay], [role="dialog"]');
+      !!target.closest(
+        '[data-above-shell-overlay], [role="dialog"], [data-testid="home-notification-center"], [data-notif-row]',
+      );
 
     const onPointerDown = (event: PointerEvent) => {
       if (event.button !== 0 && event.pointerType === "mouse") return;
@@ -3900,18 +3913,26 @@ export function ContinuousChatOverlay({
         // that the overlay itself seats at the TRUE physical bottom (the `bottom`
         // reclaim above), the resting padding must clear the WHOLE home-indicator
         // safe area (env(safe-area-inset-bottom) ~34px) plus a small gap, so the
-        // composer rests ~42–46px off the physical edge — above the indicator,
-        // not floating in a dead band above it. (Previously this multiplied the
-        // inset by 0.4 to sit the pill ~13px up; that tuning was compensating
-        // for the collapsed-ICB float — with the overlay now correctly at the
-        // true bottom, the full inset + gap is the right, native-app clearance.)
+        // composer rests ~42px off the physical edge, one finger above the
+        // indicator, not floating in a dead band above it. (Previously this
+        // multiplied the inset by 0.4 to sit the pill ~13px up; that tuning was
+        // compensating for the collapsed-ICB float. With the overlay now
+        // correctly at the true bottom via the screen.height reclaim (device r8),
+        // the full inset plus a small gap is the right, native-app clearance.)
+        // NOTE the resting `bottom` above already re-seats the overlay at the
+        // TRUE physical bottom; this padding uses the safe-area inset only (NOT
+        // the reclaim var), so there is no double-count. The r8 screenshot's
+        // "big dead band below the composer" was the reclaim reading 0 (overlay
+        // stuck 59px UP) PLUS this clearance, not this clearance itself; with the
+        // reclaim now 59 the band collapses to just this one-finger inset. The
+        // extra gap is trimmed 0.625rem to 0.5rem so it sits snug, not floating.
         // The same holds for Android gesture pills. Everything below the composer
-        // is the full-bleed wallpaper / app floor — no cosmetic strip repaints it.
+        // is the full-bleed wallpaper / app floor, no cosmetic strip repaints it.
         paddingBottom: fullBleedFrame
           ? 0
           : keyboardLiftActive
             ? "0.75rem"
-            : "calc(var(--eliza-mobile-nav-offset, 0px) + max(var(--safe-area-bottom, 0px), var(--android-gesture-inset-bottom, 0px)) + 0.625rem)",
+            : "calc(var(--eliza-mobile-nav-offset, 0px) + max(var(--safe-area-bottom, 0px), var(--android-gesture-inset-bottom, 0px)) + 0.5rem)",
       }}
       data-testid="continuous-chat-overlay"
       data-open={sheetOpen ? "true" : undefined}

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -3,8 +3,21 @@
 // Dashboard notification center behavior against the real notification store
 // (driven via the test-only ingest; HTTP mutations mocked at the API client).
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Haptics is a native bridge; stub it so the row's long-press path
+// (`void haptics.light()`) doesn't leave a real pending promise under fake
+// timers in the touch-interaction tests.
+vi.mock("../../bridge/capacitor-bridge", () => ({
+  haptics: { light: vi.fn(async () => {}), medium: vi.fn(async () => {}) },
+}));
 
 // Mutations are optimistic writes through the API client - mock the transport,
 // not the store, so mark-read/dismiss/clear exercise the real store paths.
@@ -278,5 +291,115 @@ describe("NotificationsHomeCenter", () => {
     __ingestNotificationForTests(makeNotification({ title: "plain" }));
     render(<NotificationsHomeCenter />);
     expect(screen.queryByTestId("notification-count-chip")).toBeNull();
+  });
+});
+
+// ── Touch interaction: the row's OWN pointer handlers (device r8) ──────────
+// #15080 moved the inbox inline BELOW the chat glass; "interacting is cooked"
+// on device. These tests drive the row's real pointer sequence (not just a
+// synthetic click) so tap-to-open and swipe-to-dismiss fire their handlers, and
+// pin the exemption markers that keep the ContinuousChatOverlay outside-tap
+// collapse-swallower off the notification surface.
+describe("NotificationsHomeCenter (touch interaction, device r8)", () => {
+  function pointer(
+    el: Element,
+    type: string,
+    {
+      x = 0,
+      y = 0,
+      pointerId = 1,
+    }: { x?: number; y?: number; pointerId?: number } = {},
+  ): void {
+    // jsdom has no PointerEvent ctor; fireEvent.pointerX carries clientX/Y +
+    // pointerId + pointerType onto the synthetic event the row handlers read.
+    (fireEvent as unknown as Record<string, (e: Element, i: unknown) => void>)[
+      type
+    ](el, {
+      clientX: x,
+      clientY: y,
+      pointerId,
+      pointerType: "touch",
+      button: 0,
+    });
+  }
+
+  it("tap (pointerdown → pointerup, no move) opens/deep-links the row on TOUCH", () => {
+    __ingestNotificationForTests(
+      makeNotification({ deepLink: "/settings", title: "Tap me" }),
+    );
+    render(<NotificationsHomeCenter />);
+    const swipe = screen.getByTestId("notification-row-swipe");
+    const button = screen.getByTestId("notification-row");
+    // A real touch tap: down then up on the swipe surface, no movement, then the
+    // button's synthetic click. suppressClick must NOT be set (no swipe / long
+    // press), so the tap opens the notification.
+    pointer(swipe, "pointerDown", { x: 10, y: 10 });
+    pointer(swipe, "pointerUp", { x: 10, y: 10 });
+    fireEvent.click(button);
+    expect(navigateDeepLink).toHaveBeenCalledWith("/settings");
+    expect(__getStateForTests().unreadCount).toBe(0);
+  });
+
+  it("horizontal swipe past the threshold dismisses the row (and swallows the click)", () => {
+    __ingestNotificationForTests(makeNotification({ title: "Keep" }));
+    __ingestNotificationForTests(makeNotification({ title: "Swipe away" }));
+    render(<NotificationsHomeCenter />);
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(2);
+    const li = screen.getByText("Swipe away").closest("li") as HTMLElement;
+    const swipe = li.querySelector(
+      '[data-testid="notification-row-swipe"]',
+    ) as HTMLElement;
+    const button = li.querySelector(
+      '[data-testid="notification-row"]',
+    ) as HTMLElement;
+    // Drag left well past SWIPE_DISMISS_PX (88): down at 120, move to 10 (dx=-110
+    // → axis locks x, past threshold), release → commitDismiss(left).
+    pointer(swipe, "pointerDown", { x: 120, y: 20 });
+    pointer(swipe, "pointerMove", { x: 60, y: 22 });
+    pointer(swipe, "pointerMove", { x: 10, y: 22 });
+    pointer(swipe, "pointerUp", { x: 10, y: 22 });
+    // The synthetic click a swipe emits must be swallowed (suppressClick) so the
+    // gesture doesn't ALSO open the row.
+    fireEvent.click(button);
+    expect(navigateDeepLink).not.toHaveBeenCalled();
+    // Fling-out transition then store removal (180ms timeout).
+    vi.useFakeTimers();
+    // (already released; the remove was scheduled synchronously via setTimeout)
+    vi.useRealTimers();
+    // The row is on its way out (dismissing transform applied); the store
+    // removal fires on the 180ms timer. Assert the swipe surface committed.
+    expect(swipe.style.transform).toContain("translateX(-120%)");
+  });
+
+  it("a long-press opens the row's contextual menu on TOUCH", () => {
+    vi.useFakeTimers();
+    try {
+      __ingestNotificationForTests(
+        makeNotification({ title: "Hold me", deepLink: "/x" }),
+      );
+      render(<NotificationsHomeCenter />);
+      const swipe = screen.getByTestId("notification-row-swipe");
+      pointer(swipe, "pointerDown", { x: 10, y: 10 });
+      // Hold past LONG_PRESS_MS (420) with no movement → menu opens. Wrap the
+      // timer flush in act() so the setMenuOpen(true) render commits before the
+      // query reads the DOM.
+      act(() => {
+        vi.advanceTimersByTime(450);
+      });
+      expect(screen.getByTestId("notification-row-menu")).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("marks the row + its center with the overlay-exemption hooks the collapse-swallower reads", () => {
+    __ingestNotificationForTests(makeNotification({ title: "Exempt" }));
+    render(<NotificationsHomeCenter />);
+    // The ContinuousChatOverlay outside-tap collapse-swallower exempts anything
+    // under [data-testid="home-notification-center"] or [data-notif-row]; both
+    // must be present or a row tap gets eaten (the r8 "cooked" bug).
+    expect(screen.getByTestId("home-notification-center")).toBeTruthy();
+    const row = screen.getByText("Exempt").closest("li") as HTMLElement;
+    expect(row.hasAttribute("data-notif-row")).toBe(true);
   });
 });

--- a/packages/ui/src/platform/standalone-bottom-reclaim.test.ts
+++ b/packages/ui/src/platform/standalone-bottom-reclaim.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 /**
- * MEASURED-GAP contract for the iOS standalone-PWA bottom reclaim (device r6).
+ * MEASURED-GAP contract for the iOS standalone-PWA bottom reclaim (device r8).
  *
  * ── WHY THIS TEST EXISTS ──
  * The recurring home-indicator "bottom bar" survived FIVE CSS-only PRs
@@ -12,13 +12,20 @@
  * `100lvh - 100dvh === 0` — every reclaim a no-op, the strip untouched, the
  * tests still green. A string test can never catch that.
  *
- * These tests instead pin the MEASURED gap: they reproduce the collapsed
- * geometry (true screen height via window.innerHeight / visualViewport, the
- * collapsed layout box via documentElement.clientHeight) and assert
- * `measureStandaloneBottomGap()` / the applied `--standalone-bottom-reclaim`
- * var equals the REAL delta. The pre-fix code path (CSS-unit calc) would have
- * produced a 0 reclaim in this exact geometry — that is the failing case this
- * green test now covers.
+ * #15036 then bet that `innerHeight` / `visualViewport.height` still see the
+ * true screen while only `documentElement.clientHeight` collapses. On-device
+ * diagnostics (`ih873 vv873 ce873 sh932 rc0 lv932 dv873`) proved that ALSO
+ * dead: innerHeight, visualViewport.height, AND clientHeight ALL collapse to
+ * 873, so `max(vv,inner) - clientHeight = 0`, a SIXTH no-op. The ONLY value
+ * that still sees the true 932px screen is `window.screen.height`.
+ *
+ * These tests pin the DEFINITIVE measurement: the true physical height is
+ * `screen.height` (932), the collapsed layout box is `documentElement
+ * .clientHeight` (873), and the real gap is `screen.height - clientHeight` = 59.
+ * They stub the FULL collapsed geometry (innerHeight == vv == clientHeight ==
+ * 873, screen.height == 932) exactly as the device reports it, so the #15036
+ * code path would produce 0 here, that is the failing case this green test now
+ * covers.
  */
 
 import { afterEach, describe, expect, it } from "vitest";
@@ -33,15 +40,20 @@ import {
 } from "./standalone-bottom-reclaim";
 
 /**
- * Reproduce the collapsed fixed-body geometry:
- *  - `documentElement.clientHeight` = the LAYOUT (small/collapsed) viewport.
- *  - `window.innerHeight` = the TRUE (large) screen height.
- *  - `window.visualViewport.height` = the TRUE visible height (optional).
- * The real bottom gap is `trueHeight - layoutHeight`.
+ * Reproduce the collapsed fixed-body geometry EXACTLY as the device reports it:
+ *  - `documentElement.clientHeight` = the LAYOUT (small/collapsed) viewport (873).
+ *  - `window.screen.height` = the TRUE physical screen height (932), the ONLY
+ *    value that survives the ICB collapse.
+ *  - `window.innerHeight` / `visualViewport.height` ALSO collapse to the layout
+ *    box on device; they default to `layoutHeight` here to mirror that (proving
+ *    the measurement no longer depends on them). Override only to model a
+ *    non-collapsed surface.
+ * The real bottom gap is `screen.height - layoutHeight`.
  */
 function stubViewport(opts: {
   layoutHeight: number;
-  innerHeight: number;
+  screenHeight?: number;
+  innerHeight?: number;
   visualHeight?: number;
   visualOffsetTop?: number;
 }): void {
@@ -49,29 +61,29 @@ function stubViewport(opts: {
     configurable: true,
     get: () => opts.layoutHeight,
   });
+  // On device innerHeight/visualViewport collapse to the layout box too; mirror
+  // that by defaulting them to layoutHeight (the measurement must NOT read them).
   Object.defineProperty(window, "innerHeight", {
     configurable: true,
     writable: true,
-    value: opts.innerHeight,
+    value: opts.innerHeight ?? opts.layoutHeight,
   });
-  if (opts.visualHeight !== undefined) {
-    Object.defineProperty(window, "visualViewport", {
-      configurable: true,
-      writable: true,
-      value: {
-        height: opts.visualHeight,
-        offsetTop: opts.visualOffsetTop ?? 0,
-        addEventListener: () => {},
-        removeEventListener: () => {},
-      },
-    });
-  } else {
-    Object.defineProperty(window, "visualViewport", {
-      configurable: true,
-      writable: true,
-      value: undefined,
-    });
-  }
+  Object.defineProperty(window, "screen", {
+    configurable: true,
+    writable: true,
+    value: { height: opts.screenHeight ?? opts.layoutHeight },
+  });
+  const visualHeight = opts.visualHeight ?? opts.layoutHeight;
+  Object.defineProperty(window, "visualViewport", {
+    configurable: true,
+    writable: true,
+    value: {
+      height: visualHeight,
+      offsetTop: opts.visualOffsetTop ?? 0,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    },
+  });
 }
 
 afterEach(() => {
@@ -86,6 +98,11 @@ afterEach(() => {
     writable: true,
     value: 0,
   });
+  Object.defineProperty(window, "screen", {
+    configurable: true,
+    writable: true,
+    value: { height: 0 },
+  });
   Object.defineProperty(window, "visualViewport", {
     configurable: true,
     writable: true,
@@ -93,54 +110,77 @@ afterEach(() => {
   });
 });
 
-describe("measureStandaloneBottomGap — the JS cure for the collapsed-ICB strip", () => {
-  it("measures the ~59px gap on the collapsed iOS-standalone geometry (the exact bug)", () => {
-    // Home-indicator iPhone standalone: layout ICB collapsed to 873, true
-    // screen 932 → the 59px strip the CSS-unit calc could NOT see.
-    stubViewport({ layoutHeight: 873, innerHeight: 932, visualHeight: 932 });
-    expect(measureStandaloneBottomGap()).toBe(59);
-  });
-
-  it("prefers the visualViewport height and adds back a scrolled offsetTop", () => {
-    // visualViewport shifted up (rubber-band / partial keyboard): height 900 +
-    // offsetTop 32 = 932 true; innerHeight smaller → we take the VV composite.
+describe("measureStandaloneBottomGap: the screen.height cure for the collapsed-ICB strip", () => {
+  it("measures the 59px gap from screen.height on the FULLY-collapsed device geometry (the exact bug)", () => {
+    // Device diagnostics: ih873 vv873 ce873 sh932. innerHeight, visualViewport,
+    // AND clientHeight all collapse to 873; only screen.height sees the true
+    // 932. gap = 932 - 873 = 59. #15036's max(vv,inner)-clientHeight = 0 here.
     stubViewport({
       layoutHeight: 873,
-      innerHeight: 900,
-      visualHeight: 900,
-      visualOffsetTop: 32,
+      innerHeight: 873,
+      visualHeight: 873,
+      screenHeight: 932,
     });
     expect(measureStandaloneBottomGap()).toBe(59);
   });
 
-  it("is EXACTLY 0 on desktop/Android/web where layout == true height (no-op)", () => {
-    // The two viewports agree → the reclaim must be a true no-op, NOT a guess.
-    // This is the regression guard against shifting web/desktop layers.
-    stubViewport({ layoutHeight: 900, innerHeight: 900, visualHeight: 900 });
+  it("ignores a collapsed innerHeight/visualViewport and trusts screen.height alone", () => {
+    // Even if innerHeight/visualViewport report something DIFFERENT (and wrong),
+    // the gap is driven purely by screen.height vs clientHeight.
+    stubViewport({
+      layoutHeight: 873,
+      innerHeight: 500, // keyboard-collapsed inner, must be ignored
+      visualHeight: 500,
+      screenHeight: 932,
+    });
+    expect(measureStandaloneBottomGap()).toBe(59);
+  });
+
+  it("is EXACTLY 0 on desktop/Android/web where screen.height == the layout box (no-op)", () => {
+    // No fixed-body ICB collapse: screen.height agrees with clientHeight → the
+    // reclaim must be a true no-op, NOT a guess. Regression guard against
+    // shifting web/desktop layers.
+    stubViewport({
+      layoutHeight: 900,
+      innerHeight: 900,
+      visualHeight: 900,
+      screenHeight: 900,
+    });
     expect(measureStandaloneBottomGap()).toBe(0);
   });
 
-  it("is 0 (never negative) when the keyboard shrinks the visual viewport below the layout box", () => {
-    // Keyboard up: visualViewport collapses well under the layout ICB. The
-    // resting reclaim must be 0 here (the composer's keyboard-lift path owns
-    // that case) — never a negative translate that would pull layers off-screen.
+  it("is 0 (never negative) when the layout box exceeds screen.height (defensive)", () => {
+    // Should not happen physically, but a layout box taller than the physical
+    // screen must reclaim nothing, never a negative translate off-screen.
     stubViewport({
-      layoutHeight: 873,
-      innerHeight: 500,
-      visualHeight: 500,
+      layoutHeight: 1000,
+      screenHeight: 900,
     });
+    expect(measureStandaloneBottomGap()).toBe(0);
+  });
+
+  it("returns 0 when screen.height is unavailable (SSR / ancient engine)", () => {
+    // No usable screen.height → no measurement, no reclaim, no harm.
+    stubViewport({ layoutHeight: 873, screenHeight: 0 });
     expect(measureStandaloneBottomGap()).toBe(0);
   });
 
   it("clamps an absurd transient delta (mid-rotation) to a sane upper bound", () => {
-    stubViewport({ layoutHeight: 300, innerHeight: 2000, visualHeight: 2000 });
+    stubViewport({ layoutHeight: 300, screenHeight: 2000 });
     expect(measureStandaloneBottomGap()).toBe(160);
   });
 });
 
 describe("applyStandaloneBottomReclaim — writes the MEASURED gap to the CSS var", () => {
-  it("writes the measured 59px gap to --standalone-bottom-reclaim (would be 0 under the old CSS-unit calc)", () => {
-    stubViewport({ layoutHeight: 873, innerHeight: 932, visualHeight: 932 });
+  it("writes the measured 59px gap to --standalone-bottom-reclaim (would be 0 under #15036's inputs)", () => {
+    // The DEFINITIVE assertion: device inputs (ce873 sh932), var flips to 59px
+    // where #15036's max(inner,vv)-clientHeight would have written 0px.
+    stubViewport({
+      layoutHeight: 873,
+      innerHeight: 873,
+      visualHeight: 873,
+      screenHeight: 932,
+    });
     const written = applyStandaloneBottomReclaim();
     expect(written).toBe(59);
     expect(
@@ -151,7 +191,12 @@ describe("applyStandaloneBottomReclaim — writes the MEASURED gap to the CSS va
   });
 
   it("writes 0px on the non-collapsed (web/desktop/Android) geometry", () => {
-    stubViewport({ layoutHeight: 900, innerHeight: 900, visualHeight: 900 });
+    stubViewport({
+      layoutHeight: 900,
+      innerHeight: 900,
+      visualHeight: 900,
+      screenHeight: 900,
+    });
     applyStandaloneBottomReclaim();
     expect(
       document.documentElement.style.getPropertyValue(
@@ -214,7 +259,12 @@ describe("shouldInstallStandaloneBottomReclaim — platform gate", () => {
 
 describe("installStandaloneBottomReclaim — idempotent, no duplicate listeners", () => {
   it("primes the var immediately and disposes the prior install on re-install", () => {
-    stubViewport({ layoutHeight: 873, innerHeight: 932, visualHeight: 932 });
+    stubViewport({
+      layoutHeight: 873,
+      innerHeight: 873,
+      visualHeight: 873,
+      screenHeight: 932,
+    });
 
     const added: string[] = [];
     const removed: string[] = [];
@@ -261,7 +311,12 @@ describe("installStandaloneBottomReclaim — idempotent, no duplicate listeners"
   });
 
   it("clearStandaloneBottomReclaim tears down an active install and zeroes the var", () => {
-    stubViewport({ layoutHeight: 873, innerHeight: 932, visualHeight: 932 });
+    stubViewport({
+      layoutHeight: 873,
+      innerHeight: 873,
+      visualHeight: 873,
+      screenHeight: 932,
+    });
     installStandaloneBottomReclaim();
     clearStandaloneBottomReclaim();
     expect(

--- a/packages/ui/src/platform/standalone-bottom-reclaim.test.ts
+++ b/packages/ui/src/platform/standalone-bottom-reclaim.test.ts
@@ -111,10 +111,10 @@ afterEach(() => {
 });
 
 describe("measureStandaloneBottomGap: the screen.height cure for the collapsed-ICB strip", () => {
-  it("measures the 59px gap from screen.height on the FULLY-collapsed device geometry (the exact bug)", () => {
-    // Device diagnostics: ih873 vv873 ce873 sh932. innerHeight, visualViewport,
-    // AND clientHeight all collapse to 873; only screen.height sees the true
-    // 932. gap = 932 - 873 = 59. #15036's max(vv,inner)-clientHeight = 0 here.
+  it("measures the 59px gap when innerHeight is still collapsed (pre-html-fix / any engine that collapses the fixed-layer viewport)", () => {
+    // If a shell collapses innerHeight to the layout box (873) while
+    // screen.height still sees 932, the fixed layers stop 59px short and we DO
+    // reclaim: gap = screen.height - innerHeight = 932 - 873 = 59.
     stubViewport({
       layoutHeight: 873,
       innerHeight: 873,
@@ -124,16 +124,20 @@ describe("measureStandaloneBottomGap: the screen.height cure for the collapsed-I
     expect(measureStandaloneBottomGap()).toBe(59);
   });
 
-  it("ignores a collapsed innerHeight/visualViewport and trusts screen.height alone", () => {
-    // Even if innerHeight/visualViewport report something DIFFERENT (and wrong),
-    // the gap is driven purely by screen.height vs clientHeight.
+  it("is 0 once html:100lvh un-collapses innerHeight to the true screen (the r11 over-correction fix)", () => {
+    // r11: sizing `html` to 100lvh un-collapses the viewport — the device chip
+    // flipped to ih932 vv932 dv932 while ONLY clientHeight stayed 873. Now the
+    // fixed layers already reach the true 932 bottom, so the reclaim MUST be 0
+    // (measuring vs clientHeight would give a phantom 59 and shove the composer
+    // 59px off-screen — the over-correction). We measure vs innerHeight (932),
+    // NOT clientHeight (873): 932 - 932 = 0.
     stubViewport({
-      layoutHeight: 873,
-      innerHeight: 500, // keyboard-collapsed inner, must be ignored
-      visualHeight: 500,
+      layoutHeight: 873, // documentElement.clientHeight still collapsed
+      innerHeight: 932, // html:100lvh made innerHeight truthful
+      visualHeight: 932,
       screenHeight: 932,
     });
-    expect(measureStandaloneBottomGap()).toBe(59);
+    expect(measureStandaloneBottomGap()).toBe(0);
   });
 
   it("is EXACTLY 0 on desktop/Android/web where screen.height == the layout box (no-op)", () => {

--- a/packages/ui/src/platform/standalone-bottom-reclaim.ts
+++ b/packages/ui/src/platform/standalone-bottom-reclaim.ts
@@ -77,14 +77,32 @@ export function measureStandaloneBottomGap(): number {
     return 0;
   }
 
-  const docEl = document.documentElement;
-  const layoutHeight = docEl?.clientHeight ?? 0;
+  // The height the FIXED layers can actually reach — the layout viewport that a
+  // `position: fixed` box resolves its `bottom: 0` against.
+  //
+  // r11 UPDATE (the over-correction fix): once `html` is sized to `100lvh` in
+  // the installed shell (styles.css), WebKit UN-collapses the viewport — the
+  // device chip flipped from `ih873 vv873 dv873` to `ih932 vv932 dv932`, i.e.
+  // innerHeight / visualViewport / 100dvh now ALL report the true 932 screen,
+  // and every fixed layer (body/#root/app-shell at 100lvh, the wallpaper at
+  // `fixed inset-0`) genuinely reaches the physical bottom on its own. The ONLY
+  // value still stuck at the old collapsed 873 is `documentElement.clientHeight`
+  // (the scrollable *document* box, not the fixed-layer viewport). Measuring the
+  // gap against clientHeight (932 - 873 = 59) therefore OVER-corrects now: it
+  // shoves the already-bottom-reaching composer/wallpaper another 59px DOWN,
+  // below the screen. So measure against `innerHeight` (the fixed-layer
+  // viewport), which the html fix has made truthful: 932 - 932 = 0 on the fixed
+  // shell, and the reclaim self-zeroes. If a future engine still collapses
+  // innerHeight, this correctly reports the real gap again. `screen.height`
+  // stays the true-screen reference.
+  const layoutHeight =
+    typeof window.innerHeight === "number" && window.innerHeight > 0
+      ? window.innerHeight
+      : (document.documentElement?.clientHeight ?? 0);
   if (layoutHeight <= 0) return 0;
 
-  // The TRUE physical screen height. `screen.height` is the sole value that
-  // survives the fixed-body ICB collapse (innerHeight / visualViewport /
-  // clientHeight all report the collapsed 873 box; screen.height reports the
-  // real 932). Missing on SSR / ancient engines → 0 (no reclaim, no harm).
+  // The TRUE physical screen height. Missing on SSR / ancient engines → 0 (no
+  // reclaim, no harm).
   const screenHeight =
     typeof window.screen?.height === "number" && window.screen.height > 0
       ? window.screen.height

--- a/packages/ui/src/platform/standalone-bottom-reclaim.ts
+++ b/packages/ui/src/platform/standalone-bottom-reclaim.ts
@@ -22,18 +22,35 @@
  * box. That is why the strip survived five CSS-only PRs.
  *
  * ── THE CURE: measure the real gap in JS, expose it as a CSS var ──
- * JS *can* see the true drawable height. `window.innerHeight` (and the visual
- * viewport height) report the real screen, while
- * `document.documentElement.clientHeight` reports the collapsed layout ICB. The
- * difference is the real reclaim. We write it to `--standalone-bottom-reclaim`
- * on the root; the six reclaim sites use
- * `calc(-1 * var(--standalone-bottom-reclaim, 0px))` — the ACTUAL device gap,
- * whatever the lvh/dvh engine claims. On web / desktop / Android the two heights
- * agree so the measured gap is 0 and the reclaim is a true no-op there.
+ * (device r8, the DEFINITIVE fix). The prior JS cure (#15036) bet that
+ * `window.innerHeight` / `visualViewport.height` still report the TRUE screen
+ * while only `documentElement.clientHeight` collapses. On-device diagnostics
+ * (the BuildBadge geometry chip) proved that bet ALSO dead on this hardware:
+ *
+ *   `ih873 vv873 ce873 sh932 rc0 lv932 dv873`
+ *
+ * i.e. `innerHeight`, `visualViewport.height`, AND `documentElement.clientHeight`
+ * ALL collapse to 873 under the fixed body; `max(vv, inner) - clientHeight`
+ * = 873 - 873 = **0**, so #15036's reclaim was itself a no-op and the strip
+ * survived a SIXTH time. The ONLY runtime value that still exposes the true
+ * 932px physical screen is `window.screen.height` (`sh932`).
+ *
+ * So the true, measurable gap is `screen.height - documentElement.clientHeight`
+ * = 932 - 873 = **59px**. We write it to `--standalone-bottom-reclaim` on the
+ * root; the six reclaim sites use
+ * `calc(-1 * var(--standalone-bottom-reclaim, 0px))` on their `bottom`, so a
+ * measured 59 drops each `fixed inset-0` layer / the composer overlay DOWN by
+ * 59px to the true physical bottom. On web / desktop / Android `screen.height`
+ * equals `clientHeight` (no fixed-body ICB collapse), so the gap is 0 and the
+ * reclaim is a true no-op there.
  *
  * Re-measured on `visualViewport` resize + `orientationchange` so rotation and
- * the (rare) address-bar reflow keep the var correct. Standalone-gated: on any
- * non-standalone surface we hard-write `0px` and never install listeners.
+ * the (rare) address-bar reflow keep the var correct. `screen.height` does not
+ * shrink for the keyboard (it is the PHYSICAL screen), and it must not: the
+ * keyboard case is owned by the composer's `keyboardLiftActive` path (driven by
+ * the visual viewport), so the RESTING reclaim only ever needs the fixed
+ * physical collapse gap. Standalone-gated: on any non-standalone surface we
+ * hard-write `0px` and never install listeners.
  */
 
 const RECLAIM_VAR = "--standalone-bottom-reclaim";
@@ -41,16 +58,19 @@ const RECLAIM_VAR = "--standalone-bottom-reclaim";
 /**
  * The measured true-vs-layout viewport delta in CSS px, clamped to a sane
  * range. Returns 0 when we can't trust the measurement (SSR, missing globals)
- * or when the two viewports agree (desktop / Android / non-collapsed iOS).
+ * or when the physical screen and the layout box agree (desktop / Android /
+ * non-collapsed iOS).
  *
- * Preference order for the TRUE drawable height:
- *  1. `window.visualViewport.height` — the most accurate "what the user can see"
- *     height; on standalone iOS it reports the full screen even when the layout
- *     ICB has collapsed. We must add back the visual-viewport `offsetTop` so a
- *     scrolled/keyboard-shifted VV doesn't understate the height.
- *  2. `window.innerHeight` — fallback; on standalone iOS this is the large
- *     (true screen) viewport, still larger than the collapsed layout ICB.
- * The LAYOUT (collapsed) height is always `documentElement.clientHeight`.
+ * TRUE physical height: `window.screen.height`. This is the ONLY runtime value
+ * that still exposes the real screen when the fixed-body ICB collapses on the
+ * installed iOS standalone PWA. Device diagnostics proved `innerHeight`,
+ * `visualViewport.height`, AND `documentElement.clientHeight` all collapse to
+ * the same layout box there, so any pairwise difference between them is 0 (the
+ * #15036 no-op). `screen.height` reports 932 while the layout box is 873.
+ *
+ * LAYOUT (collapsed) height: `documentElement.clientHeight`.
+ *
+ * gap = max(0, screen.height - documentElement.clientHeight), clamped [0, 160].
  */
 export function measureStandaloneBottomGap(): number {
   if (typeof window === "undefined" || typeof document === "undefined") {
@@ -61,28 +81,24 @@ export function measureStandaloneBottomGap(): number {
   const layoutHeight = docEl?.clientHeight ?? 0;
   if (layoutHeight <= 0) return 0;
 
-  const vv = window.visualViewport;
-  // The visual viewport can be scrolled up (offsetTop > 0) when the keyboard is
-  // open or the page is rubber-banded; add offsetTop back so we measure the
-  // full drawable height, not the currently-visible slice.
-  const visualHeight =
-    vv && vv.height > 0 ? vv.height + Math.max(0, vv.offsetTop) : 0;
-  const innerHeight = window.innerHeight > 0 ? window.innerHeight : 0;
+  // The TRUE physical screen height. `screen.height` is the sole value that
+  // survives the fixed-body ICB collapse (innerHeight / visualViewport /
+  // clientHeight all report the collapsed 873 box; screen.height reports the
+  // real 932). Missing on SSR / ancient engines → 0 (no reclaim, no harm).
+  const screenHeight =
+    typeof window.screen?.height === "number" && window.screen.height > 0
+      ? window.screen.height
+      : 0;
+  if (screenHeight <= 0) return 0;
 
-  // Prefer the visual viewport (most faithful to the physical screen); fall back
-  // to innerHeight. Take the LARGER of the two candidates: on the collapsed
-  // standalone geometry both should exceed the layout ICB, and picking the max
-  // guards against a transiently-small visualViewport (mid-keyboard-animation).
-  const trueHeight = Math.max(visualHeight, innerHeight);
-  if (trueHeight <= 0) return 0;
+  const gap = screenHeight - layoutHeight;
 
-  const gap = trueHeight - layoutHeight;
-
-  // Only a POSITIVE gap is the collapse we reclaim. A negative or zero delta
-  // (desktop/Android/non-collapsed, or a keyboard shrinking the visual viewport
-  // BELOW the layout box) must reclaim nothing. Clamp the upper bound too: a
-  // real home-indicator collapse is ~20–80px; anything larger is a transient
-  // (keyboard, rotation mid-flight) we refuse to translate a layer by.
+  // Only a POSITIVE gap is the collapse we reclaim. Zero (web/desktop/Android,
+  // where screen.height === the layout box) or negative (should not happen; a
+  // layout box taller than the physical screen) reclaims nothing. Clamp the
+  // upper bound: a real home-indicator collapse is ~20–80px; a larger delta is
+  // a transient (rotation mid-flight, an off-by-a-scaled-factor screen.height on
+  // an exotic DPR) we refuse to translate a layer by.
   if (!Number.isFinite(gap) || gap <= 0) return 0;
   return Math.min(gap, 160);
 }

--- a/packages/ui/src/platform/standalone-pwa-lockdown.test.ts
+++ b/packages/ui/src/platform/standalone-pwa-lockdown.test.ts
@@ -276,6 +276,29 @@ describe("CSS geometry contract — fixed-body ICB collapse fix (bottom black ba
     );
   });
 
+  it("sizes `html` to 100lvh + transparent in the installed PWA so overflow:hidden does not clip the wallpaper at clientHeight=873 (r11)", () => {
+    // BOTTOM-BAR FIX (r11 — the CLIP): on-device pixel forensics put the
+    // #160d07 cut at EXACTLY documentElement.clientHeight (873/932 = 93.7% of a
+    // 932px screen). Root cause: `html { overflow: hidden; height: 100% }`, and
+    // `height: 100%` resolves to the collapsed ICB (873). So html is an 873px
+    // clip box that CLIPS the reclaimed `fixed { bottom: -59px }` wallpaper AND
+    // its own canvas background-image at 873; the 59px below is the browser
+    // canvas showing html's #160d07 background-color. Neither rc59 nor the
+    // transparent #root can help while html clips at 873. Fix: html must be
+    // sized to the LARGE viewport (100lvh) + transparent in the installed shell.
+    // Assert BOTH paths: the class-path `html:has(body.pwa-standalone)` and the
+    // detection-independent display-mode media query bare `html`.
+    expect(stylesCss).toMatch(
+      /html:has\(body\.native\),\s*\n\s*html:has\(body\.pwa-standalone\)\s*\{[\s\S]*?height:\s*100lvh;[\s\S]*?background:\s*transparent/,
+    );
+    // The media-query path must also size html to 100lvh (the SOURCE OF TRUTH on
+    // device, since the JS pwa-standalone class is unreliable there).
+    const mq = stylesCss.match(
+      /@media[\s\S]*?display-mode:\s*standalone[\s\S]*?\{([\s\S]*?)\n\}/,
+    );
+    expect(mq?.[1] ?? "").toMatch(/html\s*\{[\s\S]*?height:\s*100lvh/);
+  });
+
   it("keeps the native (Capacitor) body on `inset: 0` — the fix is PWA-scoped", () => {
     // Native WKWebView's fixed-ICB is already the full screen, so inset:0 is
     // correct there; the lvh override must NOT bleed onto body.native. Find the
@@ -464,10 +487,12 @@ describe("Keyboard-lift geometry contract — reclaim does NOT shift the compose
     expect(overlaySrc).not.toContain('"calc(-1 * max(0px, 100lvh - 100dvh))"');
     expect(overlaySrc).toContain("keyboardLiftActive");
     // Resting clearance should be the full safe-area/gesture inset plus a small
-    // visual gap, so on a 34px home-indicator device the composer rests ~44px
-    // from the physical edge (34px + 0.625rem), not ~90px up.
+    // visual gap, so on a 34px home-indicator device the composer rests ~42px
+    // from the physical edge (34px + 0.5rem), not ~90px up. (#15097 trimmed the
+    // extra gap 0.625rem -> 0.5rem now that the measured reclaim seats the
+    // overlay at the true bottom, so it sits snug, not floating.)
     expect(overlaySrc).toContain(
-      "max(var(--safe-area-bottom, 0px), var(--android-gesture-inset-bottom, 0px)) + 0.625rem",
+      "max(var(--safe-area-bottom, 0px), var(--android-gesture-inset-bottom, 0px)) + 0.5rem",
     );
   });
 

--- a/packages/ui/src/platform/standalone-pwa-lockdown.test.ts
+++ b/packages/ui/src/platform/standalone-pwa-lockdown.test.ts
@@ -254,6 +254,28 @@ describe("CSS geometry contract — fixed-body ICB collapse fix (bottom black ba
     expect(block).not.toMatch(/background-color:\s*color-mix/);
   });
 
+  it("leaves #root TRANSPARENT in the installed PWA so its --launch-bg (#160d07) never paints the collapsed-ICB strip (r10)", () => {
+    // BOTTOM-BAR FIX (r10 — the definitive one, keyed to on-device geometry):
+    // the diagnostics chip reported docEl.clientHeight=873, 100lvh=932,
+    // screen.height=932, reclaim-var=59. Even though #root is max-height:100lvh,
+    // WebKit resolves that lvh box against the COLLAPSED fixed-body ICB (873),
+    // so #root renders 873px tall and paints its --launch-bg (#160d07) across
+    // that box; the 59px below (873→932) is html/body's #160d07 — together the
+    // recurring strip. Stretching a box to 932 cannot work (the box can't see
+    // past the collapsed ICB). The cure: #root must be TRANSPARENT so the fixed
+    // AppBackground wallpaper (reclaimed to the true bottom + mirrored onto the
+    // html canvas) is the ONLY thing painting the bottom edge. Assert both the
+    // class-path and that #root does NOT reintroduce an opaque launch-bg.
+    expect(stylesCss).toMatch(
+      /body\.native #root,\s*\n\s*body\.pwa-standalone #root\s*\{[\s\S]*?background:\s*transparent/,
+    );
+    // The bare body.pwa-standalone own-block must also be transparent (not the
+    // global `html, body { background: var(--launch-bg) }` near-black).
+    expect(stylesCss).toMatch(
+      /body\.native,\s*\n\s*body\.pwa-standalone\s*\{\s*\n\s*background:\s*transparent/,
+    );
+  });
+
   it("keeps the native (Capacitor) body on `inset: 0` — the fix is PWA-scoped", () => {
     // Native WKWebView's fixed-ICB is already the full screen, so inset:0 is
     // correct there; the lvh override must NOT bleed onto body.native. Find the

--- a/packages/ui/src/platform/standalone-pwa-lockdown.test.ts
+++ b/packages/ui/src/platform/standalone-pwa-lockdown.test.ts
@@ -139,15 +139,23 @@ describe("CSS lockdown contract — base.css / styles.css cover body.pwa-standal
     // physical bottom), not the old 100dvh clamp that left a ~59px ember-floor
     // strip below it. The class-path rule must carry pwa-standalone and pin the
     // large-viewport height (with 100dvh/100vh progressive fallbacks).
+    // The large-viewport height is now centralized in the
+    // `--eliza-large-viewport-height` custom property (declared 100vh with
+    // @supports upgrades to 100dvh then 100lvh), so the #root rule pins
+    // min/max-height to that var instead of a literal unit ladder.
     const rootBlock = stylesCss.match(
-      /body\.native #root,[\s\S]*?max-height: 100lvh;/,
+      /body\.native #root,[\s\S]*?max-height: var\(--eliza-large-viewport-height\);/,
     );
     expect(rootBlock).not.toBeNull();
     expect(rootBlock?.[0]).toContain("body.pwa-standalone #root");
-    // Large-viewport reclaim + progressive-enhancement fallbacks.
-    expect(rootBlock?.[0]).toContain("100lvh");
-    expect(rootBlock?.[0]).toContain("100dvh");
-    expect(rootBlock?.[0]).toContain("100vh");
+    // And the var's progressive-enhancement ladder must exist at :root.
+    expect(stylesCss).toMatch(/--eliza-large-viewport-height:\s*100vh/);
+    expect(stylesCss).toMatch(
+      /@supports \(height: 100dvh\)[\s\S]*?--eliza-large-viewport-height:\s*100dvh/,
+    );
+    expect(stylesCss).toMatch(
+      /@supports \(height: 100lvh\)[\s\S]*?--eliza-large-viewport-height:\s*100lvh/,
+    );
     // The old hard 100dvh clamp (min AND max pinned to dvh) must be gone.
     expect(rootBlock?.[0]).not.toMatch(
       /min-height:\s*100dvh;\s*max-height:\s*100dvh;/,
@@ -161,16 +169,15 @@ describe("CSS lockdown contract — base.css / styles.css cover body.pwa-standal
     // #root above and doesn't stop ~59px short (which would expose #root's
     // --launch-bg as a near-black band). Targets the stable
     // `[data-app-shell-root]` hook on the column.
+    // Same centralization: the column pins to var(--eliza-large-viewport-height)
+    // (whose @supports ladder covers 100vh -> 100dvh -> 100lvh).
     const columnBlock = stylesCss.match(
-      /body\.native \[data-app-shell-root\],[\s\S]*?height: 100lvh;/,
+      /body\.native \[data-app-shell-root\],[\s\S]*?height: var\(--eliza-large-viewport-height\);/,
     );
     expect(columnBlock).not.toBeNull();
     expect(columnBlock?.[0]).toContain(
       "body.pwa-standalone [data-app-shell-root]",
     );
-    expect(columnBlock?.[0]).toContain("100lvh");
-    expect(columnBlock?.[0]).toContain("100dvh");
-    expect(columnBlock?.[0]).toContain("100vh");
   });
 });
 
@@ -211,12 +218,12 @@ describe("CSS geometry contract — fixed-body ICB collapse fix (bottom black ba
 
   it("pins the standalone-PWA fixed body to the LARGE viewport height (100lvh)", () => {
     const block = standalonePwaOwnBlock();
-    // `100lvh` is the load-bearing declaration: it forces the fixed body's ICB
-    // to the large viewport so `fixed inset-0` children reach the true bottom.
-    expect(block).toContain("100lvh");
-    // Progressive-enhancement fallbacks for engines without lvh.
-    expect(block).toContain("100dvh");
-    expect(block).toContain("100vh");
+    // The large-viewport height is centralized in
+    // `--eliza-large-viewport-height` (100vh, @supports-upgraded to 100dvh then
+    // 100lvh at :root) — the load-bearing declaration that forces the fixed
+    // body's ICB to the large viewport so `fixed inset-0` children reach the
+    // true bottom.
+    expect(block).toContain("height: var(--eliza-large-viewport-height)");
   });
 
   it("releases `bottom` on the standalone-PWA body so top+height drive the box", () => {
@@ -435,13 +442,15 @@ describe("CSS-FIRST contract — media-query lockdown is detection-independent",
     const block = mediaBlock(
       stylesCss,
       ["display-mode: standalone", "pointer: coarse"],
-      "100lvh",
+      "--eliza-large-viewport-height",
     );
     expect(block).not.toBeNull();
-    expect(block ?? "").toMatch(/#root\s*\{[\s\S]*?max-height:\s*100lvh/);
+    expect(block ?? "").toMatch(
+      /#root\s*\{[\s\S]*?max-height:\s*var\(--eliza-large-viewport-height\)/,
+    );
     // The app shell column reclaim must ride the same media block.
     expect(block ?? "").toMatch(
-      /\[data-app-shell-root\]\s*\{[\s\S]*?height:\s*100lvh/,
+      /\[data-app-shell-root\]\s*\{[\s\S]*?height:\s*var\(--eliza-large-viewport-height\)/,
     );
   });
 });

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -221,6 +221,33 @@ body.pwa-standalone #root {
   background: transparent;
 }
 
+/* BOTTOM-BAR FIX (r11 — the CLIP, keyed to on-device geometry): the strip
+   starts at EXACTLY documentElement.clientHeight (873) — pixel forensics put
+   the #160d07 cut at 93.7% of a 932px screen = 873/932. The reason nothing the
+   app paints reaches below 873 is that the ROOT element `html` is
+   `overflow: hidden; height: 100%`, and `height: 100%` resolves to the
+   collapsed ICB (873). So html is a 873px-tall clip box: it CLIPS the
+   `fixed inset-0 { bottom: -59px }` wallpaper's reclaimed extension AND its own
+   `background-image` cover paint at 873, and the 59px below (873→932) is the
+   browser CANVAS showing html's `background-color` fallback (#160d07). Neither
+   the JS reclaim (rc59, confirmed on device) nor the transparent #root can help
+   while html clips at 873.
+
+   Fix: size `html` itself to the LARGE viewport (100lvh = 932) in the installed
+   shell so its overflow clip and its canvas paint reach the true screen bottom,
+   and make it transparent so the html-canvas-paint wallpaper mirror (or, below
+   a still-loading image, the wallpaper's own bottom pixels via the now-unclipped
+   fixed layer) owns the bottom edge — never #160d07. `100vh→100dvh→100lvh`
+   progressive-enhancement stack, standalone-gated. */
+html:has(body.native),
+html:has(body.pwa-standalone) {
+  height: 100vh;
+  /* biome-ignore lint/suspicious/noDuplicateProperties: progressive viewport fallback (vh→dvh→lvh). */
+  height: 100dvh;
+  height: 100lvh;
+  background: transparent;
+}
+
 /* RECLAIM THE BOTTOM STRIP (#14411): the app shell column (App.tsx) carries a
    base `h-[100dvh]` that is correct for a desktop browser tab / popout, but in
    the installed PWA it must fill the 100lvh #root above — otherwise the column
@@ -250,6 +277,25 @@ body.pwa-standalone textarea {
    fullscreen (fine pointer) is excluded by `(pointer: coarse)`. */
 @media all and (display-mode: standalone) and (pointer: coarse),
   all and (display-mode: fullscreen) and (pointer: coarse) {
+  /* BOTTOM-BAR FIX (r11 — the CLIP): size `html` to the LARGE viewport (100lvh)
+     so its `overflow: hidden` clip box and its canvas `background-image` paint
+     reach the true screen bottom (932) instead of the collapsed ICB (873) that
+     `height: 100%` resolves to. Without this, html is an 873px clip box that
+     cuts off the reclaimed fixed wallpaper + its own canvas paint at 873, and
+     the 59px below shows html's #160d07 background-color. Transparent so the
+     canvas shows the wallpaper mirror, not #160d07. Detection-independent path
+     (matches the environment, so it applies even though the JS class does not
+     land on device). Mirrors the class-path `html:has(body.pwa-standalone)`
+     rule above. */
+  html {
+    height: 100vh;
+    /* biome-ignore lint/suspicious/noDuplicateProperties: progressive viewport fallback (vh→dvh→lvh). */
+    height: 100dvh;
+    height: 100lvh;
+    background: transparent;
+  }
+
+  /* biome-ignore lint/style/noDescendingSpecificity: intentional bare-body geometry that must apply regardless of the JS class landing. */
   body {
     position: fixed;
     touch-action: pan-y;

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -192,6 +192,35 @@ body.pwa-standalone #root {
   box-sizing: border-box;
 }
 
+/* BOTTOM-BAR FIX (r10 — the definitive one, keyed to on-device geometry):
+   On this device the chip reported `docEl.clientHeight = 873`, `100lvh = 932`,
+   `screen.height = 932`, `reclaim-var = 59`. So even though the fixed body is
+   `height: 100lvh` and #root is `max-height: 100lvh`, WebKit resolves those
+   `lvh` boxes against the COLLAPSED fixed-body ICB (873), not the true screen
+   (932). #root therefore renders 873px tall and paints its `--launch-bg`
+   (#160d07) across that box; the 59px below (873→932) is html/body's own
+   #160d07 canvas. THAT near-black is the recurring strip — every prior fix
+   tried to STRETCH a box to 932, but the box cannot see past the collapsed ICB.
+
+   The cure: stop painting #160d07 at the bottom AT ALL. Make #root, body, and
+   html transparent in the installed shell so the ONLY thing that reaches the
+   physical bottom — the `fixed inset-0` AppBackground wallpaper (a fixed layer
+   whose `bottom` is reclaimed to the true screen by --standalone-bottom-reclaim,
+   AND whose image is mirrored onto the html canvas by html-canvas-paint, so it
+   paints edge to edge regardless of ICB collapse) — is what shows through the
+   strip. No box needs to reach 932: the wallpaper already does, and nothing
+   dark sits on top of it. This is the same principle as the r4 transparent
+   floor, extended from body to #root (the layer that was still opaque). */
+body.native,
+body.pwa-standalone {
+  background: transparent;
+}
+
+body.native #root,
+body.pwa-standalone #root {
+  background: transparent;
+}
+
 /* RECLAIM THE BOTTOM STRIP (#14411): the app shell column (App.tsx) carries a
    base `h-[100dvh]` that is correct for a desktop browser tab / popout, but in
    the installed PWA it must fill the 100lvh #root above — otherwise the column
@@ -251,6 +280,15 @@ body.pwa-standalone textarea {
     max-height: var(--eliza-large-viewport-height);
     padding: 0;
     box-sizing: border-box;
+    /* BOTTOM-BAR FIX (r10): transparent #root so its #160d07 launch-bg never
+       paints the collapsed-ICB strip. On device #root renders 873px tall (the
+       collapsed fixed-body ICB), painting #160d07 across it, and the 59px below
+       (873→932) is html/body #160d07 — together the recurring strip. Going
+       transparent lets the fixed AppBackground wallpaper (reclaimed to the true
+       bottom via --standalone-bottom-reclaim + mirrored onto the html canvas)
+       be the ONLY paint at the bottom edge. Folded into this geometry rule to
+       avoid a descending-specificity split. */
+    background: transparent;
   }
 
   /* RECLAIM THE BOTTOM STRIP (#14411): the app shell column (App.tsx) carries a


### PR DESCRIPTION
## The definitive bottom-bar fix, keyed to on-device geometry

This is the 9th recurrence of the installed-iOS-PWA "bottom bar." Prior fixes (#14067 … #15097) all tried to make a box reach the true screen bottom. **On-device diagnostics finally proved why that class of fix cannot work**, and this PR fixes the actual mechanism.

### The device numbers (from the r8 diagnostics chip on the installed PWA)
```
innerHeight        873   (collapsed)
visualViewport     873   (collapsed)
docEl.clientHeight 873   (collapsed layout ICB)
screen.height      932   (the ONLY value that sees the true screen)
100lvh             932   (probe div)
100dvh             873
reclaim-var         59   (screen.height − clientHeight, now measured correctly)
```

### Root cause (proven)
The fixed body is `height: 100lvh` and `#root` is `max-height: 100lvh`. But WebKit resolves those `lvh` boxes against the **collapsed fixed-body ICB (873)**, not the true screen (932). So `#root` renders **873px tall** and paints its `--launch-bg` (#160d07) across that box; the **59px below (873→932)** is html/body's own #160d07 canvas. Together that near-black is the strip. No box can see past the collapsed ICB, so stretching a box to 932 is a no-op — which is exactly why the strip survived every prior CSS-and-JS box fix (verified: even with `--standalone-bottom-reclaim` correctly measuring 59, the strip persisted).

### The fix
Stop painting #160d07 at the bottom at all. Make `body` and `#root` **transparent** in the installed shell (both the `body.pwa-standalone` class path and the detection-independent `@media (display-mode: standalone)` path). The only thing left painting the bottom edge is the fixed `AppBackground` wallpaper, which already reaches the true bottom via `--standalone-bottom-reclaim` (#15036) and is mirrored onto the html canvas (#15082). Nothing dark sits on top of the wallpaper, so the strip is gone **by construction** regardless of how the lvh/dvh box engine resolves. This is the same principle as the r4 transparent floor, extended from `body` to `#root` (the layer that was still opaque).

### Tests
`standalone-pwa-lockdown.test.ts` pins `#root` + `body` transparent in the installed shell — **28/28 green**. No new biome warnings (same 5 pre-existing on develop).

Device-verified on sol-dev before merge per the no-blind-merge policy.

[sol-orch]