### PR TITLE
fix(os-linux): anchor ISO embedding-fallback patch on the warmup signature

### DIFF
--- a/packages/os/linux/scripts/prepare-elizaos-app-overlay.mjs
+++ b/packages/os/linux/scripts/prepare-elizaos-app-overlay.mjs
@@ -1604,30 +1604,20 @@ function liveEmbeddingFallbackVector(): number[] {
 }
 `,
     );
-    // Accept both the inline `ELIZA_DISABLE_LOCAL_EMBEDDINGS` check (older
-    // shape) and the post-refactor `isLocalEmbeddingDisabledByEnv()` call.
-    const inlineCheck = `export function shouldWarmupLocalEmbeddingModel(): boolean {
-\tif (isTruthyEnv("ELIZA_DISABLE_LOCAL_EMBEDDINGS")) {
-\t\treturn false;
-\t}
+    // Inject the live-fallback short-circuit right after the function's
+    // opening brace. Earlier revisions anchored on the function's ENTIRE
+    // leading check sequence, which broke every time the plugin inserted or
+    // reordered a check upstream of the disable test (the exact drift that
+    // re-reddened the nightly while this pipeline was unreachable). The
+    // fallback check is order-independent, so the signature is the only
+    // anchor this patch actually needs; `isTruthyEnv` is a module-local
+    // helper of embedding-warmup-policy.ts, present in every shape so far.
+    const warmupSignature = `export function shouldWarmupLocalEmbeddingModel(): boolean {
 `;
-    const helperCheck = `export function shouldWarmupLocalEmbeddingModel(): boolean {
-\tif (isLocalEmbeddingDisabledByEnv()) {
-\t\treturn false;
-\t}
-`;
-    if (content.includes(inlineCheck)) {
+    if (content.includes(warmupSignature)) {
       content = content.replace(
-        inlineCheck,
-        `${inlineCheck}\tif (isTruthyEnv("ELIZAOS_LIVE_EMBEDDING_FALLBACK")) {
-\t\treturn false;
-\t}
-`,
-      );
-    } else if (content.includes(helperCheck)) {
-      content = content.replace(
-        helperCheck,
-        `${helperCheck}\tif (isTruthyEnv("ELIZAOS_LIVE_EMBEDDING_FALLBACK")) {
+        warmupSignature,
+        `${warmupSignature}\tif (isTruthyEnv("ELIZAOS_LIVE_EMBEDDING_FALLBACK")) {
 \t\treturn false;
 \t}
 `,
@@ -1765,36 +1755,26 @@ function liveEmbeddingFallbackVector() {
 }
 `,
   );
-  content = content.replace(
-    `function shouldWarmupLocalEmbeddingModel() {
-  if (isTruthyEnv("ELIZA_DISABLE_LOCAL_EMBEDDINGS")) {
+  // Inject the live-fallback short-circuit right after the compiled function's
+  // opening brace. The bundler preserves the source signature but the leading
+  // check sequence drifts whenever the plugin inserts a new check ahead of the
+  // disable test — the exact drift (a new `ELIZA_SKIP_LOCAL_EMBEDDING_WARMUP`
+  // check landing first) that re-reddened this ISO stage. The fallback check is
+  // order-independent, so the signature is the only stable anchor; `isTruthyEnv`
+  // is bundled alongside this function from embedding-warmup-policy.ts. This
+  // mirrors the source-shape patch above so both compiled and TS overlays honor
+  // the flag instead of silently no-opping the warmup skip.
+  const distWarmupSignature = `function shouldWarmupLocalEmbeddingModel() {
+`;
+  if (content.includes(distWarmupSignature)) {
+    content = content.replace(
+      distWarmupSignature,
+      `${distWarmupSignature}  if (isTruthyEnv("ELIZAOS_LIVE_EMBEDDING_FALLBACK")) {
     return false;
   }
 `,
-    `function shouldWarmupLocalEmbeddingModel() {
-  if (isTruthyEnv("ELIZA_DISABLE_LOCAL_EMBEDDINGS")) {
-    return false;
+    );
   }
-  if (isTruthyEnv("ELIZAOS_LIVE_EMBEDDING_FALLBACK")) {
-    return false;
-  }
-`,
-  );
-  content = content.replace(
-    `function shouldWarmupLocalEmbeddingModel() {
-  if (isLocalEmbeddingDisabledByEnv()) {
-    return false;
-  }
-`,
-    `function shouldWarmupLocalEmbeddingModel() {
-  if (isLocalEmbeddingDisabledByEnv()) {
-    return false;
-  }
-  if (isTruthyEnv("ELIZAOS_LIVE_EMBEDDING_FALLBACK")) {
-    return false;
-  }
-`,
-  );
   content = content.replace(
     `    const service = requireService(runtime, ModelType.TEXT_EMBEDDING);
     if (typeof service.embed !== "function") {


### PR DESCRIPTION
## Problem

The **Build elizaOS Linux ISO** workflow's heavy `Build ISO` stage (5th layer, unreachable for 10+ days behind the arch-gate/branding/setup-bun fixes in #15223/#15226/#15232) failed on **both amd64 and arm64** in verification run [28842782391](https://github.com/elizaOS/eliza/actions/runs/28842782391):

```
Error: .../@elizaos/plugin-local-inference/src/runtime/embedding-warmup-policy.ts: local inference embedding fallback patch did not apply
error: Recipe `elizaos-app` failed with exit code 1
```

`just elizaos-app` runs `prepare-elizaos-app-overlay.mjs`, whose `localInferenceFallbackWrites()` injects an `ELIZAOS_LIVE_EMBEDDING_FALLBACK` short-circuit into `shouldWarmupLocalEmbeddingModel`. It anchored on the function's **entire leading check sequence**. Upstream added a new `ELIZA_SKIP_LOCAL_EMBEDDING_WARMUP` check as the *first* statement, so every anchor missed:

- **source `.ts`** (`embedding-warmup-policy.ts`) has no `requireService`, so the signature replace was its only injection path -> **hard throw** (the CI failure).
- **compiled `dist/*.js`** (both dist anchors) missed too; those bundles happened to still contain the string via the `requireService` helper injection, so they didn't throw — but the warmup short-circuit was **silently dropped** (latent correctness bug: the packaged Live runtime wouldn't honor the flag).

## Fix

Anchor on the **function signature alone** (order-independent) for both the source and the compiled shapes, mirroring how the two patches must stay in sync. `isTruthyEnv` is bundled alongside the function in every shape, so the injected body resolves.

## Validation

Root-caused from both jobs' logs (identical failure per arch). Replayed the real `patchLocalInferenceFallback` against the actual on-disk source file and the `bun build` output of the (import-free) warmup module:

| target | flag present | short-circuit injected |
| --- | --- | --- |
| source `embedding-warmup-policy.ts` | ✅ | ✅ |
| compiled warmup (dist shape) | ✅ | ✅ |
| `provider.ts` (source, sibling in array) | ✅ | n/a (helper path) |

Re-application is idempotent (guarded by the top-of-function `includes` check — matters because the ISO build runs a `--check` verification pass). `node --check` passes. Full ~1.5h ISO assembly is re-dispatched on `develop` after merge; the specific failing step is validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)