### PR TITLE
feat(ui): notification/chat gesture polish — per-stack fan-out, drag sync, trackpad detents, scrollbar

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -3010,6 +3010,68 @@ export function ContinuousChatOverlay({
     ],
   );
 
+  // Trackpad two-finger swipe steps the sheet through its detents
+  // (pill ↔ input ↔ half ↔ full ↔ maximized) — the macOS-feel complement to
+  // the pointer drag. Wheel events accumulate with a short decay and step once
+  // per threshold with a cooldown, so a single physical swipe moves ONE detent
+  // (no accidental multi-jumps). Scoped to the sheet chrome: events that
+  // originate inside the transcript scroller belong to transcript scrolling
+  // and are ignored here, so reading history never resizes the sheet.
+  const wheelStepAccRef = React.useRef(0);
+  const wheelStepCooldownRef = React.useRef(0);
+  const wheelStepDecayRef = React.useRef<number | null>(null);
+  const onSheetWheel = React.useCallback(
+    (e: React.WheelEvent) => {
+      if (firstRunOpen || draggingRef.current) return;
+      if (
+        e.target instanceof Element &&
+        e.target.closest("#continuous-thread")
+      ) {
+        return;
+      }
+      const now = performance.now();
+      if (now < wheelStepCooldownRef.current) return;
+      if (wheelStepDecayRef.current !== null) {
+        window.clearTimeout(wheelStepDecayRef.current);
+      }
+      wheelStepDecayRef.current = window.setTimeout(() => {
+        wheelStepAccRef.current = 0;
+        wheelStepDecayRef.current = null;
+      }, 250);
+      wheelStepAccRef.current += e.deltaY;
+      const STEP_PX = 60;
+      const acc = wheelStepAccRef.current;
+      if (Math.abs(acc) < STEP_PX) return;
+      wheelStepAccRef.current = 0;
+      wheelStepCooldownRef.current = now + 450;
+      // Natural-scroll semantics: swiping UP on the trackpad (content up,
+      // deltaY > 0) grows the sheet; swiping down shrinks it.
+      const grow = acc > 0;
+      if (grow) {
+        if (pilled) goToDetent("collapsed");
+        else if (!sheetOpen) goToDetent("half");
+        else if (!expanded) goToDetent("full");
+        else if (!maximized) maximizeFromPull();
+      } else {
+        if (maximized) restoreFromMaximized();
+        else if (expanded) goToDetent("half");
+        else if (sheetOpen) goToDetent("collapsed");
+        else if (!pilled) collapseToPill();
+      }
+    },
+    [
+      firstRunOpen,
+      pilled,
+      sheetOpen,
+      expanded,
+      maximized,
+      goToDetent,
+      maximizeFromPull,
+      restoreFromMaximized,
+      collapseToPill,
+    ],
+  );
+
   // First-run onboarding pin + release. While onboarding is active the sheet
   // stays pinned FULL — a true full-screen chat (the seeded greeting/choices
   // own the screen and the chat is undismissable; every collapse path below is
