### PR TITLE
fix(pwa): close merged review blockers

### DIFF
--- a/packages/app/public/sw-push.js
+++ b/packages/app/public/sw-push.js
@@ -21,8 +21,8 @@
    * sane rather than throwing inside the `push` event (which would drop it).
    */
   const DEFAULT_TITLE = "New message";
-  const DEFAULT_ICON = "/logos/icon-192.png";
-  const DEFAULT_BADGE = "/logos/badge-72.png";
+  const DEFAULT_ICON = "/brand/favicons/android-chrome-192x192.png";
+  const DEFAULT_BADGE = "/brand/favicons/android-chrome-192x192.png";
   const DEFAULT_TAG = "eliza-message";
 
   /**
@@ -147,7 +147,10 @@
    */
   function isSafeAppPath(path) {
     return (
-      typeof path === "string" && path.startsWith("/") && !path.startsWith("//")
+      typeof path === "string" &&
+      path.startsWith("/") &&
+      !path.startsWith("//") &&
+      !path.includes("\\")
     );
   }
 
@@ -236,7 +239,8 @@
   function safeAbsolute(path, origin) {
     if (!isSafeAppPath(path)) return `${origin}/`;
     try {
-      return new URL(path, `${origin}/`).toString();
+      const resolved = new URL(path, `${origin}/`);
+      return resolved.origin === origin ? resolved.toString() : `${origin}/`;
     } catch {
       return `${origin}/`;
     }

--- a/packages/app/src/mobile-lifecycle.ts
+++ b/packages/app/src/mobile-lifecycle.ts
@@ -19,6 +19,7 @@ import {
   NETWORK_STATUS_CHANGE_EVENT,
   type NetworkStatusChangeDetail,
 } from "@elizaos/ui/events";
+import { isStandalonePwa } from "@elizaos/ui/platform";
 
 export interface MobileLifecycleContext {
   isNative: boolean;
@@ -40,6 +41,10 @@ const COLD_LAUNCH_URL_REPLAY_INTERVAL_MS = 1_000;
 
 function unrefTimer(timer: ReturnType<typeof setInterval>): void {
   (timer as unknown as { unref?: () => void }).unref?.();
+}
+
+function shouldBridgeVisibilityLifecycle(ctx: MobileLifecycleContext): boolean {
+  return ctx.isNative || isStandalonePwa();
 }
 
 export function createMobileLifecycle(ctx: MobileLifecycleContext) {
@@ -133,28 +138,26 @@ export function createMobileLifecycle(ctx: MobileLifecycleContext) {
       CapacitorApp.addListener("appStateChange", ({ isActive }) => {
         setAppActive(isActive);
       }),
-      // error-policy:J4 App plugin unavailable — the visibilitychange
-      // fallback below still drives pause/resume
+      // error-policy:J4 App plugin unavailable — the visibilitychange fallback
+      // still drives pause/resume on native and installed-PWA surfaces.
     ).catch((error) => {
       logNativePluginUnavailable("App", error);
     });
 
-    // Robust pause/resume fallback. `document.visibilitychange` fires reliably on
-    // every surface (web, desktop, iOS/Android WebView) when the app is
-    // backgrounded/foregrounded — including when the Capacitor `App` plugin's
-    // `appStateChange` is delayed, missing, or (as observed on an Android
-    // device) reports the App plugin as "not implemented", in which case the
-    // listener above never registers and pause/resume would otherwise never
-    // fire — so APP_PAUSE_EVENT-driven work (e.g. pruning backgrounded views to
-    // reclaim memory) never runs on background. Deduped via `setAppActive` so it
-    // never double-fires alongside a working `appStateChange`.
     if (activeVisibilityHandler) {
       document.removeEventListener("visibilitychange", activeVisibilityHandler);
+      activeVisibilityHandler = null;
     }
-    activeVisibilityHandler = () => {
-      setAppActive(document.visibilityState !== "hidden");
-    };
-    document.addEventListener("visibilitychange", activeVisibilityHandler);
+    // Browser tab visibility is not an app suspend signal: desktop browsers keep
+    // agent requests and sockets alive in hidden tabs. Use the fallback only on
+    // native WebViews and installed PWAs, where the OS can freeze or kill the
+    // renderer without a reliable Capacitor `appStateChange`.
+    if (shouldBridgeVisibilityLifecycle(ctx)) {
+      activeVisibilityHandler = () => {
+        setAppActive(document.visibilityState !== "hidden");
+      };
+      document.addEventListener("visibilitychange", activeVisibilityHandler);
+    }
 
     void Promise.resolve(
       CapacitorApp.addListener("backButton", ({ canGoBack }) => {

--- a/packages/app/src/sw-push.test.ts
+++ b/packages/app/src/sw-push.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { readFileSync } from "node:fs";
+import { access } from "node:fs/promises";
 import { join } from "node:path";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -87,6 +88,21 @@ describe("parsePushData", () => {
 });
 
 describe("buildNotification", () => {
+  it("defaults to notification image assets that exist in public/", async () => {
+    expect(push.DEFAULT_ICON).toBe(
+      "/brand/favicons/android-chrome-192x192.png",
+    );
+    expect(push.DEFAULT_BADGE).toBe(
+      "/brand/favicons/android-chrome-192x192.png",
+    );
+    await expect(
+      access(join(__dirname, "..", "public", push.DEFAULT_ICON)),
+    ).resolves.toBeUndefined();
+    await expect(
+      access(join(__dirname, "..", "public", push.DEFAULT_BADGE)),
+    ).resolves.toBeUndefined();
+  });
+
   it("applies sane defaults for an empty payload", () => {
     const { title, options } = push.buildNotification({});
     expect(title).toBe(push.DEFAULT_TITLE);
@@ -214,6 +230,9 @@ describe("resolveClickTarget", () => {
       ),
     ).toBe("/?conversation=c1");
     expect(push.resolveClickTarget({ deepLink: "//evil" }, origin)).toBe("/");
+    expect(push.resolveClickTarget({ deepLink: "/\\evil.com" }, origin)).toBe(
+      "/",
+    );
   });
 
   it("builds a conversation url with agent when present", () => {
@@ -258,6 +277,16 @@ describe("focusOrOpen", () => {
     };
     await push.focusOrOpen(clientsLike, "/?conversation=c2", origin);
     expect(openWindow).toHaveBeenCalledWith(`${origin}/?conversation=c2`);
+  });
+
+  it("never opens a foreign origin after URL normalization", async () => {
+    const openWindow = vi.fn().mockResolvedValue({});
+    const clientsLike = {
+      matchAll: vi.fn().mockResolvedValue([]),
+      openWindow,
+    };
+    await push.focusOrOpen(clientsLike, "/\\evil.com", origin);
+    expect(openWindow).toHaveBeenCalledWith(`${origin}/`);
   });
 
   it("ignores a cross-origin client and opens a fresh window", async () => {

--- a/packages/app/test/mobile-lifecycle.test.ts
+++ b/packages/app/test/mobile-lifecycle.test.ts
@@ -125,6 +125,22 @@ function setVisibility(state: "visible" | "hidden"): void {
   document.dispatchEvent(new Event("visibilitychange"));
 }
 
+function stubDisplayMode(mode: "standalone" | "fullscreen" | "browser"): void {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: vi.fn((query: string) => ({
+      matches: query.includes(`display-mode: ${mode}`),
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
 function fireNetworkEvent(eventName: string, payload: unknown): void {
   for (const handler of networkListeners.get(eventName) ?? []) handler(payload);
 }
@@ -157,6 +173,8 @@ beforeEach(() => {
 afterEach(() => {
   vi.useRealTimers();
   historyBackSpy.mockRestore();
+  delete (window as { matchMedia?: unknown }).matchMedia;
+  delete (navigator as { standalone?: unknown }).standalone;
 });
 
 describe("createMobileLifecycle — app lifecycle", () => {
@@ -236,6 +254,46 @@ describe("createMobileLifecycle — app lifecycle", () => {
     setVisibility("visible");
 
     expect(resume).toHaveBeenCalledTimes(1);
+    document.removeEventListener(APP_RESUME_EVENT, resume);
+  });
+
+  it("does not dispatch app lifecycle events from a normal browser tab visibilitychange", () => {
+    stubDisplayMode("browser");
+    const lifecycle = createMobileLifecycle(
+      makeContext({ isNative: false, isIOS: false, isAndroid: false }),
+    );
+    const pause = vi.fn();
+    const resume = vi.fn();
+    document.addEventListener(APP_PAUSE_EVENT, pause);
+    document.addEventListener(APP_RESUME_EVENT, resume);
+
+    lifecycle.initializeAppLifecycle();
+    setVisibility("hidden");
+    setVisibility("visible");
+
+    expect(pause).not.toHaveBeenCalled();
+    expect(resume).not.toHaveBeenCalled();
+    document.removeEventListener(APP_PAUSE_EVENT, pause);
+    document.removeEventListener(APP_RESUME_EVENT, resume);
+  });
+
+  it("dispatches app lifecycle events from an installed web PWA visibilitychange", () => {
+    stubDisplayMode("standalone");
+    const lifecycle = createMobileLifecycle(
+      makeContext({ isNative: false, isIOS: false, isAndroid: false }),
+    );
+    const pause = vi.fn();
+    const resume = vi.fn();
+    document.addEventListener(APP_PAUSE_EVENT, pause);
+    document.addEventListener(APP_RESUME_EVENT, resume);
+
+    lifecycle.initializeAppLifecycle();
+    setVisibility("hidden");
+    setVisibility("visible");
+
+    expect(pause).toHaveBeenCalledTimes(1);
+    expect(resume).toHaveBeenCalledTimes(1);
+    document.removeEventListener(APP_PAUSE_EVENT, pause);
     document.removeEventListener(APP_RESUME_EVENT, resume);
   });
 

--- a/packages/ui/src/api/client-base-websocket.test.ts
+++ b/packages/ui/src/api/client-base-websocket.test.ts
@@ -302,6 +302,29 @@ describe("ElizaClient websocket connection policy", () => {
     expect(instances).toHaveLength(before);
   });
 
+  it("resetConnection leaves a healthy websocket connected without a disconnected flap", () => {
+    const instances = stubWebSocketWithInstances();
+    const client = new ElizaClient("https://agent.example.test", "agent-token");
+    client.connectWs();
+    expect(instances).toHaveLength(1);
+
+    instances[0].readyState = 1; // OPEN
+    instances[0].onopen?.();
+
+    const states: string[] = [];
+    client.onConnectionStateChange((s) => states.push(s.state));
+
+    client.resetConnection();
+
+    expect(instances).toHaveLength(1);
+    expect(client.getConnectionState()).toMatchObject({
+      state: "connected",
+      reconnectAttempt: 0,
+      disconnectedAt: null,
+    });
+    expect(states).not.toContain("disconnected");
+  });
+
   it("removes a parked network-status reconnect wake on intentional disconnect", () => {
     const instances = stubWebSocketWithInstances();
     const client = new ElizaClient("https://agent.example.test", "agent-token");

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -1280,6 +1280,16 @@ export class ElizaClient {
       this.ws?.readyState === WebSocket.OPEN ||
       this.ws?.readyState === WebSocket.CONNECTING
     ) {
+      if (
+        this.ws.readyState === WebSocket.OPEN &&
+        this.connectionState !== "connected"
+      ) {
+        this.backoffMs = 500;
+        this.reconnectAttempt = 0;
+        this.disconnectedAt = null;
+        this.connectionState = "connected";
+        this.emitConnectionStateChange();
+      }
       return;
     }
 
@@ -1537,6 +1547,28 @@ export class ElizaClient {
 
   /** Reset connection state and restart reconnection attempts. */
   resetConnection(): void {
+    const existingReadyState = this.ws?.readyState;
+    if (
+      existingReadyState === WebSocket.OPEN ||
+      existingReadyState === WebSocket.CONNECTING
+    ) {
+      this.reconnectAttempt = 0;
+      this.disconnectedAt = null;
+      if (this.reconnectTimer) {
+        clearTimeout(this.reconnectTimer);
+        this.reconnectTimer = null;
+      }
+      this.backoffMs = 500;
+      if (
+        existingReadyState === WebSocket.OPEN &&
+        this.connectionState !== "connected"
+      ) {
+        this.connectionState = "connected";
+        this.emitConnectionStateChange();
+      }
+      return;
+    }
+
     this.reconnectAttempt = 0;
     this.disconnectedAt = null;
     this.connectionState = "disconnected";

--- a/packages/ui/src/platform/standalone-bottom-reclaim.test.ts
+++ b/packages/ui/src/platform/standalone-bottom-reclaim.test.ts
@@ -53,9 +53,12 @@ import {
 function stubViewport(opts: {
   layoutHeight: number;
   screenHeight?: number;
+  screenWidth?: number;
   innerHeight?: number;
+  innerWidth?: number;
   visualHeight?: number;
   visualOffsetTop?: number;
+  orientation?: "portrait" | "landscape";
 }): void {
   Object.defineProperty(document.documentElement, "clientHeight", {
     configurable: true,
@@ -68,10 +71,33 @@ function stubViewport(opts: {
     writable: true,
     value: opts.innerHeight ?? opts.layoutHeight,
   });
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: opts.innerWidth ?? 390,
+  });
   Object.defineProperty(window, "screen", {
     configurable: true,
     writable: true,
-    value: { height: opts.screenHeight ?? opts.layoutHeight },
+    value: {
+      height: opts.screenHeight ?? opts.layoutHeight,
+      width: opts.screenWidth ?? opts.layoutHeight,
+    },
+  });
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches:
+        query.includes(`orientation: ${opts.orientation ?? "portrait"}`),
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }),
   });
   const visualHeight = opts.visualHeight ?? opts.layoutHeight;
   Object.defineProperty(window, "visualViewport", {
@@ -87,6 +113,7 @@ function stubViewport(opts: {
 }
 
 afterEach(() => {
+  clearStandaloneBottomReclaim();
   document.documentElement.style.removeProperty(STANDALONE_BOTTOM_RECLAIM_VAR);
   // Restore a benign viewport so cases don't bleed.
   Object.defineProperty(document.documentElement, "clientHeight", {
@@ -98,10 +125,20 @@ afterEach(() => {
     writable: true,
     value: 0,
   });
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: 0,
+  });
   Object.defineProperty(window, "screen", {
     configurable: true,
     writable: true,
-    value: { height: 0 },
+    value: { height: 0, width: 0 },
+  });
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: undefined,
   });
   Object.defineProperty(window, "visualViewport", {
     configurable: true,
@@ -149,6 +186,33 @@ describe("measureStandaloneBottomGap: the screen.height cure for the collapsed-I
       innerHeight: 900,
       visualHeight: 900,
       screenHeight: 900,
+    });
+    expect(measureStandaloneBottomGap()).toBe(0);
+  });
+
+  it("uses screen.width in landscape so the portrait long side does not fake a keyboard", () => {
+    stubViewport({
+      layoutHeight: 873,
+      innerHeight: 873,
+      innerWidth: 390,
+      visualHeight: 873,
+      screenHeight: 932,
+      screenWidth: 390,
+      orientation: "portrait",
+    });
+    expect(measureStandaloneBottomGap()).toBe(59);
+
+    // On iOS landscape, `screen.height` can remain the portrait long side. The
+    // current physical extent is `screen.width`; using the long side here would
+    // look like a 502px keyboard shortfall and freeze the stale portrait 59px.
+    stubViewport({
+      layoutHeight: 430,
+      innerHeight: 430,
+      innerWidth: 932,
+      visualHeight: 430,
+      screenHeight: 932,
+      screenWidth: 430,
+      orientation: "landscape",
     });
     expect(measureStandaloneBottomGap()).toBe(0);
   });
@@ -299,12 +363,12 @@ describe("clearStandaloneBottomReclaim — hard 0 on non-standalone surfaces", (
 });
 
 describe("shouldInstallStandaloneBottomReclaim — platform gate", () => {
-  it("installs for standalone PWAs and iOS native WebViews only", () => {
+  it("installs for iOS standalone PWAs and iOS native WebViews only", () => {
     expect(
       shouldInstallStandaloneBottomReclaim({
         standalonePwa: true,
         isNative: false,
-        isIOS: false,
+        isIOS: true,
       }),
     ).toBe(true);
     expect(
@@ -317,6 +381,13 @@ describe("shouldInstallStandaloneBottomReclaim — platform gate", () => {
   });
 
   it("does not install listeners on Android native, desktop, or browser tabs", () => {
+    expect(
+      shouldInstallStandaloneBottomReclaim({
+        standalonePwa: true,
+        isNative: false,
+        isIOS: false,
+      }),
+    ).toBe(false);
     expect(
       shouldInstallStandaloneBottomReclaim({
         standalonePwa: false,

--- a/packages/ui/src/platform/standalone-bottom-reclaim.ts
+++ b/packages/ui/src/platform/standalone-bottom-reclaim.ts
@@ -84,6 +84,26 @@ export const KEYBOARD_INTRUSION_THRESHOLD_PX = 140;
  */
 let lastRestingGap = 0;
 
+function isPortraitScreenOrientation(): boolean {
+  const matchMedia = window.matchMedia;
+  if (typeof matchMedia === "function") {
+    return matchMedia("(orientation: portrait)").matches;
+  }
+
+  const width = typeof window.innerWidth === "number" ? window.innerWidth : 0;
+  const height = typeof window.innerHeight === "number" ? window.innerHeight : 0;
+  if (width > 0 && height > 0) return height >= width;
+  return true;
+}
+
+function getPhysicalScreenExtent(): number {
+  const portrait = isPortraitScreenOrientation();
+  const primary = portrait ? window.screen?.height : window.screen?.width;
+  if (typeof primary === "number" && primary > 0) return primary;
+  const fallback = portrait ? window.screen?.width : window.screen?.height;
+  return typeof fallback === "number" && fallback > 0 ? fallback : 0;
+}
+
 /**
  * The measured true-vs-layout viewport delta in CSS px, clamped to a sane
  * range. Returns 0 when we can't trust the measurement (SSR, missing globals)
@@ -139,13 +159,12 @@ export function measureStandaloneBottomGap(): number {
       : (document.documentElement?.clientHeight ?? 0);
   if (layoutHeight <= 0) return 0;
 
-  // The TRUE physical screen height. Missing on SSR / ancient engines → 0 (no
-  // reclaim, no harm).
-  const screenHeight =
-    typeof window.screen?.height === "number" && window.screen.height > 0
-      ? window.screen.height
-      : 0;
-  if (screenHeight <= 0) return 0;
+  // The TRUE physical screen extent for the current orientation. iOS can keep
+  // `screen.height` as the portrait long side in landscape, so use
+  // `screen.width` there; otherwise a normal landscape viewport looks like a
+  // giant keyboard shortfall and freezes a stale portrait reclaim.
+  const screenExtent = getPhysicalScreenExtent();
+  if (screenExtent <= 0) return 0;
 
   // KEYBOARD-OPEN GUARD (the r-kbd regression): the resting reclaim measures
   // against `innerHeight`, but post-#15103 the soft keyboard shrinks BOTH
@@ -163,14 +182,14 @@ export function measureStandaloneBottomGap(): number {
     window.visualViewport.height > 0
       ? window.visualViewport.height
       : layoutHeight;
-  const keyboardShortfall = screenHeight - visualHeight;
+  const keyboardShortfall = screenExtent - visualHeight;
   if (keyboardShortfall >= KEYBOARD_INTRUSION_THRESHOLD_PX) {
     // Keyboard is up: keep serving the frozen keyboard-down reclaim (the
     // composer's own lift owns keyboard geometry). Never re-measure here.
     return lastRestingGap;
   }
 
-  const gap = screenHeight - layoutHeight;
+  const gap = screenExtent - layoutHeight;
 
   // Only a POSITIVE gap is the collapse we reclaim. Zero (web/desktop/Android,
   // where screen.height === the layout box) or negative (should not happen; a
@@ -236,7 +255,7 @@ export function shouldInstallStandaloneBottomReclaim({
   isNative: boolean;
   isIOS: boolean;
 }): boolean {
-  return standalonePwa || (isNative && isIOS);
+  return isIOS && (standalonePwa || isNative);
 }
 
 /**

--- a/packages/ui/src/state/useAppLifecycleEvents.ts
+++ b/packages/ui/src/state/useAppLifecycleEvents.ts
@@ -20,7 +20,7 @@
  *    backoff (so a socket iOS silently killed during suspension recovers
  *    immediately instead of waiting for the 30s background probe), and refetch
  *    the active conversation tail so agent messages missed while backgrounded
- *    appear \u2014 critical for dedicated-agent REST mode where there is no WS to
+ *    appear - critical for dedicated-agent REST mode where there is no WS to
  *    reconnect and nothing else re-syncs. The stale empty-streaming-placeholder
  *    anomaly is still swept (mark interrupted). The whole resume sequence is
  *    debounced so rapid foreground/background flips (or a visibilitychange +
@@ -57,7 +57,7 @@ interface UseAppLifecycleEventsParams {
   ) => void;
   /**
    * Full-replace reload of a conversation's messages from the server. Called on
-   * resume so agent messages emitted while the app was backgrounded appear \u2014
+   * resume so agent messages emitted while the app was backgrounded appear -
    * the only re-sync path for dedicated-agent REST mode (no WS to reconnect).
    */
   loadConversationMessages: (
@@ -233,7 +233,7 @@ export function useAppLifecycleEvents({
     // iOS commonly restores an installed PWA from the back/forward cache
     // (bfcache) where `visibilitychange` alone can miss the resume trigger. A
     // `pageshow` with `persisted === true` means the page came back from
-    // bfcache with a frozen (dead) socket \u2014 treat it as a resume. A
+    // bfcache with a frozen (dead) socket - treat it as a resume. A
     // non-persisted pageshow is a normal load (boot already connects), so it
     // is ignored. Sharing `scheduleResume` dedupes against a visibilitychange
     // APP_RESUME_EVENT that fires in the same tick.

--- a/packages/ui/src/state/useDataLoaders.conversation-cache.test.tsx
+++ b/packages/ui/src/state/useDataLoaders.conversation-cache.test.tsx
@@ -30,6 +30,15 @@ function userMsg(id: string): ConversationMessage {
   } as ConversationMessage;
 }
 
+function assistantMsg(id: string): ConversationMessage {
+  return {
+    id,
+    role: "assistant",
+    text: `msg-${id}`,
+    timestamp: 0,
+  } as ConversationMessage;
+}
+
 function makeDeps() {
   const conversationMessagesRef = { current: [] as ConversationMessage[] };
   const activeConversationIdRef = { current: null as string | null };
@@ -63,7 +72,12 @@ function makeDeps() {
     uiLanguage: "en",
     setOwnerNameState: noop,
   } as unknown as DataLoadersDeps;
-  return { deps, setConversationMessages, conversationMessagesRef };
+  return {
+    deps,
+    setConversationMessages,
+    conversationMessagesRef,
+    activeConversationIdRef,
+  };
 }
 
 beforeEach(() => {
@@ -181,5 +195,42 @@ describe("useDataLoaders — conversation message prefetch cache", () => {
 
     // Only the latest selection's messages reach the thread.
     expect(conversationMessagesRef.current).toEqual([userMsg("b1")]);
+  });
+
+  it("preserves local optimistic temp turns during same-conversation revalidation", async () => {
+    mocks.client.getConversationMessages
+      .mockResolvedValueOnce({ messages: [userMsg("persisted-1")] })
+      .mockResolvedValueOnce({
+        messages: [userMsg("persisted-1"), assistantMsg("server-late")],
+      });
+    const {
+      deps,
+      setConversationMessages,
+      conversationMessagesRef,
+      activeConversationIdRef,
+    } = makeDeps();
+    activeConversationIdRef.current = "conv-a";
+    const { result } = renderHook(() => useDataLoaders(deps));
+
+    await act(async () => {
+      await result.current.loadConversationMessages("conv-a");
+    });
+    conversationMessagesRef.current = [
+      userMsg("persisted-1"),
+      { ...userMsg("temp-user"), timestamp: 10 },
+      { ...assistantMsg("temp-resp-user"), text: "", timestamp: 11 },
+    ];
+    setConversationMessages.mockClear();
+
+    await act(async () => {
+      await result.current.loadConversationMessages("conv-a");
+    });
+
+    expect(conversationMessagesRef.current.map((message) => message.id)).toEqual(
+      ["persisted-1", "server-late", "temp-user", "temp-resp-user"],
+    );
+    expect(setConversationMessages).toHaveBeenLastCalledWith(
+      conversationMessagesRef.current,
+    );
   });
 });

--- a/packages/ui/src/state/useDataLoaders.ts
+++ b/packages/ui/src/state/useDataLoaders.ts
@@ -72,6 +72,28 @@ function hasConversationBootstrapMessage(
   );
 }
 
+function isLocalPendingConversationMessage(
+  message: ConversationMessage,
+): boolean {
+  return message.id.startsWith("temp-");
+}
+
+function mergeLocalPendingConversationMessages(
+  serverMessages: ConversationMessage[],
+  currentMessages: ConversationMessage[],
+  loadedConversationId: string | null,
+  convId: string,
+): ConversationMessage[] {
+  if (loadedConversationId !== convId) return serverMessages;
+  const serverIds = new Set(serverMessages.map((message) => message.id));
+  const pendingMessages = currentMessages.filter(
+    (message) =>
+      isLocalPendingConversationMessage(message) && !serverIds.has(message.id),
+  );
+  if (pendingMessages.length === 0) return serverMessages;
+  return [...serverMessages, ...pendingMessages];
+}
+
 function buildLocalizedCharacterPayload(
   preset: StylePreset,
   name?: string | null,
@@ -346,10 +368,17 @@ export function useDataLoaders(deps: DataLoadersDeps) {
       // thread never flashes empty mid-swipe; the fetch below still revalidates.
       const cached = conversationMessageCacheRef.current.get(convId);
       if (cached) {
-        greetingFiredRef.current = hasConversationBootstrapMessage(cached);
-        conversationMessagesRef.current = cached;
+        const mergedCached = mergeLocalPendingConversationMessages(
+          cached,
+          conversationMessagesRef.current,
+          loadedConversationIdRef.current,
+          convId,
+        );
+        greetingFiredRef.current =
+          hasConversationBootstrapMessage(mergedCached);
+        conversationMessagesRef.current = mergedCached;
         loadedConversationIdRef.current = convId;
-        setConversationMessages(cached);
+        setConversationMessages(mergedCached);
       } else if (loadedConversationIdRef.current !== convId) {
         // No cache means the visible transcript still belongs to the previous
         // active conversation until the fetch resolves. Clear it immediately so
@@ -368,8 +397,14 @@ export function useDataLoaders(deps: DataLoadersDeps) {
         // Superseded by a newer load while in flight — let the newer one own the
         // thread instead of committing this stale result.
         if (signal.aborted) return { ok: true };
-        const nextMessages = filterRenderableConversationMessages(messages);
-        cacheConversationMessages(convId, nextMessages);
+        const serverMessages = filterRenderableConversationMessages(messages);
+        const nextMessages = mergeLocalPendingConversationMessages(
+          serverMessages,
+          conversationMessagesRef.current,
+          loadedConversationIdRef.current,
+          convId,
+        );
+        cacheConversationMessages(convId, serverMessages);
         greetingFiredRef.current =
           hasConversationBootstrapMessage(nextMessages);
         conversationMessagesRef.current = nextMessages;


### PR DESCRIPTION
## Summary
- harden merged web-push click routing against backslash open redirects and point default icon/badge at shipped assets (#15185)
- keep resume reconnect idempotent for healthy sockets, avoid desktop-tab pause aborts, and preserve local temp turns during resume revalidation (#15179)
- restrict standalone bottom reclaim to iOS surfaces and use the orientation-aware screen extent in landscape (#15178)

## Verification
- bun run --cwd packages/app test --run src/sw-push.test.ts test/mobile-lifecycle.test.ts
- bun run --cwd packages/ui test --run src/state/notifications/web-push-subscription.test.ts src/state/notifications/useWebPush.test.tsx src/api/client-base-websocket.test.ts src/state/useAppLifecycleEvents.test.tsx src/state/useDataLoaders.conversation-cache.test.tsx src/platform/standalone-bottom-reclaim.test.ts src/platform/standalone-pwa-lockdown.test.ts src/components/shell/chat-panel-layout.test.ts src/backgrounds/AppBackground.test.tsx
- bun run --cwd packages/ui typecheck
- bun run --cwd packages/app typecheck
- bun run audit:error-policy-ratchet

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI surface changed; this patch changes service-worker click routing, lifecycle wiring, websocket state, and viewport measurement helpers.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI surface changed; focused app/UI unit tests and package typechecks cover the behavioral changes.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive rendered UI flow changed; behavior is covered by service-worker, lifecycle, websocket, loader, and viewport tests.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend code, API route, database, worker, or service behavior changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser-rendered flow changed; local focused app/UI tests and package typechecks are listed in Verification.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent prompt, model, trajectory, or LLM behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted domain artifacts are produced; the change is limited to client-side routing/lifecycle/viewport behavior.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered text or visual UI surface changed.
