### PR TITLE
fix(ui): weather tile temperature spacing — cramped/colliding °F unit

### DIFF
--- a/packages/ui/src/components/shell/DefaultHomeWidgets.tsx
+++ b/packages/ui/src/components/shell/DefaultHomeWidgets.tsx
@@ -117,13 +117,20 @@ function WeatherTile(): React.JSX.Element {
         </button>
       ) : (
         <>
-          <div className="flex items-center gap-2">
-            <Icon className="h-7 w-7 text-accent" aria-hidden />
-            <div className="text-4xl font-semibold leading-none tabular-nums tracking-tighter">
-              {weather.temp}
+          {/* Temperature row. The unit is a flex sibling top-aligned with a
+              fixed optical offset — NOT an inline `align-top` span, whose line
+              box collides with the `leading-none` digits — and the row never
+              wraps, so the icon can't fold onto the number at narrow tile
+              widths. No letter-space tightening on numerals: it crammed the
+              digits into the degree unit; tabular-nums already keeps the
+              width stable across minute ticks. */}
+          <div className="flex items-center gap-2 whitespace-nowrap">
+            <Icon className="h-7 w-7 shrink-0 text-accent" aria-hidden />
+            <div className="flex items-start text-4xl font-semibold leading-none tabular-nums">
+              <span>{weather.temp}</span>
               <span
                 className={cn(
-                  "align-top text-base font-medium",
+                  "ml-0.5 mt-0.5 text-base font-medium leading-none",
                   WALLPAPER_TEXT.muted,
                 )}
               >


### PR DESCRIPTION
nubs flagged overlapping/badly-spaced text on the home weather tile (app.elizacloud.ai). Two defects in the ready-state markup:
1. the °F unit was an inline `align-top` span inside a `leading-none` `text-4xl` box — the unit's line box collides with the digits;
2. `tracking-tighter` on the numerals crammed the last digit into the degree sign (tabular-nums already stabilizes minute-tick width; the tightening bought nothing).

Now the unit is a top-aligned flex sibling with a fixed optical offset + normal tracking, and the temperature row is `whitespace-nowrap` with a `shrink-0` icon so nothing wraps/overlaps at narrow tile widths.

![before/after](https://raw.githubusercontent.com/elizaOS/eliza/evidence-tmp-weather/weather-fix.png)
(top = fixed · bottom = old cramped rendering)

## Evidence
- <!-- evidence-row:before-screenshots --> **Before screenshots:** bottom half of [the rendered comparison](https://raw.githubusercontent.com/elizaOS/eliza/evidence-tmp-weather/weather-fix.png) reproduces the exact shipped markup nubs pasted (cramped °F against the digits).
- <!-- evidence-row:after-screenshots --> **After screenshots:** top half of [the same comparison](https://raw.githubusercontent.com/elizaOS/eliza/evidence-tmp-weather/weather-fix.png) — real Chromium render of the new markup.
- <!-- evidence-row:walkthrough-video --> **Walkthrough video:** N/A — single static tile, no interaction; the side-by-side render covers the change entirely.
- <!-- evidence-row:backend-logs --> **Backend logs:** N/A — renderer-only markup change, no server path.
- <!-- evidence-row:frontend-logs --> **Frontend console/network logs:** DefaultHomeWidgets suite 5/5 (vitest output in CI); no network behavior touched.
- <!-- evidence-row:llm-trajectory --> **Real-LLM trajectory:** N/A — no agent/model behavior.
- <!-- evidence-row:domain-artifacts --> **Domain artifacts:** [rendered comparison PNG](https://raw.githubusercontent.com/elizaOS/eliza/evidence-tmp-weather/weather-fix.png) (temp `evidence-tmp-weather` branch, deleted after merge); OCR text readout of the render: "66°F / Drizzle" ×2, unit separated in the fixed variant (tesseract-verified locally).

— [qa-agent]