### PR TITLE
fix(ci): pr-evidence reads changed files via the paginated files API

### DIFF
--- a/scripts/pr-evidence.mjs
+++ b/scripts/pr-evidence.mjs
@@ -173,7 +173,15 @@ async function runGate(pr, body) {
     "-q",
     "[.labels[].name]|join(\",\")",
   ]).trim();
-  const changedFiles = gh(["pr", "diff", String(pr), "--name-only"])
+  // `gh pr diff` 406s past GitHub's 300-file diff cap (hit live on the 350-file
+  // #15291); the paginated files API has no such limit.
+  const changedFiles = gh([
+    "api",
+    `repos/{owner}/{repo}/pulls/${pr}/files`,
+    "--paginate",
+    "-q",
+    ".[].filename",
+  ])
     .split("\n")
     .filter(Boolean);
   const addedFiles = gh([


### PR DESCRIPTION
# Relates to

Evidence-pipeline series (#15219, #15241). Hit live while attaching evidence to the 350-file #15291.

# Risks

None — swaps one read path in a CLI helper.

# Background

## What does this PR do?

`gh pr diff --name-only` returns HTTP 406 past GitHub's 300-file diff cap,
crashing `evidence:pr rows`/`verify` on large PRs. The paginated
`pulls/{n}/files` API has no such limit; the helper now reads changed files
from it.

## What kind of change is this?

Bug fix (tooling).

# Testing

## Detailed testing steps

`node scripts/pr-evidence.mjs verify 15291` (350 files) → gate verdict instead of a 406 crash.

# Evidence Gate

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - CLI helper, no UI surface`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - CLI helper, no UI surface`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no UI flow`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: live verify against the 350-file #15291 prints all rows + "Evidence gate PASSES" (previously: HTTP 406 crash) — reproduced in the [#15291 evidence assets](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15291-acceptance-greps.txt) flow.
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs `N/A - no frontend path`.
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - deterministic CLI change`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: [15291's attached evidence set](https://github.com/elizaOS/eliza/releases/tag/pr-evidence) uploaded through the fixed path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
