### PR TITLE
feat(cloud): regression guard for 'staging pointing at prod CF'

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -1268,3 +1268,55 @@ jobs:
             nohup bash -c 'timeout 30s rm -rf "$1" || true' _ "$stale_dir" >/dev/null 2>&1 &
             echo "Scheduled best-effort cleanup for ${stale_dir}."
           fi
+
+  # ---------------------------------------------------------------------------
+  # Post-deploy routing verification (regression guard for "staging pointing at
+  # prod CF"). After the Worker + both Pages projects deploy, probe the LIVE
+  # custom domains of the just-deployed environment and assert each is served by
+  # THAT environment -- not the other one leaking through the prod
+  # `*.elizacloud.ai/*` wildcard or a mis-mapped Pages custom domain. This does
+  # NOT gate the deploy (it already happened); it surfaces a misroute as a red
+  # check. The always-on scheduled monitor is .github/workflows/verify-cf-routing.yml.
+  # ---------------------------------------------------------------------------
+  verify-routing:
+    name: Verify ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }} routing
+    needs: [deploy-api, deploy-console, deploy-app]
+    # Custom domains only exist for the real environments -- PR previews deploy to
+    # a preview branch alias, so skip them. Require all three deploys to have
+    # landed (the beacon is served by the API Worker; the domains by the two Pages
+    # projects), else there is nothing trustworthy to probe.
+    if: ${{ !cancelled() && github.event_name != 'pull_request' && needs.deploy-api.result == 'success' && needs.deploy-console.result == 'success' && needs.deploy-app.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+          show-progress: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
+      - name: Resolve deployed environment
+        id: env
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.environment }}" = "production" ]; then
+            env=production
+          elif [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            env=production
+          else
+            env=staging
+          fi
+          echo "environment=$env" >> "$GITHUB_OUTPUT"
+
+      - name: Verify the just-deployed environment serves itself
+        # This run built AND deployed the beacon-carrying Worker for this env, so
+        # require the beacon: a beaconless answer means the deploy that was
+        # supposed to carry it did not take. A genuine cross-wire is always fatal.
+        run: |
+          node packages/scripts/cloud/verify-environment-routing-cli.mjs \
+            --environment "${{ steps.env.outputs.environment }}" \
+            --require-beacon

--- a/.github/workflows/verify-cf-routing.yml
+++ b/.github/workflows/verify-cf-routing.yml
@@ -1,0 +1,93 @@
+name: Verify CF Routing
+
+# Regression guard for "staging is pointing at prod CF".
+#
+# The staging Worker (`eliza-cloud-api-staging`) owns staging.* / app-staging.* /
+# api-staging.* ONLY by claiming those hosts MORE specifically than the prod
+# Worker's `*.elizacloud.ai/*` wildcard (packages/cloud/api/wrangler.toml
+# [env.staging].routes); the staging Pages deployments likewise bake
+# API_UPSTREAM=api-staging.elizacloud.ai. If either claim lapses - a dropped
+# Worker route, a Pages custom-domain reattached to the wrong deployment, a
+# preview var drifted to prod - a staging subdomain silently starts serving
+# production. That drift is Cloudflare dashboard/route state, invisible from the
+# repo and from any single-origin health check, and it recurred (fixed manually
+# in CF + a wrangler update). This job asks each LIVE custom domain "which
+# environment answered you?" via the /api/health environment beacon and fails
+# when a staging domain is served by production (or vice-versa).
+#
+# This is a live MONITOR, not a deploy gate - it probes the domains as they are
+# right now, so it catches drift that no code push caused. It needs no secrets
+# (the beacon is public) and no dependency install (the verifier is pure Node).
+#
+# Beacon rollout: the `environment` field ships with the API Worker. Until BOTH
+# environments have deployed a build carrying it, a beaconless domain is reported
+# as a warning, not a failure. Once prod has promoted the beacon, set the repo
+# variable CF_ROUTING_REQUIRE_BEACON=true to make a missing beacon fatal too -
+# no code change required. A genuine cross-wire (a KNOWN wrong environment
+# answering) is ALWAYS fatal, beacon rollout notwithstanding.
+
+on:
+  schedule:
+    # Every 6h - the drift lived for hours before it was noticed; this bounds the
+    # blast radius without spamming. Offset off the top of the hour.
+    - cron: "17 */6 * * *"
+  workflow_dispatch:
+    inputs:
+      require_beacon:
+        description: Treat a domain whose build predates the /api/health environment beacon as a failure
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: verify-cf-routing-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify-routing:
+    name: Verify each custom domain serves its own environment
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+          show-progress: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: "24"
+
+      - name: Verify cross-environment routing
+        env:
+          # workflow_dispatch input OR the standing repo variable makes a missing
+          # beacon fatal; either being true is enough. Reachability is always
+          # required - these are always-up production/staging origins, so a
+          # persistent (post-retry) unreachable is itself a real signal.
+          REQUIRE_BEACON: ${{ github.event.inputs.require_beacon == 'true' || vars.CF_ROUTING_REQUIRE_BEACON == 'true' }}
+        run: |
+          args=(--environment all)
+          if [ "$REQUIRE_BEACON" = "true" ]; then
+            args+=(--require-beacon)
+          fi
+          node packages/scripts/cloud/verify-environment-routing-cli.mjs "${args[@]}"
+
+      - name: Notify Discord (Failure)
+        if: failure()
+        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          ack_no_webhook: true
+          title: "CF routing verification FAILED"
+          nodetail: true
+          description: |
+            A custom domain is being served by the wrong environment (staging/prod),
+            or an always-up origin is unreachable. Reconcile the Cloudflare Worker
+            routes ([env.staging].routes in packages/cloud/api/wrangler.toml) and the
+            Pages custom-domain to deployment mapping, then re-run.
+          color: 0xff0000

--- a/packages/cloud/api/health/route.ts
+++ b/packages/cloud/api/health/route.ts
@@ -16,6 +16,10 @@ app.get("/", (c) =>
       status: "ok",
       timestamp: Date.now(),
       region: (c.env as { CF_REGION?: string }).CF_REGION ?? "unknown",
+      // Parity with the index.ts fast-path health beacon (that one answers
+      // `/api/health` before the app boots, so this route is normally shadowed).
+      // Kept identical so the two can never disagree on which env answered.
+      environment: (c.env as { ENVIRONMENT?: string }).ENVIRONMENT ?? null,
     },
     200,
     { "Cache-Control": "no-store, max-age=0" },

--- a/packages/cloud/api/src/index.ts
+++ b/packages/cloud/api/src/index.ts
@@ -55,6 +55,16 @@ function healthResponse(env: AppEnv["Bindings"]): Response {
       timestamp: Date.now(),
       region: (env as { CF_REGION?: string }).CF_REGION ?? "unknown",
       commit: env.ELIZA_DEPLOY_COMMIT ?? null,
+      // Self-identify which deployment env answered. The staging worker and the
+      // prod worker share the `*.elizacloud.ai` zone; the staging worker only
+      // owns `staging.*`/`app-staging.*`/`api-staging.*` by claiming those
+      // routes MORE specifically than prod's `*.elizacloud.ai/*` wildcard
+      // (wrangler.toml [env.staging].routes). If that claim ever lapses, a
+      // staging subdomain silently falls into the prod wildcard and starts
+      // serving prod — invisible except by asking who answered. This field is
+      // the beacon the cross-environment routing verifier probes
+      // (packages/scripts/cloud/verify-environment-routing.mjs).
+      environment: env.ENVIRONMENT ?? null,
     },
     {
       status: 200,

--- a/packages/scripts/__tests__/verify-environment-routing.test.ts
+++ b/packages/scripts/__tests__/verify-environment-routing.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Exercises the cross-environment routing verifier: a staging custom domain that
+ * is answered by the production environment (or vice-versa) is a hard failure -
+ * that is the "staging pointing at prod CF" regression this guard exists to
+ * catch. Transient/rollout states (unreachable origin, pre-beacon build) are
+ * tolerated unless their strictness flag is set. The wrangler-sync case keeps the
+ * domain matrix from drifting away from the real Worker routes.
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+
+import {
+  classifyProbe,
+  decideRoutingVerdict,
+  ENVIRONMENT_ROUTING,
+  fetchServedEnvironment,
+  KNOWN_ENVIRONMENTS,
+  parseServedEnvironment,
+} from "../cloud/verify-environment-routing.mjs";
+import { selectMatrix } from "../cloud/verify-environment-routing-cli.mjs";
+
+describe("parseServedEnvironment", () => {
+  it("extracts the environment from a valid /api/health body", () => {
+    expect(
+      parseServedEnvironment(
+        JSON.stringify({ status: "ok", environment: "staging" }),
+      ),
+    ).toBe("staging");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(
+      parseServedEnvironment(JSON.stringify({ environment: "  production  " })),
+    ).toBe("production");
+  });
+
+  it("returns null when the field is absent (build predates the beacon)", () => {
+    expect(parseServedEnvironment(JSON.stringify({ status: "ok" }))).toBeNull();
+  });
+
+  it("returns null for blank / null environment", () => {
+    expect(
+      parseServedEnvironment(JSON.stringify({ environment: "  " })),
+    ).toBeNull();
+    expect(
+      parseServedEnvironment(JSON.stringify({ environment: null })),
+    ).toBeNull();
+  });
+
+  it("returns null for unparseable / non-object bodies (SPA index.html fallthrough)", () => {
+    expect(parseServedEnvironment("<!doctype html>")).toBeNull();
+    expect(parseServedEnvironment("")).toBeNull();
+    expect(parseServedEnvironment(JSON.stringify("staging"))).toBeNull();
+    // @ts-expect-error deliberately wrong type
+    expect(parseServedEnvironment(undefined)).toBeNull();
+  });
+});
+
+describe("classifyProbe", () => {
+  const P = {
+    domain: "app-staging.elizacloud.ai",
+    expected: "staging" as const,
+  };
+
+  it("ok when the observed env matches expected", () => {
+    const r = classifyProbe({ ...P, observed: "staging", reachable: true });
+    expect(r.status).toBe("ok");
+  });
+
+  it("MISROUTED when a staging domain is answered by production", () => {
+    const r = classifyProbe({ ...P, observed: "production", reachable: true });
+    expect(r.status).toBe("misrouted");
+    expect(r.message).toContain("MISROUTED");
+  });
+
+  it("MISROUTED in the reverse direction (prod domain answered by staging)", () => {
+    const r = classifyProbe({
+      domain: "app.elizacloud.ai",
+      expected: "production",
+      observed: "staging",
+      reachable: true,
+    });
+    expect(r.status).toBe("misrouted");
+  });
+
+  it("beacon_missing when reachable but no environment field", () => {
+    const r = classifyProbe({ ...P, observed: null, reachable: true });
+    expect(r.status).toBe("beacon_missing");
+  });
+
+  it("unreachable when the origin did not return a usable answer", () => {
+    const r = classifyProbe({
+      ...P,
+      observed: null,
+      reachable: false,
+      detail: "HTTP 502",
+    });
+    expect(r.status).toBe("unreachable");
+    expect(r.message).toContain("HTTP 502");
+  });
+
+  it("unexpected_env for an unrecognized environment string", () => {
+    const r = classifyProbe({ ...P, observed: "qa", reachable: true });
+    expect(r.status).toBe("unexpected_env");
+  });
+});
+
+describe("decideRoutingVerdict", () => {
+  const probe = (over: Record<string, unknown>) =>
+    classifyProbe({
+      domain: "d",
+      expected: "staging",
+      observed: "staging",
+      reachable: true,
+      ...over,
+    });
+
+  it("passes when every probe is ok", () => {
+    const v = decideRoutingVerdict({
+      probes: [probe({}), probe({ domain: "e" })],
+    });
+    expect(v.ok).toBe(true);
+    expect(v.failures).toHaveLength(0);
+  });
+
+  it("FAILS on any misrouted probe (the core regression)", () => {
+    const v = decideRoutingVerdict({
+      probes: [probe({}), probe({ observed: "production" })],
+    });
+    expect(v.ok).toBe(false);
+    expect(v.failures).toHaveLength(1);
+    expect(v.failures[0].status).toBe("misrouted");
+  });
+
+  it("FAILS on an unexpected env regardless of flags", () => {
+    const v = decideRoutingVerdict({ probes: [probe({ observed: "qa" })] });
+    expect(v.ok).toBe(false);
+  });
+
+  it("treats beacon_missing as a warning by default, a failure with requireBeacon", () => {
+    const probes = [probe({ observed: null })];
+    expect(decideRoutingVerdict({ probes }).ok).toBe(true);
+    expect(decideRoutingVerdict({ probes }).warnings).toHaveLength(1);
+    expect(decideRoutingVerdict({ probes, requireBeacon: true }).ok).toBe(
+      false,
+    );
+  });
+
+  it("fails on unreachable by default, warns when requireReachable is false", () => {
+    const probes = [probe({ observed: null, reachable: false })];
+    expect(decideRoutingVerdict({ probes }).ok).toBe(false);
+    expect(decideRoutingVerdict({ probes, requireReachable: false }).ok).toBe(
+      true,
+    );
+  });
+
+  it("summary reports status counts", () => {
+    const v = decideRoutingVerdict({
+      probes: [probe({}), probe({ observed: "production" })],
+    });
+    expect(v.summary).toContain("misrouted=1");
+    expect(v.summary).toContain("ok=1");
+  });
+
+  it("handles an empty / non-array probe list", () => {
+    expect(decideRoutingVerdict({ probes: [] }).ok).toBe(true);
+    // @ts-expect-error deliberately wrong type
+    expect(decideRoutingVerdict({ probes: null }).ok).toBe(true);
+  });
+});
+
+describe("fetchServedEnvironment - network boundary", () => {
+  const noSleep = async () => {};
+
+  it("returns the observed env on a 200 with a valid beacon", async () => {
+    const fetchImpl = (async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ environment: "staging" }),
+    })) as unknown as typeof fetch;
+    const r = await fetchServedEnvironment("app-staging.elizacloud.ai", {
+      fetchImpl,
+      sleep: noSleep,
+    });
+    expect(r).toMatchObject({ observed: "staging", reachable: true });
+  });
+
+  it("is reachable-but-beaconless on a 200 without the field", async () => {
+    const fetchImpl = (async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ status: "ok" }),
+    })) as unknown as typeof fetch;
+    const r = await fetchServedEnvironment("app.elizacloud.ai", {
+      fetchImpl,
+      sleep: noSleep,
+    });
+    expect(r).toMatchObject({ observed: null, reachable: true });
+  });
+
+  it("requests https://<domain>/api/health", async () => {
+    let requested = "";
+    const fetchImpl = (async (url: string) => {
+      requested = url;
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ environment: "production" }),
+      };
+    }) as unknown as typeof fetch;
+    await fetchServedEnvironment("api.elizacloud.ai///", {
+      fetchImpl,
+      sleep: noSleep,
+    });
+    expect(requested).toBe("https://api.elizacloud.ai/api/health");
+  });
+
+  it("retries and succeeds after a transient failure", async () => {
+    let calls = 0;
+    const fetchImpl = (async () => {
+      calls += 1;
+      if (calls < 2) throw new Error("ECONNRESET");
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ environment: "staging" }),
+      };
+    }) as unknown as typeof fetch;
+    const r = await fetchServedEnvironment("staging.elizacloud.ai", {
+      fetchImpl,
+      sleep: noSleep,
+    });
+    expect(calls).toBe(2);
+    expect(r.reachable).toBe(true);
+  });
+
+  it("reports unreachable after exhausting retries on non-200", async () => {
+    const fetchImpl = (async () => ({
+      ok: false,
+      status: 502,
+      text: async () => "bad gateway",
+    })) as unknown as typeof fetch;
+    const r = await fetchServedEnvironment("api-staging.elizacloud.ai", {
+      fetchImpl,
+      attempts: 2,
+      sleep: noSleep,
+    });
+    expect(r.reachable).toBe(false);
+    expect(r.detail).toContain("502");
+  });
+
+  it("reports unreachable when fetch always throws", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("ENOTFOUND");
+    }) as unknown as typeof fetch;
+    const r = await fetchServedEnvironment("staging.elizacloud.ai", {
+      fetchImpl,
+      attempts: 2,
+      sleep: noSleep,
+    });
+    expect(r.reachable).toBe(false);
+  });
+
+  it("returns unreachable for a blank domain without touching the network", async () => {
+    let called = false;
+    const fetchImpl = (async () => {
+      called = true;
+      return { ok: true, status: 200, text: async () => "{}" };
+    }) as unknown as typeof fetch;
+    const r = await fetchServedEnvironment("   ", {
+      fetchImpl,
+      sleep: noSleep,
+    });
+    expect(r.reachable).toBe(false);
+    expect(called).toBe(false);
+  });
+});
+
+describe("selectMatrix", () => {
+  it("returns the whole matrix for all / undefined", () => {
+    expect(selectMatrix("all")).toHaveLength(ENVIRONMENT_ROUTING.length);
+    expect(selectMatrix(undefined)).toHaveLength(ENVIRONMENT_ROUTING.length);
+  });
+
+  it("filters to one environment (and accepts the prod alias)", () => {
+    const staging = selectMatrix("staging");
+    expect(staging.every((e) => e.environment === "staging")).toBe(true);
+    expect(staging.length).toBeGreaterThan(0);
+    const prod = selectMatrix("prod");
+    expect(prod.every((e) => e.environment === "production")).toBe(true);
+  });
+});
+
+describe("ENVIRONMENT_ROUTING matrix integrity", () => {
+  it("has unique domains, all under elizacloud.ai, all with a known env", () => {
+    const domains = ENVIRONMENT_ROUTING.map((e) => e.domain);
+    expect(new Set(domains).size).toBe(domains.length);
+    for (const { domain, environment } of ENVIRONMENT_ROUTING) {
+      expect(domain.endsWith("elizacloud.ai")).toBe(true);
+      expect(KNOWN_ENVIRONMENTS).toContain(environment);
+    }
+  });
+
+  it("stays in sync with the staging Worker routes in wrangler.toml", () => {
+    // The staging Worker reclaims these hosts from the prod `*.elizacloud.ai/*`
+    // wildcard by claiming them explicitly. If a NEW staging health host is
+    // added there without being added to the matrix, the verifier would never
+    // probe it; fail here so the two cannot silently diverge.
+    const wrangler = readFileSync(
+      new URL("../../cloud/api/wrangler.toml", import.meta.url),
+      "utf8",
+    );
+    const stagingBlock = wrangler.slice(
+      wrangler.indexOf("[env.staging]"),
+      wrangler.indexOf("[env.production]"),
+    );
+    const routeHosts = [
+      ...stagingBlock.matchAll(/pattern\s*=\s*"([^"/]+)\/\*"/g),
+    ].map((m) => m[1]);
+    // Every staging route host EXCEPT the R2 blob host (which serves objects,
+    // not /api/health) must be represented in the matrix as a staging domain.
+    const healthHosts = routeHosts.filter((h) => !h.startsWith("blob-"));
+    const stagingMatrix = new Set(
+      ENVIRONMENT_ROUTING.filter((e) => e.environment === "staging").map(
+        (e) => e.domain,
+      ),
+    );
+    expect(healthHosts.length).toBeGreaterThan(0);
+    for (const host of healthHosts) {
+      expect(stagingMatrix.has(host)).toBe(true);
+    }
+  });
+});

