### PR TITLE
test(ci): resolve three plugin-shard test-vs-code deferrals at the correct layer

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -1375,9 +1375,14 @@ describe("OrchestratorTaskService — usage telemetry", () => {
       cacheTokens: 0,
     });
     const usage = must(await service.getUsage(taskId), "usage");
-    // The default spawn framework is the vendored opencode backend, so a
-    // usage frame that omits its provider is attributed to that session.
-    expect(must(usage.byProvider[0], "provider").provider).toBe("opencode");
+    // With no ELIZA_*_AGENT setting the spawn passes no explicit agentType, so
+    // the session inherits acp-service's configured default. opencode is never
+    // that default — it is explicit-selection only (acp-service DEFAULT_AGENTS
+    // orders elizaos → codex → claude → opencode, and the fallback is
+    // native→"elizaos"/non-native→"codex"). The FakeAcp here mirrors the
+    // non-native "codex" fallback, so a provider-less usage frame is attributed
+    // to "codex".
+    expect(must(usage.byProvider[0], "provider").provider).toBe("codex");
   });
 
   it("ignores empty usage frames", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/trace-usage-rollup.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/trace-usage-rollup.test.ts
@@ -8,6 +8,7 @@
  * for the code under test.
  */
 
+import { randomUUID } from "node:crypto";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -281,15 +282,27 @@ describeCore("getTraceUsage", () => {
       "child-agent",
     );
     await mkdir(dir, { recursive: true });
-    writeFileSync(
-      join(dir, "tj-dup.json"),
-      trajectoryJson("trace-parent", 80, 0.008),
-    );
+    const trajPath = join(dir, "tj-dup.json");
+    writeFileSync(trajPath, trajectoryJson("trace-parent", 80, 0.008));
 
-    // ingestChildTrajectories rescans the whole task dir each call, so a second
-    // completion appends a SECOND artifact row for the same file path.
+    // ingestChildTrajectories now path-dedupes at ingest time (#14110), so it
+    // attaches at most one row per file and a re-ingest is a no-op. getTraceUsage
+    // keeps its own path-dedupe to defend against duplicate rows that predate
+    // that fix (or a legacy multi-session rescan). Reproduce exactly that
+    // condition: ingest once for a genuine row, then attach a second row for the
+    // SAME file directly, the way a pre-dedupe rescan would have.
     await ingest(svc, taskId, sessionId);
-    await ingest(svc, taskId, sessionId);
+    await store.addArtifact({
+      id: randomUUID(),
+      taskId,
+      sessionId,
+      artifactType: "trajectory",
+      title: "Sub-agent trajectory tj-dup (duplicate row)",
+      path: trajPath,
+      verificationStatus: "pending",
+      metadata: {},
+      createdAt: new Date().toISOString(),
+    });
     const doc = await store.getTask(taskId);
     const trajRows = (doc?.artifacts ?? []).filter(
       (a) => a.artifactType === "trajectory",

--- a/plugins/plugin-computeruse/src/__tests__/android-bridge.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/android-bridge.test.ts
@@ -67,7 +67,15 @@ describe("Android Assistant and App Actions routing source", () => {
     expect(manifest).toContain("android.intent.action.ASSIST");
     expect(manifest).toContain("android.intent.action.VOICE_COMMAND");
     expect(manifest).not.toContain("android.app.role.ASSISTANT");
-    expect(manifest).not.toContain("android.permission.BIND_VOICE_INTERACTION");
+    // BIND_VOICE_INTERACTION is the standard binder guard the framework
+    // REQUIRES on the exported VoiceInteractionService/session services
+    // (`android:permission=` on the <service>) so only the system can bind them
+    // — not a privileged capability the app requests. "Without privileged voice
+    // permissions" means the app must never DECLARE it as a granted
+    // <uses-permission>; the service-protection attribute is correct and stays.
+    expect(manifest).not.toMatch(
+      /<uses-permission[^>]*android:name="android\.permission\.BIND_VOICE_INTERACTION"/,
+    );
   });
 
   it("declares Play-compatible App Actions BIIs and static shortcuts", () => {

--- a/plugins/plugin-local-inference/__tests__/mmproj-routing.test.ts
+++ b/plugins/plugin-local-inference/__tests__/mmproj-routing.test.ts
@@ -20,8 +20,9 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join as pathJoin } from "node:path";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
+	MissingMtpDrafterError,
 	resolveLocalInferenceLoadArgs,
 	resolveMmprojPath,
 } from "../src/services/active-model";
@@ -185,38 +186,27 @@ describe("WS2 mmproj routing", () => {
 		expect(resolved.mobileSpeculative).toBeUndefined();
 	});
 
-	it("falls back to a non-speculative load when a pre-cutover bundle is missing the drafter GGUF", async () => {
-		// Back-compat (#11517): a 2b/4b bundle installed BEFORE the Gemma-4 MTP
-		// cutover has no `mtp/drafter-<tier>.gguf` on disk even though the
-		// catalog now advertises runtime.mtp for the tier. The drafter is a
-		// perf-only speculative-decoding artifact — the text model must still
-		// load (warn + plain decode), never hard-throw and brick the install.
+	it("fails closed when a managed bundle is missing the drafter GGUF", async () => {
+		// A managed eliza-download 2b/4b bundle whose `mtp/drafter-<tier>.gguf`
+		// is absent (partial download, or a pre-Gemma-4-MTP-cutover bundle) is a
+		// broken install: the catalog advertises separate-drafter MTP for the
+		// tier, so refusing to activate a degraded greedy-decode path and prompting
+		// a re-download is the intended contract (MissingMtpDrafterError). Only
+		// external single-file scans (no bundleRoot) degrade to a plain load with a
+		// warning — asserted in load-args-drafter.fuzz.test.ts.
 		const tier = "2b";
 		expect(findCatalogModel(`eliza-1-${tier}`)?.runtime?.mtp?.specType).toBe(
 			"draft-mtp",
 		);
-		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-		try {
-			const bundle = makeTempBundle({ hasMmproj: true, hasMtp: false, tier });
-			const installed = installedModel({
-				id: `eliza-1-${tier}`,
-				bundleRoot: bundle.bundleRoot,
-				path: bundle.textPath,
-			});
-			const resolved = await resolveLocalInferenceLoadArgs(installed);
-			expect(resolved.modelPath).toBe(bundle.textPath);
-			expect(resolved.draftModelPath).toBeUndefined();
-			expect(resolved.draftMin).toBeUndefined();
-			expect(resolved.draftMax).toBeUndefined();
-			expect(resolved.mobileSpeculative).toBeUndefined();
-			expect(warnSpy).toHaveBeenCalledWith(
-				expect.stringContaining(
-					"Re-download the model to enable the MTP drafter",
-				),
-			);
-		} finally {
-			warnSpy.mockRestore();
-		}
+		const bundle = makeTempBundle({ hasMmproj: true, hasMtp: false, tier });
+		const installed = installedModel({
+			id: `eliza-1-${tier}`,
+			bundleRoot: bundle.bundleRoot,
+			path: bundle.textPath,
+		});
+		await expect(resolveLocalInferenceLoadArgs(installed)).rejects.toThrow(
+			MissingMtpDrafterError,
+		);
 	});
 
 	it("leaves mmprojPath undefined when bundleRoot is absent", async () => {

--- a/plugins/plugin-local-inference/src/routes/local-inference-route-contracts.fuzz.test.ts
+++ b/plugins/plugin-local-inference/src/routes/local-inference-route-contracts.fuzz.test.ts
@@ -43,6 +43,16 @@ beforeEach(() => {
 	engineMock.canTranscribeLocally.mockResolvedValue(false);
 });
 
+// Desktop AEC verdict (#12256) attached to every WAV transcription response;
+// with no playback far-end reference pushed in this lane it is the honest
+// passthrough case. Mirrors local-inference-asr-route.test.ts.
+const AEC_NO_FAR_END = {
+	applied: false,
+	reason: "no-far-end",
+	erleDb: null,
+	confidence: null,
+};
+
 function makeRng(seed: number): () => number {
 	let s = seed >>> 0;
 	return () => {
@@ -552,7 +562,11 @@ describe("POST /api/asr/local-inference - input-contract fuzz", () => {
 			state,
 		);
 		expect(out.status()).toBe(200);
-		expect(out.bodyJson()).toEqual({ text: "hello world", words: [] });
+		expect(out.bodyJson()).toEqual({
+			text: "hello world",
+			words: [],
+			aec: AEC_NO_FAR_END,
+		});
 	});
 
 	it("502s when the transcription model misbehaves (invalid shape, empty, throw)", async () => {


### PR DESCRIPTION
## What / why

A prior CI-remediation lane left three plugin-shard failures marked as "owner-intent" deferrals. Each is actually **discoverable from code + git history**: in every case a stale test assertion diverged from the intended, code-established behavior. This resolves all of them at the correct layer — aligning the losing side (the stale test) — never weakening beyond correcting an over-broad assertion to its actual intent.

All six failing assertions across the three plugins are fixed; the remaining tests in each suite stay green.

## Per-item determination + fix

### 1. agent-orchestrator

**a. `trace-usage-rollup` — "counts a trajectory file once even when duplicate rows point at it"**
The test drove duplicate artifact rows via a double-`ingestChildTrajectories`, but that path now **path-dedupes at ingest time (#14110)**, so a re-ingest is a no-op and the setup premise (`trajRows.length > 1`) no longer holds (`expected 1 to be greater than 1`). `getTraceUsage` still path-dedupes (defense against legacy pre-#14110 duplicate rows) — the real behavior under test. **Fix (test):** seed that exact legacy condition directly (ingest once, then attach a second artifact row for the same file), then assert `getTraceUsage` counts the file once. Same assertions, real duplicate rows.

**b. `orchestrator-task-service` usage telemetry — "fills the provider from the session when the frame omits it"** (`expected 'codex' to be 'opencode'`)
Determination from code: **opencode is never a default.** `acp-service.ts` `DEFAULT_AGENTS = ["elizaos","codex","claude","opencode"]` and the fallback is `native → "elizaos"` / non-native → `"codex"`; `orchestrator-task-service.ts` states *"opencode remains available only as an explicit selection."* The test's own `FakeAcp` defaults `agentType` to `"codex"` and `addStoredSession` uses `"codex"`. The `"opencode"` expectation + comment were simply wrong. **Fix (test):** expect `"codex"` (the harness default) and correct the comment.

**c. evidence-bundle URL verification** — **no code change needed.** This was a false failure: the suite failed to *load* under the prior lane because `@elizaos/core`/`shared` dist wasn't built. With deps built, `completion-evidence-bundle.test.ts` (incl. "does NOT label a URL merely mentioned in prose as verified") passes 5/5.

### 2. local-inference

**a. `route-contracts.fuzz` ASR — "transcribes via the real model-chain path, preserving byteOffset views"**
The ASR response now carries the **desktop AEC verdict (#12256)** alongside `{text,words}`; with no far-end reference pushed it's the honest passthrough `AEC_NO_FAR_END` (`{applied:false, reason:"no-far-end", erleDb:null, confidence:null}`) — exactly what the sibling `local-inference-asr-route.test.ts` already asserts. **Fix (test):** assert the full current shape including `aec: AEC_NO_FAR_END` (no weakening — full contract).

**b. `mmproj-routing` — "falls back to a non-speculative load when a pre-cutover bundle is missing the drafter GGUF"**
Determination from code + an authoritative sibling test: a **managed** eliza-download bundle (bundleRoot + `source:"eliza-download"`) missing its drafter GGUF **fails closed** with `MissingMtpDrafterError` (docstring: *"Hosted Gemma tiers must not degrade… external single-file scans remain outside this bundle contract"*). `load-args-drafter.fuzz.test.ts` already asserts exactly this: **throw** for managed bundles, **warn+fallback** only for external scans (no bundleRoot). The stale test used a managed bundle but expected the old graceful path (and a warn string the code no longer emits). **Fix (test):** assert `rejects.toThrow(MissingMtpDrafterError)`.

### 3. computeruse

**`android-bridge` — "declares default-assistant and voice-command surfaces without privileged voice permissions"**
`android:permission="android.permission.BIND_VOICE_INTERACTION"` on the exported `<service>` (VoiceInteractionService + session service) is the **framework-required binder guard** so only the system can bind them — not an app-requested capability (no `<uses-permission>` for it exists in the manifest). The broad `not.toContain(...)` tripped on the legitimate service-protection attribute. **Fix (test):** narrow to a `<uses-permission>`-scoped regex. Verified it still **catches** an app-requested `<uses-permission …BIND_VOICE_INTERACTION>` (incl. multiline) while ignoring the service attribute — a precision fix, not a weakening.

## Evidence

Per-file, post-rebase onto `develop`:

- orchestrator: `trace-usage-rollup` + `orchestrator-task-service` → **86 passed** (2 files)
- local-inference: `route-contracts.fuzz` + `mmproj-routing` → **30 passed** (2 files)
- computeruse: `android-bridge` → **23 passed**
- Full orchestrator suite before fixes: 2 real failures (this PR); full local-inference suite before fixes: 2 real failures (this PR).
- `bun run audit:error-policy-ratchet` → *no new fallback-slop* (0 production source files changed — all edits are tests).
- `bunx biome check` on changed files → clean.
- `typecheck` for all three plugins → exit 0, 0 TS errors.

No user-facing product decision required: in every case the product behavior is already firmly decided in code (and, for mmproj + ASR, corroborated by a passing sibling test); only the stale test needed to be aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)