### PR TITLE
fix(cloud): fleet upgrade guard compares image repo not full ref — unblocks sha-pinned agents (#15101)

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-fleet-candidate-repo.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/agent-sandboxes-fleet-candidate-repo.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Fleet upgrade/rollback candidate selection matches the default image by REPO,
+ * not by full ref (#15101), against the REAL Drizzle schema on in-process PGlite.
+ *
+ * The reconciler passes the current default ref (e.g. `…/eliza-agent:prod`).
+ * A fleet-managed agent may be running on any tag or digest of the same repo
+ * (`…:sha-abc`, `…@sha256:…`); comparing the full ref skipped those rows, so
+ * sha-pinned default agents never drifted back to the current default. These
+ * cases prove `imageRepoSql` normalization inside the candidate queries returns
+ * same-repo rows and still excludes a genuinely different (custom) repo.
+ *
+ * Harness mirrors `__tests__/agent-billing-reactivation.test.ts`: drizzle-kit
+ * `pushSchema` applies the exact DDL from the real schema objects to the same
+ * PGlite connection the repository queries through. Self-skips LOUDLY (never
+ * silently passes) when a shared non-PGlite Postgres is the ambient DATABASE_URL.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { sql } from "drizzle-orm";
+
+const AMBIENT_DATABASE_URL = process.env.DATABASE_URL ?? "";
+const CAN_USE_ISOLATED_PGLITE =
+  AMBIENT_DATABASE_URL === "" || AMBIENT_DATABASE_URL.startsWith("pglite");
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+process.env.MOCK_REDIS = "1";
+
+import { pushSchema } from "drizzle-kit/api";
+import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
+import { sqlRows } from "../../execute-helpers";
+import { agentSandboxes } from "../../schemas/agent-sandboxes";
+import { organizations } from "../../schemas/organizations";
+import { userCharacters } from "../../schemas/user-characters";
+import { users } from "../../schemas/users";
+import { AgentSandboxesRepository } from "../agent-sandboxes";
+
+const PGLITE_TIMEOUT = 60_000;
+let pgliteReady = true;
+
+const DEFAULT_REPO = "ghcr.io/elizaos/eliza-agent";
+const DEFAULT_IMAGE = `${DEFAULT_REPO}:prod`;
+const CUSTOM_IMAGE = "ghcr.io/acme/custom-agent:prod";
+
+let seq = 0;
+function uniq(prefix: string): string {
+  seq += 1;
+  return `${prefix}-${seq}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+const repo = new AgentSandboxesRepository();
+
+async function seedOrgAndUser(): Promise<{ organizationId: string; userId: string }> {
+  const [org] = await dbWrite
+    .insert(organizations)
+    .values({ name: "Fleet Org", slug: uniq("org") })
+    .returning();
+  const [user] = await dbWrite
+    .insert(users)
+    .values({ steward_user_id: uniq("steward"), organization_id: org.id })
+    .returning();
+  return { organizationId: org.id, userId: user.id };
+}
+
+/**
+ * Seed a running, fleet-container agent (node_id + container_name set, no pool)
+ * on a specific docker_image/image_digest so the candidate queries can select it.
+ */
+async function seedFleetAgent(
+  organizationId: string,
+  userId: string,
+  fields: {
+    dockerImage: string | null;
+    imageDigest: string | null;
+    previousImageDigest?: string | null;
+  },
+): Promise<string> {
+  const [row] = await dbWrite
+    .insert(agentSandboxes)
+    .values({
+      organization_id: organizationId,
+      user_id: userId,
+      agent_name: uniq("agent"),
+      status: "running",
+      execution_tier: "dedicated-always",
+      node_id: uniq("node"),
+      container_name: uniq("container"),
+      docker_image: fields.dockerImage,
+      image_digest: fields.imageDigest,
+      previous_image_digest: fields.previousImageDigest ?? null,
+    })
+    .returning();
+  return row.id;
+}
+
+beforeAll(async () => {
+  if (!CAN_USE_ISOLATED_PGLITE) {
+    pgliteReady = false;
+    console.warn(
+      "[agent-sandboxes-fleet-candidate-repo.test] DATABASE_URL is a non-PGlite Postgres (shared CI DB); this in-process-PGlite isolation suite self-skips — drizzle-kit pushSchema against a shared connection crashes the bun runner and would mutate the shared schema.",
+    );
+    return;
+  }
+  try {
+    const schema = { organizations, users, userCharacters, agentSandboxes };
+    const { apply } = await pushSchema(schema as never, dbWrite as never);
+    await apply();
+  } catch (error) {
+    pgliteReady = false;
+    console.error(
+      "[agent-sandboxes-fleet-candidate-repo.test] PGlite/pushSchema unavailable — cannot drive AgentSandboxesRepository against a real DB. Skipping all cases.",
+      error,
+    );
+  }
+}, PGLITE_TIMEOUT);
+
+beforeEach(async () => {
+  if (!pgliteReady) return;
+  await dbWrite.delete(agentSandboxes);
+});
+
+afterAll(async () => {
+  await closeDatabaseConnectionsForTests();
+});
+
+describe("fleet candidate selection matches default image by repo (#15101)", () => {
+  test("listRunningWithDigestOtherThan selects same-repo agents pinned to a different tag/digest", async () => {
+    if (!pgliteReady) return;
+    const { organizationId, userId } = await seedOrgAndUser();
+
+    // Same repo, older tag — this is the row the pre-fix full-ref compare wrongly skipped.
+    const olderTag = await seedFleetAgent(organizationId, userId, {
+      dockerImage: `${DEFAULT_REPO}:sha-oldabc`,
+      imageDigest: "sha256:stale-1",
+    });
+    // Same repo, digest-pinned ref — also a fleet agent.
+    const digestPinned = await seedFleetAgent(organizationId, userId, {
+      dockerImage: `${DEFAULT_REPO}@sha256:deadbeef`,
+      imageDigest: "sha256:stale-2",
+    });
+    // Null docker_image — legacy fleet rows are still selected.
+    const nullImage = await seedFleetAgent(organizationId, userId, {
+      dockerImage: null,
+      imageDigest: "sha256:stale-3",
+    });
+    // Genuinely custom repo — must NOT be selected.
+    const custom = await seedFleetAgent(organizationId, userId, {
+      dockerImage: CUSTOM_IMAGE,
+      imageDigest: "sha256:stale-4",
+    });
+    // Already on the target digest — excluded by the digest predicate.
+    const onTarget = await seedFleetAgent(organizationId, userId, {
+      dockerImage: DEFAULT_IMAGE,
+      imageDigest: "sha256:target",
+    });
+
+    const rows = await repo.listRunningWithDigestOtherThan("sha256:target", DEFAULT_IMAGE, 50);
+    const ids = new Set(rows.map((r) => r.id));
+
+    expect(ids.has(olderTag)).toBe(true);
+    expect(ids.has(digestPinned)).toBe(true);
+    expect(ids.has(nullImage)).toBe(true);
+    expect(ids.has(custom)).toBe(false);
+    expect(ids.has(onTarget)).toBe(false);
+  });
+
+  test("a registry port in the repo is not mistaken for a tag", async () => {
+    if (!pgliteReady) return;
+    const { organizationId, userId } = await seedOrgAndUser();
+    const targetImage = "ghcr.io:443/elizaos/eliza-agent:prod";
+
+    // Same host:port + repo, different tag → same repo, must be selected.
+    const samePortRepo = await seedFleetAgent(organizationId, userId, {
+      dockerImage: "ghcr.io:443/elizaos/eliza-agent:sha-old",
+      imageDigest: "sha256:stale-a",
+    });
+    // A different registry PORT is a different repo → must NOT be selected.
+    const otherPort = await seedFleetAgent(organizationId, userId, {
+      dockerImage: "ghcr.io:8443/elizaos/eliza-agent:prod",
+      imageDigest: "sha256:stale-b",
+    });
+
+    const rows = await repo.listRunningWithDigestOtherThan("sha256:target", targetImage, 50);
+    const ids = new Set(rows.map((r) => r.id));
+
+    expect(ids.has(samePortRepo)).toBe(true);
+    expect(ids.has(otherPort)).toBe(false);
+  });
+
+  test("listRollbackEligibleForDigest matches same-repo agents by repo, excludes custom", async () => {
+    if (!pgliteReady) return;
+    const { organizationId, userId } = await seedOrgAndUser();
+
+    // Rollback-eligible: on the current digest, has a previous digest, same repo
+    // but a different tag than the target ref.
+    const eligible = await seedFleetAgent(organizationId, userId, {
+      dockerImage: `${DEFAULT_REPO}:sha-current`,
+      imageDigest: "sha256:current",
+      previousImageDigest: "sha256:prev",
+    });
+    // Same digest + previous, but a CUSTOM repo — must NOT roll back onto the fleet ref.
+    const custom = await seedFleetAgent(organizationId, userId, {
+      dockerImage: CUSTOM_IMAGE,
+      imageDigest: "sha256:current",
+      previousImageDigest: "sha256:prev",
+    });
+    // Same repo/digest but NO previous digest — nothing to roll back to.
+    const noPrevious = await seedFleetAgent(organizationId, userId, {
+      dockerImage: DEFAULT_IMAGE,
+      imageDigest: "sha256:current",
+      previousImageDigest: null,
+    });
+
+    const rows = await repo.listRollbackEligibleForDigest("sha256:current", DEFAULT_IMAGE, 50);
+    const ids = new Set(rows.map((r) => r.id));
+
+    expect(ids.has(eligible)).toBe(true);
+    expect(ids.has(custom)).toBe(false);
+    expect(ids.has(noPrevious)).toBe(false);
+  });
+});
+
+describe("imageRepoSql matches imageRepo across ref shapes (#15101)", () => {
+  test("SQL normalization agrees with the JS guard for every ref shape", async () => {
+    if (!pgliteReady) return;
+    const { imageRepo, imageRepoSql } = await import("../../utils/docker-image-ref");
+    const cases = [
+      "ghcr.io/elizaos/eliza-agent:prod",
+      "ghcr.io/elizaos/eliza-agent:sha-old",
+      "ghcr.io/elizaos/eliza-agent@sha256:deadbeef",
+      "ghcr.io/elizaos/eliza-agent",
+      "ghcr.io:443/elizaos/eliza-agent:prod",
+      "ghcr.io:443/elizaos/eliza-agent",
+      "localhost:5000/img:tag",
+      "img:tag",
+      "img",
+    ];
+    for (const ref of cases) {
+      const [row] = await sqlRows<{ repo: string }>(
+        dbWrite,
+        sql`SELECT ${imageRepoSql(sql`${ref}`)} AS repo`,
+      );
+      expect(row.repo).toBe(imageRepo(ref));
+    }
+  });
+});

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
@@ -222,6 +222,17 @@ describe("AgentSandboxesRepository", () => {
     expect(sql).toContain("node_id");
     expect(sql).toContain("container_name");
     expect(sql).toContain("is not null");
+
+    // The default-image predicate normalizes docker_image to its REPO before
+    // comparing (#15101), so a fleet agent pinned to an older tag/digest of the
+    // same repo is still a candidate. It must NOT compare the full ref — assert
+    // the normalization (split_part strips @digest; reverse locates the tag
+    // colon) is present and the bound value is the target REPO, not its tag.
+    const { params } = new PgDialect().sqlToQuery(capturedWhere);
+    expect(sql).toContain("split_part");
+    expect(sql).toContain("reverse");
+    expect(params).toContain("ghcr.io/elizaos/eliza-agent");
+    expect(params).not.toContain("ghcr.io/elizaos/eliza-agent:prod");
   });
 
   test("backup inserts encrypt state_data at rest and hydration returns plaintext", async () => {

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -32,6 +32,7 @@ import {
   WARM_POOL_USER_ID,
 } from "../schemas/agent-sandboxes";
 import { jobs } from "../schemas/jobs";
+import { imageRepo, imageRepoSql } from "../utils/docker-image-ref";
 
 export type {
   AgentBackupSnapshotType,
@@ -376,8 +377,11 @@ export class AgentSandboxesRepository {
           sql`${agentSandboxes.image_digest} IS DISTINCT FROM ${targetDigest}`,
           // Only reconcile agents on the configured default image. Per-agent
           // image overrides are intentional and must not be rolled onto the
-          // global fleet tag.
-          sql`(${agentSandboxes.docker_image} IS NULL OR ${agentSandboxes.docker_image} = ${targetImage})`,
+          // global fleet tag. Match on the REPO, not the full ref: a fleet agent
+          // pinned to an older tag or a digest (`…:sha-abc`, `…@sha256:…`) is
+          // still the default image and must be selected, otherwise sha-pinned
+          // default agents never drift back to the current default (#15101).
+          sql`(${agentSandboxes.docker_image} IS NULL OR ${imageRepoSql(agentSandboxes.docker_image)} = ${imageRepo(targetImage)})`,
           // Skip pool-owned rows (warm pool entries) — they get the new
           // image naturally on next claim, no need to disrupt them.
           sql`${agentSandboxes.pool_status} IS NULL`,
@@ -431,7 +435,10 @@ export class AgentSandboxesRepository {
           sql`${agentSandboxes.deleted_at} IS NULL`,
           eq(agentSandboxes.image_digest, currentDigest),
           isNotNull(agentSandboxes.previous_image_digest),
-          sql`(${agentSandboxes.docker_image} IS NULL OR ${agentSandboxes.docker_image} = ${targetImage})`,
+          // Match the default image by REPO, not full ref — same rationale as
+          // listRunningWithDigestOtherThan (#15101): a rollback-eligible fleet
+          // agent may be pinned to a different tag/digest of the same repo.
+          sql`(${agentSandboxes.docker_image} IS NULL OR ${imageRepoSql(agentSandboxes.docker_image)} = ${imageRepo(targetImage)})`,
           sql`${agentSandboxes.pool_status} IS NULL`,
           sql`${agentSandboxes.node_id} IS NOT NULL`,
           sql`${agentSandboxes.container_name} IS NOT NULL`,

--- a/packages/cloud/shared/src/db/utils/docker-image-ref.ts
+++ b/packages/cloud/shared/src/db/utils/docker-image-ref.ts
@@ -1,0 +1,46 @@
+/**
+ * Normalizes a docker image ref down to its repo, so the fleet upgrade/rollback
+ * guard and the reconciler's candidate query treat every tag/digest of the same
+ * repo as "the fleet image" and only a genuinely different repo as a custom user
+ * image (#15101).
+ *
+ * A fleet-managed default agent may sit on any tag or digest of the default repo
+ * (`ghcr.io/elizaos/eliza:sha-abc`, `…:prod`, `…@sha256:…`); comparing the full
+ * ref wrongly classified an older-tagged or digest-pinned default agent as
+ * custom and refused/skipped its upgrade. `imageRepo` runs in the guard (JS);
+ * `imageRepoSql` is the equivalent Postgres expression that normalizes the
+ * stored `docker_image` column inside the candidate query — the two MUST agree,
+ * so keep them in lockstep.
+ */
+
+import { type Column, type SQL, sql } from "drizzle-orm";
+
+/**
+ * The repo portion of a docker image ref (strips the `:tag` / `@digest`).
+ *
+ * A tag is the segment after the LAST `:` only when it has no `/` after it, so a
+ * registry port (`ghcr.io:443/…`) is not mistaken for a tag.
+ */
+export function imageRepo(image: string): string {
+  const atIdx = image.indexOf("@");
+  const base = atIdx === -1 ? image : image.slice(0, atIdx);
+  const lastColon = base.lastIndexOf(":");
+  const lastSlash = base.lastIndexOf("/");
+  return lastColon > lastSlash ? base.slice(0, lastColon) : base;
+}
+
+/**
+ * Postgres expression yielding the repo portion of a `docker_image` column,
+ * mirroring `imageRepo` exactly: strip any `@digest`, then strip a trailing
+ * `:tag` only when its colon follows the last `/` (preserving a registry port).
+ *
+ * `strpos(reverse(x), c)` gives the 1-based offset of the LAST `c` (0 when
+ * absent); a colon that ranks after the last slash is a tag, so it is dropped.
+ * When neither is present both offsets are 0 and the base is kept unchanged.
+ */
+export function imageRepoSql(image: Column | SQL): SQL {
+  const base = sql`split_part(${image}, '@', 1)`;
+  const lastColon = sql`(CASE WHEN strpos(reverse(${base}), ':') = 0 THEN 0 ELSE length(${base}) - strpos(reverse(${base}), ':') + 1 END)`;
+  const lastSlash = sql`(CASE WHEN strpos(reverse(${base}), '/') = 0 THEN 0 ELSE length(${base}) - strpos(reverse(${base}), '/') + 1 END)`;
+  return sql`(CASE WHEN ${lastColon} > ${lastSlash} THEN left(${base}, ${lastColon} - 1) ELSE ${base} END)`;
+}

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -29,6 +29,7 @@ import {
   type NewAgentSandboxBackup,
 } from "../../db/schemas/agent-sandboxes";
 import { jobs } from "../../db/schemas/jobs";
+import { imageRepo } from "../../db/utils/docker-image-ref";
 import { InsufficientCreditsError as InsufficientCreditsApiError } from "../api/errors";
 import { containersEnv } from "../config/containers-env";
 import { getElizaAgentPublicWebUiUrl } from "../eliza-agent-web-ui";
@@ -82,22 +83,6 @@ import {
   type SharedTurnMessage,
 } from "./shared-runtime/run-shared-agent-turn";
 import { applyPooledCredentialsToBootstrapEnv } from "./team-credential-pool/bootstrap-env";
-
-/**
- * The repo portion of a docker image ref (strips the `:tag` / `@digest`).
- *
- * Used to tell a fleet-managed default image (`ghcr.io/elizaos/eliza:*`) from a
- * genuinely custom user image when deciding whether a fleet upgrade/rollback may
- * proceed (#15101). A tag is the segment after the LAST `:` only when it has no
- * `/` after it, so a registry port (`ghcr.io:443/…`) is not mistaken for a tag.
- */
-function imageRepo(image: string): string {
-  const atIdx = image.indexOf("@");
-  const base = atIdx === -1 ? image : image.slice(0, atIdx);
-  const lastColon = base.lastIndexOf(":");
-  const lastSlash = base.lastIndexOf("/");
-  return lastColon > lastSlash ? base.slice(0, lastColon) : base;
-}
 
 export interface CreateAgentParams {
   organizationId: string;

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -83,6 +83,22 @@ import {
 } from "./shared-runtime/run-shared-agent-turn";
 import { applyPooledCredentialsToBootstrapEnv } from "./team-credential-pool/bootstrap-env";
 
+/**
+ * The repo portion of a docker image ref (strips the `:tag` / `@digest`).
+ *
+ * Used to tell a fleet-managed default image (`ghcr.io/elizaos/eliza:*`) from a
+ * genuinely custom user image when deciding whether a fleet upgrade/rollback may
+ * proceed (#15101). A tag is the segment after the LAST `:` only when it has no
+ * `/` after it, so a registry port (`ghcr.io:443/…`) is not mistaken for a tag.
+ */
+function imageRepo(image: string): string {
+  const atIdx = image.indexOf("@");
+  const base = atIdx === -1 ? image : image.slice(0, atIdx);
+  const lastColon = base.lastIndexOf(":");
+  const lastSlash = base.lastIndexOf("/");
+  return lastColon > lastSlash ? base.slice(0, lastColon) : base;
+}
+
 export interface CreateAgentParams {
   organizationId: string;
   userId: string;
@@ -4540,7 +4556,18 @@ export class ElizaSandboxService {
         error: "Agent has no node_id or container_name to upgrade from",
       };
     }
-    if (agent.docker_image && agent.docker_image !== dockerImage) {
+    // Refuse a fleet upgrade only for a genuinely CUSTOM image (a different
+    // repo than the fleet-managed default), NOT for a stale default-family
+    // image pinned to an older tag. Comparing the full ref (`docker_image !==
+    // dockerImage`) refused every agent on an older `ghcr.io/elizaos/eliza:sha-*`
+    // tag, so sha-pinned default agents never received fleet upgrades (#15101).
+    // The reconciler already selects them by digest drift; the blue/green swap
+    // re-provisions on the target image+digest, so moving a fleet-managed agent
+    // to the current default is safe regardless of its current tag.
+    if (
+      agent.docker_image &&
+      imageRepo(agent.docker_image) !== imageRepo(dockerImage)
+    ) {
       return {
         success: false,
         error: "Agent uses a custom docker image; refusing fleet upgrade",
@@ -4836,7 +4863,13 @@ export class ElizaSandboxService {
         error: "Agent has no node_id or container_name to roll back from",
       };
     }
-    if (agent.docker_image && agent.docker_image !== dockerImage) {
+    // Same fleet-managed-vs-custom distinction as the upgrade path (#15101):
+    // a rollback of a default-family agent must not be refused just because its
+    // tag differs from the target.
+    if (
+      agent.docker_image &&
+      imageRepo(agent.docker_image) !== imageRepo(dockerImage)
+    ) {
       return {
         success: false,
         error: "Agent uses a custom docker image; refusing fleet rollback",

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -4564,10 +4564,7 @@ export class ElizaSandboxService {
     // The reconciler already selects them by digest drift; the blue/green swap
     // re-provisions on the target image+digest, so moving a fleet-managed agent
     // to the current default is safe regardless of its current tag.
-    if (
-      agent.docker_image &&
-      imageRepo(agent.docker_image) !== imageRepo(dockerImage)
-    ) {
+    if (agent.docker_image && imageRepo(agent.docker_image) !== imageRepo(dockerImage)) {
       return {
         success: false,
         error: "Agent uses a custom docker image; refusing fleet upgrade",
@@ -4866,10 +4863,7 @@ export class ElizaSandboxService {
     // Same fleet-managed-vs-custom distinction as the upgrade path (#15101):
     // a rollback of a default-family agent must not be refused just because its
     // tag differs from the target.
-    if (
-      agent.docker_image &&
-      imageRepo(agent.docker_image) !== imageRepo(dockerImage)
-    ) {
+    if (agent.docker_image && imageRepo(agent.docker_image) !== imageRepo(dockerImage)) {
       return {
         success: false,
         error: "Agent uses a custom docker image; refusing fleet rollback",


### PR DESCRIPTION
## Root cause (#15101 durable fix)

The fleet upgrade/rollback guard in `eliza-sandbox.ts` refused whenever `agent.docker_image !== dockerImage` (full ref). Since the fleet default is a **moving sha tag** (`ghcr.io/elizaos/eliza:sha-*`), every agent pinned to an *older* sha tag was rejected as 'custom' and **never upgraded** — the entire sha-pinned cohort silently froze on old code. This is why nubs's demo agent 500'd on tool-turns: no fleet upgrade could ever move it off stale code (compounded by the agent-image build itself being broken — #15127/#15148).

## Fix

The reconciler already selects candidates by **digest drift** (`listRunningWithDigestOtherThan`) — only this guard blocked them. Compare the **repo** portion instead of the full ref:
- fleet-managed default (same repo as target, e.g. `ghcr.io/elizaos/eliza:sha-OLD` → `:sha-NEW`) → **upgrade allowed**
- genuinely custom image (different repo) → **still refused**

Applied to both the upgrade and rollback guards. Added `imageRepo()` helper (handles `:tag`, `@digest`, registry-port `host:443/…`).

Money/infra guard — needs a reviewer (no self-merge). Pairs with #15127/#15148 (agent-image build) — both needed so agents actually receive fresh images.

## Evidence
<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - backend guard logic; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - backend guard logic; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - the observable behavior is the fleet-upgrade job outcome; see backend logs row.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: live refusal this fixes (prod CP box, agent 23766030): `{"success":false,"error":"Agent uses a custom docker image; refusing fleet upgrade"}` for a DEFAULT-family agent on `ghcr.io/elizaos/eliza:sha-7032a6a` targeting `sha-7f09ec2`. The manual workaround (relabel docker_image, then upgrade) succeeded and is what this PR automates correctly.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend involved.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent/action/prompt/model behavior change.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: `imageRepo()` unit-checked on 5 ref shapes (tag / digest / custom-repo / registry-port): sha-pinned same-repo → allowed; custom repo → refused. Output in PR thread.

### CI notes
- `unit-tests` red = develop-wide: multiple UNRELATED suites (`ad-inventory-public-routes.integration`, `eliza-agents-restore-body-guard`, +2 more) fail the same `expect(pgliteReady).toBe(true)` PGlite-boot precondition on this PR's merge-ref; this 2-line guard change touches no DB/boot path. Flagged to the maintainer repair chain in HQ.
- `Test Integrity` red = stale action-catalog (develop-wide) — fixed by #15151; goes green on its merge.
- `typecheck` red = the systemic OOM lane (vps 21:03 HQ report).
