### PR TITLE
test(app): reconcile assistant-home-flow ui-smoke with current app UI

### DIFF
--- a/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
+++ b/packages/app/test/ui-smoke/assistant-home-flow.spec.ts
@@ -303,13 +303,26 @@ async function installAssistantFlowRoutes(page: Page): Promise<{
     await route.fallback();
   });
   await page.route(
-    "**/api/conversations/assistant-home-conversation/messages",
+    // Match the base list AND its `?before=<cursor>` pagination (the infinite
+    // upward-scroll load, #13532) — the plain `**/messages` glob never matched a
+    // query string, so the cursor fetch 404'd. Anchored so it does NOT swallow
+    // the `/messages/stream` sub-route registered below.
+    /\/api\/conversations\/assistant-home-conversation\/messages(?:\?|$)/,
     async (route) => {
-      if (route.request().method() === "GET") {
-        await fulfillJson(route, { messages });
+      if (route.request().method() !== "GET") {
+        await route.fallback();
         return;
       }
-      await route.fallback();
+      // A `before` cursor asks for older history; this fixture conversation has
+      // none, so return an empty page with `hasMore:false` to stop the scroll
+      // from refetching the same cursor.
+      const hasBeforeCursor = new URL(
+        route.request().url(),
+      ).searchParams.has("before");
+      await fulfillJson(route, {
+        messages: hasBeforeCursor ? [] : messages,
+        hasMore: false,
+      });
     },
   );
   await page.route(
@@ -495,6 +508,15 @@ async function openReadyChat(page: Page, targetPath = "/"): Promise<void> {
 async function seedAssistantFlowStorage(page: Page): Promise<void> {
   await seedAppStorage(page, {
     "eliza:mobile-runtime-mode": "local",
+    // Mark the post-login permission soft-ask as already shown
+    // (PERMISSION_PRIMING_STORAGE_KEY in
+    // packages/ui/src/components/permissions/permission-priming.ts). On desktop
+    // the priming set is non-empty, so PermissionPrimingOverlay otherwise opens
+    // a modal "Set up Eliza" dialog over the ready workspace that makes the
+    // launcher/wallet buttons inert — this flow exercises views + wallet, not
+    // priming (which has its own e2e), so pre-dismiss it like the other
+    // onboarding gates seeded here.
+    "eliza:permissions-primed": "1",
   });
 }
 
@@ -790,10 +812,16 @@ test.describe("assistant home app flow", () => {
     await screenshot(page, "04-chat-pill-suppressed");
 
     await openAppPath(page, "/views");
-    await expect(launcherTile(page, "settings")).toBeVisible({
+    const settingsLauncherTile = launcherTile(page, "settings");
+    await expect(settingsLauncherTile).toBeVisible({
       timeout: 15_000,
     });
-    await expect(page.getByRole("button", { name: /Settings/i })).toBeVisible();
+    // The tile's launch control is the inner accessible button (aria-label is
+    // the view label) rendered by the launcher IconTile — scope to the tile so
+    // this asserts the Settings tile itself, not any other "settings" button.
+    await expect(
+      settingsLauncherTile.getByRole("button", { name: /Settings/i }),
+    ).toBeVisible();
     await expect(page.getByTestId("shell-home-pill")).toHaveCount(0);
     await screenshot(page, "05-views-with-pill");
 
@@ -957,9 +985,12 @@ test.describe("assistant home app flow", () => {
       pointerId: 1,
       pointerType: "mouse",
     });
-    // Holding past the push-to-talk threshold (200ms) begins capture.
+    // Holding past the push-to-talk threshold (200ms) begins capture. The held
+    // voice control is labelled "release to insert" (ContinuousChatOverlay) —
+    // push-to-talk dictates into the composer draft and does NOT auto-send, so
+    // the label is "insert", not "send".
     const releaseButton = page.getByRole("button", {
-      name: /release to send/i,
+      name: /release to insert/i,
     });
     await expect(releaseButton).toBeVisible({ timeout: 5_000 });
     const releaseHandle = await releaseButton.elementHandle();


### PR DESCRIPTION
## Problem

The **Tests → Zero-Key app browser** CI lane went red at
`assistant-home-flow.spec.ts` (added by #14459). After ~3 weeks of app-UI
drift the spec's locators no longer matched the current UI. The lane failed at
the `/views` Settings assertion; the same underlying cause also silently broke
the `/wallet` assertions further down.

## Root cause (single dominant cause + two smaller drifts)

**1. New permission-priming modal covers the ready workspace.**
`PermissionPrimingOverlay` ("Set up Eliza" soft-ask, `packages/ui/.../permissions/`)
now opens post-login on desktop (its priming set is non-empty). It is a modal
`Dialog`, so the background goes inert. The launcher/wallet tiles stay
**CSS-visible** — so `getByTestId("launcher-tile-settings").toBeVisible()`
passed — but their inner buttons leave the **accessibility tree**, so
`getByRole("button", { name: /Settings/i })` found nothing. This same modal sat
over `/wallet` too, so lane 17's "wallet testids are gone after a restructure"
was a misread: the wallet testids were never removed (`InventoryAppView.tsx`
has been unchanged since #14459) — they were just inert behind the modal.

Before (failure) — modal over `/views`, Settings tile visible but unreachable:
the aria snapshot at failure is only the `dialog "Set up Eliza"`.

**2. Unmocked pagination request 404 → page-diagnostics guard.**
Once the modal is dismissed the test runs to completion and the chat's infinite
upward-scroll (#13532) fires `GET …/messages?before=<cursor>`. The plain
`**/messages` route glob never matched a query string, so it 404'd and tripped
`expectNoPageDiagnostics`.

**3. Push-to-talk label rename.** The held voice control is now
`"release to insert"` (dictates into the composer, does not auto-send —
`ContinuousChatOverlay.tsx`), not `"release to send"`.

## Per-locator reconciliation

| Spec locator (stale) | Current UI contract | Fix |
| --- | --- | --- |
| `getByRole("button", { name: /Settings/i })` on `/views` (unreachable behind modal) | Launcher `IconTile` renders `<Button aria-label={label}>` inside `launcher-tile-settings` | Seed `eliza:permissions-primed=1` to suppress the modal; scope the assertion to `launcher-tile-settings` |
| `wallets-sidebar` / `/^Tokens$/` button / `Open RPC settings` (thought removed) | Still rendered by `InventoryAppView` → `WalletHoldingsSection` (`wallets-sidebar`, `role=button` "Tokens", `aria-label="Open RPC settings"`) | **No locator change** — they pass once the modal is gone |
| `**/api/…/messages` route (no query match) | Chat pages older history via `?before=<cursor>` | Route → regex matching base list + `?before=`, returns empty older page, `hasMore:false` |
| `getByRole("button", { name: /release to send/i })` | Held PTT control is `"release to insert"` | `/release to insert/i` |

Assertions were **not weakened**: `/views` still asserts the Settings tile's
own accessible launch button; `/wallet` still asserts the real Tokens tab + RPC
settings buttons against the fully-rendered wallet view; push-to-talk still
asserts the transcript lands in the composer and no turn is streamed.

## Evidence

- `test:e2e assistant-home-flow.spec.ts --project=chromium` — **all 5 green**
  locally (`5 passed`). Tests 1–4 stable across 4 runs; test 5 green after the
  label fix. The two CI-lane tests (`captures first-run…`, `drives the assistant
  home voice path…`) pass on 4/4 runs.
- Captured views/wallet screenshots confirm the launcher renders the Settings
  tile reachable and the wallet view renders `wallets-sidebar` with the Tokens
  tab + RPC control.

Scope: one test file, `+38/-8`. `biome lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)