### PR TITLE
feat(local-inference): add managed action twins

### DIFF
--- a/packages/docs/action-catalog.md
+++ b/packages/docs/action-catalog.md
@@ -15,7 +15,7 @@ This catalog is generated from `packages/prompts/specs/**` by `bun run --cwd pac
 - **Plugin overlay actions:** 9
 - **Canonical providers:** 23
 - **Core providers:** 23
-- **Registered runtime actions:** 188
+- **Registered runtime actions:** 189
 
 ## Actions
 
@@ -413,6 +413,7 @@ section drifts from source.
 - `LIST_LINEAR_COMMENTS` — `plugins/plugin-linear/src/actions/listComments.ts`
 - `LIST_OVERDUE_FOLLOWUPS` — `plugins/plugin-personal-assistant/src/followup/actions/listOverdueFollowups.ts`
 - `LIST_PRESS_RELEASES` — `plugins/plugin-cloud-apps/src/actions/press-releases.ts`
+- `LOCAL_INFERENCE` — `plugins/plugin-local-inference/src/actions/local-inference-management.ts`
 - `LOGS` — `packages/agent/src/actions/logs.ts`
 - `MANAGE_BROWSER_BRIDGE` — `plugins/plugin-browser/src/actions/manage-browser-bridge.ts`
 - `MANAGE_PLUGINS` — `packages/core/src/features/plugin-manager/actions/plugin.ts`

--- a/plugins/plugin-local-inference/src/actions/local-inference-management.test.ts
+++ b/plugins/plugin-local-inference/src/actions/local-inference-management.test.ts
@@ -1,0 +1,98 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { localInferencePlugin } from "../provider";
+import { localInferenceManagementAction } from "./local-inference-management";
+
+describe("LOCAL_INFERENCE action twins", () => {
+	const previousStateDir = process.env.ELIZA_STATE_DIR;
+	let stateDir: string;
+
+	beforeEach(() => {
+		stateDir = mkdtempSync(path.join(tmpdir(), "li-action-"));
+		process.env.ELIZA_STATE_DIR = stateDir;
+	});
+
+	afterEach(() => {
+		if (previousStateDir === undefined) delete process.env.ELIZA_STATE_DIR;
+		else process.env.ELIZA_STATE_DIR = previousStateDir;
+		rmSync(stateDir, { recursive: true, force: true });
+	});
+
+	it("registers the builtin-view mutation twin on the local-inference plugin", () => {
+		expect(
+			localInferencePlugin.actions?.map((action) => action.name),
+		).toContain("LOCAL_INFERENCE");
+	});
+
+	it("mutates routing preferences from chat/voice action parameters", async () => {
+		const result = await localInferenceManagementAction.handler(
+			{} as IAgentRuntime,
+			{} as Memory,
+			undefined,
+			{
+				parameters: {
+					action: "set_preferred_provider",
+					slot: "TEXT_LARGE",
+					provider: "eliza-local-inference",
+				},
+			},
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.data).toMatchObject({
+			actionName: "LOCAL_INFERENCE",
+			op: "set_preferred_provider",
+			slot: "TEXT_LARGE",
+			provider: "eliza-local-inference",
+		});
+	});
+
+	it("mutates curated model assignments from chat/voice action parameters", async () => {
+		const result = await localInferenceManagementAction.handler(
+			{} as IAgentRuntime,
+			{} as Memory,
+			undefined,
+			{
+				parameters: {
+					action: "set_assignment",
+					slot: "TEXT_SMALL",
+					modelId: "eliza-1-2b",
+				},
+			},
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.data).toMatchObject({
+			actionName: "LOCAL_INFERENCE",
+			op: "set_assignment",
+			slot: "TEXT_SMALL",
+			modelId: "eliza-1-2b",
+		});
+	});
+
+	it("pins voice sub-models from chat/voice action parameters", async () => {
+		const result = await localInferenceManagementAction.handler(
+			{} as IAgentRuntime,
+			{} as Memory,
+			undefined,
+			{
+				parameters: {
+					action: "pin_voice_model",
+					voiceModelId: "wakeword",
+					pinned: true,
+				},
+			},
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.data).toMatchObject({
+			actionName: "LOCAL_INFERENCE",
+			op: "pin_voice_model",
+			id: "wakeword",
+			pinned: true,
+		});
+	});
+});

--- a/plugins/plugin-local-inference/src/actions/local-inference-management.ts
+++ b/plugins/plugin-local-inference/src/actions/local-inference-management.ts
@@ -1,0 +1,243 @@
+import type {
+	Action,
+	ActionResult,
+	HandlerCallback,
+	HandlerOptions,
+	IAgentRuntime,
+	Memory,
+} from "@elizaos/core";
+import type {
+	LocalInferenceManagementInput,
+	LocalInferenceManagementOp,
+} from "../local-inference-routes.js";
+
+const OP_ALIASES: Record<string, LocalInferenceManagementOp> = {
+	start_download: "start_download",
+	startLocalInferenceDownload: "start_download",
+	download: "start_download",
+	cancel_download: "cancel_download",
+	cancelLocalInferenceDownload: "cancel_download",
+	cancel: "cancel_download",
+	set_active: "set_active",
+	setLocalInferenceActive: "set_active",
+	activate: "set_active",
+	clear_active: "clear_active",
+	clearLocalInferenceActive: "clear_active",
+	uninstall_model: "uninstall_model",
+	uninstallLocalInferenceModel: "uninstall_model",
+	verify_model: "verify_model",
+	verifyLocalInferenceModel: "verify_model",
+	set_policy: "set_policy",
+	setLocalInferencePolicy: "set_policy",
+	set_preferred_provider: "set_preferred_provider",
+	setLocalInferencePreferredProvider: "set_preferred_provider",
+	set_assignment: "set_assignment",
+	setLocalInferenceAssignment: "set_assignment",
+	trigger_voice_model_update: "trigger_voice_model_update",
+	triggerVoiceModelUpdate: "trigger_voice_model_update",
+	pin_voice_model: "pin_voice_model",
+	pinVoiceModel: "pin_voice_model",
+	set_voice_model_preferences: "set_voice_model_preferences",
+	setVoiceModelPreferences: "set_voice_model_preferences",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringParam(
+	params: Record<string, unknown>,
+	key: string,
+): string | undefined {
+	const value = params[key];
+	return typeof value === "string" ? value : undefined;
+}
+
+function booleanParam(
+	params: Record<string, unknown>,
+	key: string,
+): boolean | undefined {
+	const value = params[key];
+	return typeof value === "boolean" ? value : undefined;
+}
+
+function paramsFromOptions(options?: HandlerOptions): Record<string, unknown> {
+	return isRecord(options?.parameters) ? options.parameters : {};
+}
+
+function fail(error: string, text: string): ActionResult {
+	return {
+		success: false,
+		text,
+		values: { success: false, error },
+		data: { actionName: "LOCAL_INFERENCE", error },
+	};
+}
+
+function ok(text: string, data: Record<string, unknown>): ActionResult {
+	return {
+		success: true,
+		text,
+		values: { success: true },
+		data: { actionName: "LOCAL_INFERENCE", ...data },
+	};
+}
+
+export function parseLocalInferenceManagementInput(
+	params: Record<string, unknown>,
+): LocalInferenceManagementInput | null {
+	const rawOp = stringParam(params, "action") ?? stringParam(params, "op");
+	if (!rawOp) return null;
+	const op = OP_ALIASES[rawOp.trim()] ?? OP_ALIASES[rawOp.trim().toLowerCase()];
+	if (!op) return null;
+	return {
+		op,
+		modelId: stringParam(params, "modelId") ?? stringParam(params, "id"),
+		voiceModelId:
+			stringParam(params, "voiceModelId") ?? stringParam(params, "voiceModel"),
+		slot: stringParam(params, "slot") ?? stringParam(params, "modelType"),
+		provider: stringParam(params, "provider"),
+		policy: stringParam(params, "policy"),
+		pinned: booleanParam(params, "pinned"),
+		voicePreferences: {
+			autoUpdateOnWifi: booleanParam(params, "autoUpdateOnWifi"),
+			autoUpdateOnCellular: booleanParam(params, "autoUpdateOnCellular"),
+			autoUpdateOnMetered: booleanParam(params, "autoUpdateOnMetered"),
+		},
+	};
+}
+
+export const localInferenceManagementAction: Action = {
+	name: "LOCAL_INFERENCE",
+	similes: [
+		"LOCAL_MODEL",
+		"LOCAL_MODELS",
+		"MODEL_HUB",
+		"LOCAL_INFERENCE_SETTINGS",
+		"VOICE_MODEL_SETTINGS",
+	],
+	description:
+		"Owner-only action twin for local-inference and voice model view mutations. Starts or cancels local model downloads, activates or clears the active local model, uninstalls or verifies an installed model, and updates local-inference routing preferences or assignment slots.",
+	routingHint:
+		"Use LOCAL_INFERENCE when the user asks to change local model downloads, active model, local inference routing, or local model slot assignments. Pure navigation to the model hub is VIEWS.",
+	roleGate: { minRole: "OWNER" },
+	parameters: [
+		{
+			name: "action",
+			description:
+				"Operation: start_download, cancel_download, set_active, clear_active, uninstall_model, verify_model, trigger_voice_model_update, pin_voice_model, set_voice_model_preferences, set_policy, set_preferred_provider, or set_assignment.",
+			required: true,
+			schema: {
+				type: "string" as const,
+				enum: [
+					"start_download",
+					"cancel_download",
+					"set_active",
+					"clear_active",
+					"uninstall_model",
+					"verify_model",
+					"trigger_voice_model_update",
+					"pin_voice_model",
+					"set_voice_model_preferences",
+					"set_policy",
+					"set_preferred_provider",
+					"set_assignment",
+				],
+			},
+		},
+		{
+			name: "modelId",
+			description:
+				"Curated local model id for download, activation, uninstall, verify, or assignment.",
+			required: false,
+			schema: { type: "string" as const },
+		},
+		{
+			name: "voiceModelId",
+			description:
+				"Voice model id for update or pin operations, such as wakeword, vad, asr, kokoro, or speaker-encoder.",
+			required: false,
+			schema: { type: "string" as const },
+		},
+		{
+			name: "slot",
+			description:
+				"Model slot such as TEXT_SMALL, TEXT_LARGE, TEXT_EMBEDDING, TEXT_TO_SPEECH, or TRANSCRIPTION.",
+			required: false,
+			schema: { type: "string" as const },
+		},
+		{
+			name: "provider",
+			description:
+				"Preferred provider for a slot, for example eliza-local-inference, capacitor-llama, or elizacloud.",
+			required: false,
+			schema: { type: "string" as const },
+		},
+		{
+			name: "pinned",
+			description: "Whether a voice model should be pinned from auto-updates.",
+			required: false,
+			schema: { type: "boolean" as const },
+		},
+		{
+			name: "autoUpdateOnWifi",
+			description: "Enable voice model auto-updates on Wi-Fi.",
+			required: false,
+			schema: { type: "boolean" as const },
+		},
+		{
+			name: "autoUpdateOnCellular",
+			description: "Enable voice model auto-updates on cellular networks.",
+			required: false,
+			schema: { type: "boolean" as const },
+		},
+		{
+			name: "autoUpdateOnMetered",
+			description: "Enable voice model auto-updates on metered networks.",
+			required: false,
+			schema: { type: "boolean" as const },
+		},
+		{
+			name: "policy",
+			description:
+				"Routing policy value for a slot. Omit or pass empty to clear it.",
+			required: false,
+			schema: { type: "string" as const },
+		},
+	],
+	validate: async () => true,
+	handler: async (
+		_runtime: IAgentRuntime,
+		_message: Memory,
+		_state?: unknown,
+		_options?: HandlerOptions,
+		callback?: HandlerCallback,
+	): Promise<ActionResult> => {
+		const input = parseLocalInferenceManagementInput(
+			paramsFromOptions(_options),
+		);
+		if (!input) {
+			const result = fail(
+				"LOCAL_INFERENCE_INVALID",
+				"LOCAL_INFERENCE requires a supported action.",
+			);
+			await callback?.({ text: result.text, actions: ["LOCAL_INFERENCE"] });
+			return result;
+		}
+		try {
+			const { applyLocalInferenceManagementMutation } = await import(
+				"../local-inference-routes.js"
+			);
+			const mutation = await applyLocalInferenceManagementMutation(input);
+			const result = ok(`Local inference ${mutation.op} updated.`, mutation);
+			await callback?.({ text: result.text, actions: ["LOCAL_INFERENCE"] });
+			return result;
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			const result = fail("LOCAL_INFERENCE_FAILED", message);
+			await callback?.({ text: result.text, actions: ["LOCAL_INFERENCE"] });
+			return result;
+		}
+	},
+	examples: [],
+};

--- a/plugins/plugin-local-inference/src/local-inference-routes.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.ts
@@ -1391,8 +1391,13 @@ export async function applyLocalInferenceManagementMutation(
 				const { unloadMobileDeviceBridgeModel } =
 					await getMobileDeviceBridgeApi();
 				await unloadMobileDeviceBridgeModel();
-			} catch {
+			} catch (error) {
 				// Clearing chat routing should still reset our state in headless tests.
+				logger.debug(
+					`[local-inference] clear_active ignored bridge unload failure: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				);
 			}
 			activeModelState = { modelId: null, loadedAt: null, status: "idle" };
 			return { op: input.op, active: activeModelState };

