### PR TITLE
fix(voice): VAD trailing-silence default 550 -> 650 per #15267 review

### DIFF
--- a/packages/ui/src/state/persistence-vad-auto-stop.test.ts
+++ b/packages/ui/src/state/persistence-vad-auto-stop.test.ts
@@ -48,12 +48,12 @@ describe("VAD auto-stop persistence", () => {
     });
   });
 
-  it("defaults to the snappier 550ms silence window (#voice-V6)", () => {
+  it("defaults to the snappier 650ms silence window (#voice-V6)", () => {
     // The tightened default flows through from DEFAULT_LOCAL_ASR_AUTO_STOP.
-    expect(loadVadAutoStop().silenceMs).toBe(550);
+    expect(loadVadAutoStop().silenceMs).toBe(650);
   });
 
-  it("lets a persisted user silenceMs override the 550ms default (#voice-V6)", () => {
+  it("lets a persisted user silenceMs override the 650ms default (#voice-V6)", () => {
     // A user who calibrated a longer window (e.g. slow speaker) keeps it — the
     // default drop must not clobber an explicit override.
     saveVadAutoStop({ silenceMs: 900, speechRmsThreshold: 0.003 });

--- a/packages/ui/src/voice/local-asr-capture.test.ts
+++ b/packages/ui/src/voice/local-asr-capture.test.ts
@@ -224,7 +224,7 @@ describe("decodeMonoPcm16Wav / isSilentWav (#voice-V5 silence guard)", () => {
 });
 
 describe("DEFAULT_LOCAL_ASR_AUTO_STOP silence window (#voice-V6)", () => {
-  it("defaults the trailing-silence window to the snappier 550ms", () => {
-    expect(DEFAULT_LOCAL_ASR_AUTO_STOP.silenceMs).toBe(550);
+  it("defaults the trailing-silence window to the snappier 650ms", () => {
+    expect(DEFAULT_LOCAL_ASR_AUTO_STOP.silenceMs).toBe(650);
   });
 });

--- a/packages/ui/src/voice/local-asr-capture.ts
+++ b/packages/ui/src/voice/local-asr-capture.ts
@@ -139,14 +139,14 @@ export const POST_TTS_ECHO_THRESHOLD_MULTIPLIER = 4;
 export const DEFAULT_LOCAL_ASR_AUTO_STOP: LocalAsrAutoStopConfig = {
   startGraceMs: 250,
   minSpeechMs: 180,
-  // Trailing-silence window that ends a hands-free turn (#voice-V6). Dropped
-  // 900 → 550 to shave ~350ms off every turn's speech-end → capture-stop leg
-  // (the single biggest tunable in the latency budget). The user override still
-  // wins: `loadVadAutoStop()` reads a persisted `silenceMs` first and only
-  // falls back to this default. NOTE: needs on-device false-cutoff verification
-  // — a too-tight window clips speakers who pause mid-sentence; if that regresses
-  // in the field, nudge back up (or expose a per-user calibration).
-  silenceMs: 550,
+  // Trailing-silence window that ends a hands-free turn (#voice-V6). 900 → 650:
+  // still shaves ~250ms off every turn's speech-end → capture-stop leg, but keeps
+  // headroom for natural inter-clause pauses (per review on #15267: 550 risks
+  // clipping slow/deliberate speakers, and mid-sentence pauses routinely exceed
+  // 550ms). The user override still wins: `loadVadAutoStop()` reads a persisted
+  // `silenceMs` first and only falls back to this default. On-device tuning can
+  // move this again once false-cutoff behavior is verified on the installed PWA.
+  silenceMs: 650,
   maxSpeechMs: 12_000,
   speechRmsThreshold: 0.003,
   speechPeakThreshold: 0.012,


### PR DESCRIPTION
Follow-up to #15267, addressing lalalune's review comment (landed 2 minutes after merge): https://github.com/elizaOS/eliza/pull/15267#issuecomment-4901641306

550ms trailing silence risks clipping speakers who pause mid-sentence (natural inter-clause pauses routinely exceed 550ms). Per the review recommendation: 650ms keeps ~250ms of the per-turn latency win vs the old 900ms while adding headroom for natural pauses.

- Default only: the persisted user override via `loadVadAutoStop()` still wins (verified by unchanged override tests)
- On-device false-cutoff verification still planned on the installed PWA; this can be tuned again with real data

### Tests
`local-asr-capture.test.ts` + `persistence-vad-auto-stop.test.ts` updated to pin 650 — 20/20 passing (vitest).

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] N/A - one-line default tuning, no visual change

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no visual change

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - constant change; behavior pinned by tests

<!-- evidence-row:backend-logs -->
- [ ] N/A - client-only

<!-- evidence-row:frontend-logs -->
- [ ] N/A - covered by vitest suites above

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/model behavior change

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - review comment on #15267 is the design source

-- [sol-orch]