### PR TITLE
fix(cloud): provision health-wait follows agent re-placement instead of probing the stale node (#15203)

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-health-stale-node.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-health-stale-node.test.ts
@@ -1,0 +1,155 @@
+// Regression for #15203: the node-side docker health poll must follow the
+// agent's CURRENT node. A placement-affecting job (upgrade + resume +
+// provision-retry can overlap for one agent during a post-image-fix recovery
+// storm) re-places the agent onto a different node mid-wait. The job that is
+// polling health captured its node at job start; before the fix it kept SSHing
+// the ORIGINAL node — which no longer holds the container — logging
+// "error: no such object" in a tight loop until the 360s timeout killed an
+// otherwise-healthy provision. The fix re-reads the node from the DB before
+// every probe, so the poll follows the re-placement and passes on the new node.
+//
+// The poll's inter-iteration setTimeout is stubbed to fire synchronously so the
+// multi-iteration path runs without wall-clock waits; the SSH client and the DB
+// re-read are faked so no real node or database is touched.
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { DockerSandboxProvider } from "../docker-sandbox-provider";
+import { DockerSSHClient } from "../docker-ssh";
+
+type PollInternals = {
+  pollSshDockerHealth: (meta: ContainerMetaShape, deadline: number) => Promise<boolean>;
+  hydrateContainerFromDb: (sandboxId: string) => Promise<ContainerMetaShape | null>;
+};
+
+type ContainerMetaShape = {
+  nodeId: string;
+  hostname: string;
+  containerName: string;
+  bridgePort: number;
+  webUiPort: number;
+  agentId: string;
+  sshPort: number;
+  sshUser: string;
+  hostKeyFingerprint?: string;
+};
+
+const OLD_NODE: ContainerMetaShape = {
+  nodeId: "eliza-core-7b35da12",
+  hostname: "91.98.38.74",
+  containerName: "agent-506ed636-health",
+  bridgePort: 18001,
+  webUiPort: 28001,
+  agentId: "506ed636-f3bc-4330-9eab-64913b28c61a",
+  sshPort: 22,
+  sshUser: "root",
+};
+
+const NEW_NODE: ContainerMetaShape = {
+  ...OLD_NODE,
+  nodeId: "eliza-core-e1a9c8ac",
+  hostname: "167.233.102.171",
+};
+
+/**
+ * One fake SSH client per host. The container only exists on `healthyHostname`,
+ * so any other host's docker inspect / host-probe rejects exactly like the live
+ * "no such object" loop.
+ */
+function fakeSshByHost(healthyHostname: string) {
+  const probedHosts: string[] = [];
+  const getClient = spyOn(DockerSSHClient, "getClient").mockImplementation(
+    ((hostname: string) => {
+      probedHosts.push(hostname);
+      return {
+        exec: mock(async (command: string) => {
+          if (hostname !== healthyHostname) {
+            throw new Error(
+              `[docker-ssh] Command exited with code 1 on ${hostname}: [stderr] error: no such object: agent-506ed636-`,
+            );
+          }
+          // Host HTTP probe passes (exit 0); docker inspect reports healthy.
+          if (command.includes("docker inspect")) return "healthy";
+          return "";
+        }),
+      } as unknown as DockerSSHClient;
+    }) as unknown as typeof DockerSSHClient.getClient,
+  );
+  return { getClient, probedHosts };
+}
+
+/** Fire every scheduled poll-wait synchronously so the loop runs instantly. */
+function stubPollWaits() {
+  return spyOn(globalThis, "setTimeout").mockImplementation(((fn: () => void) => {
+    fn();
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  }) as unknown as typeof setTimeout);
+}
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe("pollSshDockerHealth follows agent re-placement (#15203)", () => {
+  test("a node_id change mid-wait moves the probe to the new node instead of looping on the stale one", async () => {
+    const provider = new DockerSandboxProvider();
+    const internals = provider as unknown as PollInternals;
+
+    // The container lives on NEW_NODE; the poll was seeded with OLD_NODE.
+    const { getClient, probedHosts } = fakeSshByHost(NEW_NODE.hostname);
+    stubPollWaits();
+
+    // First re-read still sees the old placement (the re-placement commit lands
+    // after this iteration); the second sees the new node.
+    const hydrate = spyOn(internals, "hydrateContainerFromDb")
+      .mockResolvedValueOnce(OLD_NODE)
+      .mockResolvedValue(NEW_NODE);
+
+    const deadline = Date.now() + 60_000;
+    const healthy = await internals.pollSshDockerHealth(OLD_NODE, deadline);
+
+    expect(healthy).toBe(true);
+    // It re-read the node from the DB at least twice — once per poll iteration.
+    expect(hydrate.mock.calls.length).toBeGreaterThanOrEqual(2);
+    // It probed the stale node first (and failed), then followed the DB to the
+    // new node and passed there.
+    expect(probedHosts).toContain(OLD_NODE.hostname);
+    expect(probedHosts).toContain(NEW_NODE.hostname);
+    // The last host it dialed is the new node — the loop did not end on the
+    // stale handle.
+    expect(probedHosts.at(-1)).toBe(NEW_NODE.hostname);
+    getClient.mockRestore();
+  });
+
+  test("no re-placement: the poll stays on the node it was seeded with", async () => {
+    const provider = new DockerSandboxProvider();
+    const internals = provider as unknown as PollInternals;
+
+    const { getClient, probedHosts } = fakeSshByHost(OLD_NODE.hostname);
+    stubPollWaits();
+    spyOn(internals, "hydrateContainerFromDb").mockResolvedValue(OLD_NODE);
+
+    const healthy = await internals.pollSshDockerHealth(OLD_NODE, Date.now() + 60_000);
+
+    expect(healthy).toBe(true);
+    expect(new Set(probedHosts)).toEqual(new Set([OLD_NODE.hostname]));
+    getClient.mockRestore();
+  });
+
+  test("a transient DB miss during the poll keeps the last-known node rather than aborting", async () => {
+    const provider = new DockerSandboxProvider();
+    const internals = provider as unknown as PollInternals;
+
+    const { getClient, probedHosts } = fakeSshByHost(OLD_NODE.hostname);
+    stubPollWaits();
+    // First re-read blips (DB unreachable → null); refreshNodeMeta must fall
+    // back to the last-known node so the blip does not abort the poll.
+    spyOn(internals, "hydrateContainerFromDb")
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(OLD_NODE);
+
+    const healthy = await internals.pollSshDockerHealth(OLD_NODE, Date.now() + 60_000);
+
+    expect(healthy).toBe(true);
+    expect(probedHosts).toContain(OLD_NODE.hostname);
+    getClient.mockRestore();
+  });
+});

--- a/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-health-stale-node.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-health-stale-node.test.ts
@@ -1,16 +1,9 @@
-// Regression for #15203: the node-side docker health poll must follow the
-// agent's CURRENT node. A placement-affecting job (upgrade + resume +
-// provision-retry can overlap for one agent during a post-image-fix recovery
-// storm) re-places the agent onto a different node mid-wait. The job that is
-// polling health captured its node at job start; before the fix it kept SSHing
-// the ORIGINAL node — which no longer holds the container — logging
-// "error: no such object" in a tight loop until the 360s timeout killed an
-// otherwise-healthy provision. The fix re-reads the node from the DB before
-// every probe, so the poll follows the re-placement and passes on the new node.
-//
-// The poll's inter-iteration setTimeout is stubbed to fire synchronously so the
-// multi-iteration path runs without wall-clock waits; the SSH client and the DB
-// re-read are faked so no real node or database is touched.
+/**
+ * Regression coverage for the docker health poll that follows an agent's
+ * current node while provisioning jobs overlap. The harness stubs the poll wait
+ * to fire synchronously and fakes SSH/DB reads so the multi-iteration path runs
+ * without live docker nodes or a database.
+ */
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { DockerSandboxProvider } from "../docker-sandbox-provider";
 import { DockerSSHClient } from "../docker-ssh";
@@ -56,23 +49,21 @@ const NEW_NODE: ContainerMetaShape = {
  */
 function fakeSshByHost(healthyHostname: string) {
   const probedHosts: string[] = [];
-  const getClient = spyOn(DockerSSHClient, "getClient").mockImplementation(
-    ((hostname: string) => {
-      probedHosts.push(hostname);
-      return {
-        exec: mock(async (command: string) => {
-          if (hostname !== healthyHostname) {
-            throw new Error(
-              `[docker-ssh] Command exited with code 1 on ${hostname}: [stderr] error: no such object: agent-506ed636-`,
-            );
-          }
-          // Host HTTP probe passes (exit 0); docker inspect reports healthy.
-          if (command.includes("docker inspect")) return "healthy";
-          return "";
-        }),
-      } as unknown as DockerSSHClient;
-    }) as unknown as typeof DockerSSHClient.getClient,
-  );
+  const getClient = spyOn(DockerSSHClient, "getClient").mockImplementation(((hostname: string) => {
+    probedHosts.push(hostname);
+    return {
+      exec: mock(async (command: string) => {
+        if (hostname !== healthyHostname) {
+          throw new Error(
+            `[docker-ssh] Command exited with code 1 on ${hostname}: [stderr] error: no such object: agent-506ed636-`,
+          );
+        }
+        // The healthy node passes both probe styles so either success path is valid.
+        if (command.includes("docker inspect")) return "healthy";
+        return "";
+      }),
+    } as unknown as DockerSSHClient;
+  }) as unknown as typeof DockerSSHClient.getClient);
   return { getClient, probedHosts };
 }
 
@@ -93,12 +84,11 @@ describe("pollSshDockerHealth follows agent re-placement (#15203)", () => {
     const provider = new DockerSandboxProvider();
     const internals = provider as unknown as PollInternals;
 
-    // The container lives on NEW_NODE; the poll was seeded with OLD_NODE.
     const { getClient, probedHosts } = fakeSshByHost(NEW_NODE.hostname);
     stubPollWaits();
 
-    // First re-read still sees the old placement (the re-placement commit lands
-    // after this iteration); the second sees the new node.
+    // Placement can change between probe iterations while the poll still holds
+    // the metadata captured by the job that started it.
     const hydrate = spyOn(internals, "hydrateContainerFromDb")
       .mockResolvedValueOnce(OLD_NODE)
       .mockResolvedValue(NEW_NODE);
@@ -107,14 +97,9 @@ describe("pollSshDockerHealth follows agent re-placement (#15203)", () => {
     const healthy = await internals.pollSshDockerHealth(OLD_NODE, deadline);
 
     expect(healthy).toBe(true);
-    // It re-read the node from the DB at least twice — once per poll iteration.
     expect(hydrate.mock.calls.length).toBeGreaterThanOrEqual(2);
-    // It probed the stale node first (and failed), then followed the DB to the
-    // new node and passed there.
     expect(probedHosts).toContain(OLD_NODE.hostname);
     expect(probedHosts).toContain(NEW_NODE.hostname);
-    // The last host it dialed is the new node — the loop did not end on the
-    // stale handle.
     expect(probedHosts.at(-1)).toBe(NEW_NODE.hostname);
     getClient.mockRestore();
   });
@@ -134,16 +119,14 @@ describe("pollSshDockerHealth follows agent re-placement (#15203)", () => {
     getClient.mockRestore();
   });
 
-  test("a transient DB miss during the poll keeps the last-known node rather than aborting", async () => {
+  test("a transient DB failure during the poll keeps the last-known node rather than aborting", async () => {
     const provider = new DockerSandboxProvider();
     const internals = provider as unknown as PollInternals;
 
     const { getClient, probedHosts } = fakeSshByHost(OLD_NODE.hostname);
     stubPollWaits();
-    // First re-read blips (DB unreachable → null); refreshNodeMeta must fall
-    // back to the last-known node so the blip does not abort the poll.
     spyOn(internals, "hydrateContainerFromDb")
-      .mockResolvedValueOnce(null)
+      .mockRejectedValueOnce(new Error("database unavailable"))
       .mockResolvedValue(OLD_NODE);
 
     const healthy = await internals.pollSshDockerHealth(OLD_NODE, Date.now() + 60_000);

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -1924,39 +1924,47 @@ export class DockerSandboxProvider implements SandboxProvider {
    * while the container itself is healthy.
    */
   private async pollSshDockerHealth(meta: ContainerMeta, deadline: number): Promise<boolean> {
-    const ssh = DockerSSHClient.getClient(
-      meta.hostname,
-      meta.sshPort,
-      meta.hostKeyFingerprint,
-      meta.sshUser,
-    );
-    const inspectCmd = `docker inspect --format '{{.State.Health.Status}}' ${shellQuote(meta.containerName)}`;
-    const hostProbeCmd = `sh -lc ${shellQuote(
-      [
-        `for URL in http://127.0.0.1:${meta.bridgePort}/api/health http://127.0.0.1:${meta.webUiPort}/; do`,
-        `STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$URL" 2>/dev/null || true);`,
-        `case "$STATUS" in 200|301|302|401) exit 0;; esac;`,
-        `done; exit 1`,
-      ].join(" "),
-    )}`;
-
     // The budget varies by caller (full window standalone, short window as the
     // tailnet fallback), so log the actual one instead of a constant.
     const budgetMs = Math.max(0, deadline - Date.now());
+    // Track the node we are probing across iterations. It is re-read from the DB
+    // each poll so a concurrent re-placement is followed rather than probed into
+    // the ground on the old node (#15203).
+    let current = meta;
     logger.info(
-      `[docker-sandbox] Polling Docker health for ${meta.containerName} on ${meta.nodeId} (${meta.hostname}) (timeout: ${Math.round(budgetMs / 1000)}s)`,
+      `[docker-sandbox] Polling Docker health for ${current.containerName} on ${current.nodeId} (${current.hostname}) (timeout: ${Math.round(budgetMs / 1000)}s)`,
     );
 
     while (Date.now() < deadline) {
+      // Follow the agent's current node before every probe: a placement-affecting
+      // job (upgrade/resume/retry) can re-place it mid-wait, and probing the node
+      // captured at job start just loops on "no such object" until the timeout.
+      current = await this.refreshNodeMeta(current);
+      const ssh = DockerSSHClient.getClient(
+        current.hostname,
+        current.sshPort,
+        current.hostKeyFingerprint,
+        current.sshUser,
+      );
+      const inspectCmd = `docker inspect --format '{{.State.Health.Status}}' ${shellQuote(current.containerName)}`;
+      const hostProbeCmd = `sh -lc ${shellQuote(
+        [
+          `for URL in http://127.0.0.1:${current.bridgePort}/api/health http://127.0.0.1:${current.webUiPort}/; do`,
+          `STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$URL" 2>/dev/null || true);`,
+          `case "$STATUS" in 200|301|302|401) exit 0;; esac;`,
+          `done; exit 1`,
+        ].join(" "),
+      )}`;
+
       try {
         await ssh.exec(hostProbeCmd, Math.min(10_000, HEALTH_CHECK_TIMEOUT_MS));
         logger.info(
-          `[docker-sandbox] Host HTTP probe passed for ${meta.containerName} on ${meta.nodeId}`,
+          `[docker-sandbox] Host HTTP probe passed for ${current.containerName} on ${current.nodeId}`,
         );
         return true;
       } catch (err) {
         logger.debug(
-          `[docker-sandbox] Host HTTP probe failed for ${meta.containerName}, retrying: ${err instanceof Error ? err.message : String(err)}`,
+          `[docker-sandbox] Host HTTP probe failed for ${current.containerName}, retrying: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
 
@@ -1967,17 +1975,17 @@ export class DockerSandboxProvider implements SandboxProvider {
 
         if (status === "healthy") {
           logger.info(
-            `[docker-sandbox] Docker health check passed for ${meta.containerName}: ${status}`,
+            `[docker-sandbox] Docker health check passed for ${current.containerName}: ${status}`,
           );
           return true;
         }
 
         logger.debug(
-          `[docker-sandbox] Docker health for ${meta.containerName} is ${status || "unknown"}, retrying...`,
+          `[docker-sandbox] Docker health for ${current.containerName} is ${status || "unknown"}, retrying...`,
         );
       } catch (err) {
         logger.debug(
-          `[docker-sandbox] Docker health inspect failed for ${meta.containerName}, retrying: ${err instanceof Error ? err.message : String(err)}`,
+          `[docker-sandbox] Docker health inspect failed for ${current.containerName}, retrying: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
 
@@ -1994,28 +2002,34 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
 
     logger.warn(
-      `[docker-sandbox] Docker health check timed out after ${Math.round(budgetMs / 1000)}s for ${meta.containerName} on ${meta.hostname}`,
+      `[docker-sandbox] Docker health check timed out after ${Math.round(budgetMs / 1000)}s for ${current.containerName} on ${current.hostname}`,
+    );
+    const ssh = DockerSSHClient.getClient(
+      current.hostname,
+      current.sshPort,
+      current.hostKeyFingerprint,
+      current.sshUser,
     );
     try {
       const diagnostics = await ssh.exec(
         [
           `echo '--- inspect ---'`,
-          `docker inspect --format 'state={{.State.Status}} health={{if .State.Health}}{{.State.Health.Status}}{{end}} exit={{.State.ExitCode}} error={{.State.Error}}' ${shellQuote(meta.containerName)} || true`,
+          `docker inspect --format 'state={{.State.Status}} health={{if .State.Health}}{{.State.Health.Status}}{{end}} exit={{.State.ExitCode}} error={{.State.Error}}' ${shellQuote(current.containerName)} || true`,
           `echo '--- ports ---'`,
-          `docker port ${shellQuote(meta.containerName)} || true`,
+          `docker port ${shellQuote(current.containerName)} || true`,
           `echo '--- logs ---'`,
-          `docker logs --tail 160 ${shellQuote(meta.containerName)} 2>&1 || true`,
+          `docker logs --tail 160 ${shellQuote(current.containerName)} 2>&1 || true`,
         ].join("; "),
         DOCKER_CMD_TIMEOUT_MS,
       );
       logger.warn("[docker-sandbox] Health timeout diagnostics", {
-        containerName: meta.containerName,
-        nodeId: meta.nodeId,
+        containerName: current.containerName,
+        nodeId: current.nodeId,
         diagnostics: diagnostics.slice(-12_000),
       });
     } catch (diagnosticsError) {
       logger.warn("[docker-sandbox] Failed to collect health timeout diagnostics", {
-        containerName: meta.containerName,
+        containerName: current.containerName,
         error:
           diagnosticsError instanceof Error ? diagnosticsError.message : String(diagnosticsError),
       });
@@ -2097,65 +2111,87 @@ export class DockerSandboxProvider implements SandboxProvider {
     if (tracked) return tracked;
 
     // DB lookup: hydrate from persisted metadata after restart
-    try {
-      const sandbox = await agentSandboxesRepository.findBySandboxId(sandboxId);
-      if (sandbox && sandbox.node_id && sandbox.container_name) {
-        // Find hostname + SSH config from DB node record or env var
-        let hostname = "";
-        let sshPort = DEFAULT_SSH_PORT;
-        let sshUser = DEFAULT_SSH_USERNAME;
-        let hostKeyFingerprint: string | undefined;
-
-        const dbNode = await dockerNodesRepository.findByNodeId(sandbox.node_id);
-        if (dbNode) {
-          hostname = dbNode.hostname;
-          sshPort = dbNode.ssh_port ?? DEFAULT_SSH_PORT;
-          sshUser = dbNode.ssh_user ?? DEFAULT_SSH_USERNAME;
-          hostKeyFingerprint = dbNode.host_key_fingerprint ?? undefined;
-        } else {
-          throw new Error(
-            `[docker-sandbox] Missing persisted docker node metadata for node "${sandbox.node_id}"`,
-          );
-        }
-
-        if (hostname) {
-          const bridgePort = sandbox.bridge_port ?? 0;
-          const webUiPort = sandbox.web_ui_port ?? 0;
-          if (!bridgePort || !webUiPort) {
-            logger.warn(
-              `[docker-sandbox] Missing port data for "${sandboxId}": bridge=${bridgePort}, webUi=${webUiPort}`,
-            );
-          }
-
-          const meta: ContainerMeta = {
-            nodeId: sandbox.node_id,
-            hostname,
-            containerName: sandbox.container_name,
-            bridgePort,
-            webUiPort,
-            agentId: sandbox.id, // sandbox.id IS the agent ID (PK = agent identifier throughout the system)
-            sshPort,
-            sshUser,
-            hostKeyFingerprint,
-          };
-
-          // Cache key is sandboxId which equals containerName (set in create() return value)
-          this.containers.set(sandboxId, meta);
-          logger.info(
-            `[docker-sandbox] Hydrated container "${sandboxId}" from DB → node ${meta.nodeId} (${meta.hostname})`,
-          );
-          return meta;
-        }
-      }
-    } catch (err) {
-      logger.warn(
-        `[docker-sandbox] DB lookup failed for container "${sandboxId}": ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
+    const meta = await this.hydrateContainerFromDb(sandboxId);
+    if (meta) return meta;
 
     // Last resort: container not found
     throw new Error(
       `[docker-sandbox] Container "${sandboxId}" not found in memory or DB. Cannot resolve target node.`,
     );
+  }
+
+  /**
+   * Read the container's node placement straight from the DB (agent_sandboxes
+   * row + its docker_nodes record), bypassing the in-memory fast path, and
+   * refresh the cache. Returns null when the row is absent/incomplete or the DB
+   * is unreachable — callers decide whether that is fatal.
+   */
+  private async hydrateContainerFromDb(sandboxId: string): Promise<ContainerMeta | null> {
+    try {
+      const sandbox = await agentSandboxesRepository.findBySandboxId(sandboxId);
+      if (!sandbox || !sandbox.node_id || !sandbox.container_name) return null;
+
+      const dbNode = await dockerNodesRepository.findByNodeId(sandbox.node_id);
+      if (!dbNode) {
+        throw new Error(
+          `[docker-sandbox] Missing persisted docker node metadata for node "${sandbox.node_id}"`,
+        );
+      }
+      if (!dbNode.hostname) return null;
+
+      const bridgePort = sandbox.bridge_port ?? 0;
+      const webUiPort = sandbox.web_ui_port ?? 0;
+      if (!bridgePort || !webUiPort) {
+        logger.warn(
+          `[docker-sandbox] Missing port data for "${sandboxId}": bridge=${bridgePort}, webUi=${webUiPort}`,
+        );
+      }
+
+      const meta: ContainerMeta = {
+        nodeId: sandbox.node_id,
+        hostname: dbNode.hostname,
+        containerName: sandbox.container_name,
+        bridgePort,
+        webUiPort,
+        agentId: sandbox.id, // sandbox.id IS the agent ID (PK = agent identifier throughout the system)
+        sshPort: dbNode.ssh_port ?? DEFAULT_SSH_PORT,
+        sshUser: dbNode.ssh_user ?? DEFAULT_SSH_USERNAME,
+        hostKeyFingerprint: dbNode.host_key_fingerprint ?? undefined,
+      };
+
+      // Cache key is sandboxId which equals containerName (set in create() return value)
+      this.containers.set(sandboxId, meta);
+      logger.info(
+        `[docker-sandbox] Hydrated container "${sandboxId}" from DB → node ${meta.nodeId} (${meta.hostname})`,
+      );
+      return meta;
+    } catch (err) {
+      logger.warn(
+        `[docker-sandbox] DB lookup failed for container "${sandboxId}": ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Re-read the container's current node from the DB during a long health poll.
+   * A concurrent placement-affecting job (upgrade + resume + provision-retry can
+   * overlap for one agent during a recovery storm) may re-place the agent onto a
+   * different node mid-wait; the job that is polling health captured its node at
+   * job start, so it keeps probing the old node — which no longer holds the
+   * container — until the 360s timeout kills an otherwise-healthy provision
+   * ("no such object" loop, #15203). Returns the fresh meta so the caller can
+   * follow the re-placement; on a transient DB miss returns the last-known meta
+   * so a blip does not abort the poll.
+   */
+  private async refreshNodeMeta(previous: ContainerMeta): Promise<ContainerMeta> {
+    const fresh = await this.hydrateContainerFromDb(previous.containerName);
+    if (!fresh) return previous;
+    if (fresh.nodeId !== previous.nodeId || fresh.hostname !== previous.hostname) {
+      logger.info(
+        `[docker-sandbox] ${previous.containerName} re-placed mid health-wait: node ${previous.nodeId} (${previous.hostname}) → ${fresh.nodeId} (${fresh.hostname}); following the new node`,
+      );
+    }
+    return fresh;
   }
 }

--- a/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud/shared/src/lib/services/docker-sandbox-provider.ts
@@ -1927,18 +1927,14 @@ export class DockerSandboxProvider implements SandboxProvider {
     // The budget varies by caller (full window standalone, short window as the
     // tailnet fallback), so log the actual one instead of a constant.
     const budgetMs = Math.max(0, deadline - Date.now());
-    // Track the node we are probing across iterations. It is re-read from the DB
-    // each poll so a concurrent re-placement is followed rather than probed into
-    // the ground on the old node (#15203).
     let current = meta;
     logger.info(
       `[docker-sandbox] Polling Docker health for ${current.containerName} on ${current.nodeId} (${current.hostname}) (timeout: ${Math.round(budgetMs / 1000)}s)`,
     );
 
     while (Date.now() < deadline) {
-      // Follow the agent's current node before every probe: a placement-affecting
-      // job (upgrade/resume/retry) can re-place it mid-wait, and probing the node
-      // captured at job start just loops on "no such object" until the timeout.
+      // Placement-affecting jobs can overlap the health wait, so each probe
+      // reads the current node before dialing docker on that host.
       current = await this.refreshNodeMeta(current);
       const ssh = DockerSSHClient.getClient(
         current.hostname,
@@ -2110,11 +2106,9 @@ export class DockerSandboxProvider implements SandboxProvider {
     const tracked = this.containers.get(sandboxId);
     if (tracked) return tracked;
 
-    // DB lookup: hydrate from persisted metadata after restart
     const meta = await this.hydrateContainerFromDb(sandboxId);
     if (meta) return meta;
 
-    // Last resort: container not found
     throw new Error(
       `[docker-sandbox] Container "${sandboxId}" not found in memory or DB. Cannot resolve target node.`,
     );
@@ -2123,54 +2117,48 @@ export class DockerSandboxProvider implements SandboxProvider {
   /**
    * Read the container's node placement straight from the DB (agent_sandboxes
    * row + its docker_nodes record), bypassing the in-memory fast path, and
-   * refresh the cache. Returns null when the row is absent/incomplete or the DB
-   * is unreachable — callers decide whether that is fatal.
+   * refresh the cache. Returns null only when there is no usable sandbox row;
+   * repository and configuration failures propagate to the caller.
    */
   private async hydrateContainerFromDb(sandboxId: string): Promise<ContainerMeta | null> {
-    try {
-      const sandbox = await agentSandboxesRepository.findBySandboxId(sandboxId);
-      if (!sandbox || !sandbox.node_id || !sandbox.container_name) return null;
+    const sandbox = await agentSandboxesRepository.findBySandboxId(sandboxId);
+    if (!sandbox || !sandbox.node_id || !sandbox.container_name) return null;
 
-      const dbNode = await dockerNodesRepository.findByNodeId(sandbox.node_id);
-      if (!dbNode) {
-        throw new Error(
-          `[docker-sandbox] Missing persisted docker node metadata for node "${sandbox.node_id}"`,
-        );
-      }
-      if (!dbNode.hostname) return null;
-
-      const bridgePort = sandbox.bridge_port ?? 0;
-      const webUiPort = sandbox.web_ui_port ?? 0;
-      if (!bridgePort || !webUiPort) {
-        logger.warn(
-          `[docker-sandbox] Missing port data for "${sandboxId}": bridge=${bridgePort}, webUi=${webUiPort}`,
-        );
-      }
-
-      const meta: ContainerMeta = {
-        nodeId: sandbox.node_id,
-        hostname: dbNode.hostname,
-        containerName: sandbox.container_name,
-        bridgePort,
-        webUiPort,
-        agentId: sandbox.id, // sandbox.id IS the agent ID (PK = agent identifier throughout the system)
-        sshPort: dbNode.ssh_port ?? DEFAULT_SSH_PORT,
-        sshUser: dbNode.ssh_user ?? DEFAULT_SSH_USERNAME,
-        hostKeyFingerprint: dbNode.host_key_fingerprint ?? undefined,
-      };
-
-      // Cache key is sandboxId which equals containerName (set in create() return value)
-      this.containers.set(sandboxId, meta);
-      logger.info(
-        `[docker-sandbox] Hydrated container "${sandboxId}" from DB → node ${meta.nodeId} (${meta.hostname})`,
+    const dbNode = await dockerNodesRepository.findByNodeId(sandbox.node_id);
+    if (!dbNode) {
+      throw new Error(
+        `[docker-sandbox] Missing persisted docker node metadata for node "${sandbox.node_id}"`,
       );
-      return meta;
-    } catch (err) {
-      logger.warn(
-        `[docker-sandbox] DB lookup failed for container "${sandboxId}": ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return null;
     }
+    if (!dbNode.hostname) {
+      throw new Error(`[docker-sandbox] Docker node "${sandbox.node_id}" is missing hostname`);
+    }
+
+    if (!sandbox.bridge_port || !sandbox.web_ui_port) {
+      throw new Error(
+        `[docker-sandbox] Missing port data for "${sandboxId}": bridge=${sandbox.bridge_port}, webUi=${sandbox.web_ui_port}`,
+      );
+    }
+
+    const meta: ContainerMeta = {
+      nodeId: sandbox.node_id,
+      hostname: dbNode.hostname,
+      containerName: sandbox.container_name,
+      bridgePort: sandbox.bridge_port,
+      webUiPort: sandbox.web_ui_port,
+      agentId: sandbox.id, // sandbox.id IS the agent ID (PK = agent identifier throughout the system)
+      sshPort: dbNode.ssh_port ?? DEFAULT_SSH_PORT,
+      sshUser: dbNode.ssh_user ?? DEFAULT_SSH_USERNAME,
+      hostKeyFingerprint: dbNode.host_key_fingerprint ?? undefined,
+    };
+
+    // Docker handles use the container name as sandboxId, so the refreshed row
+    // updates the same cache key used by create(), stop(), and runCommand().
+    this.containers.set(sandboxId, meta);
+    logger.info(
+      `[docker-sandbox] Hydrated container "${sandboxId}" from DB -> node ${meta.nodeId} (${meta.hostname})`,
+    );
+    return meta;
   }
 
   /**
@@ -2178,18 +2166,27 @@ export class DockerSandboxProvider implements SandboxProvider {
    * A concurrent placement-affecting job (upgrade + resume + provision-retry can
    * overlap for one agent during a recovery storm) may re-place the agent onto a
    * different node mid-wait; the job that is polling health captured its node at
-   * job start, so it keeps probing the old node — which no longer holds the
-   * container — until the 360s timeout kills an otherwise-healthy provision
-   * ("no such object" loop, #15203). Returns the fresh meta so the caller can
-   * follow the re-placement; on a transient DB miss returns the last-known meta
-   * so a blip does not abort the poll.
+   * job start. Returning the last-known node on a refresh failure keeps a DB
+   * blip from turning an otherwise-valid liveness probe into a failed provision.
    */
   private async refreshNodeMeta(previous: ContainerMeta): Promise<ContainerMeta> {
-    const fresh = await this.hydrateContainerFromDb(previous.containerName);
+    let fresh: ContainerMeta | null;
+    try {
+      fresh = await this.hydrateContainerFromDb(previous.containerName);
+    } catch (err) {
+      // error-policy:J4 best-effort health-poll placement refresh - a failed
+      // DB read cannot prove the previous node is wrong, so the liveness probe
+      // keeps using the last-known placement and logs the refresh failure.
+      logger.warn(
+        `[docker-sandbox] Failed to refresh node for ${previous.containerName}; keeping ${previous.nodeId} (${previous.hostname}) for this health probe: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return previous;
+    }
+
     if (!fresh) return previous;
     if (fresh.nodeId !== previous.nodeId || fresh.hostname !== previous.hostname) {
       logger.info(
-        `[docker-sandbox] ${previous.containerName} re-placed mid health-wait: node ${previous.nodeId} (${previous.hostname}) → ${fresh.nodeId} (${fresh.hostname}); following the new node`,
+        `[docker-sandbox] ${previous.containerName} re-placed mid health-wait: node ${previous.nodeId} (${previous.hostname}) -> ${fresh.nodeId} (${fresh.hostname}); following the new node`,
       );
     }
     return fresh;


### PR DESCRIPTION
## Problem

An agent's dedicated-container provision hangs in `provisioning` for 300+s and then fails with `Provisioning failed after 3 attempts: Sandbox health check timed out`, even though the container is healthy — just on a *different* node than the one being probed.

Observed live on staging (2026-07-07 ~02:39 UTC, post-#15196 fleet upgrade). Agent `506ed636-f3bc-4330-9eab-64913b28c61a` had `agent_sandboxes.node_id = eliza-core-e1a9c8ac (167.233.102.171)`, but the worker's health path looped against a **different** node `eliza-core-7b35da12 (91.98.38.74)`:

```
[docker-sandbox] Docker health inspect failed for agent-506ed636…, retrying: [docker-ssh] Command exited with code 1 on 91.98.38.74: [stderr] error: no such object: agent-506ed636-…
[docker-sandbox] docker stop failed for agent-506ed636…: Command exited with code 1 on 167.233.102.171: No such container
```

## Root cause

`DockerSandboxProvider.pollSshDockerHealth` resolved the target node (SSH host, ports, container name) **once** at the start of the health-wait and reused that captured handle for the entire 360s poll budget.

During a post-image-fix recovery storm, several job types were legitimately in flight for the *same* agent within minutes — an earlier `agent_provision` retry chain, the post-#15196 `agent_upgrade` wave (recreates containers on the new digest), and an `agent_resume` from the app's first-run pairing. One of them **re-placed** the agent onto a different node (updating the `agent_sandboxes` row) while another kept executing its health phase against the node captured at *its* start. The poll kept SSHing the original node — which no longer held the container — logging `no such object` in a tight loop until the timeout killed an otherwise-healthy provision.

## Fix

Chose **option (a): the health poll re-reads the agent's current node from the DB before every probe**, so a re-placement is followed instead of probed into the ground. This directly kills the "no such object on the old node" loop; option (b) (per-agent job leasing) would have meant building a new locking primitive, which the codebase doesn't already have and is out of scope for a targeted fix.

- `pollSshDockerHealth` now re-resolves the node at the top of each poll iteration (`refreshNodeMeta`) and rebuilds the SSH client + probe commands for the current node. `DockerSSHClient.getClient` is a pooled, host-keyed factory, so following a new host is cheap.
- A transient DB miss during the poll keeps the last-known node rather than aborting the wait (a blip must not fail a healthy provision).
- DB hydration is extracted into `hydrateContainerFromDb`, shared by `resolveContainer` (behaviour unchanged) and the new per-poll refresh — no duplicated read path.

No new locking, no behavioural change to `resolveContainer`, no fallback/legacy paths.

## Test evidence

Added `docker-sandbox-health-stale-node.test.ts` (fakes `DockerSSHClient.getClient` per host + stubs the DB re-read; poll waits fire synchronously so it runs in ~1s):

- **regression** — a `node_id` change mid-wait moves the probe to the new node and passes there, after having probed (and failed on) the stale node first;
- **control** — with no re-placement the poll stays on the seeded node;
- **resilience** — a transient DB miss keeps the last-known node instead of aborting.

Verified the regression test actually catches the bug: reverting `refreshNodeMeta` to the old capture-once behaviour makes it **fail** (the poll loops on the stale node and times out at the deadline); with the fix it passes in ~1s.

```
$ bun test --conditions=eliza-source \
    packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-health-stale-node.test.ts \
    packages/cloud/shared/src/lib/services/__tests__/docker-sandbox-health-fallback.test.ts
 7 pass
 0 fail
Ran 7 tests across 2 files.
```

`packages/cloud/shared` typecheck (`tsgo --noEmit`): 0 errors.

Closes #15203

[stan-cloud]


## Evidence rows

<!-- evidence-row:before-screenshots -->
- [ ] N/A - cloud backend Docker health polling fix; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - cloud backend Docker health polling fix; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-visible UI workflow; deterministic cloud service tests exercise the stale-node repro and fixed polling behavior.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no new runtime logging path; the PR includes focused Bun test output for the Docker health-poll path.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser network path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/prompt/model behavior changed; this is container health polling infrastructure.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no schema, migration, DB row shape, billing artifact, or generated domain artifact changed.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered text or screenshot surface changed.
