### PR TITLE
chore(cloud): enable INFERENCE_HOT_PATH_CACHES on production

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -521,7 +521,7 @@ INFERENCE_DEFERRED_ADMISSION = "false"
 # Tier-3 in-isolate decision caches (#9899): org rate-limit lease (convergent;
 # leased requests are carried back into the Redis window), 60s shouldBlockUser
 # memo, 60s model-catalog memo. Default off; rollback = flip off.
-INFERENCE_HOT_PATH_CACHES = "false"
+INFERENCE_HOT_PATH_CACHES = "true"
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob.elizacloud.ai"
 SQL_HEAVY_PAYLOAD_STORAGE = "r2"


### PR DESCRIPTION
First half of the prod inference hot-path flip. Enables the in-isolate decision caches (rate-limit convergent lease, moderation memo, catalog memo) from #15409 on prod; `INFERENCE_DEFERRED_ADMISSION` stays false (separate deliberate step). Money-bar reviewed (MERGE-FLAGS-OFF, 230/0, D1 verified against the real Redis pipeline). Prod baseline: ~2.3s warm/call; live delta measured post-deploy.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - config flag flip, no UI.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - config flag flip, no UI.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - config only.
<!-- evidence-row:backend-logs -->
- [ ] N/A - before/after gateway latency measurements posted as a PR comment post-deploy; flag correctness covered by #15409's 230/0 suites.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model-path change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no schema/data change.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no media.