### PR TITLE
fix(cloud): recover interrupted provisioning jobs on worker boot

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
@@ -145,4 +145,47 @@ describe("jobsRepository.recoverStaleJobs", () => {
       error: "Job timed out - recovered for retry (attempt 1/3)",
     });
   });
+
+  test("recovers in-progress rows claimed before a replacement worker started", async () => {
+    if (!pgliteReady) return;
+    const interruptedJobId = "00000000-0000-4000-8000-000000030854";
+    const currentJobId = "00000000-0000-4000-8000-000000040854";
+
+    await seedJob({ id: interruptedJobId, maxAttempts: 3 });
+    await seedJob({ id: currentJobId, maxAttempts: 3 });
+    await dbWrite.execute(
+      `UPDATE jobs
+       SET started_at = NOW() + INTERVAL '1 minute'
+       WHERE id = '${currentJobId}';`,
+    );
+
+    const recovered = await repo.recoverInProgressJobsStartedBefore({
+      type: "agent_message",
+      startedBefore: new Date(),
+    });
+
+    expect(recovered).toBe(1);
+    const rows = await dbWrite
+      .select({
+        id: jobs.id,
+        status: jobs.status,
+        attempts: jobs.attempts,
+        error: jobs.error,
+      })
+      .from(jobs)
+      .orderBy(jobs.id);
+
+    const interrupted = rows.find((row) => row.id === interruptedJobId);
+    const current = rows.find((row) => row.id === currentJobId);
+    expect(interrupted).toMatchObject({
+      status: "pending",
+      attempts: 1,
+      error: "Job interrupted by worker restart - recovered for retry (attempt 1/3)",
+    });
+    expect(current).toMatchObject({
+      status: "in_progress",
+      attempts: 0,
+      error: null,
+    });
+  });
 });

--- a/packages/cloud/shared/src/db/repositories/jobs.ts
+++ b/packages/cloud/shared/src/db/repositories/jobs.ts
@@ -442,6 +442,64 @@ export class JobsRepository {
   }
 
   /**
+   * Recovers in-progress jobs that were already claimed before a replacement
+   * worker process started. This is intentionally separate from
+   * `recoverStaleJobs`: the stale threshold protects slow cold boots during
+   * normal operation, while daemon startup is the one point where the previous
+   * process is known to have been replaced by systemd and its claims need to be
+   * made visible again immediately.
+   */
+  async recoverInProgressJobsStartedBefore(filters: {
+    type: string;
+    organizationId?: string;
+    startedBefore: Date;
+    maxAttempts?: number;
+  }): Promise<number> {
+    const conditions = [
+      eq(jobs.type, filters.type),
+      eq(jobs.status, "in_progress"),
+      sql`${jobs.started_at} IS NOT NULL`,
+      lt(jobs.started_at, filters.startedBefore),
+    ];
+
+    if (filters.organizationId) {
+      conditions.push(eq(jobs.organization_id, filters.organizationId));
+    }
+
+    const interruptedJobs = await dbWrite
+      .select()
+      .from(jobs)
+      .where(and(...conditions));
+
+    let recoveredCount = 0;
+
+    for (const job of interruptedJobs) {
+      const newAttempts = (job.attempts || 0) + 1;
+      const maxAttempts = job.max_attempts ?? filters.maxAttempts ?? 3;
+      const isFailed = newAttempts >= maxAttempts;
+      const error = isFailed
+        ? `Job interrupted by worker restart ${newAttempts} times - max attempts reached`
+        : `Job interrupted by worker restart - recovered for retry (attempt ${newAttempts}/${maxAttempts})`;
+
+      await dbWrite
+        .update(jobs)
+        .set({
+          status: isFailed ? "failed" : "pending",
+          ...(await prepareJobPayload({ error }, job)),
+          attempts: newAttempts,
+          updated_at: new Date(),
+        })
+        .where(eq(jobs.id, job.id));
+
+      if (!isFailed) {
+        recoveredCount++;
+      }
+    }
+
+    return recoveredCount;
+  }
+
+  /**
    * Updates a job with partial data.
    * Generic update method for any job fields.
    *

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs-lanes.test.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs-lanes.test.ts
@@ -76,4 +76,26 @@ describe("processPendingJobs — lane scoping", () => {
       recoverSpy.mockRestore();
     }
   });
+
+  test("startup interrupted-job recovery is scoped to the daemon lane", async () => {
+    const recoverSpy = spyOn(
+      jobsRepository,
+      "recoverInProgressJobsStartedBefore",
+    ).mockResolvedValue(0);
+    const startedBefore = new Date("2026-07-08T12:00:00.000Z");
+    try {
+      await provisioningJobService.recoverInterruptedJobsOnStartup(startedBefore, AGENT_JOB_TYPES);
+
+      const recoveredTypes = recoverSpy.mock.calls.map((c) => c[0].type);
+      expect(new Set(recoveredTypes)).toEqual(new Set(AGENT_JOB_TYPES));
+      for (const appsType of APPS_JOB_TYPES) {
+        expect(recoveredTypes).not.toContain(appsType);
+      }
+      for (const call of recoverSpy.mock.calls) {
+        expect(call[0].startedBefore).toBe(startedBefore);
+      }
+    } finally {
+      recoverSpy.mockRestore();
+    }
+  });
 });

--- a/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud/shared/src/lib/services/provisioning-jobs.ts
@@ -1670,6 +1670,31 @@ export class ProvisioningJobService {
     return result;
   }
 
+  /**
+   * One-shot startup recovery for jobs claimed by a previous worker process.
+   * Normal stale recovery deliberately waits longer than a full cold boot; on
+   * daemon replacement, rows claimed before this process started cannot still
+   * be owned by this process, so the singleton worker may make them retryable
+   * immediately instead of leaving agents stuck in `provisioning` until the
+   * cold-boot stale threshold expires.
+   */
+  async recoverInterruptedJobsOnStartup(
+    startedBefore: Date,
+    jobTypes: readonly ProvisioningJobType[] = Object.values(JOB_TYPES),
+  ): Promise<number> {
+    let totalRecovered = 0;
+
+    for (const jobType of jobTypes) {
+      const recovered = await jobsRepository.recoverInProgressJobsStartedBefore({
+        type: jobType,
+        startedBefore,
+      });
+      totalRecovered += recovered;
+    }
+
+    return totalRecovered;
+  }
+
   // ---------------------------------------------------------------------------
   // Internals
   // ---------------------------------------------------------------------------

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -161,6 +161,7 @@ const DEFAULT_WATCHDOG_CONSECUTIVE_TICKS = 2;
  * instead of the 3 weeks it took to notice #15160.
  */
 const DEFAULT_DB_LIVENESS_MAX_AGE_HOURS = 24;