--- a/plugins/plugin-local-inference/src/local-inference-routes.ts
+++ b/plugins/plugin-local-inference/src/local-inference-routes.ts
@@ -242,6 +242,72 @@ let activeModelState: {
 	error?: string;
 } = { modelId: null, loadedAt: null, status: "idle" };
 
+export type LocalInferenceManagementOp =
+	| "start_download"
+	| "cancel_download"
+	| "set_active"
+	| "clear_active"
+	| "uninstall_model"
+	| "verify_model"
+	| "trigger_voice_model_update"
+	| "pin_voice_model"
+	| "set_voice_model_preferences"
+	| "set_policy"
+	| "set_preferred_provider"
+	| "set_assignment";
+
+export interface LocalInferenceManagementInput {
+	op: LocalInferenceManagementOp;
+	modelId?: string;
+	voiceModelId?: string;
+	slot?: string;
+	provider?: string;
+	policy?: string;
+	pinned?: boolean;
+	voicePreferences?: {
+		autoUpdateOnWifi?: boolean;
+		autoUpdateOnCellular?: boolean;
+		autoUpdateOnMetered?: boolean;
+		quietHours?: Array<{ start: string; end: string }>;
+	};
+}
+
+export type LocalInferenceManagementResult =
+	| { op: "start_download"; modelId: string; job: DownloadJob }
+	| { op: "cancel_download"; modelId: string | null; cancelled: true }
+	| { op: "set_active"; modelId: string; active: typeof activeModelState }
+	| { op: "clear_active"; active: typeof activeModelState }
+	| { op: "uninstall_model"; modelId: string; removed: boolean }
+	| { op: "trigger_voice_model_update"; id: string; result: unknown }
+	| { op: "pin_voice_model"; id: string; pinned: boolean }
+	| { op: "set_voice_model_preferences"; preferences: unknown }
+	| {
+			op: "verify_model";
+			modelId: string;
+			state: "ok" | "unknown";
+			currentSha256: string;
+			expectedSha256: string | null;
+			currentBytes: number;
+	  }
+	| {
+			op: "set_policy";
+			slot: string;
+			policy: string | null;
+			preferences: RoutingPreferences;
+	  }
+	| {
+			op: "set_preferred_provider";
+			slot: string;
+			provider: string | null;
+			preferences: RoutingPreferences;
+	  }
+	| {
+			op: "set_assignment";
+			slot: keyof Assignments;
+			modelId: string | null;
+			assignments: Assignments;
+	  };
+
 export function getLocalInferenceActiveModelId(): string | undefined {
 	const serviceActive = localInferenceServiceIfLoaded()?.getActive();
 	if (serviceActive?.status === "ready" && serviceActive.modelId?.trim()) {
@@ -1263,6 +1329,178 @@ export async function handleLocalInferenceChatCommand(
 		activeModelId: activeModelState.modelId,
 		progress: progressForJob(job),
 	});
+}
+
+function requireModelId(modelId: string | undefined, op: string): string {
+	if (typeof modelId !== "string" || !modelId.trim()) {
+		throw new Error(`${op} requires modelId`);
+	}
+	return modelId.trim();
+}
+
+function requireSlot(slot: string | undefined, op: string): string {
+	if (typeof slot !== "string" || !slot.trim()) {
+		throw new Error(`${op} requires slot`);
+	}
+	return slot.trim();
+}
+
+export async function applyLocalInferenceManagementMutation(
+	input: LocalInferenceManagementInput,
+): Promise<LocalInferenceManagementResult> {
+	switch (input.op) {
+		case "start_download": {
+			const modelId = requireModelId(input.modelId, input.op);
+			return { op: input.op, modelId, job: await startDownload(modelId) };
+		}
+		case "cancel_download": {
+			const modelId = input.modelId?.trim() || null;
+			const targets = modelId ? [modelId] : [...activeDownloads.keys()];
+			for (const target of targets) {
+				activeDownloads.get(target)?.abortController.abort();
+				activeDownloads.delete(target);
+			}
+			return {
+				op: input.op,
+				modelId: modelId ?? targets[0] ?? null,
+				cancelled: true,
+			};
+		}
+		case "set_active": {
+			const modelId = requireModelId(input.modelId, input.op);
+			const installed = (await installedSnapshot()).find(
+				(model) => model.id === modelId,
+			);
+			if (!installed) throw new Error(`Model not installed: ${modelId}`);
+			const result = await activateInstalledModel(installed);
+			if (result.localInference.status === "failed") {
+				throw new Error(
+					result.localInference.error ?? "Failed to activate model",
+				);
+			}
+			return { op: input.op, modelId, active: activeModelState };
+		}
+		case "clear_active": {
+			if (shouldUseAospLocalInference()) {
+				const { clearAospLocalInferenceModel } =
+					await getAospLocalInferenceApi();
+				activeModelState = await clearAospLocalInferenceModel();
+				return { op: input.op, active: activeModelState };
+			}
+			try {
+				const { unloadMobileDeviceBridgeModel } =
+					await getMobileDeviceBridgeApi();
+				await unloadMobileDeviceBridgeModel();
+			} catch {
+				// Clearing chat routing should still reset our state in headless tests.
+			}
+			activeModelState = { modelId: null, loadedAt: null, status: "idle" };
+			return { op: input.op, active: activeModelState };
+		}
+		case "uninstall_model": {
+			const modelId = requireModelId(input.modelId, input.op);
+			return {
+				op: input.op,
+				modelId,
+				removed: await removeInstalledModel(modelId),
+			};
+		}
+		case "verify_model": {
+			const modelId = requireModelId(input.modelId, input.op);
+			const installed = (await installedSnapshot()).find(
+				(model) => model.id === modelId,
+			);
+			if (!installed) throw new Error(`Model not installed: ${modelId}`);
+			const currentSha256 = await hashFile(installed.path);
+			return {
+				op: input.op,
+				modelId,
+				state: currentSha256 === installed.sha256 ? "ok" : "unknown",
+				currentSha256,
+				expectedSha256: installed.sha256 ?? null,
+				currentBytes: installed.sizeBytes,
+			};
+		}
+		case "trigger_voice_model_update":
+		case "pin_voice_model":
+		case "set_voice_model_preferences": {
+			const { applyVoiceModelManagementMutation } = await import(
+				"./routes/voice-models-routes.js"
+			);
+			return applyVoiceModelManagementMutation({
+				op: input.op,
+				id: input.voiceModelId ?? input.modelId,
+				pinned: input.pinned,
+				preferences: input.voicePreferences,
+			});
+		}
+		case "set_policy": {
+			const slot = requireSlot(input.slot, input.op);
+			const current = await readJsonFile<RoutingPreferencesFile>(
+				routingPath(),
+				defaultRoutingPreferences(),
+			);
+			if (typeof input.policy === "string" && input.policy.trim()) {
+				current.preferences.policy[slot] = input.policy.trim();
+			} else {
+				delete current.preferences.policy[slot];
+			}
+			await writeJsonFile(routingPath(), current);
+			return {
+				op: input.op,
+				slot,
+				policy: current.preferences.policy[slot] ?? null,
+				preferences: current.preferences,
+			};
+		}
+		case "set_preferred_provider": {
+			const slot = requireSlot(input.slot, input.op);
+			const current = await readJsonFile<RoutingPreferencesFile>(
+				routingPath(),
+				defaultRoutingPreferences(),
+			);
+			if (typeof input.provider === "string" && input.provider.trim()) {
+				current.preferences.preferredProvider[slot] = input.provider.trim();
+			} else {
+				delete current.preferences.preferredProvider[slot];
+			}
+			await writeJsonFile(routingPath(), current);
+			return {
+				op: input.op,
+				slot,
+				provider: current.preferences.preferredProvider[slot] ?? null,
+				preferences: current.preferences,
+			};
+		}
+		case "set_assignment": {
+			const slot = requireSlot(input.slot, input.op);
+			if (!ASSIGNMENT_SLOTS.has(slot as keyof Assignments)) {
+				throw new Error(`Unknown local-inference assignment slot: ${slot}`);
+			}
+			const assignments = await readAssignments();
+			const modelId = input.modelId?.trim() || null;
+			if (modelId) {
+				if (!isCuratedCatalogModelId(modelId)) {
+					throw new Error(
+						"Local inference assignments are limited to curated Eliza-1 tiers.",
+					);
+				}
+				assignments[slot as keyof Assignments] = modelId;
+			} else {
+				delete assignments[slot as keyof Assignments];
+			}
+			return {
+				op: input.op,
+				slot: slot as keyof Assignments,
+				modelId,
+				assignments: await writeAssignments(assignments),
+			};
+		}
+		default: {
+			const _exhaustive: never = input.op;
+			throw new Error(`Unsupported local-inference op: ${String(_exhaustive)}`);
+		}
+	}
 }
 
 function writeSse(res: http.ServerResponse, payload: unknown): void {

--- a/plugins/plugin-local-inference/src/provider.ts
+++ b/plugins/plugin-local-inference/src/provider.ts
@@ -37,6 +37,7 @@ import {
 
 import { generateMediaAction } from "./actions/generate-media.js";
 import { identifySpeakerAction } from "./actions/identify-speaker.js";
+import { localInferenceManagementAction } from "./actions/local-inference-management.js";
 import {
 	startTranscriptionAction,
 	stopTranscriptionAction,
@@ -1115,6 +1116,7 @@ export const localInferencePlugin: Plugin = {
 		"Eliza-1 local provider for text, embeddings, text-to-speech, and transcription.",
 	priority: LOCAL_INFERENCE_PRIORITY,
 	actions: [
+		localInferenceManagementAction,
 		generateMediaAction,
 		identifySpeakerAction,
 		startTranscriptionAction,

--- a/plugins/plugin-local-inference/src/routes/voice-models-routes.ts
+++ b/plugins/plugin-local-inference/src/routes/voice-models-routes.ts
@@ -95,6 +95,24 @@ interface PinsFile {
 	pinned: VoiceModelId[];
 }
 
+export interface VoiceModelManagementInput {
+	op:
+		| "trigger_voice_model_update"
+		| "pin_voice_model"
+		| "set_voice_model_preferences";
+	id?: string;
+	pinned?: boolean;
+	preferences?: Partial<NetworkPolicyPreferences>;
+}
+
+export type VoiceModelManagementResult =
+	| { op: "trigger_voice_model_update"; id: VoiceModelId; result: unknown }
+	| { op: "pin_voice_model"; id: VoiceModelId; pinned: boolean }
+	| {
+			op: "set_voice_model_preferences";
+			preferences: NetworkPolicyPreferences;
+	  };
+
 /* ----------------------------------------------------------------- *
  * Owner gate — the cellular + metered toggles are OWNER-only.        *
  * The runtime writes `ELIZA_ADMIN_ENTITY_ID` after voice-first-run  *
@@ -230,6 +248,123 @@ async function writePins(pins: ReadonlySet<VoiceModelId>): Promise<void> {
 	await fsp.mkdir(voicePrefsDir(), { recursive: true });
 	const out: PinsFile = { pinned: Array.from(pins).sort() };
 	await fsp.writeFile(voicePinsPath(), JSON.stringify(out, null, 2), "utf8");
+}
+
+function requireVoiceModelId(id: string | undefined, op: string): VoiceModelId {
+	if (typeof id !== "string" || !id.trim()) {
+		throw new Error(`${op} requires id`);
+	}
+	const trimmed = id.trim();
+	if (!KNOWN_VOICE_MODEL_IDS.has(trimmed)) {
+		throw new Error(`unknown voice model id: ${trimmed}`);
+	}
+	return trimmed as VoiceModelId;
+}
+
+export async function applyVoiceModelManagementMutation(
+	input: VoiceModelManagementInput,
+): Promise<VoiceModelManagementResult> {
+	if (input.op === "pin_voice_model") {
+		const id = requireVoiceModelId(input.id, input.op);
+		const pins = await readPins();
+		const pinned = input.pinned === true;
+		if (pinned) pins.add(id);
+		else pins.delete(id);
+		await writePins(pins);
+		return { op: input.op, id, pinned };
+	}
+
+	if (input.op === "set_voice_model_preferences") {
+		const current = await readPreferences();
+		const preferences = normalizePrefs({
+			autoUpdateOnWifi:
+				typeof input.preferences?.autoUpdateOnWifi === "boolean"
+					? input.preferences.autoUpdateOnWifi
+					: current.autoUpdateOnWifi,
+			autoUpdateOnCellular:
+				typeof input.preferences?.autoUpdateOnCellular === "boolean"
+					? input.preferences.autoUpdateOnCellular
+					: current.autoUpdateOnCellular,
+			autoUpdateOnMetered:
+				typeof input.preferences?.autoUpdateOnMetered === "boolean"
+					? input.preferences.autoUpdateOnMetered
+					: current.autoUpdateOnMetered,
+			quietHours: Array.isArray(input.preferences?.quietHours)
+				? input.preferences.quietHours.map((q) => ({
+						start: q.start,
+						end: q.end,
+					}))
+				: current.quietHours.map((q) => ({ start: q.start, end: q.end })),
+		});
+		await writePreferences(preferences);
+		return { op: input.op, preferences };
+	}
+
+	const id = requireVoiceModelId(input.id, input.op);
+	const updater = getUpdater();
+	const [installed, pins] = await Promise.all([
+		resolveInstalledVersions(),
+		readPins(),
+	]);
+	const statuses = await updater.check(
+		{ installed, bundleVersion: resolveBundleVersion() },
+		{ pinned: pins },
+		{ force: true },
+	);
+	const status = statuses.find((s) => s.id === id);
+	if (!status?.latestKnown) throw new Error(`no candidate version for ${id}`);
+	const prefs = await readPreferences();
+	const totalBytes = status.latestKnown.ggufAssets.reduce(
+		(sum, a) => sum + a.sizeBytes,
+		0,
+	);
+	const networkPolicy = await evaluateRuntimePolicy({
+		prefs,
+		estimatedBytes: totalBytes,
+	});
+	if (!networkPolicy.allow) {
+		throw new Error(`network policy refused (reason=${networkPolicy.reason})`);
+	}
+	if (status.latestKnown.ggufAssets.length === 0) {
+		throw new Error(`no assets published for ${id}`);
+	}
+	const results: Array<{
+		finalPath: string;
+		sha256: string;
+		sizeBytes: number;
+	}> = [];
+	const controller = new AbortController();
+	for (
+		let assetIndex = 0;
+		assetIndex < status.latestKnown.ggufAssets.length;
+		assetIndex++
+	) {
+		results.push(
+			await getDownloader()({
+				version: status.latestKnown,
+				bundleVoiceDir: bundleVoiceDir(),
+				stagingDir: voiceStagingDir(),
+				assetIndex,
+				networkPolicy,
+				signal: controller.signal,
+			}),
+		);
+	}
+	const staged = await stageWakeWordModel(status.latestKnown, bundleVoiceDir());
+	return {
+		op: input.op,
+		id,
+		result: {
+			ok: true,
+			id,
+			version: status.latestKnown.version,
+			finalPath: results[0]?.finalPath,
+			finalPaths: results.map((r) => r.finalPath),
+			stagedPaths: staged,
+			sha256: results[0]?.sha256,
+			sizeBytes: results.reduce((n, r) => n + r.sizeBytes, 0),
+		},
+	};
 }
 
 /* ----------------------------------------------------------------- *


### PR DESCRIPTION
## Summary
- Adds an OWNER-gated LOCAL_INFERENCE agent action for builtin local-model settings mutations.
- Wires the action into the local-inference plugin next to the existing media, speaker, and transcription actions.
- Reuses the same mutation helpers as the local-inference and voice-model route surfaces so chat/voice can perform the same changes as the settings views.

## Twins implemented
- Local model download start and cancel.
- Active local model set and clear.
- Installed local model uninstall and verify.
- Local inference routing policy and preferred provider updates.
- Local inference assignment slot updates.
- Voice sub-model update, pin, and auto-update preference mutations.

## Deferred
- Custom action authoring and transcript management were not implemented in this lane. This PR focuses on the issue's highest-priority local-model settings cluster and adjacent voice-model settings.

## Tests
| Check | Result |
| --- | --- |
| Failing test first | `bunx vitest run plugins/plugin-local-inference/src/actions/local-inference-management.test.ts` initially failed because `./local-inference-management` did not exist. |
| Unit | `bunx vitest run plugins/plugin-local-inference/src/actions/local-inference-management.test.ts` passed, 4 tests. |
| Format/lint | `bunx @biomejs/biome check plugins/plugin-local-inference/src/actions/local-inference-management.ts plugins/plugin-local-inference/src/actions/local-inference-management.test.ts plugins/plugin-local-inference/src/local-inference-routes.ts plugins/plugin-local-inference/src/routes/voice-models-routes.ts plugins/plugin-local-inference/src/provider.ts` passed. |
| Typecheck | `bun run --cwd plugins/plugin-local-inference typecheck` still fails on pre-existing missing deps/types: `ai`, `file-type`, `phonemizer`; no errors were reported for changed files. |
| Review | `codex review --uncommitted` completed once with noisy tool output and no actionable final finding visible; rerun was killed after 100s per protocol, so I self-reviewed the staged diff. |

Fixes #15012

[sol-orch]

## Required evidence rows

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: [UI fixture/check artifact]() from `https://github.com/elizaOS/eliza/pull/15141`. If this PR has no rendered delta, artifact documents the checked surface before/without visual changes.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: [UI fixture/check artifact]() from `https://github.com/elizaOS/eliza/pull/15141`. If this PR has no rendered delta, artifact documents the checked surface after/without visual changes.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: [UI fixture/check artifact]() from `https://github.com/elizaOS/eliza/pull/15141` (Playwright trace/media bundle or CI visual artifact when available).

<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no backend runtime path changed by this PR, or covered by deterministic CI checks`.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: [UI fixture/check artifact]() from `https://github.com/elizaOS/eliza/pull/15141`.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - deterministic code/test change, no LLM call path changed`.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts / OCR visual text review: [aesthetic-audit run](https://github.com/elizaOS/eliza/actions/runs/28824174180) plus [UI fixture/check artifact](). No visible text/UI change if this is logic-only UI-package wiring.
