### PR TITLE
ci: stabilize PR typecheck and stale-base guard (#15140)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,10 @@ jobs:
     # Skip duplicate runs: run on push to main, or on pull_request events only
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_name == 'main')
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    # 45 not 35: typecheck runs at --concurrency=4 (see below, #15140), so a
+    # near-total affected cone (e.g. a develop→main promote PR) needs headroom
+    # on top of install + build + the 15-minute test step.
+    timeout-minutes: 45
     env:
       # Baseline CI is secret-free. Live/provider-key E2E runs in dedicated
       # opt-in or post-merge workflows, not in the PR test job.
@@ -55,10 +58,13 @@ jobs:
         run: bun run build:core
 
       # PR lane: typecheck only the merge base's dependency cone; on push to
-      # main typecheck the whole workspace (#12341).
+      # main typecheck the whole workspace (#12341). --concurrency=4 not 8:
+      # a develop→main promote PR's affected cone is near-total, and eight
+      # concurrent tsgo processes exhaust a 16 GB hosted runner (#15140);
+      # mirrors develop-pr.yml so the PR lanes stay in agreement.
       - name: Run typecheck (affected — PR)
         if: github.event_name == 'pull_request'
-        run: NODE_OPTIONS='--max-old-space-size=8192' node packages/scripts/run-turbo.mjs run typecheck --concurrency=8 --affected
+        run: NODE_OPTIONS='--max-old-space-size=8192' node packages/scripts/run-turbo.mjs run typecheck --concurrency=4 --affected
         env:
           TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
 

--- a/.github/workflows/develop-pr.yml
+++ b/.github/workflows/develop-pr.yml
@@ -95,7 +95,10 @@ jobs:
 
   typecheck:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # 35 not 20: at --concurrency=4 a near-total affected cone (~250 packages)
+    # needs headroom — the one green full-cone run spent 11 minutes in the
+    # typecheck step alone, on top of checkout/install/build:core (#15140).
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -124,8 +127,15 @@ jobs:
       - name: Build core
         run: bun run build:core
 
+      # --concurrency=4 not 8: hosted ubuntu-latest runners have 4 vCPUs and
+      # 16 GB RAM, and when the affected cone goes near-total (a base-branch
+      # commit touching turbo globalDependencies like root package.json /
+      # turbo.json makes every stale-base PR typecheck all ~250 packages) eight
+      # concurrent tsgo processes exhaust the runner — the OS SIGKILLs tasks or
+      # the runner VM itself dies (#15140). NODE_OPTIONS only bounds node-based
+      # tools, not native tsgo, so concurrency is the memory lever here.
       - name: Run typecheck (affected)
-        run: NODE_OPTIONS='--max-old-space-size=8192' node packages/scripts/run-turbo.mjs run typecheck --concurrency=8 --affected
+        run: NODE_OPTIONS='--max-old-space-size=8192' node packages/scripts/run-turbo.mjs run typecheck --concurrency=4 --affected
         env:
           TURBO_SCM_BASE: ${{ github.event.pull_request.base.sha }}
 

--- a/.github/workflows/stale-base-guard.yml
+++ b/.github/workflows/stale-base-guard.yml
@@ -54,7 +54,11 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ github.event.pull_request.base.ref }}
-          fetch-depth: 1
+          # The guard disables lazy promisor fetches while it runs. Fetch the
+          # same bounded history window up front so merge commits can resolve
+          # their parents without network fallback.
+          fetch-depth: 1500
+          filter: blob:none
           submodules: false
 
       # The guard steps below invoke `node` directly, but self-hosted

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,11 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ github.event.pull_request.base.ref }}
-          fetch-depth: 1
+          # The guard disables lazy promisor fetches while it runs. Fetch the
+          # same bounded history window up front so merge commits can resolve
+          # their parents without network fallback.
+          fetch-depth: 1500
+          filter: blob:none
           submodules: false
 
       - name: Setup Node.js for stale-base guard

--- a/packages/scripts/stale-base-guard.mjs
+++ b/packages/scripts/stale-base-guard.mjs
@@ -276,15 +276,36 @@ function historyWalk(repo, tip, window, paths) {
   return byPath;
 }
 
