### PR TITLE
chore(cloud): enable INFERENCE_DEFERRED_ADMISSION on production

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -517,7 +517,7 @@ INFERENCE_BILLING_LEDGER = ""
 # executionCtx.waitUntil; the critical path keeps a cached 402 gate (15s
 # org-balance hint + in-isolate refusal blocklist). Requires
 # INFERENCE_OPTIMISTIC_BILLING. Off until soaked; cutover is an ops flip.
-INFERENCE_DEFERRED_ADMISSION = "false"
+INFERENCE_DEFERRED_ADMISSION = "true"
 # Tier-3 in-isolate decision caches (#9899): org rate-limit lease (convergent;
 # leased requests are carried back into the Redis window), 60s shouldBlockUser
 # memo, 60s model-catalog memo. Default off; rollback = flip off.


### PR DESCRIPTION
Second/final half of the prod inference hot-path flip (caches landed in #15421). Activates deferred billing admission on prod — the billing write moves off the response critical path via waitUntil. Prod already runs optimistic billing + $5 threshold, so this is the meaningful latency activation. Money-bar reviewed in #15409 (MERGE-FLAGS-OFF; exactly-once + under-bill-bounded + sweep-covered, D1 abuse hole closed & verified vs the real Redis pipeline). Rollback = flag back to false (byte-identical, no deploy risk). Latency delta + billing-row verification posted as a comment post-deploy.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - config flag, no UI.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - config flag, no UI.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - config only.
<!-- evidence-row:backend-logs -->
- [ ] N/A - before/after gateway latency + generations-row verification posted as a PR comment post-deploy; correctness covered by #15409's 230/0 suites.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model-path change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - billing rows verified live post-deploy (comment).
<!-- evidence-row:ocr-review -->
- [ ] N/A - no media.