### PR TITLE
fix(ui): avoid www redirect for cloud pair exchange

### DIFF
--- a/packages/ui/src/components/auth/CloudPairRelay.tsx
+++ b/packages/ui/src/components/auth/CloudPairRelay.tsx
@@ -50,7 +50,11 @@ export function resolveCloudPairExchangeUrl(cloudApiBase?: string): string {
   const base = (configured || "https://elizacloud.ai")
     .replace(/\/+$/, "")
     .replace(/\/api\/v1\/?$/, "");
-  return `${base}/api/auth/pair`;
+  const url = new URL(`${base}/api/auth/pair`);
+  if (url.hostname === "www.elizacloud.ai") {
+    url.hostname = "elizacloud.ai";
+  }
+  return url.toString();
 }
 
 export async function exchangeCloudPairToken(

--- a/packages/ui/src/components/auth/__tests__/CloudPairRelay.test.tsx
+++ b/packages/ui/src/components/auth/__tests__/CloudPairRelay.test.tsx
@@ -80,6 +80,9 @@ describe("CloudPairRelay", () => {
     expect(
       resolveCloudPairExchangeUrl("https://api.elizacloud.ai/api/v1"),
     ).toBe("https://api.elizacloud.ai/api/auth/pair");
+    expect(resolveCloudPairExchangeUrl("https://www.elizacloud.ai")).toBe(
+      "https://elizacloud.ai/api/auth/pair",
+    );
   });
 
   it("detects Eliza Cloud-hosted surfaces without matching localhost", () => {


### PR DESCRIPTION
## Summary
- canonicalize `https://www.elizacloud.ai` to `https://elizacloud.ai` for the Cloud pair token exchange endpoint
- add a regression assertion so the browser pair relay cannot POST to the redirecting `www` host

Fixes the remaining pair-completion risk found under #15507 after the production Pages redeploy. The UI no longer falls into the password wall, but the deployed bundle can still carry `cloudApiBase=https://www.elizacloud.ai`; browser POST preflights to that host are rejected because `www` returns a 308 to apex.

## Validation
- `bun run --cwd packages/ui test src/components/auth/__tests__/CloudPairRelay.test.tsx` — 10 pass
- `bunx @biomejs/biome check packages/ui/src/components/auth/CloudPairRelay.tsx packages/ui/src/components/auth/__tests__/CloudPairRelay.test.tsx` — pass

## Evidence Checklist
- Real UI screenshots/video: N/A - endpoint resolver only; no rendered layout or visual state changes.
- Frontend console/network logs: see domain artifact below for live prod console/CORS proof.
- Backend logs: N/A - no backend runtime path changed.
- Real-LLM trajectories: N/A - no model/action/provider/prompt behavior changed.
- Domain artifacts: [https://github.com/elizaOS/eliza/releases/download/pr-evidence/15511-cloud-pair-www-preflight.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15511-cloud-pair-www-preflight.md).

<!-- evidence-row:before-screenshots -->
- [x] ![before-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15511-before-prod-pair.png)

<!-- evidence-row:after-screenshots -->
- [x] ![after-screenshots](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15511-after-local-patched-pair.png)

<!-- evidence-row:walkthrough-video -->
- [x] https://github.com/elizaOS/eliza/releases/download/pr-evidence/15511-walkthrough.mp4

<!-- evidence-row:backend-logs -->
- [ ] N/A - no backend runtime path changed.

<!-- evidence-row:frontend-logs -->
- [x] [15511-frontend-logs.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15511-frontend-logs.txt)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, provider, or evaluator behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [15511-cloud-pair-www-preflight.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15511-cloud-pair-www-preflight.md)

<!-- evidence-row:ocr-review -->
- [x] [15511-ocr-review.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15511-ocr-review.txt)
