### PR TITLE
feat(permissioning): role-aware PII-scrubbed artifact views (#14781)

### DIFF
--- a/packages/agent/src/api/artifact-share-role-resolver.ts
+++ b/packages/agent/src/api/artifact-share-role-resolver.ts
@@ -1,0 +1,221 @@
+/**
+ * Boundary-role resolver for artifact share-viewer tokens (#14781) — the HTTP
+ * principal seam that lets a non-owner viewer reach the artifact read routes
+ * (transcripts / meetings / files) with a per-entity identity, so the
+ * use-case layer can select full vs redacted vs omitted DTO content per
+ * viewer. Follows the WaifuChat resolver precedent: this module owns its token
+ * vocabulary end to end and registers through the trunk's
+ * {@link TokenRoleResolver} seam; the trunk auth path holds no share-token
+ * literals.
+ *
+ * Token format: `esv1.<base64url payload>.<base64url HMAC-SHA256 signature>`
+ * with payload `{ entityId, role: "USER" | "GUEST", exp }` (exp in epoch
+ * seconds), keyed by `ELIZA_ARTIFACT_SHARE_TOKEN_SECRET`. The resolver is
+ * inert when the secret is unset — local single-owner installs keep exactly
+ * one boundary (the trunk API token). Minting lives here too
+ * ({@link issueArtifactShareViewerToken}) so tests and the future sharing UX
+ * (#14782) issue tokens through one code path; there is deliberately no
+ * mint ROUTE in this change — grant-management UX is out of scope for #14781.
+ *
+ * Viewer tokens are read-only capabilities: `isRouteInScope` allows only the
+ * GET artifact routes, so a leaked viewer token can never mutate or reach the
+ * broader API surface. Byte serving is untouched — `/api/media/<sha256>` stays
+ * pre-auth per the #8876 doctrine (the hash is the capability); these tokens
+ * gate DISCLOSURE of references, not bytes.
+ */
+import crypto from "node:crypto";
+import type http from "node:http";
+import { ElizaError, type UUID, validateUuid } from "@elizaos/core";
+import {
+  type BoundaryRoleAccess,
+  registerTokenRoleResolver,
+  type TokenRoleResolver,
+} from "./boundary-role-resolver.ts";
+import { extractAuthToken } from "./server-helpers-auth.ts";
+
+/** The artifact share resolver's stable registry id. */
+export const ARTIFACT_SHARE_RESOLVER_ID = "artifact-share-viewer";
+
+const TOKEN_PREFIX = "esv1";
+const SECRET_ENV = "ELIZA_ARTIFACT_SHARE_TOKEN_SECRET";
+
+/** Roles a share-viewer token may carry — never OWNER/ADMIN; elevated tiers use the trunk boundary. */
+export type ArtifactShareViewerRole = "USER" | "GUEST";
+
+/** Validated identity carried by one share-viewer token. */
+export interface ArtifactShareViewerAccess {
+  entityId: UUID;
+  role: ArtifactShareViewerRole;
+  /** Expiry, epoch seconds. */
+  exp: number;
+}
+
+function shareSecret(): string | undefined {
+  const secret = process.env[SECRET_ENV]?.trim();
+  return secret && secret.length > 0 ? secret : undefined;
+}
+
+function b64url(input: Buffer | string): string {
+  return Buffer.from(input).toString("base64url");
+}
+
+function hmac(payloadSegment: string, secret: string): Buffer {
+  return crypto
+    .createHmac("sha256", secret)
+    .update(`${TOKEN_PREFIX}.${payloadSegment}`)
+    .digest();
+}
+
+/**
+ * Mint a share-viewer token for one entity. Server-side only (tests, and the
+ * PERM-UX sharing journey once it lands). Throws when the signing secret is
+ * not configured — minting must fail fast rather than emit dead tokens.
+ */
+export function issueArtifactShareViewerToken(
+  input: {
+    entityId: UUID;
+    role: ArtifactShareViewerRole;
+    ttlMs: number;
+  },
+  nowMs = Date.now(),
+): string {
+  const secret = shareSecret();
+  if (!secret) {
+    throw new ElizaError(
+      `${SECRET_ENV} is not configured; cannot mint share-viewer tokens`,
+      { code: "ARTIFACT_SHARE_SECRET_UNSET" },
+    );
+  }
+  if (!validateUuid(input.entityId)) {
+    throw new ElizaError("share-viewer token entityId must be a UUID", {
+      code: "ARTIFACT_SHARE_INVALID_ENTITY",
+      context: { entityId: input.entityId },
+    });
+  }
+  const payload = {
+    entityId: input.entityId,
+    role: input.role,
+    exp: Math.floor((nowMs + input.ttlMs) / 1000),
+  };
+  const payloadSegment = b64url(JSON.stringify(payload));
+  const signature = b64url(hmac(payloadSegment, secret));
+  return `${TOKEN_PREFIX}.${payloadSegment}.${signature}`;
+}
+
+/**
+ * Parse + validate a share-viewer token: `null` when the secret is unset or
+ * the token is absent, malformed, mis-signed, expired, or carries an invalid
+ * entity/role. Never throws (resolver contract).
+ */
+export function resolveArtifactShareViewerToken(
+  token: string | null | undefined,
+  nowSeconds = Math.floor(Date.now() / 1000),
+): ArtifactShareViewerAccess | null {
+  const secret = shareSecret();
+  if (!secret || !token) return null;
+  const parts = token.split(".");
+  if (parts.length !== 3 || parts[0] !== TOKEN_PREFIX) return null;
+  const [, payloadSegment, signatureSegment] = parts;
+  if (!payloadSegment || !signatureSegment) return null;
+
+  let signature: Buffer;
+  try {
+    signature = Buffer.from(signatureSegment, "base64url");
+  } catch {
+    // error-policy:J3 untrusted-input sanitizing — an undecodable signature
+    // segment is an invalid token, resolved to null (no principal).
+    return null;
+  }
+  const expected = hmac(payloadSegment, secret);
+  if (
+    signature.length !== expected.length ||
+    !crypto.timingSafeEqual(signature, expected)
+  ) {
+    return null;
+  }
+
+  let payload: Record<string, unknown>;
+  try {
+    const parsed: unknown = JSON.parse(
+      Buffer.from(payloadSegment, "base64url").toString("utf8"),
+    );
+    if (!parsed || typeof parsed !== "object") return null;
+    payload = parsed as Record<string, unknown>;
+  } catch {
+    // error-policy:J3 untrusted-input sanitizing — an unparseable payload is an
+    // invalid token, resolved to null (no principal), never a default identity.
+    return null;
+  }
+
+  const entityId =
+    typeof payload.entityId === "string"
+      ? validateUuid(payload.entityId)
+      : null;
+  if (!entityId) return null;
+  const role = payload.role;
+  if (role !== "USER" && role !== "GUEST") return null;
+  if (typeof payload.exp !== "number" || payload.exp <= nowSeconds) {
+    return null;
+  }
+  return { entityId, role, exp: payload.exp };
+}
+
+/**
+ * Read-only artifact route allowlist for share-viewer principals. A viewer
+ * token is a disclosure capability, not an account: no mutations, no chat, no
+ * admin surface.
+ */
+export function isArtifactShareScopedRoute(
+  method: string,
+  pathname: string,
+): boolean {
+  if (method !== "GET") return false;
+  if (pathname === "/api/transcripts") return true;
+  if (/^\/api\/transcripts\/[^/]+$/.test(pathname)) return true;
+  if (pathname === "/api/meetings") return true;
+  if (/^\/api\/meetings\/[^/]+$/.test(pathname)) return true;
+  if (pathname === "/api/files") return true;
+  return false;
+}
+
+function toBoundaryAccess(
+  access: ArtifactShareViewerAccess,
+): BoundaryRoleAccess {
+  return {
+    providerId: ARTIFACT_SHARE_RESOLVER_ID,
+    worldRole: access.role,
+    principal: access.entityId,
+    isAdmin: false,
+    isRouteInScope: isArtifactShareScopedRoute,
+    claims: { entityId: access.entityId, role: access.role, exp: access.exp },
+  };
+}
+
+/** The artifact share-viewer boundary-role resolver. */
+export const artifactShareRoleResolver: TokenRoleResolver = {
+  id: ARTIFACT_SHARE_RESOLVER_ID,
+  resolve(req: http.IncomingMessage): BoundaryRoleAccess | null {
+    const access = resolveArtifactShareViewerToken(extractAuthToken(req));
+    return access ? toBoundaryAccess(access) : null;
+  },
+};
+
+let unregister: (() => void) | null = null;
+
+/**
+ * Register the artifact share-viewer resolver with the trunk boundary-role
+ * registry. Idempotent — safe from module load and server setup.
+ */
+export function registerArtifactShareRoleResolver(): () => void {
+  if (!unregister) {
+    unregister = registerTokenRoleResolver(artifactShareRoleResolver);
+  }
+  return () => {
+    unregister?.();
+    unregister = null;
+  };
+}
+
+// Self-register on import (mirrors the WaifuChat resolver): any code path that
+// touches the share scheme activates it without the trunk knowing it exists.
+registerArtifactShareRoleResolver();

--- a/packages/agent/src/api/attachment-disclosure.test.ts
+++ b/packages/agent/src/api/attachment-disclosure.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Contract for per-viewer chat-attachment DTO selection (#14781): the
+ * OWNER/ADMIN-full / USER-grant-driven / GUEST-none matrix, the room-open
+ * default for unmarked messages, and the fail-closed variant swap. Pure
+ * use-case functions, no harness.
+ */
+import type { AccessContext, Memory, UUID } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  selectAttachmentsForViewer,
+  serializeMessageAttachments,
+} from "./attachment-disclosure.ts";
+
+const AGENT = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" as UUID;
+const OWNER_ENTITY = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" as UUID;
+const VIEWER = "cccccccc-cccc-4ccc-8ccc-cccccccccccc" as UUID;
+const STRANGER = "dddddddd-dddd-4ddd-8ddd-dddddddddddd" as UUID;
+
+const ORIGINAL_URL = "/api/media/aaaa1111.png";
+const REDACTED_URL = "/api/media/bbbb2222.png";
+
+function row(
+  over: Partial<Memory> = {},
+): Pick<Memory, "content" | "metadata" | "entityId"> {
+  return {
+    entityId: OWNER_ENTITY,
+    content: {
+      text: "here",
+      attachments: [
+        {
+          id: "att-1",
+          url: ORIGINAL_URL,
+          contentType: "image",
+          mimeType: "image/png",
+          title: "payslip.png",
+          description: "Payslip for Bob",
+          text: "SSN 123-45-6789",
+          thumbnailUrl: "/api/media/cccc3333.png",
+          redactedUrl: REDACTED_URL,
+        },
+      ],
+    },
+    metadata: {},
+    ...over,
+  } as Pick<Memory, "content" | "metadata" | "entityId">;
+}
+
+const ctx = (over: Partial<AccessContext> = {}): AccessContext => ({
+  requesterEntityId: VIEWER,
+  role: "USER",
+  ...over,
+});
+
+describe("selectAttachmentsForViewer", () => {
+  it("no access context (single-owner dashboard) serves the full DTO unchanged", () => {
+    const r = row();
+    expect(selectAttachmentsForViewer(r, undefined, AGENT)).toEqual(
+      serializeMessageAttachments(r.content as Record<string, unknown>),
+    );
+  });
+
+  it("unmarked messages default to room-open: any viewer in the conversation sees the full attachment", () => {
+    const out = selectAttachmentsForViewer(row(), ctx(), AGENT);
+    expect(out).toHaveLength(1);
+    expect(out?.[0].url).toBe(ORIGINAL_URL);
+    expect(out?.[0].redacted).toBeUndefined();
+  });
+
+  it("OWNER/ADMIN viewers see marked messages in full", () => {
+    const marked = row({
+      metadata: { scope: "owner-private" } as Memory["metadata"],
+    });
+    for (const c of [
+      ctx({ role: "OWNER", isOwner: true }),
+      ctx({ role: "ADMIN" }),
+    ]) {
+      const out = selectAttachmentsForViewer(marked, c, AGENT);
+      expect(out?.[0].url).toBe(ORIGINAL_URL);
+      expect(out?.[0].redacted).toBeUndefined();
+    }
+  });
+
+  it("USER with a redacted grant gets the variant URL, flagged, with original + enrichment withheld", () => {
+    const marked = row({
+      metadata: {
+        scope: "owner-private",
+        share: { grants: [{ entityId: VIEWER, mode: "redacted" }] },
+      } as Memory["metadata"],
+    });
+    const out = selectAttachmentsForViewer(marked, ctx(), AGENT);
+    expect(out).toHaveLength(1);
+    const att = out?.[0];
+    expect(att?.url).toBe(REDACTED_URL);
+    expect(att?.redacted).toBe(true);
+    // The original URL, thumbnail, and enrichment text/description derive
+    // from the ORIGINAL bytes — all withheld.
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toContain(ORIGINAL_URL);
+    expect(att?.thumbnailUrl).toBeUndefined();
+    expect(att?.text).toBeUndefined();
+    expect(att?.description).toBeUndefined();
+  });
+
+  it("a redacted grant with no stored variant discloses NOTHING (fail closed)", () => {
+    const marked = row({
+      metadata: {
+        scope: "owner-private",
+        share: { grants: [{ entityId: VIEWER, mode: "redacted" }] },
+      } as Memory["metadata"],
+    });
+    const content = marked.content as unknown as {
+      attachments: Array<Record<string, unknown>>;
+    };
+    delete content.attachments[0].redactedUrl;
+    expect(selectAttachmentsForViewer(marked, ctx(), AGENT)).toBeUndefined();
+  });
+
+  it("ungranted USER and GUEST get no attachments from a marked message", () => {
+    const marked = row({
+      metadata: { scope: "owner-private" } as Memory["metadata"],
+    });
+    for (const c of [
+      ctx({ requesterEntityId: STRANGER }),
+      ctx({ requesterEntityId: STRANGER, role: "GUEST" }),
+    ]) {
+      expect(selectAttachmentsForViewer(marked, c, AGENT)).toBeUndefined();
+    }
+  });
+
+  it("an unreadable scope marking fails closed to owner-private, never open", () => {
+    const corrupt = row({
+      metadata: { scope: "??garbage??" } as unknown as Memory["metadata"],
+    });
+    expect(selectAttachmentsForViewer(corrupt, ctx(), AGENT)).toBeUndefined();
+  });
+
+  it("a USER with a full grant sees a marked message's attachments in full", () => {
+    const marked = row({
+      metadata: {
+        scope: "owner-private",
+        share: { grants: [{ entityId: VIEWER, mode: "full" }] },
+      } as Memory["metadata"],
+    });
+    const out = selectAttachmentsForViewer(marked, ctx(), AGENT);
+    expect(out?.[0].url).toBe(ORIGINAL_URL);
+    expect(out?.[0].redacted).toBeUndefined();
+  });
+});

--- a/packages/agent/src/api/attachment-disclosure.ts
+++ b/packages/agent/src/api/attachment-disclosure.ts
@@ -1,0 +1,156 @@
+/**
+ * Chat-message attachment DTO shaping + per-viewer disclosure selection
+ * (#14781) — the use-case layer behind the conversation message-list route.
+ * Serialization (which raw `content.attachments` entries become wire DTOs)
+ * and disclosure (what THIS viewer may see of them) live here so the route
+ * only assembles fields.
+ *
+ * Disclosure follows the ONE core predicate (`resolveArtifactDisclosure`) fed
+ * with the message row's metadata. Chat messages default to scope `"room"`
+ * (open): a viewer who can read the conversation sees its attachments, which
+ * preserves existing behavior for every unmarked message. Only a message
+ * explicitly marked (scope metadata or share grants) narrows: a
+ * redacted-grant viewer gets each attachment's PII-scrubbed variant
+ * (`Media.redactedUrl`, a separate content-addressed object) flagged
+ * `redacted: true` with the original URL and enrichment text withheld; an
+ * undisclosed viewer gets nothing.
+ */
+import type { AccessContext, Memory, MemoryScope, UUID } from "@elizaos/core";
+import {
+  parseArtifactShareGrants,
+  resolveArtifactDisclosure,
+} from "@elizaos/core";
+
+/** One chat attachment as served in the message-list DTO. */
+export type SerializedMessageAttachment = {
+  id: string;
+  url: string;
+  contentType?: string;
+  title?: string;
+  description?: string;
+  source?: string;
+  text?: string;
+  mimeType?: string;
+  thumbnailUrl?: string;
+  /** Reason enrichment could not extract text/description (see Media.notProcessed). */
+  notProcessed?: string;
+  /** Present (true) when `url` is the PII-scrubbed variant, not the original (#14781). */
+  redacted?: true;
+};
+
+/**
+ * Only URLs the browser can actually load are renderable. Inline-upload
+ * placeholders (e.g. `attachment:img-0`) whose bytes were never persisted are
+ * dropped here so the client never paints a broken image — real uploads and
+ * generated media carry a served `/api/media/...`, remote https, or inline
+ * `data:`/`blob:` URL.
+ */
+const RENDERABLE_ATTACHMENT_URL = /^(?:https?:|data:|blob:|\/)/i;
+
+const str = (v: unknown): string | undefined =>
+  typeof v === "string" && v.length > 0 ? v : undefined;
+
+export function serializeMessageAttachments(
+  content: Record<string, unknown> | undefined,
+): SerializedMessageAttachment[] | undefined {
+  const raw = content?.attachments;
+  if (!Array.isArray(raw) || raw.length === 0) return undefined;
+  const out: SerializedMessageAttachment[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+    const a = item as Record<string, unknown>;
+    const url = typeof a.url === "string" ? a.url : "";
+    if (!url || !RENDERABLE_ATTACHMENT_URL.test(url)) continue;
+    out.push({
+      id: str(a.id) ?? `att-${out.length}`,
+      url,
+      ...(str(a.contentType) ? { contentType: str(a.contentType) } : {}),
+      ...(str(a.title) ? { title: str(a.title) } : {}),
+      ...(str(a.description) ? { description: str(a.description) } : {}),
+      ...(str(a.source) ? { source: str(a.source) } : {}),
+      ...(str(a.text) ? { text: str(a.text) } : {}),
+      ...(str(a.mimeType) ? { mimeType: str(a.mimeType) } : {}),
+      ...(str(a.thumbnailUrl) ? { thumbnailUrl: str(a.thumbnailUrl) } : {}),
+      ...(str(a.notProcessed) ? { notProcessed: str(a.notProcessed) } : {}),
+    });
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+/**
+ * Serialize the redacted view of a message's attachments: each entry with a
+ * `redactedUrl` variant is emitted under that URL, flagged, with the original
+ * URL, thumbnail, and enrichment text/description withheld (they derive from
+ * the ORIGINAL bytes and may carry exactly the PII the variant scrubs).
+ * Entries with no variant are omitted — fail closed, never the original.
+ */
+function serializeRedactedAttachments(
+  content: Record<string, unknown> | undefined,
+): SerializedMessageAttachment[] | undefined {
+  const raw = content?.attachments;
+  if (!Array.isArray(raw) || raw.length === 0) return undefined;
+  const out: SerializedMessageAttachment[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+    const a = item as Record<string, unknown>;
+    const redactedUrl = str(a.redactedUrl) ?? "";
+    if (!redactedUrl || !RENDERABLE_ATTACHMENT_URL.test(redactedUrl)) continue;
+    out.push({
+      id: str(a.id) ?? `att-${out.length}`,
+      url: redactedUrl,
+      ...(str(a.contentType) ? { contentType: str(a.contentType) } : {}),
+      ...(str(a.title) ? { title: str(a.title) } : {}),
+      ...(str(a.mimeType) ? { mimeType: str(a.mimeType) } : {}),
+      redacted: true,
+    });
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+const MEMORY_SCOPES: ReadonlySet<string> = new Set<MemoryScope>([
+  "global",
+  "shared",
+  "room",
+  "private",
+  "owner-private",
+  "user-private",
+  "agent-private",
+]);
+
+/**
+ * Select the attachments DTO of one message row for one viewer. No access
+ * context (the single-owner dashboard boundary) serves the full DTO,
+ * unchanged. Unknown scope strings fail CLOSED to `owner-private` — a marked
+ * row whose marking cannot be read must not widen.
+ */
+export function selectAttachmentsForViewer(
+  row: Pick<Memory, "content" | "metadata" | "entityId">,
+  accessContext: AccessContext | undefined,
+  agentId: UUID,
+): SerializedMessageAttachment[] | undefined {
+  const content = row.content as Record<string, unknown> | undefined;
+  if (!accessContext) return serializeMessageAttachments(content);
+
+  const metadata = row.metadata as Record<string, unknown> | undefined;
+  const rawScope = metadata?.scope;
+  const scope: MemoryScope =
+    rawScope === undefined
+      ? "room"
+      : typeof rawScope === "string" && MEMORY_SCOPES.has(rawScope)
+        ? (rawScope as MemoryScope)
+        : "owner-private";
+  const scopedTo = metadata?.scopedToEntityId;
+  const disclosure = resolveArtifactDisclosure(
+    {
+      scope,
+      scopedEntityId:
+        typeof scopedTo === "string" ? (scopedTo as UUID) : row.entityId,
+      grants: parseArtifactShareGrants(metadata),
+    },
+    accessContext,
+    agentId,
+  );
+  if (disclosure === "full") return serializeMessageAttachments(content);
+  if (disclosure === "redacted") return serializeRedactedAttachments(content);
+  return undefined;
+}

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -48,6 +48,10 @@ import {
 } from "@elizaos/shared";
 import type { ElizaConfig } from "../config/config.ts";
 import { resolveStateDir } from "../config/paths.ts";
+import {
+  type SerializedMessageAttachment,
+  selectAttachmentsForViewer,
+} from "./attachment-disclosure.ts";
 import type {
   AccountConnectRequest,
   ChatGenerationResult,
@@ -77,6 +81,7 @@ import {
   buildConversationRoomMetadata,
   sanitizeConversationMetadata,
 } from "./conversation-metadata.ts";
+import { resolveHttpAccessContext } from "./http-access-context.ts";
 import { evictOldestConversation } from "./memory-bounds.ts";
 import { generateMessageCorpus, seedMessageCorpus } from "./message-corpus.ts";
 import {
@@ -1202,57 +1207,10 @@ function extractConversationMetaString(
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
-type SerializedMessageAttachment = {
-  id: string;
-  url: string;
-  contentType?: string;
-  title?: string;
-  description?: string;
-  source?: string;
-  text?: string;
-  mimeType?: string;
-  thumbnailUrl?: string;
-  /** Reason enrichment could not extract text/description (see Media.notProcessed). */
-  notProcessed?: string;
-};
-
-/**
- * Only URLs the browser can actually load are renderable. Inline-upload
- * placeholders (e.g. `attachment:img-0`) whose bytes were never persisted are
- * dropped here so the client never paints a broken image — real uploads and
- * generated media carry a served `/api/media/...`, remote https, or inline
- * `data:`/`blob:` URL.
- */
-const RENDERABLE_ATTACHMENT_URL = /^(?:https?:|data:|blob:|\/)/i;
-
-export function serializeMessageAttachments(
-  content: Record<string, unknown> | undefined,
-): SerializedMessageAttachment[] | undefined {
-  const raw = content?.attachments;
-  if (!Array.isArray(raw) || raw.length === 0) return undefined;
-  const out: SerializedMessageAttachment[] = [];
-  for (const item of raw) {
-    if (!item || typeof item !== "object") continue;
-    const a = item as Record<string, unknown>;
-    const url = typeof a.url === "string" ? a.url : "";
-    if (!url || !RENDERABLE_ATTACHMENT_URL.test(url)) continue;
-    const str = (v: unknown): string | undefined =>
-      typeof v === "string" && v.length > 0 ? v : undefined;
-    out.push({
-      id: str(a.id) ?? `att-${out.length}`,
-      url,
-      ...(str(a.contentType) ? { contentType: str(a.contentType) } : {}),
-      ...(str(a.title) ? { title: str(a.title) } : {}),
-      ...(str(a.description) ? { description: str(a.description) } : {}),
-      ...(str(a.source) ? { source: str(a.source) } : {}),
-      ...(str(a.text) ? { text: str(a.text) } : {}),
-      ...(str(a.mimeType) ? { mimeType: str(a.mimeType) } : {}),
-      ...(str(a.thumbnailUrl) ? { thumbnailUrl: str(a.thumbnailUrl) } : {}),
-      ...(str(a.notProcessed) ? { notProcessed: str(a.notProcessed) } : {}),
-    });
-  }
-  return out.length > 0 ? out : undefined;
-}
+// Attachment DTO shaping + per-viewer disclosure selection live in the
+// use-case module (#14781); the serializer is re-exported for existing
+// importers of this route module.
+export { serializeMessageAttachments } from "./attachment-disclosure.ts";
 
 type ConversationRouteMessageRecord = {
   id: string;
@@ -1956,6 +1914,11 @@ export async function handleConversationRoutes(
       // Sort by createdAt ascending
       memories.sort((a, b) => (a.createdAt ?? 0) - (b.createdAt ?? 0));
       const agentId = runtime.agentId;
+      // Per-viewer attachment disclosure (#14781): a boundary-role viewer
+      // token (WaifuChat, artifact share-viewer) carries a principal; trunk
+      // owner tokens match no resolver, so the local dashboard resolves no
+      // context and serves the full DTO unchanged.
+      const viewerAccessContext = resolveHttpAccessContext(req);
       const messages = memories
         .map((m) => {
           const contentSource = (m.content as Record<string, unknown>)?.source;
@@ -2013,7 +1976,11 @@ export async function handleConversationRoutes(
             role === "assistant"
               ? normalizeChatResponseText(rawText, state.logBuffer, runtime)
               : rawText;
-          const attachments = serializeMessageAttachments(content);
+          const attachments = selectAttachmentsForViewer(
+            m,
+            viewerAccessContext,
+            agentId,
+          );
           const topics =
             Array.isArray(meta?.topics) && meta.topics.length > 0
               ? (meta.topics as unknown[]).filter(

--- a/packages/agent/src/api/dispatch-route.ts
+++ b/packages/agent/src/api/dispatch-route.ts
@@ -24,6 +24,7 @@ import type {
 import { Readable } from "node:stream";
 
 import {
+  type AccessContext,
   type AgentRuntime,
   assertPublicRouteIntent,
   type IAgentRuntime,
@@ -162,6 +163,13 @@ export interface DispatchRouteArgs {
   isAuthorized: () => boolean;
   /** true when the transport verified a trusted loopback/local request. */
   isTrustedLocal?: () => boolean;
+  /**
+   * Requester identity resolved by the authenticated boundary (e.g. a
+   * registered TokenRoleResolver principal, #14781). Omitted for the
+   * single-owner local boundary, where routes must preserve their existing
+   * unfiltered behavior (see `RouteHandlerContext.accessContext`).
+   */
+  accessContext?: AccessContext;
   /** Optional host context (config, restartRuntime, etc.) — installed on the runtime for the duration of the dispatch. */
   hostContext?: RuntimeRouteHostContext;
   /**
@@ -485,6 +493,7 @@ export async function dispatchRoute(
           runtime: runtime as IAgentRuntime,
           inProcess: args.inProcess,
           isTrustedLocal: args.isTrustedLocal?.() ?? false,
+          ...(args.accessContext ? { accessContext: args.accessContext } : {}),
         };
         return await route.routeHandler(ctx);
       }

--- a/packages/agent/src/api/files-disclosure.test.ts
+++ b/packages/agent/src/api/files-disclosure.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Contract for the Files-list per-viewer selection (#14781): OWNER/agent see
+ * the whole store; USER/GUEST get the designed restricted state (empty +
+ * `restricted: true`), never a healthy-empty fabrication. Pure use-case.
+ */
+import type { AccessContext, StoredFileListItem, UUID } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import { selectFilesForViewer } from "./files-disclosure.ts";
+
+const AGENT = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" as UUID;
+const VIEWER = "cccccccc-cccc-4ccc-8ccc-cccccccccccc" as UUID;
+
+const FILES: StoredFileListItem[] = [
+  {
+    url: "/api/media/a.png",
+    hash: "a",
+    fileName: "a.png",
+    mimeType: "image/png",
+    size: 10,
+    createdAt: 2,
+  },
+  {
+    url: "/api/media/b.pdf",
+    hash: "b",
+    fileName: "b.pdf",
+    mimeType: "application/pdf",
+    size: 20,
+    createdAt: 1,
+  },
+];
+
+const ctx = (over: Partial<AccessContext>): AccessContext => ({
+  requesterEntityId: VIEWER,
+  ...over,
+});
+
+describe("selectFilesForViewer", () => {
+  it("no access context (single-owner boundary) → full store, not restricted", () => {
+    expect(selectFilesForViewer(FILES, undefined, AGENT)).toEqual({
+      files: FILES,
+      restricted: false,
+    });
+  });
+
+  it("agent self-read → full store", () => {
+    expect(
+      selectFilesForViewer(FILES, ctx({ requesterEntityId: AGENT }), AGENT),
+    ).toEqual({ files: FILES, restricted: false });
+  });
+
+  it("OWNER and ADMIN rank → full store", () => {
+    for (const c of [
+      ctx({ role: "OWNER", isOwner: true }),
+      ctx({ role: "ADMIN" }),
+    ]) {
+      expect(selectFilesForViewer(FILES, c, AGENT)).toEqual({
+        files: FILES,
+        restricted: false,
+      });
+    }
+  });
+
+  it("USER and GUEST → restricted state (empty + flag), distinct from empty store", () => {
+    for (const c of [ctx({ role: "USER" }), ctx({ role: "GUEST" })]) {
+      expect(selectFilesForViewer(FILES, c, AGENT)).toEqual({
+        files: [],
+        restricted: true,
+      });
+    }
+  });
+
+  it("an OWNER with a genuinely empty store is NOT restricted", () => {
+    expect(
+      selectFilesForViewer([], ctx({ role: "OWNER", isOwner: true }), AGENT),
+    ).toEqual({ files: [], restricted: false });
+  });
+});

--- a/packages/agent/src/api/files-disclosure.ts
+++ b/packages/agent/src/api/files-disclosure.ts
@@ -1,0 +1,44 @@
+/**
+ * Per-viewer selection for the Files list DTO (#14781) — the use-case the
+ * `/api/files` route delegates to, so no disclosure computation lives in the
+ * route layer. Stored files are raw content-addressed blobs with NO reference
+ * metadata of their own (doctrine #8876 AD1: no file table, no per-blob ACL),
+ * so the whole-store listing is an owner/admin management surface: share
+ * grants live on referencing records (transcripts, messages) and disclose
+ * through THOSE surfaces, never by widening the raw store list.
+ *
+ * Non-privileged viewers therefore get zero rows plus an explicit
+ * `restricted: true` — a designed, distinguishable state (UI three-state
+ * rule: restricted ≠ empty ≠ error), never a healthy-empty fabrication.
+ */
+import type { AccessContext, StoredFileListItem, UUID } from "@elizaos/core";
+import { actorFromAccessContext } from "@elizaos/core";
+
+/** The `GET /api/files` response body. */
+export interface FilesListDto {
+  files: StoredFileListItem[];
+  /**
+   * True when the viewer's tier cannot see the raw store listing. The client
+   * renders the designed "restricted" state — distinct from an owner's
+   * genuinely empty store (`files: [], restricted: false`).
+   */
+  restricted: boolean;
+}
+
+/**
+ * Select the Files list for one viewer: the single-owner boundary (no
+ * context), the agent itself, and OWNER/ADMIN-rank viewers see every stored
+ * file; USER/GUEST-tier viewers see the restricted state.
+ */
+export function selectFilesForViewer(
+  files: StoredFileListItem[],
+  accessContext: AccessContext | undefined,
+  agentId: UUID,
+): FilesListDto {
+  if (!accessContext) return { files, restricted: false };
+  const actor = actorFromAccessContext(accessContext, agentId);
+  if (actor.role === "OWNER" || actor.role === "AGENT") {
+    return { files, restricted: false };
+  }
+  return { files: [], restricted: true };
+}

--- a/packages/agent/src/api/files-routes.ts
+++ b/packages/agent/src/api/files-routes.ts
@@ -11,7 +11,9 @@ import {
   type IFileStorageService,
   type Route,
   ServiceType,
+  type UUID,
 } from "@elizaos/core";
+import { selectFilesForViewer } from "./files-disclosure.ts";
 
 function getFileStorage(runtime: IAgentRuntime): IFileStorageService | null {
   return (
@@ -19,7 +21,11 @@ function getFileStorage(runtime: IAgentRuntime): IFileStorageService | null {
   );
 }
 
-/** GET /api/files — list every stored file (newest first). */
+/**
+ * GET /api/files — list stored files (newest first), selected per viewer
+ * (#14781): the single-owner boundary and OWNER/ADMIN-rank viewers see the
+ * whole store; USER/GUEST viewers get the designed restricted state.
+ */
 export const filesListRoute: Route = {
   type: "GET",
   path: "/api/files",
@@ -32,7 +38,12 @@ export const filesListRoute: Route = {
     }
     const files = await storage.list();
     files.sort((a, b) => b.createdAt - a.createdAt);
-    return { status: 200, body: { files } };
+    const body = selectFilesForViewer(
+      files,
+      ctx.accessContext,
+      ctx.runtime.agentId as UUID,
+    );
+    return { status: 200, body };
   },
 };
 

--- a/packages/agent/src/api/hono-adapter.ts
+++ b/packages/agent/src/api/hono-adapter.ts
@@ -11,7 +11,12 @@
  * handlers will be migrated onto `runtime.routes` in later phases.
  */
 
-import type { IAgentRuntime, Route, RouteHandlerResult } from "@elizaos/core";
+import type {
+  AccessContext,
+  IAgentRuntime,
+  Route,
+  RouteHandlerResult,
+} from "@elizaos/core";
 import { type Context, Hono } from "hono";
 import { stream as honoStream } from "hono/streaming";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
@@ -23,6 +28,12 @@ export interface HonoAdapterOptions {
   isAuthorized: (req: Request) => boolean;
   /** Predicate that decides whether the incoming request is trusted loopback/local. */
   isTrustedLocal?: (req: Request) => boolean;
+  /**
+   * Boundary-resolved requester identity for per-viewer DTO selection
+   * (#14781). Absent/`undefined` means the single-owner local boundary and
+   * routes serve their existing unfiltered content.
+   */
+  resolveAccessContext?: (req: Request) => AccessContext | undefined;
 }
 
 function honoMethod(type: Route["type"]): string | null {
@@ -138,6 +149,7 @@ export function mountRoutesOnHono(
         inProcess: false,
         isAuthorized: () => options.isAuthorized(request),
         isTrustedLocal: () => options.isTrustedLocal?.(request) ?? false,
+        accessContext: options.resolveAccessContext?.(request),
       }).catch(
         (err: unknown): RouteHandlerResult => ({
           status: 500,

--- a/packages/agent/src/api/hono-mount.ts
+++ b/packages/agent/src/api/hono-mount.ts
@@ -7,7 +7,7 @@
 import { Buffer } from "node:buffer";
 import type { IncomingMessage, ServerResponse } from "node:http";
 
-import type { IAgentRuntime, Route } from "@elizaos/core";
+import type { AccessContext, IAgentRuntime, Route, UUID } from "@elizaos/core";
 import type { Hono } from "hono";
 
 import { buildHonoAppForRuntime } from "./hono-adapter.ts";
@@ -21,6 +21,59 @@ interface RuntimeHonoCache {
 let cached: RuntimeHonoCache | null = null;
 const INTERNAL_AUTHORIZED_HEADER = "x-eliza-internal-authorized";
 const INTERNAL_TRUSTED_LOCAL_HEADER = "x-eliza-internal-trusted-local";
+// Carries the boundary-resolved AccessContext (JSON) from the Node listener
+// into the Hono app (#14781). Like the two headers above it is INTERNAL-ONLY:
+// tryHandleHonoRuntimeRoute always overwrites/deletes it before dispatch, so a
+// client-supplied value can never smuggle a principal in.
+const INTERNAL_ACCESS_CONTEXT_HEADER = "x-eliza-internal-access-context";
+
+const ROLE_NAMES = new Set(["OWNER", "ADMIN", "USER", "GUEST"]);
+
+/**
+ * Parse the internal access-context header back into a typed AccessContext.
+ * The value is producer-controlled (set by this module's own caller), but the
+ * parse still validates every field so a malformed value yields NO principal
+ * rather than a corrupt one.
+ */
+// error-policy:J3 untrusted-input sanitizing — a malformed header resolves to
+// undefined (no principal / owner-boundary semantics are NOT granted: routes
+// only widen disclosure when a context is absent because the caller was
+// trunk-authorized, and that path never sets this header).
+function parseInternalAccessContext(
+  value: string | null,
+): AccessContext | undefined {
+  if (!value) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!parsed || typeof parsed !== "object") return undefined;
+    const record = parsed as Record<string, unknown>;
+    if (
+      typeof record.requesterEntityId !== "string" ||
+      record.requesterEntityId.length === 0
+    ) {
+      return undefined;
+    }
+    const role =
+      typeof record.role === "string" && ROLE_NAMES.has(record.role)
+        ? (record.role as AccessContext["role"])
+        : undefined;
+    return {
+      requesterEntityId: record.requesterEntityId as UUID,
+      ...(typeof record.worldId === "string"
+        ? { worldId: record.worldId as UUID }
+        : {}),
+      ...(role ? { role } : {}),
+      ...(typeof record.isOwner === "boolean"
+        ? { isOwner: record.isOwner }
+        : {}),
+      ...(typeof record.source === "string" ? { source: record.source } : {}),
+    };
+  } catch {
+    // error-policy:J3 untrusted-input sanitizing — a malformed header yields no
+    // principal (undefined), never a fabricated identity.
+    return undefined;
+  }
+}
 
 function getHonoApp(runtime: IAgentRuntime): Hono {
   if (cached && cached.runtime.deref() === runtime) {
@@ -30,6 +83,10 @@ function getHonoApp(runtime: IAgentRuntime): Hono {
     isAuthorized: (req) => req.headers.get(INTERNAL_AUTHORIZED_HEADER) === "1",
     isTrustedLocal: (req) =>
       req.headers.get(INTERNAL_TRUSTED_LOCAL_HEADER) === "1",
+    resolveAccessContext: (req) =>
+      parseInternalAccessContext(
+        req.headers.get(INTERNAL_ACCESS_CONTEXT_HEADER),
+      ),
   });
   cached = { runtime: new WeakRef(runtime), app };
   return app;
@@ -155,6 +212,8 @@ export async function tryHandleHonoRuntimeRoute(options: {
   runtime: IAgentRuntime | null | undefined;
   isAuthorized: () => boolean;
   isTrustedLocal?: () => boolean;
+  /** Boundary-resolved requester identity for per-viewer DTO selection (#14781). */
+  accessContext?: () => AccessContext | undefined;
 }): Promise<boolean> {
   const { req, res, runtime } = options;
   if (!runtime?.routes?.length) return false;
@@ -193,6 +252,14 @@ export async function tryHandleHonoRuntimeRoute(options: {
     INTERNAL_TRUSTED_LOCAL_HEADER,
     options.isTrustedLocal?.() ? "1" : "0",
   );
+  // Always overwrite (or drop) the internal access-context header so an
+  // inbound client value can never survive into dispatch.
+  const accessContext = options.accessContext?.();
+  if (accessContext) {
+    headers.set(INTERNAL_ACCESS_CONTEXT_HEADER, JSON.stringify(accessContext));
+  } else {
+    headers.delete(INTERNAL_ACCESS_CONTEXT_HEADER);
+  }
 
   // Hono needs a Web Request. Avoid leaking the body to GET/HEAD.
   const request = new Request(url, {

--- a/packages/agent/src/api/http-access-context.ts
+++ b/packages/agent/src/api/http-access-context.ts
@@ -1,0 +1,40 @@
+/**
+ * Maps a boundary-resolved HTTP principal onto the core {@link AccessContext}
+ * DTO that use-case layers consume for per-viewer disclosure (#14781). This is
+ * the HTTP-side counterpart of the message-driven `buildAccessContext`: where
+ * a connector message resolves its role against a world, an HTTP viewer's role
+ * comes from whichever registered {@link TokenRoleResolver} recognized the
+ * request (WaifuChat, artifact share-viewer, …).
+ *
+ * The trunk-authorized owner boundary deliberately yields `undefined` — the
+ * documented single-owner contract on `RouteHandlerContext.accessContext`
+ * ("omitted means preserve existing unfiltered behavior"), so the local
+ * dashboard is byte-for-byte unchanged. A resolver principal whose id is not
+ * already a UUID (e.g. a wallet address) is mapped to a deterministic UUID so
+ * downstream grant/scope comparisons operate on the entity vocabulary.
+ */
+import type http from "node:http";
+import { type AccessContext, stringToUuid, validateUuid } from "@elizaos/core";
+import { resolveRegisteredTokenRoleAccess } from "./boundary-role-resolver.ts";
+
+/**
+ * Resolve the per-viewer access context for an HTTP request, or `undefined`
+ * for the single-owner boundary (trunk-authorized callers and requests no
+ * resolver recognizes — the latter never reach a private route handler anyway,
+ * the 401 gate already refused them).
+ */
+export function resolveHttpAccessContext(
+  req: http.IncomingMessage,
+): AccessContext | undefined {
+  const access = resolveRegisteredTokenRoleAccess(req);
+  if (!access) return undefined;
+  const requesterEntityId =
+    validateUuid(access.principal) ??
+    stringToUuid(`boundary-principal:${access.providerId}:${access.principal}`);
+  return {
+    requesterEntityId,
+    role: access.worldRole,
+    isOwner: access.worldRole === "OWNER",
+    source: access.providerId,
+  };
+}

--- a/packages/agent/src/api/media-runtime.ts
+++ b/packages/agent/src/api/media-runtime.ts
@@ -218,7 +218,13 @@ export function collectReferencedMedia(
   for (const memory of memories) {
     const attachments = (
       memory.content as
-        | { attachments?: Array<{ url?: unknown; thumbnailUrl?: unknown }> }
+        | {
+            attachments?: Array<{
+              url?: unknown;
+              thumbnailUrl?: unknown;
+              redactedUrl?: unknown;
+            }>;
+          }
         | undefined
     )?.attachments;
     if (Array.isArray(attachments)) {
@@ -232,6 +238,11 @@ export function collectReferencedMedia(
         // window, so inline previews 404 even though the full image survives.
         addUrl(attachment?.url);
         addUrl(attachment?.thumbnailUrl);
+        // The PII-scrubbed variant (#14781) is its own content-addressed file
+        // referenced only via `redactedUrl` on the same attachment; without
+        // this scan the daily GC deletes every redacted variant past the grace
+        // window and redacted-grant viewers 404.
+        addUrl(attachment?.redactedUrl);
       }
     }
 

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -1531,6 +1531,9 @@ import {
   resolveWebSocketUpgradeRejection as _resolveWebSocketUpgradeRejection,
 } from "./server-helpers-auth.ts";
 
+// Importing the artifact share-viewer scheme self-registers its resolver with
+// the trunk boundary-role registry (#14781) — same pattern as WaifuChat above.
+export { issueArtifactShareViewerToken } from "./artifact-share-role-resolver.ts";
 export {
   ensureApiTokenForBindHost,
   extractAuthToken,
@@ -1544,11 +1547,12 @@ export {
   type TerminalRunRejection,
   type WebSocketUpgradeRejection,
 } from "./server-helpers-auth.ts";
-
 // Back-compat re-export: the WaifuChat scheme now lives in its own resolver
 // module. Importing it here also self-registers the resolver with the trunk
 // boundary-role registry (#12087 item 12).
 export { isWaifuChatAuthorized } from "./waifu-chat-role-resolver.ts";
+
+import { resolveHttpAccessContext } from "./http-access-context.ts";
 
 const isAllowedHost = _isAllowedHost;
 const applyCors = _applyCors;
@@ -3538,8 +3542,19 @@ async function handleRequest(
       req,
       res,
       runtime: state.runtime,
-      isAuthorized: () => isAuthorized(req),
+      // Mirror the outer 401 gate: a registered boundary-role viewer (e.g. an
+      // artifact share-viewer token, #14781) is authorized for its in-scope
+      // routes, so the dispatch-level re-check must accept it too — otherwise
+      // resolver-authorized requests pass the outer gate and 401 in dispatch.
+      isAuthorized: () =>
+        isAuthorized(req) || isBoundaryRoleAuthorized(req, method, pathname),
       isTrustedLocal: () => isTrustedLocalRequest(req),
+      // Per-viewer principal for DTO selection (#14781). Trunk-authorized
+      // callers stay on the single-owner boundary (no context → routes serve
+      // unfiltered, unchanged); only resolver-recognized viewer tokens
+      // (WaifuChat, artifact share-viewer) carry a principal into dispatch.
+      accessContext: () =>
+        isAuthorized(req) ? undefined : resolveHttpAccessContext(req),
     })
   ) {
     return;

--- a/packages/agent/test/api/artifact-disclosure.real-server.test.ts
+++ b/packages/agent/test/api/artifact-disclosure.real-server.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Real route-level contract for role-aware artifact disclosure (#14781),
+ * exercised over a real TCP socket through the ACTUAL server dispatch chain:
+ * the 401 boundary gate (`isAuthorized || isBoundaryRoleAuthorized`), the
+ * registered share-viewer TokenRoleResolver, `resolveHttpAccessContext`, the
+ * Hono mount → `dispatchRoute` → `filesListRoute.routeHandler`, and the
+ * `selectFilesForViewer` use-case — none of it mocked. Files bytes come from
+ * the REAL `LocalFileStorageService` over a temp media store.
+ *
+ * The harness reproduces server.ts's gate + dispatch wiring verbatim EXCEPT it
+ * uses token-only trunk auth (no loopback-trust): `isAuthorized` short-circuits
+ * to OWNER for any loopback socket, which would collapse every role to OWNER, so
+ * a faithful multi-role test must model the production non-loopback boundary
+ * where a bearer token or a resolver principal is the only authority. That is
+ * the one deliberate substitution; every layer that decides disclosure is real.
+ */
+
+import fs from "node:fs";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { type IAgentRuntime, ServiceType, type UUID } from "@elizaos/core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { issueArtifactShareViewerToken } from "../../src/api/artifact-share-role-resolver.ts";
+import { filesRoutes } from "../../src/api/files-routes.ts";
+import { tryHandleHonoRuntimeRoute } from "../../src/api/hono-mount.ts";
+import { resolveHttpAccessContext } from "../../src/api/http-access-context.ts";
+import { isBoundaryRoleAuthorized } from "../../src/api/server-helpers-auth.ts";
+
+const AGENT_ID = "00000000-0000-0000-0000-0000000000a1" as UUID;
+const VIEWER = "cccccccc-cccc-4ccc-8ccc-cccccccccccc" as UUID;
+const API_TOKEN = "owner-trunk-token";
+const SHARE_SECRET = "real-server-share-secret";
+
+let stateDir: string;
+let server: http.Server;
+let baseUrl: string;
+
+/** Token-only trunk auth (mirrors a non-loopback deployment boundary). */
+function trunkAuthorized(req: http.IncomingMessage): boolean {
+  const auth = req.headers.authorization ?? "";
+  return auth === `Bearer ${API_TOKEN}`;
+}
+
+beforeAll(async () => {
+  stateDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), "artifact-disclosure-real-"),
+  );
+  process.env.ELIZA_STATE_DIR = stateDir;
+  process.env.ELIZA_ARTIFACT_SHARE_TOKEN_SECRET = SHARE_SECRET;
+
+  // Real content-addressed file storage over the temp state dir.
+  const { LocalFileStorageService } = await import(
+    "../../src/services/file-storage.ts"
+  );
+  const runtimeForStorage = { agentId: AGENT_ID } as unknown as IAgentRuntime;
+  const storage = await LocalFileStorageService.start(runtimeForStorage);
+  await storage.store(Buffer.from("hello world pdf"), "application/pdf");
+  await storage.store(Buffer.from("an image"), "image/png");
+
+  const runtime = {
+    agentId: AGENT_ID,
+    routes: filesRoutes,
+    getService: (type: string) =>
+      type === ServiceType.REMOTE_FILES ? storage : null,
+  } as unknown as IAgentRuntime;
+
+  // The server dispatch wiring, reproduced from api/server.ts.
+  server = http.createServer(async (req, res) => {
+    const url = new URL(req.url ?? "/", "http://127.0.0.1");
+    const method = req.method ?? "GET";
+    const pathname = url.pathname;
+
+    if (
+      !trunkAuthorized(req) &&
+      !isBoundaryRoleAuthorized(req, method, pathname)
+    ) {
+      res.statusCode = 401;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ error: "Unauthorized" }));
+      return;
+    }
+
+    const handled = await tryHandleHonoRuntimeRoute({
+      req,
+      res,
+      runtime,
+      isAuthorized: () =>
+        trunkAuthorized(req) || isBoundaryRoleAuthorized(req, method, pathname),
+      isTrustedLocal: () => false,
+      accessContext: () =>
+        trunkAuthorized(req) ? undefined : resolveHttpAccessContext(req),
+    });
+    if (!handled) {
+      res.statusCode = 404;
+      res.end("not found");
+    }
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  fs.rmSync(stateDir, { recursive: true, force: true });
+  delete process.env.ELIZA_ARTIFACT_SHARE_TOKEN_SECRET;
+});
+
+async function getFiles(authHeader?: string): Promise<{
+  status: number;
+  body: { files?: unknown[]; restricted?: boolean; error?: string };
+}> {
+  const res = await fetch(`${baseUrl}/api/files`, {
+    headers: authHeader ? { authorization: authHeader } : {},
+  });
+  const body = (await res.json().catch(() => ({}))) as {
+    files?: unknown[];
+    restricted?: boolean;
+    error?: string;
+  };
+  return { status: res.status, body };
+}
+
+describe("GET /api/files role-aware disclosure (real server)", () => {
+  it("refuses an unauthenticated caller with 401", async () => {
+    const { status, body } = await getFiles();
+    expect(status).toBe(401);
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  it("OWNER (trunk token) sees the full store", async () => {
+    const { status, body } = await getFiles(`Bearer ${API_TOKEN}`);
+    expect(status).toBe(200);
+    expect(body.restricted).toBe(false);
+    expect(body.files).toHaveLength(2);
+  });
+
+  it("USER share-viewer sees the designed restricted state, not the store", async () => {
+    const token = issueArtifactShareViewerToken({
+      entityId: VIEWER,
+      role: "USER",
+      ttlMs: 60_000,
+    });
+    const { status, body } = await getFiles(`Bearer ${token}`);
+    expect(status).toBe(200);
+    expect(body.restricted).toBe(true);
+    expect(body.files).toEqual([]);
+  });
+
+  it("GUEST share-viewer is likewise restricted", async () => {
+    const token = issueArtifactShareViewerToken({
+      entityId: VIEWER,
+      role: "GUEST",
+      ttlMs: 60_000,
+    });
+    const { status, body } = await getFiles(`Bearer ${token}`);
+    expect(status).toBe(200);
+    expect(body.restricted).toBe(true);
+    expect(body.files).toEqual([]);
+  });
+
+  it("a share-viewer token cannot reach a mutating route (allowlist is GET-only)", async () => {
+    const token = issueArtifactShareViewerToken({
+      entityId: VIEWER,
+      role: "USER",
+      ttlMs: 60_000,
+    });
+    const res = await fetch(`${baseUrl}/api/files/anything.png`, {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${token}` },
+    });
+    // The boundary gate refuses: DELETE is outside the viewer route allowlist.
+    expect(res.status).toBe(401);
+  });
+
+  it("an expired share-viewer token is refused at the boundary", async () => {
+    const token = issueArtifactShareViewerToken(
+      { entityId: VIEWER, role: "USER", ttlMs: 1 },
+      0,
+    );
+    const { status } = await getFiles(`Bearer ${token}`);
+    expect(status).toBe(401);
+  });
+});

--- a/packages/agent/test/api/artifact-share-role-resolver.test.ts
+++ b/packages/agent/test/api/artifact-share-role-resolver.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Contract for the artifact share-viewer boundary-role resolver (#14781):
+ * mint/verify round-trip over the real HMAC, tamper/expiry/secret gating, the
+ * GET-only artifact route allowlist, and registry integration through the
+ * trunk seam. Real crypto, real registry — only the http.IncomingMessage is a
+ * plain header carrier.
+ */
+import type http from "node:http";
+import type { UUID } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  ARTIFACT_SHARE_RESOLVER_ID,
+  artifactShareRoleResolver,
+  isArtifactShareScopedRoute,
+  issueArtifactShareViewerToken,
+  registerArtifactShareRoleResolver,
+  resolveArtifactShareViewerToken,
+} from "../../src/api/artifact-share-role-resolver.ts";
+import {
+  hasTokenRoleResolver,
+  resolveRegisteredTokenRoleAccess,
+} from "../../src/api/boundary-role-resolver.ts";
+import { resolveHttpAccessContext } from "../../src/api/http-access-context.ts";
+
+const VIEWER = "cccccccc-cccc-4ccc-8ccc-cccccccccccc" as UUID;
+const SECRET = "test-share-secret";
+
+function reqWithToken(token?: string): http.IncomingMessage {
+  return {
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+  } as unknown as http.IncomingMessage;
+}
+
+beforeEach(() => {
+  process.env.ELIZA_ARTIFACT_SHARE_TOKEN_SECRET = SECRET;
+  registerArtifactShareRoleResolver();
+});
+
+afterEach(() => {
+  delete process.env.ELIZA_ARTIFACT_SHARE_TOKEN_SECRET;
+});
+
+describe("share-viewer token mint/verify", () => {
+  it("round-trips a USER token", () => {
+    const token = issueArtifactShareViewerToken({
+      entityId: VIEWER,
+      role: "USER",
+      ttlMs: 60_000,
+    });
+    const access = resolveArtifactShareViewerToken(token);
+    expect(access).toMatchObject({ entityId: VIEWER, role: "USER" });
+  });
+
+  it("rejects expiry, tamper, wrong prefix, and garbage", () => {
+    const token = issueArtifactShareViewerToken(
+      { entityId: VIEWER, role: "USER", ttlMs: 1_000 },
+      0,
+    );
+    // Expired (minted at t=0 with 1s ttl, verified at t=10s).
+    expect(resolveArtifactShareViewerToken(token, 10)).toBeNull();
+
+    const live = issueArtifactShareViewerToken({
+      entityId: VIEWER,
+      role: "USER",
+      ttlMs: 60_000,
+    });
+    // Signature tamper.
+    expect(resolveArtifactShareViewerToken(`${live}x`)).toBeNull();
+    // Payload tamper (role escalation attempt re-signs nothing).
+    const [prefix, payload, sig] = live.split(".");
+    const forged = Buffer.from(
+      JSON.stringify({
+        entityId: VIEWER,
+        role: "OWNER",
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      }),
+    ).toString("base64url");
+    expect(
+      resolveArtifactShareViewerToken(`${prefix}.${forged}.${sig}`),
+    ).toBeNull();
+    expect(resolveArtifactShareViewerToken("esv1.garbage")).toBeNull();
+    expect(resolveArtifactShareViewerToken("not-a-token")).toBeNull();
+    expect(resolveArtifactShareViewerToken(undefined)).toBeNull();
+    void payload;
+  });
+
+  it("is inert without the secret: no verify, and minting fails fast", () => {
+    const token = issueArtifactShareViewerToken({
+      entityId: VIEWER,
+      role: "USER",
+      ttlMs: 60_000,
+    });
+    delete process.env.ELIZA_ARTIFACT_SHARE_TOKEN_SECRET;
+    expect(resolveArtifactShareViewerToken(token)).toBeNull();
+    expect(() =>
+      issueArtifactShareViewerToken({
+        entityId: VIEWER,
+        role: "USER",
+        ttlMs: 60_000,
+      }),
+    ).toThrow(/not configured/);
+  });
+
+  it("only ever mints USER/GUEST — a token can never carry an elevated tier", () => {
+    // The role type is closed at compile time; at runtime a forged elevated
+    // payload fails the role check in resolve (covered above). Verify GUEST
+    // round-trips as the only other tier.
+    const token = issueArtifactShareViewerToken({
+      entityId: VIEWER,
+      role: "GUEST",
+      ttlMs: 60_000,
+    });
+    expect(resolveArtifactShareViewerToken(token)?.role).toBe("GUEST");
+  });
+});
+
+describe("route allowlist", () => {
+  it("allows only the GET artifact read routes", () => {
+    expect(isArtifactShareScopedRoute("GET", "/api/transcripts")).toBe(true);
+    expect(isArtifactShareScopedRoute("GET", "/api/transcripts/abc")).toBe(
+      true,
+    );
+    expect(isArtifactShareScopedRoute("GET", "/api/meetings")).toBe(true);
+    expect(isArtifactShareScopedRoute("GET", "/api/meetings/abc")).toBe(true);
+    expect(isArtifactShareScopedRoute("GET", "/api/files")).toBe(true);
+
+    expect(isArtifactShareScopedRoute("DELETE", "/api/transcripts/abc")).toBe(
+      false,
+    );
+    expect(isArtifactShareScopedRoute("POST", "/api/transcripts")).toBe(false);
+    expect(isArtifactShareScopedRoute("PUT", "/api/transcripts/abc")).toBe(
+      false,
+    );
+    expect(isArtifactShareScopedRoute("DELETE", "/api/files/x.png")).toBe(
+      false,
+    );
+    expect(isArtifactShareScopedRoute("GET", "/api/conversations")).toBe(false);
+    expect(isArtifactShareScopedRoute("GET", "/api/agents")).toBe(false);
+  });
+});
+
+describe("trunk registry integration", () => {
+  it("registers under its id and resolves canonical boundary access", () => {
+    expect(hasTokenRoleResolver(ARTIFACT_SHARE_RESOLVER_ID)).toBe(true);
+    const token = issueArtifactShareViewerToken({
+      entityId: VIEWER,
+      role: "USER",
+      ttlMs: 60_000,
+    });
+    const access = resolveRegisteredTokenRoleAccess(reqWithToken(token));
+    expect(access).toMatchObject({
+      providerId: ARTIFACT_SHARE_RESOLVER_ID,
+      worldRole: "USER",
+      principal: VIEWER,
+      isAdmin: false,
+    });
+    expect(
+      artifactShareRoleResolver.resolve(reqWithToken("esv1.bad.token")),
+    ).toBeNull();
+  });
+
+  it("maps onto an AccessContext with the token's entity as requester", () => {
+    const token = issueArtifactShareViewerToken({
+      entityId: VIEWER,
+      role: "USER",
+      ttlMs: 60_000,
+    });
+    expect(resolveHttpAccessContext(reqWithToken(token))).toEqual({
+      requesterEntityId: VIEWER,
+      role: "USER",
+      isOwner: false,
+      source: ARTIFACT_SHARE_RESOLVER_ID,
+    });
+    // No token → no principal (single-owner boundary).
+    expect(resolveHttpAccessContext(reqWithToken())).toBeUndefined();
+  });
+});

--- a/packages/core/src/access-control/artifact-disclosure.test.ts
+++ b/packages/core/src/access-control/artifact-disclosure.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Unit contract for the role-aware artifact disclosure decision (#14781):
+ * the OWNER/ADMIN-full / USER-grant-driven / fail-closed matrix and the
+ * untrusted grant parser. Pure functions, no harness.
+ */
+import { describe, expect, it } from "vitest";
+import type { AccessContext, UUID } from "../types";
+import {
+	parseArtifactShareGrants,
+	resolveArtifactDisclosure,
+} from "./artifact-disclosure";
+
+const AGENT = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" as UUID;
+const OWNER = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb" as UUID;
+const VIEWER = "cccccccc-cccc-4ccc-8ccc-cccccccccccc" as UUID;
+const OTHER = "dddddddd-dddd-4ddd-8ddd-dddddddddddd" as UUID;
+
+const ctx = (over: Partial<AccessContext> = {}): AccessContext => ({
+	requesterEntityId: VIEWER,
+	...over,
+});
+
+describe("resolveArtifactDisclosure", () => {
+	it("no access context (single-owner local boundary) → full", () => {
+		expect(
+			resolveArtifactDisclosure({ scope: "owner-private" }, undefined, AGENT),
+		).toBe("full");
+	});
+
+	it("agent self-read → full", () => {
+		expect(
+			resolveArtifactDisclosure(
+				{ scope: "owner-private" },
+				ctx({ requesterEntityId: AGENT }),
+				AGENT,
+			),
+		).toBe("full");
+	});
+
+	it("OWNER and ADMIN rank → full regardless of scope or grants", () => {
+		for (const c of [
+			ctx({ role: "OWNER", isOwner: true }),
+			ctx({ role: "ADMIN" }),
+		]) {
+			expect(
+				resolveArtifactDisclosure({ scope: "owner-private" }, c, AGENT),
+			).toBe("full");
+		}
+	});
+
+	it("USER with a full grant → full even on owner-private scope", () => {
+		expect(
+			resolveArtifactDisclosure(
+				{
+					scope: "owner-private",
+					scopedEntityId: OWNER,
+					grants: [{ entityId: VIEWER, mode: "full" }],
+				},
+				ctx({ role: "USER" }),
+				AGENT,
+			),
+		).toBe("full");
+	});
+
+	it("USER with a redacted grant → redacted", () => {
+		expect(
+			resolveArtifactDisclosure(
+				{
+					scope: "owner-private",
+					scopedEntityId: OWNER,
+					grants: [{ entityId: VIEWER, mode: "redacted" }],
+				},
+				ctx({ role: "USER" }),
+				AGENT,
+			),
+		).toBe("redacted");
+	});
+
+	it("a redacted grant narrows the viewer even when scope is global", () => {
+		expect(
+			resolveArtifactDisclosure(
+				{
+					scope: "global",
+					grants: [{ entityId: VIEWER, mode: "redacted" }],
+				},
+				ctx({ role: "USER" }),
+				AGENT,
+			),
+		).toBe("redacted");
+	});
+
+	it("someone else's grant does not disclose to this viewer", () => {
+		expect(
+			resolveArtifactDisclosure(
+				{
+					scope: "owner-private",
+					scopedEntityId: OWNER,
+					grants: [{ entityId: OTHER, mode: "full" }],
+				},
+				ctx({ role: "USER" }),
+				AGENT,
+			),
+		).toBe("none");
+	});
+
+	it("ungranted USER falls back to the scope ladder", () => {
+		// owner-private default fails closed…
+		expect(
+			resolveArtifactDisclosure(
+				{ scope: "owner-private", scopedEntityId: OWNER },
+				ctx({ role: "USER" }),
+				AGENT,
+			),
+		).toBe("none");
+		// …global stays readable…
+		expect(
+			resolveArtifactDisclosure(
+				{ scope: "global" },
+				ctx({ role: "USER" }),
+				AGENT,
+			),
+		).toBe("full");
+		// …and a user still reads their OWN user-private record.
+		expect(
+			resolveArtifactDisclosure(
+				{ scope: "user-private", scopedEntityId: VIEWER },
+				ctx({ role: "USER" }),
+				AGENT,
+			),
+		).toBe("full");
+		expect(
+			resolveArtifactDisclosure(
+				{ scope: "user-private", scopedEntityId: OTHER },
+				ctx({ role: "USER" }),
+				AGENT,
+			),
+		).toBe("none");
+	});
+
+	it("GUEST role collapses to the least-privileged tier: omitted on owner-private", () => {
+		expect(
+			resolveArtifactDisclosure(
+				{ scope: "owner-private", scopedEntityId: OWNER },
+				ctx({ role: "GUEST" }),
+				AGENT,
+			),
+		).toBe("none");
+	});
+
+	it("unresolved role (no world) fails closed to the USER tier", () => {
+		expect(
+			resolveArtifactDisclosure(
+				{ scope: "owner-private", scopedEntityId: OWNER },
+				ctx(),
+				AGENT,
+			),
+		).toBe("none");
+	});
+});
+
+describe("parseArtifactShareGrants", () => {
+	it("parses well-formed grants and preserves issuer fields", () => {
+		const grants = parseArtifactShareGrants({
+			share: {
+				grants: [
+					{
+						entityId: VIEWER,
+						mode: "redacted",
+						grantedBy: OWNER,
+						grantedAtMs: 123,
+					},
+				],
+			},
+		});
+		expect(grants).toEqual([
+			{
+				entityId: VIEWER,
+				mode: "redacted",
+				grantedBy: OWNER,
+				grantedAtMs: 123,
+			},
+		]);
+	});
+
+	it("drops malformed entries instead of granting anything", () => {
+		const grants = parseArtifactShareGrants({
+			share: {
+				grants: [
+					{ entityId: "not-a-uuid", mode: "full" },
+					{ entityId: VIEWER, mode: "everything" },
+					{ entityId: VIEWER },
+					"garbage",
+					null,
+					{ entityId: VIEWER, mode: "full" },
+				],
+			},
+		});
+		expect(grants).toEqual([{ entityId: VIEWER, mode: "full" }]);
+	});
+
+	it("returns empty for absent/malformed share metadata", () => {
+		expect(parseArtifactShareGrants(undefined)).toEqual([]);
+		expect(parseArtifactShareGrants({})).toEqual([]);
+		expect(parseArtifactShareGrants({ share: "nope" })).toEqual([]);
+		expect(parseArtifactShareGrants({ share: { grants: "nope" } })).toEqual([]);
+	});
+});

--- a/packages/core/src/access-control/artifact-disclosure.ts
+++ b/packages/core/src/access-control/artifact-disclosure.ts
@@ -1,0 +1,127 @@
+/**
+ * Role-aware artifact disclosure decision for shared artifacts (transcripts,
+ * stored files, chat attachments, meeting sessions) — the read-side selector
+ * behind #14781, designed inside the #8876 attachments doctrine: bytes stay on
+ * the pre-auth content-addressed store (the sha256 URL is the capability), so
+ * "permission" here means URL/DTO disclosure on the REFERENCING record, never
+ * a byte-serve gate. Redacted variants are separate records/media objects; this
+ * module only decides which variant a viewer's DTO may reference.
+ *
+ * One decision, three outcomes: `full` (emit the artifact as stored),
+ * `redacted` (emit the redacted-variant fields, flagged), `none` (omit the row
+ * entirely). Every disclosure surface routes through this single function so
+ * the role matrix — OWNER/ADMIN/agent-self full; USER grant-driven; ungranted
+ * viewers fall back to the scope ladder (which fails closed on the
+ * `owner-private` default) — cannot drift per surface.
+ *
+ * Grants ride additively on the referencing record's metadata
+ * (`metadata.share.grants`, jsonb — no migration, no sha256-keyed table per
+ * doctrine AD1). The grant WRITE path (share actions, room-snapshot capture)
+ * belongs to the PERM-ACL/PERM-REDACT children of #14749; this module only
+ * evaluates what is stored. Default-matrix ratification is tracked in #14777 —
+ * revisit the ordering below if D4/D5 land differently.
+ */
+import type { AccessContext, MemoryScope, UUID } from "../types";
+import { actorFromAccessContext, canReadScope } from "./filter";
+
+/** What a viewer's DTO may contain for one artifact. */
+export type ArtifactDisclosure = "full" | "redacted" | "none";
+
+/** Per-viewer grant mode an owner can attach to an artifact reference. */
+export type ArtifactShareGrantMode = "full" | "redacted";
+
+/** One per-entity share grant stored on the referencing record. */
+export interface ArtifactShareGrant {
+	/** Entity the grant is issued to. */
+	entityId: UUID;
+	mode: ArtifactShareGrantMode;
+	/** Entity that issued the grant. */
+	grantedBy?: UUID;
+	/** Epoch ms the grant was issued. */
+	grantedAtMs?: number;
+}
+
+const UUID_PATTERN =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Parse `metadata.share.grants` off an untyped stored record into typed
+ * grants. Malformed entries are dropped — a grant that cannot be read grants
+ * NOTHING (fail closed), it never degrades into some default access.
+ */
+// error-policy:J3 untrusted-input sanitizing — stored jsonb is untyped at rest;
+// invalid grant entries yield an explicit empty result, never a fake grant.
+export function parseArtifactShareGrants(
+	metadata: unknown,
+): ArtifactShareGrant[] {
+	if (!metadata || typeof metadata !== "object") return [];
+	const share = (metadata as { share?: unknown }).share;
+	if (!share || typeof share !== "object") return [];
+	const grants = (share as { grants?: unknown }).grants;
+	if (!Array.isArray(grants)) return [];
+	const out: ArtifactShareGrant[] = [];
+	for (const entry of grants) {
+		if (!entry || typeof entry !== "object") continue;
+		const g = entry as Record<string, unknown>;
+		const entityId = typeof g.entityId === "string" ? g.entityId : "";
+		const mode = g.mode;
+		if (!UUID_PATTERN.test(entityId)) continue;
+		if (mode !== "full" && mode !== "redacted") continue;
+		out.push({
+			entityId: entityId as UUID,
+			mode,
+			...(typeof g.grantedBy === "string" && UUID_PATTERN.test(g.grantedBy)
+				? { grantedBy: g.grantedBy as UUID }
+				: {}),
+			...(typeof g.grantedAtMs === "number"
+				? { grantedAtMs: g.grantedAtMs }
+				: {}),
+		});
+	}
+	return out;
+}
+
+/** The disclosure-relevant fields of one artifact-referencing record. */
+export interface ArtifactDisclosureRecord {
+	/** Stored visibility scope (callers normalize; unknown fails closed). */
+	scope: MemoryScope;
+	/** Entity the record is scoped to (owner/speaker), for entity-scoped tiers. */
+	scopedEntityId?: UUID;
+	/** Parsed share grants from the record's metadata. */
+	grants?: readonly ArtifactShareGrant[];
+}
+
+/**
+ * Decide what `ctx`'s requester may see of one artifact record.
+ *
+ * Tier order (most privileged first):
+ *  1. No access context → `full`. The single-owner local boundary deliberately
+ *     omits a context (see `RouteHandlerContext.accessContext`), and existing
+ *     unfiltered behavior there is a documented product decision.
+ *  2. Agent self-read, OWNER, or ADMIN rank → `full`.
+ *  3. An explicit per-entity grant wins in BOTH directions: a `full` grant
+ *     elevates past the scope ladder, and a `redacted` grant narrows the viewer
+ *     to the variant even when the scope ladder would allow full — the owner's
+ *     per-viewer instruction (e.g. an admin "redact for everyone" pass) must
+ *     not be undone by a coarse `global` scope.
+ *  4. No grant → the scope ladder (`canReadScope`): a USER still reads global
+ *     records and their own user-private records in full; the `owner-private`
+ *     default fails closed to `none`.
+ */
+export function resolveArtifactDisclosure(
+	record: ArtifactDisclosureRecord,
+	ctx: AccessContext | undefined,
+	agentId: UUID,
+): ArtifactDisclosure {
+	if (!ctx) return "full";
+	if (ctx.requesterEntityId === agentId) return "full";
+	const actor = actorFromAccessContext(ctx, agentId);
+	if (actor.role !== "USER") return "full";
+	const grant = record.grants?.find(
+		(g) => g.entityId === ctx.requesterEntityId,
+	);
+	if (grant) return grant.mode === "full" ? "full" : "redacted";
+	return canReadScope(record.scope, record.scopedEntityId, actor)
+		? "full"
+		: "none";
+}

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -7,6 +7,7 @@
  */
 
 export * from "./access-context";
+export * from "./access-control/artifact-disclosure";
 export * from "./access-control/filter";
 export * from "./account-pool-bridge";
 export * from "./action-names";

--- a/packages/core/src/index.edge.ts
+++ b/packages/core/src/index.edge.ts
@@ -9,6 +9,7 @@
  */
 
 export * from "./access-context";
+export * from "./access-control/artifact-disclosure";
 export * from "./access-control/filter";
 export * from "./account-pool-bridge";
 export * from "./action-names";

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -7,6 +7,7 @@
  */
 
 export * from "./access-context";
+export * from "./access-control/artifact-disclosure";
 export * from "./access-control/filter";
 // Export all core modules
 export * from "./account-pool-bridge";

--- a/packages/core/src/types/primitives.ts
+++ b/packages/core/src/types/primitives.ts
@@ -304,6 +304,16 @@ export interface Media {
 	 * its presence means the bytes are stored + served but not machine-readable.
 	 */
 	notProcessed?: string;
+
+	/**
+	 * Served URL of this attachment's PII-scrubbed variant — a SEPARATE
+	 * content-addressed media object under its own sha256 (#14781; per #8876
+	 * redacted variants are new bytes, never an edit of the original). When a
+	 * viewer's disclosure resolves to `redacted`, the DTO layer emits this URL
+	 * in place of `url` and withholds the original. Never a file id — the URL
+	 * itself is the reference the media GC scans.
+	 */
+	redactedUrl?: string;
 }
 
 export const ContentType = {

--- a/packages/shared/src/meetings.ts
+++ b/packages/shared/src/meetings.ts
@@ -128,6 +128,13 @@ export interface MeetingSession {
   roomId?: string;
   /** The live/final Transcript record id (source "meeting"). */
   transcriptId?: string;
+  /**
+   * Present (true) on a served session DTO when the viewer's transcript
+   * disclosure resolved to the redacted variant (#14781): `transcriptId` stays
+   * usable (the transcripts API serves that viewer the variant under the same
+   * id) and the client renders a redacted badge. Never stored.
+   */
+  transcriptRedacted?: true;
   participants: MeetingParticipant[];
   calendarEventId?: string;
   /** Maximum duration approved for this session, in milliseconds. */

--- a/packages/shared/src/transcripts.ts
+++ b/packages/shared/src/transcripts.ts
@@ -98,6 +98,14 @@ export interface Transcript {
   /** Distinct speaker count across segments. */
   speakerCount: number;
   metadata?: Record<string, unknown>;
+  /**
+   * Present (true) only on a served DTO whose content is the PII-scrubbed
+   * variant of the artifact, selected for a redacted-grant viewer (#14781).
+   * A redacted serve always withholds `audioUrl` (audio is never redacted in
+   * v1). Never stored — stored records link variants via
+   * `metadata.redactionOf` / row `metadata.redactedVariantId` instead.
+   */
+  redacted?: true;
 }
 
 /**
@@ -214,6 +222,8 @@ export interface TranscriptSummary {
   hasAudio: boolean;
   /** Server-computed meeting fields; present only for `source: "meeting"`. */
   meeting?: TranscriptSummaryMeetingMeta;
+  /** Present (true) when this row's preview is served from the redacted variant (#14781). */
+  redacted?: true;
 }
 
 /** Default characters of transcript text kept for a list-row preview. */

--- a/packages/ui/src/api/client-files.ts
+++ b/packages/ui/src/api/client-files.ts
@@ -5,7 +5,10 @@
  * `client-*` domain modules.
  *
  * Backend contract (already implemented on the agent server):
- *  - `GET /api/files` → `{ files: StoredFile[] }` (newest first; authenticated).
+ *  - `GET /api/files` → `{ files: StoredFile[], restricted: boolean }`
+ *    (newest first; authenticated; `restricted: true` means the viewer's role
+ *    cannot see the store listing — a designed state, not an empty store,
+ *    #14781. Optional in the client type for older backends that predate it.)
  *  - `DELETE /api/files/:filename` → `{ deleted: boolean }` (authenticated).
  */
 
@@ -29,7 +32,7 @@ export interface StoredFile {
 
 declare module "./client-base" {
   interface ElizaClient {
-    listFiles(): Promise<{ files: StoredFile[] }>;
+    listFiles(): Promise<{ files: StoredFile[]; restricted?: boolean }>;
     deleteFile(fileName: string): Promise<{ deleted: boolean }>;
   }
 }

--- a/packages/ui/src/api/client-types-chat.ts
+++ b/packages/ui/src/api/client-types-chat.ts
@@ -141,6 +141,12 @@ export interface MessageAttachment {
    * never silently indistinguishable from a genuinely empty one.
    */
   notProcessed?: string;
+  /**
+   * Present (true) when `url` is the server-selected PII-scrubbed variant of
+   * the original attachment (#14781). Display-only: the server decides
+   * redaction; the tile renders a redacted badge.
+   */
+  redacted?: true;
 }
 
 export interface ConversationMessageReaction {

--- a/packages/ui/src/components/RedactedBadge.tsx
+++ b/packages/ui/src/components/RedactedBadge.tsx
@@ -1,0 +1,32 @@
+/**
+ * Badge marking content served as a PII-scrubbed (redacted) variant (#14781).
+ * The server decides redaction and stamps `redacted: true` on the DTO
+ * (transcript summaries/records, chat attachments, meeting sessions); this
+ * badge only displays that flag — the client never scrubs or derives
+ * redaction itself. Kept as one shared component so every surface renders the
+ * same, recognizable marker.
+ */
+
+import { EyeOff } from "lucide-react";
+import { cn } from "../lib/utils";
+
+export function RedactedBadge({
+  className,
+  testId = "redacted-badge",
+}: {
+  className?: string;
+  testId?: string;
+}): React.JSX.Element {
+  return (
+    <span
+      data-testid={testId}
+      className={cn(
+        "inline-flex shrink-0 items-center gap-1 rounded-sm border border-border px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted",
+        className,
+      )}
+    >
+      <EyeOff className="h-3 w-3" aria-hidden />
+      Redacted
+    </span>
+  );
+}

--- a/packages/ui/src/components/chat/MessageAttachments.tsx
+++ b/packages/ui/src/components/chat/MessageAttachments.tsx
@@ -33,6 +33,7 @@ import { cn } from "../../lib/utils";
 import { useTranslation } from "../../state/TranslationContext.hooks";
 import { resolveApiUrl } from "../../utils/asset-url";
 import { isSafeAttachmentUrl } from "../../utils/attachment-url";
+import { RedactedBadge } from "../RedactedBadge";
 import { Button } from "../ui/button";
 import { CodeBlock } from "../ui/code-block";
 import { TranscriptViewerOverlay } from "./TranscriptViewerOverlay";
@@ -1031,13 +1032,23 @@ export function MessageAttachments({
       {attachments.map((att) => {
         // A stored-but-unreadable attachment shows its tile PLUS a "Not
         // processed: <reason>" notice so the failed enrichment is visible on
-        // reload, never silently missing text.
+        // reload, never silently missing text. A server-redacted attachment
+        // (#14781) shows the shared redacted badge above its tile — the flag
+        // is server-stamped; the client only displays it.
         const notProcessed = att.notProcessed?.trim();
         const withNotice = (tile: React.ReactNode): React.ReactNode =>
-          notProcessed ? (
+          notProcessed || att.redacted ? (
             <div key={att.id} className="flex flex-col gap-1">
+              {att.redacted ? (
+                <RedactedBadge
+                  className="self-start"
+                  testId={`attachment-redacted-${att.id}`}
+                />
+              ) : null}
               {tile}
-              <NotProcessedNotice reason={notProcessed} />
+              {notProcessed ? (
+                <NotProcessedNotice reason={notProcessed} />
+              ) : null}
             </div>
           ) : (
             tile

--- a/packages/ui/src/components/pages/FilesView.test.tsx
+++ b/packages/ui/src/components/pages/FilesView.test.tsx
@@ -3,8 +3,11 @@
 // Renders the real FilesView against a mocked `../../api` client to cover the
 // stored-file grid: per-file rows with kind facets, facet filtering, and the
 // download/share hand-off (with the Share control hidden when unsupported).
-// jsdom; the api client and the download/share helper are stubbed.
+// jsdom; the api client and the download/share helper are stubbed. Renders
+// wrap in RoleProvider (OWNER by default) because the delete affordance is
+// role-gated (#14781).
 
+import type { RoleGateRole } from "@elizaos/core";
 import {
   cleanup,
   fireEvent,
@@ -15,7 +18,16 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { StoredFile } from "../../api";
+import { RoleProvider } from "../../hooks/useRole";
 import { FilesView } from "./FilesView";
+
+function renderFiles(role: RoleGateRole = "OWNER") {
+  return render(
+    <RoleProvider role={role}>
+      <FilesView />
+    </RoleProvider>,
+  );
+}
 
 // FilesView talks to the runtime exclusively through the `client` singleton
 // re-exported from `../../api`. Mock that module — the real data seam.
@@ -79,7 +91,7 @@ afterEach(() => {
 
 describe("FilesView", () => {
   it("renders a row per stored file with kind facets and metadata", async () => {
-    render(<FilesView />);
+    renderFiles();
 
     expect(await screen.findByText("photo.png")).toBeTruthy();
     expect(screen.getByText("report.pdf")).toBeTruthy();
@@ -96,7 +108,7 @@ describe("FilesView", () => {
   });
 
   it("filters the grid by the selected type facet", async () => {
-    render(<FilesView />);
+    renderFiles();
     await screen.findByText("photo.png");
 
     fireEvent.click(screen.getByTestId("file-facet-document"));
@@ -117,7 +129,7 @@ describe("FilesView", () => {
   });
 
   it("downloads a file through the helper with its url + filename", async () => {
-    render(<FilesView />);
+    renderFiles();
     await screen.findByText("photo.png");
 
     const imageCard = screen
@@ -138,7 +150,7 @@ describe("FilesView", () => {
   });
 
   it("shares a file through the helper", async () => {
-    render(<FilesView />);
+    renderFiles();
     await screen.findByText("photo.png");
 
     const imageCard = screen
@@ -157,7 +169,7 @@ describe("FilesView", () => {
 
   it("hides the Share control when sharing is unsupported", async () => {
     downloadShareMock.canShareFiles.mockReturnValue(false);
-    render(<FilesView />);
+    renderFiles();
     await screen.findByText("photo.png");
 
     expect(screen.queryByTestId("file-share")).toBeNull();
@@ -165,7 +177,7 @@ describe("FilesView", () => {
   });
 
   it("deletes a file via the client and optimistically removes the row", async () => {
-    render(<FilesView />);
+    renderFiles();
     await screen.findByText("report.pdf");
 
     const pdfCard = screen
@@ -188,7 +200,7 @@ describe("FilesView", () => {
 
   it("does not delete when the confirm is declined", async () => {
     vi.spyOn(window, "confirm").mockReturnValue(false);
-    render(<FilesView />);
+    renderFiles();
     await screen.findByText("report.pdf");
 
     const pdfCard = screen
@@ -202,7 +214,7 @@ describe("FilesView", () => {
 
   it("restores the row when the delete fails", async () => {
     clientMock.deleteFile.mockResolvedValue({ deleted: false });
-    render(<FilesView />);
+    renderFiles();
     await screen.findByText("report.pdf");
 
     const pdfCard = screen
@@ -222,7 +234,7 @@ describe("FilesView", () => {
 
   it("shows the empty state when there are no files", async () => {
     clientMock.listFiles.mockResolvedValue({ files: [] });
-    render(<FilesView />);
+    renderFiles();
 
     await waitFor(() => {
       expect(screen.getByTestId("files-empty")).toBeTruthy();
@@ -231,11 +243,32 @@ describe("FilesView", () => {
 
   it("surfaces an error when the list request fails", async () => {
     clientMock.listFiles.mockRejectedValue(new Error("boom"));
-    render(<FilesView />);
+    renderFiles();
 
     await waitFor(() => {
       expect(screen.getByRole("alert")).toBeTruthy();
     });
     expect(screen.getByRole("alert").textContent).toContain("boom");
+  });
+
+  it("renders the designed restricted state (not empty, not error) for a restricted viewer (#14781)", async () => {
+    clientMock.listFiles.mockResolvedValue({ files: [], restricted: true });
+    renderFiles("USER");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("files-restricted")).toBeTruthy();
+    });
+    // Three-state rule: restricted is its own render — no healthy-empty, no error.
+    expect(screen.queryByTestId("files-empty")).toBeNull();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("hides the delete affordance below ADMIN rank (#14781)", async () => {
+    renderFiles("USER");
+    await screen.findByText("photo.png");
+
+    expect(screen.queryAllByTestId("file-delete")).toHaveLength(0);
+    // Non-destructive affordances stay available.
+    expect(screen.getAllByTestId("file-download").length).toBeGreaterThan(0);
   });
 });

--- a/packages/ui/src/components/pages/FilesView.tsx
+++ b/packages/ui/src/components/pages/FilesView.tsx
@@ -21,6 +21,7 @@ import {
   FolderOpen,
   ImageIcon,
   Loader2,
+  Lock,
   Share2,
   Trash2,
 } from "lucide-react";
@@ -41,6 +42,7 @@ import {
   shareAttachment,
 } from "../../utils/download-share";
 import { PagePanel } from "../composites/page-panel";
+import { RoleGate } from "../RoleGate";
 import { Button } from "../ui/button";
 import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
 
@@ -308,28 +310,33 @@ const FileCard = memo(function FileCard({
             onShare={onShare}
           />
         ) : null}
-        <Button
-          ref={deleteControl.ref}
-          {...deleteControl.agentProps}
-          type="button"
-          variant="surfaceDestructive"
-          size="sm"
-          className="ml-auto"
-          data-testid="file-delete"
-          disabled={deleting}
-          aria-label={t("filesview.deleteFile", {
-            name: file.fileName,
-            defaultValue: "Delete {{name}}",
-          })}
-          onClick={() => onDelete(file)}
-        >
-          {deleting ? (
-            <Loader2 className="mr-1.5 h-4 w-4 animate-spin" aria-hidden />
-          ) : (
-            <Trash2 className="mr-1.5 h-4 w-4" aria-hidden />
-          )}
-          {t("filesview.delete", { defaultValue: "Delete" })}
-        </Button>
+        {/* Store-wide destructive affordance: ADMIN+ only (#14781). The API
+            enforces the same tier server-side; the gate keeps lower-tier
+            viewers from seeing a control that can only fail. */}
+        <RoleGate minRole="ADMIN">
+          <Button
+            ref={deleteControl.ref}
+            {...deleteControl.agentProps}
+            type="button"
+            variant="surfaceDestructive"
+            size="sm"
+            className="ml-auto"
+            data-testid="file-delete"
+            disabled={deleting}
+            aria-label={t("filesview.deleteFile", {
+              name: file.fileName,
+              defaultValue: "Delete {{name}}",
+            })}
+            onClick={() => onDelete(file)}
+          >
+            {deleting ? (
+              <Loader2 className="mr-1.5 h-4 w-4 animate-spin" aria-hidden />
+            ) : (
+              <Trash2 className="mr-1.5 h-4 w-4" aria-hidden />
+            )}
+            {t("filesview.delete", { defaultValue: "Delete" })}
+          </Button>
+        </RoleGate>
       </div>
     </li>
   );
@@ -348,6 +355,7 @@ export function FilesView() {
 function FilesViewBody() {
   const { t } = useTranslation();
   const [files, setFiles] = useState<StoredFile[]>([]);
+  const [restricted, setRestricted] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [facet, setFacet] = useState<FileFacet>("all");
@@ -373,8 +381,12 @@ function FilesViewBody() {
     setLoading(true);
     setError("");
     try {
-      const { files: list } = await client.listFiles();
+      const { files: list, restricted: restrictedFlag } =
+        await client.listFiles();
       setFiles(Array.isArray(list) ? list : []);
+      // Server-computed viewer-tier flag (#14781): restricted is a designed
+      // state distinct from an owner's empty store; the view only displays it.
+      setRestricted(restrictedFlag === true);
     } catch (err) {
       setError(
         t("filesview.loadFailed", {
@@ -548,6 +560,20 @@ function FilesViewBody() {
           >
             <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
             {t("filesview.loading", { defaultValue: "Loading files…" })}
+          </div>
+        ) : restricted ? (
+          <div className="flex flex-1 flex-col" data-testid="files-restricted">
+            <PagePanel.Empty
+              className="flex-1"
+              icon={<Lock className="h-6 w-6" aria-hidden />}
+              title={t("filesview.restrictedTitle", {
+                defaultValue: "Files are restricted",
+              })}
+              description={t("filesview.restrictedDescription", {
+                defaultValue:
+                  "Your role can't browse the file store. Shared items appear in their own views.",
+              })}
+            />
           </div>
         ) : files.length === 0 ? (
           <div className="flex flex-1 flex-col" data-testid="files-empty">

--- a/packages/ui/src/components/transcripts/TranscriptsView.tsx
+++ b/packages/ui/src/components/transcripts/TranscriptsView.tsx
@@ -32,6 +32,7 @@ import type * as React from "react";
 import { useAgentElement } from "../../agent-surface";
 import { cn } from "../../lib/utils";
 import { PagePanel } from "../composites/page-panel";
+import { RedactedBadge } from "../RedactedBadge";
 import { Button } from "../ui/button";
 import { ShellViewAgentSurface } from "../views/ShellViewAgentSurface";
 import { LiveMeetingPane } from "./LiveMeetingPane";
@@ -210,6 +211,9 @@ function TranscriptRow({
     >
       <div className="flex items-center gap-2">
         <span className="min-w-0 truncate font-medium">{summary.title}</span>
+        {summary.redacted ? (
+          <RedactedBadge testId={`transcript-redacted-${summary.id}`} />
+        ) : null}
         {isLive ? (
           <LiveIndicator testId={`transcript-live-${summary.id}`} />
         ) : null}
@@ -483,6 +487,9 @@ export function TranscriptsView({
                   <h2 className="text-base font-semibold text-txt">
                     {selected.title}
                   </h2>
+                  {selected.redacted ? (
+                    <RedactedBadge testId="transcript-detail-redacted" />
+                  ) : null}
                   {selectedIsLiveMeeting ? (
                     <LiveIndicator testId="meeting-detail-live" />
                   ) : null}

--- a/plugins/plugin-local-inference/src/routes/transcripts-routes.test.ts
+++ b/plugins/plugin-local-inference/src/routes/transcripts-routes.test.ts
@@ -91,6 +91,12 @@ const access = (requesterEntityId: UUID): AccessContext => ({
 	role: "USER",
 });
 
+const adminAccess = (requesterEntityId: UUID): AccessContext => ({
+	requesterEntityId,
+	worldId: WORLD,
+	role: "ADMIN",
+});
+
 describe("buildTranscriptFromRequest", () => {
 	it("derives duration + speaker count + defaults", () => {
 		const body: CreateTranscriptRequest = {
@@ -367,5 +373,189 @@ describe("transcripts routes", () => {
 			}),
 		);
 		expect(hidden.status).toBe(404);
+	});
+
+	it("selects full / redacted-variant / none per viewer role through the real GET routes (#14781)", async () => {
+		const { rows, runtime } = fakeRuntime();
+		const post = handlerFor("POST", "/api/transcripts");
+		const list = handlerFor("GET", "/api/transcripts");
+		const get = handlerFor("GET", "/api/transcripts/:id");
+
+		// Original owner-private transcript with PII in the text.
+		const original = await post(
+			ctx({
+				runtime: runtime as never,
+				body: {
+					title: "Payroll",
+					roomId: ROOM,
+					entityId: ENTITY,
+					scope: "owner-private",
+					segments: [
+						{
+							id: "s1",
+							speakerLabel: "Alice",
+							startMs: 0,
+							endMs: 1000,
+							text: "Bob SSN 123-45-6789",
+							words: [],
+						},
+					],
+				},
+			}),
+		);
+		const originalId = (original.body as { transcript: { id: string } })
+			.transcript.id;
+
+		// Redacted variant transcript (its own row); linked from the original.
+		const variant = await post(
+			ctx({
+				runtime: runtime as never,
+				body: {
+					title: "Payroll (redacted)",
+					roomId: ROOM,
+					entityId: ENTITY,
+					scope: "owner-private",
+					segments: [
+						{
+							id: "s1",
+							speakerLabel: "Alice",
+							startMs: 0,
+							endMs: 1000,
+							text: "Bob SSN [REDACTED]",
+							words: [],
+						},
+					],
+				},
+			}),
+		);
+		const variantId = (variant.body as { transcript: { id: string } })
+			.transcript.id;
+
+		// Read contract this issue owns (write path is PERM-REDACT #14779):
+		// original -> variant link + a redacted grant for VIEWER; variant ->
+		// original backlink so it never lists standalone.
+		const VIEWER = "44444444-4444-4444-4444-444444444444" as UUID;
+		const originalRow = rows.get(originalId);
+		if (!originalRow) throw new Error("original row missing");
+		rows.set(originalId, {
+			...originalRow,
+			metadata: {
+				...(originalRow.metadata as Record<string, unknown>),
+				redactedVariantId: variantId,
+				share: { grants: [{ entityId: VIEWER, mode: "redacted" }] },
+			},
+		});
+		const variantRow = rows.get(variantId);
+		if (!variantRow) throw new Error("variant row missing");
+		rows.set(variantId, {
+			...variantRow,
+			metadata: {
+				...(variantRow.metadata as Record<string, unknown>),
+				redactionOf: originalId,
+			},
+		});
+
+		// OWNER boundary (no context): full original, no flag.
+		const ownerGet = await get(
+			ctx({ runtime: runtime as never, params: { id: originalId } }),
+		);
+		expect(ownerGet.status).toBe(200);
+		const ownerT = (
+			ownerGet.body as {
+				transcript: { segments: Array<{ text: string }>; redacted?: true };
+			}
+		).transcript;
+		expect(ownerT.segments[0].text).toContain("123-45-6789");
+		expect(ownerT.redacted).toBeUndefined();
+
+		// ADMIN rank: full original.
+		const adminGet = await get(
+			ctx({
+				runtime: runtime as never,
+				params: { id: originalId },
+				accessContext: adminAccess(VIEWER),
+			}),
+		);
+		const adminT = (
+			adminGet.body as {
+				transcript: { redacted?: true; segments: Array<{ text: string }> };
+			}
+		).transcript;
+		expect(adminT.redacted).toBeUndefined();
+		expect(adminT.segments[0].text).toContain("123-45-6789");
+
+		// USER with the redacted grant: variant under the original id, flagged,
+		// audio + PII withheld.
+		const userGet = await get(
+			ctx({
+				runtime: runtime as never,
+				params: { id: originalId },
+				accessContext: access(VIEWER),
+			}),
+		);
+		expect(userGet.status).toBe(200);
+		const userT = (
+			userGet.body as {
+				transcript: {
+					id: string;
+					redacted?: true;
+					audioUrl?: string;
+					segments: Array<{ text: string }>;
+				};
+			}
+		).transcript;
+		expect(userT.id).toBe(originalId);
+		expect(userT.redacted).toBe(true);
+		expect(userT.audioUrl).toBeUndefined();
+		expect(userT.segments[0].text).toBe("Bob SSN [REDACTED]");
+
+		// Ungranted USER: 404 (non-enumerable).
+		const strangerGet = await get(
+			ctx({
+				runtime: runtime as never,
+				params: { id: originalId },
+				accessContext: access(OTHER_ENTITY),
+			}),
+		);
+		expect(strangerGet.status).toBe(404);
+
+		// GUEST: 404.
+		const guestGet = await get(
+			ctx({
+				runtime: runtime as never,
+				params: { id: originalId },
+				accessContext: {
+					requesterEntityId: OTHER_ENTITY,
+					worldId: WORLD,
+					role: "GUEST",
+				},
+			}),
+		);
+		expect(guestGet.status).toBe(404);
+
+		// List: VIEWER sees exactly one row (the original id, redacted-flagged);
+		// the variant row never lists standalone.
+		const userList = await list(
+			ctx({ runtime: runtime as never, accessContext: access(VIEWER) }),
+		);
+		const userRows = (
+			userList.body as {
+				transcripts: Array<{ id: string; redacted?: true; hasAudio: boolean }>;
+			}
+		).transcripts;
+		expect(userRows).toHaveLength(1);
+		expect(userRows[0]).toMatchObject({
+			id: originalId,
+			redacted: true,
+			hasAudio: false,
+		});
+
+		// Ungranted stranger: empty list.
+		const strangerList = await list(
+			ctx({ runtime: runtime as never, accessContext: access(OTHER_ENTITY) }),
+		);
+		expect(
+			(strangerList.body as { transcripts: unknown[] }).transcripts,
+		).toEqual([]);
 	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/transcript-store.test.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcript-store.test.ts
@@ -187,4 +187,185 @@ describe("TranscriptStore", () => {
 	it("exposes the partition name", () => {
 		expect(TRANSCRIPTS_TABLE).toBe("transcripts");
 	});
+
+	describe("per-viewer disclosure selection (#14781)", () => {
+		const VIEWER = "44444444-4444-4444-4444-444444444444" as UUID;
+		const STRANGER = "55555555-5555-5555-5555-555555555555" as UUID;
+		const ORIGINAL_ID = "00000000-0000-0000-0000-00000000or11";
+		const VARIANT_ID = "00000000-0000-0000-0000-00000000va22";
+
+		/** Original (owner-private, with audio) + linked redacted variant. */
+		async function seed(rt: ReturnType<typeof fakeRuntime>) {
+			const store = new TranscriptStore(rt);
+			const original = makeTranscript({
+				id: ORIGINAL_ID,
+				title: "Payroll sync",
+				createdAt: 1000,
+				segments: [
+					{
+						id: "s1",
+						speakerLabel: "Alice",
+						startMs: 0,
+						endMs: 2000,
+						text: "Bob's SSN is 123-45-6789",
+						words: [],
+					},
+				],
+			});
+			const variant = makeTranscript({
+				id: VARIANT_ID,
+				title: "Payroll sync (redacted)",
+				createdAt: 1500,
+				audioUrl: undefined,
+				segments: [
+					{
+						id: "s1",
+						speakerLabel: "Alice",
+						startMs: 0,
+						endMs: 2000,
+						text: "Bob's SSN is [REDACTED]",
+						words: [],
+					},
+				],
+			});
+			await store.create({
+				roomId: ROOM,
+				entityId: ENTITY,
+				transcript: original,
+			});
+			await store.create({
+				roomId: ROOM,
+				entityId: ENTITY,
+				transcript: variant,
+			});
+			// Read contract this issue owns; the write path is PERM-REDACT's
+			// (#14779): original links its variant, variant backlinks its original,
+			// and the redacted grant for VIEWER sits on the original's row.
+			const originalRow = rt.rows.get(ORIGINAL_ID) as Memory;
+			rt.rows.set(ORIGINAL_ID, {
+				...originalRow,
+				metadata: {
+					...(originalRow.metadata as Record<string, unknown>),
+					redactedVariantId: VARIANT_ID,
+					share: { grants: [{ entityId: VIEWER, mode: "redacted" }] },
+				} as Memory["metadata"],
+			});
+			const variantRow = rt.rows.get(VARIANT_ID) as Memory;
+			rt.rows.set(VARIANT_ID, {
+				...variantRow,
+				metadata: {
+					...(variantRow.metadata as Record<string, unknown>),
+					redactionOf: ORIGINAL_ID,
+				} as Memory["metadata"],
+			});
+			return { store, original, variant };
+		}
+
+		it("OWNER boundary (no context) and ADMIN rank see the full original", async () => {
+			const rt = fakeRuntime();
+			const { store, original } = await seed(rt);
+
+			// No access context: single-owner boundary, full record.
+			expect(await store.get(ORIGINAL_ID as UUID)).toEqual(original);
+
+			// ADMIN rank context: full record with audio.
+			const admin = { requesterEntityId: STRANGER, role: "ADMIN" as const };
+			const got = await store.get(ORIGINAL_ID as UUID, admin);
+			expect(got).toEqual(original);
+			const list = await store.list(ROOM, 100, admin);
+			expect(list).toHaveLength(1);
+			expect(list[0]).toMatchObject({ id: ORIGINAL_ID, hasAudio: true });
+			expect(list[0].redacted).toBeUndefined();
+		});
+
+		it("USER with a redacted grant gets the variant under the ORIGINAL id, flagged, audio withheld", async () => {
+			const rt = fakeRuntime();
+			const { store } = await seed(rt);
+			const viewer = { requesterEntityId: VIEWER, role: "USER" as const };
+
+			const got = await store.get(ORIGINAL_ID as UUID, viewer);
+			expect(got).not.toBeNull();
+			expect(got?.id).toBe(ORIGINAL_ID);
+			expect(got?.redacted).toBe(true);
+			expect(got?.audioUrl).toBeUndefined();
+			expect(got?.audioContentType).toBeUndefined();
+			expect(got?.segments[0]?.text).toBe("Bob's SSN is [REDACTED]");
+			expect(got?.title).toBe("Payroll sync (redacted)");
+			// Identity comes from the original, content from the variant.
+			expect(got?.createdAt).toBe(1000);
+
+			const list = await store.list(ROOM, 100, viewer);
+			expect(list).toHaveLength(1);
+			expect(list[0]).toMatchObject({
+				id: ORIGINAL_ID,
+				redacted: true,
+				hasAudio: false,
+			});
+			expect(list[0].preview).toContain("[REDACTED]");
+			expect(list[0].preview).not.toContain("123-45-6789");
+		});
+
+		it("USER with a full grant sees the original in full", async () => {
+			const rt = fakeRuntime();
+			const { store, original } = await seed(rt);
+			const originalRow = rt.rows.get(ORIGINAL_ID) as Memory;
+			rt.rows.set(ORIGINAL_ID, {
+				...originalRow,
+				metadata: {
+					...(originalRow.metadata as Record<string, unknown>),
+					share: { grants: [{ entityId: VIEWER, mode: "full" }] },
+				} as Memory["metadata"],
+			});
+			const viewer = { requesterEntityId: VIEWER, role: "USER" as const };
+			expect(await store.get(ORIGINAL_ID as UUID, viewer)).toEqual(original);
+		});
+
+		it("ungranted USER and GUEST see nothing: omitted from list, null on get", async () => {
+			const rt = fakeRuntime();
+			const { store } = await seed(rt);
+			for (const role of ["USER", "GUEST"] as const) {
+				const ctx = { requesterEntityId: STRANGER, role };
+				expect(await store.get(ORIGINAL_ID as UUID, ctx)).toBeNull();
+				expect(await store.get(VARIANT_ID as UUID, ctx)).toBeNull();
+				expect(await store.list(ROOM, 100, ctx)).toEqual([]);
+			}
+		});
+
+		it("variant rows never appear as standalone list rows", async () => {
+			const rt = fakeRuntime();
+			const { store } = await seed(rt);
+			const list = await store.list(ROOM);
+			expect(list.map((s) => s.id)).toEqual([ORIGINAL_ID]);
+		});
+
+		it("a redacted grant with a missing variant discloses NOTHING (fail closed)", async () => {
+			const rt = fakeRuntime();
+			const { store } = await seed(rt);
+			rt.rows.delete(VARIANT_ID);
+			const viewer = { requesterEntityId: VIEWER, role: "USER" as const };
+			expect(await store.get(ORIGINAL_ID as UUID, viewer)).toBeNull();
+			expect(await store.list(ROOM, 100, viewer)).toEqual([]);
+		});
+
+		it("share grants and variant links survive a text edit (update preserves metadata)", async () => {
+			const rt = fakeRuntime();
+			const { store, original } = await seed(rt);
+			await store.update({
+				...original,
+				title: "Payroll sync (edited)",
+				editedAt: 9000,
+			});
+			const row = rt.rows.get(ORIGINAL_ID) as Memory;
+			const meta = row.metadata as Record<string, unknown>;
+			expect(meta.redactedVariantId).toBe(VARIANT_ID);
+			expect(meta.share).toEqual({
+				grants: [{ entityId: VIEWER, mode: "redacted" }],
+			});
+			// The redacted-grant viewer still gets the variant after the edit.
+			const viewer = { requesterEntityId: VIEWER, role: "USER" as const };
+			expect((await store.get(ORIGINAL_ID as UUID, viewer))?.redacted).toBe(
+				true,
+			);
+		});
+	});
 });

--- a/plugins/plugin-local-inference/src/services/voice/transcript-store.ts
+++ b/plugins/plugin-local-inference/src/services/voice/transcript-store.ts
@@ -13,10 +13,12 @@
 
 import {
 	type AccessContext,
-	actorFromAccessContext,
-	canReadScope,
+	type ArtifactDisclosure,
+	type JsonObject,
 	type Memory,
 	type MemoryMetadata,
+	parseArtifactShareGrants,
+	resolveArtifactDisclosure,
 	type UUID,
 } from "@elizaos/core";
 import type {
@@ -77,39 +79,77 @@ function rowToTranscript(row: Memory): Transcript | null {
 	}
 }
 
-export function canAccessTranscriptRecord(
-	transcript: Pick<Transcript, "scope">,
-	scopedEntityId: UUID | undefined,
-	accessContext: AccessContext | undefined,
-	agentId: UUID,
-): boolean {
-	if (!accessContext) return true;
-	if (accessContext.requesterEntityId === agentId) return true;
-	const actor = actorFromAccessContext(accessContext, agentId);
-	if (actor.role === "OWNER") return true;
-	return canReadScope(
-		normalizeTranscriptScope(transcript.scope),
-		scopedEntityId,
-		actor,
-	);
-}
-
-function canAccessTranscriptRow(
+/**
+ * The viewer's disclosure decision for one transcript row — the ONE role-aware
+ * predicate from core (#14781) fed with this store's row shape: scope from the
+ * stored record (fail-closed normalize), owning entity from
+ * `metadata.scopedToEntityId` (else the row's entity), and share grants from
+ * `metadata.share.grants`.
+ */
+export function transcriptRowDisclosure(
 	row: Memory,
 	transcript: Pick<Transcript, "scope">,
 	accessContext: AccessContext | undefined,
 	agentId: UUID,
-): boolean {
+): ArtifactDisclosure {
 	const metadata = row.metadata as Record<string, unknown> | undefined;
 	const scopedTo = metadata?.scopedToEntityId;
 	const scopedEntityId =
 		typeof scopedTo === "string" ? (scopedTo as UUID) : row.entityId;
-	return canAccessTranscriptRecord(
-		transcript,
-		scopedEntityId,
+	return resolveArtifactDisclosure(
+		{
+			scope: normalizeTranscriptScope(transcript.scope),
+			scopedEntityId,
+			grants: parseArtifactShareGrants(metadata),
+		},
 		accessContext,
 		agentId,
 	);
+}
+
+/**
+ * Whether this row stores a redacted VARIANT of another transcript (write
+ * contract for PERM-REDACT #14779): the variant row's metadata carries
+ * `redactionOf: <original id>`. Variants never appear as standalone list rows —
+ * they are served only in place of their original for redacted-grant viewers.
+ */
+function redactionOriginalId(row: Memory): UUID | null {
+	const metadata = row.metadata as Record<string, unknown> | undefined;
+	const of = metadata?.redactionOf;
+	return typeof of === "string" && of.length > 0 ? (of as UUID) : null;
+}
+
+/** The original row's link to its redacted variant record, when one exists. */
+function redactedVariantId(row: Memory): UUID | null {
+	const metadata = row.metadata as Record<string, unknown> | undefined;
+	const id = metadata?.redactedVariantId;
+	return typeof id === "string" && id.length > 0 ? (id as UUID) : null;
+}
+
+/**
+ * Project a redacted variant's content onto the ORIGINAL artifact's identity
+ * for a redacted-grant viewer: one artifact keeps one id for every viewer,
+ * with per-viewer content. Audio is always withheld (never redacted in v1),
+ * and every content field (title, segments, knowledge mirror id, metadata)
+ * comes from the variant so nothing of the original can leak through.
+ */
+function serveRedactedVariant(
+	variant: Transcript,
+	original: Pick<Transcript, "id" | "createdAt" | "endedAt" | "source">,
+): Transcript {
+	const {
+		audioUrl: _audioUrl,
+		audioContentType: _audioContentType,
+		...variantFields
+	} = variant;
+	return {
+		...variantFields,
+		id: original.id,
+		createdAt: original.createdAt,
+		...(original.endedAt !== undefined ? { endedAt: original.endedAt } : {}),
+		source: original.source,
+		redacted: true,
+	};
 }
 
 /** CRUD for transcript records over the runtime memory partition. */
@@ -150,7 +190,12 @@ export class TranscriptStore {
 		return transcript;
 	}
 
-	/** List recent transcripts (newest first) as compact summaries. */
+	/**
+	 * List recent transcripts (newest first) as compact summaries, selected per
+	 * viewer (#14781): full rows for privileged viewers, the redacted variant's
+	 * preview (flagged, audio withheld) for redacted-grant viewers, nothing for
+	 * viewers with no disclosure. Variant rows themselves never list.
+	 */
 	async list(
 		roomId?: UUID,
 		limit = 100,
@@ -166,17 +211,39 @@ export class TranscriptStore {
 		const summaries: TranscriptSummary[] = [];
 		for (const row of rows) {
 			const t = rowToTranscript(row);
-			if (
-				t &&
-				canAccessTranscriptRow(row, t, accessContext, this.runtime.agentId)
-			) {
+			if (!t || redactionOriginalId(row) !== null) continue;
+			const disclosure = transcriptRowDisclosure(
+				row,
+				t,
+				accessContext,
+				this.runtime.agentId,
+			);
+			if (disclosure === "full") {
 				summaries.push(summarizeTranscript(t));
+			} else if (disclosure === "redacted") {
+				const variant = await this.loadRedactedVariant(row);
+				// A redacted grant with no readable variant discloses NOTHING —
+				// omitting the row is the fail-closed branch, never the original.
+				if (variant) {
+					summaries.push({
+						...summarizeTranscript(serveRedactedVariant(variant, t)),
+						hasAudio: false,
+						redacted: true,
+					});
+				}
 			}
 		}
 		return summaries;
 	}
 
-	/** Load one full transcript record by id. */
+	/**
+	 * Load one transcript by id, selected per viewer (#14781): the stored record
+	 * for full disclosure, the redacted variant served under the ORIGINAL id
+	 * (flagged, audio withheld) for redacted-grant viewers, and `null` — which
+	 * the route answers as 404, keeping denied ids non-enumerable — otherwise.
+	 * Addressing a variant row directly discloses only to viewers whose
+	 * disclosure on the linked original resolves `full`.
+	 */
 	async get(
 		id: UUID,
 		accessContext?: AccessContext,
@@ -185,14 +252,44 @@ export class TranscriptStore {
 		if (!row) return null;
 		const transcript = rowToTranscript(row);
 		if (!transcript) return null;
-		return canAccessTranscriptRow(
+
+		const originalId = redactionOriginalId(row);
+		if (originalId !== null) {
+			const originalRow = await this.runtime.getMemoryById(originalId);
+			const original = originalRow ? rowToTranscript(originalRow) : null;
+			// A variant whose original is gone/corrupt is owner-tier storage only.
+			const gate = originalRow && original ? originalRow : row;
+			const gateTranscript = originalRow && original ? original : transcript;
+			const disclosure = transcriptRowDisclosure(
+				gate,
+				gateTranscript,
+				accessContext,
+				this.runtime.agentId,
+			);
+			return disclosure === "full" ? transcript : null;
+		}
+
+		const disclosure = transcriptRowDisclosure(
 			row,
 			transcript,
 			accessContext,
 			this.runtime.agentId,
-		)
-			? transcript
-			: null;
+		);
+		if (disclosure === "full") return transcript;
+		if (disclosure === "redacted") {
+			const variant = await this.loadRedactedVariant(row);
+			return variant ? serveRedactedVariant(variant, transcript) : null;
+		}
+		return null;
+	}
+
+	/** Load + parse the redacted variant linked from an original's row. */
+	private async loadRedactedVariant(row: Memory): Promise<Transcript | null> {
+		const variantId = redactedVariantId(row);
+		if (!variantId) return null;
+		const variantRow = await this.runtime.getMemoryById(variantId);
+		if (!variantRow) return null;
+		return rowToTranscript(variantRow);
 	}
 
 	/**
@@ -203,6 +300,24 @@ export class TranscriptStore {
 	 */
 	async update(transcript: Transcript): Promise<Transcript> {
 		const existing = await this.runtime.getMemoryById(transcript.id as UUID);
+		// Preserve the additive keys other writers own — share grants
+		// (`share`) and redaction links (`redactedVariantId` / `redactionOf`,
+		// #14781) — through a text edit. Narrowed at the jsonb boundary (not a
+		// whole-metadata spread) so the discriminated `MemoryMetadata` union
+		// keeps its `type: "custom"` shape and no `unknown` leaks in.
+		const preserved = existing?.metadata as Record<string, unknown> | undefined;
+		const carriedShare =
+			preserved?.share && typeof preserved.share === "object"
+				? (preserved.share as JsonObject)
+				: undefined;
+		const carriedVariantId =
+			typeof preserved?.redactedVariantId === "string"
+				? preserved.redactedVariantId
+				: undefined;
+		const carriedRedactionOf =
+			typeof preserved?.redactionOf === "string"
+				? preserved.redactionOf
+				: undefined;
 		const ok = await this.runtime.updateMemory({
 			id: transcript.id as UUID,
 			content: {
@@ -219,6 +334,13 @@ export class TranscriptStore {
 				durationMs: transcript.durationMs,
 				speakerCount: transcript.speakerCount,
 				status: transcript.status,
+				...(carriedShare !== undefined ? { share: carriedShare } : {}),
+				...(carriedVariantId !== undefined
+					? { redactedVariantId: carriedVariantId }
+					: {}),
+				...(carriedRedactionOf !== undefined
+					? { redactionOf: carriedRedactionOf }
+					: {}),
 			},
 		});
 		if (!ok) {

--- a/plugins/plugin-meetings/src/routes/meetings-routes.test.ts
+++ b/plugins/plugin-meetings/src/routes/meetings-routes.test.ts
@@ -189,6 +189,119 @@ describe("/api/meetings routes", () => {
     ).toBeUndefined();
   });
 
+  it("selects the session DTO per viewer role x grant (#14781)", async () => {
+    const { ctx, adapter, fake } = makeHarness();
+    const post = route("POST", "/api/meetings");
+    const get = route("GET", "/api/meetings/:id");
+
+    const created = await post(ctx({ body: { meetingUrl: MEET_URL } }));
+    const session = (
+      created.body as { session: { id: string; transcriptId?: string } }
+    ).session;
+    await adapter.started;
+    const transcriptId = session.transcriptId as string;
+
+    // Attach a redacted grant for USER on the stored transcript row (the
+    // grant WRITE path is PERM-ACL's; this tests the read-side selection).
+    const row = fake.memories.get(transcriptId);
+    if (!row) throw new Error("transcript row missing");
+    fake.memories.set(transcriptId, {
+      ...row,
+      metadata: {
+        ...(row.metadata as Record<string, unknown>),
+        share: { grants: [{ entityId: USER, mode: "redacted" }] },
+      },
+    });
+
+    // OWNER boundary (no access context): full, unflagged.
+    const ownerGet = await get(ctx({ params: { id: session.id } }));
+    const ownerSession = (
+      ownerGet.body as {
+        session: { transcriptId?: string; transcriptRedacted?: true };
+      }
+    ).session;
+    expect(ownerSession.transcriptId).toBe(transcriptId);
+    expect(ownerSession.transcriptRedacted).toBeUndefined();
+
+    // ADMIN rank: full, unflagged.
+    const adminGet = await get(
+      ctx({
+        params: { id: session.id },
+        accessContext: { requesterEntityId: USER, role: "ADMIN" },
+      }),
+    );
+    const adminSession = (
+      adminGet.body as {
+        session: { transcriptId?: string; transcriptRedacted?: true };
+      }
+    ).session;
+    expect(adminSession.transcriptId).toBe(transcriptId);
+    expect(adminSession.transcriptRedacted).toBeUndefined();
+
+    // USER with a redacted grant: reference kept + flagged.
+    const userGet = await get(
+      ctx({ params: { id: session.id }, accessContext: userAccess }),
+    );
+    const userSession = (
+      userGet.body as {
+        session: { transcriptId?: string; transcriptRedacted?: true };
+      }
+    ).session;
+    expect(userSession.transcriptId).toBe(transcriptId);
+    expect(userSession.transcriptRedacted).toBe(true);
+
+    // Ungranted USER: reference withheld.
+    const strangerGet = await get(
+      ctx({
+        params: { id: session.id },
+        accessContext: {
+          requesterEntityId: "33333333-3333-3333-3333-333333333333" as UUID,
+          role: "USER",
+        },
+      }),
+    );
+    expect(
+      (strangerGet.body as { session: { transcriptId?: string } }).session
+        .transcriptId,
+    ).toBeUndefined();
+
+    // GUEST: reference withheld.
+    const guestGet = await get(
+      ctx({
+        params: { id: session.id },
+        accessContext: {
+          requesterEntityId: "44444444-4444-4444-4444-444444444444" as UUID,
+          role: "GUEST",
+        },
+      }),
+    );
+    expect(
+      (guestGet.body as { session: { transcriptId?: string } }).session
+        .transcriptId,
+    ).toBeUndefined();
+
+    // USER with a FULL grant: full, unflagged.
+    const row2 = fake.memories.get(transcriptId);
+    if (!row2) throw new Error("transcript row missing");
+    fake.memories.set(transcriptId, {
+      ...row2,
+      metadata: {
+        ...(row2.metadata as Record<string, unknown>),
+        share: { grants: [{ entityId: USER, mode: "full" }] },
+      },
+    });
+    const fullGrantGet = await get(
+      ctx({ params: { id: session.id }, accessContext: userAccess }),
+    );
+    const fullGrantSession = (
+      fullGrantGet.body as {
+        session: { transcriptId?: string; transcriptRedacted?: true };
+      }
+    ).session;
+    expect(fullGrantSession.transcriptId).toBe(transcriptId);
+    expect(fullGrantSession.transcriptRedacted).toBeUndefined();
+  });
+
   it("answers 503 when the meetings service is not running", async () => {
     const fake = makeFakeRuntime();
     const ctx: RouteHandlerContext = {

--- a/plugins/plugin-meetings/src/routes/meetings-routes.ts
+++ b/plugins/plugin-meetings/src/routes/meetings-routes.ts
@@ -9,23 +9,19 @@
  */
 
 import type {
-  AccessContext,
-  Memory,
   Route,
   RouteHandlerContext,
   RouteHandlerResult,
   UUID,
 } from "@elizaos/core";
-import { actorFromAccessContext, canReadScope } from "@elizaos/core";
 import type {
   MeetingJoinRequest,
   MeetingPlatform,
   MeetingSession,
 } from "@elizaos/shared";
 import { parseMeetingUrl } from "@elizaos/shared";
-import type { TranscriptScope } from "@elizaos/shared/transcripts";
-import { normalizeTranscriptScope } from "@elizaos/shared/transcripts";
 import { MeetingJoinError, type MeetingService } from "../service.js";
+import { selectSessionForViewer } from "../session-disclosure.js";
 
 function service(ctx: RouteHandlerContext): MeetingService | null {
   return ctx.runtime.getService<MeetingService>("meetings");
@@ -36,53 +32,12 @@ const unavailable: RouteHandlerResult = {
   body: { error: "meetings service is not running" },
 };
 
-function transcriptScopeFromRow(row: Memory): TranscriptScope {
-  const raw = (row.content as { transcript?: unknown } | undefined)?.transcript;
-  if (typeof raw !== "string") return "owner-private";
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    return normalizeTranscriptScope(
-      parsed && typeof parsed === "object"
-        ? (parsed as { scope?: unknown }).scope
-        : undefined,
-    );
-  } catch {
-    // error-policy:J3 untrusted stored JSON — an unparseable transcript row
-    // fails CLOSED to owner-private so corruption can never widen visibility.
-    return "owner-private";
-  }
-}
-
-function canAccessTranscriptRow(
-  row: Memory,
-  accessContext: AccessContext,
-  agentId: UUID,
-): boolean {
-  if (accessContext.requesterEntityId === agentId) return true;
-  const metadata = row.metadata as Record<string, unknown> | undefined;
-  const scopedTo = metadata?.scopedToEntityId;
-  const scopedEntityId =
-    typeof scopedTo === "string" ? (scopedTo as UUID) : row.entityId;
-  const actor = actorFromAccessContext(accessContext, agentId);
-  if (actor.role === "OWNER") return true;
-  return canReadScope(transcriptScopeFromRow(row), scopedEntityId, actor);
-}
-
-async function redactSessionTranscriptDisclosure(
+/** Per-viewer session DTO selection lives in the use-case module (#14781). */
+function sessionForViewer(
   ctx: RouteHandlerContext,
   session: MeetingSession,
 ): Promise<MeetingSession> {
-  const accessContext = ctx.accessContext;
-  if (!accessContext || !session.transcriptId) return session;
-  const row = await ctx.runtime.getMemoryById(session.transcriptId as UUID);
-  if (
-    row &&
-    canAccessTranscriptRow(row, accessContext, ctx.runtime.agentId as UUID)
-  ) {
-    return session;
-  }
-  const { transcriptId: _transcriptId, ...redacted } = session;
-  return redacted;
+  return selectSessionForViewer(ctx.runtime, ctx.accessContext, session);
 }
 
 /** The body POST /api/meetings accepts. */
@@ -176,7 +131,7 @@ const listRoute: Route = {
     const sessions = await Promise.all(
       svc
         .listSessions({ active })
-        .map((session) => redactSessionTranscriptDisclosure(ctx, session)),
+        .map((session) => sessionForViewer(ctx, session)),
     );
     return { status: 200, body: { sessions } };
   },
@@ -193,7 +148,7 @@ const getRoute: Route = {
     if (!session) return { status: 404, body: { error: "not found" } };
     return {
       status: 200,
-      body: { session: await redactSessionTranscriptDisclosure(ctx, session) },
+      body: { session: await sessionForViewer(ctx, session) },
     };
   },
 };

--- a/plugins/plugin-meetings/src/session-disclosure.ts
+++ b/plugins/plugin-meetings/src/session-disclosure.ts
@@ -1,0 +1,78 @@
+/**
+ * Per-viewer meeting-session DTO selection (#14781) — the use-case layer the
+ * meetings routes delegate to, so no disclosure computation lives in the route
+ * layer. A session references its transcript by id; what a viewer may see of
+ * that transcript is decided by the ONE role-aware predicate in core
+ * (`resolveArtifactDisclosure`) fed with the stored transcript row's scope,
+ * owning entity, and share grants:
+ *
+ *   full     → session served as stored
+ *   redacted → `transcriptId` kept + `transcriptRedacted: true` (the
+ *              transcripts API serves that viewer the redacted variant under
+ *              the same id, so the reference stays navigable)
+ *   none     → `transcriptId` withheld (the roster/lifecycle fields remain —
+ *              session existence is room knowledge, the transcript is not)
+ *
+ * No access context means the single-owner local boundary: served unchanged.
+ */
+import type { AccessContext, IAgentRuntime, Memory, UUID } from "@elizaos/core";
+import {
+  parseArtifactShareGrants,
+  resolveArtifactDisclosure,
+} from "@elizaos/core";
+import type { MeetingSession } from "@elizaos/shared";
+import type { TranscriptScope } from "@elizaos/shared/transcripts";
+import { normalizeTranscriptScope } from "@elizaos/shared/transcripts";
+
+function transcriptScopeFromRow(row: Memory): TranscriptScope {
+  const raw = (row.content as { transcript?: unknown } | undefined)?.transcript;
+  if (typeof raw !== "string") return "owner-private";
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return normalizeTranscriptScope(
+      parsed && typeof parsed === "object"
+        ? (parsed as { scope?: unknown }).scope
+        : undefined,
+    );
+  } catch {
+    // error-policy:J3 untrusted stored JSON — an unparseable transcript row
+    // fails CLOSED to owner-private so corruption can never widen visibility.
+    return "owner-private";
+  }
+}
+
+/**
+ * Select the session DTO for one viewer. Reads the linked transcript row and
+ * applies the canonical disclosure decision; a missing row withholds the
+ * reference (fail closed — a dangling id must not read as shareable).
+ */
+export async function selectSessionForViewer(
+  runtime: Pick<IAgentRuntime, "agentId" | "getMemoryById">,
+  accessContext: AccessContext | undefined,
+  session: MeetingSession,
+): Promise<MeetingSession> {
+  if (!accessContext || !session.transcriptId) return session;
+  const row = await runtime.getMemoryById(session.transcriptId as UUID);
+  if (!row) {
+    const { transcriptId: _transcriptId, ...withheld } = session;
+    return withheld;
+  }
+  const metadata = row.metadata as Record<string, unknown> | undefined;
+  const scopedTo = metadata?.scopedToEntityId;
+  const disclosure = resolveArtifactDisclosure(
+    {
+      scope: transcriptScopeFromRow(row),
+      scopedEntityId:
+        typeof scopedTo === "string" ? (scopedTo as UUID) : row.entityId,
+      grants: parseArtifactShareGrants(metadata),
+    },
+    accessContext,
+    runtime.agentId as UUID,
+  );
+  if (disclosure === "full") return session;
+  if (disclosure === "redacted") {
+    return { ...session, transcriptRedacted: true };
+  }
+  const { transcriptId: _transcriptId, ...withheld } = session;
+  return withheld;
+}


### PR DESCRIPTION
## What & why

Closes #14781 (child of epic #14749; part of #14747).

Every artifact disclosure surface today collapses to OWNER at the HTTP
boundary, so any authenticated caller gets the full artifact. This adds
**per-viewer DTO selection** for shared artifacts — transcripts, stored files,
chat-message attachments, and meeting sessions — designed **inside the #8876
attachments doctrine**:

- Bytes stay **pre-auth** on the content-addressed store (the sha256 URL is the
  capability); "permission" == URL/DTO disclosure on the **referencing record**,
  never a byte-serve gate.
- **Redacted variants are separate media objects** under their own sha256
  (`Media.redactedUrl`), never an edit of the original, never a `fileId`.
- **ONE predicate** decides disclosure everywhere.

## Design decisions

**Core — one predicate, three outcomes** (`packages/core/src/access-control/artifact-disclosure.ts`):
`resolveArtifactDisclosure(record, ctx, agentId) -> "full" | "redacted" | "none"`.
Ordering: no access context (single-owner local boundary) -> full (documented,
unchanged); agent-self / OWNER / ADMIN-rank -> full; an explicit per-entity grant
wins **both** ways (a `full` grant elevates past the scope ladder, a `redacted`
grant narrows even a `global`-scope record so an owner's "redact for this viewer"
cannot be undone by a coarse scope); otherwise the scope ladder (`canReadScope`),
which fails closed on the `owner-private` default. `parseArtifactShareGrants`
sanitizes `metadata.share.grants` at the jsonb boundary (malformed -> grants
nothing).

**Grants ride additively on the referencing record** (`metadata.share.grants`)
— zero migration, no sha256-keyed table (respects doctrine AD1). This PR
implements the **read** side; the grant **write** path (share actions,
room-snapshot capture) is #14778/#14779's.

**DTO selection lives in use-cases, not routes** (repo rule: clients render,
never compute) — `transcript-store.ts`, `plugin-meetings/session-disclosure.ts`,
`agent/api/files-disclosure.ts`, `agent/api/attachment-disclosure.ts`. Routes
only assemble.

**Per-user HTTP principal via the existing seam** — a new
`artifact-share-role-resolver` registers through the #12087 `TokenRoleResolver`
seam (WaifuChat precedent): signed share-viewer tokens (USER/GUEST only,
GET-only artifact allowlist, inert without a secret). `resolveHttpAccessContext`
maps the boundary principal to `AccessContext`; dispatch threads it to route
handlers. The trunk-authorized local owner resolves **no** context, so the
single-owner dashboard is byte-for-byte unchanged.

**GC safety** — `collectReferencedMedia` now scans `redactedUrl` so the daily
sweep keeps redacted variants alive.

## Flagged / skipped (dependencies I did not implement)

- **Grant write path** (share/redact actions, room-snapshot capture) is
  #14778/#14779; this PR only *reads* `metadata.share.grants` + the
  `redactedVariantId`/`redactionOf` variant links. Tests seed those directly.
- **#14777 (owner doctrine decisions) is `needs-shaw`** — I implemented only the
  default matrix the issue itself specifies (AGENT/ADMIN/OWNER full;
  USER/GUEST grant-driven). No signed-byte-URL / byte-revocation / AD1-reopen
  capability was built (D1-D3 recommended *decline*); if D4/D5 ratify
  differently, only the ordering in `resolveArtifactDisclosure` changes.

## Acceptance criteria

- Contract tests per role x surface (OWNER full / ADMIN full / USER-redacted
  sees variant + flag / USER-ungranted omitted / GUEST omitted). Done.
- Zero client-side redaction logic — grep-clean (`RedactedBadge` is
  display-only; the server stamps `redacted`). Done.
- Three-state rule (denied != empty != error): Files `restricted` state. Done.

## Evidence

| Type | Status |
| --- | --- |
| Per-role contract tests (transcripts, meetings, files, attachments, core predicate, resolver) | Done — 100+ assertions, see below |
| Real route-level test over a socket | Done — `artifact-disclosure.real-server.test.ts`: real `http.createServer` + real dispatch + real resolver + real `LocalFileStorageService`, driving `GET/DELETE /api/files` with owner-token / USER-share-token / GUEST-share-token / no-auth |
| Scoped typecheck (core, shared, ui, agent, plugin-meetings, plugin-local-inference) | Done — clean (pre-existing `fast-redact` symlink-artifact + `@elizaos/plugin-streaming` dynamic-import warnings are unrelated and present on develop) |
| Biome | Done — clean on the diff |
| error-policy ratchet | Done — no new empty catch / server console in touched files |
| Real-LLM trajectories | N/A — no agent/action/prompt/model behavior changed; this is DTO selection + HTTP boundary wiring |
| Rendered redacted-vs-full screenshots (desktop+mobile) | N/A — the redacted render only appears for a non-owner **viewer token**, which the `audit:app` OWNER dashboard loop cannot reach (local boundary is always OWNER, sees everything unredacted). The badge + restricted render are covered in the UI test harness (`FilesView.test.tsx`, `MessageAttachments.test.tsx`) instead. |

<details><summary>Test runs</summary>

```
core   src/access-control/              33 passed
agent  attachment-disclosure             8 passed
agent  files-disclosure                  5 passed
agent  artifact-share-role-resolver      9 passed
agent  artifact-disclosure.real-server   6 passed  (real socket)
agent  chat-attachments                 16 passed
plugin-local-inference  transcripts-routes + transcript-store   23 passed
plugin-meetings         meetings-routes   8 passed
ui  FilesView + MessageAttachments       39 passed
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)