### PR TITLE
fix(agent): cover long chat retry dedupe window

### DIFF
--- a/packages/agent/src/api/__tests__/chat-idempotency.test.ts
+++ b/packages/agent/src/api/__tests__/chat-idempotency.test.ts
@@ -12,12 +12,17 @@
 
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  __getChatDedupeTtlMsForTests,
   __resetChatDedupeForTests,
   isDuplicateChatMessage,
   normalizeClientMessageId,
 } from "../chat-routes.ts";
 
-const TTL_MS = 30_000;
+const OLD_ARRIVAL_TTL_MS = 30_000;
+const DEFAULT_GENERATION_TIMEOUT_MS = 180_000;
+const RECONNECT_WAIT_TIMEOUT_MS = 30_000;
+const RECONNECT_SIGNAL_DEBOUNCE_MS = 400;
+const TTL_MS = __getChatDedupeTtlMsForTests();
 const SCOPE = "room-a";
 
 afterEach(() => {
@@ -69,6 +74,20 @@ describe("isDuplicateChatMessage", () => {
     // Each id is independently deduped.
     expect(isDuplicateChatMessage(SCOPE, "msg-a", now)).toBe(true);
     expect(isDuplicateChatMessage(SCOPE, "msg-b", now)).toBe(true);
+  });
+
+  it("covers the long-turn reconnect retry window that exceeded the old 30s arrival TTL", () => {
+    const now = 3_500_000;
+    const retryAfterLongTurn =
+      DEFAULT_GENERATION_TIMEOUT_MS +
+      RECONNECT_WAIT_TIMEOUT_MS +
+      RECONNECT_SIGNAL_DEBOUNCE_MS;
+
+    expect(isDuplicateChatMessage(SCOPE, "msg-long-turn", now)).toBe(false);
+    expect(retryAfterLongTurn).toBeGreaterThan(OLD_ARRIVAL_TTL_MS);
+    expect(
+      isDuplicateChatMessage(SCOPE, "msg-long-turn", now + retryAfterLongTurn),
+    ).toBe(true);
   });
 
   it("does not suppress the same id once the TTL has elapsed", () => {

--- a/packages/agent/src/api/__tests__/conversation-idempotency.test.ts
+++ b/packages/agent/src/api/__tests__/conversation-idempotency.test.ts
@@ -68,6 +68,9 @@ const ROOM_ID = stringToUuid("room-1") as UUID;
 
 const STREAM_PATH = "/api/conversations/conv-1/messages/stream";
 const SEND_PATH = "/api/conversations/conv-1/messages";
+const DEFAULT_GENERATION_TIMEOUT_MS = 180_000;
+const RECONNECT_WAIT_TIMEOUT_MS = 30_000;
+const RECONNECT_SIGNAL_DEBOUNCE_MS = 400;
 
 interface MockResponseRecord {
   writes: string[];
@@ -314,6 +317,42 @@ describe("conversation-route chat idempotency wiring", () => {
     expect(frames).toHaveLength(1);
     expect(frames[0]).toMatchObject({ type: "done", fullText: "" });
     expect(retry.record.ended).toBe(true);
+  });
+
+  it("SSE: a slow reconnect retry after a long completed turn is still suppressed", async () => {
+    const { state, handleMessage, createMemory } = createHarness();
+    const body = { text: "hello", clientMessageId: "sse-long-retry-1" };
+    const firstArrival = Date.now();
+    const nowSpy = vi.spyOn(Date, "now");
+
+    try {
+      nowSpy.mockReturnValue(firstArrival);
+      const first = await runRoute("POST", STREAM_PATH, state, body);
+      expect(handleMessage).toHaveBeenCalledTimes(1);
+      const persistsAfterFirst = createMemory.mock.calls.length;
+      expect(persistsAfterFirst).toBeGreaterThan(0);
+      const firstDone = parseDataFrames(first.record).find(
+        (f) => f.type === "done",
+      );
+      expect(firstDone?.fullText).toBe("ok");
+
+      nowSpy.mockReturnValue(
+        firstArrival +
+          DEFAULT_GENERATION_TIMEOUT_MS +
+          RECONNECT_WAIT_TIMEOUT_MS +
+          RECONNECT_SIGNAL_DEBOUNCE_MS,
+      );
+      const retry = await runRoute("POST", STREAM_PATH, state, body);
+
+      expect(handleMessage).toHaveBeenCalledTimes(1);
+      expect(createMemory).toHaveBeenCalledTimes(persistsAfterFirst);
+      const retryFrames = parseDataFrames(retry.record);
+      expect(retryFrames).toHaveLength(1);
+      expect(retryFrames[0]).toMatchObject({ type: "done", fullText: "ok" });
+      expect(retry.record.ended).toBe(true);
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 
   it("SSE: a retry after a disconnect-ABORTED first attempt re-runs the turn (no dead air)", async () => {

--- a/packages/agent/src/api/chat-routes.ts
+++ b/packages/agent/src/api/chat-routes.ts
@@ -182,12 +182,21 @@ const CLIENT_MESSAGE_ID_MAX_LENGTH = 128;
  *
  * Keyed by `${conversationOrUserScope}:${clientMessageId}` so a legitimately
  * identical message in a different conversation, or the same text re-sent after
- * the TTL, is NOT suppressed. Entries expire after `CHAT_DEDUPE_TTL_MS`; the map
- * stays bounded via an amortized sweep (at most once per TTL window) — the same
- * O(1)-check / amortized-eviction shape as the WS cache.
+ * the TTL, is NOT suppressed. The TTL must cover the full server generation
+ * window plus the client's reconnect retry wait; otherwise a retry after a long
+ * but successful turn can land after the arrival timestamp expires and start a
+ * second billed LLM turn. The map stays bounded via an amortized sweep (at most
+ * once per TTL window) — the same O(1)-check / amortized-eviction shape as the
+ * WS cache.
  */
 const chatSeenMessageIds = new Map<string, number>();
-const CHAT_DEDUPE_TTL_MS = 30_000;
+const DEFAULT_CHAT_GENERATION_TIMEOUT_MS = 180_000;
+const CHAT_DEDUPE_RECONNECT_WAIT_MS = 30_000;
+const CHAT_DEDUPE_SETTLE_BUFFER_MS = 30_000;
+const CHAT_DEDUPE_TTL_MS =
+  resolveChatGenerationTimeoutMs() +
+  CHAT_DEDUPE_RECONNECT_WAIT_MS +
+  CHAT_DEDUPE_SETTLE_BUFFER_MS;
 let chatSeenLastSweepAt = 0;
 
 /** Normalize a raw body value into a usable idempotency key, or `null` when
@@ -278,6 +287,12 @@ export function getChatMessageIdFirstSeenAt(
 export function __resetChatDedupeForTests(): void {
   chatSeenMessageIds.clear();
   chatSeenLastSweepAt = 0;
+}
+
+/** Test-only: expose the configured dedupe window without freezing env policy
+ *  into the unit fixtures. */
+export function __getChatDedupeTtlMsForTests(): number {
+  return CHAT_DEDUPE_TTL_MS;
 }
 
 const ANDROID_LOCAL_DIRECT_CHAT_DENY_PATTERN =
@@ -1187,7 +1202,6 @@ function isNoProviderError(err: unknown): boolean {
 const NO_PROVIDER_CHAT_MESSAGE =
   "Connect an LLM provider to start chatting. Open Settings → Providers, " +
   "or choose Eliza Cloud during first-run setup.";
-const DEFAULT_CHAT_GENERATION_TIMEOUT_MS = 180_000;
 const NON_EXECUTABLE_FALLBACK_ACTIONS = new Set(["REPLY", "NONE", "IGNORE"]);
 type SyntheticChatFailureKind =
   | ChatFailureKind


### PR DESCRIPTION
## Summary
- extend HTTP chat idempotency retention to cover configured generation timeout plus reconnect retry wait
- add pure-cache regression for the old 30s arrival-window failure
- add route-level SSE regression proving a slow reconnect retry returns the first reply without running a second turn

Fixes the remaining D2 double-bill window in #15392.

## Validation
- bunx @biomejs/biome check --write packages/agent/src/api/chat-routes.ts packages/agent/src/api/__tests__/chat-idempotency.test.ts packages/agent/src/api/__tests__/conversation-idempotency.test.ts
- bunx vitest run --config packages/agent/vitest.config.ts packages/agent/src/api/__tests__/chat-idempotency.test.ts packages/agent/src/api/__tests__/conversation-idempotency.test.ts
- bun run --cwd packages/agent typecheck
- git diff --check

Note: direct `bun test ...` is not a valid runner for the route suite because it lacks Vitest vi.resetModules; it also hit the existing coverage WriteFailed behavior.