### PR TITLE
fix(cloud): reconcile's tailscale CLI must use the container's /tmp socket (#15228)

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-health-fallback.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-health-fallback.test.ts
@@ -1,0 +1,88 @@
+// checkHealth ingress selection on the docker sandbox provider: tailnet-first
+// with the node-side docker fallback that keeps a provision alive when the
+// CP-side mesh socket is cold, and the still-dies guarantee that a container
+// failing BOTH probes reports unhealthy — so a dead provision still times out
+// and the provision path's reprovision self-heal is preserved. The probes
+// themselves are spied (they are long-polling I/O loops); what this file pins
+// is the wiring: which probes run for which ingress, in which order, and how
+// the results combine.
+import { describe, expect, spyOn, test } from "bun:test";
+import { DockerSandboxProvider } from "../docker-sandbox-provider";
+import type { SandboxHandle } from "../sandbox-provider-types";
+
+type ProbeInternals = {
+  resolveContainer: (sandboxId: string) => Promise<unknown>;
+  pollTailnetHealth: (...args: unknown[]) => Promise<boolean>;
+  pollSshDockerHealth: (...args: unknown[]) => Promise<boolean>;
+};
+
+const META = {
+  nodeId: "node-1",
+  hostname: "node-1.internal",
+  containerName: "agent-test-1",
+  bridgePort: 18923,
+  webUiPort: 23816,
+  agentId: "agent-test-1",
+  sshPort: 22,
+  sshUser: "root",
+};
+
+function makeHandle(headscaleIp?: string): SandboxHandle {
+  return {
+    sandboxId: "agent-test-1",
+    bridgeUrl: "http://100.64.0.10:3000",
+    healthUrl: "http://100.64.0.10:3000/api",
+    metadata: {
+      provider: "docker",
+      ...META,
+      volumePath: "/data/agents/agent-test-1",
+      dockerImage: "ghcr.io/example/agent:latest",
+      imageDigest: null,
+      ...(headscaleIp ? { headscaleIp } : {}),
+    },
+  } as unknown as SandboxHandle;
+}
+
+function makeProvider(outcomes: { tailnet: boolean; sshDocker: boolean }) {
+  const provider = new DockerSandboxProvider();
+  const internals = provider as unknown as ProbeInternals;
+  const resolveSpy = spyOn(internals, "resolveContainer").mockResolvedValue(META);
+  const tailnetSpy = spyOn(internals, "pollTailnetHealth").mockResolvedValue(outcomes.tailnet);
+  const sshSpy = spyOn(internals, "pollSshDockerHealth").mockResolvedValue(outcomes.sshDocker);
+  return { provider, resolveSpy, tailnetSpy, sshSpy };
+}
+
+describe("DockerSandboxProvider.checkHealth tailnet → node-side docker fallback", () => {
+  test("tailnet pass is sufficient — the SSH fallback is never consulted", async () => {
+    const { provider, tailnetSpy, sshSpy } = makeProvider({ tailnet: true, sshDocker: false });
+    expect(await provider.checkHealth(makeHandle("100.64.0.10"))).toBe(true);
+    expect(tailnetSpy).toHaveBeenCalledTimes(1);
+    expect(sshSpy).not.toHaveBeenCalled();
+  });
+
+  test("tailnet miss + node-side docker healthy → healthy (cold CP mesh socket does not ghost-kill a healthy provision)", async () => {
+    const { provider, tailnetSpy, sshSpy } = makeProvider({ tailnet: false, sshDocker: true });
+    const before = Date.now();
+    expect(await provider.checkHealth(makeHandle("100.64.0.10"))).toBe(true);
+    expect(tailnetSpy).toHaveBeenCalledTimes(1);
+    expect(sshSpy).toHaveBeenCalledTimes(1);
+    // The fallback gets a FRESH deadline — the tailnet poll has already burned
+    // the primary window, so reusing it would make the fallback a zero-iteration no-op.
+    const [, fallbackDeadline] = sshSpy.mock.calls[0] as [unknown, number];
+    expect(fallbackDeadline).toBeGreaterThan(before);
+  });
+
+  test("STILL DIES: tailnet miss + node-side docker miss → unhealthy, so a dead provision still times out", async () => {
+    const { provider, tailnetSpy, sshSpy } = makeProvider({ tailnet: false, sshDocker: false });
+    expect(await provider.checkHealth(makeHandle("100.64.0.10"))).toBe(false);
+    expect(tailnetSpy).toHaveBeenCalledTimes(1);
+    expect(sshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("no headscale route → node-side docker health only, tailnet never dialed", async () => {
+    const { provider, tailnetSpy, sshSpy } = makeProvider({ tailnet: true, sshDocker: true });
+    expect(await provider.checkHealth(makeHandle())).toBe(true);
+    expect(tailnetSpy).not.toHaveBeenCalled();
+    expect(sshSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -444,6 +444,15 @@ const HEALTH_CHECK_POLL_INTERVAL_MS = 3_000;
  */
 export const HEALTH_CHECK_TIMEOUT_MS = 360_000;
 
+/**
+ * Budget for the node-side SSH fallback probe that runs after the tailnet
+ * poll has already burned the full HEALTH_CHECK_TIMEOUT_MS. Short on purpose:
+ * by then the container has had the whole tailnet window to boot, so docker
+ * health has settled — the fallback only needs to survive a couple of SSH
+ * round-trips, not a cold boot.
+ */
+const HEALTH_CHECK_SSH_FALLBACK_TIMEOUT_MS = 30_000;
+
 /** SSH command timeout for docker pull (can be slow on first pull). */
 export const PULL_TIMEOUT_MS = 300_000; // 5 min
 
@@ -1883,17 +1892,38 @@ export class DockerSandboxProvider implements SandboxProvider {
     const deadline = Date.now() + HEALTH_CHECK_TIMEOUT_MS;
 
     // When the agent is reachable over the headscale mesh, validate THAT
-    // ingress: the agent-router and the post-create runtime calls reach the
-    // agent over the tailnet, and the daemon is itself on the mesh. The SSH host
-    // probe below only proves the app bound the container's docker bridge, which
-    // happens before the tailnet/DERP path is warm — gating on it would let the
-    // first racing tailnet fetch tear the agent down despite it being healthy.
+    // ingress first: the agent-router and the post-create runtime calls reach
+    // the agent over the tailnet, and the daemon is itself on the mesh. The SSH
+    // host probe only proves the app bound the container's docker bridge, which
+    // happens before the tailnet/DERP path is warm — gating on it alone would
+    // let the first racing tailnet fetch tear the agent down despite it being
+    // healthy.
     const headscaleIp =
       typeof handle.metadata?.headscaleIp === "string" ? handle.metadata.headscaleIp : undefined;
     if (headscaleIp) {
-      return this.pollTailnetHealth(handle, meta, deadline);
+      if (await this.pollTailnetHealth(handle, meta, deadline)) return true;
+      // A cold CP-side mesh socket at provision time can miss every tailnet
+      // probe while the container is demonstrably healthy on its node; without
+      // this fallback the provision path ghost-kills that healthy container.
+      // Node-side docker health is NOT proof of tailnet reachability — the
+      // heartbeat cycle owns reconciling/escalating a stale tailnet IP — but at
+      // provision time it is enough evidence to avoid tearing down a container
+      // the node can prove is up. A container that fails BOTH probes still
+      // reports unhealthy, so a dead provision still times out and self-heals.
+      return this.pollSshDockerHealth(meta, Date.now() + HEALTH_CHECK_SSH_FALLBACK_TIMEOUT_MS);
     }
 
+    return this.pollSshDockerHealth(meta, deadline);
+  }
+
+  /**
+   * Node-side health: SSH to the docker node and pass when either the
+   * host-published ports answer or docker reports the container healthy. This
+   * is the only ingress evidence available without a headscale route, and the
+   * fallback that keeps a provision alive when the CP-side mesh socket is cold
+   * while the container itself is healthy.
+   */
+  private async pollSshDockerHealth(meta: ContainerMeta, deadline: number): Promise<boolean> {
     const ssh = DockerSSHClient.getClient(
       meta.hostname,
       meta.sshPort,
@@ -1910,8 +1940,11 @@ export class DockerSandboxProvider implements SandboxProvider {
       ].join(" "),
     )}`;
 
+    // The budget varies by caller (full window standalone, short window as the
+    // tailnet fallback), so log the actual one instead of a constant.
+    const budgetMs = Math.max(0, deadline - Date.now());
     logger.info(
-      `[docker-sandbox] Polling Docker health for ${meta.containerName} on ${meta.nodeId} (${meta.hostname}) (timeout: ${HEALTH_CHECK_TIMEOUT_MS / 1000}s)`,
+      `[docker-sandbox] Polling Docker health for ${meta.containerName} on ${meta.nodeId} (${meta.hostname}) (timeout: ${Math.round(budgetMs / 1000)}s)`,
     );
 
     while (Date.now() < deadline) {
@@ -1961,7 +1994,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
 
     logger.warn(
-      `[docker-sandbox] Docker health check timed out after ${HEALTH_CHECK_TIMEOUT_MS / 1000}s for ${meta.containerName} on ${meta.hostname}`,
+      `[docker-sandbox] Docker health check timed out after ${Math.round(budgetMs / 1000)}s for ${meta.containerName} on ${meta.hostname}`,
     );
     try {
       const diagnostics = await ssh.exec(

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -16,6 +16,7 @@ import { sharedRuntimeHistoryRepository } from "../../db/repositories/shared-run
 import { runWithCloudBindings } from "../runtime/cloud-bindings";
 import { logger } from "../utils/logger";
 import { apiKeysService } from "./api-keys";
+import { DockerSSHClient } from "./docker-ssh";
 import { resolveSandboxContainerLaunchConfig } from "./sandbox-container-launch-config";
 import type { SandboxProvider } from "./sandbox-provider-types";
 
@@ -763,6 +764,298 @@ describe("ElizaSandboxService heartbeat", () => {
       updateSpy.mockRestore();
     }
   });
+});
+
+// Stale-tailnet-IP reconciliation (heartbeat + recoverDisconnected). Agent
+// containers do not persist tailscale node state, so a container restart mints
+// a fresh node key → headscale assigns the NEXT IP → the stored headscale_ip /
+// bridge_url go stale while the container stays docker-healthy. These suites
+// pin the repair path (columns fixed in place, no reprovision of a healthy
+// container) AND every still-dies guard: dead containers, same-IP genuine
+// unreachability, failed re-probes, and the 3-cycle unresolvable escalation
+// must all still reach disconnected → the reprovision self-heal.
+describe("ElizaSandboxService tailnet-IP reconciliation", () => {
+  const OLD_IP = "100.64.0.10";
+  const NEW_IP = "100.64.0.11";
+  const STALE_BRIDGE = `http://${OLD_IP}:3000`;
+  const REPAIRED_BRIDGE = `http://${NEW_IP}:3000`;
+
+  function staleIpSandbox(overrides: Partial<AgentSandbox> = {}): AgentSandbox {
+    return {
+      ...customSandbox(),
+      bridge_url: STALE_BRIDGE,
+      health_url: `${STALE_BRIDGE}/api`,
+      headscale_ip: OLD_IP,
+      // 200s ago > 120s grace — the reconcile path only runs past grace.
+      last_heartbeat_at: new Date(Date.now() - 200_000),
+      ...overrides,
+    };
+  }
+
+  function nodeRecord(): DockerNode {
+    return {
+      node_id: "node-1",
+      hostname: "node-1.internal",
+      ssh_port: 22,
+      ssh_user: "root",
+      host_key_fingerprint: null,
+    } as unknown as DockerNode;
+  }
+
+  // One SSH client mock serving both node-side commands the reconcile issues:
+  // docker health inspect and the in-container `tailscale ip -4`.
+  function mockNodeSsh(opts: { health: string | Error; tailscaleIp: string | Error }) {
+    const exec = mock(async (cmd: string) => {
+      if (cmd.includes("docker inspect")) {
+        if (opts.health instanceof Error) throw opts.health;
+        return opts.health;
+      }
+      if (cmd.includes("tailscale ip")) {
+        if (opts.tailscaleIp instanceof Error) throw opts.tailscaleIp;
+        return opts.tailscaleIp;
+      }
+      throw new Error(`unexpected ssh command: ${cmd}`);
+    });
+    const getClientSpy = spyOn(DockerSSHClient, "getClient").mockReturnValue({
+      exec,
+    } as unknown as DockerSSHClient);
+    return { exec, getClientSpy };
+  }
+
+  // Bridge probes fail on the stale IP and answer 200 on the repaired one —
+  // exactly what a restarted container that re-registered under a new IP does.
+  function fetchAliveOnlyOnNewIp() {
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = fetchUrl(input);
+      if (url.includes(NEW_IP)) return new Response("ok", { status: 200 });
+      throw new Error(`unreachable: ${url}`);
+    });
+  }
+
+  function fetchAllDead() {
+    globalThis.fetch = mock(async () => {
+      throw new Error("unreachable");
+    });
+  }
+
+  test("(a) heartbeat: docker-healthy + new IP + repaired probe 200 → stays running with repaired columns", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox = staleIpSandbox();
+    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockResolvedValue(
+      sandbox,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
+      undefined as never,
+    );
+    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(nodeRecord());
+    // tailscale CLI prints the v4 line first; the parser must take the 100.x line.
+    const { getClientSpy } = mockNodeSsh({
+      health: "healthy",
+      tailscaleIp: `${NEW_IP}\nfd7a:115c:a1e0::1\n`,
+    });
+    fetchAliveOnlyOnNewIp();
+
+    try {
+      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      expect(ok).toBe(true);
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+      const [id, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+      expect(id).toBe(sandbox.id);
+      expect(patch.headscale_ip).toBe(NEW_IP);
+      expect(patch.bridge_url).toBe(REPAIRED_BRIDGE);
+      expect(patch.last_heartbeat_at).toBeInstanceOf(Date);
+      expect(patch.error_count).toBe(0);
+      // The row must NOT be disconnected — the whole point is no reprovision.
+      expect(patch.status).toBeUndefined();
+    } finally {
+      findSpy.mockRestore();
+      updateSpy.mockRestore();
+      nodeSpy.mockRestore();
+      getClientSpy.mockRestore();
+    }
+  }, 20_000);
+
+  test("(b) heartbeat: docker NOT healthy → disconnected (dead containers still self-heal via reprovision)", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox = staleIpSandbox();
+    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockResolvedValue(
+      sandbox,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
+      undefined as never,
+    );
+    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(nodeRecord());
+    const { exec, getClientSpy } = mockNodeSsh({ health: "unhealthy", tailscaleIp: NEW_IP });
+    fetchAllDead();
+
+    try {
+      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      expect(ok).toBe(false);
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+      const [, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+      expect(patch.status).toBe("disconnected");
+      expect(patch.headscale_ip).toBeUndefined();
+      // A dead container short-circuits — no IP resolve is attempted on it.
+      const tailscaleCalls = exec.mock.calls.filter(([cmd]) =>
+        String(cmd).includes("tailscale ip"),
+      );
+      expect(tailscaleCalls).toHaveLength(0);
+    } finally {
+      findSpy.mockRestore();
+      updateSpy.mockRestore();
+      nodeSpy.mockRestore();
+      getClientSpy.mockRestore();
+    }
+  }, 20_000);
+
+  test("(c) heartbeat: docker-healthy but the resolved IP equals the stored one → genuinely unreachable → disconnected", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox = staleIpSandbox();
+    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockResolvedValue(
+      sandbox,
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
+      undefined as never,
+    );
+    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(nodeRecord());
+    const { getClientSpy } = mockNodeSsh({ health: "healthy", tailscaleIp: OLD_IP });
+    fetchAllDead();
+
+    try {
+      const ok = await new ElizaSandboxService().heartbeat(sandbox.id, sandbox.organization_id);
+      expect(ok).toBe(false);
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+      const [, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+      expect(patch.status).toBe("disconnected");
+      expect(patch.headscale_ip).toBeUndefined();
+    } finally {
+      findSpy.mockRestore();
+      updateSpy.mockRestore();
+      nodeSpy.mockRestore();
+      getClientSpy.mockRestore();
+    }
+  }, 20_000);
+
+  test("(d) heartbeat: docker-healthy + IP unresolvable ratchets error_count and escalates to disconnected on the 3rd cycle", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    // error_count evolves across cycles the way the ratchet writes it.
+    let errorCount = 0;
+    const findSpy = spyOn(agentSandboxesRepository, "findRunningSandbox").mockImplementation(
+      async () => staleIpSandbox({ error_count: errorCount }),
+    );
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
+      undefined as never,
+    );
+    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(nodeRecord());
+    const { getClientSpy } = mockNodeSsh({
+      health: "healthy",
+      tailscaleIp: new Error("docker exec failed: container has no tailscale binary reachable"),
+    });
+    fetchAllDead();
+
+    try {
+      const svc = new ElizaSandboxService();
+      // Cycles 1 and 2: still running, error_count ratchets, NO disconnect.
+      for (const expected of [1, 2]) {
+        updateSpy.mockClear();
+        const ok = await svc.heartbeat(
+          "e06bb509-6c52-4c33-a9f7-66addc43e8c8",
+          "22222222-2222-4222-8222-222222222222",
+        );
+        expect(ok).toBe(false);
+        expect(updateSpy).toHaveBeenCalledTimes(1);
+        const [, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+        expect(patch.error_count).toBe(expected);
+        expect(patch.status).toBeUndefined();
+        errorCount = expected;
+      }
+      // Cycle 3 hits the cap: never keep an unreachable agent running forever.
+      updateSpy.mockClear();
+      const ok = await svc.heartbeat(
+        "e06bb509-6c52-4c33-a9f7-66addc43e8c8",
+        "22222222-2222-4222-8222-222222222222",
+      );
+      expect(ok).toBe(false);
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+      const [, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+      expect(patch.status).toBe("disconnected");
+    } finally {
+      findSpy.mockRestore();
+      updateSpy.mockRestore();
+      nodeSpy.mockRestore();
+      getClientSpy.mockRestore();
+    }
+  }, 40_000);
+
+  test("(e) recoverDisconnected: repaired IP + live re-probe → recovered with columns updated, no reprovision", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox = staleIpSandbox({ status: "disconnected" });
+    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(sandbox);
+    const casSpy = spyOn(
+      agentSandboxesRepository,
+      "markReconnectedFromDisconnected",
+    ).mockResolvedValue({ ...sandbox, status: "running" });
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
+      undefined as never,
+    );
+    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(nodeRecord());
+    const { getClientSpy } = mockNodeSsh({ health: "healthy", tailscaleIp: NEW_IP });
+    fetchAliveOnlyOnNewIp();
+
+    try {
+      const result = await new ElizaSandboxService().recoverDisconnected(
+        sandbox.id,
+        sandbox.organization_id,
+      );
+      expect(result).toBe("recovered");
+      expect(casSpy).toHaveBeenCalledTimes(1);
+      expect(casSpy.mock.calls[0]).toEqual([sandbox.id, "disconnected"]);
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+      const [id, patch] = updateSpy.mock.calls[0] as [string, Record<string, unknown>];
+      expect(id).toBe(sandbox.id);
+      expect(patch.headscale_ip).toBe(NEW_IP);
+      expect(patch.bridge_url).toBe(REPAIRED_BRIDGE);
+    } finally {
+      findSpy.mockRestore();
+      casSpy.mockRestore();
+      updateSpy.mockRestore();
+      nodeSpy.mockRestore();
+      getClientSpy.mockRestore();
+    }
+  }, 20_000);
+
+  test("(f) recoverDisconnected: repaired IP still dead → unreachable (reprovision path), nothing written", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const sandbox = staleIpSandbox({ status: "disconnected" });
+    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(sandbox);
+    const casSpy = spyOn(
+      agentSandboxesRepository,
+      "markReconnectedFromDisconnected",
+    ).mockResolvedValue(undefined);
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockResolvedValue(
+      undefined as never,
+    );
+    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(nodeRecord());
+    const { getClientSpy } = mockNodeSsh({ health: "healthy", tailscaleIp: NEW_IP });
+    fetchAllDead();
+
+    try {
+      const result = await new ElizaSandboxService().recoverDisconnected(
+        sandbox.id,
+        sandbox.organization_id,
+      );
+      // "unreachable" is the caller's contract to reprovision — same as before.
+      expect(result).toBe("unreachable");
+      expect(casSpy).not.toHaveBeenCalled();
+      expect(updateSpy).not.toHaveBeenCalled();
+    } finally {
+      findSpy.mockRestore();
+      casSpy.mockRestore();
+      updateSpy.mockRestore();
+      nodeSpy.mockRestore();
+      getClientSpy.mockRestore();
+    }
+  }, 30_000);
 });
 
 // The daemon handler for the `agent_resume` job. Covers the branch logic the

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -803,14 +803,14 @@ describe("ElizaSandboxService tailnet-IP reconciliation", () => {
   }
 
   // One SSH client mock serving both node-side commands the reconcile issues:
-  // docker health inspect and the in-container `tailscale ip -4`.
+  // docker health inspect and the in-container `tailscale --socket=... ip -4`.
   function mockNodeSsh(opts: { health: string | Error; tailscaleIp: string | Error }) {
     const exec = mock(async (cmd: string) => {
       if (cmd.includes("docker inspect")) {
         if (opts.health instanceof Error) throw opts.health;
         return opts.health;
       }
-      if (cmd.includes("tailscale ip")) {
+      if (cmd.includes("tailscale --socket")) {
         if (opts.tailscaleIp instanceof Error) throw opts.tailscaleIp;
         return opts.tailscaleIp;
       }
@@ -897,7 +897,7 @@ describe("ElizaSandboxService tailnet-IP reconciliation", () => {
       expect(patch.headscale_ip).toBeUndefined();
       // A dead container short-circuits — no IP resolve is attempted on it.
       const tailscaleCalls = exec.mock.calls.filter(([cmd]) =>
-        String(cmd).includes("tailscale ip"),
+        String(cmd).includes("tailscale --socket"),
       );
       expect(tailscaleCalls).toHaveLength(0);
     } finally {

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -4015,6 +4015,10 @@ export class ElizaSandboxService {
     }
     await agentSandboxesRepository.update(rec.id, {
       last_heartbeat_at: new Date(),
+      // Reset the unresolvable-cycle grace counter on any clean heartbeat so the
+      // "escalate after 3 consecutive unresolvable cycles" window measures from
+      // the last healthy beat, not a stale prior error_count from an old episode.
+      error_count: 0,
     });
     return true;
   }

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -58,6 +58,8 @@ import { apiKeysService } from "./api-keys";
 import { imageRequiresDigestPin, isCodingContainerImageAllowed } from "./coding-containers";
 import type { CreditReconciliationResult, CreditReservation } from "./credits";
 import type { DockerSandboxMetadata } from "./docker-sandbox-provider";
+import { shellQuote } from "./docker-sandbox-utils";
+import { DockerSSHClient } from "./docker-ssh";
 import {
   reusesExistingElizaCharacter,
   stripReservedElizaConfigKeys,
@@ -286,6 +288,20 @@ const HEARTBEAT_PROBE_RETRY_MS = 2_000;
 // on success) is the downtime clock. The ~30s heartbeat itself keeps the
 // WireGuard NAT mapping warm, so a reachable agent never trips this.
 const HEARTBEAT_DISCONNECT_AFTER_MS = 120_000;
+// IP reconciliation (heartbeat + recovery): agent containers do not persist
+// tailscale node state, so a container restart mints a fresh node key and
+// headscale hands out the NEXT sequential IP — the stored headscale_ip /
+// bridge_url go stale while the container itself is healthy. Every consumer
+// reads those stored columns (the heartbeat probe, the agent-router's
+// subdomain resolution, and therefore the public dedicated-agent proxy), so
+// the heal must REPAIR the columns, not tolerate the miss.
+const RECONCILE_SSH_CMD_TIMEOUT_MS = 15_000;
+// Cap on consecutive heartbeat cycles a docker-healthy container may stay
+// `running` while its current tailnet IP cannot be resolved (node SSH down,
+// docker exec failing). Each such cycle ratchets error_count; hitting the cap
+// escalates to `disconnected` so the recovery cycle's reprovision self-heal
+// still fires — an unreachable paid agent must never look "running" forever.
+const IP_RECONCILE_MAX_UNRESOLVED_CYCLES = 3;
 const SNAPSHOT_FETCH_TIMEOUT_MS = 120_000;
 const SNAPSHOT_RESTORE_TIMEOUT_MS = 120_000;
 const UPGRADE_RUNTIME_HEALTH_GATE_TIMEOUT_MS = 30_000;
@@ -296,6 +312,19 @@ const UPGRADE_RUNTIME_HEALTH_GATE_TIMEOUT_MS = 30_000;
 // provisioning worker. Generous over the internal caps, well under the watchdog.
 const SANDBOX_DELETE_STOP_TIMEOUT_MS = 120_000;
 type LifecycleTx = Parameters<Parameters<Database["transaction"]>[0]>[0];
+
+/** Columns the tailnet-IP reconcile path reads to locate and repair an agent. */
+type ReconcilableSandbox = Pick<
+  AgentSandbox,
+  "id" | "node_id" | "container_name" | "environment_vars" | "bridge_url" | "headscale_ip"
+>;
+
+/** Outcome of a stale-tailnet-IP reconcile attempt (see reconcileStaleTailnetIp). */
+type TailnetIpReconcileResult =
+  | { outcome: "repaired"; headscaleIp: string; bridgeUrl: string }
+  | { outcome: "container-dead" }
+  | { outcome: "ip-unresolvable" }
+  | { outcome: "unrepairable" };
 
 function digestPinnedImageRef(imageRef: string, digest: string): string {
   if (imageRef.includes("@sha256:")) return imageRef;
@@ -3936,9 +3965,48 @@ export class ElizaSandboxService {
         });
         return false;
       }
+      // Past-grace miss: before disconnecting (which reprovisions — destroying
+      // and rebuilding the container), check whether the container is alive but
+      // its stored tailnet IP went stale, and repair the columns in place. The
+      // repair heals every consumer at once (this probe, the agent-router, the
+      // public proxy) because they all read the same columns.
+      const reconcile = await this.reconcileStaleTailnetIp(rec);
+      if (reconcile.outcome === "repaired") {
+        await agentSandboxesRepository.update(rec.id, {
+          headscale_ip: reconcile.headscaleIp,
+          bridge_url: reconcile.bridgeUrl,
+          last_heartbeat_at: new Date(),
+          error_count: 0,
+        });
+        logger.info(
+          `[agent-sandbox] Reconciled stale tailnet IP ${rec.headscale_ip}→${reconcile.headscaleIp} for agent ${agentId}`,
+        );
+        return true;
+      }
+      if (reconcile.outcome === "ip-unresolvable") {
+        // Docker reports the container healthy but the node cannot tell us its
+        // current tailnet IP — indistinguishable from a transient SSH outage,
+        // so disconnecting now could destroy a healthy paid container. Ratchet
+        // error_count and only escalate once the cap of consecutive cycles is
+        // hit, so an agent that stays unresolvable still reaches the
+        // disconnect → reprovision self-heal instead of sitting unreachable
+        // at "running" forever.
+        const unresolvedCycles = (rec.error_count ?? 0) + 1;
+        if (unresolvedCycles < IP_RECONCILE_MAX_UNRESOLVED_CYCLES) {
+          await agentSandboxesRepository.update(rec.id, {
+            error_count: unresolvedCycles,
+          });
+          logger.warn(
+            "[agent-sandbox] Tailnet IP unresolvable for docker-healthy agent, deferring disconnect",
+            { agentId, unresolvedCycles },
+          );
+          return false;
+        }
+      }
       logger.warn("[agent-sandbox] Heartbeat failed past grace window, marking disconnected", {
         agentId,
         downForMs,
+        reconcileOutcome: reconcile.outcome,
       });
       await agentSandboxesRepository.update(rec.id, {
         status: "disconnected",
@@ -3989,6 +4057,141 @@ export class ElizaSandboxService {
       }
     }
     return false;
+  }
+
+  /**
+   * SSH client for the docker node hosting the agent's container. Returns null
+   * when the node cannot be located — the reconcile path treats that as "no
+   * signal", never as evidence either way.
+   */
+  private async getNodeSshForAgent(
+    rec: Pick<ReconcilableSandbox, "id" | "node_id">,
+  ): Promise<DockerSSHClient | null> {
+    if (!rec.node_id) return null;
+    // error-policy:J4 best-effort node resolve — a DB/SSH-config failure here is
+    // "cannot determine", not a heartbeat kill; the caller decides how to degrade.
+    try {
+      const node = await dockerNodesRepository.findByNodeId(rec.node_id);
+      if (!node) return null;
+      return DockerSSHClient.getClient(
+        node.hostname,
+        node.ssh_port,
+        node.host_key_fingerprint ?? undefined,
+        node.ssh_user,
+      );
+    } catch (error) {
+      logger.debug("[agent-sandbox] Failed to resolve docker node for reconcile", {
+        agentId: rec.id,
+        nodeId: rec.node_id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Node-side docker health for the agent's container. This is the authority
+   * that distinguishes a dead container (safe to disconnect → reprovision)
+   * from a live one whose stored tailnet IP went stale (must be repaired, not
+   * destroyed).
+   */
+  private async isContainerDockerHealthy(rec: ReconcilableSandbox): Promise<boolean> {
+    if (!rec.container_name) return false;
+    const ssh = await this.getNodeSshForAgent(rec);
+    if (!ssh) return false;
+    // error-policy:J4 best-effort probe — an exec failure yields "not proven
+    // healthy" (falls through to the existing disconnect self-heal), never a throw.
+    try {
+      const status = (
+        await ssh.exec(
+          `docker inspect --format '{{.State.Health.Status}}' ${shellQuote(rec.container_name)}`,
+          RECONCILE_SSH_CMD_TIMEOUT_MS,
+        )
+      ).trim();
+      return status === "healthy";
+    } catch (error) {
+      logger.debug("[agent-sandbox] Docker health inspect failed during reconcile", {
+        agentId: rec.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return false;
+    }
+  }
+
+  /**
+   * Resolve the container's CURRENT tailnet IP authoritatively from the node:
+   * `tailscale ip -4` inside the container is the same source the container
+   * registered with, so it reflects the post-restart node key/IP — unlike the
+   * stored headscale_ip, which is a provision-time snapshot.
+   */
+  private async resolveCurrentAgentTailnetIp(rec: ReconcilableSandbox): Promise<string | null> {
+    if (!rec.container_name) return null;
+    const ssh = await this.getNodeSshForAgent(rec);
+    if (!ssh) return null;
+    // error-policy:J4 best-effort resolve — a failed resolve returns null (no
+    // positive signal), never throws; the caller ratchets toward disconnect.
+    try {
+      const out = await ssh.exec(
+        `docker exec ${shellQuote(rec.container_name)} tailscale ip -4`,
+        RECONCILE_SSH_CMD_TIMEOUT_MS,
+      );
+      // First 100.64.0.0/10-shaped line; the CLI can also print IPv6 lines.
+      const ip = out
+        .split("\n")
+        .map((line) => line.trim())
+        .find((line) => line.startsWith("100."));
+      return ip && isIP(ip) === 4 ? ip : null;
+    } catch (error) {
+      logger.debug("[agent-sandbox] Current tailnet IP resolve failed during reconcile", {
+        agentId: rec.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Attempt to reconcile a bridge-probe miss as a stale stored tailnet IP.
+   * Containers do not persist tailscale node state, so a restart mints a fresh
+   * node key and headscale assigns the next IP — leaving headscale_ip /
+   * bridge_url pointing at a dead address that EVERY consumer reads (the
+   * heartbeat probe, the agent-router's subdomain resolution, and therefore
+   * the public dedicated-agent proxy). Repairing the columns heals them all;
+   * anything unrepairable falls back to the existing disconnect → reprovision
+   * self-heal. The repaired bridge_url keeps the stored scheme/port and swaps
+   * only the host — the same `http://<tailnetIp>:<containerPort>` shape the
+   * provisioner writes.
+   */
+  private async reconcileStaleTailnetIp(
+    rec: ReconcilableSandbox,
+  ): Promise<TailnetIpReconcileResult> {
+    if (!(await this.isContainerDockerHealthy(rec))) return { outcome: "container-dead" };
+    const currentIp = await this.resolveCurrentAgentTailnetIp(rec);
+    if (!currentIp) return { outcome: "ip-unresolvable" };
+    // Same IP as stored = nothing to repair: the miss is genuine
+    // unreachability at the correct address, so the dead-agent path applies.
+    if (!rec.bridge_url || currentIp === rec.headscale_ip) return { outcome: "unrepairable" };
+
+    let bridgeUrl: string;
+    try {
+      const repaired = new URL(rec.bridge_url);
+      repaired.hostname = currentIp;
+      bridgeUrl = repaired.origin;
+    } catch (error) {
+      // error-policy:J4 a malformed stored bridge_url cannot be repaired in
+      // place; degrade to the existing disconnect → reprovision self-heal.
+      logger.warn("[agent-sandbox] Stored bridge_url unparsable during reconcile", {
+        agentId: rec.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return { outcome: "unrepairable" };
+    }
+
+    // Only a live answer on the repaired address proves the new IP is the
+    // container we think it is — never persist an unverified repair.
+    const reachable = await this.probeBridgeHealth({ ...rec, bridge_url: bridgeUrl });
+    if (!reachable) return { outcome: "unrepairable" };
+    return { outcome: "repaired", headscaleIp: currentIp, bridgeUrl };
   }
 
   private async verifyUpgradeRuntimeHealth(args: {
@@ -4089,7 +4292,33 @@ export class ElizaSandboxService {
     if (!rec || (rec.status !== "disconnected" && rec.status !== "error")) return "gone";
     const recoverableStatus = rec.status;
     const reachable = await this.probeBridgeHealth(rec);
-    if (!reachable) return "unreachable";
+    if (!reachable) {
+      // The stored bridge_url may simply be stale (container restart → new
+      // tailnet IP) rather than the container being down. Repair-and-reprobe
+      // before declaring it unreachable, so recovery does not reprovision —
+      // destroy and rebuild — a healthy container that only needs its ingress
+      // columns fixed. Anything unrepairable stays "unreachable" and
+      // reprovisions exactly as before.
+      const reconcile = await this.reconcileStaleTailnetIp(rec);
+      if (reconcile.outcome !== "repaired") return "unreachable";
+      // Same guarded CAS as the plain recovery flip below: only revive a row
+      // that is STILL in the probed recoverable status, then persist the
+      // repaired ingress columns on the now-running row.
+      const revived = await agentSandboxesRepository.markReconnectedFromDisconnected(
+        rec.id,
+        recoverableStatus,
+      );
+      if (!revived) return "gone";
+      await agentSandboxesRepository.update(rec.id, {
+        headscale_ip: reconcile.headscaleIp,
+        bridge_url: reconcile.bridgeUrl,
+        error_count: 0,
+      });
+      logger.info(
+        `[agent-sandbox] Reconciled stale tailnet IP ${rec.headscale_ip}→${reconcile.headscaleIp} for agent ${agentId}`,
+      );
+      return "recovered";
+    }
     // Guarded CAS: the row can move to deletion_pending / stopped (which nulls
     // bridge_url) / provisioning during the multi-second probe. Only flip it if
     // it is STILL disconnected with a live bridge — otherwise we'd resurrect a

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -296,6 +296,12 @@ const HEARTBEAT_DISCONNECT_AFTER_MS = 120_000;
 // subdomain resolution, and therefore the public dedicated-agent proxy), so
 // the heal must REPAIR the columns, not tolerate the miss.
 const RECONCILE_SSH_CMD_TIMEOUT_MS = 15_000;
+// The agent entrypoint (cloud-agent-docker-entrypoint.sh) runs tailscaled on
+// this non-default socket (TS_SOCKET). The reconcile's in-container
+// `tailscale` CLI must be pointed at it, or it hits the default
+// /var/run/tailscale/tailscaled.sock (absent) and fails as if the daemon were
+// dead while it is actually alive here.
+const AGENT_CONTAINER_TS_SOCKET = "/tmp/tailscaled.sock";
 // Cap on consecutive heartbeat cycles a docker-healthy container may stay
 // `running` while its current tailnet IP cannot be resolved (node SSH down,
 // docker exec failing). Each such cycle ratchets error_count; hitting the cap
@@ -4127,6 +4133,12 @@ export class ElizaSandboxService {
    * `tailscale ip -4` inside the container is the same source the container
    * registered with, so it reflects the post-restart node key/IP — unlike the
    * stored headscale_ip, which is a provision-time snapshot.
+   *
+   * The CLI MUST be pointed at the container's non-default socket: the agent
+   * entrypoint (cloud-agent-docker-entrypoint.sh) starts tailscaled with
+   * `--socket=/tmp/tailscaled.sock` (TS_SOCKET), so a bare `tailscale ip` hits
+   * the default `/var/run/tailscale/tailscaled.sock`, which does not exist, and
+   * fails with "tailscaled.sock: no such file" even though the daemon is alive.
    */
   private async resolveCurrentAgentTailnetIp(rec: ReconcilableSandbox): Promise<string | null> {
     if (!rec.container_name) return null;
@@ -4136,7 +4148,7 @@ export class ElizaSandboxService {
     // positive signal), never throws; the caller ratchets toward disconnect.
     try {
       const out = await ssh.exec(
-        `docker exec ${shellQuote(rec.container_name)} tailscale ip -4`,
+        `docker exec ${shellQuote(rec.container_name)} tailscale --socket=${AGENT_CONTAINER_TS_SOCKET} ip -4`,
         RECONCILE_SSH_CMD_TIMEOUT_MS,
       );
       // First 100.64.0.0/10-shaped line; the CLI can also print IPv6 lines.


### PR DESCRIPTION
Follow-up to #15243. The IP-reconcile's `resolveCurrentAgentTailnetIp` ran `tailscale ip -4` in-container, hitting the **default** socket `/var/run/tailscale/tailscaled.sock` — but the agent entrypoint (`cloud-agent-docker-entrypoint.sh`) starts tailscaled on `--socket=/tmp/tailscaled.sock`. So every resolve failed "tailscaled.sock: no such file" **as if the daemon were dead**, making reconcile a no-op and letting the churn continue (this is what #15261 misdiagnosed as tailscaled-death).

**Proven live on a running agent container:**
```
tailscale ip -4                              → Failed to connect ... /var/run/tailscale/tailscaled.sock: no such file
tailscale --socket=/tmp/tailscaled.sock ip -4 → 100.64.1.233   ✓ (daemon alive)
```

Fix: pass `--socket=/tmp/tailscaled.sock` so resolve reaches the live daemon → the repair (headscale_ip/bridge_url) actually fires → churning agents get reconciled instead of reprovisioned. Suite **71/0**, typecheck + biome clean. Closes the real mechanism behind #15261. — [qa-agent]