### PR TITLE
fix(#15143,#15144): mobile-web same-tab cloud sign-in + real CTA instead of one-entry dropdown

### DIFF
--- a/packages/ui/src/api/client-cloud-web-base.test.ts
+++ b/packages/ui/src/api/client-cloud-web-base.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+/**
+ * Unit coverage for `resolveDirectCloudWebBase`: the WEB origin used to build
+ * browser-navigated cloud URLs (the /auth/cli-login handoff, the first-run
+ * OAuth card's authorizationUrl). Every known cloud host — API, www, app
+ * ingress, dev, and the staging pairs — must map to its apex web origin: the
+ * API worker answers `application/json` for its root and every unknown path,
+ * which iOS Safari downloads as `document.txt` instead of rendering (#15143).
+ * Pure function, no network.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    isNativePlatform: () => false,
+  },
+  CapacitorHttp: {
+    get: vi.fn(),
+    post: vi.fn(),
+    request: vi.fn(),
+  },
+}));
+
+import { resolveDirectCloudWebBase } from "./client-cloud";
+
+describe("resolveDirectCloudWebBase", () => {
+  it.each([
+    // API hosts: JSON-for-every-path workers — never navigable.
+    ["https://api.elizacloud.ai", "https://elizacloud.ai"],
+    ["https://api-staging.elizacloud.ai", "https://staging.elizacloud.ai"],
+    // www adds a redirect hop; app/dev serve non-console surfaces.
+    ["https://www.elizacloud.ai", "https://elizacloud.ai"],
+    ["https://app.elizacloud.ai", "https://elizacloud.ai"],
+    ["https://dev.elizacloud.ai", "https://elizacloud.ai"],
+    ["https://app-staging.elizacloud.ai", "https://staging.elizacloud.ai"],
+    // Apex origins are already the web origin.
+    ["https://elizacloud.ai", "https://elizacloud.ai"],
+    ["https://staging.elizacloud.ai", "https://staging.elizacloud.ai"],
+  ])("maps %s -> %s", (input, expected) => {
+    expect(resolveDirectCloudWebBase(input)).toBe(expected);
+  });
+
+  it("strips trailing slashes before matching", () => {
+    expect(resolveDirectCloudWebBase("https://api.elizacloud.ai///")).toBe(
+      "https://elizacloud.ai",
+    );
+  });
+
+  it("passes unknown hosts through unchanged (self-hosted/dev bases)", () => {
+    expect(resolveDirectCloudWebBase("http://localhost:3000")).toBe(
+      "http://localhost:3000",
+    );
+    expect(resolveDirectCloudWebBase("https://cloud.example.test")).toBe(
+      "https://cloud.example.test",
+    );
+  });
+});

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -81,9 +81,21 @@ const DIRECT_ELIZA_CLOUD_API_BY_HOST = new Map([
   ["staging.elizacloud.ai", STAGING_DIRECT_CLOUD_API_BASE_URL],
   ["app-staging.elizacloud.ai", STAGING_DIRECT_CLOUD_API_BASE_URL],
 ]);
-const DIRECT_ELIZA_CLOUD_WEB_BY_API_HOST = new Map([
+// Web origins for URLs a BROWSER will navigate to (the /auth/cli-login
+// handoff). Every known cloud host maps to its apex web origin — not just the
+// API hosts: the API worker answers `application/json` + nosniff for its root
+// and every unknown path, which iOS Safari downloads as `document.txt`
+// instead of rendering, and `www.` adds a redirect hop. A navigation URL must
+// therefore always be built on the apex, never passed through (#15143).
+const DIRECT_ELIZA_CLOUD_WEB_BY_HOST = new Map([
   ["api.elizacloud.ai", DEFAULT_DIRECT_CLOUD_BASE_URL],
+  ["elizacloud.ai", DEFAULT_DIRECT_CLOUD_BASE_URL],
+  ["www.elizacloud.ai", DEFAULT_DIRECT_CLOUD_BASE_URL],
+  ["app.elizacloud.ai", DEFAULT_DIRECT_CLOUD_BASE_URL],
+  ["dev.elizacloud.ai", DEFAULT_DIRECT_CLOUD_BASE_URL],
   ["api-staging.elizacloud.ai", STAGING_DIRECT_CLOUD_BASE_URL],
+  ["staging.elizacloud.ai", STAGING_DIRECT_CLOUD_BASE_URL],
+  ["app-staging.elizacloud.ai", STAGING_DIRECT_CLOUD_BASE_URL],
 ]);
 
 type DirectCloudAgent = {
@@ -264,11 +276,17 @@ function resolveBrowserCloudApiRequestUrl(url: string): string {
   }
 }
 
-function resolveDirectCloudWebBase(cloudBase: string): string {
+/**
+ * Resolve the WEB origin a browser navigation may target for a given cloud
+ * base. Exported for every place that turns a configured cloud API base into
+ * a user-visible URL (the OAuth card's authorizationUrl, cli-login) — an API
+ * host must never be opened as a top-level navigation (JSON download on iOS).
+ */
+export function resolveDirectCloudWebBase(cloudBase: string): string {
   const normalized = cloudBase.replace(/\/+$/, "");
   try {
     const host = new URL(normalized).hostname.toLowerCase();
-    return DIRECT_ELIZA_CLOUD_WEB_BY_API_HOST.get(host) ?? normalized;
+    return DIRECT_ELIZA_CLOUD_WEB_BY_HOST.get(host) ?? normalized;
   } catch {
     // Fall back to the provided base below.
   }

--- a/packages/ui/src/components/chat/MessageContent.sensitive-request.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.sensitive-request.test.tsx
@@ -51,6 +51,20 @@ vi.mock("../../api/client", () => ({
   client: clientMock,
 }));
 
+// Platform detection is the ONE seam the mobile-web OAuth branch turns on;
+// the real SensitiveRequestBlock runs underneath.
+const platformGuardsMocks = vi.hoisted(() => ({
+  isMobileWebBrowser: vi.fn(() => false),
+}));
+vi.mock("../../platform/platform-guards", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../platform/platform-guards")>();
+  return {
+    ...actual,
+    isMobileWebBrowser: platformGuardsMocks.isMobileWebBrowser,
+  };
+});
+
 import { MessageContent } from "./MessageContent";
 
 function baseMessage(
@@ -199,6 +213,26 @@ function pendingOAuthRequest(): ConversationMessage["secretRequest"] {
       authorizationUrl: "https://example.test/oauth/authorize?state=abc",
       submitLabel: "Connect GitHub",
       statusOnly: true,
+    },
+  };
+}
+
+// The first-run Eliza Cloud card (cloudOAuthSecretRequest in
+// use-first-run-conductor.ts): provider "elizacloud" is what unlocks the
+// same-origin /login same-tab branch on mobile web.
+function pendingCloudOAuthRequest(): ConversationMessage["secretRequest"] {
+  return {
+    key: "elizacloud",
+    reason: "Connect your Eliza Cloud account",
+    status: "pending",
+    form: {
+      type: "sensitive_request_form",
+      kind: "oauth",
+      mode: "cloud_authenticated_link",
+      fields: [],
+      submitLabel: "Connect Eliza Cloud",
+      provider: "elizacloud",
+      authorizationUrl: "https://elizacloud.ai",
     },
   };
 }
