### PR TITLE
fix(cloud): wrong_node reap requires container age past grace — prod dry-run caught a reap-a-live-provision race (#15228)

### DIFF
--- a/packages/cloud/shared/src/lib/services/orphan-container-reconciler.test.ts
+++ b/packages/cloud/shared/src/lib/services/orphan-container-reconciler.test.ts
@@ -132,7 +132,13 @@ describe("node-aware diff (#15228 — reap the stale twin a re-provision left be
     nodeId,
     updatedAtMs: NOW - ageMs,
   });
-  const c = (id: string): NodeContainerRef => ({ name: `agent-${id}`, id: `docker-${id}` });
+  // Containers default to OLD (past grace) so each test isolates the row-side
+  // condition; the container-age race has its own cases below.
+  const c = (id: string, containerAgeMs = 60 * 60_000): NodeContainerRef => ({
+    name: `agent-${id}`,
+    id: `docker-${id}`,
+    createdAtMs: NOW - containerAgeMs,
+  });
 
   test("live row points at a DIFFERENT node, stable past grace → reap as wrong_node", () => {
     // container observed on nodeA; the agent's live row says it lives on nodeB.
@@ -143,7 +149,33 @@ describe("node-aware diff (#15228 — reap the stale twin a re-provision left be
       "nodeA",
       NOW,
     );
-    expect(orphans).toEqual([{ name: "agent-x", id: "docker-x", key: "x", reason: "wrong_node" }]);
+    expect(orphans).toEqual([{ name: "agent-x", id: `docker-x`, key: "x", reason: "wrong_node" }]);
+  });
+
+  test("FRESH container + stale wrong-node row → keep (re-placement in flight)", () => {
+    // The worker creates the container on the new node BEFORE updating the row,
+    // so mid-provision the old row (old timestamp, old node) is exactly what a
+    // legitimate re-placement looks like. Caught live: a 29-second-old container
+    // drew a wrong_node verdict against a 12-day-old row.
+    const orphans = computeOrphanContainersToReap(
+      [c("x", 29_000)],
+      [onNode("x", "running", "nodeB", 12 * 24 * 60 * 60_000)],
+      cfg,
+      "nodeA",
+      NOW,
+    );
+    expect(orphans).toEqual([]);
+  });
+
+  test("container age unknown → never wrong_node-reaped (fail safe)", () => {
+    const orphans = computeOrphanContainersToReap(
+      [{ name: "agent-x", id: "docker-x" }],
+      [onNode("x", "running", "nodeB", 10 * 60_000)],
+      cfg,
+      "nodeA",
+      NOW,
+    );
+    expect(orphans).toEqual([]);
   });
 
   test("live row points at THIS node → keep (this is the canonical container)", () => {

--- a/packages/cloud/shared/src/lib/services/orphan-container-reconciler.ts
+++ b/packages/cloud/shared/src/lib/services/orphan-container-reconciler.ts
@@ -46,6 +46,15 @@ export interface NodeContainerRef {
   name: string;
   /** Docker container id (used for the `docker rm -f` target). */
   id: string;
+  /**
+   * When the container was created (epoch ms), parsed from `docker ps`'s
+   * CreatedAt. `wrong_node` reaping requires the container ITSELF to be older
+   * than the grace window: during a re-placement the worker creates the
+   * container on the NEW node before it updates the sandbox row, so a
+   * seconds-old container paired with a stale row pointing elsewhere is a
+   * provision in flight, not a twin. Unparseable/absent → never wrong_node-reaped.
+   */
+  createdAtMs?: number;
 }
 
 /**
@@ -261,6 +270,15 @@ export function computeOrphanContainersToReap(
         (r) => r.nodeId !== undefined && r.updatedAtMs !== undefined,
       );
       if (!allHaveNodeAndStamp) continue;
+      // The CONTAINER must also be older than the grace window. A row's age
+      // alone cannot protect an in-flight re-placement: the worker creates the
+      // container on the new node BEFORE updating the row, so mid-provision the
+      // stale row (old timestamp, old node) makes a seconds-old container look
+      // reapable — the row-age check would even pass MORE easily. Caught live
+      // in the prod dry-run: a 29-second-old container drew a wrong_node
+      // verdict against a 12-day-old row. Unknown container age → never reap.
+      if (container.createdAtMs === undefined) continue;
+      if (nowMs !== undefined && nowMs - container.createdAtMs < graceMs) continue;
       const newest = Math.max(...(stamps as number[]));
       if (nowMs !== undefined && nowMs - newest >= graceMs) {
         orphans.push({ name: container.name, id: container.id, key, reason: "wrong_node" });
@@ -401,7 +419,7 @@ export async function reconcileOrphanContainersOnNodes(
           const client = ssh();
           await client.connect();
           const output = await client.exec(
-            `docker ps -a --format '{{.Names}}|{{.ID}}' --filter name=${shellQuote(config.prefix)}`,
+            `docker ps -a --format '{{.Names}}|{{.ID}}|{{.CreatedAt}}' --filter name=${shellQuote(config.prefix)}`,
             ORPHAN_LIST_TIMEOUT_MS,
           );
           return (
@@ -413,8 +431,15 @@ export async function reconcileOrphanContainersOnNodes(
               // exclude any container that merely contains the prefix mid-name.
               .filter((line) => line.startsWith(config.prefix))
               .map((line) => {
-                const [name = "", id = ""] = line.split("|");
-                return { name, id };
+                const [name = "", id = "", createdAtRaw = ""] = line.split("|");
+                // docker's CreatedAt: "2026-07-07 16:45:01 +0000 UTC" — Date
+                // rejects the trailing " UTC" but parses the "+0000" offset.
+                const createdAt = Date.parse(createdAtRaw.replace(" UTC", "").trim());
+                return {
+                  name,
+                  id,
+                  ...(Number.isFinite(createdAt) ? { createdAtMs: createdAt } : {}),
+                };
               })
               .filter((c) => c.name && c.id)
           );


### PR DESCRIPTION
## The race (caught by the prod dry-run BEFORE enabling the reconciler)

My #15236 node-aware reap measured the grace window on the sandbox **row's** `updatedAt` — but the worker creates the container on the NEW node **before** updating the row. Mid-provision, a seconds-old container pairs with a stale row (old timestamp, old node) and draws a `wrong_node` verdict; the staler the row, the MORE easily the age check passes. **Observed live:** a **29-second-old** container on prod-2 flagged for reaping against a 12-day-old row pointing at prod-5 — an active re-placement the reconciler would have killed.

## Fix

`wrong_node` now ALSO requires the **container itself** to be older than the grace window: the `docker ps` listing captures `{{.CreatedAt}}` → `NodeContainerRef.createdAtMs`; unparseable/absent age → never `wrong_node`-reaped (fail-safe). Rows-side logic unchanged.

## Evidence
<!-- evidence-row:before-screenshots -->
- [x] Before: N/A - backend reconciler logic.
<!-- evidence-row:after-screenshots -->
- [x] After: N/A - backend reconciler logic.
<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough: N/A - proof is the dry-run catch + test suite.
<!-- evidence-row:backend-logs -->
- [x] [15343-reconciler-validation.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15343-reconciler-validation.log)
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend surface changed
<!-- evidence-row:llm-trajectory -->
- [x] Trajectory: N/A - no model change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain artifacts produced; change is pure reconciler decision logic

https://claude.ai/code/session_01Y9PKm5MocuCmetfstCenBH
