### PR TITLE
feat(plugin-elizacloud): in-app Cloud view + CLOUD_ACCOUNT dynamic provider + account actions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -882,6 +882,7 @@
         "corpus": "./src/cli.ts",
       },
       "dependencies": {
+        "@elizaos/core": "workspace:*",
         "zod": "^4.4.3",
       },
       "devDependencies": {
@@ -3490,6 +3491,7 @@
         "@elizaos/cloud-sdk": "workspace:*",
         "@elizaos/core": "workspace:*",
         "@elizaos/shared": "workspace:*",
+        "@elizaos/ui": "workspace:*",
         "@noble/curves": "2.2.0",
         "@noble/hashes": "1.8.0",
         "@opentelemetry/api": "1.9.1",
@@ -3510,12 +3512,23 @@
         "@clack/prompts": "^1.5.1",
         "@types/bun": "^1.3.5",
         "@types/node": "^25.0.3",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "typescript": "^6.0.3",
+        "vite": "^8.0.0",
         "vitest": "^4.1.4",
       },
       "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "zod": "^4.4.3",
       },
+      "optionalPeers": [
+        "react",
+        "react-dom",
+      ],
     },
     "plugins/plugin-embeddings": {
       "name": "@elizaos/plugin-embeddings",

--- a/packages/agent/src/api/views-registry.package-resolution.test.ts
+++ b/packages/agent/src/api/views-registry.package-resolution.test.ts
@@ -67,3 +67,38 @@ describe("registerPluginViews package-dir resolution", () => {
     expect(pluginDir).toContain("plugins/plugin-birdclaw");
   });
 });
+
+describe("registerPluginViews packageName override", () => {
+  const PLUGIN_NAME = "elizaOSCloud";
+
+  afterEach(() => {
+    unregisterPluginViews(PLUGIN_NAME);
+  });
+
+  it("resolves via plugin.packageName when the runtime name is not the npm package name", async () => {
+    // "elizaOSCloud" is a runtime/model-provider identity: its name-derived
+    // candidates (@elizaos/plugin-elizaOSCloud, elizaOSCloud) resolve nothing,
+    // so without the packageName seam its views would register unavailable.
+    const plugin: Plugin = {
+      name: PLUGIN_NAME,
+      packageName: "@elizaos/plugin-elizacloud",
+      description: "packageName resolution fixture",
+      views: [
+        {
+          id: "elizacloud-resolution-fixture",
+          label: "Cloud fixture",
+          bundlePath: "dist/views/bundle.js",
+        },
+      ],
+    } as Plugin;
+
+    await registerPluginViews(plugin);
+
+    const entry = listViews({ includeAllKinds: true }).find(
+      (view) => view.id === "elizacloud-resolution-fixture",
+    );
+    expect(entry).toBeDefined();
+    const pluginDir = (entry?.pluginDir ?? "").split("\\").join("/");
+    expect(pluginDir).toContain("plugins/plugin-elizacloud");
+  });
+});

