### PR TITLE
fix(corpus/pii): address post-merge review findings on corpus-tools + lifeops corpus

### DIFF
--- a/packages/benchmarks/lifeops-bench/eliza_lifeops_bench/lifeworld/corpus.py
+++ b/packages/benchmarks/lifeops-bench/eliza_lifeops_bench/lifeworld/corpus.py
@@ -197,8 +197,27 @@ def _email_message(row: dict[str, Any], owner_email: str) -> EmailMessage:
     )
 
 
-def _chat_channel(platform: str) -> str:
-    return "telegram" if platform == "x" else platform
+# Explicit map from corpus `platform` strings to valid ``ChatChannel`` literals.
+# ``gmail`` is intentionally absent: gmail rows are routed to the email path and
+# never reach ``_chat_channel``. ``x`` (Twitter/X) has no dedicated ChatChannel,
+# so it is folded into ``telegram`` to preserve prior behaviour.
+_PLATFORM_TO_CHAT_CHANNEL: dict[str, ChatChannel] = {
+    "x": "telegram",
+    "telegram": "telegram",
+    "discord": "discord",
+    "imessage": "imessage",
+    "signal": "signal",
+}
+
+
+def _chat_channel(platform: str) -> ChatChannel:
+    try:
+        return _PLATFORM_TO_CHAT_CHANNEL[platform]
+    except KeyError as exc:
+        raise ValueError(
+            f"unknown corpus platform {platform!r}; "
+            f"expected one of {sorted(_PLATFORM_TO_CHAT_CHANNEL)}"
+        ) from exc
 
 
 def _chat_message(row: dict[str, Any], owner_email: str) -> ChatMessage:

--- a/packages/benchmarks/lifeops-bench/tests/test_corpus_world.py
+++ b/packages/benchmarks/lifeops-bench/tests/test_corpus_world.py
@@ -9,6 +9,7 @@ import pytest
 from eliza_lifeops_bench.lifeworld.corpus import (
     CorpusLoadOptions,
     CorpusSelector,
+    _chat_channel,
     generate_corpus_world,
     load_corpus_rows,
 )
@@ -52,6 +53,19 @@ def test_local_mode_requires_directory() -> None:
 def test_huggingface_mode_requires_token() -> None:
     with pytest.raises(ValueError, match="requires HF_TOKEN"):
         load_corpus_rows(CorpusLoadOptions(mode="huggingface", token=None))
+
+
+def test_chat_channel_maps_known_platforms() -> None:
+    assert _chat_channel("x") == "telegram"
+    assert _chat_channel("telegram") == "telegram"
+    assert _chat_channel("discord") == "discord"
+    assert _chat_channel("imessage") == "imessage"
+    assert _chat_channel("signal") == "signal"
+
+
+def test_chat_channel_rejects_unknown_platform() -> None:
+    with pytest.raises(ValueError, match="unknown corpus platform"):
+        _chat_channel("myspace")
 
 
 def test_local_mode_reads_sample_directory() -> None:

--- a/packages/corpus-tools/src/pipeline/driver.ts
+++ b/packages/corpus-tools/src/pipeline/driver.ts
@@ -444,20 +444,11 @@ function defaultStage(stage: ScrubStageName): ScrubStageDefinition {
       }
       const next = stableCloneMessage(message);
       next.scrubState = targetState;
-      const mined =
-        stage === "mine"
-          ? await minePiiCandidates([message], {
-              hashSalt: context.rulesetVersion,
-            })
-          : undefined;
+      // Per-message mining here would be redundant: report.candidateCount is
+      // recomputed post-loop from the whole-corpus minePiiCandidates() call.
       return {
         message: next,
-        metadata:
-          mined === undefined
-            ? undefined
-            : {
-                candidateCount: mined.candidates.length,
-              },
+        metadata: undefined,
         cost: ZERO_COST,
       };
     },
