### PR TITLE
fix(ui): mobile cloud sign-in fallback and single-choice CTA

### DIFF
--- a/packages/ui/src/api/client-cloud-direct-auth.test.ts
+++ b/packages/ui/src/api/client-cloud-direct-auth.test.ts
@@ -71,12 +71,15 @@ describe("ElizaClient direct Cloud auth on native", () => {
         data: expect.objectContaining({ sessionId: expect.any(String) }),
       }),
     );
+    // The browser URL normalizes the configured www base to the apex host: the
+    // opened window must never ride the www 308 edge (#15143 — the extra hop
+    // is where mobile Safari attributed its "document.txt" download).
     expect(result).toEqual(
       expect.objectContaining({
         ok: true,
         apiBase: "https://api.elizacloud.ai",
         browserUrl: expect.stringMatching(
-          /^https:\/\/www\.elizacloud\.ai\/auth\/cli-login\?session=/,
+          /^https:\/\/elizacloud\.ai\/auth\/cli-login\?session=/,
         ),
       }),
     );

--- a/packages/ui/src/api/client-cloud-web-base.test.ts
+++ b/packages/ui/src/api/client-cloud-web-base.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+/**
+ * Unit coverage for `resolveDirectCloudWebBase`: the WEB origin used to build
+ * browser-navigated cloud URLs (the /auth/cli-login handoff, the first-run
+ * OAuth card's authorizationUrl). Every known cloud host — API, www, app
+ * ingress, dev, and the staging pairs — must map to its apex web origin: the
+ * API worker answers `application/json` for its root and every unknown path,
+ * which iOS Safari downloads as `document.txt` instead of rendering (#15143).
+ * Pure function, no network.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    isNativePlatform: () => false,
+  },
+  CapacitorHttp: {
+    get: vi.fn(),
+    post: vi.fn(),
+    request: vi.fn(),
+  },
+}));
+
+import { resolveDirectCloudWebBase } from "./client-cloud";
+
+describe("resolveDirectCloudWebBase", () => {
+  it.each([
+    // API hosts: JSON-for-every-path workers — never navigable.
+    ["https://api.elizacloud.ai", "https://elizacloud.ai"],
+    ["https://api-staging.elizacloud.ai", "https://staging.elizacloud.ai"],
+    // www adds a redirect hop; app/dev serve non-console surfaces.
+    ["https://www.elizacloud.ai", "https://elizacloud.ai"],
+    ["https://app.elizacloud.ai", "https://elizacloud.ai"],
+    ["https://dev.elizacloud.ai", "https://elizacloud.ai"],
+    ["https://app-staging.elizacloud.ai", "https://staging.elizacloud.ai"],
+    // Apex origins are already the web origin.
+    ["https://elizacloud.ai", "https://elizacloud.ai"],
+    ["https://staging.elizacloud.ai", "https://staging.elizacloud.ai"],
+  ])("maps %s -> %s", (input, expected) => {
+    expect(resolveDirectCloudWebBase(input)).toBe(expected);
+  });
+
+  it("strips trailing slashes before matching", () => {
+    expect(resolveDirectCloudWebBase("https://api.elizacloud.ai///")).toBe(
+      "https://elizacloud.ai",
+    );
+  });
+
+  it("passes unknown hosts through unchanged (self-hosted/dev bases)", () => {
+    expect(resolveDirectCloudWebBase("http://localhost:3000")).toBe(
+      "http://localhost:3000",
+    );
+    expect(resolveDirectCloudWebBase("https://cloud.example.test")).toBe(
+      "https://cloud.example.test",
+    );
+  });
+});

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -81,9 +81,17 @@ const DIRECT_ELIZA_CLOUD_API_BY_HOST = new Map([
   ["staging.elizacloud.ai", STAGING_DIRECT_CLOUD_API_BASE_URL],
   ["app-staging.elizacloud.ai", STAGING_DIRECT_CLOUD_API_BASE_URL],
 ]);
+// Also normalizes the non-API site hosts (www → apex): a popup/tab must never
+// be pointed through the www 308 edge — the extra redirect hop is where mobile
+// Safari's download panel attributed the #15143 "document.txt" to
+// www.elizacloud.ai — and production builds configure the cloud base as
+// https://www.elizacloud.ai (packages/app/wrangler.toml).
 const DIRECT_ELIZA_CLOUD_WEB_BY_API_HOST = new Map([
   ["api.elizacloud.ai", DEFAULT_DIRECT_CLOUD_BASE_URL],
+  ["elizacloud.ai", DEFAULT_DIRECT_CLOUD_BASE_URL],
+  ["www.elizacloud.ai", DEFAULT_DIRECT_CLOUD_BASE_URL],
   ["api-staging.elizacloud.ai", STAGING_DIRECT_CLOUD_BASE_URL],
+  ["staging.elizacloud.ai", STAGING_DIRECT_CLOUD_BASE_URL],
 ]);
 
 type DirectCloudAgent = {
@@ -264,7 +272,14 @@ function resolveBrowserCloudApiRequestUrl(url: string): string {
   }
 }
 
-function resolveDirectCloudWebBase(cloudBase: string): string {
+/**
+ * The browser-navigable Eliza Cloud WEB base for a configured cloud base URL
+ * (API hosts map to their site host; www maps to the apex). Every URL handed
+ * to a browser window/tab must be built on this — never on the raw configured
+ * base, which can be an API host whose JSON responses mobile browsers download
+ * as files instead of rendering (#15143).
+ */
+export function resolveDirectCloudWebBase(cloudBase: string): string {
   const normalized = cloudBase.replace(/\/+$/, "");
   try {
     const host = new URL(normalized).hostname.toLowerCase();

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -81,17 +81,19 @@ const DIRECT_ELIZA_CLOUD_API_BY_HOST = new Map([
   ["staging.elizacloud.ai", STAGING_DIRECT_CLOUD_API_BASE_URL],
   ["app-staging.elizacloud.ai", STAGING_DIRECT_CLOUD_API_BASE_URL],
 ]);
-// Also normalizes the non-API site hosts (www → apex): a popup/tab must never
-// be pointed through the www 308 edge — the extra redirect hop is where mobile
-// Safari's download panel attributed the #15143 "document.txt" to
-// www.elizacloud.ai — and production builds configure the cloud base as
-// https://www.elizacloud.ai (packages/app/wrangler.toml).
-const DIRECT_ELIZA_CLOUD_WEB_BY_API_HOST = new Map([
+// Also normalizes non-API site hosts (www/app/dev -> apex): a browser
+// navigation must never be pointed through the API worker or www redirect edge.
+// The former serves JSON that mobile Safari can download as document.txt; the
+// latter adds the redirect hop the owner capture attributed to www (#15143).
+const DIRECT_ELIZA_CLOUD_WEB_BY_HOST = new Map([
   ["api.elizacloud.ai", DEFAULT_DIRECT_CLOUD_BASE_URL],
   ["elizacloud.ai", DEFAULT_DIRECT_CLOUD_BASE_URL],
   ["www.elizacloud.ai", DEFAULT_DIRECT_CLOUD_BASE_URL],
+  ["app.elizacloud.ai", DEFAULT_DIRECT_CLOUD_BASE_URL],
+  ["dev.elizacloud.ai", DEFAULT_DIRECT_CLOUD_BASE_URL],
   ["api-staging.elizacloud.ai", STAGING_DIRECT_CLOUD_BASE_URL],
   ["staging.elizacloud.ai", STAGING_DIRECT_CLOUD_BASE_URL],
+  ["app-staging.elizacloud.ai", STAGING_DIRECT_CLOUD_BASE_URL],
 ]);
 
 type DirectCloudAgent = {
@@ -283,7 +285,7 @@ export function resolveDirectCloudWebBase(cloudBase: string): string {
   const normalized = cloudBase.replace(/\/+$/, "");
   try {
     const host = new URL(normalized).hostname.toLowerCase();
-    return DIRECT_ELIZA_CLOUD_WEB_BY_API_HOST.get(host) ?? normalized;
+    return DIRECT_ELIZA_CLOUD_WEB_BY_HOST.get(host) ?? normalized;
   } catch {
     // Fall back to the provided base below.
   }

--- a/packages/ui/src/components/chat/MessageContent.sensitive-request.test.tsx
+++ b/packages/ui/src/components/chat/MessageContent.sensitive-request.test.tsx
@@ -709,10 +709,50 @@ describe("MessageContent sensitive requests", () => {
     document.removeEventListener(CONNECT_EVENT, onConnect);
   });
 
-  it("surfaces a clear error when the OAuth popup is blocked", () => {
+  it("degrades a blocked OAuth popup to same-tab navigation on plain web (#15143)", () => {
     const openMock = vi.fn().mockReturnValue(null);
     const originalOpen = window.open;
     window.open = openMock as typeof window.open;
+    const assignSpy = vi.fn();
+    const originalLocationDescriptor = Object.getOwnPropertyDescriptor(
+      window,
+      "location",
+    );
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, assign: assignSpy },
+    });
+
+    const { container } = render(
+      <MessageContent
+        message={baseMessage({ secretRequest: pendingOAuthRequest() })}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("sensitive-request-oauth-start"));
+    // Mobile/plain-web browsers block windowed popups by default; instead of
+    // the dead-end "allow pop-ups" instruction, the current tab navigates to
+    // the (https-validated) consent URL.
+    expect(assignSpy).toHaveBeenCalledWith(
+      "https://example.test/oauth/authorize?state=abc",
+    );
+    expect(container.textContent).not.toContain("Pop-up blocked");
+    // No fallback message-stream emission on popup block.
+    expect(updateSecretsMock).not.toHaveBeenCalled();
+
+    window.open = originalOpen;
+    if (originalLocationDescriptor) {
+      Object.defineProperty(window, "location", originalLocationDescriptor);
+    }
+  });
+
+  it("keeps the visible popup-blocked error where same-tab navigation is unavailable (desktop shell)", () => {
+    const openMock = vi.fn().mockReturnValue(null);
+    const originalOpen = window.open;
+    window.open = openMock as typeof window.open;
+    const windowWithElectrobun = window as Window & {
+      __electrobunWindowId?: number;
+    };
+    windowWithElectrobun.__electrobunWindowId = 1;
 
     const { container } = render(
       <MessageContent
@@ -721,10 +761,10 @@ describe("MessageContent sensitive requests", () => {
     );
     fireEvent.click(screen.getByTestId("sensitive-request-oauth-start"));
     expect(container.textContent).toContain("Pop-up blocked");
-    // No fallback message-stream emission on popup block.
     expect(updateSecretsMock).not.toHaveBeenCalled();
 
     window.open = originalOpen;
+    delete windowWithElectrobun.__electrobunWindowId;
   });
 });
 

--- a/packages/ui/src/components/chat/MessageContent.tsx
+++ b/packages/ui/src/components/chat/MessageContent.tsx
@@ -38,6 +38,7 @@ import {
 } from "../../platform/mobile-permissions-client";
 import { useAppSelectorShallow } from "../../state";
 import { useChatComposer } from "../../state/ChatComposerContext.hooks";
+import { canNavigateSameTabForBlockedPopup } from "../../state/cloud-login-launch";
 import {
   createClientPermissionsRegistry,
   type PermissionCardPayload,
@@ -1151,6 +1152,18 @@ export function SensitiveRequestBlock({
                 "width=520,height=720,noreferrer",
               );
               if (!popup) {
+                // #15143: mobile browsers block windowed popups by default,
+                // and "allow pop-ups" is a dead-end instruction in a consumer
+                // flow. On plain web degrade to same-tab navigation — `url` is
+                // https-validated above, the consent/login page returns via
+                // its own redirect, and persisted app/first-run state survives
+                // the round trip. Native/desktop keep the visible error state:
+                // their external-open affordances are not popup-blocked, so a
+                // null there is a real failure.
+                if (canNavigateSameTabForBlockedPopup()) {
+                  window.location.assign(url);
+                  return;
+                }
                 setError(
                   "Pop-up blocked. Allow pop-ups for this site to continue.",
                 );
@@ -1260,8 +1273,8 @@ function OAuthRequestPanel({
         {authorizing ? "Authorizing..." : label}
       </Button>
       <div className="text-xs text-muted">
-        Authorization happens in a separate window. The token is stored securely
-        and is never shown in chat.
+        Authorization happens on the provider's secure page. The token is stored
+        securely and is never shown in chat.
       </div>
     </div>
   );

--- a/packages/ui/src/components/chat/widgets/ChoiceWidget.tsx
+++ b/packages/ui/src/components/chat/widgets/ChoiceWidget.tsx
@@ -89,11 +89,59 @@ export const ChoiceWidget = memo(function ChoiceWidget({
 
   const firstRun = isFirstRunScope(scope);
 
+  // A single-action first-run prompt ("Sign in to Eliza Cloud") is a CTA, not
+  // a choice: wrapped in the collapsible shell it read as a dropdown with one
+  // entry (header + "1 options" chip + chevron) and its secondary chip washed
+  // out on the dark cloud surface (#15144). Render it as one full-width
+  // primary button — no shell, no count chip, no chevron — keeping the same
+  // testids, aria state, and role=status line the shell path exposes.
+  const soleOption =
+    firstRun && !allowCustom && options.length === 1 ? options[0] : null;
+  if (soleOption) {
+    const isSelected = selected?.value === soleOption.value;
+    return (
+      <div
+        className="my-2 flex min-w-0 flex-col items-stretch gap-2"
+        data-choice-id={id}
+        data-choice-scope={scope}
+        data-testid={`choice-shell-${id}`}
+      >
+        <Button
+          type="button"
+          variant="default"
+          size="default"
+          disabled={selected !== null}
+          aria-label={soleOption.label}
+          aria-pressed={isSelected}
+          data-testid={`choice-${soleOption.value}`}
+          // The locked (selected) state stays at full opacity: it is the
+          // confirmation the user just acted on, not a faded leftover.
+          className="h-11 w-full justify-center px-4 text-sm font-medium disabled:opacity-100"
+          onClick={() => handleChoose(soleOption)}
+        >
+          <span className="inline-flex items-center gap-2">
+            {isSelected ? (
+              <Check className="h-4 w-4 shrink-0" aria-hidden />
+            ) : null}
+            <span>{soleOption.label}</span>
+          </span>
+        </Button>
+        {selected ? (
+          <span role="status" className="px-1 text-xs text-muted">
+            Selected: {selected.label}
+          </span>
+        ) : null}
+      </div>
+    );
+  }
+
   return (
     <ChatWidgetShell
       title={firstRun ? "Choose next step" : "Choose"}
       status={
-        <span className="rounded-sm bg-bg px-2 py-0.5 text-[11px] font-medium text-muted">
+        // bg-surface, not bg-bg: on the dark cloud/os themes bg-bg is a
+        // near-transparent alpha that left this chip unreadable (#15144).
+        <span className="rounded-sm bg-surface px-2 py-0.5 text-[11px] font-medium text-muted">
           {selected ? "Selected" : `${options.length} options`}
         </span>
       }
@@ -122,8 +170,13 @@ export const ChoiceWidget = memo(function ChoiceWidget({
             // Prominent, obviously-tappable next-step rows. The recommended
             // option gets the accent; the rest are prominent neutral
             // (secondary), so exactly one orange accent appears (brand rule).
+            // Once a pick locks the fieldset, ONLY the non-selected rows fade:
+            // the selected row is promoted to the accent tokens at full
+            // opacity — the blanket 40% wash on a low-alpha secondary chip
+            // rendered the user's own pick white-on-white on the dark cloud
+            // surface (#15144).
             const recommended = isRecommended(option.label);
-            const variant = recommended ? "default" : "secondary";
+            const variant = isSelected || recommended ? "default" : "secondary";
             return (
               <Button
                 key={option.value}
@@ -134,7 +187,11 @@ export const ChoiceWidget = memo(function ChoiceWidget({
                 aria-label={option.label}
                 aria-pressed={isSelected}
                 data-testid={`choice-${option.value}`}
-                className="h-11 w-full justify-between px-4 text-sm font-medium disabled:opacity-40 aria-disabled:opacity-40"
+                className={
+                  isSelected
+                    ? "h-11 w-full justify-between px-4 text-sm font-medium disabled:opacity-100 aria-disabled:opacity-100"
+                    : "h-11 w-full justify-between px-4 text-sm font-medium disabled:opacity-40 aria-disabled:opacity-40"
+                }
                 onClick={() => handleChoose(option)}
               >
                 <span className="inline-flex items-center gap-2">

--- a/packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx
+++ b/packages/ui/src/components/chat/widgets/interaction-widgets.behavior.test.tsx
@@ -272,6 +272,81 @@ describe("ChoiceWidget — pick an option", () => {
     expect(onChoose).toHaveBeenCalledTimes(1);
     expect(onChoose).toHaveBeenCalledWith("__first_run__:runtime:cloud");
   });
+
+  it("single-option first-run CTA is a bare primary button — no collapsible shell, no '1 options' chip, no chevron (#15144)", () => {
+    const onChoose = vi.fn();
+    render(
+      <ChoiceWidget
+        id="runtime"
+        scope="first-run"
+        options={[
+          {
+            value: "__first_run__:runtime:cloud",
+            label: "Sign in to Eliza Cloud",
+          },
+        ]}
+        onChoose={onChoose}
+      />,
+    );
+
+    // Not wrapped in ChatWidgetShell: no dropdown-like header/chevron/chip.
+    expect(screen.queryByText("Choose next step")).toBeNull();
+    expect(screen.queryByText("1 options")).toBeNull();
+    expect(screen.queryByLabelText("Collapse")).toBeNull();
+
+    // Primary (accent) button, full width — the one obvious CTA. Exact class
+    // match: "bg-bg-accent" (the washed secondary token) contains the
+    // substring "bg-accent", so a toContain would false-pass.
+    const signIn = screen.getByTestId("choice-__first_run__:runtime:cloud");
+    expect(signIn.className.split(/\s+/)).toContain("bg-accent");
+    expect(signIn.className.split(/\s+/)).toContain("w-full");
+
+    // After the tap: locked but NOT washed out, with the status line intact.
+    fireEvent.click(signIn);
+    expect((signIn as HTMLButtonElement).disabled).toBe(true);
+    expect(signIn.className).toContain("disabled:opacity-100");
+    expect(signIn.getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("status").textContent).toMatch(
+      /Sign in to Eliza Cloud/,
+    );
+    // Locked = one decision per prompt; a second tap is a no-op.
+    fireEvent.click(signIn);
+    expect(onChoose).toHaveBeenCalledTimes(1);
+  });
+
+  it("multi-option first-run: the SELECTED row keeps full-opacity accent tokens; only the non-selected locked rows fade (#15144)", () => {
+    const onChoose = vi.fn();
+    render(
+      <ChoiceWidget
+        id="runtime"
+        scope="first-run"
+        options={[
+          { value: "cloud", label: "Eliza Cloud (managed)" },
+          { value: "local", label: "On this device" },
+        ]}
+        onChoose={onChoose}
+      />,
+    );
+
+    // Multi-option keeps the shell (title + count chip), chip on a readable
+    // surface token rather than the near-transparent bg-bg.
+    expect(screen.getByText("Choose next step")).toBeTruthy();
+    const chip = screen.getByText("2 options");
+    expect(chip.className).toContain("bg-surface");
+
+    fireEvent.click(screen.getByTestId("choice-cloud"));
+
+    const picked = screen.getByTestId("choice-cloud");
+    const other = screen.getByTestId("choice-local");
+    // The pick is promoted to the primary tokens at full opacity… (exact
+    // class match — the secondary token "bg-bg-accent" contains "bg-accent")
+    expect(picked.className.split(/\s+/)).toContain("bg-accent");
+    expect(picked.className).toContain("disabled:opacity-100");
+    expect(picked.className).not.toContain("disabled:opacity-40");
+    // …while the rows the user did NOT pick fade behind it.
+    expect(other.className).toContain("disabled:opacity-40");
+    expect(onChoose).toHaveBeenCalledWith("cloud");
+  });
 });
 
 describe("ChoiceWidget — put their own in (allowCustom)", () => {

--- a/packages/ui/src/components/pages/ConfigPageView.tsx
+++ b/packages/ui/src/components/pages/ConfigPageView.tsx
@@ -15,7 +15,8 @@ import { Check } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAgentElement } from "../../agent-surface";
 import { useAppSelectorShallow } from "../../state";
-import { openExternalUrl, preOpenWindow } from "../../utils";
+import { preOpenCloudLoginWindow } from "../../state/cloud-login-launch";
+import { openExternalUrl } from "../../utils";
 import { Button } from "../ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../ui/dialog";
 import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
@@ -315,7 +316,7 @@ export function ConfigPageView({
   const cloudStatusProps = {
     connected: elizaCloudConnected,
     loginBusy: elizaCloudLoginBusy,
-    onLogin: () => void handleCloudLogin(preOpenWindow()),
+    onLogin: () => void handleCloudLogin(preOpenCloudLoginWindow()),
   };
 
   const legacyRpcChains = walletConfig?.legacyCustomChains ?? [];
@@ -359,7 +360,7 @@ export function ConfigPageView({
     }),
     group: "rpc-config",
     description: "Sign in to Eliza Cloud to use managed RPC",
-    onActivate: () => void handleCloudLogin(preOpenWindow()),
+    onActivate: () => void handleCloudLogin(preOpenCloudLoginWindow()),
   });
   const saveEl = useAgentElement<HTMLButtonElement>({
     id: "wallet-rpc-save",
@@ -577,7 +578,9 @@ export function ConfigPageView({
                   size="sm"
                   className="text-xs font-bold"
                   {...cloudConnectEl.agentProps}
-                  onClick={() => void handleCloudLogin(preOpenWindow())}
+                  onClick={() =>
+                    void handleCloudLogin(preOpenCloudLoginWindow())
+                  }
                   disabled={elizaCloudLoginBusy}
                 >
                   {elizaCloudLoginBusy

--- a/packages/ui/src/components/pages/ElizaCloudDashboard.tsx
+++ b/packages/ui/src/components/pages/ElizaCloudDashboard.tsx
@@ -28,7 +28,8 @@ import {
 import { useBranding } from "../../config/branding";
 import { isElizaCloudRuntimeLocked } from "../../first-run/mobile-runtime-mode";
 import { useAppSelectorShallow } from "../../state";
-import { openExternalUrl, preOpenWindow } from "../../utils";
+import { preOpenCloudLoginWindow } from "../../state/cloud-login-launch";
+import { openExternalUrl } from "../../utils";
 import { StripeEmbeddedCheckout } from "../cloud/StripeEmbeddedCheckout";
 import { Button } from "../ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../ui/dialog";
@@ -621,7 +622,7 @@ export function CloudDashboard() {
             variant="default"
             size="sm"
             className="h-8 rounded-sm px-3 text-xs font-semibold"
-            onClick={() => void handleCloudLogin(preOpenWindow())}
+            onClick={() => void handleCloudLogin(preOpenCloudLoginWindow())}
             disabled={elizaCloudLoginBusy}
           >
             {elizaCloudLoginBusy ? (

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -65,9 +65,12 @@ import {
 import { getBootConfig } from "../config/boot-config";
 import { ACCENT_PRESETS, useAppSelectorShallow } from "../state";
 import { useConversationMessages } from "../state/ConversationMessagesContext.hooks";
+import {
+  preOpenCloudLoginWindow,
+  resolveCloudSignInPageUrl,
+} from "../state/cloud-login-launch";
 import { hasUsableStoredStewardToken } from "../state/cloud-steward-login";
 import { startTutorial } from "../tutorial/tutorial-service";
-import { preOpenWindow } from "../utils";
 import { normalizeFirstRunName } from "./first-run";
 import {
   FIRST_RUN_ACTION_PREFIX,
@@ -95,9 +98,10 @@ const GREETING =
 
 // Cloud-only greetings (#13377). The sign-in button reuses the runtime:cloud
 // action value on purpose: the tap IS the user gesture that launches the real
-// login flow (handleCloudLogin inside the provision flow, popup-blocker safe
-// via preOpenWindow) — the OAuth secretRequest block alone only opens the
-// cloud site and never completes an in-app login.
+// login flow (handleCloudLogin inside the provision flow — popup where one can
+// open, same-tab /login navigation where popups are blocked or hostile,
+// #15143) — the OAuth secretRequest block alone only opens the cloud login
+// page and never completes an in-app login by itself.
 const CLOUD_SIGN_IN_GREETING =
   "Hi — I'm Eliza. Sign in to Eliza Cloud and I'll get you set up.";
 const CLOUD_SIGN_IN_CHOICE = [
@@ -302,7 +306,9 @@ function cloudOAuthSecretRequest(
       fields: [],
       submitLabel: "Connect Eliza Cloud",
       provider: "elizacloud",
-      authorizationUrl: getBootConfig().cloudApiBase || "https://elizacloud.ai",
+      authorizationUrl: resolveCloudSignInPageUrl(
+        getBootConfig().cloudApiBase || "https://elizacloud.ai",
+      ),
     },
   };
 }
@@ -552,7 +558,7 @@ export function useFirstRunConductor(): void {
       uiLanguage,
       elizaCloudConnected,
       handleCloudLogin,
-      preOpenWindow,
+      preOpenWindow: preOpenCloudLoginWindow,
       setRuntimeState: (key, value) => {
         setState(key, value as never);
       },

--- a/packages/ui/src/state/cloud-login-launch.test.ts
+++ b/packages/ui/src/state/cloud-login-launch.test.ts
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+// @vitest-environment-options { "url": "https://app.elizacloud.ai/" }
+//
+// Popup-vs-same-tab decision logic for the cloud sign-in (#15143). Exercises
+// the browser-agnostic runtime popup-blocked signal (null/closed handle), the
+// touch-primary capability hint, the platform exclusions (Capacitor native /
+// Electrobun desktop), the hosted-host gate, the returnTo path builder, and
+// the sign-in card URL resolution (never the raw API/www base). jsdom pinned
+// to a hosted elizacloud origin; platform globals stubbed per test.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildSameTabCloudLoginPath,
+  canNavigateSameTabForBlockedPopup,
+  hasSameOriginStewardLogin,
+  isTouchPrimaryWebBrowser,
+  preOpenCloudLoginWindow,
+  resolveCloudSignInPageUrl,
+  shouldUseSameTabCloudLogin,
+} from "./cloud-login-launch";
+
+const globalWithPlatform = globalThis as typeof globalThis & {
+  Capacitor?: { isNativePlatform?: () => boolean };
+};
+const windowWithElectrobun = window as Window & {
+  __electrobunWindowId?: number;
+};
+
+// jsdom defines both as own window properties; capture the real descriptors so
+// per-test stubs can be fully undone.
+const originalLocationDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  "location",
+);
+const originalMatchMediaDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  "matchMedia",
+);
+
+function restoreDescriptor(
+  name: "location" | "matchMedia",
+  descriptor: PropertyDescriptor | undefined,
+): void {
+  if (descriptor) {
+    Object.defineProperty(window, name, descriptor);
+  } else {
+    Reflect.deleteProperty(window, name);
+  }
+}
+
+function stubMatchMedia(matches: boolean): void {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: (query: string) =>
+      ({ matches, media: query }) as unknown as MediaQueryList,
+  });
+}
+
+function stubHostname(hostname: string, protocol = "https:"): void {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      ...window.location,
+      hostname,
+      protocol,
+      origin: `${protocol}//${hostname}`,
+    },
+  });
+}
+
+function makePopup(closed: boolean): Window {
+  return { closed } as Window;
+}
+
+afterEach(() => {
+  delete globalWithPlatform.Capacitor;
+  delete windowWithElectrobun.__electrobunWindowId;
+  vi.restoreAllMocks();
+  restoreDescriptor("location", originalLocationDescriptor);
+  restoreDescriptor("matchMedia", originalMatchMediaDescriptor);
+});
+
+describe("shouldUseSameTabCloudLogin", () => {
+  it("chooses the same-tab redirect when the popup handle is null (popup blocked)", () => {
+    expect(shouldUseSameTabCloudLogin(null)).toBe(true);
+  });
+
+  it("chooses the same-tab redirect when the popup was immediately closed", () => {
+    expect(shouldUseSameTabCloudLogin(makePopup(true))).toBe(true);
+  });
+
+  it("keeps the popup path while a live popup handle exists (desktop web)", () => {
+    expect(shouldUseSameTabCloudLogin(makePopup(false))).toBe(false);
+  });
+
+  it("prefers same-tab outright on touch-primary browsers even with a live popup", () => {
+    stubMatchMedia(true);
+    expect(shouldUseSameTabCloudLogin(makePopup(false))).toBe(true);
+  });
+
+  it("never redirects on Capacitor native (external Browser plugin owns the open)", () => {
+    globalWithPlatform.Capacitor = { isNativePlatform: () => true };
+    expect(shouldUseSameTabCloudLogin(null)).toBe(false);
+  });
+
+  it("never redirects inside Electrobun (desktop RPC owns the external open)", () => {
+    windowWithElectrobun.__electrobunWindowId = 1;
+    expect(shouldUseSameTabCloudLogin(null)).toBe(false);
+  });
+
+  it("stays on the device-code flow when the origin has no Steward login", () => {
+    stubHostname("self-hosted.example.test");
+    expect(shouldUseSameTabCloudLogin(null)).toBe(false);
+  });
+});
+
+describe("hasSameOriginStewardLogin", () => {
+  it("is true on hosted elizacloud web hosts", () => {
+    expect(hasSameOriginStewardLogin()).toBe(true);
+  });
+
+  it("is false on unknown origins with no Steward API override", () => {
+    stubHostname("localhost");
+    expect(hasSameOriginStewardLogin()).toBe(false);
+  });
+});
+
+describe("isTouchPrimaryWebBrowser", () => {
+  it("is false when the capability queries do not match (jsdom default)", () => {
+    expect(isTouchPrimaryWebBrowser()).toBe(false);
+  });
+
+  it("is true for coarse-pointer no-hover browsers", () => {
+    stubMatchMedia(true);
+    expect(isTouchPrimaryWebBrowser()).toBe(true);
+  });
+
+  it("is false for fine-pointer hover browsers", () => {
+    stubMatchMedia(false);
+    expect(isTouchPrimaryWebBrowser()).toBe(false);
+  });
+});
+
+describe("buildSameTabCloudLoginPath", () => {
+  it("carries the caller's location as returnTo", () => {
+    expect(
+      buildSameTabCloudLoginPath({ pathname: "/settings", search: "?t=c" }),
+    ).toBe(`/login?returnTo=${encodeURIComponent("/settings?t=c")}`);
+  });
+
+  it("falls back to /chat when already on the login page", () => {
+    expect(buildSameTabCloudLoginPath({ pathname: "/login", search: "" })).toBe(
+      "/login?returnTo=%2Fchat",
+    );
+  });
+
+  it("rejects protocol-relative paths", () => {
+    expect(
+      buildSameTabCloudLoginPath({ pathname: "//evil.test", search: "" }),
+    ).toBe("/login?returnTo=%2Fchat");
+  });
+
+  it("reads window.location when no location is given", () => {
+    expect(buildSameTabCloudLoginPath()).toBe("/login?returnTo=%2F");
+  });
+});
+
+describe("preOpenCloudLoginWindow", () => {
+  it("skips the popup attempt on touch-primary hosted web (redirect-first)", () => {
+    stubMatchMedia(true);
+    const openSpy = vi.spyOn(window, "open");
+    expect(preOpenCloudLoginWindow()).toBeNull();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it("pre-opens the popup on non-touch web (desktop keeps the popup path)", () => {
+    const popup = makePopup(false);
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(popup);
+    expect(preOpenCloudLoginWindow()).toBe(popup);
+    expect(openSpy).toHaveBeenCalledWith("about:blank", "_blank");
+  });
+});
+
+describe("resolveCloudSignInPageUrl", () => {
+  it("uses the same-origin login page with returnTo on hosted https web", () => {
+    expect(resolveCloudSignInPageUrl("https://www.elizacloud.ai")).toBe(
+      "https://app.elizacloud.ai/login?returnTo=%2F",
+    );
+  });
+
+  it("maps API and www bases to the apex login page elsewhere", () => {
+    stubHostname("localhost", "http:");
+    expect(resolveCloudSignInPageUrl("https://api.elizacloud.ai")).toBe(
+      "https://elizacloud.ai/login",
+    );
+    expect(resolveCloudSignInPageUrl("https://www.elizacloud.ai")).toBe(
+      "https://elizacloud.ai/login",
+    );
+  });
+
+  it("appends /login to unknown custom bases", () => {
+    stubHostname("localhost", "http:");
+    expect(resolveCloudSignInPageUrl("https://cloud.example.test")).toBe(
+      "https://cloud.example.test/login",
+    );
+  });
+});
+
+describe("canNavigateSameTabForBlockedPopup", () => {
+  it("is true on plain web", () => {
+    expect(canNavigateSameTabForBlockedPopup()).toBe(true);
+  });
+
+  it("is false on Capacitor native and Electrobun", () => {
+    globalWithPlatform.Capacitor = { isNativePlatform: () => true };
+    expect(canNavigateSameTabForBlockedPopup()).toBe(false);
+    delete globalWithPlatform.Capacitor;
+    windowWithElectrobun.__electrobunWindowId = 1;
+    expect(canNavigateSameTabForBlockedPopup()).toBe(false);
+  });
+});

--- a/packages/ui/src/state/cloud-login-launch.ts
+++ b/packages/ui/src/state/cloud-login-launch.ts
@@ -1,0 +1,168 @@
+/**
+ * Popup-vs-same-tab launch decision for the cloud sign-in flow (#15143).
+ *
+ * Mobile web browsers block `window.open` by default (iOS Safari's Block
+ * Pop-ups, Chrome on iPhone/Android), so the popup-based cloud login dead-ends
+ * on hosted web: the pre-opened window comes back null and the user is told to
+ * change browser settings — a consumer flow can't ask that. The decision here
+ * is browser-agnostic: the popup path is kept only while a live popup handle
+ * exists; when the handle is null/closed (the runtime popup-blocked signal, on
+ * any browser) the current tab navigates to the same-origin Steward
+ * `/login?returnTo=…` page instead. Touch-primary web browsers skip the popup
+ * attempt outright — a capability hint (coarse pointer + no hover), not a
+ * user-agent sniff — because even a popup that opens there is a disorienting
+ * tab switch. Native (Capacitor) keeps the external Browser plugin and desktop
+ * (Electrobun) keeps the RPC external-open; neither is popup-hostile.
+ *
+ * The same-tab round trip needs no new flow: the `/login` page sanitizes and
+ * honors `returnTo` (login-return-to.ts), the Steward token lands in this
+ * origin's localStorage, and the first-run conductor's mount-time token poll /
+ * cloud-resume marker (first-run-cloud-resume.ts) finish onboarding on return.
+ */
+
+import { resolveDirectCloudWebBase } from "../api/client-cloud";
+import { isElectrobunRuntime } from "../bridge/electrobun-runtime";
+import { configuredStewardApiUrlOverride } from "../cloud/shell/steward-config";
+import { ELIZA_CLOUD_DIRECT_API_BY_HOST } from "../cloud/shell/steward-url";
+import { preOpenWindow } from "../utils/openExternalUrl";
+
+function isCapacitorNativeRuntime(): boolean {
+  if (typeof globalThis === "undefined") return false;
+  const capacitor = (
+    globalThis as {
+      Capacitor?: { isNativePlatform?: () => boolean };
+    }
+  ).Capacitor;
+  return Boolean(capacitor?.isNativePlatform?.());
+}
+
+/** Plain web page — no native/desktop external-open affordance to prefer. */
+function isPlainWebPlatform(): boolean {
+  if (typeof window === "undefined") return false;
+  if (isCapacitorNativeRuntime()) return false;
+  if (isElectrobunRuntime()) return false;
+  return true;
+}
+
+/**
+ * Capability hint for popup-hostile browsers: a touch-primary device with no
+ * hover (phones/tablets in any browser engine). Deliberately not a user-agent
+ * check — the owner repro was Chrome on iPhone, and Android Chrome blocks the
+ * post-await popups of this flow just the same.
+ */
+export function isTouchPrimaryWebBrowser(): boolean {
+  if (typeof window === "undefined") return false;
+  if (typeof window.matchMedia !== "function") return false;
+  return (
+    window.matchMedia("(pointer: coarse)").matches &&
+    window.matchMedia("(hover: none)").matches
+  );
+}
+
+/**
+ * Whether this page's origin can complete a same-origin Steward `/login` round
+ * trip: the hosted elizacloud web hosts (steward-url.ts host map) or any host
+ * with an explicit Steward API override. Elsewhere (self-hosted dashboards,
+ * localhost dev) the `/login` page may have no reachable Steward API, so the
+ * legacy device-code flow with its copyable fallback link stays the degrade.
+ */
+export function hasSameOriginStewardLogin(): boolean {
+  if (typeof window === "undefined") return false;
+  const host = window.location.hostname.toLowerCase();
+  if (ELIZA_CLOUD_DIRECT_API_BY_HOST[host]) return true;
+  return Boolean(configuredStewardApiUrlOverride());
+}
+
+/**
+ * Pre-open the cloud-login popup for a user gesture, EXCEPT where the same-tab
+ * decision below prefers redirect-first — skipping the attempt avoids flashing
+ * a popup/tab the flow would immediately abandon.
+ */
+export function preOpenCloudLoginWindow(): Window | null {
+  if (
+    isPlainWebPlatform() &&
+    hasSameOriginStewardLogin() &&
+    isTouchPrimaryWebBrowser()
+  ) {
+    return null;
+  }
+  return preOpenWindow();
+}
+
+/**
+ * Whether the cloud sign-in should navigate THIS tab to the same-origin
+ * `/login` page instead of driving the popup device-code flow. True on plain
+ * web with a same-origin Steward login when the popup handle is dead (blocked
+ * at pre-open — the browser-agnostic runtime signal — or never attempted) or
+ * when the touch-primary hint prefers same-tab outright.
+ */
+export function shouldUseSameTabCloudLogin(
+  prePoppedWindow: Window | null,
+): boolean {
+  if (!isPlainWebPlatform()) return false;
+  if (!hasSameOriginStewardLogin()) return false;
+  if (isTouchPrimaryWebBrowser()) return true;
+  return !prePoppedWindow || prePoppedWindow.closed;
+}
+
+/**
+ * The same-origin login path carrying the caller's location as `returnTo`, so
+ * the round trip lands back where sign-in started (onboarding chat, settings,
+ * the cloud dashboard). Falls back to `/chat` — the onboarding landing — when
+ * the current path is unusable (already on `/login`, or protocol-relative).
+ */
+export function buildSameTabCloudLoginPath(location?: {
+  pathname: string;
+  search: string;
+}): string {
+  const loc =
+    location ?? (typeof window !== "undefined" ? window.location : undefined);
+  const current = loc ? `${loc.pathname}${loc.search}` : "";
+  const returnTo =
+    current.startsWith("/") &&
+    !current.startsWith("//") &&
+    !current.startsWith("/login")
+      ? current
+      : "/chat";
+  return `/login?returnTo=${encodeURIComponent(returnTo)}`;
+}
+
+/** Hard-navigate the current tab into the same-origin Steward login page. */
+export function navigateToSameTabCloudLogin(): void {
+  if (typeof window === "undefined") return;
+  window.location.assign(buildSameTabCloudLoginPath());
+}
+
+/**
+ * Whether a blocked popup may degrade to navigating the CURRENT tab to the
+ * (already https-validated) authorization URL instead of dead-ending on an
+ * "allow pop-ups" instruction. Only on plain web: the app survives the round
+ * trip via its persisted state, and browsers restore the tab on back
+ * navigation. Native/desktop keep their error state — their external-open
+ * affordances are not popup-blocked, so a null there is a real failure.
+ */
+export function canNavigateSameTabForBlockedPopup(): boolean {
+  return isPlainWebPlatform();
+}
+
+/**
+ * Direct-navigation target for the onboarding "Connect Eliza Cloud" card. Must
+ * be a browser-renderable login PAGE: pointing the card at the raw configured
+ * cloud base navigated escaped popups into API-host/www-edge responses that
+ * mobile browsers download as `document.txt` instead of rendering (#15143).
+ * On a hosted-web https origin with a same-origin Steward login the URL stays
+ * on THIS origin with a `returnTo`, so the sign-in round trip actually lands
+ * the token where onboarding resumes; everywhere else it is the cloud web
+ * base's login page.
+ */
+export function resolveCloudSignInPageUrl(cloudApiBase: string): string {
+  if (
+    isPlainWebPlatform() &&
+    hasSameOriginStewardLogin() &&
+    typeof window !== "undefined" &&
+    window.location.protocol === "https:"
+  ) {
+    return `${window.location.origin}${buildSameTabCloudLoginPath()}`;
+  }
+  return `${resolveDirectCloudWebBase(cloudApiBase)}/login`;
+}

--- a/packages/ui/src/state/useCloudState.same-tab-login.test.tsx
+++ b/packages/ui/src/state/useCloudState.same-tab-login.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+// @vitest-environment-options { "url": "https://app.elizacloud.ai/" }
+//
+// `useCloudState.handleCloudLogin` popup→same-tab fallback (#15143). On hosted
+// web (direct cloud auth, no agent proxy) a dead popup handle — null from a
+// blocked pre-open, on any browser — must navigate THIS tab to the same-origin
+// /login page with a returnTo instead of starting a device-code session whose
+// popup would never open, and must leave the first-run cloud-resume marker
+// intact for the round trip. A live popup handle keeps the device-code popup
+// flow. jsdom pinned to a hosted elizacloud origin with the API client mocked.
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { client } from "../api";
+import {
+  markCloudLoginPending,
+  readCloudLoginPending,
+} from "../first-run/first-run-cloud-resume";
+import { useCloudState } from "./useCloudState";
+
+const DEVICE_CODE_SENTINEL = "device-code-flow-reached";
+
+function makeParams() {
+  return {
+    setActionNotice: vi.fn(),
+    loadWalletConfig: vi.fn(async () => {}),
+    t: (key: string) => key,
+  };
+}
+
+describe("useCloudState — handleCloudLogin same-tab fallback on hosted web", () => {
+  let assignSpy: ReturnType<typeof vi.fn>;
+  let cloudLoginSpy: ReturnType<typeof vi.spyOn>;
+  let cloudLoginDirectSpy: ReturnType<typeof vi.spyOn>;
+  const originalLocationDescriptor = Object.getOwnPropertyDescriptor(
+    window,
+    "location",
+  );
+
+  beforeEach(() => {
+    localStorage.clear();
+    assignSpy = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, assign: assignSpy },
+    });
+    cloudLoginSpy = vi.spyOn(client, "cloudLogin").mockResolvedValue({
+      ok: false,
+      sessionId: "",
+      browserUrl: "",
+      error: DEVICE_CODE_SENTINEL,
+    });
+    cloudLoginDirectSpy = vi
+      .spyOn(client, "cloudLoginDirect")
+      .mockResolvedValue({
+        ok: false,
+        sessionId: "",
+        browserUrl: "",
+        error: DEVICE_CODE_SENTINEL,
+      });
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+    if (originalLocationDescriptor) {
+      Object.defineProperty(window, "location", originalLocationDescriptor);
+    }
+  });
+
+  const deviceCodeCalls = () =>
+    cloudLoginSpy.mock.calls.length + cloudLoginDirectSpy.mock.calls.length;
+
+  it("a dead popup handle navigates same-tab to /login with returnTo and starts no device-code session", async () => {
+    const { result } = renderHook(() => useCloudState(makeParams()));
+    await act(async () => {
+      await result.current.handleCloudLogin(null);
+    });
+
+    expect(assignSpy).toHaveBeenCalledTimes(1);
+    expect(assignSpy).toHaveBeenCalledWith("/login?returnTo=%2F");
+    expect(deviceCodeCalls()).toBe(0);
+    expect(result.current.elizaCloudLoginBusy).toBe(false);
+    expect(result.current.elizaCloudLoginError).toBeNull();
+  });
+
+  it("leaves the first-run cloud-resume marker intact across the redirect leg", async () => {
+    markCloudLoginPending({
+      runtime: "cloud",
+      localInference: "cloud-inference",
+      agentName: "Eliza",
+    });
+
+    const { result } = renderHook(() => useCloudState(makeParams()));
+    await act(async () => {
+      await result.current.handleCloudLogin(null);
+    });
+
+    expect(assignSpy).toHaveBeenCalledWith("/login?returnTo=%2F");
+    expect(readCloudLoginPending()).toEqual({
+      runtime: "cloud",
+      localInference: "cloud-inference",
+      agentName: "Eliza",
+    });
+  });
+
+  it("a live popup handle keeps the device-code popup flow (no same-tab navigation)", async () => {
+    const popup = {
+      closed: false,
+      close: vi.fn(),
+      location: { href: "" },
+      opener: {},
+    } as unknown as Window;
+
+    const { result } = renderHook(() => useCloudState(makeParams()));
+    await act(async () => {
+      await result.current.handleCloudLogin(popup);
+    });
+
+    expect(assignSpy).not.toHaveBeenCalled();
+    expect(cloudLoginDirectSpy).toHaveBeenCalledTimes(1);
+    expect(result.current.elizaCloudLoginError).toBe(DEVICE_CODE_SENTINEL);
+  });
+});

--- a/packages/ui/src/state/useCloudState.ts
+++ b/packages/ui/src/state/useCloudState.ts
@@ -45,6 +45,10 @@ import {
 } from "../utils";
 import { scrubPersistedAgentProfileTokens } from "./agent-profiles";
 import {
+  navigateToSameTabCloudLogin,
+  shouldUseSameTabCloudLogin,
+} from "./cloud-login-launch";
+import {
   getInjectedEthereumProvider,
   siweLoginWithInjectedWallet,
 } from "./cloud-siwe-login";
@@ -648,6 +652,26 @@ export function useCloudState({
           completeLogin();
           return loginCompletion;
         }
+      }
+
+      // #15143 mobile-web sign-in: when the popup path cannot work — the
+      // pre-opened handle came back null (popup blocked; the runtime signal on
+      // any browser) or this is a touch-primary browser where even a popup
+      // that opens is a disorienting tab switch — navigate THIS tab to the
+      // same-origin Steward /login page instead of starting a device-code
+      // session whose browser window would never open. The returnTo round
+      // trip lands back here and the stored Steward token completes the login
+      // (first-run resumes via its marker + mount-time token poll). Direct
+      // cloud targets only: an agent-proxied (hasBackend) login stays on the
+      // device-code flow, whose copyable fallback link is the designed
+      // degrade for blocked popups there.
+      if (useDirectAuth && shouldUseSameTabCloudLogin(prePoppedWindow)) {
+        closePrePoppedWindow();
+        navigateToSameTabCloudLogin();
+        elizaCloudLoginBusyRef.current = false;
+        setElizaCloudLoginBusy(false);
+        completeLogin();
+        return loginCompletion;
       }
 
       try {


### PR DESCRIPTION
Fixes #15143 and #15144. Supersedes #15154 by combining its single-choice CTA fix and cloud-host mapping coverage with this PR's centralized same-tab cloud-login launch path.

## What

- Hosted mobile web no longer dead-ends on popup-blocked cloud sign-in. `cloud-login-launch.ts` chooses same-tab `/login?returnTo=...` when the popup handle is null/closed or the browser is touch-primary, while native and Electrobun keep their external-open paths.
- Browser navigation URLs for Eliza Cloud now resolve to renderable web origins, not raw API/www bases that can produce JSON downloads or redirect hops on mobile.
- The first-run one-option cloud sign-in prompt now renders as a single full-width primary CTA instead of a one-entry collapsible choice widget; selected rows remain readable at full opacity.

## Verification (rebased head, develop `bc4f90bed33`)

- Passed: `bun run --cwd packages/ui test` over the sign-in / widget / conductor surface — **14 files, 180 tests, 0 fail** — including develop's expanded `use-first-run-conductor.test.ts` (#15149 integrated; the finish-path coverage lives in that suite). Full list + output in the [verification comment](https://github.com/elizaOS/eliza/pull/15156#issuecomment-4898669409).
- Passed: `bun run audit:error-policy-ratchet` (no new fallback-slop in touched files).
- Passed: `node scripts/check-markdown-links.mjs` (the two `plugin-personal-assistant` doc links that failed the earlier run were develop-side and are fixed by #15151).
- After-capture in the **real renderer** (playwright ui-smoke fixture, this branch): single full-width CTA asserted (`"1 options"` chip and `"Choose next step"` shell both `count 0`), selected state stays full-opacity, tap enters the launch decision. Artifacts below.
- The same-tab `/login` hop only arms on hosted elizacloud origins (steward host map), so on-device hosted-web phone QA remains the owner-verifiable step; the decision logic is unit-asserted in `cloud-login-launch.test.ts` and `useCloudState.same-tab-login.test.tsx`.

## Required evidence rows

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: owner phone QA screenshots attached in [#15143](https://github.com/elizaOS/eliza/issues/15143) (popup/document-download dead-end) and [#15144](https://github.com/elizaOS/eliza/issues/15144) (one-entry dropdown CTA).

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: real-renderer captures on this branch — [desktop CTA](https://gist.githubusercontent.com/NubsCarson/be457f86019fd019014354c61b53fa4c/raw/15156-after-desktop-signin-cta.jpg) · [mobile 390×844 CTA](https://gist.githubusercontent.com/NubsCarson/be457f86019fd019014354c61b53fa4c/raw/15156-after-mobile-signin-cta.jpg) · [post-tap full-opacity selected state](https://gist.githubusercontent.com/NubsCarson/be457f86019fd019014354c61b53fa4c/raw/15156-after-mobile-post-tap.jpg).
  ![after: desktop single full-width sign-in CTA](https://gist.githubusercontent.com/NubsCarson/be457f86019fd019014354c61b53fa4c/raw/15156-after-desktop-signin-cta.jpg)
  ![after: mobile sign-in CTA](https://gist.githubusercontent.com/NubsCarson/be457f86019fd019014354c61b53fa4c/raw/15156-after-mobile-signin-cta.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: [mobile first-run sign-in walkthrough (MP4)](https://gist.githubusercontent.com/NubsCarson/be457f86019fd019014354c61b53fa4c/raw/15156-after-mobile-walkthrough.mp4) — CTA render → tap → launch decision → connect step.

<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - client-side cloud sign-in launch and choice-widget rendering only; no server code path changes.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: [local run output + harness assertions](https://github.com/elizaOS/eliza/pull/15156#issuecomment-4898669409) — the suites assert the same-tab redirect, no device-code request on a dead popup, return-marker persistence, cloud URL mapping, and single-CTA rendering (jsdom `Window.open` popup-block path exercised).

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent/action/prompt/model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts / OCR visual text review: rendered-view OCR + aesthetic audit of this PR's merged code ran in CI — [app-aesthetic-audit-output artifact](https://github.com/elizaOS/eliza/actions/runs/28828029801/artifacts/8123778667) (ocr-triage + per-view captures); the strict-gate red there is the develop-wide signature receipted in the [verification comment](https://github.com/elizaOS/eliza/pull/15156#issuecomment-4898669409), on views this diff does not touch.

