### PR TITLE
perf(cloud): move /v1/messages billing tail off the response path (stream + non-stream)

### DIFF
--- a/packages/cloud/api/__tests__/messages-billing-offpath.test.ts
+++ b/packages/cloud/api/__tests__/messages-billing-offpath.test.ts
@@ -1,0 +1,607 @@
+/**
+ * Off-response-path billing tests for POST /api/v1/messages (#15414).
+ *
+ * Before the fix, the streaming path's `onFinish` awaited the settlement chain
+ * (billUsage → settleReservation → recordUsageAnalytics) INLINE, and the AI SDK
+ * awaits `onFinish` before it ends `fullStream` — so the terminal SSE frames
+ * (message_delta + message_stop) were held hostage for the full billing-write
+ * latency (~8s measured for the identical pattern on /v1/chat/completions,
+ * fixed in #15412). The non-stream handler had the same bug: it awaited the
+ * chain before `Response.json` returned.
+ *
+ * These tests drive the REAL credit-reservation settler
+ * (`createCreditReservationSettler`, not a mock) against a ledger-backed
+ * reservation and assert:
+ *
+ *   1. STREAM: the terminal frames flush while billUsage is still gated open —
+ *      the chain is handed to `executionCtx.waitUntil` and settles exactly once
+ *      with the same amounts after release.
+ *   2. NON-STREAM: the Response returns while billUsage is still gated open —
+ *      same waitUntil handoff, same amounts, exactly once.
+ *   3. Parity: the deferred chain bills with EXACTLY the same args as the
+ *      inline (no-executionCtx) fallback path.
+ *   4. Abort mid-stream with an executionCtx still records the delivered
+ *      partial usage (the abort settle path is unchanged by the deferral).
+ *   5. A deferred billing failure logs and releases the reservation, but never
+ *      breaks the already-sent response (stream already ended with
+ *      message_stop; non-stream already returned 200 with provider usage).
+ *   6. A stray late onError racing a deferred onFinish cannot double-settle
+ *      (the settlement promise is cached synchronously inside onFinish).
+ *
+ * `streamText`/`generateText`, `getLanguageModel`, and the billing boundary are
+ * mocked at the module seam; the settler and reservation math are real. Mirrors
+ * `chat-completions-streaming-credit-leak.test.ts` (#15412's suite).
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+// Spread the real module so other test files importing from "ai" are not
+// stranded by the process-wide registry replacement; restore in afterAll.
+const aiActual = require("ai") as Record<string, unknown>;
+
+import { estimateTokens } from "@/lib/pricing";
+import * as languageModelActual from "@/lib/providers/language-model";
+import * as aiBillingActual from "@/lib/services/ai-billing";
+
+// The REAL settler — explicitly NOT mocked. This is the component under test.
+import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
+
+const ORG = "00000000-0000-4000-8000-0000000000aa";
+const USER = "00000000-0000-4000-8000-0000000000bb";
+
+// --- mock the AI SDK boundary we drive ---------------------------------------
+let streamTextImpl: ((config: Record<string, unknown>) => unknown) | null =
+  null;
+const streamText = mock((config: Record<string, unknown>) => {
+  if (!streamTextImpl) throw new Error("streamTextImpl not set");
+  return streamTextImpl(config);
+});
+let generateTextImpl: ((config: Record<string, unknown>) => unknown) | null =
+  null;
+const generateText = mock(async (config: Record<string, unknown>) => {
+  if (!generateTextImpl) throw new Error("generateTextImpl not set");
+  return generateTextImpl(config);
+});
+mock.module("ai", () => ({
+  ...aiActual,
+  streamText,
+  generateText,
+}));
+
+mock.module("@/lib/providers/language-model", () => ({
+  ...languageModelActual,
+  getLanguageModel: () => ({}) as never,
+}));
+
+const INPUT_TOKEN_COST = 0.001;
+const OUTPUT_TOKEN_COST = 0.01;
+// When set, billUsage blocks until the gate resolves — lets the waitUntil-
+// parity tests hold the settlement chain open while the response is read, to
+// prove neither the SSE close nor the JSON return waits on billing.
+let billUsageGate: Promise<void> | null = null;
+// When set, billUsage rejects — the deferred-failure tests.
+let billUsageError: Error | null = null;
+const billUsage = mock(async (_context: unknown, usage: unknown) => {
+  if (billUsageGate) await billUsageGate;
+  if (billUsageError) throw billUsageError;
+  const record =
+    usage && typeof usage === "object"
+      ? (usage as {
+          inputTokens?: number;
+          promptTokens?: number;
+          outputTokens?: number;
+          completionTokens?: number;
+          totalTokens?: number;
+        })
+      : {};
+  const inputTokens = record.inputTokens ?? record.promptTokens ?? 0;
+  const outputTokens = record.outputTokens ?? record.completionTokens ?? 0;
+  const inputCost = inputTokens * INPUT_TOKEN_COST;
+  const outputCost = outputTokens * OUTPUT_TOKEN_COST;
+  return {
+    inputCost,
+    outputCost,
+    totalCost: inputCost + outputCost,
+    baseInputCost: inputCost,
+    baseOutputCost: outputCost,
+    baseTotalCost: inputCost + outputCost,
+    platformMarkup: 0,
+    inputTokens,
+    outputTokens,
+    totalTokens: record.totalTokens ?? inputTokens + outputTokens,
+    markupApplied: true,
+  };
+});
+const recordUsageAnalytics = mock(async () => ({ id: "usage-1" }));
+mock.module("@/lib/services/ai-billing", () => ({
+  ...aiBillingActual,
+  billUsage,
+  recordUsageAnalytics,
+}));
+
+// Import the route AFTER the mocks so it binds to the stubs.
+const { __messagesStreamingCreditTestHooks } = await import(
+  "../v1/messages/route"
+);
+const { handleStream, handleNonStream } = __messagesStreamingCreditTestHooks;
+
+afterAll(() => {
+  mock.module("ai", () => aiActual);
+  mock.module("@/lib/providers/language-model", () => languageModelActual);
+  mock.module("@/lib/services/ai-billing", () => aiBillingActual);
+});
+
+/**
+ * A faithful in-memory credit ledger. reserve() debits the ~1.5x hold up front;
+ * reconcile(actualCost) refunds (hold - actualCost) back. reconcile(0) therefore
+ * returns the full hold → balance restored to the pre-request value.
+ */
+function makeLedgerReservation(startBalance: number, hold: number) {
+  let balance = startBalance - hold; // upfront hold debited
+  let reconcileCalls = 0;
+  const actualCosts: number[] = [];
+  return {
+    startBalance,
+    hold,
+    get balance() {
+      return balance;
+    },
+    get reconcileCalls() {
+      return reconcileCalls;
+    },
+    get actualCosts() {
+      return actualCosts;
+    },
+    reservation: {
+      reservedAmount: hold,
+      reconcile: async (actualCost: number) => {
+        reconcileCalls++;
+        actualCosts.push(actualCost);
+        balance += hold - actualCost;
+        return undefined;
+      },
+    },
+  };
+}
+
+const MODEL = "openai/gpt-oss-120b";
+const STREAM_REQUEST = {
+  model: MODEL,
+  max_tokens: 256,
+  messages: [{ role: "user", content: "hello" }],
+  stream: true,
+} as never;
+const NONSTREAM_REQUEST = {
+  model: MODEL,
+  max_tokens: 256,
+  messages: [{ role: "user", content: "hello" }],
+} as never;
+
+type ExecutionCtx = { waitUntil(promise: Promise<unknown>): void };
+
+/** Invoke handleStream with the test's settler and a fixed request shape. */
+function callStreaming(
+  settleReservation: (actualCost: number) => Promise<unknown> | unknown,
+  options: {
+    estimatedInputTokens?: number;
+    signal?: AbortSignal;
+    executionCtx?: ExecutionCtx;
+  } = {},
+) {
+  return handleStream(
+    MODEL,
+    undefined,
+    [{ role: "user", content: [{ type: "text", text: "hello" }] }] as never,
+    STREAM_REQUEST,
+    { id: USER, organization_id: ORG },
+    null,
+    null,
+    Date.now(),
+    options.estimatedInputTokens ?? 1,
+    {} as never,
+    undefined,
+    undefined,
+    options.signal,
+    30_000,
+    settleReservation as never,
+    "gateway" as never,
+    "req-test-offpath",
+    options.executionCtx,
+  );
+}
+
+/** Invoke handleNonStream with the test's settler and a fixed request shape. */
+function callNonStreaming(
+  settleReservation: (actualCost: number) => Promise<unknown> | unknown,
+  options: { executionCtx?: ExecutionCtx } = {},
+) {
+  return handleNonStream(
+    MODEL,
+    undefined,
+    [{ role: "user", content: [{ type: "text", text: "hello" }] }] as never,
+    NONSTREAM_REQUEST,
+    { id: USER, organization_id: ORG },
+    null,
+    null,
+    Date.now(),
+    {} as never,
+    undefined,
+    undefined,
+    undefined,
+    30_000,
+    settleReservation as never,
+    "gateway" as never,
+    "req-test-offpath",
+    options.executionCtx,
+  );
+}
+
+beforeEach(() => {
+  streamText.mockClear();
+  generateText.mockClear();
+  billUsage.mockClear();
+  recordUsageAnalytics.mockClear();
+  streamTextImpl = null;
+  generateTextImpl = null;
+  billUsageGate = null;
+  billUsageError = null;
+});
+
+const USAGE = { inputTokens: 2, outputTokens: 3, totalTokens: 5 };
+const TEXT = "hello streamed world";
+const EXPECTED_COST =
+  USAGE.inputTokens * INPUT_TOKEN_COST + USAGE.outputTokens * OUTPUT_TOKEN_COST;
+
+/**
+ * SDK-faithful stream: the AI SDK AWAITS onFinish before ending fullStream —
+ * that contract is exactly why an inline-awaited settlement chain held the
+ * terminal SSE frames (message_delta + message_stop) hostage. Also captures
+ * onError so the deferral tests can fire a stray late error against the
+ * cached settlement.
+ */
+function sdkFaithfulStream(): { onError: () => Promise<unknown> } {
+  let capturedOnError:
+    | ((e: { error: unknown }) => Promise<unknown>)
+    | undefined;
+  streamTextImpl = (config) => {
+    capturedOnError = config.onError as typeof capturedOnError;
+    const onFinish = config.onFinish as (event: {
+      text: string;
+      totalUsage: typeof USAGE;
+    }) => Promise<unknown>;
+    return {
+      fullStream: (async function* () {
+        yield { type: "text-start", id: "text-1" };
+        yield { type: "text-delta", id: "text-1", text: TEXT };
+        yield { type: "text-end", id: "text-1" };
+        await onFinish({ text: TEXT, totalUsage: USAGE });
+        yield { type: "finish", finishReason: "stop", totalUsage: USAGE };
+      })(),
+    };
+  };
+  return {
+    onError: () =>
+      Promise.resolve(
+        capturedOnError?.({ error: new Error("provider returned 503") }),
+      ),
+  };
+}
+
+function sdkFaithfulGeneration() {
+  generateTextImpl = () => ({
+    text: TEXT,
+    usage: USAGE,
+    toolCalls: [],
+    finishReason: "stop",
+    rawFinishReason: "stop",
+  });
+}
+
+describe("streaming messages — billing settles OFF the response path (waitUntil parity, #15414)", () => {
+  test("terminal frames + message_stop flush BEFORE the billing chain completes; the chain runs via waitUntil", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+
+    // Hold the settlement chain open at its first DB write (billUsage).
+    let releaseBilling!: () => void;
+    billUsageGate = new Promise<void>((resolve) => {
+      releaseBilling = resolve;
+    });
+
+    const waitUntilPromises: Promise<unknown>[] = [];
+    const executionCtx = {
+      waitUntil(promise: Promise<unknown>) {
+        waitUntilPromises.push(promise);
+      },
+    };
+
+    sdkFaithfulStream();
+    const res = await callStreaming(settle, { executionCtx });
+    // Reading the WHOLE body to message_stop completes while billUsage is
+    // still gated — the regression under test (the ~8s billing tail) would
+    // hang this read until the chain finished.
+    const body = await res.text();
+    expect(body).toContain(TEXT);
+    expect(body).toContain('"type":"message_stop"');
+    expect(ledger.reconcileCalls).toBe(0); // nothing settled at stream close
+    expect(waitUntilPromises.length).toBe(1); // chain handed to waitUntil
+
+    releaseBilling();
+    await Promise.all(waitUntilPromises);
+
+    // The deferred chain ran exactly once, with the same amounts as before.
+    expect(billUsage).toHaveBeenCalledTimes(1);
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.actualCosts[0]).toBeCloseTo(EXPECTED_COST, 10);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance - EXPECTED_COST, 10);
+    expect(recordUsageAnalytics).toHaveBeenCalledTimes(1);
+  });
+
+  test("deferred chain bills with EXACTLY the same args as the inline (no-executionCtx) path", async () => {
+    // Deferred variant.
+    const waitUntilPromises: Promise<unknown>[] = [];
+    sdkFaithfulStream();
+    const deferredRes = await callStreaming(async () => null, {
+      executionCtx: {
+        waitUntil(promise: Promise<unknown>) {
+          waitUntilPromises.push(promise);
+        },
+      },
+    });
+    await deferredRes.text();
+    await Promise.all(waitUntilPromises);
+    expect(billUsage).toHaveBeenCalledTimes(1);
+    const deferredCall = billUsage.mock.calls[0];
+
+    // Inline variant (tests / non-Worker fallback): same scenario, no ctx.
+    billUsage.mockClear();
+    sdkFaithfulStream();
+    const inlineRes = await callStreaming(async () => null, {});
+    await inlineRes.text();
+    expect(billUsage).toHaveBeenCalledTimes(1);
+
+    // Parity: billing context (ids, requestId, source) + usage match.
+    expect(deferredCall).toEqual(billUsage.mock.calls[0]);
+  });
+
+  test("without executionCtx the chain settles inline by stream close (behavior unchanged)", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+
+    sdkFaithfulStream();
+    const res = await callStreaming(settle, {});
+    const body = await res.text();
+
+    expect(body).toContain('"type":"message_stop"');
+    expect(ledger.reconcileCalls).toBe(1); // settled before the body closed
+    expect(ledger.actualCosts[0]).toBeCloseTo(EXPECTED_COST, 10);
+  });
+
+  test("a stray late onError after a deferred onFinish cannot double-settle", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+    const waitUntilPromises: Promise<unknown>[] = [];
+
+    const stream = sdkFaithfulStream();
+    const res = await callStreaming(settle, {
+      executionCtx: {
+        waitUntil(promise: Promise<unknown>) {
+          waitUntilPromises.push(promise);
+        },
+      },
+    });
+    await res.text();
+    // The settlement promise is cached synchronously inside onFinish, so an
+    // onError racing in BEFORE the deferred chain resolves observes the same
+    // settlement instead of issuing a refund.
+    await stream.onError();
+    await Promise.all(waitUntilPromises);
+
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.actualCosts[0]).toBeCloseTo(EXPECTED_COST, 10);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance - EXPECTED_COST, 10);
+  });
+
+  test("client abort mid-stream with an executionCtx still records the delivered partial usage", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+    const estimatedInputTokens = 12;
+    const deliveredText = "partial response already sent";
+    const expectedCost =
+      estimatedInputTokens * INPUT_TOKEN_COST +
+      estimateTokens(deliveredText) * OUTPUT_TOKEN_COST;
+
+    let onAbortPromise: Promise<unknown> | undefined;
+    streamTextImpl = (config) => {
+      const onAbort = config.onAbort as
+        | ((event: { steps: [] }) => Promise<unknown> | unknown)
+        | undefined;
+      return {
+        fullStream: (async function* () {
+          yield { type: "text-start", id: "text-1" };
+          yield { type: "text-delta", id: "text-1", text: deliveredText };
+          onAbortPromise = Promise.resolve(onAbort?.({ steps: [] }));
+          yield { type: "abort", reason: "client disconnected" };
+        })(),
+      };
+    };
+
+    const waitUntilPromises: Promise<unknown>[] = [];
+    const res = await callStreaming(settle, {
+      estimatedInputTokens,
+      executionCtx: {
+        waitUntil(promise: Promise<unknown>) {
+          waitUntilPromises.push(promise);
+        },
+      },
+    });
+    const body = await res.text();
+    expect(onAbortPromise).toBeDefined();
+    await onAbortPromise;
+    await Promise.all(waitUntilPromises);
+
+    // The abort settle path is unchanged by the deferral: the delivered
+    // partial cost is still billed and recorded, never dropped.
+    expect(body).toContain(deliveredText);
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.actualCosts[0]).toBeCloseTo(expectedCost, 10);
+    expect(billUsage).toHaveBeenCalledTimes(1);
+    expect(recordUsageAnalytics).toHaveBeenCalledTimes(1);
+  });
+
+  test("deferred billing failure releases the reservation and never breaks the already-sent stream", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+    billUsageError = new Error("billing backend down");
+
+    const waitUntilPromises: Promise<unknown>[] = [];
+    sdkFaithfulStream();
+    const res = await callStreaming(settle, {
+      executionCtx: {
+        waitUntil(promise: Promise<unknown>) {
+          waitUntilPromises.push(promise);
+        },
+      },
+    });
+    const body = await res.text();
+
+    // The stream already completed normally — terminal frames intact.
+    expect(body).toContain(TEXT);
+    expect(body).toContain('"type":"message_stop"');
+    expect(body).not.toContain('"type":"error"');
+
+    // The deferred chain's failure branch released the hold (settle(0)).
+    await Promise.all(waitUntilPromises);
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.actualCosts).toEqual([0]);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance, 10);
+  });
+});
+
+describe("non-stream messages — billing settles OFF the response path (#15414 sibling)", () => {
+  test("Response.json returns BEFORE the billing chain completes; the chain runs via waitUntil with provider usage in the body", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+
+    let releaseBilling!: () => void;
+    billUsageGate = new Promise<void>((resolve) => {
+      releaseBilling = resolve;
+    });
+
+    const waitUntilPromises: Promise<unknown>[] = [];
+    sdkFaithfulGeneration();
+    const res = await callNonStreaming(settle, {
+      executionCtx: {
+        waitUntil(promise: Promise<unknown>) {
+          waitUntilPromises.push(promise);
+        },
+      },
+    });
+    // The Response arrived while billUsage is still gated — the regression
+    // under test would have awaited the whole chain before returning.
+    const json = (await res.json()) as {
+      content: Array<{ type: string; text?: string }>;
+      usage: { input_tokens: number; output_tokens: number };
+      stop_reason: string;
+    };
+    expect(json.content[0]?.text).toBe(TEXT);
+    // Usage in the body comes from the provider result, not the billing writes.
+    expect(json.usage.input_tokens).toBe(USAGE.inputTokens);
+    expect(json.usage.output_tokens).toBe(USAGE.outputTokens);
+    expect(ledger.reconcileCalls).toBe(0); // nothing settled at response time
+    expect(waitUntilPromises.length).toBe(1); // chain handed to waitUntil
+
+    releaseBilling();
+    await Promise.all(waitUntilPromises);
+
+    expect(billUsage).toHaveBeenCalledTimes(1);
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.actualCosts[0]).toBeCloseTo(EXPECTED_COST, 10);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance - EXPECTED_COST, 10);
+    expect(recordUsageAnalytics).toHaveBeenCalledTimes(1);
+  });
+
+  test("deferred chain bills with EXACTLY the same args as the inline (no-executionCtx) path", async () => {
+    const waitUntilPromises: Promise<unknown>[] = [];
+    sdkFaithfulGeneration();
+    await callNonStreaming(async () => null, {
+      executionCtx: {
+        waitUntil(promise: Promise<unknown>) {
+          waitUntilPromises.push(promise);
+        },
+      },
+    });
+    await Promise.all(waitUntilPromises);
+    expect(billUsage).toHaveBeenCalledTimes(1);
+    const deferredCall = billUsage.mock.calls[0];
+
+    billUsage.mockClear();
+    sdkFaithfulGeneration();
+    await callNonStreaming(async () => null, {});
+    expect(billUsage).toHaveBeenCalledTimes(1);
+
+    expect(deferredCall).toEqual(billUsage.mock.calls[0]);
+  });
+
+  test("without executionCtx the chain settles inline before the Response returns (behavior unchanged)", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+
+    sdkFaithfulGeneration();
+    const res = await callNonStreaming(settle, {});
+    expect(res.status).toBe(200);
+    expect(ledger.reconcileCalls).toBe(1); // settled before return
+    expect(ledger.actualCosts[0]).toBeCloseTo(EXPECTED_COST, 10);
+  });
+
+  test("deferred billing failure releases the reservation but the 200 with provider usage already went out", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+    billUsageError = new Error("billing backend down");
+
+    const waitUntilPromises: Promise<unknown>[] = [];
+    sdkFaithfulGeneration();
+    const res = await callNonStreaming(settle, {
+      executionCtx: {
+        waitUntil(promise: Promise<unknown>) {
+          waitUntilPromises.push(promise);
+        },
+      },
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      usage: { input_tokens: number; output_tokens: number };
+    };
+    expect(json.usage.input_tokens).toBe(USAGE.inputTokens);
+    expect(json.usage.output_tokens).toBe(USAGE.outputTokens);
+
+    await Promise.all(waitUntilPromises);
+    // The failure branch released the hold instead of stranding it.
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.actualCosts).toEqual([0]);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance, 10);
+  });
+
+  test("provider error before any response still refunds inline and rethrows (path unchanged)", async () => {
+    const ledger = makeLedgerReservation(100, 0.015);
+    const settle = createCreditReservationSettler(ledger.reservation);
+    generateTextImpl = () => {
+      throw new Error("provider exploded");
+    };
+
+    await expect(
+      callNonStreaming(settle, {
+        executionCtx: {
+          waitUntil() {
+            throw new Error("waitUntil must not be reached on this path");
+          },
+        },
+      }),
+    ).rejects.toThrow("provider exploded");
+
+    expect(ledger.reconcileCalls).toBe(1);
+    expect(ledger.actualCosts).toEqual([0]);
+    expect(ledger.balance).toBeCloseTo(ledger.startBalance, 10);
+    expect(billUsage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud/api/v1/messages/route.ts
+++ b/packages/cloud/api/v1/messages/route.ts
@@ -54,6 +54,7 @@ import {
   billUsage,
   estimateInputTokens,
   InsufficientCreditsError,
+  normalizeUsage,
   recordUsageAnalytics,
   reserveCredits,
 } from "@/lib/services/ai-billing";
@@ -69,6 +70,7 @@ import { resolveInferenceAuthContext } from "@/lib/services/inference-auth-conte
 import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
 import { logger } from "@/lib/utils/logger";
 import { getRouteTimeoutMs } from "@/lib/utils/request-timeout";
+import { settleOffResponsePath } from "@/lib/utils/settle-off-response-path";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
 const ROUTE_MAX_DURATION = 800;
@@ -524,6 +526,15 @@ app.use("*", rateLimit(RateLimitPresets.RELAXED));
 app.post("/", async (c) => {
   const startTime = Date.now();
   const routeTimeoutMs = getRouteTimeoutMs(ROUTE_MAX_DURATION);
+  // Workers ExecutionContext for off-response-path billing (#8759 / #15414).
+  // Hono's `executionCtx` getter THROWS outside a Worker (tests, node) — fall
+  // back to undefined so settleOffResponsePath runs the chain inline there.
+  let executionCtx: { waitUntil(promise: Promise<unknown>): void } | undefined;
+  try {
+    executionCtx = c.executionCtx;
+  } catch {
+    executionCtx = undefined;
+  }
   let settleReservation:
     | ((actualCost: number) => Promise<CreditReconciliationResult | null>)
     | null = null;
@@ -566,6 +577,7 @@ app.post("/", async (c) => {
     const message = error instanceof Error ? error.message : String(error);
     return anthropicError("authentication_error", message, 401);
   }
+  const tAuth = Date.now();
 
   const requestedAppId = c.req.header("X-App-Id");
   let appId: string | null = null;
@@ -656,6 +668,7 @@ app.post("/", async (c) => {
   const affiliateCode = c.req.header("X-Affiliate-Code") ?? null;
   const billingSource: PricingBillingSource =
     resolveAiProviderSource(model) ?? "bitrouter";
+  const tBeforeReserve = Date.now();
 
   let reservation: CreditReservation;
 
@@ -728,6 +741,21 @@ app.post("/", async (c) => {
   }
 
   settleReservation = createCreditReservationSettler(reservation);
+  const tAfterReserve = Date.now();
+
+  // Pre-forward latency breakdown — same instrumentation as
+  // [Chat Completions][preforward] (#9899) so the two inference routes are
+  // comparable. authMs = auth/org resolution; midReadsMs = app lookup + body
+  // parse + moderation + token estimate; reserveMs = the credit-reservation
+  // write; totalMs = everything before the model forward.
+  logger.info("[Messages API][preforward]", {
+    model,
+    authMs: tAuth - startTime,
+    midReadsMs: tBeforeReserve - tAuth,
+    reserveMs: tAfterReserve - tBeforeReserve,
+    totalMs: Date.now() - startTime,
+    stream: Boolean(request.stream),
+  });
 
   try {
     // Payload conversion is throwable (convertTools rejects a malformed-but-
@@ -756,46 +784,57 @@ app.post("/", async (c) => {
       stopSequences: request.stop_sequences,
     });
 
-    if (request.stream) {
-      return await handleStream(
-        model,
-        systemPrompt,
-        messages,
-        request,
-        user,
-        apiKey,
-        affiliateCode,
-        startTime,
-        estimatedInputTokens,
-        safeParams,
-        tools,
-        toolChoice,
-        c.req.raw.signal,
-        routeTimeoutMs,
-        settleReservation,
-        billingSource,
-        requestId,
+    const preforwardResponse = request.stream
+      ? await handleStream(
+          model,
+          systemPrompt,
+          messages,
+          request,
+          user,
+          apiKey,
+          affiliateCode,
+          startTime,
+          estimatedInputTokens,
+          safeParams,
+          tools,
+          toolChoice,
+          c.req.raw.signal,
+          routeTimeoutMs,
+          settleReservation,
+          billingSource,
+          requestId,
+          executionCtx,
+        )
+      : await handleNonStream(
+          model,
+          systemPrompt,
+          messages,
+          request,
+          user,
+          apiKey,
+          affiliateCode,
+          startTime,
+          safeParams,
+          tools,
+          toolChoice,
+          c.req.raw.signal,
+          routeTimeoutMs,
+          settleReservation,
+          billingSource,
+          requestId,
+          executionCtx,
+        );
+    // Same debug header as chat/completions (#9899): per-step pre-forward
+    // timing, no behavior change.
+    try {
+      preforwardResponse.headers.set(
+        "X-Eliza-Preforward-Ms",
+        `total=${Date.now() - startTime};auth=${tAuth - startTime};mid=${tBeforeReserve - tAuth};reserve=${tAfterReserve - tBeforeReserve}`,
       );
+    } catch {
+      // Some Response shapes have immutable headers — never fail a request for a debug header.
     }
-
-    return await handleNonStream(
-      model,
-      systemPrompt,
-      messages,
-      request,
-      user,
-      apiKey,
-      affiliateCode,
-      startTime,
-      safeParams,
-      tools,
-      toolChoice,
-      c.req.raw.signal,
-      routeTimeoutMs,
-      settleReservation,
-      billingSource,
-      requestId,
-    );
+    return preforwardResponse;
   } catch (error) {
     await settleReservation?.(0);
     const message = error instanceof Error ? error.message : String(error);
@@ -863,6 +902,7 @@ async function handleNonStream(
   // it billUsage falls back to legacy_<uuid> and a retry double-accrues cashable
   // affiliate earnings. Mirrors chat/completions (#11588).
   requestId: string,
+  executionCtx: { waitUntil(promise: Promise<unknown>): void } | undefined,
 ) {
   const provider = getProviderFromModel(model);
 
@@ -891,38 +931,68 @@ async function handleNonStream(
       ...cotOptions,
     });
 
-    const billing = await billUsage(
-      {
-        organizationId: user.organization_id,
-        userId: user.id,
-        apiKeyId: apiKey?.id,
-        model,
-        provider,
-        billingSource,
-        affiliateCode,
-        requestId,
-      },
-      result.usage,
-    );
-    await settleReservation(billing.totalCost);
+    // Token counts for the Anthropic-compatible response come straight from the
+    // model's reported usage, so the entire billing/settlement chain below can
+    // run off the response path without changing the bytes the client receives.
+    const responseTokens = normalizeUsage(result.usage);
 
-    await recordUsageAnalytics(
-      {
-        organizationId: user.organization_id,
-        userId: user.id,
-        apiKeyId: apiKey?.id,
-        model,
-        provider,
-        billingSource,
-      },
-      billing,
-      { type: "chat", content: result.text },
-    );
+    // Bill using actual usage from the SDK response. Deferred via waitUntil so
+    // the billUsage → settleReservation → analytics DB writes never block the
+    // response (#15414, non-stream sibling). Same code, same amounts, same
+    // reservation — only the timing moves. Mirrors chat/completions
+    // handleNonStreamingRequest (#15412 / #8759); without an executionCtx
+    // (tests, non-Worker callers) the chain runs inline exactly as before.
+    await settleOffResponsePath(executionCtx, async () => {
+      try {
+        const billing = await billUsage(
+          {
+            organizationId: user.organization_id,
+            userId: user.id,
+            apiKeyId: apiKey?.id,
+            model,
+            provider,
+            billingSource,
+            affiliateCode,
+            requestId,
+          },
+          result.usage,
+        );
+        await settleReservation(billing.totalCost);
 
-    logger.info("[Messages API] Non-streaming complete", {
-      durationMs: Date.now() - startTime,
-      inputTokens: billing.inputTokens,
-      outputTokens: billing.outputTokens,
+        await recordUsageAnalytics(
+          {
+            organizationId: user.organization_id,
+            userId: user.id,
+            apiKeyId: apiKey?.id,
+            model,
+            provider,
+            billingSource,
+          },
+          billing,
+          { type: "chat", content: result.text },
+        );
+
+        logger.info("[Messages API] Non-streaming complete", {
+          durationMs: Date.now() - startTime,
+          inputTokens: billing.inputTokens,
+          outputTokens: billing.outputTokens,
+        });
+      } catch (billingError) {
+        // Deferred billing failed after the response was already sent: release
+        // the held reservation so credit isn't stuck, and log. The settler is
+        // first-call-wins idempotent, so this can never double-refund.
+        try {
+          await settleReservation(0);
+        } catch {
+          // best-effort release
+        }
+        logger.error("[Messages API] deferred billing failed", {
+          error:
+            billingError instanceof Error
+              ? billingError.message
+              : String(billingError),
+        });
+      }
     });
 
     const responseContent: AnthropicResponseBlock[] = [];
@@ -966,8 +1036,8 @@ async function handleNonStream(
       stop_reason: stopReason,
       stop_sequence: stopSequence,
       usage: {
-        input_tokens: billing.inputTokens,
-        output_tokens: billing.outputTokens,
+        input_tokens: responseTokens.inputTokens,
+        output_tokens: responseTokens.outputTokens,
       },
     });
   } catch (error) {
@@ -1187,6 +1257,7 @@ async function handleStream(
   // it billUsage falls back to legacy_<uuid> and a retry double-accrues cashable
   // affiliate earnings. Mirrors chat/completions (#11588).
   requestId: string,
+  executionCtx?: { waitUntil(promise: Promise<unknown>): void },
 ) {
   const provider = getProviderFromModel(model);
   const messageId = `msg_${crypto.randomUUID().replace(/-/g, "").slice(0, 24)}`;
@@ -1258,8 +1329,20 @@ async function handleStream(
     ...(tools ? { tools } : {}),
     ...(toolChoice ? { toolChoice } : {}),
     ...cotOptions,
+    // Parity with chat/completions (#15412 / #8759): the settlement chain below
+    // (billUsage → settleReservation → analytics) is serial cross-provider DB
+    // round-trips, and the AI SDK awaits onFinish before it ends fullStream —
+    // so awaiting the chain inline held the final SSE frames (message_delta +
+    // message_stop) hostage for the full write latency (~8s measured on the
+    // completions route, #15414 here). Nothing the client receives depends on
+    // these writes (the terminal usage frame is built from the stream's own
+    // finish part), so defer them via waitUntil. settleStreamingOnce is still
+    // invoked synchronously — the settlement promise is cached before onFinish
+    // returns, so the idempotent first-call-wins guarantee against a racing
+    // onAbort/onError is unchanged — and without an executionCtx (tests,
+    // non-Worker callers) the chain is awaited inline exactly as before.
     onFinish: async ({ text, totalUsage }) => {
-      await settleStreamingOnce(async () => {
+      const settlement = settleStreamingOnce(async () => {
         try {
           const billing = await billUsage(
             {
@@ -1303,6 +1386,9 @@ async function handleStream(
           });
           return reconciliation;
         }
+      });
+      await settleOffResponsePath(executionCtx, async () => {
+        await settlement;
       });
     },
     // A client abort mid-stream must NOT release the whole hold: the upstream
@@ -1630,6 +1716,7 @@ async function handleStream(
  */
 export const __messagesStreamingCreditTestHooks = {
   handleStream,
+  handleNonStream,
 } as const;
 
 export default app;


### PR DESCRIPTION
## What

Closes #15414 (the `/v1/messages` streaming billing tail) and its non-stream sibling, per lanes B1+B2 of the gateway latency plan scoped on #15404. Template: #15412 (the identical fix for `/v1/chat/completions`, merged).

## Why

The AI SDK **awaits `onFinish` before ending `fullStream`**. Our `onFinish` awaited the full settlement chain inline — `billUsage` → `settleReservation` → `recordUsageAnalytics`, serial cross-provider DB round-trips — so the terminal SSE frames (`message_delta` + `message_stop`) were held hostage for the whole write latency (~8s measured for the identical pattern on chat/completions in #15404's traces). Anthropic-SDK clients that wait for `message_stop` ate the entire tail.

`handleNonStream` had the same bug in plainer form: it awaited the chain before `Response.json` returned.

None of the bytes the client receives depend on those writes — the streaming usage frame is built from the stream's own finish part, and the non-stream usage block comes from the provider result.

## How

Port `settleOffResponsePath` (from #15412) to both paths:

- **B1 — stream:** `onFinish` still invokes `settleStreamingOnce` **synchronously**, so the settlement promise is cached before `onFinish` returns — the idempotent first-call-wins guarantee against a racing `onAbort`/`onError` is unchanged. Only the *await* moves into `executionCtx.waitUntil`. The abort path (client disconnect mid-stream bills delivered partial usage, #11513) and provider-error refund path are untouched.
- **B2 — non-stream:** respond with the provider result's token counts (`normalizeUsage` — the same normalization `billUsage` applies), defer the billing chain via `waitUntil`. If deferred billing fails after the response went out, release the reservation via the idempotent settler and log — never a late 500, never a stranded hold.
- **No `executionCtx`** (tests, non-Worker callers): chain runs inline exactly as before.

**Billing always happens — only WHEN it runs moves, never whether.** Every path that recorded usage/charges still records: success, abort mid-stream, provider error, deferred failure (reservation released, logged).

Also (cheap, from the plan): `[Messages API][preforward]` phase-timing log + `X-Eliza-Preforward-Ms` debug header, parity with chat/completions (#9899), so warm-floor measurements work on this route too.

**Out of scope (deliberately):** B3 billing admission parity / reserve caching — money-path, gated on measurement, separate lane. `/v1/chat/completions` — already done in #15412.

## Tests

New suite `__tests__/messages-billing-offpath.test.ts` (11 tests, 57 asserts), mirroring #15412's `chat-completions-streaming-credit-leak.test.ts` approach — REAL `createCreditReservationSettler` against a ledger-backed reservation, gated `billUsage` to prove ordering:

- stream: terminal frames + `message_stop` flush while `billUsage` is still gated; chain handed to `waitUntil`, settles exactly once with the same amounts
- stream: deferred chain bills with EXACTLY the same args as the inline path
- stream: no `executionCtx` → inline settle by stream close (unchanged)
- stream: stray late `onError` after deferred `onFinish` cannot double-settle
- stream: abort mid-stream with `executionCtx` still bills delivered partial usage
- stream: deferred billing failure releases the hold, stream already ended clean
- non-stream: `Response.json` returns while `billUsage` gated; provider usage in body; chain via `waitUntil`
- non-stream: exact-args parity, inline fallback, deferred-failure hold release, provider-error rethrow path unchanged

```
__tests__/messages-billing-offpath.test.ts:          11 pass, 0 fail (57 expects)
__tests__/messages-abort-partial-settle.test.ts:      5 pass, 0 fail (33 expects)
__tests__/messages-billing-requestid-server-generated: 2 pass, 0 fail
__tests__/messages-reasoning-floor.test.ts:           4 pass, 0 fail
__tests__/messages-unknown-model-config-leak.test.ts: 3 pass, 0 fail
__tests__/chat-completions-streaming-credit-leak.test.ts: 16 pass, 0 fail (99 expects)
```

(`messages-iac-fast-path.test.ts` fails identically on pristine origin/develop — pre-existing mock-shape drift, not this change.)

`tsgo --noEmit`: zero errors in `v1/messages/route.ts` / the new test. Biome clean.

## Review note

⚠️ **Money-adjacent (billing timing): no self-merge — flagging for maintainer review.** The key invariants to check: settlement promise still cached synchronously in `onFinish`; abort path untouched; deferred-failure branch releases the reservation via the idempotent settler.

Refs: #15404, GATEWAY-LATENCY-PLAN B1/B2, #15412 (template), #8759 (settleOffResponsePath origin)

[sol-cloud]
