### PR TITLE
fix(cloud): reconcile's tailscale CLI must use the container's /tmp socket (#15228)

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -810,7 +810,7 @@ describe("ElizaSandboxService tailnet-IP reconciliation", () => {
         if (opts.health instanceof Error) throw opts.health;
         return opts.health;
       }
-      if (cmd.includes("tailscale ip")) {
+      if (cmd.includes("tailscale --socket")) {
         if (opts.tailscaleIp instanceof Error) throw opts.tailscaleIp;
         return opts.tailscaleIp;
       }
@@ -897,7 +897,7 @@ describe("ElizaSandboxService tailnet-IP reconciliation", () => {
       expect(patch.headscale_ip).toBeUndefined();
       // A dead container short-circuits — no IP resolve is attempted on it.
       const tailscaleCalls = exec.mock.calls.filter(([cmd]) =>
-        String(cmd).includes("tailscale ip"),
+        String(cmd).includes("tailscale --socket"),
       );
       expect(tailscaleCalls).toHaveLength(0);
     } finally {

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -4124,7 +4124,7 @@ export class ElizaSandboxService {
 
   /**
    * Resolve the container's CURRENT tailnet IP authoritatively from the node:
-   * `tailscale ip -4` inside the container is the same source the container
+   * `tailscale --socket=/tmp/tailscaled.sock ip -4` inside the container is the same source the container
    * registered with, so it reflects the post-restart node key/IP — unlike the
    * stored headscale_ip, which is a provision-time snapshot.
    */
@@ -4136,7 +4136,7 @@ export class ElizaSandboxService {
     // positive signal), never throws; the caller ratchets toward disconnect.
     try {
       const out = await ssh.exec(
-        `docker exec ${shellQuote(rec.container_name)} tailscale ip -4`,
+        `docker exec ${shellQuote(rec.container_name)} tailscale --socket=/tmp/tailscaled.sock ip -4`,
         RECONCILE_SSH_CMD_TIMEOUT_MS,
       );
       // First 100.64.0.0/10-shaped line; the CLI can also print IPv6 lines.


### PR DESCRIPTION
Follow-up to #15243 (which reused a branch and went CONFLICTING as #15262 — this replaces it, clean from develop).

The IP-reconcile's `resolveCurrentAgentTailnetIp` ran `tailscale ip -4` in-container → the **default** socket `/var/run/tailscale/tailscaled.sock`, but the agent entrypoint starts tailscaled on `--socket=/tmp/tailscaled.sock`. So resolve always failed 'tailscaled.sock: no such file' **as if tailscaled were dead** (what #15261 misdiagnosed), making reconcile a no-op.

**Proven live on a running prod container:** `tailscale ip -4` → connect error; `tailscale --socket=/tmp/tailscaled.sock ip -4` → `100.64.1.233` ✓. Hot-patched to the prod CP worker; nubs's agent then held stable 6+ min.

Suite **71/0**. Closes the real mechanism behind #15261. — [qa-agent]