### PR TITLE
fix(ci): green the 5 non-live Tests fan-out failures at develop tip

### DIFF
--- a/packages/agent/src/services/remote-plugin-adapter.test.ts
+++ b/packages/agent/src/services/remote-plugin-adapter.test.ts
@@ -3883,7 +3883,7 @@ export function createRouter() {
               methods: ["lookup"],
             }],
             appBridge: { hooks: ["prepareLaunch"] },
-            routes: [{ method: "POST", path: "/built-source/route", public: true, name: "built-source-route", publicReason: "Remote adapter built source fixture public route." }],
+            routes: [{ method: "POST", path: "/built-source/route", public: true, name: "built-source-route", publicReason: "Remote adapter built source fixture public route.", publicWrite: "Remote capability POST authenticated by the endpoint's own bearer token, not the local gate." }],
             views: [{ id: "built-source.view", label: "Built Source View", bundlePath: "/assets/remote-view.js" }],
           },
         ],
@@ -4302,7 +4302,7 @@ const server = createServer(async (req, res) => {
           description: "Remote plugin served from a child process.",
           actions: [{ name: "PROCESS_ACTION", description: "Run process action." }],
           providers: [{ name: "PROCESS_CONTEXT", description: "Process provider." }],
-          routes: [{ method: "POST", path: "/process/route", public: true, name: "process-route", publicReason: "Remote adapter process fixture public route." }],
+          routes: [{ method: "POST", path: "/process/route", public: true, name: "process-route", publicReason: "Remote adapter process fixture public route.", publicWrite: "Remote capability POST authenticated by the endpoint's own bearer token, not the local gate." }],
           views: [{ id: "process.view", label: "Process View", bundlePath: "/assets/process-view.js" }],
         }] } });
       }
@@ -4547,7 +4547,7 @@ createServer(async (req, res) => {
             models: [{ modelType: "DOCKER_TEXT", priority: 10 }],
             services: [{ serviceType: "docker_service", capabilityDescription: "Docker service.", methods: ["lookup"] }],
             appBridge: { hooks: ["prepareLaunch"] },
-            routes: [{ method: "POST", path: "/docker/route", public: true, name: "docker-route", publicReason: "Remote adapter Docker fixture public route." }],
+            routes: [{ method: "POST", path: "/docker/route", public: true, name: "docker-route", publicReason: "Remote adapter Docker fixture public route.", publicWrite: "Remote capability POST authenticated by the endpoint's own bearer token, not the local gate." }],
             views: [{ id: "docker.view", label: "Docker View", bundlePath: "/assets/docker-view.js" }],
           },
           {
@@ -4564,7 +4564,7 @@ createServer(async (req, res) => {
             models: [{ modelType: "DOCKER_TOOLS_TEXT", priority: 11 }],
             services: [{ serviceType: "docker_tools_service", capabilityDescription: "Docker tools service.", methods: ["lookup"] }],
             appBridge: { hooks: ["prepareLaunch"] },
-            routes: [{ method: "POST", path: "/docker-tools/route", public: true, name: "docker-tools-route", publicReason: "Remote adapter Docker tools fixture public route." }],
+            routes: [{ method: "POST", path: "/docker-tools/route", public: true, name: "docker-tools-route", publicReason: "Remote adapter Docker tools fixture public route.", publicWrite: "Remote capability POST authenticated by the endpoint's own bearer token, not the local gate." }],
             views: [{ id: "docker.tools.view", label: "Docker Tools View", bundlePath: "/assets/docker-tools-view.js" }],
           },
         ] } });

