### PR TITLE
fix(cloud): provisioning worker warns loudly when its jobs table looks abandoned

### DIFF
--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -595,6 +595,21 @@ export class JobsRepository {
       .where(and(eq(jobs.type, type), sql`${jobs.status} IN ('pending', 'in_progress')`));
     return rows[0]?.count ?? 0;
   }
+
+  /**
+   * `created_at` of the newest jobs row, any type or status; null when the
+   * table is empty. Powers the provisioning-worker DB liveness check
+   * (#15160): a jobs table nobody has written to in days usually means this
+   * process's DATABASE_URL points at a database the API stopped writing to.
+   */
+  async findLatestCreatedAt(): Promise<Date | null> {
+    const rows = await dbRead
+      .select({ created_at: jobs.created_at })
+      .from(jobs)
+      .orderBy(desc(jobs.created_at))
+      .limit(1);
+    return rows[0]?.created_at ?? null;
+  }
 }
 
 // Singleton instance

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.test.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it, mock } from "bun:test";
 import {
   assertProvisioningWorkerPreflight,
   closeOpenHandles,
+  databaseHostForLogs,
+  evaluateJobsTableLiveness,
   evaluateSelfRestart,
   formatErrorWithCause,
   maybePublishHeartbeat,
@@ -331,6 +333,134 @@ describe("readWorkerConfig (resilience knobs)", () => {
         [],
       ).watchdogConsecutiveTicks,
     ).toBe(2);
+  });
+});
+
+describe("evaluateJobsTableLiveness (#15160 — abandoned-database signal)", () => {
+  const now = new Date("2026-07-06T12:00:00Z");
+
+  it("a recent jobs row is fresh", () => {
+    const assessment = evaluateJobsTableLiveness({
+      latestJobCreatedAt: new Date("2026-07-06T11:00:00Z"),
+      maxAgeHours: 24,
+      now,
+    });
+    expect(assessment.stale).toBe(false);
+    expect(assessment.ageHours).toBeCloseTo(1, 5);
+    expect(assessment.maxAgeHours).toBe(24);
+  });
+
+  it("a row older than the threshold is stale (the #15160 shape: weeks-old queue)", () => {
+    const assessment = evaluateJobsTableLiveness({
+      latestJobCreatedAt: new Date("2026-06-17T05:08:00Z"),
+      maxAgeHours: 24,
+      now,
+    });
+    expect(assessment.stale).toBe(true);
+    expect(assessment.ageHours).toBeGreaterThan(24 * 19);
+  });
+
+  it("an EMPTY jobs table is stale — the API has never written here", () => {
+    const assessment = evaluateJobsTableLiveness({
+      latestJobCreatedAt: null,
+      maxAgeHours: 24,
+      now,
+    });
+    expect(assessment.stale).toBe(true);
+    expect(assessment.ageHours).toBeNull();
+    expect(assessment.latestJobCreatedAt).toBeNull();
+  });
+
+  it("exactly at the threshold is still fresh; one hour past is stale", () => {
+    expect(
+      evaluateJobsTableLiveness({
+        latestJobCreatedAt: new Date("2026-07-05T12:00:00Z"),
+        maxAgeHours: 24,
+        now,
+      }).stale,
+    ).toBe(false);
+    expect(
+      evaluateJobsTableLiveness({
+        latestJobCreatedAt: new Date("2026-07-05T11:00:00Z"),
+        maxAgeHours: 24,
+        now,
+      }).stale,
+    ).toBe(true);
+  });
+
+  it("a created_at in the future (clock skew) is fresh, not stale", () => {
+    const assessment = evaluateJobsTableLiveness({
+      latestJobCreatedAt: new Date("2026-07-06T13:00:00Z"),
+      maxAgeHours: 24,
+      now,
+    });
+    expect(assessment.stale).toBe(false);
+    expect(assessment.ageHours).toBeLessThan(0);
+  });
+
+  it("honors a tightened threshold", () => {
+    const assessment = evaluateJobsTableLiveness({
+      latestJobCreatedAt: new Date("2026-07-06T09:00:00Z"),
+      maxAgeHours: 2,
+      now,
+    });
+    expect(assessment.stale).toBe(true);
+    expect(assessment.maxAgeHours).toBe(2);
+  });
+});
+
+describe("databaseHostForLogs (#15160 — name the DB host, never the credentials)", () => {
+  it("extracts host:port from a Neon-style URL without leaking user or password", () => {
+    const host = databaseHostForLogs(
+      "postgresql://neondb_owner:sup3rs3cret@ep-wild-dawn-a4c7r311-pooler.us-east-1.aws.neon.tech:5432/neondb?sslmode=require",
+    );
+    expect(host).toBe(
+      "ep-wild-dawn-a4c7r311-pooler.us-east-1.aws.neon.tech:5432",
+    );
+    expect(host).not.toContain("sup3rs3cret");
+    expect(host).not.toContain("neondb_owner");
+  });
+
+  it("falls back to the data-dir path for host-less pglite URLs", () => {
+    expect(databaseHostForLogs("pglite:///home/eliza/.eliza/.pgdata")).toBe(
+      "/home/eliza/.eliza/.pgdata",
+    );
+  });
+
+  it("labels missing and unparseable URLs instead of throwing", () => {
+    expect(databaseHostForLogs(undefined)).toBe("<DATABASE_URL not set>");
+    expect(databaseHostForLogs("not a url at all")).toBe(
+      "<unparseable DATABASE_URL>",
+    );
+  });
+});
+
+describe("readWorkerConfig (db liveness threshold)", () => {
+  it("defaults to 24h", () => {
+    expect(
+      readWorkerConfig({} as NodeJS.ProcessEnv, []).dbLivenessMaxAgeHours,
+    ).toBe(24);
+  });
+
+  it("CONTAINERS_DB_LIVENESS_MAX_AGE_HOURS overrides; garbage falls back to 24", () => {
+    expect(
+      readWorkerConfig(
+        { CONTAINERS_DB_LIVENESS_MAX_AGE_HOURS: "72" } as NodeJS.ProcessEnv,
+        [],
+      ).dbLivenessMaxAgeHours,
+    ).toBe(72);
+    expect(
+      readWorkerConfig(
+        { CONTAINERS_DB_LIVENESS_MAX_AGE_HOURS: "-3" } as NodeJS.ProcessEnv,
+        [],
+      ).dbLivenessMaxAgeHours,
+    ).toBe(24);
+    expect(
+      readWorkerConfig(
+        { CONTAINERS_DB_LIVENESS_MAX_AGE_HOURS: "soon" } as NodeJS.ProcessEnv,
+        [],
+      ).dbLivenessMaxAgeHours,
+    ).toBe(24);
   });
 });
 

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -123,6 +123,14 @@ export interface ProvisioningWorkerConfig {
    * armed deliberately.
    */
   orphanReconcilerEnabled: boolean;
+  /**
+   * DB liveness threshold (#15160): when the newest `jobs` row is older than
+   * this many hours, the worker logs a loud error naming the DB host —
+   * "this database looks abandoned; check DATABASE_URL points where the API
+   * writes". Warn-only, never fatal: an idle env legitimately has old jobs.
+   * Tunable via `CONTAINERS_DB_LIVENESS_MAX_AGE_HOURS` (default 24).
+   */
+  dbLivenessMaxAgeHours: number;
 }
 
 const DEFAULT_POLL_INTERVAL_MS = 30_000;
