### PR TITLE
fix(cloud): timestamp shared chat history after first send

### DIFF
--- a/packages/cloud/shared/src/lib/services/shared-runtime/agent-tier.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/agent-tier.test.ts
@@ -84,7 +84,12 @@ describe("runSharedAgentTurn (degraded path — no model configured)", () => {
     expect(result.degraded).toBe(true);
     expect(result.reply).toContain("Nova");
     expect(result.history).toHaveLength(2);
-    expect(result.history[0]).toEqual({ role: "user", content: "hello there" });
+    expect(result.history[0]).toMatchObject({
+      role: "user",
+      content: "hello there",
+    });
+    expect(typeof result.history[0]?.createdAt).toBe("number");
     expect(result.history[1]?.role).toBe("assistant");
+    expect(typeof result.history[1]?.createdAt).toBe("number");
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/agent-tier.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/agent-tier.test.ts
@@ -51,6 +51,8 @@ describe("runSharedAgentTurn (degraded path — no model configured)", () => {
   const MODEL_KEYS = [
     "CEREBRAS_API_KEY",
     "OPENAI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "ANTHROPIC_API_KEY",
     "BITROUTER_API_KEY",
     "AI_GATEWAY_API_KEY",
     "AIGATEWAY_API_KEY",

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
@@ -90,8 +90,13 @@ describe("runSharedAgentTurn — internal failure propagates vs designed-empty d
     expect(result.model).toBe("none");
     expect(result.reply).toContain("no shared model configured");
     expect(result.history).toHaveLength(2);
-    expect(result.history[0]).toEqual({ role: "user", content: "hello there" });
+    expect(result.history[0]).toMatchObject({
+      role: "user",
+      content: "hello there",
+    });
+    expect(typeof result.history[0]?.createdAt).toBe("number");
     expect(result.history[1]?.role).toBe("assistant");
+    expect(typeof result.history[1]?.createdAt).toBe("number");
   });
 
   test("a successful turn returns the reply with degraded:false (not a tautology — real SUT runs)", async () => {
@@ -113,7 +118,12 @@ describe("runSharedAgentTurn — internal failure propagates vs designed-empty d
     expect(result.usage).toEqual({ totalTokens: 7 });
     // history + new user message + assistant reply.
     expect(result.history).toHaveLength(4);
-    expect(result.history[2]).toEqual({ role: "user", content: "hi" });
-    expect(result.history[3]).toEqual({ role: "assistant", content: "hi from Nova" });
+    expect(result.history[2]).toMatchObject({ role: "user", content: "hi" });
+    expect(typeof result.history[2]?.createdAt).toBe("number");
+    expect(result.history[3]).toMatchObject({
+      role: "assistant",
+      content: "hi from Nova",
+    });
+    expect(typeof result.history[3]?.createdAt).toBe("number");
   });
 });

--- a/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts
@@ -30,6 +30,8 @@ import {
 export interface SharedTurnMessage {
   role: "user" | "assistant";
   content: string;
+  /** Epoch-ms timestamp used by REST chat clients to reconcile persisted turns. */
+  createdAt?: number;
 }
 
 export interface SharedAgentCharacter {
@@ -116,10 +118,11 @@ function appendTurn(
   userMessage: string,
   reply: string,
 ): SharedTurnMessage[] {
+  const sentAt = Date.now();
   return [
     ...history,
-    { role: "user", content: userMessage },
-    { role: "assistant", content: reply },
+    { role: "user", content: userMessage, createdAt: sentAt },
+    { role: "assistant", content: reply, createdAt: sentAt + 1 },
   ];
 }
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
@@ -3,7 +3,8 @@
  * client talk to a server-less shared agent. The load-bearing invariants:
  *   - the conversation is canonical (id === agentId === roomId), so the list is
  *     always one item and create is idempotent;
- *   - history maps SharedTurnMessage{role,content} → REST {id,role,text};
+ *   - history maps SharedTurnMessage{role,content,createdAt} → REST
+ *     {id,role,text,timestamp};
  *   - send forwards to the bridge `message.send` and returns its reply text;
  *   - the startup shell (status/first-run/views/config/auth-me/character) returns
  *     the exact shapes the mobile app probes on boot.
@@ -205,15 +206,25 @@ describe("shared-rest-adapter — messages", () => {
   });
 
   test("GET maps bridge turn history → REST messages", async () => {
+    const before = Date.now();
     getSharedConversationHistory.mockResolvedValue([
-      { role: "user", content: "hi" },
+      { role: "user", content: "hi", createdAt: 1_783_382_400_000 },
       { role: "assistant", content: "Hello!" },
     ]);
     const { messages } = await sharedRestMessagesGet(AGENT, AGENT);
-    expect(messages).toEqual([
-      { id: `${AGENT}:0`, role: "user", text: "hi" },
-      { id: `${AGENT}:1`, role: "assistant", text: "Hello!" },
-    ]);
+    expect(messages[0]).toEqual({
+      id: `${AGENT}:0`,
+      role: "user",
+      text: "hi",
+      timestamp: 1_783_382_400_000,
+    });
+    expect(messages[1]).toMatchObject({
+      id: `${AGENT}:1`,
+      role: "assistant",
+      text: "Hello!",
+    });
+    expect(typeof messages[1]?.timestamp).toBe("number");
+    expect(messages[1]?.timestamp).toBeLessThan(before - 60_000);
     expect(getSharedConversationHistory).toHaveBeenCalledWith(AGENT, AGENT);
   });
 

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
@@ -50,6 +50,7 @@ export interface SharedRestMessage {
   id: string;
   role: "user" | "assistant";
   text: string;
+  timestamp: number;
 }
 
 /** The canonical (single) conversation id for a shared agent === its agent id. */
@@ -313,6 +314,24 @@ export function sharedRestConversationDelete(): { ok: true } {
   return { ok: true };
 }
 
+function sharedRestMessageTimestamp(
+  turn: { createdAt?: unknown },
+  index: number,
+  total: number,
+): number {
+  if (
+    typeof turn.createdAt === "number" &&
+    Number.isFinite(turn.createdAt) &&
+    turn.createdAt > 0
+  ) {
+    return turn.createdAt;
+  }
+  // Legacy shared-runtime history rows predate createdAt. Keep them finite but
+  // safely older than the UI's "just sent" reconciliation window, so a repeated
+  // failed send is still restored instead of being masked by an old same-text row.
+  return Date.now() - 5 * 60_000 - (total - index);
+}
+
 /**
  * GET .../api/conversations/:id/messages — read the bridge's persisted turn
  * history for this room and present it in the REST message shape. Ids are
@@ -330,6 +349,7 @@ export async function sharedRestMessagesGet(
     id: `${conversationId}:${index}`,
     role: turn.role,
     text: turn.content,
+    timestamp: sharedRestMessageTimestamp(turn, index, history.length),
   }));
   return { messages };
 }

--- a/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
+++ b/packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
@@ -319,11 +319,7 @@ function sharedRestMessageTimestamp(
   index: number,
   total: number,
 ): number {
-  if (
-    typeof turn.createdAt === "number" &&
-    Number.isFinite(turn.createdAt) &&
-    turn.createdAt > 0
-  ) {
+  if (typeof turn.createdAt === "number" && Number.isFinite(turn.createdAt) && turn.createdAt > 0) {
     return turn.createdAt;
   }
   // Legacy shared-runtime history rows predate createdAt. Keep them finite but


### PR DESCRIPTION
# Relates to

Fixes #15354.

Definition of Done: full standard in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

- [x] This PR targets `develop` and is rebased onto the latest `origin/develop` with zero conflicts (`origin/develop` `98e59bc4e5`; branch head `a1f8db900f`).
- [ ] `bun install` and `bun run verify` were run after sync, or any failure is recorded below with the exact unrelated blocker.
- [x] A reviewer can confirm the change works without reading the code, from the evidence attached below.

# Sync with develop

- [x] Rebased/merged onto the latest `origin/develop`; zero conflicts.
- [ ] `bun run verify` passes post-sync, or the exact unrelated blocker is documented in **Known gaps / failures** below.

# Risks

Low/medium. This changes shared-runtime chat history serialization by adding numeric timestamps to new persisted shared-agent turns and to the shared REST `/messages` response. The fallback for legacy timestamp-less rows is intentionally older than the UI's just-sent reconciliation window so old same-text turns cannot mask a failed repeat send.

# Background

## What does this PR do?

The shared-runtime REST adapter was returning persisted shared-agent messages as `{ id, role, text }` without `timestamp`. The UI send path reloads server history after a turn and uses a recent user-message timestamp to decide whether the server persisted the just-sent user turn. With no timestamp, the shared-agent reload looked like the user turn was evicted, so the UI restored the optimistic temp user bubble and added an extra undelivered assistant response. That matches #15354's `1 sent -> 2 user messages + extra assistant responses` symptom.

This PR:

- persists `createdAt` on new shared-runtime user/assistant history rows;
- maps shared-runtime `createdAt` to REST `ConversationMessage.timestamp`;
- supplies a finite but non-recent timestamp for legacy shared-runtime rows that predate `createdAt`;
- updates focused tests to assert the timestamp contract.

## What kind of change is this?

Bug fix (non-breaking change which fixes an issue).

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Start with `packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts` and `packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts`.

## Detailed testing steps

- Confirm `sharedRestMessagesGet()` now always returns `timestamp` on REST messages.
- Confirm `runSharedAgentTurn()` now appends `createdAt` to new shared history turns.
- Confirm the UI's existing `restoreEvictedUserTurn` guard can now match the persisted server user turn by text + recent timestamp instead of re-attaching the temp user bubble.

Commands run:

```bash
git fetch origin
git rebase origin/develop
bunx biome check packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.ts packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.ts packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts packages/cloud/shared/src/lib/services/shared-runtime/agent-tier.test.ts
bun run --cwd packages/cloud/shared lint:check
bun test packages/cloud/shared/src/lib/services/shared-runtime/run-shared-agent-turn.error-policy.test.ts
```

# Evidence Gate

Any change testable on the frontend is not mergeable without a video walkthrough, before/after screenshots, and logs. If you did not attach them, say why.

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend/shared-runtime TypeScript only; no rendered UI source files changed.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend/shared-runtime TypeScript only; no rendered UI source files changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - backend/shared-runtime TypeScript only; live PWA device verification is a post-deploy QA step for #15354.
<!-- evidence-row:backend-logs -->
- [x] N/A - no staging deploy was performed from this PR; the backend code path is covered by focused unit/static evidence above.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend code changed and no live PWA run was performed from this PR.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no prompt/model/provider/action behavior changed; this is history metadata serialization.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no schema migration or durable data mutation required; new JSON history rows gain optional `createdAt`, legacy rows are read with a fallback timestamp.

# Evidence Details

## Real LLM-call trajectory

N/A - no prompt/model/provider/action behavior changed.

## Backend + frontend logs

N/A - no staging deploy or live PWA run was performed from this PR. The relevant backend contract is pinned by the code/test changes: shared history now carries `createdAt`, and REST messages now carry numeric `timestamp`.

## Screenshots (before / after) + video walkthrough

N/A - backend/shared-runtime TypeScript only; no rendered `.tsx`/`.css`/`.svg`/`.html` files changed.

### Before

N/A - see reason above.

### After

N/A - see reason above.

### Walkthrough video

N/A - see reason above.

## Audio / voice walkthrough

N/A - no voice/transcript/TTS/STT behavior changed.

## Known gaps / failures

- `bun install --frozen-lockfile` could not be used in this worktree: Bun reported `lockfile had changes, but lockfile is frozen`. I did not run non-frozen install or modify `bun.lock` for this bug fix.
- `bun test packages/cloud/shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts` could not start without installed deps: `Cannot find package 'drizzle-orm' from .../eliza-sandbox.ts`.
- `bun test packages/ui/src/state/useChatSend.test.tsx --test-name-pattern "does NOT duplicate the turn when the server persisted it"` could not start without installed deps: `Cannot find module '@testing-library/react'`.
- Live iOS PWA verification is still required after this lands/deploys to prove #15354 is gone on the device path.

# Deploy Notes

Deploy Cloud backend/shared-runtime routes to staging, then repeat #15354 repro on iOS installed PWA: fresh install/sign-in -> onboarding completes into chat -> send one `hi` -> expect one user row and one assistant response, with no restored temp user or undelivered assistant bubble.





