### PR TITLE
fix(docker): drop stale plugin-shopify from the local-app linker list

### DIFF
--- a/packages/app-core/scripts/link-docker-local-app-packages.mjs
+++ b/packages/app-core/scripts/link-docker-local-app-packages.mjs
@@ -46,7 +46,6 @@ const localPackages = [
   "eliza/plugins/plugin-personal-assistant",
   "eliza/plugins/plugin-task-coordinator",
   "eliza/plugins/plugin-training",
-  "eliza/plugins/plugin-shopify",
   "eliza/packages/app-core",
   "eliza/packages/cloud/sdk",
   "eliza/packages/shared",


### PR DESCRIPTION
## Why

`plugins/plugin-shopify` no longer exists on develop, but `link-docker-local-app-packages.mjs:49` still hard-lists it. **Docker CI Smoke + Build Agent Image have been red on develop since ~17:20Z** failing on the missing path — this blocks agent/app image builds ahead of tonight's promote (run 28818824316 lineage). Surfaced + verified by the [maintainer] post-merge audit of the 18:36–19:49Z zero-approval merge wave (`git ls-tree origin/develop:plugins | grep shopify` → empty).

## Change

One line: remove the stale entry. The script's import smoke-runs clean locally (remaining warnings are the expected no-built-dist notes for core/contracts outside an image build).

## Evidence

| type | status |
|---|---|
| CI | The Docker CI Smoke lane on this PR is the test — it exercises the exact failing path. |
| screenshots/video | N/A - build-tooling one-liner, no UI surface |
| trajectories | N/A - no agent/model behavior change |
| logs | `ls-tree` proof above; develop red runs referenced |

Demo-relevant: unblocks the agent-image side of the ~21:30Z promote.

— [maintainer]