### PR TITLE
fix(android): fresh-install first launch reaches onboarding — align native auto-start with the renderer pre-seed + liveness-check the cold-boot stamp

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -201,6 +201,7 @@ public class ElizaAgentService extends Service {
     private volatile boolean foregroundStartDenied;
     private volatile boolean detachedAgentMode;
     private volatile long detachedLaunchStartedAtMs;
+    private long detachedProbeArmedForLaunchMs;
     private int restartAttempts;
     private String currentStatus = "starting";
 
@@ -1809,16 +1810,44 @@ public class ElizaAgentService extends Service {
             if (launchStartedAt > 0L
                     && (System.currentTimeMillis() - launchStartedAt)
                         < AGENT_BOOT_GRACE_MS) {
-                detachedAgentMode = true;
-                detachedLaunchStartedAtMs = launchStartedAt;
-                Map<String, String> details = new LinkedHashMap<>();
-                details.put("ageMs", String.valueOf(System.currentTimeMillis() - launchStartedAt));
-                details.put("bootGraceMs", String.valueOf(AGENT_BOOT_GRACE_MS));
-                appendDiagnosticEvent("detached-agent-cold-boot-guard", details);
-                Log.i(TAG, "Detached agent still in cold boot (launched "
+                // The stamp alone can outlive the boot it describes: a force-stop
+                // or LMK kill takes down bun AND launch-child.sh in one sweep, so
+                // no agent-child-exited line is ever journaled, and a successor
+                // service instance would shepherd a corpse for the rest of the
+                // grace window (#15189). Before trusting the stamp, check that
+                // the journaled child of THIS launch still has a live /proc
+                // entry that looks like our runtime.
+                AgentChildStart childStart = readLatestAgentChildStart(launchStartedAt);
+                if (coldBootStampTrustworthy(
+                        childStart != null,
+                        childStart != null && isAgentChildProcessAlive(childStart.childPid))) {
+                    detachedAgentMode = true;
+                    detachedLaunchStartedAtMs = launchStartedAt;
+                    Map<String, String> details = new LinkedHashMap<>();
+                    details.put("ageMs", String.valueOf(System.currentTimeMillis() - launchStartedAt));
+                    details.put("bootGraceMs", String.valueOf(AGENT_BOOT_GRACE_MS));
+                    appendDiagnosticEvent("detached-agent-cold-boot-guard", details);
+                    Log.i(TAG, "Detached agent still in cold boot (launched "
+                        + (System.currentTimeMillis() - launchStartedAt)
+                        + "ms ago); not relaunching.");
+                    // This instance may not be the one that launched the boot
+                    // (service churn while bun is still coming up). The launcher
+                    // instance's startup probe died with its process — arm one
+                    // here so the boot is shepherded to running/restart instead
+                    // of trusted blindly until the stamp expires.
+                    armDetachedStartupProbeOnce(
+                        launchStartedAt,
+                        childStart != null ? childStart.startupTraceId : null);
+                    return;
+                }
+                Map<String, String> staleDetails = new LinkedHashMap<>();
+                staleDetails.put("ageMs", String.valueOf(System.currentTimeMillis() - launchStartedAt));
+                staleDetails.put("childPid", childStart.childPid);
+                appendDiagnosticEvent("detached-agent-cold-boot-guard-stale", staleDetails);
+                Log.w(TAG, "Detached agent launch stamp is "
                     + (System.currentTimeMillis() - launchStartedAt)
-                    + "ms ago); not relaunching.");
-                return;
+                    + "ms old but child pid " + childStart.childPid
+                    + " is gone with no journaled exit; relaunching instead of trusting the stamp.");
             }
 
             String abi = resolveRuntimeAbi();
@@ -2665,7 +2694,7 @@ public class ElizaAgentService extends Service {
                     }
                 }
                 if (stillThisProcess && !shuttingDown && detachedAgentMode && code == 0) {
-                    startDetachedStartupProbe(launchStartedAtMs, startupTraceId);
+                    armDetachedStartupProbeOnce(launchStartedAtMs, startupTraceId);
                     return;
                 }
                 if (stillThisProcess && !shuttingDown) {
@@ -2831,6 +2860,143 @@ public class ElizaAgentService extends Service {
         }
     }
 
+    private static final class AgentChildStart {
+        final long timestampMs;
+        final String childPid;
+        final String startupTraceId;
+
+        AgentChildStart(long timestampMs, String childPid, String startupTraceId) {
+            this.timestampMs = timestampMs;
+            this.childPid = childPid;
+            this.startupTraceId = startupTraceId;
+        }
+    }
+
+    /**
+     * Whether the cold-boot guard may trust the persisted launch stamp. The
+     * stamp says a boot STARTED recently; only the journaled child's /proc
+     * liveness says it is still going. No journaled start yet means the
+     * launcher is inside its first second — trust the stamp rather than
+     * relaunch-churn over it. A journaled child that is gone from /proc with
+     * no exit record is the force-stop/LMK signature (#15189): the kill took
+     * launch-child.sh down with bun, so no agent-child-exited line was ever
+     * written, and trusting the stamp would shepherd a corpse for the rest of
+     * the grace window.
+     */
+    static boolean coldBootStampTrustworthy(
+            boolean childStartJournaled, boolean childProcessAlive) {
+        return !childStartJournaled || childProcessAlive;
+    }
+
+    /**
+     * Same-uid liveness check for the detached agent child. Conservative in
+     * both directions: an unparseable pid trusts the stamp (no relaunch churn
+     * on a mid-write journal tail), and a live /proc entry only counts when
+     * its cmdline still looks like our runtime — a recycled pid can be a
+     * different process wearing the number (the WebView sandbox recycles
+     * quickly after a force-stop). Every process in the launch chain carries
+     * the app data path in its argv (sh launch-child.sh <log> <agent root> …,
+     * then the bun exec), so matching "bun"/"eliza" covers both the pre-exec
+     * shell and the final runtime.
+     */
+    private static boolean isAgentChildProcessAlive(String childPid) {
+        int pid;
+        try {
+            pid = Integer.parseInt(childPid == null ? "" : childPid.trim());
+        } catch (NumberFormatException invalid) {
+            return true;
+        }
+        if (pid <= 0) {
+            return true;
+        }
+        File proc = new File("/proc/" + pid);
+        if (!proc.exists()) {
+            return false;
+        }
+        try (FileInputStream in = new FileInputStream(new File(proc, "cmdline"))) {
+            byte[] buffer = new byte[4096];
+            int read = in.read(buffer);
+            if (read <= 0) {
+                // A live process always has argv; empty cmdline here is a
+                // kernel-thread/zombie shell that cannot be our runtime.
+                return false;
+            }
+            String cmdline = new String(buffer, 0, read, StandardCharsets.UTF_8).replace('\0', ' ');
+            return cmdline.contains("bun") || cmdline.contains("eliza");
+        } catch (IOException unreadable) {
+            // error-policy:J4 /proc read denied or raced a teardown — cannot
+            // prove death, so keep the guard (relaunch churn over a live boot
+            // is the worse failure mode).
+            return true;
+        }
+    }
+
+    /**
+     * Scan the restart-diagnostics JSONL for the newest agent-child-started
+     * record belonging to this launch window, so the cold-boot guard can
+     * liveness-check the exact child the stamp describes.
+     */
+    private AgentChildStart readLatestAgentChildStart(long launchStartedAtMs) {
+        String content = readDiagnosticsForScan();
+        if (content == null) {
+            return null;
+        }
+        AgentChildStart latest = null;
+        long cutoffMs = Math.max(0L, launchStartedAtMs - 2_000L);
+        for (String line : content.split("\\n")) {
+            if (line.trim().isEmpty()) {
+                continue;
+            }
+            try {
+                JSONObject json = new JSONObject(line);
+                if (!"agent-child-started".equals(json.optString("event", ""))) {
+                    continue;
+                }
+                long timestampMs = json.optLong("ts", 0L);
+                if (timestampMs > 0L && timestampMs < cutoffMs) {
+                    continue;
+                }
+                JSONObject details = json.optJSONObject("details");
+                String childPid = details != null ? details.optString("childPid", "") : "";
+                String traceId = details != null ? details.optString("startupTraceId", "") : "";
+                latest = new AgentChildStart(timestampMs, childPid, traceId);
+            } catch (JSONException ignored) {
+                // error-policy:J3 partial or malformed diagnostic lines are invalid
+                // records; skip them and keep scanning, same as the exit reader.
+            }
+        }
+        return latest;
+    }
+
+    /**
+     * Bounded read of the restart-diagnostics journal for record scans.
+     * Shared by the child start/exit readers.
+     */
+    private String readDiagnosticsForScan() {
+        File log = new File(agentRoot(), AGENT_RESTART_DIAGNOSTICS_NAME);
+        if (!log.isFile()) {
+            return null;
+        }
+        long maxBytes = Math.min(log.length(), AGENT_RESTART_DIAGNOSTICS_MAX_BYTES);
+        if (maxBytes <= 0L) {
+            return null;
+        }
+        byte[] bytes = new byte[(int) maxBytes];
+        int read = 0;
+        try (FileInputStream input = new FileInputStream(log)) {
+            while (read < bytes.length) {
+                int n = input.read(bytes, read, bytes.length - read);
+                if (n < 0) break;
+                read += n;
+            }
+        } catch (IOException error) {
+            // error-policy:J7 diagnostic JSONL read failures must not kill the watchdog loop.
+            Log.w(TAG, "Could not read agent child diagnostics", error);
+            return null;
+        }
+        return new String(bytes, 0, read, StandardCharsets.UTF_8);
+    }
+
     /**
      * Human attribution for an agent child exit code. Codes >= 128 are
      * 128+signal deaths; the three that actually occur on-device get named
@@ -2989,28 +3155,10 @@ public class ElizaAgentService extends Service {
     }
 
     private AgentChildExit readLatestAgentChildExit(long launchStartedAtMs, String startupTraceId) {
-        File log = new File(agentRoot(), AGENT_RESTART_DIAGNOSTICS_NAME);
-        if (!log.isFile()) {
+        String content = readDiagnosticsForScan();
+        if (content == null) {
             return null;
         }
-        long maxBytes = Math.min(log.length(), AGENT_RESTART_DIAGNOSTICS_MAX_BYTES);
-        if (maxBytes <= 0L) {
-            return null;
-        }
-        byte[] bytes = new byte[(int) maxBytes];
-        int read = 0;
-        try (FileInputStream input = new FileInputStream(log)) {
-            while (read < bytes.length) {
-                int n = input.read(bytes, read, bytes.length - read);
-                if (n < 0) break;
-                read += n;
-            }
-        } catch (IOException error) {
-            // error-policy:J7 diagnostic JSONL read failures must not kill the watchdog loop.
-            Log.w(TAG, "Could not read agent child diagnostics", error);
-            return null;
-        }
-        String content = new String(bytes, 0, read, StandardCharsets.UTF_8);
         AgentChildExit latest = null;
         long cutoffMs = Math.max(0L, launchStartedAtMs - 2_000L);
         for (String line : content.split("\\n")) {
@@ -3044,6 +3192,23 @@ public class ElizaAgentService extends Service {
             }
         }
         return latest;
+    }
+
+    /**
+     * Arm the detached startup probe exactly once per launch stamp. Both the
+     * launching instance (via its exit watcher) and a successor instance that
+     * adopted the boot through the cold-boot guard call this; repeated
+     * onStartCommand deliveries for the same launch must not stack probe
+     * threads that would each schedule their own restart.
+     */
+    private void armDetachedStartupProbeOnce(long launchStartedAtMs, String startupTraceId) {
+        synchronized (processLock) {
+            if (detachedProbeArmedForLaunchMs == launchStartedAtMs) {
+                return;
+            }
+            detachedProbeArmedForLaunchMs = launchStartedAtMs;
+        }
+        startDetachedStartupProbe(launchStartedAtMs, startupTraceId);
     }
 
     private void startDetachedStartupProbe(final long launchStartedAtMs, final String startupTraceId) {
@@ -3607,18 +3772,50 @@ public class ElizaAgentService extends Service {
      * - On AOSP / ElizaOS-branded devices (`ro.elizaos.product` set or any
      *   white-label fork's `ro.<brand>os.product`), the device IS the
      *   agent: always start.
-     * - On stock Android, only start when the user has explicitly picked the
-     *   Local runtime in the onboarding picker (mobile-runtime-mode ==
-     *   "local"). Cloud, hybrid cloud, remote, tunnel, and not-yet-chosen
-     *   modes do not need this service.
+     * - On stock Android, start when the user picked the Local runtime in
+     *   the onboarding picker (mobile-runtime-mode == "local"), or when no
+     *   mode has been chosen yet on a build that ships the agent payload.
+     *   The renderer's pre-seed (pre-seed-local-runtime.ts) commits the
+     *   on-device agent as the startup target on the first frame of every
+     *   payload-shipping build — but it runs after this gate has already
+     *   been evaluated in MainActivity.onCreate, so waiting for the
+     *   persisted choice deadlocks the first-ever launch: the WebView polls
+     *   an abstract socket no one is serving until the startup timeout card
+     *   (#15189). Matching the pre-seed's build truth here closes that gap;
+     *   the cloud-thinned Play-Store build and UI-only debug builds carry no
+     *   payload and keep the cloud-first fresh-install behavior.
+     * - An explicit cloud, hybrid cloud, remote, or tunnel choice never
+     *   auto-starts this service.
      */
     public static boolean shouldAutoStart(Context context) {
-        return shouldAutoStartForRuntimeMode(isBrandedDevice(), readRuntimeMode(context));
+        return shouldAutoStartForRuntimeMode(
+            isBrandedDevice(), readRuntimeMode(context), apkBundlesAgentPayload(context));
     }
 
-    static boolean shouldAutoStartForRuntimeMode(boolean brandedDevice, String mode) {
+    static boolean shouldAutoStartForRuntimeMode(
+            boolean brandedDevice, String mode, boolean bundlesAgentPayload) {
         if (brandedDevice) return true;
-        return "local".equals(mode == null ? null : mode.trim());
+        String trimmed = mode == null ? null : mode.trim();
+        if ("local".equals(trimmed)) return true;
+        return (trimmed == null || trimmed.isEmpty()) && bundlesAgentPayload;
+    }
+
+    /**
+     * Whether this APK ships the on-device agent payload. Native mirror of the
+     * renderer's isAndroidLocalSideloadBuild() build truth: the cloud-thinning
+     * build step strips assets/agent/** from the Play-Store APK, so probing the
+     * bundle asset distinguishes the local-sideload/system builds (payload
+     * present) from cloud-thinned and UI-only WebView-debug builds.
+     */
+    static boolean apkBundlesAgentPayload(Context context) {
+        if (context == null) return false;
+        try (InputStream probe = context.getAssets().open("agent/" + AGENT_BUNDLE_NAME)) {
+            return true;
+        } catch (IOException missing) {
+            // error-policy:J3 asset probe — absence of the bundle IS the negative
+            // signal (thinned build), not a failure to report.
+            return false;
+        }
     }
 
     /**

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java
@@ -132,18 +132,21 @@ public class MainActivity extends BridgeActivity {
 
         // Auto-start the local Eliza agent runtime as a foreground service.
         // shouldAutoStart() returns true on branded devices (AOSP/ElizaOS —
-        // the device IS the agent) and on stock Android only when the user
-        // picked Local mode in onboarding. Cloud/Remote modes skip this so
-        // we don't burn battery on a service they never call. The boot
-        // receiver covers the cold-boot path; this is the fast path when
-        // the user opens the app.
+        // the device IS the agent), on stock Android when the user picked
+        // Local mode in onboarding, and on a fresh install of any build that
+        // ships the agent payload — the renderer pre-seeds the on-device
+        // agent as its backend on first paint, so the payload build must
+        // start it here or the first launch polls a socket no one serves
+        // (#15189). Explicit Cloud/Remote choices skip this so we don't burn
+        // battery on a service they never call. The boot receiver covers the
+        // cold-boot path; this is the fast path when the user opens the app.
         if (ElizaAgentService.shouldAutoStart(this)) {
             ElizaAgentService.start(this);
             // Ask for notification consent only once the user (or the device
             // image) has actually committed to running the on-device agent.
-            // Fresh stock installs stay cloud-first until onboarding records a
-            // local runtime choice, so there is no foreground service reason to
-            // cold-ask on first paint.
+            // A fresh install runs the pre-seeded agent before any recorded
+            // choice — keep first paint free of a cold permission ask and let
+            // onboarding own that moment.
             if (ElizaAgentService.hasCommittedRuntimeChoice(this)) {
                 requestPostNotificationsIfNeeded();
             }

--- a/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaAgentAutostartPolicyTest.java
+++ b/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaAgentAutostartPolicyTest.java
@@ -10,41 +10,67 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 /**
- * JVM unit tests for the stock-Android local-agent autostart policy. The
- * service must stay out of the first-run cloud path on low-RAM phones unless a
- * device image or an explicit local runtime choice needs the bundled agent.
+ * JVM unit tests for the stock-Android local-agent autostart policy. The gate
+ * must mirror the renderer's pre-seed build truth (pre-seed-local-runtime.ts):
+ * a build that ships the agent payload boots it even before onboarding records
+ * a choice — the renderer already committed to it as the startup target, and
+ * waiting for the persisted choice deadlocks the first-ever launch (#15189).
+ * Builds without the payload (cloud-thinned Play Store, UI-only debug) stay
+ * cloud-first, and an explicit non-local user choice is always respected.
  */
 public class ElizaAgentAutostartPolicyTest {
 
     @Test
     public void brandedDevicesAlwaysStartTheBundledAgent() {
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, null));
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, "cloud"));
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, "remote-mac"));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, null, true));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, null, false));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, "cloud", false));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, "remote-mac", false));
     }
 
     @Test
