### PR TITLE
fix(ui): reuse selected cloud agent in first run

### DIFF
--- a/packages/ui/src/first-run/first-run-finish.ts
+++ b/packages/ui/src/first-run/first-run-finish.ts
@@ -230,6 +230,20 @@ function runningCloudAgents(
     .sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)));
 }
 
+function preferredRunningCloudAgentId(
+  running: readonly CloudCompatAgent[],
+): string | null {
+  const active = loadPersistedActiveServer();
+  if (active?.kind !== "cloud") return null;
+  const persistedAgentId = active.id?.startsWith("cloud:")
+    ? active.id.slice("cloud:".length).trim()
+    : "";
+  if (!persistedAgentId || persistedAgentId.includes("/")) return null;
+  return running.some((agent) => agent.agent_id === persistedAgentId)
+    ? persistedAgentId
+    : null;
+}
+
 async function getCloudStatusIfSupported() {
   if (!canProbeCloudStatus()) return null;
   // error-policy:J4 cloud-status probe — unreachable/unsupported means the
@@ -715,16 +729,14 @@ export async function listOrAutoProvisionCloudAgent(
     };
   }
   const running = runningCloudAgents(list.data);
-  if (running.length > 1) {
-    ports.onStatus?.(null);
-    return { kind: "pick-cloud-agent", agents: running };
-  }
+  const preferredAgentId = preferredRunningCloudAgentId(running);
+  const agentId = preferredAgentId ?? running[0]?.agent_id ?? null;
   return bindCloudAgent(
     sourceDraft,
     authToken,
     {
       forceCreate: false,
-      ...(running[0]?.agent_id ? { preferAgentId: running[0].agent_id } : {}),
+      ...(agentId ? { preferAgentId: agentId } : {}),
     },
     ports,
   );

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -1419,6 +1419,47 @@ describe("cloud-only onboarding (runtime chooser off — the production default)
     unmount();
   });
 
+  it("a connected cloud-only session prefers the active Settings cloud agent without surfacing a picker", async () => {
+    localStorage.setItem(
+      "elizaos:active-server",
+      JSON.stringify({
+        kind: "cloud",
+        id: "cloud:agent-older-running",
+        label: "Preferred from Settings",
+        apiBase: "https://agent-older-running.elizacloud.ai",
+        accessToken: "cloud-token",
+      }),
+    );
+    mocks.client.getCloudCompatAgents.mockResolvedValue({
+      success: true,
+      data: [
+        {
+          agent_id: "agent-newest-running",
+          agent_name: "Newest",
+          status: "running",
+          created_at: "2026-01-03T00:00:00.000Z",
+        },
+        {
+          agent_id: "agent-older-running",
+          agent_name: "Preferred from Settings",
+          status: "running",
+          created_at: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+    });
+    const spies = seedAppStore({ elizaCloudConnected: true });
+    const { turn, unmount } = renderConductor();
+
+    await waitFor(() => {
+      expect(spies.completeFirstRun).toHaveBeenCalledTimes(1);
+    });
+    expect(turn("first-run:cloud-agent")).toBeUndefined();
+    expect(
+      mocks.client.selectOrProvisionCloudAgent.mock.calls[0][0],
+    ).toMatchObject({ preferAgentId: "agent-older-running" });
+    unmount();
+  });
+
   it("zero agents stay silent through the reuse lookup and narrate ONLY the real provisioning (#15133)", async () => {
     // No stored agents; selectOrProvisionCloudAgent emits the REAL client's
     // progress sequence for a create: the reuse lookup ("listing"), the actual


### PR DESCRIPTION
## Summary
- keep cloud-only first-run silent when multiple running cloud agents exist instead of surfacing the old picker
- prefer the active Settings cloud agent when it is still running
- fall back to the newest running agent, then normal provisioning, when no valid active cloud agent exists

Fixes #15517.

## Verification
- bun run --cwd packages/ui test src/first-run/use-first-run-conductor.test.ts
- bun run --cwd packages/ui test src/api/client-cloud-select-or-provision.test.ts
- bun run --cwd packages/ui typecheck
- bunx @biomejs/biome check packages/ui/src/first-run/first-run-finish.ts packages/ui/src/first-run/use-first-run-conductor.test.ts
- git diff --check

<!-- evidence-row:before-screenshots -->
- [ ] N/A - logic-only first-run binding change; no rendered UI source changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - logic-only first-run binding change; no rendered UI source changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-visible interaction or rendered UI changed

<!-- evidence-row:backend-logs -->
- [ ] N/A - client-only selection logic; no backend path changed

<!-- evidence-row:frontend-logs -->
- [ ] N/A - focused Vitest coverage exercises the client selection path without browser console/network artifacts

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, provider, or LLM behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain artifact is produced by this client selection fix
