### PR TITLE
fix(ci): green goals.owner-goals-create in the zero-key corpus lane

### DIFF
--- a/packages/test/scenarios/goals/owner-goals-create.scenario.ts
+++ b/packages/test/scenarios/goals/owner-goals-create.scenario.ts
@@ -17,7 +17,12 @@ import { scenario } from "@elizaos/scenario-runner/schema";
 import { executeRawSql } from "../../../../plugins/plugin-goals/src/db/sql.ts";
 import { createOwnerGoalsService } from "../../../../plugins/plugin-goals/src/goals-runtime.ts";
 
-const GOAL_INPUT = "Add a goal to run a marathon next year.";
+// The create path is a preview->confirm handshake (#14459/#15055):
+// `shouldRequireLifeCreateConfirmation` commits only when the create params carry
+// `confirmed:true` AND the user's message literally contains an explicit save
+// phrase. This single-turn smoke scenario predates the gate, so the message
+// carries "save it" and the tool-call args set `confirmed:true`.
+const GOAL_INPUT = "Add a goal to run a marathon next year, and save it.";
 const OWNER_GOALS = "OWNER_GOALS";
 
 type RuntimeWithScenarioLlmFixtures = AgentRuntime & {
@@ -54,8 +59,10 @@ function goalsRouteFixtures(): Array<Record<string, unknown>> {
       },
       response: {
         text: "",
+        // Non-empty so the planner-loop gate synthesizes a FINISH after the
+        // successful create instead of firing an (unfixtured) in-loop evaluator.
         thought: "Create the owner's marathon life goal.",
-        messageToUser: "",
+        messageToUser: "Added your goal.",
         completed: true,
         finishReason: "tool-calls",
         toolCalls: [
@@ -63,21 +70,60 @@ function goalsRouteFixtures(): Array<Record<string, unknown>> {
             id: "call-owner-goals",
             name: OWNER_GOALS,
             type: "function",
-            arguments: { action: "create", title: "Run a marathon" },
+            arguments: {
+              action: "create",
+              title: "Run a marathon",
+              confirmed: true,
+            },
           },
         ],
       },
       times: 1,
     },
     {
-      // The action's own resolveActionArgs extraction (a single TEXT_LARGE call).
+      // The action's own resolveActionArgs extraction. Excludes the grounding
+      // prompt (below) so the two TEXT_LARGE fixtures are mutually exclusive, and
+      // is optional because the planner already supplied the create args.
       name: "owner-goals-extraction-create",
-      match: { modelType: ModelType.TEXT_LARGE },
+      match: {
+        modelType: ModelType.TEXT_LARGE,
+        prompt: (v: string) => !v.includes("missingCriticalFields"),
+      },
       response: JSON.stringify({
         action: "create",
-        params: { title: "Run a marathon" },
+        params: { title: "Run a marathon", confirmed: true },
         missing: [],
         confidence: 0.95,
+      }),
+      times: { min: 0, max: 1 },
+    },
+    {
+      // #14459's second TEXT_LARGE grounding extractor
+      // (extractGoalCreatePlanWithLlm). Without a grounded plan the create is a
+      // NOOP_GOAL_UNGROUNDED and never persists. successCriteria/supportStrategy
+      // MUST be objects — a string/null re-triggers the NOOP gate.
+      name: "owner-goals-grounding-create",
+      match: {
+        modelType: ModelType.TEXT_LARGE,
+        prompt: (v: string) => v.includes("missingCriticalFields"),
+      },
+      response: JSON.stringify({
+        mode: "create",
+        response: null,
+        title: "Run a marathon",
+        description: "Train for and complete a marathon within the next year.",
+        cadence: { kind: "weekly" },
+        successCriteria: {
+          summary: "Finish a full 42.2km marathon within the next year.",
+        },
+        supportStrategy: {
+          summary: "Follow a progressive weekly long-run training plan.",
+        },
+        groundingState: "grounded",
+        missingCriticalFields: [],
+        confidence: 0.95,
+        evaluationSummary: "Completing a marathon within the next year.",
+        targetDomain: "fitness",
       }),
       times: 1,
     },


### PR DESCRIPTION
## What

Follow-up to #15312. Greens `goals.owner-goals-create` in the Zero-Key scenario-runner **corpus** lane — one more #14459-window secondary defect unmasked by #15294.

## Root cause

The single-turn goals smoke scenario predated two #14459/#15055 changes, so `OWNER_GOALS create` returned `success:false` with a `lifeDraft` and never persisted a goal:

1. **Grounding extractor (#14459).** `extractGoalCreatePlanWithLlm` makes a *second* `TEXT_LARGE` call; unfixtured it returned an empty plan → `groundingState≠grounded` → `NOOP_GOAL_UNGROUNDED`, no row written. Added a grounding fixture matched by the grounding prompt's `missingCriticalFields`, returning a grounded plan (object `successCriteria`/`supportStrategy` — a string/null re-triggers the NOOP gate).
2. **Preview→confirm gate (#15055).** `shouldRequireLifeCreateConfirmation` commits only when the create params carry `confirmed:true` **and** the user's message literally contains an explicit save phrase. The message now ends "…, and save it." and the create tool-call args set `confirmed:true`.

Also: the planner fixture now carries a non-empty `messageToUser` so the planner-loop gate synthesizes a FINISH after the successful create (instead of firing an unfixtured in-loop evaluator), and the `resolveActionArgs` vs grounding `TEXT_LARGE` fixtures are split by prompt so they're mutually exclusive.

## Evidence

`goals.owner-goals-create` passes (`Totals: 1 passed, 0 failed`) under the deterministic proxy (`SCENARIO_USE_LLM_PROXY=1`, all keys empty). Biome clean.

## Still deferred (not in this PR)

Corpus `reminder.*`×4 + `persona.flexible-scheduling` are a scenario-runner isolation leak (pass in isolation, fail together via a shared timezone/scheduled-task singleton — environment/host-TZ sensitive); `relationships.list-entities` is a bootstrap entity-write; lifeops `f1-timezone-boundary-edge-generic` is a genuine scheduler tz double-fire. Each needs its own separately-validated change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)