### PR TITLE
fix(cloud): mark app chat credit holds sweepable

### DIFF
--- a/packages/cloud/shared/src/lib/services/__tests__/app-credit-hold-concurrency.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credit-hold-concurrency.test.ts
@@ -97,6 +97,7 @@ let appCreditsService: typeof import("../app-credits").appCreditsService;
 let redeemableEarningsService: typeof import("../redeemable-earnings").redeemableEarningsService;
 let InsufficientCreditsError: typeof import("../credits").InsufficientCreditsError;
 let MIN_RESERVATION: typeof import("../credits").MIN_RESERVATION;
+let APP_CHAT_RESERVATION_SETTLEMENT_MARKER: typeof import("../credits").APP_CHAT_RESERVATION_SETTLEMENT_MARKER;
 
 let seq = 0;
 function uniq(p: string): string {
@@ -184,7 +185,8 @@ beforeAll(async () => {
     ({ closeDatabaseConnectionsForTests: closeDb, dbWrite } = await import("../../../db/client"));
     ({ appCreditsService } = await import("../app-credits"));
     ({ redeemableEarningsService } = await import("../redeemable-earnings"));
-    ({ InsufficientCreditsError, MIN_RESERVATION } = await import("../credits"));
+    ({ InsufficientCreditsError, MIN_RESERVATION, APP_CHAT_RESERVATION_SETTLEMENT_MARKER } =
+      await import("../credits"));
 
     const schema = {
       organizations,
@@ -219,6 +221,59 @@ afterAll(async () => {
 });
 
 describe("reserveInferenceCredits — real row-locked upfront hold (#10857)", () => {
+  test(
+    "stamps app-chat reservations with the marker and base-cost facts the stale sweeper consumes (#15472)",
+    async () => {
+      if (!pgliteReady) return;
+
+      const payerOrgId = await seedOrg("2.000000");
+      const consumerId = await seedUser(payerOrgId);
+      const creatorOrgId = await seedOrg("0.000000");
+      const creatorId = await seedUser(creatorOrgId);
+      const app = await seedApp({
+        organizationId: creatorOrgId,
+        createdByUserId: creatorId,
+        inferenceMarkupPercentage: 25,
+      });
+      await dbWrite.insert(appUsers).values({ app_id: app.id, user_id: consumerId });
+
+      const reservation = await appCreditsService.reserveInferenceCredits({
+        appId: app.id,
+        userId: consumerId,
+        estimatedBaseCost: 0,
+        description: "sweepable app-chat hold",
+        idempotencyKey: "req-sweepable-hold",
+        metadata: {
+          model: "free-model",
+          type: "caller-value-must-not-win",
+          settlement_marker: "caller-value-must-not-win",
+        },
+        app,
+      });
+
+      const row = await dbWrite.query.creditTransactions.findFirst({
+        where: eq(creditTransactions.id, reservation.reservationTransactionId ?? ""),
+      });
+      expect(row).toBeDefined();
+      const metadata =
+        typeof row?.metadata === "string"
+          ? (JSON.parse(row.metadata) as Record<string, unknown>)
+          : (row?.metadata as Record<string, unknown>);
+
+      expect(row?.type).toBe("debit");
+      expect(metadata.type).toBe("app_chat_reservation");
+      expect(metadata.settlement_marker).toBe(APP_CHAT_RESERVATION_SETTLEMENT_MARKER);
+      expect(metadata.appId).toBe(app.id);
+      expect(metadata.userId).toBe(consumerId);
+      expect(metadata.reserved_amount).toBe(MIN_RESERVATION);
+      expect(metadata.estimated_cost).toBe(0);
+      expect(metadata.baseCost).toBe(MIN_RESERVATION);
+      expect(metadata.model).toBe("free-model");
+      expect(metadata.idempotencyKey).toBe("req-sweepable-hold");
+    },
+    PGLITE_TIMEOUT,
+  );
+
   test(
     "(ported from #10909) 8 concurrent $0.30 holds on a $1.00 balance: exactly 3 win, 5 throw InsufficientCreditsError, balance never negative",
     async () => {

--- a/packages/cloud/shared/src/lib/services/app-credits.ts
+++ b/packages/cloud/shared/src/lib/services/app-credits.ts
@@ -21,6 +21,7 @@ import {
   parseAppMonetizationNumber,
 } from "./app-credit-math";
 import {
+  APP_CHAT_RESERVATION_SETTLEMENT_MARKER,
   type CreditReconciliationResult,
   type CreditReservation,
   creditsService,
@@ -477,13 +478,20 @@ export class AppCreditsService {
     // applies — and reconcile trues it up to actual cost (refunding the floor
     // when actual stays $0).
     const flooredEstimate = Math.max(estimatedBaseCost, MIN_RESERVATION);
+    const reservationMetadata = {
+      ...metadata,
+      type: "app_chat_reservation",
+      settlement_marker: APP_CHAT_RESERVATION_SETTLEMENT_MARKER,
+      reserved_amount: flooredEstimate,
+      estimated_cost: estimatedBaseCost,
+    };
 
     const deduction = await this.deductCredits({
       appId,
       userId,
       baseCost: flooredEstimate,
       description,
-      metadata: withChargeIdempotencyKey(metadata, idempotencyKey),
+      metadata: withChargeIdempotencyKey(reservationMetadata, idempotencyKey),
       app,
     });
 
@@ -509,7 +517,7 @@ export class AppCreditsService {
           estimatedBaseCost: flooredEstimate,
           actualBaseCost,
           description,
-          metadata: withChargeIdempotencyKey(metadata, idempotencyKey),
+          metadata: withChargeIdempotencyKey(reservationMetadata, idempotencyKey),
           app,
           // Server-generated key for the reconcile legs' idempotent ledger
           // writes (#11512) — the deduct row's own transaction id, never the


### PR DESCRIPTION
## Summary
- stamp monetized app-chat inference holds with the existing app_chat_reservation_v1 settlement marker
- persist reserved base cost and raw estimate facts that the stale reservation sweeper consumes
- add a real-PGlite reservation test that inspects the debit row created by reserveInferenceCredits

Fixes #15472

## Verification
- bunx @biomejs/biome check --write packages/cloud/shared/src/lib/services/app-credits.ts packages/cloud/shared/src/lib/services/__tests__/app-credit-hold-concurrency.test.ts
- bun test --coverage-reporter=lcov packages/cloud/shared/src/lib/services/__tests__/app-credit-hold-concurrency.test.ts -t "stamps app-chat reservations"
- bun test --coverage-reporter=lcov packages/cloud/shared/src/lib/services/__tests__/app-chat-sweep-double-refund.test.ts

Note: the same Bun tests also passed their assertions with the default text coverage reporter, but Bun exited 1 after an internal WriteFailed while streaming the repo-wide coverage table. The lcov reruns exited 0.