### PR TITLE
fix(lifeops): meeting-ghost rework — canonical types + real approval-queue consumer + integration test (#14870 follow-up)

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/index.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/index.ts
@@ -15,6 +15,7 @@ export * from "./goal-semantic-evaluator.js";
 export * from "./google-plugin-delegates.js";
 export * from "./implicit-referents/index.js";
 export * from "./intent-sync.js";
+export * from "./meeting-ghost/consumer.js";
 export * from "./meeting-ghost/index.js";
 export * from "./owner-profile.js";
 export * from "./policy-memory.js";

--- a/plugins/plugin-personal-assistant/src/lifeops/meeting-ghost/consumer.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/meeting-ghost/consumer.ts
@@ -1,0 +1,73 @@
+/**
+ * Runtime consumer that turns a finalized meeting transcript into queued owner
+ * approvals — the reachable path that makes `analyzeMeetingGhostTranscript`
+ * (a pure function in `./index.ts`) act on the system.
+ *
+ * A caller (the meeting post-processing hook, or a scheduled-task watcher that
+ * reads finalized `TranscriptSegment[]` off the `transcripts` memory table)
+ * hands us the diarized transcript the owner skipped plus their context. We
+ * derive the follow-up emails and calendar-deadline events the owner would send
+ * if they had attended, and enqueue each as an owner-approval request through
+ * the shared `ApprovalQueue` — every meeting-ghost side effect stays behind the
+ * owner's one-tap approve/reject, never auto-sent.
+ *
+ * `analyzeMeetingGhostTranscript` already emits `ApprovalEnqueueInput[]`, so
+ * this is a thin routing pass: analyze, then `enqueue` each request. Enqueue
+ * failures surface (no swallow) so a broken approval pipeline is observable.
+ */
+
+import type { IAgentRuntime } from "@elizaos/core";
+import { logger } from "@elizaos/core";
+import { createApprovalQueue } from "../approval-queue.js";
+import type { ApprovalRequest } from "../approval-queue.types.js";
+import {
+  analyzeMeetingGhostTranscript,
+  type MeetingGhostAnalysis,
+  type MeetingGhostOwnerContext,
+  type MeetingGhostTranscript,
+} from "./index.js";
+
+export interface RunMeetingGhostInput {
+  readonly agentId: string;
+  readonly transcript: MeetingGhostTranscript;
+  readonly owner: MeetingGhostOwnerContext;
+}
+
+export interface MeetingGhostRunResult {
+  readonly analysis: MeetingGhostAnalysis;
+  /** Approval requests created in the queue (follow-ups then calendar deadlines). */
+  readonly enqueued: readonly ApprovalRequest[];
+}
+
+/**
+ * Analyze the transcript and enqueue every derived owner-approval request.
+ * Follow-up emails enqueue before calendar-deadline events so the owner sees
+ * the reply drafts first. Returns the analysis alongside the created requests
+ * so callers can render the digest and cite the queued approvals.
+ */
+export async function runMeetingGhostForTranscript(
+  runtime: IAgentRuntime,
+  input: RunMeetingGhostInput,
+): Promise<MeetingGhostRunResult> {
+  const analysis = analyzeMeetingGhostTranscript({
+    transcript: input.transcript,
+    owner: input.owner,
+  });
+
+  const requests = [
+    ...analysis.followUpApprovals,
+    ...analysis.calendarIntents.map((intent) => intent.approval),
+  ];
+
+  const queue = createApprovalQueue(runtime, { agentId: input.agentId });
+  const enqueued: ApprovalRequest[] = [];
+  for (const request of requests) {
+    enqueued.push(await queue.enqueue(request));
+  }
+
+  logger.info(
+    `[meeting-ghost] ${input.transcript.meetingId}: ${analysis.decisions.length} decisions, ${analysis.commitments.length} commitments, ${enqueued.length} approvals queued`,
+  );
+
+  return { analysis, enqueued };
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/meeting-ghost/index.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/meeting-ghost/index.ts
@@ -1,30 +1,40 @@
 /**
  * Transcript-side producer for meetings the owner skipped.
  *
- * The live meeting joiner and diarization path can hand this module a normalized
- * transcript; this code owns the deterministic post-meeting shape that LifeOps
- * needs before it writes ledger rows, queues owner-approved follow-ups, or
- * creates calendar deadline intents. It is deliberately pure so tests can pin
- * care-about filtering and commitment extraction without mocking connectors.
+ * Given a finalized, diarized meeting transcript (the canonical
+ * `TranscriptSegment[]` that `@elizaos/plugin-meetings`' pipeline `finalize()`
+ * produces) plus owner context, this module derives the deterministic
+ * post-meeting shape LifeOps acts on: decisions, care-about hits, extracted
+ * commitments, a short digest, and — the part that leaves the module —
+ * owner-approval requests as `ApprovalEnqueueInput[]` that feed
+ * `ApprovalQueue.enqueue()` directly (no re-mapping at the call site). The
+ * scheduled-task consumer that runs this on a real transcript and routes the
+ * approvals lives in `./consumer.ts`.
+ *
+ * It is deliberately pure so tests can pin care-about filtering and commitment
+ * extraction against a realistic diarized fixture without mocking connectors.
+ * Extraction is heuristic (regex over natural utterances); a model-driven pass
+ * is out of scope here (tracked by #14870 for ASR that these rules miss).
  */
+
+import type { TranscriptSegment } from "@elizaos/shared";
+import type {
+  ApprovalEnqueueInput,
+  ApprovalPayload,
+} from "../approval-queue.types.js";
 
 export interface MeetingGhostAttendee {
   readonly name: string;
   readonly email?: string;
 }
 
-export interface MeetingGhostTranscriptSegment {
-  readonly speaker: string;
-  readonly text: string;
-  readonly offsetMs?: number;
-}
-
+/** Meeting metadata wrapping the canonical diarized segments. */
 export interface MeetingGhostTranscript {
   readonly meetingId: string;
   readonly title: string;
   readonly startedAt: string;
   readonly attendees: readonly MeetingGhostAttendee[];
-  readonly segments: readonly MeetingGhostTranscriptSegment[];
+  readonly segments: readonly TranscriptSegment[];
 }
 
 export interface MeetingGhostOwnerContext {
@@ -62,47 +72,10 @@ export interface MeetingGhostCareHit {
   readonly sourceOffsetMs: number | null;
 }
 
-export type MeetingGhostApprovalIntent =
-  | {
-      readonly requestedBy: string;
-      readonly subjectUserId: string;
-      readonly action: "send_email";
-      readonly channel: "email";
-      readonly reason: string;
-      readonly expiresAt: Date;
-      readonly payload: {
-        readonly action: "send_email";
-        readonly to: readonly string[];
-        readonly cc: readonly string[];
-        readonly bcc: readonly string[];
-        readonly subject: string;
-        readonly body: string;
-        readonly threadId: string | null;
-        readonly replyToMessageId: string | null;
-      };
-    }
-  | {
-      readonly requestedBy: string;
-      readonly subjectUserId: string;
-      readonly action: "schedule_event";
-      readonly channel: "google_calendar";
-      readonly reason: string;
-      readonly expiresAt: Date;
-      readonly payload: {
-        readonly action: "schedule_event";
-        readonly calendarId: string;
-        readonly title: string;
-        readonly startsAtMs: number;
-        readonly endsAtMs: number;
-        readonly attendees: readonly string[];
-        readonly location: string | null;
-        readonly description: string | null;
-      };
-    };
-
+/** A calendar-deadline approval bound back to the commitment that produced it. */
 export interface MeetingGhostCalendarIntent {
   readonly commitmentId: string;
-  readonly approval: MeetingGhostApprovalIntent;
+  readonly approval: ApprovalEnqueueInput;
 }
 
 export interface MeetingGhostAnalysis {
@@ -110,19 +83,31 @@ export interface MeetingGhostAnalysis {
   readonly decisions: readonly MeetingGhostDecision[];
   readonly commitments: readonly MeetingGhostCommitment[];
   readonly careHits: readonly MeetingGhostCareHit[];
-  readonly followUpApprovals: readonly MeetingGhostApprovalIntent[];
+  /** Ready to feed `ApprovalQueue.enqueue()` directly. */
+  readonly followUpApprovals: readonly ApprovalEnqueueInput[];
   readonly calendarIntents: readonly MeetingGhostCalendarIntent[];
   readonly digestLines: readonly string[];
 }
 
+// A diarized commitment reads as a natural utterance, so the extractor keys on
+// the speaker + a commitment verb ("will send the plan by Friday"), not on a
+// literal "Action:" prefix a human would never say aloud. The prefixed forms
+// are still accepted for transcripts that carry structured annotations.
 const DECISION_PREFIX_RE =
   /^(?:decision|decided|we decided|decision is)\s*[:-]\s*(.+)$/i;
+// A leading "we/the team decided (to)? X" spoken sentence.
+const SPOKEN_DECISION_RE =
+  /^(?:we|the team|everyone|the group)\s+(?:agreed|decided|settled|concluded)\s+(?:that\s+|to\s+|on\s+)?(?<body>.+?)[.;]?$/i;
 const COMMITMENT_PREFIX_RE =
   /^(?:action|commitment|follow-up)\s*[:-]\s*(?<body>.+)$/i;
+// "Mira will send the deck by Friday" / "Ben is taking the calendar update"
 const NAMED_COMMITMENT_RE =
-  /^(?<who>[A-Z][A-Za-z .'-]{1,60}?)\s+(?:will|to|owns|is taking|committed to)\s+(?<what>.+?)(?:\s+by\s+(?<due>[^.;]+))?[.;]?$/;
+  /^(?<who>[A-Z][A-Za-z .'-]{1,60}?)\s+(?:will|to|owns|is taking|committed to|is going to|can)\s+(?<what>.+?)(?:\s+by\s+(?<due>[^.;]+))?[.;]?$/;
+// First-person, who = the speaker. Requires an explicit commitment verb
+// ("I will…", "I'll…", "we can…", "I am going to…") so a bare first-person
+// remark ("I think…") is not mistaken for an action item.
 const SPEAKER_COMMITMENT_RE =
-  /^(?:i|we)\s+(?:will|can|am going to|are going to)\s+(?<what>.+?)(?:\s+by\s+(?<due>[^.;]+))?[.;]?$/i;
+  /^(?:i|we)\s*(?:'ll\s+|will\s+|can\s+|am going to\s+|are going to\s+)(?<what>.+?)(?:\s+by\s+(?<due>[^.;]+))?[.;]?$/i;
 
 const WEEKDAYS = new Map([
   ["sunday", 0],
@@ -152,18 +137,9 @@ function stableId(parts: readonly string[]): string {
     .join(":");
 }
 
-function stripSpeakerPrefix(text: string): string {
-  const trimmed = compact(text);
-  const match = trimmed.match(/^[A-Z][A-Za-z .'-]{1,60}:\s*(.+)$/);
-  if (
-    match &&
-    /^(?:action|commitment|decision|decided|follow-up)$/i.test(
-      trimmed.slice(0, trimmed.indexOf(":")).trim(),
-    )
-  ) {
-    return trimmed;
-  }
-  return match?.[1] ? compact(match[1]) : trimmed;
+/** Speaker label for a diarized segment; falls back to the entity id. */
+function speakerOf(segment: TranscriptSegment): string {
+  return segment.speakerLabel ?? segment.speakerEntityId ?? "Unknown";
 }
 
 function careAboutMatches(text: string, careAbout: string): boolean {
@@ -193,19 +169,21 @@ function findAttendeeEmail(
 }
 
 function parseDecision(
-  segment: MeetingGhostTranscriptSegment,
+  segment: TranscriptSegment,
   index: number,
 ): MeetingGhostDecision | null {
-  const text = stripSpeakerPrefix(segment.text);
-  const match = text.match(DECISION_PREFIX_RE);
-  if (!match?.[1]) return null;
-  const decision = compact(match[1]);
-  if (!decision) return null;
+  const text = compact(segment.text);
+  const decision =
+    text.match(DECISION_PREFIX_RE)?.[1] ??
+    text.match(SPOKEN_DECISION_RE)?.groups?.body ??
+    null;
+  const compacted = decision ? compact(decision) : "";
+  if (!compacted) return null;
   return {
-    id: stableId(["decision", String(index), decision]),
-    text: decision,
-    speaker: segment.speaker,
-    sourceOffsetMs: segment.offsetMs ?? null,
+    id: stableId(["decision", String(index), compacted]),
+    text: compacted,
+    speaker: speakerOf(segment),
+    sourceOffsetMs: segment.startMs,
   };
 }
 
@@ -272,13 +250,13 @@ function parseDueDate(
 
 function parseCommitment(
   transcript: MeetingGhostTranscript,
-  segment: MeetingGhostTranscriptSegment,
+  segment: TranscriptSegment,
   index: number,
 ): MeetingGhostCommitment | null {
-  const text = stripSpeakerPrefix(segment.text);
+  const text = compact(segment.text);
   const parsed = parseCommitmentBody(text);
   if (!parsed) return null;
-  const who = parsed.who ?? segment.speaker;
+  const who = parsed.who ?? speakerOf(segment);
   const dueDate = parseDueDate(parsed.dueText, transcript.startedAt);
   return {
     id: stableId(["commitment", String(index), who, parsed.what]),
@@ -288,7 +266,7 @@ function parseCommitment(
     dueText: parsed.dueText,
     dueDate,
     sourceText: text,
-    sourceOffsetMs: segment.offsetMs ?? null,
+    sourceOffsetMs: segment.startMs,
   };
 }
 
@@ -296,10 +274,20 @@ function buildFollowUpApproval(
   transcript: MeetingGhostTranscript,
   owner: MeetingGhostOwnerContext,
   commitment: MeetingGhostCommitment,
-): MeetingGhostApprovalIntent | null {
+): ApprovalEnqueueInput | null {
   if (!commitment.recipientEmail) return null;
   const subject = `Follow-up from ${transcript.title}`;
   const due = commitment.dueText ? ` by ${commitment.dueText}` : "";
+  const payload: ApprovalPayload = {
+    action: "send_email",
+    to: [commitment.recipientEmail],
+    cc: [],
+    bcc: [],
+    subject,
+    body: `${commitment.who},\n\nFollowing up from ${transcript.title}: please ${commitment.what}${due}.\n\n${owner.ownerDisplayName}`,
+    threadId: null,
+    replyToMessageId: null,
+  };
   return {
     requestedBy: owner.requestedBy,
     subjectUserId: owner.ownerUserId,
@@ -307,16 +295,7 @@ function buildFollowUpApproval(
     channel: "email",
     reason: `Queue owner-approved follow-up for ${commitment.who} from ${transcript.title}`,
     expiresAt: owner.approvalExpiresAt,
-    payload: {
-      action: "send_email",
-      to: [commitment.recipientEmail],
-      cc: [],
-      bcc: [],
-      subject,
-      body: `${commitment.who},\n\nFollowing up from ${transcript.title}: please ${commitment.what}${due}.\n\n${owner.ownerDisplayName}`,
-      threadId: null,
-      replyToMessageId: null,
-    },
+    payload,
   };
 }
 
@@ -330,6 +309,16 @@ function buildCalendarIntent(
   }
   const startsAtMs = Date.parse(`${commitment.dueDate}T09:00:00.000Z`);
   if (Number.isNaN(startsAtMs)) return null;
+  const payload: ApprovalPayload = {
+    action: "schedule_event",
+    calendarId: owner.calendarId,
+    title: `Deadline: ${commitment.what}`,
+    startsAtMs,
+    endsAtMs: startsAtMs + 30 * 60 * 1000,
+    attendees: [commitment.recipientEmail],
+    location: null,
+    description: `Commitment from ${transcript.title}: ${commitment.sourceText}`,
+  };
   return {
     commitmentId: commitment.id,
     approval: {
@@ -339,16 +328,7 @@ function buildCalendarIntent(
       channel: "google_calendar",
       reason: `Place deadline for ${commitment.who}'s commitment from ${transcript.title}`,
       expiresAt: owner.approvalExpiresAt,
-      payload: {
-        action: "schedule_event",
-        calendarId: owner.calendarId,
-        title: `Deadline: ${commitment.what}`,
-        startsAtMs,
-        endsAtMs: startsAtMs + 30 * 60 * 1000,
-        attendees: [commitment.recipientEmail],
-        location: null,
-        description: `Commitment from ${transcript.title}: ${commitment.sourceText}`,
-      },
+      payload,
     },
   };
 }
@@ -384,7 +364,12 @@ export function analyzeMeetingGhostTranscript(input: {
     const decision = parseDecision(segment, index);
     if (decision) decisions.push(decision);
 
-    const commitment = parseCommitment(input.transcript, segment, index);
+    // A group decision ("We decided to…", "The team agreed to…") is not an
+    // individual's action item — skip commitment extraction on the same
+    // segment so a collective verb never becomes a per-person follow-up.
+    const commitment = decision
+      ? null
+      : parseCommitment(input.transcript, segment, index);
     if (commitment) commitments.push(commitment);
 
     for (const careAbout of input.owner.careAbouts) {
@@ -392,9 +377,9 @@ export function analyzeMeetingGhostTranscript(input: {
         careHits.push({
           id: stableId(["care", String(index), careAbout]),
           careAbout,
-          speaker: segment.speaker,
-          text: stripSpeakerPrefix(segment.text),
-          sourceOffsetMs: segment.offsetMs ?? null,
+          speaker: speakerOf(segment),
+          text: compact(segment.text),
+          sourceOffsetMs: segment.startMs,
         });
       }
     }
@@ -404,7 +389,7 @@ export function analyzeMeetingGhostTranscript(input: {
     .map((commitment) =>
       buildFollowUpApproval(input.transcript, input.owner, commitment),
     )
-    .filter((entry): entry is MeetingGhostApprovalIntent => entry !== null);
+    .filter((entry): entry is ApprovalEnqueueInput => entry !== null);
   const calendarIntents = commitments
     .map((commitment) =>
       buildCalendarIntent(input.transcript, input.owner, commitment),

--- a/plugins/plugin-personal-assistant/test/meeting-ghost.integration.test.ts
+++ b/plugins/plugin-personal-assistant/test/meeting-ghost.integration.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Meeting-ghost consumer integration test.
+ *
+ * Drives `runMeetingGhostForTranscript` against the REAL `PgApprovalQueue` on a
+ * PGlite-backed runtime (same harness as approval-queue.integration.test.ts) —
+ * no mocked queue. Proves the dead-code gap is closed: a realistic diarized
+ * `TranscriptSegment[]` flows through the pure analyzer and every derived
+ * follow-up/calendar approval lands as a real, resolvable `pending` row the
+ * owner can approve.
+ *
+ * Run: bunx vitest run plugins/plugin-personal-assistant/test/meeting-ghost.integration.test.ts
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentRuntime } from "@elizaos/core";
+import { AgentEventService } from "@elizaos/core";
+import { schedulingPlugin } from "@elizaos/plugin-scheduling";
+import type { TranscriptSegment } from "@elizaos/shared";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createRealTestRuntime } from "../../../packages/test/helpers/real-runtime.ts";
+import { createApprovalQueue } from "../src/lifeops/approval-queue.js";
+import type { ApprovalQueue } from "../src/lifeops/approval-queue.types.js";
+import { runMeetingGhostForTranscript } from "../src/lifeops/meeting-ghost/consumer.js";
+import { personalAssistantPlugin } from "../src/plugin.js";
+
+let runtime: AgentRuntime;
+let cleanup: () => Promise<void>;
+let queue: ApprovalQueue;
+let isolatedStateDir: string;
+let isolatedConfigPath: string;
+
+const isolatedEnvKeys = [
+  "ELIZA_STATE_DIR",
+  "ELIZA_CONFIG_PATH",
+  "ELIZA_PERSIST_CONFIG_PATH",
+  "ELIZAOS_CLOUD_API_KEY",
+  "ELIZAOS_CLOUD_BASE_URL",
+] as const;
+
+const previousEnv = new Map<string, string | undefined>();
+
+function setIsolatedEnv(): void {
+  isolatedStateDir = mkdtempSync(join(tmpdir(), "meeting-ghost-state-"));
+  isolatedConfigPath = join(isolatedStateDir, "eliza.json");
+  writeFileSync(
+    isolatedConfigPath,
+    JSON.stringify({ logging: { level: "error" } }),
+    "utf8",
+  );
+  for (const key of isolatedEnvKeys) {
+    previousEnv.set(key, process.env[key]);
+    delete process.env[key];
+  }
+  process.env.ELIZA_STATE_DIR = isolatedStateDir;
+  process.env.ELIZA_CONFIG_PATH = isolatedConfigPath;
+  process.env.ELIZA_PERSIST_CONFIG_PATH = isolatedConfigPath;
+}
+
+function restoreEnv(): void {
+  for (const key of isolatedEnvKeys) {
+    const value = previousEnv.get(key);
+    if (value === undefined) {
+      delete process.env[key];
+      continue;
+    }
+    process.env[key] = value;
+  }
+}
+
+function seg(
+  speakerLabel: string,
+  startMs: number,
+  text: string,
+): TranscriptSegment {
+  return {
+    id: `${speakerLabel}-${startMs}`,
+    speakerLabel,
+    startMs,
+    endMs: startMs + 8_000,
+    text,
+    words: [],
+  };
+}
+
+beforeAll(async () => {
+  setIsolatedEnv();
+  const result = await createRealTestRuntime({
+    plugins: [schedulingPlugin, personalAssistantPlugin],
+  });
+  runtime = result.runtime;
+  cleanup = result.cleanup;
+  if (!runtime.getService(AgentEventService.serviceType)) {
+    await runtime.registerService(AgentEventService);
+    await runtime.getServiceLoadPromise(AgentEventService.serviceType);
+  }
+  queue = createApprovalQueue(runtime, { agentId: runtime.agentId });
+}, 180_000);
+
+afterAll(async () => {
+  await cleanup();
+  restoreEnv();
+  rmSync(isolatedStateDir, { recursive: true, force: true });
+});
+
+describe("meeting-ghost consumer (real approval queue)", () => {
+  it("enqueues follow-up + calendar approvals from a diarized transcript, resolvable by the owner", async () => {
+    const approvalExpiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+    const result = await runMeetingGhostForTranscript(runtime, {
+      agentId: runtime.agentId,
+      owner: {
+        ownerUserId: "owner-mtg-1",
+        ownerDisplayName: "Shaw",
+        requestedBy: "meeting-ghost",
+        careAbouts: ["launch date"],
+        calendarId: "primary",
+        approvalExpiresAt,
+      },
+      transcript: {
+        meetingId: "ops-sync-integration",
+        title: "Ops Sync",
+        startedAt: "2026-07-06T16:00:00.000Z",
+        attendees: [
+          { name: "Ava", email: "ava@example.com" },
+          { name: "Ben", email: "ben@example.com" },
+        ],
+        segments: [
+          seg("Ava", 0, "Morning, nothing blocking on my side."),
+          seg(
+            "Mira",
+            60_000,
+            "Ava will send the launch-date rollback plan by 2026-07-10.",
+          ),
+          seg(
+            "Mira",
+            120_000,
+            "Ben is going to update the public calendar by 2026-07-10.",
+          ),
+        ],
+      },
+    });
+
+    // Two commitments → two follow-up emails + two dated calendar deadlines.
+    expect(result.analysis.commitments).toHaveLength(2);
+    expect(result.enqueued).toHaveLength(4);
+    expect(result.enqueued.every((r) => r.state === "pending")).toBe(true);
+
+    const actions = result.enqueued.map((r) => r.action).sort();
+    expect(actions).toEqual([
+      "schedule_event",
+      "schedule_event",
+      "send_email",
+      "send_email",
+    ]);
+
+    // The rows are real, listable, and resolvable — not a fire-and-forget stub.
+    const pending = await queue.list({
+      subjectUserId: "owner-mtg-1",
+      state: "pending",
+      action: null,
+      limit: 20,
+    });
+    expect(pending.length).toBeGreaterThanOrEqual(4);
+
+    const firstEmail = result.enqueued.find((r) => r.action === "send_email");
+    if (!firstEmail) throw new Error("expected a send_email approval");
+    const approved = await queue.approve(firstEmail.id, {
+      resolvedBy: "owner-mtg-1",
+      resolutionReason: "send it",
+    });
+    expect(approved.state).toBe("approved");
+    if (approved.payload.action !== "send_email") {
+      throw new Error("expected send_email payload");
+    }
+    expect(approved.payload.to).toEqual(["ava@example.com"]);
+  }, 60_000);
+});

--- a/plugins/plugin-personal-assistant/test/meeting-ghost.test.ts
+++ b/plugins/plugin-personal-assistant/test/meeting-ghost.test.ts
@@ -1,16 +1,38 @@
 /**
  * Tests for the post-meeting transcript producer.
  *
- * The harness uses a seeded transcript rather than a live meeting bridge so the
- * LifeOps shape is deterministic: care-about hits, decisions, commitments,
- * approval-queued follow-ups, and calendar deadline intents all have exact
- * assertions before the live joiner path is wired in.
+ * The fixture is a realistic diarized `TranscriptSegment[]` — natural spoken
+ * utterances ("We decided to…", "Ava will send… by Friday", "I'll confirm…"),
+ * NOT pre-formatted "Decision:"/"Action:" lines — so the assertions prove the
+ * extractor actually reads meeting language rather than a shape authored to
+ * match its own regexes. Extraction is deterministic (pure function), so
+ * decisions, care-about hits, commitments, and the canonical
+ * `ApprovalEnqueueInput` follow-ups/calendar deadlines all have exact
+ * assertions. The `.integration.test.ts` sibling proves the consumer drives a
+ * real approval queue.
  */
 
+import type { TranscriptSegment } from "@elizaos/shared";
 import { describe, expect, it } from "vitest";
 import { analyzeMeetingGhostTranscript } from "../src/lifeops/meeting-ghost/index.js";
 
 const approvalExpiresAt = new Date("2026-07-06T20:00:00.000Z");
+
+/** A diarized span with no per-word timing (segment-level highlighting). */
+function seg(
+  speakerLabel: string,
+  startMs: number,
+  text: string,
+): TranscriptSegment {
+  return {
+    id: `${speakerLabel}-${startMs}`,
+    speakerLabel,
+    startMs,
+    endMs: startMs + 8_000,
+    text,
+    words: [],
+  };
+}
 
 function analyzeSeededTranscript() {
   return analyzeMeetingGhostTranscript({
@@ -18,7 +40,7 @@ function analyzeSeededTranscript() {
       ownerUserId: "owner-1",
       ownerDisplayName: "Shaw",
       requestedBy: "meeting-ghost",
-      careAbouts: ["launch date moves"],
+      careAbouts: ["launch date"],
       calendarId: "primary",
       approvalExpiresAt,
     },
@@ -33,72 +55,81 @@ function analyzeSeededTranscript() {
         { name: "Priya", email: "priya@example.com" },
       ],
       segments: [
-        {
-          speaker: "Mira",
-          offsetMs: 30_000,
-          text: "Budget is unchanged and the support rotation is fine.",
-        },
-        {
-          speaker: "Ava",
-          offsetMs: 120_000,
-          text: "Decision: launch date moves from July 18 to July 22 because QA found a payments blocker.",
-        },
-        {
-          speaker: "Ben",
-          offsetMs: 180_000,
-          text: "Decision: keep the pricing announcement embargoed until partner sign-off.",
-        },
-        {
-          speaker: "Ava",
-          offsetMs: 240_000,
-          text: "Action: Ava will send the launch-date rollback plan by Friday.",
-        },
-        {
-          speaker: "Ben",
-          offsetMs: 300_000,
-          text: "Action: Ben to update the public calendar by 2026-07-10.",
-        },
-        {
-          speaker: "Priya",
-          offsetMs: 360_000,
-          text: "I will confirm partner sign-off by tomorrow.",
-        },
+        seg(
+          "Mira",
+          30_000,
+          "Budget is unchanged and the support rotation is fine.",
+        ),
+        seg(
+          "Ava",
+          120_000,
+          "We decided to move the launch date from July 18 to July 22 because QA found a payments blocker.",
+        ),
+        seg(
+          "Ben",
+          180_000,
+          "The team agreed to keep the pricing announcement embargoed until partner sign-off.",
+        ),
+        seg(
+          "Mira",
+          240_000,
+          "Ava will send the launch-date rollback plan by Friday.",
+        ),
+        seg(
+          "Mira",
+          300_000,
+          "Ben is going to update the public calendar by 2026-07-10.",
+        ),
+        seg("Priya", 360_000, "I'll confirm partner sign-off by tomorrow."),
       ],
     },
   });
 }
 
 describe("meeting ghost transcript analysis", () => {
-  it("fires care-about hits for launch-date movement while ignoring unrelated transcript", () => {
+  it("fires care-about hits on every launch-date mention while ignoring unrelated transcript", () => {
     const analysis = analyzeSeededTranscript();
 
-    expect(analysis.careHits).toHaveLength(1);
+    // "launch date" surfaces in the reprioritization decision and in the
+    // rollback-plan action item; the owner cares about both.
+    expect(analysis.careHits.map((hit) => hit.speaker)).toEqual(["Ava", "Mira"]);
     expect(analysis.careHits[0]).toMatchObject({
-      careAbout: "launch date moves",
+      careAbout: "launch date",
       speaker: "Ava",
-      text: "Decision: launch date moves from July 18 to July 22 because QA found a payments blocker.",
+      text: "We decided to move the launch date from July 18 to July 22 because QA found a payments blocker.",
     });
+    // The word-order-shifted phrase ("move the launch date") still matches the
+    // care-about token set — extraction reads meaning, not a canned prefix.
     expect(analysis.careHits.map((hit) => hit.text).join("\n")).not.toContain(
       "support rotation",
     );
   });
 
-  it("keeps the digest to three lines and retains the seeded decisions first", () => {
+  it("extracts spoken decisions without an authored 'Decision:' prefix", () => {
+    const analysis = analyzeSeededTranscript();
+
+    expect(analysis.decisions.map((d) => d.text)).toEqual([
+      "move the launch date from July 18 to July 22 because QA found a payments blocker",
+      "keep the pricing announcement embargoed until partner sign-off",
+    ]);
+    expect(analysis.decisions[0].speaker).toBe("Ava");
+    expect(analysis.decisions[0].sourceOffsetMs).toBe(120_000);
+  });
+
+  it("keeps the digest to three lines and retains the decisions first", () => {
     const analysis = analyzeSeededTranscript();
 
     expect(analysis.digestLines).toHaveLength(3);
     expect(analysis.digestLines[0]).toBe(
-      "Decision: launch date moves from July 18 to July 22 because QA found a payments blocker.",
+      "Decision: move the launch date from July 18 to July 22 because QA found a payments blocker",
     );
     expect(analysis.digestLines[1]).toBe(
-      "Decision: keep the pricing announcement embargoed until partner sign-off.",
+      "Decision: keep the pricing announcement embargoed until partner sign-off",
     );
-    expect(analysis.digestLines[2]).toContain(
-      "Care-about hit (launch date moves)",
-    );
+    expect(analysis.digestLines[2]).toContain("Care-about hit (launch date)");
   });
 
-  it("extracts exact who/what/when commitments from explicit transcript language", () => {
+  it("extracts exact who/what/when commitments from natural transcript language", () => {
     const analysis = analyzeSeededTranscript();
 
     expect(analysis.commitments).toEqual([
@@ -108,6 +139,7 @@ describe("meeting ghost transcript analysis", () => {
         what: "send the launch-date rollback plan",
         dueText: "Friday",
         dueDate: "2026-07-10",
+        sourceOffsetMs: 240_000,
       }),
       expect.objectContaining({
         who: "Ben",
@@ -115,6 +147,7 @@ describe("meeting ghost transcript analysis", () => {
         what: "update the public calendar",
         dueText: "2026-07-10",
         dueDate: "2026-07-10",
+        sourceOffsetMs: 300_000,
       }),
       expect.objectContaining({
         who: "Priya",
@@ -122,27 +155,34 @@ describe("meeting ghost transcript analysis", () => {
         what: "confirm partner sign-off",
         dueText: "tomorrow",
         dueDate: "2026-07-07",
+        sourceOffsetMs: 360_000,
       }),
     ]);
   });
 
-  it("queues follow-up drafts under owner approval with recipients and deadlines", () => {
+  it("emits canonical ApprovalEnqueueInput follow-ups ready for the approval queue", () => {
     const analysis = analyzeSeededTranscript();
 
     expect(analysis.followUpApprovals).toHaveLength(3);
-    expect(analysis.followUpApprovals[0]).toMatchObject({
+    // Shape matches ApprovalEnqueueInput exactly (feeds ApprovalQueue.enqueue).
+    expect(analysis.followUpApprovals[0]).toEqual({
       requestedBy: "meeting-ghost",
       subjectUserId: "owner-1",
       action: "send_email",
       channel: "email",
+      reason: "Queue owner-approved follow-up for Ava from Ops Sync",
       expiresAt: approvalExpiresAt,
       payload: {
         action: "send_email",
         to: ["ava@example.com"],
+        cc: [],
+        bcc: [],
         subject: "Follow-up from Ops Sync",
         body: expect.stringContaining(
           "please send the launch-date rollback plan by Friday",
         ),
+        threadId: null,
+        replyToMessageId: null,
       },
     });
   });
@@ -178,5 +218,36 @@ describe("meeting ghost transcript analysis", () => {
         }),
       }),
     ]);
+  });
+
+  it("ignores small talk and unassignable chatter (no false commitments)", () => {
+    const analysis = analyzeMeetingGhostTranscript({
+      owner: {
+        ownerUserId: "owner-1",
+        ownerDisplayName: "Shaw",
+        requestedBy: "meeting-ghost",
+        careAbouts: ["launch date"],
+        calendarId: "primary",
+        approvalExpiresAt,
+      },
+      transcript: {
+        meetingId: "chatter-only",
+        title: "Standup",
+        startedAt: "2026-07-06T16:00:00.000Z",
+        attendees: [{ name: "Mira", email: "mira@example.com" }],
+        segments: [
+          seg("Mira", 0, "Morning everyone, how was the weekend?"),
+          seg("Mira", 5_000, "The coffee machine is broken again."),
+          seg("Mira", 10_000, "Anyway, nothing blocking on my side."),
+        ],
+      },
+    });
+
+    expect(analysis.decisions).toHaveLength(0);
+    expect(analysis.commitments).toHaveLength(0);
+    expect(analysis.careHits).toHaveLength(0);
+    expect(analysis.followUpApprovals).toHaveLength(0);
+    expect(analysis.calendarIntents).toHaveLength(0);
+    expect(analysis.digestLines).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary
Follow-up rework of #15110 (merged as dead code). Converts the meeting-ghost transcript producer from an unreachable, canonical-type-duplicating module into real, wired, integration-tested code.

- **Canonical types**: input is now `@elizaos/shared` `TranscriptSegment` (the shape `plugin-meetings` actually produces); outputs are canonical `ApprovalEnqueueInput`/`ApprovalPayload` that feed `ApprovalQueue.enqueue()` with zero re-mapping. Removed the hand-rolled `MeetingGhostApprovalIntent`/`MeetingGhostTranscriptSegment` duplicates.
- **Real consumer**: new `meeting-ghost/consumer.ts` — `runMeetingGhostForTranscript()` analyzes a real transcript and enqueues derived approvals through the existing approval queue (no new scheduler/knowledge-store). Exported from the lifeops barrel — no longer dead.
- **Real tests**: unit fixture is now realistic diarized utterances (not authored `Decision:`/`Action:` prefixes), extractor upgraded for spoken forms + group-decision guard + a zero-false-positive small-talk case; new integration test drives the consumer against the **real PGlite `PgApprovalQueue`** producing listable/approvable rows.

## Verification
- `typecheck` (tsc -p tsconfig.build.json): 0 errors
- `test/meeting-ghost.test.ts`: 7/7 ; `test/meeting-ghost.integration.test.ts`: 1/1 (real PGlite)
- `audit:error-policy-ratchet`: clean

## Honest scope notes
- Extraction remains heuristic/regex (tuned to natural spoken forms); a `runtime.useModel` extraction pass (per #14870, like `bill-extraction.ts`) is the robust long-term answer, out of scope here.
- The consumer is a reachable function; no auto-trigger is wired (plugin-meetings emits no finalize event) — a scheduled-task watcher over the transcripts table is deferred pending owner direction rather than adding scheduling surface unprompted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
