### PR TITLE
chore(cloud): enable pass-through streaming on production

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -539,7 +539,7 @@ INFERENCE_HOT_PATH_CACHES = "true"
 # web-search) byte-for-byte from the provider instead of decoding/re-encoding
 # through the AI SDK; usage is metered from a teed branch and billed through
 # the existing settle chain. Default off; rollback = flip off.
-INFERENCE_PASSTHROUGH_STREAMING = "false"
+INFERENCE_PASSTHROUGH_STREAMING = "true"
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob.elizacloud.ai"
 SQL_HEAVY_PAYLOAD_STORAGE = "r2"


### PR DESCRIPTION
Activates INFERENCE_PASSTHROUGH_STREAMING on prod (#15437, deepscanned MERGE-FLAGS-OFF). Staging idle+keyless so verification is live-on-prod with the proven pattern (baseline captured: streaming ttfb 3.75s/total 7.27s median; direct 0.6s). Rollback=flag false. Latency + billing-row + isolate-health verification posted post-deploy.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - config flag, no UI.
<!-- evidence-row:after-screenshots -->
- [ ] N/A - config flag, no UI.
<!-- evidence-row:walkthrough-video -->
- [ ] N/A - config only.
<!-- evidence-row:backend-logs -->
- [ ] N/A - before/after latency + billing-row verification posted as a PR comment post-deploy; correctness covered by #15437's 96/0 suites + independent deepscan.
<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend.
<!-- evidence-row:llm-trajectory -->
- [ ] N/A - transport change, model output unchanged.
<!-- evidence-row:domain-artifacts -->
- [ ] N/A - prod billing rows verified live post-deploy.
<!-- evidence-row:ocr-review -->
- [ ] N/A - no media.