### PR TITLE
fix(discord): abort generation on timeout — no orphaned runs, no double-dispatch

### DIFF
--- a/plugins/plugin-discord/README.md
+++ b/plugins/plugin-discord/README.md
@@ -58,6 +58,20 @@ DISCORD_SHOULD_IGNORE_DIRECT_MESSAGES=true
 # If true, only respond when explicitly @mentioned (default: true)
 DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS=true
 
+# Generation Timeout (Optional)
+# Wall-clock budget for generating a single reply before the bot gives up and
+# posts "I timed out while generating that reply." On timeout the underlying
+# model call is ABORTED (the abort signal threads through to runtime.useModel /
+# the provider fetch), so an orphaned run cannot keep burning tokens or race a
+# late response into the same channel.
+#   Default: 120000 (2 min). Minimum: 30000 (values below the floor are raised).
+#   Set to 0 to DISABLE the timeout entirely (await generation to completion —
+#   useful for long media jobs like video). Falls back to MESSAGE_TIMEOUT_MS,
+#   then to the media-generation timeout, when unset.
+# For heavy-context / multi-step agentic turns on cloud models, raise this
+# (e.g. 240000) rather than leaving replies to hit the 2-min cap.
+DISCORD_GENERATION_TIMEOUT_MS=120000
+
 # Testing (Optional)
 DISCORD_TEST_CHANNEL_ID=123456789012345678
 

