### PR TITLE
fix(ui): reconcile cloud agent bindings against running set

### DIFF
--- a/packages/ui/src/api/client-cloud-select-or-provision.test.ts
+++ b/packages/ui/src/api/client-cloud-select-or-provision.test.ts
@@ -83,6 +83,41 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
     expect(createCloudCompatAgent).not.toHaveBeenCalled();
   });
 
+  it("does not reuse a non-running existing agent; provisions from a confirmed no-running set", async () => {
+    const { client, getCloudCompatAgents, createCloudCompatAgent } =
+      fakeClient();
+    getCloudCompatAgents.mockResolvedValue({
+      success: true,
+      data: [makeAgent({ status: "stopped" })],
+    });
+    createCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: {
+        agentId: "agent-new",
+        agentName: "Eliza",
+        jobId: "job-1",
+        status: "provisioning",
+        nodeId: null,
+        message: "",
+      },
+    });
+    (client.getCloudCompatAgent as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: makeAgent({
+        agent_id: "agent-new",
+        status: "provisioning",
+        web_ui_url: "https://agent-new.example.test",
+        webUiUrl: "https://agent-new.example.test",
+      }),
+    });
+
+    const result = await client.selectOrProvisionCloudAgent(BASE_OPTS);
+
+    expect(result.created).toBe(true);
+    expect(result.agentId).toBe("agent-new");
+    expect(createCloudCompatAgent).toHaveBeenCalledTimes(1);
+  });
+
   it("marks real dedicated Eliza Cloud agent subdomains as requiring pairing", async () => {
     const { client, getCloudCompatAgents } = fakeClient();
     getCloudCompatAgents.mockResolvedValue({

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -3281,11 +3281,10 @@ export async function waitForCloudAgentRunning(
 }
 
 /**
- * Pick which agent to reuse from a cloud agent list: a specific requested id if
- * it still exists and is not terminal-bad, else the most-recently-created
- * "running" agent, else the most recent non-terminal agent. Terminal failed
- * rows are not reusable for first-run; reusing them just replays their stale
- * restore/provisioning error forever.
+ * Pick which running agent to reuse from a cloud agent list: a specific
+ * requested id if it is running, else the most-recently-created running agent.
+ * Non-running rows are not reusable for first-run binding because a stale
+ * shared/dedicated pointer can otherwise be treated as healthy while chat 404s.
  */
 function pickPreferredCloudAgent(
   agents: CloudCompatAgent[],
@@ -3294,14 +3293,14 @@ function pickPreferredCloudAgent(
   if (!agents.length) return null;
   if (preferAgentId) {
     const exact = agents.find(
-      (a) => a.agent_id === preferAgentId && !isTerminalFailedCloudAgent(a),
+      (a) => a.agent_id === preferAgentId && a.status === "running",
     );
     if (exact) return exact;
   }
   const byNewest = agents
-    .filter((a) => !isTerminalFailedCloudAgent(a))
+    .filter((a) => a.status === "running")
     .sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)));
-  return byNewest.find((a) => a.status === "running") ?? byNewest[0] ?? null;
+  return byNewest[0] ?? null;
 }
 
 ElizaClient.prototype.selectOrProvisionCloudAgent = async function (

--- a/packages/ui/src/first-run/first-run-finish.ts
+++ b/packages/ui/src/first-run/first-run-finish.ts
@@ -65,6 +65,7 @@ import {
 import { resolveFirstRunLocalAgentApiBase } from "./runtime-target";
 
 const FIRST_RUN_AGENT_WAIT_MS = 180_000;
+const RUNNING_CLOUD_AGENT_STATUS = "running";
 
 // ── Injected ports — the store seams the finish logic needs ──────────────────
 
@@ -219,6 +220,14 @@ function canProbeCloudStatus(): boolean {
     return false;
   }
   return true;
+}
+
+function runningCloudAgents(
+  agents: readonly CloudCompatAgent[],
+): CloudCompatAgent[] {
+  return agents
+    .filter((agent) => agent.status === RUNNING_CLOUD_AGENT_STATUS)
+    .sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)));
 }
 
 async function getCloudStatusIfSupported() {
@@ -695,7 +704,30 @@ export async function listOrAutoProvisionCloudAgent(
   if (!authToken) {
     return { kind: "error", message: "Eliza Cloud authentication required." };
   }
-  return bindCloudAgent(sourceDraft, authToken, { forceCreate: false }, ports);
+  ports.onStatus?.("Finding your agents...", "listing");
+  const list = await client.getCloudCompatAgents();
+  if (!list.success) {
+    return {
+      kind: "error",
+      message:
+        list.error ||
+        "Couldn't reach Eliza Cloud to find your agents. Check your connection and try again.",
+    };
+  }
+  const running = runningCloudAgents(list.data);
+  if (running.length > 1) {
+    ports.onStatus?.(null);
+    return { kind: "pick-cloud-agent", agents: running };
+  }
+  return bindCloudAgent(
+    sourceDraft,
+    authToken,
+    {
+      forceCreate: false,
+      ...(running[0]?.agent_id ? { preferAgentId: running[0].agent_id } : {}),
+    },
+    ports,
+  );
 }
 
 // ── Router entry — validate + route by runtime ───────────────────────────────

--- a/packages/ui/src/state/startup-phase-poll.test.ts
+++ b/packages/ui/src/state/startup-phase-poll.test.ts
@@ -20,6 +20,7 @@ const clientMock = vi.hoisted(() => ({
   getFirstRunOptions: vi.fn(),
   getConfig: vi.fn(),
   getCloudCompatAgent: vi.fn(),
+  getCloudCompatAgents: vi.fn(),
   hasToken: vi.fn(),
   getBaseUrl: vi.fn(() => ""),
   setBaseUrl: vi.fn(),
@@ -155,6 +156,10 @@ beforeEach(() => {
   clientMock.getCloudCompatAgent.mockResolvedValue({
     success: true,
     data: { agent_id: "agent-123" },
+  });
+  clientMock.getCloudCompatAgents.mockResolvedValue({
+    success: true,
+    data: [{ agent_id: "agent-123", status: "running" }],
   });
   clientMock.hasToken.mockReturnValue(false);
   clientMock.getBaseUrl.mockReturnValue("");
@@ -864,6 +869,69 @@ describe("runPollingBackend", () => {
     expect(clearPersistedActiveServer).toHaveBeenCalledTimes(1);
     expect(clientMock.setBaseUrl).toHaveBeenCalledWith(null);
     expect(dispatch).not.toHaveBeenCalledWith({ type: "BACKEND_NOT_FOUND" });
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "BACKEND_REACHED",
+      firstRunComplete: false,
+    });
+  });
+
+  it("routes a reclaimed shared cloud agent to agent selection instead of treating its 404 as healthy", async () => {
+    const deps = createDeps();
+    const dispatch = vi.fn();
+    (globalThis as { window?: unknown }).window = {
+      location: { origin: "http://localhost:2138", protocol: "http:" },
+    };
+    const sharedBase =
+      "https://api.elizacloud.ai/api/v1/eliza/agents/shared-dead";
+    clientMock.getBaseUrl.mockReturnValue(sharedBase);
+    clientMock.hasToken.mockReturnValue(true);
+    cloudMock.getCloudAuthToken.mockReturnValue("cloud-token");
+    clientMock.getAuthStatus.mockReset();
+    clientMock.getAuthStatus.mockRejectedValue(
+      Object.assign(new Error("Agent not found"), {
+        kind: "http",
+        status: 404,
+        path: "/api/auth/status",
+      }),
+    );
+    clientMock.getCloudCompatAgents.mockResolvedValue({
+      success: true,
+      data: [{ agent_id: "dedicated-live", status: "running" }],
+    });
+
+    const staleSharedAgent = {
+      id: "cloud:shared-dead",
+      kind: "cloud" as const,
+      label: "Shared agent",
+      apiBase: sharedBase,
+    };
+    const ctx: RestoringSessionCtx = {
+      persistedActiveServer: staleSharedAgent,
+      restoredActiveServer: staleSharedAgent,
+      shouldPreserveCompletedFirstRun: false,
+      hadPriorFirstRun: true,
+    };
+
+    await runPollingBackend(
+      deps,
+      dispatch,
+      {
+        supportsLocalRuntime: true,
+        backendTimeoutMs: 1000,
+        agentReadyTimeoutMs: 1000,
+        probeForExistingInstall: true,
+        defaultTarget: "embedded-local",
+      },
+      ctx,
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+    );
+
+    expect(clientMock.getCloudCompatAgents).toHaveBeenCalledTimes(1);
+    expect(clearPersistedActiveServer).toHaveBeenCalledTimes(1);
+    expect(clientMock.setBaseUrl).toHaveBeenCalledWith(null);
     expect(dispatch).toHaveBeenCalledWith({
       type: "BACKEND_REACHED",
       firstRunComplete: false,

--- a/packages/ui/src/state/startup-phase-poll.ts
+++ b/packages/ui/src/state/startup-phase-poll.ts
@@ -230,6 +230,19 @@ export function isRecoverableRemoteBase(args: {
 // api/client-cloud.ts and DIRECT_CLOUD_API_BASE in startup-phase-restore.ts.
 const DIRECT_CLOUD_API_BASE = "https://api.elizacloud.ai";
 
+function sharedCloudAgentIdFromBase(base: string): string | null {
+  try {
+    const url = new URL(base);
+    const match = url.pathname
+      .replace(/\/bridge\/?$/, "")
+      .match(/\/api\/v1\/eliza\/agents\/([^/]+)\/?$/);
+    return match?.[1] ? decodeURIComponent(match[1]) : null;
+  } catch {
+    // error-policy:J3 malformed base — no id can be verified.
+    return null;
+  }
+}
+
 /**
  * A DEDICATED cloud agent base just 404'd on the first-run shell endpoints.
  * That 404 is ambiguous: it is the normal "no first-run shell on a cloud agent"
@@ -266,6 +279,32 @@ async function dedicatedCloudAgentIsGone(base: string): Promise<boolean> {
     // A 404 is the positive "agent is gone" signal. Any other failure
     // (network blip, 5xx) is inconclusive — do not strand the user.
     return asApiLikeError(err)?.status === 404;
+  } finally {
+    client.setBaseUrl(priorBaseUrl || null);
+    if (!priorToken) client.setToken(null);
+  }
+}
+
+async function sharedCloudAgentIsMissingFromRunningSet(
+  base: string,
+): Promise<boolean> {
+  const agentId = sharedCloudAgentIdFromBase(base);
+  if (!agentId) return false;
+  if (!getCloudAuthToken(client)) return false;
+
+  const priorBaseUrl = client.getBaseUrl();
+  const priorToken = client.hasToken();
+  client.setBaseUrl(DIRECT_CLOUD_API_BASE);
+  try {
+    const res = await client.getCloudCompatAgents();
+    if (!res.success) return false;
+    return !res.data.some(
+      (agent) => agent.agent_id === agentId && agent.status === "running",
+    );
+  } catch {
+    // error-policy:J4 running-set verification is a recovery guard; an
+    // inconclusive control-plane read must not clear a potentially valid agent.
+    return false;
   } finally {
     client.setBaseUrl(priorBaseUrl || null);
     if (!priorToken) client.setToken(null);
@@ -887,6 +926,16 @@ export async function runPollingBackend(
             }
             if (ae?.status === 404) {
               if (isDirectCloudSharedAgentBase(client.getBaseUrl())) {
+                if (
+                  await sharedCloudAgentIsMissingFromRunningSet(
+                    client.getBaseUrl(),
+                  )
+                ) {
+                  recoverToAgentSelection(
+                    "saved shared cloud agent is missing from the running set",
+                  );
+                  return;
+                }
                 // Shared-runtime cloud bridge: no /api/first-run* shell
                 // endpoints exist (we provisioned it, so first-run IS done).
                 // Treat the 404 as complete and go to chat — the bridge serves
@@ -1102,6 +1151,14 @@ export async function runPollingBackend(
       }
       if (ae?.status === 404) {
         if (isDirectCloudSharedAgentBase(client.getBaseUrl())) {
+          if (
+            await sharedCloudAgentIsMissingFromRunningSet(client.getBaseUrl())
+          ) {
+            recoverToAgentSelection(
+              "saved shared cloud agent is missing from the running set",
+            );
+            return;
+          }
           // Shared-runtime cloud bridge: no /api/first-run* shell endpoints
           // exist (we provisioned it, so first-run IS done). Treat the 404 as
           // complete and go to chat — the bridge serves /api/conversations via


### PR DESCRIPTION
## Summary
- route cloud first-run through the live running-agent set: zero running agents provisions, one running agent binds directly, multiple running agents return the existing picker outcome
- stop reusing non-running cloud agents in selectOrProvisionCloudAgent
- verify shared cloud REST adapter 404s against the control-plane running set before treating them as healthy, so reclaimed shared agents fall back to agent selection

Follow-up for #15483.

## Verification
- bunx @biomejs/biome check --write packages/ui/src/api/client-cloud.ts packages/ui/src/api/client-cloud-select-or-provision.test.ts packages/ui/src/first-run/first-run-finish.ts packages/ui/src/state/startup-phase-poll.ts packages/ui/src/state/startup-phase-poll.test.ts
- git diff --check
- bun run --cwd packages/ui test src/api/client-cloud-select-or-provision.test.ts src/state/startup-phase-poll.test.ts
- bun run --cwd packages/ui typecheck