### PR TITLE
chore(app-core): route dev-server diagnostics through structured logger

### DIFF
--- a/packages/app-core/src/runtime/dev-server.ts
+++ b/packages/app-core/src/runtime/dev-server.ts
@@ -490,7 +490,7 @@ async function main() {
   // ELIZA_API_PORT is the app API. Overwriting ELIZA_PORT here would
   // collapse UI vs API in observability JSON and confuse tools that read env.
   if (actualPort !== port) {
-    console.error(
+    logger.error(
       `${getLogPrefix()} [CRITICAL] API bound to port ${actualPort} but orchestrator expected ${port}. ` +
         `Electrobun renderer has ELIZA_DESKTOP_API_BASE pointing at the wrong port. ` +
         `Kill the process using port ${port} or set ELIZA_API_PORT to a free port.`,
@@ -565,15 +565,14 @@ async function main() {
 // ── Global error handlers (match CLI behavior from run-main.ts) ──
 process.on("unhandledRejection", (reason) => {
   if (shouldIgnoreUnhandledRejection(reason)) {
-    console.warn(
+    logger.warn(
       `${getLogPrefix()} Provider credits appear exhausted; request failed without output. Top up credits and retry.`,
     );
     return;
   }
   // In dev mode (bun --watch), log but do NOT exit — let the watcher restart.
-  console.error(
-    `${getLogPrefix()} Unhandled rejection:`,
-    formatUncaughtError(reason),
+  logger.error(
+    `${getLogPrefix()} Unhandled rejection: ${formatUncaughtError(reason)}`,
   );
 });
 


### PR DESCRIPTION
## What

Per the repo's logger-only server commandment, convert the non-fatal diagnostic `console.*` calls in the app-core dev-server process entry to the structured `logger` (already imported and used in this file).

Converted (3):
- `console.error` → `logger.error` for the `[CRITICAL]` API/orchestrator port-mismatch diagnostic
- `console.warn` → `logger.warn` for the provider-credits-exhausted `unhandledRejection` branch (no exit)
- `console.error` → `logger.error` for the `unhandledRejection` log path (dev `--watch` restarts, no exit)

## Intentionally kept as `console` (justified)

- **Startup timing (62/104/116)** — module-eval-time instrumentation; line 62 precedes the logger import.
- **Startup banner box (523–560)** — deliberate user-facing dev banner that bypasses logger filtering (documented in-file).
- **Fatal handlers before `process.exit(1)`** (uncaughtException 580; `main().catch` fatal/cause 611/617) — `console` is synchronous and flushes before exit; the async logger transport does not.

## Scope audit result

A full `git grep` of `console.*` across `packages/agent/src`, `packages/app-core/src`, `packages/core/src`, `packages/cloud/shared/src` (excluding tests/scripts/testing) found the remaining offenders are all legitimately non-server-diagnostic and were left as-is: CLI user-facing output (`*/cli/`, help/version/REPL/banners), browser/renderer code (cloud-pair embedded scripts using `document.querySelector`; the iOS local-agent renderer transport patching `window.fetch`), the logger implementations themselves (`cloud/shared` `logger.ts` + `runtime-patches.ts` binding `console` as their sink), JSDoc examples, and deliberate dual-log stdout used for port/PID detection (agent `server.ts`/`eliza.ts`, each already paired with a `logger` call).

## Verify

- `bun x tsgo --noEmit` on `packages/app-core`: no errors on `dev-server.ts` (38 pre-existing errors are in unrelated i18n/auth-store/test files).
- `bun x biome check packages/app-core/src/runtime/dev-server.ts`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)