### PR TITLE
feat(weather): IP-based approximate fallback + dismissible location notice + settings row

### DIFF
--- a/packages/agent/src/api/misc-routes.location.test.ts
+++ b/packages/agent/src/api/misc-routes.location.test.ts
@@ -1,0 +1,195 @@
+/**
+ * GET /api/location/approximate through handleMiscRoutes against a REAL local
+ * HTTP geo-provider stub (injected via ELIZA_IP_GEO_SERVICES) — the route's
+ * actual fetch/timeout/parse path runs unmocked; only the third-party endpoint
+ * is swapped for a local server.
+ */
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  handleMiscRoutes,
+  type MiscRouteContext,
+  resetIpGeoCacheForTests,
+} from "./misc-routes";
+import { AGENT_EVENT_ALLOWED_STREAMS } from "./plugin-discovery-helpers";
+
+type GeoResponder = (res: http.ServerResponse) => void;
+
+/** One-endpoint geo provider; each test swaps `respond` and counts hits. */
+function startGeoStub(): Promise<{
+  url: string;
+  hits: () => number;
+  setResponder: (fn: GeoResponder) => void;
+  close: () => Promise<void>;
+}> {
+  let count = 0;
+  let respond: GeoResponder = (res) => {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ latitude: 40.71, longitude: -74.01 }));
+  };
+  const server = http.createServer((_req, res) => {
+    count += 1;
+    respond(res);
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({
+        url: `http://127.0.0.1:${port}/json/`,
+        hits: () => count,
+        setResponder: (fn) => {
+          respond = fn;
+        },
+        close: () =>
+          new Promise((done) => {
+            server.close(() => done());
+          }),
+      });
+    });
+  });
+}
+
+function makeLocationContext(): MiscRouteContext {
+  const req = { url: "/api/location/approximate" } as http.IncomingMessage;
+  const res = {} as http.ServerResponse;
+  return {
+    req,
+    res,
+    method: "GET",
+    pathname: "/api/location/approximate",
+    url: new URL("http://localhost/api/location/approximate"),
+    state: {
+      config: {} as MiscRouteContext["state"]["config"],
+      runtime: null,
+      agentState: "ready",
+      agentName: "Eliza",
+      shellEnabled: true,
+      broadcastWs: vi.fn(),
+      broadcastWsToClientId: vi.fn(),
+      nextEventId: 1,
+      eventBuffer: [],
+      shareIngestQueue: [],
+      startup: {},
+      broadcastStatus: vi.fn(),
+      pendingRestartReasons: [],
+    },
+    json: vi.fn(),
+    error: vi.fn(),
+    readJsonBody: vi.fn(),
+    AGENT_EVENT_ALLOWED_STREAMS,
+    resolveTerminalRunRejection: vi.fn().mockReturnValue(null),
+    resolveTerminalRunClientId: vi.fn().mockReturnValue(null),
+    isSharedTerminalClientId: vi.fn().mockReturnValue(false),
+    activeTerminalRunCount: 0,
+    setActiveTerminalRunCount: vi.fn(),
+  };
+}
+
+describe("handleMiscRoutes GET /api/location/approximate", () => {
+  const originalServices = process.env.ELIZA_IP_GEO_SERVICES;
+
+  beforeEach(() => {
+    resetIpGeoCacheForTests();
+  });
+
+  afterEach(() => {
+    if (originalServices === undefined) {
+      delete process.env.ELIZA_IP_GEO_SERVICES;
+    } else {
+      process.env.ELIZA_IP_GEO_SERVICES = originalServices;
+    }
+    resetIpGeoCacheForTests();
+  });
+
+  it("returns coarse coordinates from the provider (ipapi-style latitude/longitude keys)", async () => {
+    const stub = await startGeoStub();
+    process.env.ELIZA_IP_GEO_SERVICES = stub.url;
+    try {
+      const ctx = makeLocationContext();
+      const handled = await handleMiscRoutes(ctx);
+
+      expect(handled).toBe(true);
+      expect(ctx.error).not.toHaveBeenCalled();
+      expect(ctx.json).toHaveBeenCalledWith(ctx.res, {
+        lat: 40.71,
+        lon: -74.01,
+        accuracyMeters: 5000,
+        source: "127.0.0.1",
+      });
+    } finally {
+      await stub.close();
+    }
+  });
+
+  it("falls through a failing provider to the next one (lat/lon keys)", async () => {
+    const failing = await startGeoStub();
+    failing.setResponder((res) => {
+      res.writeHead(500);
+      res.end();
+    });
+    const working = await startGeoStub();
+    working.setResponder((res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ lat: 51.5, lon: -0.12 }));
+    });
+    process.env.ELIZA_IP_GEO_SERVICES = `${failing.url},${working.url}`;
+    try {
+      const ctx = makeLocationContext();
+      await handleMiscRoutes(ctx);
+
+      expect(ctx.error).not.toHaveBeenCalled();
+      expect(ctx.json).toHaveBeenCalledWith(
+        ctx.res,
+        expect.objectContaining({ lat: 51.5, lon: -0.12 }),
+      );
+      expect(failing.hits()).toBe(1);
+      expect(working.hits()).toBe(1);
+    } finally {
+      await failing.close();
+      await working.close();
+    }
+  });
+
+  it("responds 502 — never fabricated coordinates — when every provider fails", async () => {
+    const broken = await startGeoStub();
+    broken.setResponder((res) => {
+      // Usable HTTP but no usable coordinates: parse-reject, not transport fail.
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ message: "rate limited" }));
+    });
+    process.env.ELIZA_IP_GEO_SERVICES = broken.url;
+    try {
+      const ctx = makeLocationContext();
+      const handled = await handleMiscRoutes(ctx);
+
+      expect(handled).toBe(true);
+      expect(ctx.json).not.toHaveBeenCalled();
+      expect(ctx.error).toHaveBeenCalledWith(
+        ctx.res,
+        "IP geolocation unavailable",
+        502,
+      );
+    } finally {
+      await broken.close();
+    }
+  });
+
+  it("serves repeat requests from the cache without re-querying the provider", async () => {
+    const stub = await startGeoStub();
+    process.env.ELIZA_IP_GEO_SERVICES = stub.url;
+    try {
+      await handleMiscRoutes(makeLocationContext());
+      const second = makeLocationContext();
+      await handleMiscRoutes(second);
+
+      expect(stub.hits()).toBe(1);
+      expect(second.json).toHaveBeenCalledWith(
+        second.res,
+        expect.objectContaining({ lat: 40.71, lon: -74.01 }),
+      );
+    } finally {
+      await stub.close();
+    }
+  });
+});

