### PR TITLE
fix(core): stop injected VIEWS candidates deadlocking answered simple turns

### DIFF
--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -28,6 +28,7 @@ import {
 	inferDirectCurrentRequestCandidateActions,
 	inferLocalShellCommandFromMessageText,
 	inferWebSearchQueryFromMessageText,
+	messageHandlerFromFieldResult,
 	shouldPreferDirectCurrentCandidateActions,
 	shouldPromoteExplicitReplyToOwnedAction,
 	stripReplyWhenActionOwnsTurn,
@@ -1042,5 +1043,177 @@ describe("bare view-name voice navigation inference (#9950)", () => {
 				"settings",
 			),
 		).toEqual([]);
+	});
+});
+
+// Regression fence for the VIEWS hijack of answered simple turns (live
+// trajectories tj-501e594bfb23a7 app REST surface, tj-5d1c9601f33e8d Discord):
+// Stage 1 answered "whats 17 times 23?" with contexts=["simple"],
+// replyText="391", candidateActionNames=[] — done. The text-derived candidate
+// backstop then matched the views action's "screen-time" tag via the TIME
+// token ("times"), injected VIEWS, escalated the turn to a tool-REQUIRED
+// planner surface, rejected the planner's correct terminal answer
+// maxRequiredToolMisses times, and shipped the generic transient-failure
+// apology while discarding "391". The fix suppresses ONLY the weak
+// view-capability inference on that exact Stage-1 shape; model-emitted
+// candidates, shell/coding/web inferences, explicit-surface view asks, and
+// bare-noun voice navigation keep today's escalation.
+describe("VIEWS hijack of answered simple turns (tj-501e594bfb23a7)", () => {
+	// Mirrors the real plugin-app-control VIEWS action metadata (subset): the
+	// "screen-time" tag is what collides with "times" in ordinary chat text.
+	const viewsAction: Pick<Action, "name" | "similes" | "tags"> = {
+		name: "VIEWS",
+		similes: ["VIEW", "SHOW_VIEW", "OPEN_VIEW", "WHAT_VIEWS", "OPEN_SETTINGS"],
+		tags: [
+			"views",
+			"ui",
+			"window",
+			"panel",
+			"app",
+			"layout",
+			"view-capability",
+			"calendar",
+			"screen-time",
+			"todos",
+			"settings",
+		],
+	};
+	const replyAction: Pick<Action, "name" | "similes" | "tags"> = {
+		name: "REPLY",
+		similes: [],
+		tags: [],
+	};
+	const stageOneAnswered = (replyText: string, candidates: string[] = []) => ({
+		shouldRespond: "RESPOND" as const,
+		contexts: ["simple"],
+		intents: [],
+		replyText,
+		candidateActionNames: candidates,
+		facts: [],
+		relationships: [],
+		addressedTo: [],
+	});
+
+	it("keeps an answered simple turn direct when VIEWS arrives only by capability-token overlap", () => {
+		const routed = messageHandlerFromFieldResult(
+			stageOneAnswered("391"),
+			undefined,
+			{
+				actions: [replyAction, viewsAction],
+				messageText: "whats 17 times 23?",
+			},
+		);
+
+		expect(routed.plan.simple).toBe(true);
+		expect(routed.plan.requiresTool).toBe(false);
+		expect(routed.plan.candidateActions ?? []).toEqual([]);
+		expect(routed.plan.reply).toBe("391");
+	});
+
+	it("still plans when the MODEL itself emitted the VIEWS candidate on the same shape", () => {
+		const routed = messageHandlerFromFieldResult(
+			stageOneAnswered("391", ["VIEWS"]),
+			undefined,
+			{
+				actions: [replyAction, viewsAction],
+				messageText: "whats 17 times 23?",
+			},
+		);
+
+		expect(routed.plan.simple).toBe(false);
+		expect(routed.plan.requiresTool).toBe(true);
+		expect(routed.plan.candidateActions).toContain("VIEWS");
+	});
+
+	it("suppression is keyed on the answered shape — an unanswered turn still escalates", () => {
+		const routed = messageHandlerFromFieldResult(
+			stageOneAnswered(""),
+			undefined,
+			{
+				actions: [replyAction, viewsAction],
+				messageText: "whats 17 times 23?",
+			},
+		);
+
+		expect(routed.plan.requiresTool).toBe(true);
+		expect(routed.plan.candidateActions).toContain("VIEWS");
+	});
+
+	it("the simple_registered_action_request evaluator does not re-promote the answered turn", () => {
+		const gate = BUILTIN_RESPONSE_HANDLER_EVALUATORS.find(
+			(evaluator) => evaluator.name === "core.simple_registered_action_request",
+		);
+		expect(gate).toBeDefined();
+		const contextFor = (text: string, reply: string) =>
+			({
+				message: messageWithText(text, { source: "app" }),
+				messageHandler: {
+					processMessage: "RESPOND",
+					plan: { requiresTool: false, contexts: ["simple"], reply },
+				},
+				runtime: { actions: [replyAction, viewsAction] },
+			}) as never;
+
+		// The answered math turn must stay direct…
+		expect(gate?.shouldRun(contextFor("whats 17 times 23?", "391"))).toBe(
+			false,
+		);
+		// …while bare-noun voice navigation (#9950) keeps promoting even though
+		// Stage 1 "answered" it with a clarifying question.
+		expect(
+			gate?.shouldRun(contextFor("settings", "Which settings do you mean?")),
+		).toBe(true);
+	});
+
+	it("leaves the web backstop untouched: a live-info ack still forces the fetch", () => {
+		const webAction: Pick<Action, "name" | "similes" | "tags"> = {
+			name: "WEB_FETCH",
+			similes: [],
+			tags: [],
+		};
+		const routed = messageHandlerFromFieldResult(
+			stageOneAnswered("Checking the price now."),
+			undefined,
+			{
+				actions: [replyAction, webAction],
+				messageText: "what is btc at rn?",
+			},
+		);
+
+		expect(routed.plan.requiresTool).toBe(true);
+		expect(routed.plan.candidateActions).toContain("WEB_FETCH");
+	});
+
+	it("leaves the shell backstop untouched: a shell-inspection ask still plans", () => {
+		const shellAction: Pick<Action, "name" | "similes" | "tags"> = {
+			name: "SHELL",
+			similes: ["RUN_COMMAND", "TERMINAL"],
+			tags: [],
+		};
+		const routed = messageHandlerFromFieldResult(
+			stageOneAnswered("Checking."),
+			undefined,
+			{
+				actions: [replyAction, shellAction],
+				messageText: "show me disk usage on this server",
+			},
+		);
+
+		expect(routed.plan.requiresTool).toBe(true);
+		expect(routed.plan.candidateActions).toContain("SHELL");
+	});
+
+	it("explicit-surface view asks still escalate on an answered-looking shape", () => {
+		const routed = messageHandlerFromFieldResult(
+			stageOneAnswered("Opening the settings panel."),
+			undefined,
+			{
+				actions: [replyAction, viewsAction],
+				messageText: "open the settings panel",
+			},
+		);
+
+		expect(routed.plan.requiresTool).toBe(true);
+		expect(routed.plan.candidateActions).toContain("VIEWS");
 	});
 });

