### PR TITLE
fix(ci): unblock server surface-audit, zk diagnostics, and zk deterministic e2e

### DIFF
--- a/packages/scenario-runner/test/scenarios/deterministic-generated-app-routes.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-generated-app-routes.scenario.ts
@@ -775,13 +775,19 @@ function expectViewsList(
   return (status, body) => {
     if (status !== 200) return `expected 200, saw ${status}`;
     const views = arrayOfRecords(record(body)?.views);
-    const view = views.find((candidate) => {
-      return (
-        candidate.id === "views-manager" && candidate.viewType === viewType
-      );
-    });
+    // The views-manager ships GUI-only (#15269): "tui"/"xr" stay valid
+    // compatibility modalities but are no longer declared, so no tui-typed
+    // entry is registered. `listViews` still surfaces the manager in the TUI
+    // list as its GUI fallback (it returns DEFAULT_VIEW_TYPE when the requested
+    // modality has no dedicated registration), so the entry reports
+    // viewType="gui" in both lists while its terminal capabilities remain
+    // reachable for headless server-interact.
+    const view = views.find((candidate) => candidate.id === "views-manager");
     if (!view) {
-      return `expected ${viewType} views-manager registration, saw ${JSON.stringify(body)}`;
+      return `expected views-manager in ${viewType} list, saw ${JSON.stringify(body)}`;
+    }
+    if (view.viewType !== "gui") {
+      return `expected gui-only views-manager viewType, saw ${String(view.viewType)}`;
     }
     if (view.pluginName !== appControlPlugin.name) {
       return `expected pluginName=${appControlPlugin.name}, saw ${String(view.pluginName)}`;
@@ -987,7 +993,7 @@ export default scenario({
     },
     {
       kind: "api",
-      name: "app-control TUI view is registered in the real views registry",
+      name: "app-control views-manager surfaces in the TUI list as its GUI fallback",
       method: "GET",
       path: "/api/views?viewType=tui",
       expectedStatus: 200,

--- a/packages/scripts/audit-capability-router-plugin-surface.ts
+++ b/packages/scripts/audit-capability-router-plugin-surface.ts
@@ -49,6 +49,24 @@ const localOnly = new Set([
   // not exposed over the capability-router remote boundary (RemotePluginModuleManifest
   // has no shortcuts key and no remote-manifest builder reads it).
   "shortcuts",
+  // Pre-action dispatch hooks drained at the top of the chat loop; registered
+  // into the runtime ChatPreHandlerRegistry in-process, never mirrored over the
+  // remote wire (no manifest key, no builder reads it).
+  "chatPreHandlers",
+  // Package-dir resolution hint for the in-process view/hero/frame registry;
+  // the host resolves a remote plugin's bundles from its worker manifest, so
+  // this never crosses the remote boundary.
+  "packageName",
+  // Load-time preparation hook the plugin resolver runs before init on the host
+  // that owns the module; a remote worker prepares its own dependencies, so the
+  // hook is not part of the mirrored surface.
+  "preflight",
+  // Handler-free display/routing facts attached to `models`; consumed in-process
+  // by the model registry and not carried as its own manifest key.
+  "modelMetadata",
+  // Connector source names/aliases registered into the in-process runtime source
+  // map; connector plugins run direct, so this is not a remote-mirrored surface.
+  "connectorSources",
   "mode",
   "remote",
 ]);

--- a/plugins/plugin-computeruse/vitest.config.ts
+++ b/plugins/plugin-computeruse/vitest.config.ts
@@ -1,6 +1,6 @@
 /**
- * Vitest configuration for plugin-computeruse: aliases core/logger to source and
- * excludes the live/real/e2e lanes from the default run.
+ * Vitest configuration for plugin-computeruse: aliases core/logger/cloud-routing
+ * to source and excludes the live/real/e2e lanes from the default run.
  */
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9,6 +9,10 @@ import { defineConfig } from "vitest/config";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const coreSrcRoot = path.resolve(__dirname, "../../packages/core/src");
 const loggerSrcRoot = path.resolve(__dirname, "../../packages/logger/src");
+const cloudRoutingSrcRoot = path.resolve(
+  __dirname,
+  "../../packages/cloud/routing/src",
+);
 
 const testExcludes = [
   "dist/**",
@@ -31,6 +35,15 @@ export default defineConfig({
       {
         find: /^@elizaos\/core\/(.*)$/,
         replacement: path.join(coreSrcRoot, "$1"),
+      },
+      // Core's src re-exports the cloud routing surface from
+      // `@elizaos/cloud-routing`, which ships no dist. With @elizaos/core
+      // pinned to source above, that re-export only resolves when
+      // cloud-routing is source-aliased too — otherwise vite falls through to
+      // its missing `dist/index.js` and fails to resolve the entry.
+      {
+        find: /^@elizaos\/cloud-routing$/,
+        replacement: path.join(cloudRoutingSrcRoot, "index.ts"),
       },
       {
         find: /^@elizaos\/logger$/,


### PR DESCRIPTION
CI remediation lane — three independent "Tests" fan-out stragglers, each root-caused and fixed at the correct layer. Never weakened; each validated locally green plus biome + error-policy-ratchet.

## 1. Server Tests — `test:remote-capabilities:surface-audit` (exit 1)
`packages/scripts/audit-capability-router-plugin-surface.ts` requires every `Plugin` interface field to be classified as either remote-supported (with a matching `RemotePluginModuleManifest` key) or local-only. Five recently-added fields were unclassified:
`packageName`, `preflight`, `chatPreHandlers`, `modelMetadata`, `connectorSources`.

**Root cause:** new surface fields with no audit classification. Verified none of the five is read by any remote-manifest builder (`remote-plugin-adapter.ts`, `remote-capability-endpoint-provider.ts`, `capabilities/index.ts`) and none exists in `RemotePluginModuleManifest`; all are consumed in-process only (runtime, `ChatPreHandlerRegistry`, views-registry, model registry). Classified all five **local-only** with a per-field rationale comment, matching the existing `shortcuts` precedent.

**Validation:** `bun run test:remote-capabilities:surface-audit` → `{ ok: true, pluginFields: 36, ... }`.

## 2. Zero-Key diagnostics — `plugin-computeruse` `browser-auto-open.test.ts` (0 tests, failed suite)
Vite failed: *"Failed to resolve entry for package @elizaos/cloud-routing"* at `packages/core/src/cloud-routing.ts`.

**Root cause:** the test imports `@elizaos/core`, whose source re-exports `@elizaos/cloud-routing`, which ships no `dist`. The computeruse vitest config aliased `@elizaos/core` to source but not `@elizaos/cloud-routing`, so vite fell through to cloud-routing's missing `dist/index.js`. Source-aliased cloud-routing too, matching the documented pattern already in `plugin-app-control`, `plugin-elizacloud`, `app-core`, and `ui` vitest configs.

**Validation:** `bun run test -- test/helpers/screenshot-quality.test.ts src/__tests__/browser-auto-open.test.ts` → 2 files / 6 tests pass.

## 3. Zero-Key scenario runner — `test:deterministic:e2e` / `test:pr:e2e` (exit 1)
`deterministic-generated-app-routes` failed: *"expected tui views-manager registration, saw ...viewType:gui"*.

**Root cause:** commit `d0482495937` (#15269/#15291) intentionally made the app-control views-manager GUI-only ("tui"/"xr" modalities deliberately no longer declared). Post-change, `/api/views?viewType=tui` returns the manager as its GUI fallback (`listViews` returns `DEFAULT_VIEW_TYPE` when the requested modality has no dedicated registration), so its `viewType` is `"gui"` in both the gui and tui lists while its terminal capabilities remain intact. The scenario's `viewType === "tui"` assertion was stale test drift. Updated the assertion to the new GUI-only contract — still verifies the manager surfaces in the TUI list, is owned by app-control, and retains its terminal capabilities.

**Validation:** full `test:deterministic:e2e` lane → **39 passed, 0 failed**. Orchestrator lane 10/10, LifeOps lane 25/25 (incl. `f1-timezone` under `TZ=UTC`).

## Remaining deferrals (NOT fixed — documented per lane instructions)
After the deterministic lane is green, the `test:pr:e2e` chain proceeds to the **corpus** lane, which still fails **6 scenarios**, all mapping to the 3 active hard deferrals documented by the #15312/#15314/#15315 batch. None is the tractable fixture/catalog-id/mock-count class; each needs a risky core isolation/scheduling change, so they are left documented per the lane's guidance:

- **reminder-cluster isolation leak** (×4: `reminder.cross-platform.acknowledged-syncs`, `reminder.cross-platform.fires-on-mac-and-phone`, `reminder.escalation.intensity-up`, `reminder.escalation.silent-dismiss`) — each passes **in isolation** and as a **reminders-only batch (4/4)**, failing only in the full corpus run. An earlier corpus scenario leaks shared scheduling state (virtual clock / scheduled-task store) so "plan rung 0" never fires. Root cause is scenario-runner scheduling isolation — the risky core clock/cron area the lane says to defer.
- **relationships bootstrap-writes** (`relationships.list-entities`) — fails even standalone: 10 unnamed `person` entities are written to the knowledge graph during bootstrap, so the scenario's "fresh graph must have no entities" assertion sees 10. Deciding whether the bootstrap writes are correct behavior (scenario stale) or a bug — and fixing without weakening the assertion — needs deep knowledge-graph investigation.
- **persona.flexible-scheduling** — "expected exactly one fired for window, saw []"; scheduling-window semantics.

`f1-timezone` (the 4th documented deferral) currently **passes** in the LifeOps lane under `TZ=UTC`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)