### PR TITLE
fix(ui): sign-in view applies iOS safe-area-top inset exactly once [sol-orch]

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.safe-area.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.safe-area.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Guard for the sign-in surface safe-area contract (#15361).
+ *
+ * On the installed iOS standalone PWA the login view rendered a black band at
+ * the top (the `--launch-bg` FOUC guard showing through the status-bar zone)
+ * PLUS a pushed-down card. Two facts drive the fix:
+ *
+ *   1. The `body.desktop { padding-top: env(safe-area-inset-top) }` rule the
+ *      issue suspected is Electrobun-DESKTOP only (added by
+ *      `initializeDesktopShell()`); it is NOT present on the installed iOS PWA.
+ *      The standalone-PWA CSS blocks (base.css / styles.css) apply the
+ *      scroll-lock + height geometry but NO body-level top safe-area padding.
+ *   2. This `/login` route renders through `CloudRouterShell` (a public route),
+ *      NOT the `App.tsx` catch-all shell column — so it does NOT inherit the
+ *      shell column's `paddingTop: max(calc(var(--safe-area-top)..))`.
+ *
+ * So the login page is the SINGLE owner of the top inset on its own surface.
+ * The correct shape is therefore:
+ *   - EXACTLY ONE `env(safe-area-inset-top)` inset (the content padding), and
+ *   - a `fixed inset-0` `bg-bg` underlay so the background fills edge-to-edge
+ *     under the status bar (no black band) instead of a collapsed
+ *     `min-h-[100dvh]` slab that starts at the layout-viewport top.
+ *
+ * This is a source-level scan (jsdom cannot resolve `env()` / device viewport
+ * collapse), matching the established App.safe-area-fill.test.ts idiom.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const LOGIN_SRC = readFileSync(join(here, "login-page.tsx"), "utf8");
+
+describe("login page safe-area (#15361)", () => {
+  it("applies env(safe-area-inset-top) exactly once on the login surface", () => {
+    const matches = LOGIN_SRC.match(/env\(safe-area-inset-top/g) ?? [];
+    expect(
+      matches.length,
+      "the login surface must own the TOP inset exactly once (no double-count vs a body-level inset)",
+    ).toBe(1);
+  });
+
+  it("applies env(safe-area-inset-bottom) exactly once on the login surface", () => {
+    const matches = LOGIN_SRC.match(/env\(safe-area-inset-bottom/g) ?? [];
+    expect(
+      matches.length,
+      "the login surface must own the BOTTOM inset exactly once (audit both edges)",
+    ).toBe(1);
+  });
+
+  it("fills the background with a fixed inset-0 underlay so no black band shows under the status bar", () => {
+    // The bg fill must be viewport-anchored (fixed inset-0), not an in-flow
+    // min-h-[100dvh] slab that collapses above the status bar on iOS standalone.
+    expect(
+      /pointer-events-none fixed inset-0[^"]*bg-bg/.test(LOGIN_SRC),
+      "expected a `fixed inset-0 ... bg-bg` underlay on the login surface",
+    ).toBe(true);
+  });
+
+  it("does not put the opaque bg fill on a min-h-[100dvh] in-flow slab (the collapsed-viewport black-band shape)", () => {
+    // Guard against reintroducing `min-h-[100dvh] bg-bg` on the outer wrapper,
+    // which is exactly what left the status-bar band unpainted on device.
+    expect(
+      /min-h-\[100dvh\][^"]*\bbg-bg\b/.test(LOGIN_SRC),
+      "the bg-bg fill must not sit on a min-h-[100dvh] in-flow wrapper",
+    ).toBe(false);
+  });
+});

--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
@@ -26,7 +26,23 @@ function StewardLoginSectionFallback() {
 
 function LoginBackground({ children }: { children: React.ReactNode }) {
   return (
-    <div className="theme-cloud min-h-[100dvh] bg-bg text-txt">
+    <div className="theme-cloud relative min-h-[100dvh] text-txt">
+      {/* SAFE-AREA FILL (installed iOS PWA): the `bg-bg` fill is a `fixed
+          inset-0` underlay, NOT a `min-h-[100dvh]` slab. On the installed
+          standalone PWA the body is non-fixed (base.css / styles.css lockdown),
+          so a `fixed inset-0` element's containing block IS the true visual
+          viewport — it paints edge-to-edge UNDER the status bar and down to the
+          home-indicator edge. A `min-h-[100dvh]` in-flow div instead starts at
+          the collapsed layout-viewport top, leaving the status-bar band showing
+          the black `--launch-bg` FOUC guard through (the reported "black band").
+          The safe-area inset then lives EXACTLY ONCE, on the content padding
+          below — this public route renders through CloudRouterShell, NOT the
+          App.tsx shell column, so nothing else insets it (#15361). */}
+      <div
+        aria-hidden="true"
+        data-testid="login-safe-area-fill"
+        className="pointer-events-none fixed inset-0 z-[-1] bg-bg"
+      />
       <div
         className="flex min-h-[100dvh] w-full flex-col px-4"
         style={{


### PR DESCRIPTION
Closes #15361

## Root cause (narrower than the issue's first hypothesis)

The installed iOS standalone PWA sign-in view showed a **black band** at the top of the status-bar zone **plus a pushed-down** login card. I traced the actual owners of the top inset on this route:

1. The suspected `body.desktop { padding-top: env(safe-area-inset-top) }` (base.css L334) is **Electrobun-DESKTOP only** — `body.desktop` is added exclusively by `initializeDesktopShell()` (main.tsx). It is **NOT** present on the installed iOS PWA. The standalone-PWA CSS blocks (base.css / styles.css `@media (display-mode: standalone) and (pointer: coarse)`) apply the scroll-lock + height geometry but **no body-level top safe-area padding**.
2. `/login` renders through **`CloudRouterShell`** (a public route, `group: "auth"` in `register.ts`), **not** the `App.tsx` catch-all shell column — so it does **not** inherit the shell column's `paddingTop: max(calc(var(--safe-area-top) - 2rem), 0.75rem)`.

So the login page is the **single owner** of the top inset on its own surface, and it already applied `env(safe-area-inset-top)` **exactly once**. The real defect was the **background fill**: the outer `min-h-[100dvh] bg-bg` slab starts at the *collapsed layout-viewport top* on iOS standalone (`ce873` vs `sh932`), leaving the status-bar band unpainted so the black `--launch-bg` FOUC guard showed through (the reported "black band"), while the content padding legitimately pushed the card down — together reading as a "double-count."

## Fix

Move the `bg-bg` fill to a **`fixed inset-0` underlay** (mirroring the established `App.tsx` safe-area floor). With the non-fixed standalone body, a `fixed` element's containing block **is** the true visual viewport, so the fill paints edge-to-edge **under the status bar** (no black band) and down to the home-indicator edge. The `env(safe-area-inset-top / inset-bottom)` content padding stays as the **single inset owner** on both edges (bottom edge audited too). No-op on desktop/web where the same fill just covers the viewport.

```diff
-    <div className="theme-cloud min-h-[100dvh] bg-bg text-txt">
+    <div className="theme-cloud relative min-h-[100dvh] text-txt">
+      <div aria-hidden="true" data-testid="login-safe-area-fill"
+           className="pointer-events-none fixed inset-0 z-[-1] bg-bg" />
       <div className="flex min-h-[100dvh] w-full flex-col px-4"
         style={{ paddingTop: "max(env(safe-area-inset-top, 0px), 1rem)", ... }}>
```

## Test

New `login-page.safe-area.test.tsx` (source-level guard, matching the established `App.safe-area-fill.test.ts` idiom — jsdom can't resolve `env()` / device viewport collapse) asserts:
- exactly **one** `env(safe-area-inset-top)` on the surface
- exactly **one** `env(safe-area-inset-bottom)` (both edges audited)
- a `fixed inset-0 … bg-bg` underlay exists
- guards against reintroducing the `min-h-[100dvh] bg-bg` collapsed-slab shape

```
✓ src/cloud/public-pages/pages/login/login-page.safe-area.test.tsx (4 tests) 6ms
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

biome clean on both touched files; no new tsc errors (the only login-page tsc noise is a pre-existing `react-router-dom` module-resolution gap in the symlinked node_modules, unrelated to this change). Codex-reviewed (uncommitted): *"No discrete correctness issues were found in the staged UI change or its accompanying safe-area guard test."*

[sol-orch]

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15371-login-before-real.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15371-login-after-real.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/15371-login-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - client-only CSS layout fix (fixed inset-0 underlay on the login surface); no backend, API, DB, or service path touched

<!-- evidence-row:frontend-logs -->
- [x] [15371-login-e2e.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15371-login-e2e.log)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, prompt, model, or LLM code path involved

<!-- evidence-row:domain-artifacts -->
- [x] [15371-login-domain-artifacts.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15371-login-domain-artifacts.txt)

<!-- evidence-row:ocr-review -->
- [x] [15371-login-after-ocr.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15371-login-after-ocr.txt)
