### PR TITLE
fix(ui): bind first-run cloud agent from listed agents

### DIFF
--- a/packages/ui/src/api/client-cloud-select-or-provision.test.ts
+++ b/packages/ui/src/api/client-cloud-select-or-provision.test.ts
@@ -83,6 +83,22 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
     expect(createCloudCompatAgent).not.toHaveBeenCalled();
   });
 
+  it("reuses a caller-provided successful list without a second lookup", async () => {
+    const { client, getCloudCompatAgents, createCloudCompatAgent } =
+      fakeClient();
+    getCloudCompatAgents.mockRejectedValue(new Error("second list forbidden"));
+
+    const result = await client.selectOrProvisionCloudAgent({
+      ...BASE_OPTS,
+      knownAgents: [makeAgent({ agent_id: "agent-from-first-run-list" })],
+    });
+
+    expect(result.created).toBe(false);
+    expect(result.agentId).toBe("agent-from-first-run-list");
+    expect(getCloudCompatAgents).not.toHaveBeenCalled();
+    expect(createCloudCompatAgent).not.toHaveBeenCalled();
+  });
+
   it("does not reuse a non-running existing agent; provisions from a confirmed no-running set", async () => {
     const { client, getCloudCompatAgents, createCloudCompatAgent } =
       fakeClient();

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -1498,6 +1498,12 @@ declare module "./client-base" {
        * affects the create branch; reuse of an existing agent is unaffected.
        */
       preferSharedTier?: boolean;
+      /**
+       * Authoritative list already fetched by the caller. First-run uses this
+       * to avoid a second list/read race between "Finding your agents..." and
+       * the bind decision.
+       */
+      knownAgents?: CloudCompatAgent[];
       onProgress?: (status: string, detail?: string) => void;
       /**
        * Cold-boot wait tuning for a reused dedicated agent that is not yet
@@ -3315,6 +3321,7 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
     preferAgentId,
     forceCreate,
     preferSharedTier,
+    knownAgents,
   } = options;
   const onProgress = options.onProgress;
   const resolvedCloudApiBase = resolveDirectCloudAuthApiBase(cloudApiBase);
@@ -3331,23 +3338,28 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
   // is the fix for "a new cloud agent is created on every sign-in" — the create
   // path only runs when the user has no agent yet.
   if (!forceCreate) {
-    // "listing", not "creating": this is the reuse LOOKUP, and downstream
-    // consumers (the first-run silent cloud entry, #15133) distinguish real
-    // provisioning phases from bookkeeping by this code. Display consumers
-    // render the detail text, so the rename is invisible to them.
-    onProgress?.("listing", "Finding your agents...");
-    // A failed agent-list lookup must NOT fall through to provisioning. A
-    // transient error (expired token, network blip, or a success:false body)
-    // previously collapsed to an empty list and minted a brand-new billed agent
-    // even though the user already had one — the root of the "it creates
-    // multiple agents" report. Only an authoritative success list may conclude
-    // the user has no agent to reuse; otherwise surface the error so the caller
-    // can retry rather than duplicate.
-    const list = await this.getCloudCompatAgents().catch((cause) => ({
-      success: false as const,
-      data: [] as CloudCompatAgent[],
-      error: cause instanceof Error ? cause.message : undefined,
-    }));
+    const list = knownAgents
+      ? { success: true as const, data: knownAgents }
+      : await (async () => {
+          // "listing", not "creating": this is the reuse LOOKUP, and
+          // downstream consumers (the first-run silent cloud entry, #15133)
+          // distinguish real provisioning phases from bookkeeping by this code.
+          // Display consumers render the detail text, so the rename is
+          // invisible to them.
+          onProgress?.("listing", "Finding your agents...");
+          // A failed agent-list lookup must NOT fall through to provisioning. A
+          // transient error (expired token, network blip, or a success:false
+          // body) previously collapsed to an empty list and minted a brand-new
+          // billed agent even though the user already had one — the root of the
+          // "it creates multiple agents" report. Only an authoritative success
+          // list may conclude the user has no agent to reuse; otherwise surface
+          // the error so the caller can retry rather than duplicate.
+          return await this.getCloudCompatAgents().catch((cause) => ({
+            success: false as const,
+            data: [] as CloudCompatAgent[],
+            error: cause instanceof Error ? cause.message : undefined,
+          }));
+        })();
     if (!list.success) {
       throw new Error(
         list.error ||

--- a/packages/ui/src/first-run/first-run-finish.ts
+++ b/packages/ui/src/first-run/first-run-finish.ts
@@ -497,7 +497,11 @@ async function finishLocal(
 export async function bindCloudAgent(
   sourceDraft: FirstRunProfileDraft,
   authToken: string,
-  opts: { preferAgentId?: string | null; forceCreate?: boolean },
+  opts: {
+    preferAgentId?: string | null;
+    forceCreate?: boolean;
+    knownAgents?: CloudCompatAgent[];
+  },
   ports: FirstRunFinishPorts,
 ): Promise<FirstRunFinishOutcome> {
   ports.onStatus?.("Setting up your cloud agent", "setup");
@@ -520,6 +524,7 @@ export async function bindCloudAgent(
     bio,
     ...(opts.preferAgentId ? { preferAgentId: opts.preferAgentId } : {}),
     ...(opts.forceCreate ? { forceCreate: true } : {}),
+    ...(opts.knownAgents ? { knownAgents: opts.knownAgents } : {}),
     ...(getBootConfig().preferSharedCloudTier
       ? { preferSharedTier: true }
       : {}),
@@ -737,6 +742,7 @@ export async function listOrAutoProvisionCloudAgent(
     {
       forceCreate: false,
       ...(agentId ? { preferAgentId: agentId } : {}),
+      knownAgents: list.data,
     },
     ports,
   );

--- a/packages/ui/src/first-run/use-first-run-conductor.test.ts
+++ b/packages/ui/src/first-run/use-first-run-conductor.test.ts
@@ -1416,6 +1416,12 @@ describe("cloud-only onboarding (runtime chooser off — the production default)
     expect(
       mocks.client.selectOrProvisionCloudAgent.mock.calls[0][0],
     ).toMatchObject({ preferAgentId: "agent-newest-running" });
+    expect(
+      mocks.client.selectOrProvisionCloudAgent.mock.calls[0][0],
+    ).toHaveProperty("knownAgents", [
+      expect.objectContaining({ agent_id: "agent-newest-running" }),
+      expect.objectContaining({ agent_id: "agent-older" }),
+    ]);
     unmount();
   });
 


### PR DESCRIPTION
## Summary
- pass first-run's successful cloud-agent list into `selectOrProvisionCloudAgent`
- avoid a second list/read race between `Finding your agents...` and the bind decision
- keep the create path only for an authoritative no-running-agent set

Addresses #15516 Bug B by making the native first-run bind decision use the already-observed running agent instead of re-listing before provisioning.

## Verification
- bun run --cwd packages/ui test src/api/client-cloud-select-or-provision.test.ts
- bun run --cwd packages/ui test src/first-run/use-first-run-conductor.test.ts
- bun run --cwd packages/ui typecheck
- bunx @biomejs/biome check packages/ui/src/api/client-cloud.ts packages/ui/src/api/client-cloud-select-or-provision.test.ts packages/ui/src/first-run/first-run-finish.ts packages/ui/src/first-run/use-first-run-conductor.test.ts
- git diff --check HEAD~1 HEAD

## Notes
- Verification in a fresh worktree required linking the generated i18n data directories that `packages/core`/`packages/shared` prebuild normally generate; those links were removed before commit and are not part of the PR.

<!-- evidence-row:before-screenshots -->
- [ ] N/A - logic-only cloud-agent selection change; no rendered UI source changed

<!-- evidence-row:after-screenshots -->
- [ ] N/A - logic-only cloud-agent selection change; no rendered UI source changed

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-visible interaction or rendered UI changed

<!-- evidence-row:backend-logs -->
- [ ] N/A - client-only bind decision; no backend code changed

<!-- evidence-row:frontend-logs -->
- [ ] N/A - focused Vitest coverage exercises the selection path without browser console/network artifacts

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, provider, or LLM behavior changed

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no persistent domain artifact is produced by this client selection fix
