### PR TITLE
fix(cloud): reprovision managed agents on current fleet image

### DIFF
--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts
@@ -2035,6 +2035,129 @@ describe("ElizaSandboxService.provision dedup + port-collision retry (LARP H2)",
     }
   });
 
+  test("same-repo stale docker_image pin is replaced with the configured fleet image on provision", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const configuredImage = "ghcr.io/elizaos/eliza:sha-current";
+    const row = {
+      ...provisioningReadyRow(),
+      docker_image: "ghcr.io/elizaos/eliza:sha-stale",
+    };
+    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
+    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+      ...row,
+      status: "provisioning",
+    });
+    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(
+      undefined,
+    );
+    const finalRow: AgentSandbox = { ...row, status: "running", docker_image: configuredImage };
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+      async (_id, data) => {
+        if (data.status === "running") return finalRow;
+        return { ...row, ...data };
+      },
+    );
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
+      id: "22222222-2222-4222-8222-222222222222",
+      plainKey: "eliza_test_agent_key",
+      prefix: "eliza_test",
+    });
+    const svc = new ElizaSandboxService();
+    const ensureStartedSpy = spyOn(
+      svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
+      "ensureRuntimeAgentStarted",
+    ).mockResolvedValue(null);
+    const create = mock(async () => providerHandle());
+    const getProviderSpy = spyOn(
+      svc as unknown as { getProvider: () => Promise<SandboxProvider> },
+      "getProvider",
+    ).mockResolvedValue({
+      create,
+      stop: mock(async () => {}),
+      checkHealth: async () => true,
+    } as SandboxProvider);
+
+    try {
+      const res = await runWithCloudBindings({ ELIZA_AGENT_IMAGE: configuredImage }, () =>
+        svc.provision(AGENT, ORG),
+      );
+      expect(res.success).toBe(true);
+      expect(create.mock.calls[0]?.[0]).toMatchObject({
+        dockerImage: configuredImage,
+      });
+    } finally {
+      findSpy.mockRestore();
+      lockSpy.mockRestore();
+      backupSpy.mockRestore();
+      updateSpy.mockRestore();
+      apiKeySpy.mockRestore();
+      ensureStartedSpy.mockRestore();
+      getProviderSpy.mockRestore();
+    }
+  });
+
+  test("custom-repo docker_image pin is preserved on provision", async () => {
+    const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
+    const configuredImage = "ghcr.io/elizaos/eliza:sha-current";
+    const customImage = "ghcr.io/example/custom-agent:stable";
+    const row = {
+      ...provisioningReadyRow(),
+      docker_image: customImage,
+    };
+    const findSpy = spyOn(agentSandboxesRepository, "findByIdAndOrg").mockResolvedValue(row);
+    const lockSpy = spyOn(agentSandboxesRepository, "trySetProvisioning").mockResolvedValue({
+      ...row,
+      status: "provisioning",
+    });
+    const backupSpy = spyOn(agentSandboxesRepository, "getLatestBackup").mockResolvedValue(
+      undefined,
+    );
+    const finalRow: AgentSandbox = { ...row, status: "running" };
+    const updateSpy = spyOn(agentSandboxesRepository, "update").mockImplementation(
+      async (_id, data) => {
+        if (data.status === "running") return finalRow;
+        return { ...row, ...data };
+      },
+    );
+    const apiKeySpy = spyOn(apiKeysService, "createForAgent").mockResolvedValue({
+      id: "22222222-2222-4222-8222-222222222222",
+      plainKey: "eliza_test_agent_key",
+      prefix: "eliza_test",
+    });
+    const svc = new ElizaSandboxService();
+    const ensureStartedSpy = spyOn(
+      svc as unknown as { ensureRuntimeAgentStarted: () => Promise<unknown> },
+      "ensureRuntimeAgentStarted",
+    ).mockResolvedValue(null);
+    const create = mock(async () => providerHandle());
+    const getProviderSpy = spyOn(
+      svc as unknown as { getProvider: () => Promise<SandboxProvider> },
+      "getProvider",
+    ).mockResolvedValue({
+      create,
+      stop: mock(async () => {}),
+      checkHealth: async () => true,
+    } as SandboxProvider);
+
+    try {
+      const res = await runWithCloudBindings({ ELIZA_AGENT_IMAGE: configuredImage }, () =>
+        svc.provision(AGENT, ORG),
+      );
+      expect(res.success).toBe(true);
+      expect(create.mock.calls[0]?.[0]).toMatchObject({
+        dockerImage: customImage,
+      });
+    } finally {
+      findSpy.mockRestore();
+      lockSpy.mockRestore();
+      backupSpy.mockRestore();
+      updateSpy.mockRestore();
+      apiKeySpy.mockRestore();
+      ensureStartedSpy.mockRestore();
+      getProviderSpy.mockRestore();
+    }
+  });
+
   test("(4) a NON-unique post-create error → markError, NO retry (one create), failure", async () => {
     const { ElizaSandboxService } = await import("./eliza-sandbox.ts?actual");
     const row = provisioningReadyRow();

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -207,6 +207,18 @@ export function assertAgentImageAllowed(dockerImage: string | undefined): void {
   }
 }
 
+function resolveManagedProvisionDockerImage(
+  storedImage: string | null | undefined,
+): string | undefined {
+  const configuredImage = containersEnv.defaultAgentImageOverride();
+  if (!configuredImage) return storedImage ?? undefined;
+  // Same-repo managed pins are fleet image selections, not custom images; on
+  // reprovision they must follow the operator's current image so recovery does
+  // not replay an old broken sha tag forever.
+  if (!storedImage) return configuredImage;
+  return imageRepo(storedImage) === imageRepo(configuredImage) ? configuredImage : storedImage;
+}
+
 /**
  * Thrown when the post-create readiness probe could not REACH the container
  * (SSH transport unresolved), as distinct from the container being genuinely
@@ -1527,6 +1539,7 @@ export class ElizaSandboxService {
     // Solution: Retry loop catches unique constraint errors, cleans up ghost container, and retries.
     const MAX_PROVISION_ATTEMPTS = 3;
     let lastError: string = "Unknown error";
+    const provisionDockerImage = resolveManagedProvisionDockerImage(rec.docker_image);
 
     // Materialize the stored env for the container: BYO secrets are encrypted
     // at rest (#11332); compatibility plaintext values pass through unchanged. A
@@ -1596,7 +1609,7 @@ export class ElizaSandboxService {
             // SANDBOX_ROUTE_AGENT_ID injection).
             routeAgentId: rec.character_id ?? undefined,
             snapshotId: rec.snapshot_id ?? undefined,
-            dockerImage: rec.docker_image ?? undefined,
+            dockerImage: provisionDockerImage,
             container: containerLaunch,
           });
         }


### PR DESCRIPTION
## Summary
- resolve managed-agent provision image from the current configured `ELIZA_AGENT_IMAGE` when the stored row pin is absent or points at the same fleet-managed repo
- preserve custom-repo docker_image pins so bespoke agents are not clobbered
- add real `provision()` harness coverage for same-repo stale pins and custom repo preservation

Addresses the stale `docker_image` pin reprovision leg of #15384.

## Validation
- `bunx @biomejs/biome check --write packages/cloud/shared/src/lib/services/eliza-sandbox.ts packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts`
- `bun test --coverage-reporter=lcov packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts` — 91/91 pass
- `bun run --cwd packages/cloud/shared typecheck`
- `git diff --check`

Note: the default `bun test packages/cloud/shared/src/lib/services/eliza-sandbox.test.ts` run passes assertions but exits with the existing coverage stdout `WriteFailed`; lcov-only avoids that reporter failure.