### PR TITLE
perf(chat): defer PA MESSAGE_RECEIVED scheduled-task scans off the TTFT path

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/deferred-inbound-scans.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/deferred-inbound-scans.integration.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Acceptance for #15255 on the real runtime bus: proves a PA `MESSAGE_RECEIVED`
+ * turn's awaited edge is independent of scheduled-task scan latency, and that
+ * the trajectory-stamp constraint (synchronous stamping stays on the awaited
+ * edge) still holds. Uses the real PA + scheduling plugins over a DB-backed
+ * runner (createLifeOpsTestRuntime); an artificially slow scan is injected
+ * through `runtime.registerEvent` so the 1000ms sleep is real, not stubbed.
+ */
+
+import {
+  EventType,
+  type IAgentRuntime,
+  type Memory,
+  type MessagePayload,
+  stringToUuid,
+} from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createLifeOpsTestRuntime,
+  type RealTestRuntimeResult,
+} from "../../../test/helpers/runtime.ts";
+import { resolvePendingPromptsStore } from "../pending-prompts/store.ts";
+import { LifeOpsRepository } from "../repository.ts";
+import {
+  detachInboundScan,
+  settleDeferredInboundScans,
+} from "./deferred-inbound-scans.ts";
+import type { ScheduledTask } from "./index.ts";
+
+type Runtime = RealTestRuntimeResult["runtime"];
+
+const OWNER_ENTITY_ID = "owner-entity-1";
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/** Owner-gated so the completion pass's owner check resolves (same pattern as
+ * scheduler.integration.test.ts / inbound-reply-completion.integration.test.ts). */
+async function createOwnerScopedRuntime(): Promise<RealTestRuntimeResult> {
+  const result = await createLifeOpsTestRuntime();
+  result.runtime.setSetting("ELIZA_ADMIN_ENTITY_ID", OWNER_ENTITY_ID, false);
+  return result;
+}
+
+async function seedFiredUserRepliedTask(
+  runtime: Runtime,
+  roomId: string,
+): Promise<ScheduledTask> {
+  const repo = new LifeOpsRepository(runtime);
+  const task: ScheduledTask = {
+    taskId: `st_fired_${Math.random().toString(36).slice(2, 10)}`,
+    kind: "checkin",
+    promptInstructions: "How did it go?",
+    trigger: { kind: "manual" },
+    priority: "medium",
+    respectsGlobalPause: false,
+    source: "user_chat",
+    createdBy: runtime.agentId,
+    ownerVisible: true,
+    completionCheck: { kind: "user_replied_within" },
+    metadata: { pendingPromptRoomId: roomId },
+    state: {
+      status: "fired",
+      firedAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+      followupCount: 0,
+    },
+  };
+  await repo.upsertScheduledTask(runtime.agentId, task);
+  await resolvePendingPromptsStore(runtime).record({
+    roomId,
+    taskId: task.taskId,
+    promptSnippet: task.promptInstructions,
+    firedAt: task.state.firedAt as string,
+    expectedReplyKind: "free_form",
+  });
+  return task;
+}
+
+function ownerReply(runtime: Runtime, roomId: string): Memory {
+  return {
+    id: `msg-${Math.random().toString(36).slice(2, 10)}`,
+    entityId: OWNER_ENTITY_ID,
+    roomId,
+    agentId: runtime.agentId,
+    content: { text: "done!" },
+    createdAt: Date.now(),
+  } as unknown as Memory;
+}
+
+async function persistedStatus(
+  runtime: Runtime,
+  taskId: string,
+): Promise<string | undefined> {
+  const repo = new LifeOpsRepository(runtime);
+  const task = await repo.getScheduledTask(runtime.agentId, taskId);
+  return task?.state.status;
+}
+
+describe("deferred inbound scans — TTFT independence (#15255)", () => {
+  let runtimeResult: RealTestRuntimeResult | null = null;
+
+  afterEach(async () => {
+    // Drain any scans still in flight before tearing the runtime down so a late
+    // scan can't touch a disposed store.
+    await settleDeferredInboundScans();
+    if (runtimeResult) {
+      await runtimeResult.cleanup();
+      runtimeResult = null;
+    }
+  });
+
+  it("a 1000ms scan does not delay the awaited MESSAGE_RECEIVED edge, yet the completion still lands", async () => {
+    runtimeResult = await createOwnerScopedRuntime();
+    const { runtime } = runtimeResult;
+    const roomId = "room-ttft-1";
+    const task = await seedFiredUserRepliedTask(runtime, roomId);
+
+    // Inject a genuinely slow scan on the real bus, wrapped exactly as the PA
+    // handlers are, so it is deferred and drained the same way.
+    let slowScanRan = false;
+    runtime.registerEvent(
+      EventType.MESSAGE_RECEIVED,
+      detachInboundScan("acceptance-slow-scan", async () => {
+        await sleep(1000);
+        slowScanRan = true;
+      }),
+    );
+
+    const startedAt = performance.now();
+    await runtime.emitEvent(EventType.MESSAGE_RECEIVED, {
+      message: ownerReply(runtime, roomId),
+    });
+    const emitMs = performance.now() - startedAt;
+
+    // The awaited edge returns before the 1000ms scan finishes — TTFT is
+    // independent of scan latency.
+    expect(slowScanRan).toBe(false);
+    expect(emitMs).toBeLessThan(500);
+
+    // Scans still run: drain them and confirm both the injected scan and the
+    // real PA completion landed.
+    await settleDeferredInboundScans();
+    expect(slowScanRan).toBe(true);
+    expect(await persistedStatus(runtime, task.taskId)).toBe("completed");
+    expect(await resolvePendingPromptsStore(runtime).list(roomId)).toHaveLength(
+      0,
+    );
+  }, 180_000);
+
+  it("synchronous trajectory stamping stays on the awaited edge while scans are deferred", async () => {
+    runtimeResult = await createOwnerScopedRuntime();
+    const { runtime } = runtimeResult;
+
+    // Mirror the core trajectories handler: stamp trajectoryStepId synchronously
+    // (no await) so message.ts can read it the instant emitEvent resolves.
+    const stampedStepId = stringToUuid("stamp-guard-step");
+    (runtime as IAgentRuntime).registerEvent(
+      EventType.MESSAGE_RECEIVED,
+      async (payload: MessagePayload) => {
+        const message = payload.message;
+        if (!message.metadata) {
+          message.metadata = { type: "message" };
+        }
+        (message.metadata as Record<string, unknown>).trajectoryStepId =
+          stampedStepId;
+      },
+    );
+
+    let slowScanRan = false;
+    runtime.registerEvent(
+      EventType.MESSAGE_RECEIVED,
+      detachInboundScan("stamp-guard-slow", async () => {
+        await sleep(1000);
+        slowScanRan = true;
+      }),
+    );
+
+    const message = ownerReply(runtime, "room-stamp-guard");
+    await runtime.emitEvent(EventType.MESSAGE_RECEIVED, { message });
+
+    // The stamp is present immediately after emitEvent resolves...
+    expect((message.metadata as Record<string, unknown>).trajectoryStepId).toBe(
+      stampedStepId,
+    );
+    // ...even though the deferred scan has not finished.
+    expect(slowScanRan).toBe(false);
+
+    await settleDeferredInboundScans();
+    expect(slowScanRan).toBe(true);
+  }, 180_000);
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/deferred-inbound-scans.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/deferred-inbound-scans.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Unit coverage for the deferred-inbound-scan seam: that `detachInboundScan`
+ * resolves the awaited MESSAGE_RECEIVED edge without waiting for the scan, that
+ * a rejecting scan routes to `runtime.reportError` instead of rejecting the
+ * edge, and that `settleDeferredInboundScans` drains chained scans. The runtime
+ * here is a minimal recording stand-in for `reportError` only — the seam itself
+ * (scheduling, tracking, draining) is exercised for real.
+ */
+
+import {
+  type IAgentRuntime,
+  type Memory,
+  type MessagePayload,
+  stringToUuid,
+  type UUID,
+} from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+import {
+  detachInboundScan,
+  settleDeferredInboundScans,
+} from "./deferred-inbound-scans.js";
+
+interface ReportedError {
+  scope: string;
+  error: unknown;
+  context?: Record<string, unknown>;
+}
+
+/** Minimal runtime exposing only the `reportError` collaborator the seam uses. */
+function recordingRuntime(): {
+  runtime: IAgentRuntime;
+  reported: ReportedError[];
+} {
+  const reported: ReportedError[] = [];
+  const runtime = {
+    reportError(
+      scope: string,
+      error: unknown,
+      context?: Record<string, unknown>,
+    ) {
+      reported.push({ scope, error, context });
+    },
+  } as unknown as IAgentRuntime;
+  return { runtime, reported };
+}
+
+function payloadFor(
+  runtime: IAgentRuntime,
+  overrides?: { roomId?: UUID; messageId?: UUID },
+): MessagePayload {
+  const message = {
+    id: overrides?.messageId ?? stringToUuid("deferred-scan-msg"),
+    entityId: stringToUuid("deferred-scan-owner"),
+    roomId: overrides?.roomId ?? stringToUuid("deferred-scan-room"),
+    content: { text: "done!" },
+    createdAt: Date.now(),
+  } as unknown as Memory;
+  return { runtime, message, source: "test" } as MessagePayload;
+}
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+describe("detachInboundScan", () => {
+  it("resolves the awaited edge without waiting for a slow scan, but still runs it", async () => {
+    const { runtime } = recordingRuntime();
+    let scanRan = false;
+    const handler = detachInboundScan("slow", async () => {
+      await sleep(1500);
+      scanRan = true;
+    });
+
+    const startedAt = Date.now();
+    await handler(payloadFor(runtime));
+    const awaitedEdgeMs = Date.now() - startedAt;
+
+    // The awaited edge must return effectively immediately — the 1500ms scan
+    // is off the critical path (#15255).
+    expect(awaitedEdgeMs).toBeLessThan(200);
+    expect(scanRan).toBe(false);
+
+    await settleDeferredInboundScans();
+    expect(scanRan).toBe(true);
+  });
+
+  it("routes a scan failure to runtime.reportError and never rejects the awaited edge", async () => {
+    const { runtime, reported } = recordingRuntime();
+    const roomId = stringToUuid("deferred-scan-room-fail");
+    const messageId = stringToUuid("deferred-scan-msg-fail");
+    const failure = new Error("store down");
+    const handler = detachInboundScan("inbound-reply-completion", async () => {
+      throw failure;
+    });
+
+    // The awaited edge resolves even though the scan throws.
+    await expect(
+      handler(payloadFor(runtime, { roomId, messageId })),
+    ).resolves.toBeUndefined();
+
+    await settleDeferredInboundScans();
+
+    expect(reported).toHaveLength(1);
+    expect(reported[0]).toEqual({
+      scope: "lifeops:inbound-scan:inbound-reply-completion",
+      error: failure,
+      context: { roomId, messageId },
+    });
+  });
+
+  it("settle drains a scan that schedules another scan while it runs", async () => {
+    const { runtime } = recordingRuntime();
+    let innerRan = false;
+    const outer = detachInboundScan("outer", async () => {
+      // Schedule a second detached scan mid-flight; it outlives the outer scan.
+      const inner = detachInboundScan("inner", async () => {
+        await sleep(100);
+        innerRan = true;
+      });
+      await inner(payloadFor(runtime));
+    });
+
+    await outer(payloadFor(runtime));
+    // The chained inner scan is still pending here; settle must loop to catch it.
+    await settleDeferredInboundScans();
+    expect(innerRan).toBe(true);
+  });
+});

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/deferred-inbound-scans.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/deferred-inbound-scans.ts
@@ -1,0 +1,64 @@
+/**
+ * Detaches PA's inbound scheduled-task scans from the awaited `MESSAGE_RECEIVED`
+ * edge so a slow store/DB scan cannot delay the reply's first token (#15255).
+ *
+ * `AgentRuntime.emitEvent` awaits `Promise.all` over every registered handler,
+ * and both TTFT entry edges (`MessageService.handleMessage`, the agent API chat
+ * route) await that emit before Stage-1 work. The PA completion/dismissal scans
+ * registered on `MESSAGE_RECEIVED` are pure side effects that do not feed the
+ * first token, so wrapping each one here makes the handler return immediately
+ * and run the scan in the background. The core trajectories handler — which
+ * stamps `message.metadata.trajectoryStepId` that `message.ts` reads right after
+ * the emit resolves — is a different, un-wrapped handler and stays synchronous.
+ *
+ * A detached scan can no longer reject the emit, so its failures are surfaced
+ * through `runtime.reportError` (RECENT_ERRORS provider + logs + owner
+ * escalation) instead of the awaited call stack. The in-flight set is a
+ * module-level singleton so `settleDeferredInboundScans` (test-only) can await
+ * every scan that a `MESSAGE_RECEIVED` emit spawned before asserting store state.
+ */
+
+import type { MessagePayload } from "@elizaos/core";
+
+const inFlight = new Set<Promise<void>>();
+
+/**
+ * Wrap a `MESSAGE_RECEIVED` scan so the awaited emit edge resolves without it.
+ * The returned handler schedules `fn`, tracks it for {@link
+ * settleDeferredInboundScans}, and resolves immediately; `fn` runs to
+ * completion in the background and any rejection is reported via
+ * `payload.runtime.reportError` under the scope `lifeops:inbound-scan:<name>`.
+ */
+export function detachInboundScan(
+  name: string,
+  fn: (payload: MessagePayload) => Promise<void>,
+): (payload: MessagePayload) => Promise<void> {
+  return (payload: MessagePayload): Promise<void> => {
+    const scan: Promise<void> = fn(payload)
+      .catch((error: unknown) => {
+        // error-policy:J7 diagnostics-must-not-kill-the-loop — the turn has
+        // already moved on off the awaited edge; surface the failure through
+        // reportError (RECENT_ERRORS + logs) rather than dropping it.
+        payload.runtime.reportError(`lifeops:inbound-scan:${name}`, error, {
+          roomId: payload.message.roomId,
+          messageId: payload.message.id,
+        });
+      })
+      .finally(() => {
+        inFlight.delete(scan);
+      });
+    inFlight.add(scan);
+    return Promise.resolve();
+  };
+}
+
+/**
+ * Await every deferred inbound scan currently in flight. Loops because a scan
+ * may schedule another detached scan while it runs. Test-only: production never
+ * blocks on these side effects.
+ */
+export async function settleDeferredInboundScans(): Promise<void> {
+  while (inFlight.size > 0) {
+    await Promise.all([...inFlight]);
+  }
+}

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/inbound-reply-completion.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/inbound-reply-completion.integration.test.ts
@@ -22,6 +22,7 @@ import {
 import { CheckinService } from "../checkin/checkin-service.js";
 import { resolvePendingPromptsStore } from "../pending-prompts/store.js";
 import { LifeOpsRepository } from "../repository.js";
+import { settleDeferredInboundScans } from "./deferred-inbound-scans.js";
 import { completeFiredTasksOnOwnerReply } from "./inbound-reply-completion.js";
 import type { ScheduledTask, ScheduledTaskCompletionCheck } from "./index.js";
 
@@ -146,6 +147,9 @@ describe("inbound-reply completion — production wiring", () => {
     await runtime.emitEvent(EventType.MESSAGE_RECEIVED, {
       message: ownerReply(runtime, roomId),
     });
+    // The scans run detached off the awaited emit edge (#15255); drain them
+    // before asserting the store state they produce.
+    await settleDeferredInboundScans();
 
     expect(await persistedStatus(runtime, task.taskId)).toBe("completed");
     // The open prompt was forgotten so the planner stops steering at it.
@@ -190,6 +194,7 @@ describe("inbound-reply completion — production wiring", () => {
     const reply = ownerReply(runtime, roomId);
     reply.createdAt = base;
     await runtime.emitEvent(EventType.MESSAGE_RECEIVED, { message: reply });
+    await settleDeferredInboundScans();
 
     expect(await persistedStatus(runtime, task.taskId)).toBe("completed");
     expect(await checkins.getEscalationLevel(new Date(base))).toBe(2);
@@ -236,6 +241,7 @@ describe("inbound-reply completion — production wiring", () => {
     await runtime.emitEvent(EventType.MESSAGE_RECEIVED, {
       message: ownerReply(runtime, "room-b"),
     });
+    await settleDeferredInboundScans();
 
     expect(await persistedStatus(runtime, task.taskId)).toBe("fired");
   }, 180_000);
@@ -334,6 +340,7 @@ describe("inbound-reply completion — production wiring", () => {
     await runtime.emitEvent(EventType.MESSAGE_RECEIVED, {
       message: ownerReply(runtime, roomId),
     });
+    await settleDeferredInboundScans();
     expect(await persistedStatus(runtime, task.taskId)).toBe("fired");
 
     // The subject row lands (updatedAt = now >= firedAt) → the next
@@ -353,6 +360,7 @@ describe("inbound-reply completion — production wiring", () => {
     await runtime.emitEvent(EventType.MESSAGE_RECEIVED, {
       message: ownerReply(runtime, roomId),
     });
+    await settleDeferredInboundScans();
     expect(await persistedStatus(runtime, task.taskId)).toBe("completed");
   }, 180_000);
 });

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts
@@ -23,6 +23,7 @@ import {
 import { createGlobalPauseStore } from "../global-pause/store.ts";
 import { resolvePendingPromptsStore } from "../pending-prompts/store.ts";
 import { LifeOpsRepository } from "../repository.ts";
+import { settleDeferredInboundScans } from "./deferred-inbound-scans.ts";
 import {
   APPROVAL_DEFAULT_FOLLOWUP_AFTER_MINUTES,
   type ScheduledTask,
@@ -513,6 +514,9 @@ describe("processDueScheduledTasks — production wiring", () => {
       message,
       source: "client_chat",
     });
+    // The completion scan runs detached off the awaited emit edge (#15255);
+    // drain it before reading the store state it produces.
+    await settleDeferredInboundScans();
 
     const repo = new LifeOpsRepository(runtime);
     const completed = await repo.getScheduledTask(

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.quiet-streak.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.quiet-streak.test.ts
@@ -20,6 +20,7 @@ import {
 import { resolveOwnerFactStore } from "../owner/fact-store.ts";
 import { resolvePendingPromptsStore } from "../pending-prompts/store.ts";
 import { LifeOpsRepository } from "../repository.ts";
+import { settleDeferredInboundScans } from "./deferred-inbound-scans.ts";
 import type { ScheduledTask } from "./index.ts";
 import {
   type ProcessDueScheduledTasksResult,
@@ -414,6 +415,8 @@ describe("processDueScheduledTasks — quiet streak softens the next no-reply la
         createdAt: Date.now(),
       } as unknown as Memory,
     });
+    // The completion scan runs detached off the awaited emit edge (#15255).
+    await settleDeferredInboundScans();
 
     const persisted = await repo.getScheduledTask(
       runtime.agentId,

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/unanswered-question-followup.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/unanswered-question-followup.integration.test.ts
@@ -22,6 +22,7 @@ import {
   type RealTestRuntimeResult,
 } from "../../../test/helpers/runtime.ts";
 import { createOwnerFactStore } from "../owner/fact-store.js";
+import { settleDeferredInboundScans } from "./deferred-inbound-scans.js";
 import { getScheduledTaskRunner } from "./service.js";
 import {
   cancelQuestionFollowupsOnOwnerReply,
@@ -305,6 +306,8 @@ describe("unanswered-question follow-up — real spine", () => {
       } as Memory,
       source: "test",
     });
+    // The dismissal scan runs detached off the awaited emit edge (#15255).
+    await settleDeferredInboundScans();
 
     expect(await listQuestionFollowups(runtime, room.roomId)).toHaveLength(0);
     const dismissed = await listQuestionFollowups(

--- a/plugins/plugin-personal-assistant/src/plugin.ts
+++ b/plugins/plugin-personal-assistant/src/plugin.ts
@@ -161,6 +161,7 @@ import {
   registerLifeOpsTaskWorker,
 } from "./lifeops/runtime.js";
 import { createScheduledTaskCandidateBackstopRule } from "./lifeops/scheduled-task/candidate-backstop.js";
+import { detachInboundScan } from "./lifeops/scheduled-task/deferred-inbound-scans.js";
 import { completeFiredTasksOnOwnerReply } from "./lifeops/scheduled-task/inbound-reply-completion.js";
 import {
   installLifeOpsScheduledTaskEventBridge,
@@ -724,29 +725,34 @@ const rawPersonalAssistantPlugin: Plugin = {
     // the room (user_replied_within + stale-prompt teardown);
     // `completeFiredTasksOnOwnerReply` matches fired tasks by their own
     // pending-prompt room and re-evaluates every check kind (incl.
-    // subject_updated). Both are owner-gated and idempotent. Boundary catch:
-    // an inbound chat message must never fail because the scheduled-task
-    // store or runner host is broken.
+    // subject_updated). Both are owner-gated and idempotent.
+    //
+    // These scans are side effects that do not feed the reply's first token,
+    // so each is detached from the awaited MESSAGE_RECEIVED edge (#15255):
+    // `emitEvent` awaits `Promise.all` over every handler, and both TTFT
+    // entry edges await that emit before Stage-1 work, so a slow store scan
+    // here would land one-for-one on TTFT. `detachInboundScan` runs the scan
+    // in the background and surfaces any failure via `runtime.reportError`.
     [EventType.MESSAGE_RECEIVED]: [
-      handleScheduledTaskInboundMessage,
-      async (payload: MessagePayload): Promise<void> => {
-        try {
+      detachInboundScan(
+        "scheduled-task-inbound",
+        handleScheduledTaskInboundMessage,
+      ),
+      detachInboundScan(
+        "inbound-reply-completion",
+        async (payload: MessagePayload): Promise<void> => {
           await completeFiredTasksOnOwnerReply(
             payload.runtime,
             payload.message,
           );
-        } catch (error) {
-          logger.error(
-            { src: "lifeops:inbound-reply-completion", error },
-            `[lifeops] inbound-reply completion pass failed: ${
-              error instanceof Error ? error.message : String(error)
-            }`,
-          );
-        }
-      },
+        },
+      ),
       // Owner re-engaged: any still-scheduled unanswered-question follow-up
       // for the room is stale — dismiss it (#14676).
-      handleOwnerMessageForQuestionFollowup,
+      detachInboundScan(
+        "question-followup-cancel",
+        handleOwnerMessageForQuestionFollowup,
+      ),
     ],
     // Agent reply ends with a question the owner never answers → seed a
     // once-fired follow-up whose fire-time admission is the model moment


### PR DESCRIPTION
## What

PA registers three `MESSAGE_RECEIVED` handlers that run scheduled-task store/DB scans purely as side effects (completion for fired check-ins, inbound-reply completion, unanswered-question follow-up dismissal). `AgentRuntime.emitEvent` awaits `Promise.all` over **every** registered handler, and both TTFT entry edges — `MessageService.handleMessage` and the agent API chat route — await that emit **before** any Stage-1 work. So a slow scan (large fired-task list, slow store, slow completion check) delayed the reply's first token one-for-one.

This wraps each PA inbound scan in a new `detachInboundScan` seam: the handler returns immediately and the scan runs in the background. Failures now surface via `runtime.reportError` (RECENT_ERRORS provider + logs + owner escalation) instead of the awaited call stack.

## Why this is plugin-side only

- The fix lives entirely in `@elizaos/plugin-personal-assistant`, so it automatically covers every emit path (`message.ts`, `chat-routes.ts`, connectors) without a cross-cutting core change.
- **Trajectory stamping stays synchronous by construction.** The `message.metadata.trajectoryStepId` / `traceId` stamp is done by the core *trajectories* `MESSAGE_RECEIVED` handler — a different, un-wrapped handler — which runs its synchronous stamp during the `Promise.all` map pass. `message.ts` still reads a stamped value the instant `emitEvent` resolves. Only the PA scans are detached.

## Files

- **new** `deferred-inbound-scans.ts` — `detachInboundScan(name, fn)` fire-and-forget wrapper + `settleDeferredInboundScans()` test-only drain.
- `plugin.ts` — wrap the three `MESSAGE_RECEIVED` handlers; drop the inline try/catch around `completeFiredTasksOnOwnerReply` (its failure now routes through `reportError`).
- **new** `deferred-inbound-scans.test.ts` — unit coverage of the seam (fast edge, error routing, chained-scan drain).
- **new** `deferred-inbound-scans.integration.test.ts` — real-runtime-bus acceptance (TTFT independence + trajectory-stamp guard).
- `inbound-reply-completion.integration.test.ts`, `scheduler.integration.test.ts`, `scheduler.quiet-streak.test.ts`, `unanswered-question-followup.integration.test.ts` — settle deferred scans before asserting store state.

## Behavioral note

The only semantic change is one-turn staleness in the pathological-slow case: if a completion scan runs slower than Stage-1 + model latency, the reply for the message that answers a fired check-in may compose before the pending prompt is torn down. In practice scans finish in single-digit ms while the reply takes hundreds of ms, so ordering is preserved; the deferral only removes the guarantee in the slow case the issue explicitly de-prioritizes. No bounded await is added in providers (that would re-import the latency onto `composeState`).

## Verification

Run from the repo root / package dir. All commands below were run on this branch (rebased onto `origin/develop`).

<details>
<summary>Unit seam tests — <code>deferred-inbound-scans.test.ts</code></summary>

```
✓ detachInboundScan > resolves the awaited edge without waiting for a slow scan, but still runs it 1504ms
✓ detachInboundScan > routes a scan failure to runtime.reportError and never rejects the awaited edge 1ms
✓ detachInboundScan > settle drains a scan that schedules another scan while it runs 100ms
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

The first test asserts the awaited edge returns in `<200ms` while the wrapped scan sleeps `1500ms`, then the scan's side effect still lands after `settleDeferredInboundScans()`.
</details>

<details>
<summary>Real-runtime-bus acceptance — <code>deferred-inbound-scans.integration.test.ts</code> (DB-backed runner, real PA + scheduling plugins)</summary>

```
✓ TTFT independence (#15255) > a 1000ms scan does not delay the awaited MESSAGE_RECEIVED edge, yet the completion still lands 32616ms
✓ TTFT independence (#15255) > synchronous trajectory stamping stays on the awaited edge while scans are deferred 2594ms
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Test 1 injects a real `1000ms` scan on the runtime bus via `registerEvent`, seeds a fired `user_replied_within` task + pending prompt, then asserts: `emitEvent(MESSAGE_RECEIVED)` returns in `<500ms` **and** the scan had not completed at that point (`slowScanRan === false`) — i.e. TTFT is independent of scan latency; after `settleDeferredInboundScans()` the injected scan ran **and** the real PA completion landed (`status === "completed"`, pending prompt forgotten). This is the deterministic form of the "before/after slow scan" acceptance: awaiting the scan directly would make the same `emitEvent` exceed the 1000ms sleep. Test 2 stamps `trajectoryStepId` synchronously alongside a slow deferred scan and asserts the stamp is present the instant `emitEvent` resolves.
</details>

<details>
<summary>Existing integration suites updated to settle before asserting (unchanged semantics)</summary>

```
# inbound-reply-completion + unanswered-question-followup + scheduler.integration
 Test Files  3 passed (3)
      Tests  32 passed (32)

# scheduler.quiet-streak (unit lane, real harness)
 Test Files  1 passed (1)
      Tests  6 passed (6)
```
</details>

<details>
<summary>Typecheck + ratchets</summary>

```
# tsc --noEmit -p tsconfig.build.json (plugin-personal-assistant)
exit=0   error TS count: 0

# audit:error-policy-ratchet (diff-scoped)
[error-policy-ratchet] base origin/develop; 2 changed production source file(s)
  deferred-inbound-scans.ts: emptyCatch 0->0, serverConsole 0->0
  plugin.ts: emptyCatch 1->1, serverConsole 0->0        # try/catch removed added none
[error-policy-ratchet] no new fallback-slop in touched files

# audit:type-safety-ratchet
exit=0   (new file adds no `any` / `as unknown` / `?? <default>`)
```
</details>

## Evidence rows

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - backend event-bus latency change in `plugins/plugin-personal-assistant`; no rendered UI surface is touched.
<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - backend event-bus latency change; no rendered UI surface is touched.
<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - no user-visible flow changes; the behavior under test is `emitEvent` latency on the runtime bus, proven deterministically by the acceptance test above.
<!-- evidence-row:backend-logs -->
- Backend logs: N/A - no live-stack log capture; the real-runtime-bus acceptance test (real PGlite DB, real PA + scheduling plugins, real 1000ms scan) exercises the exact production code path and its vitest output is pasted in the Verification details blocks above — a permanent regression guard rather than a one-off capture.
<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A - no frontend code touched; nothing reaches a browser.
<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no model/prompt/action/provider behavior change; the deferral only moves side-effect scans off the awaited MESSAGE_RECEIVED edge, and the trajectory-stamp constraint is guarded by the dedicated integration test above.
<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - no separate manual dump; the DB-persisted artifacts (scheduled task `fired` → `completed`, pending prompt removed) are asserted directly against the real store by the acceptance test in the Verification section.

`reportError` surfacing (failure path) is covered by the unit test "routes a scan failure to `runtime.reportError`".

Fixes #15255

🤖 Generated with [Claude Code](https://claude.com/claude-code)
