### PR TITLE
test(pa): de-larp learning-goal preview assertion (echo-ratchet regression)

### DIFF
--- a/plugins/plugin-personal-assistant/test/scenarios/goal-learning-spanish-basic.scenario.ts
+++ b/plugins/plugin-personal-assistant/test/scenarios/goal-learning-spanish-basic.scenario.ts
@@ -34,7 +34,6 @@ export default scenario({
       kind: "message",
       name: "learning-goal grounded preview",
       text: "Let's define success as holding a 10-minute cafe-style conversation without switching to English by December 1, with four 20-minute practice blocks each week.",
-      responseIncludesAll: ["10", "Dec", "practice"],
       responseExcludes: ["details you mentioned"],
       responseJudge: {
         rubric:


### PR DESCRIPTION
## What / why

The Windows CI `framework-packages` shard (which runs `packages/scenario-runner test`) went red on the echo-assertion ratchet (`src/echo-assertion-ratchet.test.ts`), and the same test fails deterministically on Linux (platform-independent).

### Root cause
A recently-merged scenario, `plugins/plugin-personal-assistant/test/scenarios/goal-learning-spanish-basic.scenario.ts`, added an **echo-larp** assertion on its grounded-preview turn:

```ts
text: "Let's define success as holding a 10-minute cafe-style conversation ... by December 1, with four 20-minute practice blocks each week.",
responseIncludesAll: ["10", "Dec", "practice"],
```

All three substrings (`10`, `Dec`, `practice`) appear verbatim in that turn's own input text, so the assertion is *echo-satisfiable*: the agent passes by parroting the prompt, and the check can never fail for the real reason. The ratchet baseline is `0`, so this new echo-satisfiable scenario turned it RED (`grew to 1`).

### Fix
Drop the echo-larp substring check and rely on the real-effect assertions already present on that turn:
- the `responseJudge` rubric (previews the grounded goal, reflects the 10-minute evidence signal / December horizon / weekly cadence, marks it a preview step), and
- the `goalCountDelta` finalCheck (`requireSuccessCriteria` / `requireSupportStrategy` / `expectedGroundingState: "grounded"`).

This matches the accepted sibling `goal-fitness-5k-basic.scenario.ts`, which asserts the identical preview turn with judge + finalCheck only. The `responseExcludes: ["details you mentioned"]` decoy guard is retained. The ratchet baseline is **not** raised (that would permit larp).

## Validation
- `bun run --cwd packages/scenario-runner test src/echo-assertion-ratchet.test.ts` -> PASS (was RED).
- biome check on the touched file -> clean.
- `bun run audit:error-policy-ratchet` -> clean (test-only change, 0 production source files touched).

## Notes on the other two Windows-shard reds (investigated, no code change here)

- **`core-runtime` typecheck shard** (`run-turbo run typecheck --filter=@elizaos/core --filter=@elizaos/shared --filter=@elizaos/cloud-shared`): does **not** reproduce on Linux. A forced, cache-bypassed run of all three typecheck tasks is green (66/66), and both `tsgo --noEmit` and plain `tsc --noEmit` on `@elizaos/cloud-shared` exit 0. The Windows CI log shows `tsgo` starting (`$ tsgo --noEmit`) then emitting **no diagnostic** before a non-zero exit and no turbo task summary — a `tsgo` native-preview crash / transient on Windows, not a source type error. `tsgo` is platform-deterministic for real type errors, so there is nothing in TypeScript source to correct. Deferred (needs Windows repro / tooling, not a type fix).
- **`build-and-helper-smokes` `test-cloud-run.mjs` red**: the real cause was **not** the PGlite exit-99 pollution (that normalization is working — batch 8 was correctly normalized). Batch 7 had a genuine `1 fail` (status=1, correctly **not** normalized): a `mock.module("../credits", …)` factory in `app-credits-ledger.test.ts` was missing `APP_CHAT_RESERVATION_SETTLEMENT_MARKER`, and Bun's `mock.module` leaks across files in a batch, so a sibling's real `import("../credits")` failed to link (`SyntaxError: Export named 'APP_CHAT_RESERVATION_SETTLEMENT_MARKER' not found`). Already fixed on develop by **#15501** (`fix(cloud): stabilize shared test mocks`), which adds the missing export to the mock. Verified green locally: `bun test src/lib/services/__tests__/` -> 1052 tests, 0 fail, no SyntaxError. The exit-99 normalizer was intentionally left untouched — broadening it would risk masking real failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)