### PR TITLE
fix(ui): distinguish Android local-agent cold boot from death

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/AgentPlugin.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/AgentPlugin.java
@@ -44,6 +44,15 @@ public class AgentPlugin extends Plugin {
     }
 
     @PluginMethod
+    public void getLocalAgentBootState(PluginCall call) {
+        try {
+            call.resolve(toJsObject(ElizaAgentService.getLocalAgentBootState(getContext())));
+        } catch (JSONException e) {
+            call.reject("Failed to read local agent boot state", e);
+        }
+    }
+
+    @PluginMethod
     public void getLocalAgentToken(PluginCall call) {
         JSObject result = new JSObject();
         String token = ElizaAgentService.localAgentToken(getContext());

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -211,6 +211,7 @@ public class ElizaAgentService extends Service {
     // token via ELIZA_REQUIRE_LOCAL_AUTH=1.
     private static volatile String currentLocalAgentToken;
     private static volatile String currentTerminalRunToken;
+    private static volatile ElizaAgentService activeInstance;
 
     /** Called by the Capacitor agent plugin Android binding. */
     public static String localAgentToken() {
@@ -225,6 +226,70 @@ public class ElizaAgentService extends Service {
      * the dashboard at the pairing screen. Fall back to the recovery file that
      * {@link #writeLocalAgentTokenFile} persists, and cache it for this process.
      */
+    public static JSONObject getLocalAgentBootState(Context context) throws JSONException {
+        ElizaAgentService instance = activeInstance;
+        boolean socketListening = isLocalAgentSocketListening();
+        long launchStartedAtMs = 0L;
+        String status = "unknown";
+        int attempts = 0;
+        boolean hasStartWorker = false;
+        boolean detached = false;
+        if (instance != null) {
+            synchronized (instance.processLock) {
+                status = instance.currentStatus;
+                attempts = instance.restartAttempts;
+                detached = instance.detachedAgentMode;
+                launchStartedAtMs = instance.detachedLaunchStartedAtMs;
+                hasStartWorker = instance.startWorker != null && instance.startWorker.isAlive();
+            }
+        }
+        if (launchStartedAtMs <= 0L && context != null) {
+            launchStartedAtMs = context.getSharedPreferences(EXIT_INFO_PREFS, Context.MODE_PRIVATE)
+                .getLong(DETACHED_LAUNCH_STAMP_KEY, 0L);
+        }
+        long ageMs = launchStartedAtMs > 0L
+            ? Math.max(0L, System.currentTimeMillis() - launchStartedAtMs)
+            : -1L;
+
+        JSONObject result = new JSONObject();
+        if (socketListening) {
+            result.put("state", "listening");
+            result.put("reason", "request socket is accepting connections");
+        } else if ("restarting".equals(status)) {
+            result.put("state", "restarting");
+            result.put("reason", status);
+        } else if (isTerminalBootStatus(status)) {
+            result.put("state", "dead");
+            result.put("reason", status);
+        } else if (hasStartWorker
+                || "starting".equals(status)
+                || (detached && ageMs >= 0L && ageMs < AGENT_BOOT_GRACE_MS)
+                || (ageMs >= 0L && ageMs < AGENT_BOOT_GRACE_MS)) {
+            result.put("state", "booting");
+            result.put("reason", status);
+        } else {
+            result.put("state", "dead");
+            result.put("reason", "local agent service is not booting and the request socket is closed");
+        }
+        if (attempts > 0) {
+            result.put("attempt", attempts);
+        }
+        if (ageMs >= 0L) {
+            result.put("ageMs", ageMs);
+        }
+        result.put("socketListening", socketListening);
+        result.put("serviceActive", instance != null);
+        return result;
+    }
+
+    private static boolean isTerminalBootStatus(String status) {
+        if (status == null) return false;
+        return status.startsWith("agent exited:")
+            || "fatal".equals(status)
+            || status.endsWith("-failed")
+            || status.startsWith("missing-");
+    }
+
     public static String localAgentToken(Context context) {
         String token = currentLocalAgentToken;
         if (token != null && !token.trim().isEmpty()) {
@@ -634,6 +699,7 @@ public class ElizaAgentService extends Service {
     @Override
     public void onCreate() {
         super.onCreate();
+        activeInstance = this;
         ensureNotificationChannel();
 
         Notification notification = buildNotification("Eliza agent", "Starting…");
@@ -775,6 +841,9 @@ public class ElizaAgentService extends Service {
         NotificationManager mgr = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
         if (mgr != null) {
             mgr.cancel(NOTIFICATION_ID);
+        }
+        if (activeInstance == this) {
+            activeInstance = null;
         }
         super.onDestroy();
     }
@@ -2992,7 +3061,7 @@ public class ElizaAgentService extends Service {
      * #startAgentProcess()} to adopt a surviving detached agent instead of
      * killing + restarting it when the service/Activity is recreated.
      */
-    private boolean isLocalAgentSocketListening() {
+    private static boolean isLocalAgentSocketListening() {
         LocalSocket socket = new LocalSocket();
         try {
             socket.connect(new LocalSocketAddress(

--- a/packages/ui/src/api/android-native-agent-transport.ts
+++ b/packages/ui/src/api/android-native-agent-transport.ts
@@ -396,9 +396,13 @@ export async function getAndroidLocalAgentBootStateForUrl(
     ) {
       return state;
     }
-  } catch {
+  } catch (err) {
     // error-policy:J4 boot-state is a progress hint. A failed hint must fall
     // back to the existing HTTP heuristic rather than make startup fatal.
+    return {
+      state: "unknown",
+      reason: `native boot-state probe failed: ${String((err as { message?: string })?.message ?? err)}`,
+    };
   }
   return { state: "unknown", reason: "native boot-state probe failed" };
 }

--- a/packages/ui/src/api/android-native-agent-transport.ts
+++ b/packages/ui/src/api/android-native-agent-transport.ts
@@ -47,10 +47,18 @@ export interface NativeAgentRequestResult {
   bodyEncoding?: string;
 }
 
+export type AndroidLocalAgentBootState =
+  | { state: "booting"; reason?: string; ageMs?: number }
+  | { state: "listening"; reason?: string; ageMs?: number }
+  | { state: "restarting"; reason?: string; attempt?: number; ageMs?: number }
+  | { state: "dead"; reason?: string; ageMs?: number }
+  | { state: "unknown"; reason?: string };
+
 type NativeAgentPlugin = {
   start?: () => Promise<unknown>;
   stop?: () => Promise<unknown>;
   getStatus?: () => Promise<unknown>;
+  getLocalAgentBootState?: () => Promise<AndroidLocalAgentBootState>;
   request?: (
     options: NativeAgentRequestOptions,
   ) => Promise<NativeAgentRequestResult>;
@@ -82,11 +90,22 @@ function toNativeAgentPlugin(
   const start = plugin.start?.bind(plugin);
   const stop = plugin.stop?.bind(plugin);
   const getStatus = plugin.getStatus?.bind(plugin);
+  const getLocalAgentBootState = plugin.getLocalAgentBootState?.bind(plugin);
   const request = plugin.request?.bind(plugin);
   const requestStream = plugin.requestStream?.bind(plugin);
   const addListener = plugin.addListener?.bind(plugin);
-  if (!start && !stop && !getStatus && !request) return null;
-  return { start, stop, getStatus, request, requestStream, addListener };
+  if (!start && !stop && !getStatus && !request && !getLocalAgentBootState) {
+    return null;
+  }
+  return {
+    start,
+    stop,
+    getStatus,
+    getLocalAgentBootState,
+    request,
+    requestStream,
+    addListener,
+  };
 }
 
 function isNativeAndroid(): boolean {
@@ -355,6 +374,33 @@ export async function androidNativeAgentLifecycleForUrl(
 ): Promise<NativeAgentPlugin | null> {
   if (!url || !shouldAttemptNativeAgentTransport(url)) return null;
   return resolveNativeAgentPlugin();
+}
+
+export async function getAndroidLocalAgentBootStateForUrl(
+  url: string | null | undefined,
+): Promise<AndroidLocalAgentBootState> {
+  if (!url || !shouldAttemptNativeAgentTransport(url)) {
+    return { state: "unknown", reason: "not an Android local-agent URL" };
+  }
+  const agent = await resolveNativeAgentPlugin();
+  if (!agent?.getLocalAgentBootState) {
+    return { state: "unknown", reason: "native boot-state API unavailable" };
+  }
+  try {
+    const state = await agent.getLocalAgentBootState();
+    if (
+      state?.state === "booting" ||
+      state?.state === "listening" ||
+      state?.state === "restarting" ||
+      state?.state === "dead"
+    ) {
+      return state;
+    }
+  } catch {
+    // error-policy:J4 boot-state is a progress hint. A failed hint must fall
+    // back to the existing HTTP heuristic rather than make startup fatal.
+  }
+  return { state: "unknown", reason: "native boot-state probe failed" };
 }
 
 export async function androidNativeAgentTransportForUrl(

--- a/packages/ui/src/state/startup-phase-poll.test.ts
+++ b/packages/ui/src/state/startup-phase-poll.test.ts
@@ -29,8 +29,25 @@ const cloudMock = vi.hoisted(() => ({
   getCloudAuthToken: vi.fn(() => null as string | null),
 }));
 
+const androidBootStateMock = vi.hoisted(() => ({
+  getAndroidLocalAgentBootStateForUrl: vi.fn(
+    async (): Promise<{
+      state: "unknown" | "booting" | "dead" | "listening" | "restarting";
+      reason?: string;
+      ageMs?: number;
+    }> => ({
+      state: "unknown",
+    }),
+  ),
+}));
+
 vi.mock("../api", () => ({
   client: clientMock,
+}));
+
+vi.mock("../api/android-native-agent-transport", () => ({
+  getAndroidLocalAgentBootStateForUrl:
+    androidBootStateMock.getAndroidLocalAgentBootStateForUrl,
 }));
 
 vi.mock("../api/client-cloud", () => ({
@@ -127,6 +144,9 @@ beforeEach(() => {
   });
   clientMock.hasToken.mockReturnValue(false);
   clientMock.getBaseUrl.mockReturnValue("");
+  androidBootStateMock.getAndroidLocalAgentBootStateForUrl.mockResolvedValue({
+    state: "unknown",
+  });
   cloudMock.getCloudAuthToken.mockReturnValue(null);
 });
 
@@ -1382,6 +1402,84 @@ describe("runPollingBackend bounded native boot (#11030)", () => {
       expect.objectContaining({ type: "AGENT_ERROR" }),
     );
     expect(dispatch).toHaveBeenCalledWith({ type: "BACKEND_TIMEOUT" });
+  });
+
+  it("keeps Android cold boots in progress when native boot-state says booting", async () => {
+    const deps = createDeps();
+    const dispatch = vi.fn();
+    installNativeWindow();
+    clientMock.getBaseUrl.mockReturnValue(mobileLocalServer.apiBase);
+    androidBootStateMock.getAndroidLocalAgentBootStateForUrl.mockResolvedValue({
+      state: "booting",
+      reason: "launcher is still within boot grace",
+    });
+    clientMock.getAuthStatus.mockReset();
+    clientMock.getAuthStatus.mockRejectedValue(
+      Object.assign(new Error("Local agent request failed"), {
+        kind: "network",
+        path: "/api/auth/status",
+      }),
+    );
+
+    await runPollingBackend(
+      deps,
+      dispatch,
+      {
+        ...nativePolicy,
+        backendTimeoutMs: 600,
+        nativeConsecutiveFailureBudgetMs: 150,
+      },
+      nativeCtx(),
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+    );
+
+    expect(androidBootStateMock.getAndroidLocalAgentBootStateForUrl).toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledWith({ type: "BACKEND_TIMEOUT" });
+    expect(deps.setStartupError).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("consecutive failures"),
+      }),
+    );
+  });
+
+  it("burns the Android native failure budget when boot-state says dead", async () => {
+    const deps = createDeps();
+    const dispatch = vi.fn();
+    installNativeWindow();
+    clientMock.getBaseUrl.mockReturnValue(mobileLocalServer.apiBase);
+    androidBootStateMock.getAndroidLocalAgentBootStateForUrl.mockResolvedValue({
+      state: "dead",
+      reason: "agent exited: exit 127",
+    });
+    clientMock.getAuthStatus.mockReset();
+    clientMock.getAuthStatus.mockRejectedValue(
+      Object.assign(new Error("Local agent request failed"), {
+        kind: "network",
+        path: "/api/auth/status",
+      }),
+    );
+
+    await runPollingBackend(
+      deps,
+      dispatch,
+      { ...nativePolicy, nativeConsecutiveFailureBudgetMs: 150 },
+      nativeCtx(),
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+    );
+
+    expect(dispatch).toHaveBeenCalledWith({ type: "BACKEND_TIMEOUT" });
+    expect(deps.setStartupError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "backend-timeout",
+        message: expect.stringContaining("consecutive failures"),
+      }),
+    );
   });
 
   it("bounds the native boot: consecutive failures past the native budget surface the last failure", async () => {

--- a/packages/ui/src/state/startup-phase-poll.ts
+++ b/packages/ui/src/state/startup-phase-poll.ts
@@ -21,6 +21,7 @@ import {
   isIosNativeAgentBootInProgress,
   isTerminalIosNativeAgentBootErrorMessage,
 } from "../api/ios-local-agent-transport";
+import { getAndroidLocalAgentBootStateForUrl } from "../api/android-native-agent-transport";
 import { getBackendStartupTimeoutMs } from "../bridge";
 import { resumePendingCloudHandoff } from "../cloud/handoff/resume-pending-handoff";
 import {
@@ -1049,30 +1050,38 @@ export async function runPollingBackend(
       }
       lastErr = err;
       if (isCapacitorNative()) {
-        // Android detached local agent has no in-process engine-phase signal
-        // (unlike the iOS in-process runtime), so a probe hang / connect
-        // failure against the local-agent IPC base means the abstract socket
-        // is not listening YET — i.e. the detached agent is still cold-booting
-        // (a 4 GB device takes ~60s; a first-run-triggered restart doubles
-        // that). Treat that as boot-progress and do NOT burn the consecutive-
-        // failure budget, mirroring the iOS boot-in-progress branch — the
-        // overall `deadline` still bounds the whole phase, and once the socket
-        // comes up the next fast-retry probe (issue #13737) connects. An
-        // actual HTTP error from a LIVE server (a real `status`) is a genuine
-        // failure and still burns the budget below.
-        const androidLocalAgentBooting =
-          isAndroid &&
+        // Android detached local agent now exposes the service-owned boot
+        // state over the Capacitor plugin. That distinguishes a cold boot
+        // from a launcher or child process death before the renderer's HTTP
+        // probe can connect. Older plugins lack that method, so keep the
+        // legacy hang/connect-failure heuristic only when the native state is
+        // unknown. The overall `deadline` still bounds the whole phase.
+        const androidLocalAgentIpc =
           isMobileLocalAgentIpcBase(client.getBaseUrl()) &&
+          (isAndroid || isCapacitorNative());
+        const androidBootState = androidLocalAgentIpc
+          ? await getAndroidLocalAgentBootStateForUrl(client.getBaseUrl())
+          : { state: "unknown" as const };
+        const androidNativeBootProgress =
+          androidBootState.state === "booting" ||
+          androidBootState.state === "restarting" ||
+          androidBootState.state === "listening";
+        const legacyAndroidLocalAgentBooting =
+          androidBootState.state === "unknown" &&
+          androidLocalAgentIpc &&
           (err instanceof ApiHangTimeoutError ||
             (err as { status?: number } | undefined)?.status === undefined);
-        if (isIosNativeAgentBootInProgress() || androidLocalAgentBooting) {
-          // PROGRESS-AWARE budget: the in-process native agent is provably
-          // booting (engine start pending within its own timeout) or alive
-          // (fresh structured-response heartbeat). Boot-time 503s/timeouts
-          // are agent progress, not transport failures — they must not burn
-          // the consecutive-failure budget. Only a terminal engine error or
-          // heartbeat silence lets the streak resume; the overall `deadline`
-          // still bounds the whole phase.
+        if (
+          isIosNativeAgentBootInProgress() ||
+          androidNativeBootProgress ||
+          legacyAndroidLocalAgentBooting
+        ) {
+          // PROGRESS-AWARE budget: native evidence says the local agent is
+          // booting, restarting, or accepting connections. Older Android
+          // plugins that lack the boot-state method keep the legacy HTTP
+          // heuristic so existing builds remain bounded by the overall
+          // deadline. A native `dead` state falls through and burns the
+          // consecutive-failure budget.
           nativeFailureStreakStartedAt = null;
         } else {
           nativeFailureStreakStartedAt ??= Date.now();


### PR DESCRIPTION
## Summary

- Exposes Android local-agent boot state through `Agent.getLocalAgentBootState()`.
- Uses the native boot-state signal in `startup-phase-poll` so `booting`, `restarting`, and socket `listening` pause the native consecutive-failure budget, while `dead` burns it.
- Adds startup-poll coverage for Android cold boot vs dead agent timing.

Links #15107

## Evidence

- `bun run --cwd packages/core prebuild` completed and generated required validation keyword data.
- `bun run --cwd packages/ui test src/state/startup-phase-poll.test.ts` passed: 46 tests.
- `bun run --cwd packages/ui typecheck` attempted, blocked by pre-existing missing workspace dependency/type declarations such as `pg`, `stripe`, `ai`, `file-type`, `marked`, `@capacitor/keyboard`, `react-router-dom`, `sonner`, and others. The run also initially showed test mock narrowing errors, which were fixed before the final unit test pass.
- Android Gradle compile attempted with `./gradlew :app:compileDebugJavaWithJavac`, blocked by missing `JAVA_HOME` / `java` in PATH on this worker.
- Codex review attempted twice with `codex review --uncommitted`; both completed without producing actionable findings in the visible transcript, so I also self-reviewed the diff.

## Notes

Poll site: `packages/ui/src/state/startup-phase-poll.ts` around the native failure-budget branch.
Distinguishing signal: Android native `Agent.getLocalAgentBootState()` backed by `ElizaAgentService.getLocalAgentBootState()`, including socket liveness, active service status, restart attempts, terminal boot statuses, and persisted detached-launch age.
State shape: `booting | restarting | listening` count as progress and reset the streak; `dead` is treated as unreachable and burns the native consecutive-failure budget; `unknown` retains the legacy connect/hang heuristic for older native plugins.

[sol-orch]

## Required evidence rows

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: [UI fixture/check artifact](https://github.com/elizaOS/eliza/actions/runs/28823720810) from `https://github.com/elizaOS/eliza/actions/runs/28823720810`. If this PR has no rendered delta, artifact documents the checked surface before/without visual changes.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: [UI fixture/check artifact](https://github.com/elizaOS/eliza/actions/runs/28823720810) from `https://github.com/elizaOS/eliza/actions/runs/28823720810`. If this PR has no rendered delta, artifact documents the checked surface after/without visual changes.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: [UI fixture/check artifact](https://github.com/elizaOS/eliza/actions/runs/28823720810) from `https://github.com/elizaOS/eliza/actions/runs/28823720810` (Playwright trace/media bundle or CI visual artifact when available).

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no backend runtime path changed by this PR, or covered by deterministic CI checks`.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: [UI fixture/check artifact](https://github.com/elizaOS/eliza/actions/runs/28823720810) from `https://github.com/elizaOS/eliza/actions/runs/28823720810`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - deterministic code/test change, no LLM call path changed`.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts / OCR visual text review: [aesthetic-audit run](https://github.com/elizaOS/eliza/actions/runs/28823720814) plus [UI fixture/check artifact](https://github.com/elizaOS/eliza/actions/runs/28823720810). No visible text/UI change if this is logic-only UI-package wiring.
