### PR TITLE
fix(agent): polish batch - dupe returns persisted reply, single-source ack vocabulary, view-overlap miss budget cap

### DIFF
--- a/packages/agent/src/api/__tests__/conversation-idempotency.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-idempotency.test.ts
@@ -4,9 +4,12 @@
  * and its `/stream` twin). The pure decision function is pinned in
  * `chat-idempotency.test.ts`; these tests prove the routes actually consult it:
  * a first send runs the LLM turn, a retry carrying the SAME `clientMessageId`
- * within the TTL is suppressed (no second turn, no second persisted memory, a
- * clean terminal response for the client), and a send WITHOUT an idempotency
- * key behaves exactly as before (no dedupe).
+ * within the TTL is suppressed (no second turn, no second persisted memory) and
+ * — when the first attempt's assistant reply already persisted — answers with
+ * THAT reply instead of an empty ignored turn; a retry landing while the
+ * original is still mid-turn (nothing persisted yet) keeps the empty ignored
+ * shape; and a send WITHOUT an idempotency key behaves exactly as before (no
+ * dedupe).
  *
  * Deliberately mock-free at the module level (no `vi.mock`): the real route
  * handlers, real `chat-routes` helpers, and the real dedupe cache run end to
@@ -23,7 +26,7 @@
  */
 
 import http from "node:http";
