### PR TITLE
fix(android): boot receiver must not crash the app when background FGS starts are disallowed

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -3667,7 +3667,15 @@ public class ElizaAgentService extends Service {
     public static void start(Context context) {
         Intent intent = new Intent(context, ElizaAgentService.class);
         intent.setAction(ACTION_START);
-        context.startForegroundService(intent);
+        try {
+            context.startForegroundService(intent);
+        } catch (IllegalStateException error) {
+            // error-policy:J1 process boundary — same background-FGS
+            // restriction as GatewayConnectionService.start: a receiver-time
+            // start while the app is stopped must degrade to a deferred
+            // start (next foreground entry), not kill the process.
+            Log.w(TAG, "Deferred ElizaAgentService start; background FGS not allowed now: " + error.getMessage());
+        }
     }
 
     /** Request a graceful stop via the ACTION_STOP intent. */

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/GatewayConnectionService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/GatewayConnectionService.java
@@ -11,6 +11,7 @@ import android.content.Intent;
 import android.content.pm.ServiceInfo;
 import android.os.Build;
 import android.os.IBinder;
+import android.util.Log;
 
 import androidx.core.app.NotificationCompat;
 
@@ -26,6 +27,7 @@ import ai.elizaos.app.R;
  * connection is managed by the Capacitor gateway plugin on the JS side.
  */
 public class GatewayConnectionService extends Service {
+    private static final String TAG = "GatewayConnection";
 
     private static final String CHANNEL_ID = "gateway_connection";
     private static final int NOTIFICATION_ID = 1;
@@ -219,7 +221,19 @@ public class GatewayConnectionService extends Service {
             context.startService(intent);
             return;
         }
-        context.startForegroundService(intent);
+        try {
+            context.startForegroundService(intent);
+        } catch (IllegalStateException error) {
+            // error-policy:J1 process boundary — background FGS starts are
+            // disallowed while the app is force-stopped / freshly replaced
+            // (ForegroundServiceStartNotAllowedException extends
+            // IllegalStateException; pre-API-31 throws the base class).
+            // A boot/package-replace receiver hitting this must not crash
+            // the whole process ("Eliza has stopped" right after an APK
+            // update); the service starts on the next foreground entry via
+            // MainActivity instead.
+            Log.w(TAG, "Deferred GatewayConnectionService start; background FGS not allowed now: " + error.getMessage());
+        }
     }
 
     /** Request a graceful stop via the ACTION_STOP intent. */


### PR DESCRIPTION
## Fix

`ElizaBootReceiver` can call `GatewayConnectionService.start()` and `ElizaAgentService.start()` from `BOOT_COMPLETED`, `LOCKED_BOOT_COMPLETED`, or `MY_PACKAGE_REPLACED`. Android can reject those background foreground-service starts while the app is stopped or freshly replaced. The static service start helpers now translate that boundary failure into a warning and defer startup to the next foreground `MainActivity` entry instead of letting the broadcast receiver crash the process.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - no UI surface; the failure is the Android process crash shown in the logcat trace from the original PR.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - no UI surface; the intended behavior is the absence of the crash dialog.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - native receiver/service boundary only; no visible workflow to record.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: original live Seeker crash trace showed `ForegroundServiceStartNotAllowedException` escaping `ElizaBootReceiver`; post-fix code logs `Deferred ... start; background FGS not allowed now.` with the throwable instead of crashing.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - Android native service start path only.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent/action/prompt/model behavior change.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: local review on commit `5811afd594f` passed `git diff --check && git diff --cached --check` and `bun run audit:error-policy-ratchet`. `./gradlew :app:compileDebugJavaWithJavac` was attempted but the isolated review worktree lacks Capacitor package directories under `node_modules`, so Gradle stopped before Java compilation; CI/mobile build lanes must supply that environment.
