### PR TITLE
perf(chat): unify doc-augmentation embed with the per-turn recall cache

### DIFF
--- a/packages/agent/src/api/chat-augmentation.test.ts
+++ b/packages/agent/src/api/chat-augmentation.test.ts
@@ -180,4 +180,23 @@ describe("maybeAugmentChatMessageWithDocuments", () => {
     expect(documents.countMemories).toHaveBeenCalledTimes(1);
     expect(documents.searchDocuments).toHaveBeenCalled();
   });
+
+  it("passes the original message id as turnMessageId so the in-run recall embed adopts this pre-run embed (#15253)", async () => {
+    const message = makeMessage();
+    const documents = {
+      countMemories: vi.fn().mockResolvedValue(3),
+      searchDocuments: vi.fn().mockResolvedValue([]),
+    };
+    const runtime = makeRuntime(documents);
+
+    await maybeAugmentChatMessageWithDocuments(runtime, message);
+
+    // The turn key travels via the 5th `options` arg, NOT the search message —
+    // whose id is deliberately a fresh UUID for the scope-read coercion.
+    const [searchMessage, , , , options] =
+      documents.searchDocuments.mock.calls[0];
+    expect(options).toEqual({ turnMessageId: message.id });
+    expect(searchMessage.id).not.toBe(message.id);
+    expect(typeof searchMessage.id).toBe("string");
+  });
 });

--- a/packages/agent/src/api/chat-augmentation.ts
+++ b/packages/agent/src/api/chat-augmentation.ts
@@ -285,6 +285,14 @@ export async function maybeAugmentChatMessageWithDocuments(
   };
 
   const lookupTimeoutMs = resolveLookupTimeoutMs(options.lookupTimeoutMs);
+  // This augmentation embeds the recall query BEFORE the run starts (no runId
+  // yet), so the per-turn embed cache keys off the turn's message id instead.
+  // The in-run TTFT prefetch presents the same id and adopts this vector rather
+  // than issuing a second identical embed round-trip (#15253). The turn key
+  // travels via this option, NOT the search message (whose id is deliberately a
+  // fresh UUID for the scope-read coercion above).
+  const turnMessageId =
+    typeof message.id === "string" ? (message.id as UUID) : undefined;
   const loadMatches = async (
     scopeRoomId: UUID,
     queryText: string,
@@ -307,6 +315,7 @@ export async function maybeAugmentChatMessageWithDocuments(
           { roomId: scopeRoomId },
           undefined,
           accessContext,
+          { turnMessageId },
         )) ?? [],
     );
     return { matches: result.value, timedOut: result.timedOut };

--- a/packages/agent/src/api/documents-service-loader.ts
+++ b/packages/agent/src/api/documents-service-loader.ts
@@ -71,6 +71,7 @@ export interface DocumentsServiceLike {
     scope?: { roomId?: UUID; worldId?: UUID; entityId?: UUID },
     searchMode?: DocumentSearchMode,
     accessContext?: AccessContext,
+    options?: { turnMessageId?: UUID },
   ): Promise<
     Array<{
       id: UUID;

--- a/packages/core/src/features/documents/__tests__/search.test.ts
+++ b/packages/core/src/features/documents/__tests__/search.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { Memory, UUID } from "../../../types";
 import { MemoryType, ModelType } from "../../../types";
 import { bm25Scores, normalizeBm25Scores, tokenize } from "../bm25";
+import { embedRecallQuery } from "../recall-embed";
 import { DocumentService } from "../service";
 
 // ── BM25 unit tests ────────────────────────────────────────────────────────
@@ -474,6 +475,70 @@ describe("DocumentService.searchDocuments", () => {
 			// Fast embed → vector search ran (searchMemories), no keyword fallback.
 			expect(rt.searchMemories).toHaveBeenCalledOnce();
 			expect(results[0].id).toBe("frag-fast");
+		});
+	});
+
+	// Proves the `turnMessageId` option threads all the way through
+	// `_vectorSearch`/`_hybridSearch` into `embedRecallQuery`, so the pre-run
+	// augmentation search and the in-run recall embed of the same query share one
+	// round-trip (#15253). Models the real run-id transition: the pre-run search
+	// embeds under a transient id, then a live run id supersedes it.
+	describe("turnMessageId threading (#15253)", () => {
+		const TURN_MESSAGE_ID = "44444444-4444-4444-4444-444444444444" as UUID;
+		const R_AUG = "aaaaaaaa-0000-0000-0000-000000000001" as UUID;
+		const RUN_ID = "bbbbbbbb-0000-0000-0000-000000000002" as UUID;
+
+		function buildEmbedCountingRuntime() {
+			const rt = buildRuntime({
+				hasEmbedding: true,
+				fragments: [],
+			}) as ReturnType<typeof buildRuntime> & { getCurrentRunId: () => string };
+			let runId: string = R_AUG;
+			rt.getCurrentRunId = () => runId;
+			rt.useModel = vi.fn(async () => [0.1, 0.2, 0.3]) as typeof rt.useModel;
+			return {
+				rt,
+				startRun: () => {
+					runId = RUN_ID;
+				},
+			};
+		}
+
+		const embedCallCount = (rt: {
+			useModel: ReturnType<typeof vi.fn>;
+		}): number =>
+			rt.useModel.mock.calls.filter(
+				([modelType]) => modelType === ModelType.TEXT_EMBEDDING,
+			).length;
+
+		it.each([
+			"vector",
+			"hybrid",
+		] as const)("%s mode threads turnMessageId so the in-run recall embed adopts the search embed — one round-trip", async (mode) => {
+			const { rt, startRun } = buildEmbedCountingRuntime();
+			const svc = buildService(rt);
+			const text = "what is the escalation policy?";
+
+			await svc.searchDocuments(
+				makeMessage(text),
+				{ roomId: "room-1" as UUID },
+				mode,
+				undefined,
+				{ turnMessageId: TURN_MESSAGE_ID },
+			);
+			expect(rt.searchMemories).toHaveBeenCalled();
+			expect(embedCallCount(rt)).toBe(1);
+
+			// In-run recall caller (prefetch) presents the same messageId → adopts
+			// the search's pre-run vector instead of re-embedding.
+			startRun();
+			const vector = await embedRecallQuery(
+				rt as unknown as Parameters<typeof embedRecallQuery>[0],
+				text,
+				{ messageId: TURN_MESSAGE_ID },
+			);
+			expect(vector).toEqual([0.1, 0.2, 0.3]);
+			expect(embedCallCount(rt)).toBe(1);
 		});
 	});
 });

