### PR TITLE
fix(cloud): stream billing parity with non-stream (waitUntil) + stream-aware dedicated-agent proxy timeout

### DIFF
--- a/packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/chat-completions-streaming-credit-leak.test.ts
@@ -61,7 +61,12 @@ mock.module("@/lib/providers/language-model", () => ({
 
 const INPUT_TOKEN_COST = 0.001;
 const OUTPUT_TOKEN_COST = 0.01;
+// When set, billUsage blocks until the gate resolves — lets the waitUntil-
+// parity tests hold the settlement chain open while the SSE body is read, to
+// prove the stream close does not wait on billing.
+let billUsageGate: Promise<void> | null = null;
 const billUsage = mock(async (_context: unknown, usage: unknown) => {
+  if (billUsageGate) await billUsageGate;
   const record =
     usage && typeof usage === "object"
       ? (usage as {
@@ -202,6 +207,7 @@ function callStreaming(
     } | null;
     signal?: AbortSignal;
     useMonetizedAppBilling?: boolean;
+    executionCtx?: { waitUntil(promise: Promise<unknown>): void };
   } = {},
 ) {
   return handleStreamingRequest(
@@ -226,6 +232,7 @@ function callStreaming(
     "gateway" as never,
     options.pooledCredential ?? null,
     options.useMonetizedAppBilling ?? false,
+    options.executionCtx,
   );
 }
 
@@ -237,6 +244,7 @@ beforeEach(() => {
   poolRecordUse.mockClear();
   poolRecordProviderFailure.mockClear();
   streamTextImpl = null;
+  billUsageGate = null;
 });
 
 // Per-status OpenAI-compatible error.type the terminal chunk must carry —
@@ -628,5 +636,150 @@ describe("streaming chat — success settles once, no double-refund", () => {
     expect(ledger.balance).toBeCloseTo(ledger.startBalance - ACTUAL, 10);
     // The cached settle result is returned for the second call.
     expect(second).toBe(first);
+  });
+});
+
+describe("streaming chat — billing settles OFF the response path (waitUntil parity with non-stream, #8759)", () => {
+  const USAGE = { inputTokens: 2, outputTokens: 3, totalTokens: 5 };
+  const TEXT = "hello streamed world";
+  const EXPECTED_COST =
+    USAGE.inputTokens * INPUT_TOKEN_COST +
+    USAGE.outputTokens * OUTPUT_TOKEN_COST;
+
+  /**
+   * SDK-faithful stream: the AI SDK AWAITS onFinish before ending fullStream —
+   * that contract is exactly why an inline-awaited settlement chain held the
+   * final SSE frame + [DONE] hostage. Also captures onError so the deferral
+   * tests can fire a stray late error against the cached settlement.
+   */
+  function sdkFaithfulStream(): {
+    onError: () => Promise<unknown>;
+  } {
+    let capturedOnError:
+      | ((e: { error: unknown }) => Promise<unknown>)
+      | undefined;
+    streamTextImpl = (config) => {
+      capturedOnError = config.onError as typeof capturedOnError;
+      const onFinish = config.onFinish as (event: {
+        text: string;
+        usage: typeof USAGE;
+      }) => Promise<unknown>;
+      return {
+        fullStream: (async function* () {
+          yield { type: "text-delta", id: "text-1", text: TEXT };
+          await onFinish({ text: TEXT, usage: USAGE });
+          yield { type: "finish", finishReason: "stop", totalUsage: USAGE };
+        })(),
+      };
+    };
+    return {
+      onError: () =>
+        Promise.resolve(capturedOnError?.({ error: makeApiCallError(503) })),
+    };
+  }
+
+  test("final frame + [DONE] flush BEFORE the billing chain completes; the chain runs via waitUntil", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+
+    // Hold the settlement chain open at its first DB write (billUsage).
+    let releaseBilling!: () => void;
+    billUsageGate = new Promise<void>((resolve) => {
+      releaseBilling = resolve;
+    });
+
+    const waitUntilPromises: Promise<unknown>[] = [];
+    const executionCtx = {
+      waitUntil(promise: Promise<unknown>) {
+        waitUntilPromises.push(promise);
+      },
+    };
+
+    sdkFaithfulStream();
+    const res = await callStreaming(settle, { executionCtx });
+    // Reading the WHOLE body to [DONE] completes while billUsage is still
+    // gated — the regression under test (the ~8s billing tail) would hang
+    // this read until the chain finished.
+    const body = await res.text();
+    expect(body).toContain(TEXT);
+    expect(body.trimEnd().endsWith("data: [DONE]")).toBe(true);
+    expect(ledger.reconcileCalls).toBe(0); // nothing settled at stream close
+    expect(waitUntilPromises.length).toBe(1); // chain handed to waitUntil
+
+    releaseBilling();
+    await Promise.all(waitUntilPromises);
+
+    // The deferred chain ran exactly once, with the same amounts as before.
+    expect(billUsage).toHaveBeenCalledTimes(1);
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.actualCosts[0]).toBeCloseTo(EXPECTED_COST, 10);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance - EXPECTED_COST, 10);
+    expect(recordUsageAnalytics).toHaveBeenCalledTimes(1);
+    expect(aiBillingRecord).toHaveBeenCalledTimes(1);
+  });
+
+  test("deferred chain bills with EXACTLY the same args as the inline (no-executionCtx) path", async () => {
+    // Deferred variant.
+    const waitUntilPromises: Promise<unknown>[] = [];
+    sdkFaithfulStream();
+    const deferredRes = await callStreaming(async () => null, {
+      executionCtx: {
+        waitUntil(promise: Promise<unknown>) {
+          waitUntilPromises.push(promise);
+        },
+      },
+    });
+    await deferredRes.text();
+    await Promise.all(waitUntilPromises);
+    expect(billUsage).toHaveBeenCalledTimes(1);
+    const deferredCall = billUsage.mock.calls[0];
+
+    // Inline variant (tests / non-Worker fallback): same scenario, no ctx.
+    billUsage.mockClear();
+    sdkFaithfulStream();
+    const inlineRes = await callStreaming(async () => null, {});
+    await inlineRes.text();
+    expect(billUsage).toHaveBeenCalledTimes(1);
+
+    // Parity: billing context (streaming:true, ids, affiliate) + usage match.
+    expect(deferredCall).toEqual(billUsage.mock.calls[0]);
+  });
+
+  test("without executionCtx the chain settles inline by stream close (behavior unchanged)", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+
+    sdkFaithfulStream();
+    const res = await callStreaming(settle, {});
+    const body = await res.text();
+
+    expect(body.trimEnd().endsWith("data: [DONE]")).toBe(true);
+    expect(ledger.reconcileCalls).toBe(1); // settled before the body closed
+    expect(ledger.actualCosts[0]).toBeCloseTo(EXPECTED_COST, 10);
+  });
+
+  test("a stray late onError after a deferred onFinish cannot double-settle", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+    const waitUntilPromises: Promise<unknown>[] = [];
+
+    const stream = sdkFaithfulStream();
+    const res = await callStreaming(settle, {
+      executionCtx: {
+        waitUntil(promise: Promise<unknown>) {
+          waitUntilPromises.push(promise);
+        },
+      },
+    });
+    await res.text();
+    // The settlement promise is cached synchronously inside onFinish, so an
+    // onError racing in BEFORE the deferred chain resolves observes the same
+    // settlement instead of issuing a refund.
+    await stream.onError();
+    await Promise.all(waitUntilPromises);
+
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.actualCosts[0]).toBeCloseTo(EXPECTED_COST, 10);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance - EXPECTED_COST, 10);
   });
 });

