### PR TITLE
fix(ui): green the determinism + gesture-coverage gates for the inline notification center

### DIFF
--- a/packages/app/docs/CHAT_GESTURE_COVERAGE.md
+++ b/packages/app/docs/CHAT_GESTURE_COVERAGE.md
@@ -84,16 +84,17 @@ gate's `sites`). `Coverage` = the levels with a real test today.
 | 15 | Graph pan/pinch/wheel-zoom | RelationshipsGraphPanel | `RelationshipsGraphPanel.tsx` | **gap** — L3 planned (app-side `touchPinch`/`touchPan`) |
 | 16 | Slash menu open/dismiss (incl. outside pointerdown) | composer | _composer_ | L2 `ContinuousChatOverlay.slash.test.tsx` + `composer-core.test.tsx` + `MessageContent.slash-command.test.tsx` |
 | 17 | Pinch/dblclick on chat surface (should NOT zoom/break layout) | overlay | `ContinuousChatOverlay.tsx` | **gap** — L3 negative test planned |
+| 18 | Notification row swipe-dismiss / long-press menu; shade pull-expand | home notification center | `NotificationsHomeCenter.tsx` | L2 `NotificationsHomeCenter.test.tsx`; L3 `gesture-matrix.spec.ts` (list-pan + row-swipe legs) |
 
 Notifications live in `NotificationsHomeCenter`, a widget pinned on the home
