### PR TITLE
fix(ui): eliminate onboarding first-paint layout shift (composer top->bottom jump, CLS 1.29->0.38)

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -5082,8 +5082,19 @@ export function ContinuousChatOverlay({
                 // scrolls) instead of pushing the panel off-screen. paddingTop
                 // insets the scroll viewport below the floating grabber while the
                 // header is hidden (0 once the header reveals at half+).
+                // Onboarding (firstRunOpen) mounts locked at the FULL detent and
+                // never drags, but the `threadHeight` MotionValue that feeds
+                // `threadFlexBasis` starts at 0, so the FIRST paint renders the
+                // thread at 0 height and the composer stacks at the top — then a
+                // post-commit effect grows it to `openH` and the composer drops a
+                // full viewport to the bottom (~0.9 CLS on the first frame a new
+                // user sees, #15214). During onboarding there is no drag to track,
+                // so pin the flex-basis to the settled open height statically at
+                // render time — first paint already matches the resting layout, no
+                // reflow. Reverts to the live MotionValue the moment onboarding
+                // ends and the sheet becomes interactive.
                 style={{
-                  flexBasis: threadFlexBasis,
+                  flexBasis: firstRunOpen ? `${openH}px` : threadFlexBasis,
                   paddingTop: threadGrabberClearance,
                 }}
               >


### PR DESCRIPTION
Fixes #15214.

## Symptom
The first frame a new user sees on first-run onboarding jumps hard. The app's own telemetry logs it: `[RenderTelemetry] layout shifted 3x (CLS 1.293) within 1000ms` (Web Vitals "good" is < 0.1).

Captured live (buffered `PerformanceObserver`, fresh first-run, viewport 775): the **composer bar** renders at `y=8` (top) on first paint, then jumps to `y=717` (bottom) — a full-viewport shift worth **0.915** on its own.

## Root cause
`ContinuousChatOverlay.tsx`: the thread container's `flexBasis` is the `threadFlexBasis` MotionValue (`threadHeight` as px), and `threadHeight = useMotionValue(0)`. So the **first paint always renders the thread at 0 height** — the composer stacks near the top — and a post-commit effect (`animateThreadHeight(baseH)`) then grows it to the open height, reflowing the composer to the bottom. (An effect-based `.set()` can't fix this: effects run post-commit, so the first paint is already at 0. Confirmed empirically — an instant-set attempt left CLS unchanged.)

## Fix
Onboarding (`firstRunOpen`) mounts locked at the FULL detent and never drags (drag handlers early-return on `firstRunOpen`), so there is no live height to track on the first paint. Pin the thread's `flex-basis` to the settled open height (`openH`, exactly what `threadHeight` animates to) **statically at render time** when `firstRunOpen` — first paint already matches the resting layout, nothing reflows. Reverts to the live MotionValue the instant onboarding ends; `threadHeight` has already settled to `openH` by then, so the swap is continuous (no jump on sign-in). The normal (non-onboarding) path is byte-identical (`firstRunOpen ? static : threadFlexBasis`).

## Evidence (verified live, localhost:2138)
Buffered layout-shift measurement, fresh first-run before/after:
- **before:** total CLS **1.293**; dominant shift **0.915** = composer `[y=8]→[y=717]`.
- **after:** total CLS **0.375**; the 0.915 composer shift is **gone**. Residual 0.375 = the launcher `home-enter` entrance animating BEHIND the opaque onboarding backdrop (not user-visible; noted for a separate pass).
- onboarding still renders correctly: greeting present, placeholder correct, single CTA. Screenshot below.

Scoped, render-time, `firstRunOpen`-only; `tsgo` typecheck clean.

— [maintainer]
