### PR TITLE
feat(pwa): web push client foundation — SW push handlers, subscription manager, badge API

### DIFF
--- a/packages/app-core/src/api/dev-route-catalog.ts
+++ b/packages/app-core/src/api/dev-route-catalog.ts
@@ -458,6 +458,7 @@ const SETTINGS_SECTIONS: DevRouteSettingsSection[] = [
   { id: "connectors", label: "Connectors" },
   { id: "appearance", label: "Appearance" },
   { id: "background", label: "Background" },
+  { id: "notifications", label: "Notifications" },
   { id: "runtime", label: "Runtime" },
   { id: "wallet-rpc", label: "Wallet & RPC" },
   { id: "remote-plugins", label: "Remote Plugins" },

--- a/packages/app/public/sw-push.js
+++ b/packages/app/public/sw-push.js
@@ -1,0 +1,265 @@
+/**
+ * Web Push handler logic for the elizaOS service worker (iOS 16.4+ installed
+ * PWA target). Extracted from `sw.js` into a standalone, dependency-free module
+ * so the notification-shaping, click-routing, and badge logic can be unit
+ * tested without a live ServiceWorkerGlobalScope.
+ *
+ * `sw.js` loads this via `importScripts("/sw-push.js")`, which runs the IIFE
+ * below and attaches `self.__elizaPush` (the pure helpers) so the SW's event
+ * listeners can delegate to tested code. Tests import the same file into a
+ * jsdom global with a stubbed `self`/`navigator` and assert `self.__elizaPush`.
+ *
+ * NO framework, NO build step — this file ships verbatim from `public/`.
+ */
+
+"use strict";
+
+(function initElizaPush(scope) {
+  /**
+   * Default notification presentation. A push payload may override any of these;
+   * missing/garbage fields fall back so a malformed push still renders something
+   * sane rather than throwing inside the `push` event (which would drop it).
+   */
+  const DEFAULT_TITLE = "New message";
+  const DEFAULT_ICON = "/logos/icon-192.png";
+  const DEFAULT_BADGE = "/logos/badge-72.png";
+  const DEFAULT_TAG = "eliza-message";
+
+  /**
+   * Defensively parse a PushMessageData into a plain object. iOS/APNs delivers
+   * the VAPID-encrypted payload as bytes; `event.data.json()` throws on
+   * non-JSON, and a compromised/misbehaving sender could deliver anything. Any
+   * failure yields `{}` so the caller renders defaults instead of crashing.
+   */
+  function parsePushData(data) {
+    if (!data) return {};
+    try {
+      if (typeof data.json === "function") {
+        const parsed = data.json();
+        return parsed && typeof parsed === "object" ? parsed : {};
+      }
+      if (typeof data.text === "function") {
+        const text = data.text();
+        if (!text) return {};
+        const parsed = JSON.parse(text);
+        return parsed && typeof parsed === "object" ? parsed : {};
+      }
+    } catch {
+      // Malformed / non-JSON push — render defaults rather than drop.
+      return {};
+    }
+    return {};
+  }
+
+  /**
+   * Shape a parsed push payload into `showNotification(title, options)` args.
+   *
+   * Payload contract (all optional):
+   *   { title, body, icon, badge, tag, renotify, requireInteraction, silent,
+   *     badgeCount, data: { deepLink, conversationId, agentId, ... } }
+   *
+   * `tag` + `renotify` control coalescing: same-tag pushes replace the prior
+   * notification (one bubble per conversation) and only re-alert when
+   * `renotify` is true. The `data` blob is carried onto the notification so
+   * `notificationclick` can route to the right conversation.
+   */
+  function buildNotification(payload) {
+    const p = payload && typeof payload === "object" ? payload : {};
+    const src = p.data && typeof p.data === "object" ? p.data : {};
+
+    const title =
+      typeof p.title === "string" && p.title.trim() ? p.title : DEFAULT_TITLE;
+
+    const data = {
+      ...src,
+      deepLink: typeof src.deepLink === "string" ? src.deepLink : undefined,
+      conversationId:
+        typeof src.conversationId === "string" ? src.conversationId : undefined,
+      agentId: typeof src.agentId === "string" ? src.agentId : undefined,
+    };
+
+    const options = {
+      body: typeof p.body === "string" ? p.body : "",
+      icon: typeof p.icon === "string" ? p.icon : DEFAULT_ICON,
+      badge: typeof p.badge === "string" ? p.badge : DEFAULT_BADGE,
+      // Same-conversation pushes coalesce onto one bubble.
+      tag: typeof p.tag === "string" && p.tag ? p.tag : DEFAULT_TAG,
+      renotify: p.renotify === true,
+      requireInteraction: p.requireInteraction === true,
+      silent: p.silent === true,
+      data,
+    };
+
+    return { title, options };
+  }
+
+  /**
+   * Derive the app-badge count from a payload. Returns a non-negative integer
+   * when the sender provides `badgeCount`, otherwise `null` (leave the badge
+   * untouched — a push with no count shouldn't clobber an existing badge).
+   */
+  function badgeCountFromPayload(payload) {
+    const p = payload && typeof payload === "object" ? payload : {};
+    const raw = p.badgeCount;
+    if (typeof raw !== "number" || !Number.isFinite(raw) || raw < 0) return null;
+    return Math.floor(raw);
+  }
+
+  /**
+   * Set the app badge if the platform supports it and a count was provided.
+   * Feature-detected + best-effort: `setAppBadge` rejects are swallowed so a
+   * badge failure never breaks the push. No-op where unsupported (most desktop
+   * browsers, older iOS).
+   */
+  function applyBadge(navigatorLike, count) {
+    if (count === null || count === undefined) return Promise.resolve();
+    const nav = navigatorLike;
+    if (!nav || typeof nav.setAppBadge !== "function") return Promise.resolve();
+    try {
+      if (count <= 0 && typeof nav.clearAppBadge === "function") {
+        return Promise.resolve(nav.clearAppBadge()).catch(() => {});
+      }
+      return Promise.resolve(nav.setAppBadge(count)).catch(() => {});
+    } catch {
+      return Promise.resolve();
+    }
+  }
+
+  /** Clear the app badge if supported. Best-effort / feature-detected. */
+  function clearBadge(navigatorLike) {
+    const nav = navigatorLike;
+    if (!nav || typeof nav.clearAppBadge !== "function") {
+      return Promise.resolve();
+    }
+    try {
+      return Promise.resolve(nav.clearAppBadge()).catch(() => {});
+    } catch {
+      return Promise.resolve();
+    }
+  }
+
+  /**
+   * Whether a same-origin app path is a safe root-relative navigation target
+   * (mirrors `navigate-deep-link.ts` `isSafeDeepLink` for the SW context, which
+   * cannot import the UI module). Only `/foo` (not `//host`) is allowed here;
+   * absolute `http(s)://` targets are handled by `openWindow` directly and are
+   * validated by the caller. Anything else is dropped.
+   */
+  function isSafeAppPath(path) {
+    return (
+      typeof path === "string" && path.startsWith("/") && !path.startsWith("//")
+    );
+  }
+
+  /**
+   * Resolve the navigation target for a clicked notification. Prefers an
+   * explicit `deepLink`, else builds `/?conversation=<id>&agent=<id>` from the
+   * carried ids, else falls back to the app root. Returns an app-root-relative
+   * URL string (never a foreign origin — a push can't redirect the app away).
+   */
+  function resolveClickTarget(notificationData, origin) {
+    const d =
+      notificationData && typeof notificationData === "object"
+        ? notificationData
+        : {};
+
+    if (isSafeAppPath(d.deepLink)) {
+      return d.deepLink;
+    }
+
+    if (typeof d.conversationId === "string" && d.conversationId) {
+      const params = new URLSearchParams();
+      params.set("conversation", d.conversationId);
+      if (typeof d.agentId === "string" && d.agentId) {
+        params.set("agent", d.agentId);
+      }
+      return `/?${params.toString()}`;
+    }
+
+    return "/";
+  }
+
+  /**
+   * Focus an already-open client for the target path (if any) and post it a
+   * navigate message; otherwise open a new window. Returns a promise.
+   *
+   * `clientsLike.matchAll` + `openWindow` are the injectable seams. A focused
+   * client is told to navigate in-app (SPA route change) rather than a hard
+   * reload; the message shape matches what the page's SW message listener reads.
+   */
+  function focusOrOpen(clientsLike, targetPath, origin) {
+    const clients = clientsLike;
+    if (!clients || typeof clients.matchAll !== "function") {
+      return Promise.resolve(null);
+    }
+    const absoluteTarget = safeAbsolute(targetPath, origin);
+
+    return clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then((windowClients) => {
+        const list = Array.isArray(windowClients) ? windowClients : [];
+        for (const client of list) {
+          if (!client) continue;
+          // Reuse any same-origin window rather than spawning a new one.
+          const sameOrigin = isSameOrigin(client.url, origin);
+          if (sameOrigin) {
+            const focus =
+              typeof client.focus === "function"
+                ? client.focus()
+                : Promise.resolve(client);
+            if (typeof client.postMessage === "function") {
+              client.postMessage({
+                type: "eliza:push-navigate",
+                path: targetPath,
+              });
+            }
+            return Promise.resolve(focus).catch(() => client);
+          }
+        }
+        if (typeof clients.openWindow === "function" && absoluteTarget) {
+          return clients.openWindow(absoluteTarget);
+        }
+        return null;
+      });
+  }
+
+  function isSameOrigin(url, origin) {
+    if (typeof url !== "string") return false;
+    try {
+      return new URL(url).origin === origin;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Resolve an app-relative path against origin; drop anything unsafe. */
+  function safeAbsolute(path, origin) {
+    if (!isSafeAppPath(path)) return `${origin}/`;
+    try {
+      return new URL(path, `${origin}/`).toString();
+    } catch {
+      return `${origin}/`;
+    }
+  }
+
+  const api = {
+    DEFAULT_TITLE,
+    DEFAULT_ICON,
+    DEFAULT_BADGE,
+    DEFAULT_TAG,
+    parsePushData,
+    buildNotification,
+    badgeCountFromPayload,
+    applyBadge,
+    clearBadge,
+    resolveClickTarget,
+    focusOrOpen,
+    isSafeAppPath,
+  };
+
+  // Attach to the SW global for `sw.js`; also export for CommonJS/ESM test envs.
+  if (scope) scope.__elizaPush = api;
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = api;
+  }
+})(typeof self !== "undefined" ? self : undefined);

--- a/packages/app/public/sw.js
+++ b/packages/app/public/sw.js
@@ -18,6 +18,19 @@
 
 "use strict";
 
+// Web Push handler logic (push/notificationclick shaping, deep-link routing,
+// badge helpers) lives in a standalone, unit-tested module. importScripts runs
+// it synchronously at SW startup and attaches `self.__elizaPush`. Guarded so a
+// missing file (older deploy) degrades to "no push" rather than failing SW
+// install for the whole app.
+try {
+  importScripts("/sw-push.js");
+} catch (err) {
+  // Push is a progressive enhancement — the SW's caching still works without it.
+  // eslint-disable-next-line no-console
+  console.warn("[SW] push module unavailable:", err && err.message);
+}
+
 const VIEWS_CACHE_NAME = "elizaos-views-v1";
 // Bump the shell cache to evict any stale precached index/CSS in an installed
 // iOS standalone PWA (Add-to-Home-Screen runs this SW). The network-first shell
@@ -83,6 +96,48 @@ self.addEventListener("activate", (event) => {
 
       await self.clients.claim();
     })(),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Web Push (iOS 16.4+ installed PWA) — client-side foundation.
+//
+// The cloud sender lands separately; here the SW just renders an inbound push
+// as a notification, syncs the app badge, and routes a click back to the right
+// conversation. All shaping/routing logic is in `/sw-push.js` (`__elizaPush`),
+// which is unit-tested; these listeners are thin adapters over it.
+// ---------------------------------------------------------------------------
+
+self.addEventListener("push", (event) => {
+  const push = self.__elizaPush;
+  if (!push) return; // module failed to load — nothing to render.
+
+  const payload = push.parsePushData(event.data);
+  const { title, options } = push.buildNotification(payload);
+  const badgeCount = push.badgeCountFromPayload(payload);
+
+  event.waitUntil(
+    Promise.all([
+      self.registration.showNotification(title, options),
+      push.applyBadge(self.navigator, badgeCount),
+    ]),
+  );
+});
+
+self.addEventListener("notificationclick", (event) => {
+  const push = self.__elizaPush;
+  event.notification.close();
+  if (!push) return;
+
+  const data = event.notification.data;
+  const targetPath = push.resolveClickTarget(data, self.location.origin);
+
+  event.waitUntil(
+    Promise.all([
+      push.focusOrOpen(self.clients, targetPath, self.location.origin),
+      // A tapped notification means the user is reading — clear the badge.
+      push.clearBadge(self.navigator),
+    ]),
   );
 });
 
@@ -168,6 +223,15 @@ self.addEventListener("message", (event) => {
 
   if (data.type === "sw:evict-all-views") {
     event.waitUntil(caches.delete(VIEWS_CACHE_NAME));
+  }
+
+  // The page asks the SW to clear the app badge when it comes to the
+  // foreground / a conversation is opened (the page can't always call
+  // clearAppBadge itself under all install modes; the SW owns the badge it set
+  // on push receipt).
+  if (data.type === "sw:clear-badge") {
+    const push = self.__elizaPush;
+    if (push) event.waitUntil(push.clearBadge(self.navigator));
   }
 });
 

--- a/packages/app/src/sw-push.test.ts
+++ b/packages/app/src/sw-push.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Contract tests for the service-worker web-push logic (`public/sw-push.js`).
+ *
+ * The SW module is dependency-free plain JS attached to `self.__elizaPush`. We
+ * load it into the jsdom global (with a stubbed `self`) and exercise the pure
+ * helpers directly — payload parsing, notification shaping, badge sync, and
+ * click routing — without a real ServiceWorkerGlobalScope.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+interface PushApi {
+  DEFAULT_TITLE: string;
+  DEFAULT_ICON: string;
+  DEFAULT_BADGE: string;
+  DEFAULT_TAG: string;
+  parsePushData: (data: unknown) => Record<string, unknown>;
+  buildNotification: (payload: unknown) => {
+    title: string;
+    options: Record<string, unknown>;
+  };
+  badgeCountFromPayload: (payload: unknown) => number | null;
+  applyBadge: (nav: unknown, count: number | null) => Promise<unknown>;
+  clearBadge: (nav: unknown) => Promise<unknown>;
+  resolveClickTarget: (data: unknown, origin: string) => string;
+  focusOrOpen: (
+    clients: unknown,
+    targetPath: string,
+    origin: string,
+  ) => Promise<unknown>;
+  isSafeAppPath: (path: unknown) => boolean;
+}
+
+let push: PushApi;
+
+beforeAll(() => {
+  // Load and evaluate the plain-JS SW module against the jsdom global so its
+  // IIFE attaches `self.__elizaPush`. `self` is aliased to the jsdom window.
+  const scope = globalThis as unknown as {
+    self?: unknown;
+    __elizaPush?: PushApi;
+  };
+  scope.self = globalThis;
+  const src = readFileSync(
+    join(__dirname, "..", "public", "sw-push.js"),
+    "utf8",
+  );
+  // eslint-disable-next-line no-new-func
+  new Function("module", "self", src)({ exports: {} }, globalThis);
+  push = (globalThis as unknown as { __elizaPush: PushApi }).__elizaPush;
+});
+
+describe("parsePushData", () => {
+  it("returns {} for null/undefined data", () => {
+    expect(push.parsePushData(undefined)).toEqual({});
+    expect(push.parsePushData(null)).toEqual({});
+  });
+
+  it("parses a JSON payload via data.json()", () => {
+    const data = { json: () => ({ title: "Hi", body: "there" }) };
+    expect(push.parsePushData(data)).toEqual({ title: "Hi", body: "there" });
+  });
+
+  it("falls back to data.text() + JSON.parse", () => {
+    const data = { text: () => '{"title":"T"}' };
+    expect(push.parsePushData(data)).toEqual({ title: "T" });
+  });
+
+  it("returns {} when data.json() throws (non-JSON push)", () => {
+    const data = {
+      json: () => {
+        throw new Error("not json");
+      },
+    };
+    expect(push.parsePushData(data)).toEqual({});
+  });
+
+  it("returns {} when text() yields invalid JSON", () => {
+    expect(push.parsePushData({ text: () => "<<not json>>" })).toEqual({});
+  });
+
+  it("returns {} for a non-object JSON payload", () => {
+    expect(push.parsePushData({ json: () => 42 })).toEqual({});
+  });
+});
+
+describe("buildNotification", () => {
+  it("applies sane defaults for an empty payload", () => {
+    const { title, options } = push.buildNotification({});
+    expect(title).toBe(push.DEFAULT_TITLE);
+    expect(options.body).toBe("");
+    expect(options.icon).toBe(push.DEFAULT_ICON);
+    expect(options.badge).toBe(push.DEFAULT_BADGE);
+    expect(options.tag).toBe(push.DEFAULT_TAG);
+    expect(options.renotify).toBe(false);
+    expect(options.requireInteraction).toBe(false);
+    expect(options.silent).toBe(false);
+  });
+
+  it("carries title/body/tag/renotify from the payload", () => {
+    const { title, options } = push.buildNotification({
+      title: "Agent Sol",
+      body: "your build passed",
+      tag: "conv-42",
+      renotify: true,
+      requireInteraction: true,
+    });
+    expect(title).toBe("Agent Sol");
+    expect(options.body).toBe("your build passed");
+    expect(options.tag).toBe("conv-42");
+    expect(options.renotify).toBe(true);
+    expect(options.requireInteraction).toBe(true);
+  });
+
+  it("carries conversation/agent ids + deepLink onto data", () => {
+    const { options } = push.buildNotification({
+      data: {
+        deepLink: "/?conversation=abc",
+        conversationId: "abc",
+        agentId: "sol",
+        extra: "kept",
+      },
+    });
+    expect(options.data).toMatchObject({
+      deepLink: "/?conversation=abc",
+      conversationId: "abc",
+      agentId: "sol",
+      extra: "kept",
+    });
+  });
+
+  it("drops non-string ids and falls back on blank title", () => {
+    const { title, options } = push.buildNotification({
+      title: "   ",
+      data: { conversationId: 123, agentId: null, deepLink: {} },
+    });
+    expect(title).toBe(push.DEFAULT_TITLE);
+    const data = options.data as Record<string, unknown>;
+    expect(data.conversationId).toBeUndefined();
+    expect(data.agentId).toBeUndefined();
+    expect(data.deepLink).toBeUndefined();
+  });
+});
+
+describe("badgeCountFromPayload", () => {
+  it("returns null when no numeric count is present", () => {
+    expect(push.badgeCountFromPayload({})).toBeNull();
+    expect(push.badgeCountFromPayload({ badgeCount: "3" })).toBeNull();
+    expect(push.badgeCountFromPayload({ badgeCount: -1 })).toBeNull();
+    expect(push.badgeCountFromPayload({ badgeCount: Number.NaN })).toBeNull();
+  });
+
+  it("floors a valid count", () => {
+    expect(push.badgeCountFromPayload({ badgeCount: 5 })).toBe(5);
+    expect(push.badgeCountFromPayload({ badgeCount: 2.9 })).toBe(2);
+    expect(push.badgeCountFromPayload({ badgeCount: 0 })).toBe(0);
+  });
+});
+
+describe("applyBadge / clearBadge (feature detection)", () => {
+  it("no-ops when count is null", async () => {
+    const setAppBadge = vi.fn();
+    await push.applyBadge({ setAppBadge }, null);
+    expect(setAppBadge).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when setAppBadge is unsupported", async () => {
+    await expect(push.applyBadge({}, 3)).resolves.toBeUndefined();
+  });
+
+  it("sets the badge to the provided count", async () => {
+    const setAppBadge = vi.fn().mockResolvedValue(undefined);
+    await push.applyBadge({ setAppBadge }, 4);
+    expect(setAppBadge).toHaveBeenCalledWith(4);
+  });
+
+  it("clears (not sets) when count <= 0 and clearAppBadge exists", async () => {
+    const setAppBadge = vi.fn();
+    const clearAppBadge = vi.fn().mockResolvedValue(undefined);
+    await push.applyBadge({ setAppBadge, clearAppBadge }, 0);
+    expect(clearAppBadge).toHaveBeenCalled();
+    expect(setAppBadge).not.toHaveBeenCalled();
+  });
+
+  it("swallows a rejecting setAppBadge", async () => {
+    const setAppBadge = vi.fn().mockRejectedValue(new Error("nope"));
+    await expect(push.applyBadge({ setAppBadge }, 2)).resolves.toBeUndefined();
+  });
+
+  it("clearBadge no-ops when unsupported and calls when supported", async () => {
+    await expect(push.clearBadge({})).resolves.toBeUndefined();
+    const clearAppBadge = vi.fn().mockResolvedValue(undefined);
+    await push.clearBadge({ clearAppBadge });
+    expect(clearAppBadge).toHaveBeenCalled();
+  });
+});
+
+describe("resolveClickTarget", () => {
+  const origin = "https://app.example";
+
+  it("prefers a safe root-relative deepLink", () => {
+    expect(
+      push.resolveClickTarget({ deepLink: "/settings/voice" }, origin),
+    ).toBe("/settings/voice");
+  });
+
+  it("rejects an unsafe (absolute/scheme-relative) deepLink and uses ids", () => {
+    expect(
+      push.resolveClickTarget(
+        { deepLink: "https://evil.example", conversationId: "c1" },
+        origin,
+      ),
+    ).toBe("/?conversation=c1");
+    expect(push.resolveClickTarget({ deepLink: "//evil" }, origin)).toBe("/");
+  });
+
+  it("builds a conversation url with agent when present", () => {
+    expect(
+      push.resolveClickTarget({ conversationId: "c9", agentId: "sol" }, origin),
+    ).toBe("/?conversation=c9&agent=sol");
+  });
+
+  it("falls back to root when nothing routable", () => {
+    expect(push.resolveClickTarget({}, origin)).toBe("/");
+    expect(push.resolveClickTarget(null, origin)).toBe("/");
+  });
+});
+
+describe("focusOrOpen", () => {
+  const origin = "https://app.example";
+
+  it("focuses an existing same-origin client and posts a navigate message", async () => {
+    const focus = vi.fn().mockResolvedValue(undefined);
+    const postMessage = vi.fn();
+    const openWindow = vi.fn();
+    const clientsLike = {
+      matchAll: vi
+        .fn()
+        .mockResolvedValue([{ url: `${origin}/chat`, focus, postMessage }]),
+      openWindow,
+    };
+    await push.focusOrOpen(clientsLike, "/?conversation=c1", origin);
+    expect(focus).toHaveBeenCalled();
+    expect(postMessage).toHaveBeenCalledWith({
+      type: "eliza:push-navigate",
+      path: "/?conversation=c1",
+    });
+    expect(openWindow).not.toHaveBeenCalled();
+  });
+
+  it("opens a new window when no client is open", async () => {
+    const openWindow = vi.fn().mockResolvedValue({});
+    const clientsLike = {
+      matchAll: vi.fn().mockResolvedValue([]),
+      openWindow,
+    };
+    await push.focusOrOpen(clientsLike, "/?conversation=c2", origin);
+    expect(openWindow).toHaveBeenCalledWith(`${origin}/?conversation=c2`);
+  });
+
+  it("ignores a cross-origin client and opens a fresh window", async () => {
+    const openWindow = vi.fn().mockResolvedValue({});
+    const clientsLike = {
+      matchAll: vi
+        .fn()
+        .mockResolvedValue([
+          { url: "https://other.example/x", focus: vi.fn() },
+        ]),
+      openWindow,
+    };
+    await push.focusOrOpen(clientsLike, "/", origin);
+    expect(openWindow).toHaveBeenCalled();
+  });
+
+  it("resolves null when clients API is absent", async () => {
+    await expect(push.focusOrOpen({}, "/", origin)).resolves.toBeNull();
+  });
+});

--- a/packages/ui/src/components/settings/WebPushSettingsSection.tsx
+++ b/packages/ui/src/components/settings/WebPushSettingsSection.tsx
@@ -63,7 +63,7 @@ function describeState(state: ReturnType<typeof useWebPush>["state"]): {
 }
 
 export function WebPushSettingsSection() {
-  const { state, busy, ready, subscribe, unsubscribe } = useWebPush();
+  const { state, busy, error, ready, subscribe, unsubscribe } = useWebPush();
   const view = describeState(state);
 
   const onToggle = useCallback(
@@ -82,7 +82,7 @@ export function WebPushSettingsSection() {
         <SettingsRow
           icon={BellRing}
           label={view.label}
-          description={view.description}
+          description={error ?? view.description}
           control={
             <Switch
               checked={view.on}

--- a/packages/ui/src/components/settings/WebPushSettingsSection.tsx
+++ b/packages/ui/src/components/settings/WebPushSettingsSection.tsx
@@ -1,0 +1,98 @@
+/**
+ * Notifications settings section — minimal, tasteful web-push toggle for the
+ * installed iOS PWA (16.4+). Follows the existing SettingsGroup/SettingsRow
+ * pattern; the whole behavior lives in `useWebPush`. This is intentionally a
+ * single toggle + status copy, not new elaborate UX: it lets the user turn on
+ * push and reflects the coarse state, degrading gracefully everywhere push
+ * isn't available (unsupported browser, non-standalone, unconfigured VAPID).
+ */
+
+import { BellRing } from "lucide-react";
+import { useCallback } from "react";
+import { useWebPush } from "../../state/notifications/useWebPush";
+import { Switch } from "../ui/switch";
+import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
+
+/** Human copy for each coarse state. */
+function describeState(state: ReturnType<typeof useWebPush>["state"]): {
+  label: string;
+  description: string;
+  canToggle: boolean;
+  on: boolean;
+} {
+  switch (state) {
+    case "subscribed":
+      return {
+        label: "Push notifications",
+        description:
+          "On. You'll be notified of new messages when the app is closed.",
+        canToggle: true,
+        on: true,
+      };
+    case "default":
+      return {
+        label: "Push notifications",
+        description: "Get notified of new messages when the app is closed.",
+        canToggle: true,
+        on: false,
+      };
+    case "denied":
+      return {
+        label: "Push notifications",
+        description:
+          "Blocked. Enable notifications for this app in your device Settings, then reopen.",
+        canToggle: false,
+        on: false,
+      };
+    case "unconfigured":
+      return {
+        label: "Push notifications",
+        description: "Not available on this server yet.",
+        canToggle: false,
+        on: false,
+      };
+    default:
+      return {
+        label: "Push notifications",
+        description:
+          "Only available in the installed app (Add to Home Screen) on supported devices.",
+        canToggle: false,
+        on: false,
+      };
+  }
+}
+
+export function WebPushSettingsSection() {
+  const { state, busy, ready, subscribe, unsubscribe } = useWebPush();
+  const view = describeState(state);
+
+  const onToggle = useCallback(
+    (checked: boolean) => {
+      // Called from the Switch's click — inside the user gesture (iOS requires
+      // the permission prompt + subscribe to run in the gesture task).
+      if (checked) void subscribe();
+      else void unsubscribe();
+    },
+    [subscribe, unsubscribe],
+  );
+
+  return (
+    <SettingsStack>
+      <SettingsGroup title="Notifications">
+        <SettingsRow
+          icon={BellRing}
+          label={view.label}
+          description={view.description}
+          control={
+            <Switch
+              checked={view.on}
+              disabled={!view.canToggle || busy || !ready}
+              onCheckedChange={onToggle}
+              aria-label="Toggle push notifications"
+            />
+          }
+        />
+      </SettingsGroup>
+    </SettingsStack>
+  );
+}

--- a/packages/ui/src/components/settings/settings-section-meta.ts
+++ b/packages/ui/src/components/settings/settings-section-meta.ts
@@ -97,6 +97,12 @@ export const SETTINGS_SECTION_META: SettingsSectionMeta[] = [
     aliases: ["theme", "look"],
   },
   { id: "background", defaultLabel: "Background", group: "system" },
+  {
+    id: "notifications",
+    defaultLabel: "Notifications",
+    group: "system",
+    aliases: ["push", "notify"],
+  },
   { id: "runtime", defaultLabel: "Runtime", group: "system" },
   {
     id: "wallet-rpc",

--- a/packages/ui/src/components/settings/settings-sections.registration.test.ts
+++ b/packages/ui/src/components/settings/settings-sections.registration.test.ts
@@ -163,6 +163,7 @@ describe("settings information architecture (grouped display order)", () => {
     expect(catalogIdsInGroup("system")).toEqual([
       "appearance",
       "background",
+      "notifications",
       "runtime",
       "wallet-rpc",
       "remote-plugins",

--- a/packages/ui/src/components/settings/settings-sections.ts
+++ b/packages/ui/src/components/settings/settings-sections.ts
@@ -10,6 +10,7 @@
 
 import {
   Archive,
+  BellRing,
   Bot,
   Brain,
   Cloud,
@@ -100,6 +101,11 @@ const AppearanceSettingsSection = lazy(() =>
 const BackgroundSettingsSection = lazy(() =>
   import("./BackgroundSettingsSection").then((m) => ({
     default: m.BackgroundSettingsSection,
+  })),
+);
+const WebPushSettingsSection = lazy(() =>
+  import("./WebPushSettingsSection").then((m) => ({
+    default: m.WebPushSettingsSection,
   })),
 );
 const RemotePluginHostSection = lazy(() =>
@@ -379,6 +385,17 @@ const BUILTIN_SECTION_DEFINITIONS: readonly BuiltinSectionDefinition[] = [
     developerOnly: true,
     // Chrome-light so the live wallpaper shows through while choices apply.
     Component: BackgroundSettingsSection,
+  },
+  {
+    id: "notifications",
+    defaultLabel: "Notifications",
+    group: "system",
+    aliases: ["push", "notify"],
+    icon: BellRing,
+    tone: "accent",
+    hue: "accent",
+    labelKey: "settings.sections.notifications.label",
+    Component: WebPushSettingsSection,
   },
   {
     id: "runtime",

--- a/packages/ui/src/config/boot-config-store.ts
+++ b/packages/ui/src/config/boot-config-store.ts
@@ -109,6 +109,14 @@ export interface AppBootConfig {
   defaultApps?: readonly string[];
   /** API base URL — replaces window.__ELIZAOS_API_BASE__. */
   apiBase?: string;
+  /**
+   * VAPID public key (base64url, uncompressed P-256 point) for Web Push
+   * subscription. Supplied by the host/boot config; the client passes it as
+   * `applicationServerKey` to `pushManager.subscribe`. Absent/blank ⇒ push is
+   * unavailable and the settings toggle renders its "not configured" state.
+   * The matching private key + cloud sender land in the web-push cloud PR.
+   */
+  webPushVapidPublicKey?: string;
   /** API auth token used by the browser API client. */
   apiToken?: string;
   /** Cloud API base URL — replaces window.__ELIZA_CLOUD_API_BASE__. */

--- a/packages/ui/src/state/notifications/useWebPush.test.tsx
+++ b/packages/ui/src/state/notifications/useWebPush.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+/**
+ * Hook-level tests for `useWebPush` — proves it probes state on mount, exposes
+ * gesture-safe subscribe/unsubscribe that update the surfaced state, and toggles
+ * the busy flag around async work. All browser seams are injected via the
+ * `WebPushDeps` override so no real push stack is needed.
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useWebPush } from "./useWebPush";
+import type { WebPushDeps } from "./web-push-subscription";
+
+// Feature-detect seams: jsdom lacks PushManager + navigator.serviceWorker.
+const g = globalThis as unknown as { PushManager?: unknown };
+g.PushManager = class {};
+if (!("serviceWorker" in navigator)) {
+  Object.defineProperty(navigator, "serviceWorker", {
+    value: { ready: Promise.resolve(undefined) },
+    configurable: true,
+  });
+}
+
+function makeNotification(
+  permission: NotificationPermission,
+  requested: NotificationPermission = "granted",
+): typeof Notification {
+  // Mutable permission: requesting resolves the prompt and flips the getter, so
+  // a later re-probe agrees with the prompt outcome (as real browsers do).
+  let current = permission;
+  const N = (() => {}) as unknown as typeof Notification;
+  Object.defineProperty(N, "permission", {
+    get: () => current,
+    configurable: true,
+  });
+  (
+    N as unknown as { requestPermission: () => Promise<NotificationPermission> }
+  ).requestPermission = vi.fn().mockImplementation(async () => {
+    current = requested;
+    return requested;
+  });
+  return N;
+}
+
+function makeDeps(overrides: Partial<WebPushDeps> = {}): WebPushDeps {
+  // Mutable subscription so a post-subscribe re-probe reflects the new state,
+  // mirroring real PushManager semantics (getSubscription returns the created
+  // subscription on the next read).
+  let current: unknown = null;
+  const subscribe = vi.fn().mockImplementation(async () => {
+    current = { endpoint: "https://push/new" };
+    return current;
+  });
+  const getSubscription = vi.fn().mockImplementation(async () => current);
+  // Stable Notification instance so permission mutations persist across probes.
+  const { getNotification, ...rest } = overrides;
+  const notification = getNotification?.() ?? makeNotification("default");
+  return {
+    getNotification: () => notification,
+    getRegistration: async () =>
+      ({
+        pushManager: { subscribe, getSubscription },
+      }) as unknown as ServiceWorkerRegistration,
+    getVapidPublicKey: () => "BPk_test",
+    isStandalone: () => true,
+    ...rest,
+  };
+}
+
+describe("useWebPush", () => {
+  it("probes to 'default' on mount when supported + configured", async () => {
+    const deps = makeDeps();
+    const { result } = renderHook(() => useWebPush(deps));
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.state).toBe("default");
+  });
+
+  it("reports 'unconfigured' when no VAPID key", async () => {
+    const deps = makeDeps({ getVapidPublicKey: () => undefined });
+    const { result } = renderHook(() => useWebPush(deps));
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.state).toBe("unconfigured");
+  });
+
+  it("subscribe() moves state to 'subscribed'", async () => {
+    const deps = makeDeps();
+    const { result } = renderHook(() => useWebPush(deps));
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    await act(async () => {
+      await result.current.subscribe();
+    });
+    await waitFor(() => expect(result.current.state).toBe("subscribed"));
+  });
+
+  it("subscribe() surfaces 'denied' when the user rejects", async () => {
+    const deps = makeDeps({
+      getNotification: () => makeNotification("default", "denied"),
+    });
+    const { result } = renderHook(() => useWebPush(deps));
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    await act(async () => {
+      await result.current.subscribe();
+    });
+    await waitFor(() => expect(result.current.state).toBe("denied"));
+  });
+});

--- a/packages/ui/src/state/notifications/useWebPush.test.tsx
+++ b/packages/ui/src/state/notifications/useWebPush.test.tsx
@@ -46,9 +46,16 @@ function makeDeps(overrides: Partial<WebPushDeps> = {}): WebPushDeps {
   // Mutable subscription so a post-subscribe re-probe reflects the new state,
   // mirroring real PushManager semantics (getSubscription returns the created
   // subscription on the next read).
-  let current: unknown = null;
+  let current: {
+    endpoint: string;
+    unsubscribe: ReturnType<typeof vi.fn>;
+  } | null = null;
+  const unsubscribe = vi.fn().mockImplementation(async () => {
+    current = null;
+    return true;
+  });
   const subscribe = vi.fn().mockImplementation(async () => {
-    current = { endpoint: "https://push/new" };
+    current = { endpoint: "https://push/new", unsubscribe };
     return current;
   });
   const getSubscription = vi.fn().mockImplementation(async () => current);
@@ -102,5 +109,65 @@ describe("useWebPush", () => {
       await result.current.subscribe();
     });
     await waitFor(() => expect(result.current.state).toBe("denied"));
+  });
+
+  it("unsubscribe() moves subscribed state back to 'default'", async () => {
+    const deps = makeDeps();
+    const { result } = renderHook(() => useWebPush(deps));
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    await act(async () => {
+      await result.current.subscribe();
+    });
+    await waitFor(() => expect(result.current.state).toBe("subscribed"));
+
+    await act(async () => {
+      await result.current.unsubscribe();
+    });
+
+    await waitFor(() => expect(result.current.state).toBe("default"));
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces subscription failures without changing state", async () => {
+    const deps = makeDeps({
+      getRegistration: async () =>
+        ({
+          pushManager: {
+            getSubscription: vi.fn().mockResolvedValue(null),
+            subscribe: vi
+              .fn()
+              .mockRejectedValue(new Error("browser subscribe failed")),
+          },
+        }) as unknown as ServiceWorkerRegistration,
+    });
+    const { result } = renderHook(() => useWebPush(deps));
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    await act(async () => {
+      await result.current.subscribe();
+    });
+
+    await waitFor(() =>
+      expect(result.current.error).toBe(
+        "Could not update push notifications. Try again.",
+      ),
+    );
+    expect(result.current.state).toBe("default");
+  });
+
+  it("surfaces probe failures as a distinct error state", async () => {
+    const deps = makeDeps({
+      getRegistration: async () => {
+        throw new Error("service worker readiness failed");
+      },
+    });
+    const { result } = renderHook(() => useWebPush(deps));
+
+    await waitFor(() =>
+      expect(result.current.error).toBe(
+        "Could not read push notification settings.",
+      ),
+    );
+    expect(result.current.ready).toBe(true);
   });
 });

--- a/packages/ui/src/state/notifications/useWebPush.ts
+++ b/packages/ui/src/state/notifications/useWebPush.ts
@@ -1,0 +1,87 @@
+/**
+ * React hook wrapping the web-push subscription manager. Surfaces the coarse
+ * {@link WebPushState}, a busy flag, and gesture-safe `subscribe`/`unsubscribe`
+ * actions for the settings toggle. Re-probes state on mount and on window focus
+ * so an OS-level permission change (Settings app) reflects without a reload.
+ *
+ * The subscribe action MUST be invoked directly from a user-gesture handler
+ * (button onClick) — it calls `Notification.requestPermission()` + `subscribe`
+ * synchronously in the same task, which iOS requires.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  defaultWebPushDeps,
+  getWebPushState,
+  subscribeWebPush,
+  unsubscribeWebPush,
+  type WebPushDeps,
+  type WebPushState,
+} from "./web-push-subscription";
+
+export interface UseWebPushResult {
+  state: WebPushState;
+  busy: boolean;
+  /** True once the first state probe has resolved. */
+  ready: boolean;
+  /** Prompt + subscribe. Call from a user-gesture handler. */
+  subscribe: () => Promise<void>;
+  /** Tear down the subscription. */
+  unsubscribe: () => Promise<void>;
+  /** Re-probe the current state (e.g. after returning from OS settings). */
+  refresh: () => Promise<void>;
+}
+
+export function useWebPush(
+  deps: WebPushDeps = defaultWebPushDeps,
+): UseWebPushResult {
+  const [state, setState] = useState<WebPushState>("unsupported");
+  const [busy, setBusy] = useState(false);
+  const [ready, setReady] = useState(false);
+  const mountedRef = useRef(true);
+
+  const refresh = useCallback(async () => {
+    const next = await getWebPushState(deps);
+    if (mountedRef.current) {
+      setState(next);
+      setReady(true);
+    }
+  }, [deps]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    void refresh();
+    const onFocus = () => void refresh();
+    if (typeof window !== "undefined") {
+      window.addEventListener("focus", onFocus);
+    }
+    return () => {
+      mountedRef.current = false;
+      if (typeof window !== "undefined") {
+        window.removeEventListener("focus", onFocus);
+      }
+    };
+  }, [refresh]);
+
+  const subscribe = useCallback(async () => {
+    if (mountedRef.current) setBusy(true);
+    try {
+      const { state: next } = await subscribeWebPush(deps);
+      if (mountedRef.current) setState(next);
+    } finally {
+      if (mountedRef.current) setBusy(false);
+    }
+  }, [deps]);
+
+  const unsubscribe = useCallback(async () => {
+    if (mountedRef.current) setBusy(true);
+    try {
+      const next = await unsubscribeWebPush(deps);
+      if (mountedRef.current) setState(next);
+    } finally {
+      if (mountedRef.current) setBusy(false);
+    }
+  }, [deps]);
+
+  return { state, busy, ready, subscribe, unsubscribe, refresh };
+}

--- a/packages/ui/src/state/notifications/useWebPush.ts
+++ b/packages/ui/src/state/notifications/useWebPush.ts
@@ -22,6 +22,7 @@ import {
 export interface UseWebPushResult {
   state: WebPushState;
   busy: boolean;
+  error: string | null;
   /** True once the first state probe has resolved. */
   ready: boolean;
   /** Prompt + subscribe. Call from a user-gesture handler. */
@@ -37,16 +38,58 @@ export function useWebPush(
 ): UseWebPushResult {
   const [state, setState] = useState<WebPushState>("unsupported");
   const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [ready, setReady] = useState(false);
   const mountedRef = useRef(true);
 
   const refresh = useCallback(async () => {
-    const next = await getWebPushState(deps);
-    if (mountedRef.current) {
-      setState(next);
-      setReady(true);
+    try {
+      const next = await getWebPushState(deps);
+      if (mountedRef.current) {
+        setError(null);
+        setState(next);
+        setReady(true);
+      }
+    } catch (_error) {
+      // error-policy:J4 settings must distinguish push-probe failures from unsupported/empty states.
+      if (mountedRef.current) {
+        setError("Could not read push notification settings.");
+        setReady(true);
+      }
     }
   }, [deps]);
+
+  const runMutation = useCallback(
+    async (operation: () => Promise<WebPushState>) => {
+      if (mountedRef.current) {
+        setBusy(true);
+        setError(null);
+      }
+      try {
+        const next = await operation();
+        if (mountedRef.current) setState(next);
+      } catch (_error) {
+        // error-policy:J4 settings must render failed subscribe/unsubscribe operations explicitly.
+        if (mountedRef.current) {
+          setError("Could not update push notifications. Try again.");
+        }
+      } finally {
+        if (mountedRef.current) setBusy(false);
+      }
+    },
+    [],
+  );
+
+  const subscribe = useCallback(async () => {
+    await runMutation(async () => {
+      const { state: next } = await subscribeWebPush(deps);
+      return next;
+    });
+  }, [deps, runMutation]);
+
+  const unsubscribe = useCallback(async () => {
+    await runMutation(() => unsubscribeWebPush(deps));
+  }, [deps, runMutation]);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -63,25 +106,5 @@ export function useWebPush(
     };
   }, [refresh]);
 
-  const subscribe = useCallback(async () => {
-    if (mountedRef.current) setBusy(true);
-    try {
-      const { state: next } = await subscribeWebPush(deps);
-      if (mountedRef.current) setState(next);
-    } finally {
-      if (mountedRef.current) setBusy(false);
-    }
-  }, [deps]);
-
-  const unsubscribe = useCallback(async () => {
-    if (mountedRef.current) setBusy(true);
-    try {
-      const next = await unsubscribeWebPush(deps);
-      if (mountedRef.current) setState(next);
-    } finally {
-      if (mountedRef.current) setBusy(false);
-    }
-  }, [deps]);
-
-  return { state, busy, ready, subscribe, unsubscribe, refresh };
+  return { state, busy, error, ready, subscribe, unsubscribe, refresh };
 }

--- a/packages/ui/src/state/notifications/web-push-subscription.test.ts
+++ b/packages/ui/src/state/notifications/web-push-subscription.test.ts
@@ -222,6 +222,23 @@ describe("unsubscribeWebPush", () => {
     expect(state).toBe("default");
   });
 
+  it("rejects when the browser fails to unsubscribe", async () => {
+    const unsubscribe = vi
+      .fn()
+      .mockRejectedValue(new Error("unsubscribe failed"));
+    const getSubscription = vi.fn().mockResolvedValue({
+      endpoint: "https://push/x",
+      unsubscribe,
+    });
+    const reg = {
+      pushManager: { getSubscription },
+    } as unknown as ServiceWorkerRegistration;
+
+    await expect(
+      unsubscribeWebPush(makeDeps({ getRegistration: async () => reg })),
+    ).rejects.toThrow("unsubscribe failed");
+  });
+
   it("is a no-op returning unsupported off-platform", async () => {
     globalWithPush.PushManager = undefined;
     expect(await unsubscribeWebPush(makeDeps())).toBe("unsupported");

--- a/packages/ui/src/state/notifications/web-push-subscription.test.ts
+++ b/packages/ui/src/state/notifications/web-push-subscription.test.ts
@@ -1,0 +1,246 @@
+// @vitest-environment jsdom
+/**
+ * Contract tests for the web-push subscription manager. Every DOM/global seam
+ * (Notification, ServiceWorkerRegistration/PushManager, VAPID key, standalone
+ * probe) is injected, so we drive the full state machine —
+ * unsupported/unconfigured/denied/default/subscribed — without a real browser
+ * push stack.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getWebPushState,
+  getWebPushSubscription,
+  isWebPushSupported,
+  subscribeWebPush,
+  unsubscribeWebPush,
+  urlBase64ToUint8Array,
+  type WebPushDeps,
+} from "./web-push-subscription";
+
+// jsdom lacks PushManager; define a stub so `isWebPushSupported` can feature
+// detect it. Individual tests remove it to exercise the unsupported branch.
+const globalWithPush = globalThis as unknown as {
+  PushManager?: unknown;
+  atob?: (s: string) => string;
+};
+
+beforeEach(() => {
+  globalWithPush.PushManager = class {};
+  if (typeof globalWithPush.atob !== "function") {
+    globalWithPush.atob = (s: string) =>
+      Buffer.from(s, "base64").toString("binary");
+  }
+  // `isWebPushSupported` feature-detects `serviceWorker in navigator`; jsdom's
+  // navigator has none, so provide a stub for the supported-path tests.
+  if (!("serviceWorker" in navigator)) {
+    Object.defineProperty(navigator, "serviceWorker", {
+      value: { ready: Promise.resolve(undefined) },
+      configurable: true,
+    });
+  }
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeNotification(
+  permission: NotificationPermission,
+  requested: NotificationPermission = "granted",
+): typeof Notification {
+  const N = (() => {}) as unknown as typeof Notification;
+  Object.defineProperty(N, "permission", {
+    value: permission,
+    configurable: true,
+  });
+  (
+    N as unknown as { requestPermission: () => Promise<NotificationPermission> }
+  ).requestPermission = vi.fn().mockResolvedValue(requested);
+  return N;
+}
+
+function makeRegistration(existing: unknown = null) {
+  const subscribe = vi.fn().mockResolvedValue({ endpoint: "https://push/new" });
+  const getSubscription = vi.fn().mockResolvedValue(existing);
+  return {
+    reg: {
+      pushManager: { subscribe, getSubscription },
+    } as unknown as ServiceWorkerRegistration,
+    subscribe,
+    getSubscription,
+  };
+}
+
+function makeDeps(overrides: Partial<WebPushDeps> = {}): WebPushDeps {
+  return {
+    getNotification: () => makeNotification("default"),
+    getRegistration: async () => makeRegistration().reg,
+    getVapidPublicKey: () => "BPk_test_key",
+    isStandalone: () => true,
+    ...overrides,
+  };
+}
+
+describe("urlBase64ToUint8Array", () => {
+  it("decodes a base64url string with padding restored", () => {
+    const bytes = urlBase64ToUint8Array("AQID"); // [1,2,3]
+    expect(Array.from(bytes)).toEqual([1, 2, 3]);
+  });
+});
+
+describe("isWebPushSupported", () => {
+  it("is false when not standalone", () => {
+    expect(isWebPushSupported(makeDeps({ isStandalone: () => false }))).toBe(
+      false,
+    );
+  });
+
+  it("is false when Notification is absent", () => {
+    expect(
+      isWebPushSupported(makeDeps({ getNotification: () => undefined })),
+    ).toBe(false);
+  });
+
+  it("is false when PushManager is undefined", () => {
+    globalWithPush.PushManager = undefined;
+    expect(isWebPushSupported(makeDeps())).toBe(false);
+  });
+
+  it("is true when standalone + Notification + PushManager present", () => {
+    expect(isWebPushSupported(makeDeps())).toBe(true);
+  });
+});
+
+describe("getWebPushState", () => {
+  it("returns unsupported when the platform can't push", () => {
+    globalWithPush.PushManager = undefined;
+    return expect(getWebPushState(makeDeps())).resolves.toBe("unsupported");
+  });
+
+  it("returns unconfigured when no VAPID key is set", async () => {
+    const state = await getWebPushState(
+      makeDeps({ getVapidPublicKey: () => undefined }),
+    );
+    expect(state).toBe("unconfigured");
+  });
+
+  it("returns denied when permission is denied", async () => {
+    const state = await getWebPushState(
+      makeDeps({ getNotification: () => makeNotification("denied") }),
+    );
+    expect(state).toBe("denied");
+  });
+
+  it("returns subscribed when an active subscription exists", async () => {
+    const { reg } = makeRegistration({ endpoint: "https://push/x" });
+    const state = await getWebPushState(
+      makeDeps({ getRegistration: async () => reg }),
+    );
+    expect(state).toBe("subscribed");
+  });
+
+  it("returns default when supported/configured but not subscribed", async () => {
+    const state = await getWebPushState(makeDeps());
+    expect(state).toBe("default");
+  });
+});
+
+describe("subscribeWebPush", () => {
+  it("bails as unsupported off-platform", async () => {
+    globalWithPush.PushManager = undefined;
+    const result = await subscribeWebPush(makeDeps());
+    expect(result).toEqual({ state: "unsupported", subscription: null });
+  });
+
+  it("bails as unconfigured without a VAPID key", async () => {
+    const result = await subscribeWebPush(
+      makeDeps({ getVapidPublicKey: () => undefined }),
+    );
+    expect(result.state).toBe("unconfigured");
+  });
+
+  it("prompts for permission then subscribes with userVisibleOnly + key", async () => {
+    const { reg, subscribe, getSubscription } = makeRegistration(null);
+    const N = makeNotification("default", "granted");
+    const result = await subscribeWebPush(
+      makeDeps({ getNotification: () => N, getRegistration: async () => reg }),
+    );
+    expect(
+      (N as unknown as { requestPermission: ReturnType<typeof vi.fn> })
+        .requestPermission,
+    ).toHaveBeenCalled();
+    expect(getSubscription).toHaveBeenCalled();
+    expect(subscribe).toHaveBeenCalledWith(
+      expect.objectContaining({ userVisibleOnly: true }),
+    );
+    const arg = subscribe.mock.calls[0][0] as {
+      applicationServerKey: Uint8Array;
+    };
+    expect(arg.applicationServerKey).toBeInstanceOf(Uint8Array);
+    expect(result.state).toBe("subscribed");
+    expect(result.subscription).not.toBeNull();
+  });
+
+  it("returns denied when the user rejects the prompt", async () => {
+    const N = makeNotification("default", "denied");
+    const result = await subscribeWebPush(
+      makeDeps({ getNotification: () => N }),
+    );
+    expect(result).toEqual({ state: "denied", subscription: null });
+  });
+
+  it("reuses an existing subscription without re-subscribing", async () => {
+    const { reg, subscribe } = makeRegistration({
+      endpoint: "https://push/existing",
+    });
+    const N = makeNotification("granted");
+    const result = await subscribeWebPush(
+      makeDeps({ getNotification: () => N, getRegistration: async () => reg }),
+    );
+    expect(subscribe).not.toHaveBeenCalled();
+    expect(result.state).toBe("subscribed");
+  });
+});
+
+describe("unsubscribeWebPush", () => {
+  it("unsubscribes and reports the resulting default state", async () => {
+    const unsubscribe = vi.fn().mockResolvedValue(true);
+    const getSubscription = vi
+      .fn()
+      // first call (unsubscribe path) returns the sub, second call (state
+      // re-probe) returns null.
+      .mockResolvedValueOnce({ endpoint: "https://push/x", unsubscribe })
+      .mockResolvedValueOnce(null);
+    const reg = {
+      pushManager: { getSubscription },
+    } as unknown as ServiceWorkerRegistration;
+    const state = await unsubscribeWebPush(
+      makeDeps({ getRegistration: async () => reg }),
+    );
+    expect(unsubscribe).toHaveBeenCalled();
+    expect(state).toBe("default");
+  });
+
+  it("is a no-op returning unsupported off-platform", async () => {
+    globalWithPush.PushManager = undefined;
+    expect(await unsubscribeWebPush(makeDeps())).toBe("unsupported");
+  });
+});
+
+describe("getWebPushSubscription", () => {
+  it("returns the active subscription", async () => {
+    const sub = { endpoint: "https://push/x" };
+    const { reg } = makeRegistration(sub);
+    expect(
+      await getWebPushSubscription(
+        makeDeps({ getRegistration: async () => reg }),
+      ),
+    ).toBe(sub);
+  });
+
+  it("returns null off-platform", async () => {
+    globalWithPush.PushManager = undefined;
+    expect(await getWebPushSubscription(makeDeps())).toBeNull();
+  });
+});

--- a/packages/ui/src/state/notifications/web-push-subscription.ts
+++ b/packages/ui/src/state/notifications/web-push-subscription.ts
@@ -40,11 +40,11 @@ export interface WebPushDeps {
 }
 
 /** Base64url → Uint8Array for `applicationServerKey`. */
-export function urlBase64ToUint8Array(base64: string): Uint8Array {
+export function urlBase64ToUint8Array(base64: string): Uint8Array<ArrayBuffer> {
   const padding = "=".repeat((4 - (base64.length % 4)) % 4);
   const normalized = (base64 + padding).replace(/-/g, "+").replace(/_/g, "/");
   const raw = atob(normalized);
-  const output = new Uint8Array(raw.length);
+  const output = new Uint8Array(new ArrayBuffer(raw.length));
   for (let i = 0; i < raw.length; i += 1) output[i] = raw.charCodeAt(i);
   return output;
 }
@@ -71,12 +71,8 @@ export const defaultWebPushDeps: WebPushDeps = {
     ) {
       return null;
     }
-    try {
-      const reg = await navigator.serviceWorker.ready;
-      return reg ?? null;
-    } catch {
-      return null;
-    }
+    const reg = await navigator.serviceWorker.ready;
+    return reg ?? null;
   },
   getVapidPublicKey: () => {
     const key = getBootConfig().webPushVapidPublicKey;
@@ -184,11 +180,7 @@ export async function unsubscribeWebPush(
   const reg = await deps.getRegistration();
   const existing = reg ? await reg.pushManager.getSubscription() : null;
   if (existing) {
-    try {
-      await existing.unsubscribe();
-    } catch {
-      // Best-effort — a failed unsubscribe still reports the current state.
-    }
+    await existing.unsubscribe();
   }
   return getWebPushState(deps);
 }

--- a/packages/ui/src/state/notifications/web-push-subscription.ts
+++ b/packages/ui/src/state/notifications/web-push-subscription.ts
@@ -1,0 +1,194 @@
+/**
+ * Web Push subscription manager for the installed **web** PWA (iOS 16.4+).
+ *
+ * This is the client half of the web-push lane: it feature-detects push
+ * support, requests notification permission (behind an explicit user gesture —
+ * iOS rejects a non-gesture `subscribe`), creates/reads/removes the
+ * `PushSubscription`, and reports a single `WebPushState` the settings toggle
+ * renders. It is deliberately transport-agnostic: POSTing the subscription to
+ * the cloud + the sender service land in the web-push cloud PR (PR-2+). Here we
+ * only own the browser-side subscription lifecycle.
+ *
+ * Native (Capacitor) push has its own APNs/FCM path in `push-registration.ts`;
+ * this module is for the pure web PWA where that plugin is absent. The two are
+ * mutually exclusive by platform.
+ *
+ * Every DOM/global seam is injectable so the state machine is fully unit
+ * testable without a real ServiceWorker/PushManager.
+ */
+
+import { getBootConfig } from "../../config/boot-config";
+
+/** Coarse subscription state surfaced to the settings UI. */
+export type WebPushState =
+  | "unsupported" // no PushManager / SW / Notification, or not standalone
+  | "unconfigured" // supported but no VAPID public key wired up
+  | "denied" // Notification.permission === "denied"
+  | "default" // supported + configured, not yet subscribed (can prompt)
+  | "subscribed"; // an active PushSubscription exists
+
+/** The four global seams, injectable for tests. */
+export interface WebPushDeps {
+  /** `window.Notification` (or a stub). */
+  getNotification: () => typeof Notification | undefined;
+  /** Ready service-worker registration, or null if none. */
+  getRegistration: () => Promise<ServiceWorkerRegistration | null>;
+  /** VAPID public key from boot config (base64url), or undefined. */
+  getVapidPublicKey: () => string | undefined;
+  /** Whether the app is running as an installed standalone PWA. */
+  isStandalone: () => boolean;
+}
+
+/** Base64url → Uint8Array for `applicationServerKey`. */
+export function urlBase64ToUint8Array(base64: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+  const normalized = (base64 + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(normalized);
+  const output = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i += 1) output[i] = raw.charCodeAt(i);
+  return output;
+}
+
+function defaultIsStandalone(): boolean {
+  if (typeof window === "undefined") return false;
+  const nav = window.navigator as Navigator & { standalone?: boolean };
+  // iOS Safari sets navigator.standalone; other browsers expose the media query.
+  if (nav?.standalone === true) return true;
+  return (
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(display-mode: standalone)").matches
+  );
+}
+
+export const defaultWebPushDeps: WebPushDeps = {
+  getNotification: () =>
+    typeof Notification !== "undefined" ? Notification : undefined,
+  getRegistration: async () => {
+    if (
+      typeof navigator === "undefined" ||
+      !("serviceWorker" in navigator) ||
+      !navigator.serviceWorker
+    ) {
+      return null;
+    }
+    try {
+      const reg = await navigator.serviceWorker.ready;
+      return reg ?? null;
+    } catch {
+      return null;
+    }
+  },
+  getVapidPublicKey: () => {
+    const key = getBootConfig().webPushVapidPublicKey;
+    return typeof key === "string" && key.trim() ? key.trim() : undefined;
+  },
+  isStandalone: defaultIsStandalone,
+};
+
+/** Whether the runtime can do web push at all (SW + PushManager + Notification). */
+export function isWebPushSupported(
+  deps: WebPushDeps = defaultWebPushDeps,
+): boolean {
+  if (typeof window === "undefined") return false;
+  if (!("serviceWorker" in navigator)) return false;
+  if (typeof PushManager === "undefined") return false;
+  if (!deps.getNotification()) return false;
+  // iOS only allows web push for an installed (standalone) PWA.
+  return deps.isStandalone();
+}
+
+/**
+ * Resolve the current subscription state without prompting or mutating
+ * anything. Safe to call on mount / focus to render the toggle.
+ */
+export async function getWebPushState(
+  deps: WebPushDeps = defaultWebPushDeps,
+): Promise<WebPushState> {
+  if (!isWebPushSupported(deps)) return "unsupported";
+  if (!deps.getVapidPublicKey()) return "unconfigured";
+
+  const Notif = deps.getNotification();
+  if (Notif?.permission === "denied") return "denied";
+
+  const reg = await deps.getRegistration();
+  const existing = reg ? await reg.pushManager.getSubscription() : null;
+  if (existing) return "subscribed";
+
+  return "default";
+}
+
+/** Read the active subscription (or null). Never prompts. */
+export async function getWebPushSubscription(
+  deps: WebPushDeps = defaultWebPushDeps,
+): Promise<PushSubscription | null> {
+  if (!isWebPushSupported(deps)) return null;
+  const reg = await deps.getRegistration();
+  if (!reg) return null;
+  return reg.pushManager.getSubscription();
+}
+
+/**
+ * Subscribe to web push. MUST be called from within an explicit user gesture
+ * (iOS rejects otherwise). Requests notification permission if needed, then
+ * creates the `PushSubscription` with `userVisibleOnly: true` and the VAPID
+ * `applicationServerKey`. Returns the resulting state; on `subscribed` it also
+ * returns the subscription so the caller can POST it to the cloud (that POST is
+ * out of scope for this PR).
+ */
+export async function subscribeWebPush(
+  deps: WebPushDeps = defaultWebPushDeps,
+): Promise<{ state: WebPushState; subscription: PushSubscription | null }> {
+  if (!isWebPushSupported(deps)) {
+    return { state: "unsupported", subscription: null };
+  }
+  const vapid = deps.getVapidPublicKey();
+  if (!vapid) return { state: "unconfigured", subscription: null };
+
+  const Notif = deps.getNotification();
+  if (!Notif) return { state: "unsupported", subscription: null };
+
+  // Reuse an existing grant; otherwise prompt (inside the caller's gesture).
+  let permission: NotificationPermission = Notif.permission;
+  if (permission === "default") {
+    permission = await Notif.requestPermission();
+  }
+  if (permission !== "granted") {
+    return {
+      state: permission === "denied" ? "denied" : "default",
+      subscription: null,
+    };
+  }
+
+  const reg = await deps.getRegistration();
+  if (!reg) return { state: "unsupported", subscription: null };
+
+  const existing = await reg.pushManager.getSubscription();
+  if (existing) return { state: "subscribed", subscription: existing };
+
+  const subscription = await reg.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: urlBase64ToUint8Array(vapid),
+  });
+  return { state: "subscribed", subscription };
+}
+
+/**
+ * Unsubscribe from web push. Returns the resulting state. Pruning the
+ * subscription server-side is the cloud PR's job; here we only tear down the
+ * browser subscription.
+ */
+export async function unsubscribeWebPush(
+  deps: WebPushDeps = defaultWebPushDeps,
+): Promise<WebPushState> {
+  if (!isWebPushSupported(deps)) return "unsupported";
+  const reg = await deps.getRegistration();
+  const existing = reg ? await reg.pushManager.getSubscription() : null;
+  if (existing) {
+    try {
+      await existing.unsubscribe();
+    } catch {
+      // Best-effort — a failed unsubscribe still reports the current state.
+    }
+  }
+  return getWebPushState(deps);
+}


### PR DESCRIPTION
## What & why

Client-side **web push foundation** for iOS 16.4+ installed (Add-to-Home-Screen) PWAs. This is **PR-1** of the web-push lane from the PWA optimization dossier (§3). iOS only supports web push for installed standalone PWAs, requires the subscription to be created inside a user gesture, and rides APNs transparently via standard `PushManager`/VAPID — no Apple SDK needed.

Today, if the app is closed an agent reply is invisible until you reopen it. This lands the **browser half** that makes push possible. The **cloud sender lands separately** (see below).

## What's in this PR (client-side only)

**Service worker — `packages/app/public`**
- **`sw-push.js`** (new): dependency-free, unit-tested logic module — defensive push-payload parse (`event.data.json()`/`text()` with `{}` fallback so a malformed push renders defaults instead of dropping), notification shaping with `tag`/`renotify` coalescing (one bubble per conversation) + carried `conversationId`/`agentId`/`deepLink` on `data`, badge-count derivation, and deep-link-safe click routing. `sw.js` loads it via `importScripts("/sw-push.js")`, guarded so a missing file degrades to "no push" rather than failing SW install.
- **`sw.js`**: `push` → `showNotification` with sane defaults (title/body/icon/badge/tag/renotify) + `navigator.setAppBadge` when a count is provided; `notificationclick` → focus an existing same-origin client and post an in-app `eliza:push-navigate` message, else `openWindow`, and clear the badge on tap; plus a `sw:clear-badge` page→SW message so the app can clear the badge on focus. The click deep-link allowlist mirrors `navigate-deep-link.ts` (root-relative only — a push can't redirect the app to a foreign origin).

**Subscription manager — `packages/ui`**
- **`state/notifications/web-push-subscription.ts`**: feature-detected support probe (SW + `PushManager` + `Notification` + standalone display-mode), coarse `WebPushState` (`unsupported | unconfigured | denied | default | subscribed`), `subscribe` (`userVisibleOnly: true` + VAPID `applicationServerKey`, permission request **behind an explicit user gesture** per iOS), `unsubscribe`, `getSubscription`. Every DOM/global seam is injectable. Browser API failures now surface through the settings hook instead of being converted into healthy-empty states.
- **`state/notifications/useWebPush.ts`**: React hook wrapping it; re-probes on mount + window `focus` so an OS-level permission change reflects without a reload; renders distinct settings errors for failed probes or subscribe/unsubscribe operations.
- **`components/settings/WebPushSettingsSection.tsx`**: minimal, tasteful **Notifications** settings section (single toggle + status copy) following the existing `settings-section-registry` pattern exactly. Registered in the System group; `SETTINGS_SECTION_META`, the app-core `dev-route-catalog` mirror, and the IA-order test are updated in lockstep (parity guards pass).

**Config**
- `webPushVapidPublicKey` added to `AppBootConfig` — **placeholder-tolerant**: no key configured ⇒ the toggle shows an "unavailable" state. No key generation here.

## Progressive enhancement / zero regressions
- Everything is feature-detected: browsers without push, non-standalone tabs, and unconfigured VAPID all no-op gracefully. Badge API is `setAppBadge`/`clearAppBadge` feature-detected (no-op elsewhere). Native (Capacitor) push keeps its separate APNs/FCM path in `push-registration.ts`; this module is for the pure web PWA where that plugin is absent.

## Tests (vitest / jsdom — not bun test)
- SW handler logic (`packages/app/src/sw-push.test.ts`) — **26**
- Subscription-manager + hook states (`web-push-subscription.test.ts`, `useWebPush.test.tsx`) — **27**
- Settings parity/registration/tokens for the new section — **22**
- Scoped settings visual audit (`builtin-settings mobile-portrait`, `builtin-settings desktop-landscape`) — **2**

```
app:  Test Files 1 passed (1)  Tests 26 passed (26)
ui:   Test Files 2 passed (2)  Tests 27 passed (27)
ui:   Test Files 2 passed (2)  Tests 22 passed (22)
audit: 2 passed (builtin-settings mobile-portrait + desktop-landscape)
```

Two unrelated failures still reproduce after rebase and are not introduced here: `settings-sections.mvp-hidden.test.ts > voice stays visible`, and `dev-route-catalog.test.ts > uses the path declared by TAB_PATHS` (`/apps/my-apps` vs `/apps`). The settings-META parity test this PR touches passes.

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] N/A - the web-push settings section and entire client lane are NEW in this PR (+1472/-0); no prior surface existed on develop

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15185-after-settings-webpush-desktop.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/15185-walkthrough-toggle.mp4

<!-- evidence-row:backend-logs -->
- [x] [15185-unit-tests-app.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15185-unit-tests-app.log)

<!-- evidence-row:frontend-logs -->
- [x] [15185-toggle-interaction.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15185-toggle-interaction.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/model/prompt behavior in this change (service-worker + settings UI plumbing)

<!-- evidence-row:domain-artifacts -->
- [x] [15185-unit-tests-ui.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15185-unit-tests-ui.log)

## What PR-2 (cloud sender) needs
- Generate a VAPID keypair; expose the **public** key on the existing boot-config/`/api/config` path into `webPushVapidPublicKey`; store the private key as a cloud secret.
- POST the created `PushSubscription` to the cloud (this PR produces it but does not transmit it) and persist it keyed to user/agent.
- A Cloudflare-Workers-compatible web-push sender (node `web-push` won't run unmodified on Workers): sign the VAPID JWT, encrypt + POST the payload; handle `404`/`410 Gone` → prune dead subscriptions.
- Wire the agent-reply path to enqueue a push when the target user has no live/foreground client, and set `badgeCount` in the payload.
- Optional page-side: add a `message` listener for `eliza:push-navigate` to do an in-app SPA route change on focus (the `openWindow` fallback already navigates).

Not self-merged.

[sol-orch]

<!-- evidence-row:ocr-review -->
- [x] [15185-ocr-settings.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15185-ocr-settings.txt)