@@ -141,6 +149,14 @@ const DEFAULT_NODE_HEALTH_INTERVAL_MS = 5 * 60_000;
  * good cycle (the watchdog window plus one extra 15s tick), not ~2x the window.
  */
 const DEFAULT_WATCHDOG_CONSECUTIVE_TICKS = 2;
+
+/**
+ * Default DB liveness threshold. 24h is far above any healthy env's
+ * inter-job gap (agent creates, upgrades, and heartbeat-driven retries all
+ * insert jobs) but small enough to flag an abandoned database within a day
+ * instead of the 3 weeks it took to notice #15160.
+ */
+const DEFAULT_DB_LIVENESS_MAX_AGE_HOURS = 24;
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
   if (!value) return fallback;
@@ -183,6 +199,10 @@ export function readWorkerConfig(
       DEFAULT_WATCHDOG_CONSECUTIVE_TICKS,
     ),
     orphanReconcilerEnabled: env.ORPHAN_RECONCILER_ENABLED === "1",
+    dbLivenessMaxAgeHours: parsePositiveInt(
+      env.CONTAINERS_DB_LIVENESS_MAX_AGE_HOURS,
+      DEFAULT_DB_LIVENESS_MAX_AGE_HOURS,
+    ),
   };
 }
 
@@ -319,6 +339,110 @@ export async function assertProvisioningWorkerPreflight(
         `Cause: ${message}`,
     );
   }