-    public void stockFreshInstallDoesNotStartTheBundledAgent() {
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, null));
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, ""));
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "   "));
+    public void stockFreshInstallStartsTheAgentWhenTheBuildShipsIt() {
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, null, true));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "", true));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "   ", true));
     }
 
     @Test
-    public void stockCloudModesStayCloudFirst() {
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "cloud"));
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "cloud-hybrid"));
+    public void stockFreshInstallStaysCloudFirstWithoutThePayload() {
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, null, false));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "", false));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "   ", false));
+    }
+
+    @Test
+    public void stockCloudModesStayCloudFirstEvenWithThePayload() {
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "cloud", true));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "cloud-hybrid", true));
     }
 
     @Test
     public void stockExternalModesDoNotStartTheBundledAgent() {
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "remote-mac"));
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "tunnel-to-mobile"));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "remote-mac", true));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "tunnel-to-mobile", true));
     }
 
     @Test
     public void stockLocalModeStartsTheBundledAgent() {
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "local"));
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, " local "));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "local", true));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, " local ", false));
+    }
+
+    /**
+     * Cold-boot-guard stamp trust: the stamp is only as alive as the child it
+     * describes. No journaled start yet = launcher's first second, trust it; a
+     * journaled child that is gone from /proc = the force-stop/LMK signature,
+     * relaunch instead of shepherding a corpse (#15189).
+     */
+    @Test
+    public void coldBootStampTrustFollowsChildLiveness() {
+        assertTrue(ElizaAgentService.coldBootStampTrustworthy(false, false));
+        assertTrue(ElizaAgentService.coldBootStampTrustworthy(false, true));
+        assertTrue(ElizaAgentService.coldBootStampTrustworthy(true, true));
+        assertFalse(ElizaAgentService.coldBootStampTrustworthy(true, false));
     }
 }