--- a/packages/scripts/cloud/verify-environment-routing-cli.mjs
+++ b/packages/scripts/cloud/verify-environment-routing-cli.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * CLI for the cross-environment routing verifier.
+ *
+ * Probes each live custom domain's `/api/health` and asserts the environment
+ * that answered matches the environment the domain is supposed to serve -
+ * catching "staging is pointing at prod CF" (a staging subdomain that fell into
+ * the prod `*.elizacloud.ai/*` Worker wildcard, or a Pages deployment reattached
+ * to the wrong environment). See `verify-environment-routing.mjs` for the why.
+ *
+ * Usage:
+ *   node packages/scripts/cloud/verify-environment-routing-cli.mjs \
+ *     [--environment staging|production|all]   (default: all)
+ *     [--require-beacon]        treat a build-without-beacon as a failure
+ *     [--allow-unreachable]     downgrade an unreachable origin to a warning
+ *     [--json]                  emit the machine-readable report to stdout
+ *
+ * Exit code: 0 when every probed domain routed correctly; 1 on any failure
+ * (a genuine cross-wire always fails; unreachable/beacon-missing per the flags).
+ * A GitHub step summary is appended when $GITHUB_STEP_SUMMARY is set.
+ */
+import fs from "node:fs";
+
+import {
+  classifyProbe,
+  decideRoutingVerdict,
+  ENVIRONMENT_ROUTING,
+  fetchServedEnvironment,
+} from "./verify-environment-routing.mjs";
+
+function parseArgs(argv) {
+  const out = {
+    environment: "all",
+    requireBeacon: false,
+    requireReachable: true,
+    json: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--require-beacon") out.requireBeacon = true;
+    else if (arg === "--allow-unreachable") out.requireReachable = false;
+    else if (arg === "--json") out.json = true;
+    else if (arg === "--environment") out.environment = argv[++i];
+    else if (arg.startsWith("--environment=")) {
+      out.environment = arg.slice("--environment=".length);
+    }
+  }
+  return out;
+}
+
+const STATUS_LABEL = {
+  ok: "ok",
+  misrouted: "fail",
+  unexpected_env: "warn",
+  beacon_missing: "no-beacon",
+  unreachable: "unreachable",
+};
+
+function stdout(line = "") {
+  process.stdout.write(`${line}\n`);
+}
+
+function stderr(line = "") {
+  process.stderr.write(`${line}\n`);
+}
+
+function selectMatrix(environment) {
+  if (environment === "all" || !environment) return ENVIRONMENT_ROUTING;
+  const target = environment === "prod" ? "production" : environment;
+  return ENVIRONMENT_ROUTING.filter((e) => e.environment === target);
+}
+
+function writeStepSummary(verdict) {
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: GitHub Actions provides this path.
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+  const lines = [
+    "### Cross-environment routing verification",
+    "",
+    `**${verdict.ok ? "PASS" : "FAIL"}** - ${verdict.summary}`,
+    "",
+    "| Domain | Expected | Answered | Status |",
+    "| --- | --- | --- | --- |",
+    ...verdict.probes.map(
+      (p) =>
+        `| \`${p.domain}\` | ${p.expected} | ${p.observed ?? "-"} | ${STATUS_LABEL[p.status] ?? ""} ${p.status} |`,
+    ),
+    "",
+  ];
+  if (!verdict.ok) {
+    lines.push(
+      "> A **misrouted** domain means a staging host is being served by the",
+      "> production environment (or vice-versa). Reconcile the Cloudflare Worker",
+      "> routes (`packages/cloud/api/wrangler.toml` `[env.staging].routes`) and the",
+      "> Pages custom-domain to deployment mapping, then re-run this check.",
+      "",
+    );
+  }
+  try {
+    fs.appendFileSync(summaryPath, `${lines.join("\n")}\n`);
+  } catch {
+    // error-policy:J7 diagnostics-must-not-kill-the-loop - the step summary is
+    // auxiliary CI output; the process exit code still carries the verdict.
+    // A summary-write failure must never change the verdict.
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const matrix = selectMatrix(args.environment);
+  if (matrix.length === 0) {
+    stderr(
+      `verify-environment-routing: no domains match --environment=${args.environment}`,
+    );
+    process.exit(2);
+  }
+
+  const probes = await Promise.all(
+    matrix.map(async ({ domain, environment }) => {
+      const { observed, reachable, detail } =
+        await fetchServedEnvironment(domain);
+      return classifyProbe({
+        domain,
+        expected: environment,
+        observed,
+        reachable,
+        detail,
+      });
+    }),
+  );
+
+  const verdict = decideRoutingVerdict({
+    probes,
+    requireBeacon: args.requireBeacon,
+    requireReachable: args.requireReachable,
+  });
+
+  if (args.json) {
+    stdout(JSON.stringify(verdict, null, 2));
+  } else {
+    for (const p of verdict.probes) {
+      const failed = verdict.failures.includes(p);
+      const write = failed ? stderr : stdout;
+      write(`[${STATUS_LABEL[p.status] ?? "status"}] ${p.message}`);
+    }
+    stdout("");
+    stdout(`${verdict.ok ? "PASS" : "FAIL"}: ${verdict.summary}`);
+  }
+
+  writeStepSummary(verdict);
+  process.exit(verdict.ok ? 0 : 1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    // error-policy:J1 boundary translation - an unexpected verifier crash must
+    // leave CI red instead of being mistaken for healthy routing.
+    // An unexpected crash in the verifier itself must NOT be read as "routing
+    // is fine": exit non-zero so a broken monitor is visible, not silently green.
+    stderr("verify-environment-routing: unexpected error");
+    stderr(err instanceof Error ? (err.stack ?? err.message) : String(err));
+    process.exit(1);
+  });
+}
+
+export { parseArgs, selectMatrix };

