### PR TITLE
fix(cloud): re-arm gate for upgrade-freeze + swap-CAS repo-match (#15358)

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -3214,6 +3214,10 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
       expect(params).toContain(TO_DIGEST); // image_digest := toDigest
       expect(params).toContain(FROM_DIGEST); // previous_image_digest := fromDigest
       expect(params).toContain(DOCKER_IMAGE); // previous_docker_image (agent.docker_image is null → dockerImage)
+      // Success clears the upgrade-exhaustion marker: a row frozen for a prior
+      // target re-arms the moment a swap onto a new target lands (#15358).
+      const updateSql = new PgDialect().sqlToQuery(executedSql as SQL).sql.toLowerCase();
+      expect(updateSql).toContain("error_message = null");
       // The old container is best-effort torn down on its specific node; the
       // blue is the live one and is NOT stopped.
       expect(stopOnSpecificNode).toHaveBeenCalledTimes(1);
@@ -3332,6 +3336,93 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
       readSpy.mockRestore();
       snapshotSpy.mockRestore();
     }
+  });
+
+  // Shared driver for the CAS docker_image-leg cases (#15358): run a full
+  // executeUpgrade with the given row at BOTH the pre-provision read and the
+  // in-transaction CAS read, and report whether the swap UPDATE was issued.
+  async function runSwapWithRow(agentRow: AgentSandbox, casRow: AgentSandbox = agentRow) {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(agentRow);
+    const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(oldNode());
+    const { provider, stop } = await makeDockerProvider({
+      create: async () => blueHandle(TO_DIGEST),
+      checkHealth: async () => true,
+    });
+    const svc = new ElizaSandboxService(provider);
+    const lockSpy = spyOn(
+      svc as unknown as { lockLifecycle: (...a: unknown[]) => Promise<void> },
+      "lockLifecycle",
+    ).mockResolvedValue(undefined);
+    const readSpy = spyOn(
+      svc as unknown as {
+        getAgentForLifecycleMutation: (...a: unknown[]) => Promise<AgentSandbox | undefined>;
+      },
+      "getAgentForLifecycleMutation",
+    ).mockResolvedValue(casRow);
+    const snapshotSpy = spyOn(
+      svc as unknown as { snapshot: (...a: unknown[]) => Promise<{ success: boolean }> },
+      "snapshot",
+    ).mockResolvedValue({ success: true });
+    let executedSql: unknown;
+    upgradeTransactionImpl = async (fn) => {
+      const tx: UpgradeTx = {
+        execute: async (query: unknown) => {
+          executedSql = query;
+          return { rows: [{ id: AGENT }] };
+        },
+      };
+      return fn(tx);
+    };
+    try {
+      const res = await svc.executeUpgrade(AGENT, ORG, TO_DIGEST, DOCKER_IMAGE, FROM_DIGEST);
+      return { res, executedSql, stop };
+    } finally {
+      findSpy.mockRestore();
+      nodeSpy.mockRestore();
+      lockSpy.mockRestore();
+      readSpy.mockRestore();
+      snapshotSpy.mockRestore();
+    }
+  }
+
+  test("(e1) EMPTY docker_image pin + configured ref → CAS admits, swap proceeds (#15358)", async () => {
+    // 45 running prod agents carry an empty docker_image; an exact-ref CAS
+    // treated "" !== configured ref as a concurrent change and abandoned the
+    // swap AFTER the blue provision + snapshot, every attempt, until the
+    // upgrade exhausted and the failure marker froze the agent.
+    const row: AgentSandbox = { ...liveAgentRow(), docker_image: "" };
+    const { res, executedSql } = await runSwapWithRow(row);
+    expect(res.success).toBe(true);
+    expect(executedSql).toBeDefined();
+    expect(sqlBoundParams(executedSql)).toContain(TO_DIGEST);
+  });
+
+  test("(e2) same-repo different-tag pin → CAS admits, swap proceeds (#15358)", async () => {
+    // A digest-drifted fleet agent pinned to an older tag of the SAME repo is
+    // exactly what selection admits (#15101 repo-match); the CAS must mirror
+    // that, or every selected sha-pinned agent churns provision→abandon.
+    const PINNED = "ghcr.io/elizaos/eliza-agent:sha-519b5d8";
+    const row: AgentSandbox = { ...liveAgentRow(), docker_image: PINNED };
+    const { res, executedSql } = await runSwapWithRow(row);
+    expect(res.success).toBe(true);
+    // The pinned ref (not the configured one) is preserved as the rollback image.
+    expect(sqlBoundParams(executedSql)).toContain(PINNED);
+  });
+
+  test("(e3) CONCURRENT repoint at a DIFFERENT repo → CAS abandons, blue torn down (#15358)", async () => {
+    // The CAS's true purpose: the user switched the agent to a custom image
+    // while the blue provisioned — adopting the blue would clobber that choice.
+    const movedRow: AgentSandbox = {
+      ...liveAgentRow(),
+      docker_image: "ghcr.io/acme/custom-agent:latest",
+    };
+    const { res, executedSql, stop } = await runSwapWithRow(liveAgentRow(), movedRow);
+    expect(res.success).toBe(false);
+    expect(res.error).toContain("Agent changed during upgrade");
+    // No UPDATE was issued and the orphaned blue is stopped.
+    expect(executedSql).toBeUndefined();
+    expect(stop).toHaveBeenCalledWith("sandbox-new-1");
   });
 });
 

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -5150,7 +5150,19 @@ export class ElizaSandboxService {
           current.container_name !== oldContainerName ||
           current.sandbox_id !== oldSandboxId ||
           current.image_digest !== fromDigest ||
-          (current.docker_image && current.docker_image !== dockerImage)
+          // The docker_image leg of this CAS exists to catch one concurrent
+          // COMPETING change: the agent being repointed at a custom image (a
+          // DIFFERENT repo) while the blue provisioned — adopting the blue
+          // would clobber that user choice. It must NOT demand textual ref
+          // equality: selection admits any tag/digest/empty pin of the fleet
+          // repo (#15101 repo-match), so an exact-string compare abandoned
+          // every selected sha-pinned or empty-pinned row AFTER the full blue
+          // provision + snapshot, exhausted the job's retries, and the
+          // exhaustion marker then froze the agent out of all future upgrades
+          // (#15358). Mirror the selection/pre-provision semantics — abandon
+          // only on a real repo change; the digest/node/container/sandbox legs
+          // above still detect every other concurrent mutation.
+          (current.docker_image && imageRepo(current.docker_image) !== imageRepo(dockerImage))
         ) {
           return false;
         }
