### PR TITLE
fix(ui): keep character editor actions above chat composer

### DIFF
--- a/packages/ui/src/components/character/CharacterEditorPanels.tsx
+++ b/packages/ui/src/components/character/CharacterEditorPanels.tsx
@@ -221,7 +221,7 @@ export function CharacterIdentityPanel({
           onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
             handleFieldEdit("system", e.target.value)
           }
-          className="w-full resize-none min-h-[14rem] overflow-x-hidden rounded-none border-0 border-b border-border/40 bg-transparent px-0 py-2 font-mono text-xs leading-relaxed text-txt"
+          className="w-full resize-none min-h-[10rem] overflow-x-hidden rounded-none border-0 border-b border-border/40 bg-transparent px-0 py-2 font-mono text-xs leading-relaxed text-txt lg:min-h-[14rem]"
           {...systemAgentProps}
         />
       </div>
@@ -239,7 +239,7 @@ export function CharacterIdentityPanel({
           onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
             handleFieldEdit("bio", e.target.value)
           }
-          className="w-full resize-none min-h-[8rem] overflow-x-hidden rounded-none border-0 border-b border-border/40 bg-transparent px-0 py-2 font-mono text-xs leading-relaxed text-txt"
+          className="w-full resize-none min-h-[6rem] overflow-x-hidden rounded-none border-0 border-b border-border/40 bg-transparent px-0 py-2 font-mono text-xs leading-relaxed text-txt lg:min-h-[8rem]"
           {...bioAgentProps}
         />
       </div>


### PR DESCRIPTION
## Summary

Fixes the app aesthetic audit failure that surfaced while merging #15155:
`builtin-character @ ipad-portrait` was marked `needs-work` because the persistent
chat composer overlapped the lower `Add Post` action. The character identity
text areas now keep their roomy desktop heights at `lg` and use slightly more
compact minimum heights below that breakpoint, leaving the examples actions clear
of the composer on tablet/mobile viewports.

## Verification

- `ELIZA_UI_SMOKE_SKIP_VIEW_BUILD=1 ELIZA_AUDIT_APP_STRICT=1 ELIZA_AUDIT_APP_STRICT_NEEDS_WORK=1 bun run --cwd packages/app audit:app:capture --grep "builtin-character ipad-portrait"`: PASS, `good=1`, `needs-work=0`.
- `bun run --cwd packages/ui typecheck`: PASS.
- `bunx @biomejs/biome@2.5.1 check packages/ui/src/components/character/CharacterEditorPanels.tsx`: PASS.
- `node packages/scripts/view-action-ratchet.mjs`: PASS.
- `bun run audit:error-policy-ratchet`: PASS.

## Evidence rows

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: failing app audit artifact from #15155 shows `builtin-character-ipad-portrait` with composer overlap: [app-aesthetic-audit-output](https://github.com/elizaOS/eliza/actions/runs/28829301075/artifacts/8124130920).
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: filtered local app audit produced `packages/app/aesthetic-audit-output/ipad-portrait/builtin-character.png` with verdict `good`; CI will publish the durable screenshot artifact on this PR checks page: [checks](https://github.com/elizaOS/eliza/pull/15164/checks). OCR visual text review is covered by the same app-audit artifact/checks link.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: [checks](https://github.com/elizaOS/eliza/pull/15164/checks) - static layout clearance fix; no separate interaction video, the filtered audit screenshot exercises the affected viewport.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: N/A - frontend layout-only change.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no separate browser console/network artifact; filtered app audit reported no console errors for `builtin-character ipad-portrait`.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model behavior change.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [PR files](https://github.com/elizaOS/eliza/pull/15164/files) plus the filtered app audit report for `builtin-character ipad-portrait` (`good=1`, `needs-work=0`).
