### PR TITLE
perf(chat): window the ChatView transcript like the overlay's 80→400 reveal window (#15281)

### DIFF
--- a/packages/ui/src/components/conversations/ConversationsSidebar.jump.test.tsx
+++ b/packages/ui/src/components/conversations/ConversationsSidebar.jump.test.tsx
@@ -21,6 +21,8 @@ import type {
   Conversation,
   ConversationMessageSearchResult,
 } from "../../api/client-types-chat";
+import { CHAT_TRANSCRIPT_REVEAL_WINDOW_EVENT } from "../../hooks/useConversationRenderWindow";
+import { onViewEvent } from "../../views/view-event-bus";
 import { getChatMessageAnchorId } from "../composites/chat/chat-message";
 
 type AppState = Record<string, unknown>;
@@ -129,7 +131,15 @@ async function openSearchAndJump() {
   fireEvent.click(result);
 }
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  // Anchor stand-ins are appended straight to document.body (not via render), so
+  // testing-library's cleanup misses them — remove them so a leftover anchor
+  // can't satisfy the NEXT test's "anchor absent" precondition.
+  for (const el of document.body.querySelectorAll('[id^="chat-message-"]')) {
+    el.remove();
+  }
+});
 
 describe("ConversationsSidebar jump-to-message (#9955)", () => {
   beforeEach(() => {
@@ -140,6 +150,65 @@ describe("ConversationsSidebar jump-to-message (#9955)", () => {
       count: 1,
     });
     appMock.value = makeAppState();
+  });
+
+  it("emits the render-window reveal after the around-load so a windowed transcript mounts the pivot", async () => {
+    // A windowed ChatView/overlay slices the centered around-load's pivot out of
+    // the render window unless it is told to reveal (#15281). The sidebar must
+    // fire CHAT_TRANSCRIPT_REVEAL_WINDOW_EVENT after a successful around-load.
+    const scroll = scrollSpy();
+    const revealEvents: number[] = [];
+    const off = onViewEvent(CHAT_TRANSCRIPT_REVEAL_WINDOW_EVENT, () =>
+      revealEvents.push(Date.now()),
+    );
+    const loadConversationMessagesAround = vi.fn(
+      async (_conversationId: string, messageId: string) => {
+        const el = document.createElement("div");
+        el.id = getChatMessageAnchorId(messageId);
+        document.body.appendChild(el);
+        return true;
+      },
+    );
+    appMock.value = makeAppState({ loadConversationMessagesAround });
+
+    render(<ConversationsSidebar />);
+    await openSearchAndJump();
+
+    await waitFor(() => expect(scroll).toHaveBeenCalledTimes(1), {
+      timeout: 3000,
+    });
+    expect(loadConversationMessagesAround).toHaveBeenCalledWith(
+      TARGET_CONVERSATION_ID,
+      OLD_MESSAGE_ID,
+    );
+    expect(revealEvents).toHaveLength(1);
+    off();
+  });
+
+  it("does NOT emit the reveal when the hit is already in the loaded window", async () => {
+    // No around-load → no reveal: the in-window common case must not force the
+    // transcript to unbound its DOM.
+    scrollSpy();
+    const el = document.createElement("div");
+    el.id = getChatMessageAnchorId(OLD_MESSAGE_ID);
+    document.body.appendChild(el);
+    const revealEvents: number[] = [];
+    const off = onViewEvent(CHAT_TRANSCRIPT_REVEAL_WINDOW_EVENT, () =>
+      revealEvents.push(Date.now()),
+    );
+    appMock.value = makeAppState({
+      loadConversationMessagesAround: vi.fn(async () => true),
+    });
+
+    render(<ConversationsSidebar />);
+    await openSearchAndJump();
+
+    await waitFor(
+      () => expect(Element.prototype.scrollIntoView).toHaveBeenCalled(),
+      { timeout: 3000 },
+    );
+    expect(revealEvents).toHaveLength(0);
+    off();
   });
 
   it("loads the window AROUND a far-back hit (anchor absent) then scrolls it into view", async () => {

--- a/packages/ui/src/components/conversations/ConversationsSidebar.tsx
+++ b/packages/ui/src/components/conversations/ConversationsSidebar.tsx
@@ -39,8 +39,8 @@ import { useIntervalWhenDocumentVisible } from "../../hooks/useDocumentVisibilit
 import { useAppSelectorShallow } from "../../state";
 import { usePtySessions } from "../../state/PtySessionsContext.hooks";
 import { shellLocalStorage } from "../../surface-realm-channel";
-import { emitViewEvent } from "../../views/view-event-bus";
 import { errorMessage } from "../../utils/errors";
+import { emitViewEvent } from "../../views/view-event-bus";
 import { MessageSearchPanel } from "../chat/message-search/MessageSearchPanel";
 import { ChatConversationItem } from "../composites/chat/chat-conversation-item";
 import { getChatMessageAnchorId } from "../composites/chat/chat-message";

--- a/packages/ui/src/components/conversations/ConversationsSidebar.tsx
+++ b/packages/ui/src/components/conversations/ConversationsSidebar.tsx
@@ -34,10 +34,12 @@ import {
   STATUS_DOT,
 } from "../../chat/coding-agent-session-state";
 import { CHAT_MESSAGE_SEARCH_EVENT } from "../../events";
+import { CHAT_TRANSCRIPT_REVEAL_WINDOW_EVENT } from "../../hooks/useConversationRenderWindow";
 import { useIntervalWhenDocumentVisible } from "../../hooks/useDocumentVisibility";
 import { useAppSelectorShallow } from "../../state";
 import { usePtySessions } from "../../state/PtySessionsContext.hooks";
 import { shellLocalStorage } from "../../surface-realm-channel";
+import { emitViewEvent } from "../../views/view-event-bus";
 import { errorMessage } from "../../utils/errors";
 import { MessageSearchPanel } from "../chat/message-search/MessageSearchPanel";
 import { ChatConversationItem } from "../composites/chat/chat-conversation-item";
@@ -530,12 +532,17 @@ export function ConversationsSidebar({
         let el = await waitForAnchor(anchorId, 20);
         if (!el) {
           // The hit is older than the loaded recent window (#9955): load the
-          // window CENTERED on it, let the thread re-render, then scroll.
+          // window CENTERED on it, then reveal the transcript's full loaded set
+          // so the centered pivot is not sliced out of the render window
+          // (#15281) — without the reveal, a windowed ChatView/overlay drops the
+          // anchor and the jump silently no-ops. waitForAnchor's 20-frame budget
+          // covers the reveal re-render.
           const loaded = await loadConversationMessagesAround(
             result.conversationId,
             result.messageId,
           );
           if (loaded) {
+            emitViewEvent(CHAT_TRANSCRIPT_REVEAL_WINDOW_EVENT);
             el = await waitForAnchor(anchorId, 20);
           }
         }

--- a/packages/ui/src/components/pages/ChatView.render-window.test.tsx
+++ b/packages/ui/src/components/pages/ChatView.render-window.test.tsx
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+//
+// Render-window coverage for ChatView (#15281): a long thread must mount at most
+// MAX_RENDERED_SHELL_MESSAGES transcript rows (not every loaded turn), keep the
+// top sentinel mounted for scroll-up paging, and grow to the full loaded set
+// (capped at MAX_LOADED_SHELL_WINDOW) when the sidebar search-jump emits
+// CHAT_TRANSCRIPT_REVEAL_WINDOW_EVENT. It mounts the REAL ChatView with the real
+// useConversationRenderWindow + useViewEvent engines; only the voice/game-modal
+// companion hooks and the app-state/context providers are mocked (they are
+// orthogonal to windowing). jsdom has no IntersectionObserver, so
+// useLoadOlderOnScroll self-bails — scroll-driven growth is covered by the hook
+// unit tests + the real-Chromium e2e; this asserts the mount + reveal contract.
+
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ConversationMessage } from "../../api/client-types-chat";
+import { emitViewEvent } from "../../views/view-event-bus";
+import { CHAT_TRANSCRIPT_REVEAL_WINDOW_EVENT } from "../../hooks/useConversationRenderWindow";
+import {
+  MAX_LOADED_SHELL_WINDOW,
+  MAX_RENDERED_SHELL_MESSAGES,
+} from "../shell/shell-state";
+
+const THREAD_LENGTH = 450;
+
+function seedMessages(count: number): ConversationMessage[] {
+  const now = Date.now();
+  const msgs: ConversationMessage[] = [];
+  for (let i = 0; i < count; i += 1) {
+    msgs.push({
+      id: `msg-${i}`,
+      role: i % 2 === 0 ? "user" : "assistant",
+      text: `Message ${i}`,
+      timestamp: now - (count - i) * 1000,
+      source: "eliza",
+    });
+  }
+  return msgs;
+}
+
+const seeded = seedMessages(THREAD_LENGTH);
+
+const appState = {
+  agentStatus: { state: "running", canRespond: true },
+  activeConversationId: "conv-1",
+  activeInboxChat: null,
+  activeTerminalSessionId: null,
+  characterData: { name: "Eliza" },
+  chatFirstTokenReceived: false,
+  companionMessageCutoffTs: null,
+  handleChatSend: vi.fn(async () => {}),
+  handleChatStop: vi.fn(),
+  handleChatEdit: vi.fn(async () => true),
+  handleChatDelete: vi.fn(async () => {}),
+  elizaCloudConnected: false,
+  elizaCloudVoiceProxyAvailable: false,
+  elizaCloudHasPersistedKey: false,
+  setState: vi.fn(),
+  copyToClipboard: vi.fn(async () => {}),
+  droppedFiles: [],
+  analysisMode: false,
+  shareIngestNotice: "",
+  chatAgentVoiceMuted: true,
+  uiLanguage: "en",
+  sendChatText: vi.fn(async () => {}),
+  t: (key: string, opts?: { defaultValue?: string }) =>
+    opts?.defaultValue ?? key,
+  setActionNotice: vi.fn(),
+};
+
+vi.mock("../../state/app-store", () => ({
+  useAppSelectorShallow: (selector: (s: typeof appState) => unknown) =>
+    selector(appState),
+  useAppSelector: (selector: (s: typeof appState) => unknown) =>
+    selector(appState),
+  useApp: () => appState,
+}));
+
+vi.mock("../../state/ConversationMessagesContext.hooks", () => ({
+  useConversationMessages: () => ({
+    conversationMessages: seeded,
+    removeConversationMessage: vi.fn(),
+    prependConversationMessages: vi.fn(),
+    setConversationMessages: vi.fn(),
+  }),
+}));
+
+vi.mock("../../state/ChatComposerContext.hooks", () => ({
+  useChatComposer: () => ({
+    chatInput: "",
+    chatSending: false,
+    chatPendingImages: [],
+    chatReplyTarget: null,
+    setChatInput: vi.fn(),
+    setChatPendingImages: vi.fn(),
+    setChatReplyTarget: vi.fn(),
+  }),
+}));
+
+vi.mock("../../state/PtySessionsContext.hooks", () => ({
+  usePtySessions: () => ({ ptySessions: [] }),
+}));
+
+vi.mock("../../api/client", () => ({ client: {} }));
+
+vi.mock("../../hooks/useChatAvatarVoiceBridge", () => ({
+  useChatAvatarVoiceBridge: () => {},
+}));
+
+// Voice + game-modal companion hooks are orthogonal to the render window — an
+// inert voice controller (unsupported, no TTS error → the voice status bar stays
+// hidden) and an empty game-modal bridge keep the default surface rendering.
+vi.mock("./chat-view-hooks", () => ({
+  useChatVoiceController: () => ({
+    beginVoiceCapture: vi.fn(),
+    endVoiceCapture: vi.fn(),
+    continuous: {
+      status: "idle",
+      interimTranscript: "",
+      latency: null,
+      needsAudioUnlock: false,
+      unlockAudio: vi.fn(),
+      micReconnected: false,
+      ttsError: null,
+    },
+    handleEditMessage: vi.fn(),
+    handleSpeakMessage: vi.fn(),
+    stopSpeaking: vi.fn(),
+    voice: {
+      supported: false,
+      isListening: false,
+      isSpeaking: false,
+      captureMode: "idle",
+      interimTranscript: "",
+      assistantTtsQuality: undefined,
+      mouthOpen: 0,
+    },
+    voiceLatency: null,
+    voiceSpeaker: null,
+  }),
+  useGameModalMessages: () => ({
+    companionCarryover: null,
+    gameModalCarryoverOpacity: 1,
+    gameModalVisibleMsgs: [],
+  }),
+}));
+
+import { ChatView } from "./ChatView";
+
+// ChatView's default (non-glass) transcript rows carry data-testid="chat-message"
+// (the "thread-line" testid is the overlay's glass row). Attribute-equality, so
+// it counts rows only — not "chat-message-action-rail" / "chat-message-reply".
+function threadRowCount(container: HTMLElement): number {
+  return container.querySelectorAll('[data-testid="chat-message"]').length;
+}
+
+afterEach(cleanup);
+
+describe("ChatView transcript render window (#15281)", () => {
+  beforeEach(() => {
+    appState.activeConversationId = "conv-1";
+  });
+
+  it("mounts at most MAX_RENDERED_SHELL_MESSAGES rows for a long thread, with the top sentinel present", () => {
+    const { container } = render(<ChatView hideComposer />);
+
+    // The bounded window renders only the newest page, never all 450 turns.
+    expect(threadRowCount(container)).toBe(MAX_RENDERED_SHELL_MESSAGES);
+    expect(
+      container.querySelector('[data-testid="chat-transcript-top-sentinel"]'),
+    ).not.toBeNull();
+  });
+
+  it("reveals the full loaded set (capped at the DOM bound) on the search-jump event", () => {
+    const { container } = render(<ChatView hideComposer />);
+    expect(threadRowCount(container)).toBe(MAX_RENDERED_SHELL_MESSAGES);
+
+    act(() => {
+      emitViewEvent(CHAT_TRANSCRIPT_REVEAL_WINDOW_EVENT);
+    });
+
+    // 450 loaded turns → the window opens to the hard DOM bound (400), not all
+    // 450, so the far-back search pivot mounts without unbounding the DOM.
+    expect(threadRowCount(container)).toBe(
+      Math.min(THREAD_LENGTH, MAX_LOADED_SHELL_WINDOW),
+    );
+  });
+});

--- a/packages/ui/src/components/pages/ChatView.render-window.test.tsx
+++ b/packages/ui/src/components/pages/ChatView.render-window.test.tsx
@@ -15,8 +15,8 @@ import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ConversationMessage } from "../../api/client-types-chat";
-import { emitViewEvent } from "../../views/view-event-bus";
 import { CHAT_TRANSCRIPT_REVEAL_WINDOW_EVENT } from "../../hooks/useConversationRenderWindow";
+import { emitViewEvent } from "../../views/view-event-bus";
 import {
   MAX_LOADED_SHELL_WINDOW,
   MAX_RENDERED_SHELL_MESSAGES,

--- a/packages/ui/src/components/pages/ChatView.tsx
+++ b/packages/ui/src/components/pages/ChatView.tsx
@@ -33,6 +33,10 @@ import { isRoutineCodingAgentMessage } from "../../chat";
 import { readPersistedMobileRuntimeMode } from "../../first-run/mobile-runtime-mode";
 import { useChatAvatarVoiceBridge } from "../../hooks/useChatAvatarVoiceBridge";
 import { useConnectorSendAsAccount } from "../../hooks/useConnectorSendAsAccount";
+import {
+  CHAT_TRANSCRIPT_REVEAL_WINDOW_EVENT,
+  useConversationRenderWindow,
+} from "../../hooks/useConversationRenderWindow";
 import { useIntervalWhenDocumentVisible } from "../../hooks/useDocumentVisibility";
 import { useLoadOlderOnScroll } from "../../hooks/useLoadOlderOnScroll";
 import { useThreadAutoScroll } from "../../hooks/useThreadAutoScroll";
@@ -290,10 +294,6 @@ export function ChatView({
   // `scrollRef` is wired to the transcript, the load-older observer, and the
   // ChatThreadLayout scroll region).
   const topSentinelRef = useRef<HTMLDivElement>(null);
-  // Whether the server reports older turns beyond the current top. Starts true
-  // (we don't know until the first load-older) and latches false at the true
-  // top. Reset on conversation switch below.
-  const [hasMoreOlder, setHasMoreOlder] = useState(true);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const composerRef = useRef<HTMLDivElement>(null);
@@ -469,13 +469,13 @@ export function ChatView({
   //
   // The ref mirrors the active id so the async result can be dropped after a
   // mid-flight conversation switch: a page fetched for the previous thread must
-  // never prepend into (or re-arm paging state for) the newly active one.
+  // never prepend into the newly active one.
   const loadOlderConversationIdRef = useRef(activeConversationId);
   loadOlderConversationIdRef.current = activeConversationId;
-  const loadOlderMessages = useCallback(async () => {
+  const fetchOlder = useCallback(async () => {
     const conversationId = activeConversationId;
-    if (!conversationId) return;
-    const result = await loadOlderConversationMessages({
+    if (!conversationId) return { hasMore: false, prependedCount: 0 };
+    return await loadOlderConversationMessages({
       client,
       conversationId,
       currentMessages: conversationMessages,
@@ -485,16 +485,24 @@ export function ChatView({
         }
       },
     });
-    if (loadOlderConversationIdRef.current === conversationId) {
-      setHasMoreOlder(result.hasMore);
-    }
   }, [activeConversationId, conversationMessages, prependConversationMessages]);
 
-  // A fresh conversation may have older history — re-arm the loader on switch.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: activeConversationId is the intentional re-arm trigger; the body only calls the stable setter.
-  useEffect(() => {
-    setHasMoreOlder(true);
-  }, [activeConversationId]);
+  // Bound the mounted DOM to the newest window of loaded turns (#15281): the
+  // window opens lean and grows a page per scroll-to-top (reveal-before-fetch),
+  // paging older server windows only once it has drained, capped at 400 — the
+  // same engine the overlay ships. State still holds every loaded turn.
+  const renderWindow = useConversationRenderWindow({
+    renderableCount: visibleMsgs.length,
+    conversationKey: activeConversationId,
+    fetchOlder,
+  });
+  const windowedMsgs = useMemo(
+    () =>
+      visibleMsgs.length > renderWindow.windowSize
+        ? visibleMsgs.slice(-renderWindow.windowSize)
+        : visibleMsgs,
+    [visibleMsgs, renderWindow.windowSize],
+  );
 
   const {
     companionCarryover,
@@ -508,8 +516,9 @@ export function ChatView({
   });
 
   // The exact set the transcript paints into the shared scroller (the game-modal
-  // variant renders its own windowed set + a companion carryover above it).
-  const displayedMsgs = isGameModal ? gameModalVisibleMsgs : visibleMsgs;
+  // variant renders its own carryover-cutoff window + a companion carryover
+  // above it; the default surface paints the bounded render window).
+  const displayedMsgs = isGameModal ? gameModalVisibleMsgs : windowedMsgs;
   const lastDisplayed = displayedMsgs.at(-1);
   const displayedCount =
     displayedMsgs.length +
@@ -540,10 +549,21 @@ export function ChatView({
   useLoadOlderOnScroll<HTMLDivElement>({
     scrollRef: messagesRef,
     sentinelRef: topSentinelRef,
-    onLoadOlder: loadOlderMessages,
-    hasMore: hasMoreOlder && !isGameModal,
-    topItemKey: visibleMsgs[0]?.id ?? "",
+    onLoadOlder: renderWindow.onLoadOlder,
+    hasMore: !isGameModal && renderWindow.canLoadOlder,
+    // The WINDOWED first id, not the loaded-first: a reveal-grow changes the
+    // first rendered row, which is exactly what triggers useLoadOlderOnScroll's
+    // scrollHeight-delta preservation. Keying on visibleMsgs[0] would leave pure
+    // window grows unanchored and jump the viewport by the revealed height.
+    topItemKey: windowedMsgs[0]?.id ?? "",
     enabled: !isGameModal,
+  });
+
+  // A sidebar keyword-search jump to a hit older than the render window loads a
+  // centered around-window, then signals the transcript to reveal its full
+  // loaded set so the pivot mounts and the jump can scroll to it (#9955).
+  useViewEvent(CHAT_TRANSCRIPT_REVEAL_WINDOW_EVENT, () => {
+    renderWindow.revealFullWindow();
   });
 
   useChatAvatarVoiceBridge({
@@ -783,7 +803,7 @@ export function ChatView({
           carryoverMessages={companionCarryover?.messages}
           carryoverOpacity={gameModalCarryoverOpacity}
           labels={chatMessageLabels}
-          messages={isGameModal ? gameModalVisibleMsgs : visibleMsgs}
+          messages={isGameModal ? gameModalVisibleMsgs : windowedMsgs}
           onEdit={handleEditMessage}
           onSpeak={handleSpeakMessage}
           onCopy={handleCopyMessageText}

--- a/packages/ui/src/components/pages/__e2e__/chat-infinite-scroll-fixture.tsx
+++ b/packages/ui/src/components/pages/__e2e__/chat-infinite-scroll-fixture.tsx
@@ -2,15 +2,15 @@
  * REAL-browser fixture for the infinite upward scroll (#13532/#14329) — driven
  * by run-chat-infinite-scroll-e2e.mjs.
  *
- * Mounts the PRODUCTION load-older engine — the real `useLoadOlderOnScroll`
- * hook, the real `loadOlderConversationMessages` orchestration, AND the real
- * `planScrollTopLoadOlder` render-window policy — over a real scroller in a real
- * Chromium layout, so the pieces jsdom fakes (a genuine IntersectionObserver,
+ * Mounts the PRODUCTION load-older stack — the real `useLoadOlderOnScroll` hook,
+ * the real `loadOlderConversationMessages` orchestration, AND the real
+ * `useConversationRenderWindow` render-window engine — over a real scroller in a
+ * real Chromium layout, so the pieces jsdom fakes (a genuine IntersectionObserver,
  * real scrollHeight/scrollTop geometry, a real `?before=` network fetch) run for
- * real. Crucially it renders through the SAME sliding render window the overlay
- * uses (`messages.slice(-renderWindowSize)` growing via `planScrollTopLoadOlder`)
- * rather than dumping every message — so the e2e guards #14329's actual bug: a
- * fixed render cap that slices prepended older turns straight back off.
+ * real. It renders through the SAME sliding render window ChatView + the overlay
+ * use (`messages.slice(-renderWindow.windowSize)`) rather than dumping every
+ * message — so the e2e guards #14329's actual bug: a fixed render cap that slices
+ * prepended older turns straight back off.
  *
  * Query params (set by the runner): `?empty` seeds an empty thread (no fetch
  * loop); `?fail` makes the first older-page fetch reject (error path — the guard
@@ -24,16 +24,12 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 
 import type { ConversationMessage } from "../../../api/client-types-chat";
+import { useConversationRenderWindow } from "../../../hooks/useConversationRenderWindow";
 import { useLoadOlderOnScroll } from "../../../hooks/useLoadOlderOnScroll";
 import {
   type LoadOlderClient,
   loadOlderConversationMessages,
 } from "../../../state/load-older-conversation-messages";
-import {
-  MAX_LOADED_SHELL_WINDOW,
-  MAX_RENDERED_SHELL_MESSAGES,
-  planScrollTopLoadOlder,
-} from "../../shell/shell-state";
 
 const CONVERSATION_ID = "conv-infinite";
 const PAGE_SIZE = 20;
@@ -113,24 +109,13 @@ function Harness(): React.JSX.Element {
   const [messages, setMessages] = useState<ConversationMessage[]>(
     initialMessages,
   );
-  const [hasMore, setHasMore] = useState(!MODE_EMPTY);
-  // The render window mirrors the overlay: start lean, grow a page per
-  // scroll-to-top (reveal-before-fetch), bounded by MAX_LOADED_SHELL_WINDOW.
-  const [renderWindowSize, setRenderWindowSize] = useState(
-    MAX_RENDERED_SHELL_MESSAGES,
-  );
   const scrollRef = useRef<HTMLDivElement>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
   const clientRef = useRef<LoadOlderClient>(makeClient());
-  // Refs so the scroll-up handler reads live values without re-subscribing the
-  // observer — mirrors the overlay wiring exactly.
+  // Live messages for the fetch wrapper so the render window's stable
+  // onLoadOlder reads the current thread without re-subscribing the observer.
   const messagesRef = useRef(messages);
   messagesRef.current = messages;
-  const windowRef = useRef(renderWindowSize);
-  windowRef.current = renderWindowSize;
-  const hasMoreRef = useRef(hasMore);
-  hasMoreRef.current = hasMore;
-  (window as Win).__renderWindow = renderWindowSize;
 
   const prependMessages = useCallback((older: ConversationMessage[]) => {
     setMessages((prev) => {
@@ -140,52 +125,51 @@ function Harness(): React.JSX.Element {
     });
   }, []);
 
+  // The PRODUCTION fetch orchestration, wrapped exactly as ChatView / the
+  // overlay wrap it — returns the LoadOlderResult so the shared render window
+  // drives its own paging state.
+  const fetchOlder = useCallback(
+    () =>
+      loadOlderConversationMessages({
+        client: clientRef.current,
+        conversationId: CONVERSATION_ID,
+        currentMessages: messagesRef.current,
+        prependMessages,
+        limit: PAGE_SIZE,
+      }),
+    [prependMessages],
+  );
+
+  // The PRODUCTION render-window engine — the same hook ChatView + the overlay
+  // use. Its reveal-before-fetch policy is what this e2e exercises in real
+  // Chromium (jsdom can't).
+  const renderWindow = useConversationRenderWindow({
+    renderableCount: messages.length,
+    conversationKey: CONVERSATION_ID,
+    fetchOlder,
+  });
+  (window as Win).__renderWindow = renderWindow.windowSize;
+
+  // Preserve the runner's instrumentation contract: count every COMPLETED
+  // older-page load (reveal or fetch) so the ?fail lane can assert "no retry
+  // storm". A rejected fetch propagates to useLoadOlderOnScroll's boundary
+  // WITHOUT bumping the counter — matching the guard's bounded re-arm.
   const onLoadOlder = useCallback(async () => {
-    // Reveal-before-fetch, identical to ContinuousChatOverlay.loadOlderMessages:
-    // grow the render window to surface already-loaded turns before any network,
-    // and only page the next older server window once the window has drained.
-    const plan = planScrollTopLoadOlder(
-      windowRef.current,
-      messagesRef.current.length,
-      hasMoreRef.current,
-    );
-    if (plan.nextWindowSize !== windowRef.current) {
-      setRenderWindowSize(plan.nextWindowSize);
-    }
-    if (!plan.shouldFetch) {
-      (window as Win).__loadResolves = ((window as Win).__loadResolves ?? 0) + 1;
-      return;
-    }
-    const result = await loadOlderConversationMessages({
-      client: clientRef.current,
-      conversationId: CONVERSATION_ID,
-      currentMessages: messagesRef.current,
-      prependMessages,
-      limit: PAGE_SIZE,
-    });
-    (window as Win).__loadResolves = ((window as Win).__loadResolves ?? 0) + 1;
-    setHasMore(result.hasMore);
-    if (result.prependedCount > 0) {
-      setRenderWindowSize((n) =>
-        Math.min(n + result.prependedCount, MAX_LOADED_SHELL_WINDOW),
-      );
-    }
-  }, [prependMessages]);
+    await renderWindow.onLoadOlder();
+    const win = window as Win;
+    win.__loadResolves = (win.__loadResolves ?? 0) + 1;
+  }, [renderWindow.onLoadOlder]);
 
   const visible =
-    messages.length > renderWindowSize
-      ? messages.slice(-renderWindowSize)
+    messages.length > renderWindow.windowSize
+      ? messages.slice(-renderWindow.windowSize)
       : messages;
 
   useLoadOlderOnScroll<HTMLDivElement>({
     scrollRef,
     sentinelRef,
     onLoadOlder,
-    // Armed while older turns can still be revealed (window below the loaded
-    // count) OR paged (server has more), and latched off at the DOM bound.
-    hasMore:
-      renderWindowSize < MAX_LOADED_SHELL_WINDOW &&
-      (renderWindowSize < messages.length || hasMore),
+    hasMore: renderWindow.canLoadOlder,
     topItemKey: visible[0]?.id ?? "",
     enabled: true,
   });

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -61,11 +61,11 @@ import {
   sqrtRubberBand,
   useRafCoalescer,
 } from "../../gestures";
+import { useConversationRenderWindow } from "../../hooks/useConversationRenderWindow";
 import {
   LAYOUT_SHIFT_INTENT_ATTR,
   LAYOUT_SHIFT_INTENT_TRANSIENT,
 } from "../../hooks/useLayoutShiftMonitor";
-import { useConversationRenderWindow } from "../../hooks/useConversationRenderWindow";
 import { useLoadOlderOnScroll } from "../../hooks/useLoadOlderOnScroll";
 import { usePushToTalk } from "../../hooks/usePushToTalk";
 import { useThreadAutoScroll } from "../../hooks/useThreadAutoScroll";
@@ -135,7 +135,10 @@ import {
 } from "./chat-panel-layout";
 import { LIQUID_GLASS_EDGE_SHADOW, LIQUID_GLASS_SHEEN } from "./liquid-glass";
 import { SlashCommandMenu, useSlashMenu } from "./SlashCommandMenu";
-import { filterRenderableShellMessages, type ShellMessage } from "./shell-state";
+import {
+  filterRenderableShellMessages,
+  type ShellMessage,
+} from "./shell-state";
 import { TopicChipsBar } from "./TopicChipsBar";
 import { TopicGroup } from "./TopicGroup";
 import {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -65,6 +65,7 @@ import {
   LAYOUT_SHIFT_INTENT_ATTR,
   LAYOUT_SHIFT_INTENT_TRANSIENT,
 } from "../../hooks/useLayoutShiftMonitor";
+import { useConversationRenderWindow } from "../../hooks/useConversationRenderWindow";
 import { useLoadOlderOnScroll } from "../../hooks/useLoadOlderOnScroll";
 import { usePushToTalk } from "../../hooks/usePushToTalk";
 import { useThreadAutoScroll } from "../../hooks/useThreadAutoScroll";
@@ -134,13 +135,7 @@ import {
 } from "./chat-panel-layout";
 import { LIQUID_GLASS_EDGE_SHADOW, LIQUID_GLASS_SHEEN } from "./liquid-glass";
 import { SlashCommandMenu, useSlashMenu } from "./SlashCommandMenu";
-import {
-  filterRenderableShellMessages,
-  MAX_LOADED_SHELL_WINDOW,
-  MAX_RENDERED_SHELL_MESSAGES,
-  planScrollTopLoadOlder,
-  type ShellMessage,
-} from "./shell-state";
+import { filterRenderableShellMessages, type ShellMessage } from "./shell-state";
 import { TopicChipsBar } from "./TopicChipsBar";
 import { TopicGroup } from "./TopicGroup";
 import {
@@ -1548,14 +1543,6 @@ export function ContinuousChatOverlay({
   // after the user has moved on.
   const pendingExpandOnRevealRef = React.useRef(false);
   const focusThreadRef = React.useRef(false);
-  // The render window slides UP as the reader scrolls into history (#14329):
-  // it starts at MAX_RENDERED_SHELL_MESSAGES (lean idle/drag DOM) and grows a
-  // page per scroll-to-top — first revealing already-loaded turns, then paging
-  // older ones in — bounded by MAX_LOADED_SHELL_WINDOW so a long thread never
-  // unbounds the DOM. Reset when the active conversation changes (below).
-  const [renderWindowSize, setRenderWindowSize] = React.useState(
-    MAX_RENDERED_SHELL_MESSAGES,
-  );
   // Recomputed only when the thread or phase changes — NOT on every drag/draft
   // re-render. Pure windowing (empty-turn filter, with the streaming-assistant
   // exception) lives in shell-state so it's unit-tested; the count of renderable
@@ -1564,12 +1551,42 @@ export function ContinuousChatOverlay({
     () => filterRenderableShellMessages(messages, phase),
     [messages, phase],
   );
+  // Mirror the active id so an async older-page result is dropped after a
+  // mid-flight conversation switch: a page fetched for the previous thread must
+  // never prepend into the newly active one.
+  const loadOlderConversationIdRef = React.useRef(activeConversationId);
+  loadOlderConversationIdRef.current = activeConversationId;
+  const fetchOlder = React.useCallback(async () => {
+    const conversationId = activeConversationId;
+    if (!conversationId) return { hasMore: false, prependedCount: 0 };
+    return await loadOlderConversationMessages({
+      client,
+      conversationId,
+      currentMessages: conversationMessages,
+      prependMessages: (older) => {
+        if (loadOlderConversationIdRef.current === conversationId) {
+          prependConversationMessages(older);
+        }
+      },
+    });
+  }, [activeConversationId, conversationMessages, prependConversationMessages]);
+  // The render window slides UP as the reader scrolls into history (#14329,
+  // #15281): it opens at MAX_RENDERED_SHELL_MESSAGES (lean idle/drag DOM) and
+  // grows a page per scroll-to-top — first revealing already-loaded turns, then
+  // paging older ones in — bounded by MAX_LOADED_SHELL_WINDOW so a long thread
+  // never unbounds the DOM. The one shared engine (also drives ChatView),
+  // reset when the active conversation changes.
+  const renderWindow = useConversationRenderWindow({
+    renderableCount: renderableMessages.length,
+    conversationKey: activeConversationId,
+    fetchOlder,
+  });
   const visibleMessages = React.useMemo(
     () =>
-      renderableMessages.length > renderWindowSize
-        ? renderableMessages.slice(-renderWindowSize)
+      renderableMessages.length > renderWindow.windowSize
+        ? renderableMessages.slice(-renderWindow.windowSize)
         : renderableMessages,
-    [renderableMessages, renderWindowSize],
+    [renderableMessages, renderWindow.windowSize],
   );
   const lastId = visibleMessages.at(-1)?.id ?? null;
   const lastContent = visibleMessages.at(-1)?.content ?? "";
@@ -1634,84 +1651,22 @@ export function ContinuousChatOverlay({
     [visibleMessages],
   );
 
-  // ── Infinite upward scroll (#13532), wired into the overlay per #14279 ────
-  // The overlay is the primary mobile/PWA chat surface, but until now only the
-  // desktop ChatView wired load-older. Share the SAME scroller (`threadRef`,
-  // owned by useThreadAutoScroll for bottom-follow) plus a top sentinel so a
-  // scroll toward the oldest line seamlessly prepends an older page — with the
-  // reader's viewport anchored (no jump) by useLoadOlderOnScroll.
+  // ── Infinite upward scroll (#13532/#14329), wired into the overlay per #14279
+  // The overlay is the primary mobile/PWA chat surface. Share the SAME scroller
+  // (`threadRef`, owned by useThreadAutoScroll for bottom-follow) plus a top
+  // sentinel so a scroll toward the oldest line seamlessly reveals/prepends an
+  // older page — viewport anchored (no jump) by useLoadOlderOnScroll. Paging +
+  // windowing state lives in the shared useConversationRenderWindow above.
   const topSentinelRef = React.useRef<HTMLDivElement>(null);
-  const [hasMoreOlder, setHasMoreOlder] = React.useState(true);
-  // The active id captured for the async load-older result, so a page fetched
-  // for the previous conversation can't prepend into (or re-arm paging for) the
-  // newly active one after a mid-flight switch.
-  const loadOlderConversationIdRef = React.useRef(activeConversationId);
-  loadOlderConversationIdRef.current = activeConversationId;
-  // Live copies for the scroll-up handler so its identity stays stable across
-  // window growth / message churn (the observer captures it through a ref).
-  const renderWindowSizeRef = React.useRef(renderWindowSize);
-  renderWindowSizeRef.current = renderWindowSize;
-  const renderableCountRef = React.useRef(renderableMessages.length);
-  renderableCountRef.current = renderableMessages.length;
-  const hasMoreOlderRef = React.useRef(hasMoreOlder);
-  hasMoreOlderRef.current = hasMoreOlder;
-  const loadOlderMessages = React.useCallback(async () => {
-    const conversationId = activeConversationId;
-    if (!conversationId) return;
-    // Reveal-before-fetch: grow the render window a page to surface
-    // already-loaded older turns before hitting the network. Only when the
-    // window has consumed every loaded turn do we page the next older server
-    // window (and grow to render it). Both grows go through the SAME
-    // scrollHeight-delta anchor in useLoadOlderOnScroll, so the reader stays put.
-    const plan = planScrollTopLoadOlder(
-      renderWindowSizeRef.current,
-      renderableCountRef.current,
-      hasMoreOlderRef.current,
-    );
-    if (plan.nextWindowSize !== renderWindowSizeRef.current) {
-      setRenderWindowSize(plan.nextWindowSize);
-    }
-    if (!plan.shouldFetch) return;
-    const result = await loadOlderConversationMessages({
-      client,
-      conversationId,
-      currentMessages: conversationMessages,
-      prependMessages: (older) => {
-        if (loadOlderConversationIdRef.current === conversationId) {
-          prependConversationMessages(older);
-        }
-      },
-    });
-    if (loadOlderConversationIdRef.current === conversationId) {
-      setHasMoreOlder(result.hasMore);
-      if (result.prependedCount > 0) {
-        setRenderWindowSize((n) =>
-          Math.min(n + result.prependedCount, MAX_LOADED_SHELL_WINDOW),
-        );
-      }
-    }
-  }, [activeConversationId, conversationMessages, prependConversationMessages]);
-  // A fresh/switched conversation may have older history — re-arm the loader and
-  // collapse the render window back to the lean initial size.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: activeConversationId is the intentional re-arm trigger; the body only calls stable setters.
-  React.useEffect(() => {
-    setHasMoreOlder(true);
-    setRenderWindowSize(MAX_RENDERED_SHELL_MESSAGES);
-  }, [activeConversationId]);
   useLoadOlderOnScroll<HTMLDivElement>({
     scrollRef: threadRef,
     sentinelRef: topSentinelRef,
-    onLoadOlder: loadOlderMessages,
+    onLoadOlder: renderWindow.onLoadOlder,
     // Topic grouping wraps rows in collapsible segments, which breaks the
     // sentinel's flat-prepend anchor math; restrict load-older to the flat
     // transcript (the common case). A topic-grouped thread still shows its
-    // recent window; scroll-up paging there is a follow-up. The observer stays
-    // armed while older turns can still be revealed (window below the loaded
-    // count) OR paged (server has more), and latches off at the DOM bound.
-    hasMore:
-      !hasTopics &&
-      renderWindowSize < MAX_LOADED_SHELL_WINDOW &&
-      (renderWindowSize < renderableMessages.length || hasMoreOlder),
+    // recent window; scroll-up paging there is a follow-up.
+    hasMore: !hasTopics && renderWindow.canLoadOlder,
     topItemKey: visibleMessages[0]?.id ?? "",
     enabled: threadPresented && !hasTopics,
   });
@@ -1800,12 +1755,15 @@ export function ContinuousChatOverlay({
         let el = await waitForSearchAnchor(anchorId, 20);
         if (!el) {
           // The hit predates the loaded recent window: load a window CENTERED on
-          // it, let the thread re-render, then scroll.
+          // it, then reveal the full loaded set so the centered pivot is not
+          // sliced out of the render window (#15281) — without the reveal a
+          // windowed transcript drops the anchor and the jump silently no-ops.
           const loaded = await loadConversationMessagesAround(
             result.conversationId,
             result.messageId,
           );
           if (loaded) {
+            renderWindow.revealFullWindow();
             el = await waitForSearchAnchor(anchorId, 20);
           }
         }
@@ -1817,6 +1775,7 @@ export function ContinuousChatOverlay({
       loadConversationMessagesAround,
       waitForSearchAnchor,
       scrollAndFlashSearchAnchor,
+      renderWindow.revealFullWindow,
     ],
   );
 
@@ -5304,7 +5263,7 @@ export function ContinuousChatOverlay({
                         Only meaningful in the flat (non-topic) transcript. */}
                     {!firstRunOpen &&
                     !hasTopics &&
-                    hasMoreOlder &&
+                    renderWindow.canLoadOlder &&
                     visibleMessages.length > 0 ? (
                       <div
                         ref={topSentinelRef}

--- a/packages/ui/src/hooks/useConversationRenderWindow.test.tsx
+++ b/packages/ui/src/hooks/useConversationRenderWindow.test.tsx
@@ -1,0 +1,314 @@
+// @vitest-environment jsdom
+//
+// Unit coverage for the bounded render-window engine (#15281): reveal-before-
+// fetch window growth, the MAX_LOADED_SHELL_WINDOW cap latch, the hasMore latch,
+// the fetch error path (rejection propagates, no fabricated state), the
+// conversation-switch reset + mid-flight stale-result drop, and the search-jump
+// revealFullWindow. Pure hook driven with renderHook — no DOM, no vi.mock of the
+// hook under test; renderableCount + conversationKey are props so a prepend /
+// switch is simulated by re-rendering, mirroring the real caller's state flow.
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { LoadOlderResult } from "../state/load-older-conversation-messages";
+import { useConversationRenderWindow } from "./useConversationRenderWindow";
+
+const INITIAL_WINDOW = 80;
+const STEP = 50;
+const CAP = 400;
+
+/** A fetchOlder that never resolves until `resolve` is called — for race tests. */
+function deferredFetch() {
+  let resolve!: (value: LoadOlderResult) => void;
+  const fetchOlder = vi.fn(
+    () =>
+      new Promise<LoadOlderResult>((r) => {
+        resolve = r;
+      }),
+  );
+  return { fetchOlder, resolve: (v: LoadOlderResult) => resolve(v) };
+}
+
+describe("useConversationRenderWindow (#15281)", () => {
+  it("opens at MAX_RENDERED_SHELL_MESSAGES regardless of the loaded count", () => {
+    const { result } = renderHook(() =>
+      useConversationRenderWindow({
+        renderableCount: 500,
+        conversationKey: "c",
+        fetchOlder: async () => ({ hasMore: true, prependedCount: 0 }),
+      }),
+    );
+    expect(result.current.windowSize).toBe(INITIAL_WINDOW);
+    expect(result.current.canLoadOlder).toBe(true);
+  });
+
+  it("reveals already-loaded turns a page at a time before ever fetching", async () => {
+    const fetchOlder = vi.fn(
+      async (): Promise<LoadOlderResult> => ({
+        hasMore: true,
+        prependedCount: 0,
+      }),
+    );
+    const { result } = renderHook(() =>
+      useConversationRenderWindow({
+        renderableCount: 200,
+        conversationKey: "c",
+        fetchOlder,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.onLoadOlder();
+    });
+    expect(result.current.windowSize).toBe(130);
+    expect(fetchOlder).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current.onLoadOlder();
+    });
+    expect(result.current.windowSize).toBe(180);
+
+    await act(async () => {
+      await result.current.onLoadOlder();
+    });
+    // Reveal caps growth at the loaded count (200), not 230.
+    expect(result.current.windowSize).toBe(200);
+    expect(fetchOlder).not.toHaveBeenCalled();
+
+    // Window drained (== loaded count): the next scroll-up finally fetches.
+    await act(async () => {
+      await result.current.onLoadOlder();
+    });
+    expect(fetchOlder).toHaveBeenCalledTimes(1);
+  });
+
+  it("grows by a real prepend's size once the window is drained", async () => {
+    const fetchOlder = vi.fn(
+      async (): Promise<LoadOlderResult> => ({
+        hasMore: true,
+        prependedCount: STEP,
+      }),
+    );
+    const { result, rerender } = renderHook(
+      (props: { renderableCount: number }) =>
+        useConversationRenderWindow({
+          renderableCount: props.renderableCount,
+          conversationKey: "c",
+          fetchOlder,
+        }),
+      { initialProps: { renderableCount: 200 } },
+    );
+
+    // Drain the window to the loaded count (80 → 130 → 180 → 200).
+    for (let i = 0; i < 3; i += 1) {
+      await act(async () => {
+        await result.current.onLoadOlder();
+      });
+    }
+    expect(result.current.windowSize).toBe(200);
+
+    // The drained scroll-up fetches; the page prepends 50 (the caller's state
+    // grows the loaded count in lockstep, mirrored by re-rendering).
+    await act(async () => {
+      await result.current.onLoadOlder();
+    });
+    rerender({ renderableCount: 250 });
+    expect(fetchOlder).toHaveBeenCalledTimes(1);
+    expect(result.current.windowSize).toBe(250);
+    expect(result.current.canLoadOlder).toBe(true);
+  });
+
+  it("latches canLoadOlder off at the hard DOM bound and stops growing/fetching", async () => {
+    const fetchOlder = vi.fn(
+      async (): Promise<LoadOlderResult> => ({
+        hasMore: true,
+        prependedCount: 0,
+      }),
+    );
+    const { result } = renderHook(() =>
+      useConversationRenderWindow({
+        renderableCount: 600,
+        conversationKey: "c",
+        fetchOlder,
+      }),
+    );
+
+    // Reveal-grow all the way to the cap.
+    for (let i = 0; i < 20 && result.current.windowSize < CAP; i += 1) {
+      await act(async () => {
+        await result.current.onLoadOlder();
+      });
+    }
+    expect(result.current.windowSize).toBe(CAP);
+    expect(result.current.canLoadOlder).toBe(false);
+    expect(fetchOlder).not.toHaveBeenCalled();
+
+    // At the bound onLoadOlder is inert — no further grow, no fetch.
+    await act(async () => {
+      await result.current.onLoadOlder();
+    });
+    expect(result.current.windowSize).toBe(CAP);
+    expect(fetchOlder).not.toHaveBeenCalled();
+  });
+
+  it("latches canLoadOlder off when the server reports no more older turns", async () => {
+    const fetchOlder = vi.fn(
+      async (): Promise<LoadOlderResult> => ({
+        hasMore: false,
+        prependedCount: 0,
+      }),
+    );
+    const { result } = renderHook(() =>
+      useConversationRenderWindow({
+        renderableCount: 100,
+        conversationKey: "c",
+        fetchOlder,
+      }),
+    );
+
+    // Reveal to the loaded count (80 → 100), then the drained scroll-up fetches
+    // and gets hasMore:false.
+    await act(async () => {
+      await result.current.onLoadOlder();
+    });
+    expect(result.current.windowSize).toBe(100);
+    await act(async () => {
+      await result.current.onLoadOlder();
+    });
+    expect(fetchOlder).toHaveBeenCalledTimes(1);
+    expect(result.current.canLoadOlder).toBe(false);
+  });
+
+  it("propagates a fetch rejection without fabricating state, and re-arms", async () => {
+    const fetchOlder = vi.fn(
+      async (): Promise<LoadOlderResult> => ({
+        hasMore: false,
+        prependedCount: 0,
+      }),
+    );
+    // First scroll-up fetch rejects; the second falls back to the default impl.
+    fetchOlder.mockRejectedValueOnce(new Error("older-page boom"));
+    const { result } = renderHook(() =>
+      useConversationRenderWindow({
+        renderableCount: 100,
+        conversationKey: "c",
+        fetchOlder,
+      }),
+    );
+
+    // Reveal to the loaded count so the next call reaches the fetch branch.
+    await act(async () => {
+      await result.current.onLoadOlder();
+    });
+    expect(result.current.windowSize).toBe(100);
+
+    // The fetch rejects — the rejection must surface (useLoadOlderOnScroll is the
+    // boundary that catches it), and no paging state is fabricated.
+    await act(async () => {
+      await expect(result.current.onLoadOlder()).rejects.toThrow(
+        "older-page boom",
+      );
+    });
+    expect(fetchOlder).toHaveBeenCalledTimes(1);
+    expect(result.current.canLoadOlder).toBe(true);
+
+    // A subsequent scroll-up fetches again (the failure did not latch).
+    await act(async () => {
+      await result.current.onLoadOlder();
+    });
+    expect(fetchOlder).toHaveBeenCalledTimes(2);
+    expect(result.current.canLoadOlder).toBe(false);
+  });
+
+  it("resets the window and reveal on a conversation switch", async () => {
+    const fetchOlder = vi.fn(
+      async (): Promise<LoadOlderResult> => ({
+        hasMore: true,
+        prependedCount: 0,
+      }),
+    );
+    const { result, rerender } = renderHook(
+      (props: { conversationKey: string }) =>
+        useConversationRenderWindow({
+          renderableCount: 300,
+          conversationKey: props.conversationKey,
+          fetchOlder,
+        }),
+      { initialProps: { conversationKey: "c1" } },
+    );
+
+    await act(async () => {
+      await result.current.onLoadOlder();
+    });
+    act(() => {
+      result.current.revealFullWindow();
+    });
+    expect(result.current.windowSize).toBeGreaterThan(INITIAL_WINDOW);
+
+    rerender({ conversationKey: "c2" });
+    expect(result.current.windowSize).toBe(INITIAL_WINDOW);
+    expect(result.current.canLoadOlder).toBe(true);
+  });
+
+  it("drops a page that resolves after a mid-flight conversation switch", async () => {
+    const { fetchOlder, resolve } = deferredFetch();
+    const { result, rerender } = renderHook(
+      (props: { conversationKey: string }) =>
+        useConversationRenderWindow({
+          renderableCount: 90,
+          conversationKey: props.conversationKey,
+          fetchOlder,
+        }),
+      { initialProps: { conversationKey: "c1" } },
+    );
+
+    // Reveal to the loaded count (80 → 90) so the next call reaches the fetch.
+    await act(async () => {
+      await result.current.onLoadOlder();
+    });
+    expect(result.current.windowSize).toBe(90);
+
+    // Start the fetch (still pending), then switch conversations underneath it.
+    let pending!: Promise<void>;
+    act(() => {
+      pending = result.current.onLoadOlder();
+    });
+    rerender({ conversationKey: "c2" });
+
+    // The stale page resolves with growth + hasMore:false — both must be dropped
+    // because it belongs to c1, not the now-active c2.
+    await act(async () => {
+      resolve({ hasMore: false, prependedCount: 50 });
+      await pending;
+    });
+    expect(result.current.windowSize).toBe(INITIAL_WINDOW);
+    expect(result.current.canLoadOlder).toBe(true);
+  });
+
+  it("revealFullWindow renders the whole loaded set and tracks a later prepend up to the cap", () => {
+    const { result, rerender } = renderHook(
+      (props: { renderableCount: number }) =>
+        useConversationRenderWindow({
+          renderableCount: props.renderableCount,
+          conversationKey: "c",
+          fetchOlder: async () => ({ hasMore: true, prependedCount: 0 }),
+        }),
+      { initialProps: { renderableCount: 201 } },
+    );
+
+    act(() => {
+      result.current.revealFullWindow();
+    });
+    // A 201-message around-load (pivot centered ~index 100) mounts in full.
+    expect(result.current.windowSize).toBe(201);
+    // Below the bound with server history left → still loadable.
+    expect(result.current.canLoadOlder).toBe(true);
+
+    // A later prepend grows the loaded count; the revealed window follows it,
+    // clamped at the hard DOM bound.
+    rerender({ renderableCount: 420 });
+    expect(result.current.windowSize).toBe(CAP);
+    expect(result.current.canLoadOlder).toBe(false);
+  });
+});

--- a/packages/ui/src/hooks/useConversationRenderWindow.ts
+++ b/packages/ui/src/hooks/useConversationRenderWindow.ts
@@ -1,0 +1,150 @@
+/**
+ * Bounded render window for a chat transcript — the one engine behind ChatView,
+ * the ContinuousChatOverlay, and the infinite-scroll e2e fixture (#15281,
+ * #14329, #9955). State keeps every loaded turn; only the DOM is bounded.
+ *
+ * The window opens at MAX_RENDERED_SHELL_MESSAGES so even a long thread mounts a
+ * lean subtree, and grows a page at a time on scroll-to-top: first revealing
+ * already-loaded-but-windowed-out turns (network-free), then paging the next
+ * older server window once the window has drained — bounded by
+ * MAX_LOADED_SHELL_WINDOW so the DOM can never unbound. The reveal-before-fetch
+ * policy itself is {@link planScrollTopLoadOlder} in shell-state (pure,
+ * unit-tested there); this hook owns the React state, the async fetch
+ * continuation with a conversation-switch guard, and the search-jump reveal.
+ *
+ * The caller feeds `renderableCount` (its filtered/loaded turn count) and
+ * `conversationKey` (window + loader reset on change), and wires the result:
+ * `windowSize` into its `slice(-windowSize)`, `onLoadOlder` into
+ * useLoadOlderOnScroll.onLoadOlder, and `canLoadOlder` (ANDed with any
+ * surface-specific gates) into its hasMore. For a keyword-search jump to a hit
+ * older than the window, the surface subscribes to
+ * CHAT_TRANSCRIPT_REVEAL_WINDOW_EVENT and calls `revealFullWindow`.
+ *
+ * The reveal is DERIVED state (a `revealed` flag → windowSize recomputed from
+ * the current renderable count every render), never a ref read at emit time: the
+ * event fires from the sidebar's async continuation and the surface may not have
+ * re-rendered with the replaced (centered) thread yet, so a ref read would race
+ * the around-load's setState and drop the pivot — the #9955 silent-jump failure.
+ * Deriving each render instead tracks the around-load's landing whenever it
+ * commits.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  MAX_LOADED_SHELL_WINDOW,
+  MAX_RENDERED_SHELL_MESSAGES,
+  planScrollTopLoadOlder,
+} from "../components/shell/shell-state";
+import type { LoadOlderResult } from "../state/load-older-conversation-messages";
+
+/**
+ * View-event signal from the conversations sidebar's keyword-search jump: after
+ * a centered around-load lands the hit's page, this asks the active transcript
+ * to render its full loaded set (capped at the DOM bound) so the pivot mounts
+ * and the jump can scroll to it. Emitted with no payload — it targets whichever
+ * chat surface is mounted.
+ */
+export const CHAT_TRANSCRIPT_REVEAL_WINDOW_EVENT =
+  "chat-transcript-reveal-window";
+
+export interface ConversationRenderWindowOptions {
+  /** Count of filtered, loaded turns currently in state (e.g. visibleMsgs.length). */
+  renderableCount: number;
+  /** Active conversation id; the window, loader, and reveal reset on change. */
+  conversationKey: string | null;
+  /**
+   * Fetch + prepend the next older server page. The caller wraps
+   * loadOlderConversationMessages (keeping its own prepend/active-id guard) and
+   * RETURNS the result — this hook drives paging state off `hasMore` /
+   * `prependedCount` rather than the caller setting it.
+   */
+  fetchOlder: () => Promise<LoadOlderResult>;
+}
+
+export interface ConversationRenderWindow {
+  /** Effective window — feed the transcript `slice(-windowSize)`. */
+  windowSize: number;
+  /** Wire to useLoadOlderOnScroll.onLoadOlder: reveal-before-fetch, then page. */
+  onLoadOlder: () => Promise<void>;
+  /** AND with surface gates and feed useLoadOlderOnScroll.hasMore. */
+  canLoadOlder: boolean;
+  /** Search-jump: render the full loaded set (capped at MAX_LOADED_SHELL_WINDOW). */
+  revealFullWindow: () => void;
+}
+
+export function useConversationRenderWindow({
+  renderableCount,
+  conversationKey,
+  fetchOlder,
+}: ConversationRenderWindowOptions): ConversationRenderWindow {
+  // The scroll-driven window floor. Grown a page per scroll-to-top and by a
+  // real prepend's size; collapsed back on a conversation switch.
+  const [baseWindow, setBaseWindow] = useState(MAX_RENDERED_SHELL_MESSAGES);
+  // Server-reported "more older turns exist". Starts true (unknown until the
+  // first fetch) and latches false at the true top.
+  const [hasMoreOlder, setHasMoreOlder] = useState(true);
+  // Set by a search-jump; makes windowSize track the loaded count so a hit
+  // centered deep in an around-loaded page mounts.
+  const [revealed, setRevealed] = useState(false);
+
+  // Derived each render so a reveal (or a later prepend growing renderableCount)
+  // is reflected the moment it commits — the race-free property above.
+  const windowSize = revealed
+    ? Math.min(Math.max(baseWindow, renderableCount), MAX_LOADED_SHELL_WINDOW)
+    : baseWindow;
+
+  // Live mirrors so onLoadOlder keeps a stable identity while reading current
+  // values (the overlay pattern) — the scroll observer captures it once.
+  const windowSizeRef = useRef(windowSize);
+  windowSizeRef.current = windowSize;
+  const renderableCountRef = useRef(renderableCount);
+  renderableCountRef.current = renderableCount;
+  const hasMoreOlderRef = useRef(hasMoreOlder);
+  hasMoreOlderRef.current = hasMoreOlder;
+  const conversationKeyRef = useRef(conversationKey);
+  conversationKeyRef.current = conversationKey;
+  const fetchOlderRef = useRef(fetchOlder);
+  fetchOlderRef.current = fetchOlder;
+
+  const onLoadOlder = useCallback(async () => {
+    const plan = planScrollTopLoadOlder(
+      windowSizeRef.current,
+      renderableCountRef.current,
+      hasMoreOlderRef.current,
+    );
+    if (plan.nextWindowSize !== windowSizeRef.current) {
+      setBaseWindow(plan.nextWindowSize);
+    }
+    if (!plan.shouldFetch) return;
+    const key = conversationKeyRef.current;
+    const result = await fetchOlderRef.current();
+    // A page that resolved after a conversation switch belongs to the previous
+    // thread — drop it so it can neither re-arm paging nor grow the window for
+    // the newly active one.
+    if (conversationKeyRef.current !== key) return;
+    setHasMoreOlder(result.hasMore);
+    if (result.prependedCount > 0) {
+      setBaseWindow((n) =>
+        Math.min(n + result.prependedCount, MAX_LOADED_SHELL_WINDOW),
+      );
+    }
+  }, []);
+
+  // A switched conversation may have its own older history — re-arm the loader,
+  // collapse the window to the lean initial size, and clear a prior reveal.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: conversationKey is the intentional reset trigger; the body only calls stable setters.
+  useEffect(() => {
+    setBaseWindow(MAX_RENDERED_SHELL_MESSAGES);
+    setHasMoreOlder(true);
+    setRevealed(false);
+  }, [conversationKey]);
+
+  const canLoadOlder =
+    windowSize < MAX_LOADED_SHELL_WINDOW &&
+    (windowSize < renderableCount || hasMoreOlder);
+
+  const revealFullWindow = useCallback(() => setRevealed(true), []);
+
+  return { windowSize, onLoadOlder, canLoadOlder, revealFullWindow };
+}


### PR DESCRIPTION
## What

Window the desktop `ChatView` transcript the same way the continuous overlay already does: render only the newest bounded window of loaded turns instead of every loaded message. State still holds every turn; only the DOM is bounded.

This extracts the overlay's proven `80 → 400` reveal-before-fetch engine into a shared hook, `useConversationRenderWindow`, and wires it into **three** surfaces so they run one engine:

- **ChatView** (`packages/ui/src/components/pages/ChatView.tsx`) — the fix. A 400+ turn thread now mounts at most `MAX_RENDERED_SHELL_MESSAGES` (80) rows, grows a page per scroll-up (reveal-before-fetch), and caps at `MAX_LOADED_SHELL_WINDOW` (400). `topItemKey` moves to the **windowed** first id so pure window-grows stay anchored via `useLoadOlderOnScroll`'s scrollHeight-delta preservation (no viewport jump).
- **ContinuousChatOverlay** — migrated off its inline `renderWindowSize`/`hasMoreOlder` state onto the shared hook (same-seam dedup; the overlay file shrinks ~90 lines).
- **The infinite-scroll e2e fixture** — now drives the **production** hook so `run-chat-infinite-scroll-e2e` exercises the real engine in real Chromium/WebKit.

## Why

`ChatView` rendered **every** loaded message: the server's recent window alone is 200 turns and load-older paging grows it unboundedly, so a long thread mounted an unbounded DOM subtree and every streamed rAF flush re-reconciled the whole list. First-paint and memory scaled with thread length. The overlay already solved this; `ChatView` shared the `useLoadOlderOnScroll` + `useThreadAutoScroll` engines but not the render window.

### Search-jump (#9955) safety

The conversations sidebar's keyword-search jump loads a ~201-message window **centered** on an out-of-view hit (pivot at index ~100). A naive `slice(-80)` drops the pivot, so the `chat-message-<id>` anchor never mounts and the jump silently no-ops. The port therefore adds an explicit reveal step: after a successful `loadConversationMessagesAround`, the sidebar emits `CHAT_TRANSCRIPT_REVEAL_WINDOW_EVENT` and the active transcript reveals its full loaded set (capped at 400) so the pivot mounts. The reveal is **derived state** (a `revealed` flag → `windowSize` recomputed from the current renderable count each render), never a ref read at emit time, so it can't race the around-load's `setState`. This also fixes the **same latent bug the overlay shipped today** (its `handleSearchJump` never grew its window after an around-load).

Fixes #15281.

## Acceptance criteria

- [x] 400+ message thread mounts at most `MAX_RENDERED_SHELL_MESSAGES` rows — asserted in a jsdom render test (`ChatView.render-window.test.tsx`): 450 loaded → **80** mounted.
- [x] Scroll-up grows the window one page at a time (reveal-before-fetch), capped at `MAX_LOADED_SHELL_WINDOW`, top-anchored row stays put — the shared engine + `useLoadOlderOnScroll` anchoring, proven in real Chromium **and** WebKit (`run-chat-infinite-scroll-e2e`).
- [x] Bottom-follow + older-page prepend keep working through the shared `useThreadAutoScroll` + `useLoadOlderOnScroll` engines (unchanged).
- [x] Transcript DOM node count drops on a long thread (see evidence).

## Evidence

| Row | Status |
| --- | --- |
| Transcript DOM node count (before/after) | **ChatView jsdom**: 450 loaded turns → **80** `[data-testid="chat-message"]` rows mounted (was 450). **e2e big-thread**: 200 loaded → **80** rows mounted, growing to 200 only by scrolling up. |
| Real-browser walkthrough + screenshots | `run-chat-infinite-scroll-e2e` records per-mode `.webm` + step `.png` under `packages/ui/src/components/pages/__e2e__/output-infinite-scroll/` (chromium + webkit): `01-mounted-bottom`, `02-before-prepend-top`, `03-after-prepend-anchored`, big-thread reveal frames. |
| Real-LLM trajectories | N/A - pure client transcript-windowing change; no agent/action/prompt/model behavior touched. |
| Full-app video + desktop/mobile screenshots | N/A - could not stand up the full `packages/app` + Playwright perf lane headlessly in this environment; the isolated real-browser e2e above drives the identical production engine and is the load-bearing proof. |
| perf-interaction-kpi transcript-scroll p95 | N/A - same reason; the bounded DOM node count (450→80) is the direct mechanism the KPI measures. |

## Verification

<details>
<summary>Unit + jsdom suites (vitest, real hooks — no mock of the code under test)</summary>

```
# render-window hook (reveal-before-fetch, cap latch, hasMore latch, error path,
# conversation-switch reset + mid-flight drop, revealFullWindow)
$ bunx vitest run src/hooks/useConversationRenderWindow.test.tsx
 Test Files  1 passed (1)
      Tests  9 passed (9)

# ChatView mounts 80 rows for a 450-turn thread + reveal grows to 400
$ bunx vitest run src/components/pages/ChatView.render-window.test.tsx
 Test Files  1 passed (1)
      Tests  2 passed (2)

# sidebar emits the reveal after an around-load; NOT when the hit is in-window
$ bunx vitest run src/components/conversations/ConversationsSidebar.jump.test.tsx
 Test Files  1 passed (1)
      Tests  5 passed (5)

# overlay migration — no regressions
$ bunx vitest run src/components/shell/ContinuousChatOverlay*.test.tsx
 Test Files  6 passed (6)
      Tests  334 passed (334)

# broad sweep of the transcript/pages/conversations/hooks lanes
$ bunx vitest run src/components/composites/chat src/components/pages src/components/conversations src/hooks
 Test Files  107 passed (107)
      Tests  740 passed (740)
```
</details>

<details>
<summary>Real-browser e2e — production engine in Chromium AND WebKit</summary>

```
$ bun run --cwd packages/ui test:chat-infinite-scroll-e2e          # chromium
$ ENGINE=webkit bun run --cwd packages/ui test:chat-infinite-scroll-e2e   # webkit

✓ thread mounted with 40 rows
✓ no ?before= fetch fired at mount (thread starts pinned to bottom)
✓ a GET .../messages?before= request fired on scroll-to-top
✓ older rows prepended (40 → 60)
✓ anchor row viewport-y preserved across the prepend (drift 0.0px ≤ 4px, 20 → 20)
✓ empty thread issues NO ?before= fetch (no cursor to page below)
✓ the older-page fetch failed (error path exercised)
✓ no fabricated prepend on failure (40 → 40 rows unchanged)
✓ no retry storm on failure (older-page loads resolved 0 times ≤ 2)
✓ big thread mounts capped to the render window, not all 200 turns (rendered 80)
✓ rendered rows equal the render window at mount (80 === 80)
✓ the oldest loaded turn (tail-0) is windowed out at mount
✓ scroll-up grew the render window (80→130) and revealed rows (80→130)
✓ revealing already-loaded turns issued NO ?before= fetch (reveal-before-fetch)
✓ scrolling up reveals the oldest loaded turn (tail-0) — scroll-up no longer dead-ends
✓ all 200 loaded turns are reachable by scrolling up (rendered 200)
✓ no console errors (0)

All infinite-scroll assertions passed [chromium].
All infinite-scroll assertions passed [webkit].
```
</details>

<details>
<summary>Lint, error-policy ratchet, typecheck</summary>

```
$ bunx biome check <changed files>
Checked 7 files. No fixes applied.

$ bun run audit:error-policy-ratchet
[error-policy-ratchet] base origin/develop; 5 changed production source file(s)
  ConversationsSidebar.tsx: emptyCatch 3->3, serverConsole 0->0
  ChatView.tsx: emptyCatch 0->0, serverConsole 0->0
  chat-infinite-scroll-fixture.tsx: emptyCatch 0->0, serverConsole 0->0
  ContinuousChatOverlay.tsx: emptyCatch 1->1, serverConsole 0->0
  useConversationRenderWindow.ts: emptyCatch 0->0, serverConsole 0->0
[error-policy-ratchet] no new fallback-slop in touched files

$ bun run --cwd packages/ui typecheck
# 0 errors in any changed file. The only 2 errors are pre-existing on develop
# (src/surface-realm-reserved-writers.guard.test.ts imports a typeless .mjs) and
# are byte-identical to origin/develop — unchanged by this branch.
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15309-chromium-01-mounted-bottom.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15309-chromium-03-after-prepend-anchored.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/15309-chromium-01-prepend-anchor.webm

<!-- evidence-row:backend-logs -->
- [ ] N/A - client-only transcript render-window change; no backend code path changed

<!-- evidence-row:frontend-logs -->
- [x] [15309-chromium-frontend-log.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15309-chromium-frontend-log.txt)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, model, provider, action planner, or agent-response behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [15309-chromium-evidence.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15309-chromium-evidence.json)

<!-- evidence-row:ocr-review -->
- [x] [15309-pr-15309-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15309-pr-15309-ocr-review.txt)