--- a/packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts
+++ b/packages/cloud/api/__tests__/dedicated-agent-proxy.test.ts
@@ -1,5 +1,13 @@
 // Exercises cloud API tests dedicated agent proxy.test behavior with deterministic Worker route fixtures.
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 
 /**
  * Security tests for the dedicated-agent unified-auth proxy. The single
@@ -51,16 +59,20 @@ mock.module("@/lib/utils/logger", () => ({
 }));
 
 let captured: Request | null = null;
+// Per-test override for the origin fetch; null = the default instant-200 stub.
+let fetchImpl: ((request: Request) => Promise<Response>) | null = null;
 const originalFetch = globalThis.fetch;
 globalThis.fetch = (async (input: RequestInfo | URL) => {
-  captured = input instanceof Request ? input : new Request(input);
+  const request = input instanceof Request ? input : new Request(input);
+  captured = request;
+  if (fetchImpl) return fetchImpl(request);
   return new Response("ok", { status: 200 });
 }) as typeof fetch;
 afterAll(() => {
   globalThis.fetch = originalFetch;
 });
 
-const { handleDedicatedAgentProxy } = await import(
+const { handleDedicatedAgentProxy, __dedicatedProxyTestHooks } = await import(
   "../src/dedicated-agent-proxy"
 );
 
@@ -90,6 +102,7 @@ const runningDedicated = {
 
 beforeEach(() => {
   captured = null;
+  fetchImpl = null;
   authResult = "throw";
   sandboxResult = null;
   creditGateResult = { allowed: true, balance: 100 };
@@ -319,5 +332,108 @@ describe("dedicated-agent-proxy — CORS + unroutable short-circuit (#15347)", (
     const res = await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
     expect(res.headers.get("access-control-allow-origin")).toBe(ORIGIN);
     expect(captured).not.toBeNull(); // forwarded to the CP
+  });
+});
+
+/**
+ * Stream-aware origin timeout. The old `AbortSignal.timeout(30s)` on the whole
+ * fetch killed any body still flowing at t=30s — a >30s agent chat turn (or any
+ * long SSE stream) surfaced to the client as an unhandled TimeoutError
+ * (CF error 1101 / empty body) while the agent's reply persisted server-side.
+ * The timeout must gate the HEADERS phase only: once a response starts, the
+ * body flows for as long as the origin keeps it open, and a true
+ * headers-timeout becomes a structured, retryable 504 the client can read.
+ * Timeouts are shrunk to milliseconds via the test hook.
+ */
+describe("dedicated-agent-proxy — stream-aware origin timeout", () => {
+  const ORIGIN = "https://app-staging.elizacloud.ai";
+  const DEFAULT_TIMEOUT_MS = __dedicatedProxyTestHooks.originHeadersTimeoutMs;
+  const encoder = new TextEncoder();
+
+  beforeEach(() => {
+    authResult = { user: { id: "u1", organization_id: "org1" } };
+    sandboxResult = runningDedicated;
+  });
+  afterEach(() => {
+    __dedicatedProxyTestHooks.setOriginHeadersTimeoutMs(DEFAULT_TIMEOUT_MS);
+  });
+
+  test("body still streaming PAST the headers timeout is not aborted — it completes", async () => {
+    __dedicatedProxyTestHooks.setOriginHeadersTimeoutMs(50);
+
+    fetchImpl = async (request) => {
+      // Headers arrive well inside the timeout…
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          // The regression detector: if the proxy leaves its abort timer armed
+          // after headers, the signal fires at t=50ms and errors the body
+          // mid-stream (the old whole-transfer AbortSignal.timeout behavior).
+          request.signal.addEventListener("abort", () => {
+            try {
+              controller.error(
+                request.signal.reason ?? new Error("aborted mid-stream"),
+              );
+            } catch {
+              // already closed — nothing to error
+            }
+          });
+          controller.enqueue(encoder.encode("first-chunk "));
+          // …but the body keeps flowing to 3x the headers timeout.
+          setTimeout(() => {
+            controller.enqueue(encoder.encode("late-chunk-past-timeout"));
+            controller.close();
+          }, 150);
+        },
+      });
+      return new Response(body, { status: 200 });
+    };
+
+    const r = makeRequest("cloud-token", ORIGIN);
+    const res = await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
+    expect(res.status).toBe(200);
+    // Reading to completion is the assertion: the old behavior errors here.
+    const text = await res.text();
+    expect(text).toBe("first-chunk late-chunk-past-timeout");
+  });
+
+  test("origin exceeding the HEADERS timeout → structured 504 agent_timeout JSON, not a thrown TimeoutError", async () => {
+    __dedicatedProxyTestHooks.setOriginHeadersTimeoutMs(20);
+
+    // Origin never produces headers; a real fetch rejects when the signal aborts.
+    fetchImpl = (request) =>
+      new Promise<Response>((_resolve, reject) => {
+        request.signal.addEventListener("abort", () =>
+          reject(
+            request.signal.reason ??
+              new DOMException("The operation timed out.", "TimeoutError"),
+          ),
+        );
+      });
+
+    const r = makeRequest("cloud-token", ORIGIN);
+    // Old behavior: this await THROWS (client saw CF 1101 / empty body).
+    const res = await handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT);
+
+    expect(res.status).toBe(504);
+    expect(res.headers.get("Retry-After")).toBe("5");
+    // Browser-readable: CORS is backfilled on the error envelope (#15347).
+    expect(res.headers.get("access-control-allow-origin")).toBe(ORIGIN);
+    const body = (await res.json()) as { code?: string; success?: boolean };
+    expect(body.success).toBe(false);
+    expect(body.code).toBe("agent_timeout");
+  });
+
+  test("non-timeout fetch failures still propagate (fail-closed pass-through untouched)", async () => {
+    __dedicatedProxyTestHooks.setOriginHeadersTimeoutMs(1_000);
+    fetchImpl = async () => {
+      throw new TypeError("connection refused");
+    };
+
+    const r = makeRequest("cloud-token", ORIGIN);
+    // Not a headers timeout → the error is NOT swallowed into a 504.
+    await expect(
+      handleDedicatedAgentProxy(r, ENV, urlOf(r), AGENT),
+    ).rejects.toThrow("connection refused");
   });
 });

