### PR TITLE
ci: drop dangling packages/tui build + retired XR harness job from Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -392,13 +392,6 @@ jobs:
           skip-avatar-clone: "true"
           no-vision-deps: "true"
 
-      # @elizaos/tui first: the packages/ui spatial-view tests
-      # (src/spatial/__tests__/*) import @elizaos/ui/spatial/tui, whose terminal
-      # renderer externalizes @elizaos/tui — without its dist, vitest fails to
-      # resolve the package and the test files load "0 test".
-      - name: Build @elizaos/tui for spatial-view tests
-        run: bun run --cwd packages/tui build
-
       - name: Run client tests
         run: bun run test:client
 
@@ -424,54 +417,6 @@ jobs:
         with:
           name: perf-gate-e2e-artifacts
           path: packages/ui/src/components/shell/__e2e__/output-perf-gate-e2e/
-          if-no-files-found: ignore
-
-  xr-harness-e2e:
-    name: XR harness e2e
-    needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.plugins == 'true'
-    runs-on: ${{ fromJSON(vars.HETZNER_FLEET_ONLINE == 'false' && '["ubuntu-24.04"]' || '["self-hosted","hetzner-robot"]') }}
-    timeout-minutes: 25
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-        with:
-          submodules: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Setup workspace dependencies
-        uses: ./.github/actions/setup-bun-workspace
-        with:
-          bun-version: ${{ env.BUN_VERSION }}
-          install-command: bun install
-          install-native-deps: "false"
-          skip-avatar-clone: "true"
-          no-vision-deps: "true"
-
-      # app-xr is the surviving XR harness (facewear supersedes the retired
-      # plugin-xr — #9941). It is a nested, non-workspace package whose deps
-      # (@playwright/test, vite, @elizaos/core) resolve up to the root workspace
-      # install above — running `bun install` inside it would fail on its
-      # `workspace:*` core dep, so we only install Chromium here. `test:e2e`
-      # builds the nested emulator package (`build:emulator`), then drives
-      # Playwright against the real view-host route with the IWER emulator
-      # injected.
-      - name: Install Playwright Chromium
-        run: .github/scripts/install-playwright-browsers.sh chromium
-
-      - name: Run facewear app-xr e2e (real view-host route + IWER emulator)
-        run: bun run --cwd plugins/plugin-facewear/app-xr test:e2e
-
-      - name: Upload XR capture artifacts
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: xr-harness-artifacts
-          path: |
-            plugins/plugin-facewear/app-xr/test-results/
           if-no-files-found: ignore
 
   plugin-tests:
@@ -526,13 +471,8 @@ jobs:
 
       # The view-bundle coverage tests assert every view plugin has a built
       # dist/views/bundle.js; build them before running plugin tests.
-      # @elizaos/tui first: the spatial-view tests (45 plugins) import
-      # @elizaos/ui/spatial/tui, whose terminal renderer externalizes
-      # @elizaos/tui — without its dist, vitest fails to resolve the package.
       - name: Build view bundles
-        run: |
-          bun run --cwd packages/tui build
-          bun run build:views
+        run: bun run build:views
 
       - name: Run plugin tests
         # Cap step below the 95m job budget so a flaky plugin
@@ -1456,7 +1396,6 @@ jobs:
       - merge-quality-gate
       - server-tests
       - client-tests
-      - xr-harness-e2e
       - plugin-tests-status
       - integration-tests
       - desktop-contract
@@ -1481,7 +1420,6 @@ jobs:
           echo "merge-quality-gate:${{ needs.merge-quality-gate.result }}"
           echo "server-tests:     ${{ needs.server-tests.result }}"
           echo "client-tests:     ${{ needs.client-tests.result }}"
-          echo "xr-harness-e2e:   ${{ needs.xr-harness-e2e.result }}"
           echo "plugin-tests:     ${{ needs.plugin-tests-status.result }}"
           echo "integration-tests:${{ needs.integration-tests.result }}"
           echo "desktop-contract: ${{ needs.desktop-contract.result }}"
@@ -1499,7 +1437,6 @@ jobs:
             "merge-quality-gate:${{ needs.merge-quality-gate.result }}" \
             "server-tests:${{ needs.server-tests.result }}" \
             "client-tests:${{ needs.client-tests.result }}" \
-            "xr-harness-e2e:${{ needs.xr-harness-e2e.result }}" \
             "plugin-tests:${{ needs.plugin-tests-status.result }}" \
             "integration-tests:${{ needs.integration-tests.result }}" \
             "desktop-contract:${{ needs.desktop-contract.result }}" \

