### PR TITLE
fix(ci): green the @elizaos/app Client Tests coverage/gate lanes

### DIFF
--- a/packages/app/docs/LAUNCHER_INTERACTION_MATRIX.md
+++ b/packages/app/docs/LAUNCHER_INTERACTION_MATRIX.md
@@ -107,14 +107,16 @@ covered per-lane here.
 
 ## Gesture-handler source sites
 
-Every home↔launcher gesture originates in one of these two `packages/ui/src`
-handlers. The enforcement gate requires each to be mapped here — a new launcher
+Every home↔launcher gesture originates in the rail pager engine and its surface;
+a companion store carries the live "mid-gesture" signal the pager arms. The
+enforcement gate requires each source site to be mapped here — a new launcher
 gesture handler must land with its row.
 
 | Source site | Drives | Rows |
 |---|---|---|
 | `packages/ui/src/hooks/useHorizontalPager.ts` | The rail pager pointer-capture drag/flick engine | 1–8 |
 | `packages/ui/src/components/shell/HomeLauncherSurface.tsx` | Rail composition, inert/focus management, edge buttons | 1–10, 17–20 |
+| `packages/ui/src/state/rail-gesture-store.ts` | Live "rail is mid-gesture" freeze signal armed at the pager's rail-promotion window (`armRailPromotion`) and released on settle/axis-commit/unmount, so render work parks until the swipe settles | 1–8 |
 
 Tap-to-launch (rows 11–13) is a plain `onClick` on the launcher grid
 (`packages/ui/src/components/pages/Launcher.tsx`), not a pointer/touch gesture,

