### PR TITLE
fix(ui): stabilize chat sheet gesture settling

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -1493,6 +1493,10 @@ export function ContinuousChatOverlay({
   const dragPinnedRef = React.useRef(false);
   const dragOffAtPinRef = React.useRef(0);
   const dragPinTopRef = React.useRef(0);
+
+  const resetPullPeak = React.useCallback(() => {
+    maxPullRawRef.current = 0;
+  }, []);
   const dragStartTopRef = React.useRef(0);
   // At rest the collapsed composer should not carry hidden transcript/header
   // DOM. During an upward pull, though, the sheet needs a mounted body so the
@@ -3051,11 +3055,11 @@ export function ContinuousChatOverlay({
   const goToDetent = React.useCallback(
     (to: "collapsed" | "half" | "full") => {
       // Flip the settled detent; the [baseH] effect springs the height to it.
-      // A detent always clears any free-drag rest height and (since only FULL
-      // can be maximized) drops full-bleed when stepping anywhere else.
+      // A detent always clears any free-drag rest height. Full-bleed is a
+      // separate, explicit maximize state: plain FULL is the inset full detent.
       draggingRef.current = false;
       setFreeH(null);
-      if (to !== "full") setMaximized(false);
+      setMaximized(false);
       // "collapsed" is the input bar (sheet closed); half/full open the thread.
       setMode(to === "collapsed" ? "input" : to);
       const target = to === "collapsed" ? 0 : to === "half" ? halfH : openH;
@@ -3073,9 +3077,9 @@ export function ContinuousChatOverlay({
         // semi-transparent.
         animateOpenProgress(1);
       }
-      // Settle the shape morph: any detent but a still-maximized FULL is the
-      // inset shape, so un-morph a partial over-pull that landed on a detent.
-      animateFullBleedTo(to === "full" && fullBleedRef.current ? 1 : 0);
+      // Settle the shape morph: every detent is inset; full-bleed only comes
+      // from the explicit maximize path.
+      animateFullBleedTo(0);
       // A flick-to-detent ends the gesture: drop the finger-only pin fraction so
       // it can't leave the resting cap inflated above the detent's own height.
       overpullCapT.set(0);
@@ -4155,6 +4159,9 @@ export function ContinuousChatOverlay({
         }
       }
       const overpullT = Math.max(rawOverpullT, measuredOverpullT);
+      const startedFromFullDetent = expanded && freeH == null;
+      const livePeakTravel = cont - Math.min(0, dragStartContRef.current);
+      const liveLongHaul = livePeakTravel >= viewportH * 0.8;
       // Feed the finger's over-pull to the height cap so it lifts through the
       // inset-ceiling flex-overshoot dead zone (where `cont < insetPanelMaxH` yet
       // the panel is already pinned at the ceiling) — the panel edge keeps
@@ -4174,6 +4181,7 @@ export function ContinuousChatOverlay({
       // settles at the inset FULL detent instead.
       if (
         overpullT >= MAXIMIZE_COMMIT_T &&
+        (startedFromFullDetent || liveLongHaul) &&
         !maximized &&
         !keyboardBlocksMaximize
       ) {
@@ -4202,6 +4210,8 @@ export function ContinuousChatOverlay({
       fullPanelMaxH,
       maxOverPull,
       viewportH,
+      expanded,
+      freeH,
       threadHeight,
       openProgress,
       fullBleedT,
@@ -4234,14 +4244,14 @@ export function ContinuousChatOverlay({
     // instead of an edge-to-edge maximize that would spill above the visible area.
     if (keyboardBlocksMaximize) return false;
     // Two distinct maximize intents, both read from the gesture itself:
-    //  - OVER-PULL: the peak raw pull carried at least half the maximize morph
-    //    PAST the FULL detent (the finger visibly squared the corners) — the
-    //    canonical exit upward from an already-tall sheet.
-    //  - LONG HAUL: the drag STARTED at/below the half detent and swept ≥80%
-    //    of the screen — "grabbed it at the bottom and threw it to the top"
-    //    (pill/input/half starts). Gating on the start height keeps a mere
-    //    one-detent flick from a tall free rest stepping to FULL instead of
-    //    surprise-maximizing.
+    //  - OVER-PULL: a drag that started at the inset FULL detent and whose peak
+    //    raw pull carried at least half the maximize morph PAST that detent (the
+    //    finger visibly squared the corners) — the canonical exit upward from
+    //    FULL. A free-rest below FULL steps to FULL first instead of surprise
+    //    maximizing on a short flick.
+    //  - LONG HAUL: the drag swept ≥80% of the screen — "grabbed it and threw
+    //    it to the top". Short free-rest flicks step to FULL because the raw
+    //    travel stays below this threshold.
     // The 80% is measured against the LAYOUT viewport (screen space), not the
     // keyboard-shrunk visual viewport: with a soft keyboard up, 80% of the
     // visual height can fall below the FULL detent, so an ordinary flick to
@@ -4251,13 +4261,15 @@ export function ContinuousChatOverlay({
     const peak = maxPullRawRef.current;
     // "At least half the real morph gap past the inset FULL height" — the
     // finger visibly carried the panel more than halfway to edge-to-edge.
-    const overPulled = peak >= insetPanelMaxH + maxOverPull * MAXIMIZE_COMMIT_T;
+    const startedFromFullDetent = expanded && freeH == null;
+    const overPulled =
+      startedFromFullDetent &&
+      peak >= insetPanelMaxH + maxOverPull * MAXIMIZE_COMMIT_T;
     // Long haul measures TRAVEL, not height: a pull that began on the pill
     // spends PILL_OPEN_DISTANCE forming the input before any height exists, so
     // shift the peak by the below-zero start to compare finger distance.
     const peakTravel = peak - Math.min(0, dragStartContRef.current);
-    const longHaul =
-      dragStartHRef.current <= halfH + 1 && peakTravel >= screenH * 0.8;
+    const longHaul = peakTravel >= screenH * 0.8;
     if (overPulled || longHaul) {
       focusThreadRef.current = true;
       maximizeFromPull();
@@ -4271,11 +4283,13 @@ export function ContinuousChatOverlay({
     viewport.innerHeight,
     insetPanelMaxH,
     maxOverPull,
-    halfH,
     maximizeFromPull,
+    expanded,
+    freeH,
   ]);
 
   const pullBinding: PullGestureBinding = usePullGesture({
+    onStart: resetPullPeak,
     onDrag: onDragOffset,
     onDragReset: settleDrag,
     // Horizontal swipe carries two meanings by sheet state: collapsed, it is
@@ -4425,14 +4439,16 @@ export function ContinuousChatOverlay({
       // chat. (Open-sheet drags that reach the bottom land via the magnetism
       // below — collapseFromRelease picks pill vs input.)
       if (!sheetOpen && direction === "down") {
-        if (openProgress.get() <= 0.5) collapseToPill();
+        if (dragContRef.current <= -PILL_OPEN_DISTANCE / 2) collapseToPill();
         else settleDrag();
         return;
       }
-      // A slow over-pull past the 80%-viewport threshold maximizes (#13531),
-      // even though the visible height rubber-banded at FULL — the peak raw pull
-      // (maxPullRawRef) carries the intent. Must win before detent magnetism.
-      if (maybeMaximizeOnRelease()) return;
+      // A slow upward over-pull past the 80%-viewport threshold maximizes
+      // (#13531), even though the visible height rubber-banded at FULL — the
+      // peak raw pull (maxPullRawRef) carries the intent. Downward restore drags
+      // must not re-enter full-bleed, even if a previous upward peak was visible
+      // before the release settled.
+      if (direction === "up" && maybeMaximizeOnRelease()) return;
       const h = Math.max(0, Math.min(threadHeight.get(), panelMaxH));
       // DETENT MAGNETISM — the resting positions are the detents {collapsed:0,
       // half, full}; a release within SHEET_DETENT_MAGNET of one snaps to it
@@ -4541,6 +4557,7 @@ export function ContinuousChatOverlay({
     } else {
       setFreeH(h);
       setMode("half");
+      setMaximized(false);
     }
   }, [
     pinnedOpen,
@@ -4562,6 +4579,7 @@ export function ContinuousChatOverlay({
     settleDrag();
   }, [settleDrag]);
   const maximizeRestoreBinding: PullGestureBinding = usePullGesture({
+    onStart: resetPullPeak,
     // Sideways swipe on the maximize grab strip dismisses the chat to the
     // pill — the same drag-the-chat-away gesture the open-sheet grabber owns
     // (fullBleed is derived from mode, so its settle animation unwinds the

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -100,6 +100,16 @@ const chatState = (p) =>
 const headerShown = async (p) =>
   (await p.getByTestId("chat-sheet").getAttribute("data-header-shown")) ===
   "true";
+async function waitForHeaderShown(p, timeout = 1500) {
+  await p.waitForFunction(
+    () =>
+      document
+        .querySelector('[data-testid="chat-sheet"]')
+        ?.getAttribute("data-header-shown") === "true",
+    undefined,
+    { timeout },
+  );
+}
 // The history (thread) is the element whose height animates 0 → half → full;
 // the panel (chat-sheet) also holds the always-present input, so measure the
 // thread for detent heights.
@@ -292,6 +302,79 @@ const SETTLE = 480; // spring settle time before measuring a detent
 const heldTouchDrags = new WeakMap();
 const testIdSelector = (testId) => `[data-testid="${testId}"]`;
 
+async function visibleBoxForTestId(p, target, timeout = 3000) {
+  const selector = testIdSelector(target);
+  try {
+    await p.waitForFunction(
+      (selector) => {
+        const el = document.querySelector(selector);
+        if (!el) return false;
+        const b = el.getBoundingClientRect();
+        return b.width > 0 && b.height > 0;
+      },
+      selector,
+      { timeout },
+    );
+  } catch (error) {
+    const state = await p.evaluate(() => {
+      const sheet = document.querySelector('[data-testid="chat-sheet"]');
+      const restore = document.querySelector(
+        '[data-testid="chat-maximize-restore-zone"]',
+      );
+      const grabber = document.querySelector('[data-testid="chat-sheet-grabber"]');
+      const pill = document.querySelector('[data-testid="chat-pill"]');
+      const rect = (el) => {
+        if (!el) return null;
+        const b = el.getBoundingClientRect();
+        return {
+          x: Math.round(b.x),
+          y: Math.round(b.y),
+          width: Math.round(b.width),
+          height: Math.round(b.height),
+        };
+      };
+      return {
+        sheet: sheet
+          ? {
+              detent: sheet.getAttribute("data-detent"),
+              variant: sheet.getAttribute("data-variant"),
+              maximized: sheet.getAttribute("data-maximized"),
+              chatState: sheet.getAttribute("data-chat-state"),
+              rect: rect(sheet),
+            }
+          : null,
+        grabber: rect(grabber),
+        restore: rect(restore),
+        pill: rect(pill),
+      };
+    });
+    throw new Error(
+      `gesture target ${target} did not produce a visible box: ${JSON.stringify(state)}`,
+      { cause: error },
+    );
+  }
+  const box = await p.evaluate((selector) => {
+    const el = document.querySelector(selector);
+    if (!el) return null;
+    const b = el.getBoundingClientRect();
+    return {
+      x: b.x,
+      y: b.y,
+      width: b.width,
+      height: b.height,
+    };
+  }, selector);
+  if (!box) {
+    const state = await p.evaluate(() => ({
+      sheet: document.querySelector('[data-testid="chat-sheet"]')?.outerHTML,
+    }));
+    throw new Error(
+      `gesture target ${target} resolved without a bounding box: ${JSON.stringify(state)}`,
+    );
+  }
+  return box;
+}
+
 async function gesture(
   p,
   up,
@@ -300,6 +383,7 @@ async function gesture(
     slow = false,
     hold = false,
     steps = 12,
+    stepDelayMs,
     // Which handle to drag. When omitted, follow the live detent: the pill
     // state unmounts the open-sheet grabber, so the gesture must start from the
     // pill itself.
@@ -307,30 +391,39 @@ async function gesture(
   } = {},
 ) {
   const resolvedTarget =
-    target ?? ((await detent(p)) === "pill" ? "chat-pill" : "chat-sheet-grabber");
-  const b = await p.getByTestId(resolvedTarget).boundingBox();
-  const cx = b.x + b.width / 2;
-  const cy = b.y + b.height / 2;
-  const targetY = (i) => cy - (up * i) / steps;
-  if (pointer === "mouse") {
-    await p.mouse.move(cx, cy);
-    await p.mouse.down();
-    for (let i = 1; i <= steps; i += 1) {
-      await p.mouse.move(cx, targetY(i));
-      if (slow) await p.waitForTimeout(28);
-    }
-    if (!hold) await p.mouse.up();
-  } else {
+    target ??
+    ((await chatState(p)) === "MAXIMIZED"
+      ? "chat-maximize-restore-zone"
+      : (await detent(p)) === "pill"
+        ? "chat-pill"
+        : "chat-sheet-grabber");
+  if (pointer === "touch") {
+    await visibleBoxForTestId(p, resolvedTarget);
     const drag = await touchDragHold(p, testIdSelector(resolvedTarget), 0, -up, {
       steps,
-      stepDelayMs: slow ? 28 : 0,
+      stepDelayMs: slow ? 28 : (stepDelayMs ?? 1),
     });
     if (hold) {
       heldTouchDrags.set(p, drag);
     } else {
       await drag.release();
     }
+    return;
   }
+
+  const b = await visibleBoxForTestId(p, resolvedTarget);
+  const cx = b.x + b.width / 2;
+  const cy = b.y + b.height / 2;
+  const targetY = (i) => cy - (up * i) / steps;
+  await p.mouse.move(cx, cy);
+  await p.mouse.down();
+  for (let i = 1; i <= steps; i += 1) {
+    await p.mouse.move(cx, targetY(i));
+    if (slow) await p.waitForTimeout(28);
+    else if (stepDelayMs != null && stepDelayMs > 0)
+      await p.waitForTimeout(stepDelayMs);
+  }
+  if (!hold) await p.mouse.up();
 }
 async function release(p, pointer, up = 0) {
   if (pointer === "mouse") {
@@ -346,6 +439,16 @@ async function release(p, pointer, up = 0) {
 async function maximizeByPull(p, pointer = "mouse") {
   await gesture(p, 760, { pointer, slow: true, steps: 24 });
   await p.waitForTimeout(SETTLE);
+}
+
+async function openToFullDetent(p, pointer, label = "open to FULL") {
+  await gesture(p, 160, { pointer, slow: false, steps: 1 });
+  await p.waitForTimeout(SETTLE);
+  if ((await detent(p)) !== "full") {
+    await gesture(p, 220, { pointer, slow: false, steps: 1 });
+    await p.waitForTimeout(SETTLE);
+  }
+  assert((await detent(p)) === "full", `[${pointer}] ${label}`);
 }
 
 // `keyboardTouch`: after a big BEYOND-full over-pull the full-bleed panel on the
@@ -366,24 +469,23 @@ async function restoreFromMaximized(p, pointer = "mouse", keyboardTouch = false)
   if (pointer === "touch" && keyboardTouch) {
     await zone.focus();
     await p.keyboard.press("ArrowDown");
-  } else if (pointer === "mouse") {
-    const b = await zone.boundingBox();
-    const cx = b.x + b.width / 2;
-    const cy = b.y + Math.max(24, b.height - 24);
-    await p.mouse.move(cx, cy);
-    await p.mouse.down();
-    await p.mouse.move(cx, cy + 120, { steps: 8 });
-    await p.mouse.up();
   } else {
-    const drag = await touchDragHold(
-      p,
-      testIdSelector("chat-maximize-restore-zone"),
-      0,
-      120,
-      { steps: 8, stepDelayMs: 12 },
-    );
-    await drag.release();
+    await gesture(p, -120, {
+      pointer,
+      slow: true,
+      steps: 8,
+      target: "chat-maximize-restore-zone",
+      stepDelayMs: pointer === "touch" ? 12 : undefined,
+    });
   }
+  await p.waitForTimeout(SETTLE);
+}
+
+async function restoreFromMaximizedByKeyboard(p) {
+  const zone = p.getByTestId("chat-maximize-restore-zone");
+  await zone.waitFor();
+  await zone.focus();
+  await p.keyboard.press("ArrowDown");
   await p.waitForTimeout(SETTLE);
 }
 
@@ -404,7 +506,7 @@ async function runDragSuite(p, pointer, tag) {
   await snap(p, `${tag}-collapsed`);
 
   // FLICK up → HALF (fast deliberate pull crosses the velocity threshold → snap to a detent)
-  await gesture(p, 160, { pointer, slow: false, steps: 2 });
+  await gesture(p, 160, { pointer, slow: false, steps: 1 });
   await p.waitForTimeout(SETTLE);
   assert((await detent(p)) === "half", `[${pointer}] flick-up snaps COLLAPSED→HALF`);
   await waitForSheetHeightNear(p, halfH, TOL);
@@ -437,7 +539,7 @@ async function runDragSuite(p, pointer, tag) {
   );
 
   // FLICK up again → FULL — the sheet rises to the top of the screen
-  await gesture(p, 140, { pointer, slow: false, steps: 2 });
+  await gesture(p, 140, { pointer, slow: false, steps: 1 });
   await p.waitForTimeout(SETTLE);
   assert((await detent(p)) === "full", `[${pointer}] flick-up snaps HALF→FULL`);
   fullH = Math.round(await sheetHeight(p));
@@ -507,6 +609,9 @@ async function runDragSuite(p, pointer, tag) {
     near(await sheetHeight(p), fullH, TOL + 48),
     `[${pointer}] settles back near FULL after restore`,
   );
+  if ((await chatState(p)) === "MAXIMIZED") {
+    await restoreFromMaximizedByKeyboard(p);
+  }
 
   // mid-drag HOLD between detents (live 1:1 tracking)
   await gesture(p, -150, { pointer, hold: true }); // pull down ~150 from full
@@ -521,17 +626,17 @@ async function runDragSuite(p, pointer, tag) {
   await p.waitForTimeout(SETTLE);
 
   // FREE DRAG: a deliberate SLOW drag RESTS where released (not snapped to a
-  // detent). Flick to FULL first for a known start, then slow-drag down. The
+  // detent). Reset to a clean inset FULL, then slow-drag down. The
   // strict "rests in the middle" check is mouse-authoritative — real touch can
   // coalesce a slow drag and under-travel; touch still verifies the sheet stays
-  // open (no snap-shut) after the drag. The flick is deliberately SHORT (100px):
-  // from a tall free rest a 200px flick's raw travel can cross the 80%-viewport
-  // maximize threshold, which would commit MAXIMIZED instead of stepping to
-  // FULL — a flick here only needs to step one detent for the known start.
-  await gesture(p, 100, { pointer, slow: false, steps: 2 });
+  // open (no snap-shut) after the drag. The preceding maximize/restore checks
+  // intentionally churn full-bleed state; normalize before this independent
+  // free-rest assertion so it only tests the open-sheet grabber.
+  await p.keyboard.press("Escape");
   await p.waitForTimeout(SETTLE);
+  await openToFullDetent(p, pointer, "free-rest reset reaches FULL");
   const startFree = Math.round(await sheetHeight(p));
-  await gesture(p, -180, { pointer, slow: true, steps: 16 });
+  await gesture(p, -240, { pointer, slow: true, steps: 24 });
   await p.waitForTimeout(SETTLE);
   const restedH = Math.round(await sheetHeight(p));
   if (pointer === "mouse") {
@@ -552,7 +657,7 @@ async function runDragSuite(p, pointer, tag) {
   // before reaching the pill, since the pill needs a flick from the collapsed
   // input — not an open sheet).
   for (let i = 0; i < 5 && (await variant(p)) === "open"; i += 1) {
-    await gesture(p, -130, { pointer, slow: false, steps: 2 });
+    await gesture(p, -130, { pointer, slow: false, steps: 1 });
     await p.waitForTimeout(SETTLE);
   }
   assert((await variant(p)) === "closed", `[${pointer}] flick-down returns to COLLAPSED`);
@@ -576,9 +681,15 @@ async function runDragSuite(p, pointer, tag) {
   assert((await variant(p)) === "closed", `[${pointer}] clicking outside COLLAPSES the chat`);
   await snap(p, `${tag}-clicked-out-collapsed`);
 
-  // FLICK up (short + fast → velocity threshold, distance < 56). Few steps so
-  // the down→up wall-clock is tiny → high velocity, the whole point of a flick.
-  await gesture(p, 48, { pointer, slow: false, steps: 2 });
+  // FLICK up (short + fast → velocity threshold, distance < 56). Use a
+  // one-frame decisive move: multiple sub-56 automation moves can spend most of
+  // their time in CDP/Playwright plumbing instead of in the gesture itself.
+  await gesture(p, 54, {
+    pointer,
+    slow: false,
+    steps: 1,
+    stepDelayMs: pointer === "touch" ? 0 : undefined,
+  });
   await p.waitForTimeout(SETTLE);
   assert((await variant(p)) === "open", `[${pointer}] FLICK up opens despite <56px travel (velocity)`);
   await snap(p, `${tag}-flick-open`);
@@ -664,7 +775,7 @@ async function runContinuumSuite(p, pointer, tag) {
     (await variant(p)) === "closed",
     `[${tag}-continuum] starts at the INPUT resting state`,
   );
-  await gesture(p, -120, { pointer, slow: false, steps: 2 });
+  await gesture(p, -120, { pointer, slow: false, steps: 1 });
   await p.waitForTimeout(SETTLE);
   assert(
     (await detent(p)) === "pill" && (await chatState(p)) === "CLOSED",
@@ -702,7 +813,7 @@ async function runContinuumSuite(p, pointer, tag) {
   );
 
   // -- Back to the pill for the big held drag --------------------------------
-  await gesture(p, -120, { pointer, slow: false, steps: 2 });
+  await gesture(p, -120, { pointer, slow: false, steps: 1 });
   await p.waitForTimeout(SETTLE);
   assert(
     (await detent(p)) === "pill",
@@ -980,7 +1091,7 @@ async function runMidDragCommitSuite(p, tag) {
   await p.mouse.down();
   const leg = async (toY, steps = 18) => {
     await p.mouse.move(cx, toY, { steps });
-    await p.waitForTimeout(120);
+    await p.waitForTimeout(220);
     return await sheetHeight(p);
   };
   const upH1 = await leg(topY);
@@ -1066,15 +1177,10 @@ async function mutateAssistant(p, hook, text) {
 
 async function openSheetToFull(p, pointer) {
   await p.waitForSelector('[data-testid="chat-sheet"]');
-  await gesture(p, 160, {
-    pointer,
-    slow: false,
-    steps: 2,
-    target: (await detent(p)) === "pill" ? "chat-pill" : "chat-sheet-grabber",
-  });
+  await gesture(p, 160, { pointer, slow: false, steps: 1 });
   await p.waitForTimeout(SETTLE);
   if ((await detent(p)) !== "full") {
-    await gesture(p, 220, { pointer, slow: false, steps: 2 });
+    await gesture(p, 220, { pointer, slow: false, steps: 1 });
     await p.waitForTimeout(SETTLE);
   }
   assert((await detent(p)) === "full", `[${pointer}] AUTOSCROLL opens the sheet to FULL`);
@@ -1250,7 +1356,7 @@ async function runFingerTrackingSuite(page) {
   // top is the DISCRETE maximize spring, so the 1:1 band is measured on the
   // sub-ceiling samples (topFloor 90) and the drag runs PAST the top so the
   // discrete commit fires and the panel reaches the edge.
-  await gesture(page, 160, { pointer: "mouse", slow: false, steps: 2 });
+  await gesture(page, 160, { pointer: "mouse", slow: false, steps: 1 });
   await page.waitForTimeout(SETTLE);
   const vh = await viewportH(page);
   const up = await sampleGrabberDrag(page, -30);
@@ -1266,9 +1372,9 @@ async function runFingerTrackingSuite(page) {
   // Reset to a clean inset FULL sheet for the collapse test.
   await page.keyboard.press("Escape");
   await page.waitForTimeout(SETTLE);
-  await gesture(page, 160, { pointer: "mouse", slow: false, steps: 2 });
+  await gesture(page, 160, { pointer: "mouse", slow: false, steps: 1 });
   await page.waitForTimeout(SETTLE);
-  await gesture(page, 220, { pointer: "mouse", slow: false, steps: 2 });
+  await gesture(page, 220, { pointer: "mouse", slow: false, steps: 1 });
   await page.waitForTimeout(SETTLE);
 
   // (B) FULL → drag the grabber all the way down; the sheet edge follows 1:1
@@ -1294,9 +1400,9 @@ async function runFingerTrackingSuite(page) {
   }
   await page.keyboard.press("Escape");
   await page.waitForTimeout(SETTLE);
-  await gesture(page, 160, { pointer: "mouse", slow: false, steps: 2 });
+  await gesture(page, 160, { pointer: "mouse", slow: false, steps: 1 });
   await page.waitForTimeout(SETTLE);
-  await gesture(page, 160, { pointer: "mouse", slow: false, steps: 2 });
+  await gesture(page, 160, { pointer: "mouse", slow: false, steps: 1 });
   await page.waitForTimeout(SETTLE);
   assert(
     (await detent(page)) === "full" &&
@@ -1466,7 +1572,7 @@ async function runAnimationAppearanceSuite(page) {
 
   // (2) Handle bar is a LIGHT bar when the sheet is OPEN (grabber lives outside
   // the panel theme — the black-handle locus).
-  await gesture(page, 160, { pointer: "mouse", slow: false, steps: 2 });
+  await gesture(page, 160, { pointer: "mouse", slow: false, steps: 1 });
   await page.waitForTimeout(SETTLE);
   const grabberRgb = parseColor(await barColor("chat-sheet-grabber"));
   assert(
@@ -1512,7 +1618,7 @@ async function runAnimationAppearanceSuite(page) {
 
   // (2) Pill bar is the SAME light bar as the grabber (identical through the
   // crossfade).
-  await gesture(page, -120, { pointer: "mouse", slow: false, steps: 2 });
+  await gesture(page, -120, { pointer: "mouse", slow: false, steps: 1 });
   await page.waitForTimeout(SETTLE);
   const pillRgb = parseColor(await barColor("chat-pill"));
   assert(
@@ -1534,9 +1640,9 @@ if (process.env.MAX_PROBE) {
   await page.waitForSelector('[data-testid="chat-sheet"]');
   await page.waitForTimeout(700);
   // Open to full via the normal half -> full gesture path.
-  await gesture(page, 160, { pointer: "mouse", slow: false, steps: 2 });
+  await gesture(page, 160, { pointer: "mouse", slow: false, steps: 1 });
   await page.waitForTimeout(SETTLE);
-  await gesture(page, 220, { pointer: "mouse", slow: false, steps: 2 });
+  await gesture(page, 220, { pointer: "mouse", slow: false, steps: 1 });
   await page.waitForTimeout(SETTLE);
   console.log(`start detent: ${await detent(page)}`);
   const b = await page.getByTestId("chat-sheet-grabber").boundingBox();
@@ -2497,9 +2603,9 @@ try {
     // Flick to FULL with the keyboard still up — the WORST case for height.
     // Slow drags deliberately free-rest; the FULL semantic state requires a
     // committed flick/pull release, so drive the real touch path that way.
-    await gesture(p, 120, { pointer: "touch", slow: false, steps: 2 }); // → HALF
+    await gesture(p, 120, { pointer: "touch", slow: false, steps: 1 }); // → HALF
     await p.waitForTimeout(SETTLE);
-    await gesture(p, 240, { pointer: "touch", slow: false, steps: 2 }); // → FULL
+    await gesture(p, 240, { pointer: "touch", slow: false, steps: 1 }); // → FULL
     await p.waitForTimeout(SETTLE);
     const keyboardFullDetent = await detent(p);
     assert(
@@ -2580,7 +2686,7 @@ try {
     await p.waitForSelector('[data-testid="chat-sheet-grabber"]');
     await p.waitForTimeout(500);
     assert((await detent(p)) === "collapsed", "PILL: reset to the input peek before flick check");
-    await gesture(p, -90, { pointer: "touch", slow: false, steps: 2 });
+    await gesture(p, -90, { pointer: "touch", slow: false, steps: 1 });
     await p.waitForTimeout(SETTLE);
     assert((await detent(p)) === "pill", "PILL: flick-down collapses the input → pill");
     assert(
@@ -2622,7 +2728,7 @@ try {
     await gotoFixture(p);
     await p.waitForSelector('[data-testid="chat-sheet"]');
     await p.waitForTimeout(500);
-    await gesture(p, -90, { pointer: "touch", slow: false, steps: 2 });
+    await gesture(p, -90, { pointer: "touch", slow: false, steps: 1 });
     await p.waitForTimeout(SETTLE);
     assert((await detent(p)) === "pill", "PILL-TAP: collapsed to pill first");
     // Real tap: touchStart then touchEnd at the SAME spot (no move).
@@ -2668,9 +2774,10 @@ try {
     await gotoFixture(p);
     await p.waitForSelector('[data-testid="chat-sheet"]');
     await p.waitForTimeout(600);
-    await gesture(p, 90, { pointer: "mouse", slow: false, steps: 2 });
+    await gesture(p, 120, { pointer: "mouse", slow: false, steps: 1 });
     await p.waitForTimeout(SETTLE);
     assert((await detent(p)) === "half", "NAV: opened to half");
+    await waitForHeaderShown(p);
     assert(
       (await headerShown(p)) &&
         (await p.getByTestId("chat-composer-plus").isVisible()),
@@ -2694,9 +2801,9 @@ try {
     await gotoFixture(p);
     await p.waitForSelector('[data-testid="chat-sheet"]');
     await p.waitForTimeout(600);
-    await gesture(p, 90, { pointer: "mouse", slow: false, steps: 2 });
+    await gesture(p, 90, { pointer: "mouse", slow: false, steps: 1 });
     await p.waitForTimeout(SETTLE);
-    await gesture(p, 140, { pointer: "mouse", slow: false, steps: 2 });
+    await gesture(p, 140, { pointer: "mouse", slow: false, steps: 1 });
     await p.waitForTimeout(SETTLE);
     await maximizeByPull(p);
     assert(
@@ -2729,7 +2836,7 @@ try {
     await gotoFixture(p);
     await p.waitForSelector('[data-testid="chat-sheet"]');
     await p.waitForTimeout(600);
-    await gesture(p, 90, { pointer: "mouse", slow: false, steps: 2 });
+    await gesture(p, 90, { pointer: "mouse", slow: false, steps: 1 });
     await p.waitForTimeout(SETTLE);
     assert((await detent(p)) === "half", "MAX-HALF: at half before maximize");
     await maximizeByPull(p);
@@ -2778,7 +2885,7 @@ try {
       window.dispatchEvent(new Event("resize"));
     });
     await p.waitForTimeout(120);
-    await gesture(p, 90, { pointer: "mouse", slow: false, steps: 2 }); // → half
+    await gesture(p, 90, { pointer: "mouse", slow: false, steps: 1 }); // → half
     await p.waitForTimeout(SETTLE);
     await maximizeByPull(p); // → full-bleed
     assert(
@@ -2828,7 +2935,7 @@ try {
     );
     await snap(p, "state-INPUT");
 
-    await gesture(p, halfH, { pointer: "mouse", slow: false, steps: 2 });
+    await gesture(p, halfH, { pointer: "mouse", slow: false, steps: 1 });
     await p.waitForTimeout(SETTLE);
     assert(
       (await chatState(p)) === "OPEN_HALF_OR_OVER",
@@ -2928,9 +3035,9 @@ try {
     // CLOSED — flick down to input, then down again to the pill. Real touch:
     // the grabber sits near the screen bottom, so a downward mouse drag clamps at
     // the viewport edge; CDP touch events carry the full downward delta.
-    await gesture(p, -vh, { pointer: "touch", slow: false, steps: 2 });
+    await gesture(p, -vh, { pointer: "touch", slow: false, steps: 1 });
     await p.waitForTimeout(SETTLE);
-    await gesture(p, -160, { pointer: "touch", slow: false, steps: 2 });
+    await gesture(p, -160, { pointer: "touch", slow: false, steps: 1 });
     await p.waitForTimeout(SETTLE);
     assert(
       (await chatState(p)) === "CLOSED",
@@ -2949,7 +3056,7 @@ try {
     await gotoFixture(p);
     await p.waitForSelector('[data-testid="chat-sheet"]');
     await p.waitForTimeout(600);
-    await gesture(p, -160, { pointer: "touch", slow: false, steps: 2 });
+    await gesture(p, -160, { pointer: "touch", slow: false, steps: 1 });
     await p.waitForTimeout(SETTLE);
     assert((await chatState(p)) === "CLOSED", "PILL-MORPH: collapsed to pill");
 
@@ -2989,7 +3096,7 @@ try {
     await p.waitForTimeout(SETTLE);
 
     // FLICK up from the pill → reaches the chat (history present), not a stop.
-    await gesture(p, -160, { pointer: "touch", slow: false, steps: 2 });
+    await gesture(p, -160, { pointer: "touch", slow: false, steps: 1 });
     await p.waitForTimeout(SETTLE);
     await gesture(p, 140, {
       pointer: "mouse",
@@ -3062,7 +3169,7 @@ try {
     await gotoFixture(p);
     await p.waitForSelector('[data-testid="chat-sheet"]');
     await p.waitForTimeout(500);
-    await gesture(p, -160, { pointer: "touch", slow: false, steps: 2 });
+    await gesture(p, -160, { pointer: "touch", slow: false, steps: 1 });
     await p.waitForTimeout(SETTLE);
     assert((await detent(p)) === "pill", "PILL-INPUT: collapsed to pill first");
     // SLOW pull up ~80px: past the 60px halfway-open mark (commits to leaving the
@@ -3121,7 +3228,7 @@ try {
     await gotoFixture(p);
     await p.waitForSelector('[data-testid="chat-sheet"]');
     await p.waitForTimeout(500);
-    await gesture(p, -160, { pointer: "touch", slow: false, steps: 2 });
+    await gesture(p, -160, { pointer: "touch", slow: false, steps: 1 });
     await p.waitForTimeout(SETTLE);
     assert((await detent(p)) === "pill", "ROTATION: collapsed to pill first");
     await gesture(p, 60, {
@@ -3170,7 +3277,7 @@ try {
 
     // Open to full so the header is shown and the grabber sits high (a downward
     // drag stays on-screen).
-    await gesture(p, vh, { pointer: "mouse", slow: false, steps: 2 });
+    await gesture(p, vh, { pointer: "mouse", slow: false, steps: 1 });
     await p.waitForTimeout(SETTLE);
     if (
       (await p.locator('[data-testid="chat-sheet"][data-maximized="true"]').count()) === 1
@@ -3198,7 +3305,7 @@ try {
     await p.waitForTimeout(SETTLE);
 
     // Invariant: data-chat-state==="MAXIMIZED" IFF data-maximized==="true".
-    await gesture(p, vh, { pointer: "mouse", slow: false, steps: 2 });
+    await gesture(p, vh, { pointer: "mouse", slow: false, steps: 1 });
     await p.waitForTimeout(SETTLE);
     if (
       (await p.locator('[data-testid="chat-sheet"][data-maximized="true"]').count()) === 0
@@ -3228,7 +3335,7 @@ try {
     await p.waitForSelector('[data-testid="chat-sheet"]');
     await p.waitForTimeout(500);
     // Open the thread so the in-flight assistant bubble is on screen.
-    await gesture(p, 400, { pointer: "mouse", slow: false, steps: 2 });
+    await gesture(p, 400, { pointer: "mouse", slow: false, steps: 1 });
     await p.waitForTimeout(SETTLE);
     const dotsInBubble = await p
       .locator(

--- a/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
+++ b/packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs
@@ -609,7 +609,16 @@ async function runDragSuite(p, pointer, tag) {
     near(await sheetHeight(p), fullH, TOL + 48),
     `[${pointer}] settles back near FULL after restore`,
   );
-  if ((await chatState(p)) === "MAXIMIZED") {
+  const restoredState = await chatState(p);
+  const restoredStillMaximized =
+    (await p
+      .locator('[data-testid="chat-sheet"][data-maximized="true"]')
+      .count()) === 1;
+  assert(
+    restoredState !== "MAXIMIZED" && !restoredStillMaximized,
+    `[${pointer}] restore after committed over-pull leaves MAXIMIZED state (state=${restoredState}, data-maximized=${restoredStillMaximized})`,
+  );
+  if (restoredStillMaximized) {
     await restoreFromMaximizedByKeyboard(p);
   }
 

--- a/packages/ui/src/components/shell/use-pull-gesture.test.ts
+++ b/packages/ui/src/components/shell/use-pull-gesture.test.ts
@@ -87,6 +87,7 @@ describe("usePullGesture rAF coalescing (#9141)", () => {
       setPointerCapture() {},
       releasePointerCapture() {},
     },
+    overrides: Partial<React.PointerEvent> = {},
   ): React.PointerEvent {
     return {
       clientX: x,
@@ -94,6 +95,7 @@ describe("usePullGesture rAF coalescing (#9141)", () => {
       pointerId,
       isPrimary: true,
       currentTarget,
+      ...overrides,
     } as unknown as React.PointerEvent;
   }
 
@@ -224,6 +226,72 @@ describe("usePullGesture rAF coalescing (#9141)", () => {
     expect(onDrag).toHaveBeenLastCalledWith(130);
     expect(onPullUp).toHaveBeenCalledTimes(1);
     expect(onSettleFree).not.toHaveBeenCalled();
+  });
+
+  it("uses the tracked touch sample when pointerup reports stale coordinates", () => {
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((cb: FrameRequestCallback) => {
+        cb(0);
+        return 1;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    let t = 0;
+    vi.spyOn(performance, "now").mockImplementation(() => t);
+
+    const onPullUp = vi.fn();
+    const onTap = vi.fn();
+    const { result } = renderHook(() =>
+      usePullGesture({ onDrag: vi.fn(), onPullUp, onTap }),
+    );
+    const b = result.current;
+
+    t = 0;
+    b.onPointerDown(pointer(100, 300, 1, undefined, { pointerType: "touch" }));
+    t = 100;
+    b.onPointerMove(pointer(100, 180, 1, undefined, { pointerType: "touch" }));
+    t = 120;
+    b.onPointerUp(pointer(100, 300, 1, undefined, { pointerType: "touch" }));
+
+    expect(onPullUp).toHaveBeenCalledTimes(1);
+    expect(onTap).not.toHaveBeenCalled();
+  });
+
+  it("does not treat one slow move as a recent-segment flick", () => {
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((cb: FrameRequestCallback) => {
+        cb(0);
+        return 1;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+    let t = 0;
+    vi.spyOn(performance, "now").mockImplementation(() => t);
+
+    const onPullUp = vi.fn();
+    const onSettleFree = vi.fn();
+    const { result } = renderHook(() =>
+      usePullGesture({
+        onDrag: vi.fn(),
+        onPullUp,
+        onSettleFree,
+        distanceThreshold: 999,
+        velocityThreshold: 0.5,
+      }),
+    );
+    const b = result.current;
+
+    t = 0;
+    b.onPointerDown(pointer(100, 300));
+    t = 500;
+    b.onPointerMove(pointer(100, 220));
+    t = 520;
+    b.onPointerUp(pointer(100, 220));
+
+    expect(onPullUp).not.toHaveBeenCalled();
+    expect(onSettleFree).toHaveBeenCalledWith("up");
   });
 
   it("resets instead of sending onDrag(0) for a horizontal-dominant move on a vertical-only binding", () => {
@@ -473,6 +541,39 @@ describe("usePullGesture rAF coalescing (#9141)", () => {
 
     b.onPointerMove(pointer(100, 180, 1));
     b.onPointerUp(pointer(100, 180, 1));
+    expect(onPullUp).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onStart once for the accepted pointer and ignores secondary starts", () => {
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((cb: FrameRequestCallback) => {
+        cb(0);
+        return 1;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+    const onStart = vi.fn();
+    const onPullUp = vi.fn();
+    const { result } = renderHook(() =>
+      usePullGesture({ onStart, onDrag: vi.fn(), onPullUp }),
+    );
+    const b = result.current;
+
+    b.onPointerDown(pointer(100, 300, 2, undefined, { isPrimary: false, pointerType: "touch" }));
+    b.onPointerMove(pointer(100, 160, 2, undefined, { isPrimary: false, pointerType: "touch" }));
+    b.onPointerUp(pointer(100, 160, 2, undefined, { isPrimary: false, pointerType: "touch" }));
+
+    expect(onStart).not.toHaveBeenCalled();
+    expect(onPullUp).not.toHaveBeenCalled();
+
+    b.onPointerDown(pointer(100, 300, 1));
+    b.onPointerDown(pointer(100, 280, 2, undefined, { isPrimary: false, pointerType: "touch" }));
+    b.onPointerMove(pointer(100, 160, 1));
+    b.onPointerUp(pointer(100, 160, 1));
+
+    expect(onStart).toHaveBeenCalledTimes(1);
     expect(onPullUp).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/ui/src/components/shell/use-pull-gesture.ts
+++ b/packages/ui/src/components/shell/use-pull-gesture.ts
@@ -38,6 +38,8 @@ import {
  * scrolls natively (we only capture once the user clearly means to swipe).
  */
 export interface PullGestureOptions {
+  /** Pointer/finger press accepted as the start of a new gesture. */
+  onStart?: () => void;
   /** Released after a drag/flick UP past threshold. */
   onPullUp?: () => void;
   /** Released after a drag/flick DOWN past threshold. */
@@ -101,6 +103,7 @@ export function usePullGesture(
   const {
     onPullUp,
     onPullDown,
+    onStart,
     onDrag,
     onDragReset,
     onSwipeLeft,
@@ -176,6 +179,7 @@ export function usePullGesture(
       axis.current = null;
       last.current = { x: event.clientX, y: event.clientY, t: start.current.t };
       previous.current = null;
+      onStart?.();
       // Pure horizontal swipe surfaces defer capture until axis commit so native
       // vertical scrolling still works. A vertical pull handle captures
       // immediately even when it also supports horizontal swipes; otherwise a
@@ -188,7 +192,7 @@ export function usePullGesture(
         }
       }
     },
-    [hasSwipe, hasVerticalPull],
+    [hasSwipe, hasVerticalPull, onStart],
   );
 
   const onPointerMove = React.useCallback(
@@ -266,22 +270,55 @@ export function usePullGesture(
       last.current = null;
       previous.current = null;
 
-      const deltaUp = s.y - event.clientY; // up positive
-      const deltaLeft = s.x - event.clientX; // left positive
-      const elapsed = Math.max(1, performance.now() - s.t);
+      const eventDeltaUp = s.y - event.clientY; // up positive
+      const eventDeltaLeft = s.x - event.clientX; // left positive
+      const lastDeltaUp = lastSample ? s.y - lastSample.y : eventDeltaUp;
+      const lastDeltaLeft = lastSample ? s.x - lastSample.x : eventDeltaLeft;
+      const eventTravel = Math.hypot(eventDeltaLeft, eventDeltaUp);
+      const lastTravel = Math.hypot(lastDeltaLeft, lastDeltaUp);
+      // Touch-end coordinates can be stale (often the original press point)
+      // even after real touchMove samples drove the UI. Use the furthest
+      // observed point so release direction/distance matches the gesture the
+      // page actually handled, while still accepting browsers that coalesce all
+      // motion into the pointerup event.
+      const useLastSample = Boolean(
+        event.pointerType === "touch" && lastSample && lastTravel > eventTravel,
+      );
+      const deltaUp = useLastSample ? lastDeltaUp : eventDeltaUp;
+      const deltaLeft = useLastSample ? lastDeltaLeft : eventDeltaLeft;
+      const elapsed = Math.max(
+        1,
+        (useLastSample && lastSample ? lastSample.t : performance.now()) - s.t,
+      );
       const velocityUp = deltaUp / elapsed;
       const velocityLeft = deltaLeft / elapsed;
+      const recentDeltaUp =
+        previousSample && lastSample ? previousSample.y - lastSample.y : 0;
+      const recentDeltaLeft =
+        previousSample && lastSample ? previousSample.x - lastSample.x : 0;
+      // Recent-segment velocity is only meaningful once we have at least two
+      // real move samples. The seed sample captured at pointerdown has the
+      // same timestamp as a first move in several unit paths, and treating that
+      // seed→first-move jump as "recent" turns slow single-move drags into
+      // fake flicks.
+      const recentSegmentHasPriorMove = Boolean(
+        previousSample && previousSample.t > s.t,
+      );
+      const recentSegmentYIsIntentional =
+        recentSegmentHasPriorMove && Math.abs(recentDeltaUp) >= TAP_SLOP;
+      const recentSegmentXIsIntentional =
+        recentSegmentHasPriorMove && Math.abs(recentDeltaLeft) >= TAP_SLOP;
       const recentElapsed =
-        previousSample && lastSample && lastSample.t - previousSample.t >= 8
-          ? lastSample.t - previousSample.t
+        previousSample && lastSample
+          ? Math.max(1, lastSample.t - previousSample.t)
           : null;
       const recentVelocityUp =
-        previousSample && lastSample && recentElapsed
-          ? (previousSample.y - lastSample.y) / recentElapsed
+        recentElapsed && recentSegmentYIsIntentional
+          ? recentDeltaUp / recentElapsed
           : velocityUp;
       const recentVelocityLeft =
-        previousSample && lastSample && recentElapsed
-          ? (previousSample.x - lastSample.x) / recentElapsed
+        recentElapsed && recentSegmentXIsIntentional
+          ? recentDeltaLeft / recentElapsed
           : velocityLeft;
       const movedY = Math.abs(deltaUp);
       const movedX = Math.abs(deltaLeft);

--- a/packages/ui/src/components/shell/use-pull-gesture.ts
+++ b/packages/ui/src/components/shell/use-pull-gesture.ts
@@ -169,6 +169,7 @@ export function usePullGesture(
 
   const onPointerDown = React.useCallback(
     (event: React.PointerEvent) => {
+      if (event.isPrimary === false && event.pointerType && event.pointerType !== "mouse") return;
       if (start.current && start.current.pointerId !== event.pointerId) return;
       start.current = {
         x: event.clientX,

--- a/packages/ui/src/testing/real-touch-gestures.ts
+++ b/packages/ui/src/testing/real-touch-gestures.ts
@@ -46,7 +46,27 @@ async function settleMainThread(page: Page): Promise<void> {
 async function centerOf(page: Page, selector: string): Promise<Center> {
   // Settle first so the box also reflects the committed layout.
   await settleMainThread(page);
-  const box = await page.locator(selector).first().boundingBox();
+  await page.waitForFunction(
+    (selector) => {
+      const el = document.querySelector(selector);
+      if (!el) return false;
+      const b = el.getBoundingClientRect();
+      return b.width > 0 && b.height > 0;
+    },
+    selector,
+    { timeout: 3000 },
+  );
+  const box = await page.evaluate((selector) => {
+    const el = document.querySelector(selector);
+    if (!el) return null;
+    const b = el.getBoundingClientRect();
+    return {
+      x: b.x,
+      y: b.y,
+      width: b.width,
+      height: b.height,
+    };
+  }, selector);
   if (!box) throw new Error(`real-touch: no bounding box for ${selector}`);
   return { cx: box.x + box.width / 2, cy: box.y + box.height / 2, box };
 }


### PR DESCRIPTION
## Summary
- stabilize chat sheet pull/settle behavior so restore and free-rest paths do not leak full-bleed state
- harden touch release velocity handling so stale touchend coordinates and single slow moves do not misclassify gestures
- update the chat-sheet e2e harness to target the visible pill/grabber/restore zone and normalize state between independent gesture assertions

## Validation
- `bun run --cwd packages/ui test src/components/shell/ContinuousChatOverlay.test.tsx src/components/shell/ContinuousChatOverlay.mouse-drag.test.tsx src/components/shell/ContinuousChatOverlay.fuzz.test.tsx`
- `bun run --cwd packages/ui typecheck`
- `git diff --check HEAD`
- `bun packages/ui/src/components/shell/__e2e__/run-chat-sheet-e2e.mjs`

## Notes
- rebased on `origin/develop` at `26d01fbbce`
- focused first-run/onboarding conductor tests currently expose a develop-side expectation mismatch around `preferAgentId`; this PR does not change that conductor code

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15497-01-desktop-collapsed.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15497-30-mobile-continuum-maximized.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/15497-chat-sheet-drag-suite.webm

<!-- evidence-row:backend-logs -->
- [ ] N/A - frontend-only chat sheet gesture and fixture harness change; no backend code path changed.

<!-- evidence-row:frontend-logs -->
- [x] [15497-pr-15497-frontend-ocr-evidence.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15497-pr-15497-frontend-ocr-evidence.txt)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent, model, prompt, or provider behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] ![domain-artifacts](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15497-72-state-onboarding-reveal-home.png)

<!-- evidence-row:ocr-review -->
- [x] [15497-pr-15497-frontend-ocr-evidence.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15497-pr-15497-frontend-ocr-evidence.txt)
