### PR TITLE
fix(cloud): node re-registration preserves operator-set capacity

### DIFF
--- a/packages/cloud/api/__tests__/bootstrap-callback-node-identity.test.ts
+++ b/packages/cloud/api/__tests__/bootstrap-callback-node-identity.test.ts
@@ -215,11 +215,56 @@ describe("bootstrap-callback node-identity guard (#12876)", () => {
 
     expect(res.status).toBe(200);
     expect(mockUpdate).toHaveBeenCalledTimes(1);
-    // Identity preserved, non-identity field (capacity) still updated.
+    // Identity preserved. Capacity is operator-owned once the row exists, so a
+    // re-bootstrap must NOT write it — the request value is ignored here.
     expect(lastUpdateArg?.hostname).toBe("10.0.0.1");
     expect(lastUpdateArg?.ssh_user).toBe("root");
     expect(lastUpdateArg?.ssh_port).toBe(22);
-    expect(lastUpdateArg?.capacity).toBe(16);
+    expect(lastUpdateArg).not.toHaveProperty("capacity");
+  });
+
+  test("re-bootstrap preserves an operator-tuned capacity (does not reset to the request/default)", async () => {
+    // A 252 GB robot the operator hand-tuned to 24 slots via a direct DB write.
+    stored = { ...EXISTING, capacity: 24, metadata: { ...EXISTING.metadata } };
+
+    const res = await post({
+      nodeId: "node-1",
+      hostname: "10.0.0.1",
+      sshUser: "root",
+      sshPort: 22,
+      // Callback reports the small-box default; it must not clobber the tune.
+      capacity: 8,
+      hostKeyFingerprint: "SHA256:pinned-fingerprint",
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(lastUpdateArg).not.toHaveProperty("capacity");
+    expect(stored?.capacity).toBe(24);
+  });
+
+  test("brand-new node still gets its capacity stamped from the request", async () => {
+    stored = null; // findByNodeId returns null → insert path
+    let createdCapacity: number | undefined;
+    mockCreate.mockImplementationOnce(async (data: StoredNode) => {
+      createdCapacity = data.capacity;
+      stored = { ...data, id: "node-row-new" };
+      return stored;
+    });
+
+    const res = await post({
+      nodeId: "node-3",
+      hostname: "10.0.0.60",
+      sshUser: "root",
+      sshPort: 22,
+      capacity: 24,
+      hostKeyFingerprint: "SHA256:new-node",
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(createdCapacity).toBe(24);
   });
 
   test("rejects liveness re-bootstrap without the required pinned fingerprint", async () => {

--- a/packages/cloud/api/v1/admin/docker-nodes/bootstrap-callback/route.ts
+++ b/packages/cloud/api/v1/admin/docker-nodes/bootstrap-callback/route.ts
@@ -145,11 +145,17 @@ async function __hono_POST(request: Request) {
       // fingerprint-proven re-bootstrap (identityChanged && verified above);
       // otherwise the server-stored values are preserved verbatim so an
       // unauthenticated re-bootstrap caller cannot silently rewrite them.
+      //
+      // `capacity` is deliberately NOT written here: once a node exists, its
+      // slot count is operator-owned (set via the admin PATCH route or a direct
+      // DB tune). The callback default is sized for the small cpx32-class box
+      // it was born on, so re-writing it on every liveness re-bootstrap would
+      // silently reset a hand-tuned value (e.g. a 252 GB robot at capacity=24
+      // back to 8). Capacity is stamped only on the create path below.
       const updated = await dockerNodesRepository.update(existing.id, {
         hostname: identityChanged ? hostname : existing.hostname,
         ssh_port: identityChanged ? sshPort : existing.ssh_port,
         ssh_user: identityChanged ? sshUser : existing.ssh_user,
-        capacity,
         host_key_fingerprint: hasPinnedFingerprint
           ? existing.host_key_fingerprint
           : hostKeyFingerprint,

--- a/packages/scripts/cloud/admin/onboard-docker-node.test.ts
+++ b/packages/scripts/cloud/admin/onboard-docker-node.test.ts
@@ -6,6 +6,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   buildOnboardSshConfig,
+  capacityForOnboardUpsert,
   hostKeyFingerprintForOnboardUpsert,
   parseArgs,
   parseDockerPs,
@@ -163,7 +164,7 @@ describe("host-key pinning helpers", () => {
     const onHostKeyDiscovered = async () => {};
     const config = buildOnboardSshConfig(
       args,
-      { host_key_fingerprint: "pinned-fingerprint" },
+      { host_key_fingerprint: "pinned-fingerprint", capacity: 8 },
       onHostKeyDiscovered,
     );
 
@@ -183,7 +184,7 @@ describe("host-key pinning helpers", () => {
     expect(
       buildOnboardSshConfig(
         args,
-        { host_key_fingerprint: null },
+        { host_key_fingerprint: null, capacity: 8 },
         onHostKeyDiscovered,
       ).hostKeyFingerprint,
     ).toBeUndefined();
@@ -195,7 +196,7 @@ describe("host-key pinning helpers", () => {
   it("never overwrites an established pin with a re-onboard capture", () => {
     expect(
       hostKeyFingerprintForOnboardUpsert(
-        { host_key_fingerprint: "pinned-fingerprint" },
+        { host_key_fingerprint: "pinned-fingerprint", capacity: 8 },
         "attacker-fingerprint",
       ),
     ).toBe("pinned-fingerprint");
@@ -207,10 +208,28 @@ describe("host-key pinning helpers", () => {
     );
     expect(
       hostKeyFingerprintForOnboardUpsert(
-        { host_key_fingerprint: null },
+        { host_key_fingerprint: null, capacity: 8 },
         "first-pin",
       ),
     ).toBe("first-pin");
     expect(hostKeyFingerprintForOnboardUpsert(null, undefined)).toBeNull();
+  });
+});
+
+describe("capacityForOnboardUpsert", () => {
+  it("preserves an existing node's operator-tuned capacity across re-onboard", () => {
+    // Robot the operator bumped to 24 via a direct DB write; the --capacity
+    // flag still carries the small-box default and must not win.
+    expect(
+      capacityForOnboardUpsert(
+        { host_key_fingerprint: "pinned", capacity: 24 },
+        8,
+      ),
+    ).toBe(24);
+  });
+
+  it("seeds a brand-new row from the --capacity flag", () => {
+    expect(capacityForOnboardUpsert(null, 8)).toBe(8);
+    expect(capacityForOnboardUpsert(null, 4)).toBe(4);
   });
 });

--- a/packages/scripts/cloud/admin/onboard-docker-node.ts
+++ b/packages/scripts/cloud/admin/onboard-docker-node.ts
@@ -129,6 +129,7 @@ export interface OnboardArgs {
 
 interface ExistingDockerNodePin {
   host_key_fingerprint: string | null;
+  capacity: number;
 }
 
 interface OnboardSshConfig {
@@ -160,6 +161,21 @@ export function hostKeyFingerprintForOnboardUpsert(
   capturedFingerprint: string | undefined,
 ): string | null {
   return existing?.host_key_fingerprint ?? capturedFingerprint ?? null;
+}
+
+/**
+ * Capacity to write on (re-)onboard. Once a node exists, its slot count is
+ * operator-owned (tuned via the admin PATCH route or a direct DB update to
+ * match the box's real RAM), so a re-onboard preserves it and never resets it
+ * to the `--capacity` default (which is sized for the small cpx32-class node
+ * this script was born on). The flag value is only used to seed a brand-new
+ * row.
+ */
+export function capacityForOnboardUpsert(
+  existing: ExistingDockerNodePin | null,
+  flagCapacity: number,
+): number {
+  return existing?.capacity ?? flagCapacity;
 }
 
 /** Parse argv + env into a validated config. Throws on missing required fields. */
@@ -332,7 +348,9 @@ async function main(): Promise<void> {
         hostname: args.host,
         ssh_port: args.sshPort,
         ssh_user: args.sshUser,
-        capacity: args.capacity,
+        // Preserve an operator-tuned capacity across re-onboards; the
+        // `--capacity` default only seeds a brand-new row (see create branch).
+        capacity: capacityForOnboardUpsert(existing, args.capacity),
         status: "unknown",
         // Never overwrite an established pin during re-onboard; a differing
         // presented key must fail in DockerSSHClient before this update.


### PR DESCRIPTION
## Problem

Our bare-metal prod robots (12 cores / 252 GB RAM) were registered into `docker_nodes` with `capacity=8` — a value inherited from the cpx32 CLOUD autoscale default (~8 GB box, ~4 GB/agent). On a 252 GB robot measuring ~2.5 GB/agent, that leaves ~86% RAM idle and starves the pool of slots. An operator bumped the 5 robot rows to `capacity=24` with a direct DB `UPDATE`.

The risk: two node **re-registration** paths blindly write `capacity` onto an already-existing row, so the next re-register would silently reset the operator's tune back to the default:

- `POST /api/v1/admin/docker-nodes/bootstrap-callback` — the re-bootstrap branch called `update(existing.id, { ..., capacity })`, where `capacity` comes from the callback body (Zod default `8`). A liveness re-bootstrap (fresh boot, cloud-init re-POST) would clobber `24` → `8`.
- `scripts/cloud/admin/onboard-docker-node.ts` (the operator-side script robots are onboarded with) — the re-onboard branch called `update(existing.id, { ..., capacity: args.capacity })`, where `--capacity` defaults to `8`. Re-running the idempotent onboard would clobber `24` → `8`.

Capacity was being treated as caller-owned even for an existing node, unlike the two adjacent fields this code already guards: the pinned host-key fingerprint (never overwritten) and the SSH identity (server-stored is authoritative).

## Fix — option (b): re-registration never overwrites an existing row's capacity

Once a node exists, its slot count is operator-owned. Both re-registration paths now **preserve** the current `capacity` and only stamp it on **brand-new** rows:

- **bootstrap-callback**: dropped `capacity` from the re-bootstrap `update`. The Drizzle `update` no longer touches the column, so the stored value stands. The `create` path (new node) still stamps `capacity` from the request.
- **onboard-docker-node**: added a small pure helper `capacityForOnboardUpsert(existing, flagCapacity)` (mirroring the existing `hostKeyFingerprintForOnboardUpsert` pattern) returning `existing?.capacity ?? flagCapacity`, so a re-onboard keeps the DB value and only a brand-new row uses `--capacity`.

The explicit operator escape hatch is unchanged: `PATCH /api/v1/admin/docker-nodes/{nodeId}` still sets `capacity` when provided — that remains the intended way to change a live node's slot count.

### Why not also (a) resource-derived defaults

The task's optional option (a) — deriving a NEW row's capacity from reported RAM (`clamp(floor(ram_gb / RAM_GB_PER_SLOT), min, max)`) — was left out because the resource is **not available at insert time**: the bootstrap callback schema carries no `ram_mb`, and the onboard script never probes host RAM. Wiring it would mean a new SSH RAM probe / callback field + userData plumbing — a bigger change than this fix warrants. (b) alone makes any operator-set value durable, which is the actual failure. (a) is a clean follow-up once a resource field exists on the registration payload.

## Test evidence

- `packages/cloud/api/__tests__/bootstrap-callback-node-identity.test.ts` — updated the existing "liveness re-bootstrap" case to assert capacity is **not** written, and added two cases: re-bootstrap preserves an operator-tuned `capacity=24` against a callback reporting `8`; a brand-new node still gets its capacity stamped from the request. `13 pass / 0 fail`.
- `packages/scripts/cloud/admin/onboard-docker-node.test.ts` — added `capacityForOnboardUpsert` unit tests (preserve existing `24` over flag `8`; seed a new row from the flag) and threaded `capacity` through the existing pin-helper fixtures. `17 pass / 0 fail`.
- `bun run --cwd packages/cloud/shared typecheck` (tsgo) and `tsgo --noEmit` on `packages/cloud/api` both exit `0` for the touched files.

## References

- #15401 (item 2)
- #15378

[stan-cloud]

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend-only change (cloud control-plane node-registration + admin onboarding script); no UI surface

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend-only change; no UI surface

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend-only change; no UI surface

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend/client code path touched

<!-- evidence-row:ocr-review -->
- [ ] N/A - no UI surface to OCR

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/action/provider/prompt/model behavior changed; pure control-plane capacity-preservation guard

<!-- evidence-row:backend-logs -->
- [ ] N/A - deterministic guard proven by unit tests (bootstrap-callback-node-identity.test.ts 13/13, onboard-docker-node.test.ts 17/17 pass in CI unit-tests lane); no runtime log capture applicable

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - domain artifact is the docker_nodes.capacity column staying at the operator-set value on re-registration; asserted directly by the added unit tests (update omits capacity; create stamps it)