--- a/packages/app/src/plugin-registrations.test.ts
+++ b/packages/app/src/plugin-registrations.test.ts
@@ -33,7 +33,6 @@ const EXPECTED_SIDE_EFFECT_PACKAGES = [
   "@elizaos/plugin-native-settings",
   "@elizaos/plugin-phone",
   "@elizaos/plugin-polymarket",
-  "@elizaos/plugin-shopify",
   "@elizaos/plugin-trajectory-logger",
   "@elizaos/plugin-vector-browser",
   "@elizaos/plugin-wallet-ui",

--- a/packages/app/test/core-view-action-surface-coverage.test.ts
+++ b/packages/app/test/core-view-action-surface-coverage.test.ts
@@ -26,9 +26,10 @@ const CORE_SURFACE_OWNERS: Readonly<Record<string, CoreSurfaceOwner>> = {
   knowledge: {
     viewId: "documents",
     provider: "shell",
+    // The /documents route is KnowledgeView (the shell-agent-surface host) which
+    // mounts the standalone DocumentsView + its upload controls (#13594).
     files: [
-      "packages/ui/src/components/character/CharacterEditor.tsx",
-      "packages/ui/src/components/character/CharacterHubView.tsx",
+      "packages/ui/src/components/pages/KnowledgeView.tsx",
       "packages/ui/src/components/pages/DocumentsView.tsx",
       "packages/ui/src/components/pages/documents-upload.tsx",
     ],
@@ -66,9 +67,12 @@ const CORE_SURFACE_OWNERS: Readonly<Record<string, CoreSurfaceOwner>> = {
   automations: {
     viewId: "automations",
     provider: "shell",
+    // The feed has no create CTA by design (#13597 — the agent re-creates a
+    // workflow from chat instead), so its agent-addressable controls are the
+    // filter tabs, per-row open, and per-row run-workflow.
     files: ["packages/ui/src/components/pages/AutomationsFeed.tsx"],
-    minAgentElements: 4,
-    requiredSnippets: ["action-new", "run-workflow-"],
+    minAgentElements: 3,
+    requiredSnippets: ["run-workflow-"],
   },
   orchestrator: {
     viewId: "orchestrator",
@@ -159,6 +163,9 @@ const CORE_SURFACE_OWNERS: Readonly<Record<string, CoreSurfaceOwner>> = {
   },
 };
 
+// Keyed and ordered to mirror the canonical SETTINGS_SECTION_META (the
+// `settings subsection agent-surface coverage` gate asserts the keys equal
+// REQUIRED_SETTINGS_SECTION_IDS, which itself tracks that meta).
 const SETTINGS_SECTION_OWNER_FILES: Readonly<
   Record<string, readonly string[]>
 > = {
@@ -175,7 +182,6 @@ const SETTINGS_SECTION_OWNER_FILES: Readonly<
   capabilities: ["packages/ui/src/components/settings/CapabilitiesSection.tsx"],
   apps: ["packages/ui/src/components/settings/AppsManagementSection.tsx"],
   connectors: ["packages/ui/src/components/settings/ConnectorsSection.tsx"],
-  runtime: ["packages/ui/src/components/settings/RuntimeSettingsSection.tsx"],
   appearance: [
     "packages/ui/src/components/settings/AppearanceSettingsSection.tsx",
   ],
@@ -183,27 +189,31 @@ const SETTINGS_SECTION_OWNER_FILES: Readonly<
     "packages/ui/src/components/settings/BackgroundSettingsSection.tsx",
     "packages/ui/src/components/settings/BackgroundSettingsControls.tsx",
   ],
-  "remote-plugins": [
-    "packages/ui/src/components/settings/RemotePluginHostSection.tsx",
+  notifications: [
+    "packages/ui/src/components/settings/WebPushSettingsSection.tsx",
   ],
+  runtime: ["packages/ui/src/components/settings/RuntimeSettingsSection.tsx"],
   "wallet-rpc": [
     "packages/ui/src/components/settings/WalletRpcSection.tsx",
     "packages/ui/src/components/settings/WalletKeysSection.tsx",
     "packages/ui/src/components/pages/ConfigPageView.tsx",
   ],
+  "remote-plugins": [
+    "packages/ui/src/components/settings/RemotePluginHostSection.tsx",
+  ],
   updates: ["packages/ui/src/components/pages/ReleaseCenterView.tsx"],
   advanced: ["packages/ui/src/components/settings/AdvancedSection.tsx"],
-  "app-permissions": [
-    "packages/ui/src/components/settings/AppPermissionsSection.tsx",
+  secrets: [
+    "packages/ui/src/components/settings/SecretsManagerSection.tsx",
+    "packages/ui/src/components/settings/settings-agent-rows.tsx",
+    "packages/ui/src/components/settings/VaultInventoryPanel.tsx",
   ],
   permissions: [
     "packages/ui/src/components/settings/PermissionsSection.tsx",
     "packages/ui/src/components/settings/permission-controls.tsx",
   ],
-  secrets: [
-    "packages/ui/src/components/settings/SecretsManagerSection.tsx",
-    "packages/ui/src/components/settings/settings-agent-rows.tsx",
-    "packages/ui/src/components/settings/VaultInventoryPanel.tsx",
+  "app-permissions": [
+    "packages/ui/src/components/settings/AppPermissionsSection.tsx",
   ],
   security: ["packages/ui/src/components/settings/SecuritySettingsSection.tsx"],
 };

--- a/packages/app/test/external-api-mock-validation.test.ts
+++ b/packages/app/test/external-api-mock-validation.test.ts
@@ -63,10 +63,10 @@ const VALIDATED: Readonly<
  * CONTRACT_TESTED — a recorded-real contract test only (the parser is proven
  * against a captured real response; no live-drift test yet). Maps each api to its
  * specific contract test file. Promote to VALIDATED by adding a live-drift test.
+ * Empty for now (plugin-shopify was removed from the workspace); a newly
+ * contract-tested API is added here.
  */
-const CONTRACT_TESTED: Readonly<Record<string, string>> = {
-  shopify: "plugins/plugin-shopify/src/routes.contract.test.ts",
-};
+const CONTRACT_TESTED: Readonly<Record<string, string>> = {};
 
 /**
  * UNVALIDATED — inline fixtures only, no recorded-real tie. RATCHET: this set may

--- a/packages/app/test/hmr-coverage.test.ts
+++ b/packages/app/test/hmr-coverage.test.ts
@@ -19,11 +19,12 @@ const DEV_SMOKE_WORKFLOW = path.join(
 const ROOT_PACKAGE_JSON = path.join(REPO_ROOT, "package.json");
 const APP_PACKAGE_JSON = path.join(REPO_ROOT, "packages/app/package.json");
 
-const EXPECTED_NON_WORKSPACE_HMR_PROBES = new Set([
-  "shopify plugins/plugin-shopify/src/ShopifyView.tsx",
-  "social-alpha plugins/plugin-social-alpha/src/frontend/SocialAlphaView.tsx",
-  "trajectory-logger plugins/plugin-trajectory-logger/src/components/TrajectoryLoggerView.tsx",
-]);
+// Documented non-workspace HMR probes: entries whose source file lives outside
+// the workspace tree (so `probePathExists` legitimately fails) but that stay in
+// the matrix. Empty now — the shopify + social-alpha plugin views were removed
+// from the workspace (their probe levels dropped with them), and
+// plugin-trajectory-logger's view source is back in the workspace tree.
+const EXPECTED_NON_WORKSPACE_HMR_PROBES = new Set<string>([]);
 
 type GuiViewCase = {
   id: string;

--- a/packages/app/test/hmr/hmr-dependency-levels.spec.ts
+++ b/packages/app/test/hmr/hmr-dependency-levels.spec.ts
@@ -38,6 +38,12 @@ const LEVELS = [
     file: "plugins/plugin-contacts/src/components/ContactsAppView.tsx",
   },
   {
+    // The /cloud launcher view (Eliza Cloud account at a glance), served as
+    // plugin-elizacloud's `cloud` view bundle and mounted by DynamicViewLoader.
+    name: "plugin view cloud",
+    file: "plugins/plugin-elizacloud/src/components/cloud/CloudView.tsx",
+  },
+  {
     // Developer-only coding cockpit (/cockpit). CockpitRoute is the plugin-side
     // view container (wires the presentational @elizaos/ui CockpitView to the
     // live orchestrator client), so it is the source guaranteed in the view graph.
@@ -105,10 +111,6 @@ const LEVELS = [
     file: "plugins/plugin-polymarket/src/PolymarketView.tsx",
   },
   {
-    name: "plugin view shopify",
-    file: "plugins/plugin-shopify/src/ShopifyView.tsx",
-  },
-  {
     name: "plugin view wallet",
     file: "plugins/plugin-wallet-ui/src/InventoryView.tsx",
   },
@@ -127,10 +129,6 @@ const LEVELS = [
   {
     name: "plugin view screenshare",
     file: "plugins/plugin-screenshare/src/components/ScreenshareView.tsx",
-  },
-  {
-    name: "plugin view social alpha",
-    file: "plugins/plugin-social-alpha/src/frontend/SocialAlphaView.tsx",
   },
   {
     name: "plugin view task coordinator",

--- a/packages/app/test/launcher-interaction-matrix.test.ts
+++ b/packages/app/test/launcher-interaction-matrix.test.ts
@@ -94,6 +94,7 @@ function discoverLauncherGestureSites(): string[] {
 const PINNED_LAUNCHER_GESTURE_SITES: readonly string[] = [
   "packages/ui/src/components/shell/HomeLauncherSurface.tsx",
   "packages/ui/src/hooks/useHorizontalPager.ts",
+  "packages/ui/src/state/rail-gesture-store.ts",
 ];
 
 describe("launcher interaction matrix gate", () => {

--- a/packages/app/test/ui-smoke/view-switching-core-matrix.ts
+++ b/packages/app/test/ui-smoke/view-switching-core-matrix.ts
@@ -34,6 +34,9 @@ export const REQUIRED_CORE_VIEW_IDS = [
   "trajectories",
 ] as const;
 
+// Mirrors the canonical `SETTINGS_SECTION_META` order (id + group ordering is the
+// single source of truth in packages/ui/src/components/settings/settings-section-meta.ts).
+// Kept in lockstep with it — the view-switching coverage gate asserts equality.
 export const REQUIRED_SETTINGS_SECTION_IDS = [
   "identity",
   "ai-model",
@@ -41,16 +44,17 @@ export const REQUIRED_SETTINGS_SECTION_IDS = [
   "capabilities",
   "apps",
   "connectors",
-  "runtime",
   "appearance",
   "background",
-  "remote-plugins",
+  "notifications",
+  "runtime",
   "wallet-rpc",
+  "remote-plugins",
   "updates",
   "advanced",
-  "app-permissions",
-  "permissions",
   "secrets",
+  "permissions",
+  "app-permissions",
   "security",
 ] as const;
 

--- a/packages/ui/src/components/settings/WebPushSettingsSection.tsx
+++ b/packages/ui/src/components/settings/WebPushSettingsSection.tsx
@@ -9,6 +9,7 @@
 
 import { BellRing } from "lucide-react";
 import { useCallback } from "react";
+import { useAgentElement } from "../../agent-surface";
 import { useWebPush } from "../../state/notifications/useWebPush";
 import { Switch } from "../ui/switch";
 import { SettingsGroup, SettingsRow, SettingsStack } from "./settings-layout";
@@ -76,6 +77,19 @@ export function WebPushSettingsSection() {
     [subscribe, unsubscribe],
   );
 
+  // Agent-addressable so "turn on notifications" reaches the toggle from chat +
+  // voice, like every other settings control.
+  const { ref, agentProps } = useAgentElement<HTMLButtonElement>({
+    id: "notifications-push-toggle",
+    role: "toggle",
+    label: view.label,
+    group: "settings",
+    status: view.canToggle ? (view.on ? "on" : "off") : "unavailable",
+    onActivate: () => {
+      if (view.canToggle && !busy && ready) onToggle(!view.on);
+    },
+  });
+
   return (
     <SettingsStack>
       <SettingsGroup title="Notifications">
@@ -85,10 +99,12 @@ export function WebPushSettingsSection() {
           description={error ?? view.description}
           control={
             <Switch
+              ref={ref}
               checked={view.on}
               disabled={!view.canToggle || busy || !ready}
               onCheckedChange={onToggle}
               aria-label="Toggle push notifications"
+              {...agentProps}
             />
           }
         />


### PR DESCRIPTION
## Summary

The **Tests → Client Tests** lane was red on develop for `@elizaos/app` — **9 assertions across 6 launch-QA coverage/gate files**, all post-#14459 product drift where a shipped product change never propagated to its pinned gate. Each is realigned to product truth; **no gate weakened**.

### Failure inventory + per-item root cause

| # | Failing assertion | Root cause | Fix |
|---|---|---|---|
| 1 | `plugin-registrations.test.ts` > discovers every plugin that self-declares `elizaos.appRegister` | `@elizaos/plugin-shopify` pinned but removed from the workspace | Drop shopify from `EXPECTED_SIDE_EFFECT_PACKAGES` |
| 2 | `external-api-mock-validation.test.ts` > every contract-tested API keeps its recorded-contract test | Same — shopify's contract test is gone with the plugin | Empty `CONTRACT_TESTED` (shopify removed) |
| 3 | `hmr-coverage.test.ts` > keeps the HMR source-probe matrix in lockstep with every GUI view | `cloud /cloud` GUI view (plugin-elizacloud) had no HMR probe; shopify + social-alpha probes were stale (views removed); trajectory-logger's source is back in-tree | Add the cloud probe, drop the shopify+social-alpha probe levels, empty `EXPECTED_NON_WORKSPACE_HMR_PROBES` |
| 4–5 | `launcher-interaction-matrix.test.ts` > covers a stable roster / every gesture site is mapped | New launcher gesture site `packages/ui/src/state/rail-gesture-store.ts` (#15283 gesture-freeze store) not pinned/documented | Add it to `PINNED_LAUNCHER_GESTURE_SITES` + a matrix-doc row |
| 6 | `core-view-action-surface-coverage.test.ts` > keeps shell-rendered required views wrapped in their live agent surface (`knowledge -> documents`) | The `knowledge` owner file list pointed at Character files, not `KnowledgeView.tsx` (the real `/documents` shell host, #13594) | Repoint the owner at KnowledgeView + DocumentsView + documents-upload |
| 7–8 | `core-view-action-surface-coverage.test.ts` > required core view backed by agent controls / critical agent ids (`automations: 3 < 4`, `automations: action-new`) | `action-new` never existed — AutomationsFeed has **no create CTA by design** (#13597: the agent re-creates a workflow from chat) | Align owner to reality: `minAgentElements` 4→3, snippets → `["run-workflow-"]` |
| 9 | `view-switching-core-matrix-coverage.test.ts` > tracks every canonical built-in settings subsection | The pinned settings-section list drifted from canonical `SETTINGS_SECTION_META` (missing the new `notifications` section from #15185; stale order) | Realign `REQUIRED_SETTINGS_SECTION_IDS` + `SETTINGS_SECTION_OWNER_FILES` to the canonical order incl. `notifications` |

### One packages/ui touch (coordination note)

Item 9 pulls the new `notifications` settings section into the "every settings subsection is agent-addressable" contract. `WebPushSettingsSection.tsx` (#15185) shipped a push toggle that was **not** agent-wired, so it violated that contract. Fixed at the correct layer: wire the toggle via `useAgentElement` (same pattern as `AdvancedToggle`) so "turn on notifications" reaches it from chat/voice. This is the only `packages/ui` file touched; it does not overlap the 8 pre-existing `packages/ui` test failures owned by the sibling ui lane (verified: those fail at HEAD without this change).

### Evidence

Before: `6 failed | 88 passed (94)` files / `9 failed | 902 passed (911)` tests.
After: **`Test Files 94 passed (94)` / `Tests 911 passed (911)`** (`bun run --cwd packages/app test`), rebased on the latest develop base. typecheck (turbo, @elizaos/app + @elizaos/ui, 80 tasks) clean; biome + error-policy ratchet clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)