### PR TITLE
fix(ui): stop 'Backend Unreachable' crash card while a dedicated cloud agent is starting

### DIFF
--- a/packages/ui/src/state/startup-phase-poll.test.ts
+++ b/packages/ui/src/state/startup-phase-poll.test.ts
@@ -1243,6 +1243,19 @@ describe("shouldFallBackToLocalOrigin", () => {
       shouldFallBackToLocalOrigin({ ...eligible, pageProtocol: "views:" }),
     ).toBe(false);
   });
+
+  it("does NOT abandon a dedicated cloud agent base for the page origin (the crash-card trigger)", () => {
+    // A connection failure to <id>.elizacloud.ai means the agent is starting /
+    // transiently unreachable — keep polling IT, never repoint at
+    // app.elizacloud.ai (which serves no /api and 404s → "Backend Unreachable").
+    expect(
+      shouldFallBackToLocalOrigin({
+        ...eligible,
+        clientBaseUrl:
+          "https://23766030-c096-4a14-932a-a4e43c562432.elizacloud.ai",
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("runPollingBackend cancellation during options fetch", () => {

--- a/packages/ui/src/state/startup-phase-poll.ts
+++ b/packages/ui/src/state/startup-phase-poll.ts
@@ -165,6 +165,14 @@ export function shouldFallBackToLocalOrigin(args: {
 }): boolean {
   // A structured HTTP status means the server responded — not a wedge.
   if (typeof asApiLikeError(args.error)?.status === "number") return false;
+  // NEVER abandon a dedicated cloud agent base (<id>.elizacloud.ai) for the
+  // page origin. A connection-level failure there means the agent is still
+  // starting / transiently unreachable — the correct move is to keep polling
+  // IT, not repoint at app.elizacloud.ai, which serves no backend. That
+  // repoint is the actual trigger of the "Backend Unreachable / Backend API
+  // routes are unavailable on this origin (404)" crash card: once the base is
+  // the app origin, the next /api/first-run/status 404s and dead-ends startup.
+  if (isDedicatedCloudAgentBase(args.clientBaseUrl)) return false;
   return isRecoverableRemoteBase(args);
 }
 


### PR DESCRIPTION
nubs repeatedly hit a dev crash card ('Startup failed: Backend Unreachable / Backend API routes are unavailable on this origin (received 404)') on app.elizacloud.ai whenever his cloud agent was just starting (~40-90s cold boot) or transiently unreachable.

## Root cause (ultracode workflow)
`shouldFallBackToLocalOrigin` treated a connection-level failure against `<id>.elizacloud.ai` as grounds to **repoint the client at the page origin** (app.elizacloud.ai). The app origin serves no backend → the next `/api/first-run/status` 404s → startup dead-ends at the crash card. The dedicated-agent 404 branches themselves were fine; this repoint was the actual trigger chain.

## Fix
`shouldFallBackToLocalOrigin` returns `false` for a dedicated cloud agent base — the poller keeps probing the agent until it comes up, instead of abandoning it for an origin with no backend. Minimal, surgical; the fuller graceful 'agent starting…' waiting-UI (new StartupWaitingState) is a documented follow-up.

## Verification
- `startup-phase-poll` suite **48/48** incl. new regression: a dedicated cloud base with a connection error does not fall back.
- Live context: this exact card appeared during tonight's prod incident (agent crash-loop, filed #15228); with the agent now healthy the card is gone, and this makes the transient case never dead-end.

## Evidence
- <!-- evidence-row:before-screenshots --> **Before:** nubs's 'Backend Unreachable' captures in HQ #14308 / #15228.
- <!-- evidence-row:after-screenshots --> **After:** N/A — poll-logic change; the crash-card no longer triggers for a starting agent (unit-locked). Rendered staging capture to follow.
- <!-- evidence-row:walkthrough-video --> **Walkthrough:** N/A — no new UI surface; behavior locked by test.
- <!-- evidence-row:backend-logs --> **Backend logs:** N/A — client-only.
- <!-- evidence-row:frontend-logs --> **Frontend logs:** the fall-back decision is unit-tested across the dedicated-base + connection-error matrix.
- <!-- evidence-row:llm-trajectory --> **Real-LLM trajectory:** N/A.
- <!-- evidence-row:domain-artifacts --> **Domain artifacts:** 48/48 suite; the P0 root-cause (crash-loop) is #15228.

— [qa-agent]