### PR TITLE
fix(ui): re-pair via cloud session instead of dead-ending at password wall after container upgrade (#15132)

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -97,6 +97,7 @@ import { BootRecoveryConductorMount } from "./first-run/use-boot-recovery-conduc
 import { FirstRunConductorMount } from "./first-run/use-first-run-conductor";
 import { ModelStatusConductorMount } from "./first-run/use-model-status-conductor";
 import { BugReportProvider, useBugReportState, useContextMenu } from "./hooks";
+import { useAgentSessionRecovery } from "./hooks/useAgentSessionRecovery";
 import { useAuthStatus } from "./hooks/useAuthStatus";
 import { useRole } from "./hooks/useRole";
 import { useSecretsManagerModalState } from "./hooks/useSecretsManagerModal";
@@ -2096,6 +2097,18 @@ export function App() {
       startupCoordinator.phase === "first-run-required" ||
       isPopout,
   });
+  // #15132: after a dedicated cloud agent's container upgrade the persisted
+  // agent credential is stale (every agent-subdomain call 401s) while the cloud
+  // session is still valid. Rather than dead-end at the agent's internal
+  // password wall (a credential no cloud user has), transparently re-run the
+  // pairing exchange to refresh the credential. Only fires for a cloud-managed
+  // dedicated agent WITH a valid cloud session; otherwise stays "idle" and the
+  // wall renders exactly as before.
+  const agentSessionRecoveryStatus = useAgentSessionRecovery({
+    active: authState.phase === "unauthenticated",
+    reason:
+      authState.phase === "unauthenticated" ? authState.reason : undefined,
+  });
   // Don't initialize the 3D scene while the system is still booting — this
   // prevents VrmEngine's Three.js setup from blocking the JS thread and
   // delaying WebSocket agent-status updates (which would freeze the loader).
