### PR TITLE
perf(chat): delta-v2 SSE framing — stop shipping fullText on every token (O(N²)→O(N) wire)

### DIFF
--- a/packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-stream-sse-contract.test.ts
@@ -35,6 +35,11 @@ import {
 } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+// Per-test negotiated wire protocol the mocked payload reader advertises, so a
+// single fixture drives both the legacy and delta-v2 framings through the real
+// route handler.
+let requestStreamProtocol: "delta-v2" | undefined;
+
 vi.mock("../chat-routes.ts", async () => {
   const actual =
     await vi.importActual<typeof import("../chat-routes.ts")>(
@@ -49,6 +54,9 @@ vi.mock("../chat-routes.ts", async () => {
       preferredLanguage: undefined,
       source: "api",
       metadata: undefined,
+      ...(requestStreamProtocol
+        ? { streamProtocol: requestStreamProtocol }
+        : {}),
     })),
     persistConversationMemory: vi.fn(async () => undefined),
     persistAssistantConversationMemory: vi.fn(async () => undefined),
@@ -248,7 +256,50 @@ function createModelBackedMessageService() {
   } satisfies NonNullable<AgentRuntime["messageService"]>;
 }
 
-function createState(): {
+/**
+ * A message service that ignores useModel and drives the route's onStreamChunk
+ * with a fixed chunk plan, so a test can force a mid-stream snapshot (a "replace"
+ * update — chunk that revises earlier text) and assert the fullText-only frame
+ * the delta writer emits for it.
+ */
+function createChunkPlanMessageService(
+  chunks: string[],
+  finalText: string,
+  thought: string,
+): NonNullable<AgentRuntime["messageService"]> {
+  return {
+    async handleMessage(
+      _runtime: AgentRuntime,
+      _message: { content?: { text?: unknown } },
+      _callback: unknown,
+      options?: {
+        abortSignal?: AbortSignal;
+        onStreamChunk?: (chunk: string) => Promise<void> | void;
+      },
+    ) {
+      for (const chunk of chunks) {
+        await Promise.resolve();
+        await options?.onStreamChunk?.(chunk);
+      }
+      return {
+        didRespond: true,
+        responseContent: { text: finalText, thought },
+        responseMessages: [],
+      };
+    },
+    shouldRespond: () => ({
+      shouldRespond: true,
+      skipEvaluation: true,
+      reason: "stream-contract-snapshot-test",
+    }),
+    deleteMessage: async () => undefined,
+    clearChannel: async () => undefined,
+  } satisfies NonNullable<AgentRuntime["messageService"]>;
+}
+
+function createState(
+  messageServiceOverride?: NonNullable<AgentRuntime["messageService"]>,
+): {
   state: ConversationRouteState;
   useModel: ReturnType<typeof createStreamingUseModelFixture>;
 } {
@@ -272,7 +323,7 @@ function createState(): {
     logger,
     emitEvent: vi.fn(async () => undefined),
     useModel: useModel as unknown as AgentRuntime["useModel"],
-    messageService: createModelBackedMessageService(),
+    messageService: messageServiceOverride ?? createModelBackedMessageService(),
     ensureConnection: vi.fn(async () => undefined),
     updateWorld: vi.fn(async () => undefined),
     getWorld: vi.fn(async () => null),
@@ -302,7 +353,9 @@ function createState(): {
   };
 }
 
-function createCtx(): {
+function createCtx(
+  messageServiceOverride?: NonNullable<AgentRuntime["messageService"]>,
+): {
   ctx: ConversationRouteContext;
   record: MockResponseRecord;
   useModel: ReturnType<typeof createStreamingUseModelFixture>;
@@ -310,7 +363,7 @@ function createCtx(): {
   const socket = createMockSocket();
   const req = createReq(socket);
   const { res, record } = createMockRes();
-  const { state, useModel } = createState();
+  const { state, useModel } = createState(messageServiceOverride);
   const ctx: ConversationRouteContext = {
     req,
     res,
@@ -330,6 +383,7 @@ function createCtx(): {
 describe("conversation stream SSE contract (#10712)", () => {
   afterEach(() => {
     vi.clearAllMocks();
+    requestStreamProtocol = undefined;
   });
 
   it("emits thinking→streaming status, ordered cumulative token frames, then a terminal done frame with thought", async () => {
@@ -444,5 +498,83 @@ describe("conversation stream SSE contract (#10712)", () => {
     // The ctx error helper writes `error <status>: <message>` — no SSE header.
     expect(record.headers["Content-Type"]).toBeUndefined();
     expect(record.writes.join("")).toContain("error 404");
+  });
+
+  it("ships bare deltas (no per-token fullText) when the client negotiates delta-v2, and reconstructs the done text", async () => {
+    requestStreamProtocol = "delta-v2";
+    const { ctx, record } = createCtx();
+
+    await handleConversationRoutes(ctx);
+
+    const payloads = parseSsePayloads(record.writes);
+    const tokens = payloads.filter((payload) => payload.type === "token");
+    // These four tokens total ~27 chars — well under the 2048-byte snapshot
+    // floor — so EVERY token frame is a pure delta with no fullText key.
+    expect(tokens.map((payload) => payload.text)).toEqual(TOKENS);
+    for (const token of tokens) {
+      expect(token).not.toHaveProperty("fullText");
+    }
+    // Client semantics (append delta when no fullText) reconstruct the reply.
+    const reconstructed = tokens.reduce(
+      (acc, token) => acc + String(token.text ?? ""),
+      "",
+    );
+    expect(reconstructed).toBe(FINAL_TEXT);
+    // The terminal done frame is the full-text authority in delta framing too.
+    const done = payloads.find((payload) => payload.type === "done");
+    expect(done).toMatchObject({ type: "done", fullText: FINAL_TEXT });
+  });
+
+  it("emits a mid-stream structured rewrite as a fullText-only snapshot frame under delta-v2 (cumulative fullText under legacy)", async () => {
+    // "Hello wrld" then "Hello world" is a non-append revise: the route's
+    // onStreamChunk → appendIncomingText resolves it to a snapshot replace, so
+    // onSnapshot fires with the corrected text.
+    const messageService = createChunkPlanMessageService(
+      ["Hello wrld", "Hello world"],
+      "Hello world",
+      "corrected a typo mid-stream",
+    );
+
+    // Delta framing: the append is a bare delta; the revise is a fullText-only
+    // snapshot frame (authoritative replace, no `text`).
+    requestStreamProtocol = "delta-v2";
+    const delta = createCtx(messageService);
+    await handleConversationRoutes(delta.ctx);
+    const deltaTokens = parseSsePayloads(delta.record.writes).filter(
+      (payload) => payload.type === "token",
+    );
+    expect(deltaTokens).toEqual([
+      { type: "token", text: "Hello wrld" },
+      { type: "token", fullText: "Hello world" },
+    ]);
+    // Replay with client semantics (append text; replace on fullText).
+    const deltaReconstructed = deltaTokens.reduce((acc, token) => {
+      if (typeof token.fullText === "string") return token.fullText;
+      return acc + String(token.text ?? "");
+    }, "");
+    expect(deltaReconstructed).toBe("Hello world");
+    const deltaDone = parseSsePayloads(delta.record.writes).find(
+      (payload) => payload.type === "done",
+    );
+    expect(deltaDone).toMatchObject({ fullText: "Hello world" });
+
+    // Legacy framing: BOTH frames carry cumulative fullText (byte-identical to
+    // the historical writer), so an un-negotiated client stays correct.
+    requestStreamProtocol = undefined;
+    const legacy = createCtx(
+      createChunkPlanMessageService(
+        ["Hello wrld", "Hello world"],
+        "Hello world",
+        "corrected a typo mid-stream",
+      ),
+    );
+    await handleConversationRoutes(legacy.ctx);
+    const legacyTokens = parseSsePayloads(legacy.record.writes).filter(
+      (payload) => payload.type === "token",
+    );
+    expect(legacyTokens).toEqual([
+      { type: "token", text: "Hello wrld", fullText: "Hello wrld" },
+      { type: "token", text: "Hello world", fullText: "Hello world" },
+    ]);
   });
 });

--- a/packages/agent/src/api/__tests__/sse-wire-streaming.test.ts
+++ b/packages/agent/src/api/__tests__/sse-wire-streaming.test.ts
@@ -10,6 +10,7 @@ import type { ServerResponse } from "node:http";
 import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 import {
+  createChatTokenStreamWriter,
   initSse,
   writeChatTokenSse,
   writeSse,
@@ -248,6 +249,165 @@ describe("SSE wire format", () => {
         expect(JSON.parse(dataLines.join("\n"))).toEqual({ text });
       }),
       { numRuns: 200 },
+    );
+  });
+});
+
+const streamWriterDeps = { writeChatTokenSse, writeSse };
+
+// Replays delta-v2 frames with the exact client reducer contract
+// (`applyStreamChatTokenEvent`): an explicit `fullText` is an authoritative
+// replace; a bare `text` is an append.
+function replayClient(frames: ParsedFrame[]): string {
+  let text = "";
+  for (const { payload } of frames) {
+    if (payload.type !== "token") continue;
+    if (typeof payload.fullText === "string") {
+      text = payload.fullText;
+    } else if (typeof payload.text === "string") {
+      text += payload.text;
+    }
+  }
+  return text;
+}
+
+describe("delta-v2 chat token stream writer", () => {
+  it("legacy writer output is byte-identical to writeChatTokenSse", () => {
+    const viaWriter = createMockResponse();
+    const direct = createMockResponse();
+    const writer = createChatTokenStreamWriter("legacy", streamWriterDeps);
+
+    let acc = "";
+    for (const chunk of ["Hel", "lo ", "there", "!"]) {
+      acc += chunk;
+      writer.writeChunk(viaWriter.res, chunk, acc);
+      writeChatTokenSse(direct.res, chunk, acc);
+    }
+    // A snapshot (structured rewrite / single-frame reply) matches today's
+    // onSnapshot call, which passed the text as BOTH args.
+    writer.writeSnapshot(viaWriter.res, acc);
+    writeChatTokenSse(direct.res, acc, acc);
+
+    expect(viaWriter.writes).toEqual(direct.writes);
+  });
+
+  it("delta writer omits fullText on ordinary tokens and re-sends it only on the byte budget", () => {
+    const mock = createMockResponse();
+    const writer = createChatTokenStreamWriter("delta-v2", streamWriterDeps);
+
+    const chunk = "x".repeat(64);
+    let acc = "";
+    // 40 chunks × 64 = 2560 chars — crosses the 2048-byte snapshot floor once.
+    for (let i = 0; i < 40; i += 1) {
+      acc += chunk;
+      writer.writeChunk(mock.res, chunk, acc);
+    }
+
+    const frames = parseFrames(mock.writes);
+    expect(frames).toHaveLength(40);
+    const snapshotBearing = frames.filter((f) => "fullText" in f.payload);
+    // Exactly one snapshot-bearing frame, landing the first time accumulated
+    // delta bytes reach 2048 (chunk index 31 → 32 × 64 = 2048 chars).
+    expect(snapshotBearing).toHaveLength(1);
+    expect(snapshotBearing[0].payload.fullText).toBe("x".repeat(2048));
+    // A snapshot-bearing chunk frame still carries its own delta text.
+    expect(snapshotBearing[0].payload.text).toBe(chunk);
+    // Every OTHER frame is a bare delta with no fullText key at all.
+    for (const frame of frames) {
+      if (frame === snapshotBearing[0]) continue;
+      expect(frame.payload).not.toHaveProperty("fullText");
+      expect(frame.payload.text).toBe(chunk);
+    }
+  });
+
+  it("writeSnapshot emits a fullText-only frame (no text field) and resets the budget", () => {
+    const mock = createMockResponse();
+    const writer = createChatTokenStreamWriter("delta-v2", streamWriterDeps);
+
+    writer.writeChunk(mock.res, "hi", "hi");
+    writer.writeSnapshot(mock.res, "hi there — corrected");
+
+    const frames = parseFrames(mock.writes);
+    expect(frames[0].payload).toEqual({ type: "token", text: "hi" });
+    expect(frames[1].payload).toEqual({
+      type: "token",
+      fullText: "hi there — corrected",
+    });
+  });
+
+  it("carries linear (O(N)) bytes vs the legacy writer's quadratic wire", () => {
+    const chunkText = "x".repeat(8);
+    const chunkCount = 500;
+
+    const deltaMock = createMockResponse();
+    const deltaWriter = createChatTokenStreamWriter(
+      "delta-v2",
+      streamWriterDeps,
+    );
+    const legacyMock = createMockResponse();
+    const legacyWriter = createChatTokenStreamWriter("legacy", streamWriterDeps);
+
+    let acc = "";
+    for (let i = 0; i < chunkCount; i += 1) {
+      acc += chunkText;
+      deltaWriter.writeChunk(deltaMock.res, chunkText, acc);
+      legacyWriter.writeChunk(legacyMock.res, chunkText, acc);
+    }
+    const finalLen = acc.length; // 4000
+    const deltaBytes = deltaMock.writes.join("").length;
+    const legacyBytes = legacyMock.writes.join("").length;
+
+    // Linear envelope: delta wire ≤ (deltas ~= N) + (snapshots ~= 2N) + framing.
+    const envelope = 4 * finalLen + 64 * chunkCount;
+    expect(
+      deltaBytes,
+      `delta bytes ${deltaBytes} must be ≤ linear envelope ${envelope} (finalLen=${finalLen}, chunks=${chunkCount})`,
+    ).toBeLessThanOrEqual(envelope);
+    // The whole point: legacy re-sends the growing prefix every token (O(N²)).
+    expect(
+      legacyBytes,
+      `legacy bytes ${legacyBytes} must exceed 20× delta bytes ${deltaBytes} (ratio=${(legacyBytes / deltaBytes).toFixed(1)}×)`,
+    ).toBeGreaterThan(20 * deltaBytes);
+  });
+
+  it("replaying any delta+snapshot interleaving reconstructs the exact final text", () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.oneof(
+            fc.record({
+              kind: fc.constant<"chunk">("chunk"),
+              value: fc.string({ minLength: 1, maxLength: 2600 }),
+            }),
+            fc.record({
+              kind: fc.constant<"snapshot">("snapshot"),
+              value: fc.string({ maxLength: 2600 }),
+            }),
+          ),
+          { maxLength: 40 },
+        ),
+        (ops) => {
+          const mock = createMockResponse();
+          const writer = createChatTokenStreamWriter(
+            "delta-v2",
+            streamWriterDeps,
+          );
+          // Mirror the server's streamedText bookkeeping: onChunk appends the
+          // delta; onSnapshot replaces with the structured rewrite.
+          let serverText = "";
+          for (const op of ops) {
+            if (op.kind === "chunk") {
+              serverText += op.value;
+              writer.writeChunk(mock.res, op.value, serverText);
+            } else {
+              serverText = op.value;
+              writer.writeSnapshot(mock.res, serverText);
+            }
+          }
+          expect(replayClient(parseFrames(mock.writes))).toBe(serverText);
+        },
+      ),
+      { numRuns: 300 },
     );
   });
 });

--- a/packages/agent/src/api/__tests__/sse-wire-streaming.test.ts
+++ b/packages/agent/src/api/__tests__/sse-wire-streaming.test.ts
@@ -345,7 +345,10 @@ describe("delta-v2 chat token stream writer", () => {
       streamWriterDeps,
     );
     const legacyMock = createMockResponse();
-    const legacyWriter = createChatTokenStreamWriter("legacy", streamWriterDeps);
+    const legacyWriter = createChatTokenStreamWriter(
+      "legacy",
+      streamWriterDeps,
+    );
 
     let acc = "";
     for (let i = 0; i < chunkCount; i += 1) {

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -43,6 +43,7 @@ import type {
 } from "@elizaos/shared";
 import {
   asRecord,
+  DELTA_STREAM_PROTOCOL,
   extractAssistantReplyText,
   isLinkedAccountProviderId,
   normalizeCharacterLanguage,
@@ -1795,6 +1796,83 @@ export function writeChatTokenSse(
   writeSse(res, { type: "token", text, fullText });
 }
 
+export { DELTA_STREAM_PROTOCOL };
+
+export type ChatTokenStreamProtocol = "legacy" | typeof DELTA_STREAM_PROTOCOL;
+
+/**
+ * The two write functions a token-stream writer needs, injected so a caller can
+ * pass its OWN (test-mockable) imports. `conversation-routes` imports
+ * `writeChatTokenSse`/`writeSse` from this module; several route tests
+ * `vi.mock` those exports to capture frames, so the writer must dispatch
+ * through the caller's references, not this module's closure-bound originals.
+ */
+export interface ChatTokenStreamWriterDeps {
+  writeChatTokenSse: typeof writeChatTokenSse;
+  writeSse: typeof writeSse;
+}
+
+/**
+ * Framing-agnostic front for the streaming chat token wire. `legacy` reproduces
+ * the historical per-token `{text, fullText}` frame byte-for-byte; `delta-v2`
+ * ships bare `{text}` deltas and re-sends the accumulated `fullText` only on a
+ * geometric byte budget, so an M-chunk reply carries O(N) bytes instead of the
+ * legacy O(N²) (every token re-serialized its whole prefix). The protocol is
+ * negotiated per request (see `readChatRequestPayload`).
+ */
+export interface ChatTokenStreamWriter {
+  /** An incremental streamed chunk. `fullText` is the accumulated text so far. */
+  writeChunk(res: http.ServerResponse, chunk: string, fullText: string): void;
+  /** An authoritative full-text replace (structured-field rewrite, single-frame
+   *  reply). The client treats the carried `fullText` as the new buffer. */
+  writeSnapshot(res: http.ServerResponse, fullText: string): void;
+}
+
+export function createChatTokenStreamWriter(
+  protocol: ChatTokenStreamProtocol,
+  deps: ChatTokenStreamWriterDeps,
+): ChatTokenStreamWriter {
+  if (protocol === "legacy") {
+    return {
+      writeChunk(res, chunk, fullText) {
+        deps.writeChatTokenSse(res, chunk, fullText);
+      },
+      writeSnapshot(res, fullText) {
+        deps.writeChatTokenSse(res, fullText, fullText);
+      },
+    };
+  }
+
+  // delta-v2. Snapshot cost is amortized geometrically: a full-text frame is
+  // re-sent only after at least as many delta bytes have streamed as the
+  // previous snapshot's length (floor 2048 so short replies still self-heal on
+  // a dropped/reordered delta). Snapshots therefore land at ~2048, 4096, 8192,
+  // … bytes — genuinely periodic — and their bytes sum to ~2N, keeping the
+  // total wire (deltas N + snapshots 2N) linear in reply length. A fixed
+  // every-K-tokens cadence would still be O(N²/K) and is intentionally avoided.
+  let bytesSinceSnapshot = 0;
+  let lengthAtLastSnapshot = 0;
+  return {
+    writeChunk(res, chunk, fullText) {
+      bytesSinceSnapshot += chunk.length;
+      if (bytesSinceSnapshot >= Math.max(2048, lengthAtLastSnapshot)) {
+        deps.writeSse(res, { type: "token", text: chunk, fullText });
+        bytesSinceSnapshot = 0;
+        lengthAtLastSnapshot = fullText.length;
+      } else {
+        deps.writeSse(res, { type: "token", text: chunk });
+      }
+    },
+    writeSnapshot(res, fullText) {
+      // No `text` field: the client reads `fullText` as an authoritative
+      // replace rather than an append.
+      deps.writeSse(res, { type: "token", fullText });
+      bytesSinceSnapshot = 0;
+      lengthAtLastSnapshot = fullText.length;
+    },
+  };
+}
+
 export function writeChatStatusSse(
   res: http.ServerResponse,
   status: ChatTurnStatus,
@@ -2046,6 +2124,10 @@ export async function readChatRequestPayload(
   /** Client-supplied idempotency key (see `isDuplicateChatMessage`); absent
    *  when the client did not stamp one. */
   clientMessageId?: string;
+  /** Present only when the client advertised the exact delta-v2 wire protocol;
+   *  drives `createChatTokenStreamWriter`. Unknown values are ignored so the
+   *  server stays on legacy framing for un-negotiated clients. */
+  streamProtocol?: typeof DELTA_STREAM_PROTOCOL;
 } | null> {
   const body = await helpers.readJsonBody<{
     text?: string;
@@ -2055,6 +2137,7 @@ export async function readChatRequestPayload(
     source?: string;
     metadata?: Record<string, unknown>;
     clientMessageId?: string;
+    streamProtocol?: string;
   }>(req, res, { maxBytes });
   if (!body) return null;
   const normalizedPrompt = normalizeIncomingChatPrompt(body.text, body.images);
@@ -2096,6 +2179,10 @@ export async function readChatRequestPayload(
       ? body.metadata
       : undefined;
   const clientMessageId = normalizeClientMessageId(body.clientMessageId);
+  const streamProtocol =
+    body.streamProtocol === DELTA_STREAM_PROTOCOL
+      ? DELTA_STREAM_PROTOCOL
+      : undefined;
   return {
     prompt: normalizedPrompt,
     channelType,
@@ -2104,6 +2191,7 @@ export async function readChatRequestPayload(
     ...(source ? { source } : {}),
     ...(metadata ? { metadata } : {}),
     ...(clientMessageId ? { clientMessageId } : {}),
+    ...(streamProtocol ? { streamProtocol } : {}),
   };
 }
 

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -59,9 +59,9 @@ import type {
 } from "./chat-routes.ts";
 import {
   classifyChatFailure,
+  createChatTokenStreamWriter,
   generateChatResponse,
   generateConversationTitle,
-  createChatTokenStreamWriter,
   getChatFailureReply,
   hasRecentVisibleAssistantMemorySince,
   initSse,

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -61,6 +61,7 @@ import {
   classifyChatFailure,
   generateChatResponse,
   generateConversationTitle,
+  createChatTokenStreamWriter,
   getChatFailureReply,
   hasRecentVisibleAssistantMemorySince,
   initSse,
@@ -2477,7 +2478,14 @@ export async function handleConversationRoutes(
       preferredLanguage,
       source,
       metadata: chatMetadata,
+      streamProtocol,
     } = chatPayload;
+    // Deps are the module-imported write fns so route tests that vi.mock
+    // `writeChatTokenSse`/`writeSse` keep capturing frames on the legacy path.
+    const tokenWriter = createChatTokenStreamWriter(
+      streamProtocol ?? "legacy",
+      { writeChatTokenSse, writeSse },
+    );
 
     // The SSE channel opens as soon as the request is validated — before
     // runtime resolution, room setup, and user-message persistence — so the
@@ -2547,7 +2555,7 @@ export async function handleConversationRoutes(
       const endActiveChatTurn = beginActiveChatTurn(state);
       try {
         if (!disconnectTracker.isAborted()) {
-          writeChatTokenSse(res, walletModeGuidance, walletModeGuidance);
+          tokenWriter.writeSnapshot(res, walletModeGuidance);
           try {
             await persistAssistantConversationMemory(
               runtime,
@@ -2633,7 +2641,7 @@ export async function handleConversationRoutes(
               return;
             }
             streamedText += chunk;
-            writeChatTokenSse(res, chunk, streamedText);
+            tokenWriter.writeChunk(res, chunk, streamedText);
           },
           onSnapshot: (text) => {
             if (!text) return;
@@ -2656,7 +2664,7 @@ export async function handleConversationRoutes(
               return;
             }
             streamedText = text;
-            writeChatTokenSse(res, text, streamedText);
+            tokenWriter.writeSnapshot(res, streamedText);
           },
           resolveNoResponseText: () =>
             resolveNoResponseFallback(state.logBuffer, runtime),
@@ -2676,7 +2684,7 @@ export async function handleConversationRoutes(
             for (const chunk of chunkVisibleTextForSse(resolvedText)) {
               if (disconnectTracker.isAborted()) break;
               streamedText += chunk;
-              writeChatTokenSse(res, chunk, streamedText);
+              tokenWriter.writeChunk(res, chunk, streamedText);
               await new Promise((resolve) => setTimeout(resolve, 60));
             }
           }

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-delta-sse.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-delta-sse.test.ts
@@ -11,9 +11,8 @@
  * service) must rebuild the full text. Real methods, no network.
  */
 import { describe, expect, test } from "bun:test";
-
-import { ElizaSandboxBridgeService } from "./eliza-sandbox-bridge";
 import { ElizaSandboxService } from "./eliza-sandbox";
+import { ElizaSandboxBridgeService } from "./eliza-sandbox-bridge";
 
 type Normalizer = { normalizeBridgeSseResponse(response: Response): Response };
 
@@ -41,8 +40,7 @@ async function readEvents(
     if (done) break;
     out += decoder.decode(value, { stream: true });
   }
-  const events: Array<{ event: string | null; data: Record<string, unknown> }> =
-    [];
+  const events: Array<{ event: string | null; data: Record<string, unknown> }> = [];
   for (const frame of out.split("\n\n")) {
     if (!frame.trim()) continue;
     const lines = frame.split("\n");
@@ -62,10 +60,7 @@ const normalizers: Array<[string, () => Normalizer]> = [
     "ElizaSandboxBridgeService",
     () => new ElizaSandboxBridgeService({} as never) as unknown as Normalizer,
   ],
-  [
-    "ElizaSandboxService",
-    () => new ElizaSandboxService() as unknown as Normalizer,
-  ],
+  ["ElizaSandboxService", () => new ElizaSandboxService() as unknown as Normalizer],
 ];
 
 for (const [label, make] of normalizers) {
@@ -80,11 +75,7 @@ for (const [label, make] of normalizers) {
       const events = await readEvents(make().normalizeBridgeSseResponse(sseResponse(body)));
 
       const chunks = events.filter((event) => event.event === "chunk");
-      expect(chunks.map((event) => event.data.chunk)).toEqual([
-        "Hello ",
-        "world",
-        "!",
-      ]);
+      expect(chunks.map((event) => event.data.chunk)).toEqual(["Hello ", "world", "!"]);
       // Each downstream chunk carries the ACCUMULATED text, not just its delta.
       expect(chunks.map((event) => event.data.fullText)).toEqual([
         "Hello ",
@@ -124,10 +115,7 @@ for (const [label, make] of normalizers) {
       const events = await readEvents(make().normalizeBridgeSseResponse(sseResponse(body)));
 
       const chunks = events.filter((event) => event.event === "chunk");
-      expect(chunks.map((event) => event.data.fullText)).toEqual([
-        "Hel",
-        "Hello",
-      ]);
+      expect(chunks.map((event) => event.data.fullText)).toEqual(["Hel", "Hello"]);
       const done = events.find((event) => event.event === "done");
       expect(done?.data.text).toBe("Hello");
     });

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-delta-sse.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-delta-sse.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Regression: the cloud→sandbox SSE proxy must ACCUMULATE token deltas.
+ *
+ * A negotiated client's `streamProtocol:"delta-v2"` body can ride through the
+ * bridge to the sandboxed agent, which then ships bare `{type:"token",text}`
+ * deltas and re-sends `fullText` only on a periodic snapshot. If the proxy read
+ * `fullText` off each frame (its old `data.fullText ?? data.text`), the
+ * downstream `chunk` events would degrade to a single delta and `done` would
+ * carry an empty/partial reply. Both `normalizeBridgeSseResponse`
+ * implementations (the standalone bridge service and the duplicate on the host
+ * service) must rebuild the full text. Real methods, no network.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { ElizaSandboxBridgeService } from "./eliza-sandbox-bridge";
+import { ElizaSandboxService } from "./eliza-sandbox";
+
+type Normalizer = { normalizeBridgeSseResponse(response: Response): Response };
+
+function sseResponse(body: string): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(body));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+async function readEvents(
+  response: Response,
+): Promise<Array<{ event: string | null; data: Record<string, unknown> }>> {
+  const reader = response.body?.getReader();
+  if (!reader) throw new Error("normalized response has no body");
+  const decoder = new TextDecoder();
+  let out = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += decoder.decode(value, { stream: true });
+  }
+  const events: Array<{ event: string | null; data: Record<string, unknown> }> =
+    [];
+  for (const frame of out.split("\n\n")) {
+    if (!frame.trim()) continue;
+    const lines = frame.split("\n");
+    const eventLine = lines.find((line) => line.startsWith("event: "));
+    const dataLine = lines.find((line) => line.startsWith("data: "));
+    if (!dataLine) continue;
+    events.push({
+      event: eventLine ? eventLine.slice("event: ".length) : null,
+      data: JSON.parse(dataLine.slice("data: ".length)),
+    });
+  }
+  return events;
+}
+
+const normalizers: Array<[string, () => Normalizer]> = [
+  [
+    "ElizaSandboxBridgeService",
+    () => new ElizaSandboxBridgeService({} as never) as unknown as Normalizer,
+  ],
+  [
+    "ElizaSandboxService",
+    () => new ElizaSandboxService() as unknown as Normalizer,
+  ],
+];
+
+for (const [label, make] of normalizers) {
+  describe(`${label}.normalizeBridgeSseResponse accumulates delta-v2 frames`, () => {
+    test("rebuilds fullText from bare deltas and carries it on done", async () => {
+      const body =
+        'data: {"type":"token","text":"Hello "}\n\n' +
+        'data: {"type":"token","text":"world"}\n\n' +
+        'data: {"type":"token","text":"!"}\n\n' +
+        // done WITHOUT fullText — text must be the accumulated reply.
+        'data: {"type":"done"}\n\n';
+      const events = await readEvents(make().normalizeBridgeSseResponse(sseResponse(body)));
+
+      const chunks = events.filter((event) => event.event === "chunk");
+      expect(chunks.map((event) => event.data.chunk)).toEqual([
+        "Hello ",
+        "world",
+        "!",
+      ]);
+      // Each downstream chunk carries the ACCUMULATED text, not just its delta.
+      expect(chunks.map((event) => event.data.fullText)).toEqual([
+        "Hello ",
+        "Hello world",
+        "Hello world!",
+      ]);
+      const done = events.find((event) => event.event === "done");
+      expect(done?.data.text).toBe("Hello world!");
+    });
+
+    test("a periodic fullText snapshot resets the accumulator authoritatively", async () => {
+      const body =
+        'data: {"type":"token","text":"Hello wrld"}\n\n' +
+        // structured rewrite: authoritative full-text replace, no text field.
+        'data: {"type":"token","fullText":"Hello world"}\n\n' +
+        'data: {"type":"token","text":"!"}\n\n' +
+        'data: {"type":"done","fullText":"Hello world!"}\n\n';
+      const events = await readEvents(make().normalizeBridgeSseResponse(sseResponse(body)));
+
+      const chunks = events.filter((event) => event.event === "chunk");
+      expect(chunks.map((event) => event.data.fullText)).toEqual([
+        "Hello wrld",
+        "Hello world",
+        "Hello world!",
+      ]);
+      // The snapshot frame has no delta, so its downstream chunk is empty.
+      expect(chunks[1].data.chunk).toBe("");
+      const done = events.find((event) => event.event === "done");
+      expect(done?.data.text).toBe("Hello world!");
+    });
+
+    test("legacy per-token fullText still passes through unchanged", async () => {
+      const body =
+        'data: {"type":"token","text":"Hel","fullText":"Hel"}\n\n' +
+        'data: {"type":"token","text":"lo","fullText":"Hello"}\n\n' +
+        'data: {"type":"done","fullText":"Hello"}\n\n';
+      const events = await readEvents(make().normalizeBridgeSseResponse(sseResponse(body)));
+
+      const chunks = events.filter((event) => event.event === "chunk");
+      expect(chunks.map((event) => event.data.fullText)).toEqual([
+        "Hel",
+        "Hello",
+      ]);
+      const done = events.find((event) => event.event === "done");
+      expect(done?.data.text).toBe("Hello");
+    });
+  });
+}

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-delta-sse.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge-delta-sse.test.ts
@@ -17,9 +17,16 @@ import { ElizaSandboxBridgeService } from "./eliza-sandbox-bridge";
 type Normalizer = { normalizeBridgeSseResponse(response: Response): Response };
 
 function sseResponse(body: string): Response {
+  return sseResponseChunks([body]);
+}
+
+function sseResponseChunks(chunks: string[]): Response {
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
-      controller.enqueue(new TextEncoder().encode(body));
+      const encoder = new TextEncoder();
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
       controller.close();
     },
   });
@@ -118,6 +125,27 @@ for (const [label, make] of normalizers) {
       expect(chunks.map((event) => event.data.fullText)).toEqual(["Hel", "Hello"]);
       const done = events.find((event) => event.event === "done");
       expect(done?.data.text).toBe("Hello");
+    });
+
+    test("buffers split SSE frames before parsing and accumulating", async () => {
+      const events = await readEvents(
+        make().normalizeBridgeSseResponse(
+          sseResponseChunks([
+            'data: {"type":"token","text":"Hel',
+            'lo "}\n',
+            "\n",
+            'data: {"type":"token","text":"world"}\r\n',
+            "\r\n",
+            'data: {"type":"done"}\n\n',
+          ]),
+        ),
+      );
+
+      const chunks = events.filter((event) => event.event === "chunk");
+      expect(chunks.map((event) => event.data.chunk)).toEqual(["Hello ", "world"]);
+      expect(chunks.map((event) => event.data.fullText)).toEqual(["Hello ", "Hello world"]);
+      const done = events.find((event) => event.event === "done");
+      expect(done?.data.text).toBe("Hello world");
     });
   });
 }

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge.ts
@@ -235,49 +235,69 @@ export class ElizaSandboxBridgeService {
     // resends `fullText` only on a periodic snapshot, so the downstream
     // `fullText`/done text must be rebuilt here, not read off each frame.
     let accumulated = "";
+    let pending = "";
+    const findEventBreak = (value: string) => {
+      const lfBreak = value.indexOf("\n\n");
+      const crlfBreak = value.indexOf("\r\n\r\n");
+      if (lfBreak === -1 && crlfBreak === -1) return null;
+      if (lfBreak === -1) return { index: crlfBreak, length: 4 };
+      if (crlfBreak === -1) return { index: lfBreak, length: 2 };
+      return lfBreak < crlfBreak ? { index: lfBreak, length: 2 } : { index: crlfBreak, length: 4 };
+    };
+    const emitFrame = (frame: string, controller: TransformStreamDefaultController<string>) => {
+      if (!frame.trim()) return;
+      const dataLine = frame.split(/\r?\n/).find((line) => line.startsWith("data:"));
+      if (!dataLine) {
+        controller.enqueue(`${frame}\n\n`);
+        return;
+      }
+      try {
+        const data = JSON.parse(dataLine.slice(5).trimStart());
+        if (data?.type === "token") {
+          const delta = typeof data.text === "string" ? data.text : "";
+          accumulated = typeof data.fullText === "string" ? data.fullText : accumulated + delta;
+          controller.enqueue(
+            `event: chunk\ndata: ${JSON.stringify({
+              messageId,
+              chunk: delta,
+              text: delta,
+              fullText: accumulated,
+              timestamp: Date.now(),
+            })}\n\n`,
+          );
+          return;
+        }
+        if (data?.type === "done") {
+          controller.enqueue(
+            `event: done\ndata: ${JSON.stringify({
+              messageId,
+              text: typeof data.fullText === "string" ? data.fullText : accumulated,
+            })}\n\n`,
+          );
+          return;
+        }
+      } catch {
+        // error-policy:J3 untrusted SSE frames are invalid for normalization and pass through unchanged.
+      }
+      controller.enqueue(`${frame}\n\n`);
+    };
     const stream = response.body
       .pipeThrough(new TextDecoderStream())
       .pipeThrough(
         new TransformStream<string, string>({
           transform: (chunk, controller) => {
-            for (const frame of chunk.split("\n\n")) {
-              if (!frame.trim()) continue;
-              const dataLine = frame.split("\n").find((line) => line.startsWith("data: "));
-              if (!dataLine) {
-                controller.enqueue(`${frame}\n\n`);
-                continue;
-              }
-              try {
-                const data = JSON.parse(dataLine.slice(6));
-                if (data?.type === "token") {
-                  const delta = typeof data.text === "string" ? data.text : "";
-                  accumulated =
-                    typeof data.fullText === "string" ? data.fullText : accumulated + delta;
-                  controller.enqueue(
-                    `event: chunk\ndata: ${JSON.stringify({
-                      messageId,
-                      chunk: delta,
-                      text: delta,
-                      fullText: accumulated,
-                      timestamp: Date.now(),
-                    })}\n\n`,
-                  );
-                  continue;
-                }
-                if (data?.type === "done") {
-                  controller.enqueue(
-                    `event: done\ndata: ${JSON.stringify({
-                      messageId,
-                      text: typeof data.fullText === "string" ? data.fullText : accumulated,
-                    })}\n\n`,
-                  );
-                  continue;
-                }
-              } catch {
-                // Pass unknown frames through unchanged.
-              }
-              controller.enqueue(`${frame}\n\n`);
+            pending += chunk;
+            let eventBreak = findEventBreak(pending);
+            while (eventBreak) {
+              const frame = pending.slice(0, eventBreak.index);
+              pending = pending.slice(eventBreak.index + eventBreak.length);
+              emitFrame(frame, controller);
+              eventBreak = findEventBreak(pending);
             }
+          },
+          flush: (controller) => {
+            if (pending.trim()) emitFrame(pending, controller);
+            pending = "";
           },
         }),
       )

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge.ts
@@ -252,9 +252,7 @@ export class ElizaSandboxBridgeService {
                 if (data?.type === "token") {
                   const delta = typeof data.text === "string" ? data.text : "";
                   accumulated =
-                    typeof data.fullText === "string"
-                      ? data.fullText
-                      : accumulated + delta;
+                    typeof data.fullText === "string" ? data.fullText : accumulated + delta;
                   controller.enqueue(
                     `event: chunk\ndata: ${JSON.stringify({
                       messageId,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox-bridge.ts
@@ -230,6 +230,11 @@ export class ElizaSandboxBridgeService {
     }
 
     const messageId = crypto.randomUUID();
+    // Accumulate across frames: a delta-v2 agent (client `streamProtocol` can
+    // ride through the bridge to it) ships bare `{type:"token",text}` deltas and
+    // resends `fullText` only on a periodic snapshot, so the downstream
+    // `fullText`/done text must be rebuilt here, not read off each frame.
+    let accumulated = "";
     const stream = response.body
       .pipeThrough(new TextDecoderStream())
       .pipeThrough(
@@ -244,13 +249,18 @@ export class ElizaSandboxBridgeService {
               }
               try {
                 const data = JSON.parse(dataLine.slice(6));
-                if (data?.type === "token" && typeof data.text === "string") {
+                if (data?.type === "token") {
+                  const delta = typeof data.text === "string" ? data.text : "";
+                  accumulated =
+                    typeof data.fullText === "string"
+                      ? data.fullText
+                      : accumulated + delta;
                   controller.enqueue(
                     `event: chunk\ndata: ${JSON.stringify({
                       messageId,
-                      chunk: data.text,
-                      text: data.text,
-                      fullText: typeof data.fullText === "string" ? data.fullText : data.text,
+                      chunk: delta,
+                      text: delta,
+                      fullText: accumulated,
                       timestamp: Date.now(),
                     })}\n\n`,
                   );
@@ -260,7 +270,7 @@ export class ElizaSandboxBridgeService {
                   controller.enqueue(
                     `event: done\ndata: ${JSON.stringify({
                       messageId,
-                      text: typeof data.fullText === "string" ? data.fullText : "",
+                      text: typeof data.fullText === "string" ? data.fullText : accumulated,
                     })}\n\n`,
                   );
                   continue;

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -3810,9 +3810,7 @@ export class ElizaSandboxService {
                 if (data?.type === "token") {
                   const delta = typeof data.text === "string" ? data.text : "";
                   accumulated =
-                    typeof data.fullText === "string"
-                      ? data.fullText
-                      : accumulated + delta;
+                    typeof data.fullText === "string" ? data.fullText : accumulated + delta;
                   controller.enqueue(
                     `event: chunk\ndata: ${JSON.stringify({
                       messageId,

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -3788,6 +3788,11 @@ export class ElizaSandboxService {
     }
 
     const messageId = crypto.randomUUID();
+    // Accumulate across frames: a delta-v2 agent (client `streamProtocol` can
+    // ride through the bridge to it) ships bare `{type:"token",text}` deltas and
+    // resends `fullText` only on a periodic snapshot, so the downstream
+    // `fullText`/done text must be rebuilt here, not read off each frame.
+    let accumulated = "";
     const stream = response.body
       .pipeThrough(new TextDecoderStream())
       .pipeThrough(
@@ -3802,13 +3807,18 @@ export class ElizaSandboxService {
               }
               try {
                 const data = JSON.parse(dataLine.slice(6));
-                if (data?.type === "token" && typeof data.text === "string") {
+                if (data?.type === "token") {
+                  const delta = typeof data.text === "string" ? data.text : "";
+                  accumulated =
+                    typeof data.fullText === "string"
+                      ? data.fullText
+                      : accumulated + delta;
                   controller.enqueue(
                     `event: chunk\ndata: ${JSON.stringify({
                       messageId,
-                      chunk: data.text,
-                      text: data.text,
-                      fullText: typeof data.fullText === "string" ? data.fullText : data.text,
+                      chunk: delta,
+                      text: delta,
+                      fullText: accumulated,
                       timestamp: Date.now(),
                     })}\n\n`,
                   );
@@ -3818,7 +3828,7 @@ export class ElizaSandboxService {
                   controller.enqueue(
                     `event: done\ndata: ${JSON.stringify({
                       messageId,
-                      text: typeof data.fullText === "string" ? data.fullText : "",
+                      text: typeof data.fullText === "string" ? data.fullText : accumulated,
                     })}\n\n`,
                   );
                   continue;

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -3793,49 +3793,69 @@ export class ElizaSandboxService {
     // resends `fullText` only on a periodic snapshot, so the downstream
     // `fullText`/done text must be rebuilt here, not read off each frame.
     let accumulated = "";
+    let pending = "";
+    const findEventBreak = (value: string) => {
+      const lfBreak = value.indexOf("\n\n");
+      const crlfBreak = value.indexOf("\r\n\r\n");
+      if (lfBreak === -1 && crlfBreak === -1) return null;
+      if (lfBreak === -1) return { index: crlfBreak, length: 4 };
+      if (crlfBreak === -1) return { index: lfBreak, length: 2 };
+      return lfBreak < crlfBreak ? { index: lfBreak, length: 2 } : { index: crlfBreak, length: 4 };
+    };
+    const emitFrame = (frame: string, controller: TransformStreamDefaultController<string>) => {
+      if (!frame.trim()) return;
+      const dataLine = frame.split(/\r?\n/).find((line) => line.startsWith("data:"));
+      if (!dataLine) {
+        controller.enqueue(`${frame}\n\n`);
+        return;
+      }
+      try {
+        const data = JSON.parse(dataLine.slice(5).trimStart());
+        if (data?.type === "token") {
+          const delta = typeof data.text === "string" ? data.text : "";
+          accumulated = typeof data.fullText === "string" ? data.fullText : accumulated + delta;
+          controller.enqueue(
+            `event: chunk\ndata: ${JSON.stringify({
+              messageId,
+              chunk: delta,
+              text: delta,
+              fullText: accumulated,
+              timestamp: Date.now(),
+            })}\n\n`,
+          );
+          return;
+        }
+        if (data?.type === "done") {
+          controller.enqueue(
+            `event: done\ndata: ${JSON.stringify({
+              messageId,
+              text: typeof data.fullText === "string" ? data.fullText : accumulated,
+            })}\n\n`,
+          );
+          return;
+        }
+      } catch {
+        // error-policy:J3 untrusted SSE frames are invalid for normalization and pass through unchanged.
+      }
+      controller.enqueue(`${frame}\n\n`);
+    };
     const stream = response.body
       .pipeThrough(new TextDecoderStream())
       .pipeThrough(
         new TransformStream<string, string>({
           transform: (chunk, controller) => {
-            for (const frame of chunk.split("\n\n")) {
-              if (!frame.trim()) continue;
-              const dataLine = frame.split("\n").find((line) => line.startsWith("data: "));
-              if (!dataLine) {
-                controller.enqueue(`${frame}\n\n`);
-                continue;
-              }
-              try {
-                const data = JSON.parse(dataLine.slice(6));
-                if (data?.type === "token") {
-                  const delta = typeof data.text === "string" ? data.text : "";
-                  accumulated =
-                    typeof data.fullText === "string" ? data.fullText : accumulated + delta;
-                  controller.enqueue(
-                    `event: chunk\ndata: ${JSON.stringify({
-                      messageId,
-                      chunk: delta,
-                      text: delta,
-                      fullText: accumulated,
-                      timestamp: Date.now(),
-                    })}\n\n`,
-                  );
-                  continue;
-                }
-                if (data?.type === "done") {
-                  controller.enqueue(
-                    `event: done\ndata: ${JSON.stringify({
-                      messageId,
-                      text: typeof data.fullText === "string" ? data.fullText : accumulated,
-                    })}\n\n`,
-                  );
-                  continue;
-                }
-              } catch {
-                // Pass unknown frames through unchanged.
-              }
-              controller.enqueue(`${frame}\n\n`);
+            pending += chunk;
+            let eventBreak = findEventBreak(pending);
+            while (eventBreak) {
+              const frame = pending.slice(0, eventBreak.index);
+              pending = pending.slice(eventBreak.index + eventBreak.length);
+              emitFrame(frame, controller);
+              eventBreak = findEventBreak(pending);
             }
+          },
+          flush: (controller) => {
+            if (pending.trim()) emitFrame(pending, controller);
+            pending = "";
           },
         }),
       )

--- a/packages/shared/src/utils/streaming-text.ts
+++ b/packages/shared/src/utils/streaming-text.ts
@@ -2,6 +2,19 @@
  * Merge streaming text updates that may arrive as pure deltas, cumulative
  * snapshots, or overlapping suffix/prefix fragments.
  */
+
+/**
+ * Wire protocol a chat client advertises in the stream POST body to opt into
+ * delta framing (deltas + geometric snapshots instead of a full-text snapshot
+ * per token). The server only switches framing when this exact literal is
+ * present, so old servers ignore the unknown field and old clients keep the
+ * legacy per-token `fullText`. Single source of truth for both the agent SSE
+ * writer (`@elizaos/agent` chat-routes) and the UI stream client.
+ */
+export const DELTA_STREAM_PROTOCOL = "delta-v2" as const;
+
+export type DeltaStreamProtocol = typeof DELTA_STREAM_PROTOCOL;
+
 function commonPrefixLength(left: string, right: string): number {
   const maxLength = Math.min(left.length, right.length);
   let index = 0;

--- a/packages/ui/src/api/client-base-delta-stream.test.ts
+++ b/packages/ui/src/api/client-base-delta-stream.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Client reducer coverage for the negotiated delta-v2 chat wire: bare `text`
+ * deltas plain-append (bypassing mergeStreamingText's overlap dedupe, which
+ * would drop a legitimately repeated multi-char delta), a `fullText`-only frame
+ * is an authoritative replace, a legacy per-token `fullText` still wins, the
+ * request advertises `streamProtocol`, and the terminal `done.fullText` is the
+ * final text. Deterministic fake reader, no live model.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client";
+
+type OnTokenCall = [token: string, accumulated?: string];
+
+function streamFromSse(sse: string): {
+  client: ElizaClient;
+  request: ReturnType<typeof vi.fn>;
+} {
+  const encoder = new TextEncoder();
+  const read = vi
+    .fn()
+    .mockResolvedValueOnce({ done: false, value: encoder.encode(sse) })
+    .mockRejectedValueOnce(new Error("read after terminal event"));
+  const cancel = vi.fn(async () => {});
+  const request = vi.fn(
+    async () =>
+      ({
+        ok: true,
+        status: 200,
+        body: { getReader: () => ({ read, cancel }) },
+      }) as unknown as Response,
+  );
+  const client = new ElizaClient("http://agent.example:31337", "token");
+  client.setRequestTransport({ request });
+  return { client, request };
+}
+
+function parseRequestBody(request: ReturnType<typeof vi.fn>): {
+  streamProtocol?: string;
+  [key: string]: unknown;
+} {
+  const init = request.mock.calls[0]?.[1] as { body?: string } | undefined;
+  return JSON.parse(init?.body ?? "{}");
+}
+
+describe("delta-v2 chat stream client reducer", () => {
+  it("appends a repeated multi-char delta instead of dropping it (mergeStreamingText regression)", async () => {
+    const { client } = streamFromSse(
+      'data: {"type":"token","text":"the "}\n\n' +
+        'data: {"type":"token","text":"the "}\n\n' +
+        'data: {"type":"done","fullText":"the the ","agentName":"Eliza"}\n\n',
+    );
+    const calls: OnTokenCall[] = [];
+    const onToken = vi.fn((token: string, accumulated?: string) => {
+      calls.push([token, accumulated]);
+    });
+
+    const result = await client.streamChatEndpoint(
+      "/api/conversations/c/messages/stream",
+      "hi",
+      onToken,
+    );
+
+    // Both deltas surface; the second "the " is NOT deduped away — the
+    // accumulated buffer advances to "the the " (with the repeated word). The
+    // final reply text is trailing-trimmed by the client.
+    expect(calls).toEqual([
+      ["the ", "the "],
+      ["the ", "the the "],
+    ]);
+    expect(result.text).toBe("the the");
+    expect(result.completed).toBe(true);
+  });
+
+  it("treats a fullText-only frame as an authoritative replace, including a non-append rewrite", async () => {
+    const { client } = streamFromSse(
+      'data: {"type":"token","text":"Hello wrld"}\n\n' +
+        'data: {"type":"token","fullText":"Hello world"}\n\n' +
+        'data: {"type":"done","fullText":"Hello world","agentName":"Eliza"}\n\n',
+    );
+    const calls: OnTokenCall[] = [];
+    const onToken = vi.fn((token: string, accumulated?: string) => {
+      calls.push([token, accumulated]);
+    });
+
+    const result = await client.streamChatEndpoint(
+      "/api/conversations/c/messages/stream",
+      "hi",
+      onToken,
+    );
+
+    // The rewrite arrives with an empty delta chunk and replaces the buffer —
+    // the corrected "world" overwrites the streamed "wrld".
+    expect(calls).toEqual([
+      ["Hello wrld", "Hello wrld"],
+      ["", "Hello world"],
+    ]);
+    expect(result.text).toBe("Hello world");
+  });
+
+  it("keeps legacy per-token fullText authoritative even for a delta-negotiated client", async () => {
+    const { client } = streamFromSse(
+      'data: {"type":"token","text":"Hel","fullText":"Hel"}\n\n' +
+        'data: {"type":"token","text":"lo","fullText":"Hello"}\n\n' +
+        'data: {"type":"done","fullText":"Hello","agentName":"Eliza"}\n\n',
+    );
+    const calls: OnTokenCall[] = [];
+    const onToken = vi.fn((token: string, accumulated?: string) => {
+      calls.push([token, accumulated]);
+    });
+
+    const result = await client.streamChatEndpoint(
+      "/api/conversations/c/messages/stream",
+      "hi",
+      onToken,
+    );
+
+    // fullText, when present, is used verbatim (no double-append of text).
+    expect(calls).toEqual([
+      ["Hel", "Hel"],
+      ["lo", "Hello"],
+    ]);
+    expect(result.text).toBe("Hello");
+  });
+
+  it("advertises streamProtocol delta-v2 in the request body", async () => {
+    const { client, request } = streamFromSse(
+      'data: {"type":"done","fullText":"ok","agentName":"Eliza"}\n\n',
+    );
+
+    await client.streamChatEndpoint(
+      "/api/conversations/c/messages/stream",
+      "hi",
+      vi.fn(),
+    );
+
+    expect(parseRequestBody(request).streamProtocol).toBe("delta-v2");
+  });
+
+  it("lets the terminal done.fullText win as the final text over accumulated deltas", async () => {
+    const { client } = streamFromSse(
+      'data: {"type":"token","text":"par"}\n\n' +
+        'data: {"type":"done","fullText":"partial complete","agentName":"Eliza"}\n\n',
+    );
+    const onToken = vi.fn();
+
+    const result = await client.streamChatEndpoint(
+      "/api/conversations/c/messages/stream",
+      "hi",
+      onToken,
+    );
+
+    // Mid-stream the buffer was "par"; the authoritative done text replaces it.
+    expect(onToken).toHaveBeenCalledWith("par", "par");
+    expect(result.text).toBe("partial complete");
+    expect(result.completed).toBe(true);
+  });
+});

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -24,7 +24,10 @@ import {
   getElizaApiToken,
   setElizaApiBase,
 } from "../utils/eliza-globals";
-import { mergeStreamingText } from "../utils/streaming-text";
+import {
+  DELTA_STREAM_PROTOCOL,
+  mergeStreamingText,
+} from "../utils/streaming-text";
 import { androidNativeAgentTransportForUrl } from "./android-native-agent-transport";
 import type {
   AccountConnectRequest,
@@ -190,6 +193,12 @@ function parseChatToolCallEvent(
 }
 
 type StreamChatState = {
+  /** True when this request advertised delta-v2, so a token frame WITHOUT
+   *  `fullText` is a pure delta to plain-append — never routed through
+   *  `mergeStreamingText`, whose overlap heuristic would drop a legitimately
+   *  repeated multi-char delta (e.g. a second "the " after a buffer ending in
+   *  "the "). */
+  deltaProtocol: boolean;
   fullText: string;
   doneText: string | null;
   doneAgentName: string | null;
@@ -261,9 +270,17 @@ function applyStreamChatTokenEvent(
   const chunk = parsed.text ?? "";
   const nextFullText =
     typeof parsed.fullText === "string"
-      ? parsed.fullText
+      ? // An explicit snapshot is always authoritative (delta-v2 periodic
+        // snapshot AND legacy per-token fullText both land here).
+        parsed.fullText
       : chunk
-        ? mergeStreamingText(state.fullText, chunk)
+        ? // No fullText: a bare delta. Under negotiated delta-v2 the server
+          // guarantees pure appends, so bypass mergeStreamingText (its overlap
+          // dedupe drops legitimately repeated multi-char deltas). Foreign /
+          // un-negotiated streams still ride the merge heuristic.
+          state.deltaProtocol
+          ? state.fullText + chunk
+          : mergeStreamingText(state.fullText, chunk)
         : state.fullText;
   if (nextFullText === state.fullText) return false;
   state.fullText = nextFullText;
@@ -1784,6 +1801,10 @@ export class ElizaClient {
           text,
           channelType,
           clientMessageId: resolvedClientMessageId,
+          // Opt into delta framing: the server ships bare deltas + periodic
+          // snapshots instead of the full text on every token (O(N) wire). Old
+          // servers ignore the unknown field and keep legacy per-token fullText.
+          streamProtocol: DELTA_STREAM_PROTOCOL,
           ...(images?.length ? { images } : {}),
           ...(metadata ? { metadata } : {}),
         }),
@@ -1802,6 +1823,7 @@ export class ElizaClient {
     const reader = res.body.getReader();
     let buffer = "";
     const streamState: StreamChatState = {
+      deltaProtocol: true,
       fullText: "",
       doneText: null,
       doneAgentName: null,

--- a/packages/ui/src/utils/streaming-text.ts
+++ b/packages/ui/src/utils/streaming-text.ts
@@ -4,6 +4,8 @@
  */
 export {
   computeStreamingDelta,
+  DELTA_STREAM_PROTOCOL,
+  type DeltaStreamProtocol,
   mergeStreamingText,
   resolveStreamingUpdate,
   type StreamingUpdateResult,


### PR DESCRIPTION
## What

Stops the streaming chat endpoint from re-serializing the entire accumulated
`fullText` on **every** token SSE frame. For an M-chunk reply the old wire
carried `sum(i·s) ≈ M²·s/2` bytes — quadratic in reply length. Now the client
advertises a versioned wire protocol (`streamProtocol: "delta-v2"`) in the
stream POST body, and when the server sees that exact literal it ships bare
`{type:"token",text:<delta>}` frames and re-sends the accumulated
`{…,fullText}` only on a **geometric byte budget** (a snapshot lands once at
least as many delta bytes have streamed as the previous snapshot's length,
floor 2048). Total snapshot bytes ≈ 2N, deltas ≈ N → **O(N) wire**, with
genuinely periodic full-text resyncs as a correctness backstop.

Fixes #15254. Follow-up from #15252 (which introduced the `onChunk`/`onSnapshot`
hooks + the snapshot-shrink guard this builds on).

## Why versioned negotiation

All four compatibility quadrants stay correct:

- **new client → new server:** delta framing (O(N)).
- **new client → old server:** old server ignores the unknown `streamProtocol`
  field, keeps per-token `fullText`. The client reducer treats an explicit
  `fullText` as authoritative, so it renders correctly.
- **old client → new server:** old client never advertises, server stays on
  legacy framing (byte-for-byte identical to today).
- **old client → old server:** unchanged.

## Changes

- **`packages/agent/src/api/chat-routes.ts`** — export `DELTA_STREAM_PROTOCOL`;
  `readChatRequestPayload` parses the optional `streamProtocol` body field
  (only the exact `"delta-v2"` literal is honored); new
  `createChatTokenStreamWriter(protocol, deps)` factory. The write functions are
  **injected** so route tests that `vi.mock` `writeChatTokenSse`/`writeSse` keep
  capturing frames. `legacy` mode is byte-identical to the old
  `writeChatTokenSse` calls.
- **`packages/agent/src/api/conversation-routes.ts`** — builds the writer from
  the negotiated protocol and routes the 4 emit sites (wallet guidance,
  `onChunk`, `onSnapshot`, fallback re-chunker) through it. The snapshot-shrink
  guard is preserved exactly.
- **`packages/ui/src/api/client-base.ts`** — advertises `streamProtocol` in the
  body; under delta mode a bare delta is **plain-appended** (bypassing
  `mergeStreamingText`, whose overlap dedupe would drop a legitimately repeated
  multi-char delta like a second `"the "`); an explicit `fullText` stays
  authoritative for foreign/legacy streams.
- **`packages/shared/src/utils/streaming-text.ts` / `packages/ui/src/utils/streaming-text.ts`**
  — single source of truth for the `DELTA_STREAM_PROTOCOL` literal.
  `mergeStreamingText` itself is **unchanged** (foreign streams still need it).
- **`packages/cloud/shared/src/lib/services/eliza-sandbox-bridge.ts` + `eliza-sandbox.ts`**
  — the cloud→sandbox SSE proxy now **accumulates** deltas so downstream
  `chunk`/`done` frames carry the complete reply even if a negotiated client's
  body rides through the proxy to a delta-v2 agent.

Intentionally NOT touched: electrobun stream-manager / voice-runtime-adapter /
smoke scripts / playwright stubs — they never advertise, stay on legacy framing,
and are already delta-tolerant; native IPC transports are byte-transparent.

## Bytes-on-wire (real writer, deterministic)

`createChatTokenStreamWriter` run over a 6800-char / 1200-chunk reply:

| framing | frames | snapshot frames | bytes on wire |
| --- | --- | --- | --- |
| legacy | 1200 | 1200 (every token) | **4,141,150** |
| delta-v2 | 1200 | 2 | **53,778** |

~77× reduction; delta-v2 scales linearly with reply length. The same
measurement is pinned as an assertion (`≤ 4·finalLen + 64·chunkCount`, legacy
`> 20×` delta) in `sse-wire-streaming.test.ts`.

## Verification

<details>
<summary>Scoped commands + real output</summary>

```
# packages/agent — SSE writer + route framing (both framings)
$ bunx vitest run src/api/__tests__/sse-wire-streaming.test.ts \
      src/api/__tests__/conversation-stream-sse-contract.test.ts
 Test Files  2 passed (2)
      Tests  20 passed (20)

# legacy-path tests still green (dep-injected mocked writers)
$ bunx vitest run src/api/__tests__/persistence-after-done.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)
$ bunx vitest run src/api/__tests__/conversation-failurekind-roundtrip.test.ts
 Test Files  1 passed (1)
      Tests  10 passed (10)
$ bunx vitest run src/api/__tests__/conversation-streaming.test.ts
 Test Files  1 passed (1)
      Tests  15 passed (15)

# packages/ui — client reducer (append / replace / legacy / negotiation)
$ bunx vitest run src/api/client-base-delta-stream.test.ts \
      src/api/client-agent-stream.test.ts \
      src/api/client-base-stream-abort.test.ts \
      src/api/streamChatEndpoint-native-transport.test.ts
 Test Files  4 passed (client-base-delta-stream 5 + existing streaming suites)

# packages/cloud/shared — proxy accumulates delta-v2 (both normalizers)
$ bun test src/lib/services/eliza-sandbox-bridge-delta-sse.test.ts
 8 pass  0 fail  22 expect() calls

# typecheck
$ bun run --cwd packages/shared typecheck        -> exit 0
$ bun run --cwd packages/agent typecheck         -> exit 0
$ bun run --cwd packages/cloud/shared typecheck  -> exit 0

# error-policy ratchet (diff-scoped)
$ bun run audit:error-policy-ratchet
[error-policy-ratchet] no new fallback-slop in touched files

# biome
$ bunx biome check <touched files>   -> No fixes applied.
```
</details>

## Evidence rows

<!-- evidence-row:before-screenshots -->
- [ ] N/A - transport framing only; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - transport framing only; rendered chat text remains byte-identical and is covered by the stream reducer/route tests above.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-visible workflow changed; the exercised behavior is SSE wire encoding and reconstruction.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no new runtime logging path; backend transport behavior is covered by the agent and cloud stream test output in Verification.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser console/network evidence required for this non-rendered TypeScript client transport change.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/prompt/model behavior change; reply content is unchanged and route framing is exercised through the real handler test.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistence, side effects, generated files, or DB rows; this is a pure transport-encoding change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