@@ -5469,7 +5481,12 @@ export class ElizaSandboxService {
           current.container_name !== oldContainerName ||
           current.sandbox_id !== oldSandboxId ||
           current.image_digest !== fromDigest ||
-          (current.docker_image && current.docker_image !== dockerImage)
+          // Same repo-match semantics as the upgrade swap's CAS above: this
+          // leg detects a concurrent repoint at a DIFFERENT repo, not textual
+          // pin drift within the fleet repo (an empty or tag/digest-pinned
+          // docker_image on the same repo is still the fleet image — #15101,
+          // #15358). `dockerImage` here is the recorded rollback ref.
+          (current.docker_image && imageRepo(current.docker_image) !== imageRepo(dockerImage))
         ) {
           return false;
         }


### PR DESCRIPTION
Fixes #15358 — the two post-merge defects from #15311 (which merged while CHANGES_REQUESTED). Independent adversarial review: **SHIP** (100/0 tests, typecheck clean, all invariants hold).

## D1 — permanent upgrade-freeze → self-re-arming
The exhaustion writeback recorded a target-LESS `error_message` that excluded a running agent from **all** future fleet upgrades forever. Now the marker (`packages/cloud/shared/src/db/utils/upgrade-failure-marker.ts`, NEW) carries the failed `targetDigest`; `listRunningWithDigestOtherThan` skips a row **only while its marker matches the CURRENT target** → a new configured target auto-re-arms it. Unrelated `error_message` values never exclude a running row. No schema change (rides the existing column; LIKE-wildcard escaping is real-Postgres-tested).

## D2 — swap-CAS repo-match (both executeUpgrade + executeDowngrade)
The blue/green swap CAS compared `docker_image` by exact ref, contradicting #15101's repo-match selection — same-repo tag/digest pins churned (provision→abandon→exhaust→D1 freeze). Now compares `imageRepo()`; the CAS still **abandons** on a genuine different-repo concurrent repoint (pinned test). Found + fixed the identical bug in the symmetric `executeDowngrade` CAS too.

## Verification
- 4 touched test files, **100 pass / 0 fail** (real-PGlite marker suite incl. LIKE-escape + all CAS paths: empty-pin proceeds, same-repo proceeds, different-repo abandons + blue torn down). typecheck 0, biome clean, error-policy ratchet clean.

## PR-body notes (per review)
- One-time deploy churn: prod rows with the OLD target-less marker re-arm once on the first post-deploy cycle (bounded by MAX_INFLIGHT_UPGRADES=3) — this **is** the intended #15358 unfreeze.
- `executeDowngrade` CAS change is covered transitively (upgrade tests pin the shared semantics); dedicated downgrade test is a follow-up nit.

Gates the next develop→main promote (prod CP is on main, does not yet carry #15311's defects). cc @0xSolace @lalalune — [qa-agent]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only cloud shared service/repository change; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only cloud shared service/repository change; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no interactive UI flow; behavior is exercised through cloud worker/repository tests.

<!-- evidence-row:backend-logs -->
- [x] [85720208959](https://github.com/elizaOS/eliza/actions/runs/28895895447/job/85720208959)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend/browser code path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [85720208959](https://github.com/elizaOS/eliza/actions/runs/28895895447/job/85720208959)
