### PR TITLE
fix(ci): visual evidence rows require real media, not page links

### DIFF
--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -92,11 +92,29 @@ export function requiresSurfaceArtifacts(labels) {
 
 export function hasOcrEvidenceReference(rows) {
   for (const rowText of rows.values()) {
-    if (OCR_EVIDENCE_RE.test(rowText) && hasArtifactReference(rowText)) {
+    // OCR proof must reference real evidence, not a page link: either an
+    // actual media artifact or a linked report/log file next to OCR keywords.
+    if (
+      OCR_EVIDENCE_RE.test(rowText) &&
+      (hasVisualArtifactReference(rowText) ||
+        hasEvidenceFileReference(rowText))
+    ) {
       return true;
     }
   }
   return false;
+}
+
+// Linked non-media evidence file (an OCR report/JSON/log) — still stricter
+// than "any URL": the link target must look like a file, not a web page.
+const EVIDENCE_FILE_RE = /\.(json|txt|log|csv|md)(\?\S*)?(\s|$|\)|"|')/i;
+
+export function hasEvidenceFileReference(text) {
+  const value = String(text ?? "");
+  return (
+    (EVIDENCE_FILE_RE.test(value) || GITHUB_ATTACHMENT_RE.test(value)) &&
+    !RETIRED_REPO_EVIDENCE_RE.test(value)
+  );
 }
 
 export function hasNaWithReason(text) {
@@ -121,6 +139,35 @@ export function hasArtifactReference(text) {
       text,
     )
   ) {
+    return true;
+  }
+  return false;
+}
+
+// A GitHub-uploaded attachment (drag-and-drop) lands on one of these hosts;
+// these URLs are the unforgeable signal that a real image/video is embedded.
+const GITHUB_ATTACHMENT_RE =
+  /(https?:\/\/)?(github\.com\/user-attachments\/assets\/|user-images\.githubusercontent\.com\/|github\.com\/[^/\s)]+\/[^/\s)]+\/assets\/)/i;
+// A URL/path whose tail is an image or video file — a directly-linked media file.
+const MEDIA_EXT_RE =
+  /\.(png|jpe?g|gif|webp|apng|avif|bmp|svg|mp4|mov|webm|m4v|ogg)(\?\S*)?(\s|$|\)|"|')/i;
+
+/**
+ * Strict media check for the VISUAL evidence rows (screenshots, walkthrough
+ * video, OCR readout). Unlike `hasArtifactReference`, a bare link to a page —
+ * the PR itself, a `/checks` tab, a commit, a job log — does NOT count: those
+ * are how an author games the loose check while attaching no pixels. Only a
+ * real embedded/linked image or video satisfies it: a GitHub attachment-host
+ * URL, a markdown image embed `![](…)`, an `<img>`/`<video>` tag, or a URL/path
+ * ending in a known media extension. This is the difference between "here is a
+ * link" and "here is the picture".
+ */
+export function hasVisualArtifactReference(text) {
+  const value = String(text ?? "");
+  if (GITHUB_ATTACHMENT_RE.test(value)) return true;
+  if (/!\[[^\]]*\]\(\s*\S+\s*\)/.test(value)) return true; // ![alt](url) embed
+  if (/<(img|video|source|picture)\b[^>]*>/i.test(value)) return true;
+  if (MEDIA_EXT_RE.test(value) && !RETIRED_REPO_EVIDENCE_RE.test(value)) {
     return true;
   }
   return false;
