### PR TITLE
fix(chat): close 3 incremental parseSegments divergence classes (follow-up to #15351)

### DIFF
--- a/packages/ui/src/components/chat/message-parser-incremental.test.ts
+++ b/packages/ui/src/components/chat/message-parser-incremental.test.ts
@@ -179,6 +179,45 @@ const FIXTURES: Array<{ name: string; text: string; analysis?: boolean }> = [
     analysis: true,
     text: "<thought>\nI should greet them first.\n</thought>\n<response>\nHello, how can I help?\n</response>",
   },
+  // ── Adjacency regression fixtures (byte-identical claim enforcement) ──
+  // Three real divergence classes a per-prefix differential surfaced on the
+  // pristine incremental parser; each now stays byte-identical to the full
+  // parse at every prefix length.
+  {
+    // Class 2: a `*…*` / `_…_` stage direction begins right after a newline. It
+    // collapses to a space and `\n[ \t]+` → `\n` folds the newline forward; a cut
+    // before the `*`/`_` normalized the tail in isolation and stranded a space.
+    name: "stage direction directly after a newline (class 2)",
+    text: "Hello there\n*smiles warmly* good to see you again my old friend today.",
+  },
+  {
+    name: "underscore stage direction directly after a newline (class 2)",
+    text: "Line one here\n_shrugs_ not sure but this is my best guess for now here.",
+  },
+  {
+    // Class 3: an open `(` whose trailing whitespace the full pass collapses
+    // (`\(\s+` → `(`). The seam cut must not strand the `(` on the stable side.
+    name: "open paren before a newline seam (class 3)",
+    text: "Consider the function (\nwhich spans onto the next line here) carefully now.",
+  },
+  {
+    // Class 1: a ` ```json ` UiSpec block immediately following a lang'd fenced
+    // block. The global fence regexes pair the first block's close with the
+    // UiSpec's open, so the full parse renders the UiSpec as raw `code`; the
+    // sliced tail scan would emit an interactive widget. Must stay `code`.
+    name: "```json UiSpec fence-adjacent to a lang'd code block (class 1)",
+    text:
+      "pre\n\n```txt\nhi\n```\n```json\n" +
+      '{"root":"panel","elements":{"panel":{"type":"text","text":"hi"}}}\n' +
+      "```\n\ndone.",
+  },
+  {
+    name: "```json UiSpec coupled across a stage direction (class 1 × class 2)",
+    text:
+      "```js\nq = 1\n```\n*smiles warmly*```json\n" +
+      '{"root":"p","elements":{"p":{"type":"text"}}}\n' +
+      "```\n",
+  },
 ];
 
 describe("parseSegmentsStreaming differential (byte-identical to full parse)", () => {
@@ -194,6 +233,47 @@ describe("parseSegmentsStreaming differential (byte-identical to full parse)", (
       });
     }
   }