+const workerStartedAt = new Date();
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
   if (!value) return fallback;
@@ -571,6 +572,16 @@ async function processHeartbeatCycle(
 async function processRecoveryCycle(concurrency = 5): Promise<RecoveryResult> {
   const { provisioningJobService } = await loadDeps();
   return provisioningJobService.processDisconnectedRecovery(concurrency);
+}
+
+async function processStartupInterruptedJobsRecoveryCycle(
+  config: ProvisioningWorkerConfig,
+): Promise<number> {
+  const { provisioningJobService } = await loadDeps();
+  return provisioningJobService.recoverInterruptedJobsOnStartup(
+    workerStartedAt,
+    config.jobTypes,
+  );
 }
 
 /**
@@ -1691,6 +1702,28 @@ async function main(): Promise<void> {
     "db liveness preflight",
     () => processDbLivenessCheckCycle(config),
     (assessment) => logJobsTableLiveness(logger, assessment),
+  );
+
+  // A systemd restart kills the previous singleton daemon, but any job it had
+  // already claimed remains `in_progress` until stale recovery sees the full
+  // cold-boot threshold. Recover only rows claimed before THIS process existed:
+  // normal in-cycle stale recovery keeps protecting legitimate slow cold boots,
+  // while deploy restarts immediately expose interrupted provisions to retry.
+  await runBoundedPhase(
+    logger,
+    "startup interrupted-job recovery",
+    () => processStartupInterruptedJobsRecoveryCycle(config),
+    (recovered) => {
+      if (recovered > 0) {
+        logger.info(
+          "[provisioning-worker] startup interrupted-job recovery complete",
+          {
+            recovered,
+            startedBefore: workerStartedAt.toISOString(),
+          },
+        );
+      }
+    },
   );
 
   // Apps (Product 2): arm the deploy backend when enabled (gated; no-op by default).


### PR DESCRIPTION
## Summary
- add a startup-only recovery path for jobs claimed before the provisioning worker process started
- keep normal stale recovery thresholds unchanged so slow cold boots are not double-run
- scope startup recovery to the daemon's configured job lanes

Fixes #15405

## Verification
- bunx @biomejs/biome check --write packages/cloud/shared/src/db/repositories/jobs.ts packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts packages/cloud/shared/src/lib/services/provisioning-jobs.ts packages/cloud/shared/src/lib/services/provisioning-jobs-lanes.test.ts packages/scripts/cloud/admin/daemons/provisioning-worker.ts
- bun test --coverage-reporter=lcov packages/cloud/shared/src/db/repositories/__tests__/jobs-recovery.test.ts
- bun test --coverage-reporter=lcov packages/cloud/shared/src/lib/services/provisioning-jobs-lanes.test.ts packages/cloud/shared/src/lib/services/provisioning-jobs-stale-threshold.test.ts
- bun test --coverage-reporter=lcov packages/scripts/cloud/admin/daemons/provisioning-worker.test.ts packages/scripts/cloud/admin/daemons/provisioning-worker-env-reconcile.test.ts

Note: Biome reported existing noUndeclaredEnvVars warnings in provisioning-worker.ts. The env-reconcile test file also emitted the existing BSD sed warning and skipped its executed shell subtests locally; static workflow assertions and provisioning-worker tests passed.