@@ -725,6 +759,80 @@ describe("MessageContent sensitive requests", () => {
     expect(updateSecretsMock).not.toHaveBeenCalled();
 
     window.open = originalOpen;
+  });
+
+  describe("mobile-web Eliza Cloud connect (#15143 — same-tab, never a popup)", () => {
+    const originalLocation = window.location;
+    let assignSpy: ReturnType<typeof vi.fn>;
+    let openMock: ReturnType<typeof vi.fn>;
+    let originalOpen: typeof window.open;
+
+    beforeEach(() => {
+      assignSpy = vi.fn();
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: { ...originalLocation, assign: assignSpy },
+      });
+      openMock = vi.fn().mockReturnValue(null);
+      originalOpen = window.open;
+      window.open = openMock as typeof window.open;
+    });
+
+    afterEach(() => {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: originalLocation,
+      });
+      window.open = originalOpen;
+      platformGuardsMocks.isMobileWebBrowser.mockReturnValue(false);
+    });
+
+    it("navigates THIS tab to the same-origin /login with a returnTo — no window.open, no 'Pop-up blocked' copy", () => {
+      platformGuardsMocks.isMobileWebBrowser.mockReturnValue(true);
+      const { container } = render(
+        <MessageContent
+          message={baseMessage({ secretRequest: pendingCloudOAuthRequest() })}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId("sensitive-request-oauth-start"));
+
+      expect(assignSpy).toHaveBeenCalledTimes(1);
+      const target = String(assignSpy.mock.calls[0]?.[0]);
+      expect(target).toBe(
+        `/login?returnTo=${encodeURIComponent(
+          `${originalLocation.pathname}${originalLocation.search}`,
+        )}`,
+      );
+      expect(openMock).not.toHaveBeenCalled();
+      expect(container.textContent).not.toContain("Pop-up blocked");
+    });
+
+    it("keeps the popup for non-cloud OAuth providers on mobile web (no same-origin return path is wired for them)", () => {
+      platformGuardsMocks.isMobileWebBrowser.mockReturnValue(true);
+      render(
+        <MessageContent
+          message={baseMessage({ secretRequest: pendingOAuthRequest() })}
+        />,
+      );
+      fireEvent.click(screen.getByTestId("sensitive-request-oauth-start"));
+      expect(openMock).toHaveBeenCalledTimes(1);
+      expect(assignSpy).not.toHaveBeenCalled();
+    });
+
+    it("keeps the popup for the cloud card on desktop web", () => {
+      platformGuardsMocks.isMobileWebBrowser.mockReturnValue(false);
+      openMock.mockReturnValue({ opener: {} } as unknown as Window);
+      render(
+        <MessageContent
+          message={baseMessage({ secretRequest: pendingCloudOAuthRequest() })}
+        />,
+      );
+      fireEvent.click(screen.getByTestId("sensitive-request-oauth-start"));
+      expect(openMock).toHaveBeenCalledTimes(1);
+      expect(openMock.mock.calls[0]?.[0]).toBe("https://elizacloud.ai");
+      expect(assignSpy).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -31,7 +31,11 @@ import type { UiSpec } from "../../config/ui-spec";
 import { CONNECT_EVENT, dispatchAppEvent } from "../../events";
 import { normalizeRemoteAgentUrl } from "../../first-run/adopt-remote-first-run";
 import { useRenderGuard } from "../../hooks/useRenderGuard";
-import { isDesktopPlatform, isNative } from "../../platform";
+import {
+  isDesktopPlatform,
+  isMobileWebBrowser,
+  isNative,
+} from "../../platform";
 import {
   createMobileSignalsPermissionsRegistry,
   openMobilePermissionSettings,
@@ -1133,6 +1137,26 @@ export function SensitiveRequestBlock({
               setError("Invalid authorization URL.");
               return;
             }
+            if (typeof window === "undefined") return;
+            // Mobile web cannot complete the popup handoff at all: iOS Safari
+            // blocks featured/named popups by default, so the window.open
+            // below could only ever render the "Pop-up blocked" error there
+            // (#15143). The Eliza Cloud card has a same-origin escape — the
+            // /login route runs the same Steward OAuth in THIS tab and its
+            // returnTo round-trip lands the session back on the current
+            // route, where the first-run resume machinery picks it up — so
+            // navigate instead of popping. Other providers keep the popup:
+            // their consent URLs have no same-origin return path wired.
+            if (
+              request.form?.provider === "elizacloud" &&
+              isMobileWebBrowser()
+            ) {
+              const returnTo = `${window.location.pathname}${window.location.search}`;
+              window.location.assign(
+                `/login?returnTo=${encodeURIComponent(returnTo)}`,
+              );
+              return;
+            }
             try {
               // SECURITY: we never embed the authorizationUrl in chat text.
               // It is only opened in a popup. We deliberately do NOT pass
@@ -1144,7 +1168,6 @@ export function SensitiveRequestBlock({
               // and we set `popup.opener = null` ourselves immediately after
               // open as a belt-and-suspenders measure. If `window.open`
               // returns null after this, that genuinely is a blocked popup.
-              if (typeof window === "undefined") return;
               const popup = window.open(
                 url,
                 "eliza-oauth",

--- a/packages/ui/src/components/chat/widgets/ChoiceWidget.tsx
+++ b/packages/ui/src/components/chat/widgets/ChoiceWidget.tsx
@@ -89,11 +89,59 @@ export const ChoiceWidget = memo(function ChoiceWidget({
 
   const firstRun = isFirstRunScope(scope);
 
+  // A single-action first-run prompt ("Sign in to Eliza Cloud") is a CTA, not
+  // a choice: wrapped in the collapsible shell it read as a dropdown with one
+  // entry (header + "1 options" chip + chevron) and its secondary chip washed
+  // out on the dark cloud surface (#15144). Render it as one full-width
+  // primary button — no shell, no count chip, no chevron — keeping the same
+  // testids, aria state, and role=status line the shell path exposes.
+  const soleOption =
+    firstRun && !allowCustom && options.length === 1 ? options[0] : null;
+  if (soleOption) {
+    const isSelected = selected?.value === soleOption.value;
+    return (
+      <div
+        className="my-2 flex min-w-0 flex-col items-stretch gap-2"
+        data-choice-id={id}
+        data-choice-scope={scope}
+        data-testid={`choice-shell-${id}`}
+      >
+        <Button
+          type="button"
+          variant="default"
+          size="default"
+          disabled={selected !== null}
+          aria-label={soleOption.label}
+          aria-pressed={isSelected}
+          data-testid={`choice-${soleOption.value}`}
+          // The locked (selected) state stays at full opacity: it is the
+          // confirmation the user just acted on, not a faded leftover.
+          className="h-11 w-full justify-center px-4 text-sm font-medium disabled:opacity-100"
+          onClick={() => handleChoose(soleOption)}
+        >
+          <span className="inline-flex items-center gap-2">
+            {isSelected ? (
+              <Check className="h-4 w-4 shrink-0" aria-hidden />
+            ) : null}
+            <span>{soleOption.label}</span>
+          </span>
+        </Button>
+        {selected ? (
+          <span role="status" className="px-1 text-xs text-muted">
+            Selected: {selected.label}
+          </span>
+        ) : null}
+      </div>
+    );
+  }
+
   return (
     <ChatWidgetShell
       title={firstRun ? "Choose next step" : "Choose"}
       status={
-        <span className="rounded-sm bg-bg px-2 py-0.5 text-[11px] font-medium text-muted">
+        // bg-surface, not bg-bg: on the dark cloud/os themes bg-bg is a
+        // near-transparent alpha that left this chip unreadable (#15144).
+        <span className="rounded-sm bg-surface px-2 py-0.5 text-[11px] font-medium text-muted">
           {selected ? "Selected" : `${options.length} options`}
         </span>
       }
@@ -122,8 +170,13 @@ export const ChoiceWidget = memo(function ChoiceWidget({
             // Prominent, obviously-tappable next-step rows. The recommended
             // option gets the accent; the rest are prominent neutral
             // (secondary), so exactly one orange accent appears (brand rule).
+            // Once a pick locks the fieldset, ONLY the non-selected rows fade:
+            // the selected row is promoted to the accent tokens at full
+            // opacity — the blanket 40% wash on a low-alpha secondary chip
+            // rendered the user's own pick white-on-white on the dark cloud
+            // surface (#15144).
             const recommended = isRecommended(option.label);
-            const variant = recommended ? "default" : "secondary";
+            const variant = isSelected || recommended ? "default" : "secondary";
             return (
               <Button
                 key={option.value}
@@ -134,7 +187,11 @@ export const ChoiceWidget = memo(function ChoiceWidget({
                 aria-label={option.label}
                 aria-pressed={isSelected}
                 data-testid={`choice-${option.value}`}
-                className="h-11 w-full justify-between px-4 text-sm font-medium disabled:opacity-40 aria-disabled:opacity-40"
+                className={
+                  isSelected
+                    ? "h-11 w-full justify-between px-4 text-sm font-medium disabled:opacity-100 aria-disabled:opacity-100"
+                    : "h-11 w-full justify-between px-4 text-sm font-medium disabled:opacity-40 aria-disabled:opacity-40"
+                }
                 onClick={() => handleChoose(option)}
               >
                 <span className="inline-flex items-center gap-2">

--- a/packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx
+++ b/packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx
@@ -272,6 +272,81 @@ describe("ChoiceWidget — pick an option", () => {
     expect(onChoose).toHaveBeenCalledTimes(1);
     expect(onChoose).toHaveBeenCalledWith("__first_run__:runtime:cloud");
   });
+
+  it("single-option first-run CTA is a bare primary button — no collapsible shell, no '1 options' chip, no chevron (#15144)", () => {
+    const onChoose = vi.fn();
+    render(
+      <ChoiceWidget
+        id="runtime"
+        scope="first-run"
+        options={[
+          {
+            value: "__first_run__:runtime:cloud",
+            label: "Sign in to Eliza Cloud",
+          },
+        ]}
+        onChoose={onChoose}
+      />,
+    );
+
+    // Not wrapped in ChatWidgetShell: no dropdown-like header/chevron/chip.
+    expect(screen.queryByText("Choose next step")).toBeNull();
+    expect(screen.queryByText("1 options")).toBeNull();
+    expect(screen.queryByLabelText("Collapse")).toBeNull();
+
+    // Primary (accent) button, full width — the one obvious CTA. Exact class
+    // match: "bg-bg-accent" (the washed secondary token) contains the
+    // substring "bg-accent", so a toContain would false-pass.
+    const signIn = screen.getByTestId("choice-__first_run__:runtime:cloud");
+    expect(signIn.className.split(/\s+/)).toContain("bg-accent");
+    expect(signIn.className.split(/\s+/)).toContain("w-full");
+
+    // After the tap: locked but NOT washed out, with the status line intact.
+    fireEvent.click(signIn);
+    expect((signIn as HTMLButtonElement).disabled).toBe(true);
+    expect(signIn.className).toContain("disabled:opacity-100");
+    expect(signIn.getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("status").textContent).toMatch(
+      /Sign in to Eliza Cloud/,
+    );
+    // Locked = one decision per prompt; a second tap is a no-op.
+    fireEvent.click(signIn);
+    expect(onChoose).toHaveBeenCalledTimes(1);
+  });
+
+  it("multi-option first-run: the SELECTED row keeps full-opacity accent tokens; only the non-selected locked rows fade (#15144)", () => {
+    const onChoose = vi.fn();
+    render(
+      <ChoiceWidget
+        id="runtime"
+        scope="first-run"
+        options={[
+          { value: "cloud", label: "Eliza Cloud (managed)" },
+          { value: "local", label: "On this device" },
+        ]}
+        onChoose={onChoose}
+      />,
+    );
+
+    // Multi-option keeps the shell (title + count chip), chip on a readable
+    // surface token rather than the near-transparent bg-bg.
+    expect(screen.getByText("Choose next step")).toBeTruthy();
+    const chip = screen.getByText("2 options");
+    expect(chip.className).toContain("bg-surface");
+
+    fireEvent.click(screen.getByTestId("choice-cloud"));
+
+    const picked = screen.getByTestId("choice-cloud");
+    const other = screen.getByTestId("choice-local");
+    // The pick is promoted to the primary tokens at full opacity… (exact
+    // class match — the secondary token "bg-bg-accent" contains "bg-accent")
+    expect(picked.className.split(/\s+/)).toContain("bg-accent");
+    expect(picked.className).toContain("disabled:opacity-100");
+    expect(picked.className).not.toContain("disabled:opacity-40");
+    // …while the rows the user did NOT pick fade behind it.
+    expect(other.className).toContain("disabled:opacity-40");
+    expect(onChoose).toHaveBeenCalledWith("cloud");
+  });
 });
 
 describe("ChoiceWidget — put their own in (allowCustom)", () => {

--- a/packages/ui/src/first-run/first-run-finish.ts
+++ b/packages/ui/src/first-run/first-run-finish.ts
@@ -27,6 +27,7 @@ import { silentlyRepointToDedicated } from "../cloud/handoff/silent-repoint";
 import { getBootConfig } from "../config/boot-config";
 import type { UiLanguage } from "../i18n";
 import { isAndroid, isDesktopPlatform, isIOS } from "../platform/init";
+import { isMobileWebBrowser } from "../platform/platform-guards";
 import {
   addAgentProfile,
   createPersistedActiveServer,
@@ -336,7 +337,15 @@ async function finishLocal(
   if (firstRunNeedsCloudConnect(sourceDraft, ports.elizaCloudConnected)) {
     ports.setRuntimeState("firstRunRuntimeTarget", "elizacloud-hybrid");
     ports.setRuntimeState("firstRunProvider", "elizacloud");
-    const authWindow = ports.preOpenWindow?.() ?? null;
+    // Mobile web never gets a pre-opened auth window: by the time this runs
+    // the user-gesture context is gone (awaits above), so window.open could
+    // only return null there — and handleCloudLogin(null) then knows to lean
+    // on its popup-free paths (#15143). The conductor's mobile-web branch
+    // normally navigates before reaching here; this is the belt for resume
+    // paths that re-enter the finish flow without a fresh tap.
+    const authWindow = isMobileWebBrowser()
+      ? null
+      : (ports.preOpenWindow?.() ?? null);
     await ports.handleCloudLogin(authWindow);
     const cloudStatus = await getCloudStatusIfSupported();
     let cloudConnectedForFinish = isCloudStatusAuthenticated(
@@ -592,7 +601,11 @@ export async function listOrAutoProvisionCloudAgent(
     );
   }
   if (firstRunNeedsCloudConnect(sourceDraft, cloudConnectedForFinish)) {
-    const authWindow = ports.preOpenWindow?.() ?? null;
+    // Same mobile-web guard as finishLocal above: post-await window.open can
+    // only return null there, so skip the pre-open entirely (#15143).
+    const authWindow = isMobileWebBrowser()
+      ? null
+      : (ports.preOpenWindow?.() ?? null);
     await ports.handleCloudLogin(authWindow);
     const cloudStatus = await getCloudStatusIfSupported();
     cloudConnectedForFinish = isCloudStatusAuthenticated(

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -50,6 +50,9 @@ const mocks = vi.hoisted(() => ({
     }),
   },
   autoDownloadRecommendedLocalModelInBackground: vi.fn(async () => undefined),
+  // Platform detection is the ONE seam the mobile-web branch turns on: real
+  // components run underneath; only the coarse-pointer/UA probe is faked.
+  isMobileWebBrowser: vi.fn(() => false),
 }));
 
 vi.mock("../api/client", async (importOriginal) => {
@@ -61,6 +64,12 @@ vi.mock("./auto-download-recommended", () => ({
   autoDownloadRecommendedLocalModelInBackground:
     mocks.autoDownloadRecommendedLocalModelInBackground,
 }));
+
+vi.mock("../platform/platform-guards", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../platform/platform-guards")>();
+  return { ...actual, isMobileWebBrowser: mocks.isMobileWebBrowser };
+});
 
 import type { ConversationMessage, LocalAgentBackupMetadata } from "../api";
 import { __setAppValueForTests } from "../state/app-store";
@@ -217,6 +226,9 @@ beforeEach(() => {
     success: true,
     data: [],
   });
+  // clearAllMocks keeps mockReturnValue stubs — pin the desktop default so a
+  // mobile-web test can't leak its `true` into later suites.
+  mocks.isMobileWebBrowser.mockReturnValue(false);
   localStorage.setItem("steward_session_token", "cloud-token");
   // The runtime chooser (local / remote paths) is OFF by default (#13377);
   // these suites exercise the full chooser, so they opt in via the override.
@@ -1346,6 +1358,98 @@ describe("cloud-only onboarding (runtime chooser off — the production default)
     await new Promise((resolve) => setTimeout(resolve, 100));
     expect(mocks.client.getCloudCompatAgents.mock.calls.length).toBe(listed);
     expect(listed).toBeLessThanOrEqual(3);
+    unmount();
+  });
+});
+
+describe("mobile-web cloud sign-in (#15143 — same-tab /login navigation)", () => {
+  let assignSpy: ReturnType<typeof vi.fn>;
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    // Cloud-only production default (the branch also covers chooser mode —
+    // both funnel through the same runtime:cloud pick).
+    localStorage.removeItem("eliza:enable-runtime-chooser");
+    localStorage.removeItem("steward_session_token");
+    // jsdom's location.assign hard-errors on real navigation; observe it.
+    assignSpy = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, assign: assignSpy },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+    mocks.isMobileWebBrowser.mockReturnValue(false);
+  });
+
+  it("sign-in tap navigates THIS tab to /login?returnTo=/chat — no popup flow, no provisioning, resume marker armed", async () => {
+    mocks.isMobileWebBrowser.mockReturnValue(true);
+    const spies = seedAppStore({ elizaCloudConnected: false });
+    const { turn, unmount } = renderConductor();
+    await waitForTurn(turn, "first-run:greeting");
+
+    expect(tryHandleFirstRunAction("__first_run__:runtime:cloud")).toBe(true);
+    expect(assignSpy).toHaveBeenCalledTimes(1);
+    expect(assignSpy).toHaveBeenCalledWith("/login?returnTo=/chat");
+    // The durable marker survives the navigation so the return trip resumes
+    // the cloud flow instead of restarting at the greeting.
+    expect(readCloudLoginPending()).toMatchObject({
+      runtime: "cloud",
+      localInference: "cloud-inference",
+    });
+    // The popup-based provision flow did NOT start: no "Connecting…" turn,
+    // no login attempt, no agent listing.
+    expect(turn("first-run:cloud-oauth")).toBeUndefined();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(spies.handleCloudLogin).not.toHaveBeenCalled();
+    expect(mocks.client.getCloudCompatAgents).not.toHaveBeenCalled();
+    expect(mocks.client.selectOrProvisionCloudAgent).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it("desktop web keeps the in-app provision flow — never a same-tab navigation", async () => {
+    mocks.isMobileWebBrowser.mockReturnValue(false);
+    const spies = seedAppStore({ elizaCloudConnected: false });
+    const { turn, unmount } = renderConductor();
+    await waitForTurn(turn, "first-run:greeting");
+
+    // Session lands during the tap-launched login (as in the flows above).
+    localStorage.setItem("steward_session_token", "cloud-token");
+    expect(tryHandleFirstRunAction("__first_run__:runtime:cloud")).toBe(true);
+    await waitForTurn(turn, "first-run:cloud-oauth");
+    await waitFor(() => {
+      expect(spies.completeFirstRun).toHaveBeenCalledTimes(1);
+    });
+    expect(assignSpy).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it("return trip: relaunching with the armed marker + a live session resumes provisioning to completion (no greeting restart)", async () => {
+    // The state the same-tab round trip leaves behind: marker armed by the
+    // pre-navigation tap, steward JWT written to same-origin localStorage by
+    // the /login page.
+    markCloudLoginPending({
+      runtime: "cloud",
+      localInference: "cloud-inference",
+      agentName: "Eliza",
+    });
+    localStorage.setItem("steward_session_token", "cloud-token");
+    mocks.isMobileWebBrowser.mockReturnValue(true);
+    const spies = seedAppStore({ elizaCloudConnected: true });
+    const { turn, unmount } = renderConductor();
+
+    await waitFor(() => {
+      expect(spies.completeFirstRun).toHaveBeenCalledTimes(1);
+    });
+    expect(spies.completeFirstRun).toHaveBeenCalledWith("chat");
+    await waitForTurn(turn, "first-run:cloud-done");
+    expect(mocks.client.selectOrProvisionCloudAgent).toHaveBeenCalledTimes(1);
+    expect(assignSpy).not.toHaveBeenCalled();
     unmount();
   });
 });

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -57,8 +57,10 @@ import { client } from "../api";
 import {
   getCloudAuthToken,
   refreshCloudStewardSession,
+  resolveDirectCloudWebBase,
 } from "../api/client-cloud";
 import { getBootConfig } from "../config/boot-config";
+import { isMobileWebBrowser } from "../platform/platform-guards";
 import { ACCENT_PRESETS, useAppSelectorShallow } from "../state";
 import { useConversationMessages } from "../state/ConversationMessagesContext.hooks";
 import { hasUsableStoredStewardToken } from "../state/cloud-steward-login";
@@ -67,6 +69,7 @@ import { preOpenWindow } from "../utils";
 import { normalizeFirstRunName } from "./first-run";
 import {
   FIRST_RUN_ACTION_PREFIX,
+  FIRST_RUN_CLOUD_LOGIN_FALLBACK_PATH,
   setFirstRunActionHandler,
   setFirstRunTextHandler,
 } from "./first-run-action-channel";
@@ -281,7 +284,12 @@ function cloudOAuthSecretRequest(
       fields: [],
       submitLabel: "Connect Eliza Cloud",
       provider: "elizacloud",
-      authorizationUrl: getBootConfig().cloudApiBase || "https://elizacloud.ai",
+      // The card's Connect button opens this as a top-level navigation, so it
+      // must be the WEB origin: an API-host cloudApiBase serves JSON, which
+      // iOS Safari downloads as document.txt instead of rendering (#15143).
+      authorizationUrl: resolveDirectCloudWebBase(
+        getBootConfig().cloudApiBase || "https://elizacloud.ai",
+      ),
     },
   };
 }
@@ -863,6 +871,20 @@ export function useFirstRunConductor(): void {
             localInference: "cloud-inference",
             agentName: draftRef.current.agentName,
           });
+          // Mobile web: this tap is the ONLY user gesture the flow gets, and
+          // the login flow's popup path opens windows after awaits — iOS
+          // Safari silently blocks those (window.open returns null, no
+          // throw), stranding the user on a dead "Connecting…" card
+          // (#15143). Navigate THIS tab to the same-origin /login route
+          // instead: the durable marker above plus the mount-time resume
+          // machinery (readCloudLoginPending rehydrate / the 500ms
+          // steward-token poll) complete provisioning when the OAuth
+          // redirect lands back on /chat — no popup and no device-code poll
+          // (which is in-memory and would not survive this navigation).
+          if (isMobileWebBrowser()) {
+            window.location.assign(FIRST_RUN_CLOUD_LOGIN_FALLBACK_PATH);
+            return true;
+          }
           const connecting = makeTurn(
             "first-run:cloud-oauth",
             "Connecting your Eliza Cloud account…",

--- a/packages/ui/src/platform/platform-guards.test.ts
+++ b/packages/ui/src/platform/platform-guards.test.ts
@@ -5,7 +5,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const isElectrobunRuntime = vi.hoisted(() => vi.fn(() => false));
 vi.mock("../bridge/electrobun-runtime", () => ({ isElectrobunRuntime }));
 
-import { getActiveViewModality, getFrontendPlatform } from "./platform-guards";
+import {
+  getActiveViewModality,
+  getFrontendPlatform,
+  isMobileWebBrowser,
+} from "./platform-guards";
 
 const w = window as unknown as Record<string, unknown>;
 
@@ -42,5 +46,57 @@ describe("getFrontendPlatform", () => {
     isElectrobunRuntime.mockReturnValue(false);
     // jsdom + no Capacitor native platform → web.
     expect(getFrontendPlatform()).toBe("web");
+  });
+});
+
+describe("isMobileWebBrowser", () => {
+  const setMatchMedia = (coarse: boolean) => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: (query: string) => ({
+        matches: query === "(pointer: coarse)" ? coarse : false,
+      }),
+    });
+  };
+  const setUserAgent = (ua: string) => {
+    Object.defineProperty(window.navigator, "userAgent", {
+      configurable: true,
+      value: ua,
+    });
+  };
+
+  afterEach(() => {
+    isElectrobunRuntime.mockReturnValue(false);
+    Reflect.deleteProperty(window, "matchMedia");
+  });
+
+  it("is true for a coarse primary pointer on the web platform (phones, and iPadOS Safari's macOS-masquerading UA)", () => {
+    setMatchMedia(true);
+    setUserAgent(
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15",
+    );
+    expect(isMobileWebBrowser()).toBe(true);
+  });
+
+  it("is false for a fine pointer + desktop UA", () => {
+    setMatchMedia(false);
+    setUserAgent(
+      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36",
+    );
+    expect(isMobileWebBrowser()).toBe(false);
+  });
+
+  it("falls back to the UA when matchMedia misreports: a mobile UA alone is enough", () => {
+    setMatchMedia(false);
+    setUserAgent(
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1",
+    );
+    expect(isMobileWebBrowser()).toBe(true);
+  });
+
+  it("is false inside the Electrobun desktop shell even with a coarse pointer (touch-screen laptops)", () => {
+    isElectrobunRuntime.mockReturnValue(true);
+    setMatchMedia(true);
+    expect(isMobileWebBrowser()).toBe(false);
   });
 });

--- a/packages/ui/src/platform/platform-guards.ts
+++ b/packages/ui/src/platform/platform-guards.ts
@@ -56,6 +56,35 @@ export function isDynamicViewLoadingAllowed(): boolean {
   return platform !== "ios" && platform !== "android";
 }
 
+/**
+ * True when the app runs as a PLAIN mobile web page: the `web` platform (no
+ * Capacitor native bridge, no Electrobun shell) on a touch-first device.
+ *
+ * Mobile browsers — iOS Safari above all — refuse `window.open` once the
+ * user-gesture context is lost across an `await`, and block featured/named
+ * popups outright, so any login flow that pops a window there dead-ends on a
+ * "allow pop-ups" error the user cannot reasonably act on. Flows that would
+ * pop a window on desktop must branch on this guard and navigate the CURRENT
+ * tab instead (#15143).
+ *
+ * Touch-first = coarse primary pointer (`(pointer: coarse)` also catches
+ * iPadOS Safari, whose UA masquerades as macOS), with a mobile-UA fallback
+ * for engines that misreport pointer capabilities.
+ */
+export function isMobileWebBrowser(): boolean {
+  if (getFrontendPlatform() !== "web") return false;
+  if (typeof window === "undefined") return false;
+  if (
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(pointer: coarse)").matches
+  ) {
+    return true;
+  }
+  const ua =
+    typeof navigator !== "undefined" ? (navigator.userAgent ?? "") : "";
+  return /android|iphone|ipad|ipod|mobile/i.test(ua);
+}
+
 /** Presentation modality of the surface the dashboard renders inside. */
 export type ViewModality = "gui" | "tui" | "xr";
 


### PR DESCRIPTION
Closes #15143 and #15144 — nubs's iOS Safari phone QA (screenshots in the issues).

## #15143 — iOS sign-in dead-ends
Root causes found and fixed:
- `preOpenWindow` runs **after awaits** → user-gesture gone → iOS returns null → the 'Pop-up blocked. Allow pop-ups' dead-end. **Mobile web now never opens a popup**: the sign-in tap navigates the **current tab** to `/login?returnTo=…` (same-origin route); the durable pending-marker + token-poll machinery completes provisioning on return (round-trip test included). Desktop keeps the popup flow.
- **The `document.txt` mystery solved**: sign-in URLs built from API/www hosts (`api.elizacloud.ai/auth/cli-login` = JSON 404 w/ nosniff) — iOS Safari *downloads* top-level JSON navigations. `resolveDirectCloudWebBase` now maps every known cloud host (api/www/app/dev/apex + staging pairs) to the apex web origin; card authorizationUrl + plugin browserUrl paths audited.

## #15144 — choice-widget slop
- Single first-run option no longer renders dropdown chrome → one full-width **primary Button** (same handler/testids/aria).
- The washed-out unreadable chip was `disabled:opacity-40` applied to the SELECTED row + low-alpha white token: selected row now stays **full-opacity** (variant default), only non-selected rows fade; status chip on a real surface token.

## Verification
- 111/111 across 7 touched test files in the build worktree; key suites re-verified on this tree (32/32); packages/ui typecheck clean; biome + error-policy ratchet clean.
- Real components/hooks driven; only platform detection + network mocked.

## Evidence
- <!-- evidence-row:before-screenshots --> **Before screenshots:** owner's iOS captures (popup-blocked card, document.txt download, washed one-option dropdown) attached in #15143/#15144.
- <!-- evidence-row:after-screenshots --> **After screenshots:** N/A — mobile-viewport render on staging post-merge (queued with the standing staging capture session); will attach before promote.
- <!-- evidence-row:walkthrough-video --> **Walkthrough video:** N/A — bundled with that capture session.
- <!-- evidence-row:backend-logs --> **Backend logs:** N/A — client-only change.
- <!-- evidence-row:frontend-logs --> **Frontend console/network logs:** same-tab navigation sequence + return-trip resume asserted in the conductor test; host-mapping table locked by 10-case unit suite.
- <!-- evidence-row:llm-trajectory --> **Real-LLM trajectory:** N/A — no model behavior.
- <!-- evidence-row:domain-artifacts --> **Domain artifacts:** `DIRECT_ELIZA_CLOUD_WEB_BY_HOST` mapping table (the document.txt kill) unit-locked; pending-marker persistence asserted across the simulated round trip.

— [qa-agent] (workflow-built; full popup-chain diagnosis in the #15143 thread)