### PR TITLE
fix(os-linux): pin out rocm-opencl-icd to unblock ISO chroot package install

### DIFF
--- a/packages/os/linux/tails/config/chroot_apt/preferences
+++ b/packages/os/linux/tails/config/chroot_apt/preferences
@@ -41,6 +41,17 @@ Package: python3-aiorpcx python3-electrum-aionostr python3-electrum-ecc libsecp2
 Pin: release o=Debian,n=trixie-backports
 Pin-Priority: 999
 
+Explanation: rocm-opencl-icd (ROCm compute) is an unintended provider of the
+Explanation: virtual `opencl-icd` on this mesa-graphics distro, and it carries
+Explanation: `Breaks: mesa-opencl-icd`. In the multi-suite snapshot the apt
+Explanation: solver selects both it and mesa-opencl-icd (the intended provider),
+Explanation: deadlocking the chroot package install ("Reached two conflicting
+Explanation: decisions"). Pin it out so `opencl-icd` resolves to mesa-opencl-icd
+Explanation: alone. Nothing in our package lists depends on rocm directly.
+Package: rocm-opencl-icd
+Pin: release *
+Pin-Priority: -1
+
 Explanation: weirdness in chroot_apt install-binary
 Package: *
 Pin: release o=chroot_local-packages


### PR DESCRIPTION
## Problem

The nightly **Build elizaOS Linux ISO** workflow (amd64, the only required check) has been red at live-build's chroot **package install** stage (layer 8). apt's `--solver 3.0` reports:

```
E: Unable to correct problems, you have held broken packages.
E: The following information from --solver 3.0 may provide additional context:
   Unable to satisfy dependencies. Reached two conflicting decisions:
   1. rocm-opencl-icd:amd64=5.7.1-6+deb13u1 is selected for install
   2. rocm-opencl-icd:amd64=5.7.1-6+deb13u1 is not selected for install because:
      1. mesa-opencl-icd:amd64=25.0.7-2 is selected for install
      2. rocm-opencl-icd:amd64=5.7.1-6+deb13u1 Breaks mesa-opencl-icd
```

The virtual `opencl-icd` dependency has three providers in the trixie multi-suite snapshot — `mesa-opencl-icd`, `pocl-opencl-icd`, `rocm-opencl-icd` — and `rocm-opencl-icd` ships `Breaks: mesa-opencl-icd, pocl-opencl-icd`. The solver ends up selecting **both** rocm-opencl-icd and mesa-opencl-icd and deadlocks. (The long "Conflicts:" catalog that follows — bacula/zabbix/zfsutils/nvidia-libopencl1/etc. — is apt's archive-wide relationship dump, not selected packages; the authoritative solver-3.0 message isolates exactly one selected-package conflict: rocm vs mesa.)

This is a **mesa-graphics distro**. The ROCm compute ICD is unintended here; `mesa-opencl-icd` is the intended OpenCL provider.

## Fix

Pin `rocm-opencl-icd` to `Pin-Priority: -1` in `packages/os/linux/tails/config/chroot_apt/preferences` so it is never installable and drops out of the `opencl-icd` provider set, leaving `mesa-opencl-icd` to satisfy the virtual dependency alone.

```
Package: rocm-opencl-icd
Pin: release *
Pin-Priority: -1
```

## Rationale / why this is safe

- **Nothing depends on rocm directly.** `grep -ri` across `tails/config/chroot_local-packageslists/`, `config/equivs/`, and the `elizaos/`/`confidential/` config trees finds no reference to `rocm` or `opencl-icd`. The dependency is purely transitive via the virtual `opencl-icd`, which `mesa-opencl-icd` and `pocl-opencl-icd` both still provide.
- **Sole conflict.** The solver-3.0 output names exactly one selected-package conflict (rocm ↔ mesa). No other mutually-Breaking pair is actually selected.

## Validation depth

- ✅ Passes `auto/config`'s preferences sanity checks (no `a=` release syntax, no `o=Debian Backports`).
- ✅ **Reproduced the exact conflict** in a `debian:trixie` chroot — identical solver-3.0 message and identical versions (`rocm 5.7.1-6+deb13u1`, `mesa 25.0.7-2`).
- ✅ With the pin applied (mounting the real edited `preferences` file as `/etc/apt/preferences` in trixie): `apt-cache policy rocm-opencl-icd` → `Candidate: (none)`, priority `-1`; rocm-opencl-icd is **removed from the `opencl-icd` provider list** (only mesa + pocl remain); `mesa-opencl-icd` installs cleanly (23 pkgs).
- ✅ Full edited `preferences` file parses with **no apt malformed/parse warnings**.
- ⏳ ISO build re-dispatched (`build-linux-iso.yml`, channel=nightly, publish=false) to confirm the package-install stage now clears — link + outcome in a follow-up comment.

Note: arm64 is `continue-on-error` (experimental / qemu-emulated) and fails earlier at an unrelated "Architecture arm64 not yet supported (FIXME)" step; amd64 is the required check this PR targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Evidence

This is a CI/infra change: a single apt-preferences pin in
`packages/os/linux/tails/config/chroot_apt/preferences`. It touches no
application, UI, agent, model, or runtime code path — so the visual / trajectory
/ domain rows are N/A. The real proof is in the "Validation depth" section above
(reproduced the exact solver-3.0 conflict + pin behavior in a `debian:trixie`
chroot) plus the re-dispatched `build-linux-iso.yml` run linked in a comment.

<!-- evidence-row:before-screenshots -->
- [x] N/A - apt-preferences config change under packages/os/linux; no UI surface is rendered or touched.
<!-- evidence-row:after-screenshots -->
- [x] N/A - apt-preferences config change under packages/os/linux; no UI surface is rendered or touched.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; the change is an apt resolver pin exercised only during the ISO chroot build.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server code path fires. Equivalent proof is the debian:trixie apt resolver output in the PR body (pin sets rocm-opencl-icd to Candidate: (none), priority -1).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code path; nothing runs in a browser.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changes; this only alters apt package selection at ISO build time.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB rows/memories/tasks/on-chain output; the ISO build artifact is produced by the re-dispatched build-linux-iso.yml run linked in a comment.