### PR TITLE
fix(ci): pin plugin-app-manager to source in the PA integration lane

### DIFF
--- a/packages/test/vitest/integration.config.ts
+++ b/packages/test/vitest/integration.config.ts
@@ -97,6 +97,28 @@ const appControlSubpathAliases: ModuleAlias[] = existsSync(
       },
     ]
   : [];
+// plugin-app-manager was extracted from @elizaos/agent in #14459 but is not a
+// dependency of plugin-personal-assistant, so this lane's
+// `--filter='@elizaos/plugin-personal-assistant...'` build never emits its
+// dist. The agent source (which this lane aliases to src) imports it by its
+// bare `.` entry — resolvable only under the `eliza-source` exports condition
+// vite's SSR resolver ignores — so the whole PA plugin graph fails to boot.
+// Pin the package to its TS source, matching the discord/app-control pins.
+const appManagerSource = path.join(
+  elizaWorkspaceRoot,
+  "plugins",
+  "plugin-app-manager",
+  "src",
+  "index.ts",
+);
+const appManagerAliases: ModuleAlias[] = existsSync(appManagerSource)
+  ? [
+      {
+        find: /^@elizaos\/plugin-app-manager$/,
+        replacement: appManagerSource,
+      },
+    ]
+  : [];
 // Include/exclude globs are cwd-relative, but the eliza workspace sits at
 // `eliza/` in the nested eliza layout and at the repo root in a flat eliza
 // checkout (#11047). Derive the prefix instead of hardcoding `eliza/` so the
@@ -124,6 +146,7 @@ const integrationResolveAlias: ModuleAlias[] = [
   ...getOptionalPluginSdkAliases(repoRoot),
   ...discordSubpathAliases,
   ...appControlSubpathAliases,
+  ...appManagerAliases,
   ...(elizaCoreEntry
     ? [
         // Subpath aliases must precede the bare specifier. A bare-string


### PR DESCRIPTION
## Problem

The **Integration Lane (personal-assistant)** job (`bun run --cwd plugins/plugin-personal-assistant test:integration`) was red. Its three named suites all **failed to load** (0 tests, failed suite) with:

```
Error: Failed to resolve entry for package "@elizaos/plugin-app-manager".
  File: packages/agent/src/api/index.ts / packages/agent/src/runtime/eliza.ts
```

This lane first ran since June 18 (unblocked by the skip-cascade fix #15222), so the regression sat undetected inside the 3-week #14459 window.

## Root cause (one shared cause for all three files)

Not per-file assertion drift — a single module-graph load failure:

- **#14459** (`fd47ef2b275`) extracted `@elizaos/plugin-app-manager` out of `@elizaos/agent`. The agent source now imports it by its bare `.` entry (`packages/agent/src/api/index.ts`, `src/api/server.ts`, `src/runtime/eliza.ts`).
- This lane runs the agent **from source** (aliased via `getAgentSourceAliases`), but `plugin-app-manager` is **not** a dependency of `plugin-personal-assistant`, so the lane's `--filter='@elizaos/plugin-personal-assistant...'` build never emits its `dist`.
- Its `.` entry then resolves only under the `eliza-source` exports condition, which **vite's SSR resolver ignores** → the whole PA plugin graph fails to boot before any test runs. All three named suites (`integration-lane.smoke`, `life-smoke`, `owner-agent-permission-matrix`) died at import.

This is the identical class of failure already worked around in this config for `plugin-discord/user-account-scraper` and `plugin-app-control/actions/settings`.

## Fix

Pin `@elizaos/plugin-app-manager` to its TS source in `packages/test/vitest/integration.config.ts`, matching the two existing source pins. No product change and no test weakening — the config change simply makes the source-aliased module graph resolvable.

## Per-file result after the fix

| File | Result | Notes |
| --- | --- | --- |
| `integration-lane.smoke.integration.test.ts` | pass (2) | boots the PA barrel + core/node subpath |
| `life-smoke.integration.test.ts` | pass (15) | incl. `recurring create previews without fabricating success, then persists on confirm` — the #14459/#15055 create→confirm gate path |
| `owner-agent-permission-matrix.integration.test.ts` | clean skip | gated on `LIFEOPS_PERMISSION_MATRIX=1` opt-in (#8833); **20/20 assertions pass** when enabled |

## Verification (local)

- 3-file lane: `2 passed | 1 skipped (3)` files, `17 passed | 1 skipped (18)` tests.
- Permission matrix with `LIFEOPS_PERMISSION_MATRIX=1`: `20 passed (20)`.
- Sibling `vitest.src-integration.config.ts` lane (the first half of `test:integration`): `12 passed (12)` files, `71 passed (71)` tests (includes the #15300 scheduler-recurrence fix already on develop).
- `biome check` on the touched file: clean. `audit:error-policy-ratchet`: no new fallback-slop (0 changed production source files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)