### PR TITLE
chore(cloud): enable the inference hot-path stack on staging for the soak

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -360,8 +360,8 @@ REDIS_RATE_LIMITING = "true"
 # SAFE_BALANCE_THRESHOLD (USD) empty/invalid -> +Inf -> every org takes the safe
 # synchronous-reserve path. The auth+moderation hot-path cache is the default now
 # (no flag); a cache miss falls back to the authoritative slow path.
-INFERENCE_OPTIMISTIC_BILLING = "false"
-SAFE_BALANCE_THRESHOLD = ""
+INFERENCE_OPTIMISTIC_BILLING = "true"
+SAFE_BALANCE_THRESHOLD = "5.00"
 # Optimistic-billing durable backstop: "db" = inference_pending_charges ledger
 # (atomic overdraw bound + exactly-once settle + age-ordered sweep); "" = KV
 # backstop (current). Off until soaked; cutover is an ops flip (#9899).
@@ -371,11 +371,11 @@ INFERENCE_BILLING_LEDGER = ""
 # executionCtx.waitUntil; the critical path keeps a cached 402 gate (15s
 # org-balance hint + in-isolate refusal blocklist). Requires
 # INFERENCE_OPTIMISTIC_BILLING. Off until soaked; cutover is an ops flip.
-INFERENCE_DEFERRED_ADMISSION = "false"
+INFERENCE_DEFERRED_ADMISSION = "true"
 # Tier-3 in-isolate decision caches (#9899): org rate-limit lease (convergent;
 # leased requests are carried back into the Redis window), 60s shouldBlockUser
 # memo, 60s model-catalog memo. Default off; rollback = flip off.
-INFERENCE_HOT_PATH_CACHES = "false"
+INFERENCE_HOT_PATH_CACHES = "true"
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob-staging.elizacloud.ai"
 SQL_HEAVY_PAYLOAD_STORAGE = "r2"


### PR DESCRIPTION
Staging-only flag flip per the #15409 review's flip-order (prod untouched). Enables the full hot-path stack on staging: optimistic billing + $5 threshold (matching prod's proven Tier-2 config — without it deferred admission is inert), deferred admission, and the decision caches. Soak: staging traffic hammer → verify billing rows/402/rate-limit convergence → measure TTFB → then the prod flip PR.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - config-only flag flip, no UI.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - config-only flag flip, no UI.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - config-only.

<!-- evidence-row:backend-logs -->
- [ ] N/A - the soak measurements (TTFB before/after, billing-row verification) will be posted as a PR comment after the staging deploy lands; the flag behavior itself is covered by #15409's 230/0 suites.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model-path change.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - staging billing rows will be verified live post-deploy (comment to follow).

<!-- evidence-row:ocr-review -->
- [ ] N/A - no media.

🤖 Generated with [Claude Code](https://claude.com/claude-code)