### PR TITLE
fix(ui): re-pin chat to the bottom when the scroller reflows after send (#15178)

### DIFF
--- a/packages/ui/src/hooks/useThreadAutoScroll.test.tsx
+++ b/packages/ui/src/hooks/useThreadAutoScroll.test.tsx
@@ -116,14 +116,29 @@ function Harness({ growthKey, scroller, reduceMotion, onState }: HarnessProps) {
 }
 
 let rafQueue: FrameRequestCallback[] = [];
+// Captured ResizeObserver callbacks so a test can drive a scroller reflow
+// synchronously (jsdom lays nothing out, so ResizeObserver never fires on its
+// own). `fireResize` invokes them, mirroring a settle-frame of the send-detent
+// spring / keyboard geometry change that grows the scroller with no growthKey.
+let resizeObserverCallbacks: Array<() => void> = [];
 
 beforeEach(() => {
   rafQueue = [];
+  resizeObserverCallbacks = [];
   vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
     rafQueue.push(cb);
     return rafQueue.length;
   });
   vi.stubGlobal("cancelAnimationFrame", () => {});
+  class MockResizeObserver {
+    constructor(cb: () => void) {
+      resizeObserverCallbacks.push(cb);
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal("ResizeObserver", MockResizeObserver);
 });
 
 afterEach(() => {
@@ -136,6 +151,13 @@ function flushRaf() {
   rafQueue = [];
   act(() => {
     for (const cb of q) cb(0);
+  });
+}
+
+// Fire every registered ResizeObserver callback — a single reflow frame.
+function fireResize() {
+  act(() => {
+    for (const cb of resizeObserverCallbacks) cb();
   });
 }
 
@@ -268,5 +290,64 @@ describe("useThreadAutoScroll", () => {
       scroller.dispatchEvent(new Event("scroll"));
     });
     expect(cap.get().atBottom).toBe(true);
+  });
+
+  // Geometry-only re-pin: the scroller changes size (or its content reflows)
+  // with NO growthKey change, so the growth effect never fires. The overlay's
+  // send path is the motivating device regression (#15178): sending springs the
+  // sheet to its half/full detent, so the thread scroller grows over ~300ms
+  // AFTER the send-commit pin already landed. A ResizeObserver on the scroller
+  // re-pins the settle so the newest line stays in view.
+  it("re-pins to the bottom when the scroller reflows taller after the send pin (detent-spring settle, no growthKey change) (#15178)", () => {
+    // A small resting window (clientHeight 300) over 1000px of content.
+    let height = 1000;
+    const clientHeight = 300;
+    const scroller = makeClampingScroller(() => height, clientHeight);
+    const cap = capture();
+    const { rerender } = render(
+      <Harness growthKey={1} scroller={scroller} onState={cap.onState} />,
+    );
+    flushRaf();
+    expect(scroller.scrollTop).toBe(700); // 1000 - 300
+
+    // SEND: the user message appends, growing the content 1000 -> 1150.
+    height = 1150;
+    rerender(
+      <Harness growthKey={2} scroller={scroller} onState={cap.onState} />,
+    );
+    flushRaf();
+    expect(scroller.scrollTop).toBe(850); // pinned to 1150 - 300
+    expect(cap.get().atBottom).toBe(true);
+
+    // The detent spring settles: the taller sheet + laid-out reply chrome grow
+    // the CONTENT 1150 -> 1450 with the SAME growthKey (a layout-only reflow, no
+    // new line). Pre-fix nothing re-pins and the reader strands at 850 while the
+    // true bottom is 1150 — the reported "list stays where it was" on send.
+    height = 1450;
+    fireResize();
+    flushRaf();
+    expect(scroller.scrollTop).toBe(1150); // 1450 - 300, back at the true bottom
+    expect(cap.get().atBottom).toBe(true);
+  });
+
+  it("does NOT re-pin a reader who has scrolled up when the scroller reflows", () => {
+    let height = 1000;
+    const clientHeight = 300;
+    const scroller = makeClampingScroller(() => height, clientHeight);
+    const cap = capture();
+    render(<Harness growthKey={1} scroller={scroller} onState={cap.onState} />);
+    flushRaf();
+    // Reader scrolls up into history; the scroll listener flips atBottom false.
+    scroller.scrollTop = 100;
+    act(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+    expect(cap.get().atBottom).toBe(false);
+    // A reflow grows the content while they read — they must not be yanked.
+    height = 1600;
+    fireResize();
+    flushRaf();
+    expect(scroller.scrollTop).toBe(100);
+    expect(cap.get().atBottom).toBe(false);
   });
 });

