### PR TITLE
fix(ci): resolve @elizaos/core from source in cloud e2e migrate + fixture bundles

### DIFF
--- a/packages/cloud/shared/package.json
+++ b/packages/cloud/shared/package.json
@@ -35,7 +35,7 @@
     "preflight:messaging-gateways:strict": "node scripts/messaging-gateway-preflight.mjs --strict",
     "db:check-migrations": "drizzle-kit check",
     "db:generate": "drizzle-kit generate",
-    "db:migrate": "bun run ../../../packages/scripts/cloud/admin/migrate-with-diagnostics.ts",
+    "db:migrate": "bun --conditions=eliza-source ../../../packages/scripts/cloud/admin/migrate-with-diagnostics.ts",
     "db:migrate:drizzle": "drizzle-kit migrate",
     "db:studio": "drizzle-kit studio",
     "pglite:server": "bun run ../../../packages/scripts/cloud/admin/dev/pglite-server.ts",

--- a/packages/ui/src/cloud/applications/__e2e__/run-frontend-hosting-e2e.mjs
+++ b/packages/ui/src/cloud/applications/__e2e__/run-frontend-hosting-e2e.mjs
@@ -56,8 +56,17 @@ function assert(cond, msg) {
 // ---------------------------------------------------------------------------
 
 const pgdata = mkdtempSync(join(tmpdir(), "w3-hosting-visual-pg-"));
+// Resolve @elizaos/* from source (no dist build needed in a fresh checkout) so
+// the spawned migrate and cloud-api-hono-dev subprocesses reach plugin-sql's
+// peer dependency on core — same trick as run-slop-removal-e2e.mjs /
+// packages/test/cloud-e2e/playwright.config.ts.
+const bunSourceCondition = "--conditions=eliza-source";
+const bunOptions = process.env.BUN_OPTIONS?.includes(bunSourceCondition)
+  ? process.env.BUN_OPTIONS
+  : `${process.env.BUN_OPTIONS ?? ""} ${bunSourceCondition}`.trim();
 const stackEnv = {
   ...process.env,
+  BUN_OPTIONS: bunOptions,
   MOCK_REDIS: "1",
   DATABASE_URL: `pglite://${pgdata}`,
   API_DEV_PORT: String(API_PORT),
@@ -157,41 +166,159 @@ const cssResult = await postcss([tailwindPostcss()]).process(cssEntry, {
 const css = cssResult.css;
 
 console.log("== bundle fixture ==");
-// packages/ui/tsconfig.json aliases @elizaos/* → workspace src (the Node
-// graph). Hand esbuild a bare tsconfig so package `exports` "browser"
-// conditions resolve instead (e.g. @elizaos/core → dist/browser).
+// Resolve @elizaos/* from source (fresh checkout has no dist) and self-bundle
+// the shipped dashboard tab for the browser — same recipe as the sibling
+// run-slop-removal-e2e.mjs harness.
 const bareTsconfig = join(outDir, "esbuild-tsconfig.json");
 await writeFile(bareTsconfig, JSON.stringify({ compilerOptions: {} }));
+
+// Under iife, esbuild's __require shim throws at module-eval time for node
+// builtins that never actually run in the browser — stub them all with inert
+// modules (concrete named exports are required: esbuild's CJS interop copies
+// own props).
+const nodeStubPlugin = {
+  name: "node-builtin-stub",
+  setup(pluginBuild) {
+    const filter =
+      /^(node:.*|fs|fs\/promises|dns\/promises|http|https|path|stream|constants|os|crypto|util|assert|events|url|buffer|child_process|tty|module|fs-extra|graceful-fs|jsonfile|worker_threads|zlib|net|tls|dns|readline|v8|vm|perf_hooks|async_hooks|string_decoder|querystring|punycode|domain|dgram|cluster|repl|inspector|trace_events|wasi|diagnostics_channel)$/;
+    pluginBuild.onResolve({ filter }, (args) => ({
+      path: args.path,
+      namespace: "node-stub",
+    }));
+    pluginBuild.onLoad({ filter: /.*/, namespace: "node-stub" }, () => ({
+      contents: `function anyfn() { return anyfn; }
+export default anyfn;
+export const createRequire = () => anyfn;
+export const homedir = anyfn;
+export const tmpdir = anyfn;
+export const platform = anyfn;
+export const isAbsolute = anyfn;
+export const join = anyfn;
+export const resolve = anyfn;
+export const dirname = anyfn;
+export const basename = anyfn;
+export const extname = anyfn;
+export const sep = "/";
+export const createHash = () => ({ update: () => ({ digest: () => "" }) });
+export const randomBytes = anyfn;
+export const randomUUID = () => "00000000-0000-0000-0000-000000000000";
+export const createHmac = () => ({ update: () => ({ digest: () => "" }) });
+export const timingSafeEqual = () => false;
+export const createCipheriv = anyfn;
+export const createDecipheriv = anyfn;
+export const pbkdf2Sync = anyfn;
+export const scryptSync = anyfn;
+export const realpathSync = anyfn;
+export const renameSync = anyfn;
+export const Buffer = {
+  from: () => ({}),
+  isBuffer: () => false,
+  alloc: () => ({}),
+  byteLength: () => 0,
+};
+export const promises = {};
+export const existsSync = () => false;
+export const readFileSync = anyfn;
+export const writeFileSync = anyfn;
+export const mkdirSync = anyfn;
+export const readdirSync = () => [];
+export const statSync = anyfn;
+export const EventEmitter = class {};
+export const fileURLToPath = anyfn;
+export const pathToFileURL = anyfn;
+export const lookup = anyfn;
+export const request = anyfn;
+export const execFile = anyfn;
+export const exec = anyfn;
+export const promisify = () => anyfn;
+export const readFile = anyfn;
+export const readlink = anyfn;
+export const rename = anyfn;
+export const rm = anyfn;
+export const symlink = anyfn;
+export const unlink = anyfn;
+export const writeFile = anyfn;
+export const mkdir = anyfn;
+export const stat = anyfn;
+export const readdir = () => [];
+export const isIP = () => 0;
+export const statfsSync = anyfn;
+export const cp = anyfn;
+export const unlinkSync = anyfn;
+export class AsyncLocalStorage {
+  run(_store, fn, ...args) {
+    return fn(...args);
+  }
+  getStore() {
+    return undefined;
+  }
+}`,
+      loader: "js",
+    }));
+  },
+};
+
+// Not every @elizaos/{shared,ui} subpath export carries the `eliza-source`
+// condition — several map only to dist/, which does not exist in a fresh
+// checkout. Resolve them straight into the package sources.
+const elizaSourceAliasPlugin = {
+  name: "eliza-source-alias",
+  setup(pluginBuild) {
+    pluginBuild.onResolve(
+      { filter: /^@elizaos\/(shared|ui)(\/.*)?$/ },
+      async (args) => {
+        if (args.namespace === "eliza-source-alias") return undefined;
+        const m = args.path.match(/^@elizaos\/(shared|ui)(?:\/(.*))?$/);
+        const pkgSrc = join(repoRoot, "packages", m[1], "src");
+        const sub = m[2] ?? "index";
+        return pluginBuild.resolve(`./${sub}`, {
+          resolveDir: pkgSrc,
+          kind: args.kind,
+          namespace: "eliza-source-alias",
+        });
+      },
+    );
+  },
+};
+
+// Optional wallet-connector deps that wagmi lazily requires but which are not
+// installed (and never execute in this harness) — stub them inert.
+const optionalDepStubPlugin = {
+  name: "optional-dep-stub",
+  setup(pluginBuild) {
+    const filter = /^(@metamask\/connect-evm|@base-org\/account|@safe-global\/safe-apps-sdk|@safe-global\/safe-apps-provider|cbw-sdk|porto(\/.*)?)$/;
+    pluginBuild.onResolve({ filter }, (args) => ({
+      path: args.path,
+      namespace: "optional-dep-stub",
+    }));
+    pluginBuild.onLoad(
+      { filter: /.*/, namespace: "optional-dep-stub" },
+      () => ({
+        contents: "export default {};",
+        loader: "js",
+      }),
+    );
+  },
+};
+
 const bundle = await build({
   entryPoints: [join(here, "frontend-hosting-fixture.tsx")],
   bundle: true,
   format: "iife",
   platform: "browser",
   jsx: "automatic",
-  loader: { ".tsx": "tsx", ".ts": "ts" },
-  define: { "process.env.NODE_ENV": '"production"' },
+  loader: { ".tsx": "tsx", ".ts": "ts", ".css": "empty" },
+  // Resolve @elizaos/* package exports from source — the fresh-checkout dist
+  // does not exist (same condition the cloud-e2e runner passes to bun).
+  conditions: ["eliza-source"],
+  define: {
+    "process.env.NODE_ENV": '"production"',
+    // iife leaves import.meta empty; a few sources read import.meta.env
+    // without optional chaining. Point it at a page-provided empty object.
+    "import.meta.env": "globalThis.__VITE_ENV__",
+  },
   tsconfig: bareTsconfig,
-  // @elizaos/core's browser dist keeps Node deps behind lazy requires that
-  // never execute in the browser; leave them as unbundled externals.
-  external: [
-    "node:*",
-    "fs",
-    "path",
-    "stream",
-    "constants",
-    "os",
-    "crypto",
-    "util",
-    "assert",
-    "events",
-    "url",
-    "buffer",
-    "child_process",
-    "tty",
-    "fs-extra",
-    "graceful-fs",
-    "jsonfile",
-  ],
+  plugins: [elizaSourceAliasPlugin, nodeStubPlugin, optionalDepStubPlugin],
   write: false,
 });
 const js = bundle.outputFiles[0].text;
@@ -202,6 +329,9 @@ const pageHtml = (apiBase) => `<!doctype html><html><head><meta charset="utf-8">
 <style>${css}</style>
 </head><body><div id="root"></div>
 <script>
+  window.global = window;
+  window.__VITE_ENV__ = {};
+  window.process = { env: {}, platform: "browser", cwd: () => "/", versions: {} };
   window.__W3_APP_ID__ = ${JSON.stringify(APP_ID)};
   window.__W3_API_BASE__ = ${JSON.stringify(apiBase)};
   localStorage.setItem("steward_session_token", ${JSON.stringify(KEY)});

--- a/packages/ui/src/cloud/organization/__e2e__/run-credentials-e2e.mjs
+++ b/packages/ui/src/cloud/organization/__e2e__/run-credentials-e2e.mjs
@@ -93,14 +93,29 @@ process.on("exit", () => {
 // ---------------------------------------------------------------------------
 
 const pgdata = mkdtempSync(join(tmpdir(), "credpool-visual-pg-"));
+// Resolve @elizaos/* from source (no dist build needed in a fresh checkout) so
+// the spawned migrate and cloud-api-hono-dev subprocesses reach plugin-sql's
+// peer dependency on core — same trick as run-slop-removal-e2e.mjs /
+// packages/test/cloud-e2e/playwright.config.ts.
+const bunSourceCondition = "--conditions=eliza-source";
+const bunOptions = process.env.BUN_OPTIONS?.includes(bunSourceCondition)
+  ? process.env.BUN_OPTIONS
+  : `${process.env.BUN_OPTIONS ?? ""} ${bunSourceCondition}`.trim();
 const stackEnv = {
   ...process.env,
+  BUN_OPTIONS: bunOptions,
   MOCK_REDIS: "1",
   DATABASE_URL: `pglite://${pgdata}`,
   API_DEV_PORT: String(API_PORT),
   CRON_SECRET: "local-cron-secret",
   ELIZA_KMS_BACKEND: "local",
   ELIZA_LOCAL_ROOT_KEY: Buffer.alloc(32, 7).toString("base64"),
+  // The contribute flow vault-encrypts the key before pooling; the secrets
+  // service refuses to run without a master key (it will not derive the
+  // insecure all-zero key). Provide the same deterministic 32-byte hex the
+  // cloud-e2e fixtures use.
+  SECRETS_MASTER_KEY:
+    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
   ANTHROPIC_BASE_URL: `http://127.0.0.1:${PROVIDER_PORT}/v1`,
   OPENAI_BASE_URL: `http://127.0.0.1:${PROVIDER_PORT}/v1`,
   // The whole walkthrough fires from one API key in seconds, and the
@@ -211,7 +226,7 @@ const nodeStubPlugin = {
   name: "node-builtin-stub",
   setup(pluginBuild) {
     const filter =
-      /^(node:.*|fs|fs\/promises|dns\/promises|http|https|path|stream|constants|os|crypto|util|assert|events|url|buffer|child_process|tty|module|fs-extra|graceful-fs|jsonfile)$/;
+      /^(node:.*|fs|fs\/promises|dns\/promises|http|https|path|stream|constants|os|crypto|util|assert|events|url|buffer|child_process|tty|module|fs-extra|graceful-fs|jsonfile|worker_threads|zlib|net|tls|dns|readline|v8|vm|perf_hooks|async_hooks|string_decoder|querystring|punycode|domain|dgram|cluster|repl|inspector|trace_events|wasi|diagnostics_channel)$/;
     pluginBuild.onResolve({ filter }, (args) => ({
       path: args.path,
       namespace: "node-stub",
@@ -234,6 +249,7 @@ export const extname = anyfn;
 export const sep = "/";
 export const createHash = () => ({ update: () => ({ digest: () => "" }) });
 export const randomBytes = anyfn;
+export const randomUUID = () => "00000000-0000-0000-0000-000000000000";
 export const Buffer = {
   from: () => ({}),
   isBuffer: () => false,
@@ -247,6 +263,9 @@ export const writeFileSync = anyfn;
 export const mkdirSync = anyfn;
 export const readdirSync = () => [];
 export const statSync = anyfn;
+export const realpathSync = anyfn;
+export const renameSync = anyfn;
+export const unlinkSync = anyfn;
 export const EventEmitter = class {};
 export const fileURLToPath = anyfn;
 export const pathToFileURL = anyfn;
@@ -270,9 +289,63 @@ export const unlink = anyfn;
 export const writeFile = anyfn;
 export const mkdir = anyfn;
 export const stat = anyfn;
-export const readdir = () => [];`,
+export const readdir = () => [];
+export const isIP = () => 0;
+export const statfsSync = anyfn;
+export const cp = anyfn;
+export class AsyncLocalStorage {
+  run(_store, fn, ...args) {
+    return fn(...args);
+  }
+  getStore() {
+    return undefined;
+  }
+}`,
       loader: "js",
     }));
+  },
+};
+
+// Not every @elizaos/{shared,ui} subpath export carries the `eliza-source`
+// condition — several map only to dist/, which does not exist in a fresh
+// checkout. Resolve them straight into the package sources.
+const elizaSourceAliasPlugin = {
+  name: "eliza-source-alias",
+  setup(pluginBuild) {
+    pluginBuild.onResolve(
+      { filter: /^@elizaos\/(shared|ui)(\/.*)?$/ },
+      async (args) => {
+        if (args.namespace === "eliza-source-alias") return undefined;
+        const m = args.path.match(/^@elizaos\/(shared|ui)(?:\/(.*))?$/);
+        const pkgSrc = join(repoRoot, "packages", m[1], "src");
+        const sub = m[2] ?? "index";
+        return pluginBuild.resolve(`./${sub}`, {
+          resolveDir: pkgSrc,
+          kind: args.kind,
+          namespace: "eliza-source-alias",
+        });
+      },
+    );
+  },
+};
+
+// Optional wallet-connector deps that wagmi lazily requires but which are not
+// installed (and never execute in this harness) — stub them inert.
+const optionalDepStubPlugin = {
+  name: "optional-dep-stub",
+  setup(pluginBuild) {
+    const filter = /^(@metamask\/connect-evm|@base-org\/account|@safe-global\/safe-apps-sdk|@safe-global\/safe-apps-provider|cbw-sdk|porto(\/.*)?)$/;
+    pluginBuild.onResolve({ filter }, (args) => ({
+      path: args.path,
+      namespace: "optional-dep-stub",
+    }));
+    pluginBuild.onLoad(
+      { filter: /.*/, namespace: "optional-dep-stub" },
+      () => ({
+        contents: "export default {};",
+        loader: "js",
+      }),
+    );
   },
 };
 
@@ -282,10 +355,18 @@ const bundle = await build({
   format: "iife",
   platform: "browser",
   jsx: "automatic",
-  loader: { ".tsx": "tsx", ".ts": "ts" },
-  define: { "process.env.NODE_ENV": '"production"' },
+  loader: { ".tsx": "tsx", ".ts": "ts", ".css": "empty" },
+  // Resolve @elizaos/* package exports from source — the fresh-checkout dist
+  // does not exist (same condition the cloud-e2e runner passes to bun).
+  conditions: ["eliza-source"],
+  define: {
+    "process.env.NODE_ENV": '"production"',
+    // iife leaves import.meta empty; a few sources read import.meta.env
+    // without optional chaining. Point it at a page-provided empty object.
+    "import.meta.env": "globalThis.__VITE_ENV__",
+  },
   tsconfig: bareTsconfig,
-  plugins: [nodeStubPlugin],
+  plugins: [elizaSourceAliasPlugin, nodeStubPlugin, optionalDepStubPlugin],
   write: false,
 });
 const js = bundle.outputFiles[0].text;
@@ -297,6 +378,7 @@ const pageHtml = `<!doctype html><html><head><meta charset="utf-8">
 </head><body><div id="root"></div>
 <script>
   window.global = window;
+  window.__VITE_ENV__ = {};
   window.process = { env: {}, platform: "browser", cwd: () => "/", versions: {} };
   localStorage.setItem("steward_session_token", ${JSON.stringify(KEY)});
 </script>


### PR DESCRIPTION
## Problem

The **UI Fixture E2E** workflow (`ui-e2e-gate.yml`) failed at the very first cloud runner (`test:frontend-hosting-e2e`) `db:migrate` step:

```
error: Cannot find module '@elizaos/core' from '.../plugins/plugin-sql/src/index.ts'
error: script "db:migrate" exited with code 1
```

Same `#14459` resolution-condition fallout as the sibling CI stragglers (`#15287` / `#15318` / `#15319` / `#15330` / `#15333`). These three cloud runners (frontend-hosting, credentials, slop-removal) were **added by #14459** and never validated end-to-end — they boot a real mock cloud stack from a fresh checkout with **no dist built**, so every `@elizaos/*` import must resolve to source. The whole workflow was red at the shared migrate step, masking three downstream instances of the same class.

## Root causes & fixes (all the same class)

**1. `db:migrate` (`packages/cloud/shared/package.json`)** — `bun run --cwd packages/cloud/shared db:migrate` loads the cwd tsconfig and applies its `paths` only to files *under* `packages/cloud/shared`. `@elizaos/plugin-sql` resolved to source, but plugin-sql's own `import "@elizaos/core"` (a file outside that dir) fell through to `node_modules` → unbuilt dist → not found. Pass `--conditions=eliza-source` (exactly what the root `db:cloud:migrate` script already does) so package `exports` resolve to source from **any** file. Fixes migrate for every caller (the 3 UI cloud runners, cloud-e2e stack, mock-stack-up).

**2. cloud-api-hono-dev boot** — `run-frontend-hosting-e2e` and `run-credentials-e2e` built `stackEnv` **without** the `BUN_OPTIONS=--conditions=eliza-source` that `run-slop-removal-e2e` already carries, so the spawned cloud-api hit the same wall one step later. Inject it (same recipe as `packages/test/cloud-e2e/src/fixtures/env.ts`).

**3. esbuild fixture bundle** — both runners resolved `@elizaos/*` via the *browser dist* condition (which does not exist here). Switch to the proven source recipe already in `run-slop-removal-e2e`: `conditions: ["eliza-source"]`, the node-builtin stub, the `@elizaos/{shared,ui}` source-alias plugin, and the optional-dep stub. Also stub the three node exports `packages/core/src/utils/project-registry.ts` pulls in (`randomUUID` / `realpathSync` / `renameSync`).

**Credentials also needed `SECRETS_MASTER_KEY`** — the contribute flow vault-encrypts the key, and the secrets service refuses to derive the insecure all-zero key (`ALLOW_INSECURE_DEV_KMS`). Provide the same deterministic 32-byte hex the cloud-e2e fixtures use.

## Validation (local)

- `test:frontend-hosting-e2e` → **ALL GREEN** (full publish → live → v2 → rollback → delete → mobile → cloud-inactive → retry lifecycle; #10725 aesthetic gates pass).
- `test:credentials-e2e` → **ALL GREEN** (contribute probe-fail + probe-pass with real vault encryption → masked list → invite → connect landing → remove → empty).
- `test:background-e2e` (non-cloud self-bundling runner) spot-checked green — the #14459 fallout is scoped to the cloud-stack runners.
- `bun run audit:error-policy-ratchet` clean; biome clean.

## Out of scope (flagged)

`test:slop-removal-e2e` (the 3rd cloud runner in this workflow, also #14459) has the **same** resolution stub gap **plus** a deeper, unrelated failure: after the bundle is fixed it reaches leg-1 and `CloudRouterShell` renders an "Overview" view instead of redirecting `/dashboard/*` → `/settings#<section>` and mounting the fixture's `CatchAllProbe` (`probe-location` never appears). That is a product/test integration issue, not a resolution/mock/alias straggler, and needs a dedicated fix — left untouched here rather than shipping a half-fixed red suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)