### PR TITLE
perf(agent): parallelize + defer per-turn embedding calls off the reply critical path

### DIFF
--- a/packages/agent/src/api/chat-augmentation.test.ts
+++ b/packages/agent/src/api/chat-augmentation.test.ts
@@ -2,10 +2,15 @@
  * Unit tests for `maybeAugmentChatMessageWithDocuments`: the optional document
  * context must stay off the critical chat path — the lookup and LLM
  * query-recovery calls are time-bounded and aborted, recovery only fires when
- * weak candidates exist, and an empty corpus short-circuits before any
- * embed/search. Uses a mocked documents service and useModel; no live model.
+ * weak candidates exist, an empty corpus short-circuits before any
+ * embed/search, a seed-only corpus (bundled default docs) searches in keyword
+ * mode with no embed round-trip and no recovery call, and a rewrite aliases
+ * the envelope text onto the clean prompt's per-turn recall embed so in-run
+ * recall never re-embeds. Uses a mocked documents service and useModel; no
+ * live model.
  */
 import type { AgentRuntime, createMessageMemory } from "@elizaos/core";
+import { embedRecallQuery, ModelType } from "@elizaos/core";
 import { describe, expect, it, vi } from "vitest";
 
 import { maybeAugmentChatMessageWithDocuments } from "./chat-augmentation.ts";
