### PR TITLE
fix(ci): source-alias @elizaos/cloud-routing in view-test vitest configs

### DIFF
--- a/plugins/plugin-app-control/vitest.config.ts
+++ b/plugins/plugin-app-control/vitest.config.ts
@@ -8,6 +8,10 @@ import { defineConfig } from "vitest/config";
 
 const sharedSrc = path.resolve(__dirname, "../../packages/shared/src");
 const coreSrc = path.resolve(__dirname, "../../packages/core/src");
+const cloudRoutingSrc = path.resolve(
+	__dirname,
+	"../../packages/cloud/routing/src",
+);
 const loggerSrc = path.resolve(__dirname, "../../packages/logger/src");
 const tuiSrc = path.resolve(__dirname, "../../packages/tui/src");
 const uiSrc = path.resolve(__dirname, "../../packages/ui/src");
@@ -138,6 +142,15 @@ export default defineConfig({
 			{
 				find: "@elizaos/core",
 				replacement: path.join(coreSrc, "index.node.ts"),
+			},
+			// Core's src re-exports the cloud routing surface from
+			// `@elizaos/cloud-routing`, which ships no dist. With @elizaos/core
+			// pinned to source above, that re-export only resolves when
+			// cloud-routing is source-aliased too — otherwise vite falls through
+			// to its missing `dist/index.js` and fails to resolve the entry.
+			{
+				find: "@elizaos/cloud-routing",
+				replacement: path.join(cloudRoutingSrc, "index.ts"),
 			},
 			{
 				find: "@elizaos/logger",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -113,6 +113,20 @@ export default defineConfig({
         replacement: path.join(root, "packages/cloud/sdk/src/$1"),
       },
       {
+        // Core's src re-exports the cloud routing surface from
+        // `@elizaos/cloud-routing` (packages/core/src/cloud-routing.ts), which
+        // ships no dist. With @elizaos/core source-aliased above, that re-export
+        // only resolves when cloud-routing is pinned to source too — otherwise
+        // vite falls through to its `dist/index.js` entry and fails with
+        // "Failed to resolve entry for @elizaos/cloud-routing".
+        find: /^@elizaos\/cloud-routing$/,
+        replacement: path.join(root, "packages/cloud/routing/src/index.ts"),
+      },
+      {
+        find: /^@elizaos\/cloud-routing\/(.+)$/,
+        replacement: path.join(root, "packages/cloud/routing/src/$1"),
+      },
+      {
         find: /^@elizaos\/tui$/,
         replacement: path.join(root, "packages/tui/src/index.ts"),
       },


### PR DESCRIPTION
## Problem

The **Tests** workflow fan-out started actually running (skip-cascade fix #15222) for the first time since ~June 18, and the views suites failed to **even load**:

- **Server Tests**: whole-file failures for `views-system-smoke.test.ts`, `views-registry-integration.test.ts`, `plugin-tui-view-coverage.test.ts` — `Error: Failed to resolve entry for package "@elizaos/cloud-routing"`.
- **Zero-Key diagnostics**: `views-management.test.ts` — reported as a vitest `vi.mock` hoisting error whose underlying cause is the same cloud-routing resolve failure.

## Root cause

Core's src now re-exports the cloud routing surface from `@elizaos/cloud-routing` (`packages/core/src/cloud-routing.ts`, #12092 item 28). That workspace package **ships no dist**. Both the root `vitest.config.ts` (which the Server Tests job uses — it runs the agent view suites with no `--config`) and `plugins/plugin-app-control`'s standalone config source-alias `@elizaos/core` but **not** cloud-routing, so vite fell through to its missing `dist/index.js` entry and failed to resolve — taking down the whole suite before any test ran.

## Fix

Add the `@elizaos/cloud-routing` source alias to both vitest configs, mirroring the existing `@elizaos/cloud-sdk` alias already present in each. Config-only, 2 files.

The in-suite harness drift these lanes also carried (interact-route targeted-delivery protocol, `agent-surface` capability gate, removed `plugin-shopify` manifest) was fixed separately on `develop` by `fc97537018f`; with that plus this alias, all four lanes pass.

## Validation (local, CI-style)

Run exactly as CI does — root config, no `--config`, after `ensure-shared-i18n-data`:

- Server Tests trio: **74 passed (74)** — `views-system-smoke` 31, `views-registry-integration` 37, `plugin-tui-view-coverage` 6.
- Zero-Key `views-management.test.ts`: **42 passed (42)**.
- `biome check` clean; `error-policy-ratchet` clean (0 changed production source files).

## Out of scope — separate regression

**XR harness e2e** fails for an unrelated reason: `plugin-xr` was removed from `develop`, but `plugins/plugin-facewear/emulator/src/*` re-export it as the canonical XR emulator (issue #9941) and `test.yml`'s XR job `cd`s into `plugins/plugin-xr/simulator` — so the facewear emulator can't build and the job aborts at its first step. That is a missing-package repo-integrity regression (restore `plugin-xr` or complete its removal across facewear + `test.yml`), not view-test drift, and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)