### PR TITLE
ci(worker-deploy): reconcile DATABASE_URL into the CP env like the other control-plane secrets

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -93,6 +93,16 @@ jobs:
       # is unset the reconcile loop skips it and preserves any hand-set value,
       # so this is a no-op until the operator sets the GH secret.
       SANDBOX_REGISTRY_REDIS_URL: ${{ secrets.SANDBOX_REGISTRY_REDIS_URL }}
+      # Cloud database DSN for the provisioning worker + agent router. Same
+      # fallback chain as the migrator jobs (cloud-cf-deploy.yml /
+      # cloud-deploy-backend.yml) so the CP daemon always resolves the exact
+      # DB the Worker schema is migrated against. Before this, DATABASE_URL
+      # only lived hand-edited on the box: when staging moved Neon → Railway
+      # the CP silently kept polling the abandoned Neon DB for 3 weeks
+      # (#15160). Reconciled into /opt/eliza/cloud/.env.local with the same
+      # skip-when-unset semantics as HEADSCALE_* — an environment without any
+      # of these secrets keeps its current hand-set value.
+      DATABASE_URL: ${{ secrets.DATABASE_URL || secrets.RAILWAY_DATABASE_URL || secrets.NEON_DATABASE_URL }}
     steps:
       - name: Check deploy configuration
         id: deploy_config
@@ -170,7 +180,7 @@ jobs:
           username: deploy
           key: ${{ env.DEPLOY_SSH_KEY }}
           command_timeout: 10m
-          envs: DEPLOY_BRANCH,SYSTEMD_UNIT,HEADSCALE_API_URL,HEADSCALE_PUBLIC_URL,HEADSCALE_API_KEY,SANDBOX_REGISTRY_REDIS_URL
+          envs: DEPLOY_BRANCH,SYSTEMD_UNIT,HEADSCALE_API_URL,HEADSCALE_PUBLIC_URL,HEADSCALE_API_KEY,SANDBOX_REGISTRY_REDIS_URL,DATABASE_URL
           script: |
             set -euo pipefail
             echo "=== Deploying eliza-provisioning-worker (branch: $DEPLOY_BRANCH) ==="
@@ -296,19 +306,23 @@ jobs:
             sudo systemctl daemon-reload
             sudo systemctl enable "$SYSTEMD_UNIT" eliza-agent-router.service
 
-            # Reconcile Headscale wiring into the systemd EnvironmentFile so CI
-            # is the single source of truth and the box self-heals on every
-            # deploy. The daemon + cloud-shared read HEADSCALE_API_URL /
-            # HEADSCALE_PUBLIC_URL / HEADSCALE_API_KEY straight from process.env
-            # (headscale-client.ts, headscale-integration.ts,
-            # docker-sandbox-provider.ts), fed by EnvironmentFile=
-            # /opt/eliza/cloud/.env.local. The deploy's `git clean -e
-            # cloud/.env.local` preserves that file verbatim, so before this it
-            # was only ever hand-edited on the box and could drift to a stale
-            # headscale (the CP-box outage). Only rewrite a key when the CI value
-            # is non-empty — an unset GH var must never blank a working box (a
-            # blank HEADSCALE_API_KEY makes docker-sandbox-provider throw
-            # "HEADSCALE_API_KEY is not configured" when a route is required).
+            # Reconcile control-plane secrets (HEADSCALE_API_URL /
+            # HEADSCALE_PUBLIC_URL / HEADSCALE_API_KEY /
+            # SANDBOX_REGISTRY_REDIS_URL / DATABASE_URL) into the systemd
+            # EnvironmentFile so CI is the single source of truth and the box
+            # self-heals on every deploy. The daemon + cloud-shared read these
+            # straight from process.env (headscale-client.ts,
+            # headscale-integration.ts, docker-sandbox-provider.ts, the DB
+            # client), fed by EnvironmentFile=/opt/eliza/cloud/.env.local. The
+            # deploy's `git clean -e cloud/.env.local` preserves that file
+            # verbatim, so before this these keys were only ever hand-edited on
+            # the box and could drift to a stale headscale (the CP-box outage)
+            # or a stale database (#15160: the CP polled an abandoned Neon DB
+            # for 3 weeks after staging moved to Railway). Only rewrite a key
+            # when the CI value is non-empty — an unset GH var/secret must
+            # never blank a working box (a blank HEADSCALE_API_KEY makes
+            # docker-sandbox-provider throw "HEADSCALE_API_KEY is not
+            # configured" when a route is required).
             ENV_FILE=/opt/eliza/cloud/.env.local
             sudo touch "$ENV_FILE"
             # Pin this control-plane daemon to the AGENT lane. Unset, a single
