### PR TITLE
fix(os): name the dying assertion when the ISO static-smoke gate fails

### DIFF
--- a/packages/os/linux/scripts/static-smoke.sh
+++ b/packages/os/linux/scripts/static-smoke.sh
@@ -3,6 +3,11 @@
 
 set -euo pipefail
 
+# This gate is a long `set -e` assertion chain of silent test/grep commands, so
+# an unannotated failure exits with no output at all — that silence hid a red
+# nightly for over a week. Name the dying assertion on the way out.
+trap 'echo "static-smoke: FAILED at ${BASH_SOURCE[0]}:${LINENO}: ${BASH_COMMAND}" >&2' ERR
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REPO_ROOT="$(cd "${ROOT}/../../.." && pwd)"
 SOURCE_ONLY="${ELIZAOS_STATIC_SOURCE_ONLY:-0}"


### PR DESCRIPTION
## Summary

Follow-up to #15223. The ISO gate (`packages/os/linux/scripts/static-smoke.sh`) is a long `set -e` chain of silent `test`/`grep` assertions — any failure exits with **no output**. That silence hid a red nightly for 10+ days, and in verification run 28841942879 it still hides the arm64 leg's failing line (amd64's gate step went green with #15223; arm64's failed ~150ms after `==> shell syntax` with nothing printed).

An `ERR` trap now reports `file:line: command` on the way out, so the next arm64 run names its exact failing assertion instead of a bare exit 1.

## Verification

- Full local green run unaffected: `ELIZAOS_STATIC_SOURCE_ONLY=1 ./scripts/static-smoke.sh` → all sections + `static smoke passed`, exit 0 (trap emits nothing on success).
- A `workflow_dispatch` of Build elizaOS Linux ISO follows this merge to capture the arm64 failing line.

Frontend/trajectory evidence: N/A — CI gate diagnostics only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)