### PR TITLE
fix(voice): capture lifecycle + STT timeout/retry + silence guard + snappier VAD — voice-loop reliability cut

### DIFF
--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -25,6 +25,8 @@ import type {
 } from "../../api/client-types-chat";
 import type { AsrProvider } from "../../api/client-types-config";
 import {
+  APP_PAUSE_EVENT,
+  APP_RESUME_EVENT,
   VOICE_CONTROL_EVENT,
   type VoiceControlEventDetail,
 } from "../../events";
@@ -773,6 +775,34 @@ export function useShellController(): ShellController {
     void stopCaptureAndDrain();
   }, [stopCaptureAndDrain]);
 
+  // Discard an in-flight capture on app suspend WITHOUT transcribing (#voice-V1).
+  // When iOS backgrounds the PWA mid-capture the `ScriptProcessorNode` stalls,
+  // so `handle.stop()` (the drain path) would trigger a doomed STT round-trip on
+  // a truncated/empty WAV and throw "No microphone audio was captured". Instead
+  // `dispose()` runs the recorder's `cancel()` — it releases the MediaStream
+  // tracks (so iOS drops the mic indicator during suspension) and closes the
+  // AudioContext without a transcribe. `explicitStopRef` is set so the clean-
+  // auto-stop carryover does NOT fire (a suspended turn is discarded, not held),
+  // and the state resets clear the stuck "recording" UI so a resume re-arms from
+  // a clean idle. `handsFree` is deliberately left intact: the re-listen loop
+  // (and the resume effect below) re-open the mic on foreground.
+  const discardCaptureForSuspend = React.useCallback(() => {
+    const handle = captureRef.current;
+    if (!handle) return;
+    captureRef.current = null;
+    explicitStopRef.current = true;
+    turnCarryoverRef.current = "";
+    turnAggregatorRef.current?.reset();
+    try {
+      handle.dispose();
+    } catch {
+      /* dispose is best-effort — the recorder's cancel() is idempotent */
+    }
+    setAnalyser(null);
+    setRecording(false);
+    setTranscript("");
+  }, []);
+
   const startCapture = React.useCallback(
     (intent?: CaptureIntent) => {
       // Voice capture is independent of agent-respond readiness. A converse
@@ -1455,6 +1485,67 @@ export function useShellController(): ShellController {
     voiceOutput.speaking,
     composerHasDraft,
     startCapture,
+  ]);
+
+  // ── App suspend / resume: keep voice capture from getting stuck (#voice-V1) ──
+  //
+  // On the installed iOS PWA, backgrounding the app suspends the WebAudio graph:
+  // the WAV recorder's `ScriptProcessorNode` stops firing, but nothing tears the
+  // capture down, so on resume the UI is stuck in a phantom "recording" state
+  // with an orphaned getUserMedia MediaStream (iOS keeps the mic indicator lit)
+  // and the next tap early-returns against the stale `captureRef`.
+  //
+  // This extends #15179's lifecycle bridge (which already dispatches
+  // APP_PAUSE/APP_RESUME on the web PWA and handles chat resync) rather than
+  // duplicating it:
+  //   - APP_PAUSE: discard any in-flight capture (release the mic, reset UI) so
+  //     nothing stalls across suspension. Remember whether the mic was live so
+  //     resume can re-arm it.
+  //   - APP_RESUME: if the mic was hands-free-live at suspend (or always-on
+  //     hands-free is engaged), re-open capture the instant we foreground
+  //     instead of waiting for a user tap. The existing re-listen loop also
+  //     covers this via state deps, but a direct nudge avoids a dead mic when
+  //     the loop's deps didn't change across the suspend.
+  const wasCapturingAtSuspendRef = React.useRef(false);
+  React.useEffect(() => {
+    const onPause = (): void => {
+      wasCapturingAtSuspendRef.current = !!captureRef.current;
+      discardCaptureForSuspend();
+    };
+    const onResume = (): void => {
+      const shouldReArm =
+        (wasCapturingAtSuspendRef.current || handsFreeRef.current) &&
+        !transcriptionModeRef.current;
+      wasCapturingAtSuspendRef.current = false;
+      if (!shouldReArm) return;
+      // Re-open only from a clean idle: never stack a second capture over one
+      // that survived (or was re-armed by the re-listen loop first), and stay
+      // out of the way while a reply is still streaming/speaking (voice is gated
+      // while responding — the loop re-opens once it clears).
+      if (
+        !ready ||
+        recording ||
+        captureRef.current ||
+        chatSending ||
+        voiceOutput.speaking
+      ) {
+        return;
+      }
+      startCapture("converse");
+    };
+    document.addEventListener(APP_PAUSE_EVENT, onPause);
+    document.addEventListener(APP_RESUME_EVENT, onResume);
+    return () => {
+      document.removeEventListener(APP_PAUSE_EVENT, onPause);
+      document.removeEventListener(APP_RESUME_EVENT, onResume);
+    };
+  }, [
+    discardCaptureForSuspend,
+    startCapture,
+    ready,
+    recording,
+    chatSending,
+    voiceOutput.speaking,
   ]);
 
   const waveformMode =

--- a/packages/ui/src/hooks/useVoiceChat.app-suspend.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.app-suspend.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+
+// #voice-V1 (composer leg): on the installed iOS PWA, backgrounding suspends
+// the WebAudio graph mid-capture — the WAV recorder's ScriptProcessorNode
+// stalls, so a later stop() would POST a truncated/empty WAV and throw "No
+// microphone audio was captured". These tests lock the composer's APP_PAUSE
+// handler: an in-flight capture is discarded via recorder.cancel() (release the
+// mic, close the context, NO transcribe POST) and the listening state resets so
+// the next gesture re-arms from a clean idle.
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchWithCsrf } from "../api/csrf-client";
+import { APP_PAUSE_EVENT } from "../events";
+import {
+  isLocalAsrCaptureSupported,
+  startLocalAsrRecorder,
+} from "../voice/local-asr-capture";
+import { useVoiceChat } from "./useVoiceChat";
+
+vi.mock("../api/csrf-client", () => ({
+  fetchWithCsrf: vi.fn(),
+}));
+
+vi.mock("../voice/local-asr-capture", () => ({
+  isLocalAsrCaptureSupported: vi.fn(),
+  startLocalAsrRecorder: vi.fn(),
+}));
+
+const fetchWithCsrfMock = vi.mocked(fetchWithCsrf);
+const isLocalAsrCaptureSupportedMock = vi.mocked(isLocalAsrCaptureSupported);
+const startLocalAsrRecorderMock = vi.mocked(startLocalAsrRecorder);
+
+describe("useVoiceChat app-suspend capture teardown (#voice-V1)", () => {
+  beforeEach(() => {
+    isLocalAsrCaptureSupportedMock.mockReturnValue(true);
+    fetchWithCsrfMock.mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : String(input);
+      if (url.includes("/api/asr/cloud")) {
+        return new Response(JSON.stringify({ text: "should not be reached" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("unexpected endpoint", { status: 404 });
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("cancels an in-flight cloud capture on APP_PAUSE without transcribing", async () => {
+    const stop = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3, 4]));
+    const cancel = vi.fn();
+    startLocalAsrRecorderMock.mockResolvedValue({
+      stop,
+      cancel,
+      analyser: null,
+    });
+    const onTranscript = vi.fn();
+
+    const { result } = renderHook(() =>
+      useVoiceChat({
+        onTranscript,
+        voiceConfig: {
+          provider: "eliza-cloud",
+          asr: { provider: "eliza-cloud" },
+        },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.startListening("push-to-talk");
+    });
+    expect(startLocalAsrRecorderMock).toHaveBeenCalledTimes(1);
+
+    // iOS suspends the PWA mid-capture.
+    await act(async () => {
+      document.dispatchEvent(new Event(APP_PAUSE_EVENT));
+    });
+
+    // The capture was cancelled (mic released, context closed) — NOT stopped
+    // (which would trigger the doomed transcribe round-trip + empty-WAV throw).
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(stop).not.toHaveBeenCalled();
+    // No cloud POST fired for the discarded turn.
+    expect(fetchWithCsrfMock).not.toHaveBeenCalledWith(
+      "/api/asr/cloud",
+      expect.anything(),
+    );
+    // No transcript emitted for a suspended (discarded) turn.
+    expect(onTranscript).not.toHaveBeenCalled();
+    // Listening state reset so the next gesture re-arms cleanly.
+    expect(result.current.isListening).toBe(false);
+  });
+
+  it("is a no-op on APP_PAUSE when idle (no capture in flight)", async () => {
+    const cancel = vi.fn();
+    startLocalAsrRecorderMock.mockResolvedValue({
+      stop: vi.fn(),
+      cancel,
+      analyser: null,
+    });
+    const onTranscript = vi.fn();
+
+    renderHook(() =>
+      useVoiceChat({
+        onTranscript,
+        voiceConfig: {
+          provider: "eliza-cloud",
+          asr: { provider: "eliza-cloud" },
+        },
+      }),
+    );
+
+    // No startListening — pause with nothing captured must not throw or cancel.
+    await act(async () => {
+      document.dispatchEvent(new Event(APP_PAUSE_EVENT));
+    });
+
+    expect(cancel).not.toHaveBeenCalled();
+    expect(startLocalAsrRecorderMock).not.toHaveBeenCalled();
+    expect(onTranscript).not.toHaveBeenCalled();
+  });
+
+  it("re-arms cleanly: a fresh capture after suspend starts a new recorder", async () => {
+    const cancel = vi.fn();
+    const stop = vi.fn().mockResolvedValue(new Uint8Array([5, 6, 7, 8]));
+    startLocalAsrRecorderMock.mockResolvedValue({
+      stop,
+      cancel,
+      analyser: null,
+    });
+    const onTranscript = vi.fn();
+
+    const { result } = renderHook(() =>
+      useVoiceChat({
+        onTranscript,
+        voiceConfig: {
+          provider: "eliza-cloud",
+          asr: { provider: "eliza-cloud" },
+        },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.startListening("push-to-talk");
+    });
+    await act(async () => {
+      document.dispatchEvent(new Event(APP_PAUSE_EVENT));
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
+
+    // The next press starts a brand-new capture (no stuck ref early-return).
+    await act(async () => {
+      await result.current.startListening("push-to-talk");
+    });
+    expect(startLocalAsrRecorderMock).toHaveBeenCalledTimes(2);
+    expect(result.current.isListening).toBe(true);
+  });
+});

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -33,6 +33,7 @@ import {
   type TalkModeStateEvent,
   type TalkModeTranscriptEvent,
 } from "../bridge/native-plugins";
+import { APP_PAUSE_EVENT } from "../events";
 import { resolveApiUrl } from "../utils";
 import { getElizaApiToken } from "../utils/eliza-globals";
 import {
@@ -734,6 +735,51 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
     setCaptureMode("idle");
     setInterimTranscript("");
   }, []);
+
+  // Discard the composer's in-flight capture on app suspend WITHOUT transcribing
+  // (#voice-V1). iOS suspends the WebAudio graph when the PWA backgrounds: the
+  // WAV recorder's `ScriptProcessorNode` stalls, so `stop()` would POST a
+  // truncated/empty WAV (a doomed STT round-trip) and throw "No microphone audio
+  // was captured". `recorder.cancel()` releases the getUserMedia MediaStream
+  // tracks (so iOS drops the mic indicator during suspension) and closes the
+  // AudioContext without a transcribe; the browser recognizer is aborted the
+  // same way. `resetListeningState` clears the stuck "listening" UI so the next
+  // gesture re-arms from a clean idle instead of early-returning against a stale
+  // recorder ref. The composer mic is push-to-talk (gesture-driven), not
+  // hands-free, so there is nothing to auto-re-arm on resume — the user's next
+  // press starts a fresh capture.
+  const discardCaptureForSuspend = useCallback(() => {
+    if (listeningModeRef.current === "idle" && !localAsrRecorderRef.current) {
+      return;
+    }
+    enabledRef.current = false;
+    const recorder = localAsrRecorderRef.current;
+    localAsrRecorderRef.current = null;
+    if (recorder) {
+      // cancel() releases the mic tracks + closes the context, no throw, no POST.
+      recorder.cancel();
+    }
+    const recognition = recognitionRef.current;
+    recognitionRef.current = null;
+    if (recognition) {
+      try {
+        recognition.abort();
+      } catch {
+        /* already stopped */
+      }
+    }
+    // Native TalkMode owns its own mic session; ask it to stop so iOS doesn't
+    // hold the recognizer open across suspension. Best-effort — a stopped
+    // recognizer no-ops.
+    if (sttBackendRef.current === "talkmode") {
+      void getTalkModePlugin()
+        .stop()
+        .catch(() => {
+          /* ignore */
+        });
+    }
+    resetListeningState();
+  }, [resetListeningState]);
 
   const ensureTalkModeListeners = useCallback(async () => {
     if (talkModeHandlesRef.current.length > 0) return;
@@ -2717,6 +2763,24 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       window.removeEventListener("keydown", handleUserGesture, true);
     };
   }, [unlockAudio]);
+
+  // ── App suspend: release the mic mid-capture (#voice-V1) ───────────
+  // On the installed iOS PWA, backgrounding suspends the WebAudio graph and
+  // leaves the composer capture stuck (phantom "listening", orphaned mic). Tie
+  // into #15179's lifecycle bridge (which dispatches APP_PAUSE on the web PWA)
+  // to discard the in-flight capture cleanly. Only APP_PAUSE is handled here:
+  // the composer mic is push-to-talk, so resume needs no auto-re-arm — the
+  // hands-free/ambient surface (useShellController) owns re-arm on resume.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const onPause = (): void => {
+      discardCaptureForSuspend();
+    };
+    document.addEventListener(APP_PAUSE_EVENT, onPause);
+    return () => {
+      document.removeEventListener(APP_PAUSE_EVENT, onPause);
+    };
+  }, [discardCaptureForSuspend]);
 
   // ── Cleanup on unmount ────────────────────────────────────────────
 

--- a/packages/ui/src/state/persistence-vad-auto-stop.test.ts
+++ b/packages/ui/src/state/persistence-vad-auto-stop.test.ts
@@ -47,4 +47,16 @@ describe("VAD auto-stop persistence", () => {
       speechRmsThreshold: DEFAULT_LOCAL_ASR_AUTO_STOP.speechRmsThreshold,
     });
   });