@@ -326,7 +340,8 @@ jobs:
               "HEADSCALE_API_URL=$HEADSCALE_API_URL" \
               "HEADSCALE_PUBLIC_URL=$HEADSCALE_PUBLIC_URL" \
               "HEADSCALE_API_KEY=$HEADSCALE_API_KEY" \
-              "SANDBOX_REGISTRY_REDIS_URL=$SANDBOX_REGISTRY_REDIS_URL"; do
+              "SANDBOX_REGISTRY_REDIS_URL=$SANDBOX_REGISTRY_REDIS_URL" \
+              "DATABASE_URL=$DATABASE_URL"; do
               key="${kv%%=*}"
               val="${kv#*=}"
               [ -n "$val" ] || continue


### PR DESCRIPTION
## What

Adds `DATABASE_URL` to the set of control-plane secrets the provisioning-worker deploy reconciles into `/opt/eliza/cloud/.env.local`, exactly in the established `HEADSCALE_*` / `SANDBOX_REGISTRY_REDIS_URL` pattern. Item 1 of #15401.

## Why

Postmortem line from #15160: the staging CP's `DATABASE_URL` only lived hand-edited on the box (the deploy's `git clean -e cloud/.env.local` preserves it verbatim), so when staging moved Neon → Railway, the CP silently kept polling the abandoned Neon DB for **three weeks** — jobs enqueued by the Worker in the live DB were never picked up, and nothing failed loudly. This is the same drift class the `HEADSCALE_*` reconcile was added for; the DB pointer just wasn't in the reconciled set.

## How

- Secret resolved through the **same fallback chain the migrator jobs already use** on these GitHub environments (`cloud-cf-deploy.yml` / `cloud-deploy-backend.yml`): `secrets.DATABASE_URL || secrets.RAILWAY_DATABASE_URL || secrets.NEON_DATABASE_URL`. The CP daemon therefore always resolves the exact DB the Worker schema is migrated against — they can no longer diverge, which is precisely the #15160 failure mode. No new secret name invented (mirrors how `HEADSCALE_API_KEY` reused the canonical names from `arm-headscale-control-plane.yml`).
- Plumbed end-to-end like the existing keys: `env:` block → ssh-action `envs:` passthrough → reconcile loop.
- **Skip-when-unset semantics preserved**: the loop's `[ -n "$val" ] || continue` means an environment without any of the three DB secrets keeps its current hand-set value — never blanks a working box.
- Reconcile-set comments updated (env block + loop) to list `DATABASE_URL` and record the #15160 postmortem.

## Operator step

Both `staging` and `production` GitHub environments **already have `DATABASE_URL` set** (it gates the migrator's fail-fast on every deploy), so no new secret is required. Before the first deploy after merge, verify the staging environment's `DATABASE_URL` secret is the Railway `eliza_staging` DSN (post-#15160 repoint) — from then on the CP self-heals to it on every deploy, and any future DB move is done by rotating the environment secret, not by SSHing into the box.

## Validation

- `actionlint` on the workflow: clean (exit 0)
- `bash -n` on all three embedded ssh-action scripts (extracted): clean
- Reconcile-loop simulation: CI-set DSN (with `=` in query params, e.g. `?sslmode=require`) replaces a stale hand-set value without touching sibling keys like `TEST_DATABASE_URL`; unset secret preserves the hand-set value verbatim

[stan-cloud]


<!-- evidence-row:before-screenshots -->
- [ ] N/A - CI/deploy workflow secret reconciliation only; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - CI/deploy workflow secret reconciliation only; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no browser or user-facing walkthrough applies to this control-plane deploy workflow change.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend service runtime changed; validation is actionlint, bash -n on embedded scripts, and reconcile-loop simulation listed above.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code, browser console, or network surface changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, agent trajectory, or inference behavior changed.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - domain behavior is deploy-time DATABASE_URL reconciliation; PR validation above covers the set/unset and stale-value replacement cases.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual media or text-rendering surface changed.
