### PR TITLE
fix(orchestrator): unwrap DrizzleQueryError so the idempotent ADD COLUMN backfill is recognized

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-store-project-binding.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-store-project-binding.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { PGlite } from "@electric-sql/pglite";
+import { drizzle } from "drizzle-orm/pglite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { RuntimeDbTaskStore } from "../services/orchestrator-task-store.ts";
 
@@ -157,5 +158,33 @@ describe("task store project binding (real PGlite)", () => {
       ["proj-A"],
     );
     expect(rows.rows).toHaveLength(1);
+  });
+
+  it("initializes through a REAL drizzle adapter, where duplicate-column arrives wrapped in DrizzleQueryError", {
+    timeout: PGLITE_TIMEOUT,
+  }, async () => {
+    // On a fresh database the CREATE TABLE already includes project_id, so the
+    // idempotent ADD COLUMN backfill ALWAYS throws duplicate-column. Through a
+    // drizzle-backed adapter (the dev-server/pglite production path) that error
+    // arrives wrapped in DrizzleQueryError ("Failed query: …") with the real
+    // driver error on `cause`. If the store doesn't unwrap the cause chain,
+    // init caches a rejected promise and every orchestrator API call 500s.
+    const drizzleDb = drizzle(db);
+    const store = new RuntimeDbTaskStore({ db: drizzleDb });
+    const created = await store.createTask({
+      title: "born on drizzle",
+      goal: "g",
+      projectId: "proj-drizzle",
+    });
+    expect(created.task.title).toBe("born on drizzle");
+
+    const listed = await store.listTasks({ projectId: "proj-drizzle" });
+    expect(listed.map((t) => t.title)).toEqual(["born on drizzle"]);
+
+    // A second store over the same DB re-runs the migration (column now
+    // genuinely present) — the wrapped duplicate-column must be swallowed
+    // here too, not only on the fresh-table boot.
+    const store2 = new RuntimeDbTaskStore({ db: drizzleDb });
+    await expect(store2.getTask(created.task.id)).resolves.not.toBeNull();
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
@@ -106,14 +106,24 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function isDuplicateColumnError(error: unknown): boolean {
-  if (!isRecord(error)) return false;
-  if (error.code === "42701") return true;
-  const message =
-    typeof error.message === "string" ? error.message.toLowerCase() : "";
-  return (
-    message.includes("duplicate column") ||
-    /column .+ already exists/.test(message)
-  );
+  // Drizzle-backed adapters surface driver failures wrapped in
+  // DrizzleQueryError ("Failed query: …") with the real duplicate-column
+  // error on `cause`; without unwrapping, the idempotent ADD COLUMN in
+  // ensureInitialized rethrows on every boot and the cached-rejected init
+  // permanently 500s the orchestrator API on pglite/postgres runtimes.
+  for (let depth = 0; isRecord(error) && depth < 8; depth++) {
+    if (error.code === "42701") return true;
+    const message =
+      typeof error.message === "string" ? error.message.toLowerCase() : "";
+    if (
+      message.includes("duplicate column") ||
+      /column .+ already exists/.test(message)
+    ) {
+      return true;
+    }
+    error = error.cause;
+  }
+  return false;
 }
 
 /** Boundary guard for documents loaded from disk/JSON. A document must carry a


### PR DESCRIPTION
## Summary

Every `/api/orchestrator/*` route returns **500** on drizzle-backed runtimes (pglite/postgres — i.e. the dev server and every localdb install). Boot log shows:

```
Error #agent:Eliza [AGENT] [OrchestratorTask.rebuildAdmissionQueue] Failed query: ALTER TABLE orchestrator_tasks ADD COLUMN project_id TEXT
```

## Diagnosis

- On a **fresh** database, `TASK_TABLE_SQL` already creates `orchestrator_tasks` **with** `project_id`, so the #13776 idempotent backfill `ALTER TABLE … ADD COLUMN project_id` **always** throws duplicate-column — by design, and `ensureInitialized` swallows it via `isDuplicateColumnError`.
- But through the Eliza drizzle adapter path (`resolveSqlExecutor` → `adapter.db.execute`), drizzle-orm wraps the driver failure in `DrizzleQueryError` whose message is `Failed query: <sql>\nparams: <params>` with the real duplicate-column error on **`.cause`**.
- `isDuplicateColumnError` checked only the top-level error (`code === "42701"` / message patterns), never the cause chain → the wrapped error rethrew → `ensureInitialized` cached a **rejected** `initPromise` → every subsequent store call re-awaited the same rejection → permanent 500s.
- The existing regression test used a raw PGlite adapter where the driver error surfaces unwrapped — which is why it stayed green while the production path was broken.

## Fix

Walk the `cause` chain (bounded at 8 hops) in `isDuplicateColumnError` before deciding to rethrow.

## Tests — red/green proven

New test in `task-store-project-binding.test.ts` drives the store through a **real drizzle adapter over real PGlite** (`drizzle(pglite)` as `{ db }`), the exact production shape:

- **Without the fix**: `× initializes through a REAL drizzle adapter, where duplicate-column arrives wrapped in DrizzleQueryError` (1 failed | 2 passed)
- **With the fix**: `3 passed (3)`

## Live verification (real dev server, no mocks)

Before (develop): `GET /api/orchestrator/status` → `500 {"error":"Failed query: ALTER TABLE orchestrator_tasks ADD COLUMN project_id TEXT\nparams: "}`

After (this branch, rebuilt plugin, fresh boot):

```
GET /api/orchestrator/status → HTTP 200
{"taskCount":0,"activeTaskCount":0,...,"byStatus":{"open":0,...}}
GET /api/orchestrator/tasks → HTTP 200 {"tasks":[]}
grep -c "Failed query: ALTER TABLE" devserver3.log → 0
```

Frontend evidence: N/A — server-route fix; the UI consumer (orchestrator/cockpit views) goes from error-state to live data via the same endpoints shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)