### PR TITLE
fix(ci): recover wedged cloud deploys

### DIFF
--- a/.github/workflows/actions-zombie-janitor.yml
+++ b/.github/workflows/actions-zombie-janitor.yml
@@ -1,7 +1,8 @@
 name: Actions Zombie Janitor
 
 # Reap zombie workflow runs (dead-runner `in_progress`, wedged `queued`,
-# stale `waiting`) that freeze org concurrency.
+# production deploy `pending` with zero jobs, stale `waiting`) that freeze org
+# concurrency or silently block deploys.
 #
 # WHY: when a self-hosted runner box dies, its runs stay `in_progress` until
 # the job timeout (6h default, up to 12h here) — and each one keeps holding
@@ -45,6 +46,10 @@ name: Actions Zombie Janitor
 #     idempotent; every candidate is re-verified live), and any queued backlog
 #     purges itself: each lane cancels superseded queued janitor ticks.
 #   - Wedged-queued reaping: own ticks queued >60 min, anything queued >12 h.
+#   - Production Cloud CF Deploy pending/zero-job reaping: a prod deploy that
+#     never instantiates a job is neither an approval gate nor a runner backlog;
+#     after 15 minutes the janitor force-cancels it and redispatches once
+#     (#15503/#15499).
 #   - actions/github-script instead of gh/jq — self-hosted boxes only need
 #     the runner-bundled Node.
 #
@@ -76,6 +81,8 @@ name: Actions Zombie Janitor
 #     runs GitHub failed to fail — hours-old queued runs can be legitimate
 #     freeze backlog that still executes once slots free, and cancelling a
 #     required PR check strands the PR red; tune down mid-incident if needed)
+#   ACTIONS_JANITOR_PENDING_ZERO_JOB_MINUTES — default 15 (production Cloud CF
+#     Deploy pending/zero-job zombie reap + one redispatch)
 #   ACTIONS_JANITOR_SELF_QUEUED_MINUTES    — default 60 (own stale ticks)
 #   ACTIONS_JANITOR_WAITING_MAX_AGE_HOURS  — default 48 (stale environment-gate
 #     reap; far above any sane approval latency, far below GitHub's 30-day
@@ -111,13 +118,14 @@ jobs:
     if: github.repository == 'elizaOS/eliza' && vars.ACTIONS_JANITOR_DISABLED != 'true'
     timeout-minutes: 10
     steps:
-      - name: Cancel zombie in_progress + wedged queued + stale waiting runs
+      - name: Cancel zombie in_progress + wedged queued + pending deploy + stale waiting runs
         uses: actions/github-script@v7
         env:
           MAX_AGE_MINUTES: ${{ vars.ACTIONS_JANITOR_MAX_AGE_MINUTES || '' }}
           LEGACY_MAX_AGE_HOURS: ${{ vars.ACTIONS_JANITOR_MAX_AGE_HOURS || '' }}
           IDLE_MINUTES: ${{ vars.ACTIONS_JANITOR_IDLE_MINUTES || '90' }}
           QUEUED_MAX_AGE_HOURS: ${{ vars.ACTIONS_JANITOR_QUEUED_MAX_AGE_HOURS || '24' }}
+          PENDING_ZERO_JOB_MINUTES: ${{ vars.ACTIONS_JANITOR_PENDING_ZERO_JOB_MINUTES || '15' }}
           SELF_QUEUED_MINUTES: ${{ vars.ACTIONS_JANITOR_SELF_QUEUED_MINUTES || '60' }}
           WAITING_MAX_AGE_HOURS: ${{ vars.ACTIONS_JANITOR_WAITING_MAX_AGE_HOURS || '48' }}
           EXEMPT_WORKFLOWS: ${{ vars.ACTIONS_JANITOR_EXEMPT_WORKFLOWS || 'ElizaOS Cuttlefish,ElizaOS OpenAgent E1 (RISC-V AI SoC)' }}
