### PR TITLE
fix(ci): focused-test gate ignores runner.only inside strings + reformat one ui test

### DIFF
--- a/packages/scripts/audit-focused-skipped-tests.mjs
+++ b/packages/scripts/audit-focused-skipped-tests.mjs
@@ -58,10 +58,14 @@ const TEST_FILE_PATHSPECS = [
 ];
 
 // Focused-test forms. `it/describe/test/suite/bench/context` are unambiguously
-// test-runner globals inside a test file, so `<runner>.only` is always a focused
-// test. `fdescribe`/`fit` are the jasmine-style focus aliases (require a call).
+// test-runner globals inside a test file, so `<runner>.only` is a focused test —
+// but ONLY as a call (`it.only(`) or a parameterized chain (`it.only.each(` /
+// `.for(`). Requiring the `(`/chain (like SKIP_PATTERNS require `(`) is what
+// keeps a `.only` that merely appears inside a STRING or property value from
+// tripping the gate — e.g. `id: "test.only"` (an app-page id) is data, not a
+// focused test. `fdescribe`/`fit` are the jasmine-style focus aliases.
 const FOCUSED_PATTERNS = [
-  /\b(?:describe|it|test|suite|bench|context)\.only\b/,
+  /\b(?:describe|it|test|suite|bench|context)\.only\s*(?:\.(?:each|for)\b|\()/,
   /\bf(?:describe|it)\s*\(/,
 ];
 
@@ -334,6 +338,11 @@ function selfTest() {
     {
       name: "ignores unrelated .only property",
       src: 'const readonly = { only: true }; it("a", () => { expect(cfg.only).toBe(true); });',
+      expect: [],
+    },
+    {
+      name: "ignores a runner-name.only inside a string literal (page id, etc.)",
+      src: 'registerAppShellPage({ id: "test.only", label: "Solo" });\nit("a", () => {});',
       expect: [],
     },
     {

--- a/packages/ui/src/components/composites/chat/chat-message.hover-reveal.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.hover-reveal.test.tsx
@@ -108,8 +108,6 @@ describe("ChatMessage desktop hover-chrome delete control (#13533)", () => {
     );
     expect(screen.queryByTestId("chat-message-action-rail")).toBeNull();
     expect(deleteControl()).toBeNull();
-    expect(
-      screen.queryByRole("button", { name: "Reply" }),
-    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Reply" })).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Two "Quality (Extended)" reds on develop.

### 1. Develop Gate — false-positive focused-test flag
`audit-focused-skipped-tests.mjs` flagged `packages/ui/src/components/shared/SectionNav.test.tsx:174` — but that line is `id: "test.only"`, a plain string property (an app-shell page id passed to `registerAppShellPage`), **not** a focused test.

Root cause: the focused-test pattern was `/\b(?:describe|it|test|suite|bench|context)\.only\b/` — no requirement of a call, so the substring `test.only` **inside a string literal** matched. `SKIP_PATTERNS` already require a `(` for exactly this reason; the `.only` form didn't.

Fix: require a call or parameterized chain — `/…\.only\s*(?:\.(?:each|for)\b|\()/`. Matches `it.only(`, `it.only.each(`, `describe.only.for(`; ignores `.only` followed by a quote/property. Added a self-test case locking the string-literal case.

- Self-test: **21/21** (still flags every real focused form: `describe.only`, `it.only`, `it.only.each`, `fit(`, `fdescribe(`).
- Full repo scan: **`scanned 5884 test files — 0 focused, 0 orphaned`, exit 0**.

### 2. Format + Type Safety Ratchet — one unformatted file
`@elizaos/ui format:check` wanted a multi-line `expect(screen.queryByRole(...)).toBeNull()` in `chat-message.hover-reveal.test.tsx` collapsed to one line. Applied `biome format --write` to that file; full `bunx @biomejs/biome format src` now reports no changes.

The type-safety ratchet counters themselves were fixed in #15227 (already on develop); this change adds no nullish-coalescing to core/agent/app-core, so it can't regress them.

## Validation
- `node packages/scripts/audit-focused-skipped-tests.mjs --self-test` → 21/21
- `node packages/scripts/audit-focused-skipped-tests.mjs` → clean, exit 0
- `bunx @biomejs/biome format src` (packages/ui) → no fixes needed
- `biome check` on both touched files → clean

N/A rows: no runtime/UI behavior change (a CI scanner regex + a test-file whitespace reformat) — no screenshots/trajectories/logs apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)