### PR TITLE
fix(ci): green cloud unit-tests — bound per-process memory (exit 143 hang) + exposed drift

### DIFF
--- a/packages/cloud/api/__tests__/stripe-event-clawback.test.ts
+++ b/packages/cloud/api/__tests__/stripe-event-clawback.test.ts
@@ -65,9 +65,19 @@ mock.module("@/lib/services/app-charge-settlement", () => ({
 mock.module("@/lib/services/app-credits", () => ({
   appCreditsService: {},
 }));
+// The mock replaces the whole module, so it must re-export every name any
+// module pulled into this route binds, or bun fails linking ("Export named
+// 'X' not found"). Cover ai-billing's full public surface — the clawback path
+// exercises none of these; the stubs exist only to satisfy static imports.
 mock.module("@/lib/services/ai-billing", () => ({
   InsufficientCreditsError: TestInsufficientCreditsError,
   estimateInputTokens: mock(() => 0),
+  normalizeUsage: mock(() => ({})),
+  reserveCredits: mock(async () => ({})),
+  billUsage: mock(async () => ({})),
+  billFlatUsage: mock(async () => ({})),
+  recordUsageAnalytics: mock(async () => undefined),
+  createOnFinishHandler: mock(() => () => undefined),
 }));
 
 mock.module("@/lib/services/credits", () => ({

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker-env-reconcile.test.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker-env-reconcile.test.ts
@@ -120,12 +120,22 @@ function runReconcile(opts: {
     // (GNU sed is the default) and when skipped this is a no-op.
     GNU_SED === "gsed" ? 'sed() { gsed "$@"; }' : "",
     `ENV_FILE='${envFile}'`,
-    // The ssh-action `envs:` allowlist always exports these (possibly empty);
-    // under `set -u` they must be defined or the loop aborts. Empty == skipped,
-    // isolating SANDBOX_REGISTRY_REDIS_URL behavior.
-    "HEADSCALE_API_URL=''",
-    "HEADSCALE_PUBLIC_URL=''",
-    "HEADSCALE_API_KEY=''",
+    // The ssh-action `envs:` allowlist always exports every key the loop reads
+    // (possibly empty); under `set -u` each must be defined or the loop aborts.
+    // Derive them from the loop's own `"KEY=$KEY"` entries and default every key
+    // EXCEPT the one under test to empty (empty == skipped, isolating
+    // SANDBOX_REGISTRY_REDIS_URL behavior) — so a workflow that forwards another
+    // secret (e.g. DATABASE_URL) can't silently abort this test on `set -u`.
+    ...Array.from(
+      new Set(
+        Array.from(
+          loop.matchAll(/"([A-Z0-9_]+)=\$[A-Z0-9_]+"/g),
+          (match) => match[1],
+        ),
+      ),
+    )
+      .filter((name) => name !== ENV_KEY)
+      .map((name) => `${name}=''`),
     loop,
   ].join("\n");
   try {

--- a/packages/scripts/test-cloud-run.mjs
+++ b/packages/scripts/test-cloud-run.mjs
@@ -92,44 +92,22 @@ const cloudInfraTests = path.join(
 // no lane. Exclude `test/` (the e2e harness: its own `test:e2e` lane + a live
 // server) and build output.
 const cloudApiRoot = path.join(repoRoot, "packages", "cloud", "api");
+// `test/` is the api e2e harness (own `test:e2e` lane + a live server); the
+// rest is build output / vendored deps that carry no unit lane.
 const EXCLUDED_API_DIRS = new Set(["test", "node_modules", "dist", ".turbo"]);
-function walkApiUnitTests(dir) {
+// Vendored deps and build output under any non-api root: never a unit target.
+const EXCLUDED_DIRS = new Set(["node_modules", "dist", ".turbo"]);
+function walkTests(dir, excluded) {
   const out = [];
   for (const entry of readdirSync(dir)) {
-    if (EXCLUDED_API_DIRS.has(entry)) continue;
+    if (excluded.has(entry)) continue;
     const full = path.join(dir, entry);
-    if (statSync(full).isDirectory()) out.push(...walkApiUnitTests(full));
+    if (statSync(full).isDirectory()) out.push(...walkTests(full, excluded));
     else if (/\.(test|spec)\.tsx?$/.test(entry)) out.push(full);
   }
   return out;
 }
-const cloudApiUnitTests = existsSync(cloudApiRoot)
-  ? walkApiUnitTests(cloudApiRoot).sort()
-  : [];
-
-// Pass DIRECTORY targets (plus root-level test files), not the 150+ individual
-// files: on Windows the spawn goes through cmd.exe (`shell: true` below, needed
-// to resolve bun's .cmd shim), whose ~8 KiB command-line ceiling the file list
-// outgrew ("The command line is too long."). The exclusion semantics are
-// identical — the excluded dirs exist only at the api root (asserted by the
-// walk above staying the source of truth for the fail-loud non-empty check),
-// and `bun test <dir>` recurses the rest.
-function apiUnitTestTargets(root) {
-  const targets = [];
-  for (const entry of readdirSync(root)) {
-    if (EXCLUDED_API_DIRS.has(entry)) continue;
-    const full = path.join(root, entry);
-    if (statSync(full).isDirectory()) {
-      if (walkApiUnitTests(full).length > 0) targets.push(full);
-    } else if (/\.(test|spec)\.tsx?$/.test(entry)) {
-      targets.push(full);
-    }
-  }
-  return targets.sort();
-}
-const cloudApiTestTargets = existsSync(cloudApiRoot)
-  ? apiUnitTestTargets(cloudApiRoot)
-  : [];
+const walkApiUnitTests = (dir) => walkTests(dir, EXCLUDED_API_DIRS);
 
 const testRoots = {
   cloudSharedSrc,
@@ -149,11 +127,12 @@ if (missing.length > 0) {
   process.exit(1);
 }
 
-// The directory-target list is what `bun test` actually receives; the explicit
-// file walk stays the source of truth for coverage. If the api root exists but
-// holds no colocated unit tests, the directory targets would silently run
-// nothing — fail loud instead so a layout change can't quietly drop the lane.
-if (existsSync(cloudApiRoot) && cloudApiUnitTests.length === 0) {
+const cloudApiUnitTests = walkApiUnitTests(cloudApiRoot).sort();
+
+// If the api root exists but holds no colocated unit tests, the gate would
+// silently run zero api tests — fail loud so a layout change can't quietly
+// drop the lane.
+if (cloudApiUnitTests.length === 0) {
   console.error(
     `[test:cloud] no colocated cloud/api unit tests found under ${cloudApiRoot} — ` +
       "the gate would silently run zero api tests. Update packages/scripts/test-cloud-run.mjs " +
@@ -162,30 +141,82 @@ if (existsSync(cloudApiRoot) && cloudApiUnitTests.length === 0) {
   process.exit(1);
 }
 
-const result = spawnSync(
-  "bun",
-  [
-    "test",
-    cloudSharedSrc,
-    ...cloudApiTestTargets,
-    cloudScriptsTests,
-    cloudRoutingTests,
-    cloudInfraTests,
-    "--timeout",
-    "120000",
-    "--isolate",
-  ],
-  {
-    cwd: stagingDir,
-    env,
-    stdio: "inherit",
-    shell: process.platform === "win32",
-  },
-);
-
-if (result.error) {
-  console.error(result.error);
+// The full unit set is ~700 files. bun's `--isolate` gives each file a fresh
+// global but keeps ONE process, so JS heap plus external (pglite/WASM) memory
+// accumulates monotonically across the whole run — RSS climbs past 7 GB. On the
+// memory-bounded self-hosted runner that tips into GC-thrash/OOM, and because
+// the drizzle-kit `pushSchema` introspect ("Pulling schema from database…")
+// builds large full-schema JSON snapshots, the run consistently wedged there
+// and the runner reclaimed the job (SIGTERM → exit 143). Splitting the file set
+// into sequential fresh `bun test` processes bounds peak memory to one batch:
+// each process starts cold, runs its slice, and frees everything on exit before
+// the next starts.
+const allTestFiles = [
+  ...walkTests(cloudSharedSrc, EXCLUDED_DIRS),
+  ...cloudApiUnitTests,
+  ...walkTests(cloudScriptsTests, EXCLUDED_DIRS),
+  ...walkTests(cloudRoutingTests, EXCLUDED_DIRS),
+  ...walkTests(cloudInfraTests, EXCLUDED_DIRS),
+];
+if (allTestFiles.length === 0) {
+  console.error(
+    "[test:cloud] enumerated zero test files across all roots — the gate would " +
+      "silently pass. Update packages/scripts/test-cloud-run.mjs to match the layout.",
+  );
   process.exit(1);
 }
 
-process.exit(result.status ?? 1);
+// Batch size bounds per-process memory; the char cap keeps each argv under
+// Windows' ~8 KiB cmd.exe command-line ceiling (the spawn goes through cmd.exe
+// there — `shell: true` below — to resolve bun's `.cmd` shim). Whichever limit
+// a file hits first closes the current batch.
+const MAX_FILES_PER_BATCH = 80;
+const MAX_ARGS_CHARS = process.platform === "win32" ? 6000 : 100000;
+function chunkByBudget(files) {
+  const batches = [];
+  let current = [];
+  let chars = 0;
+  for (const file of files) {
+    const cost = file.length + 1;
+    if (
+      current.length > 0 &&
+      (current.length >= MAX_FILES_PER_BATCH || chars + cost > MAX_ARGS_CHARS)
+    ) {
+      batches.push(current);
+      current = [];
+      chars = 0;
+    }
+    current.push(file);
+    chars += cost;
+  }
+  if (current.length > 0) batches.push(current);
+  return batches;
+}
+const batches = chunkByBudget(allTestFiles);
+
+let anyFailed = false;
+for (let i = 0; i < batches.length; i++) {
+  const batch = batches[i];
+  console.log(
+    `[test:cloud] batch ${i + 1}/${batches.length} — ${batch.length} files`,
+  );
+  const result = spawnSync(
+    "bun",
+    ["test", ...batch, "--timeout", "120000", "--isolate"],
+    {
+      cwd: stagingDir,
+      env,
+      stdio: "inherit",
+      shell: process.platform === "win32",
+    },
+  );
+  if (result.error) {
+    console.error(result.error);
+    process.exit(1);
+  }
+  // Run every batch even after a failure so one broken suite doesn't mask the
+  // rest; aggregate into a single non-zero exit for the gate.
+  if ((result.status ?? 1) !== 0) anyFailed = true;
+}
+
+process.exit(anyFailed ? 1 : 0);


### PR DESCRIPTION
## Root cause — the exit-143 "hang"

`Cloud Tests → unit-tests` has been red for every run in the last ~60 (no green since before Jul 6), always dying with **exit 143 (SIGTERM)** at a drizzle-kit `pushSchema` step ("Pulling schema from database…"), followed by *"The runner has received a shutdown signal."*

The lane ran the **entire** cloud unit set (~700 files: `cloud/shared/src`, `cloud/api`, `scripts/cloud`, `routing`, `infra`) in **one** `bun test … --isolate` process. `--isolate` gives each file a fresh global but keeps a **single process**, so JS heap + external (pglite/WASM) memory accumulates monotonically across the whole run — local RSS climbs **past 7 GB**. On the memory-bounded self-hosted runner that tips into GC-thrash/OOM, and because `pushSchema` builds large full-schema JSON snapshots, the run consistently wedged there and the runner reclaimed the job (SIGTERM → 143).

The `AI Gateway … Unauthenticated` lines in the failing log (which named this lane) are emitted by **passing** tests that assert provider-config errors are sanitized (unknown-model) — a red herring, not the failure.

## Fix — which layer

**Primary (`packages/scripts/test-cloud-run.mjs`)** — split the file set into **sequential fresh `bun test` processes** (batches ≤80 files, argv char-capped so Windows' cmd.exe cmdline ceiling is respected). Each process starts cold, runs its slice, and frees everything on exit before the next. Peak RSS drops from **~7 GB → ~1.5 GB/batch**; the suite now completes. Batches run to completion and aggregate into one exit code (one broken suite no longer masks the rest).

**Exposed pre-existing drift** — completing the suite (it previously died mid-run, before ever reaching `scripts/cloud`) surfaced two unrelated failures the OOM had masked. Both fail standalone on `develop`; both run (not skip) on CI's Linux:

- `stripe-event-clawback.test.ts` — its `mock.module` of `ai-billing` replaced the whole module but omitted names a consumer in the route graph statically imports (`billUsage`, `recordUsageAnalytics`, …) → bun link error *"Export named 'X' not found"*. Stub ai-billing's full public surface.
- `provisioning-worker-env-reconcile.test.ts` — the workflow's reconcile loop now also reads `$DATABASE_URL`, but the test's `set -u` bash env only defined the `HEADSCALE_*` vars → *"DATABASE_URL: unbound variable"*. Derive the allowlisted vars from the loop itself so a newly forwarded secret can't break it again.

## Validation

Full cloud unit lane run locally with the CI env (`DATABASE_URL=pglite://memory`, hermetic — no network):

- **9 batches, ~5,457 tests, 0 fail, 0 error**
- Peak RSS bounded to ~1.5 GB/batch (was climbing past 7 GB)
- `bunx biome check` clean on all three files

Before this change the same command wedged at a `pushSchema` step and never completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)