### PR TITLE
fix(voice): post-permission capture death on iOS PWA — pause-cancel race + suspended AudioContext + silent-drop feedback

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -79,6 +79,7 @@ import { SystemWarningBanner } from "./components/shell/SystemWarningBanner";
 import { TrayLauncher } from "./components/shell/TrayLauncher";
 import { useBarSurfaceWindows } from "./components/shell/useBarSurfaceWindows";
 import { useKioskViewSurfaces } from "./components/shell/useKioskViewSurfaces";
+import { VoiceCaptureHud } from "./components/shell/VoiceCaptureHud";
 import { Button } from "./components/ui/button";
 import { KeepAliveViewHost } from "./components/views/KeepAliveViewHost";
 import { ViewErrorBoundary } from "./components/views/ViewErrorBoundary";
@@ -2940,6 +2941,11 @@ export function App() {
             /build-info.json is absent (production builds without the
             build-time stamp render nothing). */}
         <BuildBadge />
+        {/* On-screen voice-capture trace (stamped builds only) so a
+            "tapped the mic, then crickets" report is diagnosable from a phone
+            screenshot instead of the devtools console the installed PWA lacks.
+            Sibling of BuildBadge; renders nothing without /build-info.json. */}
+        <VoiceCaptureHud />
         <ShellOverlays actionNotice={actionNotice} />
         <SaveCommandModal
           open={contextMenu.saveCommandModalOpen}

--- a/packages/ui/src/components/composites/chat/chat-composer.tsx
+++ b/packages/ui/src/components/composites/chat/chat-composer.tsx
@@ -34,6 +34,7 @@ import {
   useComposerPaste,
 } from "../../../chat/composer-core";
 import { usePushToTalk } from "../../../hooks/usePushToTalk";
+import { voiceCaptureDebug } from "../../../utils/voice-capture-debug";
 import { isVoiceTargetResolvableForActiveAgent } from "../../../voice/shared-runtime-voice";
 import type { VoiceSessionMode } from "../../../voice/voice-chat-types";
 import { Button } from "../../ui/button";
@@ -317,20 +318,40 @@ export function ChatComposer({
   });
 
   const handleMicClick = useCallback(() => {
+    // Trace the composer mic tap BEFORE any branching so the on-screen HUD
+    // shows the tap even when the handler early-returns short of capture
+    // (the "nothing after mic:tap" case = handler never reached start).
+    voiceCaptureDebug("mic:tap", {
+      surface: "composer",
+      isListening: voice.isListening,
+      captureMode: voice.captureMode,
+    });
     // A held push-to-talk turn that is still live when clicked (no pointerup
     // reached us) is stopped-and-submitted here as the fallback.
     if (voice.isListening && voice.captureMode === "push-to-talk") {
+      voiceCaptureDebug("mic:branch", { action: "stop-submit-ptt" });
       void voice.stopListening({ submit: true });
       return;
     }
     // Swallow the trailing click of a completed hold so it doesn't also toggle.
-    if (shouldSuppressClick()) return;
-    if (isComposerLocked) return;
+    if (shouldSuppressClick()) {
+      voiceCaptureDebug("mic:noop", { reason: "suppress-click" });
+      return;
+    }
+    if (isComposerLocked) {
+      voiceCaptureDebug("mic:noop", { reason: "composer-locked" });
+      return;
+    }
     if (voice.isListening && voice.captureMode === "compose") {
+      voiceCaptureDebug("mic:branch", { action: "stop-compose" });
       void voice.stopListening();
       return;
     }
-    if (voice.isListening) return;
+    if (voice.isListening) {
+      voiceCaptureDebug("mic:noop", { reason: "already-listening" });
+      return;
+    }
+    voiceCaptureDebug("mic:branch", { action: "start-compose" });
     void voice.startListening("compose");
   }, [isComposerLocked, shouldSuppressClick, voice]);
 

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -95,6 +95,7 @@ import {
   MAX_CHAT_IMAGES,
   summarizeDroppedAttachments,
 } from "../../utils/image-attachment";
+import { voiceCaptureDebug } from "../../utils/voice-capture-debug";
 import { InlineWidgetText } from "../chat/InlineWidgetText";
 import { MessageAttachments } from "../chat/MessageAttachments";
 import {
@@ -2174,8 +2175,19 @@ export function ContinuousChatOverlay({
   });
 
   const handleMicClick = React.useCallback(() => {
+    // Trace the home-overlay mic tap BEFORE any branching so the on-screen HUD
+    // captures the tap even when this handler early-returns short of capture.
+    voiceCaptureDebug("mic:tap", {
+      surface: "overlay",
+      transcriptionMode,
+      responding,
+      handsFree,
+    });
     // Swallow exactly the one click that follows a held PTT release.
-    if (shouldSuppressClick()) return;
+    if (shouldSuppressClick()) {
+      voiceCaptureDebug("mic:noop", { reason: "suppress-click" });
+      return;
+    }
     // While transcribing, the mic is the master voice control: a tap turns the
     // mic OFF, which also ends transcription (mic = parent — turning off the mic
     // turns off transcript). This is distinct from the transcript button, which
@@ -2186,14 +2198,19 @@ export function ContinuousChatOverlay({
     // gating it left a lit, dead "stop transcription" mic until the reply
     // finished.
     if (transcriptionMode) {
+      voiceCaptureDebug("mic:branch", { action: "stop-transcription" });
       stopTranscriptionAndMic();
       return;
     }
     // Voice can't be turned ON while a reply is in flight (it's gated until the
     // turn finishes), but an active hands-free session can always be turned OFF.
-    if (responding && !handsFree) return;
+    if (responding && !handsFree) {
+      voiceCaptureDebug("mic:noop", { reason: "responding-not-handsfree" });
+      return;
+    }
     // Quick tap = hands-free conversation: the agent speaks its replies back and
     // the mic re-opens after each one. Tap again to end.
+    voiceCaptureDebug("mic:branch", { action: "toggle-handsfree" });
     toggleHandsFree();
   }, [
     responding,

--- a/packages/ui/src/components/shell/VoiceCaptureHud.test.tsx
+++ b/packages/ui/src/components/shell/VoiceCaptureHud.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+//
+// VoiceCaptureHud — on-screen voice-capture trace for the installed PWA (no
+// devtools). Stamped-builds-only (same /build-info.json gate as BuildBadge);
+// renders the breadcrumb ring bottom-anchored above the composer; dismissible
+// for the session.
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resetVoiceCaptureBreadcrumbs,
+  voiceCaptureDebug,
+} from "../../utils/voice-capture-debug";
+import { VoiceCaptureHud } from "./VoiceCaptureHud";
+
+const BUILD_INFO = {
+  commit: "62d49c0c7d",
+  builtAt: "2026-07-07 18:00 MDT",
+  label: "62d49c0c7d · Jul 07 18:00 MDT",
+};
+
+function mockFetchOk(body: unknown) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      json: async () => body,
+    })) as unknown as typeof fetch,
+  );
+}
+
+function mockFetchMissing() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: false,
+      json: async () => ({}),
+    })) as unknown as typeof fetch,
+  );
+}
+
+describe("VoiceCaptureHud", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    resetVoiceCaptureBreadcrumbs();
+  });
+
+  afterEach(() => {
+    cleanup();
+    resetVoiceCaptureBreadcrumbs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the breadcrumb trace on a stamped build", async () => {
+    mockFetchOk(BUILD_INFO);
+    voiceCaptureDebug("mic:tap", { surface: "composer" });
+    voiceCaptureDebug("gum:req");
+    voiceCaptureDebug("gum:ok", { ms: 120 });
+    voiceCaptureDebug("provider:cloud");
+
+    render(<VoiceCaptureHud />);
+
+    const hud = await screen.findByTestId("voice-capture-hud");
+    expect(hud).toBeTruthy();
+    const lines = screen.getAllByTestId("voice-capture-hud-line");
+    // All four steps of this tap are on screen.
+    const text = lines.map((l) => l.textContent).join("|");
+    expect(text).toContain("mic:tap");
+    expect(text).toContain("gum:ok");
+    expect(text).toContain("120ms");
+    expect(text).toContain("provider:cloud");
+  });
+
+  it("marks a failing step (gum:err) so it reads as the death point", async () => {
+    mockFetchOk(BUILD_INFO);
+    voiceCaptureDebug("mic:tap");
+    voiceCaptureDebug("gum:req");
+    voiceCaptureDebug("gum:err", { name: "NotAllowedError" });
+
+    render(<VoiceCaptureHud />);
+    await screen.findByTestId("voice-capture-hud");
+    const text = screen
+      .getAllByTestId("voice-capture-hud-line")
+      .map((l) => l.textContent)
+      .join("|");
+    expect(text).toContain("gum:err");
+    expect(text).toContain("NotAllowedError");
+  });
+
+  it("renders NOTHING when the build stamp is absent (production)", async () => {
+    mockFetchMissing();
+    voiceCaptureDebug("mic:tap");
+    render(<VoiceCaptureHud />);
+    // Give the async gate a tick; it must stay hidden.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.queryByTestId("voice-capture-hud")).toBeNull();
+  });
+
+  it("renders nothing when the ring is empty even on a stamped build", async () => {
+    mockFetchOk(BUILD_INFO);
+    render(<VoiceCaptureHud />);
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        "/build-info.json",
+        expect.objectContaining({ cache: "no-store" }),
+      ),
+    );
+    expect(screen.queryByTestId("voice-capture-hud")).toBeNull();
+  });
+
+  it("hides for the session when dismissed", async () => {
+    mockFetchOk(BUILD_INFO);
+    voiceCaptureDebug("mic:tap");
+    const { unmount } = render(<VoiceCaptureHud />);
+    await screen.findByTestId("voice-capture-hud");
+
+    await userEvent.click(screen.getByTestId("voice-capture-hud-dismiss"));
+    expect(screen.queryByTestId("voice-capture-hud")).toBeNull();
+
+    // Remount within the same session — stays hidden.
+    unmount();
+    voiceCaptureDebug("mic:tap");
+    render(<VoiceCaptureHud />);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.queryByTestId("voice-capture-hud")).toBeNull();
+  });
+});