--- a/packages/app/scripts/lib/device-e2e-bundle.mjs
+++ b/packages/app/scripts/lib/device-e2e-bundle.mjs
@@ -114,9 +114,14 @@ function convertPngToJpg(src, dest) {
     if (sips.status === 0 && isNonEmptyFile(dest)) return true;
   }
   if (shellAvailable("ffmpeg")) {
+    // `-update 1` is required to write a single still to a fixed (non-pattern)
+    // filename: without it the image2 muxer demands a `%d` sequence pattern and
+    // older ffmpeg builds treat the missing pattern as a fatal error (non-zero
+    // exit, no file). Newer builds only warn, so the flag keeps the conversion
+    // deterministic across ffmpeg versions on the CI runners.
     const ffmpeg = spawnSync(
       "ffmpeg",
-      ["-y", "-i", src, "-frames:v", "1", "-q:v", "2", dest],
+      ["-y", "-i", src, "-frames:v", "1", "-update", "1", "-q:v", "2", dest],
       { stdio: "ignore" },
     );
     if (ffmpeg.status === 0 && isNonEmptyFile(dest)) return true;

--- a/packages/app/src/sw-registration.ts
+++ b/packages/app/src/sw-registration.ts
@@ -49,6 +49,11 @@ export function registerViewServiceWorker(): void {
   navigator.serviceWorker
     .register("/sw.js", { scope: "/" })
     .then((registration) => {
+      // WebKit under automation (and some webviews) expose
+      // `navigator.serviceWorker` yet resolve register() to undefined rather
+      // than rejecting. That is SW-unavailable, not a failure — reading
+      // `.scope` off it would throw and masquerade as a registration error.
+      if (!registration) return;
       console.info("[SW] Registered, scope:", registration.scope);
     })
     // error-policy:J4 the service worker is a PWA enhancement — the app

--- a/packages/app/test/ui-smoke/chat-overlay-controls-interactions.spec.ts
+++ b/packages/app/test/ui-smoke/chat-overlay-controls-interactions.spec.ts
@@ -143,7 +143,7 @@ test("chat overlay: sending opens the chat, click-out collapses, Escape collapse
   });
 });
 
