### PR TITLE
test(pa-scheduler): align frozen-clock recurrence test with the #14459 no-reply ladder

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler-recurrence.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler-recurrence.integration.test.ts
@@ -363,12 +363,46 @@ describe("processDueScheduledTasks — recurrence across occurrences + tick cloc
     );
     expect(stillFired?.state.status).toBe("fired");
 
-    // 14:01 tick: now the timeout is genuinely due and applies the skip.
-    const afterTimeout = await tick(runtime, "2026-05-09T14:01:00.000Z");
-    const timedOut = afterTimeout.completionTimeouts.find(
+    // 14:01 tick: the timeout (14:00) is now genuinely due. Post-#14459 a
+    // `user_acknowledged` reminder does NOT terminally skip on the FIRST
+    // timeout — the default no-reply ladder (maxRetries 1, cadence [60m])
+    // re-nudges once before giving up (see the sibling
+    // adhd-followthrough-noreply-retry-then-skip scenario). The retry is a
+    // SNOOZE whose next-fire is computed off the tick's live clock
+    // (14:01 + 60m = 15:01); a boot-frozen clock would have driven this off
+    // 12:00 instead.
+    const firstTimeout = await tick(runtime, "2026-05-09T14:01:00.000Z");
+    const retry = firstTimeout.completionTimeouts.find(
+      (t) => t.taskId === taskB.taskId,
+    );
+    expect(retry?.status).toBe("scheduled");
+    expect(retry?.reason).toBe("no_reply_retry_1");
+    const snoozed = await repo.getScheduledTask(runtime.agentId, taskB.taskId);
+    expect(snoozed?.state.status).toBe("scheduled");
+    expect(snoozed?.state.firedAt).toBe("2026-05-09T15:01:00.000Z");
+
+    // 15:02 tick: the snooze override re-fires the reminder, and the re-fire
+    // stamps THIS tick's time — the strongest anti-frozen-clock assertion, on a
+    // tick well past boot. A frozen runner clock would stamp 12:00 again.
+    const refire = await tick(runtime, "2026-05-09T15:02:00.000Z");
+    expect(refire.errors).toEqual([]);
+    expect(refire.fires.find((f) => f.taskId === taskB.taskId)?.status).toBe(
+      "fired",
+    );
+    const refired = await repo.getScheduledTask(runtime.agentId, taskB.taskId);
+    expect(refired?.state.firedAt).toBe("2026-05-09T15:02:00.000Z");
+
+    // 15:33 tick: the re-fired occurrence's timeout (15:02 + 30m = 15:32) is
+    // due and the ladder is exhausted (retryCount 1 == maxRetries 1), so the
+    // reminder finally settles terminally skipped.
+    const terminal = await tick(runtime, "2026-05-09T15:33:00.000Z");
+    const timedOut = terminal.completionTimeouts.find(
       (t) => t.taskId === taskB.taskId,
     );
     expect(timedOut?.status).toBe("skipped");
+    expect(timedOut?.reason).toBe("no_reply_reminder_expired");
+    const settled = await repo.getScheduledTask(runtime.agentId, taskB.taskId);
+    expect(settled?.state.status).toBe("skipped");
   });
 
   it("during_window: fires on two consecutive days, once per window", async () => {


### PR DESCRIPTION
## What

Fixes the residual **Tests → Integration Lane (personal-assistant)** failure: `scheduler-recurrence.integration.test.ts` › *"tick clock is NOT frozen"*.

## Determination: intended new behavior, test was stale (NOT a regression)

The test expected a `user_acknowledged` reminder to terminally **skip** on its *first* completion timeout. Since **#14459** that is no longer the product behavior. `handleCompletionTimeout` (`scheduler.ts`) now runs a **no-reply retry/snooze ladder**: `defaultNoReplyPolicyFor` gives a `reminder` `{ maxRetries: 1, retryCadenceMinutes: [60], terminalStatus: "skipped", terminalReason: "no_reply_reminder_expired" }`, so the first timeout **snoozes** (status back to `scheduled`, reason `no_reply_retry_1`) and only settles terminally after the retry is exhausted.

Evidence this is intended, not a regression:
- The sibling scenario `plugins/plugin-personal-assistant/test/scenarios/adhd-followthrough-noreply-retry-then-skip.scenario.ts` documents the exact ladder and its **fail-without-fix anchor** explicitly states that reverting the snooze branch (so the reminder "settles terminally on the FIRST timeout") is the *broken* state.
- The MVP product doc references the conservative no-reply defaults (`packages/docs/ongoing-development/mvp/MVP.md`).
- The change was introduced by the squashed #14459 (`handleCompletionTimeout` snooze override).

**The frozen-clock invariant this test guards is not broken by the ladder.** The snooze's next-fire is computed off the tick's live clock, `firedAt` is stamped at each subsequent tick's time (not boot), and the timeout still becomes due at the correct wall-clock instant — I verified the raw runtime behavior: the first timeout returns `status: "scheduled"` / `reason: "no_reply_retry_1"`, and the quiet-streak softener does **not** apply here (default ladder). So the fix is at the **test layer**, not product code.

## Fix

The test now walks the full intended ladder instead of expecting an immediate skip:

1. `14:01` first timeout → `no_reply_retry_1` snooze to `15:01` (computed off the live tick clock).
2. `15:02` → `scheduled_override_due` re-fire, `firedAt` stamped `15:02` — a *stronger* anti-frozen-clock assertion on a post-boot tick.
3. `15:33` → retry exhausted (`retryCount 1 == maxRetries 1`) → terminal `skipped` / `no_reply_reminder_expired`.

The original anti-frozen-clock assertions (subsequent-tick `firedAt` stamping, timeout not prematurely due at `13:50`) are preserved.

## Validation (local)

- Target test: **pass**.
- Full `scheduler-recurrence.integration.test.ts`: **9/9 pass** (also re-run green after rebase onto latest develop).
- Sibling scheduler suites green: `scheduler.integration` + `inbound-reply-completion.integration` + `unanswered-question-followup.integration` = **32/32**; `scheduler.no-reply-policy` + `scheduler.no-reply-recurrence` + `scheduler.quiet-streak` + `scheduler.fire-budget` = **17/17**.
- `bunx biome check` on the touched file: clean.
- `audit:error-policy-ratchet`: no new fallback-slop (test-only change).
- `typecheck` (PA package, after building the dep closure): **0 errors**.

Test-only change (no product source touched), so no runtime evidence/trajectories apply — N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)