### PR TITLE
perf(boot): don't boot a throwaway runtime before onboarding

### DIFF
--- a/packages/agent/src/api/agent-lifecycle-routes.test.ts
+++ b/packages/agent/src/api/agent-lifecycle-routes.test.ts
@@ -1,30 +1,45 @@
 /**
- * Covers handleAgentLifecycleRoutes: POST /api/agent/start moves the shared agent
- * state to running and reports uptime/startedAt, and POST /api/agent/pause moves
- * running → paused. Deterministic: mutates a plain in-memory state object with
- * mocked json/error responders, no runtime or live model.
+ * Covers handleAgentLifecycleRoutes: POST /api/agent/start (flag-flip when a
+ * runtime is already live; a real on-demand boot through the injected
+ * `onRestart` when it is null — 503 when no boot path exists, 500 + reported
+ * "error" when the boot fails), and POST /api/agent/pause (running → paused).
+ * Deterministic: mutates a plain in-memory state object with mocked json/error
+ * responders and a fake runtime; no live model.
  */
 import type http from "node:http";
+import type { AgentRuntime } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 import {
   type AgentLifecycleRouteState,
   handleAgentLifecycleRoutes,
 } from "./agent-lifecycle-routes";
 
-function makeState(): AgentLifecycleRouteState {
+function makeState(
+  overrides: Partial<AgentLifecycleRouteState> = {},
+): AgentLifecycleRouteState {
   return {
     runtime: null,
     agentState: "stopped",
     agentName: "Eliza",
     model: undefined,
     startedAt: undefined,
+    ...overrides,
   };
+}
+
+/** Minimal AgentRuntime stand-in — only the fields the route reads. */
+function fakeRuntime(name = "Eliza"): AgentRuntime {
+  return { character: { name } } as unknown as AgentRuntime;
 }
 
 function makeCtx(
   method: string,
   pathname: string,
   state: AgentLifecycleRouteState = makeState(),
+  extra: {
+    onRestart?: () => Promise<AgentRuntime | null>;
+    onRuntimeSwapped?: () => void;
+  } = {},
 ) {
   const json = vi.fn();
   const error = vi.fn();
@@ -38,6 +53,8 @@ function makeCtx(
       json,
       error,
       readJsonBody: vi.fn(),
+      onRestart: extra.onRestart,
+      onRuntimeSwapped: extra.onRuntimeSwapped,
     },
     state,
     json,
@@ -45,9 +62,13 @@ function makeCtx(
   };
 }
 
-describe("handleAgentLifecycleRoutes", () => {
-  it("starts the agent in running state", async () => {
-    const { ctx, state, json } = makeCtx("POST", "/api/agent/start");
+describe("handleAgentLifecycleRoutes — POST /api/agent/start", () => {
+  it("flag-flips a live-but-stopped runtime to running", async () => {
+    const state = makeState({
+      runtime: fakeRuntime(),
+      agentState: "stopped",
+    });
+    const { ctx, json } = makeCtx("POST", "/api/agent/start", state);
 
     await expect(handleAgentLifecycleRoutes(ctx)).resolves.toBe(true);
 
@@ -57,22 +78,122 @@ describe("handleAgentLifecycleRoutes", () => {
       ctx.res,
       expect.objectContaining({
         ok: true,
-        status: expect.objectContaining({
-          state: "running",
-          agentName: "Eliza",
-          uptime: 0,
-          startedAt: state.startedAt,
-        }),
+        status: expect.objectContaining({ state: "running", uptime: 0 }),
       }),
     );
   });
 
-  it("keeps pause as the explicit paused transition", async () => {
-    const state = {
-      ...makeState(),
-      agentState: "running" as const,
+  it("boots on demand through onRestart when the runtime is null", async () => {
+    const swapped = vi.fn();
+    const booted = fakeRuntime("Booted");
+    const onRestart = vi.fn(async () => booted);
+    const { ctx, state, json, error } = makeCtx(
+      "POST",
+      "/api/agent/start",
+      makeState(),
+      { onRestart, onRuntimeSwapped: swapped },
+    );
+
+    await expect(handleAgentLifecycleRoutes(ctx)).resolves.toBe(true);
+
+    expect(onRestart).toHaveBeenCalledTimes(1);
+    expect(state.runtime).toBe(booted);
+    expect(state.agentState).toBe("running");
+    expect(state.agentName).toBe("Booted");
+    expect(swapped).toHaveBeenCalledTimes(1);
+    expect(error).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith(
+      ctx.res,
+      expect.objectContaining({
+        ok: true,
+        status: expect.objectContaining({ state: "running" }),
+      }),
+    );
+  });
+
+  it("503s with no runtime and no boot path (fake-ready refused)", async () => {
+    const { ctx, state, json, error } = makeCtx("POST", "/api/agent/start");
+
+    await expect(handleAgentLifecycleRoutes(ctx)).resolves.toBe(true);
+
+    // Never reports running with nothing behind it.
+    expect(state.agentState).not.toBe("running");
+    expect(json).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      expect.stringContaining("cannot boot"),
+      503,
+    );
+  });
+
+  it("500s + reports error when the on-demand boot throws", async () => {
+    const onRestart = vi.fn(async () => {
+      throw new Error("pglite open failed");
+    });
+    const { ctx, state, error } = makeCtx(
+      "POST",
+      "/api/agent/start",
+      makeState(),
+      { onRestart },
+    );
+
+    await expect(handleAgentLifecycleRoutes(ctx)).resolves.toBe(true);
+
+    expect(state.agentState).toBe("error");
+    expect(state.startedAt).toBeUndefined();
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      expect.stringContaining("pglite open failed"),
+      500,
+    );
+  });
+
+  it("500s + reports error when the boot returns no runtime", async () => {
+    const onRestart = vi.fn(async () => null);
+    const { ctx, state, error } = makeCtx(
+      "POST",
+      "/api/agent/start",
+      makeState(),
+      { onRestart },
+    );
+
+    await expect(handleAgentLifecycleRoutes(ctx)).resolves.toBe(true);
+
+    expect(state.agentState).toBe("error");
+    expect(error).toHaveBeenCalledWith(
+      ctx.res,
+      expect.stringContaining("did not initialize"),
+      500,
+    );
+  });
+
+  it("is idempotent while a boot is already in progress (starting)", async () => {
+    const onRestart = vi.fn(async () => fakeRuntime());
+    const state = makeState({ agentState: "starting" });
+    const { ctx, json } = makeCtx("POST", "/api/agent/start", state, {
+      onRestart,
+    });
+
+    await expect(handleAgentLifecycleRoutes(ctx)).resolves.toBe(true);
+
+    // Does not kick a second boot — reports the in-progress state.
+    expect(onRestart).not.toHaveBeenCalled();
+    expect(json).toHaveBeenCalledWith(
+      ctx.res,
+      expect.objectContaining({
+        status: expect.objectContaining({ state: "starting" }),
+      }),
+    );
+  });
+});
+
+describe("handleAgentLifecycleRoutes — POST /api/agent/pause", () => {
+  it("moves running → paused", async () => {
+    const state = makeState({
+      runtime: fakeRuntime(),
+      agentState: "running",
       startedAt: Date.now() - 1_000,
-    };
+    });
     const { ctx, json } = makeCtx("POST", "/api/agent/pause", state);
 
     await expect(handleAgentLifecycleRoutes(ctx)).resolves.toBe(true);

--- a/packages/agent/src/api/agent-lifecycle-routes.ts
+++ b/packages/agent/src/api/agent-lifecycle-routes.ts
@@ -6,6 +6,13 @@
  * validates its body, calls enable/disableAutonomy on the AUTONOMY_SERVICE_TYPE
  * service when present, and always syncs runtime.enableAutonomy. Sits behind the
  * authenticated dashboard gate; not public.
+ *
+ * With no live runtime, POST /api/agent/start is a real boot request, not a
+ * flag flip: it boots through the host's injected `onRestart` — the same
+ * closure POST /api/agent/restart uses, which app-core's fresh-install
+ * deferral funnels into a single-flight boot. Reporting "running" with a null
+ * runtime would be fake-ready: a host that cannot boot answers 503, and a
+ * failed boot answers 500 with the reported state flipped to "error".
  */
 import {
   type AgentRuntime,
@@ -37,6 +44,14 @@ export interface AgentLifecycleRouteContext
   extends RouteRequestMeta,
     Pick<RouteHelpers, "error" | "json" | "readJsonBody"> {
   state: AgentLifecycleRouteState;
+  /**
+   * Boots (or reboots) a runtime in-process. Injected by hosts that own a
+   * boot path (server-only startEliza, dev supervisor); absent on hosts that
+   * cannot boot, where a start request with no runtime must fail honestly.
+   */
+  onRestart?: (() => Promise<AgentRuntime | null>) | undefined;
+  /** Post-swap rewiring (streams, model broadcast) — mirrors the restart route. */
+  onRuntimeSwapped?: (() => void) | undefined;
 }
 
 type AutonomyToggleService = {
@@ -66,9 +81,67 @@ export async function handleAgentLifecycleRoutes(
     | null;
 
   if (method === "POST" && pathname === "/api/agent/start") {
-    state.agentState = "running";
-    state.startedAt = Date.now();
-    state.model = detectRuntimeModel(state.runtime);
+    if (!state.runtime) {
+      // A boot is already underway (parallel-bind warming window, an
+      // in-flight restart, or the deferred fresh-install boot): starting is
+      // idempotent — report the in-progress state and let the client poll
+      // /api/status instead of racing a second boot.
+      if (
+        state.agentState === "starting" ||
+        state.agentState === "restarting"
+      ) {
+        json(res, {
+          ok: true,
+          status: {
+            state: state.agentState,
+            agentName: state.agentName,
+            model: state.model,
+            startedAt: state.startedAt,
+          },
+        });
+        return true;
+      }
+      if (!ctx.onRestart) {
+        error(
+          res,
+          "Agent runtime is not available and this server cannot boot one on demand",
+          503,
+        );
+        return true;
+      }
+      state.agentState = "starting";
+      state.startedAt = Date.now();
+      try {
+        const booted = await ctx.onRestart();
+        if (!booted) {
+          state.agentState = "error";
+          state.startedAt = undefined;
+          error(res, "Agent start failed — runtime did not initialize", 500);
+          return true;
+        }
+        state.runtime = booted;
+        state.agentState = "running";
+        state.agentName = booted.character.name ?? state.agentName;
+        state.model = detectRuntimeModel(booted);
+        state.startedAt = Date.now();
+        ctx.onRuntimeSwapped?.();
+      } catch (err) {
+        // error-policy:J1 boundary translation — the boot failure becomes a
+        // structured 500 + reported state "error"; never a fake "running".
+        state.agentState = "error";
+        state.startedAt = undefined;
+        error(
+          res,
+          `Agent start failed: ${err instanceof Error ? err.message : String(err)}`,
+          500,
+        );
+        return true;
+      }
+    } else {
+      state.agentState = "running";
+      state.startedAt = Date.now();
+      state.model = detectRuntimeModel(state.runtime);
+    }
 
     json(res, {
       ok: true,

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -2305,6 +2305,11 @@ async function handleRequest(
       error,
       json,
       readJsonBody,
+      // Lets POST /api/agent/start boot a runtime from the runtime-less state
+      // (fresh-install deferred boot / stopped host) instead of fake-flipping
+      // the reported state to "running" with nothing behind it.
+      onRestart: ctx?.onRestart ?? undefined,
+      onRuntimeSwapped: ctx?.onRuntimeSwapped,
     })
   ) {
     return;

--- a/packages/app-core/src/api/deferred-runtime-boot.test.ts
+++ b/packages/app-core/src/api/deferred-runtime-boot.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Pins the fresh-install boot-deferral gate + single-flight boot registry
+ * (deferred-runtime-boot.ts). Uses the REAL production predicate
+ * (`hasCompatPersistedFirstRunState` via `loadElizaConfig`) against a real temp
+ * ELIZA_STATE_DIR — no mock stands in for the thing under test — so the gate is
+ * exercised exactly as `GET /api/first-run/status` and `startEliza` see it.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { saveElizaConfig } from "@elizaos/agent/config/config";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  isRuntimeBootDeferred,
+  registerDeferredRuntimeBoot,
+  resetDeferredRuntimeBootForTests,
+  shouldDeferRuntimeBootUntilOnboarding,
+  triggerDeferredRuntimeBoot,
+} from "./deferred-runtime-boot";
+
+let stateDir: string;
+const savedEnv: Record<string, string | undefined> = {};
+const ENV_KEYS = [
+  "ELIZA_STATE_DIR",
+  "ELIZA_PERSIST_CONFIG_PATH",
+  "ELIZA_CLOUD_PROVISIONED",
+  "ELIZAOS_CLOUD_ENABLED",
+  "ELIZAOS_CLOUD_API_KEY",
+  "STEWARD_AGENT_TOKEN",
+  "ANTHROPIC_API_KEY",
+  "OPENAI_API_KEY",
+  "OLLAMA_BASE_URL",
+] as const;
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+  stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "eliza-deferred-boot-"));
+  process.env.ELIZA_STATE_DIR = stateDir;
+  resetDeferredRuntimeBootForTests();
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  fs.rmSync(stateDir, { recursive: true, force: true });
+  resetDeferredRuntimeBootForTests();
+});
+
+/** Persist a completed local-target onboarding, exactly as the handler does. */
+function completeLocalOnboarding(): void {
+  saveElizaConfig({
+    meta: { firstRunComplete: true },
+    deploymentTarget: { runtime: "local" },
+    serviceRouting: { llmText: { backend: "ollama", transport: "direct" } },
+  } as never);
+}
+
+describe("shouldDeferRuntimeBootUntilOnboarding (fresh-install gate)", () => {
+  it("defers on a genuinely fresh install (no config on disk)", () => {
+    expect(shouldDeferRuntimeBootUntilOnboarding()).toBe(true);
+  });
+
+  it("does NOT defer once onboarding has persisted (returning user)", () => {
+    completeLocalOnboarding();
+    expect(shouldDeferRuntimeBootUntilOnboarding()).toBe(false);
+  });
+
+  it("does NOT defer when a provider env key is set (CI / env-configured)", () => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test";
+    expect(shouldDeferRuntimeBootUntilOnboarding()).toBe(false);
+  });
+
+  it("does NOT defer for a cloud-provisioned container", () => {
+    process.env.ELIZA_CLOUD_PROVISIONED = "1";
+    process.env.STEWARD_AGENT_TOKEN = "steward-token";
+    expect(shouldDeferRuntimeBootUntilOnboarding()).toBe(false);
+  });
+
+  it("does NOT defer when OLLAMA_BASE_URL is set (local dev provider)", () => {
+    process.env.OLLAMA_BASE_URL = "http://localhost:11434";
+    expect(shouldDeferRuntimeBootUntilOnboarding()).toBe(false);
+  });
+});
+
+describe("deferred boot registry (single-flight)", () => {
+  it("is not deferred until a boot closure is registered", () => {
+    expect(isRuntimeBootDeferred()).toBe(false);
+    registerDeferredRuntimeBoot(async () => {});
+    expect(isRuntimeBootDeferred()).toBe(true);
+  });
+
+  it("triggering with nothing registered is a no-op", async () => {
+    await expect(triggerDeferredRuntimeBoot("noop")).resolves.toBeUndefined();
+  });
+
+  it("runs the boot exactly once for concurrent triggers", async () => {
+    let resolveBoot!: () => void;
+    const boot = vi.fn(
+      () =>
+        new Promise<void>((r) => {
+          resolveBoot = r;
+        }),
+    );
+    registerDeferredRuntimeBoot(boot);
+
+    const a = triggerDeferredRuntimeBoot("first");
+    const b = triggerDeferredRuntimeBoot("second");
+    expect(boot).toHaveBeenCalledTimes(1);
+
+    resolveBoot();
+    await Promise.all([a, b]);
+    expect(boot).toHaveBeenCalledTimes(1);
+    // After success the registration clears — later triggers no-op.
+    expect(isRuntimeBootDeferred()).toBe(false);
+    await triggerDeferredRuntimeBoot("after-success");
+    expect(boot).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the registration after a failed boot so a retry can re-attempt", async () => {
+    const boot = vi
+      .fn<[], Promise<void>>()
+      .mockRejectedValueOnce(new Error("pglite open failed"))
+      .mockResolvedValueOnce(undefined);
+    registerDeferredRuntimeBoot(boot);
+
+    await expect(triggerDeferredRuntimeBoot("attempt-1")).rejects.toThrow(
+      "pglite open failed",
+    );
+    // Still deferred — the failure did not clear the registration.
+    expect(isRuntimeBootDeferred()).toBe(true);
+
+    await expect(
+      triggerDeferredRuntimeBoot("attempt-2"),
+    ).resolves.toBeUndefined();
+    expect(boot).toHaveBeenCalledTimes(2);
+    expect(isRuntimeBootDeferred()).toBe(false);
+  });
+});

--- a/packages/app-core/src/api/deferred-runtime-boot.test.ts
+++ b/packages/app-core/src/api/deferred-runtime-boot.test.ts
@@ -123,7 +123,7 @@ describe("deferred boot registry (single-flight)", () => {
 
   it("keeps the registration after a failed boot so a retry can re-attempt", async () => {
     const boot = vi
-      .fn<[], Promise<void>>()
+      .fn<() => Promise<void>>()
       .mockRejectedValueOnce(new Error("pglite open failed"))
       .mockResolvedValueOnce(undefined);
     registerDeferredRuntimeBoot(boot);

--- a/packages/app-core/src/api/deferred-runtime-boot.ts
+++ b/packages/app-core/src/api/deferred-runtime-boot.ts
@@ -1,0 +1,114 @@
+/**
+ * Fresh-install boot deferral for the server-only startup path: the gate that
+ * decides "this process is a genuinely-fresh install awaiting onboarding" and
+ * the single-flight registry that boots the agent runtime once onboarding
+ * commits.
+ *
+ * On a fresh install the GUI shows onboarding first, and the default runtime
+ * a server-only boot would build (PGlite open, migrations, plugin-sql, default
+ * character, services) is discarded the moment onboarding persists a real
+ * configuration. `startEliza` (runtime/eliza.ts) therefore consults
+ * `shouldDeferRuntimeBootUntilOnboarding()` right before its post-bind runtime
+ * boot and, when it defers, registers the boot closure here instead. The boot
+ * then fires from exactly one of: the first-run commit handler
+ * (`POST /api/first-run`, first-run-routes.ts) or an explicit
+ * `POST /api/agent/start` / `POST /api/agent/restart` (both funnel through the
+ * server's `onRestart`). All triggers share one in-flight promise so
+ * concurrent requests can never double-open the PGlite data dir.
+ *
+ * The gate must be exactly "the GUI will show onboarding": it reuses
+ * `hasCompatPersistedFirstRunState` — the predicate `GET /api/first-run/status`
+ * answers `complete` with — plus the cloud-provisioned and provider-env
+ * short-circuits, so env-configured contexts (CI with `ANTHROPIC_API_KEY`,
+ * `OLLAMA_BASE_URL` dev loops, provisioned containers) keep booting the
+ * runtime immediately, exactly as before.
+ */
+import { PROVIDER_PLUGIN_MAP } from "@elizaos/agent";
+import { loadElizaConfig } from "@elizaos/agent/config/config";
+import { logger } from "@elizaos/core";
+import { hasCompatPersistedFirstRunState } from "./compat-route-shared";
+import { isCloudProvisioned } from "./server-first-run-helpers";
+
+/**
+ * Boots the runtime and wires it into the running API server (updateRuntime +
+ * updateStartup). Must throw on failure after flipping the reported state to
+ * "error" so the client sees the designed error state, never a fake-ready.
+ */
+type DeferredRuntimeBoot = () => Promise<void>;
+
+let pendingBoot: DeferredRuntimeBoot | null = null;
+let bootInFlight: Promise<void> | null = null;
+
+/**
+ * True when a provider auto-enable env key is set — the same keys the plugin
+ * resolver uses to force-include model-provider plugins at boot. An install
+ * configured this way gets a *working* agent from the very first boot, so
+ * deferral would be a regression, not an optimization.
+ */
+function hasConfiguredProviderEnv(): boolean {
+  return Object.keys(PROVIDER_PLUGIN_MAP).some((envKey) =>
+    Boolean(process.env[envKey]?.trim()),
+  );
+}
+
+/**
+ * The fresh-install gate: defer the runtime boot iff this server would tell
+ * the GUI to run onboarding AND nothing else (cloud provisioning, provider env
+ * keys) can give the pre-onboarding runtime a working model provider.
+ */
+export function shouldDeferRuntimeBootUntilOnboarding(): boolean {
+  if (isCloudProvisioned()) {
+    return false;
+  }
+  if (hasConfiguredProviderEnv()) {
+    return false;
+  }
+  return !hasCompatPersistedFirstRunState(loadElizaConfig());
+}
+
+/**
+ * Register the boot closure for a deferred fresh-install boot. Called once by
+ * `startEliza` before the API server binds, so any trigger that can only
+ * arrive over HTTP is guaranteed to find the closure registered.
+ */
+export function registerDeferredRuntimeBoot(boot: DeferredRuntimeBoot): void {
+  pendingBoot = boot;
+  bootInFlight = null;
+}
+
+/** True while the runtime boot is deferred (registered and not yet succeeded). */
+export function isRuntimeBootDeferred(): boolean {
+  return pendingBoot !== null;
+}
+
+/**
+ * Fire the deferred boot. Single-flight: concurrent triggers share one boot
+ * promise. On success the registration is cleared (later triggers no-op); on
+ * failure it is kept so an explicit retry (`POST /api/agent/start` /
+ * `/api/agent/restart`) can attempt the boot again — the failure itself is
+ * surfaced to clients by the boot closure (reported agent state "error").
+ */
+export function triggerDeferredRuntimeBoot(reason: string): Promise<void> {
+  const boot = pendingBoot;
+  if (!boot) {
+    return Promise.resolve();
+  }
+  if (!bootInFlight) {
+    logger.info(`[eliza] Booting the deferred agent runtime (${reason})`);
+    bootInFlight = (async () => {
+      try {
+        await boot();
+        pendingBoot = null;
+      } finally {
+        bootInFlight = null;
+      }
+    })();
+  }
+  return bootInFlight;
+}
+
+/** Test-only: reset the module-scoped registry between cases. */
+export function resetDeferredRuntimeBootForTests(): void {
+  pendingBoot = null;
+  bootInFlight = null;
+}

--- a/packages/app-core/src/api/first-run-routes.ts
+++ b/packages/app-core/src/api/first-run-routes.ts
@@ -7,6 +7,11 @@
  * back so the upstream config save keeps it, then mirrors the merged config to
  * the live runtime through a loopback `PUT /api/config`.
  *
+ * A committed local-target run is also the boot trigger for a fresh install
+ * that deferred its runtime at startup (deferred-runtime-boot.ts): once the
+ * completion state is on disk, the handler fires the single-flight runtime
+ * boot; cloud/remote targets deliberately leave the process runtime-less.
+ *
  * A defensive delayed resave (`scheduleCloudApiKeyResave`) re-writes
  * `cloud.apiKey` if a concurrent config write clobbers it — a best-effort
  * workaround for an unreproduced upstream race, logged at warn on failure.
@@ -19,6 +24,7 @@ import {
 } from "@elizaos/agent";
 import { logger } from "@elizaos/core";
 import {
+  type DeploymentTargetRuntime,
   getCloudSecret,
   migrateLegacyRuntimeConfig,
   normalizeDeploymentTargetConfig,
@@ -27,7 +33,14 @@ import {
   normalizeServiceRoutingConfig,
 } from "@elizaos/shared";
 import { ensureRouteAuthorized } from "./auth.ts";
-import type { CompatRuntimeState } from "./compat-route-shared";
+import {
+  type CompatRuntimeState,
+  hasCompatPersistedFirstRunState,
+} from "./compat-route-shared";
+import {
+  isRuntimeBootDeferred,
+  triggerDeferredRuntimeBoot,
+} from "./deferred-runtime-boot";
 import { sendJson as sendJsonResponse } from "./response";
 import {
   deriveFirstRunReplayBody,
@@ -199,6 +212,7 @@ export async function handleFirstRunRoute(
   const rawBody = Buffer.concat(chunks);
 
   let capturedCloudApiKey: string | undefined;
+  let committedRuntimeTarget: DeploymentTargetRuntime | undefined;
 
   try {
     const body = JSON.parse(rawBody.toString("utf8")) as Record<
@@ -222,6 +236,7 @@ export async function handleFirstRunRoute(
     const replayDeploymentTarget = normalizeDeploymentTargetConfig(
       replayBodyRecord.deploymentTarget,
     );
+    committedRuntimeTarget = replayDeploymentTarget?.runtime;
     const replayLinkedAccounts = normalizeLinkedAccountFlagsConfig(
       replayBodyRecord.linkedAccounts,
     );
@@ -289,6 +304,34 @@ export async function handleFirstRunRoute(
 
   if (capturedCloudApiKey) {
     scheduleCloudApiKeyResave(capturedCloudApiKey);
+  }
+
+  // Fresh-install deferred boot (see deferred-runtime-boot.ts): a committed
+  // LOCAL-target onboarding is THE signal to boot the agent runtime this
+  // process skipped at startup. Cloud/remote targets stay runtime-less on
+  // purpose — the client binds the cloud/remote agent and this process never
+  // needed a local runtime (#13377). Gated on the same on-disk predicate the
+  // status route serves, so a failed persist never boots the discarded
+  // pre-onboarding default runtime. Fire-and-forget: the client's finish flow
+  // does not wait on this response for readiness (it polls /api/status, and
+  // early chat turns hold on the runtime-ready gate); a boot failure is
+  // observable there as state "error".
+  if (
+    isRuntimeBootDeferred() &&
+    committedRuntimeTarget !== "cloud" &&
+    committedRuntimeTarget !== "remote" &&
+    hasCompatPersistedFirstRunState(loadElizaConfig())
+  ) {
+    triggerDeferredRuntimeBoot("first-run onboarding committed").catch(
+      (err) => {
+        // error-policy:J5 — the failure is observed by clients via
+        // /api/status (the boot closure flips state to "error" before
+        // rethrowing); this log is the server-side record of the same event.
+        logger.error(
+          `[api] Deferred runtime boot after first-run commit failed: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`,
+        );
+      },
+    );
   }
 
   return true;

--- a/packages/app-core/src/runtime/eliza.ts
+++ b/packages/app-core/src/runtime/eliza.ts
@@ -114,6 +114,12 @@ import {
 
 const _require = createRequire(import.meta.url);
 
+import {
+  isRuntimeBootDeferred,
+  registerDeferredRuntimeBoot,
+  shouldDeferRuntimeBootUntilOnboarding,
+  triggerDeferredRuntimeBoot,
+} from "../api/deferred-runtime-boot.js";
 import { invalidateCorsAllowedPorts } from "../api/server-cors.js";
 import { bootLap } from "../boot-profile.js";
 import { isRuntimeAutonomyEnabled } from "./autonomy-policy.js";
@@ -1678,6 +1684,15 @@ export async function startEliza(
       return repaired;
     };
 
+    // Fresh-install gate, decided BEFORE the API binds so the onRestart
+    // closure below can never race an in-flight deferral decision: on a
+    // genuinely-fresh install (the GUI will run onboarding; no provider env
+    // keys, not cloud-provisioned) the runtime a server-only boot would build
+    // is pure waste — onboarding discards it. Defer it and boot on the
+    // first-run commit instead (see ../api/deferred-runtime-boot.ts).
+    const deferRuntimeBootUntilOnboarding =
+      shouldDeferRuntimeBootUntilOnboarding();
+
     // Desktop launcher sets ELIZA_API_PORT (default 31337) to match the
     // renderer's hardcoded API base; honor it when present. CLI/server-only
     // mode (no ELIZA_API_PORT) keeps the legacy `resolveServerOnlyPort`
@@ -1709,12 +1724,44 @@ export async function startEliza(
         "[eliza] Local-agent IPC mode: initializing route kernel without a TCP listener (set ELIZA_API_EXPOSE_PORT=1 to re-open the port)",
       );
     }
+    // The deferred fresh-install boot: exactly the post-bind boot sequence
+    // below (boot → updateRuntime → "running"), reachable from the first-run
+    // commit handler and the agent start/restart endpoints. Registered BEFORE
+    // the API binds so every HTTP trigger finds it; `updateRuntime` /
+    // `updateStartup` are assigned by the bind below, before any request can
+    // arrive. A failed boot flips the reported state to "error" (the client's
+    // designed error state) and rethrows — the registration is kept so an
+    // explicit start/restart can retry.
+    if (deferRuntimeBootUntilOnboarding) {
+      registerDeferredRuntimeBoot(async () => {
+        updateStartup?.({ phase: "starting", state: "starting" });
+        try {
+          currentRuntime = await bootServerOnlyRuntime();
+        } catch (err) {
+          // error-policy:J2 context-adding rethrow — flip the reported agent
+          // state to "error" first so /api/status never reads healthy.
+          updateStartup?.({ phase: "error", state: "error" });
+          throw new Error("Runtime boot after onboarding failed", {
+            cause: err,
+          });
+        }
+        if (!currentRuntime) {
+          updateStartup?.({ phase: "error", state: "error" });
+          throw new Error("Runtime boot after onboarding returned no runtime");
+        }
+        updateRuntime?.(currentRuntime);
+        updateStartup?.({ phase: "running", attempt: 0, state: "running" });
+        bootLap("startEliza:deferred runtime booted + ready:true");
+      });
+    }
+
     bootLap(
       "startEliza:before startApiServer (config/registry/embedding setup done)",
     );
     try {
-      // Bind the API server FIRST with no runtime yet (state "starting"), so
-      // the desktop webview connects + hydrates in PARALLEL with the heavier
+      // Bind the API server FIRST with no runtime yet (state "starting", or
+      // "not_started" when the fresh-install gate deferred the boot), so the
+      // desktop webview connects + hydrates in PARALLEL with the heavier
       // agent boot instead of waiting the full boot. The runtime is wired in
       // via updateRuntime once it finishes booting below. Mirrors the
       // dev-server's bind-first orchestration. In local-agent IPC mode
@@ -1723,8 +1770,18 @@ export async function startEliza(
       const startedApiServer = await startApiServer({
         port: apiPort,
         skipListen: skipApiListen,
-        initialAgentState: "starting",
+        initialAgentState: deferRuntimeBootUntilOnboarding
+          ? "not_started"
+          : "starting",
         onRestart: async () => {
+          // Before the deferred first boot has succeeded, a restart request
+          // IS the boot request — funnel it into the single-flight trigger so
+          // it can never race the first-run commit into a second concurrent
+          // PGlite open.
+          if (isRuntimeBootDeferred()) {
+            await triggerDeferredRuntimeBoot("agent start requested via API");
+            return currentRuntime ?? null;
+          }
           if (currentRuntime) {
             await upstreamShutdownRuntime(
               currentRuntime,
@@ -1778,17 +1835,33 @@ export async function startEliza(
       bootLap("startEliza:route kernel ready (IPC mode, no TCP bind)");
     }
 
-    // Now boot the runtime; the API is already reachable (state "starting"),
-    // so the UI is connecting + hydrating while this runs, then flips to
-    // "running" once the agent is ready.
-    currentRuntime = await bootServerOnlyRuntime();
-    if (!currentRuntime) {
-      updateStartup?.({ phase: "error", state: "error" });
-      return currentRuntime;
+    if (deferRuntimeBootUntilOnboarding) {
+      // Fresh install: no runtime until onboarding commits. The API server
+      // already serves everything onboarding needs (first-run status/options,
+      // auth, config); /api/status reports the designed awaiting state
+      // (state "not_started", startup.phase "awaiting-onboarding") — never a
+      // fake "running". The boot fires from POST /api/first-run (local-target
+      // commit) or POST /api/agent/start|restart, whichever comes first; a
+      // cloud/remote-target commit leaves this process runtime-less on
+      // purpose (#13377 — the client binds the cloud agent instead).
+      updateStartup?.({ phase: "awaiting-onboarding", state: "not_started" });
+      logger.info(
+        "[eliza] Fresh install — agent runtime boot deferred until onboarding commits (onboarding API routes are live)",
+      );
+      bootLap("startEliza:runtime boot deferred (awaiting onboarding)");
+    } else {
+      // Now boot the runtime; the API is already reachable (state "starting"),
+      // so the UI is connecting + hydrating while this runs, then flips to
+      // "running" once the agent is ready.
+      currentRuntime = await bootServerOnlyRuntime();
+      if (!currentRuntime) {
+        updateStartup?.({ phase: "error", state: "error" });
+        return currentRuntime;
+      }
+      updateRuntime?.(currentRuntime);
+      updateStartup?.({ phase: "running", attempt: 0, state: "running" });
+      bootLap("startEliza:runtime booted + ready:true");
     }
-    updateRuntime?.(currentRuntime);
-    updateStartup?.({ phase: "running", attempt: 0, state: "running" });
-    bootLap("startEliza:runtime booted + ready:true");
 
     console.log("[eliza] Server running. Press Ctrl+C to stop.");
 


### PR DESCRIPTION
## Problem

On a genuinely-fresh install, the server-only boot (`startEliza`, `packages/app-core/src/runtime/eliza.ts`) bound the API and then **always booted a full default agent runtime** — PGlite open (~503ms), migrations, plugin-sql registration, default character build, services — even though the GUI shows onboarding first and **discards that entire runtime** when it restarts the agent after onboarding commits. That work sat on the critical path before onboarding's first paint. It is pure waste on fresh installs, and worst on mobile + cloud-only onboarding (#13377, #14390) where the local runtime is never needed at all.

The pre-existing code already skipped the interactive first-run CLI prompt in GUI/headless mode ("the GUI will restart the agent after first-run setup") but still booted the throwaway runtime anyway (`preOnboarding` marker).

## What changed

`startEliza` (serverOnly) now consults a **fresh-install gate** right before its post-bind runtime boot. When the gate fires, the process binds **only** the API server (the first-run/status/options, auth, and config routes onboarding needs) and **defers the runtime**. The runtime boots on the real onboarding-commit signal — reusing the **same `onRestart` path the GUI already used** to restart the agent after first-run — funneled through a single-flight registry so no trigger can double-open PGlite.

### State machine (server-only boot)

```
bind API server (runtime = null, state "starting")
        │
        ▼
gate = shouldDeferRuntimeBootUntilOnboarding()
        │
        ├─ false  (returning user  |  provider env key set  |  cloud-provisioned)
        │     └─ boot runtime now ──────────────► state "running"     [unchanged today]
        │
        └─ true   (genuinely-fresh install)
              state "not_started", startup.phase "awaiting-onboarding"
              (API serves onboarding; NO agent runtime; canRespond=false)
                    │
                    │  boot triggers (single-flight, whichever comes first):
                    ├─ POST /api/first-run  with a LOCAL deployment target
                    ├─ POST /api/agent/start      (funnels via onRestart)
                    └─ POST /api/agent/restart    (funnels via onRestart)
                    │
                    ▼
              boot runtime ──► "starting" ──► "running"
                    │
                    ├─ cloud/remote onboarding target → NO local runtime ever boots (#13377):
                    │     the client binds the cloud/remote agent; this process stays runtime-less.
                    └─ boot failure → state "error" (client three-state error state), registration
                          kept so an explicit start/restart retries.
```

### The gate predicate

`shouldDeferRuntimeBootUntilOnboarding()` (`packages/app-core/src/api/deferred-runtime-boot.ts`) defers **iff all** hold:

- **not** cloud-provisioned (`isCloudProvisioned()`),
- **no** provider auto-enable env key set (`PROVIDER_PLUGIN_MAP` keys — `ANTHROPIC_API_KEY`, `OLLAMA_BASE_URL`, `ELIZA_CHAT_VIA_CLI`, …), and
- `!hasCompatPersistedFirstRunState(loadElizaConfig())` — **the exact predicate `GET /api/first-run/status` answers `complete` with.**

So env-configured contexts (CI with `ANTHROPIC_API_KEY`, `OLLAMA` dev loops, provisioned cloud containers) and any returning user keep booting the runtime **immediately, exactly as today** — the gate is scoped to the genuinely-fresh no-config state, not to headless mode. Server-only/CLI `eliza start` with a completed config, CI, and scenario-runner are all unaffected.

### Honest `/api/agent/start`

`POST /api/agent/start` with a **null runtime** used to fake-flip the reported state to `running` with nothing behind it. It now **boots on demand** through the injected `onRestart` (503 when no boot path exists; 500 + reported state `"error"` when the boot fails; idempotent while a boot is already in progress). A live-but-stopped runtime keeps the flag-flip.

### Fail-fast

No swallowed errors: a failed deferred boot flips the reported agent state to `"error"` and rethrows; the client observes it via `/api/status` (three-state rule). The first-run-commit trigger is fire-and-forget with a `runtime.reportError`-adjacent server log, and the failure surfaces to the client through the reported state — the finish flow polls `/api/status` and early chat turns hold on the runtime-ready gate.

## Files

- `packages/app-core/src/api/deferred-runtime-boot.ts` (new) — gate + single-flight boot registry
- `packages/app-core/src/runtime/eliza.ts` — serverOnly branch: gate, register deferred boot, `awaiting-onboarding` state, onRestart funnels the first boot
- `packages/app-core/src/api/first-run-routes.ts` — local-target commit fires the deferred boot; cloud/remote targets do not
- `packages/agent/src/api/agent-lifecycle-routes.ts` — `/api/agent/start` boots on demand from a null runtime
- `packages/agent/src/api/server.ts` — passes `onRestart`/`onRuntimeSwapped` into the lifecycle route

## Verification (real, end-to-end — scratch STATE_DIR fresh-install simulation)

Booted `packages/app-core/src/entry.ts start` against fresh temp state dirs with **no provider env keys**, real HTTP probes, real model turn.

### 1) Fresh install → no runtime boots, onboarding-required status, fast API bind

```
[boot-profile] startEliza:serverOnly entry                                    +1138ms
[boot-profile] startEliza:before startApiServer (config/registry setup done)  +1140ms
[boot-profile] startEliza:API bound (webview can connect, ready:false)        +3836ms
[eliza] Fresh install — agent runtime boot deferred until onboarding commits (onboarding API routes are live)
[boot-profile] startEliza:runtime boot deferred (awaiting onboarding)         +3837ms
```

Runtime-boot work (PGlite + migrations + plugins) **entirely skipped** — `grep -c PLUGIN:SQL server.log` → `0`. Status probes:

```
GET /api/first-run/status → {"complete":false,"cloudProvisioned":false}
GET /api/status           → {"state":"not_started","canRespond":false,
                             "startup":{"phase":"awaiting-onboarding",...}}   ← designed awaiting state, not error, not fake-ready
GET /api/health           → {"ready":true,"runtime":"not_initialized","agentState":"not_started"}
GET /api/auth/status      → {"required":false,"localAccess":true,...}
```

The client startup coordinator (`startup-phase-poll.ts`) sees auth `required:false` + first-run `complete:false` → dispatches `BACKEND_REACHED { firstRunComplete:false }` → onboarding shows. Phases advance identically.

### 2) Onboarding commit → runtime boots + real chat turn

Deferred fresh server (`state=not_started`, 0 runtime), then:

```
POST /api/first-run  {name, deploymentTarget:{runtime:"local"}, serviceRouting:{llmText:{backend:"cli",...}}}  → {"ok":true}
[eliza] Booting the deferred agent runtime (first-run onboarding committed)

/api/status:  not_started → starting → running   (canRespond:false → true)
[eliza] Auto-enabled plugin: @elizaos/plugin-cli-inference
[eliza] Runtime initialised in headless mode

POST /v1/chat/completions {"model":"cli","messages":[{"role":"user","content":"Reply with exactly the single word BOOTPROOF and nothing else."}]}
MODEL_REPLY: 'BOOTPROOF'          ← real model turn on the just-booted runtime
```

(Provider for the live turn: `ELIZA_CHAT_VIA_CLI=claude` persisted to config by the onboarding step — the keyless claude-CLI provider lane — so the booted runtime has a working `TEXT_GENERATION` handler. The cloud-key lane booted identically and wired the cloud-proxy provider; its live call returned the structured "cloud key not authorized" degrade because the saved dev key is expired — pipeline proven, external credential dead.)

### 3) Returning user → boots immediately, laps unchanged

State dir with a completed config (`meta.firstRunComplete`, deploymentTarget, serviceRouting):

```
grep -c "Fresh install" server.log → 0     ← gate did NOT defer
[boot-profile] startEliza:serverOnly entry                          +992ms
[boot-profile] startEliza:API bound (webview can connect, ready:false) +3904ms
[boot-profile] startEliza:runtime booted + ready:true              +12705ms  (Δ8801ms runtime boot)
GET /api/first-run/status → {"complete":true,"cloudProvisioned":false}
GET /api/status           → state "running", canRespond:true
```

Boot laps are the **unchanged** today sequence (entry → API bound → runtime booted). The ~8.8s of runtime-boot work that a fresh install now defers is exactly what a returning user still pays up front, as before.

## Tests

- `packages/app-core/src/api/deferred-runtime-boot.test.ts` (new, 9) — gate predicate (fresh/returning/provider-env/cloud-provisioned/ollama) against a **real** temp `ELIZA_STATE_DIR` + real `loadElizaConfig`/`hasCompatPersistedFirstRunState`; single-flight (one boot for concurrent triggers, clears on success, kept-and-retryable on failure).
- `packages/agent/src/api/agent-lifecycle-routes.test.ts` (7) — `/api/agent/start`: flag-flip live-but-stopped; boot-on-demand via onRestart; 503 no-boot-path; 500 + "error" on throw / on null; idempotent while starting.
- `packages/app-core/src/api/first-run-persistence.restart.test.ts` — pre-existing gate-predicate regression suite, still green.

`bun run audit:error-policy-ratchet` → no new fallback-slop. Biome clean.

## Open risks

- **`/api/health` `ready:true` during awaiting-onboarding.** `ready` is `agentState !== "starting"/"restarting"`, so `not_started` reads `ready:true` (pre-existing semantics — `ready` is true for stopped/error too). `canRespond:false` + `runtime:"not_initialized"` are the honest signals; the client routes onboarding off auth/first-run status, not `health.ready`. The desktop `waitForHealthy` treats it as "API reachable", which is correct. Left as-is to avoid changing `ready` semantics under this PR.
- **Rebase overlap.** Another lane edits `agent/src/runtime/eliza.ts` and `app-core/src/runtime/eliza.ts` (different hunks — this PR centers on the `bootServerOnlyRuntime` call site + start endpoint). Rebased clean on develop at time of push; re-check on merge.
- Live model turn used the keyless claude-CLI provider (subscription host) rather than a paid API key; the cloud-key lane proved the same boot path with a (now-expired) dev cloud key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
