### PR TITLE
fix(registry): regenerate stale first-party generated.json (facewear drift)

### DIFF
--- a/packages/registry/src/first-party/generated.json
+++ b/packages/registry/src/first-party/generated.json
@@ -2494,13 +2494,12 @@
     {
       "id": "facewear",
       "name": "Facewear",
-      "description": "Unified facewear integration for Meta Quest, XReal, Apple Vision Pro, and Even Realities G1/G2 whole-headset pairing, display text, microphone audio, side-tap mic control, bridge Wi-Fi setup, and diagnostics.",
+      "description": "Even Realities G1/G2 whole-headset pairing, display text, microphone audio, side-tap mic control, bridge Wi-Fi setup, and diagnostics.",
       "npmName": "@elizaos/plugin-facewear",
       "version": "0.1.0",
       "source": "bundled",
       "tags": [
         "facewear",
-        "xr",
         "smartglasses",
         "wearable",
         "even-realities",
@@ -2597,7 +2596,7 @@
         "icon": "Glasses",
         "group": "hardware",
         "groupOrder": 8,
-        "actions": ["enable", "configure", "launch"]
+        "actions": ["enable", "configure"]
       },
       "resources": {
         "homepage": "https://elizaos.ai",
@@ -2607,22 +2606,7 @@
       "channels": [],
       "shortIds": [],
       "kind": "plugin",
-      "subtype": "media",
-      "launch": {
-        "type": "internal-tab",
-        "target": "facewear",
-        "capabilities": [
-          "facewear",
-          "xr-view-host",
-          "smartglasses",
-          "wearable-display",
-          "wearable-microphone",
-          "whole-headset-pairing",
-          "side-tap-microphone-control",
-          "wifi-provisioning"
-        ],
-        "curatedSlug": "facewear"
-      }
+      "subtype": "media"
     },
     {
       "id": "farcaster",


### PR DESCRIPTION
## Problem

The `packages/registry generate:first-party:check` CI gate is red on `develop`.
The checked-in `packages/registry/src/first-party/generated.json` is **stale**
against the current source `registry-entry.json` files, so the `--check`
regen-diff fails.

Root cause: commit 2a5d68021b2 ("remove untested slop") made facewear a
**Settings -> Wearables** section rather than a launchable dashboard view. The
source `plugins/plugin-facewear/registry-entry.json` dropped its `launch` block
(and related fields), but the aggregated `generated.json` was never regenerated
and committed.

## Fix

Ran `bun run --cwd packages/registry generate:first-party` to regenerate the
aggregated artifact from the current source entries. The generator is the source
of truth; its output was committed verbatim (no hand-editing).

The only entry that drifted is **facewear**:
- dropped the `launch: { type: "internal-tab", target: "facewear", ... }` block
  (source no longer declares `launch`)
- removed `launch` from `render.actions` -> now `["enable", "configure"]`
- shortened the `description` and removed the stale `xr` tag

No other first-party entry changed; the derived curated/channel/provider/short-id
maps are unchanged.

## Verification

```
$ bun run --cwd packages/registry generate:first-party
[registry/generate] wrote 112 entries + 8 curated-app definitions

$ bun run --cwd packages/registry generate:first-party:check
[registry/generate] generated artifacts are up to date.   # exit 0, was exit 1

$ bunx @biomejs/biome check packages/registry/src/first-party/generated.json
Checked 1 file in 51ms. No fixes applied.
```

Diff is `+3 / -19` lines, entirely within the facewear entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)