### PR TITLE
fix(agent-orchestrator): retry task-store schema init after failure + log the DB cause chain

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/__tests__/task-store-project-binding.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/task-store-project-binding.test.ts
@@ -167,6 +167,50 @@ describe("task store project binding (real PGlite)", () => {
     await expect(store.listTasks()).resolves.toEqual([]);
   });
 
+  it("retries schema init after a transient failure instead of replaying the cached rejection (#15199)", {
+    timeout: PGLITE_TIMEOUT,
+  }, async () => {
+    // A boot-time init failure (vault mid-recovery, lock contention, watch-mode
+    // restart race) used to be memoized forever: every later store access —
+    // every supervisor tick, every /api/orchestrator/* call — replayed the same
+    // rejection until process restart. Simulate one transient DDL failure, then
+    // a healthy DB: the first read must reject (fail-fast, not fabricate), the
+    // NEXT read must re-run init and succeed, and the full cause chain must be
+    // logged (the Drizzle wrapper's message alone hides the driver error).
+    const raw = pgliteAdapter(db);
+    let failuresLeft = 1;
+    const flaky = {
+      async run(sql: string, params: unknown[] = []) {
+        if (failuresLeft > 0 && sql.startsWith("CREATE TABLE")) {
+          failuresLeft -= 1;
+          throw new Error(`Failed query: ${sql}\nparams: `, {
+            cause: Object.assign(new Error("database is locked mid-recovery"), {
+              code: "57P03",
+            }),
+          });
+        }
+        await raw.run(sql, params);
+      },
+      async all(sql: string, params: unknown[] = []) {
+        return raw.all(sql, params);
+      },
+    };
+    const warns: string[] = [];
+    const store = new RuntimeDbTaskStore(flaky, {
+      warn: (message: string) => {
+        warns.push(message);
+      },
+    });
+
+    await expect(store.listTasks()).rejects.toThrow(/Failed query/);
+    // The failure names its real cause, not just the wrapper message.
+    expect(warns.join("\n")).toContain("database is locked mid-recovery");
+    expect(warns.join("\n")).toContain("57P03");
+
+    // The DB is healthy now — a fresh access must retry init and succeed.
+    await expect(store.listTasks()).resolves.toEqual([]);
+  });
+
   it("persists project_id and filters listTasks by projectId", {
     timeout: PGLITE_TIMEOUT,
   }, async () => {

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-store.ts
@@ -105,6 +105,33 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
+/**
+ * Flatten an error's `cause` chain into one line. Drizzle-backed adapters
+ * wrap driver failures as DrizzleQueryError whose own message is just
+ * "Failed query: <sql>" — the actual reason (lock, corrupt vault, type
+ * mismatch, …) lives on `cause`, and a log line without it is undiagnosable
+ * (#15199: the dev-server supervisor warned the wrapper message every tick
+ * for hours with no way to tell WHY the DDL failed).
+ */
+function describeErrorCauseChain(error: unknown): string {
+  const parts: string[] = [];
+  for (let depth = 0; error != null && depth < 8; depth++) {
+    if (isRecord(error)) {
+      const message =
+        typeof error.message === "string" && error.message
+          ? error.message
+          : String(error);
+      const code = typeof error.code === "string" ? ` (${error.code})` : "";
+      parts.push(`${message}${code}`);
+      error = error.cause;
+    } else {
+      parts.push(String(error));
+      break;
+    }
+  }
+  return parts.join(" <- ") || String(error);
+}
+
 function isDuplicateColumnError(error: unknown): boolean {
   // Drizzle-backed adapters surface driver failures wrapped in
   // DrizzleQueryError ("Failed query: …") with the real duplicate-column
@@ -889,6 +916,7 @@ export class RuntimeDbTaskStore {
 
   constructor(
     private readonly adapter: RawSqlDatabaseAdapter | ElizaDrizzleAdapter,
+    private readonly logger?: Logger,
   ) {}
 
   private enqueue<T>(operation: () => Promise<T>): Promise<T> {
@@ -901,21 +929,39 @@ export class RuntimeDbTaskStore {
   }
 
   private async ensureInitialized(): Promise<void> {
-    this.initPromise ??= (async () => {
-      this.executor = await resolveSqlExecutor(this.adapter);
-      await this.executor.run(TASK_TABLE_SQL);
-      for (const sql of TASK_MIGRATION_SQL) {
-        try {
-          await this.executor.run(sql);
-        } catch (err) {
-          // error-policy:J6 idempotent DDL — ADD COLUMN throws on a table that
-          // already has the column (every boot after the first); the desired
-          // post-state is identical, so a duplicate-column failure is success.
-          if (!isDuplicateColumnError(err)) throw err;
+    if (!this.initPromise) {
+      const attempt = (async () => {
+        this.executor = await resolveSqlExecutor(this.adapter);
+        await this.executor.run(TASK_TABLE_SQL);
+        for (const sql of TASK_MIGRATION_SQL) {
+          try {
+            await this.executor.run(sql);
+          } catch (err) {
+            // error-policy:J6 idempotent DDL — ADD COLUMN throws on a table that
+            // already has the column (every boot after the first); the desired
+            // post-state is identical, so a duplicate-column failure is success.
+            if (!isDuplicateColumnError(err)) throw err;
+          }
         }
-      }
-      for (const sql of TASK_INDEX_SQL) await this.executor.run(sql);
-    })();
+        for (const sql of TASK_INDEX_SQL) await this.executor.run(sql);
+      })().catch((error: unknown) => {
+        // A rejected init must NOT stay memoized: every later store access
+        // (every supervisor tick, every orchestrator API call) would replay
+        // this same rejection until process restart, turning one transient
+        // boot-time failure into a permanently dead orchestrator surface
+        // (#15199). Reset so the next access retries, and log the FULL cause
+        // chain — the wrapper message alone ("Failed query: …") hides the
+        // driver error that actually explains the failure.
+        if (this.initPromise === attempt) {
+          this.initPromise = undefined;
+        }
+        this.logger?.warn?.(
+          `[RuntimeDbTaskStore] schema init failed (will retry on next access): ${describeErrorCauseChain(error)}`,
+        );
+        throw error;
+      });
+      this.initPromise = attempt;
+    }
     await this.initPromise;
   }
 
@@ -1207,7 +1253,7 @@ export class OrchestratorTaskStore {
       isPersistableAdapter(adapter)
     ) {
       this.backend = "runtime-db";
-      this.delegate = new RuntimeDbTaskStore(adapter);
+      this.delegate = new RuntimeDbTaskStore(adapter, logger);
       return;
     }
     if (options.backend === "memory") {


### PR DESCRIPTION
Fixes #15199.

**Defect 1 — permanently cached rejected init.** `RuntimeDbTaskStore.ensureInitialized` memoized `initPromise` including a rejection: one transient boot-time failure (vault mid-recovery, lock contention, watch-mode restart race) made every later store access — every `TaskSupervisorService` tick, every `/api/orchestrator/*` call — replay the identical rejection until process restart. This is tonight's live dev-server symptom: the supervisor warning `Failed query: ALTER TABLE orchestrator_tasks ADD COLUMN project_id TEXT` every tick for hours. Init now resets on rejection so the next access retries (the per-call `enqueue` already serializes; no retry-storm risk beyond the existing access rate), and a recovered vault self-heals without a restart.

**Defect 2 — swallowed cause.** The only log line was Drizzle's wrapper message; the driver error that explains WHY lives on `error.cause` and was never printed (same class as #15191/#15192 in the provisioning worker). The init failure path now logs the flattened cause chain (`describeErrorCauseChain`, mirrors the existing `isDuplicateColumnError` unwrap walk).

**Tests** (real PGlite, no mocks — extends the existing #13776 suite): new case simulates one transient `CREATE TABLE` failure with a coded cause → first read rejects AND the warn names the real cause (`database is locked mid-recovery`, `57P03`); next read re-runs init and succeeds. 5/5 green; plugin `tsgo` + biome clean.

**Evidence note:** UI-untouched server-side fix — screenshots/video N/A; the RED behavior is documented live in #15199 (tick-loop log from the :2138 dev server), and the GREEN lane is the real-PGlite test above. Once merged, the still-wedged dev vault will name its real driver error on the next boot — closing the loop on what actually corrupted it.

— [maintainer]