### PR TITLE
fix(ci): repair persistent develop-red iOS full-Bun smoke + Electrobun release contract

### DIFF
--- a/.github/workflows/mobile-build-smoke.yml
+++ b/.github/workflows/mobile-build-smoke.yml
@@ -298,6 +298,15 @@ jobs:
         with:
           submodules: false
 
+      # The full-Bun on-device engine builds the MTP-forked llama.cpp kernels
+      # (run-mobile-build.mjs ios-local with ELIZA_IOS_FULL_BUN_ENGINE=1), which
+      # requires the llama.cpp fork checkout. `submodules: false` above keeps the
+      # checkout source-clean, so init just that submodule (not the full recursive
+      # tree) before the build — build-llama-cpp-mtp.mjs otherwise aborts with
+      # "no llama.cpp fork checkout found".
+      - name: Initialize llama.cpp fork submodule (full-Bun MTP kernels)
+        run: git submodule update --init --recursive plugins/plugin-local-inference/native/llama.cpp
+
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:

--- a/packages/app-core/scripts/release-check.ts
+++ b/packages/app-core/scripts/release-check.ts
@@ -259,7 +259,7 @@ const forbiddenWorkflowSnippets = [
 const requiredElectrobunPrWorkflowSnippets = [
   "name: Validate Electrobun Release Workflow",
   "pull_request:",
-  "branches: [main, develop]",
+  "branches: [main]",
   "workflow_dispatch:",
   "permissions:",
   "contents: read",


### PR DESCRIPTION
Two failures on the **Develop Exhaustive Lane** have been red across multiple consecutive develop heads. Both are config drift, not infra flakiness. Root-caused from the actual job logs of run 28890180085.

## 1. `Electrobun desktop release / Release Workflow Contract`

**Log evidence:**
```
release-check: Electrobun PR workflow is missing lightweight release-contract validation:
  - branches: [main, develop]
error: script "release:check" exited with code 1
```

**Root cause (real, not infra):** `packages/app-core/scripts/release-check.ts` (`requiredElectrobunPrWorkflowSnippets`) still required the literal snippet `branches: [main, develop]` in `.github/workflows/test-electrobun-release.yml`. But PR #14194 ("lightweight develop-PR gate") **intentionally** stripped `develop` from that workflow's `pull_request` trigger, leaving `branches: [main]`. The contract was never updated, so `run-release-check.mjs` exits 1 on every develop head.

**Fix:** update the required snippet to `branches: [main]` so the contract matches the intended workflow shape.

**Local repro:** replicated the contract check against the real files — 0 missing required snippets, 0 forbidden snippets present, after the fix.

## 2. `Mobile build smoke / iOS Local (full-Bun) Simulator Smoke`

**Log evidence:**
```
[mobile-build] Building mtp artifact for ios-arm64-metal
[mtp-build:err] no llama.cpp fork checkout found. Run `git submodule update --init --recursive`.
Looked in:
  .../plugins/plugin-local-inference/native/llama.cpp
Error: node exited with code 1
```

**Root cause (real, not infra):** the full-Bun job (added in #13879) checks out with `submodules: false` and never initializes the llama.cpp fork submodule. But it builds with `ELIZA_IOS_FULL_BUN_ENGINE=1`, which drives `build-llama-cpp-mtp.mjs` to compile the MTP-forked llama.cpp Metal kernels — that requires the `plugins/plugin-local-inference/native/llama.cpp` checkout. The lane has been red since it was introduced.

**Fix:** initialize just that submodule (not the full recursive tree) after checkout and before the build.

## Verification
- Electrobun: contract logic replicated locally against the real files — passes.
- iOS: YAML validated; submodule path confirmed against `.gitmodules`. The build step itself needs a macOS runner with Xcode + the fork checkout, which this change provides; it will exercise on the nightly/dispatch lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)