### PR TITLE
fix(voice): capture survives app suspend on iOS PWA

### DIFF
--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -661,6 +661,7 @@ let lastCaptureOpts: CaptureOpts | null = null;
 let captureHandles: Array<{
   start: Mock<() => Promise<void>>;
   stop: Mock<() => Promise<void>>;
+  dispose: Mock<() => void>;
 }> = [];
 
 function installFakeCapture(): void {
@@ -1067,6 +1068,73 @@ describe("useShellController — voice capture routing", () => {
     expect(
       window.localStorage.getItem("eliza:voice:continuous-chat-mode"),
     ).toBe("vad-gated");
+  });
+
+  // ── #voice-V1: capture survives app suspend on iOS PWA ──
+  //
+  // The installed web PWA gets APP_PAUSE/APP_RESUME from #15179's lifecycle
+  // bridge on background/foreground. Mid-capture the WAV recorder's WebAudio
+  // graph stalls on suspend; without teardown the shell is stuck in a phantom
+  // recording state with an orphaned mic. These assert the pause discards the
+  // capture (dispose → recorder.cancel releases the mic) and resume re-arms.
+  it("APP_PAUSE discards an in-flight hands-free capture and resets recording", async () => {
+    const { result } = renderHook(() => useShellController());
+    await act(async () => {
+      result.current.toggleHandsFree();
+    });
+    expect(result.current.handsFree).toBe(true);
+    expect(result.current.recording).toBe(true);
+    expect(createVoiceCaptureMock).toHaveBeenCalledTimes(1);
+
+    // Background the app mid-capture.
+    await act(async () => {
+      document.dispatchEvent(new Event("eliza:app-pause"));
+    });
+
+    // The capture is discarded via dispose() (recorder.cancel releases the
+    // MediaStream tracks — the iOS mic indicator drops), NOT drained via stop()
+    // (which would POST an empty/truncated WAV and throw). Recording UI resets
+    // so a resume re-arms from a clean idle, but hands-free intent is retained.
+    expect(captureHandles[0]?.dispose).toHaveBeenCalledTimes(1);
+    expect(captureHandles[0]?.stop).not.toHaveBeenCalled();
+    expect(result.current.recording).toBe(false);
+    expect(result.current.handsFree).toBe(true);
+  });
+
+  it("APP_RESUME re-arms the mic after a suspend when hands-free was live", async () => {
+    const { result } = renderHook(() => useShellController());
+    await act(async () => {
+      result.current.toggleHandsFree();
+    });
+    expect(createVoiceCaptureMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      document.dispatchEvent(new Event("eliza:app-pause"));
+    });
+    expect(result.current.recording).toBe(false);
+
+    // Foreground: capture re-opens without a user tap (a fresh factory call).
+    await act(async () => {
+      document.dispatchEvent(new Event("eliza:app-resume"));
+      await Promise.resolve();
+    });
+    expect(createVoiceCaptureMock).toHaveBeenCalledTimes(2);
+    expect(captureHandles[1]?.start).toHaveBeenCalledTimes(1);
+    expect(result.current.recording).toBe(true);
+  });
+
+  it("APP_RESUME does NOT re-arm the mic when hands-free was never engaged", async () => {
+    renderHook(() => useShellController());
+    // No capture running, not hands-free.
+    await act(async () => {
+      document.dispatchEvent(new Event("eliza:app-pause"));
+    });
+    await act(async () => {
+      document.dispatchEvent(new Event("eliza:app-resume"));
+      await Promise.resolve();
+    });
+    // Nothing to re-arm — no phantom capture is created on resume.
+    expect(createVoiceCaptureMock).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -25,6 +25,8 @@ import type {
 } from "../../api/client-types-chat";
 import type { AsrProvider } from "../../api/client-types-config";
 import {
+  APP_PAUSE_EVENT,
+  APP_RESUME_EVENT,
   VOICE_CONTROL_EVENT,
   type VoiceControlEventDetail,
 } from "../../events";
@@ -773,6 +775,34 @@ export function useShellController(): ShellController {
     void stopCaptureAndDrain();
   }, [stopCaptureAndDrain]);
 
+  // Discard an in-flight capture on app suspend WITHOUT transcribing (#voice-V1).
+  // When iOS backgrounds the PWA mid-capture the `ScriptProcessorNode` stalls,
+  // so `handle.stop()` (the drain path) would trigger a doomed STT round-trip on
+  // a truncated/empty WAV and throw "No microphone audio was captured". Instead
+  // `dispose()` runs the recorder's `cancel()` — it releases the MediaStream
+  // tracks (so iOS drops the mic indicator during suspension) and closes the
+  // AudioContext without a transcribe. `explicitStopRef` is set so the clean-
+  // auto-stop carryover does NOT fire (a suspended turn is discarded, not held),
+  // and the state resets clear the stuck "recording" UI so a resume re-arms from
+  // a clean idle. `handsFree` is deliberately left intact: the re-listen loop
+  // (and the resume effect below) re-open the mic on foreground.
+  const discardCaptureForSuspend = React.useCallback(() => {
+    const handle = captureRef.current;
+    if (!handle) return;
+    captureRef.current = null;
+    explicitStopRef.current = true;
+    turnCarryoverRef.current = "";
+    turnAggregatorRef.current?.reset();
+    try {
+      handle.dispose();
+    } catch {
+      /* dispose is best-effort — the recorder's cancel() is idempotent */
+    }
+    setAnalyser(null);
+    setRecording(false);
+    setTranscript("");
+  }, []);
+
   const startCapture = React.useCallback(
     (intent?: CaptureIntent) => {
       // Voice capture is independent of agent-respond readiness. A converse
@@ -1455,6 +1485,67 @@ export function useShellController(): ShellController {
     voiceOutput.speaking,
     composerHasDraft,
     startCapture,
+  ]);
+
+  // ── App suspend / resume: keep voice capture from getting stuck (#voice-V1) ──
+  //
+  // On the installed iOS PWA, backgrounding the app suspends the WebAudio graph:
+  // the WAV recorder's `ScriptProcessorNode` stops firing, but nothing tears the
+  // capture down, so on resume the UI is stuck in a phantom "recording" state
+  // with an orphaned getUserMedia MediaStream (iOS keeps the mic indicator lit)
+  // and the next tap early-returns against the stale `captureRef`.
+  //
+  // This extends #15179's lifecycle bridge (which already dispatches
+  // APP_PAUSE/APP_RESUME on the web PWA and handles chat resync) rather than
+  // duplicating it:
+  //   - APP_PAUSE: discard any in-flight capture (release the mic, reset UI) so
+  //     nothing stalls across suspension. Remember whether the mic was live so
+  //     resume can re-arm it.
+  //   - APP_RESUME: if the mic was hands-free-live at suspend (or always-on
+  //     hands-free is engaged), re-open capture the instant we foreground
+  //     instead of waiting for a user tap. The existing re-listen loop also
+  //     covers this via state deps, but a direct nudge avoids a dead mic when
+  //     the loop's deps didn't change across the suspend.
+  const wasCapturingAtSuspendRef = React.useRef(false);
+  React.useEffect(() => {
+    const onPause = (): void => {
+      wasCapturingAtSuspendRef.current = !!captureRef.current;
+      discardCaptureForSuspend();
+    };
+    const onResume = (): void => {
+      const shouldReArm =
+        (wasCapturingAtSuspendRef.current || handsFreeRef.current) &&
+        !transcriptionModeRef.current;
+      wasCapturingAtSuspendRef.current = false;
+      if (!shouldReArm) return;
+      // Re-open only from a clean idle: never stack a second capture over one
+      // that survived (or was re-armed by the re-listen loop first), and stay
+      // out of the way while a reply is still streaming/speaking (voice is gated
+      // while responding — the loop re-opens once it clears).
+      if (
+        !ready ||
+        recording ||
+        captureRef.current ||
+        chatSending ||
+        voiceOutput.speaking
+      ) {
+        return;
+      }
+      startCapture("converse");
+    };
+    document.addEventListener(APP_PAUSE_EVENT, onPause);
+    document.addEventListener(APP_RESUME_EVENT, onResume);
+    return () => {
+      document.removeEventListener(APP_PAUSE_EVENT, onPause);
+      document.removeEventListener(APP_RESUME_EVENT, onResume);
+    };
+  }, [
+    discardCaptureForSuspend,
+    startCapture,
+    ready,
+    recording,
+    chatSending,
+    voiceOutput.speaking,
   ]);
 
   const waveformMode =

--- a/packages/ui/src/hooks/useVoiceChat.suspend.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.suspend.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchWithCsrf } from "../api/csrf-client";
+import {
+  isLocalAsrCaptureSupported,
+  startLocalAsrRecorder,
+} from "../voice/local-asr-capture";
+import { useVoiceChat } from "./useVoiceChat";
+
+vi.mock("../api/csrf-client", () => ({
+  fetchWithCsrf: vi.fn(),
+}));
+
+vi.mock("../voice/local-asr-capture", () => ({
+  isLocalAsrCaptureSupported: vi.fn(),
+  startLocalAsrRecorder: vi.fn(),
+}));
+
+const fetchWithCsrfMock = vi.mocked(fetchWithCsrf);
+const isLocalAsrCaptureSupportedMock = vi.mocked(isLocalAsrCaptureSupported);
+const startLocalAsrRecorderMock = vi.mocked(startLocalAsrRecorder);
+
+/**
+ * #voice-V1 regression guard for the composer capture surface.
+ *
+ * On the installed iOS PWA, backgrounding the app suspends the WebAudio graph
+ * mid-capture. #15179's lifecycle bridge dispatches APP_PAUSE (`eliza:app-pause`)
+ * on the web PWA; the composer must discard its in-flight capture on that event
+ * WITHOUT transcribing — releasing the getUserMedia MediaStream tracks (so the
+ * iOS mic indicator drops) and resetting the listening UI so the next gesture
+ * re-arms from a clean idle instead of stalling on a stuck recorder.
+ */
+describe("useVoiceChat — app-suspend capture teardown (#voice-V1)", () => {
+  beforeEach(() => {
+    isLocalAsrCaptureSupportedMock.mockReturnValue(true);
+    fetchWithCsrfMock.mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : String(input);
+      if (url.includes("/api/asr/cloud")) {
+        return new Response(JSON.stringify({ text: "should not be sent" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("unexpected endpoint", { status: 404 });
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("cancels the recorder and resets listening on APP_PAUSE, without transcribing", async () => {
+    const stop = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3, 4]));
+    const cancel = vi.fn();
+    startLocalAsrRecorderMock.mockResolvedValue({
+      stop,
+      cancel,
+      analyser: null,
+    });
+    const onTranscript = vi.fn();
+
+    const { result } = renderHook(() =>
+      useVoiceChat({
+        onTranscript,
+        voiceConfig: {
+          provider: "eliza-cloud",
+          asr: { provider: "eliza-cloud" },
+        },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.startListening("push-to-talk");
+    });
+    expect(startLocalAsrRecorderMock).toHaveBeenCalledTimes(1);
+    expect(result.current.isListening).toBe(true);
+
+    // Background the app mid-capture.
+    await act(async () => {
+      document.dispatchEvent(new Event("eliza:app-pause"));
+      await Promise.resolve();
+    });
+
+    // The recorder is cancelled (mic tracks released, context closed) — NOT
+    // stopped (which would POST a truncated WAV and throw).
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(stop).not.toHaveBeenCalled();
+    // No STT round-trip fired for the discarded capture.
+    expect(fetchWithCsrfMock).not.toHaveBeenCalledWith(
+      "/api/asr/cloud",
+      expect.anything(),
+    );
+    // No transcript delivered — the suspended turn is discarded, not committed.
+    expect(onTranscript).not.toHaveBeenCalled();
+    // Listening UI resets so the next gesture re-arms cleanly.
+    expect(result.current.isListening).toBe(false);
+    expect(result.current.captureMode).toBe("idle");
+  });
+
+  it("is a no-op on APP_PAUSE when nothing is capturing", async () => {
+    const cancel = vi.fn();
+    startLocalAsrRecorderMock.mockResolvedValue({
+      stop: vi.fn(),
+      cancel,
+      analyser: null,
+    });
+
+    const { result } = renderHook(() =>
+      useVoiceChat({
+        onTranscript: vi.fn(),
+        voiceConfig: {
+          provider: "eliza-cloud",
+          asr: { provider: "eliza-cloud" },
+        },
+      }),
+    );
+
+    expect(result.current.isListening).toBe(false);
+    await act(async () => {
+      document.dispatchEvent(new Event("eliza:app-pause"));
+      await Promise.resolve();
+    });
+
+    // Never started a capture → nothing to cancel, no state churn.
+    expect(cancel).not.toHaveBeenCalled();
+    expect(result.current.isListening).toBe(false);
+  });
+});

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -33,6 +33,7 @@ import {
   type TalkModeStateEvent,
   type TalkModeTranscriptEvent,
 } from "../bridge/native-plugins";
+import { APP_PAUSE_EVENT } from "../events";
 import { resolveApiUrl } from "../utils";
 import { getElizaApiToken } from "../utils/eliza-globals";
 import {
@@ -40,7 +41,6 @@ import {
   ttsDebug,
   ttsDebugTextPreview,
 } from "../utils/tts-debug";
-import { APP_PAUSE_EVENT } from "../events";
 import { hasConfiguredApiKey } from "../voice";
 import {
   isLocalAsrCaptureSupported,

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -40,6 +40,7 @@ import {
   ttsDebug,
   ttsDebugTextPreview,
 } from "../utils/tts-debug";
+import { APP_PAUSE_EVENT } from "../events";
 import { hasConfiguredApiKey } from "../voice";
 import {
   isLocalAsrCaptureSupported,
@@ -734,6 +735,51 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
     setCaptureMode("idle");
     setInterimTranscript("");
   }, []);
+
+  // Discard the composer's in-flight capture on app suspend WITHOUT transcribing
+  // (#voice-V1). iOS suspends the WebAudio graph when the PWA backgrounds: the
+  // WAV recorder's `ScriptProcessorNode` stalls, so `stop()` would POST a
+  // truncated/empty WAV (a doomed STT round-trip) and throw "No microphone audio
+  // was captured". `recorder.cancel()` releases the getUserMedia MediaStream
+  // tracks (so iOS drops the mic indicator during suspension) and closes the
+  // AudioContext without a transcribe; the browser recognizer is aborted the
+  // same way. `resetListeningState` clears the stuck "listening" UI so the next
+  // gesture re-arms from a clean idle instead of early-returning against a stale
+  // recorder ref. The composer mic is push-to-talk (gesture-driven), not
+  // hands-free, so there is nothing to auto-re-arm on resume — the user's next
+  // press starts a fresh capture.
+  const discardCaptureForSuspend = useCallback(() => {
+    if (listeningModeRef.current === "idle" && !localAsrRecorderRef.current) {
+      return;
+    }
+    enabledRef.current = false;
+    const recorder = localAsrRecorderRef.current;
+    localAsrRecorderRef.current = null;
+    if (recorder) {
+      // cancel() releases the mic tracks + closes the context, no throw, no POST.
+      recorder.cancel();
+    }
+    const recognition = recognitionRef.current;
+    recognitionRef.current = null;
+    if (recognition) {
+      try {
+        recognition.abort();
+      } catch {
+        /* already stopped */
+      }
+    }
+    // Native TalkMode owns its own mic session; ask it to stop so iOS doesn't
+    // hold the recognizer open across suspension. Best-effort — a stopped
+    // recognizer no-ops.
+    if (sttBackendRef.current === "talkmode") {
+      void getTalkModePlugin()
+        .stop()
+        .catch(() => {
+          /* ignore */
+        });
+    }
+    resetListeningState();
+  }, [resetListeningState]);
 
   const ensureTalkModeListeners = useCallback(async () => {
     if (talkModeHandlesRef.current.length > 0) return;
@@ -2717,6 +2763,24 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       window.removeEventListener("keydown", handleUserGesture, true);
     };
   }, [unlockAudio]);
+
+  // ── App suspend: release the mic mid-capture (#voice-V1) ───────────
+  // On the installed iOS PWA, backgrounding suspends the WebAudio graph and
+  // leaves the composer capture stuck (phantom "listening", orphaned mic). Tie
+  // into #15179's lifecycle bridge (which dispatches APP_PAUSE on the web PWA)
+  // to discard the in-flight capture cleanly. Only APP_PAUSE is handled here:
+  // the composer mic is push-to-talk, so resume needs no auto-re-arm — the
+  // hands-free/ambient surface (useShellController) owns re-arm on resume.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const onPause = (): void => {
+      discardCaptureForSuspend();
+    };
+    document.addEventListener(APP_PAUSE_EVENT, onPause);
+    return () => {
+      document.removeEventListener(APP_PAUSE_EVENT, onPause);
+    };
+  }, [discardCaptureForSuspend]);
 
   // ── Cleanup on unmount ────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

The installed **iOS web PWA** does not survive **app backgrounding while the mic is capturing**. Per `VOICE-LOOP-DOSSIER.md` this is the weakest failure mode in the voice loop (§2 "App suspend mid-capture", roadmap rank **V1**):

> The WAV recorder has NO lifecycle listener. iOS suspends → `ScriptProcessorNode.onaudioprocess` stalls → on resume `stop()` throws "No microphone audio was captured". #15179 resume-orchestration reconnects WS + refetches tail but does NOT re-arm/reset a mid-flight capture.

Concretely, on the installed web PWA, backgrounding suspends the WebAudio graph: the recorder's `ScriptProcessorNode` stops firing but nothing tears the capture down. On resume the UI is stuck in a phantom "recording"/"listening" state, holds an orphaned `getUserMedia` MediaStream (iOS keeps the mic indicator lit), and the next tap early-returns against a stale capture ref.

## Change (dossier lane V1)

Extend **#15179's** `APP_PAUSE`/`APP_RESUME` lifecycle bridge (which already dispatches on the web PWA and handles chat resync) into the voice-capture path — building **on** it, not duplicating it. Both mic surfaces now handle suspend:

**Ambient / hands-free (`useShellController`)**
- **APP_PAUSE:** discard the in-flight capture via `dispose()` → the recorder's `cancel()` releases the MediaStream tracks (iOS drops the mic indicator) and closes the `AudioContext` **without** the doomed empty-WAV STT round-trip/throw. Resets `recording`/`analyser`/`transcript`; keeps `handsFree` intent.
- **APP_RESUME:** if the mic was hands-free-live at suspend (or always-on is engaged) and we're not mid-response, re-open capture immediately so the mic reopens without a tap (guarded so it never stacks over a capture the re-listen loop already re-armed).

**Composer PTT (`useVoiceChat`)**
- **APP_PAUSE:** cancel the recorder (release mic tracks, no POST), abort the browser recognizer, stop native TalkMode, and reset listening state so the next press starts clean. Push-to-talk is gesture-driven, so **no** resume auto-re-arm — the ambient surface owns resume re-arm.

Discarding (not draining) on suspend avoids the empty-WAV STT call and the `"No microphone audio was captured"` throw; releasing tracks drops the iOS mic indicator during suspension.

## Why this is the right seam
- `local-asr-capture`'s `recorder.cancel()` already does exactly what suspend needs: stops all MediaStream tracks and closes the AudioContext, no throw, no transcribe. Both surfaces route through it (the factory's `dispose()` on the ambient side, the ref directly on the composer side).
- Respects #15179: it registers its own `APP_RESUME` handler for chat resync; V1 adds sibling `document` listeners for the capture concern. No shared state, no duplication.

## Tests (green)

`packages/ui` (vitest / jsdom):
- `useShellController.test.tsx` (+3): APP_PAUSE discards the in-flight hands-free capture via `dispose()` (not `stop()`) and resets recording; APP_RESUME re-arms when hands-free was live; **no** re-arm when hands-free was never engaged.
- `useVoiceChat.suspend.test.tsx` (new, +2): APP_PAUSE cancels the recorder (mic released) with **no** `/api/asr/cloud` POST and **no** transcript, resets listening state; no-op when nothing is capturing.

```
✓ src/components/shell/__tests__/useShellController.test.tsx (59 tests)
✓ src/hooks/useVoiceChat.suspend.test.tsx (2 tests)
Full voice+shell run: Test Files 40 passed (40) · Tests 339 passed (339)
```

- `biome check` clean on all touched files.
- `tsgo` typecheck: **no errors in touched files** (remaining repo-wide errors are pre-existing env dep-typing noise: `pg`/`esbuild`/`postcss`/`@tailwindcss/postcss` decls + e2e-runner stubs, unrelated to this change).
- **codex review:** attempted `codex review --base origin/develop`; it hung past a ~3.5min budget with no output (known large-diff/VPS behavior) and was cancelled — self-reviewed instead. Diff is +355 lines, additive only (2 source hooks + 2 test files), no touches to `vite.config`/`index.html`/`client-base`/`bun.lock`/workflows.

## Follow-ups (out of scope, tracked in dossier)
V4 (client STT timeout + retry), V5 (pre-POST silence guard), V6 (VAD window tighten) — separate lanes.

Ref: `VOICE-LOOP-DOSSIER.md` V1. Extends #15179.

[sol-orch]
