### PR TITLE
fix(core): hold long streaming secret openers

### DIFF
--- a/packages/core/src/security/guarded-stream.test.ts
+++ b/packages/core/src/security/guarded-stream.test.ts
@@ -65,6 +65,32 @@ function chunkings(text: string): string[][] {
 	return plans;
 }
 
+function targetedLongChunkings(
+	text: string,
+	markers: readonly string[],
+): string[][] {
+	const points = new Set<number>([1, text.length - 1]);
+	for (const marker of markers) {
+		const start = text.indexOf(marker);
+		if (start === -1) continue;
+		for (const point of [
+			start,
+			start + 1,
+			start + marker.length - 1,
+			start + marker.length,
+			start + 512,
+			start + 513,
+		]) {
+			if (point > 0 && point < text.length) points.add(point);
+		}
+	}
+	return [
+		...Array.from(points, (point) => [text.slice(0, point), text.slice(point)]),
+		[...text],
+		[text],
+	];
+}
+
 interface Fixture {
 	name: string;
 	text: string;
@@ -79,6 +105,7 @@ interface Fixture {
 	rawPii: string[];
 	/** Whether streamed output must byte-equal the whole-buffer output (single/pre-seeded entries). */
 	equivalence: boolean;
+	chunkings?: (text: string) => string[][];
 }
 
 function secretSessionWith(
@@ -110,6 +137,13 @@ const PEM_KEY =
 // Basic, so this only redacts via the `basic-auth-header` detector's
 // `Authorization:` anchor — the anchor the streaming guard must hold intact.
 const BASIC_B64 = "dXNlcjpwYXNzd29yZDEyMw==";
+const LONG_ANCHORED_VALUE = Array.from(
+	{ length: 96 },
+	(_, i) => `tok${i.toString(36)}A1b2C3d4E5f6`,
+).join("");
+const LONG_BASIC_B64 = Buffer.from(
+	`guarded-stream-user:${LONG_ANCHORED_VALUE}`,
+).toString("base64");
 
 // A single valid NANP number in every separator format the detector accepts.
 // Every form except the paren/`+1` prefix is already held by the grouped-number
@@ -301,6 +335,64 @@ async function buildFixtures(): Promise<Fixture[]> {
 			rawPii: [],
 			equivalence: true,
 		},
+		{
+			name: "long HTTP Basic auth header (anchor more than opener window behind value)",
+			text: `Header Authorization: Basic ${LONG_BASIC_B64} end of line.`,
+			factory: async () => ({ secret: secretSessionWith(), pii: null }),
+			rawSecrets: [LONG_BASIC_B64],
+			rawPii: [],
+			equivalence: true,
+			chunkings: (text) =>
+				targetedLongChunkings(text, [
+					"Authorization:",
+					"Basic ",
+					LONG_BASIC_B64,
+				]),
+		},
+		{
+			name: "long opaque Authorization Bearer header",
+			text: `Header Authorization: Bearer ${LONG_ANCHORED_VALUE} end of line.`,
+			factory: async () => ({ secret: secretSessionWith(), pii: null }),
+			rawSecrets: [LONG_ANCHORED_VALUE],
+			rawPii: [],
+			equivalence: true,
+			chunkings: (text) =>
+				targetedLongChunkings(text, [
+					"Authorization:",
+					"Bearer ",
+					LONG_ANCHORED_VALUE,
+				]),
+		},
+		{
+			name: "long ENV colon assignment with separated value",
+			text: `Set LONG_SECRET: ${LONG_ANCHORED_VALUE} before deploy.`,
+			factory: async () => ({ secret: secretSessionWith(), pii: null }),
+			rawSecrets: [LONG_ANCHORED_VALUE],
+			rawPii: [],
+			equivalence: true,
+			chunkings: (text) =>
+				targetedLongChunkings(text, ["LONG_SECRET:", LONG_ANCHORED_VALUE]),
+		},
+		{
+			name: "long JSON password field",
+			text: `Payload {"password": "${LONG_ANCHORED_VALUE}"} was sent.`,
+			factory: async () => ({ secret: secretSessionWith(), pii: null }),
+			rawSecrets: [LONG_ANCHORED_VALUE],
+			rawPii: [],
+			equivalence: true,
+			chunkings: (text) =>
+				targetedLongChunkings(text, ['"password":', LONG_ANCHORED_VALUE]),
+		},
+		{
+			name: "long CLI password flag with separated value",
+			text: `Run deploy --password ${LONG_ANCHORED_VALUE} after rotation.`,
+			factory: async () => ({ secret: secretSessionWith(), pii: null }),
+			rawSecrets: [LONG_ANCHORED_VALUE],
+			rawPii: [],
+			equivalence: true,
+			chunkings: (text) =>
+				targetedLongChunkings(text, ["--password", LONG_ANCHORED_VALUE]),
+		},
 		...PHONE_FORMS.map((phone) => ({
 			name: `NANP phone (${phone})`,
 			text: `Please call ${phone} tomorrow morning.`,
@@ -376,7 +468,7 @@ describe("GuardedStreamScanner", () => {
 				).not.toContain(raw);
 			}
 
-			for (const chunks of chunkings(fx.text)) {
+			for (const chunks of (fx.chunkings ?? chunkings)(fx.text)) {
 				const { secret, pii } = await fx.factory();
 				const scanner = new GuardedStreamScanner({
 					secretSession: secret,

--- a/packages/core/src/security/guarded-stream.ts
+++ b/packages/core/src/security/guarded-stream.ts
@@ -91,7 +91,7 @@ const OPENER_PATTERNS: readonly RegExp[] = [
 
 /** Safety bound on the grouped-number left-walk; hitting it holds everything (safe). */
 const GROUPED_RUN_SCAN_LIMIT = 512;
-/** Trailing window scanned for an in-progress opener. */
+/** Trailing window scanned for an in-progress opener before the long-value fallback. */
 const OPENER_WINDOW = 512;
 /** Longest suffix probed when detecting a partial `-----BEGIN` armor marker. */
 const ARMOR_BEGIN = "-----BEGIN";
@@ -221,7 +221,7 @@ export class GuardedStreamScanner {
 			next = Math.min(next, this.groupedNumberRunStart(next));
 			next = Math.min(next, this.phoneRunStart(next));
 			next = Math.min(next, this.bip39RunStart(next));
-			next = Math.min(next, this.openerTailStart());
+			next = Math.min(next, this.openerTailStart(next));
 			next = Math.min(next, this.openArmorStart(next));
 			next = Math.min(next, this.knownTokenCrossingStart(next));
 			next = this.snapToWhitespace(next);
@@ -399,21 +399,37 @@ export class GuardedStreamScanner {
 	}
 
 	/**
-	 * If the trailing window ends with an in-progress secret opener
-	 * (`KEY=`, JSON field, `Bearer`/`Basic`, CLI flag), hold from the opener start.
-	 * Returns `pending.length` (no hold) when none match.
+	 * If the prefix ending at `cut` ends with an in-progress secret opener (`KEY=`,
+	 * JSON field, `Bearer`/`Basic`, CLI flag), hold from the opener start. The fast
+	 * path scans the bounded suffix; the long-token fallback extends left from the
+	 * current value token so a 512+ byte value cannot orphan its anchor before the
+	 * detector sees the complete assignment/header/flag.
 	 */
-	private openerTailStart(): number {
+	private openerTailStart(cut: number): number {
 		const p = this.pending;
-		const n = p.length;
-		const base = Math.max(0, n - OPENER_WINDOW);
-		const tail = p.slice(base);
-		let start = n;
-		for (const pattern of OPENER_PATTERNS) {
-			const match = pattern.exec(tail);
-			if (match) start = Math.min(start, base + match.index);
+		const end = Math.min(cut, p.length);
+		const matchStart = (base: number): number => {
+			const tail = p.slice(base, end);
+			let start = end;
+			for (const pattern of OPENER_PATTERNS) {
+				const match = pattern.exec(tail);
+				if (match) start = Math.min(start, base + match.index);
+			}
+			return start;
+		};
+
+		const base = Math.max(0, end - OPENER_WINDOW);
+		const tailStart = matchStart(base);
+		if (tailStart < end) return tailStart;
+
+		let runStart = end;
+		while (runStart > 0 && !isAsciiWhitespace(p.charCodeAt(runStart - 1))) {
+			runStart -= 1;
 		}
-		return start;
+		if (runStart >= base) return end;
+
+		const extendedBase = Math.max(0, runStart - OPENER_WINDOW);
+		return matchStart(extendedBase);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- hold opener detection against the candidate emit prefix so long anchor-separated secrets cannot release their anchor before the value
- keep the bounded 512-character fast path and add a bounded long-token fallback around the value being released
- add regression fixtures for long Basic/Bearer Authorization headers, ENV colon assignments, JSON passwords, and CLI password flags

Fixes #15356.

## Verification
- bunx @biomejs/biome check --write packages/core/src/security/guarded-stream.ts packages/core/src/security/guarded-stream.test.ts
- git diff --check HEAD
- bun test packages/core/src/security/guarded-stream.test.ts