### PR TITLE
perf(cloud): raise inference auth-context TTL 60s → 300s — kills the 3-5.5s first-message-after-idle spike

### DIFF
--- a/packages/cloud/shared/src/lib/cache/keys.ts
+++ b/packages/cloud/shared/src/lib/cache/keys.ts
@@ -248,13 +248,19 @@ export const CacheTTL = {
     appMapping: 600, // 10 minutes - app-to-API-key mapping rarely changes
   },
   /**
-   * Inference hot-path TTLs (#9899). Deliberately short: the IAC entry caches a
-   * fully-authorized auth+moderation decision, so its TTL is the load-bearing
-   * bound on how long a revoked/banned credential is served if explicit
-   * invalidation is missed or lost to KV propagation lag.
+   * Inference hot-path TTLs (#9899). The IAC entry caches a fully-authorized
+   * auth+moderation decision. Its PRIMARY freshness mechanism is explicit
+   * confirmed-delete invalidation on every credential mutation — revoke/update
+   * (api-keys), ban (users), org deactivate (organizations) — all fail-closed
+   * (#13417), so the TTL is only the backstop for an invalidation that was
+   * never issued. At 60s every chat pause longer than a minute paid the full
+   * cold auth rebuild (~1.7s measured on prod, the dominant term of the
+   * 3-5.5s first-message-after-idle spike); 300s keeps active conversations
+   * warm across natural gaps while bounding a lost-invalidation window to the
+   * same 5 minutes org.data already accepts.
    */
   inference: {
-    authContext: 60, // 1 minute - worst-case revoked/banned exposure ~= TTL + KV lag
+    authContext: 300, // 5 min - backstop only; revoke paths invalidate explicitly (fail-closed)
     orgBalance: 15, // 15 seconds - optimistic-billing gate hint, kept tight to bound drift
     pendingCharge: 3600, // 60 min - sweep window = TTL - grace(20m) = 40m, survives cron hiccups
   },


### PR DESCRIPTION
## Summary
- `CacheTTL.inference.authContext` 60s → 300s

## Why (measured on prod `f6f91af` tonight, post latency-stack deploy)
First chat message after >60s idle: `X-Eliza-Preforward-Ms: total=2959 (auth=1684, mid=482, reserve=705)` → 5.5s turn. Same request warm: `total=109 (auth=2)` → 1.0s. The dominant cold term is the inference auth-context entry expiring between natural conversation pauses — with the pass-through stack live, this cold spike is now the single biggest remaining user-felt latency on cloud.

## Safety
The IAC's primary freshness mechanism is **explicit confirmed-delete invalidation** on every credential mutation — api-key revoke/update (`api-keys.ts:185,225`), user ban (`users.ts:259`), org deactivate (`organizations.ts:84`) — all fail-closed per #13417 (a rejected delete propagates instead of being swallowed). The TTL is only the backstop for an invalidation that was never issued; 300s bounds that window to the same 5 minutes `org.data` already accepts. `orgBalance` (15s, billing-drift bound) and `pendingCharge` are untouched.

## Tests
`messages-iac-fast-path.test.ts` 4/4 green (no test pins the numeric TTL); biome clean.

Follow-up candidates (same pattern, separate change): the `mid` (482ms) and `reserve` (705ms) cold terms have their own caches/gates worth the same warm-window review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
