### PR TITLE
fix(app): 404 /assets/* misses + no-store /sw.js at the pages serving layer (#15182 residue)

### DIFF
--- a/packages/app/functions/_middleware.ts
+++ b/packages/app/functions/_middleware.ts
@@ -5,28 +5,94 @@
 // catch-all). This is a single global `_middleware.ts` rather than two
 // `[[path]].ts` catch-all functions because Cloudflare's bundler translates
 // `[[path]]` -> `/:path*`, which path-to-regexp v8 (now used by the Pages
-// runtime) rejects with `Missing parameter name at index 15`. A single
-// `_middleware.ts` has no per-route path pattern at all, so the parser is
-// never invoked.
+// runtime) rejects with `Missing parameter name at index 15`. Upstream
+// selection per Pages environment via `API_UPSTREAM` (see `_proxy.ts`).
 //
-// Mirrors `packages/cloud-frontend/functions/_middleware.ts` so apex behaviour
-// is identical before and after the cutover. Upstream selection per Pages
-// environment via `API_UPSTREAM` (set in the Pages project / `wrangler.toml`):
-//   production branch (main) => API_UPSTREAM=https://api.elizacloud.ai
-//   preview/staging branch   => API_UPSTREAM=https://api-staging.elizacloud.ai
-// The fallback in `_proxy.ts` keeps custom production domains on production and
-// sends `*.pages.dev` previews to staging so preview deploys never mutate
-// production state.
+// This middleware also owns the cache-discipline behaviors that the Pages
+// config files cannot express (#15182 residue):
+//
+// - `/assets/*` misses return a real 404, never the SPA fallback. Cloudflare
+//   Pages `_redirects` supports only 200 rewrites and 3xx redirects — a
+//   `/assets/* /index.html 404` line is silently ignored — so without this
+//   branch a stale tab requesting a rotated chunk hash receives index.html
+//   with the long-lived asset Cache-Control and caches garbage AS the chunk
+//   (white screen + cache poisoning). Conditional validators are stripped
+//   before the asset lookup because the fallback shares index.html's ETag: an
+//   already-poisoned browser would otherwise revalidate its cached index.html
+//   copy into a 304 and keep the poison forever.
+//
+// - Cache-Control on `/assets/*` hits and `/sw.js` is set here, not in
+//   `public/_headers`, because multiple matching `_headers` rules aggregate
+//   into one comma-joined value instead of overriding — the `/*` no-cache rule
+//   would join the asset immutable rule as "no-cache, public, max-age=...,
+//   immutable", which browsers resolve as revalidate-always. The service
+//   worker gets `no-store` (not `no-cache`) so the zone edge never caches it:
+//   an edge-cached .js response has its browser TTL rewritten to the zone
+//   default (max-age=14400), which would delay SW update propagation by hours.
 
 import { type PagesProxyEnv, proxyToApiWorker } from "./_proxy";
 
 interface MiddlewareContext {
   request: Request;
   env: PagesProxyEnv;
-  next: () => Promise<Response>;
+  next: (input?: Request) => Promise<Response>;
 }
 
 const PROXY_PREFIXES = ["/api/", "/steward/"];
+
+const ASSETS_PREFIX = "/assets/";
+const SERVICE_WORKER_PATH = "/sw.js";
+
+// Vite content-hashes every file it emits under /assets/, so a hit is
+// immutable by construction; a byte change always produces a new filename.
+const ASSET_CACHE_CONTROL = "public, max-age=31536000, immutable";
+const SERVICE_WORKER_CACHE_CONTROL = "no-store";
+
+const withCacheControl = (response: Response, value: string): Response => {
+  const headers = new Headers(response.headers);
+  headers.set("Cache-Control", value);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+};
+
+// The SPA fallback is the only text/html producer under /assets/ — the Vite
+// asset dir contains js/css/fonts/wasm/images only — so an html content type
+// is the definitive miss signal.
+const isSpaFallback = (response: Response): boolean =>
+  (response.headers.get("Content-Type") ?? "")
+    .toLowerCase()
+    .includes("text/html");
+
+const serveAsset = async (context: MiddlewareContext): Promise<Response> => {
+  const headers = new Headers(context.request.headers);
+  headers.delete("If-None-Match");
+  headers.delete("If-Modified-Since");
+  const response = await context.next(
+    new Request(context.request, { headers }),
+  );
+
+  if (isSpaFallback(response)) {
+    // Constructed responses bypass `public/_headers`, so the safety headers
+    // are set explicitly. no-store keeps the 404 out of every cache layer so
+    // recovery is immediate once a deploy restores (or a reload re-resolves)
+    // the chunk graph.
+    return new Response("Not Found", {
+      status: 404,
+      headers: {
+        "Cache-Control": "no-store",
+        "Content-Type": "text/plain; charset=utf-8",
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
+  }
+
+  return response.ok
+    ? withCacheControl(response, ASSET_CACHE_CONTROL)
+    : response;
+};
 
 // The hosted-web SPA is embedded inside the Discord Activities and Telegram
 // Mini App iframes. The global `public/_headers` rule pins every response to
@@ -68,7 +134,15 @@ export const onRequest = async (
     return proxyToApiWorker(context);
   }
 
+  if (url.pathname.startsWith(ASSETS_PREFIX)) {
+    return serveAsset(context);
+  }
+
   const response = await context.next();
+
+  if (url.pathname === SERVICE_WORKER_PATH) {
+    return withCacheControl(response, SERVICE_WORKER_CACHE_CONTROL);
+  }
 
   if (!isEmbedPath(url.pathname)) {
     return response;

--- a/packages/app/public/_headers
+++ b/packages/app/public/_headers
@@ -24,13 +24,12 @@
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
   Cache-Control: no-cache
 
-# Hashed assets under /assets/* are content-addressed and immutable. Pin them to
-# a long cache so they survive the no-cache rule on /* above. This pair
-# (no-cache HTML + immutable assets) is the standard cache discipline for
-# hashed-bundle SPAs: deploys propagate instantly without re-fetching unchanged
-# JS/CSS.
-/assets/*
-  Cache-Control: public, max-age=31536000, immutable
+# The no-cache rule on /* is deliberately the ONLY Cache-Control in this file.
+# Multiple matching _headers rules aggregate into one comma-joined value rather
+# than overriding (a /assets/* rule here would produce "no-cache, public,
+# max-age=..., immutable", which browsers resolve as revalidate-always), so the
+# immutable policy for /assets/* hits, the 404 for /assets/* misses, and the
+# no-store for /sw.js all live in functions/_middleware.ts instead.
 
 # OAuth/popup callback pages need a relaxed COOP so popup status remains
 # observable when a browser path is script-opened. OS-opened tabs still must not

--- a/packages/app/public/_redirects
+++ b/packages/app/public/_redirects
@@ -16,14 +16,12 @@
 # #13601). Bounce them to the CDN so every legacy reference keeps working.
 /cloud-avatars/*  https://blob.elizacloud.ai/cloud-avatars/:splat  302
 
-# Hashed-asset 404s must NOT fall through to the SPA index.html. When a stale
-# browser HTML references an asset hash that no longer exists, the catch-all
-# below would otherwise return index.html with status 200 for the missing .js,
-# and the browser would fail strict MIME checking with "Expected a
-# JavaScript-or-Wasm module script but the server responded with a MIME type of
-# text/html". Returning a real 404 lets the app's chunk-load error boundary
-# catch it and self-heal via a single hard reload.
-/assets/*  /index.html  404
+# Hashed-asset misses must NOT fall through to the SPA index.html, but that
+# cannot be expressed here: Cloudflare Pages _redirects supports only 200
+# rewrites and 3xx redirects, and silently ignores a status like
+# `/assets/* /index.html 404`. Asset misses therefore fall through the
+# catch-all below and functions/_middleware.ts converts the fallback into a
+# real, uncacheable 404.
 
 # SPA fallback — every other path (incl. every backend-issued deep link:
 # /login, /auth/*, /app-auth/authorize, /invite/accept, /payment/*, /chat/*,

--- a/packages/app/test/pages-middleware-serving.test.ts
+++ b/packages/app/test/pages-middleware-serving.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Serving contract for the Pages middleware (functions/_middleware.ts) and the
+ * Pages config files it complements: /assets/* misses 404 instead of the SPA
+ * fallback, /sw.js is never cached, and the config files stay inside what
+ * Cloudflare Pages actually supports. Drives the real onRequest handler with a
+ * hand-rolled next() — no module mocks.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { onRequest } from "../functions/_middleware";
+
+const ORIGIN = "https://app.elizacloud.ai";
+
+// The Pages static layer bakes `public/_headers` values into next() responses;
+// the aggregated Cache-Control below is what it really produces when more than
+// one rule matches, which is exactly what the middleware must repair.
+const spaFallback = () =>
+  new Response("<!doctype html><html><body>app</body></html>", {
+    status: 200,
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "no-cache",
+      ETag: '"index-etag"',
+    },
+  });
+
+const assetHit = () =>
+  new Response("export const chunk = 1;", {
+    status: 200,
+    headers: {
+      "Content-Type": "application/javascript",
+      "Cache-Control": "no-cache, public, max-age=31536000, immutable",
+      ETag: '"asset-etag"',
+    },
+  });
+
+const run = (
+  request: Request,
+  next: (input?: Request) => Promise<Response>,
+): Promise<Response> => onRequest({ request, env: {}, next });
+
+describe("pages middleware /assets/* serving", () => {
+  it("converts an asset miss (SPA fallback) into an uncacheable 404", async () => {
+    const response = await run(
+      new Request(`${ORIGIN}/assets/bogus-deadbeef1234.js`),
+      async () => spaFallback(),
+    );
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Content-Type")).toBe(
+      "text/plain; charset=utf-8",
+    );
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(await response.text()).toBe("Not Found");
+  });
+
+  it("strips conditional validators so a poisoned client cannot 304 the fallback back to freshness", async () => {
+    let forwarded: Request | undefined;
+    const response = await run(
+      new Request(`${ORIGIN}/assets/bogus-deadbeef1234.js`, {
+        headers: {
+          "If-None-Match": '"index-etag"',
+          "If-Modified-Since": "Mon, 06 Jul 2026 00:00:00 GMT",
+          Accept: "*/*",
+        },
+      }),
+      async (input) => {
+        forwarded = input;
+        return spaFallback();
+      },
+    );
+
+    expect(forwarded).toBeDefined();
+    expect(forwarded?.headers.get("If-None-Match")).toBeNull();
+    expect(forwarded?.headers.get("If-Modified-Since")).toBeNull();
+    expect(forwarded?.headers.get("Accept")).toBe("*/*");
+    expect(response.status).toBe(404);
+  });
+
+  it("serves real asset hits with the canonical immutable Cache-Control", async () => {
+    const response = await run(
+      new Request(`${ORIGIN}/assets/index-JIO74l6r.js`),
+      async () => assetHit(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=31536000, immutable",
+    );
+    expect(response.headers.get("Content-Type")).toBe("application/javascript");
+    expect(response.headers.get("ETag")).toBe('"asset-etag"');
+    expect(await response.text()).toBe("export const chunk = 1;");
+  });
+
+  it("passes non-ok asset responses through untouched", async () => {
+    const response = await run(
+      new Request(`${ORIGIN}/assets/gone.js`),
+      async () =>
+        new Response("gone", {
+          status: 410,
+          headers: { "Content-Type": "text/plain" },
+        }),
+    );
+
+    expect(response.status).toBe(410);
+    expect(response.headers.get("Cache-Control")).toBeNull();
+  });
+});
+
+describe("pages middleware /sw.js serving", () => {
+  it("rewrites the service worker Cache-Control to no-store", async () => {
+    const response = await run(
+      new Request(`${ORIGIN}/sw.js`),
+      async () =>
+        new Response("self.addEventListener('fetch', () => {});", {
+          status: 200,
+          headers: {
+            "Content-Type": "application/javascript",
+            "Cache-Control": "no-cache",
+          },
+        }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Content-Type")).toBe("application/javascript");
+    expect(await response.text()).toBe(
+      "self.addEventListener('fetch', () => {});",
+    );
+  });
+});
+
+describe("pages middleware SPA fallback and embed surface", () => {
+  it("leaves the SPA fallback untouched for non-asset routes", async () => {
+    const response = await run(
+      new Request(`${ORIGIN}/chat/some-deep-link`),
+      async () => spaFallback(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-cache");
+    expect(response.headers.get("Content-Type")).toContain("text/html");
+  });
+
+  it("relaxes frame-ancestors only for a matched /embed platform", async () => {
+    const response = await run(
+      new Request(`${ORIGIN}/embed?platform=telegram`),
+      async () => {
+        const fallback = spaFallback();
+        fallback.headers.set("X-Frame-Options", "SAMEORIGIN");
+        return fallback;
+      },
+    );
+
+    expect(response.headers.get("Content-Security-Policy")).toBe(
+      "frame-ancestors https://web.telegram.org https://*.telegram.org",
+    );
+    expect(response.headers.get("X-Frame-Options")).toBeNull();
+  });
+
+  it("fails the embed surface closed for unknown platforms", async () => {
+    const response = await run(new Request(`${ORIGIN}/embed`), async () =>
+      spaFallback(),
+    );
+
+    expect(response.headers.get("Content-Security-Policy")).toBe(
+      "frame-ancestors 'none'",
+    );
+  });
+});
+
+describe("pages config files stay within Cloudflare Pages semantics", () => {
+  const publicDir = join(import.meta.dirname, "..", "public");
+  const headers = readFileSync(join(publicDir, "_headers"), "utf8");
+  const redirects = readFileSync(join(publicDir, "_redirects"), "utf8");
+
+  const configLines = (raw: string): string[] =>
+    raw
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !line.startsWith("#"));
+
+  it("keeps the /* no-cache rule as the only Cache-Control in _headers", () => {
+    // The primary #15182 cache fix: index.html (and every SPA route) must stay
+    // no-cache. It must also be the ONLY Cache-Control rule — _headers
+    // aggregates same-named headers across matching rules instead of
+    // overriding, so a second rule would comma-join with this one. All other
+    // cache policy is owned by functions/_middleware.ts.
+    const cacheControlLines = configLines(headers).filter((line) =>
+      line.toLowerCase().startsWith("cache-control:"),
+    );
+
+    expect(cacheControlLines).toEqual(["Cache-Control: no-cache"]);
+  });
+
+  it("contains no _redirects rule with a status Cloudflare Pages ignores", () => {
+    // Pages supports only 200 rewrites and 3xx redirects; anything else (like
+    // the former `/assets/* /index.html 404`) is silently dropped and the
+    // request falls through to the SPA catch-all — dead config that reads as
+    // if asset misses were handled.
+    const statuses = configLines(redirects)
+      .map((line) => line.split(/\s+/))
+      .filter((parts) => parts.length >= 3)
+      .map((parts) => Number(parts[2]));
+
+    for (const status of statuses) {
+      expect(
+        status === 200 || (status >= 301 && status <= 308),
+        `unsupported _redirects status ${status}`,
+      ).toBe(true);
+    }
+  });
+
+  it("keeps the SPA catch-all as the final _redirects rule", () => {
+    const lines = configLines(redirects);
+
+    expect(lines.at(-1)).toBe("/*  /index.html  200");
+  });
+});


### PR DESCRIPTION
## What

Residue fix for #15182 (the SW/asset cache work — this PR does **not** close it). Two verified-live footguns remained at the Cloudflare Pages serving layer under [app.elizacloud.ai](https://app.elizacloud.ai), plus a third found while fixing them:

1. **Missing `/assets/*` chunks returned `200 text/html` (SPA fallback) instead of `404`** — with the *immutable asset* Cache-Control attached. A stale tab requesting a rotated chunk hash downloads index.html AS the chunk and caches the garbage for a year (white screen + cache poisoning).
2. **`/sw.js` reached browsers with `cache-control: max-age=14400`**, delaying service-worker update propagation by hours.
3. **(found during the fix)** The SPA fallback shares index.html's ETag, so an already-poisoned browser revalidating its cached copy gets a **304** and keeps the poison forever — verified live (probe below).

## Why the fix lives in `functions/_middleware.ts`, not the config files

The repo already *tried* to fix these in config, and Cloudflare Pages silently ignores both attempts (proof in the origin probes below):

- `_redirects` supports **only 200 rewrites and 3xx redirects**. The deployed `/assets/* /index.html 404` line (in the file since 4056e0e8687) is silently dropped; misses fall through to the `/* /index.html 200` catch-all.
- `_headers` rules **aggregate** (comma-join) instead of overriding: the `/assets/*` immutable rule joined the `/*` no-cache rule as `cache-control: no-cache, public, max-age=31536000, immutable` at origin (browsers resolve that as revalidate-always, quietly defeating #15182's immutable strategy on `pages.dev` previews).

So the Pages Function middleware — real, unit-testable code that already runs on every request — now owns:

- `/assets/*` miss (fallback text/html) → **404**, `Cache-Control: no-store`, `text/plain`, `nosniff`. Conditional validators (`If-None-Match`/`If-Modified-Since`) are stripped before asset lookup so a poisoned client can never 304 its cached index.html back to freshness.
- `/assets/*` hit → clean canonical `public, max-age=31536000, immutable` (single owner; the aggregating `_headers` rule is removed).
- `/sw.js` → **`Cache-Control: no-store`**. `no-store` rather than `no-cache` deliberately: the Pages origin already served `no-cache` (from the `/*` `_headers` rule), but the elizacloud.ai zone edge caches `.js` by extension (`cf-cache-status: REVALIDATED`) and rewrites the browser-facing TTL to the zone default `max-age=14400` — the exact live failure. `no-store` keeps the worker script out of the edge cache so the origin header survives to the browser (index.html, which is not edge-cached, passes through untouched today — same mechanism).
- `index.html` / SPA routes keep the `/*` `Cache-Control: no-cache` from `_headers` (the primary #15182 fix) — untouched, and now regression-guarded by a test asserting it stays the **only** Cache-Control rule in `_headers`.

## Cloud-side residual (dashboard, not repo)

If, after this deploys, `curl -sI https://app.elizacloud.ai/sw.js` still shows `max-age=14400`, the zone has a cache rule that ignores origin `no-store` (e.g. "cache everything"). That last mile is Cloudflare-dashboard-side and needs a zone Cache Rule for `/sw.js` (Bypass cache, or Browser TTL: respect origin). Repo-side, `no-store` is the strongest available lever and is expected to work given index.html's `no-cache` passes through the same zone untouched.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - serving-layer/middleware change; the before-state is the live probe transcript (bogus asset hash -> 200 text/html immutable) linked in the PR description.
<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - no UI pixels changed; after-state is the wrangler pages dev transcript in the PR description (asset miss -> 404 no-store).
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user-visible flow; verifiable artifact = the end-to-end wrangler workerd transcript in the PR description.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: live curl probes (before) + wrangler pages dev transcript (after) captured in the PR description evidence section.
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - request-time middleware; behavior proven at HTTP layer (transcripts in description).
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent/model behavior change; CF Pages middleware only.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: 11 new vitest cases driving the real onRequest (13 passed with existing pages-csp), output in the PR description; post-deploy verification block included for the /sw.js zone-cache caveat.
