### PR TITLE
feat(app): SW navigation preload + immutable /assets cache-first [sol-orch]

### DIFF
--- a/packages/app/public/sw.js
+++ b/packages/app/public/sw.js
@@ -4,11 +4,16 @@
  * Cache strategies:
  *  - /api/views/:id/bundle.js  → Stale-While-Revalidate (serve cache, update in background)
  *  - /api/views/:id/hero       → Cache-First with 24h max-age
- *  - App shell (index.html)    → Network-First with cache fallback
+ *  - /assets/<hashed>.{js,css} → Cache-First (immutable: the content hash is in
+ *                                the filename, so a byte-changed asset gets a new
+ *                                URL and can never be served stale)
+ *  - App shell (index.html)    → Network-First with cache fallback + navigation
+ *                                preload (browser fetches in parallel with SW
+ *                                boot, so a cold nav doesn't wait on SW startup)
  *
- * Cache is version-keyed (VIEWS_CACHE_NAME, SHELL_CACHE_NAME) so bumping the
- * version strings in a future deploy triggers automatic cleanup of old caches
- * in the `activate` handler.
+ * Cache is version-keyed (VIEWS_CACHE_NAME, SHELL_CACHE_NAME, ASSETS_CACHE_NAME)
+ * so bumping the version strings in a future deploy triggers automatic cleanup
+ * of old caches in the `activate` handler.
  */
 
 "use strict";
@@ -22,11 +27,27 @@ const VIEWS_CACHE_NAME = "elizaos-views-v1";
 // background is the black field with the orange ember glow, and boot no
 // longer paints orange). Bump drops any cached prior shell.
 const SHELL_CACHE_NAME = "elizaos-shell-v5";
+// Immutable runtime cache for Vite's content-hashed build output (/assets/*).
+// The filename hash IS the cache key's freshness guarantee: any byte change
+// produces a new filename, so cache-first can never serve a stale asset. This
+// insulates a resumed iOS PWA from WKWebView's aggressive HTTP-cache eviction
+// under memory pressure (which otherwise forces a multi-MB re-download of the
+// same immutable bundle). Bump the version to purge the whole cache on deploy.
+const ASSETS_CACHE_NAME = "elizaos-assets-v1";
 const HERO_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 h
-const KNOWN_CACHES = [VIEWS_CACHE_NAME, SHELL_CACHE_NAME];
+// Bound the immutable /assets/* cache so a long-lived install with many deploys
+// can't grow it without limit. Content-hashed assets accumulate across builds;
+// keep the most-recently-used window and evict the oldest beyond it. 220 entries
+// comfortably covers one full eager+lazy graph (the develop dist ships ~765
+// chunks total, but a single session only touches the entry + visited routes).
+const ASSETS_CACHE_MAX_ENTRIES = 220;
+const KNOWN_CACHES = [VIEWS_CACHE_NAME, SHELL_CACHE_NAME, ASSETS_CACHE_NAME];
 
 const VIEW_BUNDLE_RE = /^\/api\/views\/[^/]+\/bundle\.js$/;
 const VIEW_HERO_RE = /^\/api\/views\/[^/]+\/hero$/;
+// Vite emits content-hashed static build output under /assets/. The hash makes
+// these safe to treat as immutable (cache-first, never revalidate).
+const IMMUTABLE_ASSET_RE = /^\/assets\/[^/]+\.(?:js|mjs|css|woff2?|json|wasm)$/;
 
 // ---------------------------------------------------------------------------
 // Lifecycle
@@ -39,16 +60,29 @@ self.addEventListener("install", (event) => {
 
 self.addEventListener("activate", (event) => {
   event.waitUntil(
-    caches
-      .keys()
-      .then((keys) =>
-        Promise.all(
-          keys
-            .filter((key) => !KNOWN_CACHES.includes(key))
-            .map((key) => caches.delete(key)),
-        ),
-      )
-      .then(() => self.clients.claim()),
+    (async () => {
+      // Drop any caches from a prior SW version (including bumped ASSETS/SHELL).
+      const keys = await caches.keys();
+      await Promise.all(
+        keys
+          .filter((key) => !KNOWN_CACHES.includes(key))
+          .map((key) => caches.delete(key)),
+      );
+
+      // Enable navigation preload: the browser fetches the navigation request
+      // in parallel with SW startup, so a cold navigation no longer stalls
+      // waiting for the worker to boot before the network fetch even begins.
+      // Feature-detected — Safari shipped this in 16.4, older engines no-op.
+      if (self.registration.navigationPreload) {
+        try {
+          await self.registration.navigationPreload.enable();
+        } catch {
+          // Non-fatal: fall back to plain network-first if enable() rejects.
+        }
+      }
+
+      await self.clients.claim();
+    })(),
   );
 });
 
@@ -83,6 +117,14 @@ self.addEventListener("fetch", (event) => {
     return;
   }
 
+  // Immutable content-hashed build assets: serve cache-first with no max-age
+  // (the hash guarantees freshness) so a memory-pressure HTTP-cache eviction on
+  // iOS can't force re-downloading the full bundle on resume.
+  if (IMMUTABLE_ASSET_RE.test(pathname)) {
+    event.respondWith(immutableAssetFirst(request, ASSETS_CACHE_NAME));
+    return;
+  }
+
   // Auth navigations are NEVER intercepted: the sign-in page and the OAuth
   // callback must always load the freshest shell from the network. A stale
   // cached shell can carry an outdated build — e.g. one baked with the wrong
@@ -99,8 +141,13 @@ self.addEventListener("fetch", (event) => {
 
   // App shell: only intercept navigation requests for index.html (not API calls
   // or static assets that the browser handles fine without SW involvement).
+  // `event.preloadResponse` carries the browser's parallel navigation-preload
+  // fetch (when enabled), so networkFirst can consume it instead of issuing a
+  // second fetch — the cold-nav win.
   if (request.mode === "navigate") {
-    event.respondWith(networkFirst(request, SHELL_CACHE_NAME));
+    event.respondWith(
+      networkFirst(request, SHELL_CACHE_NAME, event.preloadResponse),
+    );
     return;
   }
 });
@@ -194,14 +241,52 @@ async function cacheFirst(request, cacheName, maxAgeMs) {
 }
 
 /**
- * Network-First with cache fallback:
- * Try the network; on failure serve the cached version; on total miss return 503.
+ * Cache-First for immutable content-hashed assets:
+ * The filename hash guarantees freshness, so a cache hit is always safe to
+ * serve with no revalidation. On a miss, fetch + cache, then trim the cache to
+ * its bounded MRU window so a long-lived install across many deploys can't grow
+ * the asset cache without limit.
  */
-async function networkFirst(request, cacheName) {
+async function immutableAssetFirst(request, cacheName) {
+  const cache = await caches.open(cacheName);
+  const cached = await cache.match(request);
+  if (cached) return cached;
+
+  let networkResponse;
+  try {
+    networkResponse = await fetch(request.clone());
+  } catch {
+    return new Response("Offline", { status: 503 });
+  }
+
+  if (networkResponse.ok) {
+    await cache.put(request, networkResponse.clone());
+    // Bound the cache: evict oldest (insertion-order) entries beyond the cap.
+    // Cache Storage preserves put() order, so keys()[0] is the least-recently
+    // added; trimming from the front keeps the most recent window.
+    await trimCache(cacheName, ASSETS_CACHE_MAX_ENTRIES);
+  }
+
+  return networkResponse;
+}
+
+/**
+ * Network-First with cache fallback:
+ * Prefer the navigation-preload response (parallel browser fetch) when present,
+ * else fetch; cache any OK response; on network failure serve the cached shell;
+ * on total miss return 503.
+ */
+async function networkFirst(request, cacheName, preloadResponsePromise) {
   const cache = await caches.open(cacheName);
 
   try {
-    const networkResponse = await fetch(request.clone());
+    // Consume the browser's navigation-preload response if one was started;
+    // otherwise fall back to a fresh fetch. `preloadResponse` resolves to
+    // undefined when navigation preload is unsupported/disabled.
+    const preloaded = preloadResponsePromise
+      ? await preloadResponsePromise
+      : undefined;
+    const networkResponse = preloaded ?? (await fetch(request.clone()));
     if (networkResponse.ok) {
       await cache.put(request, networkResponse.clone());
     }
@@ -210,6 +295,19 @@ async function networkFirst(request, cacheName) {
     const cached = await cache.match(request);
     return cached ?? new Response("Offline", { status: 503 });
   }
+}
+
+/**
+ * Trim a cache to at most `maxEntries`, deleting the oldest entries first.
+ * Cache Storage `keys()` returns requests in insertion order, so slicing off
+ * the front removes the least-recently-added assets.
+ */
+async function trimCache(cacheName, maxEntries) {
+  const cache = await caches.open(cacheName);
+  const keys = await cache.keys();
+  if (keys.length <= maxEntries) return;
+  const excess = keys.slice(0, keys.length - maxEntries);
+  await Promise.all(excess.map((key) => cache.delete(key)));
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/app/test/service-worker-cache-strategies.test.ts
+++ b/packages/app/test/service-worker-cache-strategies.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Service-worker runtime-cache + navigation-preload contract. Evaluates the
+ * real `sw.js` inside a minimal worker-like VM (same technique as
+ * service-worker-auth-bypass.test.ts) so the fetch/activate handlers can be
+ * exercised without a browser install.
+ *
+ * Covers the cold-start wins added for the installed iOS PWA:
+ *  - navigation preload is enabled on activate (feature-detected)
+ *  - a navigation consumes event.preloadResponse instead of a second fetch
+ *  - immutable /assets/<hash>.{js,css,...} are served cache-first and cached
+ *  - the immutable asset cache is bounded (oldest entries evicted past the cap)
+ *  - unknown caches are purged on activate
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import vm from "node:vm";
+import { describe, expect, it } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+type RequestLike = {
+  method: string;
+  mode: string;
+  url: string;
+  clone: () => RequestLike;
+};
+
+type FetchEventLike = {
+  request: RequestLike;
+  preloadResponse?: Promise<Response | undefined>;
+  respondWith: (value: Promise<Response> | Response) => void;
+  _responded?: Promise<Response> | Response;
+};
+
+type ExtendableEventLike = {
+  waitUntil: (p: Promise<unknown>) => void;
+  _work: Promise<unknown>[];
+};
+
+/** In-memory Cache that preserves insertion order (like the real Cache API). */
+class FakeCache {
+  entries = new Map<string, Response>();
+  async match(request: RequestLike | string) {
+    const key = typeof request === "string" ? request : request.url;
+    return this.entries.get(key) ?? null;
+  }
+  async put(request: RequestLike | string, response: Response) {
+    const key = typeof request === "string" ? request : request.url;
+    // Re-insertion must move to the end to mirror browser MRU ordering.
+    this.entries.delete(key);
+    this.entries.set(key, response);
+  }
+  async keys() {
+    // Return request-like objects carrying the url, insertion-ordered.
+    return [...this.entries.keys()].map((url) => ({ url }));
+  }
+  async delete(request: RequestLike | string) {
+    const key = typeof request === "string" ? request : request.url;
+    return this.entries.delete(key);
+  }
+}
+
+type Harness = {
+  dispatch: (type: string, event: unknown) => void;
+  caches: Map<string, FakeCache>;
+  navPreloadEnabled: () => boolean;
+  fetchCalls: () => string[];
+};
+
+function loadServiceWorker(options?: {
+  navigationPreload?: boolean;
+  preexistingCaches?: string[];
+  fetchImpl?: (url: string) => Response;
+}): Harness {
+  const {
+    navigationPreload = true,
+    preexistingCaches = [],
+    fetchImpl,
+  } = options ?? {};
+
+  const listeners = new Map<string, ((event: unknown) => void)[]>();
+  const cacheStore = new Map<string, FakeCache>();
+  for (const name of preexistingCaches) cacheStore.set(name, new FakeCache());
+
+  let navPreloadOn = false;
+  const registration = navigationPreload
+    ? {
+        navigationPreload: {
+          enable: async () => {
+            navPreloadOn = true;
+          },
+        },
+      }
+    : {};
+
+  const self = {
+    location: { origin: "https://app.example.test" },
+    registration,
+    addEventListener(type: string, listener: (event: unknown) => void) {
+      listeners.set(type, [...(listeners.get(type) ?? []), listener]);
+    },
+    skipWaiting: () => Promise.resolve(),
+    clients: {
+      claim: () => Promise.resolve(),
+      matchAll: () => Promise.resolve([]),
+    },
+  };
+
+  const fetchCalls: string[] = [];
+  const context = vm.createContext({
+    self,
+    URL,
+    Response,
+    Promise,
+    caches: {
+      keys: async () => [...cacheStore.keys()],
+      open: async (name: string) => {
+        let cache = cacheStore.get(name);
+        if (!cache) {
+          cache = new FakeCache();
+          cacheStore.set(name, cache);
+        }
+        return cache;
+      },
+      delete: async (name: string) => cacheStore.delete(name),
+    },
+    fetch: async (request: RequestLike) => {
+      const url = typeof request === "string" ? request : request.url;
+      fetchCalls.push(url);
+      return fetchImpl
+        ? fetchImpl(url)
+        : new Response("network-body", { status: 200 });
+    },
+  });
+
+  const script = readFileSync(path.resolve(here, "../public/sw.js"), "utf8");
+  vm.runInContext(script, context, { filename: "sw.js" });
+
+  return {
+    dispatch(type, event) {
+      for (const listener of listeners.get(type) ?? []) listener(event);
+    },
+    caches: cacheStore,
+    navPreloadEnabled: () => navPreloadOn,
+    fetchCalls: () => fetchCalls,
+  };
+}
+
+function makeRequest(pathname: string, mode = "navigate"): RequestLike {
+  const request: RequestLike = {
+    method: "GET",
+    mode,
+    url: `https://app.example.test${pathname}`,
+    clone: () => request,
+  };
+  return request;
+}
+
+function makeFetchEvent(
+  pathname: string,
+  opts?: { mode?: string; preloadResponse?: Promise<Response | undefined> },
+): FetchEventLike {
+  const event: FetchEventLike = {
+    request: makeRequest(pathname, opts?.mode ?? "navigate"),
+    preloadResponse: opts?.preloadResponse,
+    respondWith(value) {
+      event._responded = value;
+    },
+  };
+  return event;
+}
+
+function makeActivateEvent(): ExtendableEventLike {
+  const work: Promise<unknown>[] = [];
+  return {
+    waitUntil(p) {
+      work.push(p);
+    },
+    _work: work,
+  };
+}
+
+describe("service worker navigation preload", () => {
+  it("enables navigation preload on activate when supported", async () => {
+    const worker = loadServiceWorker({ navigationPreload: true });
+    const event = makeActivateEvent();
+    worker.dispatch("activate", event);
+    await Promise.all(event._work);
+    expect(worker.navPreloadEnabled()).toBe(true);
+  });
+
+  it("does not throw on activate when navigation preload is unsupported", async () => {
+    const worker = loadServiceWorker({ navigationPreload: false });
+    const event = makeActivateEvent();
+    worker.dispatch("activate", event);
+    await expect(Promise.all(event._work)).resolves.toBeDefined();
+  });
+
+  it("purges unknown caches on activate but keeps known ones", async () => {
+    const worker = loadServiceWorker({
+      preexistingCaches: ["stale-cache-v0", "elizaos-shell-v5"],
+    });
+    const event = makeActivateEvent();
+    worker.dispatch("activate", event);
+    await Promise.all(event._work);
+    expect(worker.caches.has("stale-cache-v0")).toBe(false);
+    expect(worker.caches.has("elizaos-shell-v5")).toBe(true);
+  });
+
+  it("consumes the navigation preload response instead of issuing a second fetch", async () => {
+    const worker = loadServiceWorker({ navigationPreload: true });
+    const preloaded = new Response("preloaded-shell", { status: 200 });
+    const event = makeFetchEvent("/chat", {
+      preloadResponse: Promise.resolve(preloaded),
+    });
+    worker.dispatch("fetch", event);
+    const response = await event._responded;
+    expect(await response?.text()).toBe("preloaded-shell");
+    // No direct fetch() call — the preload response satisfied the navigation.
+    expect(worker.fetchCalls()).toHaveLength(0);
+  });
+
+  it("falls back to fetch when no preload response is present", async () => {
+    const worker = loadServiceWorker({ navigationPreload: true });
+    const event = makeFetchEvent("/chat");
+    worker.dispatch("fetch", event);
+    await event._responded;
+    expect(worker.fetchCalls()).toContain("https://app.example.test/chat");
+  });
+});
+
+describe("service worker immutable asset cache", () => {
+  it("caches an immutable /assets/* response on first fetch and serves it from cache next time", async () => {
+    let bodyCounter = 0;
+    const worker = loadServiceWorker({
+      fetchImpl: () =>
+        new Response(`asset-body-${bodyCounter++}`, { status: 200 }),
+    });
+    const assetPath = "/assets/main-abc123.js";
+
+    // First request: network miss → fetch + cache.
+    const first = makeFetchEvent(assetPath, { mode: "cors" });
+    worker.dispatch("fetch", first);
+    const firstBody = await (await first._responded)?.text();
+    expect(firstBody).toBe("asset-body-0");
+    expect(worker.fetchCalls()).toHaveLength(1);
+
+    // Second request: cache hit → no additional network fetch.
+    const second = makeFetchEvent(assetPath, { mode: "cors" });
+    worker.dispatch("fetch", second);
+    const secondBody = await (await second._responded)?.text();
+    expect(secondBody).toBe("asset-body-0");
+    expect(worker.fetchCalls()).toHaveLength(1);
+  });
+
+  it("does not intercept non-hashed same-origin assets outside /assets/", async () => {
+    const worker = loadServiceWorker();
+    const event = makeFetchEvent("/favicon.ico", { mode: "no-cors" });
+    worker.dispatch("fetch", event);
+    // Non-navigation, non-view, non-/assets/ request must fall through
+    // (respondWith never called).
+    expect(event._responded).toBeUndefined();
+  });
+
+  it("bounds the immutable asset cache to its cap (oldest evicted first)", async () => {
+    const worker = loadServiceWorker();
+    // Cap is 220; push 225 distinct hashed assets, expect the 5 oldest gone.
+    for (let i = 0; i < 225; i++) {
+      const event = makeFetchEvent(`/assets/chunk-${i}.js`, { mode: "cors" });
+      worker.dispatch("fetch", event);
+      // Await settle so cache put + trim complete before the next iteration.
+      // eslint-disable-next-line no-await-in-loop
+      await event._responded;
+    }
+    const assetsCache = worker.caches.get("elizaos-assets-v1");
+    expect(assetsCache).toBeDefined();
+    const keys = [...(assetsCache as FakeCache).entries.keys()];
+    expect(keys.length).toBe(220);
+    // Oldest five (chunk-0..chunk-4) should have been evicted.
+    expect(keys).not.toContain("https://app.example.test/assets/chunk-0.js");
+    expect(keys).not.toContain("https://app.example.test/assets/chunk-4.js");
+    // Newest must remain.
+    expect(keys).toContain("https://app.example.test/assets/chunk-224.js");
+  });
+});


### PR DESCRIPTION
## What

Cheap, measurable **cold-start** wins for the installed iOS PWA, from the PWA optimization dossier (lanes **C1** + **C3**). Scoped entirely to `packages/app/public/sw.js` + a new vitest contract. No app/runtime/config surface touched.

### C1 — navigation preload
- `activate` feature-detects `self.registration.navigationPreload` and `enable()`s it (Safari 16.4+; older engines no-op via the guard). The browser then fetches the navigation **in parallel with SW boot** instead of stalling until the worker starts — the meaningful win on flaky cellular.
- `networkFirst()` now consumes `event.preloadResponse` when present, and only falls back to a fresh `fetch()` when preload is unsupported/absent. No double network request on the cold-nav path.

### C3 — immutable content-hashed asset cache
- `/assets/<hash>.{js,mjs,css,woff2?,json,wasm}` are served **cache-first, no max-age**. The Vite content hash is the freshness guarantee (a byte change → new filename → new cache key), so a hit is always safe and can never go stale.
- Insulates a resumed PWA from WKWebView HTTP-cache eviction under memory pressure, which otherwise forces re-downloading the full multi-MB bundle on resume.
- **Bounded**: `ASSETS_CACHE_MAX_ENTRIES = 220`, oldest-first eviction via `trimCache`, so a long-lived install across many deploys can't grow unbounded. Version-purged on `activate` (`ASSETS_CACHE_NAME` in `KNOWN_CACHES`).

`activate` was rewritten to async/await to sequence purge → preload-enable → claim. The auth-navigation bypass (`/login`, `?code=`, `?token=`) is **unchanged** and still fires before any shell handling (the one-time OAuth code is never cached/intercepted).

## Tests
- **New** `packages/app/test/service-worker-cache-strategies.test.ts` (8 cases): evaluates the *real* `sw.js` in a worker-like VM — preload enable + no-throw when unsupported, unknown-cache purge, preload-response consumption vs fetch fallback, immutable asset hit/miss (no second fetch on hit), non-`/assets` fall-through, and the 220-entry cache bound (oldest evicted).
- **Existing** `service-worker-auth-bypass.test.ts` (4 cases) still green — no contract change to auth bypass.

```
 ✓ test/service-worker-auth-bypass.test.ts (4 tests)
 ✓ test/service-worker-cache-strategies.test.ts (8 tests)
 Test Files  2 passed (2)
      Tests  12 passed (12)
```

`node --check sw.js` OK; biome clean.

## Notes
- **A1** (rollup-plugin-visualizer) from the dossier is already wired on `develop` (`vite.config.ts` behind `emitFile:false` → `dist/stats.html`), so no change was needed there.

🤖 Generated with scoped review. Not self-merged.

Co-authored-by: wakesync <shadow@shad0w.xyz>