### PR TITLE
test(app): realign onboarding composer-lock e2e to #15339 sign-in-first

### DIFF
--- a/packages/app/test/ui-smoke/onboarding-confused-user.spec.ts
+++ b/packages/app/test/ui-smoke/onboarding-confused-user.spec.ts
@@ -268,8 +268,9 @@ test.describe("confused-user onboarding", () => {
     });
     await page.reload({ waitUntil: "domcontentloaded" });
 
-    // Nothing was persisted (no POST yet) → the conductor re-seeds a fresh,
-    // fully interactive onboarding: unlocked composer + unlocked runtime CHOICE.
+    // Nothing was persisted (no POST yet) → the conductor re-seeds a fresh
+    // onboarding surface: the runtime CHOICE is unlocked (re-offered) while the
+    // composer stays sign-in-first locked, same contract as the first paint.
     await expectChatFirstOnboarding(page);
     await screenshot(page, "after-reload-fresh-onboarding");
 

--- a/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
+++ b/packages/app/test/ui-smoke/onboarding-to-home.shared.ts
@@ -754,15 +754,16 @@ export async function expectChatFirstOnboarding(page: Page): Promise<Locator> {
   await expect(page.getByTestId(RUNTIME_CHOICE("remote"))).toBeVisible();
   await expect(page.getByTestId("first-run-runtime-chooser")).toHaveCount(0);
 
-  // Onboarding surface (#12178): the composer is UNLOCKED (typed text is
-  // answered by the in-chat conductor, never the server) with an inviting
-  // placeholder, the backdrop is OPAQUE so the launcher/home is hidden, and the
-  // pinned-open sheet is still non-dismissable — Escape must NOT collapse it.
+  // Onboarding surface (#15339): first-run is sign-in-first, so the composer is
+  // LOCKED (disabled) with a "Sign in to start chatting" cue until the user
+  // signs in — typing into a not-yet-ready chat is prevented. The backdrop is
+  // OPAQUE so the launcher/home is hidden, and the pinned-open sheet is still
+  // non-dismissable — Escape must NOT collapse it.
   const composer = page.getByTestId("chat-composer-textarea");
-  await expect(composer).toBeEnabled();
+  await expect(composer).toBeDisabled();
   await expect(composer).toHaveAttribute(
     "placeholder",
-    "Connect to cloud to enable chat",
+    "Sign in to start chatting",
   );
   await expect(page.getByTestId("chat-first-run-backdrop")).toHaveAttribute(
     "data-first-run-opaque",
@@ -1049,10 +1050,15 @@ export async function expectCloudOnlySignInOnboarding(
   await expect(
     page.getByText("where should your agent run?", { exact: false }),
   ).toHaveCount(0);
-  // Same onboarding surface contract as chooser mode: unlocked composer,
-  // opaque backdrop, non-dismissable pinned sheet.
+  // Same onboarding surface contract as chooser mode (#15339): sign-in-first
+  // locked composer ("Sign in to start chatting"), opaque backdrop,
+  // non-dismissable pinned sheet.
   const composer = page.getByTestId("chat-composer-textarea");
-  await expect(composer).toBeEnabled();
+  await expect(composer).toBeDisabled();
+  await expect(composer).toHaveAttribute(
+    "placeholder",
+    "Sign in to start chatting",
+  );
   await expect(page.getByTestId("chat-first-run-backdrop")).toHaveAttribute(
     "data-first-run-opaque",
     "true",

--- a/packages/app/test/ui-smoke/onboarding-to-home.spec.ts
+++ b/packages/app/test/ui-smoke/onboarding-to-home.spec.ts
@@ -84,8 +84,8 @@ test.describe("in-chat onboarding → home → launcher", () => {
     await page.goto("/", { waitUntil: "domcontentloaded" });
 
     // Capture the chat-first onboarding landing before driving it. The helper
-    // also asserts the onboarding lock: composer disabled ("Choose an option
-    // to continue") and Escape NOT collapsing the pinned-open sheet.
+    // also asserts the onboarding lock: composer disabled ("Sign in to start
+    // chatting") and Escape NOT collapsing the pinned-open sheet.
     await expectChatFirstOnboarding(page);
     // NEGATIVE, restated at the spec level: mid-onboarding the sheet cannot be
     // dismissed — the old Escape-collapse-to-reach-the-launcher step is gone.


### PR DESCRIPTION
## Root cause

The Scenario-PR app-browser matrix fails at `onboarding-to-home.shared.ts:762` with:

```
expect(locator).toBeEnabled() failed
Expected: enabled
Received: disabled
  at expectChatFirstOnboarding (onboarding-to-home.shared.ts:762)
```

This is **not** a harness/fixture-readiness issue. **#15339 ("clean fullscreen Cloud onboarding auth flow")** made first-run onboarding **sign-in-first**: the floating chat composer now mounts **LOCKED** (`disabled={firstRunOpen}`) with a **"Sign in to start chatting"** placeholder and only unlocks once the user signs in. That is the shipped, intended behavior, codified by the passing unit suites:

- `packages/ui/src/components/shell/ContinuousChatOverlay.firstrun.test.tsx` — asserts `input.disabled === true` and `input.placeholder === "Sign in to start chatting"`.
- `packages/ui/src/first-run/use-first-run-conductor.test.ts`.

The onboarding **e2e helpers were never updated** for #15339, so `expectChatFirstOnboarding` / `expectCloudOnlySignInOnboarding` still asserted the old #12178 "unlocked onboarding composer" contract (`toBeEnabled()` + placeholder `"Connect to cloud to enable chat"`). `onboarding-to-home.spec.ts`'s own comment already documented the intended lock ("composer disabled") — only the shared-helper body lagged.

## Fix

Realign the onboarding composer-lock assertions to the shipped behavior:
- `expect(composer).toBeEnabled()` → `toBeDisabled()`
- placeholder `"Connect to cloud to enable chat"` → `"Sign in to start chatting"`
- correct the stale placeholder strings in the spec-level comments.

Not weakening: the composer **should** be locked during onboarding now (unit-test-verified). The screenshot below shows the actual current surface — locked composer with the `Sign in to start chatting` placeholder over the still-rendered runtime chooser — matching the updated assertions.

## Verified locally (zero-key ui-smoke live stack)

`bun run --cwd packages/app test:e2e test/ui-smoke/onboarding-to-home.spec.ts ... --project=chromium`

The onboarding paths that depend **only** on the composer-lock assertion now pass: cloud-inference (`:152`), remote-connect (`:214`), tutorial-tour (`:235`), mobile cloud-inference (`:130`). Before this change they all failed at `:762`.

## Residual (NOT fixed here — needs a dedicated onboarding e2e realignment)

#15339 also rewrote the rest of the onboarding flow. These break the cloud-onboarding, cloud-only and confused-user e2e paths **independently** of the composer lock and each need the new sign-in-first flow reverse-engineered:

- **Cloud auth flow rewrite** — the in-transcript Eliza Cloud OAuth card (`sensitive_request_form` / `sensitive-request`) was **removed** in favor of a **browser-popup** sign-in ("Finish signing in in the browser window"). `completeCloudOnboardingToHome` (chooser cloud) still drives the deleted in-transcript card → fails at `shared.ts:995`.
- **Greetings changed** — cloud-only greeting `"Sign in to Eliza Cloud and I'll get you set up"` and session-injection `"Welcome back — you're already signed in"` no longer match → `shared.ts:1043` / `:1140`.
- **Post-"skip" settle** — the sheet now settles to the **HALF** detent (open, home revealed behind) instead of collapsing; specs still assert `overlay not data-open="true"`.
- **Composer locked ⇒ typing-during-onboarding removed** — the confused-user "type free text, get an in-transcript reply" test premise (#12178) is gone; `composer.fill()` now hangs on the disabled composer.
- **Failing-POST re-offer** count/flow changed (`toHaveCount(2)` → `1`).

Recommend routing the full onboarding e2e realignment (cloud-auth popup flow + greetings + settle states + re-offer) to the #15339 author for design confirmation, since the auth flow is freshly landed and still churning ("close failed cloud auth popup", "make cloud auth fallbacks explicit").

🤖 Generated with [Claude Code](https://claude.com/claude-code)