### PR TITLE
fix(mobile): boot-gate local agent on onboarding state + device-RAM-tier gating + reversible onboarding

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/DeviceRamTierPolicy.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/DeviceRamTierPolicy.java
@@ -1,0 +1,58 @@
+package ai.elizaos.app;
+
+/**
+ * Device RAM-tier policy for the bundled on-device agent (elizaOS/eliza#14390).
+ *
+ * <p>Low-RAM phones cannot sustain the Bun agent runtime: a 4 GB Moto G Play
+ * (2024) wedges boot for the full 180 s startup budget before surfacing a
+ * "Backend Timeout" card. The product policy is RAM-driven, not build-driven —
+ * a device below the 8 GB marketed-RAM floor is cloud-only and must never spawn
+ * the local agent, no matter which APK variant is installed or what runtime
+ * mode an older install persisted (the mode survives reinstalls via Capacitor
+ * Preferences).
+ *
+ * <p>{@code ActivityManager.MemoryInfo.totalMem} under-reports the marketed
+ * capacity because the kernel/carveout reserve a slice (a marketed "4 GB"
+ * device reports ~3.6 GiB, an "8 GB" one ~7.2-7.6 GiB), so the policy first
+ * rounds the reading UP to the next whole GiB — recovering the marketed size —
+ * and applies the floor to that. The renderer mirrors this exact conversion in
+ * {@code packages/ui/src/first-run/device-ram-tier.ts} (which also owns the
+ * 12/16 GB local-model tiers); keep the two in sync.
+ *
+ * <p>All methods are pure (no Android runtime calls) so the policy is covered
+ * by plain JVM unit tests; callers supply {@code totalMem} bytes.
+ */
+final class DeviceRamTierPolicy {
+
+    private DeviceRamTierPolicy() {
+    }
+
+    /** Marketed-RAM floor (GB) below which the on-device agent is disabled. */
+    static final int LOCAL_AGENT_MIN_MARKETED_RAM_GB = 8;
+
+    private static final long ONE_GIB = 1L << 30;
+
+    /**
+     * The device's marketed RAM size in GB recovered from a raw
+     * {@code totalMem} reading (round up to the next whole GiB), or -1 when the
+     * reading is absent/invalid ({@code <= 0}) — never a fabricated size.
+     */
+    static int marketedRamGb(long totalMemBytes) {
+        if (totalMemBytes <= 0) return -1;
+        return (int) ((totalMemBytes + ONE_GIB - 1) / ONE_GIB);
+    }
+
+    /**
+     * Whether this device may run the bundled on-device agent at all.
+     *
+     * <p>An unreadable {@code totalMem} (no ActivityManager — not observed on
+     * any real device) fails OPEN: the only mode that consults this gate is an
+     * explicit user "local" choice, and bricking that choice on a probe failure
+     * would be worse than the wedge it guards against.
+     */
+    static boolean allowsLocalAgent(long totalMemBytes) {
+        int marketed = marketedRamGb(totalMemBytes);
+        if (marketed < 0) return true;
+        return marketed >= LOCAL_AGENT_MIN_MARKETED_RAM_GB;
+    }
+}

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -3772,50 +3772,63 @@ public class ElizaAgentService extends Service {
      * - On AOSP / ElizaOS-branded devices (`ro.elizaos.product` set or any
      *   white-label fork's `ro.<brand>os.product`), the device IS the
      *   agent: always start.
-     * - On stock Android, start when the user picked the Local runtime in
-     *   the onboarding picker (mobile-runtime-mode == "local"), or when no
-     *   mode has been chosen yet on a build that ships the agent payload.
-     *   The renderer's pre-seed (pre-seed-local-runtime.ts) commits the
-     *   on-device agent as the startup target on the first frame of every
-     *   payload-shipping build — but it runs after this gate has already
-     *   been evaluated in MainActivity.onCreate, so waiting for the
-     *   persisted choice deadlocks the first-ever launch: the WebView polls
-     *   an abstract socket no one is serving until the startup timeout card
-     *   (#15189). Matching the pre-seed's build truth here closes that gap;
-     *   the cloud-thinned Play-Store build and UI-only debug builds carry no
-     *   payload and keep the cloud-first fresh-install behavior.
+     * - On stock Android, start ONLY when the user picked the Local runtime
+     *   in onboarding (mobile-runtime-mode == "local") AND the device clears
+     *   the {@link DeviceRamTierPolicy} 8 GB marketed-RAM floor. A persisted
+     *   "local" survives reinstalls via Capacitor Preferences, so the RAM
+     *   check re-runs every boot — a low-RAM device carrying a stale "local"
+     *   must not wedge boot for the 180 s startup budget (#14390).
+     * - No persisted mode (a fresh install) never auto-starts: onboarding
+     *   owns the runtime decision, and the renderer starts this service on
+     *   demand through the Agent Capacitor plugin the moment the user commits
+     *   to the local runtime (first-run-finish.ts startMobileLocalAgent) — no
+     *   app restart involved. That renderer-driven start replaces the old
+     *   fresh-install auto-start of payload-shipping builds (#15189), which
+     *   booted the agent on 4 GB phones before the user had chosen anything.
      * - An explicit cloud, hybrid cloud, remote, or tunnel choice never
      *   auto-starts this service.
      */
     public static boolean shouldAutoStart(Context context) {
-        return shouldAutoStartForRuntimeMode(
-            isBrandedDevice(), readRuntimeMode(context), apkBundlesAgentPayload(context));
+        String mode = readRuntimeMode(context);
+        long totalMemBytes = readDeviceTotalMemBytes(context);
+        boolean deviceAllowsLocalAgent = DeviceRamTierPolicy.allowsLocalAgent(totalMemBytes);
+        boolean start = shouldAutoStartForRuntimeMode(
+            isBrandedDevice(), mode, deviceAllowsLocalAgent);
+        String trimmed = mode == null ? null : mode.trim();
+        if (!start && "local".equals(trimmed) && !deviceAllowsLocalAgent) {
+            // Fail loud (#14390): a persisted local choice on a device below the
+            // RAM floor is refused, not silently attempted-and-wedged. The
+            // renderer heals the stale mode back to onboarding at boot
+            // (device-ram-tier.ts enforceDeviceRamPolicyOnPersistedRuntimeMode).
+            Log.w(TAG, "refusing to auto-start the on-device agent: persisted local"
+                + " runtime mode on a device below the "
+                + DeviceRamTierPolicy.LOCAL_AGENT_MIN_MARKETED_RAM_GB
+                + " GB RAM floor (marketed "
+                + DeviceRamTierPolicy.marketedRamGb(totalMemBytes) + " GB)");
+        }
+        return start;
     }
 
     static boolean shouldAutoStartForRuntimeMode(
-            boolean brandedDevice, String mode, boolean bundlesAgentPayload) {
+            boolean brandedDevice, String mode, boolean deviceAllowsLocalAgent) {
         if (brandedDevice) return true;
         String trimmed = mode == null ? null : mode.trim();
-        if ("local".equals(trimmed)) return true;
-        return (trimmed == null || trimmed.isEmpty()) && bundlesAgentPayload;
+        return "local".equals(trimmed) && deviceAllowsLocalAgent;
     }
 
     /**
-     * Whether this APK ships the on-device agent payload. Native mirror of the
-     * renderer's isAndroidLocalSideloadBuild() build truth: the cloud-thinning
-     * build step strips assets/agent/** from the Play-Store APK, so probing the
-     * bundle asset distinguishes the local-sideload/system builds (payload
-     * present) from cloud-thinned and UI-only WebView-debug builds.
+     * Device total RAM from {@code ActivityManager.MemoryInfo.totalMem}, or
+     * -1 when unreadable — the tier policy treats an unreadable total as
+     * "unknown", never as zero RAM.
      */
-    static boolean apkBundlesAgentPayload(Context context) {
-        if (context == null) return false;
-        try (InputStream probe = context.getAssets().open("agent/" + AGENT_BUNDLE_NAME)) {
-            return true;
-        } catch (IOException missing) {
-            // error-policy:J3 asset probe — absence of the bundle IS the negative
-            // signal (thinned build), not a failure to report.
-            return false;
-        }
+    private static long readDeviceTotalMemBytes(Context context) {
+        if (context == null) return -1L;
+        ActivityManager am =
+            (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+        if (am == null) return -1L;
+        ActivityManager.MemoryInfo info = new ActivityManager.MemoryInfo();
+        am.getMemoryInfo(info);
+        return info.totalMem > 0 ? info.totalMem : -1L;
     }
 
     /**
@@ -3860,8 +3873,26 @@ public class ElizaAgentService extends Service {
         }
     }
 
-    /** Start the foreground service (safe to call repeatedly). */
+    /**
+     * Start the foreground service (safe to call repeatedly).
+     *
+     * <p>Throws {@link IllegalStateException} on a stock device below the
+     * {@link DeviceRamTierPolicy} RAM floor (#14390): every start affordance
+     * — the onboarding finish via the Agent Capacitor plugin, the startup
+     * poll's revive request, the boot receiver — funnels here, so this is the
+     * one fail-loud backstop against a disallowed mode wedging boot. The
+     * renderer surfaces the rejection as the onboarding/startup error it
+     * already renders; branded devices ARE the agent and are exempt.
+     */
     public static void start(Context context) {
+        long totalMemBytes = readDeviceTotalMemBytes(context);
+        if (!isBrandedDevice() && !DeviceRamTierPolicy.allowsLocalAgent(totalMemBytes)) {
+            throw new IllegalStateException(
+                "This device (~" + DeviceRamTierPolicy.marketedRamGb(totalMemBytes)
+                + " GB RAM) is below the "
+                + DeviceRamTierPolicy.LOCAL_AGENT_MIN_MARKETED_RAM_GB
+                + " GB floor for the on-device agent; use cloud mode");
+        }
         Intent intent = new Intent(context, ElizaAgentService.class);
         intent.setAction(ACTION_START);
         try {

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaNativeBridge.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaNativeBridge.java
@@ -1,5 +1,6 @@
 package ai.elizaos.app;
 
+import android.app.ActivityManager;
 import android.content.Context;
 import android.webkit.JavascriptInterface;
 
@@ -46,6 +47,24 @@ public final class ElizaNativeBridge {
     @JavascriptInterface
     public String getStartupTraceId() {
         return ElizaStartupTrace.currentId();
+    }
+
+    /**
+     * Device total RAM in MB ({@code ActivityManager.MemoryInfo.totalMem}),
+     * or -1 when unreadable — never a fabricated zero. Synchronous on purpose:
+     * the renderer's boot-time RAM-tier gate (#14390,
+     * {@code packages/ui/src/first-run/device-ram-tier.ts}) runs before the
+     * Capacitor plugin executor is trustworthy (see the dead-Handler note in
+     * the class header) and before any agent is running.
+     */
+    @JavascriptInterface
+    public long getDeviceTotalRamMb() {
+        ActivityManager am =
+            (ActivityManager) appContext.getSystemService(Context.ACTIVITY_SERVICE);
+        if (am == null) return -1L;
+        ActivityManager.MemoryInfo info = new ActivityManager.MemoryInfo();
+        am.getMemoryInfo(info);
+        return info.totalMem > 0 ? info.totalMem / 1_048_576L : -1L;
     }
 
     @JavascriptInterface

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java
@@ -132,20 +132,22 @@ public class MainActivity extends BridgeActivity {
 
         // Auto-start the local Eliza agent runtime as a foreground service.
         // shouldAutoStart() returns true on branded devices (AOSP/ElizaOS —
-        // the device IS the agent), on stock Android when the user picked
-        // Local mode in onboarding, and on a fresh install of any build that
-        // ships the agent payload — the renderer pre-seeds the on-device
-        // agent as its backend on first paint, so the payload build must
-        // start it here or the first launch polls a socket no one serves
-        // (#15189). Explicit Cloud/Remote choices skip this so we don't burn
-        // battery on a service they never call. The boot receiver covers the
-        // cold-boot path; this is the fast path when the user opens the app.
+        // the device IS the agent) and on stock Android ONLY when the user
+        // picked Local mode in onboarding AND the device clears the 8 GB RAM
+        // floor (DeviceRamTierPolicy, #14390). A fresh install never
+        // auto-starts: onboarding owns the runtime decision, and the renderer
+        // starts this service on demand through the Agent Capacitor plugin
+        // when the user commits to the local runtime — starting a 4 GB phone's
+        // bundled agent before any choice wedged boot for the full 180 s
+        // startup budget. Explicit Cloud/Remote choices skip this so we don't
+        // burn battery on a service they never call. The boot receiver covers
+        // the cold-boot path; this is the fast path when the user opens the
+        // app.
         if (ElizaAgentService.shouldAutoStart(this)) {
             ElizaAgentService.start(this);
             // Ask for notification consent only once the user (or the device
-            // image) has actually committed to running the on-device agent.
-            // A fresh install runs the pre-seeded agent before any recorded
-            // choice — keep first paint free of a cold permission ask and let
+            // image) has actually committed to running the on-device agent —
+            // keep first paint free of a cold permission ask and let
             // onboarding own that moment.
             if (ElizaAgentService.hasCommittedRuntimeChoice(this)) {
                 requestPostNotificationsIfNeeded();

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ResourceProbePlugin.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ResourceProbePlugin.java
@@ -35,7 +35,9 @@ import java.nio.file.Paths;
  *   <li><b>battery</b> — {@link BatteryManager} level (%), charge counter (µAh),
  *       instantaneous current (µA), and charging flag.</li>
  *   <li><b>memory</b> — {@link Debug#getMemoryInfo} total PSS (the app's real
- *       footprint) plus {@link ActivityManager.MemoryInfo} device available RAM.</li>
+ *       footprint) plus {@link ActivityManager.MemoryInfo} device available
+ *       and total RAM (the latter feeds the renderer's RAM-tier gating,
+ *       #14390).</li>
  *   <li><b>cpuTimeMs</b> — process user+system jiffies from {@code /proc/self/stat}
  *       converted via {@code sysconf(_SC_CLK_TCK)}.</li>
  *   <li><b>lowPowerMode</b> — {@link PowerManager#isPowerSaveMode()}.</li>
@@ -66,6 +68,7 @@ public class ResourceProbePlugin extends Plugin {
 
         result.put("residentMemoryMb", readTotalPssMb());
         result.put("availableRamMb", readAvailableRamMb(context));
+        result.put("totalRamMb", readTotalRamMb(context));
         result.put("cpuTimeMs", readProcessCpuTimeMs());
 
         result.put("capturedAtMs", System.currentTimeMillis());
@@ -132,6 +135,21 @@ public class ResourceProbePlugin extends Plugin {
         ActivityManager.MemoryInfo info = new ActivityManager.MemoryInfo();
         am.getMemoryInfo(info);
         return info.availMem / 1_048_576.0;
+    }
+
+    /**
+     * Device total physical RAM in MB. Feeds the renderer's RAM-tier gating
+     * (#14390) on paths where the synchronous {@code ElizaNativeBridge} read
+     * is unavailable; JSON null when the OS cannot provide it.
+     */
+    private static Object readTotalRamMb(Context context) {
+        ActivityManager am = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+        if (am == null) {
+            return JSONObject.NULL;
+        }
+        ActivityManager.MemoryInfo info = new ActivityManager.MemoryInfo();
+        am.getMemoryInfo(info);
+        return info.totalMem > 0 ? info.totalMem / 1_048_576.0 : JSONObject.NULL;
     }
 
     /**

--- a/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/DeviceRamTierPolicyTest.java
+++ b/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/DeviceRamTierPolicyTest.java
@@ -1,0 +1,62 @@
+/**
+ * JVM unit tests for the device RAM-tier policy (#14390): marketed-GB recovery
+ * from raw totalMem readings and the 8 GB on-device-agent floor, pinned against
+ * real observed device readings.
+ */
+package ai.elizaos.app;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class DeviceRamTierPolicyTest {
+
+    private static long kb(long kiloBytes) {
+        return kiloBytes * 1024L;
+    }
+
+    private static long gib(double gibibytes) {
+        return (long) (gibibytes * (1L << 30));
+    }
+
+    @Test
+    public void marketedGbRecoversTheAdvertisedSizeFromKernelReducedReadings() {
+        // Moto G Play 2024, the #14390 device: /proc/meminfo MemTotal 3,747,844 kB.
+        assertEquals(4, DeviceRamTierPolicy.marketedRamGb(kb(3_747_844)));
+        // 6 GB-nominal (Pixel 6a class reports ~5.7 GiB usable).
+        assertEquals(6, DeviceRamTierPolicy.marketedRamGb(gib(5.7)));
+        // 8 GB-nominal phones report ~7.2-7.6 GiB.
+        assertEquals(8, DeviceRamTierPolicy.marketedRamGb(gib(7.2)));
+        assertEquals(8, DeviceRamTierPolicy.marketedRamGb(gib(7.6)));
+        // 12 / 16 GB-nominal.
+        assertEquals(12, DeviceRamTierPolicy.marketedRamGb(gib(11.3)));
+        assertEquals(16, DeviceRamTierPolicy.marketedRamGb(gib(15.2)));
+        // An exact power-of-two reading (emulator) is not rounded past itself.
+        assertEquals(8, DeviceRamTierPolicy.marketedRamGb(gib(8.0)));
+    }
+
+    @Test
+    public void unreadableTotalMemIsUnknownNotZero() {
+        assertEquals(-1, DeviceRamTierPolicy.marketedRamGb(0L));
+        assertEquals(-1, DeviceRamTierPolicy.marketedRamGb(-1L));
+    }
+
+    @Test
+    public void localAgentFloorIsEightMarketedGb() {
+        assertFalse(DeviceRamTierPolicy.allowsLocalAgent(kb(3_747_844)));
+        assertFalse(DeviceRamTierPolicy.allowsLocalAgent(gib(5.7)));
+        assertTrue(DeviceRamTierPolicy.allowsLocalAgent(gib(7.2)));
+        assertTrue(DeviceRamTierPolicy.allowsLocalAgent(gib(11.3)));
+        assertTrue(DeviceRamTierPolicy.allowsLocalAgent(gib(15.2)));
+    }
+
+    @Test
+    public void unreadableTotalMemFailsOpenForAnExplicitLocalChoice() {
+        // The only mode that consults this gate is an explicit user "local"
+        // choice; a probe failure must not brick it.
+        assertTrue(DeviceRamTierPolicy.allowsLocalAgent(0L));
+        assertTrue(DeviceRamTierPolicy.allowsLocalAgent(-1L));
+    }
+}

--- a/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaAgentAutostartPolicyTest.java
+++ b/packages/app-core/platforms/android/app/src/test/java/ai/elizaos/app/ElizaAgentAutostartPolicyTest.java
@@ -10,54 +10,63 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 /**
- * JVM unit tests for the stock-Android local-agent autostart policy. The gate
- * must mirror the renderer's pre-seed build truth (pre-seed-local-runtime.ts):
- * a build that ships the agent payload boots it even before onboarding records
- * a choice — the renderer already committed to it as the startup target, and
- * waiting for the persisted choice deadlocks the first-ever launch (#15189).
- * Builds without the payload (cloud-thinned Play Store, UI-only debug) stay
- * cloud-first, and an explicit non-local user choice is always respected.
+ * JVM unit tests for the stock-Android local-agent autostart policy (#14390).
+ * Only two things may auto-start the bundled agent: a branded device (the
+ * device IS the agent) or an explicit onboarding "local" choice on a device
+ * that clears the RAM-tier floor. A fresh install (no persisted mode) never
+ * auto-starts — onboarding owns the decision and the renderer starts the
+ * service on demand through the Agent Capacitor plugin — and a persisted
+ * "local" on a RAM-blocked device is refused instead of wedging boot.
  */
 public class ElizaAgentAutostartPolicyTest {
 
+    private static final boolean RAM_OK = true;
+    private static final boolean RAM_BLOCKED = false;
+
     @Test
     public void brandedDevicesAlwaysStartTheBundledAgent() {
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, null, true));
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, null, false));
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, "cloud", false));
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, "remote-mac", false));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, null, RAM_OK));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, null, RAM_BLOCKED));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, "cloud", RAM_OK));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(true, "remote-mac", RAM_BLOCKED));
     }
 
     @Test
-    public void stockFreshInstallStartsTheAgentWhenTheBuildShipsIt() {
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, null, true));
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "", true));
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "   ", true));
+    public void stockFreshInstallNeverAutoStarts() {
+        // The runtime decision belongs to onboarding: with no persisted mode the
+        // renderer must land in first-run, then start the service explicitly
+        // once the user commits to the local runtime.
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, null, RAM_OK));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "", RAM_OK));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "   ", RAM_OK));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, null, RAM_BLOCKED));
     }
 
     @Test