+}
+
+export interface JobsTableLivenessAssessment {
+  /** True when the newest jobs row is older than the threshold, or the table is empty. */
+  stale: boolean;
+  /** Hours since the newest jobs row was created; null when the table is empty. */
+  ageHours: number | null;
+  maxAgeHours: number;
+  latestJobCreatedAt: Date | null;
+}
+
+/**
+ * Pure threshold decision behind the DB liveness check (#15160). The staging
+ * outage happened because this daemon silently polled a database the API had
+ * stopped writing to for 3 weeks — zero errors, just an eternally empty
+ * queue, while every agent create sat `pending` in ANOTHER database. A jobs
+ * table whose newest row is older than the threshold (or that is empty) is
+ * treated as stale: probably not the database the API writes to. A
+ * created_at in the future (clock skew) is fresh, not stale. Exported for
+ * unit testing, mirroring `evaluateSelfRestart`.
+ */
+export function evaluateJobsTableLiveness(deps: {
+  latestJobCreatedAt: Date | null;
+  maxAgeHours: number;
+  now?: Date;
+}): JobsTableLivenessAssessment {
+  const { latestJobCreatedAt, maxAgeHours } = deps;
+  if (!latestJobCreatedAt) {
+    return {
+      stale: true,
+      ageHours: null,
+      maxAgeHours,
+      latestJobCreatedAt: null,
+    };
+  }
+  const now = deps.now ?? new Date();
+  const ageHours = (now.getTime() - latestJobCreatedAt.getTime()) / 3_600_000;
+  return {
+    stale: ageHours > maxAgeHours,
+    ageHours,
+    maxAgeHours,
+    latestJobCreatedAt,
+  };
+}
+
+/**
+ * Host portion of a database URL for log messages — never the credentials.
+ * `new URL` drops user:pass with `.host`; pglite:// URLs have no host, so
+ * fall back to the pathname (the local data dir). Exported for unit testing.
+ */
+export function databaseHostForLogs(databaseUrl: string | undefined): string {
+  if (!databaseUrl) return "<DATABASE_URL not set>";
+  try {
+    const parsed = new URL(databaseUrl);
+    return parsed.host || parsed.pathname || "<no host in DATABASE_URL>";
+  } catch {
+    return "<unparseable DATABASE_URL>";
+  }
+}
+
+/** Query side of the DB liveness check: newest jobs row → threshold decision. */
+async function processDbLivenessCheckCycle(
+  config: ProvisioningWorkerConfig,
+): Promise<JobsTableLivenessAssessment> {
+  const { jobsRepository } = await loadDeps();
+  const latestJobCreatedAt = await jobsRepository.findLatestCreatedAt();
+  return evaluateJobsTableLiveness({
+    latestJobCreatedAt,
+    maxAgeHours: config.dbLivenessMaxAgeHours,
+  });
+}
+
+/**
+ * WARN LOUDLY — level error, DB host named — when the jobs table looks
+ * abandoned, but never crash: an idle env legitimately has old jobs, so this
+ * is a signal for a human, not a fail-stop. Re-emitted on every infra
+ * maintenance sweep so the signal is unmissable in the logs, not a one-shot
+ * scrolled away at boot.
+ */
+function logJobsTableLiveness(
+  logger: WorkerLogger,
+  assessment: JobsTableLivenessAssessment,
+): void {
+  if (!assessment.stale) return;
+  const databaseHost = databaseHostForLogs(process.env.DATABASE_URL);
+  const newestRow =
+    assessment.ageHours === null
+      ? "the table is EMPTY"
+      : `the newest row is ${assessment.ageHours.toFixed(1)}h old`;
+  logger.error(
+    `[provisioning-worker] DB LIVENESS: the jobs table on ${databaseHost} looks abandoned — ` +
+      `${newestRow}, threshold ${assessment.maxAgeHours}h (CONTAINERS_DB_LIVENESS_MAX_AGE_HOURS). ` +
+      "Check that this daemon's DATABASE_URL points at the SAME database the cloud-api " +
+      "writes jobs to: a split pair polls an eternally empty queue with zero errors while " +
+      "every provision hangs pending forever (#15160). If this env is intentionally idle, " +
+      "raise the threshold.",
+    {
+      event: "worker.db_liveness_stale",
+      databaseHost,
+      latestJobCreatedAt: assessment.latestJobCreatedAt?.toISOString() ?? null,
+      ageHours: assessment.ageHours,
+      maxAgeHours: assessment.maxAgeHours,
+    },
+  );
 }
 
 async function processProvisioningWorkerCycle(
@@ -1124,6 +1248,20 @@ async function runInfraMaintenanceCycle(
 ): Promise<void> {
   // Every phase is bounded by PHASE_TIMEOUT_MS via runBoundedPhase so an
   // unresponsive node's SSH probe can never stall the whole sweep.
+
+  // #15160 guard, periodic half: re-assert DB liveness on every infra
+  // maintenance sweep (default every 5min ≈ every 10th poll cycle) so a
+  // worker polling an abandoned database keeps screaming instead of logging
+  // once at boot and going silent. First so a dragging SSH sweep can't
+  // starve it. Runs BEFORE the health check touches docker_nodes, so it is
+  // a pure read.
+  await runBoundedPhase(
+    logger,
+    "db liveness check cycle",
+    () => processDbLivenessCheckCycle(config),
+    (assessment) => logJobsTableLiveness(logger, assessment),
+  );
+
   await runBoundedPhase(
     logger,
     "node health check cycle",
@@ -1313,6 +1451,7 @@ async function main(): Promise<void> {
     selfRestartEnabled: config.selfRestartEnabled,
     watchdogConsecutiveTicks: config.watchdogConsecutiveTicks,
     orphanReconcilerEnabled: config.orphanReconcilerEnabled,
+    dbLivenessMaxAgeHours: config.dbLivenessMaxAgeHours,
   });
 
   await assertProvisioningWorkerPreflight();
@@ -1333,6 +1472,20 @@ async function main(): Promise<void> {
 
   preflightOk = true;
   logger.info("[provisioning-worker] startup preflight passed");
+
+  // #15160 guard, startup half: right after the preflight, check that the
+  // jobs table this DATABASE_URL points at has been written to recently.
+  // The KMS/SSH preflights above prove THIS worker can run jobs; this one
+  // flags the failure mode where there are simply never any jobs to run
+  // because the API writes to a different database. Bounded + caught by
+  // runBoundedPhase: a slow or unreachable DB logs an error here and the
+  // work cycles surface it properly — startup must not crash on it.
+  await runBoundedPhase(
+    logger,
+    "db liveness preflight",
+    () => processDbLivenessCheckCycle(config),
+    (assessment) => logJobsTableLiveness(logger, assessment),
+  );
 
   // Apps (Product 2): arm the deploy backend when enabled (gated; no-op by default).
   await armAppsDeployBackendIfEnabled(logger);


### PR DESCRIPTION
## Why

Post-mortem hardening from #15160: staging agent provisioning was structurally dead for ~3 weeks because the CP provisioning worker polled a Neon database the cloud-api had stopped writing to (the ~June 17 DB split). From the worker's side everything was green — KMS preflight passed, heartbeat published, 15s poll ticking — the queue was just eternally empty. Zero errors, zero signal, nothing paged. The fix for the outage itself was repointing DATABASE_URL; this PR makes sure the failure mode can never hide again.

## What

The worker now checks whether anyone is actually writing to the database it polls:

- **Startup preflight** (right next to the existing `startup preflight passed` logic) **+ periodic re-check** on every infra-maintenance sweep (default 5min ≈ every 10th poll cycle): read the newest `jobs.created_at` and compare against a threshold.
- Older than the threshold, or table empty → **log-level `error` naming the DB host**: `DB LIVENESS: the jobs table on <host> looks abandoned — … check that this daemon's DATABASE_URL points at the SAME database the cloud-api writes jobs to (#15160)`. Host comes from `DATABASE_URL` with credentials stripped.
- Threshold defaults to **24h**, tunable via `CONTAINERS_DB_LIVENESS_MAX_AGE_HOURS`.
- **Warn, never die**: an idle env legitimately has old jobs, so the check never crashes the worker — the periodic re-emit is what makes the signal unmissable. Both call sites run through `runBoundedPhase`, so a slow or unreachable DB is bounded + caught like every other cycle phase and cannot wedge startup or the sweep.
- New read-only `jobsRepository.findLatestCreatedAt()` (single indexed row, no schema change).

The threshold decision is a pure exported function (`evaluateJobsTableLiveness`) and so is the host extraction (`databaseHostForLogs`), both unit-tested following the file's existing exported-helper pattern (`evaluateSelfRestart`, `formatErrorWithCause`).

## Tests

- `cd packages/scripts && bun test cloud/admin/daemons/` → 62 pass / 4 skip / 0 fail (11 new tests: threshold boundaries, empty table, clock skew, env override, credential-free host extraction).
- `bun run --cwd packages/cloud/shared typecheck` → clean.
- `biome check` on the three touched files → clean.
- Pre-existing, unrelated: `src/db/repositories/jobs.test.ts` fails identically at pristine HEAD in this env (`Cannot find module '@elizaos/cloud-routing'`).

Closes #15207

[stan-cloud]