### PR TITLE
fix(ui): pair native cloud agents in process

### DIFF
--- a/packages/ui/src/cloud/handoff/resume-pending-handoff.test.ts
+++ b/packages/ui/src/cloud/handoff/resume-pending-handoff.test.ts
@@ -29,9 +29,16 @@ const mocks = vi.hoisted(() => ({
     base.includes("/api/v1/eliza/agents/"),
   ),
   loadPersistedActiveServer: vi.fn((): Record<string, unknown> | null => null),
-  runAgentSessionRecovery: vi.fn(async () => ({
-    ok: true as const,
+  runAgentSessionRecovery: vi.fn<
+    (_opts?: unknown) => Promise<{
+      ok: true;
+      redirectUrl: string;
+      mode: "navigate" | "in-process";
+    }>
+  >(async (_opts?: unknown) => ({
+    ok: true,
     redirectUrl: "https://dedicated-1.elizacloud.ai/pair?token=pairing",
+    mode: "navigate",
   })),
   getCloudCompatAgent: vi.fn(async (_id: string) => ({
     success: true as boolean,
@@ -48,6 +55,7 @@ const mocks = vi.hoisted(() => ({
       message: "ok",
     },
   })),
+  silentlyRepointToDedicated: vi.fn(),
 }));
 
 vi.mock("../../api", () => ({
@@ -73,6 +81,10 @@ vi.mock("../../state/persistence", () => ({
 
 vi.mock("../../state/agent-session-recovery-runner", () => ({
   runAgentSessionRecovery: mocks.runAgentSessionRecovery,
+}));
+
+vi.mock("./silent-repoint", () => ({
+  silentlyRepointToDedicated: mocks.silentlyRepointToDedicated,
 }));
 
 import {
@@ -137,6 +149,7 @@ describe("resumePendingCloudHandoff", () => {
     mocks.runAgentSessionRecovery.mockResolvedValue({
       ok: true,
       redirectUrl: "https://dedicated-1.elizacloud.ai/pair?token=pairing",
+      mode: "navigate",
     });
     mocks.getCloudCompatAgent.mockResolvedValue({
       success: true,
@@ -157,6 +170,7 @@ describe("resumePendingCloudHandoff", () => {
     __resetResumeForTests();
   });
   afterEach(() => {
+    delete (globalThis as { Capacitor?: unknown }).Capacitor;
     window.localStorage.clear();
     vi.restoreAllMocks();
   });
@@ -183,16 +197,57 @@ describe("resumePendingCloudHandoff", () => {
       cloudApiBase: "https://elizacloud.ai",
       authToken: "cloud-token",
     });
-    expect(mocks.runAgentSessionRecovery).toHaveBeenCalledWith({
-      cloudApiBase: "https://elizacloud.ai",
-      agentId: "dedicated-1",
-      cloudToken: "cloud-token",
-      navigate: expect.any(Function),
-    });
+    expect(mocks.runAgentSessionRecovery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cloudApiBase: "https://elizacloud.ai",
+        agentId: "dedicated-1",
+        cloudToken: "cloud-token",
+        navigate: expect.any(Function),
+      }),
+    );
     // Success terminal → the shared bridge row is deleted.
     expect(mocks.deleteSharedBridgeAgent).toHaveBeenCalledWith("shared-1", {
       cloudApiBase: "https://elizacloud.ai",
       authToken: "cloud-token",
+    });
+  });
+
+  it("native resume consumes the pair redirect in-process and repoints with the exchanged agent key", async () => {
+    (globalThis as { Capacitor?: unknown }).Capacitor = {
+      isNativePlatform: () => true,
+    };
+    savePendingCloudHandoff(pending());
+    mocks.loadPersistedActiveServer.mockReturnValue(activeSharedServer());
+    mocks.runAgentSessionRecovery.mockImplementationOnce(async (opts) => {
+      (
+        opts as { onPairedInProcess?: (apiToken: string) => void }
+      ).onPairedInProcess?.("agent-api-key");
+      return {
+        ok: true as const,
+        redirectUrl: "https://dedicated-1.elizacloud.ai/pair?token=pairing",
+        mode: "in-process" as const,
+      };
+    });
+    mocks.startCloudAgentHandoff.mockImplementation(async (opts) => {
+      await (opts as { onSwitch?: (base: string) => Promise<void> }).onSwitch?.(
+        "https://dedicated-1.elizacloud.ai",
+      );
+      return { status: "switched" as const, imported: 1 };
+    });
+
+    expect(resumePendingCloudHandoff()).toBe(true);
+    await settle();
+
+    expect(mocks.runAgentSessionRecovery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        consumeRedirectInProcess: true,
+        onPairedInProcess: expect.any(Function),
+      }),
+    );
+    expect(mocks.silentlyRepointToDedicated).toHaveBeenCalledWith({
+      containerBase: "https://dedicated-1.elizacloud.ai",
+      dedicatedAgentId: "dedicated-1",
+      authToken: "agent-api-key",
     });
   });
 

--- a/packages/ui/src/cloud/handoff/resume-pending-handoff.ts
+++ b/packages/ui/src/cloud/handoff/resume-pending-handoff.ts
@@ -21,6 +21,7 @@ import {
   savePendingCloudHandoff,
 } from "./pending-handoff-store";
 import { runCloudAgentHandoff } from "./run-cloud-agent-handoff";
+import { silentlyRepointToDedicated } from "./silent-repoint";
 
 let resumeAttemptedThisSession = false;
 /**
@@ -29,6 +30,17 @@ let resumeAttemptedThisSession = false;
  * leaking them.
  */
 const deadTargetRetryListeners = new Set<AbortController>();
+
+function isCapacitorNative(): boolean {
+  try {
+    const cap = (globalThis as Record<string, unknown>).Capacitor as
+      | { isNativePlatform?: () => boolean }
+      | undefined;
+    return Boolean(cap?.isNativePlatform?.());
+  } catch {
+    return false;
+  }
+}
 
 /** Test-only: allow a fresh resume attempt in the next call. */
 export function __resetResumeForTests(): void {
@@ -78,6 +90,7 @@ async function pairDedicatedCloudAgentInCurrentWindow(opts: {
   cloudApiBase: string;
   agentId: string;
   cloudToken: string;
+  containerBase?: string;
 }): Promise<void> {
   if (typeof window === "undefined") {
     throw new Error("Cloud agent sign-in requires a browser window.");
@@ -86,6 +99,18 @@ async function pairDedicatedCloudAgentInCurrentWindow(opts: {
     cloudApiBase: opts.cloudApiBase,
     agentId: opts.agentId,
     cloudToken: opts.cloudToken,
+    consumeRedirectInProcess: isCapacitorNative(),
+    onPairedInProcess: (apiToken) => {
+      if (opts.containerBase) {
+        silentlyRepointToDedicated({
+          containerBase: opts.containerBase,
+          dedicatedAgentId: opts.agentId,
+          authToken: apiToken,
+        });
+      } else {
+        client.setToken(apiToken);
+      }
+    },
     navigate: (url) => {
       window.location.replace(url);
     },
@@ -183,12 +208,14 @@ export function resumePendingCloudHandoff(): boolean {
           dedicatedAgentId: pending.dedicatedAgentId,
           cloudApiBase: pending.cloudApiBase,
           authToken,
-          onSwitch: async () =>
-            pairDedicatedCloudAgentInCurrentWindow({
+          onSwitch: async (containerBase) => {
+            await pairDedicatedCloudAgentInCurrentWindow({
               cloudApiBase: pending.cloudApiBase,
               agentId: pending.dedicatedAgentId,
               cloudToken: authToken,
-            }),
+              containerBase,
+            });
+          },
         }),
       () => {
         void client
@@ -284,12 +311,14 @@ async function runFreshDedicatedHandoff(
           dedicatedAgentId,
           cloudApiBase: pending.cloudApiBase,
           authToken,
-          onSwitch: async () =>
-            pairDedicatedCloudAgentInCurrentWindow({
+          onSwitch: async (containerBase) => {
+            await pairDedicatedCloudAgentInCurrentWindow({
               cloudApiBase: pending.cloudApiBase,
               agentId: dedicatedAgentId,
               cloudToken: authToken,
-            }),
+              containerBase,
+            });
+          },
         }),
       () => {
         void client

--- a/packages/ui/src/first-run/first-run-finish.ts
+++ b/packages/ui/src/first-run/first-run-finish.ts
@@ -23,10 +23,16 @@ import { getDesktopRuntimeMode, invokeDesktopBridgeRequest } from "../bridge";
 import { type AgentPluginLike, getAgentPlugin } from "../bridge/native-plugins";
 import { savePendingCloudHandoff } from "../cloud/handoff/pending-handoff-store";
 import { runCloudAgentHandoff } from "../cloud/handoff/run-cloud-agent-handoff";
+import { silentlyRepointToDedicated } from "../cloud/handoff/silent-repoint";
 import { getBootConfig } from "../config/boot-config";
 import type { UiLanguage } from "../i18n";
 import { clearForceFreshFirstRun } from "../platform/first-run-reset";
-import { isAndroid, isDesktopPlatform, isIOS } from "../platform/init";
+import {
+  isAndroid,
+  isDesktopPlatform,
+  isIOS,
+  isNative,
+} from "../platform/init";
 import {
   addAgentProfile,
   createPersistedActiveServer,
@@ -226,7 +232,8 @@ async function pairDedicatedCloudAgentInCurrentWindow(opts: {
   cloudApiBase: string;
   agentId: string;
   cloudToken: string;
-}): Promise<void> {
+  containerBase?: string;
+}): Promise<"navigate" | "in-process"> {
   if (typeof window === "undefined") {
     throw new Error("Cloud agent sign-in requires a browser window.");
   }
@@ -234,6 +241,18 @@ async function pairDedicatedCloudAgentInCurrentWindow(opts: {
     cloudApiBase: opts.cloudApiBase,
     agentId: opts.agentId,
     cloudToken: opts.cloudToken,
+    consumeRedirectInProcess: isNative && !isDesktopPlatform(),
+    onPairedInProcess: (apiToken) => {
+      if (opts.containerBase) {
+        silentlyRepointToDedicated({
+          containerBase: opts.containerBase,
+          dedicatedAgentId: opts.agentId,
+          authToken: apiToken,
+        });
+      } else {
+        client.setToken(apiToken);
+      }
+    },
     navigate: (url) => {
       window.location.replace(url);
     },
@@ -241,6 +260,7 @@ async function pairDedicatedCloudAgentInCurrentWindow(opts: {
   if (!result.ok) {
     throw new Error(result.message);
   }
+  return result.mode;
 }
 
 function readSyncOnDeviceAgentBearer(): string | null {
@@ -486,11 +506,20 @@ export async function bindCloudAgent(
   if (selectedAgent.requiresAgentPairing) {
     ports.onStatus?.("Signing in to your cloud agent", "pairing");
     try {
-      await pairDedicatedCloudAgentInCurrentWindow({
+      const pairMode = await pairDedicatedCloudAgentInCurrentWindow({
         cloudApiBase,
         agentId: selectedAgent.agentId,
         cloudToken: authToken,
+        containerBase: cloudAgentApiBase,
       });
+      if (pairMode === "in-process") {
+        persistMobileRuntimeModeForServerTarget("elizacloud");
+        clearForceFreshFirstRun();
+        clearPersistedFirstRunState();
+        ports.onStatus?.(null);
+        ports.completeFirstRun("chat");
+        return { kind: "done" };
+      }
       return { kind: "handoff-started" };
     } catch (err) {
       return {
@@ -594,12 +623,14 @@ export async function bindCloudAgent(
           dedicatedAgentId,
           cloudApiBase,
           authToken,
-          onSwitch: async () =>
-            pairDedicatedCloudAgentInCurrentWindow({
+          onSwitch: async (containerBase) => {
+            await pairDedicatedCloudAgentInCurrentWindow({
               cloudApiBase,
               agentId: dedicatedAgentId,
               cloudToken: authToken,
-            }),
+              containerBase,
+            });
+          },
         });
       },
       () => {

--- a/packages/ui/src/hooks/useAgentSessionRecovery.test.tsx
+++ b/packages/ui/src/hooks/useAgentSessionRecovery.test.tsx
@@ -57,6 +57,7 @@ function cloudServer(agentId: string) {
 }
 
 afterEach(() => {
+  delete (globalThis as { Capacitor?: unknown }).Capacitor;
   vi.clearAllMocks();
 });
 
@@ -86,6 +87,34 @@ describe("useAgentSessionRecovery", () => {
       cloudApiBase: "https://elizacloud.ai",
       cloudToken: "steward.jwt.token",
     });
+  });
+
+  it("uses in-process pairing on native so the WebView stays on the app origin", async () => {
+    (globalThis as { Capacitor?: unknown }).Capacitor = {
+      isNativePlatform: () => true,
+    };
+    mockCloudToken.mockReturnValue("steward.jwt.token");
+    mockActiveServer.mockReturnValue(cloudServer("agent-1"));
+    mockRunRecovery.mockReturnValue(new Promise(() => {}));
+
+    const statuses: string[] = [];
+    render(
+      <Probe
+        active
+        reason="remote_auth_required"
+        onStatus={(s) => statuses.push(s)}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(statuses).toContain("recovering");
+    });
+    expect(mockRunRecovery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        consumeRedirectInProcess: true,
+        onPairedInProcess: expect.any(Function),
+      }),
+    );
   });
 
   it("stays idle (wall) when there is no cloud session", async () => {

--- a/packages/ui/src/hooks/useAgentSessionRecovery.ts
+++ b/packages/ui/src/hooks/useAgentSessionRecovery.ts
@@ -48,6 +48,17 @@ function defaultNavigate(url: string): void {
   }
 }
 
+function shouldConsumePairRedirectInProcess(): boolean {
+  try {
+    const cap = (globalThis as Record<string, unknown>).Capacitor as
+      | { isNativePlatform?: () => boolean }
+      | undefined;
+    return Boolean(cap?.isNativePlatform?.());
+  } catch {
+    return false;
+  }
+}
+
 export function useAgentSessionRecovery(
   options: UseAgentSessionRecoveryOptions,
 ): AgentSessionRecoveryStatus {
@@ -97,6 +108,11 @@ export function useAgentSessionRecovery(
       cloudApiBase: decision.cloudApiBase,
       agentId: decision.agentId,
       cloudToken,
+      consumeRedirectInProcess: shouldConsumePairRedirectInProcess(),
+      onPairedInProcess: async (apiToken) => {
+        const { client } = await import("../api");
+        client.setToken(apiToken);
+      },
       navigate,
     })
       .then((result) => {

--- a/packages/ui/src/state/agent-session-recovery-runner.test.ts
+++ b/packages/ui/src/state/agent-session-recovery-runner.test.ts
@@ -41,7 +41,7 @@ describe("runAgentSessionRecovery", () => {
       navigate,
     });
 
-    expect(result).toEqual({ ok: true, redirectUrl });
+    expect(result).toEqual({ ok: true, redirectUrl, mode: "navigate" });
     expect(navigate).toHaveBeenCalledWith(redirectUrl);
     // Authorization header carries the cloud session token.
     const [, init] = fetchFn.mock.calls[0];
@@ -71,10 +71,37 @@ describe("runAgentSessionRecovery", () => {
       sleepFn,
     });
 
-    expect(result).toEqual({ ok: true, redirectUrl });
+    expect(result).toEqual({ ok: true, redirectUrl, mode: "navigate" });
     expect(sleepFn).toHaveBeenCalledWith(10);
     expect(fetchFn).toHaveBeenCalledTimes(2);
     expect(navigate).toHaveBeenCalledWith(redirectUrl);
+  });
+
+  it("can consume the /pair redirect in-process without navigating the native WebView", async () => {
+    const redirectUrl = "https://agent.elizacloud.ai/pair?token=one-time";
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(200, { data: { redirectUrl } }));
+    const navigate = vi.fn();
+    const exchangePairToken = vi.fn().mockResolvedValue("agent-api-key");
+    const persistPairApiToken = vi.fn();
+    const onPairedInProcess = vi.fn();
+
+    const result = await runAgentSessionRecovery({
+      ...baseDeps,
+      fetchFn: fetchFn as unknown as typeof fetch,
+      navigate,
+      consumeRedirectInProcess: true,
+      exchangePairToken,
+      persistPairApiToken,
+      onPairedInProcess,
+    });
+
+    expect(result).toEqual({ ok: true, redirectUrl, mode: "in-process" });
+    expect(navigate).not.toHaveBeenCalled();
+    expect(exchangePairToken).toHaveBeenCalledWith("one-time");
+    expect(persistPairApiToken).toHaveBeenCalledWith("agent-api-key");
+    expect(onPairedInProcess).toHaveBeenCalledWith("agent-api-key");
   });
 
   it("does NOT navigate on 401, the cloud session is invalid, wall stands", async () => {

--- a/packages/ui/src/state/agent-session-recovery-runner.ts
+++ b/packages/ui/src/state/agent-session-recovery-runner.ts
@@ -1,21 +1,27 @@
 /**
  * Executes post-upgrade agent-session recovery (#15132): refresh a stale
- * dedicated-agent credential by re-running the cloud pairing exchange in the
- * CURRENT window, then land back on `/` re-paired.
+ * dedicated-agent credential by re-running the cloud pairing exchange.
  *
  * This reuses the exact server-side exchange that first-pairing and the
  * "Open Web UI" popup use, `POST /api/v1/eliza/agents/:id/pairing-token`
  * returns a one-time `<agent>/pair?token=…` `redirectUrl`; the agent's `/pair`
  * relay consumes the token, pins the fresh API key into sessionStorage + the
- * boot-config singleton, and redirects to `/`. Because the dead-end app is
- * ALREADY on the agent, we navigate the current window rather than opening a
- * popup (no popup-blocker dependency, no second tab).
+ * boot-config singleton, and redirects to `/`. Browser shells can still hand
+ * off to that relay. Capacitor native shells must not navigate their main
+ * WebView to the remote agent origin, because the native bridge is injected
+ * only for the app origin; those callers consume the returned `/pair` token
+ * in-process instead (#15483).
  *
  * SECURITY NOTE (auth-adjacent): no auth is bypassed or weakened. The pairing
  * token is minted server-side ONLY for a caller holding a valid cloud session;
  * an unauthenticated caller gets a 401/403 here and falls through to the
  * password wall exactly as before.
  */
+
+import {
+  exchangeCloudPairToken,
+  persistCloudPairApiToken,
+} from "../components/auth/CloudPairRelay";
 
 const MAX_PAIRING_WAIT_MS = 120_000;
 const DEFAULT_RETRY_AFTER_MS = 5_000;
@@ -31,7 +37,7 @@ interface PairingTokenResponse {
 }
 
 export type AgentSessionRecoveryResult =
-  | { ok: true; redirectUrl: string }
+  | { ok: true; redirectUrl: string; mode: "navigate" | "in-process" }
   | {
       ok: false;
       reason: "not-ready" | "unauthorized" | "error";
@@ -53,6 +59,18 @@ export interface RunAgentSessionRecoveryDeps {
   nowFn?: () => number;
   /** Navigate the current window to the `/pair` relay. Injected in tests. */
   navigate: (url: string) => void;
+  /**
+   * Consume the returned `/pair?token=…` exchange inside the current app origin
+   * instead of navigating to the remote relay. Required for Capacitor native
+   * WebViews, where remote-origin navigation loses the native bridge.
+   */
+  consumeRedirectInProcess?: boolean;
+  /** Injected pair-token exchange (tests). Defaults to CloudPairRelay's exchange. */
+  exchangePairToken?: (token: string) => Promise<string>;
+  /** Injected API-key persistence (tests). Defaults to CloudPairRelay's persistence. */
+  persistPairApiToken?: (apiToken: string) => void;
+  /** Optional callback after an in-process pair succeeds. */
+  onPairedInProcess?: (apiToken: string) => void | Promise<void>;
 }
 
 const realSleep = (ms: number) =>
@@ -78,6 +96,16 @@ function retryAfterMs(res: Response, data: PairingTokenResponse): number {
   return DEFAULT_RETRY_AFTER_MS;
 }
 
+function pairTokenFromRedirectUrl(redirectUrl: string): string | null {
+  try {
+    const parsed = new URL(redirectUrl);
+    if (parsed.pathname.replace(/\/+$/, "") !== "/pair") return null;
+    return parsed.searchParams.get("token")?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Poll the cloud pairing-token endpoint until it returns a `/pair` redirect,
  * then navigate the current window there. The `/pair` relay pins the fresh
@@ -94,6 +122,11 @@ export async function runAgentSessionRecovery(
     agentId,
     cloudToken,
     navigate,
+    consumeRedirectInProcess = false,
+    exchangePairToken = (token: string) =>
+      exchangeCloudPairToken(token, { cloudApiBase }),
+    persistPairApiToken = persistCloudPairApiToken,
+    onPairedInProcess,
     fetchFn = fetch,
     sleepFn = realSleep,
     nowFn = Date.now,
@@ -160,10 +193,33 @@ export async function runAgentSessionRecovery(
           message: "Pairing token returned an unsafe redirect URL",
         };
       }
+      if (consumeRedirectInProcess) {
+        const pairToken = pairTokenFromRedirectUrl(redirectUrl);
+        if (!pairToken) {
+          return {
+            ok: false,
+            reason: "error",
+            message: "Pairing token returned a redirect without a pair token",
+          };
+        }
+        try {
+          const apiToken = await exchangePairToken(pairToken);
+          persistPairApiToken(apiToken);
+          await onPairedInProcess?.(apiToken);
+          return { ok: true, redirectUrl, mode: "in-process" };
+        } catch (err) {
+          return {
+            ok: false,
+            reason: "error",
+            message: err instanceof Error ? err.message : String(err),
+          };
+        }
+      }
+
       // Hand off to the /pair relay in the current window: it pins the fresh
       // credential and redirects to `/`, clearing the stale-credential 401 loop.
       navigate(redirectUrl);
-      return { ok: true, redirectUrl };
+      return { ok: true, redirectUrl, mode: "navigate" };
     }
 
     return {

--- a/packages/ui/src/state/startup-phase-poll.ts
+++ b/packages/ui/src/state/startup-phase-poll.ts
@@ -532,6 +532,10 @@ export async function runPollingBackend(
       cloudApiBase: decision.cloudApiBase,
       agentId: decision.agentId,
       cloudToken,
+      consumeRedirectInProcess: isCapacitorNative(),
+      onPairedInProcess: (apiToken) => {
+        client.setToken(apiToken);
+      },
       navigate: (url) => {
         if (typeof window !== "undefined") {
           window.location.assign(url);


### PR DESCRIPTION
## Summary
- add an in-process mode to the cloud agent session recovery runner so Capacitor native shells exchange the returned /pair token without navigating the main WebView to the remote agent origin
- wire native-safe pairing through first-run dedicated binding, auth-gate session recovery, startup stale-session recovery, and pending shared→dedicated handoff resume
- repoint native handoff switches to the dedicated container using the exchanged agent API key, so relaunch restores the dedicated agent instead of a dead shared bridge

Addresses #15483 (Bug 1 and the native handoff/recovery part of Bug 2). Bug 3's deployed-image CORS rollout remains separate.

## Verification
- bunx @biomejs/biome check --write packages/ui/src/first-run/first-run-finish.ts packages/ui/src/state/agent-session-recovery-runner.ts packages/ui/src/cloud/handoff/resume-pending-handoff.ts packages/ui/src/hooks/useAgentSessionRecovery.ts packages/ui/src/cloud/handoff/resume-pending-handoff.test.ts packages/ui/src/hooks/useAgentSessionRecovery.test.tsx packages/ui/src/state/agent-session-recovery-runner.test.ts
- bun run --cwd packages/ui typecheck
- bunx vitest run packages/ui/src/state/agent-session-recovery-runner.test.ts packages/ui/src/hooks/useAgentSessionRecovery.test.tsx packages/ui/src/cloud/handoff/resume-pending-handoff.test.ts packages/ui/src/state/startup-phase-poll.test.ts packages/ui/src/first-run/first-run-finish.force-fresh.test.ts