### PR TITLE
fix(ci): repair Client Tests + Plugin Tests residuals (feed mock, cloud bind assertions, battery blur)

### DIFF
--- a/packages/ui/src/components/shell/VoiceCaptureHud.tsx
+++ b/packages/ui/src/components/shell/VoiceCaptureHud.tsx
@@ -250,7 +250,7 @@ export function VoiceCaptureHud() {
         zIndex: Z_BUILD_BADGE,
       }}
     >
-      <div className="pointer-events-auto flex max-w-[calc(100%-0.5rem)] items-stretch gap-1 rounded-md border border-border bg-black/85 px-1.5 py-1 shadow-lg backdrop-blur">
+      <div className="pointer-events-auto flex max-w-[calc(100%-0.5rem)] items-stretch gap-1 rounded-md border border-border bg-black/85 px-1.5 py-1 shadow-lg">
         <div
           ref={scrollRef}
           data-testid="voice-capture-hud-lines"

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -596,7 +596,7 @@ describe("useFirstRunConductor", () => {
     ).toMatchObject({ authToken: "cloud-token" });
     expect(
       mocks.client.selectOrProvisionCloudAgent.mock.calls[0][0],
-    ).not.toHaveProperty("preferAgentId");
+    ).toMatchObject({ preferAgentId: "agent-1" });
     // The bound base owns app-shell routes → first-run persisted exactly once.
     expect(mocks.client.submitFirstRun).toHaveBeenCalledTimes(1);
 
@@ -1337,7 +1337,7 @@ describe("cloud-only onboarding (runtime chooser off — the production default)
     ).toMatchObject({ authToken: "cloud-token" });
     expect(
       mocks.client.selectOrProvisionCloudAgent.mock.calls[0][0],
-    ).not.toHaveProperty("preferAgentId");
+    ).toMatchObject({ preferAgentId: "agent-only" });
     expect(mocks.client.submitFirstRun).toHaveBeenCalledTimes(1);
     unmount();
   });
@@ -1415,7 +1415,7 @@ describe("cloud-only onboarding (runtime chooser off — the production default)
     ).toMatchObject({ authToken: "cloud-token" });
     expect(
       mocks.client.selectOrProvisionCloudAgent.mock.calls[0][0],
-    ).not.toHaveProperty("preferAgentId");
+    ).toMatchObject({ preferAgentId: "agent-newest-running" });
     unmount();
   });
 
@@ -1511,7 +1511,7 @@ describe("cloud-only onboarding (runtime chooser off — the production default)
     });
     expect(
       mocks.client.selectOrProvisionCloudAgent.mock.calls[0][0],
-    ).not.toHaveProperty("preferAgentId");
+    ).toMatchObject({ preferAgentId: "agent-console" });
     unmount();
   });
 

--- a/plugins/plugin-feed/src/components/FeedView.test.tsx
+++ b/plugins/plugin-feed/src/components/FeedView.test.tsx
@@ -52,10 +52,22 @@ vi.mock("@elizaos/app-core/ui-compat", () => ({
   client: feedClient,
   selectLatestRunForApp: latestRunForApp,
 }));
-vi.mock("@elizaos/ui/state", () => ({
-  useAppSelector: <T,>(selector: (value: typeof appState) => T) =>
-    selector(appState),
-}));
+// FeedView imports the real `@elizaos/ui` barrel (for `EmbeddedAppViewer`),
+// which loads the whole App chain — including the first-run conductor that
+// reads `ACCENT_PRESETS` (and other constants/hooks) from `../state` at module
+// load. Spread the real `@elizaos/ui/state` so every such export is present,
+// and override only `useAppSelector` to inject this test's run list.
+vi.mock("@elizaos/ui/state", async () => {
+  const actual =
+    await vi.importActual<typeof import("@elizaos/ui/state")>(
+      "@elizaos/ui/state",
+    );
+  return {
+    ...actual,
+    useAppSelector: <T,>(selector: (value: typeof appState) => T) =>
+      selector(appState),
+  };
+});
 
 import { FeedView } from "./FeedView";
 


### PR DESCRIPTION
CI remediation for two red Tests jobs on develop. All fixes are at the correct layer; no production behavior weakened. Locally verified: plugin-feed 40/40, ui conductor 56/56, ui backdrop-gate 2/2, ui + plugin-feed typecheck, biome, error-policy-ratchet all green.

## Plugin Tests (4/4) — `@elizaos/plugin-feed`

**Root cause:** `FeedView.test.tsx`'s `vi.mock("@elizaos/ui/state")` lacked `ACCENT_PRESETS`. A recent change added `ACCENT_PRESETS` to the first-run conductor (`packages/ui/src/first-run/use-first-run-conductor.ts`, `...ACCENT_PRESETS.map(...)` at module top level). FeedView imports the real `@elizaos/ui` barrel (for `EmbeddedAppViewer`), which loads the whole App chain → the conductor → the missing export throws `No "ACCENT_PRESETS" export is defined on the "@elizaos/ui/state" mock`. Same class as #15317/#15323/#15333.

**Fix:** spread the actual `@elizaos/ui/state` and override only `useAppSelector`, so `ACCENT_PRESETS` and any future export stay present. FeedView.test.tsx is the only plugin-feed test whose component-under-test loads the real barrel unmocked (verified the other ui/state-mocking plugin tests either mock the barrel or don't import it).

## Client Tests — `@elizaos/ui`

**1. `use-first-run-conductor.test.ts` (4 assertions + 4 secondary uncaught errors).** #15491 ("reconcile cloud agent bindings against running set") deliberately changed `listOrAutoProvisionCloudAgent` to pass `preferAgentId: running[0].agent_id` when exactly one cloud agent is running, but left the #15339 assertions asserting `.not.toHaveProperty("preferAgentId")`. Updated the 4 assertions to assert the intended preferred agent id. This also clears the `normalizeFirstRunName TypeError` uncaught errors: the failing assertion aborted each test before `unmount()`, leaking a mounted conductor that re-rendered against the `afterEach`-nulled store (the test fallback proxy returns a function for every field).

**2. `no-backdrop-blur-gate.test.ts`.** `VoiceCaptureHud.tsx` (an on-screen voice-capture debug-trace HUD, near-opaque `bg-black/85`) added a stray `backdrop-blur`, tripping the #9141 battery gate. It is not a designed glass surface and the blur is imperceptible over the opaque background, so removed the blur rather than widening the allow-list.

## Deferred (needs code-owner decision)

`client-cloud-connect-mock-cloud.test.ts` — 3 dedicated cold-boot **wake** tests (seed a `status:"stopped"` dedicated agent, expect resume + poll-to-running). These are red because #15491 changed `pickPreferredCloudAgent` to reuse only `status==="running"` agents, so a stopped agent is never selected → `selectOrProvisionCloudAgent` provisions a new one → `POST /api/v1/eliza/agents` (no mock route) 404s. #15491 also added a **passing** test (`client-cloud-select-or-provision.test.ts`: "does not reuse a non-running existing agent…") asserting a stopped **dedicated** agent (`makeAgent` default carries `web_ui_url`) yields `created===true`. The two contracts are mutually exclusive and both owner-authored; #15491 is the newer explicit intent, so the cold-boot-wake tests encode superseded behavior — but #15491 left the now-unreachable wake path (`selectOrProvisionCloudAgent` step 2 + `waitForCloudAgentRunning`) in place. Choosing between (a) retiring the cold-boot-wake feature + these tests or (b) relaxing `pickPreferredCloudAgent` to keep waking dedicated stopped agents (partial revert of #15491) is a product decision; forcing green either way would weaken one of two deliberately-authored guarantees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)