### PR TITLE
perf(cloud): Smart Placement soak on staging (#15513)

### DIFF
--- a/packages/cloud/api/wrangler.toml
+++ b/packages/cloud/api/wrangler.toml
@@ -277,6 +277,12 @@ TUNNEL_AUTH_KEY_COST_USD = "0.01"
 [env.staging]
 name = "eliza-cloud-api-staging"
 workers_dev = false
+# Smart Placement soak (#15513): run this Worker near the origins it fetches
+# (api.cerebras.ai / api.openai.com) instead of near the caller — the measured
+# Worker->origin hop is ~500ms of every inference call's TTFT. Staging-only
+# until the before/after ttfb comparison on api-staging holds; production
+# follows in its own change.
+placement = { mode = "smart" }
 routes = [
   { pattern = "staging.elizacloud.ai/*", zone_name = "elizacloud.ai" },
   { pattern = "app-staging.elizacloud.ai/*", zone_name = "elizacloud.ai" },


### PR DESCRIPTION
Part of #15513 (Fix B from the #15502 decomposition) — staging soak leg.

## Summary
- `placement = { mode = "smart" }` on `[env.staging]` only
- With pass-through (#15437) live, the gateway's own gates cost ~91ms warm — but client ttfb is still ~740ms vs ~130ms direct to Cerebras. The residual is the Worker→origin network hop (Worker executes in the caller's colo, pays fresh cross-network transit to api.cerebras.ai / api.openai.com on every call). Smart Placement is Cloudflare's mechanism for exactly this shape: it observes the Worker's subrequest pattern and moves execution near the origin.

## Rollout
1. This PR: staging only. Placement analysis takes a little while to kick in after deploy ([CF docs](https://developers.cloudflare.com/workers/configuration/smart-placement/)).
2. Measure warm chat-completions ttfb on `api-staging.elizacloud.ai` before/after (baseline captured today: warm ~0.75–1.0s ttfb, passthrough engaged). Also sanity-check an app/auth route for regression — placement moves the WHOLE Worker, so client-near routes could see +RTT; the inference-dominant traffic mix should still win.
3. If it holds: `[env.production]` in its own one-line change.

Rollback = remove the line + redeploy (or `mode = "off"`).

## Verification
`bunx wrangler deploy --env staging --dry-run` parses + bundles clean (16052.92 KiB, same as develop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
