### PR TITLE
fix(ui): scroll cloud pairing + CLI sign-in screens on short viewports

### DIFF
--- a/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.test.tsx
@@ -10,6 +10,9 @@
  * session-auth hook, api-client, Steward provider, and i18n are doubled.
  */
 
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -315,5 +318,36 @@ describe("CliLoginPage", () => {
     render(<CliLoginPage />);
 
     await waitFor(() => expect(clearStaleStewardSession).toHaveBeenCalled());
+  });
+});
+
+describe("CliLoginPage short-viewport scroll", () => {
+  // Every CliLoginPanel state (loading, success "Authentication Complete!",
+  // error) is a full-viewport centered card. On short screens (Light Phone III,
+  // 1080×1240) a flex `justify-center` pins the card center above scrollTop 0,
+  // hiding the action buttons below an unreachable fold. The panel must be
+  // `overflow-y-auto` with the card `my-auto`. jsdom can't measure layout, so
+  // scan the source — same idiom as login-page.safe-area.test.tsx.
+  const SRC = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "cli-login-page.tsx"),
+    "utf8",
+  );
+
+  it("makes the panel region scroll instead of clipping when it exceeds the viewport", () => {
+    expect(
+      /min-h-\[100dvh\][^"]*overflow-y-auto/.test(SRC),
+      "the CliLoginPanel wrapper must be overflow-y-auto to scroll when taller than the viewport",
+    ).toBe(true);
+  });
+
+  it("centers the card with my-auto (not a parent justify-center that clips the top)", () => {
+    expect(
+      /\bmy-auto\b[^"]*\bmax-w-md\b/.test(SRC),
+      "the panel card must center via my-auto so its top stays reachable while scrolling",
+    ).toBe(true);
+    expect(
+      /min-h-\[100dvh\][^"]*items-center justify-center/.test(SRC),
+      "the panel must not use the top-clipping items-center justify-center centering",
+    ).toBe(false);
   });
 });

--- a/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.tsx
+++ b/packages/ui/src/cloud/public-pages/pages/auth/cli-login-page.tsx
@@ -126,8 +126,14 @@ function CliLoginPanel({
 }) {
   const toneClasses = PANEL_TONE_CLASSES[tone];
   return (
-    <div className="theme-cloud relative flex min-h-[100dvh] items-center justify-center bg-bg p-4">
-      <div className="relative w-full max-w-md bg-card border border-border p-8">
+    // Scroll — never clip — when the panel is taller than the viewport. A flex
+    // `justify-center` pins the card's center and pushes its top above
+    // scrollTop 0 where it can't be reached; `overflow-y-auto` + the card's
+    // `my-auto` centers when it fits and scrolls-from-top when it overflows.
+    // Regressed on short screens (Light Phone III, 1080×1240) where the action
+    // buttons fell below an unscrollable fold — see cli-login-page.test.tsx.
+    <div className="theme-cloud relative flex min-h-[100dvh] flex-col items-center overflow-y-auto bg-bg p-4">
+      <div className="relative my-auto w-full max-w-md bg-card border border-border p-8">
         <div className="flex flex-col items-center gap-6 text-center">
           <div
             className={`flex h-14 w-14 items-center justify-center ${toneClasses.container}`}

--- a/packages/ui/src/components/auth/CloudPairRelay.tsx
+++ b/packages/ui/src/components/auth/CloudPairRelay.tsx
@@ -170,8 +170,8 @@ function describePairFailure(error: unknown): Exclude<
 
 export function CloudHostedAgentAuthNotice() {
   return (
-    <main className="flex min-h-[100dvh] items-center justify-center bg-[#08090b] px-6 text-center font-body text-white">
-      <div className="w-full max-w-[25rem]">
+    <main className="flex min-h-[100dvh] flex-col items-center overflow-y-auto bg-[#08090b] px-6 text-center font-body text-white">
+      <div className="my-auto w-full max-w-[25rem]">
         <div className="mx-auto mb-6 h-2 w-2 rotate-45 bg-[#f3a51f]" />
         <p className="mb-4 text-sm font-semibold text-white/45">Eliza</p>
         <h1 className="text-2xl font-semibold text-white">
@@ -221,8 +221,11 @@ export function CloudPairRelay({
 
   const isPairing = status.phase === "pairing";
   return (
-    <main className="flex min-h-[100dvh] items-center justify-center bg-[#08090b] px-6 text-center font-body text-white">
-      <div className="w-full max-w-[24rem]">
+    // Scroll instead of clipping on short viewports (Light Phone III, 1080×1240):
+    // `overflow-y-auto` + the inner block's `my-auto` centers when it fits and
+    // scrolls-from-top when the error copy pushes it past the fold.
+    <main className="flex min-h-[100dvh] flex-col items-center overflow-y-auto bg-[#08090b] px-6 text-center font-body text-white">
+      <div className="my-auto w-full max-w-[24rem]">
         <div className="mx-auto mb-6 h-2 w-2 rotate-45 bg-[#f3a51f]" />
         <p className="mb-4 text-sm font-semibold text-white/45">Eliza</p>
         <h1 className="text-2xl font-semibold text-white">

--- a/packages/ui/src/components/auth/__tests__/CloudPairRelay.test.tsx
+++ b/packages/ui/src/components/auth/__tests__/CloudPairRelay.test.tsx
@@ -1,5 +1,8 @@
 // @vitest-environment jsdom
 
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -182,5 +185,38 @@ describe("CloudPairRelay", () => {
     expect(screen.queryByText("Display name")).toBeNull();
     expect(screen.queryByText("Password")).toBeNull();
     expect(screen.queryByText("Remember this device for 30 days")).toBeNull();
+  });
+});
+
+describe("CloudPairRelay short-viewport scroll", () => {
+  // The pairing + hosted-agent notice screens are full-viewport centered cards.
+  // On short screens (Light Phone III, 1080×1240) a flex `justify-center`
+  // pins the card's center above scrollTop 0, so the error copy + "Back to
+  // Eliza Cloud" fell below an unreachable fold. The wrapper must be
+  // `overflow-y-auto` with the card `my-auto` (centers when it fits, scrolls
+  // from the top when it overflows) — jsdom can't measure layout, so scan the
+  // source, matching login-page.safe-area.test.tsx.
+  const SRC = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "..", "CloudPairRelay.tsx"),
+    "utf8",
+  );
+
+  it("makes both pair screens scroll instead of clipping when taller than the viewport", () => {
+    const scrollers = SRC.match(/min-h-\[100dvh\][^"]*overflow-y-auto/g) ?? [];
+    expect(
+      scrollers.length,
+      "both the pairing relay and the hosted-agent notice must be overflow-y-auto",
+    ).toBe(2);
+  });
+
+  it("centers the card with my-auto, not a top-clipping justify-center", () => {
+    expect(
+      /\bmy-auto\b[^"]*\bmax-w-\[2/.test(SRC),
+      "the card must center via my-auto so its top stays reachable while scrolling",
+    ).toBe(true);
+    expect(
+      /min-h-\[100dvh\][^"]*items-center justify-center/.test(SRC),
+      "the wrapper must not use the top-clipping items-center justify-center centering",
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## What & why

Sibling follow-up to #15470 (login page). The **CLI / device sign-in** panel and
the **cloud pairing** screens share the login page's short-viewport clip bug:
they center a card with a flex `justify-center` and no scroll container, so when
the card is taller than the viewport its **top overflows above `scrollTop: 0`**
and can't be scrolled into view.

Found continuing the Light Phone III (1080×1240, unusually short) bring-up: after
signing in, the device landed on the pairing / "Sign-in link expired" and
"Authentication Complete!" screens with the action button / **"Back to Eliza
Cloud"** clipped below an unreachable fold — and the Light Phone has no system
back button, so there was no way off the screen. Reproduces on any viewport
shorter than the card (small phones, large text/zoom, split-screen).

## Fix

The exact pattern merged in #15470:

- wrapper: `… items-center justify-center` → `… flex-col items-center overflow-y-auto`
- card: add `my-auto`

`overflow-y-auto` + `my-auto` centers the card when it fits and **scrolls from
the top** when it overflows. No visual change on tall screens.

Files:
- `pages/auth/cli-login-page.tsx` — `CliLoginPanel` (loading / success / error states)
- `components/auth/CloudPairRelay.tsx` — `CloudPairRelay` + `CloudHostedAgentAuthNotice`

## Tests

Added source-scan guards to both existing test files (same idiom as
`login-page.safe-area.test.tsx`; jsdom can't resolve device-viewport layout):
each screen's wrapper is `overflow-y-auto` and the card centers via `my-auto`,
not the top-clipping `items-center justify-center`.

- `bun run --cwd packages/ui test cli-login-page CloudPairRelay` → **21 passed**
- `biome check` on all four files → clean

## Evidence

- **Before:** on the Light Phone III the pairing / auth-complete card is centered
  with its controls clipped below the fold; no system back button = a dead end
  (device screenshot).
- **After:** the screens scroll; the previously-clipped controls are reachable.
  Full rendered before/after on the cloud preview deploy for this branch (these
  surfaces are served from the deployed cloud host, not the app bundle).

Related surfaces still on the same centering pattern but **not** hit in this
device flow (legal, payment, ballot, invite, approve, bsc pages) are left for a
follow-up so this PR stays scoped to the sign-in journey.