--- a/packages/agent/src/api/views-registry.ts
+++ b/packages/agent/src/api/views-registry.ts
@@ -289,8 +289,13 @@ export async function registerPluginViews(
   // entries first so deleted or renamed views do not survive the reload.
   unregisterPluginViews(plugin.name);
 
-  // Resolve plugin directory once for all views in this plugin.
-  const resolvedDir = pluginDir ?? (await resolvePluginPackageDir(plugin.name));
+  // Resolve plugin directory once for all views in this plugin. A plugin whose
+  // runtime `name` is not its npm package name (e.g. "elizaOSCloud" →
+  // @elizaos/plugin-elizacloud) declares `packageName` so resolution targets
+  // the real package instead of failing on name-derived candidates.
+  const resolvedDir =
+    pluginDir ??
+    (await resolvePluginPackageDir(plugin.packageName ?? plugin.name));
 
   const registered: ViewRegistryEntry[] = [];
   for (const view of views) {

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -1339,6 +1339,18 @@ export interface Plugin {
 	description: string;
 
 	/**
+	 * The plugin's npm package name, when it differs from `name`. Some plugins
+	 * keep a runtime identity that is not their package name (e.g. a
+	 * model-provider name like "elizaOSCloud" that other subsystems key on), so
+	 * the view registry cannot derive the package directory from `name` alone —
+	 * `pluginPackageNameCandidates("elizaOSCloud")` resolves nothing and any
+	 * declared view bundle silently serves 404. Declaring `packageName` lets
+	 * package-dir resolution (view bundles, heroes, frames) target the real
+	 * package without renaming the runtime identity.
+	 */
+	packageName?: string;
+
+	/**
 	 * Execution mode. Default `"direct"` — i.e., the plugin is loaded in-process
 	 * and registered with the runtime exactly as plugins have always been.
 	 * Setting `"remote"` requires a {@link Plugin.remote} block; the host

--- a/packages/scripts/lint-lane-coverage.allowlist.json
+++ b/packages/scripts/lint-lane-coverage.allowlist.json
@@ -16,32 +16,45 @@
   "entries": [
     {
       "plugin": "app-model-tester",
-      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "issues": [
+        "missing-deterministic-e2e",
+        "missing-view-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-anthropic-proxy",
-      "issues": ["missing-action-tests"],
+      "issues": [
+        "missing-action-tests"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-aosp-local-inference",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-app-manager",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-background-runner",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-benchmarks",
-      "issues": ["missing-action-tests"],
+      "issues": [
+        "missing-action-tests"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
@@ -55,17 +68,25 @@
     },
     {
       "plugin": "plugin-blocker",
-      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "issues": [
+        "missing-deterministic-e2e",
+        "missing-view-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-bluebubbles",
-      "issues": ["missing-action-e2e", "missing-deterministic-e2e"],
+      "issues": [
+        "missing-action-e2e",
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-bluesky",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
@@ -88,87 +109,118 @@
     },
     {
       "plugin": "plugin-capacitor-bridge",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-cli",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-cli-inference",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-cloud-apps",
-      "issues": ["missing-action-tests"],
+      "issues": [
+        "missing-action-tests"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-codex-cli",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-coding-tools",
-      "issues": ["missing-action-e2e", "missing-deterministic-e2e"],
+      "issues": [
+        "missing-action-e2e",
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-commands",
-      "issues": ["missing-view-tests"],
+      "issues": [
+        "missing-view-tests"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-contacts",
-      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "issues": [
+        "missing-deterministic-e2e",
+        "missing-view-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-discord-local",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-documents",
-      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "issues": [
+        "missing-deterministic-e2e",
+        "missing-view-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-e2b-sandbox",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-edge-tts",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-elevenlabs",
-      "issues": ["missing-deterministic-e2e"],
-      "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
-    },
-    {
-      "plugin": "plugin-elizacloud",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-embeddings",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-farcaster",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-feed",
-      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "issues": [
+        "missing-deterministic-e2e",
+        "missing-view-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
@@ -182,22 +234,33 @@
     },
     {
       "plugin": "plugin-finances",
-      "issues": ["missing-action-tests"],
+      "issues": [
+        "missing-action-tests"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-form",
-      "issues": ["missing-action-tests", "missing-view-tests"],
+      "issues": [
+        "missing-action-tests",
+        "missing-view-tests"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-github",
-      "issues": ["missing-action-e2e", "missing-deterministic-e2e"],
+      "issues": [
+        "missing-action-e2e",
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-gitpathologist",
-      "issues": ["missing-action-e2e", "missing-deterministic-e2e"],
+      "issues": [
+        "missing-action-e2e",
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
@@ -211,17 +274,23 @@
     },
     {
       "plugin": "plugin-hyperliquid",
-      "issues": ["missing-action-tests"],
+      "issues": [
+        "missing-action-tests"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-imessage",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-inmemorydb",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
@@ -235,27 +304,37 @@
     },
     {
       "plugin": "plugin-line",
-      "issues": ["missing-action-tests"],
+      "issues": [
+        "missing-action-tests"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-lmstudio",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-local-storage",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-localdb",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-matrix",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
@@ -269,182 +348,258 @@
     },
     {
       "plugin": "plugin-messages",
-      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "issues": [
+        "missing-deterministic-e2e",
+        "missing-view-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-activity-tracker",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-agent",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-appblocker",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-bun-runtime",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-calendar",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-camera",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-canvas",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-contacts",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-desktop",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-eliza-tasks",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-filesystem",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-gateway",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-llama",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-location",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-macosalarm",
-      "issues": ["missing-action-e2e", "missing-deterministic-e2e"],
+      "issues": [
+        "missing-action-e2e",
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-messages",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-mlkit-text",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-mobile-agent-bridge",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-mobile-signals",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-network-policy",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-phone",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-reminders",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-screencapture",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-settings",
-      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "issues": [
+        "missing-deterministic-e2e",
+        "missing-view-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-shared-types",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-swabble",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-system",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-talkmode",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-websiteblocker",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-native-wifi",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-ngrok",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-ollama",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-pdf",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-phone",
-      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "issues": [
+        "missing-deterministic-e2e",
+        "missing-view-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-pii-guard",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
@@ -458,82 +613,116 @@
     },
     {
       "plugin": "plugin-pty",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-registry",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-reminders",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-remote-desktop",
-      "issues": ["missing-action-tests"],
+      "issues": [
+        "missing-action-tests"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-scheduling",
-      "issues": ["missing-view-tests"],
+      "issues": [
+        "missing-view-tests"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-screenshare",
-      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "issues": [
+        "missing-deterministic-e2e",
+        "missing-view-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-shell",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-signal",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-slack",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-sql",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-streaming",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-tailscale",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-task-coordinator",
-      "issues": ["missing-action-tests"],
+      "issues": [
+        "missing-action-tests"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-tee",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-telegram-standalone",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-trajectory-logger",
-      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "issues": [
+        "missing-deterministic-e2e",
+        "missing-view-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
@@ -547,77 +736,112 @@
     },
     {
       "plugin": "plugin-training",
-      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "issues": [
+        "missing-deterministic-e2e",
+        "missing-view-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-tunnel",
-      "issues": ["missing-action-tests"],
+      "issues": [
+        "missing-action-tests"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-twitch",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-vector-browser",
-      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "issues": [
+        "missing-deterministic-e2e",
+        "missing-view-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-video",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-wallet",
-      "issues": ["missing-action-tests"],
+      "issues": [
+        "missing-action-tests"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-wallet-ui",
-      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "issues": [
+        "missing-deterministic-e2e",
+        "missing-view-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-web-search",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-wechat",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-whatsapp",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-wifi",
-      "issues": ["missing-deterministic-e2e", "missing-view-e2e"],
+      "issues": [
+        "missing-deterministic-e2e",
+        "missing-view-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-workflow",
-      "issues": ["missing-action-e2e", "missing-deterministic-e2e"],
+      "issues": [
+        "missing-action-e2e",
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-x402",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-xai",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     },
     {
       "plugin": "plugin-zai",
-      "issues": ["missing-deterministic-e2e"],
+      "issues": [
+        "missing-deterministic-e2e"
+      ],
       "reason": "Legacy deterministic lane coverage debt tracked in #13620; ratchet by removing entries as tests/scenarios land."
     }
   ]

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -24,6 +24,8 @@ import {
 import { ElizaClient } from "./client-base";
 import type {
   ApiError,
+  CloudApiKeys,
+  CloudApiKeySummary,
   CloudBillingCheckoutRequest,
   CloudBillingCheckoutResponse,
   CloudBillingCryptoQuoteRequest,
@@ -1018,6 +1020,7 @@ declare module "./client-base" {
   interface ElizaClient {
     getCloudStatus(): Promise<CloudStatus>;
     getCloudCredits(): Promise<CloudCredits>;
+    listCloudApiKeys(): Promise<CloudApiKeys>;
     getCloudBillingSummary(): Promise<CloudBillingSummary>;
     getCloudBillingSettings(): Promise<CloudBillingSettings>;
     updateCloudBillingSettings(
@@ -1525,6 +1528,48 @@ ElizaClient.prototype.getCloudCredits = async function (this: ElizaClient) {
     }
   }
   return this.fetch("/api/cloud/credits");
+};
+
+// API-key inventory for the in-app Cloud view (keys count + manage link).
+// Direct-cloud only: `GET /api/v1/api-keys` is session-gated upstream
+// (requireUserWithOrg) and has no /api/cloud/* agent-host proxy, so when the
+// client has no direct cloud base — or the credential is an API key rather
+// than a steward session — the result degrades to `keys: null` with a reason
+// instead of throwing or fabricating an empty list.
+ElizaClient.prototype.listCloudApiKeys = async function (this: ElizaClient) {
+  const manageUrl = `${DEFAULT_DIRECT_CLOUD_BASE_URL}/dashboard/api-keys`;
+  const directBase = resolveDirectCloudClientApiBase(this);
+  if (!directBase || !readDirectCloudToken(this)) {
+    return { keys: null, manageUrl, reason: "not-connected" as const };
+  }
+  try {
+    const data = await directCloudRequest<Record<string, unknown>>(
+      this,
+      "/api/v1/api-keys",
+    );
+    const rawKeys = Array.isArray(data?.keys) ? data.keys : [];
+    const keys: CloudApiKeySummary[] = rawKeys.flatMap((raw) => {
+      if (typeof raw !== "object" || raw === null) return [];
+      const record = raw as Record<string, unknown>;
+      const id = stringOrNull(record.id);
+      const name = stringOrNull(record.name);
+      if (!id || !name) return [];
+      return [
+        {
+          id,
+          name,
+          keyPrefix: stringOrNull(record.key_prefix),
+          createdAt: stringOrNull(record.created_at),
+        },
+      ];
+    });
+    return { keys, manageUrl };
+  } catch (err) {
+    if (isDirectCloudAuthError(err)) {
+      return { keys: null, manageUrl, reason: "session-required" as const };
+    }
+    throw err;
+  }
 };
 
 ElizaClient.prototype.getCloudBillingSummary = async function (

--- a/packages/ui/src/api/client-types-cloud.ts
+++ b/packages/ui/src/api/client-types-cloud.ts
@@ -100,6 +100,27 @@ export interface CloudCredits {
   topUpUrl?: string;
 }
 
+export interface CloudApiKeySummary {
+  id: string;
+  name: string;
+  keyPrefix: string | null;
+  createdAt: string | null;
+}
+
+/**
+ * Result of listing the org's Eliza Cloud API keys. `keys` is null — not an
+ * empty array — whenever the list could not be retrieved (signed out,
+ * session-only route rejected the credential, or no direct-cloud transport),
+ * so consumers can render a designed "manage in console" state instead of a
+ * false healthy-empty (`GET /api/v1/api-keys` requires a user session; an
+ * `eliza_` API key cannot list keys).
+ */
+export interface CloudApiKeys {
+  keys: CloudApiKeySummary[] | null;
+  manageUrl: string;
+  reason?: "not-connected" | "session-required";
+}
+
 export interface LocalAgentBackupMetadata {
   fileName: string;
   path: string;

--- a/packages/ui/src/components/pages/launcher-curation.ts
+++ b/packages/ui/src/components/pages/launcher-curation.ts
@@ -44,6 +44,9 @@ export const LAUNCHER_APPS_ORDER: readonly string[] = [
   "tasks",
   "automations",
   "browser",
+  // Cloud account app — gated to cloud-signed-in sessions via
+  // LAUNCHER_CLOUD_IDS below.
+  "cloud",
   // Character family — ONE tile. Personality/Relationships/Skills/Experience
   // are sections inside it (CharacterSectionNav strip, #13560/#13591); their
   // standalone tiles live in LAUNCHER_HIDDEN_IDS so the grid shows a single
@@ -240,7 +243,7 @@ function preferenceScore(entry: ViewEntry): number {
  * without this gate it shows as an "Apps" tile even when cloud is
  * disconnected. (#10725)
  */
-export const LAUNCHER_CLOUD_IDS: ReadonlySet<string> = new Set(["cloud-apps"]);
+export const LAUNCHER_CLOUD_IDS: ReadonlySet<string> = new Set(["cloud-apps", "cloud"]);
 
 export interface CurateLauncherOptions {
   /** Include the native-OS tiles (phone/messages/contacts/camera/files). */

--- a/plugins/plugin-elizacloud/__tests__/unit/cloud-account-actions.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/cloud-account-actions.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Cloud account action suite (CLOUD_ACCOUNT_STATUS / CLOUD_LIST_AGENTS /
+ * CLOUD_CREATE_API_KEY) — real SDK over the loopback cloud server: validate
+ * gating on the signed-in state, handler re-guards, honest empty/error paths,
+ * the session-only 401/403 fallback for key creation, the reserved-name
+ * refusal, and the show-plain-key-once contract.
+ */
+
+import type { Content, HandlerCallback, Memory, State } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cloudAccountStatusAction } from "../../src/actions/cloud-account-status";
+import { createCloudApiKeyAction, parseApiKeyName } from "../../src/actions/create-cloud-api-key";
+import { listCloudAgentsAction } from "../../src/actions/list-cloud-agents";
+import { type CloudServer, makeRuntime, startCloudServer } from "./cloud-account-harness";
+
+const STATE = {} as State;
+
+function message(text: string): Memory {
+  return { content: { text } } as Memory;
+}
+
+function collectCallback(): { replies: Content[]; callback: HandlerCallback } {
+  const replies: Content[] = [];
+  const callback: HandlerCallback = async (content) => {
+    replies.push(content);
+    return [];
+  };
+  return { replies, callback };
+}
+
+let server: CloudServer;
+
+beforeEach(async () => {
+  server = await startCloudServer();
+});
+
+afterEach(async () => {
+  await server.close();
+});
+
+describe("validate gating (signed-out actions vanish from the planner)", () => {
+  for (const action of [cloudAccountStatusAction, listCloudAgentsAction, createCloudApiKeyAction]) {
+    it(`${action.name} validates only when cloud-authenticated`, async () => {
+      const signedIn = makeRuntime({ baseUrl: server.url });
+      const signedOut = makeRuntime({ baseUrl: server.url, authenticated: false });
+      await expect(action.validate?.(signedIn, message("hi"), STATE)).resolves.toBe(true);
+      await expect(action.validate?.(signedOut, message("hi"), STATE)).resolves.toBe(false);
+    });
+  }
+});
+
+describe("CLOUD_ACCOUNT_STATUS", () => {
+  it("replies with the fresh balance", async () => {
+    const runtime = makeRuntime({ baseUrl: server.url });
+    const { replies, callback } = collectCallback();
+    const result = await cloudAccountStatusAction.handler(
+      runtime,
+      message("how many credits do I have?"),
+      STATE,
+      undefined,
+      callback
+    );
+    expect(result.success).toBe(true);
+    expect(replies[0]?.text).toContain("$12.34");
+    expect(result.data).toMatchObject({ balance: 12.34, low: false, critical: false });
+  });
+
+  it("warns and links the top-up page on a critical balance", async () => {
+    server.state.balance = 0.1;
+    const runtime = makeRuntime({ baseUrl: server.url });
+    const { replies, callback } = collectCallback();
+    const result = await cloudAccountStatusAction.handler(
+      runtime,
+      message("cloud balance?"),
+      STATE,
+      undefined,
+      callback
+    );
+    expect(result.success).toBe(true);
+    expect(replies[0]?.text).toContain("critically low");
+    expect(replies[0]?.text).toContain("dashboard/settings?tab=billing");
+  });
+
+  it("re-guards in the handler when signed out (validate is advisory)", async () => {
+    const runtime = makeRuntime({ baseUrl: server.url, authenticated: false });
+    const { replies, callback } = collectCallback();
+    const result = await cloudAccountStatusAction.handler(
+      runtime,
+      message("balance?"),
+      STATE,
+      undefined,
+      callback
+    );
+    expect(result.success).toBe(false);
+    expect(result.data).toMatchObject({ reason: "not_connected" });
+    expect(replies[0]?.text).toContain("not connected to Eliza Cloud");
+    expect(server.state.requests).toEqual([]);
+  });
+
+  it("returns an honest failure when the cloud API errors", async () => {
+    server.state.failBalance = true;
+    const runtime = makeRuntime({ baseUrl: server.url });
+    const { callback } = collectCallback();
+    const result = await cloudAccountStatusAction.handler(
+      runtime,
+      message("balance?"),
+      STATE,
+      undefined,
+      callback
+    );
+    expect(result.success).toBe(false);
+    expect(result.data).toMatchObject({ reason: "error" });
+  });
+});
+
+describe("CLOUD_LIST_AGENTS", () => {
+  it("lists hosted agents with statuses", async () => {
+    const runtime = makeRuntime({ baseUrl: server.url });
+    const { replies, callback } = collectCallback();
+    const result = await listCloudAgentsAction.handler(
+      runtime,
+      message("what agents do I have?"),
+      STATE,
+      undefined,
+      callback
+    );
+    expect(result.success).toBe(true);
+    expect(replies[0]?.text).toContain("2 agents hosted on Eliza Cloud");
+    expect(replies[0]?.text).toContain("• alpha — running");
+    expect(replies[0]?.text).toContain("• beta — stopped");
+  });
+
+  it("renders the designed empty state when there are no agents", async () => {
+    server.state.agents = [];
+    const runtime = makeRuntime({ baseUrl: server.url });
+    const { replies, callback } = collectCallback();
+    const result = await listCloudAgentsAction.handler(
+      runtime,
+      message("my hosted agents"),
+      STATE,
+      undefined,
+      callback
+    );
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({ count: 0 });
+    expect(replies[0]?.text).toContain("don't have any agents hosted");
+  });
+
+  it("fails honestly on a cloud API error", async () => {
+    server.state.failAgents = true;
+    const runtime = makeRuntime({ baseUrl: server.url });
+    const { callback } = collectCallback();
+    const result = await listCloudAgentsAction.handler(
+      runtime,
+      message("my agents"),
+      STATE,
+      undefined,
+      callback
+    );
+    expect(result.success).toBe(false);
+    expect(result.data).toMatchObject({ reason: "error" });
+  });
+});
+
+describe("parseApiKeyName", () => {
+  const NOW = new Date("2026-07-06T12:00:00.000Z");
+
+  it("prefers a quoted name", () => {
+    expect(parseApiKeyName('create a key called "ci-deploys"', NOW)).toBe("ci-deploys");
+  });
+
+  it("falls back to the word after named/called", () => {
+    expect(parseApiKeyName("make an api key named staging-bot", NOW)).toBe("staging-bot");
+  });
+
+  it("defaults to a dated name", () => {
+    expect(parseApiKeyName("make me a cloud api key", NOW)).toBe("agent-created-2026-07-06");
+  });
+});
+
+describe("CLOUD_CREATE_API_KEY", () => {
+  it("creates a key and surfaces the plain key exactly once (reply only)", async () => {
+    const runtime = makeRuntime({ baseUrl: server.url });
+    const { replies, callback } = collectCallback();
+    const result = await createCloudApiKeyAction.handler(
+      runtime,
+      message('create a cloud api key called "ci-deploys"'),
+      STATE,
+      undefined,
+      callback
+    );
+    expect(result.success).toBe(true);
+    expect(server.state.lastCreateKeyBody).toMatchObject({ name: "ci-deploys" });
+    // The plain key transits the user reply once…
+    expect(replies[0]?.text).toContain("eliza_plain_key_shown_once");
+    expect(replies[0]?.text).toContain("only time");
+    // …and never the durable action result.
+    expect(JSON.stringify(result.data)).not.toContain("eliza_plain_key_shown_once");
+    expect(result.text).not.toContain("eliza_plain_key_shown_once");
+  });
+
+  it("redirects to a signed-in session when the route rejects the agent key", async () => {
+    server.state.createKeyStatus = 403;
+    const runtime = makeRuntime({ baseUrl: server.url });
+    const { replies, callback } = collectCallback();
+    const result = await createCloudApiKeyAction.handler(
+      runtime,
+      message("make a new api key"),
+      STATE,
+      undefined,
+      callback
+    );
+    expect(result.success).toBe(false);
+    expect(result.data).toMatchObject({ reason: "session_required" });
+    expect(replies[0]?.text).toContain("signed-in session");
+    expect(replies[0]?.text).toContain("Cloud app");
+  });
+
+  it("refuses the reserved agent-sandbox: prefix without any network call", async () => {
+    const runtime = makeRuntime({ baseUrl: server.url });
+    const { replies, callback } = collectCallback();
+    const result = await createCloudApiKeyAction.handler(
+      runtime,
+      message('create a key called "agent-sandbox:sneaky"'),
+      STATE,
+      undefined,
+      callback
+    );
+    expect(result.success).toBe(false);
+    expect(result.data).toMatchObject({ reason: "reserved_name" });
+    expect(replies[0]?.text).toContain("reserved");
+    expect(server.state.requests).toEqual([]);
+  });
+});

--- a/plugins/plugin-elizacloud/__tests__/unit/cloud-account-harness.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/cloud-account-harness.ts
@@ -1,0 +1,122 @@
+/**
+ * Shared harness for the CLOUD_ACCOUNT provider/action suites: a REAL loopback
+ * HTTP server standing in for the Eliza Cloud API (the SDK, its URL building,
+ * auth headers, and error mapping all run for real — nothing under test is
+ * mocked) plus a minimal runtime fake exposing only the seams the code reads
+ * (getSetting for the base URL/key, getService("CLOUD_AUTH") for the
+ * signed-in gate).
+ */
+
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import type { IAgentRuntime } from "@elizaos/core";
+
+export interface CloudServerState {
+  balance: number;
+  agents: Array<{ id: string; agentName: string | null; status: string }>;
+  /** When true, GET /credits/balance returns 500. */
+  failBalance: boolean;
+  /** When true, GET /eliza/agents returns 500. */
+  failAgents: boolean;
+  /** HTTP status for POST /api-keys (200 = created). */
+  createKeyStatus: number;
+  /** Every request path seen, in order. */
+  requests: string[];
+  /** Body of the last POST /api-keys request. */
+  lastCreateKeyBody: Record<string, unknown> | null;
+}
+
+export interface CloudServer {
+  state: CloudServerState;
+  url: string;
+  close: () => Promise<void>;
+}
+
+export async function startCloudServer(): Promise<CloudServer> {
+  const state: CloudServerState = {
+    balance: 12.34,
+    agents: [
+      { id: "agent-1", agentName: "alpha", status: "running" },
+      { id: "agent-2", agentName: "beta", status: "stopped" },
+    ],
+    failBalance: false,
+    failAgents: false,
+    createKeyStatus: 200,
+    requests: [],
+    lastCreateKeyBody: null,
+  };
+
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url ?? "/", "http://localhost");
+    state.requests.push(`${req.method} ${url.pathname}`);
+
+    const json = (status: number, body: unknown) => {
+      res.writeHead(status, { "content-type": "application/json" });
+      res.end(JSON.stringify(body));
+    };
+
+    if (req.method === "GET" && url.pathname === "/api/v1/credits/balance") {
+      if (state.failBalance) return json(500, { success: false, error: "boom" });
+      return json(200, { balance: state.balance });
+    }
+    if (req.method === "GET" && url.pathname === "/api/v1/eliza/agents") {
+      if (state.failAgents) return json(500, { success: false, error: "boom" });
+      return json(200, { success: true, data: state.agents });
+    }
+    if (req.method === "POST" && url.pathname === "/api/v1/api-keys") {
+      let raw = "";
+      req.on("data", (chunk) => {
+        raw += chunk;
+      });
+      req.on("end", () => {
+        state.lastCreateKeyBody = JSON.parse(raw) as Record<string, unknown>;
+        if (state.createKeyStatus !== 200) {
+          return json(state.createKeyStatus, {
+            success: false,
+            error: "Session required",
+          });
+        }
+        const name = String(state.lastCreateKeyBody?.name ?? "unnamed");
+        return json(200, {
+          apiKey: {
+            id: "key-1",
+            name,
+            key_prefix: "eliza_abc1",
+            created_at: "2026-07-06T00:00:00.000Z",
+          },
+          plainKey: "eliza_plain_key_shown_once",
+        });
+      });
+      return;
+    }
+    json(404, { success: false, error: `no route for ${url.pathname}` });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    state,
+    url: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+export function makeRuntime(options: { baseUrl: string; authenticated?: boolean }): IAgentRuntime {
+  const settings: Record<string, string | undefined> = {
+    ELIZAOS_CLOUD_BASE_URL: `${options.baseUrl}/api/v1`,
+    ELIZAOS_CLOUD_API_KEY: "eliza_test_key",
+  };
+  const auth = {
+    isAuthenticated: () => options.authenticated !== false,
+    getOrganizationId: () => "org-test",
+    getUserId: () => "user-test",
+  };
+  return {
+    getSetting: (key: string) => settings[key],
+    getService: (type: string) => (type === "CLOUD_AUTH" ? auth : null),
+  } as unknown as IAgentRuntime;
+}

--- a/plugins/plugin-elizacloud/__tests__/unit/cloud-account-provider.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/cloud-account-provider.test.ts
@@ -1,0 +1,98 @@
+/**
+ * CLOUD_ACCOUNT provider suite — real SDK over a loopback cloud server (see
+ * cloud-account-harness.ts): signed-out empty gate, happy-path render, 60s
+ * cache, stale-cache-on-failure, empty-on-cold-failure, and the
+ * invalidateCloudAccountCache invariant. Only Date is faked (TTL expiry).
+ */
+
+import type { Memory, State } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cloudAccountProvider,
+  invalidateCloudAccountCache,
+} from "../../src/cloud-providers/cloud-account";
+import { type CloudServer, makeRuntime, startCloudServer } from "./cloud-account-harness";
+
+const MESSAGE = {} as Memory;
+const STATE = {} as State;
+
+let server: CloudServer;
+
+beforeEach(async () => {
+  server = await startCloudServer();
+});
+
+afterEach(async () => {
+  vi.useRealTimers();
+  await server.close();
+});
+
+describe("cloudAccountProvider", () => {
+  it("renders empty with zero network traffic when signed out", async () => {
+    const runtime = makeRuntime({ baseUrl: server.url, authenticated: false });
+    const result = await cloudAccountProvider.get(runtime, MESSAGE, STATE);
+    expect(result.text).toBe("");
+    expect(server.state.requests).toEqual([]);
+  });
+
+  it("renders balance and hosted agents when signed in", async () => {
+    const runtime = makeRuntime({ baseUrl: server.url });
+    const result = await cloudAccountProvider.get(runtime, MESSAGE, STATE);
+    expect(result.text).toContain("$12.34");
+    expect(result.text).toContain("org org-test");
+    expect(result.text).toContain("2 hosted agents");
+    expect(result.text).toContain("- alpha (running)");
+    expect(result.text).toContain("- beta (stopped)");
+    expect(result.values?.cloudAgentCount).toBe(2);
+    expect(result.values?.cloudCredits).toBe(12.34);
+  });
+
+  it("flags a low balance with the top-up pointer", async () => {
+    server.state.balance = 0.25;
+    const runtime = makeRuntime({ baseUrl: server.url });
+    const result = await cloudAccountProvider.get(runtime, MESSAGE, STATE);
+    expect(result.text).toContain("CRITICAL");
+    expect(result.values?.cloudCreditsCritical).toBe(true);
+  });
+
+  it("serves the 60s cache without re-fetching", async () => {
+    const runtime = makeRuntime({ baseUrl: server.url });
+    await cloudAccountProvider.get(runtime, MESSAGE, STATE);
+    const fetches = server.state.requests.length;
+    await cloudAccountProvider.get(runtime, MESSAGE, STATE);
+    expect(server.state.requests.length).toBe(fetches);
+  });
+
+  it("serves the stale cache when a refresh fails past the TTL", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    const runtime = makeRuntime({ baseUrl: server.url });
+    const first = await cloudAccountProvider.get(runtime, MESSAGE, STATE);
+    expect(first.text).toContain("$12.34");
+
+    vi.setSystemTime(Date.now() + 61_000);
+    server.state.failBalance = true;
+    const second = await cloudAccountProvider.get(runtime, MESSAGE, STATE);
+    // Not fabricated zeros, not empty: the last known-good snapshot.
+    expect(second.text).toContain("$12.34");
+  });
+
+  it("renders empty (never zeros) when the fetch fails with a cold cache", async () => {
+    server.state.failBalance = true;
+    const runtime = makeRuntime({ baseUrl: server.url });
+    const result = await cloudAccountProvider.get(runtime, MESSAGE, STATE);
+    expect(result.text).toBe("");
+    expect(result.values?.cloudAccountUnavailable).toBe(true);
+  });
+
+  it("re-fetches after invalidateCloudAccountCache inside the TTL", async () => {
+    const runtime = makeRuntime({ baseUrl: server.url });
+    await cloudAccountProvider.get(runtime, MESSAGE, STATE);
+    const fetches = server.state.requests.length;
+
+    server.state.balance = 99.0;
+    invalidateCloudAccountCache(runtime);
+    const result = await cloudAccountProvider.get(runtime, MESSAGE, STATE);
+    expect(server.state.requests.length).toBeGreaterThan(fetches);
+    expect(result.text).toContain("$99.00");
+  });
+});

--- a/plugins/plugin-elizacloud/build.ts
+++ b/plugins/plugin-elizacloud/build.ts
@@ -19,8 +19,13 @@ import { buildPlugin } from "../plugin-build";
 // flattened up into dist/ by the driver's `flatten` step.
 const subpathEntries = Array.from(new Bun.Glob("src/**/*.{ts,tsx}").scanSync("."))
   .filter((entry) => {
-    if (entry.includes("__tests__/") || entry.endsWith(".test.ts")) return false;
+    if (entry.includes("__tests__/") || entry.endsWith(".test.ts") || entry.endsWith(".test.tsx"))
+      return false;
     if (entry === "src/index.node.ts" || entry === "src/index.browser.ts") return false;
+    // View components are vite-only (React/JSX against host-external
+    // @elizaos/ui); the per-file bun bundle has no react external and would
+    // choke on them. They ship exclusively via `build:views` → dist/views.
+    if (entry.startsWith("src/components/")) return false;
     return true;
   })
   .sort();

--- a/plugins/plugin-elizacloud/package.json
+++ b/plugins/plugin-elizacloud/package.json
@@ -75,6 +75,7 @@
     "@elizaos/cloud-sdk": "workspace:*",
     "@elizaos/core": "workspace:*",
     "@elizaos/shared": "workspace:*",
+    "@elizaos/ui": "workspace:*",
     "@noble/curves": "2.2.0",
     "@noble/hashes": "1.8.0",
     "@opentelemetry/api": "1.9.1",
@@ -95,11 +96,26 @@
     "@clack/prompts": "^1.5.1",
     "@types/bun": "^1.3.5",
     "@types/node": "^25.0.3",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "typescript": "^6.0.3",
+    "vite": "^8.0.0",
     "vitest": "^4.1.4"
   },
   "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "zod": "^4.4.3"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    }
   },
   "scripts": {
     "dev": "bun run build.ts --watch",
@@ -112,8 +128,9 @@
     "test:unit": "vitest run __tests__/unit/",
     "test:integration": "vitest run __tests__/integration/",
     "lint:check": "bunx @biomejs/biome check .",
-    "build": "bun run build.ts",
+    "build": "bun run build.ts && bun run build:views",
     "build:ts": "bun run build.ts",
+    "build:views": "bunx --bun vite build --config vite.config.views.ts",
     "test:e2e": "node ../../packages/app-core/scripts/run-local-plugin-live-smoke.mjs",
     "test:live": "bun run test:e2e"
   },

--- a/plugins/plugin-elizacloud/src/actions/cloud-account-status.ts
+++ b/plugins/plugin-elizacloud/src/actions/cloud-account-status.ts
@@ -1,0 +1,130 @@
+/**
+ * CLOUD_ACCOUNT_STATUS — answer "how many credits do I have?" / "what's my
+ * cloud account status?" with a fresh (uncached) balance read plus the
+ * low/critical top-up nudge.
+ *
+ * Read-only: hits `GET /credits/balance` through the typed SDK with the
+ * runtime's `ELIZAOS_CLOUD_API_KEY` (never the steward token — that credential
+ * belongs to the browser). `validate` gates on the CLOUD_AUTH service being
+ * authenticated so the action vanishes from the planner tool list when the
+ * agent is signed out; the handler re-guards because validate is advisory and
+ * a native tool call can bypass it.
+ */
+
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import { isCloudAuthApiKeyService } from "../cloud/auth-service-types";
+import { createElizaCloudClient } from "../utils/sdk-client";
+
+const TOP_UP_URL = "https://www.elizacloud.ai/dashboard/settings?tab=billing";
+
+export const NO_CLOUD_MESSAGE =
+  "I'm not connected to Eliza Cloud right now — connect your account in Settings (or set ELIZAOS_CLOUD_API_KEY) and I can check your credits.";
+const ERROR_MESSAGE =
+  "I couldn't reach Eliza Cloud to check your account just now. Try again in a moment.";
+
+/** Signed-in gate shared by the cloud account actions. */
+export function cloudAccountAuthenticated(runtime: IAgentRuntime): boolean {
+  const auth = runtime.getService("CLOUD_AUTH");
+  return isCloudAuthApiKeyService(auth) && auth.isAuthenticated();
+}
+
+export const cloudAccountStatusAction: Action = {
+  name: "CLOUD_ACCOUNT_STATUS",
+  similes: ["CHECK_CLOUD_CREDITS", "CLOUD_CREDITS", "CLOUD_BALANCE"],
+  description:
+    "Check the user's Eliza Cloud account: current credit balance with a low-balance warning and top-up link. Use when the user asks about their cloud credits, balance, or account status.",
+  descriptionCompressed: "Check Eliza Cloud credit balance / account status.",
+  contexts: ["cloud", "finance", "settings"],
+
+  validate: async (runtime: IAgentRuntime): Promise<boolean> =>
+    cloudAccountAuthenticated(runtime),
+
+  handler: async (
+    runtime: IAgentRuntime,
+    _message: Memory,
+    _state?: State,
+    _options?: unknown,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    if (!cloudAccountAuthenticated(runtime)) {
+      await callback?.({ text: NO_CLOUD_MESSAGE, actions: ["CLOUD_ACCOUNT_STATUS"] });
+      return {
+        success: false,
+        text: "Not connected to Eliza Cloud.",
+        userFacingText: NO_CLOUD_MESSAGE,
+        data: { reason: "not_connected" },
+      };
+    }
+
+    try {
+      const { balance } = await createElizaCloudClient(runtime).getCreditsBalance({
+        fresh: true,
+      });
+      const low = balance < 2.0;
+      const critical = balance < 0.5;
+
+      let reply = `Your Eliza Cloud balance is $${balance.toFixed(2)}.`;
+      if (critical) {
+        reply += ` That's critically low — top up at ${TOP_UP_URL} to keep your agents running.`;
+      } else if (low) {
+        reply += ` That's running low — you can top up at ${TOP_UP_URL}.`;
+      }
+
+      await callback?.({ text: reply, actions: ["CLOUD_ACCOUNT_STATUS"] });
+      return {
+        success: true,
+        text: `Eliza Cloud balance: $${balance.toFixed(2)}.`,
+        userFacingText: reply,
+        verifiedUserFacing: true,
+        data: { balance, low, critical, topUpUrl: TOP_UP_URL },
+      };
+    } catch (err) {
+      logger.warn(
+        `[CLOUD_ACCOUNT_STATUS] Failed to fetch balance: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      await callback?.({ text: ERROR_MESSAGE, actions: ["CLOUD_ACCOUNT_STATUS"] });
+      return {
+        success: false,
+        text: "Failed to fetch Eliza Cloud balance.",
+        userFacingText: ERROR_MESSAGE,
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: { reason: "error" },
+      };
+    }
+  },
+
+  examples: [
+    [
+      { name: "{{user}}", content: { text: "how many cloud credits do I have?" } },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "Your Eliza Cloud balance is $12.40.",
+          actions: ["CLOUD_ACCOUNT_STATUS"],
+        },
+      },
+    ],
+    [
+      { name: "{{user}}", content: { text: "what's my eliza cloud account looking like" } },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "Your Eliza Cloud balance is $0.32. That's critically low — top up to keep your agents running.",
+          actions: ["CLOUD_ACCOUNT_STATUS"],
+        },
+      },
+    ],
+  ],
+};
+
+export default cloudAccountStatusAction;

--- a/plugins/plugin-elizacloud/src/actions/create-cloud-api-key.ts
+++ b/plugins/plugin-elizacloud/src/actions/create-cloud-api-key.ts
@@ -36,8 +36,11 @@ const ERROR_MESSAGE =
  * blocks on a missing name.
  */
 export function parseApiKeyName(text: string, now = new Date()): string {
-  const quoted = text.match(/["'“”']([^"'“”']{1,64})["'“”']/);
-  if (quoted?.[1]?.trim()) return quoted[1].trim();
+  // Per-quote alternation so the delimiters must MATCH (`"ci-deploys'` is not
+  // a quoted name); curly quotes pair with their curly counterparts.
+  const quoted = text.match(/"([^"]{1,64})"|'([^']{1,64})'|“([^”]{1,64})”/);
+  const quotedName = quoted?.[1] ?? quoted?.[2] ?? quoted?.[3];
+  if (quotedName?.trim()) return quotedName.trim();
   const named = text.match(/\b(?:named|called)\s+([\w][\w./-]{0,63})/i);
   if (named?.[1]) return named[1];
   return `agent-created-${now.toISOString().slice(0, 10)}`;

--- a/plugins/plugin-elizacloud/src/actions/create-cloud-api-key.ts
+++ b/plugins/plugin-elizacloud/src/actions/create-cloud-api-key.ts
@@ -1,0 +1,163 @@
+/**
+ * CLOUD_CREATE_API_KEY — mint a new Eliza Cloud API key from chat.
+ *
+ * The upstream route (`POST /api/v1/api-keys`) is session-only — an `eliza_`
+ * org API key cannot mint API keys — so when the SDK call is rejected with
+ * 401/403 the action replies honestly with a pointer to the in-app Cloud view
+ * and the console, where the user's signed-in session CAN create keys. On
+ * success the plain key is surfaced exactly once (it is never retrievable
+ * again) and never logged. Names with the reserved `agent-sandbox:` prefix
+ * are refused before any network call.
+ */
+
+import { CloudApiError } from "@elizaos/cloud-sdk";
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import { invalidateCloudAccountCache } from "../cloud-providers/cloud-account";
+import { createElizaCloudClient } from "../utils/sdk-client";
+import { cloudAccountAuthenticated, NO_CLOUD_MESSAGE } from "./cloud-account-status";
+
+const RESERVED_PREFIX = "agent-sandbox:";
+const SESSION_REQUIRED_MESSAGE =
+  "Eliza Cloud only allows API keys to be created from a signed-in session — my agent credential can't mint them. Open the Cloud app in the launcher (or the console at elizacloud.ai → dashboard → API keys) to create one.";
+const ERROR_MESSAGE =
+  "I couldn't create the API key right now — the Cloud API returned an error. Try again in a moment.";
+
+/**
+ * Pull a key name out of the message: a quoted string first, then the word
+ * after "named"/"called". Falls back to a dated default so the action never
+ * blocks on a missing name.
+ */
+export function parseApiKeyName(text: string, now = new Date()): string {
+  const quoted = text.match(/["'“”']([^"'“”']{1,64})["'“”']/);
+  if (quoted?.[1]?.trim()) return quoted[1].trim();
+  const named = text.match(/\b(?:named|called)\s+([\w][\w./-]{0,63})/i);
+  if (named?.[1]) return named[1];
+  return `agent-created-${now.toISOString().slice(0, 10)}`;
+}
+
+export const createCloudApiKeyAction: Action = {
+  name: "CLOUD_CREATE_API_KEY",
+  similes: ["NEW_CLOUD_API_KEY", "MAKE_API_KEY", "CREATE_API_KEY"],
+  description:
+    "Create a new Eliza Cloud API key with an optional name. Use when the user asks to create, generate, or mint a cloud API key. The plain key is shown once and must be copied immediately.",
+  descriptionCompressed: "Create a new Eliza Cloud API key.",
+  contexts: ["cloud", "settings"],
+
+  validate: async (runtime: IAgentRuntime): Promise<boolean> =>
+    cloudAccountAuthenticated(runtime),
+
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    _state?: State,
+    _options?: unknown,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    if (!cloudAccountAuthenticated(runtime)) {
+      await callback?.({ text: NO_CLOUD_MESSAGE, actions: ["CLOUD_CREATE_API_KEY"] });
+      return {
+        success: false,
+        text: "Not connected to Eliza Cloud.",
+        userFacingText: NO_CLOUD_MESSAGE,
+        data: { reason: "not_connected" },
+      };
+    }
+
+    const name = parseApiKeyName(message.content?.text ?? "");
+    if (name.toLowerCase().startsWith(RESERVED_PREFIX)) {
+      const reserved = `Key names starting with "${RESERVED_PREFIX}" are reserved for provisioner-managed keys — pick another name.`;
+      await callback?.({ text: reserved, actions: ["CLOUD_CREATE_API_KEY"] });
+      return {
+        success: false,
+        text: "Requested API key name uses the reserved agent-sandbox: prefix.",
+        userFacingText: reserved,
+        data: { reason: "reserved_name", name },
+      };
+    }
+
+    try {
+      const { apiKey, plainKey } = await createElizaCloudClient(runtime).createApiKey({
+        name,
+      });
+      invalidateCloudAccountCache(runtime);
+
+      const reply = [
+        `Created Eliza Cloud API key "${apiKey.name}".`,
+        "",
+        plainKey,
+        "",
+        "Copy it now — this is the only time the full key is shown. Manage or revoke it from the console (elizacloud.ai → dashboard → API keys).",
+      ].join("\n");
+
+      await callback?.({ text: reply, actions: ["CLOUD_CREATE_API_KEY"] });
+      // The plain key transits ONLY the user-facing reply; the durable action
+      // result carries the redacted summary so logs/trajectories never hold it.
+      return {
+        success: true,
+        text: `Created Eliza Cloud API key "${apiKey.name}" (${apiKey.key_prefix}…).`,
+        userFacingText: reply,
+        verifiedUserFacing: true,
+        data: { id: apiKey.id, name: apiKey.name, keyPrefix: apiKey.key_prefix },
+      };
+    } catch (err) {
+      if (err instanceof CloudApiError && (err.statusCode === 401 || err.statusCode === 403)) {
+        await callback?.({
+          text: SESSION_REQUIRED_MESSAGE,
+          actions: ["CLOUD_CREATE_API_KEY"],
+        });
+        return {
+          success: false,
+          text: "Eliza Cloud API keys require a signed-in session to create.",
+          userFacingText: SESSION_REQUIRED_MESSAGE,
+          data: { reason: "session_required" },
+        };
+      }
+      logger.warn(
+        `[CLOUD_CREATE_API_KEY] Failed to create key: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      await callback?.({ text: ERROR_MESSAGE, actions: ["CLOUD_CREATE_API_KEY"] });
+      return {
+        success: false,
+        text: "Failed to create Eliza Cloud API key.",
+        userFacingText: ERROR_MESSAGE,
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: { reason: "error" },
+      };
+    }
+  },
+
+  examples: [
+    [
+      { name: "{{user}}", content: { text: 'create a cloud api key called "ci-deploys"' } },
+      {
+        name: "{{agent}}",
+        content: {
+          text: 'Created Eliza Cloud API key "ci-deploys". Copy it now — this is the only time the full key is shown.',
+          actions: ["CLOUD_CREATE_API_KEY"],
+        },
+      },
+    ],
+    [
+      { name: "{{user}}", content: { text: "make me a new eliza cloud api key" } },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "Eliza Cloud only allows API keys to be created from a signed-in session — open the Cloud app or the console to create one.",
+          actions: ["CLOUD_CREATE_API_KEY"],
+        },
+      },
+    ],
+  ],
+};
+
+export default createCloudApiKeyAction;

--- a/plugins/plugin-elizacloud/src/actions/index.ts
+++ b/plugins/plugin-elizacloud/src/actions/index.ts
@@ -1,0 +1,3 @@
+export { cloudAccountStatusAction } from "./cloud-account-status";
+export { createCloudApiKeyAction } from "./create-cloud-api-key";
+export { listCloudAgentsAction } from "./list-cloud-agents";

--- a/plugins/plugin-elizacloud/src/actions/list-cloud-agents.ts
+++ b/plugins/plugin-elizacloud/src/actions/list-cloud-agents.ts
@@ -1,0 +1,136 @@
+/**
+ * CLOUD_LIST_AGENTS — answer "what agents do I have hosted on Eliza Cloud?".
+ *
+ * Read-only inventory over `GET /api/v1/eliza/agents` via the typed SDK with
+ * the runtime's org API key. Formats name + status lines and handles the
+ * empty / signed-out / error paths with honest, distinct replies. `validate`
+ * drops the action from the planner tool list when the agent is not
+ * cloud-connected; the handler re-guards (validate is advisory).
+ */
+
+import type { AgentListItemDto } from "@elizaos/cloud-sdk";
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import { createElizaCloudClient } from "../utils/sdk-client";
+import { cloudAccountAuthenticated, NO_CLOUD_MESSAGE } from "./cloud-account-status";
+
+const EMPTY_MESSAGE =
+  "You don't have any agents hosted on Eliza Cloud yet. You can provision one from the Cloud console, or ask me to create one.";
+const ERROR_MESSAGE =
+  "I couldn't fetch your Eliza Cloud agents right now — the Cloud API returned an error. Try again in a moment.";
+
+function formatAgentLine(agent: AgentListItemDto): string {
+  return `• ${agent.agentName ?? agent.id} — ${agent.status}`;
+}
+
+export const listCloudAgentsAction: Action = {
+  name: "CLOUD_LIST_AGENTS",
+  similes: ["MY_CLOUD_AGENTS", "SHOW_HOSTED_AGENTS", "LIST_HOSTED_AGENTS"],
+  description:
+    "List the agents the user has hosted on Eliza Cloud (name and status). Use when the user asks what agents they have in the cloud, their hosted agents, or whether their cloud agents are running.",
+  descriptionCompressed: "List the user's hosted Eliza Cloud agents.",
+  contexts: ["cloud", "settings"],
+
+  validate: async (runtime: IAgentRuntime): Promise<boolean> =>
+    cloudAccountAuthenticated(runtime),
+
+  handler: async (
+    runtime: IAgentRuntime,
+    _message: Memory,
+    _state?: State,
+    _options?: unknown,
+    callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    if (!cloudAccountAuthenticated(runtime)) {
+      await callback?.({ text: NO_CLOUD_MESSAGE, actions: ["CLOUD_LIST_AGENTS"] });
+      return {
+        success: false,
+        text: "Not connected to Eliza Cloud.",
+        userFacingText: NO_CLOUD_MESSAGE,
+        data: { reason: "not_connected" },
+      };
+    }
+
+    try {
+      const { data: agents } = await createElizaCloudClient(runtime).listAgents();
+
+      if (agents.length === 0) {
+        await callback?.({ text: EMPTY_MESSAGE, actions: ["CLOUD_LIST_AGENTS"] });
+        return {
+          success: true,
+          text: "User has no hosted Eliza Cloud agents.",
+          userFacingText: EMPTY_MESSAGE,
+          data: { count: 0, agents: [] },
+        };
+      }
+
+      const header =
+        agents.length === 1
+          ? "You have 1 agent hosted on Eliza Cloud:"
+          : `You have ${agents.length} agents hosted on Eliza Cloud:`;
+      const reply = `${header}\n${agents.map(formatAgentLine).join("\n")}`;
+
+      await callback?.({ text: reply, actions: ["CLOUD_LIST_AGENTS"] });
+      return {
+        success: true,
+        text: `Listed ${agents.length} hosted Eliza Cloud agent(s).`,
+        userFacingText: reply,
+        verifiedUserFacing: true,
+        data: {
+          count: agents.length,
+          agents: agents.map((agent) => ({
+            id: agent.id,
+            name: agent.agentName,
+            status: agent.status,
+          })),
+        },
+      };
+    } catch (err) {
+      logger.warn(
+        `[CLOUD_LIST_AGENTS] Failed to list agents: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      await callback?.({ text: ERROR_MESSAGE, actions: ["CLOUD_LIST_AGENTS"] });
+      return {
+        success: false,
+        text: "Failed to list Eliza Cloud agents.",
+        userFacingText: ERROR_MESSAGE,
+        error: err instanceof Error ? err : new Error(String(err)),
+        data: { reason: "error" },
+      };
+    }
+  },
+
+  examples: [
+    [
+      { name: "{{user}}", content: { text: "what agents do I have on eliza cloud?" } },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "You have 2 agents hosted on Eliza Cloud:\n• trading-bot — running\n• support-agent — stopped",
+          actions: ["CLOUD_LIST_AGENTS"],
+        },
+      },
+    ],
+    [
+      { name: "{{user}}", content: { text: "are my hosted agents running?" } },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "You have 1 agent hosted on Eliza Cloud:\n• trading-bot — running",
+          actions: ["CLOUD_LIST_AGENTS"],
+        },
+      },
+    ],
+  ],
+};
+
+export default listCloudAgentsAction;

--- a/plugins/plugin-elizacloud/src/cloud-providers/cloud-account.ts
+++ b/plugins/plugin-elizacloud/src/cloud-providers/cloud-account.ts
@@ -1,0 +1,157 @@
+/**
+ * CLOUD_ACCOUNT provider — a compact Eliza Cloud account summary (credit
+ * balance + hosted-agent inventory) composed into the planner context only
+ * when the turn's selected contexts touch cloud/settings/finance.
+ *
+ * `dynamic: true` keeps it out of the default composeState sweep; the plugin's
+ * `cloud` context registration (src/index.ts init) is the Stage-1 routing
+ * signal that pulls it in when the user talks about their cloud account,
+ * credits, billing, or hosted agents. Signed out it renders `{ text: "" }` —
+ * zero prompt tokens. Fetch failures serve the stale cache when warm and
+ * otherwise stay empty (never fabricated zeros), per the repo error policy.
+ *
+ * Mirrors plugin-cloud-apps' CLOUD_APPS provider, including the cache
+ * invalidation invariant: every mutating cloud action must call
+ * `invalidateCloudAccountCache(runtime)` so the 60s TTL never serves a
+ * just-changed account state within the same conversation.
+ */
+
+import type { AgentListItemDto } from "@elizaos/cloud-sdk";
+import type {
+  IAgentRuntime,
+  Memory,
+  Provider,
+  ProviderResult,
+  State,
+} from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import type { CloudAuthService } from "../services/cloud-auth";
+import { createElizaCloudClient } from "../utils/sdk-client";
+
+const TOP_UP_URL = "https://www.elizacloud.ai/dashboard/settings?tab=billing";
+const TTL = 60_000;
+const MAX_AGENTS_RENDERED = 8;
+
+interface AccountSnapshot {
+  balance: number;
+  agents: AgentListItemDto[];
+}
+
+const accountCaches = new WeakMap<
+  IAgentRuntime,
+  { value: AccountSnapshot; at: number }
+>();
+
+/**
+ * Drop the cached account snapshot so the next provider read re-fetches live.
+ * Call from every mutating cloud action (top-up, agent create/delete, key
+ * create) — otherwise the provider keeps narrating pre-mutation state for up
+ * to 60s inside the same conversation.
+ */
+export function invalidateCloudAccountCache(runtime: IAgentRuntime): void {
+  accountCaches.delete(runtime);
+}
+
+const EMPTY: ProviderResult = { text: "" };
+
+function render(snapshot: AccountSnapshot, organizationId?: string): ProviderResult {
+  const low = snapshot.balance < 2.0;
+  const critical = snapshot.balance < 0.5;
+
+  const lines: string[] = [];
+  const orgSuffix = organizationId ? ` (org ${organizationId})` : "";
+  let creditsLine = `Eliza Cloud account${orgSuffix}: $${snapshot.balance.toFixed(2)} credits`;
+  if (critical) creditsLine += ` (CRITICAL — top up at ${TOP_UP_URL})`;
+  else if (low) creditsLine += ` (LOW — top up at ${TOP_UP_URL})`;
+  lines.push(creditsLine);
+
+  if (snapshot.agents.length === 0) {
+    lines.push("Hosted agents: none yet.");
+  } else {
+    lines.push(
+      snapshot.agents.length === 1
+        ? "1 hosted agent:"
+        : `${snapshot.agents.length} hosted agents:`,
+    );
+    for (const agent of snapshot.agents.slice(0, MAX_AGENTS_RENDERED)) {
+      lines.push(`- ${agent.agentName ?? agent.id} (${agent.status})`);
+    }
+    if (snapshot.agents.length > MAX_AGENTS_RENDERED) {
+      lines.push(`…and ${snapshot.agents.length - MAX_AGENTS_RENDERED} more`);
+    }
+  }
+
+  return {
+    text: lines.join("\n"),
+    values: {
+      cloudCredits: snapshot.balance,
+      cloudCreditsLow: low,
+      cloudCreditsCritical: critical,
+      cloudAgentCount: snapshot.agents.length,
+      cloudTopUpUrl: TOP_UP_URL,
+    },
+    data: {
+      agents: snapshot.agents.slice(0, MAX_AGENTS_RENDERED).map((agent) => ({
+        id: agent.id,
+        name: agent.agentName,
+        status: agent.status,
+      })),
+    },
+  };
+}
+
+export const cloudAccountProvider: Provider = {
+  name: "CLOUD_ACCOUNT",
+  description:
+    "The user's Eliza Cloud account state: credit balance and hosted agents.",
+  descriptionCompressed: "Eliza Cloud account: credits + hosted agents.",
+  dynamic: true,
+  contexts: ["cloud", "settings", "finance"],
+  contextGate: { anyOf: ["cloud", "settings", "finance"] },
+  // Billing/operator context — admin+ only, same rationale as
+  // elizacloud_credits (#12094 item 3).
+  roleGate: { minRole: "ADMIN" },
+  cacheStable: false,
+  cacheScope: "turn",
+  position: 93,
+
+  async get(
+    runtime: IAgentRuntime,
+    _message: Memory,
+    _state: State,
+  ): Promise<ProviderResult> {
+    const auth = runtime.getService("CLOUD_AUTH") as CloudAuthService | undefined;
+    if (!auth?.isAuthenticated()) return EMPTY;
+
+    const cached = accountCaches.get(runtime);
+    if (cached && Date.now() - cached.at < TTL) {
+      return render(cached.value, auth.getOrganizationId());
+    }
+
+    try {
+      const sdk = createElizaCloudClient(runtime);
+      const [{ balance }, agentsResponse] = await Promise.all([
+        sdk.getCreditsBalance(),
+        sdk.listAgents(),
+      ]);
+      const snapshot: AccountSnapshot = {
+        balance,
+        agents: agentsResponse.data,
+      };
+      accountCaches.set(runtime, { value: snapshot, at: Date.now() });
+      return render(snapshot, auth.getOrganizationId());
+    } catch (err) {
+      logger.warn(
+        `[CloudAccount] Failed to fetch account summary: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      // Serve a stale cache when warm; otherwise stay empty — never narrate
+      // fabricated zeros from a failed fetch.
+      if (cached) return render(cached.value, auth.getOrganizationId());
+      return { text: "", values: { cloudAccountUnavailable: true }, data: {} };
+    }
+  },
+};
+
+export default cloudAccountProvider;

--- a/plugins/plugin-elizacloud/src/cloud-providers/cloud-status.ts
+++ b/plugins/plugin-elizacloud/src/cloud-providers/cloud-status.ts
@@ -16,8 +16,8 @@ export const cloudStatusProvider: Provider = {
   descriptionCompressed: "ElizaCloud container/connection status.",
   dynamic: true,
   position: 90,
-  contexts: ["settings", "finance"],
-  contextGate: { anyOf: ["settings", "finance"] },
+  contexts: ["cloud", "settings", "finance"],
+  contextGate: { anyOf: ["cloud", "settings", "finance"] },
   cacheStable: false,
   cacheScope: "turn",
   // Cloud account/connection state is operator context — admin+ only (#12094 item 3).

--- a/plugins/plugin-elizacloud/src/cloud-providers/credit-balance.ts
+++ b/plugins/plugin-elizacloud/src/cloud-providers/credit-balance.ts
@@ -15,8 +15,8 @@ export const creditBalanceProvider: Provider = {
   description: "ElizaCloud credit balance",
   descriptionCompressed: "ElizaCloud credit balance.",
   dynamic: true,
-  contexts: ["settings", "finance"],
-  contextGate: { anyOf: ["settings", "finance"] },
+  contexts: ["cloud", "settings", "finance"],
+  contextGate: { anyOf: ["cloud", "settings", "finance"] },
   cacheStable: false,
   cacheScope: "turn",
   // Cloud credit balance is operator/billing context — admin+ only (#12094 item 3).

--- a/plugins/plugin-elizacloud/src/cloud-providers/index.ts
+++ b/plugins/plugin-elizacloud/src/cloud-providers/index.ts
@@ -1,3 +1,7 @@
 export { cloudStatusProvider } from "./cloud-status";
 export { containerHealthProvider } from "./container-health";
 export { creditBalanceProvider } from "./credit-balance";
+export {
+  cloudAccountProvider,
+  invalidateCloudAccountCache,
+} from "./cloud-account";

--- a/plugins/plugin-elizacloud/src/components/cloud/CloudView.test.tsx
+++ b/plugins/plugin-elizacloud/src/components/cloud/CloudView.test.tsx
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+/**
+ * CloudView state-machine suite (jsdom): loading / signed-out / error / ready
+ * renders, the per-section designed degradation inside ready, and retry
+ * recovery. Fetchers are injected through the component's seam — the
+ * component's own state machine, card rendering, and settle logic run for
+ * real.
+ */
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { CloudViewFetchers } from "./CloudView.tsx";
+import { CloudView } from "./CloudView.tsx";
+
+const CONNECTED_STATUS = {
+  connected: true,
+  enabled: true,
+  hasApiKey: true,
+  userId: "user-1",
+  organizationId: "org-1",
+};
+
+const CREDITS = {
+  connected: true,
+  balance: 12.34,
+  low: false,
+  critical: false,
+  topUpUrl: "https://elizacloud.ai/dashboard/settings?tab=billing",
+};
+
+const AGENT = {
+  agent_id: "agent-1",
+  agent_name: "alpha",
+  node_id: null,
+  container_id: null,
+  headscale_ip: null,
+  bridge_url: null,
+  web_ui_url: null,
+  status: "running",
+  agent_config: {},
+  created_at: "2026-07-01T00:00:00.000Z",
+  updated_at: "2026-07-01T00:00:00.000Z",
+  containerUrl: "",
+  webUiUrl: null,
+  database_status: "healthy",
+  error_message: null,
+  last_heartbeat_at: null,
+};
+
+function fetchers(overrides: Partial<CloudViewFetchers> = {}): CloudViewFetchers {
+  return {
+    fetchStatus: async () => CONNECTED_STATUS,
+    fetchCredits: async () => CREDITS,
+    fetchAgents: async () => ({ success: true, data: [AGENT] }),
+    fetchApiKeys: async () => ({
+      keys: [
+        { id: "k1", name: "ci", keyPrefix: "eliza_abc1", createdAt: null },
+        { id: "k2", name: "dev", keyPrefix: "eliza_abc2", createdAt: null },
+      ],
+      manageUrl: "https://elizacloud.ai/dashboard/api-keys",
+    }),
+    fetchBillingSummary: async () => ({
+      balance: 12.34,
+      currency: "USD",
+      hasPaymentMethod: true,
+    }),
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+async function render(seam: CloudViewFetchers) {
+  await act(async () => {
+    root.render(<CloudView fetchers={seam} />);
+  });
+  // Let the async account load settle.
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function testId(id: string): HTMLElement | null {
+  return container.querySelector<HTMLElement>(`[data-testid="${id}"]`);
+}
+
+describe("CloudView", () => {
+  it("shows the loading state while the account load is in flight", async () => {
+    const never = new Promise<typeof CONNECTED_STATUS>(() => {});
+    await act(async () => {
+      root.render(<CloudView fetchers={fetchers({ fetchStatus: () => never })} />);
+    });
+    expect(testId("cloud-loading")).not.toBeNull();
+    expect(container.textContent).toContain("Loading your Eliza Cloud account");
+  });
+
+  it("renders the designed signed-out state with a connect CTA", async () => {
+    await render(
+      fetchers({ fetchStatus: async () => ({ connected: false, enabled: true }) }),
+    );
+    expect(testId("cloud-signed-out")).not.toBeNull();
+    expect(container.textContent).toContain("Connect your Eliza Cloud account");
+    expect(container.querySelector("button")?.textContent).toContain(
+      "Connect in Settings",
+    );
+  });
+
+  it("renders the error state and recovers on retry", async () => {
+    let fail = true;
+    await render(
+      fetchers({
+        fetchStatus: async () => {
+          if (fail) throw new Error("cloud unreachable");
+          return CONNECTED_STATUS;
+        },
+      }),
+    );
+    expect(testId("cloud-error")).not.toBeNull();
+    expect(container.textContent).toContain("cloud unreachable");
+
+    fail = false;
+    await act(async () => {
+      container.querySelector("button")?.click();
+      await Promise.resolve();
+    });
+    expect(testId("cloud-ready")).not.toBeNull();
+  });
+
+  it("renders the ready state: balance, agents, key count, billing", async () => {
+    await render(fetchers());
+    expect(testId("cloud-ready")).not.toBeNull();
+    expect(testId("cloud-credit-balance")?.textContent).toBe("$12.34");
+    expect(testId("cloud-org-id")?.textContent).toBe("org-1");
+    expect(testId("cloud-agent-list")?.textContent).toContain("alpha");
+    expect(testId("cloud-agent-list")?.textContent).toContain("running");
+    expect(testId("cloud-api-key-count")?.textContent).toBe("2 API keys");
+    expect(container.textContent).toContain("Payment method on file.");
+    expect(container.textContent).toContain("Top up");
+  });
+
+  it("renders the designed empty state when there are no hosted agents", async () => {
+    await render(fetchers({ fetchAgents: async () => ({ success: true, data: [] }) }));
+    expect(container.textContent).toContain("No hosted agents yet");
+  });
+
+  it("degrades a failing section to its unavailable note without faking empty", async () => {
+    await render(
+      fetchers({
+        fetchAgents: async () => {
+          throw new Error("agents endpoint down");
+        },
+      }),
+    );
+    // Still ready — credits render…
+    expect(testId("cloud-credit-balance")?.textContent).toBe("$12.34");
+    // …but the agents card is a designed unavailable note, not an empty list.
+    expect(container.textContent).toContain("Agents are unavailable right now.");
+    expect(container.textContent).not.toContain("No hosted agents yet");
+  });
+
+  it("explains the session-only key list instead of rendering a false zero", async () => {
+    await render(
+      fetchers({
+        fetchApiKeys: async () => ({
+          keys: null,
+          manageUrl: "https://elizacloud.ai/dashboard/api-keys",
+          reason: "session-required" as const,
+        }),
+      }),
+    );
+    expect(testId("cloud-api-key-count")).toBeNull();
+    expect(container.textContent).toContain("signed-in session");
+  });
+});

--- a/plugins/plugin-elizacloud/src/components/cloud/CloudView.tsx
+++ b/plugins/plugin-elizacloud/src/components/cloud/CloudView.tsx
@@ -1,0 +1,423 @@
+/**
+ * CloudView — the in-app "Cloud" launcher view: the user's Eliza Cloud account
+ * at a glance (credits + top-up, hosted agents with status, API-key inventory,
+ * billing summary) rendered app-native in the dark launcher aesthetic.
+ *
+ * Served as this plugin's `cloud` view bundle (`vite.config.views.ts`) and
+ * mounted by the shell's DynamicViewLoader at `/cloud`, so it may import ONLY
+ * host-external specifiers (react, `@elizaos/ui/api`) — console surfaces under
+ * `@elizaos/ui/cloud/*` are not in the host-external map and cannot be reused
+ * here. Data comes from the host `client` singleton's cloud wrappers, which
+ * already handle steward-token auth, direct-cloud base resolution, and native
+ * transport.
+ *
+ * State machine honors the repo three-state rule: loading / signed-out
+ * (designed connect CTA) / error (with retry) / ready — and inside ready each
+ * secondary section (agents, keys, billing) degrades to its own designed
+ * "unavailable" note on fetch failure rather than a healthy-empty render.
+ */
+
+// Narrow host-external subpath: the `@elizaos/ui` barrel would drag every chat
+// widget into the jsdom test graph for one singleton (the birdclaw lesson).
+import { client } from "@elizaos/ui/api";
+import type {
+  CloudApiKeys,
+  CloudBillingSummary,
+  CloudCompatAgent,
+  CloudCredits,
+  CloudStatus,
+} from "@elizaos/ui/api";
+import type { ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// ---------------------------------------------------------------------------
+// Fetcher seam — defaults hit the host client; tests inject offline fakes.
+// ---------------------------------------------------------------------------
+
+export interface CloudViewFetchers {
+  fetchStatus: () => Promise<CloudStatus>;
+  fetchCredits: () => Promise<CloudCredits>;
+  fetchAgents: () => Promise<{
+    success: boolean;
+    data: CloudCompatAgent[];
+    error?: string;
+  }>;
+  fetchApiKeys: () => Promise<CloudApiKeys>;
+  fetchBillingSummary: () => Promise<CloudBillingSummary>;
+}
+
+const defaultFetchers: CloudViewFetchers = {
+  fetchStatus: () => client.getCloudStatus(),
+  fetchCredits: () => client.getCloudCredits(),
+  fetchAgents: () => client.getCloudCompatAgents(),
+  fetchApiKeys: () => client.listCloudApiKeys(),
+  fetchBillingSummary: () => client.getCloudBillingSummary(),
+};
+
+/** In-shell navigation: pushState + popstate, the launcher tile convention. */
+function navigateTo(path: string): void {
+  window.history.pushState({}, "", path);
+  window.dispatchEvent(new PopStateEvent("popstate"));
+}
+
+// ---------------------------------------------------------------------------
+// Load-state machine.
+// ---------------------------------------------------------------------------
+
+/** A secondary section either has data or a designed unavailable message. */
+type Section<T> = { data: T; error: null } | { data: null; error: string };
+
+interface ReadyData {
+  status: CloudStatus;
+  credits: Section<CloudCredits>;
+  agents: Section<CloudCompatAgent[]>;
+  apiKeys: Section<CloudApiKeys>;
+  billing: Section<CloudBillingSummary>;
+}
+
+type LoadState =
+  | { kind: "loading" }
+  | { kind: "signed-out" }
+  | { kind: "error"; message: string }
+  | { kind: "ready"; data: ReadyData };
+
+const AGENT_REFRESH_MS = 30_000;
+
+function section<T>(
+  result: PromiseSettledResult<T>,
+  unavailable: string,
+): Section<T> {
+  if (result.status === "fulfilled") return { data: result.value, error: null };
+  return { data: null, error: unavailable };
+}
+
+async function loadAccount(fetchers: CloudViewFetchers): Promise<LoadState> {
+  const status = await fetchers.fetchStatus();
+  if (!status.connected) return { kind: "signed-out" };
+
+  const [credits, agents, apiKeys, billing] = await Promise.allSettled([
+    fetchers.fetchCredits(),
+    fetchers.fetchAgents(),
+    fetchers.fetchApiKeys(),
+    fetchers.fetchBillingSummary(),
+  ]);
+
+  const agentsSection: Section<CloudCompatAgent[]> =
+    agents.status === "fulfilled"
+      ? agents.value.success
+        ? { data: agents.value.data ?? [], error: null }
+        : { data: null, error: agents.value.error ?? "Agents are unavailable right now." }
+      : { data: null, error: "Agents are unavailable right now." };
+
+  return {
+    kind: "ready",
+    data: {
+      status,
+      credits: section(credits, "Credits are unavailable right now."),
+      agents: agentsSection,
+      apiKeys: section(apiKeys, "API keys are unavailable right now."),
+      billing: section(billing, "Billing is unavailable right now."),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Presentational pieces (token classes only — the launcher theme owns colors).
+// ---------------------------------------------------------------------------
+
+function Card(props: { title: string; children: ReactNode; action?: ReactNode }) {
+  return (
+    <section className="rounded-lg border border-border bg-card px-4 py-4">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold text-txt">{props.title}</h2>
+        {props.action}
+      </div>
+      {props.children}
+    </section>
+  );
+}
+
+function SectionNote(props: { message: string }) {
+  return <p className="text-sm text-muted">{props.message}</p>;
+}
+
+function ExternalLink(props: { href: string; children: ReactNode }) {
+  return (
+    <a
+      className="text-sm font-medium text-accent hover:underline"
+      href={props.href}
+      target="_blank"
+      rel="noreferrer"
+    >
+      {props.children}
+    </a>
+  );
+}
+
+function agentStatusClass(status: string): string {
+  const normalized = status.toLowerCase();
+  if (normalized === "running") return "text-ok";
+  if (normalized === "error") return "text-danger";
+  if (normalized === "provisioning" || normalized === "pending") return "text-warn";
+  return "text-muted";
+}
+
+function balanceClass(credits: CloudCredits): string {
+  if (credits.critical) return "text-danger";
+  if (credits.low) return "text-warn";
+  return "text-txt";
+}
+
+function formatBalance(balance: number | null): string {
+  return balance === null ? "—" : `$${balance.toFixed(2)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Cards.
+// ---------------------------------------------------------------------------
+
+function AccountCard(props: { status: CloudStatus }) {
+  const { status } = props;
+  return (
+    <Card
+      title="Account"
+      action={
+        <span className="rounded-md bg-accent/12 px-2 py-0.5 text-xs font-medium text-accent">
+          Connected
+        </span>
+      }
+    >
+      <dl className="space-y-1 text-sm">
+        {status.organizationId ? (
+          <div className="flex justify-between gap-2">
+            <dt className="text-muted">Organization</dt>
+            <dd className="truncate text-txt" data-testid="cloud-org-id">
+              {status.organizationId}
+            </dd>
+          </div>
+        ) : null}
+        {status.userId ? (
+          <div className="flex justify-between gap-2">
+            <dt className="text-muted">User</dt>
+            <dd className="truncate text-txt">{status.userId}</dd>
+          </div>
+        ) : null}
+      </dl>
+    </Card>
+  );
+}
+
+function CreditsCard(props: {
+  credits: Section<CloudCredits>;
+  billing: Section<CloudBillingSummary>;
+}) {
+  const { credits, billing } = props;
+  if (!credits.data) {
+    return (
+      <Card title="Credits">
+        <SectionNote message={credits.error} />
+      </Card>
+    );
+  }
+  const topUpUrl = credits.data.topUpUrl ?? billing.data?.topUpUrl;
+  return (
+    <Card
+      title="Credits"
+      action={topUpUrl ? <ExternalLink href={topUpUrl}>Top up</ExternalLink> : undefined}
+    >
+      <p
+        className={`text-2xl font-semibold ${balanceClass(credits.data)}`}
+        data-testid="cloud-credit-balance"
+      >
+        {formatBalance(credits.data.balance)}
+      </p>
+      {credits.data.critical ? (
+        <p className="mt-1 text-sm text-danger">Balance is critically low.</p>
+      ) : credits.data.low ? (
+        <p className="mt-1 text-sm text-warn">Balance is running low.</p>
+      ) : null}
+      {billing.data ? (
+        <p className="mt-2 text-sm text-muted">
+          {billing.data.hasPaymentMethod
+            ? "Payment method on file."
+            : "No payment method on file."}
+        </p>
+      ) : (
+        <p className="mt-2 text-sm text-muted">{billing.error}</p>
+      )}
+    </Card>
+  );
+}
+
+function AgentsCard(props: { agents: Section<CloudCompatAgent[]> }) {
+  const { agents } = props;
+  return (
+    <Card title="Hosted agents">
+      {agents.data === null ? (
+        <SectionNote message={agents.error} />
+      ) : agents.data.length === 0 ? (
+        <SectionNote message="No hosted agents yet. Ask me to create one, or provision from the console." />
+      ) : (
+        <ul className="space-y-2" data-testid="cloud-agent-list">
+          {agents.data.map((agent) => (
+            <li
+              key={agent.agent_id}
+              className="flex items-center justify-between gap-2 rounded-md border border-border bg-surface px-3 py-2"
+            >
+              <span className="truncate text-sm text-txt">{agent.agent_name}</span>
+              <span className={`text-xs font-medium ${agentStatusClass(agent.status)}`}>
+                {agent.status}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
+}
+
+function ApiKeysCard(props: { apiKeys: Section<CloudApiKeys> }) {
+  const { apiKeys } = props;
+  if (apiKeys.data === null) {
+    return (
+      <Card title="API keys">
+        <SectionNote message={apiKeys.error} />
+      </Card>
+    );
+  }
+  const { keys, manageUrl, reason } = apiKeys.data;
+  return (
+    <Card
+      title="API keys"
+      action={<ExternalLink href={manageUrl}>Manage</ExternalLink>}
+    >
+      {keys === null ? (
+        <SectionNote
+          message={
+            reason === "session-required"
+              ? "API keys can only be listed from a signed-in session — manage them in the console."
+              : "Sign in to Eliza Cloud to see your API keys."
+          }
+        />
+      ) : (
+        <p className="text-sm text-txt" data-testid="cloud-api-key-count">
+          {keys.length === 1 ? "1 API key" : `${keys.length} API keys`}
+        </p>
+      )}
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// View.
+// ---------------------------------------------------------------------------
+
+export interface CloudViewProps {
+  /** Test/host injection seam. Defaults to the host `client` cloud wrappers. */
+  fetchers?: CloudViewFetchers;
+}
+
+export function CloudView(props: CloudViewProps = {}): ReactNode {
+  const fetchers = props.fetchers ?? defaultFetchers;
+  const [state, setState] = useState<LoadState>({ kind: "loading" });
+
+  const fetchersRef = useRef(fetchers);
+  fetchersRef.current = fetchers;
+
+  // `background` refreshes in place (the 30s agent-status poll); user-driven
+  // loads (mount, retry) show the loading state.
+  const load = useCallback((background = false) => {
+    let cancelled = false;
+    if (!background) setState({ kind: "loading" });
+    loadAccount(fetchersRef.current)
+      .then((next) => {
+        if (!cancelled) setState(next);
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setState({
+          kind: "error",
+          message:
+            error instanceof Error
+              ? error.message
+              : "Could not load your Eliza Cloud account.",
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => load(), [load]);
+
+  // Hosted-agent statuses move (provisioning → running) — refresh in the
+  // background while the view is mounted and healthy.
+  useEffect(() => {
+    if (state.kind !== "ready") return;
+    const timer = window.setInterval(() => load(true), AGENT_REFRESH_MS);
+    return () => window.clearInterval(timer);
+  }, [state.kind, load]);
+
+  if (state.kind === "loading") {
+    return (
+      <div className="flex h-full items-center justify-center bg-bg" data-testid="cloud-loading">
+        <p className="text-sm text-muted">Loading your Eliza Cloud account…</p>
+      </div>
+    );
+  }
+
+  if (state.kind === "signed-out") {
+    return (
+      <div
+        className="flex h-full flex-col items-center justify-center gap-3 bg-bg px-6 text-center"
+        data-testid="cloud-signed-out"
+      >
+        <h1 className="text-lg font-semibold text-txt">Eliza Cloud</h1>
+        <p className="max-w-sm text-sm text-muted">
+          Connect your Eliza Cloud account to see credits, hosted agents, API
+          keys, and billing here.
+        </p>
+        <button
+          type="button"
+          className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white"
+          onClick={() => navigateTo("/settings")}
+        >
+          Connect in Settings
+        </button>
+      </div>
+    );
+  }
+
+  if (state.kind === "error") {
+    return (
+      <div
+        className="flex h-full flex-col items-center justify-center gap-3 bg-bg px-6 text-center"
+        data-testid="cloud-error"
+      >
+        <p className="text-sm text-danger">{state.message}</p>
+        <button
+          type="button"
+          className="rounded-md border border-border bg-surface px-4 py-2 text-sm font-medium text-txt"
+          onClick={() => load()}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  const { data } = state;
+  return (
+    <div className="h-full overflow-y-auto bg-bg" data-testid="cloud-ready">
+      <div className="mx-auto flex max-w-2xl flex-col gap-4 px-4 py-6">
+        <h1 className="text-lg font-semibold text-txt">Eliza Cloud</h1>
+        <AccountCard status={data.status} />
+        <CreditsCard credits={data.credits} billing={data.billing} />
+        <AgentsCard agents={data.agents} />
+        <ApiKeysCard apiKeys={data.apiKeys} />
+      </div>
+    </div>
+  );
+}
+
+export default CloudView;

--- a/plugins/plugin-elizacloud/src/components/cloud/CloudView.tsx
+++ b/plugins/plugin-elizacloud/src/components/cloud/CloudView.tsx
@@ -325,16 +325,22 @@ export function CloudView(props: CloudViewProps = {}): ReactNode {
   fetchersRef.current = fetchers;
 
   // `background` refreshes in place (the 30s agent-status poll); user-driven
-  // loads (mount, retry) show the loading state.
+  // loads (mount, retry) show the loading state. Background refreshes keep the
+  // last-good view on failure: one transient network blip mid-session must not
+  // replace a healthy dashboard with the full-screen error (or flip a
+  // momentary connected:false into the signed-out card) — errors surface only
+  // on user-driven loads, and the next poll self-corrects.
   const load = useCallback((background = false) => {
     let cancelled = false;
     if (!background) setState({ kind: "loading" });
     loadAccount(fetchersRef.current)
       .then((next) => {
-        if (!cancelled) setState(next);
+        if (cancelled) return;
+        if (background && next.kind !== "ready") return;
+        setState(next);
       })
       .catch((error: unknown) => {
-        if (cancelled) return;
+        if (cancelled || background) return;
         setState({
           kind: "error",
           message:

--- a/plugins/plugin-elizacloud/src/components/cloud/cloud-view-bundle.ts
+++ b/plugins/plugin-elizacloud/src/components/cloud/cloud-view-bundle.ts
@@ -1,0 +1,6 @@
+/**
+ * Vite bundle entry for the `cloud` view (see vite.config.views.ts). Kept as a
+ * separate one-line module so the component file stays Fast-Refresh friendly
+ * and the bundle exports exactly the declared `componentExport`.
+ */
+export { CloudView } from "./CloudView.tsx";

--- a/plugins/plugin-elizacloud/src/index.ts
+++ b/plugins/plugin-elizacloud/src/index.ts
@@ -1,6 +1,11 @@
 import type { IAgentRuntime, Plugin, ProcessEnvLike } from "@elizaos/core";
 import { logger, ModelType } from "@elizaos/core";
+// Cloud account actions
+import { cloudAccountStatusAction } from "./actions/cloud-account-status";
+import { createCloudApiKeyAction } from "./actions/create-cloud-api-key";
+import { listCloudAgentsAction } from "./actions/list-cloud-agents";
 // Cloud providers
+import { cloudAccountProvider } from "./cloud-providers/cloud-account";
 import { cloudStatusProvider } from "./cloud-providers/cloud-status";
 import { containerHealthProvider } from "./cloud-providers/container-health";
 import { creditBalanceProvider } from "./cloud-providers/credit-balance";
@@ -159,6 +164,12 @@ export function registerCloudEmbeddingModels(runtime: IAgentRuntime): void {
 
 export const elizaOSCloudPlugin: Plugin = {
   name: "elizaOSCloud",
+  // "elizaOSCloud" is a load-bearing runtime identity (model-provider name in
+  // version-compat, inference timing, runtime model context) that cannot be
+  // renamed to the npm name — packageName lets the view registry resolve the
+  // real package dir so the `cloud` view bundle is served (see
+  // registerPluginViews in packages/agent/src/api/views-registry.ts).
+  packageName: "@elizaos/plugin-elizacloud",
   description:
     "ElizaOS Cloud plugin — Multi-model AI generation, container provisioning, agent bridge, and billing management",
   autoEnable: {
@@ -242,6 +253,25 @@ export const elizaOSCloudPlugin: Plugin = {
     // stay in the static `models` map below.
     registerTextInferenceModels(runtime);
     registerCloudEmbeddingModels(runtime);
+
+    // The `cloud` routing signal: Stage-1 selects contexts from the registry
+    // catalog, and the description text is what routes "my credits / my hosted
+    // agents / my cloud billing" turns onto the planner path where the
+    // context-gated CLOUD_ACCOUNT provider and cloud actions live. tryRegister
+    // is idempotent across plugin re-registration (register throws on dupes).
+    // The ADMIN minRole also derives the effective role gate for cloud-tagged
+    // actions that declare none (#12089).
+    runtime.contexts.tryRegister({
+      id: "cloud",
+      label: "Eliza Cloud",
+      description:
+        "The user's Eliza Cloud account: sign-in status, billing, credit balance, top-ups, API keys, hosted agents/containers, and deployed cloud apps. Use when the user asks about their cloud account, credits, billing, hosted agents, or app deployments.",
+      descriptionCompressed:
+        "Eliza Cloud account/billing/credits/hosted agents & apps",
+      sensitivity: "private",
+      cacheScope: "turn",
+      roleGate: { minRole: "ADMIN" },
+    });
   },
 
   // ─── Runtime Event Handlers ──────────────────────────────────────────
@@ -280,6 +310,43 @@ export const elizaOSCloudPlugin: Plugin = {
     creditBalanceProvider,
     containerHealthProvider,
     modelRegistryProvider,
+    cloudAccountProvider,
+  ],
+
+  // ─── Cloud Account Actions ───────────────────────────────────────────
+  // All validate() on the CLOUD_AUTH signed-in state so they vanish from the
+  // planner tool list when the agent has no cloud credential; handlers
+  // re-guard because validate is advisory.
+  actions: [
+    cloudAccountStatusAction,
+    listCloudAgentsAction,
+    createCloudApiKeyAction,
+  ],
+
+  // ─── In-app view ─────────────────────────────────────────────────────
+  // The "Cloud" launcher tile: served from dist/views/bundle.js (built by
+  // vite.config.views.ts) and mounted by the shell at /cloud. Curated launcher
+  // placement + cloud-sign-in gating live in
+  // packages/ui/src/components/pages/launcher-curation.ts.
+  views: [
+    {
+      id: "cloud",
+      label: "Cloud",
+      description:
+        "Your Eliza Cloud account — credits, hosted agents, API keys, and billing",
+      icon: "Cloud",
+      path: "/cloud",
+      // Plain array literal on purpose: plugin.ts is not part of the view
+      // bundle, and a core runtime export reaching the bundle build breaks it
+      // (the wallet-ui lesson).
+      modalities: ["gui"],
+      bundlePath: "dist/views/bundle.js",
+      componentExport: "CloudView",
+      surface: { capabilities: ["agent-surface"] },
+      tags: ["cloud", "billing", "credits", "account", "api-keys", "agents"],
+      visibleInManager: true,
+      desktopTabEnabled: true,
+    },
   ],
 
   // ─── Capability Model Handlers ───────────────────────────────────────

--- a/plugins/plugin-elizacloud/test/scenarios/cloud-account-signed-out.scenario.ts
+++ b/plugins/plugin-elizacloud/test/scenarios/cloud-account-signed-out.scenario.ts
@@ -1,0 +1,47 @@
+/**
+ * Signed-out gating for the cloud account action surface: without a Cloud
+ * session (`CLOUD_AUTH` unauthenticated — no ELIZAOS_CLOUD_API_KEY in the
+ * deterministic lane), the account actions' validate() must keep them out of
+ * the planner entirely, and the reply must not pretend to know account state.
+ * The signed-in paths are covered by the loopback-server unit suites
+ * (__tests__/unit/cloud-account-actions.test.ts).
+ */
+import { scenario } from "@elizaos/scenario-runner/schema";
+export default scenario({
+  lane: "pr-deterministic",
+  id: "cloud-account-signed-out",
+  title: "Cloud account actions stay hidden without a Cloud session",
+  domain: "elizacloud.account",
+  tags: ["elizacloud", "cloud", "actions", "gating"],
+  isolation: "per-scenario",
+  requires: {
+    plugins: ["@elizaos/plugin-elizacloud"],
+  },
+  rooms: [
+    {
+      id: "main",
+      source: "dashboard",
+      title: "Cloud Account",
+    },
+  ],
+  turns: [
+    {
+      kind: "message",
+      name: "credits-question-signed-out",
+      text: "How many credits do I have on Eliza Cloud, and what agents are running?",
+      plannerExcludes: [
+        "CLOUD_ACCOUNT_STATUS",
+        "CLOUD_LIST_AGENTS",
+        "CLOUD_CREATE_API_KEY",
+      ],
+      responseIncludesAny: [
+        "cloud",
+        "sign",
+        "connect",
+        "account",
+        "credit",
+        "log in",
+      ],
+    },
+  ],
+});

--- a/plugins/plugin-elizacloud/tsconfig.build.json
+++ b/plugins/plugin-elizacloud/tsconfig.build.json
@@ -25,6 +25,7 @@
     "build.ts",
     "vitest.config.ts",
     "**/__tests__/**",
-    "**/*.test.ts"
+    "**/*.test.ts",
+    "src/components/**"
   ]
 }

--- a/plugins/plugin-elizacloud/tsconfig.json
+++ b/plugins/plugin-elizacloud/tsconfig.json
@@ -12,6 +12,7 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "jsx": "react-jsx",
     "noEmit": true,
     "outDir": "./dist",
     "rootDir": "../..",
@@ -21,15 +22,27 @@
     "noUnusedParameters": false,
     "allowImportingTsExtensions": true,
     "paths": {
+      "@elizaos/capacitor-bun-runtime": [
+        "../../plugins/plugin-native-bun-runtime/src/index.ts"
+      ],
+      "@elizaos/cloud-routing": ["../../packages/cloud/routing/src/index.ts"],
       "@elizaos/cloud-sdk": ["../../packages/cloud/sdk/src/index.ts"],
       "@elizaos/core": ["../../packages/core/src/index.node.ts"],
       "@elizaos/logger": ["../../packages/logger/src/index.ts"],
       "@elizaos/logger/*": ["../../packages/logger/src/*"],
       "@elizaos/shared": ["../../packages/shared/src/index.ts"],
-      "@elizaos/shared/*": ["../../packages/shared/src/*"]
+      "@elizaos/shared/*": ["../../packages/shared/src/*"],
+      "@elizaos/ui": ["../../packages/ui/src/index.ts"],
+      "@elizaos/ui/*": ["../../packages/ui/src/*"]
     }
   },
-  "include": ["src/**/*.ts", "__tests__/**/*.ts", "build.ts", "vitest.config.ts"],
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "__tests__/**/*.ts",
+    "build.ts",
+    "vitest.config.ts"
+  ],
   "exclude": [
     "node_modules",
     "dist",

--- a/plugins/plugin-elizacloud/vite.config.views.ts
+++ b/plugins/plugin-elizacloud/vite.config.views.ts
@@ -1,0 +1,9 @@
+import { createViewBundleConfig } from "../../packages/scripts/view-bundle-vite.config.ts";
+
+export default createViewBundleConfig({
+  packageName: "@elizaos/plugin-elizacloud",
+  viewId: "cloud",
+  entry: "./src/components/cloud/cloud-view-bundle.ts",
+  outDir: "dist/views",
+  componentExport: "CloudView",
+});

--- a/plugins/plugin-elizacloud/vitest.config.ts
+++ b/plugins/plugin-elizacloud/vitest.config.ts
@@ -1,25 +1,54 @@
+import { createRequire } from "node:module";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
+const here = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+const src = (relative: string) => path.join(here, "../../packages", relative);
+
+// Regex finds with subpath entries BEFORE the bare-package entries: a plain
+// string alias for "@elizaos/shared" would also rewrite
+// "@elizaos/shared/steward-session-client" into ".../index.ts/steward-…" once
+// the CloudView jsdom suite pulls the @elizaos/ui api graph in. The react pins
+// keep a single React copy so jsdom never mixes the workspace and hoisted
+// peers (mirrors plugin-birdclaw).
 export default defineConfig({
 	resolve: {
-			alias: {
-				"@elizaos/cloud-sdk": fileURLToPath(
-					new URL("../../packages/cloud/sdk/src/index.ts", import.meta.url),
-				),
-			"@elizaos/core": fileURLToPath(
-				new URL("../../packages/core/src/index.node.ts", import.meta.url),
-			),
-			"@elizaos/logger": fileURLToPath(
-				new URL("../../packages/logger/src/index.ts", import.meta.url),
-			),
-			"@elizaos/shared": fileURLToPath(
-				new URL("../../packages/shared/src/index.ts", import.meta.url),
-			),
-		},
+		alias: [
+			{ find: /^@elizaos\/cloud-routing$/, replacement: src("cloud/routing/src/index.ts") },
+			{ find: /^@elizaos\/cloud-sdk$/, replacement: src("cloud/sdk/src/index.ts") },
+			{ find: /^@elizaos\/core$/, replacement: src("core/src/index.node.ts") },
+			{ find: /^@elizaos\/logger$/, replacement: src("logger/src/index.ts") },
+			{ find: /^@elizaos\/shared\/(.*)$/, replacement: `${src("shared/src")}/$1` },
+			{ find: /^@elizaos\/shared$/, replacement: src("shared/src/index.ts") },
+			{ find: /^@elizaos\/ui\/(.*)$/, replacement: `${src("ui/src")}/$1` },
+			{ find: /^@elizaos\/ui$/, replacement: src("ui/src/index.ts") },
+			{
+				find: /^react$/,
+				replacement: path.dirname(require.resolve("react/package.json")),
+			},
+			{
+				find: /^react\/jsx-runtime$/,
+				replacement: require.resolve("react/jsx-runtime"),
+			},
+			{
+				find: /^react\/jsx-dev-runtime$/,
+				replacement: require.resolve("react/jsx-dev-runtime"),
+			},
+			{
+				find: /^react-dom$/,
+				replacement: path.dirname(require.resolve("react-dom/package.json")),
+			},
+			{
+				find: /^react-dom\/client$/,
+				replacement: require.resolve("react-dom/client"),
+			},
+		],
 	},
 	test: {
-		include: ["__tests__/**/*.test.ts"],
+		include: ["__tests__/**/*.test.ts", "src/**/*.test.{ts,tsx}"],
 		environment: "node",
 		server: {
 			deps: {


### PR DESCRIPTION
Nubs's ask: manage your Eliza Cloud account from INSIDE the eliza app, and ask the agent about it — without cloud state permanently occupying prompt context.

## What ships
- **Cloud launcher app** (`/cloud`, tile gated on cloud sign-in via `LAUNCHER_CLOUD_IDS`): credits + top-up, agents w/ live status (30s background poll that keeps last-good on blips), API keys + manage link, billing summary. Lean app-native view (dark launcher aesthetic), strict loading/signed-out/error/ready states, per-section designed degradation — never healthy-empty from a catch.
- **CLOUD_ACCOUNT provider** — `dynamic: true`, context-gated (cloud|settings|finance), ADMIN role-gated, 60s cache, stale-on-failure, signed-out → empty. **Zero context cost until the conversation actually touches cloud** (the context-layer routing), per the owner's requirement.
- **3 actions** — `CLOUD_ACCOUNT_STATUS`, `CLOUD_LIST_AGENTS`, `CLOUD_CREATE_API_KEY` — `validate()` gates on signed-in (they vanish signed-out); key creation shows the plain key once (never persisted in the ActionResult), refuses the reserved `agent-sandbox:` prefix, honest session-required replies.
- **`Plugin.packageName` seam** (core + views-registry): `name:"elizaOSCloud"` can't resolve its package dir for view bundles; the seam fixes it generically + test proves it.
- **`listCloudApiKeys`** client wrapper (packages/ui), typed not-connected/session-required reasons.

## Verification
- 30 new tests (23 provider/action against a REAL loopback cloud server driving the real SDK — no mocks of code under test; 7 CloudView jsdom states); plugin suite **360 passed / 0 failed**; views-registry resolution 4/4; view bundle builds green (8.9KB, static externals only, codeSplitting:false per #11040).
- Adversarially reviewed by an independent agent: 7/7 hard contracts pass, 2 minor findings — both fixed in the final commit.
- Launcher edits are two one-line insertions (merge-trivial vs #15108's character consolidation).
- Rendered on-device proof (launcher tile + /cloud view + live-LLM trajectory for the provider) to follow on a booted stack — flagged NOT-YET-VERIFIED per the evidence bar.

— [qa-agent]

## Evidence
- <!-- evidence-row:before-screenshots --> **Before screenshots:** N/A — net-new surface; no prior state exists (no Cloud tile, no /cloud view, no cloud account actions).
- <!-- evidence-row:after-screenshots --> **After screenshots:** N/A — pending a booted stack: launcher tile (cloud signed-in vs signed-out gating) + /cloud view render (loading/ready/error/signed-out) will be attached as a follow-up comment before this rides any promote; flagged NOT-YET-VERIFIED in the description per the evidence bar.
- <!-- evidence-row:walkthrough-video --> **Walkthrough video:** N/A — bundled with the after-screenshots capture session on the booted stack (single recording covering tile → view → agent actions).
- <!-- evidence-row:backend-logs --> **Backend logs:** the 23 provider/action tests run against a REAL loopback cloud server driving the real SDK — request/response traces + structured logs are the vitest output committed in the suite (`__tests__/unit/cloud-account-*.test.ts`); `views-registry` resolution proven by `views-registry.package-resolution.test.ts` (4/4) against the real plugin dir.
- <!-- evidence-row:frontend-logs --> **Frontend console/network logs:** CloudView jsdom suite (7 states) asserts the fetch orchestration incl. background-poll keep-last-good; real browser network capture ships with the after-screenshots session.
- <!-- evidence-row:llm-trajectory --> **Real-LLM trajectory:** deterministic planner-gating scenario committed (`test/scenarios/cloud-account-signed-out.scenario.ts` — signed-out validate() keeps all three actions out of the planner); live-LLM trajectory proving the "cloud" context routes CLOUD_ACCOUNT on-demand follows on the booted stack with the capture session.
- <!-- evidence-row:domain-artifacts --> **Domain artifacts:** view bundle `dist/views/bundle.js` (8.9KB, zero dynamic imports, bare externals only — verified by independent adversarial review, 7/7 contracts); plugin suite 360 passed / 0 failed; lane-coverage gate green with the elizacloud allowlist entry ratcheted out.