-import type { AgentRuntime } from "@elizaos/core";
+import type { AgentRuntime, Memory } from "@elizaos/core";
 import { logger, stringToUuid, type UUID } from "@elizaos/core";
 import {
   afterAll,
@@ -42,11 +45,13 @@ import type {
 
 let handleConversationRoutes: typeof import("../conversation-routes.ts")["handleConversationRoutes"];
 let resetChatDedupe: () => void;
+let markChatMessageSeen: typeof import("../chat-routes.ts")["isDuplicateChatMessage"];
 
 beforeAll(async () => {
   vi.resetModules();
   const chatRoutes = await import("../chat-routes.ts");
   resetChatDedupe = chatRoutes.__resetChatDedupeForTests;
+  markChatMessageSeen = chatRoutes.isDuplicateChatMessage;
   ({ handleConversationRoutes } = await import("../conversation-routes.ts"));
 });
 
@@ -99,7 +104,9 @@ interface TestHarness {
 
 /** Real-route harness: the runtime stub streams one "ok" chunk per turn via
  *  the message service, so the real `generateChatResponse` pipeline (status →
- *  token → done framing, persistence ordering) runs unmodified. */
+ *  token → done framing, persistence ordering) runs unmodified. Persisted
+ *  memories are retained and served back through `getMemories`, so the dupe
+ *  branches' persisted-first-reply lookup reads the real write path's output. */
 function createHarness(): TestHarness {
   const handleMessage = vi.fn(
     async (
@@ -117,7 +124,11 @@ function createHarness(): TestHarness {
       };
     },
   );
-  const createMemory = vi.fn(async () => stringToUuid("created-memory"));
+  const storedMemories: Memory[] = [];
+  const createMemory = vi.fn(async (memory: Memory) => {
+    storedMemories.push(memory);
+    return memory.id ?? stringToUuid("created-memory");
+  });
   const runtime = {
     agentId: AGENT_ID,
     character: {
@@ -143,7 +154,7 @@ function createHarness(): TestHarness {
       clearChannel: async () => undefined,
     },
     createMemory,
-    getMemories: vi.fn(async () => []),
+    getMemories: vi.fn(async () => storedMemories),
     ensureConnection: vi.fn(async () => undefined),
     updateWorld: vi.fn(async () => undefined),
     getWorld: vi.fn(async () => null),
@@ -259,7 +270,7 @@ describe("conversation-route chat idempotency wiring", () => {
     vi.clearAllMocks();
   });
 
-  it("SSE: first send runs the turn; a retry with the same clientMessageId is suppressed", async () => {
+  it("SSE: first send runs the turn; a retry after delivery returns the persisted first reply", async () => {
     const { state, handleMessage, createMemory } = createHarness();
     const body = { text: "hello", clientMessageId: "sse-retry-1" };
 
@@ -277,12 +288,32 @@ describe("conversation-route chat idempotency wiring", () => {
     // No second LLM turn, no additional persisted memories (user or assistant).
     expect(handleMessage).toHaveBeenCalledTimes(1);
     expect(createMemory).toHaveBeenCalledTimes(persistsAfterFirst);
-    // The client still gets a clean terminal frame (an empty completed turn →
-    // it drops the optimistic placeholder and reconciles from history).
+    // The first attempt's reply already persisted, so the retry's terminal
+    // frame carries IT — the retry delivers the original outcome instead of
+    // an empty turn the client must repair from history.
     const frames = parseDataFrames(second.record);
     expect(frames).toHaveLength(1);
-    expect(frames[0]).toMatchObject({ type: "done", fullText: "" });
+    expect(frames[0]).toMatchObject({ type: "done", fullText: "ok" });
     expect(second.record.ended).toBe(true);
+  });
+
+  it("SSE: a dupe landing while the original is still mid-turn keeps the empty ignored shape", async () => {
+    const { state, handleMessage } = createHarness();
+    // Simulate the original request's arrival being recorded with its turn
+    // still in flight: the idempotency key is seen, but no assistant reply has
+    // persisted yet.
+    expect(markChatMessageSeen(ROOM_ID, "sse-mid-turn-1")).toBe(false);
+
+    const retry = await runRoute("POST", STREAM_PATH, state, {
+      text: "hello",
+      clientMessageId: "sse-mid-turn-1",
+    });
+
+    expect(handleMessage).not.toHaveBeenCalled();
+    const frames = parseDataFrames(retry.record);
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toMatchObject({ type: "done", fullText: "" });
+    expect(retry.record.ended).toBe(true);
   });
 
   it("SSE: a retry after a disconnect-ABORTED first attempt re-runs the turn (no dead air)", async () => {
@@ -333,7 +364,7 @@ describe("conversation-route chat idempotency wiring", () => {
     }
   });
 
-  it("non-stream: first send runs the turn; a retry with the same clientMessageId gets an idempotent 200", async () => {
+  it("non-stream: first send runs the turn; a retry after delivery returns the persisted first reply", async () => {
     const { state, handleMessage, createMemory } = createHarness();
     const body = { text: "hello", clientMessageId: "json-retry-1" };
 
@@ -346,9 +377,26 @@ describe("conversation-route chat idempotency wiring", () => {
     const second = await runRoute("POST", SEND_PATH, state, body);
     expect(handleMessage).toHaveBeenCalledTimes(1);
     expect(createMemory).toHaveBeenCalledTimes(persistsAfterFirst);
-    // Same success shape as an ignored turn — the client maps it to an empty
-    // reply instead of surfacing an error for the already-delivered turn.
+    // The first attempt's reply already persisted — the retry answers with
+    // the normal success shape carrying that reply, not the empty ignored
+    // shape, so the already-delivered turn reads identically on both attempts.
     expect(second.captured.payload).toEqual({
+      text: "ok",
+      agentName: "Test Agent",
+    });
+  });
+
+  it("non-stream: a dupe landing while the original is still mid-turn keeps the ignored shape", async () => {
+    const { state, handleMessage } = createHarness();
+    expect(markChatMessageSeen(ROOM_ID, "json-mid-turn-1")).toBe(false);
+
+    const retry = await runRoute("POST", SEND_PATH, state, {
+      text: "hello",
+      clientMessageId: "json-mid-turn-1",
+    });
+
+    expect(handleMessage).not.toHaveBeenCalled();
+    expect(retry.captured.payload).toEqual({
       text: "",
       agentName: "Test Agent",
       noResponseReason: "ignored",
@@ -384,7 +432,8 @@ describe("conversation-route chat idempotency wiring", () => {
 
   it("a retry that lands on the non-stream twin of a streamed send is still suppressed", async () => {
     // Both handlers consult the SAME cache scoped by conversation room id, so
-    // a duplicate is caught regardless of which endpoint the retry hits.
+    // a duplicate is caught regardless of which endpoint the retry hits — and
+    // the delivered first reply is returned across the endpoint boundary too.
     const { state, handleMessage } = createHarness();
     const body = { text: "hello", clientMessageId: "cross-route-1" };
 
@@ -392,8 +441,9 @@ describe("conversation-route chat idempotency wiring", () => {
     const retry = await runRoute("POST", SEND_PATH, state, body);
 
     expect(handleMessage).toHaveBeenCalledTimes(1);
-    expect(retry.captured.payload).toMatchObject({
-      noResponseReason: "ignored",
+    expect(retry.captured.payload).toEqual({
+      text: "ok",
+      agentName: "Test Agent",
     });
   });
 });

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -256,6 +256,24 @@ export function releaseChatMessageId(
   chatSeenMessageIds.delete(`${scope}:${clientMessageId}`);
 }
 
+/**
+ * Original arrival timestamp recorded for a `(scope, clientMessageId)` pair,
+ * or `null` when the pair is unknown (never seen, expired and swept, or
+ * released). Consulted by the duplicate-suppression branches AFTER
+ * {@link isDuplicateChatMessage} returns `true`: the recorded arrival bounds
+ * the "since" window for looking up the FIRST attempt's persisted assistant
+ * reply, so a retry that lands after delivery can return that reply instead
+ * of an empty ignored turn. A duplicate sighting never refreshes the stored
+ * timestamp, so this is always the first attempt's arrival.
+ */
+export function getChatMessageIdFirstSeenAt(
+  scope: string,
+  clientMessageId: string | null,
+): number | null {
+  if (!clientMessageId) return null;
+  return chatSeenMessageIds.get(`${scope}:${clientMessageId}`) ?? null;
+}
+
 /** Test-only: clear the HTTP chat idempotency cache between cases. */
 export function __resetChatDedupeForTests(): void {
   chatSeenMessageIds.clear();

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -2020,6 +2020,13 @@ export async function getRecentVisibleAssistantMemoryTextSince(
   runtime: AgentRuntime,
   roomId: UUID,
   sinceMs: number,
+  // Pre-arrival slack. The boolean suppression callers keep the conservative
+  // 2s default (over-matching is safe when the answer is only "suppress").
+  // The dupe-RETURN callers pass 0: `sinceMs` (dedupe first-seen) and memory
+  // `createdAt` come from the same process clock, so any reply persisted
+  // before arrival belongs to a PREVIOUS turn — returning it would ship the
+  // prior turn's answer to a rapid-fire retry.
+  slackMs: number = 2000,
 ): Promise<string | null> {
   try {
     const recent = await runtime.getMemories({
@@ -2035,7 +2042,7 @@ export async function getRecentVisibleAssistantMemoryTextSince(
         return (
           memory.entityId === runtime.agentId &&
           Boolean(contentText) &&
-          createdAt >= sinceMs - 2000
+          createdAt >= sinceMs - slackMs
         );
       })
       .sort((a, b) => (b.createdAt ?? 0) - (a.createdAt ?? 0))[0];

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -2510,6 +2510,9 @@ export async function handleConversationRoutes(
               state.runtime,
               conv.roomId,
               firstSeenAt,
+              // No pre-arrival slack: same-process clocks mean any reply
+              // persisted before this id's first arrival is a PRIOR turn's.
+              0,
             )
           : null;
       initSse(res);
@@ -2979,6 +2982,9 @@ export async function handleConversationRoutes(
               state.runtime,
               conv.roomId,
               firstSeenAt,
+              // No pre-arrival slack: same-process clocks mean any reply
+              // persisted before this id's first arrival is a PRIOR turn's.
+              0,
             )
           : null;
       if (persistedFirstReply) {

--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -63,15 +63,17 @@ import {
   generateChatResponse,
   generateConversationTitle,
   getChatFailureReply,
+  getChatMessageIdFirstSeenAt,
+  getRecentVisibleAssistantMemoryTextSince,
   hasRecentVisibleAssistantMemorySince,
   initSse,
   isDuplicateChatMessage,
   normalizeAccountConnectRequest,
-  releaseChatMessageId,
   normalizeChatResponseText,
   persistAssistantConversationMemory,
   persistConversationMemory,
   readChatRequestPayload,
+  releaseChatMessageId,
   resolveNoResponseFallback,
   writeChatStatusSse,
   writeChatTokenSse,
@@ -2488,19 +2490,44 @@ export async function handleConversationRoutes(
     // auto-retry after a network blip (`ui/src/api/client-base.ts`), expecting
     // the server to de-dupe. A repeat within the TTL means the original request
     // already started this turn — do NOT run a second one (duplicate persisted
-    // reply + double billing). Emit the same terminal `done` shape as the
-    // "assistant reply already persisted" suppression branch below: the client
-    // drops its optimistic placeholder on an empty completed turn and then
-    // reconciles the thread from history, which carries the first attempt's
-    // reply. Requests without a clientMessageId are never treated as duplicates.
+    // reply + double billing). When the FIRST attempt's reply already
+    // persisted, return IT in the terminal `done` frame — the retry then
+    // delivers the same outcome as the original instead of an empty turn the
+    // client must repair from history. Only while the original is still
+    // mid-turn (nothing persisted since its recorded arrival) does the retry
+    // fall back to the empty ignored shape: the client drops its optimistic
+    // placeholder on an empty completed turn and reconciles from history once
+    // the first attempt lands. Requests without a clientMessageId are never
+    // treated as duplicates.
     if (isDuplicateChatMessage(conv.roomId, clientMessageId ?? null)) {
+      const firstSeenAt = getChatMessageIdFirstSeenAt(
+        conv.roomId,
+        clientMessageId ?? null,
+      );
+      const persistedFirstReply =
+        state.runtime && firstSeenAt !== null
+          ? await getRecentVisibleAssistantMemoryTextSince(
+              state.runtime,
+              conv.roomId,
+              firstSeenAt,
+            )
+          : null;
       initSse(res);
-      writeSseJson(res, {
-        type: "done",
-        fullText: "",
-        agentName: state.agentName,
-        noResponseReason: "ignored",
-      });
+      writeSseJson(
+        res,
+        persistedFirstReply
+          ? {
+              type: "done",
+              fullText: persistedFirstReply,
+              agentName: state.agentName,
+            }
+          : {
+              type: "done",
+              fullText: "",
+              agentName: state.agentName,
+              noResponseReason: "ignored",
+            },
+      );
       finishStreamResponse();
       return true;
     }
@@ -2934,16 +2961,35 @@ export async function handleConversationRoutes(
     } = chatPayload;
     // Idempotency contract (see the streaming twin above / `isDuplicateChatMessage`):
     // a retried send carrying the same clientMessageId within the TTL already
-    // ran this turn. Answer 200 with the ignored-turn success shape — the
-    // client maps `noResponseReason: "ignored"` to an empty reply — so the
-    // retry reads as success without starting a second LLM turn or persisting
-    // a duplicate assistant memory.
+    // ran this turn. When the first attempt's reply already persisted, answer
+    // 200 with THAT text (the normal success shape) so the retry delivers the
+    // original outcome; only while the original is still mid-turn does the
+    // retry answer with the ignored-turn shape — the client maps
+    // `noResponseReason: "ignored"` to an empty reply — so it still reads as
+    // success without starting a second LLM turn or persisting a duplicate
+    // assistant memory.
     if (isDuplicateChatMessage(conv.roomId, clientMessageId ?? null)) {
-      json(res, {
-        text: "",
-        agentName: state.agentName,
-        noResponseReason: "ignored",
-      });
+      const firstSeenAt = getChatMessageIdFirstSeenAt(
+        conv.roomId,
+        clientMessageId ?? null,
+      );
+      const persistedFirstReply =
+        state.runtime && firstSeenAt !== null
+          ? await getRecentVisibleAssistantMemoryTextSince(
+              state.runtime,
+              conv.roomId,
+              firstSeenAt,
+            )
+          : null;
+      if (persistedFirstReply) {
+        json(res, { text: persistedFirstReply, agentName: state.agentName });
+      } else {
+        json(res, {
+          text: "",
+          agentName: state.agentName,
+          noResponseReason: "ignored",
+        });
+      }
       return true;
     }
     // Hold the turn through the warming window (early API bind → runtime ready)

--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -1229,3 +1229,156 @@ describe("VIEWS hijack of answered simple turns (tj-501e594bfb23a7)", () => {
 		expect(routed.plan.candidateActions).toContain("VIEWS");
 	});
 });
+
+// Regression fence for the vim-window iteration burn (live trajectory,
+// 2026-07-07): "whats the best way to close a window in vim" — Stage 1
+// answered correctly on contexts=["simple"], but WINDOW is a view-surface
+// noun, so the view-SURFACE inference escalated the turn to tool-required and
+// the planner's correct answer was rejected four times (~13s of wasted
+// re-prompts) before the exhaustion rescue shipped the stage-1 answer (18.5s
+// total). The suppression valve deliberately does NOT widen to view-surface —
+// a genuine "open the settings window" ask needs the tool — so the fix caps
+// the escalated turn's required-tool miss budget to 0 instead: the rescue
+// fires after ONE rejected answer. The cap is stamped only on the exact
+// answered shape; acks, other inference kinds, and model-emitted candidates
+// keep the full corrective budget.
+describe("view-surface overlap miss-budget cap (vim-window shape)", () => {
+	const viewsAction: Pick<Action, "name" | "similes" | "tags"> = {
+		name: "VIEWS",
+		similes: ["VIEW", "SHOW_VIEW", "OPEN_VIEW", "WHAT_VIEWS", "OPEN_SETTINGS"],
+		tags: [
+			"views",
+			"ui",
+			"window",
+			"panel",
+			"app",
+			"layout",
+			"view-capability",
+			"calendar",
+			"screen-time",
+			"todos",
+			"settings",
+		],
+	};
+	const replyAction: Pick<Action, "name" | "similes" | "tags"> = {
+		name: "REPLY",
+		similes: [],
+		tags: [],
+	};
+	const stageOneAnswered = (replyText: string, candidates: string[] = []) => ({
+		shouldRespond: "RESPOND" as const,
+		contexts: ["simple"],
+		intents: [],
+		replyText,
+		candidateActionNames: candidates,
+		facts: [],
+		relationships: [],
+		addressedTo: [],
+	});
+	const VIM_ANSWER =
+		"Use :q to close the current window, or Ctrl-w c to close a split.";
+
+	it("caps the miss budget on an answered turn escalated only by a view-surface overlap", () => {
+		const routed = messageHandlerFromFieldResult(
+			stageOneAnswered(VIM_ANSWER),
+			undefined,
+			{
+				actions: [replyAction, viewsAction],
+				messageText: "whats the best way to close a window in vim",
+			},
+		);
+
+		// The turn still escalates — the valve must not widen to view-surface —
+		// but it carries the per-turn cap so the planner rescue fires after one
+		// rejected answer.
+		expect(routed.plan.requiresTool).toBe(true);
+		expect(routed.plan.candidateActions).toContain("VIEWS");
+		expect(routed.plan.reply).toBe(VIM_ANSWER);
+		expect(routed.plan.requiredToolMissBudget).toBe(0);
+	});
+
+	it("a genuine view-navigation ask keeps the full budget: the ack reply fails the answer shape", () => {
+		const routed = messageHandlerFromFieldResult(
+			stageOneAnswered("Opening the settings panel."),
+			undefined,
+			{
+				actions: [replyAction, viewsAction],
+				messageText: "open the settings panel",
+			},
+		);
+
+		expect(routed.plan.requiresTool).toBe(true);
+		expect(routed.plan.candidateActions).toContain("VIEWS");
+		expect(routed.plan.requiredToolMissBudget).toBeUndefined();
+	});
+
+	it("bare-noun voice navigation (view-navigation kind, #9950) keeps the full budget", () => {
+		const routed = messageHandlerFromFieldResult(
+			stageOneAnswered("Which settings do you mean?"),
+			undefined,
+			{
+				actions: [replyAction, viewsAction],
+				messageText: "settings",
+			},
+		);
+
+		expect(routed.plan.requiresTool).toBe(true);
+		expect(routed.plan.candidateActions).toContain("VIEWS");
+		expect(routed.plan.requiredToolMissBudget).toBeUndefined();
+	});
+
+	it("web-required turns keep the full budget", () => {
+		const webAction: Pick<Action, "name" | "similes" | "tags"> = {
+			name: "WEB_FETCH",
+			similes: [],
+			tags: [],
+		};
+		const routed = messageHandlerFromFieldResult(
+			stageOneAnswered("Checking the price now."),
+			undefined,
+			{
+				actions: [replyAction, webAction],
+				messageText: "what is btc at rn?",
+			},
+		);
+
+		expect(routed.plan.requiresTool).toBe(true);
+		expect(routed.plan.candidateActions).toContain("WEB_FETCH");
+		expect(routed.plan.requiredToolMissBudget).toBeUndefined();
+	});
+
+	it("shell-required turns keep the full budget", () => {
+		const shellAction: Pick<Action, "name" | "similes" | "tags"> = {
+			name: "SHELL",
+			similes: ["RUN_COMMAND", "TERMINAL"],
+			tags: [],
+		};
+		const routed = messageHandlerFromFieldResult(
+			stageOneAnswered("Checking."),
+			undefined,
+			{
+				actions: [replyAction, shellAction],
+				messageText: "show me disk usage on this server",
+			},
+		);
+
+		expect(routed.plan.requiresTool).toBe(true);
+		expect(routed.plan.candidateActions).toContain("SHELL");
+		expect(routed.plan.requiredToolMissBudget).toBeUndefined();
+	});
+
+	it("model-emitted candidates keep the full budget even on the answered shape", () => {
+		const routed = messageHandlerFromFieldResult(
+			stageOneAnswered(VIM_ANSWER, ["VIEWS"]),
+			undefined,
+			{
+				actions: [replyAction, viewsAction],
+				messageText: "whats the best way to close a window in vim",
+			},
+		);
+
+		expect(routed.plan.requiresTool).toBe(true);
+		expect(routed.plan.candidateActions).toContain("VIEWS");
+		expect(routed.plan.requiredToolMissBudget).toBeUndefined();
+	});
+});

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -10,7 +10,12 @@ import { describe, expect, it, vi } from "vitest";
 import { plannerTemplate } from "../../prompts/planner";
 import { type ChatMessage, ModelType } from "../../types/model";
 import { TrajectoryLimitExceeded } from "../limits";
-import { parsePlannerOutput, runPlannerLoop } from "../planner-loop";
+import {
+	PROGRESS_ONLY_ANSWER_REJECT,
+	PROGRESS_ONLY_REPLY_OPENERS_PATTERN,
+	parsePlannerOutput,
+	runPlannerLoop,
+} from "../planner-loop";
 import type { RecordedStage, TrajectoryRecorder } from "../trajectory-recorder";
 
 describe("v5 planner loop skeleton", () => {
@@ -1155,6 +1160,120 @@ describe("v5 planner loop skeleton", () => {
 		// Stage 1's replyText is preferred over the planner's rejected REPLY
 		// text — it is the cleaner ground truth for the turn.
 		expect(result.finalMessage).toBe("391");
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+	});
+
+	it("requiredToolMissBudgetOverride=0 finishes with the Stage-1 answer after exactly one rejected reply", async () => {
+		// The vim-window shape (live trajectory, 2026-07-07): Stage 1 answered
+		// the turn, a view-surface token overlap escalated it to tool-required,
+		// and the planner kept answering. Without the override the rescue fires
+		// only after the full miss budget (four rejected answers, ~18.5s live);
+		// with the per-turn cap it fires after ONE.
+		const runtime = {
+			useModel: vi.fn(async () => ({
+				text: "",
+				toolCalls: [
+					{
+						id: "reply-1",
+						name: "REPLY",
+						arguments: { text: "Use :q to close the current window." },
+					},
+				],
+			})),
+			logger: { warn: vi.fn() },
+		};
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			tools: [{ name: "VIEWS", description: "Open a UI view." }],
+			requireNonTerminalToolCall: true,
+			stageOneReplyText:
+				"Use :q to close the current window, or Ctrl-w c to close a split.",
+			requiredToolMissBudgetOverride: 0,
+			config: { maxRequiredToolMisses: 3 },
+			executeToolCall: vi.fn(),
+			evaluate: vi.fn(),
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(
+			"Use :q to close the current window, or Ctrl-w c to close a split.",
+		);
+		// Exactly one planner call: the first rejected answer exhausts the
+		// capped budget and the rescue ships the Stage-1 answer.
+		expect(runtime.useModel).toHaveBeenCalledTimes(1);
+	});
+
+	it("ignores the miss-budget override when the Stage-1 replyText is not answer-shaped", async () => {
+		// Honesty guard: with an ack-shaped Stage-1 reply there is no better
+		// answer to rescue with, so an early exhaustion could only ship a worse
+		// fallback — the full corrective budget must keep converting the
+		// planner. The override is honored ONLY when the Stage-1 text passes
+		// the answer-shape gate.
+		const runtime = {
+			useModel: vi.fn(async () => ({
+				text: "",
+				toolCalls: [
+					{
+						id: "reply-1",
+						name: "REPLY",
+						arguments: { text: "The answer is 391." },
+					},
+				],
+			})),
+			logger: { warn: vi.fn() },
+		};
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			tools: [{ name: "VIEWS", description: "Open a UI view." }],
+			requireNonTerminalToolCall: true,
+			stageOneReplyText: "Checking the price now.",
+			requiredToolMissBudgetOverride: 0,
+			config: { maxRequiredToolMisses: 1 },
+			executeToolCall: vi.fn(),
+			evaluate: vi.fn(),
+		});
+
+		expect(result.status).toBe("finished");
+		// Full budget applied (two planner calls, not one) and the rescue fell
+		// back to the planner's own rejected answer, never the ack.
+		expect(result.finalMessage).toBe("The answer is 391.");
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+	});
+
+	it("the miss-budget override can only shrink the budget, never grow it", async () => {
+		const runtime = {
+			useModel: vi.fn(async () => ({
+				text: "",
+				toolCalls: [
+					{
+						id: "reply-1",
+						name: "REPLY",
+						arguments: { text: "The answer is 391." },
+					},
+				],
+			})),
+			logger: { warn: vi.fn() },
+		};
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			tools: [{ name: "VIEWS", description: "Open a UI view." }],
+			requireNonTerminalToolCall: true,
+			stageOneReplyText: "391",
+			requiredToolMissBudgetOverride: 5,
+			config: { maxRequiredToolMisses: 1 },
+			executeToolCall: vi.fn(),
+			evaluate: vi.fn(),
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe("391");
+		// config.maxRequiredToolMisses=1 still bounds the loop: two calls, not six.
 		expect(runtime.useModel).toHaveBeenCalledTimes(2);
 	});
 
@@ -2801,5 +2920,63 @@ describe("v5 planner loop — evaluator gate", () => {
 
 		expect(result.status).toBe("finished");
 		expect(result.finalMessage).toBe("Here is your answer.");
+	});
+});
+
+// Single-source contract for the progress/ack opener vocabulary (see
+// PROGRESS_ONLY_REPLY_OPENERS_PATTERN in planner-loop.ts): the message
+// service's looksLikeProgressOnlyReply builds its regex from the SAME exported
+// pattern, and the exhaustion-path PROGRESS_ONLY_ANSWER_REJECT extends it —
+// so a new progress verb added to the shared pattern reaches both consumers,
+// and the deliberate planner-only extras stay visible as an explicit,
+// documented difference instead of silent drift.
+describe("progress-only reply vocabulary single-sourcing", () => {
+	const sharedBase = new RegExp(
+		`^(?:${PROGRESS_ONLY_REPLY_OPENERS_PATTERN})\\b`,
+		"i",
+	);
+	const sharedOpenerSamples = [
+		"Checking the price now.",
+		"Fetching the data.",
+		"Gathering results.",
+		"Looking up the forecast.",
+		"Looking into it.",
+		"Running the command.",
+		"Using the search tool.",
+		"Spawning the sub-agent now.",
+		"Starting the build.",
+		"Working on it.",
+		"One moment.",
+		"Let me pull that up.",
+		"I'll check on that.",
+		"I will get back to you.",
+	];
+	// Final-answer-only rejects: bare acknowledgements the exhaustion path must
+	// never ship as the WHOLE turn, but which the message service deliberately
+	// does NOT treat as progress-only ("Okay, the answer is 42." is routinely a
+	// legitimate finished answer for its complete-direct-reply valve).
+	const answerRejectOnlySamples = [
+		"Opening the settings panel.",
+		"Got it, on the way.",
+		"Okay, here we go.",
+		"Ok.",
+		"On it.",
+	];
+
+	it("the exhaustion-path answer reject is a strict superset of the shared opener set", () => {
+		for (const sample of sharedOpenerSamples) {
+			expect(sharedBase.test(sample.toLowerCase()), sample).toBe(true);
+			expect(PROGRESS_ONLY_ANSWER_REJECT.test(sample), sample).toBe(true);
+		}
+		for (const sample of answerRejectOnlySamples) {
+			expect(sharedBase.test(sample.toLowerCase()), sample).toBe(false);
+			expect(PROGRESS_ONLY_ANSWER_REJECT.test(sample), sample).toBe(true);
+		}
+	});
+
+	it("the answer reject embeds the shared pattern verbatim (construction, not a copy)", () => {
+		expect(PROGRESS_ONLY_ANSWER_REJECT.source).toContain(
+			PROGRESS_ONLY_REPLY_OPENERS_PATTERN,
+		);
 	});
 });

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -247,6 +247,24 @@ export async function runPlannerLoop(
 	const stageOneAnswerText = requireNonTerminalToolCall
 		? userSafeCapturedAnswerCandidate(params.stageOneReplyText)
 		: undefined;
+	// Per-turn required-tool miss budget (see
+	// PlannerLoopParams.requiredToolMissBudgetOverride). Honored ONLY when a
+	// shape-guarded Stage-1 answer is available to finish with: the reduced
+	// budget exists to surface that already-produced answer after one rejected
+	// planner reply instead of burning the full miss budget re-prompting
+	// (~13s of wasted iterations on the live vim-window shape). When Stage 1's
+	// text fails the answer-shape gate (ack/progress/unsafe), an early
+	// exhaustion could only ship a worse fallback — keep the full budget so
+	// the corrective retries still get their chance to convert the planner.
+	const effectiveMaxRequiredToolMisses =
+		stageOneAnswerText !== undefined &&
+		typeof params.requiredToolMissBudgetOverride === "number" &&
+		Number.isFinite(params.requiredToolMissBudgetOverride)
+			? Math.min(
+					config.maxRequiredToolMisses,
+					Math.max(0, Math.floor(params.requiredToolMissBudgetOverride)),
+				)
+			: config.maxRequiredToolMisses;
 
 	// Cumulative gross prompt-token counter, summed across every planner
 	// stage in this user turn. Tracked alongside the existing per-iter
@@ -422,7 +440,7 @@ export async function runPlannerLoop(
 						stageOneAnswerText ??
 						lastRejectedTerminalAnswerText;
 					if (
-						requiredToolMisses > config.maxRequiredToolMisses &&
+						requiredToolMisses > effectiveMaxRequiredToolMisses &&
 						capturedFinishText
 					) {
 						return finishWithCapturedRefusal({
@@ -434,7 +452,7 @@ export async function runPlannerLoop(
 					}
 					assertTrajectoryLimit({
 						kind: "required_tool_misses",
-						max: config.maxRequiredToolMisses,
+						max: effectiveMaxRequiredToolMisses,
 						observed: requiredToolMisses,
 					});
 					handleRequiredToolPlannerMiss({
@@ -613,7 +631,7 @@ export async function runPlannerLoop(
 						stageOneAnswerText ??
 						lastRejectedTerminalAnswerText;
 					if (
-						requiredToolMisses > config.maxRequiredToolMisses &&
+						requiredToolMisses > effectiveMaxRequiredToolMisses &&
 						capturedFinishText
 					) {
 						return finishWithCapturedRefusal({
@@ -625,7 +643,7 @@ export async function runPlannerLoop(
 					}
 					assertTrajectoryLimit({
 						kind: "required_tool_misses",
-						max: config.maxRequiredToolMisses,
+						max: effectiveMaxRequiredToolMisses,
 						observed: requiredToolMisses,
 					});
 					handleRequiredToolPlannerMiss({
@@ -3611,13 +3629,30 @@ function userSafeRefusalCandidate(
 	return candidate;
 }
 
+// Progress/ack reply openers shared with the message service's
+// looksLikeProgressOnlyReply classifier (services/message.ts). Single-sourced
+// HERE because message.ts imports from this module and the reverse import
+// would be a cycle. The two consumers deliberately extend it differently —
+// see PROGRESS_ONLY_ANSWER_REJECT below.
+export const PROGRESS_ONLY_REPLY_OPENERS_PATTERN =
+	"checking|fetching|gathering|looking (?:up|into)|running|using|spawning|starting|working on|one moment|let me|i(?:'|’)ll|i will";
+
 // Progress/ack-shaped openers that must never be surfaced as a final answer
 // from the required-tool exhaustion path: once the loop gives up, no further
 // tool work happens, so "Checking the price now." style text is a false
-// promise. Mirrors the message-service looksLikeProgressOnlyReply prefix set
-// (kept local — services/message.ts imports from this module, not vice versa).
-const PROGRESS_ONLY_ANSWER_REJECT =
-	/^(?:checking|fetching|gathering|looking (?:up|into)|running|using|spawning|starting|working on|opening|got it|okay|ok|on it|one moment|let me|i(?:'|’)ll|i will)\b/i;
+// promise. Extends the shared opener set with final-answer-only rejects
+// ("opening", "got it", "okay", "ok", "on it"): a bare acknowledgement must
+// never ship as the WHOLE turn here, but a reply beginning "Okay, …" is
+// routinely a legitimate finished answer for the message service's
+// classifier — widening that side would defeat its complete-direct-reply
+// valve. Exported so message.ts can apply the same answer-shape gate when
+// deciding whether a Stage-1 reply qualifies for the reduced view-overlap
+// miss budget (requiredToolMissBudget), keeping both sides of that handshake
+// on one vocabulary.
+export const PROGRESS_ONLY_ANSWER_REJECT = new RegExp(
+	`^(?:${PROGRESS_ONLY_REPLY_OPENERS_PATTERN}|opening|got it|okay|ok|on it)\\b`,
+	"i",
+);
 
 // Shape gate for surfacing an already-produced ANSWER — the Stage-1 replyText
 // or the planner's own explicit terminal reply the required-tool gate kept

--- a/packages/core/src/runtime/planner-types.ts
+++ b/packages/core/src/runtime/planner-types.ts
@@ -210,6 +210,20 @@ export interface PlannerLoopParams {
 	 */
 	stageOneReplyText?: string;
 	/**
+	 * Per-turn override that SHRINKS the required-tool miss budget (never
+	 * grows it — the effective budget is `min(config.maxRequiredToolMisses,
+	 * override)`). Threaded by the message service on turns Stage 1 already
+	 * answered where the only tool "evidence" is a text-inferred view-surface
+	 * token overlap (e.g. "close a window in vim" matching the views action's
+	 * WINDOW noun): the stage-1 answer is the almost-certain outcome, so the
+	 * rescue should fire after ONE rejected planner answer instead of burning
+	 * the full budget (~13s of wasted re-prompts observed live). Honored only
+	 * when `stageOneReplyText` passes the answer-shape gate — without a
+	 * finishable answer the full budget applies so corrective retries keep
+	 * their chance to convert the planner.
+	 */
+	requiredToolMissBudgetOverride?: number;
+	/**
 	 * Trajectory recorder for v5 observability. When supplied, the planner
 	 * loop records one stage per planner call, tool execution, and evaluator
 	 * call. When omitted the loop is unaffected.

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -124,6 +124,8 @@ import {
 	type PlannerToolCall,
 	type PlannerToolResult,
 	type PlannerTrajectory,
+	PROGRESS_ONLY_ANSWER_REJECT,
+	PROGRESS_ONLY_REPLY_OPENERS_PATTERN,
 	runPlannerLoop,
 	summarizeActionResultForPlanner,
 } from "../runtime/planner-loop";
@@ -4095,6 +4097,21 @@ export function messageHandlerFromFieldResult(
 	) {
 		plan.candidateActions = planCandidateActions;
 	}
+	// The escalation came ONLY from the text-derived view-surface inference on
+	// a turn Stage 1 already answered — cap the planner's miss budget so the
+	// answer-rescue fires after one rejected reply instead of four (see
+	// viewOverlapRequiredToolMissBudget).
+	if (shouldPlan && inferredDirectCandidateActions.length > 0) {
+		const inferredViewOverlapMissBudget = viewOverlapRequiredToolMissBudget({
+			inference: directCurrentInference,
+			stageOneContexts: rawContexts,
+			stageOneReplyText: replyTextRaw,
+			stageOneCandidateActions: rawCandidateActions,
+		});
+		if (inferredViewOverlapMissBudget !== undefined) {
+			plan.requiredToolMissBudget = inferredViewOverlapMissBudget;
+		}
+	}
 	const extract =
 		facts.length > 0 ||
 		relationships.length > 0 ||
@@ -4306,6 +4323,15 @@ export function applyDirectCurrentCandidateBackstopToMessageHandler(
 	const planningContexts = (messageHandler.plan.contexts ?? []).filter(
 		(context) => context !== SIMPLE_CONTEXT_ID,
 	);
+	// Same view-overlap miss-budget cap as the structured path's plan
+	// construction: this backstop is the plain-text Stage-1 shape landing on
+	// the identical escalation, so the answered-turn waste is identical too.
+	const viewOverlapMissBudget = viewOverlapRequiredToolMissBudget({
+		inference: directCurrentInference,
+		stageOneContexts: messageHandler.plan.contexts ?? [],
+		stageOneReplyText: String(messageHandler.plan.reply ?? ""),
+		stageOneCandidateActions: getMessageHandlerCandidateActions(messageHandler),
+	});
 	return {
 		...messageHandler,
 		plan: {
@@ -4317,6 +4343,9 @@ export function applyDirectCurrentCandidateBackstopToMessageHandler(
 			simple: false,
 			requiresTool: true,
 			candidateActions: runnableCandidateActions,
+			...(viewOverlapMissBudget !== undefined
+				? { requiredToolMissBudget: viewOverlapMissBudget }
+				: {}),
 		},
 	};
 }
@@ -4330,13 +4359,20 @@ const PLANNING_ACK_REPLIES = new Set([
 	"working on it.",
 ]);
 
+// Built from the vocabulary single-sourced in planner-loop.ts (which cannot
+// import from this module) so the two progress-reply classifiers — this one
+// and the exhaustion-path PROGRESS_ONLY_ANSWER_REJECT — cannot drift apart
+// when a new progress verb is added. Case-insensitivity comes from the caller
+// lowercasing, not a flag, preserving the original matching exactly.
+const PROGRESS_ONLY_REPLY_REGEX = new RegExp(
+	`^(?:${PROGRESS_ONLY_REPLY_OPENERS_PATTERN})\\b`,
+);
+
 function looksLikeProgressOnlyReply(replyText: string): boolean {
 	const normalized = replyText.trim().toLowerCase();
 	if (!normalized) return false;
 	if (PLANNING_ACK_REPLIES.has(normalized)) return true;
-	return /^(?:checking|fetching|gathering|looking (?:up|into)|running|using|spawning|starting|working on|one moment|let me|i(?:'|’)ll|i will)\b/.test(
-		normalized,
-	);
+	return PROGRESS_ONLY_REPLY_REGEX.test(normalized);
 }
 
 function looksLikeCompleteDirectReply(replyText: string): boolean {
@@ -4631,6 +4667,48 @@ function shouldSuppressInferredCandidateEscalation(args: {
 	return !args.stageOneContexts.some(
 		(context) => context.trim().toLowerCase() !== SIMPLE_CONTEXT_ID,
 	);
+}
+
+/**
+ * Per-turn required-tool miss-budget cap for the view-SURFACE flavor of the
+ * waste `shouldSuppressInferredCandidateEscalation` suppresses outright for
+ * view-capability overlaps. A view-surface inference on an already-answered
+ * simple turn (live: "whats the best way to close a window in vim" — WINDOW
+ * is a surface noun) must still escalate — a genuine "open the settings
+ * window" ask needs the tool — but when the planner then keeps ANSWERING
+ * instead of calling the view tool, every rejected answer burns a full
+ * planner round and the exhaustion rescue ships the stage-1 answer anyway
+ * (observed live: 18.5s, four rejected answers, right answer). Capping the
+ * budget to 0 fires that rescue after ONE rejected answer.
+ *
+ * Two-sided gate keeps genuine view work on the full corrective budget: this
+ * side requires the answer shape by the exhaustion path's own
+ * PROGRESS_ONLY_ANSWER_REJECT superset (an ack such as "Opening the settings
+ * panel." never qualifies), and the planner loop independently ignores the
+ * cap unless the stage-1 text passes its answer-shape gate (see
+ * PlannerLoopParams.requiredToolMissBudgetOverride). Shell / web / coding
+ * inferences and bare-noun view navigation (#9950) never reach here — the
+ * kind check excludes them.
+ */
+function viewOverlapRequiredToolMissBudget(args: {
+	inference: DirectCurrentRequestCandidateInference;
+	stageOneContexts: readonly string[];
+	stageOneReplyText: string;
+	stageOneCandidateActions: readonly string[];
+}): number | undefined {
+	if (args.inference.kind !== "view-surface") return undefined;
+	if (args.stageOneCandidateActions.length > 0) return undefined;
+	const replyText = args.stageOneReplyText.trim();
+	if (replyText.length === 0) return undefined;
+	if (PROGRESS_ONLY_ANSWER_REJECT.test(replyText)) return undefined;
+	if (
+		args.stageOneContexts.some(
+			(context) => context.trim().toLowerCase() !== SIMPLE_CONTEXT_ID,
+		)
+	) {
+		return undefined;
+	}
+	return 0;
 }
 
 const LIVE_LOOKUP_UNAVAILABLE_REPLY =
@@ -7128,6 +7206,15 @@ export async function runV5MessageRuntimeStage1(args: {
 					typeof messageHandler.plan.reply === "string"
 						? messageHandler.plan.reply
 						: undefined,
+				// Per-turn miss-budget cap for answered turns escalated only by a
+				// view-surface token overlap (see viewOverlapRequiredToolMissBudget);
+				// the loop honors it only when stageOneReplyText is answer-shaped.
+				...(typeof messageHandler.plan.requiredToolMissBudget === "number"
+					? {
+							requiredToolMissBudgetOverride:
+								messageHandler.plan.requiredToolMissBudget,
+						}
+					: {}),
 				evaluatorEffects,
 				recorder,
 				trajectoryId,

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -153,6 +153,15 @@ export interface MessageHandlerPlan {
 	contextSlices?: string[];
 	candidateActions?: string[];
 	parentActionHints?: string[];
+	/**
+	 * Per-turn cap on the planner's required-tool miss budget, set by the
+	 * Stage-1 router when the ONLY tool evidence for an already-answered
+	 * simple turn is a text-inferred view-surface token overlap. The planner
+	 * loop honors it only when the stage-1 reply passes its answer-shape gate
+	 * (see PlannerLoopParams.requiredToolMissBudgetOverride); it can shrink
+	 * the budget, never grow it.
+	 */
+	requiredToolMissBudget?: number;
 	deterministicToolCall?: MessageHandlerDeterministicToolCall;
 	[key: string]: JsonValue | MessageHandlerDeterministicToolCall | undefined;
 }


### PR DESCRIPTION
Polish batch from the 2026-07-07 adversarial reviews + latency investigation. Three code fixes plus one item verified already landed upstream. Each item is independent; zero intended behavior change outside the described shapes.

## 1. Doc-lookup skip for empty corpora — verified already landed, not re-implemented

The investigation flagged the chat path awaiting a document lookup (gateway embed, 2–4s, then the 4s cap — live log: `Document lookup timed out; skipping optional document context`) on every reply even for agents without documents. Verified on current `develop` that the structural fix already exists:

- 2c877ee59f3 (#8862) — `maybeAugmentChatMessageWithDocuments` counts `document_fragments` (agent-scoped via the documents service → `runtime.countMemories({ agentId })`) and returns before the embed+search when the corpus is empty.
- 91d3863b92c (#15304) — the augmentation embed is unified with the per-turn recall cache, so the turn never pays the same embed twice.

Re-implementing would have duplicated #8862, so this PR documents the verification instead. One caveat worth knowing: documents-enabled agents are seeded with bundled default docs (`packages/agent/src/runtime/default-documents.ts` — overview/history/cloud/help-FAQ), so their corpus is never empty and the empty-corpus skip cannot fire for them by design (the help FAQ ships as retrievable knowledge). For those agents the residual cost is the (now cache-unified) embed, which is #15304's territory.

## 2. Idempotency dupe returns the persisted first reply (agent)

`packages/agent/src/api/conversation-routes.ts`: both duplicate-suppression branches (SSE `POST /api/conversations/:id/messages/stream` and the non-stream twin) answered a blip-retry with an empty done/ignored response even when the FIRST attempt's assistant reply had already persisted — the client had to repair the thread from history.

Now the dupe branches look up the most recent visible assistant memory for the room since the original request's recorded arrival — new `getChatMessageIdFirstSeenAt` accessor on the dedupe cache (a duplicate sighting never refreshes the stored timestamp, so it is always the first attempt's arrival) + the already-existing `getRecentVisibleAssistantMemoryTextSince` — and return it: SSE emits the done frame with `fullText`, non-stream answers the normal success shape with `text`. A dupe landing while the original is still mid-turn (nothing persisted yet) keeps today's empty ignored shape, and the abort/disconnect key-release paths are untouched.

## 3. Single-source the progress-ack vocabulary (core)

`packages/core/src/runtime/planner-loop.ts` had `PROGRESS_ONLY_ANSWER_REJECT` duplicating the opener list of `looksLikeProgressOnlyReply` in `packages/core/src/services/message.ts` — two hand-maintained copies of the same vocabulary, guaranteed to drift.

The shared openers now live in one exported `PROGRESS_ONLY_REPLY_OPENERS_PATTERN` in planner-loop.ts (message.ts already imports from that module; the reverse import would cycle), and message.ts builds its regex from it. The exhaustion-path reject extends the base with the final-answer-only extras, now documented as a deliberate difference rather than drift: `opening | got it | okay | ok | on it` — a bare acknowledgement must never ship as the WHOLE turn from the exhaustion path, but a reply beginning "Okay, …" is routinely a legitimate finished answer for the message service's complete-direct-reply valve, so widening that side would regress it. **Zero behavior change on either site** (message.ts's regex source is byte-identical; the planner regex is the same alternation, reordered but equivalent under the `\b` anchor). A new test pins the superset relation and the construction (the reject regex embeds the exported pattern).

## 4. Cap the view-surface overlap miss budget (core)

Evidence: live trajectory — "whats the best way to close a window in vim" → Stage 1 answers correctly on `contexts=["simple"]`, the view-SURFACE inference escalates the turn to tool-required (WINDOW is a surface noun; the instructional-question guard only matches "what is/are", not "whats"), the planner's correct answer is rejected 4×, and the exhaustion fallback finally ships the Stage-1 answer — 18.5s total for a right answer Stage 1 had at ~5s.

The suppression valve (`shouldSuppressInferredCandidateEscalation`) deliberately stays view-capability-only — widening it to view-surface would break genuine "open the settings window" asks. Instead, the waste is capped:

- message.ts stamps `plan.requiredToolMissBudget = 0` only on the exact answered shape: view-surface inference, no Stage-1 candidates of its own, simple-only contexts, and a reply that is answer-shaped by the exhaustion path's own `PROGRESS_ONLY_ANSWER_REJECT` superset (so "Opening the settings panel." never qualifies). Applied on both the structured Stage-1 path (`messageHandlerFromFieldResult`) and the plain-text backstop (`applyDirectCurrentCandidateBackstopToMessageHandler`).
- the planner loop honors the override only when `stageOneReplyText` passes its answer-shape gate, and it can only shrink the configured budget, never grow it. With the cap, the rescue fires after ONE rejected answer.

Full corrective budget is preserved for: ack-shaped replies (live-info "Checking the price now." still forces the fetch), bare-noun voice navigation (#9950), shell/web/coding inferences, model-emitted candidates, and coding mode.

## Expected impact

- vim-shape turns (answered simple turns hijacked by a view-surface token overlap): ~18.5s → ~6s, one planner round instead of four.
- blip-retries after delivery now return the delivered reply instead of an empty turn.
- (item 1, already in develop) fresh agents with truly empty corpora skip the doc-lookup embed entirely; the ~4s/turn claim for cloud agents is covered by #8862 + #15304.

## Evidence

- **Backend logs / test output**: full vitest + typecheck transcript uploaded to the `pr-evidence` release as [`15413-polish-batch-tests.txt`](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15413-polish-batch-tests.txt) (core: planner-loop 100/100, message-routing-live-regression 44/44, direct-action-heuristics 21/21, full `src/runtime/__tests__` sweep 1008/1008; agent: conversation-idempotency 9/9, chat-idempotency 9/9, chat-augmentation suites 22/22; `tsgo --noEmit` green for core and agent).
- **Real-LLM trajectories**: N/A — the fixes are deterministic routing/limit/route-shape changes pinned by structural unit fences on the exact live shapes (the originating live trajectories are quoted in the test headers); no prompt or model behavior changed.
- **Screenshots / video**: N/A — no UI surface changed; the affected endpoints and planner internals have no rendered component.
- **Frontend console/network logs**: N/A — no client code changed; the SSE/JSON shapes returned on the dupe path are existing shapes the client already renders.
- **Domain artifacts**: N/A — no schema/memory format changes; the idempotency fix reads existing `messages` memories.

Pre-existing failure note: running the agent conversation suites together with the `vi.mock`-based sibling suites in one vitest invocation reproduces 11 cross-file mock-interference failures on clean `develop` (same result with this branch); each file passes in isolation and in its CI grouping — not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend routing/route-response change only; no rendered UI surface.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend routing/route-response change only; no rendered UI surface.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no UI flow; behavior proven by real-route tests in backend-logs.

<!-- evidence-row:backend-logs -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/15413-polish-tests.log

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code touched.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - routing/budget changes are pinned by deterministic planner-loop + live-regression suites (the live deadlock trajectories that motivated them are attached to #15393); no model-prompt change.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the domain assertions (persisted-reply returned on dupe, budget clamp, vocab equivalence) execute inside the mock-free suites in backend-logs.

<!-- evidence-row:ocr-review -->
- [ ] N/A - no visual media.
