### PR TITLE
fix(cloud): resolve the console's Eliza-app CTA origin per env — staging no longer bounces to the prod app

### DIFF
--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.merge.test.ts
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.merge.test.ts
@@ -9,6 +9,7 @@ import type { SandboxListAgent } from "../lib/use-sandbox-status-poll";
 import {
   type ElizaAgentRow,
   mergeAgentList,
+  resolveElizaAppAgentCreateUrl,
   retireExpiredTombstones,
 } from "./eliza-agents-table";
 
@@ -146,5 +147,31 @@ describe("retireExpiredTombstones (the single time-only retirement clock)", () =
     ]);
     retireExpiredTombstones(tombstones, 25_000, GRACE);
     expect([...tombstones.keys()]).toEqual(["fresh"]);
+  });
+});
+
+describe("resolveElizaAppAgentCreateUrl", () => {
+  it("maps every env host to its OWN env's app — staging never lands on prod", () => {
+    expect(resolveElizaAppAgentCreateUrl("staging.elizacloud.ai")).toBe(
+      "https://app-staging.elizacloud.ai",
+    );
+    expect(resolveElizaAppAgentCreateUrl("app-staging.elizacloud.ai")).toBe(
+      "https://app-staging.elizacloud.ai",
+    );
+    expect(resolveElizaAppAgentCreateUrl("elizacloud.ai")).toBe(
+      "https://app.elizacloud.ai",
+    );
+    expect(resolveElizaAppAgentCreateUrl("app.elizacloud.ai")).toBe(
+      "https://app.elizacloud.ai",
+    );
+  });
+
+  it("falls back to the prod app for unknown hosts and non-browser contexts", () => {
+    expect(resolveElizaAppAgentCreateUrl("localhost")).toBe(
+      "https://app.elizacloud.ai",
+    );
+    expect(resolveElizaAppAgentCreateUrl(undefined)).toBe(
+      "https://app.elizacloud.ai",
+    );
   });
 });

--- a/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
+++ b/packages/ui/src/cloud/instances/components/eliza-agents-table.tsx
@@ -160,7 +160,32 @@ function mergeSandboxRow(
  * that a delete that never took only hides the billed agent for ~a minute.
  */
 const TOMBSTONE_GRACE_MS = 60_000;
-const ELIZA_APP_AGENT_CREATE_URL = "https://app.elizacloud.ai";
+/**
+ * Browser host -> Eliza app origin for the "open the Eliza app" CTAs. The
+ * console and the app are separate deploys per env; every host must map to its
+ * OWN env's app (staging -> app-staging, never prod), else a staging user
+ * lands on the prod app with a different tenant and session. Unknown hosts
+ * (localhost, previews) fall back to prod. Same shape as
+ * ELIZA_CLOUD_DIRECT_API_BY_HOST in shell/steward-url.ts.
+ */
+const ELIZA_APP_ORIGIN_BY_HOST: Record<string, string> = {
+  "elizacloud.ai": "https://app.elizacloud.ai",
+  "www.elizacloud.ai": "https://app.elizacloud.ai",
+  "dev.elizacloud.ai": "https://app.elizacloud.ai",
+  "app.elizacloud.ai": "https://app.elizacloud.ai",
+  "staging.elizacloud.ai": "https://app-staging.elizacloud.ai",
+  "app-staging.elizacloud.ai": "https://app-staging.elizacloud.ai",
+};
+
+export function resolveElizaAppAgentCreateUrl(host?: string): string {
+  const browserHost =
+    host ??
+    (typeof window !== "undefined" ? window.location.hostname : undefined);
+  return (
+    (browserHost && ELIZA_APP_ORIGIN_BY_HOST[browserHost]) ||
+    "https://app.elizacloud.ai"
+  );
+}
 
 /**
  * Retire delete-tombstones by TIME only — the single retirement clock for both
@@ -902,7 +927,7 @@ export function ElizaAgentsTable({
         action={
           <Button asChild size="sm">
             <a
-              href={ELIZA_APP_AGENT_CREATE_URL}
+              href={resolveElizaAppAgentCreateUrl()}
               target="_blank"
               rel="noreferrer"
             >
@@ -1018,7 +1043,7 @@ export function ElizaAgentsTable({
           </Select>
           <Button asChild size="sm" className="h-9">
             <a
-              href={ELIZA_APP_AGENT_CREATE_URL}
+              href={resolveElizaAppAgentCreateUrl()}
               target="_blank"
               rel="noreferrer"
             >


### PR DESCRIPTION
## Problem
The agents table hardcodes `ELIZA_APP_AGENT_CREATE_URL = "https://app.elizacloud.ai"`, so a signed-in **staging** console user who clicks *open the Eliza app* (both the empty-state CTA and the toolbar button) lands on the **prod** app — different tenant, different session. Found while running the staging golden-path e2e for #15160.

## Fix
Replace the constant with a browser-host → app-origin map in the exact shape of `ELIZA_CLOUD_DIRECT_API_BY_HOST` (`shell/steward-url.ts`), the codebase's established per-env host-mapping pattern: staging hosts (`staging.elizacloud.ai`, `app-staging.elizacloud.ai`) resolve to `app-staging.elizacloud.ai`; prod hosts to `app.elizacloud.ai`; unknown hosts (localhost, previews, SSR) fall back to prod. Both `href` sites now call `resolveElizaAppAgentCreateUrl()`.

## Tests
Extended `eliza-agents-table.merge.test.ts` with resolver coverage (every env host maps to its OWN env's app + unknown-host/non-browser fallback). `vitest run` on the file: **12/12 pass** (10 pre-existing merge/tombstone + 2 new).

Closes #15161

[stan-cloud]