### PR TITLE
fix(ci): reconcile provisioning worker secrets master key

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -103,6 +103,13 @@ jobs:
       # skip-when-unset semantics as HEADSCALE_* — an environment without any
       # of these secrets keeps its current hand-set value.
       DATABASE_URL: ${{ secrets.DATABASE_URL || secrets.RAILWAY_DATABASE_URL || secrets.NEON_DATABASE_URL }}
+      # Field-encryption root secret used to unwrap per-org DEKs for encrypted
+      # agent environment variables. Must match the Cloudflare Worker secret:
+      # the Worker writes encrypted env vars, and this provisioning worker
+      # decrypts them while creating the agent container (#15385). Skip-empty
+      # reconcile semantics below preserve hand-set values until the secret is
+      # wired for an environment.
+      SECRETS_MASTER_KEY: ${{ secrets.SECRETS_MASTER_KEY }}
     steps:
       - name: Check deploy configuration
         id: deploy_config
@@ -180,7 +187,7 @@ jobs:
           username: deploy
           key: ${{ env.DEPLOY_SSH_KEY }}
           command_timeout: 10m
-          envs: DEPLOY_BRANCH,SYSTEMD_UNIT,HEADSCALE_API_URL,HEADSCALE_PUBLIC_URL,HEADSCALE_API_KEY,SANDBOX_REGISTRY_REDIS_URL,DATABASE_URL
+          envs: DEPLOY_BRANCH,SYSTEMD_UNIT,HEADSCALE_API_URL,HEADSCALE_PUBLIC_URL,HEADSCALE_API_KEY,SANDBOX_REGISTRY_REDIS_URL,DATABASE_URL,SECRETS_MASTER_KEY
           script: |
             set -euo pipefail
             echo "=== Deploying eliza-provisioning-worker (branch: $DEPLOY_BRANCH) ==="
@@ -308,12 +315,14 @@ jobs:
 
             # Reconcile control-plane secrets (HEADSCALE_API_URL /
             # HEADSCALE_PUBLIC_URL / HEADSCALE_API_KEY /
-            # SANDBOX_REGISTRY_REDIS_URL / DATABASE_URL) into the systemd
-            # EnvironmentFile so CI is the single source of truth and the box
-            # self-heals on every deploy. The daemon + cloud-shared read these
-            # straight from process.env (headscale-client.ts,
-            # headscale-integration.ts, docker-sandbox-provider.ts, the DB
-            # client), fed by EnvironmentFile=/opt/eliza/cloud/.env.local. The
+            # SANDBOX_REGISTRY_REDIS_URL / DATABASE_URL / SECRETS_MASTER_KEY)
+            # into the systemd EnvironmentFile so CI is the single source of
+            # truth and the box self-heals on every deploy. The daemon +
+            # cloud-shared read these straight from process.env
+            # (headscale-client.ts, headscale-integration.ts,
+            # docker-sandbox-provider.ts, the DB client, and encrypted
+            # environment-variable decrypt), fed by
+            # EnvironmentFile=/opt/eliza/cloud/.env.local. The
             # deploy's `git clean -e cloud/.env.local` preserves that file
             # verbatim, so before this these keys were only ever hand-edited on
             # the box and could drift to a stale headscale (the CP-box outage)
@@ -341,7 +350,8 @@ jobs:
               "HEADSCALE_PUBLIC_URL=$HEADSCALE_PUBLIC_URL" \
               "HEADSCALE_API_KEY=$HEADSCALE_API_KEY" \
               "SANDBOX_REGISTRY_REDIS_URL=$SANDBOX_REGISTRY_REDIS_URL" \
-              "DATABASE_URL=$DATABASE_URL"; do
+              "DATABASE_URL=$DATABASE_URL" \
+              "SECRETS_MASTER_KEY=$SECRETS_MASTER_KEY"; do
               key="${kv%%=*}"
               val="${kv#*=}"
               [ -n "$val" ] || continue

--- a/packages/app-core/src/services/__tests__/deploy-provisioning-worker-reconcile.test.ts
+++ b/packages/app-core/src/services/__tests__/deploy-provisioning-worker-reconcile.test.ts
@@ -4,11 +4,12 @@
  *
  * The deploy workflow is the single source of truth for the provisioning host's
  * `.env.local`. It reconciles a fixed set of keys — including