--- a/packages/core/src/features/documents/recall-embed.test.ts
+++ b/packages/core/src/features/documents/recall-embed.test.ts
@@ -13,6 +13,8 @@ import { embedRecallQuery } from "./recall-embed.ts";
 
 const RUN_A = "11111111-1111-1111-1111-111111111111";
 const RUN_B = "22222222-2222-2222-2222-222222222222";
+const MSG_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const MSG_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
 
 interface RuntimeMockOpts {
 	runId?: string;
@@ -164,5 +166,227 @@ describe("embedRecallQuery — per-turn cache + dedupe (item 2)", () => {
 		await embedRecallQuery(runtime, "shared query");
 		// New turn → fresh cache → a second embed call.
 		expect(calls.count).toBe(2);
+	});
+});
+
+/**
+ * A runtime whose run state is mutable: `getCurrentRunId` throws while no run is
+ * active and returns the set id once `setRun` is called. The throw exercises the
+ * defensive `runId=""` branch (some runtime shapes/tests have no run in scope);
+ * the real `AgentRuntime` instead lazily mints a transient id — that auto-mint
+ * transition is covered separately. Both reach the same messageId-keyed slot.
+ */
+function makeControllableRuntime(
+	embed: (params: { text: string }) => Promise<number[]>,
+): {
+	runtime: IAgentRuntime;
+	calls: { count: number };
+	setRun: (runId: string | null) => void;
+} {
+	const state: { runId: string | null } = { runId: null };
+	const calls = { count: 0 };
+	const runtime = createMockRuntime({
+		getCurrentRunId: () => {
+			if (state.runId === null) {
+				throw new Error("no active run");
+			}
+			return state.runId;
+		},
+		useModel: (type: string, params: { text: string }) => {
+			if (type !== ModelType.TEXT_EMBEDDING) {
+				throw new Error(`unexpected model ${type}`);
+			}
+			calls.count++;
+			return embed(params);
+		},
+	});
+	return {
+		runtime,
+		calls,
+		setRun: (runId) => {
+			state.runId = runId;
+		},
+	};
+}
+
+/** Yield a macrotask so the detached in-flight-cleanup `.finally` settles —
+ * mirrors the real gap between pre-run augmentation and the in-run prefetch. */
+const yieldMacrotask = (): Promise<void> =>
+	new Promise((resolve) => setTimeout(resolve, 0));
+
+describe("embedRecallQuery — pre-run messageId cache + in-run adoption (#15253)", () => {
+	test("pre-run embed caches by messageId, the in-run prefetch adopts it, and later runId-only callers share the slot — one embed for the whole turn", async () => {
+		const { runtime, calls, setRun } = makeControllableRuntime(async () => [
+			0.9,
+		]);
+
+		// 1) Pre-run augmentation: getCurrentRunId throws → key by messageId.
+		const preRun = await embedRecallQuery(runtime, "same text", {
+			messageId: MSG_A,
+		});
+		expect(preRun).toEqual([0.9]);
+		expect(calls.count).toBe(1);
+
+		// 2) In-run TTFT prefetch: same messageId, now with a live run → adopts the
+		//    pre-run slot and resolves from cache, no new embed.
+		setRun(RUN_A);
+		const prefetch = await embedRecallQuery(runtime, "same text", {
+			messageId: MSG_A,
+		});
+		expect(prefetch).toEqual([0.9]);
+		expect(calls.count).toBe(1);
+
+		// 3) Compose-time recall caller (relevant-conversations / document recall):
+		//    runId only, no messageId. The adopted slot now carries RUN_A → hit.
+		const composeTime = await embedRecallQuery(runtime, "same text");
+		expect(composeTime).toEqual([0.9]);
+		expect(calls.count).toBe(1);
+	});
+
+	test("real runtime shape: a transient pre-run runId replaced by startRun still unifies to one embed via messageId adoption", async () => {
+		// `AgentRuntime.getCurrentRunId()` lazily mints a run id, so the pre-run
+		// augmentation embed lands under a transient id (R_AUG) that `startRun`
+		// then replaces with the turn's real id (RUN_A). Without the messageId key,
+		// the in-run prefetch would miss R_AUG's slot and re-embed. Model exactly
+		// that id transition (no throwing — the real runtime never throws here).
+		const R_AUG = "99999999-9999-9999-9999-999999999999";
+		let runId = R_AUG;
+		const calls = { count: 0 };
+		const runtime = createMockRuntime({
+			getCurrentRunId: () => runId,
+			useModel: (type: string, _params: { text: string }) => {
+				if (type !== ModelType.TEXT_EMBEDDING) {
+					throw new Error(`unexpected model ${type}`);
+				}
+				calls.count++;
+				return Promise.resolve([0.7]);
+			},
+		});
+
+		// Augmentation embeds under the transient R_AUG, keyed by messageId.
+		await embedRecallQuery(runtime, "same text", { messageId: MSG_A });
+		expect(calls.count).toBe(1);
+
+		// startRun replaces the run id; the prefetch presents the same messageId
+		// and adopts the R_AUG slot, re-stamping it with RUN_A.
+		runId = RUN_A;
+		await embedRecallQuery(runtime, "same text", { messageId: MSG_A });
+		expect(calls.count).toBe(1);
+
+		// Compose-time recall callers key off runId only and now hit the adopted
+		// slot — no second embed for the whole turn.
+		await embedRecallQuery(runtime, "same text");
+		expect(calls.count).toBe(1);
+	});
+
+	test("adoption does not leak across turns: a new turn (different runId + messageId) re-embeds", async () => {
+		const { runtime, calls, setRun } = makeControllableRuntime(async () => [
+			0.1,
+		]);
+		await embedRecallQuery(runtime, "text one", { messageId: MSG_A });
+		setRun(RUN_A);
+		await embedRecallQuery(runtime, "text one", { messageId: MSG_A });
+		expect(calls.count).toBe(1);
+
+		// Next turn: fresh run + message → fresh cache → new embed.
+		setRun(RUN_B);
+		await embedRecallQuery(runtime, "text two", { messageId: MSG_B });
+		expect(calls.count).toBe(2);
+	});
+
+	test("a concurrent second pre-run turn evicts the single slot; the first turn's in-run call re-embeds (a miss, never a wrong vector)", async () => {
+		const { runtime, calls, setRun } = makeControllableRuntime(async () => [
+			0.2,
+		]);
+		// Two pre-run turns warm the single cache slot in sequence; the second
+		// replaces the first (single-slot per runtime, unchanged semantics).
+		await embedRecallQuery(runtime, "turn one query", { messageId: MSG_A });
+		await embedRecallQuery(runtime, "turn two query", { messageId: MSG_B });
+		expect(calls.count).toBe(2);
+
+		// Turn one now runs in-run: its messageId no longer matches the slot
+		// (occupied by MSG_B) → fresh cache → re-embed. Correct: a cache miss,
+		// never MSG_B's vector attributed to turn one.
+		setRun(RUN_A);
+		await embedRecallQuery(runtime, "turn one query", { messageId: MSG_A });
+		expect(calls.count).toBe(3);
+	});
+
+	test("a runId-only caller never adopts a pre-run slot without a messageId match (no mis-promotion)", async () => {
+		const { runtime, calls, setRun } = makeControllableRuntime(async () => [
+			0.3,
+		]);
+		// Pre-run cache under {runId:"", messageId: MSG_A}.
+		await embedRecallQuery(runtime, "query", { messageId: MSG_A });
+		expect(calls.count).toBe(1);
+
+		// An in-run caller with a live run but NO messageId must not promote the
+		// pre-run slot into its turn: fresh cache → new embed.
+		setRun(RUN_A);
+		await embedRecallQuery(runtime, "query");
+		expect(calls.count).toBe(2);
+	});
+
+	test("a failed pre-run embed is not cached across the boundary: the in-run caller re-embeds", async () => {
+		let shouldFail = true;
+		const { runtime, calls, setRun } = makeControllableRuntime(async () => {
+			if (shouldFail) {
+				throw new Error("embeddings endpoint 500");
+			}
+			return [0.4];
+		});
+		const preRun = await embedRecallQuery(runtime, "query", {
+			messageId: MSG_A,
+		});
+		expect(preRun).toBeNull();
+		expect(calls.count).toBe(1);
+
+		// Let the detached in-flight cleanup settle (as real time would).
+		await yieldMacrotask();
+
+		// The failed embed left nothing cached; the in-run caller issues a fresh
+		// round-trip (which now succeeds) rather than replaying the failure.
+		shouldFail = false;
+		setRun(RUN_A);
+		const inRun = await embedRecallQuery(runtime, "query", {
+			messageId: MSG_A,
+		});
+		expect(inRun).toEqual([0.4]);
+		expect(calls.count).toBe(2);
+	});
+
+	test("a caller with neither a run nor a messageId stays uncached: two identical calls issue two embeds", async () => {
+		const { runtime, calls } = makeControllableRuntime(async () => [0.5]);
+		// getCurrentRunId throws (no run) and no messageId → direct, uncached embed.
+		await embedRecallQuery(runtime, "background query");
+		await embedRecallQuery(runtime, "background query");
+		expect(calls.count).toBe(2);
+	});
+
+	test("in-flight dedupe spans the pre-run/in-run boundary: a pre-run embed and an in-run adopt of the same messageId share one round-trip", async () => {
+		let resolveEmbed: ((v: number[]) => void) | undefined;
+		const { runtime, calls, setRun } = makeControllableRuntime(
+			() =>
+				new Promise<number[]>((resolve) => {
+					resolveEmbed = resolve;
+				}),
+		);
+		// Pre-run embed starts and stays in flight.
+		const preRun = embedRecallQuery(runtime, "same text", { messageId: MSG_A });
+		expect(calls.count).toBe(1);
+
+		// The in-run prefetch adopts the slot and joins the in-flight promise
+		// before it resolves — no second round-trip.
+		setRun(RUN_A);
+		const prefetch = embedRecallQuery(runtime, "same text", {
+			messageId: MSG_A,
+		});
+		expect(calls.count).toBe(1);
+
+		resolveEmbed?.([1, 1, 1]);
+		const [a, b] = await Promise.all([preRun, prefetch]);
+		expect(a).toEqual([1, 1, 1]);
+		expect(b).toEqual([1, 1, 1]);
+		expect(calls.count).toBe(1);
 	});
 });

