### PR TITLE
fix(cloud): rollback-safe AGENT_UPGRADE permanent-failure writeback (#15357)

### DIFF
--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
@@ -210,7 +210,7 @@ describe("AgentSandboxesRepository", () => {
       throw new Error("listRunningWithDigestOtherThan did not build a where clause");
     const sql = new PgDialect().sqlToQuery(capturedWhere).sql.toLowerCase();
     // Only running, non-deleted, default-image, non-pool rows on a stale digest
-    // with no explicit failure marker are upgrade candidates...
+    // that are not already-exhausted against THIS target are upgrade candidates...
     expect(sql).toContain("status");
     expect(sql).toContain("is distinct from");
     expect(sql).toContain("error_message");
@@ -234,6 +234,39 @@ describe("AgentSandboxesRepository", () => {
     expect(sql).toContain("reverse");
     expect(params).toContain("ghcr.io/elizaos/eliza-agent");
     expect(params).not.toContain("ghcr.io/elizaos/eliza-agent:prod");
+  });
+
+  test("fleet-upgrade candidates re-arm on a NEW target after a rollback-safe upgrade failure (#15357)", async () => {
+    capturedWhere = undefined;
+
+    const { AgentSandboxesRepository } = await import("./agent-sandboxes");
+    const { UPGRADE_FAILURE_TARGET_MARKER_PREFIX } = await import("../schemas/agent-sandboxes");
+
+    const targetDigest = "sha256:target";
+    await new AgentSandboxesRepository().listRunningWithDigestOtherThan(
+      targetDigest,
+      "ghcr.io/elizaos/eliza-agent:prod",
+      5,
+    );
+
+    if (!capturedWhere)
+      throw new Error("listRunningWithDigestOtherThan did not build a where clause");
+    const { sql, params } = new PgDialect().sqlToQuery(capturedWhere);
+    const lower = sql.toLowerCase();
+
+    // The rollback-safe exclusion must be digest-AWARE, not a blanket
+    // `error_message IS NULL`. A single transient rollback-safe failure must
+    // NOT permanently freeze an always-on agent out of ALL future upgrades
+    // (NubsCarson's #15311 adversarial finding). The predicate re-arms the row
+    // for a NEWER target while still skipping a re-enqueue of the SAME doomed
+    // target. Assert both the marker probe and the exact-target probe are
+    // present, and that the target-scoped bind carries THIS target digest.
+    expect(lower).toContain("error_message");
+    expect(lower).toContain("not like");
+    // Marker-presence bind (any upgrade-failure marker) and the exact-target
+    // bind (marker for THIS target only) are both parameterized.
+    expect(params).toContain(`%${UPGRADE_FAILURE_TARGET_MARKER_PREFIX}%`);
+    expect(params).toContain(`%${UPGRADE_FAILURE_TARGET_MARKER_PREFIX}${targetDigest}]%`);
   });
 
   test("backup inserts encrypt state_data at rest and hydration returns plaintext", async () => {

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -362,10 +362,9 @@ export class AgentSandboxesRepository {
    * Find running, non-deleted agents whose stored `image_digest` differs from
    * `targetDigest` (treating NULL as different). Used by the fleet-upgrade
    * reconciler to enqueue blue/green swaps onto the currently-deployed image.
-   * Rows with an explicit `error_message` are skipped because an exhausted
-   * upgrade records its terminal retry state there without marking the still-live
-   * sandbox non-running. Capped by `limit` so a single cycle doesn't try to
-   * enqueue the whole fleet at once.
+   * Rollback-safe exhausted upgrades are skipped only for the exact target digest
+   * they already failed, so a later target digest re-arms the agent. Capped by
+   * `limit` so a single cycle doesn't try to enqueue the whole fleet at once.
    */
   async listRunningWithDigestOtherThan(
     targetDigest: string,

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -28,6 +28,7 @@ import {
   type NewAgentSandbox,
   type NewAgentSandboxBackup,
   type StoredAgentSandboxBackup,
+  UPGRADE_FAILURE_TARGET_MARKER_PREFIX,
   WARM_POOL_ORG_ID,
   WARM_POOL_USER_ID,
 } from "../schemas/agent-sandboxes";
@@ -393,7 +394,26 @@ export class AgentSandboxesRepository {
           eq(agentSandboxes.status, "running"),
           sql`${agentSandboxes.deleted_at} IS NULL`,
           sql`${agentSandboxes.image_digest} IS DISTINCT FROM ${targetDigest}`,
-          sql`${agentSandboxes.error_message} IS NULL`,
+          // Skip a row ONLY when it carries a rollback-safe upgrade-failure
+          // marker for THIS EXACT target digest — i.e. the same doomed upgrade
+          // already exhausted its retries, so re-enqueuing it would just fail
+          // again against the still-serving old container. Re-arm when:
+          //   - error_message IS NULL (clean row), OR
+          //   - it has some non-upgrade error_message with no target marker
+          //     (defensive: don't let an unrelated message freeze upgrades), OR
+          //   - it has a target marker for a DIFFERENT target digest — a NEWER
+          //     image was published, which may well succeed where the old target
+          //     failed. Without this, a single transient rollback-safe failure
+          //     (SSH blip, registry hiccup) would permanently exclude an
+          //     always-on agent from ALL future fleet upgrades, including
+          //     security patches (#15357 / NubsCarson's #15311 adversarial
+          //     review). Genuinely-dead upgrade failures are `status:"error"`
+          //     and already excluded by the status filter above.
+          sql`(
+            ${agentSandboxes.error_message} IS NULL
+            OR ${agentSandboxes.error_message} NOT LIKE ${`%${UPGRADE_FAILURE_TARGET_MARKER_PREFIX}%`}
+            OR ${agentSandboxes.error_message} NOT LIKE ${`%${UPGRADE_FAILURE_TARGET_MARKER_PREFIX}${targetDigest}]%`}
+          )`,
           // Only reconcile agents on the configured default image. Per-agent
           // image overrides are intentional and must not be rolled onto the
           // global fleet tag. Match on the REPO, not the full ref: a fleet agent

--- a/packages/cloud/shared/src/db/schemas/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/schemas/agent-sandboxes.ts
@@ -330,6 +330,19 @@ export const agentSandboxBackups = pgTable(
   }),
 );
 
+/**
+ * Machine-readable trailer appended to `agent_sandboxes.error_message` when an
+ * AGENT_UPGRADE exhausts retries on a ROLLBACK-SAFE failure (the old container
+ * still serves its previous version). Encodes the exhausted TARGET digest so
+ * the fleet reconciler can re-arm the agent for a NEWER target digest instead
+ * of excluding it from all future upgrades forever. Lives in error_message to
+ * avoid a schema migration; strictly additive (rows without it parse to null).
+ * Defined here (schema layer) so both the writeback (provisioning-jobs service)
+ * and the reconciler query (agent-sandboxes repository) can share it without a
+ * service↔repository import cycle. See #15357 / lalalune's #15311 review.
+ */
+export const UPGRADE_FAILURE_TARGET_MARKER_PREFIX = "[upgrade-failed-target:";
+
 export type AgentSandbox = InferSelectModel<typeof agentSandboxes>;
 export type NewAgentSandbox = InferInsertModel<typeof agentSandboxes>;
 export type StoredAgentSandboxBackup = InferSelectModel<typeof agentSandboxBackups>;

--- a/packages/cloud/shared/src/lib/services/__tests__/provisioning-jobs-agent-upgrade-writeback.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/provisioning-jobs-agent-upgrade-writeback.test.ts
@@ -1,26 +1,45 @@
 /**
  * Unit coverage for the AGENT_UPGRADE permanent-failure writeback in
- * ProvisioningJobService.buildPermanentFailureWriteback. Exhausted upgrades
- * must stop the fleet reconciler from retrying the same failing target without
- * declaring a rollback-safe, still-serving sandbox terminal.
+ * ProvisioningJobService.buildPermanentFailureWriteback.
+ *
+ * The writeback must NOT treat all exhausted upgrades identically (#15357,
+ * lalalune's #15311 review): most upgrade failures are ROLLBACK-SAFE — the old
+ * container is still serving its previous version, so marking the sandbox row
+ * terminal would make the dedicated proxy reject live traffic and expose the
+ * live container to the orphan reconciler. Rollback-safe failures keep the row
+ * `running` and record a re-armable marker (the exhausted target digest) so the
+ * fleet reconciler stops re-enqueuing the SAME doomed target WITHOUT freezing
+ * the agent out of a NEWER target. Genuinely-dead failures (old container not
+ * serving) keep the terminal `status:"error"` writeback.
  */
 import { describe, expect, test } from "bun:test";
-import { agentSandboxes } from "../../../db/schemas/agent-sandboxes";
+import {
+  agentSandboxes,
+  UPGRADE_FAILURE_TARGET_MARKER_PREFIX,
+} from "../../../db/schemas/agent-sandboxes";
 import { JOB_TYPES } from "../provisioning-job-types";
-import { ProvisioningJobService } from "../provisioning-jobs";
+import {
+  buildUpgradeFailureMarker,
+  ProvisioningJobService,
+  parseUpgradeFailureTargetDigest,
+  UpgradeFailedError,
+} from "../provisioning-jobs";
 
 const AGENT_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
 const ORG_ID = "99999999-aaaa-4bbb-8ccc-dddddddddddd";
 const USER_ID = "77777777-8888-4999-8aaa-bbbbbbbbbbbb";
+const TO_DIGEST = "sha256:newtarget000000000000000000000000000000000000000000000000000000";
 
-// Minimal DbTransaction stand-in: records every update(table).set(values) call.
+// Minimal DbTransaction stand-in: records every update(table).set(values) call
+// with the where-predicate presence so the tests can assert both the values and
+// that a status-scoped WHERE was (or was not) applied.
 function mockTx() {
-  const updates: Array<{ table: unknown; values: Record<string, unknown> }> = [];
+  const updates: Array<{ table: unknown; values: Record<string, unknown>; hadWhere: boolean }> = [];
   const tx = {
     update: (table: unknown) => ({
       set: (values: Record<string, unknown>) => ({
         where: async () => {
-          updates.push({ table, values });
+          updates.push({ table, values, hadWhere: true });
         },
       }),
     }),
@@ -30,7 +49,12 @@ function mockTx() {
 
 const service = new ProvisioningJobService();
 
-function agentUpgradeWriteback(errorMsg = "upgrade exhausted retries") {
+type WritebackFn = ((tx: unknown, j: unknown) => Promise<void>) | undefined;
+
+function agentUpgradeWriteback(
+  errorMsg = "upgrade exhausted retries",
+  upgradeFailure?: UpgradeFailedError,
+) {
   const job = {
     id: "job-upgrade-1",
     type: JOB_TYPES.AGENT_UPGRADE,
@@ -41,7 +65,7 @@ function agentUpgradeWriteback(errorMsg = "upgrade exhausted retries") {
       userId: USER_ID,
       dockerImage: "elizaos/agent:latest",
       fromDigest: "sha256:old",
-      toDigest: "sha256:new",
+      toDigest: TO_DIGEST,
     },
   };
   const cb = (
@@ -49,39 +73,142 @@ function agentUpgradeWriteback(errorMsg = "upgrade exhausted retries") {
       buildPermanentFailureWriteback: (
         j: typeof job,
         e: string,
-      ) => ((tx: unknown, j: typeof job) => Promise<void>) | undefined;
+        f?: UpgradeFailedError,
+      ) => WritebackFn;
     }
-  ).buildPermanentFailureWriteback(job, errorMsg);
+  ).buildPermanentFailureWriteback(job, errorMsg, upgradeFailure);
   return { job, cb };
 }
 
-describe("buildPermanentFailureWriteback: AGENT_UPGRADE (#15310)", () => {
+describe("buildPermanentFailureWriteback: AGENT_UPGRADE (#15357)", () => {
   test("returns a callback for AGENT_UPGRADE so exhausted upgrades have a stop signal", () => {
     const { cb } = agentUpgradeWriteback();
     expect(cb).toBeDefined();
   });
 
-  test("records an actionable error_message without marking the still-serving sandbox terminal", async () => {
-    const { job, cb } = agentUpgradeWriteback("SSH to node timed out");
-    const { tx, updates } = mockTx();
-    await cb!(tx, job);
+  describe("rollback-safe failure (old container still serving)", () => {
+    // Default (no classification) MUST be treated as rollback-safe: erroring a
+    // possibly-live agent is strictly worse than leaving a dead one non-terminal.
+    test("default (no classification) keeps the row running and records a re-armable marker", async () => {
+      const { job, cb } = agentUpgradeWriteback(
+        "Blue health check failed; rolled back to old container",
+      );
+      const { tx, updates } = mockTx();
+      await cb!(tx, job);
 
-    expect(updates).toHaveLength(1);
-    expect(updates[0].table).toBe(agentSandboxes);
-    expect(updates[0].values.status).toBeUndefined();
-    expect(updates[0].values.updated_at).toBeInstanceOf(Date);
+      expect(updates).toHaveLength(1);
+      expect(updates[0].table).toBe(agentSandboxes);
+      // Non-terminal: status is NEVER set for a rollback-safe failure.
+      expect(updates[0].values.status).toBeUndefined();
+      expect(updates[0].values.updated_at).toBeInstanceOf(Date);
+      const msg = String(updates[0].values.error_message);
+      expect(msg).toContain("Upgrade permanently failed");
+      expect(msg).toContain("Blue health check failed");
+      // No classification (undefined UpgradeFailedError), but the job data still
+      // carries the real target — so the marker records the job's toDigest, not
+      // "unknown". This keeps the reconciler's target-scoped skip precise even on
+      // the defensive worker-level-throw path (no UpgradeFailedError constructed).
+      expect(msg).not.toContain(`${UPGRADE_FAILURE_TARGET_MARKER_PREFIX}unknown]`);
+      expect(parseUpgradeFailureTargetDigest(msg)).toBe(TO_DIGEST);
+    });
 
-    const errorMessage = String(updates[0].values.error_message);
-    expect(errorMessage).toContain("Upgrade permanently failed");
-    expect(errorMessage).toContain(`after ${job.max_attempts} attempts`);
-    expect(errorMessage).toContain("SSH to node timed out");
+    test("explicit rolledBack:true keeps running and encodes the exhausted target digest", async () => {
+      const failure = new UpgradeFailedError("Pre-upgrade snapshot failed: disk full", {
+        rolledBack: true,
+        toDigest: TO_DIGEST,
+      });
+      const { job, cb } = agentUpgradeWriteback("Pre-upgrade snapshot failed: disk full", failure);
+      const { tx, updates } = mockTx();
+      await cb!(tx, job);
+
+      expect(updates).toHaveLength(1);
+      expect(updates[0].values.status).toBeUndefined();
+      const msg = String(updates[0].values.error_message);
+      expect(msg).toContain("Pre-upgrade snapshot failed: disk full");
+      // The recorded target must be the EXACT exhausted digest so the reconciler
+      // can re-arm the agent when a newer target is published.
+      expect(parseUpgradeFailureTargetDigest(msg)).toBe(TO_DIGEST);
+    });
+
+    test("falls back to the job's own toDigest when the error carries no target digest", async () => {
+      // Defensive path: an UpgradeFailedError can reach the writeback with an
+      // empty `toDigest` (e.g. a failure thrown before the target was resolved
+      // onto the error, or an unexpected re-throw). The marker MUST still record
+      // the EXACT exhausted target so the reconciler can re-arm the agent on a
+      // newer digest — otherwise it degrades to an "unknown" marker and the
+      // target-scoped skip can't distinguish this doomed target from a fresh one.
+      // The job data always carries the real target, so we fall back to it.
+      const failure = new UpgradeFailedError("Blue provision failed: node offline", {
+        rolledBack: true,
+        toDigest: "",
+      });
+      const { job, cb } = agentUpgradeWriteback("Blue provision failed: node offline", failure);
+      const { tx, updates } = mockTx();
+      await cb!(tx, job);
+
+      expect(updates).toHaveLength(1);
+      expect(updates[0].values.status).toBeUndefined();
+      const msg = String(updates[0].values.error_message);
+      // NOT "unknown": the marker carries the job's real target digest.
+      expect(msg).not.toContain(`${UPGRADE_FAILURE_TARGET_MARKER_PREFIX}unknown]`);
+      expect(parseUpgradeFailureTargetDigest(msg)).toBe(TO_DIGEST);
+    });
+
+    test("each rollback-safe executeUpgrade failure reason stays non-terminal", async () => {
+      // Every one of these reason strings comes from an executeUpgrade path that
+      // returns BEFORE the atomic swap, leaving the old container alive.
+      const rollbackSafeReasons = [
+        "Blue provision failed: node ssh dial-tcp timeout after 30000ms",
+        "Blue health check failed; rolled back to old container",
+        "Blue provisioner returned non-docker metadata",
+        "Blue image digest mismatch: expected sha256:new, got sha256:other",
+        "Blue runtime readiness gate failed: plugin @elizaos/x failed to load",
+        "Pre-upgrade snapshot failed: AEAD decrypt failed",
+        "Atomic swap UPDATE failed: Agent changed during upgrade; abandoned stale swap",
+        "Agent has no node_id or container_name to upgrade from",
+        "Agent uses a custom docker image; refusing fleet upgrade",
+        "Old node node-abc not registered in docker_nodes",
+        "Fleet upgrade only supported on docker provider",
+      ];
+      for (const reason of rollbackSafeReasons) {
+        const failure = new UpgradeFailedError(reason, { rolledBack: true, toDigest: TO_DIGEST });
+        const { job, cb } = agentUpgradeWriteback(reason, failure);
+        const { tx, updates } = mockTx();
+        await cb!(tx, job);
+        expect(updates[0].values.status).toBeUndefined();
+        expect(String(updates[0].values.error_message)).toContain(reason);
+      }
+    });
+  });
+
+  describe("genuinely-dead failure (old container not serving)", () => {
+    test("rolledBack:false marks the sandbox terminal (status error), like AGENT_PROVISION", async () => {
+      const failure = new UpgradeFailedError("Agent not running (status: stopped)", {
+        rolledBack: false,
+        toDigest: TO_DIGEST,
+      });
+      const { job, cb } = agentUpgradeWriteback("Agent not running (status: stopped)", failure);
+      const { tx, updates } = mockTx();
+      await cb!(tx, job);
+
+      expect(updates).toHaveLength(1);
+      expect(updates[0].table).toBe(agentSandboxes);
+      // Terminal: the row IS flipped to error for a genuinely-down agent.
+      expect(updates[0].values.status).toBe("error");
+      const msg = String(updates[0].values.error_message);
+      expect(msg).toContain("Upgrade permanently failed");
+      expect(msg).toContain("agent not serving");
+      expect(msg).toContain("Agent not running (status: stopped)");
+      // The terminal writeback does NOT carry the re-armable target marker: a
+      // status:"error" row is already excluded from the reconciler by status.
+      expect(msg).not.toContain(UPGRADE_FAILURE_TARGET_MARKER_PREFIX);
+    });
   });
 
   test("does not touch any other tables (no silent cross-writes)", async () => {
     const { job, cb } = agentUpgradeWriteback();
     const { tx, updates } = mockTx();
     await cb!(tx, job);
-
     expect(updates).toHaveLength(1);
     expect(updates[0].table).toBe(agentSandboxes);
   });
@@ -93,10 +220,42 @@ describe("buildPermanentFailureWriteback: AGENT_UPGRADE (#15310)", () => {
       "Node ssh dial-tcp timeout after 30000ms",
       "Container health check failed after 6 attempts",
     ]) {
-      const { job, cb } = agentUpgradeWriteback(errorMsg);
+      const failure = new UpgradeFailedError(errorMsg, { rolledBack: true, toDigest: TO_DIGEST });
+      const { job, cb } = agentUpgradeWriteback(errorMsg, failure);
       const { tx, updates } = mockTx();
       await cb!(tx, job);
       expect(String(updates[0].values.error_message)).toContain(errorMsg);
     }
+  });
+});
+
+describe("upgrade-failure marker encode/parse round-trip (#15357)", () => {
+  test("buildUpgradeFailureMarker encodes cause + target digest, parse recovers the digest", () => {
+    const marker = buildUpgradeFailureMarker(3, "Blue health check failed", TO_DIGEST);
+    expect(marker).toContain("after 3 attempts");
+    expect(marker).toContain("Blue health check failed");
+    expect(parseUpgradeFailureTargetDigest(marker)).toBe(TO_DIGEST);
+  });
+
+  test("a null / undefined target encodes 'unknown' and parses back to null (no re-arm target)", () => {
+    const marker = buildUpgradeFailureMarker(3, "unknown cause", null);
+    expect(marker).toContain(`${UPGRADE_FAILURE_TARGET_MARKER_PREFIX}unknown]`);
+    expect(parseUpgradeFailureTargetDigest(marker)).toBeNull();
+  });
+
+  test("parseUpgradeFailureTargetDigest returns null for messages without a marker", () => {
+    expect(parseUpgradeFailureTargetDigest(null)).toBeNull();
+    expect(parseUpgradeFailureTargetDigest("")).toBeNull();
+    expect(
+      parseUpgradeFailureTargetDigest("Provisioning permanently failed after 3 attempts: boom"),
+    ).toBeNull();
+  });
+
+  test("parse picks the LAST marker if a message somehow accreted more than one", () => {
+    // Defensive: error_message is single-writer, but lastIndexOf guarantees we
+    // read the freshest target if two markers ever coexist.
+    const older = buildUpgradeFailureMarker(3, "old cause", "sha256:oldtarget");
+    const combined = `${older} ${buildUpgradeFailureMarker(3, "new cause", TO_DIGEST)}`;
+    expect(parseUpgradeFailureTargetDigest(combined)).toBe(TO_DIGEST);
   });
 });

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -4916,18 +4916,44 @@ export class ElizaSandboxService {
     newContainerName?: string;
     newDigest?: string | null;
     error?: string;
+    /**
+     * True when this failure is ROLLBACK-SAFE: the OLD container was never torn
+     * down (or was confirmed alive) and is still serving traffic, so the upgrade
+     * failed WITHOUT taking the agent down. The permanent-failure writeback must
+     * NOT mark such a sandbox terminal — doing so makes the dedicated proxy
+     * reject live traffic (dedicated-agent-proxy.ts) and exposes the still-live
+     * container to the orphan reconciler (docker-node-workloads.ts). Undefined
+     * on success. `false` means the agent is genuinely not serving on the old
+     * container (e.g. it was already not running), so the terminal error
+     * writeback is correct.
+     *
+     * INVARIANT: every `success:false` path in executeUpgrade below returns
+     * before the atomic swap commits, so the OLD container is untouched — the
+     * blue/health/digest/runtime/snapshot/swap-failure paths all tear down ONLY
+     * the freshly-provisioned blue and leave old alive. The only genuinely-dead
+     * outcome is `Agent not running` (old already not serving); `Agent not
+     * found` is intercepted upstream by completeIfAgentGone and never reaches
+     * the writeback. See #15357 / lalalune's #15311 review.
+     */
+    rolledBack?: boolean;
   }> {
     const agent = await agentSandboxesRepository.findByIdAndOrg(agentId, orgId);
     if (!agent) return { success: false, error: "Agent not found" };
     if (agent.status !== "running") {
+      // Genuinely-dead: the old container is not serving (status is not
+      // running), so the terminal error writeback is correct here.
       return {
         success: false,
+        rolledBack: false,
         error: `Agent not running (status: ${agent.status})`,
       };
     }
     if (!agent.node_id || !agent.container_name) {
+      // Shared-runtime / web-only row: nothing was torn down. The old serving
+      // path is untouched. (These are already excluded by the reconciler.)
       return {
         success: false,
+        rolledBack: true,
         error: "Agent has no node_id or container_name to upgrade from",
       };
     }
@@ -4940,8 +4966,10 @@ export class ElizaSandboxService {
     // re-provisions on the target image+digest, so moving a fleet-managed agent
     // to the current default is safe regardless of its current tag.
     if (agent.docker_image && imageRepo(agent.docker_image) !== imageRepo(dockerImage)) {
+      // Refusal before any container work: old container is untouched and live.
       return {
         success: false,
+        rolledBack: true,
         error: "Agent uses a custom docker image; refusing fleet upgrade",
       };
     }
@@ -4951,8 +4979,12 @@ export class ElizaSandboxService {
     const oldSandboxId = agent.sandbox_id;
     const oldNode = await dockerNodesRepository.findByNodeId(oldNodeId);
     if (!oldNode) {
+      // We could not resolve the old node to do a blue provision, but we did NOT
+      // touch the old container — it is still running wherever it was. Treat as
+      // rollback-safe: the agent keeps serving on the old container.
       return {
         success: false,
+        rolledBack: true,
         error: `Old node ${oldNodeId} not registered in docker_nodes`,
       };
     }
@@ -4960,8 +4992,10 @@ export class ElizaSandboxService {
     const provider = await this.getProvider();
     const { DockerSandboxProvider } = await import("./docker-sandbox-provider");
     if (!(provider instanceof DockerSandboxProvider)) {
+      // No container work happened; old container is untouched and live.
       return {
         success: false,
+        rolledBack: true,
         error: "Fleet upgrade only supported on docker provider",
       };
     }
@@ -4997,6 +5031,7 @@ export class ElizaSandboxService {
     } catch (err) {
       return {
         success: false,
+        rolledBack: true,
         oldNodeId,
         oldContainerName,
         error: `Blue provision failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -5015,6 +5050,7 @@ export class ElizaSandboxService {
       }
       return {
         success: false,
+        rolledBack: true,
         oldNodeId,
         oldContainerName,
         error: "Blue health check failed; rolled back to old container",
@@ -5036,6 +5072,7 @@ export class ElizaSandboxService {
       }
       return {
         success: false,
+        rolledBack: true,
         oldNodeId,
         oldContainerName,
         error: "Blue provisioner returned non-docker metadata",
@@ -5050,6 +5087,7 @@ export class ElizaSandboxService {
       );
       return {
         success: false,
+        rolledBack: true,
         oldNodeId,
         oldContainerName,
         error: `Blue image digest mismatch: expected ${toDigest}, got ${blueMeta.imageDigest}`,
@@ -5069,6 +5107,7 @@ export class ElizaSandboxService {
       );
       return {
         success: false,
+        rolledBack: true,
         oldNodeId,
         oldContainerName,
         error: `Blue runtime readiness gate failed: ${runtimeHealth.error}`,
@@ -5093,6 +5132,7 @@ export class ElizaSandboxService {
       );
       return {
         success: false,
+        rolledBack: true,
         oldNodeId,
         oldContainerName,
         error: `Pre-upgrade snapshot failed: ${preUpgradeSnapshot.error ?? "unknown error"}`,
@@ -5155,6 +5195,7 @@ export class ElizaSandboxService {
       );
       return {
         success: false,
+        rolledBack: true,
         oldNodeId,
         oldContainerName,
         error: `Atomic swap UPDATE failed: ${errMsg}`,

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -24,7 +24,10 @@ import {
   type NewJob,
   prepareJobInsertData,
 } from "../../db/repositories/jobs";
-import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
+import {
+  agentSandboxes,
+  UPGRADE_FAILURE_TARGET_MARKER_PREFIX,
+} from "../../db/schemas/agent-sandboxes";
 import { apps } from "../../db/schemas/apps";
 import { containers } from "../../db/schemas/containers";
 import { jobs } from "../../db/schemas/jobs";
@@ -760,6 +763,74 @@ export function resolvePerJobTimeoutMs(jobType: string): number {
   return COLD_BOOT_JOB_TYPES.has(jobType as ProvisioningJobType)
     ? Math.max(PER_JOB_TIMEOUT_MS, COLD_BOOT_STALE_JOB_THRESHOLD_MS)
     : PER_JOB_TIMEOUT_MS;
+}
+
+/**
+ * Machine-readable trailer appended to `agent_sandboxes.error_message` when an
+ * AGENT_UPGRADE exhausts retries on a ROLLBACK-SAFE failure (the old container
+ * still serves). Encodes the exhausted TARGET digest so the fleet reconciler
+ * can re-arm the agent when a NEWER target digest is published, instead of
+ * excluding the row from all future upgrades forever. Kept in error_message to
+ * avoid a schema migration (mission constraint) while staying strictly
+ * additive: pre-existing rows have no trailer and parse to `null`.
+ *
+ * Format (single line, trailer at END so the human-readable cause stays first):
+ *   `<human message> [upgrade-failed-target:<digest>]`
+ * `<digest>` is the resolved sha256 target ref; `unknown` when the exhausted
+ * job carried no target digest (defensive). The prefix constant lives in the
+ * schema layer (`UPGRADE_FAILURE_TARGET_MARKER_PREFIX`) so the reconciler query
+ * can share it without a service↔repository import cycle.
+ */
+export function buildUpgradeFailureMarker(
+  maxAttempts: number,
+  cause: string,
+  toDigest: string | null,
+): string {
+  const target = toDigest && toDigest.length > 0 ? toDigest : "unknown";
+  return `Upgrade permanently failed after ${maxAttempts} attempts: ${cause} ${UPGRADE_FAILURE_TARGET_MARKER_PREFIX}${target}]`;
+}
+
+/**
+ * Parse the exhausted TARGET digest out of a rollback-safe upgrade-failure
+ * error_message. Returns null when no trailer is present (a non-upgrade error,
+ * a pre-existing row, or an `unknown` target), so callers treat "no recorded
+ * target" as "do not re-arm on target change" (conservative).
+ */
+export function parseUpgradeFailureTargetDigest(errorMessage: string | null): string | null {
+  if (!errorMessage) return null;
+  const start = errorMessage.lastIndexOf(UPGRADE_FAILURE_TARGET_MARKER_PREFIX);
+  if (start === -1) return null;
+  const from = start + UPGRADE_FAILURE_TARGET_MARKER_PREFIX.length;
+  const end = errorMessage.indexOf("]", from);
+  if (end === -1) return null;
+  const digest = errorMessage.slice(from, end);
+  return digest === "unknown" || digest.length === 0 ? null : digest;
+}
+
+/**
+ * Thrown by `executeAgentUpgrade` when `executeUpgrade` reports a failure,
+ * carrying the rollback-safe classification through the worker's generic
+ * catch → `incrementAttempt` → `buildPermanentFailureWriteback` path.
+ *
+ * `rolledBack === true` means the OLD container is still serving (a
+ * rollback-safe failure); the permanent-failure writeback must NOT mark the
+ * sandbox terminal. `rolledBack === false` means the agent is genuinely not
+ * serving on the old container, so the terminal error writeback is correct.
+ * `toDigest` is the target the exhausted upgrade was aiming at, recorded so
+ * the reconciler can re-arm the agent when a NEWER target digest is published
+ * (a rollback-safe exclusion must not be permanent — always-on agents that hit
+ * a transient rollback-safe failure must still receive future security
+ * patches). See #15357 / lalalune's #15311 review.
+ */
+export class UpgradeFailedError extends Error {
+  readonly rolledBack: boolean;
+  readonly toDigest: string;
+  constructor(message: string, opts: { rolledBack: boolean; toDigest: string }) {
+    super(message);
+    this.name = "UpgradeFailedError";
+    this.rolledBack = opts.rolledBack;
+    this.toDigest = opts.toDigest;
+  }
 }
 
 export class ProvisioningJobService {
@@ -1649,7 +1720,11 @@ export class ProvisioningJobService {
         // `onFailedInTx` makes both commit together (or roll back together,
         // so the recovery cron re-runs the whole thing). The cron stays as
         // the backstop, never the primary signal.
-        const onFailedInTx = this.buildPermanentFailureWriteback(job, errorMsg);
+        // Rollback-safe classification only exists for AGENT_UPGRADE failures
+        // (thrown as UpgradeFailedError). For every other job type this is
+        // undefined and the writeback ignores it.
+        const upgradeFailure = err instanceof UpgradeFailedError ? err : undefined;
+        const onFailedInTx = this.buildPermanentFailureWriteback(job, errorMsg, upgradeFailure);
         const updated = await jobsRepository.incrementAttempt(
           job.id,
           errorMsg,
@@ -1694,6 +1769,7 @@ export class ProvisioningJobService {
   private buildPermanentFailureWriteback(
     job: Job,
     errorMsg: string,
+    upgradeFailure?: UpgradeFailedError,
   ): ((tx: DbTransaction, failedJob: Job) => Promise<void>) | undefined {
     switch (job.type) {
       // Mark the sandbox "error" so the UI reflects reality instead of staying
@@ -1715,19 +1791,76 @@ export class ProvisioningJobService {
           });
         };
       }
+      // A permanently-exhausted AGENT_UPGRADE is NOT uniformly terminal. Most
+      // upgrade failures are ROLLBACK-SAFE (blue provision/health/digest/runtime
+      // /snapshot/swap failures) — executeUpgrade never tears down the OLD
+      // container before a successful atomic swap, so the agent keeps serving on
+      // its previous version. Marking such a row `status:"error"` would (1) make
+      // the dedicated proxy reject live traffic (dedicated-agent-proxy.ts) and
+      // (2) expose the still-live container to the orphan reconciler
+      // (docker-node-workloads.ts) — killing a healthy agent. So:
+      //   - rollback-safe (default, and the only genuinely-safe failure class):
+      //     keep `status:"running"`, record the failure + the exhausted target
+      //     digest in error_message so the reconciler stops re-enqueuing the
+      //     SAME doomed target, WITHOUT declaring the live sandbox terminal.
+      //     Encoding the target digest lets the reconciler re-arm the agent for
+      //     a NEWER target (see listRunningWithDigestOtherThan) so a transient
+      //     rollback-safe failure never permanently freezes an always-on agent
+      //     out of future security patches.
+      //   - genuinely-dead (rolledBack === false, e.g. the agent was already not
+      //     running): keep the terminal `status:"error"` writeback, mirroring
+      //     AGENT_PROVISION, so the UI reflects reality.
       case JOB_TYPES.AGENT_UPGRADE: {
-        const { agentId } = readAgentUpgradeJobData(job);
+        const upgradeData = readAgentUpgradeJobData(job);
+        const { agentId } = upgradeData;
+        // Classification is carried on the thrown UpgradeFailedError. Absent it
+        // (defensive: an upgrade that failed via the outer worker path — a
+        // withTimeout(...) wrap or an unexpected throw BEFORE executeUpgrade
+        // returns success:false — so no UpgradeFailedError is constructed),
+        // default to rollback-safe: never error a possibly-live agent on an
+        // unknown cause. Fall back to the job's own target digest (always
+        // present in the job data) so the re-armable marker still records the
+        // EXACT exhausted target — otherwise the reconciler's target-scoped
+        // skip would immediately re-enqueue the same doomed target and recreate
+        // the retry storm this marker prevents (codex #15357 P2).
+        const rolledBack = upgradeFailure?.rolledBack ?? true;
+        // Prefer the classification's target, but treat an empty/absent error
+        // digest as "not carried" and fall back to the job's own target (always
+        // present, validated by readAgentUpgradeJobData) so the re-armable marker
+        // ALWAYS records the EXACT exhausted target. A `??` alone would let an
+        // empty-string error digest through and degrade the marker to "unknown".
+        const errorDigest = upgradeFailure?.toDigest;
+        const toDigest =
+          errorDigest && errorDigest.length > 0 ? errorDigest : upgradeData.toDigest || null;
+        if (!rolledBack) {
+          // Genuinely-dead old container: terminal, like AGENT_PROVISION.
+          return async (tx) => {
+            await tx
+              .update(agentSandboxes)
+              .set({
+                status: "error",
+                error_message: `Upgrade permanently failed after ${job.max_attempts} attempts (agent not serving): ${errorMsg}`,
+                updated_at: new Date(),
+              })
+              .where(eq(agentSandboxes.id, agentId));
+            logger.warn(
+              "[provisioning-jobs] Marked sandbox error after permanent upgrade failure on a non-serving agent",
+              { jobId: job.id, agentId },
+            );
+          };
+        }
+        // Rollback-safe: keep the agent running, record a re-armable marker.
         return async (tx) => {
           await tx
             .update(agentSandboxes)
             .set({
-              error_message: `Upgrade permanently failed after ${job.max_attempts} attempts: ${errorMsg}`,
+              error_message: buildUpgradeFailureMarker(job.max_attempts, errorMsg, toDigest),
               updated_at: new Date(),
             })
             .where(and(eq(agentSandboxes.id, agentId), eq(agentSandboxes.status, "running")));
           logger.warn(
-            "[provisioning-jobs] Recorded permanent upgrade failure without marking sandbox terminal",
-            { jobId: job.id, agentId },
+            "[provisioning-jobs] Recorded rollback-safe upgrade failure without marking sandbox terminal",
+            { jobId: job.id, agentId, failedTargetDigest: toDigest },
           );
         };
       }
@@ -2275,7 +2408,20 @@ export class ProvisioningJobService {
       // Failures are visible by the row staying on the OLD image_digest; the
       // reconciler will try again on the next cycle. The worker's standard
       // error handling marks the job failed and stores this error message.
-      throw new Error(result.error ?? "Unknown agent_upgrade failure");
+      //
+      // Carry executeUpgrade's rollback-safe classification through the generic
+      // catch → incrementAttempt → buildPermanentFailureWriteback path so the
+      // permanent-failure writeback can distinguish a still-serving old
+      // container (rollback-safe: keep `running`) from a genuinely-down agent
+      // (keep the terminal error writeback). Default UNKNOWN classifications to
+      // rollback-safe (`true`): erroring a still-serving agent (proxy rejects
+      // live traffic + orphan reconciler reaps it) is strictly worse than
+      // leaving a genuinely-dead agent non-terminal (the stuck-recovery cron is
+      // the backstop for that case).
+      throw new UpgradeFailedError(result.error ?? "Unknown agent_upgrade failure", {
+        rolledBack: result.rolledBack ?? true,
+        toDigest: data.toDigest,
+      });
     }
 
     const jobResult: AgentUpgradeJobResult = {


### PR DESCRIPTION
Follow-up to #15311 (lalalune's review). Fixes #15357.

## Problem

`ProvisioningJobService.buildPermanentFailureWriteback` marked **every** exhausted `AGENT_UPGRADE` job `status:"error"`. But most upgrade failures are **rollback-safe**: `executeUpgrade` provisions a fresh *blue* container and only tears the OLD one down **after** a successful atomic swap. Every `success:false` path returns *before* that swap, so the agent keeps serving its previous version.

Marking such a still-serving row terminal:
- makes `dedicated-agent-proxy` reject live traffic, and
- exposes the live container to the orphan reconciler (`docker-node-workloads`), which can reap a **healthy** agent.

## Fix

`executeAgentUpgrade` now throws a typed `UpgradeFailedError { rolledBack, toDigest }`, carrying `executeUpgrade`'s classification through the generic catch → `incrementAttempt` → writeback path. The writeback branches on it.

### Classification table (executeUpgrade failure reason → outcome)

| Failure reason | old container | `rolledBack` | Writeback |
|---|---|---|---|
| `Agent not running (status: …)` | not serving | `false` | **terminal** `status:"error"` (like AGENT_PROVISION) |
| `Agent has no node_id/container_name` | untouched | `true` | keep `running` + re-armable marker |
| `Agent uses a custom docker image; refusing` | untouched | `true` | keep `running` + marker |
| `Old node … not registered` | untouched | `true` | keep `running` + marker |
| `Fleet upgrade only supported on docker provider` | untouched | `true` | keep `running` + marker |
| `Blue provision failed: …` | alive | `true` | keep `running` + marker |
| `Blue health check failed; rolled back` | alive | `true` | keep `running` + marker |
| `Blue provisioner returned non-docker metadata` | alive | `true` | keep `running` + marker |
| `Blue image digest mismatch: …` | alive | `true` | keep `running` + marker |
| `Blue runtime readiness gate failed: …` | alive | `true` | keep `running` + marker |
| `Pre-upgrade snapshot failed: …` | alive | `true` | keep `running` + marker |
| `Atomic swap UPDATE failed: …` | alive (blue torn down) | `true` | keep `running` + marker |
| unknown / no `UpgradeFailedError` (defensive) | assume alive | `true` (default) | keep `running` + marker |

Erroring a still-serving agent is strictly worse than leaving a genuinely-dead one non-terminal (the stuck-recovery cron is the backstop for the latter), so **unknown defaults to rollback-safe**.

### Re-armable marker (no migration)

Rollback-safe writes record `[upgrade-failed-target:<digest>]` at the end of `error_message` (prefix constant in the schema layer to avoid a service↔repo import cycle). `listRunningWithDigestOtherThan` now skips a row **only** when it carries a marker for **THIS exact target** — a **newer** target re-arms the agent. Without this, one transient rollback-safe failure (SSH blip, registry hiccup) would permanently freeze an always-on agent out of *all* future upgrades, including security patches (NubsCarson's #15311 adversarial finding). Defensive: an undefined classification or an empty error digest falls back to the **job's own** `toDigest`, so the marker always records the exact exhausted target.

## Tests

`bun test --conditions=eliza-source` (per-file, matching CI `--isolate`):

```
provisioning-jobs-agent-upgrade-writeback.test.ts   12 pass  0 fail
agent-sandboxes.test.ts                              8 pass  0 fail
```

Covers: rollback-safe vs genuinely-dead writeback, every executeUpgrade failure reason stays non-terminal, `toDigest` fallback to job data (undefined error + empty digest), marker encode/parse round-trip, and the digest-aware reconciler re-arm predicate. `biome check` clean on all 6 files; `tsgo --noEmit` clean.

Refs #15357 #15311 #15310

[sol-cloud]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only cloud shared service/repository change; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only cloud shared service/repository change; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive UI flow; behavior is exercised through cloud worker/repository tests.

<!-- evidence-row:backend-logs -->
- [x] [85721107043](https://github.com/elizaOS/eliza/actions/runs/28896148339/job/85721107043)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend/browser code path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [85721107043](https://github.com/elizaOS/eliza/actions/runs/28896148339/job/85721107043)