--- a/packages/cloud/api/docs/inference-hot-path.md
+++ b/packages/cloud/api/docs/inference-hot-path.md
@@ -36,8 +36,13 @@ cache backend; `REDIS_RATE_LIMITING=false`. Pre-forward steps, serial:
 Findings: rate-limit is already a no-op in prod (not the hotspot). `shouldBlockUser`
 is an **unconditional uncached Postgres read** on every request. `reserveCredits`
 is a Postgres write. Post-response billing (`billUsage → reconcile → analytics →
-audit`) is **already** deferred via `executionCtx.waitUntil`
-(`settleOffResponsePath`); only the **upfront** reserve is synchronous.
+audit`) is deferred via `executionCtx.waitUntil` (`settleOffResponsePath`) on
+**both** response paths: the non-streaming handler defers the whole chain, and
+the streaming handler's `onFinish` hands its (first-call-wins, single-flight)
+settlement to the same seam — the AI SDK awaits `onFinish` before ending
+`fullStream`, so an inline-awaited chain would hold the final SSE frame +
+`[DONE]` hostage for the full write latency. Only the **upfront** reserve is
+synchronous.
 
 ## Goal
 

--- a/packages/cloud/api/src/dedicated-agent-proxy.ts
+++ b/packages/cloud/api/src/dedicated-agent-proxy.ts
@@ -48,6 +48,24 @@ const DEFAULT_AGENT_ROUTER_ORIGIN_HOST = "eliza-production-1.elizacloud.ai";
 const RESUMABLE_STATUSES = new Set(["pending", "stopped", "disconnected"]);
 const RETRY_AFTER_SECONDS = 5;
 
+// The origin must produce response HEADERS within this window; the BODY then
+// streams untimed. Mutable only through __dedicatedProxyTestHooks so the
+// timeout paths are testable in milliseconds.
+let originHeadersTimeoutMs = 30_000;
+
+/**
+ * Test-only seam for the headers-phase timeout. The `__` prefix + `TestHooks`
+ * suffix mark it as non-public (same convention as the chat-completions route).
+ */
+export const __dedicatedProxyTestHooks = {
+  setOriginHeadersTimeoutMs(ms: number): void {
+    originHeadersTimeoutMs = ms;
+  },
+  get originHeadersTimeoutMs(): number {
+    return originHeadersTimeoutMs;
+  },
+} as const;
+
 function resolveOriginHost(env: Bindings): string {
   const raw = env.AGENT_ROUTER_ORIGIN_HOST?.trim().toLowerCase();
   return raw && raw.length > 0 ? raw : DEFAULT_AGENT_ROUTER_ORIGIN_HOST;
@@ -59,7 +77,7 @@ function resolveOriginHost(env: Bindings): string {
  * REPLACED with the agent's own `ELIZA_API_TOKEN` (so the container accepts it);
  * otherwise headers pass through unchanged and the container's own auth applies.
  */
-function proxyToOrigin(
+async function proxyToOrigin(
   request: Request,
   env: Bindings,
   url: URL,
@@ -83,16 +101,57 @@ function proxyToOrigin(
       targetUrl.searchParams.set("token", injectBearer);
     }
   }
+  // The timeout guards the HEADERS phase only. A blanket
+  // `AbortSignal.timeout(30s)` on the fetch aborted the WHOLE transfer, so any
+  // agent turn or SSE/WebSocket stream still flowing at t=30s was killed
+  // mid-body and the unhandled TimeoutError surfaced to the client as a
+  // CF 1101 / empty body — while the agent's reply persisted server-side. The
+  // timer is cleared the moment the Response object (headers) arrives, so an
+  // established stream flows for as long as the origin keeps it open; only an
+  // origin that never answers is aborted, and that is translated into a
+  // structured 504 the client can read instead of a thrown TimeoutError.
+  const controller = new AbortController();
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort(
+      new DOMException("origin response headers timed out", "TimeoutError"),
+    );
+  }, originHeadersTimeoutMs);
   const init: RequestInit = {
     method: request.method,
     headers,
     redirect: "manual",
-    signal: AbortSignal.timeout(30_000),
+    signal: controller.signal,
   };
   if (request.method !== "GET" && request.method !== "HEAD") {
     init.body = request.body;
   }
-  return fetch(new Request(targetUrl, init));
+  try {
+    return await fetch(new Request(targetUrl, init));
+  } catch (error) {
+    // error-policy:J1 boundary translation — the headers-phase timeout becomes
+    // a structured, retryable 504 instead of an unhandled TimeoutError (CF 1101).
+    if (!timedOut) throw error;
+    logger.warn("[dedicated-proxy] origin did not respond within timeout", {
+      host: targetUrl.hostname,
+      path: targetUrl.pathname,
+      timeoutMs: originHeadersTimeoutMs,
+    });
+    const response = Response.json(
+      {
+        success: false,
+        code: "agent_timeout",
+        error:
+          "Agent did not start responding in time. The agent may still be processing; retry shortly.",
+      },
+      { status: 504 },
+    );
+    response.headers.set("Retry-After", String(RETRY_AFTER_SECONDS));
+    return response;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 type Sandbox = NonNullable<

--- a/packages/cloud/api/v1/chat/completions/route.ts
+++ b/packages/cloud/api/v1/chat/completions/route.ts
@@ -1520,6 +1520,7 @@ export async function handleChatCompletionsPOST(
           billingSource,
           pooledCredential,
           useMonetizedAppBilling,
+          options.executionCtx,
         )
       : await handleNonStreamingRequest(
           model,
@@ -1829,6 +1830,7 @@ async function handleStreamingRequest(
   billingSource: PricingBillingSource,
   pooledCredential: PooledInferenceCredential | null,
   useMonetizedAppBilling: boolean,
+  executionCtx?: { waitUntil(promise: Promise<unknown>): void },
 ) {
   const provider = getProviderFromModel(model);
   const tools = convertTools(request.tools);
@@ -1907,8 +1909,20 @@ async function handleStreamingRequest(
     ...(experimentalOutput ? { output: experimentalOutput } : {}),
     ...(effectiveMaxTokens != null && { maxOutputTokens: effectiveMaxTokens }),
     ...cotOptions,
+    // Parity with the non-streaming path (#8759): the settlement chain below
+    // (billUsage → settleReservation → analytics → audit) is 5+ serial DB
+    // round-trips, and the AI SDK awaits onFinish before it ends fullStream —
+    // so awaiting the chain inline held the final SSE frame + [DONE] hostage
+    // for the full write latency (~8s measured in prod). Nothing the client
+    // receives depends on these writes (`text`/`usage` come from the provider
+    // result; the terminal usage frame is built from the stream's own finish
+    // part), so defer them via waitUntil. settleStreamingOnce is still invoked
+    // synchronously — the settlement promise is cached before onFinish
+    // returns, so the idempotent first-call-wins guarantee against a racing
+    // onAbort/onError is unchanged — and without an executionCtx (tests,
+    // non-Worker callers) the chain is awaited inline exactly as before.
     onFinish: async ({ text, usage }) => {
-      await settleStreamingOnce(async () => {
+      const settlement = settleStreamingOnce(async () => {
         try {
           const billingContext = buildChatBillingContext({
             user,
@@ -1980,6 +1994,9 @@ async function handleStreamingRequest(
           });
           return reconciliation;
         }
+      });
+      await settleOffResponsePath(executionCtx, async () => {
+        await settlement;
       });
     },
     onAbort: async ({


### PR DESCRIPTION
Two small, high-impact cloud-api latency/reliability fixes, measured tonight from inside a prod agent container. Refs #15404 and the HQ root-cause decomposition: https://github.com/elizaOS/eliza/discussions/14308#discussioncomment-17565768. Complementary to the Tier-3 pre-provider lane (#15409): this PR touches only the POST-provider `onFinish` section of the completions route, the streaming dispatch call site, and the dedicated-agent proxy — the admission/pre-flight code is untouched.

## Fix 1 — streaming billing tail: ~8s added to EVERY streamed inference call

**Measured (prod, identical payload):** non-stream `POST api.elizacloud.ai/v1/chat/completions` = **2.8s**; the SAME request with `stream:true` = **12.8–14.7s**. All content arrives by ~3.8s, then the gateway holds the stream ~8s before the final frame + `[DONE]`; the `generations` row is written exactly at stream-close.

**Cause:** the streaming path's `onFinish` awaited the settlement chain (`billUsage → settleReservation → recordPooledInferenceSuccess → recordUsageAnalytics → aiBillingRecordsService.record` — 5+ serial cross-provider DB round-trips) **inline**, and the AI SDK awaits `onFinish` before ending `fullStream` — so the `for await (result.fullStream)` loop could not emit the final frame + `[DONE]` until every billing write landed.

**Fix — parity with existing accepted semantics, not new billing behavior:** the non-streaming path already defers this exact chain via `executionCtx.waitUntil` (`settleOffResponsePath`, #8759). The streaming path now hands its settlement to the **same existing seam**. This closes a streaming coverage gap in the accepted inference-hot-path design: `packages/cloud/api/docs/inference-hot-path.md` (Findings) stated post-response billing "is **already** deferred via `executionCtx.waitUntil`" — that was only ever true for the non-stream path, and agents always stream. Refs: a07084e9cbc (Tier-1/Tier-2 hot-path design), 131d7da0f9e (Tier-2 optimistic billing enabled in prod); `INFERENCE_OPTIMISTIC_BILLING = "true"` is already live in `[env.production]`, so deferred/off-path billing is the accepted prod model — this change is parity within it. The doc's Findings paragraph is updated to match.

Guarantees preserved:
- **What is billed and the amounts are untouched** — only *when* the stream is released relative to the billing writes moves.
- `settleStreamingOnce` stays **first-call-wins** (#11512 / a91c60435ff): the settlement promise is still cached synchronously inside `onFinish`, so a racing `onAbort`/`onError` observes the same settlement and can never double-refund. New test proves it under deferral.
- The terminal usage frame (`stream_options.include_usage`) is built from the stream's own `finish` part (`part.totalUsage`), not from the billing writes — emitted unchanged (existing `chat-completions-stream-usage-frame` suite still green).
- Without an `executionCtx` (tests, non-Worker callers) the chain is awaited inline exactly as before — the same fallback the non-stream path uses (`settleOffResponsePath` decides defer-vs-inline).
- Provider-error / abort paths (`onError`, `onAbort`, the stream-loop catch) are untouched.

## Fix 2 — dedicated-agent proxy: 30s whole-transfer abort kills long turns

**Measured:** a chat turn >30s through `<agentId>.elizacloud.ai` (tool-ish turns hit 33s+ today) gets the stream aborted at t=30s: the client sees HTTP 500 `error code: 1101` (unhandled `TimeoutError`) or an empty body, while the agent's reply persists server-side — the user thinks the turn failed. The same abort hard-kills legitimate SSE/WebSocket streams >30s.

**Cause:** `dedicated-agent-proxy.ts` wrapped every origin fetch in `signal: AbortSignal.timeout(30_000)` — a whole-transfer bound, not a connection bound.

**Fix:**
- The timeout now guards the **headers phase only**: the abort timer is cleared the moment the `Response` object arrives, then the body streams untimed for as long as the origin keeps it open. The body pass-through shape is unchanged.
- A true headers-timeout becomes a structured, retryable **504 `{success:false, code:"agent_timeout", ...}`** (+ `Retry-After: 5`, CORS-backfilled like the proxy's other error envelopes per #15347) instead of a thrown `TimeoutError` (CF 1101).
- Non-timeout fetch failures still propagate unchanged — the fail-closed pass-through semantics are untouched (regression test included).

## Expected impact

- Simple cloud turn: **~19s → ~11s** (drops the ~8s stream-release tail).
- Tool-ish turn: **~34s → ~18s** (tail removed AND no longer 1101-killed at 30s).
- No more "reply persisted server-side but the user saw an error / empty body" on long turns.

## Tests

New, all green (plus the full cloud-api unit suite via the canonical isolated runner):
1. **Stream closes before billing:** final frame + `[DONE]` flush while `billUsage` is gated open; the settlement chain is handed to a captured `waitUntil` promise; after release it settles exactly once with the same amounts against the REAL ledger-backed settler (`chat-completions-streaming-credit-leak.test.ts`).
2. **Parity assertion:** the deferred chain bills with *exactly* the same args as the inline (no-`executionCtx`) path.
3. **Inline fallback unchanged**, and a **stray late `onError` after a deferred `onFinish` cannot double-settle** (first-call-wins under deferral).
4. **Proxy stream-aware timeout** (`dedicated-agent-proxy.test.ts`): an origin body still streaming *past* the headers timeout completes un-aborted (the mock errors the body if the old abort fires — a real regression detector); an origin exceeding the headers timeout → structured 504 `agent_timeout` JSON with CORS; non-timeout fetch failures still throw.

Verification: `bun run --cwd packages/cloud/api typecheck` (tsgo + wrangler dry-run bundle) exit 0; `node test/run-unit-isolated.mjs` 153/156 files green — the 3 failing files (`compat-agent-credit-gate`, `messages-iac-fast-path`, `stripe-event-clawback`) fail identically on clean develop `4ab6874f29e` (pre-existing, unrelated); `audit:error-policy-ratchet` clean; biome clean on touched files.

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - backend-only Worker change (SSE release timing + proxy timeout scope), no UI surface touched.

<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - backend-only Worker change, no UI surface touched.

<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - the observable behavior is SSE frame timing + HTTP status codes, proven directly by the uploaded test logs in the backend-logs row.

<!-- evidence-row:backend-logs -->
- Backend logs: real test output uploaded to the `pr-evidence` release: [15412-focused-suites.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15412-focused-suites.log) (both touched suites at head `b84dad11c08`: streaming credit-leak suite 16 pass / 0 fail incl. the 4 new waitUntil-parity tests; dedicated-agent-proxy suite 17 pass / 0 fail incl. the 3 new stream-aware-timeout tests; `typecheck` exit 0; `audit:error-policy-ratchet` clean) and [15412-unit-isolated.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15412-unit-isolated.log) (canonical `node test/run-unit-isolated.mjs`: 153/156 files pass; the 3 failing files fail identically on clean develop `4ab6874f29e` — pre-existing, unrelated).

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A - no frontend change.

<!-- evidence-row:llm-trajectory -->
- Real-LLM trajectory: N/A - no agent/action/prompt/model-behavior change; this PR moves the timing of post-response billing writes and the scope of a proxy timeout. Billing parity is asserted mechanically by test (identical args, exactly-once, real ledger-backed settler math).

<!-- evidence-row:domain-artifacts -->
- Domain artifacts: N/A - no schema/migration/contract artifacts; billing-ledger effects are covered by the ledger-backed settlement tests in the uploaded logs.

cc @lalalune

🤖 Generated with [Claude Code](https://claude.com/claude-code)
