### PR TITLE
fix(ui-voice): wire configured ASR provider into PWA capture

### DIFF
--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -23,6 +23,7 @@ import type {
   ChatTurnStatus,
   ImageAttachment,
 } from "../../api/client-types-chat";
+import type { AsrProvider } from "../../api/client-types-config";
 import {
   VOICE_CONTROL_EVENT,
   type VoiceControlEventDetail,
@@ -379,6 +380,13 @@ export function useShellController(): ShellController {
   // `stopSpeaking` into a ref the clear/switch handlers can call at gesture time
   // without a definition-order/closure problem. Defaults to a no-op until wired.
   const stopSpeakingRef = React.useRef<() => void>(() => {});
+  // The resolved ASR provider is loaded by `voiceOutput` (useShellVoiceOutput)
+  // far below, but `startCapture` (which needs it to pick the STT backend) is
+  // defined above it. Mirror it into a ref at render time — same closure/order
+  // workaround as `stopSpeakingRef` — so capture reads the current provider at
+  // gesture time. `undefined` until the voice config first loads, which the
+  // capture factory treats as "local-inference-or-browser default".
+  const asrProviderRef = React.useRef<AsrProvider | undefined>(undefined);
   // Guards the capture-failure notice so the hands-free re-listen loop's retries
   // (which re-call startCapture every ~250ms) don't spam the toast; cleared on
   // the next successful start so a later failure re-notifies.
@@ -832,6 +840,15 @@ export function useShellController(): ShellController {
       // configured sensitivity. Only consumed by the local-inference backend.
       const handle = createVoiceCapture({
         localAsrAutoStop: loadVadAutoStop(),
+        // Route to the configured STT backend. Without this the factory only
+        // ever saw `undefined` and could never select the `eliza-cloud` /
+        // `openai` cloud STT path — on a cloud box with no local ASR assets it
+        // silently fell through to browser SpeechRecognition instead of
+        // `/api/asr/cloud`. Passing the resolved provider makes the documented
+        // cloud default reachable from the ambient/hands-free capture surface.
+        ...(asrProviderRef.current
+          ? { asrProvider: asrProviderRef.current }
+          : {}),
         // Push-to-talk dictation ends on release, so the native recognizer must
         // commit its running interim as the final turn even if its silence
         // window hasn't fired. Converse stops only on toggle-off, where a
@@ -1057,6 +1074,7 @@ export function useShellController(): ShellController {
   // Wire the forward ref so the conversation-switch / clear handlers (defined
   // above `voiceOutput`) can stop in-flight assistant speech at gesture time.
   stopSpeakingRef.current = voiceOutput.stopSpeaking;
+  asrProviderRef.current = voiceOutput.asrProvider;
 
   // `recording` (push-to-talk press or continuous capture) wins over an
   // in-flight response so the pill shows the red "listening" pulse the instant

--- a/packages/ui/src/components/shell/useShellVoiceOutput.test.tsx
+++ b/packages/ui/src/components/shell/useShellVoiceOutput.test.tsx
@@ -9,7 +9,13 @@ import type { ConversationMessage } from "../../api/client-types-chat";
 const hoisted = vi.hoisted(() => ({
   queueAssistantSpeech: vi.fn(),
   stopSpeaking: vi.fn(),
-  cfg: { isSpeaking: false, voiceBootstrapTick: 1 },
+  cfg: {
+    isSpeaking: false,
+    voiceBootstrapTick: 1,
+    // Full voice config the useVoiceConfig mock returns; tests vary `asr` to
+    // check the hook surfaces the resolved ASR provider for the capture path.
+    voiceConfig: { provider: "local-inference" } as Record<string, unknown>,
+  },
 }));
 
 // The single TTS engine — mocked to capture the output calls the overlay makes.
@@ -36,7 +42,7 @@ vi.mock("../../hooks/useVoiceChat", () => ({
 
 vi.mock("../../voice/useVoiceConfig", () => ({
   useVoiceConfig: () => ({
-    voiceConfig: { provider: "local-inference" },
+    voiceConfig: hoisted.cfg.voiceConfig,
     voiceBootstrapTick: hoisted.cfg.voiceBootstrapTick,
     reloadVoiceConfig: () => {},
   }),
@@ -86,6 +92,7 @@ beforeEach(() => {
   hoisted.stopSpeaking.mockClear();
   hoisted.cfg.isSpeaking = false;
   hoisted.cfg.voiceBootstrapTick = 1;
+  hoisted.cfg.voiceConfig = { provider: "local-inference" };
 });
 
 afterEach(cleanup);
@@ -301,6 +308,25 @@ describe("useShellVoiceOutput", () => {
     hoisted.cfg.isSpeaking = true;
     const { result } = render(BASE);
     expect(result.current.speaking).toBe(true);
+  });
+
+  // Regression: the overlay's mic capture (useShellController → createVoiceCapture)
+  // reads the resolved ASR provider from here. Without it the factory only ever
+  // saw `undefined` and could never reach the eliza-cloud / openai cloud STT
+  // path, silently degrading to local-inference-or-browser.
+  it("surfaces the resolved ASR provider from the voice config", () => {
+    hoisted.cfg.voiceConfig = {
+      provider: "eliza-cloud",
+      asr: { provider: "eliza-cloud" },
+    };
+    const { result } = render(BASE);
+    expect(result.current.asrProvider).toBe("eliza-cloud");
+  });
+
+  it("surfaces undefined ASR provider when the config has no asr block", () => {
+    hoisted.cfg.voiceConfig = { provider: "local-inference" };
+    const { result } = render(BASE);
+    expect(result.current.asrProvider).toBeUndefined();
   });
 
   // #8792: proactive interaction comments are text-only by default.

--- a/packages/ui/src/components/shell/useShellVoiceOutput.ts
+++ b/packages/ui/src/components/shell/useShellVoiceOutput.ts
@@ -4,6 +4,7 @@
  */
 import * as React from "react";
 
+import type { AsrProvider } from "../../api/client-types-config";
 import type { ConversationMessage } from "../../api/client-types-chat";
 import { useVoiceChat } from "../../hooks/useVoiceChat";
 import { useVoiceConfig } from "../../voice/useVoiceConfig";
@@ -42,6 +43,15 @@ export interface ShellVoiceOutput {
   needsAudioUnlock: boolean;
   /** Resume the audio context in response to a user gesture (enable sound). */
   unlockAudio: () => void;
+  /**
+   * The resolved speech-to-text provider from the loaded voice config, or
+   * `undefined` while the config has not loaded yet. Surfaced so the overlay's
+   * mic capture ({@link useShellController} → {@link createVoiceCapture}) can
+   * route to the SAME backend the config selects — without it the factory only
+   * ever saw `undefined` and could never reach the `eliza-cloud` / `openai`
+   * cloud STT path, silently degrading to local-inference-or-browser instead.
+   */
+  asrProvider: AsrProvider | undefined;
 }
 
 export interface ShellVoiceOutputOptions {
@@ -181,5 +191,6 @@ export function useShellVoiceOutput(
     // coalesce to keep this hook's (and ShellController's) non-optional contract.
     needsAudioUnlock: needsAudioUnlock ?? false,
     unlockAudio: unlockAudio ?? (() => {}),
+    asrProvider: voiceConfig.asr?.provider,
   };
 }

--- a/packages/ui/src/hooks/useVoiceChat.cloud-asr.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.cloud-asr.test.tsx
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchWithCsrf } from "../api/csrf-client";
+import {
+  isLocalAsrCaptureSupported,
+  startLocalAsrRecorder,
+} from "../voice/local-asr-capture";
+import { useVoiceChat } from "./useVoiceChat";
+
+vi.mock("../api/csrf-client", () => ({
+  fetchWithCsrf: vi.fn(),
+}));
+
+vi.mock("../voice/local-asr-capture", () => ({
+  isLocalAsrCaptureSupported: vi.fn(),
+  startLocalAsrRecorder: vi.fn(),
+}));
+
+const fetchWithCsrfMock = vi.mocked(fetchWithCsrf);
+const isLocalAsrCaptureSupportedMock = vi.mocked(isLocalAsrCaptureSupported);
+const startLocalAsrRecorderMock = vi.mocked(startLocalAsrRecorder);
+
+/**
+ * Regression guard for the cloud STT wiring gap: an `eliza-cloud` / `openai`
+ * voice config used to fall straight through to the browser SpeechRecognition
+ * engine in the chat composer (`useVoiceChat` only branched local-inference vs
+ * browser), so the documented cloud transcriber (`/api/asr/cloud`) was never
+ * reached from the PWA. These tests lock the composer capture to the cloud
+ * proxy when the config selects a cloud provider.
+ */
+describe("useVoiceChat cloud ASR", () => {
+  beforeEach(() => {
+    isLocalAsrCaptureSupportedMock.mockReturnValue(true);
+    // The cloud path never probes /api/asr/local-inference/status; the only
+    // request it makes is the WAV POST to /api/asr/cloud, which returns { text }.
+    fetchWithCsrfMock.mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : String(input);
+      if (url.includes("/api/asr/cloud")) {
+        return new Response(JSON.stringify({ text: "hello cloud voice" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      // Any other endpoint (e.g. a stray local-inference status probe) would be
+      // a regression — surface it as a 404 so the assertions below catch it.
+      return new Response("unexpected endpoint", { status: 404 });
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("records a WAV and POSTs it to /api/asr/cloud for an eliza-cloud config", async () => {
+    const stop = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3, 4]));
+    startLocalAsrRecorderMock.mockResolvedValue({
+      stop,
+      cancel: vi.fn(),
+      analyser: null,
+    });
+    const onTranscript = vi.fn();
+
+    const { result } = renderHook(() =>
+      useVoiceChat({
+        onTranscript,
+        voiceConfig: {
+          provider: "eliza-cloud",
+          asr: { provider: "eliza-cloud" },
+        },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.startListening("push-to-talk");
+    });
+    await act(async () => {
+      await result.current.stopListening({ submit: true });
+    });
+
+    // The WAV recorder is the capture engine — NOT browser SpeechRecognition.
+    expect(startLocalAsrRecorderMock).toHaveBeenCalledTimes(1);
+    expect(stop).toHaveBeenCalledTimes(1);
+
+    // The recorded WAV is POSTed to the cloud proxy as raw audio/wav bytes.
+    expect(fetchWithCsrfMock).toHaveBeenCalledWith(
+      "/api/asr/cloud",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "Content-Type": "audio/wav",
+          Accept: "application/json",
+        }),
+      }),
+    );
+    // It must NOT have consulted the local-inference readiness/transcribe route.
+    expect(fetchWithCsrfMock).not.toHaveBeenCalledWith(
+      "/api/asr/local-inference/status",
+      expect.anything(),
+    );
+    expect(fetchWithCsrfMock).not.toHaveBeenCalledWith(
+      "/api/asr/local-inference",
+      expect.anything(),
+    );
+
+    // The cloud transcript is delivered as the final turn, tagged `cloud`.
+    expect(onTranscript).toHaveBeenCalledWith(
+      "hello cloud voice",
+      expect.objectContaining({
+        isFinal: true,
+        turn: expect.objectContaining({ source: "cloud" }),
+      }),
+    );
+  });
+
+  it("routes an openai ASR config through the same cloud proxy", async () => {
+    startLocalAsrRecorderMock.mockResolvedValue({
+      stop: vi.fn().mockResolvedValue(new Uint8Array([9, 9])),
+      cancel: vi.fn(),
+      analyser: null,
+    });
+    const onTranscript = vi.fn();
+
+    const { result } = renderHook(() =>
+      useVoiceChat({
+        onTranscript,
+        voiceConfig: {
+          provider: "eliza-cloud",
+          asr: { provider: "openai" },
+        },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.startListening("compose");
+    });
+    await act(async () => {
+      await result.current.stopListening({ submit: true });
+    });
+
+    expect(startLocalAsrRecorderMock).toHaveBeenCalledTimes(1);
+    expect(fetchWithCsrfMock).toHaveBeenCalledWith(
+      "/api/asr/cloud",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(onTranscript).toHaveBeenCalledWith(
+      "hello cloud voice",
+      expect.objectContaining({
+        isFinal: true,
+        turn: expect.objectContaining({ source: "cloud" }),
+      }),
+    );
+  });
+
+  it("does not submit a turn when the cloud proxy fails (no silent browser downgrade)", async () => {
+    startLocalAsrRecorderMock.mockResolvedValue({
+      stop: vi.fn().mockResolvedValue(new Uint8Array([1])),
+      cancel: vi.fn(),
+      analyser: null,
+    });
+    fetchWithCsrfMock.mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : String(input);
+      if (url.includes("/api/asr/cloud")) {
+        return new Response("cloud down", { status: 502 });
+      }
+      return new Response("unexpected endpoint", { status: 404 });
+    });
+    const onTranscript = vi.fn();
+
+    const { result } = renderHook(() =>
+      useVoiceChat({
+        onTranscript,
+        voiceConfig: {
+          provider: "eliza-cloud",
+          asr: { provider: "eliza-cloud" },
+        },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.startListening("push-to-talk");
+    });
+    // The stop-time transcribe swallows the error (logs it) and simply does not
+    // emit a final — the capture engine is still the cloud recorder, never a
+    // browser-final substitute.
+    await act(async () => {
+      await result.current.stopListening({ submit: true });
+    });
+
+    expect(fetchWithCsrfMock).toHaveBeenCalledWith(
+      "/api/asr/cloud",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(onTranscript).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -48,6 +48,7 @@ import {
 } from "../voice/local-asr-capture";
 import {
   isLocalInferenceAsrReady,
+  transcribeCloudWav,
   transcribeLocalInferenceWav,
 } from "../voice/local-asr-transcribe";
 import {
@@ -193,6 +194,19 @@ function shouldUseLocalInferenceAsr(config: VoiceConfig | null): boolean {
   return config?.asr?.provider === "local-inference";
 }
 
+/**
+ * True when the config selects a cloud STT provider (`eliza-cloud` / `openai`).
+ * These capture the same WAV as the local path and POST it to `/api/asr/cloud`
+ * (the agent's cloud STT proxy) — the deterministic cloud transcriber, NOT the
+ * engine-dependent browser recognizer. Without this branch a `eliza-cloud`
+ * config silently fell through to browser SpeechRecognition, which is the wrong
+ * transcriber (and unreliable / absent on iOS PWA).
+ */
+function shouldUseCloudAsr(config: VoiceConfig | null): boolean {
+  const provider = config?.asr?.provider;
+  return provider === "eliza-cloud" || provider === "openai";
+}
+
 const ACTIVE_VOICE_SESSION_MODES = new Set<Exclude<VoiceSessionMode, "idle">>([
   "compose",
   "push-to-talk",
@@ -271,7 +285,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
   const recognitionRef = useRef<SpeechRecognitionInstance | null>(null);
   const localAsrRecorderRef = useRef<LocalAsrRecorder | null>(null);
   const sttBackendRef = useRef<
-    "browser" | "local-inference" | "talkmode" | null
+    "browser" | "local-inference" | "cloud" | "talkmode" | null
   >(null);
   const talkModeHandlesRef = useRef<PluginListenerHandle[]>([]);
   // In-flight talk-mode listener registration. talkModeHandlesRef is only
@@ -505,6 +519,18 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         shouldUseLocalInferenceAsr(voiceConfigRef.current) &&
         isLocalAsrCaptureSupported();
       if (localAsrSupported) {
+        if (!cancelled) {
+          setSupported(true);
+        }
+        return;
+      }
+      // Cloud STT (`eliza-cloud` / `openai`) records the same WAV as the local
+      // path, so voice is supported whenever WAV capture primitives exist —
+      // independent of the browser SpeechRecognition engine (absent on iOS PWA).
+      const cloudAsrSupported =
+        shouldUseCloudAsr(voiceConfigRef.current) &&
+        isLocalAsrCaptureSupported();
+      if (cloudAsrSupported) {
         if (!cancelled) {
           setSupported(true);
         }
@@ -794,6 +820,13 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
     [],
   );
 
+  const transcribeCloudAudio = useCallback(
+    async (audio: Uint8Array, signal?: AbortSignal): Promise<string> => {
+      return transcribeCloudWav(audio, { signal });
+    },
+    [],
+  );
+
   const startLocalInferenceRecognition = useCallback(
     async (mode: Exclude<VoiceCaptureMode, "idle">) => {
       if (!shouldUseLocalInferenceAsr(voiceConfigRef.current)) {
@@ -813,6 +846,40 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         const recorder = await startLocalAsrRecorder();
         localAsrRecorderRef.current = recorder;
         sttBackendRef.current = "local-inference";
+        enabledRef.current = true;
+        listeningModeRef.current = mode;
+        setSupported(true);
+        setCaptureMode(mode);
+        setIsListening(true);
+        return true;
+      } catch {
+        localAsrRecorderRef.current = null;
+        return false;
+      }
+    },
+    [],
+  );
+
+  // Cloud STT: capture the SAME mono PCM16 WAV as the local-inference path and
+  // POST it to `/api/asr/cloud` on stop (see stopListening). This is the real
+  // transcriber for the `eliza-cloud` / `openai` config default — the browser
+  // recognizer is engine-dependent (and unreliable/absent on iOS PWA), so a
+  // cloud config must not fall through to it. Reuses `localAsrRecorderRef` for
+  // the mic recorder; `sttBackendRef` = "cloud" routes the stop-time transcribe.
+  const startCloudRecognition = useCallback(
+    async (mode: Exclude<VoiceCaptureMode, "idle">) => {
+      if (!shouldUseCloudAsr(voiceConfigRef.current)) {
+        return false;
+      }
+      // No WAV capture primitives (no getUserMedia / AudioContext) → there is no
+      // WAV to POST; defer to the browser recognizer as the sole client option.
+      if (!isLocalAsrCaptureSupported()) {
+        return false;
+      }
+      try {
+        const recorder = await startLocalAsrRecorder();
+        localAsrRecorderRef.current = recorder;
+        sttBackendRef.current = "cloud";
         enabledRef.current = true;
         listeningModeRef.current = mode;
         setSupported(true);
@@ -1016,6 +1083,15 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         return;
       }
 
+      // Cloud STT (`eliza-cloud` / `openai`): the deterministic transcriber for
+      // that config default. Selected ahead of talk-mode/browser so a cloud
+      // config on the PWA records a WAV for `/api/asr/cloud` instead of falling
+      // through to the engine-dependent browser recognizer.
+      const cloudStarted = await startCloudRecognition(mode);
+      if (cloudStarted) {
+        return;
+      }
+
       if (shouldPreferNativeTalkMode()) {
         const started = await startTalkModeRecognition(mode);
         if (started) {
@@ -1027,6 +1103,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
     },
     [
       startBrowserRecognition,
+      startCloudRecognition,
       startLocalInferenceRecognition,
       startTalkModeRecognition,
     ],
@@ -1070,6 +1147,31 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
             });
           }
         }
+      } else if (sttBackendRef.current === "cloud") {
+        // Symmetric with local-inference: stop the recorder, POST the WAV to
+        // `/api/asr/cloud`, and apply the returned transcript. A cloud failure
+        // is logged (fail-loud, no silent downgrade to browser STT) so the turn
+        // just doesn't submit rather than being transcribed by the wrong engine.
+        const recorder = localAsrRecorderRef.current;
+        localAsrRecorderRef.current = null;
+        if (recorder) {
+          try {
+            const audio = await recorder.stop();
+            const transcript = await transcribeCloudAudio(audio);
+            applyTranscriptUpdate(transcript, true, {
+              mode:
+                normalizeActiveVoiceSessionMode(mode) ??
+                normalizeActiveVoiceSessionMode(listeningModeRef.current) ??
+                "compose",
+              source: "cloud",
+              metadata: { source: "cloud" },
+            });
+          } catch (error) {
+            ttsDebug("asr:cloud:error", {
+              message: error instanceof Error ? error.message : String(error),
+            });
+          }
+        }
       } else {
         recognitionRef.current?.stop();
         await new Promise((resolve) =>
@@ -1079,7 +1181,12 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
 
       finalizeRecognition(submit);
     },
-    [applyTranscriptUpdate, finalizeRecognition, transcribeLocalInferenceAudio],
+    [
+      applyTranscriptUpdate,
+      finalizeRecognition,
+      transcribeCloudAudio,
+      transcribeLocalInferenceAudio,
+    ],
   );
 
   const toggleListening = useCallback(() => {


### PR DESCRIPTION
## What & why

The cloud STT path (record WAV → `POST /api/asr/cloud`) already exists and is fully unit-tested in `voice-capture-factory`, but **neither PWA capture surface could ever select it** — so on a cloud box with no local ASR assets (sol-dev), voice input silently degraded to browser `SpeechRecognition` (the wrong transcriber, unreliable/absent on iOS PWA) instead of using the configured cloud STT.

Two independent wiring gaps:

1. **Ambient/hands-free overlay** (`useShellController`) called `createVoiceCapture()` **without `asrProvider`**. The factory always saw `undefined` and resolved to local-inference-or-browser; the `eliza-cloud`/`openai` cloud branch was unreachable from this surface.
2. **Chat composer** (`useVoiceChat`) only branched local-inference vs browser `SpeechRecognition`. An `eliza-cloud`/`openai` config fell straight through to the browser recognizer — never `/api/asr/cloud`.

## Fix (wiring only — no new UX, no new provider stack)

- `useShellVoiceOutput` surfaces the resolved `asr.provider` from the loaded voice config.
- `useShellController` mirrors it into a render-time ref (same closure/order pattern as the existing `stopSpeakingRef`) and threads it into `createVoiceCapture`.
- `useVoiceChat` gains a `startCloudRecognition` sibling: records the **same WAV** as the local path and, on stop, POSTs it to `/api/asr/cloud` (fail-loud, no silent browser downgrade). Dispatched ahead of talk-mode/browser for cloud configs. Support detection now reports supported for cloud configs whenever WAV capture exists, independent of the browser engine (the iOS-PWA reliability point).

Symmetric with the established local-inference stop/transcribe path; `finalizeRecognition` / `resetListeningState` are backend-agnostic and already handle it.

## Scope guardrails

- No new buttons or voice product surfaces.
- No changes to `vite.config` / `index.html` / `turbo.json` / `bun.lock`.
- Only `packages/ui/src/{hooks/useVoiceChat.ts, components/shell/useShellVoiceOutput.ts, components/shell/useShellController.ts}` + tests.
- No collision with open voice PRs (#15108 touches header mic, not these files).

## Evidence

| Check | Result |
|---|---|
| `useVoiceChat.cloud-asr.test.tsx` (new) — eliza-cloud/openai record WAV → POST `/api/asr/cloud`, never browser SR / local-inference; transcript `source=cloud`; cloud failure submits nothing | ✅ 3/3 pass |
| `useShellVoiceOutput.test.tsx` — hook surfaces resolved `asr.provider` (+ undefined when no asr block) | ✅ 13/13 pass |
| `voice-capture-factory.test.ts` (unchanged) — cloud factory path still green | ✅ 13/13 pass |
| `useVoiceChat.local-asr.test.tsx` (unchanged) — no local-inference regression | ✅ 2/2 pass |
| `useShellController.test.tsx` + bidirectional + fail-closed | ✅ 65/65 pass |
| `tsc -p packages/ui` — zero errors in changed files (all 39 pre-existing errors are unrelated third-party-dep module-resolution noise: `pg`/`stripe`/`marked`/`esbuild` in cloud/tui/e2e tooling) | ✅ clean for touched files |
| Visual/UI screenshot | N/A — pure capture-selection/wiring logic, no rendered UI change |
| Live sol-dev device test | N/A — cannot drive a browser mic from CI/agent; Shadow to verify per readiness steps below |

## Required evidence rows

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: [UI fixture/check artifact](https://api.github.com/repos/elizaOS/eliza/actions/artifacts/8121092893/zip) from `https://github.com/elizaOS/eliza/actions/runs/28821696890`. If this PR has no rendered delta, artifact documents the checked surface before/without visual changes.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: [UI fixture/check artifact](https://api.github.com/repos/elizaOS/eliza/actions/artifacts/8121092893/zip) from `https://github.com/elizaOS/eliza/actions/runs/28821696890`. If this PR has no rendered delta, artifact documents the checked surface after/without visual changes.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: [UI fixture/check artifact](https://api.github.com/repos/elizaOS/eliza/actions/artifacts/8121092893/zip) from `https://github.com/elizaOS/eliza/actions/runs/28821696890` (Playwright trace/media bundle or CI visual artifact when available).

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no backend runtime path changed by this PR, or covered by deterministic CI checks`.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: [UI fixture/check artifact](https://api.github.com/repos/elizaOS/eliza/actions/artifacts/8121092893/zip) from `https://github.com/elizaOS/eliza/actions/runs/28821696890`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - deterministic code/test change, no LLM call path changed`.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts / OCR visual text review: [aesthetic-audit run](https://github.com/elizaOS/eliza/actions/runs/28821696867) plus [UI fixture/check artifact](https://api.github.com/repos/elizaOS/eliza/actions/artifacts/8121092893/zip). No visible text/UI change if this is logic-only UI-package wiring.

## sol-dev verification (Shadow)

1. Settings → Voice → set ASR/transcription provider to **Eliza Cloud** (or OpenAI).
2. In chat composer, hold mic (or use the ambient overlay), speak a phrase, release.
3. **Expected network:** a single `POST /api/asr/cloud` with `Content-Type: audio/wav` (NOT `/api/asr/local-inference/status`, NOT browser SpeechRecognition). Transcript lands in the composer / sends.
4. First likely blocker to report if it fails: whether `/api/asr/cloud` returns 2xx `{ text }` on sol-dev (i.e. the agent's cloud STT proxy → Eliza Cloud `/voice/stt` is actually reachable/authed on that box).

🤖 Generated with Sol (sol-orch lane)


## sol-dev verification (Shadow)

1. Settings → Voice → set ASR/transcription provider to **Eliza Cloud** (or OpenAI).
2. In chat composer, hold mic (or use the ambient overlay), speak a phrase, release.
3. **Expected network:** a single `POST /api/asr/cloud` with `Content-Type: audio/wav` (NOT `/api/asr/local-inference/status`, NOT browser SpeechRecognition). Transcript lands in the composer / sends.
4. First likely blocker to report if it fails: whether `/api/asr/cloud` returns 2xx `{ text }` on sol-dev (i.e. the agent's cloud STT proxy → Eliza Cloud `/voice/stt` is actually reachable/authed on that box).

🤖 Generated with Sol (sol-orch lane)