### PR TITLE
fix(lifeops): surface deferred inbound scan failures

### DIFF
--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/deferred-inbound-scans.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/deferred-inbound-scans.test.ts
@@ -106,6 +106,21 @@ describe("detachInboundScan", () => {
     });
   });
 
+  it("routes a synchronous scan throw to runtime.reportError off the awaited edge", async () => {
+    const { runtime, reported } = recordingRuntime();
+    const failure = new Error("missing store");
+    const handler = detachInboundScan("sync-throw", () => {
+      throw failure;
+    });
+
+    await expect(handler(payloadFor(runtime))).resolves.toBeUndefined();
+    await settleDeferredInboundScans();
+
+    expect(reported).toHaveLength(1);
+    expect(reported[0]?.scope).toBe("lifeops:inbound-scan:sync-throw");
+    expect(reported[0]?.error).toBe(failure);
+  });
+
   it("settle drains a scan that schedules another scan while it runs", async () => {
     const { runtime } = recordingRuntime();
     let innerRan = false;

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/deferred-inbound-scans.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/deferred-inbound-scans.ts
@@ -34,7 +34,8 @@ export function detachInboundScan(
   fn: (payload: MessagePayload) => Promise<void>,
 ): (payload: MessagePayload) => Promise<void> {
   return (payload: MessagePayload): Promise<void> => {
-    const scan: Promise<void> = fn(payload)
+    const scan: Promise<void> = Promise.resolve()
+      .then(() => fn(payload))
       .catch((error: unknown) => {
         // error-policy:J7 diagnostics-must-not-kill-the-loop — the turn has
         // already moved on off the awaited edge; surface the failure through

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/inbound-reply-completion.integration.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/inbound-reply-completion.integration.test.ts
@@ -247,7 +247,7 @@ describe("inbound-reply completion — production wiring", () => {
   }, 180_000);
 
   it("an owner reply in a connector room completes a connector-fired task from output.target", async () => {
-    runtimeResult = await createLifeOpsTestRuntime();
+    runtimeResult = await createOwnerScopedRuntime();
     const { runtime } = runtimeResult;
     const chatId = "telegram-chat-1";
     const roomId = stringToUuid(`${chatId}:${runtime.agentId}`);

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.quiet-streak.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.quiet-streak.test.ts
@@ -29,6 +29,8 @@ import {
 
 type Runtime = RealTestRuntimeResult["runtime"];
 
+const OWNER_ENTITY_ID = "owner-entity-1";
+
 let runtimeResult: RealTestRuntimeResult | undefined;
 
 afterEach(async () => {
@@ -378,6 +380,7 @@ describe("processDueScheduledTasks — quiet streak softens the next no-reply la
   it("an owner reply through the REAL MESSAGE_RECEIVED seam appends the streak-breaking log entry", async () => {
     runtimeResult = await createLifeOpsTestRuntime();
     const { runtime } = runtimeResult;
+    runtime.setSetting("ELIZA_ADMIN_ENTITY_ID", OWNER_ENTITY_ID, false);
     const roomId = "room-quiet-streak-1";
 
     const repo = new LifeOpsRepository(runtime);
@@ -408,7 +411,7 @@ describe("processDueScheduledTasks — quiet streak softens the next no-reply la
     await runtime.emitEvent(EventType.MESSAGE_RECEIVED, {
       message: {
         id: "msg-quiet-streak-reply",
-        entityId: "owner-entity-1",
+        entityId: OWNER_ENTITY_ID,
         roomId,
         agentId: runtime.agentId,
         content: { text: "pretty good actually" },

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.ts
@@ -17,6 +17,7 @@
  */
 import { hasOwnerAccess } from "@elizaos/agent";
 import {
+  ElizaError,
   type IAgentRuntime,
   logger,
   type Memory,
@@ -863,31 +864,35 @@ export async function processScheduledTaskInboundMessage(
 export async function handleScheduledTaskInboundMessage(
   payload: MessagePayload,
 ): Promise<void> {
-  try {
-    const runtime = payload.runtime;
-    if (!runtime || !payload.message) return;
-    const result = await processScheduledTaskInboundMessage({
-      runtime,
-      agentId: runtime.agentId,
-      message: payload.message,
-    });
-    if (result.completions.length > 0) {
-      logger.info(
-        {
-          src: "lifeops:scheduled-task",
-          agentId: runtime.agentId,
-          taskIds: result.completions.map((entry) => entry.taskId),
-        },
-        "[lifeops-scheduled-task] Completed fired scheduled task(s) from owner inbound reply",
-      );
-    }
-  } catch (error) {
-    logger.warn(
+  const runtime = payload.runtime;
+  if (!runtime || !payload.message) return;
+  const result = await processScheduledTaskInboundMessage({
+    runtime,
+    agentId: runtime.agentId,
+    message: payload.message,
+  });
+  if (result.completions.length > 0) {
+    logger.info(
       {
         src: "lifeops:scheduled-task",
-        error,
+        agentId: runtime.agentId,
+        taskIds: result.completions.map((entry) => entry.taskId),
       },
-      "[lifeops-scheduled-task] Inbound completion handler failed",
+      "[lifeops-scheduled-task] Completed fired scheduled task(s) from owner inbound reply",
+    );
+  }
+  if (result.errors.length > 0) {
+    throw new ElizaError(
+      "[lifeops-scheduled-task] inbound completion scan failed",
+      {
+        code: "LIFEOPS_INBOUND_COMPLETION_SCAN_FAILED",
+        context: {
+          agentId: runtime.agentId,
+          roomId: payload.message.roomId,
+          errors: result.errors,
+        },
+        severity: "ephemeral",
+      },
     );
   }
 }

--- a/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/unanswered-question-followup.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/scheduled-task/unanswered-question-followup.ts
@@ -301,25 +301,10 @@ export async function handleAgentMessageSentForQuestionFollowup(
   }
 }
 
-/**
- * `MESSAGE_RECEIVED` event handler. Boundary catch: an inbound chat message
- * must never fail because a follow-up row is broken.
- */
 export async function handleOwnerMessageForQuestionFollowup(
   payload: MessagePayload,
 ): Promise<void> {
-  try {
-    const runtime = payload.runtime;
-    if (!runtime || !payload.message) return;
-    await cancelQuestionFollowupsOnOwnerReply(runtime, payload.message);
-  } catch (error) {
-    // error-policy:J1 boundary translation — event-bus handler edge; the
-    // failure is logged and the message pipeline continues.
-    logger.warn(
-      { src: LOG_SRC, error },
-      `[UnansweredQuestionFollowup] follow-up cancellation failed: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
-  }
+  const runtime = payload.runtime;
+  if (!runtime || !payload.message) return;
+  await cancelQuestionFollowupsOnOwnerReply(runtime, payload.message);
 }


### PR DESCRIPTION
Follow-up to #15305. GitHub merged the old PR head before the reviewed local repair could be pushed, so this PR carries only the missing fix that was already validated locally.

What changed:
- `detachInboundScan` now catches synchronous throws from deferred scan callbacks by entering through `Promise.resolve().then(...)`.
- Inbound scheduled-task scan errors now throw an `ElizaError` after logging completions, so the detacher reports the failure instead of silently treating partial processing as healthy.
- The unanswered-question follow-up event handler no longer swallows cancellation failures; the event detacher owns diagnostics.

Validation run on `dcd3ea01a84` from `/private/tmp/eliza-pr-15305-followup`:
- `bun install --frozen-lockfile --ignore-scripts` -> passed.
- `bun run --cwd packages/shared build:i18n` -> passed.
- `node packages/scripts/run-turbo.mjs run build --filter='@elizaos/plugin-personal-assistant...' --concurrency=8 --output-logs=errors-only` -> passed, 97 build tasks successful.
- `bunx biome check` on the six touched files -> passed.
- `bun run audit:error-policy-ratchet` -> passed.
- `bun run --cwd plugins/plugin-personal-assistant typecheck` -> passed.
- `bunx vitest run --config plugins/plugin-personal-assistant/vitest.config.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/deferred-inbound-scans.test.ts --reporter=dot` -> 4 tests passed.
- `bunx vitest run --config plugins/plugin-personal-assistant/vitest.config.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.quiet-streak.test.ts --reporter=dot` -> 6 tests passed.
- `bunx vitest run --config plugins/plugin-personal-assistant/vitest.src-integration.config.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/inbound-reply-completion.integration.test.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/scheduler.integration.test.ts plugins/plugin-personal-assistant/src/lifeops/scheduled-task/unanswered-question-followup.integration.test.ts --reporter=dot` -> 3 files passed, 32 tests passed.

Evidence scope:
- Backend/plugin event-handler behavior only; no rendered UI, prompt/model, or LLM behavior changed.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend/plugin event-handler behavior only; no rendered UI changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend/plugin event-handler behavior only; no rendered UI changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend/plugin event-handler behavior only; behavior covered by targeted unit and integration tests

<!-- evidence-row:backend-logs -->
- [x] [15316](https://github.com/elizaOS/eliza/pull/15316)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend/browser code changed

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, model, provider, action planner, or agent-response behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [15316](https://github.com/elizaOS/eliza/pull/15316)