--- a/packages/ui/src/api/android-native-agent-transport.request-start.test.ts
+++ b/packages/ui/src/api/android-native-agent-transport.request-start.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Guard/dispatch behavior of requestAndroidLocalAgentStartForUrl — the
+ * startup coordinator's "ask native to start the agent you are polling" seam
+ * (#15189). Drives the REAL transport module against the real Capacitor
+ * runtime object with its platform/plugin surface patched per case; no module
+ * mocks.
+ */
+import { Capacitor } from "@capacitor/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ANDROID_LOCAL_AGENT_IPC_BASE } from "../first-run/mobile-runtime-mode";
+import { requestAndroidLocalAgentStartForUrl } from "./android-native-agent-transport";
+
+type MutableCapacitor = typeof Capacitor & {
+  getPlatform: () => string;
+  Plugins?: Record<string, unknown>;
+};
+
+const cap = Capacitor as MutableCapacitor;
+const originalGetPlatform = cap.getPlatform;
+const originalPlugins = cap.Plugins;
+
+let startCalls: number;
+
+function installAgentPlugin(plugin: Record<string, unknown>): void {
+  cap.Plugins = { Agent: plugin };
+}
+
+beforeEach(() => {
+  startCalls = 0;
+  cap.getPlatform = () => "android";
+  installAgentPlugin({
+    start: async () => {
+      startCalls += 1;
+      return { status: "starting" };
+    },
+  });
+});
+
+afterEach(() => {
+  cap.getPlatform = originalGetPlatform;
+  cap.Plugins = originalPlugins;
+});
+
+describe("requestAndroidLocalAgentStartForUrl", () => {
+  it("asks the native Agent plugin to start for the local-IPC base", async () => {
+    const requested = await requestAndroidLocalAgentStartForUrl(
+      `${ANDROID_LOCAL_AGENT_IPC_BASE}/api/auth/status`,
+    );
+    expect(requested).toBe(true);
+    expect(startCalls).toBe(1);
+  });
+
+  it("does not fire for a non-local base", async () => {
+    const requested = await requestAndroidLocalAgentStartForUrl(
+      "https://api.elizacloud.ai/api/auth/status",
+    );
+    expect(requested).toBe(false);
+    expect(startCalls).toBe(0);
+  });
+
+  it("does not fire off native Android", async () => {
+    cap.getPlatform = () => "web";
+    const requested = await requestAndroidLocalAgentStartForUrl(
+      `${ANDROID_LOCAL_AGENT_IPC_BASE}/api/auth/status`,
+    );
+    expect(requested).toBe(false);
+    expect(startCalls).toBe(0);
+  });
+
+  it("degrades to false when the plugin lacks start", async () => {
+    installAgentPlugin({
+      getStatus: async () => ({ status: "unknown" }),
+    });
+    const requested = await requestAndroidLocalAgentStartForUrl(
+      `${ANDROID_LOCAL_AGENT_IPC_BASE}/api/auth/status`,
+    );
+    expect(requested).toBe(false);
+  });
+
+  it("degrades to false when the native start rejects", async () => {
+    installAgentPlugin({
+      start: async () => {
+        startCalls += 1;
+        throw new Error("Failed to start local agent service");
+      },
+    });
+    const requested = await requestAndroidLocalAgentStartForUrl(
+      `${ANDROID_LOCAL_AGENT_IPC_BASE}/api/auth/status`,
+    );
+    expect(requested).toBe(false);
+    expect(startCalls).toBe(1);
+  });
+
+  it("handles null and undefined bases", async () => {
+    expect(await requestAndroidLocalAgentStartForUrl(null)).toBe(false);
+    expect(await requestAndroidLocalAgentStartForUrl(undefined)).toBe(false);
+    expect(startCalls).toBe(0);
+  });
+});

--- a/packages/ui/src/api/android-native-agent-transport.ts
+++ b/packages/ui/src/api/android-native-agent-transport.ts
@@ -376,6 +376,36 @@ export async function androidNativeAgentLifecycleForUrl(
   return resolveNativeAgentPlugin();
 }
 
+/**
+ * Ask the native service to start the on-device agent that `url` targets.
+ * The startup coordinator fires this for the local-agent base it polls: the
+ * poll itself cannot wake the agent (an abstract-socket connect just blocks
+ * while nobody listens), and on a fresh install nothing else will — the
+ * MainActivity auto-start gate is evaluated before the renderer pre-seeds
+ * local mode, and onboarding (the only other `Agent.start()` caller) is
+ * skipped on the pre-seeded path (#15189). Native start is idempotent — a
+ * START_AGENT delivery to a running/booting service is absorbed by the
+ * socket-adopt and cold-boot guards — so callers may fire this once per
+ * polled base without coordinating with service state. Returns whether a
+ * start request actually reached the native plugin.
+ */
+export async function requestAndroidLocalAgentStartForUrl(
+  url: string | null | undefined,
+): Promise<boolean> {
+  if (!url || !shouldAttemptNativeAgentTransport(url)) return false;
+  if (!isNativeAndroid()) return false;
+  const agent = await resolveNativeAgentPlugin();
+  if (!agent?.start) return false;
+  try {
+    await agent.start();
+    return true;
+  } catch {
+    // error-policy:J4 a failed start request leaves the poll on its existing
+    // budget/timeout paths, which surface the failure with full context.
+    return false;
+  }
+}
+
 export async function getAndroidLocalAgentBootStateForUrl(
   url: string | null | undefined,
 ): Promise<AndroidLocalAgentBootState> {

--- a/packages/ui/src/state/startup-phase-poll.test.ts
+++ b/packages/ui/src/state/startup-phase-poll.test.ts
@@ -4,6 +4,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { FirstRunOptions } from "../api";
+import { ANDROID_LOCAL_AGENT_IPC_BASE } from "../first-run/mobile-runtime-mode";
 import { clearPersistedActiveServer } from "./persistence";
 import {
   isRecoverableRemoteBase,
@@ -39,6 +40,7 @@ const androidBootStateMock = vi.hoisted(() => ({
       state: "unknown",
     }),
   ),
+  requestAndroidLocalAgentStartForUrl: vi.fn(async () => false),
 }));
 
 vi.mock("../api", () => ({
@@ -48,6 +50,8 @@ vi.mock("../api", () => ({
 vi.mock("../api/android-native-agent-transport", () => ({
   getAndroidLocalAgentBootStateForUrl:
     androidBootStateMock.getAndroidLocalAgentBootStateForUrl,
+  requestAndroidLocalAgentStartForUrl:
+    androidBootStateMock.requestAndroidLocalAgentStartForUrl,
 }));
 
 vi.mock("../api/client-cloud", () => ({
@@ -147,6 +151,9 @@ beforeEach(() => {
   androidBootStateMock.getAndroidLocalAgentBootStateForUrl.mockResolvedValue({
     state: "unknown",
   });
+  androidBootStateMock.requestAndroidLocalAgentStartForUrl.mockResolvedValue(
+    false,
+  );
   cloudMock.getCloudAuthToken.mockReturnValue(null);
 });
 
@@ -257,6 +264,71 @@ describe("runPollingBackend", () => {
       firstRunComplete: false,
     });
     expect(dispatch).not.toHaveBeenCalledWith({ type: "BACKEND_TIMEOUT" });
+  });
+
+  it("requests a native local-agent start exactly once for the polled base", async () => {
+    // #15189: on a fresh install the native auto-start gate ran before the
+    // renderer pre-seeded the local target, so the agent the poll waits for
+    // was never asked to start. The poll must fire the start request for the
+    // base it polls — and only once per base, even across retry iterations.
+    const deps = createDeps();
+    const dispatch = vi.fn();
+    const ipcBase = ANDROID_LOCAL_AGENT_IPC_BASE;
+    clientMock.getBaseUrl.mockReturnValue(ipcBase);
+    clientMock.getAuthStatus.mockReset();
+    clientMock.getAuthStatus
+      .mockRejectedValueOnce(
+        Object.assign(new Error("socket not accepting"), {
+          kind: "network",
+          path: "/api/auth/status",
+        }),
+      )
+      .mockResolvedValue({
+        required: false,
+        pairingEnabled: false,
+        expiresAt: null,
+      });
+
+    const localServer = {
+      id: "android:local-agent",
+      kind: "remote" as const,
+      label: "On-device agent",
+      apiBase: ipcBase,
+    };
+    const ctx: RestoringSessionCtx = {
+      persistedActiveServer: localServer,
+      restoredActiveServer: localServer,
+      shouldPreserveCompletedFirstRun: false,
+      hadPriorFirstRun: false,
+    };
+
+    await runPollingBackend(
+      deps,
+      dispatch,
+      {
+        supportsLocalRuntime: true,
+        backendTimeoutMs: 1000,
+        agentReadyTimeoutMs: 1000,
+        probeForExistingInstall: true,
+        defaultTarget: "embedded-local",
+      },
+      ctx,
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+    );
+
+    expect(
+      androidBootStateMock.requestAndroidLocalAgentStartForUrl,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      androidBootStateMock.requestAndroidLocalAgentStartForUrl,
+    ).toHaveBeenCalledWith(ipcBase);
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "BACKEND_REACHED",
+      firstRunComplete: false,
+    });
   });
 
   it("routes a DEV-UI-shell (port 2138) same-origin proxy outage to offline first-run instead of waiting for timeout", async () => {

--- a/packages/ui/src/state/startup-phase-poll.ts
+++ b/packages/ui/src/state/startup-phase-poll.ts
@@ -10,7 +10,10 @@ import { logger } from "@elizaos/logger";
 import { getStylePresets } from "@elizaos/shared";
 import type { FirstRunOptions } from "../api";
 import { client } from "../api";
-import { getAndroidLocalAgentBootStateForUrl } from "../api/android-native-agent-transport";
+import {
+  getAndroidLocalAgentBootStateForUrl,
+  requestAndroidLocalAgentStartForUrl,
+} from "../api/android-native-agent-transport";
 import { supportsFullAppShellRoutes } from "../api/app-shell-capabilities";
 import {
   getCloudAuthToken,
@@ -521,6 +524,9 @@ export async function runPollingBackend(
   // launch records WHICH base the poll hit and HOW it failed.
   let tracedPollFailures = 0;
   let tracedFirstSuccess = false;
+  // Local-agent start requests already fired this phase entry, keyed by base
+  // so a mid-phase base change (recoverToOnDeviceLocalAgent) gets its own.
+  const nativeStartRequestedBases = new Set<string>();
   appendIosBootTrace("polling-backend-start", {
     baseUrl: client.getBaseUrl(),
     backendTimeoutMs: policy.backendTimeoutMs,
@@ -604,6 +610,29 @@ export async function runPollingBackend(
       deps.setFirstRunLoading(false);
       dispatch({ type: "BACKEND_TIMEOUT" });
       return;
+    }
+    // The poll cannot wake the agent it is waiting for — an Android local-IPC
+    // probe just blocks while nobody serves the socket — and on a fresh
+    // install nobody else asks: the native auto-start gate was evaluated
+    // before the renderer pre-seeded the local target, and onboarding (the
+    // only other Agent.start() caller) is skipped on the pre-seeded path
+    // (#15189). Request the start explicitly, once per polled base, so the
+    // fresh boot, the Retry button, and a mid-phase recoverToOnDeviceLocalAgent
+    // all revive the agent instead of timing out against a service that was
+    // never started. Non-local bases no-op inside the helper.
+    const polledBase = client.getBaseUrl();
+    if (polledBase && !nativeStartRequestedBases.has(polledBase)) {
+      nativeStartRequestedBases.add(polledBase);
+      void requestAndroidLocalAgentStartForUrl(polledBase).then((requested) => {
+        if (requested) {
+          logger.info(
+            "[startup-phase-poll] requested native local-agent start for the polled base",
+          );
+          appendIosBootTrace("native-agent-start-requested", {
+            baseUrl: polledBase,
+          });
+        }
+      });
     }
     try {
       const auth = await traceIfStalled(


### PR DESCRIPTION
Fixes #15189.

## What

A truly-fresh install of the local-sideload APK (fresh install or `pm clear` — not `install -r`, which preserves app data) never reaches onboarding: the first launch sits on "Booting up…" for 180s and dies on the **"Startup failed: Backend Timeout"** card. Two stacked defects, fixed on both layers:

**1. Native — `shouldAutoStart` now matches the renderer pre-seed's build truth** (`ElizaAgentService.java`, `MainActivity.java` comments). The renderer pre-seeds the on-device agent as the startup target on first paint of every payload-shipping build (`pre-seed-local-runtime.ts`), but the native gate read the not-yet-written mode preference in `MainActivity.onCreate` and skipped the start — so the WebView polled an abstract socket no one served (a connect that *blocks*, not refuses → `probe-stalled` retries to the deadline). A not-yet-chosen mode on a build that ships the agent payload (probed via `assets/agent/agent-bundle.js`, exactly what the cloud-thinning step strips) now starts the service. Explicit cloud/hybrid/remote/tunnel choices are still respected; cloud-thinned and UI-only-debug builds keep cloud-first behavior.

**2. Native — the detached cold-boot guard liveness-checks the stamp's child.** A force-stop/LMK kill during boot grace takes `launch-child.sh` down with bun → no `agent-child-exited` is ever journaled → a successor service instance trusted the fresh-looking stamp, skipped the relaunch, armed no probe, and shepherded a corpse while the renderer's error card sat terminal (observed 6+ minutes of total silence on-device). The guard now reads the journaled `agent-child-started` pid and checks `/proc/<pid>` (+ cmdline sanity against pid reuse; conservative in both directions) — a provably-dead child journals `detached-agent-cold-boot-guard-stale` and falls through to relaunch. When the guard *does* hold, it arms the startup probe (deduped per launch stamp via `armDetachedStartupProbeOnce`) so a successor instance shepherds the boot instead of returning blind.

**3. Web — the startup poll requests the agent start it is waiting for** (`startup-phase-poll.ts`, `android-native-agent-transport.ts`). New `requestAndroidLocalAgentStartForUrl` (android-native guarded, J4 degrade) fires once per polled local-IPC base — covering the fresh boot, the **Retry** button, and mid-phase `recoverToOnDeviceLocalAgent`. This also heals field devices already wedged on the timeout card without an app restart, and is inert for cloud/remote bases.

## Why the pre-seed/gate mismatch survived testing

Every prior device verification used `adb install -r`, which preserves app data — the mode preference persisted by an earlier run made `shouldAutoStart` true. Tonight's `pm clear` was the first genuinely-fresh boot this build lineage ever saw. (The 15-minute `ElizaWorkScheduler` periodic was the only self-heal in the field.)

## Tests

- **JVM policy tests** (`ElizaAgentAutostartPolicyTest`): rewritten for the 3-arg gate — branded always; fresh+payload starts (the new contract); fresh−payload stays cloud-first; explicit cloud/remote modes never start; cold-boot stamp-trust truth table. `:app:testDebugUnitTest` green.
- **UI unit** (`android-native-agent-transport.request-start.test.ts`, 6 cases): real module against the real Capacitor runtime object (no module mocks) — dispatch on local base, no-op on non-local/off-platform/absent-plugin, rejection degrade, null/undefined bases.
- **UI integration** (`startup-phase-poll.test.ts`, 47/47): the poll fires the start request exactly once per polled base across retry iterations, alongside all pre-existing cases.
- `bun run --cwd packages/ui typecheck` + `lint:check` clean.

## Device evidence (RED→GREEN, Seeker, fresh vault)

RED (current develop build) — captured before the fix, attached below: `pm clear` → launch → `phase=polling-backend` → `phase=error` at exactly +180s, `dumpsys` shows **no ElizaAgentService record**, `files/agent/` never staged; Retry reproduces; force-stop during a later boot → cold-boot-guard `ageMs=43466` trusts the stamp → 6+ min corpse-shepherding with zero diagnostics events.

GREEN (this branch's APK): `pm clear` → ONE launch → FGS starts immediately → fresh-vault agent boot → onboarding paints, no restart needed. Second walk: force-stop mid-boot → relaunch → `detached-agent-cold-boot-guard-stale` journaled → immediate respawn. Evidence attached in the comment below (screenshots + logcat + diagnostics journal).

— [maintainer]
