### PR TITLE
fix(ui): scroll the sign-in card on short viewports instead of clipping

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.safe-area.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.safe-area.test.tsx
@@ -68,3 +68,29 @@ describe("login page safe-area (#15361)", () => {
     ).toBe(false);
   });
 });
+
+describe("login page short-viewport scroll", () => {
+  // Short screens (e.g. Light Phone III, 1080x1240) make the sign-in card
+  // taller than the viewport. A flex `justify-center` centers it but the top
+  // overflows above scrollTop 0 and is unreachable — the OAuth / wallet rows
+  // fell below an unscrollable fold. The card region must be `overflow-y-auto`
+  // with the card itself `my-auto`, so it centers when it fits and
+  // scrolls-from-top when it overflows.
+  it("makes the sign-in card region scrollable instead of clipping when it exceeds the viewport", () => {
+    expect(
+      /flex-1[^"]*overflow-y-auto/.test(LOGIN_SRC),
+      "the sign-in card region must be overflow-y-auto to scroll when taller than the viewport",
+    ).toBe(true);
+  });
+
+  it("centers the card with my-auto (not a parent justify-center that clips the top)", () => {
+    expect(
+      /\bmy-auto\b[^"]*\bmax-w-md\b/.test(LOGIN_SRC),
+      "the sign-in card must center via my-auto so its top stays reachable while scrolling",
+    ).toBe(true);
+    expect(
+      /flex-1 items-center justify-center/.test(LOGIN_SRC),
+      "the card region must not use the top-clipping `flex ... items-center justify-center` centering",
+    ).toBe(false);
+  });
+});

--- a/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/login/login-page.tsx
@@ -50,8 +50,15 @@ function LoginBackground({ children }: { children: React.ReactNode }) {
           paddingBottom: "max(env(safe-area-inset-bottom, 0px), 1rem)",
         }}
       >
-        <div className="relative z-10 flex flex-1 items-center justify-center">
-          <div className="w-full max-w-md rounded-xl border border-border bg-card p-6 text-txt md:p-8 motion-safe:animate-[shell-overlay-in_320ms_cubic-bezier(0.16,1,0.3,1)]">
+        {/* Center the card vertically, but SCROLL — never clip — when it is
+            taller than the viewport. `overflow-y-auto` on the scroll region plus
+            the card's own `my-auto` keeps the card's top reachable; a flex
+            `justify-center` instead pushes the overflow above scrollTop 0, where
+            it is unreachable. Regressed on short screens (Light Phone III,
+            1080×1240) where the OAuth / wallet rows fell below an unscrollable
+            fold — see login-page.safe-area.test.tsx. */}
+        <div className="relative z-10 flex flex-1 flex-col items-center overflow-y-auto">
+          <div className="my-auto w-full max-w-md rounded-xl border border-border bg-card p-6 text-txt md:p-8 motion-safe:animate-[shell-overlay-in_320ms_cubic-bezier(0.16,1,0.3,1)]">
             {children}
           </div>
         </div>


### PR DESCRIPTION
## What & why

The Eliza Cloud sign-in page (`/login`) clips its card — instead of scrolling — on **short viewports**, making the lower sign-in options (the `or continue with` OAuth row, and the wallet row when enabled) **unreachable**.

Found while sideloading the Eliza app on a **Light Phone III** (1080×1240 — an unusually short/square screen): tapping *Sign in to Eliza Cloud* opens `elizacloud.ai/login` in the device browser, and the card is cut off at `or continue with` with no way to scroll. Confirmed it renders in **full Chrome** (not the app's webview) and Chrome itself can't scroll it — so the clip is the page's own CSS, and it reproduces on any viewport shorter than the card (small phones, large text/zoom, split-screen).

## Root cause

`LoginBackground` centers the card with `flex … items-center justify-center` and no scroll container. When the card is taller than the viewport, flex `justify-center` centers the overflow **above `scrollTop: 0`**, where it can't be scrolled into view — the classic flex-centering + overflow clip.

## Fix

Make the card region a scroll container and center the card with auto margins instead:

- region: `flex flex-1 items-center justify-center` → `flex flex-1 flex-col items-center overflow-y-auto`
- card: add `my-auto`

`overflow-y-auto` + `my-auto` centers the card when it fits and **scrolls from the top** when it overflows (auto margins are bounded by the scroll container, unlike `justify-center`). No visual change on tall screens. One-container change in `login-page.tsx`.

## Tests

Extended `login-page.safe-area.test.tsx` (same source-scan idiom the file already uses, since jsdom can't resolve `env()` / device-viewport collapse) with two cases: the card region is `overflow-y-auto`, and the card centers via `my-auto` rather than the top-clipping `items-center justify-center`.

- `bun run --cwd packages/ui test login-page.safe-area` → **6 passed (6)**
- `biome check` on both files → clean

## Evidence

- **Before:** on the Light Phone III the card is clipped at `or continue with`; three firm swipes move nothing (pixel-identical) — the OAuth/wallet options are below an unscrollable fold. (Screenshot from the device.)
- **After:** the card region scrolls; the previously-clipped rows are reachable. Full rendered before/after on the cloud preview deploy for this branch (the login surface is served from the deployed `elizacloud.ai`, not the app bundle).

Related: the repo's scroll/tap-target cert harness (#14380) and `login-page.safe-area.test.tsx` (#15361) cover this surface's geometry; this adds the short-viewport scroll guarantee.
