### PR TITLE
style(cloud): format client-tls.test.ts import — unbreak cloud lint-and-types

### DIFF
--- a/packages/cloud/shared/src/db/__tests__/client-tls.test.ts
+++ b/packages/cloud/shared/src/db/__tests__/client-tls.test.ts
@@ -1,6 +1,10 @@
 // Exercises cloud DB client tls behavior with deterministic repository fixtures.
 import { afterEach, describe, expect, test } from "bun:test";
-import { applyIdleSessionTimeouts, enforceTlsForRemote, shouldSkipTlsVerification } from "../client";
+import {
+  applyIdleSessionTimeouts,
+  enforceTlsForRemote,
+  shouldSkipTlsVerification,
+} from "../client";
 
 const PREV = process.env.DATABASE_SSL_NO_VERIFY;
 afterEach(() => {


### PR DESCRIPTION
## Summary

Develop's **Cloud Tests → lint-and-types** job is red at `7c1a521bfc8`: `@elizaos/cloud-shared#lint:check` fails on a single formatter finding in `src/db/__tests__/client-tls.test.ts` — the three-name import from `../client` must wrap multi-line. This applies `biome check --write` to that file; format-only, zero code-token changes.

## Root cause

The file re-landed in develop's history rewrite with a hand-collapsed import line that biome's printer rejects. No behavioral content involved.

## Local validation (full job preempted, not just the failing step)

- `bun run --cwd packages/cloud/shared lint:check` → `Checked 1568 files … No fixes applied` ✅
- `bun run verify:cloud` (all cloud lint + typecheck incl. the #14422 worker-bundle dry-run gate) → **85/85 tasks successful** ✅
- `bun run --cwd packages/cloud/shared check:tenant-scope` → `no unannotated pk-only reads across 91 repository file(s)` ✅

(The one local hiccup was missing `validation-keyword-data` codegen in a fresh worktree — regenerated via `packages/shared/scripts/generate-keywords.mjs`; CI's `cloud-setup-test-env` already does this, so it is not a CI concern.)

Evidence rows N/A — CI-gate formatting fix with no runtime surface; the proof is the green gate outputs above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)