### PR TITLE
fix(cloud): surface running-but-unroutable staging agents as a readable CORS 503 (#15347)

### DIFF
--- a/packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts
+++ b/packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts
@@ -67,17 +67,22 @@ const { handleDedicatedAgentProxy } = await import(
 const AGENT = "11111111-1111-1111-1111-111111111111";
 const ENV = { AGENT_ROUTER_ORIGIN_HOST: "cp.example.test" } as never;
 
-function makeRequest(cloudToken?: string): Request {
+function makeRequest(cloudToken?: string, origin?: string): Request {
   const headers = new Headers();
   if (cloudToken) headers.set("authorization", `Bearer ${cloudToken}`);
+  if (origin) headers.set("origin", origin);
   return new Request(`https://${AGENT}.elizacloud.ai/api/status`, { headers });
 }
 const urlOf = (r: Request) => new URL(r.url);
 
+// A running row carries a mesh IP once it has joined headscale; without it the
+// proxy short-circuits (running-but-unroutable, #15347), so the happy-path
+// fixture pins one to prove the token-swap path still routes.
 const runningDedicated = {
   id: AGENT,
   execution_tier: "dedicated-always",
   status: "running",
+  headscale_ip: "100.64.0.21",
   environment_vars: { ELIZA_API_TOKEN: "agent-secret-token" },
   agent_name: "qa",
   updated_at: new Date(),
@@ -96,7 +101,10 @@ describe("dedicated-agent-proxy — unified auth", () => {
     authResult = { user: { id: "u1", organization_id: "org1" } };
     sandboxResult = runningDedicated;
 
-    const r = makeRequest("cloud-token-abc");
+    const r = makeRequest(
+      "cloud-token-abc",
+      "https://app-staging.elizacloud.ai",
+    );
     const res = await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
 
     expect(res.status).toBe(200);
@@ -107,6 +115,11 @@ describe("dedicated-agent-proxy — unified auth", () => {
     );
     expect(captured?.headers.get("x-api-key")).toBeNull();
     expect(new URL(captured?.url ?? "").hostname).toBe("cp.example.test");
+    // withCors backfills the browser Origin even though the mocked upstream
+    // ("ok") carried none, so the proxied response is never CORS-opaque (#15347).
+    expect(res.headers.get("access-control-allow-origin")).toBe(
+      "https://app-staging.elizacloud.ai",
+    );
   });
 
   test("NO cloud token → pass through unchanged (never injects the agent token)", async () => {
@@ -141,11 +154,16 @@ describe("dedicated-agent-proxy — unified auth", () => {
   test("owner of a NON-RUNNING agent → 202 resume, does NOT proxy to the container", async () => {
     authResult = { user: { id: "u1", organization_id: "org1" } };
     sandboxResult = { ...runningDedicated, status: "stopped" };
-    const r = makeRequest("cloud-token");
+    const r = makeRequest("cloud-token", "https://app-staging.elizacloud.ai");
     const res = await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
     expect(res.status).toBe(202);
     expect(res.headers.get("Retry-After")).toBe("5");
     expect(captured).toBeNull();
+    // Regression: the 202 previously bypassed CORS entirely (this handler is
+    // mounted before Hono's cors middleware), so the browser could not read it.
+    expect(res.headers.get("access-control-allow-origin")).toBe(
+      "https://app-staging.elizacloud.ai",
+    );
   });
 
   test("owner of a NON-RUNNING agent WITH sufficient credits → 202 and enqueues the resume (#11583)", async () => {
@@ -168,9 +186,13 @@ describe("dedicated-agent-proxy — unified auth", () => {
       balance: 0,
       error: "Insufficient credits.",
     };
-    const r = makeRequest("cloud-token");
+    const r = makeRequest("cloud-token", "https://app-staging.elizacloud.ai");
     const res = await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
     expect(res.status).toBe(402);
+    // Regression: browser-visible billing failure must carry CORS (#15347).
+    expect(res.headers.get("access-control-allow-origin")).toBe(
+      "https://app-staging.elizacloud.ai",
+    );
     const body = (await res.json()) as { code?: string };
     expect(body.code).toBe("insufficient_credits");
     expect(enqueueCalls).toBe(0); // no free compute
@@ -212,5 +234,90 @@ describe("dedicated-agent-proxy — unified auth", () => {
     expect(new URL(captured?.url ?? "").searchParams.get("token")).toBe(
       "attacker-cloud-token",
     );
+  });
+});
+
+/**
+ * The demo show-stopper (#15347): a staging agent is `running` but never joined
+ * headscale, so `headscale_ip` is empty and the CP returns a CORS-less 404 the
+ * browser reads as an opaque CORS error. The proxy must (a) answer preflights,
+ * (b) short-circuit the doomed CP round-trip with a readable 503, and (c)
+ * guarantee CORS on every browser-visible response.
+ */
+describe("dedicated-agent-proxy — CORS + unroutable short-circuit (#15347)", () => {
+  const ORIGIN = "https://app-staging.elizacloud.ai";
+
+  test("OPTIONS preflight → 204 + reflected CORS, no auth/DB/proxy work", async () => {
+    authResult = "throw"; // even a total auth failure must not reach here
+    const r = new Request(`https://${AGENT}.elizacloud.ai/api/status`, {
+      method: "OPTIONS",
+      headers: { origin: ORIGIN },
+    });
+    const res = await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
+    expect(res.status).toBe(204);
+    expect(res.headers.get("access-control-allow-origin")).toBe(ORIGIN);
+    expect(res.headers.get("access-control-allow-methods")).toContain("POST");
+    expect(captured).toBeNull(); // preflight is answered at the edge
+  });
+
+  test("owner + running + EMPTY headscale_ip + fallback off → 503 agent_unroutable + CORS, no CP round-trip", async () => {
+    authResult = { user: { id: "u1", organization_id: "org1" } };
+    sandboxResult = { ...runningDedicated, headscale_ip: "" };
+
+    const r = makeRequest("cloud-token", ORIGIN);
+    const res = await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("5");
+    expect(res.headers.get("access-control-allow-origin")).toBe(ORIGIN);
+    const body = (await res.json()) as { code?: string; success?: boolean };
+    expect(body.code).toBe("agent_unroutable");
+    expect(body.success).toBe(false);
+    // The whole point: never proxy a guaranteed CORS-less 404 to the CP.
+    expect(captured).toBeNull();
+  });
+
+  test("owner + running + NULL headscale_ip → 503 (null is treated as empty)", async () => {
+    authResult = { user: { id: "u1", organization_id: "org1" } };
+    sandboxResult = { ...runningDedicated, headscale_ip: null };
+    const r = makeRequest("cloud-token", ORIGIN);
+    const res = await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
+    expect(res.status).toBe(503);
+    expect(captured).toBeNull();
+  });
+
+  test("bridge-host fallback ON + running + empty ip → proxied, NOT short-circuited", async () => {
+    // The CP can reach the agent via published host ports when the operator
+    // opts into the fallback, so the worker must not pre-empt that with a 503.
+    authResult = { user: { id: "u1", organization_id: "org1" } };
+    sandboxResult = { ...runningDedicated, headscale_ip: "" };
+    const fallbackEnv = {
+      AGENT_ROUTER_ORIGIN_HOST: "cp.example.test",
+      AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK: "1",
+    } as never;
+
+    const r = makeRequest("cloud-token", ORIGIN);
+    const res = await handleDedicatedAgentProxy(
+      r,
+      fallbackEnv,
+      urlOf(r),
+      AGENT,
+    );
+
+    expect(res.status).toBe(200);
+    expect(captured).not.toBeNull(); // proxied to the CP
+    expect(captured?.headers.get("authorization")).toBe(
+      "Bearer agent-secret-token",
+    );
+  });
+
+  test("unauthenticated pass-through still gets CORS backfilled", async () => {
+    // No valid token → pass through to the CP unchanged; the CP has no CORS, so
+    // withCors must still backfill it or the browser sees an opaque failure.
+    authResult = "throw";
+    const r = makeRequest(undefined, ORIGIN);
+    const res = await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
+    expect(res.headers.get("access-control-allow-origin")).toBe(ORIGIN);
+    expect(captured).not.toBeNull(); // forwarded to the CP
   });
 });

--- a/packages/cloud/api/src/dedicated-agent-proxy.ts
+++ b/packages/cloud/api/src/dedicated-agent-proxy.ts
@@ -223,7 +223,54 @@ function extractQueryToken(request: Request, url: URL): string | null {
 }
 
 /**
+ * CORS headers for a browser-visible proxy response. The CP (nginx → agent-router)
+ * forwards verbatim and injects nothing, so its CORS-less 404/503 — and our own
+ * JSON error envelopes — reach the browser as an opaque
+ * "No 'Access-Control-Allow-Origin'" failure (#15347). Reflect the caller's
+ * Origin (mirrors the agent's own `resolveCorsOrigin`, which reflects any origin
+ * when provisioned); `*` only for a header-less non-browser caller.
+ */
+function corsHeadersFor(request: Request): Record<string, string> {
+  const origin = request.headers.get("origin");
+  return {
+    "access-control-allow-origin": origin ?? "*",
+    vary: "origin",
+    "access-control-allow-credentials": "true",
+    "access-control-allow-methods": "GET,POST,PUT,PATCH,DELETE,OPTIONS",
+    "access-control-allow-headers": "authorization,content-type,x-api-key",
+  };
+}
+
+/**
+ * Guarantee CORS on a browser-visible response. Applied only when the response
+ * lacks it, so the agent's own CORS-bearing responses (the happy path) pass
+ * through untouched and only the CP's/our error responses are augmented.
+ */
+function withCors(request: Request, response: Response): Response {
+  if (response.headers.has("access-control-allow-origin")) return response;
+  const headers = new Headers(response.headers);
+  for (const [key, value] of Object.entries(corsHeadersFor(request))) {
+    headers.set(key, value);
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function isBridgeHostFallbackEnabled(env: Bindings): boolean {
+  return (
+    env.AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK === "true" ||
+    env.AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK === "1"
+  );
+}
+
+/**
  * Auth-unify + proxy a request bound for `https://<agentId>.elizacloud.ai/*`.
+ * Every browser-visible return path carries CORS (`withCors`), and a CORS
+ * preflight is answered at the edge so a cross-origin agent call is never blocked
+ * by the CP's CORS-less responses (#15347).
  */
 export function handleDedicatedAgentProxy(
   request: Request,
@@ -231,74 +278,113 @@ export function handleDedicatedAgentProxy(
   url: URL,
   agentId: string,
 ): Promise<Response> {
+  if (request.method === "OPTIONS") {
+    return Promise.resolve(
+      new Response(null, { status: 204, headers: corsHeadersFor(request) }),
+    );
+  }
   return runWithCloudBindingsAsync(env, async () => {
+    const response = await proxyDedicatedAgent(request, env, url, agentId);
+    return withCors(request, response);
+  });
+}
+
+async function proxyDedicatedAgent(
+  request: Request,
+  env: Bindings,
+  url: URL,
+  agentId: string,
+): Promise<Response> {
+  try {
+    // 1. Validate the CLOUD token. It rides in the Authorization header for
+    //    HTTP, or as `?token=` for the WebSocket upgrade. No valid token →
+    //    pass through unchanged (web UI assets, the pairing exchange, the
+    //    agent's own token); the container's auth is the backstop.
+    const queryToken = extractQueryToken(request, url);
+    // Header/cookie auth validates the ORIGINAL request (preserves every
+    // existing auth method); a query-only (WS) token validates through a
+    // synthetic header request so it takes the exact same path.
+    const authRequest = queryToken
+      ? new Request(request.url, {
+          headers: { authorization: `Bearer ${queryToken}` },
+        })
+      : request;
+    let orgId: string;
+    let userId: string;
     try {
-      // 1. Validate the CLOUD token. It rides in the Authorization header for
-      //    HTTP, or as `?token=` for the WebSocket upgrade. No valid token →
-      //    pass through unchanged (web UI assets, the pairing exchange, the
-      //    agent's own token); the container's auth is the backstop.
-      const queryToken = extractQueryToken(request, url);
-      // Header/cookie auth validates the ORIGINAL request (preserves every
-      // existing auth method); a query-only (WS) token validates through a
-      // synthetic header request so it takes the exact same path.
-      const authRequest = queryToken
-        ? new Request(request.url, {
-            headers: { authorization: `Bearer ${queryToken}` },
-          })
-        : request;
-      let orgId: string;
-      let userId: string;
-      try {
-        const { user } = await requireAuthOrApiKeyWithOrg(authRequest);
-        orgId = user.organization_id;
-        userId = user.id;
-      } catch {
-        return proxyToOrigin(request, env, url);
-      }
-
-      // 2. Ownership — the caller's org MUST own this dedicated agent. Not
-      //    owned / not found / shared → pass through unchanged (never widen
-      //    access here; the container's own token auth rejects non-owners).
-      const sandbox = await agentSandboxesRepository.findByIdAndOrg(
-        agentId,
-        orgId,
-      );
-      if (!sandbox || sandbox.execution_tier === "shared") {
-        return proxyToOrigin(request, env, url);
-      }
-
-      // 3. Lifecycle — a non-running agent isn't reachable; resume + 202.
-      if (sandbox.status !== "running") {
-        return resumeAndRespond(sandbox, agentId, orgId, userId);
-      }
-
-      // 4. Unified auth — swap the validated owner's cloud token for the agent's
-      //    own ELIZA_API_TOKEN so the container accepts the request. For a WS
-      //    upgrade the token rode in `?token=`, so rewrite that too.
-      const envVars = (sandbox.environment_vars ?? {}) as Record<
-        string,
-        string
-      >;
-      const agentToken = envVars.ELIZA_API_TOKEN?.trim();
-      // No managed token (older / not-yet-provisioned agent) → pass through.
-      return proxyToOrigin(
-        request,
-        env,
-        url,
-        agentToken || undefined,
-        queryToken !== null,
-      );
-    } catch (error) {
-      // Fail-closed: any unexpected error → pass through WITHOUT injecting, so
-      // the container's own auth still gates access.
-      logger.error(
-        "[dedicated-proxy] unexpected error; passing through unauthenticated",
-        {
-          agentId,
-          error: error instanceof Error ? error.message : String(error),
-        },
-      );
+      const { user } = await requireAuthOrApiKeyWithOrg(authRequest);
+      orgId = user.organization_id;
+      userId = user.id;
+    } catch {
       return proxyToOrigin(request, env, url);
     }
-  });
+
+    // 2. Ownership — the caller's org MUST own this dedicated agent. Not
+    //    owned / not found / shared → pass through unchanged (never widen
+    //    access here; the container's own token auth rejects non-owners).
+    const sandbox = await agentSandboxesRepository.findByIdAndOrg(
+      agentId,
+      orgId,
+    );
+    if (!sandbox || sandbox.execution_tier === "shared") {
+      return proxyToOrigin(request, env, url);
+    }
+
+    // 3. Lifecycle — a non-running agent isn't reachable; resume + 202.
+    if (sandbox.status !== "running") {
+      return resumeAndRespond(sandbox, agentId, orgId, userId);
+    }
+
+    // 3b. Reachability — a `running` row can still lack a routable mesh
+    //     ingress (empty headscale_ip, bridge-host fallback off — the staging
+    //     default) because the container never finished joining headscale.
+    //     Proxying it hits the CP, which returns a CORS-less 404 the browser
+    //     reads as an opaque CORS failure, dead-ending chat (#15347). Mirror
+    //     the router's own gate and short-circuit to a readable, CORS-bearing
+    //     503 so the app renders a real "starting/unavailable" state and
+    //     retries — no doomed CP round-trip.
+    const headscaleIp = (sandbox.headscale_ip ?? "").trim();
+    if (!headscaleIp && !isBridgeHostFallbackEnabled(env)) {
+      logger.warn(
+        "[dedicated-proxy] agent running but unroutable (no headscale_ip)",
+        { agentId, orgId, status: sandbox.status },
+      );
+      const response = Response.json(
+        {
+          success: false,
+          code: "agent_unroutable",
+          error:
+            "Agent is running but has no routable network ingress yet (mesh join incomplete). Retry shortly.",
+        },
+        { status: 503 },
+      );
+      response.headers.set("Retry-After", String(RETRY_AFTER_SECONDS));
+      return response;
+    }
+
+    // 4. Unified auth — swap the validated owner's cloud token for the agent's
+    //    own ELIZA_API_TOKEN so the container accepts the request. For a WS
+    //    upgrade the token rode in `?token=`, so rewrite that too.
+    const envVars = (sandbox.environment_vars ?? {}) as Record<string, string>;
+    const agentToken = envVars.ELIZA_API_TOKEN?.trim();
+    // No managed token (older / not-yet-provisioned agent) → pass through.
+    return proxyToOrigin(
+      request,
+      env,
+      url,
+      agentToken || undefined,
+      queryToken !== null,
+    );
+  } catch (error) {
+    // Fail-closed: any unexpected error → pass through WITHOUT injecting, so
+    // the container's own auth still gates access.
+    logger.error(
+      "[dedicated-proxy] unexpected error; passing through unauthenticated",
+      {
+        agentId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return proxyToOrigin(request, env, url);
+  }
 }

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -185,6 +185,14 @@ export interface Bindings {
   /** VAPID contact subject sent to push services, e.g. `mailto:ops@example.com`. */
   ELIZA_WEB_PUSH_VAPID_SUBJECT?: string;
   AGENT_ROUTER_ORIGIN_HOST?: string;
+  /**
+   * When `"true"`/`"1"`, the agent-router reaches a running sandbox through the
+   * docker host's published bridge/web ports instead of a headscale mesh IP. The
+   * dedicated-agent proxy reads it to mirror that gate: with fallback off (the
+   * staging default), a running sandbox that has no `headscale_ip` is unroutable,
+   * so the proxy short-circuits to a readable 503 instead of a CORS-less CP 404.
+   */
+  AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK?: string;
   ELIZA_APP_WEBHOOK_GATEWAY_URL?: string;
   ELIZA_CLOUD_AGENT_BASE_DOMAIN?: string;
   WEBHOOK_GATEWAY_URL?: string;

--- a/packages/scripts/cloud/admin/daemons/agent-router.test.ts
+++ b/packages/scripts/cloud/admin/daemons/agent-router.test.ts
@@ -1,7 +1,11 @@
 // Exercises cloud admin daemons agent router.test automation behavior with deterministic script fixtures.
+
 import { describe, expect, it } from "bun:test";
+import type { IncomingMessage } from "node:http";
 import {
+  buildUnresolvedAgentResponse,
   extractAgentIdFromHost,
+  handleRequest,
   isBridgeHostFallbackEnabled,
   resolveSandboxRouting,
   selectAgentProxyTarget,
@@ -142,6 +146,92 @@ describe("selectAgentProxyTarget", () => {
     expect(selectAgentProxyTarget(routing, "/v1/chat/completions")).toBe(
       routing.bridgeTarget,
     );
+  });
+});
+
+describe("buildUnresolvedAgentResponse — CORS-bearing failure (#15347)", () => {
+  const ORIGIN = "https://app-staging.elizacloud.ai";
+
+  it("running row with no routable ingress → 503 agent_unroutable + reflected CORS + retry-after", async () => {
+    // A `running` sandbox whose headscale_ip never persisted is the exact 48/48
+    // staging state: reachable status, no mesh IP → resolveSandboxRouting = null.
+    const res = buildUnresolvedAgentResponse(
+      { status: "running", headscale_ip: null, web_ui_port: 20001 },
+      ORIGIN,
+    );
+    expect(res.status).toBe(503);
+    expect(res.headers.get("access-control-allow-origin")).toBe(ORIGIN);
+    expect(res.headers.get("vary")).toBe("origin");
+    expect(res.headers.get("access-control-allow-credentials")).toBe("true");
+    expect(res.headers.get("retry-after")).toBe("5");
+    const body = (await res.json()) as { code?: string; error?: string };
+    expect(body.code).toBe("agent_unroutable");
+  });
+
+  it("no such agent (undefined) → 404 not-found, still CORS-bearing", async () => {
+    const res = buildUnresolvedAgentResponse(undefined, ORIGIN);
+    expect(res.status).toBe(404);
+    expect(res.headers.get("access-control-allow-origin")).toBe(ORIGIN);
+    expect(res.headers.get("retry-after")).toBeNull();
+    const body = (await res.json()) as { error?: string; code?: string };
+    expect(body.error).toBe("agent not found or not running");
+    expect(body.code).toBeUndefined();
+  });
+
+  it("non-running row (pending/stopped) with empty ip → 404, NOT 503 (only running is 'unroutable')", () => {
+    for (const status of ["pending", "stopped", "disconnected"]) {
+      const res = buildUnresolvedAgentResponse(
+        { status, headscale_ip: "", web_ui_port: 20001 },
+        ORIGIN,
+      );
+      expect(res.status).toBe(404);
+    }
+  });
+
+  it("header-less (non-browser) caller → wildcard origin", () => {
+    const res = buildUnresolvedAgentResponse(
+      { status: "running", headscale_ip: null, web_ui_port: 20001 },
+      undefined,
+    );
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+  });
+});
+
+describe("handleRequest — agent-host CORS preflight (#15347)", () => {
+  const AGENT = "e06bb509-6c52-4c33-a9f7-66addc43e8c8";
+  const HOST = `${AGENT}.elizacloud.ai`;
+  const ORIGIN = "https://app-staging.elizacloud.ai";
+
+  function fakeReq(
+    method: string,
+    host: string,
+    origin?: string,
+  ): IncomingMessage {
+    return {
+      method,
+      headers: origin ? { host, origin } : { host },
+      socket: { remoteAddress: "127.0.0.1" },
+    } as unknown as IncomingMessage;
+  }
+
+  it("OPTIONS to an agent subdomain → 204 + reflected CORS, no proxy/DB hop", async () => {
+    // The preflight is answered at the router before any sandbox lookup, so a
+    // cross-origin agent call is allowed even while the agent itself is
+    // unroutable. A DB hit here would throw (no DATABASE_URL in unit env), so a
+    // clean 204 also proves the short-circuit ran before proxyAgentRequest.
+    const url = new URL(`http://${HOST}/api/agents`);
+    const res = await handleRequest(url, fakeReq("OPTIONS", HOST, ORIGIN));
+    expect(res.status).toBe(204);
+    expect(res.headers.get("access-control-allow-origin")).toBe(ORIGIN);
+    expect(res.headers.get("access-control-allow-methods")).toContain("POST");
+  });
+
+  it("non-agent host with no route match → plain 404 (unchanged)", async () => {
+    const res = await handleRequest(
+      new URL("http://cp-internal.example/nope"),
+      fakeReq("GET", "cp-internal.example"),
+    );
+    expect(res.status).toBe(404);
   });
 });
 

--- a/packages/scripts/cloud/admin/daemons/agent-router.ts
+++ b/packages/scripts/cloud/admin/daemons/agent-router.ts
@@ -49,6 +49,10 @@ const AGENT_ID_RE =
 // path open between requests, so a cold POST is rare).
 const PROXY_TAILNET_RETRY_ATTEMPTS = 1;
 const PROXY_TAILNET_RETRY_DELAY_MS = 400;
+// A `running` sandbox with no resolvable ingress (empty headscale_ip, fallback
+// off) is transient — the mesh join has not completed yet — so we advertise a
+// short client retry window rather than a terminal not-found.
+const UNROUTABLE_RETRY_AFTER_SECONDS = 5;
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
   "content-length",
@@ -305,16 +309,71 @@ function buildProxyHeaders(req: IncomingMessage, target: string): Headers {
   return headers;
 }
 
+/**
+ * CORS headers for the browser-facing agent-proxy path. nginx forwards the
+ * request here verbatim and injects nothing, so an error we return with no
+ * `access-control-allow-origin` reaches the browser as an opaque
+ * "No 'Access-Control-Allow-Origin'" failure that hides the real status (#15347).
+ * The agent's own responses already carry CORS (its `resolveCorsOrigin` reflects
+ * any origin when provisioned), so we mirror that by reflecting the caller's
+ * Origin — `*` only for a header-less (non-browser) caller, where credentials
+ * are moot.
+ */
+function corsHeaders(origin: string | undefined): Record<string, string> {
+  return {
+    "access-control-allow-origin": origin || "*",
+    vary: "origin",
+    "access-control-allow-credentials": "true",
+    "access-control-allow-methods": "GET,POST,PUT,PATCH,DELETE,OPTIONS",
+    "access-control-allow-headers": "authorization,content-type,x-api-key",
+  };
+}
+
+/**
+ * Response for an agent host request that resolves to no routable target. A
+ * `running` row with no ingress is "unroutable, retry" (503); anything else is a
+ * genuine not-found (404). Both carry CORS so the browser can read the status
+ * instead of an opaque CORS failure.
+ */
+export function buildUnresolvedAgentResponse(
+  sandbox: SandboxRoutingFields | null | undefined,
+  origin: string | undefined,
+): Response {
+  const unroutable = sandbox?.status === "running";
+  if (unroutable) {
+    return Response.json(
+      { error: "agent has no routable ingress yet", code: "agent_unroutable" },
+      {
+        status: 503,
+        headers: {
+          ...corsHeaders(origin),
+          "retry-after": String(UNROUTABLE_RETRY_AFTER_SECONDS),
+        },
+      },
+    );
+  }
+  return Response.json(
+    { error: "agent not found or not running" },
+    { status: 404, headers: corsHeaders(origin) },
+  );
+}
+
 async function proxyAgentRequest(
   agentId: string,
   url: URL,
   req: IncomingMessage,
 ): Promise<Response> {
-  const routing = await resolveAgentRouting(agentId);
+  const { findAgentSandboxRoutingById } = await loadDeps();
+  const sandbox = await findAgentSandboxRoutingById(agentId);
+  const routing = sandbox
+    ? resolveSandboxRouting(sandbox, {
+        allowBridgeHostFallback: isBridgeHostFallbackEnabled(),
+      })
+    : null;
   if (!routing) {
-    return Response.json(
-      { error: "agent not found or not running" },
-      { status: 404 },
+    return buildUnresolvedAgentResponse(
+      sandbox,
+      headerValue(req.headers.origin),
     );
   }
 
@@ -347,7 +406,7 @@ async function proxyAgentRequest(
   }
 }
 
-async function handleRequest(
+export async function handleRequest(
   url: URL,
   req?: IncomingMessage,
 ): Promise<Response> {
@@ -361,7 +420,18 @@ async function handleRequest(
   );
   if (!match) {
     const agentId = req ? extractAgentIdFromHost(getEffectiveHost(req)) : null;
-    if (agentId && req) return proxyAgentRequest(agentId, url, req);
+    if (agentId && req) {
+      // A browser preflights a cross-origin agent call with OPTIONS; answer it
+      // at the router with CORS so the real request is allowed to proceed even
+      // when the agent itself is unroutable (#15347). No DB lookup / proxy.
+      if (req.method === "OPTIONS") {
+        return new Response(null, {
+          status: 204,
+          headers: corsHeaders(headerValue(req.headers.origin)),
+        });
+      }
+      return proxyAgentRequest(agentId, url, req);
+    }
     return Response.json({ error: "not found" }, { status: 404 });
   }
   const agentId = match[1];


### PR DESCRIPTION
## Refs #15347 (code-partial — the CORS/observability layer)

Staging dedicated-agent containers never joined the headscale mesh, so **all 48 running rows have an empty `headscale_ip`**. On that path the CP `agent-router` resolves no route and returns a **bare, CORS-less 404**, which nginx and the CF worker pass through verbatim — so the browser sees an opaque `No 'Access-Control-Allow-Origin'` failure and chat dead-ends. The real failure (agents not on the mesh) is hidden instead of surfaced, violating the repo's three-state / J4 error doctrine.

This PR is the **code-fixable** half. It does **not** make chat work end-to-end — that needs the infra join (see "Human action still required" below) — but it converts the opaque CORS-masked 404 into an **observable, CORS-bearing error state**, and becomes a no-op happy path once agents carry a real `headscale_ip`.

### What changed

**Router daemon — `packages/scripts/cloud/admin/daemons/agent-router.ts`**
- `corsHeaders()` reflects the caller `Origin` (mirrors the agent's own `resolveCorsOrigin`, which reflects any origin when `ELIZA_CLOUD_PROVISIONED=1`).
- `buildUnresolvedAgentResponse()` distinguishes **running-but-unroutable** (`503 { code: "agent_unroutable" }` + `Retry-After`) from a genuine **not-found** (`404`); both now carry CORS. `proxyAgentRequest` fetches the raw sandbox (`findAgentSandboxRoutingById` already returns `status` + `headscale_ip`, so **no extra query**) and classifies on `status === "running"`.
- OPTIONS preflight on an agent-host request is answered at the router (`204` + CORS) **before** any DB/proxy work.

**CF worker — `packages/cloud/api/src/dedicated-agent-proxy.ts`**
- `withCors()` guarantees CORS on every browser-visible response, **only when it is missing** — so the agent's own CORS-bearing happy-path responses pass through untouched, and only the CP's / our error envelopes are augmented.
- OPTIONS answered at the edge (`204` + CORS).
- A `running` row with empty `headscale_ip` and bridge-host fallback off short-circuits to a **readable 503** instead of a doomed CORS-less CP round-trip, mirroring the router's own `isBridgeHostFallbackEnabled` gate.
- New `AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK` worker binding type (`packages/cloud/shared/src/types/cloud-worker-env.ts`).

Design note (commandment #4, "BFF is auth + proxy"): the worker CORS guarantee is pure edge concern. The reachability decision is authoritatively owned by the router; the worker short-circuit mirrors the router's own gate and lives beside the existing lifecycle branches in the same handler (which already return 202/402) — it avoids a round-trip that is guaranteed to fail.

### Verification

<details><summary>Router daemon + CF worker unit tests (bun) — 30 pass, 0 fail</summary>

```
$ bun test packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts packages/scripts/cloud/admin/daemons/agent-router.test.ts
 packages/cloud/api/src/dedicated-agent-proxy.ts          |  100.00 |   87.40 | ...
 30 pass
 0 fail
 82 expect() calls
Ran 30 tests across 2 files.
```

New/extended coverage:
- Router: `running` + empty/null ip → `503 agent_unroutable` + reflected CORS + `retry-after:5`; undefined sandbox → `404` + CORS; `pending`/`stopped`/`disconnected` → `404` (not 503); header-less caller → `*`; OPTIONS agent-host → `204` + CORS with **no** DB hop.
- Worker: OPTIONS → `204` + CORS, `fetch` **not** called; owner + running + empty/null ip + fallback off → `503 agent_unroutable` + CORS + `Retry-After`, **no** CP round-trip (`captured === null`); fallback **on** → proxied (not short-circuited); unauthenticated pass-through still CORS-backfilled; happy-path proxy response carries CORS even though the mocked upstream had none; **regression**: existing `202`/`402` lifecycle paths now assert CORS is present; security invariant (token injected only for a validated running owner) unchanged.
</details>

<details><summary>error-policy ratchet + biome</summary>

```
$ bun run audit:error-policy-ratchet
[error-policy-ratchet] base origin/develop (7ed598f007); 2 changed production source file(s)
  packages/cloud/api/src/dedicated-agent-proxy.ts: emptyCatch 0->0, serverConsole 0->0
  packages/cloud/shared/src/types/cloud-worker-env.ts: emptyCatch 0->0, serverConsole 0->0
[error-policy-ratchet] no new fallback-slop in touched files

$ biome check <changed files>
Checked 5 files. (1 pre-existing warning in untouched extractAgentIdFromHost default-param)
```

`bun run --cwd packages/cloud/api typecheck` surfaces only pre-existing errors (stripe API version, fal/proxy hono-version mismatch, core i18n generated files) — none in the touched files.
</details>

**Live / browser evidence — N/A in this worktree:** reproducing the fix end-to-end requires the staging headscale server + a valid `HEADSCALE_API_KEY`, which is exactly the infra part below (blocked on CF billing #15218). Post-infra, the honest check is:
`curl -i -H "Origin: https://app-staging.elizacloud.ai" https://<agentId>.staging.elizacloud.ai/api/agents` → a `503` **with** `Access-Control-Allow-Origin` (readable) instead of a CORS-masked `404`, and the app renders a real "agent starting/unavailable" state.

### Human action still required (infra/ops, blocked by CF billing #15218)

The actual "agents join headscale" work is **not** code-fixable:
1. Stand up / point the **staging** headscale control server and inject a working `HEADSCALE_API_KEY` (+ `HEADSCALE_PUBLIC_URL`/`HEADSCALE_API_URL`/`HEADSCALE_USER`) into the staging provisioning worker so `prepareContainerVPN` → `createPreAuthKey` succeeds and the container entrypoint's `tailscale up` actually registers.
2. Reap / reprovision the 48 stale `running` rows with empty `headscale_ip` (they predate the provision-time guards). The #15228 heartbeat reconciler escalates docker-healthy-but-unresolvable rows to `disconnected` → reprovision, but reprovision only succeeds once (1) lands (single-use ephemeral authkeys ⇒ a fresh container/authkey per agent).
3. Verify `TS_CONTROL_URL`/`HEADSCALE_URL` + authkey env are actually injected into staging containers and match a live headscale server.

Once agents carry a real `headscale_ip`, the router resolves a route and the code here is a transparent happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Evidence

Backend-only change (`packages/cloud/api`, `packages/cloud/shared`, `packages/scripts/cloud`) — no rendered-UI source touched. The end-to-end browser proof requires a live staging headscale server + `HEADSCALE_API_KEY`, which is exactly the infra work this PR is blocked on (CF billing #15218); it cannot be produced from this worktree.

<!-- evidence-row:before-screenshots --> Before screenshots: N/A - backend cloud-worker/daemon change; no rendered-UI source files in the diff.
<!-- evidence-row:after-screenshots --> After screenshots: N/A - backend cloud-worker/daemon change; no rendered-UI source files in the diff.
<!-- evidence-row:walkthrough-video --> Walkthrough video: N/A - end-to-end browser walkthrough needs a live staging headscale server + HEADSCALE_API_KEY (infra, blocked on #15218); not reproducible in this worktree.
<!-- evidence-row:backend-logs --> Backend logs: the new `logger.warn("[dedicated-proxy] agent running but unroutable (no headscale_ip)", …)` path is covered by the unit suites below (30 pass / 0 fail); live CP logs require the blocked staging infra. N/A - live-infra dependent, see above.
<!-- evidence-row:frontend-logs --> Frontend console/network logs: N/A - no frontend code changed; the observable effect (readable 503 + CORS instead of an opaque `No 'Access-Control-Allow-Origin'`) is asserted in the unit tests.
<!-- evidence-row:llm-trajectory --> Real-LLM trajectory: N/A - no agent/action/provider/prompt/model behavior changed; this is HTTP proxy/CORS/routing only.
<!-- evidence-row:domain-artifacts --> Domain artifacts: N/A - no DB rows/wallet/on-chain/generated-file artifacts are produced by an HTTP proxy/CORS/routing change. Proof is the unit suites for both changed surfaces: 30 pass, 0 fail, 82 expect() calls, 100% function coverage on dedicated-agent-proxy.ts (bun test packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts packages/scripts/cloud/admin/daemons/agent-router.test.ts); error-policy ratchet emptyCatch 0->0, serverConsole 0->0 on both touched production files.