### PR TITLE
test(ci): add tierForPriority to the launcher-loop e2e core stub (sister to #15320)

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/run-launcher-loop-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-launcher-loop-e2e.mjs
@@ -167,6 +167,19 @@ const stubElizaCore = {
             isViewVisible: (d, enabled) =>
               isViewKindEnabled(resolveViewKind(d), enabled),
             dedupeModalities: (m) => Array.from(new Set(Array.isArray(m) ? m : [])),
+            // The fixture defaults to attention mode, so the home notification
+            // center (NotificationsHomeCenter) mounts and triages each seeded
+            // notification by tier — it needs the REAL priority→tier mapping. A
+            // noop reads back "undefined" through esbuild's own-key __toESM
+            // interop and crashes the whole tree ("tierForPriority is not a
+            // function"), so the launcher surface never renders. Mirror core's
+            // notification.ts (matches run-home-screen-e2e.mjs's stub, #15320).
+            tierForPriority: (priority) =>
+              priority === "urgent" || priority === "high"
+                ? "interrupt"
+                : priority === "low"
+                  ? "silent"
+                  : "digest",
           },
           { get: (t, p) => (p in t ? t[p] : noop) },
         );


### PR DESCRIPTION
## What

Greens the **Chat shell gestures** workflow's `test:launcher-loop-e2e` step — the sister failure to the `test:home-screen-e2e` fix in #15320.

## Root cause

`run-launcher-loop-e2e.mjs` drives the same `home-screen-fixture` as `run-home-screen-e2e.mjs` but carries its **own** inline `@elizaos/core` stub. #15320 added the real `tierForPriority` export to the home-screen runner's stub only, so the launcher-loop runner's stub still lacked it. The launcher-loop fixture navigates to `?native` (defaults to **attention** mode), so `NotificationsHomeCenter` (#15039) mounts and calls `tierForPriority` — which read back `undefined` through esbuild's own-key `__toESM` interop → `TypeError: tierForPriority is not a function` → the whole React tree crashed → the launcher surface never rendered → `waitForSelector('[data-testid="home-launcher-surface"]')` timed out at 30s (run-launcher-loop-e2e.mjs:264).

## Fix

Mirror #15320's home-screen stub: expose the real priority→tier mapping as an OWN key of the core stub export. The two runners share the same stub *fixture files* (`home-screen-fixture.*-stub.ts` + `home-widget-mock-data.ts`), so #15320's todos/notifications data fixes carry over automatically — and this runner asserts only the launcher gesture loop (no launcher-image/notification/calendar-contrast assertions), so no other drift applies. `tierForPriority` was the sole delta between the two runners' stubs.

## Validation

`ELIZA_LOOP_ACTIONS=100 bun run --cwd packages/ui test:launcher-loop-e2e` (fresh random seed 1191961182):
```
✓ no blue on the surface before the loop (sampled 317)
  ✓ batch 1/1 — 100 actions (total 100), seed 1191961182
✓ applied ≥ 100 touch actions (got 100)
✓ no blue on the surface after the loop (sampled 317)
LAUNCHER-LOOP E2E PASSED — 100 touch actions, seed 1191961182
```
The launcher surface renders and 100 real touch actions run with all invariants (no-blue before/after, action count) holding — i.e. the gesture loop actually passes, not just the selector resolving. The default 500-action fuzz is the same mechanism at greater depth (it exceeds a single 10-min local turn on this shared VPS; CI runs the full count on its dedicated runner). An earlier full run also showed `✓ batch 1/5 — 100 actions` before a local-timeout browser teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)