--- a/packages/scripts/cloud/verify-environment-routing.mjs
+++ b/packages/scripts/cloud/verify-environment-routing.mjs
@@ -1,0 +1,278 @@
+/**
+ * Cross-environment routing verifier for the Cloudflare surfaces.
+ *
+ * Regression guard for "staging is pointing at prod CF": the staging API Worker
+ * (`eliza-cloud-api-staging`) owns `staging.*` / `app-staging.*` / `api-staging.*`
+ * ONLY by claiming those hostnames MORE specifically than the prod Worker's
+ * `*.elizacloud.ai/*` wildcard (see `packages/cloud/api/wrangler.toml`
+ * `[env.staging].routes`). The same split exists at the Pages layer: the staging
+ * SPA deployments bake `API_UPSTREAM=api-staging.elizacloud.ai` while prod bakes
+ * `api.elizacloud.ai`. If EITHER claim lapses - a dropped staging Worker route,
+ * a Pages custom-domain reattached to the wrong deployment, a preview var that
+ * drifted to prod - a staging subdomain silently starts serving production. The
+ * failure is invisible from the repo (it is Cloudflare dashboard / route state,
+ * not code) and invisible from a single-origin health check (each origin is
+ * individually "up"). The only way to catch it is to ask each live custom domain
+ * "which environment answered you?" and assert it matches the domain's intent.
+ *
+ * That answer is the `environment` field on `/api/health`
+ * (`packages/cloud/api/src/index.ts` `healthResponse`). This module is the pure
+ * decision core (matrix + per-probe classification + aggregate verdict); the I/O
+ * lives in `verify-environment-routing-cli.mjs`.
+ *
+ * FAIL-CLOSED, unlike the deploy freshness guard: this is a monitor, not a
+ * deploy gate, so a definitive cross-wire (a staging domain answering
+ * "production", or vice-versa) is a hard failure. Transient/rollout states
+ * (unreachable origin, a build predating the beacon) are configurable so the
+ * check can be strict in steady state without red-flagging during a rollout.
+ */
+
+export const ENVIRONMENT_ROUTING_SCHEMA = "elizaos.cloud.env-routing/v1";
+
+export const KNOWN_ENVIRONMENTS = /** @type {const} */ ([
+  "staging",
+  "production",
+]);
+
+/**
+ * The source-of-truth mapping of each live custom domain to the environment
+ * that MUST answer it. Kept in lockstep with `packages/cloud/api/wrangler.toml`
+ * (`[env.staging].routes` + `[env.production].routes`) - the wrangler-sync unit
+ * test fails if a staging host is added to the Worker routes without being
+ * represented here. Only hostnames that serve `/api/health` belong here
+ * (blob-staging.* serves R2 objects, not the API - it is intentionally omitted).
+ *
+ * @type {ReadonlyArray<{ domain: string, environment: "staging" | "production" }>}
+ */
+export const ENVIRONMENT_ROUTING = [
+  // Production: the prod Worker (`*.elizacloud.ai/*` wildcard + explicit
+  // api./x402.) and the prod Pages deployments (app.elizacloud.ai apex + subdomain).
+  { domain: "elizacloud.ai", environment: "production" },
+  { domain: "app.elizacloud.ai", environment: "production" },
+  { domain: "api.elizacloud.ai", environment: "production" },
+  // Staging: MUST be reclaimed from the prod wildcard by the staging Worker's
+  // more-specific routes and the staging Pages deployments.
+  { domain: "staging.elizacloud.ai", environment: "staging" },
+  { domain: "app-staging.elizacloud.ai", environment: "staging" },
+  { domain: "api-staging.elizacloud.ai", environment: "staging" },
+];
+
+/**
+ * @typedef {"ok" | "misrouted" | "unexpected_env" | "beacon_missing" | "unreachable"} ProbeStatus
+ * @typedef {object} ProbeInput
+ * @property {string} domain
+ * @property {"staging" | "production"} expected
+ * @property {string|null} observed   environment reported by /api/health, or null
+ * @property {boolean} reachable      whether /api/health returned a usable 200/JSON
+ * @property {string} [detail]        raw diagnostic (http code, error text)
+ * @typedef {object} ProbeResult
+ * @property {string} domain
+ * @property {"staging" | "production"} expected
+ * @property {string|null} observed
+ * @property {ProbeStatus} status
+ * @property {string} message
+ */
+
+/**
+ * Extract the `environment` field from a fetched `/api/health` body. Returns the
+ * trimmed string, or null when absent/blank/unparseable (SPA index.html
+ * fallthrough, an old build without the beacon, a non-JSON error page).
+ *
+ * @param {string|null|undefined} body raw response body text
+ * @returns {string|null}
+ */
+export function parseServedEnvironment(body) {
+  if (typeof body !== "string" || !body.trim()) return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    // error-policy:J3 untrusted-input sanitizing - old/incorrect deployments
+    // may answer the health URL with HTML or a non-JSON error body.
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const environment = /** @type {{ environment?: unknown }} */ (parsed)
+    .environment;
+  if (typeof environment !== "string" || !environment.trim()) return null;
+  return environment.trim();
+}
+
+/**
+ * Classify a single probe. Pure: the network result is passed in.
+ *
+ * @param {ProbeInput} input
+ * @returns {ProbeResult}
+ */
+export function classifyProbe({
+  domain,
+  expected,
+  observed,
+  reachable,
+  detail,
+}) {
+  const normalizedObserved =
+    typeof observed === "string" && observed.trim() ? observed.trim() : null;
+  const base = { domain, expected, observed: normalizedObserved };
+  const suffix = detail ? ` (${detail})` : "";
+
+  if (!reachable) {
+    return {
+      ...base,
+      status: "unreachable",
+      message: `${domain}: /api/health unreachable or non-JSON${suffix}.`,
+    };
+  }
+
+  if (!normalizedObserved) {
+    return {
+      ...base,
+      status: "beacon_missing",
+      message: `${domain}: /api/health answered but reported no environment (build predates the beacon)${suffix}.`,
+    };
+  }
+
+  if (normalizedObserved === expected) {
+    return {
+      ...base,
+      status: "ok",
+      message: `${domain}: served by ${expected}`,
+    };
+  }
+
+  // Answered with a DIFFERENT, KNOWN environment: a genuine cross-wire. This
+  // domain is being served by the wrong environment. THE regression.
+  if (KNOWN_ENVIRONMENTS.includes(/** @type {never} */ (normalizedObserved))) {
+    return {
+      ...base,
+      status: "misrouted",
+      message: `${domain}: MISROUTED - expected ${expected} but ${normalizedObserved} answered. A ${expected} domain is being served by the ${normalizedObserved} environment.`,
+    };
+  }
+
+  // Answered with an unrecognized environment string: a misconfigured
+  // ENVIRONMENT var, not a known cross-wire. Surfaced, not fatal by default.
+  return {
+    ...base,
+    status: "unexpected_env",
+    message: `${domain}: unexpected environment "${normalizedObserved}" (expected ${expected}).`,
+  };
+}
+
+/**
+ * Aggregate per-probe results into a pass/fail verdict.
+ *
+ * `misrouted` is ALWAYS a failure - it is the exact regression this guard
+ * exists to catch. `unexpected_env` is always a failure too (the env var is set
+ * to something the system does not recognize). `beacon_missing` and
+ * `unreachable` are failures only when their respective flags demand it, so the
+ * monitor can be strict in steady state yet tolerant during a beacon rollout or
+ * a transient origin blip.
+ *
+ * @param {object} args
+ * @param {ProbeResult[]} args.probes
+ * @param {boolean} [args.requireBeacon]     beacon_missing -> failure
+ * @param {boolean} [args.requireReachable]  unreachable -> failure (default true)
+ * @returns {{ ok: boolean, probes: ProbeResult[], failures: ProbeResult[], warnings: ProbeResult[], summary: string }}
+ */
+export function decideRoutingVerdict({
+  probes,
+  requireBeacon = false,
+  requireReachable = true,
+}) {
+  const list = Array.isArray(probes) ? probes : [];
+  /** @type {(p: ProbeResult) => boolean} */
+  const isFailure = (p) =>
+    p.status === "misrouted" ||
+    p.status === "unexpected_env" ||
+    (p.status === "beacon_missing" && requireBeacon) ||
+    (p.status === "unreachable" && requireReachable);
+
+  const failures = list.filter(isFailure);
+  const warnings = list.filter((p) => p.status !== "ok" && !isFailure(p));
+  const ok = failures.length === 0;
+
+  const counts = list.reduce(
+    /** @param {Record<string, number>} acc */ (acc, p) => {
+      acc[p.status] = (acc[p.status] ?? 0) + 1;
+      return acc;
+    },
+    {},
+  );
+  const countStr = Object.entries(counts)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(" ");
+  const summary = ok
+    ? `All ${list.length} domains routed correctly (${countStr}).`
+    : `${failures.length}/${list.length} domain(s) FAILED routing verification (${countStr}).`;
+
+  return { ok, probes: list, failures, warnings, summary };
+}
+
+/**
+ * Fetch `/api/health` for one base URL and return the observed environment plus
+ * reachability. Retries transient failures (the domains are always-up prod /
+ * staging origins, so a persistent failure is meaningful; a single blip is not).
+ *
+ * @param {string} domain hostname, e.g. "app-staging.elizacloud.ai"
+ * @param {object} [opts]
+ * @param {typeof fetch} [opts.fetchImpl]
+ * @param {string} [opts.healthPath]
+ * @param {number} [opts.timeoutMs]
+ * @param {number} [opts.attempts]
+ * @param {(ms: number) => Promise<void>} [opts.sleep]
+ * @returns {Promise<{ observed: string|null, reachable: boolean, detail: string }>}
+ */
+export async function fetchServedEnvironment(
+  domain,
+  {
+    fetchImpl = fetch,
+    healthPath = "/api/health",
+    timeoutMs = 20000,
+    attempts = 4,
+    sleep = (ms) => new Promise((r) => setTimeout(r, ms)),
+  } = {},
+) {
+  if (typeof domain !== "string" || !domain.trim()) {
+    return { observed: null, reachable: false, detail: "blank domain" };
+  }
+  const path = healthPath.startsWith("/") ? healthPath : `/${healthPath}`;
+  const url = `https://${domain.trim().replace(/\/+$/, "")}${path}`;
+  let lastDetail = "no attempts";
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const controller =
+      typeof AbortController !== "undefined" ? new AbortController() : null;
+    const timer = controller
+      ? setTimeout(() => controller.abort(), timeoutMs)
+      : null;
+    try {
+      const res = await fetchImpl(url, {
+        // Never accept a CDN/edge-cached copy; we need who is answering NOW.
+        headers: { "cache-control": "no-cache" },
+        ...(controller ? { signal: controller.signal } : {}),
+      });
+      if (!res?.ok) {
+        lastDetail = `HTTP ${res?.status ?? "?"}`;
+      } else {
+        const body = await res.text();
+        const observed = parseServedEnvironment(body);
+        // A reachable 200 with valid JSON is a usable answer even if the beacon
+        // field is absent. That distinction (beacon_missing vs unreachable) is
+        // the classifier's job, so return reachable:true here.
+        return { observed, reachable: true, detail: `HTTP ${res.status}` };
+      }
+    } catch (err) {
+      // error-policy:J1 boundary translation - the network boundary reports a
+      // structured unreachable probe so the aggregate verifier can decide
+      // whether that is fatal for this run.
+      lastDetail =
+        err instanceof Error ? err.message : `fetch failed: ${String(err)}`;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+    if (attempt < attempts) await sleep(attempt * 3000);
+  }
+
+  return { observed: null, reachable: false, detail: lastDetail };
+}


