### PR TITLE
fix(ui): keep default cloud onboarding steward-only

### DIFF
--- a/packages/ui/src/api/client-cloud-select-or-provision.test.ts
+++ b/packages/ui/src/api/client-cloud-select-or-provision.test.ts
@@ -153,6 +153,31 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
     expect(result.requiresAgentPairing).toBe(true);
   });
 
+  it("can reuse a dedicated agent through the Steward-token REST adapter without pairing", async () => {
+    const { client, getCloudCompatAgents } = fakeClient();
+    getCloudCompatAgents.mockResolvedValue({
+      success: true,
+      data: [
+        makeAgent({
+          agent_id: "agent-dedicated",
+          web_ui_url: "https://agent-dedicated.elizacloud.ai",
+          webUiUrl: "https://agent-dedicated.elizacloud.ai",
+        }),
+      ],
+    });
+
+    const result = await client.selectOrProvisionCloudAgent({
+      ...BASE_OPTS,
+      preferStewardAgentAdapter: true,
+    });
+
+    expect(result.created).toBe(false);
+    expect(result.apiBase).toBe(
+      "https://api.elizacloud.ai/api/v1/eliza/agents/agent-dedicated",
+    );
+    expect(result.requiresAgentPairing).toBe(false);
+  });
+
   it("does NOT provision when the list fetch throws (transient/network error)", async () => {
     const { client, getCloudCompatAgents, createCloudCompatAgent } =
       fakeClient();
@@ -500,5 +525,42 @@ describe("selectOrProvisionCloudAgent — never duplicate on a failed lookup", (
     expect(result.created).toBe(true);
     expect(result.apiBase).toContain("agent-warm.elizacloud.ai");
     expect(result.requiresAgentPairing).toBe(true);
+  });
+
+  it("keeps a warm newly-created agent on the Steward-token REST adapter when requested", async () => {
+    const { client, getCloudCompatAgents, createCloudCompatAgent } =
+      fakeClient();
+    getCloudCompatAgents.mockResolvedValue({ success: true, data: [] });
+    createCloudCompatAgent.mockResolvedValue({
+      success: true,
+      data: {
+        agentId: "agent-warm",
+        agentName: "Eliza",
+        jobId: "",
+        status: "running",
+        nodeId: null,
+        message: "",
+      },
+    });
+    (client.getCloudCompatAgent as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+      data: makeAgent({
+        agent_id: "agent-warm",
+        status: "running",
+        web_ui_url: "https://agent-warm.elizacloud.ai",
+        webUiUrl: "https://agent-warm.elizacloud.ai",
+      }),
+    });
+
+    const result = await client.selectOrProvisionCloudAgent({
+      ...BASE_OPTS,
+      preferStewardAgentAdapter: true,
+    });
+
+    expect(result.created).toBe(true);
+    expect(result.apiBase).toBe(
+      "https://api.elizacloud.ai/api/v1/eliza/agents/agent-warm",
+    );
+    expect(result.requiresAgentPairing).toBe(false);
   });
 });

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -1504,6 +1504,13 @@ declare module "./client-base" {
        * the bind decision.
        */
       knownAgents?: CloudCompatAgent[];
+      /**
+       * Return the Cloud REST adapter base (`/api/v1/eliza/agents/:id`) even
+       * when the agent also exposes a dedicated subdomain. First-run uses this
+       * for the default Steward-token flow; explicit dedicated handoff paths
+       * leave it off so they can still run the `/pair` exchange.
+       */
+      preferStewardAgentAdapter?: boolean;
       onProgress?: (status: string, detail?: string) => void;
       /**
        * Cold-boot wait tuning for a reused dedicated agent that is not yet
@@ -3322,6 +3329,7 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
     forceCreate,
     preferSharedTier,
     knownAgents,
+    preferStewardAgentAdapter,
   } = options;
   const onProgress = options.onProgress;
   const resolvedCloudApiBase = resolveDirectCloudAuthApiBase(cloudApiBase);
@@ -3401,12 +3409,14 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
           ...(onProgress ? { onProgress } : {}),
         });
       }
-      const apiBase = resolveCloudAgentApiBase({
-        bridgeUrl: agent.bridge_url,
-        webUiUrl: agent.web_ui_url ?? agent.webUiUrl,
-        agentId: agent.agent_id,
-        cloudApiBase: resolvedCloudApiBase,
-      });
+      const apiBase = preferStewardAgentAdapter
+        ? buildCloudSharedAgentApiBase(resolvedCloudApiBase, agent.agent_id)
+        : resolveCloudAgentApiBase({
+            bridgeUrl: agent.bridge_url,
+            webUiUrl: agent.web_ui_url ?? agent.webUiUrl,
+            agentId: agent.agent_id,
+            cloudApiBase: resolvedCloudApiBase,
+          });
       onProgress?.("ready", "Connected to your agent");
       return {
         agentId: agent.agent_id,
@@ -3414,7 +3424,8 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
         apiBase,
         bridgeUrl: agent.bridge_url,
         created: false,
-        requiresAgentPairing: isDedicatedCloudAgentBase(apiBase),
+        requiresAgentPairing:
+          !preferStewardAgentAdapter && isDedicatedCloudAgentBase(apiBase),
       };
     }
   }
@@ -3457,7 +3468,7 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
     detailAgent?.web_ui_url || detailAgent?.bridge_url,
   );
   const apiBase =
-    isRunning && hasDedicatedUrl
+    !preferStewardAgentAdapter && isRunning && hasDedicatedUrl
       ? resolveCloudAgentApiBase({
           bridgeUrl: detailAgent.bridge_url,
           webUiUrl: detailAgent.web_ui_url ?? detailAgent.webUiUrl,
@@ -3478,7 +3489,8 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
     // explicit `false` demotes to reuse; an absent flag (older worker) stays
     // `true` so the pre-existing create UX is unchanged.
     created: created.created !== false,
-    requiresAgentPairing: isDedicatedCloudAgentBase(apiBase),
+    requiresAgentPairing:
+      !preferStewardAgentAdapter && isDedicatedCloudAgentBase(apiBase),
   };
 };
 

--- a/packages/ui/src/first-run/first-run-finish.force-fresh.test.ts
+++ b/packages/ui/src/first-run/first-run-finish.force-fresh.test.ts
@@ -127,6 +127,9 @@ describe("bindCloudAgent clears the durable force-fresh flag on completion", () 
     expect(isForceFreshFirstRunEnabled()).toBe(false);
     // The shared-agent path must NOT POST /api/first-run.
     expect(clientMock.submitFirstRun).not.toHaveBeenCalled();
+    expect(clientMock.selectOrProvisionCloudAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ preferStewardAgentAdapter: true }),
+    );
   });
 
   it("is a no-op-safe clear when force-fresh was never armed (idempotent)", async () => {

--- a/packages/ui/src/first-run/first-run-finish.ts
+++ b/packages/ui/src/first-run/first-run-finish.ts
@@ -525,6 +525,7 @@ export async function bindCloudAgent(
     ...(opts.preferAgentId ? { preferAgentId: opts.preferAgentId } : {}),
     ...(opts.forceCreate ? { forceCreate: true } : {}),
     ...(opts.knownAgents ? { knownAgents: opts.knownAgents } : {}),
+    preferStewardAgentAdapter: true,
     ...(getBootConfig().preferSharedCloudTier
       ? { preferSharedTier: true }
       : {}),

--- a/packages/ui/src/first-run/first-run-runtime-flag.test.ts
+++ b/packages/ui/src/first-run/first-run-runtime-flag.test.ts
@@ -1,11 +1,11 @@
 // @vitest-environment jsdom
 
 /**
- * The runtime-chooser gate (#13377/#14390): cloud-only onboarding is the
+ * The runtime-chooser gate (#13377/#15527): cloud-only onboarding is the
  * default on web/desktop builds; the localStorage override flips it without a
  * rebuild; the Play-Store cloud-locked Android build can never re-enable it;
- * and the Android local sideload/system builds default it ON — they ship the
- * on-device agent and onboarding is the only thing allowed to start it.
+ * and Android local sideload/system builds follow the same cloud-only default
+ * unless a developer/test lane opts into the chooser.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -61,17 +61,14 @@ describe("isRuntimeChooserEnabled", () => {
     expect(isRuntimeChooserEnabled()).toBe(false);
   });
 
-  it("the Android local sideload build defaults the chooser ON (#14390)", () => {
-    // Fresh sideload installs land in onboarding (no pre-seed, no
-    // fresh-install auto-start), so the chooser is the only path that can
-    // start the bundled agent — hiding it would strand the build cloud-only.
+  it("the Android local sideload build still defaults the chooser OFF", () => {
     mocks.isAndroidLocalSideloadBuild.mockReturnValue(true);
-    expect(isRuntimeChooserEnabled()).toBe(true);
+    expect(isRuntimeChooserEnabled()).toBe(false);
   });
 
-  it("an explicit '0' override still turns the chooser off on the sideload build", () => {
+  it("an explicit '1' override enables the chooser on the sideload build", () => {
     mocks.isAndroidLocalSideloadBuild.mockReturnValue(true);
-    localStorage.setItem(RUNTIME_CHOOSER_OVERRIDE_STORAGE_KEY, "0");
-    expect(isRuntimeChooserEnabled()).toBe(false);
+    localStorage.setItem(RUNTIME_CHOOSER_OVERRIDE_STORAGE_KEY, "1");
+    expect(isRuntimeChooserEnabled()).toBe(true);
   });
 });

--- a/packages/ui/src/first-run/first-run-runtime-flag.ts
+++ b/packages/ui/src/first-run/first-run-runtime-flag.ts
@@ -1,23 +1,17 @@
 /**
  * Gate for the first-run runtime chooser (the local / remote onboarding paths).
  *
- * The product onboards through Eliza Cloud only on web/desktop (#13377): the
- * chooser is OFF there by default, so onboarding is a single "sign in to
- * Eliza Cloud" step. Two Android exceptions bracket it: the Play-Store
- * cloud-locked variant can never enable the chooser (that build must not
- * expose a local backend regardless of developer overrides), and the local
- * sideload/system builds default it ON (#14390) — they ship the on-device
- * agent, and onboarding is the only thing allowed to start it. Elsewhere the
- * local and remote paths stay in-tree for development: a build can enable the
- * chooser with `VITE_ELIZA_ENABLE_RUNTIME_CHOOSER=1`, and tests or a running
- * shell can flip the localStorage override without a rebuild (explicit
+ * The product onboards through Eliza Cloud only by default (#13377/#15527): the
+ * chooser is OFF unless a developer/test build explicitly enables it. The
+ * Play-Store cloud-locked Android variant can never enable the chooser because
+ * that build must not expose a local backend regardless of developer overrides.
+ * The local and remote paths stay in-tree for development: a build can enable
+ * the chooser with `VITE_ELIZA_ENABLE_RUNTIME_CHOOSER=1`, and tests or a
+ * running shell can flip the localStorage override without a rebuild (explicit
  * "1"/"0" beats the build default).
  */
 
-import {
-  isAndroidCloudBuild,
-  isAndroidLocalSideloadBuild,
-} from "../platform/android-runtime";
+import { isAndroidCloudBuild } from "../platform/android-runtime";
 
 /** localStorage override: "1" enables the chooser, "0" disables, unset defers to the build default. */
 export const RUNTIME_CHOOSER_OVERRIDE_STORAGE_KEY =
@@ -51,19 +45,15 @@ function readBuildDefault(): boolean {
 
 /**
  * Whether onboarding offers the full runtime chooser (cloud / local / remote).
- * False (the default on web/desktop/cloud builds) means cloud-only onboarding:
+ * False (the default on production builds) means cloud-only onboarding:
  * sign in to Eliza Cloud is the one and only path, and completing it completes
- * first-run. The Android local sideload/system builds default the chooser ON
- * (#14390): they ship the on-device agent as their whole point, and since the
- * fresh-install auto-start is gone (boot-gated on the onboarding choice), the
- * chooser is the only path that can ever start it — hiding it would strand the
- * build on a cloud-only flow. The explicit localStorage override still beats
- * this so tests/dev shells can force either mode.
+ * first-run. Development and test builds opt into the local/remote chooser via
+ * the Vite flag or the localStorage override; Android local sideloads no longer
+ * special-case the production default.
  */
 export function isRuntimeChooserEnabled(): boolean {
   if (isAndroidCloudBuild()) return false;
   const override = readOverride();
   if (override !== null) return override;
-  if (isAndroidLocalSideloadBuild()) return true;
   return readBuildDefault();
 }


### PR DESCRIPTION
## Summary
- keep the runtime chooser disabled by default for Android local sideload/system builds unless a developer/test lane explicitly opts in
- make first-run cloud binding request the Steward-token Cloud REST adapter so default onboarding does not route into dedicated `/pair`
- preserve existing dedicated `/pair` behavior for explicit callers that do not request the Steward adapter

## Verification
- `bun run --cwd packages/ui test src/first-run/first-run-runtime-flag.test.ts src/api/client-cloud-select-or-provision.test.ts src/first-run/first-run-finish.force-fresh.test.ts`
- `bunx @biomejs/biome check packages/ui/src/first-run/first-run-runtime-flag.ts packages/ui/src/first-run/first-run-runtime-flag.test.ts packages/ui/src/api/client-cloud.ts packages/ui/src/api/client-cloud-select-or-provision.test.ts packages/ui/src/first-run/first-run-finish.ts packages/ui/src/first-run/first-run-finish.force-fresh.test.ts`
- `git diff --check`
- `bun run --cwd packages/app audit:app` partially passed: Playwright visual audit passed 241/241 with broken=0 and undebted-needs-work=0; OCR triage failed on an unrelated `builtin-browser` mobile-portrait baseline/content drift (`Enter a URL | Open a website | Summarize a page | Search the web` missing). This branch does not touch Browser view code.

Fixes #15527

<!-- evidence-row:before-screenshots -->
- [ ] N/A - first-run cloud binding behavior change with no visual before state captured locally

<!-- evidence-row:after-screenshots -->
- [ ] N/A - app visual audit rendered the app matrix; no visual surface changed in this branch

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered user-flow change; focused tests cover first-run cloud binding behavior

<!-- evidence-row:backend-logs -->
- [ ] N/A - client-side first-run binding/routing change only

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no browser runtime walkthrough captured; focused unit tests exercise the frontend client path

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no model/action/provider/prompt behavior changed

<!-- evidence-row:domain-artifacts -->
- [x] [15532-15527-focused-tests.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15532-15527-focused-tests.txt)

<!-- evidence-row:ocr-review -->
- [x] [15532-15527-app-audit-note.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15532-15527-app-audit-note.txt)
