### PR TITLE
fix(cloud-chat): clear synthetic onboarding transcript on first-run completion (#15354)

### DIFF
--- a/packages/ui/src/first-run/clear-first-run-transcript.test.ts
+++ b/packages/ui/src/first-run/clear-first-run-transcript.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import type { ConversationMessage } from "../api";
+import {
+  clearFirstRunTranscriptMessages,
+  isFirstRunTranscriptMessage,
+} from "./clear-first-run-transcript";
+
+function firstRunTurn(
+  id: string,
+  extra: Partial<ConversationMessage> = {},
+): ConversationMessage {
+  return {
+    id,
+    role: "assistant",
+    text: "onboarding turn",
+    timestamp: 1,
+    source: "first_run",
+    ...extra,
+  };
+}
+
+function realUser(id: string, text = "hi"): ConversationMessage {
+  return { id, role: "user", text, timestamp: 2 };
+}
+
+function realAssistant(id: string, text = "hey there"): ConversationMessage {
+  return { id, role: "assistant", text, timestamp: 3 };
+}
+
+describe("isFirstRunTranscriptMessage", () => {
+  it("matches the first_run source marker", () => {
+    expect(
+      isFirstRunTranscriptMessage(firstRunTurn("first-run:greeting")),
+    ).toBe(true);
+  });
+
+  it("matches the first-run: id namespace even without the source marker", () => {
+    // A conductor turn is always seeded with BOTH signals; matching either is
+    // the robust superset so a future turn that sets only one is still caught.
+    expect(
+      isFirstRunTranscriptMessage({
+        id: "first-run:user:3",
+        role: "user",
+        text: "typed during onboarding",
+        timestamp: 1,
+      }),
+    ).toBe(true);
+  });
+
+  it("never matches a real server turn", () => {
+    expect(isFirstRunTranscriptMessage(realUser("srv-user-1"))).toBe(false);
+    expect(isFirstRunTranscriptMessage(realAssistant("srv-asst-1"))).toBe(
+      false,
+    );
+  });
+
+  it("never matches an optimistic temp- turn", () => {
+    expect(isFirstRunTranscriptMessage(realUser("temp-123"))).toBe(false);
+    expect(isFirstRunTranscriptMessage(realAssistant("temp-resp-123"))).toBe(
+      false,
+    );
+  });
+});
+
+describe("clearFirstRunTranscriptMessages", () => {
+  it("drops every synthetic first-run turn and keeps real turns in order", () => {
+    // The exact #15354 shape: a returning-account shared-tier onboarding seeds
+    // greeting + welcome-back + cloud-done (three greeting-looking assistant
+    // bubbles) plus a typed reply pair, then the user's real first turn arrives.
+    const messages: ConversationMessage[] = [
+      firstRunTurn("first-run:greeting", { text: "Sign in to Eliza Cloud" }),
+      firstRunTurn("first-run:cloud-signin", { text: "Welcome back" }),
+      firstRunTurn("first-run:user:1", { role: "user", text: "who are you" }),
+      firstRunTurn("first-run:reply:1", { text: "I'm Eliza" }),
+      firstRunTurn("first-run:cloud-done", { text: "All set" }),
+      realUser("temp-1000", "hi"),
+      realAssistant("temp-resp-1000", "hey!"),
+    ];
+
+    const result = clearFirstRunTranscriptMessages(messages);
+
+    expect(result.map((m) => m.id)).toEqual(["temp-1000", "temp-resp-1000"]);
+    // Exactly one user turn + one assistant turn survive — the single real send.
+    expect(result.filter((m) => m.role === "user")).toHaveLength(1);
+    expect(result.filter((m) => m.role === "assistant")).toHaveLength(1);
+  });
+
+  it("returns the SAME array reference when there is nothing to remove", () => {
+    // Safe to run inside a state setter without forcing a spurious re-render.
+    const clean: ConversationMessage[] = [
+      realUser("srv-user-1"),
+      realAssistant("srv-asst-1"),
+    ];
+    expect(clearFirstRunTranscriptMessages(clean)).toBe(clean);
+  });
+
+  it("is a no-op on an empty transcript (silent-reuse onboarding, #15133)", () => {
+    const empty: ConversationMessage[] = [];
+    expect(clearFirstRunTranscriptMessages(empty)).toBe(empty);
+  });
+
+  it("purges an all-first-run transcript down to empty", () => {
+    const onlyOnboarding: ConversationMessage[] = [
+      firstRunTurn("first-run:greeting"),
+      firstRunTurn("first-run:cloud-done"),
+    ];
+    expect(clearFirstRunTranscriptMessages(onlyOnboarding)).toEqual([]);
+  });
+});

--- a/packages/ui/src/first-run/clear-first-run-transcript.ts
+++ b/packages/ui/src/first-run/clear-first-run-transcript.ts
@@ -1,0 +1,62 @@
+/**
+ * Purge the synthetic onboarding transcript when first-run completes.
+ *
+ * Onboarding is PART OF THE CHAT (see `use-first-run-conductor.ts`): the
+ * conductor seeds synthetic assistant turns — the sign-in greeting, the
+ * welcome-back turn, per-step status turns, the cloud-done wrap-up, typed
+ * onboarding user/reply turns — DIRECTLY into the live `conversationMessages`
+ * store the `ContinuousChatOverlay` renders. While onboarding is active
+ * (`firstRunOpen`) the overlay filters the transcript down to the current
+ * first-run turn via `selectFirstRunDisplayMessages`, so only one card shows.
+ *
+ * On completion (`firstRunComplete` flips true / `firstRunOpen` falls to false)
+ * that first-run filter is DROPPED and the overlay renders the raw transcript.
+ * Nothing cleared the seeded turns, so every leftover `first-run:*` bubble —
+ * greeting + welcome-back + cloud-done, plus any typed reply turns — suddenly
+ * paints as ordinary chat history. The user, who sent exactly one message, sees
+ * multiple stacked "greeting"-looking assistant bubbles and duplicated user
+ * turns until the first real send's post-turn history reload full-replaces the
+ * store with server truth (#15354).
+ *
+ * The fix is to drop the synthetic first-run turns the instant onboarding
+ * completes, so the real chat opens on a clean thread and the first message is
+ * the first thing in it. This is a pure, id/source-scoped filter: it only ever
+ * removes turns the conductor itself seeded (`source === "first_run"` or an id
+ * under the `first-run:` namespace) and never touches a real server or
+ * optimistic (`temp-*`) turn.
+ */
+
+import type { ConversationMessage } from "../api";
+
+const FIRST_RUN_TURN_ID_PREFIX = "first-run:";
+const FIRST_RUN_TURN_SOURCE = "first_run";
+
+/**
+ * Whether a transcript turn is a synthetic onboarding turn seeded by the
+ * first-run conductor. Matches by BOTH the `first_run` source marker and the
+ * `first-run:` id namespace so a turn that carries either signal is caught (the
+ * conductor always sets both via `makeTurn`, but matching either is the robust
+ * superset).
+ */
+export function isFirstRunTranscriptMessage(
+  message: ConversationMessage,
+): boolean {
+  return (
+    message.source === FIRST_RUN_TURN_SOURCE ||
+    message.id.startsWith(FIRST_RUN_TURN_ID_PREFIX)
+  );
+}
+
+/**
+ * Drop every synthetic first-run turn from a transcript, preserving the order
+ * and identity of all real turns. Returns the SAME array reference when there
+ * is nothing to remove, so it is safe to run inside a state setter without
+ * forcing a spurious re-render (and a no-op when onboarding seeded nothing —
+ * the silent-reuse entry, #15133).
+ */
+export function clearFirstRunTranscriptMessages(
+  messages: ConversationMessage[],
+): ConversationMessage[] {
+  if (!messages.some(isFirstRunTranscriptMessage)) return messages;
+  return messages.filter((message) => !isFirstRunTranscriptMessage(message));
+}

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -1105,6 +1105,115 @@ describe("useFirstRunConductor", () => {
   });
 });
 
