### PR TITLE
fix(os-linux): drop sid from ISO apt sources (root fix for chroot install conflicts)

### DIFF
--- a/packages/os/linux/tails/config/chroot_apt/preferences
+++ b/packages/os/linux/tails/config/chroot_apt/preferences
@@ -1,25 +1,33 @@
+Explanation: The `sid` suite is intentionally NOT in our sources (see the
+Explanation: removed config/chroot_sources/sid.{chroot,binary}). Upstream Tails
+Explanation: pulls newer firmware + webext-ublock-origin-firefox from sid on its
+Explanation: stable base; on this trixie base every one of those packages is
+Explanation: already in trixie, and sid's presence only destabilized the apt
+Explanation: solver into cross-suite "two conflicting decisions" deadlocks
+Explanation: (rocm/mesa, StarPU, libpcp3/libpgpool). These firmware +
+Explanation: ublock pins therefore target trixie, not sid.
 Package: firmware-linux-free
-Pin: release o=Debian,n=sid
+Pin: release o=Debian,n=trixie
 Pin-Priority: 999
 
 Package: src:firmware-nonfree
-Pin: release o=Debian,n=sid
+Pin: release o=Debian,n=trixie
 Pin-Priority: 990
 
 Package: firmware-ath9k-htc
-Pin: release o=Debian,n=sid
+Pin: release o=Debian,n=trixie
 Pin-Priority: 999
 
 Package: firmware-carl9170
-Pin: release o=Debian,n=sid
+Pin: release o=Debian,n=trixie
 Pin-Priority: 999
 
 Package: firmware-sof-signed
-Pin: release o=Debian,n=sid
+Pin: release o=Debian,n=trixie
 Pin-Priority: 999
 
 Package: firmware-zd1211
-Pin: release o=Debian,n=sid
+Pin: release o=Debian,n=trixie
 Pin-Priority: 999
 
 Explanation: #15477
@@ -28,7 +36,7 @@ Pin: origin deb.tails.boum.org
 Pin-Priority: 999
 
 Package: webext-ublock-origin-firefox
-Pin: release o=Debian,n=sid
+Pin: release o=Debian,n=trixie
 Pin-Priority: 999
 
 Explanation: Upgrading to more recent version of Electrum allow us to get rid of Qt5 (tails#21085)

--- a/packages/os/linux/tails/config/chroot_sources/sid.binary
+++ b/packages/os/linux/tails/config/chroot_sources/sid.binary
@@ -1,1 +1,0 @@
-sid.chroot

--- a/packages/os/linux/tails/config/chroot_sources/sid.chroot
+++ b/packages/os/linux/tails/config/chroot_sources/sid.chroot
@@ -1,1 +1,0 @@
-deb http://time-based.snapshots.deb.tails.boum.org/debian/2026042702 sid main contrib non-free non-free-firmware


### PR DESCRIPTION
## Root fix for the ISO chroot-install conflict class

Follow-up to #15336 (rocm-opencl-icd pin) and #15340 (starpu-contrib pin). Those were correct but were treating **symptoms** of a deeper problem. The "Build elizaOS Linux ISO" chroot package install keeps deadlocking on a **sequence** of apt solver-3.0 "Reached two conflicting decisions" pairs, each surfacing only after the previous is pinned:

1. `rocm-opencl-icd` vs `mesa-opencl-icd` (#15336)
2. `libstarpumpi` vs `libstarpu-contribmpi` (#15340)
3. `libpcp3-dev` vs `libpgpool-dev` (this run: `28882915352`)

## Diagnosis: it's the `sid` suite, not a finite pin set

The vendored Tails config pulls **`sid`** alongside trixie (`config/chroot_sources/sid.{chroot,binary}`). Evidence this is a **self-inconsistent multi-suite snapshot**, not a bounded set of pins:

- **Single-suite trixie is clean.** A solve of the full `tails-common.list` against trixie only (`--no-install-recommends`, matching `--apt-recommends false`) resolves with **0 conflicts** (1783 pkgs). Every observed conflict is *absent* without the extra suites.
- **The solve is unstable.** A local `apt-get -s install` of the same list against the same multi-suite snapshot resolves **cleanly**, while CI's live-build hits a conflict on **identical inputs** — the signature of a self-inconsistent snapshot. Solver 3.0 weighs even negative-priority sid candidates (the preferences already pin sid to `-10`) and tangles the *trixie* resolution. Concretely, sid's `libpcp4-dev` reverse-depends **both** trixie's `libpcp3-dev` and `libpgpool-dev`, which `Conflict` — so sid's mere presence is what pulls both into the trixie solve.
- Pinning each pair is **whack-a-mole** that won't reliably converge.

## Why dropping sid is safe (lossless)

`sid` is **vestigial** on this trixie base. It exists only to source, for upstream Tails' *Debian-stable* base, 6 firmware packages + `webext-ublock-origin-firefox` (all 7 are the only `n=sid` pins in `preferences`). On trixie **all 7 are already available**:

| package | trixie version |
|---|---|
| webext-ublock-origin-firefox | 1.67.0+dfsg-1~deb13u1 |
| firmware-linux-free | 20241210-2 |
| firmware-linux-nonfree | 20250410-2 |
| firmware-sof-signed | 2025.01-1 |
| firmware-ath9k-htc / carl9170 / zd1211 | present |

And **ZERO** packages in `tails-common.list` are sid-exclusive (all 328 resolve from trixie).

## Change

- Remove `config/chroot_sources/sid.chroot` + `sid.binary`.
- Retarget the 7 sid pins (`Pin: release o=Debian,n=sid`) to `n=trixie`.
- Keep the #15336/#15340 pins as harmless, intent-documenting defense-in-depth.

## Validation

- ✅ Single-suite trixie: 0 conflicts (1783 pkgs).
- ✅ Multi-suite **minus sid**, full list, solver 3.0, `--no-install-recommends`: **SATISFIABLE**.
- ✅ All 328 list packages + all 7 formerly-sid-pinned packages resolve from trixie.
- ✅ Passes `auto/config` preferences sanity checks; no remaining `n=sid`; no other sid references in the config/auto tree.
- ⏳ Authoritative confirmation via the re-dispatched ISO build — run id in a comment.

> Honest caveat: my local `apt-get -s` does not *reproduce* CI's conflict (it resolves cleanly with sid too — that non-determinism is itself the evidence of instability), so the definitive proof is the CI re-dispatch. If a conflict somehow persists after dropping sid, the fallback is a snapshot-serial bump.

## Evidence

CI/infra change (apt sources + preferences under `packages/os/linux`). No app/UI/agent/model/runtime code path.

<!-- evidence-row:before-screenshots -->
- [x] N/A - apt sources/preferences change under packages/os/linux; no UI surface.
<!-- evidence-row:after-screenshots -->
- [x] N/A - apt sources/preferences change under packages/os/linux; no UI surface.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow; change is exercised only during the ISO chroot build.
<!-- evidence-row:backend-logs -->
- [x] N/A - no server code path. Proof is the debian:trixie / debootstrap-from-snapshot resolver output in the PR body.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code path.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model change; alters apt suite selection at ISO build time only.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - the build artifact (ISO) is produced by the re-dispatched build-linux-iso.yml run linked in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)