--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -14,7 +14,6 @@ const here = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(here, "..");
 const monorepoRoot = resolve(packageRoot, "../..");
 const uiSrc = resolve(packageRoot, "src");
-const tuiSrc = resolve(monorepoRoot, "packages/tui/src");
 const sharedSrc = resolve(monorepoRoot, "packages/shared/src");
 const coreSrc = resolve(monorepoRoot, "packages/core/src");
 const hostExternalStub = resolve(packageRoot, "test/stubs/host-external.ts");
@@ -121,7 +120,6 @@ const config: StorybookConfig = {
       },
       { find: /^@elizaos\/ui$/, replacement: resolve(uiSrc, "index.ts") },
       { find: /^@elizaos\/ui\/(.+)$/, replacement: resolve(uiSrc, "$1") },
-      { find: /^@elizaos\/tui$/, replacement: resolve(tuiSrc, "index.ts") },
       {
         find: /^@elizaos\/shared$/,
         replacement: resolve(sharedSrc, "index.ts"),


### PR DESCRIPTION
## Problem

Three straggler classes in the `Tests` workflow have failed on every `develop`
run since the TUI feature and the facewear XR harness were removed. All fail at
**setup, before any test executes**, with `ENOENT` on a now-missing directory
run under `-e -o pipefail`:

| Failing job(s) | Failing step | Error |
| --- | --- | --- |
| **Plugin Tests (1/4, 2/4, 3/4, 4/4)** | "Build view bundles" → `bun run --cwd packages/tui build` | `ENOENT: Could not change directory to "packages/tui"` |
| **Client Tests** | "Build @elizaos/tui for spatial-view tests" → `bun run --cwd packages/tui build` | same |
| **XR harness e2e** | "Run facewear app-xr e2e" → `bun run --cwd plugins/plugin-facewear/app-xr test:e2e` | `ENOENT: Could not change directory to "plugins/plugin-facewear/app-xr"` |

Confirmed still failing on the latest tip run (`1ba4926`): Plugin Tests 1-4/4,
Client Tests, and XR harness e2e all red at the setup step.

## Root cause

- `packages/tui` was deleted in `5350248` ("update") — the whole TUI feature.
  No source imports `@elizaos/tui` anymore; the only survivor of the spatial
  terminal subpath is `packages/ui/src/spatial/tui/index.ts`, now a
  **self-contained compatibility stub** that throws "not shipped" and imports
  only `react`. The workflow's `bun run --cwd packages/tui build` steps (and
  their "externalizes @elizaos/tui" comments) are stale.
- `plugins/plugin-facewear/app-xr` was deleted in `2a5d680` ("remove untested
  slop") along with the entire spatial XR immersive harness. Facewear ships no
  e2e/Playwright script; the `xr-harness-e2e` job has no target.

## Fix (correct layer — remove dead CI, do not weaken)

- **Client Tests**: removed the whole `Build @elizaos/tui for spatial-view
  tests` step.
- **Plugin Tests**: removed the `bun run --cwd packages/tui build` line from
  "Build view bundles", kept `bun run build:views` (the view-bundle coverage
  tests still need it).
- **XR harness e2e**: removed the dangling `xr-harness-e2e` job and its three
  `ci-ok` aggregation references (`needs`, the echo line, the `for pair` loop).
- Removed the dead `@elizaos/tui` → `packages/tui/src` alias from
  `packages/ui/.storybook/main.ts` (same removal, would resolve to a
  nonexistent path).

## Verification (local, real)

- Sole surviving consumer `packages/ui/src/spatial/__tests__/evaluate.test.tsx`
  (asserts the stub throws "not shipped"): **7/7 passed** — needs no
  `@elizaos/tui` dist.
- `bun run build:views` → **exit 0**, builds `dist/views/bundle.js`.
- `actionlint test.yml` → exit 0; `biome check` on the storybook file → clean;
  `bun run audit:error-policy-ratchet` → clean (0 changed production source).
- YAML validity confirmed; no remaining `packages/tui` / `app-xr` /
  `xr-harness` references anywhere except a historical comment in `release.yaml`.

## Dedupe

Rebased cleanly onto the current `develop` tip (`8c56e917f34`) with no conflict
and the dangling refs still present pre-rebase — this fix is not duplicated by
any newer merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)