### PR TITLE
fix(cloud-onboarding): clear force-fresh on shared-agent completion so returning users don't re-onboard (#15379)

### DIFF
--- a/packages/ui/src/first-run/first-run-finish.force-fresh.test.ts
+++ b/packages/ui/src/first-run/first-run-finish.force-fresh.test.ts
@@ -38,9 +38,9 @@ import {
   enableForceFreshFirstRun,
   isForceFreshFirstRunEnabled,
 } from "../platform/first-run-reset";
-import { bindCloudAgent } from "./first-run-finish";
-import type { FirstRunFinishPorts } from "./first-run-finish";
 import type { FirstRunProfileDraft } from "./first-run";
+import type { FirstRunFinishPorts } from "./first-run-finish";
+import { bindCloudAgent } from "./first-run-finish";
 
 const SHARED_AGENT_BASE =
   "https://staging.elizacloud.ai/api/v1/eliza/agents/cad3c071";
@@ -118,12 +118,7 @@ describe("bindCloudAgent clears the durable force-fresh flag on completion", () 
 
     // Act: complete onboarding against a SHARED cloud agent base (skips the
     // /api/first-run POST — the historically-uncovered clear path).
-    const outcome = await bindCloudAgent(
-      draft(),
-      "steward-token",
-      {},
-      ports(),
-    );
+    const outcome = await bindCloudAgent(draft(), "steward-token", {}, ports());
 
     // Assert: onboarding completed AND the durable directive is cleared, so a
     // subsequent cold boot / PWA relaunch does NOT re-run the force-fresh
@@ -136,12 +131,7 @@ describe("bindCloudAgent clears the durable force-fresh flag on completion", () 
 
   it("is a no-op-safe clear when force-fresh was never armed (idempotent)", async () => {
     expect(isForceFreshFirstRunEnabled()).toBe(false);
-    const outcome = await bindCloudAgent(
-      draft(),
-      "steward-token",
-      {},
-      ports(),
-    );
+    const outcome = await bindCloudAgent(draft(), "steward-token", {}, ports());
     expect(outcome.kind).toBe("done");
     expect(isForceFreshFirstRunEnabled()).toBe(false);
   });

--- a/packages/ui/src/first-run/first-run-finish.force-fresh.test.ts
+++ b/packages/ui/src/first-run/first-run-finish.force-fresh.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression: a returning user with a healthy running shared/dedicated cloud
+ * agent must NOT be bounced back into onboarding after a new build deploys /
+ * the PWA relaunches.
+ *
+ * Root cause (bug(cloud-onboarding): onboarding re-enters for returning user
+ * with running agent after new build deploy):
+ *
+ * The durable `elizaos:first-run:force-fresh` flag is a ONE-SHOT "re-run
+ * onboarding on next boot" directive (armed by `?reset` or an in-session agent
+ * reset). The restore phase consumes it by calling
+ * `savePersistedFirstRunComplete(false)` and clearing the active server, so a
+ * boot with the flag set legitimately re-onboards. The flag is meant to be
+ * CLEARED the moment onboarding completes so the boot AFTER completion lands in
+ * chat.
+ *
+ * For the app-shell (local / dedicated container) runtime the clear happens
+ * inside `client.submitFirstRun` (the reset client patch clears force-fresh on
+ * the POST). But a SHARED / direct cloud agent base does NOT own
+ * `/api/first-run`, so `bindCloudAgent` SKIPS `persistFirstRun` — and therefore
+ * never reached the `submitFirstRun` clear. A user who onboarded a shared cloud
+ * agent while force-fresh was armed completed onboarding with the flag STILL
+ * set, so the next cold boot / PWA relaunch re-ran the force-fresh consume and
+ * bounced them back into "Setting up your agent…" against a perfectly healthy
+ * running agent.
+ *
+ * The fix clears force-fresh on the cloud completion path too, so "completion
+ * clears force-fresh" holds for EVERY runtime. This test drives the real
+ * `bindCloudAgent` against a shared-agent base with force-fresh armed and
+ * asserts the durable flag is cleared by completion.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearForceFreshFirstRun,
+  enableForceFreshFirstRun,
+  isForceFreshFirstRunEnabled,
+} from "../platform/first-run-reset";
+import { bindCloudAgent } from "./first-run-finish";
+import type { FirstRunFinishPorts } from "./first-run-finish";
+import type { FirstRunProfileDraft } from "./first-run";
+
+const SHARED_AGENT_BASE =
+  "https://staging.elizacloud.ai/api/v1/eliza/agents/cad3c071";
+
+const clientMock = vi.hoisted(() => ({
+  selectOrProvisionCloudAgent: vi.fn(),
+  submitFirstRun: vi.fn(async () => {}),
+  setBaseUrl: vi.fn(),
+  setToken: vi.fn(),
+  getBaseUrl: vi.fn(() => ""),
+}));
+
+vi.mock("../api", () => ({ client: clientMock }));
+
+vi.mock("../config/boot-config", () => ({
+  getBootConfig: () => ({ cloudApiBase: "https://staging.elizacloud.ai" }),
+}));
+
+vi.mock("../state", () => ({
+  addAgentProfile: vi.fn(() => ({ id: "profile-1" })),
+  createPersistedActiveServer: vi.fn((v) => ({ label: "Eliza Cloud", ...v })),
+  loadPersistedActiveServer: vi.fn(() => null),
+  removeAgentProfile: vi.fn(),
+  savePersistedActiveServer: vi.fn(),
+}));
+
+vi.mock("./mobile-runtime-mode", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./mobile-runtime-mode")>()),
+  persistMobileRuntimeModeForServerTarget: vi.fn(),
+}));
+
+function draft(): FirstRunProfileDraft {
+  return {
+    agentName: "Eliza",
+    runtime: "cloud",
+    localInference: "cloud-inference",
+    remoteApiBase: "",
+    remoteToken: "",
+  };
+}
+
+function ports(): FirstRunFinishPorts {
+  return {
+    uiLanguage: "en",
+    elizaCloudConnected: true,
+    handleCloudLogin: vi.fn(async () => {}),
+    setRuntimeState: vi.fn(),
+    setTab: vi.fn(),
+    completeFirstRun: vi.fn(),
+    onStatus: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+  clientMock.selectOrProvisionCloudAgent.mockResolvedValue({
+    agentId: "cad3c071",
+    apiBase: SHARED_AGENT_BASE,
+    requiresAgentPairing: false,
+    created: false,
+  });
+});
+
+afterEach(() => {
+  clearForceFreshFirstRun();
+  window.localStorage.clear();
+});
+
+describe("bindCloudAgent clears the durable force-fresh flag on completion", () => {
+  it("a shared-agent completion clears force-fresh so the next boot lands in chat, NOT re-onboarding", async () => {
+    // Arrange: force-fresh armed (e.g. a prior ?reset / in-session agent reset)
+    enableForceFreshFirstRun();
+    expect(isForceFreshFirstRunEnabled()).toBe(true);
+
+    // Act: complete onboarding against a SHARED cloud agent base (skips the
+    // /api/first-run POST — the historically-uncovered clear path).
+    const outcome = await bindCloudAgent(
+      draft(),
+      "steward-token",
+      {},
+      ports(),
+    );
+
+    // Assert: onboarding completed AND the durable directive is cleared, so a
+    // subsequent cold boot / PWA relaunch does NOT re-run the force-fresh
+    // consume that re-onboards a returning user.
+    expect(outcome.kind).toBe("done");
+    expect(isForceFreshFirstRunEnabled()).toBe(false);
+    // The shared-agent path must NOT POST /api/first-run.
+    expect(clientMock.submitFirstRun).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op-safe clear when force-fresh was never armed (idempotent)", async () => {
+    expect(isForceFreshFirstRunEnabled()).toBe(false);
+    const outcome = await bindCloudAgent(
+      draft(),
+      "steward-token",
+      {},
+      ports(),
+    );
+    expect(outcome.kind).toBe("done");
+    expect(isForceFreshFirstRunEnabled()).toBe(false);
+  });
+});

