### PR TITLE
perf(chat-sheet): arm the layout-shift-intent marker once per motion burst (#15257)

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.mouse-drag.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.mouse-drag.test.tsx
@@ -157,6 +157,30 @@ function drag(el: Element) {
   };
 }
 
+describe("layout-shift-intent marker (#15257)", () => {
+  it("a continuous drag arms the marker ONCE, not per height tick", async () => {
+    render(<ContinuousChatOverlay controller={makeController()} />);
+    const el = grabber();
+    const setAttr = vi.spyOn(Element.prototype, "setAttribute");
+    try {
+      fireEvent.pointerDown(el, { clientY: 740, pointerId: 1 });
+      // 20 move ticks well inside the 180ms clear window (real clock): every
+      // tick refreshes the armed marker; only the FIRST may write the attribute.
+      for (let i = 1; i <= 20; i++) {
+        fireEvent.pointerMove(el, { clientY: 740 - i * 12, pointerId: 1 });
+      }
+      await settleFrames();
+      const markerWrites = setAttr.mock.calls.filter(
+        ([name]) => name === "data-eliza-layout-shift-intent",
+      ).length;
+      expect(markerWrites).toBeLessThanOrEqual(1);
+      fireEvent.pointerUp(el, { clientY: 500, pointerId: 1 });
+    } finally {
+      setAttr.mockRestore();
+    }
+  });
+});
+
 describe("adversarial mouse drags — up/down 200%, back-and-forth", () => {
   it("A) up ~200% above the screen then all the way back to the bottom COLLAPSES (not stranded open/maximized)", async () => {
     render(<ContinuousChatOverlay controller={makeController()} />);

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.mouse-drag.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.mouse-drag.test.tsx
@@ -161,20 +161,33 @@ describe("layout-shift-intent marker (#15257)", () => {
   it("a continuous drag arms the marker ONCE, not per height tick", async () => {
     render(<ContinuousChatOverlay controller={makeController()} />);
     const el = grabber();
+    // The transcript-churn effect arms the marker at MOUNT; wait (real clock)
+    // for that burst to clear so the drag below starts from a disarmed marker
+    // and the single write we count belongs to the gesture alone.
+    await waitFor(
+      () =>
+        expect(
+          document.querySelector("[data-eliza-layout-shift-intent]"),
+        ).toBeNull(),
+      { timeout: 3000 },
+    );
     const setAttr = vi.spyOn(Element.prototype, "setAttribute");
+    const d = drag(el);
     try {
-      fireEvent.pointerDown(el, { clientY: 740, pointerId: 1 });
-      // 20 move ticks well inside the 180ms clear window (real clock): every
-      // tick refreshes the armed marker; only the FIRST may write the attribute.
-      for (let i = 1; i <= 20; i++) {
-        fireEvent.pointerMove(el, { clientY: 740 - i * 12, pointerId: 1 });
+      d.down(740);
+      // 8 move ticks, each advancing the mocked clock 120ms — past the old
+      // implementation's 100ms re-arm throttle, so pre-#15257 code re-wrote
+      // the attribute on EVERY tick (~8 writes). Once-per-burst arming writes
+      // it exactly once (the marker MUST arm — 0 writes would break the CLS
+      // gate) and every later tick only refreshes the last-motion timestamp.
+      for (let i = 1; i <= 8; i++) {
+        await d.move(740 - i * 24, 120);
       }
-      await settleFrames();
       const markerWrites = setAttr.mock.calls.filter(
         ([name]) => name === "data-eliza-layout-shift-intent",
       ).length;
-      expect(markerWrites).toBeLessThanOrEqual(1);
-      fireEvent.pointerUp(el, { clientY: 500, pointerId: 1 });
+      expect(markerWrites).toBe(1);
+      d.up(548);
     } finally {
       setAttr.mockRestore();
     }

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -1467,34 +1467,34 @@ export function ContinuousChatOverlay({
   // sheet to its content (grow-from-the-bottom) instead of a tall empty panel.
   const threadContentRef = React.useRef<HTMLDivElement>(null);
   const layoutShiftIntentTimerRef = React.useRef<number | null>(null);
-  const layoutShiftIntentArmedAtRef = React.useRef(0);
+  const layoutShiftIntentLastMotionRef = React.useRef(0);
   const markLayoutShiftIntent = React.useCallback(() => {
     const overlay = overlayRef.current;
     if (!overlay || typeof window === "undefined") return;
-    // Throttle the re-arm: this fires on EVERY threadHeight tick (60+/s for
-    // the whole of a drag or settle spring), and an unconditional
-    // setAttribute + clearTimeout + setTimeout per frame is pure churn. While
-    // a timer is already pending, re-arm at most every 100ms — the intent
-    // window still clears within ~280ms of the last motion.
-    const now = performance.now();
-    if (
-      layoutShiftIntentTimerRef.current !== null &&
-      now - layoutShiftIntentArmedAtRef.current < 100
-    ) {
-      return;
-    }
-    layoutShiftIntentArmedAtRef.current = now;
+    // Arm ONCE per motion burst (#15257): this fires on EVERY threadHeight
+    // tick (60+/s across a whole drag or settle spring). While armed, a tick
+    // only refreshes the last-motion timestamp — no attribute write, no timer
+    // churn. The single clear timer extends itself while motion continues and
+    // removes the marker ~180ms after the last tick.
+    layoutShiftIntentLastMotionRef.current = performance.now();
+    if (layoutShiftIntentTimerRef.current !== null) return;
     overlay.setAttribute(
       LAYOUT_SHIFT_INTENT_ATTR,
       LAYOUT_SHIFT_INTENT_TRANSIENT,
     );
-    if (layoutShiftIntentTimerRef.current !== null) {
-      window.clearTimeout(layoutShiftIntentTimerRef.current);
-    }
-    layoutShiftIntentTimerRef.current = window.setTimeout(() => {
-      layoutShiftIntentTimerRef.current = null;
-      overlayRef.current?.removeAttribute(LAYOUT_SHIFT_INTENT_ATTR);
-    }, 180);
+    const scheduleClear = (delay: number) => {
+      layoutShiftIntentTimerRef.current = window.setTimeout(() => {
+        const since =
+          performance.now() - layoutShiftIntentLastMotionRef.current;
+        if (since < 180) {
+          scheduleClear(180 - since);
+          return;
+        }
+        layoutShiftIntentTimerRef.current = null;
+        overlayRef.current?.removeAttribute(LAYOUT_SHIFT_INTENT_ATTR);
+      }, delay);
+    };
+    scheduleClear(180);
   }, []);
   // Publish the RESTING composer footprint to --eliza-continuous-chat-clearance
   // so content below (home widgets, launcher tiles) always reserves exactly the


### PR DESCRIPTION
## What

`ContinuousChatOverlay.markLayoutShiftIntent` now arms the layout-shift-intent marker **once per motion burst** instead of writing the attribute and churning timers on every `threadHeight` tick.

The marker (`data-eliza-layout-shift-intent="transient"`) tells `useLayoutShiftMonitor` to exclude a layout shift from CLS accounting when it happens inside an intentional-motion surface (the chat sheet during a drag/settle spring). It is invoked from two hot call sites — the transcript-churn effect and the `useMotionValueEvent(threadHeight, "change")` handler — that fire 60+/s for the full duration of every drag and settle spring.

The previous implementation only throttled *re-arming* to once per 100ms (`layoutShiftIntentArmedAtRef`), and every pass through the guard still did `overlay.setAttribute(...)` + `window.clearTimeout` + `window.setTimeout` — repeated DOM writes and timer create/destroy churn on the frame-critical path.

## Why / how

- The **first** tick of a burst writes the attribute exactly once.
- Every **subsequent** tick only refreshes a `layoutShiftIntentLastMotionRef` timestamp — zero DOM writes, zero timer ops (early-returns while `layoutShiftIntentTimerRef.current !== null`).
- A single self-extending timer reschedules itself while `(performance.now() - lastMotion) < 180ms` and removes the marker otherwise, so the intent window still spans the entire drag/spring and clears ~180ms after the last tick.
- The unmount/close cleanup path (clear timer, null the ref, remove the attribute) is unchanged and remains compatible.

Net effect on a single drag: **1** attribute write and **1** timer instead of hundreds of `setAttribute` + `clearTimeout`/`setTimeout` pairs.

## Acceptance criteria (from #15257)

- [x] A single chat-sheet drag/spring arms the marker **at most once** (not per height tick) — asserted by a jsdom drag counting `setAttribute` calls on the marker path.
- [x] No behavioral change to the layout-stability gate — `run-chat-perf-gate` stays green.

## Notes for reviewers

- This commit is extracted verbatim from open PR #15290 (`feat/notifications-inline-widget`), where the same fix is HEAD commit `fb12b73`. The hunks are identical on both sides, so whichever lands first, the other merges trivially (verified conflict-free against `develop`). Landing it standalone de-risks the large, contended sync PR.
- The issue lists a third call site (`ContinuousChatOverlay.tsx:3334-3339`); that line exists only on the feature branch, not on `develop`. The fix lives inside the shared `markLayoutShiftIntent` `useCallback`, so **all** call sites are covered regardless.

## Verification

UI pixels are unchanged — the attribute is a perf/CLS-gate marker, not a visual element — so screenshot/video rows are **N/A - no rendered change**.

<details>
<summary>Unit — <code>ContinuousChatOverlay.mouse-drag</code> (jsdom, 5/5 pass incl. new #15257 test + adversarial A/B/C/D drag suite)</summary>

```
$ vitest run src/components/shell/ContinuousChatOverlay.mouse-drag.test.tsx --reporter=verbose

 ✓ layout-shift-intent marker (#15257) > a continuous drag arms the marker ONCE, not per height tick 143ms
 ✓ adversarial mouse drags — up/down 200%, back-and-forth > A) up ~200% above the screen then all the way back to the bottom COLLAPSES (not stranded open/maximized) 201ms
 ✓ adversarial mouse drags — up/down 200%, back-and-forth > B) over-drag DOWN ~200% then all the way UP to the top MAXIMIZES 363ms
 ✓ adversarial mouse drags — up/down 200%, back-and-forth > C) oscillating UP/DOWN 3× across the detents tracks the cursor 1:1 110ms
 ✓ adversarial mouse drags — up/down 200%, back-and-forth > D) oscillating past the maximize threshold then releasing at the BOTTOM does not surprise-maximize 154ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
```
</details>

<details>
<summary>Perf gate — <code>test:chat-perf-gate</code> (real headless Chromium, PASSED)</summary>

```
✓ gate catches a REAL non-transient shift (injected CLS 0.3652 > 0.1)
✓ thread (perf surface) mounted
✓ over-pull commits full-bleed (4/4 committed)
✓ top-20% pull-down restores the inset overlay (4/4 restored)

frames: 639 | fps 120.0 | p95 9.7ms | worst 10.4ms | dropped 0/639
layout: cls 0.0000 | non-intentional shifts 0

✓ non-intentional CLS 0.0000 within 0.1
✓ layout-stability detector does not flag the window
✓ observer captured real layout-shift entries during the interaction (94) — CLS=0 is not a dead observer
✓ streaming causes ZERO layout shifts outside the chat overlay (saw 0 of 12)
✓ no page errors (saw 0)

PERF GATE PASSED
```

The gate observed **94 real layout-shift entries** during the drag interaction, all correctly classified as intentional (non-intentional CLS = 0.0000). This proves the once-per-burst marker still covers the entire motion window — if it weren't armed across the whole drag, those shifts would count as non-intentional CLS.
</details>

<details>
<summary>Typecheck + lint (scoped to <code>packages/ui</code>)</summary>

```
$ tsgo --noEmit -p tsconfig.json   # 0 errors in touched files
$ biome check ContinuousChatOverlay.tsx ContinuousChatOverlay.mouse-drag.test.tsx
Checked 2 files in 70ms. No fixes applied.
```

(The only two `tsgo` diagnostics are in the unrelated, untouched `surface-realm-reserved-writers.guard.test.ts` — a worktree `.mjs`-declaration artifact, not part of this diff.)
</details>

Fixes #15257

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15301-before-perf-gate.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15301-after-perf-gate.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/15301-walkthrough-perf-gate.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - client-only React perf change (attribute write scheduling in ContinuousChatOverlay); no server code executes in this diff

<!-- evidence-row:frontend-logs -->
- [x] [15301-perf-gate-after.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15301-perf-gate-after.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model behavior change; pure UI perf fix

<!-- evidence-row:domain-artifacts -->
- [x] [15301-unit-tests.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15301-unit-tests.log)

<!-- evidence-row:ocr-review -->
- [x] [15301-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15301-ocr-review.txt)
