### PR TITLE
fix(#15173): recover healthy upgraded agents from stale status

### DIFF
--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -229,13 +229,19 @@ export class AgentSandboxesRepository {
   }
 
   /**
-   * `disconnected` always-on (paid) agents that should be reconciled back to
-   * `running`. A `dedicated-always` agent is contractually meant to stay up, so
-   * a transient tailnet drop that flipped it to `disconnected` must self-heal —
-   * the recovery cycle re-probes the bridge and either flips it back to
-   * `running` (still reachable) or re-provisions it (truly down). Scoped to
-   * `dedicated-always` because `dedicated-lazy`/`shared` are NOT meant to hold
-   * an always-on container. Deleted rows are excluded.
+   * Always-on (paid) agents that should be reconciled back to `running`. A
+   * `dedicated-always` agent is contractually meant to stay up, so a transient
+   * tailnet drop that flipped it to `disconnected` must self-heal — the recovery
+   * cycle re-probes the bridge and either flips it back to `running` (still
+   * reachable) or re-provisions it (truly down). Blue/green swaps can also race
+   * a stale monitor write that leaves a healthy container behind an `error` row;
+   * include only errored rows with a bridge to probe, rollback metadata, and no
+   * explicit `error_message`. Generic provisioning/restore failures set an
+   * operator-visible error message, can also leave a bridge behind, and must stay
+   * failed instead of being silently revived.
+   *
+   * Scoped to `dedicated-always` because `dedicated-lazy`/`shared` are NOT meant
+   * to hold an always-on container. Deleted rows are excluded.
    */
   async listRecoverable(limit = 100): Promise<
     Array<{
@@ -245,6 +251,7 @@ export class AgentSandboxesRepository {
       agent_name: string | null;
       bridge_url: string | null;
       updated_at: Date;
+      status: AgentSandboxStatus;
     }>
   > {
     return dbRead
@@ -255,11 +262,20 @@ export class AgentSandboxesRepository {
         agent_name: agentSandboxes.agent_name,
         bridge_url: agentSandboxes.bridge_url,
         updated_at: agentSandboxes.updated_at,
+        status: agentSandboxes.status,
       })
       .from(agentSandboxes)
       .where(
         and(
-          eq(agentSandboxes.status, "disconnected"),
+          sql`(
+            ${agentSandboxes.status} = 'disconnected'
+            OR (
+              ${agentSandboxes.status} = 'error'
+              AND ${agentSandboxes.bridge_url} IS NOT NULL
+              AND ${agentSandboxes.previous_image_digest} IS NOT NULL
+              AND ${agentSandboxes.error_message} IS NULL
+            )
+          )`,
           eq(agentSandboxes.execution_tier, "dedicated-always"),
           sql`${agentSandboxes.deleted_at} IS NULL`,
         ),
@@ -644,26 +660,37 @@ export class AgentSandboxesRepository {
   }
 
   /**
-   * Atomically restore a still-disconnected agent to `running` after a
-   * successful bridge re-probe. The recovery read -> probe -> write window spans
-   * seconds, during which the row may move to `deletion_pending` (delete
-   * enqueue), `stopped` (shutdown nulls `bridge_url`), or `provisioning`
-   * (re-provision). This compare-and-set only flips a row that is STILL
-   * `disconnected` with a live bridge and not soft-deleted, so a stale probe can
-   * never resurrect a being-deleted agent or wedge a stopped one at `running`
-   * with a dead bridge. Returns the row when it won, undefined when it lost the
-   * race (and the caller must NOT treat it as recovered).
+   * Atomically restore a still-recoverable agent to `running` after a successful
+   * bridge re-probe. The recovery read -> probe -> write window spans seconds,
+   * during which the row may move to `deletion_pending` (delete enqueue),
+   * `stopped` (shutdown nulls `bridge_url`), or `provisioning` (re-provision).
+   * This compare-and-set only flips a row that is STILL in the status the caller
+   * probed with a live bridge and not soft-deleted. Errored rows additionally
+   * must carry `previous_image_digest` and no explicit `error_message`, so
+   * generic provisioning/restore failures are not masked. A stale probe can never
+   * resurrect a being-deleted agent or wedge a stopped one at `running` with a
+   * dead bridge. Returns the row when it won, undefined when it lost the race
+   * (and the caller must NOT treat it as recovered).
    */
-  async markReconnectedFromDisconnected(id: string): Promise<AgentSandbox | undefined> {
+  async markReconnectedFromDisconnected(
+    id: string,
+    expectedStatus: "disconnected" | "error" = "disconnected",
+  ): Promise<AgentSandbox | undefined> {
     await ensureAgentSandboxSchema();
     const [r] = await dbWrite
       .update(agentSandboxes)
-      .set({ status: "running", last_heartbeat_at: new Date(), updated_at: new Date() })
+      .set({
+        status: "running",
+        error_message: null,
+        last_heartbeat_at: new Date(),
+        updated_at: new Date(),
+      })
       .where(
         and(
           eq(agentSandboxes.id, id),
-          eq(agentSandboxes.status, "disconnected"),
+          eq(agentSandboxes.status, expectedStatus),
           sql`${agentSandboxes.bridge_url} IS NOT NULL`,
+          sql`${expectedStatus} != 'error' OR (${agentSandboxes.previous_image_digest} IS NOT NULL AND ${agentSandboxes.error_message} IS NULL)`,
           sql`${agentSandboxes.deleted_at} IS NULL`,
         ),
       )

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -511,6 +511,37 @@ describe("ElizaSandboxService recoverDisconnected", () => {
     }
   });
 
+  test("recovers a reachable errored agent left behind by blue/green status drift", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox: AgentSandbox = {
+      ...customSandbox(),
+      status: "error",
+      error_message: null,
+      previous_image_digest: "sha256:old",
+    };
+    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockImplementation(
+      async () => sandbox,
+    );
+    const casSpy = spyOn(
+      agentSandboxesRepository,
+      "markReconnectedFromDisconnected",
+    ).mockImplementation(async () => ({ ...sandbox, status: "running", error_message: null }));
+    globalThis.fetch = mock(async () => new Response("ok", { status: 200 }));
+
+    try {
+      const result = await new ElizaSandboxService().recoverDisconnected(
+        sandbox.id,
+        sandbox.organization_id,
+      );
+      expect(result).toBe("recovered");
+      expect(casSpy).toHaveBeenCalledTimes(1);
+      expect(casSpy.mock.calls[0]).toEqual([sandbox.id, "error"]);
+    } finally {
+      findSpy.mockRestore();
+      casSpy.mockRestore();
+    }
+  });
+
   test("does NOT revive when the row left disconnected mid-probe (CAS loses -> gone)", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const sandbox = disconnectedSandbox();

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -4008,32 +4008,38 @@ export class ElizaSandboxService {
   }
 
   /**
-   * Reconcile a `disconnected` always-on (paid) agent back to health. A
+   * Reconcile a recoverable always-on (paid) agent back to health. A
    * `dedicated-always` agent is contractually meant to stay up, so the recovery
    * cycle calls this to self-heal a transient drop: re-probe the bridge and, if
    * the container answers, flip it straight back to `running` (the agent-router
-   * only routes `running`, so this also restores its subdomain). If it stays
-   * unreachable the caller re-provisions it. The guarded compare-and-set write
-   * (not a blind update-by-id) makes this safe to run concurrently with the
-   * heartbeat cycle AND with shutdown/delete/provision: the read -> probe -> write
-   * window spans seconds, so we only flip a row that is STILL `disconnected` at
-   * write time.
+   * only routes `running`, so this also restores its subdomain). Blue/green
+   * swaps can also leave a healthy bridge behind a stale `error` row; treat that
+   * the same as `disconnected`, but only after the live bridge answers. If it
+   * stays unreachable the caller re-provisions it. The guarded compare-and-set
+   * write (not a blind update-by-id) makes this safe to run concurrently with
+   * the heartbeat cycle AND with shutdown/delete/provision: the read -> probe ->
+   * write window spans seconds, so we only flip a row that is STILL in the
+   * probed recoverable status at write time.
    */
   async recoverDisconnected(
     agentId: string,
     orgId: string,
   ): Promise<"recovered" | "unreachable" | "gone"> {
     const rec = await agentSandboxesRepository.findByIdAndOrg(agentId, orgId);
-    if (!rec || rec.status !== "disconnected") return "gone";
+    if (!rec || (rec.status !== "disconnected" && rec.status !== "error")) return "gone";
+    const recoverableStatus = rec.status;
     const reachable = await this.probeBridgeHealth(rec);
     if (!reachable) return "unreachable";
     // Guarded CAS: the row can move to deletion_pending / stopped (which nulls
     // bridge_url) / provisioning during the multi-second probe. Only flip it if
     // it is STILL disconnected with a live bridge — otherwise we'd resurrect a
     // being-deleted agent or wedge a stopped one at `running` with a dead bridge.
-    const restored = await agentSandboxesRepository.markReconnectedFromDisconnected(rec.id);
+    const restored = await agentSandboxesRepository.markReconnectedFromDisconnected(
+      rec.id,
+      recoverableStatus,
+    );
     if (!restored) return "gone";
-    logger.info("[agent-sandbox] Recovered disconnected agent back to running", {
+    logger.info("[agent-sandbox] Recovered agent back to running", {
       agentId,
     });
     return "recovered";

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-recovery.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-recovery.test.ts
@@ -1,10 +1,12 @@
 /**
- * processDisconnectedRecovery — the self-heal cycle for `disconnected` always-on
+ * processDisconnectedRecovery — the self-heal cycle for recoverable always-on
  * (paid) agents. The heartbeat cycle only touches RUNNING agents, so without
  * this a `dedicated-always` agent that briefly dropped past the grace window
  * would stay `disconnected` forever (agent-router routes only `running` → its
- * subdomain 404s). This guards the orchestration seam: listRecoverable →
- * recoverDisconnected → enqueueAgentProvisionOnce only for the still-unreachable.
+ * subdomain 404s). Blue/green status drift can similarly leave a healthy
+ * container behind an `error` row. This guards the orchestration seam:
+ * listRecoverable → recoverDisconnected → enqueueAgentProvisionOnce only for
+ * the still-unreachable.
  */
 
 import { describe, expect, spyOn, test } from "bun:test";
@@ -13,7 +15,12 @@ import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes"
 import { elizaSandboxService } from "./eliza-sandbox";
 import { provisioningJobService } from "./provisioning-jobs";
 
-function recoverable(id: string, orgId: string, bridge: string | null) {
+function recoverable(
+  id: string,
+  orgId: string,
+  bridge: string | null,
+  status: "disconnected" | "error" = "disconnected",
+) {
   return {
     id,
     organization_id: orgId,
@@ -21,6 +28,7 @@ function recoverable(id: string, orgId: string, bridge: string | null) {
     agent_name: `Agent ${id}`,
     bridge_url: bridge,
     updated_at: new Date("2026-06-19T00:00:00Z"),
+    status,
   };
 }
 


### PR DESCRIPTION
## Summary
- recover dedicated-always agents whose blue/green upgrade left a healthy bridge behind a stale `error` row
- keep the existing disconnected recovery path, but only include errored rows that look like status drift: live bridge, rollback metadata, and no explicit operator error message
- guard the compare-and-set update with the same status/error-message constraints so generic provisioning or restore failures stay failed

## Tests
- `bun test packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts packages/cloud/shared/src/lib/services/provisioning-jobs-recovery.test.ts` -> 58 pass
- `bun run typecheck` attempted; current worktree baseline fails in unrelated cloud-api/cloud-shared files (`stripe-connect-webhook-route.test.ts`, `fal/proxy/route.ts`, `node-redis-adapter.ts`, `plugin-mcp/utils/json.ts`, `anthropic-web-search.ts`) before/independent of this patch
- `codex review --uncommitted` -> no discrete correctness issues after the recovery guard tightening

-- [sol-orch]