--- a/plugins/plugin-discord/__tests__/generation-abort.test.ts
+++ b/plugins/plugin-discord/__tests__/generation-abort.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Discriminating tests for `runGenerationWithAbortableTimeout` — the fix for
+ * the Discord "I timed out while generating that reply" bug where a timeout
+ * fired WITHOUT aborting the underlying generation, leaving an orphaned run
+ * that kept burning tokens and could race a late response into the same room
+ * (the alternating timeout / instant-reply pattern).
+ *
+ * Diagnosis receipts (verified against origin/develop):
+ *   - messages.ts dispatch did `Promise.race([generationPromise,
+ *     timeoutPromise])` with NO AbortController and NO abortSignal passed to
+ *     `messageService.handleMessage` (messages.ts ~1315-1382 pre-fix).
+ *   - The core chain `MessageProcessingOptions.abortSignal` →
+ *     `StreamingContext.abortSignal` → `runtime.useModel(params.signal)` is
+ *     ALREADY wired and tested (packages/core message-handler-abort.test.ts,
+ *     message.ts:9175/9290/9403). The only missing link was the connector
+ *     never creating/passing a signal.
+ *
+ * Each test states whether it reproduces the pre-fix bug (RED against the old
+ * race-without-abort behavior).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runGenerationWithAbortableTimeout } from "../messages.ts";
+
+/** Deferred promise helper — lets a test control exactly when generation settles. */
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+describe("runGenerationWithAbortableTimeout", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.runOnlyPendingTimers();
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	/**
+	 * (c) Generation completing just UNDER the timeout → normal result, no
+	 * timeout, no error. Baseline: the happy path is unaffected.
+	 */
+	it("returns a clean result when generation completes before the timeout", async () => {
+		const generate = vi.fn(async (_signal: AbortSignal) => {
+			// resolves immediately on the microtask queue
+		});
+
+		const resultPromise = runGenerationWithAbortableTimeout(generate, 1000);
+		await vi.advanceTimersByTimeAsync(0);
+		const result = await resultPromise;
+
+		expect(result.timedOut).toBe(false);
+		expect(result.settled).toBe(true);
+		expect(result.error).toBeUndefined();
+		// The signal handed to generate must not be aborted on the happy path.
+		const passedSignal = generate.mock.calls[0]?.[0];
+		expect(passedSignal?.aborted).toBe(false);
+	});
+
+	/**
+	 * (f) + (b) Hung generation that never resolves → timeout reply AND the
+	 * underlying call is ABORTED (assert the signal fired). This is the core
+	 * fix. RED against pre-fix behavior: the old code never aborted, so the
+	 * signal would remain un-aborted (in fact no signal existed at all).
+	 */
+	it("aborts a hung generation when the timeout fires (REPRODUCES BUG)", async () => {
+		let capturedSignal: AbortSignal | undefined;
+		const generate = vi.fn((signal: AbortSignal) => {
+			capturedSignal = signal;
+			// Never resolves — simulates a hung model call.
+			return new Promise<void>(() => {});
+		});
+
+		const resultPromise = runGenerationWithAbortableTimeout(generate, 2000);
+		// `generate` runs on a microtask edge (Promise.resolve().then). Flush it
+		// so the signal is captured before we assert on it.
+		await vi.advanceTimersByTimeAsync(0);
+		expect(capturedSignal?.aborted).toBe(false);
+
+		await vi.advanceTimersByTimeAsync(2000);
+		const result = await resultPromise;
+
+		expect(result.timedOut).toBe(true);
+		expect(result.settled).toBe(false);
+		// The whole point: the abort actually fired.
+		expect(capturedSignal).toBeDefined();
+		expect(capturedSignal?.aborted).toBe(true);
+	});
+
+	/**
+	 * (a) Slow generation resolving AFTER the timeout → helper reports a single
+	 * timeout; the late resolution does NOT flip the result and does NOT throw
+	 * an unhandled rejection. RED against pre-fix: old code left the orphan
+	 * live and only `.catch(()=>{})`'d it — no abort, so it kept running.
+	 */
+	it("reports one timeout and swallows a late resolution (no double-dispatch)", async () => {
+		const gate = deferred<void>();
+		let capturedSignal: AbortSignal | undefined;
+		const generate = vi.fn((signal: AbortSignal) => {
+			capturedSignal = signal;
+			return gate.promise;
+		});
+
+		const resultPromise = runGenerationWithAbortableTimeout(generate, 1500);
+		await vi.advanceTimersByTimeAsync(1500);
+		const result = await resultPromise;
+
+		expect(result.timedOut).toBe(true);
+		expect(capturedSignal?.aborted).toBe(true);
+
+		// Orphan resolves LATE — must not throw, must not change the result.
+		gate.resolve();
+		await vi.advanceTimersByTimeAsync(0);
+		// Re-assert the already-returned result is stable (value type, frozen).
+		expect(result.timedOut).toBe(true);
+	});
+
+	/**
+	 * Late REJECTION of the orphaned run must be swallowed (no unhandled
+	 * rejection crashing the process). RED against a naive fix that aborts but
+	 * forgets to catch the abandoned promise.
+	 */
+	it("swallows a late rejection from the orphaned run", async () => {
+		const gate = deferred<void>();
+		const generate = vi.fn((_signal: AbortSignal) => gate.promise);
+
+		const resultPromise = runGenerationWithAbortableTimeout(generate, 1000);
+		await vi.advanceTimersByTimeAsync(1000);
+		const result = await resultPromise;
+		expect(result.timedOut).toBe(true);
+
+		// Orphan rejects late (e.g. the aborted fetch throws AbortError). If this
+		// rejection weren't swallowed inside the helper, flushing microtasks here
+		// would surface an unhandled rejection. We assert the flush completes
+		// without throwing.
+		gate.reject(new Error("aborted"));
+		let threw = false;
+		try {
+			await vi.advanceTimersByTimeAsync(0);
+			// Extra real-microtask flush to let any un-swallowed rejection surface.
+			await Promise.resolve();
+		} catch {
+			threw = true;
+		}
+		expect(threw).toBe(false);
+	});
+
+	/**
+	 * Generation that REJECTS on its own before the timeout → surfaces the
+	 * error, not a timeout. Distinguishes provider-error path from timeout
+	 * path (the call site sends different failure copy for each).
+	 */
+	it("surfaces a genuine generation error without marking it a timeout", async () => {
+		const boom = new Error("provider 500");
+		const generate = vi.fn(async (_signal: AbortSignal) => {
+			throw boom;
+		});
+
+		const resultPromise = runGenerationWithAbortableTimeout(generate, 5000);
+		await vi.advanceTimersByTimeAsync(0);
+		const result = await resultPromise;
+
+		expect(result.timedOut).toBe(false);
+		expect(result.settled).toBe(true);
+		expect(result.error).toBe(boom);
+	});
+
+	/**
+	 * `timeoutMs === null` disables the timeout: generation is awaited to
+	 * completion and no abort is fired even for a long job. Covers the media /
+	 * long-running path (Wan video etc.).
+	 */
+	it("awaits to completion with no abort when the timeout is disabled (null)", async () => {
+		const gate = deferred<void>();
+		let capturedSignal: AbortSignal | undefined;
+		const generate = vi.fn((signal: AbortSignal) => {
+			capturedSignal = signal;
+			return gate.promise;
+		});
+
+		const resultPromise = runGenerationWithAbortableTimeout(generate, null);
+		// Advance well past any plausible timeout — nothing should fire.
+		await vi.advanceTimersByTimeAsync(600_000);
+		expect(capturedSignal?.aborted).toBe(false);
+
+		gate.resolve();
+		const result = await resultPromise;
+		expect(result.timedOut).toBe(false);
+		expect(result.settled).toBe(true);
+		expect(capturedSignal?.aborted).toBe(false);
+	});
+
+	/**
+	 * (e) Back-to-back messages: the FIRST run times out (and is aborted), the
+	 * SECOND run gets its OWN fresh controller and is NOT poisoned by the
+	 * first's abort. This is the unit-level reproduction of the alternating
+	 * pattern — each invocation is independent. RED against pre-fix where the
+	 * orphaned first run stayed live and could bleed into the next slot.
+	 */
+	it("gives each invocation an independent controller (no cross-poisoning)", async () => {
+		// First message: hangs → times out → aborted.
+		let firstSignal: AbortSignal | undefined;
+		const firstGenerate = vi.fn((signal: AbortSignal) => {
+			firstSignal = signal;
+			return new Promise<void>(() => {});
+		});
+		const firstPromise = runGenerationWithAbortableTimeout(firstGenerate, 1000);
+		await vi.advanceTimersByTimeAsync(1000);
+		const firstResult = await firstPromise;
+		expect(firstResult.timedOut).toBe(true);
+		expect(firstSignal?.aborted).toBe(true);
+
+		// Second message: completes cleanly. Its signal must be a DIFFERENT,
+		// un-aborted controller.
+		let secondSignal: AbortSignal | undefined;
+		const secondGenerate = vi.fn(async (signal: AbortSignal) => {
+			secondSignal = signal;
+		});
+		const secondPromise = runGenerationWithAbortableTimeout(
+			secondGenerate,
+			1000,
+		);
+		await vi.advanceTimersByTimeAsync(0);
+		const secondResult = await secondPromise;
+
+		expect(secondResult.timedOut).toBe(false);
+		expect(secondSignal).toBeDefined();
+		expect(secondSignal).not.toBe(firstSignal);
+		expect(secondSignal?.aborted).toBe(false);
+	});
+});