--- a/packages/ui/src/hooks/useThreadAutoScroll.ts
+++ b/packages/ui/src/hooks/useThreadAutoScroll.ts
@@ -118,6 +118,12 @@ export function useThreadAutoScroll<T extends HTMLElement = HTMLDivElement>({
   // recovers the true pre-growth position (#12348).
   const lastGrowthHeightRef = useRef(0);
 
+  // Whether the reader is resting at the bottom, mirrored into a ref so the
+  // geometry-follow observer below can read it without re-subscribing on every
+  // atBottom flip (the observer must stay attached across the whole open sheet).
+  const atBottomRef = useRef(atBottom);
+  atBottomRef.current = atBottom;
+
   const syncAtBottom = useCallback(() => {
     const el = scrollRef.current;
     if (!el) return;
@@ -136,6 +142,56 @@ export function useThreadAutoScroll<T extends HTMLElement = HTMLDivElement>({
     el.addEventListener("scroll", syncAtBottom, { passive: true });
     return () => el.removeEventListener("scroll", syncAtBottom);
   }, [syncAtBottom, enabled]);
+
+  // Re-pin the bottom when the SCROLLER'S OWN GEOMETRY changes while the reader
+  // rests at the bottom — a shrink or grow that carries no thread growth so the
+  // growthKey effect never fires. The overlay's send path is the motivating
+  // case (#15178 device regression): sending springs the sheet to its half/full
+  // detent, so the thread scroller grows over ~300ms AFTER the send-commit pin
+  // already landed. Without a re-pin the settled thread strands short of the
+  // newest line — the reader sends and the list doesn't follow. A soft keyboard
+  // opening/closing (which shrinks/grows the scroller) is the same class of
+  // geometry-only change. Gated on `atBottomRef` so a reader scrolled up into
+  // history is never yanked by a resize, and we only ever follow, never fight a
+  // manual scroll. rAF-coalesced so a multi-frame spring settle writes once per
+  // frame at most.
+  useEffect(() => {
+    if (!enabled) return;
+    if (typeof ResizeObserver === "undefined") return;
+    const el = scrollRef.current;
+    if (!el) return;
+    let raf: number | null = null;
+    const followResize = () => {
+      raf = null;
+      const node = scrollRef.current;
+      if (!node) return;
+      // Only follow a resize for a reader who was resting at the bottom. Trust
+      // the tracked `atBottom` state (kept truthful by the scroll listener)
+      // rather than a live re-measure: the reflow that fires this observer may
+      // have already grown the content past the at-bottom band with scrollTop
+      // preserved, so a live measure would read "scrolled up" and wrongly stop
+      // following — the same stale-measure trap the growth effect avoids. A
+      // reader who has scrolled up has `atBottom` false and is never yanked.
+      if (!atBottomRef.current) return;
+      node.scrollTop = node.scrollHeight;
+      lastGrowthHeightRef.current = node.scrollHeight;
+    };
+    const ro = new ResizeObserver(() => {
+      if (raf != null) return;
+      if (typeof requestAnimationFrame === "function") {
+        raf = requestAnimationFrame(followResize);
+      } else {
+        followResize();
+      }
+    });
+    ro.observe(el);
+    return () => {
+      if (raf != null && typeof cancelAnimationFrame === "function") {
+        cancelAnimationFrame(raf);
+      }
+      ro.disconnect();
+    };
+  }, [enabled]);
 
   const jumpToLatest = useCallback(() => {
     const el = scrollRef.current;


### PR DESCRIPTION
## What

The shared thread auto-scroll engine (`useThreadAutoScroll`) only follows the tail when its `growthKey` changes (a new/grown message). It never re-pins when the **scroller's own geometry** changes with no thread growth — and the overlay's send path does exactly that.

On send, `ContinuousChatOverlay.submitText` runs:

```js
setFreeH(null);
setMode((m) => (m === "half" || m === "full" ? m : "half"));
```

That springs the sheet to its half/full detent, so the thread scroller grows over ~300ms **after** the send-commit pin already landed (the growth `useLayoutEffect` fired once against the pre-spring geometry). Nothing re-pins the settle, so the transcript strands short of the newest line: on the installed iOS PWA the user "sends and the list stays where it was."

Surfaced by #15178 (standalone viewport geometry), which widened the post-send height delta so the strand became visible on device. A soft-keyboard open/close (shrinks/grows the scroller) is the same class of geometry-only change.

## Fix

Add a `ResizeObserver` on the scroller in `useThreadAutoScroll` that re-pins to the bottom on a reflow **while the reader is resting at the bottom** (`atBottom` tracked via the existing scroll listener, mirrored into a ref). A reader scrolled up into history is never yanked. rAF-coalesced so a multi-frame spring settle writes at most once per frame; guarded for environments without `ResizeObserver`.

The fix lives in the shared engine, so the desktop `ChatView` benefits too.

Root cause is on `develop` (the `setMode`-on-send + spring predate #15178); this is filed as its own PR off `develop` rather than folded into the geometry PR.

## Tests

Two new cases in `useThreadAutoScroll.test.tsx`:
- a taller reflow after the send pin re-pins to the true bottom (fails pre-fix: stranded at the old bottom)
- a reflow while scrolled up leaves the reader untouched

Green:
- `useThreadAutoScroll.test.tsx` — 9/9
- `ContinuousChatOverlay.test.tsx` — 164/164
- biome clean, tsc clean on touched files
- codex review: no findings

Co-authored-by: wakesync <shadow@shad0w.xyz>

[sol-orch]

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15234-before-develop-32-mobile-autoscroll.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15234-after-32-mobile-autoscroll-repinned.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/15234-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [x] [15234-unit.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15234-unit.log)

<!-- evidence-row:frontend-logs -->
- [x] [15234-e2e.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15234-e2e.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/model behavior; scroll-pinning UI fix

<!-- evidence-row:domain-artifacts -->
- [x] [15234-ocr.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15234-ocr.txt)

<!-- evidence-row:ocr-review -->
- [x] [15234-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15234-ocr-review.txt)