--- a/packages/ui/src/first-run/first-run-finish.ts
+++ b/packages/ui/src/first-run/first-run-finish.ts
@@ -25,6 +25,7 @@ import { savePendingCloudHandoff } from "../cloud/handoff/pending-handoff-store"
 import { runCloudAgentHandoff } from "../cloud/handoff/run-cloud-agent-handoff";
 import { getBootConfig } from "../config/boot-config";
 import type { UiLanguage } from "../i18n";
+import { clearForceFreshFirstRun } from "../platform/first-run-reset";
 import { isAndroid, isDesktopPlatform, isIOS } from "../platform/init";
 import {
   addAgentProfile,
@@ -525,6 +526,19 @@ export async function bindCloudAgent(
   if (supportsFullAppShellRoutes(cloudAgentApiBase)) {
     await persistFirstRun(plan, ports);
   }
+  // A shared/dedicated cloud agent SKIPS persistFirstRun above, so it never
+  // reaches the `client.submitFirstRun` call that clears the durable
+  // force-fresh flag via the reset client patch. Without clearing it here, a
+  // user who onboarded through the escape hatch (`?reset` / a prior in-session
+  // agent reset that armed force-fresh) completes a shared-agent onboarding but
+  // leaves `elizaos:first-run:force-fresh` armed — so the NEXT cold boot /
+  // PWA relaunch re-runs the restore-phase force-fresh consume
+  // (savePersistedFirstRunComplete(false) + clear active server) and bounces
+  // the returning user back into "Setting up your agent…" even though their
+  // agent is healthy and running. Clear it on the cloud completion path too so
+  // "completion clears force-fresh" holds for EVERY runtime (idempotent — the
+  // app-shell path's submitFirstRun already cleared it above).
+  clearForceFreshFirstRun();
   clearPersistedFirstRunState();
   ports.onStatus?.(null);
   ports.completeFirstRun("chat");


### PR DESCRIPTION
Fixes #15379.

## Problem

The cloud PWA re-enters onboarding ("Setting up your agent… shared again") for a **returning user who already completed onboarding and has a healthy running agent**, after a new build deploys / the PWA relaunches. Server-side is clean at the moment of the repro (agent `status=running`, `canRespond:true`, no new provisioning jobs, no new agents) — a pure **client** regression.

Live repro (staging.elizacloud.ai, installed iOS PWA, 2026-07-07): completed the golden path against shared agent `cad3c071` → chat working → ~45 min later staging redeployed → PWA "went back to setting up… shared again". Server verified clean at that moment.

## Root cause

`elizaos:first-run:force-fresh` is a durable **one-shot "re-run onboarding on next boot"** directive (armed by the `?reset` escape hatch or an in-session agent reset via `enableForceFreshFirstRun`). `runRestoringSession` consumes it by forcing `savePersistedFirstRunComplete(false)` + clearing the active server, so a boot with the flag set legitimately re-onboards. It's meant to be **cleared the moment onboarding completes**.

For the **app-shell** runtime (local / dedicated container) the clear happens inside `client.submitFirstRun` (the reset client-patch clears force-fresh on the `POST /api/first-run`).

But a **shared / direct cloud agent base** (`.../api/v1/eliza/agents/<id>`) does not own `/api/first-run`, so `bindCloudAgent` **skips `persistFirstRun`** (`supportsFullAppShellRoutes(cloudAgentApiBase)` is false) and never reaches the `submitFirstRun` clear. A user who onboarded a shared cloud agent while force-fresh was armed completed onboarding with the flag **still set** — so the next cold boot / PWA relaunch re-ran the force-fresh consume and bounced them back into "Setting up your agent…" against a healthy running agent. The redeploy is the trigger that forced the relaunch where the still-armed flag was re-consumed.

The invariant **"completion clears force-fresh"** was violated for the shared/dedicated cloud runtime — the exact path the staging golden path takes.

## Fix

Clear `force-fresh` on the cloud completion path (`bindCloudAgent`, right before `completeFirstRun("chat")`), so the invariant holds for **every** runtime. Idempotent — the app-shell path's `submitFirstRun` already clears it.

```
+  clearForceFreshFirstRun();
   clearPersistedFirstRunState();
   ports.onStatus?.(null);
   ports.completeFirstRun("chat");
```

Minimal diff: +1 import, +1 call, + a comment explaining why. No behavior change for the app-shell path (already cleared).

## Regression test

`packages/ui/src/first-run/first-run-finish.force-fresh.test.ts` drives the **real** `bindCloudAgent` against a shared-agent base with force-fresh armed and asserts:
1. onboarding completes (`outcome.kind === "done"`),
2. `isForceFreshFirstRunEnabled()` is `false` after completion,
3. `submitFirstRun` was NOT called (shared agent doesn't POST).

**Reproduces in a unit test:** verified RED without the fix (flag stays armed → next boot re-onboards) and GREEN with it.

```
✓ src/first-run/first-run-finish.force-fresh.test.ts (2 tests)
✓ src/first-run/use-first-run-conductor.test.ts (54 tests)
✓ src/platform/onboarding-replay.test.ts (7 tests)
✓ src/state/first-run-completion-persist.test.tsx (9 tests)
```

Failure mode #10 of the #15310 provisioning-hardening umbrella (client half).

Note: `codex review` could not complete on the build VPS (repeatedly hung/OOM on the full worktree — a known constraint noted in the repo's tooling). The change is 14 lines, self-reviewed line-by-line, and RED/GREEN-verified.

[sol-cloud]


<!-- evidence-row:before-screenshots -->
- [ ] N/A - no rendered component, layout, CSS, or visual surface changed; this is a first-run completion state cleanup for an existing flow.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - no rendered component, layout, CSS, or visual surface changed; the expected result is the existing chat surface instead of re-entering onboarding.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no live installed-PWA walkthrough was captured in this PR body; the behavioral proof here is the focused RED/GREEN unit regression for the force-fresh shared-agent completion path.

<!-- evidence-row:backend-logs -->
- [ ] N/A - client-side localStorage/first-run state change only; no backend code path or deploy log is involved.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser console/network capture was produced; the changed path does not alter network shape and is covered by the listed frontend unit tests.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM prompt, model call, or trajectory is involved.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain artifact is generated; this is first-run state hygiene only.
