### PR TITLE
fix(cloud): repair shared CI test setup

### DIFF
--- a/packages/cloud/shared/src/db/repositories/__tests__/payment-requests-numeric.test.ts
+++ b/packages/cloud/shared/src/db/repositories/__tests__/payment-requests-numeric.test.ts
@@ -37,7 +37,12 @@ process.env.MOCK_REDIS = "1";
 
 import { pushSchema } from "drizzle-kit/api";
 import { closeDatabaseConnectionsForTests, dbWrite } from "../../client";
-import { apps } from "../../schemas/apps";
+import {
+  appDeploymentStatusEnum,
+  appReviewStatusEnum,
+  apps,
+  userDatabaseStatusEnum,
+} from "../../schemas/apps";
 import { organizations } from "../../schemas/organizations";
 import { paymentRequests } from "../../schemas/payment-requests";
 import { users } from "../../schemas/users";
@@ -138,7 +143,15 @@ describe("PaymentRequestsRepository.getPaymentRequest fail-closed wiring", () =>
       return;
     }
     try {
-      const schema = { organizations, users, apps, paymentRequests };
+      const schema = {
+        organizations,
+        users,
+        apps,
+        paymentRequests,
+        appDeploymentStatusEnum,
+        appReviewStatusEnum,
+        userDatabaseStatusEnum,
+      };
       const { apply } = await pushSchema(schema as never, dbWrite as never);
       await apply();
     } catch (error) {

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
@@ -99,13 +99,13 @@ let useRepositoryMocks = false;
 let useTransactionMock = false;
 
 const warnLog = mock((..._args: unknown[]) => {});
-const dbReadMock = new Proxy(realHelpers.dbRead as Record<PropertyKey, unknown>, {
+const dbReadMock = new Proxy(realHelpers.dbRead as unknown as Record<PropertyKey, unknown>, {
   get(target, prop, receiver) {
     if (prop === "select" && useRepositoryMocks) return select;
     return Reflect.get(target, prop, receiver);
   },
 });
-const dbWriteMock = new Proxy(realHelpers.dbWrite as Record<PropertyKey, unknown>, {
+const dbWriteMock = new Proxy(realHelpers.dbWrite as unknown as Record<PropertyKey, unknown>, {
   get(target, prop, receiver) {
     if (prop === "update" && useRepositoryMocks) return update;
     if (prop === "transaction" && useTransactionMock) return transaction;

--- a/packages/cloud/shared/src/db/repositories/shared-runtime-history.test.ts
+++ b/packages/cloud/shared/src/db/repositories/shared-runtime-history.test.ts
@@ -14,7 +14,7 @@ const deleteWhere = mock((clause: SQL) => {
   return { returning };
 });
 const del = mock(() => ({ where: deleteWhere }));
-const dbWriteMock = new Proxy(realClient.dbWrite as Record<PropertyKey, unknown>, {
+const dbWriteMock = new Proxy(realClient.dbWrite as unknown as Record<PropertyKey, unknown>, {
   get(target, prop, receiver) {
     if (prop === "delete") return del;
     return Reflect.get(target, prop, receiver);

--- a/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts
+++ b/packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts
@@ -75,6 +75,7 @@ mock.module("../credits", () => ({
   // Must mirror the real export — app-credits.ts imports it for the $0-estimate
   // floor; a missing export would break the module link under this mock.
   MIN_RESERVATION: 0.000001,
+  APP_CHAT_RESERVATION_SETTLEMENT_MARKER: "app_chat_reservation_v1",
   creditsService: {
     addCredits,
     reserveAndDeductCredits,


### PR DESCRIPTION
## Summary
- Cast shared Drizzle DB test proxies through `unknown` before `Record<PropertyKey, unknown>` to satisfy repo-wide typecheck.
- Include the apps enum objects when the payment requests numeric wiring test pushes the PGlite schema.
- Mirror the app-chat reservation settlement marker in the app credits ledger mock so `app-credits.ts` links under batch mocks.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - backend test/typecheck-only repair; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - backend test/typecheck-only repair; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - CI test setup repair with no user-facing workflow.

<!-- evidence-row:backend-logs -->
- [x] Backend logs/checks: [PR checks](https://github.com/elizaOS/eliza/pull/15501/checks) plus local backend validation listed below.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend, browser, app, or network client behavior changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent prompt, provider, model call, or trajectory behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [PR file diff](https://github.com/elizaOS/eliza/pull/15501/files). Domain artifact is the repaired cloud-shared test fixtures and casts that let the actual affected cloud shared/cloud API test and typecheck paths compile instead of masking failures.

## Validation
- `bun run verify:cloud`
- `bun test packages/cloud/shared/src/db/repositories/__tests__/payment-requests-numeric.test.ts packages/cloud/shared/src/lib/services/__tests__/app-credits-ledger.test.ts`
- `DATABASE_URL=pglite://memory TEST_DATABASE_URL=pglite://memory SKIP_DB_DEPENDENT=1 SKIP_SERVER_CHECK=true bun test $(cat /tmp/cloud-batch2-files.txt) --timeout 120000 --isolate`
- Full `bun run test:cloud` also passed during the repair run before reapplying the same isolated fix to this clean branch.

Fixes the failures seen in:
- https://github.com/elizaOS/eliza/actions/runs/28970209453/job/85963957704
- https://github.com/elizaOS/eliza/actions/runs/28970209421/job/85963732225
