### PR TITLE
feat(ui): silent cloud entry for signed-in users

### DIFF
--- a/packages/ui/src/api/client-cloud-connect-mock-cloud.test.ts
+++ b/packages/ui/src/api/client-cloud-connect-mock-cloud.test.ts
@@ -401,9 +401,12 @@ describe("mock-cloud connect e2e — dedicated cold boot + shared chat bridge", 
     // Fresh post-wake URL, not the stale list-DTO URL.
     expect(result.apiBase).toBe(`${base}/dedicated/agent-ded`);
 
-    // Progress streamed through the connect flow's existing plumbing.
+    // Progress streamed through the connect flow's existing plumbing. The
+    // reuse lookup reports "listing" (not "creating") so downstream consumers
+    // — the first-run silent cloud entry (#15133) — can tell bookkeeping from
+    // a real provisioning phase.
     const statuses = progress.map(([status]) => status);
-    expect(statuses[0]).toBe("creating"); // "Finding your agents..."
+    expect(statuses[0]).toBe("listing"); // "Finding your agents..."
     expect(statuses).toContain("starting");
     expect(statuses[statuses.length - 1]).toBe("ready");
     const startingDetails = progress

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -3176,7 +3176,11 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
   // is the fix for "a new cloud agent is created on every sign-in" — the create
   // path only runs when the user has no agent yet.
   if (!forceCreate) {
-    onProgress?.("creating", "Finding your agents...");
+    // "listing", not "creating": this is the reuse LOOKUP, and downstream
+    // consumers (the first-run silent cloud entry, #15133) distinguish real
+    // provisioning phases from bookkeeping by this code. Display consumers
+    // render the detail text, so the rename is invisible to them.
+    onProgress?.("listing", "Finding your agents...");
     // A failed agent-list lookup must NOT fall through to provisioning. A
     // transient error (expired token, network blip, or a success:false body)
     // previously collapsed to an empty list and minted a brand-new billed agent

--- a/packages/ui/src/first-run/first-run-finish.ts
+++ b/packages/ui/src/first-run/first-run-finish.ts
@@ -73,8 +73,16 @@ export interface FirstRunFinishPorts {
   setTab: (tab: string) => void;
   /** Injected client-side finalizer (flips firstRunComplete; never POSTs). */
   completeFirstRun: (landingTab?: string) => void;
-  /** Status text (e.g. "Starting local agent") surfaced into the chat transcript. */
-  onStatus?: (text: string | null) => void;
+  /**
+   * Status text (e.g. "Starting local agent") surfaced into the chat
+   * transcript. `code` is the machine-readable phase behind the text: this
+   * module's own "setup" / "persist" phases plus the cloud client's
+   * `onProgress` status vocabulary ("listing" / "creating" / "provisioning" /
+   * "starting" / "ready") forwarded verbatim. The conductor's silent cloud
+   * entry (#15133) keys off it to tell a REAL provisioning wait apart from
+   * reuse narration; text-only consumers ignore it.
+   */
+  onStatus?: (text: string | null, code?: string) => void;
 }
 
 type FirstRunRuntimeStateKey =
@@ -356,7 +364,7 @@ async function finishLocal(
   );
   persistMobileRuntimeModeForServerTarget(serverTarget);
   ports.setRuntimeState("firstRunRuntimeTarget", serverTarget);
-  ports.onStatus?.("Starting local agent");
+  ports.onStatus?.("Starting local agent", "setup");
   const apiBase = resolveFirstRunLocalAgentApiBase();
   const clientBase = localAgentClientBase(apiBase);
   client.setBaseUrl(clientBase);
@@ -397,7 +405,7 @@ async function finishLocal(
     });
     addAgentProfile({ kind: "local", label: "Local agent" });
   }