@@ -132,6 +140,7 @@ jobs:
                 120,
               idleMin: Number(process.env.IDLE_MINUTES) || 90,
               queuedMaxAgeMin: (Number(process.env.QUEUED_MAX_AGE_HOURS) || 24) * 60,
+              pendingZeroJobMin: Number(process.env.PENDING_ZERO_JOB_MINUTES) || 15,
               selfQueuedMin: Number(process.env.SELF_QUEUED_MINUTES) || 60,
               waitingMaxAgeMin: (Number(process.env.WAITING_MAX_AGE_HOURS) || 48) * 60,
               // Janitor lane jobs have timeout-minutes:10; an own-workflow run
@@ -183,6 +192,14 @@ jobs:
             const liveStatus = async (runId) => {
               try {
                 return (await github.rest.actions.getWorkflowRun({ owner, repo, run_id: runId })).data.status;
+              } catch {
+                return null;
+              }
+            };
+
+            const liveRun = async (runId) => {
+              try {
+                return (await github.rest.actions.getWorkflowRun({ owner, repo, run_id: runId })).data;
               } catch {
                 return null;
               }
@@ -294,7 +311,67 @@ jobs:
               await reap(run, ageMin, ageMin, isSelf ? 'superseded janitor tick' : 'wedged queued');
             }
 
-            // ---- 3. stale waiting runs (unapproved environment gates) ----
+            // ---- 3. production deploy pending/zero-job zombies ----
+            // These runs never instantiate a job, so no environment approval,
+            // runner assignment, or job-level concurrency record exists for a
+            // human to inspect. Scope this to main->production Cloud CF Deploy:
+            // staging can legitimately sit behind active deploy work, while a
+            // production run with zero jobs and no active same-branch sibling is
+            // silent release blockage (#15503/#15499).
+            const activeCloudDeploy = new Map();
+            for (const status of ['in_progress', 'waiting']) {
+              const activeRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                owner, repo, workflow_id: 'cloud-cf-deploy.yml', status, per_page: 100,
+              });
+              for (const run of activeRuns) {
+                activeCloudDeploy.set(`${run.head_branch || ''}:${status}`, run);
+              }
+            }
+            const pendingCloudDeploy = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner, repo, workflow_id: 'cloud-cf-deploy.yml', status: 'pending', per_page: 100,
+              created: createdBefore(cfg.pendingZeroJobMin),
+            });
+            core.info(`[${cfg.lane}] pending Cloud CF Deploy listed: ${pendingCloudDeploy.length}`);
+            for (const run of pendingCloudDeploy) {
+              if (run.id === context.runId) continue;
+              if (run.head_branch !== 'main') continue;
+              if (activeCloudDeploy.has('main:in_progress') || activeCloudDeploy.has('main:waiting')) {
+                core.info(`skip pending prod deploy ${run.id}: active same-branch deploy exists`);
+                continue;
+              }
+              const ageMin = minutesSince(run.created_at);
+              if (ageMin < cfg.pendingZeroJobMin) continue;
+              const live = await liveRun(run.id);
+              if (live?.status !== 'pending') {
+                core.info(`skip (list-stale, actually '${live?.status ?? 'missing'}'): ${run.id} ${run.name}`);
+                continue;
+              }
+              const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                owner, repo, run_id: run.id, filter: 'latest', per_page: 100,
+              });
+              if (jobs.length > 0) {
+                core.info(`skip pending prod deploy ${run.id}: ${jobs.length} job(s) exist`);
+                continue;
+              }
+              await reap(run, ageMin, ageMin, 'production deploy pending with zero jobs');
+              if (run.actor?.login === 'github-actions[bot]') {
+                core.warning(`cancelled bot-dispatched pending prod deploy ${run.id}; not redispatching again`);
+                continue;
+              }
+              if (cfg.dryRun) {
+                core.info(`would redispatch Cloud CF Deploy production at ${run.head_branch}`);
+                rows.push([`${run.id}`, run.name, `${ageMin}`, `${ageMin}`, 'would redispatch production deploy (dry run)']);
+                continue;
+              }
+              await github.rest.actions.createWorkflowDispatch({
+                owner, repo, workflow_id: 'cloud-cf-deploy.yml', ref: 'main',
+                inputs: { environment: 'production', force: 'false' },
+              });
+              core.warning(`redispatched Cloud CF Deploy production after cancelling pending/zero-job run ${run.id}`);
+              rows.push([`${run.id}`, run.name, `${ageMin}`, `${ageMin}`, 'redispatched production deploy once']);
+            }
+
+            // ---- 4. stale waiting runs (unapproved environment gates) ----
             // A run `waiting` on an environment approval that never comes
             // holds its concurrency group until GitHub's 30-day auto-expiry;
             // with cancel-in-progress:false every later run of the group sits

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -549,6 +549,40 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: bunx wrangler deploy ${{ steps.env.outputs.wrangler_args }} --var ELIZA_DEPLOY_COMMIT:"$GITHUB_SHA"
 
