### PR TITLE
fix(ui): self-heal stranded cloud handoffs (marker hygiene, boot reconciliation, failure surfacing) (#15310)

### DIFF
--- a/packages/ui/src/cloud/handoff/resume-pending-handoff.test.ts
+++ b/packages/ui/src/cloud/handoff/resume-pending-handoff.test.ts
@@ -30,12 +30,29 @@ const mocks = vi.hoisted(() => ({
   ),
   loadPersistedActiveServer: vi.fn((): Record<string, unknown> | null => null),
   silentlyRepointToDedicated: vi.fn(),
+  getCloudCompatAgent: vi.fn(async (_id: string) => ({
+    success: true as boolean,
+    data: { id: "dedicated-1", status: "provisioning" },
+  })),
+  createCloudCompatAgent: vi.fn(async (_opts: Record<string, unknown>) => ({
+    success: true as boolean,
+    data: {
+      agentId: "dedicated-fresh",
+      agentName: "Eliza",
+      jobId: "job-fresh",
+      status: "provisioning",
+      nodeId: null,
+      message: "ok",
+    },
+  })),
 }));
 
 vi.mock("../../api", () => ({
   client: {
     startCloudAgentHandoff: mocks.startCloudAgentHandoff,
     deleteSharedBridgeAgent: mocks.deleteSharedBridgeAgent,
+    getCloudCompatAgent: mocks.getCloudCompatAgent,
+    createCloudCompatAgent: mocks.createCloudCompatAgent,
   },
 }));
 
@@ -88,6 +105,11 @@ function activeSharedServer(): Record<string, unknown> {
 }
 
 async function settle(): Promise<void> {
+  // The resume path awaits the target probe (getCloudCompatAgent) before
+  // kicking off the supervisor, then the supervisor awaits its own start(),
+  // then success/failure branches dispatch again. Two macrotask hops cover
+  // the full chain in these tests.
+  await new Promise((resolve) => setTimeout(resolve, 0));
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
@@ -106,6 +128,21 @@ describe("resumePendingCloudHandoff", () => {
       base.includes("/api/v1/eliza/agents/"),
     );
     mocks.loadPersistedActiveServer.mockReturnValue(null);
+    mocks.getCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: { id: "dedicated-1", status: "provisioning" },
+    });
+    mocks.createCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: {
+        agentId: "dedicated-fresh",
+        agentName: "Eliza",
+        jobId: "job-fresh",
+        status: "provisioning",
+        nodeId: null,
+        message: "ok",
+      },
+    });
     window.localStorage.clear();
     __resetResumeForTests();
   });
@@ -206,7 +243,7 @@ describe("resumePendingCloudHandoff", () => {
     expect(resumePendingCloudHandoff()).toBe(true);
   });
 
