### PR TITLE
fix(cloud): overlapping queries on a single pg client in the provisioning worker

### DIFF
--- a/packages/cloud/shared/src/db/__tests__/client-tls.test.ts
+++ b/packages/cloud/shared/src/db/__tests__/client-tls.test.ts
@@ -1,6 +1,6 @@
 // Exercises cloud DB client tls behavior with deterministic repository fixtures.
 import { afterEach, describe, expect, test } from "bun:test";
-import { enforceTlsForRemote, shouldSkipTlsVerification } from "../client";
+import { applyIdleSessionTimeouts, enforceTlsForRemote, shouldSkipTlsVerification } from "../client";
 
 const PREV = process.env.DATABASE_SSL_NO_VERIFY;
 afterEach(() => {
@@ -78,5 +78,37 @@ describe("enforceTlsForRemote", () => {
     expect(() =>
       enforceTlsForRemote("postgresql://u:p@host.example.com/db?sslmode=disable"),
     ).toThrow(/must use TLS/i);
+  });
+});
+
+// applyIdleSessionTimeouts is the pg-pool `onConnect` hook remote non-Worker
+// pools run on every fresh connection. pg-pool AWAITS it before handing the
+// client to a waiting checkout — the previous fire-and-forget
+// `pool.on("connect")` query overlapped the checkout's first query on the same
+// client, which node-pg deprecates ("Calling client.query() when the client is
+// already executing a query…", removed in pg@9).
+describe("applyIdleSessionTimeouts", () => {
+  test("issues both idle-session timeouts in a single awaited query", async () => {
+    const statements: string[] = [];
+    await applyIdleSessionTimeouts({
+      query: async (text: string) => {
+        statements.push(text);
+      },
+    });
+    expect(statements).toHaveLength(1);
+    expect(statements[0]).toContain("SET idle_session_timeout = '10min'");
+    expect(statements[0]).toContain("SET idle_in_transaction_session_timeout = '5min'");
+  });
+
+  test("stays a no-op when the server rejects the SET (pre-PG14)", async () => {
+    // A rejecting hook would make pg-pool end the client and fail the
+    // checkout, so failure tolerance is load-bearing, not defensive.
+    await expect(
+      applyIdleSessionTimeouts({
+        query: async () => {
+          throw new Error('unrecognized configuration parameter "idle_session_timeout"');
+        },
+      }),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/cloud/shared/src/db/client.ts
+++ b/packages/cloud/shared/src/db/client.ts
@@ -180,6 +180,37 @@ export function enforceTlsForRemote(url: string): {
   };
 }
 
+/**
+ * pg-pool `onConnect` hook: apply server-side idle-session timeouts to every
+ * fresh connection. Long-running Node services (agent-server, gateways,
+ * daemons) hold pooled connections on the shared Postgres. A checkout that's
+ * never released, or a transaction abandoned open, would otherwise sit forever
+ * and can exhaust max_connections ("too many clients already"). The pool reaps
+ * its OWN idle connections within seconds, so these server-side timeouts only
+ * ever fire on genuinely leaked/abandoned sessions — reclaiming the slot.
+ *
+ * Registered as `onConnect` (NOT `pool.on("connect")`): pg-pool awaits this
+ * hook to completion before handing the fresh client to a waiting checkout, so
+ * the SET can never overlap the checkout's first query on the same client —
+ * the overlap node-pg deprecates ("Calling client.query() when the client is
+ * already executing a query…", removed in pg@9). idle_session_timeout is PG14+
+ * (idle_in_transaction_session_timeout is PG9.6+); the catch keeps the hook a
+ * no-op on older servers instead of failing the connection.
+ */
+export async function applyIdleSessionTimeouts(client: {
+  query: (text: string) => Promise<unknown>;
+}): Promise<void> {
+  try {
+    await client.query(
+      "SET idle_session_timeout = '10min'; SET idle_in_transaction_session_timeout = '5min'",
+    );
+  } catch (err) {
+    logger.debug("[db] could not set idle session timeouts", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
 function createPgPool(url: string, hyperdriveUrl?: string): PgPool {
   const env = getCloudAwareEnv();
   const inWorkerRuntime = isCloudflareWorkerRuntime();
@@ -216,6 +247,13 @@ function createPgPool(url: string, hyperdriveUrl?: string): PgPool {
     options.idleTimeoutMillis = 30_000;
     options.connectionTimeoutMillis = 30_000;
   }
+
+  // Skip on Workers (maxUses=1, can't leak, and we don't want an extra
+  // round-trip per request) and on local PGlite.
+  if (!inWorkerRuntime && !isLocalTcp) {
+    options.onConnect = applyIdleSessionTimeouts;
+  }
+
   const pool = new PgPool(options);
   // node-pg emits 'error' on an IDLE pooled client that the server/proxy drops
   // (Railway/Hyperdrive recycling a connection, or the PGlite socket bridge
@@ -227,28 +265,6 @@ function createPgPool(url: string, hyperdriveUrl?: string): PgPool {
       error: err instanceof Error ? err.message : String(err),
     });
   });
-  // Long-running Node services (agent-server, gateways) hold pooled connections
-  // on the shared Postgres. A checkout that's never released, or a transaction
-  // abandoned open, would otherwise sit forever and can exhaust
-  // max_connections ("too many clients already"). The pool reaps its OWN idle
-  // connections within seconds, so these server-side timeouts only ever fire on
-  // genuinely leaked/abandoned sessions — reclaiming the slot. Skip on Workers
-  // (maxUses=1, can't leak, and we don't want an extra round-trip per request)
-  // and on local PGlite. idle_session_timeout is PG14+; the catch keeps it a
-  // no-op on older servers (idle_in_transaction_session_timeout is PG9.6+).
-  if (!inWorkerRuntime && !isLocalTcp) {
-    pool.on("connect", (client) => {
-      void client
-        .query(
-          "SET idle_session_timeout = '10min'; SET idle_in_transaction_session_timeout = '5min'",
-        )
-        .catch((err) => {
-          logger.debug("[db] could not set idle session timeouts", {
-            error: err instanceof Error ? err.message : String(err),
-          });
-        });
-    });
-  }
   if (isLocalTcp) {
     disableLocalPreparedStatements(pool, { simpleQueryMode: inWorkerRuntime });
   }


### PR DESCRIPTION
Fixes #15190

## Problem

At every boot of the provisioning worker (and any long-running Node service on the shared pool), node-pg emits:

```
DeprecationWarning: Calling client.query() when the client is already executing a query is deprecated and will be removed in pg@9.0.
```

Traced it to `createPgPool` in `packages/cloud/shared/src/db/client.ts`: the idle-session timeouts were applied with a fire-and-forget `client.query()` inside `pool.on("connect")`. In pg 8.22 / pg-pool 3.14 the handoff is fully synchronous and happens **before** `readyForQuery` is set:

1. `Client._handleReadyForQuery` runs the connection callback before `readyForQuery = true` (`pg/lib/client.js:368`).
2. pg-pool's `_acquireClient` emits `'connect'` → our SET query gets **queued** on the client (not active, since `readyForQuery` is still false).
3. pg-pool immediately hands the same client to the waiting checkout, whose first real query hits `client.query()` with `_queryQueue.length > 0` → `queryQueueLengthDeprecationNotice()` (`pg/lib/client.js:715`).

Two queries overlapping on one pooled client — works today because node-pg still queues internally, breaks for real in pg@9 when the queue is removed.

## Fix

Move the SET to pg-pool's `onConnect` hook (typed in @types/pg 8.20), which pg-pool awaits to completion **before** handing the fresh client to a waiting checkout. Same statement, same swallow-on-pre-PG14 tolerance (a rejecting `onConnect` would end the client and fail the checkout, so the catch is load-bearing), zero overlap. Extracted as `applyIdleSessionTimeouts` so it's directly testable, following the file's existing exported-helper pattern.

Workers/local-PGlite paths keep skipping the setup, unchanged.

## Test evidence

- `bun test src/db/__tests__/client-tls.test.ts` (packages/cloud/shared): **11 pass, 0 fail** — 2 new tests: single awaited query carrying both GUCs, and no-throw on server rejection.
- `bun test cloud/admin/daemons/provisioning-worker.test.ts` (packages/scripts): **23 pass, 0 fail**.
- `bun run typecheck` (packages/cloud/shared, tsgo): clean.

[stan-cloud]
