### PR TITLE
fix(ci): stub /api/location/approximate + notification POST in ui-smoke routes

### DIFF
--- a/packages/app/test/ui-smoke/helpers.ts
+++ b/packages/app/test/ui-smoke/helpers.ts
@@ -1849,6 +1849,28 @@ export async function installDefaultAppRoutes(page: Page): Promise<void> {
     });
   });
 
+  // Weather IP-fallback coordinates (useWeather → GET /api/location/approximate,
+  // #15183): fires on every home load when geolocation permission is absent —
+  // always, in this harness. The zero-key smoke stack returns 501, which the
+  // diagnostics guard flags. Serve the same San Francisco fixture coords as the
+  // ipapi stub above so the widget proceeds into the stubbed Open-Meteo reading.
+  await page.route("**/api/location/approximate", async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        lat: 37.7749,
+        lon: -122.4194,
+        accuracyMeters: 5000,
+        source: "fixture",
+      }),
+    });
+  });
+
   await page.route("**/api/health", async (route) => {
     await route.fulfill({
       status: 200,
@@ -1946,8 +1968,31 @@ export async function installDefaultAppRoutes(page: Page): Promise<void> {
   // Notifications poller — another shell-level GET on every surface. The zero-key
   // smoke stack returns 501 for it; a fresh agent simply has no notifications, so
   // an empty list matches real zero-state and keeps the diagnostics guard clean.
+  // POST to the collection is the weather approximate-location notice (useWeather
+  // files it once right after the IP-fallback coords resolve, #15183) — accept it
+  // with the canonical created shape so the once-flag settles and the 501 stack
+  // never sees it; every other method/subpath still falls through.
   await page.route("**/api/notifications**", async (route) => {
-    if (route.request().method() !== "GET") {
+    const method = route.request().method();
+    const pathname = new URL(route.request().url()).pathname;
+    if (method === "POST" && pathname === "/api/notifications") {
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({
+          notification: {
+            id: "smoke-notification-1",
+            title: "smoke",
+            category: "system",
+            priority: "low",
+            createdAt: Date.parse(SMOKE_GENERATED_AT),
+            readAt: null,
+          },
+        }),
+      });
+      return;
+    }
+    if (method !== "GET") {
       await route.fallback();
       return;
     }


### PR DESCRIPTION
## Summary

Repairs the develop-red **Scenario PR E2E → Zero-Key app browser Pixel-7 real-touch lane** (run 28840056340, job 85534743883): the weather IP-fallback (#15183) fires `GET /api/location/approximate` on every home load in the ui-smoke harness (geolocation is never granted there), the zero-key smoke stack answers **501**, and the zero-diagnostics gate flags `http.501` + the browser's automatic `console.error` on every mobile-chromium spec that touches the home surface.

Two additions to `installDefaultAppRoutes` (the lane's single stub table, same idiom as the neighbouring stubs):
- `GET /api/location/approximate` → 200 with the same San Francisco fixture coords as the adjacent ipapi stub, so the widget proceeds into the already-stubbed Open-Meteo reading (deterministic `68°F Mostly clear`).
- `POST /api/notifications` (collection, exact path) → 201 canonical created shape — the approximate path files its once-per-browser notice immediately after coords resolve, and that POST previously fell through to the 501 stack. Every other method/subpath still falls through unchanged.

Swept the other harnesses: the packages/ui home-screen fixture stubs the client module (no `client.fetch`), so the weather call lands in the designed unavailable tile with zero diagnostics — no change needed; the accounts-ui e2e runs the real server whose route exists.

## Before/after (local, mobile-chromium, exact CI runner command)

`chat-clear-swipe.spec.ts` — before: **3 failed** (2 × 501-diagnostics on the grabber-swipe tests, 4 log mentions of the route); after: **2 passed, 1 failed**, `api/location/approximate` mentions: **0**. Fixture screenshot confirms the tile renders the stubbed 68°F reading.

`gesture-matrix.spec.ts` — after: `api/location/approximate` mentions: **0**; remaining failures are behavioral `toHaveCount` assertions (launcher long-press ghost-launch, notification-list touch gestures) with distinct root causes, tracked in the sibling CI-repair lanes. Also out of this lane: `chat-full-search` missing from the half-open sheet header (`chat-clear-swipe` #3) — pre-existing on develop.

Frontend video/screenshot rows: N/A — test-harness-only change (no product surface altered); the harness's own failure screenshots above are the rendered proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)