### PR TITLE
fix(ci): path detection overrides the coarse ui label in the evidence gate

### DIFF
--- a/scripts/check-pr-evidence.mjs
+++ b/scripts/check-pr-evidence.mjs
@@ -277,9 +277,15 @@ export function evaluatePrEvidence(
   options = {},
 ) {
   const rows = extractEvidenceRows(body ?? "");
+  // When a changed-file list is available, path detection is the sole surface
+  // trigger: the auto-labeler applies `ui` to ANY packages/ui path, so the
+  // label alone forces screenshots onto non-visual .ts changes. The label
+  // trigger survives only for label-only invocations (no file list), where it
+  // is the best signal available.
   const surfaceArtifactsRequired =
-    requiresSurfaceArtifacts(options.labels) ||
-    requiresSurfaceArtifactsFromFiles(options.changedFiles);
+    parseChangedFiles(options.changedFiles).length > 0
+      ? requiresSurfaceArtifactsFromFiles(options.changedFiles)
+      : requiresSurfaceArtifacts(options.labels);
   // A wholly-new surface (every touched UI file was ADDED) has no "before"
   // state to photograph; that one row may be N/A-with-reason.
   const beforeNaAllowed = beforeScreenshotImpossible(

--- a/scripts/check-pr-evidence.test.mjs
+++ b/scripts/check-pr-evidence.test.mjs
@@ -467,6 +467,26 @@ describe("check-pr-evidence row primitives", () => {
     assert.equal(bare.ok, false);
   });
 
+  it("path detection overrides the coarse ui label when files are known", () => {
+    // The auto-labeler applies `ui` to any packages/ui path; a non-visual .ts
+    // change must not be forced to attach screenshots.
+    const body = REQUIRED_EVIDENCE_ROWS.map(
+      ({ id }) =>
+        `<!-- evidence-row:${id} -->\n- [ ] row \`N/A - non-visual .ts module change\`.`,
+    ).join("\n\n");
+    const { ok } = evaluatePrEvidence(body, REQUIRED_EVIDENCE_ROWS, {
+      labels: "ui",
+      changedFiles: ["packages/ui/src/navigation/index.ts"],
+    });
+    assert.equal(ok, true);
+    // But a rendered-UI file still forces artifacts regardless of labels.
+    const forced = evaluatePrEvidence(body, REQUIRED_EVIDENCE_ROWS, {
+      labels: "",
+      changedFiles: ["packages/ui/src/navigation/index.ts", "packages/ui/src/components/Foo.tsx"],
+    });
+    assert.equal(forced.ok, false);
+  });
+
   it("normalizes labels and detects surface labels", () => {
     assert.deepEqual(parseLabels("bug, UI\nNative"), ["bug", "ui", "native"]);
     assert.equal(requiresSurfaceArtifacts("testing,backend"), false);


### PR DESCRIPTION
# Relates to

Evidence-gate refinement series (#15204/#15208/#15219). Found live while
remediating #15221.

# Risks

Low. Strictness unchanged for any PR whose diff touches a rendered-UI file;
only label-triggered false positives on non-visual .ts changes are removed.

# Background

## What does this PR do?

The auto-labeler applies `ui` to any `packages/ui` path, and the gate's
label-based trigger then demands screenshot/video/OCR artifacts — even for a
pure `.ts` module fix with no visual surface (live case: #15221, a static-import
server-safety fix). When the changed-file list is available (always in CI),
path detection is now the sole surface trigger; labels only matter when no file
list was provided.

## What kind of change is this?

Bug fix (CI gate false positive).

# Testing

## Detailed testing steps

```bash
node scripts/check-pr-evidence.mjs --self-test   # 11
node --test scripts/check-pr-evidence.test.mjs   # 33
```

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - CI gate script only, no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - CI gate script only, no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no UI flow`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: [self-test + 33-case suite output](#evidence-details) inline below.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend code path`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - deterministic parser change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: [gate verdict flip on #15221 described below](#evidence-details).

# Evidence Details

<details><summary>Tests + live verdict flip</summary>

```
check-pr-evidence self-test passed (11 cases).
node --test scripts/check-pr-evidence.test.mjs → tests 33, pass 33, fail 0
Live: #15221 (ui-labeled, only packages/ui/src/navigation/index.ts changed)
  before: before/after/walkthrough rows = artifact-required (false positive)
  after:  N/A-with-reason rows accepted; rendered-UI diffs still forced.
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

