### PR TITLE
perf(docker): layer-split deps + registry build cache for the agent image

### DIFF
--- a/.github/workflows/build-agent-image.yml
+++ b/.github/workflows/build-agent-image.yml
@@ -99,6 +99,23 @@ jobs:
         run: |
           bun install --no-frozen-lockfile
 
+      - name: Cache Turbo build outputs
+        # The turbo build below is the single biggest pre-docker cost (~5-6
+        # min from cold). Nothing persisted turbo's local task cache between
+        # runs, so every push rebuilt every filtered package from scratch.
+        # Keying on the commit SHA (with a prefix restore-key) restores the
+        # most recent cache and saves an updated one each run, so a typical
+        # source commit only rebuilds the packages it actually touched.
+        # The key prefix is workflow-specific: entries here are produced
+        # under NODE_ENV=production, which turbo does not hash, so they must
+        # not be replayed into other workflows' builds.
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: .turbo/cache
+          key: turbo-agent-image-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            turbo-agent-image-${{ runner.os }}-
+
       - name: Apply postinstall patches
         # Belt-and-suspenders for the postinstall path: even with
         # `bun install` (postinstall enabled), the silent fallback that
@@ -149,6 +166,13 @@ jobs:
             --filter=@elizaos/plugin-wallet \
             --filter=@elizaos/plugin-workflow \
             --filter=@elizaos/plugin-x402
+
+      - name: Prune stale Turbo cache entries
+        # actions/cache restores + re-saves the whole cache dir, so without a
+        # prune the tarball grows by every commit's changed-package outputs
+        # forever. tar preserves mtimes, so age-based deletion bounds it:
+        # entries untouched for two weeks are long since superseded.
+        run: find .turbo/cache -type f -mtime +14 -delete 2>/dev/null || true
 
       - name: Normalize plugin dist for Node ESM
         # MUST run AFTER the Turbo build above. Some package builds still emit
@@ -232,8 +256,23 @@ jobs:
           tags: ${{ steps.image.outputs.name }}:ci-boot-verify
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Registry-backed build cache (checked first), with the old GHA
+          # cache kept as a read-only fallback. The GHA backend shares one
+          # repo-wide 10GB budget with every other workflow; this image's
+          # mode=max cache is multi-GB per run, so it was evicted before the
+          # next develop push — recent runs show ZERO cached layers while
+          # still spending 4+ min per run exporting a cache nothing ever
+          # read (which is also why cache-to no longer writes to gha). The
+          # ghcr :buildcache ref persists indefinitely and dedupes by blob
+          # digest, so stable layers (apt/tailscale/yt-dlp/tsx base, and the
+          # manifest-keyed runtime-deps npm closure) hit reliably and the
+          # per-run cache export only uploads blobs ghcr doesn't already
+          # have. image-manifest+oci-mediatypes make the cache manifest a
+          # ghcr-compatible OCI artifact.
+          cache-from: |
+            type=registry,ref=${{ steps.image.outputs.name }}:buildcache
+            type=gha
+          cache-to: type=registry,ref=${{ steps.image.outputs.name }}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
 
       - name: Verify image boots (real agent entrypoint)
         # Runs the production entrypoint (node --import

--- a/packages/app-core/deploy/Dockerfile.ci
+++ b/packages/app-core/deploy/Dockerfile.ci
@@ -21,16 +21,6 @@ ARG VERSION_CLEAN=""
 ARG REVISION=""
 ARG TAILSCALE_VERSION=1.90.8
 
-FROM node:${NODE_VERSION}-slim AS pruner
-WORKDIR /app
-COPY . .
-ARG APP_CORE_DIR
-ARG AGENT_DIR
-ARG APP_DIR
-
-RUN node "${APP_CORE_DIR}/scripts/relink-workspace-packages-to-dist.mjs" \
-  @elizaos/agent
-
 # Some relinked local packages expect their third-party (non-@elizaos) runtime
 # dependencies to be resolvable from /app/node_modules. Host node_modules is
 # excluded from the Docker context (see .dockerignore: **/node_modules), so
@@ -57,23 +47,55 @@ RUN node "${APP_CORE_DIR}/scripts/relink-workspace-packages-to-dist.mjs" \
 # tree) are excluded inside the script: they are linked for resolution
 # integrity but never imported by the headless server runtime, so installing
 # their frontend deps would only bloat the image.
