### PR TITLE
fix(os): track intentional app-shell drift in the ISO static-smoke branding gate

### DIFF
--- a/packages/os/linux/scripts/static-smoke.sh
+++ b/packages/os/linux/scripts/static-smoke.sh
@@ -242,19 +242,22 @@ fi
 # StartupShell is a SHARED app-shell component (@elizaos/ui), and the elizaOS OS
 # ISO bundles it verbatim — there is no downstream OS theme override for the
 # boot splash. Per the per-surface accent system, the *app* surface owns the
-# splash and it uses the launch token with the current home-shader fallback
-# (#ef5a1f). OS chrome such as the greeter/dashboard metadata/failure shell
-# stays on the blue/white palette; first-run stays inside the launch surface.
-# So this gate asserts the splash's current intentional launch token and the
-# neutral bootstrap-gate surface, and only rejects the genuinely-stale
-# dark/gradient/glow styling from the pre-redesign shell.
+# splash and it uses the launch token whose current intentional fallback is
+# #000000 — the home shader's black base field, so boot flows seamlessly into
+# the home ember glow (#9565). OS chrome such as the greeter/dashboard
+# metadata/failure shell stays on the blue/white palette; first-run stays
+# inside the launch surface. So this gate asserts the splash's current
+# intentional launch token and the neutral bootstrap-gate surface, and only
+# rejects the genuinely-stale hardcoded dark/gradient/glow styling from the
+# pre-redesign shell (the token fallback is a host-overridable seam, not a
+# hardcoded surface).
 if rg -n 'bg-\[#08080a\]|bg-\[#0a0a0a\]|radial-gradient|blur-\[' \
     "${REPO_ROOT}/packages/ui/src/components/shell/StartupShell.tsx"
 then
     echo "Startup shell must not reintroduce the old dark/gradient splash." >&2
     exit 1
 fi
-grep -Fq 'bg-[var(--launch-bg,#ef5a1f)]' \
+grep -Fq 'bg-[var(--launch-bg,#000000)]' \
     "${REPO_ROOT}/packages/ui/src/components/shell/StartupShell.tsx"
 grep -q 'bg-\[#F7F6F4\]' \
     "${REPO_ROOT}/packages/ui/src/components/shell/StartupShell.tsx"
@@ -272,11 +275,13 @@ grep -q 'text-destructive' \
     "${REPO_ROOT}/packages/ui/src/components/shell/StartupFailureView.tsx"
 # First-run onboarding now renders inline in the real floating chat overlay:
 # #10302 deleted the dedicated FirstRunChat.tsx surface and seeds the onboarding
-# greeting/choices as the same inline widgets the live chat uses. Gate that
-# overlay against the stale dark/gradient/glow styling from the pre-redesign
-# first-run shell (mirrors the #10167 repoint when CompactOnboarding was removed).
+# greeting/choices as the same inline widgets the live chat uses. The overlay's
+# text runs on the `text-txt` THEME token (hardcoded `text-white` literals were
+# retokenized so the surface follows the active theme). Gate that overlay
+# against the stale dark/gradient/glow styling from the pre-redesign first-run
+# shell (mirrors the #10167 repoint when CompactOnboarding was removed).
 first_run_shell="${REPO_ROOT}/packages/ui/src/components/shell/ContinuousChatOverlay.tsx"
-grep -q 'text-white' "${first_run_shell}"
+grep -q 'text-txt' "${first_run_shell}"
 if rg -n 'bg-\[#08080a\]|bg-\[#0a0a0a\]|radial-gradient|blur-\[' \
     "${first_run_shell}"
 then


### PR DESCRIPTION
## Summary

"Build elizaOS Linux ISO" (nightly, both arches) has been failing at the `static-smoke.sh` branding gate — silently, since the script is a `set -e` assertion chain. Local xtrace repro pinpointed two assertions that went stale under intentional app-shell changes:

1. **StartupShell launch token**: the gate asserted `bg-[var(--launch-bg,#ef5a1f)]`, but `e1b9f3f1cbe` ("black boot/launch baseline") intentionally moved the splash fallback to `bg-[var(--launch-bg,#000000)]` — the black home-shader base field (#9565), documented in the component itself.
2. **First-run overlay text**: the gate demanded a literal `text-white` in `ContinuousChatOverlay.tsx`, but `d261810ba7a` retokenized those literals to the `text-txt` theme token (count of `text-white` in the file is now 0).

The gate now asserts the current intentional tokens; the genuinely-protective stale-dark rejection patterns (`bg-[#08080a]`, gradients, glows) are untouched.

## Diagnosis notes

- Nightly has been red ≥10 consecutive days (schedule runs across many SHAs) — this predates today's develop breakage.
- amd64's job log dies at `==> elizaOS branding`; arm64's log cuts at `==> shell syntax`, but no command in that window is arch-dependent (file checks, `bash -n`, `node --check`, `python3 json.tool`) — consistent with GH runner stdout loss at abrupt exit rather than a distinct arm64 failure. The dispatch run below is the cross-arch proof.

## Verification

Full gate run locally (x86_64, static ripgrep 14.1.1, `ELIZAOS_STATIC_SOURCE_ONLY=1 ./scripts/static-smoke.sh`):

```
==> shell syntax
build.sh Docker cache contract OK
==> elizaOS branding
==> desktop entries
==> elizaOS launch policy
==> elizaOS privacy fail-closed
==> elizaOS persistence contract
==> filesystem modes
==> elizaOS package exports
==> XML
==> Python compile
==> diff whitespace
static smoke passed   (exit 0)
```

Before the fix the same run exits 1 at the `#ef5a1f` grep (and, once past it, at the `text-white` grep). A `workflow_dispatch` of Build elizaOS Linux ISO will be triggered after merge to confirm both arches end-to-end.

- Frontend evidence: N/A — CI gate script only; no runtime surface changed.
- Real-LLM trajectories: N/A — no agent behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)