### PR TITLE
fix(os): arch-parametric cache contract + install bun for the ISO in-CI app build

### DIFF
--- a/.github/workflows/build-linux-iso.yml
+++ b/.github/workflows/build-linux-iso.yml
@@ -108,6 +108,17 @@ jobs:
         # line. Install it explicitly here so the smoke check can run.
         run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends just ripgrep
 
+      - name: Setup Bun
+        # `just build` depends on `just elizaos-app`, whose ELIZAOS_BUILD_APP=1
+        # in-CI path bootstraps the workspace and compiles the Electrobun
+        # desktop artifact with bun. The runner image ships no bun, so the
+        # recipe died with `bun: command not found` (exit 127) the moment the
+        # static-smoke gate stopped masking it. Same pinned action + version
+        # the test workflows use.
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: "1.3.14"
+
       - name: Register qemu-user-static binfmt (non-amd64 only)
         if: matrix.arch != 'amd64'
         # tonistiigi/binfmt is the canonical container image for registering

--- a/packages/os/linux/scripts/build-cache-contract.test.sh
+++ b/packages/os/linux/scripts/build-cache-contract.test.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 # Contract test for build.sh's Docker builder-cache switch. Uses a fake Docker
 # binary so the test proves command construction without building an image.
+#
+# Arch-parametric: build.sh derives its platform/tag strings from ELIZAOS_ARCH,
+# and the CI job env exports it (arm64 on the arm64 leg) — so the expected
+# invocations below must be built from the same variable, not amd64 literals.
+# Hardcoded amd64 expectations made this test fail (silently, inside the
+# static-smoke set -e chain) on every non-amd64 runner.
 
 set -euo pipefail
 
+ARCH="${ELIZAOS_ARCH:-amd64}"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMP="$(mktemp -d)"
 CREATED_OUT=0
@@ -73,7 +80,7 @@ run_build_with_log() {
 
 plain_log="${TMP}/plain.log"
 run_build_with_log "${plain_log}" ELIZAOS_DOCKER_BUILDX_GHA_CACHE=0
-grep -Fqx "build --platform linux/amd64 --build-arg TARGETARCH=amd64 -t elizaos-builder-amd64 ${ROOT}" "${plain_log}"
+grep -Fqx "build --platform linux/${ARCH} --build-arg TARGETARCH=${ARCH} -t elizaos-builder-${ARCH} ${ROOT}" "${plain_log}"
 if grep -Fq "buildx build" "${plain_log}"; then
     echo "build.sh used buildx while ELIZAOS_DOCKER_BUILDX_GHA_CACHE=0" >&2
     exit 1
@@ -89,6 +96,6 @@ run_build_with_log \
     ELIZAOS_DOCKER_BUILDX_GHA_CACHE=1 \
     ELIZAOS_DOCKER_BUILDX_CACHE_SCOPE=contract-scope
 grep -Fqx "buildx version" "${cache_log}"
-grep -Fqx "buildx build --platform linux/amd64 --build-arg TARGETARCH=amd64 -t elizaos-builder-amd64 --load --cache-from type=gha,scope=contract-scope --cache-to type=gha,scope=contract-scope,mode=max ${ROOT}" "${cache_log}"
+grep -Fqx "buildx build --platform linux/${ARCH} --build-arg TARGETARCH=${ARCH} -t elizaos-builder-${ARCH} --load --cache-from type=gha,scope=contract-scope --cache-to type=gha,scope=contract-scope,mode=max ${ROOT}" "${cache_log}"
 
 echo "build.sh Docker cache contract OK"


### PR DESCRIPTION
## Summary

Layers 3 and 4 of the ISO-nightly red, exposed by #15223 (stale branding assertions) and named by #15226's ERR trap in diagnostic run 28842186961:

**arm64 — gate step, `static-smoke.sh:87`** (trap output: `FAILED at ./scripts/static-smoke.sh:87: bash scripts/build-cache-contract.test.sh`):
`build-cache-contract.test.sh` asserted docker invocations with **amd64 literals** (`--platform linux/amd64 … -t elizaos-builder-amd64`), but the arm64 job env exports `ELIZAOS_ARCH=arm64` and `build.sh` correctly derives platform/`TARGETARCH`/tag from it — so on arm64 runners the `grep -Fqx` could never match, and `set -e` killed the gate silently 150 ms after `==> shell syntax` (exactly the divergence visible since the first nightly logs). Expected strings now derive from the same `ELIZAOS_ARCH` variable the fake-docker run sees.

**amd64 — Build ISO step, exit 127**:
With the gate finally green, `just build` reached the `ELIZAOS_BUILD_APP=1` in-CI Electrobun app build (itself the fix for the previous "8+ days of red" layer, per the workflow's own comment) and died at `bun: command not found` — the ISO runner installs only `just` + `ripgrep`. Added the repo-standard pinned `oven-sh/setup-bun` step (same action SHA + 1.3.14 pin as test.yml) before Build ISO.

## Verification (fake-docker contract is host-independent)

- Red-proof: pre-fix, `ELIZAOS_ARCH=arm64 bash scripts/build-cache-contract.test.sh` → exit 1 (the exact CI failure); post-fix → OK.
- `bash scripts/build-cache-contract.test.sh` under unset / `amd64` / `arm64` → all `build.sh Docker cache contract OK`.
- Full gate `ELIZAOS_STATIC_SOURCE_ONLY=1 ./scripts/static-smoke.sh` under BOTH `ELIZAOS_ARCH=arm64` and `amd64` → `static smoke passed`, exit 0.
- `actionlint .github/workflows/build-linux-iso.yml` → clean.
- A `workflow_dispatch` verification run follows the merge. Remaining unknown after these fixes is the heavy live-build ISO assembly itself (~1.5 h cold), unreachable for 10+ days — its outcome comes from that run, not local validation.

Frontend/trajectory evidence: N/A — CI workflow + gate-test changes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)