### PR TITLE
fix(ops): prune stale runner workspaces

### DIFF
--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.test.ts
@@ -99,13 +99,13 @@ let useRepositoryMocks = false;
 let useTransactionMock = false;
 
 const warnLog = mock((..._args: unknown[]) => {});
-const dbReadMock = new Proxy(realHelpers.dbRead as Record<PropertyKey, unknown>, {
+const dbReadMock = new Proxy(realHelpers.dbRead as unknown as Record<PropertyKey, unknown>, {
   get(target, prop, receiver) {
     if (prop === "select" && useRepositoryMocks) return select;
     return Reflect.get(target, prop, receiver);
   },
 });
-const dbWriteMock = new Proxy(realHelpers.dbWrite as Record<PropertyKey, unknown>, {
+const dbWriteMock = new Proxy(realHelpers.dbWrite as unknown as Record<PropertyKey, unknown>, {
   get(target, prop, receiver) {
     if (prop === "update" && useRepositoryMocks) return update;
     if (prop === "transaction" && useTransactionMock) return transaction;

--- a/packages/cloud/shared/src/db/repositories/shared-runtime-history.test.ts
+++ b/packages/cloud/shared/src/db/repositories/shared-runtime-history.test.ts
@@ -14,7 +14,7 @@ const deleteWhere = mock((clause: SQL) => {
   return { returning };
 });
 const del = mock(() => ({ where: deleteWhere }));
-const dbWriteMock = new Proxy(realClient.dbWrite as Record<PropertyKey, unknown>, {
+const dbWriteMock = new Proxy(realClient.dbWrite as unknown as Record<PropertyKey, unknown>, {
   get(target, prop, receiver) {
     if (prop === "delete") return del;
     return Reflect.get(target, prop, receiver);

--- a/packages/scripts/cloud/admin/prune-runner-workspaces.test.ts
+++ b/packages/scripts/cloud/admin/prune-runner-workspaces.test.ts
@@ -1,4 +1,7 @@
-// Exercises safe self-hosted runner workspace cleanup planning without touching real runner paths.
+/**
+ * Exercises safe self-hosted runner workspace cleanup planning without touching
+ * real runner paths.
+ */
 
 import { afterEach, describe, expect, it } from "bun:test";
 import {

--- a/packages/scripts/cloud/admin/prune-runner-workspaces.test.ts
+++ b/packages/scripts/cloud/admin/prune-runner-workspaces.test.ts
@@ -1,0 +1,117 @@
+// Exercises safe self-hosted runner workspace cleanup planning without touching real runner paths.
+
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildRunnerWorkspacePrunePlan,
+  findRunnerWorkDirs,
+  parseRunnerWorkspacePruneArgs,
+} from "./prune-runner-workspaces";
+
+const roots: string[] = [];
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "runner-workspaces-test-"));
+  roots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0))
+    rmSync(root, { recursive: true, force: true });
+});
+
+describe("parseRunnerWorkspacePruneArgs", () => {
+  it("defaults to the prod runner root and dry-run off", () => {
+    expect(parseRunnerWorkspacePruneArgs([], {})).toEqual({
+      root: "/opt/actions-runners",
+      minAgeHours: 6,
+      dryRun: false,
+      allowActive: false,
+    });
+  });
+
+  it("accepts explicit root, age floor, dry-run, and active override", () => {
+    expect(
+      parseRunnerWorkspacePruneArgs(
+        [
+          "--root",
+          "/tmp/runners",
+          "--min-age-hours",
+          "12",
+          "--dry-run",
+          "--allow-active",
+        ],
+        {},
+      ),
+    ).toEqual({
+      root: "/tmp/runners",
+      minAgeHours: 12,
+      dryRun: true,
+      allowActive: true,
+    });
+  });
+
+  it("uses env fallback and rejects unsafe age values", () => {
+    expect(
+      parseRunnerWorkspacePruneArgs([], {
+        RUNNER_WORKSPACE_ROOT: "/var/runners",
+        RUNNER_WORKSPACE_MIN_AGE_HOURS: "24",
+      }),
+    ).toMatchObject({ root: "/var/runners", minAgeHours: 24 });
+
+    expect(() =>
+      parseRunnerWorkspacePruneArgs(["--min-age-hours", "0"], {}),
+    ).toThrow("Invalid min-age-hours");
+  });
+});
+
+describe("findRunnerWorkDirs", () => {
+  it("discovers runner _work dirs under a runner root", () => {
+    const root = tempRoot();
+    const runnerWork = join(root, "runner-1", "_work");
+    const nestedWork = join(root, "group", "_work");
+    mkdirSync(runnerWork, { recursive: true });
+    mkdirSync(nestedWork, { recursive: true });
+
+    expect(findRunnerWorkDirs(root)).toEqual([runnerWork, nestedWork].sort());
+  });
+});
+
+describe("buildRunnerWorkspacePrunePlan", () => {
+  it("selects only stale children of _work directories", () => {
+    const root = tempRoot();
+    const work = join(root, "runner-1", "_work");
+    const stale = join(work, "repo-old");
+    const fresh = join(work, "repo-new");
+    mkdirSync(stale, { recursive: true });
+    mkdirSync(fresh, { recursive: true });
+    writeFileSync(join(stale, "file.txt"), "old");
+    writeFileSync(join(fresh, "file.txt"), "new");
+
+    const now = Date.now();
+    const oldDate = new Date(now - 8 * 60 * 60_000);
+    const freshDate = new Date(now - 30 * 60_000);
+    utimesSync(stale, oldDate, oldDate);
+    utimesSync(fresh, freshDate, freshDate);
+
+    const plan = buildRunnerWorkspacePrunePlan({
+      root,
+      now,
+      minAgeHours: 6,
+    });
+
+    expect(plan.workDirs).toEqual([work]);
+    expect(plan.entries.map((entry) => entry.path)).toEqual([stale]);
+    expect(plan.skippedFresh).toBe(1);
+    expect(plan.totalBytes).toBeGreaterThan(0);
+  });
+});

--- a/packages/scripts/cloud/admin/prune-runner-workspaces.ts
+++ b/packages/scripts/cloud/admin/prune-runner-workspaces.ts
@@ -13,8 +13,8 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, lstatSync, readdirSync, rmSync, statSync } from "node:fs";
 import type { Stats } from "node:fs";
+import { existsSync, lstatSync, readdirSync, rmSync, statSync } from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -167,10 +167,24 @@ export function buildRunnerWorkspacePrunePlan(input: {
   let skippedFresh = 0;
 
   for (const workDir of workDirs) {
-    for (const child of readdirSync(workDir, { withFileTypes: true })) {
+    let children: ReturnType<typeof readdirSync>;
+    try {
+      children = readdirSync(workDir, { withFileTypes: true });
+    } catch {
+      // error-policy:J6 best-effort host cleanup; a racing runner dir can be retried on the next pass.
+      continue;
+    }
+
+    for (const child of children) {
       const childPath = path.join(workDir, child.name);
       if (!realPathInsideRoot(childPath, input.root)) continue;
-      const stat = lstatSync(childPath);
+      let stat: Stats;
+      try {
+        stat = lstatSync(childPath);
+      } catch {
+        // error-policy:J6 best-effort host cleanup; racing child deletes are harmless.
+        continue;
+      }
       const ageMs = input.now - stat.mtimeMs;
       if (ageMs < minAgeMs) {
         skippedFresh += 1;
@@ -255,6 +269,7 @@ function isMainModule(): boolean {
 
 if (isMainModule()) {
   main().catch((error) => {
+    // error-policy:J1 CLI boundary translates failures into a non-zero exit.
     console.error(
       "[prune-runner-workspaces] failed:",
       error instanceof Error ? error.message : String(error),

--- a/packages/scripts/cloud/admin/prune-runner-workspaces.ts
+++ b/packages/scripts/cloud/admin/prune-runner-workspaces.ts
@@ -1,0 +1,264 @@
+#!/usr/bin/env bun
+
+/**
+ * Local cleanup for GitHub Actions self-hosted runner workspaces on robot hosts.
+ *
+ * Runner installations keep completed-job checkouts under each runner's `_work`
+ * directory and do not reclaim them automatically. On small-root agent robots
+ * this can consume tens of GB while Docker cleanup reports nothing to reclaim.
+ * This script is intentionally host-local: run it from cron/systemd on the
+ * runner host, not from the control plane. It refuses to delete while a
+ * `Runner.Worker` process is active unless the operator explicitly overrides
+ * that guard.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, lstatSync, readdirSync, rmSync, statSync } from "node:fs";
+import type { Stats } from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface RunnerWorkspacePruneArgs {
+  root: string;
+  minAgeHours: number;
+  dryRun: boolean;
+  allowActive: boolean;
+}
+
+export interface WorkspaceEntry {
+  path: string;
+  ageMs: number;
+  bytes: number;
+}
+
+export interface WorkspacePlan {
+  workDirs: string[];
+  entries: WorkspaceEntry[];
+  skippedFresh: number;
+  totalBytes: number;
+}
+
+const DEFAULT_ROOT = "/opt/actions-runners";
+const DEFAULT_MIN_AGE_HOURS = 6;
+const MIN_AGE_HOURS_FLOOR = 1;
+
+export function parseRunnerWorkspacePruneArgs(
+  argv: string[],
+  env: NodeJS.ProcessEnv,
+): RunnerWorkspacePruneArgs {
+  const flags = new Map<string, string>();
+  let dryRun = false;
+  let allowActive = false;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === undefined) continue;
+    if (arg === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (arg === "--allow-active") {
+      allowActive = true;
+      continue;
+    }
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+      const value = argv[i + 1];
+      if (value === undefined || value.startsWith("--")) {
+        throw new Error(`Flag --${key} requires a value`);
+      }
+      flags.set(key, value);
+      i++;
+    }
+  }
+
+  const root = path.resolve(
+    flags.get("root") ?? env.RUNNER_WORKSPACE_ROOT ?? DEFAULT_ROOT,
+  );
+  const minAgeRaw =
+    flags.get("min-age-hours") ??
+    env.RUNNER_WORKSPACE_MIN_AGE_HOURS ??
+    String(DEFAULT_MIN_AGE_HOURS);
+  const minAgeHours = Number.parseInt(minAgeRaw, 10);
+  if (!Number.isInteger(minAgeHours) || minAgeHours < MIN_AGE_HOURS_FLOOR) {
+    throw new Error(`Invalid min-age-hours: ${minAgeRaw}`);
+  }
+
+  return { root, minAgeHours, dryRun, allowActive };
+}
+
+function realPathInsideRoot(candidate: string, root: string): boolean {
+  const relative = path.relative(root, candidate);
+  return (
+    relative.length > 0 &&
+    !relative.startsWith("..") &&
+    !path.isAbsolute(relative)
+  );
+}
+
+export function findRunnerWorkDirs(root: string): string[] {
+  if (!existsSync(root)) return [];
+  const stat = statSync(root);
+  if (!stat.isDirectory()) return [];
+  const dirs = new Set<string>();
+
+  const maybeAdd = (candidate: string) => {
+    const base = path.basename(candidate);
+    if (base !== "_work") return;
+    const realCandidate = path.resolve(candidate);
+    if (realCandidate !== root && !realPathInsideRoot(realCandidate, root))
+      return;
+    try {
+      if (lstatSync(realCandidate).isDirectory()) dirs.add(realCandidate);
+    } catch {
+      // error-policy:J6 best-effort host cleanup; racing deletes are harmless.
+    }
+  };
+
+  maybeAdd(root);
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const child = path.join(root, entry.name);
+    maybeAdd(child);
+    try {
+      for (const nested of readdirSync(child, { withFileTypes: true })) {
+        if (nested.isDirectory()) maybeAdd(path.join(child, nested.name));
+      }
+    } catch {
+      // error-policy:J6 best-effort host cleanup; an unreadable runner dir is skipped.
+    }
+  }
+
+  return [...dirs].sort();
+}
+
+function pathSizeBytes(target: string): number {
+  let total = 0;
+  const stack = [target];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) continue;
+    let stat: Stats;
+    try {
+      stat = lstatSync(current);
+    } catch {
+      // error-policy:J6 best-effort size reporting; cleanup still attempts the path.
+      continue;
+    }
+    total += stat.size;
+    if (!stat.isDirectory()) continue;
+    try {
+      for (const child of readdirSync(current))
+        stack.push(path.join(current, child));
+    } catch {
+      // error-policy:J6 best-effort size reporting; unreadable children are ignored.
+    }
+  }
+  return total;
+}
+
+export function buildRunnerWorkspacePrunePlan(input: {
+  root: string;
+  now: number;
+  minAgeHours: number;
+}): WorkspacePlan {
+  const minAgeMs = input.minAgeHours * 60 * 60_000;
+  const workDirs = findRunnerWorkDirs(input.root);
+  const entries: WorkspaceEntry[] = [];
+  let skippedFresh = 0;
+
+  for (const workDir of workDirs) {
+    for (const child of readdirSync(workDir, { withFileTypes: true })) {
+      const childPath = path.join(workDir, child.name);
+      if (!realPathInsideRoot(childPath, input.root)) continue;
+      const stat = lstatSync(childPath);
+      const ageMs = input.now - stat.mtimeMs;
+      if (ageMs < minAgeMs) {
+        skippedFresh += 1;
+        continue;
+      }
+      entries.push({
+        path: childPath,
+        ageMs,
+        bytes: pathSizeBytes(childPath),
+      });
+    }
+  }
+
+  return {
+    workDirs,
+    entries,
+    skippedFresh,
+    totalBytes: entries.reduce((sum, entry) => sum + entry.bytes, 0),
+  };
+}
+
+export function isRunnerWorkerActive(): boolean {
+  const result = spawnSync("pgrep", ["-f", "Runner\\.Worker"], {
+    stdio: "ignore",
+  });
+  return result.status === 0;
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KiB", "MiB", "GiB"];
+  let value = bytes;
+  let unit = units[0];
+  for (let i = 1; i < units.length && value >= 1024; i++) {
+    value /= 1024;
+    unit = units[i];
+  }
+  return `${value >= 10 || unit === "B" ? value.toFixed(0) : value.toFixed(1)} ${unit}`;
+}
+
+async function main(): Promise<void> {
+  const args = parseRunnerWorkspacePruneArgs(
+    process.argv.slice(2),
+    process.env,
+  );
+  if (!args.allowActive && isRunnerWorkerActive()) {
+    throw new Error(
+      "Runner.Worker is active; refusing to prune. Re-run after jobs finish.",
+    );
+  }
+
+  const plan = buildRunnerWorkspacePrunePlan({
+    root: args.root,
+    now: Date.now(),
+    minAgeHours: args.minAgeHours,
+  });
+
+  console.log(`[prune-runner-workspaces] root: ${args.root}`);
+  console.log(`[prune-runner-workspaces] work dirs: ${plan.workDirs.length}`);
+  console.log(
+    `[prune-runner-workspaces] stale entries: ${plan.entries.length}`,
+  );
+  console.log(
+    `[prune-runner-workspaces] skipped fresh entries: ${plan.skippedFresh}`,
+  );
+  console.log(
+    `[prune-runner-workspaces] reclaimable: ${formatBytes(plan.totalBytes)}`,
+  );
+
+  for (const entry of plan.entries) {
+    console.log(
+      `[prune-runner-workspaces] ${args.dryRun ? "would remove" : "removing"} ${entry.path} (${formatBytes(entry.bytes)})`,
+    );
+    if (!args.dryRun) rmSync(entry.path, { recursive: true, force: true });
+  }
+}
+
+function isMainModule(): boolean {
+  const entry = process.argv[1];
+  return entry ? path.resolve(entry) === fileURLToPath(import.meta.url) : false;
+}
+
+if (isMainModule()) {
+  main().catch((error) => {
+    console.error(
+      "[prune-runner-workspaces] failed:",
+      error instanceof Error ? error.message : String(error),
+    );
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- add a host-local admin tool for pruning stale GitHub self-hosted runner `_work` children under `/opt/actions-runners`
- refuse to prune while `Runner.Worker` is active unless the operator passes `--allow-active`
- support dry-run mode, root/min-age env overrides, and focused tests for parsing, discovery, and stale/fresh selection

Addresses the runner `_work` cleanup leg of #15398. Runner placement policy remains human/ops work because moving runners between hosts requires production access and capacity decisions outside this repo.

## Evidence

<!-- evidence-row:before-screenshots -->
- [x] Before screenshots: N/A - host-local ops script; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [x] After screenshots: N/A - host-local ops script; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [x] Walkthrough video: N/A - non-interactive runner maintenance CLI; no user-facing workflow changed.

<!-- evidence-row:backend-logs -->
- [x] Backend logs/checks: [PR checks](https://github.com/elizaOS/eliza/pull/15504/checks) plus local validation listed below. Live deletion on production runner hosts was not run from this branch; the command is destructive and must be scheduled by ops on the target host.

<!-- evidence-row:frontend-logs -->
- [x] Frontend console/network logs: N/A - no frontend, browser, app, or network client behavior changed.

<!-- evidence-row:llm-trajectory -->
- [x] Real-LLM trajectory: N/A - no agent prompt, provider, model call, or trajectory behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] Domain artifacts: [PR file diff](https://github.com/elizaOS/eliza/pull/15504/files). Domain artifact is the deterministic temp-root test fixture: a stale `_work` child is selected for deletion, a fresh child is skipped, and real runner paths are never touched.

## Validation
- `bunx @biomejs/biome check --write packages/scripts/cloud/admin/prune-runner-workspaces.ts packages/scripts/cloud/admin/prune-runner-workspaces.test.ts`
- `node --check packages/scripts/cloud/admin/prune-runner-workspaces.ts`
- `bun test packages/scripts/cloud/admin/prune-runner-workspaces.test.ts`
- `git diff --check`
