### PR TITLE
fix(ci): make credential tunnel route test auth explicit

### DIFF
--- a/packages/app-core/src/api/credential-tunnel-routes.test.ts
+++ b/packages/app-core/src/api/credential-tunnel-routes.test.ts
@@ -18,6 +18,7 @@ import {
   SUB_AGENT_CREDENTIAL_BRIDGE_SERVICE,
   type SubAgentCredentialBridge,
 } from "../services/credential-tunnel-service";
+import { _resetAuthRateLimiter } from "./auth";
 import type { CompatRuntimeState } from "./compat-route-shared";
 import { handleCredentialTunnelRoute } from "./credential-tunnel-routes";
 
@@ -29,6 +30,7 @@ const AUTH_ENV_KEYS = [
   "ELIZA_REQUIRE_LOCAL_AUTH",
   "NODE_ENV",
 ] as const;
+const OWNER_TOKEN = "credential-tunnel-owner-token";
 
 const savedAuthEnv: Record<(typeof AUTH_ENV_KEYS)[number], string | undefined> =
   {
@@ -81,12 +83,14 @@ function fakeReq(opts: {
   ip?: string;
   host?: string;
   headers?: http.IncomingHttpHeaders;
+  auth?: "owner" | "none";
 }): http.IncomingMessage {
   const req = new http.IncomingMessage(new Socket());
   req.method = opts.method;
   req.url = opts.pathname;
   req.headers = {
     host: opts.host ?? "localhost:2138",
+    ...(opts.auth === "none" ? {} : { authorization: `Bearer ${OWNER_TOKEN}` }),
     ...(opts.headers ?? {}),
   };
   Object.defineProperty(req.socket, "remoteAddress", {
@@ -139,9 +143,12 @@ describe("credential tunnel route", () => {
       savedAuthEnv[key] = process.env[key];
     }
     clearRouteAuthState();
+    _resetAuthRateLimiter();
+    process.env.ELIZA_API_TOKEN = OWNER_TOKEN;
   });
 
   afterEach(() => {
+    _resetAuthRateLimiter();
     Reflect.deleteProperty(globalThis, BOOT_CONFIG_STORE_KEY);
     for (const key of AUTH_ENV_KEYS) {
       if (savedAuthEnv[key] === undefined) delete process.env[key];
@@ -243,6 +250,7 @@ describe("credential tunnel route", () => {
         pathname: "/api/credential-tunnel",
         ip: "203.0.113.8",
         host: "agent.example.test",
+        auth: "none",
         body: validBody(),
       }),
       stateWithBridge({ tunnelCredential }),


### PR DESCRIPTION
## Summary
- make the credential tunnel route test authenticate with an explicit owner bearer token instead of relying on ambient local-request trust
- reset the route auth limiter around the suite so Windows shard retries do not inherit auth state
- keep the remote-host unauthorized case explicit with no auth header

## Evidence
- Windows CI app-and-cli failure showed credential tunnel route cases returning 401 instead of expected 200/400/403/409 in run https://github.com/elizaOS/eliza/actions/runs/28978592145
- `node packages/app-core/scripts/ensure-shared-i18n-data.mjs`
- `bunx @biomejs/biome check packages/app-core/src/api/credential-tunnel-routes.test.ts --no-errors-on-unmatched`
- `bun run --cwd packages/app-core test src/api/credential-tunnel-routes.test.ts`
- `git diff --check`

## Evidence Matrix
- Before screenshots: N/A - workflow/test-only CI fix; no UI before state
- After screenshots: N/A - workflow/test-only CI fix; no UI after state
- Walkthrough video: N/A - no user-facing interactive flow
- Backend logs: focused Vitest output above exercises the server-side route handler
- Frontend logs: N/A - no frontend runtime
- LLM trajectory: N/A - no agent/model behavior change
- Domain artifacts: N/A - no runtime data artifacts produced
- OCR review: N/A - no rendered UI or screenshots

<!-- evidence-row:before-screenshots -->
- [ ] N/A - workflow/test-only CI fix; no UI before state

<!-- evidence-row:after-screenshots -->
- [ ] N/A - workflow/test-only CI fix; no UI after state

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing interactive flow

<!-- evidence-row:backend-logs -->
- [ ] N/A - focused server-side route test output is recorded in the PR body; no deployed backend log artifact

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/model behavior change

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no runtime data artifacts produced

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered UI or screenshots
