### PR TITLE
fix(voice): default asr.provider to eliza-cloud for cloud-connected agents (PWA voice dead)

### DIFF
--- a/packages/ui/scripts/scan-reserved-storage-writers.d.mts
+++ b/packages/ui/scripts/scan-reserved-storage-writers.d.mts
@@ -1,0 +1,13 @@
+/**
+ * Type contract for the reserved-storage static scanner consumed by the UI
+ * guard test.
+ */
+
+export interface RawReservedStorageWriter {
+  file: string;
+  line: number;
+  op: string;
+  key: string;
+}
+
+export function findRawReservedStorageWriters(): RawReservedStorageWriter[];

--- a/packages/ui/src/voice/voice-chat-types.asr-default.test.ts
+++ b/packages/ui/src/voice/voice-chat-types.asr-default.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import type { VoiceConfig } from "../api/client-types-config";
+import { resolveEffectiveVoiceConfig } from "./voice-chat-types";
+
+/**
+ * Regression coverage for the ASR-provider default in
+ * {@link resolveEffectiveVoiceConfig} (voice-live PWA fix).
+ *
+ * The resolver upgrades the TTS `provider` to `eliza-cloud` when the agent is
+ * cloud-connected but no explicit provider was stored. It previously left the
+ * ASR side (`asr.provider`) untouched, so a cloud-connected agent whose config
+ * carried no explicit ASR provider got a NULL `asr.provider`. `shouldUseCloudAsr`
+ * then read `undefined`, the composer mic's `startCloudRecognition` early-returned,
+ * and capture fell through to the browser SpeechRecognition path — unavailable in
+ * an installed iOS PWA, so the mic did nothing at all ("voice fully cooked").
+ *
+ * The fix mirrors the TTS cloud-upgrade for ASR: seed `asr.provider =
+ * "eliza-cloud"` when cloud is connected and no explicit provider was set, never
+ * override an explicit stored provider, and stay undefined when cloud is not
+ * connected so the local/desktop defaults keep resolving downstream.
+ */
+describe("resolveEffectiveVoiceConfig — ASR provider default", () => {
+  it("seeds asr.provider = eliza-cloud when cloud-connected and asr is unset (the fix)", () => {
+    const config: VoiceConfig = {}; // no provider, no asr — a fresh cloud agent
+
+    const resolved = resolveEffectiveVoiceConfig(config, {
+      cloudConnected: true,
+    });
+
+    expect(resolved).not.toBeNull();
+    // TTS provider upgraded to cloud (existing behavior) …
+    expect(resolved?.provider).toBe("eliza-cloud");
+    // … and ASR provider is now seeded to cloud too (the fix) so the composer
+    // mic's shouldUseCloudAsr() picks the /api/asr/cloud WAV path instead of the
+    // dead browser recognizer on the iOS PWA.
+    expect(resolved?.asr?.provider).toBe("eliza-cloud");
+  });
+
+  it("carries the asr default through the elevenlabs return path too", () => {
+    const config: VoiceConfig = {
+      provider: "elevenlabs",
+      elevenlabs: { voiceId: "abc" },
+    };
+
+    const resolved = resolveEffectiveVoiceConfig(config, {
+      cloudConnected: true,
+    });
+
+    expect(resolved?.provider).toBe("elevenlabs");
+    // Even when TTS is elevenlabs, ASR still defaults to cloud when connected —
+    // the two layers are chosen independently.
+    expect(resolved?.asr?.provider).toBe("eliza-cloud");
+  });
+
+  it("does NOT override an explicit stored asr.provider (respects a local-inference user)", () => {
+    const config: VoiceConfig = {
+      asr: { provider: "local-inference" },
+    };
+
+    const resolved = resolveEffectiveVoiceConfig(config, {
+      cloudConnected: true,
+    });
+
+    // An explicit user/device choice wins — the cloud upgrade only fills a gap.
+    expect(resolved?.asr?.provider).toBe("local-inference");
+  });
+
+  it("preserves an explicit asr.modelId when defaulting the provider", () => {
+    const config: VoiceConfig = {
+      // provider unset, but a modelId hint is carried on the asr object
+      asr: { provider: undefined as unknown as "eliza-cloud", modelId: "whisper-1" },
+    };
+
+    const resolved = resolveEffectiveVoiceConfig(config, {
+      cloudConnected: true,
+    });
+
+    expect(resolved?.asr?.provider).toBe("eliza-cloud");
+    expect(resolved?.asr?.modelId).toBe("whisper-1");
+  });
+
+  it("leaves asr unset when cloud is NOT connected (local/desktop defaults resolve downstream)", () => {
+    const config: VoiceConfig = {
+      provider: "edge",
+      edge: { voice: "en-US" },
+    };
+
+    const resolved = resolveEffectiveVoiceConfig(config, {
+      cloudConnected: false,
+    });
+
+    // Without a cloud session there is no cloud STT to seed; the device+mode
+    // default (pickDefaultVoiceProvider) resolves the ASR provider elsewhere.
+    expect(resolved?.asr).toBeUndefined();
+  });
+
+  it("keeps returning null when there is no resolvable TTS provider and no cloud", () => {
+    // No provider hints + not cloud-connected → still null (unchanged contract).
+    expect(resolveEffectiveVoiceConfig({}, { cloudConnected: false })).toBeNull();
+  });
+});