-dashboard — not behind a pull gesture. Its rows are plain buttons and its list
-a native scroll container — no gesture-handler site — so it is covered by
-`NotificationsHomeCenter.test.tsx` (jsdom) and `gesture-matrix.spec.ts` (booted
-app) rather than a row here.
+dashboard. Since the inline-inbox rework (#15180) it is a real gesture site:
+rows are pointer-captured swipe-to-dismiss surfaces with a long-press menu, and
+the shade expands via a touch pan at the list top (desktop: wheel pull) — row
+18 governs it.
 
 ## Coverage gaps
 
-Every one of the 12 discovered gesture-handler sites is in a matrix row (the
+Every one of the 13 discovered gesture-handler sites is in a matrix row (the
 gate proves it). Two rows are honest **gaps** with no automated test yet:
 
 - **Row 15 (graph pan/pinch/wheel-zoom)** — `RelationshipsGraphPanel.tsx` has no

--- a/packages/app/test/chat-gesture-coverage.test.ts
+++ b/packages/app/test/chat-gesture-coverage.test.ts
@@ -94,7 +94,7 @@ function discoverGestureSites(): string[] {
 }
 
 interface GestureRow {
-  /** Matrix row number (1–17), matching docs/CHAT_GESTURE_COVERAGE.md. */
+  /** Matrix row number (1–18), matching docs/CHAT_GESTURE_COVERAGE.md. */
   id: number;
   /** The interaction under test. */
   interaction: string;
@@ -273,6 +273,19 @@ const CHAT_GESTURE_MATRIX: readonly GestureRow[] = [
     sites: [OVERLAY],
     tests: [],
   },
+  {
+    id: 18,
+    // The inline home notification center (#15180) carries real gestures:
+    // pointer-captured row swipe-to-dismiss, long-press row menu, and the
+    // shade pull-expand (touch pan at list top + desktop wheel pull).
+    interaction:
+      "Notification row swipe-dismiss / long-press menu; shade pull-expand",
+    sites: [S("components/shell/NotificationsHomeCenter.tsx")],
+    tests: [
+      S("components/shell/NotificationsHomeCenter.test.tsx"),
+      GESTURE_MATRIX_SPEC,
+    ],
+  },
 ];
 
 function rosteredSites(): Set<string> {
@@ -293,6 +306,7 @@ const PINNED_GESTURE_SITES: readonly string[] = [
   "packages/ui/src/components/shell/ContinuousChatOverlay.tsx",
   "packages/ui/src/components/shell/HomeLauncherSurface.tsx",
   "packages/ui/src/components/shell/KioskViewCanvas.tsx",
+  "packages/ui/src/components/shell/NotificationsHomeCenter.tsx",
   "packages/ui/src/components/shell/TopicGroup.tsx",
   "packages/ui/src/components/shell/use-pull-gesture.ts",
   "packages/ui/src/gestures/usePressAndHold.ts",

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -765,6 +765,32 @@ export function NotificationsHomeCenter(): React.JSX.Element | null {
     }
   }, [notifications.length]);
 
+  // useCallback keeps the clock read inside a deferred (handler) context for
+  // the UI-determinism gate — the wheel handler only ever runs on user input,
+  // never during render — and gives the scroller a stable handler identity.
+  // Hook placement: MUST stay above the empty-inbox early return below.
+  const onListWheel = useCallback(
+    (e: React.WheelEvent) => {
+      const el = scrollRef.current;
+      if (!el || !canExpandRef.current) return;
+      const now = Date.now();
+      if (now < wheelCooldownUntil.current) return;
+      // Wheel-up while the list already sits at its top is the desktop pull.
+      if (el.scrollTop > 0 || e.deltaY >= 0) {
+        wheelPull.current = 0;
+        return;
+      }
+      wheelPull.current += -e.deltaY;
+      if (wheelPull.current >= PULL_COMMIT_PX) {
+        wheelPull.current = 0;
+        // Swallow trailing momentum so one flick doesn't double-toggle.
+        wheelCooldownUntil.current = now + 500;
+        toggleShade();
+      }
+    },
+    [toggleShade],
+  );
+
   if (notifications.length === 0) return null;
 
   // Cap rendered rows, filter to the rested (interrupt-tier) slice unless
@@ -814,25 +840,6 @@ export function NotificationsHomeCenter(): React.JSX.Element | null {
     pointerPull.current = null;
     commitPull();
   };
-  const onListWheel = (e: React.WheelEvent) => {
-    const el = scrollRef.current;
-    if (!el || !canExpandRef.current) return;
-    const now = Date.now();
-    if (now < wheelCooldownUntil.current) return;
-    // Wheel-up while the list already sits at its top is the desktop pull.
-    if (el.scrollTop > 0 || e.deltaY >= 0) {
-      wheelPull.current = 0;
-      return;
-    }
-    wheelPull.current += -e.deltaY;
-    if (wheelPull.current >= PULL_COMMIT_PX) {
-      wheelPull.current = 0;
-      // Swallow trailing momentum so one flick doesn't double-toggle.
-      wheelCooldownUntil.current = now + 500;
-      toggleShade();
-    }
-  };
-
   return (
     <section
       aria-label="Notifications"


### PR DESCRIPTION
## Summary

Two of the develop-red CI jobs at `7c1a521bfc8` trace to the #15180 inline-notification-inbox re-land; this greens both gates:

1. **Quality (Extended) → Develop Gate**: `audit-ui-determinism` flagged 1 NEW render-time nondeterminism — `NotificationsHomeCenter.tsx` L820 `Date.now()`. The call lives in the desktop wheel-pull handler, which only ever runs on user input, but it was declared as a plain component-body arrow, which the auditor's AST classifier counts as render-time. Fix: wrap `onListWheel` in `useCallback` (a recognized deferred context) — honest semantics (stable handler identity for the scroller), not a baseline bump. Placed above the empty-inbox early return; the first draft below it broke rules-of-hooks and 4 component tests caught it ("Rendered fewer hooks than expected"), which is exactly why the final placement is where it is.

2. **Chat shell gestures → coverage gate**: the component is now a real gesture-handler site (pointer-captured row swipe-dismiss, long-press row menu, touch-pan/wheel shade pull) but had no `CHAT_GESTURE_MATRIX` row (13 discovered sites vs 12 rostered). Added row 18 (`sites`: NotificationsHomeCenter.tsx; `tests`: its L2 jsdom suite + the L3 `gesture-matrix.spec.ts` list-pan/row-swipe legs), the pinned-roster entry, the doc table row, and replaced the doc's stale "no gesture-handler site" paragraph.

## Local validation (all on this branch)

```
node packages/scripts/audit-ui-determinism.mjs
→ render-time=43 deferred=148 module=263 … OK PASSED (was render-time=44 FAIL on develop)

packages/app: vitest test/chat-gesture-coverage.test.ts → 5 passed (was 2 failed)
packages/ui: vitest NotificationsHomeCenter.test.tsx → 48 passed (48) (parity with pristine develop)
biome check (3 touched files) → clean
packages/ui typecheck → clean
error-policy-ratchet → no new fallback-slop
```

Screenshots: N/A — CI-gate repair; no rendered-pixel change (handler wrap + test/doc roster).

🤖 Generated with [Claude Code](https://claude.com/claude-code)