### PR TITLE
ci(ui): refresh story play ratchet baseline

### DIFF
--- a/packages/ui/test/story-gate/baseline/play-baseline.json
+++ b/packages/ui/test/story-gate/baseline/play-baseline.json
@@ -1,19 +1,21 @@
 {
   "description": "Story files with a Storybook `play` interaction test (#9943 ratchet floor). Regenerate with: bun run --cwd packages/ui audit:stories:play -- --update-baseline",
   "files": [
+    "packages/ui/src/components/chat/InlinePluginConfig.stories.tsx",
+    "packages/ui/src/components/chat/MessageContent.stories.tsx",
+    "packages/ui/src/components/chat/widgets/ChoiceWidget.stories.tsx",
     "packages/ui/src/components/chat/widgets/agent-provisioning.stories.tsx",
     "packages/ui/src/components/chat/widgets/calendar-upcoming.stories.tsx",
-    "packages/ui/src/components/chat/widgets/finances-alerts.stories.tsx",
+    "packages/ui/src/components/chat/widgets/form-request.stories.tsx",
     "packages/ui/src/components/chat/widgets/goals-attention.stories.tsx",
     "packages/ui/src/components/chat/widgets/health-sleep.stories.tsx",
     "packages/ui/src/components/chat/widgets/home-widget-card.stories.tsx",
-    "packages/ui/src/components/chat/widgets/inbox-unread.stories.tsx",
     "packages/ui/src/components/chat/widgets/model-download.stories.tsx",
     "packages/ui/src/components/chat/widgets/needs-attention.stories.tsx",
-    "packages/ui/src/components/chat/widgets/relationships-attention.stories.tsx",
     "packages/ui/src/components/composites/chat/chat-message-actions.stories.tsx",
     "packages/ui/src/components/pages/Launcher.stories.tsx",
     "packages/ui/src/components/shell/RestartBanner.stories.tsx",
-    "packages/ui/src/components/shell/ShortcutsOverlay.stories.tsx"
+    "packages/ui/src/components/shell/ShortcutsOverlay.stories.tsx",
+    "packages/ui/src/components/shell/StartupScreen.stories.tsx"
   ]
 }


### PR DESCRIPTION
## Summary

Fixes the current `develop` UI Story Gate fast-fail from run `28830578160` on `4267dc0cd8`.

The story play ratchet baseline still tracked three deleted per-domain home-widget story files:

- `packages/ui/src/components/chat/widgets/finances-alerts.stories.tsx`
- `packages/ui/src/components/chat/widgets/inbox-unread.stories.tsx`
- `packages/ui/src/components/chat/widgets/relationships-attention.stories.tsx`

Those widgets/stories are intentionally absent on current `develop`: the home-screen e2e now asserts the old domain cards stay absent, while current story coverage has moved to the surviving home widget/card surfaces. I regenerated only `packages/ui/test/story-gate/baseline/play-baseline.json`; the floor moves from 14 to 16 story files with `play` coverage.

## Validation

- `node packages/ui/test/story-gate/play-coverage-gate.mjs` PASS (`16 stories have a play`, floor `16`)
- `git diff --check` PASS
- `bunx @biomejs/biome check packages/ui/test/story-gate/baseline/play-baseline.json` PASS

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] N/A - source-only CI ratchet baseline repair; no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - source-only CI ratchet baseline repair; no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user flow changed; this only updates the story-gate source baseline.
<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend code path touched.
<!-- evidence-row:frontend-logs -->
- [x] CI/frontend gate evidence: failing `UI Story Gate` run `28830578160` reported the three obsolete story paths as lost `play`; local rerun of `node packages/ui/test/story-gate/play-coverage-gate.mjs` passes with `16 stories have a play (floor 16)`.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain artifacts changed; only `packages/ui/test/story-gate/baseline/play-baseline.json` changed.
