### PR TITLE
fix(ci): green the Windows app-and-cli shard (app-core resolution, catalog drift, path/CRLF portability)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
-*.patch whitespace=-blank-at-eol
+*.patch -text whitespace=-blank-at-eol
+# Patch bytes are hashed (patches/CHECKSUMS.sha256) and applied verbatim by bun,
+# so they must stay byte-identical across platforms — never let a Windows
+# checkout (autocrlf) rewrite them to CRLF.
+patches/CHECKSUMS.sha256 -text

--- a/packages/app-core/src/alias-env-reads.13422.test.ts
+++ b/packages/app-core/src/alias-env-reads.13422.test.ts
@@ -105,10 +105,14 @@ describe("agent-vault-id state dir (ELIZA_STATE_DIR + ELIZA_NAMESPACE)", () => {
   it("derives the canonical state dir from a branded MILADY_STATE_DIR without the mirror", () => {
     process.env.MILADY_STATE_DIR = "/var/milady/state";
 
-    expect(resolveCanonicalStateDir()).toBe("/var/milady/state");
+    // resolveCanonicalStateDir path.resolve()s the dir, so on Windows the POSIX
+    // literal canonicalizes to a drive-anchored path (D:\var\milady\state).
+    // Assert against the same resolution so the check is platform-portable.
+    const expected = path.resolve("/var/milady/state");
+    expect(resolveCanonicalStateDir()).toBe(expected);
     // The vault id is a deterministic hash of that resolved dir — proves the
     // branded value actually flowed into the keychain namespace.
-    expect(deriveAgentVaultId()).toBe(deriveAgentVaultId("/var/milady/state"));
+    expect(deriveAgentVaultId()).toBe(deriveAgentVaultId(expected));
     // Security property: the read must not synthesize the ELIZA_ mirror.
     expect(process.env.ELIZA_STATE_DIR).toBeUndefined();
   });
@@ -117,7 +121,7 @@ describe("agent-vault-id state dir (ELIZA_STATE_DIR + ELIZA_NAMESPACE)", () => {
     process.env.ELIZA_STATE_DIR = "/var/eliza/state";
     process.env.MILADY_STATE_DIR = "/var/milady/state";
 
-    expect(resolveCanonicalStateDir()).toBe("/var/eliza/state");
+    expect(resolveCanonicalStateDir()).toBe(path.resolve("/var/eliza/state"));
   });
 
   it("derives the state dir from a branded MILADY_NAMESPACE", () => {

--- a/packages/app-core/src/api/dev-route-catalog.ts
+++ b/packages/app-core/src/api/dev-route-catalog.ts
@@ -240,8 +240,10 @@ const ROUTES: DevRouteEntry[] = [
     platformGate: null,
   },
   {
+    // My Apps is the canonical `/apps` destination (mirrors TAB_PATHS in
+    // packages/ui/src/navigation; the launcher grid lives at `/views`).
     tabId: "my-apps",
-    path: "/apps/my-apps",
+    path: "/apps",
     label: "My Apps",
     group: "Apps",
     visibility: "all",

--- a/packages/app-core/test/capacitor-ios-boot-eval-guard.test.ts
+++ b/packages/app-core/test/capacitor-ios-boot-eval-guard.test.ts
@@ -148,7 +148,9 @@ describe("@capacitor/ios boot-time resume/pause eval guard (issue #11030)", () =
       "utf8",
     );
     const entry = checksums
-      .split("\n")
+      // Split on \r?\n so a CRLF checkout (Windows autocrlf) doesn't leave a
+      // trailing \r that defeats the endsWith match.
+      .split(/\r?\n/)
       .find((line) =>
         line.endsWith(`./@capacitor%2Fios@${declaredVersion}.patch`),
       );

--- a/packages/app-core/test/live-agent/automations-compat-routes.test.ts
+++ b/packages/app-core/test/live-agent/automations-compat-routes.test.ts
@@ -171,7 +171,14 @@ function buildRuntimeStub() {
   return {
     character: { name: "Eliza" },
     actions: [
-      { name: "CODE_TASK", description: "Run a coding agent task." },
+      {
+        name: "CODE_TASK",
+        description: "Run a coding agent task.",
+        // Mirror the real coding-delegation action's classification tags
+        // (tasksAction in plugin-agent-orchestrator) so classifyRuntimeActionNode
+        // surfaces this as an "agent" node rather than a plain "action".
+        tags: ["domain:agent-orchestration", "capability:delegate"],
+      },
       {
         name: "MESSAGE",
         description: "Send, read, search, or manage messages.",

--- a/packages/app-core/vitest.config.ts
+++ b/packages/app-core/vitest.config.ts
@@ -123,6 +123,20 @@ const pluginWorkflowSrc = path.join(
   "plugins/plugin-workflow/src",
 );
 const pluginX402Src = path.join(monorepoRoot, "plugins/plugin-x402/src");
+// Optional static plugins imported by
+// packages/agent/src/runtime/optional-plugin-imports.generated.ts. The Windows
+// CI app-and-cli shard runs vitest without a plugin build, so these must resolve
+// to source here like every other package in OPTIONAL_PLUGIN_IMPORTERS —
+// otherwise Vite fails the whole suite at `Failed to resolve entry for package`.
+const pluginNativeFilesystemSrc = path.join(
+  monorepoRoot,
+  "plugins/plugin-native-filesystem/src",
+);
+const pluginSchedulingSrc = path.join(
+  monorepoRoot,
+  "plugins/plugin-scheduling/src",
+);
+const pluginInboxSrc = path.join(monorepoRoot, "plugins/plugin-inbox/src");
 // Resolve react/react-dom from the location of this config file so the alias
 // works whether react is hoisted to the monorepo root or installed locally.
 // createRequire resolves through the normal Node resolution algorithm (walks up
@@ -360,6 +374,30 @@ export default defineConfig({
       {
         find: /^@elizaos\/plugin-background-runner$/,
         replacement: path.join(pluginBackgroundRunnerSrc, "index.ts"),
+      },
+      {
+        find: /^@elizaos\/plugin-native-filesystem$/,
+        replacement: path.join(pluginNativeFilesystemSrc, "index.ts"),
+      },
+      {
+        find: /^@elizaos\/plugin-native-filesystem\/(.+)$/,
+        replacement: path.join(pluginNativeFilesystemSrc, "$1"),
+      },
+      {
+        find: /^@elizaos\/plugin-scheduling$/,
+        replacement: path.join(pluginSchedulingSrc, "index.ts"),
+      },
+      {
+        find: /^@elizaos\/plugin-scheduling\/(.+)$/,
+        replacement: path.join(pluginSchedulingSrc, "$1"),
+      },
+      {
+        find: /^@elizaos\/plugin-inbox$/,
+        replacement: path.join(pluginInboxSrc, "index.ts"),
+      },
+      {
+        find: /^@elizaos\/plugin-inbox\/(.+)$/,
+        replacement: path.join(pluginInboxSrc, "$1"),
       },
       {
         find: /^@elizaos\/plugin-commands$/,


### PR DESCRIPTION
## Windows CI → `app-and-cli` shard fixes

Scoped out of #15288 as a separate workstream. The shard runs
`bun run --cwd packages/app-core test` (+ `packages/elizaos`, `cloud/shared`).
The app-core run failed first (exit 1), so the elizaos/cloud-shared steps never
executed — this PR fixes the app-core failures that gate the rest.

Failing run: [28848450401](https://github.com/elizaOS/eliza/actions/runs/28848450401)
job `app-and-cli` — **23 test files failed / 137 passed** (17 collection failures + 6 assertion failures).

### Root-cause: why the shard sees failures Linux lanes don't
The Windows prep step builds only `core`/`shared`/`logger`/`contracts`/`prompts`
— **not the plugin dists or agent**. So `packages/app-core` vitest must resolve
every `@elizaos/plugin-*` from source. It does that via ~15 explicit per-plugin
aliases in `vitest.config.ts`. Three plugins referenced by the generated
`optional-plugin-imports.generated.ts` had **no alias**, so with no `dist/` to fall
back to, Vite aborts the entire suite at the first one.

---

## Per-failure inventory + classification

### A. Regressions — reproduce on Linux (fixed at the source)

| # | Test file(s) | Root cause | Fix |
|---|---|---|---|
| 1 | 10 suites¹ failing at `Failed to resolve entry for package @elizaos/plugin-native-filesystem` | `optional-plugin-imports.generated.ts` imports `plugin-native-filesystem`, `plugin-scheduling`, `plugin-inbox`; none had a `vitest.config.ts` source alias. Reproduced identically on Linux with no dist built. | Add source aliases for the 3 plugins (mirrors the other ~15 optional plugins). |
| 2 | `src/api/dev-route-catalog.test.ts` › *uses the path declared by TAB_PATHS* | Catalog mirror had `my-apps → /apps/my-apps`; canonical `TAB_PATHS.my-apps` is `/apps`. `expected '/apps/my-apps' to be '/apps'`. | Update the mirror to `/apps`. |
| 3 | `test/live-agent/automations-compat-routes.test.ts` › *returns enabled and disabled … nodes* | Runtime stub's `CODE_TASK` action carried no `tags`; the tag-based `classifyRuntimeActionNode` returns `"action"`, but the test expects `"agent"`. The real `tasksAction` carries `domain:agent-orchestration` + `capability:delegate`. | Add those tags to the stub action. |

¹ `route-auth-policy.dispatch`, `server-first-run-helpers.masked-key`, `plugins-cli`, `app-route-plugin-skip`, `boot-hook-channel`, `repair-boot-phase`, `runtime-hook-channel`, `trigger-event-bridge`, `doctor/checks.host-config`, `server-reset-hop`.

### B. Windows-only platform assumptions (pass on Linux; fixed portably)

| # | Test file | Root cause | Fix |
|---|---|---|---|
| 4 | `src/alias-env-reads.13422.test.ts` (2 cases) | `resolveCanonicalStateDir()` `path.resolve()`s the dir; on Windows `/var/milady/state` canonicalizes to `D:\var\milady\state`. Test asserted the POSIX literal. `expected 'D:\var\milady\state' to be '/var/milady/state'`. | Assert `path.resolve("/var/milady/state")` — same normalization, platform-portable (mirrors #15288's `live-provider.alias` fix). |
| 5 | `test/capacitor-ios-boot-eval-guard.test.ts` › *CHECKSUMS matches the patch bytes* | Patch bytes are hashed (`patches/CHECKSUMS.sha256`) **and applied verbatim by bun**, but `.gitattributes` had no LF rule, so a Windows `autocrlf` checkout rewrote `*.patch`/`CHECKSUMS` to CRLF. The trailing `\r` broke `line.endsWith(...)` (`expected undefined to be defined`) and would also break the sha256. | `.gitattributes`: force `-text` (no EOL conversion) for `*.patch` + `patches/CHECKSUMS.sha256` so bytes stay identical cross-platform. Also made the checksums parse split on `/\r?\n/` defensively. |

### C. Windows-CI-runner anomalies — not reproducible off the runner (documented, NOT changed)

Not touched: I could not reproduce or root-cause these from Linux, and I will not
skip/weaken tests blind. Log evidence below; recommend Windows-runner investigation.
Windows CI re-validates on the post-merge develop push.

- **7 `.mjs`/`.ts` suites fail at collection with a bare `SyntaxError: Invalid or unexpected token`** (`run-mobile-build-android-cloud-strip`, `run-mobile-build-android-targets`, `run-mobile-build-ios-identity`, `run-mobile-build-plugin-manifest`, `voice-interactive`, `aosp/compile-libllama`, `test/scripts/mobile-auth-simulator-smoke`). Each is valid (`node --check` passes), passes on Linux, and passes locally on Windows per the existing in-repo note. This is the **same non-reproducible windows-ci transform anomaly** already documented and gated in `vitest.config.ts` for `run-mobile-build-ios-engine-gate.test.mjs` / `apple-entitlement-audit.test.mjs`. I verified CRLF alone does **not** trigger it on Linux. Root-cause needs a Windows runner; the maintainers who own that gate precedent should decide whether to extend it.
- **`src/api/auth-pairing-flow.test.ts` › *mints a revocable machine session*** — `harness.store.findSession(sessionId)` returns null on Windows (`expected null not to be null`), despite the pairing POST returning 200. Real-PGlite + real-HTTP test; passes on Linux. Looks like a PGlite-on-Windows persistence/timing issue, not a logic bug.
- **`scripts/run-node-supervisor.test.mjs` (2 cases)** — the spawned child never writes `spawn-count.txt` on Windows (`ENOENT … eliza-supervisor-*/spawn-count.txt`), so the promise's exit handler throws before `resolve()` and the test hits the 30s timeout. Passes on Linux. The real supervisor's child spawn behaves differently on the Windows runner; needs a Windows box to pin.

---

## Validation
- All 14 fixed test files green locally: the 10-suite native-filesystem cluster, `dev-route-catalog`, `automations-compat-routes`, `alias-env-reads`, `capacitor-ios-boot-eval-guard` (`node ../scripts/run-vitest.mjs run …`).
- biome clean on all touched files; `audit:error-policy-ratchet` clean (0 changed production source files add slop).
- app-core typecheck: touched files clean (remaining errors are pre-existing unbuilt-workspace-dep resolution in files this PR doesn't touch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)