--- a/packages/core/src/features/documents/recall-embed.ts
+++ b/packages/core/src/features/documents/recall-embed.ts
@@ -12,9 +12,23 @@
  * **Per-turn cache + in-flight dedupe.** The same query text is embedded more
  * than once per turn (vector + hybrid document search, experience recall,
  * relevant-conversations). Identical normalized query text within one turn
- * (keyed by `runId`) resolves to a single embed call; concurrent identical
- * embeds share one in-flight promise. The cache is scoped to the turn and
- * evicted when a new turn's `runId` is observed, so it never grows unbounded.
+ * resolves to a single embed call; concurrent identical embeds share one
+ * in-flight promise. The cache is scoped to the turn and evicted when a new
+ * turn's key is observed, so it never grows unbounded.
+ *
+ * **Turn key = `runId`, plus a `messageId` that survives the run transition.**
+ * The API chat path embeds the user query during document augmentation *before*
+ * `startRun`. `AgentRuntime.getCurrentRunId()` lazily mints a transient run id
+ * there, so the augmentation embed would otherwise cache under an id that
+ * `startRun` immediately replaces — orphaning the vector and forcing a second
+ * identical embed in-run. Augmentation therefore also presents the turn's
+ * `messageId`; the in-run TTFT prefetch presents the same `messageId` and ADOPTS
+ * the slot, re-stamping it with the real `runId` so every later `runId`-only
+ * recall caller (compose-time providers) shares the already-warmed vector
+ * instead of issuing a second round-trip. A `runId`-only caller never adopts a
+ * slot without a `messageId` match, so a concurrent turn's vectors can never be
+ * attributed to the wrong turn (worst case: a cache miss, never a wrong vector).
+ * A caller with neither key (background/non-turn) embeds directly, uncached.
  *
  * **Fail-open on error only.** A failed embed (the model handler rejects — e.g.
  * its own request timeout aborts, or the provider errors) returns `null`; the
