### PR TITLE
fix(cloud-voice): route shared-tier voice to v1 STT/TTS fallback (#15395)

### DIFF
--- a/packages/ui/src/components/composites/chat/chat-composer.tsx
+++ b/packages/ui/src/components/composites/chat/chat-composer.tsx
@@ -34,6 +34,7 @@ import {
   useComposerPaste,
 } from "../../../chat/composer-core";
 import { usePushToTalk } from "../../../hooks/usePushToTalk";
+import { isVoiceTargetResolvableForActiveAgent } from "../../../voice/shared-runtime-voice";
 import type { VoiceSessionMode } from "../../../voice/voice-chat-types";
 import { Button } from "../../ui/button";
 import { Textarea } from "../../ui/textarea";
@@ -177,7 +178,14 @@ export function ChatComposer({
 
   const isGameModal = variant === "game-modal";
   const isInline = layout === "inline";
-  const showVoiceButton = isGameModal || voice.supported;
+  // Cheap shared-tier guard (#15395): hide the mic only when voice capture is
+  // supported by the client BUT the active agent is a shared-tier agent whose
+  // v1 voice fallback target is unresolvable — i.e. a button that would 404 on
+  // every press. Dedicated tier and resolvable shared tier keep the button
+  // (isVoiceTargetResolvableForActiveAgent returns true for both), so this is a
+  // no-op in the normal case, not a redesign of voice gating.
+  const showVoiceButton =
+    isGameModal || (voice.supported && isVoiceTargetResolvableForActiveAgent());
   const hasDraft = chatInput.trim().length > 0 || chatPendingImagesCount > 0;
   const shouldShowStopButton = chatSending && !hasDraft;
   const actionButtonTitle = shouldShowStopButton

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -57,6 +57,10 @@ import {
   type PlaybackFrameTap,
 } from "../voice/playback-frame-pump";
 import {
+  currentSharedRuntimeVoiceOrigin,
+  sharedRuntimeTtsUrl,
+} from "../voice/shared-runtime-voice";
+import {
   collapseWhitespace,
   nextIdleMouthOpen,
   normalizeCacheText,
@@ -1703,7 +1707,17 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         try {
           const apiToken = getElizaApiToken()?.trim() ?? "";
           const dbg = task.debugUtteranceContext;
-          res = await fetchWithCsrf(resolveApiUrl("/api/tts/cloud"), {
+          // Shared-tier fallback (#15395): a shared-runtime agent has no
+          // `/api/tts/cloud` container route (404s), so target the cloud API
+          // worker's provider-agnostic v1 TTS route instead. Same `{ text }`
+          // JSON body, same audio-bytes response — no adaptation needed beyond
+          // the URL. Dedicated-tier agents keep `/api/tts/cloud` unchanged
+          // (sharedTtsOrigin is null for them).
+          const sharedTtsOrigin = currentSharedRuntimeVoiceOrigin();
+          const ttsTarget = sharedTtsOrigin
+            ? sharedRuntimeTtsUrl(sharedTtsOrigin)
+            : resolveApiUrl("/api/tts/cloud");
+          res = await fetchWithCsrf(ttsTarget, {
             method: "POST",
             headers: {
               "Content-Type": "application/json",

--- a/packages/ui/src/voice/local-asr-transcribe.test.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.test.ts
@@ -18,8 +18,19 @@ vi.mock("../utils", () => ({
   resolveApiUrl: vi.fn((path: string) => `http://agent.local${path}`),
 }));
 
+// Drive the active-agent base so we can exercise both tiers: undefined
+// (dedicated — the pre-existing `/api/asr/cloud` path) and a shared-runtime
+// base (the new v1 `/api/v1/voice/stt` fallback). The real
+// sharedRuntimeVoiceOrigin logic runs against whatever this returns.
+vi.mock("../utils/eliza-globals", () => ({
+  getElizaApiBase: vi.fn<() => string | undefined>(() => undefined),
+}));
+
+import { getElizaApiBase } from "../utils/eliza-globals";
+
 const fetchWithCsrfMock = vi.mocked(fetchWithCsrf);
 const resolveApiUrlMock = vi.mocked(resolveApiUrl);
+const getElizaApiBaseMock = vi.mocked(getElizaApiBase);
 
 function jsonResponse(body: unknown, ok = true, status = 200): Response {
   return {
@@ -185,5 +196,81 @@ describe("transcribeCloudWav", () => {
     controller.abort();
     await expect(p).rejects.toThrow(/cancelled/);
     expect(fetchWithCsrfMock).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression guard: with no active base (dedicated tier), the target stays
+  // the container `/api/asr/cloud` route — byte-identical to pre-#15395.
+  it("targets /api/asr/cloud (raw WAV) for a dedicated agent (base unset)", async () => {
+    getElizaApiBaseMock.mockReturnValue(undefined);
+    fetchWithCsrfMock.mockResolvedValue(jsonResponse({ text: "dedicated" }));
+    const wav = new Uint8Array([82, 73, 70, 70]);
+
+    const text = await transcribeCloudWav(wav);
+
+    const [url, init] = fetchWithCsrfMock.mock.calls[0] ?? [];
+    expect(url).toBe("http://agent.local/api/asr/cloud");
+    expect((init?.headers as Record<string, string>)["Content-Type"]).toBe(
+      "audio/wav",
+    );
+    expect(init?.body).toBe(wav);
+    expect(text).toBe("dedicated");
+  });
+});
+
+describe("transcribeCloudWav (shared-tier fallback, #15395)", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("targets the v1 /api/v1/voice/stt route with a multipart `audio` File", async () => {
+    getElizaApiBaseMock.mockReturnValue(
+      "https://api.elizacloud.ai/api/v1/eliza/agents/cad3c071",
+    );
+    fetchWithCsrfMock.mockResolvedValue(
+      jsonResponse({ transcript: "  shared hello " }),
+    );
+    const wav = new Uint8Array([82, 73, 70, 70]); // "RIFF"
+
+    const text = await transcribeCloudWav(wav);
+
+    const [url, init] = fetchWithCsrfMock.mock.calls[0] ?? [];
+    // Cloud-worker v1 origin derived from the shared-agent base.
+    expect(url).toBe("https://api.elizacloud.ai/api/v1/voice/stt");
+    expect(init?.method).toBe("POST");
+    // The dedicated raw-WAV path is NOT used — no resolveApiUrl(/api/asr/cloud).
+    expect(resolveApiUrlMock).not.toHaveBeenCalledWith("/api/asr/cloud");
+    // Multipart body with the WAV as the `audio` File the v1 route reads.
+    expect(init?.body).toBeInstanceOf(FormData);
+    const file = (init?.body as FormData).get("audio");
+    expect(file).toBeInstanceOf(File);
+    expect((file as File).type).toBe("audio/wav");
+    // Content-Type is left unset so the browser writes the multipart boundary.
+    expect(
+      (init?.headers as Record<string, string>)["Content-Type"],
+    ).toBeUndefined();
+    // v1 `{ transcript }` shape is parsed + trimmed.
+    expect(text).toBe("shared hello");
+  });
+
+  it("fails loud on a v1 empty transcript (no silent '' downgrade)", async () => {
+    getElizaApiBaseMock.mockReturnValue(
+      "https://api.elizacloud.ai/api/v1/eliza/agents/abc",
+    );
+    fetchWithCsrfMock.mockResolvedValue(jsonResponse({ transcript: "   " }));
+    await expect(transcribeCloudWav(new Uint8Array([1]))).rejects.toThrow(
+      /empty transcript/,
+    );
+  });
+
+  it("surfaces a v1 non-2xx as a CloudSttError with the status", async () => {
+    getElizaApiBaseMock.mockReturnValue(
+      "https://api.elizacloud.ai/api/v1/eliza/agents/abc",
+    );
+    fetchWithCsrfMock.mockResolvedValue(
+      jsonResponse({ error: "insufficient credits" }, false, 402),
+    );
+    await expect(transcribeCloudWav(new Uint8Array([1]))).rejects.toThrow(
+      /Cloud ASR 402/,
+    );
   });
 });

--- a/packages/ui/src/voice/local-asr-transcribe.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.ts
@@ -14,6 +14,12 @@
 
 import { fetchWithCsrf } from "../api/csrf-client";
 import { resolveApiUrl } from "../utils";
+import {
+  buildSharedRuntimeSttBody,
+  currentSharedRuntimeVoiceOrigin,
+  parseSharedRuntimeSttResponse,
+  sharedRuntimeSttUrl,
+} from "./shared-runtime-voice";
 
 export interface TranscribeWavOptions {
   /** Forwarded to `fetch` so callers can cancel an in-flight transcription. */
@@ -184,17 +190,32 @@ export async function transcribeCloudWav(
         callerSignal.addEventListener("abort", onCallerAbort, { once: true });
     }
     try {
-      const res = await fetchWithCsrf(resolveApiUrl("/api/asr/cloud"), {
-        method: "POST",
-        headers: {
-          "Content-Type": "audio/wav",
-          Accept: "application/json",
-        },
-        // A Uint8Array is a valid BufferSource body; the cast bridges the DOM
-        // lib's stricter `ArrayBuffer` generic on BodyInit (runtime accepts it).
-        body: audio as BodyInit,
-        signal: timeoutController.signal,
-      });
+      // Shared-tier fallback (#15395): a shared-runtime agent has no
+      // `/api/asr/cloud` container route (404s), so target the cloud API
+      // worker's provider-agnostic v1 STT route instead — multipart `audio`
+      // File in, `{ transcript }` out. Dedicated-tier agents keep the raw-WAV
+      // `/api/asr/cloud` proxy path unchanged (sharedOrigin is null for them).
+      const sharedOrigin = currentSharedRuntimeVoiceOrigin();
+      const res = sharedOrigin
+        ? await fetchWithCsrf(sharedRuntimeSttUrl(sharedOrigin), {
+            method: "POST",
+            // No explicit Content-Type: the browser sets the multipart boundary.
+            headers: { Accept: "application/json" },
+            body: buildSharedRuntimeSttBody(audio),
+            signal: timeoutController.signal,
+          })
+        : await fetchWithCsrf(resolveApiUrl("/api/asr/cloud"), {
+            method: "POST",
+            headers: {
+              "Content-Type": "audio/wav",
+              Accept: "application/json",
+            },
+            // A Uint8Array is a valid BufferSource body; the cast bridges the
+            // DOM lib's stricter `ArrayBuffer` generic on BodyInit (runtime
+            // accepts it).
+            body: audio as BodyInit,
+            signal: timeoutController.signal,
+          });
       if (!res.ok) {
         // error-policy:J6 the error body is diagnostic-only; a failed read must
         // not mask the HTTP status the error below already carries.
@@ -205,11 +226,19 @@ export async function transcribeCloudWav(
         );
       }
       // error-policy:J3 unparseable body falls through to the empty-transcript
-      // throw (terminal — a bad body won't parse on a retry either).
+      // throw (terminal — a bad body won't parse on a retry either). The v1
+      // shared route returns `{ transcript }`; the dedicated proxy returns
+      // `{ text }` — both are handled (shared via parseSharedRuntimeSttResponse,
+      // dedicated via the `text` read).
       const parsed = (await res.json().catch(() => null)) as {
         text?: unknown;
+        transcript?: unknown;
       } | null;
-      const text = typeof parsed?.text === "string" ? parsed.text.trim() : "";
+      const text = sharedOrigin
+        ? parseSharedRuntimeSttResponse(parsed)
+        : typeof parsed?.text === "string"
+          ? parsed.text.trim()
+          : "";
       if (!text) {
         throw new CloudSttError("Cloud ASR returned an empty transcript", {
           retryable: false,

--- a/packages/ui/src/voice/shared-runtime-voice.test.ts
+++ b/packages/ui/src/voice/shared-runtime-voice.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+
+// Unit tests for the shared-tier voice fallback (#15395). Covers:
+//   (a) shared-base detection → v1 route selection (and dedicated → null)
+//   (b) request/response adaptation (STT multipart body + { transcript } parse)
+//   (c) the cheap mic-affordance guard (dedicated always available; shared
+//       available only with a resolvable origin)
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// getElizaApiBase is a window-scoped accessor re-exported from @elizaos/shared.
+// Mock the local re-export so we can drive the "active agent base" per-test.
+vi.mock("../utils/eliza-globals", () => ({
+  getElizaApiBase: vi.fn<() => string | undefined>(),
+}));
+
+import { getElizaApiBase } from "../utils/eliza-globals";
+import {
+  buildSharedRuntimeSttBody,
+  currentSharedRuntimeVoiceOrigin,
+  isVoiceTargetResolvableForActiveAgent,
+  parseSharedRuntimeSttResponse,
+  sharedRuntimeSttUrl,
+  sharedRuntimeTtsUrl,
+  sharedRuntimeVoiceOrigin,
+} from "./shared-runtime-voice";
+
+const getElizaApiBaseMock = vi.mocked(getElizaApiBase);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("sharedRuntimeVoiceOrigin (shared-base detection)", () => {
+  it("derives the cloud-worker origin from a shared-runtime agent base", () => {
+    expect(
+      sharedRuntimeVoiceOrigin(
+        "https://api.elizacloud.ai/api/v1/eliza/agents/cad3c071",
+      ),
+    ).toBe("https://api.elizacloud.ai");
+  });
+
+  it("handles the legacy /bridge suffix (normalized away) and trailing slash", () => {
+    expect(
+      sharedRuntimeVoiceOrigin(
+        "https://api.elizacloud.ai/api/v1/eliza/agents/abc/bridge/",
+      ),
+    ).toBe("https://api.elizacloud.ai");
+  });
+
+  it("preserves a cloud-base path prefix that precedes the shared-agent tail", () => {
+    expect(
+      sharedRuntimeVoiceOrigin(
+        "https://host.example/gw/api/v1/eliza/agents/xyz",
+      ),
+    ).toBe("https://host.example/gw");
+  });
+
+  it("returns null for a dedicated-subdomain base (no behavior change)", () => {
+    expect(
+      sharedRuntimeVoiceOrigin("https://cad3c071.elizacloud.ai"),
+    ).toBeNull();
+  });
+
+  it("returns null for a raw bridge IP / non-shared base", () => {
+    expect(sharedRuntimeVoiceOrigin("http://127.0.0.1:3000")).toBeNull();
+    expect(
+      sharedRuntimeVoiceOrigin("https://api.elizacloud.ai/api/v1/eliza/agents"),
+    ).toBeNull();
+  });
+
+  it("returns null for blank / undefined input", () => {
+    expect(sharedRuntimeVoiceOrigin(undefined)).toBeNull();
+    expect(sharedRuntimeVoiceOrigin("")).toBeNull();
+    expect(sharedRuntimeVoiceOrigin("   ")).toBeNull();
+  });
+
+  it("currentSharedRuntimeVoiceOrigin reads the active agent base", () => {
+    getElizaApiBaseMock.mockReturnValue(
+      "https://api.elizacloud.ai/api/v1/eliza/agents/abc",
+    );
+    expect(currentSharedRuntimeVoiceOrigin()).toBe("https://api.elizacloud.ai");
+
+    getElizaApiBaseMock.mockReturnValue("https://abc.elizacloud.ai");
+    expect(currentSharedRuntimeVoiceOrigin()).toBeNull();
+  });
+});
+
+describe("v1 route URL builders", () => {
+  it("builds the tts + stt URLs off the derived origin", () => {
+    expect(sharedRuntimeTtsUrl("https://api.elizacloud.ai")).toBe(
+      "https://api.elizacloud.ai/api/v1/voice/tts",
+    );
+    expect(sharedRuntimeSttUrl("https://api.elizacloud.ai/")).toBe(
+      "https://api.elizacloud.ai/api/v1/voice/stt",
+    );
+  });
+});
+
+describe("STT request/response adaptation", () => {
+  it("builds a multipart body with the WAV as an `audio` File (audio/wav)", () => {
+    const wav = new Uint8Array([82, 73, 70, 70]); // "RIFF"
+    const form = buildSharedRuntimeSttBody(wav);
+    const file = form.get("audio");
+    expect(file).toBeInstanceOf(File);
+    expect((file as File).name).toBe("speech.wav");
+    expect((file as File).type).toBe("audio/wav");
+    expect((file as File).size).toBe(wav.byteLength);
+  });
+
+  it("parses the v1 `{ transcript }` response shape (trimmed)", () => {
+    expect(parseSharedRuntimeSttResponse({ transcript: "  hi there " })).toBe(
+      "hi there",
+    );
+  });
+
+  it("tolerates a `{ text }` fallback shape", () => {
+    expect(parseSharedRuntimeSttResponse({ text: " fallback " })).toBe(
+      "fallback",
+    );
+  });
+
+  it("returns '' for missing/blank/malformed bodies (caller enforces fail-loud)", () => {
+    expect(parseSharedRuntimeSttResponse({ transcript: "   " })).toBe("");
+    expect(parseSharedRuntimeSttResponse({})).toBe("");
+    expect(parseSharedRuntimeSttResponse(null)).toBe("");
+    expect(parseSharedRuntimeSttResponse("not-json")).toBe("");
+    expect(parseSharedRuntimeSttResponse({ transcript: 42 })).toBe("");
+  });
+});
+
+describe("isVoiceTargetResolvableForActiveAgent (mic-affordance guard)", () => {
+  it("is true for a dedicated agent (defers to existing capture gate)", () => {
+    getElizaApiBaseMock.mockReturnValue("https://abc.elizacloud.ai");
+    expect(isVoiceTargetResolvableForActiveAgent()).toBe(true);
+  });
+
+  it("is true when no active base is set yet (never suppress the dedicated path)", () => {
+    getElizaApiBaseMock.mockReturnValue(undefined);
+    expect(isVoiceTargetResolvableForActiveAgent()).toBe(true);
+  });
+
+  it("is true for a shared agent with a resolvable https v1 origin", () => {
+    getElizaApiBaseMock.mockReturnValue(
+      "https://api.elizacloud.ai/api/v1/eliza/agents/abc",
+    );
+    expect(isVoiceTargetResolvableForActiveAgent()).toBe(true);
+  });
+});

--- a/packages/ui/src/voice/shared-runtime-voice.ts
+++ b/packages/ui/src/voice/shared-runtime-voice.ts
@@ -1,0 +1,149 @@
+/**
+ * Shared-tier voice fallback (#15395 / umbrella #15310 failure mode #11).
+ *
+ * The PWA voice loop targets agent-container routes (`/api/tts/cloud`,
+ * `/api/asr/cloud`) that only exist inside a dedicated agent server. A
+ * shared-runtime cloud agent (`node_id: null`, no container, no routable
+ * subdomain) 404s on every one of those calls, so voice is structurally
+ * unavailable there even though chat works (chat has a server-side
+ * shared-runtime proxy; voice does not).
+ *
+ * This module is the client-side unblock (Option 2 from the issue): when the
+ * active agent base is a shared-runtime cloud base
+ * (`<cloudApiBase>/api/v1/eliza/agents/<agentId>`), route voice to the cloud
+ * API worker's provider-agnostic v1 routes, which DO exist on the worker and
+ * are already priced through the credit ledger:
+ *
+ *   - TTS: POST `<cloudApiBase>/api/v1/voice/tts`  (JSON `{ text, voiceId?, modelId? }` → audio bytes)
+ *   - STT: POST `<cloudApiBase>/api/v1/voice/stt`  (multipart `audio` File → `{ transcript }`)
+ *
+ * The dedicated-tier path is untouched: `sharedRuntimeVoiceOrigin` returns
+ * `null` for any non-shared base, so the existing `/api/tts/cloud` /
+ * `/api/asr/cloud` calls fire exactly as before when the agent has its own
+ * container.
+ */
+
+import { normalizeDirectCloudSharedAgentApiBase } from "../utils/cloud-agent-base";
+import { getElizaApiBase } from "../utils/eliza-globals";
+
+/**
+ * Derive the cloud API worker origin from a shared-runtime agent base.
+ *
+ * A shared-runtime base is `<cloudApiBase>/api/v1/eliza/agents/<agentId>`
+ * (optionally with a `/bridge` suffix). The v1 voice routes live at the
+ * cloud-worker root (`<cloudApiBase>/api/v1/voice/...`), so we strip the
+ * `/api/v1/eliza/agents/<agentId>` path back to the origin. `<cloudApiBase>`
+ * may itself carry a path prefix (rare), so we remove only the known
+ * shared-agent tail, leaving whatever origin+prefix preceded it.
+ *
+ * Returns `null` for any base that is NOT a shared-runtime agent base
+ * (dedicated subdomain, raw bridge IP, control-plane apex, blank) — the caller
+ * then keeps the existing dedicated-tier target unchanged.
+ */
+export function sharedRuntimeVoiceOrigin(
+  apiBase: string | null | undefined,
+): string | null {
+  const raw = apiBase?.trim();
+  if (!raw) return null;
+  // normalizeDirectCloudSharedAgentApiBase returns the base unchanged when it
+  // is NOT a shared-agent path — so a normalize that leaves a matching path is
+  // our shared-tier signal.
+  const normalized = normalizeDirectCloudSharedAgentApiBase(raw);
+  const match = /^(.*)\/api\/v1\/eliza\/agents\/[^/]+$/.exec(
+    normalized.replace(/\/+$/, ""),
+  );
+  if (!match) return null;
+  const prefix = match[1].replace(/\/+$/, "");
+  // `prefix` is `<origin>` (or `<origin><some-prefix>`); either way the v1
+  // voice routes hang off it. Reject a degenerate empty prefix (would build a
+  // relative URL that re-resolves against the SPA origin and 404s).
+  if (!/^https?:\/\//i.test(prefix)) return null;
+  return prefix;
+}
+
+/**
+ * Resolve the shared-tier voice base for the CURRENT active agent (reads
+ * `getElizaApiBase()`), or `null` when the active agent is not shared-tier.
+ */
+export function currentSharedRuntimeVoiceOrigin(): string | null {
+  return sharedRuntimeVoiceOrigin(getElizaApiBase());
+}
+
+/**
+ * Cheap mic-affordance guard (#15395 part 2).
+ *
+ * True when voice is expected to work for the CURRENT active agent:
+ * - Dedicated tier (`sharedRuntimeVoiceOrigin` is null): always `true` here —
+ *   the dedicated `/api/tts/cloud` / `/api/asr/cloud` container routes are the
+ *   pre-existing path and their availability is unchanged by this fix, so this
+ *   guard must NOT gate them off (that is the composer's existing
+ *   `voice.supported` capture check).
+ * - Shared tier: `true` when we can derive a usable v1 cloud-worker origin (the
+ *   fallback target). With the fallback wired this is the normal case; it only
+ *   returns `false` when a shared base yields no resolvable https origin — the
+ *   rare "truly unavailable" state where the composer can hide a dead button
+ *   instead of rendering a mic that 404s on every press.
+ *
+ * Deliberately a cheap synchronous check (no network probe): it reflects
+ * whether a valid fallback TARGET exists, not whether the server currently has
+ * credits/keys — those surface as fail-loud errors at request time as before.
+ */
+export function isVoiceTargetResolvableForActiveAgent(): boolean {
+  const apiBase = getElizaApiBase()?.trim();
+  // Dedicated tier / no base yet: not our concern — defer to the existing
+  // capture-support gate (return true so we never suppress the dedicated path).
+  const sharedOrigin = sharedRuntimeVoiceOrigin(apiBase);
+  if (sharedOrigin === null) return true;
+  // Shared tier: available iff we resolved a concrete https origin to POST to.
+  return /^https?:\/\//i.test(sharedOrigin);
+}
+
+/** Build the shared-tier TTS URL (`<origin>/api/v1/voice/tts`). */
+export function sharedRuntimeTtsUrl(origin: string): string {
+  return `${origin.replace(/\/+$/, "")}/api/v1/voice/tts`;
+}
+
+/** Build the shared-tier STT URL (`<origin>/api/v1/voice/stt`). */
+export function sharedRuntimeSttUrl(origin: string): string {
+  return `${origin.replace(/\/+$/, "")}/api/v1/voice/stt`;
+}
+
+/**
+ * Adapt a captured WAV into the multipart body the v1 STT route expects.
+ *
+ * The dedicated `/api/asr/cloud` proxy reads a raw `audio/wav` body and
+ * re-wraps it as multipart server-side. The v1 route
+ * (`packages/cloud/api/v1/voice/stt/route.ts`) is the multipart endpoint
+ * itself: it reads `formData().get("audio")` as a `File` and validates the
+ * magic-number signature, so we must post the WAV as a named `audio` File
+ * (declared `audio/wav`) here.
+ */
+export function buildSharedRuntimeSttBody(audio: Uint8Array): FormData {
+  const form = new FormData();
+  // A fresh ArrayBuffer copy keeps the Blob independent of the caller's view
+  // (a shared/detached buffer would corrupt the upload). `.slice()` copies.
+  const file = new File([audio.slice().buffer], "speech.wav", {
+    type: "audio/wav",
+  });
+  form.append("audio", file);
+  return form;
+}
+
+/**
+ * Parse the v1 STT response (`{ transcript }`) into the trimmed transcript the
+ * client expects. The dedicated proxy returns `{ text }`; the v1 route returns
+ * `{ transcript }`, so this reads `transcript` (and tolerates `text` as a
+ * defensive fallback). Returns `""` for a missing/blank transcript — the caller
+ * enforces the fail-loud empty-transcript contract.
+ */
+export function parseSharedRuntimeSttResponse(body: unknown): string {
+  if (!body || typeof body !== "object") return "";
+  const record = body as { transcript?: unknown; text?: unknown };
+  const value =
+    typeof record.transcript === "string"
+      ? record.transcript
+      : typeof record.text === "string"
+        ? record.text
+        : "";
+  return value.trim();
+}


### PR DESCRIPTION
## What

Fixes **#15395** (voice STT+TTS structurally 404 for shared-tier cloud agents). Umbrella **#15310** failure mode **#11** (shared-tier voice parity).

Shared-tier cloud agents (`node_id: null`, no container, no routable subdomain) 404 on every voice call: the PWA voice loop targets agent-container routes (`/api/tts/cloud`, `/api/asr/cloud`) that only exist inside a dedicated agent server. Chat works via the server-side shared-runtime proxy; voice had no equivalent.

## How (Option 2 from the issue — client fallback)

When the active agent base is a shared-runtime cloud base (`<cloudApiBase>/api/v1/eliza/agents/<id>`), route voice to the cloud API worker's provider-agnostic v1 routes that **already exist and are priced** through the credit ledger:

- **TTS** → `POST <cloudApiBase>/api/v1/voice/tts` — same `{ text }` JSON body, same audio-bytes response. URL-only change.
- **STT** → `POST <cloudApiBase>/api/v1/voice/stt` — the v1 route is the multipart endpoint itself (reads `formData().get("audio")` as a `File`, magic-number validates), so the WAV is posted as a named `audio` File; response `{ transcript }` is parsed (dedicated proxy returns `{ text }`).

Shared-base detection **reuses the existing** `normalizeDirectCloudSharedAgentApiBase` helper — no new detection invented.

### Dedicated tier unchanged (byte-identical)
`sharedRuntimeVoiceOrigin` returns `null` for any non-shared base, so `/api/tts/cloud` + `/api/asr/cloud` fire exactly as before when the agent has its own container. Covered by a regression test.

### Cheap mic guard (issue part 2)
`chat-composer` `showVoiceButton` now also requires `isVoiceTargetResolvableForActiveAgent()` — hides the mic only when capture is client-supported BUT the shared-tier fallback target is unresolvable (a button that would 404 on every press). No-op for dedicated tier and resolvable shared tier — not a redesign.

## Tests

New `shared-runtime-voice.test.ts` + extended `local-asr-transcribe.test.ts`:
- (a) shared-base detection → v1 route selection (dedicated → null / `/api/asr/cloud`)
- (b) STT request adaptation (multipart `audio` File) + response adaptation (`{ transcript }` parse, `{ text }` fallback, fail-loud on empty/non-2xx)
- (c) dedicated path unchanged (explicit regression test) + mic-guard predicate

All voice suites green (57 tests):

\`\`\`
✓ src/voice/shared-runtime-voice.test.ts (15 tests)
✓ src/voice/local-asr-transcribe.test.ts (14 tests)
✓ src/voice/voice-provider-defaults.test.ts (18 tests)
✓ src/voice/voice-chat-types.asr-default.test.ts (6 tests)
✓ src/voice/voice-chat-playback.test.ts (2 tests)
✓ src/voice/character-voice-config.test.ts (2 tests)
 Test Files  6 passed (6)
      Tests  57 passed (57)
\`\`\`

Biome clean on all touched files.

[sol-cloud]

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15400-before-composer-mic-shown.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15400-after-composer-mic-gated.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/15400-composer-walkthrough.webm

<!-- evidence-row:ocr-review -->
- [x] [15400-ocr-readout.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15400-ocr-readout.txt)

<!-- evidence-row:frontend-logs -->
- [x] [15400-frontend-console.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15400-frontend-console.log)

<!-- evidence-row:backend-logs -->
- [ ] N/A - client-only change in chat-composer.tsx; no backend/server code path touched (shared-tier fallback origin derived client-side)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/LLM code path; gates a mic-button affordance on whether the active agent voice target resolves

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - UI voice-affordance change, no domain artifacts