### PR TITLE
fix(cloud): prune stale agent images during disk cleanup

### DIFF
--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
@@ -99,13 +99,13 @@ let useRepositoryMocks = false;
 let useTransactionMock = false;
 
 const warnLog = mock((..._args: unknown[]) => {});
-const dbReadMock = new Proxy(realHelpers.dbRead as Record<PropertyKey, unknown>, {
+const dbReadMock = new Proxy(realHelpers.dbRead as unknown as Record<PropertyKey, unknown>, {
   get(target, prop, receiver) {
     if (prop === "select" && useRepositoryMocks) return select;
     return Reflect.get(target, prop, receiver);
   },
 });
-const dbWriteMock = new Proxy(realHelpers.dbWrite as Record<PropertyKey, unknown>, {
+const dbWriteMock = new Proxy(realHelpers.dbWrite as unknown as Record<PropertyKey, unknown>, {
   get(target, prop, receiver) {
     if (prop === "update" && useRepositoryMocks) return update;
     if (prop === "transaction" && useTransactionMock) return transaction;

--- a/packages/cloud/shared/src/db/repositories/shared-runtime-history.test.ts
+++ b/packages/cloud/shared/src/db/repositories/shared-runtime-history.test.ts
@@ -14,7 +14,7 @@ const deleteWhere = mock((clause: SQL) => {
   return { returning };
 });
 const del = mock(() => ({ where: deleteWhere }));
-const dbWriteMock = new Proxy(realClient.dbWrite as Record<PropertyKey, unknown>, {
+const dbWriteMock = new Proxy(realClient.dbWrite as unknown as Record<PropertyKey, unknown>, {
   get(target, prop, receiver) {
     if (prop === "delete") return del;
     return Reflect.get(target, prop, receiver);

--- a/packages/cloud/shared/src/lib/config/containers-env-disk.test.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env-disk.test.ts
@@ -12,6 +12,9 @@ const KEYS = [
   "NODE_DISK_PRUNE_THRESHOLD_PCT",
   "NODE_DISK_UNHEALTHY_THRESHOLD_PCT",
   "NODE_DISK_PRUNE_COOLDOWN_MS",
+  "NODE_DISK_AGENT_IMAGE_PRUNE_INTERVAL_MS",
+  "NODE_DISK_AGENT_IMAGE_PRUNE_KEEP_NEWEST",
+  "NODE_DISK_AGENT_IMAGE_PRUNE_MAX_AGE_HOURS",
 ] as const;
 
 const saved = new Map<string, string | undefined>();
@@ -79,5 +82,47 @@ describe("nodeDiskPruneCooldownMs", () => {
     expect(containersEnv.nodeDiskPruneCooldownMs()).toBe(60_000);
     setEnv({ NODE_DISK_PRUNE_COOLDOWN_MS: String(99 * 60 * 60_000) });
     expect(containersEnv.nodeDiskPruneCooldownMs()).toBe(6 * 60 * 60_000);
+  });
+});
+
+describe("nodeDiskAgentImagePruneIntervalMs", () => {
+  test("defaults to 24 hours when unset", () => {
+    setEnv({});
+    expect(containersEnv.nodeDiskAgentImagePruneIntervalMs()).toBe(24 * 60 * 60_000);
+  });
+
+  test("clamps to [1h, 7d]", () => {
+    setEnv({ NODE_DISK_AGENT_IMAGE_PRUNE_INTERVAL_MS: "1000" });
+    expect(containersEnv.nodeDiskAgentImagePruneIntervalMs()).toBe(60 * 60_000);
+    setEnv({ NODE_DISK_AGENT_IMAGE_PRUNE_INTERVAL_MS: String(30 * 24 * 60 * 60_000) });
+    expect(containersEnv.nodeDiskAgentImagePruneIntervalMs()).toBe(7 * 24 * 60 * 60_000);
+  });
+});
+
+describe("nodeDiskAgentImagePruneKeepNewest", () => {
+  test("defaults to keeping the current image plus one rollback ref", () => {
+    setEnv({});
+    expect(containersEnv.nodeDiskAgentImagePruneKeepNewest()).toBe(2);
+  });
+
+  test("clamps to [1, 10]", () => {
+    setEnv({ NODE_DISK_AGENT_IMAGE_PRUNE_KEEP_NEWEST: "0" });
+    expect(containersEnv.nodeDiskAgentImagePruneKeepNewest()).toBe(1);
+    setEnv({ NODE_DISK_AGENT_IMAGE_PRUNE_KEEP_NEWEST: "100" });
+    expect(containersEnv.nodeDiskAgentImagePruneKeepNewest()).toBe(10);
+  });
+});
+
+describe("nodeDiskAgentImagePruneMaxAgeHours", () => {
+  test("defaults to 7 days when unset", () => {
+    setEnv({});
+    expect(containersEnv.nodeDiskAgentImagePruneMaxAgeHours()).toBe(7 * 24);
+  });
+
+  test("clamps to [24h, 90d]", () => {
+    setEnv({ NODE_DISK_AGENT_IMAGE_PRUNE_MAX_AGE_HOURS: "1" });
+    expect(containersEnv.nodeDiskAgentImagePruneMaxAgeHours()).toBe(24);
+    setEnv({ NODE_DISK_AGENT_IMAGE_PRUNE_MAX_AGE_HOURS: String(365 * 24) });
+    expect(containersEnv.nodeDiskAgentImagePruneMaxAgeHours()).toBe(90 * 24);
   });
 });

--- a/packages/cloud/shared/src/lib/config/containers-env.ts
+++ b/packages/cloud/shared/src/lib/config/containers-env.ts
@@ -707,6 +707,48 @@ export const containersEnv = {
       ? Math.min(6 * 60 * 60_000, Math.max(60_000, Math.floor(parsed)))
       : defaultMs;
   },
+
+  /**
+   * Cadence for the managed-agent image GC that removes old, unused refs from
+   * the configured default-agent repository. It is deliberately separate from
+   * the emergency high-water prune so large nodes shed superseded image tags
+   * before they ever cross the disk-full threshold. Default 24h. Clamped to
+   * [1h, 7d].
+   */
+  nodeDiskAgentImagePruneIntervalMs(): number {
+    const env = getCloudAwareEnv();
+    const raw = pick(env.NODE_DISK_AGENT_IMAGE_PRUNE_INTERVAL_MS);
+    const parsed = raw ? Number(raw) : Number.NaN;
+    const defaultMs = 24 * 60 * 60_000;
+    return Number.isFinite(parsed)
+      ? Math.min(7 * 24 * 60 * 60_000, Math.max(60 * 60_000, Math.floor(parsed)))
+      : defaultMs;
+  },
+
+  /**
+   * Number of newest managed-agent image refs to preserve on each node even when
+   * unused. Keeping two refs gives operators the current image plus a quick
+   * rollback cushion while still pruning long-tail tag/digest buildup. Default
+   * 2. Clamped to [1, 10].
+   */
+  nodeDiskAgentImagePruneKeepNewest(): number {
+    const env = getCloudAwareEnv();
+    const raw = pick(env.NODE_DISK_AGENT_IMAGE_PRUNE_KEEP_NEWEST);
+    const parsed = raw ? Number(raw) : Number.NaN;
+    return Number.isFinite(parsed) ? Math.min(10, Math.max(1, Math.floor(parsed))) : 2;
+  },
+
+  /**
+   * Minimum age for an unused managed-agent image ref before stale-image GC may
+   * delete it. This avoids racing fresh deploys or rollback tags that landed
+   * shortly before the cleanup cycle. Default 7d. Clamped to [24h, 90d].
+   */
+  nodeDiskAgentImagePruneMaxAgeHours(): number {
+    const env = getCloudAwareEnv();
+    const raw = pick(env.NODE_DISK_AGENT_IMAGE_PRUNE_MAX_AGE_HOURS);
+    const parsed = raw ? Number(raw) : Number.NaN;
+    return Number.isFinite(parsed) ? Math.min(90 * 24, Math.max(24, Math.floor(parsed))) : 7 * 24;
+  },
 };
 
 /**

--- a/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts
@@ -75,6 +75,7 @@ mock.module("../credits", () => ({
   // Must mirror the real export — app-credits.ts imports it for the $0-estimate
   // floor; a missing export would break the module link under this mock.
   MIN_RESERVATION: 0.000001,
+  APP_CHAT_RESERVATION_SETTLEMENT_MARKER: "app_chat_reservation_v1",
   creditsService: {
     addCredits,
     reserveAndDeductCredits,

--- a/packages/cloud/shared/src/lib/services/node-disk-manager.test.ts
+++ b/packages/cloud/shared/src/lib/services/node-disk-manager.test.ts
@@ -19,6 +19,7 @@
 import { describe, expect, mock, test } from "bun:test";
 import {
   buildReclaimCommand,
+  buildStaleAgentImagePruneCommand,
   cleanupNodeDisks,
   type DiskNode,
   type DiskUsage,
@@ -141,6 +142,38 @@ describe("buildReclaimCommand", () => {
   });
 });
 
+describe("buildStaleAgentImagePruneCommand", () => {
+  const cmd = buildStaleAgentImagePruneCommand({
+    repository: "ghcr.io/elizaos/eliza",
+    keepNewest: 2,
+    maxAgeHours: 168,
+  });
+
+  test("targets only the configured managed-agent image repository", () => {
+    expect(cmd).toContain("repo='ghcr.io/elizaos/eliza'");
+    expect(cmd).toContain('docker image ls "$repo"');
+    expect(cmd).not.toContain("docker image prune");
+    expect(cmd).not.toContain("--volumes");
+  });
+
+  test("preserves active image IDs and newest rollback refs", () => {
+    expect(cmd).toContain("docker ps -a --format '{{.Image}}'");
+    expect(cmd).toContain("grep -qxF");
+    expect(cmd).toContain("keep_newest=2");
+    expect(cmd).toContain("max_age_hours=168");
+  });
+
+  test("requires an explicit repository", () => {
+    expect(() =>
+      buildStaleAgentImagePruneCommand({
+        repository: " ",
+        keepNewest: 2,
+        maxAgeHours: 168,
+      }),
+    ).toThrow("repository is required");
+  });
+});
+
 // ---------------------------------------------------------------------------
 // cleanupNodeDisks (orchestration over the mocked node-exec boundary)
 // ---------------------------------------------------------------------------
@@ -151,6 +184,7 @@ function fakeNode(
     usage?: DiskUsage | null;
     afterUsage?: DiskUsage | null;
     reclaimThrows?: boolean;
+    stalePruneThrows?: boolean;
   } = {},
 ): DiskNode {
   // Distinguish "explicitly null" (df read failed) from "not provided" — `??`
@@ -162,20 +196,35 @@ function fakeNode(
     if (overrides.reclaimThrows) throw new Error("reclaim failed over ssh");
     return afterUsage ?? null;
   });
+  const pruneStaleAgentImages = mock(async () => {
+    if (overrides.stalePruneThrows) throw new Error("stale image prune failed over ssh");
+  });
   return {
     node_id: overrides.node_id ?? "node-a",
     hostname: overrides.hostname ?? "10.0.0.1",
     status: overrides.status ?? "healthy",
     readDiskUsage,
     reclaim,
+    pruneStaleAgentImages,
   };
 }
 
-const cfg = (now: number, cooldown = new Map<string, number>()) => ({
+const cfg = (
+  now: number,
+  cooldown = new Map<string, number>(),
+  staleCooldown = new Map<string, number>(),
+) => ({
   pruneThresholdPct: 80,
   cooldownMs: 30 * 60_000,
   now: () => now,
   lastPrunedAt: cooldown,
+  staleAgentImagePrune: {
+    repository: "ghcr.io/elizaos/eliza",
+    keepNewest: 2,
+    maxAgeHours: 168,
+    intervalMs: 24 * 60 * 60_000,
+    lastPrunedAt: staleCooldown,
+  },
 });
 
 describe("cleanupNodeDisks", () => {
@@ -184,10 +233,13 @@ describe("cleanupNodeDisks", () => {
     const report = await cleanupNodeDisks([node], cfg(1_000_000));
 
     expect(node.reclaim).toHaveBeenCalledTimes(1);
+    expect(node.pruneStaleAgentImages).toHaveBeenCalledTimes(1);
     expect(report.pruned).toBe(1);
+    expect(report.staleAgentImagePruned).toBe(1);
     expect(report.nodesScanned).toBe(1);
     expect(report.details[0]).toMatchObject({
       action: "prune",
+      staleAgentImageAction: "prune",
       usedPercentBefore: 90,
       usedPercentAfter: 45,
       reclaimedPercent: 45,
@@ -199,8 +251,35 @@ describe("cleanupNodeDisks", () => {
     const report = await cleanupNodeDisks([node], cfg(1_000_000));
 
     expect(node.reclaim).not.toHaveBeenCalled();
+    expect(node.pruneStaleAgentImages).toHaveBeenCalledTimes(1);
     expect(report.pruned).toBe(0);
+    expect(report.staleAgentImagePruned).toBe(1);
     expect(report.details[0]?.action).toBe("skip_below_threshold");
+  });
+
+  test("skips stale agent image prune inside its interval", async () => {
+    const now = 5_000_000;
+    const staleCooldown = new Map<string, number>([["node-a", now - 60_000]]);
+    const node = fakeNode({ node_id: "node-a", usage: { usedPercent: 50 } });
+    const report = await cleanupNodeDisks([node], cfg(now, new Map(), staleCooldown));
+
+    expect(node.pruneStaleAgentImages).not.toHaveBeenCalled();
+    expect(report.staleAgentImagePruned).toBe(0);
+    expect(report.details[0]?.staleAgentImageAction).toBe("skip_interval");
+  });
+
+  test("continues to emergency reclaim when stale agent image prune fails", async () => {
+    const node = fakeNode({
+      usage: { usedPercent: 90 },
+      stalePruneThrows: true,
+    });
+    const report = await cleanupNodeDisks([node], cfg(1_000_000));
+
+    expect(node.pruneStaleAgentImages).toHaveBeenCalledTimes(1);
+    expect(node.reclaim).toHaveBeenCalledTimes(1);
+    expect(report.staleAgentImagePruneFailed).toBe(1);
+    expect(report.pruned).toBe(1);
+    expect(report.details[0]?.staleAgentImageAction).toBe("failed");
   });
 
   test("respects the cooldown: a node pruned recently is skipped even above threshold", async () => {

--- a/packages/cloud/shared/src/lib/services/node-disk-manager.ts
+++ b/packages/cloud/shared/src/lib/services/node-disk-manager.ts
@@ -43,6 +43,7 @@
  *      while a large pull is legitimately in flight.
  */
 
+import { imageRepo } from "../../db/utils/docker-image-ref";
 import { containersEnv } from "../config/containers-env";
 import { logger } from "../utils/logger";
 import { DockerSSHClient } from "./docker-ssh";
@@ -91,6 +92,12 @@ export interface DiskNode {
    * reclamation (re-read `df`), or null if the post-read failed.
    */
   reclaim(): Promise<DiskUsage | null>;
+  /**
+   * Prune stale, unused managed-agent image refs for the configured repository.
+   * This runs on a slower cadence than emergency disk reclaim so large nodes do
+   * not silently retain hundreds of GB of superseded runtime images.
+   */
+  pruneStaleAgentImages(command: string): Promise<void>;
 }
 
 export interface NodeDiskCleanupReport {
@@ -102,11 +109,16 @@ export interface NodeDiskCleanupReport {
   pruned: number;
   /** Nodes whose reclamation threw. */
   pruneFailed: number;
+  /** Nodes where the stale managed-agent image prune command ran. */
+  staleAgentImagePruned: number;
+  /** Nodes where stale managed-agent image pruning threw. */
+  staleAgentImagePruneFailed: number;
   /** Per-node detail for observability. */
   details: Array<{
     nodeId: string;
     hostname: string;
     action: DiskActionKind | "read_failed";
+    staleAgentImageAction?: "prune" | "skip_interval" | "failed";
     usedPercentBefore?: number;
     usedPercentAfter?: number;
     reclaimedPercent?: number;
@@ -253,6 +265,64 @@ export function buildReclaimCommand(): string {
   ].join("; ");
 }
 
+function shellSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+export interface StaleAgentImagePruneOptions {
+  repository: string;
+  keepNewest: number;
+  maxAgeHours: number;
+}
+
+/**
+ * Build the narrow stale-image GC command for the managed-agent image repo.
+ *
+ * This does NOT use a broad `docker image prune -a`; it only considers refs in
+ * the configured default-agent repository, preserves image IDs used by any
+ * container, keeps the newest refs as a rollback cushion, and then removes only
+ * refs older than the configured age floor.
+ */
+export function buildStaleAgentImagePruneCommand(options: StaleAgentImagePruneOptions): string {
+  const repository = options.repository.trim();
+  if (repository.length === 0) {
+    throw new Error("stale agent image prune repository is required");
+  }
+
+  const keepNewest = Math.max(1, Math.floor(options.keepNewest));
+  const maxAgeHours = Math.max(1, Math.floor(options.maxAgeHours));
+  const repo = shellSingleQuote(repository);
+
+  return [
+    `repo=${repo}`,
+    `keep_newest=${keepNewest}`,
+    `max_age_hours=${maxAgeHours}`,
+    'cutoff="$(date -u -d "$max_age_hours hours ago" +%s 2>/dev/null || true)"',
+    'if [ -n "$cutoff" ]; then tmp="$(mktemp)"',
+    'active="$(mktemp)"',
+    'trap \'rm -f "$tmp" "$active"\' EXIT',
+    "docker ps -a --format '{{.Image}}' | while IFS= read -r image; do " +
+      '[ -n "$image" ] && docker image inspect --format \'{{.Id}}\' "$image" 2>/dev/null || true; ' +
+      'done | sort -u > "$active"',
+    "docker image ls \"$repo\" --format '{{.Repository}}:{{.Tag}}' | while IFS= read -r ref; do " +
+      'case "$ref" in ""|*"<none>"*) continue;; esac; ' +
+      'id="$(docker image inspect --format \'{{.Id}}\' "$ref" 2>/dev/null || true)"; ' +
+      'created="$(docker image inspect --format \'{{.Created}}\' "$ref" 2>/dev/null || true)"; ' +
+      'created_epoch="$(date -u -d "$created" +%s 2>/dev/null || true)"; ' +
+      '[ -n "$id" ] && [ -n "$created_epoch" ] && printf "%s\\t%s\\t%s\\n" "$created_epoch" "$id" "$ref"; ' +
+      'done | sort -rn > "$tmp"',
+    "n=0",
+    "while IFS=\"$(printf '\\t')\" read -r created_epoch id ref; do " +
+      "n=$((n + 1)); " +
+      '[ "$n" -le "$keep_newest" ] && continue; ' +
+      '[ "$created_epoch" -ge "$cutoff" ] && continue; ' +
+      'grep -qxF "$id" "$active" && continue; ' +
+      'docker image rm -f "$ref" || true; ' +
+      'done < "$tmp"',
+    "fi",
+  ].join("; ");
+}
+
 /** `df -P` for the docker data root — POSIX one-data-line output. */
 function buildDfCommand(): string {
   // /var/lib/docker is the docker data root on the standard node layout; fall
@@ -271,10 +341,12 @@ function buildDfCommand(): string {
  * harmless). Kept module-local so the production wiring and the cycle share it.
  */
 const lastPrunedAtByNode = new Map<string, number>();
+const lastStaleAgentImagePrunedAtByNode = new Map<string, number>();
 
 /** Test seam: reset the in-process cooldown state. */
 export function __resetDiskCooldownStateForTests(): void {
   lastPrunedAtByNode.clear();
+  lastStaleAgentImagePrunedAtByNode.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -284,6 +356,10 @@ export function __resetDiskCooldownStateForTests(): void {
 export interface DiskCleanupConfig {
   pruneThresholdPct: number;
   cooldownMs: number;
+  staleAgentImagePrune?: StaleAgentImagePruneOptions & {
+    intervalMs: number;
+    lastPrunedAt?: Map<string, number>;
+  };
   /** Injected clock for deterministic tests. */
   now?: () => number;
   /**
@@ -304,12 +380,19 @@ export async function cleanupNodeDisks(
 ): Promise<NodeDiskCleanupReport> {
   const now = config.now ?? (() => Date.now());
   const cooldownStore = config.lastPrunedAt ?? lastPrunedAtByNode;
+  const staleImageStore =
+    config.staleAgentImagePrune?.lastPrunedAt ?? lastStaleAgentImagePrunedAtByNode;
+  const staleImageCommand = config.staleAgentImagePrune
+    ? buildStaleAgentImagePruneCommand(config.staleAgentImagePrune)
+    : null;
 
   const report: NodeDiskCleanupReport = {
     nodesScanned: 0,
     nodesSkipped: 0,
     pruned: 0,
     pruneFailed: 0,
+    staleAgentImagePruned: 0,
+    staleAgentImagePruneFailed: 0,
     details: [],
   };
 
@@ -334,13 +417,40 @@ export async function cleanupNodeDisks(
       continue;
     }
     report.nodesScanned += 1;
+    const nodeNow = now();
+    let staleAgentImageAction: "prune" | "skip_interval" | "failed" | undefined;
+
+    if (config.staleAgentImagePrune && staleImageCommand) {
+      const lastStalePrunedAt = staleImageStore.get(node.node_id) ?? null;
+      if (
+        lastStalePrunedAt !== null &&
+        nodeNow - lastStalePrunedAt < config.staleAgentImagePrune.intervalMs
+      ) {
+        staleAgentImageAction = "skip_interval";
+      } else {
+        try {
+          await node.pruneStaleAgentImages(staleImageCommand);
+          staleImageStore.set(node.node_id, nodeNow);
+          report.staleAgentImagePruned += 1;
+          staleAgentImageAction = "prune";
+        } catch (error) {
+          report.staleAgentImagePruneFailed += 1;
+          staleAgentImageAction = "failed";
+          logger.warn("[node-disk-manager] Stale agent image prune failed", {
+            nodeId: node.node_id,
+            hostname: node.hostname,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
 
     const action = decideDiskAction({
       usedPercent: usage.usedPercent,
       pruneThresholdPct: config.pruneThresholdPct,
       lastPrunedAt: cooldownStore.get(node.node_id) ?? null,
       cooldownMs: config.cooldownMs,
-      now: now(),
+      now: nodeNow,
     });
 
     if (action.kind !== "prune") {
@@ -348,6 +458,7 @@ export async function cleanupNodeDisks(
         nodeId: node.node_id,
         hostname: node.hostname,
         action: action.kind,
+        ...(staleAgentImageAction ? { staleAgentImageAction } : {}),
         usedPercentBefore: usage.usedPercent,
       });
       continue;
@@ -362,13 +473,14 @@ export async function cleanupNodeDisks(
 
     try {
       const after = await node.reclaim();
-      cooldownStore.set(node.node_id, now());
+      cooldownStore.set(node.node_id, nodeNow);
       report.pruned += 1;
       const reclaimed = after !== null ? usage.usedPercent - after.usedPercent : undefined;
       report.details.push({
         nodeId: node.node_id,
         hostname: node.hostname,
         action: "prune",
+        ...(staleAgentImageAction ? { staleAgentImageAction } : {}),
         usedPercentBefore: usage.usedPercent,
         ...(after !== null ? { usedPercentAfter: after.usedPercent } : {}),
         ...(reclaimed !== undefined ? { reclaimedPercent: reclaimed } : {}),
@@ -386,6 +498,7 @@ export async function cleanupNodeDisks(
         nodeId: node.node_id,
         hostname: node.hostname,
         action: "prune",
+        ...(staleAgentImageAction ? { staleAgentImageAction } : {}),
         usedPercentBefore: usage.usedPercent,
       });
       logger.warn("[node-disk-manager] Disk reclamation failed", {
@@ -462,6 +575,11 @@ export function buildDiskNode(node: SshNode): DiskNode {
         return null;
       }
     },
+    async pruneStaleAgentImages(command: string): Promise<void> {
+      const client = ssh();
+      await client.connect();
+      await client.exec(command, RECLAIM_TIMEOUT_MS);
+    },
   };
 }
 
@@ -490,5 +608,11 @@ export async function processNodeDiskCleanup(): Promise<NodeDiskCleanupReport> {
   return cleanupNodeDisks(diskNodes, {
     pruneThresholdPct: containersEnv.nodeDiskPruneThresholdPct(),
     cooldownMs: containersEnv.nodeDiskPruneCooldownMs(),
+    staleAgentImagePrune: {
+      repository: imageRepo(containersEnv.defaultAgentImage()),
+      keepNewest: containersEnv.nodeDiskAgentImagePruneKeepNewest(),
+      maxAgeHours: containersEnv.nodeDiskAgentImagePruneMaxAgeHours(),
+      intervalMs: containersEnv.nodeDiskAgentImagePruneIntervalMs(),
+    },
   });
 }


### PR DESCRIPTION
## Summary
- add a separate managed-agent image GC cadence to the node disk manager so large nodes shed superseded `ghcr.io/elizaos/eliza` refs before crossing the emergency disk threshold
- preserve active container image IDs, keep the newest refs for rollback, enforce an age floor, and continue to omit Docker volumes
- add env knobs for stale image prune interval, keep-newest, and max-age, with focused coverage
- route existing cloud-shared DB test mocks through `unknown` so affected cloud-api typecheck accepts the broader test files CI pulls in

Addresses the fleet-wide stale agent-image accumulation leg of #15398. The GitHub runner workspace and `/tmp/eliza-artifacts-*.tar.gz` cleanup policy in that issue remains separate ops work.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - backend-only cloud disk manager change; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - backend-only cloud disk manager change; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - backend-only scheduled node maintenance path; no user-facing UI workflow changed.

<!-- evidence-row:backend-logs -->
- [x] Backend logs/checks: [PR checks](https://github.com/elizaOS/eliza/pull/15496/checks) plus local backend validation listed below. Live SSH node cleanup was not run from this branch because the command is destructive on production nodes; the generated command is covered by unit tests and a Bash parser check.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend, browser, app, or network client behavior changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent prompt, provider, model call, or trajectory behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [PR file diff](https://github.com/elizaOS/eliza/pull/15496/files). Domain artifact is the generated stale-agent-image prune command: it targets only the configured managed-agent image repo, preserves active image IDs, keeps rollback refs, enforces age floor, and passes `bash -n`.

## Validation
- `bunx @biomejs/biome check --write packages/cloud/shared/src/lib/services/node-disk-manager.ts packages/cloud/shared/src/lib/services/node-disk-manager.test.ts packages/cloud/shared/src/lib/config/containers-env.ts packages/cloud/shared/src/lib/config/containers-env-disk.test.ts`
- `bun test --coverage-reporter=lcov packages/cloud/shared/src/lib/services/node-disk-manager.test.ts packages/cloud/shared/src/lib/config/containers-env-disk.test.ts`
- `bun -e "import { buildStaleAgentImagePruneCommand } from './packages/cloud/shared/src/lib/services/node-disk-manager.ts'; const cmd = buildStaleAgentImagePruneCommand({repository:'ghcr.io/elizaos/eliza', keepNewest:2, maxAgeHours:168}); const proc = Bun.spawnSync(['bash','-n','-c',cmd], {stdout:'pipe', stderr:'pipe'}); if (proc.exitCode !== 0) { console.error(proc.stderr.toString()); process.exit(proc.exitCode ?? 1); } console.log('bash syntax ok');"`
- `bun run --cwd packages/cloud/shared typecheck`
- `bun run --cwd packages/cloud/api typecheck`
- `DATABASE_URL=pglite://memory TEST_DATABASE_URL=pglite://memory SKIP_DB_DEPENDENT=1 SKIP_SERVER_CHECK=true bun test /Users/shawwalters/eliza-workspace/milady/eliza/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts --timeout 120000 --isolate`
- `bun test --coverage-reporter=lcov packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts packages/cloud/shared/src/db/repositories/shared-runtime-history.test.ts packages/cloud/shared/src/lib/services/node-disk-manager.test.ts packages/cloud/shared/src/lib/config/containers-env-disk.test.ts`
- `git diff --check`

