### PR TITLE
fix: Cold self-review of the 13-plugin comment-cleanup diff found and

### DIFF
--- a/plugins/plugin-native-activity-tracker/src/index.test.ts
+++ b/plugins/plugin-native-activity-tracker/src/index.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for the `__internal` line-parsing and exit-description helpers —
+ * pure string/JSON logic, no Swift binary or child process spawned.
+ */
+
 import { describe, expect, it } from "vitest";
 
 import { __internal } from "./index";

--- a/plugins/plugin-native-activity-tracker/src/index.ts
+++ b/plugins/plugin-native-activity-tracker/src/index.ts
@@ -1,9 +1,11 @@
 /**
- * Native activity-tracker driver.
+ * TypeScript host for the native macOS activity-tracker library.
  *
- * Spawns the compiled macOS `activity-collector` helper and exposes a typed
- * event stream of window/app focus transitions. Non-Darwin platforms are
- * unsupported — callers must check {@link isSupportedPlatform} and degrade.
+ * Spawns the compiled Swift `activity-collector` binary, line-parses its
+ * newline-delimited stdout JSON protocol, and re-emits typed focus-transition
+ * and HID idle-sample events to the caller. A plain library export, not a
+ * registered elizaOS `Plugin` — Darwin-only; callers must check
+ * {@link isSupportedPlatform} before calling {@link startActivityCollector}.
  */
 
 import { spawn } from "node:child_process";
@@ -44,7 +46,7 @@ export interface ActivityCollectorOptions {
   onIdleSample?: (sample: ActivityCollectorIdleSample) => void;
   /** Called when the collector exits without a fatal failure. */
   onExit?: (exit: ActivityCollectorExit) => void;
-  /** Called once per fatal collector error (process exit with non-zero, failed spawn, parse failure >5). */
+  /** Called once per fatal collector error: spawn failure or an unclean process exit. */
   onFatal?: (reason: string) => void;
 }
 
@@ -220,7 +222,7 @@ export function startActivityCollector(
   };
 }
 
