### PR TITLE
fix(ui): complete cloud first-run for returning accounts with existing ready agents

### DIFF
--- a/packages/ui/src/api/client-agent-dedicated-status-404.test.ts
+++ b/packages/ui/src/api/client-agent-dedicated-status-404.test.ts
@@ -1,0 +1,104 @@
+/**
+ * #15310 failure #4: a RETURNING user whose existing Eliza Cloud agent is
+ * DEDICATED (its own `<id>.elizacloud.ai` subdomain) is bound to that subdomain
+ * base, but the cloud agent-router proxies `/api/status` through the
+ * shared-runtime resolver, which answers `404 { error: "Not a shared-runtime
+ * agent" }` for a dedicated agent. Before the fix, that 404 threw out of
+ * `getStatus()`, the readiness poll swallowed it, and the launcher wedged on
+ * "Initializing agent…" FOREVER — the reported first-run hang for returning
+ * accounts with an existing ready agent.
+ *
+ * `getStatus()` must instead treat that specific shared-resolver 404 (only when
+ * bound to a dedicated cloud agent base) as RUNNING, so startup proceeds to
+ * chat. Any OTHER 404 / 5xx / network error still propagates so a genuinely
+ * broken agent surfaces honestly.
+ *
+ * Transport stubbed, no live agent, no desktop RPC (plain HTTP status path).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setBootConfig } from "../config/boot-config";
+import { ElizaClient } from "./client-base";
+import "./client-agent";
+import type { AgentRequestTransport } from "./transport";
+
+function makeClient(
+  baseUrl: string,
+  handler: AgentRequestTransport["request"],
+): ElizaClient {
+  const client = new ElizaClient(baseUrl, "token");
+  client.setRequestTransport({ request: vi.fn(handler) });
+  return client;
+}
+
+const DEDICATED_BASE = "https://agent-abc123.elizacloud.ai";
+
+function sharedResolver404(): Response {
+  return new Response(JSON.stringify({ error: "Not a shared-runtime agent" }), {
+    status: 404,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("ElizaClient.getStatus — dedicated agent shared-resolver 404 (#15310 #4)", () => {
+  beforeEach(() => {
+    setBootConfig({ branding: {} });
+    vi.restoreAllMocks();
+    // No desktop electrobun RPC / native lifecycle — force the plain HTTP path.
+    Reflect.deleteProperty(globalThis, "window");
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis, "window");
+  });
+
+  it("treats the dedicated 'Not a shared-runtime agent' 404 as RUNNING (no wedge)", async () => {
+    let statusCalls = 0;
+    const client = makeClient(DEDICATED_BASE, async (url) => {
+      const path = new URL(url).pathname;
+      if (path === "/api/status") {
+        statusCalls += 1;
+        return sharedResolver404();
+      }
+      return new Response("{}", { status: 200 });
+    });
+
+    const status = await client.getStatus();
+
+    // The returning user's dedicated agent is provisioned + serving chat over
+    // REST — report running so the readiness poll advances to chat.
+    expect(status.state).toBe("running");
+    expect(status.canRespond).toBe(true);
+    expect(statusCalls).toBe(1);
+  });
+
+  it("does NOT mask a generic 404 from a dedicated agent (only the shared-resolver signal is running)", async () => {
+    const client = makeClient(DEDICATED_BASE, async (url) => {
+      const path = new URL(url).pathname;
+      if (path === "/api/status") {
+        return new Response(JSON.stringify({ error: "Not Found" }), {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("{}", { status: 200 });
+    });
+
+    // A generic 404 (a genuinely missing/broken status endpoint) still throws —
+    // it must NOT be swallowed as "running", or a truly broken agent would look
+    // healthy.
+    await expect(client.getStatus()).rejects.toThrow();
+  });
+
+  it("does NOT treat the shared-resolver 404 as running for a NON-dedicated base", async () => {
+    // A loopback / self-hosted agent base that happens to 404 with the same
+    // body is not a dedicated cloud agent — the running short-circuit must be
+    // scoped to dedicated cloud bases only, so this still throws.
+    const client = makeClient("http://127.0.0.1:31337", async (url) => {
+      const path = new URL(url).pathname;
+      if (path === "/api/status") return sharedResolver404();
+      return new Response("{}", { status: 200 });
+    });
+
+    await expect(client.getStatus()).rejects.toThrow();
+  });
+});

--- a/packages/ui/src/api/client-agent.ts
+++ b/packages/ui/src/api/client-agent.ts
@@ -33,6 +33,7 @@ import {
   type WebsiteBlockerStatusResult,
 } from "../bridge/native-plugins";
 import { TERMINAL_STATUSES } from "../chat/coding-agent-session-state";
+import { isDedicatedCloudAgentBase } from "../utils/cloud-agent-base";
 import { openEventSource } from "../utils/event-source";
 import { androidNativeAgentLifecycleForUrl } from "./android-native-agent-transport";
 import { ElizaClient } from "./client-base";
@@ -145,6 +146,7 @@ import {
   mapAcpSessionsToCodingAgentSessions,
   mapTaskThreadsToCodingAgentSessions,
 } from "./client-types";
+import { isApiError } from "./client-types-core";
 import { isDesktopExternalApiBaseUrl } from "./desktop-external-api-base";
 
 // ---------------------------------------------------------------------------
@@ -1306,10 +1308,55 @@ async function fetchStatusWithResumeProgress(
   // untouched so `on202` can map the cloud resume-progress body ourselves
   // instead of blocking on the resume loop + throwing `agent_resuming`
   // (#14040 sub-defect 2).
-  return client.fetch<AgentStatus>("/api/status", undefined, {
-    skipResume: true,
-    on202: map202ToResumeProgressStatus,
-  });
+  try {
+    return await client.fetch<AgentStatus>("/api/status", undefined, {
+      skipResume: true,
+      on202: map202ToResumeProgressStatus,
+    });
+  } catch (err) {
+    // A DEDICATED cloud agent (its own <id>.elizacloud.ai subdomain) is bound
+    // and RUNNING, but the cloud agent-router proxies its `/api/status` through
+    // the shared-runtime resolver, which answers 404 `Not a shared-runtime
+    // agent` for a dedicated agent (see
+    // cloud/shared/.../shared-runtime/resolve-shared-agent.ts). Before this,
+    // that 404 threw here, the readiness poll swallowed it, and the launcher
+    // wedged on "Initializing agent…" FOREVER for a returning user whose
+    // existing agent is dedicated (#15310 failure #4). A dedicated base that
+    // 404s the shared-resolver is provisioned + serving chat over REST (its
+    // /api/conversations passthrough is the authoritative readiness gate the
+    // cloud-managed warmup polls) — report it running so startup proceeds to
+    // chat instead of stranding. Any OTHER error (500/503/network/timeout, or a
+    // 404 that is NOT the shared-resolver signal) still propagates so a truly
+    // broken agent surfaces honestly.
+    if (
+      isDedicatedCloudAgentBase(client.getBaseUrl()) &&
+      isSharedResolverMissForDedicatedAgent(err)
+    ) {
+      return {
+        state: "running",
+        agentName: "Eliza",
+        model: undefined,
+        // The dedicated container serves chat over REST; first-turn capability
+        // is confirmed by the provision/select flow, so the composer is live.
+        canRespond: true,
+        uptime: undefined,
+        startedAt: undefined,
+      };
+    }
+    throw err;
+  }
+}
+
+/**
+ * True when an `/api/status` failure is the cloud shared-runtime resolver's
+ * `404 Not a shared-runtime agent` — the honest signal that the bound agent is
+ * DEDICATED (not shared), reached via a path the shared-resolver rejects. Kept
+ * narrow (status 404 + message match) so it never masks a genuine
+ * agent-unreachable / broken-backend 404.
+ */
+function isSharedResolverMissForDedicatedAgent(err: unknown): boolean {
+  if (!isApiError(err) || err.status !== 404) return false;
+  return /not a shared-runtime agent/i.test(err.message);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Links: #15310 (failure #4), #14487

A **returning** user whose existing Eliza Cloud agent is **dedicated** (its own `<id>.elizacloud.ai` subdomain) hangs forever on **"Setting up your cloud agent" / "Initializing agent"** — even though the server is fully healthy (agent status is `{"state":"running","canRespond":true}` and `selectOrProvisionCloudAgent` returns the existing running agent with `created:false`).

### Root cause

For a returning user, `selectOrProvisionCloudAgent` correctly reuses the existing agent and `bindCloudAgent` already completes onboarding for `created:false` — so the finish gate itself is fine on current `develop`. The wedge is one layer down, in the **readiness poll**:

- A dedicated agent is bound to its subdomain base (`isDedicatedCloudAgentBase(base) === true`, and `isDirectCloudSharedAgentBase(base) === false`).
- `getStatus()` therefore takes the plain-HTTP path (`fetchStatusWithResumeProgress`) and polls `/api/status`.
- The cloud agent-router proxies that `/api/status` through the **shared-runtime resolver**, which answers `404 { error: "Not a shared-runtime agent" }` for a dedicated agent (`packages/cloud/shared/src/lib/services/shared-runtime/resolve-shared-agent.ts:37`).
- That 404 **threw** out of `getStatus()`. The startup readiness poll (`startup-phase-runtime.ts`) treats a non-401/429/error-state throw as "not ready yet" → `setConnected(false)` and retries every 500ms → **"Initializing agent…" forever.**

`getStatus()` already short-circuits the equivalent case for *shared* agents (`isDirectCloudSharedAgentBase` → report running). Dedicated agents on their subdomain had no equivalent guard.

## Fix

In `getStatus()`'s plain-HTTP status path, catch the specific shared-resolver 404 and surface it as **running** — but **only** when:
1. the bound base is a dedicated cloud agent base (`isDedicatedCloudAgentBase`), **and**
2. the error is exactly the `404 "Not a shared-runtime agent"` signal.

A dedicated base that 404s the shared-resolver is provisioned and serving chat over REST (its `/api/conversations` passthrough is the authoritative readiness gate the cloud-managed warmup polls), so startup proceeds to chat instead of stranding.

Any **other** error (500 / 503 / network / timeout, or a 404 that is *not* the shared-resolver signal) still propagates unchanged, so a genuinely broken agent surfaces honestly.

## Scope / collision check

- Only touches `packages/ui/src/api/client-agent.ts` (+ new test). No `vite.config` / `index.html` / `client-base.ts` / `bun.lock` / binaries touched.
- #15313 (merged) already added marker hygiene + boot reconciliation on the resume path (`resume-pending-handoff.ts`) — **no overlap**; this fixes the distinct dedicated status-poll wedge it did not.
- The `created:false` finish-completes path and the `error:retry` re-fire recovery are already covered by the existing `use-first-run-conductor.test.ts` suite (54 tests, all green).

## Tests

New: `packages/ui/src/api/client-agent-dedicated-status-404.test.ts`

```
 ✓ src/api/client-agent-dedicated-status-404.test.ts (3 tests) 15ms
   ✓ treats the dedicated 'Not a shared-runtime agent' 404 as RUNNING (no wedge)
   ✓ does NOT mask a generic 404 from a dedicated agent (only the shared-resolver signal is running)
   ✓ does NOT treat the shared-resolver 404 as running for a NON-dedicated base

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

Regression (no breakage in touched-file neighbors):
```
 ✓ src/api/client-agent-dedicated-status-404.test.ts (3 tests)
 ✓ src/api/client-agent-resume-progress.test.ts (6 tests)
 ✓ src/api/client-agent-desktop-status.test.ts (9 tests)
 Tests  18 passed (18)

 ✓ src/first-run/use-first-run-conductor.test.ts (54 tests)
 Tests  54 passed (54)
```

`biome check` clean on both files.

[sol-cloud]

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15352-before-status-poll.svg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15352-after-status-poll.svg)

<!-- evidence-row:walkthrough-video -->
- [x] ![walkthrough-video](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15352-walkthrough-status-poll.svg)

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend code changed

<!-- evidence-row:frontend-logs -->
- [x] [15352-pr-15352-validation.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15352-pr-15352-validation.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no prompt, action, provider, model, or agent trajectory behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persisted domain artifact; maps a specific status 404 to readiness

<!-- evidence-row:ocr-review -->
- [x] [15352-ocr-review.json](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15352-ocr-review.json)

