### PR TITLE
fix(elizaos): resolve curated root-memory by case (Windows CI portability)

### DIFF
--- a/packages/elizaos/src/migrate/migrate.test.ts
+++ b/packages/elizaos/src/migrate/migrate.test.ts
@@ -466,6 +466,23 @@ describe("oc home-format variants (cross-version)", () => {
     expect(ch.name).toBe("Quill");
   });
 
+  it("resolves curated root-memory by case, reporting the true on-disk name (Win/macOS portability)", () => {
+    // A mixed-case `Memory.md` is invisible to a fixed "MEMORY.md"/"memory.md"
+    // path probe on a case-SENSITIVE FS, and a lowercase memory.md is read but
+    // MIS-named "MEMORY.md" by that probe on a case-INSENSITIVE FS. Matching the
+    // real directory entry fixes both: found regardless of spelling, and
+    // `curatedMemoryFile` carries the actual (case-preserved) on-disk name.
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "oc-memcase-"));
+    fs.writeFileSync(path.join(home, "SOUL.md"), "# Sable\nYou are Sable.\n");
+    fs.writeFileSync(
+      path.join(home, "Memory.md"),
+      "# Sable memory\n\n## One\nmixed-case curated memory must be read.\n",
+    );
+    const src = readOcAgentHome(home, "sable");
+    expect(src.curatedMemory).toContain("mixed-case curated memory");
+    expect(src.curatedMemoryFile).toBe("Memory.md");
+  });
+
   it("derives name + sane character from a LEANER hermes-style home (GAP B/C)", () => {
     // Lean home: SOUL + AGENTS only, NO IDENTITY/USER/TOOLS/MEMORY.
     const src = readOcAgentHome(fixDir("oc-home-lean"), "someslug");

--- a/packages/elizaos/src/migrate/openclaw-reader.ts
+++ b/packages/elizaos/src/migrate/openclaw-reader.ts
@@ -70,7 +70,7 @@ export interface OcAgentSource {
   tools?: string;
   /** MEMORY.md (or legacy memory.md): curated long-term memory. */
   curatedMemory?: string;
-  /** Which root-memory filename was found ("MEMORY.md" | "memory.md" | undefined). */
+  /** The curated root-memory file's actual on-disk name (e.g. "MEMORY.md" or legacy "memory.md"), or undefined if none. */
   curatedMemoryFile?: string;
   /** <agent>-awareness.md - live open-threads / relationship state. */
   awareness?: string;
@@ -154,15 +154,37 @@ function resolveAgentRoot(home: string): string {
 }
 
 /**
- * Resolve curated root-memory: canonical "MEMORY.md" first, then legacy
- * lowercase "memory.md". Returns the text + which filename matched.
+ * Resolve curated root-memory by matching a directory entry case-insensitively.
+ *
+ * A fixed-path probe (`readFileSync(root/MEMORY.md)` then `.../memory.md`) is not
+ * portable: on a case-INSENSITIVE filesystem (Windows/macOS) the canonical
+ * "MEMORY.md" probe resolves onto a lowercase `memory.md` on disk, so the file is
+ * read but its name is mis-reported as "MEMORY.md"; on case-SENSITIVE Linux a
+ * mixed-case `Memory.md` would be missed entirely. Matching against the actual
+ * directory entries fixes both: the curated memory is found regardless of case,
+ * and `curatedMemoryFile` carries the file's true (case-preserved) on-disk name.
+ * Canonical uppercase "MEMORY.md" wins when a home carries both spellings (only
+ * possible on a case-sensitive FS); otherwise the single match is used.
  */
 function readCuratedMemory(root: string): { text?: string; file?: string } {
-  for (const name of ROOT_MEMORY_CANDIDATES) {
-    const text = readIfPresent(path.join(root, name));
-    if (text !== undefined) return { text, file: name };
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(root);
+  } catch {
+    // Missing home is tolerated per the module's reader contract: empty, no throw.
+    return {};
   }
-  return {};
+  const matches = entries.filter((entry) =>
+    ROOT_MEMORY_CANDIDATES.some(
+      (candidate) => candidate.toLowerCase() === entry.toLowerCase(),
+    ),
+  );
+  if (matches.length === 0) return {};
+  const chosen =
+    matches.find((entry) => entry === ROOT_MEMORY_CANDIDATES[0]) ?? matches[0];
+  const text = readIfPresent(path.join(root, chosen));
+  if (text === undefined) return {};
+  return { text, file: chosen };
 }
 
 /** Resolve the awareness file: prefer "<agentId>-awareness.md", else any "*-awareness.md". */


### PR DESCRIPTION
## Problem — last current-tip Windows CI failure

Windows CI (`app-and-cli` shard, `bun run --cwd packages/elizaos test`) fails the sole remaining case in `packages/elizaos/src/migrate/migrate.test.ts`:

```
FAIL src/migrate/migrate.test.ts > oc home-format variants (cross-version) > reads legacy lowercase memory.md as curated memory (GAP A)
AssertionError: expected 'MEMORY.md' to be 'memory.md'  (Object.is)
```

Passes on Linux, fails only on Windows. This is the same Windows-runner-anomaly class as #15338/#15448 — unmasked here because #15448 fixed the file's earlier module-resolution error, exposing this assertion.

## Root cause — case-insensitive filesystem + fixed-path probe

`readOcAgentHome` (`openclaw-reader.ts`) resolved the curated root-memory file with a **fixed-path probe**: `readFileSync(root/MEMORY.md)`, then legacy `root/memory.md`, recording which candidate matched in `curatedMemoryFile`.

On a **case-insensitive filesystem** (Windows NTFS, macOS APFS-default), the canonical `MEMORY.md` probe resolves onto an on-disk lowercase `memory.md`: the file is read correctly, but its name is **mis-reported** as `MEMORY.md`. So the `oc-home-legacymem` fixture (which ships a lowercase `memory.md`) yields `curatedMemoryFile === "MEMORY.md"` on Windows — hence `expected 'MEMORY.md' to be 'memory.md'`.

Reproduced deterministically: the probe returns the first candidate that `readFileSync` succeeds on, and on a case-insensitive FS the `MEMORY.md` probe **always** matches first regardless of the on-disk case.

## Fix layer — real cross-platform product fix (not a test hack, not a skip)

`curatedMemoryFile` is an observational field, and the fixed-path probe has a genuine portability defect on **both** platform classes:
- case-INSENSITIVE FS → reads a lowercase file but mis-names it `MEMORY.md`;
- case-SENSITIVE Linux → would **miss** a mixed-case `Memory.md` home entirely.

`readCuratedMemory` now matches the **actual directory entry** case-insensitively and reports the file's **true (case-preserved) on-disk name**. Canonical uppercase `MEMORY.md` still wins when a home carries both spellings (only reachable on a case-sensitive FS). This finds curated memory regardless of spelling on every platform and makes `curatedMemoryFile` accurate everywhere — so the GAP A test passes on Windows **unchanged**.

Chose the product layer over a `.toLowerCase()` test tweak or an `it.skipIf(win32)` skip because case-insensitive memory-file resolution is a real cross-platform concern (macOS is case-insensitive by default), and the field previously lied about the filename on those systems.

## Regression guard

Adds a portable test: a mixed-case `Memory.md` home must be read and reported as `Memory.md`. This **fails against the old fixed-path probe on Linux** (the probe opens neither `MEMORY.md` nor `memory.md`), so it directly guards the fix.

## Validation (Linux; Windows reasoned from case-preserving NTFS semantics + #15338/#15448 precedent)

- `bunx vitest run src/migrate/migrate.test.ts` → **22 passed** (was 21; +1 regression test).
- `tsgo --noEmit` (elizaos) → clean.
- `biome check` on both touched files → clean.
- `bun run audit:error-policy-ratchet` → no new fallback-slop (`emptyCatch 1->1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)