-// Exposed for tests.
+// Internal parsing helpers exposed only for unit tests; not part of the public API.
 export const __internal = {
   parseEventLine,
   parseCollectorLine,

--- a/plugins/plugin-native-agent/rollup.config.mjs
+++ b/plugins/plugin-native-agent/rollup.config.mjs
@@ -1,3 +1,9 @@
+/**
+ * Bundles the tsc output (`dist/esm/index.js`) into a browser IIFE
+ * (`dist/plugin.js`, global `capacitorAgent`) and a CJS build
+ * (`dist/plugin.cjs.js`) for the Capacitor plugin registry and `require()`
+ * consumers; `@capacitor/core` is left external for both targets.
+ */
 export default {
   input: "dist/esm/index.js",
   output: [

--- a/plugins/plugin-native-agent/src/definitions.ts
+++ b/plugins/plugin-native-agent/src/definitions.ts
@@ -1,14 +1,9 @@
 /**
- * @elizaos/capacitor-agent — Agent lifecycle management for Capacitor.
- *
- * Provides a cross-platform interface for starting, stopping, and
- * communicating with the embedded Eliza agent.
- *
- * - Electrobun desktop: RPC to the main-process AgentManager
- * - Android/Web: HTTP calls to the API server or bundled loopback agent
- * - iOS: HTTP for remote/cloud endpoints; local dev/sideload foreground
- *   requests bridge into the WebView ITTP kernel until the native route-kernel
- *   backend lands
+ * Shared TypeScript contract for the `Agent` Capacitor plugin, implemented
+ * identically by the web fallback (`web.ts`) and the native iOS/Android
+ * bridges. Defines the wire shape for lifecycle control (start/stop/status),
+ * chat, the path-only HTTP proxy (`request`), and the streaming variant that
+ * relays a response to the WebView incrementally via `agentStream*` events.
  */
 
 export interface AgentStatus {

--- a/plugins/plugin-native-agent/src/index.ts
+++ b/plugins/plugin-native-agent/src/index.ts
@@ -1,3 +1,8 @@
+/**
+ * TS host for the `Agent` Capacitor plugin: registers "Agent" with the
+ * Capacitor runtime and re-exports the shared type definitions consumed by
+ * both the web fallback and the native iOS/Android bridges.
+ */
 import { registerPlugin } from "@capacitor/core";
 import type { AgentPlugin } from "./definitions";
 

--- a/plugins/plugin-native-agent/src/web.test.ts
+++ b/plugins/plugin-native-agent/src/web.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for the `AgentWeb` HTTP fallback — `window` and `fetch` are
+ * fully stubbed; no real API server is involved.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { AgentWeb } from "./web";

--- a/plugins/plugin-native-agent/src/web.ts
+++ b/plugins/plugin-native-agent/src/web.ts
@@ -1,3 +1,8 @@
+/**
+ * Web/Electrobun bridge surface for the `Agent` Capacitor plugin: implements
+ * `AgentPlugin` over HTTP against the API server, used whenever no native
+ * iOS/Android implementation is registered (see `index.ts`).
+ */
 import { WebPlugin } from "@capacitor/core";
 import type {
   AgentPlugin,
@@ -227,7 +232,6 @@ export class AgentWeb extends WebPlugin implements AgentPlugin {
     return token ? { Authorization: `Bearer ${token}` } : {};
   }
 
-  /** True when we can reach the API via HTTP. */
   private canReachApi(): boolean {
     if (this.isLocalAgentIpcBase()) return false;
     if (readConfiguredApiBase()) return true;

--- a/plugins/plugin-native-appblocker/rollup.config.mjs
+++ b/plugins/plugin-native-appblocker/rollup.config.mjs
@@ -1,3 +1,8 @@
+/**
+ * Bundles the compiled `dist/esm/index.js` into an IIFE (`dist/plugin.js`,
+ * for CDN/`unpkg` consumers) and a CJS build (`dist/plugin.cjs.js`, for Node
+ * consumers); `@capacitor/core` stays external since host apps provide it.
+ */
 export default {
   input: "dist/esm/index.js",
   output: [

--- a/plugins/plugin-native-appblocker/src/backend.test.ts
+++ b/plugins/plugin-native-appblocker/src/backend.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Exercises `createNativeAppBlockerBackend`'s mapping logic against a
+ * hand-built fake `AppBlockerPlugin` — there is no real Capacitor bridge or
+ * device in this harness, only the adapter's own forwarding/shape-trimming.
+ */
 import { describe, expect, it, vi } from "vitest";
 
 import { createNativeAppBlockerBackend } from "./backend";

--- a/plugins/plugin-native-appblocker/src/definitions.ts
+++ b/plugins/plugin-native-appblocker/src/definitions.ts
@@ -1,3 +1,10 @@
+/**
+ * Shared TypeScript contract for the `ElizaAppBlocker` Capacitor plugin —
+ * the permission/status/result shapes and the `AppBlockerPlugin` method
+ * surface implemented by both `AppBlockerWeb` (web.ts) and the native
+ * Android/iOS bridges (`AppBlockerPlugin.kt` / `AppBlockerPlugin.swift`), and
+ * consumed by `backend.ts`'s adapter for `@elizaos/plugin-blocker`.
+ */
 export type AppBlockerPermissionStatus =
   | "granted"
   | "denied"

--- a/plugins/plugin-native-appblocker/src/index.ts
+++ b/plugins/plugin-native-appblocker/src/index.ts
@@ -1,3 +1,10 @@
+/**
+ * TS entry point for the `ElizaAppBlocker` Capacitor plugin: registers the
+ * bridge to the native Android/iOS app-blocking engines and lazily loads
+ * `AppBlockerWeb` when no native implementation is present. Re-exports the
+ * shared `AppBlockerPlugin` types and the `NativeAppBlockerBackend` adapter
+ * consumed by `@elizaos/plugin-blocker`.
+ */
 import { registerPlugin } from "@capacitor/core";
 
 import type { AppBlockerPlugin } from "./definitions";

--- a/plugins/plugin-native-appblocker/src/web.test.ts
+++ b/plugins/plugin-native-appblocker/src/web.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Exercises `AppBlockerWeb` directly (no mocked bridge) — its not-applicable
+ * responses and `blockApps` input validation are plain fallback logic with
+ * no native dependency to stub.
+ */
 import { describe, expect, it } from "vitest";
 
 import { AppBlockerWeb } from "./web";

--- a/plugins/plugin-native-appblocker/src/web.ts
+++ b/plugins/plugin-native-appblocker/src/web.ts
@@ -1,3 +1,12 @@
+/**
+ * Web fallback for the `ElizaAppBlocker` Capacitor plugin, loaded when the app
+ * runs outside a native Android/iOS shell where Family Controls / Usage
+ * Access are unavailable. Every method returns an explicit
+ * not-applicable/unavailable result rather than throwing, so a
+ * Capacitor-based Eliza agent app can call `AppBlocker` uniformly across
+ * platforms; input validation still runs here so malformed `blockApps`
+ * options are caught the same way on web as on the native bridges.
+ */
 import { WebPlugin } from "@capacitor/core";
 import type {
   AppBlockerPermissionResult,

--- a/plugins/plugin-native-bun-runtime/rollup.config.mjs
+++ b/plugins/plugin-native-bun-runtime/rollup.config.mjs
@@ -1,3 +1,9 @@
+/**
+ * Bundles the compiled `dist/esm/index.js` into the two artifacts Capacitor
+ * consumers load directly: an IIFE (`dist/plugin.js`, global
+ * `capacitorBunRuntime`) for script-tag/webview use and a CJS build
+ * (`dist/plugin.cjs.js`); `@capacitor/core` stays external in both.
+ */
 export default {
   input: "dist/esm/index.js",
   output: [

--- a/plugins/plugin-native-bun-runtime/src/definitions.ts
+++ b/plugins/plugin-native-bun-runtime/src/definitions.ts
@@ -1,14 +1,11 @@
 /**
- * @elizaos/capacitor-bun-runtime — iOS embedded Bun-shape JS runtime.
- *
- * Hosts a JavaScriptCore JSContext on a dedicated worker thread. The native
- * plugin either starts a bundled full Bun engine framework or installs the
- * `__ELIZA_BRIDGE__` host functions for the compatibility JSContext path.
- * The full-engine ABI lives in packages/native/bun-runtime/BRIDGE_CONTRACT.md.
- *
- * The plugin exposes a tiny surface to the React UI: start the runtime,
- * send messages, check status, and stop it. Everything else flows over the
- * `ui_post_message` / `ui_register_handler` channel inside the native side.
+ * Shared TypeScript contract for the ElizaBunRuntime Capacitor plugin — the
+ * interfaces that `web.ts`, the iOS Swift plugin, and the Android Kotlin
+ * plugin must all satisfy so the React UI can start/message/stop the
+ * on-device agent runtime the same way regardless of platform. This is the
+ * TS mirror of the native bridge ABI documented in
+ * packages/native/bun-runtime/BRIDGE_CONTRACT.md; breaking changes here
+ * should bump `__ELIZA_BRIDGE_VERSION__` on the native side too.
  */
 
 export interface StartOptions {

--- a/plugins/plugin-native-bun-runtime/src/index.ts
+++ b/plugins/plugin-native-bun-runtime/src/index.ts
@@ -1,3 +1,11 @@
+/**
+ * TS host for the ElizaBunRuntime Capacitor plugin: re-exports the shared
+ * type contract from `definitions.ts` and registers the plugin under the JS
+ * name `ElizaBunRuntime`, wiring in the web fallback (`web.ts`) for browser
+ * builds. Native builds resolve to the iOS/Android implementations through
+ * Capacitor's own plugin registry rather than the `web` factory below.
+ */
+
 import { registerPlugin } from "@capacitor/core";
 import type { ElizaBunRuntimePlugin } from "./definitions.js";
 

--- a/plugins/plugin-native-bun-runtime/src/web.ts
+++ b/plugins/plugin-native-bun-runtime/src/web.ts
@@ -1,3 +1,9 @@
+/**
+ * Web/Electrobun bridge surface for the ElizaBunRuntime Capacitor plugin:
+ * every method reports the runtime as unavailable rather than throwing, since
+ * no browser host can run the on-device Bun-shape JSContext runtime this
+ * plugin bridges to on iOS/Android.
+ */
 import { WebPlugin } from "@capacitor/core";
 import type {
   CallOptions,

--- a/plugins/plugin-native-bun-runtime/vitest.config.ts
+++ b/plugins/plugin-native-bun-runtime/vitest.config.ts
@@ -1,3 +1,8 @@
+/**
+ * Vitest config for this plugin's JS-side unit tests: runs every `.test.ts`
+ * file under `src/` in a Node environment, excluding compiled `dist/` output.
+ */
+
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";

--- a/plugins/plugin-native-calendar/rollup.config.mjs
+++ b/plugins/plugin-native-calendar/rollup.config.mjs
@@ -1,3 +1,8 @@
+/**
+ * Bundles the tsc-emitted `dist/esm/index.js` into the CJS
+ * (`dist/plugin.cjs.js`) and IIFE (`dist/plugin.js`, for unpkg) artifacts
+ * consumers outside the ESM/bun export condition load.
+ */
 export default {
   input: "dist/esm/index.js",
   output: [

--- a/plugins/plugin-native-calendar/src/definitions.ts
+++ b/plugins/plugin-native-calendar/src/definitions.ts
@@ -1,3 +1,9 @@
+/**
+ * Shared TypeScript contract for the AppleCalendar bridge — permission,
+ * calendar, event, and result shapes plus the `AppleCalendarPlugin`
+ * interface — implemented identically by the native Swift bridge
+ * (`ios/Sources/CalendarPlugin`) and the web fallback in `web.ts`.
+ */
 export type AppleCalendarPermissionState =
   | "granted"
   | "denied"

--- a/plugins/plugin-native-calendar/src/index.ts
+++ b/plugins/plugin-native-calendar/src/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Capacitor entry point for the AppleCalendar bridge: registers the plugin
+ * object whose native implementation is the Swift EventKit bridge under
+ * `ios/`, lazy-loading the web fallback only when no native implementation
+ * is registered so browser bundles avoid pulling in native-only code.
+ */
 import { registerPlugin } from "@capacitor/core";
 import type { AppleCalendarPlugin } from "./definitions";
 

--- a/plugins/plugin-native-calendar/src/macos-bridge-policy.test.ts
+++ b/plugins/plugin-native-calendar/src/macos-bridge-policy.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Unit tests for `appleCalendarMacosBridgeCandidates`: candidate ordering
+ * (env override, packaged, local) and omission of the env candidate when
+ * unset.
+ */
 import { describe, expect, it } from "vitest";
 import {
   APPLE_CALENDAR_MACOS_BRIDGE_DYLIB_BASENAME,

--- a/plugins/plugin-native-calendar/src/macos-bridge-policy.ts
+++ b/plugins/plugin-native-calendar/src/macos-bridge-policy.ts
@@ -1,3 +1,11 @@
+/**
+ * Candidate-path policy for locating the Electrobun EventKit dylib that
+ * macOS desktop hosts — not this Capacitor plugin — load to reach Apple
+ * Calendar. Host plugins try candidates in order (env override, packaged,
+ * local dev build) and use the first path that exists; the candidate list
+ * and expected dylib basename are owned here so host code and packaging
+ * stay in sync.
+ */
 export interface AppleCalendarMacosBridgeCandidate {
   label: string;
   path: string;

--- a/plugins/plugin-native-calendar/src/swift-bridge-contract.test.ts
+++ b/plugins/plugin-native-calendar/src/swift-bridge-contract.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Static contract test that greps `CalendarPlugin.swift` source text for the
+ * guard clauses TS callers depend on — event-window/timezone validation,
+ * blocked recurrence/attendee edits, string-length bounds — since this suite
+ * cannot execute Swift/EventKit directly.
+ */
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 

--- a/plugins/plugin-native-calendar/src/web.test.ts
+++ b/plugins/plugin-native-calendar/src/web.test.ts
@@ -1,3 +1,8 @@
+/**
+ * Exercises the real `AppleCalendarWeb` fallback class directly (no mocks):
+ * every method must degrade to a stable `not_supported` result and never
+ * reflect hostile or fuzzed input back to the caller.
+ */
 import { describe, expect, it } from "vitest";
 
 import { AppleCalendarWeb } from "./web";

--- a/plugins/plugin-native-calendar/src/web.ts
+++ b/plugins/plugin-native-calendar/src/web.ts
@@ -1,3 +1,9 @@
+/**
+ * Browser/web implementation of `AppleCalendarPlugin`, loaded by the
+ * Capacitor web fallback when no native bridge is registered. EventKit is
+ * unavailable outside iOS/macOS, so every method returns a fixed
+ * `not_supported` result rather than fabricating calendar data.
+ */
 import { WebPlugin } from "@capacitor/core";
 import type {
   AppleCalendarBaseResult,

--- a/plugins/plugin-native-camera/rollup.config.mjs
+++ b/plugins/plugin-native-camera/rollup.config.mjs
@@ -1,3 +1,8 @@
+/**
+ * Rollup config bundling the compiled `dist/esm/index.js` into the browser
+ * IIFE (`dist/plugin.js`) and CommonJS (`dist/plugin.cjs.js`) distributables;
+ * `@capacitor/core` is left external for the host app to resolve.
+ */
 import nodeResolve from "@rollup/plugin-node-resolve";
 
 const external = ["@capacitor/core"];

--- a/plugins/plugin-native-camera/src/definitions.ts
+++ b/plugins/plugin-native-camera/src/definitions.ts
@@ -1,3 +1,9 @@
+/**
+ * Shared TypeScript contract for the camera plugin: the `CameraPlugin`
+ * interface plus every options/result/event type it uses. Implemented by
+ * `CameraWeb` (web.ts) and the native Swift/Kotlin bridges; kept
+ * dependency-free so it can be imported from either side.
+ */
 import type { PluginListenerHandle } from "@capacitor/core";
 
 export type CameraDirection = "front" | "back" | "external";

--- a/plugins/plugin-native-camera/src/index.ts
+++ b/plugins/plugin-native-camera/src/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Capacitor entry point: registers the native camera bridge as `"ElizaCamera"`,
+ * falling back to `CameraWeb` (lazy-loaded to keep browser bundles free of the
+ * native binding stubs) when no native implementation is present. Re-exports
+ * every type in `./definitions` as the plugin's public API surface.
+ */
 import { registerPlugin } from "@capacitor/core";
 
 import type { CameraPlugin } from "./definitions";

--- a/plugins/plugin-native-camera/src/web.test.ts
+++ b/plugins/plugin-native-camera/src/web.test.ts
@@ -1,4 +1,10 @@
 // @vitest-environment jsdom
+
+/**
+ * Unit tests for `CameraWeb`, the browser fallback implementation of the
+ * camera plugin API, against a jsdom DOM with `navigator.mediaDevices` and
+ * `MediaRecorder` mocked — no real camera/microphone hardware involved.
+ */
 import fc from "fast-check";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/plugins/plugin-native-camera/src/web.ts
+++ b/plugins/plugin-native-camera/src/web.ts
@@ -1,3 +1,12 @@
+/**
+ * Browser fallback implementation of the camera plugin, backed by the
+ * `MediaDevices`/`MediaRecorder` Web APIs instead of native camera hardware.
+ * Loaded lazily by `index.ts` when Capacitor has no native binding (e.g. in a
+ * desktop browser or Electron shell). Several capabilities the native
+ * implementations expose — torch/flash control, precise device-capability
+ * probing — have no Web API equivalent and are approximated or reported
+ * unsupported here; see the plugin's CLAUDE.md for the specific gaps.
+ */
 import { WebPlugin } from "@capacitor/core";
 
 import type {
@@ -554,7 +563,6 @@ export class CameraWeb extends WebPlugin {
     const track = this.mediaStream.getVideoTracks()[0];
     if (!track) throw new Error("No video track available");
 
-    // Check if focus control is supported
     const caps = track.getCapabilities ? track.getCapabilities() : {};
     type ExtendedCaps = MediaTrackCapabilities & { focusMode?: string[] };
     if (!(caps as ExtendedCaps).focusMode?.includes("manual")) {
@@ -585,7 +593,6 @@ export class CameraWeb extends WebPlugin {
     const track = this.mediaStream.getVideoTracks()[0];
     if (!track) throw new Error("No video track available");
 
-    // Check if exposure control is supported
     const caps = track.getCapabilities ? track.getCapabilities() : {};
     type ExtendedCaps = MediaTrackCapabilities & { exposureMode?: string[] };
     if (!(caps as ExtendedCaps).exposureMode?.includes("manual")) {

--- a/plugins/plugin-native-camera/vitest.config.ts
+++ b/plugins/plugin-native-camera/vitest.config.ts
@@ -1,3 +1,8 @@
+/**
+ * Vitest config for this plugin's unit tests: targets `src` test files under
+ * the Node environment; individual files opt into a jsdom environment via a
+ * `@vitest-environment` directive when they exercise DOM/MediaDevices APIs.
+ */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-native-canvas/rollup.config.mjs
+++ b/plugins/plugin-native-canvas/rollup.config.mjs
@@ -1,3 +1,10 @@
+/**
+ * Bundles the compiled `dist/esm/index.js` output of the `ElizaCanvas`
+ * Capacitor plugin into `dist/plugin.js` (IIFE, for `<script>`/unpkg
+ * consumption) and `dist/plugin.cjs.js` (CommonJS); the ESM build comes
+ * straight from `tsc` and isn't rolled up here.
+ */
+
 import nodeResolve from "@rollup/plugin-node-resolve";
 
 const external = ["@capacitor/core"];

--- a/plugins/plugin-native-canvas/src/definitions.ts
+++ b/plugins/plugin-native-canvas/src/definitions.ts
@@ -1,3 +1,11 @@
+/**
+ * Shared type contract for the `ElizaCanvas` Capacitor plugin: the
+ * `CanvasPlugin` interface plus every argument/result/event shape it uses.
+ * Both the web bridge (`web.ts`) and the native iOS/Android implementations
+ * must satisfy this surface, so a new method or event is added here first
+ * and then implemented on each side.
+ */
+
 import type { PluginListenerHandle } from "@capacitor/core";
 
 export interface CanvasSize {

--- a/plugins/plugin-native-canvas/src/index.ts
+++ b/plugins/plugin-native-canvas/src/index.ts
@@ -1,3 +1,11 @@
+/**
+ * Registration entry point for the `ElizaCanvas` Capacitor plugin: the
+ * multi-layer 2D canvas, drawing-primitive, and A2UI web-view bridge that
+ * elizaOS UI surfaces import as `Canvas`. The web implementation
+ * (`CanvasWeb`) is loaded lazily so non-web platforms fall through to their
+ * native iOS/Android bridges instead of pulling in DOM-dependent code.
+ */
+
 import { registerPlugin } from "@capacitor/core";
 
 import type { CanvasPlugin } from "./definitions";

--- a/plugins/plugin-native-canvas/src/web.test.ts
+++ b/plugins/plugin-native-canvas/src/web.test.ts
@@ -1,5 +1,13 @@
 // @vitest-environment jsdom
 
+/**
+ * Input-validation tests for `CanvasWeb` — malformed size/layer/quality
+ * arguments must reject before mutating canvas state or the DOM. Runs
+ * against a real `CanvasWeb` instance in jsdom with only the 2D rendering
+ * context (`getContext`/`toDataURL`) stubbed, since jsdom has no canvas
+ * renderer.
+ */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CanvasWeb } from "./web";

--- a/plugins/plugin-native-canvas/src/web.ts
+++ b/plugins/plugin-native-canvas/src/web.ts
@@ -1,3 +1,13 @@
+/**
+ * Web/Electrobun bridge for the `ElizaCanvas` Capacitor plugin — the reference
+ * implementation the iOS (Swift) and Android (Kotlin) native bridges must
+ * match behaviourally. Backs multi-layer 2D drawing with per-layer
+ * `<canvas>` elements (composited as absolute-positioned DOM siblings so
+ * z-ordering follows CSS `z-index`) and backs the embedded web view with an
+ * iframe (inline/fullscreen) or a `window.open` popup, including the
+ * `eliza://` deep-link intercept and the A2UI postMessage bridge.
+ */
+
 import { WebPlugin } from "@capacitor/core";
 
 import type {
@@ -836,7 +846,6 @@ export class CanvasWeb extends WebPlugin {
   async navigate(options: NavigateOptions): Promise<void> {
     const placement = options.placement || "inline";
 
-    // Clean up any existing web view
     this.destroyWebView();
 
     // Intercept eliza:// deep links immediately

--- a/plugins/plugin-native-contacts/rollup.config.mjs
+++ b/plugins/plugin-native-contacts/rollup.config.mjs
@@ -1,3 +1,9 @@
+/**
+ * Rollup config bundling the tsc output (`dist/esm/index.js`) into the
+ * IIFE (`dist/plugin.js`, global `capacitorContacts`) and CJS
+ * (`dist/plugin.cjs.js`) artifacts Capacitor hosts load; `@capacitor/core`
+ * is left external since the host app supplies it.
+ */
 export default {
   input: "dist/esm/index.js",
   output: [

--- a/plugins/plugin-native-contacts/src/definitions.ts
+++ b/plugins/plugin-native-contacts/src/definitions.ts
@@ -1,3 +1,8 @@
+/**
+ * Shared TypeScript contract for the contacts bridge (`ContactsPlugin`) and
+ * its record/option/result shapes, implemented identically by the Android
+ * native side and the `ContactsWeb` fallback.
+ */
 import type { PermissionState } from "@capacitor/core";
 
 export interface ContactSummary {

--- a/plugins/plugin-native-contacts/src/index.ts
+++ b/plugins/plugin-native-contacts/src/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Entry point registering the `ElizaContacts` Capacitor plugin — the JS
+ * bridge to Android's `ContactsContract` (list/create/import contacts) —
+ * with `ContactsWeb` lazily loaded as the web fallback; re-exports the
+ * shared types from `./definitions`.
+ */
 import { registerPlugin } from "@capacitor/core";
 
 import type { ContactsPlugin } from "./definitions";

--- a/plugins/plugin-native-contacts/src/web.test.ts
+++ b/plugins/plugin-native-contacts/src/web.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Tests for `ContactsWeb`, the web/node fallback used when no Android
+ * bridge is present — pure in-process assertions, no device or mock bridge.
+ */
 import { describe, expect, it } from "vitest";
 
 import { ContactsWeb } from "./web";

--- a/plugins/plugin-native-contacts/src/web.ts
+++ b/plugins/plugin-native-contacts/src/web.ts
@@ -1,3 +1,8 @@
+/**
+ * Web/node fallback bridge (`ContactsWeb`) for the Android-only contacts
+ * plugin: `listContacts` returns an empty list, `createContact` and
+ * `importVCard` reject, since no contacts store exists off Android.
+ */
 import { WebPlugin } from "@capacitor/core";
 
 import type {

--- a/plugins/plugin-native-desktop/rollup.config.mjs
+++ b/plugins/plugin-native-desktop/rollup.config.mjs
@@ -1,3 +1,10 @@
+/**
+ * Bundles the tsc-compiled Desktop Capacitor plugin (`dist/esm/index.js`) into
+ * the two artifact formats Capacitor consumers load: an IIFE for direct
+ * `<script>` inclusion (`dist/plugin.js`) and CJS for bundler/Node consumption
+ * (`dist/plugin.cjs.js`). `@capacitor/core` stays external so host apps supply
+ * their own copy rather than bundling a second one.
+ */
 import nodeResolve from "@rollup/plugin-node-resolve";
 
 const external = ["@capacitor/core"];

--- a/plugins/plugin-native-desktop/src/definitions.ts
+++ b/plugins/plugin-native-desktop/src/definitions.ts
@@ -1,3 +1,10 @@
+/**
+ * Shared type contract for the Desktop Capacitor plugin: the `DesktopPlugin`
+ * interface both the Electrobun native host and the `DesktopWeb` browser
+ * fallback (`./web.ts`) implement, plus the option/result/event shapes each
+ * method uses. `index.ts` re-exports this module so renderer code importing
+ * `Desktop` gets these types without a separate import path.
+ */
 import type { PluginListenerHandle } from "@capacitor/core";
 
 export interface TrayMenuItemBase {

--- a/plugins/plugin-native-desktop/src/index.ts
+++ b/plugins/plugin-native-desktop/src/index.ts
@@ -1,3 +1,11 @@
+/**
+ * Registers the `Desktop` Capacitor plugin exposing system tray, global
+ * shortcuts, window management, notifications, clipboard, power monitor, and
+ * OS permission probing to the Eliza agent desktop UI. Capacitor resolves the
+ * native side from the host app's Electrobun plugin registration; `loadWeb`
+ * supplies the browser fallback (`DesktopWeb` in `./web`) whenever that
+ * native bridge isn't present, e.g. running in a plain browser tab.
+ */
 import { registerPlugin } from "@capacitor/core";
 
 import type { DesktopPlugin } from "./definitions";

--- a/plugins/plugin-native-desktop/src/web.test.ts
+++ b/plugins/plugin-native-desktop/src/web.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Tests `DesktopWeb`'s browser-fallback contracts — permission bridging,
+ * notifications, window focus/blur listeners, external URL safety, and
+ * battery state — against a stubbed `window`/`navigator` and mocked
+ * Electrobun RPC, not a real browser or native host.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { DesktopWeb } from "./web";

--- a/plugins/plugin-native-desktop/src/web.ts
+++ b/plugins/plugin-native-desktop/src/web.ts
@@ -1,3 +1,12 @@
+/**
+ * Browser fallback for the Desktop Capacitor plugin — implements every
+ * `DesktopPlugin` method with Web APIs (Notifications, Clipboard, Fullscreen,
+ * Battery, `navigator.permissions`) or an explicit unavailable/no-op result
+ * where no browser equivalent exists. Loaded via `registerPlugin`'s `web`
+ * handler in `index.ts` whenever the Electrobun native bridge
+ * (`__ELIZA_ELECTROBUN_RPC__`) is absent, so every device capability this
+ * plugin exposes must degrade gracefully here rather than throw.
+ */
 import { WebPlugin } from "@capacitor/core";
 
 import type {
@@ -388,8 +397,6 @@ export class DesktopWeb extends WebPlugin {
     chrome: string;
     node: string;
   }> {
-    // On web platform, version info is limited. Return actual browser info where available.
-    // Note: "version" and "name" would need to come from app config - returning "unknown" to indicate unavailability
     return {
       version: "unknown", // App version not available on web - would need to be injected at build time
       name: "unknown", // App name not available on web - would need to be injected at build time
@@ -481,7 +488,6 @@ export class DesktopWeb extends WebPlugin {
       remove: async () => {
         const i = this.pluginListeners.indexOf(entry);
         if (i >= 0) {
-          // Remove window event listener if it exists
           if (entry.windowListener) {
             if (entry.eventName === "windowFocus")
               window.removeEventListener("focus", entry.windowListener);

--- a/plugins/plugin-native-eliza-tasks/rollup.config.mjs
+++ b/plugins/plugin-native-eliza-tasks/rollup.config.mjs
@@ -1,3 +1,9 @@
+/**
+ * Bundles the compiled `dist/esm/index.js` into an IIFE (`dist/plugin.js`,
+ * global `capacitorElizaTasks`) and a CJS build (`dist/plugin.cjs.js`) —
+ * the two formats Capacitor's web/Electron targets load. `@capacitor/core`
+ * stays external; the host app provides it at runtime.
+ */
 import nodeResolve from "@rollup/plugin-node-resolve";
 
 const external = ["@capacitor/core"];

--- a/plugins/plugin-native-eliza-tasks/src/definitions.ts
+++ b/plugins/plugin-native-eliza-tasks/src/definitions.ts
@@ -1,3 +1,11 @@
+/**
+ * Shared TypeScript contract for the ElizaTasks Capacitor plugin — the
+ * interface that both `web.ts` (browser fallback) and the native Swift
+ * implementation (`ios/Sources/ElizaTasksPlugin/ElizaTasksPlugin.swift`)
+ * must satisfy. Adding a JS-callable method or wake-event kind starts here;
+ * see this package's CLAUDE.md "How to extend" section for the full
+ * checklist across both sides of the bridge.
+ */
 import type { PluginListenerHandle } from "@capacitor/core";
 
 /**

--- a/plugins/plugin-native-eliza-tasks/src/index.ts
+++ b/plugins/plugin-native-eliza-tasks/src/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Capacitor entry point for the ElizaTasks native bridge — registers the
+ * plugin and re-exports its type surface (`./definitions`) for consumers.
+ * The web implementation is loaded lazily via `loadWeb` since Capacitor
+ * only invokes it on platforms lacking the native (iOS) implementation.
+ */
 import { registerPlugin } from "@capacitor/core";
 import type { ElizaTasksPlugin } from "./definitions";
 

--- a/plugins/plugin-native-eliza-tasks/src/web.test.ts
+++ b/plugins/plugin-native-eliza-tasks/src/web.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for the web fallback (`ElizaTasksWeb`) — exercises the real
+ * class directly, asserting every method resolves an explicit
+ * `supported: false` result instead of throwing or masking the unsupported
+ * platform as success.
+ */
 import { describe, expect, it } from "vitest";
 
 import { ElizaTasksWeb } from "./web";

--- a/plugins/plugin-native-eliza-tasks/src/web.ts
+++ b/plugins/plugin-native-eliza-tasks/src/web.ts
@@ -1,3 +1,8 @@
+/**
+ * Web bridge surface for the ElizaTasks Capacitor plugin — browsers have no
+ * `BGTaskScheduler` equivalent, so this fallback reports the capability as
+ * unsupported rather than scheduling anything.
+ */
 import { WebPlugin } from "@capacitor/core";
 import type {
   ElizaTasksPlugin,

--- a/plugins/plugin-native-filesystem/src/__tests__/path-validation.test.ts
+++ b/plugins/plugin-native-filesystem/src/__tests__/path-validation.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for `normalizeDevicePath`, plus integration tests exercising the Node
+ * backend's traversal/symlink-escape guards against a real temp directory on disk (no mocks).
+ */
 import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
 import { readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";

--- a/plugins/plugin-native-filesystem/src/__tests__/plugin-registration.test.ts
+++ b/plugins/plugin-native-filesystem/src/__tests__/plugin-registration.test.ts
@@ -1,3 +1,4 @@
+/** Smoke test: the plugin wires the DeviceFilesystemBridge service and exposes no actions. */
 import { describe, expect, it } from "vitest";
 
 import { deviceFilesystemPlugin } from "../index.js";

--- a/plugins/plugin-native-filesystem/src/__tests__/round-trip.test.ts
+++ b/plugins/plugin-native-filesystem/src/__tests__/round-trip.test.ts
@@ -1,3 +1,4 @@
+/** DeviceFilesystemBridge read/write/list round-trip against a real temp directory on disk. */
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";

--- a/plugins/plugin-native-filesystem/src/index.ts
+++ b/plugins/plugin-native-filesystem/src/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Plugin entry point: registers the `DeviceFilesystemBridge` service under the
+ * `device_filesystem` service type so other plugins (e.g. `@elizaos/plugin-coding-tools`)
+ * can resolve mobile-safe file read/write/list operations. Registers no actions of its own.
+ */
 import type { Plugin } from "@elizaos/core";
 
 import { DeviceFilesystemBridge } from "./services/device-filesystem-bridge.js";

--- a/plugins/plugin-native-filesystem/src/path.ts
+++ b/plugins/plugin-native-filesystem/src/path.ts
@@ -1,3 +1,9 @@
+/**
+ * Path sanitisation for the device filesystem bridge (`services/device-filesystem-bridge.ts`).
+ * Every relative path from a caller passes through `normalizeDevicePath()` before either
+ * backend touches it; rejecting absolute paths, `..` segments, and NUL bytes here closes off
+ * traversal outside the backend root ahead of the Node backend's separate real-path check.
+ */
 import * as posix from "node:path/posix";
 
 export interface NormalizedPath {

--- a/plugins/plugin-native-filesystem/src/services/device-filesystem-bridge.ts
+++ b/plugins/plugin-native-filesystem/src/services/device-filesystem-bridge.ts
@@ -1,3 +1,13 @@
+/**
+ * Device filesystem bridge service: the platform-dispatching implementation behind
+ * the `device_filesystem` service type. Routes read/write/list calls to
+ * `@capacitor/filesystem` (Directory.Documents) when running as a native iOS/Android
+ * app, or to a `node:fs/promises`-backed workspace under `resolveStateDir()` otherwise.
+ * Every relative path is sanitised by `normalizeDevicePath()` first; the Node backend
+ * additionally resolves symlinks and verifies the real path stays under the workspace
+ * root, since a string-prefix check on the unresolved path alone cannot catch a symlink
+ * that escapes after normalization.
+ */
 import {
 	mkdir,
 	readdir,

--- a/plugins/plugin-native-filesystem/src/types.ts
+++ b/plugins/plugin-native-filesystem/src/types.ts
@@ -1,3 +1,9 @@
+/**
+ * Shared constants and wire types for the device filesystem bridge: the service-type
+ * identifier plugins resolve against (`getDeviceFilesystemBridge`), the shared log
+ * prefix, and the read/write/list types common to both the Capacitor and Node backends
+ * in `services/device-filesystem-bridge.ts`.
+ */
 export const DEVICE_FILESYSTEM_SERVICE_TYPE = "device_filesystem" as const;
 export const DEVICE_FILESYSTEM_LOG_PREFIX = "[device-filesystem]" as const;
 

--- a/plugins/plugin-native-filesystem/vitest.config.ts
+++ b/plugins/plugin-native-filesystem/vitest.config.ts
@@ -1,3 +1,8 @@
+/**
+ * Vitest config for this plugin's Node-only test suite: forces `node` resolution
+ * conditions (for `@elizaos/core`'s dual ESM/CJS entry points) and inlines it into
+ * the SSR module graph so the forked-pool transform can process the workspace package.
+ */
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/plugins/plugin-native-gateway/rollup.config.mjs
+++ b/plugins/plugin-native-gateway/rollup.config.mjs
@@ -1,3 +1,9 @@
+/**
+ * Bundles the compiled ESM output into the IIFE and CJS artifacts Capacitor
+ * plugin consumers expect (`dist/plugin.js` for unpkg, `dist/plugin.cjs.js`
+ * for CommonJS); `@capacitor/core` stays external and is resolved by the host
+ * app at runtime.
+ */
 export default {
   input: "dist/esm/index.js",
   output: [

--- a/plugins/plugin-native-gateway/src/definitions.ts
+++ b/plugins/plugin-native-gateway/src/definitions.ts
@@ -1,3 +1,11 @@
+/**
+ * Shared type contract for the `Gateway` Capacitor plugin: the `GatewayPlugin`
+ * interface implemented identically by the web, iOS, and Android bridges, plus
+ * the DTOs (endpoints, connect options/results, RPC send, and event payloads)
+ * that cross the JS-to-native boundary. `docgen` regenerates README.md from
+ * the JSDoc here, so keep it accurate for the consuming app, not just the
+ * plugin implementations.
+ */
 import type { PluginListenerHandle } from "@capacitor/core";
 
 export type JsonPrimitive = string | number | boolean | null;

--- a/plugins/plugin-native-gateway/src/index.ts
+++ b/plugins/plugin-native-gateway/src/index.ts
@@ -1,3 +1,9 @@
+/**
+ * Capacitor registration entry point for the `Gateway` plugin, exposing a
+ * single cross-platform `Gateway` object backed by web (`web.ts`), iOS
+ * (Swift), and Android (Kotlin) implementations. The web implementation is
+ * dynamically imported so native builds don't pull in browser WebSocket code.
+ */
 import { registerPlugin } from "@capacitor/core";
 import type { GatewayPlugin } from "./definitions";
 

--- a/plugins/plugin-native-gateway/src/web.test.ts
+++ b/plugins/plugin-native-gateway/src/web.test.ts
@@ -1,3 +1,9 @@
+/**
+ * Unit tests for the browser `GatewayWeb` bridge implementation, covering
+ * connect/hello handshake, RPC send, and malformed/dropped inbound frames.
+ * The harness stubs `WebSocket` with an in-process `FakeWebSocket` — no real
+ * socket or gateway server is involved.
+ */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { GatewayWeb } from "./web";

--- a/plugins/plugin-native-gateway/src/web.ts
+++ b/plugins/plugin-native-gateway/src/web.ts
@@ -1,3 +1,11 @@
+/**
+ * Browser implementation of the `Gateway` plugin: a hand-rolled WebSocket
+ * client speaking the gateway's `req`/`res`/`event` JSON protocol (connect
+ * handshake, RPC send with per-request timeout, reconnect with exponential
+ * backoff). Bonjour/mDNS discovery has no browser API, so discovery methods
+ * here are stubs that always report an empty result — only the iOS and
+ * Android implementations perform real LAN discovery.
+ */
 import { WebPlugin } from "@capacitor/core";
 
 import type {
@@ -13,18 +21,12 @@ import type {
   JsonValue,
 } from "./definitions";
 
-/**
- * Pending request waiting for a response
- */
 interface PendingRequest {
   resolve: (value: GatewaySendResult) => void;
   reject: (error: Error) => void;
   timeout: ReturnType<typeof setTimeout>;
 }
 
-/**
- * Generate a UUID v4
- */
 function generateUUID(): string {
   if (typeof crypto !== "undefined" && crypto.randomUUID) {
     return crypto.randomUUID();
@@ -107,12 +109,6 @@ function assertRpcMethod(method: unknown): string {
   return normalized;
 }
 
-/**
- * Web implementation of the Gateway Plugin
- *
- * Uses browser WebSocket API for connectivity.
- * Note: Web platform cannot perform Bonjour/mDNS discovery.
- */
 export class GatewayWeb extends WebPlugin {
   private ws: WebSocket | null = null;
   private pending = new Map<string, PendingRequest>();
@@ -162,12 +158,8 @@ export class GatewayWeb extends WebPlugin {
     };
   }
 
-  /**
-   * Connect to a Gateway server
-   */
   async connect(options: GatewayConnectOptions): Promise<GatewayConnectResult> {
     const url = assertGatewayUrl(options.url);
-    // Close existing connection if any
     if (this.ws) {
       this.closed = true;
       this.ws.close();
@@ -185,9 +177,6 @@ export class GatewayWeb extends WebPlugin {
     });
   }
 
-  /**
-   * Establish WebSocket connection
-   */
   private establishConnection(): void {
     if (this.closed || !this.options) {
       return;
@@ -215,9 +204,6 @@ export class GatewayWeb extends WebPlugin {
     });
   }
 
-  /**
-   * Send the connect frame to authenticate
-   */
   private sendConnectFrame(): void {
     if (!this.ws || !this.options || this.ws.readyState !== WebSocket.OPEN) {
       return;
@@ -255,7 +241,6 @@ export class GatewayWeb extends WebPlugin {
 
     this.ws.send(JSON.stringify(frame));
 
-    // Set up timeout for connect response
     const timeout = setTimeout(() => {
       if (this.connectReject) {
         this.connectReject(new Error("Connection timeout"));
@@ -291,9 +276,6 @@ export class GatewayWeb extends WebPlugin {
     });
   }
 
-  /**
-   * Handle successful hello response
-   */
   private handleHelloOk(hello: JsonObject): void {
     const protocol = getNumber(hello.protocol);
     const auth = isJsonObject(hello.auth) ? hello.auth : null;
@@ -322,9 +304,6 @@ export class GatewayWeb extends WebPlugin {
     }
   }
 
-  /**
-   * Handle incoming WebSocket message
-   */
   private handleMessage(raw: string): void {
     let parsedValue: JsonValue;
     try {
@@ -354,7 +333,6 @@ export class GatewayWeb extends WebPlugin {
       return;
     }
 
-    // Handle response frames
     if (frameType === "res") {
       const id = getString(parsedValue.id);
       if (!id) {
@@ -380,7 +358,6 @@ export class GatewayWeb extends WebPlugin {
       return;
     }
 
-    // Handle event frames
     if (frameType === "event") {
       const event = getString(parsedValue.event);
       if (!event) {
@@ -392,7 +369,6 @@ export class GatewayWeb extends WebPlugin {
       const payload = parsedValue.payload;
       const seq = getNumber(parsedValue.seq);
 
-      // Check for sequence gap
       if (
         seq !== undefined &&
         this.lastSeq !== null &&
@@ -406,7 +382,6 @@ export class GatewayWeb extends WebPlugin {
         this.lastSeq = seq;
       }
 
-      // Emit the event
       this.notifyListeners("gatewayEvent", {
         event,
         payload,
@@ -420,13 +395,9 @@ export class GatewayWeb extends WebPlugin {
     console.warn(`[Gateway] Dropped frame with unhandled type: ${frameType}`);
   }
 
-  /**
-   * Handle WebSocket close
-   */
   private handleClose(code: number, reason: string): void {
     this.ws = null;
 
-    // Reject all pending requests
     for (const [id, pending] of this.pending) {
       clearTimeout(pending.timeout);
       pending.reject(new Error(`Connection closed: ${reason}`));
@@ -438,7 +409,6 @@ export class GatewayWeb extends WebPlugin {
       return;
     }
 
-    // Attempt reconnection
     this.notifyStateChange("reconnecting", reason);
     this.notifyListeners("error", {
       message: `Connection lost: ${reason}`,
@@ -449,9 +419,6 @@ export class GatewayWeb extends WebPlugin {
     this.scheduleReconnect();
   }
 
-  /**
-   * Schedule a reconnection attempt
-   */
   private scheduleReconnect(): void {
     if (this.closed || this.reconnectTimer) {
       return;
@@ -464,9 +431,6 @@ export class GatewayWeb extends WebPlugin {
     }, this.backoffMs);
   }
 
-  /**
-   * Notify state change listeners
-   */
   private notifyStateChange(
     state: GatewayStateEvent["state"],
     reason?: string,
@@ -477,9 +441,6 @@ export class GatewayWeb extends WebPlugin {
     } as GatewayStateEvent);
   }
 
-  /**
-   * Get platform identifier
-   */
   private getPlatform(): string {
     if (typeof navigator !== "undefined") {
       return navigator.platform || "web";
@@ -487,9 +448,6 @@ export class GatewayWeb extends WebPlugin {
     return "web";
   }
 
-  /**
-   * Disconnect from the Gateway
-   */
   async disconnect(): Promise<void> {
     this.closed = true;
     if (this.reconnectTimer) {
@@ -505,18 +463,12 @@ export class GatewayWeb extends WebPlugin {
     this.notifyStateChange("disconnected", "Client disconnect");
   }
 
-  /**
-   * Check if connected
-   */
   async isConnected(): Promise<{ connected: boolean }> {
     return {
       connected: this.ws !== null && this.ws.readyState === WebSocket.OPEN,
     };
   }
 
-  /**
-   * Send an RPC request
-   */
   async send(options: GatewaySendOptions): Promise<GatewaySendResult> {
     const method = assertRpcMethod(options.method);
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
@@ -559,9 +511,6 @@ export class GatewayWeb extends WebPlugin {
     });
   }
 
-  /**
-   * Get connection info
-   */
   async getConnectionInfo(): Promise<{
     url: string | null;
     sessionId: string | null;

--- a/plugins/plugin-native-location/rollup.config.mjs
+++ b/plugins/plugin-native-location/rollup.config.mjs
@@ -1,3 +1,9 @@
+/**
+ * Bundles the compiled `dist/esm/index.js` into an IIFE (`dist/plugin.js`, for
+ * script-tag/Electrobun consumption) and a CJS build (`dist/plugin.cjs.js`),
+ * externalizing the `@capacitor/core` peer dependency so host apps supply their
+ * own copy rather than bundling a second one.
+ */
 export default {
   input: "dist/esm/index.js",
   output: [

--- a/plugins/plugin-native-location/src/definitions.ts
+++ b/plugins/plugin-native-location/src/definitions.ts
@@ -1,3 +1,9 @@
+/**
+ * Shared TypeScript surface for the location plugin: the `LocationPlugin`
+ * interface plus its option/result/event types, implemented identically by
+ * `LocationWeb` (web.ts) and the native iOS/Android bridges. JSDoc here is the
+ * source for the generated README (`bun run docgen`) — keep it accurate.
+ */
 import type { PluginListenerHandle } from "@capacitor/core";
 
 /**

--- a/plugins/plugin-native-location/src/index.ts
+++ b/plugins/plugin-native-location/src/index.ts
@@ -1,3 +1,9 @@
+/**
+ * TS host entry point for the location Capacitor plugin: registers "ElizaLocation"
+ * with the Capacitor bridge and re-exports the shared type surface. The `web`
+ * factory lazy-loads `LocationWeb` (web.ts) only on browser/Electrobun targets;
+ * iOS/Android resolve their native implementations through the bridge itself.
+ */
 import { registerPlugin } from "@capacitor/core";
 
 import type { LocationPlugin } from "./definitions";

--- a/plugins/plugin-native-location/src/web.test.ts
+++ b/plugins/plugin-native-location/src/web.test.ts
@@ -1,3 +1,7 @@
+/**
+ * Unit tests for `LocationWeb` (web.ts) against a stubbed `navigator.geolocation` /
+ * `navigator.permissions` — no real browser geolocation hardware is exercised.
+ */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { LocationWeb } from "./web";
 

--- a/plugins/plugin-native-location/src/web.ts
+++ b/plugins/plugin-native-location/src/web.ts
@@ -1,3 +1,8 @@
+/**
+ * Browser/Electrobun implementation of the location bridge, backed by
+ * `navigator.geolocation`. Loaded lazily via index.ts's `web` factory; the
+ * iOS/Android bridges implement the same `LocationPlugin` interface natively.
+ */
 import { WebPlugin } from "@capacitor/core";
 
 import type {
@@ -184,8 +189,8 @@ export class LocationWeb extends WebPlugin {
   }
 
   async requestPermissions(): Promise<LocationPermissionStatus> {
-    // On web, permissions are requested implicitly when calling getCurrentPosition
-    // Try to get current position to trigger permission request
+    // No Permissions API entry for geolocation on web, so the only way to
+    // trigger the browser's permission prompt is to request a position.
     try {
       await this.getCurrentPosition({ timeout: 5000 });
       return { location: "granted" };


### PR DESCRIPTION
Fixes #12763

## Summary
Cold self-review of the 13-plugin comment-cleanup diff found and fixed 3 real defects: path.ts had a physical code-declaration reorder (not just a comment move) which was reverted; web.ts in plugin-native-bun-runtime and plugin-native-eliza-tasks were missing top-of-file headers (subagents mistook post-import class JSDoc for file headers) and now have proper ones. A full sweep of all 70 touched files confirmed no other missing headers or leftover restatement comments.

## Changes
- `plugins/plugin-native-activity-tracker/src/index.ts`
- `plugins/plugin-native-activity-tracker/src/index.test.ts`
- `plugins/plugin-native-agent/rollup.config.mjs`
- `plugins/plugin-native-agent/src/definitions.ts`
- `plugins/plugin-native-agent/src/index.ts`
- `plugins/plugin-native-agent/src/web.test.ts`
- `plugins/plugin-native-agent/src/web.ts`
- `plugins/plugin-native-appblocker/rollup.config.mjs`
- `plugins/plugin-native-appblocker/src/backend.test.ts`
- `plugins/plugin-native-appblocker/src/definitions.ts`
- `plugins/plugin-native-appblocker/src/index.ts`
- `plugins/plugin-native-appblocker/src/web.test.ts`
- `plugins/plugin-native-appblocker/src/web.ts`
- `plugins/plugin-native-bun-runtime/rollup.config.mjs`
- `plugins/plugin-native-bun-runtime/src/definitions.ts`
- `plugins/plugin-native-bun-runtime/src/index.ts`
- `plugins/plugin-native-bun-runtime/src/web.ts`
- `plugins/plugin-native-bun-runtime/vitest.config.ts`
- `plugins/plugin-native-calendar/rollup.config.mjs`
- `plugins/plugin-native-calendar/src/macos-bridge-policy.ts`
- `plugins/plugin-native-calendar/src/macos-bridge-policy.test.ts`
- `plugins/plugin-native-calendar/src/swift-bridge-contract.test.ts`
- `plugins/plugin-native-calendar/src/index.ts`
- `plugins/plugin-native-calendar/src/definitions.ts`
- `plugins/plugin-native-calendar/src/web.test.ts`
- `plugins/plugin-native-calendar/src/web.ts`
- `plugins/plugin-native-camera/rollup.config.mjs`
- `plugins/plugin-native-camera/vitest.config.ts`
- `plugins/plugin-native-camera/src/web.test.ts`
- `plugins/plugin-native-camera/src/index.ts`
- `plugins/plugin-native-camera/src/definitions.ts`
- `plugins/plugin-native-camera/src/web.ts`
- `plugins/plugin-native-canvas/rollup.config.mjs`
- `plugins/plugin-native-canvas/src/index.ts`
- `plugins/plugin-native-canvas/src/definitions.ts`
- `plugins/plugin-native-canvas/src/web.ts`
- `plugins/plugin-native-canvas/src/web.test.ts`
- `plugins/plugin-native-contacts/rollup.config.mjs`
- `plugins/plugin-native-contacts/src/web.test.ts`
- `plugins/plugin-native-contacts/src/index.ts`
- `plugins/plugin-native-contacts/src/definitions.ts`
- `plugins/plugin-native-contacts/src/web.ts`
- `plugins/plugin-native-desktop/rollup.config.mjs`
- `plugins/plugin-native-desktop/src/index.ts`
- `plugins/plugin-native-desktop/src/definitions.ts`
- `plugins/plugin-native-desktop/src/web.ts`
- `plugins/plugin-native-desktop/src/web.test.ts`
- `plugins/plugin-native-eliza-tasks/rollup.config.mjs`
- `plugins/plugin-native-eliza-tasks/src/web.test.ts`
- `plugins/plugin-native-eliza-tasks/src/index.ts`
- `plugins/plugin-native-eliza-tasks/src/definitions.ts`
- `plugins/plugin-native-eliza-tasks/src/web.ts`
- `plugins/plugin-native-filesystem/vitest.config.ts`
- `plugins/plugin-native-filesystem/src/path.ts`
- `plugins/plugin-native-filesystem/src/types.ts`
- `plugins/plugin-native-filesystem/src/index.ts`
- `plugins/plugin-native-filesystem/src/services/device-filesystem-bridge.ts`
- `plugins/plugin-native-filesystem/src/__tests__/round-trip.test.ts`
- `plugins/plugin-native-filesystem/src/__tests__/plugin-registration.test.ts`
- `plugins/plugin-native-filesystem/src/__tests__/path-validation.test.ts`
- `plugins/plugin-native-gateway/rollup.config.mjs`
- `plugins/plugin-native-gateway/src/web.test.ts`
- `plugins/plugin-native-gateway/src/index.ts`
- `plugins/plugin-native-gateway/src/definitions.ts`
- `plugins/plugin-native-gateway/src/web.ts`
- `plugins/plugin-native-location/rollup.config.mjs`
- `plugins/plugin-native-location/src/web.test.ts`
- `plugins/plugin-native-location/src/index.ts`
- `plugins/plugin-native-location/src/definitions.ts`
- `plugins/plugin-native-location/src/web.ts`

## How this was tested
Ran `develop` locally.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - comment-only native bridge documentation cleanup; no rendered UI surface changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - comment-only native bridge documentation cleanup; no rendered UI surface changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - comment-only cleanup; behavior is unchanged and verified by check:comment-only

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime behavior changed; code tokens are identical to origin/develop

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime behavior changed; code tokens are identical to origin/develop

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or agent planning behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - comment-only cleanup; local check:comment-only reports 70 source files with identical code tokens