-test("chat overlay: the attach control opens an image picker", async ({
+test("chat overlay: the + menu's Upload file opens an image picker", async ({
   page,
 }) => {
   await openAppPath(page, "/chat");
@@ -151,23 +151,34 @@ test("chat overlay: the attach control opens an image picker", async ({
     timeout: 60_000,
   });
 
-  const attach = page.getByTestId("chat-composer-attach");
-  await expect(attach).toBeVisible({ timeout: 15_000 });
+  // Attachment is a chat-actions "+" menu affordance, not a standalone button:
+  // the plus opens the surface-local menu, and its "Upload file" item is what
+  // triggers the hidden file input / OS picker.
+  const plus = page.getByTestId("chat-composer-plus");
+  await expect(plus).toBeVisible({ timeout: 15_000 });
+  await plus.click();
+
+  const upload = page.getByRole("menuitem", { name: /upload file/i });
+  await expect(upload).toBeVisible({ timeout: 10_000 });
   const [chooser] = await Promise.all([
     page.waitForEvent("filechooser", { timeout: 10_000 }),
-    attach.click(),
+    upload.click(),
   ]);
   expect(chooser).toBeTruthy();
 });
 
-test("chat overlay: transcript text is selectable and the old transcribe toggle is absent", async ({
+test("chat overlay: transcript text is selectable and the transcribe toggle is present", async ({
   page,
 }) => {
   await openAppPath(page, "/chat");
   const overlay = page.getByTestId("continuous-chat-overlay");
   await expect(overlay).toBeVisible({ timeout: 60_000 });
 
-  await expect(page.getByTestId("chat-composer-transcribe")).toHaveCount(0);
+  // The mic dictation toggle is an intentional trailing composer control
+  // (#10699) that sits beside the voice button in the default (no-draft) state.
+  await expect(page.getByTestId("chat-composer-transcribe")).toBeVisible({
+    timeout: 15_000,
+  });
 
   const prompt = "show selectable transcript text";
   const composer = page.getByTestId("chat-composer-textarea");

--- a/packages/scenario-runner/test/scenarios/deterministic-browser-actions.scenario.ts
+++ b/packages/scenario-runner/test/scenarios/deterministic-browser-actions.scenario.ts
@@ -98,6 +98,17 @@ function clearWaitForUrlCallbackTimer(): void {
   }
 }
 
+// Hold the tab at START for this long after the fixture first observes it there,
+// then flip it to CALLBACK. The window must comfortably exceed the latency
+// between BROWSER_WAIT_FOR_URL navigating the tab to START and its FIRST poll —
+// which is gated behind an awaited, streamed "watching…" callback whose cost
+// balloons on a contended CI runner. At 150ms that latency occasionally won the
+// race, so the tab reached CALLBACK before the first poll and the action matched
+// on poll 1 (< the asserted ≥2). 500ms keeps the first poll safely inside the
+// START window on any plausibly-loaded runner without approaching the action's
+// 4s poll budget.
+const WAIT_FOR_URL_START_HOLD_MS = 500;
+
 function scheduleWaitForUrlCallbackNavigation(): void {
   clearWaitForUrlCallbackTimer();
   const startedAt = Date.now();
@@ -110,7 +121,7 @@ function scheduleWaitForUrlCallbackNavigation(): void {
       );
       if (waitTab?.id) {
         startSeenAt ??= Date.now();
-        if (Date.now() - startSeenAt < 150) {
+        if (Date.now() - startSeenAt < WAIT_FOR_URL_START_HOLD_MS) {
           return;
         }
         clearWaitForUrlCallbackTimer();
@@ -122,11 +133,13 @@ function scheduleWaitForUrlCallbackNavigation(): void {
         return;
       }
 
-      if (Date.now() - startedAt > 3_000) {
+      // Give up only if START never appears; once seen, the hold above owns the
+      // timing (its window is deliberately shorter than this abort budget).
+      if (startSeenAt === null && Date.now() - startedAt > 6_000) {
         clearWaitForUrlCallbackTimer();
       }
     })().catch(() => {
-      if (Date.now() - startedAt > 3_000) {
+      if (Date.now() - startedAt > 6_000) {
         clearWaitForUrlCallbackTimer();
       }
     });

--- a/packages/ui/src/cloud/shell/ConsoleShell.test.tsx
+++ b/packages/ui/src/cloud/shell/ConsoleShell.test.tsx
@@ -206,7 +206,7 @@ describe("ConsoleShell", () => {
     await waitFor(() => expect(screen.getByTestId("login-page")).toBeTruthy());
   });
 
-  it("keeps a visible keyboard focus treatment on the account menu trigger", () => {
+  it("keeps the account menu trigger on the shared focus reset, not a per-component ring", () => {
     render(
       <MemoryRouter initialEntries={["/dashboard"]}>
         <ConsoleShell>
@@ -216,7 +216,13 @@ describe("ConsoleShell", () => {
     );
 
     const accountMenu = screen.getByRole("button", { name: /qa@e\.test/i });
-    expect(accountMenu.className).toContain("focus-visible:ring-2");
+    // Product policy (styles.css): focus rings are disabled globally with
+    // !important, so per-component focus-ring utilities are dead. The trigger
+    // carries only the shared `outline-none` reset and must never reintroduce
+    // a banned focus-ring utility — the tree-wide guarantee no-focus-ring-gate
+    // enforces.
+    expect(accountMenu.className).toContain("outline-none");
+    expect(accountMenu.className).not.toContain("focus-visible:ring");
   });
 
   it("redirects to /login (returnTo preserved) when the session dies — never a fake-empty console (#13709)", () => {

--- a/packages/ui/src/components/chat/message-parser-incremental.test.ts
+++ b/packages/ui/src/components/chat/message-parser-incremental.test.ts
@@ -273,7 +273,13 @@ describe("adjacency-heavy random-assembly differential (byte-identical)", () => 
       // chunk = 1 is the strictest streaming: every single-char prefix is a frame.
       assertDifferential(false, prefixesByChunk(text, 1));
     }
-  });
+    // Explicit timeout, not the 5s default: this is a heavy deterministic
+    // correctness fuzz — 1500 fence-dense assemblies diffed at every single-char
+    // frame — and #15373's adjacent-fence-cluster full-parse fallback keeps the
+    // whole cluster in the live tail scan for exactly this corpus. The wall-clock
+    // cost is real but bounded; a shared CI runner under load must not flake it
+    // into a false red. The per-frame `toEqual` assertions are the coverage.
+  }, 30_000);
 });
 
 describe("normalize seam locality (computeSafeNormCut)", () => {
@@ -356,7 +362,12 @@ describe("work bound (O(delta), not O(N·L))", () => {
     // large fraction below the quadratic baseline.
     expect(incrementalScanned).toBeLessThan(20 * total);
     expect(incrementalScanned).toBeLessThan(baselineScanned / 10);
-  });
+    // Explicit timeout, not the 5s default: the baseline arm re-parses ~1600
+    // growing prefixes up to 100KB (an intentional O(N·L) reference), tens of
+    // millions of char-scans that take several seconds unloaded and far more on
+    // a contended shared runner. The work-bound ratios above — not wall-clock —
+    // are what actually guard the O(delta) property.
+  }, 30_000);
 
   it("keeps full parses rare across the stream", () => {
     const body = buildStreamBody(40 * 1024);

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -5216,7 +5216,7 @@ export function ContinuousChatOverlay({
                   // horizontal scrollbar strip across the sheet on iOS — the
                   // "weird side scroll thingy." This transcript only ever scrolls
                   // vertically; pin the horizontal axis closed.
-                  className="scrollbar-hide relative flex min-h-0 w-full flex-1 touch-pan-y flex-col overflow-y-auto overflow-x-hidden overscroll-contain px-5 outline-none [scrollbar-width:none] focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-[rgba(255,247,240,0.22)] [-webkit-overflow-scrolling:touch] [&::-webkit-scrollbar]:hidden"
+                  className="scrollbar-hide relative flex min-h-0 w-full flex-1 touch-pan-y flex-col overflow-y-auto overflow-x-hidden overscroll-contain px-5 outline-none [scrollbar-width:none] [-webkit-overflow-scrolling:touch] [&::-webkit-scrollbar]:hidden"
                   style={{ opacity: threadContentOpacity }}
                 >
                   {/* Empty-thread loading: a fresh/cleared chat awaiting its

--- a/packages/ui/test/story-gate/log-capture-wiring.test.mjs
+++ b/packages/ui/test/story-gate/log-capture-wiring.test.mjs
@@ -118,11 +118,25 @@ describe("story-gate log-capture wiring (#13624)", () => {
   });
 
   it("deriveNetworkFailureIssues escalates a rendered story to broken on a net failure", () => {
+    // Only a REAL catalog-bundle fault escalates (#15370): a same-origin code
+    // chunk / stylesheet the static server should serve but that 502s or fails.
+    // `/api/*` and public-asset failures are expected-absent in the backend-less
+    // catalog and stay soft — covered by story-gate-classify.test.mjs.
+    const origin = "http://x";
     const cap = {
-      failedResponses: [{ status: 502, url: "http://x/api/a" }],
-      requestFailures: [{ failure: "net::ERR_FAILED", url: "http://x/api/b" }],
+      failedResponses: [{ status: 502, url: `${origin}/assets/app.chunk.js` }],
+      requestFailures: [
+        { failure: "net::ERR_FAILED", url: `${origin}/assets/app.css` },
+      ],
     };
-    const { escalate, issues } = deriveNetworkFailureIssues(cap, "good");
+    // Pass the catalog origin exactly as the runner does (run-story-gate.mjs
+    // derives it from baseUrl); the origin gates same-origin bundle faults from
+    // external hosts.
+    const { escalate, issues } = deriveNetworkFailureIssues(
+      cap,
+      "good",
+      origin,
+    );
     expect(escalate).toBe(true);
     expect(issues).toHaveLength(2);
     expect(issues[0]).toContain("network-failure: net-response 502");

--- a/plugins/plugin-workflow/__tests__/integration/embedded-harness.ts
+++ b/plugins/plugin-workflow/__tests__/integration/embedded-harness.ts
@@ -57,7 +57,13 @@ export async function makeEmbeddedHarness(agentSeed: string): Promise<EmbeddedHa
       error: () => {},
     },
     services,
-    getSetting: () => null,
+    // Suppress the default health-check workflow seed: these harnesses verify
+    // run/dispatch mechanics against explicitly-created workflows, and the
+    // auto-seeded default (which also runs once and arms a schedule on start)
+    // is orthogonal pollution here — it would otherwise leave a stray execution
+    // row and trigger task. The seed path is covered by the embedded service's
+    // own unit suite.
+    getSetting: (key: string) => (key === 'WORKFLOW_SEED_DEFAULTS' ? 'false' : null),
     getService: (type: string) => {
       const entries = services.get(type);
       return entries && entries.length > 0 ? entries[0] : null;

--- a/plugins/plugin-workflow/__tests__/integration/trigger-dispatch-e2e.test.ts
+++ b/plugins/plugin-workflow/__tests__/integration/trigger-dispatch-e2e.test.ts
@@ -132,7 +132,12 @@ async function makeHarness(): Promise<Harness> {
       error: () => {},
     },
     services,
-    getSetting: () => null,
+    // Suppress the default health-check workflow seed: this suite verifies the
+    // trigger/dispatch/tick mechanics against explicitly-created workflows. The
+    // auto-seeded default (which runs once and arms its own trigger task on
+    // start) would otherwise add a second TRIGGER_DISPATCH task and a stray
+    // execution row, skewing the exact task/execution counts asserted below.
+    getSetting: (key: string) => (key === 'WORKFLOW_SEED_DEFAULTS' ? 'false' : null),
     getService: (type: string) => {
       const entries = services.get(type);
       return entries && entries.length > 0 ? entries[0] : null;


### PR DESCRIPTION
Repairs the five current-tip **non-live** jobs from the develop-HEAD `Tests` run (28937426001 / push 28937218658, both at develop HEAD 9c99e6556c5). Each fixed at the correct layer per fail-fast doctrine; **no coverage weakened**. Verified locally.

## Per-job inventory + root cause + fix

### 1. Server Tests — `test:remote-capabilities:docker`
- **Root cause:** the central RouteAuth gate (`core/src/types/plugin.ts assertPublicRouteIntent`) rejects a `public` write-method route without a `publicWrite` declaration. The docker/process/built-source/docker-tools fixtures in `remote-plugin-adapter.test.ts` declared public `POST` routes without it (the `localhost` fixture already had one — the others were missed when the gate landed).
- **Fix:** add `publicWrite` to all four fixture routes.
- **Verified:** `test:remote-capabilities:docker` → 1 passed, 43 skipped.

### 2. Client Tests — `test` (app + ui)
- **`sw-registration.ts`** (28 ui-smoke webkit failures, the `Expected -1`/`Received +3` diff): WebKit under automation exposes `navigator.serviceWorker` yet resolves `register()` to `undefined`; reading `.scope` threw → logged as `console.error` → tripped `plugin-views-visual.spec.ts`'s `pageErrors === []` gate on every view. **Fix:** guard the undefined registration (SW-unavailable, not a failure).
- **`ContinuousChatOverlay.tsx`** (no-focus-ring-gate): a later commit (96a405f) re-introduced `focus-visible:ring-*` utilities that the global no-focus-ring policy (`styles.css`, `!important`) bans; the gate flagged line 5219. **Fix:** remove them again (as 16773c599b7 originally did).
- **`ConsoleShell.test.tsx`**: the source correctly dropped its per-component ring (16773c599b7) but this stale assertion still expected `focus-visible:ring-2`. **Fix:** align it with the policy (asserts `outline-none` reset, no ring).
- **`device-e2e-bundle.mjs`**: the PNG→JPG `ffmpeg` call omitted `-update 1`, so the runner's ffmpeg treats the image2 muxer's missing sequence pattern as fatal (non-zero, no JPG). **Fix:** add `-update 1` for version-independent single-image writes.
- **`log-capture-wiring.test.mjs`**: #15370 added the `isCatalogResourceFailure` filter; the escalation fixture still used `/api/*` URLs (now correctly expected-absent) **and** omitted the `staticOrigin` the runner always passes — `new URL(url, null)` throws, so nothing escalated. **Fix:** use a same-origin bundle-resource fixture + pass the origin (mirrors production).
- **`message-parser-incremental.test.ts`**: two heavy deterministic tests (1500 fence-dense per-char-frame assemblies; a 100KB O(N·L) baseline arm) timed out at the 5s default on the ~10x-contended runner (the ui suite took **726s**). Both are wall-clock timeouts, not assertion failures. **Fix:** explicit 30s timeouts; every correctness/work-bound assertion kept.
- **Verified:** ui (no-focus-ring + ConsoleShell + log-capture + message-parser) → 179 passed; app device-e2e-bundle → 7 passed.

### 3. Plugin Tests (2/4) — `test:plugins` → `@elizaos/plugin-workflow`
- **Root cause:** `EmbeddedWorkflowService.start` seeds **and runs** a default `system-device-health-check` workflow, leaving a stray execution + trigger task. That polluted the mechanics fixtures: run-op (c)/(d) saw 1 execution not 0; WI-6 (a) saw 2 trigger tasks; WI-6 (c)/(e)/(f) `.find()`'d the health-check task so the test workflow never fired (0 executions).
- **Fix:** opt the two harnesses out via the **existing** `WORKFLOW_SEED_DEFAULTS` setting (the product knob for exactly this). Seed behavior is covered by the embedded service's own unit suite.
- **Verified:** full `plugin-workflow` suite → 379 passed, 0 fail.

### 4. Zero-Key app browser — `test:e2e`
- **28 failures = the SW `Expected -1`** — fixed by #2's `sw-registration.ts` guard.
- **2 failures** (`chat-overlay-controls-interactions.spec.ts`) asserted an **un-merged composer redesign** (a `chat-composer-attach` button; the transcribe toggle removed) that contradicts the current source **and its passing unit tests** (`ContinuousChatOverlay.test.tsx` asserts the transcribe toggle exists). **Fix:** rewrite to the real composer — attach via the "+" menu's "Upload file" item; the transcribe toggle (#10699) is present.
- **Composer-disabled matrix note (for the coordinator):** the Scenario-matrix `chat-composer-textarea stays disabled` symptom is a **separate root** — the `firstRunOpen` (onboarding/sign-in-first) gate; the composer is disabled until the fixture reaches signed-in/onboarded state. It is **not** the same as the SW `Expected -1`, and it does **not** occur in this Tests job (the sibling `:107` send test passes here → composer enabled). That symptom needs a dedicated Scenario-app-browser fixture-readiness lane.
- App e2e (webkit) cannot run in this isolated-linker worktree; the 2 spec rewrites are grounded in the composer source + its passing unit tests and confirmed by CI.

### 5. Zero-Key scenario runner — `test:pr:e2e`
- **Root cause:** the `deterministic-browser-actions` scenario's `wait_for_url` matched on poll 1 (asserted ≥2). The fixture held the tab at `START` only **150ms** after first sighting — shorter than the navigate→streamed-"watching…"-callback→first-poll latency under load — so the tab reached `CALLBACK` before the first poll.
- **Fix:** raise the hold to **500ms** and key the abort off "START never seen" (once seen, the hold owns the timing). The bun `Internal error: directory mismatch for ".../tsconfig.json"` line is **benign teardown noise** printed after the scenario finished — not the failure.
- **Verified:** `deterministic-browser-actions` → 1 passed, 0 failed.

## Dedupe
Distinct from already-fixed `:live-ci-audit` (#15444), `:surface-audit` (#15330), #15447 (z-index/overlay), #15321-25, #15333/#15337. Rebased on current develop (6c70d626629, #15450/#15451) — no overlap with either.

## Validation
`biome check` clean; `audit:error-policy-ratchet` no new fallback-slop; `typecheck` 83 packages successful (scenario-runner's only errors are pre-existing `TS2307 @elizaos/capacitor-*` module-resolution gaps in untouched ui files, linked in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)