### PR TITLE
fix(ui): re-request the native local-agent start on every poll iteration (#15189 follow-up)

### DIFF
--- a/packages/ui/src/state/startup-phase-poll.test.ts
+++ b/packages/ui/src/state/startup-phase-poll.test.ts
@@ -40,7 +40,9 @@ const androidBootStateMock = vi.hoisted(() => ({
       state: "unknown",
     }),
   ),
-  requestAndroidLocalAgentStartForUrl: vi.fn(async () => false),
+  requestAndroidLocalAgentStartForUrl: vi.fn(
+    async (_url: string | null | undefined) => false,
+  ),
 }));
 
 vi.mock("../api", () => ({
@@ -266,11 +268,13 @@ describe("runPollingBackend", () => {
     expect(dispatch).not.toHaveBeenCalledWith({ type: "BACKEND_TIMEOUT" });
   });
 
-  it("requests a native local-agent start exactly once for the polled base", async () => {
+  it("requests a native local-agent start on every poll iteration for the polled base", async () => {
     // #15189: on a fresh install the native auto-start gate ran before the
     // renderer pre-seeded the local target, so the agent the poll waits for
     // was never asked to start. The poll must fire the start request for the
-    // base it polls — and only once per base, even across retry iterations.
+    // base it polls on EVERY iteration — one request can be lost to a service
+    // teardown race or a child death, and native start is idempotent, so
+    // re-asking each retry is what makes the revive self-healing.
     const deps = createDeps();
     const dispatch = vi.fn();
     const ipcBase = ANDROID_LOCAL_AGENT_IPC_BASE;
@@ -319,12 +323,17 @@ describe("runPollingBackend", () => {
       { current: null },
     );
 
+    // Two iterations ran (one rejected probe, one success) → two requests,
+    // both for the polled base. The per-iteration re-ask is deliberate: it is
+    // what revives the agent when an earlier request was lost.
     expect(
       androidBootStateMock.requestAndroidLocalAgentStartForUrl,
-    ).toHaveBeenCalledTimes(1);
+    ).toHaveBeenCalledTimes(2);
     expect(
-      androidBootStateMock.requestAndroidLocalAgentStartForUrl,
-    ).toHaveBeenCalledWith(ipcBase);
+      androidBootStateMock.requestAndroidLocalAgentStartForUrl.mock.calls.map(
+        (call) => call[0],
+      ),
+    ).toEqual([ipcBase, ipcBase]);
     expect(dispatch).toHaveBeenCalledWith({
       type: "BACKEND_REACHED",
       firstRunComplete: false,

--- a/packages/ui/src/state/startup-phase-poll.ts
+++ b/packages/ui/src/state/startup-phase-poll.ts
@@ -524,9 +524,6 @@ export async function runPollingBackend(
   // launch records WHICH base the poll hit and HOW it failed.
   let tracedPollFailures = 0;
   let tracedFirstSuccess = false;
-  // Local-agent start requests already fired this phase entry, keyed by base
-  // so a mid-phase base change (recoverToOnDeviceLocalAgent) gets its own.
-  const nativeStartRequestedBases = new Set<string>();
   appendIosBootTrace("polling-backend-start", {
     baseUrl: client.getBaseUrl(),
     backendTimeoutMs: policy.backendTimeoutMs,
@@ -616,13 +613,16 @@ export async function runPollingBackend(
     // install nobody else asks: the native auto-start gate was evaluated
     // before the renderer pre-seeded the local target, and onboarding (the
     // only other Agent.start() caller) is skipped on the pre-seeded path
-    // (#15189). Request the start explicitly, once per polled base, so the
-    // fresh boot, the Retry button, and a mid-phase recoverToOnDeviceLocalAgent
-    // all revive the agent instead of timing out against a service that was
-    // never started. Non-local bases no-op inside the helper.
+    // (#15189). Request the start on EVERY iteration, not once per base: a
+    // single request can be lost (service teardown race, FGS-window denial,
+    // a child that dies right after starting), and native start is idempotent
+    // — a START_AGENT delivery to a running/booting service is absorbed by
+    // the socket-adopt and cold-boot guards. Re-asking each retry makes the
+    // revive self-healing for the whole phase, covering the fresh boot, the
+    // Retry button, and a mid-phase recoverToOnDeviceLocalAgent base switch.
+    // Non-local bases no-op inside the helper.
     const polledBase = client.getBaseUrl();
-    if (polledBase && !nativeStartRequestedBases.has(polledBase)) {
-      nativeStartRequestedBases.add(polledBase);
+    if (polledBase) {
       void requestAndroidLocalAgentStartForUrl(polledBase).then((requested) => {
         if (requested) {
           logger.info(


### PR DESCRIPTION
Follow-up to #15198 (refs #15189), directed by nubs during the on-device test bench.

The merged version requested the native start **once per polled base**. A single request can be lost — a service teardown race, an FGS-window denial, a child that dies right after starting — and the phase then waits out its whole budget on a revive nobody re-asks for. Native start is idempotent (a START_AGENT delivery to a running/booting service is absorbed by the socket-adopt and cold-boot guards, and the successor-probe arming added in #15198 is deduped per launch stamp), so the poll now re-requests on **every retry iteration**, making the revive self-healing for the entire phase.

Cost on native: one intent per retry iteration (250ms–1s cadence only while the backend is down, bounded by the phase budget); each delivery is a cheap socket-listening check / journal scan on an already-running service.

**Tests**: `startup-phase-poll.test.ts` case updated to assert the per-iteration contract (two iterations — one rejected probe, one success — produce exactly two requests, both for the polled base). 47/47 green; `tsgo` clean.

**Evidence**: server-behavior-only change to the just-verified #15198 seam — the RED/GREEN device walk on [#15198's evidence comment](https://github.com/elizaOS/eliza/pull/15198#issuecomment-4899466975) covers the flow; this PR only increases the request cadence within it. Screenshots/video N/A (no rendered change).

— [maintainer]