### PR TITLE
fix(cloud): clear stale provision handles on retry

### DIFF
--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
@@ -127,6 +127,42 @@ describe("AgentSandboxesRepository", () => {
     expect(new PgDialect().sqlToQuery(capturedWhere).sql).toContain("'sleeping'");
   });
 
+  test("provisioning lock clears stale handles only when retrying permanent provision failures", async () => {
+    set.mockClear();
+
+    const { AgentSandboxesRepository } = await import("./agent-sandboxes");
+
+    await new AgentSandboxesRepository().trySetProvisioning("e06bb509-6c52-4c33-a9f7-66addc43e8c8");
+
+    const capturedSet = set.mock.calls.at(-1)?.[0];
+    if (!capturedSet) throw new Error("trySetProvisioning did not build an update payload");
+
+    const handleColumns = [
+      "sandbox_id",
+      "bridge_url",
+      "health_url",
+      "node_id",
+      "container_name",
+      "bridge_port",
+      "web_ui_port",
+      "headscale_ip",
+    ] as const;
+
+    for (const column of handleColumns) {
+      const expression = capturedSet[column];
+      const sql =
+        expression && typeof expression === "object"
+          ? new PgDialect().sqlToQuery(expression as SQL).sql.toLowerCase()
+          : "";
+      expect(sql).toContain("case when");
+      expect(sql).toContain("status");
+      expect(sql).toContain("error_message");
+      expect(sql).toContain("provisioning permanently failed%");
+      expect(sql).toContain("then null");
+      expect(sql).toContain(`"${column}" end`);
+    }
+  });
+
   test("provisioning lock admits a running row ONLY when it has no container (re-provision unblock)", async () => {
     // Bug: a direct/shared provision inserts the row as `running` BEFORE any
     // container exists. If that provision crashes, the row is stuck at

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -709,15 +709,30 @@ export class AgentSandboxesRepository {
    * agent: the moment a container is created the provision path stamps
    * `container_name`/`sandbox_id`, so a live agent can NEVER satisfy this branch
    * and can NEVER have its lock taken from under it.
+   *
+   * Terminal provision failures are different from transport-unresolved
+   * `provisioning` retries: the old handle already failed every job attempt and
+   * must not be re-probed as the next wake/restart target. Clear only that
+   * permanent-failure handle while acquiring the new lock so a retry starts from
+   * provider.create with a fresh container record.
    */
   async trySetProvisioning(id: string): Promise<AgentSandbox | undefined> {
     await ensureAgentSandboxSchema();
+    const permanentProvisionFailure = sql`${agentSandboxes.status} = 'error' AND ${agentSandboxes.error_message} LIKE 'Provisioning permanently failed%'`;
     const [r] = await dbWrite
       .update(agentSandboxes)
       .set({
         status: "provisioning",
         updated_at: new Date(),
         error_message: null,
+        sandbox_id: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.sandbox_id} END`,
+        bridge_url: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.bridge_url} END`,
+        health_url: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.health_url} END`,
+        node_id: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.node_id} END`,
+        container_name: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.container_name} END`,
+        bridge_port: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.bridge_port} END`,
+        web_ui_port: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.web_ui_port} END`,
+        headscale_ip: sql`CASE WHEN ${permanentProvisionFailure} THEN NULL ELSE ${agentSandboxes.headscale_ip} END`,
       })
       .where(
         and(


### PR DESCRIPTION
## Summary
- clear persisted runtime handle columns when retrying rows whose provisioning job permanently failed
- keep transport-unresolved provisioning retries and other wake/restart locks unchanged
- add repository SQL regression coverage for the guarded cleanup

Fixes #15384

## Validation
- bunx @biomejs/biome check --write packages/cloud/shared/src/db/repositories/agent-sandboxes.ts packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
- bun test --coverage-reporter=lcov packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
- bun run --cwd packages/cloud/shared typecheck
- git diff --check