### PR TITLE
feat(ui): notifications fill home column to the chat; drop clock greeting; margin under header

### DIFF
--- a/packages/ui/src/components/shell/DefaultHomeWidgets.tsx
+++ b/packages/ui/src/components/shell/DefaultHomeWidgets.tsx
@@ -70,18 +70,10 @@ const WEATHER_ICON: Record<WeatherKind, LucideIcon> = {
   storm: CloudLightning,
 };
 
-function greeting(hour: number): string {
-  if (hour < 5) return "Good night";
-  if (hour < 12) return "Good morning";
-  if (hour < 17) return "Good afternoon";
-  if (hour < 21) return "Good evening";
-  return "Good night";
-}
-
 /**
  * The weather half of the time/weather pair - a naked 2×2 tile that mirrors the
  * time tile's footprint (bottom-aligned so the reading settles against the same
- * baseline band as the greeting, giving the pair a shared horizon).
+ * baseline band as the date, giving the pair a shared horizon).
  */
 function WeatherTile(): React.JSX.Element {
   const weather = useWeather();
@@ -198,9 +190,6 @@ const HomeClock = memo(function HomeClock(): React.JSX.Element {
       <div className={cn("mt-3 text-base font-medium", WALLPAPER_TEXT.primary)}>
         {dateLabel}
       </div>
-      <div className="mt-1 text-sm font-medium text-accent/90">
-        {greeting(hours)}
-      </div>
     </div>
   );
 });
