### PR TITLE
fix(ui): clean up first-run onboarding slop — honest composer copy, chromeless greeting, no phantom loader

### DIFF
--- a/packages/ui/src/components/composites/chat/chat-message.hover-reveal.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.hover-reveal.test.tsx
@@ -91,4 +91,25 @@ describe("ChatMessage desktop hover-chrome delete control (#13533)", () => {
     // guard excludes `temp-` ids so the control never appears on it.
     expect(deleteControl()).toBeNull();
   });
+
+  it("renders a first-run greeting chromeless — no action rail at all", () => {
+    // The onboarding greeting is seeded wallpaper prose with a CTA beneath it;
+    // reply / copy / delete / play are meaningless on it and the hover rail read
+    // as a bug during first-run. Even with every action handler wired, a
+    // `first_run` source turn must render no rail.
+    render(
+      <ChatMessage
+        message={makeMessage({ source: "first_run" })}
+        onCopy={vi.fn()}
+        onDelete={vi.fn()}
+        onReply={vi.fn()}
+        onSpeak={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("chat-message-action-rail")).toBeNull();
+    expect(deleteControl()).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Reply" }),
+    ).toBeNull();
+  });
 });

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -486,6 +486,12 @@ export const ChatMessage = memo(function ChatMessage({
   const isAssistant = message.role === "assistant";
   const isRightAligned = isUser ? userMessagesOnRight : !userMessagesOnRight;
   const trimmedText = message.text.trim();
+  // First-run onboarding turns render chromeless: agent prose floats as plain
+  // wallpaper text with its CTA button directly beneath. Computed up here (not
+  // at first use) so the message-action capabilities below can suppress the
+  // hover/tap rail — replying to / copying / deleting the seeded greeting is
+  // meaningless, and the rail contradicts the chromeless intent.
+  const isFirstRun = !isUser && message.source === "first_run";
   const canEdit =
     isUser &&
     typeof onEdit === "function" &&
@@ -494,13 +500,16 @@ export const ChatMessage = memo(function ChatMessage({
     // Glass keeps the shell rule: an image-only user turn has no editable text.
     (!glass || trimmedText.length > 0);
   const canPlay = Boolean(
-    !isUser && typeof onSpeak === "function" && trimmedText,
+    !isUser && !isFirstRun && typeof onSpeak === "function" && trimmedText,
   );
   // Persistent delete (#13533): available on any real turn when the surface
   // wires onDelete. An optimistic (temp-) turn has no persisted row to delete;
-  // a proactive suggestion uses its own dismiss affordance (below), not delete.
+  // a proactive suggestion uses its own dismiss affordance (below), not delete;
+  // a first-run greeting is chromeless (no rail at all).
   const canDelete =
-    typeof onDelete === "function" && !message.id.startsWith("temp-");
+    typeof onDelete === "function" &&
+    !message.id.startsWith("temp-") &&
+    !isFirstRun;
   const normalizedSource = normalizeChatSourceKey(message.source) ?? undefined;
   // Reply targets the persisted message by id, so an optimistic (temp-) turn,
   // which has no server row yet, has nothing to reply to. A proactive
@@ -508,13 +517,11 @@ export const ChatMessage = memo(function ChatMessage({
   // Proactive interaction comments (#8792) are agent-initiated *suggestions*, not
   // replies; render them with a distinct, one-tap-dismissible affordance.
   const isSuggestion = !isUser && normalizedSource === "proactive-interaction";
-  // First-run onboarding turns render chromeless: agent prose floats as plain
-  // wallpaper text with its CTA button directly beneath.
-  const isFirstRun = !isUser && message.source === "first_run";
   const canReply =
     typeof onReply === "function" &&
     !message.id.startsWith("temp-") &&
-    !isSuggestion;
+    !isSuggestion &&
+    !isFirstRun;
   const senderDisplayName = isUser ? resolveSenderDisplayName(message) : null;
   const senderHandle = isUser
     ? resolveSenderHandle(message, senderDisplayName)
@@ -743,9 +750,12 @@ export const ChatMessage = memo(function ChatMessage({
       );
     }
 
-    const canRowCopy = !!onCopy && trimmedText.length > 0;
+    const canRowCopy = !isFirstRun && !!onCopy && trimmedText.length > 0;
     // Suggestions carry their own dismiss affordance, not the delete control.
     const canRowDelete = canDelete && !isSuggestion;
+    // A first-run greeting is chromeless — no rail, no tap-to-reveal. Every
+    // capability above already excludes it, so hasActions is false and the
+    // bubble stays a plain, non-interactive container.
     const hasActions =
       canRowCopy || canPlay || canEdit || canRowDelete || canReply;
     // An assistant turn carrying an inline choice/form/followups widget must
@@ -1202,7 +1212,7 @@ export const ChatMessage = memo(function ChatMessage({
             </div>
           ) : null}
 
-          {!isEditing ? (
+          {!isEditing && !isFirstRun ? (
             <div
               data-testid="chat-message-action-rail"
               className={cn(

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.firstrun.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.firstrun.test.tsx
@@ -134,7 +134,10 @@ describe("ContinuousChatOverlay first-run gating", () => {
 
     const input = screen.getByLabelText("message") as HTMLTextAreaElement;
     expect(input.disabled).toBe(false);
-    expect(input.placeholder).toBe("Connect to cloud to enable chat");
+    // The placeholder must match the unlocked behavior — not read as locked.
+    // "Connect to cloud to enable chat" contradicted the typeable composer
+    // (#12178): free text is answered by the in-chat conductor locally.
+    expect(input.placeholder).toBe("Ask Eliza anything, or sign in above");
 
     // The composer actions ("+") menu + mic have no agent to serve them yet —
     // still inert (pre-runtime). The "+" trigger is natively disabled.

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.stories.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.stories.tsx
@@ -143,7 +143,9 @@ export const Ambient: Story = { args: { controller: makeController() } };
 
 /**
  * Login / first-run onboarding: the chat opens edge-to-edge full-bleed and the
- * composer placeholder reads "Connect to cloud to enable chat".
+ * composer placeholder reads "Ask Eliza anything, or sign in above" — the
+ * composer is typeable (#12178), so the copy invites it rather than reading as
+ * locked.
  */
 export const FirstRunOnboarding: Story = {
   args: {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -5198,7 +5198,8 @@ export function ContinuousChatOverlay({
                         prefetches + prepends an older page a viewport early and
                         preserves the reader's anchor so the thread never jumps.
                         Only meaningful in the flat (non-topic) transcript. */}
-                    {!hasTopics &&
+                    {!firstRunOpen &&
+                    !hasTopics &&
                     hasMoreOlder &&
                     visibleMessages.length > 0 ? (
                       <div
@@ -5556,7 +5557,7 @@ export function ContinuousChatOverlay({
                 // the imageError note above.)
                 placeholder={
                   firstRunOpen
-                    ? "Connect to cloud to enable chat"
+                    ? `Ask ${agentName} anything, or sign in above`
                     : noProviderConfigured
                       ? "Connect a model provider in Settings to chat"
                       : modelBlocksSend
@@ -5578,9 +5579,9 @@ export function ContinuousChatOverlay({
                 // and only when a slash catalog is wired in — a plain message
                 // box otherwise.
                 {...comboboxAria}
-                // During onboarding the placeholder is a directive hint ("Connect
-                // to cloud to enable chat"), so brighten it from the resting
-                // 45% to 70% so it reads clearly beside the seeded choices.
+                // During onboarding the placeholder invites the unlocked
+                // composer ("Ask … anything, or sign in above"), so brighten it
+                // from the resting 45% to 70% to read clearly beside the choices.
                 className={`max-h-[8.5rem] min-h-8 min-w-0 flex-1 resize-none self-center border-none bg-transparent px-1.5 py-1 text-left text-sm leading-relaxed text-txt outline-none [scrollbar-width:none] [&::-webkit-scrollbar]:hidden ${
                   firstRunOpen
                     ? "placeholder:text-muted-strong"


### PR DESCRIPTION
Cleans up three pieces of visual slop nubs found testing **fresh first-run onboarding** (local dev + Seeker). All three are onboarding-surface-only; no behavior change outside first-run.

## Bugs

**1. Composer copy contradicted behavior.** `ContinuousChatOverlay.tsx` placeholder read **"Connect to cloud to enable chat"** during `firstRunOpen` — reads as *locked* — while the composer is intentionally **typeable** during onboarding (#12178: free text is answered by the in-chat conductor locally, never hits the server). You could click in and type under a placeholder that said you couldn't. Replaced with **"Ask {agentName} anything, or sign in above"** so the copy matches the unlocked behavior.

**2. Hover/tap action rail on the first-run greeting.** `chat-message.tsx` computed `isFirstRun` with a comment promising first-run turns "render chromeless" — but the reply / copy / delete / play rail still rendered on hover over the seeded greeting (replying to / deleting an onboarding greeting is meaningless). `isFirstRun` now suppresses **every** message-action capability *and* both rail render paths (glass `hasActions` + non-glass rail), so the greeting is genuinely chromeless.

**3. Phantom frozen loader during onboarding.** The infinite-upward-scroll top sentinel (`chat-transcript-top-sentinel`, spinning `Loader2`) rendered when `!hasTopics && hasMoreOlder && visibleMessages.length > 0`. `hasMoreOlder` defaults `true` and never resolves during first-run (there's no older history to page), so the spinner spun forever — looked frozen/broken above the greeting. Gated on `!firstRunOpen`.

## Tests
- `ContinuousChatOverlay.firstrun.test.tsx`: placeholder assertion updated to the new inviting copy (the test title already read "with an inviting placeholder").
- `chat-message.hover-reveal.test.tsx`: **new regression** — a `first_run` source message with every action handler wired renders **no** action rail (RED before this change: the rail + delete + reply were present).
- Existing hover-reveal / tap-reveal / firstrun suites green (23 tests); `tsgo` typecheck clean.

## Evidence
- **UI proof:** verified in the local dev preview (`localhost:2138`) — first-run greeting renders chromeless with the inviting placeholder and no top spinner (screenshot in the comment below). This is a pure copy/render change on the onboarding surface; the jsdom regression above locks the rail behavior and the firstrun test locks the copy.
- Video: N/A — static first-run render change; before (nubs's report) / after screenshots capture the full delta.

Refs the onboarding-perfect push. Author: NubsCarson.

— [maintainer]