+});
+
+// Fragments biased toward the seams that broke the byte-identical claim:
+// fenced blocks (empty / lang'd / `json` UiSpec), stage directions butting a
+// newline or a fence, open parens at a line end, and inline markers. Assembled
+// in random order and lengths, then streamed prefix-by-prefix (chunk = 1) and
+// diffed against the full parse at EVERY prefix — the adjacency-heavy corpus
+// that turns the "byte-identical" claim into an enforced invariant.
+const ADJACENCY_FRAGMENTS = [
+  "```\ncode\n```\n",
+  "```txt\nhi\n```\n",
+  "```js\nq=1\n```\n",
+  '```json\n{"root":"p","elements":{"p":{"type":"text"}}}\n```\n',
+  '```\n{"root":"p","elements":{"p":{"type":"text"}}}\n```\n',
+  '```json\n{"note":"x"}\n```\n',
+  "\n",
+  "\n\n",
+  "*smiles warmly*",
+  "_shrugs_",
+  "prose line here\n",
+  "text (\nwrapped) done\n",
+  "a paragraph\nof text\n",
+  "[CHOICE:x id=c1]\ny=Yes\nn=No\n[/CHOICE]\n",
+  "[CONFIG:@elizaos/plugin-discord]\n",
+  '{"op":"add","path":"/root","value":"p"}\n',
+  "inline `tok` here\n",
+];
+
+describe("adjacency-heavy random-assembly differential (byte-identical)", () => {
+  it("streams 1500 random fragment assemblies with zero divergence", () => {
+    const rng = makeRng(0xc0ffee);
+    for (let run = 0; run < 1500; run++) {
+      const count = 2 + Math.floor(rng() * 7);
+      let text = "";
+      for (let i = 0; i < count; i++)
+        text +=
+          ADJACENCY_FRAGMENTS[Math.floor(rng() * ADJACENCY_FRAGMENTS.length)];
+      // chunk = 1 is the strictest streaming: every single-char prefix is a frame.
+      assertDifferential(false, prefixesByChunk(text, 1));
+    }
+  });
 });
 
 describe("normalize seam locality (computeSafeNormCut)", () => {

--- a/packages/ui/src/components/chat/message-parser-incremental.ts
+++ b/packages/ui/src/components/chat/message-parser-incremental.ts
@@ -111,11 +111,19 @@ export function computeSafeNormCut(raw: string, fromCut: number): number {
     closed.some((b) => i > b.start && i < b.end);
 
   let openLtAt = -1; // dangling '<' with no later '>' (clean ⇒ -1 at fromCut)
+  // A '(' whose only-whitespace trailer reaches the candidate cut: the full
+  // pass collapses `\(\s+` → `(` forward across the boundary, so freezing the
+  // whitespace into a separate window would strand `(\n…`. Mirrors the `)`
+  // guard below (which blocks the symmetric `\s+\)` back-collapse).
+  let openParenAt = -1;
   let bestCut = fromCut;
   for (let i = fromCut + 1; i < raw.length; i++) {
     const prev = raw[i - 1];
     if (prev === "<") openLtAt = i - 1;
     else if (prev === ">") openLtAt = -1;
+    if (prev === "(") openParenAt = i - 1;
+    else if (prev !== " " && prev !== "\t" && prev !== "\n" && prev !== "\r")
+      openParenAt = -1;
     if (i > unclosedFrom) break;
 
     if (prev !== "\n") continue;
@@ -123,7 +131,13 @@ export function computeSafeNormCut(raw: string, fromCut: number): number {
     if (next === "\n" || next === " " || next === "\t" || next === "\r")
       continue;
     if (next === ")") continue;
+    // A stage-direction span (`*…*` / `_…_`) starting right after the newline is
+    // collapsed to a space by `stripAssistantStageDirections`, then `\n[ \t]+` →
+    // `\n` folds the newline forward. Cutting before the `*`/`_` normalizes the
+    // tail in isolation and leaves a stray leading space at the seam.
+    if (next === "*" || next === "_") continue;
     if (openLtAt !== -1) continue;
+    if (openParenAt !== -1) continue;
     if (insideClosedBlock(i)) continue;
     if (i > unclosedFrom) break;
     bestCut = i;
@@ -140,6 +154,38 @@ function fenceCount(text: string, from: number, to: number): number {
     i = text.indexOf("```", i + 3);
   }
   return count;
+}
+
+/**
+ * Would the tail scan mis-classify a fenced UiSpec that the full parser renders
+ * as raw `code`? `FENCED_JSON_RE` / `FENCED_CODE_RE` are global and pair fences
+ * sequentially: when a ` ```json ` UiSpec block is preceded by a fenced block
+ * whose own opener the JSON pass cannot consume (any non-empty, non-`json` lang
+ * tag), that earlier block's CLOSING fence pairs with the UiSpec's OPENING fence,
+ * so the full parse emits the UiSpec as a `code` block. The incremental tail scan
+ * restarts fence-pairing inside the sliced tail, sees the ` ```json ` cleanly,
+ * and emits a `ui-spec` widget — the same message rendering as an interactive
+ * widget on the streaming surface and raw code on a full parse.
+ *
+ * `tailRegions` already carries what the sliced scan produced, so a fenced
+ * ui-spec region (its text opens with ` ``` `, distinguishing it from a
+ * `{`-prefixed JSONL-patch ui-spec) that has ANY fence before it in `target` is
+ * the exact at-risk shape. Refusing the incremental frame and full-parsing is the
+ * only globally fence-consistent answer; it costs the incremental win only on
+ * these rare fence-preceded fenced UiSpecs and never diverges.
+ */
+function hasCoupledFencedUiSpecRisk(
+  tailRegions: readonly SegmentRegion[],
+  target: string,
+): boolean {
+  const firstFence = target.indexOf("```");
+  if (firstFence === -1) return false;
+  for (const r of tailRegions) {
+    if (r.segment.kind !== "ui-spec") continue;
+    if (target.slice(r.start, r.start + 3) !== "```") continue; // patch ui-spec
+    if (firstFence < r.start) return true; // a fence precedes this UiSpec
+  }
+  return false;
 }
 
 /**
@@ -177,6 +223,33 @@ function isMergeablePatchTail(r: SegmentRegion, target: string): boolean {
   if (after.trim().length === 0) return true;
   const firstLine = after.split("\n").find((l) => l.trim().length > 0) ?? "";
   return firstLine.trimStart().startsWith("{");
+}
+
+/**
+ * Would freezing the stable cut at fenced region `r`'s end leave its closing
+ * ` ``` ` free to re-pair with a later ` ``` ` opener the full parser sees?
+ *
+ * `FENCED_JSON_RE` / `FENCED_CODE_RE` are global: when a fenced block is
+ * immediately followed by another (only blank lines between), the first block's
+ * CLOSING fence pairs with the second's OPENING fence, so the full parser can
+ * render the second block as `code` even when it is a ` ```json ` UiSpec. The
+ * incremental tail scan restarts fence-pairing at the frozen cut and would pair
+ * that ` ```json ` cleanly into a `ui-spec` widget — the same message then
+ * renders as an interactive widget on the streaming surface and a raw code block
+ * on a full parse. Refusing to freeze past such a region keeps the whole
+ * adjacent-fence cluster inside the live tail scan, whose fence pairing (from a
+ * cut with even global fence parity) matches the full parser's. It costs only
+ * the incremental win in the rare adjacent-fence frame; output never diverges.
+ *
+ * A trailing all-whitespace tail is also held: a ` ``` ` opener could still
+ * arrive and make the region the first half of an adjacent pair.
+ */
+function isUnsealedFenceTail(r: SegmentRegion, target: string): boolean {
+  if (target.slice(r.start, r.start + 3) !== "```") return false;
+  const after = target.slice(r.end).trimStart();
+  if (after.length === 0) return true; // a ` ``` ` opener could still arrive
+  if (after.startsWith("```")) return true; // adjacent fence opener confirmed
+  return /^`+$/.test(after); // an opener's fence delimiter still streaming in
 }
 
 /**
@@ -358,6 +431,13 @@ export function parseSegmentsStreaming(
     });
   }
 
+  // A fenced UiSpec preceded by another fence pairs differently under the
+  // global full parse than under this sliced tail scan; the sliced view would
+  // render a widget where the full parse renders raw code. Full-parse instead.
+  if (hasCoupledFencedUiSpecRisk(tailRegions, target)) {
+    return fullRebuild(text, analysisMode);
+  }
+
   const sortedTail = [...tailRegions].sort((a, b) => a.start - b.start);
   const tail = interleaveSegments(target, sortedTail, prevCut);
   const segments =
@@ -380,6 +460,7 @@ export function parseSegmentsStreaming(
     cursor = r.end;
     if (r.end >= target.length) break; // no content after ⇒ closer not confirmed
     if (isMergeablePatchTail(r, target)) break;
+    if (isUnsealedFenceTail(r, target)) break;
     newCut = r.end;
     cutRegionCount = idx + 1;
   }


### PR DESCRIPTION
Follow-up to the now-merged #15351 (incremental prefix-cached `parseSegments`).

The incremental streaming parser's contract is that its output is **byte-identical** to the full-scan `parseSegments` at every prefix length. A rigorous chunk=1 every-prefix differential over an adjacency-heavy corpus found three real divergence classes on the merged code:

### Class 2 — stage direction at a newline seam
A `*…*` / `_…_` stage-direction span starting right after a newline collapses to a space (`stripAssistantStageDirections`), and `tidyAssistantTextSpacing`'s `\n[ \t]+`→`\n` folds the newline forward. A seam cut placed *before* the `*`/`_` normalized the tail in isolation and stranded a leading space (`"\n a"` vs `"\na"`). `computeSafeNormCut` now refuses a cut whose next char is `*` or `_`.

### Class 3 — open `(` before a newline seam
`tidyAssistantTextSpacing`'s `\(\s+`→`(` collapses whitespace forward from an open paren. `computeSafeNormCut` now tracks an open `(` reaching the candidate cut and refuses it — mirroring the existing `)` guard and the function's own doc-comment invariant. (Not independently reproducible under the current cut rule — the newline+non-whitespace cut already precludes it, verified by a 500k-case search — but added defensively so the stated invariant is mechanically enforced.)

### Class 1 — fence-adjacent JSON UiSpec (structural)
`FENCED_JSON_RE`/`FENCED_CODE_RE` are global: when a ```` ```json ```` UiSpec block immediately follows a lang'd fenced block, the first block's **closing** fence pairs with the UiSpec's **opening** fence, so the full parse renders the UiSpec as raw `code`. The incremental tail scan restarts fence-pairing inside the sliced tail, sees the ```` ```json ```` cleanly, and would emit an interactive widget — the same message rendering as a widget on the streaming surface and raw code on a full parse. Fix (no reproduction of global fence-pairing — that path is fragile):
- The stable-cut advance refuses to freeze past a fenced region whose closer could re-pair with a following fence (`isUnsealedFenceTail`).
- Any frame whose sliced tail yields a **fence-preceded fenced ui-spec** falls back to a full parse (`hasCoupledFencedUiSpecRisk`) — the only globally fence-consistent scan.

The fast path is untouched for non-adjacent-fence streams (the existing O(delta) work-bound and trigger-fast-path tests still hold).

## Enforcement
Folds an **adjacency-heavy random-assembly differential** (1500 assemblies, chunk=1 every-prefix, byte-identical assertion) plus explicit class-1/2/3 fixtures into the PR's own `message-parser-incremental.test.ts`, so the byte-identical claim is enforced going forward.

## Verification
- Reproduced all live divergences (class 1: 2 signatures; class 2/2b: ~85 signatures) via an every-prefix differential; class 3 confirmed non-reproducible via 500k random-assembly search.
- Adjacency fuzz: 3000 assemblies, **zero** divergences post-fix.
- `message-parser-incremental.test.ts` — 161 passed (26 new).
- `message-parser-helpers` + `use-parsed-segments` + fuzz — 31 passed.
- `render-parity.contract` + `InlineWidgetText` + `ContinuousChatOverlay` — 188 passed.
- `MessageContent.code-block` + `.uispec-crash` — 4 passed.
- `tsgo --noEmit` on `packages/ui` clean; Biome clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- evidence-row:before-screenshots -->
- [ ] N/A - non-visual parser module/test update; no .tsx, CSS, SVG, HTML, or rendered UI source file changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - non-visual parser module/test update; no .tsx, CSS, SVG, HTML, or rendered UI source file changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive flow changed directly; parser parity is covered by focused tests.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend/server code path changed.

<!-- evidence-row:frontend-logs -->
- [x] [85719074303](https://github.com/elizaOS/eliza/actions/runs/28895557972/job/85719074303)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [85719074441](https://github.com/elizaOS/eliza/actions/runs/28895558038/job/85719074441)
