### PR TITLE
fix(ci): make the vacuous-green floor shard-aware (Plugin Tests shards 1-4)

### DIFF
--- a/packages/scripts/run-all-tests.mjs
+++ b/packages/scripts/run-all-tests.mjs
@@ -1130,6 +1130,12 @@ let started = startAt.length === 0;
 // subset through a worker pool instead of the historical strictly-serial loop.
 const tasks = [];
 const skippedPlanEntries = [];
+// Count of real, runnable tasks the lane's filters matched across the WHOLE
+// lane — before TEST_SHARD carves out this shard's slice. The vacuous-green
+// floor is a lane-level property ("did a filter/glob collapse the lane?"), so
+// it must be measured here and not against `tasks.length`, which only holds
+// this shard's ~1/M share once sharding is active.
+let laneMatchedTaskCount = 0;
 
 for (const packageJsonPath of packageJsonPaths) {
   const cwd = path.dirname(packageJsonPath);
@@ -1174,25 +1180,35 @@ for (const packageJsonPath of packageJsonPaths) {
     if (scriptFilter && !scriptFilter.test(scriptName)) {
       continue;
     }
-    // Shard filtering: deterministic by relative package dir hash. Keeps a
-    // package's `test` + `test:e2e` tasks colocated in the same shard.
-    if (!taskBelongsToShard(relativeDir, shardConfig)) {
+    const belongsToShard = taskBelongsToShard(relativeDir, shardConfig);
+    if (shouldSkipEmptyVitestScript(cwd, scriptName, scripts)) {
+      // Scope the skip log/plan entry to this shard so per-shard output stays
+      // readable; the empty-script check itself runs for every task because it
+      // decides what counts as real lane work below.
+      if (belongsToShard) {
+        if (planEnabled) {
+          skippedPlanEntries.push({
+            label,
+            packageName,
+            relativeDir,
+            scriptName,
+            reason: "no local test files for vitest script",
+          });
+        } else {
+          console.log(
+            `[eliza-test] SKIP ${label} (no local test files for vitest script)`,
+          );
+        }
+      }
       continue;
     }
-    if (shouldSkipEmptyVitestScript(cwd, scriptName, scripts)) {
-      if (planEnabled) {
-        skippedPlanEntries.push({
-          label,
-          packageName,
-          relativeDir,
-          scriptName,
-          reason: "no local test files for vitest script",
-        });
-      } else {
-        console.log(
-          `[eliza-test] SKIP ${label} (no local test files for vitest script)`,
-        );
-      }
+
+    // Real runnable task for the lane. Count it before sharding narrows the set.
+    laneMatchedTaskCount += 1;
+
+    // Shard filtering: deterministic by relative package dir hash. Keeps a
+    // package's `test` + `test:e2e` tasks colocated in the same shard.
+    if (!belongsToShard) {
       continue;
     }
 
@@ -1204,10 +1220,23 @@ const laneEnv = buildLaneEnv();
 
 // Collection-time vacuous-green floor. Evaluated before any task runs so a lane
 // that matched nothing fails immediately instead of "passing" with no work.
-if (minTasks > 0 && tasks.length < minTasks) {
+// The floor is measured against the lane-wide matched total, not this shard's
+// slice: TEST_SHARD intentionally splits a healthy lane into M parts, so a
+// shard legitimately owning 1/M of the work is not a collapsed glob. When
+// sharded we still fail an empty shard, which signals broken shard math rather
+// than an intentional split.
+if (minTasks > 0 && laneMatchedTaskCount < minTasks) {
   console.error(
-    `[eliza-test] VACUOUS-GREEN GUARD collected ${tasks.length} task(s) < required ${minTasks}. ` +
-      "A filter/shard/glob collapsed this lane to (near-)zero work. Failing loudly instead of reporting green.",
+    `[eliza-test] VACUOUS-GREEN GUARD lane matched ${laneMatchedTaskCount} task(s) < required ${minTasks}` +
+      (shardConfig ? ` (this shard: ${tasks.length})` : "") +
+      ". A filter/shard/glob collapsed this lane to (near-)zero work. Failing loudly instead of reporting green.",
+  );
+  process.exit(3);
+}
+if (minTasks > 0 && shardConfig && tasks.length === 0) {
+  console.error(
+    `[eliza-test] VACUOUS-GREEN GUARD shard ${TEST_SHARD} collected 0 of ${laneMatchedTaskCount} lane task(s). ` +
+      "The shard split assigned this shard no work. Failing loudly instead of reporting green.",
   );
   process.exit(3);
 }


### PR DESCRIPTION
## Problem

All four **Plugin Tests (N/4)** shards and the **Plugin Tests** aggregator fail on `develop` — the first develop run since the four-way `TEST_SHARD` matrix landed in #14459. Every shard exits `3` at test-collection time:

```
[eliza-test] VACUOUS-GREEN GUARD collected 43 task(s) < required 100 ...
[eliza-test] VACUOUS-GREEN GUARD collected 37 task(s) < required 100 ...
[eliza-test] VACUOUS-GREEN GUARD collected 23 task(s) < required 100 ...
[eliza-test] VACUOUS-GREEN GUARD collected 38 task(s) < required 100 ...
```

## Root cause

`test:plugins` runs `run-all-tests.mjs ... --min-tasks=100` under `strategy.matrix.shard: [1,2,3,4]` with `TEST_SHARD=<n>/4`. Both the `--min-tasks=100` floor **and** the 4-shard matrix were introduced in the same commit (#14459), but the floor was evaluated against each shard's *post-shard* slice (`tasks.length`), while `100` is a **whole-lane** floor. The plugin lane matches **141** test tasks total; sharded 4 ways it splits `43 / 37 / 23 / 38` — so every shard is below 100 and trips the guard. The guard fires at collection time, so **no plugin test ever runs**.

## Fix

Measure the vacuous-green floor against the **lane-wide matched total** (counted before `TEST_SHARD` narrows the set) rather than this shard's slice. Sharding is an intentional split of a healthy lane, not a collapsed glob.

- Real collapse (a filter/glob matching nothing) still fails — the lane total is `0`.
- An empty shard still fails via a dedicated check, catching broken shard math.
- Unsharded lanes are byte-for-byte unaffected: `laneMatchedTaskCount === tasks.length` when no shard is active.

## Validation

Reproduced and verified via `--plan` mode (guard runs at collection time, before any task):

| case | before | after |
|---|---|---|
| shard 1/4, `--min-tasks=100` | exit 3 (43<100) | exit 0 (lane 141) |
| shard 2/4, `--min-tasks=100` | exit 3 (37<100) | exit 0 |
| shard 3/4, `--min-tasks=100` | exit 3 (23<100) | exit 0 |
| shard 4/4, `--min-tasks=100` | exit 3 (38<100) | exit 0 |
| bogus filter (matches 0), `--min-tasks=100` | exit 3 | **exit 3** (lane matched 0) |
| empty shard `1/500`, `--min-tasks=100` | — | **exit 3** (0 of 141) |
| unsharded, `--min-tasks=200` (141<200) | exit 3 | **exit 3** (unchanged) |

`biome lint` clean (no new diagnostics), `error-policy-ratchet` clean on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)