### PR TITLE
perf(launcher): throttle WebGL wallpaper rAF present during rail gestures

### DIFF
--- a/packages/ui/src/backgrounds/ProgrammableShaderBackground.gesture-throttle.test.tsx
+++ b/packages/ui/src/backgrounds/ProgrammableShaderBackground.gesture-throttle.test.tsx
@@ -1,0 +1,242 @@
+// @vitest-environment jsdom
+/**
+ * Rail-gesture present-throttle contract (#15282): while the home↔launcher rail
+ * is mid-gesture the loop must keep the rAF ticking but cap the GL present to
+ * RAIL_GESTURE_FRAME_INTERVAL_MS, resume full rate within one frame of settle
+ * with monotonic wall-clock u_time, and never let the throttle feed the
+ * gpu-stall watchdog. THREE is mocked so `renderer.render` (the present) is a
+ * countable side effect; rAF is a manually-drained queue and performance.now is
+ * a driven clock, so frame timing is fully deterministic under jsdom.
+ */
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  beginRailGesture,
+  endRailGesture,
+  resetRailGestureForTests,
+} from "../state/rail-gesture-store";
+import { ProgrammableShaderBackground } from "./ProgrammableShaderBackground";
+import { getShaderPreset } from "./shader-presets";
+import { DEFAULT_SHADER_UNIFORMS } from "./shader-schema";
+
+const state = vi.hoisted(() => ({
+  renderCalls: 0,
+  uniformSets: [] as Array<Record<string, { value: unknown }>>,
+}));
+
+vi.mock("three", () => {
+  const compilingGl = {
+    FRAGMENT_SHADER: 0x8b30,
+    COMPILE_STATUS: 0x8b81,
+    createShader: () => ({}),
+    shaderSource: () => {},
+    compileShader: () => {},
+    getShaderParameter: () => true,
+    getShaderInfoLog: () => "",
+    deleteShader: () => {},
+  };
+  class WebGLRenderer {
+    domElement = document.createElement("canvas");
+    getContext() {
+      return compilingGl;
+    }
+    setPixelRatio() {}
+    setSize() {}
+    render() {
+      state.renderCalls += 1;
+    }
+    dispose() {}
+  }
+  class Vector2 {
+    set() {}
+  }
+  class Vector3 {
+    constructor(
+      public x = 0,
+      public y = 0,
+      public z = 0,
+    ) {}
+    set(x: number, y: number, z: number) {
+      this.x = x;
+      this.y = y;
+      this.z = z;
+      return this;
+    }
+  }
+  class Scene {
+    add() {}
+  }
+  class Camera {}
+  class BufferGeometry {
+    setAttribute() {}
+    dispose() {}
+  }
+  class BufferAttribute {}
+  class RawShaderMaterial {
+    uniforms: Record<string, { value: unknown }>;
+    constructor(params: { uniforms: Record<string, { value: unknown }> }) {
+      this.uniforms = params.uniforms;
+      state.uniformSets.push(params.uniforms);
+    }
+    dispose() {}
+  }
+  class Mesh {}
+  return {
+    WebGLRenderer,
+    Vector2,
+    Vector3,
+    Scene,
+    Camera,
+    BufferGeometry,
+    BufferAttribute,
+    RawShaderMaterial,
+    Mesh,
+  };
+});
+
+const SOURCE = getShaderPreset("aurora")?.source ?? "";
+
+// The wallpaper loop reads performance.now() (not the rAF callback arg) for its
+// clock, so a driven clock + a manually-drained rAF queue make one "vsync" a
+// single `tick(ms)` call: advance the clock, then run exactly one queued frame.
+let fakeNow = 0;
+let rafQueue: Array<FrameRequestCallback>;
+let nextRafId: number;
+
+function tick(ms: number): void {
+  fakeNow += ms;
+  const cb = rafQueue.shift();
+  if (!cb) throw new Error("no rAF scheduled — the loop stopped ticking");
+  cb(fakeNow);
+}
+
+const MOUNT_TIME = 1_000;
+
+beforeEach(() => {
+  state.renderCalls = 0;
+  state.uniformSets.length = 0;
+  resetRailGestureForTests();
+  fakeNow = MOUNT_TIME;
+  rafQueue = [];
+  nextRafId = 0;
+  vi.spyOn(performance, "now").mockImplementation(() => fakeNow);
+  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    rafQueue.push(cb);
+    nextRafId += 1;
+    return nextRafId;
+  });
+  vi.stubGlobal("cancelAnimationFrame", () => {});
+});
+
+afterEach(() => {
+  cleanup();
+  resetRailGestureForTests();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function mount() {
+  return render(
+    <ProgrammableShaderBackground
+      source={SOURCE}
+      uniforms={DEFAULT_SHADER_UNIFORMS}
+      color="#ef5a1f"
+    />,
+  );
+}
+
+describe("ProgrammableShaderBackground — rail-gesture present throttle (#15282)", () => {
+  it("presents every tick at full rate when no gesture is active", () => {
+    mount();
+    // Mount schedules the loop but does not present; each vsync presents once.
+    expect(state.renderCalls).toBe(0);
+    for (let i = 1; i <= 5; i += 1) {
+      tick(16);
+      expect(state.renderCalls).toBe(i);
+    }
+  });
+
+  it("caps presents to the throttle interval while the rail gesture is active", () => {
+    mount();
+    beginRailGesture();
+    const before = state.renderCalls;
+    // 8 vsyncs at 16ms = 128ms of gesture: with a 66ms cap only the first tick
+    // (seeded to present) and the one crossing the next 66ms boundary present.
+    for (let i = 0; i < 8; i += 1) tick(16);
+    expect(state.renderCalls - before).toBe(2);
+    // The rAF kept ticking the whole time — the loop is still scheduled.
+    expect(rafQueue).toHaveLength(1);
+  });
+
+  it("resumes full-rate within one frame of settle with monotonic u_time and no reset", () => {
+    mount();
+    beginRailGesture();
+    for (let i = 0; i < 4; i += 1) tick(16); // throttled window
+    const throttledPresents = state.renderCalls;
+    const uTimeBefore = state.uniformSets[0].u_time.value as number;
+
+    endRailGesture();
+    tick(16); // first vsync after settle MUST present
+
+    expect(state.renderCalls).toBe(throttledPresents + 1);
+    const uTimeAfter = state.uniformSets[0].u_time.value as number;
+    // Wall-clock continuity: u_time strictly advances and equals (now-start)/s,
+    // proving skipped presents never reset or rewind shader time on resume.
+    expect(uTimeAfter).toBeGreaterThan(uTimeBefore);
+    expect(uTimeAfter).toBeCloseTo((fakeNow - MOUNT_TIME) / 1000, 10);
+  });
+
+  it("throttled ticks never feed the gpu-stall watchdog (no false fallback)", () => {
+    const onFallback = vi.fn();
+    render(
+      <ProgrammableShaderBackground
+        source={SOURCE}
+        uniforms={DEFAULT_SHADER_UNIFORMS}
+        color="#ef5a1f"
+        onFallback={onFallback}
+      />,
+    );
+    beginRailGesture();
+    // 10 healthy 16ms vsyncs while throttled: dt stays 16ms per tick, so the
+    // watchdog's slow-frame counter never climbs — the regression a pause-based
+    // design would trip (a >120ms resume dt fabricating a gpu-stall).
+    for (let i = 0; i < 10; i += 1) tick(16);
+    expect(onFallback).not.toHaveBeenCalled();
+  });
+
+  it("reduced-motion renders one static frame and schedules no loop, gesture or not", () => {
+    vi.stubGlobal(
+      "matchMedia",
+      () => ({ matches: true }) as unknown as MediaQueryList,
+    );
+    mount();
+    beginRailGesture();
+    // Reduced motion paints exactly one static frame and never starts a rAF, so
+    // the throttle path is unreachable — behavior is unchanged by the gesture.
+    expect(state.renderCalls).toBe(1);
+    expect(rafQueue).toHaveLength(0);
+  });
+
+  it("gesture already active at mount still presents the first frame", () => {
+    beginRailGesture();
+    mount();
+    expect(state.renderCalls).toBe(0);
+    tick(16);
+    // lastPresented is seeded one interval in the past, so an in-flight gesture
+    // cannot suppress the first paint — the wallpaper is never blank on arrival.
+    expect(state.renderCalls).toBe(1);
+  });
+
+  it("self-heals to full rate after the park-max window if a release edge is missed", () => {
+    mount();
+    beginRailGesture();
+    // Age the gesture past the 5s park-max in healthy 100ms steps (dt < 120ms so
+    // the watchdog stays quiet); throttling caps presents across this window.
+    while (fakeNow - MOUNT_TIME < 5_000) tick(100);
+    const before = state.renderCalls;
+    // Valve is now open: consecutive 16ms vsyncs each present despite the
+    // never-released gesture, so a stuck signal can't wedge the wallpaper.
+    for (let i = 0; i < 3; i += 1) tick(16);
+    expect(state.renderCalls - before).toBe(3);
+  });
+});

--- a/packages/ui/src/backgrounds/ProgrammableShaderBackground.tsx
+++ b/packages/ui/src/backgrounds/ProgrammableShaderBackground.tsx
@@ -13,6 +13,10 @@
  *   5. prefers-reduced-motion renders a single static frame (no rAF).
  * Any failure calls onFallback and the parent (AppBackground) paints the plain
  * color field instead — a hostile shader can never white-screen or hang the app.
+ *
+ * While the home↔launcher rail is mid-gesture the loop keeps ticking but skips
+ * the GL present to free GPU budget for the swipe (#15282); it never pauses the
+ * rAF, which would fabricate a slow frame for the watchdog on resume.
  */
 
 import type * as React from "react";
@@ -20,11 +24,27 @@ import { useEffect, useRef } from "react";
 import * as THREE from "three";
 import { STANDALONE_BOTTOM_RECLAIM_OFFSET } from "../platform/standalone-bottom-reclaim";
 import {
+  isRailGestureActive,
+  railGestureActiveMs,
+} from "../state/rail-gesture-store";
+import {
   hexToRgb,
   normalizeUniforms,
   type ShaderUniformValues,
   uniformsEqual,
 } from "./shader-schema";
+
+/** Present cap while the home↔launcher rail is mid-gesture (#15282): the
+ * compositor is already translating the promoted rail layer (plus, on one half,
+ * a backdrop-blur notification stack), so the wallpaper drops to ~15fps to free
+ * GPU/main-thread budget for the swipe. u_time stays wall-clock derived, so a
+ * skipped present never desyncs shader time — resume needs no fix-up. */
+const RAIL_GESTURE_FRAME_INTERVAL_MS = 66;
+
+/** Self-heal valve mirroring useActivityEvents' RAIL_GESTURE_PARK_MAX_MS: if a
+ * gesture-release edge is ever missed, the throttle lifts after this window so a
+ * stuck signal can never wedge the wallpaper below full rate indefinitely. */
+const RAIL_GESTURE_PARK_MAX_MS = 5_000;
 
 /** RawShaderMaterial gets no three.js injection, so the vertex stage is explicit.
  * A single fullscreen triangle covers clip space with one primitive. */
@@ -236,6 +256,9 @@ export function ProgrammableShaderBackground({
     // (3) frame-time watchdog: a shader that stalls the GPU makes frames huge;
     // after several consecutive slow frames, stop and fall back.
     let last = start;
+    // Seed one interval in the past so the first tick always presents — a
+    // gesture already in flight at mount never shows a blank/stale frame.
+    let lastPresented = start - RAIL_GESTURE_FRAME_INTERVAL_MS;
     const loop = () => {
       const now =
         typeof performance !== "undefined" ? performance.now() : last + 16;
@@ -250,6 +273,19 @@ export function ProgrammableShaderBackground({
       } else if (slowFrames > 0) {
         slowFrames -= 1;
       }
+      // Mid-gesture, cap the present rate but keep the rAF ticking: the watchdog
+      // dt above stays per-tick honest (throttling can never trip a false
+      // gpu-stall) and the first tick after settle presents within one frame.
+      // The park-max valve lifts the throttle if a release edge is missed.
+      if (
+        isRailGestureActive() &&
+        railGestureActiveMs() < RAIL_GESTURE_PARK_MAX_MS &&
+        now - lastPresented < RAIL_GESTURE_FRAME_INTERVAL_MS
+      ) {
+        raf = requestAnimationFrame(loop);
+        return;
+      }
+      lastPresented = now;
       renderAt((now - start) / 1000);
       raf = requestAnimationFrame(loop);
     };


### PR DESCRIPTION
## What

`ProgrammableShaderBackground` (the programmable GLSL wallpaper) drove an unconditional full-rate `requestAnimationFrame` **present** every vsync. During a home↔launcher rail swipe the compositor is already promoting and translating the rail layer (plus a `backdrop-blur-xl` + `mask-image` notification stack on one half), and the wallpaper's per-frame WebGL draw competes for GPU/main-thread frame budget — surfacing as swipe micro-stutter, worst in the installed iOS Safari PWA.

This wires the wallpaper into the **rail-gesture signal** shipped by #15283 (`packages/ui/src/state/rail-gesture-store.ts`), the same signal `useActivityEvents` already consumes to park live-widget flushes mid-swipe. While `isRailGestureActive()` is true, the loop keeps ticking but **skips the GL present** unless the ~66ms (~15fps) cap has elapsed.

## Why this shape (and not "pause the rAF")

Two mechanism facts in the existing loop dictate the design:

1. **`u_time` is wall-clock derived** (`(now - start) / 1000`), so skipping presents keeps shader time monotonic — resume needs no fix-up, and there is no reset flash on settle.
2. **The gpu-stall watchdog measures `dt` per rAF tick** (`last = now` every callback). Fully *pausing* the rAF would register a >120ms `dt` on resume and falsely increment `slowFrames`, eventually fabricating a spurious `gpu-stall` fallback (wallpaper silently replaced by the flat color field). So the throttle keeps the rAF ticking (~0.01ms/tick of JS) and gates **only** the GL draw. This also gives a full-rate resume within one frame of settle.

A **park-max valve** (mirroring `useActivityEvents`' `RAIL_GESTURE_PARK_MAX_MS = 5_000`) lifts the throttle if a gesture-release edge is ever missed, so a stuck signal can never wedge the wallpaper below full rate indefinitely. Reduced-motion is untouched — the pager never promotes there, so the signal never activates and the single-static-frame path is unchanged.

Scope is the one file: `ShaderBackground.tsx` and `html-canvas-paint.ts` have no rAF loops.

Fixes #15282
Parent: #15283 (merged — shipped `rail-gesture-store` and deferred this wallpaper item).

## Verification

New unit suite `ProgrammableShaderBackground.gesture-throttle.test.tsx` (jsdom, THREE mocked so `renderer.render` = a countable present; rAF is a manually-drained queue; `performance.now` is a driven clock) covers the happy path **and** the edges/regressions:

- full-rate baseline when no gesture is active
- present capped to the interval while active (frame-tick counter per the acceptance criterion) with the rAF still ticking
- one-frame resume on settle with **strictly-increasing, wall-clock-equal `u_time`** (proves no reset/rewind)
- throttled ticks never trip the gpu-stall watchdog (the regression a pause-based design would fail)
- reduced-motion unchanged (one static frame, no loop, gesture or not)
- gesture already active at mount still presents the first frame (never a blank/stale wallpaper)
- park-max self-heal after a missed release edge

<details>
<summary>Scoped tests + typecheck + lint (real output)</summary>

```
# New suite
$ vitest run src/backgrounds/ProgrammableShaderBackground.gesture-throttle.test.tsx --reporter=verbose
 ✓ … > presents every tick at full rate when no gesture is active
 ✓ … > caps presents to the throttle interval while the rail gesture is active
 ✓ … > resumes full-rate within one frame of settle with monotonic u_time and no reset
 ✓ … > throttled ticks never feed the gpu-stall watchdog (no false fallback)
 ✓ … > reduced-motion renders one static frame and schedules no loop, gesture or not
 ✓ … > gesture already active at mount still presents the first frame
 ✓ … > self-heals to full rate after the park-max window if a release edge is missed
 Test Files  1 passed (1)
      Tests  7 passed (7)

# Regression: all three ProgrammableShaderBackground suites (existing .test + .rebuild + new)
$ vitest run src/backgrounds/ProgrammableShaderBackground
 Test Files  3 passed (3)
      Tests  13 passed (13)

# Lint (biome, read-only) on changed files
$ biome check ProgrammableShaderBackground.tsx ProgrammableShaderBackground.gesture-throttle.test.tsx
Checked 2 files in 10ms. No fixes applied.

# Typecheck (tsgo -p tsconfig.json) — no error references either changed file.
# The 3 remaining errors are pre-existing/environmental in this fresh worktree
# (uninstalled `iwer` dep + a guard-test implicit-any last touched by #15247),
# not introduced here.
```
</details>

## Evidence rows

- **Real-LLM trajectories** — N/A: no agent/action/provider/prompt/model behavior changed; pure client rAF-scheduling perf change.
- **Backend logs** — N/A: no server code touched.
- **Frontend console/network logs** — N/A: no request/response or store change; the effect is a client-side draw-scheduling gate.
- **Before/after screenshots** — N/A: the wallpaper's appearance at rest and on settle is unchanged by design (unit test proves monotonic `u_time`, i.e. no visual discontinuity). There is no static-pixel diff to show.
- **Video walkthrough / perf-KPI numbers** — Recommended verification is `perf-interaction-kpi` `sheet-drag`/rail-swipe p95 + worst-frame with the GLSL wallpaper active, plus a home↔launcher swipe recording on the **installed iOS Safari PWA**. N/A here: the regression this fixes is GPU/compositor contention specific to the on-device PWA — it does not reproduce in headless desktop Chromium (jsdom has no WebGL; the desktop audit harness doesn't recreate the iOS compositor), so a headless capture would not honestly demonstrate the improvement. The deterministic unit suite is the mechanism proof; on-device KPI capture is the human-verify step.
- **Domain artifacts** — N/A: none produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)