### PR TITLE
fix(ui): re-anchor keyboard-open chat geometry to the visual viewport (post-#15103 regression) [sol-orch]

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -65,7 +65,12 @@ import { useThreadAutoScroll } from "../../hooks/useThreadAutoScroll";
 import { Z_SHELL_OVERLAY } from "../../lib/floating-layers";
 import { cn } from "../../lib/utils";
 import { claimAssistantLaunchPayloadFromHash } from "../../platform/assistant-launch-payload";
-import { STANDALONE_BOTTOM_RECLAIM_OFFSET } from "../../platform/standalone-bottom-reclaim";
+import { isIOS, isNative, isStandalonePwa } from "../../platform/init";
+import {
+  KEYBOARD_INTRUSION_THRESHOLD_PX,
+  STANDALONE_BOTTOM_RECLAIM_OFFSET,
+  shouldInstallStandaloneBottomReclaim,
+} from "../../platform/standalone-bottom-reclaim";
 import { useAppSelectorShallow } from "../../state";
 import {
   clearChatDraft,
@@ -210,6 +215,23 @@ const CHAT_PANEL_THEME = {
 // opacity/translate only: animating blur/filter or scaling a scrollable
 // transcript repaints too much of the viewport and visibly janks on laptops.
 const OVERLAY_EASE: [number, number, number, number] = [0.22, 1, 0.36, 1];
+
+// Whether the `screen.height`-derived keyboard signal in `readViewport` is
+// trustworthy. Only on the iOS standalone PWA / iOS native WebView is
+// `window.screen.height` a valid full-viewport reference (the value that still
+// exposes the true keyboard-down height after #15103 un-collapsed innerHeight,
+// device chip `sh932`). On desktop `screen.height` is the whole monitor and on
+// Android / non-standalone it is the full device screen — both far larger than
+// the layout viewport at REST, so a screen-vs-vv delta would be a large
+// false-positive keyboard. Mirrors the bottom-reclaim install gate exactly, so
+// the two systems agree on which surface owns the collapsed-viewport geometry.
+const SCREEN_KEYBOARD_SIGNAL_ACTIVE =
+  typeof window !== "undefined" &&
+  shouldInstallStandaloneBottomReclaim({
+    standalonePwa: isStandalonePwa(),
+    isNative,
+    isIOS,
+  });
 
 // Pull-sheet detents. The chat-history window is bottom-anchored just above the
 // fixed composer; its height animates between the closed composer/grabber and
@@ -2056,9 +2078,58 @@ export function ContinuousChatOverlay({
     const vv = window.visualViewport;
     const innerHeight = window.innerHeight;
     const height = vv?.height ?? innerHeight;
-    const keyboardInset = vv
-      ? Math.max(0, innerHeight - vv.height - vv.offsetTop)
-      : 0;
+    // How far the keyboard intrudes from the layout bottom. Historically this
+    // was `innerHeight - vv.height`: on iOS (`resize:"body"`, pre-#15103)
+    // innerHeight stayed at the FULL height while vv.height shrank, so the delta
+    // WAS the keyboard height; on Android (adjustResize) innerHeight shrinks
+    // with vv.height so the delta is ~0 and the native-lift path owns it.
+    //
+    // r-kbd REGRESSION: post-#15103 `html` is `100lvh`, which UN-collapsed the
+    // iOS layout viewport — now the soft keyboard shrinks `innerHeight` AND
+    // `visualViewport.height` TOGETHER to the visible area (device chip
+    // `ih542 vv542 sh932`). So `innerHeight - vv.height = 0` and the keyboard is
+    // invisible to this delta: the composer never lifts and hides behind the
+    // keyboard. The value that still exposes the full keyboard-down height on
+    // the installed iOS PWA is `window.screen.height` (`sh932`), so also derive
+    // the intrusion as `screen.height - vv.height` and take the larger signal.
+    //
+    // The screen-based signal is GATED to the iOS standalone-PWA / iOS-native
+    // surface (SCREEN_KEYBOARD_SIGNAL_ACTIVE — the same gate the bottom-reclaim
+    // installs on). Everywhere else `screen.height` is NOT a viewport height:
+    // on a desktop browser it is the whole monitor (e.g. 1080 while the window
+    // is 800), and on Android Chrome / non-standalone it is the full device
+    // screen — so `screen.height - vv.height` would be a large false-positive at
+    // REST and wrongly lift the composer. Those surfaces keep the pure
+    // `innerHeight - vv.height` delta (Android adjustResize / web) untouched.
+    // The screen delta also picks up the resting fixed-body ICB collapse (~59px,
+    // NOT a keyboard) on iOS, so it is additionally gated below the intrusion
+    // threshold: a real soft keyboard eats ~250-400px, the resting collapse only
+    // ~20-80px.
+    let keyboardInset = 0;
+    if (vv) {
+      const insetFromInner = Math.max(
+        0,
+        innerHeight - vv.height - vv.offsetTop,
+      );
+      let screenKeyboard = 0;
+      if (SCREEN_KEYBOARD_SIGNAL_ACTIVE) {
+        const screenHeight =
+          typeof window.screen?.height === "number" && window.screen.height > 0
+            ? window.screen.height
+            : 0;
+        const insetFromScreen =
+          screenHeight > 0
+            ? Math.max(0, screenHeight - vv.height - vv.offsetTop)
+            : 0;
+        // Only trust the screen-based signal once it clears the resting-collapse
+        // band (so the ~59px fixed-body ICB collapse is never a keyboard).
+        screenKeyboard =
+          insetFromScreen >= KEYBOARD_INTRUSION_THRESHOLD_PX
+            ? insetFromScreen
+            : 0;
+      }
+      keyboardInset = Math.max(insetFromInner, screenKeyboard);
+    }
     // innerHeight is the LAYOUT viewport: on Android it shrinks (adjustResize)
     // when the keyboard opens, on iOS (`resize: "body"`) it does not. The lift
     // math below uses that to avoid double-counting the keyboard. innerWidth +

--- a/packages/ui/src/components/shell/chat-panel-layout.test.ts
+++ b/packages/ui/src/components/shell/chat-panel-layout.test.ts
@@ -217,6 +217,54 @@ describe("resolveChatPanelLayout", () => {
     expect(276 + 12 + buggyPanelMaxH).toBeGreaterThan(393);
   });
 
+  it("seats the panel between the notch and the keyboard on the measured device geometry (ih542 vv542 sh932, kbd 390)", () => {
+    // The EXACT device chip that reproduced the bug: keyboard open in the
+    // continuous-chat overlay, ih542 vv542 ce873 sh932. Post the readViewport
+    // fix the keyboard is DETECTED via screen.height - vv.height = 390, so both
+    // keyboardInset and effectiveKeyboardInset are 390 (visual viewport already
+    // reflects the shrink) and nothing extra is subtracted. The panel bounds to
+    // the 542px visual viewport, its bottom rides the keyboard top, and its top
+    // lands one notch-margin below the screen top — NO wallpaper void, composer
+    // visible above the keyboard.
+    const KB = 390;
+    const VISIBLE = 542; // visualViewport.height with the keyboard up
+    const PHYS = 932; // screen.height
+    const input: ChatPanelLayoutInput = {
+      viewportH: VISIBLE, // sizes to the visible area, not lvh/screen
+      bottomPad: 12, // keyboardLiftActive padding (0.75rem)
+      keyboardInset: KB, // now DETECTED (was 0 pre-fix -> the void)
+      effectiveKeyboardInset: KB,
+      safeAreaTopPx: NOTCH,
+      fullBleed: false,
+    };
+    const { topMargin, panelMaxH } = resolveChatPanelLayout(input);
+    // No unreported lift: keyboardInset === effectiveKeyboardInset, so the panel
+    // sizes cleanly against the visible viewport.
+    expect(panelMaxH).toBe(
+      VISIBLE - 12 - Math.max(SHEET_TOP_MARGIN, NOTCH + 8),
+    );
+    expect(PHYS - KB).toBe(VISIBLE); // the keyboard top IS the visible bottom
+    // panelTopFromBottom measures the panel TOP from the physical screen bottom
+    // (effectiveKeyboardInset + bottomPad + panelMaxH). The panel top must land
+    // topMargin below the physical screen TOP — i.e. PHYS - topMargin measured
+    // from the bottom — so it is on-screen, never above the notch, no void.
+    const topFromBottom = panelTopFromBottom(input, panelMaxH);
+    expect(topFromBottom).toBe(PHYS - topMargin);
+    // In screen-top coordinates the panel top is exactly topMargin (below the
+    // notch): PHYS - topFromBottom = 72.
+    expect(PHYS - topFromBottom).toBe(topMargin);
+    // The panel bottom sits just above the keyboard: the overlay is lifted the
+    // full keyboard height (KB) plus its own composer padding (bottomPad), so
+    // the panel bottom in screen-top coords is PHYS - KB - bottomPad, one small
+    // 0.75rem gap above the keyboard top (VISIBLE = PHYS - KB). No void.
+    const panelBottomFromTop = PHYS - (KB + input.bottomPad);
+    expect(panelBottomFromTop).toBe(VISIBLE - input.bottomPad);
+    expect(panelBottomFromTop - (PHYS - topFromBottom)).toBe(panelMaxH);
+    // The composer (overlay bottom) is lifted the full keyboard height, so it is
+    // visible above the keyboard rather than hidden behind it.
+    expect(input.effectiveKeyboardInset).toBe(KB);
+  });
+
   it("treats a non-finite safe-area measurement as zero", () => {
     const { topMargin } = resolveChatPanelLayout({
       viewportH: 800,

--- a/packages/ui/src/platform/standalone-bottom-reclaim.test.ts
+++ b/packages/ui/src/platform/standalone-bottom-reclaim.test.ts
@@ -170,8 +170,81 @@ describe("measureStandaloneBottomGap: the screen.height cure for the collapsed-I
   });
 
   it("clamps an absurd transient delta (mid-rotation) to a sane upper bound", () => {
-    stubViewport({ layoutHeight: 300, screenHeight: 2000 });
+    // A mid-rotation transient where the LAYOUT box (innerHeight) is briefly
+    // tiny while screen.height reads the post-rotation dimension. The visual
+    // viewport tracks the screen here (NOT a keyboard shrink), so the keyboard
+    // guard stays disarmed and the clamp path runs: gap 1700 -> 160.
+    stubViewport({
+      layoutHeight: 300,
+      innerHeight: 300,
+      visualHeight: 2000,
+      screenHeight: 2000,
+    });
     expect(measureStandaloneBottomGap()).toBe(160);
+  });
+});
+
+describe("measureStandaloneBottomGap: keyboard-open freeze (the r-kbd regression, device chip ih542 vv542 ce873 sh932)", () => {
+  it("FREEZES the resting reclaim while the soft keyboard is up instead of re-measuring against the shrunk innerHeight", () => {
+    // 1) Establish the resting keyboard-DOWN reclaim first. Post-#15103 the
+    //    un-collapsed shell reads ih932 vv932 sh932 -> reclaim 0 (self-zero).
+    stubViewport({
+      layoutHeight: 932,
+      innerHeight: 932,
+      visualHeight: 932,
+      screenHeight: 932,
+    });
+    expect(measureStandaloneBottomGap()).toBe(0);
+
+    // 2) Now the soft keyboard opens: the DEVICE chip geometry ih542 vv542
+    //    sh932. A naive re-measure would read screen.height - innerHeight =
+    //    932 - 542 = 390 (clamped 160) and shove every fixed layer down,
+    //    fighting the composer's own keyboard lift. The keyboard guard detects
+    //    the visual-viewport shortfall (932 - 542 = 390 >= 140) and FREEZES the
+    //    resting value (0) instead. The composer lift owns keyboard geometry.
+    stubViewport({
+      layoutHeight: 873, // documentElement.clientHeight stays 873 with kbd up
+      innerHeight: 542, // keyboard shrank innerHeight (the r-kbd trap)
+      visualHeight: 542, // and the visual viewport too
+      screenHeight: 932,
+    });
+    expect(measureStandaloneBottomGap()).toBe(0);
+  });
+
+  it("re-serves a NON-zero resting reclaim (a collapsed shell) unchanged while the keyboard is up", () => {
+    // If a shell collapses innerHeight to 873 at rest (screen 932 -> resting
+    // gap 59), the keyboard-up branch must re-serve that 59 (NOT jump to the
+    // 390 keyboard delta). The resting reclaim is a fixed physical-collapse
+    // constant; the keyboard must never change it.
+    stubViewport({
+      layoutHeight: 873,
+      innerHeight: 873,
+      visualHeight: 873,
+      screenHeight: 932,
+    });
+    expect(measureStandaloneBottomGap()).toBe(59); // resting, keyboard down
+
+    stubViewport({
+      layoutHeight: 873,
+      innerHeight: 483, // keyboard up, innerHeight shrank
+      visualHeight: 483, // visual viewport shrank (shortfall 449 >= 140)
+      screenHeight: 932,
+    });
+    expect(measureStandaloneBottomGap()).toBe(59); // frozen resting value
+  });
+
+  it("does NOT freeze for the resting fixed-body collapse (shortfall below the keyboard threshold)", () => {
+    // The resting ICB collapse (~59px) drops the visual viewport only slightly
+    // below the screen (932 - 873 = 59 < 140), so the guard stays disarmed and
+    // the reclaim measures normally. This proves the threshold separates the
+    // resting collapse from a real keyboard.
+    stubViewport({
+      layoutHeight: 873,
+      innerHeight: 873,
+      visualHeight: 873, // shortfall 59 < 140 -> NOT a keyboard
+      screenHeight: 932,
+    });
+    expect(measureStandaloneBottomGap()).toBe(59);
   });
 });
 

--- a/packages/ui/src/platform/standalone-bottom-reclaim.ts
+++ b/packages/ui/src/platform/standalone-bottom-reclaim.ts
@@ -56,6 +56,35 @@
 const RECLAIM_VAR = "--standalone-bottom-reclaim";
 
 /**
+ * A visual-viewport shortfall (`screen.height - visualViewport.height`) at or
+ * above this many CSS px is treated as a soft-keyboard intrusion, not the
+ * resting fixed-body ICB collapse. The resting collapse is ~20-80px (the
+ * home-indicator strip); a soft keyboard eats ~250-400px. 140 sits well above
+ * the largest plausible resting collapse (clamped to 160 elsewhere) and well
+ * below the smallest soft keyboard, so it separates the two regimes cleanly.
+ *
+ * WHY THIS GUARD EXISTS (the keyboard-open regression, device r-kbd):
+ * post-#15103 `html` is `100lvh`, which UN-collapsed `innerHeight` — at rest it
+ * now reads the true screen (932). But when the soft keyboard opens on the
+ * installed iOS PWA, `innerHeight` AND `visualViewport.height` BOTH shrink to
+ * the visible area (chip: `ih542 vv542 sh932`). The resting reclaim measures
+ * `screen.height - innerHeight`; with the keyboard up that is `932 - 542 = 390`
+ * (clamped 160), which would shove every fixed layer 160px DOWN mid-keyboard
+ * and fight the composer's own keyboard lift. The resting reclaim must only
+ * ever describe the keyboard-DOWN collapse, so when this shortfall says a
+ * keyboard is up we FREEZE the last resting value instead of re-measuring.
+ */
+export const KEYBOARD_INTRUSION_THRESHOLD_PX = 140;
+
+/**
+ * The last reclaim value measured while the keyboard was DOWN. Frozen and
+ * re-served whenever a soft keyboard is detected up, so the resting reclaim var
+ * never absorbs the keyboard-shrunk `innerHeight`. Seeded 0 (a no-op) until the
+ * first keyboard-down measurement runs.
+ */
+let lastRestingGap = 0;
+
+/**
  * The measured true-vs-layout viewport delta in CSS px, clamped to a sane
  * range. Returns 0 when we can't trust the measurement (SSR, missing globals)
  * or when the physical screen and the layout box agree (desktop / Android /
@@ -95,6 +124,15 @@ export function measureStandaloneBottomGap(): number {
   // shell, and the reclaim self-zeroes. If a future engine still collapses
   // innerHeight, this correctly reports the real gap again. `screen.height`
   // stays the true-screen reference.
+  //
+  // r-kbd UPDATE (the keyboard-open regression): because we now measure against
+  // `innerHeight`, and the soft keyboard shrinks `innerHeight` (post-#15103,
+  // device chip `ih542` with the keyboard up), a naive re-measure would read a
+  // 390px "gap" mid-keyboard and shove every layer down. The keyboard guard
+  // below (visual-viewport shortfall >= KEYBOARD_INTRUSION_THRESHOLD_PX) freezes
+  // the last keyboard-DOWN value while the keyboard is up, so the resting
+  // reclaim only ever describes the keyboard-down collapse. The keyboard's own
+  // lift is owned by the composer's `effectiveKeyboardInset` path, not here.
   const layoutHeight =
     typeof window.innerHeight === "number" && window.innerHeight > 0
       ? window.innerHeight
@@ -109,6 +147,29 @@ export function measureStandaloneBottomGap(): number {
       : 0;
   if (screenHeight <= 0) return 0;
 
+  // KEYBOARD-OPEN GUARD (the r-kbd regression): the resting reclaim measures
+  // against `innerHeight`, but post-#15103 the soft keyboard shrinks BOTH
+  // `innerHeight` and `visualViewport.height` to the visible area (device chip
+  // `ih542 vv542 sh932`). Re-measuring then would give `932 - 542 = 390`
+  // (clamped 160) and shove every fixed layer down mid-keyboard, fighting the
+  // composer's own `effectiveKeyboardInset` lift. Detect the keyboard via the
+  // visual-viewport shortfall (a keyboard eats ~250-400px, the resting collapse
+  // only ~20-80px) and FREEZE the last resting value instead of contaminating
+  // it. `visualViewport.height` is the reliable keyboard signal here because it
+  // ALWAYS tracks the visible area (the resting collapse leaves it within the
+  // threshold of the screen; the keyboard drops it far below).
+  const visualHeight =
+    typeof window.visualViewport?.height === "number" &&
+    window.visualViewport.height > 0
+      ? window.visualViewport.height
+      : layoutHeight;
+  const keyboardShortfall = screenHeight - visualHeight;
+  if (keyboardShortfall >= KEYBOARD_INTRUSION_THRESHOLD_PX) {
+    // Keyboard is up: keep serving the frozen keyboard-down reclaim (the
+    // composer's own lift owns keyboard geometry). Never re-measure here.
+    return lastRestingGap;
+  }
+
   const gap = screenHeight - layoutHeight;
 
   // Only a POSITIVE gap is the collapse we reclaim. Zero (web/desktop/Android,
@@ -117,8 +178,17 @@ export function measureStandaloneBottomGap(): number {
   // upper bound: a real home-indicator collapse is ~20–80px; a larger delta is
   // a transient (rotation mid-flight, an off-by-a-scaled-factor screen.height on
   // an exotic DPR) we refuse to translate a layer by.
-  if (!Number.isFinite(gap) || gap <= 0) return 0;
-  return Math.min(gap, 160);
+  if (!Number.isFinite(gap) || gap <= 0) {
+    // A clean keyboard-down measurement of 0 (un-collapsed shell) is the new
+    // resting truth — remember it so the keyboard-up branch freezes 0, not a
+    // stale non-zero from an earlier collapsed frame.
+    lastRestingGap = 0;
+    return 0;
+  }
+  const clamped = Math.min(gap, 160);
+  // Freeze this keyboard-down value so the keyboard-up branch can re-serve it.
+  lastRestingGap = clamped;
+  return clamped;
 }
 
 /**
@@ -144,6 +214,9 @@ export function clearStandaloneBottomReclaim(): void {
     activeDisposer();
     activeDisposer = null;
   }
+  // Forget any frozen resting gap: a surface re-initialised as non-standalone
+  // must not re-serve a stale iOS collapse value if it later re-arms.
+  lastRestingGap = 0;
   if (typeof document === "undefined") return;
   document.documentElement.style.setProperty(RECLAIM_VAR, "0px");
 }

--- a/packages/ui/src/platform/standalone-pwa-lockdown.test.ts
+++ b/packages/ui/src/platform/standalone-pwa-lockdown.test.ts
@@ -523,6 +523,37 @@ describe("Keyboard-lift geometry contract — reclaim does NOT shift the compose
     expect(layoutSrc).not.toContain("100lvh");
     expect(layoutSrc).not.toContain("100dvh");
   });
+
+  it("detects the soft keyboard via screen.height (not just innerHeight - vv.height) so post-#15103 the composer still lifts", () => {
+    // r-kbd REGRESSION guard: post-#15103 `html:100lvh` un-collapsed the iOS
+    // layout viewport, so the soft keyboard shrinks innerHeight AND
+    // visualViewport.height TOGETHER (device chip ih542 vv542 sh932). The old
+    // `innerHeight - vv.height` delta then reads 0 and the composer never lifts
+    // (hidden behind the keyboard, wallpaper void above the panel). readViewport
+    // must ALSO derive the intrusion from `screen.height - vv.height` and take
+    // the larger signal, gated above KEYBOARD_INTRUSION_THRESHOLD_PX so the
+    // resting fixed-body collapse (~59px) is never read as a keyboard.
+    expect(overlaySrc).toContain("insetFromScreen");
+    expect(overlaySrc).toContain("window.screen?.height");
+    expect(overlaySrc).toContain("KEYBOARD_INTRUSION_THRESHOLD_PX");
+    // The two signals are combined with max() so Android/web (which keep the
+    // pure inner-delta) are unchanged.
+    expect(overlaySrc).toContain(
+      "keyboardInset = Math.max(insetFromInner, screenKeyboard)",
+    );
+  });
+
+  it("gates the screen.height keyboard signal to iOS standalone/native (never desktop/Android where screen.height is the whole device)", () => {
+    // screen.height is only a valid full-viewport reference on the iOS
+    // standalone PWA / iOS native WebView (where the reclaim installs). On
+    // desktop it is the monitor and on Android / non-standalone the full device
+    // screen, both far larger than the layout viewport at rest — so the
+    // screen-vs-vv delta must be OFF there or it would false-positive a keyboard
+    // and lift the composer at rest. The gate mirrors the reclaim install gate.
+    expect(overlaySrc).toContain("SCREEN_KEYBOARD_SIGNAL_ACTIVE");
+    expect(overlaySrc).toContain("if (SCREEN_KEYBOARD_SIGNAL_ACTIVE) {");
+    expect(overlaySrc).toContain("shouldInstallStandaloneBottomReclaim({");
+  });
 });
 
 describe("Fixed background layers reach the TRUE physical bottom (bottom-bar root cause)", () => {


### PR DESCRIPTION
## fix(ui): re-anchor keyboard-open chat geometry to the visual viewport (post-#15103 regression)

The iOS standalone-PWA continuous-chat overlay broke when the soft keyboard opened: the glass panel floated in the **middle** of the screen with a large wallpaper void above it, and the **composer was hidden behind the keyboard** (user cannot see what they type).

### Evidence

| what | value |
|---|---|
| before-evidence | Shadow device screenshot, sol-dev build `8a923b5ae1` (develop tip), 2026-07-06 14:44 MDT |
| geometry chip (BuildBadge) | `ih542 vv542 ce873 sh932 rc0 lv932 dv873` |
| meaning | keyboard consumes 390px; innerHeight/visualViewport correctly report the 542 visible area; documentElement.clientHeight stays 873; screen 932 |
| symptom 1 | panel floats mid-screen, wallpaper void above the panel top |
| symptom 2 | composer not visible above the keyboard |

### Root cause (a regression from #15103's `html:100lvh`)

- **#15103** sized `html` to `100lvh`, which UN-collapsed the iOS layout viewport. Before it, iOS (`resize:"body"`) kept `innerHeight` at the full height while `visualViewport.height` shrank for the keyboard, so `innerHeight - vv.height` **was** the keyboard height. After it, the soft keyboard shrinks `innerHeight` **and** `visualViewport.height` **together** to the visible area (both 542) — so that delta reads **0**. The keyboard is invisible: `keyboardInset = 0`, `keyboardLiftActive = false`, the composer never lifts (hidden behind the keyboard), and the panel is anchored at the resting bottom while sized to the 542 visible area, leaving the void above it.
- The resting bottom-reclaim (`measureStandaloneBottomGap`) measures against `innerHeight`; with the keyboard shrinking innerHeight to 542 it computed `screen.height(932) - 542 = 390` (clamped 160) and would shove every fixed layer 160px down mid-keyboard, fighting the composer lift (why `rc` is unstable while the keyboard animates).

### Fix

- **`readViewport`** also derives the keyboard intrusion from `screen.height - visualViewport.height` (the value that still exposes the true keyboard-down height post-#15103, `sh932`) and takes the larger of it and the legacy inner-delta.
  - Gated to the iOS standalone-PWA / iOS-native surface (`SCREEN_KEYBOARD_SIGNAL_ACTIVE`, mirrors the reclaim install gate) so desktop (screen = monitor) and Android / non-standalone (screen = full device) never false-positive a keyboard at rest.
  - Gated above `KEYBOARD_INTRUSION_THRESHOLD_PX` (140) so the ~59px resting fixed-body collapse is never read as a keyboard.
  - Now the keyboard is detected (390), the composer lifts above it, and the panel bounds cleanly to the 542 visible viewport — **no void**.
- **`standalone-bottom-reclaim`** freezes the last keyboard-DOWN reclaim value while a soft keyboard is up (detected by the same visual-viewport shortfall) instead of re-measuring against the keyboard-shrunk innerHeight. The resting reclaim now only ever describes the keyboard-down collapse; the keyboard's own lift is owned by the composer's `effectiveKeyboardInset` path.

### Keyboard-state geometry contract (implemented)

| state | reclaim var | composer lift | panel bounds |
|---|---|---|---|
| keyboard DOWN (rest) | `screen - innerHeight` (0 post-#15103, 59 on a collapsed shell) | 0 (resting reclaim seats the composer at true bottom) | full visible viewport |
| keyboard UP | **frozen** at the resting value (not the 390 keyboard delta) | `effectiveKeyboardInset` = detected keyboard height (390) | visual viewport (542): top below notch, bottom at keyboard top |

Both transitions run through the existing rAF-coalesced measurement path, no flicker loop; keyboard close un-freezes the reclaim and un-lifts the composer back to the resting state shipped in #15103.

### Files
- `packages/ui/src/components/shell/ContinuousChatOverlay.tsx` — screen.height keyboard signal in `readViewport`, gated to iOS standalone/native.
- `packages/ui/src/platform/standalone-bottom-reclaim.ts` — keyboard-open freeze of the resting reclaim + `KEYBOARD_INTRUSION_THRESHOLD_PX`.
- `packages/ui/src/platform/standalone-bottom-reclaim.test.ts` — keyboard-open freeze contract (measured geometry).
- `packages/ui/src/components/shell/chat-panel-layout.test.ts` — measured keyboard geometry (542/932, kbd 390) panel-bounds contract.
- `packages/ui/src/platform/standalone-pwa-lockdown.test.ts` — screen.height signal + threshold + iOS-standalone gate assertions.

### Tests

```
vitest run standalone-bottom-reclaim.test.ts chat-panel-layout.test.ts standalone-pwa-lockdown.test.ts
 ✓ chat-panel-layout.test.ts (18 tests)
 ✓ standalone-bottom-reclaim.test.ts (17 tests)
 ✓ standalone-pwa-lockdown.test.ts (31 tests)
 Test Files  3 passed (3)
      Tests  66 passed (66)

+ ContinuousChatOverlay.test.tsx (163 tests) — all pass (render regression guard)
+ BuildBadge.test.tsx — pass

biome check: clean (5 files)
tsc: no errors in the touched files (pre-existing cloud/tui/e2e module-resolution noise only)
```

> [!IMPORTANT]
> **Do NOT self-merge.** Hot-deploy to sol-dev for Shadow's on-device verify FIRST.

[sol-orch]

Co-authored-by: wakesync <shadow@shad0w.xyz>

## Required evidence rows

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: [fixture/e2e visual artifact run](https://github.com/elizaOS/eliza/actions/runs/28823430148) and [aesthetic audit run](https://github.com/elizaOS/eliza/actions/runs/28823430155); pre-fix defect recorded from Shadow device screenshot/thread for keyboard-open geometry regression.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: [fixture/e2e visual artifact run](https://github.com/elizaOS/eliza/actions/runs/28823430148) and [aesthetic audit run](https://github.com/elizaOS/eliza/actions/runs/28823430155); PR branch visual artifacts attached by CI when jobs complete.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: [fixture/e2e Playwright trace/media run](https://github.com/elizaOS/eliza/actions/runs/28823430148); keyboard-open geometry path captured in CI/device-verification handoff.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - frontend/iOS PWA geometry fix only, no backend code path changed`.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: [fixture/e2e run](https://github.com/elizaOS/eliza/actions/runs/28823430148) and [aesthetic audit run](https://github.com/elizaOS/eliza/actions/runs/28823430155).

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - deterministic viewport/layout geometry fix, no LLM call path changed`.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts / OCR visual text review: [aesthetic-audit run](https://github.com/elizaOS/eliza/actions/runs/28823430155) plus [fixture/e2e run](https://github.com/elizaOS/eliza/actions/runs/28823430148); visual text/geometry evidence is in CI artifacts and device-verification handoff.