+// ── completion edge purges the synthetic onboarding transcript (#15354) ───────
+
+/**
+ * Mount the conductor with a preseedable, ref-backed transcript AND the ability
+ * to flip `firstRunComplete` between renders — so the onboarding-complete edge
+ * (`active` → false) is drivable exactly as the store flip drives it live.
+ */
+function renderConductorWithControls(initialFirstRunComplete: boolean) {
+  const transcript: { current: ConversationMessage[] } = { current: [] };
+  const value: ConversationMessagesValue = {
+    conversationMessages: [],
+    removeConversationMessage: () => {},
+    prependConversationMessages: () => {},
+    setConversationMessages: (updater) => {
+      transcript.current =
+        typeof updater === "function" ? updater(transcript.current) : updater;
+    },
+  };
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(ConversationMessagesCtx.Provider, { value }, children);
+  seedAppStore({ firstRunComplete: initialFirstRunComplete });
+  const utils = renderHook(() => useFirstRunConductor(), { wrapper });
+  const setFirstRunComplete = (complete: boolean) => {
+    seedAppStore({ firstRunComplete: complete });
+    utils.rerender();
+  };
+  return { transcript, setFirstRunComplete, ...utils };
+}
+
+describe("first-run completion clears the synthetic onboarding transcript", () => {
+  it("drops leftover first-run turns on the complete edge so one send is not shown as many (#15354)", async () => {
+    const { transcript, setFirstRunComplete, unmount } =
+      renderConductorWithControls(false);
+    // Let the mount effect register + seed its greeting (active onboarding).
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    // Reproduce the #15354 store shape at the moment onboarding completes: the
+    // conductor-seeded first-run turns (greeting + welcome-back + cloud-done)
+    // are still in the live transcript, and the user's one real optimistic send
+    // has been appended by the chat send path.
+    transcript.current = [
+      {
+        id: "first-run:greeting",
+        role: "assistant",
+        text: "Sign in to Eliza Cloud",
+        timestamp: 1,
+        source: "first_run",
+      },
+      {
+        id: "first-run:cloud-signin",
+        role: "assistant",
+        text: "Welcome back",
+        timestamp: 2,
+        source: "first_run",
+      },
+      {
+        id: "first-run:cloud-done",
+        role: "assistant",
+        text: "All set",
+        timestamp: 3,
+        source: "first_run",
+      },
+      { id: "temp-1000", role: "user", text: "hi", timestamp: 4 },
+      { id: "temp-resp-1000", role: "assistant", text: "hey!", timestamp: 5 },
+    ];
+
+    // The store flips firstRunComplete → true (onboarding done). The conductor's
+    // completion effect must purge the synthetic turns.
+    setFirstRunComplete(true);
+    await waitFor(() => {
+      expect(
+        transcript.current.some((m) => m.id.startsWith("first-run:")),
+      ).toBe(false);
+    });
+
+    // Exactly the single real turn survives: ONE user message + ONE response.
+    expect(transcript.current.map((m) => m.id)).toEqual([
+      "temp-1000",
+      "temp-resp-1000",
+    ]);
+    expect(transcript.current.filter((m) => m.role === "user")).toHaveLength(1);
+    expect(
+      transcript.current.filter((m) => m.role === "assistant"),
+    ).toHaveLength(1);
+    unmount();
+  });
+
+  it("leaves a real, already-clean thread untouched on completion (no spurious mutation)", async () => {
+    const { transcript, setFirstRunComplete, unmount } =
+      renderConductorWithControls(false);
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    transcript.current = [
+      { id: "srv-user-1", role: "user", text: "hi", timestamp: 4 },
+      { id: "srv-asst-1", role: "assistant", text: "hey!", timestamp: 5 },
+    ];
+
+    setFirstRunComplete(true);
+    // Flush the completion effect.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    expect(transcript.current.map((m) => m.id)).toEqual([
+      "srv-user-1",
+      "srv-asst-1",
+    ]);
+    unmount();
+  });
+});
+
 // ── surfaceCloudLoginRetryTurn (pure transcript seam) ────────────────────────
 
 function applyRetry(existing: ConversationMessage[]): ConversationMessage[] {

--- a/packages/ui/src/first-run/use-first-run-conductor.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.ts
@@ -76,6 +76,7 @@ import { useConversationMessages } from "../state/ConversationMessagesContext.ho
 import { preOpenCloudLoginWindow } from "../state/cloud-login-launch";
 import { hasUsableStoredStewardToken } from "../state/cloud-steward-login";
 import { startTutorial } from "../tutorial/tutorial-service";
+import { clearFirstRunTranscriptMessages } from "./clear-first-run-transcript";
 import {
   peekDeviceRamTierAssessment,
   resolveDeviceRamTierAssessment,
@@ -1341,6 +1342,17 @@ export function useFirstRunConductor(): void {
     if (!active) {
       setFirstRunActionHandler(null);
       setFirstRunTextHandler(null);
+      // Onboarding just completed: the overlay stops filtering the transcript to
+      // the current first-run card (`selectFirstRunDisplayMessages`) and renders
+      // the raw store, so every synthetic `first-run:*` turn the conductor
+      // seeded (greeting + welcome-back + cloud-done + typed reply turns) would
+      // otherwise paint as stacked real chat bubbles — the first message then
+      // looks duplicated into multiple greetings + doubled user turns until the
+      // first send's history reload full-replaces the store (#15354). Drop them
+      // now so the real chat opens on a clean thread. Pure id/source-scoped
+      // filter: it never touches a real server or optimistic `temp-*` turn, and
+      // is a no-op when onboarding seeded nothing (silent reuse, #15133).
+      setConversationMessages(clearFirstRunTranscriptMessages);
       return;
     }
     resetFirstRunPersistGuard();
@@ -1533,7 +1545,13 @@ export function useFirstRunConductor(): void {
       setFirstRunActionHandler(null);
       setFirstRunTextHandler(null);
     };
-  }, [active, seedBackupRestoreChoice, seedRuntimeChoice, seedTurn]);
+  }, [
+    active,
+    seedBackupRestoreChoice,
+    seedRuntimeChoice,
+    seedTurn,
+    setConversationMessages,
+  ]);
 }
 
 /** Mount point — call once inside the AppContext provider tree. Renders null. */