@@ -219,15 +266,16 @@ export function evaluatePrEvidence(
     if (rowText.length === 0) return { id, label, status: "blank" };
     const artifactRequired =
       surfaceArtifactsRequired && SURFACE_ARTIFACT_ROW_IDS.includes(id);
-    if (artifactRequired && !hasArtifactReference(rowText)) {
+    // Visual rows on a surface PR demand REAL media (attachment/embed/media
+    // URL) — a link to the PR page or a /checks tab is not a screenshot.
+    if (artifactRequired && !hasVisualArtifactReference(rowText)) {
       return { id, label, status: "artifact-required" };
     }
     return {
       id,
       label,
-      status: isRowSatisfiedForContext(rowText, { artifactRequired })
-        ? "ok"
-        : "blank",
+      status:
+        artifactRequired || isRowSatisfied(rowText) ? "ok" : "blank",
     };
   });
   if (surfaceArtifactsRequired && !hasOcrEvidenceReference(rows)) {

--- a/scripts/check-pr-evidence.test.mjs
+++ b/scripts/check-pr-evidence.test.mjs
@@ -17,6 +17,7 @@ import {
   hasArtifactReference,
   hasNaWithReason,
   hasOcrEvidenceReference,
+  hasVisualArtifactReference,
   isChecked,
   isRowSatisfied,
   isRowSatisfiedForContext,
@@ -309,6 +310,65 @@ describe("check-pr-evidence row primitives", () => {
     assert.equal(isChecked("- [X] done"), true);
     assert.equal(isChecked("- [ ] not done"), false);
     assert.equal(isRowSatisfied("- [x] done"), false);
+  });
+
+  it("requires real media on visual rows — page links do not count", () => {
+    // The gaming vector: linking the PR itself or its /checks tab.
+    assert.equal(
+      hasVisualArtifactReference(
+        "- [ ] Before: https://github.com/elizaOS/eliza/pull/15178/checks",
+      ),
+      false,
+    );
+    assert.equal(
+      hasVisualArtifactReference(
+        "- [ ] After: https://github.com/elizaOS/eliza/pull/15178",
+      ),
+      false,
+    );
+    // Real media forms all count.
+    assert.equal(
+      hasVisualArtifactReference(
+        "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
+      ),
+      true,
+    );
+    assert.equal(
+      hasVisualArtifactReference("![after](https://example.com/x/after)"),
+      true,
+    );
+    assert.equal(
+      hasVisualArtifactReference(
+        '<img src="https://example.com/shot" width="400">',
+      ),
+      true,
+    );
+    assert.equal(
+      hasVisualArtifactReference("see https://example.com/walkthrough.mp4"),
+      true,
+    );
+  });
+
+  it("fails a UI-labeled PR whose visual rows link only to the PR/checks page", () => {
+    const { ok, findings } = evaluatePrEvidence(
+      buildBody({
+        "before-screenshots":
+          "- [ ] Before screenshots: https://github.com/elizaOS/eliza/pull/15178",
+        "after-screenshots":
+          "- [ ] After screenshots: https://github.com/elizaOS/eliza/pull/15178/checks",
+        "walkthrough-video":
+          "- [ ] Walkthrough video: https://github.com/elizaOS/eliza/pull/15178/checks",
+      }),
+      REQUIRED_EVIDENCE_ROWS,
+      { labels: "ui" },
+    );
+    assert.equal(ok, false);
+    for (const id of SURFACE_ARTIFACT_ROW_IDS) {
+      assert.equal(
+        findings.find((finding) => finding.id === id).status,
+        "artifact-required",
+      );
+    }
   });
 
   it("detects rendered-UI source files in the diff", () => {


### PR DESCRIPTION
# Relates to

Follow-up to #15204 (evidence-gate hardening, epic #14541). Closes the gaming
vector found by sweeping the live open-PR set with the new gate.

- [x] Targets `develop`, based on latest `origin/develop`, zero conflicts.
- [x] Gate self-test + 31 unit tests pass post-change.
- [x] Reviewer can confirm from the evidence below without reading code.

# Risks

Low, additive strictness. UI-surface PRs whose screenshot/video rows link only
to a web page (their own PR, a /checks tab) will now fail the gate — intended.

# Background

## What does this PR do?

Sweeping the six live open PRs against the #15204 gate showed five "passing"
despite having **zero attached images or video** — their visual evidence rows
satisfied the loose any-URL check with links to their own PR page or `/checks`
tab. This PR adds `hasVisualArtifactReference`: on surface PRs, the
before/after-screenshot and walkthrough-video rows accept only **real media** —
a GitHub attachment URL (`user-attachments/assets`, `user-images.…`), a
markdown image embed `![](…)`, an `<img>`/`<video>` tag, or a URL ending in a
media extension. OCR proof likewise requires media or a linked report file
(.json/.txt/.log), never a page link.

## What kind of change is this?

Bug fix (CI enforcement hole).

# Testing

## Where should a reviewer start?

`hasVisualArtifactReference` in `scripts/check-pr-evidence.mjs` and the two new
regression tests ("page links do not count").

## Detailed testing steps

```bash
node scripts/check-pr-evidence.mjs --self-test    # 11 cases
node --test scripts/check-pr-evidence.test.mjs    # 31 cases
```

# Evidence Gate

No UI surface — CI script only. Visual rows are honestly N/A; logs are inline.

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - CI gate script only, no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - CI gate script only, no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no UI flow; behavior shown in command output below`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: [gate sweep + test output](#backend-logs--command-output) inline below.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend code path`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent/model/prompt behavior changed; deterministic parser only`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: [live open-PR sweep verdicts](#backend-logs--command-output) below.

# Evidence Details

## Backend logs / command output

<details><summary>Live open-PR sweep: loose gate vs strict gate</summary>

```
# BEFORE this fix (loose any-URL check):
PR #15185: PASS   PR #15179: PASS   PR #15178: PASS
PR #15171: PASS   PR #15057: FAIL   PR #15053: PASS
# — five UI PRs "pass" with zero attached media; e.g. #15178's rows link
#   https://github.com/elizaOS/eliza/pull/15178/checks as its "screenshots".

# AFTER this fix (real-media requirement):
PR #15185: FAIL (5 rows)   PR #15179: FAIL (5 rows)   PR #15178: FAIL (5 rows)
PR #15171: FAIL (5 rows)   PR #15057: FAIL (9 rows)   PR #15053: FAIL (5 rows)
# — an honestly-evidenced body (real user-attachments links / N/A-with-reason
#   on a non-UI diff) still passes: verified against #15204's own body.
```
</details>

<details><summary>Tests</summary>

```
check-pr-evidence self-test passed (11 cases).
node --test scripts/check-pr-evidence.test.mjs → tests 31, pass 31, fail 0
```
</details>

## Known gaps / failures

None. Deterministic parser change, fully covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