-function commitMeta(repo, sha) {
-  const line = gitText(repo, [
-    "show",
-    "-s",
-    "--format=%H\u001f%cI\u001f%s",
+function parseCommit(repo, sha) {
+  const raw = gitText(repo, ["cat-file", "commit", sha]);
+  const [headers, message = ""] = raw.split(/\n\n/, 2);
+  const committer = headers
+    .split("\n")
+    .find((line) => line.startsWith("committer "));
+  if (!committer) throw new Error(`commit ${sha} has no committer header`);
+  const match = committer.match(/ (\d+) ([+-]\d{4})$/);
+  if (!match) throw new Error(`commit ${sha} has invalid committer header`);
+  const subject = message.split("\n")[0] ?? "";
+  return {
     sha,
-  ]);
-  const [full, date, subject] = line.split("\u001f");
-  return { sha: full, shortSha: full.slice(0, 10), date, subject };
+    ct: Number(match[1]),
+    date: formatGitIso(match[1], match[2]),
+    subject,
+  };
+}
+
+function formatGitIso(timestamp, tz) {
+  const offsetMinutes = Number(tz.slice(1, 3)) * 60 + Number(tz.slice(3, 5));
+  const signedOffsetMinutes = tz.startsWith("-")
+    ? -offsetMinutes
+    : offsetMinutes;
+  const localMs = Number(timestamp) * 1000 + signedOffsetMinutes * 60 * 1000;
+  return `${new Date(localMs).toISOString().replace(".000Z", "")}${tz.slice(0, 3)}:${tz.slice(3)}`;
+}
+
+function commitMeta(repo, sha) {
+  const parsed = parseCommit(repo, sha);
+  return { ...parsed, shortSha: parsed.sha.slice(0, 10) };
 }
 
 function main() {
@@ -332,8 +353,7 @@ function main() {
       `${mergeBase}..${base}`,
     ]),
   );
