### PR TITLE
fix(cloud): coalesce empty-pin rollback ref with || not ?? (follow-up to #15374)

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-create-idempotency.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-create-idempotency.test.ts
@@ -65,7 +65,7 @@ mock.module("@/lib/auth/workers-hono-auth", () => ({
   requireUserOrApiKeyWithOrg,
 }));
 
-// Mirror the real exported error so the route's `instanceof` check works.
+// Mirror the real exported errors so the route's `instanceof` checks work.
 class AgentQuotaExceededError extends Error {
   readonly count: number;
   readonly max: number;
@@ -79,9 +79,21 @@ class AgentQuotaExceededError extends Error {
   }
 }
 
+class AgentImageNotAllowedError extends Error {
+  readonly image: string;
+  readonly reason: "not_allowlisted" | "not_digest_pinned";
+  constructor(image: string, reason: "not_allowlisted" | "not_digest_pinned") {
+    super(`Docker image '${image}' is not allowed.`);
+    this.name = "AgentImageNotAllowedError";
+    this.image = image;
+    this.reason = reason;
+  }
+}
+
 mock.module("@/lib/services/eliza-sandbox", () => ({
   elizaSandboxService: { createAgent, updateAgentEnvironment, listAgents },
   AgentQuotaExceededError,
+  AgentImageNotAllowedError,
 }));
 
 mock.module("@/lib/services/provisioning-jobs", () => ({

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -3396,6 +3396,7 @@ describe("ElizaSandboxService.executeUpgrade blue/green rollback + CAS guard (LA
     expect(res.success).toBe(true);
     expect(executedSql).toBeDefined();
     expect(sqlBoundParams(executedSql)).toContain(TO_DIGEST);
+    expect(sqlBoundParams(executedSql)).toContain(DOCKER_IMAGE);
   });
 
   test("(e2) same-repo different-tag pin → CAS admits, swap proceeds (#15358)", async () => {
@@ -3541,9 +3542,9 @@ describe("ElizaSandboxService.executeDowngrade rollback onto previous_image_dige
     }
   });
 
-  test("happy path → restores pre-upgrade snapshot then swaps back onto PREV_DIGEST + clears prior columns", async () => {
+  test("happy path with empty persisted image ref → restores pre-upgrade snapshot then swaps back onto PREV_DIGEST", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
-    const agent = upgradedAgentRow();
+    const agent: AgentSandbox = { ...upgradedAgentRow(), previous_docker_image: "" };
     const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(agent);
     const nodeSpy = spyOn(dockerNodesRepository, "findByNodeId").mockResolvedValue(curNode());
     // The pre-upgrade restore point + its reconstruction.
@@ -3608,6 +3609,9 @@ describe("ElizaSandboxService.executeDowngrade rollback onto previous_image_dige
       expect(params).toContain("sandbox-rb-1");
       expect(params).toContain("node-rb");
       expect(params).toContain(PREV_DIGEST); // image_digest := previous
+      expect(create.mock.calls[0]?.[0]).toMatchObject({
+        dockerImage: `ghcr.io/elizaos/eliza-agent@${PREV_DIGEST}`,
+      });
       expect(create).toHaveBeenCalledTimes(1);
       expect(checkHealth).toHaveBeenCalledTimes(1);
       // The old (post-upgrade) container is torn down; blue stays.

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -5179,7 +5179,7 @@ export class ElizaSandboxService {
             headscale_ip = ${blueMeta.headscaleIp ?? null},
             image_digest = ${toDigest},
             previous_image_digest = ${fromDigest},
-            previous_docker_image = ${current.docker_image ?? dockerImage},
+            previous_docker_image = ${current.docker_image || dockerImage},
             error_message = NULL,
             last_heartbeat_at = NOW(),
             updated_at = NOW()
@@ -5332,7 +5332,7 @@ export class ElizaSandboxService {
       };
     }
 
-    const rollbackImage = agent.previous_docker_image ?? dockerImage;
+    const rollbackImage = agent.previous_docker_image || dockerImage;
     // Materialize at-rest-encrypted BYO secrets before container create (#11332).
     const rollbackEnv = await decryptAgentEnvVars(
       (agent.environment_vars as Record<string, string>) ?? {},


### PR DESCRIPTION
Standalone re-file of review nit **N1** from #15358/#15374 — #15374 auto-merged before the nit push landed on its branch, so this carries it.

Empty `docker_image` (`""`) is not caught by `??`. So an empty-pin agent's `previous_docker_image` was persisted as `""` (eliza-sandbox.ts:5182) and a later fleet-rollback computed `agent.previous_docker_image ?? dockerImage` = `""` (:5335) → `digestPinnedImageRef("", …)` builds a malformed `@sha256:…` ref → `provider.create` fails. Both sites now use `||` so empty coalesces to the target digest. Contained (control-plane fleet-rollback path only; owner downgrade route already 409s on empty pin). Biome clean; focused eliza-sandbox regression test and cloud shared typecheck pass locally. — [qa-agent]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend/control-plane rollback reference coalescing only; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend/control-plane rollback reference coalescing only; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only two-line rollback path fix; no browser walkthrough applies.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no live backend deploy or rollback execution was run from this PR; behavior is covered by code inspection plus CI on the focused diff.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code, console behavior, or browser network flow changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no LLM prompt, model call, or trajectory is involved.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no domain artifact is generated; this is rollback image-ref hygiene only.

