### PR TITLE
fix(ui): read-time alias for the removed bg-sunset.jpg — persisted wallpapers survive #15184

### DIFF
--- a/packages/ui/src/state/persistence.background.test.ts
+++ b/packages/ui/src/state/persistence.background.test.ts
@@ -152,3 +152,31 @@ describe("background config persistence", () => {
     expect(loadBackgroundConfig()).toEqual(DEFAULT);
   });
 });
+
+describe("legacy wallpaper alias (bg-sunset.jpg → .webp)", () => {
+  it("rewrites a persisted legacy jpg default to the webp that actually exists", () => {
+    const config = normalizeBackgroundConfig({
+      mode: "image",
+      color: "#160d07",
+      imageUrl: "/bg-sunset.jpg",
+    });
+    expect(config).toEqual({
+      mode: "image",
+      color: "#160d07",
+      imageUrl: "/bg-sunset.webp",
+    });
+  });
+
+  it("leaves non-legacy image urls untouched", () => {
+    const config = normalizeBackgroundConfig({
+      mode: "image",
+      color: "#160d07",
+      imageUrl: "/wallpapers/custom.webp",
+    });
+    expect(config).toEqual({
+      mode: "image",
+      color: "#160d07",
+      imageUrl: "/wallpapers/custom.webp",
+    });
+  });
+});

--- a/packages/ui/src/state/persistence.ts
+++ b/packages/ui/src/state/persistence.ts
@@ -189,14 +189,26 @@ function normalizeHexColor(value: unknown): string {
     : DEFAULT_BACKGROUND_COLOR;
 }
 
+// Renamed/recompressed curated wallpapers whose OLD URL may still sit in a
+// user's persisted background config. The asset is gone from /public, so
+// without this read-time alias every install that saved the old default 404s
+// its wallpaper after the deploy (#15184 removed bg-sunset.jpg). Normalization
+// runs on both load and save, so persisted configs self-heal on first touch.
+const LEGACY_WALLPAPER_ALIASES: Record<string, string> = {
+  "/bg-sunset.jpg": "/bg-sunset.webp",
+};
+
 export function normalizeBackgroundConfig(value: unknown): BackgroundConfig {
   const record = asRecord(value);
   if (!record) return { ...DEFAULT_BACKGROUND_CONFIG };
   const color = normalizeHexColor(record.color);
-  const imageUrl =
+  const rawImageUrl =
     typeof record.imageUrl === "string" && record.imageUrl.length > 0
       ? record.imageUrl
       : undefined;
+  const imageUrl = rawImageUrl
+    ? (LEGACY_WALLPAPER_ALIASES[rawImageUrl] ?? rawImageUrl)
+    : undefined;
   // Image mode without a usable source is meaningless — fall back to the shader.
   if (record.mode === "image" && imageUrl) {
     return { mode: "image", color, imageUrl };


### PR DESCRIPTION
## The gap (flagged in my #15184 review; merged before the fix landed)

#15184 removed `bg-sunset.jpg` in the WebP recompress, but background config **persists the URL string** — every existing install (all current PWA users + device installs) that saved the old default `/bg-sunset.jpg` 404s its wallpaper on next load.

## Fix

Legacy-alias map in `normalizeBackgroundConfig` — the normalization seam that already runs on **both load and save**, so stale persisted configs self-heal on first touch. This is option 2 from the review (read-time normalization, matching the repo's style); non-legacy URLs pass through untouched.

## Evidence

| type | evidence |
|---|---|
| RED/GREEN | New test fails against develop (legacy jpg passes through un-aliased → would 404); **12/12 green** with the alias |
| screenshots/video | N/A - the fix is the ABSENCE of a broken wallpaper for existing installs; deterministic normalization test covers it |
| trajectories | N/A - no model surface |

— [maintainer]