### PR TITLE
fix(app): capture iOS device failure forensics

### DIFF
--- a/packages/app/scripts/ios-device-e2e.mjs
+++ b/packages/app/scripts/ios-device-e2e.mjs
@@ -34,6 +34,7 @@
  *     [--no-skip-appexes] [--skip-logs] [--require-chat]
  *     [--bundle-id <id>] [--output <dir>]
  */
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -55,6 +56,8 @@ import {
 } from "./lib/device-e2e-bundle.mjs";
 import {
   buildDeviceDeployCommand,
+  buildDeviceFailureBootTraceCommand,
+  buildDeviceFailureScreenshotCommand,
   buildDeviceLogsCommand,
   buildDeviceSmokeCommand,
   planIosDeviceE2eSteps,
@@ -74,9 +77,75 @@ const fail = (message) => {
   process.exit(1);
 };
 
+let activeDeviceContext = null;
+
+function isNonEmptyFile(filePath) {
+  try {
+    return fs.statSync(filePath).isFile() && fs.statSync(filePath).size > 0;
+  } catch {
+    // error-policy:J3 Failure artifacts are optional diagnostics; absence is
+    // recorded in the command log rather than treated as a captured file.
+    return false;
+  }
+}
+
+function directFiles(dir) {
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => path.join(dir, entry.name));
+}
+
+function writeFailureCommandLog({ failureDir, label, command, result }) {
+  const logPath = path.join(failureDir, `${label}.log`);
+  const status =
+    result.status === null
+      ? `signal ${result.signal}`
+      : `exit ${result.status}`;
+  fs.writeFileSync(
+    logPath,
+    [
+      `$ ${command.cmd} ${command.args.join(" ")}`,
+      `status: ${status}`,
+      "",
+      "stdout:",
+      result.stdout || "",
+      "",
+      "stderr:",
+      result.stderr || "",
+      "",
+      "error:",
+      result.error?.message || "",
+    ].join("\n"),
+  );
+  return logPath;
+}
+
+function captureFailureCommand({ failureDir, label, command, expectedFiles }) {
+  const before = new Set(directFiles(failureDir));
+  const expected = new Set(expectedFiles);
+  const result = spawnSync(command.cmd, command.args, {
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  const captured = expectedFiles.filter(isNonEmptyFile);
+  const after = directFiles(failureDir).filter((file) => !before.has(file));
+  const diagnosticLog = writeFailureCommandLog({
+    failureDir,
+    label,
+    command,
+    result,
+  });
+  const commandProducedUnexpectedFiles = after.filter(
+    (file) =>
+      file !== diagnosticLog && !expected.has(file) && isNonEmptyFile(file),
+  );
+  return [...captured, ...commandProducedUnexpectedFiles, diagnosticLog];
+}
+
 // Failure forensics for a chained-child step: the child script already wrote its
-// own artifacts into smoke/ or logs/; this records the cause so the triage
-// bundle names why the lane stopped.
+// own artifacts into smoke/ or logs/ when it reached those phases, and this adds
+// point-of-failure evidence from the physical phone when the host tools allow it.
 function captureDeviceFailure(bundle, step, error) {
   return captureFailureForensics(
     bundle,
@@ -84,7 +153,36 @@ function captureDeviceFailure(bundle, step, error) {
     ({ failureDir }) => {
       const causePath = path.join(failureDir, "failure-cause.txt");
       fs.writeFileSync(causePath, `${error?.message ?? error}\n`);
-      return [causePath];
+      const artifacts = [causePath];
+      if (!activeDeviceContext) return artifacts;
+
+      const screenshotPath = path.join(failureDir, "screen.png");
+      artifacts.push(
+        ...captureFailureCommand({
+          failureDir,
+          label: "screenshot-capture",
+          command: buildDeviceFailureScreenshotCommand({
+            deviceUdid: activeDeviceContext.udid,
+            outputFile: screenshotPath,
+          }),
+          expectedFiles: [screenshotPath],
+        }),
+      );
+
+      artifacts.push(
+        ...captureFailureCommand({
+          failureDir,
+          label: "boot-trace-capture",
+          command: buildDeviceFailureBootTraceCommand({
+            scriptsDir,
+            deviceId: activeDeviceContext.deviceId,
+            outputFile: path.join(failureDir, "boot-trace-run"),
+            bundleId: activeDeviceContext.bundleId,
+          }),
+          expectedFiles: [],
+        }),
+      );
+      return artifacts;
     },
     error,
   );
@@ -130,6 +228,12 @@ async function main() {
   // opts back in when per-appex profiles exist.
   const skipAppexes = !args["no-skip-appexes"];
   const bundleId = args["bundle-id"] || null;
+  activeDeviceContext = {
+    bundleId,
+    deviceId,
+    identifier: device.identifier,
+    udid: device.udid,
+  };
 
   const bundle = createDeviceE2eBundle({
     appDir: appRoot,

--- a/packages/app/scripts/lib/ios-device-e2e-lib.mjs
+++ b/packages/app/scripts/lib/ios-device-e2e-lib.mjs
@@ -165,3 +165,56 @@ export function buildDeviceLogsCommand({
   if (bundleId) args.push("--bundle-id", bundleId);
   return { cmd: "node", args };
 }
+
+/**
+ * Absolute argv for the physical-device screenshot used only after a lane step
+ * fails. Xcode's `devicectl` does not expose a screenshot subcommand on current
+ * runners, so this intentionally uses libimobiledevice's stable
+ * `idevicescreenshot` CLI when the host has it installed. The caller records a
+ * diagnostic artifact when the command is missing or the phone has no mounted
+ * developer disk image.
+ *
+ * @param {{ deviceUdid: string, outputFile: string }} opts
+ * @returns {{ cmd: string, args: string[] }}
+ */
+export function buildDeviceFailureScreenshotCommand({
+  deviceUdid,
+  outputFile,
+}) {
+  if (!deviceUdid)
+    throw new Error(
+      "buildDeviceFailureScreenshotCommand: deviceUdid is required",
+    );
+  if (!outputFile)
+    throw new Error(
+      "buildDeviceFailureScreenshotCommand: outputFile is required",
+    );
+  return {
+    cmd: "idevicescreenshot",
+    args: ["--udid", deviceUdid, outputFile],
+  };
+}
+
+/**
+ * Absolute node argv for the best-effort boot-trace pull used after a physical
+ * lane step fails. This reuses the supported `ios-device-logs.mjs` path rather
+ * than opening a debug console, because console attach kills the app on detach
+ * and SIGTRAPs full-Bun engine-host builds (#11515).
+ *
+ * @param {{ scriptsDir: string, deviceId: string, outputFile: string,
+ *           bundleId?: string | null }} opts
+ * @returns {{ cmd: string, args: string[] }}
+ */
+export function buildDeviceFailureBootTraceCommand({
+  scriptsDir,
+  deviceId,
+  outputFile,
+  bundleId = null,
+}) {
+  return buildDeviceLogsCommand({
+    scriptsDir,
+    deviceId,
+    outputFile,
+    bundleId,
+  });
+}

--- a/packages/app/scripts/lib/ios-device-e2e-lib.test.mjs
+++ b/packages/app/scripts/lib/ios-device-e2e-lib.test.mjs
@@ -10,6 +10,8 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   buildDeviceDeployCommand,
+  buildDeviceFailureBootTraceCommand,
+  buildDeviceFailureScreenshotCommand,
   buildDeviceLogsCommand,
   buildDeviceSmokeCommand,
   IOS_DEVICE_E2E_STEP_IDS,
@@ -121,5 +123,43 @@ describe("buildDeviceLogsCommand", () => {
     expect(() => buildDeviceLogsCommand({ scriptsDir, deviceId })).toThrow(
       /outputFile is required/,
     );
+  });
+});
+
+describe("buildDeviceFailureScreenshotCommand", () => {
+  it("uses idevicescreenshot against the physical device UDID", () => {
+    const { cmd, args } = buildDeviceFailureScreenshotCommand({
+      deviceUdid: deviceId,
+      outputFile: "/bundle/failure/screen.png",
+    });
+    expect(cmd).toBe("idevicescreenshot");
+    expect(args).toEqual(["--udid", deviceId, "/bundle/failure/screen.png"]);
+  });
+  it("throws without an output file", () => {
+    expect(() =>
+      buildDeviceFailureScreenshotCommand({ deviceUdid: deviceId }),
+    ).toThrow(/outputFile is required/);
+  });
+});
+
+describe("buildDeviceFailureBootTraceCommand", () => {
+  it("reuses the no-console boot-trace pull path for failure forensics", () => {
+    const { args } = buildDeviceFailureBootTraceCommand({
+      scriptsDir,
+      deviceId,
+      outputFile: "/bundle/failure/boot-trace-run",
+      bundleId: "ai.elizaos.app",
+    });
+    expect(args).toEqual([
+      path.join(scriptsDir, "ios-device-logs.mjs"),
+      "--device",
+      deviceId,
+      "--no-console",
+      "--pull-boot-trace",
+      "--output",
+      "/bundle/failure/boot-trace-run",
+      "--bundle-id",
+      "ai.elizaos.app",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- add physical iOS device failure forensics to the one-command device e2e lane
- capture best-effort `idevicescreenshot` output plus boot-trace pull diagnostics into each failing step's failure directory
- cover the new physical-device forensic argv builders in the existing pure command test suite

Fixes #14338

## Verification
- `bun test packages/app/scripts/lib/ios-device-e2e-lib.test.mjs`
- `bunx @biomejs/biome check packages/app/scripts/ios-device-e2e.mjs packages/app/scripts/lib/ios-device-e2e-lib.mjs packages/app/scripts/lib/ios-device-e2e-lib.test.mjs`
- `git diff --check origin/develop..HEAD`

## Evidence
<!-- pr-evidence:start -->
| Evidence | Link / Notes |
| --- | --- |
| before-screenshots | N/A - scripts-only device runner failure-forensics change; no rendered UI surface changed. |
| after-screenshots | N/A - scripts-only device runner failure-forensics change; no rendered UI surface changed. |
| walkthrough-video | N/A - no user-facing UI flow changed; physical-device execution requires a lane phone. |
| backend-logs | N/A - no server/runtime backend path changed. |
| frontend-logs | N/A - no frontend runtime path changed. |
| llm-trajectory | N/A - no model, prompt, action, provider, or evaluator behavior changed. |
| domain-artifacts | Verification transcript to attach via `scripts/pr-evidence.mjs rows`. |
<!-- pr-evidence:end -->

<!-- evidence-row:before-screenshots -->
- [ ] N/A - scripts-only device runner failure-forensics change; no rendered UI surface changed.

<!-- evidence-row:after-screenshots -->
- [ ] N/A - scripts-only device runner failure-forensics change; no rendered UI surface changed.

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing UI flow changed; physical-device execution requires a lane phone.

<!-- evidence-row:backend-logs -->
- [ ] N/A - no server/runtime backend path changed.

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime path changed.

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model, prompt, action, provider, or evaluator behavior changed.

<!-- evidence-row:domain-artifacts -->
- [x] [15530-ios-device-forensics-verification.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15530-ios-device-forensics-verification.txt)
