### PR TITLE
fix(ui): enforce single-greeting invariant at the setConversationMessages seam

### DIFF
--- a/packages/ui/src/state/useChatState.greeting.test.ts
+++ b/packages/ui/src/state/useChatState.greeting.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+//
+// `useChatState.setConversationMessages` enforces the single-greeting-per-thread
+// invariant at the one commit point every seed path routes through. Regression
+// for the device-review duplicate-greeting defect: a create/fetch race across a
+// cloud agent switch landed two greeting-sourced bubbles with identical text
+// that the per-seed `appendGreetingOnce` guard could not catch once state reset
+// between seeds. The setter now routes through `dedupeGreetings`, so no seed
+// path — SET, append, or reseed — can commit two greetings.
+
+import { MESSAGE_SOURCE_AGENT_GREETING } from "@elizaos/core";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { ConversationMessage } from "../api";
+import { useChatState } from "./useChatState";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+function greeting(
+  id: string,
+  text = "Hey, I'm Agent. What can I help you with?",
+): ConversationMessage {
+  return {
+    id,
+    role: "assistant",
+    text,
+    timestamp: 1,
+    source: MESSAGE_SOURCE_AGENT_GREETING,
+  };
+}
+
+function greetingSources(messages: ConversationMessage[]): number {
+  return messages.filter(
+    (m) => m.role === "assistant" && m.source === MESSAGE_SOURCE_AGENT_GREETING,
+  ).length;
+}
+
+describe("useChatState single-greeting invariant", () => {
+  it("collapses a SET that would commit two greeting bubbles to one", () => {
+    const { result } = renderHook(() => useChatState());
+    act(() => {
+      // A racing seed path commits a thread already carrying two greetings
+      // (identical text — the exact device defect).
+      result.current.setConversationMessages([greeting("g1"), greeting("g2")]);
+    });
+    expect(greetingSources(result.current.state.conversationMessages)).toBe(1);
+    // Earliest greeting wins so the visible bubble never swaps.
+    expect(result.current.state.conversationMessages[0].id).toBe("g1");
+    expect(result.current.conversationMessagesRef.current[0].id).toBe("g1");
+  });
+
+  it("keeps the first greeting when a late functional append seeds a second", () => {
+    const { result } = renderHook(() => useChatState());
+    act(() => {
+      result.current.setConversationMessages([greeting("inline")]);
+    });
+    act(() => {
+      // A late fetch appends a second greeting (different id, same source) —
+      // the interleaving `appendGreetingOnce` misses after a state reset.
+      result.current.setConversationMessages((prev) => [
+        ...prev,
+        greeting("late"),
+      ]);
+    });
+    expect(greetingSources(result.current.state.conversationMessages)).toBe(1);
+    expect(result.current.state.conversationMessages[0].id).toBe("inline");
+  });
+
+  it("is a no-op for a normal thread (preserves non-greeting order + tail)", () => {
+    const { result } = renderHook(() => useChatState());
+    const thread: ConversationMessage[] = [
+      greeting("g1"),
+      { id: "u1", role: "user", text: "hello", timestamp: 2 },
+      { id: "a1", role: "assistant", text: "hi back", timestamp: 3 },
+    ];
+    act(() => {
+      result.current.setConversationMessages(thread);
+    });
+    expect(result.current.state.conversationMessages.map((m) => m.id)).toEqual([
+      "g1",
+      "u1",
+      "a1",
+    ]);
+  });
+});

--- a/packages/ui/src/state/useChatState.ts
+++ b/packages/ui/src/state/useChatState.ts
@@ -15,6 +15,7 @@ import type {
 } from "../api";
 import type { AutonomyEventStore, AutonomyRunHealthMap } from "./autonomy";
 import type { ChatReplyTarget } from "./ChatComposerContext.hooks";
+import { dedupeGreetings } from "./greeting-dedupe";
 import {
   loadChatAvatarVisible,
   loadChatVoiceMuted,
@@ -372,8 +373,21 @@ export function useChatState(): ChatStateHook {
         | ConversationMessage[]
         | ((prev: ConversationMessage[]) => ConversationMessage[]),
     ) => {
-      const next =
+      const raw =
         typeof v === "function" ? v(conversationMessagesRef.current) : v;
+      // Enforce the single-greeting-per-thread invariant at the one commit
+      // point every seed path routes through. Multiple independent paths seed
+      // an agent greeting (inline `createConversation({ bootstrapGreeting })`
+      // SET, the `fetchGreeting` fallback APPEND, and the cloud agent-switch
+      // reseed); a create/fetch race across an agent switch could otherwise
+      // land two greeting-sourced bubbles with identical text, which the
+      // per-seed `appendGreetingOnce` guard cannot catch once state resets
+      // between the two seeds (the device-review duplicate-greeting defect).
+      // `dedupeGreetings` returns the SAME reference when the invariant already
+      // holds, so this is a no-op for every normal commit and only collapses a
+      // would-be duplicate — keeping the earliest greeting so the visible
+      // bubble never swaps under the user.
+      const next = dedupeGreetings(raw);
       conversationMessagesRef.current = next;
       dispatch({ type: "SET_MESSAGES", value: next });
     },


### PR DESCRIPTION
## The bug

The chat showed **two identical agent-greeting bubbles** — "Hey, I'm <agent>. What can I help you with?" — on the cloud dedicated-agent path. Device-observed on the Seeker during onboarding after cloud sign-in + agent auto-resume (agent "Launch Verify Dedicated"). This is the documented device-review duplicate-greeting defect that `greeting-dedupe.ts` was created to fix.

## Root cause

`greeting-dedupe.ts` documents the single-greeting-per-thread invariant and provides the seam (`appendGreetingOnce` / `dedupeGreetings`), but **only the `fetchGreeting` APPEND path routes through it**. Two other seed paths bypass it:
- the inline `createConversation({ bootstrapGreeting })` greeting (a raw `setConversationMessages([greeting])` SET), and
- the cloud agent-switch reseed.

A create/fetch race across the agent switch — where chat state resets between the two seeds — lands two greeting-sourced bubbles with **identical** text. Per-seed `appendGreetingOnce` can't catch it because its `prev` no longer reflects the other seed after the reset.

## Fix

Enforce the invariant at the **one commit point every seed path routes through** — `useChatState.setConversationMessages` — via the existing `dedupeGreetings`. It returns the **same reference** when the invariant already holds (a no-op for every normal commit, zero extra renders) and otherwise collapses to the **earliest** greeting so the visible bubble never swaps under the user. This makes the documented "single dedupe seam every greeting mutation routes through" actually universal, closing the cloud-path race and any future seed path — without touching the individual seed sites.

Not papering over: the file explicitly defines the single-greeting invariant as the contract; this enforces it at the state-commit boundary, which is exactly where such an invariant belongs.

## Evidence

| type | evidence |
|---|---|
| repro | Two identical cloud-agent greeting bubbles captured on the Seeker (screenshot on file); the `greeting-dedupe.ts` header documents the same defect class |
| tests | **3 new** `setConversationMessages` invariant cases (SET-double collapse, late functional-append collapse, normal-thread no-op preserving order) + existing `greeting-dedupe` and `useChatState.prepend` suites — **15/15 green** locally |
| screenshots/video | N/A - the fix is the ABSENCE of a duplicate bubble; covered by the deterministic state-level regression tests |
| trajectories | N/A - no agent/model/prompt behavior change |

Found during the native-app device verification (companion to the merged #15105 boot fixes).

— [maintainer]