### PR TITLE
fix(training): complete @elizaos/ui/components barrel mock in FineTuningView tests

### DIFF
--- a/plugins/plugin-training/src/ui/FineTuningTuiView.test.tsx
+++ b/plugins/plugin-training/src/ui/FineTuningTuiView.test.tsx
@@ -116,13 +116,34 @@ vi.mock("../../../../packages/ui/src/api/index.ts", () => ({
   client: trainingClient,
 }));
 
+// The real FineTuningView pulls Button/Input/Textarea and the Select family
+// straight from this barrel (its AgentTextField/AgentTextAreaField/
+// AgentNativeSelect). Every referenced symbol must be present or vitest's mock
+// proxy throws "No <name> export" and aborts the render before any assertion.
 vi.mock("@elizaos/ui/components", () => ({
   Button: ({
     children,
     ...props
   }: React.ButtonHTMLAttributes<HTMLButtonElement>) =>
     React.createElement("button", { type: "button", ...props }, children),
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) =>
+    React.createElement("input", props),
   registerDetailExtension: uiExtensionMocks.registerDetailExtension,
+  Select: ({ children }: { children: React.ReactNode }) =>
+    React.createElement("select", {}, children),
+  SelectContent: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, {}, children),
+  SelectItem: ({
+    value,
+    children,
+  }: {
+    value: string;
+    children: React.ReactNode;
+  }) => React.createElement("option", { value }, children),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  Textarea: (props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) =>
+    React.createElement("textarea", props),
 }));
 
 // FineTuningView reads useApp/useAppSelector from @elizaos/ui/state (not the

--- a/plugins/plugin-training/src/ui/fine-tuning-analysis-coverage.test.tsx
+++ b/plugins/plugin-training/src/ui/fine-tuning-analysis-coverage.test.tsx
@@ -147,8 +147,12 @@ vi.mock("@elizaos/ui/utils", () => ({
   parsePositiveInteger: (value: string) => Number.parseInt(value, 10),
 }));
 
-// Primitives the REAL panels (rendered by FineTuningView) import — these panels
-// are intentionally NOT mocked so the view boots with the production tree.
+// Primitives FineTuningView imports straight from the barrel — its own
+// AgentTextAreaField/AgentNativeSelect render Textarea and the Select family
+// from here (the sub-panels reach for the /ui/select and /ui/settings-controls
+// subpaths mocked below). Every barrel symbol the view references must be
+// present or vitest's mock proxy throws "No <name> export" and aborts the whole
+// render before any assertion can run.
 vi.mock("@elizaos/ui/components", () => ({
   Button: ({
     children,
@@ -158,6 +162,21 @@ vi.mock("@elizaos/ui/components", () => ({
   Input: (props: React.InputHTMLAttributes<HTMLInputElement>) =>
     React.createElement("input", props),
   registerDetailExtension: vi.fn(),
+  Select: ({ children }: { children: React.ReactNode }) =>
+    React.createElement("select", {}, children),
+  SelectContent: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, {}, children),
+  SelectItem: ({
+    value,
+    children,
+  }: {
+    value: string;
+    children: React.ReactNode;
+  }) => React.createElement("option", { value }, children),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  Textarea: (props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) =>
+    React.createElement("textarea", props),
 }));
 
 vi.mock("@elizaos/ui/components/ui/select", () => ({

--- a/plugins/plugin-training/src/ui/summarize-analysis-coverage.contract.test.tsx
+++ b/plugins/plugin-training/src/ui/summarize-analysis-coverage.contract.test.tsx
@@ -129,6 +129,10 @@ vi.mock("@elizaos/ui/utils", () => ({
   parsePositiveInteger: (value: string) => Number.parseInt(value, 10),
 }));
 
+// FineTuningView pulls Textarea and the Select family straight from the barrel
+// (its own AgentTextAreaField/AgentNativeSelect), so every referenced barrel
+// symbol must be present — a missing one makes vitest's mock proxy throw
+// "No <name> export" and abort the render before any assertion runs.
 vi.mock("@elizaos/ui/components", () => ({
   Button: ({
     children,
@@ -138,6 +142,21 @@ vi.mock("@elizaos/ui/components", () => ({
   Input: (props: React.InputHTMLAttributes<HTMLInputElement>) =>
     React.createElement("input", props),
   registerDetailExtension: vi.fn(),
+  Select: ({ children }: { children: React.ReactNode }) =>
+    React.createElement("select", {}, children),
+  SelectContent: ({ children }: { children: React.ReactNode }) =>
+    React.createElement(React.Fragment, {}, children),
+  SelectItem: ({
+    value,
+    children,
+  }: {
+    value: string;
+    children: React.ReactNode;
+  }) => React.createElement("option", { value }, children),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  Textarea: (props: React.TextareaHTMLAttributes<HTMLTextAreaElement>) =>
+    React.createElement("textarea", props),
 }));
 
 vi.mock("@elizaos/ui/components/ui/select", () => ({


### PR DESCRIPTION
## Problem

CI **Plugin Tests** shard (`test:plugins`) was red on the fine-tuning view tests:

```
TestingLibraryElementError: Unable to find an element with the text: finetuningview.NoAnalysisIndexBuilt
TestingLibraryElementError: Unable to find a label with the text of: Build index
```

## Root cause — incomplete test mocks (not i18n, not the component)

`FineTuningView` imports `Button, Input, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Textarea` **straight from the `@elizaos/ui/components` barrel** (in its own `AgentTextField` / `AgentTextAreaField` / `AgentNativeSelect` helpers). The barrel legitimately re-exports these (`export * from "./ui/select"` / `"./ui/textarea"`).

Three tests that render the real `FineTuningView` mocked that barrel with only a subset of symbols:
- `fine-tuning-analysis-coverage.test.tsx` — had `Button/Input/registerDetailExtension` (missing `Textarea`, `Select*`)
- `summarize-analysis-coverage.contract.test.tsx` — same
- `FineTuningTuiView.test.tsx` — had only `Button/registerDetailExtension` (missing `Input`, `Textarea`, `Select*`)

When the render reached `<Textarea>` / `<Input>`, vitest's mock proxy threw `No "<name>" export is defined on the "@elizaos/ui/components" mock` and **aborted the whole render before any assertion ran**. That surfaced misleadingly as testing-library "cannot find `finetuningview.NoAnalysisIndexBuilt` / `Build index`" — the panel had simply never rendered. The i18n key rendering was a red herring.

This is second-wave breakage: `FineTuningView`'s primitive imports were consolidated onto the barrel, but these test mocks still targeted the old `/ui/select` and `/ui/settings-controls` subpaths (which the sub-panels still use, and which remain mocked).

## Fix

Add the missing `Input` / `Textarea` / `Select*` exports to the barrel mock in all three files that render `FineTuningView`, mirroring the existing subpath-mock shapes. Test-only change; no product code touched.

## Validation

- `bun run --cwd plugins/plugin-training test src/ui` → **40 passed (5 files)** (was 12 failed).
- Targeted: `fine-tuning-analysis-coverage` + `summarize-analysis-coverage` → 3 passed; `FineTuningTuiView` → 15 passed.
- `packages/ui` `injected.test.tsx` (unrelated `FineTuningView` wrapper) → 3 passed, unaffected.
- Biome check on the 3 files → clean.
- `@elizaos/plugin-training:typecheck` (turbo, deps built) → pass.
- `audit:error-policy-ratchet` → no new fallback-slop (test-only).

N/A: no UI/runtime behavior change (test mocks only), so no screenshots/trajectories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)