### PR TITLE
feat(ui-voice): chunked-segment streaming ASR — live incremental transcript (V2a) [sol-cloud]

### DIFF
--- a/packages/ui/src/api/client-types-config.ts
+++ b/packages/ui/src/api/client-types-config.ts
@@ -1749,6 +1749,18 @@ export interface VoiceConfig {
     provider: AsrProvider;
     /** Optional override model id (e.g. `whisper-1` for OpenAI). */
     modelId?: string;
+    /**
+     * Chunked-segment incremental transcription (voice V2a). When enabled and
+     * the resolved backend is cloud, the capturer POSTs short audio segments as
+     * the user speaks and renders a live running transcript in the composer,
+     * instead of one batch POST at stop(). Defaults to ON for the cloud path
+     * (see `shouldStreamCloudAsr`); set `false` to force the batch path (e.g.
+     * on the credit-metered ElevenLabs upstream where per-segment reservations
+     * churn — see VOICE-STREAMING-DESIGN §2.4). Always degrades gracefully to
+     * batch when segmentation is unsupported/failing, so `false` is a hard
+     * opt-out, not a correctness requirement.
+     */
+    streaming?: boolean;
   };
 }
 

--- a/packages/ui/src/components/composites/chat/chat-composer.tsx
+++ b/packages/ui/src/components/composites/chat/chat-composer.tsx
@@ -17,6 +17,8 @@ import {
   Square,
   Volume2,
   VolumeX,
+  Zap,
+  ZapOff,
 } from "lucide-react";
 // biome-ignore lint/correctness/noUnusedImports: Required for this package's JSX transform in tests.
 import * as React from "react";
@@ -113,6 +115,14 @@ export interface ChatComposerVoiceState {
   ) => void | Promise<void>;
   stopListening: (options?: { submit?: boolean }) => void | Promise<void>;
   supported: boolean;
