### PR TITLE
fix(ui): keep cloud pair links out of the owner-password wall (split from #15366)

### DIFF
--- a/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.test.ts
+++ b/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.test.ts
@@ -18,6 +18,7 @@ function appWithCors() {
   app.use("*", corsMiddleware);
   app.get("/ping", (c) => c.json({ ok: true }));
   app.post("/ping", (c) => c.json({ ok: true }));
+  app.post("/api/auth/pair", (c) => c.json({ ok: true }));
   app.get("/api/v1/models", (c) => c.json({ ok: true }));
   app.post("/api/v1/chat/completions", (c) => c.json({ ok: true }));
   return app;
@@ -77,6 +78,7 @@ describe("isFirstPartyOrigin — Eliza app WebView origins", () => {
 describe("isPublicTokenApiPath", () => {
   test("recognizes explicit public token API paths", () => {
     expect(isPublicTokenApiPath("/api/v1/chat/completions")).toBe(true);
+    expect(isPublicTokenApiPath("/api/auth/pair")).toBe(true);
     expect(isPublicTokenApiPath("/api/v1/app-credits/balance")).toBe(true);
     expect(isPublicTokenApiPath("/api/v1/models/openai/gpt-oss-120b")).toBe(true);
     expect(isPublicTokenApiPath("/api/v1/twilio/connect")).toBe(false);
@@ -156,6 +158,21 @@ describe("corsMiddleware — third-party app origins (open, NO credentials)", ()
   test("does not allow wildcard CORS on session-capable non-public paths", async () => {
     const res = await req("OPTIONS", "https://malicious.apps.elizacloud.ai", true, "/ping");
     expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  test("allows hosted agent subdomains to exchange one-time Cloud pair tokens", async () => {
+    const res = await req(
+      "OPTIONS",
+      "https://23766030-c096-4a14-932a-a4e43c562432.elizacloud.ai",
+      true,
+      "/api/auth/pair",
+    );
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    expect(res.headers.get("access-control-allow-credentials")).toBeNull();
+    expect(res.headers.get("access-control-allow-methods")).toContain("POST");
+    expect((res.headers.get("access-control-allow-headers") || "").toLowerCase()).toContain(
+      "content-type",
+    );
   });
 });
 

--- a/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.ts
+++ b/packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.ts
@@ -75,6 +75,7 @@ const PUBLIC_TOKEN_API_PATH_PREFIXES = [
   "/api/v1/models/",
 ];
 const PUBLIC_TOKEN_API_PATHS = new Set<string>([
+  "/api/auth/pair",
   "/api/v1/app-credits",
   "/api/v1/chat",
   "/api/v1/chat/completions",

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -51,6 +51,12 @@ import {
 import { getOverlayAppLazyComponent } from "./components/apps/AppWindowRenderer.helpers";
 import { GameViewOverlay } from "./components/apps/GameViewOverlay";
 import { getOverlayApp } from "./components/apps/overlay-app-registry";
+import {
+  CloudHostedAgentAuthNotice,
+  CloudPairRelay,
+  getCloudPairTokenFromLocation,
+  isElizaCloudHostedLocation,
+} from "./components/auth/CloudPairRelay";
 import { LoginView } from "./components/auth/LoginView";
 import { SaveCommandModal } from "./components/chat/SaveCommandModal";
 import { CustomActionEditor } from "./components/custom-actions/CustomActionEditor";
@@ -2176,6 +2182,8 @@ export function App() {
       : undefined;
   const overlayAppSurfaceActive = Boolean(resolvedOverlayApp);
   const contextMenu = useContextMenu();
+  const cloudPairToken = getCloudPairTokenFromLocation();
+  const isElizaCloudHosted = isElizaCloudHostedLocation();
 
   useSecretsManagerShortcut();
 
@@ -2595,6 +2603,19 @@ export function App() {
     );
   }
 
+  // Hosted Cloud agent handoff: `/pair?token=X` must never fall through to the
+  // local password auth screen. The server-side relay owns the happy path, but
+  // this protects stale/edge-hosted SPA fallbacks by exchanging the token in the
+  // browser and then reloading the agent root with the paired API key pinned.
+  if (cloudPairToken) {
+    return (
+      <BugReportProvider value={bugReport}>
+        <CloudPairRelay token={cloudPairToken} />
+        <BugReportModal />
+      </BugReportProvider>
+    );
+  }
+
   // Self-driving voice round-trip test screen — runs the real STT->agent->TTS
   // loop against a known phrase and reports PASS/FAIL with no human in the loop.
   // Self-contained (its own ElizaClient + AudioContext); no app chrome / gate.
@@ -2716,6 +2737,14 @@ export function App() {
         return (
           <BugReportProvider value={bugReport}>
             <StartupScreen />
+            <BugReportModal />
+          </BugReportProvider>
+        );
+      }
+      if (isElizaCloudHosted) {
+        return (
+          <BugReportProvider value={bugReport}>
+            <CloudHostedAgentAuthNotice />
             <BugReportModal />
           </BugReportProvider>
         );

--- a/packages/ui/src/components/auth/CloudPairRelay.tsx
+++ b/packages/ui/src/components/auth/CloudPairRelay.tsx
@@ -1,0 +1,237 @@
+import { useEffect, useState } from "react";
+import { getBootConfig, setBootConfig } from "../../config/boot-config";
+import { setElizaApiToken } from "../../utils/eliza-globals";
+
+export const CLOUD_PAIR_SESSION_STORAGE_KEY = "eliza:cloud-pair:api-token";
+
+interface PairExchangeResponse {
+  apiKey?: unknown;
+  error?: unknown;
+}
+
+export class CloudPairExchangeError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "CloudPairExchangeError";
+  }
+}
+
+export function getCloudPairTokenFromLocation(
+  locationLike: Pick<Location, "pathname" | "search"> | null = typeof window ===
+  "undefined"
+    ? null
+    : window.location,
+): string | null {
+  if (!locationLike) return null;
+  if (locationLike.pathname.replace(/\/+$/, "") !== "/pair") return null;
+  const token = new URLSearchParams(locationLike.search).get("token")?.trim();
+  return token || null;
+}
+
+export function isElizaCloudHostedLocation(
+  locationLike: Pick<
+    Location,
+    "hostname" | "protocol"
+  > | null = typeof window === "undefined" ? null : window.location,
+): boolean {
+  if (!locationLike) return false;
+  if (locationLike.protocol !== "https:" && locationLike.protocol !== "http:") {
+    return false;
+  }
+  const hostname = locationLike.hostname.trim().toLowerCase();
+  return hostname === "elizacloud.ai" || hostname.endsWith(".elizacloud.ai");
+}
+
+export function resolveCloudPairExchangeUrl(cloudApiBase?: string): string {
+  const configured = cloudApiBase?.trim() || getBootConfig().cloudApiBase;
+  const base = (configured || "https://elizacloud.ai")
+    .replace(/\/+$/, "")
+    .replace(/\/api\/v1\/?$/, "");
+  return `${base}/api/auth/pair`;
+}
+
+export async function exchangeCloudPairToken(
+  token: string,
+  options: {
+    signal?: AbortSignal;
+    fetchFn?: typeof fetch;
+    cloudApiBase?: string;
+  } = {},
+): Promise<string> {
+  const fetchFn = options.fetchFn ?? fetch;
+  const response = await fetchFn(
+    resolveCloudPairExchangeUrl(options.cloudApiBase),
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ token }),
+      signal: options.signal,
+    },
+  );
+
+  const body = (await response
+    .json()
+    .catch(() => null)) as PairExchangeResponse | null;
+
+  if (!response.ok) {
+    const message =
+      typeof body?.error === "string" && body.error.trim()
+        ? body.error.trim()
+        : "Cloud pairing failed.";
+    throw new CloudPairExchangeError(message, response.status);
+  }
+
+  if (typeof body?.apiKey !== "string" || !body.apiKey.trim()) {
+    throw new CloudPairExchangeError(
+      "Cloud did not return an agent session.",
+      502,
+    );
+  }
+
+  return body.apiKey.trim();
+}
+
+function tryPersistCloudPairSessionToken(apiToken: string): boolean {
+  try {
+    window.sessionStorage.setItem(CLOUD_PAIR_SESSION_STORAGE_KEY, apiToken);
+    return true;
+  } catch (_storageError) {
+    // Session storage can be disabled by hardened browsers. Boot config still
+    // carries the token for this page load, so the redirect can continue.
+    return false;
+  }
+}
+
+export function persistCloudPairApiToken(apiToken: string): void {
+  const token = apiToken.trim();
+  if (!token) throw new Error("Missing cloud pair API token.");
+
+  tryPersistCloudPairSessionToken(token);
+
+  const nextConfig = { ...getBootConfig(), apiToken: token };
+  setBootConfig(nextConfig);
+  setElizaApiToken(token);
+  (globalThis as Record<string, unknown>).__ELIZA_APP_BOOT_CONFIG__ =
+    nextConfig;
+
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent("steward-token-sync"));
+  }
+}
+
+type CloudPairStatus =
+  | { phase: "pairing" }
+  | { phase: "error"; title: string; message: string };
+
+export type CloudPairExchangeFn = (
+  token: string,
+  options?: { signal?: AbortSignal },
+) => Promise<string>;
+
+export interface CloudPairRelayProps {
+  token: string;
+  exchangeFn?: CloudPairExchangeFn;
+  persistFn?: (apiToken: string) => void;
+  onPaired?: () => void;
+}
+
+function describePairFailure(error: unknown): Exclude<
+  CloudPairStatus,
+  {
+    phase: "pairing";
+  }
+> {
+  if (error instanceof CloudPairExchangeError) {
+    if ([401, 403, 410].includes(error.status)) {
+      return {
+        phase: "error",
+        title: "Sign-in link expired",
+        message: "Open this agent from Eliza Cloud again to continue.",
+      };
+    }
+    if (error.status === 429) {
+      return {
+        phase: "error",
+        title: "Too many sign-in attempts",
+        message: "Wait a minute, then open this agent from Eliza Cloud again.",
+      };
+    }
+  }
+
+  return {
+    phase: "error",
+    title: "Could not sign in",
+    message: "Open this agent from Eliza Cloud again to continue.",
+  };
+}
+
+export function CloudHostedAgentAuthNotice() {
+  return (
+    <main className="flex min-h-[100dvh] items-center justify-center bg-[#08090b] px-6 text-center font-body text-white">
+      <div className="w-full max-w-[25rem]">
+        <div className="mx-auto mb-6 h-2 w-2 rotate-45 bg-[#f3a51f]" />
+        <p className="mb-4 text-sm font-semibold text-white/45">Eliza</p>
+        <h1 className="text-2xl font-semibold text-white">
+          Open this agent from Eliza Cloud
+        </h1>
+        <p className="mt-3 text-sm leading-6 text-white/60">
+          This Cloud agent uses your Eliza Cloud session. Open it from Eliza
+          Cloud again to create a fresh secure sign-in link.
+        </p>
+      </div>
+    </main>
+  );
+}
+
+function redirectToAgentRoot(): void {
+  window.location.replace("/");
+}
+
+export function CloudPairRelay({
+  token,
+  exchangeFn = exchangeCloudPairToken,
+  persistFn = persistCloudPairApiToken,
+  onPaired = redirectToAgentRoot,
+}: CloudPairRelayProps) {
+  const [status, setStatus] = useState<CloudPairStatus>({ phase: "pairing" });
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let active = true;
+
+    exchangeFn(token, { signal: controller.signal })
+      .then((apiToken) => {
+        if (!active) return;
+        persistFn(apiToken);
+        onPaired();
+      })
+      .catch((error) => {
+        if (!active || controller.signal.aborted) return;
+        setStatus(describePairFailure(error));
+      });
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [exchangeFn, onPaired, persistFn, token]);
+
+  const isPairing = status.phase === "pairing";
+  return (
+    <main className="flex min-h-[100dvh] items-center justify-center bg-[#08090b] px-6 text-center font-body text-white">
+      <div className="w-full max-w-[24rem]">
+        <div className="mx-auto mb-6 h-2 w-2 rotate-45 bg-[#f3a51f]" />
+        <p className="mb-4 text-sm font-semibold text-white/45">Eliza</p>
+        <h1 className="text-2xl font-semibold text-white">
+          {isPairing ? "Signing in to your agent" : status.title}
+        </h1>
+        <p className="mt-3 text-sm leading-6 text-white/60">
+          {isPairing ? "This tab will continue automatically." : status.message}
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/packages/ui/src/components/auth/__tests__/CloudPairRelay.test.tsx
+++ b/packages/ui/src/components/auth/__tests__/CloudPairRelay.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_BOOT_CONFIG,
+  getBootConfig,
+  setBootConfig,
+} from "../../../config/boot-config";
+import {
+  clearElizaApiToken,
+  getElizaApiToken,
+} from "../../../utils/eliza-globals";
+import {
+  CLOUD_PAIR_SESSION_STORAGE_KEY,
+  CloudHostedAgentAuthNotice,
+  CloudPairExchangeError,
+  CloudPairRelay,
+  exchangeCloudPairToken,
+  getCloudPairTokenFromLocation,
+  isElizaCloudHostedLocation,
+  persistCloudPairApiToken,
+  resolveCloudPairExchangeUrl,
+} from "../CloudPairRelay";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("CloudPairRelay", () => {
+  beforeEach(() => {
+    setBootConfig(DEFAULT_BOOT_CONFIG);
+    clearElizaApiToken();
+    window.sessionStorage.clear();
+    window.history.replaceState(null, "", "/");
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("detects only /pair URLs with a non-empty token", () => {
+    expect(
+      getCloudPairTokenFromLocation({
+        pathname: "/pair",
+        search: "?token=pair-token",
+      }),
+    ).toBe("pair-token");
+    expect(
+      getCloudPairTokenFromLocation({
+        pathname: "/pair/",
+        search: "?token=%20pair-token%20",
+      }),
+    ).toBe("pair-token");
+    expect(
+      getCloudPairTokenFromLocation({
+        pathname: "/chat",
+        search: "?token=pair-token",
+      }),
+    ).toBeNull();
+    expect(
+      getCloudPairTokenFromLocation({
+        pathname: "/pair",
+        search: "?token= ",
+      }),
+    ).toBeNull();
+  });
+
+  it("resolves the Cloud pair exchange endpoint from site and API bases", () => {
+    expect(resolveCloudPairExchangeUrl("https://elizacloud.ai")).toBe(
+      "https://elizacloud.ai/api/auth/pair",
+    );
+    expect(
+      resolveCloudPairExchangeUrl("https://api.elizacloud.ai/api/v1"),
+    ).toBe("https://api.elizacloud.ai/api/auth/pair");
+  });
+
+  it("detects Eliza Cloud-hosted surfaces without matching localhost", () => {
+    expect(
+      isElizaCloudHostedLocation({
+        protocol: "https:",
+        hostname: "23766030-c096-4a14-932a-a4e43c562432.elizacloud.ai",
+      }),
+    ).toBe(true);
+    expect(
+      isElizaCloudHostedLocation({
+        protocol: "https:",
+        hostname: "app.elizacloud.ai",
+      }),
+    ).toBe(true);
+    expect(
+      isElizaCloudHostedLocation({
+        protocol: "http:",
+        hostname: "localhost",
+      }),
+    ).toBe(false);
+  });
+
+  it("exchanges the pairing token with Cloud and returns the agent API key", async () => {
+    const fetchFn = vi.fn(async () => jsonResponse({ apiKey: "agent-key" }));
+
+    await expect(
+      exchangeCloudPairToken("pair-token", {
+        fetchFn: fetchFn as unknown as typeof fetch,
+        cloudApiBase: "https://api.elizacloud.ai/api/v1",
+      }),
+    ).resolves.toBe("agent-key");
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      "https://api.elizacloud.ai/api/auth/pair",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ token: "pair-token" }),
+      }),
+    );
+  });
+
+  it("persists the paired API key into the app token channels", () => {
+    persistCloudPairApiToken(" agent-key ");
+
+    expect(getBootConfig().apiToken).toBe("agent-key");
+    expect(getElizaApiToken()).toBe("agent-key");
+    expect(window.sessionStorage.getItem(CLOUD_PAIR_SESSION_STORAGE_KEY)).toBe(
+      "agent-key",
+    );
+    expect(
+      (globalThis as Record<string, unknown>).__ELIZA_APP_BOOT_CONFIG__,
+    ).toEqual(expect.objectContaining({ apiToken: "agent-key" }));
+  });
+
+  it("pairs, stores the returned API key, and redirects without showing LoginView", async () => {
+    const onPaired = vi.fn();
+
+    render(
+      <CloudPairRelay
+        token="pair-token"
+        exchangeFn={vi.fn(async () => "agent-key")}
+        onPaired={onPaired}
+      />,
+    );
+
+    expect(screen.getByText("Signing in to your agent")).toBeTruthy();
+    expect(screen.queryByText("Display name")).toBeNull();
+    expect(screen.queryByText("Password")).toBeNull();
+
+    await waitFor(() => expect(onPaired).toHaveBeenCalledOnce());
+    expect(getBootConfig().apiToken).toBe("agent-key");
+    expect(window.sessionStorage.getItem(CLOUD_PAIR_SESSION_STORAGE_KEY)).toBe(
+      "agent-key",
+    );
+  });
+
+  it("shows a clean Cloud-pair error instead of the local password form", async () => {
+    render(
+      <CloudPairRelay
+        token="expired-token"
+        exchangeFn={vi.fn(async () => {
+          throw new CloudPairExchangeError("expired", 410);
+        })}
+        onPaired={vi.fn()}
+      />,
+    );
+
+    await screen.findByText("Sign-in link expired");
+    expect(
+      screen.getByText("Open this agent from Eliza Cloud again to continue."),
+    ).toBeTruthy();
+    expect(screen.queryByText("Display name")).toBeNull();
+    expect(screen.queryByText("Password")).toBeNull();
+    expect(screen.queryByText("Remember this device for 30 days")).toBeNull();
+  });
+
+  it("shows a Cloud-hosted auth notice without the local password wall", () => {
+    render(<CloudHostedAgentAuthNotice />);
+
+    expect(screen.getByText("Open this agent from Eliza Cloud")).toBeTruthy();
+    expect(screen.queryByText("Display name")).toBeNull();
+    expect(screen.queryByText("Password")).toBeNull();
+    expect(screen.queryByText("Remember this device for 30 days")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Splits out and lands **only** the sound, secure, tested pair-link half of #15366.

Hosted Cloud agent `/pair?token=X` handoffs are intercepted **before** the auth gate so a stale/edge-hosted SPA fallback can never fall through to the self-hosted owner-password `LoginView`. `CloudPairRelay` exchanges the one-time token against Cloud, pins the returned agent API key into the same boot-config/session channels the client already reads, then reloads the agent root (`window.location.replace("/")`). Invalid/expired tokens render a distinguishable **error** state (not the password form). The password wall is suppressed **only** on `*.elizacloud.ai` hosts (`isElizaCloudHostedLocation`), which see an "open from Eliza Cloud" notice instead.

CORS: `/api/auth/pair` is added to `PUBLIC_TOKEN_API_PATHS` so hosted agent subdomains can exchange the token, with credentials disabled (`access-control-allow-credentials: null`).

## Relationship to #15366

This is the pair-link half of #15366, split out from the bundled onboarding-CTA / greeting redesign. That other half (`use-first-run-conductor.ts` OAuth-card removal, greeting-copy rewrites, `ChoiceWidget` status-line removal, `ContinuousChatOverlay`/`ShellOverlays`/`useLayoutShiftMonitor` churn, OCR-triage changes) is **not** included here: it is undocumented, overlaps the #15339/#15365 onboarding-conductor lane, and lacks the required `audit:app` visual evidence. It should be resubmitted as its own documented, evidenced PR. Credit to @NubsCarson for the original fix.

## Validation

- `bun x vitest run CloudPairRelay.test.tsx` → 8/8 pass
- `bun test cloud-api-hono-cors.test.ts` → 15/15 pass (incl. new `/api/auth/pair` public-path + hosted-subdomain CORS assertions)
- `bun x tsgo --noEmit -p packages/ui/tsconfig.json` → clean
- `bun x biome check` on all 5 touched files → clean

## Files (5, pair-fix only)

- `packages/ui/src/App.tsx` — pair-token interception before auth gate + host-gated password-wall suppression
- `packages/ui/src/components/auth/CloudPairRelay.tsx` (new) — token-exchange relay + hosted notice
- `packages/ui/src/components/auth/__tests__/CloudPairRelay.test.tsx` (new)
- `packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.ts` — `/api/auth/pair` public token path
- `packages/cloud/shared/src/lib/cors/cloud-api-hono-cors.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)