+      - name: Verify deployed API commit
+        if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true'
+        working-directory: ${{ env.CHECKOUT_DIR }}
+        env:
+          API_URL: ${{ steps.env.outputs.deploy_environment == 'production' && 'https://api.elizacloud.ai' || 'https://api-staging.elizacloud.ai' }}
+          DEPLOY_ENVIRONMENT: ${{ steps.env.outputs.deploy_environment }}
+        run: |
+          set -euo pipefail
+          expected_commit="$GITHUB_SHA"
+          expected_environment="$DEPLOY_ENVIRONMENT"
+          health_url="${API_URL%/}/api/health"
+          for attempt in 1 2 3 4 5 6; do
+            tmp="$(mktemp)"
+            code="$(curl -sS -o "$tmp" -w '%{http_code}' -m 20 "$health_url" || echo "000")"
+            if [ "$code" = "200" ] && head -c 1 "$tmp" | grep -q '[{[]'; then
+              observed_commit="$(node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(data.commit || '')" "$tmp")"
+              observed_environment="$(node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); process.stdout.write(data.environment || '')" "$tmp")"
+              if [ "$observed_commit" = "$expected_commit" ] && [ "$observed_environment" = "$expected_environment" ]; then
+                echo "API health serves commit ${observed_commit} for ${observed_environment}."
+                rm -f "$tmp"
+                exit 0
+              fi
+              echo "API health attempt ${attempt}: commit=${observed_commit:-<missing>} environment=${observed_environment:-<missing>}, expected commit=${expected_commit} environment=${expected_environment}" >&2
+            else
+              echo "API health attempt ${attempt}: HTTP ${code} from ${health_url}" >&2
+              head -c 300 "$tmp" >&2 2>/dev/null || true
+              echo >&2
+            fi
+            rm -f "$tmp"
+            [ "$attempt" -lt 6 ] && sleep 10
+          done
+          echo "::error::API health did not serve the deployed commit ${expected_commit} for ${expected_environment}."
+          exit 1
+
       - name: Clean temp checkout
         if: always()
         working-directory: /tmp

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -535,11 +535,11 @@ jobs:
           SERVED_URL: ${{ steps.env.outputs.deploy_environment == 'production' && 'https://api.elizacloud.ai' || 'https://api-staging.elizacloud.ai' }}
           FORCE: ${{ github.event_name == 'workflow_dispatch' && inputs.force == true }}
         run: |
-          node packages/scripts/cloud/deploy-freshness-guard-cli.mjs \
-            --run-sha "$GITHUB_SHA" \
-            --served-url "$SERVED_URL" \
-            --served-path /api/health \
-            $([ "$FORCE" = "true" ] && echo --force)
+          args=(--run-sha "$GITHUB_SHA" --served-url "$SERVED_URL" --served-path /api/health)
+          if [ "$FORCE" = "true" ]; then
+            args+=(--force)
+          fi
+          node packages/scripts/cloud/deploy-freshness-guard-cli.mjs "${args[@]}"
 
       - name: Deploy to Cloudflare Workers
         if: steps.cf.outputs.configured == 'true' && steps.freshness.outputs.should_deploy == 'true'
