### PR TITLE
test(agent): cover stream cors preflight

### DIFF
--- a/packages/agent/src/api/__fixtures__/stream-cors-preflight-harness.ts
+++ b/packages/agent/src/api/__fixtures__/stream-cors-preflight-harness.ts
@@ -1,0 +1,66 @@
+/**
+ * Subprocess harness for the dedicated-agent stream CORS preflight regression.
+ *
+ * The agent vitest lane cannot import `server.ts` in-process, but a plain Bun
+ * subprocess can boot the real HTTP server. This fixture starts that server,
+ * sends the browser preflight that native Capacitor chat streaming emits, and
+ * reports the wire response as JSON for the parent test to assert.
+ */
+
+async function main(): Promise<void> {
+  const port = Number(process.argv[2]);
+  if (!Number.isInteger(port) || port <= 0) {
+    process.stdout.write(
+      `${JSON.stringify({ ok: false, error: "usage: <port>" })}\n`,
+    );
+    process.exit(2);
+  }
+
+  process.env.ELIZA_API_PORT = String(port);
+
+  const { startApiServer } = await import("../server.ts");
+  const server = await startApiServer({
+    port,
+    initialAgentState: "starting",
+    skipDeferredStartupWork: true,
+  });
+
+  try {
+    const response = await fetch(
+      `http://127.0.0.1:${server.port}/api/conversations/conv-1/messages/stream`,
+      {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://localhost",
+          "access-control-request-method": "POST",
+          "access-control-request-headers":
+            "authorization,content-type,x-elizaos-client-id",
+        },
+      },
+    );
+
+    process.stdout.write(
+      `${JSON.stringify({
+        ok: true,
+        status: response.status,
+        allowOrigin: response.headers.get("access-control-allow-origin"),
+        allowMethods: response.headers.get("access-control-allow-methods"),
+        allowHeaders: response.headers.get("access-control-allow-headers"),
+      })}\n`,
+    );
+  } finally {
+    await server.close();
+  }
+
+  process.exit(0);
+}
+
+main().catch((err: unknown) => {
+  process.stdout.write(
+    `${JSON.stringify({
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    })}\n`,
+  );
+  process.exit(1);
+});

--- a/packages/agent/src/api/server-cors-preflight.test.ts
+++ b/packages/agent/src/api/server-cors-preflight.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Real-server regression for native chat-streaming CORS preflight.
+ *
+ * Dedicated cloud agents receive `/api/conversations/:id/messages/stream` from
+ * a Capacitor WebView origin, and the browser preflight includes
+ * `x-elizaos-client-id`. This test boots the actual agent HTTP server in a Bun
+ * subprocess and asserts the stream preflight inherits the full CORS allowlist,
+ * not a route-local minimal one.
+ */
+
+import { execFile, execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import net from "node:net";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+const HARNESS_PATH = join(
+  import.meta.dirname,
+  "__fixtures__",
+  "stream-cors-preflight-harness.ts",
+);
+
+function resolveBunExecutable(): string | null {
+  if (typeof (globalThis as { Bun?: unknown }).Bun !== "undefined") {
+    return process.execPath;
+  }
+  const locator = process.platform === "win32" ? "where" : "which";
+  try {
+    const resolved = execFileSync(locator, ["bun"], { encoding: "utf8" })
+      .split("\n")
+      .map((line) => line.trim())
+      .find(Boolean);
+    if (resolved && existsSync(resolved)) return resolved;
+  } catch {
+    /* not on PATH; try absolute fallbacks */
+  }
+  const candidates = [
+    process.env.BUN_INSTALL ? join(process.env.BUN_INSTALL, "bin", "bun") : "",
+    "/usr/local/bin/bun",
+    "/opt/homebrew/bin/bun",
+  ].filter(Boolean);
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function findFreePort(host = "127.0.0.1"): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, host, () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve(port);
+      });
+    });
+  });
+}
+
+async function runPreflightHarness(port: number): Promise<
+  | {
+      ok: true;
+      status: number;
+      allowOrigin: string | null;
+      allowMethods: string | null;
+      allowHeaders: string | null;
+    }
+  | { ok: false; error: string }
+> {
+  const bun = resolveBunExecutable();
+  if (!bun) {
+    return { ok: false, error: "bun executable not found on this host" };
+  }
+
+  try {
+    const { stdout } = await execFileAsync(bun, [HARNESS_PATH, String(port)], {
+      timeout: 120_000,
+      env: { ...process.env },
+    });
+    const lastLine = stdout.trim().split("\n").filter(Boolean).at(-1) ?? "{}";
+    return JSON.parse(lastLine);
+  } catch (err) {
+    const stdout =
+      typeof (err as { stdout?: unknown }).stdout === "string"
+        ? (err as { stdout: string }).stdout
+        : "";
+    const lastLine = stdout.trim().split("\n").filter(Boolean).at(-1);
+    if (lastLine) {
+      try {
+        return JSON.parse(lastLine);
+      } catch {
+        /* fall through to the process error below */
+      }
+    }
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+describe("stream route CORS preflight", () => {
+  it("allows the native client-id header on /messages/stream", async () => {
+    const result = await runPreflightHarness(await findFreePort());
+    if (!result.ok) {
+      throw new Error(`preflight harness failed: ${result.error}`);
+    }
+
+    expect(result.status).toBe(204);
+    expect(result.allowOrigin).toBe("https://localhost");
+    expect(result.allowMethods).toContain("POST");
+    expect(result.allowHeaders?.toLowerCase()).toContain("x-elizaos-client-id");
+  }, 180_000);
+});


### PR DESCRIPTION
Addresses the remaining stream-CORS regression check from #15483.

## What changed
- Adds a Bun subprocess harness that boots the real `startApiServer` path.
- Sends an actual `OPTIONS /api/conversations/:id/messages/stream` preflight from `https://localhost`.
- Asserts the response is `204` and `Access-Control-Allow-Headers` includes `x-elizaos-client-id`.

## Verification
- `bunx @biomejs/biome check --write packages/agent/src/api/server-cors-preflight.test.ts packages/agent/src/api/__fixtures__/stream-cors-preflight-harness.ts`
- `bun test packages/agent/src/api/server-cors-preflight.test.ts`

## Evidence
- Test output: 1 pass, 0 fail; real server preflight returned 204 with the native client-id header allowed.