### PR TITLE
fix(ci): green residual Windows CI shards (elizaos + task-coordinator)

### DIFF
--- a/packages/elizaos/src/commands/deploy.test.ts
+++ b/packages/elizaos/src/commands/deploy.test.ts
@@ -183,8 +183,10 @@ describe("runDeploy", () => {
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining("Invalid project metadata JSON"),
       );
+      // Path is rendered with the OS separator (backslash on Windows), so match
+      // the joined form rather than a hardcoded POSIX substring.
       expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining(".elizaos/template.json"),
+        expect.stringContaining(path.join(".elizaos", "template.json")),
       );
     } finally {
       process.chdir(originalCwd);
@@ -215,8 +217,10 @@ describe("runDeploy", () => {
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining("Invalid Eliza Cloud credentials JSON"),
       );
+      // Path is rendered with the OS separator (backslash on Windows), so match
+      // the joined form rather than a hardcoded POSIX substring.
       expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining(".elizaos/credentials.json"),
+        expect.stringContaining(path.join(".elizaos", "credentials.json")),
       );
     } finally {
       rmSync(homeDir, { recursive: true, force: true });

--- a/packages/elizaos/vitest.config.ts
+++ b/packages/elizaos/vitest.config.ts
@@ -3,9 +3,31 @@
  * because generated projects carry their own test configuration.
  */
 
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
+const rootDir = dirname(fileURLToPath(import.meta.url));
+// Vite alias replacements must be POSIX-separated even on Windows.
+const toVitePath = (value: string): string => value.replaceAll("\\", "/");
+const agentSrc = resolve(rootDir, "../agent/src");
+
 export default defineConfig({
+  resolve: {
+    alias: [
+      // `migrate.test.ts` exercises the real `@elizaos/agent` importer via the
+      // `./services/agent-export` subpath. That subpath only resolves to source
+      // through the package's `eliza-source`/`bun` export conditions, which
+      // vitest does not apply — bare resolution falls through to `./dist`, which
+      // is absent when this suite runs standalone (e.g. the Windows CI lane
+      // builds only core/shared, not agent). Anchor the subpath to source; its
+      // transitive imports are `@elizaos/core` (prebuilt) plus sibling source.
+      {
+        find: /^@elizaos\/agent\/services\/agent-export$/,
+        replacement: toVitePath(resolve(agentSrc, "services/agent-export.ts")),
+      },
+    ],
+  },
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],

--- a/plugins/plugin-task-coordinator/vitest.config.ts
+++ b/plugins/plugin-task-coordinator/vitest.config.ts
@@ -9,6 +9,10 @@ const pluginBrowserSrc = resolve(rootDir, "../plugin-browser/src");
 const pluginCommandsSrc = resolve(rootDir, "../plugin-commands/src");
 const pluginTrainingSrc = resolve(rootDir, "../plugin-training/src");
 const sharedSrc = resolve(rootDir, "../../packages/shared/src");
+const importConversationsSrc = resolve(
+  rootDir,
+  "../../packages/import-conversations/src",
+);
 
 export default defineConfig({
   resolve: {
@@ -37,6 +41,21 @@ export default defineConfig({
       {
         find: /^@elizaos\/ui\/(.+)$/,
         replacement: `${toVitePath(resolve(rootDir, "../../packages/ui/src"))}/$1`,
+      },
+      // `@elizaos/ui` (aliased to source above) pulls MemoryViewerView, which
+      // imports the `@elizaos/import-conversations/browser` subpath. That subpath
+      // only resolves to source through the package's `eliza-source` export
+      // condition, which vitest does not apply — bare resolution falls through to
+      // `./dist`, absent when this suite runs standalone (the Windows CI lane
+      // builds only core/shared). Anchor it to source; import-conversations/src
+      // has no external deps, so this is self-contained.
+      {
+        find: /^@elizaos\/import-conversations$/,
+        replacement: toVitePath(resolve(importConversationsSrc, "index.ts")),
+      },
+      {
+        find: /^@elizaos\/import-conversations\/(.+)$/,
+        replacement: `${toVitePath(importConversationsSrc)}/$1`,
       },
       {
         find: /^@elizaos\/plugin-health\/screen-time\/mobile-signal-setup$/,


### PR DESCRIPTION
## What

Greens the two Windows CI lanes still red on `develop` after #15445 — `windows (app-and-cli, …)` and `windows (plugins, …)`. #15446/#15447 landed after #15445 but touched only scenario + ui-smoke suites, not these shards, so these are **additional** residuals #15445 did not cover.

Verified against the newest completed Windows run (`28931905762`, headSha `6c032d4` = #15445 merge; run predates #15446/#15447 which don't touch these shards). The other three lanes (core-runtime, framework-packages, build-and-helper-smokes) are green.

## Per-failure root cause + class

All three roots share the same mechanism: the Windows lane's prep builds **only** core/shared/logger/contracts/prompts. Packages like `@elizaos/agent` and `@elizaos/import-conversations` are **not** built, and their subpath exports only map to source through the package `eliza-source`/`bun` export conditions — which **vitest does not apply**. Bare resolution falls through to absent `./dist`. On Linux CI everything is built first, so it passes there; hence Windows-lane-specific.

**app-and-cli — `packages/elizaos`:**
1. `migrate.test.ts` — `Cannot find package '@elizaos/agent/services/agent-export'` (`ERR_MODULE_NOT_FOUND`). **Class: missing test-lane source alias.** Fix: anchor the `@elizaos/agent/services/agent-export` subpath to source in `packages/elizaos/vitest.config.ts`. Transitive deps are `@elizaos/core` (prebuilt in prep) + sibling source files only, so it's self-contained.
2. `deploy.test.ts:186` (`fails corrupt project metadata before app lookup`) — `expect.stringContaining(".elizaos/template.json")` vs Windows-emitted `…\.elizaos\template.json`. **Class: path-separator.** `deploy.ts` builds the path with `path.join` (correct OS-native behavior), so the **test** was non-portable. Fix: assert `path.join(".elizaos", "template.json")`.
3. `deploy.test.ts:218` (`fails corrupt credentials before deploy request`) — same, `.elizaos/credentials.json`. Same fix.

**plugins — `plugins/plugin-task-coordinator` (3 suites: `CockpitSessionPane.test.tsx`, `orchestrator-capability-parity.test.ts`, `orchestrator-inspector-terminal-task.test.tsx`):**
4. All fail with `Cannot find package '@elizaos/import-conversations/browser'` reached via `@elizaos/ui` (already aliased to source) → `MemoryViewerView.tsx`. **Class: missing test-lane source alias.** Fix: anchor `@elizaos/import-conversations` + its subpaths to source in the plugin's vitest config. `import-conversations/src` has **zero** external imports, so fully self-contained.

## Validation

Linux, under a **faithful Windows-prep dist state** (only core+shared+logger+contracts+prompts built — exactly what the Windows lane has):

- `bun run --cwd packages/elizaos test` → **11 files / 87 tests pass** (was `2 failed | 9 passed`; migrate.test now collects, adding its tests).
- `bun run --cwd plugins/plugin-task-coordinator test` → **28 files / 222 tests pass** (was `3 failed | 25 passed`; the 3 suites now collect, +30 tests).
- Biome clean on all 3 files; `audit:error-policy-ratchet` clean (0 changed production source files — test + config only).

No product code touched (test assertion + two vitest configs). The path-separator fix only corrects a non-portable assertion; the two aliases only add source resolution.

## Dedupe notes

- #15445 fixed 7 CRLF/PATHEXT/ui-dist failures; these 4 are additional (different files/roots).
- #15446 (f1-timezone scenario) and #15447 (ui-smoke z-index) don't touch the app-and-cli/plugins shards — confirmed by their diffs.

## Windows-machine-blocked residue

The `app-and-cli` shard's 3rd command (`packages/cloud/shared test`) and the `plugins` shard's 7th (`plugin-browser test`) never executed on Windows because each shard stops at the first failure (elizaos / task-coordinator). Both were in the pre-existing green set and have no evidence of a Windows issue; the next Windows run after this merge will confirm them. If either surfaces a new failure, it is a fresh residual, not a regression from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)