### PR DESCRIPTION
# Relates to

Fixes #15354. Relates to #15310 (umbrella, failure mode #9), #15339 (the onboarding flow this was first observed after), and #15363 (the complementary server-side half — see below).

# Root cause

The in-chat first-run conductor (`use-first-run-conductor.ts`) seeds synthetic `first-run:*` **assistant** turns — the sign-in greeting, the welcome-back turn, the cloud-done wrap-up, and any typed onboarding user/reply turns — **directly into the live `conversationMessages` store** that `ContinuousChatOverlay` renders.

While onboarding is active (`firstRunOpen === true`), the overlay filters that transcript down to the current first-run card via `selectFirstRunDisplayMessages` (added in #15339), so only one card is visible.

On completion, `firstRunComplete` flips true → `firstRunOpen` falls to false → **the overlay drops the first-run filter and renders the raw store.** Nothing ever cleared the seeded turns, so every leftover `first-run:*` bubble (greeting + welcome-back + cloud-done) suddenly paints as ordinary chat history. A returning shared-tier user who sends exactly one "hi" then sees **multiple stacked greeting-looking assistant bubbles**, right until the first real send's post-turn `loadConversationMessages` full-replaces the store with server truth. That matches the `3 assistant greetings` half of #15354, and is consistent with the single-turn billing ledger (no extra server turns — it's purely a client-side leftover-render).