@@ -3967,7 +4029,13 @@ export function ContinuousChatOverlay({
       // continuous pull reads pill → input → chat (and a flick-up no longer
       // flashes a chat sliver, since the thread only grows after the morph).
       if (pilled) {
-        let up = Math.max(0, effOffset);
+        // FLOOR consumption (mirror of the ceiling rebase below): the pill is
+        // the bottom of the continuum — travel BELOW it has nothing to shrink,
+        // so absorb it into the offset base. Without this the below-floor
+        // travel was banked and a reversal had to pay it all back before the
+        // pill responded (the "drag down, drag up, sheet lags my mouse" drift).
+        if (effOffset < 0) dragOffsetBaseRef.current = offset;
+        let up = Math.max(0, offset - dragOffsetBaseRef.current);
         // The pill sits at height 0, so the raw finger travel IS the equivalent
         // pull height. Tracking it here (like the open-sheet path below) lets a
         // single held drag from the pill clear the maximize threshold — pill →
@@ -4080,6 +4148,19 @@ export function ContinuousChatOverlay({
         maxPullRawRef.current >= insetPanelMaxH + maxOverPull / 2
       ) {
         maxPullRawRef.current = 0;
+      }
+      // FLOOR consumption (mirror of the ceiling rebase above): once the drag
+      // has consumed the whole thread AND the input→pill morph
+      // (raw < -PILL_OPEN_DISTANCE) there is nothing left to shrink — absorb
+      // further downward travel into the offset base. Banked below-floor
+      // travel meant a full-screen down-up-down-up mouse drag drifted out of
+      // sync: the sheet sat at the bottom while the pointer's banked debt was
+      // paid back pixel-for-pixel before it would rise again.
+      if (sheetOpen && raw < -PILL_OPEN_DISTANCE) {
+        const overshoot = raw + PILL_OPEN_DISTANCE; // negative
+        dragOffsetBaseRef.current += overshoot;
+        off -= overshoot;
+        raw = -PILL_OPEN_DISTANCE;
       }
       // Re-arm the maximize commit only once the pull has dropped back below the
       // inset FULL height — hysteresis so leaving a committed maximize (which
@@ -4826,6 +4907,7 @@ export function ContinuousChatOverlay({
           ref={bindPanelRef}
           aria-label="Chat composer"
           data-testid="chat-sheet"
+          onWheel={onSheetWheel}
           data-variant={sheetOpen ? "open" : "closed"}
           data-detent={detentLabel}
           data-maximized={fullBleed ? "true" : undefined}
@@ -5254,7 +5336,7 @@ export function ContinuousChatOverlay({
                   // horizontal scrollbar strip across the sheet on iOS — the
                   // "weird side scroll thingy." This transcript only ever scrolls
                   // vertically; pin the horizontal axis closed.
-                  className="relative flex min-h-0 w-full flex-1 touch-pan-y flex-col overflow-y-auto overflow-x-hidden overscroll-contain px-5 outline-none [scrollbar-width:none] [-webkit-overflow-scrolling:touch] [&::-webkit-scrollbar]:hidden"
+                  className="scrollbar-hide relative flex min-h-0 w-full flex-1 touch-pan-y flex-col overflow-y-auto overflow-x-hidden overscroll-contain px-5 outline-none [-webkit-overflow-scrolling:touch]"
                   style={{ opacity: threadContentOpacity }}
                 >
                   {/* Empty-thread loading: a fresh/cleared chat awaiting its
@@ -5689,7 +5771,7 @@ export function ContinuousChatOverlay({
                 // During onboarding the placeholder invites the unlocked
                 // composer ("Ask … anything, or sign in above"), so brighten it
                 // from the resting 45% to 70% to read clearly beside the choices.
-                className={`max-h-[8.5rem] min-h-8 min-w-0 flex-1 resize-none self-center border-none bg-transparent px-1.5 py-1 text-left text-sm leading-relaxed text-txt outline-none [scrollbar-width:none] [&::-webkit-scrollbar]:hidden ${
+                className={`scrollbar-hide max-h-[8.5rem] min-h-8 min-w-0 flex-1 resize-none self-center border-none bg-transparent px-1.5 py-1 text-left text-sm leading-relaxed text-txt outline-none ${
                   firstRunOpen
                     ? "placeholder:text-muted-strong"
                     : "placeholder:text-muted"

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.render-count.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.render-count.test.tsx
@@ -163,9 +163,12 @@ describe("NotificationsHomeCenter render count (#14559)", () => {
     act(() => {
       vi.advanceTimersByTime(0);
     });
-    // Fan the shade out so all 30 rows paint flat (rested stacks would hide
-    // same-category rows behind their group's top card).
+    // Fan the shade AND the group's stack out so all 30 rows paint flat
+    // (stacks persist through the shade toggle now).
     fireEvent.click(screen.getByTestId("notifications-expand-toggle"));
+    for (const label of screen.getAllByTestId("notification-group-label")) {
+      if (!(label as HTMLButtonElement).disabled) fireEvent.click(label);
+    }
     expect(screen.getAllByTestId("notification-row")).toHaveLength(30);
     expect(rowRenders).toBeGreaterThanOrEqual(30);
 

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -439,12 +439,14 @@ describe("NotificationsHomeCenter", () => {
     ).toBeGreaterThan(0);
   });
 
-  it("caps rendering at 100 rows when the shade is expanded", () => {
+  it("caps rendering at 100 rows when the shade + stack are expanded", () => {
     for (let i = 0; i < 120; i++) {
       __ingestNotificationForTests(makeNotification({ priority: "high" }));
     }
     render(<NotificationsHomeCenter />);
     fireEvent.click(screen.getByTestId("notifications-expand-toggle"));
+    // Stacks persist through the shade toggle; fan the group to see its rows.
+    fireEvent.click(screen.getByTestId("notification-group-label"));
     expect(screen.getAllByTestId("notification-row")).toHaveLength(100);
   });
 
@@ -457,6 +459,7 @@ describe("NotificationsHomeCenter", () => {
     );
     render(<NotificationsHomeCenter />);
     fireEvent.click(screen.getByTestId("notifications-expand-toggle"));
+    fireEvent.click(screen.getByTestId("notification-group-label"));
     // A notification is its glass card - no leading edge highlight even for
     // urgent rows, no per-row icon chip.
     expect(screen.getAllByTestId("notification-row")).toHaveLength(2);
@@ -511,7 +514,9 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
     expect(peeks).toHaveLength(2);
     for (const peek of peeks) {
       expect(peek.className).toContain("eliza-notif-glass");
-      expect(peek.getAttribute("aria-hidden")).toBe("true");
+      // Peeks are TAPPABLE (tap fans the stack) and blur with depth.
+      expect(peek.tagName).toBe("BUTTON");
+      expect(peek.style.filter).toContain("blur(");
       expect(peek.style.transform).toMatch(/translateY\(\d+px\) scale\(0\.9/);
     }
     // Deeper cards sit lower in Z and protrude further.
@@ -545,7 +550,7 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
     expect(screen.queryByTestId("notification-stack-peek")).toBeNull();
   });
 
-  it("expanding the shade fans every stack out flat", () => {
+  it("expanding the shade keeps the stacks; tapping a peek fans the group in place", () => {
     __ingestNotificationForTests(
       makeNotification({ title: "A", priority: "high" }),
     );
@@ -557,7 +562,12 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
     );
     render(<NotificationsHomeCenter />);
     expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
+    // The shade toggle reveals more GROUPS but never flattens a stack.
     fireEvent.click(screen.getByTestId("notifications-expand-toggle"));
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
+    expect(screen.getByTestId("notification-stack")).toBeTruthy();
+    // Tapping the peeked card below the top one fans the stack out.
+    fireEvent.click(screen.getAllByTestId("notification-stack-peek")[0]);
     expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
     expect(screen.queryByTestId("notification-stack")).toBeNull();
     expect(screen.queryByTestId("notification-stack-peek")).toBeNull();
@@ -566,6 +576,10 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
       .getAllByTestId("notification-row")
       .map((el) => el.textContent ?? "");
     expect(titles[0]).toContain("C");
+    // The eyebrow folds it back into the stack.
+    fireEvent.click(screen.getByTestId("notification-group-label"));
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
+    expect(screen.getByTestId("notification-stack")).toBeTruthy();
   });
 
   it("swiping away the top card surfaces the next card in the stack", () => {
@@ -680,10 +694,14 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
     fireEvent.click(screen.getByTestId("notifications-expand-toggle"));
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
-    expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
+    // All three priorities are now represented — still stacked (1 top card +
+    // 2 tappable peeks); the shade toggle reveals groups, never flattens them.
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
+    expect(screen.getAllByTestId("notification-stack-peek")).toHaveLength(2);
     fireEvent.click(screen.getByTestId("notifications-expand-toggle"));
     expect(list.getAttribute("data-shade-mode")).toBe("rested");
     expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
+    expect(screen.queryAllByTestId("notification-stack-peek")).toHaveLength(0);
   });
 
   it("a mouse pull-down past the commit travel expands the shade", () => {
@@ -710,7 +728,9 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
       clientY: 140,
     });
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
-    expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
+    // Stacks persist through the pull; the peeks carry the revealed rows.
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
+    expect(screen.getAllByTestId("notification-stack-peek")).toHaveLength(2);
   });
 
   it("a short pull springs back without toggling", () => {
@@ -752,7 +772,9 @@ describe("NotificationsHomeCenter (pull to expand / collapse)", () => {
     });
     fireEvent.touchEnd(list, { touches: [] });
     expect(list.getAttribute("data-shade-mode")).toBe("expanded");
-    expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
+    // Stacks persist through the pull; the peeks carry the revealed rows.
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(1);
+    expect(screen.getAllByTestId("notification-stack-peek")).toHaveLength(2);
   });
 
   it("a continuous drag that scrolls the expanded list back to the top does NOT collapse (re-base at the crossing)", () => {

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.test.tsx
@@ -582,6 +582,65 @@ describe("NotificationsHomeCenter (Z-stacked groups)", () => {
     expect(screen.getByTestId("notification-stack")).toBeTruthy();
   });
 
+  it("keeps a fanned stack open when the shade expands", () => {
+    __ingestNotificationForTests(
+      makeNotification({ title: "A", priority: "high" }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({ title: "B", priority: "high" }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({ title: "C", priority: "urgent" }),
+    );
+    render(<NotificationsHomeCenter />);
+    fireEvent.click(screen.getAllByTestId("notification-stack-peek")[0]);
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
+    const list = screen.getByTestId("home-notification-list");
+    fireEvent.click(screen.getByTestId("notifications-expand-toggle"));
+    expect(list.getAttribute("data-shade-mode")).toBe("expanded");
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
+    expect(screen.queryByTestId("notification-stack-peek")).toBeNull();
+  });
+
+  it("swiping down on a stack fans it without also pulling the shade open", () => {
+    __ingestNotificationForTests(
+      makeNotification({ title: "A", priority: "high" }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({ title: "B", priority: "high" }),
+    );
+    __ingestNotificationForTests(
+      makeNotification({ title: "C", priority: "urgent" }),
+    );
+    render(<NotificationsHomeCenter />);
+    const list = screen.getByTestId("home-notification-list");
+    const stack = screen.getByTestId("notification-stack");
+    fireEvent.pointerDown(stack, {
+      pointerType: "mouse",
+      button: 0,
+      isPrimary: true,
+      pointerId: 8,
+      clientY: 10,
+    });
+    fireEvent.pointerMove(stack, {
+      pointerType: "mouse",
+      button: 0,
+      isPrimary: true,
+      pointerId: 8,
+      clientY: 110,
+    });
+    fireEvent.pointerUp(list, {
+      pointerType: "mouse",
+      button: 0,
+      isPrimary: true,
+      pointerId: 8,
+      clientY: 110,
+    });
+    expect(list.getAttribute("data-shade-mode")).toBe("rested");
+    expect(screen.getAllByTestId("notification-row")).toHaveLength(3);
+    expect(screen.queryByTestId("notification-stack-peek")).toBeNull();
+  });
+
   it("swiping away the top card surfaces the next card in the stack", () => {
     __ingestNotificationForTests(
       makeNotification({ title: "Below", priority: "high" }),

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -14,8 +14,9 @@
  *    highest-priority card on top, the rest peeking out beneath it (the iOS
  *    lock-screen stack idiom, stacked by priority). A quiet "N more" hint (not
  *    a button) names what's hidden.
- *  - EXPANDED fans every stack out flat and includes all priorities; the list
- *    is height-capped and scrolls internally.
+ *  - EXPANDED includes all priorities but preserves each view-group stack until
+ *    the user fans that group out in place; the list is height-capped and
+ *    scrolls internally.
  *
  *  Pulling DOWN on the shade (touch drag / mouse drag / wheel-up) while the
  *  list sits at its top toggles between the modes: at rest the pull expands;
@@ -643,8 +644,8 @@ NotificationRow.displayName = "NotificationRow";
 export function NotificationsHomeCenter(): React.JSX.Element | null {
   notificationsHomeCenterRenderObserverForTests?.();
   const { notifications } = useNotifications();
-  // Shade mode: rested (priority triage, stacked groups) vs expanded (all
-  // rows, flat). Toggled by the pull gesture — there are no more/less buttons.
+  // Shade mode: rested (priority triage) vs expanded (all priority tiers).
+  // Groups stay stacked until individually fanned out.
   const [shadeExpanded, setShadeExpanded] = useState(false);
   // Single-open option strip: expanding one row collapses the others.
   const [expandedRowId, setExpandedRowId] = useState<string | null>(null);
@@ -705,12 +706,14 @@ export function NotificationsHomeCenter(): React.JSX.Element | null {
   const toggleShade = useCallback(() => {
     setShadeExpanded((v) => !v);
     setExpandedRowId(null);
-    // Folding the shade folds every fanned stack with it — the rested shade
-    // always comes back in its compact triage form.
-    setExpandedStacks(new Set());
+    if (shadeExpanded) {
+      // Folding the shade folds every fanned stack with it — the rested shade
+      // always comes back in its compact triage form.
+      setExpandedStacks(new Set());
+    }
     // Both modes start reading from the top of the shade.
     if (scrollRef.current) scrollRef.current.scrollTop = 0;
-  }, []);
+  }, [shadeExpanded]);
 
   const commitPull = useCallback(() => {
     if (pullPxRef.current >= PULL_COMMIT_PX) toggleShade();
@@ -1048,7 +1051,7 @@ export function NotificationsHomeCenter(): React.JSX.Element | null {
                 onPointerUp={() => {
                   stackFanGesture.current = null;
                 }}
-                className="flex items-center px-2 pb-0.5 pt-2 text-left text-2xs font-medium uppercase tracking-[0.08em] text-white/55 first:pt-1 disabled:pointer-events-none"
+                className="flex min-h-touch items-center px-2 pb-0.5 pt-2 text-left text-2xs font-medium uppercase tracking-[0.08em] text-white/55 first:pt-1 disabled:pointer-events-none"
               >
                 {group.label}
                 {fanable ? (
@@ -1081,6 +1084,7 @@ export function NotificationsHomeCenter(): React.JSX.Element | null {
                   className="relative"
                   onPointerDown={(e) => {
                     if (e.pointerType !== "mouse" || e.button !== 0) return;
+                    e.stopPropagation();
                     stackFanGesture.current = {
                       key: group.label,
                       startY: e.clientY,

--- a/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
+++ b/packages/ui/src/components/shell/NotificationsHomeCenter.tsx
@@ -91,6 +91,9 @@ const PULL_SLOP_PX = 8;
 /** How many cards may peek out beneath a rested stack's top card. */
 const MAX_STACK_PEEKS = 2;
 
+/** Mouse travel (px) that fans a Z-stack out when swiping down over it. */
+const STACK_FAN_SWIPE_PX = 32;
+
 /** Vertical offset (px) each successive peek card protrudes beneath the top. */
 const STACK_PEEK_OFFSET_PX = 8;
 
@@ -645,6 +648,21 @@ export function NotificationsHomeCenter(): React.JSX.Element | null {
   const [shadeExpanded, setShadeExpanded] = useState(false);
   // Single-open option strip: expanding one row collapses the others.
   const [expandedRowId, setExpandedRowId] = useState<string | null>(null);
+  // Per-group stack expansion (iOS-shade idiom): a group fans out in place
+  // when its stack is tapped below the top card or swiped down, and folds back
+  // on an eyebrow tap / upward swipe. Independent of the shade toggle, so the
+  // expanded shade keeps its stacks too — the pull just reveals more groups.
+  const [expandedStacks, setExpandedStacks] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const toggleStack = useCallback((key: string) => {
+    setExpandedStacks((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
   // Dampened live pull (px). State drives the rubber-band transform; the ref
   // mirrors it for the native touch listeners' commit path.
   const [pullPx, setPullPxState] = useState(0);
@@ -675,6 +693,9 @@ export function NotificationsHomeCenter(): React.JSX.Element | null {
   // Mirrors whether the shade currently has more to reveal (rested) — the
   // native touch listeners read it without re-binding on every data change.
   const canExpandRef = useRef(false);
+  // In-flight mouse swipe-down on a Z-stack (fans the stack out). Touch keeps
+  // vertical drags for the scroller; touch fans via peek taps.
+  const stackFanGesture = useRef<{ key: string; startY: number } | null>(null);
 
   const setPullPx = useCallback((px: number) => {
     pullPxRef.current = px;
@@ -684,6 +705,9 @@ export function NotificationsHomeCenter(): React.JSX.Element | null {
   const toggleShade = useCallback(() => {
     setShadeExpanded((v) => !v);
     setExpandedRowId(null);
+    // Folding the shade folds every fanned stack with it — the rested shade
+    // always comes back in its compact triage form.
+    setExpandedStacks(new Set());
     // Both modes start reading from the top of the shade.
     if (scrollRef.current) scrollRef.current.scrollTop = 0;
   }, []);
@@ -831,6 +855,7 @@ export function NotificationsHomeCenter(): React.JSX.Element | null {
   useEffect(() => {
     if (notifications.length === 0) {
       setShadeExpanded(false);
+      setExpandedStacks(new Set());
       setExpandedRowId(null);
       setPullPx(0);
     }
@@ -965,40 +990,116 @@ export function NotificationsHomeCenter(): React.JSX.Element | null {
         className={cn(
           // select-none: a mouse pull-drag must read as a gesture, not a text
           // selection sweep across the cards (platform-shade idiom).
-          "eliza-notif-scroll flex min-h-0 flex-1 select-none flex-col gap-1 overflow-y-auto overscroll-y-contain px-1.5 pb-1.5",
+          "eliza-notif-scroll flex min-h-0 flex-1 select-none flex-col gap-2 overflow-y-auto overscroll-y-contain px-1.5 pb-1.5",
         )}
       >
         {groups.map((group) => {
-          const stacked = !shadeExpanded && group.rows.length > 1;
+          const stackExpanded = expandedStacks.has(group.label);
+          const stacked = !stackExpanded && group.rows.length > 1;
           const peeks = stacked ? group.rows.slice(1, 1 + MAX_STACK_PEEKS) : [];
           const rows = stacked
             ? [group.rows[0] as AgentNotification]
             : group.rows;
+          const fanable = group.rows.length > 1;
           return (
-            <li key={group.label} className="flex flex-col gap-1">
+            <li key={group.label} className="flex flex-col gap-1.5">
               {/* View group header (Apple-shade idiom: group by destination).
-                  A quiet eyebrow, not a boxed section — restraint over chrome. */}
-              <span
+                  A quiet eyebrow — and for multi-row groups, the fold/unfold
+                  control: tap (or swipe up over it) folds a fanned group back
+                  into its stack. */}
+              <button
+                type="button"
                 data-testid="notification-group-label"
-                className="px-2 pb-0.5 pt-2 text-2xs font-medium uppercase tracking-[0.08em] text-white/55 first:pt-1"
+                data-notif-control=""
+                disabled={!fanable}
+                onClick={fanable ? () => toggleStack(group.label) : undefined}
+                aria-expanded={fanable ? stackExpanded : undefined}
+                aria-label={
+                  fanable
+                    ? stackExpanded
+                      ? `Collapse ${group.label} notifications`
+                      : `Expand ${group.label} notifications`
+                    : undefined
+                }
+                onPointerDown={(e) => {
+                  if (
+                    !fanable ||
+                    !stackExpanded ||
+                    e.pointerType !== "mouse" ||
+                    e.button !== 0
+                  ) {
+                    return;
+                  }
+                  stackFanGesture.current = {
+                    key: group.label,
+                    startY: e.clientY,
+                  };
+                }}
+                onPointerMove={(e) => {
+                  const g = stackFanGesture.current;
+                  if (!g || g.key !== group.label || !stackExpanded) return;
+                  // Mouse swipe UP over the fanned group's header folds it
+                  // back into its stack (mirror of the swipe-down fan-out).
+                  if (g.startY - e.clientY >= STACK_FAN_SWIPE_PX) {
+                    stackFanGesture.current = null;
+                    toggleStack(group.label);
+                  }
+                }}
+                onPointerUp={() => {
+                  stackFanGesture.current = null;
+                }}
+                className="flex items-center px-2 pb-0.5 pt-2 text-left text-2xs font-medium uppercase tracking-[0.08em] text-white/55 first:pt-1 disabled:pointer-events-none"
               >
                 {group.label}
-                {stacked ? (
-                  <span
-                    data-testid="notification-stack-count"
-                    className="pl-1.5 normal-case tracking-normal text-white/40 tabular-nums"
-                  >
-                    {group.rows.length}
-                  </span>
+                {fanable ? (
+                  <>
+                    <span
+                      data-testid="notification-stack-count"
+                      className="pl-1.5 normal-case tracking-normal text-white/40 tabular-nums"
+                    >
+                      {group.rows.length}
+                    </span>
+                    <ChevronDown
+                      aria-hidden
+                      className={cn(
+                        "ml-1 h-3 w-3 text-white/40 transition-transform",
+                        stackExpanded && "rotate-180",
+                      )}
+                    />
+                  </>
                 ) : null}
-              </span>
+              </button>
               {stacked ? (
                 // The Z-stack: the group's highest-priority card on top, the
                 // next cards peeking out beneath it — depth in Z, ordered by
                 // the same priority→recency order the fanned list uses.
+                // A mouse swipe DOWN on the stack fans it out (touch fans via
+                // a tap on the peeked cards — a touch vertical drag belongs to
+                // the shade scroller).
                 <div
                   data-testid="notification-stack"
                   className="relative"
+                  onPointerDown={(e) => {
+                    if (e.pointerType !== "mouse" || e.button !== 0) return;
+                    stackFanGesture.current = {
+                      key: group.label,
+                      startY: e.clientY,
+                    };
+                  }}
+                  onPointerMove={(e) => {
+                    const g = stackFanGesture.current;
+                    if (!g || g.key !== group.label) return;
+                    if (e.clientY - g.startY >= STACK_FAN_SWIPE_PX) {
+                      stackFanGesture.current = null;
+                      toggleStack(group.label);
+                    }
+                  }}
+                  onPointerUp={() => {
+                    stackFanGesture.current = null;
+                  }}
+                  onPointerCancel={() => {
+                    stackFanGesture.current = null;
+                  }}
                   style={{
                     paddingBottom: peeks.length * STACK_PEEK_OFFSET_PX,
                   }}
@@ -1020,14 +1121,21 @@ export function NotificationsHomeCenter(): React.JSX.Element | null {
                     />
                   </ul>
                   {peeks.map((peek, i) => (
-                    <div
+                    // The cards behind the top one blur with depth and are
+                    // TAPPABLE: touching the visible sliver below the top card
+                    // fans the stack out in place (iOS shade idiom).
+                    <button
                       key={peek.id}
-                      aria-hidden
+                      type="button"
                       data-testid="notification-stack-peek"
-                      className="eliza-notif-glass pointer-events-none absolute inset-0 rounded-2xl"
+                      data-notif-control=""
+                      aria-label={`Show all ${group.rows.length} ${group.label} notifications`}
+                      onClick={() => toggleStack(group.label)}
+                      className="eliza-notif-glass absolute inset-0 rounded-2xl"
                       style={{
                         zIndex: 1 - i,
                         opacity: 0.75 - i * 0.25,
+                        filter: `blur(${(i + 1) * 1.25}px)`,
                         transform: `translateY(${(i + 1) * STACK_PEEK_OFFSET_PX}px) scale(${
                           1 - (i + 1) * 0.045
                         })`,
@@ -1036,7 +1144,7 @@ export function NotificationsHomeCenter(): React.JSX.Element | null {
                   ))}
                 </div>
               ) : (
-                <ul className="flex flex-col gap-1">
+                <ul className="flex flex-col gap-1.5">
                   {rows.map((notification) => (
                     <NotificationRow
                       key={notification.id}

--- a/packages/ui/src/components/shell/__e2e__/capture-default-notifications.mjs
+++ b/packages/ui/src/components/shell/__e2e__/capture-default-notifications.mjs
@@ -264,8 +264,8 @@ for (const [name, width, height] of [
   });
   console.log(`  📸 notifications-${name}-rested.png`);
 
-  // 2. PULL TO EXPAND: a real mouse drag down from the list top fans every
-  //    stack out flat and reveals all priorities.
+  // 2. PULL TO EXPAND: a real mouse drag down from the list top reveals every
+  //    priority tier — but the Z-stacks PERSIST (per-stack fan-out below).
   await pullDown(page);
   await page.waitForFunction(
     (sel) =>
@@ -275,9 +275,20 @@ for (const [name, width, height] of [
     LIST,
   );
   check("pull-down expands the shade", (await shadeMode(page)) === "expanded");
+  check(
+    "stacks persist through the shade expand",
+    (await page.locator('[data-testid="notification-stack-peek"]').count()) >
+      0,
+  );
+  // Fan every multi-row group via its eyebrow (the peek sliver taps too).
+  for (const label of await page
+    .locator('[data-testid="notification-group-label"]:not([disabled])')
+    .all()) {
+    await label.click();
+  }
   check("all seven rows visible", (await page.locator(ROW).count()) === 7);
   check(
-    "stacks fanned out (no peeks)",
+    "stacks fanned out per group (no peeks left)",
     (await page.locator('[data-testid="notification-stack-peek"]').count()) ===
       0,
   );

--- a/packages/ui/src/hooks/useHorizontalPager.ts
+++ b/packages/ui/src/hooks/useHorizontalPager.ts
@@ -608,6 +608,15 @@ export function useHorizontalPager<
       ) {
         return;
       }
+      // A gesture that starts on a notification row belongs to the row's
+      // swipe-to-dismiss — the pager must yield it entirely, or a horizontal
+      // dismiss drags the whole launcher rail along with the card.
+      if (
+        event.target instanceof Element &&
+        event.target.closest("[data-notif-row]")
+      ) {
+        return;
+      }
       cancelScheduledOffset();
       const currentPage = clampPage(pageRef.current, pageCountRef.current);
       const width = measureWidth();


### PR DESCRIPTION
Clean re-land of the 8-item gesture-polish sweep onto develop. The original vehicle (`feat/notifications-inline-widget`, PR #15290) had its history rewritten by a concurrent lane, which dropped this work; this PR restores it as a small, isolated change (6 files) off current develop.

**Notification shade**
- Stacks persist through the shade pull — expanding reveals more groups, never flattens; each group fans in place.
- Peeked cards blur with depth and are tappable (the sliver fans the stack); mouse swipe-down fans, swipe-up over the fanned header folds; the eyebrow is a button with count + chevron.
- The launcher pager yields horizontal gestures that start on a notification row, so swipe-to-dismiss no longer drags the whole launcher rail.

**Chat sheet**
- Symmetric floor consumption: repeated full-screen down-up drags stay 1:1 with the pointer (fixes the desync where the sheet lagged behind).
- Two-finger trackpad wheel steps one detent per swipe (pill ↔ input ↔ half ↔ full ↔ maximized), with accumulate/decay/cooldown; transcript scrolling untouched; touch stays drag-only.
- Transcript + composer scrollbars actually hidden on desktop web (`.scrollbar-hide` beats the un-layered universal `scrollbar-width: thin`).

**Verification**: UI typecheck clean; 225 unit tests pass (NotificationsHomeCenter + render-count + ChatOverlay + mouse-drag adversarial suite); notification browser harness (`capture-default-notifications.mjs`) updated to the per-stack model.

Supersedes the gesture portion of #15290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15332-15290-before-flat-expand.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15332-15290-after-per-stack.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/15332-15290-chat-drag-walkthrough.mp4

<!-- evidence-row:frontend-logs -->
- [x] [15332-15290-frontend.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15332-15290-frontend.log)

<!-- evidence-row:ocr-review -->
- [x] [15332-15290-ocr.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15332-15290-ocr.txt)

<!-- evidence-row:backend-logs -->
- [ ] N/A - client-only gesture/rendering change; no server code path

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model changes

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB/memory/scheduled-task/wallet/file output; the artifacts are the rendered pixels + gesture state shown above