+
+  it("defaults to the snappier 550ms silence window (#voice-V6)", () => {
+    // The tightened default flows through from DEFAULT_LOCAL_ASR_AUTO_STOP.
+    expect(loadVadAutoStop().silenceMs).toBe(550);
+  });
+
+  it("lets a persisted user silenceMs override the 550ms default (#voice-V6)", () => {
+    // A user who calibrated a longer window (e.g. slow speaker) keeps it — the
+    // default drop must not clobber an explicit override.
+    saveVadAutoStop({ silenceMs: 900, speechRmsThreshold: 0.003 });
+    expect(loadVadAutoStop().silenceMs).toBe(900);
+  });
 });

--- a/packages/ui/src/voice/local-asr-capture.test.ts
+++ b/packages/ui/src/voice/local-asr-capture.test.ts
@@ -6,8 +6,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createLocalAsrAutoStopDetector,
+  DEFAULT_LOCAL_ASR_AUTO_STOP,
+  decodeMonoPcm16Wav,
   encodeMonoPcm16Wav,
   isSilentPcmAudio,
+  isSilentWav,
   measurePcmAudio,
   startLocalAsrRecorder,
 } from "./local-asr-capture";
@@ -145,5 +148,83 @@ describe("startLocalAsrRecorder resume failure", () => {
     );
     expect(trackStop).toHaveBeenCalledTimes(1);
     expect(contextClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("decodeMonoPcm16Wav / isSilentWav (#voice-V5 silence guard)", () => {
+  it("round-trips PCM16 WAV encode → decode within quantization error", () => {
+    const pcm = new Float32Array([0, 0.5, -0.5, 0.999, -0.999]);
+    const wav = encodeMonoPcm16Wav(pcm, 16000);
+    const decoded = decodeMonoPcm16Wav(wav);
+
+    expect(decoded.length).toBe(pcm.length);
+    for (let i = 0; i < pcm.length; i += 1) {
+      // 16-bit quantization: max error ~1/32768.
+      expect(decoded[i]).toBeCloseTo(pcm[i] ?? 0, 3);
+    }
+  });
+
+  it("reads a near-silent capture as silent (no cloud round-trip)", () => {
+    // A few tiny frames below the 0.0005 peak floor: a captured-but-silent tap.
+    const pcm = new Float32Array(1600);
+    pcm[10] = 0.0002;
+    pcm[11] = -0.0002;
+    const wav = encodeMonoPcm16Wav(pcm, 16000);
+
+    expect(isSilentPcmAudio(pcm)).toBe(true);
+    expect(isSilentWav(wav)).toBe(true);
+  });
+
+  it("reads a WAV carrying real speech as non-silent (POST proceeds)", () => {
+    const pcm = new Float32Array(1600);
+    pcm[800] = 0.4;
+    pcm[801] = -0.35;
+    const wav = encodeMonoPcm16Wav(pcm, 16000);
+
+    expect(isSilentWav(wav)).toBe(false);
+  });
+
+  it("treats an undecodable / non-WAV body as silent (safe default)", () => {
+    // Not a RIFF header → empty PCM → silent (don't burn a round-trip on junk).
+    const notWav = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(decodeMonoPcm16Wav(notWav)).toHaveLength(0);
+    expect(isSilentWav(notWav)).toBe(true);
+  });
+
+  it("locates the data chunk even when other sub-chunks precede it", () => {
+    // Hand-build RIFF/WAVE with a bogus 4-byte 'LIST' chunk before 'data'.
+    const pcmBytes = new Uint8Array([0x00, 0x40, 0x00, 0xc0]); // two int16 samples
+    const listPayload = new Uint8Array([9, 9, 9, 9]);
+    const total = 12 + (8 + listPayload.length) + (8 + pcmBytes.length);
+    const buf = new ArrayBuffer(total);
+    const view = new DataView(buf);
+    const u8 = new Uint8Array(buf);
+    const ascii = (o: number, s: string) => {
+      for (let i = 0; i < s.length; i += 1)
+        view.setUint8(o + i, s.charCodeAt(i));
+    };
+    ascii(0, "RIFF");
+    view.setUint32(4, total - 8, true);
+    ascii(8, "WAVE");
+    let o = 12;
+    ascii(o, "LIST");
+    view.setUint32(o + 4, listPayload.length, true);
+    u8.set(listPayload, o + 8);
+    o += 8 + listPayload.length;
+    ascii(o, "data");
+    view.setUint32(o + 4, pcmBytes.length, true);
+    u8.set(pcmBytes, o + 8);
+
+    const decoded = decodeMonoPcm16Wav(u8);
+    expect(decoded.length).toBe(2);
+    // 0x4000 = 16384 → ~0.5, 0xC000 = -16384 → ~-0.5.
+    expect(decoded[0]).toBeCloseTo(0.5, 2);
+    expect(decoded[1]).toBeCloseTo(-0.5, 2);
+  });
+});
+
+describe("DEFAULT_LOCAL_ASR_AUTO_STOP silence window (#voice-V6)", () => {
+  it("defaults the trailing-silence window to the snappier 550ms", () => {
+    expect(DEFAULT_LOCAL_ASR_AUTO_STOP.silenceMs).toBe(550);
   });
 });

--- a/packages/ui/src/voice/local-asr-capture.ts
+++ b/packages/ui/src/voice/local-asr-capture.ts
@@ -139,7 +139,14 @@ export const POST_TTS_ECHO_THRESHOLD_MULTIPLIER = 4;
 export const DEFAULT_LOCAL_ASR_AUTO_STOP: LocalAsrAutoStopConfig = {
   startGraceMs: 250,
   minSpeechMs: 180,
-  silenceMs: 900,
+  // Trailing-silence window that ends a hands-free turn (#voice-V6). Dropped
+  // 900 → 550 to shave ~350ms off every turn's speech-end → capture-stop leg
+  // (the single biggest tunable in the latency budget). The user override still
+  // wins: `loadVadAutoStop()` reads a persisted `silenceMs` first and only
+  // falls back to this default. NOTE: needs on-device false-cutoff verification
+  // — a too-tight window clips speakers who pause mid-sentence; if that regresses
+  // in the field, nudge back up (or expose a per-user calibration).
+  silenceMs: 550,
   maxSpeechMs: 12_000,
   speechRmsThreshold: 0.003,
   speechPeakThreshold: 0.012,
@@ -246,6 +253,77 @@ export function encodeMonoPcm16Wav(
   }
 
   return new Uint8Array(buffer);
+}
+
+/**
+ * Decode a mono PCM16 WAV (as produced by {@link encodeMonoPcm16Wav}) back to a
+ * Float32 sample buffer in [-1, 1]. Used by the pre-POST silence guard
+ * (#voice-V5): the capture recorder hands the factory an already-encoded WAV,
+ * so to test it for silence with {@link isSilentPcmAudio} we read the PCM back
+ * out of the RIFF body rather than plumbing a second Float32 buffer through the
+ * recorder API.
+ *
+ * Best-effort + defensive: it locates the `data` chunk instead of assuming the
+ * canonical 44-byte header, and returns an empty buffer for anything it can't
+ * parse (a non-WAV / truncated body). An empty buffer reads as silent, which is
+ * the safe default for the guard (a body we can't decode is not worth a STT
+ * round-trip).
+ */
+export function decodeMonoPcm16Wav(wav: Uint8Array): Float32Array {
+  // Minimum parseable size: RIFF/WAVE header (12) + a `data` sub-chunk header
+  // (8) = 20. (The canonical encoder writes a 44-byte header, but a valid WAV
+  // with a non-canonical chunk layout can be smaller — don't over-reject.)
+  if (wav.length < 20) return new Float32Array(0);
+  const view = new DataView(wav.buffer, wav.byteOffset, wav.byteLength);
+  const riff =
+    view.getUint8(0) === 0x52 && // 'R'
+    view.getUint8(1) === 0x49 && // 'I'
+    view.getUint8(2) === 0x46 && // 'F'
+    view.getUint8(3) === 0x46; // 'F'
+  if (!riff) return new Float32Array(0);
+
+  // Walk sub-chunks from offset 12 to find `data` (chunks may precede it, e.g.
+  // `fmt `); don't assume the 44-byte canonical layout.
+  let offset = 12;
+  let dataStart = -1;
+  let dataBytes = 0;
+  while (offset + 8 <= wav.length) {
+    const id0 = view.getUint8(offset);
+    const id1 = view.getUint8(offset + 1);
+    const id2 = view.getUint8(offset + 2);
+    const id3 = view.getUint8(offset + 3);
+    const chunkBytes = view.getUint32(offset + 4, true);
+    // 'data'
+    if (id0 === 0x64 && id1 === 0x61 && id2 === 0x74 && id3 === 0x61) {
+      dataStart = offset + 8;
+      dataBytes = chunkBytes;
+      break;
+    }
+    // Chunks are word-aligned (odd sizes get a pad byte).
+    offset += 8 + chunkBytes + (chunkBytes % 2);
+  }
+  if (dataStart < 0) return new Float32Array(0);
+
+  // Clamp to the actual buffer length in case the header over-reports.
+  const available = Math.max(0, wav.length - dataStart);
+  const usableBytes = Math.min(dataBytes, available);
+  const sampleCount = Math.floor(usableBytes / 2);
+  const out = new Float32Array(sampleCount);
+  for (let i = 0; i < sampleCount; i += 1) {
+    const int16 = view.getInt16(dataStart + i * 2, true);
+    out[i] = int16 < 0 ? int16 / 0x8000 : int16 / 0x7fff;
+  }
+  return out;
+}
+
+/**
+ * True when a captured WAV carries no usable speech (peak amplitude below the
+ * {@link isSilentPcmAudio} floor) — the pre-POST silence guard (#voice-V5) uses
+ * this to no-op an accidental near-silent tap instead of burning a cloud STT
+ * round-trip / credit and surfacing a spurious empty-transcript error.
+ */
+export function isSilentWav(wav: Uint8Array): boolean {
+  return isSilentPcmAudio(decodeMonoPcm16Wav(wav));
 }
 
 export async function startLocalAsrRecorder(

--- a/packages/ui/src/voice/local-asr-transcribe.test.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.test.ts
@@ -73,13 +73,117 @@ describe("transcribeCloudWav", () => {
     );
   });
 
-  it("forwards an abort signal to fetch", async () => {
-    fetchWithCsrfMock.mockResolvedValue(jsonResponse({ text: "ok" }));
+  it("passes an AbortSignal to fetch that aborts when the caller's signal aborts (#voice-V4)", async () => {
+    // V4 composes the caller's signal with a per-attempt timeout controller, so
+    // fetch no longer receives the caller's signal by identity — it receives the
+    // internal controller's signal. The contract that matters: a caller abort
+    // still aborts the in-flight fetch (the signal fetch actually saw).
+    let sawSignal: AbortSignal | undefined;
+    fetchWithCsrfMock.mockImplementation((_url, init) => {
+      sawSignal = (init as RequestInit | undefined)?.signal ?? undefined;
+      // Never resolve — hold the request open so we can observe the abort chain.
+      return new Promise<Response>((_resolve, reject) => {
+        sawSignal?.addEventListener("abort", () =>
+          reject(new DOMException("aborted", "AbortError")),
+        );
+      });
+    });
     const controller = new AbortController();
-    await transcribeCloudWav(new Uint8Array([1]), {
+    const p = transcribeCloudWav(new Uint8Array([1]), {
       signal: controller.signal,
     });
-    const [, init] = fetchWithCsrfMock.mock.calls[0] ?? [];
-    expect(init?.signal).toBe(controller.signal);
+    // Let the fetch mock run and capture the signal it received.
+    await Promise.resolve();
+    expect(sawSignal).toBeInstanceOf(AbortSignal);
+    expect(sawSignal?.aborted).toBe(false);
+    // The caller aborts mid-flight → the signal fetch saw is aborted too.
+    controller.abort();
+    expect(sawSignal?.aborted).toBe(true);
+    await expect(p).rejects.toThrow(/cancelled/);
+  });
+
+  it("aborts the fetch when its client-side timeout elapses (#voice-V4)", async () => {
+    vi.useFakeTimers();
+    try {
+      let sawSignal: AbortSignal | undefined;
+      // A fetch that never resolves until aborted, so the timeout is what ends it.
+      fetchWithCsrfMock.mockImplementation((_url, init) => {
+        sawSignal = (init as RequestInit | undefined)?.signal ?? undefined;
+        return new Promise<Response>((_resolve, reject) => {
+          sawSignal?.addEventListener("abort", () => {
+            reject(new DOMException("aborted", "AbortError"));
+          });
+        });
+      });
+      // Only ONE attempt (retryable timeout) => expect exactly 2 fetch calls
+      // (initial + single retry), then a timeout error surfaces.
+      const p = transcribeCloudWav(new Uint8Array([1]), { timeoutMs: 15_000 });
+      const assertion = expect(p).rejects.toThrow(/timed out after 15000ms/);
+      // First attempt times out …
+      await vi.advanceTimersByTimeAsync(15_000);
+      // … retry fires, times out too.
+      await vi.advanceTimersByTimeAsync(15_000);
+      await assertion;
+      expect(fetchWithCsrfMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("auto-retries ONCE on a network-class failure then succeeds (#voice-V4)", async () => {
+    fetchWithCsrfMock
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(jsonResponse({ text: "second try" }));
+    const text = await transcribeCloudWav(new Uint8Array([1]));
+    expect(text).toBe("second try");
+    expect(fetchWithCsrfMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries once on a 5xx then surfaces the error if it persists (#voice-V4)", async () => {
+    fetchWithCsrfMock.mockResolvedValue(
+      jsonResponse({ error: "upstream" }, false, 502),
+    );
+    await expect(transcribeCloudWav(new Uint8Array([1]))).rejects.toThrow(
+      /Cloud ASR 502/,
+    );
+    // initial + one retry (502 is retryable) — no third attempt.
+    expect(fetchWithCsrfMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT retry a terminal 4xx client error (#voice-V4)", async () => {
+    fetchWithCsrfMock.mockResolvedValue(
+      jsonResponse({ error: "no api key" }, false, 401),
+    );
+    await expect(transcribeCloudWav(new Uint8Array([1]))).rejects.toThrow(
+      /Cloud ASR 401/,
+    );
+    // 401 is terminal — a single attempt, no retry.
+    expect(fetchWithCsrfMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT retry an empty transcript (terminal) (#voice-V4)", async () => {
+    fetchWithCsrfMock.mockResolvedValue(jsonResponse({ text: "   " }));
+    await expect(transcribeCloudWav(new Uint8Array([1]))).rejects.toThrow(
+      /empty transcript/,
+    );
+    expect(fetchWithCsrfMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT retry when the caller aborts (terminal) (#voice-V4)", async () => {
+    const controller = new AbortController();
+    fetchWithCsrfMock.mockImplementation((_url, init) => {
+      const s = (init as RequestInit | undefined)?.signal;
+      return new Promise<Response>((_resolve, reject) => {
+        s?.addEventListener("abort", () =>
+          reject(new DOMException("aborted", "AbortError")),
+        );
+      });
+    });
+    const p = transcribeCloudWav(new Uint8Array([1]), {
+      signal: controller.signal,
+    });
+    controller.abort();
+    await expect(p).rejects.toThrow(/cancelled/);
+    expect(fetchWithCsrfMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/ui/src/voice/local-asr-transcribe.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.ts
@@ -20,6 +20,50 @@ export interface TranscribeWavOptions {
   signal?: AbortSignal;
 }
 
+/** Default per-attempt client-side STT timeout (#voice-V4). */
+export const DEFAULT_CLOUD_STT_TIMEOUT_MS = 15_000;
+
+export interface TranscribeCloudWavOptions extends TranscribeWavOptions {
+  /**
+   * Per-attempt client-side timeout (#voice-V4). A flaky-cellular POST that
+   * never resolves would otherwise hang the turn in "processing" forever
+   * (fetch has no default timeout). Each attempt gets its own AbortController
+   * armed to this deadline; on a network-class failure the helper retries ONCE
+   * before surfacing the error. Defaults to {@link DEFAULT_CLOUD_STT_TIMEOUT_MS}.
+   */
+  timeoutMs?: number;
+}
+
+/**
+ * Error thrown by {@link transcribeCloudWav} carrying the HTTP status (when the
+ * failure was an HTTP response) so callers / the retry logic can distinguish a
+ * retryable transport hiccup (timeout, 5xx, 429) from a terminal client error
+ * (401/402/413 — retrying won't help).
+ */
+export class CloudSttError extends Error {
+  /** HTTP status when the failure was a response; `undefined` for transport/timeout. */
+  readonly status?: number;
+  /** True when this failure class is safe to retry once (network/timeout/5xx/429). */
+  readonly retryable: boolean;
+  constructor(
+    message: string,
+    opts: { status?: number; retryable: boolean; cause?: unknown },
+  ) {
+    super(
+      message,
+      opts.cause !== undefined ? { cause: opts.cause } : undefined,
+    );
+    this.name = "CloudSttError";
+    this.status = opts.status;
+    this.retryable = opts.retryable;
+  }
+}
+
+/** HTTP statuses worth one automatic retry (transient upstream/transport). */
+function isRetryableStatus(status: number): boolean {
+  return status === 408 || status === 429 || (status >= 500 && status <= 599);
+}
+
 export interface TranscribeWavResult {
   /** Trimmed transcript text. Never empty — the helper throws instead. */
   text: string;
@@ -108,37 +152,112 @@ function bytesToBase64(bytes: Uint8Array): string {
  *
  * Fails loud: a non-2xx response or an empty transcript throws, so the capture
  * surface renders an error state rather than silently substituting browser STT.
+ *
+ * Resilient (#voice-V4): each attempt is bounded by a client-side timeout
+ * (`timeoutMs`, default 15s) and a single automatic retry covers a network-class
+ * failure (transport error, timeout, 5xx, 429) so a flaky-cellular STT doesn't
+ * hard-fail the turn on the first hiccup. Terminal client errors (401/402/413)
+ * and an empty transcript are NOT retried — retrying won't change the outcome.
+ * A caller-initiated abort (`options.signal`) is honored immediately and never
+ * retried.
  */
 export async function transcribeCloudWav(
   audio: Uint8Array,
-  options?: TranscribeWavOptions,
+  options?: TranscribeCloudWavOptions,
 ): Promise<string> {
-  const res = await fetchWithCsrf(resolveApiUrl("/api/asr/cloud"), {
-    method: "POST",
-    headers: {
-      "Content-Type": "audio/wav",
-      Accept: "application/json",
-    },
-    // A Uint8Array is a valid BufferSource body; the cast bridges the DOM lib's
-    // stricter `ArrayBuffer` generic on BodyInit (the runtime accepts it as-is).
-    body: audio as BodyInit,
-    signal: options?.signal,
-  });
-  if (!res.ok) {
-    // error-policy:J6 the error body is diagnostic-only; a failed read must not
-    // mask the real signal (the HTTP status the throw below already carries).
-    const body = await res.text().catch(() => "");
-    throw new Error(`Cloud ASR ${res.status}: ${body.slice(0, 200)}`);
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_CLOUD_STT_TIMEOUT_MS;
+  const callerSignal = options?.signal;
+
+  // One attempt: arm a per-attempt timeout AbortController, compose it with the
+  // caller's signal, POST, and classify any failure as retryable or terminal.
+  const attempt = async (): Promise<string> => {
+    const timeoutController = new AbortController();
+    const timer = setTimeout(() => {
+      timeoutController.abort();
+    }, timeoutMs);
+    // Chain the caller's abort into this attempt so an outer cancel still
+    // aborts the in-flight fetch (and is distinguishable from a timeout below).
+    const onCallerAbort = () => timeoutController.abort();
+    if (callerSignal) {
+      if (callerSignal.aborted) timeoutController.abort();
+      else
+        callerSignal.addEventListener("abort", onCallerAbort, { once: true });
+    }
+    try {
+      const res = await fetchWithCsrf(resolveApiUrl("/api/asr/cloud"), {
+        method: "POST",
+        headers: {
+          "Content-Type": "audio/wav",
+          Accept: "application/json",
+        },
+        // A Uint8Array is a valid BufferSource body; the cast bridges the DOM
+        // lib's stricter `ArrayBuffer` generic on BodyInit (runtime accepts it).
+        body: audio as BodyInit,
+        signal: timeoutController.signal,
+      });
+      if (!res.ok) {
+        // error-policy:J6 the error body is diagnostic-only; a failed read must
+        // not mask the HTTP status the error below already carries.
+        const body = await res.text().catch(() => "");
+        throw new CloudSttError(
+          `Cloud ASR ${res.status}: ${body.slice(0, 200)}`,
+          { status: res.status, retryable: isRetryableStatus(res.status) },
+        );
+      }
+      // error-policy:J3 unparseable body falls through to the empty-transcript
+      // throw (terminal — a bad body won't parse on a retry either).
+      const parsed = (await res.json().catch(() => null)) as {
+        text?: unknown;
+      } | null;
+      const text = typeof parsed?.text === "string" ? parsed.text.trim() : "";
+      if (!text) {
+        throw new CloudSttError("Cloud ASR returned an empty transcript", {
+          retryable: false,
+        });
+      }
+      return text;
+    } catch (err) {
+      if (err instanceof CloudSttError) throw err;
+      // A caller-initiated abort is terminal + must surface as the caller's
+      // cancel, not a timeout retry.
+      if (callerSignal?.aborted) {
+        throw new CloudSttError("Cloud ASR request was cancelled", {
+          retryable: false,
+          cause: err,
+        });
+      }
+      // Our own timeout fired — retryable transport-class failure.
+      if (timeoutController.signal.aborted) {
+        throw new CloudSttError(`Cloud ASR timed out after ${timeoutMs}ms`, {
+          retryable: true,
+          cause: err,
+        });
+      }
+      // Any other throw (fetch TypeError = DNS/offline/connection reset) is a
+      // network-class failure — retry once.
+      throw new CloudSttError(
+        `Cloud ASR request failed: ${err instanceof Error ? err.message : String(err)}`,
+        { retryable: true, cause: err },
+      );
+    } finally {
+      clearTimeout(timer);
+      callerSignal?.removeEventListener("abort", onCallerAbort);
+    }
+  };
+
+  try {
+    return await attempt();
+  } catch (err) {
+    // One auto-retry on a network-class failure, unless the caller cancelled.
+    if (
+      err instanceof CloudSttError &&
+      err.retryable &&
+      !callerSignal?.aborted
+    ) {
+      return await attempt();
+    }
+    throw err;
   }
-  // error-policy:J3 unparseable body falls through to the empty-transcript throw
-  const parsed = (await res.json().catch(() => null)) as {
-    text?: unknown;
-  } | null;
-  const text = typeof parsed?.text === "string" ? parsed.text.trim() : "";
-  if (!text) {
-    throw new Error("Cloud ASR returned an empty transcript");
-  }
-  return text;
 }
 
 export async function transcribeLocalInferenceWav(

--- a/packages/ui/src/voice/voice-capture-factory.test.ts
+++ b/packages/ui/src/voice/voice-capture-factory.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getTalkModePlugin } from "../bridge/native-plugins";
 import {
   isLocalAsrCaptureSupported,
+  isSilentWav,
   type LocalAsrRecorderOptions,
   startLocalAsrRecorder,
 } from "./local-asr-capture";
@@ -18,6 +19,7 @@ import { createVoiceCapture } from "./voice-capture-factory";
 
 vi.mock("./local-asr-capture", () => ({
   isLocalAsrCaptureSupported: vi.fn(),
+  isSilentWav: vi.fn(),
   startLocalAsrRecorder: vi.fn(),
 }));
 
@@ -37,6 +39,7 @@ vi.mock("../bridge/native-plugins", async (importOriginal) => ({
 }));
 
 const isLocalAsrCaptureSupportedMock = vi.mocked(isLocalAsrCaptureSupported);
+const isSilentWavMock = vi.mocked(isSilentWav);
 const startLocalAsrRecorderMock = vi.mocked(startLocalAsrRecorder);
 const isLocalInferenceAsrReadyMock = vi.mocked(isLocalInferenceAsrReady);
 const transcribeCloudWavMock = vi.mocked(transcribeCloudWav);
@@ -70,6 +73,9 @@ function makeFakeTalkMode(overrides?: { started?: boolean; error?: string }) {
 describe("createVoiceCapture", () => {
   beforeEach(() => {
     isLocalAsrCaptureSupportedMock.mockReturnValue(true);
+    // Default: captured audio carries speech, so the V5 silence guard is a
+    // no-op and the cloud POST proceeds (individual tests flip it to silent).
+    isSilentWavMock.mockReturnValue(false);
     isLocalInferenceAsrReadyMock.mockResolvedValue(true);
     transcribeLocalInferenceWavMock.mockResolvedValue({
       text: "Ada Lovelace",
@@ -367,6 +373,41 @@ describe("createVoiceCapture", () => {
     expect(onTranscript).toHaveBeenCalledWith(
       expect.objectContaining({ backend: "cloud", text: "Grace Hopper" }),
     );
+  });
+
+  it("silent cloud capture is a quiet no-op — no POST, no transcript, no error (#voice-V5)", async () => {
+    // A near-silent accidental tap captured a few frames (so the recorder's
+    // stop() didn't throw) but carries no speech. The pre-POST silence guard
+    // must skip the cloud round-trip AND not surface an error toast — just
+    // settle back to idle so the next tap re-arms cleanly.
+    const wav = new Uint8Array([1, 2, 3, 4]);
+    startLocalAsrRecorderMock.mockResolvedValue({
+      stop: vi.fn().mockResolvedValue(wav),
+      cancel: vi.fn(),
+      analyser: null,
+    });
+    isSilentWavMock.mockReturnValue(true);
+    const onTranscript = vi.fn();
+    const onStateChange = vi.fn();
+    const capture = createVoiceCapture({
+      asrProvider: "eliza-cloud",
+      onTranscript,
+      onStateChange,
+    });
+
+    await capture.start();
+    await capture.stop();
+
+    // No cloud round-trip, no transcript emitted.
+    expect(isSilentWavMock).toHaveBeenCalledWith(wav);
+    expect(transcribeCloudWavMock).not.toHaveBeenCalled();
+    expect(onTranscript).not.toHaveBeenCalled();
+    // Not an error state — a clean settle back to idle.
+    const states = onStateChange.mock.calls.map(([s]) => s);
+    expect(states).not.toContain("error");
+    expect(onStateChange).toHaveBeenLastCalledWith("idle", undefined);
+    // The handle is no longer active (stop drained it).
+    expect(capture.isActive()).toBe(false);
   });
 
   it("cloud STT failure surfaces an error state — no silent browser downgrade", async () => {

--- a/packages/ui/src/voice/voice-capture-factory.ts
+++ b/packages/ui/src/voice/voice-capture-factory.ts
@@ -34,6 +34,7 @@ import {
 } from "../bridge/native-plugins";
 import {
   isLocalAsrCaptureSupported,
+  isSilentWav,
   type LocalAsrAutoStopOptions,
   type LocalAsrRecorder,
   startLocalAsrRecorder,
@@ -442,9 +443,25 @@ export function createVoiceCapture(
       }
       try {
         const wav = await current.stop();
+        // Pre-POST silence guard (#voice-V5): an accidental / near-silent tap
+        // captured a few frames (so `stop()` didn't throw the empty-capture
+        // error) but carries no speech. POSTing it burns a cloud STT round-trip
+        // / credit and surfaces a spurious "empty transcript" error. Treat it as
+        // a quiet no-op instead: no transcript, no error toast — just settle the
+        // state machine back to idle so the next tap re-arms cleanly. (Gates the
+        // cloud path where the round-trip has a cost; the local-inference path
+        // is free/offline, so it stays unguarded to avoid clipping quiet-mic
+        // users whose real speech reads near the silence floor on-device.)
+        if (kind === "cloud" && isSilentWav(wav)) {
+          setState("stopped");
+          setState("idle");
+          return;
+        }
         if (kind === "cloud") {
           // Cloud STT returns text only (no per-word timings); the WAV is still
-          // attached so the transcript recorder can retain the audio.
+          // attached so the transcript recorder can retain the audio. A ~15s
+          // per-attempt timeout + one auto-retry (#voice-V4) rides inside
+          // transcribeCloudWav so flaky cellular doesn't hard-fail the turn.
           const text = await transcribeCloudWav(wav);
           onTranscript({
             text,


### PR DESCRIPTION
## Voice-loop reliability cut — installed iOS PWA

Implements the dossier's recommended first cut **"make the loop reliable on iPhone"** — lanes **V1 + V4 + V5 + V6** (all low-effort, PR-ready in the ranked roadmap). Small, share files, landed together. Builds on the already-merged #15128 (cloud-ASR wiring) and #15179 (resume-from-background) — extends, doesn't compete.

Ref: `VOICE-LOOP-DOSSIER.md` §2 (failure-mode audit), §4 (quality gaps), §5 (ranked roadmap V1/V4/V5/V6).

### V1 — pause/re-arm voice capture across app lifecycle (rank 1, impact 5)
The WAV recorder had **no lifecycle listener**: when iOS suspends the PWA mid-capture the `ScriptProcessorNode` stalls, so a later `stop()` throws *"No microphone audio was captured"* and the UI is stuck in a phantom `listening`/`recording` state with an orphaned `getUserMedia` MediaStream (mic indicator stays lit).

- **`useVoiceChat`** (composer / push-to-talk): on `APP_PAUSE` discard the in-flight capture via `recorder.cancel()` — releases the mic tracks + closes the `AudioContext`, **no transcribe POST**. `resetListeningState()` clears the stuck UI so the next gesture re-arms from a clean idle. PTT needs no resume auto-re-arm.
- **`useShellController`** (ambient / hands-free): same `APP_PAUSE` discard, plus on `APP_RESUME` re-arm hands-free the instant we foreground (guarded against double-capture + gated while responding). Extends #15179's `APP_PAUSE`/`APP_RESUME` bridge (both dispatched on the web PWA).

### V4 — client STT timeout + one retry (rank 4, impact 4)
`transcribeCloudWav` had **no client-side timeout** (fetch has no default) — a flaky-cellular POST could hang the turn forever.
- Per-attempt `AbortController` timeout (~15s, `DEFAULT_CLOUD_STT_TIMEOUT_MS`), composed with the caller's `signal`.
- **One** auto-retry on a network-class failure (transport error / timeout / 5xx / 429). Terminal failures (401/402/413, empty transcript, caller-abort) are **not** retried.
- New `CloudSttError` carries `status` + `retryable` for classification.

### V5 — pre-POST silence guard (rank 5, impact 3)
`isSilentPcmAudio` existed but wasn't gating the cloud POST — a near-silent accidental tap still burned a round-trip / STT credit and surfaced a spurious empty-transcript error.
- New `decodeMonoPcm16Wav` + `isSilentWav`; the factory's **cloud** `stop()` path gates the POST behind `!isSilentWav(wav)`. Silent capture = quiet no-op (state settles to `idle`, no round-trip, **no error toast**). Local-inference path stays unguarded (free/offline).

### V6 — snappier VAD default (rank 6, impact 3)
- `DEFAULT_LOCAL_ASR_AUTO_STOP.silenceMs` **900 → 550** (shaves ~350ms off every hands-free turn — the biggest tunable in the §4.3 latency budget). The user override via `loadVadAutoStop()` still wins.
- ⚠️ **Needs on-device false-cutoff verification** — a too-tight window can clip speakers who pause mid-sentence. Add a "talk with a mid-sentence pause" step to the device checklist; if it regresses, nudge back up.

### Tests (vitest / jsdom — 47 passing)
- **V1**: pause mid-capture cancels cleanly (no empty-capture throw, no POST, no transcript), idle-pause is a no-op, resume re-arms a fresh recorder.
- **V4**: timeout fires + single retry + then errors; retry only on network-class (TypeError / 5xx); **no** retry on 4xx / empty / caller-abort; caller abort chains into the in-flight fetch signal.
- **V5**: WAV encode→decode round-trip, non-canonical chunk layout, junk-body safe-default; silent cloud capture = quiet no-op (`onStateChange` never `error`, ends `idle`).
- **V6**: default is 550, a persisted `silenceMs` override wins.
- No regressions in existing `useVoiceChat.cloud-asr` / `.local-asr` suites.

### Collision check
`gh pr list --search voice` → only **#15249** (boot-perf, `perf/client-boot-parallel`) — does not touch capture/ASR/TTS files. No overlap (dossier §6 confirmed + reverified).

### Not self-merged
Voice is a **device-verify class** change (iOS backgrounding + VAD cutoff need on-device confirmation on the installed PWA). Requesting review + a device pass before merge.

[sol-orch]

Co-authored-by: wakesync <shadow@shad0w.xyz>## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] N/A - non-visual reliability change (capture lifecycle, STT timeout, silence guard, VAD default); no UI pixels changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no visual delta; the meaningful "after" is the on-device iOS PWA verify pass requested before merge

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - behavior is suspend timing + injected network failure, asserted by 47 vitest contract tests (output pasted above)

<!-- evidence-row:backend-logs -->
- [ ] N/A - client-only diff (packages/ui voice capture/transcribe); no backend changes

<!-- evidence-row:frontend-logs -->
- [ ] N/A - failure paths asserted in vitest (no POST on silent WAV, single network-class retry, abort chaining); device log capture will accompany the device-verify pass

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/model behavior change; voice transport reliability only

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - design source is VOICE-LOOP-DOSSIER.md (fleet doc, repo-third-party); vitest output in Tests section is the artifact