### PR TITLE
fix(cloud): passthrough OpenAI embeddings

### DIFF
--- a/packages/cloud/api/__tests__/embeddings-affiliate-clamp.integration.test.ts
+++ b/packages/cloud/api/__tests__/embeddings-affiliate-clamp.integration.test.ts
@@ -138,6 +138,7 @@ mock.module("@/lib/providers/language-model", () => ({
   hasTextEmbeddingProviderConfigured: () => true,
   getTextEmbeddingModel: () => ({}) as never,
   resolveEmbeddingProviderSource: () => "openai",
+  resolvePassthroughEmbeddingsUpstreamForModel: () => null,
   getAiProviderConfigurationError: () => "AI services are not configured",
 }));
 

--- a/packages/cloud/api/__tests__/embeddings-passthrough.test.ts
+++ b/packages/cloud/api/__tests__/embeddings-passthrough.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Pass-through fast path for POST /api/v1/embeddings (#15512).
+ *
+ * Tests the route-adjacent forwarder directly with real env-based upstream
+ * resolution. The route suites import the full embeddings route separately;
+ * this file avoids module mocks so it cannot poison their billing/auth mocks in
+ * Bun's shared test module registry.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const realFetch = globalThis.fetch;
+const savedEnv = {
+  INFERENCE_PASSTHROUGH_EMBEDDINGS:
+    process.env.INFERENCE_PASSTHROUGH_EMBEDDINGS,
+  INFERENCE_PASSTHROUGH_EMBEDDINGS_TEST:
+    process.env.INFERENCE_PASSTHROUGH_EMBEDDINGS_TEST,
+  OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+  OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
+};
+
+const { tryPassthroughEmbeddingsRequest, __embeddingsPassthroughTestHooks } =
+  await import("../v1/embeddings/passthrough");
+
+function restoreEnv() {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function enablePassthroughEnv() {
+  process.env.INFERENCE_PASSTHROUGH_EMBEDDINGS = "true";
+  process.env.INFERENCE_PASSTHROUGH_EMBEDDINGS_TEST = "true";
+  process.env.OPENAI_API_KEY = "test-openai-key";
+  process.env.OPENAI_BASE_URL = "https://api.openai.test/v1";
+}
+
+beforeEach(() => {
+  restoreEnv();
+  globalThis.fetch = realFetch;
+});
+
+afterEach(() => {
+  restoreEnv();
+  globalThis.fetch = realFetch;
+});
+
+describe("embeddings pass-through forwarder", () => {
+  test("returns upstream JSON and extracts prompt_tokens for billing", async () => {
+    enablePassthroughEnv();
+    const fetchMock = mock();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const upstreamBody = {
+      object: "list",
+      data: [{ object: "embedding", embedding: [0.25, -0.75, 1], index: 0 }],
+      model: "text-embedding-3-small",
+      usage: { prompt_tokens: 7, total_tokens: 7 },
+    };
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify(upstreamBody), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const settleReservation = mock();
+
+    const result = await tryPassthroughEmbeddingsRequest({
+      model: "openai/text-embedding-3-small",
+      request: { model: "openai/text-embedding-3-small", input: "hello" },
+      estimatedInputTokens: 2,
+      settleReservation,
+      abortSignal: undefined,
+    });
+
+    expect(result).toEqual({
+      kind: "success",
+      bodyText: JSON.stringify(upstreamBody),
+      contentType: "application/json",
+      actualTokens: 7,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      model: "text-embedding-3-small",
+      input: "hello",
+    });
+    expect(settleReservation).not.toHaveBeenCalled();
+  });
+
+  test("upstream errors release the hold and return a structured error response", async () => {
+    enablePassthroughEnv();
+    const fetchMock = mock();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    fetchMock.mockResolvedValue(
+      Response.json(
+        { error: { message: "rate limited upstream" } },
+        { status: 429 },
+      ),
+    );
+    const settleReservation = mock(async () => undefined);
+
+    const result = await tryPassthroughEmbeddingsRequest({
+      model: "text-embedding-3-small",
+      request: { model: "text-embedding-3-small", input: "hello" },
+      estimatedInputTokens: 2,
+      settleReservation,
+      abortSignal: undefined,
+    });
+
+    expect(result?.kind).toBe("response");
+    if (result?.kind !== "response") throw new Error("expected response");
+    expect(result.response.status).toBe(429);
+    expect(await result.response.json()).toMatchObject({
+      error: { message: "rate limited upstream" },
+    });
+    expect(settleReservation).toHaveBeenCalledTimes(1);
+    expect(settleReservation).toHaveBeenCalledWith(0);
+  });
+
+  test("flag-off and unresolved upstream fall through to the SDK path", async () => {
+    process.env.INFERENCE_PASSTHROUGH_EMBEDDINGS = "false";
+    process.env.INFERENCE_PASSTHROUGH_EMBEDDINGS_TEST = "true";
+    process.env.OPENAI_API_KEY = "test-openai-key";
+    process.env.OPENAI_BASE_URL = "https://api.openai.test/v1";
+    await expect(
+      tryPassthroughEmbeddingsRequest({
+        model: "text-embedding-3-small",
+        request: { model: "text-embedding-3-small", input: "hello" },
+        estimatedInputTokens: 2,
+        settleReservation: mock(),
+        abortSignal: undefined,
+      }),
+    ).resolves.toBeNull();
+
+    process.env.INFERENCE_PASSTHROUGH_EMBEDDINGS = "true";
+    process.env.INFERENCE_PASSTHROUGH_EMBEDDINGS_TEST = "true";
+    delete process.env.OPENAI_API_KEY;
+    await expect(
+      tryPassthroughEmbeddingsRequest({
+        model: "text-embedding-3-small",
+        request: { model: "text-embedding-3-small", input: "hello" },
+        estimatedInputTokens: 2,
+        settleReservation: mock(),
+        abortSignal: undefined,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  test("status mapper keeps caller-fault statuses and hides provider auth/server failures", () => {
+    const { mapPassthroughEmbeddingsStatus } = __embeddingsPassthroughTestHooks;
+    expect(mapPassthroughEmbeddingsStatus(400)).toBe(400);
+    expect(mapPassthroughEmbeddingsStatus(402)).toBe(402);
+    expect(mapPassthroughEmbeddingsStatus(404)).toBe(404);
+    expect(mapPassthroughEmbeddingsStatus(429)).toBe(429);
+    expect(mapPassthroughEmbeddingsStatus(401)).toBe(503);
+    expect(mapPassthroughEmbeddingsStatus(403)).toBe(503);
+    expect(mapPassthroughEmbeddingsStatus(500)).toBe(503);
+  });
+});

--- a/packages/cloud/api/__tests__/embeddings-route-billing.test.ts
+++ b/packages/cloud/api/__tests__/embeddings-route-billing.test.ts
@@ -69,6 +69,7 @@ mock.module("@/lib/providers/language-model", () => ({
   hasTextEmbeddingProviderConfigured: () => true,
   getTextEmbeddingModel: () => ({}) as never,
   resolveEmbeddingProviderSource: () => "openai",
+  resolvePassthroughEmbeddingsUpstreamForModel: () => null,
   getAiProviderConfigurationError: () => "AI services are not configured",
 }));
 

--- a/packages/cloud/api/v1/embeddings/passthrough.ts
+++ b/packages/cloud/api/v1/embeddings/passthrough.ts
@@ -1,0 +1,188 @@
+/**
+ * OpenAI-native embeddings pass-through for the cloud inference gateway.
+ *
+ * The route owns auth, rate limiting, request validation, and credit admission;
+ * this helper only replaces the AI-SDK embedding call for requests that can be
+ * represented as a plain OpenAI-compatible JSON forward. It returns either the
+ * upstream JSON body and usage tokens for the existing settlement chain, a
+ * structured error response after releasing the hold, or null to let the route
+ * fall back to the SDK path.
+ */
+
+import { resolvePassthroughEmbeddingsUpstreamForModel } from "@/lib/providers/language-model";
+import { isPassthroughEmbeddingsEnabled } from "@/lib/services/inference-passthrough";
+import { logger } from "@/lib/utils/logger";
+
+export interface EmbeddingsPassthroughRequest {
+  input: string | string[];
+  model: string;
+  encoding_format?: "float" | "base64";
+  dimensions?: number;
+  user?: string;
+}
+
+export type EmbeddingsReservationSettler = (
+  actualCost: number,
+) => Promise<unknown>;
+
+export type EmbeddingsPassthroughResult =
+  | {
+      kind: "success";
+      bodyText: string;
+      contentType: string;
+      actualTokens: number;
+    }
+  | { kind: "response"; response: Response }
+  | null;
+
+function mapPassthroughEmbeddingsStatus(status: number): number {
+  if (status === 400 || status === 402 || status === 404 || status === 429) {
+    return status;
+  }
+  return 503;
+}
+
+function passthroughEmbeddingsErrorResponse(
+  status: number,
+  message: string,
+): Response {
+  return Response.json(
+    {
+      error: {
+        message,
+        type: status === 429 ? "rate_limit_error" : "service_unavailable",
+        code: status === 429 ? "rate_limit_exceeded" : "provider_error",
+      },
+    },
+    { status },
+  );
+}
+
+function parseObject(value: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object"
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    // error-policy:J3 untrusted upstream JSON parse; invalid JSON becomes an explicit provider error response, never a fake-success embedding payload.
+    return null;
+  }
+}
+
+function extractPromptTokens(
+  body: Record<string, unknown>,
+  fallback: number,
+): number {
+  const usage =
+    body.usage && typeof body.usage === "object"
+      ? (body.usage as Record<string, unknown>)
+      : null;
+  const promptTokens = usage?.prompt_tokens;
+  if (typeof promptTokens === "number" && Number.isFinite(promptTokens)) {
+    return promptTokens;
+  }
+  const totalTokens = usage?.total_tokens;
+  if (typeof totalTokens === "number" && Number.isFinite(totalTokens)) {
+    return totalTokens;
+  }
+  return fallback;
+}
+
+export async function tryPassthroughEmbeddingsRequest(params: {
+  model: string;
+  request: EmbeddingsPassthroughRequest;
+  estimatedInputTokens: number;
+  settleReservation: EmbeddingsReservationSettler;
+  abortSignal: AbortSignal | undefined;
+}): Promise<EmbeddingsPassthroughResult> {
+  if (!isPassthroughEmbeddingsEnabled()) return null;
+  const upstream = resolvePassthroughEmbeddingsUpstreamForModel(params.model);
+  if (!upstream) return null;
+
+  const upstreamBody = {
+    ...params.request,
+    model: upstream.modelId,
+  };
+
+  let response: Response;
+  try {
+    response = await fetch(upstream.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${upstream.apiKey}`,
+      },
+      body: JSON.stringify(upstreamBody),
+      ...(params.abortSignal ? { signal: params.abortSignal } : {}),
+    });
+  } catch (error) {
+    // error-policy:J1 route helper boundary — transport failures release the reservation and become an explicit provider-error HTTP response.
+    await params.settleReservation(0);
+    logger.error("[Embeddings] Passthrough upstream fetch failed", {
+      model: params.model,
+      provider: upstream.providerId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return {
+      kind: "response",
+      response: passthroughEmbeddingsErrorResponse(
+        503,
+        "upstream provider request failed",
+      ),
+    };
+  }
+
+  const bodyText = await response.text();
+  if (!response.ok) {
+    await params.settleReservation(0);
+    const status = mapPassthroughEmbeddingsStatus(response.status);
+    let message = "upstream provider error";
+    if (status !== 503) {
+      const upstreamMessage = parseObject(bodyText)?.error;
+      message =
+        upstreamMessage &&
+        typeof upstreamMessage === "object" &&
+        typeof (upstreamMessage as Record<string, unknown>).message === "string"
+          ? String((upstreamMessage as Record<string, unknown>).message)
+          : `upstream provider returned ${response.status}`;
+    }
+    logger.error("[Embeddings] Passthrough upstream error status", {
+      model: params.model,
+      provider: upstream.providerId,
+      upstreamStatus: response.status,
+      mappedStatus: status,
+    });
+    return {
+      kind: "response",
+      response: passthroughEmbeddingsErrorResponse(status, message),
+    };
+  }
+
+  const parsed = parseObject(bodyText);
+  if (!parsed) {
+    await params.settleReservation(0);
+    logger.error("[Embeddings] Passthrough upstream returned invalid JSON", {
+      model: params.model,
+      provider: upstream.providerId,
+    });
+    return {
+      kind: "response",
+      response: passthroughEmbeddingsErrorResponse(
+        503,
+        "upstream provider returned invalid JSON",
+      ),
+    };
+  }
+
+  return {
+    kind: "success",
+    bodyText,
+    contentType: response.headers.get("Content-Type") ?? "application/json",
+    actualTokens: extractPromptTokens(parsed, params.estimatedInputTokens),
+  };
+}
+
+export const __embeddingsPassthroughTestHooks = {
+  mapPassthroughEmbeddingsStatus,
+};

--- a/packages/cloud/api/v1/embeddings/route.ts
+++ b/packages/cloud/api/v1/embeddings/route.ts
@@ -51,6 +51,7 @@ import { usageService } from "@/lib/services/usage";
 import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
+import { tryPassthroughEmbeddingsRequest } from "./passthrough";
 
 interface EmbeddingsRequest {
   input: string | string[];
@@ -449,8 +450,30 @@ app.post("/", async (c) => {
 
     let embeddings: number[][];
     let actualTokens = 0;
+    let passthroughResponse:
+      | {
+          bodyText: string;
+          contentType: string;
+        }
+      | undefined;
 
-    if (Array.isArray(request.input)) {
+    const passthrough = await tryPassthroughEmbeddingsRequest({
+      model,
+      request,
+      estimatedInputTokens,
+      settleReservation,
+      abortSignal: c.req.raw.signal,
+    });
+    if (passthrough?.kind === "response") return passthrough.response;
+
+    if (passthrough?.kind === "success") {
+      embeddings = [];
+      actualTokens = passthrough.actualTokens;
+      passthroughResponse = {
+        bodyText: passthrough.bodyText,
+        contentType: passthrough.contentType,
+      };
+    } else if (Array.isArray(request.input)) {
       const result = await embedMany({
         model: getTextEmbeddingModel(model),
         values: request.input,
@@ -551,6 +574,13 @@ app.post("/", async (c) => {
 
     if (typeof c.executionCtx?.waitUntil === "function") {
       c.executionCtx.waitUntil(billedPromise);
+    }
+
+    if (passthroughResponse) {
+      return c.body(passthroughResponse.bodyText, 200, {
+        "Content-Type": passthroughResponse.contentType,
+        "X-Eliza-Inference-Path": "passthrough",
+      });
     }
 
     return c.json({

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -170,6 +170,10 @@ INFERENCE_HOT_PATH_CACHES = "false"
 # through the AI SDK; usage is metered from a teed branch and billed through
 # the existing settle chain. Default off; rollback = flip off.
 INFERENCE_PASSTHROUGH_STREAMING = "false"
+# Pass-through embeddings fast path (#15512): "true" forwards OpenAI-native
+# embeddings directly to the OpenAI-compatible upstream, then bills from the
+# returned usage. Kept separate from streaming chat for isolated rollback.
+INFERENCE_PASSTHROUGH_EMBEDDINGS = "false"
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob.elizacloud.ai"
 SQL_HEAVY_PAYLOAD_STORAGE = "r2"
@@ -388,6 +392,9 @@ INFERENCE_HOT_PATH_CACHES = "true"
 # through the AI SDK; usage is metered from a teed branch and billed through
 # the existing settle chain. Default off; rollback = flip off.
 INFERENCE_PASSTHROUGH_STREAMING = "true"
+# Pass-through embeddings fast path (#15512): direct OpenAI-native embeddings
+# forward + returned-usage billing. Rollback = flip off.
+INFERENCE_PASSTHROUGH_EMBEDDINGS = "true"
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob-staging.elizacloud.ai"
 SQL_HEAVY_PAYLOAD_STORAGE = "r2"
@@ -540,6 +547,9 @@ INFERENCE_HOT_PATH_CACHES = "true"
 # through the AI SDK; usage is metered from a teed branch and billed through
 # the existing settle chain. Default off; rollback = flip off.
 INFERENCE_PASSTHROUGH_STREAMING = "true"
+# Pass-through embeddings fast path (#15512): direct OpenAI-native embeddings
+# forward + returned-usage billing. Rollback = flip off.
+INFERENCE_PASSTHROUGH_EMBEDDINGS = "true"
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob.elizacloud.ai"
 SQL_HEAVY_PAYLOAD_STORAGE = "r2"

--- a/packages/cloud/shared/src/lib/providers/language-model.ts
+++ b/packages/cloud/shared/src/lib/providers/language-model.ts
@@ -367,6 +367,38 @@ export function resolvePassthroughUpstreamForModel(model: string): PassthroughUp
   };
 }
 
+export interface EmbeddingsPassthroughUpstream {
+  providerId: "openai-api";
+  /** Full embeddings endpoint URL. */
+  url: string;
+  apiKey: string;
+  /** Model id to send upstream (normalized the same way getTextEmbeddingModel does). */
+  modelId: string;
+}
+
+/**
+ * Resolve the direct upstream for embeddings pass-through. This deliberately
+ * mirrors only the OpenAI-native branch of getTextEmbeddingModel: Vercel AI
+ * Gateway stays on the SDK path because its compatibility and routing
+ * behavior are part of the current contract, while native OpenAI embeddings are
+ * a plain OpenAI-compatible JSON request/response.
+ */
+export function resolvePassthroughEmbeddingsUpstreamForModel(
+  model: string,
+): EmbeddingsPassthroughUpstream | null {
+  if (!isOpenAINativeModel(model) || requiresGatewayRouting(model)) return null;
+  const apiKey = getProviderKey("OPENAI_API_KEY");
+  if (!apiKey) return null;
+  const baseURL =
+    getProviderKey("OPENAI_BASE_URL")?.replace(/\/+$/, "") ?? "https://api.openai.com/v1";
+  return {
+    providerId: "openai-api",
+    url: `${baseURL}/embeddings`,
+    apiKey,
+    modelId: normalizeOpenAIModelId(model),
+  };
+}
+
 /**
  * Canonicalize a requested model id for pricing AND routing. Dedicated agents
  * emit decorated ids like "openai/gpt-oss-120b:nitro" / "openai/zai-glm-4.7:nitro"

--- a/packages/cloud/shared/src/lib/services/inference-passthrough.ts
+++ b/packages/cloud/shared/src/lib/services/inference-passthrough.ts
@@ -15,6 +15,9 @@
  *   - the `INFERENCE_PASSTHROUGH_STREAMING` flag (default OFF — same
  *     soak-then-cutover discipline as the #9899 INFERENCE_* flags; flag off is
  *     byte-identical to today),
+ *   - the `INFERENCE_PASSTHROUGH_EMBEDDINGS` flag for the non-streaming
+ *     embeddings sibling path, kept separate so rollout can isolate chat TTFB
+ *     from memory-recall embedding latency,
  *   - the background meter: an SSE reader for the teed branch that extracts
  *     the terminal `stream_options.include_usage` usage frame plus the
  *     delivered text, which the route feeds into the EXISTING billing settle
@@ -37,6 +40,21 @@ type StringEnv = Record<string, string | undefined>;
  */
 export function isPassthroughStreamingEnabled(env: StringEnv = getCloudAwareEnv()): boolean {
   return (env.INFERENCE_PASSTHROUGH_STREAMING ?? "").trim() === "true";
+}
+
+/**
+ * Fast-path flag for POST /v1/embeddings. Default OFF; "true" forwards
+ * OpenAI-native embedding requests directly to the OpenAI-compatible upstream,
+ * then bills from the returned usage before handing the provider JSON back.
+ */
+export function isPassthroughEmbeddingsEnabled(env: StringEnv = getCloudAwareEnv()): boolean {
+  if (
+    env.NODE_ENV === "test" &&
+    (env.INFERENCE_PASSTHROUGH_EMBEDDINGS_TEST ?? "").trim() !== "true"
+  ) {
+    return false;
+  }
+  return (env.INFERENCE_PASSTHROUGH_EMBEDDINGS ?? "").trim() === "true";
 }
 
 /**

--- a/packages/cloud/shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud/shared/src/types/cloud-worker-env.ts
@@ -256,6 +256,11 @@ export interface Bindings {
   // branch and billed through the existing settle chain. Default off;
   // rollback = flip off (the SDK path is untouched).
   INFERENCE_PASSTHROUGH_STREAMING?: string;
+  // Pass-through embeddings fast path (#15512): "true" forwards OpenAI-native
+  // embedding requests directly to the OpenAI-compatible upstream and bills
+  // from the returned usage. Separate from chat streaming so either path can be
+  // rolled back independently.
+  INFERENCE_PASSTHROUGH_EMBEDDINGS?: string;
   RATE_LIMIT_DISABLED?: string;
   RATE_LIMIT_MULTIPLIER?: string;
   PLAYWRIGHT_TEST_AUTH?: string;


### PR DESCRIPTION
## Summary
- add an `INFERENCE_PASSTHROUGH_EMBEDDINGS` fast path for OpenAI-native `/v1/embeddings` requests
- forward qualifying embedding requests directly to the OpenAI-compatible upstream after auth/rate-limit/credit admission, then bill from returned usage
- keep SDK fallback for flag-off, unresolved upstream, gateway-backed embeddings, and tests unless explicitly opted in

Fixes #15512.

## Validation
- `bun test --coverage-reporter=lcov packages/cloud/api/__tests__/embeddings-passthrough.test.ts`
- `bun test --coverage-reporter=lcov packages/cloud/api/__tests__/embeddings-route-billing.test.ts`
- `bun test --coverage-reporter=lcov packages/cloud/api/__tests__/embeddings-affiliate-reserve.test.ts`
- `bun test --coverage-reporter=lcov packages/cloud/api/__tests__/embeddings-optimistic-billing.test.ts`
- `bun test --coverage-reporter=lcov packages/cloud/api/__tests__/embeddings-credit-leak.test.ts`
- `bun test --coverage-reporter=lcov packages/cloud/api/__tests__/embeddings-affiliate-clamp.integration.test.ts`
- `bun run --cwd packages/cloud/api typecheck`
- `bunx @biomejs/biome check ...`
- `git diff --check origin/develop...HEAD`
- `bun run audit:error-policy-ratchet --report`

Note: the route-level embeddings suites use process-wide Bun module mocks and are validated as isolated files; combining all route suites in a single Bun process causes pre-existing route-cache mock collisions.

## Evidence
Pending PR evidence rows will be attached after PR creation.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - backend inference route change; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - backend inference route change; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - backend route/helper change verified by request-path tests, no UI flow.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend code path changed.

<!-- evidence-row:backend-logs -->
- [x] [15519-backend-logs.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15519-backend-logs.md)

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - embeddings transport/billing path change; no prompt/model response behavior or agent planner path changed.

<!-- evidence-row:domain-artifacts -->
- [x] [15519-domain-artifacts.md](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15519-domain-artifacts.md)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no UI pixels changed.
