### PR TITLE
fix(ui): self-heal stale console lazy chunks after a deploy (#15383)

### DIFF
--- a/packages/ui/src/cloud/shell/CloudRouteErrorBoundary.test.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouteErrorBoundary.test.tsx
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+
+/**
+ * CloudRouteErrorBoundary: post-deploy stale-chunk self-heal for console
+ * routes (#15383). Pins the recovery contract both ways — a chunk-load error
+ * triggers exactly ONE cooldown-guarded reload (timestamped marker in
+ * sessionStorage), a second chunk failure inside the cooldown does NOT reload
+ * (manual Reload card instead), a lapsed cooldown re-arms one more attempt,
+ * and a non-chunk render crash degrades to the Retry card with zero reloads
+ * and the marker untouched. Also covers the steward-runtime lazy mount
+ * (StewardAuthProvider) being wrapped by this boundary, so a stale `@stwd/*`
+ * runtime chunk self-heals instead of escaping to the app-root boundary.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The steward-runtime coverage case needs a valid Steward URL (an invalid one
+// short-circuits to the config-error card before the lazy chunk ever loads).
+vi.mock("./steward-url", () => ({
+  resolveBrowserStewardApiUrl: () => "https://api.elizacloud.ai/steward",
+}));
+
+// Simulate the #15383 failure for the steward runtime: after a mid-session
+// deploy the lazy `@stwd/*` chunk 404s and the dynamic import rejects with the
+// browser's chunk-fetch error; React surfaces that rejection by throwing it
+// while rendering the lazy component under the Suspense, so a default export
+// that throws the same error models what the boundary sees. (A throwing mock
+// FACTORY can't — vitest wraps factory errors in its own message, which would
+// defeat isChunkLoadError.)
+vi.mock("./StewardProviderRuntime", () => ({
+  default: () => {
+    throw new Error(
+      "Failed to fetch dynamically imported module: https://elizacloud.ai/assets/StewardProviderRuntime-CvR8b1x2.js",
+    );
+  },
+}));
+
+import { CloudRouteErrorBoundary } from "./CloudRouteErrorBoundary";
+import { StewardAuthProvider } from "./StewardProvider";
+
+/** Must match CHUNK_RELOAD_AT_KEY in utils/chunk-load-recovery.ts. */
+const RELOAD_MARKER_KEY = "eliza:chunk-reload-attempted-at";
+const COOLDOWN_MS = 5 * 60 * 1000;
+
+const CHUNK_ERROR_MESSAGE =
+  "Failed to fetch dynamically imported module: https://elizacloud.ai/assets/BillingPage-Bx1v9qQ3.js";
+
+function ChunkBoom(): React.JSX.Element {
+  throw new Error(CHUNK_ERROR_MESSAGE);
+}
+
+function PlainBoom(): React.JSX.Element {
+  throw new Error("kaboom");
+}
+
+let reloadSpy: ReturnType<typeof vi.fn>;
+const originalLocation = window.location;
+
+beforeEach(() => {
+  window.sessionStorage.clear();
+  reloadSpy = vi.fn();
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { ...originalLocation, reload: reloadSpy },
+  });
+  // jsdom logs the caught render error; silence the noise for a clean run.
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: originalLocation,
+  });
+  vi.restoreAllMocks();
+});
+
+describe("CloudRouteErrorBoundary — chunk-load recovery", () => {
+  it("reloads exactly once on a chunk-load error and stamps the cooldown marker", () => {
+    render(
+      <CloudRouteErrorBoundary routePath="dashboard/billing">
+        <ChunkBoom />
+      </CloudRouteErrorBoundary>,
+    );
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    const marker = Number(window.sessionStorage.getItem(RELOAD_MARKER_KEY));
+    // Timestamped (not a latched boolean) so a LATER deploy in the same
+    // session can auto-heal again after the cooldown lapses.
+    expect(marker).toBeGreaterThan(0);
+    expect(Date.now() - marker).toBeLessThan(COOLDOWN_MS);
+  });
+
+  it("does NOT auto-reload again inside the cooldown: shows the manual Reload card", () => {
+    // A recovery attempt already happened moments ago (marker = now).
+    window.sessionStorage.setItem(RELOAD_MARKER_KEY, String(Date.now()));
+
+    render(
+      <CloudRouteErrorBoundary routePath="dashboard/billing">
+        <ChunkBoom />
+      </CloudRouteErrorBoundary>,
+    );
+
+    // No reload loop: the budget is spent, so the failure degrades to the
+    // designed card with an explicit user-initiated Reload affordance.
+    expect(reloadSpy).not.toHaveBeenCalled();
+    expect(screen.getByTestId("cloud-route-error-fallback")).toBeTruthy();
+    const reloadButton = screen.getByTestId("cloud-route-error-reload");
+    expect(reloadButton.textContent).toContain("Reload");
+
+    fireEvent.click(reloadButton);
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows one more auto-reload after the cooldown lapses", () => {
+    const staleAttempt = Date.now() - (COOLDOWN_MS + 60_000);
+    window.sessionStorage.setItem(RELOAD_MARKER_KEY, String(staleAttempt));
+
+    render(
+      <CloudRouteErrorBoundary routePath="dashboard/billing">
+        <ChunkBoom />
+      </CloudRouteErrorBoundary>,
+    );
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    // The marker was re-stamped for the new attempt window.
+    const marker = Number(window.sessionStorage.getItem(RELOAD_MARKER_KEY));
+    expect(marker).toBeGreaterThan(staleAttempt);
+  });
+
+  it("shows the Retry card for a NON-chunk render error: zero reloads, marker untouched", () => {
+    render(
+      <CloudRouteErrorBoundary routePath="dashboard/billing">
+        <PlainBoom />
+      </CloudRouteErrorBoundary>,
+    );
+
+    expect(reloadSpy).not.toHaveBeenCalled();
+    expect(window.sessionStorage.getItem(RELOAD_MARKER_KEY)).toBeNull();
+    const card = screen.getByTestId("cloud-route-error-fallback");
+    expect(card.textContent).toContain("kaboom");
+    expect(screen.getByTestId("cloud-route-error-retry")).toBeTruthy();
+    expect(screen.queryByTestId("cloud-route-error-reload")).toBeNull();
+  });
+
+  it("Retry remounts the subtree and recovers once the child no longer throws", () => {
+    function Recoverable({ crash }: { crash: boolean }): React.JSX.Element {
+      if (crash) throw new Error("kaboom");
+      return <div data-testid="recovered">recovered ok</div>;
+    }
+    function Harness(): React.JSX.Element {
+      const [crash, setCrash] = useState(true);
+      return (
+        <div>
+          <button
+            type="button"
+            data-testid="fix-child"
+            onClick={() => setCrash(false)}
+          >
+            fix
+          </button>
+          <CloudRouteErrorBoundary routePath="dashboard/billing">
+            <Recoverable crash={crash} />
+          </CloudRouteErrorBoundary>
+        </div>
+      );
+    }
+
+    render(<Harness />);
+    expect(screen.getByTestId("cloud-route-error-fallback")).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("fix-child"));
+    fireEvent.click(screen.getByTestId("cloud-route-error-retry"));
+
+    expect(screen.getByTestId("recovered")).toBeTruthy();
+    expect(screen.queryByTestId("cloud-route-error-fallback")).toBeNull();
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("StewardAuthProvider — steward-runtime chunk failures self-heal (D2)", () => {
+  function renderDashboard() {
+    return render(
+      <MemoryRouter initialEntries={["/dashboard/billing"]}>
+        <StewardAuthProvider>
+          <div data-testid="protected-child" />
+        </StewardAuthProvider>
+      </MemoryRouter>,
+    );
+  }
+
+  it("catches a stale steward-runtime chunk and fires the one-shot reload recovery", async () => {
+    renderDashboard();
+
+    // The lazy import rejection must be caught by the boundary WRAPPING the
+    // Suspense — not escape to (a nonexistent) app-root handler — and hand off
+    // to the shared reload recovery.
+    expect(
+      await screen.findByTestId("cloud-route-error-fallback"),
+    ).toBeTruthy();
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    expect(
+      Number(window.sessionStorage.getItem(RELOAD_MARKER_KEY)),
+    ).toBeGreaterThan(0);
+  });
+
+  it("degrades to the manual Reload card when the steward chunk fails inside the cooldown", async () => {
+    window.sessionStorage.setItem(RELOAD_MARKER_KEY, String(Date.now()));
+
+    renderDashboard();
+
+    expect(await screen.findByTestId("cloud-route-error-reload")).toBeTruthy();
+    expect(reloadSpy).not.toHaveBeenCalled();
+    // The auth-consuming children never render without the provider.
+    expect(screen.queryByTestId("protected-child")).toBeNull();
+  });
+});

--- a/packages/ui/src/cloud/shell/CloudRouteErrorBoundary.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouteErrorBoundary.tsx
@@ -1,0 +1,140 @@
+/**
+ * Per-route crash container for the cloud console's registered routes.
+ *
+ * Every console page (Overview / Agents / Billing / API Keys / Account, …) is
+ * a `React.lazy` chunk mounted by `CloudRouterShell`. After a Pages deploy the
+ * running shell still references ITS build's hashed assets, so navigating to a
+ * not-yet-visited page rejects with "Failed to fetch dynamically imported
+ * module" (#15383). Without a boundary here that rejection escaped past the
+ * route `<Suspense>` to the app-root `ErrorBoundary` in `packages/app`, which
+ * has no chunk recovery — the whole console blanked into a generic crash card
+ * until a manual hard refresh.
+ *
+ * This mirrors `components/views/ViewErrorBoundary`: a chunk-load error hands
+ * off to the SHARED one-shot reload recovery (`utils/chunk-load-recovery`,
+ * timestamped 5-min cooldown — never a reload loop); anything else degrades to
+ * a themed error card while the console chrome (sidebar/top bar) stays
+ * mounted. It stays deliberately thinner than ViewErrorBoundary because the
+ * view-lifecycle controller and view-runtime telemetry are app-shell-only
+ * machinery — console routes have no viewId to feed them.
+ */
+
+import { logger } from "@elizaos/logger";
+import { useCallback, useRef, useState } from "react";
+import { Button } from "../../components/ui/button";
+import { ErrorBoundary } from "../../components/ui/error-boundary";
+import {
+  isChunkLoadError,
+  tryChunkReloadRecovery,
+} from "../../utils/chunk-load-recovery";
+
+export interface CloudRouteErrorBoundaryProps {
+  /** Registered route path (e.g. `"dashboard/billing"`), used for keying + logs. */
+  routePath: string;
+  children: React.ReactNode;
+}
+
+function CloudRouteErrorFallback({
+  error,
+  onRetry,
+}: {
+  error: Error;
+  onRetry: () => void;
+}): React.JSX.Element {
+  // A chunk failure that reaches this card exhausted the auto-reload budget
+  // (or recovery already fired and the page is about to navigate away). A
+  // boundary reset cannot heal it — React.lazy latches the rejected import —
+  // so the affordance is an explicit user-initiated page reload instead of a
+  // remount. User clicks can't loop: each reload boots a fresh shell.
+  const staleChunk = isChunkLoadError(error);
+  return (
+    <div
+      data-testid="cloud-route-error-fallback"
+      className="mx-auto flex min-h-[40vh] max-w-prose flex-col items-center justify-center gap-3 p-8 text-center"
+    >
+      <p className="text-sm font-semibold text-destructive">
+        {staleChunk
+          ? "This page needs a newer version of the console"
+          : "This page ran into a problem"}
+      </p>
+      <p className="max-w-sm break-words font-mono text-[11px] text-muted opacity-70">
+        {error.message}
+      </p>
+      {staleChunk ? (
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="rounded-sm text-xs"
+          onClick={() => window.location.reload()}
+          data-testid="cloud-route-error-reload"
+        >
+          Reload
+        </Button>
+      ) : (
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="rounded-sm text-xs"
+          onClick={onRetry}
+          data-testid="cloud-route-error-retry"
+        >
+          Retry
+        </Button>
+      )}
+    </div>
+  );
+}
+
+export function CloudRouteErrorBoundary({
+  routePath,
+  children,
+}: CloudRouteErrorBoundaryProps): React.JSX.Element {
+  const [recoverKey, setRecoverKey] = useState(0);
+  // Latch the error so the log/recovery fires once per crash, not per render.
+  const reportedError = useRef<Error | null>(null);
+
+  const handleError = useCallback(
+    (error: Error) => {
+      if (reportedError.current === error) return;
+      reportedError.current = error;
+      // Mid-session deploy: this route's lazy chunk is gone from the server.
+      // One shared, cooldown-guarded reload picks up the current build and
+      // heals every route at once; only when the attempt budget is spent does
+      // this fall through to the error card.
+      if (isChunkLoadError(error) && tryChunkReloadRecovery()) {
+        logger.info(
+          `[CloudRouteErrorBoundary] route "${routePath}" hit a stale-deploy chunk failure — reloading to the current build`,
+        );
+        return;
+      }
+      logger.error(
+        `[CloudRouteErrorBoundary] route "${routePath}" crashed: ${error.message}`,
+      );
+    },
+    [routePath],
+  );
+
+  return (
+    // error-policy:J4 explicit user-facing degrade — the route body crashed;
+    // render a designed error card (with recovery affordance) in its slot so
+    // the console chrome stays usable.
+    <ErrorBoundary
+      key={`${routePath}:${recoverKey}`}
+      onError={handleError}
+      fallback={(error, resetErrorBoundary) => (
+        <CloudRouteErrorFallback
+          error={error}
+          onRetry={() => {
+            reportedError.current = null;
+            resetErrorBoundary();
+            setRecoverKey((k) => k + 1);
+          }}
+        />
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/packages/ui/src/cloud/shell/CloudRouterShell.tsx
+++ b/packages/ui/src/cloud/shell/CloudRouterShell.tsx
@@ -20,12 +20,7 @@
  */
 
 import { QueryClientProvider } from "@tanstack/react-query";
-import {
-  type ComponentType,
-  type LazyExoticComponent,
-  type ReactNode,
-  Suspense,
-} from "react";
+import { type ComponentType, type ReactNode, Suspense } from "react";
 import {
   BrowserRouter,
   Navigate,
@@ -41,6 +36,7 @@ import {
   CloudI18nProvider,
   resolveInitialCloudLang,
 } from "./CloudI18nProvider";
+import { CloudRouteErrorBoundary } from "./CloudRouteErrorBoundary";
 import { ConsoleShell } from "./ConsoleShell";
 import {
   type CloudRouteDef,
@@ -123,14 +119,18 @@ function LegacySettingsTabRedirect(): React.JSX.Element {
   return <Navigate to={`${target}${location.search}`} replace />;
 }
 
-function renderRouteElement(
-  element: LazyExoticComponent<ComponentType<unknown>> | ComponentType<unknown>,
-): React.JSX.Element {
-  const RouteComponent = element as ComponentType<unknown>;
+function renderRouteElement(route: CloudRouteDef): React.JSX.Element {
+  const RouteComponent = route.element as ComponentType<unknown>;
   return (
-    <Suspense fallback={<RouteChunkFallback />}>
-      <RouteComponent />
-    </Suspense>
+    // The boundary sits INSIDE the console chrome / auth providers so a route
+    // crash (or a post-deploy stale lazy chunk — see CloudRouteErrorBoundary)
+    // degrades in the page slot instead of escaping to the app-root boundary
+    // and blanking the whole console.
+    <CloudRouteErrorBoundary routePath={route.path}>
+      <Suspense fallback={<RouteChunkFallback />}>
+        <RouteComponent />
+      </Suspense>
+    </CloudRouteErrorBoundary>
   );
 }
 
@@ -221,7 +221,7 @@ function CloudRouteElement({
 }: {
   route: CloudRouteDef;
 }): React.JSX.Element {
-  const body = applyRouteGate(route.gate, renderRouteElement(route.element));
+  const body = applyRouteGate(route.gate, renderRouteElement(route));
   if (route.public) {
     return <>{body}</>;
   }

--- a/packages/ui/src/cloud/shell/StewardProvider.tsx
+++ b/packages/ui/src/cloud/shell/StewardProvider.tsx
@@ -13,6 +13,7 @@
 
 import { lazy, type ReactNode, Suspense, useEffect, useRef } from "react";
 import { useLocation } from "react-router-dom";
+import { CloudRouteErrorBoundary } from "./CloudRouteErrorBoundary";
 import { isPlaceholderValue, readStoredToken } from "./StewardProviderShared";
 import {
   configuredStewardTenantId,
@@ -193,10 +194,20 @@ export function StewardAuthProvider({ children }: { children: ReactNode }) {
   }
 
   return (
-    <Suspense fallback={<StewardRuntimeLoading />}>
-      <StewardAuthRuntimeProvider apiUrl={apiUrl} tenantId={tenantId}>
-        {children}
-      </StewardAuthRuntimeProvider>
-    </Suspense>
+    // The boundary sits OUTSIDE the Suspense that awaits the lazy `@stwd/*`
+    // runtime chunk: after a mid-session deploy the first authenticated
+    // navigation rejects this import ("Failed to fetch dynamically imported
+    // module", #15383), and without a boundary here that rejection escaped to
+    // the app-root ErrorBoundary — which has no chunk recovery — blanking the
+    // whole console. CloudRouteErrorBoundary hands the failure to the shared
+    // one-shot reload recovery so the steward chunk self-heals like every
+    // registered route chunk.
+    <CloudRouteErrorBoundary routePath="steward-runtime">
+      <Suspense fallback={<StewardRuntimeLoading />}>
+        <StewardAuthRuntimeProvider apiUrl={apiUrl} tenantId={tenantId}>
+          {children}
+        </StewardAuthRuntimeProvider>
+      </Suspense>
+    </CloudRouteErrorBoundary>
   );
 }


### PR DESCRIPTION
Fixes #15383.

## Problem

Every cloud console route (Overview / Agents / Billing / API Keys / Account, …) is a `React.lazy` chunk mounted by `CloudRouterShell`, and the Steward auth runtime (`@stwd/*`) is another lazy chunk mounted by `StewardAuthProvider`. After a Pages deploy, a running shell still references **its** build's hashed assets, so the first navigation to a not-yet-visited page — or the first authenticated navigation that loads the steward runtime — rejects with `Failed to fetch dynamically imported module`. Both mounts sat under a bare `<Suspense>` with no error boundary above them, so the rejection escaped to the app-root `ErrorBoundary` (which has no chunk recovery) and the **whole console blanked** into a generic crash card until a manual hard refresh.

## Fix

- **New `packages/ui/src/cloud/shell/CloudRouteErrorBoundary.tsx`** — reuses the shared one-shot reload recovery (`utils/chunk-load-recovery`: `isChunkLoadError` + `tryChunkReloadRecovery`, timestamped 5-minute cooldown in `sessionStorage`, so a later deploy in the same session can also self-heal and a genuinely-missing asset can never cause a reload loop). Chunk failures past the attempt budget degrade to a manual **Reload** card; non-chunk render crashes degrade to a **Retry** card — in both cases the console chrome (sidebar/top bar) stays mounted. Mirrors `components/views/ViewErrorBoundary`, minus the app-shell-only view-lifecycle/telemetry machinery.
- **`CloudRouterShell.tsx`** — `renderRouteElement` wraps every registered route element in the boundary, **outside** the route `<Suspense>`, so every console route lazy chunk is covered.
- **`StewardProvider.tsx`** — the lazy `@stwd/*` runtime mount is wrapped in the same boundary, **outside** its `<Suspense>`, so a stale steward-runtime chunk self-heals instead of blanking the console (the exact first-authenticated-navigation-after-deploy symptom).

## Tests — `CloudRouteErrorBoundary.test.tsx` (7 pass)

Pins the contract both ways:

1. chunk-load error → **exactly one** `window.location.reload` + timestamped cooldown marker stamped;
2. second chunk error **inside** the 5-min cooldown → **no** auto-reload, manual Reload card (user click reloads);
3. cooldown lapse → one more auto-reload attempt, marker re-stamped;
4. **non-chunk** render error → Retry card, zero reloads, marker untouched;
5. Retry remounts and recovers once the child stops throwing;
6. steward-runtime chunk failure at `/dashboard/*` → caught by the wrapping boundary, one-shot reload recovery fires;
7. steward-runtime chunk failure inside the cooldown → manual Reload card, auth-consuming children never render.

## Verification

- `bun run --cwd packages/ui test src/cloud/shell/CloudRouteErrorBoundary.test.tsx` → **7 passed (7)**
- `bun run --cwd packages/ui test src/cloud/shell/` → 58 passed, 1 failed: `ConsoleShell.test.tsx > keeps a visible keyboard focus treatment on the account menu trigger` — **pre-existing on `origin/develop`** (this branch touches neither `ConsoleShell.tsx` nor its test; the expected `focus-visible:ring-2` class is absent from the component on develop too).
- `bun run --cwd packages/ui typecheck` → clean (exit 0)
- `biome check` on the 4 touched files → clean

Recovery mechanism (one-shot reload, cooldown holds, non-chunk degrade) was also verified end-to-end in a live browser against a simulated stale deploy during the original implementation pass.

[qa-agent]
