### PR TITLE
fix(ci): verify Pages frontend freshness

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -919,6 +919,19 @@ jobs:
             sleep $((attempt * 20))
           done
 
+      - name: Verify Pages frontend freshness
+        if: steps.cf.outputs.configured == 'true' && github.event_name != 'pull_request' && steps.freshness.outputs.should_deploy == 'true'
+        working-directory: ${{ env.CHECKOUT_DIR }}
+        env:
+          SERVED_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://elizacloud.ai' || 'https://staging.elizacloud.ai' }}
+        run: |
+          node packages/scripts/cloud/verify-pages-frontend-cli.mjs \
+            --served-url "$SERVED_URL" \
+            --dist packages/app/dist \
+            --require-text "Signing in to your agent" \
+            --require-text "This tab will continue automatically" \
+            --require-text "Open this agent from Eliza Cloud"
+
       # Same-origin checks against the SITE_URL custom domains were removed: those
       # domains were served by Vercel, which has been decommissioned. We verify the
       # freshly-deployed Cloudflare API Worker directly instead.
@@ -1292,6 +1305,19 @@ jobs:
             echo "::warning::Cloudflare Pages deploy attempt ${attempt} failed; retrying"
             sleep $((attempt * 20))
           done
+
+      - name: Verify Pages frontend freshness
+        if: steps.cf.outputs.configured == 'true' && github.event_name != 'pull_request' && steps.freshness.outputs.should_deploy == 'true'
+        working-directory: ${{ env.CHECKOUT_DIR }}
+        env:
+          SERVED_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://app.elizacloud.ai' || 'https://app-staging.elizacloud.ai' }}
+        run: |
+          node packages/scripts/cloud/verify-pages-frontend-cli.mjs \
+            --served-url "$SERVED_URL" \
+            --dist packages/app/dist \
+            --require-text "Signing in to your agent" \
+            --require-text "This tab will continue automatically" \
+            --require-text "Open this agent from Eliza Cloud"
 
       - name: Clean temp checkout
         if: always()

