### PR TITLE
fix(agent-image): build:docker-dist drifted from build:dist — image ships without dynamic-view-host-external.mjs, agent unbootable

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -38,7 +38,7 @@
     "build:ios-bun": "bun run scripts/build-mobile-bundle.mjs --target=ios",
     "build:ios-jsc": "bun run scripts/build-mobile-bundle.mjs --target=ios-jsc",
     "verify:mobile-workspace-resolution": "bun run scripts/build-mobile-bundle.mjs --verify-workspace-resolution",
-    "build:docker-dist": "node scripts/assert-package-boundary-imports.mjs && node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/agent && node ../scripts/copy-package-assets.mjs packages/agent assets && node ../scripts/rewrite-dist-relative-imports-node-esm.mjs packages/agent",
+    "build:docker-dist": "bun run build:dist",
     "typecheck": "tsgo --noEmit -p tsconfig.json",
     "build:dist": "node scripts/assert-package-boundary-imports.mjs && node ../scripts/rm-path-recursive.mjs dist && tsc --noCheck -p tsconfig.build.json && node ../scripts/prepare-package-dist.mjs packages/agent && node ../scripts/copy-package-assets.mjs packages/agent assets && node ../scripts/rewrite-dist-relative-imports-node-esm.mjs packages/agent && node ../scripts/copy-package-assets.mjs packages/agent src/api/dynamic-view-host-external.mjs src/api/dynamic-view-host-external.d.mts",
     "test:sandbox-live": "bun run scripts/live-sandbox-smoke.ts",


### PR DESCRIPTION
## Problem
**The `:develop` agent image is not bootable** — Docker CI Smoke red since 01:23 UTC ([run 5c8a3321](https://github.com/elizaOS/eliza/actions/workflows/docker-ci-smoke.yml)): `ERR_MODULE_NOT_FOUND: /app/packages/agent/dist/api/dynamic-view-host-external.mjs imported from dist/api/views-routes.js`. Live impact observed on staging tonight: **every dedicated-tier sandbox crash-loops silently at boot** (~10 reboots/2min, dies right after 'Bundled skills dir', zero error in container logs), so all dedicated provisions fail with 'Sandbox health check timed out' — reproduced on two different nodes, follows the image.

## Root cause
#15127 (18a1c67edc7) fixed exactly this by appending the hand-authored `.mjs`/`.d.mts` copy step — **but only to `build:dist`**. The Docker path (`packages/app-core/scripts/docker-ci-smoke.sh` 'Building agent workspace', and the image build) runs the twin script **`build:docker-dist`**, which kept the pre-fix command. The smoke log shows it plainly: turbo's `@elizaos/agent:build` runs the fixed command, then the smoke script re-runs the OLD one, which starts with `rm dist` — destroying the correctly-built output and rebuilding without the copy.

## Fix
`build:docker-dist` → `bun run build:dist`. The two scripts were byte-identical apart from the missing tail; independent copies of the same giant build command are exactly how this drifted once already. One pipeline, no twin to forget next time.

## Evidence
Fresh worktree on develop tip: `bun run build:docker-dist` exits 0 and `dist/api/` now contains both `dynamic-view-host-external.mjs` and `.d.mts`.

Unblocks: Docker CI Smoke, the ghcr `:develop` image, and every dedicated-tier staging sandbox (the last blocker of the #15160 arc — worker/DB plumbing is verified live, only the image boot remained). Part of the #15152 landmine class.

[stan-cloud]