### PR TITLE
fix(os-linux): pin out contrib StarPU family (next ISO chroot apt conflict)

### DIFF
--- a/packages/os/linux/tails/config/chroot_apt/preferences
+++ b/packages/os/linux/tails/config/chroot_apt/preferences
@@ -52,6 +52,20 @@ Package: rocm-opencl-icd
 Pin: release *
 Pin-Priority: -1
 
+Explanation: The starpu-contrib source builds an alternative StarPU that
+Explanation: provides the same virtuals as mainline StarPU (e.g.
+Explanation: libstarpu-anympi-1.4-3) while carrying `Conflicts:` against every
+Explanation: mainline counterpart (libstarpumpi, libstarpufft, ...). Identical
+Explanation: failure mode to rocm above: in the multi-suite snapshot the solver
+Explanation: selects both a contrib and a mainline StarPU provider and deadlocks
+Explanation: the chroot install. Nothing here wants StarPU at all (it is only
+Explanation: ever pulled transitively as a virtual provider), so pin the whole
+Explanation: contrib source out (src: covers libstarpu-contrib*, starpu-contrib-*)
+Explanation: and let the mainline satisfy those virtuals.
+Package: src:starpu-contrib
+Pin: release *
+Pin-Priority: -1
+
 Explanation: weirdness in chroot_apt install-binary
 Package: *
 Pin: release o=chroot_local-packages


### PR DESCRIPTION
## Problem

Follow-up to #15336 (which pinned out `rocm-opencl-icd`). With that merged, the re-dispatched **Build elizaOS Linux ISO** (amd64) advanced **past** the rocm/mesa conflict — proving that fix works — and the chroot package install now deadlocks one layer deeper on the **identical structural pattern**. apt solver 3.0:

```
E: Unable to correct problems, you have held broken packages.
E: The following information from --solver 3.0 may provide additional context:
   Unable to satisfy dependencies. Reached two conflicting decisions:
   1. libstarpumpi-1.4-3t64:amd64=1.4.7+dfsg-2 is selected for install
   2. libstarpumpi-1.4-3t64 is not selected for install because:
      1. libstarpu-contribmpi-1.4-3t64:amd64=1.4.7+dfsg-2 is selected for install
      2. libstarpu-contribmpi-1.4-3t64 Conflicts libstarpumpi-1.4-3t64
```

## Fix

`libstarpu-contrib*` (Debian source `starpu-contrib`) is an **alternative** StarPU build that provides the same virtuals as mainline StarPU (e.g. `libstarpu-anympi-1.4-3`) while declaring `Conflicts:` against every mainline counterpart (`libstarpumpi`, `libstarpufft`, ...). In the Tails multi-suite snapshot the solver selects **both** a contrib and a mainline StarPU provider for a virtual and deadlocks — exactly like `rocm-opencl-icd` vs `mesa-opencl-icd`.

Pin the whole contrib source to `Pin-Priority: -1` (a `src:` pin covers `libstarpu-contrib*` **and** `starpu-contrib-*`) so the virtuals resolve to the mainline StarPU alone:

```
Package: src:starpu-contrib
Pin: release *
Pin-Priority: -1
```

## Why it's safe / root

- **Nothing on this distro wants StarPU.** A single-suite trixie solve of the full package list is clean; `aptitude why libstarpumpi` reports *"No dependencies require to install"* and none of the contrib binaries has a reverse-dependency — they are only ever pulled transitively as virtual providers.
- These conflicts are a **multi-suite-snapshot artifact**: single-suite trixie (`--no-install-recommends`, matching Tails' `--apt-recommends false`) solves cleanly (1783 pkgs, no conflict); only the sid-inclusive snapshot exposes mainline + alternative providers of the same virtual as co-installable and lets the solver pick both. Same class as #15336; each layer is pinned to the intended (mainline / mesa) provider.

## Validation

- ✅ Passes `auto/config`'s preferences sanity checks (no `a=` / `o=Debian Backports`).
- ✅ With the full edited `preferences` mounted in a `debian:trixie` chroot: `rocm-opencl-icd`, `libstarpu-contribmpi`, `starpu-contrib-tools` all → `Candidate: (none)` @ `-1`; mainline `libstarpumpi` (1.4.7+dfsg-2) and `mesa-opencl-icd` (25.0.7-2) stay installable.
- ⏳ ISO build re-dispatched to confirm this layer clears — run id in a follow-up comment.

Note: arm64 is `continue-on-error` (experimental, unrelated pre-existing "Architecture arm64 not yet supported" step); amd64 is the required check this PR targets.

## Evidence

CI/infra change: a single apt-preferences pin under `packages/os/linux`. No application / UI / agent / model / runtime code path — visual, trajectory, and domain rows are N/A. Proof is the `debian:trixie` resolver output above and the re-dispatched `build-linux-iso.yml` run.

<!-- evidence-row:before-screenshots -->
- [x] N/A - apt-preferences config change under packages/os/linux; no UI surface is rendered or touched.
<!-- evidence-row:after-screenshots -->
- [x] N/A - apt-preferences config change under packages/os/linux; no UI surface is rendered or touched.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; the change is an apt resolver pin exercised only during the ISO chroot build.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server code path fires. Equivalent proof is the debian:trixie apt resolver output above (contrib StarPU family → Candidate: (none), priority -1).
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code path; nothing runs in a browser.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior changes; this only alters apt package selection at ISO build time.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB rows/memories/tasks/on-chain output; the ISO build artifact is produced by the re-dispatched build-linux-iso.yml run linked in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)