-  ports.onStatus?.("Saving first-run profile");
+  ports.onStatus?.("Saving first-run profile", "persist");
   const plan = buildFirstRunSubmitPlan({
     draft: { ...sourceDraft, runtime: "local" },
     uiLanguage: ports.uiLanguage,
@@ -434,7 +442,7 @@ export async function bindCloudAgent(
   opts: { preferAgentId?: string | null; forceCreate?: boolean },
   ports: FirstRunFinishPorts,
 ): Promise<FirstRunFinishOutcome> {
-  ports.onStatus?.("Setting up your cloud agent");
+  ports.onStatus?.("Setting up your cloud agent", "setup");
   const plan = buildFirstRunSubmitPlan({
     draft: { ...sourceDraft, runtime: "cloud" },
     uiLanguage: ports.uiLanguage,
@@ -456,7 +464,7 @@ export async function bindCloudAgent(
     ...(getBootConfig().preferSharedCloudTier
       ? { preferSharedTier: true }
       : {}),
-    onProgress: (status, detail) => ports.onStatus?.(detail ?? status),
+    onProgress: (status, detail) => ports.onStatus?.(detail ?? status, status),
   });
   const cloudAgentApiBase = selectedAgent.apiBase;
   client.setBaseUrl(cloudAgentApiBase);
@@ -477,7 +485,7 @@ export async function bindCloudAgent(
       : {}),
   });
   persistMobileRuntimeModeForServerTarget("elizacloud");
-  ports.onStatus?.("Saving first-run profile");
+  ports.onStatus?.("Saving first-run profile", "persist");
   // Direct Cloud agent bases are chat runtimes, not full app-shell setup
   // servers — they do not own /api/first-run. Only persist when the bound base
   // owns the app-shell routes.

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -50,11 +50,25 @@ const mocks = vi.hoisted(() => ({
     }),
   },
   autoDownloadRecommendedLocalModelInBackground: vi.fn(async () => undefined),
+  // The same-origin Steward cookie refresh (POST w/ credentials) — a network
+  // boundary like the client, mocked so the silent cookie-recovery entry
+  // (#15133) is drivable without a real .elizacloud.ai session.
+  refreshCloudStewardSession: vi.fn(
+    async (): Promise<{ token?: string } | null> => null,
+  ),
 }));
 
 vi.mock("../api/client", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../api/client")>();
   return { ...actual, client: mocks.client };
+});
+
+vi.mock("../api/client-cloud", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../api/client-cloud")>();
+  return {
+    ...actual,
+    refreshCloudStewardSession: mocks.refreshCloudStewardSession,
+  };
 });
 
 vi.mock("./auto-download-recommended", () => ({
@@ -217,6 +231,7 @@ beforeEach(() => {
     success: true,
     data: [],
   });
+  mocks.refreshCloudStewardSession.mockResolvedValue(null);
   localStorage.setItem("steward_session_token", "cloud-token");
   // The runtime chooser (local / remote paths) is OFF by default (#13377);
   // these suites exercise the full chooser, so they opt in via the override.
@@ -228,6 +243,9 @@ afterEach(() => {
   __setAppValueForTests(null);
   resetTutorialState();
   ensureLocalStorage().clear();
+  // Drop the steward-authed marker cookie some cloud-only tests plant — a
+  // leaked cookie would flip later mounts into the silent recovery branch.
+  document.cookie = "steward-authed=; expires=Thu, 01 Jan 1970 00:00:00 GMT";
 });
 
 describe("useFirstRunConductor", () => {
@@ -1097,22 +1115,35 @@ describe("cloud-only onboarding (runtime chooser off — the production default)
     unmount();
   });
 
-  it("session injection: a usable stored session skips the sign-in ask and provisioning success completes onboarding for real", async () => {
-    // steward_session_token is present via the outer beforeEach.
+  it("silent entry (#15133): a usable stored session + one agent seeds ZERO onboarding turns — no greeting, no welcome-back, no reuse narration, no done wrap-up", async () => {
+    // steward_session_token is present via the outer beforeEach; the account
+    // already owns one running agent, so this is a pure reuse.
+    mocks.client.getCloudCompatAgents.mockResolvedValue({
+      success: true,
+      data: [
+        {
+          agent_id: "agent-only",
+          agent_name: "Only",
+          status: "running",
+          created_at: "2026-01-02T00:00:00.000Z",
+        },
+      ],
+    });
     const spies = seedAppStore({ elizaCloudConnected: true });
-    const { turn, unmount } = renderConductor();
+    const { transcript, unmount } = renderConductor();
 
-    await waitForTurn(turn, "first-run:cloud-signin");
     await waitFor(() => {
       expect(spies.completeFirstRun).toHaveBeenCalledTimes(1);
     });
     expect(spies.completeFirstRun).toHaveBeenCalledWith("chat");
-    // Sign-in IS onboarding: no tutorial/accent completion gate.
-    expect(turn("first-run:tutorial")).toBeUndefined();
-    expect(turn("first-run:appearance")).toBeUndefined();
-    await waitForTurn(turn, "first-run:cloud-done");
-    // The sign-in ask never appeared.
-    expect(turn("first-run:greeting")).toBeUndefined();
+    // The #15133 bar: an authenticated user's next rendered state is the
+    // agent chat itself — the transcript carries NOT ONE onboarding turn.
+    expect(transcript.current).toEqual([]);
+    // The single agent was adopted directly (no picker, no create).
+    expect(mocks.client.selectOrProvisionCloudAgent).toHaveBeenCalledTimes(1);
+    expect(
+      mocks.client.selectOrProvisionCloudAgent.mock.calls[0][0],
+    ).toMatchObject({ preferAgentId: "agent-only", authToken: "cloud-token" });
     expect(mocks.client.submitFirstRun).toHaveBeenCalledTimes(1);
     unmount();
   });
@@ -1158,7 +1189,7 @@ describe("cloud-only onboarding (runtime chooser off — the production default)
     unmount();
   });
 
-  it("existing cloud agents are auto-adopted — first of the list, no picker turn (#13377)", async () => {
+  it("multiple agents surface the existing in-chat selector (#15133) — newest-running first — and the pick binds + completes", async () => {
     mocks.client.getCloudCompatAgents.mockResolvedValue({
       success: true,
       data: [
@@ -1177,19 +1208,201 @@ describe("cloud-only onboarding (runtime chooser off — the production default)
       ],
     });
     const spies = seedAppStore({ elizaCloudConnected: true });
-    const { turn, unmount } = renderConductor();
+    const { transcript, turn, unmount } = renderConductor();
 
-    await waitForTurn(turn, "first-run:cloud-signin");
+    // The selector is the FIRST rendered turn: the silent entry seeds no
+    // greeting/welcome-back ahead of it.
+    const choice = await waitForTurn(turn, "first-run:cloud-agent");
+    expect(transcript.current.map((m) => m.id)).toEqual([
+      "first-run:cloud-agent",
+    ]);
+    expect(choice.text).toContain(
+      "__first_run__:cloud-agent:agent-newest-running=Newest",
+    );
+    expect(choice.text).toContain("__first_run__:cloud-agent:agent-older=");
+    expect(choice.text).toContain(
+      "__first_run__:cloud-agent:new=Create a new agent",
+    );
+    expect(choice.text.indexOf("agent-newest-running")).toBeLessThan(
+      choice.text.indexOf("agent-older"),
+    );
+    // Nothing bound before the user chose.
+    expect(mocks.client.selectOrProvisionCloudAgent).not.toHaveBeenCalled();
+    expect(spies.completeFirstRun).not.toHaveBeenCalled();
+
+    // Picking an agent binds exactly it and completes onboarding; the
+    // selector was an interactive ask, so the done wrap-up renders again.
+    expect(
+      tryHandleFirstRunAction("__first_run__:cloud-agent:agent-older"),
+    ).toBe(true);
     await waitFor(() => {
       expect(spies.completeFirstRun).toHaveBeenCalledTimes(1);
     });
-    // No picker was interposed; the bind targeted the first listed agent.
-    expect(turn("first-run:cloud-agent")).toBeUndefined();
-    const provisionArgs = mocks.client.selectOrProvisionCloudAgent.mock
-      .calls[0]?.[0] as { preferAgentId?: string };
-    expect(provisionArgs?.preferAgentId).toBe("agent-newest-running");
+    expect(
+      mocks.client.selectOrProvisionCloudAgent.mock.calls[0][0],
+    ).toMatchObject({ preferAgentId: "agent-older" });
     await waitForTurn(turn, "first-run:cloud-done");
     unmount();
+  });
+
+  it("zero agents stay silent through the reuse lookup and narrate ONLY the real provisioning (#15133)", async () => {
+    // No stored agents; selectOrProvisionCloudAgent emits the REAL client's
+    // progress sequence for a create: the reuse lookup ("listing"), the actual
+    // create ("creating"), then ready.
+    mocks.client.getCloudCompatAgents.mockResolvedValue({
+      success: true,
+      data: [],
+    });
+    mocks.client.selectOrProvisionCloudAgent.mockImplementation(
+      async (options: Record<string, unknown>) => {
+        const onProgress = options.onProgress as (
+          status: string,
+          detail?: string,
+        ) => void;
+        onProgress("listing", "Finding your agents...");
+        onProgress("creating", "Creating Eliza...");
+        onProgress("ready", "Cloud agent ready!");
+        return {
+          apiBase: "https://agent.example.test",
+          agentId: "agent-new",
+          created: true,
+        };
+      },
+    );
+    const spies = seedAppStore({ elizaCloudConnected: true });
+    const { transcript, turn, unmount } = renderConductor();
+
+    await waitFor(() => {
+      expect(spies.completeFirstRun).toHaveBeenCalledTimes(1);
+    });
+    // Bookkeeping narration stays silent…
+    expect(turn("first-run:greeting")).toBeUndefined();
+    expect(turn("first-run:cloud-signin")).toBeUndefined();
+    expect(
+      turn("first-run:status:Setting up your cloud agent"),
+    ).toBeUndefined();
+    expect(turn("first-run:status:Finding your agents...")).toBeUndefined();
+    // …but the REAL create is a genuine wait, so it narrates honestly from
+    // its first "creating" code onward (including the done wrap-up).
+    await waitForTurn(turn, "first-run:status:Creating Eliza...");
+    await waitForTurn(turn, "first-run:status:Cloud agent ready!");
+    await waitForTurn(turn, "first-run:cloud-done");
+    expect(
+      transcript.current.every(
+        (m) =>
+          m.id.startsWith("first-run:status:") ||
+          m.id === "first-run:cloud-done",
+      ),
+    ).toBe(true);
+    unmount();
+  });
+
+  it("cross-subdomain cookie at mount (#15133): recovers the session BEFORE seeding anything — zero onboarding turns, straight into the single agent", async () => {
+    // First visit to the app subdomain after signing in on the console: no
+    // app-origin localStorage, but the non-HttpOnly steward-authed marker is
+    // present and the bounded refresh returns a token.
+    localStorage.removeItem("steward_session_token");
+    document.cookie = "steward-authed=1";
+    mocks.refreshCloudStewardSession.mockResolvedValue({
+      token: "cookie-token",
+    });
+    mocks.client.getCloudCompatAgents.mockResolvedValue({
+      success: true,
+      data: [
+        {
+          agent_id: "agent-console",
+          agent_name: "Console",
+          status: "running",
+          created_at: "2026-01-02T00:00:00.000Z",
+        },
+      ],
+    });
+    const spies = seedAppStore({ elizaCloudConnected: false });
+    const { transcript, unmount } = renderConductor();
+
+    await waitFor(() => {
+      expect(spies.completeFirstRun).toHaveBeenCalledTimes(1);
+    });
+    expect(spies.completeFirstRun).toHaveBeenCalledWith("chat");
+    // The recovered token was persisted for the app origin…
+    expect(mocks.refreshCloudStewardSession).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem("steward_session_token")).toBe("cookie-token");
+    // …and the user saw NOTHING: no greeting flash, no welcome-back, no
+    // provisioning theater — the next rendered state is the agent chat.
+    expect(transcript.current).toEqual([]);
+    expect(
+      mocks.client.selectOrProvisionCloudAgent.mock.calls[0][0],
+    ).toMatchObject({
+      preferAgentId: "agent-console",
+      authToken: "cookie-token",
+    });
+    unmount();
+  });
+
+  it("a stale marker cookie degrades to today's sign-in greeting after the bounded refresh fails — then the token poll still upgrades to welcome-back", async () => {
+    localStorage.removeItem("steward_session_token");
+    document.cookie = "steward-authed=1";
+    mocks.refreshCloudStewardSession.mockResolvedValue(null);
+    mocks.client.getCloudStatus.mockResolvedValue({ connected: false });
+    const spies = seedAppStore({ elizaCloudConnected: false });
+    const { turn, unmount } = renderConductor();
+
+    // The failed recovery falls back to EXACTLY the unauthenticated flow: the
+    // normal sign-in greeting, no fabricated session, nothing provisioned.
+    const greeting = await waitForTurn(turn, "first-run:greeting");
+    expect(greeting.text).toContain("Sign in to Eliza Cloud");
+    expect(spies.completeFirstRun).not.toHaveBeenCalled();
+    expect(mocks.client.getCloudCompatAgents).not.toHaveBeenCalled();
+
+    // The degrade also armed the 500ms token poll, so a session landing later
+    // (login in another tab) still upgrades — with the welcome-back turn,
+    // because a greeting was genuinely shown on this path.
+    localStorage.setItem("steward_session_token", "cloud-token");
+    mocks.client.getCloudStatus.mockResolvedValue({ connected: true });
+    await waitFor(
+      () => {
+        expect(turn("first-run:cloud-signin")).toBeTruthy();
+      },
+      { timeout: 3_000 },
+    );
+    await waitFor(
+      () => {
+        expect(spies.completeFirstRun).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 3_000 },
+    );
+    unmount();
+  });
+
+  it("the silent cookie hold answers free text with the provisioning persona, and an unmount mid-refresh seeds nothing", async () => {
+    localStorage.removeItem("steward_session_token");
+    document.cookie = "steward-authed=1";
+    let resolveRefresh: (value: { token: string } | null) => void = () => {};
+    mocks.refreshCloudStewardSession.mockImplementation(
+      () =>
+        new Promise<{ token: string } | null>((resolve) => {
+          resolveRefresh = resolve;
+        }),
+    );
+    seedAppStore({ elizaCloudConnected: false });
+    const { transcript, turn, unmount } = renderConductor();
+
+    // During the bounded hold nothing is seeded — the shell shows the empty
+    // first-run chat. Typing gets the "hang tight" persona (there is no
+    // sign-in ask on screen for the signIn nudge to point at).
+    expect(transcript.current).toEqual([]);
+    expect(tryHandleFirstRunText("hello?")).toBe(true);
+    const reply = await waitForTurn(turn, "first-run:reply:1");
+    expect(reply.text).toContain("Hang tight");
+
+    // The effect-cleanup cancelled flag: a refresh settling after unmount
+    // must not seed the greeting into a dead transcript (or resume anything).
+    const turnsAtUnmount = transcript.current.length;
+    unmount();
+    resolveRefresh(null);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(transcript.current.length).toBe(turnsAtUnmount);
+    expect(mocks.client.getCloudCompatAgents).not.toHaveBeenCalled();
   });
 
   it("a token hydrating AFTER mount (native storage restore) auto-continues without a tap", async () => {
@@ -1246,9 +1459,10 @@ describe("cloud-only onboarding (runtime chooser off — the production default)
       error: "cloud agent list failed",
     });
     const spies = seedAppStore({ elizaCloudConnected: true });
-    const { transcript, turn, unmount } = renderConductor();
-    await waitForTurn(turn, "first-run:cloud-signin");
+    const { transcript, unmount } = renderConductor();
 
+    // The silent entry seeds no welcome-back turn; the failure surfaces as
+    // the error recovery turn directly (errors always render, silent or not).
     await waitFor(() => {
       expect(
         transcript.current.some((message) =>

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -37,9 +37,13 @@
  * `isRuntimeChooserEnabled()` and OFF by default. With the chooser off,
  * onboarding is a single "sign in to Eliza Cloud" step — the greeting IS the
  * sign-in prompt, an already-usable session (hosted web with a live login, a
- * durable token, a completed mobile OAuth round trip) skips the ask entirely,
- * and provisioning success flips the real gate immediately. The tutorial is
- * never a completion gate in this mode; it stays reachable from its home tile.
+ * durable token, a completed mobile OAuth round trip, or a session recovered
+ * from the console's cross-subdomain cookie) enters SILENTLY (#15133): zero
+ * onboarding turns for a pure agent reuse, the real provisioning narration
+ * only when an agent is actually created or cold-boot woken, the existing
+ * in-chat selector when the account has several agents. Provisioning success
+ * flips the real gate immediately. The tutorial is never a completion gate in
+ * this mode; it stays reachable from its home tile.
  */
 
 import { logger } from "@elizaos/logger";
@@ -105,6 +109,23 @@ const CLOUD_WELCOME_BACK =
   "Welcome back — you're already signed in to Eliza Cloud. Setting up your agent…";
 const CLOUD_ONLY_DONE =
   'You\'re all set — ask me anything. Want a quick tour? Type "restart tutorial" whenever you like.';
+
+// Bounded cookie-recovery refresh at conductor mount (#15133). Mirrors
+// STEWARD_RESTORE_REFRESH_TIMEOUT_MS in startup-phase-restore.ts so a hung
+// same-origin refresh costs an authenticated console user at most this long of
+// quiet empty chat before degrading to the normal sign-in greeting.
+const FIRST_RUN_COOKIE_REFRESH_TIMEOUT_MS = 4_000;
+
+// onStatus codes that mark a REAL provisioning wait — an actual agent create,
+// a sandbox build, or a dedicated container's cold-boot wake. Every other code
+// the finish path narrates ("setup" / "listing" / "ready" / "persist") wraps a
+// couple of fast REST calls, which reads as fake provisioning theater to an
+// already-signed-in user (#15133) — the silent entry drops those.
+const REAL_PROVISION_STATUS_CODES = new Set([
+  "creating",
+  "provisioning",
+  "starting",
+]);
 
 /** User-facing recovery message when a cloud provisioning call rejects. */
 function cloudFailureMessage(err: unknown): string {
@@ -400,6 +421,15 @@ export function useFirstRunConductor(): void {
   // True while a finish error's recovery choice is on screen; steers the
   // free-text reply persona (below). Cleared when the next pick supersedes it.
   const erroredRef = React.useRef(false);
+  // Silent cloud entry (#15133): set when onboarding starts with an
+  // already-usable session (stored token, live connection, or a session
+  // recovered from the console's cross-subdomain cookie). The user already
+  // signed in, so the conductor seeds NOTHING — no greeting, no welcome-back,
+  // no reuse-narration statuses, no done wrap-up; a pure agent reuse lands
+  // straight in chat. The silence ends (ref cleared) the moment something
+  // genuinely interactive or genuinely slow must render: a REAL provisioning
+  // status, the multi-agent selector, a sign-in retry ask, or an error turn.
+  const silentCloudEntryRef = React.useRef(false);
   // Monotonic id source for typed-text turns: guarantees a unique user/reply id
   // per send even when two land in the same millisecond, so `seedTurn`'s id
   // dedup never silently swallows an acknowledged message.
@@ -473,7 +503,13 @@ export function useFirstRunConductor(): void {
     if (completedRef.current) return;
     provisionedRef.current = true;
     completedRef.current = true;
-    seedTurn(makeTurn("first-run:cloud-done", CLOUD_ONLY_DONE));
+    // A silent entry that STAYED silent was a pure reuse (#15133): the user is
+    // already signed in and their agent already exists — land straight in chat
+    // with no wrap-up turn. A create/wake path cleared the ref on its first
+    // real provisioning status, so its wrap-up still renders.
+    if (!silentCloudEntryRef.current) {
+      seedTurn(makeTurn("first-run:cloud-done", CLOUD_ONLY_DONE));
+    }
     completeFirstRun("chat");
   }, [seedTurn, completeFirstRun]);
 
@@ -528,10 +564,20 @@ export function useFirstRunConductor(): void {
         }
         completeCloudOnly();
       },
-      onStatus: (text) => {
-        if (text) {
-          seedTurn(makeTurn(`first-run:status:${text}`, text));
+      onStatus: (text, code) => {
+        if (!text) return;
+        if (silentCloudEntryRef.current) {
+          // Silent cloud entry (#15133): reuse narration ("Setting up your
+          // cloud agent", "Finding your agents...", "Connected to your
+          // agent", "Saving first-run profile") wraps two fast REST calls —
+          // provisioning theater for someone who already has an agent. Only
+          // a REAL wait breaks the silence: an actual create, a sandbox
+          // build, or a dedicated cold-boot wake take genuinely long, so
+          // clear the ref and narrate honestly from that point on.
+          if (!code || !REAL_PROVISION_STATUS_CODES.has(code)) return;
+          silentCloudEntryRef.current = false;
         }
+        seedTurn(makeTurn(`first-run:status:${text}`, text));
       },
     }),
     [
@@ -551,6 +597,10 @@ export function useFirstRunConductor(): void {
   const seedError = React.useCallback(
     (message: string) => {
       erroredRef.current = true;
+      // An error turn ends a silent cloud entry: from here on the user is in
+      // an interactive recovery conversation, so retry statuses and the done
+      // wrap-up must render again.
+      silentCloudEntryRef.current = false;
       // A DISTINCT, non-looping error surface: the error turn carries its own
       // recovery choice (retry / restart / Settings escape) so onboarding is
       // always recoverable. It must NOT re-append the runtime CHOICE — that
@@ -627,15 +677,20 @@ export function useFirstRunConductor(): void {
           }
           return;
         case "pick-cloud-agent": {
-          // Cloud-only onboarding (#13377): signing in IS onboarding — never
-          // interpose an agent picker. Adopt the first agent; the list arrives
-          // newest-first with running agents prioritized.
+          // Cloud-only onboarding (#13377/#15133): exactly one agent means
+          // there is nothing to choose — adopt it directly (the list arrives
+          // newest-first with running agents prioritized). Two or more get
+          // the existing in-chat selector, per the #15133 spec — silently
+          // adopting agents[0] hid the user's other agents behind Settings.
           if (!isRuntimeChooserEnabled()) {
             const first = outcome.agents[0]?.agent_id;
-            if (first) {
+            if (outcome.agents.length === 1 && first) {
               bindCloudAgentByIdRef.current?.(first);
               return;
             }
+            // The selector is an interactive ask — end any silent entry so
+            // the post-pick bind statuses render.
+            silentCloudEntryRef.current = false;
           }
           seedCloudAgentChoice(
             outcome.agents.map((a) => ({ id: a.agent_id, name: a.agent_name })),
@@ -655,6 +710,9 @@ export function useFirstRunConductor(): void {
             : draftRef.current.runtime === "cloud"
               ? "cloud"
               : "hybrid";
+          // Asking for a sign-in ends a silent entry: the session turned out
+          // not to be usable, so the flow is back to the visible ask path.
+          silentCloudEntryRef.current = false;
           surfaceCloudLoginRetryTurn({ seedTurn, replaceTurn });
           return;
         }
@@ -1084,8 +1142,13 @@ export function useFirstRunConductor(): void {
     (text: string): boolean => {
       const trimmed = text.trim();
       if (!trimmed) return true;
+      // A silent cloud entry counts as provisioning even before its first
+      // network call lands (the bounded cookie refresh): there is no sign-in
+      // ask on screen, so the signIn nudge would point at nothing.
       const reply =
-        busyRef.current || bindInFlightRef.current
+        busyRef.current ||
+        bindInFlightRef.current ||
+        silentCloudEntryRef.current
           ? FIRST_RUN_TEXT_REPLY.provisioning
           : provisionedRef.current
             ? FIRST_RUN_TEXT_REPLY.wrapUp
@@ -1119,20 +1182,25 @@ export function useFirstRunConductor(): void {
       return;
     }
     resetFirstRunPersistGuard();
+    // A fresh activation decides silence for itself below — a stale `true`
+    // from a previous mount (silent entry unmounted mid-flight, user signed
+    // out, conductor re-entered) must not suppress this run's turns.
+    silentCloudEntryRef.current = false;
     setFirstRunActionHandler((value) => handleActionRef.current(value));
     setFirstRunTextHandler((value) => handleTextRef.current(value));
     // Cloud-only onboarding (#13377): sign in to Eliza Cloud is the single
     // path. An already-usable session (hosted web where the user is logged in
-    // to Eliza Cloud, a durable token from a previous login, or a completed
-    // OAuth round trip after a mobile WebView eviction) skips the sign-in ask
-    // entirely and provisions immediately without a gesture —
-    // launchStewardLogin short-circuits on the stored token, so no sign-in
-    // surface ever appears. Otherwise the greeting offers the one sign-in
-    // button; its tap enters the normal cloud pick path (the gesture the real
-    // login flow needs). A cold relaunch just re-enters this branch, so no
-    // durable resume marker is needed — any stale chooser-mode marker is
-    // dropped. The local-backup restore probe is skipped: restoring a local
-    // agent is a chooser-mode concept.
+    // to Eliza Cloud, a durable token from a previous login, a completed
+    // OAuth round trip after a mobile WebView eviction, or a session
+    // recovered from the console's cross-subdomain cookie) enters SILENTLY
+    // (#15133): no greeting, no welcome-back, no reuse narration — a pure
+    // reuse lands straight in chat, and only a real provision/wake narrates.
+    // Otherwise the greeting offers the one sign-in button; its tap enters
+    // the normal cloud pick path (the gesture the real login flow needs). A
+    // cold relaunch just re-enters this branch, so no durable resume marker
+    // is needed — any stale chooser-mode marker is dropped. The local-backup
+    // restore probe is skipped: restoring a local agent is a chooser-mode
+    // concept.
     if (!isRuntimeChooserEnabled()) {
       clearCloudLoginPending();
       draftRef.current = {
@@ -1140,51 +1208,30 @@ export function useFirstRunConductor(): void {
         runtime: "cloud",
         localInference: "cloud-inference",
       };
-      // The resume is armed in BOTH branches: with a usable session it drives
+      // The resume is armed in ALL branches: with a usable session it drives
       // the immediate provision; without one it lets a session that lands
       // later without a tap (login from another same-origin tab, an injected
       // hosted-web session) auto-continue via the auto-resume effect.
       pendingCloudResumeRef.current = "cloud";
       let tokenPoll: ReturnType<typeof setInterval> | null = null;
-      if (elizaCloudConnectedRef.current || hasUsableStoredStewardToken()) {
-        seedTurn(makeTurn("first-run:cloud-signin", CLOUD_WELCOME_BACK));
-        runCloudResumeRef.current("cloud");
-      } else {
+      let cancelled = false;
+      // Degrade target shared by the no-session path and a failed cookie
+      // recovery: the sign-in greeting plus a cheap localStorage poll. A
+      // usable session can LAND after mount without any elizaCloudConnected
+      // flip (the native storage bridge hydrates the durable token from
+      // Capacitor Preferences asynchronously; a web login in another
+      // same-origin tab writes it directly), so poll (one localStorage read
+      // per tick) and upgrade to the welcome-back skip the moment it appears;
+      // a pick already in flight always wins. The welcome-back turn stays on
+      // THIS path only — a greeting was genuinely shown, so silently yanking
+      // the conversation would read as broken.
+      const seedSignInGreetingAndPoll = () => {
         seedTurn(
           makeTurn(
             "first-run:greeting",
             `${CLOUD_SIGN_IN_GREETING}\n\n${CLOUD_SIGN_IN_CHOICE}`,
           ),
         );
-        // Cross-subdomain SSO: a user already signed in on the console carries
-        // the shared, HttpOnly .elizacloud.ai refresh cookie, but localStorage
-        // does not cross subdomains — so this app origin has no stored token
-        // and would ask them to sign in AGAIN. Recover the access token from
-        // the cookie (same-origin refresh route, same pattern as the /login
-        // page); the token poll below then upgrades to welcome-back within
-        // 500ms. Fire-and-forget: a failed refresh simply leaves the normal
-        // sign-in greeting in place.
-        if (typeof window !== "undefined" && hasStewardAuthedCookie()) {
-          // error-policy:J4 failed cookie refresh degrades to the sign-in
-          // greeting already on screen; it never fabricates a session.
-          refreshCloudStewardSession()
-            .then((refreshed) => {
-              if (!refreshed?.token) return;
-              writeStoredStewardToken(refreshed.token);
-              try {
-                window.dispatchEvent(new CustomEvent("steward-token-sync"));
-              } catch {
-                // error-policy:J6 best-effort nudge — the poll re-reads anyway.
-              }
-            })
-            .catch(() => undefined);
-        }
-        // A usable session can also LAND after this mount without any
-        // elizaCloudConnected flip: the native storage bridge hydrates the
-        // durable token from Capacitor Preferences asynchronously, and a web
-        // login in another same-origin tab writes it directly. Poll cheaply
-        // (one localStorage read) and upgrade to the welcome-back skip the
-        // moment it appears; a pick already in flight always wins.
         tokenPoll = setInterval(() => {
           if (
             busyRef.current ||
@@ -1199,8 +1246,59 @@ export function useFirstRunConductor(): void {
           seedTurn(makeTurn("first-run:cloud-signin", CLOUD_WELCOME_BACK));
           runCloudResumeRef.current("cloud");
         }, 500);
+      };
+      if (elizaCloudConnectedRef.current || hasUsableStoredStewardToken()) {
+        silentCloudEntryRef.current = true;
+        runCloudResumeRef.current("cloud");
+      } else if (typeof window !== "undefined" && hasStewardAuthedCookie()) {
+        // Cross-subdomain SSO (#15089/#15133): a user already signed in on
+        // the console carries the shared, HttpOnly .elizacloud.ai refresh
+        // cookie, but localStorage does not cross subdomains — so this app
+        // origin has no stored token yet. Seed NOTHING and recover the access
+        // token first (same-origin refresh, bounded like
+        // startup-phase-restore's resolveRestoredStewardToken) so an
+        // authenticated user never sees a sign-in greeting that a
+        // welcome-back then has to walk back — the "onboarding theater"
+        // report. During the sub-second hold the already-painted shell shows
+        // the empty first-run chat; a stale marker cookie costs at most the
+        // 4s bound before the normal greeting appears. Web-only by
+        // construction: native has no document cookie and carries the durable
+        // token through the branch above.
+        silentCloudEntryRef.current = true;
+        void (async () => {
+          let refreshTimeout: ReturnType<typeof setTimeout> | undefined;
+          // error-policy:J4 a failed/timed-out cookie refresh degrades to the
+          // normal sign-in greeting below; it never fabricates a session.
+          const refreshed = await Promise.race([
+            refreshCloudStewardSession().catch(() => null),
+            new Promise<null>((resolve) => {
+              refreshTimeout = setTimeout(
+                () => resolve(null),
+                FIRST_RUN_COOKIE_REFRESH_TIMEOUT_MS,
+              );
+            }),
+          ]);
+          if (refreshTimeout) clearTimeout(refreshTimeout);
+          if (cancelled) return;
+          if (refreshed?.token) {
+            writeStoredStewardToken(refreshed.token);
+            try {
+              window.dispatchEvent(new CustomEvent("steward-token-sync"));
+            } catch {
+              // error-policy:J6 best-effort nudge — consumers re-read the
+              // stored token on their next tick regardless.
+            }
+            runCloudResumeRef.current("cloud");
+            return;
+          }
+          silentCloudEntryRef.current = false;
+          seedSignInGreetingAndPoll();
+        })();
+      } else {
+        seedSignInGreetingAndPoll();
       }
       return () => {
+        cancelled = true;
         if (tokenPoll) clearInterval(tokenPoll);
         setFirstRunActionHandler(null);
         setFirstRunTextHandler(null);


### PR DESCRIPTION
Closes #15133 — nubs's exact spec: already-authed users opening app.elizacloud.ai must see NONE of the onboarding theater (greeting → 'you're already signed in' → fake provisioning narration).

## What ships
- **Session known at mount** (stored token / connected) → seed **zero turns**, resume directly into the agent.
- **Shared `.elizacloud.ai` cookie, no app-origin token** → seed nothing; bounded **4s** cookie refresh (mirrors startup-phase-restore); on token → silent resume; on failure → degrade to exactly today's greeting + poll (stale cookie costs ≤4s, signed-out flow untouched).
- **Three-way entry**: exactly 1 agent → **direct bind** · **≥2 → the existing in-chat agent selector** (was dead code on the live path — now wired) · 0 agents → auto-create showing **only real provisioning narration** (`creating`/`provisioning`/`starting` codes end the silence; `setup`/`listing`/`persist` reuse-noise suppressed via new machine-readable onStatus codes).
- Silence self-clears on errors/needs-login so failures still speak.

## Verification
- Conductor suite **45/45** (re-run on this tree) — new cases: cookie+1-agent → zero turns + completeFirstRun; 0-agent → only real-create narration; ≥2 → selector-first + pick binds; stale-cookie degrade; mid-refresh unmount. Full first-run + cloud-client sweep in worktree: **293 tests / 23 files green**; packages/ui typecheck clean; biome clean.
- Network-boundary-only mocks; real conductor + real `hasStewardAuthedCookie` via jsdom cookies.

## Evidence
- <!-- evidence-row:before-screenshots --> **Before screenshots:** owner phone captures of the theater sequence (greeting + connect card + 'Connecting your Eliza Cloud account…') attached in #15133/#15143 threads.
- <!-- evidence-row:after-screenshots --> **After screenshots:** N/A — staging rendered E2E (console sign-in → app for 1-agent / 0-agent / multi-agent accounts) queued for the post-merge staging deploy; will attach before this rides a promote.
- <!-- evidence-row:walkthrough-video --> **Walkthrough video:** N/A — bundled with the staging E2E capture session.
- <!-- evidence-row:backend-logs --> **Backend logs:** N/A — renderer-only change; no server behavior touched.
- <!-- evidence-row:frontend-logs --> **Frontend console/network logs:** refresh→token→resume network sequence asserted in the conductor suite (45/45).
- <!-- evidence-row:llm-trajectory --> **Real-LLM trajectory:** N/A — deterministic conductor flow, no model behavior.
- <!-- evidence-row:domain-artifacts --> **Domain artifacts:** persisted steward token + completeFirstRun profile asserted post-silent-entry in the new tests; status-code contract (`REAL_PROVISION_STATUS_CODES`) unit-locked.

— [qa-agent] (workflow-built per the beat-by-beat diagnosis in the #15133 thread)