@@ -526,6 +517,17 @@ async function writeReport(
   await fs.writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`);
 }
 
+/**
+ * Ensure a state directory exists and can never be accidentally committed by
+ * writing a `*`-glob `.gitignore` into it. This makes safety independent of
+ * where `--state-dir` happens to point (previously it relied on the dir
+ * sitting under a `data/`-covered path). Safe to call repeatedly.
+ */
+async function ensureStateDirIgnored(stateDir: string): Promise<void> {
+  await fs.mkdir(stateDir, { recursive: true });
+  await fs.writeFile(path.join(stateDir, ".gitignore"), "*\n");
+}
+
 async function writePiiSweepClassification(
   stateDir: string,
   rows: readonly {
@@ -538,9 +540,24 @@ async function writePiiSweepClassification(
     "pii-sweep-classification.json",
   );
   await fs.mkdir(stateDir, { recursive: true });
+  // Strip the raw PII cleartext (`text`) from the on-disk artifact. Only
+  // non-sensitive classification fields are persisted; the in-memory pipeline
+  // result returned to callers still carries the full span.
+  const sanitizedRows = rows.map((row) => ({
+    messageId: row.messageId,
+    replacements: row.replacements.map((replacement) => ({
+      kind: replacement.kind,
+      start: replacement.start,
+      end: replacement.end,
+      confidence: replacement.confidence,
+      engine: replacement.engine,
+      valueHash: replacement.valueHash,
+      replacement: replacement.replacement,
+    })),
+  }));
   await fs.writeFile(
     classificationPath,
-    `${JSON.stringify({ rows }, null, 2)}\n`,
+    `${JSON.stringify({ rows: sanitizedRows }, null, 2)}\n`,
   );
   return classificationPath;
 }
@@ -560,6 +577,10 @@ export async function runScrubPipeline(
     options.outputPath ?? path.join(stateDir, "scrub-output.jsonl");
   const reportPath =
     options.reportPath ?? path.join(stateDir, "scrub-report.json");
+  // Guarantee the state dir (ledger + all artifacts, including pre-scrub
+  // snapshots that still contain raw PII) can never be committed, regardless of
+  // where it points. Runs before any ledger/artifact write.
+  await ensureStateDirIgnored(stateDir);
   const ledger = options.resume
     ? await loadLedger(ledgerPath)
     : { recordsRead: 0, byKey: new Map<string, ScrubLedgerRecord>() };

--- a/packages/corpus-tools/src/pipeline/llm-pii.test.ts
+++ b/packages/corpus-tools/src/pipeline/llm-pii.test.ts
@@ -150,13 +150,23 @@ describe("scrub pipeline llm stage", () => {
     );
     expect(llmReport?.piiSpanCount).toBe(400);
     expect(result.report.piiSweepArtifacts?.classificationPath).toBeTruthy();
-    const artifact = JSON.parse(
-      await fs.readFile(
-        result.report.piiSweepArtifacts?.classificationPath ?? "",
-        "utf8",
-      ),
-    ) as { rows: { replacements: unknown[] }[] };
+    const artifactRaw = await fs.readFile(
+      result.report.piiSweepArtifacts?.classificationPath ?? "",
+      "utf8",
+    );
+    const artifact = JSON.parse(artifactRaw) as {
+      rows: { replacements: Record<string, unknown>[] }[];
+    };
     expect(artifact.rows).toHaveLength(100);
+    // The on-disk artifact must never carry raw PII cleartext.
+    expect(artifactRaw).not.toContain("Maple Street");
+    for (const row of artifact.rows) {
+      for (const replacement of row.replacements) {
+        expect(replacement).not.toHaveProperty("text");
+        expect(replacement).toHaveProperty("valueHash");
+        expect(replacement).toHaveProperty("replacement");
+      }
+    }
     expect(
       result.messages.every(
         (row) =>

--- a/packages/corpus-tools/src/pipeline/mine.ts
+++ b/packages/corpus-tools/src/pipeline/mine.ts
@@ -111,7 +111,11 @@ function contactGazetteerEntries(
 function redactPatternMatches(text: string): RawCandidate[] {
   const candidates: RawCandidate[] = [];
   for (const rawPattern of getDefaultRedactPatterns()) {
-    const pattern = new RegExp(rawPattern, "gi");
+    // Do not force the `i` flag: case-insensitive matching corrupts
+    // case-sensitive secret patterns (base64/hex/prefixed keys). Any pattern
+    // that genuinely needs case-insensitivity must encode `(?i)`-style intent
+    // in its own source string.
+    const pattern = new RegExp(rawPattern, "g");
     for (const match of text.matchAll(pattern)) {
       const value = match[match.length - 1] || match[0];
       if (!value) continue;


### PR DESCRIPTION
Follow-up fixes from an automated review of the recently-merged corpus/PII scrub stack (#15058–#15074) and lifeops corpus loader (#15061). Each item was a reviewer-flagged finding that landed on `develop` as-is; this PR addresses them without reverting any merged work.

## Fixes
1. **Redundant per-message PII mining** (`corpus-tools/pipeline/driver.ts`) — the `mine` stage mined each message individually to populate `metadata.candidateCount`, which the loop accumulated and then the post-loop whole-corpus `minePiiCandidates()` unconditionally overwrote (mining ran N+1×). Removed the per-message path; the authoritative post-loop count is unchanged.
2. **Regex `i`-flag corruption** (`corpus-tools/pipeline/mine.ts`) — redact patterns were compiled with `new RegExp(rawPattern, "gi")`, forcing case-insensitive matching onto case-sensitive secret patterns (base64/hex/prefixed keys). Now `"g"`. Verified all `DEFAULT_REDACT_PATTERNS` are case-sensitive by design.
3. **Scrub-state artifacts never committed** (`corpus-tools/pipeline/driver.ts`) — the ledger persists full plaintext message snapshots (incl. pre-scrub PII); safety previously relied on the state dir sitting under a `data/`-covered path. Added `ensureStateDirIgnored()` which writes a `*`-glob `.gitignore` into the state dir up front, regardless of `--state-dir` location.
4. **Raw PII cleartext in sweep artifact** (`corpus-tools/pipeline/driver.ts`) — `pii-sweep-classification.json` re-persisted the raw `text` of each PII span. The on-disk artifact now omits `text`, keeping only `kind`/offsets/`confidence`/`engine`/`valueHash`/`replacement`. In-memory results to callers are unchanged.
5. **Unvalidated platform→channel mapping** (`lifeops-bench/lifeworld/corpus.py`) — `_chat_channel` passed arbitrary platform strings through an unchecked `cast(ChatChannel, ...)`. Replaced with an explicit map that raises `ValueError` on unknown platforms.

## Tests
- corpus-tools (vitest): 6 files / 24 tests pass; strengthened the sweep-artifact test to assert no raw cleartext on disk.
- lifeops-bench (pytest `test_corpus_world.py`): 7 pass (5 existing + 2 new for known/unknown platform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)