### PR TITLE
fix(ci): stop the push-event skip cascade — stale-base-preflight no-op-succeeds on non-PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,17 @@ permissions:
 jobs:
   stale-base-preflight:
     name: PR stale-base preflight
-    if: github.event_name == 'pull_request'
+    # PR-only in EFFECT — every step gates on github.event_name ==
+    # 'pull_request' — but the JOB itself runs (and no-op-succeeds) on every
+    # event. It used to be job-level `if: github.event_name == 'pull_request'`,
+    # which SKIPPED it on push; because `changes` needs this job and GitHub
+    # evaluates the implicit success() over the TRANSITIVE needs chain
+    # (actions/runner#491), that one skipped ancestor silently skip-cascaded
+    # every push-event lane downstream of `changes` whose `if` carries no
+    # status-check function — develop push runs went vacuously red from the
+    # moment the needs edge landed. Step-level gating keeps the PR-only
+    # contract (ci-merge-gate-contract.mjs) and the `changes` ordering while
+    # letting push/schedule/dispatch fan-outs actually run.
     runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
     timeout-minutes: 10
     env:
@@ -57,6 +67,7 @@ jobs:
       ACK: ${{ contains(github.event.pull_request.labels.*.name, 'stale-base-ack') && '1' || '' }}
     steps:
       - name: Checkout target branch (guard logic comes from the base, not the PR)
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ github.event.pull_request.base.ref }}
@@ -68,11 +79,13 @@ jobs:
           submodules: false
 
       - name: Setup Node.js for stale-base guard
+        if: github.event_name == 'pull_request'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Fetch PR head + bounded history (blobless)
+        if: github.event_name == 'pull_request'
         run: |
           set -euo pipefail
           git fetch --quiet --no-tags --filter=blob:none --depth=1500 \
@@ -81,9 +94,11 @@ jobs:
             "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
 
       - name: Self-test the guard on fixture repos
+        if: github.event_name == 'pull_request'
         run: node packages/scripts/stale-base-guard.self-test.mjs
 
       - name: Detect silent reverts + stale base before fanning out tests
+        if: github.event_name == 'pull_request'
         env:
           GIT_NO_LAZY_FETCH: "1"
         run: |


### PR DESCRIPTION
## Root cause (with evidence)

Every `test.yml` push run on develop has been **vacuously red since Jun 18** — last green: `f30ec764bc` (run 27730400179), the tip before the `changes → stale-base-preflight` needs edge landed.

Causal chain, evidenced on run **28840056337** (develop tip `7c1a521bfc8`):

1. `stale-base-preflight` was job-gated `if: github.event_name == 'pull_request'` → on push it completes **skipped**.
2. `changes` (`needs: stale-base-preflight`, `if: always() && (…)`) overrides the skip and **succeeds** — outputs all set (job 85532031927, "Evaluate and set job outputs": server/client/plugins/desktop/zero_key/cloud).
3. Every lane downstream of `changes` carries either no `if` (vacuous-green guard) or an `if` **without a status-check function** (`github.event_name != 'pull_request' || needs.changes.outputs.X == 'true'`). GitHub injects the implicit `success()` into such conditions, and `success()` for jobs evaluates over the **transitive** needs chain (actions/runner#491) — the skipped preflight ancestor poisons it even though the direct parent succeeded.
4. Result on every push: Server/Client Tests, Plugin shards, all five Zero-Key slices, XR harness, Electrobun contract, Integration Lane, Cloud Live E2E, vacuous-green guard, and Merge Queue Quality Gate all complete **skipped in 0s with no runner assigned** (`runner_name: null`, `steps: 0` — API-verified), and the strict aggregators fail exactly as designed: `Plugin shard matrix finished with 'skipped'` (job 85532130593), `zero-key-* finished with skipped` ×5 (job 85532130634), then `ci-ok` fails.

At `f30ec764bc` (last green) `changes` had **no** `needs:` edge — confirmed by `git show f30ec764bc:.github/workflows/test.yml`.

## Fix

Kill the poison at its source instead of sprinkling `!cancelled()` over ~14 job conditions: `stale-base-preflight` now **runs on every event** and gates **every step** on `github.event_name == 'pull_request'`. On push it no-op-completes as `success`, so the transitive chain is clean and the fan-out actually runs; on PRs it does exactly the same work as before, and a guard failure still fails the job → `changes` skips → lanes skip → `ci-ok` red (unchanged).

Contract compatibility (this workflow's shape is machine-enforced):
- `ci-merge-gate-contract.mjs` requires the PR-only marker regex in the job body (still present, now at step level), the `changes` needs edge (kept), and the hosted-fallback `runs-on` (untouched).
- `ci-ok`'s `stale-base-preflight` skipped-on-non-PR carve-out simply never fires now; `success` passes the strict loop.

## Validation

- `ci-merge-gate-contract.mjs` (+ `--self-test`, 17 cases), `ci-workflow-dedup-contract.mjs`, `ci-turbo-cache-contract.mjs`, `ci-bun-version-contract.mjs`, `ci-zero-key-command-ownership-contract.mjs`, `ci-windows-command-coverage-contract.mjs`, `ci-path-gate.self-test.mjs` — **all pass** locally on the edited tree.
- `actionlint` on `.github/workflows/test.yml`: clean (exit 0).
- Runtime proof arrives with the next develop push run: the fan-out lanes must show real runners/steps instead of 0-second skips. Screenshots/video: N/A — workflow-graph fix, no UI surface; the run graph itself is the artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)