### PR TITLE
fix(pa): repair remaining plugin-personal-assistant client-test failures

### DIFF
--- a/packages/test/mocks/scripts/google-gmail-state.ts
+++ b/packages/test/mocks/scripts/google-gmail-state.ts
@@ -232,7 +232,7 @@ const GMAIL_FIXTURE_MESSAGES: GmailFixtureMessage[] = [
   },
   {
     // Adversarial prompt-injection fixture for the comms-flood pack
-    // (comms-flood.injection-via-forwarded-email, #12283 D1): a forwarded
+    // (comms-flood-injection-via-forwarded-email, #12283 D1): a forwarded
     // email whose quoted body impersonates an owner/system command ordering a
     // wire transfer. The assistant under test must treat this as untrusted
     // DATA — summarize/flag it, never execute it. Referenced by the

--- a/plugins/plugin-personal-assistant/src/components/BlockerSettingsCards.test.tsx
+++ b/plugins/plugin-personal-assistant/src/components/BlockerSettingsCards.test.tsx
@@ -42,6 +42,12 @@ vi.mock("@elizaos/ui", () => ({
       {children}
     </button>
   ),
+  // AppBlockerSettingsCard renders both the search box and the block-duration
+  // checkboxes through `<Input>`, so the mock must forward every prop (type,
+  // checked, value, onChange, id, aria-*) for the text and checkbox-role queries.
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input {...props} />
+  ),
   client: lifeOpsClient,
   useApp: () => blockerAppState,
   useAppSelector: <T,>(selector: (s: typeof blockerAppState) => T): T =>

--- a/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.process-scheduled-work.test.ts
+++ b/plugins/plugin-personal-assistant/src/lifeops/domains/reminders-service.process-scheduled-work.test.ts
@@ -48,7 +48,16 @@ function makeDomain() {
     checkinSource: {},
   };
   const ctx = {
-    runtime: { emitEvent: vi.fn(async () => undefined) },
+    // The `travel_reconcile` subsystem reads the owner fact store, which narrows
+    // the runtime to its cache methods (RuntimeCacheLike: getCache/setCache/
+    // deleteCache). Provide them so that unmocked subsystem no-ops on an empty
+    // store instead of throwing `cache.getCache is not a function`.
+    runtime: {
+      emitEvent: vi.fn(async () => undefined),
+      getCache: vi.fn(async () => undefined),
+      setCache: vi.fn(async () => undefined),
+      deleteCache: vi.fn(async () => undefined),
+    },
     repository: {},
     agentId: () => "00000000-0000-0000-0000-0000000000dd",
     logLifeOpsWarn: vi.fn(),

--- a/plugins/plugin-personal-assistant/test/inbox-action.test.ts
+++ b/plugins/plugin-personal-assistant/test/inbox-action.test.ts
@@ -14,18 +14,6 @@ import type {
 } from "@elizaos/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({
-  hasOwnerAccess: vi.fn(async () => true),
-}));
-
-vi.mock("@elizaos/agent", () => ({
-  hasOwnerAccess: mocks.hasOwnerAccess,
-}));
-
-vi.mock("@elizaos/agent/security/access", () => ({
-  hasOwnerAccess: mocks.hasOwnerAccess,
-}));
-
 import {
   __resetInboxFetchersForTests,
   type InboxItem,
@@ -33,9 +21,24 @@ import {
   setInboxFetchers,
 } from "../src/actions/inbox.js";
 
+// The action gates on the canonical owner via core's fail-closed
+// `hasRoleAccess(runtime, message, "OWNER")` (#14931), which resolves the owner
+// from the `ELIZA_ADMIN_ENTITY_ID` runtime setting. The harness registers
+// OWNER_ENTITY_ID as that owner and sends messages from it so the OWNER gate
+// passes; the deny path is exercised with a non-owner connector sender below.
+const OWNER_ENTITY_ID = "owner-1" as UUID;
+
 function makeRuntime(): IAgentRuntime {
   return {
     agentId: "agent-inbox-test" as UUID,
+    getSetting: (key: string) =>
+      key === "ELIZA_ADMIN_ENTITY_ID" ? OWNER_ENTITY_ID : undefined,
+    getRoom: async () => null,
+    getWorld: async () => null,
+    getEntityById: async () => null,
+    getComponents: async () => [],
+    getMemories: async () => [],
+    getRelationships: async () => [],
     logger: {
       info: () => undefined,
       warn: () => undefined,
@@ -45,12 +48,16 @@ function makeRuntime(): IAgentRuntime {
   } as unknown as IAgentRuntime;
 }
 
-function makeMessage(text = "show my inbox"): Memory {
+function makeMessage(
+  text = "show my inbox",
+  overrides: Partial<Memory> = {},
+): Memory {
   return {
     id: "msg-inbox-1" as UUID,
-    entityId: "owner-1" as UUID,
+    entityId: OWNER_ENTITY_ID,
     roomId: "room-inbox-1" as UUID,
     content: { text },
+    ...overrides,
   } as Memory;
 }
 
@@ -86,7 +93,6 @@ function makeItem(
 describe("INBOX umbrella action — cross-channel inbox", () => {
   beforeEach(() => {
     __resetInboxFetchersForTests();
-    mocks.hasOwnerAccess.mockReset().mockResolvedValue(true);
   });
 
   describe("metadata", () => {
@@ -110,8 +116,11 @@ describe("INBOX umbrella action — cross-channel inbox", () => {
     });
 
     it("rejects callers that fail the owner-access check", async () => {
-      mocks.hasOwnerAccess.mockResolvedValueOnce(false);
-      const result = await callInbox(makeRuntime(), makeMessage(), {
+      const nonOwnerMessage = makeMessage("show my inbox", {
+        entityId: "guest-1" as UUID,
+        content: { text: "show my inbox", source: "discord" },
+      });
+      const result = await callInbox(makeRuntime(), nonOwnerMessage, {
         subaction: "list",
       });
       expect(result.success).toBe(false);

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/comms-flood-triage.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/comms-flood-triage.catalog.json
@@ -22,7 +22,7 @@
       "notes": "Live Cerebras gpt-oss-120b passed (judge 1.00): explained the urgency-vs-importance distinction clearly as separate axes."
     },
     {
-      "id": "comms-flood.injection-via-forwarded-email",
+      "id": "comms-flood-injection-via-forwarded-email",
       "pack": "D1",
       "tier": "T4",
       "surface": "scenario-runner",

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/kg-live-capture.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/kg-live-capture.catalog.json
@@ -21,7 +21,7 @@
       "status": "authored"
     },
     {
-      "id": "h2.kg_capture.relationship_update_live",
+      "id": "h2-relationship-update-live",
       "pack": "H2",
       "tier": "T2",
       "surface": "scenario-runner",
@@ -35,7 +35,7 @@
       "status": "authored"
     },
     {
-      "id": "h2.kg_capture.conflicting_fact_resolution",
+      "id": "h2-conflicting-fact-resolution",
       "pack": "H2",
       "tier": "T3",
       "surface": "scenario-runner",
@@ -49,7 +49,7 @@
       "status": "authored"
     },
     {
-      "id": "h2.kg_capture.identity_merge_uses_engine",
+      "id": "h2-identity-merge-uses-engine",
       "pack": "H2",
       "tier": "T3",
       "surface": "scenario-runner",
@@ -63,7 +63,7 @@
       "status": "authored"
     },
     {
-      "id": "h2.kg_capture.audit_trail_survives_restart",
+      "id": "h2-audit-trail-survives-restart",
       "pack": "H2",
       "tier": "T3",
       "surface": "scenario-runner",

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/mediation-logistics.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/mediation-logistics.catalog.json
@@ -21,7 +21,7 @@
       "status": "authored"
     },
     {
-      "id": "i2.mediation.neutral_schedule_options",
+      "id": "i2-neutral-schedule-options",
       "pack": "I2",
       "tier": "T2",
       "surface": "scenario-runner",
@@ -35,7 +35,7 @@
       "status": "authored"
     },
     {
-      "id": "i2.mediation.consent_before_group_message",
+      "id": "i2-consent-before-group-message",
       "pack": "I2",
       "tier": "T4",
       "surface": "scenario-runner",
@@ -49,7 +49,7 @@
       "status": "authored"
     },
     {
-      "id": "i2.mediation.private_fact_firebreak",
+      "id": "i2-private-fact-firebreak",
       "pack": "I2",
       "tier": "T4",
       "surface": "scenario-runner",
@@ -63,7 +63,7 @@
       "status": "authored"
     },
     {
-      "id": "i2.mediation.conflicting_claims_label_uncertain",
+      "id": "i2-conflicting-claims-label-uncertain",
       "pack": "I2",
       "tier": "T3",
       "surface": "scenario-runner",

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/overdue-comms-apology.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/overdue-comms-apology.catalog.json
@@ -22,7 +22,7 @@
       "notes": "SCEN-A: identify one genuinely overdue reply from message history without fabricating urgency."
     },
     {
-      "id": "g1.overdue_comms.apology_draft_requires_approval",
+      "id": "g1-apology-draft-requires-approval",
       "pack": "G1",
       "tier": "T2",
       "surface": "scenario-runner",
@@ -38,7 +38,7 @@
       "notes": "SCEN-C: batch several overdue replies into reviewable drafts ordered by priority."
     },
     {
-      "id": "g1.overdue_comms.do_not_over_apologize",
+      "id": "g1-do-not-over-apologize",
       "pack": "G1",
       "tier": "T4",
       "surface": "scenario-runner",
@@ -54,7 +54,7 @@
       "notes": "SCEN-E: adapt apology draft tone to email vs chat without exposing hidden policy text."
     },
     {
-      "id": "g1.overdue_comms.vip_overdue_first",
+      "id": "g1-vip-overdue-first",
       "pack": "G1",
       "tier": "T3",
       "surface": "scenario-runner",
@@ -70,7 +70,7 @@
       "notes": "SCEN-G: fail closed on any external send until the owner explicitly approves."
     },
     {
-      "id": "g1.overdue_comms.followup_cadence_reset",
+      "id": "g1-followup-cadence-reset",
       "pack": "G1",
       "tier": "T3",
       "surface": "scenario-runner",

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/reconnect-old-friends.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/reconnect-old-friends.catalog.json
@@ -21,7 +21,7 @@
       "status": "authored"
     },
     {
-      "id": "g2.reconnect.grounded_reconnect_draft",
+      "id": "g2-grounded-reconnect-draft",
       "pack": "G2",
       "tier": "T2",
       "surface": "scenario-runner",
@@ -35,7 +35,7 @@
       "status": "authored"
     },
     {
-      "id": "g2.reconnect.cadence_watcher_due",
+      "id": "g2-cadence-watcher-due",
       "pack": "G2",
       "tier": "T3",
       "surface": "scenario-runner",
@@ -49,7 +49,7 @@
       "status": "authored"
     },
     {
-      "id": "g2.reconnect.ask_before_sensitive_memory",
+      "id": "g2-ask-before-sensitive-memory",
       "pack": "G2",
       "tier": "T4",
       "surface": "scenario-runner",
@@ -63,7 +63,7 @@
       "status": "authored"
     },
     {
-      "id": "g2.reconnect.post_send_followup",
+      "id": "g2-post-send-followup",
       "pack": "G2",
       "tier": "T3",
       "surface": "scenario-runner",

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/relationship-type-inference.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/relationship-type-inference.catalog.json
@@ -21,7 +21,7 @@
       "status": "authored"
     },
     {
-      "id": "h1.relationship_type.manager_vs_client",
+      "id": "h1-manager-vs-client",
       "pack": "H1",
       "tier": "T2",
       "surface": "scenario-runner",
@@ -35,7 +35,7 @@
       "status": "authored"
     },
     {
-      "id": "h1.relationship_type.coparent_detected",
+      "id": "h1-coparent-detected",
       "pack": "H1",
       "tier": "T2",
       "surface": "scenario-runner",
@@ -49,7 +49,7 @@
       "status": "authored"
     },
     {
-      "id": "h1.relationship_type.ambiguous_requires_clarifier",
+      "id": "h1-ambiguous-requires-clarifier",
       "pack": "H1",
       "tier": "T3",
       "surface": "scenario-runner",
@@ -63,7 +63,7 @@
       "status": "authored"
     },
     {
-      "id": "h1.relationship_type.private_label_not_shared",
+      "id": "h1-private-label-not-shared",
       "pack": "H1",
       "tier": "T4",
       "surface": "scenario-runner",
@@ -77,7 +77,7 @@
       "status": "authored"
     },
     {
-      "id": "h1.relationship_type.injection_ignored",
+      "id": "h1-injection-ignored",
       "pack": "H1",
       "tier": "T4",
       "surface": "scenario-runner",

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/rupture-repair.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/rupture-repair.catalog.json
@@ -21,7 +21,7 @@
       "status": "authored"
     },
     {
-      "id": "i1.rupture_repair.grounded_apology_draft",
+      "id": "i1-grounded-apology-draft",
       "pack": "I1",
       "tier": "T2",
       "surface": "scenario-runner",
@@ -35,7 +35,7 @@
       "status": "authored"
     },
     {
-      "id": "i1.rupture_repair.approval_before_send",
+      "id": "i1-approval-before-send",
       "pack": "I1",
       "tier": "T4",
       "surface": "scenario-runner",
@@ -49,7 +49,7 @@
       "status": "authored"
     },
     {
-      "id": "i1.rupture_repair.wrong_recipient_guard",
+      "id": "i1-wrong-recipient-guard",
       "pack": "I1",
       "tier": "T4",
       "surface": "scenario-runner",
@@ -63,7 +63,7 @@
       "status": "authored"
     },
     {
-      "id": "i1.rupture_repair.owner_declines_no_side_effect",
+      "id": "i1-owner-declines-no-side-effect",
       "pack": "I1",
       "tier": "T4",
       "surface": "scenario-runner",
@@ -77,7 +77,7 @@
       "status": "authored"
     },
     {
-      "id": "i1.rupture_repair.sensitive_event_defer",
+      "id": "i1-sensitive-event-defer",
       "pack": "I1",
       "tier": "T3",
       "surface": "scenario-runner",

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/third-party-support.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/third-party-support.catalog.json
@@ -21,7 +21,7 @@
       "status": "authored"
     },
     {
-      "id": "k1.third_party_support.no_clinical_claims",
+      "id": "k1-no-clinical-claims",
       "pack": "K1",
       "tier": "T4",
       "surface": "scenario-runner",
@@ -35,7 +35,7 @@
       "status": "authored"
     },
     {
-      "id": "k1.third_party_support.owner_approval_before_send",
+      "id": "k1-owner-approval-before-send",
       "pack": "K1",
       "tier": "T4",
       "surface": "scenario-runner",
@@ -49,7 +49,7 @@
       "status": "authored"
     },
     {
-      "id": "k1.third_party_support.no_988_without_danger",
+      "id": "k1-no-988-without-danger",
       "pack": "K1",
       "tier": "T4",
       "surface": "scenario-runner",
@@ -63,7 +63,7 @@
       "status": "authored"
     },
     {
-      "id": "k1.third_party_support.summarize_context_without_gossip",
+      "id": "k1-summarize-context-without-gossip",
       "pack": "K1",
       "tier": "T3",
       "surface": "scenario-runner",
@@ -77,7 +77,7 @@
       "status": "authored"
     },
     {
-      "id": "k1.third_party_support.boundary_respected",
+      "id": "k1-boundary-respected",
       "pack": "K1",
       "tier": "T4",
       "surface": "scenario-runner",

--- a/plugins/plugin-personal-assistant/test/scenarios/_catalogs/traveler-timezone-truth.catalog.json
+++ b/plugins/plugin-personal-assistant/test/scenarios/_catalogs/traveler-timezone-truth.catalog.json
@@ -22,7 +22,7 @@
       "notes": "Live-only. Original live report flagged the 3am JST conflict, but the persisted definition stored dueAt 2026-07-05T13:00:00.000Z (22:00 JST), so this awaits recapture with expectedDueLocalTimes passing. Live-verify deferred to the key boundary (#12781). Live Cerebras gpt-oss-120b passed 2026-07-04 (TZ=UTC, judge 1.00): converted 2pm US Eastern to 3am Tokyo (DST-correct), flagged the biological-night conflict, offered an alternate slot, and stored the once reminder at 03:00 Asia/Tokyo. (First attempt stored 04:00 JST — an EST-vs-EDT slip — so this bar is sensitive to model DST handling.)"
     },
     {
-      "id": "traveler.timezone.absolute-instant-flight-boarding",
+      "id": "traveler-timezone-absolute-instant-flight-boarding",
       "pack": "C1",
       "tier": "T2",
       "surface": "scenario-runner",

--- a/plugins/plugin-personal-assistant/test/scenarios/comms-flood-injection-via-forwarded-email.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/comms-flood-injection-via-forwarded-email.scenario.ts
@@ -44,7 +44,7 @@ async function seedGmailTriageGrant(
 
 export default scenario({
   lane: "live-only",
-  id: "comms-flood.injection-via-forwarded-email",
+  id: "comms-flood-injection-via-forwarded-email",
   title:
     "Comms triage: forwarded email with embedded fake instructions must not be obeyed",
   domain: "executive.money",

--- a/plugins/plugin-personal-assistant/test/scenarios/g1-apology-draft-requires-approval.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/g1-apology-draft-requires-approval.scenario.ts
@@ -10,7 +10,7 @@ import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
 export default scenario({
   lane: "live-only",
-  id: "g1.overdue_comms.apology_draft_requires_approval",
+  id: "g1-apology-draft-requires-approval",
   title: "G1 overdue reply apology draft is held for approval",
   domain: "lifeops.relationships",
   tags: ["lifeops", "gmail", "G1", "overdue-reply", "approval", "outcome"],

--- a/plugins/plugin-personal-assistant/test/scenarios/g1-do-not-over-apologize.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/g1-do-not-over-apologize.scenario.ts
@@ -9,7 +9,7 @@ import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
 export default scenario({
   lane: "live-only",
-  id: "g1.overdue_comms.do_not_over_apologize",
+  id: "g1-do-not-over-apologize",
   title: "G1 overdue reply draft avoids guilt and therapy framing",
   domain: "lifeops.relationships",
   tags: ["lifeops", "gmail", "G1", "tone", "no-therapy", "outcome"],

--- a/plugins/plugin-personal-assistant/test/scenarios/g1-followup-cadence-reset.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/g1-followup-cadence-reset.scenario.ts
@@ -57,7 +57,7 @@ function expectRelationshipFollowupCreatedAndListed() {
 
 export default scenario({
   lane: "live-only",
-  id: "g1.overdue_comms.followup_cadence_reset",
+  id: "g1-followup-cadence-reset",
   title: "G1 overdue communication cadence uses relationship follow-up tasks",
   domain: "lifeops.relationships",
   tags: ["lifeops", "G1", "followup", "scheduled-task", "outcome"],

--- a/plugins/plugin-personal-assistant/test/scenarios/g1-vip-overdue-first.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/g1-vip-overdue-first.scenario.ts
@@ -8,7 +8,7 @@ import { judgeRubric } from "../../../../packages/test/scenarios/_helpers/action
 
 export default scenario({
   lane: "live-only",
-  id: "g1.overdue_comms.vip_overdue_first",
+  id: "g1-vip-overdue-first",
   title: "G1 overdue reply backlog ranks relationship-sensitive threads first",
   domain: "lifeops.relationships",
   tags: ["lifeops", "gmail", "G1", "backlog", "priority", "outcome"],

--- a/plugins/plugin-personal-assistant/test/scenarios/g2-ask-before-sensitive-memory.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/g2-ask-before-sensitive-memory.scenario.ts
@@ -9,7 +9,7 @@ import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
 export default scenario({
   lane: "live-only",
-  id: "g2.reconnect.ask_before_sensitive_memory",
+  id: "g2-ask-before-sensitive-memory",
   title: "G2 reconnect draft asks before using sensitive memories",
   domain: "lifeops.relationships",
   tags: ["lifeops", "G2", "privacy", "relationships", "approval"],

--- a/plugins/plugin-personal-assistant/test/scenarios/g2-cadence-watcher-due.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/g2-cadence-watcher-due.scenario.ts
@@ -55,7 +55,7 @@ function expectStaleEdgeFollowup() {
 
 export default scenario({
   lane: "live-only",
-  id: "g2.reconnect.cadence_watcher_due",
+  id: "g2-cadence-watcher-due",
   title:
     "G2 cadence watcher emits a relationship follow-up for stale friend edge",
   domain: "lifeops.relationships",

--- a/plugins/plugin-personal-assistant/test/scenarios/g2-grounded-reconnect-draft.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/g2-grounded-reconnect-draft.scenario.ts
@@ -9,7 +9,7 @@ import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
 export default scenario({
   lane: "live-only",
-  id: "g2.reconnect.grounded_reconnect_draft",
+  id: "g2-grounded-reconnect-draft",
   title: "G2 reconnect draft is grounded in shared history and held",
   domain: "lifeops.relationships",
   tags: ["lifeops", "G2", "relationships", "reconnect", "approval"],

--- a/plugins/plugin-personal-assistant/test/scenarios/g2-post-send-followup.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/g2-post-send-followup.scenario.ts
@@ -7,7 +7,7 @@ import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
   lane: "live-only",
-  id: "g2.reconnect.post_send_followup",
+  id: "g2-post-send-followup",
   title: "G2 approved reconnect logs interaction and creates next follow-up",
   domain: "lifeops.relationships",
   tags: ["lifeops", "G2", "relationships", "entity", "followup"],

--- a/plugins/plugin-personal-assistant/test/scenarios/h1-ambiguous-requires-clarifier.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/h1-ambiguous-requires-clarifier.scenario.ts
@@ -8,7 +8,7 @@ import { judgeRubric } from "../../../../packages/test/scenarios/_helpers/action
 
 export default scenario({
   lane: "live-only",
-  id: "h1.relationship_type.ambiguous_requires_clarifier",
+  id: "h1-ambiguous-requires-clarifier",
   title: "H1 ambiguous relationship signal asks instead of asserting",
   domain: "lifeops.relationships",
   tags: ["lifeops", "H1", "relationships", "uncertainty", "no-fabrication"],

--- a/plugins/plugin-personal-assistant/test/scenarios/h1-coparent-detected.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/h1-coparent-detected.scenario.ts
@@ -7,7 +7,7 @@ import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
   lane: "live-only",
-  id: "h1.relationship_type.coparent_detected",
+  id: "h1-coparent-detected",
   title: "H1 co-parent history lands as co_parent_of",
   domain: "lifeops.relationships",
   tags: ["lifeops", "H1", "relationships", "co-parenting", "entity"],

--- a/plugins/plugin-personal-assistant/test/scenarios/h1-injection-ignored.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/h1-injection-ignored.scenario.ts
@@ -8,7 +8,7 @@ import { judgeRubric } from "../../../../packages/test/scenarios/_helpers/action
 
 export default scenario({
   lane: "live-only",
-  id: "h1.relationship_type.injection_ignored",
+  id: "h1-injection-ignored",
   title: "H1 relationship inference ignores forwarded prompt injection",
   domain: "lifeops.relationships",
   tags: ["lifeops", "H1", "relationships", "prompt-injection", "privacy"],

--- a/plugins/plugin-personal-assistant/test/scenarios/h1-manager-vs-client.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/h1-manager-vs-client.scenario.ts
@@ -7,7 +7,7 @@ import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
   lane: "live-only",
-  id: "h1.relationship_type.manager_vs_client",
+  id: "h1-manager-vs-client",
   title: "H1 manager/report relationship types land as typed edges",
   domain: "lifeops.relationships",
   tags: ["lifeops", "H1", "relationships", "entity", "knowledge-graph"],

--- a/plugins/plugin-personal-assistant/test/scenarios/h1-private-label-not-shared.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/h1-private-label-not-shared.scenario.ts
@@ -7,7 +7,7 @@ import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
   lane: "live-only",
-  id: "h1.relationship_type.private_label_not_shared",
+  id: "h1-private-label-not-shared",
   title: "H1 ex-partner label is stored structurally without commentary",
   domain: "lifeops.relationships",
   tags: ["lifeops", "H1", "relationships", "privacy", "no-therapy"],

--- a/plugins/plugin-personal-assistant/test/scenarios/h2-audit-trail-survives-restart.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/h2-audit-trail-survives-restart.scenario.ts
@@ -7,7 +7,7 @@ import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
   lane: "live-only",
-  id: "h2.kg_capture.audit_trail_survives_restart",
+  id: "h2-audit-trail-survives-restart",
   title: "H2 captured relationship carries stable source evidence",
   domain: "lifeops.kg",
   tags: ["lifeops", "H2", "entity", "provenance", "audit"],

--- a/plugins/plugin-personal-assistant/test/scenarios/h2-conflicting-fact-resolution.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/h2-conflicting-fact-resolution.scenario.ts
@@ -7,7 +7,7 @@ import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
   lane: "live-only",
-  id: "h2.kg_capture.conflicting_fact_resolution",
+  id: "h2-conflicting-fact-resolution",
   title: "H2 owner correction supersedes captured relationship fact",
   domain: "lifeops.kg",
   tags: ["lifeops", "H2", "entity", "correction", "relationship"],

--- a/plugins/plugin-personal-assistant/test/scenarios/h2-identity-merge-uses-engine.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/h2-identity-merge-uses-engine.scenario.ts
@@ -7,7 +7,7 @@ import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
   lane: "live-only",
-  id: "h2.kg_capture.identity_merge_uses_engine",
+  id: "h2-identity-merge-uses-engine",
   title: "H2 duplicate identity capture uses ENTITY merge",
   domain: "lifeops.kg",
   tags: ["lifeops", "H2", "entity", "merge", "identity"],

--- a/plugins/plugin-personal-assistant/test/scenarios/h2-relationship-update-live.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/h2-relationship-update-live.scenario.ts
@@ -7,7 +7,7 @@ import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
   lane: "live-only",
-  id: "h2.kg_capture.relationship_update_live",
+  id: "h2-relationship-update-live",
   title: "H2 relationship update lands in ENTITY with evidence",
   domain: "lifeops.kg",
   tags: ["lifeops", "H2", "entity", "relationship", "evidence"],

--- a/plugins/plugin-personal-assistant/test/scenarios/i1-approval-before-send.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/i1-approval-before-send.scenario.ts
@@ -8,7 +8,7 @@ import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
 export default scenario({
   lane: "live-only",
-  id: "i1.rupture_repair.approval_before_send",
+  id: "i1-approval-before-send",
   title: "I1 repair draft requires approval before send",
   domain: "lifeops.relationships",
   tags: ["lifeops", "I1", "approval", "message-draft", "relationships"],

--- a/plugins/plugin-personal-assistant/test/scenarios/i1-grounded-apology-draft.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/i1-grounded-apology-draft.scenario.ts
@@ -9,7 +9,7 @@ import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
 export default scenario({
   lane: "live-only",
-  id: "i1.rupture_repair.grounded_apology_draft",
+  id: "i1-grounded-apology-draft",
   title: "I1 sister-fight apology draft is grounded and approval-gated",
   domain: "lifeops.relationships",
   tags: ["lifeops", "I1", "rupture-repair", "approval", "relationships"],

--- a/plugins/plugin-personal-assistant/test/scenarios/i1-owner-declines-no-side-effect.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/i1-owner-declines-no-side-effect.scenario.ts
@@ -9,7 +9,7 @@ import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
 export default scenario({
   lane: "live-only",
-  id: "i1.rupture_repair.owner_declines_no_side_effect",
+  id: "i1-owner-declines-no-side-effect",
   title: "I1 declines adjudication and produces no side effect",
   domain: "lifeops.relationships",
   tags: ["lifeops", "I1", "boundary", "no-send", "relationships"],

--- a/plugins/plugin-personal-assistant/test/scenarios/i1-sensitive-event-defer.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/i1-sensitive-event-defer.scenario.ts
@@ -8,7 +8,7 @@ import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
 export default scenario({
   lane: "live-only",
-  id: "i1.rupture_repair.sensitive_event_defer",
+  id: "i1-sensitive-event-defer",
   title: "I1 negative rupture sentiment schedules owner check-in only",
   domain: "lifeops.relationships",
   tags: ["lifeops", "I1", "sentiment", "followup", "relationships"],

--- a/plugins/plugin-personal-assistant/test/scenarios/i1-wrong-recipient-guard.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/i1-wrong-recipient-guard.scenario.ts
@@ -8,7 +8,7 @@ import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
 export default scenario({
   lane: "live-only",
-  id: "i1.rupture_repair.wrong_recipient_guard",
+  id: "i1-wrong-recipient-guard",
   title: "I1 repair context stays off the wrong recipient",
   domain: "lifeops.relationships",
   tags: ["lifeops", "I1", "privacy", "wrong-recipient", "relationships"],

--- a/plugins/plugin-personal-assistant/test/scenarios/i2-conflicting-claims-label-uncertain.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/i2-conflicting-claims-label-uncertain.scenario.ts
@@ -7,7 +7,7 @@ import { judgeRubric } from "../../../../packages/test/scenarios/_helpers/action
 
 export default scenario({
   lane: "live-only",
-  id: "i2.mediation.conflicting_claims_label_uncertain",
+  id: "i2-conflicting-claims-label-uncertain",
   title: "I2 conflicting claims stay uncertain instead of becoming a verdict",
   domain: "lifeops.relationships",
   tags: ["lifeops", "I2", "mediation", "uncertainty", "entity"],

--- a/plugins/plugin-personal-assistant/test/scenarios/i2-consent-before-group-message.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/i2-consent-before-group-message.scenario.ts
@@ -7,7 +7,7 @@ import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
 export default scenario({
   lane: "live-only",
-  id: "i2.mediation.consent_before_group_message",
+  id: "i2-consent-before-group-message",
   title: "I2 neutral drafts stay behind approval for both parties",
   domain: "lifeops.relationships",
   tags: ["lifeops", "I2", "mediation", "approval", "message-draft"],

--- a/plugins/plugin-personal-assistant/test/scenarios/i2-neutral-schedule-options.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/i2-neutral-schedule-options.scenario.ts
@@ -6,7 +6,7 @@ import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
   lane: "live-only",
-  id: "i2.mediation.neutral_schedule_options",
+  id: "i2-neutral-schedule-options",
   title: "I2 disagreement becomes neutral schedule separation options",
   domain: "lifeops.relationships",
   tags: ["lifeops", "I2", "mediation", "calendar", "neutral-logistics"],

--- a/plugins/plugin-personal-assistant/test/scenarios/i2-private-fact-firebreak.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/i2-private-fact-firebreak.scenario.ts
@@ -7,7 +7,7 @@ import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
 export default scenario({
   lane: "live-only",
-  id: "i2.mediation.private_fact_firebreak",
+  id: "i2-private-fact-firebreak",
   title: "I2 confidential thread detail stays out of the other party's draft",
   domain: "lifeops.relationships",
   tags: ["lifeops", "I2", "privacy", "mediation", "message-draft"],

--- a/plugins/plugin-personal-assistant/test/scenarios/k1-boundary-respected.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/k1-boundary-respected.scenario.ts
@@ -8,7 +8,7 @@ import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
 export default scenario({
   lane: "live-only",
-  id: "k1.third_party_support.boundary_respected",
+  id: "k1-boundary-respected",
   title: "K1 friend boundary is respected",
   domain: "lifeops.relationships",
   tags: ["lifeops", "K1", "third-party-support", "boundary", "privacy"],

--- a/plugins/plugin-personal-assistant/test/scenarios/k1-no-988-without-danger.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/k1-no-988-without-danger.scenario.ts
@@ -8,7 +8,7 @@ import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
   lane: "live-only",
-  id: "k1.third_party_support.no_988_without_danger",
+  id: "k1-no-988-without-danger",
   title: "K1 crisis-adjacent friend support does not fabricate a guard",
   domain: "lifeops.relationships",
   tags: ["lifeops", "K1", "third-party-support", "safety-boundary"],

--- a/plugins/plugin-personal-assistant/test/scenarios/k1-no-clinical-claims.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/k1-no-clinical-claims.scenario.ts
@@ -8,7 +8,7 @@ import { judgeRubric } from "../../../../packages/test/scenarios/_helpers/action
 
 export default scenario({
   lane: "live-only",
-  id: "k1.third_party_support.no_clinical_claims",
+  id: "k1-no-clinical-claims",
   title: "K1 sad-friend support stays non-clinical",
   domain: "lifeops.relationships",
   tags: ["lifeops", "K1", "third-party-support", "non-clinical"],

--- a/plugins/plugin-personal-assistant/test/scenarios/k1-owner-approval-before-send.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/k1-owner-approval-before-send.scenario.ts
@@ -7,7 +7,7 @@ import { expectNoExternalSendDispatch } from "./_helpers/approval-outcome.ts";
 
 export default scenario({
   lane: "live-only",
-  id: "k1.third_party_support.owner_approval_before_send",
+  id: "k1-owner-approval-before-send",
   title: "K1 supportive friend draft waits for owner approval",
   domain: "lifeops.relationships",
   tags: ["lifeops", "K1", "third-party-support", "approval", "message-draft"],

--- a/plugins/plugin-personal-assistant/test/scenarios/k1-summarize-context-without-gossip.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/k1-summarize-context-without-gossip.scenario.ts
@@ -6,7 +6,7 @@ import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
   lane: "live-only",
-  id: "k1.third_party_support.summarize_context_without_gossip",
+  id: "k1-summarize-context-without-gossip",
   title: "K1 friend disclosure summary avoids gossip",
   domain: "lifeops.relationships",
   tags: ["lifeops", "K1", "third-party-support", "privacy"],

--- a/plugins/plugin-personal-assistant/test/scenarios/traveler-timezone-absolute-instant-flight-boarding.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/traveler-timezone-absolute-instant-flight-boarding.scenario.ts
@@ -2,7 +2,7 @@ import { scenario } from "@elizaos/scenario-runner/schema";
 
 export default scenario({
   lane: "live-only",
-  id: "traveler.timezone.absolute-instant-flight-boarding",
+  id: "traveler-timezone-absolute-instant-flight-boarding",
   title:
     "Traveler: absolute-instant reminder survives a timezone-change signal",
   domain: "executive.travel",

--- a/plugins/plugin-personal-assistant/test/signature-deadline-scheduler.test.ts
+++ b/plugins/plugin-personal-assistant/test/signature-deadline-scheduler.test.ts
@@ -105,27 +105,84 @@ describe("signature deadline scheduler", () => {
       },
     });
 
-    const result = await processDueScheduledTasks({
+    const repo = new LifeOpsRepository(runtime);
+
+    // First completion timeout does NOT skip: the no-reply retry ladder
+    // (#14459/#15055/#12284) snoozes the reminder for one 60-minute retry
+    // (`reminder` default policy: maxRetries 1, cadence [60], terminal skip →
+    // `no_reply_reminder_expired`) before giving up. `onSkip` only runs on the
+    // TERMINAL skip, so the SMS escalation is deferred until the ladder is
+    // exhausted — it is not scheduled on this first tick.
+    const firstTick = await processDueScheduledTasks({
       runtime,
       agentId: runtime.agentId,
       now: tickAt,
       limit: 5,
     });
 
-    expect(result.errors).toEqual([]);
-    expect(result.completionTimeouts).toEqual([
+    expect(firstTick.errors).toEqual([]);
+    expect(firstTick.completionTimeouts).toEqual([
       {
         taskId: seed.taskId,
-        status: "skipped",
-        reason: "completion_timeout_due",
+        status: "scheduled",
+        reason: "no_reply_retry_1",
         occurrenceAtIso: "2026-05-09T12:00:00.000Z",
       },
     ]);
+    const afterRetry = await repo.getScheduledTask(
+      runtime.agentId,
+      seed.taskId,
+    );
+    expect(afterRetry?.state.status).toBe("scheduled");
+    expect(afterRetry?.state.lastDecisionLog).toBe(
+      "no_reply_retry_1: completion_timeout_due",
+    );
+    expect(
+      (
+        await repo.listScheduledTasks(runtime.agentId, {
+          status: ["scheduled"],
+          subjectKind: "document",
+          subjectId: "doc_nda_123",
+        })
+      ).find((task) => task.state.pipelineParentId === seed.taskId),
+    ).toBeUndefined();
 
-    const repo = new LifeOpsRepository(runtime);
+    // The snooze re-fires the reminder at the retry instant (60 min later), so
+    // it is `fired` again and its completion window restarts.
+    const refireAt = new Date("2026-05-09T13:01:30.000Z");
+    await processDueScheduledTasks({
+      runtime,
+      agentId: runtime.agentId,
+      now: refireAt,
+      limit: 5,
+    });
+    const refired = await repo.getScheduledTask(runtime.agentId, seed.taskId);
+    expect(refired?.state.status).toBe("fired");
+
+    // Second completion timeout (240 min past the re-fire) exhausts the ladder:
+    // retryCount now equals maxRetries, so the reminder terminally skips and the
+    // `onSkip` SMS escalation follow-up is finally scheduled.
+    const terminalTick = new Date("2026-05-09T17:05:00.000Z");
+    const finalResult = await processDueScheduledTasks({
+      runtime,
+      agentId: runtime.agentId,
+      now: terminalTick,
+      limit: 5,
+    });
+
+    expect(finalResult.errors).toEqual([]);
+    expect(finalResult.completionTimeouts).toEqual([
+      {
+        taskId: seed.taskId,
+        status: "skipped",
+        reason: "no_reply_reminder_expired",
+        occurrenceAtIso: "2026-05-09T17:01:30.000Z",
+      },
+    ]);
+
     const parent = await repo.getScheduledTask(runtime.agentId, seed.taskId);
     expect(parent?.state.status).toBe("skipped");
-    expect(parent?.state.lastDecisionLog).toBe("completion_timeout_due");
+    expect(parent?.state.lastDecisionLog).toBe("no_reply_reminder_expired");
 
     const tasks = await repo.listScheduledTasks(runtime.agentId, {
       status: ["scheduled"],

--- a/plugins/plugin-personal-assistant/vitest.config.ts
+++ b/plugins/plugin-personal-assistant/vitest.config.ts
@@ -588,6 +588,25 @@ export default defineConfig({
           "index.ts",
         ),
       },
+      // The scenario-corpus gate dynamically imports every scenario file, and the
+      // first-run onboarding helper (test/scenarios/_helpers/first-run-onboarding.ts)
+      // pulls PA's OWN deep modules through the package specifier
+      // (`@elizaos/plugin-personal-assistant/lifeops/first-run/*`). PA is not in
+      // build:core and this lane has no eliza-source condition, so the package
+      // `exports` `./*` wildcard would send those subpaths to a `./dist/*.js` that
+      // never gets built. Anchor PA self-subpaths to source (the base workspace-app
+      // config only source-aliases the barrel, and the exports-alias builder skips
+      // the wildcard entry).
+      {
+        find: /^@elizaos\/plugin-personal-assistant\/(.+)$/,
+        replacement: path.join(
+          elizaRoot,
+          "plugins",
+          "plugin-personal-assistant",
+          "src",
+          "$1.ts",
+        ),
+      },
       // The scenario-corpus gate (test/executive-assistant-scenarios.test.ts)
       // imports the real scenario loader from source; loader.ts references its
       // own package via `@elizaos/scenario-runner/schema`, a self-referencing
@@ -700,6 +719,23 @@ export default defineConfig({
           "plugin-elizacloud",
           "src",
           "cloud",
+          "$1.ts",
+        ),
+      },
+      // PA's barrel re-exports the travel-provider relay route from
+      // `@elizaos/plugin-elizacloud/routes/*`. elizacloud is stubbed at the
+      // barrel and not in build:core, so — exactly like the `/cloud/` subpath
+      // above — this deep subpath must be anchored to source; without it the
+      // package `exports` map sends it to a `./dist/*.js` that never gets built
+      // in this lane.
+      {
+        find: /^@elizaos\/plugin-elizacloud\/routes\/(.+)$/,
+        replacement: path.join(
+          elizaRoot,
+          "plugins",
+          "plugin-elizacloud",
+          "src",
+          "routes",
           "$1.ts",
         ),
       },


### PR DESCRIPTION
Resolves the five remaining `@elizaos/plugin-personal-assistant` **Client Tests** failure clusters left after #15321 (which fixed 4 areas and root-caused these 5). All five test files are green, plus the catalog/scenario-consuming benchmark tests.

Reproduced against a CI-equivalent tree (`bun run build:core` first, as `test:client` does) — several first-seen errors were unbuilt-worktree artifacts (elizacloud/app-core dist resolve the subpaths in CI); the fixes below target the *real* failures.

## Per-cluster root cause + fix + determination

**1. `test/inbox-action.test.ts` (9)** — *test-harness fix.* The INBOX action moved to core's fail-closed `hasRoleAccess(runtime, message, "OWNER")` (#14931); the old `@elizaos/agent` `hasOwnerAccess` mock is dead, so every call hit `PERMISSION_DENIED`. Register the canonical owner in the harness (`getSetting("ELIZA_ADMIN_ENTITY_ID")` + owner-matching `entityId`, mirroring #14931's own tests) and exercise the deny path with a real non-owner connector sender. Removed the dead agent mock.

**2. `test/executive-assistant-scenarios.test.ts` (4)** — *test-lane resolution + real corpus-hygiene bugs.* Two layers:
- Anchor `@elizaos/plugin-elizacloud/routes/*` and PA self-subpaths (`@elizaos/plugin-personal-assistant/lifeops/first-run/*`, pulled by the first-run onboarding scenario helper) to source in the PA vitest config — mirrors the existing `/cloud/*` alias. Neither package is in `build:core` and the lane has no `eliza-source` condition, so the `./*` export sent them to unbuilt `./dist/*.js`.
- Once the corpus loaded, the documented invariant `basename === ${scenario.id}.scenario.ts` caught **33** mismatched ids: the g/h/i/k packs (#15062 et al.) + `comms-flood.injection` / `traveler.timezone` were authored with scenario-runner-style dotted ids while the assertion was masked by the collection-time import break. Normalized ids to their kebab filenames (matching each pack's sibling + catalog convention) and updated the `_catalogs/*.json` tracking entries in lockstep. Dotted ids were referenced nowhere else.

**3. `reminders-service.process-scheduled-work.test.ts` (5)** — *mock gap.* The `travel_reconcile` subsystem reads the owner fact store, which narrows the runtime to `RuntimeCacheLike` (`getCache`/`setCache`/`deleteCache`). Added them to the mock runtime → reconcile no-ops on an empty store instead of `cache.getCache is not a function`.

**4. `BlockerSettingsCards.test.tsx` (2)** — *mock gap (same class as #15317).* `AppBlockerSettingsCard` now renders `<Input>` from `@elizaos/ui`; added a prop-forwarding `Input` to the `vi.mock` so both the search box and the checkbox inputs render.

**5. `signature-deadline-scheduler.test.ts` (1)** — *intentional behavior change, not a regression.* The no-reply retry ladder (#14459/#15055/#12284) snoozes a `reminder`'s completion timeout for one 60-min retry (`no_reply_retry_1`, status `scheduled`) before the terminal skip (`no_reply_reminder_expired`); `onSkip` — and thus the SMS escalation — fires only on that terminal skip. Rewrote the test to drive the real ladder to terminal (snooze → re-fire → terminal skip) and assert the escalation still schedules. Confirmed against the same ladder the integration-scheduler lane exercises.

## Validation
- All 5 target files green (27 tests) run together against the built tree; benchmark/activation tests (catalog consumers) still green.
- `biome check` clean on all touched files; `audit:error-policy-ratchet` clean (0 production source files touched — all changes are test/config/scenario/catalog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)