- * `SANDBOX_REGISTRY_REDIS_URL`, which gates connector inbound routing (#8621) —
- * with **skip-empty-before-delete** semantics: an empty secret value must
- * `continue` (leaving any existing value intact) and must never reach the
- * `sed -i "/^KEY=/d"` delete. Without that ordering, a momentarily-unset GitHub
- * secret would silently blank the live key on the next deploy.
+ * `SANDBOX_REGISTRY_REDIS_URL`, which gates connector inbound routing (#8621),
+ * and `SECRETS_MASTER_KEY`, which unwraps Worker-written encrypted agent env
+ * vars (#15385) — with **skip-empty-before-delete** semantics: an empty secret
+ * value must `continue` (leaving any existing value intact) and must never reach
+ * the `sed -i "/^KEY=/d"` delete. Without that ordering, a momentarily-unset
+ * GitHub secret would silently blank the live key on the next deploy.
  *
  * Runtime env parsing of `SANDBOX_REGISTRY_REDIS_URL` is covered by
  * `@elizaos/shared`'s `sandbox-registry.test.ts`; this test covers the workflow
@@ -25,12 +26,13 @@ const workflowPath = resolve(
 const workflow = readFileSync(workflowPath, "utf8");
 
 describe("deploy-eliza-provisioning-worker reconcile loop", () => {
-  it("reconciles SANDBOX_REGISTRY_REDIS_URL alongside the headscale keys", () => {
-    // Both must flow through the same reconcile loop so the box self-heals on
-    // every deploy. Losing the redis line silently breaks #8621 inbound routing.
+  it("reconciles control-plane secrets alongside the headscale keys", () => {
+    // These must flow through the same reconcile loop so the box self-heals on
+    // every deploy; losing one silently breaks runtime-only control-plane paths.
     expect(workflow).toContain(
       "SANDBOX_REGISTRY_REDIS_URL=$SANDBOX_REGISTRY_REDIS_URL",
     );
+    expect(workflow).toContain("SECRETS_MASTER_KEY=$SECRETS_MASTER_KEY");
     expect(workflow).toContain("HEADSCALE_API_KEY=$HEADSCALE_API_KEY");
   });
 

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker-env-reconcile.test.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker-env-reconcile.test.ts
@@ -7,11 +7,11 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 // Regression guard for #8756 (operator-step bug): the provisioning-worker
-// deploy workflow must reconcile SANDBOX_REGISTRY_REDIS_URL into the systemd
-// EnvironmentFile (/opt/eliza/cloud/.env.local). The daemon's consumer reads
-// it straight from process.env (docker-sandbox-provider.ts) fed by that file;
-// if the workflow doesn't write it, provisioned sandboxes never self-register
-// and Discord/Telegram inbound routing silently breaks.
+// deploy workflow must reconcile control-plane secrets into the systemd
+// EnvironmentFile (/opt/eliza/cloud/.env.local). The daemon's consumers read
+// them straight from process.env fed by that file; if the workflow doesn't
+// write them, provisioned sandboxes lose routing secrets or cannot decrypt
+// Worker-written encrypted environment variables.
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(here, "../../../../..");
@@ -22,6 +22,7 @@ const workflowPath = path.join(
 const workflow = readFileSync(workflowPath, "utf8");
 
 const ENV_KEY = "SANDBOX_REGISTRY_REDIS_URL";
+const FIELD_ENCRYPTION_KEY = "SECRETS_MASTER_KEY";
 
 // The reconcile loop runs the workflow's VERBATIM bash, which uses GNU
 // `sed -i "/^KEY=/d"` (no backup-suffix argument). BSD/macOS `sed -i` parses
@@ -71,6 +72,23 @@ describe("deploy-eliza-provisioning-worker.yml SANDBOX_REGISTRY_REDIS_URL wiring
     // The loop body iterates "KEY=$VALUE" entries; the entry for our key must
     // be present so the sed-delete + tee-append rewrites it into the file.
     expect(workflow).toContain(`"${ENV_KEY}=$${ENV_KEY}"`);
+  });
+
+  it("keeps the field-encryption root key in the same source/forward/reconcile path", () => {
+    expect(workflow).toContain(
+      `${FIELD_ENCRYPTION_KEY}: \${{ secrets.${FIELD_ENCRYPTION_KEY} }}`,
+    );
+    const envsLine = workflow
+      .split("\n")
+      .find(
+        (line) =>
+          line.trim().startsWith("envs:") &&
+          line.includes(FIELD_ENCRYPTION_KEY),
+      );
+    expect(envsLine).toBeDefined();
+    expect(workflow).toContain(
+      `"${FIELD_ENCRYPTION_KEY}=$${FIELD_ENCRYPTION_KEY}"`,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- forward SECRETS_MASTER_KEY into the provisioning worker deploy ssh-action env allowlist
- reconcile SECRETS_MASTER_KEY into /opt/eliza/cloud/.env.local with the same skip-empty-before-delete semantics as existing control-plane secrets
- extend workflow regression tests so the field-encryption root key cannot silently drift out of the deploy path

Fixes #15385

## Verification
- actionlint .github/workflows/deploy-eliza-provisioning-worker.yml
- bunx @biomejs/biome check --write packages/scripts/cloud/admin/daemons/provisioning-worker-env-reconcile.test.ts packages/app-core/src/services/__tests__/deploy-provisioning-worker-reconcile.test.ts
- bun test --coverage-reporter=lcov packages/scripts/cloud/admin/daemons/provisioning-worker-env-reconcile.test.ts
- bunx vitest run packages/app-core/src/services/__tests__/deploy-provisioning-worker-reconcile.test.ts

Note: the provisioning-worker env reconcile test emits the existing BSD sed warning on macOS and skips GNU-sed-dependent executed shell cases locally; static workflow assertions passed.