### PR TITLE
fix(scheduling): de-flake f1-timezone zero-key scenario (catch-up window, not a tz-offset bug)

### DIFF
--- a/plugins/plugin-personal-assistant/test/scenarios/f1-timezone-boundary-edge-generic.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/f1-timezone-boundary-edge-generic.scenario.ts
@@ -18,13 +18,20 @@
  *
  * Tasks are created through the REAL REST surface; ticks are the REAL scheduler
  * entry. Delivery goes through a scenario-registered always-delivering channel.
- * Run keyless with `TZ=UTC`.
+ * Run keyless with `TZ=UTC`. Creation is pinned via `createdAtIso`
+ * (CREATED_AT_INSTANT) so the tested occurrence is deterministically the first
+ * one at/after creation — otherwise the 36h cron catch-up window would fire a
+ * just-missed prior-day occurrence at the naive tick on runs that happen to
+ * create the task shortly before that day's occurrence (a wall-clock flake, not
+ * a tz bug). The catch-up window itself is intentional and load-bearing for
+ * other scheduled items (e.g. traveler-reanchor), so it is left untouched.
  *
- * Fail-without-fix anchor: revert the cron `tz` handling in
- * `plugins/plugin-scheduling/src/scheduled-task/next-fire-at.ts` so the daily
- * cron is evaluated in the host zone instead of America/New_York, and the
- * zone-instant tick records no fire while a naive-UTC tick does — the
- * literal-instant fire turn and the single-delivery finalCheck fail.
+ * Fail-without-fix anchor: revert the cron `tz` resolution in `cronDue`
+ * (`plugins/plugin-scheduling/src/scheduled-task/due.ts`, via `resolveTriggerTz`
+ * + `computeNextCronRunAtMs`) so the daily cron is evaluated in the host zone
+ * instead of America/New_York: the occurrence collapses onto 07:30 UTC, the
+ * naive-UTC tick fires, and the literal-instant fire turn plus the
+ * single-delivery finalCheck fail.
  */
 
 import type { ScenarioContext } from "@elizaos/scenario-runner/schema";
@@ -94,6 +101,18 @@ const NAIVE_UTC_INSTANT = (() => {
   return naive;
 })();
 const ZONE_TICK = new Date(ZONE_INSTANT.getTime() + MINUTE_MS);
+// Pin the reminder's creation instant 12h before the tested occurrence so the
+// proof is deterministic rather than a function of the real wall-clock at run
+// time. It lands strictly between the PRIOR 07:30-NY occurrence (~24h earlier)
+// and the naive tick (~4h earlier than ZONE_INSTANT), so the ONLY occurrence at
+// or after creation is ZONE_INSTANT itself: the cron catch-up window has no
+// stale prior-day occurrence to pick up at the naive tick. Without it, a run
+// that happens to create the task in the ~3h before that day's occurrence would
+// see the catch-up window fire the just-missed occurrence at the naive tick —
+// a real-time-dependent flake, not a tz regression. The repository preserves a
+// caller-supplied `createdAtIso` (it only backfills from the row insert time
+// when absent), so this reaches `cronDue` verbatim.
+const CREATED_AT_INSTANT = new Date(ZONE_INSTANT.getTime() - 12 * HOUR_MS);
 const CRON_EXPRESSION = `${LOCAL_MINUTE} ${LOCAL_HOUR} * * *`;
 
 interface ChannelContributionLike {
@@ -301,7 +320,10 @@ export default scenario({
         createdBy: SCENARIO_ID,
         ownerVisible: true,
         idempotencyKey: `${SCENARIO_ID}-zoned`,
-        metadata: { scenario: SCENARIO_ID },
+        metadata: {
+          scenario: SCENARIO_ID,
+          createdAtIso: CREATED_AT_INSTANT.toISOString(),
+        },
       },
       expectedStatus: 201,
       assertResponse: assertCreated,


### PR DESCRIPTION
## Summary

The `f1-timezone-boundary-edge-generic` zero-key scenario intermittently failed its naive-tick assertion (`reminder must NOT fire at the naive 07:30-UTC instant`). This has been deferred by multiple prior lanes. This PR fixes it at the correct layer after a full root-cause determination.

## Root cause: catch-up window (b), NOT a tz-offset drop (a)

The task framed two hypotheses: (a) a timezone-offset bug in the fire-time computation, or (b) the 36h catch-up window firing a stale occurrence.

- **It is (b).** `computeNextCronRunAtMs` / `cronDue` resolve `30 7 * * *` in `America/New_York` to its true UTC instant correctly — `11:30 UTC` under EDT (= 07:30 EDT). Verified end-to-end: the fired occurrence at the zone tick is exactly `2026-07-09T11:30:00Z`. **No tz-offset bug exists.**
- The failure is the **36h cron catch-up window firing a stale prior-day occurrence at the naive tick.** The scenario creates the reminder at the *real* wall-clock time, then only ticks it the next day. On runs where creation lands in the ~3h window before that day's 07:30-NY occurrence (e.g. created `07-08 09:16Z`, occurrence `07-08 11:30Z`), that just-missed occurrence is inside the catch-up window and fires at the naive tick (`07-09 07:30Z`, ~20h stale). This is **real-time-dependent flakiness**, not a tz regression.

## Why the product catch-up is NOT changed

The catch-up window is intentional and load-bearing. The sibling canary `traveler-reanchor-on-timezone-change-signal` **asserts a reminder fires from an even more stale occurrence** (~21h+) at a deliberately far-future tick.

- f1 requires a **~20h-stale** occurrence to **NOT** fire.
- traveler requires a **~21h+-stale** occurrence **TO** fire.

Because the "don't fire" case is *less* stale than the "must fire" case, **no staleness/proximity gate in `cronDue` can satisfy both** (empirically confirmed: adding a half-period midpoint gate greened f1 but broke traveler with `expected exactly one fired for task, saw []`). Any catch-up-semantics change that fixes f1 breaks traveler, so the product is left untouched.

## Fix (test-layer, deterministic; product source unchanged)

Pin the reminder's creation instant (`createdAtIso`) 12h before the tested occurrence — strictly between the prior 07:30-NY occurrence and the naive tick. The only occurrence at/after creation is then `ZONE_INSTANT` itself, so the catch-up window has no stale prior-day occurrence to pick up at the naive tick. The repository preserves a caller-supplied `createdAtIso` (`z.record` schema + hydration only backfills when absent), so it reaches `cronDue` verbatim.

- Assertions are **unchanged**.
- The tz-regression guard still holds: a host-tz cron drop still collapses the occurrence onto 07:30 UTC and fires at the naive tick, failing the test (anchor updated to point at `cronDue`/`due.ts`, the authoritative tz resolution).

## Validation — all green

| Suite | Result |
| --- | --- |
| `f1-timezone-boundary-edge-generic` | ✅ passes (naive tick: no fire; zone tick: fires once at `2026-07-09T11:30:00Z`) |
| Full PA `pr-deterministic` scenario suite | ✅ **25/25** (every `traveler-*`, `persona.*`, `shift-rotation-*`, `lowact-*`, `f1-*`) |
| `plugin-scheduling` scheduled-task suite | ✅ 243 |
| PA `src/lifeops/scheduled-task/` suites (scheduler-recurrence, no-reply, quiet-streak) | ✅ 64 |
| biome | ✅ |
| error-policy-ratchet | ✅ 0 production source files touched |

No production source changed — diff is one scenario file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)