### PR TITLE
fix(ci): skip hetzner reaper on rejected token

### DIFF
--- a/.github/workflows/hetzner-e2e.yml
+++ b/.github/workflows/hetzner-e2e.yml
@@ -99,6 +99,10 @@ jobs:
         if: steps.secret_config.outputs.configured == 'true'
         run: bun install --no-save --ignore-scripts
 
+      - name: Ensure generated shared i18n data
+        if: steps.secret_config.outputs.configured == 'true'
+        run: bun packages/app-core/scripts/ensure-shared-i18n-data.mjs
+
       - name: Check cloud API auth
         id: cloud_auth
         if: steps.secret_config.outputs.configured == 'true'
@@ -386,6 +390,10 @@ jobs:
       - name: Install dependencies
         if: steps.secret_config.outputs.configured == 'true'
         run: bun install --no-save --ignore-scripts
+
+      - name: Ensure generated shared i18n data
+        if: steps.secret_config.outputs.configured == 'true'
+        run: bun packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
       - name: Download state artifact
         if: steps.secret_config.outputs.configured == 'true'

--- a/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-reaper.ts
+++ b/packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-reaper.ts
@@ -2,11 +2,14 @@
 /**
  * Sweep stale CI servers older than 60 minutes. Run on a schedule so a
  * crashed workflow can't leak servers indefinitely. Gracefully exits 0
- * when HCLOUD_TOKEN_CI is unset (so it doesn't spam-fail before secrets
- * are configured).
+ * when HCLOUD_TOKEN_CI is unset or rejected (so it doesn't spam-fail before
+ * secrets are configured).
  */
 
-import { HetznerCloudClient } from "@elizaos/cloud-shared/lib/services/containers/hetzner-cloud-api";
+import {
+  HetznerCloudClient,
+  HetznerCloudError,
+} from "@elizaos/cloud-shared/lib/services/containers/hetzner-cloud-api";
 
 const MAX_AGE_MS = 60 * 60 * 1000;
 
@@ -17,10 +20,22 @@ async function main(): Promise<void> {
     return;
   }
   const client = HetznerCloudClient.withToken(token);
-  const servers = await client.listServers({
-    ci: "true",
-    workflow: "hetzner-e2e",
-  });
+  let servers: Awaited<ReturnType<typeof client.listServers>>;
+  try {
+    servers = await client.listServers({
+      ci: "true",
+      workflow: "hetzner-e2e",
+    });
+  } catch (err) {
+    // error-policy:J4 Scheduled cleanup must not page on absent or revoked CI credentials.
+    if (err instanceof HetznerCloudError && err.code === "missing_token") {
+      console.warn(
+        "[hetzner-e2e-reaper] HCLOUD_TOKEN_CI rejected by Hetzner; skipping",
+      );
+      return;
+    }
+    throw err;
+  }
   const now = Date.now();
   let deleted = 0;
   for (const server of servers) {
@@ -35,6 +50,7 @@ async function main(): Promise<void> {
       await client.deleteServer(server.id);
       deleted++;
     } catch (err) {
+      // error-policy:J6 Best-effort cleanup keeps sweeping other stale servers.
       const message = err instanceof Error ? err.message : String(err);
       console.warn(
         `[hetzner-e2e-reaper] delete ${server.id} failed: ${message}`,


### PR DESCRIPTION
## Summary
- treat Hetzner `missing_token` responses from the scheduled reaper list call as a configured-unavailable state
- generate shared i18n data in both Hetzner Agent E2E jobs after `bun install --ignore-scripts`, including teardown
- keep scheduled/push Hetzner cleanup lanes green when credentials are unset, revoked, or when a skipped deploy still runs teardown
- annotate the reaper catch sites under the error-policy categories

## Evidence
- Fresh develop reaper failure after #15534: https://github.com/elizaOS/eliza/actions/runs/28981121757
- Fresh develop Hetzner Agent E2E teardown failure: https://github.com/elizaOS/eliza/actions/runs/28981121121
- YAML parse for `.github/workflows/hetzner-e2e.yml` and `.github/workflows/hetzner-e2e-reaper.yml`
- `actionlint .github/workflows/hetzner-e2e.yml .github/workflows/hetzner-e2e-reaper.yml`
- `node packages/app-core/scripts/ensure-shared-i18n-data.mjs`
- `HCLOUD_TOKEN_CI= bun run packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-reaper.ts` -> skipped unset token
- local mock Hetzner API returning 401 `{ error: { code: "unauthorized", message: "the token you have provided is invalid" } }` with `HCLOUD_TOKEN_CI=invalid HCLOUD_API_BASE_URL=http://127.0.0.1:<port>/v1 bun run packages/scripts/cloud/admin/hetzner-e2e/hetzner-e2e-reaper.ts` -> skipped rejected token, exit 0
- `bun run audit:error-policy-ratchet`
- `git diff --check`

## Evidence Matrix
- Before screenshots: N/A - workflow/script-only CI fix; no UI before state
- After screenshots: N/A - workflow/script-only CI fix; no UI after state
- Walkthrough video: N/A - no user-facing interactive flow
- Backend logs: N/A - local script output is summarized above; no deployed backend log artifact
- Frontend logs: N/A - no frontend runtime
- LLM trajectory: N/A - no agent/model behavior change
- Domain artifacts: N/A - no Hetzner server deletion was executed; local mock API verified the auth failure path
- OCR review: N/A - no rendered UI or screenshots

<!-- evidence-row:before-screenshots -->
- [ ] N/A - workflow/script-only CI fix; no UI before state

<!-- evidence-row:after-screenshots -->
- [ ] N/A - workflow/script-only CI fix; no UI after state

<!-- evidence-row:walkthrough-video -->
- [ ] N/A - no user-facing interactive flow

<!-- evidence-row:backend-logs -->
- [ ] N/A - local script output is summarized in the PR body; no deployed backend log artifact

<!-- evidence-row:frontend-logs -->
- [ ] N/A - no frontend runtime

<!-- evidence-row:llm-trajectory -->
- [ ] N/A - no agent/model behavior change

<!-- evidence-row:domain-artifacts -->
- [ ] N/A - no Hetzner server deletion was executed; local mock API verified the auth failure path

<!-- evidence-row:ocr-review -->
- [ ] N/A - no rendered UI or screenshots
