### PR TITLE
fix(lifeops): implicit-referent resolver rework — real consumer + honest test + integration coverage (#14848 follow-up)

### DIFF
--- a/packages/docs/action-catalog.md
+++ b/packages/docs/action-catalog.md
@@ -15,7 +15,7 @@ This catalog is generated from `packages/prompts/specs/**` by `bun run --cwd pac
 - **Plugin overlay actions:** 9
 - **Canonical providers:** 23
 - **Core providers:** 23
-- **Registered runtime actions:** 189
+- **Registered runtime actions:** 190
 
 ## Actions
 
@@ -452,6 +452,7 @@ section drifts from source.
 - `PROBE_PLUGIN_CONFIG_REQUIREMENTS` — `packages/core/src/features/plugin-config/actions/probe-plugin-config-requirements.ts`
 - `PROXY_STATUS` — `plugins/plugin-anthropic-proxy/src/actions/proxy-status.action.ts`
 - `REGENERATE_APP_API_KEY` — `plugins/plugin-cloud-apps/src/actions/regenerate-app-api-key.ts`
+- `RESOLVE_REFERENT` — `plugins/plugin-personal-assistant/src/actions/resolve-referent.ts`
 - `RESOLVE_REQUEST` — `plugins/plugin-personal-assistant/src/actions/resolve-request.ts`
 - `RETRIEVE_CHILD_AGENT_RESULTS` — `packages/core/src/features/sub-agent-credentials/actions/retrieve-child-agent-results.ts`
 - `REVOKE_OAUTH_CREDENTIAL` — `packages/core/src/features/oauth/actions/revoke-oauth-credential.ts`

--- a/plugins/plugin-personal-assistant/src/actions/resolve-referent.ts
+++ b/plugins/plugin-personal-assistant/src/actions/resolve-referent.ts
@@ -1,0 +1,164 @@
+/**
+ * `RESOLVE_REFERENT` action — the live consumer of the implicit-referent
+ * resolver.
+ *
+ * When the owner issues an under-specified ask ("book the usual", "clear my
+ * afternoon, you know why"), this action gathers candidate referents from the
+ * owner's real stores ({@link gatherImplicitReferentCandidates} — fact memory
+ * table + OwnerFactStore) and ranks them with {@link resolveImplicitReferent}.
+ * It is preview-first by construction: it never executes the underlying
+ * operation. A confident resolution returns the confirmation preview text (the
+ * downstream executor action still runs behind an approval), and an ambiguous
+ * ask is recorded as an open disambiguating question in the PendingPromptsStore
+ * so the owner's next reply reopens it — the same pending-prompt channel the
+ * scheduled-task runner uses.
+ *
+ * The `prior` (semantic-relevance) signal is supplied by the candidate sources
+ * from each fact's persisted `similarity`/`confidence`; it is not fabricated
+ * here. Embedding/BM25 retrieval will strengthen that prior upstream without
+ * changing this call site.
+ */
+
+import type {
+  Action,
+  ActionResult,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import { hasLifeOpsAccess } from "../lifeops/access.js";
+import { gatherImplicitReferentCandidates } from "../lifeops/implicit-referents/candidate-sources.js";
+import { resolveImplicitReferent } from "../lifeops/implicit-referents/index.js";
+import { resolvePendingPromptsStore } from "../lifeops/pending-prompts/store.js";
+import { messageText } from "../lifeops/voice/grounded-reply.js";
+
+/**
+ * Markers a bare ask carries when it points at prior context rather than naming
+ * its own referent. Only these route to the resolver; a fully-specified ask
+ * needs no referent resolution and should reach its domain action directly.
+ */
+const IMPLICIT_MARKERS = [
+  "the usual",
+  "you know why",
+  "you know which",
+  "same as last time",
+  "same reason",
+  "last time",
+  "as always",
+  "like always",
+  "the same one",
+] as const;
+
+function isImplicitAsk(ask: string): boolean {
+  const normalized = ask.toLowerCase();
+  return IMPLICIT_MARKERS.some((marker) => normalized.includes(marker));
+}
+
+export const resolveReferentAction: Action & {
+  suppressPostActionContinuation?: boolean;
+} = {
+  name: "RESOLVE_REFERENT",
+  similes: [
+    "RESOLVE_IMPLICIT_REFERENT",
+    "DISAMBIGUATE_REFERENT",
+    "WHICH_ONE",
+    "THE_USUAL",
+  ],
+  description:
+    "Resolve an under-specified owner ask ('book the usual', 'clear my afternoon, you know why', 'same as last time') by ranking candidate referents from the owner's facts and preferences. Preview-first: returns the resolved interpretation for confirmation, or asks one disambiguating question. Does NOT execute the underlying operation.",
+  descriptionCompressed:
+    "resolve implicit owner ask ('the usual'/'you know why'/'same as last time') -> confirm interpretation or ask one disambiguating question; preview-first, no execution",
+  routingHint:
+    "under-specified ask that leans on prior context ('book the usual', 'you know why', 'same as last time') -> RESOLVE_REFERENT; a fully-named request goes straight to its domain action (CALENDAR/OWNER_REMINDERS/...)",
+  tags: ["domain:assistant", "capability:read", "surface:internal"],
+  contexts: ["memory", "tasks", "calendar", "messaging"],
+  roleGate: { minRole: "OWNER" },
+  suppressPostActionContinuation: true,
+  validate: async (_runtime: IAgentRuntime, message: Memory) =>
+    isImplicitAsk(messageText(message)),
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    _state: State | undefined,
+    _options,
+    callback,
+  ): Promise<ActionResult> => {
+    if (!(await hasLifeOpsAccess(runtime, message))) {
+      const text = "Resolving your requests is restricted to the owner.";
+      await callback?.({ text, source: "action", action: "RESOLVE_REFERENT" });
+      return { text, success: false, data: { error: "PERMISSION_DENIED" } };
+    }
+
+    const ask = messageText(message).trim();
+    const candidates = await gatherImplicitReferentCandidates(runtime);
+    const resolution = resolveImplicitReferent({
+      ask,
+      nowIso: new Date().toISOString(),
+      candidates,
+    });
+
+    if (resolution.decision === "resolved") {
+      const text = resolution.confirmationText;
+      await callback?.({ text, source: "action", action: "RESOLVE_REFERENT" });
+      return {
+        text,
+        success: true,
+        data: {
+          decision: "resolved",
+          selectedId: resolution.selected.candidate.id,
+          executorHint: resolution.selected.candidate.executorHint ?? null,
+          score: resolution.selected.score,
+        },
+      };
+    }
+
+    // Ambiguous ask: record the disambiguating question as an open pending
+    // prompt so the owner's next reply reopens this thread, then surface it.
+    const text = resolution.question;
+    await resolvePendingPromptsStore(runtime).record({
+      roomId: message.roomId,
+      taskId: `implicit-referent:${message.id ?? ask}`,
+      promptSnippet: text,
+      firedAt: new Date().toISOString(),
+      expectedReplyKind: "free_form",
+    });
+    await callback?.({ text, source: "action", action: "RESOLVE_REFERENT" });
+    return {
+      text,
+      success: true,
+      data: {
+        decision: "ask",
+        rankedIds: resolution.ranked.map((entry) => entry.candidate.id),
+      },
+    };
+  },
+  parameters: [],
+  examples: [
+    [
+      {
+        name: "{{name1}}",
+        content: { text: "Book the usual." },
+      },
+      {
+        name: "{{agentName}}",
+        content: {
+          text: 'Resolving "Book the usual." as booking the Osteria corner table.',
+          action: "RESOLVE_REFERENT",
+        },
+      },
+    ],
+    [
+      {
+        name: "{{name1}}",
+        content: { text: "Clear it, you know why." },
+      },
+      {
+        name: "{{agentName}}",
+        content: {
+          text: "Do you mean the board prep block or the investor prep block?",
+          action: "RESOLVE_REFERENT",
+        },
+      },
+    ],
+  ],
+};

--- a/plugins/plugin-personal-assistant/src/index.ts
+++ b/plugins/plugin-personal-assistant/src/index.ts
@@ -47,6 +47,7 @@ export {
   personalAssistantAction,
 } from "./actions/owner-surfaces.js";
 export { remoteDesktopAction } from "./actions/remote-desktop.js";
+export { resolveReferentAction } from "./actions/resolve-referent.js";
 export { resolveRequestAction } from "./actions/resolve-request.js";
 export { voiceCallAction } from "./actions/voice-call.js";
 export * from "./api/client-lifeops.js";

--- a/plugins/plugin-personal-assistant/src/lifeops/implicit-referents/candidate-sources.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/implicit-referents/candidate-sources.ts
@@ -1,0 +1,173 @@
+/**
+ * Gathers implicit-referent candidates from the owner's real memory stores so
+ * `resolveImplicitReferent` ranks live data, not fixtures.
+ *
+ * Candidates come from two existing stores — no new store is introduced:
+ *   - the `facts` memory table (free-form durable/current owner facts), which is
+ *     also what the core FACTS provider reads; and
+ *   - the {@link OwnerFactStore} scalar record (preferred name, travel
+ *     preferences, notification channel), which carries the owner's typed
+ *     policy/preference facts.
+ *
+ * The `prior` the resolver consumes as its semantic-relevance signal is taken
+ * from each candidate's own persisted signal, never fabricated: a fact memory
+ * retrieved via semantic search carries `similarity`; absent that, its stored
+ * `metadata.confidence` is the honest per-fact weight. When neither exists the
+ * `prior` is simply omitted and the resolver ranks on its lexical/signal terms
+ * alone. Richer embedding/BM25 retrieval (the standing-preferences lane) will
+ * populate `similarity` on more candidates without changing this contract.
+ */
+
+import type { FactMetadata, IAgentRuntime, Memory } from "@elizaos/core";
+import { resolveOwnerFactStore } from "../owner/fact-store.js";
+import type {
+  ImplicitReferentCandidate,
+  ImplicitReferentSource,
+} from "./index.js";
+
+/** How many recent fact memories to pull before the resolver ranks them. */
+const FACT_CANDIDATE_LIMIT = 40;
+
+/**
+ * Read a fact memory's metadata as {@link FactMetadata}. Fact-table rows store
+ * the fact shape, but `Memory.metadata` is typed as the message-oriented union,
+ * so a narrow is required — the same access the core FACTS provider performs.
+ */
+function factMetadata(memory: Memory): FactMetadata {
+  const meta = memory.metadata;
+  if (!meta || typeof meta !== "object" || Array.isArray(meta)) return {};
+  return meta as FactMetadata;
+}
+
+function factText(memory: Memory): string {
+  const text = memory.content.text;
+  return typeof text === "string" ? text.trim() : "";
+}
+
+/**
+ * The semantic-relevance prior for a fact memory. `similarity` is set by the
+ * adapter only when the fact was retrieved via embedding search; `confidence`
+ * is the persisted extractor weight. Both are genuine [0,1] signals — we never
+ * substitute a literal for a missing one, so an unranked fact simply has no
+ * prior.
+ */
+function factPrior(memory: Memory): number | undefined {
+  if (
+    typeof memory.similarity === "number" &&
+    Number.isFinite(memory.similarity)
+  ) {
+    return memory.similarity;
+  }
+  const confidence = factMetadata(memory).confidence;
+  if (typeof confidence === "number" && Number.isFinite(confidence)) {
+    return confidence;
+  }
+  return undefined;
+}
+
+function factTags(memory: Memory): string[] | undefined {
+  const keywords = factMetadata(memory).keywords;
+  if (!Array.isArray(keywords)) return undefined;
+  const tags = keywords.filter(
+    (keyword): keyword is string =>
+      typeof keyword === "string" && keyword.length > 0,
+  );
+  return tags.length > 0 ? tags : undefined;
+}
+
+function factOccurredAt(memory: Memory): string | undefined {
+  const validAt = factMetadata(memory).validAt;
+  if (typeof validAt === "string" && Number.isFinite(Date.parse(validAt))) {
+    return validAt;
+  }
+  if (
+    typeof memory.createdAt === "number" &&
+    Number.isFinite(memory.createdAt)
+  ) {
+    return new Date(memory.createdAt).toISOString();
+  }
+  return undefined;
+}
+
+function factToCandidate(
+  memory: Memory,
+  index: number,
+): ImplicitReferentCandidate | null {
+  const summary = factText(memory);
+  if (!summary) return null;
+  const source: ImplicitReferentSource = "owner_fact";
+  const label =
+    summary.length > 60 ? `${summary.slice(0, 59).trimEnd()}…` : summary;
+  const prior = factPrior(memory);
+  const tags = factTags(memory);
+  const occurredAt = factOccurredAt(memory);
+  return {
+    id: memory.id ?? `fact:${index}`,
+    source,
+    label,
+    summary,
+    confirmation: summary,
+    ...(tags ? { tags } : {}),
+    ...(occurredAt ? { occurredAt } : {}),
+    ...(prior !== undefined ? { prior } : {}),
+  };
+}
+
+/**
+ * Project the owner's scalar preference facts (travel + notification channel)
+ * into referent candidates. These are the standing "the usual" preferences a
+ * bare owner ask most often points at, and they live in {@link OwnerFactStore},
+ * not the fact memory table.
+ */
+async function ownerPreferenceCandidates(
+  runtime: IAgentRuntime,
+): Promise<ImplicitReferentCandidate[]> {
+  const facts = await resolveOwnerFactStore(runtime).read();
+  const candidates: ImplicitReferentCandidate[] = [];
+  if (facts.travelBookingPreferences) {
+    candidates.push({
+      id: "owner-fact:travelBookingPreferences",
+      source: "owner_fact",
+      label: "usual travel booking preferences",
+      summary: facts.travelBookingPreferences.value,
+      confirmation: `using your usual travel preferences (${facts.travelBookingPreferences.value})`,
+      tags: ["usual", "travel"],
+      occurredAt: facts.travelBookingPreferences.provenance.recordedAt,
+    });
+  }
+  if (facts.preferredNotificationChannel) {
+    candidates.push({
+      id: "owner-fact:preferredNotificationChannel",
+      source: "owner_fact",
+      label: "preferred notification channel",
+      summary: `Owner prefers ${facts.preferredNotificationChannel.value} for notifications.`,
+      confirmation: `sending it via your usual channel (${facts.preferredNotificationChannel.value})`,
+      tags: ["usual", "channel"],
+      occurredAt: facts.preferredNotificationChannel.provenance.recordedAt,
+    });
+  }
+  return candidates;
+}
+
+/**
+ * Assemble the candidate set for an implicit owner ask from the fact memory
+ * table and the owner-fact store. The caller passes the result straight to
+ * {@link resolveImplicitReferent}.
+ */
+export async function gatherImplicitReferentCandidates(
+  runtime: IAgentRuntime,
+): Promise<ImplicitReferentCandidate[]> {
+  const factMemories = await runtime.getMemories({
+    tableName: "facts",
+    agentId: runtime.agentId,
+    count: FACT_CANDIDATE_LIMIT,
+    includeEmbedding: false,
+  });
+  const factCandidates = factMemories
+    .map((memory, index) => factToCandidate(memory, index))
+    .filter(
+      (candidate): candidate is ImplicitReferentCandidate => candidate !== null,
+    );
+  const preferenceCandidates = await ownerPreferenceCandidates(runtime);
+  return [...preferenceCandidates, ...factCandidates];
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/index.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/index.ts
@@ -13,6 +13,7 @@ export * from "./engine.js";
 export * from "./goal-grounding.js";
 export * from "./goal-semantic-evaluator.js";
 export * from "./google-plugin-delegates.js";
+export * from "./implicit-referents/candidate-sources.js";
 export * from "./implicit-referents/index.js";
 export * from "./intent-sync.js";
 export * from "./meeting-ghost/index.js";

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -80,6 +80,7 @@ import {
   personalAssistantAction,
 } from "./actions/owner-surfaces.js";
 import { prioritizeAction } from "./actions/prioritize.js";
+import { resolveReferentAction } from "./actions/resolve-referent.js";
 import { resolveRequestAction } from "./actions/resolve-request.js";
 import { scheduledTaskAction } from "./actions/scheduled-task.js";
 import { voiceCallAction } from "./actions/voice-call.js";
@@ -651,6 +652,7 @@ const rawPersonalAssistantPlugin: Plugin = {
       promoteSubactionsToActions(action),
     ),
     ...promoteSubactionsToActions(personalAssistantAction),
+    resolveReferentAction,
     entityAction,
     ...promoteSubactionsToActions(ownerDocumentsAction),
     ...promoteSubactionsToActions(briefAction),

--- a/plugins/plugin-personal-assistant/test/implicit-referents.test.ts
+++ b/plugins/plugin-personal-assistant/test/implicit-referents.test.ts
@@ -2,8 +2,9 @@
  * Tests for implicit referent resolution.
  *
  * Candidate stores are represented by seeded facts, threads, calendar records,
- * and episodic anchors so the ranking contract is deterministic before live
- * retrieval and executor wiring are added.
+ * and episodic anchors so the ranking contract is deterministic. Each case names
+ * exactly what it proves: lexical/signal ranking, semantic-prior resolution with
+ * a negative control, episodic anchoring, and one-question disambiguation.
  */
 
 import { describe, expect, it } from "vitest";
@@ -52,42 +53,67 @@ describe("implicit referent resolver", () => {
     expect(result.confirmationText).toContain('Resolving "Clear my afternoon');
   });
 
-  it("resolves 'the usual' from owner facts without requiring restaurant-name lexical overlap", () => {
+  it("resolves 'the usual' by semantic prior when neither candidate shares a lexical token with the ask", () => {
+    // "Book the usual." carries no non-stop-word tokens, so lexicalScore is 0 for
+    // every candidate. Both candidates are owner facts tagged "usual", so the
+    // source-signal boost is identical too. The only signal that separates them
+    // is `prior` (the semantic-relevance score a retrieval layer supplies). This
+    // is the case the resolver exists for: pick the right referent with no shared
+    // words. The negative control below confirms `prior` is load-bearing here.
+    const candidates = [
+      {
+        id: "fact:osteria",
+        source: "owner_fact" as const,
+        label: "Osteria corner table",
+        summary: "corner table at Osteria for dinner",
+        confirmation: "booking the Osteria corner table",
+        tags: ["usual", "restaurant", "dinner"],
+        occurredAt: "2026-07-04T20:00:00.000Z",
+        executorHint: "calendar.create_event.preview",
+      },
+      {
+        id: "fact:coffee",
+        source: "owner_fact" as const,
+        label: "Blue Bottle morning order",
+        summary: "oat cappuccino each morning",
+        confirmation: "ordering the morning coffee",
+        tags: ["usual", "coffee", "morning"],
+        occurredAt: "2026-07-04T16:00:00.000Z",
+      },
+    ];
+
     const result = resolveImplicitReferent({
-      ask: "Book the usual for Thursday.",
+      ask: "Book the usual.",
       nowIso,
-      candidates: [
-        {
-          id: "fact:osteria",
-          source: "owner_fact",
-          label: "Osteria corner table preference",
-          summary:
-            "Owner's usual Thursday dinner is a corner table at Osteria at 7pm.",
-          confirmation: "booking the usual Thursday Osteria corner table",
-          tags: ["usual", "weekday", "restaurant", "thursday"],
-          occurredAt: "2026-06-29T20:00:00.000Z",
-          prior: 0.75,
-          executorHint: "calendar.create_event.preview",
-        },
-        {
-          id: "fact:coffee",
-          source: "owner_fact",
-          label: "Blue Bottle morning order",
-          summary: "Owner usually gets an oat cappuccino in the morning.",
-          confirmation: "ordering the usual morning coffee",
-          tags: ["usual", "coffee"],
-          occurredAt: "2026-06-20T16:00:00.000Z",
-          prior: 0.3,
-        },
-      ],
+      candidates: candidates.map((candidate) =>
+        candidate.id === "fact:osteria"
+          ? { ...candidate, prior: 0.95 }
+          : { ...candidate, prior: 0.1 },
+      ),
     });
 
     expect(result.decision).toBe("resolved");
     if (result.decision !== "resolved") throw new Error("expected resolved");
     expect(result.selected.candidate.id).toBe("fact:osteria");
-    expect(result.confirmationText).toContain(
-      "booking the usual Thursday Osteria corner table",
+    // No lexical match fired — the resolution is driven by prior, not overlap.
+    expect(result.selected.evidence).not.toContain('matched "usual"');
+    expect(result.selected.evidence.some((e) => e.startsWith("matched "))).toBe(
+      false,
     );
+    expect(result.selected.evidence).toContain("prior=0.95");
+    expect(result.confirmationText).toContain(
+      "booking the Osteria corner table",
+    );
+
+    // Negative control: strip the semantic prior and the identical facts become
+    // indistinguishable — the resolver must ask rather than guess. This proves
+    // the prior is what carried the resolution above.
+    const withoutPrior = resolveImplicitReferent({
+      ask: "Book the usual.",
+      nowIso,
+      candidates,
+    });
+    expect(withoutPrior.decision).toBe("ask");
   });
 
   it("resolves same-as-last-time asks against episodic anchors", () => {

--- a/plugins/plugin-personal-assistant/test/resolve-referent-action.integration.test.ts
+++ b/plugins/plugin-personal-assistant/test/resolve-referent-action.integration.test.ts
@@ -1,0 +1,190 @@
+/**
+ * `RESOLVE_REFERENT` action — real end-to-end integration test.
+ *
+ * Boots a real PGLite-backed runtime (real `facts` memory table, real cache)
+ * and drives the real action handler — no resolver mock. Proves the live path:
+ * candidate gathering from the fact memory table + OwnerFactStore, ranking by
+ * `resolveImplicitReferent`, a confident resolution returning the confirmation
+ * preview, and an ambiguous ask writing a real disambiguating pending prompt
+ * into the (cache-backed) PendingPromptsStore. Owner access is satisfied by the
+ * agent-as-owner message (`entityId === agentId`, i.e. `isAgentSelf`).
+ *
+ * The runtime is deliberately minimal (no PA plugin barrel) so the store-backed
+ * resolution path is exercised without booting the connector/React graph; the
+ * OwnerFactStore and PendingPromptsStore both fall back to the same cache the
+ * production services use, so behavior is identical.
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  ChannelType,
+  type HandlerOptions,
+  type Memory,
+  type UUID,
+} from "@elizaos/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  createRealTestRuntime,
+  type RealTestRuntimeResult,
+} from "../../../packages/app-core/test/helpers/real-runtime.ts";
+import { resolveReferentAction } from "../src/actions/resolve-referent.js";
+import { resolveOwnerFactStore } from "../src/lifeops/owner/fact-store.js";
+import { resolvePendingPromptsStore } from "../src/lifeops/pending-prompts/store.js";
+
+let testRuntime: RealTestRuntimeResult;
+let runtime: RealTestRuntimeResult["runtime"];
+let stateDir: string;
+let previousStateDir: string | undefined;
+
+const ROOM_ID = "00000000-0000-4000-8000-00000000c0de" as UUID;
+const WORLD_ID = "00000000-0000-4000-8000-0000000000d1" as UUID;
+
+function ownerMessage(text: string): Memory {
+  return {
+    id: crypto.randomUUID() as UUID,
+    entityId: runtime.agentId as UUID,
+    roomId: ROOM_ID,
+    content: { text },
+  } as Memory;
+}
+
+async function seedFact(
+  text: string,
+  metadata: { confidence?: number; keywords?: string[]; validAt?: string },
+): Promise<void> {
+  await runtime.createMemory(
+    {
+      id: crypto.randomUUID() as UUID,
+      entityId: runtime.agentId as UUID,
+      agentId: runtime.agentId as UUID,
+      roomId: ROOM_ID,
+      content: { text },
+      metadata: {
+        type: "custom",
+        source: "test_seed",
+        kind: "durable",
+        category: "preference",
+        ...metadata,
+      },
+    } as unknown as Memory,
+    "facts",
+  );
+}
+
+async function runHandler(text: string) {
+  return resolveReferentAction.handler(
+    runtime,
+    ownerMessage(text),
+    undefined,
+    { parameters: {} } as unknown as HandlerOptions,
+    async () => undefined,
+  );
+}
+
+beforeAll(async () => {
+  previousStateDir = process.env.ELIZA_STATE_DIR;
+  stateDir = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), "resolve-referent-"),
+  );
+  process.env.ELIZA_STATE_DIR = stateDir;
+  testRuntime = await createRealTestRuntime({
+    characterName: "resolve-referent-test-agent",
+  });
+  runtime = testRuntime.runtime;
+  await runtime.ensureWorldExists({
+    id: WORLD_ID,
+    name: "resolve-referent-world",
+    agentId: runtime.agentId,
+  } as Parameters<typeof runtime.ensureWorldExists>[0]);
+  await runtime.ensureConnection({
+    entityId: runtime.agentId,
+    roomId: ROOM_ID,
+    worldId: WORLD_ID,
+    userName: "owner",
+    name: "owner",
+    source: "test",
+    channelId: "resolve-referent-room",
+    type: ChannelType.DM,
+  });
+}, 180_000);
+
+afterAll(async () => {
+  await testRuntime?.cleanup();
+  await fs.promises.rm(stateDir, { recursive: true, force: true });
+  if (previousStateDir === undefined) {
+    delete process.env.ELIZA_STATE_DIR;
+  } else {
+    process.env.ELIZA_STATE_DIR = previousStateDir;
+  }
+});
+
+describe("RESOLVE_REFERENT action (real runtime)", () => {
+  it("validates only for under-specified asks", async () => {
+    await expect(
+      resolveReferentAction.validate(runtime, ownerMessage("Book the usual.")),
+    ).resolves.toBe(true);
+    await expect(
+      resolveReferentAction.validate(
+        runtime,
+        ownerMessage("Book a table at Osteria for 7pm."),
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it("resolves 'the usual' against a high-confidence owner fact and previews it", async () => {
+    // One clearly-dominant fact (high confidence prior + lexical 'usual') and a
+    // weak distractor. The resolver must confidently pick the strong one.
+    await seedFact(
+      "Owner's usual dinner is the corner table at Osteria at 7pm.",
+      { confidence: 0.95, keywords: ["usual", "dinner", "osteria"] },
+    );
+    await seedFact("Owner sometimes grabs coffee.", {
+      confidence: 0.1,
+      keywords: ["coffee"],
+    });
+
+    const result = await runHandler("Book the usual.");
+    expect(result?.success).toBe(true);
+    expect(result?.data?.decision).toBe("resolved");
+    expect(String(result?.text)).toContain("Osteria");
+  });
+
+  it("records a real disambiguating pending prompt when it must ask", async () => {
+    // Two near-identical owner facts leave the resolver unable to choose, so it
+    // asks — and must persist that open question to the PendingPromptsStore.
+    await seedFact(
+      "Owner's usual is the board prep block on Thursday afternoon.",
+      { confidence: 0.6, keywords: ["usual", "board", "thursday"] },
+    );
+    await seedFact(
+      "Owner's usual is the investor prep block on Thursday afternoon.",
+      { confidence: 0.6, keywords: ["usual", "investor", "thursday"] },
+    );
+
+    const before = await resolvePendingPromptsStore(runtime).list(ROOM_ID);
+    const result = await runHandler("Clear the usual for Thursday.");
+    expect(result?.success).toBe(true);
+    // Two equally-weighted facts force a tie the resolver cannot break, so it
+    // asks — and the open question must land as a real pending prompt.
+    expect(result?.data?.decision).toBe("ask");
+    expect(String(result?.text).length).toBeGreaterThan(0);
+    const after = await resolvePendingPromptsStore(runtime).list(ROOM_ID);
+    expect(after.length).toBeGreaterThan(before.length);
+    expect(
+      after.some((prompt) => prompt.taskId.startsWith("implicit-referent:")),
+    ).toBe(true);
+  });
+
+  it("gathers OwnerFactStore preferences as candidates without crashing on empty stores", async () => {
+    await resolveOwnerFactStore(runtime).update(
+      { travelBookingPreferences: "aisle seat, red-eye, TSA-pre" },
+      { source: "profile_save", recordedAt: new Date().toISOString() },
+    );
+    const result = await runHandler("Book the usual travel for me.");
+    expect(result?.success).toBe(true);
+    expect(["resolved", "ask"]).toContain(result?.data?.decision);
+  });
+});

--- a/plugins/plugin-personal-assistant/vitest.src-integration.config.ts
+++ b/plugins/plugin-personal-assistant/vitest.src-integration.config.ts
@@ -46,6 +46,7 @@ export default defineConfig({
       `${packageRootFromRepo}/test/global-pause.integration.test.ts`,
       `${packageRootFromRepo}/test/approval-queue.integration.test.ts`,
       `${packageRootFromRepo}/test/approval-queue-notify-error.integration.test.ts`,
+      `${packageRootFromRepo}/test/resolve-referent-action.integration.test.ts`,
     ],
     exclude: [
       "dist/**",


### PR DESCRIPTION
## Summary
Follow-up rework of #15112 (merged as dead code). Turns the implicit-referent resolver from an unreachable lexical ranker with a misleading test into a real, wired, integration-tested capability.

- **Fixed the over-claiming test**: the old "without restaurant-name lexical overlap" case actually won on the shared token "thursday". Replaced with a genuinely zero-lexical-overlap ask where the only differentiator is the semantic `prior`, plus a negative control (strip `prior` → falls to `ask`) proving `prior` is load-bearing.
- **Real consumer, no new store**: `candidate-sources.ts` gathers candidates from the existing `facts` memory table + `OwnerFactStore`; `prior` comes from each fact's persisted `similarity`/`confidence` (real signal, never fabricated). New `RESOLVE_REFERENT` action (registered) — preview-first (never executes), records the disambiguating question into `PendingPromptsStore` on `ask`.
- **Real E2E**: new integration test drives the real handler on a real PGLite runtime + seeded `facts` table through both resolved-preview and ask-recorded paths (wired into the src-integration CI lane).

## Verification
- typecheck clean; `implicit-referents.test.ts` 4/4; integration 4/4; `audit:error-policy-ratchet` clean.

## Honest notes
- Not blocked on #14693 — `prior` is real today (per-fact confidence/similarity); semantic retrieval would only strengthen it upstream without changing this call site.
- Consumer is a deterministic ranker (no model call), so the real-LLM-trajectory bar is N/A; proof is the real-runtime integration test. A full planner-routes-every-ask interceptor is a larger product decision, out of scope. #14848 left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