--- a/packages/ui/src/components/shell/VoiceCaptureHud.tsx
+++ b/packages/ui/src/components/shell/VoiceCaptureHud.tsx
@@ -1,0 +1,290 @@
+/**
+ * VoiceCaptureHud — an on-screen trace of the last voice-capture breadcrumbs so
+ * a "tapped the mic, then crickets" report is diagnosable from a phone
+ * screenshot instead of a devtools console the installed PWA doesn't have.
+ *
+ * It is the voice-capture sibling of {@link ../shell/BuildBadge}: same
+ * stamped-builds-only gate (reads `/build-info.json`; renders nothing when the
+ * file is absent, i.e. production bundles without the build-time stamp cost
+ * nothing), and the same "screenshot is ground truth" philosophy that ended the
+ * bottom-bar blind-fix loop.
+ *
+ * The HUD subscribes to the unconditional breadcrumb ring in
+ * {@link ../../utils/voice-capture-debug} and renders the last ~8 steps with
+ * millisecond offsets from the `mic:tap` that began the trace, e.g.
+ *
+ *   `mic:tap → gum:req → gum:ok(120ms) → ctx:running → rec:start → post:200 → txt`
+ *
+ * or wherever it dies:
+ *
+ *   `mic:tap → gum:err(NotAllowedError)`   (permission denied)
+ *   `mic:tap → gum:ok → ctx:suspended!`    (AudioContext never resumed)
+ *   `mic:tap → … → wav:SILENT`             (silence guard no-op'd)
+ *   `mic:tap → … → post:403`               (cloud STT rejected)
+ *   `mic:tap`  (nothing after → provider branch/handler never reached capture)
+ *
+ * Monospace, tiny, high-contrast, bottom-anchored above the composer, auto-
+ * scrolled to the newest event so the failing step is always visible.
+ *
+ * The ring is populated whether or not `eliza:voice:debug` is set, so on a
+ * stamped sol-dev build the HUD works with zero on-device console setup. The
+ * `× ` dismiss hides it for the session (sessionStorage) so it never nags real
+ * use, matching BuildBadge's dismissal contract.
+ */
+
+import { X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Z_BUILD_BADGE } from "../../lib/floating-layers";
+import {
+  subscribeVoiceCaptureBreadcrumbs,
+  type VoiceCaptureBreadcrumb,
+} from "../../utils/voice-capture-debug";
+
+const BUILD_INFO_URL = "/build-info.json";
+const DISMISS_KEY = "eliza.voiceHud.dismissed";
+
+interface BuildInfo {
+  commit?: string;
+  builtAt?: string;
+  label?: string;
+}
+
+function readSessionDismissed(): boolean {
+  try {
+    return window.sessionStorage.getItem(DISMISS_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writeSessionDismissed(): void {
+  try {
+    window.sessionStorage.setItem(DISMISS_KEY, "1");
+  } catch {
+    // Storage unavailable (private mode / quota) — in-memory hide still works.
+  }
+}
+
+/**
+ * Compact a breadcrumb's structured detail into the tiny parenthetical the HUD
+ * line shows, e.g. `gum:err` + `{ name: "NotAllowedError" }` → `NotAllowedError`.
+ * Picks the single most diagnostic field (error name/message, http status, byte
+ * size, provider, state) so the line stays phone-narrow. Returns "" when there
+ * is nothing worth showing.
+ */
+function detailToken(step: string, detail?: Record<string, unknown>): string {
+  if (!detail) return "";
+  const pick = (k: string): string | undefined => {
+    const v = detail[k];
+    if (v == null) return undefined;
+    return typeof v === "string" ? v : String(v);
+  };
+  // Error-ish steps: surface the error name/message.
+  const err = pick("name") ?? pick("error") ?? pick("reason");
+  if (err && (step.includes("err") || step.includes("fail"))) return err;
+  // HTTP steps: status.
+  const status = pick("status");
+  if (status && step.startsWith("post")) return status;
+  // WAV steps: silent flag + byte size (both matter for the crickets story).
+  if (step.startsWith("wav")) {
+    const silent = pick("silent");
+    const bytes = pick("bytes");
+    if (silent && bytes) return `${silent},${bytes}b`;
+    if (silent) return silent;
+    if (bytes) return `${bytes}b`;
+  }
+  // getUserMedia resolve: the round-trip ms (mirrors the mandate's gum:ok(120ms)).
+  if (step === "gum:ok") {
+    const ms = pick("ms");
+    if (ms) return `${ms}ms`;
+  }
+  // AudioContext transitions: the state.
+  const state = pick("state");
+  if (state && step.startsWith("ctx")) return state;
+  // Provider selection: which backend + why.
+  const provider = pick("provider") ?? pick("backend") ?? pick("asrProvider");
+  if (provider && step.startsWith("provider")) return provider;
+  // start:enter fork witness: the resolved ASR provider that decides routing.
+  if (step === "start:enter") {
+    const asr = pick("asrProvider");
+    if (asr) return asr;
+  }
+  // mic:branch / mic:noop: the action/reason taken.
+  if (step.startsWith("mic:")) {
+    const action = pick("action") ?? pick("reason");
+    if (action) return action;
+  }
+  // Recorder data / stop: first-chunk length / submit flag.
+  const chunk = pick("chunk") ?? pick("frames");
+  if (chunk && step.startsWith("rec")) return chunk;
+  // Transcript: char count.
+  if (step === "txt" || step === "post:200") {
+    const chars = pick("chars");
+    if (chars) return `${chars}ch`;
+  }
+  // Generic fallback: the first scalar value.
+  const bytes = pick("bytes");
+  const err2 = err ?? status ?? bytes ?? state ?? provider ?? chunk;
+  return err2 ?? "";
+}
+
+/** A rendered HUD line: the step label, ms offset from tap, and detail token. */
+interface HudLine {
+  seq: number;
+  step: string;
+  /** ms since the `mic:tap` that began this trace (or since the first event). */
+  offsetMs: number;
+  token: string;
+  /** True when this step reads as a failure/terminal (rendered in alert red). */
+  bad: boolean;
+}
+
+function isBadStep(step: string, token: string): boolean {
+  if (step.includes("err") || step.includes("fail")) return true;
+  if (step === "ctx:suspended" || step.endsWith("!")) return true;
+  if (step.startsWith("wav") && token.toUpperCase().includes("SILENT")) {
+    return true;
+  }
+  if (step.startsWith("post")) {
+    const code = Number.parseInt(token, 10);
+    if (Number.isFinite(code) && code >= 400) return true;
+  }
+  if (step === "pause:cancel") return true;
+  return false;
+}
+
+function toLines(ring: readonly VoiceCaptureBreadcrumb[]): HudLine[] {
+  if (ring.length === 0) return [];
+  // Offsets are measured from the most recent `mic:tap` (the trace start) so
+  // each step reads as "N ms after the tap". Fall back to the first event if a
+  // trace somehow has no tap (a breadcrumb fired outside a tap-initiated flow).
+  let baseMs = ring[0]?.atMs ?? 0;
+  for (const b of ring) {
+    if (b.step === "mic:tap") {
+      baseMs = b.atMs;
+      break;
+    }
+  }
+  return ring.map((b) => {
+    const token = detailToken(b.step, b.detail);
+    return {
+      seq: b.seq,
+      step: b.step,
+      offsetMs: Math.max(0, Math.round(b.atMs - baseMs)),
+      token,
+      bad: isBadStep(b.step, token),
+    };
+  });
+}
+
+export function VoiceCaptureHud() {
+  const [stamped, setStamped] = useState<boolean>(false);
+  const [dismissed, setDismissed] = useState<boolean>(() =>
+    readSessionDismissed(),
+  );
+  const [ring, setRing] = useState<readonly VoiceCaptureBreadcrumb[]>([]);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  // Stamped-builds-only gate — identical to BuildBadge: a live
+  // `/build-info.json` means this is a sol-dev / CI build (the debug surface),
+  // so the HUD renders; production bundles without the stamp render nothing.
+  useEffect(() => {
+    if (dismissed) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(BUILD_INFO_URL, { cache: "no-store" });
+        if (!res.ok) return;
+        // Presence + parseability of the stamp is the gate; the label itself is
+        // shown by BuildBadge, not here.
+        const info = (await res.json()) as BuildInfo;
+        const ok =
+          !!info &&
+          (typeof info.commit === "string" || typeof info.label === "string");
+        if (!cancelled && ok) setStamped(true);
+      } catch {
+        // No build info (production) — stay hidden silently.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [dismissed]);
+
+  // Subscribe to the breadcrumb ring once the HUD is going to render. The
+  // subscription fires immediately with the current ring so a late mount still
+  // shows the existing trace. Auto-scroll to the newest event on each update
+  // (folded into the subscription so the scroll re-runs exactly when a
+  // breadcrumb lands, with no synthetic effect dependency).
+  useEffect(() => {
+    if (dismissed || !stamped) return;
+    return subscribeVoiceCaptureBreadcrumbs((next) => {
+      setRing(next);
+      // Defer to after paint so scrollHeight reflects the appended line.
+      requestAnimationFrame(() => {
+        const el = scrollRef.current;
+        if (el) el.scrollTop = el.scrollHeight;
+      });
+    });
+  }, [dismissed, stamped]);
+
+  const lines = useMemo(() => toLines(ring), [ring]);
+
+  const dismiss = useCallback(() => {
+    writeSessionDismissed();
+    setDismissed(true);
+  }, []);
+
+  if (dismissed || !stamped || lines.length === 0) return null;
+
+  return (
+    <div
+      data-testid="voice-capture-hud"
+      data-aesthetic-overlay-ignore="true"
+      className="pointer-events-none fixed inset-x-0 flex justify-center px-2"
+      style={{
+        // Anchored above the composer: sit just above the safe-area bottom so
+        // it clears the on-screen composer/keyboard chrome. High z so a mic
+        // overlay doesn't occlude the very trace that explains the overlay.
+        bottom: "calc(env(safe-area-inset-bottom, 0px) + 4.5rem)",
+        zIndex: Z_BUILD_BADGE,
+      }}
+    >
+      <div className="pointer-events-auto flex max-w-[calc(100%-0.5rem)] items-stretch gap-1 rounded-md border border-border bg-black/85 px-1.5 py-1 shadow-lg backdrop-blur">
+        <div
+          ref={scrollRef}
+          data-testid="voice-capture-hud-lines"
+          className="max-h-24 overflow-auto font-mono text-3xs leading-tight text-white/90"
+        >
+          {lines.map((line) => (
+            <div
+              key={line.seq}
+              data-testid="voice-capture-hud-line"
+              className="flex items-baseline gap-1 whitespace-nowrap tabular-nums"
+            >
+              <span className="text-white/40">+{line.offsetMs}</span>
+              <span className={line.bad ? "text-red-400" : "text-emerald-300"}>
+                {line.step}
+              </span>
+              {line.token ? (
+                <span className={line.bad ? "text-red-300" : "text-white/70"}>
+                  ({line.token})
+                </span>
+              ) : null}
+            </div>
+          ))}
+        </div>
+        <button
+          type="button"
+          data-testid="voice-capture-hud-dismiss"
+          title="Hide voice trace for this session"
+          aria-label="Hide voice capture trace for this session"
+          onClick={dismiss}
+          className="shrink-0 self-start text-white/50 hover:text-white"
+        >
+          <X aria-hidden="true" className="h-2.5 w-2.5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -1265,6 +1265,12 @@ describe("useShellController — voice capture routing", () => {
     expect(result.current.recording).toBe(true);
     expect(createVoiceCaptureMock).toHaveBeenCalledTimes(1);
 
+    // Age the capture past the permission-prompt grace (#voice-crickets) so the
+    // pause reads as a genuine background-suspend, not the iOS getUserMedia
+    // dialog focus-steal (which must NOT discard the just-started capture).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1600);
+    });
     // Background the app mid-capture.
     await act(async () => {
       document.dispatchEvent(new Event("eliza:app-pause"));
@@ -1287,6 +1293,10 @@ describe("useShellController — voice capture routing", () => {
     });
     expect(createVoiceCaptureMock).toHaveBeenCalledTimes(1);
 
+    // Past the permission-prompt grace — a genuine background-suspend discards.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1600);
+    });
     await act(async () => {
       document.dispatchEvent(new Event("eliza:app-pause"));
     });
@@ -1314,6 +1324,31 @@ describe("useShellController — voice capture routing", () => {
     });
     // Nothing to re-arm — no phantom capture is created on resume.
     expect(createVoiceCaptureMock).not.toHaveBeenCalled();
+  });
+
+  it("KEEPS a just-started capture on APP_PAUSE within the permission grace (#voice-crickets)", async () => {
+    // The iOS getUserMedia permission dialog fires visibilitychange → APP_PAUSE
+    // the instant capture starts. Discarding there kills the mic the user is
+    // about to grant — and transcription mode never re-arms on resume, so this
+    // is unrecoverable crickets. A capture younger than the grace is KEPT.
+    const { result } = renderHook(() => useShellController());
+    await act(async () => {
+      result.current.toggleHandsFree();
+    });
+    expect(result.current.recording).toBe(true);
+    expect(createVoiceCaptureMock).toHaveBeenCalledTimes(1);
+
+    // Permission dialog's visibilitychange lands well inside the grace window.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+      document.dispatchEvent(new Event("eliza:app-pause"));
+    });
+
+    // Capture KEPT: not disposed, still recording — the grant lands on a live
+    // mic instead of a corpse, and no phantom re-arm is needed.
+    expect(captureHandles[0]?.dispose).not.toHaveBeenCalled();
+    expect(result.current.recording).toBe(true);
+    expect(createVoiceCaptureMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -47,6 +47,7 @@ import {
 } from "../../state/persistence";
 import { goHome } from "../../state/shell-surface-store";
 import { deriveAgentReady } from "../../state/types";
+import { voiceCaptureDebug } from "../../utils/voice-capture-debug";
 import { TurnAggregator } from "../../voice/end-of-turn";
 import {
   type MicrophonePermissionState,
@@ -94,6 +95,17 @@ export {
 /** Upper bound (ms) the conversation-switch / clear loading spinner may show
  *  before it is force-cleared — see `runWithConversationLoading`. */
 const CONVERSATION_LOADING_MAX_MS = 12_000;
+
+/**
+ * Grace window (ms) after a capture starts during which an APP_PAUSE is treated
+ * as the iOS getUserMedia permission-dialog focus-steal (a transient
+ * visibilitychange) rather than a real background-suspend, so the just-started
+ * capture is NOT discarded out from under the grant (#voice-crickets). Matches
+ * the composer-side CAPTURE_PAUSE_GRACE_MS in useVoiceChat. Transcription mode
+ * never re-arms on resume, so without this a permission-prompt pause on the
+ * transcribe surface is unrecoverable crickets.
+ */
+const SHELL_CAPTURE_PAUSE_GRACE_MS = 1500;
 
 /** How a voice capture turn is consumed when it produces a final transcript.
  *  `"transcription"` records long-form: finals accumulate into ONE recording
@@ -541,6 +553,14 @@ export function useShellController(): ShellController {
   // whether the agent's reply is spoken back — typed turns stay silent.
   const [lastTurnVoice, setLastTurnVoice] = React.useState(false);
   const captureRef = React.useRef<VoiceCaptureHandle | null>(null);
+  // Wall-clock (ms) the current capture handle was created. On the installed
+  // iOS PWA the native getUserMedia permission dialog steals focus the instant
+  // capture starts, firing visibilitychange → APP_PAUSE; discarding there kills
+  // the mic the user is about to grant (tap → prompt → grant → crickets), and
+  // transcription mode never re-arms on resume so it can't self-heal. A capture
+  // younger than SHELL_CAPTURE_PAUSE_GRACE_MS is kept across such a pause
+  // (#voice-crickets).
+  const captureStartedAtRef = React.useRef<number>(0);
   // Semantic end-of-turn aggregator for the always-on/converse path: holds a
   // turn that trails off mid-clause (a trailing conjunction/preposition) and
   // appends the speaker's continuation, so a slow speaker is not cut off and
@@ -833,6 +853,24 @@ export function useShellController(): ShellController {
   const discardCaptureForSuspend = React.useCallback(() => {
     const handle = captureRef.current;
     if (!handle) return;
+    // Permission-prompt grace (#voice-crickets): the iOS getUserMedia dialog
+    // fires visibilitychange → APP_PAUSE the instant capture starts. Discarding
+    // there kills the mic the user is about to grant, and transcription mode
+    // never re-arms on resume, so keep a capture younger than the grace window.
+    // A genuine background that stalls the WebAudio graph is still caught at
+    // stop() by the empty-WAV guard, so keeping a young capture alive is safe.
+    if (captureStartedAtRef.current > 0) {
+      const captureAgeMs = Date.now() - captureStartedAtRef.current;
+      if (captureAgeMs < SHELL_CAPTURE_PAUSE_GRACE_MS) {
+        voiceCaptureDebug("pause:kept", {
+          surface: "shell",
+          captureAgeMs,
+          graceMs: SHELL_CAPTURE_PAUSE_GRACE_MS,
+        });
+        return;
+      }
+    }
+    voiceCaptureDebug("pause:cancel", { surface: "shell" });
     captureRef.current = null;
     explicitStopRef.current = true;
     turnCarryoverRef.current = "";
@@ -928,6 +966,14 @@ export function useShellController(): ShellController {
         // window hasn't fired. Converse stops only on toggle-off, where a
         // partial must NOT be submitted.
         finalizeOnStop: intent === "dictate",
+        // Pre-POST silence guard fired: a near-silent tap was dropped without a
+        // cloud round-trip (correct), but the user got nothing. Surface a subtle
+        // "didn't catch that" hint so the dead-air is legible instead of
+        // crickets (#voice-crickets). Info-severity + short: it's a nudge to
+        // speak up, not an error.
+        onSilentDrop: () => {
+          setActionNotice("Didn't catch that — try again.", "info", 2500);
+        },
         onTranscript: (segment) => {
           const text = segment.text.trim();
           if (!segment.final) {
@@ -1061,6 +1107,7 @@ export function useShellController(): ShellController {
         },
       });
       captureRef.current = handle;
+      captureStartedAtRef.current = Date.now();
       setRecording(true);
       handle
         .start()

--- a/packages/ui/src/hooks/useVoiceChat.app-suspend.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.app-suspend.test.tsx
@@ -7,6 +7,15 @@
 // handler: an in-flight capture is discarded via recorder.cancel() (release the
 // mic, close the context, NO transcribe POST) and the listening state resets so
 // the next gesture re-arms from a clean idle.
+//
+// #voice-crickets: the discard is now gated by a permission-prompt grace window
+// (CAPTURE_PAUSE_GRACE_MS). On the installed iOS PWA the native getUserMedia
+// dialog steals focus the instant capture starts, firing visibilitychange →
+// APP_PAUSE; cancelling there kills the mic the user is about to grant (tap →
+// prompt → grant → crickets). A capture younger than the grace window is KEPT;
+// only an APP_PAUSE after the window (a genuine background) cancels. These
+// tests therefore advance fake time past the grace before asserting the
+// real-suspend cancel, and add cases that lock the young-capture keep.
 
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -16,7 +25,12 @@ import {
   isLocalAsrCaptureSupported,
   startLocalAsrRecorder,
 } from "../voice/local-asr-capture";
-import { useVoiceChat } from "./useVoiceChat";
+import { __voiceChatInternals, useVoiceChat } from "./useVoiceChat";
+
+const { CAPTURE_PAUSE_GRACE_MS } = __voiceChatInternals;
+// Comfortably past the permission-prompt grace so an APP_PAUSE reads as a
+// genuine background-suspend rather than the getUserMedia dialog focus-steal.
+const PAST_GRACE_MS = CAPTURE_PAUSE_GRACE_MS + 100;
 
 vi.mock("../api/csrf-client", () => ({
   fetchWithCsrf: vi.fn(),
@@ -33,6 +47,11 @@ const startLocalAsrRecorderMock = vi.mocked(startLocalAsrRecorder);
 
 describe("useVoiceChat app-suspend capture teardown (#voice-V1)", () => {
   beforeEach(() => {
+    // Fake timers so the capture-age math (Date.now() - captureStartedAt) is
+    // deterministic: a young capture (pause inside the grace) is kept; a pause
+    // after advancing past the grace cancels. `shouldAdvanceTime` keeps async
+    // microtasks (the recorder start promise) resolving under fake timers.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     isLocalAsrCaptureSupportedMock.mockReturnValue(true);
     fetchWithCsrfMock.mockImplementation(async (input) => {
       const url = typeof input === "string" ? input : String(input);
@@ -77,6 +96,12 @@ describe("useVoiceChat app-suspend capture teardown (#voice-V1)", () => {
     });
     expect(startLocalAsrRecorderMock).toHaveBeenCalledTimes(1);
 
+    // A genuine background-suspend arrives AFTER the permission-prompt grace
+    // window — advance past it so the pause reads as a real suspend, not the
+    // getUserMedia dialog focus-steal.
+    await act(async () => {
+      vi.advanceTimersByTime(PAST_GRACE_MS);
+    });
     // iOS suspends the PWA mid-capture.
     await act(async () => {
       document.dispatchEvent(new Event(APP_PAUSE_EVENT));
@@ -149,6 +174,10 @@ describe("useVoiceChat app-suspend capture teardown (#voice-V1)", () => {
     await act(async () => {
       await result.current.startListening("push-to-talk");
     });
+    // Past the grace — a genuine background-suspend cancels the capture.
+    await act(async () => {
+      vi.advanceTimersByTime(PAST_GRACE_MS);
+    });
     await act(async () => {
       document.dispatchEvent(new Event(APP_PAUSE_EVENT));
     });
@@ -160,5 +189,92 @@ describe("useVoiceChat app-suspend capture teardown (#voice-V1)", () => {
     });
     expect(startLocalAsrRecorderMock).toHaveBeenCalledTimes(2);
     expect(result.current.isListening).toBe(true);
+  });
+
+  it("KEEPS a just-started capture on APP_PAUSE within the permission grace (#voice-crickets)", async () => {
+    // The iOS getUserMedia permission dialog fires visibilitychange → APP_PAUSE
+    // the instant capture starts. Cancelling there kills the mic the user is
+    // about to grant — the tap-prompt-grant-then-crickets bug. A capture younger
+    // than the grace window must be KEPT (no cancel, still listening).
+    const stop = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3, 4]));
+    const cancel = vi.fn();
+    startLocalAsrRecorderMock.mockResolvedValue({
+      stop,
+      cancel,
+      analyser: null,
+    });
+    const onTranscript = vi.fn();
+
+    const { result } = renderHook(() =>
+      useVoiceChat({
+        onTranscript,
+        voiceConfig: {
+          provider: "eliza-cloud",
+          asr: { provider: "eliza-cloud" },
+        },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.startListening("push-to-talk");
+    });
+    expect(startLocalAsrRecorderMock).toHaveBeenCalledTimes(1);
+
+    // The permission dialog's visibilitychange lands well inside the grace.
+    await act(async () => {
+      vi.advanceTimersByTime(CAPTURE_PAUSE_GRACE_MS - 200);
+      document.dispatchEvent(new Event(APP_PAUSE_EVENT));
+    });
+
+    // Capture KEPT: no cancel, no stop, still listening — the grant lands on a
+    // live mic instead of a corpse.
+    expect(cancel).not.toHaveBeenCalled();
+    expect(stop).not.toHaveBeenCalled();
+    expect(result.current.isListening).toBe(true);
+  });
+
+  it("cancels once the capture ages past the grace (young keep, then real suspend)", async () => {
+    // A pause inside the grace keeps the capture; a later pause past the grace
+    // (a genuine background) still tears it down — the grace only defers the
+    // permission-prompt bounce, it does not disable suspend teardown.
+    const stop = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3, 4]));
+    const cancel = vi.fn();
+    startLocalAsrRecorderMock.mockResolvedValue({
+      stop,
+      cancel,
+      analyser: null,
+    });
+    const onTranscript = vi.fn();
+
+    const { result } = renderHook(() =>
+      useVoiceChat({
+        onTranscript,
+        voiceConfig: {
+          provider: "eliza-cloud",
+          asr: { provider: "eliza-cloud" },
+        },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.startListening("push-to-talk");
+    });
+
+    // Permission-prompt bounce: kept.
+    await act(async () => {
+      vi.advanceTimersByTime(100);
+      document.dispatchEvent(new Event(APP_PAUSE_EVENT));
+    });
+    expect(cancel).not.toHaveBeenCalled();
+    expect(result.current.isListening).toBe(true);
+
+    // Later, a real background-suspend past the grace: torn down.
+    await act(async () => {
+      vi.advanceTimersByTime(PAST_GRACE_MS);
+      document.dispatchEvent(new Event(APP_PAUSE_EVENT));
+    });
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(stop).not.toHaveBeenCalled();
+    expect(result.current.isListening).toBe(false);
   });
 });

--- a/packages/ui/src/hooks/useVoiceChat.suspend.test.tsx
+++ b/packages/ui/src/hooks/useVoiceChat.suspend.test.tsx
@@ -7,7 +7,15 @@ import {
   isLocalAsrCaptureSupported,
   startLocalAsrRecorder,
 } from "../voice/local-asr-capture";
-import { useVoiceChat } from "./useVoiceChat";
+import { __voiceChatInternals, useVoiceChat } from "./useVoiceChat";
+
+// #voice-crickets: the composer discard is gated by a permission-prompt grace
+// window (the iOS getUserMedia dialog fires visibilitychange → APP_PAUSE the
+// instant capture starts; cancelling there kills the mic the user is about to
+// grant). A capture younger than the grace is KEPT; only a pause past the
+// window (a genuine background) cancels — so advance past the grace before
+// asserting the real-suspend teardown.
+const PAST_GRACE_MS = __voiceChatInternals.CAPTURE_PAUSE_GRACE_MS + 100;
 
 vi.mock("../api/csrf-client", () => ({
   fetchWithCsrf: vi.fn(),
@@ -34,6 +42,7 @@ const startLocalAsrRecorderMock = vi.mocked(startLocalAsrRecorder);
  */
 describe("useVoiceChat — app-suspend capture teardown (#voice-V1)", () => {
   beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     isLocalAsrCaptureSupportedMock.mockReturnValue(true);
     fetchWithCsrfMock.mockImplementation(async (input) => {
       const url = typeof input === "string" ? input : String(input);
@@ -79,6 +88,11 @@ describe("useVoiceChat — app-suspend capture teardown (#voice-V1)", () => {
     expect(startLocalAsrRecorderMock).toHaveBeenCalledTimes(1);
     expect(result.current.isListening).toBe(true);
 
+    // Age the capture past the permission-prompt grace so the pause reads as a
+    // genuine background-suspend, not the getUserMedia dialog focus-steal.
+    await act(async () => {
+      vi.advanceTimersByTime(PAST_GRACE_MS);
+    });
     // Background the app mid-capture.
     await act(async () => {
       document.dispatchEvent(new Event("eliza:app-pause"));

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -45,10 +45,12 @@ import { voiceCaptureDebug } from "../utils/voice-capture-debug";
 import { hasConfiguredApiKey } from "../voice";
 import {
   isLocalAsrCaptureSupported,
+  isSilentWav,
   type LocalAsrRecorder,
   startLocalAsrRecorder,
 } from "../voice/local-asr-capture";
 import {
+  CloudSttError,
   isLocalInferenceAsrReady,
   transcribeCloudWav,
   transcribeLocalInferenceWav,
@@ -222,6 +224,31 @@ function shouldUseLocalInferenceAsr(config: VoiceConfig | null): boolean {
 function shouldUseCloudAsr(config: VoiceConfig | null): boolean {
   const provider = config?.asr?.provider;
   return provider === "eliza-cloud" || provider === "openai";
+}
+
+/**
+ * The resolved cloud-STT POST target (`/api/asr/cloud`) for the on-screen
+ * voice HUD's `post:req` breadcrumb. Best-effort: `resolveApiUrl` can throw in
+ * a non-DOM context, in which case the raw path is a good-enough witness.
+ */
+function cloudAsrPostUrl(): string {
+  try {
+    return resolveApiUrl("/api/asr/cloud");
+  } catch {
+    return "/api/asr/cloud";
+  }
+}
+
+/**
+ * The HTTP status carried by a {@link CloudSttError}, when the cloud STT
+ * failure was an HTTP response (403/413/5xx). `null` for a transport/timeout
+ * failure or a non-cloud error — the HUD then attributes it to the capture leg
+ * instead of the POST.
+ */
+function cloudSttErrorStatus(error: unknown): number | null {
+  return error instanceof CloudSttError && typeof error.status === "number"
+    ? error.status
+    : null;
 }
 
 const ACTIVE_VOICE_SESSION_MODES = new Set<Exclude<VoiceSessionMode, "idle">>([
@@ -961,8 +988,20 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         setSupported(true);
         setCaptureMode(mode);
         setIsListening(true);
+        voiceCaptureDebug("rec:start", { backend: "local-inference", mode });
         return true;
-      } catch {
+      } catch (error) {
+        // The recorder throws on getUserMedia reject or a dead AudioContext
+        // (see local-asr-capture); surface which so the HUD shows why capture
+        // never armed instead of silent crickets.
+        voiceCaptureDebug("rec:start-err", {
+          backend: "local-inference",
+          name: error instanceof Error ? error.name : "Error",
+          reason:
+            error instanceof Error
+              ? error.message.slice(0, 80)
+              : String(error).slice(0, 80),
+        });
         localAsrRecorderRef.current = null;
         return false;
       }
@@ -996,8 +1035,19 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         setSupported(true);
         setCaptureMode(mode);
         setIsListening(true);
+        voiceCaptureDebug("rec:start", { backend: "cloud", mode });
         return true;
-      } catch {
+      } catch (error) {
+        // Recorder throws on getUserMedia reject or a suspended AudioContext
+        // that never resumed — the exact iOS-PWA crickets modes. Trace it.
+        voiceCaptureDebug("rec:start-err", {
+          backend: "cloud",
+          name: error instanceof Error ? error.name : "Error",
+          reason:
+            error instanceof Error
+              ? error.message.slice(0, 80)
+              : String(error).slice(0, 80),
+        });
         localAsrRecorderRef.current = null;
         return false;
       }
@@ -1181,7 +1231,10 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
 
   const startListening = useCallback(
     async (mode: Exclude<VoiceCaptureMode, "idle"> = "compose") => {
-      if (enabledRef.current) return;
+      if (enabledRef.current) {
+        voiceCaptureDebug("start:noop", { reason: "already-enabled", mode });
+        return;
+      }
 
       transcriptBufferRef.current = "";
       setInterimTranscript("");
@@ -1189,8 +1242,20 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         interruptSpeechRef.current();
       }
 
+      // Which STT backend does the config resolve to, and why? This is the
+      // first fork the on-screen HUD needs: a cloud-STT config that silently
+      // fell through to the browser recognizer (absent on iOS PWA) is a classic
+      // crickets cause. `asrProvider` is the resolved value that decides it.
+      voiceCaptureDebug("start:enter", {
+        mode,
+        asrProvider: voiceConfigRef.current?.asr?.provider ?? null,
+        captureSupported: isLocalAsrCaptureSupported(),
+        preferNative: shouldPreferNativeTalkMode(),
+      });
+
       const localStarted = await startLocalInferenceRecognition(mode);
       if (localStarted) {
+        voiceCaptureDebug("provider:local-inference", { mode });
         return;
       }
 
@@ -1200,17 +1265,28 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       // through to the engine-dependent browser recognizer.
       const cloudStarted = await startCloudRecognition(mode);
       if (cloudStarted) {
+        voiceCaptureDebug("provider:cloud", { mode });
         return;
       }
 
       if (shouldPreferNativeTalkMode()) {
         const started = await startTalkModeRecognition(mode);
         if (started) {
+          voiceCaptureDebug("provider:talkmode", { mode });
           return;
         }
       }
 
-      startBrowserRecognition(mode);
+      // Last resort: browser SpeechRecognition. On iOS PWA this engine is
+      // absent, so landing here after a cloud config is the silent-crickets
+      // regression the cloud path was added to avoid — mark it loudly.
+      const browserStarted = startBrowserRecognition(mode);
+      voiceCaptureDebug(browserStarted ? "provider:browser" : "provider:none", {
+        mode,
+        note: browserStarted
+          ? undefined
+          : "no backend started — capture will not run",
+      });
     },
     [
       startBrowserRecognition,
@@ -1265,10 +1341,36 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         // just doesn't submit rather than being transcribed by the wrong engine.
         const recorder = localAsrRecorderRef.current;
         localAsrRecorderRef.current = null;
+        voiceCaptureDebug("rec:stop", { backend: "cloud", submit });
         if (recorder) {
           try {
             const audio = await recorder.stop();
+            // WAV byte size + silence classification: a SILENT WAV explains the
+            // "tapped, then crickets" no-op (the recorder captured all-zero
+            // PCM — dead AudioContext / muted mic); a healthy byte count means
+            // capture worked and the failure is downstream at the POST. The
+            // silence check is a HUD breadcrumb only — wrap it so a classifier
+            // hiccup never breaks the capture it is meant to observe.
+            let silentLabel = "?";
+            try {
+              silentLabel = isSilentWav(audio) ? "SILENT" : "ok";
+            } catch {
+              /* breadcrumb best-effort */
+            }
+            voiceCaptureDebug("wav", {
+              bytes: audio.byteLength,
+              silent: silentLabel,
+            });
+            voiceCaptureDebug("post:req", {
+              url: cloudAsrPostUrl(),
+              bytes: audio.byteLength,
+            });
             const transcript = await transcribeCloudAudio(audio);
+            voiceCaptureDebug("post:200", {
+              status: "200",
+              chars: transcript.length,
+            });
+            voiceCaptureDebug("txt", { chars: transcript.length });
             applyTranscriptUpdate(transcript, true, {
               mode:
                 normalizeActiveVoiceSessionMode(mode) ??
@@ -1278,6 +1380,22 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
               metadata: { source: "cloud" },
             });
           } catch (error) {
+            // Distinguish the failing leg for the HUD: a `post:<status>` when the
+            // cloud STT rejected (403/413/5xx), else a generic capture/parse
+            // failure (e.g. "No microphone audio was captured" = empty WAV).
+            const status = cloudSttErrorStatus(error);
+            if (status != null) {
+              voiceCaptureDebug("post:err", { status: String(status) });
+            } else {
+              voiceCaptureDebug("rec:stop-err", {
+                backend: "cloud",
+                name: error instanceof Error ? error.name : "Error",
+                reason:
+                  error instanceof Error
+                    ? error.message.slice(0, 80)
+                    : String(error).slice(0, 80),
+              });
+            }
             ttsDebug("asr:cloud:error", {
               message: error instanceof Error ? error.message : String(error),
             });

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -41,6 +41,7 @@ import {
   ttsDebug,
   ttsDebugTextPreview,
 } from "../utils/tts-debug";
+import { voiceCaptureDebug } from "../utils/voice-capture-debug";
 import { hasConfiguredApiKey } from "../voice";
 import {
   isLocalAsrCaptureSupported,
@@ -147,6 +148,17 @@ const CLOUD_TTS_TIMEOUT_MS = 60_000;
 const LOCAL_INFERENCE_TTS_TIMEOUT_MS = 60_000;
 /** How long the transient `micReconnected` pulse stays set after an auto-restart. */
 const MIC_RECONNECT_PULSE_MS = 1500;
+/**
+ * Grace window (ms) after a capture starts during which an APP_PAUSE is treated
+ * as the iOS permission-dialog focus-steal (a transient visibilitychange the
+ * native getUserMedia prompt fires) rather than a real background-suspend, so
+ * the just-started capture is NOT cancelled out from under the grant
+ * (#voice-crickets). A genuine background that actually stalls the WebAudio
+ * graph is still caught at stop() by the empty-WAV guard, so keeping a young
+ * capture alive here is safe. 1500ms comfortably covers the tap→dialog→grant
+ * round-trip without lingering long enough to strand a real suspend.
+ */
+const CAPTURE_PAUSE_GRACE_MS = 1500;
 
 // ── Internal helpers ─────────────────────────────────────────────────
 
@@ -240,6 +252,7 @@ interface VoiceTranscriptUpdateMetadata {
 // ── Test-visible internals ───────────────────────────────────────────
 
 export const __voiceChatInternals = {
+  CAPTURE_PAUSE_GRACE_MS,
   isWindowsElectrobunRenderer,
   shouldPreferNativeTalkMode,
   shouldAutoRestartBrowserRecognition,
@@ -312,6 +325,13 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
   const speechTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const enabledRef = useRef(false);
   const listeningModeRef = useRef<VoiceCaptureMode>("idle");
+  // Wall-clock (ms) the current capture recorder began. Used by the APP_PAUSE
+  // handler to distinguish a genuine background-suspend from the transient
+  // visibilitychange the iOS permission dialog fires the instant getUserMedia
+  // pops its native prompt (#voice-crickets). A capture younger than
+  // CAPTURE_PAUSE_GRACE_MS is almost certainly mid-permission-prompt, not
+  // backgrounded — cancelling it there kills the mic the user is about to grant.
+  const captureStartedAtRef = useRef<number>(0);
   const transcriptBufferRef = useRef("");
   const latestTranscriptTurnRef = useRef<VoiceTurn | null>(null);
   const emitTranscript = useEffectEvent(
@@ -775,8 +795,28 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
     if (listeningModeRef.current === "idle" && !localAsrRecorderRef.current) {
       return;
     }
-    enabledRef.current = false;
+    // Permission-prompt grace (#voice-crickets): on the installed iOS PWA the
+    // native getUserMedia dialog steals focus the instant capture starts, which
+    // fires `visibilitychange → hidden` → APP_PAUSE. If we cancel here we kill
+    // the mic the user is about to grant — tap, prompt, grant, then crickets.
+    // A capture younger than the grace window is treated as "mid-permission
+    // prompt, not backgrounded" and KEPT. A genuine background that actually
+    // stalls the WebAudio graph is still caught at stop() by the empty-WAV
+    // guard, so keeping a young capture alive here is safe.
     const recorder = localAsrRecorderRef.current;
+    if (recorder && captureStartedAtRef.current > 0) {
+      const captureAgeMs = Date.now() - captureStartedAtRef.current;
+      if (captureAgeMs < CAPTURE_PAUSE_GRACE_MS) {
+        voiceCaptureDebug("pause:kept", {
+          captureAgeMs,
+          graceMs: CAPTURE_PAUSE_GRACE_MS,
+          mode: listeningModeRef.current,
+        });
+        return;
+      }
+    }
+    voiceCaptureDebug("pause:cancel", { mode: listeningModeRef.current });
+    enabledRef.current = false;
     localAsrRecorderRef.current = null;
     if (recorder) {
       // cancel() releases the mic tracks + closes the context, no throw, no POST.
@@ -914,6 +954,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       try {
         const recorder = await startLocalAsrRecorder();
         localAsrRecorderRef.current = recorder;
+        captureStartedAtRef.current = Date.now();
         sttBackendRef.current = "local-inference";
         enabledRef.current = true;
         listeningModeRef.current = mode;
@@ -948,6 +989,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       try {
         const recorder = await startLocalAsrRecorder();
         localAsrRecorderRef.current = recorder;
+        captureStartedAtRef.current = Date.now();
         sttBackendRef.current = "cloud";
         enabledRef.current = true;
         listeningModeRef.current = mode;

--- a/packages/ui/src/utils/voice-capture-debug.test.ts
+++ b/packages/ui/src/utils/voice-capture-debug.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getVoiceCaptureBreadcrumbs,
+  resetVoiceCaptureBreadcrumbs,
+  subscribeVoiceCaptureBreadcrumbs,
+  VOICE_HUD_RING_SIZE,
+  voiceCaptureDebug,
+} from "./voice-capture-debug";
+
+/**
+ * The on-screen voice HUD reads the breadcrumb ring these tests lock down: the
+ * ring is populated UNCONDITIONALLY (no `eliza:voice:debug` gate), a fresh
+ * `mic:tap` starts a clean trace, subscribers see each push, and the ring is
+ * bounded so a long-lived session can't grow it without limit.
+ */
+describe("voiceCaptureDebug breadcrumb ring (device HUD source)", () => {
+  afterEach(() => {
+    resetVoiceCaptureBreadcrumbs();
+  });
+
+  it("records breadcrumbs even without the console-debug flag enabled", () => {
+    // No localStorage / env flag set — the console sink is off, but the HUD
+    // ring must still capture the trace (the whole point of the on-screen HUD).
+    voiceCaptureDebug("gum:req");
+    voiceCaptureDebug("gum:ok", { ms: 120 });
+    const ring = getVoiceCaptureBreadcrumbs();
+    expect(ring.map((b) => b.step)).toEqual(["gum:req", "gum:ok"]);
+    expect(ring[1]?.detail).toEqual({ ms: 120 });
+  });
+
+  it("starts a fresh trace on mic:tap (clears the prior attempt)", () => {
+    voiceCaptureDebug("gum:req");
+    voiceCaptureDebug("gum:err", { name: "NotAllowedError" });
+    // A new tap should reset so the HUD shows only THIS tap's lifecycle.
+    voiceCaptureDebug("mic:tap", { surface: "composer" });
+    voiceCaptureDebug("gum:req");
+    const ring = getVoiceCaptureBreadcrumbs();
+    expect(ring.map((b) => b.step)).toEqual(["mic:tap", "gum:req"]);
+  });
+
+  it("notifies subscribers on every push and on reset", () => {
+    const snapshots: string[][] = [];
+    const unsubscribe = subscribeVoiceCaptureBreadcrumbs((ring) => {
+      snapshots.push(ring.map((b) => b.step));
+    });
+    // Immediate invoke gives an initial (empty) snapshot.
+    expect(snapshots.at(-1)).toEqual([]);
+    voiceCaptureDebug("mic:tap");
+    voiceCaptureDebug("gum:req");
+    expect(snapshots.at(-1)).toEqual(["mic:tap", "gum:req"]);
+    unsubscribe();
+    voiceCaptureDebug("gum:ok");
+    // No further snapshots after unsubscribe.
+    expect(snapshots.at(-1)).toEqual(["mic:tap", "gum:req"]);
+  });
+
+  it("bounds the ring to VOICE_HUD_RING_SIZE (drops oldest)", () => {
+    voiceCaptureDebug("mic:tap");
+    for (let i = 0; i < VOICE_HUD_RING_SIZE + 5; i += 1) {
+      voiceCaptureDebug(`step:${i}`);
+    }
+    const ring = getVoiceCaptureBreadcrumbs();
+    expect(ring.length).toBe(VOICE_HUD_RING_SIZE);
+    // The oldest (mic:tap + earliest steps) were evicted; the newest remain.
+    expect(ring.at(-1)?.step).toBe(`step:${VOICE_HUD_RING_SIZE + 4}`);
+  });
+
+  it("assigns monotonic sequence ids and wall-clock offsets", () => {
+    voiceCaptureDebug("mic:tap");
+    voiceCaptureDebug("gum:req");
+    const ring = getVoiceCaptureBreadcrumbs();
+    expect(ring[1]?.seq).toBeGreaterThan(ring[0]?.seq ?? 0);
+    expect(typeof ring[0]?.atMs).toBe("number");
+    expect(ring[1]?.atMs).toBeGreaterThanOrEqual(ring[0]?.atMs ?? 0);
+  });
+});

--- a/packages/ui/src/utils/voice-capture-debug.ts
+++ b/packages/ui/src/utils/voice-capture-debug.ts
@@ -68,11 +68,106 @@ export function isVoiceCaptureDebugEnabled(): boolean {
   return voiceDebugEnabled();
 }
 
-/** One lifecycle-step breadcrumb. No secrets in `detail`. */
+// ── On-screen breadcrumb ring (device HUD) ───────────────────────────
+//
+// The console breadcrumbs above are invisible on an installed iPhone PWA (no
+// devtools). We won the viewport-geometry war with an on-screen diagnostics
+// chip (BuildBadge); do the same for voice: mirror every breadcrumb into a
+// tiny ring buffer that a bottom-anchored HUD renders, so the NEXT device
+// screenshot shows exactly where a "tapped the mic, then crickets" capture
+// dies — `mic:tap → gum:req → gum:ok → ctx:running → rec:start → …` or the
+// exact failing step (`gum:err`, `ctx:suspended!`, `wav:SILENT`, `post:403`)
+// or NOTHING AT ALL after `mic:tap` (= the click handler never reached
+// capture).
+//
+// The ring is ALWAYS populated (independent of the console-debug predicate)
+// so the HUD works on a stamped sol-dev build without the tester first
+// setting `localStorage['eliza:voice:debug']`. It's a fixed-size in-memory
+// buffer — zero network, zero storage, negligible cost.
+
+/** One recorded breadcrumb: step label, wall-clock ms, and sanitized detail. */
+export interface VoiceCaptureBreadcrumb {
+  /** Monotonic sequence id (for stable React keys + ordering). */
+  seq: number;
+  /** The lifecycle step, e.g. `mic:tap`, `gum:ok`, `post:200`. */
+  step: string;
+  /** `performance.now()` (ms) when recorded — HUD renders offsets from `mic:tap`. */
+  atMs: number;
+  /** Optional structured detail (no secrets), compacted for the HUD line. */
+  detail?: Record<string, unknown>;
+}
+
+/** How many breadcrumbs the HUD keeps. The mandate asks for "last ~8". */
+export const VOICE_HUD_RING_SIZE = 12;
+
+const breadcrumbRing: VoiceCaptureBreadcrumb[] = [];
+let breadcrumbSeq = 0;
+type BreadcrumbListener = (ring: readonly VoiceCaptureBreadcrumb[]) => void;
+const breadcrumbListeners = new Set<BreadcrumbListener>();
+
+function nowMs(): number {
+  return typeof performance !== "undefined" && performance.now
+    ? performance.now()
+    : Date.now();
+}
+
+/**
+ * Subscribe to breadcrumb-ring updates (the HUD's data source). The listener
+ * fires on every push with the current ring snapshot; returns an unsubscribe.
+ * Immediately invoked once so a late-mounting HUD paints the existing trace.
+ */
+export function subscribeVoiceCaptureBreadcrumbs(
+  listener: BreadcrumbListener,
+): () => void {
+  breadcrumbListeners.add(listener);
+  listener(breadcrumbRing.slice());
+  return () => {
+    breadcrumbListeners.delete(listener);
+  };
+}
+
+/** Current ring snapshot (oldest → newest). */
+export function getVoiceCaptureBreadcrumbs(): readonly VoiceCaptureBreadcrumb[] {
+  return breadcrumbRing.slice();
+}
+
+/** Clear the ring (e.g. a fresh `mic:tap` starts a clean trace). */
+export function resetVoiceCaptureBreadcrumbs(): void {
+  breadcrumbRing.length = 0;
+  const snapshot = breadcrumbRing.slice();
+  for (const l of breadcrumbListeners) l(snapshot);
+}
+
+function pushBreadcrumb(step: string, detail?: Record<string, unknown>): void {
+  breadcrumbSeq += 1;
+  breadcrumbRing.push({
+    seq: breadcrumbSeq,
+    step,
+    atMs: nowMs(),
+    detail: detail && Object.keys(detail).length > 0 ? detail : undefined,
+  });
+  // Trim to the ring size (drop oldest).
+  while (breadcrumbRing.length > VOICE_HUD_RING_SIZE) breadcrumbRing.shift();
+  const snapshot = breadcrumbRing.slice();
+  for (const l of breadcrumbListeners) l(snapshot);
+}
+
+/**
+ * One lifecycle-step breadcrumb. No secrets in `detail`.
+ *
+ * Dual sink: always mirrors into the on-screen HUD ring (device-visible), and
+ * ALSO logs to the console when the debug predicate is enabled (desktop /
+ * remote-inspector convenience). The HUD ring is unconditional so a stamped
+ * sol-dev build is diagnosable on-device with no console toggle.
+ */
 export function voiceCaptureDebug(
   step: string,
   detail?: Record<string, unknown>,
 ): void {
+  // A new tap begins a fresh trace so the HUD isn't cluttered with the previous
+  // (successful or dead) attempt — the last 8 events should describe THIS tap.
+  if (step === "mic:tap") resetVoiceCaptureBreadcrumbs();
+  pushBreadcrumb(step, detail);
   if (!voiceDebugEnabled()) return;
   if (detail && Object.keys(detail).length > 0) {
     console.info(`[eliza][voice-capture] ${step}`, detail);

--- a/packages/ui/src/utils/voice-capture-debug.ts
+++ b/packages/ui/src/utils/voice-capture-debug.ts
@@ -1,0 +1,82 @@
+/**
+ * Voice-capture lifecycle tracing (opt-in). Prefix: `[eliza][voice-capture]`.
+ *
+ * Purpose: make the next "tapped the mic, then crickets" report diagnosable
+ * from the device console in seconds. Each breadcrumb marks one step of the
+ * capture lifecycle so a silent no-op is legible instead of invisible:
+ *
+ *   `start:cloud` / `start:local-inference` — a WAV recorder began.
+ *   `pause:cancel` — an APP_PAUSE discarded an in-flight capture.
+ *   `pause:kept` — an APP_PAUSE fired inside the permission-prompt grace window
+ *                  and the young capture was KEPT (the iOS getUserMedia dialog
+ *                  steals focus → visibilitychange → this must not cancel).
+ *   `silent:drop` — the pre-POST silence guard no-op'd a near-silent WAV
+ *                   (crickets BY DESIGN — the UI now surfaces a subtle hint).
+ *   `posted` — a WAV was POSTed to the STT proxy.
+ *   `transcript` — a final transcript was emitted.
+ *
+ * Zero-cost when disabled: the predicate short-circuits before any string work.
+ *
+ * Enable with:
+ * - **Renderer (WebView / installed PWA):** `localStorage.setItem("eliza:voice:debug", "1")`
+ *   then reload — the fastest path on a physical device (Safari Web Inspector or
+ *   the installed-PWA remote console), no rebuild needed.
+ * - **Build-time:** `ELIZA_VOICE_DEBUG=1` (mirrored via Vite `define`), same as
+ *   the sibling TTS debug flag.
+ */
+type RuntimeImportMeta = ImportMeta & {
+  env?: Record<string, unknown>;
+};
+
+function truthy(raw: string | undefined | null): boolean {
+  if (raw == null) return false;
+  const v = String(raw).trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes" || v === "on";
+}
+
+function voiceDebugEnabled(): boolean {
+  // localStorage first: it's the on-device toggle that needs no rebuild — set
+  // it in the console on the physical iPhone and reload to capture the next tap.
+  try {
+    if (
+      typeof localStorage !== "undefined" &&
+      truthy(localStorage.getItem("eliza:voice:debug"))
+    ) {
+      return true;
+    }
+  } catch {
+    /* localStorage blocked (sandbox / private mode) — fall through */
+  }
+
+  if (typeof process !== "undefined" && process.env) {
+    if (truthy(process.env.ELIZA_VOICE_DEBUG)) return true;
+  }
+
+  try {
+    const viteEnv = (import.meta as RuntimeImportMeta).env;
+    if (truthy(String(viteEnv?.ELIZA_VOICE_DEBUG ?? ""))) return true;
+    if (truthy(String(viteEnv?.VITE_ELIZA_VOICE_DEBUG ?? ""))) return true;
+  } catch {
+    /* no import.meta */
+  }
+
+  return false;
+}
+
+/** Same predicate as {@link voiceCaptureDebug}. */
+export function isVoiceCaptureDebugEnabled(): boolean {
+  return voiceDebugEnabled();
+}
+
+/** One lifecycle-step breadcrumb. No secrets in `detail`. */
+export function voiceCaptureDebug(
+  step: string,
+  detail?: Record<string, unknown>,
+): void {
+  if (!voiceDebugEnabled()) return;
+  if (detail && Object.keys(detail).length > 0) {
+    console.info(`[eliza][voice-capture] ${step}`, detail);
+  } else {
+    console.info(`[eliza][voice-capture] ${step}`);
+  }
+}

--- a/packages/ui/src/voice/local-asr-capture.test.ts
+++ b/packages/ui/src/voice/local-asr-capture.test.ts
@@ -150,6 +150,82 @@ describe("startLocalAsrRecorder resume failure", () => {
     expect(trackStop).toHaveBeenCalledTimes(1);
     expect(contextClose).toHaveBeenCalledTimes(1);
   });
+
+  it("rejects when resume() RESOLVES but state stays suspended (#voice-crickets iOS quirk)", async () => {
+    // WebKit quirk: after the getUserMedia permission dialog interrupts the
+    // gesture, `resume()` can resolve while `state` is still "suspended" — the
+    // graph never actually runs, so PCM is all zeros and the WAV reads silent
+    // (crickets). A single await isn't proof; the retry loop re-checks state and
+    // must reject (surface error → not silent crickets) if it never flips.
+    const trackStop = vi.fn();
+    const stream = {
+      getTracks: () => [{ stop: trackStop }],
+    } as unknown as MediaStream;
+    const getUserMedia = vi.fn().mockResolvedValue(stream);
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+
+    const contextClose = vi.fn().mockResolvedValue(undefined);
+    const resume = vi.fn().mockResolvedValue(undefined);
+    class StuckSuspendedContext {
+      state = "suspended"; // never flips to "running"
+      resume = resume;
+      close = contextClose;
+    }
+    vi.stubGlobal("window", { AudioContext: StuckSuspendedContext });
+
+    await expect(startLocalAsrRecorder()).rejects.toThrow(
+      "AudioContext could not resume for local ASR capture",
+    );
+    // Retried before giving up (more than one resume attempt).
+    expect(resume.mock.calls.length).toBeGreaterThanOrEqual(2);
+    // Mic + context released on the failed start (no lingering capture indicator).
+    expect(trackStop).toHaveBeenCalledTimes(1);
+    expect(contextClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("succeeds when a suspended context flips to running on a retry (#voice-crickets recovery)", async () => {
+    // The dialog dismissed and the queued resume lands a beat later: the second
+    // state read is "running", so capture proceeds instead of falsely rejecting.
+    const trackStop = vi.fn();
+    const stream = {
+      getTracks: () => [{ stop: trackStop }],
+    } as unknown as MediaStream;
+    const getUserMedia = vi.fn().mockResolvedValue(stream);
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+
+    let resumeCalls = 0;
+    const fakeNode = {
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      fftSize: 0,
+      smoothingTimeConstant: 0,
+    };
+    class RecoveringContext {
+      state = "suspended";
+      sampleRate = 16000;
+      resume = vi.fn().mockImplementation(async () => {
+        resumeCalls += 1;
+        // Flip to running only on the SECOND resume — the first resolves while
+        // still suspended (the iOS quirk), the retry lands it.
+        if (resumeCalls >= 2) this.state = "running";
+      });
+      close = vi.fn().mockResolvedValue(undefined);
+      createMediaStreamSource = vi.fn().mockReturnValue(fakeNode);
+      createScriptProcessor = vi.fn().mockReturnValue({
+        ...fakeNode,
+        onaudioprocess: null,
+      });
+      createAnalyser = vi.fn().mockReturnValue({ ...fakeNode });
+      destination = {};
+    }
+    vi.stubGlobal("window", { AudioContext: RecoveringContext });
+
+    const recorder = await startLocalAsrRecorder();
+    expect(recorder).toBeTruthy();
+    expect(resumeCalls).toBeGreaterThanOrEqual(2);
+    // Mic NOT released — the capture is live.
+    expect(trackStop).not.toHaveBeenCalled();
+  });
 });
 
 describe("decodeMonoPcm16Wav / isSilentWav (#voice-V5 silence guard)", () => {

--- a/packages/ui/src/voice/local-asr-capture.ts
+++ b/packages/ui/src/voice/local-asr-capture.ts
@@ -2,6 +2,7 @@
  * Mic-capture recorder for local ASR: records mono PCM16, exposes a live analyser
  * for amplitude visualization, and stops/cancels the audio context cleanly.
  */
+import { voiceCaptureDebug } from "../utils/voice-capture-debug";
 import {
   DEFAULT_POST_TTS_COOLDOWN_MS,
   isTtsEchoGateActive as sharedTtsEchoGateActive,
@@ -386,18 +387,52 @@ export async function startLocalAsrRecorder(
     throw new Error("Microphone capture is not available for local ASR");
   }
 
-  const stream = await navigator.mediaDevices.getUserMedia({
-    audio: {
-      channelCount: 1,
-      // Gemma ASR ingests 16 kHz mono; request it at capture so the
-      // browser resamples once instead of us downsampling a 48 kHz buffer.
-      sampleRate: 16000,
-      echoCancellation: true,
-      noiseSuppression: true,
-      autoGainControl: true,
-    },
+  // getUserMedia round-trip: on iOS PWA this pops the native permission dialog.
+  // Trace the request/resolve/reject so the on-screen HUD shows whether the
+  // grant was denied (`gum:err(NotAllowedError)`) or resolved but the graph
+  // then died (a later `ctx:suspended!`) — the two crickets modes look
+  // identical without this split.
+  voiceCaptureDebug("gum:req", {});
+  const gumStartMs = nowMs();
+  let stream: MediaStream;
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        channelCount: 1,
+        // Gemma ASR ingests 16 kHz mono; request it at capture so the
+        // browser resamples once instead of us downsampling a 48 kHz buffer.
+        sampleRate: 16000,
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+      },
+    });
+  } catch (err) {
+    voiceCaptureDebug("gum:err", {
+      name: err instanceof Error ? err.name : "Error",
+      reason:
+        err instanceof Error
+          ? err.message.slice(0, 80)
+          : String(err).slice(0, 80),
+    });
+    throw err;
+  }
+  voiceCaptureDebug("gum:ok", {
+    ms: Math.round(nowMs() - gumStartMs),
+    // Defensive: some capture stubs expose only `getTracks`; never let a HUD
+    // breadcrumb throw and break the capture it's meant to observe.
+    tracks:
+      typeof stream.getAudioTracks === "function"
+        ? stream.getAudioTracks().length
+        : typeof stream.getTracks === "function"
+          ? stream.getTracks().length
+          : undefined,
   });
   const context = new AudioContextCtor();
+  voiceCaptureDebug(
+    context.state === "running" ? "ctx:running" : `ctx:${context.state}`,
+    { state: context.state },
+  );
   if (context.state === "suspended") {
     // A context that cannot resume produces silence (all-zero PCM → the WAV
     // reads as silent → a quiet no-op → the user sees crickets). Surface the
@@ -432,8 +467,14 @@ export async function startLocalAsrRecorder(
       // "running". The cast widens the read back to the full union so the
       // comparison reflects the mutated value instead of the stale narrow.
       const liveState = context.state as AudioContextState;
-      if (liveState !== "suspended") break;
+      if (liveState !== "suspended") {
+        voiceCaptureDebug("ctx:resumed", { state: liveState, attempt });
+        break;
+      }
       if (attempt === 2) {
+        // The graph never resumed after the permission dialog — it will record
+        // all-zero PCM → SILENT WAV → crickets. Mark it terminally (`!`).
+        voiceCaptureDebug("ctx:suspended!", { state: liveState, attempt });
         await failResume(
           new Error("AudioContext stayed suspended after resume"),
         );
@@ -452,11 +493,18 @@ export async function startLocalAsrRecorder(
   const chunks: Float32Array[] = [];
   let stopped = false;
   let autoStopRequested = false;
+  let firstChunkTraced = false;
   const autoStopDetector = createLocalAsrAutoStopDetector(options.autoStop);
 
   processor.onaudioprocess = (event) => {
     if (stopped) return;
     const input = event.inputBuffer;
+    // First real audio callback: proof the graph is actually delivering frames
+    // (not a dead/suspended context that silently never fires onaudioprocess).
+    if (!firstChunkTraced) {
+      firstChunkTraced = true;
+      voiceCaptureDebug("rec:data", { chunk: String(input.length) });
+    }
     const frameCount = input.length;
     const channelCount = Math.max(1, input.numberOfChannels);
     const mono = new Float32Array(frameCount);

--- a/packages/ui/src/voice/local-asr-capture.ts
+++ b/packages/ui/src/voice/local-asr-capture.ts
@@ -399,20 +399,47 @@ export async function startLocalAsrRecorder(
   });
   const context = new AudioContextCtor();
   if (context.state === "suspended") {
-    // A context that cannot resume produces silence — surface the failure to
-    // the caller (voice-capture-factory setState("error")) instead of
-    // recording a dead stream. Release the mic + context first so the failed
+    // A context that cannot resume produces silence (all-zero PCM → the WAV
+    // reads as silent → a quiet no-op → the user sees crickets). Surface the
+    // failure to the caller (voice-capture-factory setState("error")) instead
+    // of recording a dead stream. Release the mic + context first so the failed
     // start does not leave the capture indicator on.
-    try {
-      await context.resume();
-    } catch (err) {
+    //
+    // iOS/WebKit quirk (#voice-crickets): `context.resume()` can RESOLVE while
+    // `state` is still "suspended" — the resume is queued behind a user gesture
+    // that the getUserMedia permission dialog interrupted. A single await
+    // therefore isn't proof the graph is live; re-check the state and retry a
+    // couple of times before giving up, so a context that just needed a beat to
+    // actually resume after the dialog dismissed isn't misread as dead.
+    const failResume = async (cause: unknown): Promise<never> => {
       // error-policy:J2 release the hot mic, then rethrow with context
       for (const track of stream.getTracks()) track.stop();
       // error-policy:J6 teardown — the context may already be closed
       await context.close().catch(() => undefined);
       throw new Error("AudioContext could not resume for local ASR capture", {
-        cause: err,
+        cause,
       });
+    };
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        await context.resume();
+      } catch (err) {
+        await failResume(err);
+      }
+      // resume() resolved — but on iOS it may not have actually taken effect.
+      // Re-read the LIVE state: the `if (context.state === "suspended")` guard
+      // above narrows the literal, but resume() can have flipped it to
+      // "running". The cast widens the read back to the full union so the
+      // comparison reflects the mutated value instead of the stale narrow.
+      const liveState = context.state as AudioContextState;
+      if (liveState !== "suspended") break;
+      if (attempt === 2) {
+        await failResume(
+          new Error("AudioContext stayed suspended after resume"),
+        );
+      }
+      // Yield a frame so a gesture-queued resume can land before the re-check.
+      await new Promise((resolve) => setTimeout(resolve, 50));
     }
   }
 

--- a/packages/ui/src/voice/voice-capture-factory.test.ts
+++ b/packages/ui/src/voice/voice-capture-factory.test.ts
@@ -389,10 +389,12 @@ describe("createVoiceCapture", () => {
     isSilentWavMock.mockReturnValue(true);
     const onTranscript = vi.fn();
     const onStateChange = vi.fn();
+    const onSilentDrop = vi.fn();
     const capture = createVoiceCapture({
       asrProvider: "eliza-cloud",
       onTranscript,
       onStateChange,
+      onSilentDrop,
     });
 
     await capture.start();
@@ -402,6 +404,9 @@ describe("createVoiceCapture", () => {
     expect(isSilentWavMock).toHaveBeenCalledWith(wav);
     expect(transcribeCloudWavMock).not.toHaveBeenCalled();
     expect(onTranscript).not.toHaveBeenCalled();
+    // #voice-crickets: the guard fired, but the surface is notified so it can
+    // show a subtle "didn't catch that" hint instead of pure silence.
+    expect(onSilentDrop).toHaveBeenCalledTimes(1);
     // Not an error state — a clean settle back to idle.
     const states = onStateChange.mock.calls.map(([s]) => s);
     expect(states).not.toContain("error");

--- a/packages/ui/src/voice/voice-capture-factory.ts
+++ b/packages/ui/src/voice/voice-capture-factory.ts
@@ -32,6 +32,7 @@ import {
   type TalkModeErrorEvent,
   type TalkModeTranscriptEvent,
 } from "../bridge/native-plugins";
+import { voiceCaptureDebug } from "../utils/voice-capture-debug";
 import {
   isLocalAsrCaptureSupported,
   isSilentWav,
@@ -107,6 +108,15 @@ export interface VoiceCaptureFactoryOptions {
   onTranscript: (segment: VoiceCaptureTranscriptSegment) => void;
   /** Called when capture state changes. Optional. */
   onStateChange?: (state: VoiceCaptureState, error?: Error) => void;
+  /**
+   * Called when the pre-POST silence guard (#voice-V5) no-ops a near-silent
+   * capture instead of POSTing it to cloud STT. The guard is CORRECT (a silent
+   * WAV isn't worth a round-trip), but a pure silent no-op reads as "crickets"
+   * on-device — the user tapped, spoke (or thought they did), and got nothing,
+   * no transcript AND no feedback (#voice-crickets). This lets the surface emit
+   * a subtle "didn't catch that" hint so the dead-air is legible. Optional.
+   */
+  onSilentDrop?: () => void;
   /**
    * Which ASR backend to prefer. Default: `local-inference` when supported,
    * with browser SpeechRecognition as automatic fallback.
@@ -219,6 +229,7 @@ export function createVoiceCapture(
   const {
     onTranscript,
     onStateChange,
+    onSilentDrop,
     asrProvider,
     lang = "en-US",
     localAsrAutoStop,
@@ -257,6 +268,7 @@ export function createVoiceCapture(
     });
     recorder = next;
     active = true;
+    voiceCaptureDebug("start", { backend: backendKind ?? "wav" });
     setState("listening");
   }
 
@@ -453,6 +465,11 @@ export function createVoiceCapture(
         // is free/offline, so it stays unguarded to avoid clipping quiet-mic
         // users whose real speech reads near the silence floor on-device.)
         if (kind === "cloud" && isSilentWav(wav)) {
+          voiceCaptureDebug("silent:drop", { backend: kind });
+          // Subtle "didn't catch that" hint instead of pure silence: the guard
+          // is right (no cloud round-trip for a silent WAV), but crickets with
+          // zero feedback is a UX bug even when the guard fires correctly.
+          onSilentDrop?.();
           setState("stopped");
           setState("idle");
           return;
@@ -462,7 +479,12 @@ export function createVoiceCapture(
           // attached so the transcript recorder can retain the audio. A ~15s
           // per-attempt timeout + one auto-retry (#voice-V4) rides inside
           // transcribeCloudWav so flaky cellular doesn't hard-fail the turn.
+          voiceCaptureDebug("posted", { backend: kind, wavBytes: wav.length });
           const text = await transcribeCloudWav(wav);
+          voiceCaptureDebug("transcript", {
+            backend: kind,
+            chars: text.length,
+          });
           onTranscript({
             text,
             final: true,


### PR DESCRIPTION
## Symptom
On the installed iOS PWA, tapping the mic (mic surface **and** "transcribe") prompts for permission, the user grants, then **crickets**: no listening indicator, no transcript, no error toast, nothing. Backend proven healthy (staging TTS→STT round-trips 200), so the break is client-side.

## Root cause (confirmed with file:line receipts)
1. **Pause-cancel race (top cause).** The native `getUserMedia` permission dialog steals focus the instant capture starts, firing `visibilitychange → hidden`. `mobile-lifecycle.ts:149` bridges that straight to `APP_PAUSE` on the installed PWA (`isStandalonePwa`), and both `useVoiceChat.discardCaptureForSuspend` and `useShellController.discardCaptureForSuspend` cancel/dispose the recorder the moment it's created. User grants → the capture is already dead → crickets. Transcription mode never re-arms on resume, so it can't self-heal. (suspect #3 confirmed)
2. **Suspended AudioContext (iOS/WebKit quirk).** `context.resume()` in `local-asr-capture.ts` can **resolve** while `state` stays `"suspended"` — the graph never runs, PCM is all zeros, the WAV reads silent → the pre-POST silence guard no-ops it → crickets by design. (suspect #5 confirmed)
3. **Silent-drop feedback gap.** `voice-capture-factory.ts` did `setState("stopped"); setState("idle")` on `isSilentWav` with **zero** user feedback. (suspect c confirmed)

## Fix
- **Permission-prompt grace window** (`CAPTURE_PAUSE_GRACE_MS` / `SHELL_CAPTURE_PAUSE_GRACE_MS`, 1500ms): an `APP_PAUSE` within the grace of a capture start is treated as the dialog focus-steal, not a background-suspend — the young capture is **kept**. A genuine background that stalls the WebAudio graph is still caught at `stop()` by the empty-WAV guard, so keeping a young capture is safe. Applied to **both** composer and hands-free/transcribe surfaces.
- **Harden `startLocalAsrRecorder`**: after `resume()` resolves, re-read the **live** `AudioContext` state and retry a couple of times; only reject (surface an error state, not silent crickets) if it never leaves `"suspended"`.
- **Silent-drop feedback**: new `onSilentDrop` callback → subtle "Didn't catch that — try again." hint instead of pure silence.
- **Diagnostic breadcrumb** (`utils/voice-capture-debug.ts`, opt-in via `localStorage 'eliza:voice:debug'` on-device or `ELIZA_VOICE_DEBUG` at build): `start / pause:kept / pause:cancel / silent:drop / posted / transcript`. Zero-cost when off. Makes the next crickets report diagnosable from the device console in seconds.

## Tests
Existing #voice-V1 suspend tests updated to advance past the grace before asserting real-suspend teardown; new tests lock the young-capture keep (both surfaces), aged-past-grace cancel, resume-resolves-but-stays-suspended rejection + recovery-on-retry, and the `onSilentDrop` hint.

```
Test Files  5 passed (5)
     Tests  109 passed (109)
```
biome clean (10 files). tsc clean (only pre-existing pg/stripe/esbuild/postcss dep-type errors, none in touched files).

## Verify on device
Set `localStorage.setItem("eliza:voice:debug","1")` in the installed-PWA console, reload, tap mic. Expect `start` → (`pause:kept` when the dialog bounces) → `posted` → `transcript`. A `pause:cancel` right after `start` = the race is still firing.

**DO NOT merge** — orchestrator hot-deploys to sol-dev for device verify first.

[sol-orch]

🤖 authored by Sol
Co-authored-by: wakesync <shadow@shad0w.xyz>
