### PR TITLE
fix(ui): green ui format:check + chat-sheet restore-after-committed-over-pull

### DIFF
--- a/packages/ui/src/components/shell/use-pull-gesture.test.ts
+++ b/packages/ui/src/components/shell/use-pull-gesture.test.ts
@@ -544,6 +544,52 @@ describe("usePullGesture rAF coalescing (#9141)", () => {
     expect(onPullUp).toHaveBeenCalledTimes(1);
   });
 
+  it("re-seeds a fresh gesture after the prior gesture's element unmounted mid-drag (stranded start)", () => {
+    // The maximize restore strip only exists while maximized: the instant a
+    // restore un-maximizes, its element unmounts BEFORE its captured pointerup
+    // lands, so `start` is stranded with the old pointerId. A later PRIMARY
+    // pointerdown on the remounted strip (a new id, no other finger down) must
+    // start a fresh gesture, not be rejected by the dead id — otherwise every
+    // restore after the first is dead-on-arrival (the touch-only regression the
+    // two-cycle maximize→restore→maximize→restore chat-sheet e2e path caught).
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((cb: FrameRequestCallback) => {
+        cb(0);
+        return 1;
+      }),
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+    const onStart = vi.fn();
+    const onDrag = vi.fn();
+    const onPullUp = vi.fn();
+    const { result } = renderHook(() =>
+      usePullGesture({ onStart, onDrag, onPullUp }),
+    );
+    const b = result.current;
+
+    // Gesture 1 (pid=1): press + drag, then its element unmounts — the pointerup
+    // NEVER arrives, so `start` stays set to pid=1.
+    b.onPointerDown(pointer(100, 300, 1));
+    b.onPointerMove(pointer(100, 200, 1));
+    expect(onStart).toHaveBeenCalledTimes(1);
+    expect(onDrag).toHaveBeenLastCalledWith(100);
+
+    onStart.mockClear();
+    onDrag.mockClear();
+
+    // Gesture 2 (pid=2, primary) on the remounted strip: must be adopted despite
+    // the stranded pid=1, so it drives + releases a full pull.
+    b.onPointerDown(pointer(100, 300, 2));
+    b.onPointerMove(pointer(100, 160, 2));
+    b.onPointerUp(pointer(100, 160, 2));
+
+    expect(onStart).toHaveBeenCalledTimes(1);
+    expect(onDrag).toHaveBeenLastCalledWith(140);
+    expect(onPullUp).toHaveBeenCalledTimes(1);
+  });
+
   it("calls onStart once for the accepted pointer and ignores secondary starts", () => {
     vi.stubGlobal(
       "requestAnimationFrame",
@@ -561,15 +607,35 @@ describe("usePullGesture rAF coalescing (#9141)", () => {
     );
     const b = result.current;
 
-    b.onPointerDown(pointer(100, 300, 2, undefined, { isPrimary: false, pointerType: "touch" }));
-    b.onPointerMove(pointer(100, 160, 2, undefined, { isPrimary: false, pointerType: "touch" }));
-    b.onPointerUp(pointer(100, 160, 2, undefined, { isPrimary: false, pointerType: "touch" }));
+    b.onPointerDown(
+      pointer(100, 300, 2, undefined, {
+        isPrimary: false,
+        pointerType: "touch",
+      }),
+    );
+    b.onPointerMove(
+      pointer(100, 160, 2, undefined, {
+        isPrimary: false,
+        pointerType: "touch",
+      }),
+    );
+    b.onPointerUp(
+      pointer(100, 160, 2, undefined, {
+        isPrimary: false,
+        pointerType: "touch",
+      }),
+    );
 
     expect(onStart).not.toHaveBeenCalled();
     expect(onPullUp).not.toHaveBeenCalled();
 
     b.onPointerDown(pointer(100, 300, 1));
-    b.onPointerDown(pointer(100, 280, 2, undefined, { isPrimary: false, pointerType: "touch" }));
+    b.onPointerDown(
+      pointer(100, 280, 2, undefined, {
+        isPrimary: false,
+        pointerType: "touch",
+      }),
+    );
     b.onPointerMove(pointer(100, 160, 1));
     b.onPointerUp(pointer(100, 160, 1));
 

--- a/packages/ui/src/components/shell/use-pull-gesture.ts
+++ b/packages/ui/src/components/shell/use-pull-gesture.ts
@@ -169,8 +169,22 @@ export function usePullGesture(
 
   const onPointerDown = React.useCallback(
     (event: React.PointerEvent) => {
-      if (event.isPrimary === false && event.pointerType && event.pointerType !== "mouse") return;
-      if (start.current && start.current.pointerId !== event.pointerId) return;
+      if (
+        event.isPrimary === false &&
+        event.pointerType &&
+        event.pointerType !== "mouse"
+      )
+        return;
+      // A press that reaches here is the primary pointer (a secondary touch
+      // finger returned above), so it is the ONLY pointer down. Any `start` still
+      // held with a different id is therefore stale — the previous gesture's
+      // element unmounted before delivering the pointerup/cancel that clears it
+      // (the maximize restore strip unmounts the instant a restore un-maximizes,
+      // so its captured release never lands and `start` is stranded with the old
+      // id). Re-seed from this press instead of letting the dead id reject every
+      // future gesture on the remounted element; only a duplicate down for the
+      // pointer we already track is ignored.
+      if (start.current?.pointerId === event.pointerId) return;
       start.current = {
         x: event.clientX,
         y: event.clientY,


### PR DESCRIPTION
Two fresh current-tip CI failures, both introduced by **#15497 (39c72afff51)**.

## 1. Quality (Extended) → `@elizaos/ui format:check` (biome format drift)

#15497 merged two files that were not biome-formatted:
`packages/ui/src/components/shell/use-pull-gesture.ts` and its
`use-pull-gesture.test.ts` (an unwrapped multi-condition `if`). Ran biome
`format --write` on **exactly those two drifted files** — no unrelated
reformatting. `bun run --cwd packages/ui format:check` now passes (2589 files,
no fixes).

## 2. `test:chat-sheet-e2e` → `[touch] restore after committed over-pull leaves MAXIMIZED state`

**Regression, not intentional contract change — fixed the product.** The
assertion is NEW in #15497 (a two-cycle maximize → restore → maximize → restore
path on touch). It exposed a real bug in the shared pull-gesture state machine.

**Root cause (proven with per-frame instrumentation):** the
`chat-maximize-restore-zone` element exists *only while maximized*. The instant
the FIRST restore un-maximizes, that element unmounts — so its captured
`pointerup`/`pointercancel` never lands, and `usePullGesture`'s `start` ref is
**stranded** with the old `pointerId`. When the sheet is re-maximized and the
SECOND restore's `pointerdown` fires (a new `pointerId`), the pre-existing guard
`if (start.current && start.current.pointerId !== event.pointerId) return`
rejected it, so `start` stayed pinned to the dead id and **every** subsequent
`pointermove` was dropped (`startPid 5 ≠ eventPid 7`) — `onDrag`/`onRestoreDrag`
never ran and the sheet could never un-maximize. Geometry was identical between
the working and failing restores (restore-zone center on-screen at cx=490 in a
980px viewport), ruling out the "panel wider than viewport" theory in the test's
own comment. Mouse escaped this (lostpointercapture fires on unmount / constant
pointerId), which is why only `[touch]` failed.

**Fix — at the correct layer (the shared gesture hook):** a primary pointerdown
means no other finger is down, so any lingering `start` with a different id is
definitively stale — re-seed the gesture from the fresh press instead of letting
the dead id reject the remounted element's next gesture. This makes every
consumer robust to its bound element unmounting mid-gesture. Added a unit
regression test that reproduces the stranded-`start` scenario and **fails with
the old guard**.

## Validation (local, run to completion)
- `bun run --cwd packages/ui format:check` → green
- `bun run --cwd packages/ui test:chat-sheet-e2e` → **294/294 green** (both
  `[mouse]` and `[touch]` "restore after committed over-pull" now report
  `state=OPEN_HALF_OR_OVER, data-maximized=false`)
- `use-pull-gesture` unit suite → 30/30 (new test fails without the fix)
- biome lint clean on both touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)