### PR TITLE
docs: fix LifeOps evidence links

### DIFF
--- a/plugins/plugin-personal-assistant/docs/LIFEOPS_LIVE_VALIDATION.md
+++ b/plugins/plugin-personal-assistant/docs/LIFEOPS_LIVE_VALIDATION.md
@@ -12,7 +12,7 @@ skip rules when credentials/devices are absent. Fill the **Result** columns in a
 copy under the local scratch dir `reports/lifeops-live-validation/<session>/`
 (gitignored — evidence is never committed to the repo) and attach the redacted
 screenshots / logs **inline in the PR/issue** per
-[`PR_EVIDENCE.md`](../../../PR_EVIDENCE.md) (MP4 video, JPG screenshots, logs in
+[`CONTRIBUTING.md`](../../../CONTRIBUTING.md) (MP4 video, JPG screenshots, logs in
 a `<details>` block).
 
 ## How to run a live session

--- a/plugins/plugin-personal-assistant/docs/owner-agent-validation-matrix.md
+++ b/plugins/plugin-personal-assistant/docs/owner-agent-validation-matrix.md
@@ -147,7 +147,7 @@ native-permission states are captured manually against the §3 identities.
 Stage session artifacts under the local scratch dir
 `reports/lifeops-live-validation/<session>/` (gitignored — evidence is never
 committed to the repo) and attach the redacted screenshots / logs **inline in
-the PR/issue** per [`PR_EVIDENCE.md`](../../../PR_EVIDENCE.md).
+the PR/issue** per [`CONTRIBUTING.md`](../../../CONTRIBUTING.md).
 
 | Connector family | Owner evidence | Agent evidence | Status |
 |---|---|---|---|


### PR DESCRIPTION
## What

Current `develop` already contains the CLOUD_* action-catalog regeneration from #15120 fallout. After rebasing, this PR now keeps only the remaining unique fix: two LifeOps validation docs linked to the removed `PR_EVIDENCE.md`; both now point to the canonical root `CONTRIBUTING.md` evidence standard.

## Verification

- `node scripts/check-markdown-links.mjs` passed.
- `node packages/scripts/view-action-ratchet.mjs` passed on current develop.
- `git diff --check && git diff --cached --check` passed before commit.

## Required evidence rows

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: N/A - docs-only broken-link repair.

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: N/A - docs-only broken-link repair.

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: N/A - docs-only broken-link repair.

<!-- evidence-row:backend-logs -->
- [ ] Backend logs: N/A - docs-only broken-link repair.

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: N/A - docs-only broken-link repair.

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: N/A - docs-only broken-link repair.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: N/A - docs-only broken-link repair; `node scripts/check-markdown-links.mjs` verified the repaired relative links.

