### PR TITLE
fix(android): native app boot wedge — self-heal runtime symlinks + fs-shim /data alias acceptance

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -101,6 +101,7 @@ public class ElizaAgentService extends Service {
     private static final String AGENT_STATE_DIR_NAME = ".eliza";
     private static final String AGENT_BUNDLE_NAME = "agent-bundle.js";
     private static final String AGENT_LAUNCH_SCRIPT = "launch.sh";
+    private static final String AGENT_LAUNCH_CHILD_SCRIPT = "launch-child.sh";
     private static final String BUN_BINARY = "bun";
     private static final String AGENT_LOG_NAME = "agent.log";
     private static final String AGENT_RESTART_DIAGNOSTICS_NAME = "agent-restart-diagnostics.jsonl";
@@ -1206,6 +1207,10 @@ public class ElizaAgentService extends Service {
         // Staging is fresh, so copyAssetIfMissing always copies here.
         copyAssetIfMissing(assets, "agent/" + AGENT_BUNDLE_NAME, new File(stagingRoot, AGENT_BUNDLE_NAME));
         copyAssetIfPresent(assets, "agent/" + AGENT_LAUNCH_SCRIPT, new File(stagingRoot, AGENT_LAUNCH_SCRIPT));
+        // Detached-child half of the launcher (see stage-android-agent.mjs:
+        // LAUNCH_CHILD_SCRIPT) — launch.sh invokes it by path, so it must land
+        // in the same atomic stage as launch.sh itself.
+        copyAssetIfPresent(assets, "agent/" + AGENT_LAUNCH_CHILD_SCRIPT, new File(stagingRoot, AGENT_LAUNCH_CHILD_SCRIPT));
 
         // PGlite runtime assets. pglite.wasm + initdb.wasm + pglite.data sit
         // next to the bundle (`new URL("./pglite.X", import.meta.url)`).

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -1273,21 +1273,43 @@ public class ElizaAgentService extends Service {
             }
         }
 
-        boolean stdcxxLinkedFromNative = linkPackagedRuntimeLibrary(
+        ensureRuntimeLibraryLinks(abiDir);
+    }
+
+    /**
+     * Make the runtime soname symlinks (`libstdc++.so.6`, `libgcc_s.so.1`)
+     * valid against THIS process's install paths. bun requests those sonames
+     * at load time; the packaged copies live in {@link #nativeLibraryDir()}
+     * under jniLibs names (`libeliza_stdcpp.so` / `libeliza_gcc_s.so`), so the
+     * abi dir carries soname symlinks into the install dir.
+     *
+     * The install dir under /data/app/~~<random>/ is minted fresh on EVERY
+     * package update, so an absolute symlink staged by a previous install
+     * dangles after `adb install -r` / a store update — bun then dies within
+     * ~1s of exec ("Error loading shared library libstdc++.so.6") with its
+     * stdio on /dev/null, which presented as the silent
+     * `local_agent_unavailable` boot wedge. This method is therefore called
+     * BOTH from extraction finalize and from {@link #startAgentProcess}
+     * immediately before every spawn: staging correctness is not enough —
+     * the links must be re-validated against the live ApplicationInfo each
+     * time the agent launches.
+     */
+    private void ensureRuntimeLibraryLinks(File abiDir) {
+        boolean stdcxxLinkedFromNative = ensureRuntimeLibraryLink(
             abiDir,
             "libstdc++.so.6",
             "libeliza_stdcpp.so"
         );
-        linkPackagedRuntimeLibrary(abiDir, "libgcc_s.so.1", "libeliza_gcc_s.so");
+        ensureRuntimeLibraryLink(abiDir, "libgcc_s.so.1", "libeliza_gcc_s.so");
 
-        // bun requests `libstdc++.so.6` (the soname) at runtime, but the file we
-        // shipped is the versioned realpath (`libstdc++.so.6.0.33`). Without a
-        // symlink the musl loader can't find the shared object and bun crashes
-        // with hundreds of "Error relocating: symbol not found" lines. Link the
-        // soname to the realpath inside the same abi dir so LD_LIBRARY_PATH
-        // resolution works without LD_PRELOAD.
+        // No packaged libstdc++ in nativeLibraryDir (legacy assets-channel
+        // APKs): link the soname to the versioned realpath shipped next to it
+        // (`libstdc++.so.6.0.33`). The relative target is immune to install-dir
+        // churn, so only create it when missing or dangling.
         if (!stdcxxLinkedFromNative) {
-            for (String name : abiFiles) {
+            String[] names = abiDir.list();
+            if (names == null) return;
+            for (String name : names) {
                 if (name.startsWith("libstdc++.so.6.")) {
                     File realPath = new File(abiDir, name);
                     File symlink = new File(abiDir, "libstdc++.so.6");
@@ -1309,6 +1331,39 @@ public class ElizaAgentService extends Service {
                 }
             }
         }
+    }
+
+    /**
+     * Ensure one soname symlink resolves to the packaged copy in the CURRENT
+     * {@link #nativeLibraryDir()}. A link that already resolves to that exact
+     * target is left untouched; a missing, dangling, or stale-target link is
+     * recreated (the repair is logged — it is the fingerprint of the
+     * post-update dangling-symlink boot failure). Returns false when the
+     * packaged copy does not exist in this build, so the caller can fall back
+     * to the versioned-realpath link.
+     */
+    private boolean ensureRuntimeLibraryLink(
+        File abiDir,
+        String soname,
+        String packagedName
+    ) {
+        File packaged = new File(nativeLibraryDir(), packagedName);
+        if (!packaged.exists() || packaged.length() <= 0) return false;
+        File symlink = new File(abiDir, soname);
+        java.nio.file.Path linkPath = symlink.toPath();
+        try {
+            if (java.nio.file.Files.isSymbolicLink(linkPath)) {
+                java.nio.file.Path target = java.nio.file.Files.readSymbolicLink(linkPath);
+                if (target.equals(packaged.toPath()) && symlink.exists()) {
+                    return true;
+                }
+                Log.w(TAG, "Runtime symlink " + soname + " is dangling or stale ("
+                        + target + "); relinking to " + packaged.getAbsolutePath());
+            }
+        } catch (IOException error) {
+            // Unreadable link state — fall through and recreate it.
+        }
+        return linkPackagedRuntimeLibrary(abiDir, soname, packagedName);
     }
 
     /**
@@ -1808,6 +1863,13 @@ public class ElizaAgentService extends Service {
                 loader = preferPackagedExecutable(loader, packagedLoaderName);
             }
             bun = preferPackagedExecutable(bun, "libeliza_bun.so");
+
+            // Re-validate the soname symlinks against THIS install's
+            // nativeLibraryDir on every spawn: a package update mints a new
+            // /data/app/~~<random>/ dir and dangles absolute links staged by
+            // the previous install, which kills bun ~1s into exec with no
+            // visible error (stdio is on /dev/null).
+            ensureRuntimeLibraryLinks(abiDir);
 
             // Generate a fresh per-boot token for the WebView↔agent loopback.
             // Without this the loopback API would accept any local request

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java
@@ -88,6 +88,17 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(ResourceProbePlugin.class);
         super.onCreate(savedInstanceState);
 
+        // Replace the auto-registered community PushNotifications plugin with
+        // the Firebase-guarded subclass. Must run AFTER super.onCreate: the
+        // bridge exists, auto-registration has happened, and
+        // Bridge.registerPlugin is a plain map.put — last one wins. Without
+        // this, any build lacking google-services.json hard-crashes the
+        // process the moment the renderer calls PushNotifications.register()
+        // with notification permission already granted.
+        if (getBridge() != null) {
+            getBridge().registerPlugin(SafePushNotificationsPlugin.class);
+        }
+
         // Keep the screen on while the agent app is in the foreground.
         // Voice turns (ASR → LLM → TTS) on local-runtime builds regularly
         // take 1-5 seconds; screen-off mid-turn breaks the "is the agent

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/SafePushNotificationsPlugin.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/SafePushNotificationsPlugin.java
@@ -1,0 +1,70 @@
+package ai.elizaos.app;
+
+import android.Manifest;
+import com.capacitorjs.plugins.pushnotifications.PushNotificationsPlugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+import com.getcapacitor.annotation.Permission;
+import com.google.firebase.FirebaseApp;
+
+/**
+ * Firebase-guarded replacement for the community PushNotifications plugin.
+ *
+ * Sideload/local builds ship without google-services.json (the gradle build
+ * only applies the google-services plugin when the file exists), so
+ * FirebaseApp never initializes. The stock plugin's register() then throws
+ * IllegalStateException from FirebaseMessaging.getInstance() ON THE
+ * CapacitorPlugins HANDLER THREAD — which is a hard process crash ("Eliza
+ * has stopped"), not a rejected JS promise. The renderer calls register()
+ * whenever notification permission is already granted (see
+ * packages/ui/src/state/notifications/push-registration.ts), so every
+ * Firebase-less build died the moment the shell painted.
+ *
+ * This subclass rejects the call cleanly when no FirebaseApp exists and
+ * defers to the stock behavior otherwise. MainActivity registers it directly
+ * on the bridge AFTER super.onCreate(), which wins the plugin-name slot from
+ * the auto-registered stock plugin (Bridge.registerPlugin is a plain
+ * map.put — last registration wins).
+ */
+@CapacitorPlugin(
+    name = "PushNotifications",
+    permissions = @Permission(
+        strings = { Manifest.permission.POST_NOTIFICATIONS },
+        alias = "receive"
+    )
+)
+public class SafePushNotificationsPlugin extends PushNotificationsPlugin {
+
+    private boolean firebaseAvailable() {
+        try {
+            return !FirebaseApp.getApps(getContext()).isEmpty();
+        } catch (RuntimeException error) {
+            return false;
+        }
+    }
+
+    @Override
+    @PluginMethod
+    public void register(PluginCall call) {
+        if (!firebaseAvailable()) {
+            call.reject(
+                "push-unavailable: this build has no Firebase configuration (google-services.json absent)"
+            );
+            return;
+        }
+        super.register(call);
+    }
+
+    @Override
+    @PluginMethod
+    public void unregister(PluginCall call) {
+        if (!firebaseAvailable()) {
+            call.reject(
+                "push-unavailable: this build has no Firebase configuration (google-services.json absent)"
+            );
+            return;
+        }
+        super.unregister(call);
+    }
+}

--- a/packages/app-core/scripts/lib/stage-android-agent.mjs
+++ b/packages/app-core/scripts/lib/stage-android-agent.mjs
@@ -300,7 +300,32 @@ else
 fi
 
 (
-  setsid sh -c 'log_file=$1; agent_root=$2; runtime_ld=$3; port=$4; diagnostics_file=$5; startup_trace_id=$6; shift 6
+  setsid sh "\${AGENT_ROOT}/launch-child.sh" "\${LOG_FILE}" "\${AGENT_ROOT}" "\${RUNTIME_LD_LIBRARY_PATH}" "\${PORT:-}" "\${DIAGNOSTICS_FILE}" "\${STARTUP_TRACE_ID}" "$@" &
+) &
+disown 2>/dev/null || true
+exit 0
+`;
+
+/**
+ * Detached-child half of launch.sh's double-fork, shipped as its OWN file.
+ *
+ * This logic used to be inlined as a multi-line \`sh -c '...'\` string inside
+ * launch.sh. That is a runtime trap: the script body contains single-quoted
+ * printf formats AND brace groups with commas ({"childPid":"%s",...}), so the
+ * quoting fuses into an unquoted segment that Android's mksh BRACE-EXPANDS
+ * into multiple words — the -c script truncates mid-body and mksh execs the
+ * leftover tail as a filename. The detached agent then never spawns, silently
+ * (launcher stdio is /dev/null). Desktop shells don't brace-expand unquoted
+ * words, so sh -n and laptop runs never catch it; the breakage is
+ * device-only. A standalone file has no nested-quoting layer at all.
+ */
+const LAUNCH_CHILD_SCRIPT = `#!/system/bin/sh
+# launch-child.sh — detached child half of launch.sh's setsid double-fork.
+# Invoked as: sh launch-child.sh LOG_FILE AGENT_ROOT RUNTIME_LD PORT \\
+#             DIAGNOSTICS_FILE STARTUP_TRACE_ID <argv...>
+# Redirects stdio, spawns the agent argv, and journals child start/exit into
+# the restart-diagnostics JSONL so a dead spawn is visible from adb run-as.
+log_file=$1; agent_root=$2; runtime_ld=$3; port=$4; diagnostics_file=$5; startup_trace_id=$6; shift 6
 append_diag() {
   event=$1
   child_pid=$2
@@ -317,10 +342,7 @@ append_diag "agent-child-started" "$agent_pid" ""
 wait "$agent_pid"
 status=$?
 append_diag "agent-child-exited" "$agent_pid" "$status"
-exit "$status"' sh "\${LOG_FILE}" "\${AGENT_ROOT}" "\${RUNTIME_LD_LIBRARY_PATH}" "\${PORT:-}" "\${DIAGNOSTICS_FILE}" "\${STARTUP_TRACE_ID}" "$@" &
-) &
-disown 2>/dev/null || true
-exit 0
+exit "$status"
 `;
 
 function logFor(log) {
@@ -1440,6 +1462,18 @@ export async function stageAndroidAgentRuntime({
         launchTarget,
       ),
       source: { kind: "stage-android-agent", constant: "LAUNCH_SCRIPT" },
+    }),
+  );
+  const launchChildTarget = path.join(assetsAgentDir, "launch-child.sh");
+  if (writeIfChanged(launchChildTarget, LAUNCH_CHILD_SCRIPT)) stagedCount += 1;
+  stagedFiles.push(
+    fileProvenanceEntry({
+      filePath: launchChildTarget,
+      relativePath: path.relative(
+        path.join(androidDir, "app", "src", "main"),
+        launchChildTarget,
+      ),
+      source: { kind: "stage-android-agent", constant: "LAUNCH_CHILD_SCRIPT" },
     }),
   );
   const llamaDiagnosticTarget = path.join(

--- a/plugins/plugin-capacitor-bridge/src/android/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/bridge.ts
@@ -63,7 +63,10 @@ process.env.ELIZA_DISABLE_TRAJECTORY_LOGGING ||= "1";
 import * as nodeFs from "node:fs";
 import nodePath from "node:path";
 import type { IAgentRuntime } from "@elizaos/core";
-import { installMobileFsShim } from "../shared/fs-shim.ts";
+import {
+	androidAliasSibling,
+	installMobileFsShim,
+} from "../shared/fs-shim.ts";
 import {
 	createStdioBridge,
 	type StdioBridgeResponseFrame,
@@ -146,20 +149,47 @@ function setupAndroidBridgeEnvironment(): string {
 		canonicalHome = rawHome;
 	}
 
-	// Remap any env var that starts with the symlinked prefix to the
-	// canonical (real) prefix so downstream code resolves paths consistently.
-	if (canonicalHome !== rawHome) {
-		if (process.env.HOME) process.env.HOME = canonicalHome;
+	// Remap any env var carrying a non-canonical spelling of the home dir to
+	// the canonical prefix so downstream path construction produces matching
+	// strings. Two sources of drift, remapped independently: the raw HOME the
+	// process was launched with (when it was itself a symlink spelling), and
+	// the Android /data/data ↔ /data/user/0 alias of the canonical home —
+	// which can appear in OTHER env vars (ELIZA_STATE_DIR, TMPDIR, …) even
+	// when HOME arrived already canonical, so gating all remaps on
+	// `canonicalHome !== rawHome` missed it and the fs shim rejected every
+	// state-dir path at startEliza (silent on-device boot death).
+	const stalePrefixes = new Set<string>();
+	if (canonicalHome !== rawHome) stalePrefixes.add(rawHome);
+	const aliasOfCanonical = androidAliasSibling(canonicalHome);
+	if (aliasOfCanonical) stalePrefixes.add(aliasOfCanonical);
+	stalePrefixes.delete(canonicalHome);
+	if (stalePrefixes.size > 0) {
+		if (process.env.HOME && process.env.HOME !== canonicalHome) {
+			for (const prefix of stalePrefixes) {
+				if (
+					process.env.HOME === prefix ||
+					process.env.HOME.startsWith(`${prefix}/`)
+				) {
+					process.env.HOME =
+						canonicalHome + process.env.HOME.slice(prefix.length);
+					break;
+				}
+			}
+		}
 		for (const key of [
 			"ELIZA_STATE_DIR",
-			"ELIZA_STATE_DIR",
-			"ELIZA_WORKSPACE_DIR",
 			"ELIZA_WORKSPACE_DIR",
 			"TMPDIR",
+			"LOG_FILE",
+			"DIAGNOSTICS_FILE",
 		] as const) {
 			const val = process.env[key];
-			if (val?.startsWith(rawHome)) {
-				process.env[key] = canonicalHome + val.slice(rawHome.length);
+			if (!val) continue;
+			for (const prefix of stalePrefixes) {
+				if (val === prefix || val.startsWith(`${prefix}/`)) {
+					process.env[key] = canonicalHome + val.slice(prefix.length);
+					break;
+				}
 			}
 		}
 	}

--- a/plugins/plugin-capacitor-bridge/src/android/bridge.ts
+++ b/plugins/plugin-capacitor-bridge/src/android/bridge.ts
@@ -63,10 +63,7 @@ process.env.ELIZA_DISABLE_TRAJECTORY_LOGGING ||= "1";
 import * as nodeFs from "node:fs";
 import nodePath from "node:path";
 import type { IAgentRuntime } from "@elizaos/core";
-import {
-	androidAliasSibling,
-	installMobileFsShim,
-} from "../shared/fs-shim.ts";
+import { androidAliasSibling, installMobileFsShim } from "../shared/fs-shim.ts";
 import {
 	createStdioBridge,
 	type StdioBridgeResponseFrame,

--- a/plugins/plugin-capacitor-bridge/src/shared/fs-shim.alias.test.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/fs-shim.alias.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Android /data/data ↔ /data/user/0 alias handling in the mobile fs sandbox.
+ * The pure mapper is exercised in-process; the shim's accept/reject behavior
+ * is proven against the REAL installMobileFsShim in a Bun subprocess (the
+ * shim patches node:fs process-wide, so installing it inside the test runner
+ * would sandbox vitest itself). Regression for the on-device boot death where
+ * an alias-spelled ELIZA_STATE_DIR was rejected against a canonical root and
+ * the agent died at startEliza before it could even write diagnostics.
+ */
+
+import { execFileSync } from "node:child_process";
+import nodePath from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { androidAliasSibling } from "./fs-shim.ts";
+
+const SHIM_PATH = nodePath.resolve(
+	nodePath.dirname(fileURLToPath(import.meta.url)),
+	"fs-shim.ts",
+);
+
+describe("androidAliasSibling", () => {
+	it("maps /data/data/<pkg> to /data/user/0/<pkg> and back", () => {
+		expect(androidAliasSibling("/data/data/ai.elizaos.app")).toBe(
+			"/data/user/0/ai.elizaos.app",
+		);
+		expect(androidAliasSibling("/data/user/0/ai.elizaos.app")).toBe(
+			"/data/data/ai.elizaos.app",
+		);
+	});
+
+	it("preserves the path suffix under the package dir", () => {
+		expect(
+			androidAliasSibling("/data/data/ai.elizaos.app/files/eliza/eliza.json"),
+		).toBe("/data/user/0/ai.elizaos.app/files/eliza/eliza.json");
+		expect(androidAliasSibling("/data/user/0/pkg.x/files")).toBe(
+			"/data/data/pkg.x/files",
+		);
+	});
+
+	it("returns null for non-aliased paths", () => {
+		// Secondary Android users are NOT the /data/data alias — only user 0.
+		expect(androidAliasSibling("/data/user/10/ai.elizaos.app")).toBeNull();
+		expect(androidAliasSibling("/data/local/tmp/.eliza")).toBeNull();
+		expect(androidAliasSibling("/var/mobile/Containers/x")).toBeNull();
+		expect(androidAliasSibling("/data/data")).toBeNull();
+	});
+
+	it("does not treat sibling-prefixed package names as aliases of each other", () => {
+		expect(androidAliasSibling("/data/data/pkg")).toBe("/data/user/0/pkg");
+		// A path like /data/data/pkg-evil must map only to its own name.
+		expect(androidAliasSibling("/data/data/pkg-evil/x")).toBe(
+			"/data/user/0/pkg-evil/x",
+		);
+	});
+});
+
+describe("installMobileFsShim alias acceptance (real shim, Bun subprocess)", () => {
+	it("accepts the alias spelling of the workspace root and still blocks escapes", () => {
+		const script = [
+			`const { installMobileFsShim, sandboxedPath } = await import(${JSON.stringify(SHIM_PATH)});`,
+			`installMobileFsShim("/data/user/0/test.alias.pkg/files");`,
+			`const out = { aliasAccepted: false, canonicalAccepted: false, escapeBlocked: false, otherPkgBlocked: false };`,
+			`try { sandboxedPath("/data/data/test.alias.pkg/files/eliza/eliza.json"); out.aliasAccepted = true; } catch {}`,
+			`try { sandboxedPath("/data/user/0/test.alias.pkg/files/agent/agent-bundle.js"); out.canonicalAccepted = true; } catch {}`,
+			`try { sandboxedPath("/data/user/0/test.alias.pkg/files-escape/x"); } catch { out.escapeBlocked = true; }`,
+			`try { sandboxedPath("/data/data/other.pkg/files/x"); } catch { out.otherPkgBlocked = true; }`,
+			`console.log(JSON.stringify(out));`,
+		].join("\n");
+		const stdout = execFileSync("bun", ["-e", script], {
+			encoding: "utf8",
+			timeout: 30_000,
+		});
+		const lastLine = stdout.trim().split("\n").at(-1) ?? "";
+		const result = JSON.parse(lastLine) as Record<string, boolean>;
+		expect(result).toEqual({
+			aliasAccepted: true,
+			canonicalAccepted: true,
+			escapeBlocked: true,
+			otherPkgBlocked: true,
+		});
+	});
+});

--- a/plugins/plugin-capacitor-bridge/src/shared/fs-shim.ts
+++ b/plugins/plugin-capacitor-bridge/src/shared/fs-shim.ts
@@ -81,6 +81,7 @@ import {
 let _installed = false;
 let _workspaceRoot = "";
 let _workspaceRootReal = "";
+let _workspaceRootAlias = "";
 let _readOnlyRoots: string[] = [];
 let _readOnlyRootReals: string[] = [];
 const rawExistsSync = nodeFs.existsSync.bind(nodeFs);
@@ -142,6 +143,26 @@ function realpathIfPossible(pathname: string): string {
 	}
 }
 
+/**
+ * Android spells one app-data directory two ways: `/data/data/<pkg>` and
+ * `/data/user/0/<pkg>` (one is a symlink to the other; WHICH one is the link
+ * varies by OS build). Paths reach the shim in both spellings — Java-side env
+ * vars, `run-as` shells, and `import.meta.url` each pick their own — and
+ * relying on realpath alone to unify them fails when resolving the alias is
+ * denied (observed on-device: the agent died at startEliza because
+ * `ELIZA_STATE_DIR` arrived `/data/data`-spelled against a `/data/user/0`
+ * root, and the fatal-diagnostics write was rejected the same way, making the
+ * crash silent). Returns the sibling spelling, or null for non-Android paths.
+ * Accepting both spellings widens nothing: they are the same directory.
+ */
+export function androidAliasSibling(pathname: string): string | null {
+	const dataData = pathname.match(/^\/data\/data\/([^/]+)((?:\/.*)?)$/);
+	if (dataData) return `/data/user/0/${dataData[1]}${dataData[2]}`;
+	const dataUser = pathname.match(/^\/data\/user\/0\/([^/]+)((?:\/.*)?)$/);
+	if (dataUser) return `/data/data/${dataUser[1]}${dataUser[2]}`;
+	return null;
+}
+
 function nearestExistingParent(pathname: string): string | null {
 	let current = nodePath.resolve(pathname);
 	for (;;) {
@@ -163,6 +184,8 @@ function validateResolvedRealPath(
 		const real = realpathIfPossible(resolved);
 		if (isInsideRoot(real, _workspaceRootReal || _workspaceRoot))
 			return resolved;
+		if (_workspaceRootAlias && isInsideRoot(real, _workspaceRootAlias))
+			return resolved;
 		if (
 			allowedReadOnly &&
 			_readOnlyRootReals.some((root) => isInsideRoot(real, root))
@@ -179,6 +202,8 @@ function validateResolvedRealPath(
 	if (!existing) return resolved;
 	const real = realpathIfPossible(existing);
 	if (isInsideRoot(real, _workspaceRootReal || _workspaceRoot)) return resolved;
+	if (_workspaceRootAlias && isInsideRoot(real, _workspaceRootAlias))
+		return resolved;
 	throw accessError(
 		inputPath,
 		`mobile-fs-shim: write parent escapes workspace root: ${real}`,
@@ -235,6 +260,14 @@ function resolveSandboxed(
 	// Use a trailing-sep check to prevent a root like /data/workspace being
 	// accepted as a prefix for /data/workspace-escape.
 	if (isInsideRoot(resolved, _workspaceRoot)) {
+		return validateResolvedRealPath(inputPath, resolved, mode, false);
+	}
+
+	// Android alias spelling of the same directory (/data/data/<pkg> ↔
+	// /data/user/0/<pkg>) — see androidAliasSibling. Checked BEFORE the
+	// realpath second-chance because resolving the alias link itself can be
+	// denied on some devices, which silently killed the agent at boot.
+	if (_workspaceRootAlias && isInsideRoot(resolved, _workspaceRootAlias)) {
 		return validateResolvedRealPath(inputPath, resolved, mode, false);
 	}
 
@@ -913,6 +946,7 @@ export function installMobileFsShim(workspaceRoot: string): void {
 
 	_workspaceRoot = canonical;
 	_workspaceRootReal = realpathIfPossible(canonical);
+	_workspaceRootAlias = androidAliasSibling(canonical) ?? "";
 	_readOnlyRoots = envReadOnlyRoots().filter(
 		(root) => !isInsideRoot(root, canonical),
 	);


### PR DESCRIPTION
Fixes the native Android app's silent boot death ("Booting up…" → 180s → Backend Timeout, `local_agent_unavailable`). On-device debugging on the Seeker found **two stacked root causes**, both fixed here:

## Root cause 1 — dangling runtime symlinks after every APK update

Every package update mints a new `/data/app/~~<random>/` install dir. `ElizaAgentService` stages the on-device agent with **absolute symlinks** into that dir:

```
files/agent/<abi>/libstdc++.so.6  → /data/app/~~<old-random>/…/lib/arm64/libeliza_stdcpp.so   (DANGLING after update)
files/agent/<abi>/libgcc_s.so.1   → /data/app/~~<old-random>/…/lib/arm64/libeliza_gcc_s.so    (DANGLING after update)
```

bun then dies ~1s into exec (`Error loading shared library libstdc++.so.6` + relocation storm) — silently, because child stdio is on `/dev/null` (SELinux TIOCGWINSZ workaround). A later force-stop+relaunch re-stages correct links (fresh `ApplicationInfo`), so installs appeared *randomly* broken.

**Fix:** `ensureRuntimeLibraryLinks` — soname links are re-validated against the **current** `nativeLibraryDir` before **every** agent spawn (not just at extraction), recreated when missing/dangling/stale, with a logged fingerprint.

**Proof:** manual exec of the staged loader chain via `run-as` fails on the dangling links; after relink the same chain prints `sigsys-handler-arm64: installed` + `bun 1.3.14`.

## Root cause 2 — mobile fs-shim rejects the Android `/data/data` alias spelling

With valid symlinks the agent STILL died at `startEliza`:

```
Error: mobile-fs-shim: path escapes workspace root (/data/user/0/ai.elizaos.app): /data/data/ai.elizaos.app/files/eliza/eliza.json
```

`/data/data/<pkg>` and `/data/user/0/<pkg>` are the **same directory** (one is a symlink; which one varies by OS build). The shim's prefix check only knew one spelling; its realpath second-chance fails when resolving the alias is denied; and the env remap in `setupAndroidBridgeEnvironment` only fired when `HOME` itself was alias-spelled — an alias-spelled `ELIZA_STATE_DIR` behind a canonical `HOME` was never rewritten. **The fatal-diagnostics write was rejected by the same check**, which is why the death left no trace (captured it via a foreground `run-as` run + the launch.sh child diag).

**Fix:**
- `fs-shim`: track the alias sibling of the workspace root; accept it in the prefix check and both real-path validations. Widens nothing — the two spellings are one physical directory. Escapes (other packages, `files-escape` prefix tricks, system dirs) still blocked.
- `android/bridge`: remap env vars from EITHER stale spelling (raw `HOME` or the alias of canonical `HOME`) to the canonical prefix; `LOG_FILE`/`DIAGNOSTICS_FILE` included so crash reporting survives spelling drift.

**Tests:** pure mapper cases + a Bun-subprocess test that drives the REAL `installMobileFsShim` (alias accepted, canonical accepted, escape + other-package blocked). Package suite: 16 files / 118 tests green. (Repo `typecheck` currently red on develop's known `message-corpus.ts:514` failure — pre-existing, fixed by #15092.)

## Downstream effect chain (why this presented as a web-side hang)

dead agent → device bridge never connects → `/api/auth/status` 503 `local_agent_unavailable` → startup coordinator polls to the full 180s deadline (the 90s native fail-fast budget never fires — probe hangs reset the streak; filed #15107 for that hardening) → terminal "Backend Timeout" card.

## Evidence

Full on-device verification walk completed 2026-07-06 20:44–20:56Z on the Seeker — detail + boot-phase traces in the [evidence comment](https://github.com/elizaOS/eliza/pull/15105#issuecomment-4897620356).

| type | evidence |
|---|---|
| video walkthrough | Boot-walk MP4 captured on-device (screenrecord); with nubs for inline drag-drop — summary + phase timeline in the evidence comment |
| screenshots | JPG series: home screen (new launcher + seeded cards), sign-in page, "Authentication Complete!", logged-in conductor, chat with verbatim "Paris" reply — in the evidence comment / with nubs |
| backend logs | logcat `[startup-coordinator]` phase trace (14s to first-run-required), `ElizaAgent` launcher + "Detached agent health check passed", `agent-restart-diagnostics.jsonl` first-ever `agent-child-started` — inline in the evidence comment |
| frontend logs | Capacitor console: auth/status 200 after fix (was 503 loop), cloud agent list 200 + resume 202 — inline in the evidence comment |
| trajectories | N/A - no agent/model/prompt behavior change in this PR; the live cloud-chat round-trip ("capital of France?" → "Paris") is the real-model proof |
| per-platform capture | Real device (Seeker, arm64) — the target platform of every change. iOS N/A - Android-only staging/launcher paths; the fs-shim alias helper no-ops on non-/data paths (unit-tested) |
| domain artifacts | `agent-restart-diagnostics.jsonl` child-spawn journal, repaired symlink `readlink` outputs, dash-parse repro of RC3 — inline in the evidence comment |

Rebased onto current develop (carries #15123 et al.); review requested from @lalalune (no self-merge).

— [maintainer]