--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -1163,6 +1163,18 @@ describe("VIEWS hijack of answered simple turns (tj-501e594bfb23a7)", () => {
 		expect(
 			gate?.shouldRun(contextFor("settings", "Which settings do you mean?")),
 		).toBe(true);
+		// An ack-shaped replyText is a delegation commitment, not an answer —
+		// suppressing on it would ship "On it." as the whole turn with nothing
+		// behind it (the ack-rescue paths cover shell/web/coding, never views).
+		// A view-capability overlap with an ack reply must keep promoting.
+		expect(gate?.shouldRun(contextFor("show my screen time", "On it."))).toBe(
+			true,
+		);
+		expect(
+			gate?.shouldRun(
+				contextFor("whats my screen time", "Let me pull that up."),
+			),
+		).toBe(true);
 	});
 
 	it("leaves the web backstop untouched: a live-info ack still forces the fetch", () => {

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -2230,6 +2230,76 @@ describe("runV5MessageRuntimeStage1", () => {
 		}
 	});
 
+	it("answers a trivial math turn directly despite a views capability-token overlap (tj-501e594bfb23a7)", async () => {
+		// Full Stage-1 pipeline fence for the VIEWS hijack: Stage 1 answers
+		// "whats 17 times 23?" with contexts=["simple"] / replyText="391" /
+		// candidateActionNames=[]. The registered views action's "screen-time"
+		// tag overlaps the TIME token ("times"), which previously injected a
+		// VIEWS candidate AFTER Stage 1 (both in messageHandlerFromFieldResult
+		// and via the core.simple_registered_action_request evaluator), forced
+		// the planner into toolChoice=required, exhausted required_tool_misses
+		// rejecting the correct terminal answer, and shipped the generic
+		// apology. The answered-simple shape must stay a one-call direct reply.
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["simple"],
+				replyText: "391",
+			}),
+		]);
+		const viewsHandler = vi.fn(async () => ({
+			success: true,
+			text: "opened",
+			data: { actionName: "VIEWS" },
+		}));
+		runtime.actions = [
+			{
+				name: "VIEWS",
+				similes: ["VIEW", "SHOW_VIEW", "OPEN_VIEW", "OPEN_SETTINGS"],
+				tags: [
+					"views",
+					"ui",
+					"panel",
+					"view-capability",
+					"screen-time",
+					"settings",
+				],
+				description: "Manage and navigate UI views.",
+				parameters: [
+					{
+						name: "action",
+						description: "Operation",
+						required: true,
+						schema: { type: "string" },
+					},
+				],
+				examples: [],
+				validate: async () => true,
+				handler: viewsHandler,
+			},
+		] as never;
+		const message = makeMessage();
+		message.content = {
+			...message.content,
+			text: "whats 17 times 23?",
+			mentionContext: { isMention: true },
+		};
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message,
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("direct_reply");
+		expect(viewsHandler).not.toHaveBeenCalled();
+		// One HANDLE_RESPONSE call only — no planner round, no forced tool.
+		expect(useModelCalls(runtime)).toHaveLength(1);
+		if (result.kind === "direct_reply") {
+			expect(result.result.responseContent?.text).toBe("391");
+		}
+	});
+
 	it("routes progress-only coding delegation replies through the planner", () => {
 		const routed = messageHandlerFromFieldResult(
 			{

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -1117,6 +1117,106 @@ describe("v5 planner loop skeleton", () => {
 		expect(runtime.useModel).toHaveBeenCalledTimes(3);
 	});
 
+	it("surfaces the Stage-1 replyText when the required-tool cap exhausts without a refusal", async () => {
+		// Live regression (tj-501e594bfb23a7 / tj-5d1c9601f33e8d): "whats 17
+		// times 23?" — Stage 1 answered "391", but an injected VIEWS candidate
+		// forced requireNonTerminalToolCall. The planner kept answering via
+		// REPLY; none of those replies were refusal-shaped, so nothing was
+		// captured, the loop threw required_tool_misses, and the caller shipped
+		// the generic transient-failure apology while the correct answer was
+		// discarded. With stageOneReplyText threaded in, exhaustion finishes
+		// with Stage 1's own answer instead of throwing.
+		const runtime = {
+			useModel: vi.fn(async () => ({
+				text: "",
+				toolCalls: [
+					{
+						id: "reply-1",
+						name: "REPLY",
+						arguments: { text: "The answer is 391." },
+					},
+				],
+			})),
+			logger: { warn: vi.fn() },
+		};
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			tools: [{ name: "VIEWS", description: "Open a UI view." }],
+			requireNonTerminalToolCall: true,
+			stageOneReplyText: "391",
+			config: { maxRequiredToolMisses: 1 },
+			executeToolCall: vi.fn(),
+			evaluate: vi.fn(),
+		});
+
+		expect(result.status).toBe("finished");
+		// Stage 1's replyText is preferred over the planner's rejected REPLY
+		// text — it is the cleaner ground truth for the turn.
+		expect(result.finalMessage).toBe("391");
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+	});
+
+	it("falls back to the planner's own rejected REPLY answer when no Stage-1 replyText exists", async () => {
+		const runtime = {
+			useModel: vi.fn(async () => ({
+				text: "",
+				toolCalls: [
+					{
+						id: "reply-1",
+						name: "REPLY",
+						arguments: { text: "The answer is 391." },
+					},
+				],
+			})),
+			logger: { warn: vi.fn() },
+		};
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			tools: [{ name: "VIEWS", description: "Open a UI view." }],
+			requireNonTerminalToolCall: true,
+			config: { maxRequiredToolMisses: 1 },
+			executeToolCall: vi.fn(),
+			evaluate: vi.fn(),
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe("The answer is 391.");
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+	});
+
+	it("still throws at exhaustion when the Stage-1 replyText is ack-shaped and nothing else was captured", async () => {
+		// Honesty guard: a progress-only Stage-1 ack ("Checking the price
+		// now.") must never ship as the final answer — once the loop gives up,
+		// no fetch happens, so surfacing the ack would be a false promise. With
+		// no refusal, no answer-shaped replyText, and no usable rejected
+		// terminal text, the existing apology path is unchanged.
+		const runtime = {
+			useModel: vi.fn(async () => ({ text: "", toolCalls: [] })),
+			logger: { warn: vi.fn() },
+		};
+
+		await expect(
+			runPlannerLoop({
+				runtime,
+				context: { id: "ctx" },
+				tools: [{ name: "WEB_FETCH", description: "Fetch a URL." }],
+				requireNonTerminalToolCall: true,
+				stageOneReplyText: "Checking the price now.",
+				config: { maxRequiredToolMisses: 1 },
+				executeToolCall: vi.fn(),
+				evaluate: vi.fn(),
+			}),
+		).rejects.toMatchObject({
+			name: "TrajectoryLimitExceeded",
+			kind: "required_tool_misses",
+		});
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+	});
+
 	it("does not surface a captured refusal before the required-tool retry budget is exhausted", async () => {
 		const runtime = {
 			useModel: vi

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -240,6 +240,13 @@ export async function runPlannerLoop(
 	const requireNonTerminalToolCall =
 		(params.requireNonTerminalToolCall === true || codingMode) &&
 		hasExposedNonTerminalTool(params.tools);
+	// Stage 1's own answer for this turn, shape-guarded once up front. Consulted
+	// only when the required-tool gate exhausts without a captured refusal — the
+	// ground-truth answer Stage 1 already produced beats the caller's generic
+	// apology (see PlannerLoopParams.stageOneReplyText).
+	const stageOneAnswerText = requireNonTerminalToolCall
+		? userSafeCapturedAnswerCandidate(params.stageOneReplyText)
+		: undefined;
 
 	// Cumulative gross prompt-token counter, summed across every planner
 	// stage in this user turn. Tracked alongside the existing per-iter
@@ -287,6 +294,13 @@ export async function runPlannerLoop(
 	// `maxRequiredToolMisses`, throws `TrajectoryLimitExceeded`, and the
 	// caller surfaces a generic apology instead of the planner's real answer.
 	let lastTerminalRefusalText: string | undefined;
+	// The most recent REJECTED terminal ANSWER (non-refusal-shaped, explicit /
+	// REPLY-call sources only) across required-tool misses — e.g. the planner
+	// kept answering "391" via REPLY while the gate demanded a non-terminal
+	// tool. Last-resort fallback when the miss budget exhausts with no captured
+	// refusal and no Stage-1 replyText: the model's own discarded answer still
+	// beats the generic apology.
+	let lastRejectedTerminalAnswerText: string | undefined;
 	// Sanitized widget-bearing terminal text from the previous required-tool
 	// miss. When the model re-emits the identical widget reply after one
 	// corrective retry it is deterministically committed to that answer —
@@ -390,16 +404,32 @@ export async function runPlannerLoop(
 					lastMissWidgetText = widgetCandidate;
 					const captured = refusalCandidate ?? widgetCandidate;
 					if (captured) lastTerminalRefusalText = captured;
+					// Only the EXPLICIT messageToUser is a safe answer source in
+					// this branch — the native free-text fallback can be a pre-tool
+					// thought (#9874 item 3), so it is never captured as an answer.
+					const rejectedAnswerCandidate =
+						captured === undefined
+							? userSafeCapturedAnswerCandidate(
+									lastPlannerExplicitMessageToUser,
+								)
+							: undefined;
+					if (rejectedAnswerCandidate) {
+						lastRejectedTerminalAnswerText = rejectedAnswerCandidate;
+					}
 					requiredToolMisses++;
+					const capturedFinishText =
+						lastTerminalRefusalText ??
+						stageOneAnswerText ??
+						lastRejectedTerminalAnswerText;
 					if (
 						requiredToolMisses > config.maxRequiredToolMisses &&
-						lastTerminalRefusalText
+						capturedFinishText
 					) {
 						return finishWithCapturedRefusal({
 							trajectory,
 							iteration,
 							thought: plannerOutput.thought,
-							refusal: lastTerminalRefusalText,
+							refusal: capturedFinishText,
 						});
 					}
 					assertTrajectoryLimit({
@@ -562,16 +592,33 @@ export async function runPlannerLoop(
 					lastMissWidgetText = widgetCandidate;
 					const captured = refusalCandidate ?? widgetCandidate;
 					if (captured) lastTerminalRefusalText = captured;
+					// A REPLY tool call's text is user-directed by construction; a
+					// STOP/IGNORE-only terminal's free text is scratch reasoning
+					// (see the hasReplyCall comment below) and is never captured.
+					const rejectedAnswerCandidate =
+						captured === undefined &&
+						plannerOutput.toolCalls.some(
+							(toolCall) => toolCall.name.toUpperCase() === "REPLY",
+						)
+							? userSafeCapturedAnswerCandidate(terminalText)
+							: undefined;
+					if (rejectedAnswerCandidate) {
+						lastRejectedTerminalAnswerText = rejectedAnswerCandidate;
+					}
 					requiredToolMisses++;
+					const capturedFinishText =
+						lastTerminalRefusalText ??
+						stageOneAnswerText ??
+						lastRejectedTerminalAnswerText;
 					if (
 						requiredToolMisses > config.maxRequiredToolMisses &&
-						lastTerminalRefusalText
+						capturedFinishText
 					) {
 						return finishWithCapturedRefusal({
 							trajectory,
 							iteration,
 							thought: plannerOutput.thought,
-							refusal: lastTerminalRefusalText,
+							refusal: capturedFinishText,
 						});
 					}
 					assertTrajectoryLimit({
@@ -3559,6 +3606,39 @@ function userSafeRefusalCandidate(
 	if (IN_FLIGHT_ACTION_CLAIM.some((pattern) => pattern.test(candidate))) {
 		return undefined;
 	}
+	return candidate;
+}
+
+// Progress/ack-shaped openers that must never be surfaced as a final answer
+// from the required-tool exhaustion path: once the loop gives up, no further
+// tool work happens, so "Checking the price now." style text is a false
+// promise. Mirrors the message-service looksLikeProgressOnlyReply prefix set
+// (kept local — services/message.ts imports from this module, not vice versa).
+const PROGRESS_ONLY_ANSWER_REJECT =
+	/^(?:checking|fetching|gathering|looking (?:up|into)|running|using|spawning|starting|working on|opening|got it|okay|ok|on it|one moment|let me|i(?:'|’)ll|i will)\b/i;
+
+// Shape gate for surfacing an already-produced ANSWER — the Stage-1 replyText
+// or the planner's own explicit terminal reply the required-tool gate kept
+// rejecting — when the miss budget exhausts without a captured refusal. Same
+// safety rejects as userSafeRefusalCandidate (leaked tool-call/reasoning
+// markup, pre-tool deliberation, in-flight action claims) minus the
+// refusal-marker requirement: the text surfaced here is a real answer
+// ("391"), not an inability statement, plus a progress-only-opener reject so
+// a bare ack never ships as the whole turn. Callers must only feed it
+// user-directed sources (Stage-1 replyText, explicit messageToUser, REPLY
+// tool-call text) — never the ambiguous native free-text fallback, which can
+// be a pre-tool thought.
+function userSafeCapturedAnswerCandidate(
+	message: string | undefined,
+): string | undefined {
+	const candidate = sanitizePlannerMessage(message);
+	if (!candidate) return undefined;
+	if (isUnsafeUserVisibleText(candidate)) return undefined;
+	if (looksLikePreToolThought(candidate)) return undefined;
+	if (IN_FLIGHT_ACTION_CLAIM.some((pattern) => pattern.test(candidate))) {
+		return undefined;
+	}
+	if (PROGRESS_ONLY_ANSWER_REJECT.test(candidate)) return undefined;
 	return candidate;
 }
 

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -592,15 +592,17 @@ export async function runPlannerLoop(
 					lastMissWidgetText = widgetCandidate;
 					const captured = refusalCandidate ?? widgetCandidate;
 					if (captured) lastTerminalRefusalText = captured;
-					// A REPLY tool call's text is user-directed by construction; a
-					// STOP/IGNORE-only terminal's free text is scratch reasoning
-					// (see the hasReplyCall comment below) and is never captured.
+					// A REPLY tool call's OWN params text is user-directed by
+					// construction; a STOP/IGNORE-only terminal's free text is scratch
+					// reasoning (see the hasReplyCall comment below) and is never
+					// captured. Deliberately NO messageToUser fallback here: a REPLY
+					// call with empty params would otherwise capture the native
+					// free-text fallback, which can be a pre-tool thought.
 					const rejectedAnswerCandidate =
-						captured === undefined &&
-						plannerOutput.toolCalls.some(
-							(toolCall) => toolCall.name.toUpperCase() === "REPLY",
-						)
-							? userSafeCapturedAnswerCandidate(terminalText)
+						captured === undefined
+							? userSafeCapturedAnswerCandidate(
+									terminalMessageFromToolCalls(plannerOutput.toolCalls),
+								)
 							: undefined;
 					if (rejectedAnswerCandidate) {
 						lastRejectedTerminalAnswerText = rejectedAnswerCandidate;

--- a/packages/core/src/runtime/planner-types.ts
+++ b/packages/core/src/runtime/planner-types.ts
@@ -199,6 +199,17 @@ export interface PlannerLoopParams {
 	 */
 	requireNonTerminalToolCall?: boolean;
 	/**
+	 * The Stage-1 router's own replyText for this turn, when it produced one.
+	 * When the required-tool gate exhausts its miss budget without a captured
+	 * refusal, the loop finishes with this text (shape-guarded) instead of
+	 * throwing `TrajectoryLimitExceeded` — the router's real answer is
+	 * strictly better than the generic transient-failure apology the caller
+	 * would otherwise substitute for it (observed live: "whats 17 times 23?"
+	 * answered "391" by Stage 1, then discarded for the apology when an
+	 * injected VIEWS candidate deadlocked the required-tool gate).
+	 */
+	stageOneReplyText?: string;
+	/**
 	 * Trajectory recorder for v5 observability. When supplied, the planner
 	 * loop records one stage per planner call, tool execution, and evaluator
 	 * call. When omitted the loop is unaffected.

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -4622,6 +4622,12 @@ function shouldSuppressInferredCandidateEscalation(args: {
 	if (args.inference.kind !== "view-capability") return false;
 	if (args.stageOneCandidateActions.length > 0) return false;
 	if (args.stageOneReplyText.trim().length === 0) return false;
+	// An ack-shaped reply ("On it.", "Let me pull that up.") is a delegation
+	// commitment, not an answer — suppressing the candidate here would ship the
+	// ack as the whole turn with nothing behind it (the ack-rescue paths only
+	// cover shell/web/coding, never views). Only a genuinely answer-shaped
+	// replyText qualifies the turn as "already answered".
+	if (looksLikeProgressOnlyReply(args.stageOneReplyText)) return false;
 	return !args.stageOneContexts.some(
 		(context) => context.trim().toLowerCase() !== SIMPLE_CONTEXT_ID,
 	);

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -269,11 +269,13 @@ import { ChannelTopicsService } from "./channel-topics";
 import { runPostTurnEvaluators } from "./evaluator";
 import { runBotNoiseTriage } from "./message/bot-noise-triage";
 import {
+	type DirectCurrentRequestCandidateInference,
 	findCodingDelegationActionName,
 	findShellDirectActionName,
 	findWebLookupActionName,
 	findWebLookupActionNames,
 	inferDirectCurrentRequestCandidateActions as inferDirectCurrentRequestCandidateActionsFromHeuristics,
+	inferDirectCurrentRequestCandidateInference as inferDirectCurrentRequestCandidateInferenceFromHeuristics,
 	inferLocalShellCommandFromMessageText,
 	inferWebSearchQueryFromMessageText,
 	isShellDirectActionName,
@@ -3027,17 +3029,37 @@ export const BUILTIN_RESPONSE_HANDLER_EVALUATORS: readonly ResponseHandlerEvalua
 				if (nonSimpleContexts.length > 0) return false;
 				const text = getUserMessageText(message);
 				if (!text?.trim()) return false;
-				return (
-					inferDirectCurrentRequestCandidateActions(runtime.actions ?? [], text)
-						.length > 0
-				);
-			},
-			evaluate: ({ message, runtime }) => {
-				const text = getUserMessageText(message) ?? "";
-				const candidateActions = inferDirectCurrentRequestCandidateActions(
+				const inference = inferDirectCurrentRequestCandidateInference(
 					runtime.actions ?? [],
 					text,
 				);
+				if (inference.names.length === 0) return false;
+				// Same escalation valve as messageHandlerFromFieldResult: this
+				// evaluator re-runs the text inference on the SIMPLE path, so
+				// without the valve it re-promotes the exact answered turn the
+				// structured path just declined to force-plan (and clobbers the
+				// finished replyText with an "On it." ack that never delivers).
+				return !shouldSuppressInferredCandidateEscalation({
+					inference,
+					stageOneContexts: messageHandler.plan.contexts ?? [],
+					stageOneReplyText: String(messageHandler.plan.reply ?? ""),
+					stageOneCandidateActions: messageHandler.plan.candidateActions ?? [],
+				});
+			},
+			evaluate: ({ message, messageHandler, runtime }) => {
+				const text = getUserMessageText(message) ?? "";
+				const inference = inferDirectCurrentRequestCandidateInference(
+					runtime.actions ?? [],
+					text,
+				);
+				const candidateActions = shouldSuppressInferredCandidateEscalation({
+					inference,
+					stageOneContexts: messageHandler.plan.contexts ?? [],
+					stageOneReplyText: String(messageHandler.plan.reply ?? ""),
+					stageOneCandidateActions: messageHandler.plan.candidateActions ?? [],
+				})
+					? []
+					: inference.names;
 				if (candidateActions.length === 0) return undefined;
 				return {
 					requiresTool: true,
@@ -3827,13 +3849,25 @@ export function messageHandlerFromFieldResult(
 					return exposedActionMatches(runtimeContext.actions, normalized);
 				})
 			: candidateActions.length > 0;
-	const directCurrentCandidateActions =
+	const directCurrentInference =
 		!subAgentCompletionRelay && currentMessageText.trim().length > 0
-			? inferDirectCurrentRequestCandidateActions(
+			? inferDirectCurrentRequestCandidateInference(
 					runtimeContext?.actions ?? [],
 					currentMessageText,
 				)
-			: [];
+			: ({ names: [], kind: null } as DirectCurrentRequestCandidateInference);
+	// A weak view-capability token overlap must not force-plan a turn Stage 1
+	// already answered (see shouldSuppressInferredCandidateEscalation) — drop
+	// the inferred candidates entirely so the turn keeps its direct reply.
+	const directCurrentCandidateActions =
+		shouldSuppressInferredCandidateEscalation({
+			inference: directCurrentInference,
+			stageOneContexts: rawContexts,
+			stageOneReplyText: replyTextRaw,
+			stageOneCandidateActions: rawCandidateActions,
+		})
+			? []
+			: directCurrentInference.names;
 	const preferDirectCurrentCandidateActions =
 		shouldPreferDirectCurrentCandidateActions({
 			candidateActions,
@@ -4200,12 +4234,26 @@ export function applyDirectCurrentCandidateBackstopToMessageHandler(
 		return messageHandler;
 	}
 
-	const directCurrentCandidateActions =
-		inferDirectCurrentRequestCandidateActions(
-			runtimeContext.actions,
-			currentMessageText,
-		);
+	const directCurrentInference = inferDirectCurrentRequestCandidateInference(
+		runtimeContext.actions,
+		currentMessageText,
+	);
+	const directCurrentCandidateActions = directCurrentInference.names;
 	if (directCurrentCandidateActions.length === 0) return messageHandler;
+	// Same escalation valve as messageHandlerFromFieldResult: a plain-text
+	// Stage-1 answer routed through this backstop must not be force-planned
+	// over a weak view-capability token overlap either.
+	if (
+		shouldSuppressInferredCandidateEscalation({
+			inference: directCurrentInference,
+			stageOneContexts: messageHandler.plan.contexts ?? [],
+			stageOneReplyText: String(messageHandler.plan.reply ?? ""),
+			stageOneCandidateActions:
+				getMessageHandlerCandidateActions(messageHandler),
+		})
+	) {
+		return messageHandler;
+	}
 
 	const runnableCandidateActions = filterRunnableCandidateActions(
 		uniqueActionNames([
@@ -4530,6 +4578,52 @@ export function inferDirectCurrentRequestCandidateActions(
 			looksLikeCodingWorkRequest,
 			findCodingDelegationActionName,
 		},
+	);
+}
+
+function inferDirectCurrentRequestCandidateInference(
+	actions: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>,
+	messageText: string,
+): DirectCurrentRequestCandidateInference {
+	return inferDirectCurrentRequestCandidateInferenceFromHeuristics(
+		actions,
+		messageText,
+		{
+			looksLikeCodingWorkRequest,
+			findCodingDelegationActionName,
+		},
+	);
+}
+
+/**
+ * True when a text-inferred (never model-emitted) candidate set must NOT
+ * escalate this turn to a tool-required planner surface: Stage 1 already
+ * ANSWERED the turn (only simple/absent contexts, a non-empty replyText, and
+ * zero candidateActionNames of its own) and the only "evidence" for a tool is
+ * a weak view-capability token overlap (e.g. "whats 17 TIMES 23" matching the
+ * views action's "screen-time" tag via TIME). Observed live on both the app
+ * REST surface and Discord (trajectories tj-501e594bfb23a7, tj-5d1c9601f33e8d):
+ * the injected VIEWS candidate forced toolChoice=required, the planner's
+ * correct terminal answer was rejected maxRequiredToolMisses times, and the
+ * user got the generic transient-failure apology instead of the answer.
+ *
+ * Deliberately narrow — keyed on the Stage-1 plan SHAPE, not the connector:
+ * model-emitted candidates always escalate, shell/coding/web inferences keep
+ * their backstop behavior (live-info acks still force the fetch), and the
+ * strong view inferences (explicit surface nouns, bare-name voice navigation)
+ * still escalate so genuine view-switching UX is untouched.
+ */
+function shouldSuppressInferredCandidateEscalation(args: {
+	inference: DirectCurrentRequestCandidateInference;
+	stageOneContexts: readonly string[];
+	stageOneReplyText: string;
+	stageOneCandidateActions: readonly string[];
+}): boolean {
+	if (args.inference.kind !== "view-capability") return false;
+	if (args.stageOneCandidateActions.length > 0) return false;
+	if (args.stageOneReplyText.trim().length === 0) return false;
+	return !args.stageOneContexts.some(
+		(context) => context.trim().toLowerCase() !== SIMPLE_CONTEXT_ID,
 	);
 }
 
@@ -7020,6 +7114,14 @@ export async function runV5MessageRuntimeStage1(args: {
 				config: args.plannerLoopConfig,
 				tools: plannerTools.length > 0 ? plannerTools : undefined,
 				requireNonTerminalToolCall,
+				// Fallback honesty for required-tool exhaustion: Stage 1's own
+				// replyText (when answer-shaped) is surfaced instead of the
+				// generic transient-failure apology. Duplicate delivery is safe —
+				// early-reply turns dedup via plannedTextRepeatsEarlyReply.
+				stageOneReplyText:
+					typeof messageHandler.plan.reply === "string"
+						? messageHandler.plan.reply
+						: undefined,
 				evaluatorEffects,
 				recorder,
 				trajectoryId,

--- a/packages/core/src/services/message/direct-action-heuristics.test.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.test.ts
@@ -15,6 +15,7 @@ import {
 	findShellDirectActionName,
 	hasActionTags,
 	inferDirectCurrentRequestCandidateActions,
+	inferDirectCurrentRequestCandidateInference,
 	isShellDirectActionName,
 	looksLikeLocalShellRequest,
 	looksLikeWebSearchRequest,
@@ -211,5 +212,80 @@ describe("shell-direct coupling grep guard (#12636)", () => {
 		// And it routes through the tag-aware resolver/classifier.
 		expect(src).toContain("findShellDirectActionName");
 		expect(src).toContain("isShellDirectActionName");
+	});
+});
+
+// The inference KIND is the load-bearing signal for the answered-simple-turn
+// escalation valve in services/message.ts (VIEWS hijack, tj-501e594bfb23a7):
+// only "view-capability" — an incidental token overlap with a views action's
+// tag/simile vocabulary — is suppressible; every stronger detector keeps its
+// escalation. Fence the classification so a refactor cannot silently widen or
+// narrow the valve.
+describe("inferDirectCurrentRequestCandidateInference kinds", () => {
+	const viewsAction: Pick<Action, "name" | "similes" | "tags"> = {
+		name: "VIEWS",
+		similes: ["VIEW", "SHOW_VIEW", "OPEN_VIEW", "OPEN_SETTINGS"],
+		tags: [
+			"views",
+			"ui",
+			"panel",
+			"view-capability",
+			"screen-time",
+			"settings",
+		],
+	};
+
+	it("classifies the live hijack message as weak view-capability evidence", () => {
+		// "whats" bypasses the instructional-question guard ("what is" does not)
+		// and "times" singularizes to TIME, matching the "screen-time" tag.
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction],
+				"whats 17 times 23?",
+			),
+		).toEqual({ names: ["VIEWS"], kind: "view-capability" });
+	});
+
+	it("classifies explicit surface asks and bare-noun navigation as strong evidence", () => {
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[viewsAction],
+				"open the settings panel",
+			),
+		).toEqual({ names: ["VIEWS"], kind: "view-surface" });
+		expect(
+			inferDirectCurrentRequestCandidateInference([viewsAction], "settings"),
+		).toEqual({ names: ["VIEWS"], kind: "view-navigation" });
+	});
+
+	it("classifies shell and web detections under their own kinds", () => {
+		const shellAction: Pick<Action, "name" | "similes" | "tags"> = {
+			name: "SHELL",
+			similes: [],
+			tags: [],
+		};
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[shellAction],
+				"show me disk usage on this server",
+			),
+		).toEqual({ names: ["SHELL"], kind: "shell" });
+		const webAction: Pick<Action, "name" | "similes" | "tags"> = {
+			name: "WEB_FETCH",
+			similes: [],
+			tags: [],
+		};
+		expect(
+			inferDirectCurrentRequestCandidateInference(
+				[webAction],
+				"what is btc at rn?",
+			),
+		).toEqual({ names: ["WEB_FETCH"], kind: "web" });
+	});
+
+	it("returns a null kind when nothing matches", () => {
+		expect(
+			inferDirectCurrentRequestCandidateInference([viewsAction], "hello"),
+		).toEqual({ names: [], kind: null });
 	});
 });

--- a/packages/core/src/services/message/direct-action-heuristics.ts
+++ b/packages/core/src/services/message/direct-action-heuristics.ts
@@ -269,18 +269,61 @@ export function isShellDirectActionName(
 	);
 }
 
+/**
+ * Which detector produced a direct-current-request candidate inference. Lets
+ * callers weigh the EVIDENCE STRENGTH of an inferred (never model-emitted)
+ * candidate:
+ * - "shell" / "coding" / "web": explicit intent phrasing in the message.
+ * - "view-surface": an operation verb PLUS an explicit UI-surface noun
+ *   (view/window/panel/app/screen/ui) — strong navigation evidence.
+ * - "view-navigation": the message is nothing but a bare registered surface
+ *   name ("settings") — the voice-transcription navigation contract (#9950).
+ * - "view-capability": only an incidental token overlap between the message
+ *   and a views action's tag/simile vocabulary (e.g. "whats 17 TIMES 23"
+ *   matching the "screen-time" tag via TIME). Weak evidence — observed live
+ *   hijacking already-answered trivial chat turns into a required-tool
+ *   planner deadlock (trajectories tj-501e594bfb23a7, tj-5d1c9601f33e8d).
+ */
+export type DirectCurrentRequestCandidateKind =
+	| "shell"
+	| "coding"
+	| "view-surface"
+	| "view-navigation"
+	| "view-capability"
+	| "web";
+
+export interface DirectCurrentRequestCandidateInference {
+	names: string[];
+	kind: DirectCurrentRequestCandidateKind | null;
+}
+
+const EMPTY_DIRECT_CANDIDATE_INFERENCE: DirectCurrentRequestCandidateInference =
+	{ names: [], kind: null };
+
 export function inferDirectCurrentRequestCandidateActions(
 	actions: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>,
 	messageText: string,
 	hooks: DirectActionInferenceHooks = {},
 ): string[] {
+	return inferDirectCurrentRequestCandidateInference(
+		actions,
+		messageText,
+		hooks,
+	).names;
+}
+
+export function inferDirectCurrentRequestCandidateInference(
+	actions: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>,
+	messageText: string,
+	hooks: DirectActionInferenceHooks = {},
+): DirectCurrentRequestCandidateInference {
 	if (looksLikeLocalShellRequest(messageText)) {
 		const shellAction = findShellDirectActionName(actions);
-		if (shellAction) return [shellAction];
+		if (shellAction) return { names: [shellAction], kind: "shell" };
 	}
 	if (hooks.looksLikeCodingWorkRequest?.(messageText)) {
 		const codingAction = hooks.findCodingDelegationActionName?.(actions);
-		if (codingAction) return [codingAction];
+		if (codingAction) return { names: [codingAction], kind: "coding" };
 	}
 	const viewShellAction = findViewShellActionName(actions, messageText);
 	if (viewShellAction) {
@@ -297,9 +340,12 @@ export function inferDirectCurrentRequestCandidateActions(
 			messageText,
 		);
 		if (appControlAction && appControlAction !== viewShellAction) {
-			return [viewShellAction, appControlAction];
+			return {
+				names: [viewShellAction, appControlAction],
+				kind: "view-surface",
+			};
 		}
-		return [viewShellAction];
+		return { names: [viewShellAction], kind: "view-surface" };
 	}
 	// Voice-transcription contract: a message that is nothing but a bare
 	// surface name ("settings", "wallet", "inbox") is a navigation command, not
@@ -314,17 +360,21 @@ export function inferDirectCurrentRequestCandidateActions(
 		actions,
 		messageText,
 	);
-	if (bareViewNavigationAction) return [bareViewNavigationAction];
+	if (bareViewNavigationAction) {
+		return { names: [bareViewNavigationAction], kind: "view-navigation" };
+	}
 	const viewCapabilityAction = findViewCapabilityActionName(
 		actions,
 		messageText,
 	);
-	if (viewCapabilityAction) return [viewCapabilityAction];
+	if (viewCapabilityAction) {
+		return { names: [viewCapabilityAction], kind: "view-capability" };
+	}
 	if (looksLikeWebSearchRequest(messageText)) {
 		const lookupActions = findWebLookupActionNames(actions);
-		if (lookupActions.length > 0) return lookupActions;
+		if (lookupActions.length > 0) return { names: lookupActions, kind: "web" };
 	}
-	return [];
+	return EMPTY_DIRECT_CANDIDATE_INFERENCE;
 }
 
 // Specific web-tool action names, split by capability. A bare "SEARCH" must NOT


### PR DESCRIPTION
## The bug

A user asks `whats 17 times 23?` in the app or Discord. Stage-1 answers it correctly (`{"contexts":["simple"],"replyText":"391","candidateActionNames":[]}`) — and the user gets **"Something went wrong on my end. Please try again."** after ~18s.

Live evidence (self-hosted bot, trajectory `tj-501e594bfb23a7`, plus the same failure on a fresh dedicated cloud agent, plus a Discord coding-task turn `tj-5d1c9601f33e8d`):

1. The **text-derived candidate backstop** (post-stage-1) matches the VIEWS action's **`screen-time` tag** via the `TIME` token (`"times"` singularized) → injects `VIEWS` into `candidateActions`. (`"what is 17 times 23?"` is saved by the instructional-question regex; the colloquial `"whats"` bypasses it.)
2. Injected candidate → tiered action surface → turn marked **tool-REQUIRED** (`toolChoice: required`).
3. The planner keeps returning the correct terminal answer; the loop rejects it 4× ("Planner returned terminal output before satisfying a required tool call") — the model rightly refuses to run a junk VIEWS call.
4. `TrajectoryLimitExceeded: required_tool_misses (4/3)` → generic apology → **the correct answer is discarded**.

The benchmark-turn guard (message.ts) documents this exact over-flag ("candidateActions ['VIEWS'] on abstract-algebra MCQs") but real chat turns had no protection.

## The fix (surgical, shape-keyed — NOT a backstop removal)

**Fix A (routing):** `inferDirectCurrentRequestCandidateInference` now reports WHICH detector fired (`shell | coding | web | view-surface | view-navigation | view-capability`). Only the weak **`view-capability`** kind (incidental token overlap with a views action's tag/simile vocabulary) is barred from escalating a turn stage-1 already answered (`simple`-only contexts + non-empty replyText + zero model-emitted candidates). Model-emitted VIEWS, explicit surface nouns, bare-noun voice navigation (#9950), and the shell/coding/web backstops escalate exactly as before — the backstop is load-bearing and untouched for those kinds.

**Fix B (fallback honesty):** when the required-tool miss budget exhausts, the loop now surfaces `lastTerminalRefusalText ?? stageOneReplyText ?? lastRejectedTerminalAnswerText` instead of throwing to the apology. Answer capture reads only user-directed sources (stage-1 replyText, explicit messageToUser, REPLY tool-call text — never the native free-text fallback, which can be a pre-tool thought), with the same safety rejects as `userSafeRefusalCandidate` plus a progress-only-opener reject so a bare ack never ships as the whole turn. Nothing captured → the existing throw path is byte-identical.

## Evidence

- **14 new tests** across 4 files, incl. a full-pipeline integration test (answered turn → direct "391" reply, VIEWS handler never invoked, exactly 1 model call). **Proof the fence bites:** with the 4 source files reverted to develop, the integration test fails at exactly the live deadlock throw; with the fix, passes.
- `packages/core` suite: 3668 passed / 1 failed — the failure reproduces identically on pristine develop (pre-existing), typecheck + build:node + biome clean.
- **Live-verified** on the running bot (ported): before → apology + `errored` trajectories; after → `17 × 23 = 391` delivered in Discord, `finished`, plannerIter=0; greeting/coding/live-info probes all `finished`; WEB_FETCH turn still plans + fetches (backstop intact).

Root-cause analysis thread: elizaOS/eliza#14308 (discussioncomment-17564759).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- evidence-row:before-screenshots -->
- [ ] N/A - core runtime routing/planner behavior only; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - core runtime routing/planner behavior only; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no browser or UI walkthrough applies to this core conversation-runtime fix.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no live backend deploy or server log capture was run from this PR; behavior is covered by the focused package tests and live trajectory evidence below.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code or browser network flow changed.

<!-- evidence-row:llm-trajectory -->
- [x] Live trajectory evidence: tj-501e594bfb23a7 and tj-5d1c9601f33e8d reproduced the before failure; after porting the fix, the bot delivered `17 x 23 = 391` with plannerIter=0 and WEB_FETCH intact. Root-cause/evidence thread: https://github.com/elizaOS/eliza/discussions/14308#discussioncomment-17564759

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no DB row, memory, scheduled task, generated file, or other domain artifact is produced by this routing/planner behavior change.
