### PR TITLE
fix(cloud): trusted-bridge restore push must carry the agent token — fleet-wide restore-401 from the image roll (#15261)

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -240,6 +240,84 @@ describe("resolveSandboxContainerLaunchConfig", () => {
   });
 });
 
+describe("ElizaSandboxService state restore auth", () => {
+  test("attaches the agent token when restoring to a trusted bridge URL string", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const requests: Array<{
+      url: string;
+      headers: Record<string, string>;
+      body: string;
+    }> = [];
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push({
+        url: fetchUrl(input),
+        headers: fetchHeaders(init?.headers),
+        body: String(init?.body ?? ""),
+      });
+      return Response.json({ ok: true });
+    });
+
+    const sandbox = customSandbox();
+    await (
+      new ElizaSandboxService() as unknown as {
+        pushState: (
+          bridgeUrl: string,
+          state: { memories: unknown[]; config: Record<string, unknown>; workspaceFiles: object },
+          options: { trusted: true; authRec: Pick<AgentSandbox, "id" | "environment_vars"> },
+        ) => Promise<void>;
+      }
+    ).pushState(
+      "https://runtime.example",
+      { memories: [], config: { restored: true }, workspaceFiles: {} },
+      { trusted: true, authRec: sandbox },
+    );
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0].url).toBe("https://runtime.example/api/restore");
+    expect(requests[0].headers).toMatchObject({
+      "Content-Type": "application/json",
+      Authorization: "Bearer agent-token",
+      "X-Api-Key": "agent-token",
+      "X-Eliza-Token": "agent-token",
+    });
+    expect(JSON.parse(requests[0].body)).toEqual({
+      memories: [],
+      config: { restored: true },
+      workspaceFiles: {},
+    });
+  });
+
+  test("keeps legacy bridge URL restores unauthenticated when no sandbox record is supplied", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const requests: Array<{ headers: Record<string, string> }> = [];
+    globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push({ headers: fetchHeaders(init?.headers) });
+      return Response.json({ ok: true });
+    });
+
+    await (
+      new ElizaSandboxService() as unknown as {
+        pushState: (
+          bridgeUrl: string,
+          state: { memories: unknown[]; config: Record<string, unknown>; workspaceFiles: object },
+          options?: { trusted?: boolean },
+        ) => Promise<void>;
+      }
+    ).pushState(
+      "https://runtime.example",
+      {
+        memories: [],
+        config: {},
+        workspaceFiles: {},
+      },
+      { trusted: true },
+    );
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0].headers).toEqual({ "Content-Type": "application/json" });
+  });
+});
+
 describe("ElizaSandboxService bridge status", () => {
   test("reports web-only custom agents as running through the router origin in Workers", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -1598,7 +1598,10 @@ export class ElizaSandboxService {
         }
         if (restoreState) {
           try {
-            await this.pushState(handle.bridgeUrl, restoreState, { trusted: true });
+            await this.pushState(handle.bridgeUrl, restoreState, {
+              trusted: true,
+              authRec: rec,
+            });
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             if (
@@ -5298,7 +5301,10 @@ export class ElizaSandboxService {
       );
       if (restoreState) {
         try {
-          await this.pushState(blueHandle.bridgeUrl, restoreState, { trusted: true });
+          await this.pushState(blueHandle.bridgeUrl, restoreState, {
+            trusted: true,
+            authRec: agent,
+          });
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           await provider.stop(blueHandle.sandboxId).catch((stopErr) =>
@@ -5705,7 +5711,17 @@ export class ElizaSandboxService {
         >
       | string,
     state: AgentBackupStateData,
-    options?: { trusted?: boolean },
+    options?: {
+      trusted?: boolean;
+      // Bridge-URL callers pass a bare string, so `pushState` cannot derive the
+      // agent's ELIZA_API_TOKEN from it and the trusted branch used to send no
+      // auth header. That worked while `/api/restore` exempted trusted-bridge
+      // requests, but the cloud agent image now requires the token even over the
+      // tailnet (server-helpers-auth `isCloudProvisionedContainer()` disables the
+      // local-trust exemption) — so an unauthenticated restore deterministically
+      // 401s (#15261). Pass the sandbox record here to attach the token.
+      authRec?: Pick<AgentSandbox, "id" | "environment_vars">;
+    },
   ) {
     const restoreEndpoint =
       typeof sandboxOrBridgeUrl === "string"
@@ -5715,7 +5731,9 @@ export class ElizaSandboxService {
       method: "POST",
       headers:
         typeof sandboxOrBridgeUrl === "string"
-          ? { "Content-Type": "application/json" }
+          ? options?.authRec
+            ? this.getAgentJsonHeaders(options.authRec)
+            : { "Content-Type": "application/json" }
           : this.getAgentJsonHeaders(sandboxOrBridgeUrl),
       body: JSON.stringify(state),
       signal: AbortSignal.timeout(SNAPSHOT_RESTORE_TIMEOUT_MS),


### PR DESCRIPTION
## Fleet-wide restore-401 regression (#15261)

Blue/green restore succeeded on the old image, then resume/restore started returning HTTP 401 after the default agent image rolled forward to a build whose `/api/restore` requires the agent token even over the trusted tailnet bridge.

The worker's resume and blue/green restore paths passed a bare bridge URL string to `pushState`. Before this PR, the string branch sent only `Content-Type`; the sandbox-object branch already sent the token headers. This PR threads the sandbox record into the trusted string-bridge restore calls and uses `getAgentJsonHeaders` there too.

## Tests

- `bun install --frozen-lockfile --ignore-scripts`
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/core build`
- `bun test --reporter=dots --coverage-reporter=lcov src/lib/services/eliza-sandbox.test.ts` from `packages/cloud/shared` -> 68 pass / 0 fail

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend worker-to-container restore auth path; no rendered UI surface.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend worker-to-container restore auth path; no rendered UI surface.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend service request-header behavior; focused service test covers the restored path.

<!-- evidence-row:backend-logs -->
- [ ] Focused service test output: `bun test --reporter=dots --coverage-reporter=lcov src/lib/services/eliza-sandbox.test.ts` passed 68/68 locally; coverage is in [eliza-sandbox.test.ts](packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts).

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or agent planning behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifact is the trusted restore request captured in [eliza-sandbox.test.ts](packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts): string bridge URL restore now sends `Authorization`, `X-Api-Key`, and `X-Eliza-Token` from `ELIZA_API_TOKEN`.