--- a/packages/scripts/__tests__/verify-pages-frontend.test.ts
+++ b/packages/scripts/__tests__/verify-pages-frontend.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Exercises the Cloudflare Pages frontend freshness guard. The deployment
+ * workflow needs a live custom-domain check because `wrangler pages deploy`
+ * can succeed while the production domain still serves an older Vite entry
+ * bundle, which leaves onboarding fixes absent from the user-facing app.
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  extractEntryAssets,
+  normalizeAssetPath,
+  normalizeBaseUrl,
+  verifyPagesFrontendOnce,
+} from "../cloud/verify-pages-frontend.mjs";
+import { parseArgs } from "../cloud/verify-pages-frontend-cli.mjs";
+
+const tmpRoots: string[] = [];
+
+function makeDist(asset = "assets/index-fresh.js") {
+  const dir = mkdtempSync(join(tmpdir(), "pages-frontend-"));
+  tmpRoots.push(dir);
+  writeFileSync(
+    join(dir, "index.html"),
+    `<html><head><script type="module" src="/${asset}"></script></head></html>`,
+  );
+  return dir;
+}
+
+function response(body: string, ok = true, status = ok ? 200 : 500) {
+  return { ok, status, text: async () => body };
+}
+
+afterEach(() => {
+  for (const root of tmpRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("extractEntryAssets", () => {
+  it("extracts unique Vite entry script assets from HTML", () => {
+    expect(
+      extractEntryAssets(`
+        <script type="module" src="/assets/index-a.js"></script>
+        <link rel="modulepreload" href="./assets/index-b.js">
+        <script src="/assets/chunk.js"></script>
+        <script type="module" src="/assets/index-a.js"></script>
+      `),
+    ).toEqual(["assets/index-a.js", "assets/index-b.js"]);
+  });
+
+  it("ignores non-string input", () => {
+    // @ts-expect-error deliberately wrong type
+    expect(extractEntryAssets(null)).toEqual([]);
+  });
+});
+
+describe("normalizers", () => {
+  it("normalizes base URLs and asset paths", () => {
+    expect(normalizeBaseUrl("https://app.elizacloud.ai")?.href).toBe(
+      "https://app.elizacloud.ai/",
+    );
+    expect(normalizeBaseUrl("not a url")).toBeNull();
+    expect(normalizeAssetPath("/assets/index-x.js")).toBe("assets/index-x.js");
+    expect(
+      normalizeAssetPath("https://app.elizacloud.ai/assets/index-x.js"),
+    ).toBe("assets/index-x.js");
+  });
+});
+
+describe("verifyPagesFrontendOnce", () => {
+  const noSleep = async () => {};
+
+  it("passes when the live index serves the local entry bundle with required text", async () => {
+    const distDir = makeDist();
+    const fetchImpl = (async (url: string) => {
+      if (url === "https://app.elizacloud.ai/") {
+        return response(
+          '<script type="module" src="/assets/index-fresh.js"></script>',
+        );
+      }
+      if (url === "https://app.elizacloud.ai/assets/index-fresh.js") {
+        return response("Signing in to your agent\nCloudPairRelay");
+      }
+      throw new Error(`unexpected URL ${url}`);
+    }) as unknown as typeof fetch;
+
+    const report = await verifyPagesFrontendOnce({
+      servedUrl: "https://app.elizacloud.ai",
+      distDir,
+      requiredTexts: ["Signing in to your agent", "CloudPairRelay"],
+      fetchImpl,
+      retrySleep: noSleep,
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.reason).toBe("ok");
+  });
+
+  it("fails when the custom domain still serves a stale entry bundle", async () => {
+    const distDir = makeDist();
+    const fetchImpl = (async () =>
+      response(
+        '<script type="module" src="/assets/index-stale.js"></script>',
+      )) as unknown as typeof fetch;
+
+    const report = await verifyPagesFrontendOnce({
+      servedUrl: "https://app.elizacloud.ai",
+      distDir,
+      fetchImpl,
+      retrySleep: noSleep,
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.reason).toBe("stale_entry_asset");
+    expect(report.detail).toContain("index-stale");
+    expect(report.detail).toContain("index-fresh");
+  });
+
+  it("fails when the served entry bundle misses required onboarding text", async () => {
+    const distDir = makeDist();
+    const fetchImpl = (async (url: string) => {
+      if (url.endsWith("/assets/index-fresh.js")) {
+        return response("Sign in with your password");
+      }
+      return response(
+        '<script type="module" src="/assets/index-fresh.js"></script>',
+      );
+    }) as unknown as typeof fetch;
+
+    const report = await verifyPagesFrontendOnce({
+      servedUrl: "https://app.elizacloud.ai",
+      distDir,
+      requiredTexts: ["Signing in to your agent"],
+      fetchImpl,
+      retrySleep: noSleep,
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.reason).toBe("required_text_missing");
+    expect(report.requiredTextResults).toEqual([
+      { text: "Signing in to your agent", present: false },
+    ]);
+  });
+
+  it("reports an unreachable live index", async () => {
+    const distDir = makeDist();
+    const fetchImpl = (async () =>
+      response("bad gateway", false, 502)) as unknown as typeof fetch;
+
+    const report = await verifyPagesFrontendOnce({
+      servedUrl: "https://app.elizacloud.ai",
+      distDir,
+      fetchImpl,
+      fetchAttempts: 1,
+      retrySleep: noSleep,
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.reason).toBe("index_unreachable");
+    expect(report.detail).toContain("502");
+  });
+});
+
+describe("parseArgs", () => {
+  it("parses required text and retry flags", () => {
+    expect(
+      parseArgs([
+        "--served-url",
+        "https://app.elizacloud.ai",
+        "--dist=packages/app/dist",
+        "--require-text",
+        "Signing in to your agent",
+        "--require-text=CloudPairRelay",
+        "--attempts",
+        "9",
+        "--interval-ms=250",
+        "--json",
+      ]),
+    ).toEqual({
+      servedUrl: "https://app.elizacloud.ai",
+      distDir: "packages/app/dist",
+      requiredTexts: ["Signing in to your agent", "CloudPairRelay"],
+      attempts: 9,
+      intervalMs: 250,
+      json: true,
+    });
+  });
+});

--- a/packages/scripts/cloud/verify-pages-frontend-cli.mjs
+++ b/packages/scripts/cloud/verify-pages-frontend-cli.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+/**
+ * CLI for the Cloudflare Pages frontend freshness verifier.
+ *
+ * Runs after `wrangler pages deploy` and probes the live custom domain, not the
+ * preview URL printed by wrangler, because launch regressions happen when the
+ * custom domain remains pinned to an older Pages deployment. The local `dist`
+ * entry chunk is the deployment contract; optional `--require-text` values add
+ * flow-level proof that critical UI code is present in the served bundle.
+ *
+ * Usage:
+ *   node packages/scripts/cloud/verify-pages-frontend-cli.mjs \
+ *     --served-url https://app.elizacloud.ai \
+ *     --dist packages/app/dist \
+ *     --require-text "Signing in to your agent"
+ */
+import fs from "node:fs";
+
+import { verifyPagesFrontendOnce } from "./verify-pages-frontend.mjs";
+
+function parseArgs(argv) {
+  const out = {
+    servedUrl: null,
+    distDir: null,
+    requiredTexts: [],
+    attempts: 6,
+    intervalMs: 10_000,
+    json: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--served-url") out.servedUrl = argv[++i];
+    else if (arg.startsWith("--served-url=")) {
+      out.servedUrl = arg.slice("--served-url=".length);
+    } else if (arg === "--dist") out.distDir = argv[++i];
+    else if (arg.startsWith("--dist="))
+      out.distDir = arg.slice("--dist=".length);
+    else if (arg === "--require-text") out.requiredTexts.push(argv[++i]);
+    else if (arg.startsWith("--require-text=")) {
+      out.requiredTexts.push(arg.slice("--require-text=".length));
+    } else if (arg === "--attempts") out.attempts = Number(argv[++i]);
+    else if (arg.startsWith("--attempts=")) {
+      out.attempts = Number(arg.slice("--attempts=".length));
+    } else if (arg === "--interval-ms") out.intervalMs = Number(argv[++i]);
+    else if (arg.startsWith("--interval-ms=")) {
+      out.intervalMs = Number(arg.slice("--interval-ms=".length));
+    } else if (arg === "--json") out.json = true;
+  }
+  return out;
+}
+
+function stdout(line = "") {
+  process.stdout.write(`${line}\n`);
+}
+
+function stderr(line = "") {
+  process.stderr.write(`${line}\n`);
+}
+
+function writeStepSummary(report) {
+  // biome-ignore lint/suspicious/noUndeclaredEnvVars: GitHub Actions provides this path.
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+  const requiredRows =
+    report.requiredTextResults.length === 0
+      ? ["| _none_ | - |"]
+      : report.requiredTextResults.map(
+          (result) =>
+            `| \`${result.text.replaceAll("`", "\\`")}\` | ${result.present ? "present" : "missing"} |`,
+        );
+  const lines = [
+    "### Pages frontend freshness verification",
+    "",
+    `**${report.ok ? "PASS" : "FAIL"}** - ${report.reason}`,
+    "",
+    `- Detail: ${report.detail}`,
+    `- Expected entry asset(s): ${report.expectedAssets.join(", ") || "-"}`,
+    `- Served entry asset(s): ${report.servedAssets.join(", ") || "-"}`,
+    "",
+    "| Required text | Status |",
+    "| --- | --- |",
+    ...requiredRows,
+    "",
+  ];
+  try {
+    fs.appendFileSync(summaryPath, `${lines.join("\n")}\n`);
+  } catch {
+    // error-policy:J7 diagnostics-must-not-kill-the-loop - the step summary is
+    // auxiliary CI output; the process exit code still carries the verdict.
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.servedUrl || !args.distDir) {
+    stderr(
+      "verify-pages-frontend: --served-url and --dist are required arguments",
+    );
+    process.exit(2);
+  }
+
+  let report = null;
+  const retrySleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  for (let attempt = 1; attempt <= args.attempts; attempt += 1) {
+    report = await verifyPagesFrontendOnce({
+      servedUrl: args.servedUrl,
+      distDir: args.distDir,
+      requiredTexts: args.requiredTexts,
+      retrySleep,
+    });
+    if (report.ok) break;
+    stderr(
+      `verify-pages-frontend attempt ${attempt}/${args.attempts}: ${report.reason} - ${report.detail}`,
+    );
+    if (attempt < args.attempts) await retrySleep(args.intervalMs);
+  }
+
+  if (args.json) {
+    stdout(JSON.stringify(report, null, 2));
+  } else {
+    stdout(`${report.ok ? "PASS" : "FAIL"}: ${report.reason}`);
+    stdout(report.detail);
+    stdout(`expected=${report.expectedAssets.join(",") || "-"}`);
+    stdout(`served=${report.servedAssets.join(",") || "-"}`);
+    for (const result of report.requiredTextResults) {
+      stdout(
+        `required-text ${result.present ? "present" : "missing"}: ${result.text}`,
+      );
+    }
+  }
+
+  writeStepSummary(report);
+  process.exit(report.ok ? 0 : 1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    // error-policy:J1 boundary translation - verifier crashes must fail the
+    // deployment gate instead of letting a stale frontend read as healthy.
+    stderr("verify-pages-frontend: unexpected error");
+    stderr(err instanceof Error ? (err.stack ?? err.message) : String(err));
+    process.exit(1);
+  });
+}
+
+export { parseArgs };

--- a/packages/scripts/cloud/verify-pages-frontend.mjs
+++ b/packages/scripts/cloud/verify-pages-frontend.mjs
@@ -1,0 +1,228 @@
+/**
+ * Verifies that a Cloudflare Pages custom domain is serving the frontend bundle
+ * that was just built by the deploy job. The check follows the live
+ * `index.html` to its Vite entry chunk, compares that chunk name to the local
+ * build output, and can require sentinel text that proves a specific user flow
+ * is present in the served JavaScript.
+ */
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const DEFAULT_ATTEMPTS = 3;
+const DEFAULT_TIMEOUT_MS = 20_000;
+
+function normalizeBaseUrl(url) {
+  const trimmed = `${url ?? ""}`.trim();
+  if (!trimmed) return null;
+  try {
+    return new URL(trimmed.endsWith("/") ? trimmed : `${trimmed}/`);
+  } catch {
+    // error-policy:J3 invalid user-provided URLs produce an explicit invalid report.
+    return null;
+  }
+}
+
+function normalizeAssetPath(asset) {
+  const trimmed = `${asset ?? ""}`.trim();
+  if (!trimmed) return null;
+  if (/^https?:\/\//.test(trimmed)) {
+    try {
+      return new URL(trimmed).pathname.replace(/^\/+/, "");
+    } catch {
+      // error-policy:J3 invalid asset URLs are ignored rather than treated as valid matches.
+      return null;
+    }
+  }
+  return trimmed.replace(/^\.?\//, "");
+}
+
+function extractEntryAssets(html) {
+  if (typeof html !== "string") return [];
+  const assets = new Set();
+  for (const match of html.matchAll(
+    /(?:src|href)=["']([^"']*assets\/index-[^"']+\.js)["']/g,
+  )) {
+    const asset = normalizeAssetPath(match[1]);
+    if (asset) assets.add(asset);
+  }
+  return [...assets].sort();
+}
+
+function normalizeRequiredTexts(requiredTexts) {
+  if (!Array.isArray(requiredTexts)) return [];
+  return requiredTexts
+    .map((text) => `${text ?? ""}`.trim())
+    .filter((text) => text.length > 0);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchText(url, options = {}) {
+  const {
+    fetchImpl = globalThis.fetch,
+    attempts = DEFAULT_ATTEMPTS,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    retrySleep = sleep,
+    intervalMs = 2_000,
+  } = options;
+  let lastDetail = "not attempted";
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetchImpl(url, { signal: controller.signal });
+      const text = await response.text();
+      if (response.ok) {
+        clearTimeout(timeout);
+        return { ok: true, text, detail: `HTTP ${response.status}` };
+      }
+      lastDetail = `HTTP ${response.status}: ${text.slice(0, 200)}`;
+    } catch (err) {
+      // error-policy:J1 boundary translation - network failures become verifier failure details.
+      lastDetail = err instanceof Error ? err.message : String(err);
+    } finally {
+      clearTimeout(timeout);
+    }
+    if (attempt < attempts) await retrySleep(intervalMs);
+  }
+  return { ok: false, text: "", detail: lastDetail };
+}
+
+async function readExpectedAssets(distDir) {
+  const indexPath = path.join(distDir, "index.html");
+  const html = await readFile(indexPath, "utf8");
+  return extractEntryAssets(html);
+}
+
+async function verifyPagesFrontendOnce(options) {
+  const {
+    servedUrl,
+    distDir,
+    requiredTexts = [],
+    fetchImpl,
+    fetchAttempts = DEFAULT_ATTEMPTS,
+    retrySleep = sleep,
+    fetchIntervalMs = 2_000,
+  } = options;
+  const baseUrl = normalizeBaseUrl(servedUrl);
+  const required = normalizeRequiredTexts(requiredTexts);
+  if (!baseUrl) {
+    return {
+      ok: false,
+      reason: "invalid_served_url",
+      detail: `Invalid served URL: ${servedUrl ?? ""}`,
+      expectedAssets: [],
+      servedAssets: [],
+      requiredTextResults: [],
+    };
+  }
+
+  const expectedAssets = await readExpectedAssets(distDir);
+  const indexFetch = await fetchText(baseUrl.href, {
+    fetchImpl,
+    attempts: fetchAttempts,
+    retrySleep,
+    intervalMs: fetchIntervalMs,
+  });
+  if (!indexFetch.ok) {
+    return {
+      ok: false,
+      reason: "index_unreachable",
+      detail: indexFetch.detail,
+      expectedAssets,
+      servedAssets: [],
+      requiredTextResults: [],
+    };
+  }
+
+  const servedAssets = extractEntryAssets(indexFetch.text);
+  const missingExpectedAssets = expectedAssets.filter(
+    (asset) => !servedAssets.includes(asset),
+  );
+  if (expectedAssets.length === 0 || servedAssets.length === 0) {
+    return {
+      ok: false,
+      reason: "entry_asset_missing",
+      detail: `expected=${expectedAssets.join(",") || "-"} served=${servedAssets.join(",") || "-"}`,
+      expectedAssets,
+      servedAssets,
+      missingExpectedAssets,
+      requiredTextResults: [],
+    };
+  }
+  if (missingExpectedAssets.length > 0) {
+    return {
+      ok: false,
+      reason: "stale_entry_asset",
+      detail: `Live index is serving ${servedAssets.join(", ")}; expected ${expectedAssets.join(", ")}`,
+      expectedAssets,
+      servedAssets,
+      missingExpectedAssets,
+      requiredTextResults: [],
+    };
+  }
+
+  const bundleTexts = await Promise.all(
+    expectedAssets.map(async (asset) => {
+      const assetUrl = new URL(asset, baseUrl);
+      const bundleFetch = await fetchText(assetUrl.href, {
+        fetchImpl,
+        attempts: fetchAttempts,
+        retrySleep,
+        intervalMs: fetchIntervalMs,
+      });
+      return { asset, ...bundleFetch };
+    }),
+  );
+  const failedBundle = bundleTexts.find((bundle) => !bundle.ok);
+  if (failedBundle) {
+    return {
+      ok: false,
+      reason: "entry_asset_unreachable",
+      detail: `${failedBundle.asset}: ${failedBundle.detail}`,
+      expectedAssets,
+      servedAssets,
+      missingExpectedAssets,
+      requiredTextResults: [],
+    };
+  }
+
+  const combinedBundle = bundleTexts.map((bundle) => bundle.text).join("\n");
+  const requiredTextResults = required.map((text) => ({
+    text,
+    present: combinedBundle.includes(text),
+  }));
+  const missingTexts = requiredTextResults
+    .filter((result) => !result.present)
+    .map((result) => result.text);
+  if (missingTexts.length > 0) {
+    return {
+      ok: false,
+      reason: "required_text_missing",
+      detail: `Missing required text: ${missingTexts.join(", ")}`,
+      expectedAssets,
+      servedAssets,
+      missingExpectedAssets,
+      requiredTextResults,
+    };
+  }
+
+  return {
+    ok: true,
+    reason: "ok",
+    detail: `Live bundle matches ${expectedAssets.join(", ")}`,
+    expectedAssets,
+    servedAssets,
+    missingExpectedAssets,
+    requiredTextResults,
+  };
+}
+
+export {
+  extractEntryAssets,
+  normalizeAssetPath,
+  normalizeBaseUrl,
+  verifyPagesFrontendOnce,
+};

--- a/turbo.json
+++ b/turbo.json
@@ -260,6 +260,7 @@
         "@elizaos/plugin-agent-skills#build",
         "@elizaos/plugin-app-manager#build",
         "@elizaos/plugin-inbox#build",
+        "@elizaos/plugin-sql#build",
         "@elizaos/plugin-task-coordinator#build"
       ],
       "outputs": []
@@ -337,11 +338,7 @@
       "outputs": []
     },
     "@elizaos/plugin-capacitor-bridge#typecheck": {
-      "dependsOn": [
-        "@elizaos/core#build",
-        "@elizaos/shared#build",
-        "^build"
-      ],
+      "dependsOn": ["@elizaos/core#build", "@elizaos/shared#build", "^build"],
       "outputs": []
     },
     "@elizaos/example-autonomous#typecheck": {


### PR DESCRIPTION
## Summary
- add a Cloudflare Pages frontend freshness verifier that compares the live custom-domain Vite entry asset to the freshly built `packages/app/dist/index.html`
- require the onboarding relay strings from #15507 in the served entry bundle after deploy
- wire the guard into both Pages jobs: apex `eliza-cloud` and app `eliza-app`
- add `@elizaos/plugin-sql#build` to root `typecheck` dependencies so CI typecheck does not race consumers of the generated plugin-sql build output

Fixes #15507 by adding the missing CI/deploy guard. It does not perform the prod deploy itself.

## Validation
- `bun test packages/scripts/__tests__/verify-pages-frontend.test.ts packages/scripts/__tests__/ci-turbo-cache-contract.test.ts packages/scripts/__tests__/turbo-cache-key.test.ts packages/scripts/__tests__/turbo-build-stamp-env-contract.test.ts` — 22 pass
- `bunx @biomejs/biome check turbo.json packages/scripts/cloud/verify-pages-frontend.mjs packages/scripts/cloud/verify-pages-frontend-cli.mjs packages/scripts/__tests__/verify-pages-frontend.test.ts` — pass
- `actionlint .github/workflows/cloud-cf-deploy.yml` — pass
- `git diff --check origin/develop...HEAD` — pass
- `bun run audit:error-policy-ratchet --report` — pass, no new fallback slop
- `node scripts/pr-evidence.mjs verify 15510` — pass

## Live Proof
Using current staging `index.html` as the expected fresh build:
- `verify-pages-frontend-cli --served-url https://app-staging.elizacloud.ai ...` passed and found `Signing in to your agent`, `This tab will continue automatically`, and `Open this agent from Eliza Cloud`.
- `verify-pages-frontend-cli --served-url https://app.elizacloud.ai ...` failed with `stale_entry_asset` when prod served a different entry asset than staging.

Follow-up live string check after the direct deploy moved forward:
- `https://app.elizacloud.ai` now serves relay strings.
- `https://elizacloud.ai` still served a bundle matching only `Sign in with your password`, so the apex Pages job also needs this guard.

## Evidence Checklist
- Real UI screenshots/video: N/A - CI/deploy guard only; no rendered UI component changed.
- Frontend console/network logs: N/A - no browser runtime path changed.
- Backend logs: N/A - no backend runtime path changed.
- Real-LLM trajectories: N/A - no model/action/provider/prompt behavior changed.
- Domain artifacts: live custom-domain asset/string proof included below.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - CI deploy guard only; no rendered UI component changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - CI deploy guard only; no rendered UI component changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - CI deploy guard only; no user flow implementation changed.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime path changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser runtime path changed; verifier output is attached as domain artifact.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, provider, or evaluator behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [15510-domain-artifacts.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15510-domain-artifacts.md)