-    public void stockFreshInstallStaysCloudFirstWithoutThePayload() {
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, null, false));
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "", false));
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "   ", false));
-    }
-
-    @Test
-    public void stockCloudModesStayCloudFirstEvenWithThePayload() {
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "cloud", true));
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "cloud-hybrid", true));
+    public void stockCloudModesStayCloudFirst() {
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "cloud", RAM_OK));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "cloud-hybrid", RAM_OK));
     }
 
     @Test
     public void stockExternalModesDoNotStartTheBundledAgent() {
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "remote-mac", true));
-        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "tunnel-to-mobile", true));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "remote-mac", RAM_OK));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "tunnel-to-mobile", RAM_OK));
     }
 
     @Test
-    public void stockLocalModeStartsTheBundledAgent() {
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "local", true));
-        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, " local ", false));
+    public void stockLocalModeStartsTheBundledAgentWhenRamAllows() {
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "local", RAM_OK));
+        assertTrue(ElizaAgentService.shouldAutoStartForRuntimeMode(false, " local ", RAM_OK));
+    }
+
+    @Test
+    public void stockLocalModeIsRefusedBelowTheRamFloor() {
+        // A persisted "local" survives reinstalls via Capacitor Preferences, so
+        // a low-RAM device can carry one it can no longer honor — refusing here
+        // is what keeps a 4 GB phone from wedging boot for the 180 s budget.
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, "local", RAM_BLOCKED));
+        assertFalse(ElizaAgentService.shouldAutoStartForRuntimeMode(false, " local ", RAM_BLOCKED));
     }
 
     /**

--- a/packages/app-core/platforms/ios/App/App/ElizaIntentPlugin.swift
+++ b/packages/app-core/platforms/ios/App/App/ElizaIntentPlugin.swift
@@ -339,12 +339,19 @@ public class ElizaIntentPlugin: CAPPlugin, CAPBridgedPlugin {
         let charging = device.batteryState == .charging || device.batteryState == .full
         device.isBatteryMonitoringEnabled = priorMonitoring
 
+        // Device total physical RAM: feeds the renderer's RAM-tier gating
+        // (#14390) alongside the marketed-GB figure in getDeviceCapabilities.
+        let totalRamMb: Any = info.physicalMemory > 0
+            ? Double(info.physicalMemory) / 1_048_576.0
+            : NSNull()
+
         call.resolve([
             "platform": "ios",
             "thermalState": thermal,
             "lowPowerMode": info.isLowPowerModeEnabled,
             "residentMemoryMb": residentMb,
             "availableRamMb": availableMb,
+            "totalRamMb": totalRamMb,
             "cpuTimeMs": cpuMs,
             "batteryLevelPct": batteryPct,
             "isCharging": charging,

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -476,12 +476,12 @@ installDesktopPermissionsClientPatch(client);
 applyCloudPairSessionToken();
 applyRuntimeChooserOverrideFromUrl();
 
-// NOTE: do not gate on isElizaOS() here — that requires the `ElizaOS/` UA
-// marker which only AOSP/branded device images carry, so it excluded the
-// stock-phone local sideload build (the on-device-agent APK) and left it stuck
-// on cloud onboarding. preSeedAndroidLocalRuntimeIfFresh() self-gates to the
-// local Android build (native android + non-cloud build), so it's safe to call
-// unconditionally here; it no-ops on iOS/desktop/web and cloud builds.
+// Branded AOSP/ElizaOS device images ARE the agent: pre-seed the on-device
+// agent as the startup target on first frame. Stock-phone sideload builds
+// self-exclude inside preSeedAndroidLocalRuntimeIfFresh (#14390): a fresh
+// install lands in onboarding, whose runtime chooser (enabled by default on
+// those builds) starts the local agent on demand only after the user picks
+// it. No-op on iOS/desktop/web and cloud builds.
 if (!hasFirstRunRuntimeOverride()) {
   preSeedAndroidLocalRuntimeIfFresh();
 }

--- a/packages/ui/src/api/android-native-agent-transport.ts
+++ b/packages/ui/src/api/android-native-agent-transport.ts
@@ -380,14 +380,15 @@ export async function androidNativeAgentLifecycleForUrl(
  * Ask the native service to start the on-device agent that `url` targets.
  * The startup coordinator fires this for the local-agent base it polls: the
  * poll itself cannot wake the agent (an abstract-socket connect just blocks
- * while nobody listens), and on a fresh install nothing else will — the
- * MainActivity auto-start gate is evaluated before the renderer pre-seeds
- * local mode, and onboarding (the only other `Agent.start()` caller) is
- * skipped on the pre-seeded path (#15189). Native start is idempotent — a
- * START_AGENT delivery to a running/booting service is absorbed by the
- * socket-adopt and cold-boot guards — so callers may fire this once per
- * polled base without coordinating with service state. Returns whether a
- * start request actually reached the native plugin.
+ * while nobody listens). A branded device auto-starts the agent at boot and a
+ * stock device starts it from the onboarding finish once the user commits to
+ * the local runtime (#14390), but a START_AGENT can be lost to a
+ * service-teardown race or a child death, so the poll re-requests it as a
+ * self-healing backstop. Native start is idempotent — a delivery to a
+ * running/booting service is absorbed by the socket-adopt and cold-boot
+ * guards — so callers may fire this once per polled base without coordinating
+ * with service state. Returns whether a start request actually reached the
+ * native plugin.
  */
 export async function requestAndroidLocalAgentStartForUrl(
   url: string | null | undefined,

--- a/packages/ui/src/bridge/native-plugins.ts
+++ b/packages/ui/src/bridge/native-plugins.ts
@@ -275,6 +275,8 @@ export interface AgentPluginLike extends NativePlugin {
     body?: string | null;
   }>;
   start?: (options?: { apiBase?: string; mode?: string }) => Promise<unknown>;
+  /** Stop the on-device agent service (reversal cleanup, #14390). */
+  stop?: () => Promise<unknown>;
 }
 
 export interface MobileSignalsPermissionStatus {

--- a/packages/ui/src/first-run/device-ram-gate.test.ts
+++ b/packages/ui/src/first-run/device-ram-gate.test.ts
@@ -1,0 +1,260 @@
+// @vitest-environment jsdom
+
+/**
+ * Device RAM-gate coverage (#14390) through its REAL seams: the synchronous
+ * `globalThis.ElizaNative.getDeviceTotalRamMb()` Android bridge, the async
+ * native resource snapshot fallback, the fail-loud finish assertion, and the
+ * boot-time enforcement that reverts a stale persisted "local" mode on a
+ * RAM-blocked device. Only the platform constant and the native snapshot call
+ * (device boundaries) are substituted; classification, caching, and the
+ * persisted-state cleanup run for real against jsdom localStorage.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  isAndroid: true,
+  isIOS: false,
+  resourceSnapshot: null as { totalRamMb: number | null } | null,
+}));
+
+vi.mock("../platform/init", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../platform/init")>();
+  return {
+    ...actual,
+    get isAndroid() {
+      return mocks.isAndroid;
+    },
+    get isIOS() {
+      return mocks.isIOS;
+    },
+  };
+});
+
+vi.mock(
+  "../services/local-inference/resource-snapshot-bridge",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("../services/local-inference/resource-snapshot-bridge")
+      >();
+    return {
+      ...actual,
+      getDeviceResourceSnapshot: async () => mocks.resourceSnapshot,
+    };
+  },
+);
+
+import {
+  loadPersistedActiveServer,
+  savePersistedActiveServer,
+} from "../state/persistence";
+import {
+  assertDeviceRamTierAllowsLocalRuntime,
+  enforceDeviceRamPolicyOnPersistedRuntimeModeAtBoot,
+  peekDeviceRamTierAssessment,
+  resetDeviceRamGateForTests,
+  resolveDeviceRamTierAssessment,
+} from "./device-ram-gate";
+import {
+  ANDROID_LOCAL_AGENT_IPC_BASE,
+  ANDROID_LOCAL_AGENT_LABEL,
+  ANDROID_LOCAL_AGENT_SERVER_ID,
+  persistMobileRuntimeMode,
+  readPersistedMobileRuntimeMode,
+} from "./mobile-runtime-mode";
+
+// This jsdom env exposes `window.localStorage` as an object without methods;
+// install a real in-memory Storage (mirrors `first-run.test.ts`).
+function ensureLocalStorage(): Storage {
+  if (typeof window.localStorage?.clear === "function") {
+    return window.localStorage;
+  }
+  const values = new Map<string, string>();
+  const storage = {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      values.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      values.set(key, String(value));
+    },
+  } satisfies Storage;
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+  return storage;
+}
+
+type GlobalWithBridge = typeof globalThis & {
+  ElizaNative?: { getDeviceTotalRamMb?: () => number };
+};
+
+function installSyncBridge(totalRamMb: number): void {
+  (globalThis as GlobalWithBridge).ElizaNative = {
+    getDeviceTotalRamMb: () => totalRamMb,
+  };
+}
+
+beforeEach(() => {
+  ensureLocalStorage().clear();
+  resetDeviceRamGateForTests();
+  mocks.isAndroid = true;
+  mocks.isIOS = false;
+  mocks.resourceSnapshot = null;
+  delete (globalThis as GlobalWithBridge).ElizaNative;
+});
+
+afterEach(() => {
+  ensureLocalStorage().clear();
+  delete (globalThis as GlobalWithBridge).ElizaNative;
+});
+
+describe("peekDeviceRamTierAssessment", () => {
+  it("classifies synchronously from the Android native bridge", () => {
+    // The #14390 Moto G Play: totalMem ~3660 MB → marketed 4 GB → cloud-only.
+    installSyncBridge(3660);
+    const a = peekDeviceRamTierAssessment();
+    expect(a?.tier).toBe("cloud-only");
+    expect(a?.marketedRamGb).toBe(4);
+    expect(a?.allowsLocalAgent).toBe(false);
+  });
+
+  it("treats the bridge's -1 unreadable sentinel as not-yet-known", () => {
+    installSyncBridge(-1);
+    expect(peekDeviceRamTierAssessment()).toBeNull();
+  });
+
+  it("returns null on mobile before any probe answered", () => {
+    expect(peekDeviceRamTierAssessment()).toBeNull();
+  });
+
+  it("classifies non-mobile platforms as the ungated unknown tier", () => {
+    mocks.isAndroid = false;
+    mocks.isIOS = false;
+    const a = peekDeviceRamTierAssessment();
+    expect(a?.tier).toBe("unknown");
+    expect(a?.allowsLocalAgent).toBe(true);
+  });
+});
+
+describe("resolveDeviceRamTierAssessment", () => {
+  it("falls back to the async resource snapshot when no sync bridge exists (iOS path)", async () => {
+    mocks.isAndroid = false;
+    mocks.isIOS = true;
+    mocks.resourceSnapshot = { totalRamMb: 7.5 * 1024 };
+    const a = await resolveDeviceRamTierAssessment();
+    expect(a.tier).toBe("no-local-models");
+    expect(a.marketedRamGb).toBe(8);
+    // The resolved assessment is cached for synchronous peeks.
+    expect(peekDeviceRamTierAssessment()?.tier).toBe("no-local-models");
+  });
+
+  it("classifies an unreachable probe as the explicit unknown tier", async () => {
+    mocks.resourceSnapshot = null;
+    const a = await resolveDeviceRamTierAssessment();
+    expect(a.tier).toBe("unknown");
+    expect(a.allowsLocalAgent).toBe(true);
+  });
+});
+
+describe("assertDeviceRamTierAllowsLocalRuntime", () => {
+  it("throws for ANY local runtime on a sub-8 GB device", async () => {
+    installSyncBridge(3660);
+    await expect(
+      assertDeviceRamTierAllowsLocalRuntime("all-local"),
+    ).rejects.toThrow(/on-device agent/);
+    await expect(
+      assertDeviceRamTierAllowsLocalRuntime("cloud-inference"),
+    ).rejects.toThrow(/on-device agent/);
+  });
+
+  it("allows the hybrid runtime but rejects on-device models on 8-11 GB", async () => {
+    installSyncBridge(7500);
+    await expect(
+      assertDeviceRamTierAllowsLocalRuntime("cloud-inference"),
+    ).resolves.toBeUndefined();
+    await expect(
+      assertDeviceRamTierAllowsLocalRuntime("configure-later"),
+    ).resolves.toBeUndefined();
+    await expect(
+      assertDeviceRamTierAllowsLocalRuntime("all-local"),
+    ).rejects.toThrow(/on-device models/);
+  });
+
+  it("passes everything on a 16 GB+ device", async () => {
+    installSyncBridge(15.5 * 1024);
+    await expect(
+      assertDeviceRamTierAllowsLocalRuntime("all-local"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("never blocks when the device total is unreadable (unknown tier)", async () => {
+    mocks.resourceSnapshot = { totalRamMb: null };
+    await expect(
+      assertDeviceRamTierAllowsLocalRuntime("all-local"),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("enforceDeviceRamPolicyOnPersistedRuntimeModeAtBoot", () => {
+  function seedLocalCommitment(): void {
+    persistMobileRuntimeMode("local");
+    savePersistedActiveServer({
+      id: ANDROID_LOCAL_AGENT_SERVER_ID,
+      kind: "remote",
+      label: ANDROID_LOCAL_AGENT_LABEL,
+      apiBase: ANDROID_LOCAL_AGENT_IPC_BASE,
+    });
+  }
+
+  it("reverts a stale persisted local mode on a RAM-blocked device", () => {
+    installSyncBridge(3660);
+    seedLocalCommitment();
+
+    expect(enforceDeviceRamPolicyOnPersistedRuntimeModeAtBoot()).toBe(true);
+    expect(readPersistedMobileRuntimeMode()).toBeNull();
+    expect(loadPersistedActiveServer()).toBeNull();
+  });
+
+  it("keeps a persisted local mode on a capable device", () => {
+    installSyncBridge(15.5 * 1024);
+    seedLocalCommitment();
+
+    expect(enforceDeviceRamPolicyOnPersistedRuntimeModeAtBoot()).toBe(false);
+    expect(readPersistedMobileRuntimeMode()).toBe("local");
+    expect(loadPersistedActiveServer()?.id).toBe(ANDROID_LOCAL_AGENT_SERVER_ID);
+  });
+
+  it("never touches cloud/remote modes even on a blocked device", () => {
+    installSyncBridge(3660);
+    persistMobileRuntimeMode("cloud");
+
+    expect(enforceDeviceRamPolicyOnPersistedRuntimeModeAtBoot()).toBe(false);
+    expect(readPersistedMobileRuntimeMode()).toBe("cloud");
+  });
+
+  it("does nothing when the RAM tier is not synchronously known", () => {
+    // No sync bridge: the boot path must not block on the async probe; the
+    // native shouldAutoStart gate independently refuses a blocked start.
+    seedLocalCommitment();
+
+    expect(enforceDeviceRamPolicyOnPersistedRuntimeModeAtBoot()).toBe(false);
+    expect(readPersistedMobileRuntimeMode()).toBe("local");
+  });
+
+  it("is a no-op off mobile", () => {
+    mocks.isAndroid = false;
+    installSyncBridge(3660);
+    persistMobileRuntimeMode("local");
+
+    expect(enforceDeviceRamPolicyOnPersistedRuntimeModeAtBoot()).toBe(false);
+    expect(readPersistedMobileRuntimeMode()).toBe("local");
+  });
+});

--- a/packages/ui/src/first-run/device-ram-gate.ts
+++ b/packages/ui/src/first-run/device-ram-gate.ts
@@ -1,0 +1,154 @@
+/**
+ * Device RAM-tier gate (#14390): probes the phone's total physical RAM through
+ * the native bridges, classifies it (`device-ram-tier.ts`), and enforces the
+ * policy at the two renderer seams that can commit a local runtime — the boot
+ * path (a stale persisted "local" on a RAM-blocked device is reverted to
+ * onboarding before startup resolves its target) and the first-run finish
+ * (`first-run-finish.ts` calls `assertDeviceRamTierAllowsLocalRuntime` before
+ * starting anything, so a disallowed mode fails loud instead of wedging).
+ *
+ * Probe order: the synchronous Android `ElizaNative.getDeviceTotalRamMb()`
+ * JavascriptInterface first (available before the Capacitor plugin executor
+ * and before any agent runs), then the async native resource snapshot
+ * (`ResourceProbe`/`ElizaIntent.getResourceSnapshot`, which now carries
+ * `totalRamMb`). Web/desktop are not governed by this policy — desktop has its
+ * own device-tier system (`client-local-inference.ts`) — and classify as
+ * "unknown" (gates nothing).
+ *
+ * The resolved assessment is cached for the session: total RAM cannot change
+ * while the app runs, and the onboarding pick handlers need a synchronous
+ * `peek` at decision time.
+ */
+
+import { logger } from "@elizaos/logger";
+import { isAndroid, isIOS } from "../platform/init";
+import { getDeviceResourceSnapshot } from "../services/local-inference/resource-snapshot-bridge";
+import {
+  classifyDeviceRamTier,
+  type DeviceRamTierAssessment,
+  marketedRamGbFromTotalRamMb,
+} from "./device-ram-tier";
+import { readPersistedMobileRuntimeMode } from "./mobile-runtime-mode";
+import { clearPersistedLocalRuntimeCommitment } from "./revert-local-runtime-commitment";
+
+interface ElizaNativeRamBridge {
+  getDeviceTotalRamMb?: () => number;
+}
+
+/** The synchronous Android bridge read, or null off-Android / unavailable. */
+function readSyncDeviceTotalRamMb(): number | null {
+  try {
+    const bridge = (
+      globalThis as typeof globalThis & { ElizaNative?: ElizaNativeRamBridge }
+    ).ElizaNative;
+    const raw = bridge?.getDeviceTotalRamMb?.();
+    // The bridge returns -1 for "unreadable" — never a fabricated zero.
+    return typeof raw === "number" && Number.isFinite(raw) && raw > 0
+      ? raw
+      : null;
+  } catch {
+    // error-policy:J4 native-bridge probe — no sync bridge means this shell
+    // doesn't expose it; the async snapshot probe still runs.
+    return null;
+  }
+}
+
+let cachedAssessment: DeviceRamTierAssessment | null = null;
+let resolveInFlight: Promise<DeviceRamTierAssessment> | null = null;
+
+/** Test seam: drop the session cache. */
+export function resetDeviceRamGateForTests(): void {
+  cachedAssessment = null;
+  resolveInFlight = null;
+}
+
+/**
+ * The already-known assessment, resolving the synchronous Android bridge on
+ * first call; null while only the async probe could answer (iOS before
+ * `resolveDeviceRamTierAssessment` lands). Pick handlers use this at decision
+ * time; the finish path re-checks with the authoritative async resolve.
+ */
+export function peekDeviceRamTierAssessment(): DeviceRamTierAssessment | null {
+  if (cachedAssessment) return cachedAssessment;
+  if (!isAndroid && !isIOS) {
+    cachedAssessment = classifyDeviceRamTier(null);
+    return cachedAssessment;
+  }
+  const syncMb = readSyncDeviceTotalRamMb();
+  if (syncMb !== null) {
+    cachedAssessment = classifyDeviceRamTier(
+      marketedRamGbFromTotalRamMb(syncMb),
+    );
+    return cachedAssessment;
+  }
+  return null;
+}
+
+/**
+ * Resolve (and cache) the device RAM-tier assessment. Never rejects: an
+ * unreachable probe classifies as the explicit "unknown" tier.
+ */
+export async function resolveDeviceRamTierAssessment(): Promise<DeviceRamTierAssessment> {
+  const peeked = peekDeviceRamTierAssessment();
+  if (peeked) return peeked;
+  if (!resolveInFlight) {
+    resolveInFlight = (async () => {
+      const snapshot = await getDeviceResourceSnapshot();
+      const assessment = classifyDeviceRamTier(
+        marketedRamGbFromTotalRamMb(snapshot?.totalRamMb ?? null),
+      );
+      cachedAssessment = assessment;
+      return assessment;
+    })().finally(() => {
+      resolveInFlight = null;
+    });
+  }
+  return resolveInFlight;
+}
+
+/**
+ * The fail-loud backstop for the first-run finish: throws when this device
+ * may not run the on-device agent at all, or may not run on-device models
+ * while the draft asks for them. The thrown message is user-facing — the
+ * finish boundary renders it as the onboarding error turn with the recovery
+ * choice (retry / different runtime / Settings).
+ */
+export async function assertDeviceRamTierAllowsLocalRuntime(
+  localInference: string,
+): Promise<void> {
+  const assessment = await resolveDeviceRamTierAssessment();
+  if (!assessment.allowsLocalAgent) {
+    throw new Error(
+      `This device can't run the on-device agent: ${assessment.reason}. Pick "Eliza Cloud (managed)" instead.`,
+    );
+  }
+  if (localInference === "all-local" && !assessment.allowsLocalModels) {
+    throw new Error(
+      `This device can't run on-device models: ${assessment.reason}. Pick "Eliza Cloud inference" instead.`,
+    );
+  }
+}
+
+/**
+ * Boot-time enforcement, run right after the persisted-mode build reconcile in
+ * `useStartupCoordinator` and before startup resolves its target: a persisted
+ * "local" (or hybrid) mode on a RAM-blocked device — carried across reinstalls
+ * by Capacitor Preferences, or written by a pre-#14390 build — is cleared so
+ * the boot lands in onboarding instead of polling an agent the native gate
+ * (ElizaAgentService.shouldAutoStart) now refuses to start. Uses the
+ * synchronous probe only: Android is the platform whose native service
+ * auto-start wedged boot; the iOS transport gates itself.
+ */
+export function enforceDeviceRamPolicyOnPersistedRuntimeModeAtBoot(): boolean {
+  if (!isAndroid && !isIOS) return false;
+  const mode = readPersistedMobileRuntimeMode();
+  if (mode !== "local" && mode !== "cloud-hybrid") return false;
+  const assessment = peekDeviceRamTierAssessment();
+  if (!assessment || assessment.allowsLocalAgent) return false;
+  const cleared = clearPersistedLocalRuntimeCommitment();
+  logger.warn(
+    { mode, marketedRamGb: assessment.marketedRamGb, ...cleared },
+    "[DeviceRamGate] persisted local runtime mode is below the RAM floor; reverting to onboarding",
+  );
+  return true;
+}

--- a/packages/ui/src/first-run/device-ram-tier.test.ts
+++ b/packages/ui/src/first-run/device-ram-tier.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit coverage for the pure RAM-tier policy (#14390): marketed-GB recovery
+ * from raw device totals and the 8/12/16 GB tier boundaries, pinned against
+ * real observed device readings. Pure functions, no device.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  classifyDeviceRamTier,
+  marketedRamGbFromTotalRamMb,
+} from "./device-ram-tier";
+
+/** MB reading a device with `kb` kB of MemTotal reports (mirrors totalMem). */
+function mbFromKb(kb: number): number {
+  return kb / 1024;
+}
+
+describe("marketedRamGbFromTotalRamMb", () => {
+  it("recovers the marketed size from kernel-reduced readings", () => {
+    // Moto G Play 2024, the #14390 device: MemTotal 3,747,844 kB (~3.57 GiB).
+    expect(marketedRamGbFromTotalRamMb(mbFromKb(3_747_844))).toBe(4);
+    // Pixel 6a class "6 GB" reports ~5.7 GiB.
+    expect(marketedRamGbFromTotalRamMb(5.7 * 1024)).toBe(6);
+    // "8 GB" phones report ~7.2-7.6 GiB.
+    expect(marketedRamGbFromTotalRamMb(7.2 * 1024)).toBe(8);
+    expect(marketedRamGbFromTotalRamMb(7.6 * 1024)).toBe(8);
+    // "12 GB" / "16 GB" flagships.
+    expect(marketedRamGbFromTotalRamMb(11.3 * 1024)).toBe(12);
+    expect(marketedRamGbFromTotalRamMb(15.2 * 1024)).toBe(16);
+    // An exact power-of-two reading (emulator) is not rounded past itself.
+    expect(marketedRamGbFromTotalRamMb(8 * 1024)).toBe(8);
+  });
+
+  it("treats unreadable totals as null, never zero", () => {
+    expect(marketedRamGbFromTotalRamMb(null)).toBeNull();
+    expect(marketedRamGbFromTotalRamMb(undefined)).toBeNull();
+    expect(marketedRamGbFromTotalRamMb(0)).toBeNull();
+    expect(marketedRamGbFromTotalRamMb(-1)).toBeNull();
+    expect(marketedRamGbFromTotalRamMb(Number.NaN)).toBeNull();
+    expect(marketedRamGbFromTotalRamMb(Number.POSITIVE_INFINITY)).toBeNull();
+  });
+});
+
+describe("classifyDeviceRamTier", () => {
+  it("blocks the local agent entirely under 8 GB (cloud-only)", () => {
+    for (const gb of [1, 4, 6, 7]) {
+      const a = classifyDeviceRamTier(gb);
+      expect(a.tier).toBe("cloud-only");
+      expect(a.allowsLocalAgent).toBe(false);
+      expect(a.allowsLocalModels).toBe(false);
+      expect(a.localModelsWarning).toBe(false);
+      expect(a.marketedRamGb).toBe(gb);
+      expect(a.reason).toContain(`~${gb} GB`);
+    }
+  });
+
+  it("allows the agent but blocks on-device models on 8-11 GB", () => {
+    for (const gb of [8, 10, 11]) {
+      const a = classifyDeviceRamTier(gb);
+      expect(a.tier).toBe("no-local-models");
+      expect(a.allowsLocalAgent).toBe(true);
+      expect(a.allowsLocalModels).toBe(false);
+      expect(a.localModelsWarning).toBe(false);
+    }
+  });
+
+  it("allows on-device models with a warning on 12-15 GB", () => {
+    for (const gb of [12, 15]) {
+      const a = classifyDeviceRamTier(gb);
+      expect(a.tier).toBe("local-models-warn");
+      expect(a.allowsLocalAgent).toBe(true);
+      expect(a.allowsLocalModels).toBe(true);
+      expect(a.localModelsWarning).toBe(true);
+    }
+  });
+
+  it("is unrestricted from 16 GB up", () => {
+    for (const gb of [16, 24, 64]) {
+      const a = classifyDeviceRamTier(gb);
+      expect(a.tier).toBe("full-local");
+      expect(a.allowsLocalAgent).toBe(true);
+      expect(a.allowsLocalModels).toBe(true);
+      expect(a.localModelsWarning).toBe(false);
+    }
+  });
+
+  it("classifies an unreadable total as the explicit unknown tier that gates nothing", () => {
+    const a = classifyDeviceRamTier(null);
+    expect(a.tier).toBe("unknown");
+    expect(a.marketedRamGb).toBeNull();
+    expect(a.allowsLocalAgent).toBe(true);
+    expect(a.allowsLocalModels).toBe(true);
+    expect(a.localModelsWarning).toBe(false);
+  });
+});

--- a/packages/ui/src/first-run/device-ram-tier.ts
+++ b/packages/ui/src/first-run/device-ram-tier.ts
@@ -1,0 +1,124 @@
+/**
+ * Pure RAM-tier classification for the mobile runtime policy (#14390): which
+ * runtime options a phone may be offered, keyed on marketed RAM size.
+ *
+ * Low-RAM phones cannot sustain the on-device agent — a 4 GB Moto G Play
+ * wedges boot for the full 180 s startup budget — so the policy is RAM-driven,
+ * not build-driven: under 8 GB the local agent is disabled outright (cloud
+ * only); under 12 GB the agent may run but on-device models are disabled
+ * (cloud-inference only); under 16 GB on-device models are allowed with a
+ * performance/thermal warning; 16 GB and up is unrestricted.
+ *
+ * The OS under-reports marketed capacity (kernel/carveout reserve a slice: a
+ * "4 GB" device reads ~3.6 GiB, an "8 GB" one ~7.2-7.6 GiB), so raw readings
+ * are rounded UP to the next whole GB to recover the marketed size before the
+ * thresholds apply. The Android service-side gate mirrors this conversion in
+ * `DeviceRamTierPolicy.java`; keep the two in sync.
+ *
+ * Everything here is pure — probing the device and enforcing the policy live
+ * in `device-ram-gate.ts`.
+ */
+
+export type DeviceRamTier =
+  | "cloud-only"
+  | "no-local-models"
+  | "local-models-warn"
+  | "full-local"
+  | "unknown";
+
+export interface DeviceRamTierAssessment {
+  tier: DeviceRamTier;
+  /** Marketed RAM size in GB, or null when the device total is unreadable. */
+  marketedRamGb: number | null;
+  /** May this device run the on-device agent at all (>= 8 GB)? */
+  allowsLocalAgent: boolean;
+  /** May this device download/run on-device models (>= 12 GB)? */
+  allowsLocalModels: boolean;
+  /** On-device models allowed but sub-16 GB: warn about perf/thermal/battery. */
+  localModelsWarning: boolean;
+  /** Short human line explaining the classification, for chat turns/labels. */
+  reason: string;
+}
+
+export const LOCAL_AGENT_MIN_MARKETED_RAM_GB = 8;
+export const LOCAL_MODELS_MIN_MARKETED_RAM_GB = 12;
+export const LOCAL_MODELS_WARN_BELOW_MARKETED_RAM_GB = 16;
+
+/**
+ * Recover the marketed RAM size (whole GB) from a raw device total in MB.
+ * Rounds UP so kernel-reserved slices don't demote a device a whole tier
+ * (a Moto G Play "4 GB" reads ~3660 MB → 4; a Pixel "8 GB" ~7500 MB → 8).
+ * Invalid/unreadable input is null — never a fabricated size.
+ */
+export function marketedRamGbFromTotalRamMb(
+  totalRamMb: number | null | undefined,
+): number | null {
+  if (
+    typeof totalRamMb !== "number" ||
+    !Number.isFinite(totalRamMb) ||
+    totalRamMb <= 0
+  ) {
+    return null;
+  }
+  return Math.ceil(totalRamMb / 1024);
+}
+
+/**
+ * Classify a marketed RAM size into the runtime-policy tier. `null` (RAM
+ * unreadable, or a platform the mobile policy does not govern) classifies as
+ * "unknown" and gates nothing: the only consumer of an unknown tier is an
+ * explicit user choice, which a probe failure must not brick — the distinct
+ * tier keeps that decision visible rather than fabricating a capable device.
+ */
+export function classifyDeviceRamTier(
+  marketedRamGb: number | null,
+): DeviceRamTierAssessment {
+  if (marketedRamGb === null || !Number.isFinite(marketedRamGb)) {
+    return {
+      tier: "unknown",
+      marketedRamGb: null,
+      allowsLocalAgent: true,
+      allowsLocalModels: true,
+      localModelsWarning: false,
+      reason: "device memory could not be determined",
+    };
+  }
+  if (marketedRamGb < LOCAL_AGENT_MIN_MARKETED_RAM_GB) {
+    return {
+      tier: "cloud-only",
+      marketedRamGb,
+      allowsLocalAgent: false,
+      allowsLocalModels: false,
+      localModelsWarning: false,
+      reason: `this device has ~${marketedRamGb} GB RAM and the on-device agent needs ${LOCAL_AGENT_MIN_MARKETED_RAM_GB} GB or more`,
+    };
+  }
+  if (marketedRamGb < LOCAL_MODELS_MIN_MARKETED_RAM_GB) {
+    return {
+      tier: "no-local-models",
+      marketedRamGb,
+      allowsLocalAgent: true,
+      allowsLocalModels: false,
+      localModelsWarning: false,
+      reason: `this device has ~${marketedRamGb} GB RAM and on-device models need ${LOCAL_MODELS_MIN_MARKETED_RAM_GB} GB or more`,
+    };
+  }
+  if (marketedRamGb < LOCAL_MODELS_WARN_BELOW_MARKETED_RAM_GB) {
+    return {
+      tier: "local-models-warn",
+      marketedRamGb,
+      allowsLocalAgent: true,
+      allowsLocalModels: true,
+      localModelsWarning: true,
+      reason: `this device has ~${marketedRamGb} GB RAM — on-device models will work but can be slow and run warm (${LOCAL_MODELS_WARN_BELOW_MARKETED_RAM_GB} GB recommended)`,
+    };
+  }
+  return {
+    tier: "full-local",
+    marketedRamGb,
+    allowsLocalAgent: true,
+    allowsLocalModels: true,
+    localModelsWarning: false,
+    reason: `this device has ~${marketedRamGb} GB RAM`,
+  };
+}

--- a/packages/ui/src/first-run/first-run-finish.ts
+++ b/packages/ui/src/first-run/first-run-finish.ts
@@ -36,6 +36,7 @@ import {
 } from "../state";
 import { isCloudStatusAuthenticated } from "../utils";
 import { autoDownloadRecommendedLocalModelInBackground } from "./auto-download-recommended";
+import { assertDeviceRamTierAllowsLocalRuntime } from "./device-ram-gate";
 import {
   buildFirstRunSubmitPlan,
   clearPersistedFirstRunState,
@@ -338,6 +339,13 @@ async function finishLocal(
   sourceDraft: FirstRunProfileDraft,
   ports: FirstRunFinishPorts,
 ): Promise<FirstRunFinishOutcome> {
+  // RAM-tier gate (#14390), enforced BEFORE any side effect: a device below
+  // the 8 GB floor may not run the on-device agent at all, and one below the
+  // 12 GB floor may not download/run on-device models. The onboarding UI
+  // already blocks these picks, but this is the fail-loud backstop for every
+  // caller — the throw surfaces as the onboarding error turn with the
+  // runtime-recovery choice.
+  await assertDeviceRamTierAllowsLocalRuntime(sourceDraft.localInference);
   syncIdentity(sourceDraft, ports);
   // Local + cloud-inference (hybrid) routes inference through Eliza Cloud, so
   // connect the cloud account first.

--- a/packages/ui/src/first-run/first-run-runtime-flag.test.ts
+++ b/packages/ui/src/first-run/first-run-runtime-flag.test.ts
@@ -1,19 +1,23 @@
 // @vitest-environment jsdom
 
 /**
- * The runtime-chooser gate (#13377): cloud-only onboarding is the default on
- * every build; the localStorage override flips it without a rebuild and the
- * Play-Store cloud-locked Android build can never re-enable it.
+ * The runtime-chooser gate (#13377/#14390): cloud-only onboarding is the
+ * default on web/desktop builds; the localStorage override flips it without a
+ * rebuild; the Play-Store cloud-locked Android build can never re-enable it;
+ * and the Android local sideload/system builds default it ON — they ship the
+ * on-device agent and onboarding is the only thing allowed to start it.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   isAndroidCloudBuild: vi.fn(() => false),
+  isAndroidLocalSideloadBuild: vi.fn(() => false),
 }));
 
 vi.mock("../platform/android-runtime", () => ({
   isAndroidCloudBuild: mocks.isAndroidCloudBuild,
+  isAndroidLocalSideloadBuild: mocks.isAndroidLocalSideloadBuild,
 }));
 
 import {
@@ -24,6 +28,7 @@ import {
 beforeEach(() => {
   localStorage.clear();
   mocks.isAndroidCloudBuild.mockReturnValue(false);
+  mocks.isAndroidLocalSideloadBuild.mockReturnValue(false);
 });
 
 afterEach(() => {
@@ -53,6 +58,20 @@ describe("isRuntimeChooserEnabled", () => {
   it("the cloud-locked Android build can never re-enable the chooser", () => {
     mocks.isAndroidCloudBuild.mockReturnValue(true);
     localStorage.setItem(RUNTIME_CHOOSER_OVERRIDE_STORAGE_KEY, "1");
+    expect(isRuntimeChooserEnabled()).toBe(false);
+  });
+
+  it("the Android local sideload build defaults the chooser ON (#14390)", () => {
+    // Fresh sideload installs land in onboarding (no pre-seed, no
+    // fresh-install auto-start), so the chooser is the only path that can
+    // start the bundled agent — hiding it would strand the build cloud-only.
+    mocks.isAndroidLocalSideloadBuild.mockReturnValue(true);
+    expect(isRuntimeChooserEnabled()).toBe(true);
+  });
+
+  it("an explicit '0' override still turns the chooser off on the sideload build", () => {
+    mocks.isAndroidLocalSideloadBuild.mockReturnValue(true);
+    localStorage.setItem(RUNTIME_CHOOSER_OVERRIDE_STORAGE_KEY, "0");
     expect(isRuntimeChooserEnabled()).toBe(false);
   });
 });

--- a/packages/ui/src/first-run/first-run-runtime-flag.ts
+++ b/packages/ui/src/first-run/first-run-runtime-flag.ts
@@ -1,17 +1,23 @@
 /**
  * Gate for the first-run runtime chooser (the local / remote onboarding paths).
  *
- * The product currently onboards through Eliza Cloud only (#13377): the chooser
- * is OFF by default on every build, so onboarding is a single "sign in to
- * Eliza Cloud" step. The local and remote paths stay in-tree for development —
- * a build can re-enable the chooser with `VITE_ELIZA_ENABLE_RUNTIME_CHOOSER=1`,
- * and tests or a running shell can flip the localStorage override without a
- * rebuild (explicit "1"/"0" beats the build default). The Play-Store
- * cloud-locked Android variant can never re-enable it: that build must not
- * expose a local backend regardless of developer overrides.
+ * The product onboards through Eliza Cloud only on web/desktop (#13377): the
+ * chooser is OFF there by default, so onboarding is a single "sign in to
+ * Eliza Cloud" step. Two Android exceptions bracket it: the Play-Store
+ * cloud-locked variant can never enable the chooser (that build must not
+ * expose a local backend regardless of developer overrides), and the local
+ * sideload/system builds default it ON (#14390) — they ship the on-device
+ * agent, and onboarding is the only thing allowed to start it. Elsewhere the
+ * local and remote paths stay in-tree for development: a build can enable the
+ * chooser with `VITE_ELIZA_ENABLE_RUNTIME_CHOOSER=1`, and tests or a running
+ * shell can flip the localStorage override without a rebuild (explicit
+ * "1"/"0" beats the build default).
  */
 
-import { isAndroidCloudBuild } from "../platform/android-runtime";
+import {
+  isAndroidCloudBuild,
+  isAndroidLocalSideloadBuild,
+} from "../platform/android-runtime";
 
 /** localStorage override: "1" enables the chooser, "0" disables, unset defers to the build default. */
 export const RUNTIME_CHOOSER_OVERRIDE_STORAGE_KEY =
@@ -45,12 +51,19 @@ function readBuildDefault(): boolean {
 
 /**
  * Whether onboarding offers the full runtime chooser (cloud / local / remote).
- * False (the default everywhere) means cloud-only onboarding: sign in to
- * Eliza Cloud is the one and only path, and completing it completes first-run.
+ * False (the default on web/desktop/cloud builds) means cloud-only onboarding:
+ * sign in to Eliza Cloud is the one and only path, and completing it completes
+ * first-run. The Android local sideload/system builds default the chooser ON
+ * (#14390): they ship the on-device agent as their whole point, and since the
+ * fresh-install auto-start is gone (boot-gated on the onboarding choice), the
+ * chooser is the only path that can ever start it — hiding it would strand the
+ * build on a cloud-only flow. The explicit localStorage override still beats
+ * this so tests/dev shells can force either mode.
  */
 export function isRuntimeChooserEnabled(): boolean {
   if (isAndroidCloudBuild()) return false;
   const override = readOverride();
   if (override !== null) return override;
+  if (isAndroidLocalSideloadBuild()) return true;
   return readBuildDefault();
 }

--- a/packages/ui/src/first-run/pre-seed-local-runtime.test.ts
+++ b/packages/ui/src/first-run/pre-seed-local-runtime.test.ts
@@ -1,30 +1,20 @@
 // @vitest-environment jsdom
 
 /**
- * Unit coverage for the decision matrix in `preSeedAndroidLocalRuntimeIfFresh`:
- * it seeds the on-device local agent only when the device IS the local agent
- * and nothing has already chosen a server/runtime. Capacitor + platform mocked,
- * no real device.
+ * Unit coverage for the decision matrix in `preSeedAndroidLocalRuntimeIfFresh`
+ * (#14390): only a branded ElizaOS device image (the device IS the agent) is
+ * pre-seeded, and only while nothing has already chosen a server/runtime.
+ * Stock-phone sideload builds are never pre-seeded — their fresh install lands
+ * in onboarding, which starts the local agent on demand after the user picks
+ * it. UA detection mocked, no real device.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  capacitorPlatform: "web" as string,
-  isAndroidCloudBuild: vi.fn(() => false),
   isAospElizaUserAgent: vi.fn(() => false),
   readPersistedMobileRuntimeMode: vi.fn(() => null as string | null),
   persistMobileRuntimeModeForServerTarget: vi.fn(),
-}));
-
-vi.mock("@capacitor/core", () => ({
-  Capacitor: {
-    getPlatform: () => mocks.capacitorPlatform,
-  },
-}));
-
-vi.mock("../platform/android-runtime", () => ({
-  isAndroidCloudBuild: mocks.isAndroidCloudBuild,
 }));
 
 vi.mock("../platform/aosp-user-agent", () => ({
@@ -99,8 +89,6 @@ function readSeededActiveServer(): unknown {
 describe("preSeedAndroidLocalRuntimeIfFresh", () => {
   beforeEach(() => {
     ensureLocalStorage().clear();
-    mocks.capacitorPlatform = "web";
-    mocks.isAndroidCloudBuild.mockReturnValue(false);
     mocks.isAospElizaUserAgent.mockReturnValue(false);
     mocks.readPersistedMobileRuntimeMode.mockReturnValue(null);
     mocks.persistMobileRuntimeModeForServerTarget.mockClear();
@@ -127,30 +115,12 @@ describe("preSeedAndroidLocalRuntimeIfFresh", () => {
     });
   });
 
-  it("seeds the local agent on the stock-phone local sideload build", () => {
-    // The `android` sideload build ships the on-device agent as its backend, so
-    // a fresh launch should default to it instead of falling back to cloud.
-    // Gating only on the branded `ElizaOS/<tag>` UA marker excluded this build
-    // and left it stuck on cloud onboarding.
-    mocks.capacitorPlatform = "android";
-    mocks.isAndroidCloudBuild.mockReturnValue(false);
-    setUserAgent(STOCK_WEBVIEW_UA);
-
-    expect(preSeedAndroidLocalRuntimeIfFresh()).toBe(true);
-    expect(mocks.persistMobileRuntimeModeForServerTarget).toHaveBeenCalledWith(
-      "local",
-    );
-    expect(readSeededActiveServer()).toEqual({
-      id: ANDROID_LOCAL_AGENT_SERVER_ID,
-      kind: "remote",
-      label: ANDROID_LOCAL_AGENT_LABEL,
-      apiBase: ANDROID_LOCAL_AGENT_IPC_BASE,
-    });
-  });
-
-  it("does not seed the cloud-locked Android build", () => {
-    mocks.capacitorPlatform = "android";
-    mocks.isAndroidCloudBuild.mockReturnValue(true);
+  it("does not seed the stock-phone sideload build (onboarding owns the choice, #14390)", () => {
+    // Pre-#14390 this build was pre-seeded, which committed "local" before
+    // any user choice and auto-booted the bundled agent on phones that cannot
+    // sustain it. The sideload now defaults the runtime chooser ON
+    // (first-run-runtime-flag.ts) and starts the agent from the finish path
+    // only after the user picks "On this device".
     setUserAgent(STOCK_WEBVIEW_UA);
 
     expect(preSeedAndroidLocalRuntimeIfFresh()).toBe(false);
@@ -160,9 +130,8 @@ describe("preSeedAndroidLocalRuntimeIfFresh", () => {
     expect(readSeededActiveServer()).toBeNull();
   });
 
-  it("does not seed when an active server is already persisted", () => {
-    mocks.capacitorPlatform = "android";
-    setUserAgent(STOCK_WEBVIEW_UA);
+  it("does not seed a branded device when an active server is already persisted", () => {
+    mocks.isAospElizaUserAgent.mockReturnValue(true);
     localStorage.setItem(
       ACTIVE_SERVER_STORAGE_KEY,
       JSON.stringify({
@@ -179,10 +148,9 @@ describe("preSeedAndroidLocalRuntimeIfFresh", () => {
     ).not.toHaveBeenCalled();
   });
 
-  it("does not seed when an explicit non-local runtime mode is persisted", () => {
-    mocks.capacitorPlatform = "android";
+  it("does not seed a branded device with an explicit non-local runtime mode", () => {
+    mocks.isAospElizaUserAgent.mockReturnValue(true);
     mocks.readPersistedMobileRuntimeMode.mockReturnValue("cloud");
-    setUserAgent(STOCK_WEBVIEW_UA);
 
     expect(preSeedAndroidLocalRuntimeIfFresh()).toBe(false);
     expect(
@@ -191,8 +159,7 @@ describe("preSeedAndroidLocalRuntimeIfFresh", () => {
     expect(readSeededActiveServer()).toBeNull();
   });
 
-  it("does not seed a stock Android browser (no WebView marker, no brand UA)", () => {
-    mocks.capacitorPlatform = "web";
+  it("does not seed a stock Android browser (no brand UA)", () => {
     setUserAgent(STOCK_BROWSER_UA);
 
     expect(preSeedAndroidLocalRuntimeIfFresh()).toBe(false);

--- a/packages/ui/src/first-run/pre-seed-local-runtime.ts
+++ b/packages/ui/src/first-run/pre-seed-local-runtime.ts
@@ -1,10 +1,21 @@
 /**
  * Pre-seed the AOSP ElizaOS APK when the device itself is the local agent.
+ *
+ * Branded device images (`ElizaOS/<tag>` UA marker) ARE the agent: their
+ * native shell auto-starts the on-device service unconditionally
+ * (ElizaAgentService.shouldAutoStart), so the renderer commits it as the
+ * startup target on first frame instead of falling back to cloud-connect.
+ *
+ * Stock-phone sideload builds are deliberately NOT pre-seeded (#14390): a
+ * fresh install must land in onboarding and pick a runtime — the runtime
+ * chooser is enabled by default on those builds (first-run-runtime-flag.ts)
+ * and the finish path starts the service on demand once the user commits to
+ * the local runtime. Pre-committing "local" here booted the bundled agent on
+ * phones that cannot sustain it (a 4 GB device wedges boot for the full 180 s
+ * startup budget) before the user had chosen anything.
  */
 
-import { isAndroidCloudBuild } from "../platform/android-runtime";
 import { isAospElizaUserAgent } from "../platform/aosp-user-agent";
-import { getFrontendPlatform } from "../platform/platform-guards";
 import {
   ANDROID_LOCAL_AGENT_IPC_BASE,
   ANDROID_LOCAL_AGENT_LABEL,
@@ -64,38 +75,11 @@ function isBrandedAndroidDevice(): boolean {
   return isAospElizaUserAgent(navigator.userAgent);
 }
 
-/**
- * The stock-phone local sideload build (`android` / `android-system`, renderer
- * mode `local`) ships the on-device agent — that IS its backend. The
- * `android-cloud` Play-Store build is a thin cloud client with no on-device
- * agent, so it must never seed local. iOS/desktop/web are not android and
- * resolve to a non-cloud mode by default, so gate on the native platform too.
- */
-function isAndroidLocalSideloadBuild(): boolean {
-  return getFrontendPlatform() === "android" && !isAndroidCloudBuild();
-}
-
-/**
- * Whether to pre-seed the on-device local agent as the active server.
- *
- * Fires for branded ElizaOS device images AND the stock-phone local sideload
- * build (the on-device-agent APK). Both run the on-device agent as their
- * backend, so a fresh launch should default to it instead of falling back to
- * cloud-connect. Gating only on the branded `ElizaOS/<tag>` UA marker (as
- * before) excluded the stock sideload and left it stuck on cloud onboarding —
- * which is exactly the bug the caller in `main.tsx` documents. The explicit
- * cloud/remote-choice and existing-active-server guards in
- * `preSeedAndroidLocalRuntimeIfFresh` still respect a user who picked cloud.
- */
-function shouldPreSeedLocalRuntime(): boolean {
-  return isBrandedAndroidDevice() || isAndroidLocalSideloadBuild();
-}
-
 export function preSeedAndroidLocalRuntimeIfFresh(): boolean {
-  if (!shouldPreSeedLocalRuntime()) return false;
+  if (!isBrandedAndroidDevice()) return false;
   // Respect an explicit cloud/remote choice, but treat null or "local" as
-  // seedable: a stock-phone sideload may carry a "local" mode with no active
-  // server yet (so the dashboard would otherwise fall back to cloud-connect).
+  // seedable: a branded image may carry a "local" mode with no active server
+  // yet (so the dashboard would otherwise fall back to cloud-connect).
   const persistedMode = readPersistedMobileRuntimeMode();
   if (persistedMode != null && persistedMode !== "local") return false;
   if (hasPersistedActiveServer()) return false;

--- a/packages/ui/src/first-run/revert-local-runtime-commitment.test.ts
+++ b/packages/ui/src/first-run/revert-local-runtime-commitment.test.ts
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+
+/**
+ * Reversal-cleanup coverage (#14390): backing out of an un-finished local
+ * runtime pick must clear the persisted runtime mode + local active server
+ * and stop the mobile agent service, while never touching a cloud/remote
+ * commitment. Real persistence + runtime-mode modules against jsdom
+ * localStorage; only the platform constant and the native Agent bridge are
+ * substituted.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  isAndroid: true,
+  isIOS: false,
+  agentStop: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("../platform/init", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../platform/init")>();
+  return {
+    ...actual,
+    get isAndroid() {
+      return mocks.isAndroid;
+    },
+    get isIOS() {
+      return mocks.isIOS;
+    },
+  };
+});
+
+vi.mock("../bridge/native-plugins", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../bridge/native-plugins")>();
+  return {
+    ...actual,
+    getAgentPlugin: () => ({ stop: mocks.agentStop }),
+  };
+});
+
+import {
+  loadPersistedActiveServer,
+  savePersistedActiveServer,
+} from "../state/persistence";
+import {
+  ANDROID_LOCAL_AGENT_IPC_BASE,
+  ANDROID_LOCAL_AGENT_LABEL,
+  ANDROID_LOCAL_AGENT_SERVER_ID,
+  MOBILE_RUNTIME_MODE_STORAGE_KEY,
+  persistMobileRuntimeMode,
+  readPersistedMobileRuntimeMode,
+} from "./mobile-runtime-mode";
+import {
+  clearPersistedLocalRuntimeCommitment,
+  revertLocalRuntimeCommitment,
+} from "./revert-local-runtime-commitment";
+
+// This jsdom env exposes `window.localStorage` as an object without methods;
+// install a real in-memory Storage (mirrors `first-run.test.ts`).
+function ensureLocalStorage(): Storage {
+  if (typeof window.localStorage?.clear === "function") {
+    return window.localStorage;
+  }
+  const values = new Map<string, string>();
+  const storage = {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key: string) => values.get(key) ?? null,
+    key: (index: number) => Array.from(values.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      values.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      values.set(key, String(value));
+    },
+  } satisfies Storage;
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+  return storage;
+}
+
+function seedLocalCommitment(): void {
+  persistMobileRuntimeMode("local");
+  savePersistedActiveServer({
+    id: ANDROID_LOCAL_AGENT_SERVER_ID,
+    kind: "remote",
+    label: ANDROID_LOCAL_AGENT_LABEL,
+    apiBase: ANDROID_LOCAL_AGENT_IPC_BASE,
+  });
+}
+
+beforeEach(() => {
+  ensureLocalStorage().clear();
+  mocks.isAndroid = true;
+  mocks.isIOS = false;
+  mocks.agentStop.mockClear();
+  mocks.agentStop.mockResolvedValue({ ok: true });
+});
+
+afterEach(() => {
+  ensureLocalStorage().clear();
+});
+
+describe("clearPersistedLocalRuntimeCommitment", () => {
+  it("clears a persisted local mode and the local active server", () => {
+    seedLocalCommitment();
+
+    const cleared = clearPersistedLocalRuntimeCommitment();
+
+    expect(cleared).toEqual({
+      clearedRuntimeMode: true,
+      clearedActiveServer: true,
+    });
+    expect(readPersistedMobileRuntimeMode()).toBeNull();
+    expect(localStorage.getItem(MOBILE_RUNTIME_MODE_STORAGE_KEY)).toBeNull();
+    expect(loadPersistedActiveServer()).toBeNull();
+  });
+
+  it("clears a hybrid (local runtime + cloud inference) commitment too", () => {
+    persistMobileRuntimeMode("cloud-hybrid");
+
+    const cleared = clearPersistedLocalRuntimeCommitment();
+
+    expect(cleared.clearedRuntimeMode).toBe(true);
+    expect(readPersistedMobileRuntimeMode()).toBeNull();
+  });
+
+  it("never touches a cloud mode or a non-local active server", () => {
+    persistMobileRuntimeMode("cloud");
+    savePersistedActiveServer({
+      id: "cloud:agent-1",
+      kind: "cloud",
+      label: "Cloud agent",
+      apiBase: "https://agent.example.test",
+    });
+
+    const cleared = clearPersistedLocalRuntimeCommitment();
+
+    expect(cleared).toEqual({
+      clearedRuntimeMode: false,
+      clearedActiveServer: false,
+    });
+    expect(readPersistedMobileRuntimeMode()).toBe("cloud");
+    expect(loadPersistedActiveServer()?.id).toBe("cloud:agent-1");
+  });
+
+  it("is a no-op on a fresh state", () => {
+    const cleared = clearPersistedLocalRuntimeCommitment();
+    expect(cleared).toEqual({
+      clearedRuntimeMode: false,
+      clearedActiveServer: false,
+    });
+  });
+});
+
+describe("revertLocalRuntimeCommitment", () => {
+  it("stops the mobile agent service when a local mode was committed", async () => {
+    seedLocalCommitment();
+
+    const cleared = await revertLocalRuntimeCommitment();
+
+    expect(cleared.clearedRuntimeMode).toBe(true);
+    expect(mocks.agentStop).toHaveBeenCalledTimes(1);
+    expect(readPersistedMobileRuntimeMode()).toBeNull();
+    expect(loadPersistedActiveServer()).toBeNull();
+  });
+
+  it("does not call the stop bridge when nothing local was committed", async () => {
+    persistMobileRuntimeMode("cloud");
+
+    await revertLocalRuntimeCommitment();
+
+    expect(mocks.agentStop).not.toHaveBeenCalled();
+    expect(readPersistedMobileRuntimeMode()).toBe("cloud");
+  });
+
+  it("still clears the persisted commitment when the stop bridge rejects", async () => {
+    seedLocalCommitment();
+    mocks.agentStop.mockRejectedValueOnce(new Error("service not running"));
+
+    const cleared = await revertLocalRuntimeCommitment();
+
+    expect(cleared.clearedRuntimeMode).toBe(true);
+    expect(readPersistedMobileRuntimeMode()).toBeNull();
+    expect(loadPersistedActiveServer()).toBeNull();
+  });
+
+  it("skips the stop bridge off-mobile but still clears persisted records", async () => {
+    mocks.isAndroid = false;
+    mocks.isIOS = false;
+    persistMobileRuntimeMode("local");
+
+    const cleared = await revertLocalRuntimeCommitment();
+
+    expect(cleared.clearedRuntimeMode).toBe(true);
+    expect(mocks.agentStop).not.toHaveBeenCalled();
+    expect(readPersistedMobileRuntimeMode()).toBeNull();
+  });
+});

--- a/packages/ui/src/first-run/revert-local-runtime-commitment.ts
+++ b/packages/ui/src/first-run/revert-local-runtime-commitment.ts
@@ -1,0 +1,97 @@
+/**
+ * Reversal cleanup for an un-finished local-runtime choice (#14390): when the
+ * user backs out of "On this device" mid-onboarding (the back affordance, the
+ * error-recovery "choose a different way to run", or a direct cloud/remote
+ * re-pick), nothing the local path committed may survive — the persisted
+ * `eliza:mobile-runtime-mode`, the local active-server record, and the mobile
+ * agent service itself must all be unwound, or the next boot auto-starts an
+ * agent the user chose against.
+ *
+ * `finishLocal` persists the runtime mode BEFORE it starts the service, so a
+ * cleared runtime mode is the reliable signal that the service may have been
+ * started; the stop bridge call is only attempted then (and is a no-op when
+ * the service never came up). Desktop is deliberately untouched beyond the
+ * persisted records: the embedded desktop agent is owned by the shell
+ * lifecycle, not by onboarding.
+ */
+
+import { logger } from "@elizaos/logger";
+import { getAgentPlugin } from "../bridge/native-plugins";
+import { isAndroid, isIOS } from "../platform/init";
+import {
+  clearPersistedActiveServer,
+  loadPersistedActiveServer,
+} from "../state/persistence";
+import {
+  ANDROID_LOCAL_AGENT_SERVER_ID,
+  MOBILE_LOCAL_AGENT_SERVER_ID,
+  persistMobileRuntimeMode,
+  readPersistedMobileRuntimeMode,
+} from "./mobile-runtime-mode";
+
+const LOCAL_AGENT_SERVER_IDS = new Set<string>([
+  ANDROID_LOCAL_AGENT_SERVER_ID,
+  MOBILE_LOCAL_AGENT_SERVER_ID,
+  "local:desktop",
+  "local:app-shell",
+]);
+
+export interface ClearedLocalRuntimeCommitment {
+  clearedRuntimeMode: boolean;
+  clearedActiveServer: boolean;
+}
+
+/**
+ * Clear the persisted local-runtime records (runtime mode + local active
+ * server) if present. Synchronous so the boot-time RAM-policy enforcement
+ * (`device-ram-gate.ts`) can run it before startup resolves its target.
+ * "cloud-hybrid" is a local-agent commitment too (local runtime with cloud
+ * inference); "cloud"/"remote" modes and non-local servers are never touched.
+ */
+export function clearPersistedLocalRuntimeCommitment(): ClearedLocalRuntimeCommitment {
+  const mode = readPersistedMobileRuntimeMode();
+  const clearedRuntimeMode = mode === "local" || mode === "cloud-hybrid";
+  if (clearedRuntimeMode) {
+    persistMobileRuntimeMode(null);
+  }
+
+  const active = loadPersistedActiveServer();
+  const clearedActiveServer =
+    active != null &&
+    (active.kind === "local" || LOCAL_AGENT_SERVER_IDS.has(active.id));
+  if (clearedActiveServer) {
+    clearPersistedActiveServer();
+  }
+
+  return { clearedRuntimeMode, clearedActiveServer };
+}
+
+/**
+ * Full reversal: clear the persisted commitment and, on mobile, stop the
+ * on-device agent service that a partially-completed local finish may have
+ * started. Never throws — reversal runs on the user's way OUT of the local
+ * path, and a failed stop must not block them from picking cloud.
+ */
+export async function revertLocalRuntimeCommitment(): Promise<ClearedLocalRuntimeCommitment> {
+  const cleared = clearPersistedLocalRuntimeCommitment();
+  if ((isAndroid || isIOS) && cleared.clearedRuntimeMode) {
+    try {
+      await getAgentPlugin().stop?.();
+    } catch (err) {
+      // error-policy:J6 best-effort teardown — the service may simply never
+      // have started (the finish failed before the start), and the boot gate
+      // no longer auto-starts it once the mode is cleared above.
+      logger.warn(
+        { err },
+        "[revertLocalRuntimeCommitment] on-device agent stop bridge call failed",
+      );
+    }
+  }
+  if (cleared.clearedRuntimeMode || cleared.clearedActiveServer) {
+    logger.info(
+      { ...cleared },
+      "[revertLocalRuntimeCommitment] reverted un-finished local runtime commitment",
+    );
+  }
+  return cleared;
+}

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -56,6 +56,12 @@ const mocks = vi.hoisted(() => ({
   refreshCloudStewardSession: vi.fn(
     async (): Promise<{ token?: string } | null> => null,
   ),
+  // The device RAM probe is a native boundary like the client: tests inject a
+  // tier here (null = jsdom's honest "unknown"); the gate's own probe path is
+  // covered in device-ram-gate.test.ts against the real bridge seam.
+  deviceRamTier: null as
+    | import("./device-ram-tier").DeviceRamTierAssessment
+    | null,
 }));
 
 vi.mock("../api/client", async (importOriginal) => {
@@ -76,6 +82,32 @@ vi.mock("./auto-download-recommended", () => ({
     mocks.autoDownloadRecommendedLocalModelInBackground,
 }));
 
+vi.mock("./device-ram-gate", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./device-ram-gate")>();
+  return {
+    ...actual,
+    peekDeviceRamTierAssessment: () => mocks.deviceRamTier,
+    resolveDeviceRamTierAssessment: async () =>
+      mocks.deviceRamTier ?? actual.peekDeviceRamTierAssessment(),
+    // Mirrors the real backstop contract against the injected tier so the
+    // finish path enforces the same policy the conductor gates on.
+    assertDeviceRamTierAllowsLocalRuntime: async (localInference: string) => {
+      const tier = mocks.deviceRamTier;
+      if (!tier) return;
+      if (!tier.allowsLocalAgent) {
+        throw new Error(
+          `This device can't run the on-device agent: ${tier.reason}.`,
+        );
+      }
+      if (localInference === "all-local" && !tier.allowsLocalModels) {
+        throw new Error(
+          `This device can't run on-device models: ${tier.reason}.`,
+        );
+      }
+    },
+  };
+});
+
 import type { ConversationMessage, LocalAgentBackupMetadata } from "../api";
 import { __setAppValueForTests } from "../state/app-store";
 import {
@@ -83,6 +115,7 @@ import {
   type ConversationMessagesValue,
 } from "../state/ConversationMessagesContext.hooks";
 import type { AppContextValue } from "../state/internal";
+import { classifyDeviceRamTier } from "./device-ram-tier";
 import {
   tryHandleFirstRunAction,
   tryHandleFirstRunText,
@@ -98,6 +131,7 @@ import {
   resetFirstRunPersistGuard,
   runFirstRunFinish,
 } from "./first-run-finish";
+import { MOBILE_RUNTIME_MODE_STORAGE_KEY } from "./mobile-runtime-mode";
 import {
   surfaceCloudLoginRetryTurn,
   useFirstRunConductor,
@@ -217,6 +251,7 @@ async function waitForTurn(
 beforeEach(() => {
   ensureLocalStorage().clear();
   vi.clearAllMocks();
+  mocks.deviceRamTier = null;
   mocks.client.listLocalAgentBackups.mockResolvedValue([]);
   // `clearAllMocks` resets call history but NOT implementations, so restore the
   // default resolved implementations that individual tests override (a leaked
@@ -1697,6 +1732,213 @@ describe("useFirstRunConductor — free-text replies (#12178 composer unlock)", 
     await waitForTurn(turn, "first-run:greeting");
     const before = transcript.current.length;
     expect(tryHandleFirstRunText("   ")).toBe(true);
+    expect(transcript.current.length).toBe(before);
+    unmount();
+  });
+});
+
+describe("device RAM-tier gating + reversible onboarding (#14390)", () => {
+  it("labels the local option unavailable on a sub-8 GB device and refuses the pick with the reason", async () => {
+    mocks.deviceRamTier = classifyDeviceRamTier(4);
+    seedAppStore();
+    const { transcript, turn, unmount } = renderConductor();
+
+    // The greeting's local option is visibly gated — never silently hidden.
+    const greeting = await waitForTurn(turn, "first-run:greeting");
+    expect(greeting.text).toContain("__first_run__:runtime:local=");
+    expect(greeting.text).toContain("unavailable — needs 8 GB+ RAM");
+    expect(greeting.text).toContain("~4 GB detected");
+
+    // The tap is refused at the decision point: a refusal turn with the
+    // reason and a FRESH runtime choice — no provider step, no finish.
+    expect(tryHandleFirstRunAction("__first_run__:runtime:local")).toBe(true);
+    await waitFor(() => {
+      expect(
+        transcript.current.some((m) =>
+          m.id.startsWith("first-run:runtime-blocked:"),
+        ),
+      ).toBe(true);
+    });
+    const blocked = transcript.current.find((m) =>
+      m.id.startsWith("first-run:runtime-blocked:"),
+    );
+    expect(blocked?.text).toContain("~4 GB RAM");
+    expect(blocked?.text).toContain("[CHOICE:first-run id=runtime]");
+    expect(turn("first-run:provider")).toBeUndefined();
+    expect(mocks.client.submitFirstRun).not.toHaveBeenCalled();
+
+    // Cloud remains a live way forward from the re-offered choice.
+    expect(tryHandleFirstRunAction("__first_run__:runtime:cloud")).toBe(true);
+    await waitForTurn(turn, "first-run:cloud-oauth");
+    unmount();
+  });
+
+  it("blocks on-device models on a sub-12 GB device but finishes the hybrid local runtime", async () => {
+    mocks.deviceRamTier = classifyDeviceRamTier(8);
+    seedAppStore();
+    const { transcript, turn, unmount } = renderConductor();
+    await waitForTurn(turn, "first-run:greeting");
+
+    // The local AGENT is allowed on this band; only on-device models gate.
+    expect(tryHandleFirstRunAction("__first_run__:runtime:local")).toBe(true);
+    const provider = await waitForTurn(turn, "first-run:provider");
+    expect(provider.text).toContain("unavailable — needs 12 GB+ RAM");
+    expect(provider.text).toContain(
+      "__first_run__:provider:elizacloud=Eliza Cloud inference (recommended)",
+    );
+    expect(provider.text).toContain("__first_run__:back:runtime=");
+
+    // The blocked on-device pick is refused with a fresh provider choice.
+    expect(tryHandleFirstRunAction("__first_run__:provider:on-device")).toBe(
+      true,
+    );
+    await waitFor(() => {
+      expect(
+        transcript.current.some((m) =>
+          m.id.startsWith("first-run:provider:retry:"),
+        ),
+      ).toBe(true);
+    });
+    expect(mocks.client.submitFirstRun).not.toHaveBeenCalled();
+    expect(
+      mocks.autoDownloadRecommendedLocalModelInBackground,
+    ).not.toHaveBeenCalled();
+
+    // Eliza Cloud inference (hybrid) is the allowed local path here and
+    // completes the REAL finish: exactly one POST, no model download, and the
+    // hybrid runtime mode persisted.
+    expect(tryHandleFirstRunAction("__first_run__:provider:elizacloud")).toBe(
+      true,
+    );
+    await waitForTurn(turn, "first-run:tutorial");
+    expect(mocks.client.submitFirstRun).toHaveBeenCalledTimes(1);
+    expect(
+      mocks.autoDownloadRecommendedLocalModelInBackground,
+    ).not.toHaveBeenCalled();
+    expect(localStorage.getItem(MOBILE_RUNTIME_MODE_STORAGE_KEY)).toBe(
+      "cloud-hybrid",
+    );
+    unmount();
+  });
+
+  it("annotates (but allows) on-device models on the 12-15 GB warn band", async () => {
+    mocks.deviceRamTier = classifyDeviceRamTier(12);
+    seedAppStore();
+    const { turn, unmount } = renderConductor();
+    await waitForTurn(turn, "first-run:greeting");
+
+    expect(tryHandleFirstRunAction("__first_run__:runtime:local")).toBe(true);
+    const provider = await waitForTurn(turn, "first-run:provider");
+    expect(provider.text).toContain("Heads up:");
+    expect(provider.text).toContain("can be slow and run warm");
+    expect(provider.text).toContain(
+      "__first_run__:provider:on-device=On this device (recommended)",
+    );
+    unmount();
+  });
+
+  it("goes back from the provider step to a fresh, unlocked runtime choice", async () => {
+    seedAppStore();
+    const { transcript, turn, unmount } = renderConductor();
+    await waitForTurn(turn, "first-run:greeting");
+
+    expect(tryHandleFirstRunAction("__first_run__:runtime:local")).toBe(true);
+    const provider = await waitForTurn(turn, "first-run:provider");
+    expect(provider.text).toContain("__first_run__:back:runtime=");
+
+    expect(tryHandleFirstRunAction("__first_run__:back:runtime")).toBe(true);
+    await waitFor(() => {
+      expect(
+        transcript.current.some((m) =>
+          m.id.startsWith("first-run:greeting:retry:"),
+        ),
+      ).toBe(true);
+    });
+    const reoffer = transcript.current.find((m) =>
+      m.id.startsWith("first-run:greeting:retry:"),
+    );
+    expect(reoffer?.text).toContain("__first_run__:runtime:cloud=");
+    // Nothing was committed or POSTed by the abandoned local path.
+    expect(mocks.client.submitFirstRun).not.toHaveBeenCalled();
+    expect(localStorage.getItem(MOBILE_RUNTIME_MODE_STORAGE_KEY)).toBeNull();
+
+    // The re-offered choice is live: cloud proceeds normally.
+    expect(tryHandleFirstRunAction("__first_run__:runtime:cloud")).toBe(true);
+    await waitForTurn(turn, "first-run:cloud-oauth");
+    unmount();
+  });
+
+  it("offers a back affordance under the remote connect form", async () => {
+    seedAppStore();
+    const { turn, unmount } = renderConductor();
+    await waitForTurn(turn, "first-run:greeting");
+
+    expect(tryHandleFirstRunAction("__first_run__:runtime:remote")).toBe(true);
+    const connect = await waitForTurn(turn, "first-run:remote-connect");
+    expect(connect.secretRequest?.form?.kind).toBe("remote_connect");
+    expect(connect.text).toContain("__first_run__:back:runtime=");
+    unmount();
+  });
+
+  it("unwinds a partially-committed local finish when the user switches to cloud (restart)", async () => {
+    seedAppStore();
+    // The local finish gets as far as persisting the runtime mode + active
+    // server, then its POST fails — the exact partial-commitment shape the
+    // reversal must clean up.
+    mocks.client.submitFirstRun.mockRejectedValueOnce(
+      new Error("first-run persist failed"),
+    );
+    const { transcript, turn, unmount } = renderConductor();
+    await waitForTurn(turn, "first-run:greeting");
+
+    expect(tryHandleFirstRunAction("__first_run__:runtime:local")).toBe(true);
+    await waitForTurn(turn, "first-run:provider");
+    expect(tryHandleFirstRunAction("__first_run__:provider:on-device")).toBe(
+      true,
+    );
+    await waitFor(() => {
+      expect(
+        transcript.current.some((m) => m.id.startsWith("first-run:error:")),
+      ).toBe(true);
+    });
+    // The failed local path left real committed state behind.
+    expect(localStorage.getItem(MOBILE_RUNTIME_MODE_STORAGE_KEY)).toBe("local");
+    expect(localStorage.getItem("elizaos:active-server")).toContain("local:");
+
+    // "Choose a different way to run" reverts the commitment before
+    // re-offering, so switching to cloud leaves nothing local behind.
+    expect(tryHandleFirstRunAction("__first_run__:error:restart")).toBe(true);
+    await waitFor(() => {
+      expect(
+        transcript.current.some((m) =>
+          m.id.startsWith("first-run:greeting:retry:"),
+        ),
+      ).toBe(true);
+    });
+    expect(localStorage.getItem(MOBILE_RUNTIME_MODE_STORAGE_KEY)).toBeNull();
+    expect(localStorage.getItem("elizaos:active-server")).toBeNull();
+
+    expect(tryHandleFirstRunAction("__first_run__:runtime:cloud")).toBe(true);
+    await waitForTurn(turn, "first-run:cloud-oauth");
+    unmount();
+  });
+
+  it("consumes back picks as stale no-ops in cloud-only mode", async () => {
+    localStorage.removeItem("eliza:enable-runtime-chooser");
+    localStorage.removeItem("steward_session_token");
+    seedAppStore({ elizaCloudConnected: false });
+    const { transcript, turn, unmount } = renderConductor();
+    await waitForTurn(turn, "first-run:greeting");
+
+    const before = transcript.current.length;
+    expect(tryHandleFirstRunAction("__first_run__:back:runtime")).toBe(true);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    // No re-offered runtime chooser exists in cloud-only mode.
+    expect(
+      transcript.current.some((m) =>
+        m.id.startsWith("first-run:greeting:retry:"),
+      ),
+    ).toBe(false);
     expect(transcript.current.length).toBe(before);
     unmount();
   });

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -33,6 +33,16 @@
  * - needs-cloud-login re-offers an UNLOCKED runtime choice and arms a
  *   connect-and-resume continuation (`pendingCloudResumeRef`).
  *
+ * Device RAM-tier gating + reversibility (#14390): the runtime and provider
+ * CHOICE blocks are built per-seed against the device's RAM-tier assessment
+ * (`device-ram-gate.ts`) — a sub-8 GB phone sees "On this device" labeled
+ * unavailable and its tap refused with the reason; a sub-12 GB phone gets
+ * on-device models blocked the same way (never silently hidden). Every
+ * sub-step CHOICE carries a "← Back" option whose handler unwinds any
+ * partially-committed local runtime (persisted mode, local active server,
+ * started service) before re-offering a fresh runtime choice, so onboarding
+ * is never forward-only and switching local→cloud leaves nothing running.
+ *
  * Cloud-only mode (#13377): the runtime chooser (local / remote) is gated by
  * `isRuntimeChooserEnabled()` and OFF by default. With the chooser off,
  * onboarding is a single "sign in to Eliza Cloud" step — the greeting IS the
@@ -71,6 +81,11 @@ import {
 } from "../state/cloud-login-launch";
 import { hasUsableStoredStewardToken } from "../state/cloud-steward-login";
 import { startTutorial } from "../tutorial/tutorial-service";
+import {
+  peekDeviceRamTierAssessment,
+  resolveDeviceRamTierAssessment,
+} from "./device-ram-gate";
+import type { DeviceRamTierAssessment } from "./device-ram-tier";
 import { normalizeFirstRunName } from "./first-run";
 import {
   FIRST_RUN_ACTION_PREFIX,
@@ -92,6 +107,7 @@ import {
   runFirstRunFinish,
 } from "./first-run-finish";
 import { isRuntimeChooserEnabled } from "./first-run-runtime-flag";
+import { revertLocalRuntimeCommitment } from "./revert-local-runtime-commitment";
 
 const GREETING =
   "Hi — I'm Eliza. Let's get you set up. First, where should your agent run?";
@@ -194,6 +210,13 @@ function newestLocalBackup(
   );
 }
 
+// The "go back and change an earlier pick" option appended to every sub-step
+// CHOICE (#14390): onboarding must never be forward-only. Its handler runs the
+// reversal cleanup (revert-local-runtime-commitment.ts) before re-offering a
+// fresh runtime choice, so backing out of a partially-committed local pick
+// leaves no persisted mode, no local active server, and no running service.
+const BACK_TO_RUNTIME_OPTION = `${FIRST_RUN_ACTION_PREFIX}back:runtime=← Back — change where your agent runs`;
+
 // The first-run location chooser: Cloud (managed), On this device, or Remote
 // (connect to an existing agent elsewhere). "Bring your own keys" is NOT a
 // location — it lives one step later on the provider sub-choice as
@@ -201,13 +224,26 @@ function newestLocalBackup(
 // runtime with `configure-later` and hands off provider setup to Settings via
 // the finish path's banner. Remote picks an already-running agent by URL +
 // token; it owns its own provider, so it skips the provider sub-step.
-const RUNTIME_CHOICE = [
-  "[CHOICE:first-run id=runtime]",
-  `${FIRST_RUN_ACTION_PREFIX}runtime:cloud=Eliza Cloud (managed)`,
-  `${FIRST_RUN_ACTION_PREFIX}runtime:local=On this device`,
-  `${FIRST_RUN_ACTION_PREFIX}runtime:remote=Connect to a remote agent`,
-  "[/CHOICE]",
-].join("\n");
+//
+// Built per-render because the local option is RAM-tier-gated (#14390): on a
+// device below the 8 GB floor it stays VISIBLE but labeled unavailable (never
+// silently hidden), and its tap is refused with the reason. The tier probe is
+// synchronous on Android; when it has not resolved yet (iOS first frames) the
+// plain label renders and the pick handler + finish backstop still enforce.
+function runtimeChoiceBlock(): string {
+  const tier = peekDeviceRamTierAssessment();
+  const localLabel =
+    tier && !tier.allowsLocalAgent
+      ? `On this device (unavailable — needs 8 GB+ RAM, ~${tier.marketedRamGb} GB detected)`
+      : "On this device";
+  return [
+    "[CHOICE:first-run id=runtime]",
+    `${FIRST_RUN_ACTION_PREFIX}runtime:cloud=Eliza Cloud (managed)`,
+    `${FIRST_RUN_ACTION_PREFIX}runtime:local=${localLabel}`,
+    `${FIRST_RUN_ACTION_PREFIX}runtime:remote=Connect to a remote agent`,
+    "[/CHOICE]",
+  ].join("\n");
+}
 
 const BACKUP_RESTORE_CHOICE = [
   "[CHOICE:first-run id=backup-restore]",
@@ -216,15 +252,33 @@ const BACKUP_RESTORE_CHOICE = [
   "[/CHOICE]",
 ].join("\n");
 
-function providerChoice(opts: { defaultId: "on-device" | "other" }): string {
-  const onDevice = `${FIRST_RUN_ACTION_PREFIX}provider:on-device=On this device (recommended)`;
-  const cloud = `${FIRST_RUN_ACTION_PREFIX}provider:elizacloud=Eliza Cloud inference`;
+// RAM-tier-gated (#14390): below the 12 GB on-device-model floor the
+// on-device option stays visible but labeled unavailable (its tap is refused
+// with the reason) and the recommendation moves to Eliza Cloud inference —
+// the local agent remains allowed in cloud-inference mode on that band.
+function providerChoice(opts: {
+  defaultId: "on-device" | "other";
+  tier: DeviceRamTierAssessment | null;
+}): string {
+  const modelsBlocked = opts.tier != null && !opts.tier.allowsLocalModels;
+  const onDevice = modelsBlocked
+    ? `${FIRST_RUN_ACTION_PREFIX}provider:on-device=On this device (unavailable — needs 12 GB+ RAM, ~${opts.tier?.marketedRamGb} GB detected)`
+    : `${FIRST_RUN_ACTION_PREFIX}provider:on-device=On this device (recommended)`;
+  const cloud = modelsBlocked
+    ? `${FIRST_RUN_ACTION_PREFIX}provider:elizacloud=Eliza Cloud inference (recommended)`
+    : `${FIRST_RUN_ACTION_PREFIX}provider:elizacloud=Eliza Cloud inference`;
   const other = `${FIRST_RUN_ACTION_PREFIX}provider:other=Other / configure in Settings`;
-  const ordered =
-    opts.defaultId === "on-device"
+  const ordered = modelsBlocked
+    ? [cloud, onDevice, other]
+    : opts.defaultId === "on-device"
       ? [onDevice, cloud, other]
       : [other, onDevice, cloud];
-  return ["[CHOICE:first-run id=provider]", ...ordered, "[/CHOICE]"].join("\n");
+  return [
+    "[CHOICE:first-run id=provider]",
+    ...ordered,
+    BACK_TO_RUNTIME_OPTION,
+    "[/CHOICE]",
+  ].join("\n");
 }
 
 const TUTORIAL_CHOICE = [
@@ -364,7 +418,7 @@ export function surfaceCloudLoginRetryTurn(writer: FirstRunTurnWriter): void {
   // runtime to re-pick: the retry turn re-offers the single sign-in button
   // (whose tap re-enters the cloud flow with a fresh user gesture).
   const retryText = isRuntimeChooserEnabled()
-    ? `Connect your Eliza Cloud account to continue — I'll pick up where we left off. You can also pick how to run your agent again.\n\n${RUNTIME_CHOICE}`
+    ? `Connect your Eliza Cloud account to continue — I'll pick up where we left off. You can also pick how to run your agent again.\n\n${runtimeChoiceBlock()}`
     : `Sign in to Eliza Cloud to continue — I'll pick up where we left off.\n\n${CLOUD_SIGN_IN_CHOICE}`;
   const connectTurn = makeTurn("first-run:cloud-oauth", retryText, {
     secretRequest: cloudOAuthSecretRequest("failed"),
@@ -497,7 +551,7 @@ export function useFirstRunConductor(): void {
 
   const seedRuntimeChoice = React.useCallback(() => {
     seedTurn(
-      makeTurn("first-run:greeting", `${GREETING}\n\n${RUNTIME_CHOICE}`),
+      makeTurn("first-run:greeting", `${GREETING}\n\n${runtimeChoiceBlock()}`),
     );
   }, [seedTurn]);
 
@@ -645,6 +699,11 @@ export function useFirstRunConductor(): void {
       lines.push(
         `${FIRST_RUN_ACTION_PREFIX}cloud-agent:new=Create a new agent`,
       );
+      // Cloud-only mode has no runtime to go back to; only offer the back
+      // affordance when the chooser owns this flow.
+      if (isRuntimeChooserEnabled()) {
+        lines.push(BACK_TO_RUNTIME_OPTION);
+      }
       seedFreshChoiceTurn(
         "first-run:cloud-agent",
         `Which Eliza Cloud agent should I use?\n\n[CHOICE:first-run id=cloud-agent]\n${lines.join("\n")}\n[/CHOICE]`,
@@ -896,11 +955,18 @@ export function useFirstRunConductor(): void {
       // every further first-run pick is a stale-widget no-op.
       if (completedRef.current) return true;
       // Cloud-only mode: runtime:cloud is the live "Sign in to Eliza Cloud"
-      // button; every other runtime / provider / backup-restore pick can only
-      // be a stale widget from a chooser-mode transcript (or garbage) —
-      // consume those untouched so they can't start a local/remote flow.
+      // button; every other runtime / provider / backup-restore / back pick
+      // can only be a stale widget from a chooser-mode transcript (or
+      // garbage) — consume those untouched so they can't start a local/remote
+      // flow (there is no runtime chooser to go "back" to).
       if (!isRuntimeChooserEnabled()) {
-        if (group === "provider" || group === "backup-restore") return true;
+        if (
+          group === "provider" ||
+          group === "backup-restore" ||
+          group === "back"
+        ) {
+          return true;
+        }
         if (group === "runtime" && id !== "cloud") return true;
       }
       // A fresh pick supersedes any armed connect-and-resume continuation —
@@ -913,6 +979,13 @@ export function useFirstRunConductor(): void {
 
       if (group === "runtime") {
         if (id !== "cloud" && id !== "local" && id !== "remote") return true;
+        // Switching AWAY from a previously-picked (possibly partially
+        // committed) local runtime must unwind it: clear the persisted mode +
+        // local active server and stop a service a failed finish may have
+        // started (#14390). No-op when nothing local was committed.
+        if (id !== "local") {
+          void revertLocalRuntimeCommitment();
+        }
         if (id === "cloud") {
           draftRef.current = {
             ...draftRef.current,
@@ -945,27 +1018,48 @@ export function useFirstRunConductor(): void {
           // its own provider, so there is no provider sub-step — and it never
           // routes through runFirstRunFinish, so draftRef (a FirstRunFinishDraft,
           // which excludes "remote") is intentionally left untouched.
+          // The back CHOICE rides in the same turn's text, under the inline
+          // connect form — the form comes from `secretRequest`, the widget
+          // from the text, and both render (#14390 reversibility).
           const connect = makeTurn(
             "first-run:remote-connect",
-            "Enter your remote agent's URL and access token to connect.",
+            `Enter your remote agent's URL and access token to connect.\n\n[CHOICE:first-run id=remote-back]\n${BACK_TO_RUNTIME_OPTION}\n[/CHOICE]`,
             { secretRequest: remoteConnectSecretRequest() },
           );
           seedTurn(connect);
           replaceTurn("first-run:remote-connect", connect);
           return true;
         }
-        // On this device: run the local backend, then ask which model provider.
-        // BYOK is the provider:other sub-choice ("Other / configure in
-        // Settings"), which finishes with `configure-later` and defers provider
-        // setup to Settings.
+        // On this device: RAM-tier gate first (#14390). A device below the
+        // 8 GB floor is refused with the reason and re-offered a fresh
+        // runtime choice — enforced at the decision point, not just labeled.
+        const tier = peekDeviceRamTierAssessment();
+        if (tier && !tier.allowsLocalAgent) {
+          seedTurn(
+            makeTurn(
+              `first-run:runtime-blocked:${Date.now()}`,
+              `I can't run on this device — ${tier.reason}. Eliza Cloud runs your agent with nothing to install, or you can connect to an agent running somewhere else.\n\n${runtimeChoiceBlock()}`,
+            ),
+          );
+          return true;
+        }
+        // Run the local backend, then ask which model provider. BYOK is the
+        // provider:other sub-choice ("Other / configure in Settings"), which
+        // finishes with `configure-later` and defers provider setup to
+        // Settings. Sub-16 GB devices get the perf warning inline; sub-12 GB
+        // devices get the on-device option blocked inside providerChoice.
         draftRef.current = {
           ...draftRef.current,
           runtime: "local",
           localInference: "all-local",
         };
+        const modelWarning =
+          tier?.localModelsWarning || (tier && !tier.allowsLocalModels)
+            ? ` Heads up: ${tier.reason}.`
+            : "";
         seedFreshChoiceTurn(
           "first-run:provider",
-          `Which model provider should ${draftRef.current.agentName} use?\n\n${providerChoice({ defaultId: "on-device" })}`,
+          `Which model provider should ${draftRef.current.agentName} use?${modelWarning}\n\n${providerChoice({ defaultId: "on-device", tier })}`,
         );
         return true;
       }
@@ -1020,6 +1114,19 @@ export function useFirstRunConductor(): void {
         if (id !== "on-device" && id !== "elizacloud" && id !== "other") {
           return true;
         }
+        // RAM-tier gate (#14390): below the 12 GB floor on-device models are
+        // refused at the decision point with the reason and a fresh provider
+        // choice; the finish backstop enforces the same rule for any caller.
+        if (id === "on-device") {
+          const tier = peekDeviceRamTierAssessment();
+          if (tier && !tier.allowsLocalModels) {
+            seedFreshChoiceTurn(
+              "first-run:provider",
+              `On-device models won't work here — ${tier.reason}. Eliza Cloud inference keeps the agent on this device and runs the models in the cloud.\n\n${providerChoice({ defaultId: "on-device", tier })}`,
+            );
+            return true;
+          }
+        }
         if (id === "other") {
           // "Other / configure in Settings" (bring your own keys): finish the
           // LOCAL runtime with no provider wired and no model download.
@@ -1062,6 +1169,25 @@ export function useFirstRunConductor(): void {
         return true;
       }
 
+      if (group === "back") {
+        if (id !== "runtime") return true;
+        // Reversal (#14390): unwind anything the abandoned path committed —
+        // the persisted local mode/server and a service a partial finish may
+        // have started — then re-offer a FRESH (unlocked) runtime choice.
+        void revertLocalRuntimeCommitment();
+        draftRef.current = {
+          ...draftRef.current,
+          runtime: "cloud",
+          localInference: "all-local",
+        };
+        cloudPrefsRef.current = {};
+        seedFreshChoiceTurn(
+          "first-run:greeting",
+          `${GREETING}\n\n${runtimeChoiceBlock()}`,
+        );
+        return true;
+      }
+
       if (group === "error") {
         if (id !== "retry" && id !== "restart" && id !== "settings") {
           return true;
@@ -1072,14 +1198,18 @@ export function useFirstRunConductor(): void {
         }
         if (id === "restart" && isRuntimeChooserEnabled()) {
           // Re-offer a FRESH (unlocked) runtime choice so the user can switch
-          // how their agent runs after a failed finish. seedFreshChoiceTurn
-          // seeds a retry turn when the greeting already exists (the original
-          // runtime widget locked itself on its first pick). Cloud-only mode
-          // never offers restart; a stale restart tap falls through to retry
-          // below — the only other way to run doesn't exist there.
+          // how their agent runs after a failed finish — unwinding whatever
+          // the failed local path committed first (#14390), so switching to
+          // cloud can't leave a half-started local agent behind.
+          // seedFreshChoiceTurn seeds a retry turn when the greeting already
+          // exists (the original runtime widget locked itself on its first
+          // pick). Cloud-only mode never offers restart; a stale restart tap
+          // falls through to retry below — the only other way to run doesn't
+          // exist there.
+          void revertLocalRuntimeCommitment();
           seedFreshChoiceTurn(
             "first-run:greeting",
-            `${GREETING}\n\n${RUNTIME_CHOICE}`,
+            `${GREETING}\n\n${runtimeChoiceBlock()}`,
           );
           return true;
         }
@@ -1188,6 +1318,12 @@ export function useFirstRunConductor(): void {
       return;
     }
     resetFirstRunPersistGuard();
+    // Warm the RAM-tier probe (#14390) so the pick handlers' synchronous
+    // `peek` has an answer by the time a human can tap: Android resolves
+    // synchronously inside peek anyway; this covers the iOS async path. Never
+    // gates the greeting — the finish backstop enforces the policy even when
+    // a pick lands before the probe settles.
+    void resolveDeviceRamTierAssessment();
     // A fresh activation decides silence for itself below — a stale `true`
     // from a previous mount (silent entry unmounted mid-flight, user signed
     // out, conductor re-entered) must not suppress this run's turns.

--- a/packages/ui/src/platform/android-runtime.ts
+++ b/packages/ui/src/platform/android-runtime.ts
@@ -21,6 +21,8 @@
  * cannot try to provision an on-device agent that physically isn't there.
  */
 
+import { getFrontendPlatform } from "./platform-guards";
+
 export type AndroidRuntimeMode = "cloud" | "local";
 
 type RuntimeEnv = Record<string, string | boolean | undefined>;
@@ -62,4 +64,16 @@ export function isAndroidCloudBuild(): boolean {
       ? ((import.meta as { env: RuntimeEnv }).env as RuntimeEnv)
       : {};
   return resolveAndroidRuntimeMode(env) === "cloud";
+}
+
+/**
+ * True on the Android builds that ship the on-device agent runtime
+ * (`android` sideload / `android-system`): a native Android shell that is not
+ * the cloud-locked Play-Store variant. These builds' whole point is the local
+ * agent, so onboarding must offer the local runtime path
+ * (first-run-runtime-flag.ts) — but never auto-start it before the user picks
+ * it (#14390).
+ */
+export function isAndroidLocalSideloadBuild(): boolean {
+  return getFrontendPlatform() === "android" && !isAndroidCloudBuild();
 }

--- a/packages/ui/src/services/local-inference/resource-snapshot-bridge.test.ts
+++ b/packages/ui/src/services/local-inference/resource-snapshot-bridge.test.ts
@@ -14,6 +14,7 @@ describe("normalizeResourceSnapshot", () => {
         lowPowerMode: false,
         residentMemoryMb: 812.5,
         availableRamMb: 2048,
+        totalRamMb: 7654,
         cpuTimeMs: 12345,
         batteryLevelPct: 73,
         batteryChargeMicroAmpHours: 2_900_000,
@@ -29,6 +30,7 @@ describe("normalizeResourceSnapshot", () => {
       lowPowerMode: false,
       residentMemoryMb: 812.5,
       availableRamMb: 2048,
+      totalRamMb: 7654,
       cpuTimeMs: 12345,
       batteryLevelPct: 73,
       batteryChargeMicroAmpHours: 2_900_000,
@@ -54,6 +56,7 @@ describe("normalizeResourceSnapshot", () => {
       5_555,
     );
     expect(s.availableRamMb).toBeNull();
+    expect(s.totalRamMb).toBeNull();
     expect(s.cpuTimeMs).toBeNull();
     expect(s.batteryLevelPct).toBeNull();
     expect(s.batteryChargeMicroAmpHours).toBeNull();

--- a/packages/ui/src/services/local-inference/resource-snapshot-bridge.ts
+++ b/packages/ui/src/services/local-inference/resource-snapshot-bridge.ts
@@ -41,6 +41,8 @@ export interface DeviceResourceSnapshot {
   residentMemoryMb: number | null;
   /** Device-wide available RAM in MB before memory pressure. */
   availableRamMb: number | null;
+  /** Device total physical RAM in MB (feeds RAM-tier gating, #14390). */
+  totalRamMb: number | null;
   /** Cumulative process CPU time in ms. */
   cpuTimeMs: number | null;
   batteryLevelPct: number | null;
@@ -94,6 +96,7 @@ export function normalizeResourceSnapshot(
     lowPowerMode: boolOrNull(r.lowPowerMode),
     residentMemoryMb: finiteOrNull(r.residentMemoryMb),
     availableRamMb: finiteOrNull(r.availableRamMb),
+    totalRamMb: finiteOrNull(r.totalRamMb),
     cpuTimeMs: finiteOrNull(r.cpuTimeMs),
     batteryLevelPct: finiteOrNull(r.batteryLevelPct),
     batteryChargeMicroAmpHours: finiteOrNull(r.batteryChargeMicroAmpHours),

--- a/packages/ui/src/state/startup-phase-poll.ts
+++ b/packages/ui/src/state/startup-phase-poll.ts
@@ -617,18 +617,16 @@ export async function runPollingBackend(
       return;
     }
     // The poll cannot wake the agent it is waiting for — an Android local-IPC
-    // probe just blocks while nobody serves the socket — and on a fresh
-    // install nobody else asks: the native auto-start gate was evaluated
-    // before the renderer pre-seeded the local target, and onboarding (the
-    // only other Agent.start() caller) is skipped on the pre-seeded path
-    // (#15189). Request the start on EVERY iteration, not once per base: a
-    // single request can be lost (service teardown race, FGS-window denial,
-    // a child that dies right after starting), and native start is idempotent
-    // — a START_AGENT delivery to a running/booting service is absorbed by
-    // the socket-adopt and cold-boot guards. Re-asking each retry makes the
-    // revive self-healing for the whole phase, covering the fresh boot, the
-    // Retry button, and a mid-phase recoverToOnDeviceLocalAgent base switch.
-    // Non-local bases no-op inside the helper.
+    // probe just blocks while nobody serves the socket. A branded device
+    // auto-starts the agent at boot and a stock device starts it from the
+    // onboarding finish (#14390), but that one START_AGENT can be lost to a
+    // service teardown race, an FGS-window denial, or a child that dies right
+    // after starting. Request the start on EVERY iteration, not once per base:
+    // native start is idempotent — a START_AGENT delivery to a running/booting
+    // service is absorbed by the socket-adopt and cold-boot guards. Re-asking
+    // each retry makes the revive self-healing for the whole phase, covering
+    // the boot, the Retry button, and a mid-phase recoverToOnDeviceLocalAgent
+    // base switch. Non-local bases no-op inside the helper.
     const polledBase = client.getBaseUrl();
     if (polledBase) {
       void requestAndroidLocalAgentStartForUrl(polledBase).then((requested) => {

--- a/packages/ui/src/state/useStartupCoordinator.ts
+++ b/packages/ui/src/state/useStartupCoordinator.ts
@@ -18,6 +18,7 @@ import { logger } from "@elizaos/logger";
 import { useCallback, useEffect, useReducer, useRef } from "react";
 import { client } from "../api";
 import { isElectrobunRuntime } from "../bridge";
+import { enforceDeviceRamPolicyOnPersistedRuntimeModeAtBoot } from "../first-run/device-ram-gate";
 import { reconcilePersistedMobileRuntimeModeAtBoot } from "../first-run/reconcile-mobile-runtime-mode";
 import { isAndroid, isElizaOS, isIOS, isNative } from "../platform";
 import {
@@ -213,6 +214,12 @@ export function useStartupCoordinator(
     // local-agent transports stay policy-locked and boot hangs. No-op on
     // web/desktop and whenever the persisted mode is still usable.
     reconcilePersistedMobileRuntimeModeAtBoot();
+    // RAM-tier enforcement (#14390) runs AFTER the build reconcile so a mode
+    // the reconcile just adopted is also policy-checked: a persisted/adopted
+    // "local" on a device below the 8 GB floor is reverted here, landing the
+    // boot in onboarding instead of polling an agent the native gate refuses
+    // to start. No-op on web/desktop and on capable devices.
+    enforceDeviceRamPolicyOnPersistedRuntimeModeAtBoot();
     // error-policy:J5 expected failures are dispatched to the state machine
     // inside the runner; this catch only keeps an unexpected runner bug from
     // becoming an unhandled rejection, logged so a wedged boot phase is


### PR DESCRIPTION
Fixes #14390.

## Problem
On a 4 GB Moto G Play (2024) the sideload build **auto-started the on-device Bun agent at boot** and hung ~180s before a `Startup failed: Backend Timeout` card. The device cannot run the local agent, but the app tried on every launch. This is the structural fix (device-tier gating + boot-gate + reversible onboarding), not just the vision-poller symptom fixed in #14377.

## What changed

### 1. Boot-gate the local agent on onboarding state
- **`ElizaAgentService.shouldAutoStart`** (Android): no longer auto-starts a payload build on a **fresh install** (`mode==null`). Only a **branded device** or an **explicit persisted `local`** choice **on a RAM-capable device** auto-starts. The old `bundlesAgentPayload && mode==null → true` path is gone — that was the exact 4 GB boot wedge.
- A fresh install lands in **onboarding**; the renderer starts the service **on demand** through the Agent Capacitor plugin the moment the user commits to `local` (`finishLocal → startMobileLocalAgent`) — verified no app restart needed (the plugin `start()` bridge is already the mid-onboarding path).
- Stock sideload builds **no longer pre-seed `local`** (pre-seed is now branded-device-only); the **runtime chooser defaults ON** for those builds so onboarding is the only thing that starts the agent. Branded-device auto-start behavior is unchanged.

### 2. Device RAM-tier gating (hard policy, native + renderer, shared thresholds)
New `DeviceRamTierPolicy.java` + `device-ram-tier.ts` (shared marketed-GB recovery: round `totalMem` up to the next whole GiB, since the kernel under-reports — a "4 GB" device reads ~3.6 GiB):
- **< 8 GB** → local agent **disabled** (cloud-only)
- **< 12 GB** → on-device **models disabled** (local agent allowed in cloud-inference/hybrid mode)
- **< 16 GB** → models **allowed with a perf/thermal warning**
- **≥ 16 GB** → full local

Enforced at every decision point, **not merely advisory**:
- Onboarding runtime + provider CHOICE options render **disabled/warn states with the reason** (never silently hidden) and **refuse** blocked picks.
- `assertDeviceRamTierAllowsLocalRuntime` is the **fail-loud backstop** in `finishLocal`.
- `ElizaAgentService.start` **throws** below the floor (defense-in-depth for the boot receiver / poll paths).
- A **stale persisted `local`** (carried across reinstalls by Capacitor Preferences, or written by a pre-#14390 build) is **reverted to onboarding at boot** (`enforceDeviceRamPolicyOnPersistedRuntimeModeAtBoot`).
- Total RAM surfaced via `ElizaNative.getDeviceTotalRamMb()` (sync Android bridge, runs before the Capacitor executor), `ResourceProbe`/`ElizaIntent` `getResourceSnapshot.totalRamMb`.

### 3. Reversible onboarding
- Every sub-step CHOICE carries a **"← Back"** option; going back (or error-recovery "choose a different way to run") **unwinds** a partially-committed local runtime — persisted mode, local active server, **and a started service** — via `revertLocalRuntimeCommitment` before re-offering a fresh runtime choice. Picking local → back → cloud leaves **no agent running and no pre-seed flags set**.

## Tests
- **JVM (54 app unit tests pass, Java 21):** new `DeviceRamTierPolicyTest` (marketed-GB recovery + 8 GB floor, pinned to the real Moto G Play `MemTotal 3,747,844 kB`); rewritten `ElizaAgentAutostartPolicyTest` (fresh install never auto-starts; persisted `local` refused below the floor).
- **Renderer vitest:** `device-ram-tier` (tier boundaries), `device-ram-gate` (sync Android bridge → async snapshot fallback → fail-loud finish assertion → boot revert, real persistence), `revert-local-runtime-commitment` (real persistence + Agent bridge seam), extended `use-first-run-conductor` suite (tier gating + reversibility driven through the **real** finish path), updated `pre-seed`, `runtime-flag`, `resource-snapshot` suites. All green.

## Evidence

| Type | Status |
| --- | --- |
| Backend/JVM logs | JVM: 54/54 app unit tests pass (`DeviceRamTierPolicyTest` 4, `ElizaAgentAutostartPolicyTest` 7 + existing). Renderer: `device-ram-*`, `revert-*`, `use-first-run-conductor` (82 in the core group) pass. |
| Real-LLM trajectories | N/A — no agent/prompt/model behavior changed; this is boot-gating + onboarding UI + device-policy logic. |
| Before/after screenshots (desktop+mobile) | **N/A on this lane — requires the physical device matrix; the fleet's device lane owns capture** (< 8 GB Moto G Play cloud-only + lands in onboarding, mid-tier local-agent-ok/models-blocked, high-RAM full-local, reversible walkthrough). |
| Video walkthrough | **N/A on this lane — device-captured by the fleet device lane** (reversible onboarding back/change/switch). |
| Frontend console/network logs | **N/A on this lane — device-captured by the fleet device lane.** |
| Per-platform capture (device/sim) | **N/A on this lane — device-captured by the fleet device lane** (real < 8GB / mid / high-RAM devices per the issue's acceptance). |
| Domain artifacts | Reversal cleanup asserted on real localStorage (`eliza:mobile-runtime-mode` + `elizaos:active-server` cleared, service `stop` called); persisted-mode boot-revert asserted. |

## Not done without a device (explicit)
The issue's **Acceptance** requires real on-device verification on a < 8 GB device, a mid-tier device, and a high-RAM device plus a recorded reversible-onboarding walkthrough. Those captures need the physical device matrix and are **left to the fleet's device lane** — the logic they exercise is fully unit-covered here (JVM + renderer), including the exact Moto G Play RAM reading from the #14390 / #14377 logcat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
