### PR TITLE
fix(ui): revert warm ember dark palette to neutral black — reads as brown on device

### DIFF
--- a/packages/ui/src/cloud-ui/components/drawer.tsx
+++ b/packages/ui/src/cloud-ui/components/drawer.tsx
@@ -67,7 +67,7 @@ function DrawerContent({
         data-slot="drawer-content"
         className={cn(
           // SOLID warm-dark surface so the sheet is fully opaque over the field
-          // (no see-through). `bg-card` resolves to --surface-1 (#1d130c) in the
+          // (no see-through). `bg-card` resolves to --surface-1 (--surface-1) in the
           // dark theme — same value, now a token instead of a hardcode.
           //
           // min-h-0 is load-bearing: it lets a `DrawerBody` flex child shrink

--- a/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-home-screen-e2e.mjs
@@ -185,7 +185,7 @@ const stubElizaCore = {
 // fixture loads no app CSS, so the handful of brand vars the home widgets read
 // must be declared inline.
 const headHtml = `<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
-<style>:root{--eliza-continuous-chat-clearance:5.25rem;--safe-area-bottom:0px;--eliza-mobile-nav-offset:0px;--brand-white:#fdfaf7;--brand-black:#140c07;--brand-orange:#ff6a1f}</style>`;
+<style>:root{--eliza-continuous-chat-clearance:5.25rem;--safe-area-bottom:0px;--eliza-mobile-nav-offset:0px;--brand-white:#fdfaf7;--brand-black:#000000;--brand-orange:#ff6a1f}</style>`;
 const url = await writeFixturePage({
   entry: join(here, "home-screen-fixture.tsx"),
   outDir,

--- a/packages/ui/src/styles/base.css
+++ b/packages/ui/src/styles/base.css
@@ -6,10 +6,10 @@
   /* Brand accent: warm orange (#ff6a1f). The prior #ff8a24 skewed yellow; this
      is the locked Sol accent. */
   --brand-orange: #ff6a1f;
-  /* No pure black anywhere. The brand near-black is a deep warm brown-black so
-     every dark surface carries a hint of ember warmth (pure #000 reads cold and
-     cheap, and never appears in the 2am editorial reference). */
-  --brand-black: #140c07;
+  /* True black canvas. A warm-tinted near-black (#140c07) was tried here and
+     read as brown on OLED at device brightness (owner-reverted 2026-07-07).
+     Warmth belongs in accents/gradients, never the base surface token. */
+  --brand-black: #000000;
   --brand-white: #fdfaf7;
   --brand-gray: #d1d0d4;
   --sky-0: rgba(0, 0, 0, 0.6);
@@ -190,14 +190,13 @@
   --bg-hover: rgba(255, 255, 255, 0.08);
   --bg-muted: rgba(255, 255, 255, 0.06);
 
-  /* Warm-dark SOLID surfaces. The home/chat float over a warm ember field, so a
-     translucent-black card let the field bleed through (the #1 "too
-     transparent" complaint). These are opaque warm near-blacks: an elevated
-     card tone and a hair-lighter raised tone, each tinted toward the ember so
-     they sit in the world instead of punching a cold hole in it. */
-  --surface-1: #1d130c;
-  --surface-2: #251810;
-  --surface-3: #2f1f15;
+  /* SOLID dark surfaces. Opaque (translucent-black cards let the background
+     bleed through — the #1 "too transparent" complaint) and NEUTRAL: the warm
+     ember near-blacks (#1d130c/#251810/#2f1f15) read as brown on OLED at
+     device brightness (owner-reverted 2026-07-07). */
+  --surface-1: #121212;
+  --surface-2: #1a1a1a;
+  --surface-3: #242424;
   --card: var(--surface-1);
   --card-foreground: var(--brand-white);
   --surface: rgba(255, 255, 255, 0.06);
@@ -206,10 +205,8 @@
   --text-strong: var(--brand-white);
   --chat-text: var(--brand-white);
   --txt: var(--text);
-  /* Warm-tinted muted text (toward the brand hue) reads richer than flat white
-     alpha on a warm-dark field. */
-  --muted: rgba(255, 240, 230, 0.56);
-  --muted-strong: rgba(255, 244, 236, 0.76);
+  --muted: rgba(255, 255, 255, 0.56);
+  --muted-strong: rgba(255, 255, 255, 0.76);
 
   /* shadcn token aliases */
   --foreground: var(--text);

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -4,7 +4,7 @@
      palette is black + white + orange accent only. */
   --brand-blue: rgba(0, 0, 0, 0.6);
   --brand-orange: #ff6a1f;
-  --brand-black: #140c07;
+  --brand-black: #000000;
   --brand-white: #fdfaf7;
   --sky-0: rgba(0, 0, 0, 0.8);
   --sky-1: rgba(0, 0, 0, 0.6);
@@ -64,22 +64,22 @@
   --bg-elevated: rgba(255, 255, 255, 0.04);
   --bg-hover: rgba(255, 255, 255, 0.08);
   --bg-muted: rgba(255, 255, 255, 0.06);
-  --surface-1: #1d130c;
-  --surface-2: #251810;
-  --surface-3: #2f1f15;
+  --surface-1: #121212;
+  --surface-2: #1a1a1a;
+  --surface-3: #242424;
   --card: var(--surface-1);
   --card-foreground: var(--brand-white);
   --surface: rgba(255, 255, 255, 0.06);
   --text: var(--brand-white);
   --text-strong: var(--brand-white);
   --txt: var(--text);
-  --muted: rgba(255, 240, 230, 0.56);
-  --muted-strong: rgba(255, 244, 236, 0.76);
+  --muted: rgba(255, 255, 255, 0.56);
+  --muted-strong: rgba(255, 255, 255, 0.76);
   --border: rgba(255, 255, 255, 0.12);
   --border-strong: rgba(255, 255, 255, 0.22);
-  /* Modal/drawer scrim: brand black at a fixed dim so an open sheet reads as a
-     genuine backdrop (never off-palette "ember" rgba). */
-  --scrim: rgba(20, 12, 7, 0.72);
+  /* Modal/drawer scrim: neutral black at a fixed dim so an open sheet reads as
+     a genuine backdrop (warm rgb(20,12,7) cast a brown tint — owner-reverted). */
+  --scrim: rgba(0, 0, 0, 0.72);
   --accent: var(--brand-orange);
   --accent-rgb: 255, 106, 31;
   --accent-foreground: var(--brand-white);


### PR DESCRIPTION
## Problem
The #15178 token pass introduced a warm 'ember' dark palette: `--brand-black: #140c07`, warm solid surfaces (`#1d130c/#251810/#2f1f15`), warm-tinted muted text, and a warm scrim in theme.css. Design intent was 'no pure black anywhere'; on real hardware (installed iOS PWA, OLED, device brightness) the warm field reads as **brown bleeding into every dark surface**. Owner-reported and owner-directed revert (wakesync, #cc-eliza-2, 2026-07-07 15:08 MDT: 'ok yea lets make it black again').

It also visibly clashed with the default shader background, which is pure `#000000` (e1b9f3f1cbe), so the current state was internally inconsistent regardless of taste.

## Change (tokens only, 4 files)
- `--brand-black`: `#140c07` → `#000000` (theme.css, base.css, e2e fixture mirror)
- dark solid surfaces: `#1d130c/#251810/#2f1f15` → neutral `#121212/#1a1a1a/#242424` (kept OPAQUE — the anti-see-through fix from #15178 is preserved, only the hue is neutralized)
- muted text: warm `rgba(255,240,230/244,236)` alphas → neutral white alphas
- theme.css scrim: `rgba(20,12,7,.72)` → `rgba(0,0,0,.72)` (base.css scrim was already neutral, with a comment explaining the brown-cast problem — this finishes the job)
- drawer.tsx: comment-only update (referenced the old hex)

Warmth stays in the accent layer (`#ff6a1f` orange untouched). No layout, geometry, or component changes — the viewport/keyboard work from #15178 is untouched.

## Verification
- `background-catalog.test.ts` 10/10 pass
- `cloud-settings-theme-tokens.test.ts` 2/2 pass
- biome clean on all touched files
- grep: zero remaining `140c07/1d130c/251810/2f1f15/rgba(20,12,7)` outside explanatory comments
- `settings-section-tokens.test.ts` fails identically on pristine develop (missing worktree codegen artifact) — pre-existing, unrelated

[sol-cloud]

Co-authored-by: wakesync <shadow@shad0w.xyz>

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15388-before-home-mobile-desktop.jpg)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15388-after-home-mobile-desktop.jpg)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/15388-mobile-launcher-flow.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - UI token-only change; no backend route or server behavior changed.

<!-- evidence-row:frontend-logs -->
- [x] [15388-home-screen-browser-log.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15388-home-screen-browser-log.txt)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - No agent, action, prompt, or model behavior changed; CSS token-only UI surface.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - No DB, memory, scheduled task, or domain artifact is produced by this visual token-only change.

<!-- evidence-row:ocr-review -->
- [x] [15388-ocr-manual-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15388-ocr-manual-review.txt)
