### PR TITLE
fix(ci): repair dead script refs in chat-shell-gestures workflow

### DIFF
--- a/.github/workflows/chat-shell-gestures.yml
+++ b/.github/workflows/chat-shell-gestures.yml
@@ -119,15 +119,12 @@ jobs:
         run: bun run --cwd packages/ui test -- src/components/chat/render-parity.contract.test.tsx
 
       # Conversation-nav interleaving fuzz (jsdom) — the pure most-recent-first
-      # invariants across swipe / new / select sequences (#10042).
+      # invariants across new / select sequences (#10042). Chat-to-chat swipe
+      # was removed by the single-infinite-thread redesign (#13531), so the swipe
+      # e2e + its jank hook were retired in #13826; the remaining overlay gesture
+      # cost is now covered by the maximize/restore perf gate below.
       - name: Conversation-nav unit + interleaving
-        run: bun run --cwd packages/ui test -- src/components/shell/conversation-nav.test.ts src/hooks/useConversationSwipeJank.test.ts
-
-      # Real-overlay conversation-swipe interleaving (headless chromium, real
-      # pointer gestures): swipe-back → new → swipe-forward → new → forward →
-      # swipe-back with per-step interleaving invariants + swipe-jank telemetry.
-      - name: Conversation-swipe interleaving e2e
-        run: bun run --cwd packages/ui test:conversation-swipe-e2e
+        run: bun run --cwd packages/ui test -- src/components/shell/conversation-nav.test.ts
 
       # The iOS-style chat-sheet detent/gesture state machine (mouse + touch).
       - name: Chat-sheet gesture e2e
@@ -221,7 +218,6 @@ jobs:
           name: chat-shell-gesture-artifacts
           path: |
             packages/ui/src/components/shell/__e2e__/output/
-            packages/ui/src/components/shell/__e2e__/output-conversation-swipe/
             packages/ui/src/components/shell/__e2e__/output-chatux/
             packages/ui/src/components/shell/__e2e__/output-home/
             packages/ui/src/components/shell/__e2e__/output-launcher-loop/


### PR DESCRIPTION
## Root cause

The **Chat shell gestures** workflow (`.github/workflows/chat-shell-gestures.yml`) has hard-failed on every `develop` push for days. The step **Conversation-swipe interleaving e2e** ran:

```
bun run --cwd packages/ui test:conversation-swipe-e2e
```

but that npm script **no longer exists** in `packages/ui/package.json` — Bun exits non-zero with `error: Script not found "test:conversation-swipe-e2e"`.

The script was removed in **#13826** (commit `db19f67a189`, "retire swipe e2e"). After the single-infinite-thread redesign (**#13531** / PR #13644) removed chat-to-chat swipe from the overlay, #13826 deleted:
- the runner `run-conversation-swipe-e2e.mjs` + its `conversation-swipe-fixture`,
- the `test:conversation-swipe-e2e` package.json script,
- the `useConversationSwipeJank` hook **and its test** (`src/hooks/useConversationSwipeJank.test.ts`),
- the orphaned `conversation-swipe-jank` telemetry.

That PR **never updated this workflow**, leaving two dead references behind.

## What changed and why (remove-step, not restore-script)

The swipe *feature* is gone by design, and the PR that removed it explicitly **retargeted the perf gate onto the surviving overlay gestures** (thread-scroll + pull-to-maximize/restore). So the correct fix is to remove the obsolete step, not resurrect a deleted spec. Coverage is preserved elsewhere:
- **`test:chat-perf-gate` / `test:perf-gate-e2e`** now drive maximize/restore (the surviving high-cost gestures) — both still called by this workflow and present in package.json.
- **`conversation-nav.test.ts`** still fuzzes the most-recent-first interleaving invariants across new/select sequences (#10042) and passes 8/8.

Edits to `.github/workflows/chat-shell-gestures.yml`:
1. **Removed** the `Conversation-swipe interleaving e2e` step (the missing script — the actual CI failure).
2. **Dropped** the deleted `src/hooks/useConversationSwipeJank.test.ts` path from the `Conversation-nav unit + interleaving` step and corrected its comment. (Vitest silently ignored the missing path, matching only the existing file, so this was a dead reference but not itself failing.)
3. **Removed** the never-produced `output-conversation-swipe/` artifact-upload path (`if-no-files-found: warn`, so non-fatal, but dead).

## Verification

- Grepped every `test:*` script the workflow calls against `packages/ui/package.json` — **all 11 present** (`chat-sheet-e2e`, `chat-scroll-web-e2e`, `chat-scroll-axis-lock-e2e`, `chatux-gesture-e2e`, `home-screen-e2e`, `launcher-loop-e2e`, `bottombar-e2e`, `warmup-eviction-e2e`, `chat-ambient-e2e`, `chat-perf-gate`, `perf-gate-e2e`). No remaining dead script refs.
- Ran the surviving unit step exactly as CI does:
  ```
  bun run --cwd packages/ui test -- src/components/shell/conversation-nav.test.ts
  → Test Files 1 passed (1) · Tests 8 passed (8)
  ```
- YAML parses clean (`yaml.safe_load`).

## Sibling investigation — "UI Fixture E2E"

Investigated the reported UI Fixture E2E failure (`ui-fixture-e2e.yml`). The failing step was **Background view e2e** (`run-background-e2e.mjs`), failing on two GLSL-render assertions ("an unknown GLSL preset id is ignored", "first undo steps back to the previous GLSL config"). All 10 failures cluster in a single window on 2026-07-06 (17:20–20:15) during concurrent wallpaper/GLSL work; **every run since (30 consecutive on 2026-07-07) is green.** I ran `test:background-e2e` on current develop and it passes fully — including both previously-failing assertions. This is a headless-WebGL render-timing flake that has already self-resolved on develop, **not** a broken reference. No fix warranted; not chasing a flake.


---

## Evidence

CI/workflow change only (`.github/workflows/chat-shell-gestures.yml`): removes a step calling `test:conversation-swipe-e2e`, deleted in #13826. All 11 remaining `test:*` scripts confirmed present; `conversation-nav.test.ts` 8/8 pass; YAML clean.

<!-- evidence-row:before-screenshots -->
- **Before screenshots:** N/A - no rendered UI surface changed.
<!-- evidence-row:after-screenshots -->
- **After screenshots:** N/A - no rendered UI surface changed.
<!-- evidence-row:walkthrough-video -->
- **Walkthrough video:** N/A - no interactive/user-facing flow changed.
<!-- evidence-row:backend-logs -->
- **Backend logs:** N/A - no runtime/backend code changed; the affected behavior is a CI script's exit code, verified locally.
<!-- evidence-row:frontend-logs -->
- **Frontend console/network logs:** N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
- **Real-LLM trajectory:** N/A - no agent/action/prompt/model behavior changed.
<!-- evidence-row:domain-artifacts -->
- **Domain artifacts:** N/A - CI-only change; verification (unit tests / script exit codes) is described in the PR body above.
