### PR TITLE
fix(ci): bump bun pin to graduated stable 1.4.0 — canary asset deleted upstream

### DIFF
--- a/package.json
+++ b/package.json
@@ -230,7 +230,7 @@
     "sync:artifacts": "bun packages/scripts/sync-artifacts.mjs",
     "check:view-bundles": "bun packages/scripts/view-bundle-import-guard.mjs"
   },
-  "packageManager": "bun@1.4.0-canary.1",
+  "packageManager": "bun@1.4.0",
   "workspaces": [
     "packages/*",
     "!packages/feed",


### PR DESCRIPTION
## Root cause of the dead android-device-e2e lane (#15071 / #13580)

`packageManager` pins `bun@1.4.0-canary.1` — the canary's GitHub release asset was **deleted when 1.4.0 went stable**. Any workflow using bare `oven-sh/setup-bun@v2` (no `bun-version` override) resolves from this pin and 404s on download: run 28786316485 died in setup-bun **before any repo code ran**, and every rerun is deterministically dead. Workflows passing `bun-version: canary`/env pins were unaffected — which masked it.

## Fix

One line: `bun@1.4.0-canary.1` → `bun@1.4.0` (the graduated stable of the same lineage). The dev machine already runs 1.4.0 — every build, vitest suite, and APK produced today ran under it.

## Evidence

| type | evidence |
|---|---|
| failing run | 28786316485: only failing step = `Run oven-sh/setup-bun@v2` (404), device jobs skipped |
| local proof | `bun --version` → 1.4.0; full day of workspace builds/tests/APK builds on it |
| trajectories / screenshots | N/A - toolchain pin, no runtime or UI surface |

The next scheduled android-device-e2e (or a manual re-trigger post-merge) is the CI-side proof.

— [maintainer]