--- a/packages/ui/src/voice/voice-chat-types.asr-default.test.ts
+++ b/packages/ui/src/voice/voice-chat-types.asr-default.test.ts
@@ -11,7 +11,7 @@ import { resolveEffectiveVoiceConfig } from "./voice-chat-types";
  * ASR side (`asr.provider`) untouched, so a cloud-connected agent whose config
  * carried no explicit ASR provider got a NULL `asr.provider`. `shouldUseCloudAsr`
  * then read `undefined`, the composer mic's `startCloudRecognition` early-returned,
- * and capture fell through to the browser SpeechRecognition path — unavailable in
+ * and capture fell through to the browser SpeechRecognition path, unavailable in
  * an installed iOS PWA, so the mic did nothing at all ("voice fully cooked").
  *
  * The fix mirrors the TTS cloud-upgrade for ASR: seed `asr.provider =
@@ -19,18 +19,18 @@ import { resolveEffectiveVoiceConfig } from "./voice-chat-types";
  * override an explicit stored provider, and stay undefined when cloud is not
  * connected so the local/desktop defaults keep resolving downstream.
  */
-describe("resolveEffectiveVoiceConfig — ASR provider default", () => {
+describe("resolveEffectiveVoiceConfig - ASR provider default", () => {
   it("seeds asr.provider = eliza-cloud when cloud-connected and asr is unset (the fix)", () => {
-    const config: VoiceConfig = {}; // no provider, no asr — a fresh cloud agent
+    const config: VoiceConfig = {}; // no provider, no asr: a fresh cloud agent
 
     const resolved = resolveEffectiveVoiceConfig(config, {
       cloudConnected: true,
     });
 
     expect(resolved).not.toBeNull();
-    // TTS provider upgraded to cloud (existing behavior) …
+    // TTS provider upgraded to cloud (existing behavior) ...
     expect(resolved?.provider).toBe("eliza-cloud");
-    // … and ASR provider is now seeded to cloud too (the fix) so the composer
+    // ... and ASR provider is now seeded to cloud too (the fix) so the composer
     // mic's shouldUseCloudAsr() picks the /api/asr/cloud WAV path instead of the
     // dead browser recognizer on the iOS PWA.
     expect(resolved?.asr?.provider).toBe("eliza-cloud");
@@ -47,7 +47,7 @@ describe("resolveEffectiveVoiceConfig — ASR provider default", () => {
     });
 
     expect(resolved?.provider).toBe("elevenlabs");
-    // Even when TTS is elevenlabs, ASR still defaults to cloud when connected —
+    // Even when TTS is elevenlabs, ASR still defaults to cloud when connected;
     // the two layers are chosen independently.
     expect(resolved?.asr?.provider).toBe("eliza-cloud");
   });
@@ -61,14 +61,17 @@ describe("resolveEffectiveVoiceConfig — ASR provider default", () => {
       cloudConnected: true,
     });
 
-    // An explicit user/device choice wins — the cloud upgrade only fills a gap.
+    // An explicit user/device choice wins; the cloud upgrade only fills a gap.
     expect(resolved?.asr?.provider).toBe("local-inference");
   });
 
   it("preserves an explicit asr.modelId when defaulting the provider", () => {
     const config: VoiceConfig = {
       // provider unset, but a modelId hint is carried on the asr object
-      asr: { provider: undefined as unknown as "eliza-cloud", modelId: "whisper-1" },
+      asr: {
+        provider: undefined as unknown as "eliza-cloud",
+        modelId: "whisper-1",
+      },
     };
 
     const resolved = resolveEffectiveVoiceConfig(config, {
@@ -95,7 +98,9 @@ describe("resolveEffectiveVoiceConfig — ASR provider default", () => {
   });
 
   it("keeps returning null when there is no resolvable TTS provider and no cloud", () => {
-    // No provider hints + not cloud-connected → still null (unchanged contract).
-    expect(resolveEffectiveVoiceConfig({}, { cloudConnected: false })).toBeNull();
+    // No provider hints + not cloud-connected: still null (unchanged contract).
+    expect(
+      resolveEffectiveVoiceConfig({}, { cloudConnected: false }),
+    ).toBeNull();
   });
 });

--- a/packages/ui/src/voice/voice-chat-types.ts
+++ b/packages/ui/src/voice/voice-chat-types.ts
@@ -491,9 +491,30 @@ export function resolveEffectiveVoiceConfig(
     provider = "eliza-cloud";
   }
 
+  // Resolve the ASR (speech-to-text) provider the same way we resolve the TTS
+  // provider above. `VoiceConfig.asr` is documented as "when unset, fall back to
+  // the device+mode default", but the effective-config resolver previously left
+  // it untouched — so a cloud-connected agent whose stored config carried no
+  // explicit `asr.provider` got working cloud TTS but a NULL ASR provider.
+  // `shouldUseCloudAsr` (useVoiceChat) then read `undefined`, the composer mic's
+  // `startCloudRecognition` early-returned, and capture fell through to the
+  // browser SpeechRecognition path — which is unavailable/unreliable in an
+  // installed iOS PWA, so the mic did nothing at all. Mirroring the TTS
+  // cloud-upgrade here seeds `asr.provider = "eliza-cloud"` when cloud is
+  // connected and no explicit provider was set, so the interactive WAV → cloud
+  // STT path (`/api/asr/cloud`) is actually selected. Deliberately DOES NOT
+  // override an explicit stored provider (e.g. a user who chose
+  // `local-inference`), and stays undefined when cloud is not connected so the
+  // local/desktop defaults keep resolving through `pickDefaultVoiceProvider`.
+  const resolvedAsr: VoiceConfig["asr"] | undefined = base.asr?.provider
+    ? base.asr
+    : cloudConnected
+      ? { ...(base.asr ?? {}), provider: "eliza-cloud" }
+      : base.asr;
+
   if (!provider) return null;
   if (provider !== "elevenlabs") {
-    return { ...base, provider };
+    return { ...base, provider, asr: resolvedAsr };
   }
 
   const currentElevenLabs = base.elevenlabs ?? {};
@@ -535,6 +556,7 @@ export function resolveEffectiveVoiceConfig(
     provider,
     mode,
     elevenlabs,
+    asr: resolvedAsr,
   };
 }
 

--- a/packages/ui/src/voice/voice-chat-types.ts
+++ b/packages/ui/src/voice/voice-chat-types.ts
@@ -494,14 +494,14 @@ export function resolveEffectiveVoiceConfig(
   // Resolve the ASR (speech-to-text) provider the same way we resolve the TTS
   // provider above. `VoiceConfig.asr` is documented as "when unset, fall back to
   // the device+mode default", but the effective-config resolver previously left
-  // it untouched — so a cloud-connected agent whose stored config carried no
+  // it untouched, so a cloud-connected agent whose stored config carried no
   // explicit `asr.provider` got working cloud TTS but a NULL ASR provider.
   // `shouldUseCloudAsr` (useVoiceChat) then read `undefined`, the composer mic's
   // `startCloudRecognition` early-returned, and capture fell through to the
-  // browser SpeechRecognition path — which is unavailable/unreliable in an
+  // browser SpeechRecognition path, which is unavailable/unreliable in an
   // installed iOS PWA, so the mic did nothing at all. Mirroring the TTS
   // cloud-upgrade here seeds `asr.provider = "eliza-cloud"` when cloud is
-  // connected and no explicit provider was set, so the interactive WAV → cloud
+  // connected and no explicit provider was set, so the interactive WAV to cloud
   // STT path (`/api/asr/cloud`) is actually selected. Deliberately DOES NOT
   // override an explicit stored provider (e.g. a user who chose
   // `local-inference`), and stays undefined when cloud is not connected so the


### PR DESCRIPTION
## Summary

Fixes the cloud-connected PWA voice path where the effective voice config upgraded TTS to `eliza-cloud` but left `asr.provider` unset. With `asr.provider` undefined, `shouldUseCloudAsr()` skipped the `/api/asr/cloud` path and the installed PWA fell through to browser SpeechRecognition, which is unavailable/unreliable in that environment.

The resolver now mirrors the TTS cloud upgrade for ASR: when cloud is connected and no explicit ASR provider is stored, it seeds `asr.provider = "eliza-cloud"`. Explicit ASR providers are preserved, and non-cloud configs still resolve downstream local/device defaults.

This PR also adds a declaration file for the reserved-storage scanner so `@elizaos/ui` typecheck remains green on current develop.

## Tests

- `bun install --frozen-lockfile --ignore-scripts`
- `node packages/shared/scripts/generate-keywords.mjs --target ts`
- `bun run --cwd packages/core build`
- `bunx vitest run packages/ui/src/voice/voice-chat-types.asr-default.test.ts --coverage.enabled=false` -> 6 pass / 0 fail
- `bun run --cwd packages/ui typecheck`

## Evidence

<!-- evidence-row:before-screenshots -->
- [ ] N/A - TypeScript config-resolution and type-declaration change; no rendered UI surface.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - TypeScript config-resolution and type-declaration change; no rendered UI surface.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - voice backend selection is covered by deterministic resolver tests; no visual workflow changed in this diff.

<!-- evidence-row:backend-logs -->
- [ ] N/A - client-side resolver/typecheck change; no backend route changed.

<!-- evidence-row:frontend-logs -->
- [ ] Focused frontend proof is the resolver suite in [voice-chat-types.asr-default.test.ts](packages/ui/src/voice/voice-chat-types.asr-default.test.ts): `bunx vitest run packages/ui/src/voice/voice-chat-types.asr-default.test.ts --coverage.enabled=false` passed 6/6 and `bun run --cwd packages/ui typecheck` passed locally.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, provider, or agent planning behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifact is the ASR provider selection invariant in [voice-chat-types.asr-default.test.ts](packages/ui/src/voice/voice-chat-types.asr-default.test.ts): cloud-connected configs with no explicit ASR provider resolve to `eliza-cloud`, explicit local providers are preserved, and non-cloud configs remain unset.

