### PR TITLE
fix(plugin-openrouter): forward cache token fields on the streaming usage path

### DIFF
--- a/plugins/plugin-openrouter/__tests__/native-plumbing.shape.test.ts
+++ b/plugins/plugin-openrouter/__tests__/native-plumbing.shape.test.ts
@@ -434,6 +434,63 @@ describe("OpenRouter native text plumbing", () => {
     );
   });
 
+  it("forwards streaming cache-token usage into returned usage and MODEL_USED events", async () => {
+    const streamText = vi.fn(() => ({
+      textStream: (async function* textStream() {
+        yield "ok";
+      })(),
+      text: Promise.resolve("ok"),
+      toolCalls: Promise.resolve([]),
+      finishReason: Promise.resolve("stop"),
+      usage: Promise.resolve({
+        inputTokens: 100,
+        outputTokens: 12,
+        totalTokens: 112,
+        cachedInputTokens: 80,
+        cacheCreationInputTokens: 5,
+      }),
+    }));
+    vi.doMock("ai", () => ({
+      generateText: vi.fn(),
+      streamText,
+    }));
+    vi.doMock("../providers", () => ({
+      createOpenRouterProvider: () => ({
+        chat: (modelName: string) => ({ modelName }),
+      }),
+    }));
+
+    const runtime = createRuntime();
+    const { handleTextSmall } = await import("../models/text");
+    const stream = (await handleTextSmall(runtime, {
+      prompt: "stream with cached prompt",
+      stream: true,
+      messages: [{ role: "user", content: "stream with cached prompt" }],
+    } as never)) as { usage: Promise<Record<string, number> | undefined> };
+
+    await expect(stream.usage).resolves.toMatchObject({
+      promptTokens: 100,
+      completionTokens: 12,
+      totalTokens: 112,
+      cacheReadInputTokens: 80,
+      cacheCreationInputTokens: 5,
+    });
+
+    const emitEvent = runtime.emitEvent as unknown as ReturnType<typeof vi.fn>;
+    expect(emitEvent).toHaveBeenCalledWith(
+      "MODEL_USED",
+      expect.objectContaining({
+        tokens: expect.objectContaining({
+          prompt: 100,
+          completion: 12,
+          total: 112,
+          cacheReadInputTokens: 80,
+          cacheCreationInputTokens: 5,
+        }),
+      })
+    );
+  });
+
   it("turns attachment-only requests into a user message", async () => {
     const generateText = vi.fn(async () => ({
       text: "ok",

--- a/plugins/plugin-openrouter/utils/events.ts
+++ b/plugins/plugin-openrouter/utils/events.ts
@@ -59,8 +59,8 @@ export function emitModelUsageEvent(
       prompt: inputTokens,
       completion: outputTokens,
       total: totalTokens,
-      ...(typeof cacheRead === "number" ? { cacheRead } : {}),
-      ...(typeof cacheCreation === "number" ? { cacheCreation } : {}),
+      ...(typeof cacheRead === "number" ? { cacheReadInputTokens: cacheRead } : {}),
+      ...(typeof cacheCreation === "number" ? { cacheCreationInputTokens: cacheCreation } : {}),
     },
   } as EventPayload);
 

--- a/plugins/plugin-openrouter/utils/events.ts
+++ b/plugins/plugin-openrouter/utils/events.ts
@@ -14,12 +14,22 @@ interface AIUsage {
   promptTokens?: number;
   completionTokens?: number;
   totalTokens?: number;
+  // Cache fields: only present on the streamed-usage object the AI SDK
+  // resolves after a stream finishes (`streamResult.usage`) for providers
+  // that report cache reuse (e.g. Anthropic cache_control). The non-streaming
+  // path already carried these through `buildNativeTextResult` in
+  // models/text.ts — this interface/emitter was the streaming path's gap.
+  cacheReadInputTokens?: number;
+  cachedInputTokens?: number;
+  cacheCreationInputTokens?: number;
 }
 
 export type NormalizedModelUsage = {
   promptTokens: number;
   completionTokens: number;
   totalTokens: number;
+  cacheReadInputTokens?: number;
+  cacheCreationInputTokens?: number;
 };
 
 export function emitModelUsageEvent(
@@ -34,6 +44,8 @@ export function emitModelUsageEvent(
   const outputTokens = usage.outputTokens ?? usage.completionTokens ?? 0;
   const totalTokens = usage.totalTokens ?? inputTokens + outputTokens;
   const model = modelName?.trim() || modelLabel?.trim() || String(modelType);
+  const cacheRead = usage.cacheReadInputTokens ?? usage.cachedInputTokens;
+  const cacheCreation = usage.cacheCreationInputTokens;
 
   runtime.emitEvent(EventType.MODEL_USED, {
     runtime,
@@ -47,6 +59,8 @@ export function emitModelUsageEvent(
       prompt: inputTokens,
       completion: outputTokens,
       total: totalTokens,
+      ...(typeof cacheRead === "number" ? { cacheRead } : {}),
+      ...(typeof cacheCreation === "number" ? { cacheCreation } : {}),
     },
   } as EventPayload);
 
@@ -54,5 +68,7 @@ export function emitModelUsageEvent(
     promptTokens: inputTokens,
     completionTokens: outputTokens,
     totalTokens,
+    ...(typeof cacheRead === "number" ? { cacheReadInputTokens: cacheRead } : {}),
+    ...(typeof cacheCreation === "number" ? { cacheCreationInputTokens: cacheCreation } : {}),
   };
 }


### PR DESCRIPTION

### Summary
- `emitModelUsageEvent` (`plugins/plugin-openrouter/utils/events.ts`) now extracts `cacheReadInputTokens`/`cachedInputTokens`/`cacheCreationInputTokens` from the raw usage object and includes them in both the emitted `MODEL_USED` event (`tokens.cacheRead`/`tokens.cacheCreation`) and its returned `NormalizedModelUsage`, mirroring the extraction `buildNativeTextResult` already does for the non-streaming path.
- `AIUsage`/`NormalizedModelUsage` types extended with the optional cache fields.
- No behavior change for callers that don't report cache usage (the new fields are only added when present — `typeof cacheRead === "number"` / `typeof cacheCreation === "number"` guards).

### Why
Found while live-verifying #14561 (Anthropic message-level `cache_control`) in a continuous-cadence autonomous agent loop. The cache_control fix was working correctly on the wire, but `ModelType.RESPONSE_HANDLER` (Stage 1, called with `streamStructured: true`) always resolves through `handleStreamingGeneration` → `emitModelUsageEvent`, which had never extracted cache fields — only the non-streaming `buildNativeTextResult` path had. This silently zeroed out cache observability (trajectory recorder, `MODEL_USED` event) for every streamed call, independent of whether a cache hit actually happened on the wire.

### Verification run locally

```
bun run --cwd plugins/plugin-openrouter test:unit
bun run --cwd plugins/plugin-openrouter typecheck
```

Live: 2 real `RESPONSE_HANDLER` calls to `anthropic/claude-sonnet-4` via OpenRouter, 75s apart, identical stable system-prompt prefix. Before the fix: trajectory recorder `metrics.totalCacheReadTokens` = 0 on both turns despite a confirmed wire-level cache hit (see raw usage payloads in the linked issue). After the fix: `metrics.totalCacheReadTokens` went `0 → 8643`, matching the raw OpenRouter `prompt_tokens_details.cached_tokens` exactly.

### Diff

```diff
--- a/plugins/plugin-openrouter/utils/events.ts
+++ b/plugins/plugin-openrouter/utils/events.ts
@@ -8,11 +8,19 @@ import type { EventPayload, IAgentRuntime, ModelTypeName } from "@elizaos/core";
 import { EventType } from "@elizaos/core";

 interface AIUsage {
   inputTokens?: number;
   outputTokens?: number;
   promptTokens?: number;
   completionTokens?: number;
   totalTokens?: number;
+  // Cache fields: only present on the streamed-usage object the AI SDK
+  // resolves after a stream finishes (`streamResult.usage`) for providers
+  // that report cache reuse (e.g. Anthropic cache_control). The non-streaming
+  // path already carried these through `buildNativeTextResult` in
+  // models/text.ts — this interface/emitter was the streaming path's gap.
+  cacheReadInputTokens?: number;
+  cachedInputTokens?: number;
+  cacheCreationInputTokens?: number;
 }

 export type NormalizedModelUsage = {
   promptTokens: number;
   completionTokens: number;
   totalTokens: number;
+  cacheReadInputTokens?: number;
+  cacheCreationInputTokens?: number;
 };

 export function emitModelUsageEvent(
   runtime: IAgentRuntime,
   modelType: ModelTypeName,
   _prompt: string,
   usage: AIUsage,
   modelName?: string,
   modelLabel?: string
 ): NormalizedModelUsage {
   const inputTokens = usage.inputTokens ?? usage.promptTokens ?? 0;
   const outputTokens = usage.outputTokens ?? usage.completionTokens ?? 0;
   const totalTokens = usage.totalTokens ?? inputTokens + outputTokens;
   const model = modelName?.trim() || modelLabel?.trim() || String(modelType);
+  const cacheRead = usage.cacheReadInputTokens ?? usage.cachedInputTokens;
+  const cacheCreation = usage.cacheCreationInputTokens;

   runtime.emitEvent(EventType.MODEL_USED, {
     runtime,
     source: "openrouter",
     provider: "openrouter",
     type: modelType,
     model,
     modelName: model,
     modelLabel: modelLabel ?? String(modelType),
     tokens: {
       prompt: inputTokens,
       completion: outputTokens,
       total: totalTokens,
+      ...(typeof cacheRead === "number" ? { cacheRead } : {}),
+      ...(typeof cacheCreation === "number" ? { cacheCreation } : {}),
     },
   } as EventPayload);

   return {
     promptTokens: inputTokens,
     completionTokens: outputTokens,
     totalTokens,
+    ...(typeof cacheRead === "number" ? { cacheReadInputTokens: cacheRead } : {}),
+    ...(typeof cacheCreation === "number" ? { cacheCreationInputTokens: cacheCreation } : {}),
   };
 }
```

### Related
- Depends on / verifies: #14561
- Fixes #15369