### PR TITLE
fix(cloud): count only live slots for node allocated_count — stop phantom slots forcing billable cloud-node spawn

### DIFF
--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.count.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.count.test.ts
@@ -1,7 +1,8 @@
-// Verifies countAllocatedWorkloadsOnNode counts LIVE slots only — a sandbox in a
-// terminal status (its container should not be running) must not inflate a
-// node's allocated_count, or the autoscaler reads bare-metal robots as full and
-// bills new Hetzner-cloud nodes instead (#15378).
+/**
+ * Live-slot accounting coverage for Docker node allocation counts. Terminal
+ * agent sandbox rows must not inflate allocated_count, or the autoscaler reads
+ * bare-metal robots as full and bills new Hetzner-cloud nodes instead (#15378).
+ */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.count.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.count.test.ts
@@ -1,0 +1,75 @@
+// Verifies countAllocatedWorkloadsOnNode counts LIVE slots only — a sandbox in a
+// terminal status (its container should not be running) must not inflate a
+// node's allocated_count, or the autoscaler reads bare-metal robots as full and
+// bills new Hetzner-cloud nodes instead (#15378).
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import type { SQL } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+
+const capturedWheres: SQL[] = [];
+
+// dbRead.select().from().where(clause) captures each clause and resolves to a
+// single count row, so the query builder runs end-to-end without a live DB.
+const where = mock((clause: SQL) => {
+  capturedWheres.push(clause);
+  return [{ count: 1 }];
+});
+const from = mock(() => ({ where }));
+const select = mock(() => ({ from }));
+
+// Replace the whole helpers module: dbRead captures the query, the rest are
+// stubs so every static import in the transitive chain still resolves.
+mock.module("../../db/helpers", () => ({
+  dbRead: { select },
+  dbWrite: { update: mock(() => ({ set: mock(() => ({ where: mock(() => []) })) })) },
+  useReadDb: mock(),
+  useWriteDb: mock(),
+  readQuery: mock(),
+  writeQuery: mock(),
+  writeTransaction: mock(),
+  getReadDb: mock(),
+  getWriteDb: mock(),
+  logDbRouting: mock(),
+  getDbRoutingInfo: mock(() => ({})),
+}));
+
+const { countAllocatedWorkloadsOnNode } = await import("./docker-node-workloads");
+
+function renderParams(clause: SQL): string[] {
+  const { params } = new PgDialect().sqlToQuery(clause);
+  return params.map((p) => String(p));
+}
+
+describe("countAllocatedWorkloadsOnNode — live-slot accounting (#15378)", () => {
+  beforeEach(() => {
+    capturedWheres.length = 0;
+    where.mockClear();
+  });
+
+  test("the agent_sandboxes filter excludes every terminal status, not just stopped/error", async () => {
+    await countAllocatedWorkloadsOnNode("node-under-test");
+
+    // Two queries run (containers + agent_sandboxes); the agent one is the
+    // clause whose params carry the sandbox terminal-status vocab.
+    const agentParams = capturedWheres
+      .map(renderParams)
+      .find((params) => params.includes("sleeping"));
+
+    expect(agentParams).toBeDefined();
+    // Regression: the previous filter only excluded stopped/error, so sleeping
+    // and deletion_failed sandboxes kept holding phantom slots.
+    for (const terminal of ["stopped", "error", "sleeping", "deletion_failed"]) {
+      expect(agentParams).toContain(terminal);
+    }
+    // disconnected is NON-terminal (container up but unreachable) — it still
+    // occupies the slot and must NOT be excluded from the count.
+    expect(agentParams).not.toContain("disconnected");
+    expect(agentParams).not.toContain("running");
+  });
+
+  test("sums container + agent counts (one row each here) into total live slots", async () => {
+    const total = await countAllocatedWorkloadsOnNode("node-under-test");
+    expect(where).toHaveBeenCalledTimes(2);
+    expect(total).toBe(2);
+  });
+});

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
@@ -21,11 +21,39 @@ async function countRows(query: Promise<Array<{ count: number }>>): Promise<numb
 }
 
 /**
+ * agent_sandboxes statuses that mean the container should NOT be running. A
+ * container backing a row in one of these states is reapable just like one
+ * with no row at all: the lifecycle has decided this agent has no live
+ * container, so a leftover Docker process is a leak.
+ *
+ * `deletion_failed` is included deliberately — that state exists precisely
+ * because the delete-time container teardown did not succeed, so reaping it
+ * here is the recovery path. `deletion_pending` is NOT terminal: an
+ * agent_delete job is actively in flight and owns the teardown; reaping under
+ * it would race the worker.
+ */
+const TERMINAL_SANDBOX_STATUSES = new Set<string>([
+  "stopped",
+  "error",
+  "sleeping",
+  "deletion_failed",
+]);
+
+/**
  * Active compute slots on a Docker node.
  *
  * Stopped containers are intentionally excluded here because their Docker
  * process has been removed and `allocated_count` should represent live slot
  * pressure, not retained storage.
+ *
+ * The agent side excludes the same {@link TERMINAL_SANDBOX_STATUSES} the orphan
+ * reconciler uses to decide a container "should NOT be running" — a row in one
+ * of those states holds no live slot. Excluding only `('stopped','error')` here
+ * (the previous behaviour) left `sleeping`/`deletion_failed` rows inflating
+ * `allocated_count` above a node's real load, which made the autoscaler read
+ * bare-metal robots as full and bill new Hetzner-cloud nodes instead (#15378).
+ * `disconnected` is deliberately NOT excluded: it is non-terminal (the
+ * container is up but unreachable) and still occupies the slot.
  */
 export async function countAllocatedWorkloadsOnNode(nodeId: string): Promise<number> {
   const [containerCount, agentCount] = await Promise.all([
@@ -47,7 +75,10 @@ export async function countAllocatedWorkloadsOnNode(nodeId: string): Promise<num
         .where(
           and(
             eq(agentSandboxes.node_id, nodeId),
-            sql`${agentSandboxes.status} not in ('stopped','error')`,
+            sql`${agentSandboxes.status} not in (${sql.join(
+              [...TERMINAL_SANDBOX_STATUSES].map((status) => sql`${status}`),
+              sql`, `,
+            )})`,
           ),
         ),
     ),
@@ -74,25 +105,6 @@ export async function countAllocatedWorkloadsOnNode(nodeId: string): Promise<num
 // parses the id out of `agent-<id>`, and the agent terminal-status vocab (plus
 // the agent_sandboxes status query and a log tag).
 // ---------------------------------------------------------------------------
-
-/**
- * agent_sandboxes statuses that mean the container should NOT be running. A
- * container backing a row in one of these states is reapable just like one
- * with no row at all: the lifecycle has decided this agent has no live
- * container, so a leftover Docker process is a leak.
- *
- * `deletion_failed` is included deliberately — that state exists precisely
- * because the delete-time container teardown did not succeed, so reaping it
- * here is the recovery path. `deletion_pending` is NOT terminal: an
- * agent_delete job is actively in flight and owns the teardown; reaping under
- * it would race the worker.
- */
-const TERMINAL_SANDBOX_STATUSES = new Set<string>([
-  "stopped",
-  "error",
-  "sleeping",
-  "deletion_failed",
-]);
 
 /**
  * Extract the agent id from an `agent-<id>` container name, or null when the


### PR DESCRIPTION
## Problem (#15378) — live on prod
The autoscaler keeps spinning up **billable Hetzner-cloud** nodes even though the 5 **bare-metal robots** (already paid for) have real spare capacity. Live prod: `docker_nodes` shows `eliza-core-prod-6` = **11/8**, `prod-4` = **9/8** (allocated_count > capacity) while only **6-7 agents** are actually running on each. The autoscaler reads the robots as full → bills cloud instead.

## Root cause
`countAllocatedWorkloadsOnNode` (the single count both `syncAllocatedCounts` and the autoscaler's `evaluateCapacity` read) excluded agent_sandboxes only where status `NOT IN ('stopped','error')`. But the same file defines `TERMINAL_SANDBOX_STATUSES = {stopped, error, sleeping, deletion_failed}` — 'statuses that mean the container should NOT be running', used by the orphan reconciler. So **`sleeping` and `deletion_failed` rows kept holding a live slot**, inflating allocated_count above a node's real load.

## Fix
Reuse `TERMINAL_SANDBOX_STATUSES` for the agent-side count (one source of truth for 'no live container'), via a parameterized `sql`…not in (…)`` built from the set (matches the module's existing raw-sql style; `sql.join` idiom already used in `org-rate-limits.ts`). `disconnected` stays **counted** — it is non-terminal (container up but unreachable) and still occupies the slot. Moved the set above the function so both consumers share it.

## Impact
Robots report their true load → the autoscaler uses paid-for bare metal → stops billing redundant cloud nodes. No behaviour change for `running`/`disconnected`/`provisioning` (still counted).

## Tests
New `docker-node-workloads.count.test.ts` renders the generated WHERE via `PgDialect` and asserts the agent filter excludes all four terminal statuses (regression: `sleeping`+`deletion_failed` were leaking) and does NOT exclude `disconnected`/`running`. **2 pass / 9 assertions.** `packages/cloud/shared` typecheck (tsgo) exit 0; node-autoscaler.test.ts 8/8 still green (it mocks this fn).

Follow-ups tracked in #15378: verify `processSyncAllocatedCountsCycle` actually fires on prod (the 11/8 drift hints it isn't), reap running-with-null-node orphans, deregister offline cloud nodes.

Closes #15378

[stan-cloud]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only node allocation-count query/test change; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only node allocation-count query/test change; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only node allocation-count query/test change; no browser walkthrough applies.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no live backend deploy or prod mutation was run from this PR; behavior is covered by the focused SQL-rendering regression test and CI.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser network flow changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM call or model trajectory is involved.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain artifact is generated; this is node allocation accounting behavior only.
