### PR TITLE
chore(deslop): break two real circular dependencies

### DIFF
--- a/packages/app-core/src/api/auth.ts
+++ b/packages/app-core/src/api/auth.ts
@@ -24,7 +24,11 @@ import {
   findActiveSession,
   verifyCsrfToken,
 } from "./auth/sessions.js";
-import { tokenMatches } from "./auth/tokens.js";
+import {
+  extractHeaderValue,
+  getProvidedApiToken,
+  tokenMatches,
+} from "./auth/tokens.js";
 import { isTrustedLocalRequest } from "./compat-route-shared.js";
 import { sendJsonError } from "./response.js";
 
@@ -34,7 +38,11 @@ export {
   ensureSessionForRequest,
   type ResolvedAuthContext,
 } from "./auth/auth-context.js";
-export { tokenMatches } from "./auth/tokens.js";
+export {
+  extractHeaderValue,
+  getProvidedApiToken,
+  tokenMatches,
+} from "./auth/tokens.js";
 
 export interface CompatStateLike {
   current:
@@ -43,51 +51,11 @@ export interface CompatStateLike {
 }
 
 /**
- * Normalise a potentially multi-valued HTTP header into a single string.
- * Returns `null` when the header is absent or empty.
- */
-export function extractHeaderValue(
-  value: string | string[] | undefined,
-): string | null {
-  if (typeof value === "string") return value;
-  return Array.isArray(value) && typeof value[0] === "string" ? value[0] : null;
-}
-
-/**
  * Read the configured API token from env (`ELIZA_API_TOKEN` / `ELIZA_API_TOKEN`).
  * Returns `null` when no token is configured (open access).
  */
 export function getCompatApiToken(): string | null {
   return resolveApiToken(process.env);
-}
-
-/**
- * Extract the API token from an incoming request.
- *
- * Checks (in order):
- *   1. `Authorization: Bearer <token>`
- *   2. `x-eliza-token`
- *   3. `x-elizaos-token`
- *   4. `x-api-key` / `x-api-token`
- */
-export function getProvidedApiToken(
-  req: Pick<http.IncomingMessage, "headers">,
-): string | null {
-  const authHeader = extractHeaderValue(req.headers.authorization)
-    ?.slice(0, 1024)
-    ?.trim();
-  if (authHeader) {
-    const match = /^Bearer\s{1,8}(.+)$/i.exec(authHeader);
-    if (match?.[1]) return match[1].trim();
-  }
-
-  const headerToken =
-    extractHeaderValue(req.headers["x-eliza-token"]) ??
-    extractHeaderValue(req.headers["x-elizaos-token"]) ??
-    extractHeaderValue(req.headers["x-api-key"]) ??
-    extractHeaderValue(req.headers["x-api-token"]);
-
-  return headerToken?.trim() || null;
 }
 
 /**

--- a/packages/app-core/src/api/auth/auth-context.ts
+++ b/packages/app-core/src/api/auth/auth-context.ts
@@ -19,8 +19,8 @@ import type {
   AuthSessionRow,
   AuthStore,
 } from "../../services/auth-store";
-import { getProvidedApiToken } from "../auth.js";
 import { findActiveSession, parseSessionCookie } from "./sessions.js";
+import { getProvidedApiToken } from "./tokens.js";
 
 export type AuthContextSource =
   | "cookie"

--- a/packages/app-core/src/api/auth/tokens.ts
+++ b/packages/app-core/src/api/auth/tokens.ts
@@ -5,6 +5,7 @@
  * compare and folds the true length check into the returned boolean.
  */
 import crypto from "node:crypto";
+import type http from "node:http";
 
 /** Timing-safe token comparison (constant-time regardless of input length). */
 export function tokenMatches(expected: string, provided: string): boolean {
@@ -17,4 +18,44 @@ export function tokenMatches(expected: string, provided: string): boolean {
   b.copy(bPadded);
   const contentMatch = crypto.timingSafeEqual(aPadded, bPadded);
   return a.length === b.length && contentMatch;
+}
+
+/**
+ * Normalise a potentially multi-valued HTTP header into a single string.
+ * Returns `null` when the header is absent or empty.
+ */
+export function extractHeaderValue(
+  value: string | string[] | undefined,
+): string | null {
+  if (typeof value === "string") return value;
+  return Array.isArray(value) && typeof value[0] === "string" ? value[0] : null;
+}
+
+/**
+ * Extract the API token from an incoming request.
+ *
+ * Checks (in order):
+ *   1. `Authorization: Bearer <token>`
+ *   2. `x-eliza-token`
+ *   3. `x-elizaos-token`
+ *   4. `x-api-key` / `x-api-token`
+ */
+export function getProvidedApiToken(
+  req: Pick<http.IncomingMessage, "headers">,
+): string | null {
+  const authHeader = extractHeaderValue(req.headers.authorization)
+    ?.slice(0, 1024)
+    ?.trim();
+  if (authHeader) {
+    const match = /^Bearer\s{1,8}(.+)$/i.exec(authHeader);
+    if (match?.[1]) return match[1].trim();
+  }
+
+  const headerToken =
+    extractHeaderValue(req.headers["x-eliza-token"]) ??
+    extractHeaderValue(req.headers["x-elizaos-token"]) ??
+    extractHeaderValue(req.headers["x-api-key"]) ??
+    extractHeaderValue(req.headers["x-api-token"]);
+
+  return headerToken?.trim() || null;
 }

--- a/packages/ui/src/cloud/handoff/resume-pending-handoff.ts
+++ b/packages/ui/src/cloud/handoff/resume-pending-handoff.ts
@@ -12,8 +12,8 @@ import {
   type CloudHandoffRetryDetail,
   dispatchCloudHandoffPhase,
 } from "../../events";
-import { loadPersistedActiveServer } from "../../state";
 import { runAgentSessionRecovery } from "../../state/agent-session-recovery-runner";
+import { loadPersistedActiveServer } from "../../state/persistence";
 import {
   clearPendingCloudHandoff,
   loadPendingCloudHandoff,


### PR DESCRIPTION
## Summary

`madge --circular` on `packages/{core,ui,agent,app-core,shared,elizaos}/src` surfaced 6 cycles. Four are deliberate / madge false-positives (type-only imports or intentional dynamic-import seams); **two were real barrel / wrong-direction edges** and are broken here.

### Fixed (real cycles)

1. **app-core `api/auth.ts` ⇄ `api/auth/auth-context.ts`** — `auth-context` imported `getProvidedApiToken` from the `auth.ts` barrel while `auth.ts` re-exported `auth-context`'s session helpers. Moved the two pure header-parsing helpers (`extractHeaderValue`, `getProvidedApiToken`) down into the leaf `api/auth/tokens.ts`. `auth.ts` re-exports them (public API unchanged) and `auth-context` imports from `./tokens.js`. Cycle gone.
2. **ui `cloud/handoff/resume-pending-handoff.ts`** pulled `loadPersistedActiveServer` from the `../../state` barrel, closing a `state/index → AppContext → useStartupCoordinator → startup-phase-poll → resume-pending-handoff` loop. Now imports directly from `../../state/persistence`. Cycle gone.

### Left as-is (reported, not fixed)

- **core `entities.ts` ⇄ `roles.ts`** — already runtime-safe: type-only import + lazy `await import("./roles")`. Deliberate, documented.
- **ui `DynamicViewLoader` → `index.ts`** — intentional dynamic `import("../../index.ts")` manifest-broker seam; no static runtime cycle.
- **plugin-local-inference management ⇄ routes ⇄ provider** — the management→routes edge is `import type` only (erased); no runtime cycle.
- **app-core `account-pool` ⇄ `coding-account-bridge`** — genuine bidirectional runtime dependency (each calls the other's functions); needs a design inversion, out of scope for a safe mechanical fix.

## Verification

- `madge --circular` re-run on app-core and ui: both fixed cycles removed.
- `tsgo --noEmit` on app-core: clean on touched files (only pre-existing missing-generated-file errors unrelated to this change).
- `biome check` clean on all touched files.

Note: a full-repo `knip` dead-code pass was attempted but did not complete in the CI-less sandbox (25+ min, no output); no dead-code removals are included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)