### PR TITLE
fix(cloud): reuse the existing agent in first-run onboarding instead of 503 dead-end during worker outage

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-create-idempotency.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-create-idempotency.test.ts
@@ -23,6 +23,10 @@ const requireUserOrApiKeyWithOrg = mock(async () => ({
 const createAgent = mock();
 const updateAgentEnvironment = mock(async () => undefined);
 const listAgents = mock(async () => []);
+// Default false = the org has no reusable agent, so the worker-health gate
+// runs exactly as it did before the #15516 reuse-peek — existing tests keep
+// their original gate semantics.
+const hasReusableNonTerminalAgent = mock(async () => false);
 
 const enqueueAgentProvision = mock(async () => ({
   id: "job-1",
@@ -37,7 +41,11 @@ const checkAgentCreditGate = mock(
     balance: 100,
   }),
 );
-const checkProvisioningWorkerHealth = mock(async () => ({ ok: true }));
+const checkProvisioningWorkerHealth = mock(
+  async (): Promise<{ ok: boolean; status?: number; code?: string }> => ({
+    ok: true,
+  }),
+);
 const prepareManagedElizaEnvironment = mock(async () => ({
   changed: false,
   environmentVars: {},
@@ -91,7 +99,12 @@ class AgentImageNotAllowedError extends Error {
 }
 
 mock.module("@/lib/services/eliza-sandbox", () => ({
-  elizaSandboxService: { createAgent, updateAgentEnvironment, listAgents },
+  elizaSandboxService: {
+    createAgent,
+    updateAgentEnvironment,
+    listAgents,
+    hasReusableNonTerminalAgent,
+  },
   AgentImageNotAllowedError,
   AgentQuotaExceededError,
 }));
@@ -157,6 +170,9 @@ describe("POST /api/v1/eliza/agents — reuse idempotency", () => {
     triggerImmediate.mockClear();
     checkAgentCreditGate.mockClear();
     checkProvisioningWorkerHealth.mockClear();
+    checkProvisioningWorkerHealth.mockResolvedValue({ ok: true });
+    hasReusableNonTerminalAgent.mockClear();
+    hasReusableNonTerminalAgent.mockResolvedValue(false);
     prepareManagedElizaEnvironment.mockClear();
     loggerInfo.mockClear();
   });
@@ -361,5 +377,74 @@ describe("POST /api/v1/eliza/agents — reuse idempotency", () => {
       reuseExistingNonTerminal?: boolean;
     };
     expect(passed.reuseExistingNonTerminal).toBe(true);
+  });
+
+  test("#15516: a provisioning-worker outage does NOT block reuse — reusable agent exists → gate skipped, 200 with the existing agent", async () => {
+    // Reuse enqueues nothing, so worker capacity is irrelevant to it. The
+    // route must resolve reuse candidacy BEFORE the health gate; otherwise a
+    // heartbeat gap 503s first-run onboarding for a user whose one healthy
+    // agent needed no provisioning at all (the #15516 dead-end).
+    hasReusableNonTerminalAgent.mockResolvedValue(true);
+    checkProvisioningWorkerHealth.mockResolvedValue({
+      ok: false,
+      status: 503,
+      code: "PROVISIONING_WORKER_UNHEALTHY",
+    });
+    const agent = pendingAgent();
+    createAgent.mockResolvedValue({ agent, idempotent: true });
+
+    const res = await postCreate({
+      agentName: "alpha",
+      dockerImage: "ghcr.io/example/agent:latest",
+    });
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { created: boolean };
+    expect(json.created).toBe(false);
+    // The gate was skipped entirely — not just tolerated.
+    expect(checkProvisioningWorkerHealth).not.toHaveBeenCalled();
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
+  });
+
+  test("#15516: worker outage with NO reusable agent still fails closed → 503, createAgent never runs", async () => {
+    hasReusableNonTerminalAgent.mockResolvedValue(false);
+    checkProvisioningWorkerHealth.mockResolvedValue({
+      ok: false,
+      status: 503,
+      code: "PROVISIONING_WORKER_UNHEALTHY",
+    });
+
+    const res = await postCreate({
+      agentName: "alpha",
+      dockerImage: "ghcr.io/example/agent:latest",
+    });
+
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { success: boolean; code: string };
+    expect(body.success).toBe(false);
+    expect(body.code).toBe("PROVISIONING_WORKER_UNHEALTHY");
+    expect(createAgent).not.toHaveBeenCalled();
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
+  });
+
+  test("#15516: forceCreate never skips the gate — a fresh mint during a worker outage 503s even when a reusable agent exists", async () => {
+    // forceCreate explicitly opts out of reuse, so its create WILL enqueue —
+    // the worker gate must keep protecting it regardless of reuse candidacy.
+    hasReusableNonTerminalAgent.mockResolvedValue(true);
+    checkProvisioningWorkerHealth.mockResolvedValue({
+      ok: false,
+      status: 503,
+      code: "PROVISIONING_WORKER_UNHEALTHY",
+    });
+
+    const res = await postCreate({
+      agentName: "alpha",
+      dockerImage: "ghcr.io/example/agent:latest",
+      forceCreate: true,
+    });
+
+    expect(res.status).toBe(503);
+    expect(createAgent).not.toHaveBeenCalled();
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
   });
 });

--- a/packages/cloud/api/__tests__/eliza-agents-orphan-cleanup.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-orphan-cleanup.test.ts
@@ -84,6 +84,9 @@ mock.module("@/lib/services/eliza-sandbox", () => ({
     createAgent,
     updateAgentEnvironment,
     listAgents: mock(async () => []),
+    // #15516 reuse-peek: false = no reusable agent, so the worker-health gate
+    // behaves exactly as before the peek existed.
+    hasReusableNonTerminalAgent: mock(async () => false),
   },
 }));
 

--- a/packages/cloud/api/__tests__/eliza-agents-warm-pool-empty-on-claim.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-warm-pool-empty-on-claim.test.ts
@@ -83,7 +83,14 @@ class AgentQuotaExceededError extends Error {}
 class AgentImageNotAllowedError extends Error {}
 
 mock.module("@/lib/services/eliza-sandbox", () => ({
-  elizaSandboxService: { createAgent, updateAgentEnvironment, listAgents },
+  elizaSandboxService: {
+    createAgent,
+    updateAgentEnvironment,
+    listAgents,
+    // #15516 reuse-peek: false = no reusable agent, so the worker-health gate
+    // behaves exactly as before the peek existed.
+    hasReusableNonTerminalAgent: mock(async () => false),
+  },
   AgentQuotaExceededError,
   AgentImageNotAllowedError,
 }));

--- a/packages/cloud/api/v1/eliza/agents/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/route.ts
@@ -366,16 +366,31 @@ app.post("/", async (c) => {
       );
     }
 
-    const workerHealth = await checkProvisioningWorkerHealth();
-    if (!workerHealth.ok) {
-      logger.warn("[agent-api] Agent creation blocked: worker unavailable", {
-        orgId: user.organization_id,
-        code: workerHealth.code,
-      });
-      return c.json(
-        provisioningWorkerFailureBody(workerHealth),
-        workerHealth.status,
-      );
+    // The worker-health gate protects only FRESH provisions (a create that
+    // enqueues a job no worker will run). When the org already has a reusable
+    // non-terminal agent, `createAgent` below hands it back without touching
+    // the provisioning queue — so a worker outage must not 503 that caller
+    // (#15516: first-run onboarding dead-ended for a user whose one healthy
+    // agent needed no provisioning at all). The peek is advisory; if the
+    // candidate vanishes before `createAgent`'s locked re-check, the fresh
+    // create's job just waits in the queue for the worker to recover.
+    const reuseWouldServe =
+      !parsed.data.forceCreate &&
+      (await elizaSandboxService.hasReusableNonTerminalAgent(
+        user.organization_id,
+      ));
+    if (!reuseWouldServe) {
+      const workerHealth = await checkProvisioningWorkerHealth();
+      if (!workerHealth.ok) {
+        logger.warn("[agent-api] Agent creation blocked: worker unavailable", {
+          orgId: user.organization_id,
+          code: workerHealth.code,
+        });
+        return c.json(
+          provisioningWorkerFailureBody(workerHealth),
+          workerHealth.status,
+        );
+      }
     }
   }
 

--- a/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud/shared/src/db/repositories/agent-sandboxes.ts
@@ -175,6 +175,31 @@ export class AgentSandboxesRepository {
       .orderBy(desc(agentSandboxes.created_at));
   }
 
+  /**
+   * Read-only peek at whether `createAgent`'s idempotent-reuse guard would
+   * hand back an existing agent for this org. Mirrors that guard's predicate
+   * EXACTLY (org-scoped, `pool_status IS NULL`, status
+   * pending/provisioning/running — see eliza-sandbox.ts `createAgent`); keep
+   * the two in sync. Advisory: the guard re-checks under its org advisory
+   * lock, so this may only ever be used to soften capacity gates (#15516),
+   * never as the reuse decision itself.
+   */
+  async hasReusableNonTerminalByOrganization(orgId: string): Promise<boolean> {
+    await ensureAgentSandboxSchema();
+    const [existing] = await dbRead
+      .select({ id: agentSandboxes.id })
+      .from(agentSandboxes)
+      .where(
+        and(
+          eq(agentSandboxes.organization_id, orgId),
+          sql`${agentSandboxes.pool_status} IS NULL`,
+          sql`${agentSandboxes.status} IN ('pending', 'provisioning', 'running')`,
+        ),
+      )
+      .limit(1);
+    return Boolean(existing);
+  }
+
   async findBySandboxId(sandboxId: string): Promise<AgentSandbox | undefined> {
     await ensureAgentSandboxSchema();
     const [r] = await dbRead

--- a/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud/shared/src/lib/services/eliza-sandbox.ts
@@ -962,6 +962,20 @@ export class ElizaSandboxService {
     }
   }
 
+  /**
+   * Read-only peek at `createAgent`'s idempotent-reuse guard: would a
+   * `reuseExistingNonTerminal` create hand back an existing agent instead of
+   * inserting one? Routes use this to skip capacity gates (the
+   * provisioning-worker health 503) when no new provision would be enqueued:
+   * reuse needs no provisioning capacity, so a worker outage must not block a
+   * user who already has an agent (#15516). Advisory only — `createAgent`
+   * re-checks under its org advisory lock; a candidate deleted in the gap
+   * means a fresh create whose provision job simply waits in the queue.
+   */
+  async hasReusableNonTerminalAgent(organizationId: string): Promise<boolean> {
+    return agentSandboxesRepository.hasReusableNonTerminalByOrganization(organizationId);
+  }
+
   async createAgent(params: CreateAgentParams): Promise<{
     agent: AgentSandbox;
     idempotent: boolean;

--- a/packages/ui/src/api/client-cloud-connect-mock-cloud.test.ts
+++ b/packages/ui/src/api/client-cloud-connect-mock-cloud.test.ts
@@ -574,6 +574,66 @@ describe("mock-cloud connect e2e — dedicated cold boot + shared chat bridge", 
     );
   });
 
+  it("honors a remembered non-running agent over a different running one (waking it instead of silently swapping conversations)", async () => {
+    // The remembered (persisted) agent is stopped; a NEWER running agent also
+    // exists. Binding the other agent would swap the user's conversations and
+    // memories — the remembered choice must win and be woken (#15516).
+    const remembered = seedDedicated({
+      id: "agent-remembered",
+      webUiUrl: `${base}/dedicated/agent-remembered-stale`,
+      runningWebUiUrl: `${base}/dedicated/agent-remembered`,
+      bootAfterPolls: 1,
+    });
+    const other: MockAgent = {
+      id: "agent-other",
+      agentName: "Other Eliza",
+      status: "running",
+      webUiUrl: `${base}/dedicated/agent-other`,
+      bridgeUrl: null,
+      bootAfterPolls: 0,
+      resumeRequested: false,
+      pollsSinceResume: 0,
+      proxy202sRemaining: 0,
+    };
+    state.agents.set(other.id, other);
+
+    const client = makeClient();
+    const result = await client.selectOrProvisionCloudAgent({
+      cloudApiBase: base,
+      authToken: AUTH_TOKEN,
+      name: "Eliza",
+      preferAgentId: "agent-remembered",
+      wakePollIntervalMs: 20,
+      wakeTimeoutMs: 5_000,
+    });
+
+    expect(result.agentId).toBe("agent-remembered");
+    expect(result.created).toBe(false);
+    expect(state.resumeCalls).toEqual(["agent-remembered"]);
+    expect(remembered.status).toBe("running");
+    expect(result.apiBase).toBe(`${base}/dedicated/agent-remembered`);
+  });
+
+  it("falls through to create only when every existing agent is terminally failed", async () => {
+    // A terminal `error` row is genuinely unreusable — the pick must NOT hand
+    // it back (nor wait on it); the flow proceeds to the create POST, which
+    // this mock does not implement (404) — proving create was attempted.
+    seedDedicated({
+      id: "agent-dead",
+      status: "error",
+      errorMessage: "container image pull failed",
+    });
+    const client = makeClient();
+    await expect(
+      client.selectOrProvisionCloudAgent({
+        cloudApiBase: base,
+        authToken: AUTH_TOKEN,
+        name: "Eliza",
+      }),
+    ).rejects.toThrow(/no mock route for POST \/api\/v1\/eliza\/agents/i);
+    expect(state.resumeCalls).toEqual([]);
+  });
+
   it("rejects (never provisions a duplicate) when the control plane refuses the list", async () => {
     seedDedicated();
     const client = makeClient();

--- a/packages/ui/src/api/client-cloud.ts
+++ b/packages/ui/src/api/client-cloud.ts
@@ -3287,26 +3287,42 @@ export async function waitForCloudAgentRunning(
 }
 
 /**
- * Pick which running agent to reuse from a cloud agent list: a specific
- * requested id if it is running, else the most-recently-created running agent.
- * Non-running rows are not reusable for first-run binding because a stale
- * shared/dedicated pointer can otherwise be treated as healthy while chat 404s.
+ * Pick which agent to reuse from a cloud agent list: a specific requested id
+ * when it is running, else the most-recently-created running agent, else the
+ * newest NON-TERMINAL agent (pending/provisioning/stopped/…). A running-only
+ * pick (#15491) left any transiently-not-running account with zero reuse
+ * candidates, so first-run fell through to a fresh create — which the server
+ * 503-blocks during a provisioning-worker outage even though the user's
+ * existing agent was fine (#15516). Non-running picks are never bound
+ * directly: the reuse branch routes them through `waitForCloudAgentRunning`,
+ * which resolves with the FRESH post-wake record — that (not refusing reuse)
+ * is the guard against binding a stale pointer whose chat 404s. Only terminal
+ * `error`/`failed` rows are unreusable.
  */
 function pickPreferredCloudAgent(
   agents: CloudCompatAgent[],
   preferAgentId?: string | null,
 ): CloudCompatAgent | null {
   if (!agents.length) return null;
+  const byNewest = (rows: CloudCompatAgent[]) =>
+    [...rows].sort((a, b) =>
+      String(b.created_at).localeCompare(String(a.created_at)),
+    );
   if (preferAgentId) {
+    // Honor the remembered agent whenever it is not terminally failed —
+    // silently binding a DIFFERENT agent would swap the user's conversations
+    // and memories; a cold-boot wait on the remembered one is the honest cost.
     const exact = agents.find(
-      (a) => a.agent_id === preferAgentId && a.status === "running",
+      (a) => a.agent_id === preferAgentId && !isTerminalFailedCloudAgent(a),
     );
     if (exact) return exact;
   }
-  const byNewest = agents
-    .filter((a) => a.status === "running")
-    .sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)));
-  return byNewest[0] ?? null;
+  const running = byNewest(agents.filter((a) => a.status === "running"));
+  if (running[0]) return running[0];
+  const nonTerminal = byNewest(
+    agents.filter((a) => !isTerminalFailedCloudAgent(a)),
+  );
+  return nonTerminal[0] ?? null;
 }
 
 ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
@@ -3373,23 +3389,15 @@ ElizaClient.prototype.selectOrProvisionCloudAgent = async function (
       list.data.every(isTerminalFailedCloudAgent);
     if (chosen) {
       let agent = chosen;
-      const initialBase = resolveCloudAgentApiBase({
-        bridgeUrl: chosen.bridge_url,
-        webUiUrl: chosen.web_ui_url ?? chosen.webUiUrl,
-        agentId: chosen.agent_id,
-        cloudApiBase: resolvedCloudApiBase,
-      });
-      // A DEDICATED agent (its record exposes the container subdomain / bridge
-      // base rather than the shared REST adapter) that is not `running` is a
-      // ~5-minute cold boot (#8621). Binding its base immediately makes the
-      // first chat call exhaust the ~60 s 202-retry budget and error out — so
-      // wait for `running` here, streaming progress through the connect flow's
-      // existing onProgress plumbing. Shared agents never wait (container-free,
-      // served instantly by the in-Worker runtime).
-      const isDedicated =
-        !isDirectCloudSharedAgentBase(initialBase) &&
-        Boolean(chosen.web_ui_url ?? chosen.webUiUrl ?? chosen.bridge_url);
-      if (isDedicated && agent.status !== "running") {
+      // A picked agent that is not `running` is a dedicated cold boot: shared
+      // rows are BORN `running` (they are container-free, served instantly by
+      // the in-Worker runtime), so a non-running pick always has a container
+      // to wake (~5 minutes — #8621). Binding its list-row base immediately
+      // would exhaust the ~60 s 202-retry budget on the first chat call AND
+      // risks a stale pointer (the list row's URLs predate the wake) — so wait
+      // for `running` here; `waitForCloudAgentRunning` kicks a resume and
+      // resolves with the FRESH post-wake record, whose URLs we bind below.
+      if (agent.status !== "running") {
         agent = await waitForCloudAgentRunning(this, {
           agentId: chosen.agent_id,
           ...(typeof options.wakePollIntervalMs === "number"


### PR DESCRIPTION
## What & why (#15516 Bug B)

On a real LP3 device, native cloud onboarding **provisioned + 503'd and dead-ended** for a user whose one healthy agent (running/ready/pairable) needed no provisioning at all. Two stacked defects, both fixed here:

### Client — the reuse pick refused every non-running agent
#15491 changed `pickPreferredCloudAgent` to **running-only**. Any transiently non-running row (`starting`/`stopped`/status churn during the very outage that 503s creates) produced zero reuse candidates → first-run fell through to a fresh create. The reuse branch's cold-boot wait (`waitForCloudAgentRunning`) had become **unreachable dead code** — a pick was always running, so the wait never fired.

**Fix:** pick prefers running, then falls back to the **newest non-terminal** row, routed through `waitForCloudAgentRunning` — which kicks a resume and resolves with the **fresh post-wake record** (post-wake URLs). That is the correct guard against #15491's stale-pointer concern (never bind a stale row directly), instead of refusing reuse outright. Safe because shared rows are **born `running`** (`eliza-sandbox.ts` create: `shared → "running"`), so a non-running pick always has a container to wake. A remembered `preferAgentId` is honored whenever non-terminal — silently binding a *different* agent would swap the user's conversations/memories.

### Server — the worker-health gate ran before its own reuse safety-net
`POST /api/v1/eliza/agents` ran `checkProvisioningWorkerHealth()` **before** `createAgent`'s idempotent reuse — so during a heartbeat gap (real outage in the CP journal: Redis socket timeouts 20:26–20:40, key TTL 60s; **zero provision jobs 20:00–21:33**, all pre-enqueue rejects) even callers whose create would be served by reuse got 503.

**Fix:** the route peeks reuse candidacy first (read-only repository mirror of the guard predicate, documented as such) and only gates a create that would genuinely enqueue. `forceCreate` **always stays gated** (it opts out of reuse by definition). Fail-closed behavior for no-agent orgs is unchanged.

## Proof

**The existing mock-cloud connect suite was RED on develop** — 3 tests fail on the unfixed code with the exact bug signature (create POST fired instead of reusing the stopped agent):
```
× waits out a dedicated cold boot: resume kick, starting progress, fresh post-wake base…
× fails fast with the agent's error message on a terminal error status
× times out with an actionable message when the container never reports running
  → Cloud request failed (404): no mock route for POST /api/v1/eliza/agents
```
With this fix: **9/9 pass** (incl. 2 new: remembered-agent wake priority; all-terminal → create fall-through).

**Route suites (bun): 12/12 idempotency (3 new #15516 ordering tests), 5/5 orphan-cleanup, 2/2 warm-pool** (per-file, matching CI; the combined-single-process run has pre-existing cross-suite mock.module interference on develop too — verified 0-pass/2-fail on untouched develop). New ordering coverage:
- worker outage + reusable agent → **200 reuse, gate skipped entirely** (`checkProvisioningWorkerHealth` not called)
- worker outage + no reusable agent → **503 fail-closed**, createAgent never runs
- worker outage + `forceCreate` + reusable agent → **503** (forceCreate never skips the gate)

Biome clean; `typecheck` clean for `packages/ui`, `packages/cloud/shared`, `packages/cloud/api` (filtered to touched files).

## Evidence rows
- Backend logs: CP journal forensics + prod DB job-table evidence in the root-cause comment on #15516 (heartbeat outage windows, zero-jobs gap). N/A for staging traces — the fix is proven by the red→green suite + route tests above.
- Screenshots / video: N/A — no rendered UI change; the flow fix is client-logic + API. The on-device re-verify (fresh LP3 pass through onboarding, including during a simulated heartbeat gap) is @qa-agent's device lane per the issue.
- LLM trajectory: N/A — no agent/prompt/model behavior change.
- Domain artifacts: route tests assert the exact wire shapes (200 reuse envelope, 503 `PROVISIONING_WORKER_UNHEALTHY` body).

Residual (separate, flagged on #15516): the `/provision` route's healthy-agent 200 fast-path requires `bridge_url` AND `health_url` — a healthy agent missing either still falls into the gate; that's #15477-adjacent (provisioning-durability lane).

Fixes #15516 (Bug B) · root cause + tracer evidence: https://github.com/elizaOS/eliza/issues/15516#issuecomment-4919716995 · `[cloud-agent]`

## Evidence rows
<!-- evidence-row:before-screenshots -->
- [ ] Before screenshots `N/A - no rendered UI change (client flow-logic + API route ordering); on-device before/after is the qa device-lane re-verify per #15516`.
<!-- evidence-row:after-screenshots -->
- [ ] After screenshots `N/A - no UI surface changed`.
<!-- evidence-row:walkthrough-video -->
- [ ] Walkthrough video `N/A - no user-visible web/desktop flow change; the LP3 on-device walkthrough is the qa device lane's re-verify step tracked on #15516`.
<!-- evidence-row:backend-logs -->
- [ ] Backend logs: CP journal + prod jobs-table forensics (heartbeat outage windows, zero-jobs gap) in the root-cause comment: https://github.com/elizaOS/eliza/issues/15516#issuecomment-4919716995
<!-- evidence-row:frontend-logs -->
- [ ] Frontend logs: the mock-cloud suite drives the REAL client HTTP path against a real HTTP server and asserts the request log (red on develop, 9/9 green here); original device logcat: https://github.com/elizaOS/eliza/issues/15516
<!-- evidence-row:llm-trajectory -->
- [ ] Real-LLM trajectory `N/A - no agent/action/provider/prompt/model behavior change; control-plane transport only`.
<!-- evidence-row:domain-artifacts -->
- [ ] Domain artifacts: route tests assert the exact wire shapes (200 reuse envelope, 503 PROVISIONING_WORKER_UNHEALTHY fail-closed, forceCreate gated) — see test output in the PR description; suite files: https://github.com/elizaOS/eliza/pull/15541/files
<!-- evidence-row:ocr-review -->
- [ ] OCR visual text review `N/A - no media/screenshot artifacts in this change`.
