### PR TITLE
fix(ci): pin android-device-e2e setup-bun to 1.3.14 (#15071)

### DIFF
--- a/.github/workflows/android-device-e2e.yml
+++ b/.github/workflows/android-device-e2e.yml
@@ -78,6 +78,8 @@ jobs:
           submodules: recursive
 
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14" # pinned: repo packageManager is bun@1.4.0, an unpublished version (GH+npm 404) that makes bare setup-bun fail here; match .github/ci-bun-version.json (#15071)
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
@@ -282,6 +284,8 @@ jobs:
           submodules: recursive
 
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14" # pinned: repo packageManager is bun@1.4.0, an unpublished version (GH+npm 404) that makes bare setup-bun fail here; match .github/ci-bun-version.json (#15071)
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
@@ -407,6 +411,8 @@ jobs:
           submodules: recursive
 
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14" # pinned: repo packageManager is bun@1.4.0, an unpublished version (GH+npm 404) that makes bare setup-bun fail here; match .github/ci-bun-version.json (#15071)
       - uses: actions/setup-java@v5
         with:
           distribution: temurin


### PR DESCRIPTION
## Summary

Fixes #15071. The Android device-e2e lane has **never reached device test code** — it dies at `setup-bun`.

Root cause: the three `oven-sh/setup-bun@v2` steps in `android-device-e2e.yml` had **no `bun-version`**, so setup-bun fell back to the repo's `packageManager` field — which is pinned to `bun@1.4.0`, **a version oven-sh/bun never published**. So every run 404s downloading the toolchain.

`#15172` previously tried to fix this by repinning `packageManager` to `bun@1.4.0` "graduated stable" — but that release does not exist, so the 404 persisted.

## Fix

Pin all three `setup-bun` steps to `1.3.14`, matching:
- `.github/ci-bun-version.json` (the CI source-of-truth enforced by `ci-bun-version-contract.mjs`), and
- the explicit `bun-version: "1.3.14"` pins the `ci.yaml` / `benchmark-tests.yml` / windows gate workflows already carry.

Deliberately **does not** touch the repo-wide `packageManager` (that's a broader change with local-install / lockfile-serialization implications — out of scope for unblocking this lane). Contract-safe: the only concrete pin added equals `version` (1.3.14).

## Verification (live, 2026-07-08)

```
GET github.com/oven-sh/bun/releases/download/bun-v1.4.0/bun-linux-x64.zip  → HTTP 404
GET github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-x64.zip → HTTP 200
oven-sh/bun latest 6 tags: bun-v1.3.14, 1.3.13, 1.3.12, 1.3.11, 1.3.10, 1.3.9   (no 1.4.0)
```

Prior failing evidence (from #15071): dispatch run `28834506483` failed both `native-plugin-androidtest` and `android-e2e` at setup-bun with `Obtained version 1.4.0 from package.json … Error: Unexpected HTTP response: 404`.

**Follow-up (separate):** the repo-wide `packageManager: bun@1.4.0` is a latent landmine for any other path that reads it — worth aligning to the source-of-truth `1.3.14` (or a real canary) in its own change.

— [maintainer]