@@ -224,9 +213,9 @@ export function DefaultHomeWidgets(): React.JSX.Element | null {
       className="grid grid-cols-4 items-start gap-x-4 gap-y-2"
     >
       {/* Time, the editorial header. Big, left-aligned, with a tight tracking
-          display feel; the date + greeting sit beneath as a quiet stack so the
-          hierarchy is unmistakable (hero numeral, supporting line, soft
-          greeting). White on the ember field with a legibility shadow.
+          display feel; the date sits beneath as a quiet supporting line so the
+          hierarchy is unmistakable (hero numeral, supporting line). White on the
+          ember field with a legibility shadow.
 
           Hideable from Appearance settings (#10706): only render when the user
           hasn't hidden the time tile. The tile footprint is reserved immediately;

--- a/packages/ui/src/components/shell/HomeScreen.test.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.test.tsx
@@ -144,8 +144,24 @@ describe("HomeScreen", () => {
     expect(
       header.compareDocumentPosition(card) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeGreaterThan(0);
+    // The wrapper grows to fill the column down to the chat (flex-1) and keeps a
+    // small margin below the header (mt-4).
+    const wrapper = card.parentElement;
+    expect(wrapper?.className).toContain("flex-1");
+    expect(wrapper?.className).toContain("mt-4");
+    // The inbox itself fills its wrapper and scrolls internally.
+    expect(card.className).toContain("flex-1");
     // Rows are grouped by view.
     expect(screen.getByTestId("notification-group-label")).toBeTruthy();
+  });
+
+  it("does NOT grow the notification region when the inbox is empty (calm centred home)", () => {
+    render(<HomeScreen onOpenTile={vi.fn()} />);
+    // Empty inbox self-hides; the widget breathing region keeps the flex-1 fill.
+    expect(screen.queryByTestId("home-notification-center")).toBeNull();
+    const hostWrapper = screen.getByTestId("home-widget-host").parentElement;
+    expect(hostWrapper?.className).toContain("flex-1");
+    expect(hostWrapper?.className).toContain("justify-center");
   });
 
   // GESTURE-HINT OVERLAP FIX (#14945 follow-up): the one-time gesture hint

--- a/packages/ui/src/components/shell/HomeScreen.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.tsx
@@ -15,6 +15,7 @@ import { useEffect, useRef, useState } from "react";
 import { useActivityEvents } from "../../hooks/useActivityEvents";
 import { isRenderTelemetryEnabled } from "../../hooks/useRenderGuard";
 import { cn } from "../../lib/utils";
+import { useNotifications } from "../../state/notifications/notification-store";
 import { LAYOUT_SHIFT_OBSERVER_INIT } from "../../testing/layout-stability";
 import { WidgetHost } from "../../widgets/WidgetHost";
 import { Button } from "../ui/button";
@@ -174,6 +175,13 @@ export function HomeScreen({
   // Dev/test-only: observe home layout shifts on the shared telemetry channel.
   useHomeLayoutShiftObserver();
 
+  // When the inbox has notifications it becomes the home's primary content and
+  // grows to fill the column down to the chat; the ranked widget host then sits
+  // below it at natural height. With an empty inbox the widget host reclaims the
+  // `flex-1` breathing region (centred), so a quiet home stays calmly centred.
+  const { notifications } = useNotifications();
+  const hasNotifications = notifications.length > 0;
+
   return (
     <>
       <div
@@ -226,25 +234,31 @@ export function HomeScreen({
 
           {/* Notifications live inline on the SAME layer as the widgets, in the
             band between the time/weather header above and the chat below —
-            self-hiding when the inbox is empty. It fades in (Apple-style) on
-            first appearance; its rows carry their own staggered slide-in. */}
-          <div className={enterClass} style={{ animationDelay: "90ms" }}>
-            <NotificationsHomeCenter />
-          </div>
-
-          {/* The prioritized data widgets (#9143) live in the breathing region:
-            a `flex-1` block that grows to fill the space between the header and
-            the bottom tiles, so the column always spans the full height. Its
-            content is vertically centred within that region - when widgets are
-            present they sit in the visual middle (no top-heavy clustering with a
-            void beneath); when the host self-hides everything, the empty region
-            simply reads as calm, intentional space rather than a dead gap. A
-            little top padding sets the stack apart from the editorial header as
-            its own section. */}
+            self-hiding when the inbox is empty. A small `mt-4` sets it apart
+            from the editorial header. When present it grows (`flex-1 min-h-0`)
+            to fill the column down to the chat, its list scrolling internally;
+            it fades in (Apple-style) on first appearance. */}
           <div
             className={cn(
               enterClass,
-              "flex flex-1 flex-col justify-center py-6",
+              "mt-4",
+              hasNotifications && "flex min-h-0 flex-1 flex-col",
+            )}
+            style={{ animationDelay: "90ms" }}
+          >
+            <NotificationsHomeCenter />
+          </div>
+
+          {/* The prioritized data widgets (#9143). With notifications present
+            they sit at natural height directly beneath the (grown) inbox. With
+            an EMPTY inbox this reclaims the `flex-1` breathing region and centres
+            its content, so a quiet home reads as calm airiness rather than a
+            broken gap. A little padding sets the stack apart as its own section. */}
+          <div
+            className={cn(
+              enterClass,
+              "flex flex-col py-6",
+              !hasNotifications && "flex-1 justify-center",
             )}
             style={{ animationDelay: "110ms" }}
           >

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -54,13 +54,6 @@ const SWIPE_DISMISS_PX = 88;
 const LONG_PRESS_MS = 420;
 
 /**
- * Height cap for the scrolling list (the header stays pinned above it). Sized
- * so the dashboard keeps the widget grid visible below on a phone while still
- * showing ~4–5 rows before scrolling.
- */
-const LIST_MAX_HEIGHT = "max-h-[min(45dvh,19.5rem)]";
-
-/**
  * Upper bound on rendered rows. The store caps the inbox at 300 but painting
  * hundreds of buttons on the always-mounted home hurts low-end mobile; 100
  * matches the HTTP hydrate limit, and dismiss/clear manage volume beyond it.
@@ -682,8 +675,9 @@ export function NotificationsHomeCenter(): React.JSX.Element | null {
       // inline on the home field directly under the time/weather header — rows
       // are separated by spacing and their hover wash, so the list reads as bare
       // lock-screen notes, not a boxed panel. `eliza-notif-center-in` fades the
-      // whole inbox in (Apple-style) the moment it first appears.
-      className="eliza-notif-center-in flex flex-col overflow-hidden"
+      // whole inbox in (Apple-style) the moment it first appears. `min-h-0 flex-1`
+      // lets it fill the home column down to the chat when the parent grows it.
+      className="eliza-notif-center-in flex min-h-0 flex-1 flex-col overflow-hidden"
     >
       <style>{NOTIF_SCROLL_CSS}</style>
       {/* Pinned header: a quiet eyebrow + unread count, actions to the right.
@@ -729,8 +723,7 @@ export function NotificationsHomeCenter(): React.JSX.Element | null {
         onScroll={syncEdgeFades}
         data-testid="home-notification-list"
         className={cn(
-          "eliza-notif-scroll flex flex-col gap-0.5 overflow-y-auto overscroll-y-contain px-1.5 pb-1.5",
-          LIST_MAX_HEIGHT,
+          "eliza-notif-scroll flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto overscroll-y-contain px-1.5 pb-1.5",
         )}
       >
         {groups.map((group) => (


### PR DESCRIPTION
## Notifications fill the home column; drop clock greeting; margin under header

Follow-up to the inline notification inbox. Three refinements from the desktop view:

- **Fill the height down to the chat.** When the inbox has notifications it now grows (`flex-1 min-h-0`) to fill the home column from the header down to the floating chat, its list scrolling internally, instead of a short fixed-height block with dead space beneath. The ranked widget host then sits below it at natural height. An **empty** inbox keeps the centred `flex-1` breathing region, so a quiet home stays calmly centred (unchanged).
- **Margin under the header.** `mt-4` between the time/weather header and the inbox.
- **Drop the "Good afternoon" greeting** line under the date in `DefaultHomeWidgets`.

Removed the notification list's fixed `max-h` cap in favor of the fill-and-scroll layout.

### Tests
`HomeScreen.test.tsx` — asserts the inbox wrapper grows (`flex-1`) + keeps `mt-4` when populated, and that an empty inbox leaves the widget region's centred `flex-1` fill intact. 9 HomeScreen + 17 NotificationsHomeCenter + 7 DefaultHomeWidgets tests pass; typecheck + biome clean. Real-app e2e (`gesture-matrix` notification center) passes; screenshot attached showing the filled column with no greeting.
