### PR TITLE
fix(core): stop persisting document-augmentation wrapper as user message text

### DIFF
--- a/packages/cloud/api/__tests__/elizaos-core-stub.test.ts
+++ b/packages/cloud/api/__tests__/elizaos-core-stub.test.ts
@@ -6,8 +6,10 @@ import {
   DEFAULT_ELIZA_CLOUD_FREE_TEXT_MODEL,
   DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
   fetchWithSsrfGuard,
+  hasDocumentAugmentationEnvelope,
   runWithTrajectoryPurpose,
   SsrfBlockedError,
+  stripAugmentationForPersistence,
 } from "../src/stubs/elizaos-core";
 
 describe("elizaos-core Worker stub", () => {
@@ -23,6 +25,30 @@ describe("elizaos-core Worker stub", () => {
     await expect(
       runWithTrajectoryPurpose("inbox_triage", async () => "ok"),
     ).resolves.toBe("ok");
+  });
+
+  test("strips document augmentation before Worker-side persistence", () => {
+    const message = {
+      content: {
+        text: [
+          "Answer the user request using the contextual documents below as the source of truth when they contain the answer.",
+          "",
+          "<contextual_documents>",
+          "source text",
+          "</contextual_documents>",
+          "",
+          "<user_request>",
+          "just fixing eliza app for demo",
+          "[Language instruction: Reply in Spanish]",
+          "</user_request>",
+        ].join("\n"),
+      },
+    };
+
+    expect(hasDocumentAugmentationEnvelope(message.content.text)).toBe(true);
+    expect(stripAugmentationForPersistence(message)).toEqual({
+      content: { text: "just fixing eliza app for demo" },
+    });
   });
 
   describe("fetchWithSsrfGuard", () => {

--- a/packages/cloud/api/src/stubs/elizaos-core.ts
+++ b/packages/cloud/api/src/stubs/elizaos-core.ts
@@ -29,6 +29,39 @@ function readEnvValue(
   return undefined;
 }
 
+const DOCUMENT_AUGMENTATION_PREFIX =
+  "Answer the user request using the contextual documents";
+const USER_REQUEST_WRAPPER = /<user_request>\s*([\s\S]*?)\s*<\/user_request>/i;
+const LANGUAGE_INSTRUCTION_SUFFIX = /\n*\[language instruction:[^\]]*\]\s*$/i;
+
+function extractDocumentAugmentedUserText(raw: string): string {
+  const match = raw.match(USER_REQUEST_WRAPPER);
+  return (match?.[1] ?? raw).replace(LANGUAGE_INSTRUCTION_SUFFIX, "").trim();
+}
+
+export function hasDocumentAugmentationEnvelope(text: unknown): boolean {
+  if (typeof text !== "string") return false;
+  return text.trimStart().startsWith(DOCUMENT_AUGMENTATION_PREFIX);
+}
+
+export function stripAugmentationForPersistence<
+  T extends { content?: unknown } | null | undefined,
+>(message: T): T {
+  const content = message?.content;
+  if (!content || typeof content !== "object") return message;
+  const rendered = (content as { text?: unknown }).text;
+  if (!hasDocumentAugmentationEnvelope(rendered)) return message;
+  const clean = extractDocumentAugmentedUserText(rendered as string);
+  if (clean === rendered) return message;
+  return {
+    ...message,
+    content: {
+      ...(content as Record<string, unknown>),
+      text: clean,
+    },
+  } as T;
+}
+
 // --- ElizaError: worker-safe mirror of @elizaos/core/errors (pure-JS Error
 // subclass, no I/O). Cloud Worker services (active-billing-numeric, user-mcps,
 // twap-price-oracle, cloudflare-registrar, …) import + extend it, so the shim

--- a/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/services/cloud-bootstrap-message-service/service.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/services/cloud-bootstrap-message-service/service.ts
@@ -265,10 +265,7 @@ export class CloudBootstrapMessageService implements IMessageService {
       if (existingMemory) {
         memoryToQueue = existingMemory;
       } else {
-        const createdMemoryId = await runtime.createMemory(
-          persistableMessage,
-          "messages",
-        );
+        const createdMemoryId = await runtime.createMemory(persistableMessage, "messages");
         memoryToQueue = { ...persistableMessage, id: createdMemoryId };
       }
       await runtime.queueEmbeddingGeneration(memoryToQueue, "high");

--- a/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/services/cloud-bootstrap-message-service/service.ts
+++ b/packages/cloud/shared/src/lib/eliza/plugin-cloud-bootstrap/services/cloud-bootstrap-message-service/service.ts
@@ -21,6 +21,7 @@ import {
   parseBooleanFromText,
   type Room,
   type State,
+  stripAugmentationForPersistence,
   truncateToCompleteSentence,
   type UUID,
 } from "@elizaos/core";
@@ -250,21 +251,31 @@ export class CloudBootstrapMessageService implements IMessageService {
       `[CloudBootstrap] Processing: ${truncateToCompleteSentence(message.content.text || "", 50)}...`,
     );
 
-    // Save incoming message to memory
+    // Save incoming message to memory. The document augmentation envelope
+    // (`<contextual_documents>...</contextual_documents>` + `<user_request>`)
+    // is a model-facing wrapper added just for this turn's LLM prompt; strip it
+    // before persisting/embedding so the stored memory holds the clean user
+    // text. Otherwise the raw wrapper XML echoes back into the user's own chat
+    // bubble and re-enters context as history on later turns. `message` (used
+    // downstream for this turn's generation) keeps its wrap.
+    const persistableMessage = stripAugmentationForPersistence(message);
     let memoryToQueue: Memory;
     if (message.id) {
       const existingMemory = await runtime.getMemoryById(message.id);
       if (existingMemory) {
         memoryToQueue = existingMemory;
       } else {
-        const createdMemoryId = await runtime.createMemory(message, "messages");
-        memoryToQueue = { ...message, id: createdMemoryId };
+        const createdMemoryId = await runtime.createMemory(
+          persistableMessage,
+          "messages",
+        );
+        memoryToQueue = { ...persistableMessage, id: createdMemoryId };
       }
       await runtime.queueEmbeddingGeneration(memoryToQueue, "high");
     } else {
-      const memoryId = await runtime.createMemory(message, "messages");
+      const memoryId = await runtime.createMemory(persistableMessage, "messages");
       message.id = memoryId;
-      memoryToQueue = { ...message, id: memoryId };
+      memoryToQueue = { ...persistableMessage, id: memoryId };
       await runtime.queueEmbeddingGeneration(memoryToQueue, "normal");
     }
 

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -252,7 +252,10 @@ import {
 	parseContextRoutingMetadata,
 	setContextRoutingMetadata,
 } from "../utils/context-routing";
-import { getUserMessageText } from "../utils/message-text";
+import {
+	getUserMessageText,
+	stripAugmentationForPersistence,
+} from "../utils/message-text";
 import { readEnv } from "../utils/read-env";
 import {
 	extractFirstSentence,
@@ -8993,6 +8996,15 @@ export class DefaultMessageService implements IMessageService {
 		);
 		let memoryToQueue: Memory;
 
+		// The document augmentation envelope
+		// (`<contextual_documents>...</contextual_documents>` + `<user_request>`)
+		// is a model-facing wrapper added just for this turn's LLM prompt. Persist
+		// and embed the clean user text so the stored memory does not echo raw
+		// wrapper XML back into the user's chat bubble or re-enter context as
+		// history on later turns. `message` (used downstream this turn) keeps its
+		// wrap.
+		const persistableMessage = stripAugmentationForPersistence(message);
+
 		if (message.id) {
 			const existingMemory = await runtime.getMemoryById(message.id);
 			if (existingMemory) {
@@ -9002,14 +9014,17 @@ export class DefaultMessageService implements IMessageService {
 				);
 				memoryToQueue = existingMemory;
 			} else {
-				const createdMemoryId = await runtime.createMemory(message, "messages");
-				memoryToQueue = { ...message, id: createdMemoryId };
+				const createdMemoryId = await runtime.createMemory(
+					persistableMessage,
+					"messages",
+				);
+				memoryToQueue = { ...persistableMessage, id: createdMemoryId };
 			}
 			await runtime.queueEmbeddingGeneration(memoryToQueue, "high");
 		} else {
-			const memoryId = await runtime.createMemory(message, "messages");
+			const memoryId = await runtime.createMemory(persistableMessage, "messages");
 			message.id = memoryId;
-			memoryToQueue = { ...message, id: memoryId };
+			memoryToQueue = { ...persistableMessage, id: memoryId };
 			await runtime.queueEmbeddingGeneration(memoryToQueue, "normal");
 		}
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1371,7 +1371,9 @@ export { extractAndParseJSONObjectFromText } from "./utils/json-llm";
 export {
 	extractUserText,
 	getUserMessageText,
+	hasDocumentAugmentationEnvelope,
 	normalizeUserMessageText,
+	stripAugmentationForPersistence,
 } from "./utils/message-text";
 // `export * from "./utils"` (in index.node.ts etc.) resolves to this file, not
 // to a `./utils/index.ts`. Any helper in the `utils/` directory that needs to be

--- a/packages/core/src/utils/message-text.test.ts
+++ b/packages/core/src/utils/message-text.test.ts
@@ -1,10 +1,16 @@
 /**
  * Tests for `getUserMessageText`, covering that a connector's current-turn text
- * wins over the rendered channel envelope stored on the message content.
+ * wins over the rendered channel envelope stored on the message content, and
+ * for `stripAugmentationForPersistence`, which keeps the model-facing document
+ * augmentation envelope out of persisted / echoed user memories.
  */
 import { describe, expect, it } from "vitest";
 import type { Memory } from "../types/memory";
-import { getUserMessageText } from "./message-text";
+import {
+	getUserMessageText,
+	hasDocumentAugmentationEnvelope,
+	stripAugmentationForPersistence,
+} from "./message-text";
 
 describe("getUserMessageText", () => {
 	it("prefers connector-provided current-turn text over rendered envelopes", () => {
@@ -18,5 +24,88 @@ describe("getUserMessageText", () => {
 		expect(getUserMessageText(message)).toBe(
 			"Can you tell me what elizaOS is?",
 		);
+	});
+});
+
+// The exact model-facing wrapper that chat-augmentation.ts assembles around a
+// user's text so retrieved documents reach the LLM. This is what leaked into
+// the user's own chat bubble as raw XML (device screenshot, 2026-07-06).
+function augmentedText(userText: string): string {
+	return [
+		"Answer the user request using the contextual documents below as the source of truth when they contain the answer.",
+		"If the answer appears verbatim in the contextual documents, repeat it exactly.",
+		"Do not ask follow-up questions or invoke tools/actions when the contextual documents already answer the request.",
+		"",
+		"<contextual_documents>",
+		'<source title="notes.md" similarity="0.412">',
+		"some retrieved snippet",
+		"</source>",
+		"</contextual_documents>",
+		"",
+		"<user_request>",
+		userText,
+		"</user_request>",
+	].join("\n");
+}
+
+describe("stripAugmentationForPersistence", () => {
+	it("unwraps the document augmentation envelope so persisted text is what the user typed", () => {
+		const userText = "just fixing eliza app for demo";
+		const message = {
+			id: "m1",
+			content: { text: augmentedText(userText), source: "client_chat" },
+		} as unknown as Memory;
+
+		const persisted = stripAugmentationForPersistence(message);
+
+		// The stored/echoed text is the clean user message, no XML wrapper.
+		expect(persisted.content.text).toBe(userText);
+		expect(persisted.content.text).not.toContain("<user_request>");
+		expect(persisted.content.text).not.toContain("<contextual_documents>");
+		// Other content fields survive the copy.
+		expect((persisted.content as { source?: string }).source).toBe(
+			"client_chat",
+		);
+	});
+
+	it("does not mutate the in-flight message (LLM turn keeps its wrap)", () => {
+		const wrapped = augmentedText("hello there");
+		const message = {
+			content: { text: wrapped },
+		} as unknown as Memory;
+
+		const persisted = stripAugmentationForPersistence(message);
+
+		expect(persisted).not.toBe(message);
+		expect(message.content.text).toBe(wrapped);
+		expect(persisted.content.text).toBe("hello there");
+	});
+
+	it("is a no-op passthrough for ordinary unwrapped user messages", () => {
+		const message = {
+			content: { text: "what is the weather today?" },
+		} as unknown as Memory;
+
+		const persisted = stripAugmentationForPersistence(message);
+
+		// Same reference back: hot path pays nothing for the common case.
+		expect(persisted).toBe(message);
+	});
+
+	it("leaves lookalike text that lacks the augmentation preamble untouched", () => {
+		// A user genuinely typing <user_request> tags must NOT be unwrapped.
+		const text = "why does <user_request>foo</user_request> show up in logs?";
+		const message = { content: { text } } as unknown as Memory;
+
+		const persisted = stripAugmentationForPersistence(message);
+
+		expect(persisted).toBe(message);
+		expect(persisted.content.text).toBe(text);
+	});
+
+	it("detects the envelope via hasDocumentAugmentationEnvelope", () => {
+		expect(hasDocumentAugmentationEnvelope(augmentedText("hi"))).toBe(true);
+		expect(hasDocumentAugmentationEnvelope("plain user text")).toBe(false);
+		expect(hasDocumentAugmentationEnvelope(undefined)).toBe(false);
 	});
 });

--- a/packages/core/src/utils/message-text.ts
+++ b/packages/core/src/utils/message-text.ts
@@ -47,3 +47,47 @@ export function normalizeUserMessageText(
 ): string {
 	return getUserMessageText(message).toLowerCase().replace(/\s+/g, " ").trim();
 }
+
+/**
+ * Returns true when a message's rendered `content.text` carries the document
+ * augmentation envelope (the `Answer the user request using the contextual
+ * documents ...` preamble wrapping the real text in `<user_request>` tags).
+ *
+ * The envelope is a model-facing wrapper: it is added right before the LLM
+ * prompt is assembled so retrieved document context reaches the model. It must
+ * never be persisted or echoed back to a client, or it renders as raw XML in
+ * the user's own chat bubble and re-enters context on later turns as history.
+ */
+export function hasDocumentAugmentationEnvelope(text: unknown): boolean {
+	if (typeof text !== "string") return false;
+	return text.trimStart().startsWith(DOCUMENT_AUGMENTATION_PREFIX);
+}
+
+/**
+ * Produces a persist-safe copy of an inbound user `Memory` whose `content.text`
+ * has been stripped of the document augmentation envelope. The wrapper is added
+ * transiently for the current turn's LLM prompt; the stored memory (and its
+ * embedding) must hold the clean user text so the UI echo, message history, and
+ * subsequent-turn context all see what the user actually typed.
+ *
+ * Returns the original reference unchanged when there is no envelope to strip,
+ * so callers on the hot path pay nothing for the common (unaugmented) case and
+ * the live in-flight message keeps its wrap for the current LLM call.
+ */
+export function stripAugmentationForPersistence<T extends Pick<Memory, "content">>(
+	message: T,
+): T {
+	const content = message?.content;
+	if (!content || typeof content !== "object") return message;
+	const rendered = (content as { text?: unknown }).text;
+	if (!hasDocumentAugmentationEnvelope(rendered)) return message;
+	const clean = extractUserText(rendered as string);
+	if (clean === rendered) return message;
+	return {
+		...message,
+		content: {
+			...(content as Record<string, unknown>),
+			text: clean,
+		},
+	} as T;
+}


### PR DESCRIPTION
## What

A user's chat bubble in the continuous chat overlay could render **raw prompt-assembly XML** instead of the text the user typed. Device screenshot (Shadow's PWA, 2026-07-06) showed a user bubble containing:

```
</contextual_documents>

<user_request>
just fixing eliza app for demo
</user_request>
```

The user typed only `just fixing eliza app for demo`. The UI displayed the model-facing prompt wrapper around it.

This is distinct from the stale-transcript bug fixed in #15121. This one is the document-augmentation envelope leaking into persisted user memories.

## Root cause (persistence bug, not a UI bug)

`maybeAugmentChatMessageWithDocuments` (`packages/agent/src/api/chat-augmentation.ts`) rewrites `message.content.text` into a model-facing envelope so retrieved documents reach the LLM:

```
Answer the user request using the contextual documents ...
<contextual_documents>...</contextual_documents>
<user_request>{clean user text}</user_request>
```

That augmented message object is then handed to the message service, which persists it verbatim:

- `packages/cloud/shared/.../cloud-bootstrap-message-service/service.ts` line ~260/265: `runtime.createMemory(message, "messages")`
- `packages/core/src/services/message.ts` line ~9005/9010: same pattern

So the **wrapped** text is what lands in the store, gets echoed back over the socket, and is re-read on history load. The bubble shows the XML.

The runtime already treats this envelope as transient everywhere it reads the user's text for logic (`getUserMessageText` / `extractUserText` unwrap it). The two persistence sites were the only places that stored the raw wrap.

### Secondary effects fixed
- **Double-wrapping in context:** persisted wrapped text re-enters the LLM prompt as `recentMessages` on later turns (`recentMessages.ts` reads `content.text` raw), degrading reply quality. Now the stored history is clean.
- **Embedding pollution:** the message embedding was computed on the wrapper tokens. `memoryToQueue` now derives from the clean copy.

## Fix

Add `stripAugmentationForPersistence` to the core `message-text` util and apply it at both inbound-message persistence sites. The stored memory + its embedding hold the clean user text; the live in-flight message keeps its wrap for the current turn's LLM prompt, so document context still reaches the model.

The helper:
- is a no-op passthrough (same reference) for ordinary messages, so the hot path pays nothing
- only unwraps when the exact augmentation preamble is present, so a user genuinely typing `<user_request>` tags is left untouched
- does not mutate the live message

No UI regex band-aid: the architecture does **not** store wrapped text by design; storing it was the bug, so the fix is at the source.

## History pollution (flagged, not migrated)

Message rows persisted **before** this fix remain wrapped and will still render the XML on history load. This PR prevents all new pollution but does not scrub existing rows. A one-time cleanup (unwrap `content.text` on message memories whose text starts with the augmentation preamble) would be needed to fully clear old bubbles. Flagging per protocol rather than shipping a migration unprompted. A render-time sanitizer in the UI could also serve as defense-in-depth for legacy rows if desired.

## Tests

`packages/core/src/utils/message-text.test.ts` (extended, vitest):
- unwraps the exact augmentation envelope so persisted text == what the user typed
- does not mutate the in-flight message (LLM turn keeps its wrap)
- no-op passthrough for ordinary unwrapped messages
- leaves lookalike `<user_request>` text lacking the preamble untouched
- `hasDocumentAugmentationEnvelope` detection

```
Test Files  1 passed (1)
     Tests  6 passed (6)
```

Regression check: `message-runtime-stage1.test.ts` (85) + `message-failure-reply.test.ts` (1) pass. `tsc --noEmit` clean for the touched files in core and cloud/shared (remaining tsc errors are pre-existing missing-optional-dep noise, unrelated).

## Evidence

| Scenario | Before | After |
| --- | --- | --- |
| User bubble content | raw `<contextual_documents>` / `<user_request>` XML (device screenshot, Discord artifact 2026-07-06) | clean `just fixing eliza app for demo` (unit test pins persisted text == typed text) |
| History re-injection | wrapped text re-enters LLM context on later turns | clean text stored, no re-wrap |
| Message embedding | computed over wrapper tokens | computed over clean text |

Before-evidence is the device screenshot in the report/Discord (non-reproducible here as a code artifact; cited as the failing-state reference). After-evidence is the round-trip unit test.

---
[sol-orch]

## Required evidence rows

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: [UI fixture/check artifact]() from `https://github.com/elizaOS/eliza/pull/15134`. If this PR has no rendered delta, artifact documents the checked surface before/without visual changes.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: [UI fixture/check artifact]() from `https://github.com/elizaOS/eliza/pull/15134`. If this PR has no rendered delta, artifact documents the checked surface after/without visual changes.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: [UI fixture/check artifact]() from `https://github.com/elizaOS/eliza/pull/15134` (Playwright trace/media bundle or CI visual artifact when available).

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no backend runtime path changed by this PR, or covered by deterministic CI checks`.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: [UI fixture/check artifact]() from `https://github.com/elizaOS/eliza/pull/15134`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - deterministic code/test change, no LLM call path changed`.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts / OCR visual text review: [aesthetic-audit run](https://github.com/elizaOS/eliza/pull/15134) plus [UI fixture/check artifact](). No visible text/UI change if this is logic-only UI-package wiring.
