### PR TITLE
fix(ui): resume-from-background reliability — web PWA lifecycle events + WS reconnect + tail refetch

### DIFF
--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -1958,16 +1958,11 @@ async function initializePlatform(): Promise<void> {
     );
   }
 
-  // Foreground/background lifecycle + connectivity are wired on EVERY surface,
-  // including the installed **web** PWA — not only native Capacitor (#PWA-D1).
-  // `createMobileLifecycle` guards every Capacitor call and falls back to
-  // `document.visibilitychange` (pause/resume) and window `online`/`offline`
-  // (network) so it degrades cleanly with no plugins. Before this, the web PWA
-  // never dispatched APP_RESUME_EVENT/APP_PAUSE_EVENT, so a backgrounded PWA
-  // came back with a dead WS + stale transcript and nothing forced a
-  // reconnect/refetch (the exact iOS daily-driver jank). `setAppActive` in the
-  // factory dedupes so a working Capacitor `appStateChange` never double-fires
-  // alongside the visibilitychange fallback on native.
+  // Foreground/background lifecycle + connectivity are wired on every surface,
+  // including installed web PWAs (#PWA-D1). `createMobileLifecycle` guards
+  // Capacitor calls and falls back to `document.visibilitychange` plus window
+  // `online`/`offline`; `setAppActive` dedupes native `appStateChange` so the
+  // browser fallback cannot double-fire resume handling.
   getMobileLifecycle().initializeAppLifecycle();
   void getMobileLifecycle().initializeNetworkListener();
 

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -1958,12 +1958,23 @@ async function initializePlatform(): Promise<void> {
     );
   }
 
