### PR TITLE
fix(ci): harden sandbox retry and UI gates

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -3153,6 +3153,93 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
       getProviderSpy.mockRestore();
     }
   });
+
+  test("(10b) retry adoption refuses persisted docker container without node_id", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const row: AgentSandbox = {
+      ...provisioningReadyRow(),
+      status: "provisioning",
+      sandbox_id: "sandbox-blue-1",
+      bridge_url: "https://runtime-blue.example",
+      health_url: "https://runtime-blue.example/api/health",
+      node_id: null,
+      container_name: "agent-blue-1",
+      bridge_port: 3333,
+      web_ui_port: 4444,
+      headscale_ip: "100.64.0.42",
+    };
+    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
+    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue(row);
+    const findByIdSpy = spyOn(agentSandboxesRepository, "findById").mockResolvedValue(row);
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+      async (_id, data) => ({ ...row, ...data }) as AgentSandbox,
+    );
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
+      id: "22222222-2222-4222-8222-222222222222",
+      plainKey: "eliza_test_agent_key",
+      prefix: "eliza_test",
+    });
+    const create = mock(async () => providerHandle());
+    const stop = mock(async () => {});
+    const healthInputs: Array<{ sandboxId: string; metadata?: Record<string, unknown> }> = [];
+    const svc = new ElizaSandboxService();
+    const ensureStartedSpy = spyOn(
+      svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
+      "ensureRuntimeAgentStarted",
+    ).mockResolvedValue(null);
+    const getProviderSpy = spyOn(
+      svc as unknown as { getProvider: () => Promise<SandboxProvider> },
+      "getProvider",
+    ).mockResolvedValue({
+      create,
+      stop,
+      checkHealth: async () => true,
+      checkHealthDetailed: async (handle) => {
+        healthInputs.push({ sandboxId: handle.sandboxId, metadata: handle.metadata });
+        return { ready: true, verdict: "ready" as const };
+      },
+    } as unknown as SandboxProvider);
+
+    try {
+      const res = await svc.provision(AGENT, ORG);
+
+      expect(res.success).toBe(false);
+      expect(create).not.toHaveBeenCalled();
+      expect(stop).toHaveBeenCalledTimes(1);
+      expect(healthInputs).toEqual([
+        {
+          sandboxId: "sandbox-blue-1",
+          metadata: {
+            provider: "docker",
+            nodeId: "",
+            hostname: "",
+            containerName: "agent-blue-1",
+            bridgePort: 3333,
+            webUiPort: 4444,
+            headscaleIp: "100.64.0.42",
+          },
+        },
+      ]);
+      expect(
+        updateSpy.mock.calls.some(([, data]) => (data as { status?: string }).status === "running"),
+      ).toBe(false);
+      const errorWrite = updateSpy.mock.calls.find(
+        ([, data]) => (data as { status?: string }).status === "error",
+      );
+      expect(errorWrite).toBeDefined();
+      expect(String((errorWrite?.[1] as { error_message?: string }).error_message)).toContain(
+        "provision attribution guard:",
+      );
+    } finally {
+      findSpy.mockRestore();
+      lockSpy.mockRestore();
+      findByIdSpy.mockRestore();
+      updateSpy.mockRestore();
+      apiKeySpy.mockRestore();
+      ensureStartedSpy.mockRestore();
+      getProviderSpy.mockRestore();
+    }
+  });
 });
 
 // Snapshot-degrade error classification (`isUnrecoverableSnapshotError`), proven

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -6042,11 +6042,26 @@ export class ElizaSandboxService {
    */
   private buildProvisioningRetryHandle(rec: AgentSandbox): SandboxHandle | null {
     if (!rec.sandbox_id || !rec.bridge_url || !rec.health_url) return null;
+    const hasDockerFleetColumns = Boolean(
+      rec.node_id || rec.container_name || rec.bridge_port || rec.web_ui_port,
+    );
     return {
       sandboxId: rec.sandbox_id,
       bridgeUrl: rec.bridge_url,
       healthUrl: rec.health_url,
-      metadata: rec.headscale_ip ? { headscaleIp: rec.headscale_ip } : undefined,
+      metadata: hasDockerFleetColumns
+        ? {
+            provider: "docker",
+            nodeId: rec.node_id ?? "",
+            hostname: rec.node_id ?? "",
+            containerName: rec.container_name ?? "",
+            bridgePort: rec.bridge_port ?? undefined,
+            webUiPort: rec.web_ui_port ?? undefined,
+            headscaleIp: rec.headscale_ip ?? undefined,
+          }
+        : rec.headscale_ip
+          ? { headscaleIp: rec.headscale_ip }
+          : undefined,
     };
   }
 

--- a/packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx
+++ b/packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx
@@ -20,7 +20,6 @@ import type { ReactNode } from "react";
 import { CopyButton } from "../../../components/ui/copy-button";
 import { EmptyState } from "../../../components/ui/empty-state";
 import { Skeleton } from "../../../components/ui/skeleton";
-import { ListSkeleton } from "../../../components/ui/skeleton-layouts";
 import { cn } from "../../lib/utils";
 import { BrandButton } from "../brand/brand-button";
 import { DashboardTableSkeleton } from "../data-list/dashboard-table-skeleton";
@@ -217,7 +216,22 @@ export function AppsEmptyState({ description, action }: AppsEmptyStateProps) {
 }
 
 export function AppsSkeleton() {
-  return <ListSkeleton rows={3} />;
+  return (
+    <DashboardTableSkeleton
+      columns={[
+        { key: "app", label: "App", skeletonClassName: "w-32" },
+        { key: "status", label: "Status", skeletonClassName: "h-6 w-20" },
+        { key: "revenue", label: "Revenue", skeletonClassName: "w-20" },
+        { key: "updated", label: "Updated", skeletonClassName: "w-24" },
+        {
+          key: "actions",
+          label: "Actions",
+          cellClassName: "text-right",
+          skeletonClassName: "ml-auto h-8 w-20",
+        },
+      ]}
+    />
+  );
 }
 
 export function ContainersSkeleton() {

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -1063,7 +1063,12 @@ async function mutateAssistant(p, hook, text) {
 
 async function openSheetToFull(p, pointer) {
   await p.waitForSelector('[data-testid="chat-sheet"]');
-  await gesture(p, 160, { pointer, slow: false, steps: 2 });
+  await gesture(p, 160, {
+    pointer,
+    slow: false,
+    steps: 2,
+    target: (await detent(p)) === "pill" ? "chat-pill" : "chat-sheet-grabber",
+  });
   await p.waitForTimeout(SETTLE);
   if ((await detent(p)) !== "full") {
     await gesture(p, 220, { pointer, slow: false, steps: 2 });


### PR DESCRIPTION
## Summary
- Preserve docker provider attribution when adopting persisted provisioning retry handles so docker-backed rows without `node_id` fail closed instead of flipping to running.
- Add a regression test for the persisted retry adoption path from #15477.
- Render the cloud apps loading skeleton as a dashboard table skeleton so the story gate no longer classifies the story as single-color/blank.
- Make the chat-sheet E2E `openSheetToFull` helper reopen from the pill handle when the prior suite legitimately leaves the sheet in pill mode.

Fixes #15477.

## Verification
- `bun test packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts -t "retry adoption refuses persisted docker container without node_id"`
- `node ../../node_modules/.bun/storybook@10.4.6+dedd922bdcaa412a/node_modules/storybook/dist/bin/dispatcher.js build --output-dir storybook-static --quiet`
- `node test/story-gate/run-story-gate.mjs --static-dir storybook-static --grep cloudui-dashboard-clouddashboardcomponents--apps-list-loading --out test/story-gate/output-apps-list-loading`
- `bun run --cwd packages/ui test:chat-sheet-e2e`
- `bunx @biomejs/biome check --write packages/cloud/shared/src/lib/services/eliza-sandbox.ts packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs`

## Evidence Notes
- Story-gate targeted result: 1 story, good=1, broken=0, console-err=0, a11y=0.
- Chat-sheet E2E result: passed locally with 72 screenshots, 0 uncaught page errors, 0 error-level console messages.
- Full cloud test file reached and passed the new `(10b)` regression during a full-file run, but Bun failed while printing the very large coverage table in this linked worktree setup; the exact regression was rerun and passed with exit 0.
