### PR TITLE
fix(cloud): agent provisioning broken on all nodes by dash '&;' syntax error in pre-pull command

### DIFF
--- a/packages/cloud/shared/src/lib/services/docker-node-manager-prepull-self-heal.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager-prepull-self-heal.test.ts
@@ -94,6 +94,16 @@ describe("tracked pre-pull commands", () => {
     expect(tracked.command).toContain("printf");
   });
 
+  test("tracked pre-pull script is dash-parseable: no '&;' from joining after the backgrounded pull", () => {
+    const tracked = buildTrackedPrePullCommand(IMAGE, "linux/amd64", "test-marker");
+
+    // Regression: joining the script lines with "; " turned `(docker pull …) &`
+    // into `&;`, a hard dash syntax error ("Syntax error: \";\" unexpected") —
+    // every pull/provision on a node failed at parse time.
+    expect(tracked.command).not.toContain("&;");
+    expect(tracked.command).not.toContain("& ;");
+  });
+
   test("builds a scoped reap command for only the recorded pre-pull PID", () => {
     const command = buildPrePullReapCommand(PID_FILE, IMAGE);
 
@@ -103,6 +113,8 @@ describe("tracked pre-pull commands", () => {
     expect(command).toContain(IMAGE);
     expect(command).toContain('kill -9 "$pid"');
     expect(command).not.toContain("pkill");
+    // Regression: "; "-joining `if …; then` yields `then;` (dash syntax error).
+    expect(command).not.toContain("then;");
   });
 
   test("builds a force recovery command for a daemon whose graceful restart hangs", () => {

--- a/packages/cloud/shared/src/lib/services/docker-node-manager.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-manager.ts
@@ -151,7 +151,11 @@ export function buildTrackedPrePullCommand(
     "status=$?",
     'rm -f "$pidfile"',
     'exit "$status"',
-  ].join("; ");
+    // Join with newlines, NOT "; ": one line ends in `&` (the backgrounded
+    // pull). The node's /bin/sh is dash, where `&` immediately followed by `;`
+    // ("&;") is a hard syntax error ("Syntax error: ";" unexpected"), so every
+    // pull would fail at parse time. Newlines are valid separators after `&`.
+  ].join("\n");
   return { command: `sh -c ${shellQuote(script)}`, pidFile };
 }
 
@@ -168,7 +172,9 @@ export function buildPrePullReapCommand(pidFile: string, image: string): string 
     "fi",
     'rm -f "$pidfile"',
     "fi",
-  ].join("; ");
+    // Newlines, NOT "; ": `if …; then` joined with "; " yields `then;`, which
+    // is a dash syntax error. Newlines compose correctly with if/case/&/fi.
+  ].join("\n");
   return `sh -c ${shellQuote(script)}`;
 }
 


### PR DESCRIPTION
## 🚨 Launch-blocker: no agent can provision (staging **and** prod)

`buildTrackedPrePullCommand` and `buildPrePullReapCommand` join their script lines with `"; "`. But:
- the tracked-pull script has a line ending in **`&`** (the backgrounded `docker pull`) → `"; "`-joining produces **`&;`**
- the reap has **`if …; then`** → joining produces **`then;`**

The node's `/bin/sh` is **dash**, where both are hard syntax errors:
```
sh: 1: Syntax error: ";" unexpected
```
So **every pull and provision command fails at parse time on the node → no agent can be provisioned.**

## Verified live
On staging, agent `85a07f11` (stuck `pending` 2 days) — clicked **Resume Agent** in the console → provision job failed → agent back to `pending`. Worker log, every pre-pull cycle:
```
[docker-node-manager] Agent image pre-pull failed {
  nodeId: 'eliza-core-95ea703e', image: 'ghcr.io/elizaos/eliza:develop',
  error: '[docker-ssh] Command exited with code 2 on 167.233.112.155: [stderr] sh: 1: Syntax error: ";" unexpected'
}
```
**`buildTrackedPrePullCommand` is also present in `main` (prod, `799a5a494`)** — same bug → prod provisioning is broken too. (Existing already-running agents keep working; *new* provision/wake fails.)

## Fix
Join with `"\n"` instead of `"; "` (newlines are valid statement separators after `&`, `then`, `case`, `fi`). Two builders fixed; the plain-command self-heal builder (no `&`/`if`) is left on `"; "`. Regression tests assert neither command contains `&;` or `then;`. **8 pass / 0 fail**, biome-clean.

## Deploy urgency
Needs to land on develop → staging, and be included in the next develop→main promote so prod can provision agents for the demo.