### PR TITLE
fix(ci): green cloud unit-tests — pin lane to in-process PGlite + resolve test/schema drift

### DIFF
--- a/packages/cloud/api/v1/eliza/agents/[agentId]/pairing-token/route.test.ts
+++ b/packages/cloud/api/v1/eliza/agents/[agentId]/pairing-token/route.test.ts
@@ -166,7 +166,11 @@ describe("eliza agent pairing token route", () => {
     });
   });
 
-  test("falls back to the headscale direct Web UI URL when bridge_url is missing", async () => {
+  test("skips a browser-unreachable tailnet headscale URL and falls back to the public managed hostname", async () => {
+    // headscale IPs live on the 100.64/10 tailnet (CGNAT) our containers run on;
+    // a browser can never reach one, so the direct-headscale rung is filtered and
+    // the route must fall back to the public managed hostname (never a dead
+    // http://100.64.x.x redirect).
     findByIdAndOrg.mockResolvedValue({
       ...runningSandbox("dedicated-lazy"),
       bridge_url: null,
@@ -180,7 +184,8 @@ describe("eliza agent pairing token route", () => {
       success: true,
       data: {
         token: "pair-token",
-        redirectUrl: "http://100.64.0.12:19028/pair?token=pair-token",
+        redirectUrl:
+          "https://e06bb509-6c52-4c33-a9f7-66addc43e8c8.elizacloud.ai/pair?token=pair-token",
         expiresIn: 60,
       },
     });

--- a/packages/cloud/shared/src/lib/services/__tests__/ad-campaign-bid-strategy.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/ad-campaign-bid-strategy.test.ts
@@ -164,8 +164,16 @@ describe("advertisingService bid controls persistence", () => {
     const provider = stubProvider();
     const createOnProvider = track(spyOn(provider, "createCampaign"));
     track(spyOn(advertisingService, "getProvider").mockReturnValue(provider));
+    // createCampaign persists via the spend-cap-checked atomic create, not the
+    // bare create(); mock that variant with its { status, campaign } result.
     const createRow = track(
-      spyOn(adCampaignsRepository, "create").mockImplementation(async (data) => data as never),
+      spyOn(adCampaignsRepository, "createWithAccountSpendCapCheck").mockImplementation(
+        async (data) =>
+          ({
+            status: "created",
+            campaign: { ...(data as Record<string, unknown>), id: "campaign-row-1" },
+          }) as never,
+      ),
     );
     track(spyOn(adTransactionsRepository, "create").mockResolvedValue({} as never));
 

--- a/packages/cloud/shared/src/lib/services/__tests__/ad-campaign-dayparting.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/ad-campaign-dayparting.test.ts
@@ -301,7 +301,7 @@ describe("updateCampaign on an unsynced campaign", () => {
         name: "Renamed",
         dayparting: schedule,
       }),
-    ).rejects.toThrow("only dayparting can be updated before sync");
+    ).rejects.toThrow("only dayparting and spend caps can be updated before sync");
 
     expect(update).not.toHaveBeenCalled();
   });

--- a/packages/cloud/shared/src/lib/services/__tests__/container-billing-idempotency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/container-billing-idempotency.test.ts
@@ -96,7 +96,8 @@ beforeAll(async () => {
         description text,
         metadata jsonb NOT NULL DEFAULT '{}',
         stripe_payment_intent_id text,
-        created_at timestamp NOT NULL DEFAULT now()
+        created_at timestamp NOT NULL DEFAULT now(),
+        settled_at timestamp
       )`,
       `CREATE TABLE IF NOT EXISTS containers (
         id uuid PRIMARY KEY,

--- a/packages/cloud/shared/src/lib/services/__tests__/credits-deduct-guard.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/credits-deduct-guard.test.ts
@@ -124,7 +124,8 @@ beforeAll(async () => {
         description text,
         metadata jsonb NOT NULL DEFAULT '{}',
         stripe_payment_intent_id text,
-        created_at timestamp NOT NULL DEFAULT now()
+        created_at timestamp NOT NULL DEFAULT now(),
+        settled_at timestamp
       )`,
       // The refund/credit path's `applyCreditIncrease` uses
       // `ON CONFLICT (stripe_payment_intent_id) DO NOTHING`, which requires this

--- a/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.test.ts
+++ b/packages/cloud/shared/src/lib/services/advertising/providers/linkedin.test.ts
@@ -601,9 +601,15 @@ describe("advertisingService with the LinkedIn provider", () => {
         "getCredentials",
       ).mockResolvedValue({ accessToken: "linkedin-token" } as never),
     );
+    // createCampaign persists via the spend-cap-checked atomic create, not the
+    // bare create(); mock that variant with its { status, campaign } result.
     const createRow = track(
-      spyOn(adCampaignsRepository, "create").mockImplementation(
-        async (data) => ({ ...(data as Record<string, unknown>), id: "campaign-row-1" }) as never,
+      spyOn(adCampaignsRepository, "createWithAccountSpendCapCheck").mockImplementation(
+        async (data) =>
+          ({
+            status: "created",
+            campaign: { ...(data as Record<string, unknown>), id: "campaign-row-1" },
+          }) as never,
       ),
     );
     track(spyOn(adTransactionsRepository, "create").mockResolvedValue({} as never));

--- a/packages/scripts/test-cloud-run.mjs
+++ b/packages/scripts/test-cloud-run.mjs
@@ -27,8 +27,20 @@ writeFileSync(
   "[test]\ntimeout = 120000\ncoverage = false\n",
 );
 
+// The unit lane runs with NO database service (Cloud Tests → unit-tests calls
+// cloud-setup-test-env without setup-db). DB-touching suites are built to fall
+// back to in-process PGlite, but that fallback only engages when DATABASE_URL is
+// empty or `pglite://` — and the Cloud Tests workflow sets a real
+// `postgresql://…:5432` URL at the workflow level, which every job inherits.
+// Left as-is, that ambient URL points every suite at a Postgres socket nothing
+// is listening on: the isolated-PGlite guards disable themselves (their loud
+// "pglite applied" assertions fail) and the raw-SQL suites hit ECONNREFUSED.
+// Pin the unit lane to in-process PGlite so it is self-contained; suites that
+// need a networked DB opt out via SKIP_DB_DEPENDENT.
 const env = {
   ...process.env,
+  DATABASE_URL: "pglite://memory",
+  TEST_DATABASE_URL: "pglite://memory",
   SKIP_DB_DEPENDENT: "1",
   SKIP_SERVER_CHECK: "true",
 };


### PR DESCRIPTION
## Problem

`Cloud Tests → unit-tests` was red (19 failing tests across 13 files).

Root cause for the bulk: the `unit-tests` job inherits a real `DATABASE_URL` (`postgresql://…:5432`) from the workflow-level `env` but never provisions a DB (`cloud-setup-test-env` is called **without** `setup-db`). DB-touching cloud unit suites are built to fall back to in-process PGlite, but that fallback only engages when `DATABASE_URL` is empty or `pglite://`. The ambient real URL defeated it — isolated-PGlite guards disabled themselves (their loud `pglite applied` assertions failed) and raw-SQL suites hit `ECONNREFUSED`.

## Fix

Pin the unit lane to `pglite://memory` in `test-cloud-run.mjs` — the same thing `vitest.config.ts` already does for the vitest step, and it also makes local `bun run test:cloud` self-contained. Scoped to the unit lane only (`test:cloud:integration`/`:e2e` use separate runners and still provision a real DB).

That greens the env-driven failures: `app-frontend-deployments`, `embeddings-affiliate-clamp`, `domains-buy-cross-app-replay`, `ad-inventory-public-routes`, and the `stripe-connect`/`bluebubbles` dedupe suites.

## Per-test root cause (product vs test/schema drift)

| Test(s) | Root cause | Verdict |
|---|---|---|
| pglite-harness + raw-SQL suites (6 files) | ambient real `DATABASE_URL` in a no-DB lane defeated the in-process-PGlite fallback | **env drift** — pin lane to `pglite://memory` |
| `ad-campaign-dayparting` "only dayparting…before sync" | product now allows dayparting **and spend caps** pre-sync; test knew only the old substring | **test drift** — updated assertion |
| `pairing-token` "…headscale direct…" | product filters browser-unreachable CGNAT `100.64/10` headscale URLs and falls back to the public managed hostname (no more dead `http://100.64.x.x` redirect) | **test drift** — updated to assert the guard |
| `container-billing-idempotency`, `credits-deduct-guard` (reconcile) | hand-written `credit_transactions` DDL missing `settled_at` (added by migration `0165`); reconcile/settlement SQL selects it → `column settled_at does not exist` | **schema drift** in test DDL — added the column |
| `ad-campaign-bid-strategy`, `linkedin` (#11621) | `createCampaign` now persists via atomic `createWithAccountSpendCapCheck`, not `create()`; tests still mocked `create()`, so the real spend-cap-checked variant hit the DB | **test drift** — mock the current method |

**Security note:** the money-out fail-open Decimal gate (`redeemable-earnings-numeric`) was **already green** — that fragment came from a stale run. No security assertion was weakened; the fail-closed money-out guards remain intact.

## Validation

All 13 previously-failing files pass locally under the fix env (`DATABASE_URL=pglite://memory`), verified file-by-file, plus a full `bun run test:cloud` run clean (0 failures). Change is test-layer + the unit-lane runner env contract only — no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)