### PR TITLE
fix(ui): clear stale chat transcript on uncached switch

### DIFF
--- a/packages/ui/src/state/useChatCallbacks.select-race.test.tsx
+++ b/packages/ui/src/state/useChatCallbacks.select-race.test.tsx
@@ -420,12 +420,10 @@ describe("rapid conversation switching must never delete a real conversation", (
     });
     // The committed draft is legitimately cleaned up…
     expect(h.deletedConversationIds()).toEqual(["draft-d"]);
-    // …while the thread STILL holds the draft's greeting (B has not committed).
+    // …while the uncached target clears the visible thread until B commits.
     expect(h.activeConversationIdRef.current).toBe("conv-b");
-    expect(h.conversationMessagesRef.current).toEqual([greetingMessage()]);
-    expect(result.current.loaders.loadedConversationIdRef.current).toBe(
-      "draft-d",
-    );
+    expect(h.conversationMessagesRef.current).toEqual([]);
+    expect(result.current.loaders.loadedConversationIdRef.current).toBeNull();
 
     // Before B's messages commit, select C. THE BUG: this call read
     // prevId=conv-b but prevMessages=[draft greeting] and fired

--- a/packages/ui/src/state/useDataLoaders.conversation-cache.test.tsx
+++ b/packages/ui/src/state/useDataLoaders.conversation-cache.test.tsx
@@ -126,6 +126,36 @@ describe("useDataLoaders — conversation message prefetch cache", () => {
     expect(mocks.client.getConversationMessages).toHaveBeenCalledTimes(1);
   });
 
+  it("clears stale messages immediately when loading an uncached conversation", async () => {
+    let resolveConvB: ((m: ConversationMessage[]) => void) | undefined;
+    mocks.client.getConversationMessages.mockImplementation(
+      (id: string) =>
+        new Promise((resolve) => {
+          if (id === "conv-b") {
+            resolveConvB = (m) => resolve({ messages: m });
+          }
+        }),
+    );
+    const { deps, setConversationMessages, conversationMessagesRef } =
+      makeDeps();
+    conversationMessagesRef.current = [userMsg("old-thread")];
+    const { result } = renderHook(() => useDataLoaders(deps));
+
+    let loadPromise: Promise<unknown>;
+    act(() => {
+      loadPromise = result.current.loadConversationMessages("conv-b");
+    });
+
+    expect(setConversationMessages).toHaveBeenCalledWith([]);
+    expect(conversationMessagesRef.current).toEqual([]);
+
+    await act(async () => {
+      resolveConvB?.([userMsg("new-thread")]);
+      await loadPromise;
+    });
+    expect(conversationMessagesRef.current).toEqual([userMsg("new-thread")]);
+  });
+
   it("a newer load aborts the prior in-flight one so a stale fetch never wins", async () => {
     const resolvers: Record<string, (m: ConversationMessage[]) => void> = {};
     mocks.client.getConversationMessages.mockImplementation(

--- a/packages/ui/src/state/useDataLoaders.ts
+++ b/packages/ui/src/state/useDataLoaders.ts
@@ -350,6 +350,15 @@ export function useDataLoaders(deps: DataLoadersDeps) {
         conversationMessagesRef.current = cached;
         loadedConversationIdRef.current = convId;
         setConversationMessages(cached);
+      } else if (loadedConversationIdRef.current !== convId) {
+        // No cache means the visible transcript still belongs to the previous
+        // active conversation until the fetch resolves. Clear it immediately so
+        // the home overlay cannot render old-room context under the newly
+        // selected conversation while the network request is in flight.
+        greetingFiredRef.current = false;
+        conversationMessagesRef.current = [];
+        loadedConversationIdRef.current = null;
+        setConversationMessages([]);
       }
 
       try {


### PR DESCRIPTION
## Summary
- clear the active transcript immediately when switching to an uncached conversation
- keep cached neighbor switches instant, and mark the live message holder unknown while the new fetch is in flight
- update rapid-switch coverage so the old draft-deletion guard still passes with the cleared interim state

## Diagnosis
Interpretation A was real. ContinuousChatOverlay reads the shared conversationMessages context, which is hydrated by useDataLoaders.loadConversationMessages. On an uncached conversation switch, loadConversationMessages aborted the previous fetch but left conversationMessagesRef/current context pointing at the previous room until the new network response committed, so the home overlay rendered old-room context under the newly selected conversation.

Interpretation B was not the primary issue in this lane. I checked the agent-side context paths enough to identify a separate open PR, #15091, touching evaluator room/entity context, but Shadow's PWA home overlay symptom maps directly to the UI stale-store path fixed here.

## Evidence
| Row | Evidence |
|---|---|
| Before screenshots | N/A - state-store bug; failing test demonstrates stale previous-room messages before fix. |
| After screenshots | N/A - no visual surface changed; UI now clears messages immediately on uncached conversation switch, covered by test. |
| Walkthrough video | N/A - non-visual chat state isolation fix; deterministic unit coverage is the proof. |
| Backend logs | N/A - frontend state leak only; no backend route or server logs involved. |
| Frontend console/network logs | N/A - no runtime console/network error; bug was stale in-memory store state during an in-flight fetch. |
| Real-LLM trajectory | N/A - no model call path changed; this fixes which cached UI transcript is rendered while loading. |
| Domain artifacts | N/A - no domain-specific artifact. |
| OCR visual text review | N/A - no visual copy/layout change; state isolation tested directly. |

## Tests
- `bun run --cwd packages/core prebuild`
- `cd packages/ui && bunx vitest run src/state/useDataLoaders.conversation-cache.test.tsx`
- `cd packages/ui && bunx vitest run src/state/useChatCallbacks.select-race.test.tsx src/state/useDataLoaders.conversation-cache.test.tsx`
- `bunx biome check packages/ui/src/state/useDataLoaders.ts packages/ui/src/state/useDataLoaders.conversation-cache.test.tsx packages/ui/src/state/useChatCallbacks.select-race.test.tsx`

## Review
- `codex review --uncommitted` attempted. It inspected the diff, then its internal test attempt hit an EACCES writing packages/ui/node_modules/.vite-temp from the symlinked node_modules. I self-reviewed the changed paths and ran the targeted tests above successfully.

[sol-orch]

Co-authored-by: wakesync <shadow@shad0w.xyz>