-RUN mkdir -p /tmp/docker-runtime-deps \
-  && cd /tmp/docker-runtime-deps \
+#
+# This stage deliberately COPYs ONLY the dependency manifests (bun.lock + the
+# workspace package.json set — the sole inputs of
+# collect-docker-runtime-deps.mjs), NOT the whole source tree. That keeps the
+# expensive `npm install` layer's cache key independent of per-commit source
+# changes: it only rebuilds when the lockfile, a workspace package.json, or
+# the collector script itself changes. With the registry build cache this
+# turns ~80s of npm install into a cache hit on the typical source-only
+# commit.
+FROM node:${NODE_VERSION}-slim AS runtime-deps
+WORKDIR /app
+ARG APP_CORE_DIR
+COPY --parents bun.lock \
+  packages/*/package.json \
+  packages/cloud/*/package.json \
+  plugins/*/package.json \
+  ${APP_CORE_DIR}/scripts/collect-docker-runtime-deps.mjs \
+  ./
+RUN mkdir -p /deps \
+  && cd /deps \
   && npm init -y >/dev/null \
   && node "/app/${APP_CORE_DIR}/scripts/collect-docker-runtime-deps.mjs" \
-       > /tmp/docker-runtime-deps/deps.txt \
-  && echo "Installing $(wc -l < /tmp/docker-runtime-deps/deps.txt) derived runtime deps" \
+       > /deps/deps.txt \
+  && echo "Installing $(wc -l < /deps/deps.txt) derived runtime deps" \
   && npm install --omit=dev --ignore-scripts --no-package-lock \
     --legacy-peer-deps \
     --fetch-retries=5 \
     --fetch-retry-mintimeout=20000 \
     --fetch-retry-maxtimeout=120000 \
-    $(cat /tmp/docker-runtime-deps/deps.txt) \
-  && mkdir -p /app/node_modules \
+    $(cat /deps/deps.txt)
+
+FROM node:${NODE_VERSION}-slim AS pruner
+WORKDIR /app
+COPY . .
+ARG APP_CORE_DIR
+ARG AGENT_DIR
+ARG APP_DIR
+
+RUN node "${APP_CORE_DIR}/scripts/relink-workspace-packages-to-dist.mjs" \
+  @elizaos/agent
+
+# Overlay the derived third-party runtime closure (prepared by the
+# runtime-deps stage above) onto /app/node_modules. The rm -rf pre-clean
+# keeps the closure authoritative over any same-named copies a build context
+# might carry, matching the previous in-stage install semantics.
+RUN mkdir -p /app/node_modules \
   && node "/app/${APP_CORE_DIR}/scripts/collect-docker-runtime-deps.mjs" --names \
-     | while IFS= read -r dep; do [ -n "$dep" ] && rm -rf "/app/node_modules/$dep"; done \
-  && cp -a /tmp/docker-runtime-deps/node_modules/. /app/node_modules/ \
-  && rm -rf /tmp/docker-runtime-deps
+     | while IFS= read -r dep; do [ -n "$dep" ] && rm -rf "/app/node_modules/$dep"; done
+COPY --from=runtime-deps /deps/node_modules/ /app/node_modules/
 
 RUN node "${APP_CORE_DIR}/scripts/link-docker-local-app-packages.mjs"
 


### PR DESCRIPTION
Cuts the agent-image pipeline (`Build Agent Image`, ghcr.io/elizaos/eliza) from ~24.5 min to an expected ~14–16 min for a typical source-only develop push. Layer restructure + cache config only — **the runtime image content and boot behavior are unchanged**, and the ci-boot-verify gate still runs against the exact bytes that get pushed.

## Where the 24.5 min actually goes (run [28903633586](https://github.com/elizaOS/eliza/actions/runs/28903633586), develop, green)

| Step | Time | Problem |
|---|---|---|
| turbo build (runner-side) | 5m43s | no turbo cache persisted → cold rebuild of all ~25 filtered packages every push |
| docker build | 9m49s | **zero** `CACHED` layers — the gha cache is evicted before the next develop push; 81s in-image `npm install` re-runs every commit behind `COPY . .`; **258s spent exporting a mode=max gha cache that nothing ever reads** |
| image load (buildx→daemon) | ~3.5m | inherent to `load: true` (not touched) |
| docker push | 5m12s | real bytes (not touched) |

## The three changes

### 1. Dockerfile: manifest-only `runtime-deps` stage (saves ~80s/commit + unlocks caching)
The derived third-party runtime closure (`collect-docker-runtime-deps.mjs` → `npm install`, 136 deps) used to run inside the `pruner` stage **after** `COPY . .`, so every commit invalidated it. The collector's only inputs are `bun.lock` + the workspace `package.json` set, so the install now lives in its own stage that `COPY --parents` copies exactly those manifests (stable under `# syntax=docker/dockerfile:1.23`, verified locally). The pruner overlays the prebuilt closure with `COPY --from=runtime-deps` at the same point in the sequence, preceded by the same `rm -rf` pre-clean.

**Invalidation, before → after:** every commit → only when `bun.lock`, a workspace `package.json`, or the collector script changes.

### 2. Workflow: persist turbo's local task cache (saves ~4min/commit)
`actions/cache` on `.turbo/cache`, sha-keyed with a prefix restore-key, so a typical commit rebuilds only the packages it touched instead of all of them from cold. Workflow-scoped key prefix (entries are built under `NODE_ENV=production`, which turbo doesn't hash — they must not leak into other workflows). An mtime prune keeps the tarball bounded.

**Invalidation, before → after:** every run was cold → per-package turbo task hashes (source/deps/config of each package).

### 3. Workflow: registry build cache on ghcr (saves ~4-6min/commit)
`cache-from` now checks `ghcr.io/elizaos/eliza:buildcache` first (gha kept as a read-only fallback), `cache-to` writes the registry ref with `mode=max,image-manifest=true,oci-mediatypes=true`. The gha backend shares one repo-wide 10GB budget with every other workflow and this cache is multi-GB per run, so it was evicted before the next develop push — the run above shows 0 cached layers while still paying 258s/run to export it. The ghcr ref persists, dedupes by blob digest (per-run export only uploads blobs ghcr doesn't already have), and gives reliable hits on the apt/tailscale/yt-dlp/tsx base layers (~45s) and the new runtime-deps closure (~80s).

**Invalidation, before → after:** effectively always-miss → content-addressed, persistent.

## What is deliberately NOT changed
- Image contents: same 136-dep closure pinned by the same collector (local build's `deps.txt` is byte-count-identical to the last green CI run's "Installing 136 derived runtime deps"), same relink → closure-overlay → link → prune sequence, same final stage, same entrypoint.
- The verify-then-retag-push flow (`push: false` + `load: true` + boot gate) — untouched, so the published bytes are still exactly the verified bytes.
- `docker-ci-smoke.sh` and `tee-build-deploy.yml` build this same Dockerfile with plain `docker build` — the new stage needs nothing beyond the already-pinned dockerfile frontend.
- Not addressed here (future work): the ~3.5min buildx→daemon load round-trip and the 5min push.

## Validation
- Workflow YAML parses (`yaml.safe_load`); `docker build --check` clean.
- The new `runtime-deps` stage was built **for real** against the repo context (docker 29.5.3): collector emitted 136 specifiers (matches CI), npm installed 1377 packages.
- Cache-key proof: appended a comment to `packages/core/src/index.ts` and rebuilt — the manifest `COPY --parents` layer and the npm layer stayed `CACHED`.
- `--target pruner` on a dist-less tree fails at the pre-existing relink step exactly as develop's Dockerfile does (dists are built by the workflow before docker), confirming stage wiring is unchanged upstream of the swap.
- Real end-to-end proof needs a workflow run on the Hetzner runners; see the dispatch runs linked in comments below (first run = cold cache/baseline shape, second run = warmed caches). **Please don't merge before the branch run is green.**

<!-- evidence-row:video --> N/A - CI/build infrastructure change, no user-facing surface to record.
<!-- evidence-row:screenshots-desktop --> N/A - no UI change.
<!-- evidence-row:screenshots-mobile --> N/A - no UI change.
<!-- evidence-row:backend-logs --> Local validation log attached (release asset `pr-evidence`): real `docker build` of the new runtime-deps stage + CACHED-layer proof under a source-only change + deps.txt parity with CI run 28903633586.
<!-- evidence-row:frontend-logs --> N/A - no frontend involved.
<!-- evidence-row:trajectories --> N/A - no agent/model/prompt behavior change; the image runtime content is byte-equivalent by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- evidence-row:before-screenshots -->
- [ ] N/A - CI/docker pipeline change; no UI surface.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - CI/docker pipeline change; no UI surface.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no UI; the proof is two real pipeline runs (A/B table in the PR comment).

<!-- evidence-row:backend-logs -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/15403-backend-logs.txt

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model-path change; build pipeline only.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the domain artifacts ARE the two green workflow runs (cold 21m18s, warm 15m29s, boot-verify passed) linked in the PR comment A/B table.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual media.
