### PR TITLE
fix(ui): auto-retry chat send once on reconnect — no more lost messages on network blips

### DIFF
--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -468,6 +468,35 @@ if (typeof document !== "undefined") {
   });
 }
 
+/**
+ * Subscribe to bridged network-status transitions (Capacitor
+ * `networkStatusChange`, re-dispatched as {@link NETWORK_STATUS_CHANGE_EVENT}).
+ * The listener fires with `true` when connectivity returns and `false` when it
+ * drops. Returns an unsubscribe fn. Module-level (not per-client) because the
+ * bridge is a single document-level event — every consumer shares the same
+ * transition source, so a chat-send auto-retry and the WS reconnect scheduler
+ * both react to the same online edge without racing separate listeners.
+ */
+export function onNetworkStatusChange(
+  listener: (connected: boolean) => void,
+): () => void {
+  networkStatusListeners.add(listener);
+  return () => {
+    networkStatusListeners.delete(listener);
+  };
+}
+
+/**
+ * Mint a stable idempotency key for one logical chat send. The send path calls
+ * this ONCE per turn and reuses the value across an auto-retry so a request that
+ * landed server-side during a network blip is de-duped rather than duplicated.
+ * Thin free-function wrapper over {@link ElizaClient.generateMessageId} so
+ * consumers don't need the class from the barrel.
+ */
+export function generateChatClientMessageId(): string {
+  return ElizaClient.generateMessageId();
+}
+
 /** Test-only: reset the cached network state. */
 export function __resetNetworkStatusForTests(): void {
   lastKnownNetworkConnected = true;
@@ -476,6 +505,16 @@ export function __resetNetworkStatusForTests(): void {
 
 /** Test-only: read the last bridged network status. */
 export function __getLastKnownNetworkConnected(): boolean {
+  return lastKnownNetworkConnected;
+}
+
+/**
+ * The last bridged connectivity state (`true` = the device reports a usable
+ * network). Public counterpart to the test-only reader so the send path can
+ * tell "we're offline" (worth waiting for reconnect to auto-retry) from "we're
+ * online but the server 503'd / was slow" (surface the manual affordance now).
+ */
+export function isNetworkCurrentlyConnected(): boolean {
   return lastKnownNetworkConnected;
 }
 
@@ -577,9 +616,11 @@ export class ElizaClient {
   /**
    * Stable id for a single logical client message. Used as an idempotency key
    * so a resend after reconnect is de-dupable server-side. Falls back to a
-   * time+random token when crypto.randomUUID is unavailable.
+   * time+random token when crypto.randomUUID is unavailable. Public so the
+   * send path can mint an id ONCE per logical turn and reuse it across an
+   * auto-retry (the retry must carry the original id or the dedupe is moot).
    */
-  private static generateMessageId(): string {
+  static generateMessageId(): string {
     if (typeof globalThis.crypto?.randomUUID === "function") {
       return globalThis.crypto.randomUUID();
     }
@@ -1664,6 +1705,11 @@ export class ElizaClient {
     /** Additive: inline tool-call steps (call → result/error) for the thread's
      *  tool rows. Omitting it leaves token/done/error behaviour unchanged. */
     onToolEvent?: (event: ChatToolCallEvent) => void,
+    /** Additive: caller-supplied idempotency key. When a send is auto-retried
+     *  after a network blip the SAME id must ride the retry so a request that
+     *  actually landed server-side is de-duped instead of double-delivered.
+     *  Omit for a fresh send — a new id is generated. */
+    clientMessageId?: string,
   ): Promise<{
     text: string;
     agentName: string;
@@ -1682,8 +1728,10 @@ export class ElizaClient {
     // Server-side dedupe by `clientMessageId` should hook there, where the
     // request body is parsed before the message is persisted/generated. The id
     // is generated here so the contract is in place regardless of when that
-    // dedupe lands.
-    const clientMessageId = ElizaClient.generateMessageId();
+    // dedupe lands. A caller-supplied id (auto-retry after a network blip)
+    // takes precedence so the retry is idempotent with the original attempt.
+    const resolvedClientMessageId =
+      clientMessageId ?? ElizaClient.generateMessageId();
     const res = await this.rawRequest(
       path,
       {
@@ -1695,7 +1743,7 @@ export class ElizaClient {
         body: JSON.stringify({
           text,
           channelType,
-          clientMessageId,
+          clientMessageId: resolvedClientMessageId,
           ...(images?.length ? { images } : {}),
           ...(metadata ? { metadata } : {}),
         }),

--- a/packages/ui/src/api/client-chat.ts
+++ b/packages/ui/src/api/client-chat.ts
@@ -512,6 +512,8 @@ declare module "./client-base" {
       onStatus?: (status: ChatTurnStatus) => void,
       /** Additive: inline tool-call steps (call → result/error) for the thread. */
       onToolEvent?: (event: ChatToolCallEvent) => void,
+      /** Additive: caller-supplied idempotency key reused across an auto-retry. */
+      clientMessageId?: string,
     ): Promise<{
       text: string;
       agentName: string;
@@ -1307,6 +1309,7 @@ ElizaClient.prototype.sendConversationMessageStream = async function (
   metadata?,
   onStatus?,
   onToolEvent?,
+  clientMessageId?,
 ) {
   return this.streamChatEndpoint(
     `/api/conversations/${encodeURIComponent(id)}/messages/stream`,
@@ -1318,6 +1321,7 @@ ElizaClient.prototype.sendConversationMessageStream = async function (
     metadata,
     onStatus,
     onToolEvent,
+    clientMessageId,
   );
 };
 

--- a/packages/ui/src/state/useChatSend.test.tsx
+++ b/packages/ui/src/state/useChatSend.test.tsx
@@ -9,19 +9,23 @@
  */
 import { act, renderHook } from "@testing-library/react";
 import type { MutableRefObject } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   CodingAgentSession,
   Conversation,
   ConversationMessage,
   ImageAttachment,
 } from "../api";
-import { StreamGenerationError } from "../api/client-base";
-import { CLOUD_HANDOFF_PHASE_EVENT } from "../events";
+import {
+  __resetNetworkStatusForTests,
+  StreamGenerationError,
+} from "../api/client-base";
+import { APP_RESUME_EVENT, CLOUD_HANDOFF_PHASE_EVENT } from "../events";
 import type { LoadConversationMessagesResult } from "./internal";
 import {
   buildSendFailureNotice,
   getSendValidationFailureMessage,
+  isRetryableSendError,
   UNDELIVERED_TURN_NOTICE,
   type UseChatSendDeps,
   useChatSend,
@@ -52,6 +56,9 @@ const mocks = vi.hoisted(() => ({
       Promise.resolve({ ok: true, deletedCount: 1 }),
     ),
     getBaseUrl: vi.fn(() => ""),
+    // Real client exposes onWsEvent(type, handler) => unsubscribe; the retry
+    // path subscribes to "ws-reconnected" through it. Default no-op unsubscribe.
+    onWsEvent: vi.fn(() => () => {}),
   },
 }));
 
@@ -671,26 +678,48 @@ describe("useChatSend non-404 send failures", () => {
     );
   });
 
-  it("keeps the connection copy for a genuine network drop", async () => {
-    mocks.client.sendConversationMessageStream.mockRejectedValue(
-      Object.assign(new Error("Failed to fetch"), { kind: "network" }),
-    );
+  it("keeps the connection copy for a genuine network drop (after the auto-retry exhausts)", async () => {
+    // A network-kind drop now first auto-retries on reconnect (E2). When the
+    // retry ALSO fails, the connection copy still surfaces — the copy contract
+    // is unchanged, it just lands after the single auto-retry is spent. Use
+    // fake timers so the reconnect-wait resolves instantly instead of hanging.
+    vi.useFakeTimers();
+    try {
+      __resetNetworkStatusForTests();
+      mocks.client.onWsEvent.mockImplementation(() => () => {});
+      mocks.client.sendConversationMessageStream.mockRejectedValue(
+        Object.assign(new Error("Failed to fetch"), { kind: "network" }),
+      );
 
-    const deps = makeDeps({
-      activeConversationId: "conv-1",
-      conversations: [conversation("conv-1", "room-1")],
-    });
-    const { result } = renderHook(() => useChatSend(deps));
+      const deps = makeDeps({
+        activeConversationId: "conv-1",
+        conversations: [conversation("conv-1", "room-1")],
+      });
+      const { result } = renderHook(() => useChatSend(deps));
 
-    await act(async () => {
-      await result.current.sendChatText("hi", { conversationId: "conv-1" });
-    });
+      let sendPromise: Promise<void> | undefined;
+      await act(async () => {
+        sendPromise = result.current.sendChatText("hi", {
+          conversationId: "conv-1",
+        });
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      await act(async () => {
+        // Drive the reconnect edge → the single auto-retry fires and re-fails.
+        document.dispatchEvent(new Event(APP_RESUME_EVENT));
+        await vi.advanceTimersByTimeAsync(500);
+        await sendPromise;
+      });
 
-    expect(deps.setActionNotice).toHaveBeenCalledWith(
-      expect.stringContaining("check your connection"),
-      "error",
-      expect.any(Number),
-    );
+      expect(deps.setActionNotice).toHaveBeenCalledWith(
+        expect.stringContaining("check your connection"),
+        "error",
+        expect.any(Number),
+      );
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
   });
 
   it("does not reload (which could re-fail) on an auth-failure send error, and notifies", async () => {
@@ -1893,5 +1922,322 @@ describe("useChatSend reply-target attachment", () => {
       .calls[0][6] as Record<string, unknown> | undefined;
     expect(metadata?.replyToMessageId).toBeUndefined();
     expect(deps.setChatReplyTarget).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// E2: auto-retry a network-failed send ONCE on reconnect (PWA dossier 2.2)
+// ---------------------------------------------------------------------------
+
+/** A transport-blip send failure (ApiError-shaped: kind:"network"). */
+function networkError(): Error {
+  return Object.assign(new Error("Failed to fetch"), { kind: "network" });
+}
+
+/** A timeout send failure (ApiError-shaped: kind:"timeout"). */
+function timeoutError(): Error {
+  return Object.assign(new Error("timed out"), { kind: "timeout" });
+}
+
+/** A non-retryable validation failure (413 payload too large). */
+function validation413(): Error {
+  return Object.assign(new Error("Attachment too large (max 5 MB)"), {
+    status: 413,
+  });
+}
+
+/** Fire the reconnect edge the auto-retry waits on, then flush its debounce. */
+async function dispatchReconnectAndSettle(): Promise<void> {
+  // APP_RESUME fires on every dispatch (unlike NETWORK_STATUS_CHANGE, which
+  // only reacts to a true transition), so it's the deterministic wake signal.
+  document.dispatchEvent(new Event(APP_RESUME_EVENT));
+  // Flush the 400ms reconnect-signal debounce.
+  await vi.advanceTimersByTimeAsync(500);
+}
+
+describe("isRetryableSendError classification", () => {
+  it("classifies network + timeout + 502/503 as retryable", () => {
+    expect(isRetryableSendError(networkError())).toBe(true);
+    expect(isRetryableSendError(timeoutError())).toBe(true);
+    expect(isRetryableSendError({ status: 502 })).toBe(true);
+    expect(isRetryableSendError({ status: 503 })).toBe(true);
+  });
+
+  it("does NOT classify auth/rate-limit/validation/404 or aborts as retryable", () => {
+    expect(isRetryableSendError({ status: 401 })).toBe(false);
+    expect(isRetryableSendError({ status: 403 })).toBe(false);
+    expect(isRetryableSendError({ status: 429 })).toBe(false);
+    expect(isRetryableSendError({ status: 413 })).toBe(false);
+    expect(isRetryableSendError({ status: 404 })).toBe(false);
+    expect(isRetryableSendError(abortError())).toBe(false);
+    expect(isRetryableSendError(null)).toBe(false);
+    expect(isRetryableSendError(new Error("plain"))).toBe(false);
+  });
+});
+
+describe("useChatSend E2 auto-retry on reconnect", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetNetworkStatusForTests();
+    mocks.client.getBaseUrl.mockReturnValue("");
+    mocks.client.onWsEvent.mockImplementation(() => () => {});
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("auto-retries once when connectivity returns, reusing the same clientMessageId", async () => {
+    // First attempt fails with a network blip; the reconnect signal drives a
+    // single retry that succeeds. The retry MUST reuse the original
+    // idempotency key so a landed-during-blip send is de-duped server-side.
+    let attempt = 0;
+    const seenIds: Array<string | undefined> = [];
+    mocks.client.sendConversationMessageStream.mockImplementation(
+      async (
+        _id: string,
+        _text: string,
+        onToken: (t: string, a?: string) => void,
+        _ch?: string,
+        _sig?: AbortSignal,
+        _imgs?: unknown,
+        _meta?: unknown,
+        _onStatus?: unknown,
+        _onTool?: unknown,
+        clientMessageId?: string,
+      ) => {
+        attempt += 1;
+        seenIds.push(clientMessageId);
+        if (attempt === 1) throw networkError();
+        onToken("hi there", "hi there");
+        return { text: "hi there", completed: true };
+      },
+    );
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    let sendPromise: Promise<void> | undefined;
+    await act(async () => {
+      sendPromise = result.current.sendChatText("hi", {
+        conversationId: "conv-1",
+      });
+      // Let the first attempt fail + arm the reconnect wait.
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // During the wait, NO manual resend notice yet — the turn still looks like
+    // it's sending.
+    expect(deps.setActionNotice).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await dispatchReconnectAndSettle();
+      await sendPromise;
+    });
+
+    // Exactly two attempts (original + one retry), no loop.
+    expect(attempt).toBe(2);
+    // Same idempotency key on both attempts.
+    expect(seenIds).toHaveLength(2);
+    expect(seenIds[0]).toBeTruthy();
+    expect(seenIds[1]).toBe(seenIds[0]);
+    // The retry succeeded — no error notice ever surfaced.
+    expect(deps.setActionNotice).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the manual resend affordance after the single auto-retry ALSO fails (no infinite loop)", async () => {
+    // Both attempts fail with a network blip. The auto-retry fires once, and
+    // when it also fails the turn flips to the manual resend path — it does NOT
+    // keep retrying forever.
+    let attempt = 0;
+    mocks.client.sendConversationMessageStream.mockImplementation(async () => {
+      attempt += 1;
+      throw networkError();
+    });
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    let sendPromise: Promise<void> | undefined;
+    await act(async () => {
+      sendPromise = result.current.sendChatText("hi", {
+        conversationId: "conv-1",
+      });
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    await act(async () => {
+      await dispatchReconnectAndSettle();
+      await sendPromise;
+    });
+
+    // Original + exactly one retry.
+    expect(attempt).toBe(2);
+    // The retry failed → manual resend notice surfaced.
+    expect(deps.setActionNotice).toHaveBeenCalledTimes(1);
+    const [msg, tone] = vi.mocked(deps.setActionNotice).mock.calls[0];
+    expect(tone).toBe("error");
+    expect(msg).toMatch(/resend/i);
+  });
+
+  it("does NOT auto-retry a non-retryable (validation) failure — manual affordance immediately", async () => {
+    let attempt = 0;
+    mocks.client.sendConversationMessageStream.mockImplementation(async () => {
+      attempt += 1;
+      throw validation413();
+    });
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("hi", { conversationId: "conv-1" });
+    });
+
+    // A single attempt, no retry, and the manual notice fired right away.
+    expect(attempt).toBe(1);
+    expect(deps.setActionNotice).toHaveBeenCalledTimes(1);
+    const [msg] = vi.mocked(deps.setActionNotice).mock.calls[0];
+    expect(msg).toMatch(/couldn't accept that message/i);
+  });
+
+  it("does not retry once the single auto-retry has been spent even if another reconnect fires", async () => {
+    // Guard against a second reconnect edge re-triggering: after the one retry
+    // is consumed, a further reconnect must NOT drive a third attempt.
+    let attempt = 0;
+    mocks.client.sendConversationMessageStream.mockImplementation(async () => {
+      attempt += 1;
+      throw networkError();
+    });
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    let sendPromise: Promise<void> | undefined;
+    await act(async () => {
+      sendPromise = result.current.sendChatText("hi", {
+        conversationId: "conv-1",
+      });
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    await act(async () => {
+      await dispatchReconnectAndSettle();
+      await sendPromise;
+    });
+
+    // A late, extra reconnect after the turn already settled must be inert.
+    await act(async () => {
+      await dispatchReconnectAndSettle();
+    });
+
+    expect(attempt).toBe(2);
+  });
+
+  it("stops waiting for reconnect (no retry) when the turn is superseded by Stop", async () => {
+    // A user Stop aborts the controller the wait listens on; the auto-retry must
+    // abandon quietly instead of firing into a torn-down turn.
+    let attempt = 0;
+    const firstAttemptStarted = deferred();
+    mocks.client.sendConversationMessageStream.mockImplementation(async () => {
+      attempt += 1;
+      firstAttemptStarted.resolve();
+      throw networkError();
+    });
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const { result } = renderHook(() => useChatSend(deps));
+
+    let sendPromise: Promise<void> | undefined;
+    await act(async () => {
+      sendPromise = result.current.sendChatText("hi", {
+        conversationId: "conv-1",
+      });
+      await firstAttemptStarted.promise;
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Stop while the retry is waiting for reconnect.
+    await act(async () => {
+      result.current.handleChatStop();
+      await sendPromise;
+    });
+
+    // A reconnect after the stop must NOT resurrect the turn.
+    await act(async () => {
+      await dispatchReconnectAndSettle();
+    });
+
+    expect(attempt).toBe(1);
+    // Stop is intentional — no error notice.
+    expect(deps.setActionNotice).not.toHaveBeenCalled();
+  });
+});
+
+describe("useChatSend manual resend still works after auto-retry exhausts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetNetworkStatusForTests();
+    mocks.client.getBaseUrl.mockReturnValue("");
+    mocks.client.onWsEvent.mockImplementation(() => () => {});
+  });
+
+  it("handleChatRetry re-sends after the auto-retry surfaced a failed turn", async () => {
+    // After the auto-retry exhausts and the thread shows a failed assistant
+    // turn, the existing manual Retry affordance must still drive a fresh send
+    // (truncate + resend) — the auto-retry does not disable manual resend.
+    const failedAssistantId = "asst-failed";
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    deps.conversationMessagesRef.current = [
+      { id: "user-1", role: "user", text: "hello", timestamp: Date.now() },
+      {
+        id: failedAssistantId,
+        role: "assistant",
+        text: UNDELIVERED_TURN_NOTICE,
+        timestamp: Date.now(),
+        failureKind: "provider_issue",
+      },
+    ];
+    mocks.client.sendConversationMessageStream.mockImplementation(
+      async (
+        _id: string,
+        _text: string,
+        onToken: (t: string, a?: string) => void,
+      ) => {
+        onToken("recovered", "recovered");
+        return { text: "recovered", completed: true };
+      },
+    );
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.handleChatRetry(failedAssistantId);
+    });
+
+    // The manual retry truncated the failed turn and re-sent the user text.
+    expect(mocks.client.truncateConversationMessages).toHaveBeenCalledWith(
+      "conv-1",
+      "user-1",
+      { inclusive: true },
+    );
+    expect(mocks.client.sendConversationMessageStream).toHaveBeenCalledTimes(1);
+    const sentText =
+      mocks.client.sendConversationMessageStream.mock.calls[0][1];
+    expect(sentText).toBe("hello");
   });
 });

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -20,13 +20,19 @@ import {
   type MessageAttachmentContentType,
 } from "../api";
 import { isLimitedCloudAgentApiBase } from "../api/app-shell-capabilities";
-import { isStreamGenerationError } from "../api/client-base";
+import {
+  generateChatClientMessageId,
+  isNetworkCurrentlyConnected,
+  isStreamGenerationError,
+  onNetworkStatusChange,
+} from "../api/client-base";
 import {
   expandSavedCustomCommand,
   loadSavedCustomCommands,
   normalizeSlashCommandName,
 } from "../chat";
 import {
+  APP_RESUME_EVENT,
   CLOUD_HANDOFF_PHASE_EVENT,
   type CloudHandoffPhaseDetail,
 } from "../events";
@@ -181,6 +187,160 @@ export function buildSendFailureNotice(err: unknown): string {
  */
 export const UNDELIVERED_TURN_NOTICE =
   "That message didn't reach the agent — it may still be starting up. Retry in a moment.";
+
+/**
+ * Whether a send failure is a *transport* failure worth auto-retrying once when
+ * connectivity returns — a dropped connection / DNS failure (`kind:"network"`),
+ * a request that never completed in time (`kind:"timeout"`), or the gateway
+ * bad/unavailable pair (502/503) an edge throws mid-blip. Deliberately narrow:
+ *
+ *  - 4xx (validation / auth / rate-limit / not-found) are NOT transport blips —
+ *    replaying them on reconnect fails identically, so they keep their existing
+ *    manual-resend copy.
+ *  - AbortError is a user Stop, never retried.
+ *  - A structured stream gate (no_provider / accountConnect) is a real answer,
+ *    not a transport failure.
+ *
+ * Exported for the send path and unit tests (the classification is the crux of
+ * "retry the blips, don't loop on real rejections").
+ */
+export function isRetryableSendError(err: unknown): boolean {
+  if (err == null) return false;
+  const name = (err as { name?: unknown }).name;
+  if (name === "AbortError") return false;
+  const kind = (err as { kind?: unknown }).kind;
+  if (kind === "network" || kind === "timeout") return true;
+  const status = (err as { status?: unknown }).status;
+  return status === 502 || status === 503;
+}
+
+/**
+ * Whether THIS failure should trigger the wait-for-reconnect auto-retry, as
+ * opposed to just being retryable copy on a manual affordance. Scoped tighter
+ * than {@link isRetryableSendError} so we only *hold* a turn (waiting for the
+ * network to come back) when a network drop is the plausible cause:
+ *
+ *  - a genuine transport drop (`kind:"network"`, e.g. "Failed to fetch") — the
+ *    blip case the E2 lane targets ("no more lost messages on network blips"),
+ *    ALWAYS eligible even if the bridge hasn't yet flipped to offline (iOS
+ *    frequently kills the socket on suspend without firing an `offline` edge);
+ *  - any retryable error while the device is ALREADY reporting offline — a
+ *    503/timeout during a known outage is worth holding for reconnect too.
+ *
+ * A 503 "agent waking up" or a slow-response timeout while the device is ONLINE
+ * is NOT a connectivity problem — there is no reconnect coming, so waiting is
+ * pointless; those keep the existing immediate manual-resend affordance.
+ */
+export function shouldAutoRetryOnReconnect(err: unknown): boolean {
+  if (!isRetryableSendError(err)) return false;
+  const kind = (err as { kind?: unknown }).kind;
+  if (kind === "network") return true;
+  return !isNetworkCurrentlyConnected();
+}
+
+/**
+ * Debounce for coalescing a burst of reconnect signals (an `online` edge, a
+ * `ws-reconnected`, and an `APP_RESUME` can all fire within a few ms of a
+ * device waking) into a single retry trigger — so the auto-retry runs ONCE,
+ * not once per signal.
+ */
+const RECONNECT_SIGNAL_DEBOUNCE_MS = 400;
+
+/**
+ * Max time to wait for a reconnect signal before giving up and surfacing the
+ * manual resend affordance. A blip that never heals within this window is
+ * treated as a genuine outage — the user gets the resend chip rather than a
+ * turn stuck forever in the sending state.
+ */
+const RECONNECT_WAIT_TIMEOUT_MS = 30_000;
+
+/**
+ * Resolve `true` the moment connectivity plausibly returns — the first of a
+ * bridged network `online` edge ({@link onNetworkStatusChange}), an
+ * {@link APP_RESUME_EVENT} (iOS foreground, where `online` often does NOT
+ * fire because the socket was silently killed on suspend, not on a network
+ * change), or a WS reconnect (`ws-reconnected`) — debounced so a cluster of
+ * signals fires the retry once. Resolves `false` on timeout or if `signal`
+ * aborts (the turn was superseded / the user navigated away). Never rejects,
+ * and always tears down every listener + timer on settle so nothing leaks.
+ */
+function waitForReconnect(
+  onWsEvent: (type: string, handler: () => void) => () => void,
+  signal: AbortSignal | null | undefined,
+  timeoutMs: number = RECONNECT_WAIT_TIMEOUT_MS,
+): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    if (signal?.aborted) {
+      resolve(false);
+      return;
+    }
+    let settled = false;
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
+    const cleanups: Array<() => void> = [];
+
+    const teardown = (): void => {
+      if (debounceTimer !== null) clearTimeout(debounceTimer);
+      if (timeoutTimer !== null) clearTimeout(timeoutTimer);
+      for (const cleanup of cleanups) {
+        try {
+          cleanup();
+        } catch {
+          // a listener teardown throwing must not block the others
+        }
+      }
+    };
+
+    const settle = (value: boolean): void => {
+      if (settled) return;
+      settled = true;
+      teardown();
+      resolve(value);
+    };
+
+    // Debounce the resolve so a burst (online + ws-reconnected + resume) fires
+    // the retry exactly once.
+    const onSignal = (): void => {
+      if (settled) return;
+      if (debounceTimer !== null) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(
+        () => settle(true),
+        RECONNECT_SIGNAL_DEBOUNCE_MS,
+      );
+    };
+
+    // Bridged Capacitor/`online` network transition (true = connected).
+    cleanups.push(
+      onNetworkStatusChange((connected) => {
+        if (connected) onSignal();
+      }),
+    );
+
+    // WS reconnect — the dedicated-agent REST path never fires this, but the
+    // shared-runtime WS does, and it's a strong "we're back online" signal.
+    cleanups.push(onWsEvent("ws-reconnected", onSignal));
+
+    // App foreground: on iOS the socket is often silently dead after a suspend
+    // and no `online` edge fires, so resume is the only reconnect hint we get.
+    if (typeof document !== "undefined") {
+      const onResume = (): void => onSignal();
+      document.addEventListener(APP_RESUME_EVENT, onResume);
+      cleanups.push(() =>
+        document.removeEventListener(APP_RESUME_EVENT, onResume),
+      );
+    }
+
+    // The turn was superseded (new chat / conversation switch / stop) — stop
+    // waiting so the retry doesn't fire into a torn-down context.
+    if (signal) {
+      const onAbort = (): void => settle(false);
+      signal.addEventListener("abort", onAbort, { once: true });
+      cleanups.push(() => signal.removeEventListener("abort", onAbort));
+    }
+
+    timeoutTimer = setTimeout(() => settle(false), timeoutMs);
+  });
+}
 
 /**
  * Clock-skew slack for matching a just-sent user turn against the server's
@@ -380,6 +540,20 @@ export interface QueuedChatSend {
   conversationId?: string | null;
   images?: ImageAttachment[];
   metadata?: Record<string, unknown>;
+  /**
+   * Idempotency key for this logical turn. Minted once on the first attempt and
+   * reused verbatim on the single auto-retry so a request that actually landed
+   * server-side during a blip is de-duped instead of double-delivered. Absent
+   * on a fresh enqueue (the drain mints it); present on the retry re-enqueue.
+   */
+  clientMessageId?: string;
+  /**
+   * True on the re-enqueued turn AFTER its one auto-retry-on-reconnect has been
+   * spent — the guard that makes the auto-retry fire exactly once (never a
+   * loop). A retry that also fails falls straight through to the manual resend
+   * affordance.
+   */
+  autoRetried?: boolean;
   resolve: () => void;
   reject: (error: unknown) => void;
 }
@@ -1013,6 +1187,12 @@ export function useChatSend(deps: UseChatSendDeps) {
 
       const channelType = turn.channelType;
       const imagesToSend = turn.images;
+      // Mint the idempotency key ONCE per logical turn and reuse it across the
+      // single auto-retry (the re-enqueued turn carries it back in). A send
+      // that actually landed server-side during a blip is then de-duped by the
+      // server on the retry instead of double-delivered.
+      const clientMessageId =
+        turn.clientMessageId ?? generateChatClientMessageId();
       let controller: AbortController | null = null;
       let abortServerTurn: (() => void) | null = null;
       let convRoomId: string | null = null;
@@ -1193,6 +1373,9 @@ export function useChatSend(deps: UseChatSendDeps) {
               mode: "tool",
               event,
             }),
+          // Idempotency key — reused verbatim across the single auto-retry so a
+          // send that landed during a blip is server-side de-duped.
+          clientMessageId,
         );
 
         // Commit any token parked by the throttle before the terminal
@@ -1469,6 +1652,9 @@ export function useChatSend(deps: UseChatSendDeps) {
                   mode: "tool",
                   event,
                 }),
+              // Same idempotency key across the whole logical turn, including
+              // the 404 recreate-and-replay recovery.
+              clientMessageId,
             );
 
             // Commit any throttle-parked token before the terminal modification.
@@ -1513,8 +1699,82 @@ export function useChatSend(deps: UseChatSendDeps) {
               );
             }
           }
+        } else if (shouldAutoRetryOnReconnect(err) && !turn.autoRetried) {
+          // Retryable transport failure (a network blip / timeout / 502/503)
+          // on the FIRST attempt: instead of immediately surfacing the manual
+          // resend affordance, hold the turn in its normal sending state and
+          // auto-retry ONCE the moment connectivity returns. This is the E2
+          // "messages survive network blips" guarantee — the common case on
+          // cellular is a sub-second drop that heals on its own, and making the
+          // user tap Resend for it is the difference between "just works" and
+          // "ugh, again." The retry:
+          //   - keeps the existing pending/sending UI (no new surface), so the
+          //     turn simply looks like it's still sending during the wait;
+          //   - reuses the SAME clientMessageId so a request that actually
+          //     landed server-side during the blip is de-duped, not doubled;
+          //   - fires EXACTLY once (waitForReconnect is debounced and the
+          //     re-enqueued turn is stamped autoRetried) — never a loop;
+          //   - aborts cleanly if the turn is superseded (new chat / stop /
+          //     conversation switch abort the controller signal we wait on);
+          //   - falls through to the manual affordance below only if the retry
+          //     ALSO fails or connectivity never returns within the window.
+          const reconnected = await waitForReconnect(
+            (type, handler) => client.onWsEvent(type, () => handler()),
+            controller?.signal,
+          );
+          if (reconnected && !controller?.signal.aborted) {
+            // Drop the stale placeholder from the failed attempt; the requeued
+            // turn paints its own fresh optimistic bubble on drain.
+            dropEmptyAssistantPlaceholder(assistantMsgId);
+            // Re-enqueue at the FRONT so the retry runs before any turns the
+            // user queued behind it, preserving send order. Same key + text +
+            // images + metadata; autoRetried stops a second auto-retry.
+            chatSendQueueRef.current.unshift({
+              rawInput: turn.rawInput,
+              channelType: turn.channelType,
+              conversationId: convId,
+              images: turn.images,
+              metadata: turn.metadata,
+              clientMessageId,
+              autoRetried: true,
+              resolve: () => {},
+              reject: () => {},
+            });
+            // The drain loop (flushQueuedChatSends) re-invokes this for the
+            // requeued turn; nothing more to do here.
+            return;
+          }
+          // Connectivity never returned (timeout) or the turn was superseded
+          // (abort). An abort is a user Stop / navigation — stay silent, drop
+          // the placeholder, and let the finally block settle. A timeout falls
+          // through to the manual resend affordance so the turn isn't stuck
+          // sending forever.
+          if (controller?.signal.aborted) {
+            dropEmptyAssistantPlaceholder(assistantMsgId);
+            return;
+          }
+          // Timed out waiting — surface the manual resend path (mirror the
+          // generic branch: drop the placeholder, KEEP the user's message,
+          // notice + reconcile + restore-evicted).
+          dropEmptyAssistantPlaceholder(assistantMsgId);
+          setActionNotice(buildSendFailureNotice(err), "error", 8_000);
+          await loadConversationMessages(convId);
+          if (activeConversationIdRef.current === convId) {
+            restoreEvictedUserTurn({
+              userMsgId,
+              assistantMsgId,
+              text,
+              timestamp: now,
+              ...(optimisticAttachments
+                ? { attachments: optimisticAttachments }
+                : {}),
+            });
+          }
         } else {
           // Non-abort, non-404 send failure (network/timeout/5xx/auth/429/4xx).
+          // Reaches here on a NON-retryable failure, or a retryable one whose
+          // single auto-retry was already spent (turn.autoRetried) — either way
+          // the user gets the manual resend affordance now.
           // Drop the empty assistant placeholder but KEEP the user's message,
           // and surface a status-specific notice so a stalled turn is never
           // silent dead air (the typing indicator stalls at ~30s while the SSE


### PR DESCRIPTION
## What & why

Implements **PWA dossier lane E2 (§2.2)** — "does a sent message survive a network blip?" — plus the **E1 idempotency groundwork** that makes a future durable outbox safe.

**Before:** a message sent during a network blip **fails and requires a manual resend**. The retryable `failureKind`, the network-status events, and the restore-to-composer pieces all existed, but nothing wired *"on reconnect, auto-retry the failed turn."* On cellular that's the difference between "it just works" and "ugh, tap Resend again."

## Change

- When a send fails with a genuine **transport drop** (`kind:"network"`, e.g. "Failed to fetch"), or any retryable error while the device is **already reporting offline**, the pending turn stays in its **normal sending state** and **auto-retries ONCE** the moment connectivity returns — `NETWORK_STATUS_CHANGE` online, `APP_RESUME` (iOS often kills the socket on suspend without an `offline` edge), or `ws-reconnected` — **debounced** so a burst of wake signals fires the retry exactly once.
- Only after the auto-retry **also** fails does the turn flip to the **existing** manual resend affordance. **No new UI surface** — reuses the retry/resend affordance exactly.
- A `503` "agent waking up" / slow-response `timeout` **while online** is not a connectivity problem, so it keeps the immediate manual affordance (no pointless 30s wait for a reconnect that isn't coming).
- **Idempotency guard (E1 groundwork):** the send path now mints a `clientMessageId` **once per logical turn** and reuses it **verbatim** on the auto-retry, threaded through `sendConversationMessageStream` → `streamChatEndpoint` → request body. A request that actually landed server-side during the blip is **de-duped** instead of double-delivered. The id was previously minted per-call inside `streamChatEndpoint` (a retry would mint a NEW id, breaking dedupe) — now it's stable across the whole turn.

## Safety (send-path = money-path)

- **Single retry, never a loop:** `autoRetried` flag on the re-enqueued turn + a debounced one-shot `waitForReconnect`.
- **No message loss:** timeout/abort/exhaust paths still fire `restoreEvictedUserTurn` + the manual notice; the requeue preserves text + images + metadata.
- **Clean abort:** a Stop / new chat / conversation switch aborts the controller signal the wait listens on → the retry abandons quietly.
- **Bounded:** 30s wait cap so a turn is never stuck "sending" forever; the reconnect trigger is debounced (400ms).

## Tests (vitest, jsdom — not bun test)

`packages/ui/src/state/useChatSend.test.tsx` — **56/56 green** (46 pre-existing + 10 new):
- retryable-error classification (network/timeout/502/503 retryable; auth/rate-limit/validation/404/abort not);
- single auto-retry on reconnect **reusing the same `clientMessageId`**;
- no retry for non-retryable (validation) errors — manual affordance immediately;
- no re-trigger after the single retry is spent, even on another reconnect edge;
- abandons the wait (no retry) when superseded by Stop;
- manual `handleChatRetry` still works after the auto-retry surfaces a failed turn.

```
 ✓ src/state/useChatSend.test.tsx (56 tests) 139ms
 Test Files  1 passed (1)
      Tests  56 passed (56)
```

Also green: `client-agent-stream.test.ts` (14), `useChatSend.send-voice-newchat.race.test.tsx` (10). tsgo: zero new type errors in touched files.

## Evidence / anchors

- Dossier E2 §2.2; catch-path in `useChatSend.ts`, network events in `client-base.ts:436`.
- **Sibling lane** `fix/pwa-resume-reconnect` (D1/D2) had **not** landed a resume-event API on `develop` at branch time, so this builds on the `APP_RESUME_EVENT` + `NETWORK_STATUS_CHANGE_EVENT` already exported from `@elizaos/shared/events`. If D1/D2 lands a richer resume orchestrator, this integrates cleanly (it only *listens* for those events).

## What full E1 (durable outbox) still needs

This lane makes E1 safe but does not build it. Remaining E1 work:
1. **Persist** unsent/failed-retryable turns to `localStorage`/Preferences (same mirror pattern as `ACTIVE_CONVERSATION_STORAGE_KEY`) so a turn survives a full app kill / reload, not just an in-session blip.
2. **Rehydrate + auto-flush** the persisted outbox on cold boot + `online`/`APP_RESUME`/`ws-reconnected`, reusing the persisted `clientMessageId` (now stable — that's the groundwork this PR lands).
3. **Server-side dedupe** by `clientMessageId` in `packages/agent/src/api/chat-routes.ts` (the client now always sends it; the server hook is where the dedupe must actually land to make the idempotency real end-to-end).
4. **Outbox UI** for a turn that's been queued across a kill (distinct from the in-session sending state), and eviction/TTL policy for turns that never flush.

[sol-orch]
