### PR TITLE
fix(cloud): exclude terminal sandboxes from allocated counts (#15378)

### DIFF
--- a/packages/cloud/shared/src/lib/services/docker-node-workloads-count.test.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads-count.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Regression coverage for live node-slot accounting (#15378).
+ *
+ * `countAllocatedWorkloadsOnNode` feeds both allocated_count reconciliation and
+ * the autoscaler's capacity decision, so terminal agent lifecycle rows must not
+ * hold live slots on a Docker node. This runs the real Drizzle count SQL against
+ * in-process PGlite with only the columns the count query touches.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL = "pglite://memory";
+process.env.TEST_DATABASE_URL = "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+const PGLITE_TIMEOUT = 60000;
+
+let dbWrite: typeof import("../../db/client").dbWrite;
+let closeDb: typeof import("../../db/client").closeDatabaseConnectionsForTests | undefined;
+let countAllocatedWorkloadsOnNode:
+  | typeof import("./docker-node-workloads").countAllocatedWorkloadsOnNode
+  | undefined;
+let pgliteReady = true;
+
+beforeAll(async () => {
+  try {
+    ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../db/client"));
+    ({ countAllocatedWorkloadsOnNode } = await import("./docker-node-workloads"));
+
+    const ddl = [
+      `CREATE TABLE IF NOT EXISTS containers (
+        id text PRIMARY KEY,
+        node_id text,
+        status text NOT NULL
+      )`,
+      `CREATE TABLE IF NOT EXISTS agent_sandboxes (
+        id text PRIMARY KEY,
+        node_id text,
+        status text NOT NULL
+      )`,
+    ];
+    for (const stmt of ddl) {
+      await dbWrite.execute(stmt);
+    }
+  } catch (error) {
+    pgliteReady = false;
+    console.warn("[docker-node-workloads-count] PGlite unavailable, skipping DB cases:", error);
+  }
+}, PGLITE_TIMEOUT);
+
+afterAll(async () => {
+  if (closeDb) await closeDb();
+});
+
+describe("countAllocatedWorkloadsOnNode", () => {
+  test(
+    "excludes terminal agent sandbox statuses from live slot pressure",
+    async () => {
+      if (!pgliteReady || !countAllocatedWorkloadsOnNode) return;
+      await dbWrite.execute(`DELETE FROM containers;`);
+      await dbWrite.execute(`DELETE FROM agent_sandboxes;`);
+
+      for (const [id, status] of [
+        ["container-running", "running"],
+        ["container-pending", "pending"],
+        ["container-stopped", "stopped"],
+        ["container-failed", "failed"],
+        ["container-deleted", "deleted"],
+      ]) {
+        await dbWrite.execute(
+          `INSERT INTO containers (id, node_id, status) VALUES ('${id}', 'node-1', '${status}');`,
+        );
+      }
+
+      for (const [id, status] of [
+        ["agent-running", "running"],
+        ["agent-provisioning", "provisioning"],
+        ["agent-pending", "pending"],
+        ["agent-disconnected", "disconnected"],
+        ["agent-deletion-pending", "deletion_pending"],
+        ["agent-stopped", "stopped"],
+        ["agent-error", "error"],
+        ["agent-sleeping", "sleeping"],
+        ["agent-deletion-failed", "deletion_failed"],
+        ["agent-other-node", "running"],
+      ]) {
+        const nodeId = id === "agent-other-node" ? "node-2" : "node-1";
+        await dbWrite.execute(
+          `INSERT INTO agent_sandboxes (id, node_id, status) VALUES ('${id}', '${nodeId}', '${status}');`,
+        );
+      }
+
+      expect(await countAllocatedWorkloadsOnNode("node-1")).toBe(7);
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+test("PGlite schema applied for allocated workload counting - never a silent skip", () => {
+  expect(pgliteReady).toBe(true);
+  expect(countAllocatedWorkloadsOnNode).toBeDefined();
+});

--- a/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
+++ b/packages/cloud/shared/src/lib/services/docker-node-workloads.ts
@@ -1,7 +1,7 @@
 // Coordinates cloud service docker node workloads behavior behind route handlers.
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, eq, inArray, notInArray, sql } from "drizzle-orm";
 import { dbRead } from "../../db/helpers";
-import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
+import { agentSandboxes, type AgentSandboxStatus } from "../../db/schemas/agent-sandboxes";
 import { containers } from "../../db/schemas/containers";
 import { AGENT_CONTAINER_NAME_PREFIX } from "./docker-sandbox-utils";
 import {
@@ -21,11 +21,31 @@ async function countRows(query: Promise<Array<{ count: number }>>): Promise<numb
 }
 
 /**
+ * agent_sandboxes statuses that mean the container should NOT be running. A
+ * container backing a row in one of these states is reapable just like one
+ * with no row at all: the lifecycle has decided this agent has no live
+ * container, so a leftover Docker process is a leak.
+ *
+ * `deletion_failed` is included deliberately — that state exists precisely
+ * because the delete-time container teardown did not succeed, so reaping it
+ * here is the recovery path. `deletion_pending` is NOT terminal: an
+ * agent_delete job is actively in flight and owns the teardown; reaping under
+ * it would race the worker.
+ */
+const TERMINAL_SANDBOX_STATUS_VALUES: AgentSandboxStatus[] = [
+  "stopped",
+  "error",
+  "sleeping",
+  "deletion_failed",
+];
+const TERMINAL_SANDBOX_STATUSES = new Set<string>(TERMINAL_SANDBOX_STATUS_VALUES);
+
+/**
  * Active compute slots on a Docker node.
  *
- * Stopped containers are intentionally excluded here because their Docker
- * process has been removed and `allocated_count` should represent live slot
- * pressure, not retained storage.
+ * Terminal containers and terminal agent sandboxes are intentionally excluded
+ * here because their Docker process should be gone and `allocated_count` should
+ * represent live slot pressure, not retained storage or failed lifecycle rows.
  */
 export async function countAllocatedWorkloadsOnNode(nodeId: string): Promise<number> {
   const [containerCount, agentCount] = await Promise.all([
@@ -47,7 +67,7 @@ export async function countAllocatedWorkloadsOnNode(nodeId: string): Promise<num
         .where(
           and(
             eq(agentSandboxes.node_id, nodeId),
-            sql`${agentSandboxes.status} not in ('stopped','error')`,
+            notInArray(agentSandboxes.status, TERMINAL_SANDBOX_STATUS_VALUES),
           ),
         ),
     ),
@@ -74,25 +94,6 @@ export async function countAllocatedWorkloadsOnNode(nodeId: string): Promise<num
 // parses the id out of `agent-<id>`, and the agent terminal-status vocab (plus
 // the agent_sandboxes status query and a log tag).
 // ---------------------------------------------------------------------------
-
-/**
- * agent_sandboxes statuses that mean the container should NOT be running. A
- * container backing a row in one of these states is reapable just like one
- * with no row at all: the lifecycle has decided this agent has no live
- * container, so a leftover Docker process is a leak.
- *
- * `deletion_failed` is included deliberately — that state exists precisely
- * because the delete-time container teardown did not succeed, so reaping it
- * here is the recovery path. `deletion_pending` is NOT terminal: an
- * agent_delete job is actively in flight and owns the teardown; reaping under
- * it would race the worker.
- */
-const TERMINAL_SANDBOX_STATUSES = new Set<string>([
-  "stopped",
-  "error",
-  "sleeping",
-  "deletion_failed",
-]);
 
 /**
  * Extract the agent id from an `agent-<id>` container name, or null when the


### PR DESCRIPTION
## Summary

- Makes `countAllocatedWorkloadsOnNode` reuse the agent terminal-status vocabulary instead of hardcoding only `stopped,error`.
- Stops `sleeping` and `deletion_failed` agent sandbox rows from holding live capacity slots in allocated-count reconciliation and autoscaler capacity checks.
- Adds focused PGlite-backed regression coverage for the live-slot count query.

Fixes #15378.

## Validation

- `bunx biome check packages/cloud/shared/src/lib/services/docker-node-workloads.ts packages/cloud/shared/src/lib/services/docker-node-workloads.test.ts packages/cloud/shared/src/lib/services/docker-node-workloads-count.test.ts` ✅
- `git diff --check` ✅
- `bun test packages/cloud/shared/src/lib/services/docker-node-workloads-count.test.ts` blocked locally: this checkout has no `node_modules`, and `bun install --frozen-lockfile` refuses with `lockfile had changes, but lockfile is frozen`; without dependencies the test cannot resolve `drizzle-orm/node-postgres`. The test has a loud PGlite guard, so this does not silently pass locally. CI should be the dependency-complete verifier.
- `bun test packages/cloud/shared/src/lib/services/docker-node-workloads.test.ts` blocked locally for the same missing `drizzle-orm` dependency state.

## Notes

This does not mutate prod, repair existing `allocated_count` drift, reap `running` rows with `node_id = NULL`, or scale down cloud nodes. It only fixes the shared count source that feeds reconcile/autoscaler decisions.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only allocation-count query change; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only allocation-count query change; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only allocation-count query change; no browser walkthrough applies.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no live backend deploy or prod mutation was run from this PR; behavior is covered by the focused DB regression test and CI.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser network flow changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM call or model trajectory is involved.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain artifact is generated; this is accounting/query behavior only.
