### PR TITLE
fix(ci): green residual Server + Client Tests at develop tip

### DIFF
--- a/packages/agent/src/runtime/view-capability-audit.test.ts
+++ b/packages/agent/src/runtime/view-capability-audit.test.ts
@@ -55,9 +55,15 @@ const repoRoot = path.resolve(here, "../../../..");
 
 /**
  * Map each audited view id → the plugin directory that owns its view source.
- * Only views whose `.tsx` actually live in a `plugins/<dir>/src` tree are listed
- * — host/built-in views (`lifeops`, `training`, `settings`) have no plugin
- * source to scan and are exercised through `validateViewCoverage` below instead.
+ * Only views whose `.tsx` actually live in a `plugins/<dir>/src` tree AND are
+ * declared as a dashboard `views:` entry by their plugin are listed — host/
+ * built-in views (`lifeops`, `training`, `settings`) have no plugin source to
+ * scan and are exercised through `validateViewCoverage` below instead. Facewear
+ * belongs to that settings-category set too: its smartglasses UI is not a
+ * standalone dashboard view but a Settings → Wearables section (`register.ts`
+ * registers a settings section; `SmartglassesView` renders lazily inside it),
+ * so the plugin declares no `views:`/`relatedActions` and its registry entry
+ * asserts no `launch` (see plugin-facewear/registry-entry.json + its test).
  * Every key here must declare relatedActions in its plugin entry (asserted in
  * the suite) so this stays a meaningful subset of the registered surface, not a
  * parallel list.
@@ -74,7 +80,6 @@ const VIEW_SOURCE_DIRS: Readonly<Record<string, string>> = {
   relationships: "plugin-relationships",
   documents: "plugin-documents",
   orchestrator: "plugin-task-coordinator",
-  facewear: "plugin-facewear",
   polymarket: "plugin-polymarket",
   hyperliquid: "plugin-hyperliquid",
 };

--- a/packages/app/scripts/lib/device-e2e-bundle.mjs
+++ b/packages/app/scripts/lib/device-e2e-bundle.mjs
@@ -9,7 +9,10 @@
  */
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
+
+const require = createRequire(import.meta.url);
 
 const INLINE_EXTENSIONS = new Set([".jpg", ".jpeg", ".mp4"]);
 const IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg"]);
@@ -126,7 +129,32 @@ function convertPngToJpg(src, dest) {
     );
     if (ffmpeg.status === 0 && isNonEmptyFile(dest)) return true;
   }
