### PR TITLE
fix(ci): preserve engine-specific zero-key commands

### DIFF
--- a/packages/scripts/__tests__/ci-zero-key-command-ownership-contract.test.ts
+++ b/packages/scripts/__tests__/ci-zero-key-command-ownership-contract.test.ts
@@ -138,7 +138,7 @@ describe("ci-zero-key-command-ownership-contract", () => {
     );
   });
 
-  test("normalizes leading env assignments before ownership checks", () => {
+  test("normalizes non-semantic leading env assignments before ownership checks", () => {
     withRepo(
       {
         "scenario-pr.yml": workflow({
@@ -158,6 +158,38 @@ describe("ci-zero-key-command-ownership-contract", () => {
         expect(() => runContract(root)).toThrow(
           /Duplicate zero-key command ownership/,
         );
+      },
+    );
+  });
+
+  test("keeps engine selector env assignments when they define distinct browser legs", () => {
+    withRepo(
+      {
+        "ui-fixture-e2e.yml": workflow({
+          name: "UI fixture",
+          jobName: "Zero-Key UI fixture",
+          commands: [
+            "bun run --cwd packages/ui test:chat-infinite-scroll-e2e",
+            "ENGINE=webkit bun run --cwd packages/ui test:chat-infinite-scroll-e2e",
+          ],
+        }),
+      },
+      (root) => {
+        const rows = collectZeroKeyCommands(root);
+        expect(rows).toContainEqual(
+          expect.objectContaining({
+            workflow: ".github/workflows/ui-fixture-e2e.yml",
+            command: "bun run --cwd packages/ui test:chat-infinite-scroll-e2e",
+          }),
+        );
+        expect(rows).toContainEqual(
+          expect.objectContaining({
+            workflow: ".github/workflows/ui-fixture-e2e.yml",
+            command:
+              "ENGINE=webkit bun run --cwd packages/ui test:chat-infinite-scroll-e2e",
+          }),
+        );
+        expect(findDuplicateOwnedCommands(rows)).toEqual([]);
       },
     );
   });

--- a/packages/scripts/ci-zero-key-command-ownership-contract.mjs
+++ b/packages/scripts/ci-zero-key-command-ownership-contract.mjs
@@ -53,8 +53,11 @@ const STATIC_DELEGATION_JOBS = new Set([
 const ALLOWED_DUPLICATE_COMMANDS = new Set([
   "node packages/app-core/scripts/ensure-shared-i18n-data.mjs",
   "bunx playwright install --with-deps chromium",
+  "bunx playwright install --with-deps chromium webkit",
   "node packages/scripts/ci-zero-key-command-ownership-contract.mjs",
 ]);
+
+const OWNERSHIP_RELEVANT_ENV = new Set(["ENGINE"]);
 
 function assert(condition, message) {
   if (!condition) throw new Error(message);
@@ -70,13 +73,21 @@ function stripInlineComment(line) {
 
 function stripLeadingEnvAssignments(line) {
   let command = line.trim();
+  const preserved = [];
   if (command.startsWith("env ")) {
     command = command.slice(4).trimStart();
   }
   for (;;) {
-    const next = command.replace(LEADING_ENV_ASSIGNMENT, "").trimStart();
-    if (next === command) return command;
-    command = next;
+    const match = command.match(LEADING_ENV_ASSIGNMENT);
+    if (!match) {
+      return preserved.length > 0
+        ? `${preserved.join(" ")} ${command}`.trim()
+        : command;
+    }
+    const assignment = match[0].trim();
+    const name = assignment.slice(0, assignment.indexOf("="));
+    if (OWNERSHIP_RELEVANT_ENV.has(name)) preserved.push(assignment);
+    command = command.slice(match[0].length).trimStart();
   }
 }
 
@@ -84,6 +95,10 @@ function normalizeCommand(line) {
   return stripLeadingEnvAssignments(stripInlineComment(line))
     .replace(/\s+/g, " ")
     .trim();
+}
+
+function commandExecutable(command) {
+  return command.replace(LEADING_ENV_ASSIGNMENT, "").trimStart();
 }
 
 function extractJobBlocks(workflowText) {
@@ -137,7 +152,7 @@ function extractCommands(jobText) {
       const command = normalizeCommand(rawLine);
       if (!command || command.startsWith("#")) continue;
       if (IGNORED_LINE.test(command)) continue;
-      if (!COMMAND_PREFIX.test(command)) continue;
+      if (!COMMAND_PREFIX.test(commandExecutable(command))) continue;
       commands.push(command);
     }
   }


### PR DESCRIPTION
## Summary
- fixes the zero-key ownership contract false-positive on distinct `ENGINE=webkit` browser legs
- allows the shared Chromium+WebKit Playwright install as setup, matching current fixture usage
- adds regression coverage for engine-specific command ownership

## Tests
- `node packages/scripts/ci-zero-key-command-ownership-contract.mjs`
- `bun test packages/scripts/__tests__/ci-zero-key-command-ownership-contract.test.ts`
- `codex review --uncommitted`

[sol-orch] ci-medic