### PR TITLE
perf(cloud): pass-through fast path for /v1/embeddings (#15512)

### DIFF
--- a/packages/cloud/api/__tests__/embeddings-affiliate-clamp.integration.test.ts
+++ b/packages/cloud/api/__tests__/embeddings-affiliate-clamp.integration.test.ts
@@ -139,6 +139,7 @@ mock.module("@/lib/providers/language-model", () => ({
   getTextEmbeddingModel: () => ({}) as never,
   resolveEmbeddingProviderSource: () => "openai",
   getAiProviderConfigurationError: () => "AI services are not configured",
+  resolvePassthroughEmbeddingsUpstream: () => null,
 }));
 
 // The embedding provider — usage.tokens is the per-test lever that makes the

--- a/packages/cloud/api/__tests__/embeddings-affiliate-reserve.test.ts
+++ b/packages/cloud/api/__tests__/embeddings-affiliate-reserve.test.ts
@@ -78,6 +78,7 @@ mock.module("@/lib/providers/language-model", () => ({
   getTextEmbeddingModel: () => ({}) as never,
   resolveEmbeddingProviderSource: () => "openai",
   getAiProviderConfigurationError: () => "AI services are not configured",
+  resolvePassthroughEmbeddingsUpstream: () => null,
 }));
 
 // --- Deterministic pricing so the affiliate math is exact. -------------------

--- a/packages/cloud/api/__tests__/embeddings-credit-leak.test.ts
+++ b/packages/cloud/api/__tests__/embeddings-credit-leak.test.ts
@@ -53,6 +53,7 @@ mock.module("@/lib/providers/language-model", () => ({
   getTextEmbeddingModel: () => ({}) as never,
   resolveEmbeddingProviderSource: () => "openai",
   getAiProviderConfigurationError: () => "AI services are not configured",
+  resolvePassthroughEmbeddingsUpstream: () => null,
 }));
 
 const reserveCredits = mock();

--- a/packages/cloud/api/__tests__/embeddings-passthrough.test.ts
+++ b/packages/cloud/api/__tests__/embeddings-passthrough.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Tests for the /api/v1/embeddings pass-through fast path (#15512): with
+ * INFERENCE_PASSTHROUGH_EMBEDDINGS on and a direct-OpenAI source, the route
+ * forwards the request verbatim over a mocked global `fetch` and returns the
+ * upstream bytes untouched, while billing/settle runs identically to the SDK
+ * path. Auth/rate-limit/billing are mocked at the module boundary; the flag,
+ * the qualification gates, the error mapping, and the hold-release paths run
+ * for real.
+ */
+
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { Context } from "hono";
+import * as workersHonoAuthActual from "@/lib/auth/workers-hono-auth";
+import * as rateLimitActual from "@/lib/middleware/rate-limit";
+// Spread the real modules: bun's `mock.module` replaces the registry entry
+// process-wide, so dropping the other real exports would strand later test
+// files that import from these modules. afterAll restores them.
+import * as languageModelActual from "@/lib/providers/language-model";
+import * as aiBillingActual from "@/lib/services/ai-billing";
+import * as inferenceAuthActual from "@/lib/services/inference-auth-context";
+import * as usageActual from "@/lib/services/usage";
+import type { AppEnv } from "@/types/cloud-worker-env";
+
+type AppCtx = Context<AppEnv>;
+
+const ORG = "00000000-0000-4000-8000-0000000000aa";
+const USER = "00000000-0000-4000-8000-0000000000bb";
+const API_KEY_ID = "00000000-0000-4000-8000-0000000000cc";
+
+const UPSTREAM_URL = "https://api.openai.com/v1/embeddings";
+const UPSTREAM_KEY = "sk-upstream-test";
+
+// --- module mocks (same boundaries as the sibling embeddings suites) --------
+const requireUserOrApiKeyWithOrg = mock();
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  ...workersHonoAuthActual,
+  requireUserOrApiKeyWithOrg,
+}));
+
+const enforceOrgRateLimit = mock();
+mock.module("@/lib/middleware/rate-limit", () => ({
+  ...rateLimitActual,
+  enforceOrgRateLimit,
+}));
+
+const resolveInferenceAuthContext = mock();
+mock.module("@/lib/services/inference-auth-context", () => ({
+  ...inferenceAuthActual,
+  resolveInferenceAuthContext,
+}));
+
+// Source selection is controlled per-test; the resolver stays REAL so the
+// flag/source/key qualification logic is what's under test.
+let providerSource: "openai" | "gateway" | null = "openai";
+mock.module("@/lib/providers/language-model", () => ({
+  ...languageModelActual,
+  hasTextEmbeddingProviderConfigured: () => true,
+  getTextEmbeddingModel: () => ({}) as never,
+  resolveEmbeddingProviderSource: () => providerSource,
+}));
+
+const reserveCredits = mock();
+const billUsage = mock();
+mock.module("@/lib/services/ai-billing", () => ({
+  ...aiBillingActual,
+  reserveCredits,
+  billUsage,
+}));
+
+const usageCreate = mock();
+mock.module("@/lib/services/usage", () => ({
+  ...usageActual,
+  usageService: { ...usageActual.usageService, create: usageCreate },
+}));
+
+// The SDK embedder — must never be reached on the pass-through path.
+const embed = mock();
+const embedMany = mock();
+mock.module("ai", () => ({
+  ...(require("ai") as object),
+  embed,
+  embedMany,
+}));
+
+// Import the route AFTER the mocks so it binds to the stubs.
+const embeddingsRoute = (await import("../v1/embeddings/route")).default;
+
+// --- global fetch mock (the direct upstream boundary) ------------------------
+const realFetch = globalThis.fetch;
+let fetchImpl:
+  | ((input: RequestInfo | URL, init?: RequestInit) => Promise<Response>)
+  | null = null;
+const fetchMock = mock(
+  (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    if (!fetchImpl) throw new Error("fetchImpl not set");
+    return fetchImpl(input, init);
+  },
+);
+
+const ENV_KEYS = [
+  "INFERENCE_PASSTHROUGH_EMBEDDINGS",
+  "OPENAI_API_KEY",
+  "OPENAI_BASE_URL",
+] as const;
+const savedEnv: Record<string, string | undefined> = {};
+for (const key of ENV_KEYS) savedEnv[key] = process.env[key];
+
+afterAll(() => {
+  mock.module("@/lib/auth/workers-hono-auth", () => workersHonoAuthActual);
+  mock.module("@/lib/middleware/rate-limit", () => rateLimitActual);
+  mock.module(
+    "@/lib/services/inference-auth-context",
+    () => inferenceAuthActual,
+  );
+  mock.module("@/lib/providers/language-model", () => languageModelActual);
+  mock.module("@/lib/services/ai-billing", () => aiBillingActual);
+  mock.module("@/lib/services/usage", () => usageActual);
+  globalThis.fetch = realFetch;
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+});
+
+/** Collects the promises scheduled via executionCtx.waitUntil. */
+function makeExecutionCtx() {
+  const scheduled: Promise<unknown>[] = [];
+  return {
+    ctx: {
+      waitUntil: (p: Promise<unknown>) => {
+        scheduled.push(Promise.resolve(p));
+      },
+      passThroughOnException: () => undefined,
+    } as unknown as ExecutionContext,
+    scheduled,
+  };
+}
+
+function post(body: unknown, ctx?: ExecutionContext) {
+  return embeddingsRoute.request(
+    "/",
+    {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer eliza_test_key",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+    {},
+    ctx,
+  );
+}
+
+/** Tracks the credit hold: reconcile(0) = released, reconcile(cost) = settled. */
+function armReservation() {
+  const reconcileCosts: number[] = [];
+  reserveCredits.mockResolvedValue({
+    reservedAmount: 0.01,
+    reconcile: async (actualCost: number) => {
+      reconcileCosts.push(actualCost);
+      return undefined;
+    },
+  });
+  return reconcileCosts;
+}
+
+const UPSTREAM_BODY = {
+  object: "list",
+  data: [{ object: "embedding", embedding: [0.25, -0.5, 1], index: 0 }],
+  model: "text-embedding-3-small",
+  usage: { prompt_tokens: 7, total_tokens: 7 },
+};
+
+beforeEach(() => {
+  requireUserOrApiKeyWithOrg.mockReset();
+  resolveInferenceAuthContext.mockReset();
+  enforceOrgRateLimit.mockReset();
+  reserveCredits.mockReset();
+  billUsage.mockReset();
+  usageCreate.mockReset();
+  embed.mockReset();
+  embedMany.mockReset();
+  fetchMock.mockClear();
+  fetchImpl = null;
+  providerSource = "openai";
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  process.env.INFERENCE_PASSTHROUGH_EMBEDDINGS = "true";
+  process.env.OPENAI_API_KEY = UPSTREAM_KEY;
+  delete process.env.OPENAI_BASE_URL;
+
+  requireUserOrApiKeyWithOrg.mockImplementation(async (c: AppCtx) => {
+    c.set("apiKeyId", API_KEY_ID);
+    return {
+      id: USER,
+      organization_id: ORG,
+      organization: { id: ORG, name: "Org", is_active: true },
+      is_active: true,
+    };
+  });
+  resolveInferenceAuthContext.mockResolvedValue({
+    kind: "slow_path",
+    reason: "non_api_key",
+  });
+  enforceOrgRateLimit.mockResolvedValue(null);
+  billUsage.mockResolvedValue({
+    inputCost: 0.001,
+    outputCost: 0,
+    totalCost: 0.001,
+    baseInputCost: 0.001,
+    baseOutputCost: 0,
+    baseTotalCost: 0.001,
+    platformMarkup: 0,
+    inputTokens: 7,
+    outputTokens: 0,
+    totalTokens: 7,
+    markupApplied: true,
+  });
+  usageCreate.mockResolvedValue({ id: "usage-1" });
+});
+
+describe("embeddings pass-through (#15512)", () => {
+  test("flag on + openai source: upstream bytes returned verbatim, SDK never called, usage billed from upstream", async () => {
+    armReservation();
+    let upstreamInit: RequestInit | undefined;
+    let upstreamInput: RequestInfo | URL | undefined;
+    fetchImpl = async (input, init) => {
+      upstreamInput = input;
+      upstreamInit = init;
+      return new Response(JSON.stringify(UPSTREAM_BODY), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    const { ctx, scheduled } = makeExecutionCtx();
+    const res = await post(
+      { model: "text-embedding-3-small", input: "hello world" },
+      ctx,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Eliza-Inference-Path")).toBe("passthrough");
+    // Byte-for-byte: the client sees exactly what the provider sent.
+    expect(await res.json()).toEqual(UPSTREAM_BODY);
+
+    expect(String(upstreamInput)).toBe(UPSTREAM_URL);
+    const headers = new Headers(upstreamInit?.headers);
+    expect(headers.get("Authorization")).toBe(`Bearer ${UPSTREAM_KEY}`);
+    const forwarded = JSON.parse(String(upstreamInit?.body));
+    expect(forwarded.model).toBe("text-embedding-3-small");
+    expect(forwarded.input).toBe("hello world");
+
+    expect(embed).not.toHaveBeenCalled();
+    expect(embedMany).not.toHaveBeenCalled();
+
+    // Billing is scheduled (waitUntil), not awaited — and bills the upstream's
+    // reported prompt_tokens, not the local estimate.
+    await Promise.all(scheduled);
+    expect(billUsage).toHaveBeenCalledTimes(1);
+    const usageArg = billUsage.mock.calls[0]?.[1] as {
+      inputTokens: number;
+    };
+    expect(usageArg.inputTokens).toBe(7);
+  });
+
+  test("flag off: SDK path runs, upstream fetch never fires", async () => {
+    process.env.INFERENCE_PASSTHROUGH_EMBEDDINGS = "false";
+    armReservation();
+    embed.mockResolvedValue({ embedding: [1, 2, 3], usage: { tokens: 3 } });
+
+    const { ctx, scheduled } = makeExecutionCtx();
+    const res = await post(
+      { model: "text-embedding-3-small", input: "hello" },
+      ctx,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Eliza-Inference-Path")).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(embed).toHaveBeenCalledTimes(1);
+    await Promise.all(scheduled);
+  });
+
+  test("gateway source: stays on the SDK path even with the flag on", async () => {
+    providerSource = "gateway";
+    armReservation();
+    embed.mockResolvedValue({ embedding: [1], usage: { tokens: 1 } });
+
+    const { ctx, scheduled } = makeExecutionCtx();
+    const res = await post(
+      { model: "text-embedding-3-small", input: "hi" },
+      ctx,
+    );
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(embed).toHaveBeenCalledTimes(1);
+    await Promise.all(scheduled);
+  });
+
+  test("upstream 429 maps to 429 and releases the credit hold", async () => {
+    const reconcileCosts = armReservation();
+    fetchImpl = async () =>
+      new Response(JSON.stringify({ error: { message: "rate limited" } }), {
+        status: 429,
+      });
+
+    const { ctx } = makeExecutionCtx();
+    const res = await post(
+      { model: "text-embedding-3-small", input: "hello" },
+      ctx,
+    );
+
+    expect(res.status).toBe(429);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("rate_limit_exceeded");
+    // The hold was released (reconcile(0)), never settled at cost.
+    expect(reconcileCosts).toEqual([0]);
+    expect(billUsage).not.toHaveBeenCalled();
+  });
+
+  test("upstream 500 maps to 503 and releases the credit hold", async () => {
+    const reconcileCosts = armReservation();
+    fetchImpl = async () => new Response("upstream boom", { status: 500 });
+
+    const { ctx } = makeExecutionCtx();
+    const res = await post(
+      { model: "text-embedding-3-small", input: "hello" },
+      ctx,
+    );
+
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("provider_error");
+    expect(reconcileCosts).toEqual([0]);
+  });
+
+  test("upstream body without usage bills the local estimate instead of zero", async () => {
+    armReservation();
+    const noUsage = { ...UPSTREAM_BODY, usage: undefined };
+    fetchImpl = async () =>
+      new Response(JSON.stringify(noUsage), { status: 200 });
+
+    const { ctx, scheduled } = makeExecutionCtx();
+    const res = await post(
+      { model: "text-embedding-3-small", input: "four words of input" },
+      ctx,
+    );
+
+    expect(res.status).toBe(200);
+    await Promise.all(scheduled);
+    const usageArg = billUsage.mock.calls[0]?.[1] as { inputTokens: number };
+    expect(usageArg.inputTokens).toBeGreaterThan(0);
+  });
+
+  test("OPENAI_BASE_URL override routes the pass-through to the custom upstream", async () => {
+    process.env.OPENAI_BASE_URL = "https://proxy.example.com/v1/";
+    armReservation();
+    let upstreamInput: RequestInfo | URL | undefined;
+    fetchImpl = async (input) => {
+      upstreamInput = input;
+      return new Response(JSON.stringify(UPSTREAM_BODY), { status: 200 });
+    };
+
+    const { ctx, scheduled } = makeExecutionCtx();
+    const res = await post(
+      { model: "text-embedding-3-small", input: "hello" },
+      ctx,
+    );
+
+    expect(res.status).toBe(200);
+    expect(String(upstreamInput)).toBe(
+      "https://proxy.example.com/v1/embeddings",
+    );
+    await Promise.all(scheduled);
+  });
+});

--- a/packages/cloud/api/__tests__/embeddings-route-billing.test.ts
+++ b/packages/cloud/api/__tests__/embeddings-route-billing.test.ts
@@ -70,6 +70,7 @@ mock.module("@/lib/providers/language-model", () => ({
   getTextEmbeddingModel: () => ({}) as never,
   resolveEmbeddingProviderSource: () => "openai",
   getAiProviderConfigurationError: () => "AI services are not configured",
+  resolvePassthroughEmbeddingsUpstream: () => null,
 }));
 
 // Billing surface.

--- a/packages/cloud/api/v1/embeddings/route.ts
+++ b/packages/cloud/api/v1/embeddings/route.ts
@@ -3,7 +3,9 @@
  *
  * OpenAI-compatible embeddings endpoint. Routes through the AI SDK + AI
  * Gateway with credit reservation/bill-and-record on the SDK's reported
- * usage.
+ * usage. When INFERENCE_PASSTHROUGH_EMBEDDINGS is on and OpenAI serves the
+ * model directly, the upstream JSON is returned verbatim (#15512) — the same
+ * admission/settle chain runs either way, only the middle hop changes.
  */
 
 import { APICallError, embed, embedMany, RetryError } from "ai";
@@ -26,6 +28,7 @@ import {
   getTextEmbeddingModel,
   hasTextEmbeddingProviderConfigured,
   resolveEmbeddingProviderSource,
+  resolvePassthroughEmbeddingsUpstream,
 } from "@/lib/providers/language-model";
 import {
   billUsage,
@@ -47,6 +50,7 @@ import {
   createLedgerDebitSettler,
   resolveInferenceBillingLedger,
 } from "@/lib/services/inference-billing-ledger";
+import { isPassthroughEmbeddingsEnabled } from "@/lib/services/inference-passthrough";
 import { usageService } from "@/lib/services/usage";
 import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
 import { logger } from "@/lib/utils/logger";
@@ -447,10 +451,53 @@ app.post("/", async (c) => {
       estimatedTokens: estimatedInputTokens,
     });
 
-    let embeddings: number[][];
+    let embeddings: number[][] = [];
     let actualTokens = 0;
 
-    if (Array.isArray(request.input)) {
+    // #15512 pass-through fast path: when OpenAI serves the model directly,
+    // forward the validated request verbatim and return the upstream bytes
+    // untouched — no AI-SDK decode/validate/re-encode of the float arrays.
+    // Usage is parsed once from the same buffer so the settle chain below
+    // bills exactly what the provider reported, identical to the SDK path.
+    // The Vercel AI Gateway fallback keeps the SDK path (resolver returns it
+    // only for the direct-OpenAI source).
+    let passthroughBody: ArrayBuffer | null = null;
+    const passthroughUpstream =
+      isPassthroughEmbeddingsEnabled() &&
+      resolveEmbeddingProviderSource() === "openai"
+        ? resolvePassthroughEmbeddingsUpstream(model)
+        : null;
+
+    if (passthroughUpstream) {
+      const upstreamResponse = await fetch(passthroughUpstream.url, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${passthroughUpstream.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          ...request,
+          model: passthroughUpstream.modelId,
+        }),
+      });
+      if (!upstreamResponse.ok) {
+        // Throw the same error shape the SDK path produces so the route catch
+        // maps it (429/402/503) and releases the credit hold — one failure path.
+        throw new APICallError({
+          message: `Upstream embeddings request failed with status ${upstreamResponse.status}`,
+          url: passthroughUpstream.url,
+          requestBodyValues: { model: passthroughUpstream.modelId },
+          statusCode: upstreamResponse.status,
+          responseHeaders: {},
+          responseBody: await upstreamResponse.text(),
+        });
+      }
+      passthroughBody = await upstreamResponse.arrayBuffer();
+      const parsed = JSON.parse(new TextDecoder().decode(passthroughBody)) as {
+        usage?: { prompt_tokens?: number };
+      };
+      actualTokens = parsed.usage?.prompt_tokens || estimatedInputTokens;
+    } else if (Array.isArray(request.input)) {
       const result = await embedMany({
         model: getTextEmbeddingModel(model),
         values: request.input,
@@ -551,6 +598,20 @@ app.post("/", async (c) => {
 
     if (typeof c.executionCtx?.waitUntil === "function") {
       c.executionCtx.waitUntil(billedPromise);
+    }
+
+    // Verbatim upstream bytes for the pass-through path — billing above ran
+    // identically, only the response encoding hop is skipped. The header lets
+    // probes distinguish the paths without log access (same convention as
+    // /v1/chat/completions).
+    if (passthroughBody) {
+      return new Response(passthroughBody, {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "X-Eliza-Inference-Path": "passthrough",
+        },
+      });
     }
 
     return c.json({

--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -170,6 +170,12 @@ INFERENCE_HOT_PATH_CACHES = "false"
 # through the AI SDK; usage is metered from a teed branch and billed through
 # the existing settle chain. Default off; rollback = flip off.
 INFERENCE_PASSTHROUGH_STREAMING = "false"
+
+# Sibling flag for the non-streaming embeddings pipe (#15512): "true" forwards
+# qualifying embeddings requests (direct-OpenAI source) verbatim and returns
+# the upstream JSON untouched; usage parses from the same buffer and bills
+# through the identical settle chain. Default off; rollback = flip off.
+INFERENCE_PASSTHROUGH_EMBEDDINGS = "false"
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob.elizacloud.ai"
 SQL_HEAVY_PAYLOAD_STORAGE = "r2"
@@ -388,6 +394,12 @@ INFERENCE_HOT_PATH_CACHES = "true"
 # through the AI SDK; usage is metered from a teed branch and billed through
 # the existing settle chain. Default off; rollback = flip off.
 INFERENCE_PASSTHROUGH_STREAMING = "true"
+
+# Sibling flag for the non-streaming embeddings pipe (#15512): "true" forwards
+# qualifying embeddings requests (direct-OpenAI source) verbatim and returns
+# the upstream JSON untouched; usage parses from the same buffer and bills
+# through the identical settle chain. Default off; rollback = flip off.
+INFERENCE_PASSTHROUGH_EMBEDDINGS = "true"
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob-staging.elizacloud.ai"
 SQL_HEAVY_PAYLOAD_STORAGE = "r2"
@@ -540,6 +552,12 @@ INFERENCE_HOT_PATH_CACHES = "true"
 # through the AI SDK; usage is metered from a teed branch and billed through
 # the existing settle chain. Default off; rollback = flip off.
 INFERENCE_PASSTHROUGH_STREAMING = "true"
+
+# Sibling flag for the non-streaming embeddings pipe (#15512): "true" forwards
+# qualifying embeddings requests (direct-OpenAI source) verbatim and returns
+# the upstream JSON untouched; usage parses from the same buffer and bills
+# through the identical settle chain. Default off; rollback = flip off.
+INFERENCE_PASSTHROUGH_EMBEDDINGS = "true"
 FORCE_REDIS_EVENTS = "false"
 R2_PUBLIC_HOST = "blob.elizacloud.ai"
 SQL_HEAVY_PAYLOAD_STORAGE = "r2"

--- a/packages/cloud/shared/src/lib/providers/language-model.ts
+++ b/packages/cloud/shared/src/lib/providers/language-model.ts
@@ -367,6 +367,39 @@ export function resolvePassthroughUpstreamForModel(model: string): PassthroughUp
   };
 }
 
+export interface PassthroughEmbeddingsUpstream {
+  providerId: "openai-api";
+  /** Full embeddings endpoint URL. */
+  url: string;
+  apiKey: string;
+  /** Model id to send upstream (normalized the same way getTextEmbeddingModel does). */
+  modelId: string;
+}
+
+/**
+ * Resolve the direct upstream for a pass-through embeddings request, mirroring
+ * getTextEmbeddingModel's routing precedence (OpenAI direct only — the Vercel
+ * AI Gateway fallback keeps the SDK path since its wire shape is not
+ * guaranteed OpenAI-verbatim). Null when no OpenAI key is configured — callers
+ * must fall through to the SDK path.
+ */
+export function resolvePassthroughEmbeddingsUpstream(
+  model: string,
+): PassthroughEmbeddingsUpstream | null {
+  const apiKey = getProviderKey("OPENAI_API_KEY");
+  if (!apiKey) return null;
+  const baseURL = (getProviderKey("OPENAI_BASE_URL") ?? "https://api.openai.com/v1").replace(
+    /\/+$/,
+    "",
+  );
+  return {
+    providerId: "openai-api",
+    url: `${baseURL}/embeddings`,
+    apiKey,
+    modelId: normalizeOpenAIModelId(model),
+  };
+}
+
 /**
  * Canonicalize a requested model id for pricing AND routing. Dedicated agents
  * emit decorated ids like "openai/gpt-oss-120b:nitro" / "openai/zai-glm-4.7:nitro"

--- a/packages/cloud/shared/src/lib/services/inference-passthrough.ts
+++ b/packages/cloud/shared/src/lib/services/inference-passthrough.ts
@@ -40,6 +40,15 @@ export function isPassthroughStreamingEnabled(env: StringEnv = getCloudAwareEnv(
 }
 
 /**
+ * Sibling flag for the non-streaming embeddings pipe (#15512). Same soak
+ * discipline and rollback shape as the streaming flag; embeddings are simpler
+ * (single JSON response, no tee) so the two roll out independently.
+ */
+export function isPassthroughEmbeddingsEnabled(env: StringEnv = getCloudAwareEnv()): boolean {
+  return (env.INFERENCE_PASSTHROUGH_EMBEDDINGS ?? "").trim() === "true";
+}
+
+/**
  * Token usage extracted from the upstream's terminal usage frame, in the field
  * names `billUsage` normalizes — so the settle chain bills exactly what the
  * provider reported, same as the SDK path's `onFinish` usage.


### PR DESCRIPTION
Closes #15512.

## Summary
- pass-through fast path for `/api/v1/embeddings`: when `INFERENCE_PASSTHROUGH_EMBEDDINGS` is on and the direct-OpenAI source serves the model, forward the validated request verbatim and return the upstream JSON untouched — no AI-SDK decode/validate/re-encode of the float arrays
- usage parses once from the same buffer, so the deferred settle chain (`billUsage` → settler → `usageService`) bills exactly what the provider reported — identical to the SDK path
- upstream failures throw the same `APICallError` shape the SDK path produces, so the existing route catch maps them (429/402/503) and releases the credit hold — one failure path, no new error handling
- the Vercel AI Gateway fallback source keeps the SDK path (its wire shape is not guaranteed OpenAI-verbatim)
- `X-Eliza-Inference-Path: passthrough` response header for probes, same convention as `/v1/chat/completions` (#15437)
- flag default **off**; `[env.staging.vars]` + `[env.production.vars]` set true — same soak-then-cutover shape as #15473; rollback = flip off

## Why
Measured on prod 2026-07-08 (same input): gateway `/v1/embeddings` **1.14–3.83s** vs direct api.openai.com **0.22–0.28s**. Agent runtimes make 2–3 embedding calls per message turn (the always-on recall provider embeds every incoming message), so this is currently the single largest remaining cloud-agent latency item post-#15437/#15508 — worth 2–10s per turn.

## Tests
New `embeddings-passthrough.test.ts` (7 cases, mirrors the sibling suites' module-boundary harness; the flag/qualification/error-mapping/hold-release logic runs real):
- verbatim upstream bytes + header + SDK never called + billed from upstream `usage.prompt_tokens` via `waitUntil`
- flag off → SDK path, no upstream fetch
- gateway source → SDK path even with flag on
- upstream 429 → 429 `rate_limit_exceeded` + hold released (`reconcile(0)`)
- upstream 500 → 503 `provider_error` + hold released
- missing upstream usage → bills the local estimate, never zero
- `OPENAI_BASE_URL` override respected

All 5 sibling embeddings suites (34 tests) + the chat pass-through suite (28) green. `biome check` clean on touched files.

Evidence: prod before/after latency table is in #15512 (live measurements, this branch not yet deployed anywhere — staging soak will produce the after-numbers once merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