--- a/plugins/plugin-discord/__tests__/generation-timeout-dispatch.test.ts
+++ b/plugins/plugin-discord/__tests__/generation-timeout-dispatch.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Integration coverage for the Discord generation-timeout DISPATCH path:
+ * drives the REAL `MessageManager.handleMessage` and asserts the connector
+ * now (a) threads an `abortSignal` into `messageService.handleMessage`,
+ * (b) ABORTS that signal when the generation timeout fires, and (c) sends
+ * exactly ONE "I timed out" reply without a second dispatch when the
+ * orphaned run resolves late.
+ *
+ * This is the connector-level reproduction of the screenshot bug: real
+ * questions hit the ~2min timeout while the underlying model call kept
+ * running as an orphan (no abort), able to race a late response into the
+ * same room and poison the next slot.
+ *
+ * Uses fake timers to fast-forward the (30s-floored) generation timeout.
+ * Only the discord.js SDK surface is stubbed — no token, no network.
+ */
+import type { Content, Memory, UUID } from "@elizaos/core";
+import { ChannelType } from "@elizaos/core";
+import type { Message as DiscordMessage } from "discord.js";
+import { ChannelType as DiscordChannelType } from "discord.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MessageManager } from "../messages.ts";
+import type { ICompatRuntime, IDiscordService } from "../types.ts";
+
+const AGENT_ID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" as UUID;
+const noop = () => {};
+
+const INBOUND_MEMORY: Memory = {
+	id: "12345678-1234-1234-1234-123456789abc" as UUID,
+	entityId: "87654321-4321-4321-4321-cba987654321" as UUID,
+	agentId: AGENT_ID,
+	roomId: "11111111-2222-3333-4444-555555555555" as UUID,
+	content: { text: "a real question that takes a while", source: "discord" },
+};
+
+interface Sent {
+	content?: string;
+}
+
+interface HandleMessageOptions {
+	abortSignal?: AbortSignal;
+}
+
+/**
+ * Runtime whose messageService HANGS (never resolves) and records the
+ * abortSignal it was handed. Lets the test assert the timeout aborts it.
+ */
+function makeHangingRuntime(settings: Record<string, string> = {}): {
+	runtime: ICompatRuntime;
+	errors: string[];
+	captured: { signal?: AbortSignal };
+	handleCalls: number;
+} {
+	const errors: string[] = [];
+	const captured: { signal?: AbortSignal } = {};
+	let handleCalls = 0;
+	const runtime = {
+		agentId: AGENT_ID,
+		character: { name: "Eliza" },
+		logger: {
+			debug: noop,
+			info: noop,
+			warn: noop,
+			error: (...args: unknown[]) => {
+				errors.push(JSON.stringify(args));
+			},
+		},
+		getSetting: (key: string) =>
+			key === "ELIZA_LIFEOPS_PASSIVE_CONNECTORS"
+				? "false"
+				: (settings[key] ?? undefined),
+		getService: () => null,
+		ensureConnection: async () => {},
+		getMemoryById: async () => null,
+		createMemory: async (memory: Memory) => memory.id,
+		messageService: {
+			handleMessage: (
+				_runtime: unknown,
+				_message: Memory,
+				_callback: (content: Content) => Promise<unknown>,
+				options?: HandleMessageOptions,
+			) => {
+				handleCalls += 1;
+				captured.signal = options?.abortSignal;
+				// Hang forever — simulates a slow/stuck model call.
+				return new Promise<never>(() => {});
+			},
+		},
+	} as unknown as ICompatRuntime;
+	return {
+		runtime,
+		errors,
+		captured,
+		get handleCalls() {
+			return handleCalls;
+		},
+	};
+}
+
+function makeDmChannel(sends: Sent[]) {
+	return {
+		id: "777000000000000000",
+		type: DiscordChannelType.DM,
+		isThread: () => false,
+		send: async (options: Sent) => {
+			sends.push(options);
+			return { id: "990000000000000001", ...options };
+		},
+		sendTyping: async () => {},
+	};
+}
+
+function makeDiscordService(client: unknown): IDiscordService {
+	return {
+		client,
+		accountId: "default",
+		getChannelType: async () => ChannelType.DM,
+		discordSettings: {
+			autoReply: true,
+			dmPolicy: "open",
+			shouldIgnoreBotMessages: true,
+			shouldIgnoreDirectMessages: false,
+			replyToMode: "off",
+		},
+		buildMemoryFromMessage: async () => INBOUND_MEMORY,
+	} as unknown as IDiscordService;
+}
+
+function makeInbound(channel: unknown): DiscordMessage {
+	return {
+		id: "666000000000000000",
+		content: "a real question that takes a while",
+		createdTimestamp: Date.now(),
+		author: {
+			id: "555000111222333444",
+			bot: false,
+			username: "tester",
+			globalName: "Tester",
+			displayName: "Tester",
+			discriminator: "0",
+		},
+		member: null,
+		channel,
+		guild: undefined,
+		interaction: null,
+		reference: undefined,
+		embeds: [],
+		stickers: { size: 0 },
+		attachments: { size: 0 },
+		mentions: {
+			users: new Map(),
+			repliedUser: undefined,
+			has: () => true,
+		},
+	} as unknown as DiscordMessage;
+}
+
+describe("Discord generation timeout aborts the underlying run (dispatch path)", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+	afterEach(() => {
+		vi.runOnlyPendingTimers();
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("aborts the abortSignal handed to messageService when the timeout fires", async () => {
+		const sends: Sent[] = [];
+		const channel = makeDmChannel(sends);
+		const client = { user: { id: "888000000000000000" } };
+		// 30s floor is the smallest the resolver allows.
+		const { runtime, captured } = makeHangingRuntime({
+			DISCORD_GENERATION_TIMEOUT_MS: "30000",
+		});
+		const manager = new MessageManager(makeDiscordService(client), runtime);
+
+		const handled = manager.handleMessage(makeInbound(channel));
+		// Let inbound guards + memory build + dispatch reach the hanging call.
+		await vi.advanceTimersByTimeAsync(0);
+		expect(captured.signal).toBeDefined();
+		expect(captured.signal?.aborted).toBe(false);
+
+		// Fire the generation timeout.
+		await vi.advanceTimersByTimeAsync(30_000);
+		await handled;
+
+		// The abort MUST have propagated to the model-facing signal.
+		expect(captured.signal?.aborted).toBe(true);
+		// Exactly one timeout reply.
+		const timeoutReplies = sends.filter((s) =>
+			String(s.content).includes("timed out"),
+		);
+		expect(timeoutReplies).toHaveLength(1);
+	});
+
+	it("does not double-dispatch when the orphaned run resolves late", async () => {
+		const sends: Sent[] = [];
+		const channel = makeDmChannel(sends);
+		const client = { user: { id: "888000000000000000" } };
+
+		// Runtime whose handleMessage resolves LATE (after the timeout) via a
+		// gate we control, and never emits a response through the callback.
+		let release: (() => void) | undefined;
+		let handleCalls = 0;
+		let capturedSignal: AbortSignal | undefined;
+		const runtime = {
+			agentId: AGENT_ID,
+			character: { name: "Eliza" },
+			logger: { debug: noop, info: noop, warn: noop, error: noop },
+			getSetting: (key: string) =>
+				key === "ELIZA_LIFEOPS_PASSIVE_CONNECTORS"
+					? "false"
+					: key === "DISCORD_GENERATION_TIMEOUT_MS"
+						? "30000"
+						: undefined,
+			getService: () => null,
+			ensureConnection: async () => {},
+			getMemoryById: async () => null,
+			createMemory: async (memory: Memory) => memory.id,
+			messageService: {
+				handleMessage: (
+					_r: unknown,
+					_m: Memory,
+					_cb: (content: Content) => Promise<unknown>,
+					options?: HandleMessageOptions,
+				) => {
+					handleCalls += 1;
+					capturedSignal = options?.abortSignal;
+					return new Promise<void>((resolve) => {
+						release = resolve;
+					});
+				},
+			},
+		} as unknown as ICompatRuntime;
+
+		const manager = new MessageManager(makeDiscordService(client), runtime);
+		const handled = manager.handleMessage(makeInbound(channel));
+		await vi.advanceTimersByTimeAsync(0);
+		await vi.advanceTimersByTimeAsync(30_000);
+		await handled;
+
+		expect(capturedSignal?.aborted).toBe(true);
+		const timeoutRepliesBefore = sends.filter((s) =>
+			String(s.content).includes("timed out"),
+		).length;
+		expect(timeoutRepliesBefore).toBe(1);
+
+		// Orphan resolves LATE — must not trigger a second dispatch or a
+		// second outbound message.
+		release?.();
+		await vi.advanceTimersByTimeAsync(0);
+		await Promise.resolve();
+
+		expect(handleCalls).toBe(1);
+		const timeoutRepliesAfter = sends.filter((s) =>
+			String(s.content).includes("timed out"),
+		).length;
+		expect(timeoutRepliesAfter).toBe(1);
+	});
+
+	/**
+	 * The abort must NOT break the `activeTaskAgentWork` suppression path.
+	 * Background task-agents (SWARM_COORDINATOR) run in a SEPARATE service,
+	 * decoupled from the inbound handleMessage streaming context, so aborting
+	 * the inline generation does not kill them. When a task-agent is still
+	 * working on this message, the timeout reply is SUPPRESSED (the agent will
+	 * deliver its result later) even though the inline signal was aborted.
+	 */
+	it("suppresses the timeout reply while task-agent work is active (abort still safe)", async () => {
+		const sends: Sent[] = [];
+		const channel = makeDmChannel(sends);
+		const client = { user: { id: "888000000000000000" } };
+
+		// A live task-agent whose originating messageId matches the inbound
+		// memory id — this is what hasActiveTaskAgentWorkForMessage keys on.
+		const tasks = new Map<string, unknown>([
+			[
+				"session-1",
+				{
+					status: "tool_running",
+					originMetadata: { messageId: INBOUND_MEMORY.id },
+				},
+			],
+		]);
+
+		let capturedSignal: AbortSignal | undefined;
+		const runtime = {
+			agentId: AGENT_ID,
+			character: { name: "Eliza" },
+			logger: { debug: noop, info: noop, warn: noop, error: noop },
+			getSetting: (key: string) =>
+				key === "ELIZA_LIFEOPS_PASSIVE_CONNECTORS"
+					? "false"
+					: key === "DISCORD_GENERATION_TIMEOUT_MS"
+						? "30000"
+						: undefined,
+			getService: (serviceType: string) =>
+				serviceType === "SWARM_COORDINATOR" ? { tasks } : null,
+			ensureConnection: async () => {},
+			getMemoryById: async () => null,
+			createMemory: async (memory: Memory) => memory.id,
+			messageService: {
+				handleMessage: (
+					_r: unknown,
+					_m: Memory,
+					_cb: (content: Content) => Promise<unknown>,
+					options?: HandleMessageOptions,
+				) => {
+					capturedSignal = options?.abortSignal;
+					return new Promise<never>(() => {});
+				},
+			},
+		} as unknown as ICompatRuntime;
+
+		const manager = new MessageManager(makeDiscordService(client), runtime);
+		const handled = manager.handleMessage(makeInbound(channel));
+		await vi.advanceTimersByTimeAsync(0);
+		await vi.advanceTimersByTimeAsync(30_000);
+		await handled;
+
+		// Abort fired (harmless — the task-agent lives in a separate service).
+		expect(capturedSignal?.aborted).toBe(true);
+		// But NO timeout reply: the task-agent will deliver its result later.
+		const timeoutReplies = sends.filter((s) =>
+			String(s.content).includes("timed out"),
+		);
+		expect(timeoutReplies).toHaveLength(0);
+	});
+});

--- a/plugins/plugin-discord/messages.ts
+++ b/plugins/plugin-discord/messages.ts
@@ -246,6 +246,122 @@ export function shouldSuppressTimeoutForInFlightDispatchForTests({
 	return generationTimedOut && responseDispatchInFlight;
 }
 
+/**
+ * Outcome of {@link runGenerationWithAbortableTimeout}.
+ *
+ * - `timedOut`   — the timeout won the race; the abort signal was fired.
+ * - `settled`    — the generation promise fulfilled or rejected before the
+ *                  timeout. When `timedOut` is true, `settled` reflects
+ *                  whether the orphaned generation had ALREADY completed at
+ *                  the moment the timeout fired (almost always `false`).
+ * - `error`      — the rejection value when generation rejected on its own
+ *                  (not a timeout). `undefined` on success or timeout.
+ */
+export interface AbortableTimeoutResult {
+	timedOut: boolean;
+	settled: boolean;
+	error?: unknown;
+}
+
+/**
+ * Runs a single generation attempt against a wall-clock timeout, wiring an
+ * {@link AbortController} so that a timeout ACTUALLY CANCELS the underlying
+ * work instead of leaving it running as an orphan.
+ *
+ * Why this exists (the bug):
+ * The previous Discord dispatch did `Promise.race([generationPromise,
+ * timeoutPromise])` where `generationPromise` called
+ * `messageService.handleMessage(runtime, message, callback)` with NO abort
+ * signal. When the timeout won the race we set a `generationTimedOut` flag
+ * and sent the "I timed out" reply — but the model call kept running,
+ * burning tokens and (worse) racing to emit a late response into the same
+ * room. The alternating "timeout / then instant" pattern is the classic
+ * signature of an orphaned run that resolves late and poisons the next slot.
+ *
+ * The core message service ALREADY threads
+ * `MessageProcessingOptions.abortSignal` → `StreamingContext.abortSignal` →
+ * `runtime.useModel` (`params.signal ??= abortSignal`) → provider fetch
+ * (see packages/core/src/services/message.ts and
+ * message-handler-abort.test.ts). The only missing link was the connector
+ * never CREATING a controller and never PASSING the signal down. This helper
+ * closes that gap.
+ *
+ * Contract:
+ * - `generate(signal)` MUST forward `signal` into the generation call so the
+ *   abort actually propagates. The helper cannot enforce this — the call
+ *   site is responsible for plumbing `{ abortSignal: signal }` through.
+ * - On timeout: `controller.abort()` fires, `timedOut` is `true`, and the
+ *   orphaned promise's eventual rejection is swallowed so it never surfaces
+ *   as an unhandled rejection.
+ * - `timeoutMs === null` disables the timeout entirely (media / long jobs);
+ *   the generation is awaited to completion and no controller races it.
+ *
+ * @param generate  Callback receiving the abort signal; returns the
+ *                  generation promise. Must forward the signal downstream.
+ * @param timeoutMs Wall-clock budget in ms, or `null` to disable the timeout.
+ * @returns         {@link AbortableTimeoutResult} describing how the race
+ *                  resolved.
+ */
+export async function runGenerationWithAbortableTimeout(
+	generate: (signal: AbortSignal) => Promise<unknown>,
+	timeoutMs: number | null,
+): Promise<AbortableTimeoutResult> {
+	const controller = new AbortController();
+	let settled = false;
+
+	const generationPromise = Promise.resolve()
+		.then(() => generate(controller.signal))
+		.then(
+			() => {
+				settled = true;
+				return { kind: "ok" as const };
+			},
+			(error: unknown) => {
+				settled = true;
+				return { kind: "error" as const, error };
+			},
+		);
+
+	// Never let the orphaned generation surface as an unhandled rejection.
+	// The `.then(onRejected)` above already converts rejection into a value,
+	// but attach a defensive catch in case `generate` throws synchronously
+	// off the microtask edge.
+	void generationPromise.catch(() => {});
+
+	if (timeoutMs === null) {
+		const outcome = await generationPromise;
+		return {
+			timedOut: false,
+			settled: true,
+			...(outcome.kind === "error" ? { error: outcome.error } : {}),
+		};
+	}
+
+	let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+	const timeoutPromise = new Promise<"timeout">((resolve) => {
+		timeoutHandle = setTimeout(() => resolve("timeout"), timeoutMs);
+	});
+
+	try {
+		const winner = await Promise.race([generationPromise, timeoutPromise]);
+		if (winner === "timeout") {
+			// Timeout won: abort the underlying work so the orphaned run stops
+			// burning tokens and cannot race a late response into the room.
+			controller.abort();
+			return { timedOut: true, settled };
+		}
+		return {
+			timedOut: false,
+			settled: true,
+			...(winner.kind === "error" ? { error: winner.error } : {}),
+		};
+	} finally {
+		if (timeoutHandle) {
+			clearTimeout(timeoutHandle);
+		}
+	}
+}
+
 export async function createDiscordMessageMemoryOnce(
 	runtime: Pick<
 		IAgentRuntime,
@@ -1310,6 +1426,14 @@ export class MessageManager {
 
 			const messagingAPI = getMessagingAPI(this.runtime);
 			const messageService = getMessageService(this.runtime);
+			// AbortController for the whole generation attempt. On timeout we fire
+			// this so the underlying model call ACTUALLY cancels instead of running
+			// on as an orphan (the root cause of the alternating timeout / instant
+			// pattern). The signal threads into `messageService.handleMessage`
+			// options → StreamingContext → runtime.useModel → provider fetch. See
+			// runGenerationWithAbortableTimeout above and __tests__/generation-abort.
+			const generationAbortController = new AbortController();
+			const generationSignal = generationAbortController.signal;
 			let generationTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
 			try {
 				const generationPromise = (async () => {
@@ -1322,6 +1446,7 @@ export class MessageManager {
 							this.runtime,
 							newMessage,
 							callback,
+							{ abortSignal: generationSignal },
 						);
 					} else if (messagingAPI?.handleMessage) {
 						this.runtime.logger.debug(
@@ -1365,6 +1490,8 @@ export class MessageManager {
 					}
 				})();
 
+				// Never let the orphaned generation surface as an unhandled
+				// rejection once we stop awaiting it on timeout.
 				generationPromise.catch(() => {});
 				if (generationTimeoutMs === null) {
 					await generationPromise;
@@ -1372,6 +1499,11 @@ export class MessageManager {
 					const timeoutPromise = new Promise<never>((_, reject) => {
 						generationTimeoutHandle = setTimeout(() => {
 							generationTimedOut = true;
+							// Abort the underlying generation BEFORE rejecting so the
+							// orphaned model call stops burning tokens and cannot race a
+							// late response into this room. Without this the run stayed
+							// live and poisoned the next message slot.
+							generationAbortController.abort();
 							reject(
 								new Error(
 									`Discord generation timeout after ${generationTimeoutMs}ms`,


### PR DESCRIPTION
## Diagnosis narrative

**Symptom (screenshot-verified, soliza Discord DM):** real questions hit a
~2min "I timed out while generating that reply. Please retry." while trivial
follow-ups reply instantly — an alternating pattern.

**Root cause (file:line receipts):**
- `plugins/plugin-discord/messages.ts` dispatch raced generation vs a timeout:
  `await Promise.race([generationPromise, timeoutPromise])` where
  `generationPromise` called `messageService.handleMessage(this.runtime,
  newMessage, callback)` **with no abortSignal** (4th `options` param omitted).
- On timeout it set `generationTimedOut = true`, rejected, and sent the
  timeout reply — but the underlying model call **kept running as an orphan**.
  Only `generationPromise.catch(() => {})` swallowed its late rejection. Nothing
  aborted it.
- The orphan kept burning tokens and could **race a late response into the same
  room** and poison the next message slot. That orphaned-run-resolving-late
  behavior is the classic signature of the alternating timeout/instant pattern.

**Why the fix is NOT cosmetic — the core chain already works:**
The core message service ALREADY threads the abort end-to-end:
`MessageProcessingOptions.abortSignal` (`packages/core/src/types/message-service.ts:36`)
→ `StreamingContext.abortSignal` (`packages/core/src/services/message.ts:9290`)
→ `runtime.useModel` (`params.signal`, `message.ts:9403`; runtime auto-injects
`paramsAsStreaming.signal ??= abortSignal`) → provider fetch. This is covered by
`packages/core/src/services/message-handler-abort.test.ts`. **The only missing
link was the connector never CREATING a controller and never PASSING the signal
down.** This PR closes exactly that gap.

## Fix summary
- Create an `AbortController` per generation attempt in `messages.ts`; thread
  its signal into `messageService.handleMessage(..., { abortSignal })`.
- On timeout, `controller.abort()` **before** rejecting, so the model call
  actually cancels instead of orphaning.
- Export `runGenerationWithAbortableTimeout` as the tested reference contract
  for the race+abort+swallow-orphan+independent-controller semantics.
- Verified safe vs the `activeTaskAgentWork` suppression path: background
  task-agents run in a **separate `SWARM_COORDINATOR` service**, decoupled from
  the inbound `handleMessage` streaming context, so the abort does not kill them
  (dedicated test locks this).

## Timeout value question
- Default **120000ms (2 min)**, floored at **30s**; set **0 to disable**.
- Configurable via `DISCORD_GENERATION_TIMEOUT_MS` (falls back to
  `MESSAGE_TIMEOUT_MS`, then the media-generation timeout).
- For heavy-context / multi-step cloud turns, **raise it** (e.g. 240000) rather
  than hitting the 2-min cap. Documented in the plugin README Configuration.
- The root issue here is orphaned-not-aborted, not merely slow generation; with
  the abort a genuinely slow turn now cleanly cancels + tells the user to retry
  instead of silently poisoning the next slot.

## Test matrix

| Test | File | Scenario | RED against pre-fix? |
|------|------|----------|----------------------|
| completes before timeout | generation-abort | (c) under-timeout completion → clean result, signal not aborted | no (happy path unchanged) |
| aborts a hung generation | generation-abort | (b)(f) never-resolving gen → timeout + signal ABORTED | **YES** |
| one timeout, swallow late resolve | generation-abort | (a) slow gen resolves after timeout → single timeout, no double-dispatch | **YES** |
| swallow late rejection | generation-abort | orphan rejects late → no unhandled rejection | no (defensive) |
| genuine error not a timeout | generation-abort | gen rejects on its own → error surfaced, timedOut=false | no |
| null timeout disables | generation-abort | timeoutMs=null → await to completion, no abort | no |
| independent controllers | generation-abort | (e) back-to-back: 2nd run fresh controller, not poisoned | **YES** |
| abort propagates to messageService | generation-timeout-dispatch | real MessageManager: timeout aborts the signal handed to handleMessage | **YES** |
| no double-dispatch on late orphan | generation-timeout-dispatch | orphan resolves late → handleMessage called once, one reply | **YES** |
| task-agent suppression holds | generation-timeout-dispatch | timeout w/ active SWARM_COORDINATOR task → reply suppressed, abort still safe | no (regression guard) |

Pre-fix RED proven by neutering (a) the `controller.abort()` call and (b) the
`{ abortSignal }` arg, then re-running: exactly the marked rows fail; the rest
stay green.

## Test output
```
Test Files  5 passed (5)
     Tests  26 passed (26)
```
(generation-timeout, generation-abort, generation-timeout-dispatch,
messages-component-delivery, messages-url)

`tsgo` + `biome` clean on all touched files (pre-existing repo-wide tsgo errors
are unrelated: missing generated i18n data + unbuilt optional browser deps in
core/plugin-browser/plugin-meetings, none in touched files).

## Review notes
- Codex review exceeded the 100s budget and was killed per protocol; a rigorous
  self-review was performed instead (abort/task-agent interaction analysis
  above; abort scoped to the `messageService` branch only — the `messagingAPI`
  / event-based branches use a different `onResponse` options shape and are
  unaffected; abort is a harmless no-op there).

<!-- evidence-row:before-screenshots -->
- [x] N/A - backend/connector timeout race; no UI surface changed. Behavior is captured by RED-then-GREEN unit + dispatch tests.
<!-- evidence-row:after-screenshots -->
- [x] N/A - backend/connector; no UI surface changed.
<!-- evidence-row:walkthrough-video -->
- [x] N/A - no user-facing flow change; covered by deterministic tests with fake timers.
<!-- evidence-row:backend-logs -->
- [x] N/A - abort path is timing-dependent (30s+ real timeout); exercised deterministically via fake-timer tests driving the real MessageManager.handleMessage dispatch (generation-timeout-dispatch.test.ts) rather than live logs.
<!-- evidence-row:frontend-logs -->
- [x] N/A - no frontend.
<!-- evidence-row:llm-trajectory -->
- [x] N/A - no agent/action/provider/prompt/model behavior change; this is connector-level cancellation plumbing. The model-facing signal propagation is asserted directly via the captured abortSignal in tests.
<!-- evidence-row:domain-artifacts -->
- [x] N/A - no DB/memory/task/wallet artifacts produced.

[sol-orch]