@@ -179,6 +184,163 @@ describe("maybeAugmentChatMessageWithDocuments", () => {
 
     expect(documents.countMemories).toHaveBeenCalledTimes(1);
     expect(documents.searchDocuments).toHaveBeenCalled();
+  });
+
+  it("searches a seed-only corpus in keyword mode — no embed round-trip, no LLM recovery, and no injection for a zero-overlap query", async () => {
+    const message = makeMessage();
+    // Corpus is exactly the bundled seed set: keyword (BM25) search must be
+    // requested so the turn never pays the blocking gateway embed, and the
+    // seed corpus must never trigger the query-recovery model call even when
+    // weak candidates fall below the relevance threshold.
+    const documents = {
+      countMemories: vi.fn().mockResolvedValue(14),
+      getMemories: vi
+        .fn()
+        .mockResolvedValue([
+          { metadata: { addedFrom: "default-seed" } },
+          { metadata: { addedFrom: "default-seed" } },
+        ]),
+      searchDocuments: vi.fn().mockResolvedValue([
+        {
+          content: { text: "weakly overlapping FAQ fragment" },
+          similarity: 0.1,
+          metadata: {},
+        },
+      ]),
+    };
+    const useModel = vi.fn();
+    const runtime = makeRuntime(documents, useModel);
+
+    const result = await maybeAugmentChatMessageWithDocuments(runtime, message);
+
+    expect(result).toBe(message);
+    expect(documents.getMemories).toHaveBeenCalledWith(
+      expect.objectContaining({ tableName: "documents" }),
+    );
+    const [, , searchMode] = documents.searchDocuments.mock.calls[0];
+    expect(searchMode).toBe("keyword");
+    // Neither an embed nor the TEXT_LARGE recovery call may fire.
+    expect(useModel).not.toHaveBeenCalled();
+  });
+
+  it("still injects seed-FAQ context on a real keyword match — the seed-only gate skips the embed, not the lookup", async () => {
+    const message = makeMessage();
+    const documents = {
+      countMemories: vi.fn().mockResolvedValue(14),
+      getMemories: vi
+        .fn()
+        .mockResolvedValue([{ metadata: { addedFrom: "default-seed" } }]),
+      searchDocuments: vi.fn().mockResolvedValue([
+        {
+          content: { text: "Eliza Cloud monetization: set inference markup." },
+          similarity: 0.85,
+          metadata: { filename: "eliza-cloud-monetization.txt" },
+        },
+      ]),
+    };
+    const runtime = makeRuntime(documents);
+
+    const result = await maybeAugmentChatMessageWithDocuments(runtime, message);
+
+    expect(result).not.toBe(message);
+    expect(result.content.text).toContain("<contextual_documents>");
+    expect(result.content.text).toContain("set inference markup");
+    const [, , searchMode] = documents.searchDocuments.mock.calls[0];
+    expect(searchMode).toBe("keyword");
+  });
+
+  it("keeps the full hybrid path when any non-seed document exists", async () => {
+    const message = makeMessage();
+    const documents = {
+      countMemories: vi.fn().mockResolvedValue(20),
+      getMemories: vi
+        .fn()
+        .mockResolvedValue([
+          { metadata: { addedFrom: "default-seed" } },
+          { metadata: { addedFrom: "upload" } },
+        ]),
+      searchDocuments: vi.fn().mockResolvedValue([]),
+    };
+    const runtime = makeRuntime(documents);
+
+    await maybeAugmentChatMessageWithDocuments(runtime, message);
+
+    const [, , searchMode] = documents.searchDocuments.mock.calls[0];
+    expect(searchMode).toBeUndefined();
+  });
+
+  it("fails open to the hybrid path when the seed probe errors or the corpus exceeds the probe cap", async () => {
+    const probeCases = [
+      // Probe rejects → classification unknown → full retrieval path.
+      vi.fn().mockRejectedValue(new Error("documents table unavailable")),
+      // Corpus at the probe cap → cannot be the bundled seed set → hybrid,
+      // even though every probed row carries the seed marker.
+      vi.fn().mockResolvedValue(
+        Array.from({ length: 32 }, () => ({
+          metadata: { addedFrom: "default-seed" },
+        })),
+      ),
+    ];
+    for (const getMemories of probeCases) {
+      const message = makeMessage();
+      const documents = {
+        countMemories: vi.fn().mockResolvedValue(40),
+        getMemories,
+        searchDocuments: vi.fn().mockResolvedValue([]),
+      };
+      const runtime = makeRuntime(documents);
+
+      await maybeAugmentChatMessageWithDocuments(runtime, message);
+
+      const [, , searchMode] = documents.searchDocuments.mock.calls[0];
+      expect(searchMode).toBeUndefined();
+    }
+  });
+
+  it("aliases the augmentation envelope onto the clean prompt's recall embed — in-run recall of the rewritten text issues zero new embeds", async () => {
+    const message = makeMessage();
+    const documents = {
+      countMemories: vi.fn().mockResolvedValue(3),
+      getMemories: vi
+        .fn()
+        .mockResolvedValue([{ metadata: { addedFrom: "upload" } }]),
+      searchDocuments: vi.fn().mockResolvedValue([
+        {
+          content: { text: "The QA codeword is BLUEBIRD." },
+          similarity: 0.9,
+          metadata: { filename: "qa.txt" },
+        },
+      ]),
+    };
+    const embedCalls: string[] = [];
+    const useModel = vi.fn(
+      async (modelType: string, params: { text: string }) => {
+        if (modelType !== ModelType.TEXT_EMBEDDING) {
+          throw new Error(`unexpected model ${modelType}`);
+        }
+        embedCalls.push(params.text);
+        return [0.1, 0.2, 0.3];
+      },
+    );
+    const runtime = makeRuntime(documents, useModel);
+
+    const result = await maybeAugmentChatMessageWithDocuments(runtime, message);
+    expect(result).not.toBe(message);
+    expect(result.content.text).toContain("<contextual_documents>");
+
+    // The rewrite warmed ONE embed of the clean prompt (the mocked service
+    // never embedded, so the warm is the turn's only round-trip)…
+    expect(embedCalls).toEqual(["what are you up to?"]);
+
+    // …and the in-run recall callers presenting the ENVELOPE text (as the
+    // message-service prefetch and relevant-conversations provider do) resolve
+    // the aliased vector with no additional embed.
+    const envelopeText = result.content.text as string;
+    const vec = await embedRecallQuery(runtime, envelopeText, {
+      messageId: message.id as string,
+    });
+    expect(vec).toEqual([0.1, 0.2, 0.3]);
+    expect(embedCalls).toEqual(["what are you up to?"]);
   });
 
   it("passes the original message id as turnMessageId so the in-run recall embed adopts this pre-run embed (#15253)", async () => {

--- a/packages/agent/src/api/chat-augmentation.ts
+++ b/packages/agent/src/api/chat-augmentation.ts
@@ -22,10 +22,16 @@ import type {
   Memory,
   UUID,
 } from "@elizaos/core";
-import { buildAccessContext, parseJSONObjectFromText } from "@elizaos/core";
+import {
+  aliasRecallQuery,
+  buildAccessContext,
+  embedRecallQuery,
+  parseJSONObjectFromText,
+} from "@elizaos/core";
 import { normalizeCharacterLanguage } from "@elizaos/shared";
 import { extractCompatTextContent } from "./compat-utils.ts";
 import {
+  type DocumentSearchMode,
   type DocumentsServiceLike,
   getDocumentsService,
 } from "./documents-service-loader.ts";
@@ -86,6 +92,13 @@ const MAX_CHAT_DOCUMENTS_LOOKUP_TIMEOUT_MS = 30_000;
 const MAX_CHAT_DOCUMENTS_RECOVERY_TIMEOUT_MS = 30_000;
 const CHAT_DOCUMENTS_RECOVERY_MODEL = "TEXT_LARGE";
 
+// Upper bound on the documents-table probe that classifies the corpus as
+// seed-only. The bundled seed set (default-documents.ts + the per-topic help
+// FAQ) is ~14 documents; a corpus at or above this cap cannot be seed-only, so
+// the probe treats hitting the cap as "user documents exist" without paging.
+const CHAT_DOCUMENTS_SEED_PROBE_LIMIT = 32;
+const SEED_DOCUMENT_ADDED_FROM = "default-seed";
+
 // Sentinel requester id for an unresolved/unauthenticated chat turn. It is the
 // nil UUID — guaranteed to be neither the agent nor any real owner — so the
 // scope-read filter resolves it to a least-privileged USER and strips every
@@ -139,6 +152,31 @@ function resolveRecoveryTimeoutMs(explicit?: number): number {
     "ELIZA_CHAT_DOCUMENT_RECOVERY_TIMEOUT_MS",
     DEFAULT_CHAT_DOCUMENTS_RECOVERY_TIMEOUT_MS,
     MAX_CHAT_DOCUMENTS_RECOVERY_TIMEOUT_MS,
+  );
+}
+
+/**
+ * True when every document in the corpus is a bundled seed document
+ * (`metadata.addedFrom === "default-seed"` — the Eliza overview / Cloud basics
+ * / help-FAQ set from default-documents.ts). Character knowledge
+ * (`addedFrom: "character"`) and anything a user or the agent added count as a
+ * real corpus. Fails open to `false` (the full retrieval path) on a probe
+ * error or when the corpus is too large to be the seed set.
+ */
+async function corpusHasOnlySeedDocuments(
+  documents: DocumentsServiceLike,
+): Promise<boolean> {
+  const docs = await documents.getMemories({
+    tableName: "documents",
+    count: CHAT_DOCUMENTS_SEED_PROBE_LIMIT,
+  });
+  if (docs.length === 0 || docs.length >= CHAT_DOCUMENTS_SEED_PROBE_LIMIT) {
+    return false;
+  }
+  return docs.every(
+    (doc) =>
+      (doc.metadata as Record<string, unknown> | undefined)?.addedFrom ===
+      SEED_DOCUMENT_ADDED_FROM,
   );
 }
 
@@ -213,6 +251,35 @@ export async function maybeAugmentChatMessageWithDocuments(
   } catch {
     // Count failed — do not skip; let the normal search path run.
   }
+
+  // Classify the corpus: bundled seed docs only, or a real (user/agent-added)
+  // corpus. Agents whose only corpus is the default seed set — every default
+  // cloud agent — otherwise pay the hybrid search's blocking embed round-trip
+  // (~1.5-2.7s of gateway floor, the dominant pre-reply latency) on EVERY turn,
+  // and because hybrid similarity is max-normalized over the candidate set the
+  // top seed fragment almost always clears the relevance threshold, injecting
+  // help-FAQ snippets into unrelated turns. Seed-only corpora therefore search
+  // in keyword (BM25) mode: no embed round-trip, and the FAQ still surfaces on
+  // real term overlap (BM25 scores zero-overlap queries 0 → no injection). A
+  // probe failure falls open to the full hybrid path.
+  let seedOnlyCorpus = false;
+  try {
+    seedOnlyCorpus = await corpusHasOnlySeedDocuments(documents.service);
+  } catch (error) {
+    // error-policy:J4 a failed probe degrades to the FULL hybrid retrieval
+    // path (the pre-optimization behavior), never to a skipped or downgraded
+    // lookup — retrieval richness is preserved, only the latency win is lost.
+    runtime.logger.warn(
+      {
+        src: "api:chat-augmentation",
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "Seed-corpus probe failed; using the full hybrid document retrieval path",
+    );
+  }
+  const searchMode: DocumentSearchMode | undefined = seedOnlyCorpus
+    ? "keyword"
+    : undefined;
 
   const agentId = runtime.agentId as UUID;
 
@@ -313,7 +380,7 @@ export async function maybeAugmentChatMessageWithDocuments(
             },
           },
           { roomId: scopeRoomId },
-          undefined,
+          searchMode,
           accessContext,
           { turnMessageId },
         )) ?? [],
