### PR TITLE
fix(ci): close config/module gaps in Quality, Server Tests, and Client lanes

### DIFF
--- a/packages/app/scripts/check-startup-budget.test.ts
+++ b/packages/app/scripts/check-startup-budget.test.ts
@@ -23,10 +23,13 @@ import {
   shouldPassAfterBaselineUpdate,
 } from "./check-startup-budget.mjs";
 
-const SCRIPT_PATH = path.resolve(
-  process.cwd(),
-  "packages/app/scripts/check-startup-budget.mjs",
-);
+// Resolve the CLI relative to this test file (a sibling .mjs), not
+// process.cwd(): the client test lane runs vitest from packages/app, so a
+// cwd-relative "packages/app/..." path doubles into
+// packages/app/packages/app/... and the spawned Node can't find the module.
+// import.meta.dirname is a plain filesystem string, so it sidesteps jsdom's
+// http base-URL override that breaks fileURLToPath(import.meta.url) here.
+const SCRIPT_PATH = path.join(import.meta.dirname, "check-startup-budget.mjs");
 
 function traceRun(kind: string, marks: Array<[string, number]>, extra = {}) {
   return {

--- a/packages/ui/src/App.surface-mutation-fuzz.test.tsx
+++ b/packages/ui/src/App.surface-mutation-fuzz.test.tsx
@@ -37,7 +37,11 @@ import type * as React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { BuiltinTab } from "./navigation";
 import type { BackgroundConfig } from "./state/ui-preferences";
-import { SurfaceRealmDeniedError, getActiveSurfaceRealmScope, surfaceViewStoragePrefix } from "./surface-realm-broker";
+import {
+  SurfaceRealmDeniedError,
+  getActiveSurfaceRealmScope,
+  surfaceViewStoragePrefix,
+} from "./surface-realm-broker";
 import { shellHistory, shellLocalStorage } from "./surface-realm-channel";
 
 const appState = vi.hoisted(() => ({
@@ -715,9 +719,9 @@ describe("App in-process host-realm mutation isolation (#14179)", () => {
     writeChatDraft(conversationId, "half-typed message");
     expect(readChatDraft(conversationId)).toBe("half-typed message");
     // It landed under the real reserved key, not a view-namespaced fallback.
-    expect(window.localStorage.getItem(chatDraftStorageKey(conversationId))).toBe(
-      "half-typed message",
-    );
+    expect(
+      window.localStorage.getItem(chatDraftStorageKey(conversationId)),
+    ).toBe("half-typed message");
     // Clearing (removeItem on the reserved key) also works under the scope.
     writeChatDraft(conversationId, "");
     expect(readChatDraft(conversationId)).toBeNull();

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -135,7 +135,10 @@ import {
   firstRunOwnsLoginSurface,
 } from "./state/top-level-auth-gate";
 import { isLoopbackGatewayHost } from "./state/use-startup-shell-controller";
-import { SurfaceRealmScope, setActiveSurfaceRealmScope } from "./surface-realm-broker";
+import {
+  SurfaceRealmScope,
+  setActiveSurfaceRealmScope,
+} from "./surface-realm-broker";
 import { shellHistory } from "./surface-realm-channel";
 import { TutorialConductorMount } from "./tutorial/TutorialConductor";
 import { confirmDesktopAction } from "./utils/desktop-dialogs";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -97,6 +97,20 @@ export default defineConfig({
         replacement: path.join(root, "packages/shared/src/$1"),
       },
       {
+        // Leaf auth package (account storage, credentials, oauth flows,
+        // atomic-json). It ships no dist in the test lane, so its `.` and `./*`
+        // exports resolve to `dist/*.js` and vite fails with "Cannot find
+        // package '@elizaos/auth/...'". Pin both the barrel and subpaths to
+        // source so targeted tests (e.g. remote-plugin-adapter → app-package
+        // -modules → `@elizaos/auth/atomic-json`) resolve without a build.
+        find: /^@elizaos\/auth$/,
+        replacement: path.join(root, "packages/auth/src/index.ts"),
+      },
+      {
+        find: /^@elizaos\/auth\/(.+)$/,
+        replacement: path.join(root, "packages/auth/src/$1"),
+      },
+      {
         find: /^@elizaos\/vault$/,
         replacement: path.join(root, "packages/vault/src/index.ts"),
       },


### PR DESCRIPTION
## CI second-wave: config/module gaps

Closes three CI-lane gaps that surfaced after the #14459 launch-QA merge (all verified failing at develop tip and green after this change).

### 1. Server Tests — `Cannot find package '@elizaos/auth/atomic-json'`
`bun run test:remote-capabilities` runs vitest from the **repo root**, i.e. the root `vitest.config.ts`. That config source-aliases every workspace package it targets **except `@elizaos/auth`**. `packages/agent/src/services/app-package-modules.ts` (added in #14459) imports `@elizaos/auth/atomic-json`; with no alias and no built `dist`, vite resolved the package's `./*` export to `dist/atomic-json.js` and failed **4 of 9** app-package suites. The base config (`packages/test/vitest/default.config.ts`) already has this alias — the root config was simply never updated.

**Fix:** add `@elizaos/auth` barrel + `@elizaos/auth/(.+)` subpath source aliases to the root config, mirroring the sibling leaf packages. (Same class as the cloud-routing gap #15287.)

Evidence — `bun run --cwd packages/agent test:remote-capabilities`:
```
Test Files  9 passed (9)
     Tests  233 passed | 3 skipped (236)
```

### 2. Quality (Extended) → format:check — `@elizaos/ui`
Two files from #15247 were unformatted (`App.tsx`, `App.surface-mutation-fuzz.test.tsx`). `biome format --write` on exactly those two; **format only, no code tokens change**. Workspace `bun run format:check` is now green (239/239 turbo tasks). Type-safety ratchet + focused-tests audits (the rest of the Quality job) confirmed green with no regression.

### 3. Client Tests — `packages/app` startup-budget spawn (one of several failures)
`check-startup-budget.test.ts` resolved the spawned CLI via `path.resolve(process.cwd(), "packages/app/scripts/…")`, assuming a repo-root cwd. The client lane runs vitest from `packages/app`, doubling the path to `packages/app/packages/app/scripts/…` so the spawn 404'd. Anchored to `import.meta.dirname` (a sibling of the test) — cwd-independent, and it sidesteps jsdom's http base-URL that breaks `fileURLToPath(import.meta.url)` here. Passes from both repo-root and `packages/app` cwd (21/21).

### Not fixed here — Client Tests has a separate, larger workstream
Beyond the startup-budget cwd bug, Client Tests is red on develop from **real logic/assertion regressions** across four packages that are **not** config/module gaps and need a domain-owner lane:
- `plugin-personal-assistant` — `contracts.test.ts` `decideDispatchPolicy` returns `surface_degraded` where the test expects `fail` (terminal-beats-degraded); plus `runtime-wiring.owner-facing-copy.test.ts` length mismatches.
- `packages/ui` — `chat/widgets/todo.test.tsx` deep-equal + Testing-Library "Ready"/checkbox not found.
- `plugin-training` / PA fast-check — `expected 'pa-simulation-agent' to be ''`.

These are behavior assertions (largely from the #14459 era) and are called out for a follow-up owner rather than papered over in this config lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)