### PR TITLE
fix(core): add optimized context config artifacts

### DIFF
--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -299,7 +299,11 @@ export {
 } from "./services/message/direct-action-heuristics";
 export * from "./services/notification";
 export * from "./services/optimized-prompt";
-export { resolveOptimizedPromptForRuntime } from "./services/optimized-prompt-resolver";
+export {
+	applyOptimizedProviderSelection,
+	resolveOptimizedContextConfigForRuntime,
+	resolveOptimizedPromptForRuntime,
+} from "./services/optimized-prompt-resolver";
 export * from "./services/pairing";
 export * from "./services/pairing-integration";
 export * from "./services/relationships-graph-builder";

--- a/packages/core/src/services/optimized-prompt-resolver.test.ts
+++ b/packages/core/src/services/optimized-prompt-resolver.test.ts
@@ -21,6 +21,8 @@ import {
 	parseDisabledTasksEnv,
 } from "./optimized-prompt";
 import {
+	applyOptimizedProviderSelection,
+	resolveOptimizedContextConfig,
 	resolveOptimizedPrompt,
 	resolveOptimizedPromptForRuntime,
 } from "./optimized-prompt-resolver";
@@ -162,6 +164,7 @@ describe("resolveOptimizedPromptForRuntime — per-task wiring", () => {
 		optimizedPrompt: string;
 	}> = [
 		{ task: "should_respond", optimizedPrompt: "OPT_SHOULD_RESPOND" },
+		{ task: "context_routing", optimizedPrompt: "OPT_CONTEXT_ROUTING" },
 		{ task: "action_planner", optimizedPrompt: "OPT_ACTION_PLANNER" },
 		{ task: "response", optimizedPrompt: "OPT_RESPONSE" },
 		{ task: "media_description", optimizedPrompt: "OPT_MEDIA_DESCRIPTION" },
@@ -255,5 +258,70 @@ describe("resolveOptimizedPromptForRuntime — per-task wiring", () => {
 	test("runtime without getService → baseline", () => {
 		const out = resolveOptimizedPromptForRuntime({}, "response", BASELINE);
 		expect(out).toBe(BASELINE);
+	});
+});
+
+describe("optimized context config", () => {
+	test("resolves contextConfig from the optimized artifact", () => {
+		const service = new OptimizedPromptService();
+		service.setDisabledTasksFromEnv(undefined);
+		const direct = service as unknown as {
+			cache: Partial<
+				Record<
+					OptimizedPromptTask,
+					{ artifact: OptimizedPromptArtifact; loadedAt: number }
+				>
+			>;
+		};
+		direct.cache.action_planner = {
+			artifact: {
+				...makeArtifact("action_planner", "OPT_ACTION_PLANNER"),
+				contextConfig: {
+					providerSet: ["RECENT_MESSAGES", "ACTIONS", "FACTS"],
+					providerOrder: ["FACTS", "RECENT_MESSAGES"],
+					renderTemplates: {
+						RECENT_MESSAGES: "{{role}}: {{text}}",
+					},
+					budgetVector: {
+						RECENT_MESSAGES: 1200,
+					},
+				},
+			},
+			loadedAt: Date.now(),
+		};
+
+		expect(resolveOptimizedContextConfig(service, "action_planner")).toEqual({
+			providerSet: ["RECENT_MESSAGES", "ACTIONS", "FACTS"],
+			providerOrder: ["FACTS", "RECENT_MESSAGES"],
+			renderTemplates: {
+				RECENT_MESSAGES: "{{role}}: {{text}}",
+			},
+			budgetVector: {
+				RECENT_MESSAGES: 1200,
+			},
+		});
+	});
+
+	test("applies provider set and order without inventing providers", () => {
+		const selected = applyOptimizedProviderSelection(
+			["ACTIONS", "RECENT_MESSAGES", "FACTS", "PLATFORM"],
+			{
+				providerSet: ["RECENT_MESSAGES", "FACTS", "MISSING"],
+				providerOrder: ["MISSING", "FACTS", "RECENT_MESSAGES"],
+			},
+		);
+
+		expect(selected).toEqual(["FACTS", "RECENT_MESSAGES"]);
+	});
+
+	test("preserves eligible providers not named in providerOrder", () => {
+		const selected = applyOptimizedProviderSelection(
+			["ACTIONS", "RECENT_MESSAGES", "FACTS"],
+			{
+				providerOrder: ["FACTS"],
+			},
+		);
+
+		expect(selected).toEqual(["FACTS", "ACTIONS", "RECENT_MESSAGES"]);
 	});
 });

--- a/packages/core/src/services/optimized-prompt-resolver.ts
+++ b/packages/core/src/services/optimized-prompt-resolver.ts
@@ -19,6 +19,7 @@
 
 import {
 	OPTIMIZED_PROMPT_SERVICE,
+	type OptimizedPromptContextConfig,
 	type OptimizedPromptFewShotExample,
 	type OptimizedPromptService,
 	type OptimizedPromptTask,
@@ -65,6 +66,55 @@ export function resolveOptimizedPrompt(
 		return optimized.prompt;
 	}
 	return injectDemonstrations(optimized.prompt, optimized.fewShotExamples);
+}
+
+export function resolveOptimizedContextConfig(
+	service: OptimizedPromptService | null | undefined,
+	task: OptimizedPromptTask,
+): OptimizedPromptContextConfig | null {
+	if (!service) return null;
+	const optimized = service.getPrompt(task);
+	return optimized?.contextConfig ?? null;
+}
+
+export function resolveOptimizedContextConfigForRuntime(
+	runtime: OptimizedPromptRuntimeLike,
+	task: OptimizedPromptTask,
+): OptimizedPromptContextConfig | null {
+	const service =
+		(runtime.getService?.(OPTIMIZED_PROMPT_SERVICE) as
+			| OptimizedPromptService
+			| null
+			| undefined) ?? null;
+	return resolveOptimizedContextConfig(service, task);
+}
+
+/**
+ * Apply a learned provider selection/order genome to the provider names the
+ * runtime already deemed eligible. This is deliberately pure: runtime hook
+ * registration can call it without giving artifacts authority to invent
+ * providers that are not registered for the current turn.
+ */
+export function applyOptimizedProviderSelection(
+	current: readonly string[],
+	contextConfig: OptimizedPromptContextConfig | null | undefined,
+): string[] {
+	if (!contextConfig) return [...current];
+	const allowed =
+		contextConfig.providerSet && contextConfig.providerSet.length > 0
+			? new Set(contextConfig.providerSet)
+			: null;
+	const deduped = new Set<string>();
+	for (const name of current) {
+		if (typeof name !== "string" || name.length === 0) continue;
+		if (allowed && !allowed.has(name)) continue;
+		deduped.add(name);
+	}
+	const ordered: string[] = [];
+	for (const name of contextConfig.providerOrder ?? []) {
+		if (deduped.delete(name)) ordered.push(name);
+	}
+	return [...ordered, ...deduped];
 }
 
 /**

--- a/packages/core/src/services/optimized-prompt.test.ts
+++ b/packages/core/src/services/optimized-prompt.test.ts
@@ -32,6 +32,7 @@ import {
 	type OptimizedPromptArtifact,
 	OptimizedPromptService,
 	parseDisabledTasksEnv,
+	parseOptimizedPromptArtifact,
 } from "./optimized-prompt";
 
 /**
@@ -109,6 +110,35 @@ describe("OptimizedPromptService — symlink-based versioning", () => {
 		expect(readlinkSync(join(dir, OPTIMIZED_PROMPT_PREVIOUS2_LINK))).toBe(
 			"v1.json",
 		);
+	});
+
+	it("strict parser preserves a valid contextConfig channel", () => {
+		const parsed = parseOptimizedPromptArtifact({
+			...makeArtifact(1),
+			contextConfig: {
+				providerSet: ["RECENT_MESSAGES", "", "FACTS"],
+				providerOrder: ["FACTS", "RECENT_MESSAGES"],
+				renderTemplates: {
+					RECENT_MESSAGES: "{{role}}: {{text}}",
+					EMPTY: "",
+				},
+				budgetVector: {
+					RECENT_MESSAGES: 1200,
+					NEGATIVE: -1,
+				},
+			},
+		});
+
+		expect(parsed?.contextConfig).toEqual({
+			providerSet: ["RECENT_MESSAGES", "FACTS"],
+			providerOrder: ["FACTS", "RECENT_MESSAGES"],
+			renderTemplates: {
+				RECENT_MESSAGES: "{{role}}: {{text}}",
+			},
+			budgetVector: {
+				RECENT_MESSAGES: 1200,
+			},
+		});
 	});
 
 	it("retains the most recent OPTIMIZED_PROMPT_RETAIN_VERSIONS artifacts", async () => {

--- a/packages/core/src/services/optimized-prompt.ts
+++ b/packages/core/src/services/optimized-prompt.ts
@@ -66,6 +66,7 @@ export const OPTIMIZED_PROMPT_SERVICE = "optimized_prompt";
 
 export type OptimizedPromptTask =
 	| "should_respond"
+	| "context_routing"
 	| "action_planner"
 	| "response"
 	| "media_description"
@@ -88,6 +89,10 @@ export type OptimizedPromptTask =
 
 export const OPTIMIZED_PROMPT_TASKS: readonly OptimizedPromptTask[] = [
 	"should_respond",
+	// The context-routing dataset is trained separately from should_respond;
+	// keeping it as its own artifact task lets the optimizer promote routing
+	// prompts without aliasing them onto the response gate.
+	"context_routing",
 	"action_planner",
 	"response",
 	"media_description",
@@ -155,6 +160,13 @@ export interface OptimizedPromptLineageEntry {
 	notes?: string;
 }
 
+export interface OptimizedPromptContextConfig {
+	providerSet?: readonly string[];
+	providerOrder?: readonly string[];
+	renderTemplates?: Readonly<Record<string, string>>;
+	budgetVector?: Readonly<Record<string, number>>;
+}
+
 export interface OptimizedPromptArtifact {
 	task: OptimizedPromptTask;
 	optimizer: OptimizerName;
@@ -167,11 +179,13 @@ export interface OptimizedPromptArtifact {
 	generatedAt: string;
 	fewShotExamples?: OptimizedPromptFewShotExample[];
 	lineage: OptimizedPromptLineageEntry[];
+	contextConfig?: OptimizedPromptContextConfig;
 }
 
 export interface OptimizedPromptResolved {
 	prompt: string;
 	fewShotExamples?: OptimizedPromptFewShotExample[];
+	contextConfig?: OptimizedPromptContextConfig;
 	optimizerSource: OptimizerName;
 }
 
@@ -380,7 +394,61 @@ export function parseOptimizedPromptArtifact(
 		generatedAt: raw.generatedAt,
 		lineage,
 		fewShotExamples: fewShot,
+		contextConfig: coerceContextConfig(raw.contextConfig),
 	};
+}
+
+function coerceStringArray(value: unknown): string[] | undefined {
+	if (!Array.isArray(value)) return undefined;
+	const out = value.filter(
+		(entry): entry is string =>
+			typeof entry === "string" && entry.trim().length > 0,
+	);
+	return out.length > 0 ? out : undefined;
+}
+
+function coerceStringRecord(
+	value: unknown,
+): Readonly<Record<string, string>> | undefined {
+	if (!isStringRecord(value)) return undefined;
+	const out: Record<string, string> = {};
+	for (const [key, entry] of Object.entries(value)) {
+		if (typeof entry === "string" && entry.trim().length > 0) {
+			out[key] = entry;
+		}
+	}
+	return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function coerceNumberRecord(
+	value: unknown,
+): Readonly<Record<string, number>> | undefined {
+	if (!isStringRecord(value)) return undefined;
+	const out: Record<string, number> = {};
+	for (const [key, entry] of Object.entries(value)) {
+		if (typeof entry === "number" && Number.isFinite(entry) && entry >= 0) {
+			out[key] = entry;
+		}
+	}
+	return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function coerceContextConfig(
+	value: unknown,
+): OptimizedPromptContextConfig | undefined {
+	if (!isStringRecord(value)) return undefined;
+	const config: OptimizedPromptContextConfig = {
+		providerSet: coerceStringArray(value.providerSet),
+		providerOrder: coerceStringArray(value.providerOrder),
+		renderTemplates: coerceStringRecord(value.renderTemplates),
+		budgetVector: coerceNumberRecord(value.budgetVector),
+	};
+	return config.providerSet ||
+		config.providerOrder ||
+		config.renderTemplates ||
+		config.budgetVector
+		? config
+		: undefined;
 }
 
 function coerceFewShot(
@@ -509,6 +577,7 @@ export class OptimizedPromptService extends Service {
 		return {
 			prompt: entry.artifact.prompt,
 			fewShotExamples: entry.artifact.fewShotExamples,
+			contextConfig: entry.artifact.contextConfig,
 			optimizerSource: entry.artifact.optimizer,
 		};
 	}

--- a/plugins/plugin-training/src/core/promotion-persist.test.ts
+++ b/plugins/plugin-training/src/core/promotion-persist.test.ts
@@ -42,16 +42,23 @@ interface StubServiceState {
   storeRoot: string;
   currentPrompt: string | null;
   promotedWrites: number;
+  lastArtifact: Parameters<
+    typeof gatedPersistNativeResult
+  >[0]["result"]["result"] &
+    Record<string, unknown>;
 }
 
 function makeStubService(state: StubServiceState) {
   return {
     setPrompt: async (
       task: string,
-      artifact: { prompt: string; generatedAt: string },
+      artifact: Parameters<
+        Parameters<typeof gatedPersistNativeResult>[0]["service"]["setPrompt"]
+      >[1],
     ) => {
       state.promotedWrites += 1;
       state.currentPrompt = artifact.prompt;
+      state.lastArtifact = artifact;
       const dir = join(state.storeRoot, task);
       await mkdir(dir, { recursive: true });
       const stamp = artifact.generatedAt.replace(/[^0-9]/g, "");
@@ -123,6 +130,7 @@ describe("gatedPersistNativeResult", () => {
       storeRoot: tempRoot,
       currentPrompt: null,
       promotedWrites: 0,
+      lastArtifact: {},
     };
   });
 
@@ -154,6 +162,50 @@ describe("gatedPersistNativeResult", () => {
     // No rejected file should be written.
     const rejectedDir = join(tempRoot, "action_planner", REJECTED_DIRNAME);
     expect(existsSync(rejectedDir)).toBe(false);
+  });
+
+  it("persists contextConfig on promoted artifacts", async () => {
+    const scorer = fixedScorer({
+      [baselinePrompt]: 0.5,
+      [goodCandidatePrompt]: 0.9,
+    });
+    const service = makeStubService(state);
+    await gatedPersistNativeResult({
+      task: "context_routing",
+      datasetPath: "/tmp/context-routing.jsonl",
+      runId: "run-test-context-config",
+      baselinePrompt,
+      result: {
+        ...makeNativeResult(goodCandidatePrompt, scorer),
+        result: {
+          optimizedPrompt: goodCandidatePrompt,
+          lineage: [{ round: 0, variant: 0, score: 0.5, notes: "baseline" }],
+          contextConfig: {
+            providerSet: ["time", "recentMessages", "facts"],
+            providerOrder: ["facts", "time"],
+            renderTemplates: {
+              facts: "{{facts}}",
+            },
+            budgetVector: {
+              facts: 1200,
+            },
+          },
+        },
+      },
+      service,
+      notesPrefix: [],
+    });
+
+    expect(state.lastArtifact.contextConfig).toEqual({
+      providerSet: ["time", "recentMessages", "facts"],
+      providerOrder: ["facts", "time"],
+      renderTemplates: {
+        facts: "{{facts}}",
+      },
+      budgetVector: {
+        facts: 1200,
+      },
+    });
   });
 
   it("rejects a candidate that regresses and writes candidate_rejected_<ts>.json", async () => {

--- a/plugins/plugin-training/src/core/promotion-persist.ts
+++ b/plugins/plugin-training/src/core/promotion-persist.ts
@@ -20,6 +20,7 @@
  */
 
 import type { OptimizationExample, PromptScorer } from "../optimizers/index.js";
+import type { OptimizedPromptContextConfig } from "../optimizers/types.js";
 import {
   DEFAULT_PROMOTED_ARTIFACT_RETENTION,
   prunePromotedArtifacts,
@@ -62,6 +63,7 @@ export interface PromotionArtifactInput {
     notes?: string;
   }>;
   fewShotExamples?: PromotionFewShotExample[];
+  contextConfig?: OptimizedPromptContextConfig;
 }
 
 export interface PromotionServiceLike {
@@ -99,6 +101,7 @@ export interface PromotionNativeBackendResultLike {
       notes?: string;
     }>;
     fewShotExamples?: PromotionFewShotExample[];
+    contextConfig?: OptimizedPromptContextConfig;
   };
   /** Full parsed dataset. Fallback target for the gate when no holdout exists. */
   dataset: OptimizationExample[];
@@ -212,6 +215,7 @@ export async function gatedPersistNativeResult(
     generatedAt,
     lineage: input.result.result.lineage,
     fewShotExamples: input.result.result.fewShotExamples,
+    contextConfig: input.result.result.contextConfig,
   });
   notes.push(`artifact written to ${writePath}`);
 

--- a/plugins/plugin-training/src/optimizers/index.ts
+++ b/plugins/plugin-training/src/optimizers/index.ts
@@ -42,6 +42,7 @@ export type {
   LlmAdapter,
   OptimizationExample,
   OptimizedPromptArtifact,
+  OptimizedPromptContextConfig,
   OptimizerLineageEntry,
   OptimizerName,
   OptimizerResult,

--- a/plugins/plugin-training/src/optimizers/types.ts
+++ b/plugins/plugin-training/src/optimizers/types.ts
@@ -83,6 +83,13 @@ export interface OptimizerLineageEntry {
   notes?: string;
 }
 
+export interface OptimizedPromptContextConfig {
+  providerSet?: readonly string[];
+  providerOrder?: readonly string[];
+  renderTemplates?: Readonly<Record<string, string>>;
+  budgetVector?: Readonly<Record<string, number>>;
+}
+
 /** Common shape returned by all native optimizers. */
 export interface OptimizerResult {
   optimizedPrompt: string;
@@ -119,4 +126,5 @@ export interface OptimizedPromptArtifact {
   generatedAt: string;
   fewShotExamples?: OptimizationExample[];
   lineage: OptimizerLineageEntry[];
+  contextConfig?: OptimizedPromptContextConfig;
 }


### PR DESCRIPTION
## Summary

- add `context_routing` as an optimized-prompt task so context routing no longer has to alias onto `should_respond`
- extend optimized prompt artifacts with an optional `contextConfig` channel (`providerSet`, `providerOrder`, `renderTemplates`, `budgetVector`) in core and plugin-training types
- expose runtime helpers to resolve learned context config and apply provider set/order safely to the providers already eligible for the current turn
- persist promoted optimizer artifacts with `contextConfig` and add parser/resolver/promotion tests for the new channel

## Evidence

<!-- evidence-row:before-screenshots -->
N/A - no UI or rendered surface changed.

<!-- evidence-row:after-screenshots -->
N/A - no UI or rendered surface changed.

<!-- evidence-row:walkthrough-video -->
N/A - no UI or interactive flow changed.

<!-- evidence-row:backend-logs -->
N/A - no server route or long-running backend service path changed; this PR adds typed artifact parsing/resolution and persistence helpers covered by focused tests.

<!-- evidence-row:frontend-logs -->
N/A - no frontend code changed.

<!-- evidence-row:llm-trajectory -->
N/A - this PR is the typed artifact/resolver/persistence foundation. Full acceptance for issue #14875 still needs provider attribution and a live GEPA run over dynamic context.

<!-- evidence-row:domain-artifacts -->
Focused domain validation: [optimized-prompt tests](packages/core/src/services/optimized-prompt.test.ts), [optimized-prompt resolver tests](packages/core/src/services/optimized-prompt-resolver.test.ts), and [promotion persistence tests](plugins/plugin-training/src/core/promotion-persist.test.ts).

## Validation Commands

| Type | Command | Result |
| --- | --- | --- |
| Focused core tests | `bun run --cwd packages/core test -- src/services/optimized-prompt.test.ts src/services/optimized-prompt-resolver.test.ts` | Pass: 2 files / 105 tests |
| Training promotion persistence tests | `bun run --cwd plugins/plugin-training test -- src/core/promotion-persist.test.ts` | Pass: 1 file / 7 tests |
| Core typecheck | `bun run --cwd packages/core typecheck` | Pass |
| Core build | `bun run --cwd packages/core prebuild && bun run --cwd packages/cloud/routing build && bun run --cwd packages/core build:node` | Pass |
| Training plugin build | `bun run --cwd plugins/plugin-training build` | Pass |
| Formatting/lint scope | `bun x biome check packages/core/src/services/optimized-prompt.ts packages/core/src/services/optimized-prompt.test.ts packages/core/src/services/optimized-prompt-resolver.ts packages/core/src/services/optimized-prompt-resolver.test.ts packages/core/src/index.node.ts plugins/plugin-training/src/optimizers/types.ts plugins/plugin-training/src/optimizers/index.ts plugins/plugin-training/src/core/promotion-persist.ts plugins/plugin-training/src/core/promotion-persist.test.ts` | Pass |
| Diff checks | `git diff --check && bun run audit:error-policy-ratchet` | Pass |
| Training package typecheck | `bun run --cwd plugins/plugin-training typecheck` | Fails on pre-existing ambient package setup: missing Node/workspace declarations (`node:fs`, `process`, `@elizaos/shared`, `@elizaos/ui/*`, etc.) plus unrelated strictness errors in existing training UI/routes/services; no new touched-file errors were identified by the focused tests/builds above |

## Notes

This PR intentionally does not register a live `compose_state_providers` runtime hook or claim a completed context-optimization loop. It makes the artifact channel, cache parsing, resolver surface, safe provider ordering helper, and promotion persistence available for that follow-on work.

Fixes part of #14875.