@@ -462,8 +529,16 @@ export async function maybeAugmentChatMessageWithDocuments(
     // indexed, or — on hosts forced onto zero/low-dim embeddings, e.g. cloud
     // agents pinned to local gte-small — nothing ever clears retrieval), the
     // recovery call is guaranteed to match nothing too: it just burns one full
-    // generate-text round-trip on every plain-chat turn. Skip it.
-    if (relevantMatches.length === 0 && initialMatches.matches.length > 0) {
+    // generate-text round-trip on every plain-chat turn. Skip it. Seed-only
+    // corpora skip recovery outright: it exists to find user documents
+    // referenced obliquely ("the uploaded file"); with no user documents the
+    // rephrased queries can only re-match the same bundled FAQ the direct
+    // search already scored.
+    if (
+      !seedOnlyCorpus &&
+      relevantMatches.length === 0 &&
+      initialMatches.matches.length > 0
+    ) {
       const recoveredQueries = await recoverDocumentSearchQueriesWithLlm();
       // Run the recovered-query searches concurrently. Each is an independent
       // embedding round-trip (~1.5s); awaiting them one at a time was the bulk
@@ -529,23 +604,44 @@ export async function maybeAugmentChatMessageWithDocuments(
     })
     .join("\n\n");
 
+  const augmentedText = [
+    "Answer the user request using the contextual documents below as the source of truth when they contain the answer.",
+    "If the answer appears verbatim in the contextual documents, repeat it exactly.",
+    "Do not ask follow-up questions or invoke tools/actions when the contextual documents already answer the request.",
+    "",
+    "<contextual_documents>",
+    contextualDocuments,
+    "</contextual_documents>",
+    "",
+    "<user_request>",
+    userPrompt,
+    "</user_request>",
+  ].join("\n");
+
+  // The rewrite changes the text every in-run recall caller (TTFT prefetch,
+  // relevant-conversations, FACTS) presents to the shared per-turn embed cache,
+  // which would miss and issue a second serial embed round-trip (~1.5-2.7s of
+  // gateway floor) for a query polluted by the injected snippets. Warm the
+  // clean-prompt embed (a cache hit when the hybrid search above already
+  // embedded it; a fresh fire-and-forget round-trip on the keyword/seed-only
+  // path, overlapping the turn instead of blocking it) and alias the envelope
+  // text onto it, so the whole turn shares one embed of what the user actually
+  // asked. `embedRecallQuery` registers its in-flight promise synchronously,
+  // so the alias below always finds it.
+  if (turnMessageId) {
+    void embedRecallQuery(runtime, userPrompt, { messageId: turnMessageId });
+    aliasRecallQuery(runtime, {
+      messageId: turnMessageId,
+      sourceText: userPrompt,
+      aliasText: augmentedText,
+    });
+  }
+
   return {
     ...message,
     content: {
       ...(message.content as Content),
-      text: [
-        "Answer the user request using the contextual documents below as the source of truth when they contain the answer.",
-        "If the answer appears verbatim in the contextual documents, repeat it exactly.",
-        "Do not ask follow-up questions or invoke tools/actions when the contextual documents already answer the request.",
-        "",
-        "<contextual_documents>",
-        contextualDocuments,
-        "</contextual_documents>",
-        "",
-        "<user_request>",
-        userPrompt,
-        "</user_request>",
-      ].join("\n"),
+      text: augmentedText,
     },
   };
 }

--- a/packages/core/src/features/documents/index.ts
+++ b/packages/core/src/features/documents/index.ts
@@ -55,7 +55,7 @@ export { documentAction, documentActions } from "./actions";
 export type { Bm25Document, Bm25Options, Bm25Score } from "./bm25";
 export { bm25Scores, normalizeBm25Scores, tokenize } from "./bm25";
 export { documentsProvider } from "./provider";
-export { embedRecallQuery } from "./recall-embed";
+export { aliasRecallQuery, embedRecallQuery } from "./recall-embed";
 export type { SearchMode } from "./service";
 export { DocumentService } from "./service";
 export * from "./types";

--- a/packages/core/src/features/documents/recall-embed.test.ts
+++ b/packages/core/src/features/documents/recall-embed.test.ts
@@ -1,15 +1,18 @@
 /**
- * Unit tests for `embedRecallQuery`: it returns the embedding on success, fails
- * open to `null` on an embed error (never throwing onto the reply path), and
- * caches/dedupes identical normalized recall queries within a turn (including
- * across providers). Runs against `createMockRuntime` with a synchronous fake
- * embed model — deterministic, no live LLM.
+ * Unit tests for `embedRecallQuery` + `aliasRecallQuery`: the embed returns the
+ * vector on success, fails open to `null` on an embed error (never throwing
+ * onto the reply path), and caches/dedupes identical normalized recall queries
+ * within a turn (including across providers); the alias maps a rewritten
+ * (document-augmented) prompt onto the clean prompt's cached or in-flight
+ * vector so a rewrite never costs a second per-turn embed. Runs against
+ * `createMockRuntime` with a synchronous fake embed model — deterministic, no
+ * live LLM.
  */
 import { describe, expect, test } from "vitest";
 import { createMockRuntime } from "../../testing/mock-runtime";
 import type { IAgentRuntime } from "../../types";
 import { ModelType } from "../../types";
-import { embedRecallQuery } from "./recall-embed.ts";
+import { aliasRecallQuery, embedRecallQuery } from "./recall-embed.ts";
 
 const RUN_A = "11111111-1111-1111-1111-111111111111";
 const RUN_B = "22222222-2222-2222-2222-222222222222";
@@ -68,6 +71,24 @@ describe("embedRecallQuery — resolve / fail-open", () => {
 			embed: async () => {
 				throw new Error("embeddings endpoint 500");
 			},
+		});
+		await expect(embedRecallQuery(runtime, "boom")).resolves.toBeNull();
+	});
+
+	test("a SYNCHRONOUSLY-throwing model handler also fails open — fire-and-forget callers never see an unhandled rejection", async () => {
+		const runtime = createMockRuntime({
+			getCurrentRunId: () => RUN_A,
+			useModel: () => {
+				throw new Error("no TEXT_EMBEDDING handler registered");
+			},
+		});
+		await expect(embedRecallQuery(runtime, "boom")).resolves.toBeNull();
+	});
+
+	test("a handler resolving to a non-array fails open to null, not a garbage value", async () => {
+		const runtime = createMockRuntime({
+			getCurrentRunId: () => RUN_A,
+			useModel: () => Promise.resolve(undefined),
 		});
 		await expect(embedRecallQuery(runtime, "boom")).resolves.toBeNull();
 	});
