### PR TITLE
fix(#15161): staging dashboard create-agent bounces to prod — derive app URL per-env

### DIFF
--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
@@ -49,6 +49,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "../../../components/ui/button";
 import { Checkbox } from "../../../components/ui/checkbox";
+import { currentElizaAppOrigin } from "../../../utils/cloud-agent-base";
 import { api, apiWithStatus } from "../../lib/api-client";
 import { useT } from "../lib/i18n";
 import { openWebUIWithPairing } from "../lib/open-web-ui";
@@ -160,7 +161,11 @@ function mergeSandboxRow(
  * that a delete that never took only hides the billed agent for ~a minute.
  */
 const TOMBSTONE_GRACE_MS = 60_000;
-const ELIZA_APP_AGENT_CREATE_URL = "https://app.elizacloud.ai";
+// Derive the create-agent / "Open Eliza app" target from the CURRENT console
+// host so a signed-in staging user isn't bounced to the PROD app (different
+// tenant/session) — #15161. Resolved once at module load: the console host is
+// stable for the lifetime of the page.
+const ELIZA_APP_AGENT_CREATE_URL = currentElizaAppOrigin();
 
 /**
  * Retire delete-tombstones by TIME only — the single retirement clock for both

--- a/packages/ui/src/utils/cloud-agent-base.app-origin.test.ts
+++ b/packages/ui/src/utils/cloud-agent-base.app-origin.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit coverage for the per-environment Eliza app-origin resolver (#15161).
+ * The console dashboard links out to the app for create-agent; that link must
+ * stay within the SAME environment or a signed-in staging user bounces to the
+ * PROD app (different tenant/session). Pure function, no DOM.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  PROD_ELIZA_APP_ORIGIN,
+  resolveElizaAppOrigin,
+  STAGING_ELIZA_APP_ORIGIN,
+} from "./cloud-agent-base";
+
+describe("resolveElizaAppOrigin", () => {
+  it("resolves the staging console apex to the staging app (not prod)", () => {
+    // REGRESSION for #15161: staging.elizacloud.ai must NOT resolve to the
+    // prod app.elizacloud.ai — that was the bounce-to-prod bug.
+    expect(resolveElizaAppOrigin("staging.elizacloud.ai")).toBe(
+      STAGING_ELIZA_APP_ORIGIN,
+    );
+    expect(resolveElizaAppOrigin("staging.elizacloud.ai")).not.toBe(
+      PROD_ELIZA_APP_ORIGIN,
+    );
+  });
+
+  it("resolves the staging api + app hosts to the staging app", () => {
+    expect(resolveElizaAppOrigin("api-staging.elizacloud.ai")).toBe(
+      STAGING_ELIZA_APP_ORIGIN,
+    );
+    expect(resolveElizaAppOrigin("app-staging.elizacloud.ai")).toBe(
+      STAGING_ELIZA_APP_ORIGIN,
+    );
+  });
+
+  it("is case-insensitive and trims the host", () => {
+    expect(resolveElizaAppOrigin("  STAGING.ElizaCloud.AI  ")).toBe(
+      STAGING_ELIZA_APP_ORIGIN,
+    );
+  });
+
+  it("resolves every prod console host to the prod app (behavior-preserving)", () => {
+    for (const host of [
+      "elizacloud.ai",
+      "www.elizacloud.ai",
+      "app.elizacloud.ai",
+      "api.elizacloud.ai",
+      "dev.elizacloud.ai",
+    ]) {
+      expect(resolveElizaAppOrigin(host)).toBe(PROD_ELIZA_APP_ORIGIN);
+    }
+  });
+
+  it("fails safe to the prod app for unknown / local / empty hosts", () => {
+    expect(resolveElizaAppOrigin("localhost")).toBe(PROD_ELIZA_APP_ORIGIN);
+    expect(resolveElizaAppOrigin("agent-123.elizacloud.ai")).toBe(
+      PROD_ELIZA_APP_ORIGIN,
+    );
+    expect(resolveElizaAppOrigin("")).toBe(PROD_ELIZA_APP_ORIGIN);
+    expect(resolveElizaAppOrigin(null)).toBe(PROD_ELIZA_APP_ORIGIN);
+    expect(resolveElizaAppOrigin(undefined)).toBe(PROD_ELIZA_APP_ORIGIN);
+  });
+});

--- a/packages/ui/src/utils/cloud-agent-base.ts
+++ b/packages/ui/src/utils/cloud-agent-base.ts
@@ -152,3 +152,54 @@ export function dedicatedCloudAgentIdFromBase(
   const label = host.slice(0, host.length - ".elizacloud.ai".length);
   return label.includes(".") ? label.slice(label.lastIndexOf(".") + 1) : label;
 }
+
+/** Production Eliza *app* origin — where the agent-app (chat / create-agent)
+ * lives. The console (elizacloud.ai / dashboard) is NOT the app; the app is
+ * served from `app.elizacloud.ai`. */
+export const PROD_ELIZA_APP_ORIGIN = "https://app.elizacloud.ai";
+/** Staging Eliza *app* origin. The staging console lives at
+ * `staging.elizacloud.ai`; its paired app is `app-staging.elizacloud.ai`
+ * (a DIFFERENT tenant/session from prod). */
+export const STAGING_ELIZA_APP_ORIGIN = "https://app-staging.elizacloud.ai";
+
+/** Console hostnames that belong to the STAGING environment. Derived from the
+ * same control-plane host knowledge used elsewhere (client-cloud.ts /
+ * steward-url.ts): the staging console apex, its API origins, and the staging
+ * app host itself all point back to the staging app. */
+const STAGING_CONSOLE_HOSTS = new Set([
+  "staging.elizacloud.ai",
+  "api-staging.elizacloud.ai",
+  "app-staging.elizacloud.ai",
+]);
+
+/**
+ * Resolve the Eliza *app* origin (the create-agent / "Open Eliza app" target)
+ * for the CURRENT console host. The console dashboard has no create-agent flow
+ * of its own and links out to the app; that link must stay within the SAME
+ * environment or a signed-in staging user bounces to the PROD app (different
+ * tenant, different session — #15161).
+ *
+ * Fail-safe: a staging console host resolves to the staging app; every other
+ * host (prod apex/api, per-agent subdomains, localhost, unknown) resolves to
+ * the prod app origin — the historical default, so prod + local behavior is
+ * unchanged and only staging is corrected.
+ */
+export function resolveElizaAppOrigin(
+  hostname: string | null | undefined,
+): string {
+  const host = hostname?.trim().toLowerCase();
+  if (host && STAGING_CONSOLE_HOSTS.has(host)) {
+    return STAGING_ELIZA_APP_ORIGIN;
+  }
+  return PROD_ELIZA_APP_ORIGIN;
+}
+
+/**
+ * Browser-safe wrapper: resolve the Eliza app origin from the live
+ * `window.location.hostname`. Falls back to the prod app origin when there is
+ * no DOM (SSR / tests without a window).
+ */
+export function currentElizaAppOrigin(): string {
+  if (typeof window === "undefined") return PROD_ELIZA_APP_ORIGIN;
+  return resolveElizaAppOrigin(window.location.hostname);
+}


### PR DESCRIPTION
## Problem (#15161)

The Eliza **console** dashboard (`staging.elizacloud.ai`, `elizacloud.ai`) has no create-agent flow of its own — it links out to the **app**. `eliza-agents-table.tsx` hardcoded that link target to the PROD app:

```ts
const ELIZA_APP_AGENT_CREATE_URL = "https://app.elizacloud.ai";
```

used as the `href` on both "Open Eliza app" buttons (empty-state + toolbar). So a signed-in **staging** user who clicked create/open landed on the **PROD** app — a different tenant, a different session. Found during the staging golden-path e2e (#15160 investigation).

## Fix

Derive the app origin from the **current console host** instead of a literal, reusing the same control-plane host knowledge already encoded in `api/client-cloud.ts` and `cloud/shell/steward-url.ts`:

- new pure, exported `resolveElizaAppOrigin(hostname)` + browser-safe `currentElizaAppOrigin()` in `utils/cloud-agent-base.ts` (the module that already owns `ELIZA_CLOUD_CONTROL_PLANE_HOSTS`), mirroring the `apex-host.ts` / `login-return-to.ts` host-derivation pattern.
- staging console hosts (`staging.`/`api-staging.`/`app-staging.elizacloud.ai`) → `https://app-staging.elizacloud.ai`.
- **fail-safe**: every prod apex/api host, per-agent subdomain, `localhost`, and unknown/empty host → the prod app origin (`https://app.elizacloud.ai`), the historical default — so **prod and local behavior are unchanged**; only staging is corrected.
- both `href` sites in `eliza-agents-table.tsx` now go through the resolver (resolved once at module load; the console host is stable for the page lifetime).

## Tests / checks

- `cloud-agent-base.app-origin.test.ts` — **5/5**: staging-console-resolves-to-staging-NOT-prod regression (#15161), staging api+app hosts, case-insensitive/trim, all prod hosts preserved, fail-safe for unknown/local/empty/null.
- existing `eliza-agents-table.{merge,render}.test` — **16/16**, no regression from the import change.
- `ui` tsgo — **0 errors** (none in touched files).
- biome — clean on all 3 touched files.

Forbidden files untouched (no vite.config/index.html/client-base/bun.lock/dist).

-- [sol-orch]