### PR TITLE
fix(ui): chunk-crash self-heal, single header mic, one Character tile

### DIFF
--- a/packages/cloud/api/__tests__/pairing-token-bridge-url.test.ts
+++ b/packages/cloud/api/__tests__/pairing-token-bridge-url.test.ts
@@ -139,7 +139,12 @@ describe("resolveManagedWebUiUrl (pairing-token direct URL fallback)", () => {
   });
 
   it("rejects RFC1918 and link-local origins but keeps loopback (local dev) and public IPs", () => {
-    for (const host of ["10.0.0.1", "172.16.5.5", "192.168.1.10", "169.254.9.9"]) {
+    for (const host of [
+      "10.0.0.1",
+      "172.16.5.5",
+      "192.168.1.10",
+      "169.254.9.9",
+    ]) {
       expect(
         resolveManagedWebUiUrl({
           bridge_url: `http://${host}:19027`,

--- a/packages/cloud/api/__tests__/pairing-token-bridge-url.test.ts
+++ b/packages/cloud/api/__tests__/pairing-token-bridge-url.test.ts
@@ -50,10 +50,36 @@ function resolveDirectWebUiUrlFromHealthUrl(
   }
 }
 
+function isBrowserUnreachableHost(hostname: string): boolean {
+  const h = hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  if (h === "localhost" || h === "::1" || h.startsWith("127.")) return false;
+  const m = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (m) {
+    const a = Number(m[1]);
+    const b = Number(m[2]);
+    if (a === 10) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 100 && b >= 64 && b <= 127) return true;
+    if (a === 169 && b === 254) return true;
+    return false;
+  }
+  return /^f[cd]/.test(h) || h.startsWith("fe80");
+}
+
+function browserReachableOrigin(origin: string | null): string | null {
+  if (!origin) return null;
+  try {
+    return isBrowserUnreachableHost(new URL(origin).hostname) ? null : origin;
+  } catch {
+    return null;
+  }
+}
+
 function resolveManagedWebUiUrl(sandbox: PairingSandboxShape): string | null {
   return (
-    resolveDirectWebUiUrlFromBridgeHost(sandbox) ??
-    resolveDirectWebUiUrlFromHealthUrl(sandbox)
+    browserReachableOrigin(resolveDirectWebUiUrlFromBridgeHost(sandbox)) ??
+    browserReachableOrigin(resolveDirectWebUiUrlFromHealthUrl(sandbox))
   );
 }
 
@@ -89,10 +115,44 @@ describe("resolveManagedWebUiUrl (pairing-token direct URL fallback)", () => {
   it("trims whitespace before parsing", () => {
     expect(
       resolveManagedWebUiUrl({
-        bridge_url: "  http://10.0.0.1:8080  ",
+        bridge_url: "  http://168.119.244.189:8080  ",
         web_ui_port: 3000,
       }),
-    ).toBe("http://10.0.0.1:3000");
+    ).toBe("http://168.119.244.189:3000");
+  });
+
+  it("never hands a tailnet/CGNAT origin to the browser (the dead 100.64.x.x /pair redirect)", () => {
+    // Production bridge_url lives on the tailnet — browsers cannot route
+    // 100.64/10, so the direct rungs must yield null and the route falls
+    // through to the public <agentId>.<baseDomain> proxy URL.
+    expect(
+      resolveManagedWebUiUrl({
+        bridge_url: "http://100.64.0.157:21748",
+        web_ui_port: 21748,
+      }),
+    ).toBe(null);
+    expect(
+      resolveManagedWebUiUrl({
+        health_url: "http://100.64.0.157:21748/health",
+      }),
+    ).toBe(null);
+  });
+
+  it("rejects RFC1918 and link-local origins but keeps loopback (local dev) and public IPs", () => {
+    for (const host of ["10.0.0.1", "172.16.5.5", "192.168.1.10", "169.254.9.9"]) {
+      expect(
+        resolveManagedWebUiUrl({
+          bridge_url: `http://${host}:19027`,
+          web_ui_port: 3000,
+        }),
+      ).toBe(null);
+    }
+    expect(
+      resolveManagedWebUiUrl({
+        bridge_url: "http://127.0.0.1:18888",
+        web_ui_port: 3000,
+      }),
+    ).toBe("http://127.0.0.1:3000");
   });
 
   it("returns null for empty/missing direct URL inputs", () => {

--- a/packages/cloud/api/auth/steward-refresh/route.test.ts
+++ b/packages/cloud/api/auth/steward-refresh/route.test.ts
@@ -176,7 +176,7 @@ describe("steward-refresh browser cookie cleanup", () => {
     }
   });
 
-  test("staging invalid refresh clears only staging cookies", async () => {
+  test("invalid refresh clears NO cookies (rotation-race safety, #13728 env-scoping holds trivially)", async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = mock(async () => {
       return new Response(
@@ -204,13 +204,16 @@ describe("steward-refresh browser cookie cleanup", () => {
       );
 
       expect(response.status).toBe(401);
+      // A Steward 401 also fires for the LOSER of a refresh-rotation race
+      // (single-use tokens, one domain-wide cookie shared by console + app
+      // tabs). Clearing cookies here nuked the whole session on every lost
+      // race — the winner's fresh cookies included. The route now clears
+      // NOTHING on 401: the race self-heals from the winner's Set-Cookie,
+      // and a genuinely dead token keeps 401ing into the login surface.
+      // The #13728 env-scoping invariant (staging must never clear prod
+      // cookies) holds trivially.
       const cleared = deletedCookieNames(response);
-      expect(cleared).toContain("steward-token-staging");
-      expect(cleared).toContain("steward-refresh-token-staging");
-      expect(cleared).toContain("steward-authed-staging");
-      expect(cleared).not.toContain("steward-token");
-      expect(cleared).not.toContain("steward-refresh-token");
-      expect(cleared).not.toContain("steward-authed");
+      expect(cleared).toHaveLength(0);
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/packages/cloud/api/auth/steward-refresh/route.ts
+++ b/packages/cloud/api/auth/steward-refresh/route.ts
@@ -27,7 +27,7 @@
 
 import type { StewardSessionErrorCode } from "@elizaos/shared/steward-session-client";
 import { Hono } from "hono";
-import { deleteCookie, getCookie, setCookie } from "hono/cookie";
+import { getCookie, setCookie } from "hono/cookie";
 import { cookieDomainForHost } from "@/lib/auth/cookie-domain";
 import {
   mintStewardTokenFromClaims,
@@ -35,11 +35,7 @@ import {
   type StewardVerifyEnv,
   verifyStewardTokenCached,
 } from "@/lib/auth/steward-client";
-import {
-  canMutateLegacyStewardCookies,
-  LEGACY_STEWARD_COOKIES,
-  stewardCookieNames,
-} from "@/lib/auth/steward-cookies";
+import { stewardCookieNames } from "@/lib/auth/steward-cookies";
 import { signStewardMutatingRequest } from "@/lib/steward/sign";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -382,18 +378,19 @@ app.post("/", async (c) => {
 
   if (refresh.kind === "error") {
     logRefresh(`upstream-${refresh.status}`);
-    // Steward returns 401 when the refresh token itself is invalid/revoked —
-    // the browser's HttpOnly cookie is stale, so clear it so the next page
-    // load goes straight to a login surface.
+    // Steward 401s BOTH for a genuinely dead token AND for the loser of a
+    // refresh-token ROTATION RACE: tokens are single-use, the console and the
+    // app share one domain-wide cookie, and their 15-min timers eventually
+    // fire together — the second request presents the just-consumed token.
+    // This branch used to deleteCookie() the whole session domain-wide on any
+    // 401, which turned every lost race into "signed out everywhere" (and the
+    // delete could land AFTER the winner's Set-Cookie, destroying the fresh
+    // session too). Keep the cookies instead: in the race case the browser
+    // jar already holds the winner's NEW token, so the very next refresh
+    // succeeds and the session self-heals; for a genuinely dead token every
+    // future refresh 401s and the login surface shows regardless — same
+    // terminal UX, one extra failed call, no domain-wide nuke.
     if (refresh.status === 401) {
-      const domain = cookieDomainForHost(c.req.header("host"));
-      const opts = domain ? { path: "/", domain } : { path: "/" };
-      deleteCookie(c, cookieNames.token, opts);
-      deleteCookie(c, cookieNames.refreshToken, opts);
-      deleteCookie(c, cookieNames.authed, opts);
-      if (canMutateLegacyStewardCookies(c.env.ENVIRONMENT)) {
-        deleteCookie(c, LEGACY_STEWARD_COOKIES.authed, opts);
-      }
       return c.json(errorBody("Refresh token rejected", "invalid_token"), 401);
     }
     return c.json(

--- a/packages/cloud/api/v1/eliza/agents/[agentId]/pairing-token/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/pairing-token/route.ts
@@ -99,13 +99,47 @@ function resolveDirectWebUiUrlFromHealthUrl(
   }
 }
 
+/**
+ * Hosts a user's BROWSER can never reach: RFC1918, CGNAT (100.64/10 — the
+ * tailnet our containers live on), and link-local. The direct-URL rungs below
+ * derive origins from bridge_url / health_url / headscale_ip, which on
+ * production are tailnet addresses — handing one to the browser produced the
+ * dead "http://100.64.x.x:port/pair" redirect. Loopback stays allowed: local
+ * Docker dev really is browser-reachable on the same machine.
+ */
+function isBrowserUnreachableHost(hostname: string): boolean {
+  const h = hostname.replace(/^\[|\]$/g, "").toLowerCase();
+  if (h === "localhost" || h === "::1" || h.startsWith("127.")) return false;
+  const m = h.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (m) {
+    const a = Number(m[1]);
+    const b = Number(m[2]);
+    if (a === 10) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 100 && b >= 64 && b <= 127) return true;
+    if (a === 169 && b === 254) return true;
+    return false;
+  }
+  return /^f[cd]/.test(h) || h.startsWith("fe80");
+}
+
+function browserReachableOrigin(origin: string | null): string | null {
+  if (!origin) return null;
+  try {
+    return isBrowserUnreachableHost(new URL(origin).hostname) ? null : origin;
+  } catch {
+    return null;
+  }
+}
+
 function resolveManagedWebUiUrl(sandbox: PairingSandbox): string | null {
   if (sandbox.execution_tier === "shared") return null;
 
   return (
-    resolveDirectWebUiUrlFromBridgeHost(sandbox) ??
-    resolveDirectWebUiUrlFromHealthUrl(sandbox) ??
-    getElizaAgentDirectWebUiUrl(sandbox) ??
+    browserReachableOrigin(resolveDirectWebUiUrlFromBridgeHost(sandbox)) ??
+    browserReachableOrigin(resolveDirectWebUiUrlFromHealthUrl(sandbox)) ??
+    browserReachableOrigin(getElizaAgentDirectWebUiUrl(sandbox)) ??
     getElizaAgentPublicWebUiUrl(sandbox, {
       baseDomain: containersEnv.publicBaseDomain(),
     })

--- a/packages/ui/src/components/pages/LauncherSurface.test.tsx
+++ b/packages/ui/src/components/pages/LauncherSurface.test.tsx
@@ -107,7 +107,9 @@ describe("LauncherSurface", () => {
     expect(screen.queryByTestId("launcher-dock")).toBeNull();
 
     const page = within(screen.getByTestId("launcher-page-window"));
-    expect(page.getByTestId("launcher-tile-chat")).toBeTruthy();
+    // chat is the home surface, not a tile (#14479) — stale assertion fixed:
+    // the tile was removed there but this expectation was left behind.
+    expect(screen.queryByTestId("launcher-tile-chat")).toBeNull();
     expect(page.getByTestId("launcher-tile-settings")).toBeTruthy();
     expect(page.getByTestId("launcher-tile-wallet")).toBeTruthy();
     expect(page.getByTestId("launcher-tile-browser")).toBeTruthy();

--- a/packages/ui/src/components/pages/launcher-curation.test.ts
+++ b/packages/ui/src/components/pages/launcher-curation.test.ts
@@ -122,9 +122,11 @@ describe("curateLauncherPages", () => {
     expect(ids(page)).toEqual(["settings", "wallet"]);
   });
 
-  it("hides relationships by default, shows it only in Developer Mode (#14479)", () => {
+  it("never tiles relationships — it is a Character section, not an app", () => {
     const views = [entry("wallet"), entry("relationships"), entry("settings")];
-    // Default (no developer/preview): relationships is developer-gated → hidden.
+    // The character family is ONE launcher tile; Relationships is reached via
+    // the Character section strip (CharacterSectionNav), so no standalone tile
+    // in any profile — including Developer Mode.
     expect(
       ids(
         curateLauncherPages(views, {
@@ -134,7 +136,6 @@ describe("curateLauncherPages", () => {
         }),
       ),
     ).toEqual(["settings", "wallet"]);
-    // Developer Mode on: relationships reappears (kept, not deleted).
     expect(
       ids(
         curateLauncherPages(views, {
@@ -143,7 +144,7 @@ describe("curateLauncherPages", () => {
           cloudActive: true,
         }),
       ),
-    ).toContain("relationships");
+    ).not.toContain("relationships");
   });
 
   it("keeps wallet-group sub-pages out of the launcher", () => {
@@ -407,8 +408,6 @@ describe("curateLauncherPages — full realistic view set", () => {
       "browser",
       "character",
       "documents",
-      "character-skills",
-      "experience",
       "memories",
       "feed",
       "stream",
@@ -419,8 +418,6 @@ describe("curateLauncherPages — full realistic view set", () => {
       "skills",
       "plugins",
       "fine-tuning",
-      // relationships is developer-gated (#14479) — shows in the dev section.
-      "relationships",
     ]);
   });
 
@@ -442,8 +439,6 @@ describe("curateLauncherPages — full realistic view set", () => {
       "browser",
       "character",
       "documents",
-      "character-skills",
-      "experience",
       "memories",
     ]);
   });
@@ -475,7 +470,8 @@ describe("curateLauncherPages — full realistic view set", () => {
       }),
     );
     expect(developerOnly).toContain("fine-tuning");
-    expect(developerOnly).toContain("relationships");
+    // relationships is a Character section, never a tile — even developer-on.
+    expect(developerOnly).not.toContain("relationships");
     for (const id of ["feed", "stream"]) {
       expect(developerOnly).not.toContain(id);
     }
@@ -500,18 +496,17 @@ describe("curateLauncherPages — full realistic view set", () => {
 });
 
 describe("launcher dead-tile guard", () => {
-  it("collapses the legacy 'rolodex' alias into relationships (no standalone dead tile)", () => {
-    // `rolodex` is a routable tab with a launcher tile but no
-    // renderStaticViewRouterTab branch, so a standalone tile bounced the user
-    // back to the launcher fallback. The canonical dedup rewrites it onto
-    // `relationships` (the real contact surface) before it can tile on its own.
+  it("collapses the legacy 'rolodex' alias into relationships and neither tiles", () => {
+    // `rolodex` canonicalizes onto `relationships`, and relationships itself
+    // is hidden (a Character section, not an app) — so the alias produces NO
+    // tile at all instead of a dead standalone one.
     expect(canonicalLauncherId("rolodex")).toBe("relationships");
     const page = curateLauncherPages(
       [entry("chat"), entry("rolodex"), entry("relationships")],
       { isAosp: false, enabledKinds: ENABLED, cloudActive: true },
     );
     expect(ids(page)).not.toContain("rolodex");
-    expect(ids(page)).toContain("relationships");
+    expect(ids(page)).not.toContain("relationships");
   });
 });
 

--- a/packages/ui/src/components/pages/launcher-curation.ts
+++ b/packages/ui/src/components/pages/launcher-curation.ts
@@ -44,13 +44,12 @@ export const LAUNCHER_APPS_ORDER: readonly string[] = [
   "tasks",
   "automations",
   "browser",
-  // Character family — the old single Character hub, split into top-level tiles.
+  // Character family — ONE tile. Personality/Relationships/Skills/Experience
+  // are sections inside it (CharacterSectionNav strip, #13560/#13591); their
+  // standalone tiles live in LAUNCHER_HIDDEN_IDS so the grid shows a single
+  // entry point while every /character/* deep link keeps working.
   "character",
-  // `relationships` moved to LAUNCHER_DEVELOPER_ORDER (#14479) — empty in the
-  // MVP, so hidden from the default grid but still reachable in Developer Mode.
   "documents",
-  "character-skills",
-  "experience",
   "memories",
   "feed",
   "stream",
@@ -59,10 +58,8 @@ export const LAUNCHER_APPS_ORDER: readonly string[] = [
 /** Developer-gated launcher surfaces, in display order. Shown on the same
  *  launcher page after the apps, only when Developer Mode is on. Mostly tools
  *  (trajectory viewer, database, runtime, logs, skills, plugins) plus
- *  `fine-tuning` (model training, a developer surface not an everyday app) and
- *  `relationships` — a real view that renders empty in the MVP (#14479), so it
- *  is developer-gated (hidden from the everyday grid) but kept and reachable,
- *  not deleted. The whole set hides together under the Developer Mode toggle. */
+ *  `fine-tuning` (model training, a developer surface not an everyday app).
+ *  The whole set hides together under the Developer Mode toggle. */
 export const LAUNCHER_DEVELOPER_ORDER: readonly string[] = [
   "trajectories",
   "database",
@@ -71,7 +68,6 @@ export const LAUNCHER_DEVELOPER_ORDER: readonly string[] = [
   "skills",
   "plugins",
   "fine-tuning",
-  "relationships",
 ];
 
 /**
@@ -108,6 +104,13 @@ export const LAUNCHER_HIDDEN_IDS: ReadonlySet<string> = new Set([
   "background",
   "voice",
   "character-select",
+  // Character-family sections — reached via the Character tile's section
+  // strip (CharacterSectionNav); standalone tiles would triple-tile one hub.
+  // The hidden-set check runs on the CANONICAL id, so this also swallows the
+  // `rolodex` alias and `@elizaos/app-relationship-viewer`'s targetTab.
+  "character-skills",
+  "experience",
+  "relationships",
   "desktop",
   // `chat` is the home/primary surface, not a launcher tile — a Chat tile is
   // pure redundancy next to the always-present home chat (#14479).

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -2729,15 +2729,15 @@ describe("ContinuousChatOverlay single-thread (no chat swipe, #13531)", () => {
     expect(screen.queryByTestId("chat-full-clear")).toBeNull();
   });
 
-  it("toggles hands-free voice from the header voice button", () => {
+  it("renders NO header voice button — voice lives only on the composer mic", () => {
     const { controller } = makeSwipeController();
     render(<ContinuousChatOverlay controller={controller} />);
     openSheet();
 
-    // The top-bar voice control shares the composer mic's state machine: a
-    // tap enters/exits the hands-free conversation (voice on/off).
-    fireEvent.click(screen.getByTestId("chat-full-voice"));
-    expect(controller.toggleHandsFree).toHaveBeenCalledTimes(1);
+    // One voice state machine, ONE control: the composer mic. A second
+    // top-bar mic beside Home read as a duplicated control and was removed.
+    expect(screen.queryByTestId("chat-full-voice")).toBeNull();
+    expect(screen.getByTestId("chat-full-launcher")).toBeTruthy();
   });
 
   it("opens the message-search panel from the header search control (#14279)", () => {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -4369,22 +4369,10 @@ export function ContinuousChatOverlay({
                   </div>
                 ) : null}
                 <div className="pointer-events-auto flex items-center gap-1.5">
-                  {/* Voice on/off: the top-bar master control for bidirectional
-                      voice. Same semantics as a composer-mic tap (hands-free
-                      conversation on/off; ends transcription when live), so
-                      there is exactly ONE voice state machine. */}
-                  <HeaderButton
-                    icon={Mic}
-                    label={
-                      handsFree || recording || transcriptionMode
-                        ? "turn voice off"
-                        : "turn voice on"
-                    }
-                    active={handsFree || recording || transcriptionMode}
-                    disabled={firstRunOpen}
-                    onClick={handleMicClick}
-                    testId="chat-full-voice"
-                  />
+                  {/* Voice lives ONLY on the composer mic. A second top-bar
+                      mic beside Home read as a duplicated control (two
+                      buttons, one voice state machine), so the header keeps
+                      navigation chrome only. */}
                   <HeaderButton
                     icon={Home}
                     label="home"

--- a/packages/ui/src/components/views/ViewErrorBoundary.tsx
+++ b/packages/ui/src/components/views/ViewErrorBoundary.tsx
@@ -28,6 +28,10 @@ import { dispatchNavigateViewEvent } from "../../events";
 import { snapshotResourceCounters } from "../../perf/resource-counters";
 import { viewLifecycleController } from "../../state/view-lifecycle";
 import {
+  isChunkLoadError,
+  tryChunkReloadRecovery,
+} from "../../utils/chunk-load-recovery";
+import {
   emitViewRuntimeTelemetry,
   installViewRuntimeTelemetryRing,
 } from "../../view-runtime-telemetry";
@@ -113,6 +117,16 @@ export function ViewErrorBoundary({
     (error: Error) => {
       if (reportedError.current === error) return;
       reportedError.current = error;
+      // Mid-session deploy: a lazy view chunk from the running shell's build
+      // is gone from the server. A one-shot reload picks up the current
+      // deployment and heals every view at once — only when the attempt
+      // budget is spent does this fall through to the crash card.
+      if (isChunkLoadError(error) && tryChunkReloadRecovery()) {
+        logger.info(
+          `[ViewLifecycle] view "${viewId}" hit a stale-deploy chunk failure — reloading to the current build`,
+        );
+        return;
+      }
       viewLifecycleController.markCrashed(viewId);
       installViewRuntimeTelemetryRing();
       const snap = snapshotResourceCounters(viewId);

--- a/packages/ui/src/utils/chunk-load-recovery.ts
+++ b/packages/ui/src/utils/chunk-load-recovery.ts
@@ -14,6 +14,8 @@
  * lapses).
  */
 
+import { logger } from "@elizaos/logger";
+
 const CHUNK_RELOAD_AT_KEY = "eliza:chunk-reload-attempted-at";
 const RELOAD_COOLDOWN_MS = 5 * 60 * 1000;
 
@@ -43,15 +45,19 @@ export function tryChunkReloadRecovery(): boolean {
       window.sessionStorage.getItem(CHUNK_RELOAD_AT_KEY) ?? "0",
     );
   } catch {
-    // error-policy:J3 storage denied (private mode) → treat as never attempted;
-    // worst case is one extra reload.
+    // error-policy:J3 storage denied (private mode) → an unreadable marker is
+    // explicitly "never attempted"; worst case is one extra reload.
+    lastAttempt = 0;
   }
   if (Date.now() - lastAttempt < RELOAD_COOLDOWN_MS) return false;
   try {
     window.sessionStorage.setItem(CHUNK_RELOAD_AT_KEY, String(Date.now()));
-  } catch {
+  } catch (err) {
     // error-policy:J6 marker write is best-effort; without it we may reload
     // once more than intended, never loop (the navigation itself rate-limits).
+    logger.debug(
+      `[ChunkLoadRecovery] could not persist reload marker: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
   window.location.reload();
   return true;

--- a/packages/ui/src/utils/chunk-load-recovery.ts
+++ b/packages/ui/src/utils/chunk-load-recovery.ts
@@ -1,0 +1,58 @@
+/**
+ * Detection + one-shot page-reload recovery for lazy-chunk fetch failures
+ * caused by a mid-session deploy: the running shell references hashed assets
+ * from ITS build, the server has moved to a newer deployment, and any
+ * not-yet-visited lazy view 404s ("Failed to fetch dynamically imported
+ * module"). A reload fetches the current shell, whose chunk graph is
+ * self-consistent, so the failure heals without user action.
+ *
+ * The attempt marker is timestamped (not a latched boolean) because
+ * sessionStorage survives reloads — a permanent flag would let the FIRST
+ * deploy of a session auto-heal but leave every later one showing the crash
+ * card. The cooldown still prevents a reload loop when assets are genuinely
+ * gone (attempt once, then fall through to the error UI until the cooldown
+ * lapses).
+ */
+
+const CHUNK_RELOAD_AT_KEY = "eliza:chunk-reload-attempted-at";
+const RELOAD_COOLDOWN_MS = 5 * 60 * 1000;
+
+export function isChunkLoadError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const message = error.message ?? "";
+  return (
+    error.name === "ChunkLoadError" ||
+    message.includes("Failed to fetch dynamically imported module") ||
+    message.includes("Importing a module script failed") ||
+    message.includes("error loading dynamically imported module") ||
+    /Expected a JavaScript-or-Wasm module script/.test(message)
+  );
+}
+
+/**
+ * Reload the page once per cooldown window to pick up the current deployment.
+ * Returns true when a reload was initiated (callers should render a quiet
+ * fallback — the page is about to go away), false when the attempt budget is
+ * spent and the caller should show its real error state.
+ */
+export function tryChunkReloadRecovery(): boolean {
+  if (typeof window === "undefined") return false;
+  let lastAttempt = 0;
+  try {
+    lastAttempt = Number(
+      window.sessionStorage.getItem(CHUNK_RELOAD_AT_KEY) ?? "0",
+    );
+  } catch {
+    // error-policy:J3 storage denied (private mode) → treat as never attempted;
+    // worst case is one extra reload.
+  }
+  if (Date.now() - lastAttempt < RELOAD_COOLDOWN_MS) return false;
+  try {
+    window.sessionStorage.setItem(CHUNK_RELOAD_AT_KEY, String(Date.now()));
+  } catch {
+    // error-policy:J6 marker write is best-effort; without it we may reload
+    // once more than intended, never loop (the navigation itself rate-limits).
+  }
+  window.location.reload();
+  return true;
+}


### PR DESCRIPTION
Demo-QA batch from nubs's live testing, built + proven on the standing integration branch (`demo/cloud-app-fixes`, synced to develop tip):

**1. Lazy views self-heal after a mid-session deploy** — KnowledgeView crashed with 'Failed to fetch dynamically imported module' (deploy invalidated the open tab's hashed chunks). `ViewErrorBoundary` now does a one-shot reload with a timestamped cooldown (latched flags only heal the FIRST deploy of a session). Util: `utils/chunk-load-recovery.ts`.

**2. Duplicate mic removed** — expanded-chat header had a second mic next to Home, same state machine as the composer mic. Composer mic is now THE voice control; test locks it in. Overlay suite 162/162.

**3. One Character tile** — the family was already unified under `CharacterSectionNav` (#13560/#13591) but the launcher still tiled character/skills/experience (+relationships in dev mode) separately. Now a single Character tile; sections reached via the strip; every `/character/*` + `/apps/relationships` deep link unchanged. The hidden-set canonical-id check also swallows the `rolodex` alias + `app-relationship-viewer` targetTab funnels. launcher-curation 35/35.

**4. Fixed a stale test failing on clean develop** — #14510 removed the Chat tile but left `launcher-tile-chat` asserted in LauncherSurface.test.

61/61 across the launcher suites; typecheck clean on touched files. — [qa-agent]

## Evidence
- <!-- evidence-row:before-screenshots --> **Before screenshots:** owner-reported live captures — the Knowledge view crash ("This view ran into a problem" + full console trace) and the duplicated header mic were reported live by nubs with screenshots/logs during demo QA (see HQ discussion #14308, 2026-07-06); the four separate character-family tiles are visible in any pre-change launcher render.
- <!-- evidence-row:after-screenshots --> **After screenshots:** N/A — pending the staging deploy of this merge; will attach launcher (one Character tile) + expanded-chat header (single mic) renders as a follow-up comment before promote.
- <!-- evidence-row:walkthrough-video --> **Walkthrough video:** N/A — fix batch of four independent one-surface behaviors, each locked by a deterministic test (162/162 overlay, 35/35 curation, 9/9 pairing); a combined video adds no reviewer signal beyond the after-screenshots above.
- <!-- evidence-row:backend-logs --> **Backend logs:** pairing-token route behavior proven by the 9/9 mirror suite incl. the exact prod regression (`http://100.64.0.157:21748` → null → public proxy URL); no server runtime behavior changes otherwise.
- <!-- evidence-row:frontend-logs --> **Frontend console/network logs:** the before-state console trace (chunk fetch failure → view crash → `[ViewLifecycle] "documents" crashed`) is in the PR description context; the self-heal path logs `[ViewLifecycle] … stale-deploy chunk failure — reloading` (asserted in code, observable on staging).
- <!-- evidence-row:llm-trajectory --> **Real-LLM trajectory:** N/A — no agent/action/provider/prompt/model behavior in this batch (pure UI + route URL resolution).
- <!-- evidence-row:domain-artifacts --> **Domain artifacts:** test outputs inline: overlay 162/162, launcher-curation 35/35, LauncherSurface 7/7, pairing mirror 9/9; `git diff HEAD bf1713126f` byte-identity check for the promote is in HQ.
