### PR TITLE
fix(ci): keep Windows full-matrix install green when GNU patch aborts

### DIFF
--- a/packages/scripts/patch-llama-cpp-capacitor.mjs
+++ b/packages/scripts/patch-llama-cpp-capacitor.mjs
@@ -301,6 +301,19 @@ for (const { label, dir: pkgDir } of candidates) {
 
     if (result.status === 0 || result.status === 1) {
       patched++;
+    } else if (process.platform === "win32") {
+      // Windows CI ships GNU patch 2.5.9 from Strawberry Perl
+      // (C:\Strawberry\c\bin\patch.exe), which aborts with an internal
+      // assertion ("patch.c, Line 354, Expression: hunk") on these hunks
+      // instead of applying them. This patch only rewrites Android build
+      // files (build.gradle / CMakeLists / LlamaCpp.java) that are never
+      // built on Windows, so a failed apply here is not fatal — the
+      // string-based repair below still runs and Windows never consumes the
+      // Android artifacts. Treat it as a skip so `bun install` stays green.
+      skipped++;
+      console.warn(
+        `[patch-llama-cpp-capacitor] \`patch\` failed on Windows for ${label}; Android build files are not consumed here, continuing.`,
+      );
     } else {
       failed++;
       console.error(
@@ -317,7 +330,10 @@ for (const { label, dir: pkgDir } of candidates) {
   }
 }
 
-if (failed > 0) {
+// Never fail the install on Windows: the only artifacts this script touches
+// are Android build files, which are not built on Windows, and the Strawberry
+// Perl `patch.exe` there is prone to aborting on otherwise-valid hunks.
+if (failed > 0 && process.platform !== "win32") {
   process.exitCode = 1;
 }
 


### PR DESCRIPTION
## Problem

The **Windows full matrix** lane has been red across multiple consecutive `develop` heads (persistent, not a flake). Reference run: `28890180085` (head `279ab6b6e`).

## Common root cause (4 of 5 shards)

`app-and-cli`, `build-and-helper-smokes`, `framework-packages`, and `plugins` all die at the **same shared step** — `bun install`'s postinstall — long before their test commands run:

```
$ bun packages/scripts/... && bun packages/scripts/patch-llama-cpp-capacitor.mjs && ...
[patch-llama-cpp-capacitor] Failed to patch node_modules/.bun/llama-cpp-capacitor@0.1.5+...:
Assertation failed!
Program: C:\Strawberry\c\bin\patch.exe
File: .\src\patch\2.5.9\patch-2.5.9-src\patch.c, Line 354
Expression: hunk
[patch-llama-cpp-capacitor] patched=0 already-applied=0 repaired=1 failed=1
error: postinstall script from "eliza" exited with 1
```

`patch-llama-cpp-capacitor.mjs` shells out to the system `patch` binary. On the Windows runner that binary is **Strawberry Perl's GNU patch 2.5.9**, which **aborts with an internal assertion** (`patch.c, Line 354, Expression: hunk`) instead of applying the hunks. The script counted that as a hard failure (`failed++` → `process.exitCode = 1`), which failed the postinstall → failed `bun install` → took down every Windows shard.

The intermittent-recovery behaviour (some shards occasionally survive on the `bun install` retry) is explained by the script's string-based `repairPatchedPackage()` step: on a second install the top-level copy already carries the `'arm64-v8a', 'riscv64'` abiFilter, so `isPatchAlreadyApplied()` short-circuits and `patch.exe` is never invoked. This is why the failure looks flaky-but-persistent.

## Fix

The patch **only rewrites Android build files** (`build.gradle`, `CMakeLists.txt`, `LlamaCpp.java`) that are **never built on Windows**. So a failed apply there is harmless. On `win32`:

- treat a `patch` binary crash as a **skip** (the string-based repair still runs), and
- never set a nonzero exit code from this script.

Linux and macOS keep the original fail-fast behaviour, where the Android artifacts are actually consumed.

## Per-shard breakdown

| Shard | Cause |
| --- | --- |
| `app-and-cli` | postinstall `patch.exe` abort (common root cause) — **fixed** |
| `build-and-helper-smokes` | postinstall `patch.exe` abort — **fixed** |
| `framework-packages` | postinstall `patch.exe` abort — **fixed** |
| `plugins` | postinstall `patch.exe` abort — **fixed** |
| `core-runtime` | install recovered on retry; then a **separate** test assertion failure (see below) — *not* addressed here |

## Secondary finding (not fixed here — out of scope)

`core-runtime` got past install and instead failed one test:

```
FAIL src/services/message/pre-llm-direct-hook-removed.test.ts > ... routes missed-call owner chat through Stage 1 instead of a canned hook reply
AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
  ❯ src/services/message/pre-llm-direct-hook-removed.test.ts:193:20
```

This is an orthogonal `useModel`-called-twice assertion, unrelated to the Windows install root cause. It should be triaged on its own (likely a real logic/ordering issue or a shared-mock leak, not Windows-specific). Flagged here for visibility rather than papered over.

## Verification

- macOS host — cannot run Windows CI locally. Evidence is the CI logs quoted above (run `28890180085`).
- `node --check packages/scripts/patch-llama-cpp-capacitor.mjs` passes.
- Change is guarded to `process.platform === "win32"`, so Linux/macOS Android-build behaviour is byte-for-byte unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)