### PR TITLE
feat(ui): top glass notification banners (iOS/Android heads-up) instead of bottom toast

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -68,6 +68,7 @@ import { HomeLauncherSurface } from "./components/shell/HomeLauncherSurface";
 import { HomePill } from "./components/shell/HomePill";
 import { HomeScreen, type HomeTileTarget } from "./components/shell/HomeScreen";
 import { KioskViewCanvas } from "./components/shell/KioskViewCanvas";
+import { NotificationBanners } from "./components/shell/NotificationBanners";
 import { NotificationsShellBoot } from "./components/shell/notifications-boot";
 import { ShellControllerProvider } from "./components/shell/ShellControllerContext";
 import { useShellControllerContext } from "./components/shell/ShellControllerContext.hooks";
@@ -2841,6 +2842,9 @@ export function App() {
             to the dashboard, where NotificationsHomeCenter is the one
             notification surface. Renders null. */}
         <NotificationsShellBoot />
+        {/* Top-of-screen glass banners for live notification arrivals (iOS/
+            Android heads-up idiom). Renders only while the queue is non-empty. */}
+        <NotificationBanners />
         {/* Tiny dismissible build stamp (bottom-left) so testers can verify
             PWA cache freshness at a glance. Best-effort: hidden when
             /build-info.json is absent (production builds without the

--- a/packages/ui/src/components/shell/NotificationBanners.stories.tsx
+++ b/packages/ui/src/components/shell/NotificationBanners.stories.tsx
@@ -1,0 +1,112 @@
+/**
+ * NotificationBanners stories — the top-of-screen glass banner queue, rendered
+ * over a wallpaper-like field so the glass reads. Each story seeds the banner
+ * store on mount so the portal has something to paint.
+ */
+import type { Meta, StoryObj } from "@storybook/react";
+import { useEffect } from "react";
+import {
+  __resetNotificationBannersForTests,
+  pushNotificationBanner,
+} from "../../state/notifications/notification-banner-store";
+import { NotificationBanners } from "./NotificationBanners";
+
+const BASE = 1_720_000_000_000;
+
+function Seed({
+  banners,
+}: {
+  banners: Array<Parameters<typeof pushNotificationBanner>[0]>;
+}): null {
+  useEffect(() => {
+    __resetNotificationBannersForTests();
+    for (const b of [...banners].reverse()) pushNotificationBanner(b);
+    return () => __resetNotificationBannersForTests();
+  }, [banners]);
+  return null;
+}
+
+const meta: Meta<typeof NotificationBanners> = {
+  title: "Shell/NotificationBanners",
+  component: NotificationBanners,
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          position: "relative",
+          minHeight: "60vh",
+          background:
+            "linear-gradient(160deg,#f7b58a 0%,#e8896b 45%,#c9607e 100%)",
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof NotificationBanners>;
+
+export const Stack: Story = {
+  render: () => (
+    <>
+      <Seed
+        banners={[
+          {
+            id: "n-urgent",
+            title: "Payment failed",
+            body: "Your card ending 4242 was declined.",
+            category: "system",
+            priority: "urgent",
+            source: "billing",
+            createdAt: BASE,
+            readAt: null,
+          },
+          {
+            id: "n-msg",
+            title: "New message from Alice",
+            body: "“Did you get a chance to look at the design doc?”",
+            category: "message",
+            priority: "normal",
+            source: "messages",
+            createdAt: BASE - 60_000,
+            readAt: null,
+          },
+          {
+            id: "n-reminder",
+            title: "Reminder: stand-up in 10 minutes",
+            category: "reminder",
+            priority: "high",
+            source: "calendar",
+            createdAt: BASE - 120_000,
+            readAt: null,
+          },
+        ]}
+      />
+      <NotificationBanners />
+    </>
+  ),
+};
+
+export const Single: Story = {
+  render: () => (
+    <>
+      <Seed
+        banners={[
+          {
+            id: "n-1",
+            title: "Deploy pipeline update",
+            body: "Step 5/5: released to staging.",
+            category: "workflow",
+            priority: "normal",
+            source: "ci",
+            createdAt: BASE,
+            readAt: null,
+          },
+        ]}
+      />
+      <NotificationBanners />
+    </>
+  ),
+};

--- a/packages/ui/src/components/shell/NotificationBanners.test.tsx
+++ b/packages/ui/src/components/shell/NotificationBanners.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+/**
+ * NotificationBanners: the top-of-screen glass banner queue. Drives the real
+ * banner store; navigate + mark-read are mocked so tap-through and auto-dismiss
+ * are asserted without a server.
+ */
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const navigateDeepLink = vi.hoisted(() => vi.fn());
+vi.mock("../../state/notifications/navigate-deep-link", async (orig) => ({
+  ...(await orig()),
+  navigateDeepLink,
+}));
+
+const markNotificationRead = vi.hoisted(() => vi.fn());
+vi.mock("../../state/notifications/notification-store", () => ({
+  markNotificationRead: (...a: unknown[]) => markNotificationRead(...a),
+}));
+
+import type { AgentNotification } from "@elizaos/core";
+import {
+  __resetNotificationBannersForTests,
+  pushNotificationBanner,
+} from "../../state/notifications/notification-banner-store";
+import { NotificationBanners } from "./NotificationBanners";
+
+function makeNotification(
+  o: Partial<AgentNotification> = {},
+): AgentNotification {
+  return {
+    id: o.id ?? "b-1",
+    title: o.title ?? "Deploy done",
+    body: o.body,
+    category: o.category ?? "system",
+    priority: o.priority ?? "normal",
+    source: o.source ?? "agent",
+    deepLink: o.deepLink,
+    createdAt: o.createdAt ?? Date.now(),
+    readAt: o.readAt ?? null,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  __resetNotificationBannersForTests();
+  navigateDeepLink.mockReset();
+  markNotificationRead.mockReset();
+  vi.useRealTimers();
+});
+
+describe("NotificationBanners", () => {
+  it("renders nothing while the queue is empty", () => {
+    render(<NotificationBanners />);
+    expect(screen.queryByTestId("notification-banners")).toBeNull();
+  });
+
+  it("renders an arriving notification as a glass banner card", () => {
+    render(<NotificationBanners />);
+    act(() => pushNotificationBanner(makeNotification({ body: "Build #42" })));
+    const card = screen.getByTestId("notification-banner");
+    expect(card.textContent).toContain("Deploy done");
+    // Glass look: translucent surface + hairline border + blur on the card body.
+    const surface = card.parentElement;
+    expect(surface?.className).toMatch(/backdrop-blur/);
+    expect(surface?.className).toMatch(/border/);
+  });
+
+  it("carries an urgent accent rail", () => {
+    render(<NotificationBanners />);
+    act(() => pushNotificationBanner(makeNotification({ priority: "urgent" })));
+    expect(screen.getByTestId("notification-banner-accent")).toBeTruthy();
+  });
+
+  it("tapping marks read, follows a safe deep link, and dismisses the banner", () => {
+    render(<NotificationBanners />);
+    act(() =>
+      pushNotificationBanner(makeNotification({ deepLink: "/settings" })),
+    );
+    fireEvent.click(screen.getByTestId("notification-banner"));
+    expect(markNotificationRead).toHaveBeenCalledWith("b-1");
+    expect(navigateDeepLink).toHaveBeenCalledWith("/settings");
+    expect(screen.queryByTestId("notification-banner")).toBeNull();
+  });
+
+  it("the X dismisses the banner without marking it read", () => {
+    render(<NotificationBanners />);
+    act(() => pushNotificationBanner(makeNotification()));
+    fireEvent.click(screen.getByTestId("notification-banner-dismiss"));
+    expect(screen.queryByTestId("notification-banner")).toBeNull();
+    expect(markNotificationRead).not.toHaveBeenCalled();
+  });
+
+  it("auto-dismisses after the priority-scaled dwell", () => {
+    vi.useFakeTimers();
+    render(<NotificationBanners />);
+    act(() => pushNotificationBanner(makeNotification({ priority: "normal" })));
+    expect(screen.getByTestId("notification-banner")).toBeTruthy();
+    // Normal dwell is 4000ms; advance past it.
+    act(() => {
+      vi.advanceTimersByTime(4100);
+    });
+    expect(screen.queryByTestId("notification-banner")).toBeNull();
+  });
+});

--- a/packages/ui/src/components/shell/NotificationBanners.tsx
+++ b/packages/ui/src/components/shell/NotificationBanners.tsx
@@ -1,0 +1,167 @@
+/**
+ * Top-of-screen notification banners — the iOS/Android "heads-up" surface. When
+ * a live notification arrives, the store's delivery path queues it in the
+ * banner store; this renders that queue as a stack of glass cards that slide
+ * down from the top, auto-dismiss after a priority-scaled dwell, and open the
+ * notification's view on tap. It is separate from the persistent home inbox
+ * (NotificationsHomeCenter) and from the bottom `setActionNotice` toast used by
+ * other surfaces: a banner is the momentary alert; the inbox is the record.
+ *
+ * Portal-mounted at the shell-overlay z-layer and only while the queue is
+ * non-empty, so at rest the app pays zero DOM cost.
+ */
+import type { AgentNotification } from "@elizaos/core";
+import { X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { Z_SHELL_OVERLAY } from "../../lib/floating-layers";
+import { cn } from "../../lib/utils";
+import { TOAST_TTL_MS } from "../../state/action-notice";
+import {
+  isSafeDeepLink,
+  navigateDeepLink,
+} from "../../state/notifications/navigate-deep-link";
+import {
+  dismissNotificationBanner,
+  useNotificationBanners,
+} from "../../state/notifications/notification-banner-store";
+import { markNotificationRead } from "../../state/notifications/notification-store";
+import { RelativeTime } from "./RelativeTime";
+
+// Slide down from the top + fade; an upward swipe/close scales it away. Opacity
+// and transform only, fully stilled under prefers-reduced-motion.
+const BANNER_CSS = `
+@keyframes eliza-notif-banner-in {
+  from { opacity: 0; transform: translateY(-14px) scale(0.98); }
+  to   { opacity: 1; transform: none; }
+}
+.eliza-notif-banner { animation: eliza-notif-banner-in 260ms cubic-bezier(0.22,1,0.36,1) both; }
+@media (prefers-reduced-motion: reduce) {
+  .eliza-notif-banner { animation: none; }
+}
+`;
+
+/** Dwell before auto-dismiss, scaled by how interruptive the arrival is. */
+function dwellMs(priority: AgentNotification["priority"]): number {
+  return priority === "high" || priority === "urgent"
+    ? TOAST_TTL_MS.notificationInterruptive
+    : TOAST_TTL_MS.notification;
+}
+
+function BannerCard({
+  notification,
+}: {
+  notification: AgentNotification;
+}): React.JSX.Element {
+  const urgent = notification.priority === "urgent";
+  const high = notification.priority === "high";
+  // Pause the auto-dismiss timer while the pointer is over the card so a banner
+  // being read doesn't vanish mid-glance; it restarts on leave.
+  const [hovered, setHovered] = useState(false);
+
+  useEffect(() => {
+    if (hovered) return undefined;
+    const id = window.setTimeout(
+      () => dismissNotificationBanner(notification.id),
+      dwellMs(notification.priority),
+    );
+    return () => window.clearTimeout(id);
+  }, [hovered, notification.id, notification.priority]);
+
+  const open = () => {
+    if (!notification.readAt) void markNotificationRead(notification.id);
+    if (notification.deepLink && isSafeDeepLink(notification.deepLink)) {
+      navigateDeepLink(notification.deepLink);
+    }
+    dismissNotificationBanner(notification.id);
+  };
+
+  return (
+    <div
+      className="eliza-notif-banner pointer-events-auto"
+      onPointerEnter={() => setHovered(true)}
+      onPointerLeave={() => setHovered(false)}
+    >
+      <div
+        className={cn(
+          // Glass card: translucent dark surface + hairline border + blur, the
+          // iOS/Android banner idiom. `supports-[backdrop-filter]` keeps an
+          // opaque-enough fallback where blur is unsupported.
+          "group relative flex items-stretch overflow-hidden rounded-2xl border shadow-lg",
+          "border-white/15 bg-black/55 text-white backdrop-blur-xl supports-[backdrop-filter]:bg-black/45",
+          urgent && "border-red-400/40",
+        )}
+      >
+        {/* Priority rail: urgent/high only, a 2px leading tint — restraint. */}
+        {urgent || high ? (
+          <span
+            aria-hidden
+            data-testid="notification-banner-accent"
+            className={cn(
+              "absolute inset-y-2 left-0 w-0.5 rounded-full",
+              urgent ? "bg-red-400/80" : "bg-white/70",
+            )}
+          />
+        ) : null}
+        <button
+          type="button"
+          data-testid="notification-banner"
+          aria-label={`${notification.title}${
+            notification.body ? `. ${notification.body}` : ""
+          }`}
+          onClick={open}
+          className="flex min-w-0 flex-1 flex-col gap-0.5 px-4 py-3 pr-10 text-left active:scale-[0.99] motion-reduce:active:scale-100"
+        >
+          <span className="flex items-baseline gap-1.5">
+            <span className="truncate text-sm font-semibold">
+              {notification.title}
+            </span>
+            <RelativeTime
+              ts={notification.createdAt}
+              className="ml-auto shrink-0 pl-2 text-2xs tabular-nums text-white/60"
+            />
+          </span>
+          {notification.body ? (
+            <span className="line-clamp-2 text-xs leading-snug text-white/70">
+              {notification.body}
+            </span>
+          ) : null}
+        </button>
+        <button
+          type="button"
+          aria-label="Dismiss notification"
+          data-testid="notification-banner-dismiss"
+          onClick={() => dismissNotificationBanner(notification.id)}
+          className="absolute right-1.5 top-1.5 rounded-full p-1.5 text-white/55 transition-colors hover:bg-white/10 hover:text-white pointer-coarse:min-h-touch pointer-coarse:min-w-touch"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** The live banner stack. Renders nothing while the queue is empty. */
+export function NotificationBanners(): React.JSX.Element | null {
+  const banners = useNotificationBanners();
+  const portalTarget = useRef<HTMLElement | null>(null);
+  if (typeof document === "undefined") return null;
+  portalTarget.current ??= document.body;
+  if (banners.length === 0) return null;
+
+  return createPortal(
+    <div
+      data-testid="notification-banners"
+      // Top-centered, non-interactive container (cards re-enable pointer events)
+      // so the banners never block taps on the app behind the gaps between them.
+      className="pointer-events-none fixed inset-x-0 top-0 z-[var(--z)] mx-auto flex w-full max-w-md flex-col gap-2 px-3 pt-[calc(env(safe-area-inset-top,0px)+0.5rem)]"
+      style={{ ["--z" as string]: Z_SHELL_OVERLAY + 6 }}
+    >
+      <style>{BANNER_CSS}</style>
+      {banners.map((n) => (
+        <BannerCard key={n.id} notification={n} />
+      ))}
+    </div>,
+    portalTarget.current,
+  );
+}

--- a/packages/ui/src/components/shell/notifications-boot.tsx
+++ b/packages/ui/src/components/shell/notifications-boot.tsx
@@ -1,25 +1,24 @@
 /**
  * Headless notification wiring for the app shell. Mounted once in App.tsx, it
- * boots the notification store (hydrate + live WS stream), routes interrupt
- * toasts through the shell's ActionNotice, and answers the surface-agnostic
- * OPEN_NOTIFICATION_CENTER_EVENT (desktop menu/tray "Notifications", the
- * `<scheme>://notifications` deep link) by navigating to the home dashboard —
- * the NotificationsHomeCenter widget there IS the notification center, so
- * "open notifications" means "go to the dashboard".
+ * boots the notification store (hydrate + live WS stream). Live arrivals fan out
+ * to the OS/native sinks and the in-app top banner queue (rendered by
+ * `NotificationBanners`); this module only needs to boot the store and answer
+ * the surface-agnostic OPEN_NOTIFICATION_CENTER_EVENT (desktop menu/tray
+ * "Notifications", the `<scheme>://notifications` deep link) by navigating to the
+ * home dashboard — the NotificationsHomeCenter widget there IS the notification
+ * center, so "open notifications" means "go to the dashboard".
  */
 import { useEffect } from "react";
 import { OPEN_NOTIFICATION_CENTER_EVENT } from "../../events";
 import { useAppSelector } from "../../state";
 import {
   initNotifications,
-  registerNotificationToastSink,
   seedDevNotificationsIfEmpty,
 } from "../../state/notifications/notification-store";
 import { initPushRegistration } from "../../state/notifications/push-registration";
 import { goHome } from "../../state/shell-surface-store";
 
 export function NotificationsShellBoot(): null {
-  const setActionNotice = useAppSelector((s) => s.setActionNotice);
   const setTab = useAppSelector((s) => s.setTab);
 
   // Idempotent store boot — the store guards against re-init.
@@ -37,13 +36,6 @@ export function NotificationsShellBoot(): null {
       // `import.meta.env` unavailable (non-Vite host) — treat as non-dev.
     }
   }, []);
-
-  // The single shared toast sink: interrupt-worthy notifications surface as
-  // transient ActionNotice toasts. Re-pointed if the shell remounts.
-  useEffect(() => {
-    registerNotificationToastSink(setActionNotice);
-    return () => registerNotificationToastSink(null);
-  }, [setActionNotice]);
 
   // Route every "open notifications" entry point to the dashboard: the combined
   // Home/Launcher route on its Home half, where the notification widget lives.

--- a/packages/ui/src/state/notifications/notification-banner-store.ts
+++ b/packages/ui/src/state/notifications/notification-banner-store.ts
@@ -1,0 +1,60 @@
+/**
+ * Transient banner queue for freshly-arrived notifications — the top-of-screen
+ * "heads-up" surface (iOS/Android banner idiom). The notification store's
+ * delivery path pushes an interruptive/focused arrival here; `NotificationBanners`
+ * renders the live queue as glass cards that slide in from the top and auto-
+ * dismiss. This is separate from the notification inbox (the persistent list on
+ * the home) and from the shared `setActionNotice` toast (bottom, other surfaces):
+ * a banner is the momentary alert, the inbox is the durable record.
+ */
+import type { AgentNotification } from "@elizaos/core";
+import { useSyncExternalStore } from "react";
+
+/** Newest-first cap: at most this many banners stack on screen at once. */
+const MAX_BANNERS = 3;
+
+let banners: readonly AgentNotification[] = [];
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+/**
+ * Queue a notification as a top banner. Newest first; a repeat of an id already
+ * showing refreshes it in place (so a superseding same-id update doesn't stack a
+ * duplicate). Trimmed to {@link MAX_BANNERS} — older banners drop off the bottom.
+ */
+export function pushNotificationBanner(notification: AgentNotification): void {
+  const withoutDup = banners.filter((b) => b.id !== notification.id);
+  banners = [notification, ...withoutDup].slice(0, MAX_BANNERS);
+  emit();
+}
+
+/** Remove a banner (auto-dismiss timeout, tap-through, or explicit close). */
+export function dismissNotificationBanner(id: string): void {
+  const next = banners.filter((b) => b.id !== id);
+  if (next.length === banners.length) return;
+  banners = next;
+  emit();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function getSnapshot(): readonly AgentNotification[] {
+  return banners;
+}
+
+/** Subscribe to the live banner queue (newest first). */
+export function useNotificationBanners(): readonly AgentNotification[] {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+/** Test-only reset. */
+export function __resetNotificationBannersForTests(): void {
+  banners = [];
+  listeners.clear();
+}

--- a/packages/ui/src/state/notifications/notification-store.test.ts
+++ b/packages/ui/src/state/notifications/notification-store.test.ts
@@ -42,6 +42,12 @@ vi.mock("../../bridge/native-notifications", () => ({
     showNativeNotification(...args),
 }));
 
+const pushNotificationBanner = vi.fn();
+vi.mock("./notification-banner-store", () => ({
+  pushNotificationBanner: (...args: unknown[]) =>
+    pushNotificationBanner(...args),
+}));
+
 import {
   __getStateForTests,
   __ingestNotificationForTests,
@@ -50,7 +56,6 @@ import {
   initNotifications,
   markAllNotificationsRead,
   markNotificationRead,
-  registerNotificationToastSink,
   removeNotification,
   seedDevNotificationsIfEmpty,
 } from "./notification-store";
@@ -90,7 +95,7 @@ describe("notification-store", () => {
     onWsEvent.mockReset();
     invokeDesktopBridgeRequest.mockReset().mockResolvedValue(null);
     showNativeNotification.mockReset().mockResolvedValue("none");
-    registerNotificationToastSink(null);
+    pushNotificationBanner.mockReset();
     // Default: window focused.
     vi.spyOn(document, "hasFocus").mockReturnValue(true);
     Object.defineProperty(document, "visibilityState", {
@@ -148,29 +153,25 @@ describe("notification-store", () => {
     expect(showNativeNotification).not.toHaveBeenCalled();
   });
 
-  it("keeps silent-tier notifications out of the toast sink", () => {
-    const sink = vi.fn();
-    registerNotificationToastSink(sink);
+  it("keeps silent-tier notifications out of the banner queue", () => {
     __ingestNotificationForTests(makeNotification({ priority: "low" }));
-    expect(sink).not.toHaveBeenCalled();
+    expect(pushNotificationBanner).not.toHaveBeenCalled();
   });
 
-  it("routes a toast through the registered sink", () => {
-    const sink = vi.fn();
-    registerNotificationToastSink(sink);
+  it("pushes an arriving notification to the top banner queue", () => {
     __ingestNotificationForTests(
       makeNotification({ title: "Deploy done", body: "Build #42" }),
       1,
     );
-    expect(sink).toHaveBeenCalledTimes(1);
-    expect(sink.mock.calls[0][0]).toContain("Deploy done");
+    expect(pushNotificationBanner).toHaveBeenCalledTimes(1);
+    expect(pushNotificationBanner.mock.calls[0][0].title).toBe("Deploy done");
   });
 
-  it("uses an error toast tone for urgent notifications", () => {
-    const sink = vi.fn();
-    registerNotificationToastSink(sink);
+  it("banners an urgent notification even when the window is blurred", () => {
+    vi.spyOn(document, "hasFocus").mockReturnValue(false);
     __ingestNotificationForTests(makeNotification({ priority: "urgent" }), 1);
-    expect(sink.mock.calls[0][1]).toBe("error");
+    expect(pushNotificationBanner).toHaveBeenCalledTimes(1);
+    expect(pushNotificationBanner.mock.calls[0][0].priority).toBe("urgent");
   });
 
   it("initNotifications hydrates and subscribes to the WS stream once", async () => {
@@ -191,10 +192,8 @@ describe("notification-store", () => {
     const handler = onWsEvent.mock.calls[0][1] as (
       d: Record<string, unknown>,
     ) => void;
-    const sink = vi.fn();
-    registerNotificationToastSink(sink);
     handler({ stream: "assistant", payload: { text: "hi" } });
-    expect(sink).not.toHaveBeenCalled();
+    expect(pushNotificationBanner).not.toHaveBeenCalled();
   });
 
   it("WS handler ingests a notification-stream event", () => {
@@ -202,8 +201,6 @@ describe("notification-store", () => {
     const handler = onWsEvent.mock.calls[0][1] as (
       d: Record<string, unknown>,
     ) => void;
-    const sink = vi.fn();
-    registerNotificationToastSink(sink);
     handler({
       stream: "notification",
       payload: {
@@ -212,8 +209,8 @@ describe("notification-store", () => {
         unreadCount: 1,
       },
     });
-    expect(sink).toHaveBeenCalledTimes(1);
-    expect(sink.mock.calls[0][0]).toContain("From WS");
+    expect(pushNotificationBanner).toHaveBeenCalledTimes(1);
+    expect(pushNotificationBanner.mock.calls[0][0].title).toBe("From WS");
   });
 
   it("WS handler drops a payload missing id or title (validated, not cast)", () => {
@@ -221,8 +218,6 @@ describe("notification-store", () => {
     const handler = onWsEvent.mock.calls[0][1] as (
       d: Record<string, unknown>,
     ) => void;
-    const sink = vi.fn();
-    registerNotificationToastSink(sink);
     // No title → unrenderable → dropped.
     handler({
       stream: "notification",
@@ -233,7 +228,7 @@ describe("notification-store", () => {
       stream: "notification",
       payload: { notification: { title: "no id" } },
     });
-    expect(sink).not.toHaveBeenCalled();
+    expect(pushNotificationBanner).not.toHaveBeenCalled();
     expect(__getStateForTests().notifications).toHaveLength(0);
   });
 
@@ -268,8 +263,6 @@ describe("notification-store", () => {
     const handler = onWsEvent.mock.calls[0][1] as (
       d: Record<string, unknown>,
     ) => void;
-    const sink = vi.fn();
-    registerNotificationToastSink(sink);
     handler({
       stream: "notification",
       payload: {
@@ -288,7 +281,7 @@ describe("notification-store", () => {
     );
     expect(stored?.readAt).toBe(123);
     expect(__getStateForTests().unreadCount).toBe(0);
-    expect(sink).not.toHaveBeenCalled();
+    expect(pushNotificationBanner).not.toHaveBeenCalled();
     expect(showNativeNotification).not.toHaveBeenCalled();
   });
 

--- a/packages/ui/src/state/notifications/notification-store.ts
+++ b/packages/ui/src/state/notifications/notification-store.ts
@@ -1,7 +1,7 @@
 /**
  * Client store for agent notifications: validates untrusted WS payloads into
  * typed AgentNotification records, tracks unread state, and fans out to the
- * toast + native-notification bridges. Subscribed via useSyncExternalStore.
+ * banner + native-notification bridges. Subscribed via useSyncExternalStore.
  */
 import {
   type AgentNotification,
@@ -16,11 +16,7 @@ import { useSyncExternalStore } from "react";
 import { client } from "../../api/client";
 import { invokeDesktopBridgeRequest } from "../../bridge/electrobun-rpc";
 import { showNativeNotification } from "../../bridge/native-notifications";
-import {
-  type ActionTone,
-  TOAST_TTL_MS,
-  toastToneForPriority,
-} from "../action-notice";
+import { pushNotificationBanner } from "./notification-banner-store";
 
 /**
  * Notification center store.
@@ -29,10 +25,10 @@ import {
  * notification center. It hydrates the inbox from `GET /api/notifications`
  * once, subscribes to the live WS `agent_event` stream filtered to
  * `stream === "notification"`, and fans each new notification out to the
- * interrupt sinks (desktop OS notification, mobile native notification, and
- * an optional in-app toast registered by the app shell) based on priority and
- * window focus. The inbox itself is always updated — the center is the
- * source-of-truth surface; the OS/toast sinks are best-effort interrupts.
+ * interrupt sinks (desktop OS notification, mobile native notification, and the
+ * in-app top banner queue) based on priority and window focus. The inbox itself
+ * is always updated — the center is the source-of-truth surface; the OS/banner
+ * sinks are best-effort interrupts.
  */
 
 export interface NotificationState {
@@ -40,8 +36,6 @@ export interface NotificationState {
   unreadCount: number;
   hydrated: boolean;
 }
-
-type ToastSink = (text: string, tone?: ActionTone, ttlMs?: number) => void;
 
 let state: NotificationState = {
   notifications: [],
@@ -51,7 +45,6 @@ let state: NotificationState = {
 
 const listeners = new Set<() => void>();
 let initialized = false;
-let toastSink: ToastSink | null = null;
 
 function emit(): void {
   for (const listener of listeners) listener();
@@ -153,20 +146,13 @@ function deliver(notification: AgentNotification): void {
     }).catch(() => {});
   }
 
-  // In-app toast: interruptive priorities always surface a toast; quieter
-  // notifications only toast when the window is focused (so the user who is
-  // looking still gets a glance) and otherwise rely on the OS notification.
-  if (toastSink && (interruptive || focused)) {
-    const text = notification.body
-      ? `${notification.title} — ${notification.body}`
-      : notification.title;
-    toastSink(
-      text,
-      toastToneForPriority(notification.priority),
-      interruptive
-        ? TOAST_TTL_MS.notificationInterruptive
-        : TOAST_TTL_MS.notification,
-    );
+  // In-app banner: interruptive priorities always surface a top banner card;
+  // quieter notifications only banner when the window is focused (so the user
+  // who is looking still gets a glance) and otherwise rely on the OS
+  // notification. The banner is the momentary heads-up; the inbox (updated in
+  // ingest) is the durable record.
+  if (interruptive || focused) {
+    pushNotificationBanner(notification);
   }
 }
 
@@ -346,11 +332,6 @@ export async function seedDevNotificationsIfEmpty(): Promise<void> {
   }
 }
 
-/** Register the in-app toast sink (the app shell wires `setActionNotice`). */
-export function registerNotificationToastSink(sink: ToastSink | null): void {
-  toastSink = sink;
-}
-
 // ── Mutations (optimistic; backed by the HTTP API) ──────────────────────────
 
 /**
@@ -441,7 +422,6 @@ export function __resetNotificationStoreForTests(): void {
   state = { notifications: [], unreadCount: 0, hydrated: false };
   initialized = false;
   devSeedAttempted = false;
-  toastSink = null;
   listeners.clear();
 }
 


### PR DESCRIPTION
## Top glass notification banners (iOS/Android heads-up) instead of a bottom toast

Live notification arrivals were popping as a toast at the **bottom**, over the chat text. They now surface as a stack of **glass cards at the top** that slide down, auto-dismiss, and open the notification's view on tap — the iOS/Android heads-up idiom.

### What changed
- **`notification-banner-store`** — a small newest-first queue (cap 3) with `pushNotificationBanner` / `dismissNotificationBanner` / `useNotificationBanners`.
- **`NotificationBanners`** — portal'd, top-centered stack of glass cards: `backdrop-blur-xl` translucent surface + hairline border + shadow, a priority accent rail (red for urgent, white for high), slide-in animation, **hover pauses** the auto-dismiss so a banner being read doesn't vanish, **tap** opens the safe deep link + marks read, **X** dismisses. Mounted once in the App shell; renders nothing at rest. Respects `safe-area-inset-top`.
- **`notification-store`** — `deliver()` now pushes interruptive/focused arrivals to the banner queue instead of the shared `setActionNotice` toast (removed the toast-sink plumbing). The bottom toast stays for other surfaces (settings, cloud, etc.); the inbox stays the durable record.

### Tests
`NotificationBanners.test.tsx` (6) — renders a glass card, urgent accent, tap → mark-read + deep-link + dismiss, X-dismiss-without-read, auto-dismiss after dwell. `notification-store.test.ts` updated to assert banner delivery (29). Story added (`Shell/NotificationBanners`, story-gate coverage). Typecheck + biome clean.

Verified in Storybook — two stacked glass cards render top-anchored ("Payment failed" urgent with red rail, "Reminder" high with white rail); the normal one auto-dismissed at its 4s dwell.
