### PR TITLE
fix(ci): green the @elizaos/plugin-training Client Tests lane

### DIFF
--- a/plugins/plugin-training/src/core/lifeops-judge-scorer.test.ts
+++ b/plugins/plugin-training/src/core/lifeops-judge-scorer.test.ts
@@ -37,8 +37,9 @@ function clientReturning(
 }
 
 describe("LIFEOPS_JUDGE_TASKS", () => {
-  it("names exactly the four prose/NL capabilities", () => {
+  it("names exactly the five prose/NL capabilities", () => {
     expect([...LIFEOPS_JUDGE_TASKS].sort()).toEqual([
+      "creative_draft",
       "meeting_prep",
       "morning_brief",
       "reminder_dispatch",

--- a/plugins/plugin-training/src/core/lifeops-judge-scorer.ts
+++ b/plugins/plugin-training/src/core/lifeops-judge-scorer.ts
@@ -1,7 +1,7 @@
 // Judge-based scorer for the prose/NL LifeOps optimization tasks (#11384).
 //
-// Four of the eight LifeOps capabilities emit narrative text
-// (reminder_dispatch, meeting_prep, morning_brief) or a prose-bearing JSON
+// Five of the LifeOps capabilities emit narrative text (reminder_dispatch,
+// meeting_prep, morning_brief, creative_draft) or a prose-bearing JSON
 // envelope (screentime_recap). The deterministic scorers in
 // `optimizers/scoring.ts` (exact structured-field match / token overlap)
 // return ~0 for any live completion of those tasks, so GEPA has no gradient
@@ -21,6 +21,7 @@ export const LIFEOPS_JUDGE_TASKS: ReadonlySet<string> = new Set([
   "meeting_prep",
   "morning_brief",
   "screentime_recap",
+  "creative_draft",
 ]);
 
 /**

--- a/plugins/plugin-training/src/core/training-orchestrator.ts
+++ b/plugins/plugin-training/src/core/training-orchestrator.ts
@@ -391,6 +391,22 @@ rules:
 return:
 JSON object only: { recap, topApps: [{ app, minutes }], suggestion }.`;
 
+const CREATIVE_DRAFT_BASELINE = `task: Draft in the owner's voice from the supplied memos and style card.
+
+memos:
+{{memos}}
+
+styleCard:
+{{styleCard}}
+
+rules:
+- preserve each memo's argument and affect; map an affect directive to the matching section instead of smoothing it away
+- sound like the owner on a good day, not like a consultant
+- revise the standing draft artifact when one is supplied; keep accepted edits and never reintroduce vetoed phrasing
+
+return:
+Narrative text only, unless the caller requested a structured outline.`;
+
 function defaultBaselineForTask(task: TrajectoryTrainingTask): string {
   switch (task) {
     case "should_respond":
@@ -421,6 +437,8 @@ function defaultBaselineForTask(task: TrajectoryTrainingTask): string {
       return HEALTH_CHECKIN_BASELINE;
     case "screentime_recap":
       return SCREENTIME_RECAP_BASELINE;
+    case "creative_draft":
+      return CREATIVE_DRAFT_BASELINE;
   }
 }
 
@@ -528,6 +546,12 @@ async function loadLiveLifeOpsBaseline(
         ["SCREENTIME_RECAP_INSTRUCTIONS"],
         "../../../plugin-health/src/actions/optimized-prompt-instructions.ts",
       );
+    case "creative_draft":
+      return loadFirstStringExport(
+        "@elizaos/plugin-personal-assistant/lifeops/creative-draft",
+        ["CREATIVE_DRAFT_INSTRUCTIONS"],
+        "../../../plugin-personal-assistant/src/lifeops/creative-draft/index.ts",
+      );
     default:
       return null;
   }
@@ -566,6 +590,8 @@ function pathForTask(
       return paths.healthCheckinPath;
     case "screentime_recap":
       return paths.screentimeRecapPath;
+    case "creative_draft":
+      return paths.creativeDraftPath;
   }
 }
 
@@ -744,7 +770,8 @@ export async function loadBaselineForTask(
     case "meeting_prep":
     case "morning_brief":
     case "health_checkin":
-    case "screentime_recap": {
+    case "screentime_recap":
+    case "creative_draft": {
       const liveBaseline = await loadLiveLifeOpsBaseline(task);
       return liveBaseline ?? defaultBaselineForTask(task);
     }

--- a/plugins/plugin-training/src/core/trajectory-export-bundle.ts
+++ b/plugins/plugin-training/src/core/trajectory-export-bundle.ts
@@ -145,6 +145,7 @@ function taskPathMap(
     morning_brief: paths.morningBriefPath,
     health_checkin: paths.healthCheckinPath,
     screentime_recap: paths.screentimeRecapPath,
+    creative_draft: paths.creativeDraftPath,
   };
 }
 

--- a/plugins/plugin-training/src/core/trajectory-quality-review.ts
+++ b/plugins/plugin-training/src/core/trajectory-quality-review.ts
@@ -42,6 +42,8 @@ export const LIFEOPS_QUALITY_RUBRICS: Record<LifeOpsTrainingTask, string> = {
     "The output is an appropriate health/sleep check-in for the input data: grounded in the numbers provided, empathetic but direct, with at most small actionable suggestions and no medical overreach.",
   screentime_recap:
     "The output accurately recaps the screen-time data in the input and proposes a proportionate focus adjustment. Numbers match the input; recommendations follow from them.",
+  creative_draft:
+    "The output drafts in the owner's voice from the supplied memos and style card: it preserves each memo's argument and affect, sounds like the owner rather than a consultant, respects any standing draft's accepted/vetoed edits, and invents no claims the memos do not support.",
 };
 
 /** One sampled model-boundary call queued for judging. */

--- a/plugins/plugin-training/src/core/trajectory-task-datasets.lifeops.test.ts
+++ b/plugins/plugin-training/src/core/trajectory-task-datasets.lifeops.test.ts
@@ -99,6 +99,6 @@ describe("LifeOps trajectory task datasets", () => {
     for (const task of LIFEOPS_TRAINING_TASKS) {
       expect(ALL_TRAJECTORY_TRAINING_TASKS).toContain(task);
     }
-    expect(ALL_TRAJECTORY_TRAINING_TASKS).toHaveLength(14);
+    expect(ALL_TRAJECTORY_TRAINING_TASKS).toHaveLength(15);
   });
 });

--- a/plugins/plugin-training/src/core/trajectory-task-datasets.ts
+++ b/plugins/plugin-training/src/core/trajectory-task-datasets.ts
@@ -50,6 +50,7 @@ export const ALL_TRAJECTORY_TRAINING_TASKS = [
   "morning_brief",
   "health_checkin",
   "screentime_recap",
+  "creative_draft",
 ] as const;
 
 export type TrajectoryTrainingTask =
@@ -65,6 +66,7 @@ export const LIFEOPS_TRAINING_TASKS = [
   "morning_brief",
   "health_checkin",
   "screentime_recap",
+  "creative_draft",
 ] as const satisfies readonly TrajectoryTrainingTask[];
 
 export type LifeOpsTrainingTask = (typeof LIFEOPS_TRAINING_TASKS)[number];
@@ -95,6 +97,7 @@ export interface TrajectoryTaskDatasetPaths {
   morningBriefPath: string;
   healthCheckinPath: string;
   screentimeRecapPath: string;
+  creativeDraftPath: string;
   summaryPath: string;
 }
 
@@ -147,6 +150,7 @@ const TASK_FILE_NAMES: Record<TrajectoryTrainingTask, string> = {
   morning_brief: "morning_brief_trajectories.jsonl",
   health_checkin: "health_checkin_trajectories.jsonl",
   screentime_recap: "screentime_recap_trajectories.jsonl",
+  creative_draft: "creative_draft_trajectories.jsonl",
 };
 
 const NATIVE_MODEL_BOUNDARIES = new Set<string>(ELIZA_NATIVE_MODEL_BOUNDARIES);
@@ -761,6 +765,7 @@ export async function exportTrajectoryTaskDatasets(
     morningBriefPath: join(outputDir, TASK_FILE_NAMES.morning_brief),
     healthCheckinPath: join(outputDir, TASK_FILE_NAMES.health_checkin),
     screentimeRecapPath: join(outputDir, TASK_FILE_NAMES.screentime_recap),
+    creativeDraftPath: join(outputDir, TASK_FILE_NAMES.creative_draft),
     summaryPath: join(outputDir, "trajectory_dataset_summary.json"),
   };
   const summary: TrajectoryTaskDatasetSummary = {

--- a/plugins/plugin-training/src/dspy/artifact.ts
+++ b/plugins/plugin-training/src/dspy/artifact.ts
@@ -28,6 +28,7 @@ export type DspyArtifactTask =
   | "morning_brief"
   | "health_checkin"
   | "screentime_recap"
+  | "creative_draft"
   | "action_descriptions"
   | "autonomy";
 

--- a/plugins/plugin-training/src/optimizers/scoring.ts
+++ b/plugins/plugin-training/src/optimizers/scoring.ts
@@ -308,6 +308,7 @@ export const LIFEOPS_SCORER_TASKS = [
   "morning_brief",
   "health_checkin",
   "screentime_recap",
+  "creative_draft",
 ] as const;
 
 /** LifeOps tasks whose output is a structured JSON object (exact-field match). */

--- a/plugins/plugin-training/vitest.config.ts
+++ b/plugins/plugin-training/vitest.config.ts
@@ -103,6 +103,16 @@ export default defineConfig({
         find: /^@elizaos\/agent\/(.+)$/,
         replacement: path.join(agentSrc, "$1"),
       },
+      // Production code (core/cerebras-eval-model.ts) imports the shared
+      // CerebrasJudge from scenario-runner's `cerebras-judge` subpath; the test
+      // lane never builds scenario-runner's dist, so resolve it to source.
+      {
+        find: /^@elizaos\/scenario-runner\/cerebras-judge$/,
+        replacement: path.join(
+          repoRoot,
+          "packages/scenario-runner/src/cerebras-judge.ts",
+        ),
+      },
       {
         find: /^react-syntax-highlighter\/dist\/esm\/languages\/prism\/.+$/,
         replacement: path.join(


### PR DESCRIPTION
## Summary

The **Tests → Client Tests** lane was red on develop for `@elizaos/plugin-training`. Two failures, both fixed at the correct layer (no gate weakened).

### Failure inventory + per-item root cause

| # | Failing test | Root cause | Fix |
|---|---|---|---|
| 1 | `src/scripts/lifeops-gepa-seed.test.ts` — **suite fails to load**: `Cannot find package '@elizaos/scenario-runner/cerebras-judge'` | Production `core/cerebras-eval-model.ts` imports the `@elizaos/scenario-runner/cerebras-judge` subpath (a #14459-extracted shared judge). The test lane never builds scenario-runner's `dist`, and there was no source alias for that subpath. | Add a `@elizaos/scenario-runner/cerebras-judge → packages/scenario-runner/src/cerebras-judge.ts` source alias in the plugin's `vitest.config.ts` (harness gap, matches the existing scenario-runner/schema alias pattern). |
| 2 | `src/services/training-trigger.test.ts > bootstrap task set > includes every LifeOps capability from @elizaos/core` — `expected […] to include 'creative_draft'` | **Real product gap.** #15099 added `creative_draft` to core's `LIFEOPS_OPTIMIZED_PROMPT_TASKS` (with a live PA runtime consumer) but never extended plugin-training's trajectory-training taxonomy, so `BOOTSTRAP_TASKS`'s `TRAINING_TASK_SET` filter silently dropped it. The gate exists to force training-side integration when core adds a capability. | Integrate `creative_draft` end-to-end as a **judge-scored prose** training task. |

### `creative_draft` integration (item 2)

Added `creative_draft` across the training taxonomy so the mirror invariant holds:
- `ALL_TRAJECTORY_TRAINING_TASKS` + `LIFEOPS_TRAINING_TASKS`, the dataset `TASK_FILE_NAMES` + `TrajectoryTaskDatasetPaths` (`creativeDraftPath`) + path construction.
- `training-orchestrator`: `CREATIVE_DRAFT_BASELINE`, the default-baseline / live-instruction-loader (`CREATIVE_DRAFT_INSTRUCTIONS` from PA) / `pathForTask` switches.
- `optimizers/scoring` `LIFEOPS_SCORER_TASKS` (prose → **not** structured), `lifeops-judge-scorer` `LIFEOPS_JUDGE_TASKS`, `dspy/artifact` task union, `trajectory-export-bundle`, `trajectory-quality-review` rubric.
- Bumped the pinned assertions this widens: `ALL_TRAJECTORY_TRAINING_TASKS` length 14→15, `LIFEOPS_JUDGE_TASKS` "four"→"five".

### Evidence

Before: `1 failed | 381 passed (382)` + 1 failed suite.
After: **`Test Files 59 passed (59)` / `Tests 397 passed (397)`** (`bun run --cwd plugins/plugin-training test`), on the latest develop base. `bun run --cwd plugins/plugin-training typecheck` (turbo, 66 tasks) clean; biome + error-policy ratchet clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)