### PR TITLE
fix(ui): target live chat sheet handle in e2e

### DIFF
--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -300,12 +300,15 @@ async function gesture(
     slow = false,
     hold = false,
     steps = 12,
-    // Which handle to drag: the open-sheet grabber (default) or the collapsed
-    // pill — the pill→input→chat open paths must be driven from the pill itself.
-    target = "chat-sheet-grabber",
+    // Which handle to drag. When omitted, follow the live detent: the pill
+    // state unmounts the open-sheet grabber, so the gesture must start from the
+    // pill itself.
+    target,
   } = {},
 ) {
-  const b = await p.getByTestId(target).boundingBox();
+  const resolvedTarget =
+    target ?? ((await detent(p)) === "pill" ? "chat-pill" : "chat-sheet-grabber");
+  const b = await p.getByTestId(resolvedTarget).boundingBox();
   const cx = b.x + b.width / 2;
   const cy = b.y + b.height / 2;
   const targetY = (i) => cy - (up * i) / steps;
@@ -318,7 +321,7 @@ async function gesture(
     }
     if (!hold) await p.mouse.up();
   } else {
-    const drag = await touchDragHold(p, testIdSelector(target), 0, -up, {
+    const drag = await touchDragHold(p, testIdSelector(resolvedTarget), 0, -up, {
       steps,
       stepDelayMs: slow ? 28 : 0,
     });


### PR DESCRIPTION
Fixes the chat-sheet gesture CI failure seen on develop run 28966470660 / 28966470231.

## What changed
- The shared chat-sheet e2e `gesture()` helper now resolves the live drag handle when no explicit target is provided.
- If the current detent is `pill`, it starts from `chat-pill`; otherwise it uses `chat-sheet-grabber`.
- Explicit target callers are unchanged.

## Why
The suite can legitimately leave the sheet in the pill detent after a collapse/release path. In that state the open-sheet grabber is unmounted, so a later default gesture timed out waiting for `chat-sheet-grabber`.

## Verification
- `bun run --cwd packages/ui test:chat-sheet-e2e` — passed end to end (`CHAT-SHEET E2E PASSED`, 72 screenshots, no page errors).
- `git diff --check` — passed.

Note: Biome ignores this `.mjs` e2e harness by repository config, so `biome check --write` processed no files.