### PR DESCRIPTION
## Why

App **staging was pointing at prod Cloudflare** (fixed manually in CF + a wrangler update). This adds CI that regression-tests that a staging surface is never served by the production environment (or vice-versa).

### Root cause this guards
The prod API Worker owns the `*.elizacloud.ai/*` **wildcard**; the staging Worker owns `staging.*` / `app-staging.*` / `api-staging.*` **only** by claiming those hosts more specifically (`packages/cloud/api/wrangler.toml` `[env.staging].routes`). The staging Pages deployments likewise bake `API_UPSTREAM=api-staging.elizacloud.ai`. If **either** claim lapses — a dropped Worker route, a Pages custom-domain remapped to the wrong deployment, a preview var drifted to prod — a staging subdomain silently starts serving production. The failure is **Cloudflare route/dashboard state**, so it is invisible from the repo and from any single-origin health check (each origin is individually "up").

## What

1. **Environment beacon** — `/api/health` now returns `environment` (`staging`|`production`), so a live probe can tell **which Worker actually answered** a given custom domain.
2. **`verify-environment-routing.mjs`** — pure matrix (domain → expected env) + per-domain classify + verdict. A staging domain answered by `production` (a *known* wrong env) is a **hard failure** — the exact regression. Tolerant of pre-beacon builds / transient blips via flags. Thin live-probe CLI + **29 deterministic tests**, incl. a wrangler-sync guard so the matrix can't drift from the staging Worker routes.
3. **`verify-cf-routing.yml`** — scheduled (every 6h) + `workflow_dispatch` monitor. No secrets, no install (pure-Node). Catches CF drift that **no code push caused** — which is how this bug manifested.
4. **`cloud-cf-deploy.yml`** — post-deploy `verify-routing` job confirms the just-deployed environment serves itself.

Once prod has promoted the beacon, set repo var `CF_ROUTING_REQUIRE_BEACON=true` to make a missing beacon fatal too (no code change).

## Evidence

**Unit tests (deterministic):**
```
29 pass / 0 fail — packages/scripts/__tests__/verify-environment-routing.test.ts
```

**Live probe against the real domains** (beacon not yet deployed → correctly classified `no-beacon`, proving reachability + classification end-to-end, no false misroute during rollout):
```
[no-beacon] elizacloud.ai / app.elizacloud.ai / api.elizacloud.ai
[no-beacon] staging.elizacloud.ai / app-staging.elizacloud.ai / api-staging.elizacloud.ai
PASS: All 6 domains routed correctly (beacon_missing=6).
```
Raw `/api/health` today (no `environment` field yet — this PR adds it):
```
{"status":"ok","timestamp":...,"region":"unknown","commit":"7e455ca6..."}   # api-staging
{"status":"ok","timestamp":...,"region":"unknown","commit":"376e02b2..."}   # api
```

`biome check` clean; `actionlint` clean (only baseline-style shellcheck info notes shared with the rest of the file).

N/A rows: no UI change (backend + CI only) → no screenshots/video; no model/agent path → no trajectories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
