### PR TITLE
fix(ci): unbreak zero-key command ownership contract on develop

### DIFF
--- a/.github/workflows/ui-fixture-e2e.yml
+++ b/.github/workflows/ui-fixture-e2e.yml
@@ -71,7 +71,7 @@ jobs:
           skip-avatar-clone: "true"
           no-vision-deps: "true"
 
-      - name: Install Playwright Chromium
+      - name: Install Playwright Chromium + WebKit
         run: bunx playwright install --with-deps chromium webkit
 
       # The permission-priming fixture pulls @elizaos/shared, whose i18n module

--- a/packages/scripts/__tests__/ci-zero-key-command-ownership-contract.test.ts
+++ b/packages/scripts/__tests__/ci-zero-key-command-ownership-contract.test.ts
@@ -194,6 +194,34 @@ describe("ci-zero-key-command-ownership-contract", () => {
     );
   });
 
+  test("treats the shared chromium+webkit playwright install as setup, not ownership", () => {
+    withRepo(
+      {
+        "test.yml": workflow({
+          name: "Tests",
+          jobName: "Zero-Key deterministic",
+          commands: [
+            "bunx playwright install --with-deps chromium webkit",
+            "bun run test:server",
+          ],
+        }),
+        "ui-fixture-e2e.yml": workflow({
+          name: "UI Fixture E2E",
+          jobName: "Fixture e2e",
+          commands: [
+            "bunx playwright install --with-deps chromium webkit",
+            "bun run --cwd packages/ui test:launcher-e2e",
+          ],
+        }),
+      },
+      (root) => {
+        const rows = collectZeroKeyCommands(root);
+        expect(findDuplicateOwnedCommands(rows)).toEqual([]);
+        expect(runContract(root).commandCount).toBe(6);
+      },
+    );
+  });
+
   test("ignores static classifier and delegation jobs that mention the contract", () => {
     withRepo(
       {

--- a/packages/scripts/ci-zero-key-command-ownership-contract.mjs
+++ b/packages/scripts/ci-zero-key-command-ownership-contract.mjs
@@ -8,7 +8,11 @@
  * This is a static YAML census: it does not run workflows. It scans only the
  * zero-key/keyless workflow surface listed below, extracts shell commands from
  * zero-key job blocks, normalizes them, and fails when the same non-setup
- * command appears more than once.
+ * command is owned by more than one workflow job. Ownership is counted per
+ * workflow#job: a job may deliberately re-run its own suite under a different
+ * env parameterization (e.g. an ENGINE=webkit cross-engine pass) - that is
+ * still a single owner, while the same suite surfacing in two jobs or two
+ * workflows fails even when the invocations differ only by env prefixes.
  */
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
@@ -53,6 +57,9 @@ const STATIC_DELEGATION_JOBS = new Set([
 const ALLOWED_DUPLICATE_COMMANDS = new Set([
   "node packages/app-core/scripts/ensure-shared-i18n-data.mjs",
   "bunx playwright install --with-deps chromium",
+  // Browser install is per-runner setup, not a suite: every job that drives a
+  // WebKit lane must install its own browsers, so the chromium+webkit variant
+  // is shared setup exactly like the chromium-only line above.
   "bunx playwright install --with-deps chromium webkit",
   "node packages/scripts/ci-zero-key-command-ownership-contract.mjs",
 ]);
@@ -190,7 +197,11 @@ export function findDuplicateOwnedCommands(rows) {
     byCommand.set(row.command, existing);
   }
   return [...byCommand.entries()]
-    .filter(([, locations]) => locations.length > 1)
+    .filter(
+      ([, locations]) =>
+        new Set(locations.map(({ workflow, job }) => `${workflow}#${job}`))
+          .size > 1,
+    )
     .map(([command, locations]) => ({ command, locations }));
 }
 


### PR DESCRIPTION
## What

develop `Tests` is red for everyone (every push run since 07-05 ~20:00; latest evidence: run [28814723141](https://github.com/elizaOS/eliza/actions/runs/28814723141)). The zero-key command ownership contract fails in the `changes` (Classify changed paths) job:

```
[ci-zero-key-command-ownership-contract] FAIL Duplicate zero-key command ownership found:
- bunx playwright install --with-deps chromium webkit
  - .github/workflows/test.yml#zero-key-browser (test-orchestrator)
  - .github/workflows/ui-fixture-e2e.yml#fixture-e2e (ui-fixture-e2e)
- bun run --cwd packages/ui test:chat-infinite-scroll-e2e
  - .github/workflows/ui-fixture-e2e.yml#fixture-e2e (ui-fixture-e2e)
  - .github/workflows/ui-fixture-e2e.yml#fixture-e2e (ui-fixture-e2e)
```

The `Plugin Tests` / `Zero-Key Deterministic E2E` / `ci-ok` failures in the same run are pure knock-ons: when `changes` fails, `Determine affected test lanes` never runs, every path-gated lane skips, and the strict result checkers fail on `skipped`. One root cause.

## Root cause

- **07-05 14:25** — #14189 introduced the ownership contract (`packages/scripts/ci-zero-key-command-ownership-contract.mjs`), allowlisting `bunx playwright install --with-deps chromium` as shared setup.
- **07-05 19:52** — #14491 (webkit e2e lane for the #14329 flaky WebKit scroll-anchor) landed over a base that predated the contract. It upgraded ui-fixture-e2e's install line to `chromium webkit` (colliding with `test.yml#zero-key-browser`, which has installed both since the job existed) and added the `ENGINE=webkit` re-run of the infinite-scroll suite (the guard strips leading env assignments, so both steps normalize to the same command — inside the *same job*).

Both #14491 additions are intentional coverage, so the fix updates the contract rather than reverting the lane:

1. **Allowlist `bunx playwright install --with-deps chromium webkit`** — browser install is per-runner setup, not a suite; every job that drives a WebKit lane must install its own browsers. Same rationale as the existing chromium-only allowlist entry.
2. **Count duplicate ownership by distinct `workflow#job`** — the contract is about *ownership* ("each real test/suite command must have exactly one owner"). A job deliberately re-running its own suite under a different env parameterization (the documented cross-engine WebKit pass) is still a single owner. Cross-job/cross-workflow duplication still fails, including when invocations differ only by env prefixes (the existing test pinning that stays green).
3. Regression tests for both behaviors; renamed the stale "Install Playwright Chromium" step name (it installs WebKit too).

## Verification

- `node packages/scripts/ci-zero-key-command-ownership-contract.mjs` → `passed (116 command(s), 4 workflow(s) scanned)` (fails on develop tip)
- `bun test packages/scripts/__tests__/ci-zero-key-command-ownership-contract.test.ts` → 9 pass / 0 fail (7 existing incl. the real-repo census + env-normalization cross-workflow pin, 2 new)
- All sibling `changes`-job guards green against this tree: path-gate self-test, workflow dedup contract, turbo cache contract, bun pin contract, windows command coverage contract, merge-gate contract self-test
- Workflow YAML parse-validated; actionlint not available on this host. GH-hosted CI can't be fully reproduced locally — the changed guard + its test suite are the strongest local signal.

## Merge-order context

Per the maintainer's HQ triage this is the "duplicate playwright-install ownership" red; #15092 is order #1 and #15088 order #2 — this PR is **independent CI repair** and does not overlap #15088's file scope (its diff is packages/ui fixture runners; this diff is `.github/` + `packages/scripts/` only). The other develop red (chat-sheet drag-gesture e2e, ui-e2e-gate.yml) is intentionally not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - CI workflow/guard-script change only; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - CI workflow/guard-script change only; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user-visible flow; the verifiable artifact is the contract guard run. Before/after guard output: https://github.com/elizaOS/eliza/pull/15118#issuecomment-4896876425
<!-- evidence-row:backend-logs -->
- [x] Backend logs: guard run before (fails on develop tip: 2 violations from #14491) and after (passes: 116 command(s), 4 workflow(s) scanned) - captured in https://github.com/elizaOS/eliza/pull/15118#issuecomment-4896876425
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend involved; CI guard change only.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent/action/prompt/model behavior change; CI contract guard only.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: contract test suite 9/9 pass (real-repo census + cross-workflow env-normalization pin); all 6 sibling changes-job guards green on the fixed tree - see https://github.com/elizaOS/eliza/pull/15118#issuecomment-4896876425
