### PR TITLE
fix(agent,ui): duplicate-greeting root cause — serialize server greeting ensure + close the two remaining client seams

### DIFF
--- a/packages/agent/src/api/__tests__/conversation-greeting-idempotency.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-greeting-idempotency.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Concurrency test for `POST /api/conversations/:id/greeting` — the
+ * duplicate-greeting root cause. The greeting ensure is a read-check-then-write
+ * (getMemories scan → persist) with no room-level uniqueness on (room, source):
+ * two OVERLAPPING callers both read an empty room and both persist an identical
+ * greeting row, which paints the doubled "Hey, I'm <agent>" bubble and leaks a
+ * duplicate row into model context. Drives the real `handleConversationRoutes`
+ * against a real `InMemoryDatabaseAdapter` (thin runtime shim) and asserts the
+ * per-conversation coalescing holds: two concurrent requests, exactly ONE
+ * greeting-sourced memory, both responses carrying the same text.
+ */
+
+import type { Memory, UUID } from "@elizaos/core";
+import { ChannelType, MESSAGE_SOURCE_AGENT_GREETING } from "@elizaos/core";
+import { beforeEach, describe, expect, it } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../../../core/src/database/inMemoryAdapter.ts";
+import {
+  type ConversationRouteContext,
+  type ConversationRouteState,
+  handleConversationRoutes,
+} from "../conversation-routes.ts";
+import type { ConversationMeta } from "../server-types.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000c1" as UUID;
+const CONV_ID = "11111111-1111-4111-8111-111111111111";
+const ROOM_ID = "22222222-2222-4222-8222-222222222222" as UUID;
+
+function makeRuntime(adapter: InMemoryDatabaseAdapter): unknown {
+  return {
+    agentId: AGENT_ID,
+    character: { name: "Eliza" },
+    async ensureConnection(params: { roomId: UUID; roomName?: string }) {
+      await adapter.createRooms([
+        {
+          id: params.roomId,
+          agentId: AGENT_ID,
+          name: params.roomName,
+          source: "test",
+          type: ChannelType.DM,
+        } as Parameters<InMemoryDatabaseAdapter["createRooms"]>[0][number],
+      ]);
+    },
+    async createMemory(memory: Memory, tableName: string) {
+      const [id] = await adapter.createMemories([{ memory, tableName }]);
+      return id;
+    },
+    async getMemories(params: {
+      roomId: UUID;
+      tableName: string;
+      limit?: number;
+    }) {
+      return adapter.getMemories({
+        roomId: params.roomId,
+        tableName: params.tableName,
+        count: params.limit,
+      });
+    },
+    // World/room plumbing exercised by ensureConversationRoom on the greeting
+    // route. The world is a mutable in-shim record so ownership/role writes
+    // round-trip like the real adapter's.
+    __worlds: new Map<string, Record<string, unknown>>(),
+    async getWorld(worldId: UUID) {
+      const worlds = (this as { __worlds: Map<string, unknown> }).__worlds;
+      if (!worlds.has(worldId)) {
+        worlds.set(worldId, {
+          id: worldId,
+          agentId: AGENT_ID,
+          name: "test-world",
+          serverId: "test-server",
+          metadata: {},
+        });
+      }
+      return worlds.get(worldId);
+    },
+    async updateWorld(world: { id: UUID }) {
+      (this as { __worlds: Map<string, unknown> }).__worlds.set(
+        world.id,
+        world,
+      );
+    },
+    async getRoom(roomId: UUID) {
+      const rooms = await adapter.getRoomsByIds([roomId]);
+      return rooms?.[0] ?? null;
+    },
+    adapter: {
+      async updateRoom() {
+        /* room metadata refresh is irrelevant to the greeting invariant */
+      },
+    },
+  };
+}
+
+function makeState(adapter: InMemoryDatabaseAdapter): ConversationRouteState {
+  const conv: ConversationMeta = {
+    id: CONV_ID,
+    title: "Chat",
+    roomId: ROOM_ID,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  } as ConversationMeta;
+  return {
+    runtime: makeRuntime(adapter),
+    agentName: "Eliza",
+    config: { ui: {} },
+    conversations: new Map<string, ConversationMeta>([[CONV_ID, conv]]),
+    deletedConversationIds: new Set<string>(),
+    conversationRestorePromise: null,
+  } as unknown as ConversationRouteState;
+}
+
+interface Captured {
+  status: number;
+  body: Record<string, unknown> & { error?: string; text?: string };
+}
+
+function greetingRequest(state: ConversationRouteState): Promise<Captured> {
+  return new Promise((resolve) => {
+    const captured: Partial<Captured> = {};
+    const ctx = {
+      req: {
+        url: `/api/conversations/${CONV_ID}/greeting`,
+        headers: { host: "localhost" },
+      },
+      res: {},
+      method: "POST",
+      pathname: `/api/conversations/${CONV_ID}/greeting`,
+      readJsonBody: () => Promise.resolve({}),
+      json: (_res: unknown, data: unknown, status = 200) => {
+        captured.status = status;
+        captured.body = data as Captured["body"];
+        resolve(captured as Captured);
+      },
+      error: (_res: unknown, message: string, status = 500) => {
+        captured.status = status;
+        captured.body = { error: message };
+        resolve(captured as Captured);
+      },
+      state,
+    } as unknown as ConversationRouteContext;
+    void handleConversationRoutes(ctx);
+  });
+}
+
+async function greetingRows(adapter: InMemoryDatabaseAdapter) {
+  const memories = await adapter.getMemories({
+    roomId: ROOM_ID,
+    tableName: "messages",
+    count: 50,
+  });
+  return memories.filter(
+    (m) =>
+      (m.content as Record<string, unknown> | undefined)?.source ===
+      MESSAGE_SOURCE_AGENT_GREETING,
+  );
+}
+
+describe("POST /api/conversations/:id/greeting — concurrent ensure coalescing", () => {
+  let adapter: InMemoryDatabaseAdapter;
+
+  beforeEach(async () => {
+    adapter = new InMemoryDatabaseAdapter();
+    await adapter.initialize();
+  });
+
+  it("two CONCURRENT greeting requests persist exactly one greeting row", async () => {
+    const state = makeState(adapter);
+    const [a, b] = await Promise.all([
+      greetingRequest(state),
+      greetingRequest(state),
+    ]);
+
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200);
+    expect(a.body.text).toBeTruthy();
+    // Coalesced callers observe the SAME committed greeting.
+    expect(b.body.text).toBe(a.body.text);
+
+    const rows = await greetingRows(adapter);
+    expect(rows).toHaveLength(1);
+  });
+
+  it("a SEQUENTIAL second request returns the stored greeting without re-persisting", async () => {
+    const state = makeState(adapter);
+    const first = await greetingRequest(state);
+    const second = await greetingRequest(state);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(second.body.text).toBe(first.body.text);
+    // Late caller reads the existing row (persisted:false semantics preserved).
+    expect(second.body.persisted).toBe(false);
+
+    const rows = await greetingRows(adapter);
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -1290,7 +1290,50 @@ type ConversationRouteMessageRecord = {
   accountConnect?: AccountConnectRequest;
 };
 
+// Serializes concurrent greeting ensures per conversation. The body is a
+// read-check-then-write (getMemories scan → persistConversationMemory) with no
+// room-level uniqueness on (room, source): each persist mints a fresh UUID so
+// isDuplicateMemoryError never fires. Two overlapping callers — the
+// bootstrapGreeting create racing a superseding hydration's POST /greeting, the
+// new-chat fallback racing the empty-thread auto-greet, or two sessions
+// hydrating the same fresh conversation — both read an empty room and both
+// persist an identical deterministic greeting, minting the duplicate
+// "Hey, I'm <agent>" row (which also leaks into model context via getMemories).
+// Coalescing on one in-flight promise per conversation makes the second caller
+// observe the first's committed row instead of re-racing it. Sequential
+// create-then-fetch is unaffected: the entry is deleted before any later call.
+const greetingEnsureInFlight = new Map<
+  string,
+  Promise<{
+    text: string;
+    agentName: string;
+    generated: boolean;
+    persisted: boolean;
+  }>
+>();
+
 async function ensureConversationGreetingStored(
+  state: ConversationRouteState,
+  conv: ConversationMeta,
+  lang: string,
+): Promise<{
+  text: string;
+  agentName: string;
+  generated: boolean;
+  persisted: boolean;
+}> {
+  const inFlight = greetingEnsureInFlight.get(conv.id);
+  if (inFlight) return inFlight;
+  const run = ensureConversationGreetingStoredUnlocked(state, conv, lang);
+  greetingEnsureInFlight.set(conv.id, run);
+  try {
+    return await run;
+  } finally {
+    greetingEnsureInFlight.delete(conv.id);
+  }
+}
+
+async function ensureConversationGreetingStoredUnlocked(
   state: ConversationRouteState,
   conv: ConversationMeta,
   lang: string,

--- a/packages/ui/src/state/useChatCallbacks.ts
+++ b/packages/ui/src/state/useChatCallbacks.ts
@@ -971,6 +971,13 @@ export function useChatCallbacks(deps: UseChatCallbacksDeps) {
         let greetingText = inlineGreeting?.text?.trim() || "";
         let greetingLocalInference = inlineGreeting?.localInference;
         if (!greetingText) {
+          // Register the in-flight conversation BEFORE the request leaves. This
+          // fallback bypasses fetchGreeting, so without the ref the empty-thread
+          // auto-greet effect passes every guard during this await and fires a
+          // SECOND concurrent POST /greeting for the same fresh conversation —
+          // the overlapping pair that double-persists two identical greeting
+          // rows server-side (the other half of the duplicate-greeting defect).
+          greetingInFlightConversationRef.current = conversation.id;
           try {
             const resp = await client.requestGreeting(
               conversation.id,
@@ -980,6 +987,10 @@ export function useChatCallbacks(deps: UseChatCallbacksDeps) {
             greetingLocalInference = resp.localInference;
           } catch {
             // Greeting generation failed — continue without greeting
+          } finally {
+            if (greetingInFlightConversationRef.current === conversation.id) {
+              greetingInFlightConversationRef.current = null;
+            }
           }
         }
 
@@ -1094,6 +1105,7 @@ export function useChatCallbacks(deps: UseChatCallbacksDeps) {
       conversationHydrationEpochRef,
       conversationMessagesRef,
       greetingFiredRef,
+      greetingInFlightConversationRef,
       loadedConversationIdRef,
       send.interruptActiveChatPipeline,
       setActiveConversationId,

--- a/packages/ui/src/state/useChatState.prepend.test.ts
+++ b/packages/ui/src/state/useChatState.prepend.test.ts
@@ -106,3 +106,76 @@ describe("useChatState prependConversationMessages", () => {
     expect(result.current.conversationMessagesRef.current).toEqual(kept);
   });
 });
+
+// ── Single-greeting invariant across pagination (duplicate-greeting defect) ──
+// A poisoned thread's duplicated greeting pair sits at the very HEAD, so both
+// rows arrive in the same load-older batch and would bypass the
+// setConversationMessages dedupe seam entirely.
+import { MESSAGE_SOURCE_AGENT_GREETING } from "@elizaos/core";
+
+function greetingRow(id: string, timestamp: number): ConversationMessage {
+  return {
+    id,
+    role: "assistant",
+    text: "Hey, I'm Agent. What can I help you with?",
+    timestamp,
+    source: MESSAGE_SOURCE_AGENT_GREETING,
+  };
+}
+
+describe("prependConversationMessages single-greeting invariant", () => {
+  it("keeps ONE greeting when a batch carries a duplicated pair", () => {
+    const { result } = renderHook(() => useChatState());
+    act(() => {
+      result.current.setConversationMessages([msg("tail", 100)]);
+    });
+    act(() => {
+      result.current.prependConversationMessages([
+        greetingRow("g1", 1),
+        greetingRow("g2", 2),
+        msg("old", 50),
+      ]);
+    });
+    const greetings = result.current.state.conversationMessages.filter(
+      (m) => m.source === MESSAGE_SOURCE_AGENT_GREETING,
+    );
+    expect(greetings).toHaveLength(1);
+    expect(greetings[0].id).toBe("g1");
+    expect(ids(result.current.state.conversationMessages)).toEqual([
+      "g1",
+      "old",
+      "tail",
+    ]);
+  });
+
+  it("drops an older greeting when the window already carries one", () => {
+    const { result } = renderHook(() => useChatState());
+    act(() => {
+      result.current.setConversationMessages([
+        greetingRow("kept", 10),
+        msg("m1", 20),
+      ]);
+    });
+    act(() => {
+      result.current.prependConversationMessages([greetingRow("dupe", 1)]);
+    });
+    expect(ids(result.current.state.conversationMessages)).toEqual([
+      "kept",
+      "m1",
+    ]);
+  });
+
+  it("passes a healthy single greeting through untouched", () => {
+    const { result } = renderHook(() => useChatState());
+    act(() => {
+      result.current.setConversationMessages([msg("m1", 20)]);
+    });
+    act(() => {
+      result.current.prependConversationMessages([greetingRow("g1", 1)]);
+    });
+    expect(ids(result.current.state.conversationMessages)).toEqual([
+      "g1",
+      "m1",
+    ]);
+  });
+});

--- a/packages/ui/src/state/useChatState.ts
+++ b/packages/ui/src/state/useChatState.ts
@@ -15,7 +15,7 @@ import type {
 } from "../api";
 import type { AutonomyEventStore, AutonomyRunHealthMap } from "./autonomy";
 import type { ChatReplyTarget } from "./ChatComposerContext.hooks";
-import { dedupeGreetings } from "./greeting-dedupe";
+import { dedupeGreetings, isAgentGreetingMessage } from "./greeting-dedupe";
 import {
   loadChatAvatarVisible,
   loadChatVoiceMuted,
@@ -398,11 +398,23 @@ export function useChatState(): ChatStateHook {
     (older: ConversationMessage[]) => {
       if (older.length === 0) return;
       const current = conversationMessagesRef.current;
+      // Single-greeting invariant across pagination: on an already-poisoned
+      // thread the duplicated greeting pair sits at the very HEAD, so both rows
+      // arrive together in a load-older batch and would bypass the
+      // setConversationMessages dedupe seam. Filter the batch before BOTH
+      // commits (ref + dispatch) so the reducer's id-merge sees the same
+      // survivors and stays in lockstep. Healthy threads are untouched: a window
+      // that legitimately missed its single greeting still prepends it (current
+      // has none → dedupeGreetings(older) is a same-ref no-op).
+      const olderDeduped = current.some(isAgentGreetingMessage)
+        ? older.filter((m) => !isAgentGreetingMessage(m))
+        : dedupeGreetings(older);
+      if (olderDeduped.length === 0) return;
       const existingIds = new Set(current.map((m) => m.id));
-      const olderToAdd = older.filter((m) => !existingIds.has(m.id));
+      const olderToAdd = olderDeduped.filter((m) => !existingIds.has(m.id));
       if (olderToAdd.length === 0) return;
       conversationMessagesRef.current = [...olderToAdd, ...current];
-      dispatch({ type: "PREPEND_MESSAGES", value: older });
+      dispatch({ type: "PREPEND_MESSAGES", value: olderDeduped });
     },
     [],
   );


### PR DESCRIPTION
## Context

Completes the duplicate-greeting stack. #15166 enforced the invariant at RENDER commits; a 12-agent adversarial trace (verify pass included) then located the actual **pipeline** defect and two residual holes. Per the repo error doctrine (fix the pipeline, don't mask at read time), this eliminates duplicates at the source.

## The three fixes

**1. Server root cause** — `ensureConversationGreetingStored` is a read-check-then-write (getMemories scan → persist) with no room-level uniqueness on (room, source); every persist mints a fresh UUID so `isDuplicateMemoryError` never fires. Overlapping callers (bootstrapGreeting create × superseding hydration's POST /greeting; new-chat fallback × empty-thread auto-greet; two sessions on one fresh conversation) both read an empty room and both persist — duplicate rows that also **leak into model context** via getMemories. Fix: coalesce on one in-flight promise per conversation; the second caller observes the first's committed row. Sequential semantics unchanged (`persisted:false` for late callers preserved).

**2. Client seed guard** — `handleNewConversation`'s raw `requestGreeting` fallback bypassed `fetchGreeting`'s in-flight ref, so the auto-greet effect could fire a second concurrent POST during the await. The ref now registers around the request (finally-cleared; the old-server `fetchGreeting` retry path still fires).

**3. Prepend seam** — a poisoned thread's duplicated pair sits at the HEAD, arrives together in a load-older batch, and bypassed the #15166 setter seam. The batch is now filtered before BOTH commits (ref + dispatch stay in lockstep), so **already-poisoned prod threads** render one greeting across pagination too.

## Evidence

| type | evidence |
|---|---|
| RED/GREEN proof | `conversation-greeting-idempotency.test.ts` (real `handleConversationRoutes` + real `InMemoryDatabaseAdapter`, no mocks of the unit under test): two CONCURRENT POSTs → pre-fix **FAILS** — each caller persisted its own random greeting ('hey. what do you need?' ≠ 'hey, good to see you.'); post-fix **2/2 green**, exactly ONE greeting row |
| UI tests | +3 prepend pagination-invariant cases; all greeting/dedupe/hydrate/prepend suites **26/26 green** |
| device repro | The doubled 'Hey, I'm Launch Verify Dedicated' bubble captured on the Seeker (evidence on #15166); after the render seam the same thread shows ONE bubble — this PR stops the rows being minted at all |
| trajectories | N/A - no model/prompt change; the DB-row assertion is the domain artifact (inspected in-test) |
| screenshots/video | N/A - fix is server/state-level; deterministic tests + the Seeker before/after on #15166 cover the visible behavior |

Companion to #15166 (render), #15105/#15142 (native boot/crash) — the full mobile-QA defect stack from tonight's device pass.

— [maintainer]