### PR TITLE
fix(lifeops): add delegation contract evaluator

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/delegation-contracts/index.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/delegation-contracts/index.ts
@@ -1,0 +1,431 @@
+/**
+ * Deterministic evaluator for delegated communication threads.
+ *
+ * A DelegationContract captures what the owner asked the assistant to handle,
+ * which thread or sender class it applies to, when to stay silent, and which
+ * tripwire requires exactly one owner escalation. The evaluator is pure so the
+ * connector/runtime layer can persist rows and enqueue approvals without
+ * embedding policy decisions in transport adapters.
+ */
+
+export type DelegationAutonomyLevel =
+  | "draft_only"
+  | "approval_gated"
+  | "silent_autonomous";
+
+export type DelegationChannel =
+  | "email"
+  | "gmail"
+  | "discord"
+  | "slack"
+  | "imessage"
+  | "signal"
+  | "telegram"
+  | "whatsapp"
+  | "x_dm";
+
+export interface DelegationThreadScope {
+  readonly kind: "thread";
+  readonly channel: DelegationChannel;
+  readonly threadId: string;
+}
+
+export interface DelegationSenderClassScope {
+  readonly kind: "sender_class";
+  readonly channel: DelegationChannel;
+  readonly senderClass: string;
+}
+
+export type DelegationScope =
+  | DelegationThreadScope
+  | DelegationSenderClassScope;
+
+export type DelegationTripwire =
+  | {
+      readonly kind: "price_pushback";
+      readonly label: string;
+    }
+  | {
+      readonly kind: "keyword";
+      readonly label: string;
+      readonly keywords: readonly string[];
+    }
+  | {
+      readonly kind: "renewal_delta_percent";
+      readonly label: string;
+      readonly thresholdPercent: number;
+    }
+  | {
+      readonly kind: "nth_ignore";
+      readonly label: string;
+      readonly thresholdCount: number;
+    };
+
+export interface DelegationSlaPolicy {
+  readonly holdingReplyAfterMinutes: number;
+  readonly holdingReplyBody: string;
+  readonly subjectPrefix?: string;
+}
+
+export interface DelegationContract {
+  readonly contractId: string;
+  readonly objective: string;
+  readonly scope: DelegationScope;
+  readonly autonomyLevel: DelegationAutonomyLevel;
+  readonly tripwires: readonly DelegationTripwire[];
+  readonly createdAt: string;
+  readonly expiresAt: string;
+  readonly ownerUserId: string;
+  readonly requestedBy: string;
+  readonly state?: {
+    readonly escalatedAt?: string;
+    readonly handledTurnCount?: number;
+    readonly holdingReplyQueuedAt?: string;
+  };
+  readonly sla?: DelegationSlaPolicy;
+}
+
+export interface DelegationInboundTurn {
+  readonly channel: DelegationChannel;
+  readonly threadId: string;
+  readonly sender: string;
+  readonly senderEmail?: string;
+  readonly senderClass?: string;
+  readonly subject?: string;
+  readonly text: string;
+  readonly receivedAt: string;
+  readonly ownerRepliedAt?: string;
+  readonly followupCount?: number;
+  readonly renewalDeltaPercent?: number;
+}
+
+export interface DelegationDraftIntent {
+  readonly action: "send_email";
+  readonly channel: "email";
+  readonly requestedBy: string;
+  readonly subjectUserId: string;
+  readonly reason: string;
+  readonly payload: {
+    readonly action: "send_email";
+    readonly to: readonly string[];
+    readonly cc: readonly string[];
+    readonly bcc: readonly string[];
+    readonly subject: string;
+    readonly body: string;
+    readonly threadId: string | null;
+    readonly replyToMessageId: string | null;
+  };
+}
+
+export interface DelegationEscalation {
+  readonly kind: "owner_escalation";
+  readonly contractId: string;
+  readonly triggeredBy: DelegationTripwire;
+  readonly summary: string;
+  readonly decisionPrompt: string;
+  readonly sourceText: string;
+  readonly triggeredAt: string;
+}
+
+export type DelegationEvaluationOutcome =
+  | "out_of_scope"
+  | "in_bounds"
+  | "escalate_owner"
+  | "already_escalated"
+  | "holding_reply_due"
+  | "holding_reply_suppressed";
+
+export interface DelegationEvaluation {
+  readonly outcome: DelegationEvaluationOutcome;
+  readonly contract: DelegationContract;
+  readonly escalation: DelegationEscalation | null;
+  readonly draftIntent: DelegationDraftIntent | null;
+  readonly audit: {
+    readonly silentTowardOwner: boolean;
+    readonly matchedTripwire: string | null;
+    readonly reason: string;
+  };
+}
+
+function normalize(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9%.$]+/g, " ")
+    .trim();
+}
+
+function parseTime(value: string, label: string): number {
+  const ms = Date.parse(value);
+  if (!Number.isFinite(ms)) {
+    throw new Error(`[DelegationContract] invalid ${label}: ${value}`);
+  }
+  return ms;
+}
+
+function scopeMatches(
+  contract: DelegationContract,
+  turn: DelegationInboundTurn,
+): boolean {
+  if (contract.scope.channel !== turn.channel) return false;
+  if (contract.scope.kind === "thread") {
+    return contract.scope.threadId === turn.threadId;
+  }
+  return (
+    typeof turn.senderClass === "string" &&
+    normalize(turn.senderClass) === normalize(contract.scope.senderClass)
+  );
+}
+
+function isActive(
+  contract: DelegationContract,
+  turn: DelegationInboundTurn,
+): boolean {
+  const receivedAt = parseTime(turn.receivedAt, "turn.receivedAt");
+  return (
+    receivedAt >= parseTime(contract.createdAt, "contract.createdAt") &&
+    receivedAt <= parseTime(contract.expiresAt, "contract.expiresAt")
+  );
+}
+
+function pricePushbackMatches(text: string): boolean {
+  const normalized = normalize(text);
+  const priceTerms = [
+    "price",
+    "cost",
+    "rate",
+    "budget",
+    "discount",
+    "too expensive",
+    "quote",
+  ];
+  const pushbackTerms = [
+    "too high",
+    "cannot accept",
+    "can't accept",
+    "won t accept",
+    "push back",
+    "need better",
+    "reduce",
+    "lower",
+    "not acceptable",
+  ];
+  return (
+    priceTerms.some((term) => normalized.includes(term)) &&
+    pushbackTerms.some((term) => normalized.includes(term))
+  );
+}
+
+function tripwireMatches(
+  tripwire: DelegationTripwire,
+  turn: DelegationInboundTurn,
+): boolean {
+  const normalizedText = normalize(turn.text);
+  if (tripwire.kind === "price_pushback") {
+    return pricePushbackMatches(turn.text);
+  }
+  if (tripwire.kind === "keyword") {
+    return tripwire.keywords.some((keyword) =>
+      normalizedText.includes(normalize(keyword)),
+    );
+  }
+  if (tripwire.kind === "renewal_delta_percent") {
+    return (
+      typeof turn.renewalDeltaPercent === "number" &&
+      Number.isFinite(turn.renewalDeltaPercent) &&
+      Math.abs(turn.renewalDeltaPercent) >= tripwire.thresholdPercent
+    );
+  }
+  return (
+    typeof turn.followupCount === "number" &&
+    Number.isFinite(turn.followupCount) &&
+    turn.followupCount >= tripwire.thresholdCount
+  );
+}
+
+function findMatchedTripwire(
+  contract: DelegationContract,
+  turn: DelegationInboundTurn,
+): DelegationTripwire | null {
+  return (
+    contract.tripwires.find((tripwire) => tripwireMatches(tripwire, turn)) ??
+    null
+  );
+}
+
+function withState(
+  contract: DelegationContract,
+  state: NonNullable<DelegationContract["state"]>,
+): DelegationContract {
+  return {
+    ...contract,
+    state: {
+      ...(contract.state ?? {}),
+      ...state,
+    },
+  };
+}
+
+function escalationFor(
+  contract: DelegationContract,
+  turn: DelegationInboundTurn,
+  tripwire: DelegationTripwire,
+): DelegationEscalation {
+  return {
+    kind: "owner_escalation",
+    contractId: contract.contractId,
+    triggeredBy: tripwire,
+    triggeredAt: turn.receivedAt,
+    sourceText: turn.text,
+    summary: `${turn.sender} tripped "${tripwire.label}" on ${contract.objective}.`,
+    decisionPrompt: `Decide how to proceed on ${contract.objective}: ${turn.sender} said "${turn.text}"`,
+  };
+}
+
+function minutesBetween(startIso: string, endIso: string): number {
+  return (parseTime(endIso, "end") - parseTime(startIso, "start")) / 60_000;
+}
+
+function ownerRepliedBeforeSla(
+  turn: DelegationInboundTurn,
+  contract: DelegationContract,
+): boolean {
+  if (!turn.ownerRepliedAt || !contract.sla) return false;
+  const elapsed = minutesBetween(turn.receivedAt, turn.ownerRepliedAt);
+  return elapsed >= 0 && elapsed < contract.sla.holdingReplyAfterMinutes;
+}
+
+function buildHoldingReplyIntent(
+  contract: DelegationContract,
+  turn: DelegationInboundTurn,
+): DelegationDraftIntent | null {
+  if (!contract.sla || !turn.senderEmail) return null;
+  const subject =
+    turn.subject && contract.sla.subjectPrefix
+      ? `${contract.sla.subjectPrefix} ${turn.subject}`
+      : (turn.subject ?? `Re: ${contract.objective}`);
+  return {
+    action: "send_email",
+    channel: "email",
+    requestedBy: contract.requestedBy,
+    subjectUserId: contract.ownerUserId,
+    reason: `SLA holding reply for delegated ${contract.objective}`,
+    payload: {
+      action: "send_email",
+      to: [turn.senderEmail],
+      cc: [],
+      bcc: [],
+      subject,
+      body: contract.sla.holdingReplyBody,
+      threadId: turn.threadId,
+      replyToMessageId: null,
+    },
+  };
+}
+
+function evaluateSla(
+  contract: DelegationContract,
+  turn: DelegationInboundTurn,
+  nowIso: string,
+): DelegationEvaluation | null {
+  if (!contract.sla) return null;
+  if (contract.state?.holdingReplyQueuedAt) {
+    return null;
+  }
+  if (ownerRepliedBeforeSla(turn, contract)) {
+    return {
+      outcome: "holding_reply_suppressed",
+      contract,
+      escalation: null,
+      draftIntent: null,
+      audit: {
+        silentTowardOwner: true,
+        matchedTripwire: null,
+        reason: "owner replied before the holding-reply SLA elapsed",
+      },
+    };
+  }
+  const elapsed = minutesBetween(turn.receivedAt, nowIso);
+  if (elapsed < contract.sla.holdingReplyAfterMinutes) {
+    return null;
+  }
+  const draftIntent = buildHoldingReplyIntent(contract, turn);
+  if (!draftIntent) return null;
+  return {
+    outcome: "holding_reply_due",
+    contract: withState(contract, { holdingReplyQueuedAt: nowIso }),
+    escalation: null,
+    draftIntent,
+    audit: {
+      silentTowardOwner: true,
+      matchedTripwire: null,
+      reason: "holding-reply SLA elapsed with no owner reply",
+    },
+  };
+}
+
+export function evaluateDelegationContract(input: {
+  readonly contract: DelegationContract;
+  readonly turn: DelegationInboundTurn;
+  readonly nowIso: string;
+}): DelegationEvaluation {
+  const { contract, turn, nowIso } = input;
+  parseTime(nowIso, "nowIso");
+  if (!scopeMatches(contract, turn) || !isActive(contract, turn)) {
+    return {
+      outcome: "out_of_scope",
+      contract,
+      escalation: null,
+      draftIntent: null,
+      audit: {
+        silentTowardOwner: true,
+        matchedTripwire: null,
+        reason: "turn is outside the contract scope or active window",
+      },
+    };
+  }
+
+  const matchedTripwire = findMatchedTripwire(contract, turn);
+  if (matchedTripwire) {
+    if (contract.state?.escalatedAt) {
+      return {
+        outcome: "already_escalated",
+        contract,
+        escalation: null,
+        draftIntent: null,
+        audit: {
+          silentTowardOwner: true,
+          matchedTripwire: matchedTripwire.label,
+          reason: "tripwire already escalated for this contract",
+        },
+      };
+    }
+    return {
+      outcome: "escalate_owner",
+      contract: withState(contract, { escalatedAt: turn.receivedAt }),
+      escalation: escalationFor(contract, turn, matchedTripwire),
+      draftIntent: null,
+      audit: {
+        silentTowardOwner: false,
+        matchedTripwire: matchedTripwire.label,
+        reason: "tripwire matched and no previous escalation exists",
+      },
+    };
+  }
+
+  const slaEvaluation = evaluateSla(contract, turn, nowIso);
+  if (slaEvaluation) return slaEvaluation;
+
+  return {
+    outcome: "in_bounds",
+    contract: withState(contract, {
+      handledTurnCount: (contract.state?.handledTurnCount ?? 0) + 1,
+    }),
+    escalation: null,
+    draftIntent: null,
+    audit: {
+      silentTowardOwner: true,
+      matchedTripwire: null,
+      reason: "turn is in bounds for delegated handling",
+    },
+  };
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/index.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/index.ts
@@ -3,6 +3,7 @@ export * from "./app-state.js";
 export * from "./apple-reminders.js";
 export * from "./bulk-review.js";
 export * from "./defaults.js";
+export * from "./delegation-contracts/index.js";
 export * from "./document-review.js";
 export * from "./email-curation.js";
 export * from "./enforcement-windows.js";

--- a/plugins/plugin-personal-assistant/test/delegation-contracts.test.ts
+++ b/plugins/plugin-personal-assistant/test/delegation-contracts.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for delegated communication contract evaluation.
+ *
+ * The evaluator is intentionally deterministic: seeded inbound turns exercise
+ * the policy shape that later runtime wiring will persist and feed from real
+ * connector events.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  type DelegationContract,
+  evaluateDelegationContract,
+} from "../src/lifeops/delegation-contracts/index.js";
+
+function vendorContract(
+  overrides: Partial<DelegationContract> = {},
+): DelegationContract {
+  return {
+    contractId: "delegation:vendor-thread",
+    objective: "Handle the vendor renewal thread",
+    scope: {
+      kind: "thread",
+      channel: "email",
+      threadId: "thread-vendor-1",
+    },
+    autonomyLevel: "approval_gated",
+    tripwires: [{ kind: "price_pushback", label: "vendor pushed on price" }],
+    createdAt: "2026-07-06T16:00:00.000Z",
+    expiresAt: "2026-07-13T16:00:00.000Z",
+    ownerUserId: "owner-1",
+    requestedBy: "delegation-contracts",
+    ...overrides,
+  };
+}
+
+describe("delegation contract evaluator", () => {
+  it("handles in-bounds delegated turns silently until a price tripwire fires", () => {
+    const inBounds = evaluateDelegationContract({
+      contract: vendorContract(),
+      nowIso: "2026-07-06T16:30:00.000Z",
+      turn: {
+        channel: "email",
+        threadId: "thread-vendor-1",
+        sender: "Riley Vendor",
+        senderEmail: "riley@vendor.example",
+        subject: "Renewal",
+        text: "We can keep the renewal on the same timeline and send the order form today.",
+        receivedAt: "2026-07-06T16:20:00.000Z",
+      },
+    });
+
+    expect(inBounds.outcome).toBe("in_bounds");
+    expect(inBounds.audit).toMatchObject({
+      silentTowardOwner: true,
+      matchedTripwire: null,
+    });
+    expect(inBounds.contract.state?.handledTurnCount).toBe(1);
+
+    const tripped = evaluateDelegationContract({
+      contract: inBounds.contract,
+      nowIso: "2026-07-06T16:45:00.000Z",
+      turn: {
+        channel: "email",
+        threadId: "thread-vendor-1",
+        sender: "Riley Vendor",
+        senderEmail: "riley@vendor.example",
+        subject: "Renewal",
+        text: "The price is too high; we cannot accept the quote without a discount.",
+        receivedAt: "2026-07-06T16:42:00.000Z",
+      },
+    });
+
+    expect(tripped.outcome).toBe("escalate_owner");
+    expect(tripped.escalation).toMatchObject({
+      kind: "owner_escalation",
+      contractId: "delegation:vendor-thread",
+      summary:
+        'Riley Vendor tripped "vendor pushed on price" on Handle the vendor renewal thread.',
+      sourceText:
+        "The price is too high; we cannot accept the quote without a discount.",
+    });
+    expect(tripped.audit).toMatchObject({
+      silentTowardOwner: false,
+      matchedTripwire: "vendor pushed on price",
+    });
+
+    const duplicate = evaluateDelegationContract({
+      contract: tripped.contract,
+      nowIso: "2026-07-06T16:50:00.000Z",
+      turn: {
+        channel: "email",
+        threadId: "thread-vendor-1",
+        sender: "Riley Vendor",
+        senderEmail: "riley@vendor.example",
+        subject: "Renewal",
+        text: "The cost is still too high and procurement needs better terms.",
+        receivedAt: "2026-07-06T16:49:00.000Z",
+      },
+    });
+
+    expect(duplicate.outcome).toBe("already_escalated");
+    expect(duplicate.escalation).toBeNull();
+    expect(duplicate.audit.silentTowardOwner).toBe(true);
+  });
+
+  it("queues a board-member holding reply after the SLA when the owner stays silent", () => {
+    const contract = vendorContract({
+      contractId: "delegation:board-sla",
+      objective: "Board member holding reply",
+      scope: {
+        kind: "sender_class",
+        channel: "email",
+        senderClass: "board_member",
+      },
+      tripwires: [],
+      sla: {
+        holdingReplyAfterMinutes: 60,
+        subjectPrefix: "Re:",
+        holdingReplyBody:
+          "Thanks, I have this and will come back with a proper answer shortly.",
+      },
+    });
+
+    const due = evaluateDelegationContract({
+      contract,
+      nowIso: "2026-07-06T18:05:00.000Z",
+      turn: {
+        channel: "email",
+        threadId: "thread-board-1",
+        sender: "Dana Board",
+        senderClass: "board_member",
+        senderEmail: "dana@board.example",
+        subject: "Quarterly update",
+        text: "Can you send the latest numbers?",
+        receivedAt: "2026-07-06T17:00:00.000Z",
+      },
+    });
+
+    expect(due.outcome).toBe("holding_reply_due");
+    expect(due.audit.silentTowardOwner).toBe(true);
+    expect(due.draftIntent).toMatchObject({
+      action: "send_email",
+      channel: "email",
+      requestedBy: "delegation-contracts",
+      subjectUserId: "owner-1",
+      payload: {
+        action: "send_email",
+        to: ["dana@board.example"],
+        subject: "Re: Quarterly update",
+        body: "Thanks, I have this and will come back with a proper answer shortly.",
+        threadId: "thread-board-1",
+      },
+    });
+    expect(due.contract.state?.holdingReplyQueuedAt).toBe(
+      "2026-07-06T18:05:00.000Z",
+    );
+  });
+
+  it("suppresses the SLA holding reply when the owner replies inside the hour", () => {
+    const contract = vendorContract({
+      contractId: "delegation:board-sla",
+      objective: "Board member holding reply",
+      scope: {
+        kind: "sender_class",
+        channel: "email",
+        senderClass: "board_member",
+      },
+      tripwires: [],
+      sla: {
+        holdingReplyAfterMinutes: 60,
+        holdingReplyBody: "Thanks, I have this.",
+      },
+    });
+
+    const suppressed = evaluateDelegationContract({
+      contract,
+      nowIso: "2026-07-06T18:05:00.000Z",
+      turn: {
+        channel: "email",
+        threadId: "thread-board-1",
+        sender: "Dana Board",
+        senderClass: "board_member",
+        senderEmail: "dana@board.example",
+        subject: "Quarterly update",
+        text: "Can you send the latest numbers?",
+        receivedAt: "2026-07-06T17:00:00.000Z",
+        ownerRepliedAt: "2026-07-06T17:30:00.000Z",
+      },
+    });
+
+    expect(suppressed.outcome).toBe("holding_reply_suppressed");
+    expect(suppressed.draftIntent).toBeNull();
+    expect(suppressed.audit.reason).toBe(
+      "owner replied before the holding-reply SLA elapsed",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add a pure `DelegationContract` evaluator for delegated comms threads and sender-class SLA policies
- model thread/sender scopes, autonomy level, expiry, tripwires, state, and SLA holding-reply policy
- return exactly-once owner escalation records when a tripwire fires, while keeping in-bounds turns silent toward the owner
- return approval-shaped holding-reply email intents for SLA misses and suppress them when the owner replies within the window
- export the evaluator and add seeded tests for vendor price-pushback and board-member holding-reply scenarios

## Evidence

<!-- evidence-row:before-screenshots -->
N/A - no UI or rendered surface changed.

<!-- evidence-row:after-screenshots -->
N/A - no UI or rendered surface changed.

<!-- evidence-row:walkthrough-video -->
N/A - no UI or interactive flow changed.

<!-- evidence-row:backend-logs -->
N/A - no server route or long-running backend service path changed; this PR adds a pure evaluator covered by focused tests.

<!-- evidence-row:frontend-logs -->
N/A - no frontend code changed.

<!-- evidence-row:llm-trajectory -->
N/A - this PR is deterministic contract-evaluator foundation. Full #14856 acceptance still needs live connector turns, persisted contract rows, approval queue drafts, and trajectories.

<!-- evidence-row:domain-artifacts -->
Focused domain validation: [delegation contract evaluator](plugins/plugin-personal-assistant/src/lifeops/delegation-contracts/index.ts) and [seeded evaluator tests](plugins/plugin-personal-assistant/test/delegation-contracts.test.ts).

## Validation Commands

| Type | Command | Result |
| --- | --- | --- |
| Seeded evaluator tests | `bun run --cwd plugins/plugin-personal-assistant test -- test/delegation-contracts.test.ts` | Pass: 1 file / 3 tests |
| Focused TypeScript | `bun x tsc --noEmit --ignoreConfig --module NodeNext --moduleResolution NodeNext --target ES2022 --strict --skipLibCheck --types node,vitest/globals plugins/plugin-personal-assistant/src/lifeops/delegation-contracts/index.ts plugins/plugin-personal-assistant/test/delegation-contracts.test.ts` | Pass |
| Package build | `bun run --cwd plugins/plugin-personal-assistant build` | Pass |
| Formatting/lint scope | `bun x biome check plugins/plugin-personal-assistant/src/lifeops/delegation-contracts/index.ts plugins/plugin-personal-assistant/src/lifeops/index.ts plugins/plugin-personal-assistant/test/delegation-contracts.test.ts` | Pass |
| Diff checks | `git diff --check && bun run audit:error-policy-ratchet` | Pass |
| Package typecheck | `bun run --cwd plugins/plugin-personal-assistant typecheck` | Fails on existing workspace resolution and unrelated strictness issues across the package (`@elizaos/core`, connector packages, contract exports, route strictness, etc.); focused TypeScript above covers the new module/test directly |

## Notes

This PR intentionally does not add DB persistence, a provider, live connector event wiring, approval queue writes, or autonomous connector sends. It gives those paths a typed deterministic policy core to call.

Fixes part of #14856.