### PR TITLE
chore(cloud): enable pass-through streaming on staging for the soak

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -387,7 +387,7 @@ INFERENCE_HOT_PATH_CACHES = "true"
 # web-search) byte-for-byte from the provider instead of decoding/re-encoding
 # through the AI SDK; usage is metered from a teed branch and billed through
 # the existing settle chain. Default off; rollback = flip off.
-INFERENCE_PASSTHROUGH_STREAMING = "false"
+INFERENCE_PASSTHROUGH_STREAMING = "true"
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob-staging.elizacloud.ai"
 SQL_HEAVY_PAYLOAD_STORAGE = "r2"


### PR DESCRIPTION
Staging-only flip of INFERENCE_PASSTHROUGH_STREAMING (from #15437; prod stays false). Deepscanned MERGE-FLAGS-OFF. Post-deploy: latency probe (expect ~5s→~1s), billing-row comparison, isolate-memory watch (the tee ceiling), then prod flip.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - config flag, no UI.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - config flag, no UI.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - config only.
<!-- evidence-row:backend-logs -->
- [ ] N/A - staging soak numbers posted as a PR comment post-deploy; flag correctness covered by #15437's 96/0 suites.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model-path change.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - staging billing rows verified live post-deploy.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no media.