### PR TITLE
fix(corpus-tools): restore case-insensitive PII mining — align miner flags with the production redactor

### DIFF
--- a/packages/corpus-tools/src/pipeline/mine.test.ts
+++ b/packages/corpus-tools/src/pipeline/mine.test.ts
@@ -90,6 +90,29 @@ describe("minePiiCandidates", () => {
     ).toBe(true);
   });
 
+  it("matches name-based redact patterns case-insensitively, like the production redactor", async () => {
+    // Regression for the gi->g flag change (#15116 follow-up): core compiles
+    // the identical pattern list with "gi" (redact.ts parsePattern,
+    // secret-swap.ts); the miner going case-sensitive silently under-reported
+    // these on the stage-0 human-review surface.
+    const rows = [
+      message("case-1", "password: hunter2"),
+      message("case-2", "token=abc4567"),
+      message("case-3", "authorization: bearer eyJhbGciOiJIUzI1NiJ9.e30.abc"),
+    ];
+
+    const artifacts = await minePiiCandidates(rows, { hashSalt: "case-v1" });
+    const byMemory = new Set(
+      artifacts.candidates
+        .filter((candidate) => candidate.kind === "redact-pattern")
+        .map((candidate) => candidate.sourceRef.memoryId),
+    );
+
+    for (const id of ["case-1", "case-2", "case-3"]) {
+      expect(byMemory.has(id), `redact-pattern miss on ${id}`).toBe(true);
+    }
+  });
+
   it("emits stable hashes and contact-gazetteer candidates", async () => {
     const contacts: CorpusContact[] = [
       {

--- a/packages/corpus-tools/src/pipeline/mine.ts
+++ b/packages/corpus-tools/src/pipeline/mine.ts
@@ -111,11 +111,19 @@ function contactGazetteerEntries(
 function redactPatternMatches(text: string): RawCandidate[] {
   const candidates: RawCandidate[] = [];
   for (const rawPattern of getDefaultRedactPatterns()) {
-    // Do not force the `i` flag: case-insensitive matching corrupts
-    // case-sensitive secret patterns (base64/hex/prefixed keys). Any pattern
-    // that genuinely needs case-insensitivity must encode `(?i)`-style intent
-    // in its own source string.
-    const pattern = new RegExp(rawPattern, "g");
+    // `gi`, matching how the production redactor and secret-swap compile the
+    // IDENTICAL pattern list (core/src/security/redact.ts parsePattern and
+    // secret-swap.ts both default to "gi"). The name-based patterns
+    // (password:/token=/authorization: bearer/...) are case-divergent in the
+    // wild - compiling them case-sensitively here made this recall-oriented
+    // miner strictly less sensitive than the redactor it feeds, silently
+    // under-reporting candidates on the stage-0 human-review surface.
+    // JS RegExp has no inline (?i), so per-pattern case intent cannot live in
+    // the pattern source; a genuinely case-sensitive pattern belongs in the
+    // /pattern/flags escape-hatch form core supports. Over-matching here only
+    // adds rows to a human-review CSV - the correct failure direction for a
+    // miner.
+    const pattern = new RegExp(rawPattern, "gi");
     for (const match of text.matchAll(pattern)) {
       const value = match[match.length - 1] || match[0];
       if (!value) continue;


### PR DESCRIPTION
## The regression (confirmed in the post-merge audit of the 07-06 wave, adversarially verified)

#15116 switched `redactPatternMatches` from `gi` to `g`, with the rationale that the patterns are 'case-sensitive by design'. That doesn't hold: **core compiles the IDENTICAL pattern list case-insensitively** (`core/src/security/redact.ts` `parsePattern` → `gi`; `secret-swap.ts` `SECRET_PATTERNS` → `gi`), and the name-based patterns are case-divergent in the wild.

Empirically verified: `password: hunter2`, `token=abc4567`, lowercase HTTP/2 `authorization: bearer <jwt>`, `\"ApiKey\": \"abcd1234\"` all match under `gi` and **zero-match under `g`**. Consequences:
- The stage-0 human-review surface (owner CSV, frequency table, `report.candidateCount`) **silently under-reports** these secrets in a privacy-scrub pipeline.
- Lowercase name-based secrets with values under `MIN_SWAP_VALUE_LENGTH=8` now have **no detector anywhere** (the llm stage only covers password|passcode|pin).
- The comment's suggested remedy — encode '(?i)-style intent in the pattern source' — is impossible: JS `RegExp` rejects inline `(?i)` (SyntaxError).

## Fix

Restore `gi`; correct the rationale comment. Over-matching only adds rows to a human-review CSV — the right failure direction for a recall-oriented miner. A genuinely case-sensitive pattern belongs in the `/pattern/flags` escape-hatch form core already supports.

## Evidence

| type | evidence |
|---|---|
| RED/GREEN | New regression test (three case-divergent canaries must each yield a redact-pattern candidate): **fails against `g`** (1 failed/3 passed), **4/4 green with `gi`** |
| suite | `mine.test.ts` fully green; the `driver.test.ts` fast-track red is **pre-existing on develop** (verified by stash A/B against unpatched baseline — not introduced here) |
| trajectories | N/A - deterministic pattern-matching change, no model behavior |
| screenshots | N/A - no UI surface |

— [maintainer]