--- a/packages/agent/src/api/misc-routes.ts
+++ b/packages/agent/src/api/misc-routes.ts
@@ -3,10 +3,12 @@
  * process restart (POST /api/restart), the share-sheet ingest queue
  * (POST | GET /api/ingest/share), agent event-stream ingestion into the WS
  * broadcast buffer (POST /api/agent/event and the per-agent
- * /api/agents/:id/event variant), authorized single-line terminal command
- * execution (POST /api/terminal/run), and custom-action CRUD + NL generation +
- * test (/api/custom-actions...). Terminal runs and shell/code custom actions
- * sit behind the local-code-execution gate and terminal-authorization checks.
+ * /api/agents/:id/event variant), coarse IP-based coordinates for the weather
+ * widget's no-permission fallback (GET /api/location/approximate), authorized
+ * single-line terminal command execution (POST /api/terminal/run), and
+ * custom-action CRUD + NL generation + test (/api/custom-actions...). Terminal
+ * runs and shell/code custom actions sit behind the local-code-execution gate
+ * and terminal-authorization checks.
  */
 import crypto from "node:crypto";
 import type http from "node:http";
@@ -16,6 +18,7 @@ import {
   composePrompt,
   customActionGenerateTemplate,
   isLocalCodeExecutionAllowed,
+  logger,
   ModelType,
 } from "@elizaos/core";
 import type { ReadJsonBodyOptions } from "@elizaos/shared";
@@ -59,6 +62,98 @@ type TerminalRunRequestBody = {
   clientId?: unknown;
   terminalToken?: string;
 };
