### PR TITLE
fix(cloud): give staging its own agent wildcard — <id>.staging.elizacloud.ai, not the prod domain

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -265,6 +265,12 @@ routes = [
   { pattern = "staging.elizacloud.ai/*", zone_name = "elizacloud.ai" },
   { pattern = "app-staging.elizacloud.ai/*", zone_name = "elizacloud.ai" },
   { pattern = "api-staging.elizacloud.ai/*", zone_name = "elizacloud.ai" },
+  # Per-agent subdomains for staging (#15205): mirrors prod's *.elizacloud.ai so
+  # the STAGING Worker (not the prod one) proxies staging agents. Requires the
+  # matching *.staging.elizacloud.ai DNS wildcard and ELIZA_CLOUD_AGENT_BASE_DOMAIN
+  # = staging.elizacloud.ai (below). Without it, staging agent URLs fall into the
+  # prod *.elizacloud.ai wildcard and the prod worker 404s them (CORS dead-end).
+  { pattern = "*.staging.elizacloud.ai/*", zone_name = "elizacloud.ai" },
   # Public R2 objects for staging. Without this explicit route the host falls
   # into [env.production]'s *.elizacloud.ai wildcard and the PROD worker serves
   # the PROD bucket for staging-minted URLs.
@@ -291,7 +297,11 @@ ELIZA_CLOUD_URL = "https://staging.elizacloud.ai"
 # prod fallback (www.elizacloud.ai). Tenant row provisioned manually.
 STEWARD_TENANT_ID = "elizacloud-staging"
 NEXT_PUBLIC_STEWARD_TENANT_ID = "elizacloud-staging"
-ELIZA_CLOUD_AGENT_BASE_DOMAIN = "elizacloud.ai"
+# Staging agents live at <id>.staging.elizacloud.ai (mirrors prod's
+# <id>.elizacloud.ai), served by the *.staging.elizacloud.ai/* route above.
+# Was "elizacloud.ai", which minted staging agent URLs on the PROD wildcard so
+# the prod worker (which has no staging agents) served CORS-less 404s (#15205).
+ELIZA_CLOUD_AGENT_BASE_DOMAIN = "staging.elizacloud.ai"
 # Routes agent-subdomain traffic to the staging control-plane VM. Without this
 # the Worker falls back to DEFAULT_AGENT_ROUTER_ORIGIN_HOST in
 # packages/cloud/api/src/index.ts (= eliza-production-1.elizacloud.ai) so


### PR DESCRIPTION
## Problem (#15205)
Staging set `ELIZA_CLOUD_AGENT_BASE_DOMAIN = "elizacloud.ai"` — same as prod — so the cloud-api minted every staging agent's canonical URL as `<id>.elizacloud.ai`. That host matches `[env.production]`'s `*.elizacloud.ai/*` route and hits the **prod** worker, which has no staging agents → the app's per-agent `/api` polls got CORS-less 404s and the chat dead-ended in the self-hosted **PairingView** ('Pairing is not enabled on this server'), even though the agent was **RUNNING**.

Nobody reached this hop until staging provisioning was revived tonight (#15160 DB repoint + #15196 image boot fix) and a staging agent finally got to `running` for the first time in weeks. Live-reproduced end to end: sign-in → pair → /chat opens → 183× CORS+ERR_FADED on `<id>.elizacloud.ai/api/status` → PairingView wall.

## Fix
Mirror the existing per-env pattern (api-staging / app-staging): staging agents now live at `<id>.staging.elizacloud.ai`, served by a new `*.staging.elizacloud.ai/*` route on the **staging** worker, with `ELIZA_CLOUD_AGENT_BASE_DOMAIN = "staging.elizacloud.ai"`. Prod (`[env.production]`) and the top-level `[vars]` default are untouched — diff is staging-only, +11/-1.

## Zone side (already applied out-of-band, matches this config)
- DNS: `*.staging.elizacloud.ai` A → 216.150.16.193 + 216.150.1.193, proxied (mirrors prod's `*.elizacloud.ai`).
- Worker route: `*.staging.elizacloud.ai/*` → `eliza-cloud-api-staging` (id 693d005c…).
Both live in the Cloudflare zone now; this PR makes them durable so the next `wrangler deploy --env staging` reconciles them instead of deleting the route / reverting the var.

## Verification
`wrangler deploy --env staging --dry-run` builds clean (bundle 16 MB). The final live `wrangler deploy --env staging --keep-vars` (preserves the 202 secrets + out-of-band vars, applies the base-domain change) is pending an operator with deploy rights — filed here so it lands with review.

Closes #15205

[stan-cloud]