### PR TITLE
fix(ci): pr-evidence attach fails per-file on empty artifacts

### DIFF
--- a/scripts/pr-evidence.mjs
+++ b/scripts/pr-evidence.mjs
@@ -101,6 +101,12 @@ function attach(pr, files) {
   const staged = [];
   for (const file of files) {
     if (!existsSync(file)) fail(`no such file: ${file}`);
+    // GitHub rejects zero-byte release assets with an opaque 400
+    // (Bad Content-Length) that aborts the whole batch — fail per-file with
+    // the actual reason instead. An empty artifact is never real evidence.
+    if (readFileSync(file).length === 0) {
+      fail(`refusing to upload empty file (0 bytes): ${file}`);
+    }
     const name = `${pr}-${basename(file).replace(new RegExp(`^${pr}-`), "")}`;
     const url = `${ASSET_BASE}/${name}`;
     urls.set(name, url);


### PR DESCRIPTION
# Relates to

Evidence-pipeline UX series (#15219). Live bug found while attaching evidence to #15240.

# Risks

None — adds one guard to a CLI helper.

# Background

## What does this PR do?

`gh release upload` rejects zero-byte assets with an opaque `HTTP 400: Bad
Content-Length` that aborted the whole `evidence:pr attach` batch mid-way
(remaining files silently unuploaded). The tool now refuses 0-byte files
per-file with the real reason — an empty artifact is never evidence.

## What kind of change is this?

Bug fix (tooling).

# Testing

## Detailed testing steps

`touch empty.txt && node scripts/pr-evidence.mjs attach 1 empty.txt` → clear
per-file failure instead of a batch crash.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - CLI helper guard, no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - CLI helper guard, no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no UI flow`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: [reproduction on #15240's OCR artifact described below](#evidence-details).
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend path`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - deterministic CLI guard`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: the recovered upload — [15240-glass-ocr-plus-menu.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15240-glass-ocr-plus-menu.txt) (uploaded after replacing the empty file).

# Evidence Details

Live repro: a grep pipeline produced a 0-byte OCR file; `attach 15240 …7 files`
crashed at the batch upload with `HTTP 400: Bad Content-Length`, leaving later
files unuploaded (`15240-glass-ocr-plus-menu.txt` 404'd until re-uploaded
manually). With the guard: `refusing to upload empty file (0 bytes): <path>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
