### PR TITLE
fix(docker): drop stale plugin-shopify refs breaking the agent-image build

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -353,7 +353,6 @@
         "@capacitor/keyboard",
         "@capacitor/push-notifications",
         "@elizaos/plugin-personal-assistant",
-        "@elizaos/plugin-shopify",
         "@elizaos/plugin-browser",
         "@elizaos/plugin-discord",
         "@elizaos/plugin-local-inference",

--- a/packages/agent/tsconfig.json
+++ b/packages/agent/tsconfig.json
@@ -79,7 +79,6 @@
       "@elizaos/plugin-wifi": ["../../plugins/plugin-wifi/src/index.ts"],
       "@elizaos/app-core": ["../app-core/src/index.ts"],
       "@elizaos/app-core/*": ["../app-core/src/*"],
-      "@elizaos/plugin-shopify": ["../../plugins/plugin-shopify/src/index.ts"],
       "@elizaos/ui": ["../ui/src/index.ts"],
       "@elizaos/ui/*": ["../ui/src/*"],
       "@elizaos/import-conversations": ["../import-conversations/src/index.ts"],

--- a/packages/app-core/scripts/collect-docker-runtime-deps.mjs
+++ b/packages/app-core/scripts/collect-docker-runtime-deps.mjs
@@ -75,7 +75,6 @@ const LINKED_WORKSPACE_PACKAGES = [
   "plugins/plugin-personal-assistant",
   "plugins/plugin-task-coordinator",
   "plugins/plugin-training",
-  "plugins/plugin-shopify",
   "plugins/plugin-agent-skills",
   "plugins/plugin-app-manager",
   "plugins/plugin-browser",

--- a/packages/app-core/scripts/link-docker-local-app-packages.mjs
+++ b/packages/app-core/scripts/link-docker-local-app-packages.mjs
@@ -46,7 +46,6 @@ const localPackages = [
   "eliza/plugins/plugin-personal-assistant",
   "eliza/plugins/plugin-task-coordinator",
   "eliza/plugins/plugin-training",
-  "eliza/plugins/plugin-shopify",
   "eliza/packages/app-core",
   "eliza/packages/cloud/sdk",
   "eliza/packages/shared",


### PR DESCRIPTION
## Root cause

`Build Agent Image` on main fails deterministically (run 28813140979): `link-docker-local-app-packages.mjs` lists `eliza/plugins/plugin-shopify` but the plugin no longer exists on develop or main — the docker build dies with `Error: Missing local package manifest: eliza/plugins/plugin-shopify/package.json`. This is one of the pieces keeping dedicated-agent provisioning on pre-promote code tonight.

## Fix

Remove the ghost refs from all 4 build-path files (link list, runtime-deps list, knip config, agent tsconfig paths). Validated **every remaining entry** in both docker lists resolves to a real `package.json` on develop — no other ghost entries exist. Remaining `plugin-shopify` mentions in the repo are doc-examples (plugin-manager action samples) and a benchmark budget entry — not on the build path.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - docker build config only; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - docker build config only; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - the verifiable artifact is the agent-image build; failing run 28813140979 shows the exact error this removes.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: failing build log https://github.com/elizaOS/eliza/actions/runs/28813140979 — `#20 1.039 Error: Missing local package manifest: eliza/plugins/plugin-shopify/package.json` → `buildx failed`. Post-merge the next main promote rebuilds the image without the ghost entry.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend involved.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent/action/prompt/model behavior change; build config only.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: entry-validation sweep output posted at https://github.com/elizaOS/eliza/pull/15125#issuecomment-4897317307 — 38 entries in the link list checked, exactly one missing (`eliza/plugins/plugin-shopify`); after the fix 37+36 entries all resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

