### PR TITLE
fix(ci): green the Plugin Tests shards — #14459 fallout across 16 plugins

### DIFF
--- a/packages/import-conversations/package.json
+++ b/packages/import-conversations/package.json
@@ -118,5 +118,10 @@
   },
   "devDependencies": {
     "@types/node": "^24.0.0"
+  },
+  "elizaos": {
+    "scripts": {
+      "coreBuild": true
+    }
   }
 }

--- a/packages/test/vitest/shims/elizaos-core-connector.ts
+++ b/packages/test/vitest/shims/elizaos-core-connector.ts
@@ -92,6 +92,18 @@ export const ModelType = {
   IMAGE_DESCRIPTION: "IMAGE_DESCRIPTION",
 } as const;
 
+// Canonical role-rank table mirroring `@elizaos/core`'s `ROLE_RANK` (roles.ts).
+// `@elizaos/ui`'s ShellRoleProvider derives its recognized role set at module
+// load via `Object.keys(ROLE_RANK)`; the real module pulls entities/logger, so
+// the shim carries the literal (matching the enum stubs above) rather than
+// re-exporting it, keeping the barrel loadable in the keyless lane.
+export const ROLE_RANK = {
+  GUEST: 1,
+  USER: 2,
+  ADMIN: 3,
+  OWNER: 4,
+} as const;
+
 export function stringToUuid(value: string): string {
   const hex = createHash("sha1").update(value).digest("hex").slice(0, 32);
   return [

--- a/plugins/plugin-app-control/src/actions/settings.test.ts
+++ b/plugins/plugin-app-control/src/actions/settings.test.ts
@@ -637,7 +637,7 @@ describe("SETTINGS action: set on an owned route section", () => {
 
 	it("fills an empty voice config's missing silence with the capture default when setting RMS", async () => {
 		// Empty `messages` — setting only the RMS must seed the missing silenceMs
-		// with the canonical capture default (900ms) so the twin stays aligned.
+		// with the canonical capture default (550ms) so the twin stays aligned.
 		const routeFetch = vi.fn<SettingsRouteFetch>(async (request) => {
 			if (request.method === "GET") {
 				return { ok: true, data: { messages: {} } };

--- a/plugins/plugin-app-control/src/actions/settings.ts
+++ b/plugins/plugin-app-control/src/actions/settings.ts
@@ -772,8 +772,13 @@ const VOICE_CONTINUOUS_ALIASES: ReadonlyMap<string, VoiceContinuousMode> =
 // mechanically by a test that imports the canonical constant.
 export const DEFAULT_VOICE_SETTINGS_PREFS: VoiceSettingsPrefs = {
 	continuous: "off",
+	// Must track the canonical capture default (`DEFAULT_LOCAL_ASR_AUTO_STOP` in
+	// @elizaos/ui): a chat-write that seeds a partial voice config must persist the
+	// same VAD sensitivity the running capture path uses, or the stored value
+	// diverges from what the Voice UI applies. #15267 dropped the canonical
+	// silence window 900 → 550; settings.test.ts pins these in sync.
 	vadAutoStop: {
-		silenceMs: 900,
+		silenceMs: 550,
 		speechRmsThreshold: 0.003,
 	},
 };

--- a/plugins/plugin-goals/vitest.config.ts
+++ b/plugins/plugin-goals/vitest.config.ts
@@ -21,6 +21,14 @@ export default defineConfig({
     // @elizaos/core + drizzle).
     alias: [
       {
+        find: /^@elizaos\/plugin-goals\/db\/schema$/,
+        replacement: sourceOf("src/db/schema.ts"),
+      },
+      {
+        find: /^@elizaos\/plugin-reminders\/db\/schema$/,
+        replacement: sourceOf("../plugin-reminders/src/db/schema.ts"),
+      },
+      {
         find: /^@elizaos\/plugin-inbox\/db\/schema$/,
         replacement: sourceOf("../plugin-inbox/src/db/schema.ts"),
       },

--- a/plugins/plugin-health/vitest.config.ts
+++ b/plugins/plugin-health/vitest.config.ts
@@ -4,24 +4,26 @@
  */
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
-import {
-  providerSdkAliases,
-  providerSdkShimPlugin,
-} from "../../packages/test/vitest/provider-sdk-aliases";
+import { providerSdkShimPlugin } from "../../packages/test/vitest/provider-sdk-aliases";
 
-// Cross-plugin gate coverage must exercise sibling source, not stale dist.
-const aliases = {
-  ...providerSdkAliases,
-  "@elizaos/shared": fileURLToPath(
-    new URL("../../packages/shared/src/index.ts", import.meta.url),
-  ),
-  "@elizaos/tui": fileURLToPath(
-    new URL("../../packages/tui/src/index.ts", import.meta.url),
-  ),
-  "@elizaos/plugin-scheduling": fileURLToPath(
-    new URL("../plugin-scheduling/src/index.ts", import.meta.url),
-  ),
-};
+const fromHere = (relative: string) =>
+  fileURLToPath(new URL(relative, import.meta.url));
+
+// Cross-plugin gate coverage must exercise the sibling scheduling gate/anchor
+// registries from source, not stale dist — so only `@elizaos/plugin-scheduling`
+// is pinned to source. `@elizaos/shared` and `@elizaos/tui` deliberately stay
+// on their (coreBuild) dist: the smoke test loads the full health plugin, whose
+// `HealthView` pulls in `@elizaos/ui`'s dist, which imports ~25 `@elizaos/shared`
+// subpaths. Redirecting bare `@elizaos/shared` to source while those subpaths
+// resolve to dist splits `shared` across two builds and leaves an export
+// undefined at eval time (`Object.keys(undefined)`); keeping shared uniformly on
+// dist avoids the split. Provider SDK shims come from `providerSdkShimPlugin()`.
+const aliases = [
+  {
+    find: /^@elizaos\/plugin-scheduling$/,
+    replacement: fromHere("../plugin-scheduling/src/index.ts"),
+  },
+];
 
 export default defineConfig({
   plugins: [providerSdkShimPlugin()],

--- a/plugins/plugin-local-inference/src/services/downloader.test.ts
+++ b/plugins/plugin-local-inference/src/services/downloader.test.ts
@@ -94,7 +94,7 @@ function eliza1Manifest(overrides: {
 			vad: [{ path: vadPath, sha256: overrides.shaFor("vad") }],
 		},
 		kernels: {
-			required: ["turboquant_q4", "qjl", "polarquant", "turbo3_tcq"],
+			required: ["turboquant_q4", "qjl", "polarquant", "turbo3_tcq", "mtp"],
 			optional: [],
 			verifiedBackends,
 		},
@@ -421,7 +421,7 @@ describe("local inference downloader status", () => {
 				vad: [{ path: vadPath, sha256: sha256(vad) }],
 			},
 			kernels: {
-				required: ["turboquant_q4", "qjl", "polarquant", "turbo3_tcq"],
+				required: ["turboquant_q4", "qjl", "polarquant", "turbo3_tcq", "mtp"],
 				optional: [],
 				verifiedBackends: {
 					metal: {
@@ -636,7 +636,7 @@ describe("local inference downloader status", () => {
 				cache: [{ path: cachePath, sha256: sha256("c") }],
 			},
 			kernels: {
-				required: ["turboquant_q4", "qjl", "polarquant", "turbo3_tcq"],
+				required: ["turboquant_q4", "qjl", "polarquant", "turbo3_tcq", "mtp"],
 				optional: [],
 				verifiedBackends: {
 					metal: { status: "skipped", atCommit: "t", report: "n/a" },

--- a/plugins/plugin-music/src/__tests__/core-test-mock.ts
+++ b/plugins/plugin-music/src/__tests__/core-test-mock.ts
@@ -47,6 +47,12 @@ vi.mock("@elizaos/core", () => {
       return result;
     },
     promoteSubactionsToActions: (action: unknown) => [action],
+    // Pass-through so the real sibling suno provider (aliased to source) runs
+    // its operation and records nothing — mirrors suno's own behavior test.
+    recordLlmCall: vi.fn(
+      async (_runtime: unknown, _details: unknown, operation: () => unknown) =>
+        operation(),
+    ),
     Service,
     logger,
   };

--- a/plugins/plugin-music/vitest.config.ts
+++ b/plugins/plugin-music/vitest.config.ts
@@ -1,9 +1,24 @@
 /**
  * Vitest configuration for deterministic node-based music plugin tests.
+ * `music.test.ts` exercises the real sibling `@elizaos/plugin-suno` handler,
+ * whose dist is not built in the keyless Plugin Tests lane — anchor its `.`
+ * entry to source so the integration runs against the real handler.
  */
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
+const rootDir = dirname(fileURLToPath(import.meta.url));
+
 export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: /^@elizaos\/plugin-suno$/,
+        replacement: resolve(rootDir, "../plugin-suno/src/index.ts"),
+      },
+    ],
+  },
   test: {
     environment: "node",
     include: ["src/**/*.test.ts", "src/__tests__/**/*.test.ts"],

--- a/plugins/plugin-native-settings/src/components/DeviceSettingsAppView.test.ts
+++ b/plugins/plugin-native-settings/src/components/DeviceSettingsAppView.test.ts
@@ -40,6 +40,8 @@ vi.mock("@elizaos/ui", () => ({
   }: React.ButtonHTMLAttributes<HTMLButtonElement>) =>
     // biome-ignore lint/a11y/useButtonType: test mock supplies an explicit default type.
     React.createElement("button", { type, ...props }, children),
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) =>
+    React.createElement("input", props),
 }));
 
 import { DeviceSettingsAppView } from "./DeviceSettingsAppView";

--- a/plugins/plugin-native-settings/src/components/device-settings-contract.test.ts
+++ b/plugins/plugin-native-settings/src/components/device-settings-contract.test.ts
@@ -41,6 +41,8 @@ vi.mock("@elizaos/ui", () => ({
   }: React.ButtonHTMLAttributes<HTMLButtonElement>) =>
     // biome-ignore lint/a11y/useButtonType: test mock supplies an explicit default type.
     React.createElement("button", { type, ...props }, children),
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) =>
+    React.createElement("input", props),
 }));
 
 import { DeviceSettingsAppView } from "./DeviceSettingsAppView";

--- a/plugins/plugin-phone/test/plugin.test.ts
+++ b/plugins/plugin-phone/test/plugin.test.ts
@@ -1,7 +1,8 @@
 /**
  * Guards the appPhonePlugin manifest shape: no actions (VOICE_CALL stays
  * host-adapted by personal-assistant), exactly the phoneCallLog provider, and
- * one phone view spanning all three modalities.
+ * one phone view advertising the "gui" modality (XR/TUI surfaces removed in
+ * #15269/#15291).
  */
 
 import { describe, expect, it } from "vitest";
@@ -14,19 +15,20 @@ describe("appPhonePlugin manifest", () => {
     expect("voiceCallAction" in phoneExports).toBe(false);
   });
 
-  it("registers ONE phone view drawing all three modalities + the read-only call-log provider", () => {
+  it("registers ONE gui-modality phone view + the read-only call-log provider", () => {
     expect(appPhonePlugin.providers?.map((provider) => provider.name)).toEqual([
       "phoneCallLog",
     ]);
 
-    // Single source of truth: one declaration, modalities ["gui","xr","tui"],
-    // the unified PhoneView spatial component.
+    // Single source of truth: one declaration for the unified PhoneView. #15269
+    // /#15291 removed the shipped XR/TUI view surfaces (preserving viewType), so
+    // the view now advertises the "gui" modality only.
     const views = appPhonePlugin.views ?? [];
     expect(views).toHaveLength(1);
     const [view] = views;
     expect(view.id).toBe("phone");
     expect(view.componentExport).toBe("PhoneView");
-    expect(view.modalities).toEqual(["gui", "xr", "tui"]);
+    expect(view.modalities).toEqual(["gui"]);
     // No per-viewType duplicate declarations remain.
     expect(view.viewType).toBeUndefined();
   });

--- a/plugins/plugin-telegram/__tests__/core-test-mock.ts
+++ b/plugins/plugin-telegram/__tests__/core-test-mock.ts
@@ -16,6 +16,17 @@ vi.mock("@elizaos/core", async () => {
     "../../../packages/core/src/messaging/interactions/index"
   );
 
+  // The message-triage adapter base + service are equally pure (only `logger`
+  // and type imports), so the mock delegates to the real submodules rather than
+  // re-stubbing — `triage-adapter.ts` subclasses BaseMessageAdapter at module
+  // eval, so the real class must be present or `./index` fails to load.
+  const { BaseMessageAdapter } = await import(
+    "../../../packages/core/src/features/messaging/triage/adapters/base"
+  );
+  const { getDefaultTriageService } = await import(
+    "../../../packages/core/src/features/messaging/triage/triage-service"
+  );
+
   const logger = {
     debug: vi.fn(),
     error: vi.fn(),
@@ -106,9 +117,11 @@ vi.mock("@elizaos/core", async () => {
 
   return {
     ...interactions,
+    BaseMessageAdapter,
     ChannelType,
     CommandRegistryService,
     EventType,
+    getDefaultTriageService,
     ModelType,
     Role,
     Service,


### PR DESCRIPTION
## Summary

The develop **Tests → Plugin Tests** shards (1–4) have been red on ~19 plugins. Enumerating all four shard logs, almost every failure roots in **PR #14459** ("launch QA fixture contract"), which extracted `@elizaos/import-conversations`, changed the Eliza-1 manifest required-kernel set, added a smoke test that loads the full UI, and added an Android VoiceInteractionService — without updating the keyless Plugin Tests lane. This PR sweeps the tractable majority (16 plugins fully green) and isolates the domain-judgment remainder (3 plugins, documented below).

## Full plugin-shard failure inventory + per-item root cause & fix

### Build graph — one fix greens 9 UI-chain plugins
`@elizaos/import-conversations` is a `workspace:*` dep of `@elizaos/ui` but was **never built** in the Plugin Tests lane, so `@elizaos/ui`'s `MemoryViewerView` could not resolve `@elizaos/import-conversations/browser` (`dist/browser.js` missing → `ERR_MODULE_NOT_FOUND` for dist-resolving tests / "Failed to resolve import" for source-aliasing tests). turbo *knows* the `ui → import-conversations` edge, but the pre-existing `cloud-shared ↔ ui ↔ plugin-elizacloud` cycle drops it from the `^build` closure, so `build:core` never built it (verified: after `bun run build:core`, `packages/ui/dist` exists but `packages/import-conversations/dist` does not).
**Fix:** tag `packages/import-conversations` `elizaos.scripts.coreBuild: true` so `build:core` builds it explicitly.
**Greens:** `plugin-calendar`, `plugin-contacts`, `plugin-finances`, `plugin-todos`, `plugin-blocker`, `plugin-feed`, `plugin-goals` (UI files), `plugin-task-coordinator`, `plugin-workflow`, and the UI test files of `plugin-agent-orchestrator` + `plugin-local-inference`.

### Incomplete test doubles missing a newly-imported export
| Plugin | Failure | Fix |
| --- | --- | --- |
| `plugin-telegram` | `No "BaseMessageAdapter" export … on the "@elizaos/core" mock` | Add `BaseMessageAdapter` + `getDefaultTriageService` to the shared `vi.mock("@elizaos/core")` (delegating to the real pure triage submodules); `triage-adapter.ts` subclasses it at module eval. |
| `plugin-native-settings` | `No "Input" export … on the "@elizaos/ui" mock` | Add `Input` to the `@elizaos/ui` `vi.mock` in `DeviceSettingsAppView.test.ts` **and** `device-settings-contract.test.ts`. |
| `plugin-health` (root cause) | `TypeError: Cannot convert undefined or null to object` at `ShellRoleProvider` | The keyless `@elizaos/core` shim (`packages/test/vitest/shims/elizaos-core-connector.ts`) omitted `ROLE_RANK`; `@elizaos/ui`'s `ShellRoleProvider` does `Object.keys(ROLE_RANK)` at module load, crashing the entire ui barrel when health's smoke test imported it. Add `ROLE_RANK`. |

### Missing test-lane source aliases for extracted-package subpaths
| Plugin | Failure | Fix |
| --- | --- | --- |
| `plugin-goals` | `Cannot find package '@elizaos/plugin-goals/db/schema'` (PA repository imports it) | Alias `@elizaos/plugin-goals/db/schema` (self) + `@elizaos/plugin-reminders/db/schema` to source. |
| `plugin-health` | `ENOTDIR … packages/shared/src/index.ts/runtime-env` | Bare `@elizaos/shared` string alias prefix-matched every `@elizaos/shared/*` subpath. Scheduling source only needs the `plugin-scheduling → source` pin, so drop the shared/tui source aliases and let `@elizaos/shared` resolve to its (coreBuild) **dist** — consistent with `@elizaos/ui`. |
| `plugin-music` | `Failed to resolve entry for package "@elizaos/plugin-suno"` | Alias `@elizaos/plugin-suno` to source + add a `recordLlmCall` pass-through to the mock so the real sibling handler runs. |

### Stale assertion vs intentional behavior change
| Plugin | Failure | Citation / fix |
| --- | --- | --- |
| `plugin-phone` | `expected ['gui'] to deeply equal ['gui','xr','tui']` | XR/TUI view surfaces removed in **#15269/#15291**; assert `["gui"]`. |
| `plugin-local-inference` | `Invalid Eliza-1 manifest … missing required kernel for tier 2b: mtp` (12 downloader tests) | #14459 made `mtp` a required 2b kernel (`REQUIRED_KERNELS_BY_TIER`); add `mtp` to the downloader test manifest fixtures. |

### Real product bug
| Plugin | Failure | Fix |
| --- | --- | --- |
| `plugin-app-control` | `expected { silenceMs: 900 } to deeply equal { silenceMs: 550 }` | `DEFAULT_VOICE_SETTINGS_PREFS.vadAutoStop.silenceMs` stayed **900** after **#15267** dropped the canonical capture default (`DEFAULT_LOCAL_ASR_AUTO_STOP`) to **550**, so a chat-write persisted a different VAD sensitivity than the Voice UI applies. Align product to 550 (the test pins these in sync by design). |

## Deferred — domain judgment (isolated, NOT weakened)
All #14459 fallout; each needs product-intent I can't resolve unilaterally without risking a fake-green:
- **agent-orchestrator** (3 tests): default spawn framework `'codex'` vs expected `'opencode'`; completion-evidence URL-verification labeling; trace-usage duplicate-row rollup counting.
- **local-inference** (2 tests): `mmproj-routing` non-speculative fallback when a pre-cutover bundle lacks the drafter GGUF; ASR route response-shape (`{text, words, …}` vs `{text, words}`).
- **computeruse** (1 test): `AndroidManifest.xml` now declares a VoiceInteractionService with `android:permission="…BIND_VOICE_INTERACTION"` (standard service *protection*, added by #14459), which the test's broad `not.toContain("…BIND_VOICE_INTERACTION")` string check flags. The assertion likely needs narrowing to `<uses-permission>`, but that is a deliberate Android-contract call.

## Verification
Every touched plugin's suite run locally and green:
`telegram` 129, `native-settings` 22, `contacts` 56, `blocker`/`feed` 7 files, `todos` 5, `finances` 11, `calendar` 27, `task-coordinator` 230, `workflow` 379, `goals` 69, `health` 185, `music` 90, `app-control` 1493, `phone` 83, `local-inference` `downloader.test.ts` 26.
`bun run audit:error-policy-ratchet` clean; biome clean; `plugin-app-control` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)