+  // Foreground/background lifecycle + connectivity are wired on EVERY surface,
+  // including the installed **web** PWA — not only native Capacitor (#PWA-D1).
+  // `createMobileLifecycle` guards every Capacitor call and falls back to
+  // `document.visibilitychange` (pause/resume) and window `online`/`offline`
+  // (network) so it degrades cleanly with no plugins. Before this, the web PWA
+  // never dispatched APP_RESUME_EVENT/APP_PAUSE_EVENT, so a backgrounded PWA
+  // came back with a dead WS + stale transcript and nothing forced a
+  // reconnect/refetch (the exact iOS daily-driver jank). `setAppActive` in the
+  // factory dedupes so a working Capacitor `appStateChange` never double-fires
+  // alongside the visibilitychange fallback on native.
+  getMobileLifecycle().initializeAppLifecycle();
+  void getMobileLifecycle().initializeNetworkListener();
+
   if (isIOS || isAndroid) {
     await initializeStatusBar();
     await initializeKeyboard();
-    getMobileLifecycle().initializeAppLifecycle();
     initializeMobileRuntimeModeListener();
-    void getMobileLifecycle().initializeNetworkListener();
     void initializeMobileDeviceBridge();
     void initializeMobileAgentTunnel();
     void registerMobileBlockerBackends();
@@ -2075,7 +2086,7 @@ async function initializeKeyboard(): Promise<void> {
 }
 
 /**
- * Live Android/Capacitor lifecycle helper. `main.tsx` keeps its own
+ * Live cross-platform lifecycle helper. `main.tsx` keeps its own
  * status-bar / keyboard wiring, but the app-lifecycle path (foreground/
  * background events + the `visibilitychange` fallback, the hardware-back
  * contract — `dispatchBackIntent()` first, then `history.back()` /

--- a/packages/ui/src/state/AppContext.tsx
+++ b/packages/ui/src/state/AppContext.tsx
@@ -1640,16 +1640,19 @@ function AppProviderInner({
     greetingInFlightConversationRef,
   });
 
-  // ── Capacitor app lifecycle (APP_RESUME / APP_PAUSE) ────────────────
-  // Bridges native lifecycle events into the chat pipeline: aborts
-  // in-flight streams before iOS suspends the process, persists the
-  // active conversation id, and re-probes /api/health on resume so the
-  // renderer notices a respawned FGS / dev server on a new port.
+  // ── App lifecycle (APP_RESUME / APP_PAUSE) ───────────────────────────
+  // Bridges lifecycle events into the chat pipeline on every surface
+  // (native + installed web PWA): aborts in-flight streams before iOS
+  // suspends the process and persists the active conversation id on
+  // pause; on resume re-probes /api/health, forces a WS reconnect, and
+  // refetches the active conversation tail so messages missed while
+  // backgrounded appear (esp. dedicated-agent REST mode with no WS).
   useAppLifecycleEvents({
     activeConversationIdRef,
     conversationMessagesRef,
     chatAbortRef,
     setConversationMessages,
+    loadConversationMessages,
   });
 
   // ── Chat composer draft persistence ────────────────────────────────

--- a/packages/ui/src/state/useAppLifecycleEvents.test.tsx
+++ b/packages/ui/src/state/useAppLifecycleEvents.test.tsx
@@ -1,0 +1,278 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook } from "@testing-library/react";
+import type { MutableRefObject } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConversationMessage } from "../api";
+import { APP_PAUSE_EVENT, APP_RESUME_EVENT } from "../events";
+import type { LoadConversationMessagesResult } from "./internal";
+import {
+  RESUME_DEBOUNCE_MS,
+  useAppLifecycleEvents,
+} from "./useAppLifecycleEvents";
+
+/**
+ * Pins the resume-from-background reliability wiring (dossier D1/D2/D3):
+ *  - APP_RESUME_EVENT (dispatched on the web PWA too, not just native) forces
+ *    a WS reconnect (client.resetConnection) AND refetches the active
+ *    conversation tail so messages missed while backgrounded appear.
+ *  - The resume sequence is debounced so rapid fg/bg flips (or a
+ *    visibilitychange + bfcache pageshow in the same tick) run once.
+ *  - A persisted `pageshow` (iOS bfcache restore) also triggers a resume; a
+ *    non-persisted pageshow does not.
+ *  - Listeners detach on unmount (no leak).
+ *  - APP_PAUSE persists the active conversation id + aborts in-flight streams.
+ * Real hook under jsdom with fake timers to observe the debounce.
+ */
+
+const mocks = vi.hoisted(() => ({
+  client: {
+    resetConnection: vi.fn(),
+    fetch: vi.fn(async () => ({ ok: true })),
+  },
+}));
+
+vi.mock("../api", () => ({
+  client: mocks.client,
+}));
+
+function makeMessages(...ms: ConversationMessage[]): ConversationMessage[] {
+  return ms;
+}
+
+interface SetupOpts {
+  activeId?: string | null;
+  messages?: ConversationMessage[];
+}
+
+function setup(opts: SetupOpts = {}) {
+  const activeConversationIdRef = {
+    // `null` is a meaningful value (no active conversation), so only default
+    // when the key is absent — nullish-coalescing would swallow an explicit null.
+    current: "activeId" in opts ? (opts.activeId ?? null) : "conv-1",
+  } as MutableRefObject<string | null>;
+  const conversationMessagesRef = {
+    current: opts.messages ?? [],
+  } as MutableRefObject<ConversationMessage[]>;
+  const chatAbortRef = {
+    current: null,
+  } as MutableRefObject<AbortController | null>;
+  const setConversationMessages = vi.fn();
+  const loadConversationMessages = vi.fn(
+    async (): Promise<LoadConversationMessagesResult> => ({ ok: true }),
+  );
+
+  const view = renderHook(() =>
+    useAppLifecycleEvents({
+      activeConversationIdRef,
+      conversationMessagesRef,
+      chatAbortRef,
+      setConversationMessages,
+      loadConversationMessages,
+    }),
+  );
+
+  return {
+    activeConversationIdRef,
+    conversationMessagesRef,
+    chatAbortRef,
+    setConversationMessages,
+    loadConversationMessages,
+    view,
+  };
+}
+
+function dispatchResume(): void {
+  document.dispatchEvent(new Event(APP_RESUME_EVENT));
+}
+
+function dispatchPause(): void {
+  document.dispatchEvent(new Event(APP_PAUSE_EVENT));
+}
+
+function dispatchPageShow(persisted: boolean): void {
+  // jsdom doesn't construct PageTransitionEvent with `persisted`; synthesize it.
+  const event = new Event("pageshow") as PageTransitionEvent & {
+    persisted: boolean;
+  };
+  Object.defineProperty(event, "persisted", { value: persisted });
+  window.dispatchEvent(event);
+}
+
+describe("useAppLifecycleEvents", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.client.resetConnection.mockClear();
+    mocks.client.fetch.mockClear();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    // Unmount every rendered hook FIRST (detaches its listeners + clears any
+    // pending debounce timer) so a leftover timer from this test can't fire
+    // into the next one's freshly-cleared mocks.
+    cleanup();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("on resume: forces WS reconnect + refetches the active conversation tail (D2)", () => {
+    const { loadConversationMessages } = setup({ activeId: "conv-42" });
+
+    dispatchResume();
+    // Debounced — nothing fires synchronously.
+    expect(mocks.client.resetConnection).not.toHaveBeenCalled();
+    expect(loadConversationMessages).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(RESUME_DEBOUNCE_MS);
+
+    expect(mocks.client.resetConnection).toHaveBeenCalledTimes(1);
+    expect(loadConversationMessages).toHaveBeenCalledTimes(1);
+    expect(loadConversationMessages).toHaveBeenCalledWith("conv-42");
+  });
+
+  it("debounces rapid fg/bg flips into a single reconnect + refetch", () => {
+    const { loadConversationMessages } = setup();
+
+    dispatchResume();
+    vi.advanceTimersByTime(100);
+    dispatchResume();
+    vi.advanceTimersByTime(100);
+    dispatchResume();
+    // Still within the debounce window — not fired yet.
+    expect(mocks.client.resetConnection).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(RESUME_DEBOUNCE_MS);
+
+    expect(mocks.client.resetConnection).toHaveBeenCalledTimes(1);
+    expect(loadConversationMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a persisted pageshow (bfcache restore) as a resume (D3)", () => {
+    const { loadConversationMessages } = setup({ activeId: "conv-bfcache" });
+
+    dispatchPageShow(true);
+    vi.advanceTimersByTime(RESUME_DEBOUNCE_MS);
+
+    expect(mocks.client.resetConnection).toHaveBeenCalledTimes(1);
+    expect(loadConversationMessages).toHaveBeenCalledWith("conv-bfcache");
+  });
+
+  it("ignores a non-persisted pageshow (normal load already connects)", () => {
+    const { loadConversationMessages } = setup();
+
+    dispatchPageShow(false);
+    vi.advanceTimersByTime(RESUME_DEBOUNCE_MS);
+
+    expect(mocks.client.resetConnection).not.toHaveBeenCalled();
+    expect(loadConversationMessages).not.toHaveBeenCalled();
+  });
+
+  it("coalesces a visibilitychange resume + bfcache pageshow in the same tick into one run", () => {
+    const { loadConversationMessages } = setup();
+
+    dispatchResume();
+    dispatchPageShow(true);
+    vi.advanceTimersByTime(RESUME_DEBOUNCE_MS);
+
+    expect(mocks.client.resetConnection).toHaveBeenCalledTimes(1);
+    expect(loadConversationMessages).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the tail refetch when there is no active conversation, still reconnects", () => {
+    const { loadConversationMessages } = setup({ activeId: null });
+
+    dispatchResume();
+    vi.advanceTimersByTime(RESUME_DEBOUNCE_MS);
+
+    expect(mocks.client.resetConnection).toHaveBeenCalledTimes(1);
+    expect(loadConversationMessages).not.toHaveBeenCalled();
+  });
+
+  it("marks a stale empty streaming assistant placeholder as interrupted on resume", () => {
+    const { setConversationMessages } = setup({
+      messages: makeMessages({
+        id: "m1",
+        role: "assistant",
+        text: "",
+      } as ConversationMessage),
+    });
+
+    dispatchResume();
+    vi.advanceTimersByTime(RESUME_DEBOUNCE_MS);
+
+    expect(setConversationMessages).toHaveBeenCalledTimes(1);
+    const updater = setConversationMessages.mock.calls[0][0] as (
+      prev: ConversationMessage[],
+    ) => ConversationMessage[];
+    const next = updater([
+      { id: "m1", role: "assistant", text: "" } as ConversationMessage,
+    ]);
+    expect(next[0].interrupted).toBe(true);
+  });
+
+  it("does not touch messages when the last turn is not an empty placeholder", () => {
+    const { setConversationMessages } = setup({
+      messages: makeMessages({
+        id: "m1",
+        role: "assistant",
+        text: "hello",
+      } as ConversationMessage),
+    });
+
+    dispatchResume();
+    vi.advanceTimersByTime(RESUME_DEBOUNCE_MS);
+
+    expect(setConversationMessages).not.toHaveBeenCalled();
+  });
+
+  it("survives a throwing resetConnection and still refetches the tail", () => {
+    mocks.client.resetConnection.mockImplementationOnce(() => {
+      throw new Error("reconnect boom");
+    });
+    const { loadConversationMessages } = setup({ activeId: "conv-x" });
+
+    dispatchResume();
+    vi.advanceTimersByTime(RESUME_DEBOUNCE_MS);
+
+    expect(loadConversationMessages).toHaveBeenCalledWith("conv-x");
+  });
+
+  it("detaches resume + pageshow listeners on unmount (no leak, no post-unmount fire)", () => {
+    const { loadConversationMessages, view } = setup();
+
+    view.unmount();
+
+    dispatchResume();
+    dispatchPageShow(true);
+    vi.advanceTimersByTime(RESUME_DEBOUNCE_MS * 2);
+
+    expect(mocks.client.resetConnection).not.toHaveBeenCalled();
+    expect(loadConversationMessages).not.toHaveBeenCalled();
+  });
+
+  it("cancels a pending debounced resume if the hook unmounts mid-window", () => {
+    const { loadConversationMessages, view } = setup();
+
+    dispatchResume();
+    vi.advanceTimersByTime(RESUME_DEBOUNCE_MS / 2);
+    view.unmount();
+    vi.advanceTimersByTime(RESUME_DEBOUNCE_MS);
+
+    expect(mocks.client.resetConnection).not.toHaveBeenCalled();
+    expect(loadConversationMessages).not.toHaveBeenCalled();
+  });
+
+  it("on pause: persists the active conversation id + aborts an in-flight stream", () => {
+    const controller = new AbortController();
+    const { chatAbortRef } = setup({ activeId: "conv-persist" });
+    chatAbortRef.current = controller;
+
+    dispatchPause();
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(window.localStorage.getItem("eliza:chat:activeConversationId")).toBe(
+      "conv-persist",
+    );
+  });
+});

--- a/packages/ui/src/state/useAppLifecycleEvents.ts
+++ b/packages/ui/src/state/useAppLifecycleEvents.ts
@@ -1,9 +1,12 @@
 /**
- * Wires Capacitor app lifecycle events to runtime state.
+ * Wires app lifecycle events to runtime state on EVERY surface.
  *
- * The native shell (`packages/app/src/main.tsx`) bridges
- * `CapacitorApp.appStateChange` into `APP_RESUME_EVENT` /
- * `APP_PAUSE_EVENT`. This hook is the renderer-side consumer:
+ * The shell (`packages/app/src/main.tsx`) now bridges foreground/background
+ * into `APP_RESUME_EVENT` / `APP_PAUSE_EVENT` on the installed **web** PWA too,
+ * not only native Capacitor: `createMobileLifecycle` registers a
+ * `document.visibilitychange` fallback unconditionally, so this hook's resume
+ * path runs on the exact iOS PWA surface where a backgrounded app came back
+ * with a dead WebSocket and a stale transcript (#PWA-D1/D2/D3).
  *
  *  - On `APP_PAUSE_EVENT`:
  *    abort any in-flight chat stream before iOS suspends the process and
@@ -12,20 +15,35 @@
  *    the value survives a WKWebView localStorage purge under memory
  *    pressure).
  *
- *  - On `APP_RESUME_EVENT`:
- *    re-probe `/api/health` to detect that the FGS / dev server respawned
- *    on a new port and clean up the "last assistant turn was an empty
- *    streaming placeholder" anomaly (mark interrupted).
+ *  - On `APP_RESUME_EVENT` (and on a persisted `pageshow` bfcache restore):
+ *    re-probe `/api/health`, force a WebSocket reconnect / reset the reconnect
+ *    backoff (so a socket iOS silently killed during suspension recovers
+ *    immediately instead of waiting for the 30s background probe), and refetch
+ *    the active conversation tail so agent messages missed while backgrounded
+ *    appear \u2014 critical for dedicated-agent REST mode where there is no WS to
+ *    reconnect and nothing else re-syncs. The stale empty-streaming-placeholder
+ *    anomaly is still swept (mark interrupted). The whole resume sequence is
+ *    debounced so rapid foreground/background flips (or a visibilitychange +
+ *    bfcache pageshow arriving together) do not stampede reconnects/refetches.
  */
 
 import type { MutableRefObject } from "react";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { type ConversationMessage, client } from "../api";
 import { APP_PAUSE_EVENT, APP_RESUME_EVENT } from "../events";
+import type { LoadConversationMessagesResult } from "./internal";
 
 /** Storage key for the last-known active conversation id. */
 export const ACTIVE_CONVERSATION_STORAGE_KEY =
   "eliza:chat:activeConversationId";
+
+/**
+ * Coalesce window for the resume sequence. iOS can fire visibilitychange and a
+ * bfcache `pageshow` back-to-back on a single foreground, and a user tabbing
+ * quickly can flip background/foreground several times; debouncing collapses
+ * those into ONE reconnect + refetch instead of a stampede.
+ */
+export const RESUME_DEBOUNCE_MS = 400;
 
 interface UseAppLifecycleEventsParams {
   activeConversationIdRef: MutableRefObject<string | null>;
@@ -36,6 +54,14 @@ interface UseAppLifecycleEventsParams {
       | ConversationMessage[]
       | ((prev: ConversationMessage[]) => ConversationMessage[]),
   ) => void;
+  /**
+   * Full-replace reload of a conversation's messages from the server. Called on
+   * resume so agent messages emitted while the app was backgrounded appear \u2014
+   * the only re-sync path for dedicated-agent REST mode (no WS to reconnect).
+   */
+  loadConversationMessages: (
+    convId: string,
+  ) => Promise<LoadConversationMessagesResult>;
 }
 
 interface HealthBody {
@@ -77,6 +103,7 @@ export function useAppLifecycleEvents({
   conversationMessagesRef,
   chatAbortRef,
   setConversationMessages,
+  loadConversationMessages,
 }: UseAppLifecycleEventsParams): void {
   // ── APP_PAUSE: gracefully abort in-flight streams before suspend ──
   useEffect(() => {
@@ -112,15 +139,28 @@ export function useAppLifecycleEvents({
     };
   }, [activeConversationIdRef, chatAbortRef]);
 
-  // ── APP_RESUME: re-probe health + sweep stale assistant placeholder ──
-  useEffect(() => {
-    const onResume = (): void => {
-      void probeAgentHealth();
+  // ── APP_RESUME: reconnect + refetch tail + sweep stale placeholder ──
+  //
+  // Latest refs are read at fire time so the debounced sequence and the
+  // pageshow bridge see current values without re-subscribing the listeners.
+  const conversationMessagesRefStable = conversationMessagesRef;
+  const activeConversationIdRefStable = activeConversationIdRef;
+  const setConversationMessagesRef = useRef(setConversationMessages);
+  setConversationMessagesRef.current = setConversationMessages;
+  const loadConversationMessagesRef = useRef(loadConversationMessages);
+  loadConversationMessagesRef.current = loadConversationMessages;
 
-      const messages = conversationMessagesRef.current;
+  useEffect(() => {
+    let resumeTimer: ReturnType<typeof setTimeout> | null = null;
+
+    // Sweep the "last assistant turn is an empty streaming placeholder"
+    // anomaly (a stream that never produced text before suspend) so the UI
+    // does not show a perpetually-loading bubble after resume.
+    const sweepStalePlaceholder = (): void => {
+      const messages = conversationMessagesRefStable.current;
       const last = messages.length > 0 ? messages[messages.length - 1] : null;
       if (last && last.role === "assistant" && last.text === "") {
-        setConversationMessages((prev) =>
+        setConversationMessagesRef.current((prev) =>
           prev.map((message) =>
             message.id === last.id
               ? { ...message, interrupted: true }
@@ -130,9 +170,80 @@ export function useAppLifecycleEvents({
       }
     };
 
-    document.addEventListener(APP_RESUME_EVENT, onResume);
-    return () => {
-      document.removeEventListener(APP_RESUME_EVENT, onResume);
+    // The actual resume work, run once per debounced burst.
+    const runResume = (): void => {
+      resumeTimer = null;
+
+      void probeAgentHealth();
+
+      // Force a WS reconnect / reset the reconnect backoff. iOS often does NOT
+      // fire `online` on resume (the socket was silently killed during
+      // suspension, not a network change), so the resumed PWA can otherwise
+      // sit on a dead socket until the 30s background probe or a user action.
+      // `resetConnection` clears the pending backoff timer, resets the attempt
+      // counter, and re-runs `connectWs()`. For dedicated-agent REST bases
+      // `connectWs()` short-circuits to connected-over-REST (no socket, no
+      // churn), so this is safe when the WS is absent.
+      try {
+        client.resetConnection();
+      } catch {
+        // error-policy:J4 a reconnect that throws must not strand the refetch
+        // below; the background probe loop remains a fallback.
+      }
+
+      // Refetch the active conversation tail so agent messages emitted while
+      // backgrounded appear. This is the ONLY re-sync path for dedicated-agent
+      // REST mode (no WS reconnect fires `onReconnect`/RESYNC_EVENT there), and
+      // a belt-and-suspenders refresh for the WS path where the socket resync
+      // reconciliation would otherwise be the only trigger.
+      const convId = activeConversationIdRefStable.current;
+      if (convId) {
+        void loadConversationMessagesRef.current(convId).catch(() => {
+          // error-policy:J4 resume tail refetch — a failed reload leaves the
+          // last-known transcript in place; the next interaction/open retries.
+        });
+      }
+
+      sweepStalePlaceholder();
     };
-  }, [conversationMessagesRef, setConversationMessages]);
+
+    // Debounce: collapse a visibilitychange-driven APP_RESUME_EVENT and a
+    // near-simultaneous bfcache pageshow (and rapid fg/bg flips) into one run.
+    const scheduleResume = (): void => {
+      if (resumeTimer !== null) clearTimeout(resumeTimer);
+      resumeTimer = setTimeout(runResume, RESUME_DEBOUNCE_MS);
+    };
+
+    const onResume = (): void => {
+      scheduleResume();
+    };
+
+    // ── D3: bfcache restore ──
+    // iOS commonly restores an installed PWA from the back/forward cache
+    // (bfcache) where `visibilitychange` alone can miss the resume trigger. A
+    // `pageshow` with `persisted === true` means the page came back from
+    // bfcache with a frozen (dead) socket \u2014 treat it as a resume. A
+    // non-persisted pageshow is a normal load (boot already connects), so it
+    // is ignored. Sharing `scheduleResume` dedupes against a visibilitychange
+    // APP_RESUME_EVENT that fires in the same tick.
+    const onPageShow = (event: PageTransitionEvent): void => {
+      if (event.persisted) scheduleResume();
+    };
+
+    document.addEventListener(APP_RESUME_EVENT, onResume);
+    if (typeof window !== "undefined") {
+      window.addEventListener("pageshow", onPageShow);
+    }
+
+    return () => {
+      if (resumeTimer !== null) clearTimeout(resumeTimer);
+      document.removeEventListener(APP_RESUME_EVENT, onResume);
+      if (typeof window !== "undefined") {
+        window.removeEventListener("pageshow", onPageShow);
+      }
+    };
+    // Listeners subscribe once and read the latest handlers/values through
+    // refs, so they never re-subscribe (avoids tearing down a pending
+    // debounce mid-resume). `client` is module-stable.
+  }, [conversationMessagesRefStable, activeConversationIdRefStable]);
 }

--- a/packages/ui/src/state/useAppLifecycleEvents.ts
+++ b/packages/ui/src/state/useAppLifecycleEvents.ts
@@ -1,12 +1,12 @@
 /**
- * Wires app lifecycle events to runtime state on EVERY surface.
+ * Wires app lifecycle events to chat runtime state on every browser and native surface.
  *
- * The shell (`packages/app/src/main.tsx`) now bridges foreground/background
- * into `APP_RESUME_EVENT` / `APP_PAUSE_EVENT` on the installed **web** PWA too,
- * not only native Capacitor: `createMobileLifecycle` registers a
- * `document.visibilitychange` fallback unconditionally, so this hook's resume
- * path runs on the exact iOS PWA surface where a backgrounded app came back
- * with a dead WebSocket and a stale transcript (#PWA-D1/D2/D3).
+ * The shell (`packages/app/src/main.tsx`) bridges foreground/background into
+ * `APP_RESUME_EVENT` / `APP_PAUSE_EVENT` with Capacitor listeners when
+ * available and browser fallbacks for installed PWAs. This hook keeps chat
+ * state coherent after OS suspension, where iOS can silently kill a WebSocket
+ * and leave the transcript stale until the renderer explicitly reconnects and
+ * reloads the active conversation tail (#PWA-D1/D2/D3).
  *
  *  - On `APP_PAUSE_EVENT`:
  *    abort any in-flight chat stream before iOS suspends the process and
@@ -27,6 +27,7 @@
  *    bfcache pageshow arriving together) do not stampede reconnects/refetches.
  */
 
+import { logger } from "@elizaos/logger";
 import type { MutableRefObject } from "react";
 import { useEffect, useRef } from "react";
 import { type ConversationMessage, client } from "../api";
@@ -91,9 +92,10 @@ async function probeAgentHealth(): Promise<boolean> {
       timeoutMs: 5_000,
     });
     return isHealthy(body);
-  } catch {
-    // error-policy:J4 resume health probe — an unreachable agent IS the
+  } catch (error) {
+    // error-policy:J4 resume health probe - an unreachable agent IS the
     // unhealthy signal; the caller reacts by rediscovering the runtime.
+    logger.debug({ error }, "[AppLifecycle] resume health probe failed");
     return false;
   }
 }
@@ -125,10 +127,14 @@ export function useAppLifecycleEvents({
           } else {
             window.localStorage.removeItem(ACTIVE_CONVERSATION_STORAGE_KEY);
           }
-        } catch {
-          // localStorage may throw under sandbox / quota; the storage
-          // bridge already mirrors writes to Capacitor Preferences, so a
-          // failure here is not fatal.
+        } catch (error) {
+          // error-policy:J4 active-conversation persistence mirrors through
+          // the storage bridge; localStorage may be blocked by sandbox/quota.
+          // The next resume still uses the in-memory active id when present.
+          logger.debug(
+            { activeId, error },
+            "[AppLifecycle] local active conversation persistence failed",
+          );
         }
       }
     };
@@ -141,8 +147,8 @@ export function useAppLifecycleEvents({
 
   // ── APP_RESUME: reconnect + refetch tail + sweep stale placeholder ──
   //
-  // Latest refs are read at fire time so the debounced sequence and the
-  // pageshow bridge see current values without re-subscribing the listeners.
+  // Resume listeners stay subscribed while refs carry the latest values into
+  // debounced work and bfcache pageshow handling.
   const conversationMessagesRefStable = conversationMessagesRef;
   const activeConversationIdRefStable = activeConversationIdRef;
   const setConversationMessagesRef = useRef(setConversationMessages);
@@ -170,7 +176,7 @@ export function useAppLifecycleEvents({
       }
     };
 
-    // The actual resume work, run once per debounced burst.
+    // One resume burst runs at most one reconnect and one tail reload.
     const runResume = (): void => {
       resumeTimer = null;
 
@@ -186,21 +192,26 @@ export function useAppLifecycleEvents({
       // churn), so this is safe when the WS is absent.
       try {
         client.resetConnection();
-      } catch {
-        // error-policy:J4 a reconnect that throws must not strand the refetch
-        // below; the background probe loop remains a fallback.
+      } catch (error) {
+        // error-policy:J4 resume reconnect - the tail refetch below is the
+        // user-visible freshness path, and the background probe remains a
+        // retry path for the websocket.
+        logger.warn({ error }, "[AppLifecycle] resume reconnect failed");
       }
 
       // Refetch the active conversation tail so agent messages emitted while
-      // backgrounded appear. This is the ONLY re-sync path for dedicated-agent
-      // REST mode (no WS reconnect fires `onReconnect`/RESYNC_EVENT there), and
-      // a belt-and-suspenders refresh for the WS path where the socket resync
-      // reconciliation would otherwise be the only trigger.
+      // backgrounded appear. Dedicated-agent REST mode has no websocket
+      // reconnect event, so this explicit reload is its transcript re-sync
+      // path after suspension.
       const convId = activeConversationIdRefStable.current;
       if (convId) {
-        void loadConversationMessagesRef.current(convId).catch(() => {
-          // error-policy:J4 resume tail refetch — a failed reload leaves the
-          // last-known transcript in place; the next interaction/open retries.
+        void loadConversationMessagesRef.current(convId).catch((error) => {
+          // error-policy:J4 resume tail refetch - a failed reload leaves the
+          // last-known transcript visible; the next interaction/open retries.
+          logger.warn(
+            { convId, error },
+            "[AppLifecycle] resume conversation tail refetch failed",
+          );
         });
       }
 
@@ -218,7 +229,7 @@ export function useAppLifecycleEvents({
       scheduleResume();
     };
 
-    // ── D3: bfcache restore ──
+    // ── bfcache restore ──
     // iOS commonly restores an installed PWA from the back/forward cache
     // (bfcache) where `visibilitychange` alone can miss the resume trigger. A
     // `pageshow` with `persisted === true` means the page came back from


### PR DESCRIPTION
## Problem

The installed **iOS web PWA** comes back **stale** after backgrounding — the #1 daily-driver jank. Two failures compound:

1. **APP_RESUME/PAUSE events never fire on the web PWA.** `createMobileLifecycle`'s `visibilitychange`→lifecycle bridge was gated behind `isIOS || isAndroid` (native Capacitor) in `main.tsx`. On the installed web PWA (`isNative === false`) it never ran, so `APP_RESUME_EVENT`/`APP_PAUSE_EVENT` were never dispatched on the exact surface that needs them.
2. **Nothing forces a reconnect/refetch on resume.** iOS silently kills the WebSocket during suspension *without* a network change, so `online` doesn't fire on resume and the PWA sits on a dead socket until the 30s background probe. For **dedicated cloud agents (REST, no WS at all)** there's no realtime channel — missed agent messages only appear on an explicit refetch, and nothing refetched.

Evidence + anchors: `PWA-OPTIMIZATION-DOSSIER §2.1`.

## Changes (dossier D1 / D2 / D3)

### D1 — dispatch lifecycle events on the web PWA too
`packages/app/src/main.tsx`: `getMobileLifecycle().initializeAppLifecycle()` + `initializeNetworkListener()` now run **unconditionally** in `initializePlatform()` (which itself runs on every surface), not only under `isIOS || isAndroid`. The factory guards every Capacitor call and falls back to `document.visibilitychange` (pause/resume) and window `online`/`offline` (network), so it degrades cleanly with no plugins. `setAppActive`/`setConnected` dedupe against a working native `appStateChange`/`Network` listener, so **no double-fire on native**. Single source of resume truth.

### D2 — reconnect + tail refetch on resume
`packages/ui/src/state/useAppLifecycleEvents.ts`: on `APP_RESUME_EVENT`:
- **force WS reconnect / reset backoff** via `client.resetConnection()` (clears the pending backoff timer, resets the attempt counter, re-runs `connectWs()`). For dedicated-agent REST bases `connectWs()` short-circuits to connected-over-REST — **safe when the WS is absent, no churn**.
- **refetch the active conversation tail** via `loadConversationMessages(activeId)` so agent messages missed while backgrounded appear. This is the **only** re-sync path for dedicated-agent REST mode.
- **debounced (400ms)** so rapid fg/bg flips don't stampede reconnects/refetches.

### D3 — bfcache (`pageshow`) resume
Same file: a `pageshow` with `persisted === true` (iOS bfcache restore, where `visibilitychange` alone can miss the trigger) is treated as a resume. A non-persisted pageshow (normal load — boot already connects) is ignored. Shares the debounced scheduler, so a `visibilitychange` resume + a same-tick bfcache `pageshow` coalesce into **one** run.

## Evidence table

| Symptom | Root cause | Fix |
|---|---|---|
| Web PWA never dispatches APP_RESUME/PAUSE | lifecycle bridge native-gated (`main.tsx` `isIOS \|\| isAndroid`) | D1: register unconditionally, dedup-guarded |
| Resumed PWA on a dead socket until 30s probe | iOS kills WS on suspend w/o `online` event | D2a: `resetConnection()` on resume |
| Dedicated-agent (REST) shows stale transcript, missed agent msgs | no WS → no `onReconnect`/RESYNC_EVENT → no refetch | D2b: refetch active conversation tail on resume |
| iOS bfcache restore misses the reconnect trigger | `visibilitychange` alone can miss bfcache restores | D3: persisted `pageshow` → resume |

## Tests

`packages/ui/src/state/useAppLifecycleEvents.test.tsx` — 12 reliability contract tests (vitest / jsdom):
- resume forces reconnect + tail refetch (D2)
- debounce collapses rapid fg/bg flips into one run
- persisted `pageshow` triggers resume (D3); non-persisted does not
- visibilitychange resume + same-tick bfcache pageshow coalesce
- skips tail refetch w/ no active conversation, still reconnects
- stale empty-streaming placeholder marked interrupted; non-placeholder untouched
- throwing `resetConnection` still refetches the tail
- listeners detach on unmount (no leak); cancels a pending debounce mid-window
- pause persists active conversation id + aborts in-flight stream

```
✓ src/state/useAppLifecycleEvents.test.tsx (12 tests)
  Tests  12 passed (12)
```
No regressions in `AppContext.resync.test.tsx`, `view-lifecycle*.test.tsx`, `client-base-stream-abort.test.ts`.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15179-lifecycle-before-resume.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15179-lifecycle-after-resume.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/15179-walkthrough-resume.mp4

<!-- evidence-row:backend-logs -->
- [x] [15179-unit-tests.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15179-unit-tests.log)

<!-- evidence-row:frontend-logs -->
- [x] [15179-lifecycle-demo.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15179-lifecycle-demo.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/model behavior; lifecycle/WS-reconnect plumbing verified by the behavioral demo

<!-- evidence-row:domain-artifacts -->
- [x] [15179-lifecycle-video.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15179-lifecycle-video.log)

<!-- evidence-row:ocr-review -->
- [x] [15179-ocr.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15179-ocr.txt)

## Notes
- Reliability code: idempotent handlers (per-instance/module-scope guards), cleanup on unmount, backoff-aware (no reconnect storms), works when WS is absent (REST mode).
- Codex review hung >100s on the VPS (killed per protocol); self-reviewed the diff instead — confirmed `initializePlatform()` runs on all surfaces, idempotency guards hold, no double-fire on native, REST-mode reconnect is a no-op short-circuit.
- **Not self-merged** — UI change, needs device-verify hold.

[sol-orch]