@@ -2627,6 +2640,19 @@ export function App() {
       );
     }
     if (authState.phase === "unauthenticated") {
+      // #15132: a stale post-upgrade agent credential with a valid cloud session
+      // is recoverable, so hold the startup surface while the re-pair runs (it
+      // ends in a full-page navigation to `/pair`) instead of flashing the
+      // password wall. Recovery drops back to "idle" if it can't proceed, and
+      // the wall renders then.
+      if (agentSessionRecoveryStatus === "recovering") {
+        return (
+          <BugReportProvider value={bugReport}>
+            <StartupScreen />
+            <BugReportModal />
+          </BugReportProvider>
+        );
+      }
       return (
         <BugReportProvider value={bugReport}>
           <LoginView onLoginSuccess={refetchAuth} reason={authState.reason} />

--- a/packages/ui/src/hooks/useAgentSessionRecovery.test.tsx
+++ b/packages/ui/src/hooks/useAgentSessionRecovery.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for useAgentSessionRecovery (#15132): the dead-end -> recovering state
+ * transition at the top-level auth gate.
+ *
+ * This is the regression guard for the reported bug: after a container upgrade,
+ * an unauthenticated (`remote_auth_required`) state on a cloud-managed dedicated
+ * agent with a valid cloud session must transition to "recovering" (transparent
+ * re-pair) instead of "idle" (password-wall dead-end).
+ */
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Mock the three environment reads the hook makes so we can drive the decision.
+const mockCloudToken = vi.fn<() => string | null>();
+const mockActiveServer = vi.fn();
+const mockBootConfig = vi.fn(() => ({ cloudApiBase: "https://elizacloud.ai" }));
+const mockRunRecovery = vi.fn();
+
+vi.mock("../api/client-cloud", () => ({
+  getCloudAuthToken: () => mockCloudToken(),
+}));
+vi.mock("../state/persistence", () => ({
+  loadPersistedActiveServer: () => mockActiveServer(),
+}));
+vi.mock("../config/boot-config", () => ({
+  getBootConfig: () => mockBootConfig(),
+}));
+vi.mock("../state/agent-session-recovery-runner", () => ({
+  runAgentSessionRecovery: (...args: unknown[]) => mockRunRecovery(...args),
+}));
+
+import { useAgentSessionRecovery } from "./useAgentSessionRecovery";
+
+function Probe(props: {
+  active: boolean;
+  reason?: "remote_auth_required" | "remote_password_not_configured";
+  onStatus: (s: string) => void;
+}) {
+  const status = useAgentSessionRecovery({
+    active: props.active,
+    reason: props.reason,
+    navigate: () => {},
+  });
+  props.onStatus(status);
+  return null;
+}
+
+function cloudServer(agentId: string) {
+  return {
+    kind: "cloud" as const,
+    id: `cloud:${agentId}`,
+    label: "Dedicated",
+    apiBase: `https://elizacloud.ai/api/v1/eliza/agents/${agentId}`,
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useAgentSessionRecovery", () => {
+  it("transitions dead-end -> recovering for a cloud agent with a valid cloud session", async () => {
+    mockCloudToken.mockReturnValue("steward.jwt.token");
+    mockActiveServer.mockReturnValue(cloudServer("agent-1"));
+    // Never resolves, keeps the hook in "recovering".
+    mockRunRecovery.mockReturnValue(new Promise(() => {}));
+
+    const statuses: string[] = [];
+    render(
+      <Probe
+        active
+        reason="remote_auth_required"
+        onStatus={(s) => statuses.push(s)}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(statuses).toContain("recovering");
+    });
+    expect(mockRunRecovery).toHaveBeenCalledTimes(1);
+    const call = mockRunRecovery.mock.calls[0][0];
+    expect(call).toMatchObject({
+      agentId: "agent-1",
+      cloudApiBase: "https://elizacloud.ai",
+      cloudToken: "steward.jwt.token",
+    });
+  });
+
+  it("stays idle (wall) when there is no cloud session", async () => {
+    mockCloudToken.mockReturnValue(null);
+    mockActiveServer.mockReturnValue(cloudServer("agent-1"));
+
+    const statuses: string[] = [];
+    render(
+      <Probe
+        active
+        reason="remote_auth_required"
+        onStatus={(s) => statuses.push(s)}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(statuses.length).toBeGreaterThan(0);
+    });
+    expect(statuses).not.toContain("recovering");
+    expect(mockRunRecovery).not.toHaveBeenCalled();
+  });
+
+  it("drops back to idle (wall) when recovery fails", async () => {
+    mockCloudToken.mockReturnValue("steward.jwt.token");
+    mockActiveServer.mockReturnValue(cloudServer("agent-1"));
+    mockRunRecovery.mockResolvedValue({
+      ok: false,
+      reason: "unauthorized",
+      message: "no",
+    });
+
+    const statuses: string[] = [];
+    render(
+      <Probe
+        active
+        reason="remote_auth_required"
+        onStatus={(s) => statuses.push(s)}
+      />,
+    );
+
+    await waitFor(() => {
+      // Ended back on idle so the wall renders.
+      expect(statuses[statuses.length - 1]).toBe("idle");
+    });
+  });
+
+  it("does not attempt recovery for the password-not-configured wall", async () => {
+    mockCloudToken.mockReturnValue("steward.jwt.token");
+    mockActiveServer.mockReturnValue(cloudServer("agent-1"));
+
+    const statuses: string[] = [];
+    render(
+      <Probe
+        active
+        reason="remote_password_not_configured"
+        onStatus={(s) => statuses.push(s)}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(statuses.length).toBeGreaterThan(0);
+    });
+    expect(statuses).not.toContain("recovering");
+    expect(mockRunRecovery).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/hooks/useAgentSessionRecovery.ts
+++ b/packages/ui/src/hooks/useAgentSessionRecovery.ts
@@ -62,7 +62,7 @@ export function useAgentSessionRecovery(
       // Reset when the app leaves the unauthenticated state (e.g. a successful
       // re-pair reloaded auth), so a later genuine 401 can recover again.
       attemptedRef.current = false;
-      if (status !== "idle") setStatus("idle");
+      setStatus("idle");
       return;
     }
 
@@ -77,7 +77,7 @@ export function useAgentSessionRecovery(
 
     if (decision.action !== "re-pair") {
       // Nothing to recover, let the auth gate render the wall.
-      if (status !== "idle") setStatus("idle");
+      setStatus("idle");
       return;
     }
 
@@ -112,8 +112,8 @@ export function useAgentSessionRecovery(
     return () => {
       cancelled = true;
     };
-    // `reason`/`active` drive the effect; status is read, not a trigger.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // `active`/`reason`/`navigate` are the only external inputs; setStatus and
+    // attemptedRef are stable, so the dependency list is exhaustive as written.
   }, [active, reason, navigate]);
 
   return status;

--- a/packages/ui/src/hooks/useAgentSessionRecovery.ts
+++ b/packages/ui/src/hooks/useAgentSessionRecovery.ts
@@ -1,0 +1,120 @@
+/**
+ * useAgentSessionRecovery, bridges the unauthenticated auth state (#15132) to
+ * a transparent re-pair instead of the password-wall dead-end.
+ *
+ * When `/api/auth/me` 401s AFTER a dedicated cloud agent's container upgrade,
+ * the browser's persisted agent credential is stale but the cloud session is
+ * still valid. This hook detects that exact case and re-runs the cloud pairing
+ * exchange in the current window (the same flow first-pairing uses), which pins
+ * a fresh credential and reloads onto `/` re-paired. In every other case (no
+ * cloud session / self-hosted / already-attempted) it stays "idle" so the
+ * top-level auth gate renders `LoginView` exactly as before.
+ *
+ * SECURITY (auth-adjacent): this NEVER bypasses the wall. Recovery only fires
+ * when a valid cloud session exists to re-pair from; the server still gates the
+ * pairing-token mint, and any 401/403 from it hands control back to the wall.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { getCloudAuthToken } from "../api/client-cloud";
+import { getBootConfig } from "../config/boot-config";
+import {
+  type AgentSessionUnauthReason,
+  resolveAgentSessionRecovery,
+} from "../state/agent-session-recovery";
+import { runAgentSessionRecovery } from "../state/agent-session-recovery-runner";
+import { loadPersistedActiveServer } from "../state/persistence";
+
+export type AgentSessionRecoveryStatus =
+  /** Not a recoverable state, the auth gate should render the wall. */
+  | "idle"
+  /** A re-pair is in flight, the auth gate should hold (no wall yet). */
+  | "recovering";
+
+interface UseAgentSessionRecoveryOptions {
+  /**
+   * Whether the app is currently in the unauthenticated state, and (when so)
+   * the `/api/auth/me` reason. `active: false` disables the hook entirely.
+   */
+  active: boolean;
+  reason: AgentSessionUnauthReason;
+  /** Injected navigate (tests). Defaults to a full-page window assignment. */
+  navigate?: (url: string) => void;
+}
+
+function defaultNavigate(url: string): void {
+  if (typeof window !== "undefined") {
+    window.location.assign(url);
+  }
+}
+
+export function useAgentSessionRecovery(
+  options: UseAgentSessionRecoveryOptions,
+): AgentSessionRecoveryStatus {
+  const { active, reason, navigate = defaultNavigate } = options;
+  const [status, setStatus] = useState<AgentSessionRecoveryStatus>("idle");
+  // One attempt per mount cycle: if re-pairing fails we must NOT retry into an
+  // infinite loop, fall through to the wall instead.
+  const attemptedRef = useRef(false);
+
+  useEffect(() => {
+    if (!active) {
+      // Reset when the app leaves the unauthenticated state (e.g. a successful
+      // re-pair reloaded auth), so a later genuine 401 can recover again.
+      attemptedRef.current = false;
+      if (status !== "idle") setStatus("idle");
+      return;
+    }
+
+    const decision = resolveAgentSessionRecovery({
+      reason,
+      activeServer: loadPersistedActiveServer(),
+      cloudToken: getCloudAuthToken(),
+      cloudApiBase:
+        getBootConfig().cloudApiBase?.trim() || "https://elizacloud.ai",
+      alreadyAttempted: attemptedRef.current,
+    });
+
+    if (decision.action !== "re-pair") {
+      // Nothing to recover, let the auth gate render the wall.
+      if (status !== "idle") setStatus("idle");
+      return;
+    }
+
+    if (attemptedRef.current) return;
+    attemptedRef.current = true;
+
+    const cloudToken = getCloudAuthToken();
+    if (!cloudToken) {
+      setStatus("idle");
+      return;
+    }
+
+    setStatus("recovering");
+    let cancelled = false;
+
+    void runAgentSessionRecovery({
+      cloudApiBase: decision.cloudApiBase,
+      agentId: decision.agentId,
+      cloudToken,
+      navigate,
+    })
+      .then((result) => {
+        if (cancelled) return;
+        // On success the runner triggers a full-page navigation to `/pair`, so
+        // this component unmounts. On failure, drop to the wall.
+        if (!result.ok) setStatus("idle");
+      })
+      .catch(() => {
+        if (!cancelled) setStatus("idle");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+    // `reason`/`active` drive the effect; status is read, not a trigger.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, reason, navigate]);
+
+  return status;
+}

--- a/packages/ui/src/state/agent-session-recovery-runner.test.ts
+++ b/packages/ui/src/state/agent-session-recovery-runner.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for the post-upgrade agent-session recovery runner (#15132).
+ *
+ * The runner re-runs the cloud pairing exchange to refresh a stale
+ * dedicated-agent credential and navigates the current window to the `/pair`
+ * relay, which pins the fresh credential and redirects to `/`, replacing the
+ * password-wall dead-end with a transparent re-pair.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { runAgentSessionRecovery } from "./agent-session-recovery-runner";
+
+function jsonResponse(
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+}
+
+const baseDeps = {
+  cloudApiBase: "https://elizacloud.ai",
+  agentId: "23766030-0000-0000-0000-000000000000",
+  cloudToken: "steward.jwt.token",
+};
+
+describe("runAgentSessionRecovery", () => {
+  it("navigates the current window to the /pair redirect and reports success", async () => {
+    const redirectUrl =
+      "https://agent-23766030.elizacloud.ai/pair?token=one-time";
+    const fetchFn = vi.fn().mockResolvedValue(
+      jsonResponse(200, { data: { redirectUrl } }),
+    );
+    const navigate = vi.fn();
+
+    const result = await runAgentSessionRecovery({
+      ...baseDeps,
+      fetchFn: fetchFn as unknown as typeof fetch,
+      navigate,
+    });
+
+    expect(result).toEqual({ ok: true, redirectUrl });
+    expect(navigate).toHaveBeenCalledWith(redirectUrl);
+    // Authorization header carries the cloud session token.
+    const [, init] = fetchFn.mock.calls[0];
+    expect((init as RequestInit).method).toBe("POST");
+    expect(
+      (init as RequestInit).headers as Record<string, string>,
+    ).toMatchObject({ Authorization: "Bearer steward.jwt.token" });
+    // Targets the cloud pairing-token endpoint for the dedicated agent.
+    expect(fetchFn.mock.calls[0][0]).toContain(
+      "/api/v1/eliza/agents/23766030-0000-0000-0000-000000000000/pairing-token",
+    );
+  });
+
+  it("polls through 202 (agent warming) then navigates once ready", async () => {
+    const redirectUrl = "https://agent.elizacloud.ai/pair?token=X";
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(202, { data: { retryAfterMs: 10 } }))
+      .mockResolvedValueOnce(jsonResponse(200, { data: { redirectUrl } }));
+    const navigate = vi.fn();
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+
+    const result = await runAgentSessionRecovery({
+      ...baseDeps,
+      fetchFn: fetchFn as unknown as typeof fetch,
+      navigate,
+      sleepFn,
+    });
+
+    expect(result).toEqual({ ok: true, redirectUrl });
+    expect(sleepFn).toHaveBeenCalledWith(10);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(navigate).toHaveBeenCalledWith(redirectUrl);
+  });
+
+  it("does NOT navigate on 401, the cloud session is invalid, wall stands", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(401, { error: "unauthorized" }));
+    const navigate = vi.fn();
+
+    const result = await runAgentSessionRecovery({
+      ...baseDeps,
+      fetchFn: fetchFn as unknown as typeof fetch,
+      navigate,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("unauthorized");
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("does not loop forever: gives up with not-ready after the deadline", async () => {
+    let now = 1_000;
+    const nowFn = () => now;
+    const fetchFn = vi.fn().mockImplementation(async () => {
+      // Every poll returns 202 (still warming); advance the clock past the cap.
+      now += 60_000;
+      return jsonResponse(202, { data: { retryAfterMs: 1 } });
+    });
+    const navigate = vi.fn();
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+
+    const result = await runAgentSessionRecovery({
+      ...baseDeps,
+      fetchFn: fetchFn as unknown as typeof fetch,
+      navigate,
+      sleepFn,
+      nowFn,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("not-ready");
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("does NOT navigate to an unsafe (non-http) redirect URL", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      jsonResponse(200, {
+        data: { redirectUrl: "javascript:alert(1)" },
+      }),
+    );
+    const navigate = vi.fn();
+
+    const result = await runAgentSessionRecovery({
+      ...baseDeps,
+      fetchFn: fetchFn as unknown as typeof fetch,
+      navigate,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("error");
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("reports error (no navigate) when fetch throws", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error("network down"));
+    const navigate = vi.fn();
+
+    const result = await runAgentSessionRecovery({
+      ...baseDeps,
+      fetchFn: fetchFn as unknown as typeof fetch,
+      navigate,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("error");
+      expect(result.message).toContain("network down");
+    }
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/state/agent-session-recovery-runner.ts
+++ b/packages/ui/src/state/agent-session-recovery-runner.ts
@@ -1,0 +1,177 @@
+/**
+ * Executes post-upgrade agent-session recovery (#15132): refresh a stale
+ * dedicated-agent credential by re-running the cloud pairing exchange in the
+ * CURRENT window, then land back on `/` re-paired.
+ *
+ * This reuses the exact server-side exchange that first-pairing and the
+ * "Open Web UI" popup use, `POST /api/v1/eliza/agents/:id/pairing-token`
+ * returns a one-time `<agent>/pair?token=…` `redirectUrl`; the agent's `/pair`
+ * relay consumes the token, pins the fresh API key into sessionStorage + the
+ * boot-config singleton, and redirects to `/`. Because the dead-end app is
+ * ALREADY on the agent, we navigate the current window rather than opening a
+ * popup (no popup-blocker dependency, no second tab).
+ *
+ * SECURITY NOTE (auth-adjacent): no auth is bypassed or weakened. The pairing
+ * token is minted server-side ONLY for a caller holding a valid cloud session;
+ * an unauthenticated caller gets a 401/403 here and falls through to the
+ * password wall exactly as before.
+ */
+
+const MAX_PAIRING_WAIT_MS = 120_000;
+const DEFAULT_RETRY_AFTER_MS = 5_000;
+
+interface PairingTokenResponse {
+  data?: {
+    redirectUrl?: string;
+    retryAfterMs?: number;
+    status?: string;
+    message?: string;
+  };
+  error?: string;
+}
+
+export type AgentSessionRecoveryResult =
+  | { ok: true; redirectUrl: string }
+  | { ok: false; reason: "not-ready" | "unauthorized" | "error"; message: string };
+
+export interface RunAgentSessionRecoveryDeps {
+  /** Cloud control-plane base (boot config `cloudApiBase`). */
+  cloudApiBase: string;
+  /** The dedicated agent to re-pair with. */
+  agentId: string;
+  /** Cloud session token (Steward JWT) authorizing the pairing-token mint. */
+  cloudToken: string;
+  /** Injected fetch (tests). Defaults to global `fetch`. */
+  fetchFn?: typeof fetch;
+  /** Injected sleep (tests). Defaults to real setTimeout. */
+  sleepFn?: (ms: number) => Promise<void>;
+  /** Injected clock (tests). Defaults to `Date.now`. */
+  nowFn?: () => number;
+  /** Navigate the current window to the `/pair` relay. Injected in tests. */
+  navigate: (url: string) => void;
+}
+
+const realSleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/** Only absolute http(s) URLs are safe full-page navigation targets. */
+function isSafeRedirectUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "https:" || parsed.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+function retryAfterMs(res: Response, data: PairingTokenResponse): number {
+  const fromBody = data.data?.retryAfterMs;
+  if (typeof fromBody === "number" && fromBody > 0) return fromBody;
+
+  const retryAfter = Number(res.headers.get("Retry-After"));
+  if (Number.isFinite(retryAfter) && retryAfter > 0) return retryAfter * 1000;
+
+  return DEFAULT_RETRY_AFTER_MS;
+}
+
+/**
+ * Poll the cloud pairing-token endpoint until it returns a `/pair` redirect,
+ * then navigate the current window there. The `/pair` relay pins the fresh
+ * credential and redirects to `/`, so a successful run does not return control
+ * to the caller, it hands off to a full-page navigation. Returns a failure
+ * result (without navigating) when the agent never becomes ready, the caller is
+ * unauthorized, or the request errors, so the caller can fall back to the wall.
+ */
+export async function runAgentSessionRecovery(
+  deps: RunAgentSessionRecoveryDeps,
+): Promise<AgentSessionRecoveryResult> {
+  const {
+    cloudApiBase,
+    agentId,
+    cloudToken,
+    navigate,
+    fetchFn = fetch,
+    sleepFn = realSleep,
+    nowFn = Date.now,
+  } = deps;
+
+  const base = cloudApiBase.replace(/\/+$/, "");
+  const url = `${base}/api/v1/eliza/agents/${encodeURIComponent(
+    agentId,
+  )}/pairing-token`;
+
+  const deadline = nowFn() + MAX_PAIRING_WAIT_MS;
+  while (nowFn() < deadline) {
+    let res: Response;
+    try {
+      res = await fetchFn(url, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${cloudToken}` },
+      });
+    } catch (err) {
+      return {
+        ok: false,
+        reason: "error",
+        message: err instanceof Error ? err.message : String(err),
+      };
+    }
+
+    const data = (await res
+      .json()
+      .catch(() => ({ error: "Unknown error" }))) as PairingTokenResponse;
+
+    if (res.status === 202) {
+      await sleepFn(retryAfterMs(res, data));
+      continue;
+    }
+
+    if (res.status === 401 || res.status === 403) {
+      // No valid cloud session after all, let the wall stand.
+      return {
+        ok: false,
+        reason: "unauthorized",
+        message: data.error || `Unauthorized (HTTP ${res.status})`,
+      };
+    }
+
+    if (!res.ok) {
+      return {
+        ok: false,
+        reason: "error",
+        message:
+          data.error || `Failed to generate pairing token (HTTP ${res.status})`,
+      };
+    }
+
+    const redirectUrl = data.data?.redirectUrl;
+    if (redirectUrl) {
+      // Defense-in-depth (auth-adjacent): only navigate to an absolute http(s)
+      // URL. The value comes from the authenticated cloud response, but a
+      // full-page navigation must never honor a `javascript:`/`data:` or
+      // otherwise malformed target.
+      if (!isSafeRedirectUrl(redirectUrl)) {
+        return {
+          ok: false,
+          reason: "error",
+          message: "Pairing token returned an unsafe redirect URL",
+        };
+      }
+      // Hand off to the /pair relay in the current window: it pins the fresh
+      // credential and redirects to `/`, clearing the stale-credential 401 loop.
+      navigate(redirectUrl);
+      return { ok: true, redirectUrl };
+    }
+
+    return {
+      ok: false,
+      reason: "error",
+      message: "No redirect URL returned from pairing token endpoint",
+    };
+  }
+
+  return {
+    ok: false,
+    reason: "not-ready",
+    message: "Agent did not become ready in time",
+  };
+}

--- a/packages/ui/src/state/agent-session-recovery.test.ts
+++ b/packages/ui/src/state/agent-session-recovery.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the post-upgrade agent-session recovery decision (#15132).
+ *
+ * After a dedicated cloud agent's container is upgraded (blue/green recreate),
+ * the browser's persisted agent credential belongs to the OLD container, so
+ * every agent-subdomain call 401s and the app renders the agent's internal
+ * password wall, a credential no cloud user possesses. This is a terminal
+ * dead-end.
+ *
+ * `resolveAgentSessionRecovery` decides whether the client can transparently
+ * re-pair via the still-valid cloud session (the same flow first-pairing uses)
+ * instead of stranding the user at the password wall. The wall must remain the
+ * behavior ONLY when there is no cloud session (self-hosted direct access).
+ */
+import { describe, expect, it } from "vitest";
+import {
+  type AgentSessionRecoveryDecision,
+  resolveAgentSessionRecovery,
+} from "./agent-session-recovery";
+
+function cloudServer(agentId: string) {
+  return {
+    kind: "cloud" as const,
+    id: `cloud:${agentId}`,
+    label: "Dedicated",
+    apiBase: `https://elizacloud.ai/api/v1/eliza/agents/${agentId}`,
+  };
+}
+
+describe("resolveAgentSessionRecovery", () => {
+  it("re-pairs when a cloud-managed dedicated agent 401s with a valid cloud session", () => {
+    const decision: AgentSessionRecoveryDecision = resolveAgentSessionRecovery({
+      reason: "remote_auth_required",
+      activeServer: cloudServer("23766030-0000-0000-0000-000000000000"),
+      cloudToken: "steward.jwt.token",
+      cloudApiBase: "https://elizacloud.ai",
+      alreadyAttempted: false,
+    });
+
+    expect(decision.action).toBe("re-pair");
+    if (decision.action === "re-pair") {
+      expect(decision.agentId).toBe(
+        "23766030-0000-0000-0000-000000000000",
+      );
+      expect(decision.cloudApiBase).toBe("https://elizacloud.ai");
+    }
+  });
+
+  it("falls back to the password wall when there is NO cloud session (self-hosted)", () => {
+    const decision = resolveAgentSessionRecovery({
+      reason: "remote_auth_required",
+      activeServer: {
+        kind: "remote",
+        id: "remote:vps",
+        label: "VPS",
+        apiBase: "https://box.example.com",
+      },
+      cloudToken: null,
+      cloudApiBase: "https://elizacloud.ai",
+      alreadyAttempted: false,
+    });
+
+    expect(decision.action).toBe("show-wall");
+  });
+
+  it("does NOT re-pair a cloud agent when the cloud session is also gone", () => {
+    const decision = resolveAgentSessionRecovery({
+      reason: "remote_auth_required",
+      activeServer: cloudServer("agent-1"),
+      cloudToken: null,
+      cloudApiBase: "https://elizacloud.ai",
+      alreadyAttempted: false,
+    });
+
+    // No cloud session ⇒ nothing to re-pair with ⇒ wall is the honest state.
+    expect(decision.action).toBe("show-wall");
+  });
+
+  it("does not loop: after an attempt already ran, show the wall", () => {
+    const decision = resolveAgentSessionRecovery({
+      reason: "remote_auth_required",
+      activeServer: cloudServer("agent-1"),
+      cloudToken: "steward.jwt.token",
+      cloudApiBase: "https://elizacloud.ai",
+      alreadyAttempted: true,
+    });
+
+    expect(decision.action).toBe("show-wall");
+  });
+
+  it("does not re-pair the password-not-configured wall (no agent credential to refresh)", () => {
+    // remote_password_not_configured means the host never set an owner password;
+    // re-pairing cannot manufacture one. Keep the actionable setup wall.
+    const decision = resolveAgentSessionRecovery({
+      reason: "remote_password_not_configured",
+      activeServer: cloudServer("agent-1"),
+      cloudToken: "steward.jwt.token",
+      cloudApiBase: "https://elizacloud.ai",
+      alreadyAttempted: false,
+    });
+
+    expect(decision.action).toBe("show-wall");
+  });
+
+  it("does not re-pair a local runtime (same-origin, not a cloud dedicated agent)", () => {
+    const decision = resolveAgentSessionRecovery({
+      reason: "remote_auth_required",
+      activeServer: {
+        kind: "local",
+        id: "local",
+        label: "Local",
+      },
+      cloudToken: "steward.jwt.token",
+      cloudApiBase: "https://elizacloud.ai",
+      alreadyAttempted: false,
+    });
+
+    expect(decision.action).toBe("show-wall");
+  });
+
+  it("does not re-pair when the active server is missing (nothing to recover)", () => {
+    const decision = resolveAgentSessionRecovery({
+      reason: "remote_auth_required",
+      activeServer: null,
+      cloudToken: "steward.jwt.token",
+      cloudApiBase: "https://elizacloud.ai",
+      alreadyAttempted: false,
+    });
+
+    expect(decision.action).toBe("show-wall");
+  });
+
+  it("resolves the agent id from a cloud apiBase when the id prefix is absent", () => {
+    const decision = resolveAgentSessionRecovery({
+      reason: "remote_auth_required",
+      activeServer: {
+        kind: "cloud",
+        // Older persisted records may not use the `cloud:<id>` id form; the
+        // agent id must still be recoverable from the REST adapter base.
+        id: "cloud",
+        label: "Dedicated",
+        apiBase: "https://elizacloud.ai/api/v1/eliza/agents/abc-123",
+      },
+      cloudToken: "steward.jwt.token",
+      cloudApiBase: "https://elizacloud.ai",
+      alreadyAttempted: false,
+    });
+
+    expect(decision.action).toBe("re-pair");
+    if (decision.action === "re-pair") {
+      expect(decision.agentId).toBe("abc-123");
+    }
+  });
+});

--- a/packages/ui/src/state/agent-session-recovery.ts
+++ b/packages/ui/src/state/agent-session-recovery.ts
@@ -1,0 +1,148 @@
+/**
+ * Post-upgrade agent-session recovery (#15132).
+ *
+ * When a dedicated cloud agent's container is upgraded (blue/green recreate,
+ * fleet-upgrade #15101), the browser's persisted agent credential belongs to
+ * the OLD container. Every agent-subdomain call then 401s and the top-level
+ * auth gate would render the agent runtime's internal "Sign in with your
+ * password" wall, a credential no cloud user possesses. With a valid cloud
+ * session sitting right there, that wall is a terminal dead-end.
+ *
+ * This module makes the ROUTING decision: given the 401 reason, the active
+ * runtime, and whether a cloud session exists, should the client transparently
+ * re-run the pairing/token-swap (the same flow first-pairing uses) to refresh
+ * the persisted agent credential, or is the password wall the honest state
+ * (self-hosted direct access with no cloud session to re-pair from)?
+ *
+ * SECURITY NOTE (auth-adjacent): this weakens nothing. Re-pairing exchanges an
+ * EXISTING valid cloud session for a fresh agent credential via the same
+ * server-side pairing exchange that first-pairing uses. It never bypasses the
+ * password wall, when there is no cloud session, the wall stands.
+ */
+
+import { isDirectCloudSharedAgentBase } from "../api/client-cloud";
+import type { PersistedActiveServer } from "./persistence";
+
+/**
+ * A 401 reason from `/api/auth/me`. `remote_auth_required` means the session /
+ * bearer was rejected (the stale-credential case we can recover). undefined is
+ * the generic unauthenticated state.
+ */
+export type AgentSessionUnauthReason =
+  | "remote_auth_required"
+  | "remote_password_not_configured"
+  | undefined;
+
+export type AgentSessionRecoveryDecision =
+  | {
+      /** Re-run the cloud pairing exchange to refresh the stale credential. */
+      action: "re-pair";
+      /** The dedicated agent to re-pair with. */
+      agentId: string;
+      /** Cloud control-plane base the pairing-token endpoint lives on. */
+      cloudApiBase: string;
+    }
+  | {
+      /** Show the agent's internal password wall (no recovery available). */
+      action: "show-wall";
+    };
+
+export interface AgentSessionRecoveryInput {
+  /** The `/api/auth/me` 401 reason that triggered the unauthenticated state. */
+  reason: AgentSessionUnauthReason;
+  /** The currently-active runtime, or null when none is persisted. */
+  activeServer: PersistedActiveServer | null;
+  /**
+   * The current cloud session token (Steward JWT), or null when the browser has
+   * no cloud session. `getCloudAuthToken()` is the canonical resolver.
+   */
+  cloudToken: string | null;
+  /** Cloud control-plane base URL (boot config `cloudApiBase`). */
+  cloudApiBase: string;
+  /**
+   * True once a recovery attempt has already run this cycle. Prevents an
+   * infinite re-pair/401 loop when re-pairing itself fails, fall through to
+   * the wall so the user gets an actionable surface instead of a spinner.
+   */
+  alreadyAttempted: boolean;
+}
+
+const SHOW_WALL: AgentSessionRecoveryDecision = { action: "show-wall" };
+
+/**
+ * Extract the dedicated agent id from a persisted cloud runtime record. Prefers
+ * the `cloud:<id>` id form written by `silentlyRepointToDedicated`, then falls
+ * back to parsing the REST adapter base
+ * (`<cloudApiBase>/api/v1/eliza/agents/<agentId>`), so older persisted records
+ * without the id prefix still recover.
+ */
+export function resolveDedicatedAgentId(
+  server: PersistedActiveServer,
+): string | null {
+  if (server.id.startsWith("cloud:")) {
+    const id = server.id.slice("cloud:".length).trim();
+    if (id) return id;
+  }
+
+  const base = server.apiBase?.trim();
+  if (base) {
+    const match = base.match(/\/api\/v1\/eliza\/agents\/([^/]+)(?:\/bridge)?\/?$/);
+    if (match?.[1]) {
+      try {
+        return decodeURIComponent(match[1]);
+      } catch {
+        // Malformed encoding, use the raw segment rather than dropping it.
+        return match[1];
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Decide how to handle an agent-subdomain 401 at the top-level auth gate.
+ *
+ * Re-pair ONLY when ALL hold:
+ *   - the 401 is `remote_auth_required` (a rejected session/bearer, the
+ *     stale-credential case; NOT `remote_password_not_configured`, which
+ *     re-pairing cannot satisfy),
+ *   - the active runtime is a cloud-managed dedicated agent,
+ *   - a cloud session token exists to re-pair from, and
+ *   - we have not already tried this cycle.
+ *
+ * Otherwise the password wall is the honest, actionable state.
+ */
+export function resolveAgentSessionRecovery(
+  input: AgentSessionRecoveryInput,
+): AgentSessionRecoveryDecision {
+  const { reason, activeServer, cloudToken, cloudApiBase, alreadyAttempted } =
+    input;
+
+  if (alreadyAttempted) return SHOW_WALL;
+
+  // Only a rejected session/bearer is recoverable by re-pairing. When the host
+  // never configured an owner password, re-pairing cannot manufacture one, so
+  // keep the actionable setup wall.
+  if (reason !== "remote_auth_required") return SHOW_WALL;
+
+  if (!activeServer) return SHOW_WALL;
+
+  // A cloud-managed dedicated agent: kind "cloud", OR a cloud REST adapter base.
+  const isCloudManaged =
+    activeServer.kind === "cloud" ||
+    isDirectCloudSharedAgentBase(activeServer.apiBase);
+  if (!isCloudManaged) return SHOW_WALL;
+
+  // No cloud session means nothing to re-pair with, so the wall is honest.
+  const token = cloudToken?.trim();
+  if (!token) return SHOW_WALL;
+
+  const agentId = resolveDedicatedAgentId(activeServer);
+  if (!agentId) return SHOW_WALL;
+
+  const base = cloudApiBase.trim();
+  if (!base) return SHOW_WALL;
+
+  return { action: "re-pair", agentId, cloudApiBase: base };
+}


### PR DESCRIPTION
## Summary

Fixes #15132, after a dedicated cloud agent's container is upgraded (blue/green recreate, fleet-upgrade #15101), the browser's persisted agent credential belongs to the OLD container. Every agent-subdomain call then 401s and `App.tsx`'s top-level auth gate rendered the agent runtime's internal "Sign in with your password" wall, a credential no cloud user possesses, stranding users who have a perfectly valid cloud session at an unsatisfiable prompt. Terminal dead-end.

This adds a **recovery-billing proxy** at the auth gate. On a `remote_auth_required` 401 for a cloud-managed dedicated agent **with a valid cloud session**, the client transparently re-runs the pairing/token-swap exchange (POST agents pairing-token then the agent `/pair` relay, the same flow first-pairing and "Open Web UI" use) in the current window, refreshing the persisted agent credential and landing back on `/` re-paired. The internal password wall now renders **only** when there is NO cloud session (self-hosted direct access), exactly as intended.

## Dead-end mechanism

`packages/ui/src/App.tsx` (auth gate, previously ~line 2629): `authState.phase === "unauthenticated"` unconditionally rendered `<LoginView>` (the password wall) even when the app was pointed at a cloud-managed dedicated agent whose stale container credential 401'd post-upgrade. `useAuthStatus` publishes `unauthenticated` on the agent-subdomain 401; nothing consulted the still-valid cloud session to re-pair.

## Recovery path implemented

- `packages/ui/src/state/agent-session-recovery.ts`, pure routing decision. Re-pairs ONLY when: reason is `remote_auth_required` (rejected session, not `remote_password_not_configured`), the active runtime is cloud-managed, a cloud session token exists, and no attempt has run this cycle. Otherwise `show-wall`.
- `packages/ui/src/state/agent-session-recovery-runner.ts`, polls the cloud pairing-token endpoint (202 warm-up aware) and navigates the current window to the `/pair` relay (which pins the fresh credential + redirects to `/`). Refuses non-http redirect targets.
- `packages/ui/src/hooks/useAgentSessionRecovery.ts`, bridges the auth gate to the decision + runner; one-attempt guard prevents re-pair/401 loops.
- `packages/ui/src/App.tsx`, while recovering, holds the `<StartupScreen>` surface instead of flashing the wall; drops to the wall if recovery can't proceed.

## ⚠️ AUTH-ADJACENT, human review requested

This touches the auth/session gate. It does **not** weaken or bypass the password wall:

- Recovery fires only when a **valid cloud session** exists to re-pair from. No cloud session → wall stands.
- The **server still gates** the pairing-token mint; any 401/403 from it falls back to the wall (no navigation).
- `remote_password_not_configured` keeps its actionable setup wall (re-pairing cannot manufacture an owner password).
- One-attempt guard prevents infinite re-pair/401 loops.
- Runner navigates only to absolute http(s) targets from the authenticated cloud response.

Please review the routing/UX recovery logic, not as a new auth system, no new auth surfaces were added; it reuses the existing first-pairing exchange.

## Evidence

| Check | Result |
| --- | --- |
| New unit tests | 18 passed (`agent-session-recovery.test.ts` 8, `agent-session-recovery-runner.test.ts` 6, `useAgentSessionRecovery.test.tsx` 4) |
| Failing-test-first | Decision + dead-end→recovering state-transition tests written before impl |
| Typecheck | `tsc --noEmit -p packages/ui/tsconfig.json` clean for changed files |
| Forbidden files | none touched (vite.config / index.html / turbo.json / bun.lock) |
| Codex review | exceeded 100s with no output; self-review performed (added redirect-URL safety guard as a result) |

## Test output

```
✓ src/state/agent-session-recovery-runner.test.ts (6 tests)
✓ src/hooks/useAgentSessionRecovery.test.tsx (4 tests)
✓ src/state/agent-session-recovery.test.ts (8 tests)

 Test Files  3 passed (3)
      Tests  18 passed (18)
```

Closes #15132

-- [sol-orch]

## Required evidence rows

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: [UI fixture/check artifact](https://github.com/elizaOS/eliza/actions/runs/28823924122) from `https://github.com/elizaOS/eliza/actions/runs/28823924122`. If this PR has no rendered delta, artifact documents the checked surface before/without visual changes.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: [UI fixture/check artifact](https://github.com/elizaOS/eliza/actions/runs/28823924122) from `https://github.com/elizaOS/eliza/actions/runs/28823924122`. If this PR has no rendered delta, artifact documents the checked surface after/without visual changes.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: [UI fixture/check artifact](https://github.com/elizaOS/eliza/actions/runs/28823924122) from `https://github.com/elizaOS/eliza/actions/runs/28823924122` (Playwright trace/media bundle or CI visual artifact when available).

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no backend runtime path changed by this PR, or covered by deterministic CI checks`.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: [UI fixture/check artifact](https://github.com/elizaOS/eliza/actions/runs/28823924122) from `https://github.com/elizaOS/eliza/actions/runs/28823924122`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - deterministic code/test change, no LLM call path changed`.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts / OCR visual text review: [aesthetic-audit run](https://github.com/elizaOS/eliza/actions/runs/28823924164) plus [UI fixture/check artifact](https://github.com/elizaOS/eliza/actions/runs/28823924122). No visible text/UI change if this is logic-only UI-package wiring.
