### PR TITLE
fix(app): split baked launcher-icon blob out of the eager entry chunk (loadperf gate)

### DIFF
--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1438,6 +1438,21 @@ function resolveManualChunk(id: string): string | undefined {
     return "runtime-shims";
   }
 
+  // The baked launcher-icon map (`view-icons.generated.ts`) is ~900 KB of
+  // base64 PNG data URIs — a self-contained data blob (no imports) that the
+  // launcher preloads so tiles never show a loading/empty state. It is
+  // statically reachable from the eager entry (App → LauncherSurface →
+  // view-catalog → this map), so Rollup otherwise folds all ~630 KB brotli of
+  // it into the app-logic `index` entry chunk, making that single chunk the
+  // largest in the bundle and blowing the `largestChunkBrotli` budget. Pinning
+  // it to its own chunk keeps the icons eagerly preloaded (design intent
+  // preserved) while splitting the immutable data payload off the frequently-
+  // changing app-logic chunk, so it caches independently and no longer
+  // dominates the entry. Mirrors the vendor-* splits below.
+  if (normalizedId.includes("/components/views/view-icons.generated")) {
+    return "view-icons";
+  }
+
   // Self-contained leaf libraries needed EAGERLY by @elizaos/core's browser
   // SOURCE graph (`utils/crypto-compat.ts` → @noble; runtime/services → uuid),
   // which mobile builds bundle via USE_CORE_SOURCE_BROWSER_ENTRY, and that the


### PR DESCRIPTION
## What / why

The **Client Tests** lane fails the loadperf bundle gate:

```
FAIL  largestChunkBrotli: 1800.8 KB / budget 1562.5 KB
```

The app-logic `index` entry chunk carries **two** large eager payloads:

1. **~632 KB brotli** — the baked launcher-icon data blob
   `packages/ui/src/components/views/view-icons.generated.ts` (~900 KB of
   base64 PNG data URIs). It is statically reachable from the eager entry
   (`main → App → LauncherSurface → view-catalog → this map`), so it has
   always been inlined into the entry chunk.
2. **~574 KB brotli** — the `@elizaos/core` browser bundle. This is the
   **regression**: at the 2026-07-02 CI baseline (largest chunk 1359.2 KB,
   PASS) core lived inside the then-**eager** `vendor-crypto` chunk. Once
   `vendor-crypto` was moved off the eager path (a good eager-graph
   optimization, now enforced by `verify-chunk-safety.mjs`'s boot-eagerness
   guard), Rollup could no longer keep the eagerly-required core bundle in the
   now-**lazy** `vendor-crypto` chunk and hoisted it into the `index` entry
   chunk. That +574 KB (net of ~130 KB of removed tutorial/help views) pushed
   the entry from 1359 → 1800 KB.

## Fix

Add one `manualChunks` rule pinning `view-icons.generated.ts` to its own
`view-icons` chunk. It is a self-contained, import-free **data** module, so
this cannot form a cross-chunk init cycle (unlike the delicate core/crypto
graph, which is intentionally left untouched). The entry still statically
imports the new chunk and it stays `modulepreload`ed, so the icons remain
**eagerly preloaded** — no loading/empty state, design intent preserved. The
immutable icon payload now caches independently of the frequently-changing
app-logic chunk instead of dominating it.

## Before / after (`bun run check:loadperf-bundle`, local, brotli)

| check | before | after | budget |
| --- | --- | --- | --- |
| **largestChunkBrotli** | **1800.8 KB FAIL** | **1168.3 KB PASS** | 1562.5 KB |
| initialEntryBrotli | 1884.7 KB | 1884.5 KB | 3183.6 KB |
| eagerGraphBrotli | 2632.8 KB | 2633.0 KB | 3252.0 KB |
| totalAssetsBrotli | 5071.5 KB | 5074.0 KB | 5859.4 KB |
| maxDuplicateLibBytes | 0.0 KB | 0.0 KB | 24.4 KB |

`largest chunk: index-*.js  1800.8 KB` → `index-*.js  1168.3 KB` (new
`view-icons-*.js` 632.3 KB is its own eagerly-preloaded chunk).

The budget is a regression gate and is **not** raised.

## Validation

- `bun run --cwd packages/app build:web` succeeds; `verify-chunk-safety.mjs`
  crypto-confinement + boot-eagerness guards pass.
- Static-serve boot smoke: `index.html` + entry chunk + `view-icons` chunk all
  serve 200 and parse as valid ESM.
- Entry chunk statically imports `view-icons-*.js` and it is `modulepreload`ed
  → icons still eager (no behavior change).
- `biome check` clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)