### PR TITLE
perf(ui): shared auto-scroll engine, memo/parse fast-paths, rAF-coalesced streaming + gesture freeze

### DIFF
--- a/packages/ui/src/components/chat/message-parser-helpers.test.ts
+++ b/packages/ui/src/components/chat/message-parser-helpers.test.ts
@@ -14,9 +14,13 @@ import {
   looksLikePatch,
   normalizeDisplayText,
   parseFormSubmitDisplay,
+  parseSegments,
   sanitizePatchValue,
   tryParsePatch,
 } from "./message-parser-helpers";
+// Side-effect import: registers the built-in inline widgets (choice/followups/
+// form/workflow/background/checklist) the pre-gate tests below parse through.
+import "./widgets/inline-builtins";
 
 describe("sanitizePatchValue (prototype-pollution guard)", () => {
   it("drops __proto__/constructor/prototype keys at every nesting level", () => {
@@ -208,5 +212,79 @@ describe("normalizeDisplayText", () => {
     // A chunk that ends mid-tag during streaming must not leak the fragment.
     expect(normalizeDisplayText("Hello<thi")).toBe("Hello");
     expect(normalizeDisplayText("  spaced  ")).toBe("spaced");
+  });
+});
+
+describe("parseSegments trigger-character pre-gate", () => {
+  it("returns one text segment for plain streamed prose (no trigger chars)", () => {
+    // The common streaming shape: growing prose with none of ` [ { < — the
+    // pre-gate must short-circuit to a single text segment whose content is
+    // exactly the normalized text (identical to the full-scan result).
+    const prose =
+      "Sure — I checked the calendar and you have three meetings tomorrow. " +
+      "The first starts at 9am, then a design review after lunch.";
+    expect(parseSegments(prose, false)).toEqual([
+      { kind: "text", text: prose },
+    ]);
+  });
+
+  it("still returns a single text segment when trigger chars appear in plain prose", () => {
+    // The gate only skips work; text that CONTAINS a trigger char but no real
+    // region must come out identical to before (one text segment).
+    const prose = "Set the value to {something} in [brackets] with a < sign.";
+    expect(parseSegments(prose, false)).toEqual([
+      { kind: "text", text: prose },
+    ]);
+  });
+
+  it("parses a [CONFIG:…] marker (gated on '[')", () => {
+    const segments = parseSegments("Set it up: [CONFIG:openai]", false);
+    expect(segments).toEqual([
+      { kind: "text", text: "Set it up: " },
+      { kind: "config", pluginId: "openai" },
+    ]);
+  });
+
+  it("parses an inline widget marker (gated on '[')", () => {
+    const segments = parseSegments(
+      "[CHOICE:pick]\none=One\ntwo=Two\n[/CHOICE]",
+      false,
+    );
+    expect(segments.some((s) => s.kind === "widget")).toBe(true);
+  });
+
+  it("parses a fenced UiSpec (gated on '`')", () => {
+    const spec = '{"root":"a","elements":{"a":{"type":"text"}}}';
+    const segments = parseSegments(`\`\`\`json\n${spec}\n\`\`\``, false);
+    expect(segments.some((s) => s.kind === "ui-spec")).toBe(true);
+  });
+
+  it("parses a JSONL patch block (gated on '{')", () => {
+    const patches = [
+      '{"op":"add","path":"/root","value":"a"}',
+      '{"op":"add","path":"/elements/a","value":{"type":"text"}}',
+    ].join("\n");
+    const segments = parseSegments(patches, false);
+    expect(segments.some((s) => s.kind === "ui-spec")).toBe(true);
+  });
+
+  it("parses a fenced code block (gated on '`')", () => {
+    const segments = parseSegments("```ts\nconst x = 1;\n```", false);
+    expect(segments).toEqual([
+      { kind: "code", code: "const x = 1;", inline: false, lang: "ts" },
+    ]);
+  });
+
+  it("parses a permission request card (gated on '{' / '`')", () => {
+    const payload =
+      '{"action":"permission_request","permission":"camera",' +
+      '"reason":"to scan the QR code","feature":"QR scan"}';
+    const segments = parseSegments(`May I use the camera?\n${payload}`, false);
+    expect(segments.some((s) => s.kind === "permission")).toBe(true);
+  });
+
+  it("parses analysis-mode XML blocks (gated on '<')", () => {
+    const segments = parseSegments("<thought>weighing options</thought>", true);
+    expect(segments.some((s) => s.kind === "analysis-xml")).toBe(true);
   });
 });

--- a/packages/ui/src/components/chat/message-parser-helpers.ts
+++ b/packages/ui/src/components/chat/message-parser-helpers.ts
@@ -366,11 +366,37 @@ export function splitInlineCode(text: string): InlineTextPart[] {
   return parts;
 }
 
+/**
+ * Cheap pre-gate for {@link parseSegments}: every non-text region the parser
+ * can produce REQUIRES at least one of these characters, so a message without
+ * any of them is guaranteed plain prose and can skip the whole multi-pass scan
+ * (permission parse, [CONFIG], widget parsers, fenced-JSON JSON.parse, JSONL
+ * patches, fenced code). parseSegments runs on every streaming rAF flush over
+ * the full accumulated text, so for typical streamed prose this single scan
+ * replaces ~8 regex/JSON passes per frame.
+ *
+ * Region → required character:
+ *   - fenced code / fenced-JSON UiSpec / permission fenced body → `` ` ``
+ *   - [CONFIG:…] and every registry inline widget marker
+ *     ([CHOICE]/[FOLLOWUPS]/[FORM]/[WORKFLOW]/[BACKGROUND]/[CHECKLIST]/[TASK])
+ *     → `[` (plugin-registered widgets must also use a `[…]` marker — see
+ *     inline-registry.tsx)
+ *   - JSONL patch lines (`{"op":…` / `{ "op":…`) and the permission card's
+ *     bare-JSON tail → `{`
+ *   - analysis-mode XML blocks (<thought>/<action>/…) → `<`
+ */
+const SEGMENT_TRIGGER_RE = /[`[{<]/;
+
 export function parseSegments(text: string, analysisMode: boolean): Segment[] {
   // If analysis mode is enabled, we parse the raw text to extract XML blocks,
   // otherwise we use the normalized text which strips them.
   const targetText = analysisMode ? text : normalizeDisplayText(text);
   if (!targetText) return [{ kind: "text", text: "" }];
+
+  // Plain prose (no trigger character anywhere) → one text segment, no scans.
+  if (!SEGMENT_TRIGGER_RE.test(targetText)) {
+    return [{ kind: "text", text: targetText }];
+  }
 
   const permissionRequest = analysisMode
     ? null

--- a/packages/ui/src/components/chat/widgets/inline-registry.tsx
+++ b/packages/ui/src/components/chat/widgets/inline-registry.tsx
@@ -47,7 +47,14 @@ export interface InlineWidgetMatch<TData = unknown> {
 export interface InlineWidgetDefinition<TData = unknown> {
   /** Unique marker kind, e.g. `"task"`, `"choice"`. */
   readonly kind: string;
-  /** Scan a reply for this widget's regions, left to right. */
+  /**
+   * Scan a reply for this widget's regions, left to right.
+   *
+   * Marker contract: the text form MUST be a bracketed `[…]` marker (like all
+   * built-ins). `parseSegments` pre-gates the whole widget scan on the message
+   * containing one of `` ` `` `[` `{` `<`, so a marker without any of those
+   * characters would never reach this parser on plain-prose messages.
+   */
   parse(text: string): InlineWidgetMatch<TData>[];
   /** Render one matched payload. `key` is React-stable; `ctx` drives chat. */
   render(data: TData, ctx: InlineWidgetContext, key: string): ReactNode;

--- a/packages/ui/src/components/composites/chat/chat-message.tsx
+++ b/packages/ui/src/components/composites/chat/chat-message.tsx
@@ -438,6 +438,11 @@ function arePropsEqual(
     a.voiceSpeaker === b.voiceSpeaker &&
     a.failureKind === b.failureKind &&
     a.attachments === b.attachments &&
+    // Inline tool-call rows: a mode:"tool" stream update replaces `toolEvents`
+    // by reference while every other compared field stays identical, so without
+    // this compare the memo swallows the re-render and the running tool row
+    // never flips to its settled state.
+    a.toolEvents === b.toolEvents &&
     // Turn-settle fields the glass body renderer reads: a settled turn can gain
     // reasoning / a secret request without its text changing.
     a.reasoning === b.reasoning &&

--- a/packages/ui/src/components/composites/chat/chat-transcript.memoization.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-transcript.memoization.test.tsx
@@ -8,6 +8,7 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type { NativeToolCallEvent } from "../../../api/client-types-cloud";
 import { ChatTranscript } from "./chat-transcript";
 import type { ChatMessageData } from "./chat-types";
 
@@ -21,6 +22,17 @@ function makeMessage(
   text: string,
 ): ChatMessageData {
   return { id, role, text };
+}
+
+function makeToolEvent(callId: string): NativeToolCallEvent {
+  return {
+    id: `traj-${callId}`,
+    type: "tool_call",
+    timestamp: 1,
+    callId,
+    toolName: "search",
+    status: "running",
+  };
 }
 
 describe("ChatTranscript memoization", () => {
@@ -55,5 +67,82 @@ describe("ChatTranscript memoization", () => {
     expect(screen.getByTestId("content-msg-2").textContent).toBe(
       "thinking harder",
     );
+  });
+
+  it("re-renders a row when a streamed tool event lands (toolEvents identity change)", () => {
+    // A mode:"tool" stream update rebuilds the message with a NEW toolEvents
+    // array while text/id/every other compared field stays identical. The memo
+    // must let that through — this is the row flipping a tool from running to
+    // settled (#13535). Fails without the a.toolEvents === b.toolEvents compare.
+    const user = makeMessage("msg-1", "user", "run the tool");
+    const assistant: ChatMessageData = {
+      ...makeMessage("msg-2", "assistant", "on it"),
+      toolEvents: [makeToolEvent("call-1")],
+    };
+    const renderMessageContent = vi.fn((message: ChatMessageData) => (
+      <span data-testid={`content-${message.id}`}>
+        {message.toolEvents?.map((event) => event.status).join(",") ?? "none"}
+      </span>
+    ));
+
+    const rendered = render(
+      <ChatTranscript
+        messages={[user, assistant]}
+        renderMessageContent={renderMessageContent}
+      />,
+    );
+    expect(renderMessageContent).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId("content-msg-2").textContent).toBe("running");
+
+    rendered.rerender(
+      <ChatTranscript
+        messages={[
+          { ...user },
+          {
+            ...assistant,
+            toolEvents: [{ ...makeToolEvent("call-1"), status: "completed" }],
+          },
+        ]}
+        renderMessageContent={renderMessageContent}
+      />,
+    );
+
+    // Only the tool row re-rendered, and it shows the settled status.
+    expect(renderMessageContent).toHaveBeenCalledTimes(3);
+    expect(renderMessageContent.mock.calls[2]?.[0].id).toBe("msg-2");
+    expect(screen.getByTestId("content-msg-2").textContent).toBe("completed");
+  });
+
+  it("does NOT re-render a row whose toolEvents reference is unchanged", () => {
+    // The transcript rebuilds message OBJECTS every parent render; a row whose
+    // toolEvents array is the SAME reference (no tool change) must still be
+    // memo-skipped, exactly like unchanged text.
+    const toolEvents = [makeToolEvent("call-1")];
+    const user = makeMessage("msg-1", "user", "run the tool");
+    const assistant: ChatMessageData = {
+      ...makeMessage("msg-2", "assistant", "on it"),
+      toolEvents,
+    };
+    const renderMessageContent = vi.fn((message: ChatMessageData) => (
+      <span data-testid={`content-${message.id}`}>{message.text}</span>
+    ));
+
+    const rendered = render(
+      <ChatTranscript
+        messages={[user, assistant]}
+        renderMessageContent={renderMessageContent}
+      />,
+    );
+    expect(renderMessageContent).toHaveBeenCalledTimes(2);
+
+    rendered.rerender(
+      <ChatTranscript
+        messages={[{ ...user }, { ...assistant, toolEvents }]}
+        renderMessageContent={renderMessageContent}
+      />,
+    );
+
+    // Same compared fields + same toolEvents reference → no row re-rendered.
+    expect(renderMessageContent).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/ui/src/components/pages/ChatView.tsx
+++ b/packages/ui/src/components/pages/ChatView.tsx
@@ -35,6 +35,7 @@ import { useChatAvatarVoiceBridge } from "../../hooks/useChatAvatarVoiceBridge";
 import { useConnectorSendAsAccount } from "../../hooks/useConnectorSendAsAccount";
 import { useIntervalWhenDocumentVisible } from "../../hooks/useDocumentVisibility";
 import { useLoadOlderOnScroll } from "../../hooks/useLoadOlderOnScroll";
+import { useThreadAutoScroll } from "../../hooks/useThreadAutoScroll";
 import { useViewEvent } from "../../hooks/useViewEvent";
 import { claimAssistantLaunchPayloadFromHash } from "../../platform/assistant-launch-payload";
 import {
@@ -283,9 +284,11 @@ export function ChatView({
     [appTranslate],
   );
 
-  const messagesRef = useRef<HTMLDivElement>(null);
   // Top sentinel for infinite upward scroll (#13532): rendered just above the
   // first transcript row; when it nears the viewport the older page prefetches.
+  // The scroller node itself is owned by useThreadAutoScroll below (its returned
+  // `scrollRef` is wired to the transcript, the load-older observer, and the
+  // ChatThreadLayout scroll region).
   const topSentinelRef = useRef<HTMLDivElement>(null);
   // Whether the server reports older turns beyond the current top. Starts true
   // (we don't know until the first load-older) and latches false at the true
@@ -493,15 +496,6 @@ export function ChatView({
     setHasMoreOlder(true);
   }, [activeConversationId]);
 
-  useLoadOlderOnScroll<HTMLDivElement>({
-    scrollRef: messagesRef,
-    sentinelRef: topSentinelRef,
-    onLoadOlder: loadOlderMessages,
-    hasMore: hasMoreOlder && !isGameModal,
-    topItemKey: visibleMsgs[0]?.id ?? "",
-    enabled: !isGameModal,
-  });
-
   const {
     companionCarryover,
     gameModalCarryoverOpacity,
@@ -513,59 +507,50 @@ export function ChatView({
     visibleMsgs,
   });
 
+  // The exact set the transcript paints into the shared scroller (the game-modal
+  // variant renders its own windowed set + a companion carryover above it).
+  const displayedMsgs = isGameModal ? gameModalVisibleMsgs : visibleMsgs;
+  const lastDisplayed = displayedMsgs.at(-1);
+  const displayedCount =
+    displayedMsgs.length +
+    (isGameModal ? (companionCarryover?.messages.length ?? 0) : 0);
+  // Bottom-follow via the ONE shared thread-scroll engine (#12348), replacing
+  // the legacy per-flush `scrollTo` that re-read layout and restarted a smooth
+  // scroll on every streamed rAF flush (yanking scrolled-up readers). The engine
+  // follows the tail only while the reader rests at the bottom — measured against
+  // the pre-growth height so a big single-commit append is not misread as
+  // "scrolled up" — coalesces the follow into a single rAF write, and leaves a
+  // reader who scrolled up to read history alone. `growthKey` tracks tail
+  // mutation (streamed tokens → instant follow); `lineKey` marks a NEW line
+  // (smooth glide). The transcript is unmounted on the terminal/inbox branches,
+  // so gate the engine there: the false→true edge on return re-pins instantly
+  // instead of flashing at the top.
+  const { scrollRef: messagesRef } = useThreadAutoScroll<HTMLDivElement>({
+    growthKey: `${displayedCount}:${lastDisplayed?.id ?? ""}:${lastDisplayed?.text.length ?? 0}`,
+    lineKey: lastDisplayed?.id ?? "",
+    enabled: !activeTerminalSessionId && !inboxChat,
+  });
+
+  // Infinite upward scroll shares the SAME scroller node as the auto-scroll
+  // engine (#13532). It owns the OTHER direction — an older-page prepend grows
+  // the thread upward and it anchors the reader's viewport by the scrollHeight
+  // delta so a reader parked in history stays put (the anchoring that replaces
+  // the legacy moved-but-present-top guard). The auto-scroll engine above never
+  // fights it: a prepend leaves the reader off-bottom, so it does not follow.
+  useLoadOlderOnScroll<HTMLDivElement>({
+    scrollRef: messagesRef,
+    sentinelRef: topSentinelRef,
+    onLoadOlder: loadOlderMessages,
+    hasMore: hasMoreOlder && !isGameModal,
+    topItemKey: visibleMsgs[0]?.id ?? "",
+    enabled: !isGameModal,
+  });
+
   useChatAvatarVoiceBridge({
     mouthOpen: voice.mouthOpen,
     isSpeaking: voice.isSpeaking,
     onSpeakingChange: handleChatAvatarSpeakingChange,
   });
-
-  // Auto-scroll on new messages. Use instant scroll when already near the
-  // bottom (or when the user is actively sending) to prevent the visible
-  // "scroll from top" effect that occurs when many background messages
-  // (e.g. coding-agent updates) arrive in rapid succession during smooth
-  // scrolling. Only smooth-scroll when the user has scrolled up and a new
-  // message nudges them back down.
-  //
-  // Previous FIRST visible id, used to recognize an older-page prepend
-  // (#13532): the prior top message is still present, just pushed down by the
-  // new page. New content always lands at the TAIL, so a moved-but-present top
-  // means the reader is parked in history and useLoadOlderOnScroll has just
-  // restored their anchor — pulling them to the bottom would undo it.
-  const prevTopVisibleIdRef = useRef<string | null>(null);
-  useEffect(() => {
-    const prevTopId = prevTopVisibleIdRef.current;
-    prevTopVisibleIdRef.current = visibleMsgs[0]?.id ?? null;
-    const displayedCompanionMessageCount =
-      (companionCarryover?.messages.length ?? 0) + gameModalVisibleMsgs.length;
-    if (
-      !chatSending &&
-      visibleMsgs.length === 0 &&
-      (!isGameModal || displayedCompanionMessageCount === 0)
-    ) {
-      return;
-    }
-    if (
-      prevTopId !== null &&
-      visibleMsgs[0]?.id !== prevTopId &&
-      visibleMsgs.some((m) => m.id === prevTopId)
-    ) {
-      return;
-    }
-    const el = messagesRef.current;
-    if (!el) return;
-    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    const nearBottom = distanceFromBottom < 150;
-    el.scrollTo({
-      top: el.scrollHeight,
-      behavior: nearBottom ? "instant" : "smooth",
-    });
-  }, [
-    chatSending,
-    companionCarryover,
-    gameModalVisibleMsgs,
-    isGameModal,
-    visibleMsgs,
-  ]);
 
   // Auto-resize textarea
   useEffect(() => {

--- a/packages/ui/src/components/shell/HomeLauncherSurface.tsx
+++ b/packages/ui/src/components/shell/HomeLauncherSurface.tsx
@@ -124,7 +124,11 @@ export function HomeLauncherSurface({
           // rail flick. Without it a touch device hands a horizontal drag to the
           // browser's own scroll/back gesture, which fires `pointercancel`
           // instead of `pointerup` — the flick silently never commits.
-          className="relative h-full w-1/2 shrink-0 touch-pan-y"
+          // `contain: layout style paint`: each half is a fixed-size pane, so
+          // scope layout/style/paint invalidation to it — a widget re-render
+          // inside one half then can't dirty the other half (or the promoted
+          // rail layer's geometry) mid-gesture.
+          className="relative h-full w-1/2 shrink-0 touch-pan-y [contain:layout_style_paint]"
           onPointerDown={pager.handlers.onPointerDown}
           onPointerMove={pager.handlers.onPointerMove}
           onPointerUp={pager.handlers.onPointerUp}
@@ -139,8 +143,9 @@ export function HomeLauncherSurface({
           aria-hidden={page !== "launcher"}
           inert={page !== "launcher" || undefined}
           // Same as the home half: vertical scroll (the tile grid) stays with
-          // the browser, horizontal flicks (right → back home) are ours.
-          className="relative h-full w-1/2 shrink-0 touch-pan-y"
+          // the browser, horizontal flicks (right → back home) are ours; and
+          // the same containment so tile churn can't invalidate the home half.
+          className="relative h-full w-1/2 shrink-0 touch-pan-y [contain:layout_style_paint]"
           onPointerDown={pager.handlers.onPointerDown}
           onPointerMove={pager.handlers.onPointerMove}
           onPointerUp={pager.handlers.onPointerUp}

--- a/packages/ui/src/components/views/ViewTileImage.tsx
+++ b/packages/ui/src/components/views/ViewTileImage.tsx
@@ -165,6 +165,9 @@ export function ViewTileImage({
           draggable={false}
           loading="lazy"
           decoding="async"
+          // Decorative hero art must never compete with interactive work
+          // (gesture frames, chat streaming) for network/decode bandwidth.
+          fetchPriority="low"
           onError={() => {
             emitViewInteraction({
               source,

--- a/packages/ui/src/hooks/useActivityEvents.test.tsx
+++ b/packages/ui/src/hooks/useActivityEvents.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+//
+// Unit coverage for useActivityEvents' rail-gesture park (#swipe-smoothness):
+// WS activity events that land while the home↔launcher rail is mid-gesture must
+// NOT commit state (a WidgetHost re-render re-rasterizes the promoted, moving
+// rail layer) — they accumulate in the ring buffer and flush exactly once on
+// settle. Real hook under jsdom with a fake WS client and a driven rAF queue.
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  beginRailGesture,
+  endRailGesture,
+  resetRailGestureForTests,
+} from "../state/rail-gesture-store";
+import { useActivityEvents } from "./useActivityEvents";
+
+type WsHandler = (data: Record<string, unknown>) => void;
+
+const mocks = vi.hoisted(() => ({
+  handlers: new Map<string, WsHandler>(),
+  client: {
+    onWsEvent: vi.fn((type: string, handler: WsHandler) => {
+      mocks.handlers.set(type, handler);
+      return () => mocks.handlers.delete(type);
+    }),
+  },
+}));
+
+vi.mock("../api", () => ({
+  client: mocks.client,
+}));
+
+let rafQueue: FrameRequestCallback[] = [];
+
+beforeEach(() => {
+  rafQueue = [];
+  mocks.handlers.clear();
+  mocks.client.onWsEvent.mockClear();
+  resetRailGestureForTests();
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    rafQueue.push(cb);
+    return rafQueue.length;
+  });
+  vi.stubGlobal("cancelAnimationFrame", () => {});
+});
+
+afterEach(() => {
+  resetRailGestureForTests();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function flushRaf(): number {
+  const q = rafQueue;
+  rafQueue = [];
+  act(() => {
+    for (const cb of q) cb(0);
+  });
+  return q.length;
+}
+
+/** Deliver one pty-session-event through the captured WS handler. */
+function emitPtyEvent(summaryId: string): void {
+  const handler = mocks.handlers.get("pty-session-event");
+  if (!handler) throw new Error("pty-session-event handler not bound");
+  act(() => {
+    handler({ eventType: "task_complete", sessionId: summaryId, ts: 1 });
+  });
+}
+
+describe("useActivityEvents rail-gesture park", () => {
+  it("commits events through a single rAF flush when no gesture is active", () => {
+    const { result } = renderHook(() => useActivityEvents());
+    emitPtyEvent("s1");
+    expect(result.current.events).toHaveLength(0); // parked until the frame
+    expect(flushRaf()).toBe(1);
+    expect(result.current.events).toHaveLength(1);
+    expect(result.current.events[0]?.summary).toBe("Task completed");
+  });
+
+  it("does not commit events while the rail gesture is active, then flushes exactly once on settle", () => {
+    const { result } = renderHook(() => useActivityEvents());
+
+    act(() => {
+      beginRailGesture();
+    });
+    emitPtyEvent("s1");
+    emitPtyEvent("s2");
+    // Nothing scheduled, nothing committed — the moving rail is left alone.
+    expect(flushRaf()).toBe(0);
+    expect(result.current.events).toHaveLength(0);
+
+    act(() => {
+      endRailGesture();
+    });
+    // The release edge schedules exactly ONE frame, whose commit carries the
+    // latest buffered state (both parked events).
+    expect(flushRaf()).toBe(1);
+    expect(result.current.events).toHaveLength(2);
+    expect(result.current.events[0]?.sessionId).toBe("s2"); // newest first
+    expect(result.current.events[1]?.sessionId).toBe("s1");
+
+    // No further flush is pending after the settle flush.
+    expect(flushRaf()).toBe(0);
+  });
+
+  it("settle with no parked events schedules nothing", () => {
+    const { result } = renderHook(() => useActivityEvents());
+    act(() => {
+      beginRailGesture();
+    });
+    act(() => {
+      endRailGesture();
+    });
+    expect(flushRaf()).toBe(0);
+    expect(result.current.events).toHaveLength(0);
+  });
+
+  it("flushes anyway when a gesture window sticks past the safety cap", () => {
+    // A missed release edge must never park the widget rail forever: an event
+    // arriving after RAIL_GESTURE_PARK_MAX_MS flushes despite the stuck signal.
+    let clock = 1_000;
+    vi.spyOn(performance, "now").mockImplementation(() => clock);
+    const { result } = renderHook(() => useActivityEvents());
+    act(() => {
+      beginRailGesture();
+    });
+    clock += 60_000;
+    emitPtyEvent("s1");
+    expect(flushRaf()).toBe(1);
+    expect(result.current.events).toHaveLength(1);
+  });
+});

--- a/packages/ui/src/hooks/useActivityEvents.ts
+++ b/packages/ui/src/hooks/useActivityEvents.ts
@@ -1,14 +1,27 @@
 /**
  * Hook that subscribes to WebSocket activity events and maintains a ring buffer
- * of recent entries for the chat widget rail.
+ * of recent entries for the chat widget rail. State commits are rAF-coalesced
+ * and parked entirely while the home↔launcher rail is mid-gesture
+ * (rail-gesture-store) — a widget re-render would re-rasterize the promoted,
+ * moving rail layer — then flushed once on settle.
  */
 
 import { activityEventToPlaintext } from "@elizaos/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { client } from "../api";
 import { parseProactiveMessageEvent } from "../state/parsers";
+import {
+  isRailGestureActive,
+  railGestureActiveMs,
+  subscribeRailGesture,
+} from "../state/rail-gesture-store";
 
 const RING_BUFFER_CAP = 200;
+
+// Safety valve for the rail-gesture park below: if the gesture window somehow
+// stays open longer than this (a missed release edge), events flush anyway so
+// the widget rail can never go permanently stale behind a stuck signal.
+const RAIL_GESTURE_PARK_MAX_MS = 5_000;
 
 export interface ActivityEventSource {
   type: "pty-session-event" | "proactive-message" | "agent_event";
@@ -95,6 +108,9 @@ export function useActivityEvents() {
   const [events, setEvents] = useState<ActivityEvent[]>([]);
   const bufferRef = useRef<ActivityEvent[]>([]);
   const flushHandleRef = useRef<number | null>(null);
+  // True while bufferRef holds entries the rendered `events` state has not seen
+  // yet — the "something is parked" flag the rail-gesture release edge checks.
+  const dirtyRef = useRef(false);
 
   const cancelPendingFlush = useCallback(() => {
     if (flushHandleRef.current === null) {
@@ -110,6 +126,7 @@ export function useActivityEvents() {
     }
     flushHandleRef.current = requestAnimationFrame(() => {
       flushHandleRef.current = null;
+      dirtyRef.current = false;
       setEvents([...bufferRef.current]);
     });
   }, []);
@@ -122,8 +139,33 @@ export function useActivityEvents() {
       if (buf.length > RING_BUFFER_CAP) {
         buf.length = RING_BUFFER_CAP;
       }
+      dirtyRef.current = true;
+      // Park the state commit while the launcher rail is mid-gesture: a flush
+      // re-renders WidgetHost inside the promoted rail layer, re-rasterizing
+      // the surface the finger is dragging. The ring buffer keeps accumulating;
+      // the release-edge subscription below commits ONCE on settle. The time
+      // cap bounds staleness if a release edge is ever missed.
+      if (
+        isRailGestureActive() &&
+        railGestureActiveMs() < RAIL_GESTURE_PARK_MAX_MS
+      ) {
+        return;
+      }
       scheduleFlush();
     },
+    [scheduleFlush],
+  );
+
+  // Flush the parked buffer exactly once when the rail gesture settles. The
+  // rAF coalescer already dedupes against an event that lands in the same
+  // frame as the release edge.
+  useEffect(
+    () =>
+      subscribeRailGesture(() => {
+        if (!isRailGestureActive() && dirtyRef.current) {
+          scheduleFlush();
+        }
+      }),
     [scheduleFlush],
   );
 
@@ -207,6 +249,7 @@ export function useActivityEvents() {
 
   const clearEvents = useCallback(() => {
     bufferRef.current = [];
+    dirtyRef.current = false;
     cancelPendingFlush();
     setEvents([]);
   }, [cancelPendingFlush]);

--- a/packages/ui/src/hooks/useHorizontalPager.test.tsx
+++ b/packages/ui/src/hooks/useHorizontalPager.test.tsx
@@ -10,6 +10,10 @@
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import * as React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  isRailGestureActive,
+  resetRailGestureForTests,
+} from "../state/rail-gesture-store";
 import { runAnimationFramesImmediately } from "../testing/run-animation-frames-immediately";
 import { useHorizontalPager } from "./useHorizontalPager";
 
@@ -17,6 +21,7 @@ let clock = 1000;
 
 beforeEach(() => {
   clock = 1000;
+  resetRailGestureForTests();
   vi.spyOn(performance, "now").mockImplementation(() => clock);
 });
 
@@ -510,15 +515,17 @@ describe("useHorizontalPager — drag-scoped GPU promotion (#swipe-smoothness)",
     });
   }
 
-  it("promotes the rail to its own layer for the drag, drops it on settle end", () => {
+  it("promotes the rail at pointerdown, holds through the drag, drops on settle end", () => {
     const { getByTestId } = render(<Harness />);
     const rail = getByTestId("rail");
     act(() => {
       clock = 1000;
       fireEvent.pointerDown(rail, { ...touch, clientX: 800 });
-      // Axis still pending under the commit slop — no promotion yet.
-      expect(rail.style.willChange).toBe("");
-      // Cross the slop horizontally: the gesture commits to X and promotes.
+      // Armed at pointerdown — the compositor gets the whole slop window to
+      // build the layer before the first tracked frame — and the rail-gesture
+      // signal opens with it.
+      expect(rail.style.willChange).toBe("transform");
+      expect(isRailGestureActive()).toBe(true);
       fireEvent.pointerMove(rail, { ...touch, clientX: 770 });
     });
     expect(rail.style.willChange).toBe("transform");
@@ -529,24 +536,51 @@ describe("useHorizontalPager — drag-scoped GPU promotion (#swipe-smoothness)",
       fireEvent.pointerUp(rail, { ...touch, clientX: 400 });
     });
     expect(rail.style.willChange).toBe("transform");
-    // Dropped only once the settle transition has actually ended.
+    expect(isRailGestureActive()).toBe(true);
+    // Dropped only once the settle transition has actually ended; the
+    // rail-gesture signal releases on the same edge.
     endTransform(rail);
     expect(rail.style.willChange).toBe("");
+    expect(isRailGestureActive()).toBe(false);
   });
 
-  it("never promotes the rail for a vertical-committed gesture", () => {
+  it("drops the pointerdown promotion the moment a gesture commits VERTICAL", () => {
     const { getByTestId } = render(<Harness />);
     const rail = getByTestId("rail");
     act(() => {
       clock = 1000;
       fireEvent.pointerDown(rail, { ...touch, clientX: 500 });
-      // Vertical-dominant move: axis commits to Y, the rail must stay unpromoted.
+      expect(rail.style.willChange).toBe("transform");
+      expect(isRailGestureActive()).toBe(true);
+      // Vertical-dominant move: axis commits to Y — this is the widget list
+      // scrolling, not a rail pan, so the promotion (and the signal) must
+      // release immediately, not linger through the scroll.
       fireEvent.pointerMove(rail, { ...touch, clientX: 505, clientY: 400 });
+      expect(rail.style.willChange).toBe("");
+      expect(isRailGestureActive()).toBe(false);
       fireEvent.pointerMove(rail, { ...touch, clientX: 505, clientY: 500 });
       clock = 1120;
       fireEvent.pointerUp(rail, { ...touch, clientX: 505, clientY: 500 });
     });
     expect(rail.style.willChange).toBe("");
+    expect(isRailGestureActive()).toBe(false);
+  });
+
+  it("drops the pointerdown promotion after a plain tap (zero-delta settle, no transitionend)", () => {
+    const { getByTestId } = render(<Harness />);
+    const rail = getByTestId("rail");
+    act(() => {
+      clock = 1000;
+      fireEvent.pointerDown(rail, { ...touch, clientX: 500 });
+      expect(rail.style.willChange).toBe("transform");
+      clock = 1050;
+      // No movement: the settle writes the same transform back, so no
+      // transitionend will ever fire — finish() must drop the promotion (and
+      // release the signal) itself or it would leak until the next gesture.
+      fireEvent.pointerUp(rail, { ...touch, clientX: 500 });
+    });
+    expect(rail.style.willChange).toBe("");
+    expect(isRailGestureActive()).toBe(false);
   });
 
   it("drops the promotion when the surface unmounts mid-gesture", () => {

--- a/packages/ui/src/hooks/useHorizontalPager.ts
+++ b/packages/ui/src/hooks/useHorizontalPager.ts
@@ -13,6 +13,7 @@ import {
   useClickSuppression,
   useRafCoalescer,
 } from "../gestures";
+import { beginRailGesture, endRailGesture } from "../state/rail-gesture-store";
 
 // The pager's tuned axis/flick/edge values live in the shared gesture constants
 // module as named PAGER_* overrides (see gestures/constants.ts for why each
@@ -289,18 +290,33 @@ export function useHorizontalPager<
     if (!railPromotedRef.current) return;
     railPromotedRef.current = false;
     if (rail) rail.style.willChange = "";
+    // The gesture/settle window closed — release any consumer (live-widget
+    // flushes) parked on the rail-gesture signal.
+    endRailGesture();
   }, []);
   const armRailPromotion = React.useCallback(() => {
     const rail = railRef.current;
     if (!rail || railPromotedRef.current) return;
     // Reduced motion has no animated settle to composite — a pan that jumps
     // page-to-page never runs the transition, so the promotion would only ever
-    // be dropped by the next drag. Skip it entirely (matches #14501).
+    // be dropped by the next drag. Skip it entirely (matches #14501). The
+    // rail-gesture signal is skipped with it: with no promoted layer there is
+    // no re-rasterize cost to shield, and pausing widget updates would be pure
+    // staleness.
     if (prefersReducedMotion()) return;
     railPromotedRef.current = true;
     rail.style.willChange = "transform";
+    // Broadcast the gesture window so live-widget flushes inside the promoted
+    // layer can buffer until the settle ends (they'd repaint the moving
+    // surface mid-swipe otherwise).
+    beginRailGesture();
   }, []);
 
+  // Offset of the most recent transform write. Lets the settle paths detect a
+  // ZERO-DELTA write (a tap, or an abandoned drag that never moved): such a
+  // write changes nothing, so no `transitionend` will ever fire to drop the
+  // pointerdown-armed rail promotion — the caller must drop it directly.
+  const lastWrittenOffsetRef = React.useRef(0);
   const writeOffset = React.useCallback(
     (offset: number, transitionMs: number | null) => {
       const rail = railRef.current;
@@ -314,6 +330,7 @@ export function useHorizontalPager<
       rail.style.transition =
         ms == null ? "none" : `transform ${ms}ms ${SETTLE_EASING}`;
       rail.style.transform = `translate3d(${roundedPx(offset)},0,0)`;
+      lastWrittenOffsetRef.current = offset;
     },
     [],
   );
@@ -364,8 +381,20 @@ export function useHorizontalPager<
     // Re-measure: a viewport resize DURING the drag makes state.width stale, so
     // settling to pageOffset(page, staleWidth) would leave the rail permanently
     // mis-offset.
-    writeOffset(pageOffset(state.page, measureWidth()), SETTLE_MS);
-  }, [cancelScheduledOffset, measureWidth, releaseCapture, writeOffset]);
+    const target = pageOffset(state.page, measureWidth());
+    const noMove = Math.abs(target - lastWrittenOffsetRef.current) < 1;
+    writeOffset(target, SETTLE_MS);
+    // A no-move abandon (press, then the button released off-surface before any
+    // travel) writes the same transform back — no settle transition runs, so no
+    // `transitionend` will drop the pointerdown-armed promotion. Drop it here.
+    if (noMove) dropRailPromotion();
+  }, [
+    cancelScheduledOffset,
+    dropRailPromotion,
+    measureWidth,
+    releaseCapture,
+    writeOffset,
+  ]);
 
   React.useLayoutEffect(() => {
     const width = measureWidth();
@@ -433,6 +462,9 @@ export function useHorizontalPager<
       if (!railPromotedRef.current) return;
       railPromotedRef.current = false;
       if (rail) rail.style.willChange = "";
+      // Mirror dropRailPromotion: an unmount mid-gesture must also release
+      // consumers parked on the rail-gesture signal.
+      endRailGesture();
     };
   }, []);
 
@@ -602,8 +634,17 @@ export function useHorizontalPager<
         hadButtons: event.pointerType !== "touch" && event.buttons > 0,
       };
       writeOffset(baseOffset, null);
+      // Promote the rail NOW, not on the first horizontal-committed move frame:
+      // arming at pointerdown gives the compositor the whole slop window to
+      // build the layer before the first tracked translate, so the opening
+      // frames of a swipe composite instead of paying the promotion raster
+      // right when the finger starts moving. A gesture that commits VERTICAL
+      // drops the promotion immediately (see onPointerMove); a plain tap drops
+      // it in finish()'s zero-delta path. Reduced motion still skips inside
+      // armRailPromotion.
+      armRailPromotion();
     },
-    [cancelScheduledOffset, measureWidth, writeOffset],
+    [armRailPromotion, cancelScheduledOffset, measureWidth, writeOffset],
   );
 
   const onPointerMove = React.useCallback(
@@ -634,14 +675,13 @@ export function useHorizontalPager<
         const ay = Math.abs(dy);
         if (Math.max(ax, ay) < AXIS_COMMIT_SLOP) return;
         state.axis = ax > ay * AXIS_DOMINANCE_RATIO ? "horizontal" : "vertical";
-        // The gesture is now known to be a horizontal pan: promote the rail to
-        // its own compositor layer for the rest of the drag + settle so the
-        // finger-tracked translate (and the blurred/masked notification stack it
-        // carries) composites instead of repainting per frame (#swipe-
-        // smoothness). Armed here (first horizontal-committed frame), not on
-        // pointerdown, so a purely vertical scroll of the home widget list never
-        // needlessly promotes the rail. Dropped on the settle `transitionend`.
-        if (state.axis === "horizontal") armRailPromotion();
+        // The promotion was armed at pointerdown (so the compositor had the
+        // slop window to build the layer before the first tracked frame). A
+        // gesture that commits VERTICAL is the home widget list scrolling, not
+        // a rail pan — the rail will not move, so drop the layer (and release
+        // the rail-gesture signal) immediately instead of holding GPU memory
+        // and parked widget flushes through a scroll.
+        if (state.axis === "vertical") dropRailPromotion();
       }
       if (state.axis !== "horizontal") return;
 
@@ -673,7 +713,7 @@ export function useHorizontalPager<
       }
       scheduleOffset(state.baseOffset + visualDragOffset(state, dx));
     },
-    [abandonDrag, armRailPromotion, scheduleOffset, visualDragOffset],
+    [abandonDrag, dropRailPromotion, scheduleOffset, visualDragOffset],
   );
 
   const onPointerUp = React.useCallback(

--- a/packages/ui/src/state/rail-gesture-store.ts
+++ b/packages/ui/src/state/rail-gesture-store.ts
@@ -1,0 +1,102 @@
+/**
+ * Live "the home↔launcher rail is mid-gesture" signal, so render work that
+ * would re-rasterize the promoted rail layer (e.g. live-widget flushes from
+ * useActivityEvents) can park until the swipe settles.
+ *
+ * The window is exactly the pager's rail-promotion window: armed at
+ * pointerdown (useHorizontalPager.armRailPromotion), released when the settle
+ * transition ends / the gesture commits to the vertical axis / the surface
+ * unmounts (dropRailPromotion). Under prefers-reduced-motion the pager never
+ * promotes, so this never activates — matching that skip.
+ *
+ * Module-level store shared via globalThis (survives HMR + reachable from the
+ * pager's imperative gesture handlers outside any React subtree) +
+ * useSyncExternalStore, mirroring `shell-surface-store.ts`.
+ */
+import * as React from "react";
+
+interface RailGestureStore {
+  active: boolean;
+  /** performance.now()/Date.now() timestamp of the activating edge, so parked
+   *  consumers can bound staleness if a release edge is ever missed. */
+  since: number;
+  listeners: Set<() => void>;
+}
+
+function store(): RailGestureStore {
+  const g = globalThis as Record<PropertyKey, unknown>;
+  const k = Symbol.for("elizaos.ui.rail-gesture-store");
+  const existing = g[k] as RailGestureStore | undefined;
+  if (existing) return existing;
+  const created: RailGestureStore = {
+    active: false,
+    since: 0,
+    listeners: new Set(),
+  };
+  g[k] = created;
+  return created;
+}
+
+function now(): number {
+  return typeof performance !== "undefined" ? performance.now() : Date.now();
+}
+
+function commit(s: RailGestureStore, active: boolean): void {
+  if (s.active === active) return;
+  s.active = active;
+  s.since = active ? now() : 0;
+  for (const l of s.listeners) l();
+}
+
+// ── Imperative actions (called from the pager's gesture handlers) ────────────
+
+/** The rail entered its gesture/settle window. Idempotent. */
+export function beginRailGesture(): void {
+  commit(store(), true);
+}
+
+/** The rail's gesture window closed (settle ended / axis went vertical /
+ *  surface unmounted). Idempotent. */
+export function endRailGesture(): void {
+  commit(store(), false);
+}
+
+/** Read the signal imperatively (event handlers / non-React callers). */
+export function isRailGestureActive(): boolean {
+  return store().active;
+}
+
+/** Milliseconds the current gesture window has been open; 0 when inactive. */
+export function railGestureActiveMs(): number {
+  const s = store();
+  return s.active ? now() - s.since : 0;
+}
+
+/** Subscribe to activate/release edges. Returns the unsubscribe. */
+export function subscribeRailGesture(listener: () => void): () => void {
+  const s = store();
+  s.listeners.add(listener);
+  return () => s.listeners.delete(listener);
+}
+
+/** Reset to defaults. Test-only. */
+export function resetRailGestureForTests(): void {
+  const s = store();
+  s.active = false;
+  s.since = 0;
+  for (const l of s.listeners) l();
+}
+
+// ── React binding ─────────────────────────────────────────────────────────────
+
+export function useRailGestureActive(): boolean {
+  const s = store();
+  return React.useSyncExternalStore(
+    (l) => {
+      s.listeners.add(l);
+      return () => s.listeners.delete(l);
+    },
+    () => s.active,
+    () => false,
+  );
+}

--- a/packages/ui/src/state/useChatSend.test.tsx
+++ b/packages/ui/src/state/useChatSend.test.tsx
@@ -11,6 +11,8 @@ import { act, renderHook } from "@testing-library/react";
 import type { MutableRefObject } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
+  ChatToolCallEvent,
+  ChatTurnStatus,
   CodingAgentSession,
   Conversation,
   ConversationMessage,
@@ -596,6 +598,164 @@ describe("useChatSend always streams (#9174)", () => {
     expect(deps.setChatFirstTokenReceived).toHaveBeenCalledWith(true);
     // The streaming callback actually received incremental tokens.
     expect(tokens).toEqual([["Hello", " world"]]);
+  });
+});
+
+describe("useChatSend streaming-frame coalescing (text + status + tool)", () => {
+  let rafQueue: FrameRequestCallback[];
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.client.getBaseUrl.mockReturnValue("");
+    mocks.client.renameConversation.mockResolvedValue(undefined);
+    rafQueue = [];
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      rafQueue.push(cb);
+      return rafQueue.length;
+    });
+    vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+      rafQueue[id - 1] = () => {};
+    });
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function flushRaf(): number {
+    const q = rafQueue;
+    rafQueue = [];
+    act(() => {
+      for (const cb of q) cb(0);
+    });
+    return q.length;
+  }
+
+  it("parks token+status+tool from one SSE burst into a SINGLE frame, committing all three together", async () => {
+    // Capture the per-event callbacks from a stream that stays pending so the
+    // rAF frame can be observed BEFORE the terminal synchronous flush.
+    let onTokenCb!: (t: string, a?: string) => void;
+    let onStatusCb!: (s: ChatTurnStatus) => void;
+    let onToolCb!: (e: ChatToolCallEvent) => void;
+    let resolveStream!: (v: { text: string; completed: boolean }) => void;
+    mocks.client.sendConversationMessageStream.mockImplementation(
+      (
+        _id: string,
+        _text: string,
+        onToken: (t: string, a?: string) => void,
+        _channelType: string,
+        _signal: AbortSignal,
+        _images: unknown,
+        _metadata: unknown,
+        onStatus: (s: ChatTurnStatus) => void,
+        onTool: (e: ChatToolCallEvent) => void,
+      ) => {
+        onTokenCb = onToken;
+        onStatusCb = onStatus;
+        onToolCb = onTool;
+        return new Promise((resolve) => {
+          resolveStream = resolve;
+        });
+      },
+    );
+
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const setStatusSpy = deps.setServerTurnStatus as ReturnType<typeof vi.fn>;
+    const { result } = renderHook(() => useChatSend(deps));
+
+    let sendPromise: Promise<void> | undefined;
+    await act(async () => {
+      sendPromise = result.current.sendChatText("hi", {
+        conversationId: "conv-1",
+      });
+      // Let the send reach the streaming call and register the callbacks.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // One SSE burst: a token, a status phase, and a tool call all arrive in the
+    // same tick — before any frame runs.
+    act(() => {
+      onTokenCb("Search", "Search");
+      onStatusCb({ kind: "running_tool", toolName: "web_search" });
+      onToolCb({ phase: "call", callId: "c1", toolName: "web_search" });
+    });
+
+    // Nothing has committed yet: no text on the assistant turn, no status set,
+    // no tool rows — all three are parked for the single scheduled frame.
+    const assistantBefore = deps.conversationMessagesRef.current.find(
+      (m) => m.role === "assistant",
+    );
+    expect(assistantBefore?.text ?? "").toBe("");
+    expect(assistantBefore?.toolEvents ?? []).toHaveLength(0);
+    expect(setStatusSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "running_tool" }),
+    );
+
+    // Exactly one frame was scheduled for the whole burst; flushing it commits
+    // text, tool row, and status together.
+    const framesRun = flushRaf();
+    expect(framesRun).toBe(1);
+
+    const assistantAfter = deps.conversationMessagesRef.current.find(
+      (m) => m.role === "assistant",
+    );
+    expect(assistantAfter?.text).toBe("Search");
+    expect(assistantAfter?.toolEvents ?? []).toHaveLength(1);
+    expect(setStatusSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "running_tool", toolName: "web_search" }),
+    );
+
+    // Terminal transition: resolve the stream and drain.
+    await act(async () => {
+      resolveStream({ text: "Search done", completed: true });
+      await sendPromise;
+    });
+  });
+
+  it("flushes parked tool/status synchronously on the terminal transition even if no frame ran", async () => {
+    // A tool event + status arrive, then the stream resolves in the SAME tick
+    // before any rAF fires. The synchronous flushStreamingText() before the
+    // terminal modification must still commit them (no lost tool row / status).
+    mocks.client.sendConversationMessageStream.mockImplementation(
+      async (
+        _id: string,
+        _text: string,
+        onToken: (t: string, a?: string) => void,
+        _channelType: string,
+        _signal: AbortSignal,
+        _images: unknown,
+        _metadata: unknown,
+        onStatus: (s: ChatTurnStatus) => void,
+        onTool: (e: ChatToolCallEvent) => void,
+      ) => {
+        onToken("partial", "partial");
+        onStatus({ kind: "running_tool", toolName: "web_search" });
+        onTool({ phase: "call", callId: "c1", toolName: "web_search" });
+        // No rAF flush between here and return — the terminal path must flush.
+        return { text: "partial done", completed: true };
+      },
+    );
+
+    const deps = makeDeps({
+      activeConversationId: "conv-1",
+      conversations: [conversation("conv-1", "room-1")],
+    });
+    const setStatusSpy = deps.setServerTurnStatus as ReturnType<typeof vi.fn>;
+    const { result } = renderHook(() => useChatSend(deps));
+
+    await act(async () => {
+      await result.current.sendChatText("hi", { conversationId: "conv-1" });
+    });
+
+    // The tool row survived to the final thread (merged before the reload's
+    // no-op) and the status phase was committed at least once.
+    expect(setStatusSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "running_tool" }),
+    );
+    // Status is cleared to null when the turn settles.
+    expect(setStatusSpy).toHaveBeenLastCalledWith(null);
   });
 });
 

--- a/packages/ui/src/state/useChatSend.ts
+++ b/packages/ui/src/state/useChatSend.ts
@@ -11,6 +11,7 @@ import { asRecord } from "@elizaos/shared";
 import { type MutableRefObject, useCallback, useEffect, useRef } from "react";
 import type { Conversation, CustomActionDef } from "../api";
 import {
+  type ChatToolCallEvent,
   type ChatTurnStatus,
   type CodingAgentSession,
   type ConversationChannelType,
@@ -54,6 +55,12 @@ import {
 // ── Types ────────────────────────────────────────────────────────────
 
 const CONTEXT_ROUTING_METADATA_KEY = "__responseContext";
+
+// Sentinel for the streaming buffer's `pendingStatus`: "no status update
+// parked", distinct from a parked `null` (an explicit clear-the-status commit).
+// Module scope (not per-render) so the flush callbacks stay referentially
+// stable across renders.
+const NO_PENDING_STATUS = Symbol("no-pending-status");
 
 /** Derive the rendered-attachment kind for an optimistic bubble from its MIME. */
 function optimisticAttachmentKind(
@@ -688,33 +695,102 @@ export function useChatSend(deps: UseChatSendDeps) {
   const handoffFrozenRef = useRef(false);
 
   // Streaming-commit throttle.
-  // The SSE `onToken` callback fires once per token (often >60/sec on a fast
-  // model). Instead of committing each one, the latest cumulative text is parked
-  // here and applied at most once per animation frame. Chat sends are serialized
-  // through the queue, so a single in-flight buffer is sufficient.
+  // The SSE stream fires three per-event callbacks that each trigger a state
+  // commit: `onToken` (cumulative text, often >60/sec on a fast model),
+  // `onStatus` (live turn phase), and `onToolEvent` (inline tool-call steps).
+  // Committing each one synchronously means up to three React renders per SSE
+  // event; instead every callback parks its latest value here and a single rAF
+  // commits all three in ONE frame. Chat sends are serialized through the
+  // queue, so a single in-flight buffer is sufficient.
+  //
+  // `pendingStatus` uses the NO_PENDING_STATUS sentinel = "no status update
+  // parked", distinct from a parked `null` (an explicit clear-the-status
+  // commit).
   const streamingFlushRef = useRef<{
     messageId: string;
     pendingText: string | null;
+    pendingStatus: ChatTurnStatus | null | typeof NO_PENDING_STATUS;
+    pendingToolEvents: ChatToolCallEvent[];
     frameId: number | null;
-  }>({ messageId: "", pendingText: null, frameId: null });
+  }>({
+    messageId: "",
+    pendingText: null,
+    pendingStatus: NO_PENDING_STATUS,
+    pendingToolEvents: [],
+    frameId: null,
+  });
 
-  // Apply whatever cumulative text is parked for the in-flight turn, then clear
-  // the pending slot. Safe to call when nothing is pending (no-op).
+  // Commit whatever text/status/tool events are parked for the in-flight turn in
+  // one pass, then clear the pending slots. Order matters: tool events merge
+  // onto the same turn as the text, and the status is a sibling indicator — all
+  // three settle together so the frame reflects a single coherent stream state.
+  // Safe to call when nothing is pending (no-op).
+  const commitStreamingBuffer = useCallback(() => {
+    const buffer = streamingFlushRef.current;
+    if (buffer.pendingText !== null) {
+      const fullText = buffer.pendingText;
+      buffer.pendingText = null;
+      applyStreamingTextModification(setConversationMessages, {
+        messageId: buffer.messageId,
+        mode: "replace",
+        fullText,
+      });
+    }
+    if (buffer.pendingToolEvents.length > 0) {
+      const toolEvents = buffer.pendingToolEvents;
+      buffer.pendingToolEvents = [];
+      for (const event of toolEvents) {
+        applyStreamingTextModification(setConversationMessages, {
+          messageId: buffer.messageId,
+          mode: "tool",
+          event,
+        });
+      }
+    }
+    if (buffer.pendingStatus !== NO_PENDING_STATUS) {
+      const status = buffer.pendingStatus;
+      buffer.pendingStatus = NO_PENDING_STATUS;
+      setServerTurnStatus(status);
+    }
+  }, [setConversationMessages, setServerTurnStatus]);
+
+  // Apply whatever streaming state is parked for the in-flight turn NOW
+  // (synchronously) and cancel the pending frame — called before every terminal
+  // / abort transition so no token, tool row, or status is lost. Safe when
+  // nothing is pending (no-op).
   const flushStreamingText = useCallback(() => {
     const buffer = streamingFlushRef.current;
     if (buffer.frameId !== null) {
       cancelAnimationFrame(buffer.frameId);
       buffer.frameId = null;
     }
-    if (buffer.pendingText === null) return;
-    const fullText = buffer.pendingText;
+    commitStreamingBuffer();
+  }, [commitStreamingBuffer]);
+
+  // Reset the buffer to a fresh turn when `messageId` changes, dropping any
+  // stale parked state (text/status/tool) from the prior turn. Runs BEFORE a
+  // scheduler parks its value, so the reset never clobbers the value just set.
+  const startStreamingTurn = useCallback((messageId: string) => {
+    const buffer = streamingFlushRef.current;
+    if (buffer.messageId === messageId) return;
+    if (buffer.frameId !== null) cancelAnimationFrame(buffer.frameId);
+    buffer.messageId = messageId;
     buffer.pendingText = null;
-    applyStreamingTextModification(setConversationMessages, {
-      messageId: buffer.messageId,
-      mode: "replace",
-      fullText,
+    buffer.pendingStatus = NO_PENDING_STATUS;
+    buffer.pendingToolEvents = [];
+    buffer.frameId = null;
+  }, []);
+
+  // Ensure a single rAF is scheduled to commit whatever is currently parked.
+  // Repeated calls within a frame never schedule additional frames.
+  const ensureStreamingFrame = useCallback(() => {
+    const buffer = streamingFlushRef.current;
+    if (buffer.frameId !== null) return;
+    buffer.frameId = requestAnimationFrame(() => {
+      buffer.frameId = null;
+      commitStreamingBuffer();
     });
-  }, [setConversationMessages]);
+  }, [commitStreamingBuffer]);
 
   // Park the latest cumulative text for `messageId` and ensure a single rAF is
   // scheduled to commit it. Repeated calls within a frame overwrite the parked
@@ -722,28 +798,35 @@ export function useChatSend(deps: UseChatSendDeps) {
   // commit per frame.
   const scheduleStreamingText = useCallback(
     (messageId: string, fullText: string) => {
-      const buffer = streamingFlushRef.current;
-      // A new turn started — drop any stale parked text from the prior turn.
-      if (buffer.messageId !== messageId) {
-        if (buffer.frameId !== null) cancelAnimationFrame(buffer.frameId);
-        buffer.messageId = messageId;
-        buffer.frameId = null;
-      }
-      buffer.pendingText = fullText;
-      if (buffer.frameId !== null) return;
-      buffer.frameId = requestAnimationFrame(() => {
-        buffer.frameId = null;
-        if (buffer.pendingText === null) return;
-        const next = buffer.pendingText;
-        buffer.pendingText = null;
-        applyStreamingTextModification(setConversationMessages, {
-          messageId: buffer.messageId,
-          mode: "replace",
-          fullText: next,
-        });
-      });
+      startStreamingTurn(messageId);
+      streamingFlushRef.current.pendingText = fullText;
+      ensureStreamingFrame();
     },
-    [setConversationMessages],
+    [startStreamingTurn, ensureStreamingFrame],
+  );
+
+  // Park a live turn-status phase for `messageId`; the latest value wins within
+  // a frame (superseded phases are never rendered). Coalesced into the same
+  // frame as text/tool events (#8813).
+  const scheduleServerTurnStatus = useCallback(
+    (messageId: string, status: ChatTurnStatus | null) => {
+      startStreamingTurn(messageId);
+      streamingFlushRef.current.pendingStatus = status;
+      ensureStreamingFrame();
+    },
+    [startStreamingTurn, ensureStreamingFrame],
+  );
+
+  // Park one inline tool-call step for `messageId`. Unlike text/status these
+  // ACCUMULATE within a frame — each step (call → result/error) is a distinct
+  // merge onto the turn's `toolEvents`, so none may be dropped (#13535).
+  const scheduleToolEvent = useCallback(
+    (messageId: string, event: ChatToolCallEvent) => {
+      startStreamingTurn(messageId);
+      streamingFlushRef.current.pendingToolEvents.push(event);
+      ensureStreamingFrame();
+    },
+    [startStreamingTurn, ensureStreamingFrame],
   );
 
   // Cancel any in-flight frame on unmount so a late rAF never commits into a
@@ -756,6 +839,8 @@ export function useChatSend(deps: UseChatSendDeps) {
         buffer.frameId = null;
       }
       buffer.pendingText = null;
+      buffer.pendingStatus = NO_PENDING_STATUS;
+      buffer.pendingToolEvents = [];
     };
   }, []);
 
@@ -1363,16 +1448,14 @@ export function useChatSend(deps: UseChatSendDeps) {
           imagesToSend,
           turn.metadata,
           // Live server phase → the rich status indicator. Additive; the reply
-          // streams through onToken above regardless.
-          (status) => setServerTurnStatus(status),
+          // streams through onToken above regardless. Coalesced into the same
+          // rAF frame as the text/tool commits (flushed synchronously below
+          // before any terminal transition).
+          (status) => scheduleServerTurnStatus(assistantMsgId, status),
           // Inline tool-call steps → the turn's tool rows (call → result/error),
           // merged by callId so one row flips running → settled (#13535).
-          (event) =>
-            applyStreamingTextModification(setConversationMessages, {
-              messageId: assistantMsgId,
-              mode: "tool",
-              event,
-            }),
+          // Coalesced into the streaming frame with the text + status.
+          (event) => scheduleToolEvent(assistantMsgId, event),
           // Idempotency key — reused verbatim across the single auto-retry so a
           // send that landed during a blip is server-side de-duped.
           clientMessageId,
@@ -1645,13 +1728,9 @@ export function useChatSend(deps: UseChatSendDeps) {
               controller?.signal,
               imagesToSend,
               turn.metadata,
-              (serverStatus) => setServerTurnStatus(serverStatus),
-              (event) =>
-                applyStreamingTextModification(setConversationMessages, {
-                  messageId: replayAssistantId,
-                  mode: "tool",
-                  event,
-                }),
+              (serverStatus) =>
+                scheduleServerTurnStatus(replayAssistantId, serverStatus),
+              (event) => scheduleToolEvent(replayAssistantId, event),
               // Same idempotency key across the whole logical turn, including
               // the 404 recreate-and-replay recovery.
               clientMessageId,
@@ -1884,6 +1963,8 @@ export function useChatSend(deps: UseChatSendDeps) {
       elizaCloudConnected,
       pollCloudCredits,
       scheduleStreamingText,
+      scheduleServerTurnStatus,
+      scheduleToolEvent,
       flushStreamingText,
     ],
   );
@@ -2199,14 +2280,10 @@ export function useChatSend(deps: UseChatSendDeps) {
             undefined,
             buildChatViewMetadata(tab),
             // No overlay status on the action/DM path (its finally doesn't clear
-            // it); still stream inline tool rows onto the turn (#13535).
+            // it); still stream inline tool rows onto the turn (#13535),
+            // coalesced into the streaming frame with the text.
             undefined,
-            (event) =>
-              applyStreamingTextModification(setConversationMessages, {
-                messageId: assistantMsgId,
-                mode: "tool",
-                event,
-              }),
+            (event) => scheduleToolEvent(assistantMsgId, event),
           );
 
           // Commit any token parked by the throttle before the terminal
@@ -2350,6 +2427,7 @@ export function useChatSend(deps: UseChatSendDeps) {
       tab,
       uiLanguage,
       scheduleStreamingText,
+      scheduleToolEvent,
       flushStreamingText,
     ],
   );


### PR DESCRIPTION
## What

Six **safe-mechanical** streaming + launcher-gesture performance fixes, all in `packages/ui`. Companion needs-design items are filed as follow-ups (#15280, #15281, #15282).

| # | Fix | File(s) | Kind |
|---|-----|---------|------|
| 1 | ChatView legacy auto-scroll → shared `useThreadAutoScroll` engine | `components/pages/ChatView.tsx` | perf + correctness |
| 2 | `chat-message` `arePropsEqual` `toolEvents` memo hole | `components/composites/chat/chat-message.tsx` | correctness |
| 3 | `parseSegments` trigger-char pre-gate | `components/chat/message-parser-helpers.ts`, `widgets/inline-registry.tsx` | perf |
| 4 | rAF-coalesce tool/status SSE events | `state/useChatSend.ts` | perf |
| 5 | Freeze live-widget flushes during launcher rail gesture | `state/rail-gesture-store.ts` (new), `hooks/useHorizontalPager.ts`, `hooks/useActivityEvents.ts` | perf |
| 6 | Compositor hints (contain, pointerdown-arm, fetchpriority) | `components/shell/HomeLauncherSurface.tsx`, `hooks/useHorizontalPager.ts`, `components/views/ViewTileImage.tsx` | perf |

### 1 — ChatView legacy auto-scroll (highest visible desktop win)
The old effect re-read `scrollHeight`/`scrollTop`/`clientHeight` and called `el.scrollTo({ behavior: nearBottom ? "instant" : "smooth" })` on **every** `visibleMsgs` identity change — i.e. **every streamed rAF flush** — restarting a smooth scroll each frame and yanking scrolled-up readers. Replaced with the same shared engine `ContinuousChatOverlay` + `ChatSurface` use: pre-growth-height anti-yank (#12348), ≤1 rAF write/frame, never yanks a reader parked in history. Older-page-prepend anchoring stays owned by `useLoadOlderOnScroll` on the shared scroller node; the engine never fights it (a prepend leaves the reader off-bottom, so it doesn't follow).

### 2 — toolEvents memo hole (correctness)
`arePropsEqual` compared every `ChatMessageData` field **except** `toolEvents`, so a `mode:"tool"` stream update (new message object, identical compared fields) was swallowed by the memo and the running tool row never flipped to settled (#13535). Added the compare + a pinning test that fails without the fix.

### 3 — parseSegments pre-gate
Bail to a single text segment when the normalized text contains **none** of `` ` `` `[` `{` `<` before the multi-pass scan (permission parse, `[CONFIG]`, widget parsers, fenced-JSON `JSON.parse` per frame, JSONL patches, fenced code). Every region kind requires ≥1 gated char (documented in-file; the widget-marker contract is pinned in `inline-registry.tsx`). Typical streamed prose now skips ~8 passes per rAF flush.

### 4 — rAF-coalesce tool/status
`onStatus` → `setServerTurnStatus` and `onToolEvent` → `applyStreamingTextModification` each committed per SSE event. Parked beside `pendingText` in the existing `streamingFlushRef` buffer and committed in one frame. The **synchronous** flush before every terminal/abort transition now flushes tool/status too, so nothing is lost.

### 5 — freeze live-widget flushes during rail drag
New module-scope `rail-gesture-store` (mirrors `shell-surface-store` idiom) is driven by the pager's promotion window. `useActivityEvents` buffers its ring-buffer state commit while a gesture is active and flushes **once** on settle, so a WS activity event mid-swipe can't re-rasterize the promoted, moving rail layer. Time-capped so a missed release edge can never park the rail forever.

### 6 — compositor hints
(a) `contain: layout style paint` on each rail half. (b) Arm rail promotion at **pointerdown** (drop on vertical-axis commit / tap zero-delta settle / unmount) so the compositor has the whole slop window to build the layer. (c) `fetchpriority="low"` on launcher tile hero images (keeps `loading="eager" decoding="async"` intent — note: launcher tiles are glyph-only, so this applies to the catalog-card hero path).

## Tests

New/extended, all green:

- `chat-transcript.memoization.test.tsx` — tool-event lands → row re-renders; unchanged `toolEvents` reference → no re-render (fix 2, fails without the compare).
- `message-parser-helpers.test.ts` — gated-out prose returns one segment identical to before; each region kind (config, widget, fenced UiSpec, JSONL patch, fenced code, permission, analysis XML) still parses (fix 3).
- `useHorizontalPager.test.tsx` — pointerdown-arm + rail-gesture signal on; vertical-commit drop; tap zero-delta drop (fix 5/6b).
- `useActivityEvents.test.tsx` (new) — events during active gesture don't commit; settle flushes exactly once with latest state; safety-cap flush (fix 5).
- `useChatSend.test.tsx` — token+status+tool from one SSE burst park into a **single** frame committing all three together; terminal transition flushes parked tool/status synchronously (fix 4).
- Existing perf-lock suites green: `chat-transcript.render-count`, `chat-transcript.memoization`, `useThreadAutoScroll`, `useStreamingText`, parser suites.

## Interaction-framerate KPI (perf-interaction-kpi.spec.ts)

<!-- KPI_TABLE -->
**Best-effort — headless synthetic environment, signal dominated by noise; proof carried by the unit deltas below.**

The `perf-interaction-kpi` harness self-builds a cold dev renderer and runs the **mobile continuous-overlay** shell under headless Chromium on a shared VPS. rAF is capped ~60fps and the box is contended, so run-to-run variance on *identical* code swamps any realistic delta: two "after" runs of the same commit gave `live-token-stream` **23fps / p95 83ms** and **19fps / p95 100ms** — a 17ms p95 swing with no code change. A single before/after pair here is not a trustworthy signal, and the develop-baseline build did not complete in the window.

After-branch measurement run (all 5 scenarios, this commit):

| scenario | fps | p95 (ms) | worst (ms) |
|---|---|---|---|
| live-token-stream | 19–23 | 83–100 | 133–167 |
| transcript-scroll | 26 | 66.7 | 83.4 |
| sheet-open-close | 32 | 50.0 | 66.7 |
| sheet-drag | 25 | 66.7 | 83.4 |
| chat-to-settings | 50 | 33.3 | 50.0 |

Note this spec exercises the **mobile overlay**, not the desktop `ChatView` that Fix 1 targets — so it only covers fixes 2/3/4 (shared streaming path) and 5/6 (gesture). The load-bearing proof is the **deterministic unit assertions**, which are not subject to headless noise:

- **Fix 2** — `chat-transcript.memoization.test.tsx`: a tool event lands → the row re-renders (fails without the `toolEvents` compare); an unchanged `toolEvents` reference → **0** extra row renders. Genuine dropped-update bug, now covered.
- **Fix 3** — `message-parser-helpers.test.ts`: gated-out prose returns one segment (skips ~8 regex/JSON passes per flush); every region kind still parses.
- **Fix 4** — `useChatSend.test.tsx`: a token+status+tool SSE burst commits in **one** rAF frame (was up to 3 React commits/event); terminal transition flushes parked tool/status synchronously (no loss).
- **Fix 1** — `useThreadAutoScroll.test.tsx` + `chat-transcript.render-count.test.tsx`: ≤1 scroll write/frame, no yank of a scrolled-up reader (replaces the per-flush `scrollTo` that restarted a smooth scroll every streamed frame).
- **Fix 5** — `useActivityEvents.test.tsx`: events during an active rail gesture commit **0** times; settle flushes **exactly once** with the latest state.
- **Fix 6** — `useHorizontalPager.test.tsx`: promotion armed at pointerdown, dropped on vertical-commit / tap / unmount.

## Verification

- `packages/ui` `tsc --noEmit`: **clean (exit 0)**.
- Biome check on all touched files: **clean**.
- Unit/integration suites above: **green**.
- App-level typecheck errors in this worktree are pre-existing sibling-dist resolution noise (unbuilt `@elizaos/core`/`agent`/`auth` dists; app resolving `@elizaos/ui` to source) — none reference any touched file; all changes are `packages/ui`-only.

## Follow-ups (needs-design, deferred)

- #15280 — incremental prefix-cached `parseSegments` for streaming tails (O(len²) → O(delta))
- #15281 — window `ChatView` transcript like the overlay's 80→400 reveal window
- #15282 — throttle WebGL wallpaper rAF during rail gestures

🤖 Generated with [Claude Code](https://claude.com/claude-code)