### PR TITLE
fix(plugins): hide prose before structured stream envelopes

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/text-streaming.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/text-streaming.test.ts
@@ -665,6 +665,39 @@ describe("streamNativeChatCompletion — forced HANDLE_RESPONSE reply envelope",
     expect(visible.join("")).not.toContain("shouldRespond");
     expect(visible.join("")).not.toContain("contexts");
   });
+
+  it("hides provider prose that arrives before the forced tool-call envelope", async () => {
+    nextResponse = sseResponse([
+      dataFrame(contentDelta("pre")),
+      dataFrame(toolCallDelta("", { id: "call_1", name: "HANDLE_RESPONSE" })),
+      dataFrame(toolCallDelta('{"replyText":"hel')),
+      dataFrame(toolCallDelta('lo"}')),
+      "data: [DONE]\n\n",
+    ]);
+
+    const result = await streamNativeChatCompletion(
+      fakeRuntime(),
+      "RESPONSE_HANDLER" as never,
+      structuredParams(),
+      { modelName: "gpt-oss-120b", prompt: "hi" }
+    );
+
+    const chunks = await readStream(result);
+    expect(chunks.join("")).toBe('{"replyText":"hello"}');
+    expect(chunks.join("")).not.toContain("pre");
+
+    const visible: string[] = [];
+    const extractor = new ResponseSkeletonStreamExtractor({
+      skeleton: { spans: [], id: "test" },
+      streamFields: ["replyText"],
+      unordered: true,
+      onChunk: (chunk) => visible.push(chunk),
+    });
+    for (const chunk of chunks) extractor.push(chunk);
+    extractor.flush();
+
+    expect(visible.join("")).toBe("hello");
+  });
 });
 
 describe("resolveTextTimeoutMs", () => {

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -1598,9 +1598,14 @@ export async function streamNativeChatCompletion(
         const choice = asRecord(choices[0]);
         const delta = recordAt(choice, "delta");
         // Raw (un-trimmed) content — inter-token whitespace is significant.
+        // Structured Stage-1 streams must start with the tool-argument envelope;
+        // compatible providers that narrate before the forced tool call would
+        // otherwise flip the runtime extractor into plaintext passthrough.
         if (typeof delta.content === "string" && delta.content.length > 0) {
-          accumulated += delta.content;
-          yield delta.content;
+          if (!streamReplyToolArgs) {
+            accumulated += delta.content;
+            yield delta.content;
+          }
         }
         if (delta.tool_calls) {
           accumulateToolCallDeltas(toolAcc, delta.tool_calls);

--- a/plugins/plugin-openai/__tests__/streamstructured-tool-input-delta.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/streamstructured-tool-input-delta.shape.test.ts
@@ -2,10 +2,10 @@
  * Shape tests for streamStructured tool-input-delta forwarding: structured
  * Stage-1 calls force the response envelope out as a native tool call, and the
  * AI SDK's `textStream` drops tool-input deltas — so with `streamStructured`
- * the handler must consume `fullStream` and forward both text-delta and
- * tool-input-delta parts. Mocked `ai` SDK (fresh stream objects per call via
- * mockImplementation — generators are single-use), no network; the live
- * trajectory evidence rides the PR.
+ * the handler must consume `fullStream` and forward only tool-input-delta parts.
+ * Mocked `ai` SDK (fresh stream objects per call via mockImplementation —
+ * generators are single-use), no network; the live trajectory evidence rides
+ * the PR.
  */
 import { describe, expect, it, vi } from "vitest";
 
@@ -91,7 +91,7 @@ async function collect(stream: { textStream: AsyncIterable<string> }) {
 }
 
 describe("streamStructured tool-input-delta forwarding", () => {
-  it("streamStructured=true: tool-input deltas surface through textStream (with any text-deltas, in order)", async () => {
+  it("streamStructured=true: tool-input deltas stream while preceding text-deltas stay hidden", async () => {
     armToolForcedStream({ alsoText: true });
 
     const onStreamChunk = vi.fn();
@@ -109,8 +109,9 @@ describe("streamStructured tool-input-delta forwarding", () => {
 
     const chunks = await collect(stream);
 
-    expect(chunks).toEqual(["pre", '{"replyText":"', "hello", '"}']);
-    expect(onStreamChunk).toHaveBeenCalledTimes(4);
+    expect(chunks).toEqual(['{"replyText":"', "hello", '"}']);
+    expect(onStreamChunk).toHaveBeenCalledTimes(3);
+    expect(chunks.join("")).not.toContain("pre");
     // The authoritative envelope still arrives via the completed toolCalls.
     await expect(stream.toolCalls).resolves.toEqual([
       { toolName: "HANDLE_RESPONSE", input: { replyText: "hello" } },

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -1722,30 +1722,28 @@ async function generateTextByModelType(
             // call, and the AI SDK's textStream carries only text-delta parts —
             // tool-input (argument) deltas are silently dropped, so nothing
             // streams while the model writes the envelope. Consume fullStream
-            // instead and forward BOTH shapes: the runtime's unordered skeleton
-            // extractor filters the merged stream down to `replyText`, and the
-            // authoritative parse still comes from the completed toolCalls.
+            // instead and forward only tool-input deltas. Some compatible
+            // providers narrate before the required tool call; if that prose is
+            // mixed into the structured stream, the runtime extractor correctly
+            // switches to plaintext passthrough and the raw envelope becomes
+            // visible. The authoritative parse still comes from toolCalls.
             // Gated on streamStructured so planner/coding tool-call JSON never
             // leaks into a visible stream.
             for await (const part of result.fullStream) {
               // The AI SDK renamed these delta fields across v6 minors
-              // (`text-delta`: text→delta; `tool-input-delta`:
-              // delta→inputTextDelta), and the workspace's declared (^6.0.30)
-              // and hoisted (6.0.174) copies disagree — read both spellings so
-              // the forwarding survives either resolution. A part carrying
-              // neither is a non-delta frame and is skipped.
+              // (`tool-input-delta`: delta→inputTextDelta), and the workspace's
+              // declared (^6.0.30) and hoisted (6.0.174) copies disagree — read
+              // both spellings so the forwarding survives either resolution. A
+              // part carrying neither is a non-delta frame and is skipped.
               const record = part as {
                 type: string;
                 delta?: string;
-                text?: string;
                 inputTextDelta?: string;
               };
               const chunk =
-                record.type === "text-delta"
-                  ? (record.delta ?? record.text ?? null)
-                  : record.type === "tool-input-delta"
-                    ? (record.inputTextDelta ?? record.delta ?? null)
-                    : null;
+                record.type === "tool-input-delta"
+                  ? (record.inputTextDelta ?? record.delta ?? null)
+                  : null;
               if (!chunk) continue;
               responseChunks.push(chunk);
               params.onStreamChunk?.(chunk);


### PR DESCRIPTION
## Summary
- stop forwarding ordinary `text-delta` frames from OpenAI `streamStructured` fullStream into the visible structured stream
- suppress Eliza Cloud SSE `delta.content` prose while the structured Stage-1 reply envelope is streamed from tool-call argument deltas
- add mixed-order regression coverage for both OpenAI and Eliza Cloud so leading prose cannot force plaintext passthrough and expose raw JSON

## Verification
- `bun run --cwd plugins/plugin-openai test __tests__/streamstructured-tool-input-delta.shape.test.ts`
- `bun run --cwd plugins/plugin-elizacloud test __tests__/text-streaming.test.ts`
- `bun run --cwd plugins/plugin-openai typecheck`
- `bun run --cwd plugins/plugin-elizacloud typecheck`
- `bunx @biomejs/biome check plugins/plugin-openai/models/text.ts plugins/plugin-openai/__tests__/streamstructured-tool-input-delta.shape.test.ts plugins/plugin-elizacloud/src/models/text.ts plugins/plugin-elizacloud/__tests__/text-streaming.test.ts`
- `git diff --check`

Fixes #15531

<!-- evidence-row:before-screenshots -->
- [ ] N/A - provider streaming bug; no UI surface changed directly

<!-- evidence-row:after-screenshots -->
- [ ] N/A - provider streaming bug; no UI surface changed directly

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no rendered workflow change; deterministic stream tests cover the leak path

<!-- evidence-row:backend-logs -->
- [x] [15533-15531-openai-streamstructured-test.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15533-15531-openai-streamstructured-test.txt)

<!-- evidence-row:frontend-logs -->
- [ ] N/A - provider/backend stream shaping only

<!-- evidence-row:llm-trajectory -->
- [x] [15533-15531-live-trajectory-note.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15533-15531-live-trajectory-note.txt)

<!-- evidence-row:domain-artifacts -->
- [x] [15533-15531-elizacloud-text-streaming-test.txt](https://github.com/elizaOS/eliza/releases/download/pr-evidence/15533-15531-elizacloud-text-streaming-test.txt)

<!-- evidence-row:ocr-review -->
- [ ] N/A - no app UI/OCR surface changed
