### PR TITLE
fix(scenario-runner): complete computeruse stub for keyless COMPUTER_USE scenarios

### DIFF
--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -196,8 +196,29 @@ type ScenarioRoomDefinition = {
   userName: string;
 };
 
+// Mirrors the subset of the real (display-dependent) ComputerUseService that
+// scenario providers/actions read through `getService("computeruse")`: the
+// computer-state and scene providers and the COMPUTER_USE progress/CLIPBOARD
+// paths call these at compose/run time, so a stub missing any of them throws
+// mid-turn (e.g. `getApprovalSnapshot is not a function`).
 type ScenarioComputerUseService = {
   getCapabilities: () => Record<string, { available: boolean; tool: string }>;
+  getScreenDimensions: () => { width: number; height: number };
+  getDisplays: () => Array<{
+    id: number;
+    name: string;
+    bounds?: unknown;
+    scaleFactor?: number;
+    primary?: boolean;
+  }>;
+  getApprovalSnapshot: () => {
+    mode: string;
+    pendingCount: number;
+    pendingApprovals: Array<{ id: string; command?: string }>;
+  };
+  getRecentActions: () => Array<{ action: string; success: boolean }>;
+  getCurrentScene: () => null;
+  refreshScene: (reason: string) => Promise<null>;
   executeDesktopAction: (params: Record<string, unknown>) => Promise<unknown>;
   executeBrowserAction: (params: Record<string, unknown>) => Promise<unknown>;
   executeFileAction: (params: Record<string, unknown>) => Promise<unknown>;
@@ -1219,8 +1240,19 @@ function createScenarioComputerUseService(): ScenarioComputerUseService {
         browser: { available: true, tool: "scenario-browser" },
         terminal: { available: true, tool: "scenario-terminal" },
         fileSystem: { available: true, tool: "scenario-file-system" },
+        clipboard: { available: true, tool: "scenario-clipboard" },
       };
     },
+    getScreenDimensions: () => ({ width: 2560, height: 1600 }),
+    getDisplays: () => [],
+    getApprovalSnapshot: () => ({
+      mode: "full_control",
+      pendingCount: 0,
+      pendingApprovals: [],
+    }),
+    getRecentActions: () => [],
+    getCurrentScene: () => null,
+    refreshScene: async () => null,
     executeDesktopAction: run,
     executeBrowserAction: run,
     executeFileAction: run,


### PR DESCRIPTION
## What

Follow-up to #15312 (merged). During the fleet integration of the zero-key
scenario-runner lane fixes, one piece was dropped: the scenario runtime's
`ComputerUseService` stub was left incomplete.

The stub (resolved via `getService("computeruse")`) only implemented
`getCapabilities` + the `execute*Action` verbs. The **real** service also exposes
a read-only computer-state surface (`getScreenDimensions`, `getDisplays`,
`getApprovalSnapshot`, `getRecentActions`, `getCurrentScene`, `refreshScene`) that
the computer-state/scene providers and the COMPUTER_USE progress + CLIPBOARD paths
call at compose/run time. A stub omitting them throws mid-turn —
`service.getApprovalSnapshot is not a function` — which the corpus scenario
`computeruse.get-cursor-position` surfaced.

This adds those methods + the `clipboard` capability, mirroring the benchmark
fixture stub (`packages/test/mocks/helpers/benchmark-runtime-fixtures.ts`) that
#15312 already aligned to the real service.

## Root cause

`computeruse.get-cursor-position` (corpus lane) invokes COMPUTER_USE, whose
progress/approval path calls `getApprovalSnapshot()` on the computeruse service.
The scenario stub never had it, so the action threw and the assertion failed.
This is a harness-completeness gap (a new caller in the #14459 window; the stub
lagged the real service), not a product defect.

## Verification

- `computeruse.get-cursor-position` → passes (was `getApprovalSnapshot is not a function`).
- Deterministic lane stays **39/39** green.

## Still-red on the zero-key corpus/lifeops lanes (deferred, out of scope here)

These are independent, deeper defects not addressed by this PR or #15312:
- `goals.owner-goals-create` — GOAL_CREATE runs but persists no goal (real action bug; fails in isolation).
- `relationships.list-entities` — a "fresh" EntityStore surfaces 10 pre-seeded entities (real seeding/isolation bug; fails in isolation).
- `persona.flexible-scheduling` — a scheduled window never fires (real scheduling bug; fails in isolation).
- `reminder.cross-platform.*` / `reminder.escalation.*` (4) — pass in isolation, fail in the full corpus run → cross-scenario state leakage.
- `f1-timezone-boundary-edge-generic` (lifeops) — the cron tz math is correct, but `cronDue` catches up a stale prior-day occurrence within the 36h catch-up window at the naive tick; fixing that changes catch-up semantics for all cron tasks (risky, out of proportion for one scenario).

🤖 Generated with [Claude Code](https://claude.com/claude-code)