-  return false;
+  return convertPngToJpgWithSharp(src, dest);
+}
+
+// Final PNG->JPG fallback for hosts without sips/ffmpeg — notably the Linux CI
+// runners, which ship neither. `sharp` is a declared packages/app dependency,
+// so it is always installed here; run it out-of-process to keep this converter
+// synchronous like the sips/ffmpeg spawns above (prepareInlineArtifacts and
+// every runner call site depend on the sync contract, and sharp's API is async
+// only). Returns false if sharp cannot be resolved or the encode fails.
+function convertPngToJpgWithSharp(src, dest) {
+  let sharpEntry;
+  try {
+    sharpEntry = require.resolve("sharp");
+  } catch {
+    return false;
+  }
+  const encode =
+    "const sharp=require(process.argv[3]);" +
+    "sharp(process.argv[1]).jpeg({quality:82}).toFile(process.argv[2])" +
+    ".then(()=>process.exit(0)).catch(()=>process.exit(1));";
+  const result = spawnSync(
+    process.execPath,
+    ["-e", encode, src, dest, sharpEntry],
+    { stdio: "ignore" },
+  );
+  return result.status === 0 && isNonEmptyFile(dest);
 }
 
 function remuxMovToMp4(src, dest) {

--- a/packages/ui/src/components/settings/CapabilitiesSection.tsx
+++ b/packages/ui/src/components/settings/CapabilitiesSection.tsx
@@ -20,7 +20,13 @@ import {
   PlugZap,
   Wallet,
 } from "lucide-react";
-import { type FormEvent, useCallback, useEffect, useState } from "react";
+import {
+  type FormEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { client } from "../../api/client";
 import { isApiError } from "../../api/client-types-core";
 import { invalidateWeatherCache } from "../../hooks/useWeather";
@@ -161,6 +167,18 @@ export function CapabilitiesSection() {
   const [capabilityConnectResult, setCapabilityConnectResult] =
     useState<CapabilityRouterConnectResponse | null>(null);
 
+  // The auto-training fetch resolves after the mount effect fires; writing state
+  // once the section is gone is a browser no-op but throws under the jsdom test
+  // teardown (React's scheduler reads `window`). Guard every async write past
+  // unmount — the canonical ui-hook pattern (see useCachedResource.ts).
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   const refreshAutoTraining = useCallback(async () => {
     setAutoTrainingLoading(true);
     try {
@@ -168,10 +186,12 @@ export function CapabilitiesSection() {
         client.fetch<AutoTrainingConfigResponse>("/api/training/auto/config"),
         client.fetch<AutoTrainingStatusResponse>("/api/training/auto/status"),
       ]);
+      if (!mountedRef.current) return;
       setAutoTrainingConfig(configResponse.config);
       setAutoTrainingAvailable(statusResponse.serviceRegistered !== false);
       setAutoTrainingError(false);
     } catch (err) {
+      if (!mountedRef.current) return;
       // error-policy:J4 404 = training plugin not hosted on this runtime — the
       // designed "unavailable" degrade. Any other failure (5xx, transport,
       // parse) renders the explicit error icon instead of silently disabling
@@ -180,7 +200,7 @@ export function CapabilitiesSection() {
       setAutoTrainingAvailable(false);
       setAutoTrainingError(!(isApiError(err) && err.status === 404));
     } finally {
-      setAutoTrainingLoading(false);
+      if (mountedRef.current) setAutoTrainingLoading(false);
     }
   }, []);
 

--- a/packages/ui/src/hooks/useWeather.ts
+++ b/packages/ui/src/hooks/useWeather.ts
@@ -365,7 +365,21 @@ export function useWeather(): WeatherState {
     return cached ? { ...cached, status: "ready" } : LOADING;
   });
 
+  // fetchWeather/promptForCoords settle after the effect fires; a state write
+  // once the component is gone is a no-op in the browser but throws under the
+  // jsdom test teardown (React's scheduler reads `window`). Skip every async
+  // continuation past unmount — the canonical guard used across the ui hooks
+  // (see useCachedResource.ts).
+  const mountedRef = React.useRef(true);
+  React.useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   const applyUnavailable = React.useCallback(() => {
+    if (!mountedRef.current) return;
     // Only fall to "unavailable" when we have nothing cached to show.
     setWeather((prev) =>
       prev.status === "ready" ? prev : { ...LOADING, status: "unavailable" },
@@ -380,11 +394,13 @@ export function useWeather(): WeatherState {
       return Promise.resolve();
     return fetchWeather()
       .then((next) => {
+        if (!mountedRef.current) return;
         setWeather(next);
         writeCache({ ...next, fetchedAt: Date.now() });
         if (next.approximate) noteApproximateLocationOnce();
       })
       .catch(() => {
+        if (!mountedRef.current) return;
         // error-policy:J4 stale/no-location/weather failure renders the
         // explicit unavailable tile instead of a healthy old reading.
         setWeather({ ...LOADING, status: "unavailable" });
@@ -406,6 +422,7 @@ export function useWeather(): WeatherState {
     void promptForCoords()
       .then((coords) => fetchWeatherAt(coords, false))
       .then((next) => {
+        if (!mountedRef.current) return;
         setWeather(next);
         writeCache({ ...next, fetchedAt: Date.now() });
       })


### PR DESCRIPTION
Repairs the two non-live Tests failures at develop tip (Server Tests + Client Tests). Live E2E jobs are workflow_dispatch-only and out of scope.

## Server Tests — `view-capability-audit` facewear (`expected 0 to be greater than 0`)

Root cause: `remove untested slop` (2a5d68021b2) removed the standalone facewear `views:` declaration when the XR/spatial surface was cut. Facewear's smartglasses UI now renders lazily **inside a Settings → Wearables section** (`plugins/plugin-facewear/src/register.ts` registers a settings section; `SmartglassesView` is `lazy()`-loaded inside `WearablesSettingsSection`). The plugin declares no `views:`/`relatedActions`, and `plugins/plugin-facewear/registry-entry.json` (+ `facewear-registry.test.ts`) explicitly asserts **no `launch`** and `render.actions: ["enable","configure"]`.

The static audit's `VIEW_SOURCE_DIRS` still mapped `facewear → plugin-facewear`, so the "every audited plugin view declares relatedActions" gate failed. Facewear is a settings-category surface now, not a dashboard view — dropped from the audited map (same treatment as `lifeops`/`training`/`settings`) with a documenting comment. **No coverage weakened**: it is no longer a registered plugin dashboard view, so re-adding a `views:` declaration would contradict the intentional consolidation and the registry contract.

## Client Tests

**packages/app — `device-e2e-bundle` PNG→JPG** (`converts PNG screenshots into inline JPG artifacts`): `convertPngToJpg` required `sips` (macOS) or `ffmpeg`; the Linux CI runners ship neither (the prior `-update 1` fix only helps when ffmpeg exists), so `inline/screen.jpg` was never produced. Added a `sharp` fallback — a **declared `packages/app` dependency**, so always installed here — run out-of-process to keep the converter synchronous (every runner call site + the test depend on the sync contract; sharp's API is async-only). Verified passing **with and without** ffmpeg on PATH; output has a valid JPEG magic (`ffd8ff`).

**packages/ui — 5 unhandled rejections `ReferenceError: window is not defined`**: `useWeather` and `CapabilitiesSection` wrote React state from mount-fired async fetches (`fetchWeather` / `client.fetch("/api/training/auto/*")`) that settle **after** the jsdom environment is torn down under the contended CI runner; React's scheduler reads `window` during the state write and throws, which vitest counts as an unhandled error and fails the suite (all 754 test files pass). Guarded the async state writes past unmount with the **canonical `mountedRef` pattern already used across the ui hooks** (`useCachedResource.ts`). No behavioral change while mounted.

## Verification
- Server: `view-capability-audit.test.ts` → 19 passed (was 1 failed).
- Client app: `device-e2e-bundle.test.mjs` → 7 passed with ffmpeg present AND with ffmpeg hidden.
- Client ui: `HomeScreen.test.tsx`, `settings-stories-smoke.test.tsx`, `useWeather.test.ts`, `CapabilitiesSection.test.tsx` + capability suites → 109 passed, no unhandled rejections.
- `packages/ui` + `packages/agent` typecheck clean; biome clean; error-policy ratchet clean (no new empty-catch/console).

🤖 Generated with [Claude Code](https://claude.com/claude-code)