### PR TITLE
fix(ci): sandbox-live-smoke non-strict must skip unconfigured providers, not hard-fail

### DIFF
--- a/packages/agent/scripts/live-sandbox-smoke.ts
+++ b/packages/agent/scripts/live-sandbox-smoke.ts
@@ -1,7 +1,7 @@
 /** Runs a live sandbox smoke path for agent plugin isolation and runtime launch behavior. */
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { createInterface } from "node:readline";
-import type { IAgentRuntime, UUID } from "@elizaos/core";
+import { CapabilityError, type IAgentRuntime, type UUID } from "@elizaos/core";
 import {
   E2BRemoteCapabilityRouterService,
   type E2BSandboxFactory,
@@ -38,9 +38,14 @@ for (const target of targets) {
   try {
     outcomes.push(await runTarget(target));
   } catch (error) {
+    // A CAPABILITY_UNAVAILABLE thrown from the router means the provider is not
+    // configured/installed in this environment (e.g. the e2b factory plugin is
+    // absent, or credentials are partial) — that is a SKIP, not a failure. The
+    // `strict && skipped` gate below still fails-closed under --strict. Any
+    // other error is a genuine smoke failure and stays `failed`.
     outcomes.push({
       target,
-      status: "failed",
+      status: isCapabilityUnavailable(error) ? "skipped" : "failed",
       message: error instanceof Error ? error.message : String(error),
     });
   }
@@ -80,6 +85,22 @@ async function runSandboxProviderSmoke(
   // sandbox factory so the router can reach the e2b provider in this smoke.
   const factory =
     provider === "e2b" ? await loadE2BSandboxFactory(runtime) : undefined;
+  // In non-strict mode a provider that cannot initialize is a SKIP, not a
+  // failure: `--strict` is the fail-closed switch (the workflow only passes it
+  // on manual dispatch), so a routine push smoke must stay green when a
+  // provider is genuinely unconfigurable in this environment. Here the e2b
+  // backend is unreachable whenever its optional plugin (and the `e2b` SDK it
+  // pulls in) is not installed — surface that as a clear skip up front rather
+  // than letting the router throw CAPABILITY_UNAVAILABLE mid-run and reading as
+  // a hard failure.
+  if (provider === "e2b" && !factory) {
+    return {
+      target: provider,
+      status: "skipped",
+      message:
+        "e2b backend unavailable: @elizaos/plugin-e2b-sandbox is not installed (add the plugin, or run with --strict to fail-close).",
+    };
+  }
   const service = new E2BRemoteCapabilityRouterService(
     runtime,
     undefined,
@@ -344,6 +365,12 @@ function requireObject(value: unknown, label: string): JsonRecord {
 
 function isObject(value: unknown): value is JsonRecord {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isCapabilityUnavailable(error: unknown): boolean {
+  return (
+    error instanceof CapabilityError && error.code === "CAPABILITY_UNAVAILABLE"
+  );
 }
 
 async function withTimeout<T>(


### PR DESCRIPTION
## Root cause

The **Sandbox Live Smoke** workflow runs non-strict on every push to `develop`
(`bun run --cwd packages/agent test:sandbox-live -- --target=all`). `E2B_API_KEY`
is supplied to the job, so the `e2b` target is attempted. But
`@elizaos/plugin-e2b-sandbox` is **not a dependency of `@elizaos/agent`** and is
not installed/built in that CI job, so the harness's dynamic
`import("@elizaos/plugin-e2b-sandbox")` (in `loadE2BSandboxFactory`) fails and the
injected factory is `undefined`. The router then falls back to
`DefaultSandboxFactory`, which — correctly and by design — throws
`CapabilityError { code: "CAPABILITY_UNAVAILABLE", method: "sandbox.create" }`
because the e2b provider genuinely cannot initialize.

Two things then combined to redden `develop`:
1. `availability()` returns `available: true` purely because `E2B_API_KEY` is set,
   so the run proceeds **past** the availability skip-gate into `pty.runCommand`.
2. The top-level loop classified the resulting `CAPABILITY_UNAVAILABLE` as
   `failed`, and `failures.length > 0` sets exit 1 **even in non-strict mode**.

Result: every non-strict push smoke has failed for 12+ hours.

## Fix chosen — and why (option b, scoped)

I chose **(b): in non-strict mode, treat "provider genuinely unconfigurable" as a
clearly-logged SKIP, not a hard failure**, rather than **(a) wiring the plugin in**.

The design contract is unambiguous: `--strict` exists precisely as the
fail-closed switch, and the workflow only passes `--strict` on manual dispatch.
A routine non-strict push smoke is meant to stay green when a provider can't be
configured in that environment; `--strict` is what fails-closed. Option (a) would
also require adding the heavy `e2b` SDK vendor dependency plus a live E2B account
round-trip to actually pass — which is exactly the live-gated behavior `--strict`
is designed to guard, not something a push smoke should require.

The router's own fail-fast (`throw CAPABILITY_UNAVAILABLE` when the factory is
absent) is intentional and unit-tested — I did not touch it. The fix lives at the
**harness boundary**, which is what decides pass/skip/fail:

- **Front-gate**: when `provider === "e2b"` and the optional factory plugin could
  not be loaded, skip the e2b target up front with a clear reason.
- **Error classification**: a `CapabilityError` with code `CAPABILITY_UNAVAILABLE`
  thrown mid-run is reclassified as a **skip** (unconfigured/plugin-absent);
  **every other error stays `failed`** (a real fs/git/timeout bug against a
  configured provider still fails the smoke). The existing
  `strict && skipped.length > 0` gate is untouched, so `--strict` still
  fails-closed on any skip.

**Files changed:** `packages/agent/scripts/live-sandbox-smoke.ts` (+29 / -2).

## Local verification

```
# non-strict, no creds -> clean SKIPs, exit 0
$ bun run --cwd packages/agent test:sandbox-live -- --target=all
SKIPPED e2b: E2B remote runner requires E2B_API_KEY, E2B_ACCESS_TOKEN, or matching runtime setting.
SKIPPED eliza-cloud: Eliza Cloud runner requires ELIZA_CLOUD_CODING_REMOTE_RUNNER_IMAGE or a direct runner URL.
SKIPPED home: Home runner requires ELIZA_HOME_REMOTE_RUNNER_URL.
PASSED codex-app-server: stdio app-server initialized and responded to model/account RPCs
EXIT=0

# strict, no creds -> fail-closed, exit 1
$ bun run --cwd packages/agent test:sandbox-live -- --target=all --strict
SKIPPED e2b: ...
SKIPPED eliza-cloud: ...
SKIPPED home: ...
PASSED codex-app-server: ...
EXIT=1

# unit tests (router behavior unchanged)
$ bun vitest run src/services/e2b-capability-router.test.ts
Test Files  1 passed (1)
     Tests  18 passed (18)
```

`bun run --cwd packages/agent typecheck` reports only 4 pre-existing
`TS2688 Cannot find type definition file` errors (bun/node/react/react-dom) from
missing `@types` in the isolated worktree — none in the touched file. Biome check
on the file is clean.

> Note: locally the `e2b` SDK happens to be installed, so the e2b target instead
> skips via the availability gate (no creds) or, with a fake key, fails on
> **invalid key format** — a real config error that correctly stays `failed`.
> The CI-specific path (plugin/SDK absent → `CAPABILITY_UNAVAILABLE`) is the one
> both the front-gate and the classifier convert to a skip.


---

## Evidence

CI/test-harness change only (`packages/agent/scripts/live-sandbox-smoke.ts`). No UI, agent, model, or user-facing surface. Local: non-strict `--target=all` no-creds → SKIPs, exit 0; `--strict` → exit 1 (fail-closed); `e2b-capability-router.test.ts` 18/18 pass.

<!-- evidence-row:before-screenshots -->
- **Before screenshots:** N/A - no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- **After screenshots:** N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- **Walkthrough video:** N/A - no interactive/user-facing flow changed.
<!-- evidence-row:backend-logs -->
- **Backend logs:** N/A - no runtime/backend code changed; the affected behavior is a CI script's exit code, verified locally.
<!-- evidence-row:frontend-logs -->
- **Frontend console/network logs:** N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- **Real-LLM trajectory:** N/A - no agent/action/prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- **Domain artifacts:** N/A - CI-only change; verification (unit tests / script exit codes) is described in the PR body above.
