### PR TITLE
fix(scripts): clean stale artifact sync archives

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/payment-requests-numeric.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/payment-requests-numeric.test.ts
@@ -37,7 +37,12 @@ process.env.MOCK_REDIS = "1";
 
 import { pushSchema } from "drizzle-kit/api";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
-import { apps } from "../../schemas/apps";
+import {
+  appDeploymentStatusEnum,
+  appReviewStatusEnum,
+  apps,
+  userDatabaseStatusEnum,
+} from "../../schemas/apps";
 import { organizations } from "../../schemas/organizations";
 import { paymentRequests } from "../../schemas/payment-requests";
 import { users } from "../../schemas/users";
@@ -138,7 +143,15 @@ describe("PaymentRequestsRepository.getPaymentRequest fail-closed wiring", () =>
       return;
     }
     try {
-      const schema = { organizations, users, apps, paymentRequests };
+      const schema = {
+        organizations,
+        users,
+        apps,
+        paymentRequests,
+        appDeploymentStatusEnum,
+        appReviewStatusEnum,
+        userDatabaseStatusEnum,
+      };
       const { apply } = await pushSchema(schema as never, dbWrite as never);
       await apply();
     } catch (error) {

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
@@ -99,13 +99,13 @@ let useRepositoryMocks = false;
 let useTransactionMock = false;
 
 const warnLog = mock((..._args: unknown[]) => {});
-const dbReadMock = new Proxy(realHelpers.dbRead as Record<PropertyKey, unknown>, {
+const dbReadMock = new Proxy(realHelpers.dbRead as unknown as Record<PropertyKey, unknown>, {
   get(target, prop, receiver) {
     if (prop === "select" && useRepositoryMocks) return select;
     return Reflect.get(target, prop, receiver);
   },
 });
-const dbWriteMock = new Proxy(realHelpers.dbWrite as Record<PropertyKey, unknown>, {
+const dbWriteMock = new Proxy(realHelpers.dbWrite as unknown as Record<PropertyKey, unknown>, {
   get(target, prop, receiver) {
     if (prop === "update" && useRepositoryMocks) return update;
     if (prop === "transaction" && useTransactionMock) return transaction;

--- a/packages/cloud/shared/src/db/repositories/shared-runtime-history.test.ts
+++ b/packages/cloud/shared/src/db/repositories/shared-runtime-history.test.ts
@@ -14,7 +14,7 @@ const deleteWhere = mock((clause: SQL) => {
   return { returning };
 });
 const del = mock(() => ({ where: deleteWhere }));
-const dbWriteMock = new Proxy(realClient.dbWrite as Record<PropertyKey, unknown>, {
+const dbWriteMock = new Proxy(realClient.dbWrite as unknown as Record<PropertyKey, unknown>, {
   get(target, prop, receiver) {
     if (prop === "delete") return del;
     return Reflect.get(target, prop, receiver);

--- a/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts
@@ -75,6 +75,7 @@ mock.module("../credits", () => ({
   // Must mirror the real export — app-credits.ts imports it for the $0-estimate
   // floor; a missing export would break the module link under this mock.
   MIN_RESERVATION: 0.000001,
+  APP_CHAT_RESERVATION_SETTLEMENT_MARKER: "app_chat_reservation_v1",
   creditsService: {
     addCredits,
     reserveAndDeductCredits,

--- a/packages/scripts/sync-artifacts.mjs
+++ b/packages/scripts/sync-artifacts.mjs
@@ -23,8 +23,10 @@ import { once } from "node:events";
 import {
   createWriteStream,
   existsSync,
+  readdirSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -36,6 +38,8 @@ const MANIFEST = join(ROOT, "packages", "scripts", "artifacts-manifest.json");
 const MARKER = join(ROOT, ".eliza-artifacts-version");
 const log = (m) => console.log(`[sync-artifacts] ${m}`);
 const warn = (m) => console.warn(`[sync-artifacts] WARNING: ${m}`);
+const PROGRESS_INTERVAL_MS = 5000;
+const STALE_TMP_MAX_AGE_MS = 6 * 60 * 60_000;
 
 if (process.env.ELIZA_SKIP_ARTIFACT_SYNC === "1") {
   log("skipped (ELIZA_SKIP_ARTIFACT_SYNC=1)");
@@ -48,6 +52,8 @@ if (!existsSync(MANIFEST)) {
 
 const m = JSON.parse(readFileSync(MANIFEST, "utf8"));
 const { version, asset } = m;
+cleanupStaleTempArchives();
+
 if (existsSync(MARKER) && readFileSync(MARKER, "utf8").trim() === version) {
   log(`artifacts already at ${version}; nothing to do`);
   process.exit(0);
@@ -57,7 +63,6 @@ const url =
   asset.url ||
   `https://github.com/${asset.repo}/releases/download/${asset.tag}/${asset.name}`;
 const tmp = join(tmpdir(), `eliza-artifacts-${process.pid}.tar.gz`);
-const PROGRESS_INTERVAL_MS = 5000;
 
 function formatBytes(bytes) {
   if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
@@ -97,6 +102,37 @@ function progressStatus(received, total, startedAt) {
   }
   parts.push(`at ${formatBytes(bytesPerSecond)}/s`);
   return parts.join(" ");
+}
+
+function cleanupStaleTempArchives() {
+  const now = Date.now();
+  let removed = 0;
+  for (const entry of readdirSync(tmpdir())) {
+    if (!/^eliza-artifacts-\d+\.tar\.gz$/.test(entry)) continue;
+    const file = join(tmpdir(), entry);
+    let stat;
+    try {
+      stat = statSync(file);
+    } catch (err) {
+      // error-policy:J6 best-effort temp cleanup; a racing process may remove the file first.
+      warn(`could not stat stale temp archive ${file}: ${err.message}`);
+      continue;
+    }
+    if (!stat.isFile()) continue;
+    if (now - stat.mtimeMs < STALE_TMP_MAX_AGE_MS) continue;
+    try {
+      rmSync(file, { force: true });
+      removed += 1;
+    } catch (err) {
+      // error-policy:J6 best-effort temp cleanup; failed cleanup must not block install.
+      warn(`could not remove stale temp archive ${file}: ${err.message}`);
+    }
+  }
+  if (removed > 0) {
+    log(
+      `removed ${removed} stale artifact temp archive${removed === 1 ? "" : "s"}`,
+    );
+  }
 }
 
 async function streamToFileWithProgress(response, dest, expectedBytes) {


### PR DESCRIPTION
## Summary
- remove stale `eliza-artifacts-<pid>.tar.gz` files from the OS temp directory before artifact sync no-ops or downloads
- preserve fresh archives under six hours old so concurrent installs are not disturbed
- keep the existing current-download `finally` cleanup for normal success/failure paths
- route existing cloud-shared DB test mocks through `unknown` so affected cloud-api typecheck accepts the broader test files CI pulls in

Addresses the `/tmp/eliza-artifacts-*.tar.gz` leak called out in #15398. Runner `_work` cleanup and runner placement policy remain separate ops work.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - backend/script cleanup change; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - backend/script cleanup change; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - install-time artifact sync script; no user-facing UI workflow changed.

<!-- evidence-row:backend-logs -->
- [x] Backend logs/checks: [PR checks](https://github.com/elizaOS/eliza/pull/15498/checks) plus local script smoke listed below.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend, browser, app, or network client behavior changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent prompt, provider, model call, or trajectory behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [PR file diff](https://github.com/elizaOS/eliza/pull/15498/files). Domain artifact is the temp directory smoke: an old `eliza-artifacts-999999.tar.gz` was removed, a fresh `eliza-artifacts-888888.tar.gz` was preserved, and the script exited through the current-marker no-op path without downloading the artifact bundle.

## Validation
- `bunx @biomejs/biome check --write packages/scripts/sync-artifacts.mjs` (existing env-var warnings only: `ELIZA_SKIP_ARTIFACT_SYNC`, `SystemRoot`)
- `node --check packages/scripts/sync-artifacts.mjs`
- `bun run --cwd packages/cloud/api typecheck`
- `DATABASE_URL=pglite://memory TEST_DATABASE_URL=pglite://memory SKIP_DB_DEPENDENT=1 SKIP_SERVER_CHECK=true bun test /Users/shawwalters/eliza-workspace/milady/eliza/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts --timeout 120000 --isolate`
- `bun test --coverage-reporter=lcov packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts packages/cloud/shared/src/db/repositories/shared-runtime-history.test.ts`
- `set -e; tmp_dir=$(mktemp -d); stale="$tmp_dir/eliza-artifacts-999999.tar.gz"; fresh="$tmp_dir/eliza-artifacts-888888.tar.gz"; printf stale > "$stale"; printf fresh > "$fresh"; STALE="$stale" node -e "const fs=require('fs'); const stale=process.env.STALE; const t=new Date(Date.now()-7*60*60*1000); fs.utimesSync(stale,t,t);"; TMPDIR="$tmp_dir" node packages/scripts/sync-artifacts.mjs; test ! -e "$stale"; test -e "$fresh"; rm -rf "$tmp_dir"; echo 'stale temp cleanup smoke ok'`
- `git diff --check -- packages/scripts/sync-artifacts.mjs`
