### PR TITLE
fix(cloud): serialize org rate-limit lease flushes

### DIFF
--- a/packages/cloud/shared/src/lib/middleware/rate-limit-org-lease.test.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit-org-lease.test.ts
@@ -25,6 +25,16 @@ let carriedCounts: number[] = [];
  */
 let simulateWindow = false;
 let windowCount = 0;
+let pauseRedisChecks = false;
+const redisCheckWaiters: Array<() => void> = [];
+
+async function waitForRedisWaiters(count: number): Promise<void> {
+  for (let i = 0; i < 100; i++) {
+    if (redisCheckWaiters.length >= count) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error(`Timed out waiting for ${count} paused Redis checks`);
+}
 
 mock.module("./rate-limit-redis", () => ({
   ...rateLimitRedisActual,
@@ -37,6 +47,9 @@ mock.module("./rate-limit-redis", () => ({
     redisChecks++;
     const carried = options?.carriedCount ?? 0;
     carriedCounts.push(carried);
+    if (pauseRedisChecks) {
+      await new Promise<void>((resolve) => redisCheckWaiters.push(resolve));
+    }
     if (!simulateWindow) return redisResult;
     windowCount += carried;
     const allowed = windowCount < maxRequests;
@@ -87,6 +100,8 @@ describe("enforceOrgRateLimit lease (#9899 Tier-3)", () => {
     redisChecks = 0;
     tierReads = 0;
     carriedCounts = [];
+    pauseRedisChecks = false;
+    redisCheckWaiters.length = 0;
     simulateWindow = false;
     windowCount = 0;
     tierConfig = { windowMs: 60_000, maxRequests: 120 };
@@ -149,6 +164,42 @@ describe("enforceOrgRateLimit lease (#9899 Tier-3)", () => {
     expect(redisChecks).toBe(2);
     // The 3 leased requests were flushed into the sliding window.
     expect(carriedCounts).toEqual([0, 3]);
+  });
+
+  test("concurrent authoritative checks claim the carry once and cannot publish a stale replacement lease (#15415)", async () => {
+    const org = uid();
+    // remaining=1 < pro-rated share → one leased serve, then every concurrent
+    // request after it falls through to Redis.
+    redisResult = { allowed: true, remaining: 1, resetAt: Date.now() + 60_000 };
+    await enforceOrgRateLimit(org, "completions"); // authoritative (carried 0)
+    await enforceOrgRateLimit(org, "completions"); // lease 1/1
+    expect(redisChecks).toBe(1);
+
+    pauseRedisChecks = true;
+    const owner = enforceOrgRateLimit(org, "completions");
+    const nonOwner = enforceOrgRateLimit(org, "completions");
+    await waitForRedisWaiters(2);
+
+    // The first fallthrough claims and resets the carry synchronously. The
+    // second fallthrough still performs its own authoritative check, but it
+    // must not append the same leased request again.
+    expect(carriedCounts).toEqual([0, 1, 0]);
+
+    // Let the non-owner return first. If it publishes a replacement lease, the
+    // next request below would serve from that stale lease and skip Redis.
+    redisCheckWaiters[1]();
+    expect(await nonOwner).toBeNull();
+    expect(redisChecks).toBe(3);
+
+    const whileOwnerInFlight = enforceOrgRateLimit(org, "completions");
+    await waitForRedisWaiters(3);
+    expect(redisChecks).toBe(4);
+    expect(carriedCounts).toEqual([0, 1, 0, 0]);
+
+    redisCheckWaiters[0]();
+    redisCheckWaiters[2]();
+    expect(await owner).toBeNull();
+    expect(await whileOwnerInFlight).toBeNull();
   });
 
   test("a denial is leased: repeats within the TTL 429 without another Redis round-trip", async () => {

--- a/packages/cloud/shared/src/lib/middleware/rate-limit.ts
+++ b/packages/cloud/shared/src/lib/middleware/rate-limit.ts
@@ -346,6 +346,13 @@ interface OrgRateLimitLease {
   /** Local allowance: min(remaining, pro-rated share of the window per TTL). */
   localBudget: number;
   expiresAt: number;
+  /**
+   * Single-flight owner for flushing `localUsed` into Redis. A request claims
+   * this synchronously before any await; concurrent authoritative checks may
+   * still ask Redis for their own request, but cannot double-carry the same
+   * local usage or publish a stale replacement lease.
+   */
+  flushToken?: symbol;
 }
 
 // A plain Map (not the TTL LRU): expiry must NOT delete an entry, because its
@@ -384,6 +391,9 @@ export async function enforceOrgRateLimit(
   // Read the lease even when the flag is off: a flag flip must still flush any
   // pending carry into the window instead of orphaning it.
   const lease = orgRateLimitLeases.get(leaseKey);
+  const flushToken = Symbol(leaseKey);
+  let ownsLeaseFlush = false;
+  let carriedCount = 0;
 
   if (leaseEnabled && lease && lease.expiresAt > now) {
     if (!lease.result.allowed) {
@@ -394,7 +404,7 @@ export async function enforceOrgRateLimit(
         "redis",
       );
     }
-    if (lease.localUsed < lease.localBudget) {
+    if (!lease.flushToken && lease.localUsed < lease.localBudget) {
       lease.localUsed++;
       return null;
     }
@@ -402,24 +412,33 @@ export async function enforceOrgRateLimit(
     // flushes localUsed into the window before deciding.
   }
 
+  if (lease && !lease.flushToken) {
+    carriedCount = lease.localUsed;
+    lease.localUsed = 0;
+    lease.flushToken = flushToken;
+    ownsLeaseFlush = true;
+  }
+
   const config = await getOrgRpmForEndpoint(organizationId, endpointType);
   const { windowMs, maxRequests } = config;
   const key = `org:${organizationId}:${endpointType}`;
-  const carriedCount = lease?.localUsed ?? 0;
   const result = await checkRateLimitRedis(key, windowMs, maxRequests, { carriedCount });
   if (leaseEnabled) {
     evictSettledLeases(now);
-    orgRateLimitLeases.set(leaseKey, {
-      config,
-      result,
-      localUsed: 0,
-      localBudget: Math.min(
-        result.remaining,
-        Math.ceil((maxRequests * ORG_RATE_LIMIT_LEASE_TTL_MS) / windowMs),
-      ),
-      expiresAt: now + ORG_RATE_LIMIT_LEASE_TTL_MS,
-    });
-  } else if (lease) {
+    const currentLease = orgRateLimitLeases.get(leaseKey);
+    if (!lease || (ownsLeaseFlush && currentLease === lease && lease.flushToken === flushToken)) {
+      orgRateLimitLeases.set(leaseKey, {
+        config,
+        result,
+        localUsed: lease && currentLease === lease ? lease.localUsed : 0,
+        localBudget: Math.min(
+          result.remaining,
+          Math.ceil((maxRequests * ORG_RATE_LIMIT_LEASE_TTL_MS) / windowMs),
+        ),
+        expiresAt: now + ORG_RATE_LIMIT_LEASE_TTL_MS,
+      });
+    }
+  } else if (lease && ownsLeaseFlush) {
     // Flag flipped off: the carry above was just flushed — drop the entry.
     orgRateLimitLeases.delete(leaseKey);
   }


### PR DESCRIPTION
## Summary
- claim org rate-limit lease flushes synchronously before any await
- prevent active flushes from serving more local lease hits or publishing stale replacement leases
- add a forced interleaving test for the #15415 double-carry/stale-overwrite race

Addresses the rate-limit lease race portion of #15415. The web-push/WhatsApp batch contamination note did not reproduce in the targeted current-tree batch below, so I am not closing the whole issue from this PR.

## Verification
- bunx @biomejs/biome check --write packages/cloud/shared/src/lib/middleware/rate-limit.ts packages/cloud/shared/src/lib/middleware/rate-limit-org-lease.test.ts
- bun test --coverage-reporter=lcov packages/cloud/shared/src/lib/middleware/rate-limit-org-lease.test.ts
- bun test --coverage-reporter=lcov packages/cloud/shared/src/lib/middleware/rate-limit-org-lease.test.ts packages/cloud/shared/src/lib/web-push/notify-service.test.ts packages/cloud/shared/src/lib/utils/whatsapp-api.test.ts