### PR TITLE
fix(cloud): degrade to fresh boot on unrecoverable snapshot retrieval, not just decrypt

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -2106,6 +2106,7 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       agentSandboxesRepository,
       "getReconstructedBackupState",
     ).mockResolvedValue({ memories: [], config: {}, workspaceFiles: {} });
+    const pruneSpy = spyOn(agentSandboxesRepository, "pruneBackups").mockResolvedValue(0);
     let runningWrites = 0;
     const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
       async (_id, data) => {
@@ -2148,12 +2149,16 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       expect(markErrorSpy).toHaveBeenCalledTimes(1);
       // Ghost cleanup still stops the container whose restore failed.
       expect(stop).toHaveBeenCalledWith("sandbox-blue-1");
+      // A transient 5xx must NOT be classified as unrecoverable: the snapshot
+      // chain stays intact for the retry that may restore it.
+      expect(pruneSpy).not.toHaveBeenCalled();
     } finally {
       findSpy.mockRestore();
       findByIdSpy.mockRestore();
       lockSpy.mockRestore();
       backupSpy.mockRestore();
       reconstructedSpy.mockRestore();
+      pruneSpy.mockRestore();
       updateSpy.mockRestore();
       apiKeySpy.mockRestore();
       markErrorSpy.mockRestore();
@@ -2221,7 +2226,7 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       expect(pruneSpy).toHaveBeenCalledWith(AGENT, 0);
       // The degrade is logged with context, never silent.
       const logged = errorLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
-      expect(logged).toContain("Undecryptable snapshot, booting fresh");
+      expect(logged).toContain("Unrecoverable snapshot, booting fresh");
       // A degrade is not a container failure — no ghost cleanup.
       expect(stop).not.toHaveBeenCalled();
     } finally {
@@ -2305,7 +2310,7 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       expect(pushStateSpy).not.toHaveBeenCalled();
       expect(pruneSpy).toHaveBeenCalledWith(AGENT, 0);
       const logged = errorLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
-      expect(logged).toContain("Undecryptable snapshot, booting fresh");
+      expect(logged).toContain("Unrecoverable snapshot, booting fresh");
     } finally {
       findSpy.mockRestore();
       lockSpy.mockRestore();
@@ -2376,7 +2381,7 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       // Must NOT degrade: the snapshot chain is untouched, no degrade logged.
       expect(pruneSpy).not.toHaveBeenCalled();
       const logged = errorLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
-      expect(logged).not.toContain("Undecryptable snapshot");
+      expect(logged).not.toContain("Unrecoverable snapshot");
       // Ghost cleanup still stops the just-created container.
       expect(stop).toHaveBeenCalledTimes(1);
     } finally {
@@ -2393,43 +2398,368 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       getProviderSpy.mockRestore();
     }
   });