# Fix

Purge the synthetic first-run turns the instant onboarding completes — in the conductor's completion effect (the `active -> false` edge), which already runs exactly once on that transition. The purge is a pure, id/source-scoped filter (`clearFirstRunTranscriptMessages`) that:

- removes only turns the conductor itself seeded (`source === "first_run"` OR an id under the `first-run:` namespace);
- **never** touches a real server or optimistic (`temp-*`) turn;
- returns the **same array reference** when there's nothing to remove, so it's a safe no-op inside a state setter (no spurious re-render, no loop) and a clean no-op for the silent-reuse entry (#15133) that seeds nothing.

So the real chat opens on a clean thread and the first message is the first thing in it.

# Relationship to #15363 (NubsCarson)

#15354 has **two independent contributing bugs**; this PR and #15363 are complementary, non-overlapping (zero shared files):

- **This PR (client, `packages/ui/src/first-run/*`)** — the leftover synthetic greeting bubbles → the multiple-assistant-greetings half.
- **#15363 (server, `packages/cloud/shared/src/lib/services/shared-runtime/*`)** — the shared REST adapter returned messages without `timestamp`, so `restoreEvictedUserTurn`'s recency match failed and the UI re-attached the optimistic user bubble + an extra undelivered assistant → the duplicate-user half.

Both are needed to fully close #15354. Coordinated in the issue thread.

# Testing

## Where a reviewer should start

`packages/ui/src/first-run/clear-first-run-transcript.ts` (the pure filter) and the `active -> false` branch of the completion effect in `use-first-run-conductor.ts`.

## New regression coverage

- `clear-first-run-transcript.test.ts` (8 tests): the exact #15354 store shape (greeting + welcome-back + cloud-done + a typed reply pair + one real send) collapses to exactly one user + one assistant turn; real/`temp-*` turns are never touched; same-reference no-op when clean; no-op on the empty silent-reuse transcript.
- `use-first-run-conductor.test.ts` (+2 tests): mounts the REAL conductor with a ref-backed transcript, seeds the leftover first-run turns + one real optimistic send, flips `firstRunComplete` true, and asserts **one send → one rendered user message + one response** with zero `first-run:*` turns surviving; plus a "clean thread untouched on completion" guard.

## Commands run

```
cd packages/core && node ../shared/scripts/generate-keywords.mjs --target ts
cd packages/cloud/routing && bun run build
cd packages/ui && NODE_OPTIONS="--conditions=eliza-source" bunx vitest run \
  src/first-run/clear-first-run-transcript.test.ts \
  src/first-run/use-first-run-conductor.test.ts \
  src/first-run/use-first-run-conductor.fuzz.test.ts
```

Result: **69 passed** (8 new pure + 56 conductor incl. 2 new + 5 fuzz), 0 failed. `biome check` clean on all four touched files.

```
 ✓ src/first-run/clear-first-run-transcript.test.ts (8 tests)
 ✓ src/first-run/use-first-run-conductor.test.ts (56 tests)
 ✓ src/first-run/use-first-run-conductor.fuzz.test.ts (5 tests)
 Test Files  3 passed (3)
      Tests  69 passed (69)
```

# Risks

Low. Client-only, additive: a pure filter fired on the onboarding-complete edge. It cannot touch real or optimistic turns (id/source scoped), and it is reference-stable so it forces no extra render. No change to the send path, the greeting-dedupe seam, or the server.

# Kind of change

Bug fix (non-breaking).

[sol-cloud]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - non-visual first-run transcript state/helper change; no .tsx, CSS, SVG, HTML, or rendered UI source file changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - non-visual first-run transcript state/helper change; no .tsx, CSS, SVG, HTML, or rendered UI source file changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no direct rendered surface change; behavior is covered by first-run state tests and UI fixture CI.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend/server code path changed.

<!-- evidence-row:frontend-logs -->
- [x] [85719829130](https://github.com/elizaOS/eliza/actions/runs/28895781312/job/85719829130)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [85719830310](https://github.com/elizaOS/eliza/actions/runs/28895781466/job/85719830310)
