### PR TITLE
fix(ui): clear character editor mobile actions

### DIFF
--- a/packages/ui/src/components/character/CharacterEditorPanels.tsx
+++ b/packages/ui/src/components/character/CharacterEditorPanels.tsx
@@ -214,14 +214,14 @@ export function CharacterIdentityPanel({
         <Textarea
           ref={systemRef}
           value={systemText}
-          rows={10}
+          rows={4}
           placeholder={t("charactereditor.SystemPromptPlaceholder", {
             defaultValue: "Write in first person...",
           })}
           onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
             handleFieldEdit("system", e.target.value)
           }
-          className="w-full resize-none min-h-[10rem] overflow-x-hidden rounded-none border-0 border-b border-border/40 bg-transparent px-0 py-2 font-mono text-xs leading-relaxed text-txt lg:min-h-[14rem]"
+          className="w-full resize-none min-h-[7rem] overflow-x-hidden rounded-none border-0 border-b border-border/40 bg-transparent px-0 py-2 font-mono text-xs leading-relaxed text-txt sm:min-h-[10rem] lg:min-h-[14rem]"
           {...systemAgentProps}
         />
       </div>
@@ -232,14 +232,14 @@ export function CharacterIdentityPanel({
         <Textarea
           ref={bioRef}
           value={bioText}
-          rows={8}
+          rows={3}
           placeholder={t("charactereditor.AboutMePlaceholder", {
             defaultValue: "Describe who your agent is...",
           })}
           onChange={(e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
             handleFieldEdit("bio", e.target.value)
           }
-          className="w-full resize-none min-h-[6rem] overflow-x-hidden rounded-none border-0 border-b border-border/40 bg-transparent px-0 py-2 font-mono text-xs leading-relaxed text-txt lg:min-h-[8rem]"
+          className="w-full resize-none min-h-[4.5rem] overflow-x-hidden rounded-none border-0 border-b border-border/40 bg-transparent px-0 py-2 font-mono text-xs leading-relaxed text-txt sm:min-h-[6rem] lg:min-h-[8rem]"
           {...bioAgentProps}
         />
       </div>


### PR DESCRIPTION
## Summary

- compact the character editor identity textareas on phone portrait
- keep tablet and desktop textarea heights at the existing roomy breakpoints
- clear the `Add rule` / conversation actions above the floating chat composer

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: https://github.com/elizaOS/eliza/actions/runs/28831588013/artifacts/8124937587 contains the failing `builtin-character mobile-portrait` app-audit screenshot showing the composer overlapping the style controls.

<!-- evidence-row:after-screenshots -->
- After screenshots: https://github.com/elizaOS/eliza/pull/15176/checks plus local filtered app-audit artifacts `packages/app/aesthetic-audit-output/mobile-portrait/builtin-character.png` and `packages/app/aesthetic-audit-output/mobile-portrait/builtin-character-select.png`, manually reviewed after both focused mobile portrait audits passed. OCR visual text review is covered by the same app-audit artifact/checks link.

<!-- evidence-row:walkthrough-video -->
- Walkthrough video: https://github.com/elizaOS/eliza/pull/15176/checks - static responsive layout fix; the app aesthetic audit captures the affected view state instead of a separate interaction video.

<!-- evidence-row:backend-logs -->
- Backend logs: N/A - UI-only layout fix; no backend runtime path changes.

<!-- evidence-row:frontend-logs -->
- Frontend logs: https://github.com/elizaOS/eliza/pull/15176/checks - local filtered `builtin-character mobile-portrait` and `builtin-character-select mobile-portrait` app audits passed with no hover, density, or clearance failures.

<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no prompt, provider, planner, action, or model behavior changes.

<!-- evidence-row:domain-artifacts -->
- Domain artifacts: https://github.com/elizaOS/eliza/pull/15176/checks shows the only code change is the character editor mobile textarea sizing. Local verification: `bun run --cwd packages/ui typecheck` (pass); `bunx @biomejs/biome@2.5.1 check packages/ui/src/components/character/CharacterEditorPanels.tsx` (pass); `ELIZA_UI_SMOKE_SKIP_VIEW_BUILD=1 ELIZA_AUDIT_APP_STRICT=1 ELIZA_AUDIT_APP_STRICT_NEEDS_WORK=1 bun run --cwd packages/app audit:app:capture --grep "builtin-character mobile-portrait"` (pass); `ELIZA_UI_SMOKE_SKIP_VIEW_BUILD=1 ELIZA_AUDIT_APP_STRICT=1 ELIZA_AUDIT_APP_STRICT_NEEDS_WORK=1 bun run --cwd packages/app audit:app:capture --grep "builtin-character-select mobile-portrait"` (pass); `bun run audit:error-policy-ratchet` (pass); `node packages/scripts/view-action-ratchet.mjs` (pass); `git diff --check && git diff --cached --check` (pass).