+
+// ---------------------------------------------------------------------------
+// Approximate (IP-based) location
+// ---------------------------------------------------------------------------
+
+// Server-side IP-geolocation for the weather widget's no-permission fallback.
+// The lookup runs here rather than in the browser because the public geo
+// services CORS-fail on hosted app origins and would each need a CSP carve-out
+// per app shell; the agent process has neither constraint. Mirrors the
+// Electrobun desktop LocationManager's provider set and its coarse-accuracy
+// contract: IP resolution is a city centroid (~5 km median), surfaced as
+// `accuracyMeters` so no consumer can mistake it for a GPS reading.
+const DEFAULT_IP_GEO_SERVICES = ["https://ipapi.co/json/", "https://ipwho.is/"];
+const IP_GEO_ACCURACY_METERS = 5000;
+const IP_GEO_TIMEOUT_MS = 5_000;
+// A public IP's city doesn't move minute-to-minute; the cache keeps repeated
+// widget revalidations from hammering the free-tier providers.
+const IP_GEO_CACHE_TTL_MS = 15 * 60_000;
+
+export interface ApproximateLocation {
+  lat: number;
+  lon: number;
+  accuracyMeters: number;
+  source: string;
+}
+
+let ipGeoCache: { value: ApproximateLocation; fetchedAt: number } | null = null;
+let ipGeoInFlight: Promise<ApproximateLocation | null> | null = null;
+
+/** Test seam + self-hoster override: comma-separated lookup URLs. */
+function ipGeoServiceUrls(): string[] {
+  const raw = process.env.ELIZA_IP_GEO_SERVICES;
+  if (!raw) return DEFAULT_IP_GEO_SERVICES;
+  const urls = raw
+    .split(",")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+  return urls.length > 0 ? urls : DEFAULT_IP_GEO_SERVICES;
+}
+
+/** Exported for tests: drop the module-level cache between cases. */
+export function resetIpGeoCacheForTests(): void {
+  ipGeoCache = null;
+  ipGeoInFlight = null;
+}
+
+async function lookupApproximateLocation(): Promise<ApproximateLocation | null> {
+  for (const url of ipGeoServiceUrls()) {
+    try {
+      const resp = await fetch(url, {
+        signal: AbortSignal.timeout(IP_GEO_TIMEOUT_MS),
+      });
+      if (!resp.ok) {
+        logger.warn(
+          `[MiscRoutes] IP geolocation provider returned ${resp.status} (${url})`,
+        );
+        continue;
+      }
+      const data = (await resp.json()) as Record<string, unknown>;
+      // ipapi.co uses latitude/longitude; ipwho.is and ip-api.com use lat/lon.
+      const lat = typeof data.lat === "number" ? data.lat : data.latitude;
+      const lon = typeof data.lon === "number" ? data.lon : data.longitude;
+      if (
+        typeof lat !== "number" ||
+        typeof lon !== "number" ||
+        !Number.isFinite(lat) ||
+        !Number.isFinite(lon)
+      ) {
+        logger.warn(
+          `[MiscRoutes] IP geolocation provider returned no usable coordinates (${url})`,
+        );
+        continue;
+      }
+      return {
+        lat,
+        lon,
+        accuracyMeters: IP_GEO_ACCURACY_METERS,
+        source: new URL(url).hostname,
+      };
+    } catch (err) {
+      // error-policy:J4 multi-provider fallback chain — each provider failure
+      // is logged and the next provider is tried; exhausting the list yields
+      // an explicit null that the route turns into a 502, never fabricated
+      // coordinates.
+      logger.warn(
+        { err },
+        `[MiscRoutes] IP geolocation provider failed (${url})`,
+      );
+    }
+  }
+  return null;
+}
 
 function resolveTerminalShellCommand(): {
   command: string;
@@ -149,6 +244,26 @@ export async function handleMiscRoutes(
 ): Promise<boolean> {
   const { req, res, method, pathname, url, state, json, error, readJsonBody } =
     ctx;
+
+  // ── GET /api/location/approximate ───────────────────────────────────
+  if (method === "GET" && pathname === "/api/location/approximate") {
+    if (ipGeoCache && Date.now() - ipGeoCache.fetchedAt < IP_GEO_CACHE_TTL_MS) {
+      json(res, ipGeoCache.value);
+      return true;
+    }
+    // Concurrent widget revalidations share one upstream lookup.
+    ipGeoInFlight ??= lookupApproximateLocation().finally(() => {
+      ipGeoInFlight = null;
+    });
+    const value = await ipGeoInFlight;
+    if (!value) {
+      error(res, "IP geolocation unavailable", 502);
+      return true;
+    }
+    ipGeoCache = { value, fetchedAt: Date.now() };
+    json(res, value);
+    return true;
+  }
 
   // ── POST /api/restart ───────────────────────────────────────────────
   if (method === "POST" && pathname === "/api/restart") {

--- a/packages/agent/src/api/server-lazy-routes.ts
+++ b/packages/agent/src/api/server-lazy-routes.ts
@@ -413,6 +413,7 @@ export async function handleMiscRoutes(
     !ctx ||
     !(
       ctx.pathname === "/api/restart" ||
+      ctx.pathname === "/api/location/approximate" ||
       ctx.pathname === "/api/ingest/share" ||
       ctx.pathname === "/api/agent/event" ||
       /^\/api\/agents\/[^/]+\/event$/.test(ctx.pathname) ||

--- a/packages/ui/src/components/settings/CapabilitiesSection.tsx
+++ b/packages/ui/src/components/settings/CapabilitiesSection.tsx
@@ -2,9 +2,10 @@
  * Settings → Capabilities section (the `capabilities` section id). Toggles the
  * wallet / browser / computer-use capabilities on the App state, sets the
  * proactive-interaction chattiness (persisted to `config.env` under
- * ELIZA_PROACTIVE_INTERACTIONS), manages auto-training config, and hosts the
- * Capability Router connect form for endpoint- or cloud-hosted capability
- * providers.
+ * ELIZA_PROACTIVE_INTERACTIONS), hosts the device-location permission row (the
+ * weather widget's approximate-location notification deep-links here), manages
+ * auto-training config, and hosts the Capability Router connect form for
+ * endpoint- or cloud-hosted capability providers.
  */
 
 import {
@@ -13,6 +14,7 @@ import {
   Globe,
   GraduationCap,
   Loader2,
+  MapPin,
   MessageCircle,
   MonitorCog,
   PlugZap,
@@ -21,6 +23,7 @@ import {
 import { type FormEvent, useCallback, useEffect, useState } from "react";
 import { client } from "../../api/client";
 import { isApiError } from "../../api/client-types-core";
+import { invalidateWeatherCache } from "../../hooks/useWeather";
 import { useAppSelector, useAppSelectorShallow } from "../../state";
 import { AdvancedToggle } from "./AdvancedToggle";
 import { useAdvancedSettingsEnabled } from "./AdvancedToggle.hooks";
@@ -517,6 +520,8 @@ export function CapabilitiesSection() {
         />
       </SettingsGroup>
 
+      <DeviceLocationGroup />
+
       {advancedEnabled ? (
         <form onSubmit={handleCapabilityConnect}>
           <SettingsGroup
@@ -795,6 +800,148 @@ export function CapabilitiesSection() {
         </form>
       ) : null}
     </SettingsStack>
+  );
+}
+
+type LocationPermission =
+  | "loading"
+  | "granted"
+  | "prompt"
+  | "denied"
+  | "unsupported";
+
+/**
+ * Device-location permission row. Weather (and any location-aware surface)
+ * uses precise device coordinates only while the browser permission is
+ * granted; otherwise it runs on the server's coarse IP-based fallback. This
+ * row is where that fallback's notification deep-links: it shows the live
+ * permission state and hosts the explicit user-initiated prompt (settings and
+ * the weather tile tap are the only places allowed to trigger the OS dialog).
+ */
+function DeviceLocationGroup() {
+  const t = useAppSelector((s) => s.t);
+  const [permission, setPermission] = useState<LocationPermission>("loading");
+  const [requesting, setRequesting] = useState(false);
+
+  useEffect(() => {
+    if (typeof navigator === "undefined" || !navigator.geolocation) {
+      setPermission("unsupported");
+      return;
+    }
+    let disposed = false;
+    let status: PermissionStatus | null = null;
+    const apply = (state: PermissionState) => {
+      if (!disposed) setPermission(state);
+    };
+    const perms = navigator.permissions;
+    if (!perms?.query) {
+      // No Permissions API (older WebKit): the state can't be read, but the
+      // prompt button still works — render the not-granted affordance.
+      setPermission("prompt");
+      return;
+    }
+    perms
+      .query({ name: "geolocation" })
+      .then((s) => {
+        status = s;
+        apply(s.state);
+        s.onchange = () => apply(s.state);
+      })
+      .catch(() => {
+        // error-policy:J3 geolocation not a queryable permission here — same
+        // designed degrade as the missing-API path above.
+        apply("prompt");
+      });
+    return () => {
+      disposed = true;
+      if (status) status.onchange = null;
+    };
+  }, []);
+
+  const requestPrecise = useCallback(() => {
+    if (typeof navigator === "undefined" || !navigator.geolocation) return;
+    setRequesting(true);
+    navigator.geolocation.getCurrentPosition(
+      () => {
+        setRequesting(false);
+        setPermission("granted");
+        // Drop the cached (approximate) reading so the widget refetches
+        // precise conditions on its next revalidate instead of after the TTL.
+        invalidateWeatherCache();
+      },
+      () => {
+        setRequesting(false);
+        // Denied (or timed out): re-render from the live permission state —
+        // a hard "denied" means the browser will no longer re-prompt and the
+        // description below tells the user where to unblock it.
+        navigator.permissions
+          ?.query({ name: "geolocation" })
+          .then((s) => setPermission(s.state))
+          .catch(() => setPermission("prompt")); // error-policy:J3 unreadable state renders the prompt affordance
+      },
+      { timeout: 10_000 },
+    );
+  }, []);
+
+  const statusLabel =
+    permission === "granted"
+      ? t("settings.sections.capabilities.locationGranted", {
+          defaultValue: "Precise location is on",
+        })
+      : permission === "denied"
+        ? t("settings.sections.capabilities.locationDenied", {
+            defaultValue:
+              "Blocked — allow location for this app in your browser or OS settings",
+          })
+        : permission === "unsupported"
+          ? t("settings.sections.capabilities.locationUnsupported", {
+              defaultValue: "Not available on this device",
+            })
+          : t("settings.sections.capabilities.locationOff", {
+              defaultValue:
+                "Off — weather uses your approximate (network-based) location",
+            });
+
+  return (
+    <SettingsGroup
+      title={t("settings.sections.capabilities.locationGroupTitle", {
+        defaultValue: "Device Location",
+      })}
+    >
+      <SettingsRow
+        icon={MapPin}
+        label={t("settings.sections.capabilities.locationLabel", {
+          defaultValue: "Precise location",
+        })}
+        description={statusLabel}
+        control={
+          permission === "prompt" || permission === "loading" ? (
+            <SettingsActionButton
+              agentId="capability-location-enable"
+              agentGroup="capabilities"
+              agentLabel={t(
+                "settings.sections.capabilities.locationEnableLabel",
+                { defaultValue: "Enable precise location" },
+              )}
+              agentStatus={requesting ? "loading" : undefined}
+              disabled={requesting || permission === "loading"}
+              onClick={requestPrecise}
+              className="h-9 gap-2 rounded-md text-sm"
+              data-testid="settings-location-enable"
+            >
+              {requesting ? (
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              ) : (
+                <MapPin className="h-4 w-4" aria-hidden />
+              )}
+              {t("settings.sections.capabilities.locationEnable", {
+                defaultValue: "Enable",
+              })}
+            </SettingsActionButton>
+          ) : undefined
+        }
+      />
+    </SettingsGroup>
   );
 }
 

--- a/packages/ui/src/components/shell/DefaultHomeWidgets.tsx
+++ b/packages/ui/src/components/shell/DefaultHomeWidgets.tsx
@@ -82,6 +82,12 @@ function WeatherTile(): React.JSX.Element {
     <div
       data-testid="home-weather"
       data-status={weather.status}
+      data-approximate={weather.approximate || undefined}
+      title={
+        weather.status === "ready" && weather.approximate
+          ? "Estimated from your network address — enable precise location in Settings → Capabilities"
+          : undefined
+      }
       className={cn(
         "col-span-2 row-span-2 flex min-w-0 flex-col items-end justify-end text-right text-white",
         WALLPAPER_FLOAT_SHADOW,

--- a/packages/ui/src/hooks/useWeather.test.ts
+++ b/packages/ui/src/hooks/useWeather.test.ts
@@ -19,7 +19,69 @@ const originalGeolocationDescriptor = Object.getOwnPropertyDescriptor(
   navigator,
   "geolocation",
 );
-const WEATHER_CACHE_KEY = "eliza:weather:v1";
+const WEATHER_CACHE_KEY = "eliza:weather:v2";
+const LOCATION_NOTICE_FLAG_KEY = "eliza:weather:location-notice:v1";
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/**
+ * fetch stub covering every backend the hook can reach: the agent's
+ * IP-geolocation route, the notification POST the approximate path files, and
+ * Open-Meteo. Each can be overridden to exercise a failure leg.
+ */
+function installFetchRouter(overrides?: {
+  approximate?: () => Response | Promise<Response>;
+  openMeteo?: () => Response | Promise<Response>;
+  notifications?: () => Response | Promise<Response>;
+}) {
+  const calls: string[] = [];
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input instanceof Request ? input.url : input);
+    calls.push(url);
+    if (url.includes("/api/location/approximate")) {
+      return (
+        overrides?.approximate?.() ??
+        jsonResponse({
+          lat: 40.71,
+          lon: -74.01,
+          accuracyMeters: 5000,
+          source: "test-geo",
+        })
+      );
+    }
+    if (url.includes("/api/notifications")) {
+      return (
+        overrides?.notifications?.() ??
+        jsonResponse({ notification: { id: "n-1" } }, 201)
+      );
+    }
+    if (url.includes("api.open-meteo.com")) {
+      return (
+        overrides?.openMeteo?.() ??
+        jsonResponse({ current: { temperature_2m: 18.6, weather_code: 0 } })
+      );
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return { fetchMock, calls };
+}
+
+function denyGeolocation(): void {
+  Object.defineProperty(navigator, "permissions", {
+    configurable: true,
+    value: { query: vi.fn().mockResolvedValue({ state: "denied" }) },
+  });
+  Object.defineProperty(navigator, "geolocation", {
+    configurable: true,
+    value: undefined,
+  });
+}
 
 afterEach(() => {
   cleanup();
@@ -125,26 +187,62 @@ describe("prefers24HourClock (#14345)", () => {
 });
 
 describe("useWeather", () => {
-  it("does not call third-party weather services without granted geolocation", async () => {
-    const fetchMock = vi.fn();
-    globalThis.fetch = fetchMock;
-    Object.defineProperty(navigator, "permissions", {
-      configurable: true,
-      value: {
-        query: vi.fn().mockResolvedValue({ state: "denied" }),
-      },
+  it("falls back to the server's IP-based coordinates without granted geolocation", async () => {
+    const { calls } = installFetchRouter();
+    denyGeolocation();
+
+    const { result } = renderHook(() => useWeather());
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("ready");
     });
-    Object.defineProperty(navigator, "geolocation", {
-      configurable: true,
-      value: undefined,
+    expect(result.current.approximate).toBe(true);
+    expect(result.current.temp).toBe(19); // rounded from 18.6
+    // The Open-Meteo request carries the IP-derived coordinates.
+    const meteoUrl = calls.find((u) => u.includes("api.open-meteo.com"));
+    expect(meteoUrl).toContain("latitude=40.71");
+    expect(meteoUrl).toContain("longitude=-74.01");
+    // Never the OS prompt: no geolocation object existed to prompt with.
+  });
+
+  it("files the approximate-location notification once, flag-guarded across dismissals", async () => {
+    const { calls } = installFetchRouter();
+    denyGeolocation();
+
+    const first = renderHook(() => useWeather());
+    await waitFor(() => expect(first.result.current.status).toBe("ready"));
+    await waitFor(() =>
+      expect(localStorage.getItem(LOCATION_NOTICE_FLAG_KEY)).toBe("posted"),
+    );
+    const notifyPosts = () =>
+      calls.filter((u) => u.includes("/api/notifications")).length;
+    expect(notifyPosts()).toBe(1);
+    first.unmount();
+
+    // A remount (or a later approximate fetch after the user dismissed the
+    // row) must NOT re-file — the localStorage flag, not the server groupKey,
+    // is the once-guard.
+    localStorage.removeItem(WEATHER_CACHE_KEY);
+    const second = renderHook(() => useWeather());
+    await waitFor(() => expect(second.result.current.status).toBe("ready"));
+    expect(notifyPosts()).toBe(1);
+  });
+
+  it("degrades to unavailable when BOTH device location and the IP fallback fail", async () => {
+    const { calls } = installFetchRouter({
+      approximate: () => jsonResponse({ error: "unavailable" }, 502),
     });
+    denyGeolocation();
 
     const { result } = renderHook(() => useWeather());
 
     await waitFor(() => {
       expect(result.current.status).toBe("unavailable");
     });
-    expect(fetchMock).not.toHaveBeenCalled();
+    // No coords → the third-party weather service is never called.
+    expect(calls.some((u) => u.includes("api.open-meteo.com"))).toBe(false);
+    // And no notification is filed for a failed fallback.
+    expect(calls.some((u) => u.includes("/api/notifications"))).toBe(false);
   });
 
   it("ignores cached readings whose unit does not match the current locale", async () => {
@@ -158,31 +256,24 @@ describe("useWeather", () => {
         unit: wrongUnit,
         condition: "Clear",
         kind: "clear",
+        approximate: false,
         fetchedAt: Date.now(),
       }),
     );
-    const fetchMock = vi.fn();
-    globalThis.fetch = fetchMock;
-    Object.defineProperty(navigator, "permissions", {
-      configurable: true,
-      value: {
-        query: vi.fn().mockResolvedValue({ state: "denied" }),
-      },
-    });
-    Object.defineProperty(navigator, "geolocation", {
-      configurable: true,
-      value: undefined,
-    });
+    installFetchRouter();
+    denyGeolocation();
 
     const { result } = renderHook(() => useWeather());
 
+    // The mismatched-unit cache is ignored (no stale °F flash on a °C locale);
+    // the IP fallback then loads real conditions in the CURRENT unit.
     expect(result.current.status).toBe("loading");
-    await waitFor(() => expect(result.current.status).toBe("unavailable"));
+    await waitFor(() => expect(result.current.status).toBe("ready"));
     expect(result.current.unit).toBe(currentUnit.label);
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.current.temp).toBe(19);
   });
 
-  it("does not keep a stale cached reading as ready when revalidation cannot run", async () => {
+  it("does not keep a stale cached reading as ready when revalidation fails", async () => {
     const currentUnit = temperatureUnitForLocale();
     localStorage.setItem(
       WEATHER_CACHE_KEY,
@@ -192,31 +283,47 @@ describe("useWeather", () => {
         unit: currentUnit.label,
         condition: "Clear",
         kind: "clear",
+        approximate: true,
         fetchedAt: Date.now() - 31 * 60_000,
       }),
     );
-    const fetchMock = vi.fn();
-    globalThis.fetch = fetchMock;
-    Object.defineProperty(navigator, "permissions", {
-      configurable: true,
-      value: {
-        query: vi.fn().mockResolvedValue({ state: "denied" }),
-      },
+    installFetchRouter({
+      approximate: () => jsonResponse({ error: "unavailable" }, 502),
     });
-    Object.defineProperty(navigator, "geolocation", {
-      configurable: true,
-      value: undefined,
-    });
+    denyGeolocation();
 
     const { result } = renderHook(() => useWeather());
 
+    // Paints instantly from the (stale) cache, then the failed revalidation
+    // surfaces the explicit unavailable state instead of a healthy-old lie.
     expect(result.current.status).toBe("ready");
     await waitFor(() => expect(result.current.status).toBe("unavailable"));
-    expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("tap-to-grant (requestLocation) prompts for location, then loads real conditions (#14345)", async () => {
-    // Auto path denied (no prompt), but geolocation exists for the explicit tap.
+  it("drops v1 cache entries that predate the `approximate` field", async () => {
+    localStorage.setItem(
+      WEATHER_CACHE_KEY,
+      JSON.stringify({
+        status: "ready",
+        temp: 72,
+        unit: temperatureUnitForLocale().label,
+        condition: "Clear",
+        kind: "clear",
+        fetchedAt: Date.now(),
+      }),
+    );
+    installFetchRouter();
+    denyGeolocation();
+
+    const { result } = renderHook(() => useWeather());
+    // Field missing → cache invalid → fresh load (no ready-from-cache paint).
+    expect(result.current.status).toBe("loading");
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+  });
+
+  it("tap-to-grant (requestLocation) prompts for location, then loads precise conditions (#14345)", async () => {
+    // Auto path not granted (runs on the IP fallback), but geolocation exists
+    // for the explicit tap.
     const getCurrentPosition = vi.fn((success: PositionCallback) =>
       success({
         coords: { latitude: 37.7, longitude: -122.4 },
@@ -230,29 +337,28 @@ describe("useWeather", () => {
       configurable: true,
       value: { getCurrentPosition },
     });
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        current: { temperature_2m: 21.4, weather_code: 0 },
-      }),
-    });
-    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const { calls } = installFetchRouter();
 
     const { result } = renderHook(() => useWeather());
-    // Home load: no granted permission → unavailable, no prompt, no fetch.
-    await waitFor(() => expect(result.current.status).toBe("unavailable"));
+    // Home load: no granted permission → approximate conditions, no OS prompt.
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(result.current.approximate).toBe(true);
     expect(getCurrentPosition).not.toHaveBeenCalled();
-    expect(fetchMock).not.toHaveBeenCalled();
 
-    // Explicit tap → the ONE allowed OS prompt → fetch → ready.
+    // Explicit tap → the ONE allowed OS prompt → precise fetch → ready.
     act(() => {
       result.current.requestLocation();
     });
-    await waitFor(() => expect(result.current.status).toBe("ready"));
+    await waitFor(() => expect(result.current.approximate).toBe(false));
+    expect(result.current.status).toBe("ready");
     expect(getCurrentPosition).toHaveBeenCalledTimes(1);
-    expect(result.current.temp).toBe(21); // rounded from 21.4
-    // The Open-Meteo request carries the locale-derived unit param.
-    const url = String(fetchMock.mock.calls[0]?.[0]);
-    expect(url).toMatch(/temperature_unit=(celsius|fahrenheit)/);
+    expect(result.current.temp).toBe(19);
+    // The precise Open-Meteo request carries the device coordinates + the
+    // locale-derived unit param.
+    const preciseUrl = calls
+      .filter((u) => u.includes("api.open-meteo.com"))
+      .at(-1);
+    expect(preciseUrl).toContain("latitude=37.7");
+    expect(preciseUrl).toMatch(/temperature_unit=(celsius|fahrenheit)/);
   });
 });

--- a/packages/ui/src/hooks/useWeather.ts
+++ b/packages/ui/src/hooks/useWeather.ts
@@ -1,8 +1,12 @@
 /**
  * Current-conditions weather for the home weather widget, sourced from Open-Meteo
- * with permission-gated geolocation and all network/clock work in effects.
+ * with permission-gated geolocation, an IP-based approximate fallback, and all
+ * network/clock work in effects.
  */
+
+import { logger } from "@elizaos/logger";
 import * as React from "react";
+import { client } from "../api/client";
 import { useIntervalWhenDocumentVisible } from "./useDocumentVisibility";
 
 /**
@@ -10,10 +14,17 @@ import { useIntervalWhenDocumentVisible } from "./useDocumentVisibility";
  *
  * Source: Open-Meteo (https://open-meteo.com) — free, no API key, and reachable
  * under the app CSP. Location comes from the browser/Capacitor Geolocation API
- * only when permission is already granted; first-run/home load never triggers a
- * location prompt or noisy third-party IP lookup. All network + clock work
- * happens in effects (never the render path) so the home's determinism gate
- * stays clean.
+ * when permission is already granted; without permission the widget falls back
+ * to the agent server's coarse IP-based coordinates (GET
+ * /api/location/approximate — server-side because the public IP-geo services
+ * CORS-fail on hosted app origins), flagged `approximate` end-to-end. First-run
+ * /home load never triggers a location prompt. All network + clock work happens
+ * in effects (never the render path) so the home's determinism gate stays clean.
+ *
+ * The first time a session lands on the approximate path it files ONE
+ * dismissible notification (stable groupKey; posted-once localStorage flag)
+ * deep-linking to Settings → Capabilities, where precise location can be
+ * enabled.
  *
  * The result is cached in localStorage for {@link WEATHER_TTL_MS} so remounts
  * (every home visit) paint instantly from cache and only refetch when stale.
@@ -40,11 +51,19 @@ export interface Weather {
   condition: string;
   /** Coarse bucket for icon selection. */
   kind: WeatherKind;
+  /** True when coords came from the IP fallback (city-level), not the device. */
+  approximate: boolean;
 }
 
 const WEATHER_TTL_MS = 30 * 60_000; // refetch at most every 30 min
-const WEATHER_CACHE_KEY = "eliza:weather:v1";
+// v2: cache entries carry `approximate`; the bump discards v1 entries that lack it.
+const WEATHER_CACHE_KEY = "eliza:weather:v2";
 const GEO_TIMEOUT_MS = 8_000;
+/** Posted-once guard for the approximate-location notification. A stable
+ *  groupKey makes a duplicate POST collapse server-side, but after the user
+ *  DISMISSES the row a re-post would resurrect it — this flag makes the nag
+ *  once-per-browser instead. */
+const LOCATION_NOTICE_FLAG_KEY = "eliza:weather:location-notice:v1";
 
 interface CachedWeather extends Weather {
   fetchedAt: number;
@@ -133,6 +152,7 @@ function readCache(): CachedWeather | null {
     if (!raw) return null;
     const parsed = JSON.parse(raw) as CachedWeather;
     if (typeof parsed.fetchedAt !== "number") return null;
+    if (typeof parsed.approximate !== "boolean") return null;
     if (parsed.unit !== TEMPERATURE_UNIT.label) return null;
     return parsed;
   } catch {
@@ -153,8 +173,8 @@ function writeCache(value: CachedWeather): void {
 
 /** Has the user ALREADY granted geolocation? We never trigger the OS permission
  *  prompt from the home — precise device location is used only when it's already
- *  allowed; otherwise the widget degrades to its unavailable state (no prompt,
- *  and no IP-lookup fallback — see {@link resolveCoords}). */
+ *  allowed; otherwise {@link resolveCoords} falls back to the server's coarse
+ *  IP-based coordinates. */
 async function geolocationAlreadyGranted(): Promise<boolean> {
   try {
     const perms = navigator.permissions;
@@ -163,37 +183,64 @@ async function geolocationAlreadyGranted(): Promise<boolean> {
     return status.state === "granted";
   } catch {
     // error-policy:J3 Permissions API unsupported (older WebKit) reads as
-    // "not granted" — the widget degrades to its unavailable state (the
-    // designed no-prompt path; no IP-lookup fallback).
+    // "not granted" — the widget uses the IP-based approximate fallback
+    // instead of prompting.
     return false;
   }
 }
 
+interface ResolvedCoords extends Coords {
+  approximate: boolean;
+}
+
+/** Server-side coarse IP-geolocation (city centroid). Same-origin/agent-API
+ *  call, so it works on hosted origins where a browser-side lookup CORS-fails. */
+async function fetchApproximateCoords(): Promise<ResolvedCoords> {
+  const data = await client.fetch<{ lat: number; lon: number }>(
+    "/api/location/approximate",
+  );
+  if (
+    typeof data.lat !== "number" ||
+    typeof data.lon !== "number" ||
+    !Number.isFinite(data.lat) ||
+    !Number.isFinite(data.lon)
+  ) {
+    throw new Error("approximate-location: no usable coordinates");
+  }
+  return { lat: data.lat, lon: data.lon, approximate: true };
+}
+
 /**
- * Resolve coordinates with precise device location ONLY if already granted.
- * Without existing permission, degrade to unavailable instead of making a
- * browser-side IP lookup that can CORS-fail on hosted app origins.
+ * Resolve coordinates: precise device location if permission is ALREADY
+ * granted (never prompting from the home), otherwise the agent server's
+ * IP-based approximate coordinates. Only when both paths fail does the widget
+ * degrade to its unavailable state.
  */
-async function resolveCoords(): Promise<Coords> {
+async function resolveCoords(): Promise<ResolvedCoords> {
   const canUseDevice =
     typeof navigator !== "undefined" &&
     !!navigator.geolocation &&
     (await geolocationAlreadyGranted());
-  if (!canUseDevice) throw new Error("no-location");
 
-  const deviceCoords = await new Promise<Coords | null>((resolve) => {
-    navigator.geolocation.getCurrentPosition(
-      (pos) => resolve({ lat: pos.coords.latitude, lon: pos.coords.longitude }),
-      () => resolve(null),
-      { timeout: GEO_TIMEOUT_MS, maximumAge: WEATHER_TTL_MS },
-    );
-  });
+  if (canUseDevice) {
+    const deviceCoords = await new Promise<Coords | null>((resolve) => {
+      navigator.geolocation.getCurrentPosition(
+        (pos) =>
+          resolve({ lat: pos.coords.latitude, lon: pos.coords.longitude }),
+        () => resolve(null),
+        { timeout: GEO_TIMEOUT_MS, maximumAge: WEATHER_TTL_MS },
+      );
+    });
+    if (deviceCoords) return { ...deviceCoords, approximate: false };
+  }
 
-  if (deviceCoords) return deviceCoords;
-  throw new Error("no-location");
+  return fetchApproximateCoords();
 }
 
-async function fetchWeatherAt(coords: Coords): Promise<Weather> {
+async function fetchWeatherAt(
+  coords: Coords,
+  approximate: boolean,
+): Promise<Weather> {
   const url = `https://api.open-meteo.com/v1/forecast?latitude=${coords.lat}&longitude=${coords.lon}&current=temperature_2m,weather_code&temperature_unit=${TEMPERATURE_UNIT.param}`;
   const res = await fetch(url);
   if (!res.ok) throw new Error(`open-meteo ${res.status}`);
@@ -210,11 +257,54 @@ async function fetchWeatherAt(coords: Coords): Promise<Weather> {
     unit: TEMPERATURE_UNIT.label,
     condition,
     kind,
+    approximate,
   };
 }
 
 async function fetchWeather(): Promise<Weather> {
-  return fetchWeatherAt(await resolveCoords());
+  const resolved = await resolveCoords();
+  return fetchWeatherAt(resolved, resolved.approximate);
+}
+
+/**
+ * One-time (per browser) dismissible notification telling the user weather is
+ * running on approximate location, deep-linking to Settings → Capabilities
+ * where precise location can be enabled. The localStorage flag — not the
+ * notification's groupKey — is the once-guard, so a user who dismisses the row
+ * is never re-nagged by a later approximate fetch (see
+ * {@link LOCATION_NOTICE_FLAG_KEY}).
+ */
+function noteApproximateLocationOnce(): void {
+  try {
+    if (localStorage.getItem(LOCATION_NOTICE_FLAG_KEY) === "posted") return;
+  } catch {
+    // error-policy:J3 storage denied (private mode) reads as "already
+    // posted": without a durable flag the nag would re-file on every visit,
+    // which is worse than not filing it.
+    return;
+  }
+  client
+    .createNotification({
+      title: "Weather is using approximate location",
+      body: "Location access is off, so weather is estimated from your network address (city-level). Enable precise location in Settings → Capabilities for accurate conditions.",
+      category: "system",
+      priority: "low",
+      source: "system",
+      deepLink: "/settings#capabilities",
+      groupKey: "weather:approximate-location",
+    })
+    .then(() => {
+      localStorage.setItem(LOCATION_NOTICE_FLAG_KEY, "posted");
+    })
+    .catch((err: unknown) => {
+      // error-policy:J7 the notice is a side diagnostic of the weather path —
+      // a failed POST must not break the widget; the unset flag retries on
+      // the next approximate fetch, and the failure is logged.
+      logger.warn(
+        { err },
+        "[useWeather] approximate-location notification post failed",
+      );
+    });
 }
 
 /**
@@ -235,12 +325,28 @@ async function promptForCoords(): Promise<Coords> {
   });
 }
 
+/**
+ * Drop the cached reading so the next revalidate refetches immediately — used
+ * by Settings → Capabilities right after precise location is granted, so the
+ * widget doesn't keep showing the approximate reading for the rest of the TTL.
+ */
+export function invalidateWeatherCache(): void {
+  try {
+    localStorage.removeItem(WEATHER_CACHE_KEY);
+  } catch (err) {
+    // error-policy:J6 best-effort cache drop; a surviving stale entry only
+    // delays the precise refetch until the TTL lapses.
+    logger.debug({ err }, "[useWeather] weather cache invalidation failed");
+  }
+}
+
 const LOADING: Weather = {
   status: "loading",
   temp: null,
   unit: TEMPERATURE_UNIT.label,
   condition: "",
   kind: "cloudy",
+  approximate: false,
 };
 
 export interface WeatherState extends Weather {
@@ -275,6 +381,7 @@ export function useWeather(): WeatherState {
       .then((next) => {
         setWeather(next);
         writeCache({ ...next, fetchedAt: Date.now() });
+        if (next.approximate) noteApproximateLocationOnce();
       })
       .catch(() => {
         // error-policy:J4 stale/no-location/weather failure renders the
@@ -296,7 +403,7 @@ export function useWeather(): WeatherState {
 
   const requestLocation = React.useCallback(() => {
     void promptForCoords()
-      .then((coords) => fetchWeatherAt(coords))
+      .then((coords) => fetchWeatherAt(coords, false))
       .then((next) => {
         setWeather(next);
         writeCache({ ...next, fetchedAt: Date.now() });


### PR DESCRIPTION
## Summary

The home weather widget dead-ended on **"Tap to enable location"** whenever geolocation permission was absent. Now:

1. **IP-based prediction without permission** — the widget loads real conditions from coarse IP-derived coordinates (city-level), flagged `approximate` end-to-end; the tap-to-enable tile remains only for the both-paths-failed case.
2. **Dismissible notification** — the first approximate fetch files ONE notification ("Weather is using approximate location", Settings category) with the standard per-row dismiss; dismissing deletes it server-side and it never re-files (localStorage once-flag, not the groupKey, is the guard).
3. **Set it in Settings** — the notification deep-links to **Settings → Capabilities → Device Location**: a new row showing the live permission state with the explicit user-initiated enable prompt (grants also invalidate the weather cache so the next revalidate is precise).

## Design notes

- The IP lookup is **server-side** (`GET /api/location/approximate` in misc-routes): the public geo services CORS-fail on hosted app origins and would need per-shell CSP carve-outs; the agent process has neither constraint. Provider chain `ipapi.co` → `ipwho.is` (override: `ELIZA_IP_GEO_SERVICES`), 5 s timeout each, 15-min cache + in-flight dedupe, **502 on total failure — never fabricated coordinates**. Coarse-accuracy contract (`accuracyMeters: 5000`) mirrored from the Electrobun `LocationManager`.
- The home-load **no-OS-prompt rule (#14345) is intact** — prompting still happens only from the tile tap or the new settings row.
- Weather cache bumped to `v2` (entries now carry `approximate`; v1 entries are dropped, not defaulted).

## Tests (all real-path, no module mocks)

- `packages/agent/src/api/misc-routes.location.test.ts` — the route against a **real local HTTP geo-provider stub** (real fetch/timeout/parse): ipapi-style + ip-api-style keys, provider fall-through, 502 on no-usable-coordinates, cache short-circuit. **4/4**
- `packages/ui/src/hooks/useWeather.test.ts` — IP fallback end state + coords propagation to Open-Meteo, notification filed once and flag-guarded across remounts/dismissals, both-fail → unavailable (and no notification for a failed fallback), stale-cache honesty, v1-cache rejection, tap-to-grant precise path. **26/26**
- `DefaultHomeWidgets` + `CapabilitiesSection` component suites: **11/11**
- Typecheck (`packages/ui`, `packages/agent`), biome, and `error-policy-ratchet` (no new empty catches): clean.

## Live verification (real dev server, real providers — reviewed by hand)

`GET /api/location/approximate` on the running server:
```
{"lat":40.6799,"lon":-74.0028,"accuracyMeters":5000,"source":"ipapi.co"}  HTTP 200
```

Widget with **no** geolocation permission — real conditions from the IP path (`data-approximate=true`), notification present with dismiss X:

![home with approximate weather + notification](https://gist.githubusercontent.com/lalalune/64291e2294a059ad31467e4218e3e90c/raw/weather-01b-home-with-notification.png)

Notification tap deep-links to Settings → Capabilities with the new Device Location row (live "Off — approximate" state + Enable prompt):

![settings device location row](https://gist.githubusercontent.com/lalalune/64291e2294a059ad31467e4218e3e90c/raw/weather-02-settings-capabilities.png)

Row-scoped dismiss removes the notification (server-side delete; Playwright asserted `visible: false` after):

![home after dismiss](https://gist.githubusercontent.com/lalalune/64291e2294a059ad31467e4218e3e90c/raw/weather-03-home-after-dismiss.png)

- Real-LLM trajectories: N/A — no agent/action/provider/prompt/model behavior change (widget + HTTP route + settings row).
- Audio walkthrough: N/A — no voice surface.
- Per-platform native capture: N/A — web dashboard change; the Capacitor/Electrobun shells consume the same UI bundle, and the Electrobun shell separately keeps its own native IP-geo fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)