### PR TITLE
fix(cloud): provisioning health gate after idempotent reuse — worker blips no longer 503 onboarding (#15516 Bug B server half)

### DIFF
--- a/packages/cloud/api/__tests__/eliza-agents-create-idempotency.test.ts
+++ b/packages/cloud/api/__tests__/eliza-agents-create-idempotency.test.ts
@@ -49,9 +49,14 @@ const loggerError = mock(() => undefined);
 
 const claimWarmContainer = mock(async () => null);
 const listByOrganization = mock(async () => []);
+const sandboxDelete = mock(async () => undefined);
 
 mock.module("@/db/repositories/agent-sandboxes", () => ({
-  agentSandboxesRepository: { claimWarmContainer, listByOrganization },
+  agentSandboxesRepository: {
+    claimWarmContainer,
+    listByOrganization,
+    delete: sandboxDelete,
+  },
 }));
 
 mock.module("@/db/repositories/characters", () => ({
@@ -157,6 +162,8 @@ describe("POST /api/v1/eliza/agents — reuse idempotency", () => {
     triggerImmediate.mockClear();
     checkAgentCreditGate.mockClear();
     checkProvisioningWorkerHealth.mockClear();
+    checkProvisioningWorkerHealth.mockResolvedValue({ ok: true });
+    sandboxDelete.mockClear();
     prepareManagedElizaEnvironment.mockClear();
     loggerInfo.mockClear();
   });
@@ -186,6 +193,56 @@ describe("POST /api/v1/eliza/agents — reuse idempotency", () => {
     expect(enqueueAgentProvision).not.toHaveBeenCalled();
     expect(triggerImmediate).not.toHaveBeenCalled();
     expect(prepareManagedElizaEnvironment).not.toHaveBeenCalled();
+  });
+
+  test("#15516 Bug B: worker outage does NOT block the idempotent reuse path", async () => {
+    // Worker heartbeat is down — the old pre-create gate 503'd here even
+    // though the org's existing agent could be handed back with no worker.
+    checkProvisioningWorkerHealth.mockResolvedValue({
+      ok: false,
+      code: "worker_heartbeat_stale",
+      error: "provisioning worker heartbeat is stale",
+      status: 503,
+    } as never);
+    const agent = pendingAgent();
+    createAgent.mockResolvedValue({ agent, idempotent: true });
+
+    const res = await postCreate({
+      agentName: "alpha",
+      dockerImage: "ghcr.io/example/agent:latest",
+    });
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { created: boolean };
+    expect(json.created).toBe(false);
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
+    expect(sandboxDelete).not.toHaveBeenCalled();
+  });
+
+  test("#15516 Bug B: worker outage on a FRESH create → 503 with the canonical body AND the pending row rolled back", async () => {
+    checkProvisioningWorkerHealth.mockResolvedValue({
+      ok: false,
+      code: "worker_heartbeat_stale",
+      error: "provisioning worker heartbeat is stale",
+      status: 503,
+    } as never);
+    const agent = { ...pendingAgent(), status: "pending" };
+    createAgent.mockResolvedValue({ agent, idempotent: false });
+
+    const res = await postCreate({
+      agentName: "alpha",
+      dockerImage: "ghcr.io/example/agent:latest",
+    });
+
+    expect(res.status).toBe(503);
+    const json = (await res.json()) as { success: boolean; code: string };
+    expect(json.success).toBe(false);
+    expect(json.code).toBe("worker_heartbeat_stale");
+    // No job enqueued, and the just-created pending row was rolled back so no
+    // orphan is left for the cleanup cron.
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
+    expect(sandboxDelete).toHaveBeenCalledTimes(1);
+    expect(sandboxDelete).toHaveBeenCalledWith(agent.id, "org-1");
   });
 
   test("fresh create (idempotent:false) still enqueues a job and returns 202", async () => {

--- a/packages/cloud/api/v1/eliza/agents/route.ts
+++ b/packages/cloud/api/v1/eliza/agents/route.ts
@@ -366,17 +366,10 @@ app.post("/", async (c) => {
       );
     }
 
-    const workerHealth = await checkProvisioningWorkerHealth();
-    if (!workerHealth.ok) {
-      logger.warn("[agent-api] Agent creation blocked: worker unavailable", {
-        orgId: user.organization_id,
-        code: workerHealth.code,
-      });
-      return c.json(
-        provisioningWorkerFailureBody(workerHealth),
-        workerHealth.status,
-      );
-    }
+    // Worker health is deliberately NOT checked here — it moved to the
+    // enqueue site below so a worker-heartbeat gap can't block the idempotent
+    // reuse / shared-tier / warm-pool paths that don't need the worker at all
+    // (#15516 Bug B).
   }
 
   let created: Awaited<ReturnType<typeof elizaSandboxService.createAgent>>;
@@ -611,6 +604,33 @@ app.post("/", async (c) => {
     }
 
     // ── Async path (default) ──────────────────────────────────────────────
+    // Worker-health gate, checked HERE (immediately before the enqueue) and
+    // not before createAgent: only the enqueued provision job needs a live
+    // worker. Gating earlier blocked every path that works fine during a
+    // worker-heartbeat gap — the idempotent reuse of the org's existing agent
+    // (the #15516 Bug B server half: the backend's own reuse safety-net was
+    // unreachable during an outage, so clients fell into create→503 loops),
+    // shared-tier creates, non-eager creates, and warm-pool claims.
+    const workerHealth = await checkProvisioningWorkerHealth();
+    if (!workerHealth.ok) {
+      // Explicit rollback + return (not a throw): withOrphanCleanup only
+      // fires on throw, and throwing would change the wire shape clients
+      // already parse — this keeps the exact pre-reorder 503 body.
+      await agentSandboxesRepository.delete(agent.id, user.organization_id);
+      logger.warn(
+        "[agent-api] Agent provisioning blocked: worker unavailable (row rolled back)",
+        {
+          agentId: agent.id,
+          orgId: user.organization_id,
+          code: workerHealth.code,
+        },
+      );
+      return c.json(
+        provisioningWorkerFailureBody(workerHealth),
+        workerHealth.status,
+      );
+    }
+
     // `expectedUpdatedAt` is intentionally omitted: the row was just created
     // (and possibly touched by the managed-env update above), so there is no
     // concurrent handle to guard against — passing the stale create timestamp


### PR DESCRIPTION
Server half of #15516 Bug B (root-caused by [cloud-agent] at [#15516 comment](https://github.com/elizaOS/eliza/issues/15516)) — coordinated split: [cloud-agent] owns the client-pick regression (#15491 running-only), this PR fixes the server gate ordering.

## Summary
- `POST /api/v1/eliza/agents` checked `checkProvisioningWorkerHealth()` **before** `createAgent`'s idempotent reuse — so during a worker-heartbeat gap (real outage in the CP journal), the backend's own "reuse the org's existing agent" safety net was unreachable: every create 503'd pre-enqueue and LP3 onboarding dead-ended in create→503 loops while a healthy agent existed
- the gate now sits **immediately before the provision-job enqueue** — the only step that needs a live worker; idempotent reuse, shared-tier creates, non-eager creates, and warm-pool claims all work through a worker blip
- fresh-create path with an unhealthy worker: the just-created pending row is **rolled back explicitly** and the exact pre-reorder 503 body returns (`withOrphanCleanup` only fires on throw; throwing would change the wire shape clients parse) — no orphan for the cleanup cron
- `v1/agents/route.ts` untouched: no idempotent reuse there, its pre-create gate blocks nothing that could otherwise succeed

## Tests
Two regressions added to `eliza-agents-create-idempotency.test.ts`:
1. worker-down + existing agent → **200 reuse** (no enqueue, no rollback) — the exact scenario that 503'd before
2. worker-down + fresh create → **503 canonical body** + `agentSandboxesRepository.delete` called once (row rolled back)

Suite 11/11; sibling suites (orphan-cleanup 5, warm-pool 2, shared-fallback 2, credit-gate 11) green individually — the combined-run mock-bleed 2-error is pre-existing on clean develop (verified via stash). biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