@@ -40,7 +54,12 @@ function normalizeQuery(text: string): string {
 }
 
 interface TurnEmbedCache {
+	/** The run id this slot is keyed under: the live run id in-run, or (pre-run)
+	 * the transient id `getCurrentRunId` minted / `""` if it threw — re-stamped to
+	 * the live id on adoption. */
 	runId: string;
+	/** Turn message id — the pre-run turn key, set when the caller presents one. */
+	messageId?: string;
 	/** Resolved vectors keyed by normalized query text. */
 	results: Map<string, number[]>;
 	/** In-flight embeds keyed by normalized query text (dedupe concurrent calls). */
@@ -54,15 +73,47 @@ interface TurnEmbedCache {
  */
 const turnCaches = new WeakMap<IAgentRuntime, TurnEmbedCache>();
 
-function getTurnCache(runtime: IAgentRuntime, runId: string): TurnEmbedCache {
+/**
+ * Resolve the current turn's cache, creating a fresh one on a turn boundary.
+ *
+ * A cache matches when its `runId` equals a non-empty caller `runId`, OR when
+ * its `messageId` equals the caller's `messageId`. On a `messageId` match where
+ * the caller has a live `runId` that differs from the slot's, the slot is
+ * ADOPTED — its `runId` is re-stamped in place so subsequent `runId`-only
+ * callers this turn resolve to it.
+ *
+ * Adoption spans the pre-run→in-run transition on the API chat path:
+ * `AgentRuntime.getCurrentRunId()` lazily mints a run id, so the pre-run
+ * document-augmentation embed caches under a transient id; `startRun()` then
+ * mints the turn's real id. Keying the pre-run embed by `messageId` lets the
+ * in-run prefetch (same `messageId`) re-stamp the slot with the real `runId`
+ * instead of orphaning that vector under the transient one.
+ *
+ * A `runId`-only caller (no `messageId`) matches only on a real `runId`, so it
+ * can never promote an unrelated concurrent turn's slot into its own — worst
+ * case a cache miss, never a wrong vector. No match replaces the slot wholesale,
+ * bounding memory to a single turn's distinct queries.
+ */
+function getTurnCache(
+	runtime: IAgentRuntime,
+	runId: string,
+	messageId?: string,
+): TurnEmbedCache {
 	const existing = turnCaches.get(runtime);
-	if (existing && existing.runId === runId) {
-		return existing;
+	if (existing) {
+		const runIdMatch = runId !== "" && existing.runId === runId;
+		const messageIdMatch =
+			messageId !== undefined && existing.messageId === messageId;
+		if (runIdMatch || messageIdMatch) {
+			if (messageIdMatch && runId !== "" && existing.runId !== runId) {
+				existing.runId = runId;
+			}
+			return existing;
+		}
 	}
-	// New turn (or first call): start a fresh cache. The previous turn's entries
-	// are dropped wholesale, bounding memory to a single turn's distinct queries.
 	const fresh: TurnEmbedCache = {
 		runId,
+		messageId,
 		results: new Map(),
 		inFlight: new Map(),
 	};
@@ -75,6 +126,10 @@ function getTurnCache(runtime: IAgentRuntime, runId: string): TurnEmbedCache {
  * recall providers (documents, experience, relevant-conversations) sharing the
  * same runtime + `runId`.
  *
+ * @param options.messageId - the turn's message id, supplied by pre-run callers
+ *   (document augmentation) so the embed caches before a `runId` exists and the
+ *   first in-run caller adopts it. Omit for the common in-run recall callers,
+ *   which key off `runId`.
  * @returns the embedding vector, or `null` when the embed failed — in which case
  *   the caller MUST fail open to keyword/BM25 recall (or, where no keyword path
  *   exists, to empty recall context); never drop recall silently.
@@ -82,6 +137,7 @@ function getTurnCache(runtime: IAgentRuntime, runId: string): TurnEmbedCache {
 export async function embedRecallQuery(
 	runtime: IAgentRuntime,
 	queryText: string,
+	options?: { messageId?: string },
 ): Promise<number[] | null> {
 	const normalized = normalizeQuery(queryText);
 	if (!normalized) {
@@ -92,11 +148,18 @@ export async function embedRecallQuery(
 	try {
 		runId = runtime.getCurrentRunId();
 	} catch {
-		// No active run (e.g. a non-turn caller): skip caching, embed directly.
+		// No active run yet (a pre-run caller such as document augmentation): fall
+		// back to the messageId turn key below so the vector still caches.
 		runId = "";
 	}
 
-	const cache = runId ? getTurnCache(runtime, runId) : null;
+	const messageId = options?.messageId;
+	// Cache whenever there is a turn key: a live `runId`, or a pre-run
+	// `messageId`. A caller with neither (background/non-turn) embeds directly.
+	const cache =
+		runId !== "" || messageId !== undefined
+			? getTurnCache(runtime, runId, messageId)
+			: null;
 
 	const cached = cache?.results.get(normalized);
 	if (cached) {

--- a/packages/core/src/features/documents/service.ts
+++ b/packages/core/src/features/documents/service.ts
@@ -935,6 +935,7 @@ export class DocumentService extends Service {
 		scope?: { roomId?: UUID; worldId?: UUID; entityId?: UUID },
 		searchMode?: SearchMode,
 		accessContext?: AccessContext,
+		options?: { turnMessageId?: UUID },
 	): Promise<StoredDocument[]> {
 		if (!message.content.text || message.content.text.trim().length === 0) {
 			logger.warn("Invalid or empty message content for document query");
@@ -969,11 +970,23 @@ export class DocumentService extends Service {
 		}
 
 		if (effectiveMode === "vector") {
-			return this._vectorSearch(queryText, filterScope, message, accessContext);
+			return this._vectorSearch(
+				queryText,
+				filterScope,
+				message,
+				accessContext,
+				options?.turnMessageId,
+			);
 		}
 
 		// hybrid: vector + BM25 combined
-		return this._hybridSearch(queryText, filterScope, message, accessContext);
+		return this._hybridSearch(
+			queryText,
+			filterScope,
+			message,
+			accessContext,
+			options?.turnMessageId,
+		);
 	}
 
 	/** Pure vector (cosine-similarity) search. */
@@ -982,11 +995,16 @@ export class DocumentService extends Service {
 		filterScope: { roomId?: UUID; worldId?: UUID; entityId?: UUID },
 		message?: Memory,
 		accessContext?: AccessContext,
+		turnMessageId?: UUID,
 	): Promise<StoredDocument[]> {
 		// Bound the recall embed and fail open to keyword/BM25 recall on a
 		// slow/unavailable embed (issue #47): a slow embed costs recall richness,
-		// never reply latency. `embedRecallQuery` caches + dedupes per turn.
-		const embedding = await embedRecallQuery(this.runtime, queryText);
+		// never reply latency. `embedRecallQuery` caches + dedupes per turn; the
+		// pre-run augmentation caller threads `turnMessageId` so the in-run
+		// prefetch adopts this vector instead of re-embedding (#15253).
+		const embedding = await embedRecallQuery(this.runtime, queryText, {
+			messageId: turnMessageId,
+		});
 		if (!embedding) {
 			return this._keywordSearch(
 				queryText,
@@ -1088,12 +1106,17 @@ export class DocumentService extends Service {
 		filterScope: { roomId?: UUID; worldId?: UUID; entityId?: UUID },
 		message?: Memory,
 		accessContext?: AccessContext,
+		turnMessageId?: UUID,
 	): Promise<StoredDocument[]> {
 		// Bound the recall embed and fail open to keyword/BM25 recall on a
 		// slow/unavailable embed (issue #47). `_keywordSearch` is the same BM25
 		// path hybrid would otherwise blend in, so a slow embed degrades
 		// gracefully to keyword-only recall instead of blocking the reply.
-		const embedding = await embedRecallQuery(this.runtime, queryText);
+		// `turnMessageId` lets the pre-run augmentation caller warm the per-turn
+		// cache the in-run prefetch adopts (#15253).
+		const embedding = await embedRecallQuery(this.runtime, queryText, {
+			messageId: turnMessageId,
+		});
 		if (!embedding) {
 			return this._keywordSearch(
 				queryText,

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -9434,11 +9434,20 @@ export class DefaultMessageService implements IMessageService {
 		// (keyed by this run), so they await this in-flight result rather than
 		// starting a fresh round-trip. Fire-and-forget; the value is re-read from
 		// the per-run cache by its normalized-text key.
+		// Present the turn's `messageId` so this prefetch ADOPTS the pre-run cache
+		// the API chat path's document augmentation already warmed under the same
+		// id (#15253): on a no-match turn the query text is byte-identical, so the
+		// adopted vector resolves here with ZERO new embed instead of a second
+		// identical round-trip.
 		// error-policy:J7 diagnostics-must-not-kill-the-loop — a warm failure only
 		// forfeits the overlap; the compose-time caller re-embeds and fails open.
 		const recallWarmText = message.content?.text;
 		if (typeof recallWarmText === "string" && recallWarmText.trim() !== "") {
-			void embedRecallQuery(runtime, recallWarmText).catch((error) =>
+			const recallWarmMessageId =
+				typeof message.id === "string" ? message.id : undefined;
+			void embedRecallQuery(runtime, recallWarmText, {
+				messageId: recallWarmMessageId,
+			}).catch((error) =>
 				runtime.reportError("MessageService.recallEmbedPrefetch", error, {
 					roomId: message.roomId,
 					runId,

--- a/packages/core/src/services/message.ttft-prefetch.test.ts
+++ b/packages/core/src/services/message.ttft-prefetch.test.ts
@@ -23,6 +23,10 @@ const USER_ID = "00000000-0000-0000-0000-0000000000c1" as UUID;
 const ROOM_ID = "00000000-0000-0000-0000-0000000000d1" as UUID;
 const WORLD_ID = "00000000-0000-0000-0000-0000000000e1" as UUID;
 const RUN_ID = "00000000-0000-0000-0000-0000000000f1" as UUID;
+// The transient run id `AgentRuntime.getCurrentRunId()` lazily mints during the
+// pre-run augmentation window, before `startRun` mints RUN_ID. Distinct from
+// RUN_ID so the R_aug≠R_run mismatch the fix targets is actually exercised.
+const PRERUN_ID = "00000000-0000-0000-0000-0000000000f9" as UUID;
 const MESSAGE_ID = "00000000-0000-0000-0000-0000000000e2" as UUID;
 const WARM_VECTOR = [0.11, 0.22, 0.33];
 
@@ -31,6 +35,13 @@ interface RuntimeOptions {
 	muted?: boolean;
 	/** Force LLM-off-by-default so the turn drops before compose. */
 	llmOff?: boolean;
+	/**
+	 * Model the real run lifecycle: `getCurrentRunId` lazily mints a transient
+	 * PRERUN_ID until `startRun` mints RUN_ID, reproducing the pre-run
+	 * document-augmentation window on the API chat path where the augmentation
+	 * embed caches under a run id that `startRun` then replaces.
+	 */
+	deferRunUntilStart?: boolean;
 }
 
 function makeRuntime(opts: RuntimeOptions = {}) {
@@ -57,14 +68,18 @@ function makeRuntime(opts: RuntimeOptions = {}) {
 		if (modelType === ModelType.TEXT_EMBEDDING) return WARM_VECTOR;
 		throw new Error(`unexpected non-embedding model call: ${modelType}`);
 	});
+	let runStarted = !opts.deferRunUntilStart;
 	const runtime = {
 		agentId: AGENT_ID,
 		character: { name: "Eliza" },
 		logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 		stateCache: new Map(),
 		turnControllers: new TurnControllerRegistry(),
-		startRun: vi.fn(() => RUN_ID),
-		getCurrentRunId: vi.fn(() => RUN_ID),
+		startRun: vi.fn(() => {
+			runStarted = true;
+			return RUN_ID;
+		}),
+		getCurrentRunId: vi.fn(() => (runStarted ? RUN_ID : PRERUN_ID)),
 		emitEvent: vi.fn(async () => undefined),
 		runActionsByMode: vi.fn(async () => undefined),
 		reportError: vi.fn(),
@@ -145,6 +160,39 @@ describe("recall-query embed prefetch (per-turn cache warm)", () => {
 			([modelType]) => modelType === ModelType.TEXT_EMBEDDING,
 		);
 		expect(embedCalls).toHaveLength(1);
+	});
+
+	it("adopts the pre-run augmentation embed — one embed for the whole turn (#15253)", async () => {
+		// Reproduce the API chat sequence: document augmentation embeds the query
+		// BEFORE the run starts (getCurrentRunId mints the transient PRERUN_ID,
+		// keyed here by messageId), then handleMessage calls startRun (minting the
+		// distinct RUN_ID) and the prefetch fires. Presenting the same messageId,
+		// the prefetch adopts the pre-run vector — re-stamping the slot with
+		// RUN_ID — instead of issuing a second identical round-trip.
+		const { runtime, useModel } = makeRuntime({ deferRunUntilStart: true });
+		const service = new DefaultMessageService();
+		const text = "what is the refund policy?";
+
+		// Pre-run augmentation embed (no active run yet).
+		const preRun = await embedRecallQuery(runtime, text, {
+			messageId: MESSAGE_ID,
+		});
+		expect(preRun).toEqual(WARM_VECTOR);
+		expect(
+			useModel.mock.calls.filter(
+				([modelType]) => modelType === ModelType.TEXT_EMBEDDING,
+			),
+		).toHaveLength(1);
+
+		await service.handleMessage(runtime, userMessage(text));
+
+		// The in-run prefetch adopted the pre-run slot → still exactly one embed
+		// for the whole turn.
+		const embedCalls = useModel.mock.calls.filter(
+			([modelType]) => modelType === ModelType.TEXT_EMBEDDING,
+		);
+		expect(embedCalls).toHaveLength(1);
+		expect(embedCalls[0][1]).toEqual({ text });
 	});
 
 	it("issues no embed for a muted turn (dropped turn = zero model calls)", async () => {


### PR DESCRIPTION
## What

On the API chat path, document augmentation embeds the user query **before** `startRun`. `AgentRuntime.getCurrentRunId()` (`packages/core/src/runtime.ts:1266`) lazily mints a *transient* run id in that window, so the augmentation embed caches under an id that `startRun` (`services/message.ts:8941`) immediately replaces — orphaning the vector. The #15252 TTFT prefetch then re-embeds the identical query text in-run. Any agent with `document_fragments > 0` paid **two** full `TEXT_EMBEDDING` round-trips per turn for the same normalized query.

This keys the pre-run augmentation embed by the turn's `messageId` and lets the first in-run caller **adopt** that cache slot, re-stamping it with the live `runId` so every later `runId`-only recall caller (compose-time providers) shares the already-warmed vector.

## Why this design (Option B)

The issue offered two options. **Option A** (move augmentation inside the run scope) needs either core importing agent-layer code or a run-lifecycle restructure in `chat-routes`/`processMessage` — large blast radius. **Option B** (this PR) keys the shared recall-embed cache by `messageId`, which is available pre-run:

- no run-lifecycle change, no `core → agent` inversion;
- the single-slot per-turn memory bound is preserved (wholesale eviction on the next turn);
- a `runId`-only caller **never** adopts a slot without a `messageId` match, so a concurrent turn's vectors can never be attributed to the wrong turn (worst case a cache miss, never a wrong vector — locked by a dedicated no-mis-promotion test).

> Note: the issue body's mechanism ("`getCurrentRunId()` throws → `runId=""`") is imprecise — the real runtime *auto-mints* a transient id rather than throwing. The net double-embed is the same, but the fix must adopt across a *transient-id → real-id* transition, not just a `""` slot. The adoption rule and tests reflect the real behavior; the defensive `runId=""` throw branch is still covered.

## Changes

- **`recall-embed.ts`** — cache keyed by `runId` **or** (pre-run) `messageId`; on a `messageId` match with a differing live `runId`, the slot is adopted (re-stamped). Failures stay uncached; background callers (no run, no messageId) embed directly, unchanged.
- **`documents/service.ts`** — `searchDocuments` gains an optional `{ turnMessageId }` (5th param) threaded into `_vectorSearch`/`_hybridSearch` → `embedRecallQuery(runtime, text, { messageId })`. `_keywordSearch` does not embed — untouched. Fully back-compat: every other caller passes fewer args.
- **`documents-service-loader.ts`** — mirror the optional 5th param on the structural `DocumentsServiceLike`.
- **`chat-augmentation.ts`** — pass `{ turnMessageId: message.id }`; the search message's `id` stays a fresh UUID for the scope-read coercion.
- **`message.ts`** — the TTFT prefetch presents `{ messageId: message.id }` so it adopts the pre-run slot (kept the `error-policy:J7` annotation).

## Behavioral outcome

- no-match corpus turn = **exactly one** embed for the query text (was two);
- empty-corpus turn = one (prefetch only; augmentation short-circuits on `fragmentCount 0`) — unchanged;
- match turn = two, the second for the genuinely different `<contextual_documents>` envelope text (documented residual, out of scope);
- fail-open when no embedding model is registered is untouched (`searchDocuments` falls to keyword mode before embedding; `embedRecallQuery` still returns `null` on model errors).

## Verification

```
bun run --cwd packages/core test src/features/documents/recall-embed.test.ts \
  src/services/message.ttft-prefetch.test.ts src/features/documents/__tests__/search.test.ts
bun run --cwd packages/core typecheck
bun run --cwd packages/agent typecheck
bun run audit:error-policy-ratchet
```

<details>
<summary>Real output</summary>

```
# core: recall-embed + ttft-prefetch + documents/search
 Test Files  3 passed (3)
      Tests  49 passed (49)

# core typecheck
$ tsgo --noEmit -p ./tsconfig.json    (clean)

# agent typecheck
$ tsgo --noEmit -p tsconfig.json      (clean)

# agent: chat-augmentation suites (direct vitest)
 Test Files  1 passed (1)   Tests  6 passed (6)   # chat-augmentation.test.ts
 Test Files  2 passed (2)   Tests  7 passed (7)   # access-context + route

# recall consumers unaffected
 core: experience.findSimilar + message.mute-drop + message.shortcut-gate → 16 passed
 agent: relevant-conversations (+ fastfail) → 6 passed

# error-policy ratchet
[error-policy-ratchet] base origin/develop (32ca6a8b7c); 5 changed production source file(s)
[error-policy-ratchet] no new fallback-slop in touched files
```
</details>

**New/extended tests (all deterministic, no live model):**
- `recall-embed.test.ts` (+8): pre-run→adoption happy path; real-runtime transient-id→real-id transition; no cross-turn leak; concurrent-slot eviction (miss, never wrong vector); runId-only no-mis-promotion; failed pre-run embed not cached; no-run/no-messageId stays uncached; in-flight dedupe across the pre-run/in-run boundary.
- `message.ttft-prefetch.test.ts` (+1): drives the real `DefaultMessageService.handleMessage` with a runtime that mints a transient `PRERUN_ID` before `startRun` mints `RUN_ID`; a simulated augmentation embed is adopted → exactly one `TEXT_EMBEDDING` for the turn. Existing muted / LLM-off zero-embed cases still pass.
- `documents/__tests__/search.test.ts` (+2, `it.each` vector/hybrid): real `DocumentService.searchDocuments(..., { turnMessageId })` over a mock runtime, then an in-run `embedRecallQuery` with the same `messageId` → one embed. Proves the option threads through `_vectorSearch`/`_hybridSearch`.
- `chat-augmentation.test.ts` (+1): asserts `searchDocuments` receives `{ turnMessageId: <original message.id> }` and the search message's `id` is a fresh UUID ≠ `message.id`.

### Evidence rows

<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots: `N/A - backend-only caching change; the diff touches only core/agent .ts files, no rendered UI surface.`

<!-- evidence-row:after-screenshots -->
- [ ] After screenshots: `N/A - backend-only caching change; no rendered UI surface in the diff.`

<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video: `N/A - no user-visible flow changes; the only observable is one fewer TEXT_EMBEDDING span per corpus turn.`

<!-- evidence-row:backend-logs -->
- [ ] Backend logs: `N/A - no live server involved; the deterministic useModel-spy tests assert the exact per-turn TEXT_EMBEDDING call count (base = two, branch = one) that a live GET /api/dev/inference-timing capture would show. Full vitest output is in the Verification details block above.`

<!-- evidence-row:frontend-logs -->
- [ ] Frontend console/network logs: `N/A - no frontend change.`

<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory: `N/A - no agent/action/prompt/model behavior change. Recall results are byte-identical (same vector, fewer round-trips); correctness is locked by the deterministic embed-count tests.`

<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: `N/A - the domain artifact is the per-turn TEXT_EMBEDDING round-trip count, asserted exactly (2 -> 1) by the new recall-embed / ttft-prefetch / DocumentService-seam tests listed above.`

Fixes #15253. Follow-up from #15252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