+
+  // The HQ 14308 incident, end to end: the restore push to the new container is
+  // rejected 401 Unauthorized (bridge URL routing to a dead/rotated container),
+  // which is deterministic on every attempt — retrying only burned the
+  // provision attempts and bricked agent 23766030 into status=error
+  // ("Provisioning failed after 3 attempts: State restore failed: HTTP 401
+  // {"error":"Unauthorized"}"). It must instead degrade to a fresh boot on the
+  // FIRST detection. Drives the REAL pushState (fetch intercepted with the
+  // incident's exact response) so the classified error is the code's own throw
+  // shape, not a hand-rolled string.
+  test("(13) restore push rejected 401 (dead/rotated container) degrades to a fresh boot on the first attempt", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const row: AgentSandbox = { ...provisioningReadyRow(), execution_tier: "dedicated-lazy" };
+    const finalRow: AgentSandbox = { ...row, status: "running" };
+    const backup: AgentSandboxBackup = {
+      id: "66666666-6666-4666-8666-666666666666",
+      sandbox_record_id: row.id,
+      snapshot_type: "pre-shutdown",
+      state_data: { memories: [], config: {}, workspaceFiles: {} },
+      state_data_storage: "inline",
+      state_data_key: null,
+      size_bytes: 2,
+      backup_kind: "full",
+      parent_backup_id: null,
+      content_hash: null,
+      created_at: new Date("2026-06-04T12:05:00.000Z"),
+    };
+    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
+    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+      ...row,
+      status: "provisioning",
+    });
+    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(backup);
+    const reconstructedSpy = spyOn(
+      agentSandboxesRepository,
+      "getReconstructedBackupState",
+    ).mockResolvedValue({ memories: [], config: {}, workspaceFiles: {} });
+    const pruneSpy = spyOn(agentSandboxesRepository, "pruneBackups").mockResolvedValue(1);
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+      async (_id, data) => (data.status === "running" ? finalRow : { ...row, ...data }),
+    );
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
+      id: "22222222-2222-4222-8222-222222222222",
+      plainKey: "eliza_test_agent_key",
+      prefix: "eliza_test",
+    });
+    const errorLogSpy = spyOn(logger, "error").mockImplementation(() => {});
+    const svc = new ElizaSandboxService();
+    const markErrorSpy = spyOn(
+      svc as unknown as { markError: (rec: AgentSandbox, msg: string) => Promise<void> },
+      "markError",
+    ).mockResolvedValue(undefined);
+    const ensureStartedSpy = spyOn(
+      svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
+      "ensureRuntimeAgentStarted",
+    ).mockResolvedValue(null);
+    // REAL pushState: only the fetch layer is intercepted, replaying the
+    // incident's exact response, so the thrown error is pushState's own
+    // `State restore failed: HTTP 401 {"error":"Unauthorized"}`.
+    const restoreCalls: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      restoreCalls.push(fetchUrl(input));
+      return new Response('{"error":"Unauthorized"}', { status: 401 });
+    }) as typeof fetch;
+    const create = mock(async () => providerHandle());
+    const stop = mock(async () => {});
+    const getProviderSpy = spyOn(
+      svc as unknown as { getProvider: () => Promise<SandboxProvider> },
+      "getProvider",
+    ).mockResolvedValue({ create, stop, checkHealth: async () => true } as SandboxProvider);
+    try {
+      const res = await svc.provision(AGENT, ORG);
+      // Fresh boot: the provision SUCCEEDS instead of bricking the agent.
+      expect(res.success).toBe(true);
+      expect(res.sandboxRecord).toBe(finalRow);
+      // The restore POST really went to the new container's bridge.
+      expect(restoreCalls).toEqual(["https://runtime-blue.example/api/restore"]);
+      // Degrade on FIRST detection: one create, no retry burn, no ghost
+      // cleanup of the healthy container, no markError.
+      expect(create).toHaveBeenCalledTimes(1);
+      expect(stop).not.toHaveBeenCalled();
+      expect(markErrorSpy).not.toHaveBeenCalled();
+      // The dead chain is dropped so the next resume boots clean.
+      expect(pruneSpy).toHaveBeenCalledWith(AGENT, 0);
+      const logged = errorLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
+      expect(logged).toContain("Unrecoverable snapshot, booting fresh");
+    } finally {
+      findSpy.mockRestore();
+      lockSpy.mockRestore();
+      backupSpy.mockRestore();
+      reconstructedSpy.mockRestore();
+      pruneSpy.mockRestore();
+      updateSpy.mockRestore();
+      apiKeySpy.mockRestore();
+      errorLogSpy.mockRestore();
+      markErrorSpy.mockRestore();
+      ensureStartedSpy.mockRestore();
+      getProviderSpy.mockRestore();
+    }
+  });
+
+  // A restore-endpoint 404 on a NON-custom tier is equally deterministic (the
+  // image will never grow the endpoint mid-provision) — same degrade, via the
+  // real pushState throw shape.
+  test("(14) restore push rejected 404 on a non-custom tier degrades to a fresh boot", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const row: AgentSandbox = { ...provisioningReadyRow(), execution_tier: "dedicated-lazy" };
+    const finalRow: AgentSandbox = { ...row, status: "running" };
+    const backup: AgentSandboxBackup = {
+      id: "77777777-7777-4777-8777-777777777777",
+      sandbox_record_id: row.id,
+      snapshot_type: "pre-shutdown",
+      state_data: { memories: [], config: {}, workspaceFiles: {} },
+      state_data_storage: "inline",
+      state_data_key: null,
+      size_bytes: 2,
+      backup_kind: "full",
+      parent_backup_id: null,
+      content_hash: null,
+      created_at: new Date("2026-06-04T12:05:00.000Z"),
+    };
+    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
+    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+      ...row,
+      status: "provisioning",
+    });
+    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(backup);
+    const reconstructedSpy = spyOn(
+      agentSandboxesRepository,
+      "getReconstructedBackupState",
+    ).mockResolvedValue({ memories: [], config: {}, workspaceFiles: {} });
+    const pruneSpy = spyOn(agentSandboxesRepository, "pruneBackups").mockResolvedValue(1);
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+      async (_id, data) => (data.status === "running" ? finalRow : { ...row, ...data }),
+    );
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
+      id: "22222222-2222-4222-8222-222222222222",
+      plainKey: "eliza_test_agent_key",
+      prefix: "eliza_test",
+    });
+    const errorLogSpy = spyOn(logger, "error").mockImplementation(() => {});
+    const svc = new ElizaSandboxService();
+    const markErrorSpy = spyOn(
+      svc as unknown as { markError: (rec: AgentSandbox, msg: string) => Promise<void> },
+      "markError",
+    ).mockResolvedValue(undefined);
+    const ensureStartedSpy = spyOn(
+      svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
+      "ensureRuntimeAgentStarted",
+    ).mockResolvedValue(null);
+    globalThis.fetch = (async () => new Response("Not Found", { status: 404 })) as typeof fetch;
+    const create = mock(async () => providerHandle());
+    const stop = mock(async () => {});
+    const getProviderSpy = spyOn(
+      svc as unknown as { getProvider: () => Promise<SandboxProvider> },
+      "getProvider",
+    ).mockResolvedValue({ create, stop, checkHealth: async () => true } as SandboxProvider);
+    try {
+      const res = await svc.provision(AGENT, ORG);
+      expect(res.success).toBe(true);
+      expect(markErrorSpy).not.toHaveBeenCalled();
+      expect(stop).not.toHaveBeenCalled();
+      expect(pruneSpy).toHaveBeenCalledWith(AGENT, 0);
+      const logged = errorLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
+      expect(logged).toContain("Unrecoverable snapshot, booting fresh");
+    } finally {
+      findSpy.mockRestore();
+      lockSpy.mockRestore();
+      backupSpy.mockRestore();
+      reconstructedSpy.mockRestore();
+      pruneSpy.mockRestore();
+      updateSpy.mockRestore();
+      apiKeySpy.mockRestore();
+      errorLogSpy.mockRestore();
+      markErrorSpy.mockRestore();
+      ensureStartedSpy.mockRestore();
+      getProviderSpy.mockRestore();
+    }
+  });
+
+  // Custom-tier images legitimately lack /api/restore: that 404 stays the
+  // designed benign skip — the snapshot is KEPT (no prune) for a future image
+  // that has the endpoint. Guards the branch ordering: the skip must win over
+  // the unrecoverable degrade.
+  test("(15) restore push 404 on a custom tier stays a benign skip — snapshot kept, no degrade", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const row = provisioningReadyRow(); // execution_tier: "custom"
+    const finalRow: AgentSandbox = { ...row, status: "running" };
+    const backup: AgentSandboxBackup = {
+      id: "88888888-8888-4888-8888-888888888888",
+      sandbox_record_id: row.id,
+      snapshot_type: "pre-shutdown",
+      state_data: { memories: [], config: {}, workspaceFiles: {} },
+      state_data_storage: "inline",
+      state_data_key: null,
+      size_bytes: 2,
+      backup_kind: "full",
+      parent_backup_id: null,
+      content_hash: null,
+      created_at: new Date("2026-06-04T12:05:00.000Z"),
+    };
+    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
+    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+      ...row,
+      status: "provisioning",
+    });
+    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(backup);
+    const reconstructedSpy = spyOn(
+      agentSandboxesRepository,
+      "getReconstructedBackupState",
+    ).mockResolvedValue({ memories: [], config: {}, workspaceFiles: {} });
+    const pruneSpy = spyOn(agentSandboxesRepository, "pruneBackups").mockResolvedValue(0);
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+      async (_id, data) => (data.status === "running" ? finalRow : { ...row, ...data }),
+    );
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
+      id: "22222222-2222-4222-8222-222222222222",
+      plainKey: "eliza_test_agent_key",
+      prefix: "eliza_test",
+    });
+    const infoLogSpy = spyOn(logger, "info").mockImplementation(() => {});
+    const errorLogSpy = spyOn(logger, "error").mockImplementation(() => {});
+    const svc = new ElizaSandboxService();
+    const ensureStartedSpy = spyOn(
+      svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
+      "ensureRuntimeAgentStarted",
+    ).mockResolvedValue(null);
+    globalThis.fetch = (async () => new Response("Not Found", { status: 404 })) as typeof fetch;
+    const create = mock(async () => providerHandle());
+    const getProviderSpy = spyOn(
+      svc as unknown as { getProvider: () => Promise<SandboxProvider> },
+      "getProvider",
+    ).mockResolvedValue({
+      create,
+      stop: mock(async () => {}),
+      checkHealth: async () => true,
+    } as SandboxProvider);
+    try {
+      const res = await svc.provision(AGENT, ORG);
+      expect(res.success).toBe(true);
+      // Benign skip, not a degrade: chain untouched, no error-level log.
+      expect(pruneSpy).not.toHaveBeenCalled();
+      const info = infoLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
+      expect(info).toContain("custom image has no restore endpoint");
+      const logged = errorLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
+      expect(logged).not.toContain("Unrecoverable snapshot");
+    } finally {
+      findSpy.mockRestore();
+      lockSpy.mockRestore();
+      backupSpy.mockRestore();
+      reconstructedSpy.mockRestore();
+      pruneSpy.mockRestore();
+      updateSpy.mockRestore();
+      apiKeySpy.mockRestore();
+      infoLogSpy.mockRestore();
+      errorLogSpy.mockRestore();
+      ensureStartedSpy.mockRestore();
+      getProviderSpy.mockRestore();
+    }
+  });
 });
 