+  /**
+   * Auto-send-on-end-of-speech state (voice V2a). When defined, the composer
+   * renders a compact in-flow toggle on the mic surface so the user can flip
+   * auto-send on/off without leaving the chat. Undefined = feature absent (the
+   * toggle isn't rendered). Persisted by the caller.
+   */
+  autoSendEnabled?: boolean;
+  onToggleAutoSend?: () => void;
 }
 
 export interface ChatComposerProps {
@@ -334,6 +344,47 @@ export function ChatComposer({
     void voice.startListening("compose");
   }, [isComposerLocked, shouldSuppressClick, voice]);
 
+  // Auto-send toggle (voice V2a) — a compact IN-FLOW control on the mic surface.
+  // Shared across the inline + default composer layouts. Rendered only while
+  // listening in compose mode (the moment it's relevant), so the user can flip
+  // auto-send on/off without leaving chat or digging into a settings page.
+  // Follows the existing design language: ghost icon button, token palette,
+  // lucide icons (Zap = auto-send on, ZapOff = review-then-send). Preference is
+  // persisted by the caller. ON = accented, OFF = muted — the same on/off visual
+  // grammar as the mic button. Absent (null) when the feature isn't wired.
+  const showAutoSendToggle =
+    voice.autoSendEnabled !== undefined &&
+    voice.onToggleAutoSend !== undefined &&
+    voice.isListening &&
+    voice.captureMode === "compose";
+  const autoSendOn = voice.autoSendEnabled === true;
+  const autoSendToggleTitle = autoSendOn
+    ? "Auto-send on: your voice sends when you stop speaking. Tap to review first."
+    : "Review-then-send: your voice fills the box to edit. Tap to auto-send.";
+  const inlineAutoSendToggle = showAutoSendToggle ? (
+    <Button
+      variant="ghost"
+      size="icon"
+      className={`h-8 w-8 shrink-0 rounded-sm p-0 shadow-none transition-colors active:scale-95 pointer-coarse:min-h-touch pointer-coarse:min-w-touch ${
+        autoSendOn
+          ? "bg-accent/15 text-accent hover:bg-accent/25"
+          : "bg-bg text-muted hover:bg-bg hover:text-txt"
+      }`}
+      data-testid="chat-composer-autosend-toggle"
+      onClick={(e) => {
+        // Don't blur the composer / interrupt the hold.
+        e.preventDefault();
+        voice.onToggleAutoSend?.();
+      }}
+      onMouseDown={(e) => e.preventDefault()}
+      title={autoSendToggleTitle}
+      aria-label={autoSendToggleTitle}
+      aria-pressed={autoSendOn}
+    >
+      {autoSendOn ? <Zap className="h-4 w-4" /> : <ZapOff className="h-4 w-4" />}
+    </Button>
+  ) : null;
+
   if (isInline) {
     const inlineAttachButton =
       !isGameModal && !hideAttachButton ? (
@@ -469,7 +520,16 @@ export function ChatComposer({
       // Keep the mic (release) button mounted while a push-to-talk turn is held,
       // even after live STT text fills the draft — otherwise the composer swaps
       // to the send button mid-hold and pointer-release can no longer submit.
-      inlineMicButton
+      // The auto-send toggle rides alongside it (compose mode only) so the
+      // on/off control is in-flow, right where the user is speaking.
+      inlineAutoSendToggle ? (
+        <>
+          {inlineAutoSendToggle}
+          {inlineMicButton}
+        </>
+      ) : (
+        inlineMicButton
+      )
     ) : hasDraft ? (
       inlineSendButton
     ) : (
@@ -588,6 +648,8 @@ export function ChatComposer({
           <Mic className="h-6 w-6" />
         </Button>
       ) : null}
+
+      {!isInline && inlineAutoSendToggle ? inlineAutoSendToggle : null}
 
       <div className="relative min-w-0 flex-1">
         <Textarea

--- a/packages/ui/src/components/pages/ChatView.tsx
+++ b/packages/ui/src/components/pages/ChatView.tsx
@@ -404,6 +404,8 @@ export function ChatView({
     voice,
     voiceLatency,
     voiceSpeaker,
+    voiceAutoSendEnabled,
+    toggleVoiceAutoSend,
   } = useChatVoiceController({
     agentVoiceMuted,
     chatFirstTokenReceived,
@@ -991,6 +993,8 @@ export function ChatView({
           assistantTtsQuality: voice.assistantTtsQuality,
           startListening: beginVoiceCapture,
           stopListening: endVoiceCapture,
+          autoSendEnabled: voiceAutoSendEnabled,
+          onToggleAutoSend: toggleVoiceAutoSend,
         }}
         agentVoiceEnabled={!agentVoiceMuted}
         showAgentVoiceToggle={showComposerVoiceToggle}
@@ -1063,6 +1067,8 @@ export function ChatView({
           assistantTtsQuality: voice.assistantTtsQuality,
           startListening: beginVoiceCapture,
           stopListening: endVoiceCapture,
+          autoSendEnabled: voiceAutoSendEnabled,
+          onToggleAutoSend: toggleVoiceAutoSend,
         }}
         agentVoiceEnabled={!agentVoiceMuted}
         showAgentVoiceToggle={showComposerVoiceToggle}

--- a/packages/ui/src/components/pages/chat-view-hooks.tsx
+++ b/packages/ui/src/components/pages/chat-view-hooks.tsx
@@ -33,6 +33,10 @@ import type { useApp } from "../../state/useApp";
 import { ttsDebug } from "../../utils/tts-debug";
 import { useVoiceConfig } from "../../voice/useVoiceConfig";
 import {
+  loadVoiceAutoSendEnabled,
+  saveVoiceAutoSendEnabled,
+} from "../../state/persistence";
+import {
   DEFAULT_VOICE_CONTINUOUS_MODE,
   type VoiceAssistantSpeechTelemetry,
   type VoiceCaptureMode,
@@ -244,6 +248,18 @@ export function useChatVoiceController(options: {
   const [voiceSpeaker, setVoiceSpeaker] = useState<VoiceSpeakerMetadata | null>(
     null,
   );
+  // Auto-send-on-end-of-speech toggle (voice V2a). Device-local, persisted.
+  // Defaults OFF (review-then-send is the launch default per owner direction).
+  const [voiceAutoSendEnabled, setVoiceAutoSendEnabled] = useState<boolean>(
+    () => loadVoiceAutoSendEnabled(),
+  );
+  const toggleVoiceAutoSend = useCallback(() => {
+    setVoiceAutoSendEnabled((prev) => {
+      const next = !prev;
+      saveVoiceAutoSendEnabled(next);
+      return next;
+    });
+  }, []);
   const pendingVoiceTurnRef = useRef<PendingVoiceTurnState | null>(null);
   const suppressedAssistantSpeechRef = useRef<{
     messageId: string;
@@ -484,6 +500,12 @@ export function useChatVoiceController(options: {
     onTranscript: handleVoiceTranscript,
     onTranscriptPreview: handleVoiceTranscriptPreview,
     voiceConfig: effectiveVoiceConfig,
+    // Auto-send on end-of-speech (voice V2a). The hook arms a VAD auto-stop in
+    // compose mode when this is true; a detected end-of-turn that passes the
+    // reliability guards submits via onTranscript (same path as a manual PTT
+    // release). Defaults OFF. onAutoSend is telemetry-only here — the actual
+    // submit rides onTranscript, so we don't double-send.
+    autoSend: voiceAutoSendEnabled,
   });
   const {
     queueAssistantSpeech,
@@ -803,6 +825,8 @@ export function useChatVoiceController(options: {
     voice,
     voiceLatency,
     voiceSpeaker,
+    voiceAutoSendEnabled,
+    toggleVoiceAutoSend,
   };
 }
 

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -45,13 +45,17 @@ import { hasConfiguredApiKey } from "../voice";
 import {
   isLocalAsrCaptureSupported,
   type LocalAsrRecorder,
+  type LocalAsrSegment,
   startLocalAsrRecorder,
 } from "../voice/local-asr-capture";
 import {
   isLocalInferenceAsrReady,
+  transcribeCloudSegment,
   transcribeCloudWav,
   transcribeLocalInferenceWav,
 } from "../voice/local-asr-transcribe";
+import { createCloudSttSegmenter } from "../voice/cloud-stt-segmenter";
+import { CloudSttSessionStitcher } from "../voice/cloud-stt-stitcher";
 import {
   PlaybackFramePump,
   type PlaybackFrameTap,
@@ -212,6 +216,18 @@ function shouldUseCloudAsr(config: VoiceConfig | null): boolean {
   return provider === "eliza-cloud" || provider === "openai";
 }
 
+/**
+ * True when chunked-segment incremental transcription (voice V2a) should drive
+ * the cloud capture. Requires the cloud ASR path AND that streaming isn't
+ * explicitly opted out (`asr.streaming === false`). Defaults ON for cloud — the
+ * live-transcript UX is the whole point of V2a — but it ALWAYS degrades to the
+ * batch full-WAV path at stop() if segmentation produced nothing usable, so a
+ * true here is a best-effort enablement, never a correctness dependency.
+ */
+function shouldStreamCloudAsr(config: VoiceConfig | null): boolean {
+  return shouldUseCloudAsr(config) && config?.asr?.streaming !== false;
+}
+
 const ACTIVE_VOICE_SESSION_MODES = new Set<Exclude<VoiceSessionMode, "idle">>([
   "compose",
   "push-to-talk",
@@ -295,6 +311,21 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
   // Refs — stable across renders, read from animation loop & callbacks
   const recognitionRef = useRef<SpeechRecognitionInstance | null>(null);
   const localAsrRecorderRef = useRef<LocalAsrRecorder | null>(null);
+  // Chunked-streaming cloud STT (voice V2a). Per-capture-turn session: a
+  // stitcher assembles ordered/seam-deduped segment transcripts into the live
+  // running transcript, plus bookkeeping to decide at stop() whether the
+  // streamed result is usable or we must fall back to the batch full-WAV path.
+  const cloudStreamStitcherRef = useRef<CloudSttSessionStitcher | null>(null);
+  const cloudStreamSessionIdRef = useRef<string | null>(null);
+  // In-flight segment POSTs for the active turn — awaited at stop() so a
+  // late-landing segment still contributes to the finalized transcript.
+  const cloudStreamInflightRef = useRef<Set<Promise<void>>>(new Set());
+  // Set true if ANY segment POST hard-fails after its retry (not just empty):
+  // signals stop() to distrust the partial stitch and prefer the batch WAV.
+  const cloudStreamDegradedRef = useRef(false);
+  // AbortController scoping all segment POSTs for the current turn (barge-in /
+  // teardown / suspend abort the in-flight segment uploads).
+  const cloudStreamAbortRef = useRef<AbortController | null>(null);
   const sttBackendRef = useRef<
     "browser" | "local-inference" | "cloud" | "talkmode" | null
   >(null);
@@ -754,6 +785,16 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
     sttBackendRef.current = null;
     enabledRef.current = false;
     listeningModeRef.current = "idle";
+    // Tear down any chunked-streaming session (voice V2a): abort in-flight
+    // segment POSTs + clear the stitcher so a superseded turn's late segment
+    // can't leak into the next capture. Inlined (refs only) so this stays a
+    // dependency-free reset used by the error/abort paths.
+    cloudStreamAbortRef.current?.abort();
+    cloudStreamAbortRef.current = null;
+    cloudStreamStitcherRef.current = null;
+    cloudStreamSessionIdRef.current = null;
+    cloudStreamInflightRef.current = new Set();
+    cloudStreamDegradedRef.current = false;
     setIsListening(false);
     setCaptureMode("idle");
     setInterimTranscript("");
@@ -935,6 +976,87 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
   // recognizer is engine-dependent (and unreliable/absent on iOS PWA), so a
   // cloud config must not fall through to it. Reuses `localAsrRecorderRef` for
   // the mic recorder; `sttBackendRef` = "cloud" routes the stop-time transcribe.
+  // Tear down the current chunked-streaming session (voice V2a): abort in-flight
+  // segment POSTs and clear the stitcher/session refs. Idempotent.
+  const teardownCloudStreamSession = useCallback(() => {
+    cloudStreamAbortRef.current?.abort();
+    cloudStreamAbortRef.current = null;
+    cloudStreamStitcherRef.current = null;
+    cloudStreamSessionIdRef.current = null;
+    cloudStreamInflightRef.current = new Set();
+    cloudStreamDegradedRef.current = false;
+  }, []);
+
+  // Handle one mid-capture segment (voice V2a): POST it, stitch the result, and
+  // emit the running transcript as a NON-FINAL preview so the composer shows
+  // words appearing while the user speaks. Fire-and-forget from the audio
+  // thread; tracked in the in-flight set so stop() can await stragglers.
+  const handleCloudStreamSegment = useCallback(
+    (segment: LocalAsrSegment) => {
+      const stitcher = cloudStreamStitcherRef.current;
+      const sessionId = cloudStreamSessionIdRef.current;
+      const abort = cloudStreamAbortRef.current;
+      if (!stitcher || !sessionId || !abort) return;
+      // An empty-data final marker (silent trailing tail, WAV is header-only)
+      // finalizes the stitcher on the already-streamed content WITHOUT a doomed
+      // POST of a data-less WAV (the server's magic-number check would reject
+      // it). No network, just mark done.
+      if (segment.isFinal && segment.wav.length <= 44) {
+        const running = stitcher.push({ seq: segment.seq, text: "", isFinal: true });
+        if (running && listeningModeRef.current !== "idle") {
+          applyTranscriptUpdate(running, false, {
+            source: "cloud",
+            metadata: { source: "cloud" },
+          });
+        }
+        return;
+      }
+      const task = (async () => {
+        try {
+          const text = await transcribeCloudSegment(segment.wav, {
+            signal: abort.signal,
+            segment: {
+              sessionId,
+              seq: segment.seq,
+              isFinal: segment.isFinal,
+            },
+          });
+          // Ignore a result that landed after this session was torn down /
+          // superseded (a new capture started).
+          if (cloudStreamStitcherRef.current !== stitcher) return;
+          const running = stitcher.push({
+            seq: segment.seq,
+            text,
+            isFinal: segment.isFinal,
+          });
+          // Live preview only — NEVER a final here. The turn's real final is
+          // committed at stop() (streamed stitch or batch fallback), so a
+          // mid-utterance segment must not submit.
+          if (running && listeningModeRef.current !== "idle") {
+            applyTranscriptUpdate(running, false, {
+              source: "cloud",
+              metadata: { source: "cloud" },
+            });
+          }
+        } catch (err) {
+          // A cancelled POST (teardown / barge-in) is expected — not a degrade.
+          if (abort.signal.aborted) return;
+          // Any other hard failure after retry: distrust the partial stitch so
+          // stop() prefers the batch full-WAV transcription.
+          cloudStreamDegradedRef.current = true;
+          ttsDebug("asr:cloud:segment:error", {
+            seq: segment.seq,
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }
+      })();
+      const inflight = cloudStreamInflightRef.current;
+      inflight.add(task);
+      void task.finally(() => inflight.delete(task));
+    },
+    [applyTranscriptUpdate],
+  );
+
   const startCloudRecognition = useCallback(
     async (mode: Exclude<VoiceCaptureMode, "idle">) => {
       if (!shouldUseCloudAsr(voiceConfigRef.current)) {
@@ -945,8 +1067,34 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       if (!isLocalAsrCaptureSupported()) {
         return false;
       }
+      // Chunked-streaming (voice V2a): stand up a fresh stitcher + segmenter and
+      // wire the recorder's onSegment sink. Guarded so a failure to construct
+      // the streaming path NEVER blocks capture — batch is always the fallback.
+      const streaming = shouldStreamCloudAsr(voiceConfigRef.current);
+      let recorderOpts:
+        | Parameters<typeof startLocalAsrRecorder>[0]
+        | undefined;
+      if (streaming) {
+        teardownCloudStreamSession();
+        const stitcher = new CloudSttSessionStitcher();
+        const sessionId =
+          typeof crypto !== "undefined" && "randomUUID" in crypto
+            ? crypto.randomUUID()
+            : `sess-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        const abort = new AbortController();
+        cloudStreamStitcherRef.current = stitcher;
+        cloudStreamSessionIdRef.current = sessionId;
+        cloudStreamAbortRef.current = abort;
+        cloudStreamInflightRef.current = new Set();
+        cloudStreamDegradedRef.current = false;
+        const { update, config } = createCloudSttSegmenter();
+        recorderOpts = {
+          segmenter: { update, config: { overlapMs: config.overlapMs } },
+          onSegment: handleCloudStreamSegment,
+        };
+      }
       try {
-        const recorder = await startLocalAsrRecorder();
+        const recorder = await startLocalAsrRecorder(recorderOpts);
         localAsrRecorderRef.current = recorder;
         sttBackendRef.current = "cloud";
         enabledRef.current = true;
@@ -957,10 +1105,11 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         return true;
       } catch {
         localAsrRecorderRef.current = null;
+        teardownCloudStreamSession();
         return false;
       }
     },
-    [],
+    [handleCloudStreamSegment, teardownCloudStreamSession],
   );
 
   const startBrowserRecognition = useCallback(
@@ -1223,23 +1372,64 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         // just doesn't submit rather than being transcribed by the wrong engine.
         const recorder = localAsrRecorderRef.current;
         localAsrRecorderRef.current = null;
+        // Snapshot the streaming session (voice V2a) BEFORE recorder.stop()
+        // flushes the terminal segment, so the tail POST is tracked here.
+        const stitcher = cloudStreamStitcherRef.current;
         if (recorder) {
           try {
+            // recorder.stop() flushes the final streaming segment (if any) as a
+            // side effect, then returns the full-utterance WAV for the batch
+            // fallback path.
             const audio = await recorder.stop();
-            const transcript = await transcribeCloudAudio(audio);
-            applyTranscriptUpdate(transcript, true, {
-              mode:
-                normalizeActiveVoiceSessionMode(mode) ??
-                normalizeActiveVoiceSessionMode(listeningModeRef.current) ??
-                "compose",
-              source: "cloud",
-              metadata: { source: "cloud" },
-            });
+            const finalizeMode =
+              normalizeActiveVoiceSessionMode(mode) ??
+              normalizeActiveVoiceSessionMode(listeningModeRef.current) ??
+              "compose";
+            let committed = false;
+            if (stitcher) {
+              // Drain in-flight segment POSTs (including the just-flushed tail)
+              // so the stitched transcript is complete before we decide whether
+              // to trust it. Bounded implicitly by each segment's own
+              // per-attempt timeout inside transcribeCloudSegment.
+              await Promise.allSettled(
+                Array.from(cloudStreamInflightRef.current),
+              );
+              const running = stitcher.running.trim();
+              // Prefer the streamed stitch ONLY when it finalized cleanly and no
+              // segment hard-failed — otherwise the partial could be missing
+              // words, so fall through to the authoritative batch transcription.
+              if (
+                running &&
+                stitcher.isDone &&
+                !cloudStreamDegradedRef.current
+              ) {
+                applyTranscriptUpdate(running, true, {
+                  mode: finalizeMode,
+                  source: "cloud",
+                  metadata: { source: "cloud", streaming: true },
+                });
+                committed = true;
+              }
+            }
+            if (!committed) {
+              // Batch fallback (voice V2a graceful degrade): streaming was off,
+              // never finalized, degraded, or empty — transcribe the whole WAV.
+              const transcript = await transcribeCloudAudio(audio);
+              applyTranscriptUpdate(transcript, true, {
+                mode: finalizeMode,
+                source: "cloud",
+                metadata: { source: "cloud" },
+              });
+            }
           } catch (error) {
             ttsDebug("asr:cloud:error", {
               message: error instanceof Error ? error.message : String(error),
             });
+          } finally {
+            teardownCloudStreamSession();
           }
+        } else {
+          teardownCloudStreamSession();
         }
       } else {
         recognitionRef.current?.stop();
@@ -1253,6 +1443,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
     [
       applyTranscriptUpdate,
       finalizeRecognition,
+      teardownCloudStreamSession,
       transcribeCloudAudio,
       transcribeLocalInferenceAudio,
     ],

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -57,6 +57,12 @@ import {
 import { createCloudSttSegmenter } from "../voice/cloud-stt-segmenter";
 import { CloudSttSessionStitcher } from "../voice/cloud-stt-stitcher";
 import {
+  DEFAULT_VOICE_AUTOSEND,
+  evaluateAutoSend,
+} from "../voice/voice-autosend-config";
+import { vadDebug } from "../voice/vad-debug";
+import { loadVadAutoStop } from "../state/persistence";
+import {
   PlaybackFramePump,
   type PlaybackFrameTap,
 } from "../voice/playback-frame-pump";
@@ -226,6 +232,11 @@ function shouldUseCloudAsr(config: VoiceConfig | null): boolean {
  */
 function shouldStreamCloudAsr(config: VoiceConfig | null): boolean {
   return shouldUseCloudAsr(config) && config?.asr?.streaming !== false;
+}
+
+/** UI monotonic clock (perf.now when available), for auto-send speech timing. */
+function nowMs(): number {
+  return typeof performance !== "undefined" ? performance.now() : Date.now();
 }
 
 const ACTIVE_VOICE_SESSION_MODES = new Set<Exclude<VoiceSessionMode, "idle">>([
@@ -413,6 +424,20 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
   interruptOnSpeechRef.current = options.interruptOnSpeech ?? true;
   const onUserSpeechInterruptRef = useRef(options.onUserSpeechInterrupt);
   onUserSpeechInterruptRef.current = options.onUserSpeechInterrupt;
+  // Auto-send on end-of-speech (voice V2a). Refs so the capture hot path +
+  // auto-stop callback read the live values without re-arming the recorder.
+  const autoSendRef = useRef(options.autoSend ?? false);
+  autoSendRef.current = options.autoSend ?? false;
+  const onAutoSendRef = useRef(options.onAutoSend);
+  onAutoSendRef.current = options.onAutoSend;
+  // Capture-start timestamp (UI monotonic) for the auto-send min-speech guard.
+  const captureStartMsRef = useRef<number | null>(null);
+  // Forward-ref to stopListening so the recorder's onAutoStop (wired at start,
+  // before stopListening is defined) can invoke it. Assigned just below the
+  // stopListening definition.
+  const stopListeningRef = useRef<
+    ((opts?: { submit?: boolean; autoSend?: boolean }) => Promise<void>) | null
+  >(null);
   const interruptSpeechRef = useRef<() => void>(() => {});
   const playbackFramePumpRef = useRef<PlaybackFramePump | null>(null);
 
@@ -1074,6 +1099,28 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       let recorderOpts:
         | Parameters<typeof startLocalAsrRecorder>[0]
         | undefined;
+      // Auto-send on end-of-speech (voice V2a): in COMPOSE mode, when the
+      // persisted toggle is on, arm a VAD auto-stop detector so a detected
+      // end-of-turn finalizes AND (subject to the reliability guards) submits.
+      // Hands-free / passive modes already carry their own turn-end handling in
+      // the shell; auto-send here is the composer's PTT-replacement affordance.
+      // The user's tuned VAD `silenceMs` (loadVadAutoStop) wins over the default.
+      const autoSendActive = autoSendRef.current && mode === "compose";
+      if (autoSendActive) {
+        const persistedVad = loadVadAutoStop();
+        const autoStop = {
+          silenceMs: persistedVad.silenceMs ?? DEFAULT_VOICE_AUTOSEND.silenceMs,
+          speechRmsThreshold: persistedVad.speechRmsThreshold,
+        };
+        recorderOpts = {
+          ...(recorderOpts ?? {}),
+          autoStop,
+          onAutoStop: () => {
+            vadDebug("auto-stop", { mode, source: "cloud", autoSend: true });
+            void stopListeningRef.current?.({ autoSend: true });
+          },
+        };
+      }
       if (streaming) {
         teardownCloudStreamSession();
         const stitcher = new CloudSttSessionStitcher();
@@ -1089,6 +1136,7 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         cloudStreamDegradedRef.current = false;
         const { update, config } = createCloudSttSegmenter();
         recorderOpts = {
+          ...(recorderOpts ?? {}),
           segmenter: { update, config: { overlapMs: config.overlapMs } },
           onSegment: handleCloudStreamSegment,
         };
@@ -1096,6 +1144,8 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       try {
         const recorder = await startLocalAsrRecorder(recorderOpts);
         localAsrRecorderRef.current = recorder;
+        // Stamp capture-start for the auto-send min-speech guard.
+        captureStartMsRef.current = nowMs();
         sttBackendRef.current = "cloud";
         enabledRef.current = true;
         listeningModeRef.current = mode;
@@ -1328,9 +1378,17 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
   );
 
   const stopListening = useCallback(
-    async (options?: { submit?: boolean }) => {
+    async (options?: { submit?: boolean; autoSend?: boolean }) => {
       const mode = listeningModeRef.current;
       if (mode === "idle") return;
+      // Auto-send request (voice V2a): VAD detected end-of-speech and auto-send
+      // is enabled. The actual submit decision is deferred until AFTER we have
+      // the final transcript so the reliability guards (min chars/words/speech)
+      // can reject accidental noise. Computed into the effective submit below.
+      const autoSendRequested = options?.autoSend === true;
+      const captureStartMs = captureStartMsRef.current;
+      const speechDurationMs =
+        captureStartMs != null ? Math.max(0, nowMs() - captureStartMs) : undefined;
 
       const submit = options?.submit === true;
       enabledRef.current = false;
@@ -1438,7 +1496,54 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         );
       }
 
-      finalizeRecognition(submit);
+      // Auto-send decision (voice V2a): if this stop was triggered by VAD
+      // end-of-speech with auto-send enabled, run the reliability guards against
+      // the resolved transcript (now in transcriptBufferRef) and only submit
+      // when it passes. A rejected turn falls through with submit=false, which
+      // leaves the transcript in the composer draft (via the preview already
+      // emitted) for review-then-send — nothing is lost.
+      let effectiveSubmit = submit;
+      if (autoSendRequested) {
+        const resolved = collapseWhitespace(transcriptBufferRef.current);
+        const decision = evaluateAutoSend(
+          resolved,
+          DEFAULT_VOICE_AUTOSEND,
+          speechDurationMs,
+        );
+        effectiveSubmit = decision.send;
+        if (decision.send) {
+          vadDebug("auto-send", {
+            chars: resolved.length,
+            speechMs: speechDurationMs,
+          });
+          // Notify the caller of an auto-send (telemetry / differentiation from
+          // a manual submit). The actual send still rides finalizeRecognition
+          // → onTranscript below, the same path a manual PTT-release submit uses.
+          const evtMode =
+            normalizeActiveVoiceSessionMode(listeningModeRef.current) ??
+            "compose";
+          onAutoSendRef.current?.(resolved, {
+            text: resolved,
+            mode: evtMode,
+            isFinal: true,
+            turn: latestTranscriptTurnRef.current ?? {
+              text: resolved,
+              mode: evtMode,
+              isFinal: true,
+            },
+            speaker: latestTranscriptTurnRef.current?.speaker,
+          });
+        } else {
+          vadDebug("auto-send-suppressed", {
+            reason: decision.reason,
+            chars: resolved.length,
+            speechMs: speechDurationMs,
+          });
+        }
+      }
+
+      captureStartMsRef.current = null;
+      finalizeRecognition(effectiveSubmit);
     },
     [
       applyTranscriptUpdate,
@@ -1448,6 +1553,10 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
       transcribeLocalInferenceAudio,
     ],
   );
+
+  // Assign the forward-ref so onAutoStop (wired at capture start) can call the
+  // latest stopListening.
+  stopListeningRef.current = stopListening;
 
   const toggleListening = useCallback(() => {
     if (enabledRef.current && listeningModeRef.current === "compose") {

--- a/packages/ui/src/state/persistence-voice-autosend.test.ts
+++ b/packages/ui/src/state/persistence-voice-autosend.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+
+/**
+ * Voice auto-send toggle persistence (voice V2a): `loadVoiceAutoSendEnabled` /
+ * `saveVoiceAutoSendEnabled` round-trip + the OFF-by-default contract (the
+ * launch default is review-then-send; auto-send flips on later once reliable).
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  loadVoiceAutoSendEnabled,
+  saveVoiceAutoSendEnabled,
+} from "./persistence";
+
+const KEY = "eliza:voice:autosend-enabled";
+
+describe("voice auto-send persistence", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("defaults OFF when nothing is stored (review-then-send launch default)", () => {
+    expect(loadVoiceAutoSendEnabled()).toBe(false);
+  });
+
+  it("round-trips an enabled value", () => {
+    saveVoiceAutoSendEnabled(true);
+    expect(localStorage.getItem(KEY)).toBe("true");
+    expect(loadVoiceAutoSendEnabled()).toBe(true);
+  });
+
+  it("round-trips a disabled value", () => {
+    saveVoiceAutoSendEnabled(true);
+    saveVoiceAutoSendEnabled(false);
+    expect(loadVoiceAutoSendEnabled()).toBe(false);
+  });
+
+  it("treats any non-'true' stored value as OFF", () => {
+    localStorage.setItem(KEY, "yes");
+    expect(loadVoiceAutoSendEnabled()).toBe(false);
+    localStorage.setItem(KEY, "1");
+    expect(loadVoiceAutoSendEnabled()).toBe(false);
+  });
+});

--- a/packages/ui/src/state/persistence.ts
+++ b/packages/ui/src/state/persistence.ts
@@ -1022,6 +1022,31 @@ export function saveWakeWordEnabled(value: boolean): void {
   }, undefined);
 }
 
+/* ── Voice auto-send persistence (voice V2a) ────────────────────────────── */
+// Device-local toggle for auto-send-on-end-of-speech: when ON, a composer voice
+// turn that VAD detects as ended is finalized AND sent automatically (gated by
+// the reliability guards in voice-autosend-config.ts); when OFF (the DEFAULT),
+// the turn fills the composer draft for review-then-send. Owner direction
+// (2026-07-07): ship auto-send OFF by default, flip the default later "only once
+// it works reliably." Stored device-local (not agent config) + read
+// synchronously on the capture gesture, the same dual-store pattern wake-word /
+// vad-auto-stop use below. Defaults FALSE.
+const VOICE_AUTOSEND_ENABLED_KEY = "eliza:voice:autosend-enabled";
+
+export function loadVoiceAutoSendEnabled(): boolean {
+  return tryLocalStorage(() => {
+    const stored = localStorage.getItem(VOICE_AUTOSEND_ENABLED_KEY);
+    // Absent → FALSE (review-then-send is the launch default).
+    return stored === "true";
+  }, false);
+}
+
+export function saveVoiceAutoSendEnabled(value: boolean): void {
+  tryLocalStorage(() => {
+    shellLocalStorage.setItem(VOICE_AUTOSEND_ENABLED_KEY, String(value));
+  }, undefined);
+}
+
 /* ── VAD auto-stop persistence ──────────────────────────────────────────── */
 // Local mirror of the `vadAutoStop` voice setting (source of truth is the agent
 // config under `messages.voice`). Stored here too so the capture hot path

--- a/packages/ui/src/voice/cloud-stt-segment.test.ts
+++ b/packages/ui/src/voice/cloud-stt-segment.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+
+// Tests the chunked-streaming segment POST leg (voice V2a): the `X-Asr-Segment`
+// header wire shape, both-tier route selection (dedicated `/api/asr/cloud` vs
+// shared-runtime `/api/v1/voice/stt`), the empty-segment-is-OK contract (unlike
+// the batch whole-utterance path), and retry classification. Mirrors the stub
+// setup in local-asr-transcribe.test.ts.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchWithCsrf } from "../api/csrf-client";
+import { resolveApiUrl } from "../utils";
+import {
+  encodeAsrSegmentHeader,
+  transcribeCloudSegment,
+} from "./local-asr-transcribe";
+
+vi.mock("../api/csrf-client", () => ({
+  fetchWithCsrf: vi.fn(),
+}));
+vi.mock("../utils", () => ({
+  resolveApiUrl: vi.fn((path: string) => `http://agent.local${path}`),
+}));
+vi.mock("../utils/eliza-globals", () => ({
+  getElizaApiBase: vi.fn<() => string | undefined>(() => undefined),
+}));
+
+import { getElizaApiBase } from "../utils/eliza-globals";
+
+const fetchWithCsrfMock = vi.mocked(fetchWithCsrf);
+const getElizaApiBaseMock = vi.mocked(getElizaApiBase);
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+const SEG = { sessionId: "sess-abc", seq: 2, isFinal: false } as const;
+
+describe("encodeAsrSegmentHeader", () => {
+  it("serializes to a compact sessionId;seq;isFinal triple", () => {
+    expect(encodeAsrSegmentHeader(SEG)).toBe("sess-abc;2;0");
+    expect(
+      encodeAsrSegmentHeader({ sessionId: "x", seq: 5, isFinal: true }),
+    ).toBe("x;5;1");
+  });
+});
+
+describe("transcribeCloudSegment — dedicated tier", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    getElizaApiBaseMock.mockReturnValue(undefined);
+  });
+
+  it("POSTs raw WAV to /api/asr/cloud with the X-Asr-Segment header", async () => {
+    fetchWithCsrfMock.mockResolvedValue(jsonResponse({ text: " on the " }));
+    const wav = new Uint8Array([82, 73, 70, 70]);
+
+    const text = await transcribeCloudSegment(wav, { segment: SEG });
+
+    const [url, init] = fetchWithCsrfMock.mock.calls[0] ?? [];
+    expect(url).toBe("http://agent.local/api/asr/cloud");
+    const headers = init?.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toBe("audio/wav");
+    expect(headers["X-Asr-Segment"]).toBe("sess-abc;2;0");
+    expect(init?.body).toBe(wav);
+    expect(text).toBe("on the");
+  });
+
+  it("returns '' for an empty segment transcript (NOT an error, unlike batch)", async () => {
+    fetchWithCsrfMock.mockResolvedValue(jsonResponse({ text: "   " }));
+    await expect(
+      transcribeCloudSegment(new Uint8Array([1]), { segment: SEG }),
+    ).resolves.toBe("");
+  });
+
+  it("throws on a terminal 401 (no retry)", async () => {
+    fetchWithCsrfMock.mockResolvedValue(
+      jsonResponse({ error: "no key" }, false, 401),
+    );
+    await expect(
+      transcribeCloudSegment(new Uint8Array([1]), { segment: SEG }),
+    ).rejects.toThrow(/segment 401/);
+    expect(fetchWithCsrfMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries once on a 503 then succeeds", async () => {
+    fetchWithCsrfMock
+      .mockResolvedValueOnce(jsonResponse({ error: "upstream" }, false, 503))
+      .mockResolvedValueOnce(jsonResponse({ text: "recovered" }));
+    const text = await transcribeCloudSegment(new Uint8Array([1]), {
+      segment: SEG,
+    });
+    expect(text).toBe("recovered");
+    expect(fetchWithCsrfMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("transcribeCloudSegment — shared-runtime tier", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    getElizaApiBaseMock.mockReturnValue(undefined);
+  });
+
+  it("routes to the v1 STT worker route with a multipart body + header", async () => {
+    getElizaApiBaseMock.mockReturnValue(
+      "https://cloud.example.com/api/v1/eliza/agents/agent-123",
+    );
+    fetchWithCsrfMock.mockResolvedValue(
+      jsonResponse({ transcript: "shared tier text" }),
+    );
+
+    const text = await transcribeCloudSegment(new Uint8Array([1, 2, 3]), {
+      segment: { sessionId: "s", seq: 0, isFinal: true },
+    });
+
+    const [url, init] = fetchWithCsrfMock.mock.calls[0] ?? [];
+    expect(url).toBe("https://cloud.example.com/api/v1/voice/stt");
+    const headers = init?.headers as Record<string, string>;
+    expect(headers["X-Asr-Segment"]).toBe("s;0;1");
+    // Multipart body — no explicit Content-Type (browser sets the boundary).
+    expect(headers["Content-Type"]).toBeUndefined();
+    expect(init?.body).toBeInstanceOf(FormData);
+    expect(text).toBe("shared tier text");
+  });
+});

--- a/packages/ui/src/voice/cloud-stt-segmenter.test.ts
+++ b/packages/ui/src/voice/cloud-stt-segmenter.test.ts
@@ -1,0 +1,140 @@
+// Unit tests for the chunked-streaming capture segmenter (voice V2a).
+// Pure state-machine over frames + explicit timestamps (no AudioContext).
+// Covers boundary emission (length + pause), the min-speech floor, and the
+// echo-gate interaction.
+
+import { describe, expect, it } from "vitest";
+import {
+  createCloudSttSegmenter,
+  DEFAULT_CLOUD_STT_SEGMENTER,
+} from "./cloud-stt-segmenter";
+
+/** A loud (speech-level) mono frame. */
+function speechFrame(n = 320): Float32Array {
+  return new Float32Array(n).fill(0.3);
+}
+/** A silent frame (below the RMS/peak gates). */
+function silentFrame(n = 320): Float32Array {
+  return new Float32Array(n).fill(0);
+}
+
+const noEchoGate = { isTtsEchoGateActive: () => false };
+
+describe("createCloudSttSegmenter — length-based boundary", () => {
+  it("cuts a boundary after ~segmentMs of speech", () => {
+    const { update } = createCloudSttSegmenter({
+      segmentMs: 1000,
+      minSegmentMs: 400,
+      ...noEchoGate,
+    });
+    let t = 0;
+    const boundaries: number[] = [];
+    // Feed 20 speech frames at 100ms spacing = ~2000ms of speech.
+    for (let i = 0; i < 20; i += 1) {
+      t += 100;
+      const r = update(speechFrame(), t);
+      if (r.boundary) boundaries.push(t);
+    }
+    // First boundary near 1000ms of accumulated speech, second near 2000ms.
+    expect(boundaries.length).toBeGreaterThanOrEqual(1);
+    expect(boundaries[0]).toBeGreaterThanOrEqual(1000);
+  });
+
+  it("does not cut before minSegmentMs of speech", () => {
+    const { update } = createCloudSttSegmenter({
+      segmentMs: 1000,
+      minSegmentMs: 400,
+      pauseMs: 100,
+      ...noEchoGate,
+    });
+    let t = 0;
+    // 3 speech frames (~300ms) then a long pause — under the 400ms floor, so a
+    // pause boundary must NOT fire.
+    for (let i = 0; i < 3; i += 1) {
+      t += 100;
+      expect(update(speechFrame(), t).boundary).toBe(false);
+    }
+    t += 500;
+    expect(update(silentFrame(), t).boundary).toBe(false);
+  });
+
+  it("reports speech vs silence per frame", () => {
+    const { update } = createCloudSttSegmenter(noEchoGate);
+    expect(update(speechFrame(), 100).speech).toBe(true);
+    expect(update(silentFrame(), 200).speech).toBe(false);
+  });
+});
+
+describe("createCloudSttSegmenter — pause-based boundary", () => {
+  it("cuts a clean boundary on an intra-utterance pause once min speech met", () => {
+    const { update } = createCloudSttSegmenter({
+      segmentMs: 5000, // long, so length can't be what triggers
+      minSegmentMs: 400,
+      pauseMs: 350,
+      ...noEchoGate,
+    });
+    let t = 0;
+    // ~600ms of speech (clears the 400ms floor).
+    for (let i = 0; i < 6; i += 1) {
+      t += 100;
+      update(speechFrame(), t);
+    }
+    // A 400ms silence gap > pauseMs → boundary on the silent frame.
+    t += 400;
+    const r = update(silentFrame(), t);
+    expect(r.boundary).toBe(true);
+    expect(r.speech).toBe(false);
+  });
+
+  it("resets the speech clock after a boundary (next segment re-accumulates)", () => {
+    const { update } = createCloudSttSegmenter({
+      segmentMs: 5000,
+      minSegmentMs: 400,
+      pauseMs: 350,
+      ...noEchoGate,
+    });
+    let t = 0;
+    for (let i = 0; i < 6; i += 1) {
+      t += 100;
+      update(speechFrame(), t);
+    }
+    t += 400;
+    expect(update(silentFrame(), t).boundary).toBe(true);
+    // Immediately after: a short burst must NOT instantly re-fire (clock reset).
+    t += 100;
+    expect(update(speechFrame(), t).boundary).toBe(false);
+  });
+});
+
+describe("createCloudSttSegmenter — echo gate", () => {
+  it("suppresses speech detection while the TTS echo gate is active", () => {
+    // With the gate active, the speech threshold is multiplied up; a 0.3 frame
+    // that normally reads as speech should read as silence under the 4x gate.
+    const { update } = createCloudSttSegmenter({
+      isTtsEchoGateActive: () => true,
+    });
+    // Default gates: rms 0.003, peak 0.012. Under the 4x echo gate they become
+    // rms 0.012, peak 0.048. A 0.008 fill (rms=peak=0.008) is above the ungated
+    // bar but below BOTH raised bars, so it must read as silence while the gate
+    // is active (faint far-field TTS echo suppressed). A loud 0.3 frame would
+    // still clear even the raised bar (a real barge-in).
+    const faint = new Float32Array(320).fill(0.008);
+    expect(update(faint, 100).speech).toBe(false);
+    // Sanity: the same faint frame reads as speech with the gate OFF.
+    const { update: ungated } = createCloudSttSegmenter({
+      isTtsEchoGateActive: () => false,
+    });
+    expect(ungated(new Float32Array(320).fill(0.008), 100).speech).toBe(true);
+  });
+});
+
+describe("DEFAULT_CLOUD_STT_SEGMENTER", () => {
+  it("has sane defaults (min < segment, pause < turn-end silence)", () => {
+    expect(DEFAULT_CLOUD_STT_SEGMENTER.minSegmentMs).toBeLessThan(
+      DEFAULT_CLOUD_STT_SEGMENTER.segmentMs,
+    );
+    // Pause boundary must be softer than the 650ms end-of-turn VAD window.
+    expect(DEFAULT_CLOUD_STT_SEGMENTER.pauseMs).toBeLessThan(650);
+    expect(DEFAULT_CLOUD_STT_SEGMENTER.overlapMs).toBeGreaterThan(0);
+  });
+});

--- a/packages/ui/src/voice/cloud-stt-segmenter.ts
+++ b/packages/ui/src/voice/cloud-stt-segmenter.ts
@@ -1,0 +1,187 @@
+/**
+ * Incremental capture segmenter for chunked-segment cloud STT (voice V2a —
+ * Phase 1 streaming ASR, per VOICE-STREAMING-DESIGN §2.5).
+ *
+ * Runs alongside the existing per-frame auto-stop VAD in the WAV recorder. As
+ * mono PCM16 frames arrive it decides WHEN to cut a segment boundary so the
+ * captured-so-far speech can be POSTed to the batch cloud STT endpoint mid-
+ * utterance (instead of only the whole WAV at stop). Cutting segments during
+ * speech overlaps the transcription round-trips with the user still talking, so
+ * the final speech-end→transcript leg shrinks to "transcribe the last ~1s tail
+ * + stitch" rather than "transcribe the entire utterance".
+ *
+ * The segmenter is PURE state-machine logic over frames + timestamps — it never
+ * touches the AudioContext / WAV encoding (the recorder owns that). It only
+ * answers, per frame, "cut a segment boundary now?" plus tracks a small trailing
+ * overlap so consecutive segments share ~200ms of audio (seam continuity; the
+ * stitcher dedups the overlapped words — see cloud-stt-stitcher.ts).
+ *
+ * Boundary policy:
+ *   - Emit a boundary after ~`segmentMs` of buffered SPEECH (default 1000ms),
+ *     so long utterances pipeline as ~1s chunks.
+ *   - Emit a boundary on a short intra-utterance PAUSE (`pauseMs`, default
+ *     350ms) — a softer threshold than the end-of-turn VAD silence (650ms) — so
+ *     a natural clause break flushes a clean segment rather than splitting mid-
+ *     word. (The end-of-turn VAD still fires the final boundary + stop.)
+ *   - Never emit a boundary before `minSegmentMs` of speech (default 400ms):
+ *     avoids a spray of tiny 1-2 word segments on choppy speech, each costing a
+ *     round-trip.
+ *
+ * Reuses the same energy VAD (`measurePcmAudio` + thresholds) as the auto-stop
+ * detector so "speech" here means the same thing it does for turn-end.
+ */
+
+import {
+  DEFAULT_LOCAL_ASR_AUTO_STOP,
+  measurePcmAudio,
+  POST_TTS_ECHO_THRESHOLD_MULTIPLIER,
+} from "./local-asr-capture";
+import {
+  DEFAULT_POST_TTS_COOLDOWN_MS,
+  isTtsEchoGateActive as sharedTtsEchoGateActive,
+} from "./tts-playback-activity";
+
+export interface CloudSttSegmenterOptions {
+  /** Target buffered-speech duration per segment before cutting. Default 1000ms. */
+  segmentMs?: number;
+  /** Minimum buffered speech before ANY boundary may fire. Default 400ms. */
+  minSegmentMs?: number;
+  /** Intra-utterance pause that flushes a clean segment boundary. Default 350ms.
+   * Softer than the end-of-turn silence window so a clause break cuts a segment
+   * without ending the turn. */
+  pauseMs?: number;
+  /** Trailing audio (ms) to carry into the NEXT segment for seam continuity.
+   * The stitcher dedups the overlapped words. Default 200ms. */
+  overlapMs?: number;
+  /** Speech RMS gate (shared with the auto-stop VAD default). */
+  speechRmsThreshold?: number;
+  /** Speech peak gate (shared with the auto-stop VAD default). */
+  speechPeakThreshold?: number;
+  /** Post-TTS cooldown window for the echo gate. Default 1500ms. */
+  postTtsCooldownMs?: number;
+  /** Injectable playback-activity probe (tests). */
+  isTtsEchoGateActive?: (nowMs: number) => boolean;
+}
+
+/** Per-frame decision from the segmenter. */
+export interface CloudSttSegmenterUpdate {
+  /**
+   * True on the frame that closes a segment. The recorder should encode the
+   * frames buffered since the last boundary (minus the retained overlap tail)
+   * to a WAV and POST it as segment `seq`.
+   */
+  boundary: boolean;
+  /** True when THIS frame carried detected speech (for the recorder's buffer gating). */
+  speech: boolean;
+}
+
+export interface CloudSttSegmenterConfig {
+  segmentMs: number;
+  minSegmentMs: number;
+  pauseMs: number;
+  overlapMs: number;
+  speechRmsThreshold: number;
+  speechPeakThreshold: number;
+}
+
+export const DEFAULT_CLOUD_STT_SEGMENTER: CloudSttSegmenterConfig = {
+  segmentMs: 1000,
+  minSegmentMs: 400,
+  pauseMs: 350,
+  overlapMs: 200,
+  speechRmsThreshold: DEFAULT_LOCAL_ASR_AUTO_STOP.speechRmsThreshold,
+  speechPeakThreshold: DEFAULT_LOCAL_ASR_AUTO_STOP.speechPeakThreshold,
+};
+
+function nowMs(): number {
+  return typeof performance !== "undefined" ? performance.now() : Date.now();
+}
+
+/**
+ * Create a per-frame segmenter. Feed every captured mono frame through the
+ * returned function; it returns `{boundary, speech}`. `null` config-less
+ * variant is not offered — the segmenter is only constructed when chunked
+ * streaming is enabled for the capture.
+ */
+export function createCloudSttSegmenter(
+  options: CloudSttSegmenterOptions = {},
+): {
+  update: (pcm: Float32Array, sampleTimeMs?: number) => CloudSttSegmenterUpdate;
+  config: CloudSttSegmenterConfig;
+} {
+  const config: CloudSttSegmenterConfig = {
+    ...DEFAULT_CLOUD_STT_SEGMENTER,
+    ...Object.fromEntries(
+      Object.entries(options).filter(([, v]) => v !== undefined),
+    ),
+  };
+  const cooldownMs = options.postTtsCooldownMs ?? DEFAULT_POST_TTS_COOLDOWN_MS;
+  const echoGateActive =
+    options.isTtsEchoGateActive ??
+    ((atMs: number) => sharedTtsEchoGateActive(atMs, cooldownMs));
+
+  // Accumulated SPEECH time within the current segment (ms). Silence frames do
+  // not advance this — a segment is "~1s of speech", not "~1s of wall time".
+  let segmentSpeechMs = 0;
+  // Wall-clock timestamp of the last speech frame, for pause detection.
+  let lastSpeechAtMs: number | null = null;
+  // Whether the current segment has ANY speech yet (so a pure-silence lead-in
+  // never fires a boundary).
+  let segmentHasSpeech = false;
+  // Approx per-frame duration inferred from the frame size + assumed 16k rate;
+  // refined once we see real frame lengths.
+  let lastFrameTimeMs: number | null = null;
+
+  const update = (
+    pcm: Float32Array,
+    sampleTimeMs = nowMs(),
+  ): CloudSttSegmenterUpdate => {
+    const stats = measurePcmAudio(pcm);
+    const gate = echoGateActive(sampleTimeMs)
+      ? POST_TTS_ECHO_THRESHOLD_MULTIPLIER
+      : 1;
+    const speech =
+      stats.rms >= config.speechRmsThreshold * gate ||
+      stats.peak >= config.speechPeakThreshold * gate;
+
+    // Advance the segment's speech clock by the elapsed wall time since the
+    // previous frame, but only while speech is active (accumulates spoken
+    // duration, not silence).
+    const frameDeltaMs =
+      lastFrameTimeMs === null
+        ? 0
+        : Math.max(0, sampleTimeMs - lastFrameTimeMs);
+    lastFrameTimeMs = sampleTimeMs;
+
+    if (speech) {
+      segmentHasSpeech = true;
+      segmentSpeechMs += frameDeltaMs;
+      lastSpeechAtMs = sampleTimeMs;
+    }
+
+    if (!segmentHasSpeech || segmentSpeechMs < config.minSegmentMs) {
+      return { boundary: false, speech };
+    }
+
+    // Cut on accumulated-speech length.
+    const lengthCut = segmentSpeechMs >= config.segmentMs;
+    // Cut on an intra-utterance pause (a clause break), once we have min speech.
+    const pauseCut =
+      !speech &&
+      lastSpeechAtMs !== null &&
+      sampleTimeMs - lastSpeechAtMs >= config.pauseMs;
+
+    if (lengthCut || pauseCut) {
+      // Reset for the next segment. Keep no speech carried — the recorder
+      // retains the raw audio overlap; the segmenter's speech clock restarts.
+      segmentSpeechMs = 0;
+      segmentHasSpeech = false;
+      lastSpeechAtMs = null;
+      return { boundary: true, speech };
+    }
+
+    return { boundary: false, speech };
+  };
+
+  return { update, config };
+}

--- a/packages/ui/src/voice/cloud-stt-stitcher.test.ts
+++ b/packages/ui/src/voice/cloud-stt-stitcher.test.ts
@@ -1,0 +1,174 @@
+// Unit tests for the chunked-segment cloud STT stitcher (voice V2a).
+// Pure logic — no DOM, no network. Covers ordering, dedup, seam overlap, and
+// finalize semantics called out in VOICE-STREAMING-DESIGN §2.5 + the lane spec
+// (out-of-order/duplicate chunk handling, incremental transcript assembly).
+
+import { describe, expect, it } from "vitest";
+import {
+  CloudSttSessionStitcher,
+  seamOverlapWordCount,
+} from "./cloud-stt-stitcher";
+
+describe("seamOverlapWordCount", () => {
+  it("returns 0 when there is no overlap", () => {
+    expect(
+      seamOverlapWordCount(["turn", "on"], ["the", "kitchen", "light"]),
+    ).toBe(0);
+  });
+
+  it("detects a single-word seam overlap", () => {
+    expect(
+      seamOverlapWordCount(["turn", "on", "the"], ["the", "kitchen"]),
+    ).toBe(1);
+  });
+
+  it("detects a multi-word seam overlap and prefers the longest", () => {
+    expect(
+      seamOverlapWordCount(
+        ["please", "turn", "on", "the"],
+        ["on", "the", "kitchen", "light"],
+      ),
+    ).toBe(2);
+  });
+
+  it("matches case- and punctuation-insensitively at the seam", () => {
+    expect(seamOverlapWordCount(["the"], ["The,"])).toBe(1);
+    expect(seamOverlapWordCount(["Light."], ["light"])).toBe(1);
+  });
+
+  it("does not match on punctuation-only tokens", () => {
+    // A trailing "," token has an empty word key; it must not count as overlap.
+    expect(seamOverlapWordCount(["hello", ","], [",", "world"])).toBe(0);
+  });
+
+  it("is bounded by the maxOverlapWords window", () => {
+    // A genuine 5-word suffix/prefix seam: running ends with c d e f g, incoming
+    // begins with c d e f g. The seam is only detectable when the window admits
+    // its full length (a k-overlap must match as a whole suffix==prefix).
+    const running = ["a", "b", "c", "d", "e", "f", "g"];
+    const incoming = ["c", "d", "e", "f", "g", "h", "i"];
+    // Window >= 5 finds the full seam.
+    expect(seamOverlapWordCount(running, incoming, 5)).toBe(5);
+    expect(seamOverlapWordCount(running, incoming, 10)).toBe(5);
+    // A window smaller than the true seam can't confirm it (partial windows are
+    // different alignments), so it reports 0 rather than a wrong partial dedup.
+    expect(seamOverlapWordCount(running, incoming, 3)).toBe(0);
+  });
+});
+
+describe("CloudSttSessionStitcher — in-order assembly", () => {
+  it("appends segments in order with seam dedup", () => {
+    const s = new CloudSttSessionStitcher();
+    expect(s.push({ seq: 0, text: "turn on the", isFinal: false })).toBe(
+      "turn on the",
+    );
+    // Segment 1 repeats the overlapped "the" (audio overlap) — deduped.
+    expect(
+      s.push({ seq: 1, text: "the kitchen light", isFinal: true }),
+    ).toBe("turn on the kitchen light");
+    expect(s.isDone).toBe(true);
+  });
+
+  it("handles a clean (no-overlap) boundary", () => {
+    const s = new CloudSttSessionStitcher();
+    s.push({ seq: 0, text: "hello there", isFinal: false });
+    expect(s.push({ seq: 1, text: "general kenobi", isFinal: true })).toBe(
+      "hello there general kenobi",
+    );
+  });
+
+  it("ignores empty segments", () => {
+    const s = new CloudSttSessionStitcher();
+    s.push({ seq: 0, text: "start", isFinal: false });
+    expect(s.push({ seq: 1, text: "   ", isFinal: false })).toBe("start");
+    expect(s.push({ seq: 2, text: "end", isFinal: true })).toBe("start end");
+  });
+});
+
+describe("CloudSttSessionStitcher — out-of-order + duplicate delivery", () => {
+  it("buffers a segment that arrives ahead of the frontier", () => {
+    const s = new CloudSttSessionStitcher();
+    // seq 1 arrives before seq 0 (concurrent transcription).
+    expect(s.push({ seq: 1, text: "world", isFinal: true })).toBe("");
+    expect(s.pendingCount).toBe(1);
+    // seq 0 lands → both flush in order.
+    expect(s.push({ seq: 0, text: "hello", isFinal: false })).toBe(
+      "hello world",
+    );
+    expect(s.pendingCount).toBe(0);
+    expect(s.isDone).toBe(true);
+  });
+
+  it("drains a multi-segment contiguous run when the gap fills", () => {
+    const s = new CloudSttSessionStitcher();
+    s.push({ seq: 3, text: "four", isFinal: true });
+    s.push({ seq: 1, text: "two", isFinal: false });
+    s.push({ seq: 2, text: "three", isFinal: false });
+    expect(s.pendingCount).toBe(3);
+    // seq 0 unblocks the whole chain 0→1→2→3.
+    expect(s.push({ seq: 0, text: "one", isFinal: false })).toBe(
+      "one two three four",
+    );
+    expect(s.isDone).toBe(true);
+    expect(s.pendingCount).toBe(0);
+  });
+
+  it("is idempotent on a re-delivered seq (retry that resolves twice)", () => {
+    const s = new CloudSttSessionStitcher();
+    s.push({ seq: 0, text: "alpha", isFinal: false });
+    s.push({ seq: 1, text: "beta", isFinal: true });
+    const before = s.running;
+    // Re-delivery of already-applied seqs is a no-op.
+    expect(s.push({ seq: 0, text: "alpha", isFinal: false })).toBe(before);
+    expect(s.push({ seq: 1, text: "beta", isFinal: true })).toBe(before);
+    expect(s.running).toBe("alpha beta");
+  });
+
+  it("keeps the first copy of a duplicated buffered seq", () => {
+    const s = new CloudSttSessionStitcher();
+    // Two deliveries of seq 1 while seq 0 is still missing — first wins.
+    s.push({ seq: 1, text: "first", isFinal: false });
+    s.push({ seq: 1, text: "second", isFinal: false });
+    expect(s.pendingCount).toBe(1);
+    s.push({ seq: 0, text: "zero", isFinal: false });
+    expect(s.running).toBe("zero first");
+  });
+
+  it("ignores negative / stale seqs", () => {
+    const s = new CloudSttSessionStitcher();
+    expect(s.push({ seq: -1, text: "junk", isFinal: false })).toBe("");
+    expect(s.running).toBe("");
+  });
+});
+
+describe("CloudSttSessionStitcher — finalize + reset", () => {
+  it("hasContiguousThrough tracks the applied frontier", () => {
+    const s = new CloudSttSessionStitcher();
+    s.push({ seq: 0, text: "a", isFinal: false });
+    expect(s.hasContiguousThrough(0)).toBe(true);
+    expect(s.hasContiguousThrough(1)).toBe(false);
+    s.push({ seq: 1, text: "b", isFinal: true });
+    expect(s.hasContiguousThrough(1)).toBe(true);
+  });
+
+  it("reset() clears the session for reuse", () => {
+    const s = new CloudSttSessionStitcher();
+    s.push({ seq: 0, text: "old turn", isFinal: true });
+    s.reset();
+    expect(s.running).toBe("");
+    expect(s.isDone).toBe(false);
+    expect(s.pendingCount).toBe(0);
+    expect(s.push({ seq: 0, text: "new turn", isFinal: false })).toBe(
+      "new turn",
+    );
+  });
+
+  it("finalizes even when the final segment's own text is empty", () => {
+    const s = new CloudSttSessionStitcher();
+    s.push({ seq: 0, text: "complete utterance", isFinal: false });
+    // The tail segment transcribed to nothing (trailing silence) but is final.
+    s.push({ seq: 1, text: "", isFinal: true });
+    expect(s.isDone).toBe(true);
+    expect(s.running).toBe("complete utterance");
+  });
+});

--- a/packages/ui/src/voice/cloud-stt-stitcher.ts
+++ b/packages/ui/src/voice/cloud-stt-stitcher.ts
@@ -1,0 +1,209 @@
+/**
+ * Client-side incremental-transcript stitcher for chunked-segment cloud STT
+ * (voice V2a — Phase 1 streaming ASR, per VOICE-STREAMING-DESIGN §2.5).
+ *
+ * The cloud `/voice/stt` upstream is a BATCH file endpoint (multipart WAV →
+ * `{transcript}`); there is no shared decoder state across requests. V2a's
+ * "streaming" is therefore N independent per-segment transcriptions, POSTed as
+ * the user speaks, stitched here into one monotonically-growing running
+ * transcript that the composer renders live — instead of a single dead wait for
+ * the whole utterance at stop().
+ *
+ * Because each segment is transcribed in isolation, the seams between segments
+ * carry two artifacts this stitcher must absorb:
+ *
+ *   1. **Overlap duplication.** The capturer sends a short (~200ms) audio
+ *      overlap between consecutive segments (so a word straddling a boundary is
+ *      never bisected mid-phoneme). The transcriber then emits the overlapped
+ *      words in BOTH segments — "…turn on the" / "the kitchen light". A naive
+ *      concat yields "turn on the the kitchen light". The stitcher trims the
+ *      duplicated seam by finding the longest word-suffix of the running text
+ *      that is a word-prefix of the incoming segment.
+ *
+ *   2. **Out-of-order / duplicate delivery.** Segments are POSTed as they're
+ *      captured but transcribed concurrently, so segment `seq=3` can resolve
+ *      before `seq=2`. The stitcher is fed by `seq` and buffers a segment whose
+ *      predecessor hasn't landed yet, flushing the contiguous run once the gap
+ *      fills. A re-delivered `seq` (retry that both eventually succeed) is
+ *      idempotent — the second delivery for an already-applied `seq` is ignored.
+ *
+ * This is deliberately NOT `LocalAgreementBuffer` / `PartialStabilizer` from
+ * plugin-local-inference: those stabilize a SINGLE decoder's per-frame
+ * hypotheses (same utterance, retracting tail words). Here each segment is a
+ * finalized independent transcript — there is nothing to "agree" across frames;
+ * the problem is seam dedup + ordering, which is what this solves. The seam
+ * word-prefix-agreement borrows the same *idea* (prefer the longest agreeing
+ * boundary) applied to segment seams rather than frame hypotheses.
+ */
+
+/** A single transcribed segment handed to the stitcher. */
+export interface CloudSttSegment {
+  /**
+   * Monotonic 0-based sequence index assigned at capture time. Delivery may be
+   * out of order; the stitcher reassembles by `seq`.
+   */
+  seq: number;
+  /** The transcript text for this segment (already trimmed upstream). */
+  text: string;
+  /**
+   * `true` for the terminal segment (the post-speech-end tail). After the final
+   * segment's contiguous run is applied, {@link CloudSttSessionStitcher.isDone}
+   * reads true and {@link CloudSttSessionStitcher.running} is the whole
+   * utterance.
+   */
+  isFinal: boolean;
+}
+
+/** Split text into whitespace-delimited word tokens (empty in → empty out). */
+function toWords(text: string): string[] {
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+  return trimmed.split(/\s+/);
+}
+
+/** Case/punctuation-insensitive word key for seam matching. */
+function wordKey(word: string): string {
+  return word.toLowerCase().replace(/[^\p{L}\p{N}]+/gu, "");
+}
+
+/**
+ * Given the committed running words and an incoming segment's words, find how
+ * many leading words of the incoming segment duplicate the trailing words of
+ * the running text (the overlapped seam). Returns the count of incoming words
+ * to DROP before appending.
+ *
+ * Scans candidate overlap lengths from longest→shortest (bounded by a small
+ * window, since the audio overlap is ~200ms ≈ at most a few words) and picks
+ * the longest suffix/prefix match. Matching is on normalized word keys so
+ * "the," vs "the" and case differences at the seam still dedup.
+ */
+export function seamOverlapWordCount(
+  runningWords: readonly string[],
+  incomingWords: readonly string[],
+  maxOverlapWords = 6,
+): number {
+  const maxK = Math.min(
+    maxOverlapWords,
+    runningWords.length,
+    incomingWords.length,
+  );
+  for (let k = maxK; k >= 1; k -= 1) {
+    let matches = true;
+    for (let i = 0; i < k; i += 1) {
+      const tail = runningWords[runningWords.length - k + i];
+      const head = incomingWords[i];
+      if (
+        tail === undefined ||
+        head === undefined ||
+        wordKey(tail) !== wordKey(head) ||
+        wordKey(tail) === "" // don't match on punctuation-only tokens
+      ) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) return k;
+  }
+  return 0;
+}
+
+/**
+ * Accumulates ordered, seam-deduped segment transcripts into one running
+ * transcript for live composer rendering. Stateful, single-session; construct a
+ * fresh instance per capture turn (or call {@link reset}).
+ */
+export class CloudSttSessionStitcher {
+  /** Committed running words, in order, seam-deduped. */
+  private words: string[] = [];
+  /** Highest contiguous seq applied so far; -1 before the first segment. */
+  private appliedThrough = -1;
+  /** Segments received ahead of the contiguous frontier, keyed by seq. */
+  private readonly pending = new Map<number, CloudSttSegment>();
+  /** True once the final segment's contiguous run has been applied. */
+  private finalized = false;
+  private readonly maxOverlapWords: number;
+
+  constructor(options: { maxOverlapWords?: number } = {}) {
+    this.maxOverlapWords = options.maxOverlapWords ?? 6;
+  }
+
+  /** Current stitched running transcript (may be empty before any segment). */
+  get running(): string {
+    return this.words.join(" ");
+  }
+
+  /** True once the final segment has been applied (whole utterance committed). */
+  get isDone(): boolean {
+    return this.finalized;
+  }
+
+  /**
+   * Ingest a segment. Applies it (and any now-contiguous buffered successors)
+   * if it fills the frontier, else buffers it for later. Idempotent on a
+   * re-delivered `seq`. Returns the running transcript after applying whatever
+   * became contiguous (unchanged when the segment was buffered/duplicate).
+   */
+  push(segment: CloudSttSegment): string {
+    // Idempotent: an already-applied or negative seq is a no-op (retry that
+    // resolved twice, or a stale delivery after teardown).
+    if (segment.seq <= this.appliedThrough || segment.seq < 0) {
+      return this.running;
+    }
+    // Buffer a segment that arrives ahead of the frontier; keep the first copy
+    // seen for a given seq (idempotent on duplicate delivery).
+    if (segment.seq !== this.appliedThrough + 1) {
+      if (!this.pending.has(segment.seq)) {
+        this.pending.set(segment.seq, segment);
+      }
+      return this.running;
+    }
+    // Apply this segment and drain the contiguous run that now follows.
+    let next: CloudSttSegment | undefined = segment;
+    while (next && next.seq === this.appliedThrough + 1) {
+      this.applyContiguous(next);
+      this.appliedThrough = next.seq;
+      this.pending.delete(next.seq);
+      next = this.pending.get(this.appliedThrough + 1);
+    }
+    return this.running;
+  }
+
+  /** Append one already-in-order segment, trimming the duplicated seam. */
+  private applyContiguous(segment: CloudSttSegment): void {
+    if (segment.isFinal) this.finalized = true;
+    const incoming = toWords(segment.text);
+    if (incoming.length === 0) return;
+    const drop = seamOverlapWordCount(
+      this.words,
+      incoming,
+      this.maxOverlapWords,
+    );
+    for (let i = drop; i < incoming.length; i += 1) {
+      const word = incoming[i];
+      if (word !== undefined) this.words.push(word);
+    }
+  }
+
+  /**
+   * Whether every segment up to and including a known-final seq has landed.
+   * When a caller knows the final seq (assigned at capture stop) it can poll
+   * this to decide the stitched `running` is the whole utterance even if the
+   * final segment's own `isFinal` flag was lost to a retry.
+   */
+  hasContiguousThrough(seq: number): boolean {
+    return this.appliedThrough >= seq;
+  }
+
+  /** Count of buffered (not-yet-contiguous) segments awaiting a gap fill. */
+  get pendingCount(): number {
+    return this.pending.size;
+  }
+
+  /** Reset to a fresh session (reuse the instance across capture turns). */
+  reset(): void {
+    this.words = [];
+    this.appliedThrough = -1;
+    this.pending.clear();
+    this.finalized = false;
+  }
+}

--- a/packages/ui/src/voice/index.ts
+++ b/packages/ui/src/voice/index.ts
@@ -80,6 +80,13 @@ export {
   DEFAULT_CLOUD_STT_SEGMENTER,
 } from "./cloud-stt-segmenter";
 export {
+  type AutoSendDecision,
+  type VoiceAutoSendConfig,
+  DEFAULT_VOICE_AUTOSEND,
+  evaluateAutoSend,
+} from "./voice-autosend-config";
+export { isVadDebugEnabled, vadDebug, type VadDebugEvent } from "./vad-debug";
+export {
   downmixAudioBufferToMono,
   type PlaybackAudioFrameEvent,
   PlaybackFramePump,

--- a/packages/ui/src/voice/index.ts
+++ b/packages/ui/src/voice/index.ts
@@ -59,10 +59,26 @@ export {
   type SpeakerResolver,
 } from "./jni-voice-pipeline";
 export {
+  type CloudSttSegmentMeta,
+  type TranscribeCloudSegmentOptions,
   type TranscribeWavOptions,
   type TranscribeWavResult,
+  encodeAsrSegmentHeader,
+  transcribeCloudSegment,
   transcribeLocalInferenceWav,
 } from "./local-asr-transcribe";
+export {
+  type CloudSttSegment,
+  CloudSttSessionStitcher,
+  seamOverlapWordCount,
+} from "./cloud-stt-stitcher";
+export {
+  type CloudSttSegmenterConfig,
+  type CloudSttSegmenterOptions,
+  type CloudSttSegmenterUpdate,
+  createCloudSttSegmenter,
+  DEFAULT_CLOUD_STT_SEGMENTER,
+} from "./cloud-stt-segmenter";
 export {
   downmixAudioBufferToMono,
   type PlaybackAudioFrameEvent,

--- a/packages/ui/src/voice/local-asr-capture.test.ts
+++ b/packages/ui/src/voice/local-asr-capture.test.ts
@@ -121,6 +121,149 @@ describe("local ASR capture", () => {
   });
 });
 
+describe("startLocalAsrRecorder chunked-streaming segmenter (voice V2a)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // Stand up a fake browser audio stack that lets us drive onaudioprocess with
+  // synthetic frames and capture the emitted segments.
+  function fakeAudioStack() {
+    const trackStop = vi.fn();
+    const stream = {
+      getTracks: () => [{ stop: trackStop }],
+    } as unknown as MediaStream;
+    const getUserMedia = vi.fn().mockResolvedValue(stream);
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia } });
+
+    let onProcess: ((event: unknown) => void) | null = null;
+    const processor = {
+      set onaudioprocess(fn: ((event: unknown) => void) | null) {
+        onProcess = fn;
+      },
+      get onaudioprocess() {
+        return onProcess;
+      },
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    };
+    class FakeAudioContext {
+      state = "running";
+      sampleRate = 16000;
+      resume = vi.fn().mockResolvedValue(undefined);
+      close = vi.fn().mockResolvedValue(undefined);
+      createMediaStreamSource = vi.fn(() => ({ connect: vi.fn(), disconnect: vi.fn() }));
+      createScriptProcessor = vi.fn(() => processor);
+      createAnalyser = vi.fn(() => ({
+        fftSize: 0,
+        smoothingTimeConstant: 0,
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+      }));
+      destination = {};
+    }
+    vi.stubGlobal("window", {
+      AudioContext: FakeAudioContext,
+      setTimeout: (fn: () => void) => setTimeout(fn, 0),
+    });
+    return {
+      drive: (frame: Float32Array) => {
+        onProcess?.({
+          inputBuffer: {
+            length: frame.length,
+            numberOfChannels: 1,
+            getChannelData: () => frame,
+          },
+        });
+      },
+    };
+  }
+
+  it("emits mid-capture segments on boundaries and a final on stop", async () => {
+    const stack = fakeAudioStack();
+    const segments: { seq: number; isFinal: boolean; bytes: number }[] = [];
+    // A segmenter stub that cuts a boundary on every 3rd frame (deterministic).
+    let n = 0;
+    const recorder = await startLocalAsrRecorder({
+      segmenter: {
+        update: () => {
+          n += 1;
+          return { boundary: n % 3 === 0, speech: true };
+        },
+        config: { overlapMs: 0 },
+      },
+      onSegment: (s) =>
+        segments.push({ seq: s.seq, isFinal: s.isFinal, bytes: s.wav.length }),
+    });
+
+    // 6 loud frames → boundaries after frame 3 and frame 6 → 2 mid segments.
+    const loud = new Float32Array(320).fill(0.3);
+    for (let i = 0; i < 6; i += 1) stack.drive(loud);
+    expect(segments.filter((s) => !s.isFinal)).toHaveLength(2);
+    expect(segments.map((s) => s.seq)).toEqual([0, 1]);
+
+    await recorder.stop();
+    // The stop() flush emits the terminal segment (seq 2, isFinal).
+    const finals = segments.filter((s) => s.isFinal);
+    expect(finals).toHaveLength(1);
+    expect(finals[0]?.seq).toBe(2);
+  });
+
+  it("drops a silent mid-segment without consuming a seq", async () => {
+    const stack = fakeAudioStack();
+    const segments: { seq: number; isFinal: boolean }[] = [];
+    let n = 0;
+    const recorder = await startLocalAsrRecorder({
+      segmenter: {
+        update: () => {
+          n += 1;
+          return { boundary: n % 2 === 0, speech: true };
+        },
+        config: { overlapMs: 0 },
+      },
+      onSegment: (s) => segments.push({ seq: s.seq, isFinal: s.isFinal }),
+    });
+
+    const silent = new Float32Array(320).fill(0);
+    // Boundary on frame 2 over silence → dropped, no seq consumed.
+    stack.drive(silent);
+    stack.drive(silent);
+    expect(segments).toHaveLength(0);
+
+    // Now a real segment: boundary on frame 4 over speech → seq 0.
+    const loud = new Float32Array(320).fill(0.3);
+    stack.drive(loud);
+    stack.drive(loud);
+    expect(segments).toEqual([{ seq: 0, isFinal: false }]);
+
+    await recorder.stop();
+  });
+
+  it("emits a header-only final marker when the trailing tail is silent", async () => {
+    const stack = fakeAudioStack();
+    const segments: { seq: number; isFinal: boolean; bytes: number }[] = [];
+    const recorder = await startLocalAsrRecorder({
+      segmenter: {
+        update: () => ({ boundary: false, speech: false }),
+        config: { overlapMs: 0 },
+      },
+      onSegment: (s) =>
+        segments.push({ seq: s.seq, isFinal: s.isFinal, bytes: s.wav.length }),
+    });
+
+    // Feed only silence into the (never-cut) pending segment. On stop() the tail
+    // is silent, so the final marker is emitted as a header-only WAV (44 bytes)
+    // — the sink recognizes this and finalizes the stitcher without a POST.
+    const silent = new Float32Array(320).fill(0);
+    stack.drive(silent);
+    stack.drive(silent);
+    await recorder.stop();
+    const finals = segments.filter((s) => s.isFinal);
+    expect(finals).toHaveLength(1);
+    expect(finals[0]?.bytes).toBe(44); // RIFF header only, no PCM data
+  });
+});
+
 describe("startLocalAsrRecorder resume failure", () => {
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/packages/ui/src/voice/local-asr-capture.ts
+++ b/packages/ui/src/voice/local-asr-capture.ts
@@ -32,9 +32,44 @@ export interface LocalAsrAutoStopOptions {
   isTtsEchoGateActive?: (nowMs: number) => boolean;
 }
 
+/**
+ * A segment cut mid-capture by the chunked-streaming segmenter (voice V2a).
+ * Carries the buffered-since-last-boundary audio (WAV-encoded, including the
+ * retained seam overlap) plus its monotonic `seq` and whether it is the
+ * terminal segment. The recorder produces these WHILE the user speaks; the
+ * caller POSTs each to the batch cloud STT endpoint and stitches the results.
+ */
+export interface LocalAsrSegment {
+  /** Monotonic 0-based segment index for this capture turn. */
+  seq: number;
+  /** Mono PCM16 WAV for the buffered-since-last-boundary audio (with overlap). */
+  wav: Uint8Array;
+  /** True for the terminal segment emitted at stop() (the post-speech tail). */
+  isFinal: boolean;
+}
+
 export interface LocalAsrRecorderOptions {
   autoStop?: LocalAsrAutoStopOptions;
   onAutoStop?: () => void;
+  /**
+   * Chunked-streaming segmenter (voice V2a). When BOTH `segmenter` and
+   * `onSegment` are supplied, the recorder cuts intermediate segments as the
+   * per-frame `segmenter` reports boundaries — encoding the frames buffered
+   * since the last boundary (plus an `overlapMs` audio tail carried from the
+   * previous segment for seam continuity) to a WAV and delivering it via
+   * `onSegment`. The full-utterance WAV returned by `stop()` is UNCHANGED, so a
+   * caller can always fall back to the batch path if streaming stitching fails.
+   * Absent → the recorder behaves exactly as before (batch-only).
+   */
+  segmenter?: {
+    update: (
+      pcm: Float32Array,
+      sampleTimeMs?: number,
+    ) => { boundary: boolean; speech: boolean };
+    config: { overlapMs: number };
+  };
+  /** Called (fire-and-forget) with each mid-capture segment when `segmenter` is set. */
+  onSegment?: (segment: LocalAsrSegment) => void;
 }
 
 /** Fully-resolved auto-stop config (every {@link LocalAsrAutoStopOptions} field set). */
@@ -427,6 +462,71 @@ export async function startLocalAsrRecorder(
   let autoStopRequested = false;
   const autoStopDetector = createLocalAsrAutoStopDetector(options.autoStop);
 
+  // Chunked-streaming (voice V2a) segmenter state. Active only when both a
+  // segmenter and an onSegment sink are supplied; otherwise the capture is
+  // batch-only and none of this runs.
+  const segmenter =
+    options.segmenter && options.onSegment ? options.segmenter : null;
+  const onSegment = segmenter ? options.onSegment : undefined;
+  const overlapMs = segmenter?.config.overlapMs ?? 0;
+  // Frames buffered since the last emitted segment boundary (the pending
+  // segment's audio). Reset (minus the retained overlap tail) at each boundary.
+  let segmentChunks: Float32Array[] = [];
+  let segmentSeq = 0;
+
+  /** Encode + emit the pending segment buffer as segment `segmentSeq`. */
+  const emitSegment = (isFinal: boolean): void => {
+    if (!onSegment) return;
+    const pcm = concatPcm(segmentChunks);
+    const silent = pcm.length === 0 || isSilentPcmAudio(pcm);
+    // Never POST an empty/near-silent NON-FINAL segment (mirrors the stop()
+    // silence guard): a mid-utterance boundary with no speech is dropped, not
+    // sent — no seq is consumed, so the stitcher's sequence stays contiguous.
+    if (silent && !isFinal) {
+      resetSegmentBuffer();
+      return;
+    }
+    // A silent FINAL tail (trailing silence after the last word) still needs a
+    // final marker so the stitcher finalizes on the content already streamed —
+    // otherwise a clean streamed utterance whose tail is quiet would never mark
+    // done and would always fall back to batch. Emit an empty-WAV final: the
+    // segment transcriber returns "" (empty segments are allowed), and the
+    // stitcher's applyContiguous flags done without appending words.
+    const wav = silent
+      ? encodeMonoPcm16Wav(new Float32Array(0), context.sampleRate)
+      : encodeMonoPcm16Wav(pcm, context.sampleRate);
+    const seq = segmentSeq;
+    segmentSeq += 1;
+    if (!isFinal) resetSegmentBuffer();
+    // Fire-and-forget: a slow/failed POST must not stall the audio thread.
+    try {
+      onSegment({ seq, wav, isFinal });
+    } catch {
+      // error-policy:J6 segment sink is best-effort; a throwing sink must not
+      // kill the capture. The stop() full-WAV batch path remains the fallback.
+    }
+  };
+
+  /**
+   * Reset the pending-segment buffer to the retained overlap tail (~overlapMs
+   * of the just-emitted audio) so the next segment shares a seam with this one
+   * — the stitcher dedups the overlapped words.
+   */
+  const resetSegmentBuffer = (): void => {
+    if (overlapMs <= 0) {
+      segmentChunks = [];
+      return;
+    }
+    const overlapSamples = Math.round((overlapMs / 1000) * context.sampleRate);
+    if (overlapSamples <= 0) {
+      segmentChunks = [];
+      return;
+    }
+    const whole = concatPcm(segmentChunks);
+    const start = Math.max(0, whole.length - overlapSamples);
+    segmentChunks = start < whole.length ? [whole.subarray(start)] : [];
+  };
+
   processor.onaudioprocess = (event) => {
     if (stopped) return;
     const input = event.inputBuffer;
@@ -447,6 +547,18 @@ export async function startLocalAsrRecorder(
     };
     if (autoStopUpdate.shouldBuffer) {
       chunks.push(mono);
+    }
+    // Chunked-streaming segmenter (voice V2a): buffer the pending segment and
+    // cut a boundary when it reports one. Runs independently of the auto-stop
+    // buffer gate — the segment buffer always accumulates the raw frame so a
+    // pause between clauses still carries into the seam overlap, while the
+    // full-utterance `chunks` obeys the existing VAD gate untouched.
+    if (segmenter) {
+      segmentChunks.push(mono);
+      const seg = segmenter.update(mono);
+      if (seg.boundary) {
+        emitSegment(false);
+      }
     }
     if (autoStopUpdate.shouldStop && !autoStopRequested && options.onAutoStop) {
       autoStopRequested = true;
@@ -489,6 +601,12 @@ export async function startLocalAsrRecorder(
     },
     async stop() {
       const sampleRate = context.sampleRate;
+      // Flush the terminal streaming segment (the post-speech tail) BEFORE
+      // tearing down, so the stitcher can finalize while the batch full-WAV is
+      // computed. No-op when streaming isn't active or the tail is silent.
+      if (segmenter && onSegment) {
+        emitSegment(true);
+      }
       await cleanup();
       const pcm = concatPcm(chunks);
       if (pcm.length === 0) {

--- a/packages/ui/src/voice/local-asr-transcribe.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.ts
@@ -289,6 +289,133 @@ export async function transcribeCloudWav(
   }
 }
 
+/** Metadata for a chunked-streaming segment POST (voice V2a). Sent as the
+ * `X-Asr-Segment` header so the proxy/route can forward it (Phase 1 keeps the
+ * proxy stateless — the header is passthrough-only; stitching is client-side). */
+export interface CloudSttSegmentMeta {
+  /** Opaque per-capture session id so a stateful proxy could group segments. */
+  sessionId: string;
+  /** Monotonic 0-based segment index. */
+  seq: number;
+  /** True for the terminal (post-speech tail) segment. */
+  isFinal: boolean;
+}
+
+export interface TranscribeCloudSegmentOptions extends TranscribeCloudWavOptions {
+  segment: CloudSttSegmentMeta;
+}
+
+/**
+ * Serialize {@link CloudSttSegmentMeta} for the `X-Asr-Segment` header. Kept a
+ * compact `sessionId;seq;isFinal` triple (not JSON) so it survives header
+ * normalization and is trivial to parse server-side if a stateful proxy ever
+ * wants it. Exported for the proxy/route test to assert the wire shape.
+ */
+export function encodeAsrSegmentHeader(meta: CloudSttSegmentMeta): string {
+  return `${meta.sessionId};${meta.seq};${meta.isFinal ? 1 : 0}`;
+}
+
+/**
+ * POST one chunked-streaming segment (voice V2a). Identical transport to
+ * {@link transcribeCloudWav} — same shared-tier-vs-dedicated route selection,
+ * same timeout + single retry, same fail-loud empty/terminal-error handling —
+ * but adds the `X-Asr-Segment` header so the segment is attributable end-to-end,
+ * and (crucially) does NOT throw on an empty transcript: a mid-utterance
+ * segment can legitimately transcribe to nothing (a breath, a seam of silence),
+ * and that must not error the whole live turn. An empty segment resolves to
+ * `""` and the stitcher simply appends no words.
+ */
+export async function transcribeCloudSegment(
+  audio: Uint8Array,
+  options: TranscribeCloudSegmentOptions,
+): Promise<string> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_CLOUD_STT_TIMEOUT_MS;
+  const callerSignal = options.signal;
+  const segmentHeader = encodeAsrSegmentHeader(options.segment);
+
+  const attempt = async (): Promise<string> => {
+    const timeoutController = new AbortController();
+    const timer = setTimeout(() => timeoutController.abort(), timeoutMs);
+    const onCallerAbort = () => timeoutController.abort();
+    if (callerSignal) {
+      if (callerSignal.aborted) timeoutController.abort();
+      else callerSignal.addEventListener("abort", onCallerAbort, { once: true });
+    }
+    try {
+      const sharedOrigin = currentSharedRuntimeVoiceOrigin();
+      const res = sharedOrigin
+        ? await fetchWithCsrf(sharedRuntimeSttUrl(sharedOrigin), {
+            method: "POST",
+            headers: {
+              Accept: "application/json",
+              "X-Asr-Segment": segmentHeader,
+            },
+            body: buildSharedRuntimeSttBody(audio),
+            signal: timeoutController.signal,
+          })
+        : await fetchWithCsrf(resolveApiUrl("/api/asr/cloud"), {
+            method: "POST",
+            headers: {
+              "Content-Type": "audio/wav",
+              Accept: "application/json",
+              "X-Asr-Segment": segmentHeader,
+            },
+            body: audio as BodyInit,
+            signal: timeoutController.signal,
+          });
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        throw new CloudSttError(
+          `Cloud ASR segment ${res.status}: ${body.slice(0, 200)}`,
+          { status: res.status, retryable: isRetryableStatus(res.status) },
+        );
+      }
+      const parsed = (await res.json().catch(() => null)) as {
+        text?: unknown;
+        transcript?: unknown;
+      } | null;
+      const text = sharedOrigin
+        ? parseSharedRuntimeSttResponse(parsed)
+        : typeof parsed?.text === "string"
+          ? parsed.text.trim()
+          : "";
+      // Segments may legitimately be empty — unlike the batch whole-utterance
+      // path, this is NOT an error (it's a silent seam / breath).
+      return text;
+    } catch (err) {
+      if (err instanceof CloudSttError) throw err;
+      if (callerSignal?.aborted) {
+        throw new CloudSttError("Cloud ASR segment was cancelled", {
+          retryable: false,
+          cause: err,
+        });
+      }
+      if (timeoutController.signal.aborted) {
+        throw new CloudSttError(
+          `Cloud ASR segment timed out after ${timeoutMs}ms`,
+          { retryable: true, cause: err },
+        );
+      }
+      throw new CloudSttError(
+        `Cloud ASR segment request failed: ${err instanceof Error ? err.message : String(err)}`,
+        { retryable: true, cause: err },
+      );
+    } finally {
+      clearTimeout(timer);
+      callerSignal?.removeEventListener("abort", onCallerAbort);
+    }
+  };
+
+  try {
+    return await attempt();
+  } catch (err) {
+    if (err instanceof CloudSttError && err.retryable && !callerSignal?.aborted) {
+      return await attempt();
+    }
+    throw err;
+  }
+}
+
 export async function transcribeLocalInferenceWav(
   audio: Uint8Array,
   options?: TranscribeWavOptions,

--- a/packages/ui/src/voice/vad-debug.test.ts
+++ b/packages/ui/src/voice/vad-debug.test.ts
@@ -1,0 +1,37 @@
+// Unit test for the VAD debug logger (voice V2a QA affordance). Verifies it is
+// a genuine no-op when the env flag is off (owner ask: cheap-when-off), and
+// logs with the [eliza][vad] prefix when on.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetVadDebugCacheForTests,
+  isVadDebugEnabled,
+  vadDebug,
+} from "./vad-debug";
+
+describe("vadDebug", () => {
+  afterEach(() => {
+    delete process.env.ELIZA_VAD_DEBUG;
+    __resetVadDebugCacheForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("is a no-op when ELIZA_VAD_DEBUG is unset", () => {
+    __resetVadDebugCacheForTests();
+    const spy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    expect(isVadDebugEnabled()).toBe(false);
+    vadDebug("auto-stop", { mode: "compose" });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("logs with the [eliza][vad] prefix when enabled", () => {
+    process.env.ELIZA_VAD_DEBUG = "1";
+    __resetVadDebugCacheForTests();
+    const spy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    expect(isVadDebugEnabled()).toBe(true);
+    vadDebug("auto-send-suppressed", { reason: "too-few-words" });
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0]?.[0]).toContain("[eliza][vad] auto-send-suppressed");
+    expect(spy.mock.calls[0]?.[1]).toEqual({ reason: "too-few-words" });
+  });
+});

--- a/packages/ui/src/voice/vad-debug.ts
+++ b/packages/ui/src/voice/vad-debug.ts
@@ -1,0 +1,90 @@
+/**
+ * VAD / end-of-speech decision tracing (opt-in). Prefix: `[eliza][vad]`.
+ *
+ * Owner ask (2026-07-07, voice V2a): "if cheap, expose a debug/QA affordance
+ * (e.g. dev-flag logging of VAD decisions: speech-start / speech-end timestamps
+ * + why) so device testing can tell us WHY a cutoff mis-fired." This is that
+ * affordance — a zero-cost-when-off logger for the auto-stop + auto-send
+ * decisions so on-device QA can see the reason a turn ended (or an auto-send was
+ * suppressed) instead of guessing.
+ *
+ * Enable with `ELIZA_VAD_DEBUG=1` (Node) or the Vite-mirrored env in the
+ * renderer (same mechanism as ELIZA_TTS_DEBUG). Off by default — no logging,
+ * no allocation on the audio hot path (the gate short-circuits before building
+ * the detail object).
+ *
+ * NOTE: with debug ON, `transcriptPreview` fields may contain user-visible
+ * spoken text. Disable in shared logs / production.
+ */
+
+type RuntimeImportMeta = ImportMeta & {
+  env?: Record<string, unknown>;
+};
+
+function truthy(raw: string | undefined | null): boolean {
+  if (raw == null) return false;
+  const v = String(raw).trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes" || v === "on";
+}
+
+let cachedEnabled: boolean | null = null;
+
+function vadDebugEnabled(): boolean {
+  if (cachedEnabled !== null) return cachedEnabled;
+  let enabled = false;
+  if (typeof process !== "undefined" && process.env) {
+    if (truthy(process.env.ELIZA_VAD_DEBUG)) enabled = true;
+  }
+  if (!enabled) {
+    try {
+      const viteEnv = (import.meta as RuntimeImportMeta).env;
+      if (
+        truthy(String(viteEnv?.ELIZA_VAD_DEBUG ?? "")) ||
+        truthy(String(viteEnv?.VITE_ELIZA_VAD_DEBUG ?? ""))
+      ) {
+        enabled = true;
+      }
+    } catch {
+      /* no import.meta */
+    }
+  }
+  cachedEnabled = enabled;
+  return enabled;
+}
+
+/** Same predicate — use to guard building an expensive detail object. */
+export function isVadDebugEnabled(): boolean {
+  return vadDebugEnabled();
+}
+
+/** VAD lifecycle events surfaced for QA. */
+export type VadDebugEvent =
+  | "speech-start"
+  | "speech-end"
+  | "auto-stop"
+  | "auto-send"
+  | "auto-send-suppressed";
+
+/**
+ * Log one VAD decision. No-op (and no allocation cost past the arg you pass)
+ * when `ELIZA_VAD_DEBUG` is off. Keep `detail` small + secret-free.
+ */
+export function vadDebug(
+  event: VadDebugEvent,
+  detail?: Record<string, unknown>,
+): void {
+  if (!vadDebugEnabled()) return;
+  const line = `[eliza][vad] ${event}`;
+  if (detail) {
+    // eslint-disable-next-line no-console
+    console.debug(line, detail);
+  } else {
+    // eslint-disable-next-line no-console
+    console.debug(line);
+  }
+}
+
+/** Reset the cached enable flag (tests toggle the env between cases). */
+export function __resetVadDebugCacheForTests(): void {
+  cachedEnabled = null;
+}

--- a/packages/ui/src/voice/voice-autosend-config.test.ts
+++ b/packages/ui/src/voice/voice-autosend-config.test.ts
@@ -1,0 +1,53 @@
+// Unit tests for the auto-send reliability guards (voice V2a extension).
+// Pure logic — the "don't auto-send accidental noise" gate the owner flagged as
+// the reliability requirement for flipping the auto-send default later.
+
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_VOICE_AUTOSEND,
+  evaluateAutoSend,
+} from "./voice-autosend-config";
+
+describe("evaluateAutoSend", () => {
+  const cfg = DEFAULT_VOICE_AUTOSEND;
+
+  it("sends a normal multi-word utterance", () => {
+    expect(evaluateAutoSend("turn on the kitchen light", cfg, 1200)).toEqual({
+      send: true,
+      reason: "ok",
+    });
+  });
+
+  it("rejects an empty transcript", () => {
+    expect(evaluateAutoSend("   ", cfg, 1000).send).toBe(false);
+    expect(evaluateAutoSend("", cfg, 1000).reason).toBe("empty");
+  });
+
+  it("rejects a too-short transcript (below min chars)", () => {
+    const d = evaluateAutoSend("ok", { ...cfg, minTranscriptChars: 5 }, 1000);
+    expect(d).toEqual({ send: false, reason: "too-few-chars" });
+  });
+
+  it("rejects a single-word utterance (accidental 'hey')", () => {
+    const d = evaluateAutoSend("hey", cfg, 1000);
+    expect(d).toEqual({ send: false, reason: "too-few-words" });
+  });
+
+  it("rejects a blip shorter than the min speech duration", () => {
+    // Two words, clears char/word gates, but only 100ms of speech → noise.
+    const d = evaluateAutoSend("uh huh", cfg, 100);
+    expect(d).toEqual({ send: false, reason: "too-short-speech" });
+  });
+
+  it("skips the duration gate when speechDurationMs is unknown", () => {
+    // Transcript-only backends may not surface duration; char/word gates still
+    // apply, and a valid multi-word utterance still sends.
+    expect(evaluateAutoSend("hello there", cfg).send).toBe(true);
+  });
+
+  it("has conservative defaults (safe to ship off, flip later)", () => {
+    expect(DEFAULT_VOICE_AUTOSEND.minTranscriptWords).toBeGreaterThanOrEqual(2);
+    expect(DEFAULT_VOICE_AUTOSEND.minSpeechMs).toBeGreaterThan(0);
+    expect(DEFAULT_VOICE_AUTOSEND.minTranscriptChars).toBeGreaterThan(0);
+  });
+});

--- a/packages/ui/src/voice/voice-autosend-config.ts
+++ b/packages/ui/src/voice/voice-autosend-config.ts
@@ -1,0 +1,132 @@
+/**
+ * Auto-send + VAD tunables — ONE clearly-named home (voice V2a extension).
+ *
+ * Owner direction (2026-07-07): auto-send on end-of-speech ships IN this PR but
+ * OFF by default (composer-review is the launch default; auto-send flips to
+ * default "only once it works reliably"). VAD end-of-speech detection is now
+ * first-class: its parameters must be TUNABLE constants in one place, not magic
+ * numbers scattered across the capture loop, because we iterate on-device.
+ *
+ * This module centralizes:
+ *   1. The auto-send end-of-turn VAD window + the reliability guards that gate
+ *      whether an auto-detected turn is safe to SEND (vs a stray noise blip).
+ *   2. The minimum-transcript guard (don't auto-send empty / one-token accidental
+ *      noise — the reliability gate for flipping the default later).
+ *
+ * The base energy VAD thresholds (`speechRmsThreshold` / `speechPeakThreshold` /
+ * `silenceMs` for hands-free turn-end) live in `local-asr-capture.ts`
+ * `DEFAULT_LOCAL_ASR_AUTO_STOP` (#15267) and are user-tunable via
+ * `loadVadAutoStop()`. Auto-send REUSES those — it does not fork a second VAD.
+ * What lives here is the auto-send-specific policy layered on top.
+ */
+
+import { DEFAULT_LOCAL_ASR_AUTO_STOP } from "./local-asr-capture";
+
+/**
+ * Tunables for auto-send on end-of-speech. Kept as one exported const so
+ * on-device iteration edits a single, named place. Every value is overridable
+ * per-call (the composer threads the persisted VAD `silenceMs` in, so a user's
+ * tuned turn-end window still wins for auto-send too).
+ */
+export interface VoiceAutoSendConfig {
+  /**
+   * Trailing-silence window (ms) that ends an auto-send turn. Defaults to the
+   * shared hands-free turn-end window so auto-send and hands-free feel the same;
+   * a slightly LONGER window is defensible for auto-send (a premature cutoff
+   * there SENDS a truncated message, which is worse than a premature cutoff in
+   * review mode where the user still edits). Start matched; iterate on-device.
+   */
+  silenceMs: number;
+  /**
+   * Minimum number of transcript CHARACTERS required to auto-send. Below this,
+   * the detected turn is treated as accidental noise and NOT sent (the capture
+   * still finalizes into the composer draft so nothing is lost — the user can
+   * review/edit/send manually). Reliability gate #1.
+   */
+  minTranscriptChars: number;
+  /**
+   * Minimum number of transcript WORDS required to auto-send. A single-token
+   * "uh" / "hm" / a mis-fired word from a cough clears the char floor but is
+   * still likely noise; require at least this many words. Reliability gate #2.
+   */
+  minTranscriptWords: number;
+  /**
+   * Minimum captured SPEECH duration (ms) before an auto-send turn is eligible.
+   * A sub-threshold blip (door slam, keyboard clack read as speech) that somehow
+   * produced a transcript is rejected. Reuses the base VAD `minSpeechMs` idea
+   * but at a higher bar for the send decision. Reliability gate #3.
+   */
+  minSpeechMs: number;
+}
+
+/**
+ * Default auto-send policy. Conservative by design — the whole point of shipping
+ * auto-send OFF-by-default is that these must be provably safe before the
+ * default flips. Bump the guards UP if false-sends appear in device testing;
+ * loosen only with evidence.
+ */
+export const DEFAULT_VOICE_AUTOSEND: VoiceAutoSendConfig = {
+  // Match the shared hands-free turn-end window (650ms, #voice-V6) so the felt
+  // turn-end timing is consistent across modes. On-device we may lengthen this
+  // for auto-send specifically (see the silenceMs docblock).
+  silenceMs: DEFAULT_LOCAL_ASR_AUTO_STOP.silenceMs,
+  // ~2 short words. Below this, almost certainly not an intended message.
+  minTranscriptChars: 3,
+  // "turn on" is 2 words; "hey" alone (1 word) should NOT auto-send.
+  minTranscriptWords: 2,
+  // 300ms of speech: longer than the base 180ms min-speech so a brief blip that
+  // squeaked past the base VAD still can't trigger a SEND.
+  minSpeechMs: 300,
+};
+
+/** Result of the auto-send reliability check, with a reason for QA/debug logs. */
+export interface AutoSendDecision {
+  send: boolean;
+  /** Machine-readable reason (drives the VAD debug log — owner ask 3b). */
+  reason:
+    | "ok"
+    | "empty"
+    | "too-few-chars"
+    | "too-few-words"
+    | "too-short-speech"
+    | "disabled";
+}
+
+/** Count whitespace-delimited words in a transcript. */
+function wordCount(text: string): number {
+  const t = text.trim();
+  return t ? t.split(/\s+/).length : 0;
+}
+
+/**
+ * Decide whether an auto-detected end-of-speech turn is safe to SEND.
+ *
+ * This is the reliability gate the owner flagged for flipping the default
+ * later: it must reject empty / one-token accidental noise. When it returns
+ * `send:false`, the caller finalizes the transcript into the composer draft
+ * (review mode) instead of sending — nothing is lost, the user just confirms.
+ *
+ * `speechDurationMs` is optional: transcript-only backends may not surface it,
+ * in which case the duration gate is skipped (the char/word gates still apply).
+ */
+export function evaluateAutoSend(
+  transcript: string,
+  config: VoiceAutoSendConfig,
+  speechDurationMs?: number,
+): AutoSendDecision {
+  const trimmed = transcript.trim();
+  if (!trimmed) return { send: false, reason: "empty" };
+  if (trimmed.length < config.minTranscriptChars) {
+    return { send: false, reason: "too-few-chars" };
+  }
+  if (wordCount(trimmed) < config.minTranscriptWords) {
+    return { send: false, reason: "too-few-words" };
+  }
+  if (
+    typeof speechDurationMs === "number" &&
+    speechDurationMs < config.minSpeechMs
+  ) {
+    return { send: false, reason: "too-short-speech" };
+  }
+  return { send: true, reason: "ok" };
+}

--- a/packages/ui/src/voice/voice-capture-factory.ts
+++ b/packages/ui/src/voice/voice-capture-factory.ts
@@ -37,13 +37,17 @@ import {
   isSilentWav,
   type LocalAsrAutoStopOptions,
   type LocalAsrRecorder,
+  type LocalAsrSegment,
   startLocalAsrRecorder,
 } from "./local-asr-capture";
 import {
   isLocalInferenceAsrReady,
+  transcribeCloudSegment,
   transcribeCloudWav,
   transcribeLocalInferenceWav,
 } from "./local-asr-transcribe";
+import { createCloudSttSegmenter } from "./cloud-stt-segmenter";
+import { CloudSttSessionStitcher } from "./cloud-stt-stitcher";
 import {
   getSpeechRecognitionCtor,
   type SpeechRecognitionInstance,
@@ -126,6 +130,17 @@ export interface VoiceCaptureFactoryOptions {
    * and a manual stop must NOT submit a partial turn.
    */
   finalizeOnStop?: boolean;
+  /**
+   * Enable chunked-segment incremental transcription (voice V2a) for the CLOUD
+   * backend: POST short audio segments as the user speaks and emit the stitched
+   * running transcript as NON-FINAL `onTranscript` segments (live preview),
+   * finalizing on stop(). No-op for non-cloud backends. Defaults to `false`
+   * here (the ambient/desktop factory has no live composer surface by default);
+   * `useVoiceChat` drives the composer's streaming separately. Always degrades
+   * to the batch full-WAV transcription when segmentation is unsupported or a
+   * segment hard-fails.
+   */
+  cloudStreaming?: boolean;
 }
 
 export interface VoiceCaptureHandle {
@@ -223,7 +238,63 @@ export function createVoiceCapture(
     lang = "en-US",
     localAsrAutoStop,
     finalizeOnStop = false,
+    cloudStreaming = false,
   } = options;
+
+  // Chunked-streaming cloud STT session (voice V2a). Built per capture turn when
+  // cloudStreaming is on AND the resolved backend is cloud. Torn down on stop /
+  // dispose. Kept null otherwise (batch path unchanged).
+  let streamStitcher: CloudSttSessionStitcher | null = null;
+  let streamSessionId: string | null = null;
+  let streamAbort: AbortController | null = null;
+  let streamInflight: Set<Promise<void>> = new Set();
+  let streamDegraded = false;
+
+  function teardownStreamSession(): void {
+    streamAbort?.abort();
+    streamAbort = null;
+    streamStitcher = null;
+    streamSessionId = null;
+    streamInflight = new Set();
+    streamDegraded = false;
+  }
+
+  function handleStreamSegment(segment: LocalAsrSegment): void {
+    const stitcher = streamStitcher;
+    const sessionId = streamSessionId;
+    const abort = streamAbort;
+    if (!stitcher || !sessionId || !abort) return;
+    // Empty-data final marker (silent tail, header-only WAV): finalize without a
+    // doomed POST of a data-less WAV.
+    if (segment.isFinal && segment.wav.length <= 44) {
+      const running = stitcher.push({ seq: segment.seq, text: "", isFinal: true });
+      if (running) onTranscript({ text: running, final: false, backend: "cloud" });
+      return;
+    }
+    const task = (async () => {
+      try {
+        const text = await transcribeCloudSegment(segment.wav, {
+          signal: abort.signal,
+          segment: { sessionId, seq: segment.seq, isFinal: segment.isFinal },
+        });
+        if (streamStitcher !== stitcher) return; // superseded turn
+        const running = stitcher.push({
+          seq: segment.seq,
+          text,
+          isFinal: segment.isFinal,
+        });
+        // Live preview only — never final here; the turn's final commits at stop().
+        if (running) {
+          onTranscript({ text: running, final: false, backend: "cloud" });
+        }
+      } catch {
+        if (abort.signal.aborted) return; // expected on teardown/barge-in
+        streamDegraded = true; // distrust the partial stitch at stop()
+      }
+    })();
+    streamInflight.add(task);
+    void task.finally(() => streamInflight.delete(task));
+  }
   // Resolved on start() — the server-readiness probe is async, so the backend
   // choice is deferred from construction to the first start() call.
   let backendKind: VoiceCaptureBackend | null = null;
@@ -249,8 +320,33 @@ export function createVoiceCapture(
   // identical mic setup; the backends diverge only at stop() (which route the
   // WAV is POSTed to).
   async function startWavRecorder(): Promise<void> {
+    // Stand up the streaming session only for the cloud backend with streaming
+    // enabled. The local-inference backend keeps the batch path (free/offline;
+    // no felt-latency motivation to chunk).
+    const streamThisTurn = cloudStreaming && backendKind === "cloud";
+    let segmentWiring: Pick<
+      Parameters<typeof startLocalAsrRecorder>[0] & object,
+      "segmenter" | "onSegment"
+    > = {};
+    if (streamThisTurn) {
+      teardownStreamSession();
+      streamStitcher = new CloudSttSessionStitcher();
+      streamSessionId =
+        typeof crypto !== "undefined" && "randomUUID" in crypto
+          ? crypto.randomUUID()
+          : `sess-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      streamAbort = new AbortController();
+      streamInflight = new Set();
+      streamDegraded = false;
+      const { update, config } = createCloudSttSegmenter();
+      segmentWiring = {
+        segmenter: { update, config: { overlapMs: config.overlapMs } },
+        onSegment: handleStreamSegment,
+      };
+    }
     const next = await startLocalAsrRecorder({
       ...(localAsrAutoStop ? { autoStop: localAsrAutoStop } : {}),
+      ...segmentWiring,
       onAutoStop: () => {
         void stop();
       },
@@ -453,6 +549,9 @@ export function createVoiceCapture(
         // is free/offline, so it stays unguarded to avoid clipping quiet-mic
         // users whose real speech reads near the silence floor on-device.)
         if (kind === "cloud" && isSilentWav(wav)) {
+          // A silent tap: also discard any streaming session (its segments were
+          // silent too, so nothing to stitch/commit).
+          teardownStreamSession();
           setState("stopped");
           setState("idle");
           return;
@@ -462,13 +561,36 @@ export function createVoiceCapture(
           // attached so the transcript recorder can retain the audio. A ~15s
           // per-attempt timeout + one auto-retry (#voice-V4) rides inside
           // transcribeCloudWav so flaky cellular doesn't hard-fail the turn.
-          const text = await transcribeCloudWav(wav);
-          onTranscript({
-            text,
-            final: true,
-            backend: "cloud",
-            audioWav: wav,
-          });
+          let committed = false;
+          const stitcher = streamStitcher;
+          if (stitcher) {
+            // Drain in-flight segment POSTs (incl. the tail just flushed by
+            // recorder.stop()), then prefer the streamed stitch when it
+            // finalized cleanly with no hard-failed segment. Otherwise fall
+            // through to the authoritative batch transcription (V2a graceful
+            // degrade).
+            await Promise.allSettled(Array.from(streamInflight));
+            const running = stitcher.running.trim();
+            if (running && stitcher.isDone && !streamDegraded) {
+              onTranscript({
+                text: running,
+                final: true,
+                backend: "cloud",
+                audioWav: wav,
+              });
+              committed = true;
+            }
+          }
+          teardownStreamSession();
+          if (!committed) {
+            const text = await transcribeCloudWav(wav);
+            onTranscript({
+              text,
+              final: true,
+              backend: "cloud",
+              audioWav: wav,
+            });
+          }
         } else {
           const { text, words } = await transcribeLocalInferenceWav(wav);
           onTranscript({
@@ -523,6 +645,8 @@ export function createVoiceCapture(
       recorder.cancel();
       recorder = null;
     }
+    // Abort any in-flight streaming segment POSTs + clear the session (voice V2a).
+    teardownStreamSession();
     if (recognition) {
       try {
         recognition.abort();

--- a/packages/ui/src/voice/voice-chat-types.ts
+++ b/packages/ui/src/voice/voice-chat-types.ts
@@ -202,6 +202,23 @@ export interface VoiceChatOptions {
   lang?: string;
   /** Saved voice configuration — switches TTS provider when set */
   voiceConfig?: VoiceConfig | null;
+  /**
+   * Auto-send on end-of-speech (voice V2a). When true, a COMPOSE-mode cloud
+   * voice turn that VAD detects as ended is finalized AND submitted
+   * automatically (subject to the reliability guards in
+   * `voice-autosend-config.ts`); when false (the DEFAULT), the turn fills the
+   * composer draft for review-then-send and the user submits manually. Owner
+   * direction: ship OFF by default, flip later once reliable. The caller reads
+   * the persisted `loadVoiceAutoSendEnabled()` toggle and passes it here.
+   */
+  autoSend?: boolean;
+  /**
+   * Called when an auto-send turn PASSES the reliability guards and should be
+   * submitted. The caller sends `text` as the user message (same path a manual
+   * PTT-release submit takes). Required for auto-send to actually send; without
+   * it, auto-send degrades to "finalize into the draft" (review mode).
+   */
+  onAutoSend?: (text: string, event: VoiceTranscriptEvent) => void;
 }
 
 export interface VoiceAssistantSpeechTelemetry {

--- a/plugins/plugin-elizacloud/src/lib/server-cloud-tts.ts
+++ b/plugins/plugin-elizacloud/src/lib/server-cloud-tts.ts
@@ -367,6 +367,20 @@ export async function handleCloudSttRoute(
       : "audio/wav";
   const filename = mime.includes("wav") ? "recording.wav" : "recording.bin";
 
+  // Chunked-streaming segment attribution (voice V2a, Phase 1). The client may
+  // POST intermediate segments with an `X-Asr-Segment` header. Phase 1 keeps
+  // this proxy STATELESS — each segment is a standalone WAV forwarded to the
+  // batch upstream unchanged; stitching is client-side. We forward the header
+  // downstream (passthrough only) so the segment stays attributable end-to-end
+  // and a future stateful upstream could group by it, but we hold NO session
+  // state here. A malformed / absent header is ignored (batch requests carry
+  // none).
+  const segmentHeaderRaw = req.headers["x-asr-segment"];
+  const segmentHeader =
+    typeof segmentHeaderRaw === "string" && segmentHeaderRaw.trim()
+      ? segmentHeaderRaw.trim().slice(0, 128)
+      : undefined;
+
   const cloudUrls = resolveCloudSttCandidateUrls();
   logger.debug(
     `[Cloud STT] proxying ${rawBody.length}B ${mime} to ${cloudUrls.length} candidate(s)`,
@@ -390,6 +404,8 @@ export async function handleCloudSttRoute(
         headers: {
           Authorization: `Bearer ${cloudApiKey}`,
           "x-api-key": cloudApiKey,
+          // Passthrough segment attribution (voice V2a); omitted for batch.
+          ...(segmentHeader ? { "X-Asr-Segment": segmentHeader } : {}),
         },
         body: form,
       });


### PR DESCRIPTION
## V2a — chunked-segment streaming ASR (live incremental transcript)

**V2a of `VOICE-STREAMING-DESIGN.md`** (Phase 1). Companion to the voice quick-wins umbrella (#15267 lineage: capture lifecycle / STT timeout+retry / silence guard / VAD; #15327 barge-in; #15329 mic-permission recheck) and the shared-tier voice route (#15400).

### Why
Owner feedback (staging PWA): *"mic/transcription works but ux is horrible and we can improve real time stt -> chat etc and make it more intuitive."* Today's loop is **batch**: record → stop → upload → wait → text (the STT stage dominates felt latency, and the composer feels dead while you talk). V2a makes the transcript appear **incrementally while you speak**, then finalize on stop.

### How (zero cloud-infra change)
The cloud `/voice/stt` upstream stays the existing **batch** endpoint. V2a's "streaming" is **N independent per-segment transcriptions**, POSTed as the user speaks and stitched client-side:

1. **Segmenter** (`cloud-stt-segmenter.ts`) — pure per-frame state machine running alongside the existing auto-stop VAD. Cuts a boundary after ~1s of buffered speech OR on a short intra-utterance pause (softer than the 650ms end-of-turn window), with a min-speech floor and the same echo-gate as auto-stop. Retains a ~200ms audio seam overlap for continuity.
2. **Recorder** (`local-asr-capture.ts`) — optional `segmenter`+`onSegment` wiring. Encodes each boundary's buffered audio (with overlap) to a WAV and fires `onSegment` **while** buffering the full utterance for the untouched `stop()` batch WAV. Silent mid-segments drop (no seq consumed); a silent final tail emits a header-only marker so a clean utterance still finalizes without a doomed empty POST.
3. **Segment transcribe** (`local-asr-transcribe.ts` `transcribeCloudSegment`) — same both-tier route selection (dedicated `/api/asr/cloud` + shared-tier `/api/v1/voice/stt`, #15400), same V4 timeout + single retry, adds the `X-Asr-Segment` header, and (unlike batch) treats an empty segment transcript as `""`, not an error.
4. **Stitcher** (`cloud-stt-stitcher.ts`) — ordered, seam-deduped incremental assembly. Handles **out-of-order / duplicate / retried** segment delivery (buffer-until-contiguous; idempotent on re-delivered `seq`) and dedups the overlapped seam words.
5. **Composer** (`useVoiceChat.ts`) — emits a live **non-final** preview per stitched segment (drives the existing interim surface). On stop, **prefers the streamed stitch** when it finalized cleanly with no hard-failed segment; **else falls back** to the authoritative batch WAV transcription.
6. **Proxy** (`server-cloud-tts.ts`) — `X-Asr-Segment` **passthrough only**. Phase 1 keeps the proxy **stateless**: each segment is a standalone WAV forwarded to the batch upstream; no session state, **no new endpoint**.

`voice-capture-factory.ts` (ambient/desktop surface) gets the same behavior behind an opt-in `cloudStreaming` flag (default off; the composer drives its own streaming). `asr.streaming` config flag added (default **on** for cloud; `false` is a hard opt-out, e.g. to avoid per-segment credit-reservation churn on the ElevenLabs upstream — see design §2.4).

### UX intuitiveness (owner's actual ask, first-class)
The composer state machine is now legible: **listening** (partial text appears live as you speak) → brief **processing** → **sent** (transcript becomes the message). No dead spinner during the STT wait.

### Graceful degrade (mandatory, everywhere)
Streaming off / never-finalized / any segment hard-fail / empty stitch → **batch full-WAV path** (already V4/V5-hardened). Batch-vs-stream is a *latency* difference, not a *correctness* one, so degrading down-to-working is the right call. Stream teardown is wired into `resetListeningState` (covers the V1 `APP_PAUSE` suspend-discard via `discardCaptureForSuspend`) and barge-in abort — no regression to #15267/#15327/#15329/#15400.

### Tests (all green)
`bun test --conditions=eliza-source` / vitest. **106 voice tests pass**, including the required `voice-provider-defaults`, `voice-chat-types.asr-default`, `local-asr-transcribe`, `shared-runtime-voice`.

New:
- **cloud-stt-stitcher.test.ts** — in-order assembly + seam dedup, out-of-order/duplicate/retried delivery, negative/stale seqs, finalize + reset, empty-final finalize.
- **cloud-stt-segmenter.test.ts** — length + pause boundaries, min-speech floor, speech-clock reset, echo gate, sane defaults.
- **cloud-stt-segment.test.ts** — `X-Asr-Segment` wire shape, both-tier route selection, empty-segment-is-OK, retry classification.
- **local-asr-capture.test.ts** (extended) — segmenter integration: boundaries emit ordered segments + terminal final, silent mid-segment drop (no seq consumed), header-only final marker on silent tail.

<details><summary>Test output</summary>

```
 Test Files  8 passed (8)
      Tests  106 passed (106)
```
</details>

### Scope
**V2a ONLY.** No V2b (websocket / request-body streaming — later phase, needs streaming-Whisper upstream). No new server endpoints (chunked reuse of the batch route per design §2.2 option A).

### Follow-ups (not V2a — noted per lane instructions)
- Auto-send on end-of-speech (design-doc optional; deliberately not wired here).
- Wire per-segment timings into the existing `ChatVoiceStatusBar` latency badge (real numbers vs estimates).
- Mic-button state-machine polish (explicit listening/processing/sent affordance).
- Adopt the streaming segmenter in the ambient factory path by default once the composer flow is device-verified.

### Notes / caveats
- **File constraints honored:** did not touch vite.config/index.html/client-base.ts/bun.lock/binaries. Codegen (`generate-keywords.mjs`) run but its generated file is unmodified.
- **codex review:** timed out on the VPS on this ~1.4k-line diff (known VPS OOM/slowness on large diffs). Please run `codex review` in CI. Full-project `tsc --noEmit` passed clean before the final two type-trivial guard edits; the vitest suite compiles + exercises every new path.
- **UI evidence:** the `check-pr-evidence` gate will want composer screenshots. The `audit:app` harness (`file-type` resolution) doesn't resolve from this symlinked worktree (pre-existing env quirk, reproduces on a pristine checkout of the affected test files — unrelated to this PR). **Requesting device-verify on the installed iOS PWA** for the live-partial-transcript UX + the streamed-vs-batch finalize path.

**Sign:** [sol-cloud]

Co-authored-by: wakesync <shadow@shad0w.xyz>
