### PR TITLE
fix(ci): install the agent host bridge in the accounts-UI e2e server

### DIFF
--- a/packages/app/e2e/accounts-ui/accounts-api-server.ts
+++ b/packages/app/e2e/accounts-ui/accounts-api-server.ts
@@ -33,6 +33,21 @@ import {
   handleAccountsRoutes,
 } from "../../../agent/src/api/accounts-routes.ts";
 import type { ElizaConfig } from "../../../agent/src/config/types.eliza.ts";
+import {
+  defaultAgentHostBridge,
+  setAgentHostBridge,
+} from "../../../agent/src/runtime/host-bridge.ts";
+
+// This process IS the host: the accounts routes read the pool through the
+// agent host-bridge seam (`getPool()` → `getAgentHostBridge()`), which the
+// real dashboard installs in its boot funnel. Without this injection the
+// routes see the no-op bridge's `null` pool and every pool-touching request
+// 500s — validation-only paths (e.g. the zod reject) still worked, which is
+// how the gap stayed invisible until scenario 04 exercised a successful add.
+setAgentHostBridge({
+  ...defaultAgentHostBridge,
+  getDefaultAccountPool,
+});
 
 const HOME = process.env.ELIZA_HOME?.trim();
 if (!HOME) {

--- a/packages/app/e2e/accounts-ui/run-accounts-ui-e2e.mjs
+++ b/packages/app/e2e/accounts-ui/run-accounts-ui-e2e.mjs
@@ -193,9 +193,16 @@ const child = spawn(
     stdio: ["ignore", "pipe", "pipe"],
   },
 );
+// Mirror the API child's output live (prefixed) AND collect it for the
+// evidence log — a boot crash must print its own stack, not a bare
+// "exited early (code 1)" with the cause buried in a file that the
+// early-rejection path never wrote.
 child.stderr.on("data", (d) => {
   for (const line of String(d).split("\n")) {
-    if (line.trim()) serverLog.push(line.trim());
+    if (line.trim()) {
+      serverLog.push(line.trim());
+      console.error(`[api] ${line.trim()}`);
+    }
   }
 });
 
@@ -207,7 +214,11 @@ const port = await new Promise((resolvePort, rejectPort) => {
   let buffer = "";
   child.stdout.on("data", (d) => {
     buffer += String(d);
-    for (const line of buffer.split("\n")) {
+    // Consume completed lines only: a chunk boundary can't split the
+    // readiness JSON, and repeated chunks can't re-mirror earlier lines.
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
       try {
         const parsed = JSON.parse(line);
         if (parsed.ready && parsed.port) {
@@ -216,7 +227,12 @@ const port = await new Promise((resolvePort, rejectPort) => {
           return;
         }
       } catch {
-        // not the readiness line
+        // Not the readiness line — mirror it like stderr so nothing the
+        // server prints is invisible.
+        if (line.trim()) {
+          serverLog.push(line.trim());
+          console.error(`[api] ${line.trim()}`);
+        }
       }
     }
   });


### PR DESCRIPTION
## Root cause

The **Zero-Key accounts-UI e2e** (scenario 04, "valid add → dialog closes on success") timed out with the Radix dialog stuck `data-state="open"` after the account-add POST returned **500**. This was the last red after #15233 fixed the import crash.

The e2e API server (`accounts-api-server.ts`) mounts the **real** `handleAccountsRoutes`, but it boots outside app-core's funnel and so **never called `setAgentHostBridge`**. Inside the routes, `getPool()` reads `getAgentHostBridge().getDefaultAccountPool()`, which therefore resolved to the **no-op default bridge's `null` pool**. Every pool-touching request 500'd on the null deref:

- **POST add** → `pool.upsert(null)` → 500, so the dialog's `onCreated`/`onClose` never fired and it stayed open.
- **Validation-only paths** (the zod reject in scenario 03) return *before* `getPool()`, so they passed.
- **GET-list failures** are swallowed by `useAccounts.refresh()` (data stays `null` → empty state renders), which is why scenarios 01/03 masked the gap until 04 exercised a *successful* add.

The browser POST body was never the problem — the client already sends the required `source:"api-key"` discriminator (`client-agent.ts:4699`).

## Fix (harness layer, right layer)

Install the host bridge in `accounts-api-server.ts` — the e2e process **is** the host, mirroring what the real dashboard does in app-core's boot funnel:

```ts
setAgentHostBridge({ ...defaultAgentHostBridge, getDefaultAccountPool });
```

No product code changed; the form and server contract were already correct.

Also mirror the API child's stdout/stderr through the runner (prefixed `[api]`) and consume only completed stdout lines, so a server-side verdict or boot crash is visible in the run instead of a bare `exited early (code 1)`.

## Evidence — full suite green including scenario 04

```
[api] [accounts-e2e-api] POST /api/accounts/anthropic-api -> 400   # 03 zod reject
PASS  invalid API key (<8 chars) surfaces the server's validation error inline
[api] Info  [auth] Saved anthropic-api account "…" (label="Personal")
[api] [accounts-e2e-api] POST /api/accounts/anthropic-api -> 201   # 04 add succeeds
PASS  added account is in the REAL pool (label=Personal)
PASS  credential record written to the on-disk store
PASS  card shows the API-key source badge
… (05–12 reorder / strategy / health / disable / delete / empty) …
PASS  zero page errors across the whole flow

ALL ASSERTIONS PASSED — 13 screenshots
```

- `bun run --cwd packages/app test:e2e:accounts-ui` → all assertions pass (server logs now visible).
- Biome clean on both touched files.
- `audit:error-policy-ratchet` → no new fallback-slop (harness files are not production source).
- `packages/ui` accounts stories smoke test → 27 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)