-// Snapshot-degrade error classification (`isUndecryptableSnapshotError`), proven
+// Snapshot-degrade error classification (`isUnrecoverableSnapshotError`), proven
 // against REAL @elizaos/security errors produced by the crypto stack — the
 // precise crypto-vs-transient distinction the degrade path keys on.
-describe("isUndecryptableSnapshotError (KMS timebomb classification)", () => {
-  test("classifies a real KeyNotFoundError (memory-KMS key rotated away) as undecryptable", async () => {
-    const { isUndecryptableSnapshotError } = await import("./eliza-sandbox.ts?actual");
+describe("isUnrecoverableSnapshotError (permanent-vs-transient classification)", () => {
+  test("classifies a real KeyNotFoundError (memory-KMS key rotated away) as unrecoverable", async () => {
+    const { isUnrecoverableSnapshotError } = await import("./eliza-sandbox.ts?actual");
     const err = await realKeyRotatedAwayError();
     // The exact prod incident: the memory backend restart orphaned the key.
     expect(err).toBeInstanceOf(KeyNotFoundError);
-    expect(isUndecryptableSnapshotError(err)).toBe(true);
+    expect(isUnrecoverableSnapshotError(err)).toBe(true);
   });
 
-  test("classifies a real AeadError (auth-tag failure) as undecryptable", async () => {
-    const { isUndecryptableSnapshotError } = await import("./eliza-sandbox.ts?actual");
+  test("classifies a real AeadError (auth-tag failure) as unrecoverable", async () => {
+    const { isUnrecoverableSnapshotError } = await import("./eliza-sandbox.ts?actual");
     const err = await realAeadDecryptError();
     expect(err.name).toBe("AeadError");
-    expect(isUndecryptableSnapshotError(err)).toBe(true);
+    expect(isUnrecoverableSnapshotError(err)).toBe(true);
   });
 
-  test("does NOT classify transient / non-crypto failures as undecryptable", async () => {
-    const { isUndecryptableSnapshotError } = await import("./eliza-sandbox.ts?actual");
+  test("classifies permanent snapshot HTTP rejections (401/403/404/410) as unrecoverable", async () => {
+    const { isUnrecoverableSnapshotError } = await import("./eliza-sandbox.ts?actual");
+    // The exact HQ 14308 incident string, as pushState throws it (status +
+    // first 200 bytes of the response body).
+    expect(
+      isUnrecoverableSnapshotError(
+        new Error('State restore failed: HTTP 401 {"error":"Unauthorized"}'),
+      ),
+    ).toBe(true);
+    expect(isUnrecoverableSnapshotError(new Error("State restore failed: HTTP 403 "))).toBe(true);
+    expect(
+      isUnrecoverableSnapshotError(new Error("State restore failed: HTTP 404 Not Found")),
+    ).toBe(true);
+    expect(isUnrecoverableSnapshotError(new Error("State restore failed: HTTP 410 Gone"))).toBe(
+      true,
+    );
+    // fetchSnapshotState's shape (no body suffix). Its 404 is mapped to the
+    // SNAPSHOT_ENDPOINT_UNSUPPORTED sentinel before ever surfacing, but the
+    // auth statuses surface verbatim.
+    expect(isUnrecoverableSnapshotError(new Error("Snapshot fetch failed: HTTP 401"))).toBe(true);
+    expect(isUnrecoverableSnapshotError(new Error("Snapshot fetch failed: HTTP 403"))).toBe(true);
+    expect(isUnrecoverableSnapshotError(new Error("Snapshot fetch failed: HTTP 410"))).toBe(true);
+  });
+
+  test("does NOT classify transient snapshot HTTP failures — those must retry", async () => {
+    const { isUnrecoverableSnapshotError } = await import("./eliza-sandbox.ts?actual");
+    // 5xx (container mid-boot / overloaded), 408 (timeout), 429 (throttled):
+    // all can heal on the next attempt, so degrading would discard restorable
+    // state.
+    expect(
+      isUnrecoverableSnapshotError(
+        new Error("State restore failed: HTTP 500 Internal Server Error"),
+      ),
+    ).toBe(false);
+    expect(
+      isUnrecoverableSnapshotError(new Error("State restore failed: HTTP 502 Bad Gateway")),
+    ).toBe(false);
+    expect(isUnrecoverableSnapshotError(new Error("State restore failed: HTTP 503 "))).toBe(false);
+    expect(isUnrecoverableSnapshotError(new Error("State restore failed: HTTP 408 "))).toBe(false);
+    expect(isUnrecoverableSnapshotError(new Error("State restore failed: HTTP 429 "))).toBe(false);
+    expect(isUnrecoverableSnapshotError(new Error("Snapshot fetch failed: HTTP 500"))).toBe(false);
+    expect(isUnrecoverableSnapshotError(new Error("Snapshot fetch failed: HTTP 503"))).toBe(false);
+  });
+
+  test("matches only this file's snapshot throw shapes — anchored, exact status", async () => {
+    const { isUnrecoverableSnapshotError, SNAPSHOT_ENDPOINT_UNSUPPORTED } = await import(
+      "./eliza-sandbox.ts?actual"
+    );
+    // Network-level fetch failures carry no HTTP status and must propagate.
+    expect(isUnrecoverableSnapshotError(new TypeError("fetch failed"))).toBe(false);
+    // A message that merely EMBEDS the wrapper (e.g. the markError re-wrap) is
+    // not the raw restore-path error the degrade classifies.
+    expect(
+      isUnrecoverableSnapshotError(
+        new Error(
+          'Provisioning failed after 3 attempts: State restore failed: HTTP 401 {"error":"Unauthorized"}',
+        ),
+      ),
+    ).toBe(false);
+    // The "image has no snapshot endpoint" sentinel is a benign skip elsewhere,
+    // never a degrade.
+    expect(isUnrecoverableSnapshotError(new Error(SNAPSHOT_ENDPOINT_UNSUPPORTED))).toBe(false);
+    expect(isUnrecoverableSnapshotError(new Error("Sandbox is not running"))).toBe(false);
+  });
+
+  test("does NOT classify transient / non-crypto failures as unrecoverable", async () => {
+    const { isUnrecoverableSnapshotError } = await import("./eliza-sandbox.ts?actual");
     // A DB/network blip, a base Steward KmsError (HTTP 5xx transient), and
     // non-Errors must all propagate — degrading on them would discard state a
     // retry would have restored.
-    expect(isUndecryptableSnapshotError(new Error("connection terminated unexpectedly"))).toBe(
+    expect(isUnrecoverableSnapshotError(new Error("connection terminated unexpectedly"))).toBe(
       false,
     );
     expect(
-      isUndecryptableSnapshotError(
+      isUnrecoverableSnapshotError(
         new KmsError("Steward KMS decrypt failed (503 Service Unavailable)"),
       ),
     ).toBe(false);
-    expect(isUndecryptableSnapshotError("AEAD decrypt failed")).toBe(false);
-    expect(isUndecryptableSnapshotError(null)).toBe(false);
-    expect(isUndecryptableSnapshotError(undefined)).toBe(false);
+    expect(isUnrecoverableSnapshotError("AEAD decrypt failed")).toBe(false);
+    expect(isUnrecoverableSnapshotError(null)).toBe(false);
+    expect(isUnrecoverableSnapshotError(undefined)).toBe(false);
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -395,28 +395,53 @@ export function computeManagedAgentDbEnv(
     : { DATABASE_URL: dbUri };
 }
 
+// HTTP statuses that make a snapshot fetch/restore deterministically fail for
+// THIS snapshot: 401/403 (auth — a dead/rotated container or rotated token
+// rejects every retry identically), 404 (endpoint or snapshot gone), 410
+// (gone). Everything else — 5xx, 408/429, network/timeout — can heal on a
+// retry and must NOT appear here.
+const PERMANENT_SNAPSHOT_HTTP_STATUSES = new Set([401, 403, 404, 410]);
+// Anchored on the exact `fetchSnapshotState` / `pushState` throw shapes so only
+// this file's snapshot HTTP throw sites classify — an unrelated error that
+// merely embeds one of these strings does not.
+const SNAPSHOT_HTTP_ERROR_SHAPE =
+  /^(?:Snapshot fetch failed|State restore failed): HTTP (\d{3})(?:\s|$)/;
+
 /**
- * True only when a stored backup snapshot can never be decrypted again: the
- * AEAD auth tag fails to verify (corruption / wrong key / wrong AAD, surfaced
- * by `@elizaos/security` as `AeadError`) or the KMS key version that encrypted
- * it no longer exists (`KeyNotFoundError` — thrown only by the ephemeral
- * `memory` KMS backend, which derives a fresh per-process key on every restart
- * and thus orphans everything it previously encrypted). Both are permanent
- * regardless of retries, so a resume degrades to a fresh boot on them rather
- * than failing the whole provision closed (see the restore path in `provision`).
+ * True only when a stored backup snapshot can never be applied, no matter how
+ * many times the provision retries. An agent's identity, config, and durable
+ * data live in the DB record; a snapshot holds only volatile in-memory session
+ * state — so the designed degrade for an unrecoverable snapshot (#15210) is
+ * "boot fresh, lose only the volatile session", never "brick the whole agent".
+ * Two shapes qualify:
  *
- * Deliberately NARROW so it never swallows a recoverable failure: a transient
- * KMS error (the Steward backend surfaces HTTP 5xx as a base `KmsError`, not
- * `KeyNotFoundError`), a DB/network/IO error, or anything else is NOT matched
- * and still propagates — degrading on one of those would silently discard state
- * that a retry would have restored. Matched by error class NAME rather than
- * `instanceof` because `AeadError` is internal to `@elizaos/security` (not
- * exported) and this code runs bundled, where a cross-realm `instanceof` on a
- * dependency's error class is unreliable.
+ * - UNDECRYPTABLE: the AEAD auth tag fails to verify (corruption / wrong key /
+ *   wrong AAD, surfaced by `@elizaos/security` as `AeadError`) or the KMS key
+ *   version that encrypted it no longer exists (`KeyNotFoundError` — thrown
+ *   only by the ephemeral `memory` KMS backend, which derives a fresh
+ *   per-process key on every restart and thus orphans everything it previously
+ *   encrypted). Matched by error class NAME rather than `instanceof` because
+ *   `AeadError` is internal to `@elizaos/security` (not exported) and this code
+ *   runs bundled, where a cross-realm `instanceof` on a dependency's error
+ *   class is unreliable.
+ * - UNRETRIEVABLE / UNRESTORABLE: the snapshot fetch or restore push was
+ *   rejected with a permanently-failing HTTP status (see
+ *   `PERMANENT_SNAPSHOT_HTTP_STATUSES`). The incident shape (HQ 14308, agent
+ *   23766030): `State restore failed: HTTP 401 {"error":"Unauthorized"}` from a
+ *   bridge URL pointing at a dead/rotated container — deterministic on every
+ *   attempt, so retrying only re-failed the provision into status=error.
+ *
+ * Deliberately NARROW so it never swallows a recoverable failure: HTTP 5xx /
+ * 408 / 429, network/timeout errors, a transient KMS error (the Steward
+ * backend surfaces HTTP 5xx as a base `KmsError`, not `KeyNotFoundError`), and
+ * DB/IO errors are NOT matched and still propagate — degrading on one of those
+ * would silently discard state that a retry would have restored.
  */
-export function isUndecryptableSnapshotError(error: unknown): boolean {
+export function isUnrecoverableSnapshotError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
-  return error.name === "AeadError" || error.name === "KeyNotFoundError";
+  if (error.name === "AeadError" || error.name === "KeyNotFoundError") return true;
+  const match = SNAPSHOT_HTTP_ERROR_SHAPE.exec(error.message);
+  return match !== null && PERMANENT_SNAPSHOT_HTTP_STATUSES.has(Number(match[1]));
 }
 
 export class ElizaSandboxService {
@@ -1540,17 +1565,22 @@ export class ElizaSandboxService {
 
         // 5. Restore from backup (reconstructs incrementals back to a full).
         //
-        // Fetching + reconstructing the snapshot decrypts its state under the
-        // org DEK. An UNDECRYPTABLE snapshot — the key that encrypted it is gone
-        // (the ephemeral `memory` KMS backend rotates its key on every restart,
-        // orphaning older ciphertext) or the bytes are corrupt — is unrecoverable
-        // no matter how many times we retry, so it degrades to a FRESH boot
-        // instead of failing the whole provision closed (error-policy:J4 designed
-        // degrade — a corrupt snapshot is unrecoverable regardless, so booting
-        // without prior in-memory state is correct, not a fabricated success).
-        // Only crypto/auth/key-missing failures degrade; a transient DB/IO/network
-        // error is rethrown so the provision fails and the resume job retries
-        // rather than silently discarding recoverable state.
+        // The snapshot holds only volatile in-memory session state — the agent's
+        // identity, config, and durable data live in the DB record — so an
+        // UNRECOVERABLE snapshot degrades to a FRESH boot instead of failing the
+        // whole provision closed (error-policy:J4 designed degrade — the state is
+        // unrestorable regardless of retries, so booting without prior in-memory
+        // state is correct, not a fabricated success). Two unrecoverable shapes,
+        // classified by `isUnrecoverableSnapshotError`: UNDECRYPTABLE (the org
+        // DEK that encrypted it is gone — the ephemeral `memory` KMS backend
+        // rotates its key on every restart — or the bytes are corrupt) and
+        // UNRESTORABLE (the restore push is rejected with a permanent HTTP
+        // status; HQ 14308 bricked an agent on a deterministic 401). Degrading on
+        // FIRST detection matters: these failures re-fail identically on every
+        // attempt, so retrying only burns the provision attempts and lands in
+        // markError. A transient DB/IO/network/5xx error is rethrown so the
+        // provision fails and the resume job retries rather than silently
+        // discarding recoverable state.
         let backup: Awaited<ReturnType<typeof agentSandboxesRepository.getLatestBackup>>;
         let restoreState: Awaited<
           ReturnType<typeof agentSandboxesRepository.getReconstructedBackupState>
@@ -1561,23 +1591,8 @@ export class ElizaSandboxService {
             ? await agentSandboxesRepository.getReconstructedBackupState(backup.id)
             : undefined;
         } catch (error) {
-          if (!isUndecryptableSnapshotError(error)) throw error;
-          logger.error("[agent-sandbox] Undecryptable snapshot, booting fresh", {
-            agentId: rec.id,
-            backupId: backup?.id,
-            error: error instanceof Error ? error.message : String(error),
-          });
-          // Drop the whole orphaned backup chain (all its rows share the now-lost
-          // org DEK) so the next resume boots clean instead of re-hitting this
-          // dead snapshot every time. error-policy:J6 best-effort — a failed prune
-          // only means we warn + degrade again next boot, never that we fail to
-          // boot fresh, so it must not throw out of the provision.
-          await agentSandboxesRepository.pruneBackups(rec.id, 0).catch((pruneErr) => {
-            logger.warn("[agent-sandbox] Failed to drop orphaned snapshot after degrade", {
-              agentId: rec.id,
-              error: pruneErr instanceof Error ? pruneErr.message : String(pruneErr),
-            });
-          });
+          if (!isUnrecoverableSnapshotError(error)) throw error;
+          await this.degradeUnrecoverableSnapshot(rec.id, backup?.id, error);
           backup = undefined;
           restoreState = undefined;
         }
@@ -1587,18 +1602,24 @@ export class ElizaSandboxService {
           } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             if (
-              rec.execution_tier !== "custom" ||
-              !message.startsWith("State restore failed: HTTP 404")
+              rec.execution_tier === "custom" &&
+              message.startsWith("State restore failed: HTTP 404")
             ) {
+              // Designed benign skip, checked BEFORE the unrecoverable degrade:
+              // a custom image simply lacks the restore endpoint, so the
+              // snapshot stays intact for a future image that has one.
+              logger.info(
+                "[agent-sandbox] Backup restore skipped: custom image has no restore endpoint",
+                {
+                  agentId: rec.id,
+                  backupId: backup?.id,
+                },
+              );
+            } else if (isUnrecoverableSnapshotError(error)) {
+              await this.degradeUnrecoverableSnapshot(rec.id, backup?.id, error);
+            } else {
               throw error;
             }
-            logger.info(
-              "[agent-sandbox] Backup restore skipped: custom image has no restore endpoint",
-              {
-                agentId: rec.id,
-                backupId: backup?.id,
-              },
-            );
           }
         } else if (backup) {
           logger.warn("[agent-sandbox] Backup restore skipped: reconstructed state was null", {
@@ -5595,6 +5616,34 @@ export class ElizaSandboxService {
       agentId: sandboxRecordId,
       type,
       bytes: backup?.size_bytes ?? sizeBytes,
+    });
+  }
+
+  /**
+   * The single degrade path for a snapshot `isUnrecoverableSnapshotError`
+   * classified as permanently lost (#15210): log it loudly, then drop the dead
+   * backup chain so the next resume boots clean instead of re-hitting the same
+   * unrecoverable snapshot on every provision. Never throws — the caller
+   * continues to a fresh boot, which must not be derailed by cleanup.
+   */
+  private async degradeUnrecoverableSnapshot(
+    agentId: string,
+    backupId: string | undefined,
+    error: unknown,
+  ): Promise<void> {
+    logger.error("[agent-sandbox] Unrecoverable snapshot, booting fresh", {
+      agentId,
+      backupId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    // error-policy:J6 best-effort — a failed prune only means we warn + degrade
+    // again next boot, never that we fail to boot fresh, so it must not throw
+    // out of the provision.
+    await agentSandboxesRepository.pruneBackups(agentId, 0).catch((pruneErr) => {
+      logger.warn("[agent-sandbox] Failed to drop orphaned snapshot after degrade", {
+        agentId,
+        error: pruneErr instanceof Error ? pruneErr.message : String(pruneErr),
+      });
     });
   }
 


### PR DESCRIPTION
<!-- Fill every visible section. Keep every evidence row visible; use N/A with a concrete reason when a row does not apply. -->

# Relates to

Follow-up to #15210 (merged as af63c3a89ea) and the HQ #14308 incident thread: at 05:38Z agent `23766030` bricked into `status=error` with

```
Provisioning failed after 3 attempts: State restore failed: HTTP 401 {"error":"Unauthorized"}
```

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop`
      with zero conflicts (`git fetch origin && git rebase origin/develop`).
- [x] `bun install` and `bun run verify` were run after sync, or any failure is
      recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the
      evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [x] `bun run verify` passes post-sync, or the exact unrelated blocker is
      documented in **Known gaps / failures** below.

# Risks

Low. One backend file (`packages/cloud/shared/src/lib/services/eliza-sandbox.ts`) plus its test file. The only behavior change is inside `provision()`'s backup-restore block: four specific HTTP statuses (401/403/404/410) from this file's own snapshot fetch/restore throw shapes now take the **existing** #15210 degrade path instead of failing the provision. The dangerous failure mode — swallowing a *transient* error and discarding a restorable snapshot — is guarded three ways: the predicate is anchored on this file's exact throw-message shapes, it allowlists only the four deterministic statuses (5xx/408/429/network/timeout/DB errors still propagate and retry), and the tests pin both sides of the boundary.

# Background

## What does this PR do?

#15210 established the design rule for one failure class: an agent's identity, config, and durable data live in the DB record; a snapshot holds **only volatile in-memory session state** — so failing to *decrypt* a snapshot must never brick the agent, only degrade to a fresh boot. Tonight the same restore block bricked agent `23766030` through the sibling class the fix didn't cover: the snapshot **restore push** was rejected with `HTTP 401 {"error":"Unauthorized"}` (bridge URL routing to a dead/rotated container). That failure is deterministic for the snapshot/container pairing, so the provision re-failed identically, exhausted its attempts, and `markError`'d the whole agent into `status=error`.

This PR extends the **same** degrade path (not a parallel one) to snapshot retrieval/restore failures that are permanent:

- `isUndecryptableSnapshotError()` → `isUnrecoverableSnapshotError()`: still matches the two real crypto shapes (`AeadError`, `KeyNotFoundError`), and now also matches this file's two snapshot HTTP throw shapes — `Snapshot fetch failed: HTTP <status>` and `State restore failed: HTTP <status> <body>` — **only** for statuses 401/403/404/410. The regex is anchored (`^`) so a wrapped or merely-embedding message never classifies, and the status must be exactly one of the four. 5xx, 408, 429, network/timeout errors, base `KmsError` (Steward 5xx), and DB errors all return `false` and propagate so the resume job retries — a wrong classification that eats a transient failure would silently discard restorable state, which is the one harmful outcome, so the predicate is deliberately narrow.
- The restore-push `catch` in `provision()` now routes unrecoverable errors through the same `degradeUnrecoverableSnapshot()` helper #15210's path uses (error-log with agentId+backupId, best-effort prune of the orphaned chain, continue to fresh boot). The degrade happens at **first detection**, inside the try body — the provision succeeds on attempt 1 instead of ghost-stopping a healthy container and burning attempts on a failure that re-fails deterministically.
- The custom-tier `HTTP 404` benign skip keeps its existing no-prune semantics and is checked **before** the degrade (a custom image legitimately lacks `/api/restore`; its snapshot stays intact for a future image that has one). A non-custom 404 — an image that will never grow the endpoint mid-provision — degrades.

Once deployed, agent `23766030` self-heals on its next resume: the same 401 is now classified unrecoverable → orphaned chain pruned → fresh boot → `status=running`. And because the chain is pruned, subsequent resumes skip the restore push entirely, so the agent stays healthy even if the underlying bridge auth issue persists.

## What kind of change is this?

Bug fix (non-breaking): a provisioning resilience fix in the cloud backend.

# Documentation changes needed?

My changes do not require a change to the project documentation. The behavior contract lives in the predicate's doc comment and the restore-block comment, both updated in place.

# Testing

## Where should a reviewer start?

`packages/cloud/shared/src/lib/services/eliza-sandbox.ts` — `isUnrecoverableSnapshotError()` (the classification boundary) and step 5 of `provision()` (the two catch sites sharing `degradeUnrecoverableSnapshot()`). Then the test file's provision tests (13)–(15) and the `isUnrecoverableSnapshotError` describe block.

## Detailed testing steps

`bun run --cwd packages/cloud/shared test src/lib/services/eliza-sandbox.test.ts` — all branches of the new boundary are pinned:

- **(13) incident repro**: drives the REAL `pushState` (only `fetch` is intercepted, replaying the incident's exact `401 {"error":"Unauthorized"}` response) so the classified error is the code's own throw shape. Asserts: provision **succeeds**, restore POST really hit the new container bridge, exactly one `provider.create` (degrade on first detection, no retry burn), no ghost `stop`, no `markError`, chain pruned, degrade logged.
- **(14) 404 on a non-custom tier** (real `pushState`, real 404 response): same degrade.
- **(15) 404 on a custom tier**: stays the benign skip — success, **no prune**, info log, no degrade (guards the branch ordering).
- **(9, extended) 5xx transient**: `State restore failed: HTTP 500` still **propagates** — provision fails, `markError` fires, ghost cleanup stops the container, and (new assertion) `pruneBackups` is **not** called, so the snapshot survives for the retry.
- **(10)/(11) decrypt shapes**: real `KeyNotFoundError` / real `AeadError` (produced by the actual `@elizaos/security` crypto stack) still degrade — #15210 behavior preserved.
- **Classification matrix**: 401/403/404/410 × both throw shapes → true; 500/502/503/408/429 × both shapes → false; network `TypeError("fetch failed")`, the wrapped `Provisioning failed after 3 attempts: …` string (anchoring), the `SNAPSHOT_ENDPOINT_UNSUPPORTED` sentinel, DB-blip errors, base `KmsError`, and non-Errors → false.

# Evidence Gate

Any change testable on the frontend is not mergeable without a video walkthrough,
before/after screenshots, and logs. If you did not attach them, say why.

Attach each applicable artifact **inline in this PR** (drag-and-drop into the
description or a comment), or write `N/A - <reason>` on the row. Do not leave
evidence rows blank. Videos must be **MP4** (GitHub renders them inline);
prefer **JPG over PNG** for screenshots. Do not commit evidence files to the
repo.

<!-- evidence-row:before-screenshots -->
- [x] Before full-page screenshots: N/A - backend-only change in `packages/cloud/shared` (provisioning service + its tests); no rendered UI surface exists in this diff.
<!-- evidence-row:after-screenshots -->
- [x] After full-page screenshots: N/A - backend-only change in `packages/cloud/shared`; no rendered UI surface exists in this diff.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - no user-facing flow; the change is a server-side error-classification boundary in the provisioning service, proven by the deterministic test run linked in the domain-artifacts row.
<!-- evidence-row:backend-logs -->
- [x] Backend logs: [eliza-sandbox-suite-run.log](https://gist.githubusercontent.com/NubsCarson/1ba771551aff73c6f4393d40d657a43d/raw/7b37d0e680112c2d5574b2f4bf05cb1428615b1f/eliza-sandbox-suite-run.log) — full `bun test` run of the sandbox suite (73 pass / 0 fail) with the service's structured `[agent-sandbox]` logs; the degrade line (`Unrecoverable snapshot, booting fresh`) is asserted via the logger spy in tests 10/11/13/14 and the transient branch still propagates in tests 9/12 (evidence bundle: https://gist.github.com/NubsCarson/1ba771551aff73c6f4393d40d657a43d).
<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend in this change; nothing renders or issues client requests.
<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent/action/provider/prompt/model behavior changes; this is container-provisioning error handling, no LLM in the loop.
<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: per-test JUnit results [eliza-sandbox-junit.xml](https://gist.githubusercontent.com/NubsCarson/1ba771551aff73c6f4393d40d657a43d/raw/6bc720a1145dc2733712f2ef4ac270f53dbccfef/eliza-sandbox-junit.xml) (73 testcases, `failures="0"`, incl. the incident repro asserting the DB-facing effects: `pruneBackups(agent, 0)` called on degrade, NOT called on transient/custom-skip, agent row ends `status=running` not `status=error`) + scoped typecheck [cloud-shared-typecheck.log](https://gist.githubusercontent.com/NubsCarson/1ba771551aff73c6f4393d40d657a43d/raw/2b4347eb72d5fb7062a4bccc759e7e02e8ee23de/cloud-shared-typecheck.log) (`tsgo --noEmit`, exit=0).

# Known gaps / failures

- Repo-wide `bun run verify` is not feasible in this lane; ran the scoped equivalents instead: `bun run --cwd packages/cloud/shared typecheck` — clean, exit 0 (linked above) — and `biome check` on the two touched files — clean.
- The whole-package `bun test` shared-process run fails identically in this local lane on **base and branch** (A/B compared): every eliza-sandbox test in the shared run dies with the same pre-existing cross-file mock contamination (`SyntaxError: export 'InsufficientCreditsError' not found in './credits'`) on both sides, and the failure sets are identical modulo this PR's added/renamed tests. The touched file's own suite is green standalone (73/73, linked above); CI runs the properly-harnessed lanes.