-  const ctOf = (sha) =>
-    Number(gitText(repo, ["show", "-s", "--format=%ct", sha]));
+  const ctOf = (sha) => parseCommit(repo, sha).ct;
   const behindHours = Math.max(0, (ctOf(base) - ctOf(mergeBase)) / 3600);
   const staleReasons = [];
   if (behindCommits > args.maxBehindCommits) {

--- a/plugins/plugin-personal-assistant/docs/LIFEOPS_LIVE_VALIDATION.md
+++ b/plugins/plugin-personal-assistant/docs/LIFEOPS_LIVE_VALIDATION.md
@@ -12,7 +12,7 @@ skip rules when credentials/devices are absent. Fill the **Result** columns in a
 copy under the local scratch dir `reports/lifeops-live-validation/<session>/`
 (gitignored — evidence is never committed to the repo) and attach the redacted
 screenshots / logs **inline in the PR/issue** per
-[`PR_EVIDENCE.md`](../../../PR_EVIDENCE.md) (MP4 video, JPG screenshots, logs in
+[`CONTRIBUTING.md`](../../../CONTRIBUTING.md) (MP4 video, JPG screenshots, logs in
 a `<details>` block).
 
 ## How to run a live session
@@ -34,7 +34,7 @@ bun run test:e2e:record                 # recorded walkthrough for the PR video
 # 6. Drive each view/action below as OWNER, then repeat as a non-owner AGENT
 #    identity to confirm the permission matrix. Stage all artifacts under
 #    reports/lifeops-live-validation/<session>/ and attach them inline on the
-#    PR/issue per PR_EVIDENCE.md.
+#    PR/issue per CONTRIBUTING.md.
 ```
 
 The HITL runner tracks this lane as the `lifeops-live` group

--- a/plugins/plugin-personal-assistant/docs/owner-agent-validation-matrix.md
+++ b/plugins/plugin-personal-assistant/docs/owner-agent-validation-matrix.md
@@ -147,7 +147,7 @@ native-permission states are captured manually against the §3 identities.
 Stage session artifacts under the local scratch dir
 `reports/lifeops-live-validation/<session>/` (gitignored — evidence is never
 committed to the repo) and attach the redacted screenshots / logs **inline in
-the PR/issue** per [`PR_EVIDENCE.md`](../../../PR_EVIDENCE.md).
+the PR/issue** per [`CONTRIBUTING.md`](../../../CONTRIBUTING.md).
 
 | Connector family | Owner evidence | Agent evidence | Status |
 |---|---|---|---|


### PR DESCRIPTION
Fixes #15140.

## Problem

Since ~20:13 UTC 2026-07-06, the `Develop PR` workflow's `typecheck` job has failed on **every** PR — 20/20 runs surveyed, zero successes — with turbo tasks dying by `SIGKILL` (`@elizaos/electrobun`, `@elizaos/ui`, `@elizaos/agent`) or the whole step reported `The operation was canceled.` after `Shutting down Turborepo tasks...`. The same branches typecheck clean locally. Receipts (failing-run links) are collected in #15140.

While re-running blocked PRs, two follow-on CI issues also showed up:

- The stale-base guard checks out the base with `fetch-depth: 1` and then disables lazy promisor fetches via `GIT_NO_LAZY_FETCH=1`, so merge commits can fail with `fatal: could not fetch <parent> from promisor remote` even when the PR is current.
- Two LifeOps docs still linked to the removed `PR_EVIDENCE.md`, causing the relative markdown link guard to fail on branches that touch the docs lane.

## Root cause

Memory exhaustion, not code:

- The job runs `node packages/scripts/run-turbo.mjs run typecheck --concurrency=8 --affected` on a standard hosted `ubuntu-latest` runner (4 vCPU / 16 GB).
- #15092 (the type-error repair that merged at 20:12 UTC) touched root `package.json` and `turbo.json` — both turbo `globalDependencies`. `TURBO_SCM_BASE` comes from `github.event.pull_request.base.sha`, which goes stale as the base branch moves, while the checkout is the PR **merge** commit — so for every PR whose recorded base predates #15092, the `--affected` diff contains those global files and the cone resolves **near-total**. The failing job log for run [28824759550](https://github.com/elizaOS/eliza/actions/runs/28824759550) (a one-file PR diff) shows `Running typecheck in 251 packages`, then `The runner has received a shutdown signal`, then `@elizaos/agent:typecheck ... SIGKILL`.
- Eight concurrent `tsgo` processes across a near-total cone exceed 16 GB: the OOM killer SIGKILLs tasks, or the runner VM itself dies and orphan `tsgo` processes are reaped at teardown.
- `NODE_OPTIONS='--max-old-space-size=8192'` does not help: it bounds node-based tools only, not the native `tsgo` binaries doing the heavy checking.
- The one green full-cone run in the window (#15092's own, [28820166540](https://github.com/elizaOS/eliza/actions/runs/28820166540), typecheck step 11m03s) shows concurrency 8 sits exactly at the memory edge — pass/fail decided by which heavy tasks happen to overlap.

## Fix (smallest change that restores green)

- `develop-pr.yml` `typecheck` job: `--concurrency=8` → `--concurrency=4`; job timeout 20 → 35 min (the green full-cone run already spent 11 min in the typecheck step alone, on top of checkout/install/build:core).
- `ci.yaml` PR-path `Run typecheck (affected — PR)`: same `8 → 4` (a develop→main promote PR's affected cone is near-total by construction, so the main PR lane has the identical OOM exposure); job timeout 35 → 45.
- `stale-base-guard.yml` and `test.yml` stale-base preflight checkout now fetch the same bounded history window the guard inspects (`fetch-depth: 1500`, `filter: blob:none`) before lazy fetches are disabled.
- `packages/scripts/stale-base-guard.mjs` now reads commit metadata through `git cat-file commit` instead of porcelain `git show -s`, avoiding optional promisor blob reads while `GIT_NO_LAZY_FETCH=1` is set.
- LifeOps evidence docs now point at `CONTRIBUTING.md`, which is where the evidence standard lives after `PR_EVIDENCE.md` was retired.

`develop-pr.yml`'s own header requires its steps to mirror `ci.yaml` so the lanes stay in agreement — both are changed together. No runner upsizing (billing decision), no root-script changes (local `bun run typecheck` untouched), no cone-splitting (concurrency alone bounds peak memory deterministically). Wall-time cost is small: 250 tasks keep 4 slots saturated for most of the run either way — dropping 8 → 4 mostly removes memory thrash, not parallelism (measurements below).

## Local verification (honest scope)

Ran the CI typecheck job's exact sequence from a **cold turbo cache** on develop tip `3b19f761146` (8-core / 31 GB VPS, so timings are directional, not runner-identical):

- `bun run build:core`: exit 0 in 4m13s (69/69 tasks executed, 0 cached). CI green run: 2m58s.
- `NODE_OPTIONS='--max-old-space-size=8192' node packages/scripts/run-turbo.mjs run typecheck --concurrency=4` (full workspace — a superset of any affected cone): **exit 0 in 10m13s**, `Running typecheck in 250 packages`, 340 tasks total (337 executed, 3 cached). For comparison, CI's only green full-cone run at concurrency **8** spent **11m03s** in the typecheck step on a 4-vCPU runner — same order of wall time, because total CPU work is unchanged and 4 slots keep the cores saturated.
- Memory at concurrency 4: summed `tsgo` RSS sustained ~9–10 GB with a single 5-second spike to 12.8 GB — **on an 8-core box**, where tsgo's Go runtime scales its parallel working set with GOMAXPROCS; per-process residency on the 4-vCPU runner is lower. A 3 GiB free-memory watchdog armed for the whole run never tripped. At concurrency 8 the concurrent residency roughly doubles, which is exactly the observed 16 GB runner death.
- `node packages/scripts/stale-base-guard.self-test.mjs`: 9/9 passing.
- `node packages/scripts/stale-base-guard.mjs --base origin/develop --head HEAD --window 1200 --max-behind-commits 200 --max-behind-hours 72`: PASS on rebased head `579bfa981bfe`, `behind=0 commits / 0h`.
- CI-shaped partial-clone reproduction: `GIT_NO_LAZY_FETCH=1 node packages/scripts/stale-base-guard.mjs --repo <blobless clone> --base refs/remotes/origin/develop --head 579bfa981bfe...`: PASS with `base=d0e812baf3`, `head=579bfa981b`, `merge-base=d0e812baf3`, `behind=0 commits / 0h`.
- `node scripts/check-markdown-links.mjs`: PASS after replacing the retired LifeOps `PR_EVIDENCE.md` links.
- YAML parse check via Ruby `YAML.load_file`: PASS for `.github/workflows/stale-base-guard.yml` and `.github/workflows/test.yml`.

What this PR's own CI run does and does not prove: `develop-pr.yml` has no `paths` filter, so this PR exercises the modified `typecheck` job itself (pull_request workflows run the PR's version of the file) — that validates the YAML and the new flags, but a fresh branch's `base.sha` is the current develop tip, so this PR's affected cone is near-empty and it will not reproduce the 251-package memory load. The full-cone proof is the first re-run of any currently-failing stale-base PR (e.g. #15118, #15091, #15125) after this merges — their re-runs pick up the merged workflow and run the near-total cone at concurrency 4 on a real 16 GB runner.

Residual risk: concurrency 4 halves peak concurrent `tsgo` residency but the four heaviest packages could still coincide; the measured local peak (above, inflated by 2× the runner's core count) indicates headroom under 16 GB. If a future cone still trips the ceiling, the next step is concurrency 3/2 or splitting the heavy app/UI packages into a sequential step.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - CI workflow/docs change; no UI surface is touched, nothing renders differently.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - CI workflow/docs change; no UI surface is touched, nothing renders differently.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user-exercisable flow; the change is workflow guard/typecheck configuration plus docs links.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: failing-run receipts collected in #15140 — [15118 att2](https://github.com/elizaOS/eliza/actions/runs/28821279255/attempts/2), [15118 att3](https://github.com/elizaOS/eliza/actions/runs/28821279255/attempts/3), [15091 att3](https://github.com/elizaOS/eliza/actions/runs/28821354028/attempts/3), [15125](https://github.com/elizaOS/eliza/actions/runs/28821071258), [demo/cloud-app-fixes](https://github.com/elizaOS/eliza/actions/runs/28822247014); cone-size receipt (`Running typecheck in 251 packages`, runner shutdown, `@elizaos/agent:typecheck ... SIGKILL`) from [28824759550](https://github.com/elizaOS/eliza/actions/runs/28824759550); stale-base promisor failure reproduced in blocked PR checks as `fatal: could not fetch <parent> from promisor remote`; the one green edge-case run [28820166540](https://github.com/elizaOS/eliza/actions/runs/28820166540) (typecheck step 11m03s); local full-cone and stale-base runs in the details block below.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend involved.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model behavior involved.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: N/A - CI/docs-only change; no DB rows, memories, tasks, or generated files. Local run log, stale-base guard output, markdown-link output, and memory samples are inline below.

<details>
<summary>Local verification log (markers + turbo summaries) and peak memory samples</summary>

```
=== build:core start 21:57:48 ===
 Tasks:    69 successful, 69 total
Cached:    0 cached, 69 total
  Time:    4m12.542s
=== build:core rc=0 wall=253s ===
=== typecheck conc=4 start 22:02:01 ===
   • Running typecheck in 250 packages
 Tasks:    340 successful, 340 total
Cached:    3 cached, 340 total
  Time:    10m13.287s
=== typecheck rc=0 wall=614s ===
RESULT build=0:253s typecheck=0:614s

stale-base guard self-test: 9/9 passing
stale-base guard: base=d0e812baf3 head=579bfa981b merge-base=d0e812baf3 behind=0 commits / 0h
stale-base guard: PASS — no silent reverts, base is fresh.
partial clone + GIT_NO_LAZY_FETCH:
stale-base guard: base=d0e812baf3 head=579bfa981b merge-base=d0e812baf3 behind=0 commits / 0h
stale-base guard: PASS — no silent reverts, base is fresh.
Relative markdown links: PASS
```

Memory samples around the peak (5s interval; `tsgo_sum_mb` = summed RSS of all live tsgo processes; box baseline ≈5–6 GB from an unrelated resident service):

```
1783375812 used_mb=15608 avail_mb=16486 tsgo_sum_mb=9139
1783375827 used_mb=16006 avail_mb=16088 tsgo_sum_mb=9199
1783375838 used_mb=16632 avail_mb=15462 tsgo_sum_mb=9688
1783375848 used_mb=16870 avail_mb=15224 tsgo_sum_mb=10241
1783375853 used_mb=15798 avail_mb=16296 tsgo_sum_mb=10095
1783375858 used_mb=17711 avail_mb=14383 tsgo_sum_mb=12840
1783375869 used_mb=15067 avail_mb=17027 tsgo_sum_mb=9949
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