@@ -887,10 +887,11 @@ jobs:
           SERVED_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://elizacloud.ai' || 'https://staging.elizacloud.ai' }}
           FORCE: ${{ github.event_name == 'workflow_dispatch' && inputs.force == true }}
         run: |
-          node packages/scripts/cloud/deploy-freshness-guard-cli.mjs \
-            --run-sha "$GITHUB_SHA" \
-            --served-url "$SERVED_URL" \
-            $([ "$FORCE" = "true" ] && echo --force)
+          args=(--run-sha "$GITHUB_SHA" --served-url "$SERVED_URL")
+          if [ "$FORCE" = "true" ]; then
+            args+=(--force)
+          fi
+          node packages/scripts/cloud/deploy-freshness-guard-cli.mjs "${args[@]}"
 
       - name: Deploy to Cloudflare Pages
         if: steps.cf.outputs.configured == 'true' && (github.event_name == 'pull_request' || steps.freshness.outputs.should_deploy == 'true')
@@ -1262,10 +1263,11 @@ jobs:
           SERVED_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://app.elizacloud.ai' || 'https://app-staging.elizacloud.ai' }}
           FORCE: ${{ github.event_name == 'workflow_dispatch' && inputs.force == true }}
         run: |
-          node packages/scripts/cloud/deploy-freshness-guard-cli.mjs \
-            --run-sha "$GITHUB_SHA" \
-            --served-url "$SERVED_URL" \
-            $([ "$FORCE" = "true" ] && echo --force)
+          args=(--run-sha "$GITHUB_SHA" --served-url "$SERVED_URL")
+          if [ "$FORCE" = "true" ]; then
+            args+=(--force)
+          fi
+          node packages/scripts/cloud/deploy-freshness-guard-cli.mjs "${args[@]}"
 
       - name: Deploy to Cloudflare Pages
         if: steps.cf.outputs.configured == 'true' && (github.event_name == 'pull_request' || steps.freshness.outputs.should_deploy == 'true')


### PR DESCRIPTION
## Summary
- add production Cloud CF Deploy pending/zero-job detection to the freeze-proof Actions janitor
- force-cancel wedged production deploy runs and redispatch exactly once unless the retry was already bot-created
- assert the deployed API Worker `/api/health` commit and environment immediately after `wrangler deploy`
- quote freshness-guard argv construction so workflow actionlint passes cleanly

Fixes #15499
Refs #15503

## Validation
- `actionlint .github/workflows/actions-zombie-janitor.yml .github/workflows/cloud-cf-deploy.yml`
- `git diff --check origin/develop...HEAD`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/actions-zombie-janitor.yml .github/workflows/cloud-cf-deploy.yml`

## Evidence
<!-- evidence-row:before-screenshots -->
N/A - workflow-only CI/deploy recovery; no UI surface changed.
<!-- evidence-row:after-screenshots -->
N/A - workflow-only CI/deploy recovery; no UI surface changed.
<!-- evidence-row:walkthrough-video -->
N/A - workflow-only CI/deploy recovery; no interactive UI flow changed.
<!-- evidence-row:backend-logs -->
N/A - not run against production; validation is static workflow lint plus GitHub API inspection of the historical pending/zero-job run shape.
<!-- evidence-row:frontend-logs -->
N/A - no frontend code changed.
<!-- evidence-row:llm-trajectory -->
N/A - no agent/model/prompt behavior changed.
<!-- evidence-row:domain-artifacts -->
N/A - workflow-only guard; no domain artifact is produced until the next scheduled janitor/deploy run.

