### PR TITLE
fix(cloud): preserve recoverable snapshot chain on auth degrade (#15274)

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -2786,12 +2786,10 @@ describe("isPermanentlyLostSnapshot (prune-vs-preserve gating)", () => {
 
   test("classifies HTTP 404/410 (snapshot gone) as permanently lost — safe to prune", async () => {
     const { isPermanentlyLostSnapshot } = await import("./eliza-sandbox.ts?actual");
-    expect(
-      isPermanentlyLostSnapshot(new Error("State restore failed: HTTP 404 Not Found")),
-    ).toBe(true);
-    expect(isPermanentlyLostSnapshot(new Error("State restore failed: HTTP 410 Gone"))).toBe(
+    expect(isPermanentlyLostSnapshot(new Error("State restore failed: HTTP 404 Not Found"))).toBe(
       true,
     );
+    expect(isPermanentlyLostSnapshot(new Error("State restore failed: HTTP 410 Gone"))).toBe(true);
     expect(isPermanentlyLostSnapshot(new Error("Snapshot fetch failed: HTTP 410"))).toBe(true);
   });
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -2480,8 +2480,12 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       expect(create).toHaveBeenCalledTimes(1);
       expect(stop).not.toHaveBeenCalled();
       expect(markErrorSpy).not.toHaveBeenCalled();
-      // The dead chain is dropped so the next resume boots clean.
-      expect(pruneSpy).toHaveBeenCalledWith(AGENT, 0);
+      // A 401 is an AUTH failure — RECOVERABLE (#15263), not a permanently-lost
+      // snapshot. It degrades to a fresh boot so the agent never bricks, but the
+      // backup chain is PRESERVED so a later token-corrected resume can restore
+      // it. Pruning here would be silent, permanent data loss (#15274), so the
+      // chain-nuking `pruneBackups(agentId, 0)` must NOT fire on this path.
+      expect(pruneSpy).not.toHaveBeenCalledWith(AGENT, 0);
       const logged = errorLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
       expect(logged).toContain("Unrecoverable snapshot, booting fresh");
     } finally {
@@ -2760,6 +2764,68 @@ describe("isUnrecoverableSnapshotError (permanent-vs-transient classification)",
     expect(isUnrecoverableSnapshotError("AEAD decrypt failed")).toBe(false);
     expect(isUnrecoverableSnapshotError(null)).toBe(false);
     expect(isUnrecoverableSnapshotError(undefined)).toBe(false);
+  });
+});
+
+// Snapshot PRUNE-gating classification (`isPermanentlyLostSnapshot`, #15274).
+// A strict SUBSET of `isUnrecoverableSnapshotError`: an auth 401/403 is
+// unrecoverable for THIS provision (boot fresh) but the snapshot is NOT
+// permanently lost — a token-corrected resume (#15263) can still restore it —
+// so it must NEVER gate a `pruneBackups(agentId, 0)`. Only crypto-loss and
+// HTTP 404/410 are permanently lost and safe to prune.
+describe("isPermanentlyLostSnapshot (prune-vs-preserve gating)", () => {
+  test("classifies crypto-loss shapes (KeyNotFoundError / AeadError) as permanently lost", async () => {
+    const { isPermanentlyLostSnapshot } = await import("./eliza-sandbox.ts?actual");
+    const keyGone = await realKeyRotatedAwayError();
+    expect(keyGone).toBeInstanceOf(KeyNotFoundError);
+    expect(isPermanentlyLostSnapshot(keyGone)).toBe(true);
+    const corrupt = await realAeadDecryptError();
+    expect(corrupt.name).toBe("AeadError");
+    expect(isPermanentlyLostSnapshot(corrupt)).toBe(true);
+  });
+
+  test("classifies HTTP 404/410 (snapshot gone) as permanently lost — safe to prune", async () => {
+    const { isPermanentlyLostSnapshot } = await import("./eliza-sandbox.ts?actual");
+    expect(
+      isPermanentlyLostSnapshot(new Error("State restore failed: HTTP 404 Not Found")),
+    ).toBe(true);
+    expect(isPermanentlyLostSnapshot(new Error("State restore failed: HTTP 410 Gone"))).toBe(
+      true,
+    );
+    expect(isPermanentlyLostSnapshot(new Error("Snapshot fetch failed: HTTP 410"))).toBe(true);
+  });
+
+  test("does NOT classify auth 401/403 as permanently lost — recoverable, must PRESERVE the chain (#15274)", async () => {
+    const { isPermanentlyLostSnapshot, isUnrecoverableSnapshotError } = await import(
+      "./eliza-sandbox.ts?actual"
+    );
+    // The exact HQ 14308 incident string. It IS unrecoverable-for-this-provision
+    // (degrade to fresh boot) but NOT permanently lost: PR #15263 shows the 401
+    // was a healthy container missing the agent token, which a corrected resume
+    // restores. Pruning here = silent permanent data loss.
+    const auth401 = new Error('State restore failed: HTTP 401 {"error":"Unauthorized"}');
+    expect(isUnrecoverableSnapshotError(auth401)).toBe(true);
+    expect(isPermanentlyLostSnapshot(auth401)).toBe(false);
+    const auth403 = new Error("State restore failed: HTTP 403 ");
+    expect(isUnrecoverableSnapshotError(auth403)).toBe(true);
+    expect(isPermanentlyLostSnapshot(auth403)).toBe(false);
+    expect(isPermanentlyLostSnapshot(new Error("Snapshot fetch failed: HTTP 401"))).toBe(false);
+    expect(isPermanentlyLostSnapshot(new Error("Snapshot fetch failed: HTTP 403"))).toBe(false);
+  });
+
+  test("does NOT classify transient / non-matching errors as permanently lost", async () => {
+    const { isPermanentlyLostSnapshot } = await import("./eliza-sandbox.ts?actual");
+    // Transient HTTP and network/DB errors were never unrecoverable to begin
+    // with; they must never prune.
+    expect(
+      isPermanentlyLostSnapshot(new Error("State restore failed: HTTP 500 Internal Server Error")),
+    ).toBe(false);
+    expect(isPermanentlyLostSnapshot(new Error("State restore failed: HTTP 503 "))).toBe(false);
+    expect(isPermanentlyLostSnapshot(new Error("connection terminated unexpectedly"))).toBe(false);
+    expect(isPermanentlyLostSnapshot(new TypeError("fetch failed"))).toBe(false);
+    expect(isPermanentlyLostSnapshot("AEAD decrypt failed")).toBe(false);
+    expect(isPermanentlyLostSnapshot(null)).toBe(false);
+    expect(isPermanentlyLostSnapshot(undefined)).toBe(false);
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -395,12 +395,21 @@ export function computeManagedAgentDbEnv(
     : { DATABASE_URL: dbUri };
 }
 
-// HTTP statuses that make a snapshot fetch/restore deterministically fail for
-// THIS snapshot: 401/403 (auth — a dead/rotated container or rotated token
-// rejects every retry identically), 404 (endpoint or snapshot gone), 410
-// (gone). Everything else — 5xx, 408/429, network/timeout — can heal on a
-// retry and must NOT appear here.
-const PERMANENT_SNAPSHOT_HTTP_STATUSES = new Set([401, 403, 404, 410]);
+// HTTP statuses that make a snapshot fetch/restore fail for THIS snapshot in a
+// way the current provision cannot retry away, so it must degrade to a fresh
+// boot instead of bricking the agent (#15210): 401/403 (auth — a dead/rotated
+// container or an unauthenticated/rotating token rejects every retry
+// identically), 404 (endpoint or snapshot gone), 410 (gone). Everything else —
+// 5xx, 408/429, network/timeout — can heal on a retry and must NOT appear here.
+const UNRECOVERABLE_SNAPSHOT_HTTP_STATUSES = new Set([401, 403, 404, 410]);
+// The subset that is also PERMANENTLY LOST — the snapshot itself is gone and no
+// later resume can restore it, so the dead backup chain should be pruned: 404
+// (endpoint or snapshot gone) and 410 (gone). 401/403 are auth failures, which
+// are RECOVERABLE (missing/rotating token — see #15263, where the incident 401
+// was a healthy container whose restore push simply omitted the agent token),
+// so they must degrade-but-PRESERVE the chain: never prune a snapshot a
+// token-corrected resume could still restore (#15274).
+const PERMANENTLY_LOST_SNAPSHOT_HTTP_STATUSES = new Set([404, 410]);
 // Anchored on the exact `fetchSnapshotState` / `pushState` throw shapes so only
 // this file's snapshot HTTP throw sites classify — an unrelated error that
 // merely embeds one of these strings does not.
@@ -425,23 +434,53 @@ const SNAPSHOT_HTTP_ERROR_SHAPE =
  *   runs bundled, where a cross-realm `instanceof` on a dependency's error
  *   class is unreliable.
  * - UNRETRIEVABLE / UNRESTORABLE: the snapshot fetch or restore push was
- *   rejected with a permanently-failing HTTP status (see
- *   `PERMANENT_SNAPSHOT_HTTP_STATUSES`). The incident shape (HQ 14308, agent
+ *   rejected with an unrecoverable-for-this-provision HTTP status (see
+ *   `UNRECOVERABLE_SNAPSHOT_HTTP_STATUSES`). The incident shape (HQ 14308, agent
  *   23766030): `State restore failed: HTTP 401 {"error":"Unauthorized"}` from a
- *   bridge URL pointing at a dead/rotated container — deterministic on every
- *   attempt, so retrying only re-failed the provision into status=error.
+ *   bridge URL — deterministic on every attempt of THIS provision, so retrying
+ *   only re-failed it into status=error.
  *
  * Deliberately NARROW so it never swallows a recoverable failure: HTTP 5xx /
  * 408 / 429, network/timeout errors, a transient KMS error (the Steward
  * backend surfaces HTTP 5xx as a base `KmsError`, not `KeyNotFoundError`), and
  * DB/IO errors are NOT matched and still propagate — degrading on one of those
  * would silently discard state that a retry would have restored.
+ *
+ * NOTE: "unrecoverable for this provision" (boot fresh) is a strictly WIDER
+ * classification than "permanently lost" (also prune the chain). A 401/403 is
+ * unrecoverable here but the snapshot is NOT permanently lost — an auth failure
+ * heals once the token is attached/rotated correctly (#15263), so
+ * `isPermanentlyLostSnapshot` must gate any pruning, never this predicate.
  */
 export function isUnrecoverableSnapshotError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   if (error.name === "AeadError" || error.name === "KeyNotFoundError") return true;
   const match = SNAPSHOT_HTTP_ERROR_SHAPE.exec(error.message);
-  return match !== null && PERMANENT_SNAPSHOT_HTTP_STATUSES.has(Number(match[1]));
+  return match !== null && UNRECOVERABLE_SNAPSHOT_HTTP_STATUSES.has(Number(match[1]));
+}
+
+/**
+ * True only when the snapshot is PERMANENTLY LOST — no later resume, on any
+ * container with any token, can ever restore it — so the dead backup chain is
+ * safe to prune. A strict SUBSET of `isUnrecoverableSnapshotError`:
+ *
+ * - The crypto shapes (`AeadError` / `KeyNotFoundError`): the bytes can never
+ *   be decrypted again (corruption, or the ephemeral `memory` KMS key that
+ *   encrypted them is gone), so the chain is genuinely dead.
+ * - HTTP 404 (endpoint or snapshot gone) / 410 (gone): the snapshot resource
+ *   itself no longer exists to fetch.
+ *
+ * Excludes 401/403: those are AUTH failures (missing/rotating token), which are
+ * RECOVERABLE — pruning on one would silently, permanently discard a snapshot a
+ * token-corrected resume could still restore (#15274 regression class). On an
+ * auth failure we still degrade to a fresh boot (never brick), but we PRESERVE
+ * the chain and let the next authenticated resume restore it.
+ */
+export function isPermanentlyLostSnapshot(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if (error.name === "AeadError" || error.name === "KeyNotFoundError") return true;
+  const match = SNAPSHOT_HTTP_ERROR_SHAPE.exec(error.message);
+  return match !== null && PERMANENTLY_LOST_SNAPSHOT_HTTP_STATUSES.has(Number(match[1]));
 }
 
 export class ElizaSandboxService {
@@ -5621,21 +5660,37 @@ export class ElizaSandboxService {
 
   /**
    * The single degrade path for a snapshot `isUnrecoverableSnapshotError`
-   * classified as permanently lost (#15210): log it loudly, then drop the dead
-   * backup chain so the next resume boots clean instead of re-hitting the same
-   * unrecoverable snapshot on every provision. Never throws — the caller
-   * continues to a fresh boot, which must not be derailed by cleanup.
+   * cannot restore on THIS provision (#15210): log it loudly, then boot fresh
+   * instead of bricking the agent. Never throws — the caller continues to a
+   * fresh boot, which must not be derailed by cleanup.
+   *
+   * Pruning the backup chain is gated on `isPermanentlyLostSnapshot` (#15274):
+   * only drop it when the snapshot can NEVER be restored (crypto corruption /
+   * gone-key, or HTTP 404/410). For a RECOVERABLE auth failure (401/403) we
+   * still boot fresh but PRESERVE the chain, so a later token-corrected resume
+   * (#15263) can restore it — pruning a recoverable snapshot on a transient 401
+   * is silent, permanent data loss (`pruneBackups(agentId, 0)` deletes the
+   * whole chain and there is no undo).
    */
   private async degradeUnrecoverableSnapshot(
     agentId: string,
     backupId: string | undefined,
     error: unknown,
   ): Promise<void> {
+    const permanentlyLost = isPermanentlyLostSnapshot(error);
     logger.error("[agent-sandbox] Unrecoverable snapshot, booting fresh", {
       agentId,
       backupId,
+      permanentlyLost,
+      // A recoverable auth failure keeps the chain for the next authenticated
+      // resume; a permanent loss drops it so the next resume boots clean.
+      backupChain: permanentlyLost ? "pruned" : "preserved",
       error: error instanceof Error ? error.message : String(error),
     });
+    // Preserve the chain on a recoverable failure (auth 401/403): a
+    // token-corrected resume can still restore it, so pruning here would be
+    // silent, permanent data loss (#15274).
+    if (!permanentlyLost) return;
     // error-policy:J6 best-effort — a failed prune only means we warn + degrade
     // again next boot, never that we fail to boot fresh, so it must not throw
     // out of the provision.


### PR DESCRIPTION
## Summary

Fixes #15274, a data-loss regression where restore/fetch HTTP 401/403 was treated as permanently unrecoverable and could call `pruneBackups(agentId, 0)` before booting fresh.

401/403 are auth failures, which are recoverable. This keeps the existing degrade-to-fresh-boot behavior so the agent does not brick, but only prunes the backup chain for permanently lost snapshot classes: crypto loss and HTTP 404/410. Auth 401/403 now preserve the chain so a later token-corrected resume can restore it.

## Tests

- `bun install --frozen-lockfile --ignore-scripts`
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/core build`
- `bun test src/lib/services/eliza-sandbox.test.ts` from `packages/cloud/shared` -> 77 pass / 0 fail

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend snapshot-restore classification change; no rendered UI surface.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend snapshot-restore classification change; no rendered UI surface.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend service invariant change; behavior is covered by the focused service test listed above.

<!-- evidence-row:backend-logs -->
- [ ] Focused service test output: `bun test src/lib/services/eliza-sandbox.test.ts` passed 77/77 locally after the formatting repair; coverage is in [eliza-sandbox.test.ts](packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts).

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or agent planning behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifact is the backup-chain invariant in [eliza-sandbox.test.ts](packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts): auth 401/403 degrades but does not call `pruneBackups(agentId, 0)`, while crypto loss and HTTP 404/410 still prune.
