### PR TITLE
docs: headless-agent evidence attachment path (pr-evidence release assets)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,23 @@ Post videos as MP4 so GitHub renders them inline, screenshots as JPG where
 possible, and long logs in a `<details>` block. Re-capture evidence after
 rebasing when `develop` changes the behavior under review.
 
+**Headless agents (no browser, cannot drag-and-drop):** upload media to the
+dedicated [`pr-evidence` release](https://github.com/elizaOS/eliza/releases/tag/pr-evidence)
+and embed the asset URLs — they end in a media extension, render inline via
+`![](…)`, and satisfy the evidence gate:
+
+```bash
+# name files <pr-number>-<artifact>.<ext>, then:
+gh release upload pr-evidence 15171-after-desktop.jpg 15171-walkthrough.mp4
+# embed in the PR evidence rows:
+#   ![after](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15171-after-desktop.jpg)
+```
+
+Never delete assets referenced by an open PR. A worked example of a fully
+evidenced PR (before/after screenshots, MP4 walkthroughs, OCR readout,
+vision-QA trajectory with the model named, pixel-diff report, zero-error
+frontend logs) is [#15171](https://github.com/elizaOS/eliza/pull/15171).
+
 ## Security Reporting
 
 The canonical security policy — reporting channel, disclosure window, and


### PR DESCRIPTION
# Relates to

Follow-up to #15204/#15208 (evidence-gate hardening). Closes the last practical
gap in "all agents always post evidence": headless agents had no way to attach
media (drag-and-drop needs a browser).

- [x] Targets develop, based on latest origin/develop, zero conflicts.
- [x] Docs-only; markdown link check covers it.

# Risks

None — documentation only.

# Background

## What does this PR do?

Documents the CLI-scriptable evidence-attachment path for headless agents: the
dedicated `pr-evidence` release (`gh release upload pr-evidence <files>`) whose
asset URLs end in media extensions, render inline via `![](…)`, and satisfy the
strict evidence gate. Links PR #15171 — remediated end-to-end with this exact
flow — as the worked example.

## What kind of change is this?

Documentation.

# Testing

## Where should a reviewer start?

CONTRIBUTING.md § Evidence, the new "Headless agents" block.

## Detailed testing steps

Open #15171: the gate (`check-pr-evidence`) passes with release-asset media;
screenshots render inline in the evidence comment.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - documentation-only change, no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - documentation-only change, no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - documentation-only change`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs `N/A - no code path; the documented flow is proven live on PR #15171 (gate passed)`.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend change`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent/model behavior change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: the live demonstration — [15171-vision-qa.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15171-vision-qa.json) and the passing gate run on #15171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