-  it("attempts at most once per session when a resume was started", () => {
+  it("attempts at most once per session when a resume was started", async () => {
     savePendingCloudHandoff(pending());
     mocks.loadPersistedActiveServer.mockReturnValue(activeSharedServer());
     mocks.startCloudAgentHandoff.mockResolvedValue({
@@ -216,12 +253,120 @@ describe("resumePendingCloudHandoff", () => {
 
     expect(resumePendingCloudHandoff()).toBe(true);
     expect(resumePendingCloudHandoff()).toBe(false);
+    await settle();
     expect(mocks.startCloudAgentHandoff).toHaveBeenCalledTimes(1);
   });
 
   it("no-ops with no marker", () => {
     expect(resumePendingCloudHandoff()).toBe(false);
     expect(mocks.loadPersistedActiveServer).not.toHaveBeenCalled();
+  });
+
+  it("clears the marker and does NOT resume when the dedicated target is gone (control-plane 404)", async () => {
+    savePendingCloudHandoff(pending());
+    mocks.loadPersistedActiveServer.mockReturnValue(activeSharedServer());
+    // Control-plane lookup reports the target no longer exists.
+    mocks.getCloudCompatAgent.mockResolvedValue({
+      success: false,
+      data: { id: "dedicated-1" },
+    });
+
+    // A resume DECISION is initiated (probe in flight).
+    expect(resumePendingCloudHandoff()).toBe(true);
+
+    // Capture the failed phase surfaced by the dead-target path so the tile
+    // lights up instead of silently persisting "Setting up…".
+    const seenPhases: Array<Record<string, unknown>> = [];
+    const onPhase = (event: Event) => {
+      seenPhases.push((event as CustomEvent).detail as Record<string, unknown>);
+    };
+    window.addEventListener("eliza:cloud-handoff-phase", onPhase);
+
+    await settle();
+
+    // Marker is cleared; the supervisor is never called with the dead id.
+    expect(loadPendingCloudHandoff()).toBeNull();
+    expect(mocks.startCloudAgentHandoff).not.toHaveBeenCalled();
+    expect(mocks.getCloudCompatAgent).toHaveBeenCalledWith("dedicated-1");
+
+    // A failed phase for the shared agent id is dispatched so the widget shows
+    // its failure surface (existing "Setup paused" + Retry copy).
+    const failed = seenPhases.find(
+      (d) => d.agentId === "shared-1" && d.phase === "failed",
+    );
+    expect(failed).toBeTruthy();
+    expect(failed?.error).toEqual(expect.stringContaining("no longer"));
+    window.removeEventListener("eliza:cloud-handoff-phase", onPhase);
+  });
+
+  it("still resumes normally when the target probe is inconclusive (network error, not 404) — never strand on an unprovable assumption", async () => {
+    savePendingCloudHandoff(pending());
+    mocks.loadPersistedActiveServer.mockReturnValue(activeSharedServer());
+    // A 5xx / network blip is inconclusive; treat as live so the supervisor's
+    // own retry/TTL bounds the migration.
+    mocks.getCloudCompatAgent.mockRejectedValue(
+      Object.assign(new Error("transient"), { status: 503 }),
+    );
+
+    expect(resumePendingCloudHandoff()).toBe(true);
+    await settle();
+
+    // Resume still fires against the SAME (pending) target — no fresh create.
+    expect(mocks.startCloudAgentHandoff).toHaveBeenCalledTimes(1);
+    expect(mocks.startCloudAgentHandoff.mock.calls[0][0]).toMatchObject({
+      dedicatedAgentId: "dedicated-1",
+    });
+    expect(mocks.createCloudCompatAgent).not.toHaveBeenCalled();
+  });
+
+  it("on Retry after a dead-target clear, mints a FRESH dedicated agent (forceCreate) instead of the dead id", async () => {
+    // Use unique ids so no armed retry listener from earlier tests
+    // (`runCloudAgentHandoff`'s own retry arming on failed/timed-out) can match
+    // and double-fire on our dispatched retry event.
+    const uniqueShared = "shared-retry-flow";
+    const uniqueDedicated = "dedicated-retry-flow-dead";
+    savePendingCloudHandoff(
+      pending({
+        sharedAgentId: uniqueShared,
+        dedicatedAgentId: uniqueDedicated,
+      }),
+    );
+    mocks.loadPersistedActiveServer.mockReturnValue({
+      kind: "cloud",
+      id: `cloud:${uniqueShared}`,
+      apiBase: SHARED_BASE,
+      accessToken: "cloud-token",
+    });
+    mocks.getCloudCompatAgent.mockResolvedValue({
+      success: false,
+      data: { id: uniqueDedicated },
+    });
+
+    expect(resumePendingCloudHandoff()).toBe(true);
+    await settle();
+    expect(loadPendingCloudHandoff()).toBeNull();
+    expect(mocks.startCloudAgentHandoff).not.toHaveBeenCalled();
+
+    // Simulate the widget's Retry click: dispatch the retry event for the
+    // shared agent id. The armed dead-target listener should mint a FRESH
+    // dedicated agent (forceCreate:true) and re-run the handoff against it.
+    window.dispatchEvent(
+      new CustomEvent("eliza:cloud-handoff-retry", {
+        detail: { agentId: uniqueShared },
+      }),
+    );
+    await settle();
+
+    expect(mocks.createCloudCompatAgent).toHaveBeenCalledTimes(1);
+    expect(mocks.createCloudCompatAgent.mock.calls[0][0]).toMatchObject({
+      forceCreate: true,
+    });
+    expect(mocks.startCloudAgentHandoff).toHaveBeenCalledTimes(1);
+    // Never re-uses the dead id from the cleared marker.
+    expect(mocks.startCloudAgentHandoff.mock.calls[0][0]).toMatchObject({
+      agentId: uniqueShared,
+      dedicatedAgentId: "dedicated-fresh",
+    });
   });
 });
 

--- a/packages/ui/src/cloud/handoff/resume-pending-handoff.test.ts
+++ b/packages/ui/src/cloud/handoff/resume-pending-handoff.test.ts
@@ -268,7 +268,7 @@ describe("resumePendingCloudHandoff", () => {
     // Control-plane lookup reports the target no longer exists.
     mocks.getCloudCompatAgent.mockResolvedValue({
       success: false,
-      data: { id: "dedicated-1" },
+      data: { id: "dedicated-1", status: "deleted" },
     });
 
     // A resume DECISION is initiated (probe in flight).
@@ -339,7 +339,7 @@ describe("resumePendingCloudHandoff", () => {
     });
     mocks.getCloudCompatAgent.mockResolvedValue({
       success: false,
-      data: { id: uniqueDedicated },
+      data: { id: uniqueDedicated, status: "deleted" },
     });
 
     expect(resumePendingCloudHandoff()).toBe(true);
@@ -366,6 +366,12 @@ describe("resumePendingCloudHandoff", () => {
     expect(mocks.startCloudAgentHandoff.mock.calls[0][0]).toMatchObject({
       agentId: uniqueShared,
       dedicatedAgentId: "dedicated-fresh",
+    });
+    expect(loadPendingCloudHandoff()).toMatchObject({
+      sharedAgentId: uniqueShared,
+      dedicatedAgentId: "dedicated-fresh",
+      sharedApiBase: SHARED_BASE,
+      cloudApiBase: "https://elizacloud.ai",
     });
   });
 });

--- a/packages/ui/src/cloud/handoff/resume-pending-handoff.ts
+++ b/packages/ui/src/cloud/handoff/resume-pending-handoff.ts
@@ -7,19 +7,70 @@ import {
   getCloudAuthToken,
   isDirectCloudSharedAgentBase,
 } from "../../api/client-cloud";
+import {
+  CLOUD_HANDOFF_RETRY_EVENT,
+  type CloudHandoffRetryDetail,
+  dispatchCloudHandoffPhase,
+} from "../../events";
 import { loadPersistedActiveServer } from "../../state";
 import {
   clearPendingCloudHandoff,
   loadPendingCloudHandoff,
+  type PendingCloudHandoff,
 } from "./pending-handoff-store";
 import { runCloudAgentHandoff } from "./run-cloud-agent-handoff";
 import { silentlyRepointToDedicated } from "./silent-repoint";
 
 let resumeAttemptedThisSession = false;
+/**
+ * Live AbortControllers for dead-target Retry listeners — tracked so a
+ * relaunch (or a test reset) can abort any still-armed listeners instead of
+ * leaking them.
+ */
+const deadTargetRetryListeners = new Set<AbortController>();
 
 /** Test-only: allow a fresh resume attempt in the next call. */
 export function __resetResumeForTests(): void {
   resumeAttemptedThisSession = false;
+  for (const ac of deadTargetRetryListeners) ac.abort();
+  deadTargetRetryListeners.clear();
+}
+
+/**
+ * Verify the pending handoff's dedicated TARGET still exists before resuming.
+ *
+ * A resume re-runs the SAME migration against `pending.dedicatedAgentId`. If
+ * that dedicated agent was deleted / errored server-side (the worker gave up,
+ * an admin tombstoned it, the create half never landed), resuming is pointless:
+ * the supervisor would poll a dead id until it times out, leaving the user on
+ * the shared adapter with the "Setting up…" tile pinned for the marker's full
+ * 24h TTL. Probing the control-plane once — the same lookup
+ * `startup-phase-poll` uses to disambiguate a dead dedicated base — lets us
+ * fail fast: clear the marker so the user re-enters provisioning instead of
+ * waiting out a migration that can never complete.
+ *
+ * Returns `"gone"` ONLY on a positive absence signal (a `success:false` lookup
+ * or a 404). A network blip / 5xx / missing-auth is `"unknown"` — inconclusive,
+ * so we do NOT clear the marker on an unprovable assumption and let the resume
+ * proceed (the supervisor's own retry/TTL still bounds it).
+ */
+async function dedicatedHandoffTargetState(
+  dedicatedAgentId: string,
+): Promise<"gone" | "live" | "unknown"> {
+  if (!getCloudAuthToken(client)) return "unknown";
+  try {
+    const res = await client.getCloudCompatAgent(dedicatedAgentId);
+    // A successful lookup always carries the agent id, so success alone proves
+    // the record still exists. success:false => the control-plane has no such
+    // agent (deleted).
+    return res.success ? "live" : "gone";
+  } catch (err) {
+    // A 404 is the positive "target is gone" signal. Any other failure
+    // (network blip, 5xx) is inconclusive — never strand on an unprovable
+    // assumption.
+    const status = (err as { status?: unknown } | null)?.status;
+    return status === 404 ? "gone" : "unknown";
+  }
 }
 
 /**
@@ -32,9 +83,15 @@ export function __resetResumeForTests(): void {
  * is created here) is re-run through {@link runCloudAgentHandoff}, giving back
  * the lifecycle events, the retry arming, and the gated shared-bridge delete.
  *
- * Returns true when a resume was started. No-ops (and self-cleans the marker
- * where it is provably stale) otherwise. At most one attempt per session — the
- * supervisor owns retries after that.
+ * Before re-running, it verifies the persisted dedicated TARGET still exists
+ * (a control-plane probe). A dead target (deleted/errored) can never complete
+ * the migration, so the marker is cleared and no resume fires — killing the
+ * stranded 24h "Setting up…" state instead of polling a dead id to its TTL.
+ *
+ * Returns true when a resume DECISION was started (the target probe is in
+ * flight and the handoff kicks off unless the target proves gone). No-ops (and
+ * self-cleans the marker where it is provably stale) otherwise. At most one
+ * attempt per session — the supervisor owns retries after that.
  */
 export function resumePendingCloudHandoff(): boolean {
   if (resumeAttemptedThisSession) return false;
@@ -68,38 +125,165 @@ export function resumePendingCloudHandoff(): boolean {
     return false;
   }
 
-  runCloudAgentHandoff(
-    pending.sharedAgentId,
-    () =>
-      client.startCloudAgentHandoff({
+  // Marker hygiene: verify the dedicated TARGET still exists before resuming.
+  // A dead target (deleted/errored server-side) can never complete the
+  // migration, so resuming just pins the "Setting up…" tile for the marker's
+  // full 24h TTL. Probe once; on a positive "gone" clear the marker and do NOT
+  // resume a dead migration. Inconclusive (`unknown`) still resumes — the
+  // supervisor's own retry/TTL bounds it, and we never strand on an unprovable
+  // assumption. The probe is async, so the sync entry returns true (a resume
+  // decision is in flight) and the kickoff is gated behind it.
+  void dedicatedHandoffTargetState(pending.dedicatedAgentId).then((state) => {
+    if (state === "gone") {
+      clearPendingCloudHandoff();
+      console.warn(
+        `[resumePendingCloudHandoff] dedicated handoff target ${pending.dedicatedAgentId} is gone; clearing marker instead of resuming a dead migration`,
+      );
+      // Surface a first-class `failed` phase so the provisioning tile lights
+      // up instead of silently persisting "Setting up…". Arm a one-shot Retry
+      // listener that mints a FRESH dedicated target (the dead id is never
+      // reused) so the widget's existing Retry affordance works.
+      dispatchCloudHandoffPhase({
         agentId: pending.sharedAgentId,
-        sharedApiBase: pending.sharedApiBase,
-        conversationId: pending.sharedAgentId,
-        dedicatedAgentId: pending.dedicatedAgentId,
-        cloudApiBase: pending.cloudApiBase,
-        authToken,
-        onSwitch: (containerBase) => {
-          silentlyRepointToDedicated({
-            containerBase,
-            authToken,
-            dedicatedAgentId: pending.dedicatedAgentId,
-          });
-        },
-      }),
-    () => {
-      void client
-        .deleteSharedBridgeAgent(pending.sharedAgentId, {
+        phase: "failed",
+        error: "Dedicated agent target is no longer available.",
+      });
+      armFreshRetryForDeadTarget(pending, authToken);
+      return;
+    }
+    runCloudAgentHandoff(
+      pending.sharedAgentId,
+      () =>
+        client.startCloudAgentHandoff({
+          agentId: pending.sharedAgentId,
+          sharedApiBase: pending.sharedApiBase,
+          conversationId: pending.sharedAgentId,
+          dedicatedAgentId: pending.dedicatedAgentId,
           cloudApiBase: pending.cloudApiBase,
           authToken,
-        })
-        .then((res) => {
-          if (!res.success) {
-            console.warn(
-              `[resumePendingCloudHandoff] shared bridge delete failed (leaked row ${pending.sharedAgentId}): ${res.error ?? "unknown"}`,
-            );
-          }
-        });
-    },
-  );
+          onSwitch: (containerBase) => {
+            silentlyRepointToDedicated({
+              containerBase,
+              authToken,
+              dedicatedAgentId: pending.dedicatedAgentId,
+            });
+          },
+        }),
+      () => {
+        void client
+          .deleteSharedBridgeAgent(pending.sharedAgentId, {
+            cloudApiBase: pending.cloudApiBase,
+            authToken,
+          })
+          .then((res) => {
+            if (!res.success) {
+              console.warn(
+                `[resumePendingCloudHandoff] shared bridge delete failed (leaked row ${pending.sharedAgentId}): ${res.error ?? "unknown"}`,
+              );
+            }
+          });
+      },
+    );
+  });
   return true;
+}
+
+/**
+ * One-shot listener for `CLOUD_HANDOFF_RETRY_EVENT` that re-runs the handoff
+ * with a FRESH dedicated create instead of the dead id from the cleared
+ * marker. Bounded by an AbortController + TTL to match the runner's own retry
+ * arming (so a never-clicked Retry does not leak the listener).
+ */
+const DEAD_TARGET_RETRY_TTL_MS = 10 * 60_000;
+
+function armFreshRetryForDeadTarget(
+  pending: PendingCloudHandoff,
+  authToken: string,
+): void {
+  if (typeof window === "undefined") return;
+  const ac = new AbortController();
+  deadTargetRetryListeners.add(ac);
+  const cleanup = () => {
+    deadTargetRetryListeners.delete(ac);
+  };
+  ac.signal.addEventListener("abort", cleanup, { once: true });
+  const ttl = setTimeout(() => ac.abort(), DEAD_TARGET_RETRY_TTL_MS);
+  const onRetry = (event: Event) => {
+    const detail = (event as CustomEvent<CloudHandoffRetryDetail>).detail;
+    if (detail?.agentId !== pending.sharedAgentId) return;
+    clearTimeout(ttl);
+    ac.abort();
+    void runFreshDedicatedHandoff(pending, authToken);
+  };
+  window.addEventListener(CLOUD_HANDOFF_RETRY_EVENT, onRetry, {
+    signal: ac.signal,
+  });
+}
+
+/**
+ * Mint a FRESH dedicated agent (forceCreate) and run the handoff against it,
+ * routing lifecycle through the same {@link runCloudAgentHandoff} runner so
+ * the widget stays in sync. The dead id from the cleared marker is never
+ * reused. Best-effort: a failure to mint surfaces as a `failed` phase with the
+ * error, mirroring the original handoff's failure semantics.
+ */
+async function runFreshDedicatedHandoff(
+  pending: PendingCloudHandoff,
+  authToken: string,
+): Promise<void> {
+  try {
+    const created = await client.createCloudCompatAgent({
+      agentName: "Eliza",
+      forceCreate: true,
+    });
+    if (!created.success || !created.data.agentId) {
+      dispatchCloudHandoffPhase({
+        agentId: pending.sharedAgentId,
+        phase: "failed",
+        error:
+          created.data?.message ?? "Failed to create a fresh dedicated agent.",
+      });
+      return;
+    }
+    const dedicatedAgentId = created.data.agentId;
+    runCloudAgentHandoff(
+      pending.sharedAgentId,
+      () =>
+        client.startCloudAgentHandoff({
+          agentId: pending.sharedAgentId,
+          sharedApiBase: pending.sharedApiBase,
+          conversationId: pending.sharedAgentId,
+          dedicatedAgentId,
+          cloudApiBase: pending.cloudApiBase,
+          authToken,
+          onSwitch: (containerBase) => {
+            silentlyRepointToDedicated({
+              containerBase,
+              authToken,
+              dedicatedAgentId,
+            });
+          },
+        }),
+      () => {
+        void client
+          .deleteSharedBridgeAgent(pending.sharedAgentId, {
+            cloudApiBase: pending.cloudApiBase,
+            authToken,
+          })
+          .then((res) => {
+            if (!res.success) {
+              console.warn(
+                `[runFreshDedicatedHandoff] shared bridge delete failed (leaked row ${pending.sharedAgentId}): ${res.error ?? "unknown"}`,
+              );
+            }
+          });
+      },
+    );
+  } catch (err) {
+    dispatchCloudHandoffPhase({
+      agentId: pending.sharedAgentId,
+      phase: "failed",
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 }

--- a/packages/ui/src/cloud/handoff/resume-pending-handoff.ts
+++ b/packages/ui/src/cloud/handoff/resume-pending-handoff.ts
@@ -17,6 +17,7 @@ import {
   clearPendingCloudHandoff,
   loadPendingCloudHandoff,
   type PendingCloudHandoff,
+  savePendingCloudHandoff,
 } from "./pending-handoff-store";
 import { runCloudAgentHandoff } from "./run-cloud-agent-handoff";
 import { silentlyRepointToDedicated } from "./silent-repoint";
@@ -246,6 +247,13 @@ async function runFreshDedicatedHandoff(
       return;
     }
     const dedicatedAgentId = created.data.agentId;
+    savePendingCloudHandoff({
+      sharedAgentId: pending.sharedAgentId,
+      dedicatedAgentId,
+      sharedApiBase: pending.sharedApiBase,
+      cloudApiBase: pending.cloudApiBase,
+      startedAt: Date.now(),
+    });
     runCloudAgentHandoff(
       pending.sharedAgentId,
       () =>


### PR DESCRIPTION
Closes part of #15310 (client half: marker hygiene + failure surfacing).

## What this fixes

Live QA on staging exposed a chain where a failed `shared → dedicated` cloud-agent handoff strands the client on `"Setting up your cloud agent…"` with no recovery. The `eliza:cloud-handoff-pending` localStorage marker (24h TTL) pins boot to a dead dedicated agent id; the resume path treats "not switched" as "still migrating" forever, and nothing surfaces the failure or arms a live Retry. This PR implements two of the three client behaviors in the umbrella contract, plus a follow-up plan for the third.

## Behaviors

### 1. Handoff marker hygiene at resume (`resume-pending-handoff.ts`)

Before re-running a pending handoff, probe `pending.dedicatedAgentId` against the control-plane via the existing `client.getCloudCompatAgent` helper (the same lookup `startup-phase-poll.ts` uses to disambiguate a dead dedicated base):

- `success:false` (record deleted) or HTTP 404 → **positive "gone" signal**: `clearPendingCloudHandoff()`, one `console.warn`, and do NOT resume a migration that can never complete.
- Any other failure (network blip, 5xx, missing auth) → **inconclusive**: still resume. The supervisor's own retry / TTL bounds it, and we never strand on an unprovable assumption.

This kills the stranded 24h `"Setting up…"` state instead of polling a dead id all the way to its TTL.

### 3. Failure surfacing + Retry-fires-fresh-create

When (1) detects a dead target and clears the marker, dispatch a first-class `dispatchCloudHandoffPhase({ phase: "failed", agentId: pending.sharedAgentId, error: "Dedicated agent target is no longer available." })`. The existing `AgentProvisioningWidget` already renders `"Setup paused"` + a `Retry` badge on the `failed` phase, so this lights up the failure surface with no widget-code change.

At the same time, arm a one-shot listener on `CLOUD_HANDOFF_RETRY_EVENT` for that `sharedAgentId`. On the widget's existing Retry click, it:
- mints a **fresh** dedicated agent via `client.createCloudCompatAgent({ forceCreate: true })`, and
- re-runs the handoff through the same `runCloudAgentHandoff` lifecycle (which self-dispatches `migrating` → the tile flips back to `"Setting up…"` instantly for feedback).

The dead id from the cleared marker is never reused. Listener is bounded by an `AbortController` + 10-minute TTL (mirrors the runner's own `armRetry`) and is tracked in a module-scope `Set` so `__resetResumeForTests` can clean up between tests and a relaunch can abort armed listeners cleanly.

## What's deferred (item 2: boot reconciliation)

The umbrella issue's item 2 asks for boot reconciliation at the persisted-active-server restore path: if the bound cloud agent 404s / is deleted server-side AND local first-run is complete, clear the stale binding + pending-handoff marker and route into the create/provisioning flow instead of a dead home.

`packages/ui/src/state/startup-phase-poll.ts` already implements this **for dedicated bases**: `dedicatedCloudAgentIsGone(base)` probes the control-plane, and on a positive absence it calls `recoverToAgentSelection(...)` (clears the persisted server, resets client base/token, dispatches `BACKEND_REACHED` with `firstRunComplete:false`). The gap is on the **shared** base at boot: today a 404 on the first-run shell for a shared base short-circuits to "first-run complete" and calls `resumePendingCloudHandoff()`; if the shared bridge itself is orphaned server-side there is no probe.

I deliberately did NOT touch that path in this PR. The boot-restore chain in `startup-phase-poll.ts` (~250 lines with multiple recover branches: `recoverToAgentSelection`, `recoverToOnDeviceLocalAgent`, iOS boot-trace hooks, mobile local-agent build guards) is intricate enough that a bolt-on shared-side reconciliation raises the risk-to-value ratio for this lane. Given that (a) marker hygiene here already prunes the dead-dedicated stranding case that was the primary failure mode in the receipts, and (b) the shared-side orphan is rarer and would need its own probe helper + test surface, I'm following the task's explicit escape hatch and writing this as a follow-up.

Follow-up sketch (for a separate PR):
- Add `sharedBridgeAgentIsGone(base)` mirroring `dedicatedCloudAgentIsGone`, probing `getCloudCompatAgent(<sharedId>)` via the control-plane.
- In the shared-base 404 branch (`startup-phase-poll.ts` around lines 833-838 and 1008-1016), gate the `resumePendingCloudHandoff()` short-circuit on that probe: if the shared bridge is gone, call `recoverToAgentSelection(...)` instead of resuming.
- Add tests to `startup-phase-poll` (existing test file if present) covering shared-gone → agent-selection, shared-live → resume-as-today.

## Tests

Added to `packages/ui/src/cloud/handoff/resume-pending-handoff.test.ts`:

- **(a) dead target → clear + no resume + failed phase**: `getCloudCompatAgent` returns `success:false` → marker cleared, `startCloudAgentHandoff` never called, a `failed` phase for the shared agent id is dispatched.
- **(b) inconclusive probe → still resume**: `getCloudCompatAgent` rejects with `status:503` → resume proceeds against the same (pending) dedicated id; no fresh create.
- **(c) Retry after dead-target clear mints a fresh dedicated create**: after (a) clears the marker, dispatching `eliza:cloud-handoff-retry` triggers `createCloudCompatAgent({forceCreate:true})` and `startCloudAgentHandoff` with `dedicatedAgentId: "dedicated-fresh"`, never the dead id from the cleared marker.
- Existing 9 cases stay green (async `settle()` widened by one macrotask to cover the probe hop).

The provisioning tile's failed-state + Retry test (`agent-provisioning.test.tsx`) is already covered upstream and unchanged.

### Runs (real, at HEAD of this branch)

```
packages/ui vitest src/cloud/handoff/ src/components/chat/widgets/agent-provisioning.test.tsx src/events/cloud-handoff-phase.test.ts
 ✓ cloud-handoff-supervisor.test.ts (3 tests) 9ms
 ✓ conversation-handoff.continuity.test.ts (3 tests) 10ms
 ✓ conversation-handoff.test.ts (8 tests) 13ms
 ✓ silent-repoint.test.ts (2 tests) 9ms
 ✓ cloud-handoff-phase.test.ts (4 tests) 9ms
 ✓ run-cloud-agent-handoff.test.ts (15 tests) 44ms
 ✓ resume-pending-handoff.test.ts (12 tests) 36ms
 ✓ agent-provisioning.test.tsx (7 tests) 89ms
 Test Files  8 passed (8)
      Tests  54 passed (54)

packages/ui vitest src/first-run/
 Test Files  22 passed (22)
      Tests  283 passed (283)
```

### Quality

- `biome check packages/ui/src/cloud/handoff/resume-pending-handoff.ts packages/ui/src/cloud/handoff/resume-pending-handoff.test.ts` → clean.
- `codex review --commit HEAD` (Fable 5): ran wide file exploration for the full 90s window without converging on structured findings (known Fable 5 audit-timeout mode) → self-reviewed instead. Notes:
  - Probe uses the existing control-plane helper — same lookup `dedicatedCloudAgentIsGone` uses — no new API surface.
  - Only positive absence signals (`success:false` or HTTP 404) clear the marker; inconclusive states never strand.
  - Dead-target Retry listener is bounded (AbortController + 10min TTL) and tracked in a module Set for test isolation + relaunch cleanup.
  - Marker cleared BEFORE the `failed` phase dispatch so a fast retry can't race a stale marker read.
  - User-facing string has no em-dashes.

## Coordination

Not self-merged. This is the CLIENT half of #15310. Server half (KMS preflight + worker re-enqueue-fresh) is a separate lane.

[sol-cloud]

Co-authored-by: wakesync <shadow@shad0w.xyz>

<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered UI files changed; state-machine/client handoff logic only

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered UI files changed; state-machine/client handoff logic only

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered UI files changed; behavior covered by targeted handoff/widget tests

<!-- evidence-row:backend-logs -->
- [ ] N/A - client-only browser state and handoff logic

<!-- evidence-row:frontend-logs -->
- [x] [15313#issuecomment-4903175233](https://github.com/elizaOS/eliza/pull/15313#issuecomment-4903175233)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, model, provider, action planner, or agent-response behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [15313#issuecomment-4903175233](https://github.com/elizaOS/eliza/pull/15313#issuecomment-4903175233)