@@ -361,6 +382,167 @@ describe("embedRecallQuery — pre-run messageId cache + in-run adoption (#15253
 		await embedRecallQuery(runtime, "background query");
 		await embedRecallQuery(runtime, "background query");
 		expect(calls.count).toBe(2);
+	});
+
+	test("aliasRecallQuery maps a rewritten prompt onto a RESOLVED clean-prompt vector — the in-run envelope caller issues zero new embeds", async () => {
+		const { runtime, calls, setRun } = makeControllableRuntime(async () => [
+			0.6, 0.7,
+		]);
+
+		// Pre-run document augmentation embeds the clean user prompt…
+		const clean = await embedRecallQuery(
+			runtime,
+			"what is the refund policy?",
+			{
+				messageId: MSG_A,
+			},
+		);
+		expect(clean).toEqual([0.6, 0.7]);
+		expect(calls.count).toBe(1);
+
+		// …then rewrites the message into the contextual-documents envelope and
+		// declares the two texts equivalent for this turn's recall.
+		const envelope =
+			"Answer the user request using the contextual documents below…\n<user_request>\nwhat is the refund policy?\n</user_request>";
+		aliasRecallQuery(runtime, {
+			messageId: MSG_A,
+			sourceText: "what is the refund policy?",
+			aliasText: envelope,
+		});
+
+		// In-run recall callers (prefetch / relevant-conversations / FACTS) present
+		// the envelope text: same vector, no second round-trip.
+		setRun(RUN_A);
+		const inRun = await embedRecallQuery(runtime, envelope, {
+			messageId: MSG_A,
+		});
+		expect(inRun).toEqual([0.6, 0.7]);
+		const composeTime = await embedRecallQuery(runtime, envelope);
+		expect(composeTime).toEqual([0.6, 0.7]);
+		expect(calls.count).toBe(1);
+	});
+
+	test("aliasRecallQuery joins an IN-FLIGHT source embed — alias registered synchronously after a fire-and-forget warm still shares the one round-trip", async () => {
+		let resolveEmbed: ((v: number[]) => void) | undefined;
+		const { runtime, calls, setRun } = makeControllableRuntime(
+			() =>
+				new Promise<number[]>((resolve) => {
+					resolveEmbed = resolve;
+				}),
+		);
+
+		// Fire-and-forget warm of the clean prompt (the keyword/seed-only path:
+		// no search embed preceded it), alias registered immediately while the
+		// embed is still in flight.
+		const warm = embedRecallQuery(runtime, "clean prompt", {
+			messageId: MSG_A,
+		});
+		aliasRecallQuery(runtime, {
+			messageId: MSG_A,
+			sourceText: "clean prompt",
+			aliasText: "envelope wrapping the clean prompt",
+		});
+		expect(calls.count).toBe(1);
+
+		// The in-run envelope caller joins the shared in-flight promise.
+		setRun(RUN_A);
+		const inRun = embedRecallQuery(
+			runtime,
+			"envelope wrapping the clean prompt",
+			{
+				messageId: MSG_A,
+			},
+		);
+		expect(calls.count).toBe(1);
+
+		resolveEmbed?.([0.8]);
+		await expect(warm).resolves.toEqual([0.8]);
+		await expect(inRun).resolves.toEqual([0.8]);
+		expect(calls.count).toBe(1);
+
+		// Once resolved, later envelope callers hit the result cache.
+		await expect(
+			embedRecallQuery(runtime, "envelope wrapping the clean prompt"),
+		).resolves.toEqual([0.8]);
+		expect(calls.count).toBe(1);
+	});
+
+	test("aliasRecallQuery is a safe no-op when the source was never embedded — the alias-text caller embeds directly (fail-open unchanged)", async () => {
+		const { runtime, calls, setRun } = makeControllableRuntime(async () => [
+			0.2,
+		]);
+		aliasRecallQuery(runtime, {
+			messageId: MSG_A,
+			sourceText: "never embedded",
+			aliasText: "envelope text",
+		});
+		setRun(RUN_A);
+		const vec = await embedRecallQuery(runtime, "envelope text", {
+			messageId: MSG_A,
+		});
+		expect(vec).toEqual([0.2]);
+		expect(calls.count).toBe(1);
+	});
+
+	test("aliasRecallQuery does not cache a FAILED source embed under the alias: the alias caller joins the in-flight failure, fails open, then re-embeds fresh", async () => {
+		let shouldFail = true;
+		const { runtime, calls, setRun } = makeControllableRuntime(async () => {
+			if (shouldFail) {
+				throw new Error("embeddings endpoint 500");
+			}
+			return [0.9];
+		});
+
+		const warm = embedRecallQuery(runtime, "clean prompt", {
+			messageId: MSG_A,
+		});
+		aliasRecallQuery(runtime, {
+			messageId: MSG_A,
+			sourceText: "clean prompt",
+			aliasText: "envelope text",
+		});
+		setRun(RUN_A);
+		// Joins the shared (failing) in-flight promise → fails open to null.
+		const joined = embedRecallQuery(runtime, "envelope text", {
+			messageId: MSG_A,
+		});
+		await expect(warm).resolves.toBeNull();
+		await expect(joined).resolves.toBeNull();
+		expect(calls.count).toBe(1);
+
+		await yieldMacrotask();
+
+		// Nothing poisoned the cache: the next envelope caller re-embeds fresh.
+		shouldFail = false;
+		await expect(
+			embedRecallQuery(runtime, "envelope text", { messageId: MSG_A }),
+		).resolves.toEqual([0.9]);
+		expect(calls.count).toBe(2);
+	});
+
+	test("aliasRecallQuery no-ops on identical normalized texts and on callers with no turn key", async () => {
+		const { runtime, calls, setRun } = makeControllableRuntime(async () => [
+			0.5,
+		]);
+		await embedRecallQuery(runtime, "same text", { messageId: MSG_A });
+		expect(calls.count).toBe(1);
+
+		// Identical normalized source/alias: nothing to map.
+		aliasRecallQuery(runtime, {
+			messageId: MSG_A,
+			sourceText: "same text",
+			aliasText: "  SAME   text ",
+		});
+		setRun(RUN_A);
+		await embedRecallQuery(runtime, "same text", { messageId: MSG_A });
+		expect(calls.count).toBe(1);
+
+		// No run + no messageId: no slot exists to alias into; must not throw.
+		setRun(null);
+		aliasRecallQuery(runtime, {
+			sourceText: "same text",
+			aliasText: "other text",
+		});
 	});
 
 	test("in-flight dedupe spans the pre-run/in-run boundary: a pre-run embed and an in-run adopt of the same messageId share one round-trip", async () => {

--- a/packages/core/src/features/documents/recall-embed.ts
+++ b/packages/core/src/features/documents/recall-embed.ts
@@ -30,6 +30,16 @@
  * attributed to the wrong turn (worst case: a cache miss, never a wrong vector).
  * A caller with neither key (background/non-turn) embeds directly, uncached.
  *
+ * **Alias keys for rewritten prompts.** Document augmentation rewrites the
+ * turn's `content.text` into a contextual-documents envelope AFTER the recall
+ * embed of the clean user prompt already ran. Every in-run recall caller then
+ * presents the envelope text, whose normalized key would miss the cached
+ * vector and issue a second, serial embed round-trip for the same turn.
+ * `aliasRecallQuery` lets the rewriter declare both texts equivalent for this
+ * turn's recall, mapping the envelope key onto the clean-prompt vector — which
+ * is also the semantically correct recall query (the user's request, not the
+ * injected document context).
+ *
  * **Fail-open on error only.** A failed embed (the model handler rejects — e.g.
  * its own request timeout aborts, or the provider errors) returns `null`; the
  * caller falls open to keyword/BM25 recall (or, for callers with no keyword
@@ -169,9 +179,28 @@ export async function embedRecallQuery(
 	// Dedupe concurrent identical embeds to a single in-flight round-trip.
 	let pending = cache?.inFlight.get(normalized);
 	if (!pending) {
-		pending = runtime.useModel(ModelType.TEXT_EMBEDDING, {
-			text: queryText,
-		}) as Promise<number[]>;
+		try {
+			// Promise.resolve guards a model handler that returns a bare value (or
+			// nothing); the catch guards one that throws synchronously. Both are the
+			// same failure as a rejected embed and must fail OPEN here — several
+			// callers (the augmentation warm, the message-service prefetch) invoke
+			// this fire-and-forget, so a rejection escaping this async fn would
+			// surface as an unhandled rejection instead of degraded recall.
+			pending = Promise.resolve(
+				runtime.useModel(ModelType.TEXT_EMBEDDING, {
+					text: queryText,
+				}) as Promise<number[]>,
+			);
+		} catch (error) {
+			logger.debug(
+				{
+					src: "core:documents:recall-embed",
+					error: error instanceof Error ? error.message : String(error),
+				},
+				"Recall-query embed threw synchronously; failing open to keyword recall",
+			);
+			return null;
+		}
 		cache?.inFlight.set(normalized, pending);
 		// Populate the per-turn result cache so a later identical query in the same
 		// turn reuses this vector instead of issuing a new call, and clear the
@@ -192,7 +221,10 @@ export async function embedRecallQuery(
 	}
 
 	try {
-		return await pending;
+		const vector = await pending;
+		// A handler that resolved to a non-array (e.g. undefined) failed to embed;
+		// report that as the fail-open null, not a garbage value.
+		return Array.isArray(vector) ? vector : null;
 	} catch (error) {
 		logger.debug(
 			{
@@ -203,4 +235,77 @@ export async function embedRecallQuery(
 		);
 		return null;
 	}
+}
+
+/**
+ * Declare `aliasText` equivalent to `sourceText` for this turn's recall: any
+ * recall caller presenting `aliasText` resolves to `sourceText`'s vector from
+ * the per-turn cache instead of issuing its own embed round-trip.
+ *
+ * The one producer is document augmentation: after it rewrites the turn's
+ * message text into the contextual-documents envelope, the in-run recall
+ * callers (TTFT prefetch, relevant-conversations, FACTS) all present the
+ * envelope text. Without the alias each turn with a document match pays a
+ * second serial embed for a query that is strictly WORSE (the injected
+ * document snippets drown the user's request); with it, one embed of the clean
+ * prompt serves the whole turn.
+ *
+ * The alias joins an in-flight source embed rather than waiting for it, so it
+ * can be registered synchronously right after a fire-and-forget
+ * `embedRecallQuery` warm of the source text. When the source was never
+ * embedded (or its embed failed), this is a no-op and alias-text callers embed
+ * directly — the fail-open contract is unchanged.
+ */
+export function aliasRecallQuery(
+	runtime: IAgentRuntime,
+	options: { messageId?: string; sourceText: string; aliasText: string },
+): void {
+	const sourceKey = normalizeQuery(options.sourceText);
+	const aliasKey = normalizeQuery(options.aliasText);
+	if (!sourceKey || !aliasKey || sourceKey === aliasKey) {
+		return;
+	}
+
+	let runId: string;
+	try {
+		runId = runtime.getCurrentRunId();
+	} catch {
+		// No active run (the pre-run augmentation caller): key by messageId, the
+		// same fallback embedRecallQuery uses, so both resolve one slot.
+		runId = "";
+	}
+	if (runId === "" && options.messageId === undefined) {
+		// No turn key at all — nothing is cached for this caller, so there is no
+		// slot to alias into.
+		return;
+	}
+
+	const cache = getTurnCache(runtime, runId, options.messageId);
+	const resolved = cache.results.get(sourceKey);
+	if (resolved) {
+		cache.results.set(aliasKey, resolved);
+		return;
+	}
+
+	const pending = cache.inFlight.get(sourceKey);
+	if (!pending) {
+		return;
+	}
+	// Mirror embedRecallQuery's in-flight bookkeeping under the alias key so a
+	// concurrent alias-text caller joins the source round-trip instead of
+	// starting its own.
+	cache.inFlight.set(aliasKey, pending);
+	void pending
+		.then((vector) => {
+			if (Array.isArray(vector) && vector.length > 0) {
+				cache.results.set(aliasKey, vector);
+			}
+		})
+		.catch(() => {
+			// Swallow: the source caller logs + fails open; an alias-text caller
+			// awaiting this shared promise fails open through its own catch.
+		})
+		.finally(() => {
+			cache.inFlight.delete(aliasKey);
+		});
 }


### PR DESCRIPTION
Cuts the serial gateway embedding round-trips a dedicated-agent chat turn pays before its reply model call. Refs #15428 (gateway adds a ~1.5-2.7s floor per call; a turn was making 1 RESPONSE_HANDLER + 2-3 embedding calls, serially). Complementary to the already-landed per-turn embed dedupe (#15253) and the empty-corpus doc-lookup skip (#8862) — this PR closes the two per-turn embed costs those left behind.

## The measured map of pre-turn embedding calls (develop, before this PR)

| # | Call | Where | Blocking? | Notes |
|---|------|-------|-----------|-------|
| 1 | doc-lookup recall embed | `maybeAugmentChatMessageWithDocuments` → `searchDocuments` → `embedRecallQuery` (`packages/agent/src/api/chat-augmentation.ts`) | **YES — pre-run, strictly serial before `handleMessage` starts** | #8862'''s `document_fragments` count skip never fires for default cloud agents: `default-documents.ts` seeds a 14-doc help-FAQ corpus, so every turn pays this embed. Worse: hybrid search max-normalizes similarity over the candidate set, so the **top seed fragment scores ≥ 0.6 whenever any candidate clears the raw 0.05 cosine floor** — the 0.2 relevance threshold passes and unrelated FAQ snippets get injected into casual turns. |
| 2 | in-run recall embed of the REWRITTEN text | message-service TTFT prefetch + relevant-conversations + FACTS (`packages/core/src/services/message.ts`, `packages/agent/src/providers/relevant-conversations.ts`) | **YES — a second serial round-trip on every doc-match turn** | #15253'''s shared per-turn cache keys on normalized text. When augmentation rewrites `content.text` into the contextual-documents envelope, every in-run recall caller presents the *envelope* text → cache miss → a fresh embed of a query polluted by the injected snippets. Because of the ≥ 0.6 guarantee above, seed-doc agents hit this on most turns: **2 serial embeds + 1 RESPONSE_HANDLER ≈ the "2-3 embeddings/turn" measured in #15428.** |
| 3 | user-message persist embedding | `queueEmbeddingGeneration` → `EMBEDDING_GENERATION_REQUESTED` → background `BatchQueue` (`packages/core/src/services/message.ts:9503-9517`, `runtime.ts:9051`, `services/embedding.ts`) | no — already deferred | Already off the reply path on develop; the memory row gets its vector from the background queue, computed from the **clean stripped text** (`stripAugmentationForPersistence`). Untouched. |
| 4 | relevant-conversations / experience / FACTS embeds | compose-time providers | no — already deduped | All route through `embedRecallQuery` (#15253) and adopt the turn'''s single vector. Untouched — this PR makes the dedupe *survive the rewrite* (row 2). |

So of "parallelize the 2-3 independent embeds": develop already collapsed them to one shared embed per turn (#15253) — better than parallel — **except** rows 1 and 2, which this PR removes.

## What changed

**1. Seed-only corpora search in keyword (BM25) mode — zero embed round-trips (`chat-augmentation.ts`).** A cheap `documents`-table probe (≤ 32 rows, one indexed read next to the existing fragment count) classifies the corpus: when every document carries `metadata.addedFrom === "default-seed"`, the lookup runs `searchDocuments(..., "keyword", ...)` — pure in-process BM25, an existing first-class search mode (it is already the no-embedding-model fallback). The help FAQ still surfaces on real term overlap ("how do I monetize on Eliza Cloud" → FAQ context injected — test proves it); a zero-overlap casual turn scores 0 → no candidates → no injection (fixing the ≥ 0.6 hybrid-normalization FAQ pollution as a side effect). The `TEXT_LARGE` query-recovery call is also skipped for seed-only corpora — it exists to find user documents referenced obliquely ("the uploaded file"); with no user documents it can only re-score the same bundled FAQ. Any user/agent/`character`-added document, a probe error, or a corpus at the probe cap ⇒ the full hybrid path, unchanged (fail-open, warn-logged).

**2. `aliasRecallQuery`: the envelope text maps onto the clean prompt'''s per-turn vector (`recall-embed.ts` + the rewrite site in `chat-augmentation.ts`).** On a rewrite, augmentation warms the clean-prompt embed (a cache hit when the hybrid search already embedded it; a fire-and-forget start of the turn'''s single embed on the keyword path) and declares the envelope text equivalent. The in-run prefetch, relevant-conversations, and FACTS then resolve the cached/in-flight vector — **zero additional embeds** — and semantic recall queries what the user actually asked instead of a prompt drowned in injected snippets. The alias joins in-flight promises, never caches a failed embed, and no-ops (fail-open, alias callers embed directly) when the source was never embedded.

**3. `embedRecallQuery` hardened to its documented fail-open contract.** Making the warm fire-and-forget exposed a latent bug: a model handler that throws synchronously (or resolves a non-array) made `embedRecallQuery` **reject** instead of returning `null`, surfacing as an unhandled rejection at every fire-and-forget call site (including the pre-existing message-service prefetch). Now both failure shapes fail open to `null` exactly like a rejected embed.

## Expected wall-clock impact (per #15428'''s ~1.5-2.7s/call gateway floor)

- **Default (seed-doc-only) cloud agent, casual turn:** was `embed(pre-run, blocking) + embed(envelope, in-run) + RESPONSE_HANDLER` ≈ 3 serial gateway calls; now `RESPONSE_HANDLER` + one recall embed that overlaps compose ⇒ **~3-5s off every turn**, plus a smaller Stage-1 prompt (no spurious FAQ block).
- **User-doc agent, document-match turn:** the envelope re-embed disappears ⇒ **~1.5-2.7s off**.
- **No-match turns on user-doc corpora:** unchanged (already one shared embed).

## What is NOT changed

- Embedding model/provider, memory persistence, and semantic recall storage: message vectors still come from the background embedding queue, computed from the clean stripped text. Same-turn recall never depended on the *persist* embedding (the recall query has its own shared embed), so nothing can miss.
- The hybrid path, scope/access-context enforcement, timeouts, and the recovery flow for real corpora are byte-identical.

## Tests (all green, output in the backend-logs row)

- `packages/agent/src/api/chat-augmentation.test.ts` (11): seed-only ⇒ keyword mode + **zero** `useModel` calls (no embed, no recovery) + no injection on weak overlap; seed FAQ **still injected** on a real keyword match; any non-seed doc ⇒ hybrid; probe error / probe-cap ⇒ hybrid (fail-open); rewrite ⇒ envelope recall resolves the aliased vector with zero new embeds; plus all 6 pre-existing tests (timeout bounding, recovery gating, #8862 skip, #15253 turn-key threading) unchanged.
- `packages/core/src/features/documents/recall-embed.test.ts` (22): alias over resolved and **in-flight** vectors (one round-trip for warm + alias + in-run + compose-time callers), failed-source alias fails open then re-embeds fresh (no cache poisoning), no-turn-key/identical-text no-ops; sync-throw and non-array handlers resolve `null`; all 15 pre-existing cache/adoption/dedupe tests unchanged.
- Full `packages/core` documents feature + embedding-service suites: 88/88 (deferred persist-embedding pipeline covered by the existing `services/embedding.test.ts` — the waitUntil-equivalent here is the background `BatchQueue`).
- `packages/core` typecheck exit 0; `packages/agent` typecheck has 9 pre-existing TS2307 optional-plugin resolution errors, **identical on clean develop `0b7daae36f3`** (verified via `git stash`); `audit:error-policy-ratchet` clean; biome clean on touched files.

## Honest risk

- **Could deferring/aliasing break same-turn recall?** The persist embedding was already deferred upstream and is not what same-turn recall uses; the alias only changes *which vector* in-run recall uses on rewrite turns — from the envelope'''s to the clean user prompt'''s, which is the provider'''s stated intent ("re-ranked by similarity to the current message"). Failure modes all fail open to a fresh embed or keyword recall.
- **Seed-FAQ retrieval quality:** keyword mode means a *paraphrased* help question with zero term overlap won'''t surface the FAQ where hybrid might have. In exchange, casual turns stop getting FAQ snippets injected as "source of truth". Any real document (including character knowledge) restores full hybrid retrieval.
- **One extra DB read per turn** (the ≤ 32-row documents probe) on corpora with fragments — negligible next to the removed 1.5-2.7s embed, and it sits beside the existing per-turn fragment count.

## Evidence

<!-- evidence-row:before-screenshots -->
- Before screenshots: N/A - backend-only runtime change (embedding call scheduling on the agent chat path), no UI surface touched.

<!-- evidence-row:after-screenshots -->
- After screenshots: N/A - backend-only runtime change, no UI surface touched.

<!-- evidence-row:walkthrough-video -->
- Walkthrough video: N/A - the observable behavior is gateway-call count/ordering per turn, proven by the deterministic call-count assertions in the uploaded test logs.

<!-- evidence-row:backend-logs -->
- Backend logs: real test output uploaded to the `pr-evidence` release: [15428-turn-embeddings-suites.log](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15428-turn-embeddings-suites.log) — core documents+embedding suites 88/88 (8 files), agent chat-augmentation suites 15/15 (2 files), core typecheck exit 0, agent typecheck 9 pre-existing TS2307s (identical on clean develop), `audit:error-policy-ratchet` clean, biome clean on all 5 touched files, at head of this branch.

<!-- evidence-row:frontend-logs -->
- Frontend console/network logs: N/A - no frontend change.

<!-- evidence-row:trajectories -->
- Real-LLM trajectories: N/A - this container has no live cloud-gateway credentials; the change is a call-count/ordering optimization whose contract (same vectors, fewer round-trips) is asserted deterministically. A live before/after `InferenceTiming` comparison on a staging dedicated agent is the right follow-up measurement and is called out in #15428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- evidence-row:llm-trajectory -->
- [ ] N/A - retrieval-mode change (hybrid→BM25 for seed-only corpora) + embed-alias; behavior pinned by deterministic chat-augmentation + recall-embed suites (backend-logs). No model-prompt/output change; a staging InferenceTiming before/after is the noted follow-up.

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - the domain assertions (seed corpus → BM25 zero-embed, real doc → hybrid unchanged, deferred persist still vectors the memory row) execute inside the mock-free suites in backend-logs.
<!-- gate-rerun -->