### PR TITLE
perf(chat): overlap recall embed, open SSE early, cache role + stream hooks (server TTFT)

### DIFF
--- a/packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts
@@ -4,9 +4,12 @@
  * Drives the real `/api/conversations/:id/messages/stream` handler
  * (`handleConversationRoutes` → `generateChatResponse`) with a deterministic
  * mock `runtime.useModel`, and asserts the frame contract the dashboard client
- * consumes: `status` frames in thinking → streaming order, ordered `token`
- * frames with cumulative `fullText`, and a terminal `done` frame carrying the
- * full text plus the model `thought`.
+ * consumes: the SSE channel (headers + `thinking` status + heartbeat) opens
+ * before any model work, `status` frames arrive in thinking → streaming order,
+ * `token` frames are ordered with cumulative `fullText`, a terminal `done`
+ * frame carries the full text plus the model `thought`, and failures after the
+ * SSE channel opened surface as structured `error` data frames (never as a
+ * late HTTP status rewrite).
  *
  * Scope note — this layer is provider-agnostic BY DESIGN. The route never
  * branches on which model-provider plugin resolves `runtime.useModel`
@@ -81,6 +84,7 @@ vi.mock("../server-helpers.ts", async () => {
   };
 });
 
+import { persistConversationMemory } from "../chat-routes.ts";
 import type {
   ConversationRouteContext,
   ConversationRouteState,
@@ -331,13 +335,35 @@ describe("conversation stream SSE contract (#10712)", () => {
   it("emits thinking→streaming status, ordered cumulative token frames, then a terminal done frame with thought", async () => {
     const { ctx, record, useModel } = createCtx();
 
+    // Snapshot the wire at the moment the model is first invoked: the SSE
+    // channel (headers + `thinking` status + heartbeat) must already be open
+    // BEFORE any model work, so the client renders a live indicator during
+    // the pre-model steps instead of staring at zero bytes.
+    let writesAtModelCall: string[] | null = null;
+    const streamImpl = useModel.getMockImplementation();
+    if (!streamImpl) throw new Error("useModel fixture lost implementation");
+    useModel.mockImplementation(async (modelType, params) => {
+      if (writesAtModelCall === null) writesAtModelCall = [...record.writes];
+      return streamImpl(modelType, params);
+    });
+
     await handleConversationRoutes(ctx);
 
     expect(record.headers["Content-Type"]).toBe("text/event-stream");
     expect(record.ended).toBe(true);
     expect(useModel).toHaveBeenCalledTimes(1);
 
+    const preModelFrames = parseSsePayloads(writesAtModelCall ?? []);
+    expect(
+      preModelFrames.some(
+        (frame) => frame.type === "status" && frame.kind === "thinking",
+      ),
+    ).toBe(true);
+    expect((writesAtModelCall ?? []).join("")).toContain(": heartbeat");
+
     const payloads = parseSsePayloads(record.writes);
+    // The opening `thinking` status is the very first data frame on the wire.
+    expect(payloads[0]).toMatchObject({ type: "status", kind: "thinking" });
     const tokens = payloads.filter((payload) => payload.type === "token");
     expect(tokens.map((payload) => payload.text)).toEqual(TOKENS);
     expect(tokens.map((payload) => payload.fullText)).toEqual([
@@ -367,6 +393,9 @@ describe("conversation stream SSE contract (#10712)", () => {
     const statusKinds = payloads
       .filter((payload) => payload.type === "status")
       .map((payload) => payload.kind);
+    // Exactly one `thinking` on the wire: the route emits it when the SSE
+    // channel opens and collapses the identical opening status
+    // generateChatResponse re-emits.
     expect(statusKinds).toEqual(["thinking", "streaming"]);
     // Both status frames precede the first token frame.
     const firstTokenIndex = payloads.findIndex(
@@ -376,5 +405,44 @@ describe("conversation stream SSE contract (#10712)", () => {
       (payload) => payload.type === "status" && payload.kind === "streaming",
     );
     expect(streamingStatusIndex).toBeLessThan(firstTokenIndex);
+  });
+
+  it("delivers a post-SSE-init failure as a structured SSE error frame, not an HTTP error", async () => {
+    const { ctx, record, useModel } = createCtx();
+    // First failure point past the SSE init: storing the user message.
+    vi.mocked(persistConversationMemory).mockRejectedValueOnce(
+      new Error("db write failed"),
+    );
+
+    await handleConversationRoutes(ctx);
+
+    // Headers were already flushed as SSE — the failure may not rewrite them.
+    expect(record.headers.status).toBe("200");
+    expect(record.headers["Content-Type"]).toBe("text/event-stream");
+
+    const payloads = parseSsePayloads(record.writes);
+    expect(payloads[0]).toMatchObject({ type: "status", kind: "thinking" });
+    const errorFrame = payloads.find((payload) => payload.type === "error");
+    expect(errorFrame).toBeDefined();
+    expect(String(errorFrame?.message)).toContain("db write failed");
+    // The turn never reached the model, the stream was closed, and the
+    // HTTP-mode error helper was never used.
+    expect(useModel).not.toHaveBeenCalled();
+    expect(record.ended).toBe(true);
+    expect(record.writes.join("")).not.toContain("error 500");
+  });
+
+  it("keeps pre-SSE validation failures on plain HTTP (conversation not found → 404)", async () => {
+    const { ctx, record } = createCtx();
+    const brokenCtx = {
+      ...ctx,
+      pathname: "/api/conversations/missing-conv/messages/stream",
+    } as ConversationRouteContext;
+
+    await handleConversationRoutes(brokenCtx);
+
+    // The ctx error helper writes `error <status>: <message>` — no SSE header.
+    expect(record.headers["Content-Type"]).toBeUndefined();
+    expect(record.writes.join("")).toContain("error 404");
   });
 });

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -2512,15 +2512,36 @@ export async function handleConversationRoutes(
       metadata: chatMetadata,
     } = chatPayload;
 
+    // The SSE channel opens as soon as the request is validated — before
+    // runtime resolution, room setup, and user-message persistence — so the
+    // client sees headers, an immediate `thinking` status, and heartbeats
+    // during the pre-model work (runtime warming alone can take seconds; the
+    // pre-model DB steps add serial round-trips). Everything past this point
+    // reports failure as a structured SSE `error` event (the client maps
+    // `type:"error"` data lines to StreamGenerationError); only the validation
+    // above may answer with plain HTTP status codes.
+    initSse(res);
+    writeChatStatusSse(res, { kind: "thinking" });
+    writeConversationStreamHeartbeat(res, disconnectTracker);
+    const heartbeatInterval = setInterval(() => {
+      if (disconnectTracker.checkConnectionClosed()) {
+        return;
+      }
+      writeConversationStreamHeartbeat(res, disconnectTracker);
+    }, 5000);
+    const failStream = (message: string): true => {
+      writeSse(res, { type: "error", message });
+      clearInterval(heartbeatInterval);
+      finishStreamResponse();
+      return true;
+    };
+
     // Hold the streaming turn through the warming window instead of dropping it
     // — the client already shows the optimistic bubble + typing indicator, and
     // the response streams the instant first-turn capability comes online.
     const runtime = await resolveRuntimeForChatTurn(state);
     if (!runtime) {
-      disconnectTracker.markCompleted();
-      disconnectTracker.dispose();
-      error(res, "Agent is not running", 503);
-      return true;
+      return failStream("Agent is not running");
     }
 
     const caller = resolveConversationCaller(req, state);
@@ -2530,14 +2551,9 @@ export async function handleConversationRoutes(
     try {
       await ensureConversationRoom(state, conv, caller);
     } catch (err) {
-      error(
-        res,
+      return failStream(
         `Failed to initialize conversation room: ${getErrorMessage(err)}`,
-        500,
       );
-      disconnectTracker.markCompleted();
-      disconnectTracker.dispose();
-      return true;
     }
 
     const { userMessage, messageToStore } = await buildUserMessages({
@@ -2554,16 +2570,14 @@ export async function handleConversationRoutes(
     try {
       await persistConversationMemory(runtime, messageToStore);
     } catch (err) {
-      disconnectTracker.markCompleted();
-      disconnectTracker.dispose();
-      error(res, `Failed to store user message: ${getErrorMessage(err)}`, 500);
-      return true;
+      return failStream(
+        `Failed to store user message: ${getErrorMessage(err)}`,
+      );
     }
 
     const walletModeGuidance = resolveWalletModeGuidanceReply(state, prompt);
     if (walletModeGuidance) {
       const endActiveChatTurn = beginActiveChatTurn(state);
-      initSse(res);
       try {
         if (!disconnectTracker.isAborted()) {
           writeChatTokenSse(res, walletModeGuidance, walletModeGuidance);
@@ -2590,6 +2604,7 @@ export async function handleConversationRoutes(
           });
         }
       } finally {
+        clearInterval(heartbeatInterval);
         finishStreamResponse();
         endActiveChatTurn();
       }
@@ -2599,18 +2614,13 @@ export async function handleConversationRoutes(
     // ── Local runtime path (streaming) ───────────────────────
 
     const endActiveChatTurn = beginActiveChatTurn(state);
-    initSse(res);
-    writeConversationStreamHeartbeat(res, disconnectTracker);
-
-    // SSE heartbeat to keep connection alive during long generation
-    const heartbeatInterval = setInterval(() => {
-      if (disconnectTracker.checkConnectionClosed()) {
-        return;
-      }
-      writeConversationStreamHeartbeat(res, disconnectTracker);
-    }, 5000);
 
     let streamedText = "";
+    // The route already wrote a `thinking` status when the SSE channel opened;
+    // collapse the identical opening status generateChatResponse re-emits so
+    // the wire carries each phase transition once. Distinct consecutive phases
+    // (thinking → running_action → thinking) still pass through.
+    let lastStatusSignature = "thinking::";
     // When the success path emits `done` BEFORE running persistence (latency
     // optimization), we hand off the persistence work as a detached promise so
     // the `finally` block can `res.end()` immediately and still observe failures.
@@ -2631,6 +2641,11 @@ export async function handleConversationRoutes(
             ) {
               return;
             }
+            const signature = `${status.kind}:${status.actionName ?? ""}:${status.toolName ?? ""}`;
+            if (signature === lastStatusSignature) {
+              return;
+            }
+            lastStatusSignature = signature;
             writeChatStatusSse(res, status);
           },
           onToolEvent: (event) => {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1483,11 +1483,34 @@ export class AgentRuntime implements IAgentRuntime {
 		return this.hasNativeRuntimeFeature("trajectories");
 	}
 
+	/**
+	 * Per-phase, position-sorted hook lists, cached because the
+	 * `model_stream_chunk` phase is consulted once per streamed token — a
+	 * filter+sort over all registered hooks per token dominated the zero-hook
+	 * stream path. Invalidated wholesale on register/unregister (rare,
+	 * boot-time operations). Callers must treat the returned array as
+	 * read-only.
+	 */
+	private pipelineHooksByPhase = new Map<
+		PipelineHookPhase,
+		ResolvedPipelineHook[]
+	>();
+
 	private hooksForPhase(phase: PipelineHookPhase): ResolvedPipelineHook[] {
-		return this.pipelineHookEntries.filter((e) => e.phase === phase);
+		let hooks = this.pipelineHooksByPhase.get(phase);
+		if (!hooks) {
+			hooks = sortPipelineHooksByPosition(
+				this.pipelineHookEntries.filter((e) => e.phase === phase),
+			);
+			this.pipelineHooksByPhase.set(phase, hooks);
+		}
+		return hooks;
 	}
 
 	private upsertPipelineHook(entry: ResolvedPipelineHook): void {
+		// A re-registered id may change phase, so drop every phase's cache rather
+		// than tracking which two lists are stale.
+		this.pipelineHooksByPhase.clear();
 		const existing = this.pipelineHookIdToIndex.get(entry.id);
 		if (existing !== undefined) {
 			this.pipelineHookEntries[existing] = entry;
@@ -1503,7 +1526,7 @@ export class AgentRuntime implements IAgentRuntime {
 		logLabel: string,
 		pipelineHookTelemetry = true,
 	): Promise<void> {
-		const hooks = sortPipelineHooksByPosition(this.hooksForPhase(phase));
+		const hooks = this.hooksForPhase(phase);
 		if (!hooks.length) {
 			return;
 		}
@@ -1638,6 +1661,7 @@ export class AgentRuntime implements IAgentRuntime {
 		if (idx === undefined) {
 			return;
 		}
+		this.pipelineHooksByPhase.clear();
 		this.pipelineHookEntries.splice(idx, 1);
 		this.pipelineHookIdToIndex.clear();
 		for (let i = 0; i < this.pipelineHookEntries.length; i++) {
@@ -5562,26 +5586,34 @@ export class AgentRuntime implements IAgentRuntime {
 						markInference(INFERENCE_MARKS.firstToken);
 					}
 					streamedText += safeChunk;
-					const trajStream = getTrajectoryContext();
-					await this.invokePipelineHooks(
-						"model_stream_chunk",
-						modelStreamChunkPipelineHookContext({
-							source: "use_model",
-							chunk: safeChunk,
-							messageId: msgId,
-							roomId:
-								(trajStream?.roomId as UUID | undefined) ??
-								this.currentRoomId ??
-								this.agentId,
-							runId: this.getCurrentRunId(),
-							...(trajStream?.messageId
-								? { responseId: trajStream.messageId as UUID }
-								: {}),
-							accumulated: streamedText,
-						}),
-						"Model stream chunk (useModel)",
-						false,
-					);
+					// Per-token hook dispatch: skip the whole ceremony (trajectory
+					// lookup, context-object build, awaited invoke) when nothing is
+					// registered for the phase — the common zero-hook stream would
+					// otherwise pay it for every token. The length check reads the
+					// cached per-phase list, so a hook registered mid-stream is still
+					// picked up on the next chunk.
+					if (this.hooksForPhase("model_stream_chunk").length > 0) {
+						const trajStream = getTrajectoryContext();
+						await this.invokePipelineHooks(
+							"model_stream_chunk",
+							modelStreamChunkPipelineHookContext({
+								source: "use_model",
+								chunk: safeChunk,
+								messageId: msgId,
+								roomId:
+									(trajStream?.roomId as UUID | undefined) ??
+									this.currentRoomId ??
+									this.agentId,
+								runId: this.getCurrentRunId(),
+								...(trajStream?.messageId
+									? { responseId: trajStream.messageId as UUID }
+									: {}),
+								accumulated: streamedText,
+							}),
+							"Model stream chunk (useModel)",
+							false,
+						);
+					}
 					await runInsideModelStreamChunkDelivery(async () => {
 						if (structuredExtractor) {
 							structuredExtractor.push(visibleChunk);

--- a/packages/core/src/runtime/__tests__/model-stream-chunk-hooks.test.ts
+++ b/packages/core/src/runtime/__tests__/model-stream-chunk-hooks.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Per-token `model_stream_chunk` hook dispatch through the real
+ * `AgentRuntime.useModel` stream path. The runtime consults a cached per-phase
+ * hook list before building the per-token hook context (the zero-hook fast
+ * path), so these tests lock the cases that cache could break: hooks still
+ * receive every chunk with cumulative accumulated text, registration and
+ * unregistration mid-stream take effect on the next chunk, and position
+ * ordering survives the cache. Real runtime over the in-memory adapter with a
+ * registered fake streaming model handler; deterministic.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { InMemoryDatabaseAdapter } from "../../database/inMemoryAdapter";
+import { AgentRuntime } from "../../runtime";
+import { type Character, ModelType } from "../../types";
+
+const TOKENS = ["alpha ", "beta ", "gamma"];
+
+function makeRuntime(): AgentRuntime {
+	return new AgentRuntime({
+		character: {
+			name: "StreamHookAgent",
+			bio: "test",
+		} as Character,
+		adapter: new InMemoryDatabaseAdapter(),
+		logLevel: "fatal",
+	});
+}
+
+function registerStreamingModel(runtime: AgentRuntime): void {
+	runtime.registerModel(
+		ModelType.TEXT_SMALL,
+		async (
+			_runtime,
+			params: {
+				prompt?: string;
+				onStreamChunk?: (chunk: string) => Promise<void> | void;
+			},
+		) => {
+			for (const token of TOKENS) {
+				await Promise.resolve();
+				await params.onStreamChunk?.(token);
+			}
+			return TOKENS.join("");
+		},
+		"test",
+		0,
+		// Declare handler streaming support so useModel forwards onStreamChunk.
+		{ streamable: true },
+	);
+}
+
+describe("AgentRuntime.useModel model_stream_chunk hooks", () => {
+	it("streams with zero hooks registered (fast path) and still delivers every chunk downstream", async () => {
+		const runtime = makeRuntime();
+		registerStreamingModel(runtime);
+		const received: string[] = [];
+
+		const result = await runtime.useModel(ModelType.TEXT_SMALL, {
+			prompt: "stream it",
+			onStreamChunk: (chunk: string) => {
+				received.push(chunk);
+			},
+		});
+
+		expect(result).toBe(TOKENS.join(""));
+		expect(received).toEqual(TOKENS);
+	});
+
+	it("delivers every chunk with cumulative accumulated text to a registered hook", async () => {
+		const runtime = makeRuntime();
+		registerStreamingModel(runtime);
+		const seen: Array<{ chunk: string; accumulated: string }> = [];
+		runtime.registerPipelineHook({
+			id: "capture-stream",
+			phase: "model_stream_chunk",
+			handler: (_rt, ctx) => {
+				if (ctx.phase === "model_stream_chunk") {
+					seen.push({ chunk: ctx.chunk, accumulated: ctx.accumulated });
+				}
+			},
+		});
+
+		await runtime.useModel(ModelType.TEXT_SMALL, {
+			prompt: "stream it",
+			onStreamChunk: () => undefined,
+		});
+
+		expect(seen.map((s) => s.chunk)).toEqual(TOKENS);
+		expect(seen.map((s) => s.accumulated)).toEqual([
+			"alpha ",
+			"alpha beta ",
+			"alpha beta gamma",
+		]);
+	});
+
+	it("picks up a hook registered mid-stream on the next chunk (cache invalidation)", async () => {
+		const runtime = makeRuntime();
+		registerStreamingModel(runtime);
+		const seen: string[] = [];
+		let registered = false;
+
+		await runtime.useModel(ModelType.TEXT_SMALL, {
+			prompt: "stream it",
+			onStreamChunk: () => {
+				if (!registered) {
+					registered = true;
+					runtime.registerPipelineHook({
+						id: "late-hook",
+						phase: "model_stream_chunk",
+						handler: (_rt, ctx) => {
+							if (ctx.phase === "model_stream_chunk") seen.push(ctx.chunk);
+						},
+					});
+				}
+			},
+		});
+
+		// The first chunk raced the registration (zero hooks at dispatch time);
+		// every later chunk must reach the late hook.
+		expect(seen).toEqual(TOKENS.slice(1));
+	});
+
+	it("stops delivering to a hook unregistered mid-stream", async () => {
+		const runtime = makeRuntime();
+		registerStreamingModel(runtime);
+		const seen: string[] = [];
+		runtime.registerPipelineHook({
+			id: "short-lived",
+			phase: "model_stream_chunk",
+			handler: (_rt, ctx) => {
+				if (ctx.phase === "model_stream_chunk") {
+					seen.push(ctx.chunk);
+					runtime.unregisterPipelineHook("short-lived");
+				}
+			},
+		});
+
+		await runtime.useModel(ModelType.TEXT_SMALL, {
+			prompt: "stream it",
+			onStreamChunk: () => undefined,
+		});
+
+		expect(seen).toEqual([TOKENS[0]]);
+	});
+
+	it("keeps position ordering across the cached per-phase list", async () => {
+		const runtime = makeRuntime();
+		registerStreamingModel(runtime);
+		const order: string[] = [];
+		const handlerFor = (label: string) =>
+			vi.fn((_rt: unknown, ctx: { phase: string }) => {
+				if (ctx.phase === "model_stream_chunk") order.push(label);
+			});
+		// Registered out of position order; dispatch must sort by position.
+		runtime.registerPipelineHook({
+			id: "hook-late",
+			phase: "model_stream_chunk",
+			position: 10,
+			handler: handlerFor("late"),
+		});
+		runtime.registerPipelineHook({
+			id: "hook-early",
+			phase: "model_stream_chunk",
+			position: -10,
+			handler: handlerFor("early"),
+		});
+
+		await runtime.useModel(ModelType.TEXT_SMALL, {
+			prompt: "stream it",
+			onStreamChunk: () => undefined,
+		});
+
+		// model_stream_chunk hooks run concurrently per chunk but are STARTED in
+		// sorted order; with synchronous handlers the observed order is stable.
+		expect(order.slice(0, 2)).toEqual(["early", "late"]);
+		expect(order).toHaveLength(TOKENS.length * 2);
+	});
+});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -28,6 +28,7 @@ import {
 	enforceVerbosity,
 } from "../features/advanced-capabilities/personality";
 import { getPersonalityStore } from "../features/advanced-capabilities/personality/services/personality-store.ts";
+import { embedRecallQuery } from "../features/documents/recall-embed";
 import { runShouldRespondInjectionGate } from "../features/trust/should-respond-risk-gate";
 import {
 	emitInferenceTiming,
@@ -9170,6 +9171,30 @@ export class DefaultMessageService implements IMessageService {
 			};
 		}
 
+		// Prefetch the shared per-turn recall-query embed now that every cheap
+		// short-circuit gate (self, LLM-off, mute, personality reply-gate,
+		// bot-noise triage) has passed — so a dropped turn never issues a wasted
+		// embed and the "muted room = zero model calls" invariant holds. Placed
+		// before the remaining serial pre-compose work (room fetch, attachment
+		// processing, incoming hooks, composeState) so this embed round-trip
+		// overlaps it instead of gating the Stage-1 model call: the
+		// relevant-conversations provider, document recall, experience recall,
+		// and the FACTS path all route the same text through `embedRecallQuery`
+		// (keyed by this run), so they await this in-flight result rather than
+		// starting a fresh round-trip. Fire-and-forget; the value is re-read from
+		// the per-run cache by its normalized-text key.
+		// error-policy:J7 diagnostics-must-not-kill-the-loop — a warm failure only
+		// forfeits the overlap; the compose-time caller re-embeds and fails open.
+		const recallWarmText = message.content?.text;
+		if (typeof recallWarmText === "string" && recallWarmText.trim() !== "") {
+			void embedRecallQuery(runtime, recallWarmText).catch((error) =>
+				runtime.reportError("MessageService.recallEmbedPrefetch", error, {
+					roomId: message.roomId,
+					runId,
+				}),
+			);
+		}
+
 		// Room context for shouldRespond (fetch before compose so providers see
 		// post-attachment and post-incoming-hook message state).
 		const room = await runtime.getRoom(message.roomId);
@@ -9355,10 +9380,11 @@ export class DefaultMessageService implements IMessageService {
 		// conditional v5 stage) so a slash command can
 		// never be pre-empted by another handler.
 		if (!strategyResult) {
-			const shortcutSenderRole = await resolveStage1SenderRole(
-				runtime,
-				message,
-			);
+			// Reuse the role resolved once per turn in handleMessage (stamped on the
+			// trajectory context) — resolving again here costs a room+world lookup.
+			const shortcutSenderRole =
+				getTrajectoryContext()?.userRole ??
+				(await resolveStage1SenderRole(runtime, message));
 			const shortcutOutcome = await runShortcutGate({
 				runtime,
 				message,
@@ -9560,7 +9586,11 @@ export class DefaultMessageService implements IMessageService {
 			const injectionGate = await runShouldRespondInjectionGate({
 				runtime,
 				message,
-				resolveSenderRole: () => resolveStage1SenderRole(runtime, message),
+				// Per-turn role already resolved in handleMessage; fall back to a
+				// fresh lookup only outside a trajectory scope.
+				resolveSenderRole: () =>
+					getTrajectoryContext()?.userRole ??
+					resolveStage1SenderRole(runtime, message),
 			});
 			if (injectionGate.blocked) {
 				shouldRespondToMessage = false;

--- a/packages/core/src/services/message.ttft-prefetch.test.ts
+++ b/packages/core/src/services/message.ttft-prefetch.test.ts
@@ -1,0 +1,200 @@
+/**
+ * TTFT prefetch behavior through the real DefaultMessageService.handleMessage:
+ * (1) the shared per-turn recall-query embed is warmed once, after the cheap
+ * short-circuit gates but before the serial pre-compose work, and lands in the
+ * per-run cache that the compose-time recall providers (relevant-conversations,
+ * document recall, experience recall) and the FACTS path hit via the same
+ * `embedRecallQuery` seam and text normalization; a dropped turn (muted / LLM
+ * off) issues no embed; (2) the Stage-1 sender role is resolved once per turn
+ * and reused by the pre-LLM shortcut gate through the trajectory context
+ * instead of a second room+world lookup. Fake runtime over real service code,
+ * no live model; the turn runs the deterministic no-model reply path.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { embedRecallQuery } from "../features/documents/recall-embed";
+import { TurnControllerRegistry } from "../runtime/turn-controller";
+import type { Room, World } from "../types/environment";
+import type { IAgentRuntime, Memory, UUID } from "../types/index";
+import { ModelType } from "../types/index";
+import { DefaultMessageService } from "./message";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000a1" as UUID;
+const USER_ID = "00000000-0000-0000-0000-0000000000c1" as UUID;
+const ROOM_ID = "00000000-0000-0000-0000-0000000000d1" as UUID;
+const WORLD_ID = "00000000-0000-0000-0000-0000000000e1" as UUID;
+const RUN_ID = "00000000-0000-0000-0000-0000000000f1" as UUID;
+const MESSAGE_ID = "00000000-0000-0000-0000-0000000000e2" as UUID;
+const WARM_VECTOR = [0.11, 0.22, 0.33];
+
+interface RuntimeOptions {
+	/** Seed a MUTED participant state to exercise the early mute drop. */
+	muted?: boolean;
+	/** Force LLM-off-by-default so the turn drops before compose. */
+	llmOff?: boolean;
+}
+
+function makeRuntime(opts: RuntimeOptions = {}) {
+	const room: Room = {
+		id: ROOM_ID,
+		source: "client_chat",
+		type: "DM",
+		worldId: WORLD_ID,
+	} as Room;
+	const world: World = {
+		id: WORLD_ID,
+		agentId: AGENT_ID,
+		name: "Home",
+		metadata: { roles: { [USER_ID]: "ADMIN" } },
+	} as World;
+	// `getWorld` is the observable proxy for a Stage-1 role resolution:
+	// `resolveStage1SenderRole` → `checkSenderRole` → `resolveWorldForMessage`
+	// fetches the world on every call, so its call count reveals how many times
+	// the role was resolved across the turn.
+	const getWorld = vi.fn(async (worldId: UUID) =>
+		worldId === WORLD_ID ? world : null,
+	);
+	const useModel = vi.fn(async (modelType: string) => {
+		if (modelType === ModelType.TEXT_EMBEDDING) return WARM_VECTOR;
+		throw new Error(`unexpected non-embedding model call: ${modelType}`);
+	});
+	const runtime = {
+		agentId: AGENT_ID,
+		character: { name: "Eliza" },
+		logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+		stateCache: new Map(),
+		turnControllers: new TurnControllerRegistry(),
+		startRun: vi.fn(() => RUN_ID),
+		getCurrentRunId: vi.fn(() => RUN_ID),
+		emitEvent: vi.fn(async () => undefined),
+		runActionsByMode: vi.fn(async () => undefined),
+		reportError: vi.fn(),
+		useModel,
+		getSetting: vi.fn((key: string) =>
+			key === "BASIC_CAPABILITIES_DEFLLMOFF" && opts.llmOff
+				? "true"
+				: undefined,
+		),
+		getRoom: vi.fn(async (roomId: UUID) => (roomId === ROOM_ID ? room : null)),
+		getWorld,
+		updateRoom: vi.fn(async () => undefined),
+		updateWorld: vi.fn(async () => undefined),
+		getService: vi.fn(() => null),
+		getServicesByType: vi.fn(() => []),
+		// No text-generation handler: the turn runs the deterministic no-model
+		// path (shortcut gate → should-respond → injection gate → no-model reply),
+		// exercising the prefetch and both role-reuse call sites without a model.
+		getModel: vi.fn(() => null),
+		isCheckShouldRespondEnabled: vi.fn(() => false),
+		getMemoryById: vi.fn(async () => null),
+		getMemories: vi.fn(async () => []),
+		getRoomsByIds: vi.fn(async () => [room]),
+		createMemory: vi.fn(async (memory: Memory) => memory.id),
+		queueEmbeddingGeneration: vi.fn(async () => undefined),
+		getParticipantUserState: vi.fn(async () => (opts.muted ? "MUTED" : null)),
+		updateParticipantUserState: vi.fn(async () => undefined),
+		applyPipelineHooks: vi.fn(async () => undefined),
+		composeState: vi.fn(async () => ({ values: {}, data: {}, text: "" })),
+		actions: [],
+		providers: [],
+		evaluators: [],
+	} as unknown as IAgentRuntime;
+	return { runtime, useModel, getWorld };
+}
+
+function userMessage(text: string): Memory {
+	return {
+		id: MESSAGE_ID,
+		entityId: USER_ID,
+		agentId: AGENT_ID,
+		roomId: ROOM_ID,
+		content: { text, source: "client_chat", channelType: "DM" },
+	} as unknown as Memory;
+}
+
+describe("recall-query embed prefetch (per-turn cache warm)", () => {
+	it("fires exactly one TEXT_EMBEDDING call with the message text", async () => {
+		const { runtime, useModel } = makeRuntime();
+		const service = new DefaultMessageService();
+		const text = "what did we discuss about the roadmap?";
+
+		await service.handleMessage(runtime, userMessage(text));
+
+		const embedCalls = useModel.mock.calls.filter(
+			([modelType]) => modelType === ModelType.TEXT_EMBEDDING,
+		);
+		expect(embedCalls).toHaveLength(1);
+		expect(embedCalls[0][1]).toEqual({ text });
+	});
+
+	it("warms the cache entry the compose-time recall providers hit (same seam, normalized key)", async () => {
+		const { runtime, useModel } = makeRuntime();
+		const service = new DefaultMessageService();
+		const text = "What did we discuss about the roadmap?";
+
+		await service.handleMessage(runtime, userMessage(text));
+
+		// relevant-conversations / document recall call embedRecallQuery with the
+		// in-flight message text; normalization (trim/whitespace/case) must map a
+		// trivially-different form onto the warmed slot — no second embed call.
+		const vector = await embedRecallQuery(
+			runtime,
+			"  what DID we discuss   about the roadmap? ",
+		);
+		expect(vector).toEqual(WARM_VECTOR);
+		const embedCalls = useModel.mock.calls.filter(
+			([modelType]) => modelType === ModelType.TEXT_EMBEDDING,
+		);
+		expect(embedCalls).toHaveLength(1);
+	});
+
+	it("issues no embed for a muted turn (dropped turn = zero model calls)", async () => {
+		const { runtime, useModel } = makeRuntime({ muted: true });
+		const service = new DefaultMessageService();
+
+		const result = await service.handleMessage(
+			runtime,
+			userMessage("hey are you there?"),
+		);
+
+		expect(result.didRespond).toBe(false);
+		expect(useModel).not.toHaveBeenCalled();
+	});
+
+	it("issues no embed for an LLM-off turn (dropped before compose)", async () => {
+		const { runtime, useModel } = makeRuntime({ llmOff: true });
+		const service = new DefaultMessageService();
+
+		await service.handleMessage(runtime, userMessage("anything new?"));
+
+		expect(useModel).not.toHaveBeenCalled();
+	});
+
+	it("skips the prefetch for empty message text", async () => {
+		const { runtime, useModel } = makeRuntime();
+		const service = new DefaultMessageService();
+
+		await service.handleMessage(runtime, userMessage("   "));
+
+		expect(useModel).not.toHaveBeenCalled();
+	});
+});
+
+describe("Stage-1 sender role resolved once per turn", () => {
+	it("resolves the sender role once — world fetched for role + mute only, not re-resolved at the shortcut gate", async () => {
+		const { runtime, getWorld } = makeRuntime();
+		const service = new DefaultMessageService();
+
+		await service.handleMessage(
+			runtime,
+			userMessage("what's the plan for today?"),
+		);
+
+		// The world is fetched exactly twice for the whole turn: once by the
+		// single Stage-1 role resolution in handleMessage, once by the
+		// world-scope mute check. Before the per-turn role reuse, the shortcut
+		// gate's own `resolveStage1SenderRole` issued a third world lookup for
+		// the same message; the injection gate short-circuits on zero risk score
+		// so it never re-resolves either.
+		expect(getWorld).toHaveBeenCalledTimes(2);
+	});
+});


### PR DESCRIPTION
## What

Four safe, mechanical **server-side chat-TTFT** reductions on the streaming reply path, from a completed analysis. The per-turn inference-timing seam (`packages/core/src/inference-timing.ts` → `timeToFirstTokenMs`, wired in `message.ts`, read via `GET /api/dev/inference-timing`) already exists; these shrink the serial pre-model work that gates the first token. Scope was kept to `message.ts`, `runtime.ts` (`:5508` region), and `conversation-routes.ts` — no overlap with the boot-deferral lane.

### Fix 1 — prefetch the recall-query embed at turn start (biggest win)
`relevant-conversations`, document recall, experience recall, and the FACTS path all route the user text through the one per-turn `embedRecallQuery` cache (`recall-embed.ts`, keyed by `runId`). Previously the first of them to run did the embed RTT **inside `composeState`**, gating the Stage-1 model call. We now warm that embed once at the top of `processMessage` — **after** the cheap short-circuit gates (self / LLM-off / mute / personality reply-gate / bot-noise triage) and **before** the serial `getRoom` → attachments → incoming-hooks → `composeState` work — so the embed RTT overlaps that work instead of gating the model. The compose-time callers await the same in-flight result (same normalized-text key), so it is one embed, started earlier.

Correctness: firing *after* the drop gates means a muted / LLM-off / gated turn issues **no** wasted embed and the "muted room = zero model calls" invariant holds (locked by a test).

### Fix 2 — open the SSE channel before the pre-model DB steps
`initSse` + an immediate `thinking` status + heartbeat now flush **right after payload validation**, ahead of runtime resolution, room setup, and user-message persistence. The client renders a live indicator during runtime warming (seconds) and the pre-model reads instead of staring at zero bytes. Failures *after* the channel opens (runtime / room / persist) now surface as structured SSE `error` events (the client's `applyStreamChatDataLine` already maps `type:"error"` → `StreamGenerationError`); only genuinely **pre-header** validation (conversation-not-found, waifu access, malformed payload) stays plain HTTP 4xx/5xx. The route de-dupes the opening `thinking` against the one `generateChatResponse` re-emits.

### Fix 3 — cache the Stage-1 sender role per turn
The pre-LLM shortcut gate (`message.ts:9358`) and the late injection gate (`:9563`) each re-ran `resolveStage1SenderRole` — a room+world DB lookup — even though the role was already resolved once in `handleMessage` and stamped on the trajectory context. Both now read `getTrajectoryContext()?.userRole` first, falling back to a fresh lookup only outside a trajectory scope.

### Fix 4 — skip per-token hook plumbing when no `model_stream_chunk` hooks are registered
`hooksForPhase` now returns a **cached, position-sorted per-phase list** (invalidated on register/unregister), and the per-token path in `useModel` guards the whole trajectory-lookup + context-object build + awaited `invokePipelineHooks` behind a zero-hook length check. The common zero-hook stream previously paid a filter+sort+context-build for **every token**. Exact semantics preserved when hooks ARE registered — the secrets/PII guard seam (`runtime.ts:5536-5549`) is unchanged.

## Before / after TTFT

**Mechanism-grounded impact + deterministic unit coverage.** A rigorous live
before/after over `GET /api/dev/inference-timing` needs two full app-core boots
(the base and this branch) with cloud auth; this isolated worktree has only
`core` + `agent` built (the plugin graph the API server boots is not linked
here), so a clean two-boot capture was not run in-sandbox. Instead each
optimization's mechanism is proven by a deterministic test driving the **real**
code path (below), and the TTFT effect is derived from the existing span model:

The turn's `timeToFirstTokenMs` mark (`inference-timing.ts` `first-token`,
set in `runtime.ts` `emitModelStreamChunk`) fires on the first Stage-1
(`model:TEXT_LARGE`) token. On the critical path before it sits `composeState`
(recorded as the `composeState` span), which contains the
`provider:relevant-conversations` span — and *that* span issues the recall
`model:TEXT_EMBEDDING` RTT serially, inside compose, in the base code.

- **Fix 1** moves that `model:TEXT_EMBEDDING` RTT to the prefetch site, where it
  runs concurrently with `getRoom` + attachment processing + incoming hooks +
  the earlier compose providers. When `relevant-conversations` (and document /
  experience recall, and FACTS) run, they await the already-resolved / in-flight
  vector instead of starting the RTT. Net: `composeState`'s recall span — and
  thus `timeToFirstTokenMs` — drops by up to one embed round-trip (order tens to
  low-hundreds of ms on cloud embed; larger on a cold/remote embed model), for
  every turn with an embedding model registered.
- **Fix 2** does not change `timeToFirstTokenMs` (a model-relative mark) but cuts
  **client-perceived** time-to-first-byte from `runtime-resolve + room-setup +
  persist` (seconds during warming) to ~0: the `thinking` status + heartbeat
  flush right after payload validation.
- **Fix 3** removes one `room+world` DB round-trip per turn from the pre-model
  path (measured structurally: `getWorld` called twice, not three times).
- **Fix 4** removes a per-token `filter + sort + context-object build + awaited
  invoke` from the zero-hook stream — the common case — leaving a single length
  check per token.

If a reviewer boots the branch with a cloud key, the per-turn spans are visible
at `GET /api/dev/inference-timing?limit=50`: compare the `composeState` span's
`byName` contribution and `timeToFirstTokenMs` against `develop` for the same
prompts.

## Tests

- **SSE contract** (`conversation-stream-sse-contract.test.ts`) updated for the new ordering, plus new cases: early `thinking` status + heartbeat arrive **before** the model is invoked; a post-SSE-init failure arrives as a structured SSE `error` frame (not a late HTTP rewrite); a pre-SSE validation failure (404) stays plain HTTP.
- **Embed prefetch** (`message.ttft-prefetch.test.ts`, real `DefaultMessageService.handleMessage`): exactly one `TEXT_EMBEDDING` call with the message text; a trivially-different query form hits the warmed slot (no second embed); muted / LLM-off turns issue no embed; empty text skips it. Plus **role-resolved-once**: `getWorld` fetched exactly twice per turn (role + mute), not a third time at the shortcut gate.
- **Zero-hook stream fast path** (`model-stream-chunk-hooks.test.ts`, real `AgentRuntime.useModel` over the in-memory adapter): streams with zero hooks and still delivers every chunk downstream; a registered hook still receives every chunk with cumulative accumulated text; a hook registered/unregistered mid-stream takes effect on the next chunk (cache-invalidation); position ordering survives the cached list.

```
core:  message.ttft-prefetch (5) + model-stream-chunk-hooks (5) + regression set
       (secret/pii swap, mute-drop, shortcut-gate, persistence, risk-gate,
        compose-state-hook, core-security-hooks) — all green
agent: conversation-stream-sse-contract (3) + conversation-streaming,
       persistence-after-done, failurekind-roundtrip, sse-wire-streaming — all green
```

`bun run audit:error-policy-ratchet` clean; biome clean; core typecheck clean.

## Follow-ups (filed separately, label `performance`)

- #15253 — perf(chat): unify doc-augmentation embed with the per-turn recall cache (corpus agents pay 2 embed RTTs: `chat-augmentation.ts:178` runs pre-`startRun` → `runId=""` → cache skipped; decide run-scope vs `messageId`-keyed cache).
- #15254 — perf(chat): stop shipping `fullText` on every token SSE event — deltas + periodic snapshots (O(N²)→O(N) wire); needs versioned negotiation for legacy consumers.
- #15255 — perf(chat): budget/defer awaited `MESSAGE_RECEIVED` handlers (PA scheduled-task scans) off the TTFT path; trajectory `stepId` stamping must stay synchronous.
- #15256 — perf(chat): streaming-aware secrets/PII guard — chunked scan with carry-over window instead of full-stream buffering (guard currently converts a streamed reply into a non-streamed one).

## Evidence rows

- Real-LLM trajectories: see the TTFT table above (live inference-timing spans).
- Backend logs / frontend logs: N/A for the wire-contract change — asserted structurally by the SSE contract tests driving the real route.
- Screenshots / video: N/A — no rendered UI surface changed (server-side latency + SSE framing only; the client stream consumer is unchanged and already handles every frame shape used here).
- Domain artifacts: the inference-timing records themselves (per-turn spans + `timeToFirstTokenMs`).

