### PR TITLE
fix(core): required-tool gate must not discard grammar-valid widget replies — capture [FORM]/[CHOICE] terminal text like refusals (#15230)

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -1443,6 +1443,174 @@ describe("v5 planner loop skeleton", () => {
 		expect(runtime.useModel).toHaveBeenCalledTimes(2);
 	});
 
+	// #15230: on the CLI text lane the model answers a tool-required turn with a
+	// grammar-valid [FORM] widget reply instead of routing JSON. The gate must
+	// capture that as a legitimate terminal answer instead of burning the miss
+	// budget and letting the caller synthesize a failure apology.
+	const FORM_REPLY =
+		'Happy to set that up — pick what works:\n[FORM]\n{"title":"Schedule it","submit_label":"Save","fields":[{"name":"date","label":"Date","type":"date"},{"name":"time","label":"Time","type":"time"}]}\n[/FORM]';
+
+	it("finishes with the model's own [FORM] reply when it is re-emitted after the required-tool retry (#15230)", async () => {
+		const executeToolCall = vi.fn();
+		const runtime = {
+			useModel: vi.fn(async () => ({ text: FORM_REPLY, toolCalls: [] })),
+			logger: { warn: vi.fn() },
+		};
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			tools: [{ name: "LOOKUP", description: "Lookup current status." }],
+			requireNonTerminalToolCall: true,
+			config: { maxRequiredToolMisses: 3 },
+			executeToolCall,
+			evaluate: vi.fn(),
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toContain("[FORM]");
+		expect(result.finalMessage).toContain('"date"');
+		expect(result.finalMessage).toContain('"time"');
+		// One corrective retry, then the identical re-emission finishes the turn
+		// — NOT maxRequiredToolMisses+1 model spawns and NOT a throw.
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+		expect(executeToolCall).not.toHaveBeenCalled();
+	});
+
+	it("surfaces the latest widget reply at required-tool exhaustion when re-emissions differ (#15230)", async () => {
+		const secondReply =
+			'Sure — just need the details:\n[FORM]\n{"title":"Schedule it","fields":[{"name":"when","label":"When","type":"datetime"}]}\n[/FORM]';
+		const runtime = {
+			useModel: vi
+				.fn()
+				.mockResolvedValueOnce({ text: FORM_REPLY, toolCalls: [] })
+				.mockResolvedValueOnce({ text: secondReply, toolCalls: [] }),
+			logger: { warn: vi.fn() },
+		};
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			tools: [{ name: "LOOKUP", description: "Lookup current status." }],
+			requireNonTerminalToolCall: true,
+			config: { maxRequiredToolMisses: 1 },
+			executeToolCall: vi.fn(),
+			evaluate: vi.fn(),
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(secondReply);
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+	});
+
+	it("finishes with a REPLY-wrapped [FORM] reply under the required-tool gate (#15230)", async () => {
+		// A planner that DOES wrap its widget answer in an explicit REPLY call
+		// hits the terminal_only_tool_calls branch — the same capture must apply.
+		const runtime = {
+			useModel: vi.fn(async () => ({
+				text: "",
+				toolCalls: [
+					{ id: "reply-1", name: "REPLY", arguments: { text: FORM_REPLY } },
+				],
+			})),
+			logger: { warn: vi.fn() },
+		};
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			tools: [{ name: "LOOKUP", description: "Lookup current status." }],
+			requireNonTerminalToolCall: true,
+			config: { maxRequiredToolMisses: 3 },
+			executeToolCall: vi.fn(),
+			evaluate: vi.fn(),
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toContain("[FORM]");
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not capture a malformed widget block as a terminal answer (#15230)", async () => {
+		// The strict parser leaves a malformed block as plain text (no newline
+		// framing, invalid JSON) — zero parsed blocks means the text gets no
+		// widget escape hatch and prose acceptance cannot creep in.
+		const runtime = {
+			useModel: vi.fn(async () => ({
+				text: "Pick what works: [FORM] not-json [/FORM]",
+				toolCalls: [],
+			})),
+			logger: { warn: vi.fn() },
+		};
+
+		await expect(
+			runPlannerLoop({
+				runtime,
+				context: { id: "ctx" },
+				tools: [{ name: "LOOKUP", description: "Lookup current status." }],
+				requireNonTerminalToolCall: true,
+				config: { maxRequiredToolMisses: 1 },
+				executeToolCall: vi.fn(),
+				evaluate: vi.fn(),
+			}),
+		).rejects.toMatchObject({
+			name: "TrajectoryLimitExceeded",
+			kind: "required_tool_misses",
+		});
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+	});
+
+	it("rejects a widget reply carrying leaked tool markup (#15230)", async () => {
+		const runtime = {
+			useModel: vi.fn(async () => ({
+				text: `I need to call SEARCH_MESSAGES first. {"parameters": {"q":"x"}}\n${FORM_REPLY}`,
+				toolCalls: [],
+			})),
+			logger: { warn: vi.fn() },
+		};
+
+		await expect(
+			runPlannerLoop({
+				runtime,
+				context: { id: "ctx" },
+				tools: [{ name: "LOOKUP", description: "Lookup current status." }],
+				requireNonTerminalToolCall: true,
+				config: { maxRequiredToolMisses: 1 },
+				executeToolCall: vi.fn(),
+				evaluate: vi.fn(),
+			}),
+		).rejects.toMatchObject({
+			name: "TrajectoryLimitExceeded",
+			kind: "required_tool_misses",
+		});
+	});
+
+	it("captures a widget reply that says 'let me know' or promises follow-through (#15230)", async () => {
+		// Pins two deliberate gate choices: "let me know" is carved out of the
+		// in-flight reject (widget replies legitimately ask the user to respond),
+		// and a forward-looking "I'll …" conditioned on user input is allowed —
+		// the form gates the side effect on the user's answer.
+		const reply = `Pick a time and let me know — I'll set it up right after.\n[FORM]\n{"title":"Schedule it","fields":[{"name":"time","label":"Time","type":"time"}]}\n[/FORM]`;
+		const runtime = {
+			useModel: vi.fn(async () => ({ text: reply, toolCalls: [] })),
+			logger: { warn: vi.fn() },
+		};
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			tools: [{ name: "LOOKUP", description: "Lookup current status." }],
+			requireNonTerminalToolCall: true,
+			config: { maxRequiredToolMisses: 3 },
+			executeToolCall: vi.fn(),
+			evaluate: vi.fn(),
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(reply);
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+	});
+
 	it("retries planner calls to tools that are not exposed this turn", async () => {
 		const runtime = {
 			useModel: vi

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -11,6 +11,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { computeCallCostUsd } from "../features/trajectories/pricing";
 import { logger } from "../logger";
+import { parseInteractionBlocks } from "../messaging/interactions/parse";
 import { plannerSchema, plannerTemplate } from "../prompts/planner";
 import { resolveOptimizedPromptForRuntime } from "../services/optimized-prompt-resolver";
 import {
@@ -286,6 +287,12 @@ export async function runPlannerLoop(
 	// `maxRequiredToolMisses`, throws `TrajectoryLimitExceeded`, and the
 	// caller surfaces a generic apology instead of the planner's real answer.
 	let lastTerminalRefusalText: string | undefined;
+	// Sanitized widget-bearing terminal text from the previous required-tool
+	// miss. When the model re-emits the identical widget reply after one
+	// corrective retry it is deterministically committed to that answer —
+	// finish with it instead of burning the remaining miss budget (which costs
+	// four cold CLI spawns on the text-planner lane, #15230).
+	let lastMissWidgetText: string | undefined;
 
 	// Coding/full-surface mode (set above from ELIZA_PLANNER_FULL_ACTION_SURFACE):
 	// when the model emits a batch of tool calls in a single response, execute
@@ -361,7 +368,28 @@ export async function runPlannerLoop(
 					const refusalCandidate =
 						userSafeRefusalCandidate(lastPlannerExplicitMessageToUser) ??
 						userSafeRefusalCandidate(plannerOutput.messageToUser);
-					if (refusalCandidate) lastTerminalRefusalText = refusalCandidate;
+					// A widget-bearing reply ([FORM]/[CHOICE]/…) is a legitimate
+					// terminal answer that asks the user for input — capture it like a
+					// refusal so it survives required-tool exhaustion, and finish
+					// immediately when the model re-emits it verbatim after one
+					// corrective retry (#15230).
+					const widgetCandidate =
+						refusalCandidate === undefined
+							? (userSafeWidgetReplyCandidate(
+									lastPlannerExplicitMessageToUser,
+								) ?? userSafeWidgetReplyCandidate(plannerOutput.messageToUser))
+							: undefined;
+					if (widgetCandidate && widgetCandidate === lastMissWidgetText) {
+						return finishWithCapturedRefusal({
+							trajectory,
+							iteration,
+							thought: plannerOutput.thought,
+							refusal: widgetCandidate,
+						});
+					}
+					lastMissWidgetText = widgetCandidate;
+					const captured = refusalCandidate ?? widgetCandidate;
+					if (captured) lastTerminalRefusalText = captured;
 					requiredToolMisses++;
 					if (
 						requiredToolMisses > config.maxRequiredToolMisses &&
@@ -511,13 +539,29 @@ export async function runPlannerLoop(
 					requireNonTerminalToolCall &&
 					!hasExecutedNonTerminalTool(trajectory)
 				) {
-					const refusalCandidate = userSafeRefusalCandidate(
-						terminalMessageFromToolCalls(
-							plannerOutput.toolCalls,
-							plannerOutput.messageToUser,
-						),
+					const terminalText = terminalMessageFromToolCalls(
+						plannerOutput.toolCalls,
+						plannerOutput.messageToUser,
 					);
-					if (refusalCandidate) lastTerminalRefusalText = refusalCandidate;
+					const refusalCandidate = userSafeRefusalCandidate(terminalText);
+					// Same widget-reply escape hatch as the no_tool_calls branch above:
+					// a planner that wraps its [FORM] answer in an explicit REPLY call
+					// must not lose it to the required-tool gate either (#15230).
+					const widgetCandidate =
+						refusalCandidate === undefined
+							? userSafeWidgetReplyCandidate(terminalText)
+							: undefined;
+					if (widgetCandidate && widgetCandidate === lastMissWidgetText) {
+						return finishWithCapturedRefusal({
+							trajectory,
+							iteration,
+							thought: plannerOutput.thought,
+							refusal: widgetCandidate,
+						});
+					}
+					lastMissWidgetText = widgetCandidate;
+					const captured = refusalCandidate ?? widgetCandidate;
+					if (captured) lastTerminalRefusalText = captured;
 					requiredToolMisses++;
 					if (
 						requiredToolMisses > config.maxRequiredToolMisses &&
@@ -3513,6 +3557,42 @@ function userSafeRefusalCandidate(
 	if (isUnsafeUserVisibleText(candidate)) return undefined;
 	if (looksLikePreToolThought(candidate)) return undefined;
 	if (IN_FLIGHT_ACTION_CLAIM.some((pattern) => pattern.test(candidate))) {
+		return undefined;
+	}
+	return candidate;
+}
+
+// In-flight narration reject for widget replies. Narrower than
+// IN_FLIGHT_ACTION_CLAIM because widget replies legitimately say "let me know" /
+// "pick a time and let me know", and a forward-looking promise conditioned on
+// user input ("I'll set it up once you pick a time") is not a false "doing it
+// now" claim — the widget block itself proves the turn ends by asking the user.
+const WIDGET_REPLY_IN_FLIGHT_CLAIM = [
+	/\blet me\b(?!\s+know\b)/i,
+	/\bI'?m\s+(?:checking|fetching|searching|looking|pulling|reviewing|gathering|working|getting|grabbing|loading|digging|querying)\b/i,
+	/\b(?:one|just a)\s+(?:sec|second|moment|min|minute)\b/i,
+	/\bplease (?:hold|wait)\b/i,
+	/\b(?:be right back|brb|hang on)\b/i,
+];
+
+// A terminal reply that renders as an interactive widget (grammar-valid
+// [FORM]/[CHOICE]/[FOLLOWUPS] block) is a request for user input — the
+// conversational analog of an honest refusal to act without more information.
+// Under the required-tool gate it must be capturable the same way a refusal is
+// (#15230): the CLI text lane cannot express REPLY as a native tool call, and
+// discarding a grammar-valid [FORM] answer to synthesize an apology fabricates
+// a failure. The strict block parser is the authenticity check: a pre-tool
+// thought never contains a parse-valid widget block (a malformed block is left
+// as plain text and yields zero blocks).
+function userSafeWidgetReplyCandidate(
+	message: string | undefined,
+): string | undefined {
+	const candidate = sanitizePlannerMessage(message);
+	if (!candidate) return undefined;
+	if (parseInteractionBlocks(candidate).blocks.length === 0) return undefined;
+	if (isUnsafeUserVisibleText(candidate)) return undefined;
+	if (looksLikePreToolThought(candidate)) return undefined;
+	if (WIDGET_REPLY_IN_FLIGHT_CLAIM.some((pattern) => pattern.test(candidate))) {
 		return undefined;
 	}
 	return candidate;


### PR DESCRIPTION
Fixes #15230.

## Root cause (in `packages/core/src/runtime/planner-loop.ts`, not the plugin)

On the CLI text-planner lane (`ELIZA_CHAT_VIA_CLI=claude`), a tool-required turn (`requireNonTerminalToolCall=true`, `toolChoice:"required"`) that the model answers **correctly** with a grammar-valid `[FORM]` widget reply goes down the `no_tool_calls` miss branch. The only escape hatch there is `userSafeRefusalCandidate`, whose positive allowlist (`REFUSAL_MARKERS`) accepts only inability statements. A request-for-input widget reply carries no refusal marker, so the loop discards the identical correct answer up to `maxRequiredToolMisses+1` times (4 cold CLI spawns), throws `TrajectoryLimitExceeded(required_tool_misses)`, and the caller LLM-writes a fabricated apology ("Something glitched on my end…") — tripping scenario-runner's `runtimeFailureReply` guard.

A plugin-side fix (wrapping prose into a REPLY tool call) cannot work: under the gate an explicit REPLY call hits the `terminal_only_tool_calls` miss branch and is discarded through the same refusal gate.

## Fix

Extends the #9874 refusal-capture precedent with a widget-reply capture gate:

- **`userSafeWidgetReplyCandidate`** — accepts terminal text ONLY when it contains a parse-valid interaction block (`parseInteractionBlocks`, strict: malformed blocks parse as plain text → zero blocks → not captured), and still rejects leaked tool markup (`isUnsafeUserVisibleText`), pre-tool deliberation, and in-flight narration. The in-flight reject is deliberately narrower than `IN_FLIGHT_ACTION_CLAIM`: widget replies legitimately say "pick a time and let me know", and a forward-looking "I'll set it up once you pick" is gated on user input by the form itself.
- **Both miss branches** (`no_tool_calls` and `terminal_only_tool_calls`) capture the widget candidate into the existing `lastTerminalRefusalText` exhaustion path, and **finish early** when the model re-emits the byte-identical widget reply after one corrective retry — the model is deterministically committed to that answer; burning 4 CLI spawns to reach the same text is pure latency.
- Refusal capture takes precedence; non-widget, non-refusal terminal text behaves exactly as before (corrective retry → throw → apology), preserving the anti-narration guarantee ("Creating the app now…" has no widget block and is never captured).

## Tests (fail-without-fix verified)

6 new tests in `planner-loop.test.ts`; on unfixed develop the 4 positive ones fail and the 2 negatives pass (regression fence intact):

```
× finishes with the model's own [FORM] reply when it is re-emitted after the required-tool retry (#15230)
× surfaces the latest widget reply at required-tool exhaustion when re-emissions differ (#15230)
× finishes with a REPLY-wrapped [FORM] reply under the required-tool gate (#15230)
× captures a widget reply that says 'let me know' or promises follow-through (#15230)
Tests  4 failed | 71 passed (75)   ← develop
Tests  75 passed (75)              ← this branch
```

Negatives kept green: malformed `[FORM] not-json [/FORM]` (zero parsed blocks) still throws; widget text carrying leaked tool markup (`call SEARCH_MESSAGES`, `{"parameters":`) still rejected; all pre-existing #9874 intent-narration tests unmodified and green.

## Verification

- `vitest run src/runtime/__tests__/planner-loop.test.ts` → 75/75
- `vitest run src/runtime/__tests__/planner-output-safety.test.ts src/messaging/interactions/interactions.test.ts` → 54/54
- `tsgo --noEmit -p packages/core/tsconfig.json` → clean
- `biome check` on both touched files → clean
- No import cycle: `messaging/interactions/parse.ts` imports only `types/interactions`.

## Evidence notes

- Video/screenshots: N/A — core planner-loop control flow; no UI surface changes.
- Live CLI-lane trajectories (`ELIZA_CHAT_VIA_CLI=claude` + `live-chat-widgets-form-roundtrip` ×4): the deterministic repro of the exact discarded-reply shape (grammar-valid `[FORM]` text under `toolChoice=required`, taken from the #15231 trajectories that discovered this bug) is pinned in the unit suite with fail-without-fix proof above; a subscription-host live re-run per #14822's baseline protocol is the confirmation lane and can be attached from any claude-CLI host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence Matrix

<!-- evidence-row:before-screenshots -->
- [ ] N/A - core planner-loop control-flow change; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - core planner-loop control-flow change; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing UI flow changed; deterministic planner-loop tests exercise the branch.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no server process or route changed; focused core tests verify the runtime branch without backend logs.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code, console, or network path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - live CLI/LLM trajectory is not attached in this PR body; deterministic tests pin the exact raw model-output shapes but live trajectory remains required before final merge review.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no database rows, files, scheduled tasks, media, wallet/on-chain state, or other persisted domain artifact changed.
